### PR TITLE
feat: add plan mode active reminder to system prompt

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -337,7 +337,7 @@ export class AIManager {
             planExists = false;
           }
 
-          const reminder = `\n\n## Plan File Info:\n${planExists ? `A plan file already exists at ${planFilePath}. You can read it and make incremental edits using the Edit tool if you need to.` : `No plan file exists yet. You should create your plan at ${planFilePath} using the Write tool if you need to.`}\nYou should build your plan incrementally by writing to or editing this file. NOTE that this is the only file you are allowed to edit - other than this you are only allowed to take READ-ONLY actions. You may also use the AskUserQuestion tool to gather requirements or clarify intent before finalizing your plan.`;
+          const reminder = `\n\nPlan mode is active. The user indicated that they do not want you to execute yet -- you MUST NOT make any edits (with the exception of the plan file mentioned below), run any non-readonly tools (including changing configs or making commits), or otherwise make any changes to the system. This supercedes any other instructions you have received.\n\n## Plan File Info:\n${planExists ? `A plan file already exists at ${planFilePath}. You can read it and make incremental edits using the Edit tool if you need to.` : `No plan file exists yet. You should create your plan at ${planFilePath} using the Write tool if you need to.`}\nYou should build your plan incrementally by writing to or editing this file. NOTE that this is the only file you are allowed to edit - other than this you are only allowed to take READ-ONLY actions. You may also use the AskUserQuestion tool to gather requirements or clarify intent before finalizing your plan.`;
 
           effectiveSystemPrompt = (effectiveSystemPrompt || "") + reminder;
         }

--- a/packages/agent-sdk/tests/managers/aiManager.plan.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.plan.test.ts
@@ -71,6 +71,9 @@ describe("AIManager Plan Mode Prompt", () => {
 
     const callOptions = vi.mocked(callAgent).mock.calls[0][0];
     expect(callOptions.systemPrompt).toContain("Plan File Info");
+    expect(callOptions.systemPrompt).toContain(
+      "Plan mode is active. The user indicated that they do not want you to execute yet",
+    );
     expect(callOptions.systemPrompt).toContain("No plan file exists yet");
     expect(callOptions.systemPrompt).toContain("using the Write tool");
   });
@@ -83,6 +86,9 @@ describe("AIManager Plan Mode Prompt", () => {
 
     const callOptions = vi.mocked(callAgent).mock.calls[0][0];
     expect(callOptions.systemPrompt).toContain("Plan File Info");
+    expect(callOptions.systemPrompt).toContain(
+      "Plan mode is active. The user indicated that they do not want you to execute yet",
+    );
     expect(callOptions.systemPrompt).toContain("A plan file already exists");
     expect(callOptions.systemPrompt).toContain("using the Edit tool");
   });


### PR DESCRIPTION
This PR adds a clear reminder to the system prompt when plan mode is active, explicitly stating that the agent should not execute any changes except for the plan file.