### PR TITLE
feat: remove workdir filtering from bash history

### DIFF
--- a/packages/agent-sdk/tests/utils/bashHistoryDelete.test.ts
+++ b/packages/agent-sdk/tests/utils/bashHistoryDelete.test.ts
@@ -78,6 +78,29 @@ describe("deleteBashCommandFromHistory", () => {
     ).toBeUndefined();
   });
 
+  it("should delete all instances of a command if workdir is not provided", () => {
+    const mockHistory = {
+      version: 1,
+      commands: [
+        { command: "ls", timestamp: 1000, workdir: "/dir1" },
+        { command: "cd ..", timestamp: 2000, workdir: "/dir2" },
+        { command: "ls", timestamp: 3000, workdir: "/dir3" },
+      ],
+    };
+
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(mockHistory));
+
+    deleteBashCommandFromHistory("ls");
+
+    expect(fs.writeFileSync).toHaveBeenCalled();
+    const [, data] = vi.mocked(fs.writeFileSync).mock.calls[0];
+    const savedHistory = JSON.parse(data as string) as BashHistory;
+
+    expect(savedHistory.commands).toHaveLength(1);
+    expect(savedHistory.commands[0].command).toBe("cd ..");
+  });
+
   it("should not save if command is not found", () => {
     const workdir = "/test/workdir";
     const mockHistory = {

--- a/packages/code/src/components/BashHistorySelector.tsx
+++ b/packages/code/src/components/BashHistorySelector.tsx
@@ -23,7 +23,7 @@ export const BashHistorySelector: React.FC<BashHistorySelectorProps> = ({
 
   // Search bash history
   useEffect(() => {
-    const results = searchBashHistory(searchQuery, 10, workdir);
+    const results = searchBashHistory(searchQuery, 10);
     setCommands(results);
     setSelectedIndex(0);
     logger.debug("Bash history search:", {


### PR DESCRIPTION
This PR removes the working directory filtering from bash history search and recent commands, allowing users to see and search their command history across all directories. It also makes the workdir parameter optional in deleteBashCommandFromHistory to allow global command deletion.