### PR TITLE
fix: improve bash command chain permission matching and frontmatter parsing

### DIFF
--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -572,14 +572,11 @@ export class PermissionManager {
     // Handle Bash command rules
     if (toolName === BASH_TOOL_NAME) {
       const command = String(context.toolInput?.command || "");
-      const parts = splitBashCommand(command);
-      return parts.some((part) => {
-        const processedPart = stripRedirections(stripEnvVars(part));
-        if (pattern.endsWith(":*")) {
-          return processedPart.startsWith(pattern.slice(0, -2));
-        }
-        return processedPart === pattern;
-      });
+      const processedPart = stripRedirections(stripEnvVars(command));
+      if (pattern.endsWith(":*")) {
+        return processedPart.startsWith(pattern.slice(0, -2));
+      }
+      return processedPart === pattern;
     }
 
     // Handle path-based rules (e.g., "Read(**/*.env)")
@@ -673,6 +670,7 @@ export class PermissionManager {
           );
 
           if (allowedByRule) return true;
+
           return !this.isRestrictedTool(ctx.toolName);
         });
       }

--- a/packages/agent-sdk/src/types/permissions.ts
+++ b/packages/agent-sdk/src/types/permissions.ts
@@ -72,4 +72,4 @@ export const RESTRICTED_TOOLS = [
 /** Type for restricted tool names */
 export type RestrictedTool = (typeof RESTRICTED_TOOLS)[number];
 
-export { AskUserQuestion, AskUserQuestionInput, AskUserQuestionOption };
+export type { AskUserQuestion, AskUserQuestionInput, AskUserQuestionOption };

--- a/packages/agent-sdk/src/utils/markdownParser.ts
+++ b/packages/agent-sdk/src/utils/markdownParser.ts
@@ -87,13 +87,17 @@ export function parseMarkdownFile(filePath: string): ParsedMarkdownFile {
         config.description = frontmatter.description;
       }
 
-      if (
-        frontmatter["allowed-tools"] &&
-        Array.isArray(frontmatter["allowed-tools"])
-      ) {
-        config.allowedTools = frontmatter["allowed-tools"].filter(
-          (item): item is string => typeof item === "string",
-        );
+      if (frontmatter["allowed-tools"]) {
+        if (Array.isArray(frontmatter["allowed-tools"])) {
+          config.allowedTools = frontmatter["allowed-tools"].filter(
+            (item): item is string => typeof item === "string",
+          );
+        } else if (typeof frontmatter["allowed-tools"] === "string") {
+          config.allowedTools = frontmatter["allowed-tools"]
+            .split(",")
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+        }
       }
     }
 


### PR DESCRIPTION
This PR improves the permission manager to correctly handle chained bash commands and prefix matching. It also updates the markdown parser to support comma-separated allowed-tools in frontmatter.