### PR TITLE
feat: Implement expand/collapse functionality for chat interface

### DIFF
--- a/packages/code/src/components/ChatInterface.tsx
+++ b/packages/code/src/components/ChatInterface.tsx
@@ -1,9 +1,8 @@
-import React, { useRef, useEffect } from "react";
+import React from "react";
 import { Box } from "ink";
 import { MessageList } from "./MessageList.js";
 import { InputBox } from "./InputBox.js";
 import { useChat } from "../contexts/useChat.js";
-import type { Message } from "wave-agent-sdk";
 
 export const ChatInterface: React.FC = () => {
   const {
@@ -25,51 +24,18 @@ export const ChatInterface: React.FC = () => {
     hasSlashCommand,
   } = useChat();
 
-  // Create a ref to store messages in expanded mode
-  const expandedMessagesRef = useRef<Message[]>([]);
-
-  useEffect(() => {
-    // Only sync when collapsed
-    if (!isExpanded) {
-      expandedMessagesRef.current = messages.map((message, index) => {
-        // If it's the last message, deep copy its blocks
-        if (index === messages.length - 1) {
-          return {
-            ...message,
-            blocks: message.blocks.map((block) => ({ ...block })),
-          };
-        }
-        return message;
-      });
-    }
-  }, [isExpanded, messages]);
-
   if (!sessionId) return null;
 
   return (
     <Box flexDirection="column" height="100%">
-      <Box flexGrow={1} flexDirection="column" paddingX={1}>
-        {isExpanded ? (
-          // Expanded mode uses messages from ref, loading and tokens are hardcoded to false and 0
-          <MessageList
-            messages={expandedMessagesRef.current}
-            isLoading={false}
-            isCommandRunning={false}
-            latestTotalTokens={0}
-            isExpanded={true}
-          />
-        ) : (
-          // Normal mode uses real-time state
-          <MessageList
-            messages={messages}
-            isLoading={isLoading}
-            isCommandRunning={isCommandRunning}
-            isCompressing={isCompressing}
-            latestTotalTokens={latestTotalTokens}
-            isExpanded={false}
-          />
-        )}
-      </Box>
+      <MessageList
+        messages={messages}
+        isLoading={isLoading}
+        isCommandRunning={isCommandRunning}
+        isCompressing={isCompressing}
+        latestTotalTokens={latestTotalTokens}
+        isExpanded={isExpanded}
+      />
 
       {!isExpanded && (
         <InputBox

--- a/packages/code/src/components/InputBox.tsx
+++ b/packages/code/src/components/InputBox.tsx
@@ -147,7 +147,7 @@ export const InputBox: React.FC<InputBoxProps> = ({
   }
 
   return (
-    <Box flexDirection="column" width={"100%"}>
+    <Box flexDirection="column">
       {showFileSelector && (
         <FileSelector
           files={filteredFiles}

--- a/packages/code/src/components/MessageList.tsx
+++ b/packages/code/src/components/MessageList.tsx
@@ -9,7 +9,6 @@ import { MemoryDisplay } from "./MemoryDisplay.js";
 import { CompressDisplay } from "./CompressDisplay.js";
 import { SubagentBlock } from "./SubagentBlock.js";
 import { usePagination } from "../hooks/usePagination.js";
-import { logger } from "@/utils/logger.js";
 
 export interface MessageListProps {
   messages: Message[];
@@ -29,15 +28,6 @@ export const MessageList = React.memo(
     latestTotalTokens = 0,
     isExpanded = false,
   }: MessageListProps) => {
-    logger.debug(
-      "rerender",
-      messages.length,
-      isLoading,
-      isCommandRunning,
-      latestTotalTokens,
-      isExpanded,
-    );
-
     // Memoize the renderMessageItem function to prevent recreation on every render
     const renderMessageItem = useCallback(
       (
@@ -63,7 +53,6 @@ export const MessageList = React.memo(
             )}
 
             <Box
-              marginLeft={2}
               flexDirection="column"
               gap={1}
               marginTop={shouldShowHeader ? 1 : 0}
@@ -163,7 +152,7 @@ export const MessageList = React.memo(
     }
 
     return (
-      <Box flexDirection="column" gap={1} marginTop={1}>
+      <Box flexDirection="column" gap={1} paddingX={1}>
         {/* Message list */}
         <Box flexDirection="column" gap={1}>
           {currentMessagesWithIndex.map(({ message, originalIndex }) => {


### PR DESCRIPTION
This PR implements expand/collapse functionality for the chat interface with the following changes:

- Simplified ChatInterface component by removing expanded mode message handling
- Updated MessageList to handle expanded state internally
- Modified useChat context to skip updates when in expanded mode using ref pattern
- Removed usage tracking functionality
- Improved layout and styling consistency

The expand/collapse feature allows users to toggle between live chat updates and a static expanded view using Ctrl+O.