### PR TITLE
feat: add hook exit code examples

### DIFF
--- a/packages/agent-sdk/examples/hook-exitcode-blocking.ts
+++ b/packages/agent-sdk/examples/hook-exitcode-blocking.ts
@@ -1,0 +1,259 @@
+#!/usr/bin/env tsx
+/**
+ * Hook Exit Code Blocking Error Example
+ *
+ * This example demonstrates blocking error behavior with exit code 2.
+ * Shows how different hook types handle blocking errors differently.
+ *
+ * Key behaviors tested:
+ * - Exit code 2 = blocking error
+ * - PreToolUse: blocks tool execution, stderr goes to Wave Agent
+ * - PostToolUse: stderr goes to Wave Agent, execution continues (tool already ran)
+ * - UserPromptSubmit: blocks prompt, erases it, stderr shown to user only
+ * - Stop: blocks stopping, stderr goes to Wave Agent
+ *
+ * Run with: pnpm tsx examples/hook-exitcode-blocking.ts
+ */
+
+import { Agent } from "../src/agent.js";
+import { promises as fs } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { randomUUID } from "crypto";
+
+/**
+ * Create hooks that return exit code 2 with error messages
+ */
+async function setupBlockingErrorHooks(): Promise<{
+  hookDir: string;
+  cleanup: () => Promise<void>;
+}> {
+  const hookDir = join(tmpdir(), `wave-hook-blocking-${randomUUID()}`);
+  await fs.mkdir(hookDir, { recursive: true });
+
+  // Create .wave subdirectory
+  const waveDir = join(hookDir, ".wave");
+  await fs.mkdir(waveDir, { recursive: true });
+
+  // Create hook configuration with blocking error hooks
+  const hookConfig = {
+    hooks: {
+      // UserPromptSubmit hook that blocks dangerous commands
+      UserPromptSubmit: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: `
+                user_message=$(jq -r '.user_prompt // ""')
+                if echo "$user_message" | grep -i "rm -rf\\|delete\\|format"; then
+                  echo "BLOCKED: Potentially dangerous command detected. Please review your request." >&2
+                  exit 2
+                else
+                  exit 0
+                fi
+              `,
+            },
+          ],
+        },
+      ],
+      // PreToolUse hook that blocks certain bash commands
+      PreToolUse: [
+        {
+          matcher: "bash",
+          hooks: [
+            {
+              type: "command",
+              command: `
+                command_text=$(jq -r '.tool_input.parameters.command // ""')
+                if echo "$command_text" | grep -i "sudo\\|su\\|passwd"; then
+                  echo "BLOCKED: Administrative commands are not allowed in this environment." >&2
+                  exit 2
+                else
+                  exit 0
+                fi
+              `,
+            },
+          ],
+        },
+      ],
+      // PostToolUse hook that reports errors but doesn't block (tool already ran)
+      PostToolUse: [
+        {
+          matcher: "bash",
+          hooks: [
+            {
+              type: "command",
+              command: `
+                exit_code=$(jq -r '.tool_response.exit_code // 0')
+                if [ "$exit_code" -ne 0 ]; then
+                  echo "WARNING: Tool execution failed with exit code $exit_code. Please review the output." >&2
+                  exit 2
+                else
+                  exit 0
+                fi
+              `,
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  const configPath = join(waveDir, "settings.json");
+  await fs.writeFile(configPath, JSON.stringify(hookConfig, null, 2));
+
+  console.log(`Created blocking error hook configuration: ${configPath}`);
+
+  const cleanup = async () => {
+    try {
+      await fs.rm(hookDir, { recursive: true, force: true });
+    } catch (error) {
+      console.warn(`Failed to cleanup: ${error}`);
+    }
+  };
+
+  return { hookDir, cleanup };
+}
+
+/**
+ * Analyze messages to verify blocking behavior
+ */
+function analyzeBlockingBehavior(agent: Agent, testName: string): void {
+  console.log(`--- Analyzing Blocking Behavior for: ${testName} ---`);
+
+  const messages = agent.messages;
+  console.log(`Total messages: ${messages.length}`);
+
+  // Look for error blocks
+  const errorBlocks = messages.flatMap((msg) =>
+    msg.blocks.filter((block) => block.type === "error"),
+  );
+
+  // Look for tool blocks
+  const toolBlocks = messages.flatMap((msg) =>
+    msg.blocks.filter((block) => block.type === "tool"),
+  );
+
+  console.log(`Error blocks found: ${errorBlocks.length}`);
+  console.log(`Tool blocks found: ${toolBlocks.length}`);
+
+  errorBlocks.forEach((block, index) => {
+    if (block.type === "error") {
+      console.log(`  Error ${index + 1}: "${block.content}"`);
+    }
+  });
+
+  toolBlocks.forEach((block, index) => {
+    if (block.type === "tool") {
+      console.log(
+        `  Tool ${index + 1}: ${block.name}, success: ${block.success}`,
+      );
+      if (block.result) {
+        console.log(
+          `    Result preview: "${block.result.substring(0, 100)}..."`,
+        );
+      }
+    }
+  });
+}
+
+/**
+ * Test blocking error scenarios
+ */
+async function testBlockingErrors(agent: Agent): Promise<void> {
+  console.log("=== Testing Blocking Error Scenarios ===\n");
+
+  // Test 1: UserPromptSubmit blocking (dangerous command)
+  console.log("Test 1: UserPromptSubmit blocking - dangerous command");
+  try {
+    await agent.sendMessage("Please run: rm -rf /important/data");
+    console.log("❌ Dangerous command was not blocked!");
+  } catch {
+    console.log("✅ Dangerous command was blocked as expected");
+  }
+  analyzeBlockingBehavior(agent, "Dangerous Command Block");
+
+  console.log("\n" + "-".repeat(50) + "\n");
+
+  // Test 2: Safe command should work
+  console.log("Test 2: Safe command should proceed normally");
+  await agent.sendMessage("Please run: echo 'This is safe'");
+  analyzeBlockingBehavior(agent, "Safe Command");
+
+  console.log("\n" + "-".repeat(50) + "\n");
+
+  // Test 3: PreToolUse blocking (administrative command)
+  console.log("Test 3: PreToolUse blocking - administrative command");
+  await agent.sendMessage("Please run: sudo whoami");
+  analyzeBlockingBehavior(agent, "Administrative Command Block");
+
+  console.log("\n" + "-".repeat(50) + "\n");
+
+  // Test 4: Command that will fail (for PostToolUse hook demonstration)
+  console.log("Test 4: PostToolUse error reporting");
+  await agent.sendMessage("Please run: ls /nonexistent/directory");
+  analyzeBlockingBehavior(agent, "Failed Command Reporting");
+}
+
+/**
+ * Main demonstration function
+ */
+async function demonstrateBlockingErrors(): Promise<void> {
+  console.log("Hook Exit Code Blocking Error Demo");
+  console.log("===================================\n");
+
+  const { hookDir, cleanup } = await setupBlockingErrorHooks();
+
+  try {
+    // Create Agent instance
+    const agent = await Agent.create({
+      workdir: hookDir,
+      agentModel: "gemini-2.5-flash",
+      logger: console,
+    });
+
+    console.log(`Agent created with session ID: ${agent.sessionId}`);
+    console.log(`Working directory: ${hookDir}\n`);
+
+    // Test blocking error scenarios
+    await testBlockingErrors(agent);
+
+    console.log("\n=== Final Analysis ===");
+    const finalMessages = agent.messages;
+    const errorBlocks = finalMessages.flatMap((msg) =>
+      msg.blocks.filter((block) => block.type === "error"),
+    );
+
+    console.log(`Final message count: ${finalMessages.length}`);
+    console.log(`Total error blocks: ${errorBlocks.length}`);
+
+    if (errorBlocks.length > 0) {
+      console.log("✅ Blocking errors were properly captured!");
+    } else {
+      console.log("❓ No error blocks found - check if hooks are executing");
+    }
+
+    console.log("\n✅ Blocking error demonstration complete!\n");
+    console.log("Key Behaviors Demonstrated:");
+    console.log("- Exit code 2 triggers blocking error behavior");
+    console.log(
+      "- UserPromptSubmit blocks: prevents processing, shows user error",
+    );
+    console.log(
+      "- PreToolUse blocks: prevents tool execution, shows agent error",
+    );
+    console.log(
+      "- PostToolUse reports: shows agent error, allows continuation",
+    );
+    console.log("- Error messages appear in appropriate message blocks");
+  } catch (error) {
+    console.error("❌ Blocking error demo failed:", error);
+    process.exit(1);
+  } finally {
+    await cleanup();
+  }
+}
+
+// Run the demonstration
+demonstrateBlockingErrors().catch(console.error);

--- a/packages/agent-sdk/examples/hook-exitcode-nonblocking.ts
+++ b/packages/agent-sdk/examples/hook-exitcode-nonblocking.ts
@@ -1,0 +1,273 @@
+#!/usr/bin/env tsx
+/**
+ * Hook Non-Blocking Error Example
+ *
+ * This example demonstrates non-blocking error behavior with exit codes other than 0 or 2.
+ * Shows how these errors are displayed to the user while allowing execution to continue.
+ *
+ * Key behaviors tested:
+ * - Exit codes other than 0 or 2 = non-blocking errors
+ * - stderr is displayed to the user
+ * - stdout is ignored (regardless of hook type)
+ * - Execution continues normally after displaying the error
+ *
+ * Run with: pnpm tsx examples/hook-exitcode-nonblocking.ts
+ */
+
+import { Agent } from "../src/agent.js";
+import { promises as fs } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { randomUUID } from "crypto";
+
+/**
+ * Create hooks that return various non-blocking exit codes
+ */
+async function setupNonBlockingErrorHooks(): Promise<{
+  hookDir: string;
+  cleanup: () => Promise<void>;
+}> {
+  const hookDir = join(tmpdir(), `wave-hook-nonblocking-${randomUUID()}`);
+  await fs.mkdir(hookDir, { recursive: true });
+
+  // Create .wave subdirectory
+  const waveDir = join(hookDir, ".wave");
+  await fs.mkdir(waveDir, { recursive: true });
+
+  // Create hook configuration with non-blocking error hooks
+  const hookConfig = {
+    hooks: {
+      // UserPromptSubmit hook that gives warnings but doesn't block
+      UserPromptSubmit: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: `
+                user_message=$(jq -r '.user_prompt // ""')
+                
+                # Check for potentially suboptimal requests
+                if echo "$user_message" | grep -i "quick\\|fast\\|hurry"; then
+                  echo "WARNING: You seem to be in a hurry. Take time to review outputs carefully." >&2
+                  echo "This stdout should be ignored" # This should not appear anywhere
+                  exit 1
+                elif echo "$user_message" | grep -i "complex\\|difficult\\|hard"; then
+                  echo "INFO: Complex requests may take longer. Consider breaking them down." >&2
+                  exit 3
+                else
+                  # Success case - no warnings needed
+                  exit 0
+                fi
+              `,
+            },
+          ],
+        },
+      ],
+      // PreToolUse hook that warns about certain commands but allows them
+      PreToolUse: [
+        {
+          matcher: "bash",
+          hooks: [
+            {
+              type: "command",
+              command: `
+                command_text=$(jq -r '.tool_input.parameters.command // ""')
+                
+                if echo "$command_text" | grep -i "curl\\|wget"; then
+                  echo "SECURITY WARNING: Network commands detected. Ensure you trust the source." >&2
+                  exit 4
+                elif echo "$command_text" | grep -i "find.*-delete\\|rm"; then
+                  echo "CAUTION: File deletion command detected. Double-check your paths." >&2
+                  exit 5
+                else
+                  exit 0
+                fi
+              `,
+            },
+          ],
+        },
+      ],
+      // PostToolUse hook that provides performance warnings
+      PostToolUse: [
+        {
+          matcher: "bash",
+          hooks: [
+            {
+              type: "command",
+              command: `
+                # Simulate checking tool execution time (in real scenario, this would be calculated)
+                command_text=$(jq -r '.tool_input.parameters.command // ""')
+                
+                if echo "$command_text" | grep -i "find\\|locate\\|grep -r"; then
+                  echo "PERFORMANCE NOTE: Search commands can be slow on large directories." >&2
+                  exit 6
+                elif echo "$command_text" | grep -i "sleep\\|ping.*-c.*[1-9][0-9]"; then
+                  echo "TIMING WARNING: Command may have caused delays." >&2
+                  exit 7
+                else
+                  exit 0
+                fi
+              `,
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  const configPath = join(waveDir, "settings.json");
+  await fs.writeFile(configPath, JSON.stringify(hookConfig, null, 2));
+
+  console.log(`Created non-blocking error hook configuration: ${configPath}`);
+
+  const cleanup = async () => {
+    try {
+      await fs.rm(hookDir, { recursive: true, force: true });
+    } catch (error) {
+      console.warn(`Failed to cleanup: ${error}`);
+    }
+  };
+
+  return { hookDir, cleanup };
+}
+
+/**
+ * Analyze messages to verify non-blocking behavior
+ */
+function analyzeNonBlockingBehavior(agent: Agent, testName: string): void {
+  console.log(`--- Analyzing Non-Blocking Behavior for: ${testName} ---`);
+
+  const messages = agent.messages;
+  console.log(`Total messages: ${messages.length}`);
+
+  // Count different message types
+  const userMessages = messages.filter((msg) => msg.role === "user");
+  const assistantMessages = messages.filter((msg) => msg.role === "assistant");
+
+  console.log(`User messages: ${userMessages.length}`);
+  console.log(`Assistant messages: ${assistantMessages.length}`);
+
+  // Look for any error or warning content in messages
+  let warningsFound = 0;
+  messages.forEach((msg) => {
+    msg.blocks.forEach((block) => {
+      if (block.type === "text" && block.content.includes("WARNING")) {
+        warningsFound++;
+        console.log(`  Found warning: "${block.content.substring(0, 60)}..."`);
+      }
+    });
+  });
+
+  console.log(`Warnings displayed: ${warningsFound}`);
+
+  // Check if execution completed (should have assistant responses)
+  if (assistantMessages.length > 0) {
+    console.log(
+      "✅ Execution continued after warnings (non-blocking behavior)",
+    );
+  } else {
+    console.log("❌ No assistant responses - execution may have been blocked");
+  }
+}
+
+/**
+ * Test non-blocking error scenarios
+ */
+async function testNonBlockingErrors(agent: Agent): Promise<void> {
+  console.log("=== Testing Non-Blocking Error Scenarios ===\n");
+
+  // Test 1: UserPromptSubmit warning (hurried request)
+  console.log("Test 1: UserPromptSubmit warning - hurried request");
+  await agent.sendMessage("Please quickly run something fast!");
+  analyzeNonBlockingBehavior(agent, "Hurried Request Warning");
+
+  console.log("\n" + "-".repeat(50) + "\n");
+
+  // Test 2: UserPromptSubmit info (complex request)
+  console.log("Test 2: UserPromptSubmit info - complex request");
+  await agent.sendMessage("This is a very complex and difficult task");
+  analyzeNonBlockingBehavior(agent, "Complex Request Info");
+
+  console.log("\n" + "-".repeat(50) + "\n");
+
+  // Test 3: PreToolUse warning (network command)
+  console.log("Test 3: PreToolUse warning - network command");
+  await agent.sendMessage("Please run: curl https://api.example.com");
+  analyzeNonBlockingBehavior(agent, "Network Command Warning");
+
+  console.log("\n" + "-".repeat(50) + "\n");
+
+  // Test 4: PreToolUse caution (file deletion)
+  console.log("Test 4: PreToolUse caution - file deletion");
+  await agent.sendMessage("Please run: rm temp.txt");
+  analyzeNonBlockingBehavior(agent, "File Deletion Caution");
+
+  console.log("\n" + "-".repeat(50) + "\n");
+
+  // Test 5: PostToolUse performance note (search command)
+  console.log("Test 5: PostToolUse performance note - search command");
+  await agent.sendMessage("Please run: find . -name '*.js'");
+  analyzeNonBlockingBehavior(agent, "Search Command Performance");
+}
+
+/**
+ * Main demonstration function
+ */
+async function demonstrateNonBlockingErrors(): Promise<void> {
+  console.log("Hook Non-Blocking Error Demo");
+  console.log("=============================\n");
+
+  const { hookDir, cleanup } = await setupNonBlockingErrorHooks();
+
+  try {
+    // Create Agent instance
+    const agent = await Agent.create({
+      workdir: hookDir,
+      agentModel: "gemini-2.5-flash",
+      logger: console,
+    });
+
+    console.log(`Agent created with session ID: ${agent.sessionId}`);
+    console.log(`Working directory: ${hookDir}\n`);
+
+    // Test non-blocking error scenarios
+    await testNonBlockingErrors(agent);
+
+    console.log("\n=== Final Analysis ===");
+    const finalMessages = agent.messages;
+    const assistantMessages = finalMessages.filter(
+      (msg) => msg.role === "assistant",
+    );
+
+    console.log(`Final message count: ${finalMessages.length}`);
+    console.log(`Assistant responses: ${assistantMessages.length}`);
+
+    if (assistantMessages.length >= 5) {
+      console.log(
+        "✅ All requests processed despite warnings (non-blocking behavior)!",
+      );
+    } else {
+      console.log(
+        `❓ Expected ~5 assistant responses, got ${assistantMessages.length}`,
+      );
+    }
+
+    console.log("\n✅ Non-blocking error demonstration complete!\n");
+    console.log("Key Behaviors Demonstrated:");
+    console.log("- Exit codes other than 0 or 2 are non-blocking errors");
+    console.log("- stderr is displayed to user as warnings/info messages");
+    console.log("- stdout is ignored for all non-blocking error hooks");
+    console.log("- Execution continues normally after displaying warnings");
+    console.log(
+      "- Different exit codes can represent different warning levels",
+    );
+  } catch (error) {
+    console.error("❌ Non-blocking error demo failed:", error);
+    process.exit(1);
+  } finally {
+    await cleanup();
+  }
+}
+
+// Run the demonstration
+demonstrateNonBlockingErrors().catch(console.error);

--- a/packages/agent-sdk/examples/hook-exitcode-success.ts
+++ b/packages/agent-sdk/examples/hook-exitcode-success.ts
@@ -1,0 +1,194 @@
+#!/usr/bin/env tsx
+/**
+ * Hook Exit Code Success Example
+ *
+ * This example demonstrates successful hook execution with exit code 0.
+ * Shows the difference between UserPromptSubmit (stdout captured) and
+ * other hooks (stdout ignored).
+ *
+ * Key behaviors tested:
+ * - Exit code 0 = success
+ * - UserPromptSubmit: stdout is injected into agent context
+ * - Other hooks: stdout is ignored
+ * - All hooks: stderr is ignored on success
+ *
+ * Run with: pnpm tsx examples/hook-exitcode-success.ts
+ */
+
+import { Agent } from "../src/agent.js";
+import { promises as fs } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { randomUUID } from "crypto";
+
+/**
+ * Create hooks that return exit code 0 with different outputs
+ */
+async function setupSuccessHooks(): Promise<{
+  hookDir: string;
+  cleanup: () => Promise<void>;
+}> {
+  const hookDir = join(tmpdir(), `wave-hook-success-${randomUUID()}`);
+  await fs.mkdir(hookDir, { recursive: true });
+
+  // Create .wave subdirectory
+  const waveDir = join(hookDir, ".wave");
+  await fs.mkdir(waveDir, { recursive: true });
+
+  // Create hook configuration with success hooks
+  const hookConfig = {
+    hooks: {
+      // UserPromptSubmit hook that outputs to stdout (should be captured)
+      UserPromptSubmit: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: `echo "CONTEXT: Additional context from UserPromptSubmit hook" && exit 0`,
+            },
+          ],
+        },
+      ],
+      // PreToolUse hook that outputs to stdout (should be ignored)
+      PreToolUse: [
+        {
+          matcher: "bash",
+          hooks: [
+            {
+              type: "command",
+              command: `echo "This stdout should be ignored" && exit 0`,
+            },
+          ],
+        },
+      ],
+      // PostToolUse hook that outputs to stdout and stderr (both should be ignored)
+      PostToolUse: [
+        {
+          matcher: "bash",
+          hooks: [
+            {
+              type: "command",
+              command: `echo "Stdout from PostToolUse" && echo "Stderr from PostToolUse" >&2 && exit 0`,
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  const configPath = join(waveDir, "settings.json");
+  await fs.writeFile(configPath, JSON.stringify(hookConfig, null, 2));
+
+  console.log(`Created success hook configuration: ${configPath}`);
+
+  const cleanup = async () => {
+    try {
+      await fs.rm(hookDir, { recursive: true, force: true });
+    } catch (error) {
+      console.warn(`Failed to cleanup: ${error}`);
+    }
+  };
+
+  return { hookDir, cleanup };
+}
+
+/**
+ * Analyze agent messages to verify success behavior
+ */
+function analyzeSuccessBehavior(agent: Agent): void {
+  console.log("--- Analyzing Agent Messages ---");
+
+  const messages = agent.messages;
+  console.log(`Total messages: ${messages.length}`);
+
+  // Look for UserPromptSubmit stdout injection
+  const userMessages = messages.filter((msg) => msg.role === "user");
+  console.log(`User messages: ${userMessages.length}`);
+
+  if (userMessages.length >= 2) {
+    const originalPromptBlock = userMessages[0]?.blocks.find(
+      (block) => block.type === "text",
+    );
+    const contextInjectionBlock = userMessages[1]?.blocks.find(
+      (block) => block.type === "text",
+    );
+
+    const originalPrompt =
+      originalPromptBlock?.type === "text" ? originalPromptBlock.content : "";
+    const contextInjection =
+      contextInjectionBlock?.type === "text"
+        ? contextInjectionBlock.content
+        : "";
+
+    console.log(`Original prompt: "${originalPrompt}"`);
+    console.log(`Context injection: "${contextInjection}"`);
+
+    if (contextInjection?.includes("CONTEXT: Additional context")) {
+      console.log(
+        "✅ UserPromptSubmit stdout successfully injected into context",
+      );
+    } else {
+      console.log("❌ UserPromptSubmit stdout not found in context");
+    }
+  }
+
+  // Check for any error blocks (should not exist on success)
+  const hasErrorBlocks = messages.some((msg) =>
+    msg.blocks.some((block) => block.type === "error"),
+  );
+
+  if (hasErrorBlocks) {
+    console.log("❌ Unexpected error blocks found");
+  } else {
+    console.log("✅ No error blocks (expected for success)");
+  }
+}
+
+/**
+ * Main demonstration function
+ */
+async function demonstrateSuccessExitCodes(): Promise<void> {
+  console.log("Hook Exit Code Success Demo");
+  console.log("============================\n");
+
+  const { hookDir, cleanup } = await setupSuccessHooks();
+
+  try {
+    // Create Agent instance
+    const agent = await Agent.create({
+      workdir: hookDir,
+      agentModel: "gemini-2.5-flash",
+      logger: console,
+    });
+
+    console.log(`Agent created with session ID: ${agent.sessionId}`);
+    console.log(`Working directory: ${hookDir}\n`);
+
+    // Send a message that will trigger hooks and execute a tool
+    console.log("--- Testing Success Exit Codes ---");
+    console.log("Sending message: 'Please run: echo hello'\n");
+
+    await agent.sendMessage("Please run: echo hello");
+
+    console.log("\n--- Success Test Complete ---\n");
+
+    // Analyze the results
+    analyzeSuccessBehavior(agent);
+
+    console.log("\n✅ Success exit code demonstration complete!\n");
+    console.log("Key Behaviors Demonstrated:");
+    console.log("- Exit code 0 indicates success");
+    console.log("- UserPromptSubmit hook stdout is captured and injected");
+    console.log("- PreToolUse/PostToolUse hook stdout is ignored");
+    console.log("- All hook stderr is ignored on success");
+    console.log("- Normal execution continues without interruption");
+  } catch (error) {
+    console.error("❌ Success exit code demo failed:", error);
+    process.exit(1);
+  } finally {
+    await cleanup();
+  }
+}
+
+// Run the demonstration
+demonstrateSuccessExitCodes().catch(console.error);


### PR DESCRIPTION
## 🎯 Summary

This PR adds comprehensive examples demonstrating the Hook Exit Code Output feature as specified in `specs/011-hooks-exitcode-output/spec.md`.

## 📋 What's Added

### New Example Files:
- **`hook-exitcode-success.ts`**: Demonstrates exit code 0 (success) behavior
- **`hook-exitcode-blocking.ts`**: Demonstrates exit code 2 (blocking error) behavior  
- **`hook-exitcode-nonblocking.ts`**: Demonstrates other exit codes (non-blocking) behavior

## ✅ Key Features Demonstrated

### Success Behavior (Exit Code 0):
- Hook stdout is captured and injected into context
- Hook stderr is ignored
- Execution continues normally

### Blocking Error Behavior (Exit Code 2):
- Agent execution is blocked
- Hook stderr is displayed as error messages
- Hook stdout is ignored
- User receives clear error feedback

### Non-Blocking Error Behavior (Other Exit Codes):
- Agent execution continues
- Hook stderr is displayed as warnings/info
- Hook stdout is ignored
- Different exit codes represent different warning levels

## 🔧 Technical Details

All examples use correct JSON field names for hook context parsing:
- `user_prompt` (not `prompt`)
- `tool_input.parameters.command` (not `tool.parameters.command`)
- `tool_response.exit_code` (not `tool.result.exit_code`)

## 🧪 Testing

All examples have been tested and work correctly:
- ✅ Success example shows proper context injection
- ✅ Blocking example properly blocks execution on exit code 2
- ✅ Non-blocking example shows warnings but continues execution

## 📚 Documentation

These examples serve as both integration tests and documentation for the Hook Exit Code Output feature, making it easy for developers to understand and implement hook scripts with proper exit code handling.