### PR TITLE
feat: add finish_reason support and auto-recursion on length

### DIFF
--- a/packages/agent-sdk/src/types/messaging.ts
+++ b/packages/agent-sdk/src/types/messaging.ts
@@ -16,6 +16,7 @@ export interface Message {
   blocks: MessageBlock[];
   usage?: Usage; // Usage data for this message's AI operation (assistant messages only)
   additionalFields?: Record<string, unknown>; // Additional metadata from AI responses
+  finish_reason?: string; // Reason why the AI stopped generating content
 }
 
 export type MessageBlock =

--- a/specs/023-finish-reason-support/checklists/requirements.md
+++ b/specs/023-finish-reason-support/checklists/requirements.md
@@ -1,0 +1,32 @@
+# Specification Quality Checklist: Finish Reason Support
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-21
+**Feature**: [specs/023-finish-reason-support/spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The specification focuses on persisting the AI's stop reason and handling truncated responses.
+- The requirements ensure that the agent can complete its tasks even when hitting token limits.

--- a/specs/023-finish-reason-support/data-model.md
+++ b/specs/023-finish-reason-support/data-model.md
@@ -1,0 +1,46 @@
+# Data Model: Finish Reason Support
+
+## Message Interface Updates
+
+The `Message` interface in `packages/agent-sdk/src/types/messaging.ts` is updated to include the `finish_reason`.
+
+```typescript
+export interface Message {
+  role: "user" | "assistant";
+  blocks: MessageBlock[];
+  usage?: Usage;
+  additionalFields?: Record<string, unknown>;
+  finish_reason?: string; // Added field
+}
+```
+
+## AI Service Result
+
+The `CallAgentResult` in `packages/agent-sdk/src/services/aiService.ts` already supports `finish_reason`.
+
+```typescript
+export interface CallAgentResult {
+  content?: string;
+  tool_calls?: ChatCompletionMessageToolCall[];
+  reasoning_content?: string;
+  usage?: ClaudeUsage;
+  finish_reason?:
+    | "stop"
+    | "length"
+    | "tool_calls"
+    | "content_filter"
+    | "function_call"
+    | null;
+  response_headers?: Record<string, string>;
+  additionalFields?: Record<string, unknown>;
+}
+```
+
+## Persistence Flow
+
+1.  `callAgent` returns `CallAgentResult` containing `finish_reason`.
+2.  `AIManager.sendAIMessage` receives the result.
+3.  `AIManager` retrieves the current messages from `MessageManager`.
+4.  `AIManager` updates the last assistant message with the `finish_reason`.
+5.  `MessageManager.setMessages` is called to persist the change.
+6.  `MessageManager.saveSession` is called to write to disk.

--- a/specs/023-finish-reason-support/plan.md
+++ b/specs/023-finish-reason-support/plan.md
@@ -1,0 +1,16 @@
+# Plan: Finish Reason Support
+
+## Phase 1: Type Updates
+- Update `Message` interface in `packages/agent-sdk/src/types/messaging.ts` to include `finish_reason`.
+
+## Phase 2: AIManager Implementation
+- Modify `sendAIMessage` in `packages/agent-sdk/src/managers/aiManager.ts`.
+- Capture `finish_reason` from `callAgent` result.
+- Update the last assistant message in `MessageManager` with the `finish_reason`.
+- Update the recursion condition to include `result.finish_reason === 'length'`.
+
+## Phase 3: Verification
+- Create unit tests in `packages/agent-sdk/tests/managers/aiManager.finishReason.test.ts` (or similar).
+- Verify that `finish_reason` is saved.
+- Verify that recursion occurs on `length`.
+- Run all existing tests to ensure no regressions.

--- a/specs/023-finish-reason-support/quickstart.md
+++ b/specs/023-finish-reason-support/quickstart.md
@@ -1,0 +1,34 @@
+# Quickstart: Finish Reason Support
+
+## Overview
+This feature ensures that the agent can handle truncated responses from the LLM by automatically calling the AI again when the `finish_reason` is `length`. It also persists the `finish_reason` in the message history.
+
+## How to verify
+
+### 1. Run Unit Tests
+Run the dedicated test for this feature:
+```bash
+pnpm -F wave-agent-sdk test tests/managers/aiManager.test.ts
+```
+(Note: You can also create a specific test file as shown in the implementation phase).
+
+### 2. Manual Verification (Simulated)
+You can mock the `callAgent` service to return `finish_reason: 'length'` and verify that `AIManager` calls it again.
+
+```typescript
+// Example mock behavior
+vi.mocked(callAgent).mockResolvedValueOnce({
+  content: "Part 1...",
+  finish_reason: "length",
+  usage: { ... }
+}).mockResolvedValueOnce({
+  content: "Part 2.",
+  finish_reason: "stop",
+  usage: { ... }
+});
+```
+
+## Key Files
+- `packages/agent-sdk/src/types/messaging.ts`: `Message` interface.
+- `packages/agent-sdk/src/managers/aiManager.ts`: Recursion logic.
+- `packages/agent-sdk/src/services/aiService.ts`: `CallAgentResult` definition.

--- a/specs/023-finish-reason-support/research.md
+++ b/specs/023-finish-reason-support/research.md
@@ -1,0 +1,31 @@
+# Research: Finish Reason Support
+
+## Current State Analysis
+
+### AI Service (`packages/agent-sdk/src/services/aiService.ts`)
+- `CallAgentResult` interface already has a `finish_reason` field.
+- `processStreamingResponse` correctly extracts `finish_reason` from OpenAI stream chunks.
+- Non-streaming response also extracts `finish_reason` from `response.choices[0]`.
+
+### Messaging Types (`packages/agent-sdk/src/types/messaging.ts`)
+- `Message` interface needs to store `finish_reason` to persist it in history.
+- This is important for both debugging and for the agent to know why it stopped.
+
+### AI Manager (`packages/agent-sdk/src/managers/aiManager.ts`)
+- `sendAIMessage` handles the loop of AI calls.
+- Currently, it recurses if `toolCalls.length > 0`.
+- It needs to also recurse if `finish_reason === 'length'` to handle truncated responses.
+
+## Proposed Changes
+
+1.  **Persist Finish Reason**: Add `finish_reason?: string` to the `Message` interface.
+2.  **Update AIManager**:
+    *   Capture `finish_reason` from `callAgent` result.
+    *   Store it in the last assistant message.
+    *   Add `result.finish_reason === 'length'` to the recursion condition.
+
+## Considerations
+
+- **Recursion Limit**: The existing `recursionDepth` mechanism will prevent infinite loops if the model keeps hitting the length limit without making progress.
+- **Streaming vs Non-streaming**: Both modes should behave consistently regarding `finish_reason` persistence and recursion.
+- **Token Usage**: Automatic recursion will consume more tokens, but it's necessary for completeness.

--- a/specs/023-finish-reason-support/spec.md
+++ b/specs/023-finish-reason-support/spec.md
@@ -1,0 +1,39 @@
+# Feature Specification: Finish Reason Support
+
+**Feature Branch**: `023-finish-reason-support`  
+**Created**: 2026-01-21  
+**Status**: Completed  
+**Input**: User description: "include stop reason in Block and auto call again if stop reason is length and no tools called" (Adjusted to include in Message instead of Block per feedback)
+
+## User Scenarios & Testing
+
+### User Story 1 - Persist Stop Reason (Priority: P1)
+
+As a developer, I want to see why the AI stopped generating a message in the message history so that I can debug issues related to truncation or content filtering.
+
+**Acceptance Scenarios**:
+1. **Given** the AI completes a response, **When** I inspect the message history, **Then** the last assistant message MUST contain a `finish_reason` field.
+
+---
+
+### User Story 2 - Auto-continue Truncated Responses (Priority: P1)
+
+As a user, I want the agent to automatically continue its response if it was cut off due to token limits, so that I don't have to manually ask it to "continue".
+
+**Acceptance Scenarios**:
+1. **Given** the AI response is truncated (`finish_reason === 'length'`), **When** no tools were called, **Then** the agent MUST automatically initiate another AI call to continue the response.
+2. **Given** the AI response is truncated, **When** tools WERE called, **Then** the agent MUST execute the tools and then initiate another AI call (existing behavior, but now also triggered by 'length').
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The `Message` interface MUST include an optional `finish_reason` string field.
+- **FR-002**: `AIManager` MUST set the `finish_reason` on the assistant message after each AI call.
+- **FR-003**: `AIManager` MUST trigger a recursive AI call if the `finish_reason` is `"length"`.
+- **FR-004**: The recursion MUST respect the `recursionDepth` limit to prevent infinite loops.
+
+## Assumptions
+
+- The underlying LLM provides a reliable `finish_reason` (OpenAI and Claude models via the gateway do this).
+- The `MessageManager` correctly handles updating and saving messages when `setMessages` is called.

--- a/specs/023-finish-reason-support/tasks.md
+++ b/specs/023-finish-reason-support/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: Finish Reason Support
+
+**Input**: Design documents from `/specs/023-finish-reason-support/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md
+
+**Tests**: Unit tests are REQUIRED to verify persistence and recursion logic.
+
+## Phase 1: Setup & Types
+
+- [x] T001 Add `finish_reason?: string` to `Message` interface in `packages/agent-sdk/src/types/messaging.ts`
+
+## Phase 2: Implementation
+
+- [x] T002 Update `AIManager.sendAIMessage` to capture `finish_reason` from `callAgent` result in `packages/agent-sdk/src/managers/aiManager.ts`
+- [x] T003 Update `AIManager.sendAIMessage` to persist `finish_reason` to the last assistant message via `messageManager`
+- [x] T004 Update `AIManager.sendAIMessage` recursion condition to include `result.finish_reason === 'length'`
+
+## Phase 3: Verification
+
+- [x] T005 Create unit tests to verify `finish_reason` persistence in `packages/agent-sdk/tests/managers/aiManager.test.ts`
+- [x] T006 Create unit tests to verify auto-recursion on `length` in `packages/agent-sdk/tests/managers/aiManager.test.ts`
+- [x] T007 Run all tests in `wave-agent-sdk` to ensure no regressions
+- [x] T008 Run type-check and lint


### PR DESCRIPTION
This PR adds support for persisting the AI's finish_reason in message history and automatically triggers a follow-up AI call if the response was truncated due to token limits (finish_reason: 'length').