### PR TITLE
feat(agent-sdk): log warning with headers when AI response is truncated

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -430,9 +430,13 @@ export class AIManager {
 
       // Log finish reason and response headers if available
       if (result.finish_reason) {
-        this.logger?.debug(
-          `AI response finished with reason: ${result.finish_reason}`,
-        );
+        // Log warning headers when finish reason is length
+        if (result.finish_reason === "length") {
+          this.logger?.warn(
+            "AI response truncated due to length limit. Response headers:",
+            result.response_headers,
+          );
+        }
       }
       if (
         result.response_headers &&

--- a/packages/agent-sdk/tests/managers/aiManager.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.test.ts
@@ -186,6 +186,25 @@ describe("AIManager", () => {
       );
     });
 
+    it("should log warning when finish reason is length", async () => {
+      const { callAgent } = await import("../../src/services/aiService.js");
+      const mockHeaders = { "x-test-header": "test-value" };
+      vi.mocked(callAgent).mockResolvedValue({
+        content: "Truncated response",
+        finish_reason: "length",
+        response_headers: mockHeaders,
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+        tool_calls: [],
+      });
+
+      await aiManager.sendAIMessage();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "AI response truncated due to length limit. Response headers:",
+        mockHeaders,
+      );
+    });
+
     it("should save session during each recursion regardless of tool execution results", async () => {
       // Mock callAgent to return tool calls
       const { callAgent } = await import("../../src/services/aiService.js");


### PR DESCRIPTION
This PR adds a warning log that includes response headers when the AI response is truncated due to the length limit. This helps in diagnosing token limit issues.