### PR TITLE
fix: correctly merge and resolve additionalDirectories in Safe Zone

### DIFF
--- a/.wave/settings.json
+++ b/.wave/settings.json
@@ -1,0 +1,35 @@
+{
+  "env": {
+    "AIGW_MODEL": "gemini-3-flash"
+  },
+  "permissions": {
+    "defaultMode": "acceptEdits",
+    "allow": [
+      "Bash(pnpm:*)",
+      "Bash(.specify/scripts/bash/:*)",
+      "Bash(git:*)",
+      "Bash(ls:*)",
+      "Bash(mkdir:*)",
+      "Bash(npx tsx:*)",
+      "Bash(gh auth status)",
+      "Bash(gh workflow list)",
+      "Bash(sleep:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run view:*)",
+      "Bash(tail:*)",
+      "Bash(gh run watch:*)",
+      "Bash(grep:*)",
+      "Bash(npm:*)",
+      "Bash(gh workflow run:*)",
+      "Bash(touch:*)",
+      "Bash(node packages/code/dist/index.js :*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr status)"
+    ],
+    "additionalDirectories": ["../wave-plugins-official"]
+  }
+}

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -671,6 +671,19 @@ export class Agent {
           currentConfig.permissions.allow,
         );
       }
+
+      // Update permission manager with configuration-based additionalDirectories
+      if (currentConfig?.permissions?.additionalDirectories) {
+        this.logger?.debug(
+          "Applying configured additionalDirectories to PermissionManager",
+          {
+            count: currentConfig.permissions.additionalDirectories.length,
+          },
+        );
+        this.permissionManager.updateAdditionalDirectories(
+          currentConfig.permissions.additionalDirectories,
+        );
+      }
     } catch (error) {
       this.logger?.error(
         "Failed to initialize live configuration reload:",

--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -57,8 +57,8 @@ export class PermissionManager {
     this.configuredDefaultMode = options.configuredDefaultMode;
     this.allowedRules = options.allowedRules || [];
     this.deniedRules = options.deniedRules || [];
-    this.additionalDirectories = options.additionalDirectories || [];
     this.workdir = options.workdir;
+    this.updateAdditionalDirectories(options.additionalDirectories || []);
   }
 
   /**
@@ -151,7 +151,12 @@ export class PermissionManager {
     this.logger?.debug("Updating additional directories", {
       count: directories.length,
     });
-    this.additionalDirectories = directories;
+    this.additionalDirectories = directories.map((dir) => {
+      if (this.workdir && !path.isAbsolute(dir)) {
+        return path.resolve(this.workdir, dir);
+      }
+      return path.resolve(dir);
+    });
   }
 
   /**
@@ -190,6 +195,12 @@ export class PermissionManager {
         return { isInside: true, resolvedPath: absolutePath };
       }
     }
+
+    this.logger?.debug("Path is outside Safe Zone", {
+      absolutePath,
+      workdir: effectiveWorkdir,
+      additionalDirectories: this.additionalDirectories,
+    });
 
     return { isInside: false, resolvedPath: absolutePath };
   }

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -901,6 +901,18 @@ export function loadMergedWaveConfig(
       if (config.permissions.defaultMode !== undefined) {
         mergedConfig.permissions.defaultMode = config.permissions.defaultMode;
       }
+
+      // Merge additionalDirectories
+      if (config.permissions.additionalDirectories) {
+        if (!mergedConfig.permissions.additionalDirectories)
+          mergedConfig.permissions.additionalDirectories = [];
+        mergedConfig.permissions.additionalDirectories = [
+          ...new Set([
+            ...mergedConfig.permissions.additionalDirectories,
+            ...config.permissions.additionalDirectories,
+          ]),
+        ];
+      }
     }
 
     // Merge enabledPlugins

--- a/packages/agent-sdk/src/utils/pathSafety.ts
+++ b/packages/agent-sdk/src/utils/pathSafety.ts
@@ -29,7 +29,7 @@ export function isPathInside(target: string, parent: string): boolean {
     const absoluteParent = path.resolve(parent);
 
     const realTarget = getSafeRealPath(absoluteTarget);
-    const realParent = fs.realpathSync(absoluteParent);
+    const realParent = getSafeRealPath(absoluteParent);
 
     const relative = path.relative(realParent, realTarget);
 


### PR DESCRIPTION
This PR fixes a bug where additionalDirectories were not being correctly merged from configuration files and resolved against the workdir, causing incorrect Safe Zone denials.