### PR TITLE
fix(agent-sdk): ensure plan file path is generated when default mode is plan

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -243,6 +243,7 @@ export class Agent {
       workdir: this.workdir,
     });
     this.permissionManager.setOnConfiguredDefaultModeChange((mode) => {
+      this.handlePlanModeTransition(mode);
       this.options.callbacks?.onPermissionModeChange?.(mode);
     });
 
@@ -1177,6 +1178,16 @@ export class Agent {
     this.logger?.debug("Setting permission mode", { mode });
     this.toolManager.setPermissionMode(mode);
 
+    this.handlePlanModeTransition(mode);
+
+    this.options.callbacks?.onPermissionModeChange?.(mode);
+  }
+
+  /**
+   * Handle plan mode transition, generating or clearing plan file path
+   * @param mode - The current effective permission mode
+   */
+  private handlePlanModeTransition(mode: PermissionMode): void {
     if (mode === "plan") {
       this.planManager
         .getOrGeneratePlanFilePath()
@@ -1190,8 +1201,6 @@ export class Agent {
     } else {
       this.permissionManager.setPlanFilePath(undefined);
     }
-
-    this.options.callbacks?.onPermissionModeChange?.(mode);
   }
 
   /**

--- a/packages/agent-sdk/tests/agent/agent.planModeDefault.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.planModeDefault.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Agent } from "../../src/agent.js";
+import { ConfigurationService } from "../../src/services/configurationService.js";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+// Mock ConfigurationService
+vi.mock("../../src/services/configurationService.js", () => {
+  return {
+    ConfigurationService: vi.fn().mockImplementation(() => {
+      return {
+        loadMergedConfiguration: vi.fn().mockResolvedValue({
+          success: true,
+          configuration: {
+            permissions: {
+              defaultMode: "plan",
+            },
+          },
+        }),
+        resolveGatewayConfig: vi.fn().mockReturnValue({
+          apiKey: "test-key",
+          baseURL: "https://test.api",
+        }),
+        resolveModelConfig: vi.fn().mockReturnValue({
+          agentModel: "test-model",
+          fastModel: "test-fast-model",
+        }),
+        resolveMaxInputTokens: vi.fn().mockReturnValue(100000),
+        getEnvironmentVars: vi.fn().mockReturnValue({}),
+      };
+    }),
+  };
+});
+
+// Mock fs/promises
+vi.mock("node:fs/promises", () => {
+  return {
+    default: {
+      mkdir: vi.fn().mockResolvedValue(undefined),
+      readFile: vi.fn().mockResolvedValue(""),
+      access: vi.fn().mockRejectedValue(new Error("ENOENT")),
+    },
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn().mockResolvedValue(""),
+    access: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  };
+});
+
+describe("Agent Plan Mode Default", () => {
+  const workdir = "/test/workdir";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should generate plan file path when default mode is plan in configuration", async () => {
+    const agent = await Agent.create({ workdir });
+
+    // Wait for async plan file path generation
+    // We need to wait because the callback is async and not awaited in initialize
+    let planFilePath: string | undefined;
+    for (let i = 0; i < 20; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      // @ts-expect-error - accessing private for testing
+      planFilePath = agent.permissionManager.getPlanFilePath();
+      if (planFilePath) break;
+    }
+
+    expect(agent.getPermissionMode()).toBe("plan");
+    expect(planFilePath).toBeDefined();
+    expect(planFilePath).toContain(path.join(os.homedir(), ".wave", "plans"));
+    expect(fs.mkdir).toHaveBeenCalledWith(
+      path.join(os.homedir(), ".wave", "plans"),
+      { recursive: true },
+    );
+  });
+
+  it("should NOT generate plan file path when default mode is NOT plan in configuration", async () => {
+    // Override mock for this test
+    const { ConfigurationService } = await import(
+      "../../src/services/configurationService.js"
+    );
+    vi.mocked(ConfigurationService).mockImplementationOnce(() => {
+      return {
+        loadMergedConfiguration: vi.fn().mockResolvedValue({
+          success: true,
+          configuration: {
+            permissions: {
+              defaultMode: "default",
+            },
+          },
+        }),
+        resolveGatewayConfig: vi.fn().mockReturnValue({
+          apiKey: "test-key",
+          baseURL: "https://test.api",
+        }),
+        resolveModelConfig: vi.fn().mockReturnValue({
+          agentModel: "test-model",
+          fastModel: "test-fast-model",
+        }),
+        resolveMaxInputTokens: vi.fn().mockReturnValue(100000),
+        getEnvironmentVars: vi.fn().mockReturnValue({}),
+      } as unknown as ConfigurationService;
+    });
+
+    const agent = await Agent.create({ workdir });
+
+    expect(agent.getPermissionMode()).toBe("default");
+    // @ts-expect-error - accessing private for testing
+    expect(agent.permissionManager.getPlanFilePath()).toBeUndefined();
+    expect(fs.mkdir).not.toHaveBeenCalled();
+  });
+});

--- a/specs/050-support-plan-mode/tasks.md
+++ b/specs/050-support-plan-mode/tasks.md
@@ -29,7 +29,7 @@
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
 - [X] T004 Update `PermissionManager` to support `planFilePath` and `plan` mode logic in `packages/agent-sdk/src/managers/permissionManager.ts`
-- [X] T005 Update `Agent` class to integrate `PlanManager` and handle mode transitions in `packages/agent-sdk/src/agent.ts`
+- [X] T005 Update `Agent` class to integrate `PlanManager` and handle mode transitions in `packages/agent-sdk/src/agent.ts` (Fixed: ensure plan file path is generated when default mode is plan in configuration)
 - [X] T006 Update `AIManager` to append the Plan Mode reminder (including plan file existence check) to the system prompt in `packages/agent-sdk/src/managers/aiManager.ts`
 
 **Checkpoint**: Foundation ready - user story implementation can now begin in parallel


### PR DESCRIPTION
Fixes the issue where plan file path generation was skipped when 'plan' mode was set as the default in settings. Refactored transition logic into handlePlanModeTransition and integrated it with PermissionManager's configuration change callback.