### PR TITLE
feat: support allowed-tools in slash commands

### DIFF
--- a/packages/agent-sdk/examples/allowed-tools-demo.ts
+++ b/packages/agent-sdk/examples/allowed-tools-demo.ts
@@ -1,0 +1,104 @@
+#!/usr/bin/env tsx
+
+/**
+ * Allowed Tools Slash Command Example
+ *
+ * Demonstrates that tools listed in allowed-tools frontmatter are auto-approved.
+ */
+
+import { Agent } from "../src/agent.js";
+import { tmpdir } from "os";
+import { join } from "path";
+import { mkdir, writeFile, rm } from "fs/promises";
+
+const tempDir = join(tmpdir(), `allowed-tools-demo-${Date.now()}`);
+
+console.log("🚀 Allowed Tools Slash Command Example");
+
+// Setup temp project with custom command
+await mkdir(join(tempDir, ".wave", "commands"), { recursive: true });
+
+// Create a custom command with allowed-tools
+await writeFile(
+  join(tempDir, ".wave", "commands", "test-allowed.md"),
+  `---
+name: test-allowed
+allowed-tools:
+  - Write
+---
+
+Write "hello" to a file named "hello.txt".
+`,
+);
+
+// Create another custom command WITHOUT allowed-tools
+await writeFile(
+  join(tempDir, ".wave", "commands", "test-restricted.md"),
+  `---
+name: test-restricted
+---
+
+Write "world" to a file named "world.txt".
+`,
+);
+
+// Change to temp directory and create agent
+process.chdir(tempDir);
+
+let callbackCalled = false;
+
+const agent = await Agent.create({
+  permissionMode: "default",
+  canUseTool: async (context) => {
+    console.log(`\n🛡️ Permission callback called for: ${context.toolName}`);
+    callbackCalled = true;
+    return { behavior: "allow" };
+  },
+  callbacks: {
+    onToolBlockUpdated: (params) => {
+      if (params.stage === "running") {
+        console.log(`\n🔧 Executing tool: ${params.name}`);
+      }
+    },
+  },
+});
+
+async function main() {
+  try {
+    console.log(
+      "\n--- Testing /test-allowed (should NOT trigger permission prompt) ---",
+    );
+    callbackCalled = false;
+    await agent.sendMessage("/test-allowed");
+    if (callbackCalled) {
+      console.log("❌ FAILED: Permission callback was called for allowed tool");
+    } else {
+      console.log(
+        "✅ SUCCESS: Permission callback was NOT called for allowed tool",
+      );
+    }
+
+    console.log(
+      "\n--- Testing /test-restricted (SHOULD trigger permission prompt) ---",
+    );
+    callbackCalled = false;
+    await agent.sendMessage("/test-restricted");
+    if (callbackCalled) {
+      console.log(
+        "✅ SUCCESS: Permission callback was called for restricted tool",
+      );
+    } else {
+      console.log(
+        "❌ FAILED: Permission callback was NOT called for restricted tool",
+      );
+    }
+  } catch (error) {
+    console.error("❌ Error:", error);
+  } finally {
+    await agent.destroy();
+    await rm(tempDir, { recursive: true, force: true });
+    console.log("\n🧹 Cleaned up");
+  }
+}
+
+main().catch(console.error);

--- a/packages/agent-sdk/examples/allowed-tools-test.md
+++ b/packages/agent-sdk/examples/allowed-tools-test.md
@@ -1,0 +1,6 @@
+---
+allowed-tools:
+  - Bash
+---
+
+Run `ls` and tell me what you see.

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -350,6 +350,7 @@ export class Agent {
       logger: this.logger,
       backgroundBashManager: this.backgroundBashManager,
       hookManager: this.hookManager,
+      permissionManager: this.permissionManager,
       callbacks: {
         ...callbacks,
         onUsageAdded: (usage: Usage) => {

--- a/packages/agent-sdk/src/managers/slashCommandManager.ts
+++ b/packages/agent-sdk/src/managers/slashCommandManager.ts
@@ -263,7 +263,7 @@ export class SlashCommandManager {
   private async executeCustomCommandInMainAgent(
     commandName: string,
     content: string,
-    config?: { model?: string },
+    config?: { model?: string; allowedTools?: string[] },
     args?: string,
   ): Promise<void> {
     try {
@@ -317,6 +317,7 @@ export class SlashCommandManager {
       // Execute the AI conversation with custom configuration
       await this.aiManager.sendAIMessage({
         model: config?.model,
+        allowedTools: config?.allowedTools,
       });
     } catch (error) {
       this.logger?.error(

--- a/packages/agent-sdk/src/types/commands.ts
+++ b/packages/agent-sdk/src/types/commands.ts
@@ -13,6 +13,7 @@ export interface SlashCommand {
 export interface CustomSlashCommandConfig {
   model?: string;
   description?: string;
+  allowedTools?: string[];
 }
 
 export interface CustomSlashCommand {

--- a/packages/agent-sdk/tests/managers/permissionManager.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.test.ts
@@ -274,6 +274,62 @@ describe("PermissionManager", () => {
       });
     });
 
+    describe("temporary rules (addTemporaryRules)", () => {
+      it("should allow a restricted tool if it is in temporary rules", async () => {
+        permissionManager.addTemporaryRules(["Edit"]);
+
+        const context: ToolPermissionContext = {
+          toolName: "Edit",
+          permissionMode: "default",
+        };
+
+        const result = await permissionManager.checkPermission(context);
+
+        expect(result).toEqual({ behavior: "allow" });
+      });
+
+      it("should allow Bash if it is in temporary rules", async () => {
+        permissionManager.addTemporaryRules(["Bash"]);
+
+        const context: ToolPermissionContext = {
+          toolName: "Bash",
+          permissionMode: "default",
+          toolInput: { command: "rm -rf /" }, // Even dangerous commands are allowed if tool is in temporary rules
+        };
+
+        const result = await permissionManager.checkPermission(context);
+
+        expect(result).toEqual({ behavior: "allow" });
+      });
+
+      it("should not affect other tools not in the list", async () => {
+        permissionManager.addTemporaryRules(["Edit"]);
+
+        const context: ToolPermissionContext = {
+          toolName: "Delete",
+          permissionMode: "default",
+        };
+
+        const result = await permissionManager.checkPermission(context);
+
+        expect(result.behavior).toBe("deny");
+      });
+
+      it("should clear temporary rules", async () => {
+        permissionManager.addTemporaryRules(["Edit"]);
+        permissionManager.clearTemporaryRules();
+
+        const context: ToolPermissionContext = {
+          toolName: "Edit",
+          permissionMode: "default",
+        };
+
+        const result = await permissionManager.checkPermission(context);
+
+        expect(result.behavior).toBe("deny");
+      });
+    });
+
     describe("default mode with unrestricted tools", () => {
       it("should allow unrestricted tools without callback", async () => {
         const unrestrictedTools = ["Read", "Grep", "LS", "Glob", "TodoWrite"];

--- a/specs/048-slash-command-allowed-tools/checklists/requirements.md
+++ b/specs/048-slash-command-allowed-tools/checklists/requirements.md
@@ -1,0 +1,33 @@
+# Specification Quality Checklist: Slash Command Allowed Tools
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-15
+**Feature**: [specs/048-slash-command-allowed-tools/spec.md](spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous (Leverages existing PermissionManager logic)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified (Empty list, Invalid patterns, Session persistence, Overlapping patterns)
+- [x] Scope is clearly bounded (Temporary merge into PermissionManager, no persistence)
+- [x] Dependencies and assumptions identified (PermissionManager behavior)
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows (Removed redundant User Story 3 as it is already implemented in PermissionManager)
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec covers the core requirements of auto-approval for specific tools by merging them into the existing `PermissionManager` logic.
+- Edge cases like non-matching tools and session termination (recursion end) are addressed.
+- Assumptions about the pattern syntax matching `settings.json` are documented.

--- a/specs/048-slash-command-allowed-tools/data-model.md
+++ b/specs/048-slash-command-allowed-tools/data-model.md
@@ -1,0 +1,27 @@
+# Data Model: Slash Command Allowed Tools
+
+## Entities
+
+### CustomSlashCommandConfig (Extension)
+The configuration object extracted from slash command markdown frontmatter.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `allowedTools` | `string[]` | List of tool permission rules (e.g., `Bash(git status:*)`) |
+
+### PermissionManager (State Extension)
+The internal state of the permission manager.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `temporaryRules` | `string[]` | In-memory rules added for the duration of a slash command |
+
+## Validation Rules
+- `allowedTools` must be an array of strings.
+- Each string should follow the `ToolName(pattern)` format, consistent with `settings.json`.
+
+## State Transitions
+1. **Slash Command Triggered**: `allowedTools` are extracted from the command config.
+2. **AI Cycle Start**: `PermissionManager.addTemporaryRules()` is called with the extracted tools.
+3. **Tool Execution**: `PermissionManager.checkPermission()` matches against both `allowedRules` and `temporaryRules`.
+4. **AI Cycle End**: `PermissionManager.clearTemporaryRules()` is called in the `finally` block of `sendAIMessage`.

--- a/specs/048-slash-command-allowed-tools/plan.md
+++ b/specs/048-slash-command-allowed-tools/plan.md
@@ -1,0 +1,89 @@
+# Implementation Plan: Slash Command Allowed Tools
+
+**Feature Branch**: `048-slash-command-allowed-tools`  
+**Created**: 2026-01-15  
+**Status**: Draft  
+**Feature Spec**: [spec.md](spec.md)
+
+## Technical Context
+
+### Architecture Overview
+The feature integrates with the existing `PermissionManager` in `agent-sdk`. When a slash command is triggered, its `allowed-tools` metadata will be parsed and temporarily added to the `PermissionManager`'s allowed rules. These rules will be active only for the duration of the `sendAIMessage` recursion cycle.
+
+### Key Components
+- **`AIManager` (`packages/agent-sdk/src/managers/aiManager.ts`)**: Responsible for managing the AI response cycle and recursion. It will handle the temporary addition and removal of allowed rules.
+- **`PermissionManager` (`packages/agent-sdk/src/managers/permissionManager.ts`)**: Needs to be updated to support temporary rules that are not persisted to `settings.json`.
+- **`SlashCommand` parsing**: The logic that triggers slash commands needs to extract `allowed-tools` and pass them to `AIManager.sendAIMessage`.
+
+### Dependencies & Integrations
+- **`agent-sdk`**: Core logic for AI and permissions.
+- **`code`**: CLI interface where slash commands are defined and triggered.
+
+### Unknowns & Risks
+- **[NEEDS CLARIFICATION: PermissionManager API]**: Does `PermissionManager` currently support adding rules in-memory without saving to disk? (Research Phase 0)
+- **[NEEDS CLARIFICATION: Slash Command Metadata]**: How are slash command headers currently parsed and where is the best place to extract `allowed-tools`? (Research Phase 0)
+- **[NEEDS CLARIFICATION: Recursion Lifecycle]**: How to reliably ensure temporary rules are removed even if an error occurs during recursion? (Research Phase 0)
+
+## Constitution Check
+
+### Principles
+- **I. Package-First Architecture**: Changes will be primarily in `agent-sdk`.
+- **II. TypeScript Excellence**: Strict typing for new permission methods.
+- **IX. Type System Evolution**: Evolve `PermissionManager` and `AIManager` options.
+- **X. Data Model Minimalism**: Keep the temporary rules structure simple.
+
+### Quality Standards
+- **Type Check**: `pnpm run type-check` must pass.
+- **Linting**: `pnpm lint` must pass.
+- **Testing**: Vitest tests for `PermissionManager` and `AIManager` integration.
+
+## Evaluation Gates
+
+| Gate | Requirement | Status | Justification |
+|------|-------------|--------|---------------|
+| 1 | No circular dependencies | PASS | Changes are within existing package boundaries. |
+| 2 | Type safety | PASS | Will use strict TS. |
+| 3 | Test coverage | PASS | Tests will be added in Phase 3. |
+
+## Phase 0: Outline & Research
+
+### Research Tasks
+1. **Research PermissionManager API**: Check if `PermissionManager` has methods for temporary rules.
+2. **Research Slash Command Parsing**: Identify where slash command metadata is parsed in the `code` package.
+3. **Research Recursion Lifecycle**: Determine the best way to wrap `sendAIMessage` with temporary permissions.
+
+## Phase 1: Design & Contracts
+
+### Data Model (`data-model.md`)
+- **TemporaryPermissionRule**: A simple string array in `PermissionManager`.
+
+### API Contracts
+- **`PermissionManager.addTemporaryRules(rules: string[])`**
+- **`PermissionManager.removeTemporaryRules(rules: string[])`**
+- **`AIManager.sendAIMessage(options: { allowedTools?: string[], ... })`**
+
+### Agent Context Update
+- Run `update-agent-context.sh` after design.
+
+## Phase 2: Implementation Plan
+
+### Step 1: Update PermissionManager
+- Add `temporaryRules` property.
+- Update `checkPermission` to include `temporaryRules`.
+- Add methods to add/remove temporary rules.
+
+### Step 2: Update AIManager
+- Modify `sendAIMessage` to accept `allowedTools`.
+- Implement the logic to add rules before recursion and remove them after.
+
+### Step 3: Update Slash Command Trigger
+- Ensure `allowed-tools` are extracted and passed to `AIManager`.
+
+## Phase 3: Testing & Validation
+
+### Unit Tests
+- `PermissionManager` tests for temporary rules.
+- `AIManager` tests for rule lifecycle.
+
+### Integration Tests
+- End-to-end test with a mock slash command.

--- a/specs/048-slash-command-allowed-tools/quickstart.md
+++ b/specs/048-slash-command-allowed-tools/quickstart.md
@@ -1,0 +1,34 @@
+# Quickstart: Slash Command Allowed Tools
+
+## Overview
+This feature allows slash commands to define a set of "allowed tools" that the AI can execute without manual user confirmation. These permissions are temporary and scoped to the execution of the slash command.
+
+## How to use
+
+### 1. Define a Slash Command with Allowed Tools
+Create a markdown file in `.wave/commands/my-command.md`:
+
+```markdown
+---
+description: A command that checks git status automatically
+allowed-tools:
+  - Bash(git status)
+  - Bash(git diff:*)
+---
+
+Check the git status and diff for me.
+```
+
+### 2. Trigger the Command
+In the Wave Agent chat, type:
+```text
+/my-command
+```
+
+### 3. Automatic Execution
+The AI will now be able to run `git status` and `git diff` without prompting you for permission. Other restricted tools (like `Write` or `Delete`) will still require confirmation unless they are also listed in `allowed-tools` or your `settings.json`.
+
+## Security Note
+- Permissions are **temporary**. They are revoked as soon as the AI finishes its response cycle for the slash command.
+- Permissions are **scoped**. They only apply to the tools and patterns you explicitly list.
+- Wildcards are supported (e.g., `Bash(git:*)`).

--- a/specs/048-slash-command-allowed-tools/research.md
+++ b/specs/048-slash-command-allowed-tools/research.md
@@ -1,0 +1,24 @@
+# Research: Slash Command Allowed Tools
+
+## Decision: PermissionManager API Extension
+**Decision**: Extend `PermissionManager` with `addTemporaryRules(rules: string[])` and `clearTemporaryRules()` methods.
+**Rationale**: `PermissionManager` already has `allowedRules` and `isAllowedByRule` logic. Adding a separate `temporaryRules` array allows us to merge them during permission checks without affecting the persistent `allowedRules` or requiring disk I/O.
+**Alternatives considered**: 
+- Modifying `allowedRules` directly: Risky as it might be overwritten by configuration reloads or accidentally persisted.
+- Creating a new `TemporaryPermissionManager`: Overkill and would require duplicating complex bash parsing/matching logic.
+
+## Decision: Slash Command Metadata Extraction
+**Decision**: Update `CustomSlashCommandConfig` type to include `allowedTools?: string[]` and update `parseFrontmatter` in `markdownParser.ts` to support array parsing.
+**Rationale**: Slash commands are defined in markdown files with YAML frontmatter. The `markdownParser.ts` already handles `model` and `description`. Extending it to handle `allowed-tools` is the most natural fit.
+**Alternatives considered**:
+- Parsing `allowed-tools` in `SlashCommandManager`: Possible, but `markdownParser` is where all other frontmatter is handled.
+
+## Decision: Recursion Lifecycle Management
+**Decision**: Wrap the `sendAIMessage` recursion in `AIManager.ts` using a `try...finally` block at the top-level call (`recursionDepth === 0`).
+**Rationale**: The `finally` block in `sendAIMessage` is already used for cleanup (resetting `isLoading`, etc.). It's the most reliable place to ensure `clearTemporaryRules()` is called, even if the AI cycle fails or is aborted.
+**Alternatives considered**:
+- Manual cleanup in `SlashCommandManager`: Less reliable as `sendAIMessage` is asynchronous and can be aborted from multiple places.
+
+## Decision: Merging Behavior
+**Decision**: `PermissionManager.isAllowedByRule` will check both `allowedRules` and `temporaryRules`.
+**Rationale**: This ensures `allowed-tools` from slash commands behave exactly like `permissions.allow` in `settings.json`, including wildcard support.

--- a/specs/048-slash-command-allowed-tools/spec.md
+++ b/specs/048-slash-command-allowed-tools/spec.md
@@ -1,0 +1,72 @@
+# Feature Specification: Slash Command Allowed Tools
+
+**Feature Branch**: `048-slash-command-allowed-tools`  
+**Created**: 2026-01-15  
+**Status**: Draft  
+**Input**: User description: "---
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+description: Create a git commit
+---
+for such a slash command, system should support allowed-tools util ai stop. for allowed-tools, user don't have to confirm"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Auto-approved Tool Execution (Priority: P1)
+
+As a user, I want the AI to execute specific tools automatically when I trigger a slash command, so that I don't have to manually confirm every step of a known workflow.
+
+**Why this priority**: This is the core value of the feature—reducing friction for common automated tasks.
+
+**Independent Test**: Can be tested by triggering a slash command with `allowed-tools` and verifying that the AI executes those tools without prompting the user for confirmation, by leveraging the existing `PermissionManager` logic.
+
+**Acceptance Scenarios**:
+
+1. **Given** a slash command defined with `allowed-tools: Bash(git status:*)`, **When** the user triggers this command and the AI calls `Bash(git status)`, **Then** the tool should execute immediately without a confirmation prompt because it is temporarily added to the allowed rules.
+2. **Given** a slash command with `allowed-tools`, **When** the AI calls a tool NOT in the list (e.g., `Write`), **Then** the system MUST prompt the user for confirmation as usual (unless it's already allowed in `settings.json`).
+
+---
+
+### User Story 2 - Session Termination (Priority: P2)
+
+As a system, I want to revoke the auto-approval privilege once the AI response cycle completes, to ensure security and prevent unauthorized tool usage in subsequent interactions.
+
+**Why this priority**: Essential for security and ensuring that "allowed tools" don't persist indefinitely beyond the intended scope of the slash command.
+
+**Independent Test**: Can be tested by verifying that after the AI finishes its response cycle (recursion stops), tools that were previously auto-approved now require manual confirmation for any new user input.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active slash command session with `allowed-tools`, **When** the AI finishes its task and the `sendAIMessage` recursion ends, **Then** all subsequent tool executions MUST require manual confirmation.
+
+---
+
+### Edge Cases
+
+- **Empty Allowed Tools**: If a slash command is defined without `allowed-tools`, all tool executions MUST require manual confirmation.
+- **Invalid Pattern Syntax**: If an `allowed-tools` pattern is syntactically invalid, the system SHOULD ignore that specific pattern and default to manual confirmation for matching tools.
+- **Session Persistence**: If the user starts a new task or switches context, any active `allowed-tools` privileges from a previous slash command MUST be revoked.
+- **Overlapping Patterns**: If multiple patterns match a tool execution, the most permissive one (auto-approval) takes precedence.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST parse the `allowed-tools` metadata from the slash command header (YAML/Markdown format).
+- **FR-002**: System MUST temporarily merge the `allowed-tools` into the `PermissionManager`'s allowed rules for the duration of the `sendAIMessage` recursion cycle.
+- **FR-003**: System MUST use the existing `PermissionManager.checkPermission` logic to determine if a tool call is auto-approved, ensuring consistency with `settings.json` behavior.
+- **FR-004**: System MUST leverage the existing wildcard matching (e.g., `:*`) in `PermissionManager` for `allowed-tools`.
+- **FR-005**: System MUST remove the temporary `allowed-tools` from the `PermissionManager` when the `sendAIMessage` recursion cycle completes.
+- **FR-006**: System MUST NOT persist `allowed-tools` from a slash command to `settings.json` or `settings.local.json`.
+
+### Key Entities *(include if feature involves data)*
+
+- **Slash Command Definition**: The configuration object containing the command name, description, and `allowed-tools` list.
+- **Allowed Tool Pattern**: A string or object representing a permitted tool and its allowed argument patterns (e.g., `Bash(git status:*)`).
+- **Privileged Session**: The stateful context that tracks whether auto-approval is currently active and which tools are allowed.
+
+## Assumptions
+
+- The auto-approval state is scoped to a single `sendAIMessage` call (including its recursive tool-use calls).
+- The `allowed-tools` configuration follows the same syntax as `permissions.allow` in `settings.json` (e.g., `Bash(git status:*)`).
+- The `PermissionManager` will be updated to support temporary addition/removal of rules.
+- The system already has a mechanism for tool confirmation that can be bypassed.

--- a/specs/048-slash-command-allowed-tools/tasks.md
+++ b/specs/048-slash-command-allowed-tools/tasks.md
@@ -1,0 +1,138 @@
+# Tasks: Slash Command Allowed Tools
+
+**Input**: Design documents from `/home/liuyiqi/personal-projects/wave-agent/specs/048-slash-command-allowed-tools/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md
+
+**Tests**: Tests are explicitly requested in the implementation plan (Phase 3: Testing & Validation).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization and basic structure
+
+- [X] T001 Update `CustomSlashCommandConfig` interface to include `allowedTools?: string[]` in `packages/agent-sdk/src/types/commands.ts`
+- [X] T002 [P] Update `parseFrontmatter` to support array parsing for `allowed-tools` in `packages/agent-sdk/src/utils/markdownParser.ts`
+- [X] T003 [P] Update `parseMarkdownFile` to map `allowed-tools` from frontmatter to `config.allowedTools` in `packages/agent-sdk/src/utils/markdownParser.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before ANY user story can be implemented
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T004 Add `temporaryRules` private property and `addTemporaryRules`/`clearTemporaryRules` public methods to `PermissionManager` in `packages/agent-sdk/src/managers/permissionManager.ts`
+- [X] T005 Update `isAllowedByRule` in `PermissionManager` to check both `allowedRules` and `temporaryRules` in `packages/agent-sdk/src/managers/permissionManager.ts`
+- [X] T006 Update `AIManagerOptions` to include `permissionManager: PermissionManager` in `packages/agent-sdk/src/managers/aiManager.ts`
+- [X] T007 Update `Agent` constructor to pass `permissionManager` to `AIManager` in `packages/agent-sdk/src/agent.ts`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin in parallel
+
+---
+
+## Phase 3: User Story 1 - Auto-approved Tool Execution (Priority: P1) 🎯 MVP
+
+**Goal**: Enable automatic tool execution for tools listed in a slash command's `allowed-tools` metadata.
+
+**Independent Test**: Trigger a slash command with `allowed-tools` and verify that the AI executes those tools without prompting for confirmation.
+
+### Tests for User Story 1
+
+**NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T008 [P] [US1] Unit test for `PermissionManager.addTemporaryRules` and `isAllowedByRule` in `packages/agent-sdk/tests/managers/permissionManager.test.ts`
+- [X] T009 [P] [US1] Integration test for `AIManager` with temporary permissions in `packages/agent-sdk/tests/managers/aiManager.test.ts`
+
+### Implementation for User Story 1
+
+- [X] T010 [US1] Update `sendAIMessage` in `AIManager` to accept `allowedTools?: string[]` in options in `packages/agent-sdk/src/managers/aiManager.ts`
+- [X] T011 [US1] Implement logic in `sendAIMessage` to call `permissionManager.addTemporaryRules` when `recursionDepth === 0` in `packages/agent-sdk/src/managers/aiManager.ts`
+- [X] T012 [US1] Update `executeCustomCommandInMainAgent` in `SlashCommandManager` to pass `config.allowedTools` to `aiManager.sendAIMessage` in `packages/agent-sdk/src/managers/slashCommandManager.ts`
+
+**Checkpoint**: At this point, User Story 1 should be fully functional and testable independently.
+
+---
+
+## Phase 4: User Story 2 - Session Termination (Priority: P2)
+
+**Goal**: Ensure that temporary permissions are revoked once the AI response cycle (recursion) completes.
+
+**Independent Test**: Verify that after a slash command finishes, subsequent tool calls (even for the same tools) require manual confirmation.
+
+### Tests for User Story 2
+
+- [X] T013 [P] [US2] Unit test for `PermissionManager.clearTemporaryRules` in `packages/agent-sdk/tests/managers/permissionManager.test.ts`
+- [X] T014 [P] [US2] Integration test verifying permission revocation after `sendAIMessage` returns in `packages/agent-sdk/tests/managers/aiManager.test.ts`
+
+### Implementation for User Story 2
+
+- [X] T015 [US2] Implement `finally` block logic in `sendAIMessage` to call `permissionManager.clearTemporaryRules` when `recursionDepth === 0` in `packages/agent-sdk/src/managers/aiManager.ts`
+
+**Checkpoint**: At this point, User Stories 1 AND 2 should both work independently.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories
+
+- [X] T016 [P] Run `pnpm run type-check` and `pnpm lint` across `agent-sdk`
+- [X] T017 [P] Verify `quickstart.md` scenarios manually with a sample slash command
+- [X] T018 [P] Ensure no `allowed-tools` are persisted to `settings.json` during execution
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately.
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories.
+- **User Stories (Phase 3+)**: All depend on Foundational phase completion.
+- **Polish (Final Phase)**: Depends on all desired user stories being complete.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2).
+- **User Story 2 (P2)**: Can start after Foundational (Phase 2), but logically follows US1 as it handles the cleanup of US1's state.
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel.
+- T004 and T005 can run in parallel.
+- T008 and T009 (tests) can run in parallel.
+- T013 and T014 (tests) can run in parallel.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch tests for User Story 1 together:
+Task: "Unit test for PermissionManager.addTemporaryRules and isAllowedByRule in packages/agent-sdk/tests/managers/permissionManager.test.ts"
+Task: "Integration test for AIManager with temporary permissions in packages/agent-sdk/tests/managers/aiManager.test.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. **STOP and VALIDATE**: Test User Story 1 independently.
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Foundation ready.
+2. Add User Story 1 → Test independently → Deploy/Demo (MVP!).
+3. Add User Story 2 → Test independently → Deploy/Demo.


### PR DESCRIPTION
This PR implements support for 'allowed-tools' in slash command frontmatter, allowing specified tools to run without manual confirmation during the command execution.