### PR TITLE
feat: update selector components to have only top border

### DIFF
--- a/packages/code/src/components/BashHistorySelector.tsx
+++ b/packages/code/src/components/BashHistorySelector.tsx
@@ -98,8 +98,10 @@ export const BashHistorySelector: React.FC<BashHistorySelectorProps> = ({
         flexDirection="column"
         borderStyle="single"
         borderColor="yellow"
-        padding={1}
-        marginBottom={1}
+        borderBottom={false}
+        borderLeft={false}
+        borderRight={false}
+        paddingTop={1}
       >
         <Text color="yellow">
           No bash history found {searchQuery && `for "${searchQuery}"`}
@@ -137,9 +139,11 @@ export const BashHistorySelector: React.FC<BashHistorySelectorProps> = ({
       flexDirection="column"
       borderStyle="single"
       borderColor="blue"
-      padding={1}
+      borderBottom={false}
+      borderLeft={false}
+      borderRight={false}
+      paddingTop={1}
       gap={1}
-      marginBottom={1}
     >
       <Box>
         <Text color="blue" bold>

--- a/packages/code/src/components/BashShellManager.tsx
+++ b/packages/code/src/components/BashShellManager.tsx
@@ -133,9 +133,11 @@ export const BashShellManager: React.FC<BashShellManagerProps> = ({
         flexDirection="column"
         borderStyle="single"
         borderColor="cyan"
-        padding={1}
+        borderBottom={false}
+        borderLeft={false}
+        borderRight={false}
+        paddingTop={1}
         gap={1}
-        marginBottom={1}
       >
         <Box>
           <Text color="cyan" bold>
@@ -211,8 +213,10 @@ export const BashShellManager: React.FC<BashShellManagerProps> = ({
         flexDirection="column"
         borderStyle="single"
         borderColor="cyan"
-        padding={1}
-        marginBottom={1}
+        borderBottom={false}
+        borderLeft={false}
+        borderRight={false}
+        paddingTop={1}
       >
         <Text color="cyan" bold>
           Background Bash Shells
@@ -229,8 +233,10 @@ export const BashShellManager: React.FC<BashShellManagerProps> = ({
         flexDirection="column"
         borderStyle="single"
         borderColor="cyan"
-        padding={1}
-        marginBottom={1}
+        borderBottom={false}
+        borderLeft={false}
+        borderRight={false}
+        paddingTop={1}
       >
         <Text color="cyan" bold>
           Background Bash Shells
@@ -246,9 +252,11 @@ export const BashShellManager: React.FC<BashShellManagerProps> = ({
       flexDirection="column"
       borderStyle="single"
       borderColor="cyan"
-      padding={1}
+      borderBottom={false}
+      borderLeft={false}
+      borderRight={false}
+      paddingTop={1}
       gap={1}
-      marginBottom={1}
     >
       <Box>
         <Text color="cyan" bold>

--- a/packages/code/src/components/CommandSelector.tsx
+++ b/packages/code/src/components/CommandSelector.tsx
@@ -91,8 +91,10 @@ export const CommandSelector: React.FC<CommandSelectorProps> = ({
         flexDirection="column"
         borderStyle="single"
         borderColor="yellow"
-        padding={1}
-        marginBottom={1}
+        borderBottom={false}
+        borderLeft={false}
+        borderRight={false}
+        paddingTop={1}
       >
         <Text color="yellow">No commands found for "{searchQuery}"</Text>
         <Text dimColor>Press Escape to cancel</Text>
@@ -105,9 +107,11 @@ export const CommandSelector: React.FC<CommandSelectorProps> = ({
       flexDirection="column"
       borderStyle="single"
       borderColor="magenta"
-      padding={1}
+      borderBottom={false}
+      borderLeft={false}
+      borderRight={false}
+      paddingTop={1}
       gap={1}
-      marginBottom={1}
     >
       <Box>
         <Text color="magenta" bold>

--- a/packages/code/src/components/Confirmation.tsx
+++ b/packages/code/src/components/Confirmation.tsx
@@ -359,8 +359,7 @@ export const Confirmation: React.FC<ConfirmationProps> = ({
       borderBottom={false}
       borderLeft={false}
       borderRight={false}
-      padding={1}
-      marginBottom={1}
+      paddingTop={1}
     >
       <Text color="yellow" bold>
         Tool: {toolName}

--- a/packages/code/src/components/FileSelector.tsx
+++ b/packages/code/src/components/FileSelector.tsx
@@ -49,8 +49,10 @@ export const FileSelector: React.FC<FileSelectorProps> = ({
         flexDirection="column"
         borderStyle="single"
         borderColor="yellow"
-        padding={1}
-        marginBottom={1}
+        borderBottom={false}
+        borderLeft={false}
+        borderRight={false}
+        paddingTop={1}
       >
         <Text color="yellow">📁 No files found for "{searchQuery}"</Text>
         <Text dimColor>Press Escape to cancel</Text>
@@ -86,8 +88,10 @@ export const FileSelector: React.FC<FileSelectorProps> = ({
       flexDirection="column"
       borderStyle="single"
       borderColor="cyan"
-      padding={1}
-      marginBottom={1}
+      borderBottom={false}
+      borderLeft={false}
+      borderRight={false}
+      paddingTop={1}
     >
       <Text color="cyan" bold>
         📁 Select File/Directory{" "}

--- a/packages/code/src/components/McpManager.tsx
+++ b/packages/code/src/components/McpManager.tsx
@@ -144,9 +144,11 @@ export const McpManager: React.FC<McpManagerProps> = ({
         flexDirection="column"
         borderStyle="single"
         borderColor="cyan"
-        padding={1}
+        borderBottom={false}
+        borderLeft={false}
+        borderRight={false}
+        paddingTop={1}
         gap={1}
-        marginBottom={1}
       >
         <Box>
           <Text color="cyan" bold>
@@ -247,8 +249,10 @@ export const McpManager: React.FC<McpManagerProps> = ({
         flexDirection="column"
         borderStyle="single"
         borderColor="cyan"
-        padding={1}
-        marginBottom={1}
+        borderBottom={false}
+        borderLeft={false}
+        borderRight={false}
+        paddingTop={1}
       >
         <Text color="cyan" bold>
           Manage MCP servers
@@ -267,9 +271,11 @@ export const McpManager: React.FC<McpManagerProps> = ({
       flexDirection="column"
       borderStyle="single"
       borderColor="cyan"
-      padding={1}
+      borderBottom={false}
+      borderLeft={false}
+      borderRight={false}
+      paddingTop={1}
       gap={1}
-      marginBottom={1}
     >
       <Box>
         <Text color="cyan" bold>

--- a/packages/code/src/components/MemoryTypeSelector.tsx
+++ b/packages/code/src/components/MemoryTypeSelector.tsx
@@ -55,9 +55,11 @@ export const MemoryTypeSelector: React.FC<MemoryTypeSelectorProps> = ({
       flexDirection="column"
       borderStyle="single"
       borderColor="green"
-      padding={1}
+      borderBottom={false}
+      borderLeft={false}
+      borderRight={false}
+      paddingTop={1}
       gap={1}
-      marginBottom={1}
     >
       <Box>
         <Text color="green" bold>

--- a/packages/code/tests/components/Confirmation.test.tsx
+++ b/packages/code/tests/components/Confirmation.test.tsx
@@ -740,9 +740,11 @@ describe("Confirmation", () => {
       // Wait for text and selection to update
       await new Promise((resolve) => setTimeout(resolve, 100));
 
-      // Verify we're on alternative option and see the spaces
+      // Verify we're on alternative option and placeholder is gone
       const frameAfterSpaces = lastFrame();
-      expect(frameAfterSpaces).toContain("   ");
+      expect(frameAfterSpaces).not.toContain(
+        "Type here to tell Wave what to do differently",
+      );
       expect(frameAfterSpaces).toContain("> 3.");
 
       // Try to confirm - should not call onDecision because trimmed text is empty


### PR DESCRIPTION
Update all selector components and the confirmation component to have only a top border and remove unnecessary padding and margins to save space and align with the confirm component.