### PR TITLE
Exclude ExitPlanMode and AskUserQuestion in bypassPermissions mode

### DIFF
--- a/packages/agent-sdk/src/managers/toolManager.ts
+++ b/packages/agent-sdk/src/managers/toolManager.ts
@@ -218,6 +218,11 @@ class ToolManager {
     const effectivePermissionMode = this.getPermissionMode();
     const builtInToolsConfig = Array.from(this.tools.values())
       .filter((tool) => {
+        if (effectivePermissionMode === "bypassPermissions") {
+          if (tool.name === "ExitPlanMode" || tool.name === "AskUserQuestion") {
+            return false;
+          }
+        }
         if (tool.name === "ExitPlanMode") {
           return effectivePermissionMode === "plan";
         }

--- a/specs/051-exit-plan-mode-tool/plan.md
+++ b/specs/051-exit-plan-mode-tool/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Add an `ExitPlanMode` tool that allows the agent to signal completion of the planning phase. This tool will trigger a user confirmation (reusing `canUseTool`) with three options: Default execution, Accept Edits mode, or providing Feedback. The tool will only be available when the agent is in "plan mode" and will display the contents of the plan file to the user for review.
+Add an `ExitPlanMode` tool that allows the agent to signal completion of the planning phase. This tool will trigger a user confirmation (reusing `canUseTool`) with three options: Default execution, Accept Edits mode, or providing Feedback. The tool will only be available when the agent is in "plan mode" and will display the contents of the plan file to the user for review. It MUST NOT be available in `bypassPermissions` mode.
 
 **Technical Approach**:
 - Implement `ExitPlanMode` tool in `agent-sdk` that reads the plan file and calls `permissionManager.canUseTool`.
@@ -22,7 +22,7 @@ Add an `ExitPlanMode` tool that allows the agent to signal completion of the pla
 **Target Platform**: Linux/Node.js
 **Project Type**: Monorepo (TypeScript)
 **Performance Goals**: Instant UI response for confirmation prompt.
-**Constraints**: MUST reuse `canUseTool` mechanism; MUST only be visible in plan mode.
+**Constraints**: MUST reuse `canUseTool` mechanism; MUST only be visible in plan mode; MUST NOT be available in `bypassPermissions` mode.
 **Scale/Scope**: Single tool implementation with state transition and UI integration.
 
 ## Constitution Check

--- a/specs/051-exit-plan-mode-tool/spec.md
+++ b/specs/051-exit-plan-mode-tool/spec.md
@@ -46,6 +46,7 @@ As an agent in plan mode, I want to use the `ExitPlanMode` tool after I have fin
 - **FR-005**: Upon user selection of "Feedback", the agent MUST remain in "plan mode" and receive the user's input as the tool's output.
 - **FR-006**: `ExitPlanMode` MUST ONLY be included in the available tools list when the agent is in "plan mode".
 - **FR-007**: If the agent is NOT in "plan mode", the `ExitPlanMode` tool MUST NOT be exposed to the LLM.
+- **FR-008**: `ExitPlanMode` MUST NOT be available when `permissionMode` is set to `bypassPermissions`.
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/051-exit-plan-mode-tool/tasks.md
+++ b/specs/051-exit-plan-mode-tool/tasks.md
@@ -13,6 +13,7 @@
 - [X] T002 Define `ExitPlanMode` tool in `packages/agent-sdk/src/tools/exitPlanMode.ts`
 - [X] T003 Add `ExitPlanMode` to `RESTRICTED_TOOLS` in `packages/agent-sdk/src/types/permissions.ts`
 - [X] T004 Update `ToolManager` to filter `ExitPlanMode` based on `permissionMode` in `packages/agent-sdk/src/managers/toolManager.ts`
+- [X] T013 Ensure `ExitPlanMode` is NOT available when `permissionMode` is `bypassPermissions` in `packages/agent-sdk/src/managers/toolManager.ts`
 - [X] T005 Register `ExitPlanMode` tool in `Agent` class in `packages/agent-sdk/src/agent.ts`
 
 ## Phase 3: User Story 1 - Approve Plan via ExitPlanMode (Priority: P1)

--- a/specs/052-add-ask-user-tool/plan.md
+++ b/specs/052-add-ask-user-tool/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Implement the `AskUserQuestion` tool to allow the agent to ask structured multiple-choice questions for clarification and decision-making. This involves creating a new built-in tool in `agent-sdk` and updating the `Confirmation` component in `code` to render the interactive questioning UI.
+Implement the `AskUserQuestion` tool to allow the agent to ask structured multiple-choice questions for clarification and decision-making. This involves creating a new built-in tool in `agent-sdk` and updating the `Confirmation` component in `code` to render the interactive questioning UI. The tool MUST NOT be available in `bypassPermissions` mode.
 
 ## Technical Context
 
@@ -16,7 +16,7 @@ Implement the `AskUserQuestion` tool to allow the agent to ask structured multip
 **Target Platform**: CLI (Node.js)
 **Project Type**: Monorepo (agent-sdk + code)
 **Performance Goals**: Instant UI response for user input
-**Constraints**: Max 4 questions, 2-4 options per question
+**Constraints**: Max 4 questions, 2-4 options per question; MUST NOT be available in `bypassPermissions` mode.
 **Scale/Scope**: Built-in tool available to all agent sessions
 
 ## Constitution Check

--- a/specs/052-add-ask-user-tool/spec.md
+++ b/specs/052-add-ask-user-tool/spec.md
@@ -73,6 +73,7 @@ As an AI agent in Plan Mode, I want to ask the user for missing requirements bef
 - **FR-008**: The tool MUST return the user's answers as a mapping from question text to the selected answer(s).
 - **FR-009**: In Plan Mode, the agent MUST be instructed to use `AskUserQuestion` for clarifications but NOT for plan approval.
 - **FR-010**: The agent MUST be discouraged from asking questions via plain text and encouraged to use this tool instead.
+- **FR-011**: `AskUserQuestion` MUST NOT be available when `permissionMode` is set to `bypassPermissions`.
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/052-add-ask-user-tool/tasks.md
+++ b/specs/052-add-ask-user-tool/tasks.md
@@ -96,6 +96,7 @@
 
 - [X] T022 [US3] Update Plan Mode instructions to allow AskUserQuestion but forbid it for plan approval in packages/agent-sdk/src/agent.ts
 - [X] T023 [US3] Ensure AskUserQuestion is available and functional when permissionMode is 'plan' in packages/agent-sdk/src/managers/toolManager.ts
+- [X] T028 [US3] Ensure AskUserQuestion is NOT available when permissionMode is 'bypassPermissions' in packages/agent-sdk/src/managers/toolManager.ts
 
 **Checkpoint**: All user stories are independently functional.
 


### PR DESCRIPTION
This PR updates the specifications, implementation plans, and code to ensure that the ExitPlanMode and AskUserQuestion tools are not available when the agent is in bypassPermissions mode.