### PR TITLE
fix(agent-sdk): preserve invalid tool arguments in safeToolArguments

### DIFF
--- a/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
+++ b/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
@@ -24,8 +24,10 @@ function safeToolArguments(args: string): string {
     return args;
   } catch (error) {
     logger.error(`Invalid tool arguments: ${args}`, error);
-    // If not valid JSON, return a fallback empty object
-    return "{}";
+    // If not valid JSON, return a fallback empty object with the original string as a comment or property
+    return JSON.stringify({
+      invalid_arguments: args,
+    });
   }
 }
 


### PR DESCRIPTION
When tool arguments are not valid JSON, preserve the original string in a JSON object instead of returning an empty object.