### PR TITLE
feat: implement dynamic tool definitions for Skill and Task tools

### DIFF
--- a/packages/agent-sdk/src/tools/taskTool.ts
+++ b/packages/agent-sdk/src/tools/taskTool.ts
@@ -6,45 +6,50 @@ import type { SubagentManager } from "../managers/subagentManager.js";
  * Note: SubagentManager should be initialized before calling this function
  */
 export function createTaskTool(subagentManager: SubagentManager): ToolPlugin {
-  // Get available subagents from the initialized subagent manager
-  const availableSubagents = subagentManager.getConfigurations();
-  const subagentList = availableSubagents
-    .map((config) => `- ${config.name}: ${config.description}`)
-    .join("\n");
+  // Ensure SubagentManager is initialized
+  subagentManager.getConfigurations();
 
-  const description = `Delegate a task to a specialized subagent. Use this when you need specialized expertise or want to break down complex work into focused subtasks.
+  return {
+    name: "Task",
+    get config() {
+      // Get available subagents from the initialized subagent manager
+      const availableSubagents = subagentManager.getConfigurations();
+      const subagentList = availableSubagents
+        .map((config) => `- ${config.name}: ${config.description}`)
+        .join("\n");
+
+      const description = `Delegate a task to a specialized subagent. Use this when you need specialized expertise or want to break down complex work into focused subtasks.
 
 Available subagents:
 ${subagentList || "No subagents configured"}`;
 
-  return {
-    name: "Task",
-    config: {
-      type: "function",
-      function: {
-        name: "Task",
-        description,
-        parameters: {
-          type: "object",
-          properties: {
-            description: {
-              type: "string",
-              description:
-                "A clear, concise description of what needs to be accomplished",
+      return {
+        type: "function" as const,
+        function: {
+          name: "Task",
+          description,
+          parameters: {
+            type: "object",
+            properties: {
+              description: {
+                type: "string",
+                description:
+                  "A clear, concise description of what needs to be accomplished",
+              },
+              prompt: {
+                type: "string",
+                description:
+                  "The specific instructions or prompt to send to the subagent",
+              },
+              subagent_type: {
+                type: "string",
+                description: `The type or name of subagent to use. Available options: ${availableSubagents.map((c) => c.name).join(", ") || "none"}`,
+              },
             },
-            prompt: {
-              type: "string",
-              description:
-                "The specific instructions or prompt to send to the subagent",
-            },
-            subagent_type: {
-              type: "string",
-              description: `The type or name of subagent to use. Available options: ${availableSubagents.map((c) => c.name).join(", ") || "none"}`,
-            },
+            required: ["description", "prompt", "subagent_type"],
           },
-          required: ["description", "prompt", "subagent_type"],
         },
-      },
+      };
     },
 
     execute: async (

--- a/packages/agent-sdk/tests/tools/dynamicTool.test.ts
+++ b/packages/agent-sdk/tests/tools/dynamicTool.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SkillManager } from "../../src/managers/skillManager.js";
+import { createSkillTool } from "../../src/tools/skillTool.js";
+import { SubagentManager } from "../../src/managers/subagentManager.js";
+import { createTaskTool } from "../../src/tools/taskTool.js";
+import type {
+  Logger,
+  GatewayConfig,
+  ModelConfig,
+} from "../../src/types/index.js";
+import type { ToolManager } from "../../src/managers/toolManager.js";
+import type { MessageManager } from "../../src/managers/messageManager.js";
+import type { SubagentConfiguration } from "../../src/utils/subagentParser.js";
+
+describe("Dynamic Tool Definitions", () => {
+  let mockLogger: Logger;
+
+  beforeEach(() => {
+    mockLogger = {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    };
+  });
+
+  describe("Skill Tool", () => {
+    it("should dynamically reflect skills added after tool creation", async () => {
+      const skillManager = new SkillManager({
+        logger: mockLogger,
+        workdir: "/test/workdir",
+      });
+
+      // Mock initialization to avoid fs calls
+      (skillManager as unknown as { initialized: boolean }).initialized = true;
+
+      const tool = createSkillTool(skillManager);
+
+      // Initially no skills
+      vi.spyOn(skillManager, "getAvailableSkills").mockReturnValue([]);
+      expect(tool.config.function.description).toContain(
+        "No skills are currently available",
+      );
+      const params = tool.config.function.parameters as unknown as {
+        properties: {
+          skill_name: { enum: string[] };
+        };
+      };
+      expect(params.properties.skill_name.enum).toEqual([]);
+
+      // Add a skill
+      const mockSkills = [
+        {
+          name: "test-skill",
+          type: "personal" as const,
+          description: "Test skill",
+          skillPath: "/path/to/test",
+        },
+      ];
+      vi.spyOn(skillManager, "getAvailableSkills").mockReturnValue(mockSkills);
+
+      // Tool config should now reflect the new skill
+      expect(tool.config.function.description).toContain("test-skill");
+      const updatedParams = tool.config.function.parameters as unknown as {
+        properties: {
+          skill_name: { enum: string[] };
+        };
+      };
+      expect(updatedParams.properties.skill_name.enum).toEqual(["test-skill"]);
+    });
+  });
+
+  describe("Task Tool", () => {
+    it("should dynamically reflect subagents added after tool creation", async () => {
+      const subagentManager = new SubagentManager({
+        workdir: "/test/workdir",
+        parentToolManager: {} as unknown as ToolManager,
+        parentMessageManager: {} as unknown as MessageManager,
+        logger: mockLogger,
+        getGatewayConfig: () => ({}) as unknown as GatewayConfig,
+        getModelConfig: () => ({}) as unknown as ModelConfig,
+        getMaxInputTokens: () => 1000,
+        onUsageAdded: () => {},
+      });
+
+      // Mock initialization
+      (
+        subagentManager as unknown as {
+          cachedConfigurations: SubagentConfiguration[];
+        }
+      ).cachedConfigurations = [];
+
+      const tool = createTaskTool(subagentManager);
+
+      // Initially no subagents
+      vi.spyOn(subagentManager, "getConfigurations").mockReturnValue([]);
+      expect(tool.config.function.description).toContain(
+        "No subagents configured",
+      );
+      const params = tool.config.function.parameters as unknown as {
+        properties: {
+          subagent_type: { description: string };
+        };
+      };
+      expect(params.properties.subagent_type.description).toContain(
+        "Available options: none",
+      );
+
+      // Add a subagent
+      const mockSubagents: SubagentConfiguration[] = [
+        {
+          name: "test-subagent",
+          description: "Test subagent",
+          systemPrompt: "You are a test subagent",
+          filePath: "/path/to/test-subagent.md",
+          scope: "project",
+          priority: 1,
+        },
+      ];
+      vi.spyOn(subagentManager, "getConfigurations").mockReturnValue(
+        mockSubagents,
+      );
+
+      // Tool config should now reflect the new subagent
+      expect(tool.config.function.description).toContain("test-subagent");
+      const updatedParams = tool.config.function.parameters as unknown as {
+        properties: {
+          subagent_type: { description: string };
+        };
+      };
+      expect(updatedParams.properties.subagent_type.description).toContain(
+        "Available options: test-subagent",
+      );
+    });
+  });
+});

--- a/specs/043-expand-plugin-capabilities/plan.md
+++ b/specs/043-expand-plugin-capabilities/plan.md
@@ -67,6 +67,14 @@ packages/agent-sdk/
 
 **Structure Decision**: Monorepo package structure (agent-sdk).
 
+## Phase 8: Dynamic Tool Definitions
+
+Goal: Ensure that tools like `Skill` and `Task` dynamically reflect the current set of available components (skills, subagents) even if they are added after the tool is initialized.
+
+- T029 [P] Modify `Skill` tool to use a getter for its `config` property to dynamically reflect available skills.
+- T030 [P] Modify `Task` tool to use a getter for its `config` property to dynamically reflect available subagents.
+- T031 [P] Add unit tests to verify dynamic tool definitions.
+
 ## Complexity Tracking
 
 *Fill ONLY if Constitution Check has violations that must be justified*

--- a/specs/043-expand-plugin-capabilities/research.md
+++ b/specs/043-expand-plugin-capabilities/research.md
@@ -41,6 +41,18 @@ The `PluginManifest` interface in `packages/agent-sdk/src/types/plugins.ts` will
 - **Separation of Concerns**: Managers remain responsible for the runtime behavior of components, while the plugin system handles their discovery and registration.
 - **Validation**: Centralized validation in `PluginLoader` ensures that plugins follow the required directory structure.
 
+## Decision: Dynamic Tool Definitions
+
+### Summary
+Tools that depend on a dynamic list of components (like `Skill` and `Task` tools) will use getters for their `config` property.
+
+### Rationale
+When plugins are loaded after the initial tool registration, static tool definitions become stale. By using a getter for the `config` property, the tool definition (including descriptions and parameter enums) is dynamically generated every time it is requested by the AI, ensuring it always reflects the current state of the system (including components added by plugins).
+
+### Alternatives Considered
+- **Re-initializing tools**: Re-running the tool initialization logic after plugins are loaded. Rejected because it's more complex to orchestrate and doesn't handle live configuration changes as cleanly as getters.
+- **Event-driven updates**: Having tools listen for changes in their respective managers. Rejected as over-engineered for this specific use case.
+
 ### Alternatives Considered
 - **Manifest-based registration**: Requiring all components to be explicitly listed in `plugin.json`. Rejected because file-system discovery is more developer-friendly and consistent with how `commands/` and `skills/` already work in the core system.
 - **Dynamic loading on demand**: Loading components only when needed. Rejected because most components (LSP, MCP, Hooks) need to be registered at startup to function correctly.

--- a/specs/043-expand-plugin-capabilities/spec.md
+++ b/specs/043-expand-plugin-capabilities/spec.md
@@ -124,6 +124,7 @@ A developer wants to ensure their plugin is correctly structured to avoid common
 - **FR-008**: System MUST support a `commands/` directory at the plugin root for slash commands as Markdown files.
 - **FR-009**: System MUST enforce that only `plugin.json` is located inside the `.claude-plugin/` directory.
 - **FR-010**: System MUST load these components when the plugin is installed or Agent Code is restarted.
+- **FR-011**: System MUST ensure that tool definitions (e.g., `Skill`, `Task`) dynamically reflect components added by plugins without requiring a tool re-initialization.
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/043-expand-plugin-capabilities/tasks.md
+++ b/specs/043-expand-plugin-capabilities/tasks.md
@@ -56,6 +56,13 @@ Goal: Final verification, documentation, and cleanup.
 - [X] T027 [P] Run `pnpm test`, `pnpm run type-check`, and `pnpm lint` across the workspace
 - [X] T028 [P] Ensure all "Claude" references in new code/logs are replaced with "Agent"
 
+## Phase 8: Dynamic Tool Definitions
+Goal: Ensure that tools like `Skill` and `Task` dynamically reflect the current set of available components (skills, subagents) even if they are added after the tool is initialized.
+
+- [X] T029 [P] Modify `Skill` tool to use a getter for its `config` property to dynamically reflect available skills.
+- [X] T030 [P] Modify `Task` tool to use a getter for its `config` property to dynamically reflect available subagents.
+- [X] T031 [P] Add unit tests to verify dynamic tool definitions.
+
 ## Dependencies
 - Phase 2 must be completed before Phase 3, 4, 5, and 6.
 - Phase 3, 4, 5, and 6 can be implemented in parallel after Phase 2 is complete.


### PR DESCRIPTION
This PR implements dynamic tool definitions for the Skill and Task tools using TypeScript getters. This ensures that skills and subagents loaded via plugins after initialization are correctly reflected in the tool configurations provided to the AI.

Key changes:
- Modified Skill tool to use a getter for its config property.
- Modified Task tool to use a getter for its config property.
- Added unit tests to verify dynamic updates.
- Updated project specifications to include Phase 8: Dynamic Tool Definitions.