### PR TITLE
feat: support permissions.deny in settings.json

### DIFF
--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -234,7 +234,20 @@ export class ConfigurationService {
             !config.permissions.allow.every((rule) => typeof rule === "string")
           ) {
             result.isValid = false;
-            result.errors.push("All permission rules must be strings");
+            result.errors.push("All permission allow rules must be strings");
+          }
+        }
+
+        // Validate deny if present
+        if (config.permissions.deny !== undefined) {
+          if (!Array.isArray(config.permissions.deny)) {
+            result.isValid = false;
+            result.errors.push("Permissions deny must be an array of strings");
+          } else if (
+            !config.permissions.deny.every((rule) => typeof rule === "string")
+          ) {
+            result.isValid = false;
+            result.errors.push("All permission deny rules must be strings");
           }
         }
 
@@ -869,6 +882,17 @@ export function loadMergedWaveConfig(
           ...new Set([
             ...mergedConfig.permissions.allow,
             ...config.permissions.allow,
+          ]),
+        ];
+      }
+
+      // Merge deny rules
+      if (config.permissions.deny) {
+        if (!mergedConfig.permissions.deny) mergedConfig.permissions.deny = [];
+        mergedConfig.permissions.deny = [
+          ...new Set([
+            ...mergedConfig.permissions.deny,
+            ...config.permissions.deny,
           ]),
         ];
       }

--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -120,42 +120,36 @@ Usage notes:
     }
 
     // Permission check after validation but before real operation
-    if (
-      context.permissionManager &&
-      context.permissionMode &&
-      context.permissionMode !== "bypassPermissions"
-    ) {
-      if (context.permissionManager.isRestrictedTool("Bash")) {
-        try {
-          const permissionContext = context.permissionManager.createContext(
-            "Bash",
-            context.permissionMode,
-            context.canUseToolCallback,
-            {
-              command,
-              description,
-              run_in_background: runInBackground,
-              timeout,
-              workdir: context.workdir,
-            },
-          );
-          const permissionResult =
-            await context.permissionManager.checkPermission(permissionContext);
+    if (context.permissionManager) {
+      try {
+        const permissionContext = context.permissionManager.createContext(
+          "Bash",
+          context.permissionMode || "default",
+          context.canUseToolCallback,
+          {
+            command,
+            description,
+            run_in_background: runInBackground,
+            timeout,
+            workdir: context.workdir,
+          },
+        );
+        const permissionResult =
+          await context.permissionManager.checkPermission(permissionContext);
 
-          if (permissionResult.behavior === "deny") {
-            return {
-              success: false,
-              content: "",
-              error: `Bash operation denied by user, reason: ${permissionResult.message || "No reason provided"}`,
-            };
-          }
-        } catch {
+        if (permissionResult.behavior === "deny") {
           return {
             success: false,
             content: "",
-            error: "Permission check failed",
+            error: `Bash operation denied, reason: ${permissionResult.message || "No reason provided"}`,
           };
         }
+      } catch {
+        return {
+          success: false,
+          content: "",
+          error: "Permission check failed",
+        };
       }
     }
 

--- a/packages/agent-sdk/src/tools/deleteFileTool.ts
+++ b/packages/agent-sdk/src/tools/deleteFileTool.ts
@@ -47,38 +47,31 @@ export const deleteFileTool: ToolPlugin = {
       const filePath = resolvePath(targetFile, context.workdir);
 
       // Permission check after validation but before real operation
-      if (
-        context.permissionManager &&
-        context.permissionMode &&
-        context.permissionMode !== "bypassPermissions"
-      ) {
-        if (context.permissionManager.isRestrictedTool("Delete")) {
-          try {
-            const permissionContext = context.permissionManager.createContext(
-              "Delete",
-              context.permissionMode,
-              context.canUseToolCallback,
-              { target_file: targetFile },
-            );
-            const permissionResult =
-              await context.permissionManager.checkPermission(
-                permissionContext,
-              );
+      // Permission check after validation but before real operation
+      if (context.permissionManager) {
+        try {
+          const permissionContext = context.permissionManager.createContext(
+            "Delete",
+            context.permissionMode || "default",
+            context.canUseToolCallback,
+            { target_file: targetFile },
+          );
+          const permissionResult =
+            await context.permissionManager.checkPermission(permissionContext);
 
-            if (permissionResult.behavior === "deny") {
-              return {
-                success: false,
-                content: "",
-                error: `Delete operation denied by user, reason: ${permissionResult.message || "No reason provided"}`,
-              };
-            }
-          } catch {
+          if (permissionResult.behavior === "deny") {
             return {
               success: false,
               content: "",
-              error: "Permission check failed",
+              error: `Delete operation denied, reason: ${permissionResult.message || "No reason provided"}`,
             };
           }
+        } catch {
+          return {
+            success: false,
+            content: "",
+            error: "Permission check failed",
+          };
         }
       }
 

--- a/packages/agent-sdk/src/tools/editTool.ts
+++ b/packages/agent-sdk/src/tools/editTool.ts
@@ -152,43 +152,35 @@ export const editTool: ToolPlugin = {
       }
 
       // Permission check after validation but before real operation
-      if (
-        context.permissionManager &&
-        context.permissionMode &&
-        context.permissionMode !== "bypassPermissions"
-      ) {
-        if (context.permissionManager.isRestrictedTool("Edit")) {
-          try {
-            const permissionContext = context.permissionManager.createContext(
-              "Edit",
-              context.permissionMode,
-              context.canUseToolCallback,
-              {
-                file_path: filePath,
-                old_string: oldString,
-                new_string: newString,
-                replace_all: replaceAll,
-              },
-            );
-            const permissionResult =
-              await context.permissionManager.checkPermission(
-                permissionContext,
-              );
+      if (context.permissionManager) {
+        try {
+          const permissionContext = context.permissionManager.createContext(
+            "Edit",
+            context.permissionMode || "default",
+            context.canUseToolCallback,
+            {
+              file_path: filePath,
+              old_string: oldString,
+              new_string: newString,
+              replace_all: replaceAll,
+            },
+          );
+          const permissionResult =
+            await context.permissionManager.checkPermission(permissionContext);
 
-            if (permissionResult.behavior === "deny") {
-              return {
-                success: false,
-                content: "",
-                error: `Edit operation denied by user, reason: ${permissionResult.message || "No reason provided"}`,
-              };
-            }
-          } catch {
+          if (permissionResult.behavior === "deny") {
             return {
               success: false,
               content: "",
-              error: "Permission check failed",
+              error: `Edit operation denied, reason: ${permissionResult.message || "No reason provided"}`,
             };
           }
+        } catch {
+          return {
+            success: false,
+            content: "",
+            error: "Permission check failed",
+          };
         }
       }
 

--- a/packages/agent-sdk/src/tools/lsTool.ts
+++ b/packages/agent-sdk/src/tools/lsTool.ts
@@ -62,6 +62,25 @@ export const lsTool: ToolPlugin = {
       };
     }
 
+    // Check permissions
+    if (context.permissionManager) {
+      const permissionContext = context.permissionManager.createContext(
+        "LS",
+        context.permissionMode || "default",
+        context.canUseToolCallback,
+        args,
+      );
+      const decision =
+        await context.permissionManager.checkPermission(permissionContext);
+      if (decision.behavior === "deny") {
+        return {
+          success: false,
+          content: "",
+          error: decision.message || "Permission denied",
+        };
+      }
+    }
+
     try {
       // Check if path exists and is a directory
       const stats = await fs.promises.stat(targetPath);

--- a/packages/agent-sdk/src/tools/multiEditTool.ts
+++ b/packages/agent-sdk/src/tools/multiEditTool.ts
@@ -226,38 +226,30 @@ export const multiEditTool: ToolPlugin = {
       }
 
       // Permission check after validation but before real operation
-      if (
-        context.permissionManager &&
-        context.permissionMode &&
-        context.permissionMode !== "bypassPermissions"
-      ) {
-        if (context.permissionManager.isRestrictedTool("MultiEdit")) {
-          try {
-            const permissionContext = context.permissionManager.createContext(
-              "MultiEdit",
-              context.permissionMode,
-              context.canUseToolCallback,
-              { file_path: filePath, edits },
-            );
-            const permissionResult =
-              await context.permissionManager.checkPermission(
-                permissionContext,
-              );
+      if (context.permissionManager) {
+        try {
+          const permissionContext = context.permissionManager.createContext(
+            "MultiEdit",
+            context.permissionMode || "default",
+            context.canUseToolCallback,
+            { file_path: filePath, edits },
+          );
+          const permissionResult =
+            await context.permissionManager.checkPermission(permissionContext);
 
-            if (permissionResult.behavior === "deny") {
-              return {
-                success: false,
-                content: "",
-                error: `MultiEdit operation denied by user, reason: ${permissionResult.message || "No reason provided"}`,
-              };
-            }
-          } catch {
+          if (permissionResult.behavior === "deny") {
             return {
               success: false,
               content: "",
-              error: "Permission check failed",
+              error: `MultiEdit operation denied, reason: ${permissionResult.message || "No reason provided"}`,
             };
           }
+        } catch {
+          return {
+            success: false,
+            content: "",
+            error: "Permission check failed",
+          };
         }
       }
 

--- a/packages/agent-sdk/src/tools/readTool.ts
+++ b/packages/agent-sdk/src/tools/readTool.ts
@@ -183,6 +183,25 @@ export const readTool: ToolPlugin = {
       };
     }
 
+    // Check permissions
+    if (context.permissionManager) {
+      const permissionContext = context.permissionManager.createContext(
+        "Read",
+        context.permissionMode || "default",
+        context.canUseToolCallback,
+        args,
+      );
+      const decision =
+        await context.permissionManager.checkPermission(permissionContext);
+      if (decision.behavior === "deny") {
+        return {
+          success: false,
+          content: "",
+          error: decision.message || "Permission denied",
+        };
+      }
+    }
+
     // Check if this is an image file
     if (isImageFile(filePath)) {
       return processImageFile(filePath, context);

--- a/packages/agent-sdk/src/tools/writeTool.ts
+++ b/packages/agent-sdk/src/tools/writeTool.ts
@@ -99,38 +99,30 @@ export const writeTool: ToolPlugin = {
       }
 
       // Permission check after validation but before real operation
-      if (
-        context.permissionManager &&
-        context.permissionMode &&
-        context.permissionMode !== "bypassPermissions"
-      ) {
-        if (context.permissionManager.isRestrictedTool("Write")) {
-          try {
-            const permissionContext = context.permissionManager.createContext(
-              "Write",
-              context.permissionMode,
-              context.canUseToolCallback,
-              { file_path: filePath, content },
-            );
-            const permissionResult =
-              await context.permissionManager.checkPermission(
-                permissionContext,
-              );
+      if (context.permissionManager) {
+        try {
+          const permissionContext = context.permissionManager.createContext(
+            "Write",
+            context.permissionMode || "default",
+            context.canUseToolCallback,
+            { file_path: filePath, content },
+          );
+          const permissionResult =
+            await context.permissionManager.checkPermission(permissionContext);
 
-            if (permissionResult.behavior === "deny") {
-              return {
-                success: false,
-                content: "",
-                error: `Write operation denied by user, reason: ${permissionResult.message || "No reason provided"}`,
-              };
-            }
-          } catch {
+          if (permissionResult.behavior === "deny") {
             return {
               success: false,
               content: "",
-              error: "Permission check failed",
+              error: `Write operation denied, reason: ${permissionResult.message || "No reason provided"}`,
             };
           }
+        } catch {
+          return {
+            success: false,
+            content: "",
+            error: "Permission check failed",
+          };
         }
       }
 

--- a/packages/agent-sdk/src/types/configuration.ts
+++ b/packages/agent-sdk/src/types/configuration.ts
@@ -17,6 +17,7 @@ export interface WaveConfiguration {
   /** New field for persistent permissions */
   permissions?: {
     allow?: string[];
+    deny?: string[];
     defaultMode?: "default" | "bypassPermissions" | "acceptEdits"; // Default permission mode for restricted tools
     /**
      * List of directories that are considered part of the Safe Zone.

--- a/specs/049-deny-permissions-support/checklists/requirements.md
+++ b/specs/049-deny-permissions-support/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Support permissions.deny in settings.json
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-15
+**Updated**: 2026-01-15
+**Feature**: [/home/liuyiqi/personal-projects/wave-agent/specs/049-deny-permissions-support/spec.md]
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec updated after researching current permission implementation in `PermissionManager` and `ConfigurationService`.
+- Confirmed that `permissions.deny` should follow the same pattern as `permissions.allow` for consistency.
+- Added specific requirements for merging and validation.
+- Added support for path-based permission rules like `Read(path)`, `Write(path)`, `Delete(path)`, etc., for both allow and deny lists. This applies to tools that take a single file or directory path as a primary input.
+- Excluded `Glob` and `Grep` from path-based rules as their path parameter is optional.
+- Explicitly stated that `deny` rules apply to ALL tools, even those not in the `RESTRICTED_TOOLS` list.

--- a/specs/049-deny-permissions-support/data-model.md
+++ b/specs/049-deny-permissions-support/data-model.md
@@ -1,0 +1,37 @@
+# Data Model: Support permissions.deny in settings.json
+
+## WaveConfiguration Evolution
+
+The `WaveConfiguration` interface in `packages/agent-sdk/src/types/configuration.ts` will be updated to include `deny`.
+
+```typescript
+export interface WaveConfiguration {
+  // ... existing fields
+  permissions?: {
+    allow?: string[];
+    deny?: string[]; // New field
+    defaultMode?: "default" | "bypassPermissions" | "acceptEdits";
+    additionalDirectories?: string[];
+  };
+  // ...
+}
+```
+
+## PermissionManagerOptions Evolution
+
+```typescript
+export interface PermissionManagerOptions {
+  // ... existing fields
+  allowedRules?: string[];
+  deniedRules?: string[]; // New field
+  // ...
+}
+```
+
+## Rule Formats
+
+1. **Tool Name**: `Bash`, `Write`, `Read`
+2. **Bash Command**: `Bash(ls -la)`, `Bash(rm:*)`
+3. **Path-based**: `Read(**/*.env)`, `Write(/etc/**)`, `Delete(/tmp/test.txt)`
+   - Format: `ToolName(glob_pattern)`
+   - Supported tools: `Read`, `Write`, `Edit`, `MultiEdit`, `Delete`, `LS`

--- a/specs/049-deny-permissions-support/plan.md
+++ b/specs/049-deny-permissions-support/plan.md
@@ -1,0 +1,82 @@
+# Implementation Plan: Support permissions.deny in settings.json
+
+**Branch**: `049-deny-permissions-support` | **Date**: 2026-01-15 | **Spec**: [/specs/049-deny-permissions-support/spec.md]
+
+## Summary
+
+Implement a `permissions.deny` field in `settings.json` that allows users to explicitly forbid specific tools, bash commands, or file paths. Deny rules will have the highest precedence in the permission system, ensuring that any denied action is blocked regardless of other allow rules or auto-accept modes.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x
+**Primary Dependencies**: `agent-sdk`, `minimatch` (for glob matching in rules)
+**Storage**: `settings.json`, `settings.local.json`
+**Testing**: `vitest`
+**Target Platform**: Node.js
+**Project Type**: Monorepo (pnpm)
+**Performance Goals**: Sub-millisecond overhead for permission checks.
+**Constraints**: Must support hot-reloading and merging from multiple config sources.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Package-First Architecture**: PASS. Changes are within `agent-sdk`.
+- **II. TypeScript Excellence**: PASS. Strict typing will be maintained.
+- **III. Test Alignment**: PASS. Tests will be added to existing test suites.
+- **IV. Build Dependencies**: PASS. `pnpm build` will be run.
+- **V. Documentation Minimalism**: PASS. Only necessary spec/plan files created.
+- **VI. Quality Gates**: PASS. `type-check` and `lint` will be run.
+- **VII. Source Code Structure**: PASS. Follows manager/service pattern.
+- **VIII. Test-Driven Development**: PASS. New tests will cover the feature.
+- **IX. Type System Evolution**: PASS. Existing interfaces will be extended.
+- **X. Data Model Minimalism**: PASS. Simple string array for deny rules.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/049-deny-permissions-support/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── spec.md              # Feature specification
+```
+
+### Source Code (repository root)
+
+```
+packages/agent-sdk/
+├── src/
+│   ├── managers/
+│   │   └── permissionManager.ts    # Update checkPermission, add matchesRule
+│   ├── services/
+│   │   └── configurationService.ts # Update merging and validation
+│   ├── tools/
+│   │   ├── readTool.ts             # Add checkPermission call
+│   │   └── lsTool.ts               # Add checkPermission call
+│   └── types/
+│       ├── configuration.ts        # Update WaveConfiguration
+│       └── permissions.ts          # Update PermissionManagerOptions
+└── tests/
+    ├── managers/
+    │   └── permissionManager.test.ts
+    └── services/
+        └── configurationService.test.ts
+```
+
+**Structure Decision**: Single project (monorepo package). Changes are focused on `agent-sdk`.
+
+## Complexity Tracking
+
+*Fill ONLY if Constitution Check has violations that must be justified*
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |
+

--- a/specs/049-deny-permissions-support/quickstart.md
+++ b/specs/049-deny-permissions-support/quickstart.md
@@ -1,0 +1,56 @@
+# Quickstart: Using permissions.deny
+
+You can now explicitly deny permissions in your `settings.json` or `settings.local.json`. Deny rules always take precedence over allow rules.
+
+## Examples
+
+### Deny a specific tool
+To completely prevent the agent from using `Bash`:
+```json
+{
+  "permissions": {
+    "deny": ["Bash"]
+  }
+}
+```
+
+### Deny specific bash commands
+To prevent the agent from using `rm`:
+```json
+{
+  "permissions": {
+    "deny": ["Bash(rm:*)"]
+  }
+}
+```
+
+### Deny access to sensitive files
+To prevent the agent from reading any `.env` files:
+```json
+{
+  "permissions": {
+    "deny": ["Read(**/.env)"]
+  }
+}
+```
+
+To prevent the agent from writing to the `/etc` directory:
+```json
+{
+  "permissions": {
+    "deny": ["Write(/etc/**)"]
+  }
+}
+```
+
+### Precedence Example
+If you have both allow and deny rules, the deny rule wins:
+```json
+{
+  "permissions": {
+    "allow": ["Bash"],
+    "deny": ["Bash(rm:*)"]
+  }
+}
+```
+In this case, the agent can use `Bash` for most commands, but `rm` will be blocked.

--- a/specs/049-deny-permissions-support/research.md
+++ b/specs/049-deny-permissions-support/research.md
@@ -1,0 +1,67 @@
+# Research: Support permissions.deny in settings.json
+
+## Decision: Implement `permissions.deny` with high precedence
+
+### Rationale
+To ensure maximum security, `permissions.deny` must be checked before any other permission logic, including `bypassPermissions` mode or `RESTRICTED_TOOLS` checks. This follows the principle of "deny takes precedence".
+
+### Implementation Details
+1. **Rule Matching**:
+   - Tool-only rules: `Bash`, `Write`, `Read`, etc.
+   - Command-specific rules: `Bash(rm:*)`.
+   - Path-based rules: `Read(**/*.env)`, `Write(/etc/**)`, `Delete(/tmp/test.txt)`.
+   - The matching logic for `ToolName(path_pattern)` will use the `minimatch` library (which is already a dependency of `agent-sdk`) to match the `path_pattern` against the `file_path` or `target_file` in the tool input.
+   - **Rationale for `minimatch` over `glob`**: While `glob` is used for searching the filesystem, `minimatch` is the underlying library used by `glob` for string-to-pattern matching. Since permission checks must work for non-existent files (e.g., `Write` or `Delete` operations) and should not hit the disk for performance reasons, `minimatch` is the appropriate tool for this task.
+   - A new private method `matchesRule(context, rule)` will be implemented in `PermissionManager` to centralize matching logic.
+
+2. **Precedence**:
+   - `checkPermission` will first check if the request matches any rule in `deniedRules`.
+   - If denied, return `{ behavior: "deny", message: "..." }`.
+   - This check happens BEFORE `bypassPermissions` mode check to ensure `deny` always wins.
+   - Then proceed with existing logic (bypass, allow rules, restricted tools).
+
+3. **Tool Integration**:
+   - `Read` and `LS` tools will be updated to call `checkPermission`.
+   - The `isRestrictedTool` check inside tools will be reviewed; `checkPermission` should be called for all tools that might be denied, but `checkPermission` itself will handle the "is restricted" logic for the default allow case.
+
+4. **Configuration Merging**:
+   - `loadMergedWaveConfig` in `configurationService.ts` will be updated to merge `permissions.deny` arrays from all sources (user, project, local) into a unique set.
+
+5. **Validation**:
+   - `validateConfiguration` will be updated to check that `permissions.deny` is an array of strings.
+
+## Alternatives Considered
+
+### Alternative 1: Only support tool-level denial
+- **Pros**: Simpler to implement.
+- **Cons**: Doesn't meet the requirement for path-based denial (e.g., blocking access to `.env` files while allowing other reads).
+- **Decision**: Rejected in favor of more granular control.
+
+### Alternative 2: Use a separate `deny` field for paths
+- **Pros**: Clearer separation.
+- **Cons**: Inconsistent with `permissions.allow` which we want to keep similar.
+- **Decision**: Rejected for consistency.
+
+## Research Tasks
+
+### Task 1: Path-based matching logic
+- **Goal**: Determine how to extract the path from various tool inputs and match it against glob patterns.
+- **Findings**:
+  - `Read`: `file_path`
+  - `Write`: `file_path`
+  - `Edit`: `file_path`
+  - `MultiEdit`: `file_path`
+  - `Delete`: `target_file`
+  - `LS`: `path`
+  - We can use `isPathInside` or a glob matcher. Since the requirement mentions glob patterns like `**/*.env`, a glob matcher is more appropriate.
+
+### Task 2: Precedence in `checkPermission`
+- **Goal**: Ensure `deny` is checked first.
+- **Findings**:
+  - Current `checkPermission` starts with `bypassPermissions` check.
+  - We should move `deny` check to the very top.
+
+### Task 3: Merging logic
+- **Goal**: Ensure `deny` rules are merged correctly.
+- **Findings**:
+  - `loadMergedWaveConfig` already merges `allow` rules. We can replicate this for `deny`.

--- a/specs/049-deny-permissions-support/spec.md
+++ b/specs/049-deny-permissions-support/spec.md
@@ -1,0 +1,80 @@
+# Feature Specification: Support permissions.deny in settings.json
+
+**Feature Branch**: `049-deny-permissions-support`  
+**Created**: 2026-01-15  
+**Status**: Draft  
+**Input**: User description: "support permissions.deny in settings.json, having same permission rule like permissions.allow, but deny them."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Deny specific tool access (Priority: P1)
+
+As a security-conscious user, I want to explicitly forbid the agent from using certain powerful tools (like `Bash` or `Write`) to ensure it cannot make unauthorized changes to my system, even if those tools are generally available.
+
+**Why this priority**: This is the core functionality requested. It provides immediate security value by allowing users to restrict the agent's capabilities.
+
+**Independent Test**: Can be tested by adding a tool name to `permissions.deny` in `settings.json` and verifying that the agent is unable to execute that tool, receiving a "permission denied" error instead.
+
+**Acceptance Scenarios**:
+
+1. **Given** `permissions.deny` contains `["Bash"]`, **When** the agent attempts to run a bash command, **Then** the system MUST block the execution and inform the user/agent that the tool is explicitly denied.
+2. **Given** `permissions.deny` is empty or does not contain `Bash`, **When** the agent attempts to run a bash command (and it's allowed by other rules), **Then** the system SHOULD allow the execution.
+3. **Given** `permissions.deny` contains `["Bash(rm:*)"]`, **When** the agent attempts to run `rm -rf /`, **Then** the system MUST block the execution.
+
+---
+
+### User Story 2 - Deny access to specific file paths (Priority: P1)
+
+As a user with sensitive data, I want to prevent the agent from accessing specific directories or files (e.g., `.env` files, SSH keys, or system configuration directories) by defining deny rules for tools that operate on specific file paths.
+
+**Why this priority**: Protecting sensitive data is a primary use case for permissions. Deny rules are often easier to manage for "everything except X" or "allow all except Y" scenarios.
+
+**Independent Test**: Can be tested by adding a rule like `Read(**/.env)` or `Delete(/etc/**)` to `permissions.deny` and verifying that the corresponding tool is blocked when attempting to access matching paths.
+
+**Acceptance Scenarios**:
+
+1. **Given** `permissions.deny` contains `["Read(**/.env)"]`, **When** the agent attempts to read a file named `.env` in any directory using the `Read` tool, **Then** the system MUST deny the request.
+2. **Given** `permissions.deny` contains `["Write(/etc/**)"]`, **When** the agent attempts to write to a file in `/etc/` using the `Write` tool, **Then** the system MUST deny the request.
+3. **Given** `permissions.deny` contains `["Delete(/etc/**)"]`, **When** the agent attempts to delete a file in `/etc/`, **Then** the system MUST deny the request.
+4. **Given** `permissions.deny` contains `["Bash(ls /etc:*)"]`, **When** the agent attempts to run `ls /etc/passwd`, **Then** the system MUST deny the request.
+
+---
+
+### User Story 3 - Precedence of Deny over Allow (Priority: P2)
+
+As a user, I want to be certain that if I explicitly deny a permission, it cannot be overridden by an allow rule. This "deny-by-default" for specific items ensures predictable security.
+
+**Why this priority**: Ensures the security model is robust and follows the principle of least privilege. It resolves potential conflicts between allow and deny rules.
+
+**Independent Test**: Can be tested by adding the same resource/tool to both `permissions.allow` and `permissions.deny` and verifying that the request is denied.
+
+**Acceptance Scenarios**:
+
+1. **Given** `permissions.allow` contains `["*"]` and `permissions.deny` contains `["Bash"]`, **When** the agent attempts to run a bash command, **Then** the system MUST deny the request because the deny rule takes precedence.
+
+---
+
+### Edge Cases
+
+- **What happens when a deny rule is malformed?** The system should ideally log a warning and treat the malformed rule as "deny nothing" (to avoid breaking the whole system) or "deny everything" (for maximum safety). Given the context, a warning and ignoring the specific malformed rule is standard, but for security, it might be better to fail safe. **Assumption**: Malformed rules will be ignored with a warning, but valid rules will still be enforced.
+- **How does the system handle overlapping glob patterns?** If multiple deny rules match, the result is still "denied".
+- **What if `settings.json` is missing `permissions.deny`?** The system should behave as it currently does, only relying on `permissions.allow` and default behaviors.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST support a `permissions.deny` field in `settings.json`.
+- **FR-002**: `permissions.deny` MUST support the same rule types and formats as `permissions.allow` (e.g., tool names, `Bash(cmd)`, `Bash(prefix:*)`).
+- **FR-003**: System MUST support path-based permission rules in the format `ToolName(path_pattern)` for both `allow` and `deny` lists. This MUST apply to tools that take a single file or directory path as a primary input (e.g., `Read`, `Write`, `Edit`, `MultiEdit`, `Delete`, `LS`). Tools like `Glob` and `Grep` are excluded from this path-based rule format as their path parameter is optional and they often operate on patterns.
+- **FR-004**: If a permission request matches any rule in `permissions.deny`, the system MUST deny the request immediately, even if the tool is not in the `RESTRICTED_TOOLS` list and even if it would otherwise be allowed by `permissions.allow` or auto-accept logic.
+- **FR-005**: `permissions.deny` MUST take precedence over `permissions.allow`. If a request matches both an allow rule and a deny rule, it MUST be denied.
+- **FR-006**: The system MUST provide a clear and informative error message when a permission is denied due to an explicit deny rule, distinguishing it from a lack of an allow rule.
+- **FR-007**: The system MUST support hot-reloading of `permissions.deny` rules when `settings.json` is modified.
+- **FR-008**: `permissions.deny` rules from different configuration sources (user, project, local) MUST be merged into a single unique set, similar to `permissions.allow`.
+- **FR-009**: The system MUST validate that `permissions.deny` is an array of strings during configuration loading.
+
+### Key Entities *(include if feature involves data)*
+
+- **Permission Rule**: A string or object defining a capability (tool) or resource (file path) that is subject to access control.
+- **Settings**: The configuration object loaded from `settings.json` which now includes both `allow` and `deny` permission lists.

--- a/specs/049-deny-permissions-support/tasks.md
+++ b/specs/049-deny-permissions-support/tasks.md
@@ -1,0 +1,161 @@
+---
+description: "Task list for implementing permissions.deny support"
+---
+
+# Tasks: Support permissions.deny in settings.json
+
+**Input**: Design documents from `/specs/049-deny-permissions-support/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md
+
+**Tests**: Tests are included as they are essential for verifying security-critical permission logic.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization and basic structure
+
+- [X] T001 [P] Update `WaveConfiguration` interface to include `permissions.deny` in `packages/agent-sdk/src/types/configuration.ts`
+- [X] T002 [P] Update `PermissionManagerOptions` interface to include `deniedRules` in `packages/agent-sdk/src/types/permissions.ts`
+- [X] T003 [P] Verify `minimatch` is correctly imported and used in `packages/agent-sdk/src/managers/permissionManager.ts` (it is already a dependency)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before ANY user story can be implemented
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T004 Update `ConfigurationService.validateConfiguration` to validate `permissions.deny` as an array of strings in `packages/agent-sdk/src/services/configurationService.ts`
+- [X] T005 Update `loadMergedWaveConfig` to merge `permissions.deny` rules from all sources in `packages/agent-sdk/src/services/configurationService.ts`
+- [X] T006 Implement private `matchesRule(context, rule)` helper in `PermissionManager` using `minimatch` for path patterns in `packages/agent-sdk/src/managers/permissionManager.ts`
+- [X] T007 Update `PermissionManager.checkPermission` to check `deniedRules` at the very beginning (before bypass check) in `packages/agent-sdk/src/managers/permissionManager.ts`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin in parallel
+
+---
+
+## Phase 3: User Story 1 - Deny specific tool access (Priority: P1) 🎯 MVP
+
+**Goal**: Allow users to explicitly forbid the agent from using certain tools (e.g., Bash, Write).
+
+**Independent Test**: Add "Bash" to `permissions.deny` and verify that any bash command is blocked with a clear error message.
+
+### Tests for User Story 1
+
+- [X] T008 [P] [US1] Add unit tests for tool-level denial in `packages/agent-sdk/tests/managers/permissionManager.test.ts`
+- [X] T009 [P] [US1] Add integration test for tool denial in `packages/agent-sdk/tests/services/configurationService.test.ts`
+
+### Implementation for User Story 1
+
+- [X] T010 [US1] Ensure `matchesRule` correctly handles simple tool name matches (e.g., "Bash") in `packages/agent-sdk/src/managers/permissionManager.ts`
+- [X] T011 [US1] Verify `checkPermission` returns informative error message for denied tools in `packages/agent-sdk/src/managers/permissionManager.ts`
+
+**Checkpoint**: User Story 1 is fully functional. Tools can be explicitly denied.
+
+---
+
+## Phase 4: User Story 2 - Deny access to specific file paths (Priority: P1)
+
+**Goal**: Prevent the agent from accessing specific directories or files using `ToolName(path_pattern)` rules.
+
+**Independent Test**: Add `Read(**/.env)` to `permissions.deny` and verify that `Read` tool is blocked when accessing any `.env` file.
+
+### Tests for User Story 2
+
+- [X] T012 [P] [US2] Add unit tests for path-based denial (e.g., `Read(**/*.env)`) in `packages/agent-sdk/tests/managers/permissionManager.test.ts`
+- [X] T013 [P] [US2] Add unit tests for bash command prefix denial (e.g., `Bash(rm:*)`) in `packages/agent-sdk/tests/managers/permissionManager.test.ts`
+
+### Implementation for User Story 2
+
+- [X] T014 [US2] Update `matchesRule` to handle `ToolName(pattern)` format and extract paths from `toolInput` in `packages/agent-sdk/src/managers/permissionManager.ts`
+- [X] T015 [US2] Update `Read` tool to call `checkPermission` in `packages/agent-sdk/src/tools/readTool.ts`
+- [X] T016 [US2] Update `LS` tool to call `checkPermission` in `packages/agent-sdk/src/tools/lsTool.ts`
+- [X] T017 [US2] Ensure `matchesRule` correctly handles `Bash(prefix:*)` rules in `packages/agent-sdk/src/managers/permissionManager.ts`
+
+**Checkpoint**: User Story 2 is functional. Granular path and command denial is supported.
+
+---
+
+## Phase 5: User Story 3 - Precedence of Deny over Allow (Priority: P2)
+
+**Goal**: Ensure `deny` rules always win over `allow` rules and auto-accept modes.
+
+**Independent Test**: Add `Bash` to both `allow` and `deny` and verify it is denied.
+
+### Tests for User Story 3
+
+- [X] T018 [P] [US3] Add unit tests for deny-over-allow precedence in `packages/agent-sdk/tests/managers/permissionManager.test.ts`
+- [X] T019 [P] [US3] Add unit tests for deny-over-acceptEdits precedence in `packages/agent-sdk/tests/managers/permissionManager.test.ts`
+
+### Implementation for User Story 3
+
+- [X] T020 [US3] Verify `checkPermission` logic correctly prioritizes `deniedRules` check in `packages/agent-sdk/src/managers/permissionManager.ts`
+
+**Checkpoint**: Security model is robust. Deny rules cannot be bypassed.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation and cleanup
+
+- [X] T021 [P] Run `pnpm build` in `packages/agent-sdk`
+- [X] T022 [P] Run `pnpm run type-check` and `pnpm run lint` in workspace root
+- [X] T023 [P] Verify `quickstart.md` examples work as expected
+- [X] T024 [P] Ensure all restricted tools (`Write`, `Delete`, `Edit`, `MultiEdit`) correctly handle the new deny logic
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Phase 1.
+- **User Stories (Phase 3-5)**: Depend on Phase 2. Can proceed in parallel.
+- **Polish (Phase 6)**: Depends on all user stories.
+
+### User Story Dependencies
+
+- **US1 (P1)**: MVP.
+- **US2 (P1)**: High priority for data safety.
+- **US3 (P2)**: Ensures consistency.
+
+### Parallel Opportunities
+
+- T001, T002, T003 can run in parallel.
+- Once Phase 2 is done, US1, US2, and US3 tests and implementations can proceed in parallel.
+- T021-T024 can run in parallel.
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 & 2.
+2. Complete Phase 3 (US1).
+3. Validate that tool-level denial works.
+
+### Incremental Delivery
+
+1. Foundation ready.
+2. Add tool denial (US1).
+3. Add path/command denial (US2).
+4. Verify precedence (US3).
+5. Final polish.
+
+---
+
+## Notes
+
+- `minimatch` is used for glob matching in rules.
+- `checkPermission` is the central point for all permission logic.
+- `Read` and `LS` tools are updated to participate in the permission system.


### PR DESCRIPTION
This PR implements support for `permissions.deny` in `settings.json`, allowing users to explicitly forbid specific tools, bash commands, or file paths. Deny rules have the highest precedence and are checked before any other permission logic.

Key changes:
- Updated `WaveConfiguration` and `PermissionManagerOptions` to include `deny` rules.
- Implemented `matchesRule` helper in `PermissionManager` using `minimatch` for path-based denial.
- Updated `ConfigurationService` to merge and validate `deny` rules from all sources.
- Updated core tools (`Read`, `LS`, `Bash`, `Write`, `Edit`, `MultiEdit`, `Delete`) to enforce deny rules.
- Added comprehensive unit and integration tests.