### PR TITLE
fix: ensure WAVE_PROJECT_DIR is injected into config and hooks

### DIFF
--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -83,8 +83,12 @@ export class ConfigurationService {
             ? `No valid configuration found despite attempting to load: ${loadingContext.join(", ")}`
             : "No configuration files found in user or project directories";
 
+        // Still set system environment variables even if no config is found
+        const env = { WAVE_PROJECT_DIR: workdir };
+        this.setEnvironmentVars(env);
+
         return {
-          configuration: null,
+          configuration: { env },
           success: true, // No config is valid
           warnings: [message],
         };
@@ -106,10 +110,13 @@ export class ConfigurationService {
       // Success case
       this.currentConfiguration = mergedConfig;
 
-      // Set environment variables if present in the merged config
-      if (mergedConfig.env) {
-        this.setEnvironmentVars(mergedConfig.env);
-      }
+      // Set environment variables from merged config and inject system variables
+      const env = {
+        ...(mergedConfig.env || {}),
+        WAVE_PROJECT_DIR: workdir,
+      };
+      this.setEnvironmentVars(env);
+      mergedConfig.env = env;
 
       const sourcePaths = loadingContext.join(" and ");
 

--- a/packages/agent-sdk/src/services/hook.ts
+++ b/packages/agent-sdk/src/services/hook.ts
@@ -144,7 +144,7 @@ export async function executeCommand(
         ...("env" in context ? context.env || {} : {}), // Additional environment variables from configuration (if ExtendedHookExecutionContext)
         HOOK_EVENT: context.event,
         HOOK_TOOL_NAME: context.toolName || "",
-        HOOK_PROJECT_DIR: context.projectDir,
+        WAVE_PROJECT_DIR: context.projectDir,
       },
     });
 

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -92,6 +92,7 @@ describe("ConfigurationService", () => {
       expect(result.configuration?.env).toEqual({
         USER_VAR: "user",
         PROJECT_VAR: "project",
+        WAVE_PROJECT_DIR: tempDir,
       });
       expect(result.configuration?.permissions?.allow).toContain("rule1");
       expect(result.configuration?.permissions?.allow).toContain("rule2");
@@ -136,7 +137,9 @@ describe("ConfigurationService", () => {
       const result = await configService.loadMergedConfiguration(tempDir);
 
       expect(result.success).toBe(true);
-      expect(result.configuration).toBeNull();
+      expect(result.configuration).toEqual({
+        env: { WAVE_PROJECT_DIR: tempDir },
+      });
       expect(result.warnings).toContain(
         "No configuration files found in user or project directories",
       );

--- a/packages/agent-sdk/tests/services/hook.test.ts
+++ b/packages/agent-sdk/tests/services/hook.test.ts
@@ -256,7 +256,7 @@ describe("Hook Services", () => {
       });
 
       const resultPromise = executeCommand(
-        "echo $HOOK_PROJECT_DIR",
+        "echo $WAVE_PROJECT_DIR",
         mockContext,
       );
 
@@ -269,7 +269,7 @@ describe("Hook Services", () => {
       expect(spawnEnv).toBeDefined();
       expect(spawnEnv!.HOOK_EVENT).toBe("PostToolUse");
       expect(spawnEnv!.HOOK_TOOL_NAME).toBe("Edit");
-      expect(spawnEnv!.HOOK_PROJECT_DIR).toBe("/test/project");
+      expect(spawnEnv!.WAVE_PROJECT_DIR).toBe("/test/project");
     });
 
     it("should handle context without tool name", async () => {


### PR DESCRIPTION
This PR fixes the naming of the project directory environment variable from HOOK_PROJECT_DIR to WAVE_PROJECT_DIR and ensures it is correctly injected into the merged configuration and hook execution environment.