### PR TITLE
refactor: replace hardcoded tool name strings with centralized constants

### DIFF
--- a/packages/agent-sdk/src/constants/prompts.ts
+++ b/packages/agent-sdk/src/constants/prompts.ts
@@ -1,3 +1,17 @@
+import {
+  ASK_USER_QUESTION_TOOL_NAME,
+  BASH_TOOL_NAME,
+  EDIT_TOOL_NAME,
+  GLOB_TOOL_NAME,
+  GREP_TOOL_NAME,
+  LS_TOOL_NAME,
+  MULTI_EDIT_TOOL_NAME,
+  READ_TOOL_NAME,
+  TASK_TOOL_NAME,
+  TODO_WRITE_TOOL_NAME,
+  WRITE_TOOL_NAME,
+} from "./tools.js";
+
 export const BASE_SYSTEM_PROMPT = `You are an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
 
 # Doing tasks
@@ -17,21 +31,21 @@ The user will primarily request you perform software engineering tasks. This inc
 
 export const TASK_MANAGEMENT_POLICY = `
 # Task Management
-You have access to the TodoWrite tools to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
+You have access to the ${TODO_WRITE_TOOL_NAME} tools to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
 These tools are also EXTREMELY helpful for planning tasks, and for breaking down larger complex tasks into smaller steps. If you do not use this tool when planning, you may forget to do important tasks - and that is unacceptable.
 It is critical that you mark todos as completed as soon as you are done with a task. Do not batch up multiple tasks before marking them as completed.`;
 
 export const ASK_USER_POLICY = `
 # Asking questions as you work
-You have access to the AskUserQuestion tool to ask the user questions when you need clarification, want to validate assumptions, or need to make a decision you're unsure about. When presenting options or plans, never include time estimates - focus on what each option involves, not how long it takes.`;
+You have access to the ${ASK_USER_QUESTION_TOOL_NAME} tool to ask the user questions when you need clarification, want to validate assumptions, or need to make a decision you're unsure about. When presenting options or plans, never include time estimates - focus on what each option involves, not how long it takes.`;
 
 export const SUBAGENT_POLICY = `
-- When doing file search, prefer to use the Task tool in order to reduce context usage.
-- You should proactively use the Task tool with specialized agents when the task at hand matches the agent's description.
-- VERY IMPORTANT: When exploring the codebase to gather context or to answer a question that is not a needle query for a specific file/class/function, it is CRITICAL that you use the Task tool with subagent_type=Explore instead of running search commands directly.`;
+- When doing file search, prefer to use the ${TASK_TOOL_NAME} tool in order to reduce context usage.
+- You should proactively use the ${TASK_TOOL_NAME} tool with specialized agents when the task at hand matches the agent's description.
+- VERY IMPORTANT: When exploring the codebase to gather context or to answer a question that is not a needle query for a specific file/class/function, it is CRITICAL that you use the ${TASK_TOOL_NAME} tool with subagent_type=Explore instead of running search commands directly.`;
 
 export const FILE_TOOL_POLICY = `
-- Use specialized tools instead of bash commands when possible, as this provides a better user experience. For file operations, use dedicated tools: Read for reading files instead of cat/head/tail, Edit/MultiEdit for editing instead of sed/awk, Write for creating files instead of cat with heredoc or echo redirection, and LS/Glob/Grep for searching and listing files instead of find/ls/grep.`;
+- Use specialized tools instead of bash commands when possible, as this provides a better user experience. For file operations, use dedicated tools: ${READ_TOOL_NAME} for reading files instead of cat/head/tail, ${EDIT_TOOL_NAME}/${MULTI_EDIT_TOOL_NAME} for editing instead of sed/awk, ${WRITE_TOOL_NAME} for creating files instead of cat with heredoc or echo redirection, and ${LS_TOOL_NAME}/${GLOB_TOOL_NAME}/${GREP_TOOL_NAME} for searching and listing files instead of find/ls/grep.`;
 
 export const BASH_POLICY = `
 - Reserve bash tools exclusively for actual system commands and terminal operations that require shell execution. NEVER use bash echo or other command-line tools to communicate thoughts, explanations, or instructions to the user. Output all communication directly in your response text instead.
@@ -48,30 +62,30 @@ export function buildSystemPrompt(
     tools.map((t) => t.function?.name || t.name).filter(Boolean),
   );
 
-  if (toolNames.has("TodoWrite")) {
+  if (toolNames.has(TODO_WRITE_TOOL_NAME)) {
     prompt += TASK_MANAGEMENT_POLICY;
   }
-  if (toolNames.has("AskUserQuestion")) {
+  if (toolNames.has(ASK_USER_QUESTION_TOOL_NAME)) {
     prompt += ASK_USER_POLICY;
   }
 
-  if (toolNames.has("Task")) {
+  if (toolNames.has(TASK_TOOL_NAME)) {
     prompt += SUBAGENT_POLICY;
   }
 
   if (
-    toolNames.has("Read") ||
-    toolNames.has("Edit") ||
-    toolNames.has("MultiEdit") ||
-    toolNames.has("Write") ||
-    toolNames.has("LS") ||
-    toolNames.has("Glob") ||
-    toolNames.has("Grep")
+    toolNames.has(READ_TOOL_NAME) ||
+    toolNames.has(EDIT_TOOL_NAME) ||
+    toolNames.has(MULTI_EDIT_TOOL_NAME) ||
+    toolNames.has(WRITE_TOOL_NAME) ||
+    toolNames.has(LS_TOOL_NAME) ||
+    toolNames.has(GLOB_TOOL_NAME) ||
+    toolNames.has(GREP_TOOL_NAME)
   ) {
     prompt += FILE_TOOL_POLICY;
   }
 
-  if (toolNames.has("Bash")) {
+  if (toolNames.has(BASH_TOOL_NAME)) {
     prompt += BASH_POLICY;
   }
 

--- a/packages/agent-sdk/src/constants/tools.ts
+++ b/packages/agent-sdk/src/constants/tools.ts
@@ -1,0 +1,17 @@
+export const ASK_USER_QUESTION_TOOL_NAME = "AskUserQuestion";
+export const BASH_TOOL_NAME = "Bash";
+export const BASH_OUTPUT_TOOL_NAME = "BashOutput";
+export const KILL_BASH_TOOL_NAME = "KillBash";
+export const DELETE_FILE_TOOL_NAME = "Delete";
+export const EDIT_TOOL_NAME = "Edit";
+export const EXIT_PLAN_MODE_TOOL_NAME = "ExitPlanMode";
+export const GLOB_TOOL_NAME = "Glob";
+export const GREP_TOOL_NAME = "Grep";
+export const LSP_TOOL_NAME = "LSP";
+export const LS_TOOL_NAME = "LS";
+export const MULTI_EDIT_TOOL_NAME = "MultiEdit";
+export const READ_TOOL_NAME = "Read";
+export const SKILL_TOOL_NAME = "Skill";
+export const TASK_TOOL_NAME = "Task";
+export const TODO_WRITE_TOOL_NAME = "TodoWrite";
+export const WRITE_TOOL_NAME = "Write";

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -7,6 +7,9 @@ export * from "./services/jsonlHandler.js";
 export * from "./services/configurationService.js"; // New configuration management service
 export * from "./services/MarketplaceService.js";
 
+// Export constants
+export * from "./constants/tools.js";
+
 // Export managers
 export * from "./managers/pluginManager.js";
 export * from "./managers/pluginScopeManager.js";

--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -24,6 +24,15 @@ import {
   DANGEROUS_COMMANDS,
 } from "../utils/bashParser.js";
 import { isPathInside } from "../utils/pathSafety.js";
+import {
+  BASH_TOOL_NAME,
+  EDIT_TOOL_NAME,
+  MULTI_EDIT_TOOL_NAME,
+  DELETE_FILE_TOOL_NAME,
+  WRITE_TOOL_NAME,
+  READ_TOOL_NAME,
+  LS_TOOL_NAME,
+} from "../constants/tools.js";
 
 const SAFE_COMMANDS = ["cd", "ls", "pwd", "true", "false"];
 
@@ -302,7 +311,12 @@ export class PermissionManager {
 
     // 1.1 If acceptEdits mode, allow Edit, MultiEdit, Delete, Write
     if (context.permissionMode === "acceptEdits") {
-      const autoAcceptedTools = ["Edit", "MultiEdit", "Delete", "Write"];
+      const autoAcceptedTools = [
+        EDIT_TOOL_NAME,
+        MULTI_EDIT_TOOL_NAME,
+        DELETE_FILE_TOOL_NAME,
+        WRITE_TOOL_NAME,
+      ];
       if (autoAcceptedTools.includes(context.toolName)) {
         // Enforce Safe Zone for file operations
         const targetPath = (context.toolInput?.file_path ||
@@ -342,14 +356,19 @@ export class PermissionManager {
 
     // 1.3 If plan mode, allow Read-only tools and Edit/Write for plan file
     if (context.permissionMode === "plan") {
-      if (context.toolName === "Bash") {
+      if (context.toolName === BASH_TOOL_NAME) {
         return {
           behavior: "deny",
           message: "Bash commands are not allowed in plan mode.",
         };
       }
 
-      const writeTools = ["Edit", "MultiEdit", "Write", "Delete"];
+      const writeTools = [
+        EDIT_TOOL_NAME,
+        MULTI_EDIT_TOOL_NAME,
+        WRITE_TOOL_NAME,
+        DELETE_FILE_TOOL_NAME,
+      ];
       if (writeTools.includes(context.toolName)) {
         const targetPath = (context.toolInput?.file_path ||
           context.toolInput?.target_file) as string | undefined;
@@ -457,7 +476,7 @@ export class PermissionManager {
     toolInput?: Record<string, unknown>,
   ): ToolPermissionContext {
     let suggestedPrefix: string | undefined;
-    if (toolName === "Bash" && toolInput?.command) {
+    if (toolName === BASH_TOOL_NAME && toolInput?.command) {
       const command = String(toolInput.command);
       const parts = splitBashCommand(command);
       // Only suggest prefix for single commands to avoid confusion with complex chains
@@ -476,7 +495,7 @@ export class PermissionManager {
     };
 
     // Set hidePersistentOption for dangerous or out-of-bounds bash commands
-    if (toolName === "Bash" && toolInput?.command) {
+    if (toolName === BASH_TOOL_NAME && toolInput?.command) {
       const command = String(toolInput.command);
       const workdir = toolInput.workdir as string | undefined;
       const parts = splitBashCommand(command);
@@ -547,7 +566,7 @@ export class PermissionManager {
     }
 
     // Handle Bash command rules
-    if (toolName === "Bash") {
+    if (toolName === BASH_TOOL_NAME) {
       const command = String(context.toolInput?.command || "");
       const parts = splitBashCommand(command);
       return parts.some((part) => {
@@ -560,7 +579,14 @@ export class PermissionManager {
     }
 
     // Handle path-based rules (e.g., "Read(**/*.env)")
-    const pathTools = ["Read", "Write", "Edit", "MultiEdit", "Delete", "LS"];
+    const pathTools = [
+      READ_TOOL_NAME,
+      WRITE_TOOL_NAME,
+      EDIT_TOOL_NAME,
+      MULTI_EDIT_TOOL_NAME,
+      DELETE_FILE_TOOL_NAME,
+      LS_TOOL_NAME,
+    ];
     if (pathTools.includes(toolName)) {
       const targetPath = (context.toolInput?.file_path ||
         context.toolInput?.target_file ||
@@ -583,7 +609,7 @@ export class PermissionManager {
       return true;
     }
 
-    if (context.toolName === "Bash" && context.toolInput?.command) {
+    if (context.toolName === BASH_TOOL_NAME && context.toolInput?.command) {
       const command = String(context.toolInput.command);
       const parts = splitBashCommand(command);
       if (parts.length === 0) return false;

--- a/packages/agent-sdk/src/tools/askUserQuestion.ts
+++ b/packages/agent-sdk/src/tools/askUserQuestion.ts
@@ -1,12 +1,16 @@
 import { ToolPlugin } from "./types.js";
 import { AskUserQuestionInput } from "../types/tools.js";
+import {
+  ASK_USER_QUESTION_TOOL_NAME,
+  EXIT_PLAN_MODE_TOOL_NAME,
+} from "../constants/tools.js";
 
 export const askUserQuestionTool: ToolPlugin = {
-  name: "AskUserQuestion",
+  name: ASK_USER_QUESTION_TOOL_NAME,
   config: {
     type: "function",
     function: {
-      name: "AskUserQuestion",
+      name: ASK_USER_QUESTION_TOOL_NAME,
       description: `Asks the user multiple choice questions to gather information, clarify ambiguity, understand preferences, make decisions or offer them choices.
 Use this tool when you need to ask the user questions during execution. This allows you to:
 1. Gather user preferences or requirements
@@ -19,7 +23,7 @@ Usage notes:
 - Use multiSelect: true to allow multiple answers to be selected for a question
 - If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label
 
-Plan mode note: In plan mode, use this tool to clarify requirements or choose between approaches BEFORE finalizing your plan. Do NOT use this tool to ask "Is my plan ready?" or "Should I proceed?" - use ExitPlanMode for plan approval.`,
+Plan mode note: In plan mode, use this tool to clarify requirements or choose between approaches BEFORE finalizing your plan. Do NOT use this tool to ask "Is my plan ready?" or "Should I proceed?" - use ${EXIT_PLAN_MODE_TOOL_NAME} for plan approval.`,
       parameters: {
         type: "object",
         properties: {
@@ -82,12 +86,12 @@ Plan mode note: In plan mode, use this tool to clarify requirements or choose be
 
     if (!context.permissionManager) {
       throw new Error(
-        "Permission manager is required for AskUserQuestion tool",
+        `Permission manager is required for ${ASK_USER_QUESTION_TOOL_NAME} tool`,
       );
     }
 
     const permissionContext = context.permissionManager.createContext(
-      "AskUserQuestion",
+      ASK_USER_QUESTION_TOOL_NAME,
       context.permissionMode || "default",
       context.canUseToolCallback,
       { questions },

--- a/packages/agent-sdk/src/tools/deleteFileTool.ts
+++ b/packages/agent-sdk/src/tools/deleteFileTool.ts
@@ -2,16 +2,17 @@ import { unlink } from "fs/promises";
 import { logger } from "../utils/globalLogger.js";
 import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
 import { resolvePath, getDisplayPath } from "../utils/path.js";
+import { DELETE_FILE_TOOL_NAME } from "../constants/tools.js";
 
 /**
  * Delete file tool plugin
  */
 export const deleteFileTool: ToolPlugin = {
-  name: "Delete",
+  name: DELETE_FILE_TOOL_NAME,
   config: {
     type: "function",
     function: {
-      name: "Delete",
+      name: DELETE_FILE_TOOL_NAME,
       description: `Deletes a file at the specified path. The operation will fail gracefully if:
     - The file doesn't exist
     - The operation is rejected for security reasons
@@ -51,7 +52,7 @@ export const deleteFileTool: ToolPlugin = {
       if (context.permissionManager) {
         try {
           const permissionContext = context.permissionManager.createContext(
-            "Delete",
+            DELETE_FILE_TOOL_NAME,
             context.permissionMode || "default",
             context.canUseToolCallback,
             { target_file: targetFile },
@@ -63,7 +64,7 @@ export const deleteFileTool: ToolPlugin = {
             return {
               success: false,
               content: "",
-              error: `Delete operation denied, reason: ${permissionResult.message || "No reason provided"}`,
+              error: `${DELETE_FILE_TOOL_NAME} operation denied, reason: ${permissionResult.message || "No reason provided"}`,
             };
           }
         } catch {

--- a/packages/agent-sdk/src/tools/editTool.ts
+++ b/packages/agent-sdk/src/tools/editTool.ts
@@ -6,6 +6,7 @@ import {
   findIndentationInsensitiveMatch,
   escapeRegExp,
 } from "../utils/editUtils.js";
+import { EDIT_TOOL_NAME, READ_TOOL_NAME } from "../constants/tools.js";
 
 /**
  * Format compact parameter display
@@ -22,14 +23,13 @@ function formatCompactParams(
  * Single file edit tool plugin
  */
 export const editTool: ToolPlugin = {
-  name: "Edit",
+  name: EDIT_TOOL_NAME,
   formatCompactParams,
   config: {
     type: "function",
     function: {
-      name: "Edit",
-      description:
-        "Performs exact string replacements in files. \n\nUsage:\n- You must use your `Read` tool at least once in the conversation before editing. This tool will error if you attempt an edit without reading the file. \n- When editing text from read_file tool output, ensure you preserve the exact indentation (tabs/spaces) as it appears AFTER the line number prefix. The line number prefix format is: spaces + line number + tab. Everything after that tab is the actual file content to match. Never include any part of the line number prefix in the old_string or new_string.\n- ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.\n- Only use emojis if the user explicitly requests it. Avoid adding emojis to files unless asked.\n- The edit will FAIL if `old_string` is not unique in the file. Either provide a larger string with more surrounding context to make it unique or use `replace_all` to change every instance of `old_string`. \n- Use `replace_all` for replacing and renaming strings across the file. This parameter is useful if you want to rename a variable for instance.",
+      name: EDIT_TOOL_NAME,
+      description: `Performs exact string replacements in files. \n\nUsage:\n- You must use your \`${READ_TOOL_NAME}\` tool at least once in the conversation before editing. This tool will error if you attempt an edit without reading the file. \n- When editing text from read_file tool output, ensure you preserve the exact indentation (tabs/spaces) as it appears AFTER the line number prefix. The line number prefix format is: spaces + line number + tab. Everything after that tab is the actual file content to match. Never include any part of the line number prefix in the old_string or new_string.\n- ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.\n- Only use emojis if the user explicitly requests it. Avoid adding emojis to files unless asked.\n- The edit will FAIL if \`old_string\` is not unique in the file. Either provide a larger string with more surrounding context to make it unique or use \`replace_all\` to change every instance of \`old_string\`. \n- Use \`replace_all\` for replacing and renaming strings across the file. This parameter is useful if you want to rename a variable for instance.`,
       parameters: {
         type: "object",
         properties: {
@@ -155,7 +155,7 @@ export const editTool: ToolPlugin = {
       if (context.permissionManager) {
         try {
           const permissionContext = context.permissionManager.createContext(
-            "Edit",
+            EDIT_TOOL_NAME,
             context.permissionMode || "default",
             context.canUseToolCallback,
             {
@@ -172,7 +172,7 @@ export const editTool: ToolPlugin = {
             return {
               success: false,
               content: "",
-              error: `Edit operation denied, reason: ${permissionResult.message || "No reason provided"}`,
+              error: `${EDIT_TOOL_NAME} operation denied, reason: ${permissionResult.message || "No reason provided"}`,
             };
           }
         } catch {

--- a/packages/agent-sdk/src/tools/exitPlanMode.ts
+++ b/packages/agent-sdk/src/tools/exitPlanMode.ts
@@ -1,16 +1,17 @@
 import { readFile } from "fs/promises";
 import { logger } from "../utils/globalLogger.js";
 import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
+import { EXIT_PLAN_MODE_TOOL_NAME } from "../constants/tools.js";
 
 /**
  * Exit Plan Mode Tool Plugin
  */
 export const exitPlanModeTool: ToolPlugin = {
-  name: "ExitPlanMode",
+  name: EXIT_PLAN_MODE_TOOL_NAME,
   config: {
     type: "function",
     function: {
-      name: "ExitPlanMode",
+      name: EXIT_PLAN_MODE_TOOL_NAME,
       description:
         "Use this tool when you are in plan mode and have finished writing your plan to the plan file and are ready for user approval. This tool will read the plan from the file specified in the system message and present it to the user for confirmation. You should have already written your plan to that file before calling this tool.",
       parameters: {
@@ -56,7 +57,7 @@ export const exitPlanModeTool: ToolPlugin = {
 
       // Permission check triggers the 3-option UI
       const permissionContext = context.permissionManager.createContext(
-        "ExitPlanMode",
+        EXIT_PLAN_MODE_TOOL_NAME,
         context.permissionMode || "plan",
         context.canUseToolCallback,
         { plan_content: planContent },

--- a/packages/agent-sdk/src/tools/globTool.ts
+++ b/packages/agent-sdk/src/tools/globTool.ts
@@ -3,18 +3,18 @@ import { stat } from "fs/promises";
 import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
 import { resolvePath, getDisplayPath } from "../utils/path.js";
 import { getGlobIgnorePatterns } from "../utils/fileFilter.js";
+import { GLOB_TOOL_NAME, TASK_TOOL_NAME } from "../constants/tools.js";
 
 /**
  * Glob Tool Plugin - Fast file pattern matching
  */
 export const globTool: ToolPlugin = {
-  name: "Glob",
+  name: GLOB_TOOL_NAME,
   config: {
     type: "function",
     function: {
-      name: "Glob",
-      description:
-        '- Fast file pattern matching tool that works with any codebase size\n- Supports glob patterns like "**/*.js" or "src/**/*.ts"\n- Returns matching file paths sorted by modification time\n- Use this tool when you need to find files by name patterns\n- When you are doing an open ended search that may require multiple rounds of globbing and grepping, use the Agent tool instead\n- You have the capability to call multiple tools in a single response. It is always better to speculatively perform multiple searches as a batch that are potentially useful.',
+      name: GLOB_TOOL_NAME,
+      description: `- Fast file pattern matching tool that works with any codebase size\n- Supports glob patterns like "**/*.js" or "src/**/*.ts"\n- Returns matching file paths sorted by modification time\n- Use this tool when you need to find files by name patterns\n- When you are doing an open ended search that may require multiple rounds of globbing and grepping, use the ${TASK_TOOL_NAME} tool instead\n- You have the capability to call multiple tools in a single response. It is always better to speculatively perform multiple searches as a batch that are potentially useful.`,
       parameters: {
         type: "object",
         properties: {

--- a/packages/agent-sdk/src/tools/grepTool.ts
+++ b/packages/agent-sdk/src/tools/grepTool.ts
@@ -3,18 +3,22 @@ import { spawn } from "child_process";
 import { getGlobIgnorePatterns } from "../utils/fileFilter.js";
 import { rgPath } from "@vscode/ripgrep";
 import { getDisplayPath } from "../utils/path.js";
+import {
+  GREP_TOOL_NAME,
+  BASH_TOOL_NAME,
+  TASK_TOOL_NAME,
+} from "../constants/tools.js";
 
 /**
  * Grep tool plugin - powerful search tool based on ripgrep
  */
 export const grepTool: ToolPlugin = {
-  name: "Grep",
+  name: GREP_TOOL_NAME,
   config: {
     type: "function",
     function: {
-      name: "Grep",
-      description:
-        'A powerful search tool built on ripgrep\n\n  Usage:\n  - ALWAYS use Grep for search tasks. NEVER invoke `grep` or `rg` as a Bash command. The Grep tool has been optimized for correct permissions and access.\n  - Supports full regex syntax (e.g., "log.*Error", "function\\s+\\w+")\n  - Filter files with glob parameter (e.g., "*.js", "**/*.tsx") or type parameter (e.g., "js", "py", "rust")\n  - Output modes: "content" shows matching lines, "files_with_matches" shows only file paths (default), "count" shows match counts\n  - Use Task tool for open-ended searches requiring multiple rounds\n  - Pattern syntax: Uses ripgrep (not grep) - literal braces need escaping (use `interface\\{\\}` to find `interface{}` in Go code)\n  - Multiline matching: By default patterns match within single lines only. For cross-line patterns like `struct \\{[\\s\\S]*?field`, use `multiline: true`',
+      name: GREP_TOOL_NAME,
+      description: `A powerful search tool built on ripgrep\n\n  Usage:\n  - ALWAYS use ${GREP_TOOL_NAME} for search tasks. NEVER invoke \`grep\` or \`rg\` as a ${BASH_TOOL_NAME} command. The ${GREP_TOOL_NAME} tool has been optimized for correct permissions and access.\n  - Supports full regex syntax (e.g., "log.*Error", "function\\s+\\w+")\n  - Filter files with glob parameter (e.g., "*.js", "**/*.tsx") or type parameter (e.g., "js", "py", "rust")\n  - Output modes: "content" shows matching lines, "files_with_matches" shows only file paths (default), "count" shows match counts\n  - Use ${TASK_TOOL_NAME} tool for open-ended searches requiring multiple rounds\n  - Pattern syntax: Uses ripgrep (not grep) - literal braces need escaping (use \`interface\\{\\}\` to find \`interface{}\` in Go code)\n  - Multiline matching: By default patterns match within single lines only. For cross-line patterns like \`struct \\{[\\s\\S]*?field\`, use \`multiline: true\``,
       parameters: {
         type: "object",
         properties: {

--- a/packages/agent-sdk/src/tools/lsTool.ts
+++ b/packages/agent-sdk/src/tools/lsTool.ts
@@ -3,18 +3,22 @@ import * as path from "path";
 import { minimatch } from "minimatch";
 import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
 import { isBinary, getDisplayPath } from "@/utils/path.js";
+import {
+  LS_TOOL_NAME,
+  GLOB_TOOL_NAME,
+  GREP_TOOL_NAME,
+} from "../constants/tools.js";
 
 /**
  * LS Tool Plugin - List files and directories
  */
 export const lsTool: ToolPlugin = {
-  name: "LS",
+  name: LS_TOOL_NAME,
   config: {
     type: "function",
     function: {
-      name: "LS",
-      description:
-        "Lists files and directories in a given path. The path parameter must be an absolute path, not a relative path. You can optionally provide an array of glob patterns to ignore with the ignore parameter. You should generally prefer the Glob and Grep tools, if you know which directories to search.",
+      name: LS_TOOL_NAME,
+      description: `Lists files and directories in a given path. The path parameter must be an absolute path, not a relative path. You can optionally provide an array of glob patterns to ignore with the ignore parameter. You should generally prefer the ${GLOB_TOOL_NAME} and ${GREP_TOOL_NAME} tools, if you know which directories to search.`,
       parameters: {
         type: "object",
         properties: {
@@ -65,7 +69,7 @@ export const lsTool: ToolPlugin = {
     // Check permissions
     if (context.permissionManager) {
       const permissionContext = context.permissionManager.createContext(
-        "LS",
+        LS_TOOL_NAME,
         context.permissionMode || "default",
         context.canUseToolCallback,
         args,

--- a/packages/agent-sdk/src/tools/lspTool.ts
+++ b/packages/agent-sdk/src/tools/lspTool.ts
@@ -2,6 +2,7 @@ import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
 import { relative } from "path";
 import { logger } from "../utils/globalLogger.js";
 import { getDisplayPath } from "../utils/path.js";
+import { LSP_TOOL_NAME } from "../constants/tools.js";
 import type {
   LspLocation as Location,
   LspLocationLink as LocationLink,
@@ -480,11 +481,11 @@ function formatOutgoingCallsResult(
  * LSP tool plugin - interact with LSP servers for code intelligence
  */
 export const lspTool: ToolPlugin = {
-  name: "LSP",
+  name: LSP_TOOL_NAME,
   config: {
     type: "function",
     function: {
-      name: "LSP",
+      name: LSP_TOOL_NAME,
       description: `Interact with Language Server Protocol (LSP) servers to get code intelligence features.
 
 Supported operations:

--- a/packages/agent-sdk/src/tools/multiEditTool.ts
+++ b/packages/agent-sdk/src/tools/multiEditTool.ts
@@ -6,6 +6,11 @@ import {
   findIndentationInsensitiveMatch,
   escapeRegExp,
 } from "../utils/editUtils.js";
+import {
+  MULTI_EDIT_TOOL_NAME,
+  EDIT_TOOL_NAME,
+  READ_TOOL_NAME,
+} from "../constants/tools.js";
 
 interface EditOperation {
   old_string: string;
@@ -31,14 +36,13 @@ function formatCompactParams(
  * Multi-edit tool plugin
  */
 export const multiEditTool: ToolPlugin = {
-  name: "MultiEdit",
+  name: MULTI_EDIT_TOOL_NAME,
   formatCompactParams,
   config: {
     type: "function",
     function: {
-      name: "MultiEdit",
-      description:
-        "This is a tool for making multiple edits to a single file in one operation. It is built on top of the Edit tool and allows you to perform multiple find-and-replace operations efficiently. Prefer this tool over the Edit tool when you need to make multiple edits to the same file.\n\nBefore using this tool:\n\n1. Use the Read tool to understand the file's contents and context\n2. Verify the directory path is correct\n\nTo make multiple file edits, provide the following:\n1. file_path: The absolute path to the file to modify (must be absolute, not relative)\n2. edits: An array of edit operations to perform, where each edit contains:\n   - old_string: The text to replace (must match the file contents exactly, including all whitespace and indentation)\n   - new_string: The edited text to replace the old_string\n   - replace_all: Replace all occurences of old_string. This parameter is optional and defaults to false.\n\nIMPORTANT:\n- All edits are applied in sequence, in the order they are provided\n- Each edit operates on the result of the previous edit\n- All edits must be valid for the operation to succeed - if any edit fails, none will be applied\n- This tool is ideal when you need to make several changes to different parts of the same file\n- For Jupyter notebooks (.ipynb files), use the NotebookEdit instead\n\nCRITICAL REQUIREMENTS:\n1. All edits follow the same requirements as the single Edit tool\n2. The edits are atomic - either all succeed or none are applied\n3. Plan your edits carefully to avoid conflicts between sequential operations\n\nWARNING:\n- The tool will fail if edits.old_string doesn't match the file contents exactly (including whitespace)\n- The tool will fail if edits.old_string and edits.new_string are the same\n- Since edits are applied in sequence, ensure that earlier edits don't affect the text that later edits are trying to find\n\nWhen making edits:\n- Ensure all edits result in idiomatic, correct code\n- Do not leave the code in a broken state\n- Always use absolute file paths (starting with /)\n- Only use emojis if the user explicitly requests it. Avoid adding emojis to files unless asked.\n- Use replace_all for replacing and renaming strings across the file. This parameter is useful if you want to rename a variable for instance.",
+      name: MULTI_EDIT_TOOL_NAME,
+      description: `This is a tool for making multiple edits to a single file in one operation. It is built on top of the ${EDIT_TOOL_NAME} tool and allows you to perform multiple find-and-replace operations efficiently. Prefer this tool over the ${EDIT_TOOL_NAME} tool when you need to make multiple edits to the same file.\n\nBefore using this tool:\n\n1. Use the ${READ_TOOL_NAME} tool to understand the file's contents and context\n2. Verify the directory path is correct\n\nTo make multiple file edits, provide the following:\n1. file_path: The absolute path to the file to modify (must be absolute, not relative)\n2. edits: An array of edit operations to perform, where each edit contains:\n   - old_string: The text to replace (must match the file contents exactly, including all whitespace and indentation)\n   - new_string: The edited text to replace the old_string\n   - replace_all: Replace all occurences of old_string. This parameter is optional and defaults to false.\n\nIMPORTANT:\n- All edits are applied in sequence, in the order they are provided\n- Each edit operates on the result of the previous edit\n- All edits must be valid for the operation to succeed - if any edit fails, none will be applied\n- This tool is ideal when you need to make several changes to different parts of the same file\n- For Jupyter notebooks (.ipynb files), use the NotebookEdit instead\n\nCRITICAL REQUIREMENTS:\n1. All edits follow the same requirements as the single ${EDIT_TOOL_NAME} tool\n2. The edits are atomic - either all succeed or none are applied\n3. Plan your edits carefully to avoid conflicts between sequential operations\n\nWARNING:\n- The tool will fail if edits.old_string doesn't match the file contents exactly (including whitespace)\n- The tool will fail if edits.old_string and edits.new_string are the same\n- Since edits are applied in sequence, ensure that earlier edits don't affect the text that later edits are trying to find\n\nWhen making edits:\n- Ensure all edits result in idiomatic, correct code\n- Do not leave the code in a broken state\n- Always use absolute file paths (starting with /)\n- Only use emojis if the user explicitly requests it. Avoid adding emojis to files unless asked.\n- Use replace_all for replacing and renaming strings across the file. This parameter is useful if you want to rename a variable for instance.`,
       parameters: {
         type: "object",
         properties: {
@@ -229,7 +233,7 @@ export const multiEditTool: ToolPlugin = {
       if (context.permissionManager) {
         try {
           const permissionContext = context.permissionManager.createContext(
-            "MultiEdit",
+            MULTI_EDIT_TOOL_NAME,
             context.permissionMode || "default",
             context.canUseToolCallback,
             { file_path: filePath, edits },
@@ -241,7 +245,7 @@ export const multiEditTool: ToolPlugin = {
             return {
               success: false,
               content: "",
-              error: `MultiEdit operation denied, reason: ${permissionResult.message || "No reason provided"}`,
+              error: `${MULTI_EDIT_TOOL_NAME} operation denied, reason: ${permissionResult.message || "No reason provided"}`,
             };
           }
         } catch {

--- a/packages/agent-sdk/src/tools/readTool.ts
+++ b/packages/agent-sdk/src/tools/readTool.ts
@@ -8,6 +8,7 @@ import {
   getBinaryDocumentError,
 } from "../utils/fileFormat.js";
 import { convertImageToBase64 } from "../utils/messageOperations.js";
+import { READ_TOOL_NAME } from "../constants/tools.js";
 
 /**
  * Supported image file extensions
@@ -129,13 +130,12 @@ async function processImageFile(
  * Read Tool Plugin - Read file content
  */
 export const readTool: ToolPlugin = {
-  name: "Read",
+  name: READ_TOOL_NAME,
   config: {
     type: "function",
     function: {
-      name: "Read",
-      description:
-        "Reads a file from the local filesystem. You can access any file directly by using this tool.\nAssume this tool is able to read all files on the machine. If the User provides a path to a file assume that path is valid. It is okay to read a file that does not exist; an error will be returned.\n\nUsage:\n- The file_path parameter must be an absolute path, not a relative path\n- By default, it reads up to 2000 lines starting from the beginning of the file\n- You can optionally specify a line offset and limit (especially handy for long files), but it's recommended to read the whole file by not providing these parameters\n- Any lines longer than 2000 characters will be truncated\n- Results are returned using cat -n format, with line numbers starting at 1\n- This tool allows Agent to read images (eg PNG, JPG, etc). When reading an image file the contents are presented visually as Agent is a multimodal LLM.\n- This tool can read Jupyter notebooks (.ipynb files) and returns all cells with their outputs, combining code, text, and visualizations.\n- You have the capability to call multiple tools in a single response. It is always better to speculatively read multiple files as a batch that are potentially useful.\n- You will regularly be asked to read screenshots. If the user provides a path to a screenshot ALWAYS use this tool to view the file at the path. This tool will work with all temporary file paths like /var/folders/123/abc/T/TemporaryItems/NSIRD_screencaptureui_ZfB1tD/Screenshot.png\n- If you read a file that exists but has empty contents you will receive a system reminder warning in place of file contents.\n- Binary document formats (PDF, DOC, DOCX, XLS, XLSX, PPT, PPTX) are not supported and will return an error.",
+      name: READ_TOOL_NAME,
+      description: `Reads a file from the local filesystem. You can access any file directly by using this tool.\nAssume this tool is able to read all files on the machine. If the User provides a path to a file assume that path is valid. It is okay to read a file that does not exist; an error will be returned.\n\nUsage:\n- The file_path parameter must be an absolute path, not a relative path\n- By default, it reads up to 2000 lines starting from the beginning of the file\n- You can optionally specify a line offset and limit (especially handy for long files), but it's recommended to read the whole file by not providing these parameters\n- Any lines longer than 2000 characters will be truncated\n- Results are returned using cat -n format, with line numbers starting at 1\n- This tool allows Agent to read images (eg PNG, JPG, etc). When reading an image file the contents are presented visually as Agent is a multimodal LLM.\n- This tool can read Jupyter notebooks (.ipynb files) and returns all cells with their outputs, combining code, text, and visualizations.\n- You have the capability to call multiple tools in a single response. It is always better to speculatively read multiple files as a batch that are potentially useful.\n- You will regularly be asked to read screenshots. If the user provides a path to a screenshot ALWAYS use this tool to view the file at the path. This tool will work with all temporary file paths like /var/folders/123/abc/T/TemporaryItems/NSIRD_screencaptureui_ZfB1tD/Screenshot.png\n- If you read a file that exists but has empty contents you will receive a system reminder warning in place of file contents.\n- Binary document formats (PDF, DOC, DOCX, XLS, XLSX, PPT, PPTX) are not supported and will return an error.`,
       parameters: {
         type: "object",
         properties: {
@@ -186,7 +186,7 @@ export const readTool: ToolPlugin = {
     // Check permissions
     if (context.permissionManager) {
       const permissionContext = context.permissionManager.createContext(
-        "Read",
+        READ_TOOL_NAME,
         context.permissionMode || "default",
         context.canUseToolCallback,
         args,

--- a/packages/agent-sdk/src/tools/skillTool.ts
+++ b/packages/agent-sdk/src/tools/skillTool.ts
@@ -1,5 +1,6 @@
 import type { ToolPlugin, ToolResult } from "./types.js";
 import type { SkillManager } from "../managers/skillManager.js";
+import { SKILL_TOOL_NAME } from "../constants/tools.js";
 
 /**
  * Create a skill tool plugin that uses the provided SkillManager
@@ -10,7 +11,7 @@ export function createSkillTool(skillManager: SkillManager): ToolPlugin {
   skillManager.getAvailableSkills();
 
   return {
-    name: "Skill",
+    name: SKILL_TOOL_NAME,
     get config() {
       const availableSkills = skillManager.getAvailableSkills();
 
@@ -32,7 +33,7 @@ export function createSkillTool(skillManager: SkillManager): ToolPlugin {
       return {
         type: "function" as const,
         function: {
-          name: "Skill",
+          name: SKILL_TOOL_NAME,
           description: getToolDescription(),
           parameters: {
             type: "object",

--- a/packages/agent-sdk/src/tools/taskTool.ts
+++ b/packages/agent-sdk/src/tools/taskTool.ts
@@ -1,5 +1,6 @@
 import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
 import type { SubagentManager } from "../managers/subagentManager.js";
+import { TASK_TOOL_NAME } from "../constants/tools.js";
 
 /**
  * Create a task tool plugin that uses the provided SubagentManager
@@ -10,7 +11,7 @@ export function createTaskTool(subagentManager: SubagentManager): ToolPlugin {
   subagentManager.getConfigurations();
 
   return {
-    name: "Task",
+    name: TASK_TOOL_NAME,
     get config() {
       // Get available subagents from the initialized subagent manager
       const availableSubagents = subagentManager.getConfigurations();
@@ -19,14 +20,14 @@ export function createTaskTool(subagentManager: SubagentManager): ToolPlugin {
         .join("\n");
 
       const description = `Delegate a task to a specialized subagent. Use this when you need specialized expertise or want to break down complex work into focused subtasks.
-
-Available subagents:
-${subagentList || "No subagents configured"}`;
+    
+    Available subagents:
+    ${subagentList || "No subagents configured"}`;
 
       return {
         type: "function" as const,
         function: {
-          name: "Task",
+          name: TASK_TOOL_NAME,
           description,
           parameters: {
             type: "object",

--- a/packages/agent-sdk/src/tools/todoWriteTool.ts
+++ b/packages/agent-sdk/src/tools/todoWriteTool.ts
@@ -1,4 +1,5 @@
 import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
+import { TODO_WRITE_TOOL_NAME } from "../constants/tools.js";
 
 interface TodoItem {
   content: string;
@@ -10,11 +11,11 @@ interface TodoItem {
  * TodoWrite tool for creating and managing structured task lists
  */
 export const todoWriteTool: ToolPlugin = {
-  name: "TodoWrite",
+  name: TODO_WRITE_TOOL_NAME,
   config: {
     type: "function",
     function: {
-      name: "TodoWrite",
+      name: TODO_WRITE_TOOL_NAME,
       description: `Use this tool to create and manage a structured task list for your current coding session. This helps you track progress, organize complex tasks, and demonstrate thoroughness to the user.
 It also helps the user understand the progress of the task and overall progress of their requests.
 

--- a/packages/agent-sdk/src/types/permissions.ts
+++ b/packages/agent-sdk/src/types/permissions.ts
@@ -8,6 +8,15 @@ import {
   AskUserQuestionInput,
   AskUserQuestionOption,
 } from "./tools.js";
+import {
+  EDIT_TOOL_NAME,
+  MULTI_EDIT_TOOL_NAME,
+  DELETE_FILE_TOOL_NAME,
+  BASH_TOOL_NAME,
+  WRITE_TOOL_NAME,
+  EXIT_PLAN_MODE_TOOL_NAME,
+  ASK_USER_QUESTION_TOOL_NAME,
+} from "../constants/tools.js";
 
 /** Permission mode configuration */
 export type PermissionMode =
@@ -51,13 +60,13 @@ export interface ToolPermissionContext {
 
 /** List of tools that require permission checks in default mode */
 export const RESTRICTED_TOOLS = [
-  "Edit",
-  "MultiEdit",
-  "Delete",
-  "Bash",
-  "Write",
-  "ExitPlanMode",
-  "AskUserQuestion",
+  EDIT_TOOL_NAME,
+  MULTI_EDIT_TOOL_NAME,
+  DELETE_FILE_TOOL_NAME,
+  BASH_TOOL_NAME,
+  WRITE_TOOL_NAME,
+  EXIT_PLAN_MODE_TOOL_NAME,
+  ASK_USER_QUESTION_TOOL_NAME,
 ] as const;
 
 /** Type for restricted tool names */

--- a/packages/code/src/components/Confirmation.tsx
+++ b/packages/code/src/components/Confirmation.tsx
@@ -1,6 +1,15 @@
 import React, { useState } from "react";
 import { Box, Text, useInput } from "ink";
 import type { PermissionDecision, AskUserQuestionInput } from "wave-agent-sdk";
+import {
+  BASH_TOOL_NAME,
+  EDIT_TOOL_NAME,
+  MULTI_EDIT_TOOL_NAME,
+  DELETE_FILE_TOOL_NAME,
+  WRITE_TOOL_NAME,
+  EXIT_PLAN_MODE_TOOL_NAME,
+  ASK_USER_QUESTION_TOOL_NAME,
+} from "wave-agent-sdk";
 import { Markdown } from "./Markdown.js";
 import { DiffDisplay } from "./DiffDisplay.js";
 
@@ -14,19 +23,19 @@ const getActionDescription = (
   }
 
   switch (toolName) {
-    case "Bash":
+    case BASH_TOOL_NAME:
       return `Execute command: ${toolInput.command || "unknown command"}`;
-    case "Edit":
+    case EDIT_TOOL_NAME:
       return `Edit file: ${toolInput.file_path || "unknown file"}`;
-    case "MultiEdit":
+    case MULTI_EDIT_TOOL_NAME:
       return `Edit multiple sections in: ${toolInput.file_path || "unknown file"}`;
-    case "Delete":
+    case DELETE_FILE_TOOL_NAME:
       return `Delete file: ${toolInput.target_file || "unknown file"}`;
-    case "Write":
+    case WRITE_TOOL_NAME:
       return `Write to file: ${toolInput.file_path || "unknown file"}`;
-    case "ExitPlanMode":
+    case EXIT_PLAN_MODE_TOOL_NAME:
       return "Review and approve the plan";
-    case "AskUserQuestion":
+    case ASK_USER_QUESTION_TOOL_NAME:
       return "Answer questions to clarify intent";
     default:
       return "Execute operation";
@@ -87,10 +96,10 @@ export const Confirmation: React.FC<ConfirmationProps> = ({
   const currentQuestion = questions[currentQuestionIndex];
 
   const getAutoOptionText = () => {
-    if (toolName === "ExitPlanMode") {
+    if (toolName === EXIT_PLAN_MODE_TOOL_NAME) {
       return "Yes, and auto-accept edits";
     }
-    if (toolName === "Bash") {
+    if (toolName === BASH_TOOL_NAME) {
       if (suggestedPrefix) {
         return `Yes, and don't ask again for: ${suggestedPrefix}`;
       }
@@ -107,7 +116,7 @@ export const Confirmation: React.FC<ConfirmationProps> = ({
       return;
     }
 
-    if (toolName === "AskUserQuestion") {
+    if (toolName === ASK_USER_QUESTION_TOOL_NAME) {
       if (!currentQuestion) return;
 
       const options = [...currentQuestion.options, { label: "Other" }];
@@ -219,13 +228,13 @@ export const Confirmation: React.FC<ConfirmationProps> = ({
     // Handle Enter to confirm selection
     if (key.return) {
       if (state.selectedOption === "allow") {
-        if (toolName === "ExitPlanMode") {
+        if (toolName === EXIT_PLAN_MODE_TOOL_NAME) {
           onDecision({ behavior: "allow", newPermissionMode: "default" });
         } else {
           onDecision({ behavior: "allow" });
         }
       } else if (state.selectedOption === "auto") {
-        if (toolName === "Bash") {
+        if (toolName === BASH_TOOL_NAME) {
           const rule = suggestedPrefix
             ? `Bash(${suggestedPrefix}:*)`
             : `Bash(${toolInput?.command})`;
@@ -254,7 +263,7 @@ export const Confirmation: React.FC<ConfirmationProps> = ({
     // Handle numeric keys for quick selection (only if not typing in alternative)
     if (state.selectedOption !== "alternative" || !state.hasUserInput) {
       if (input === "1") {
-        if (toolName === "ExitPlanMode") {
+        if (toolName === EXIT_PLAN_MODE_TOOL_NAME) {
           onDecision({ behavior: "allow", newPermissionMode: "default" });
         } else {
           onDecision({ behavior: "allow" });
@@ -263,7 +272,7 @@ export const Confirmation: React.FC<ConfirmationProps> = ({
       }
       if (input === "2") {
         if (!hidePersistentOption) {
-          if (toolName === "Bash") {
+          if (toolName === BASH_TOOL_NAME) {
             const rule = suggestedPrefix
               ? `Bash(${suggestedPrefix}:*)`
               : `Bash(${toolInput?.command})`;
@@ -368,7 +377,7 @@ export const Confirmation: React.FC<ConfirmationProps> = ({
 
       <DiffDisplay toolName={toolName} parameters={JSON.stringify(toolInput)} />
 
-      {toolName === "AskUserQuestion" && currentQuestion && (
+      {toolName === ASK_USER_QUESTION_TOOL_NAME && currentQuestion && (
         <Box flexDirection="column" marginTop={1}>
           <Box marginBottom={1}>
             <Box
@@ -440,8 +449,8 @@ export const Confirmation: React.FC<ConfirmationProps> = ({
         </Box>
       )}
 
-      {toolName !== "AskUserQuestion" &&
-        toolName === "ExitPlanMode" &&
+      {toolName !== ASK_USER_QUESTION_TOOL_NAME &&
+        toolName === EXIT_PLAN_MODE_TOOL_NAME &&
         !!toolInput?.plan_content && (
           <Box flexDirection="column" marginTop={1}>
             <Text color="cyan" bold>
@@ -451,7 +460,7 @@ export const Confirmation: React.FC<ConfirmationProps> = ({
           </Box>
         )}
 
-      {toolName !== "AskUserQuestion" && (
+      {toolName !== ASK_USER_QUESTION_TOOL_NAME && (
         <>
           <Box marginTop={1}>
             <Text>Do you want to proceed?</Text>
@@ -468,7 +477,7 @@ export const Confirmation: React.FC<ConfirmationProps> = ({
                 bold={state.selectedOption === "allow"}
               >
                 {state.selectedOption === "allow" ? "> " : "  "}1.{" "}
-                {toolName === "ExitPlanMode"
+                {toolName === EXIT_PLAN_MODE_TOOL_NAME
                   ? "Yes, proceed with default mode"
                   : "Yes"}
               </Text>

--- a/packages/code/src/components/DiffDisplay.tsx
+++ b/packages/code/src/components/DiffDisplay.tsx
@@ -1,5 +1,10 @@
 import React, { useMemo } from "react";
 import { Box, Text, useStdout } from "ink";
+import {
+  WRITE_TOOL_NAME,
+  EDIT_TOOL_NAME,
+  MULTI_EDIT_TOOL_NAME,
+} from "wave-agent-sdk";
 import { transformToolBlockToChanges } from "../utils/toolParameterTransforms.js";
 import { diffLines, diffWords } from "diff";
 
@@ -18,7 +23,8 @@ export const DiffDisplay: React.FC<DiffDisplayProps> = ({
   }, [stdout?.rows]);
 
   const showDiff =
-    toolName && ["Write", "Edit", "MultiEdit"].includes(toolName);
+    toolName &&
+    [WRITE_TOOL_NAME, EDIT_TOOL_NAME, MULTI_EDIT_TOOL_NAME].includes(toolName);
 
   // Diff detection and transformation using typed parameters
   const changes = useMemo(() => {


### PR DESCRIPTION
This PR refactors the codebase to use centralized constants for tool names instead of hardcoded strings. This ensures consistency across the SDK logic, system prompts, permission management, and UI components.