### PR TITLE
github action publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,5 +38,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Configure npm for OIDC
+        run: |
+          echo "//registry.npmjs.org/:aud=https://github.com/netease-lcap" >> ./.npmrc
+          echo "//registry.npmjs.org/:_authToken=\${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" >> ./.npmrc
+
       - name: Publish
         run: pnpm -r publish --no-git-checks --access public


### PR DESCRIPTION
- **fix: replace restricted pnpm/action-setup with npm install in publish workflow**
- **chore: remove redundant --provenance flag from publish command**
- **fix: use OIDC for publishing by removing registry-url and explicit tokens**
- **chore: simplify publish workflow by removing redundant build and test steps**
- **fix: configure npm for OIDC in publish workflow**
