### PR TITLE
feat: update wave plugin list output format to plugin_name@market_name

### DIFF
--- a/packages/code/src/commands/plugin/list.ts
+++ b/packages/code/src/commands/plugin/list.ts
@@ -52,7 +52,7 @@ export async function listPluginsCommand() {
             : "disabled"
           : "not installed";
         const versionStr = p.version ? ` v${p.version}` : "";
-        console.log(`- ${p.name}${versionStr} (@${p.marketplace}) [${status}]`);
+        console.log(`- ${pluginId}${versionStr} [${status}]`);
       });
     }
     process.exit(0);

--- a/packages/code/tests/commands/plugin/scope.test.ts
+++ b/packages/code/tests/commands/plugin/scope.test.ts
@@ -138,7 +138,7 @@ describe("Plugin Scope Integration Tests", () => {
     await listPluginsCommand();
 
     expect(mockLog).toHaveBeenCalledWith(
-      expect.stringContaining("- test-plugin v1.0.0 (@market) [enabled]"),
+      expect.stringContaining("- test-plugin@market v1.0.0 [enabled]"),
     );
   });
 
@@ -157,7 +157,7 @@ describe("Plugin Scope Integration Tests", () => {
     await listPluginsCommand();
 
     expect(mockLog).toHaveBeenCalledWith(
-      expect.stringContaining("- test-plugin v1.0.0 (@market) [disabled]"),
+      expect.stringContaining("- test-plugin@market v1.0.0 [disabled]"),
     );
   });
 });


### PR DESCRIPTION
Updated the 'wave plugin list' command to return the plugin name in the 'plugin_name@market_name' format for easier copying and usage in other commands.