### PR TITLE
feat(agent-sdk): add vertexai thinking_config for gemini-3 models

### DIFF
--- a/packages/agent-sdk/src/services/aiService.ts
+++ b/packages/agent-sdk/src/services/aiService.ts
@@ -94,7 +94,13 @@ function isGitRepository(dirPath: string): string {
 type OpenAIModelConfig = Omit<
   ChatCompletionCreateParamsNonStreaming,
   "messages"
->;
+> & {
+  vertexai?: {
+    thinking_config: {
+      thinking_level: string;
+    };
+  };
+};
 
 /**
  * Get specific configuration parameters based on model name
@@ -116,6 +122,14 @@ function getModelConfig(
   if (modelName.includes("gpt-5-codex")) {
     // gpt-5-codex model sets temperature to undefined
     config.temperature = undefined;
+  }
+
+  if (modelName.startsWith("gemini-3")) {
+    config.vertexai = {
+      thinking_config: {
+        thinking_level: "minimal",
+      },
+    };
   }
 
   return config;


### PR DESCRIPTION
This PR adds the required vertexai thinking_config for gemini-3 models in the AI service.