### PR TITLE
feat: auto-append arguments to slash commands when no placeholders exist

### DIFF
--- a/packages/agent-sdk/src/managers/slashCommandManager.ts
+++ b/packages/agent-sdk/src/managers/slashCommandManager.ts
@@ -84,10 +84,18 @@ export class SlashCommandManager {
           description,
           handler: async (args?: string) => {
             // Substitute parameters in the command content
-            const processedContent =
-              hasParameterPlaceholders(command.content) && args
-                ? substituteCommandParameters(command.content, args)
-                : command.content;
+            let processedContent = command.content;
+            if (args) {
+              if (hasParameterPlaceholders(command.content)) {
+                processedContent = substituteCommandParameters(
+                  command.content,
+                  args,
+                );
+              } else {
+                // If no placeholders, append arguments to the content
+                processedContent = `${command.content.trim()} ${args}`;
+              }
+            }
 
             await this.executeCustomCommandInMainAgent(
               command.name,
@@ -130,10 +138,18 @@ export class SlashCommandManager {
         description,
         handler: async (args?: string) => {
           // Substitute parameters in the command content
-          const processedContent =
-            hasParameterPlaceholders(command.content) && args
-              ? substituteCommandParameters(command.content, args)
-              : command.content;
+          let processedContent = command.content;
+          if (args) {
+            if (hasParameterPlaceholders(command.content)) {
+              processedContent = substituteCommandParameters(
+                command.content,
+                args,
+              );
+            } else {
+              // If no placeholders, append arguments to the content
+              processedContent = `${command.content.trim()} ${args}`;
+            }
+          }
 
           await this.executeCustomCommandInMainAgent(
             namespacedName,

--- a/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
+++ b/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { SlashCommandManager } from "../../src/managers/slashCommandManager.js";
 import { MessageManager } from "../../src/managers/messageManager.js";
 import { AIManager } from "../../src/managers/aiManager.js";
-import { CustomSlashCommand } from "../../src/types/index.js";
+import { CustomSlashCommand, TextBlock } from "../../src/types/index.js";
 
 describe("SlashCommandManager", () => {
   let slashCommandManager: SlashCommandManager;
@@ -164,6 +164,32 @@ describe("SlashCommandManager", () => {
       expect(slashCommandManager.hasCommand("test-plugin:cmd1")).toBe(true);
       const cmd = slashCommandManager.getCommand("test-plugin:cmd1");
       expect(cmd?.name).toBe("test-plugin:cmd1");
+    });
+
+    it("should append arguments to content if no placeholders are present", async () => {
+      const pluginName = "test-plugin";
+      const commands = [
+        {
+          id: "append-test",
+          name: "append-test",
+          content: "Base content",
+        },
+      ];
+
+      slashCommandManager.registerPluginCommands(
+        pluginName,
+        commands as unknown as CustomSlashCommand[],
+      );
+
+      const cmd = slashCommandManager.getCommand("test-plugin:append-test");
+      await cmd?.handler("extra arguments");
+
+      const messages = messageManager.getMessages();
+      const lastMessage = messages[messages.length - 1];
+      const textBlock = lastMessage.blocks[0] as TextBlock;
+      expect(textBlock.customCommandContent).toBe(
+        "Base content extra arguments",
+      );
     });
   });
 });

--- a/specs/005-slash-commands-spec/contracts/slash-command-manager.md
+++ b/specs/005-slash-commands-spec/contracts/slash-command-manager.md
@@ -110,8 +110,9 @@ interface ParameterSubstitution {
   // Processing order
   order: [
     "parse-arguments",
-    "substitute-$ARGUMENTS", 
-    "substitute-positional-descending",
+    "check-for-placeholders",
+    "if-placeholders-exist:substitute-$ARGUMENTS-and-positional",
+    "if-no-placeholders:append-arguments-to-content",
     "execute-bash-commands",
     "send-to-ai-manager"
   ]

--- a/specs/005-slash-commands-spec/data-model.md
+++ b/specs/005-slash-commands-spec/data-model.md
@@ -157,10 +157,14 @@ echo "Current directory: $(pwd)"
 
 **Processing Order**:
 1. Parse command arguments into array
-2. Replace `$ARGUMENTS` with raw input
-3. Replace positional parameters `$N` in descending order (prevents `$10` → `$1` + "0")
-4. Execute any embedded bash commands
-5. Send processed content to AI manager
+2. Check if content contains any parameter placeholders ($ARGUMENTS, $1, etc.)
+3. If placeholders exist:
+   a. Replace `$ARGUMENTS` with raw input
+   b. Replace positional parameters `$N` in descending order
+4. If NO placeholders exist and arguments are provided:
+   a. Append arguments to the end of command content
+5. Execute any embedded bash commands
+6. Send processed content to AI manager
 
 ## Error States and Recovery
 

--- a/specs/005-slash-commands-spec/spec.md
+++ b/specs/005-slash-commands-spec/spec.md
@@ -52,6 +52,7 @@ Users can create commands that accept arguments and use parameter substitution t
 1. **Given** a command contains `$ARGUMENTS` in its content, **When** user executes `/command-name some arguments`, **Then** `$ARGUMENTS` is replaced with "some arguments"
 2. **Given** a command contains `$1 $2` placeholders, **When** user executes `/command-name first second`, **Then** `$1` becomes "first" and `$2` becomes "second"
 3. **Given** a command expects parameters, **When** user provides quoted arguments with spaces, **Then** the quoted content is treated as a single parameter
+4. **Given** a command contains NO parameter placeholders, **When** user executes `/command-name some arguments`, **Then** "some arguments" is automatically appended to the command content
 
 ---
 
@@ -110,6 +111,7 @@ Users can define commands at both project level (`.wave/commands/`) and user lev
 - **FR-010**: System MUST validate slash command syntax and provide appropriate error handling for malformed commands
 - **FR-011**: System MUST support command abortion/cancellation for long-running operations
 - **FR-012**: System MUST log command execution status and errors for debugging purposes
+- **FR-013**: System MUST automatically append user arguments to command content if the command markdown contains no parameter placeholders ($ARGUMENTS or $1, $2, etc.)
 
 ### Key Entities
 


### PR DESCRIPTION
This PR implements a new feature for custom slash commands: if a command markdown contains no parameter placeholders ( or , , etc.), user arguments are automatically appended to the command content. This improves usability for simple commands that don't explicitly define parameters.