### PR TITLE
ui: remove left padding from permission mode display in InputBox

### DIFF
--- a/packages/code/src/components/InputBox.tsx
+++ b/packages/code/src/components/InputBox.tsx
@@ -236,7 +236,7 @@ export const InputBox: React.FC<InputBoxProps> = ({
               )}
             </Text>
           </Box>
-          <Box paddingX={1}>
+          <Box paddingRight={1}>
             <Text color="gray">
               Mode:{" "}
               <Text color={permissionMode === "plan" ? "yellow" : "cyan"}>


### PR DESCRIPTION
This PR removes the left padding from the permission mode display in the InputBox component to align it with the input text.