### PR TITLE
feat: render plan content in subagent block

### DIFF
--- a/packages/code/src/components/MessageItem.tsx
+++ b/packages/code/src/components/MessageItem.tsx
@@ -85,7 +85,9 @@ export const MessageItem = ({
               <CompressDisplay block={block} isExpanded={isExpanded} />
             )}
 
-            {block.type === "subagent" && <SubagentBlock block={block} />}
+            {block.type === "subagent" && (
+              <SubagentBlock block={block} isExpanded={isExpanded} />
+            )}
 
             {block.type === "reasoning" && <ReasoningDisplay block={block} />}
           </Box>

--- a/packages/code/src/components/PlanDisplay.tsx
+++ b/packages/code/src/components/PlanDisplay.tsx
@@ -1,0 +1,48 @@
+import React, { useMemo } from "react";
+import { Box, Text, useStdout } from "ink";
+import { Markdown } from "./Markdown.js";
+
+interface PlanDisplayProps {
+  planContent?: string;
+  isExpanded?: boolean;
+}
+
+export const PlanDisplay: React.FC<PlanDisplayProps> = ({
+  planContent,
+  isExpanded = false,
+}) => {
+  const { stdout } = useStdout();
+  const maxHeight = useMemo(() => {
+    return Math.max(5, (stdout?.rows || 24) - 20);
+  }, [stdout?.rows]);
+
+  if (!planContent) return null;
+
+  const planLines = planContent.split("\n");
+  const isTruncated = !isExpanded && planLines.length > maxHeight;
+
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text color="cyan" bold>
+        Plan Content:
+      </Text>
+      <Box
+        paddingLeft={2}
+        borderLeft
+        borderColor="gray"
+        flexDirection="column"
+        overflow="hidden"
+        height={isExpanded ? undefined : isTruncated ? maxHeight : undefined}
+      >
+        <Markdown>{planContent}</Markdown>
+      </Box>
+      {isTruncated && (
+        <Box marginTop={1}>
+          <Text color="yellow" dimColor>
+            Plan truncated. Press Ctrl+O to expand.
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/packages/code/src/components/SubagentBlock.tsx
+++ b/packages/code/src/components/SubagentBlock.tsx
@@ -1,13 +1,21 @@
 import React from "react";
 import { Box, Text } from "ink";
-import type { SubagentBlock as SubagentBlockType } from "wave-agent-sdk";
+import type {
+  SubagentBlock as SubagentBlockType,
+  ToolBlock,
+} from "wave-agent-sdk";
 import { useChat } from "../contexts/useChat.js";
+import { PlanDisplay } from "./PlanDisplay.js";
 
 interface SubagentBlockProps {
   block: SubagentBlockType;
+  isExpanded?: boolean;
 }
 
-export const SubagentBlock: React.FC<SubagentBlockProps> = ({ block }) => {
+export const SubagentBlock: React.FC<SubagentBlockProps> = ({
+  block,
+  isExpanded = false,
+}) => {
   const { subagentMessages } = useChat();
 
   // Get messages for this subagent from context
@@ -59,6 +67,25 @@ export const SubagentBlock: React.FC<SubagentBlockProps> = ({ block }) => {
 
   const { tools: lastTwoTools, totalToolCount } = getLastTwoTools();
 
+  // Find the latest planContent in subagent messages
+  const getLatestPlanContent = (): string | undefined => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+      for (let j = message.blocks.length - 1; j >= 0; j--) {
+        const messageBlock = message.blocks[j];
+        if (
+          messageBlock.type === "tool" &&
+          (messageBlock as ToolBlock).planContent
+        ) {
+          return (messageBlock as ToolBlock).planContent;
+        }
+      }
+    }
+    return undefined;
+  };
+
+  const planContent = getLatestPlanContent();
+
   return (
     <Box
       borderRight={false}
@@ -105,6 +132,9 @@ export const SubagentBlock: React.FC<SubagentBlockProps> = ({ block }) => {
           ))}
         </Box>
       )}
+
+      {/* Plan content display - handled by PlanDisplay component */}
+      <PlanDisplay planContent={planContent} isExpanded={isExpanded} />
     </Box>
   );
 };

--- a/packages/code/src/components/ToolResultDisplay.tsx
+++ b/packages/code/src/components/ToolResultDisplay.tsx
@@ -1,8 +1,8 @@
-import React, { useMemo } from "react";
-import { Box, Text, useStdout } from "ink";
+import React from "react";
+import { Box, Text } from "ink";
 import type { ToolBlock } from "wave-agent-sdk";
 import { DiffDisplay } from "./DiffDisplay.js";
-import { Markdown } from "./Markdown.js";
+import { PlanDisplay } from "./PlanDisplay.js";
 
 interface ToolResultDisplayProps {
   block: ToolBlock;
@@ -50,11 +50,6 @@ export const ToolResultDisplay: React.FC<ToolResultDisplayProps> = ({
     const imageCount = block.images!.length;
     return imageCount === 1 ? "🖼️" : `🖼️×${imageCount}`;
   };
-
-  const { stdout } = useStdout();
-  const maxHeight = useMemo(() => {
-    return Math.max(5, (stdout?.rows || 24) - 20);
-  }, [stdout?.rows]);
 
   const toolName = name ? String(name) : "Tool";
 
@@ -152,37 +147,8 @@ export const ToolResultDisplay: React.FC<ToolResultDisplayProps> = ({
       {/* Diff display - handled by DiffDisplay component */}
       <DiffDisplay toolBlock={block} />
 
-      {/* Plan content display for ExitPlanMode tool */}
-      {planContent && (
-        <Box flexDirection="column" marginTop={1}>
-          <Text color="cyan" bold>
-            Plan Content:
-          </Text>
-          <Box
-            paddingLeft={2}
-            borderLeft
-            borderColor="gray"
-            flexDirection="column"
-            overflow="hidden"
-            height={
-              isExpanded
-                ? undefined
-                : planContent.split("\n").length > maxHeight
-                  ? maxHeight
-                  : undefined
-            }
-          >
-            <Markdown>{planContent}</Markdown>
-          </Box>
-          {!isExpanded && planContent.split("\n").length > maxHeight && (
-            <Box marginTop={1}>
-              <Text color="yellow" dimColor>
-                Plan truncated. Press Ctrl+O to expand.
-              </Text>
-            </Box>
-          )}
-        </Box>
-      )}
+      {/* Plan content display - handled by PlanDisplay component */}
+      <PlanDisplay planContent={planContent} isExpanded={isExpanded} />
     </Box>
   );
 };

--- a/specs/051-exit-plan-mode-tool/tasks.md
+++ b/specs/051-exit-plan-mode-tool/tasks.md
@@ -32,6 +32,7 @@
 - [X] T011 Run `pnpm build` and verify cross-package compatibility
 - [X] T012 Run `pnpm run type-check` and `pnpm lint` across the monorepo
 - [X] T013 [US1] Add max height and expansion (Ctrl+O) support for plan rendering in `packages/code/src/components/ToolResultDisplay.tsx`
+- [X] T014 Render plan content in `SubagentBlock` by reusing logic from `ToolResultDisplay` in `packages/code/src/components/SubagentBlock.tsx`
 
 ## Dependencies
 


### PR DESCRIPTION
This PR extracts the plan rendering logic into a reusable PlanDisplay component and uses it in both ToolResultDisplay and SubagentBlock. This allows subagent blocks to display the latest plan content from their message history.