### PR TITLE
feat: add Ctrl+d shortcut to delete bash history entries

### DIFF
--- a/packages/code/src/components/BashHistorySelector.tsx
+++ b/packages/code/src/components/BashHistorySelector.tsx
@@ -8,6 +8,7 @@ export interface BashHistorySelectorProps {
   workdir: string;
   onSelect: (command: string) => void;
   onExecute: (command: string) => void;
+  onDelete: (command: string, workdir?: string) => void;
   onCancel: () => void;
 }
 
@@ -16,10 +17,12 @@ export const BashHistorySelector: React.FC<BashHistorySelectorProps> = ({
   workdir,
   onSelect,
   onExecute,
+  onDelete,
   onCancel,
 }) => {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [commands, setCommands] = useState<BashHistoryEntry[]>([]);
+  const [refreshCounter, setRefreshCounter] = useState(0);
 
   // Search bash history
   useEffect(() => {
@@ -30,8 +33,9 @@ export const BashHistorySelector: React.FC<BashHistorySelectorProps> = ({
       searchQuery,
       workdir,
       resultCount: results.length,
+      refreshCounter,
     });
-  }, [searchQuery, workdir]);
+  }, [searchQuery, workdir, refreshCounter]);
 
   useInput((input, key) => {
     logger.debug("BashHistorySelector useInput:", {
@@ -65,6 +69,15 @@ export const BashHistorySelector: React.FC<BashHistorySelectorProps> = ({
 
     if (key.escape) {
       onCancel();
+      return;
+    }
+
+    if (key.ctrl && input === "d") {
+      if (commands.length > 0 && selectedIndex < commands.length) {
+        const selectedCommand = commands[selectedIndex];
+        onDelete(selectedCommand.command, selectedCommand.workdir);
+        setRefreshCounter((prev) => prev + 1);
+      }
       return;
     }
 
@@ -155,7 +168,8 @@ export const BashHistorySelector: React.FC<BashHistorySelectorProps> = ({
 
       <Box>
         <Text dimColor>
-          Use ↑↓ to navigate, Enter to execute, Tab to insert, Escape to cancel
+          Use ↑↓ to navigate, Enter to execute, Tab to insert, Ctrl+d to remove,
+          Escape to cancel
         </Text>
       </Box>
     </Box>

--- a/packages/code/src/components/InputBox.tsx
+++ b/packages/code/src/components/InputBox.tsx
@@ -103,6 +103,7 @@ export const InputBox: React.FC<InputBoxProps> = ({
     setUserInputHistory,
     // Complex handlers combining multiple operations
     handleBashHistoryExecuteAndSend,
+    handleBashHistoryDelete,
     // Main handler
     handleInput,
     // Manager ready state
@@ -188,6 +189,7 @@ export const InputBox: React.FC<InputBoxProps> = ({
           workdir={currentWorkdir}
           onSelect={handleBashHistorySelect}
           onExecute={handleBashHistoryExecuteAndSend}
+          onDelete={handleBashHistoryDelete}
           onCancel={handleCancelBashHistorySelect}
         />
       )}

--- a/packages/code/src/hooks/useInputManager.ts
+++ b/packages/code/src/hooks/useInputManager.ts
@@ -324,6 +324,13 @@ export const useInputManager = (
     managerRef.current?.handleBashHistoryExecuteAndSend(command);
   }, []);
 
+  const handleBashHistoryDelete = useCallback(
+    (command: string, workdir?: string) => {
+      managerRef.current?.handleBashHistoryDelete(command, workdir);
+    },
+    [],
+  );
+
   return {
     // State
     inputText,
@@ -445,6 +452,7 @@ export const useInputManager = (
 
     // Complex handlers combining multiple operations
     handleBashHistoryExecuteAndSend,
+    handleBashHistoryDelete,
 
     // Main input handler
     handleInput: useCallback(

--- a/packages/code/src/managers/InputManager.ts
+++ b/packages/code/src/managers/InputManager.ts
@@ -1,6 +1,7 @@
 import { FileItem } from "../components/FileSelector.js";
 import {
   searchFiles as searchFilesUtil,
+  deleteBashCommandFromHistory,
   PermissionMode,
   Logger,
 } from "wave-agent-sdk";
@@ -509,6 +510,16 @@ export class InputManager {
       : `!${commandToExecute}`;
     this.clearInput();
     this.callbacks.onSendMessage?.(bashCommand);
+  }
+
+  handleBashHistoryDelete(command: string, workdir?: string): void {
+    deleteBashCommandFromHistory(command, workdir);
+    // Trigger a refresh of the selector state to force re-render of BashHistorySelector
+    this.callbacks.onBashHistorySelectorStateChange?.(
+      this.showBashHistorySelector,
+      this.bashHistorySearchQuery,
+      this.exclamationPosition,
+    );
   }
 
   checkForExclamationDeletion(cursorPosition: number): boolean {


### PR DESCRIPTION
Allows users to delete bash history entries using Ctrl+d in the BashHistorySelector. The Delete key remains available for filtering.