### PR TITLE
fix(agent-sdk): limit grep output line length

### DIFF
--- a/packages/agent-sdk/src/tools/grepTool.ts
+++ b/packages/agent-sdk/src/tools/grepTool.ts
@@ -119,7 +119,7 @@ export const grepTool: ToolPlugin = {
 
     try {
       const workdir = context.workdir;
-      const rgArgs: string[] = ["--color=never"];
+      const rgArgs: string[] = ["--color=never", "--max-columns=500"];
 
       // Set output mode
       if (outputMode === "files_with_matches") {

--- a/packages/agent-sdk/tests/tools/grepTool.test.ts
+++ b/packages/agent-sdk/tests/tools/grepTool.test.ts
@@ -207,7 +207,7 @@ src/utils.ts:1:export const logger = {};
     // Verify that the -i flag was passed
     expect(mockSpawn).toHaveBeenCalledWith(
       "/mock/rg",
-      expect.arrayContaining(["-i"]),
+      expect.arrayContaining(["-i", "--max-columns=500"]),
       expect.any(Object),
     );
   });


### PR DESCRIPTION
Limit ripgrep output line length to 500 characters to reduce token usage, matching Claude Code behavior.