### PR TITLE
feat: support language setting in configuration and system prompt

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -70,6 +70,8 @@ export interface AgentOptions {
   fastModel?: string;
   maxInputTokens?: number;
   maxTokens?: number;
+  /** Preferred language for agent communication */
+  language?: string;
 
   // Existing options (preserved)
   callbacks?: AgentCallbacks;
@@ -158,6 +160,10 @@ export class Agent {
     return this.configurationService.resolveMaxInputTokens(
       this.options.maxInputTokens,
     );
+  }
+
+  public getLanguage(): string | undefined {
+    return this.configurationService.resolveLanguage(this.options.language);
   }
 
   /**
@@ -353,6 +359,7 @@ export class Agent {
       getGatewayConfig: () => this.getGatewayConfig(),
       getModelConfig: () => this.getModelConfig(),
       getMaxInputTokens: () => this.getMaxInputTokens(),
+      getLanguage: () => this.getLanguage(),
       hookManager: this.hookManager,
       onUsageAdded: (usage) => this.addUsage(usage),
     });
@@ -377,6 +384,7 @@ export class Agent {
       getGatewayConfig: () => this.getGatewayConfig(),
       getModelConfig: () => this.getModelConfig(),
       getMaxInputTokens: () => this.getMaxInputTokens(),
+      getLanguage: () => this.getLanguage(),
       getEnvironmentVars: () => this.configurationService.getEnvironmentVars(), // Provide access to configuration environment variables
     });
 

--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -71,6 +71,7 @@ export interface SubagentManagerOptions {
   getGatewayConfig: () => GatewayConfig;
   getModelConfig: () => ModelConfig;
   getMaxInputTokens: () => number;
+  getLanguage: () => string | undefined;
   hookManager?: HookManager;
   onUsageAdded?: (usage: Usage) => void;
 }
@@ -87,6 +88,7 @@ export class SubagentManager {
   private getGatewayConfig: () => GatewayConfig;
   private getModelConfig: () => ModelConfig;
   private getMaxInputTokens: () => number;
+  private getLanguage: () => string | undefined;
   private hookManager?: HookManager;
   private onUsageAdded?: (usage: Usage) => void;
 
@@ -99,6 +101,7 @@ export class SubagentManager {
     this.getGatewayConfig = options.getGatewayConfig;
     this.getModelConfig = options.getModelConfig;
     this.getMaxInputTokens = options.getMaxInputTokens;
+    this.getLanguage = options.getLanguage;
     this.hookManager = options.hookManager;
     this.onUsageAdded = options.onUsageAdded;
   }
@@ -211,6 +214,7 @@ export class SubagentManager {
         };
       },
       getMaxInputTokens: this.getMaxInputTokens,
+      getLanguage: this.getLanguage,
       callbacks: {
         onUsageAdded: this.onUsageAdded,
       },
@@ -491,6 +495,7 @@ export class SubagentManager {
             agentModel: modelToUse,
           }),
           getMaxInputTokens: this.getMaxInputTokens,
+          getLanguage: this.getLanguage,
           callbacks: {
             onUsageAdded: this.onUsageAdded,
           },

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -493,6 +493,26 @@ export class ConfigurationService {
   }
 
   /**
+   * Resolves preferred language with fallbacks
+   * Resolution priority: options > settings.json > undefined
+   * @param constructorLanguage - Language from constructor (optional)
+   * @returns Resolved language or undefined
+   */
+  resolveLanguage(constructorLanguage?: string): string | undefined {
+    // 1. Constructor options (highest priority)
+    if (constructorLanguage !== undefined) {
+      return constructorLanguage;
+    }
+
+    // 2. settings.json (merged)
+    if (this.currentConfiguration?.language) {
+      return this.currentConfiguration.language;
+    }
+
+    return undefined;
+  }
+
+  /**
    * Resolves max output tokens with fallbacks
    * Resolution priority: options > env (from settings.json) > process.env > default
    * @param constructorLimit - Max output tokens from constructor (optional)
@@ -781,6 +801,7 @@ export function loadWaveConfigFromFile(
       env: config.env || undefined,
       permissions: config.permissions || undefined,
       enabledPlugins: config.enabledPlugins || undefined,
+      language: config.language || undefined,
     };
   } catch (error) {
     if (error instanceof SyntaxError) {
@@ -932,6 +953,11 @@ export function loadMergedWaveConfig(
       if (!mergedConfig.enabledPlugins) mergedConfig.enabledPlugins = {};
       Object.assign(mergedConfig.enabledPlugins, config.enabledPlugins);
     }
+
+    // Merge language (last one wins)
+    if (config.language !== undefined) {
+      mergedConfig.language = config.language;
+    }
   }
 
   return {
@@ -953,5 +979,6 @@ export function loadMergedWaveConfig(
       Object.keys(mergedConfig.enabledPlugins).length > 0
         ? mergedConfig.enabledPlugins
         : undefined,
+    language: mergedConfig.language,
   };
 }

--- a/packages/agent-sdk/src/types/configuration.ts
+++ b/packages/agent-sdk/src/types/configuration.ts
@@ -28,6 +28,8 @@ export interface WaveConfiguration {
   };
   /** New field for scoped plugin management */
   enabledPlugins?: Record<string, boolean>;
+  /** Preferred language for agent communication */
+  language?: string;
 }
 
 /**

--- a/packages/agent-sdk/tests/integration/subagentPlanMode.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/subagentPlanMode.integration.test.ts
@@ -98,6 +98,7 @@ describe("Subagent Plan Mode Integration", () => {
         permissionMode: "plan",
       }),
       getMaxInputTokens: () => 100000,
+      getLanguage: () => undefined,
     });
   });
 

--- a/packages/agent-sdk/tests/managers/aiManager.latestTotalTokens.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.latestTotalTokens.test.ts
@@ -91,6 +91,7 @@ describe("AIManager - latestTotalTokens calculation", () => {
       getGatewayConfig: () => mockGatewayConfig,
       getModelConfig: () => mockModelConfig,
       getMaxInputTokens: () => 96000,
+      getLanguage: () => undefined,
     });
   });
 

--- a/packages/agent-sdk/tests/managers/aiManager.plan.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.plan.test.ts
@@ -45,6 +45,7 @@ describe("AIManager Plan Mode Prompt", () => {
       getGatewayConfig: () => ({}) as GatewayConfig,
       getModelConfig: () => ({ agentModel: "gpt-4" }) as ModelConfig,
       getMaxInputTokens: () => 1000,
+      getLanguage: () => undefined,
     });
 
     vi.mocked(callAgent).mockResolvedValue({

--- a/packages/agent-sdk/tests/managers/aiManager.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.test.ts
@@ -90,6 +90,89 @@ describe("AIManager", () => {
       getGatewayConfig: () => mockGatewayConfig,
       getModelConfig: () => mockModelConfig,
       getMaxInputTokens: () => 96000,
+      getLanguage: () => undefined,
+    });
+  });
+
+  describe("Language Prompt Injection", () => {
+    it("should inject language prompt when language is set", async () => {
+      const { callAgent } = await import("../../src/services/aiService.js");
+      vi.mocked(callAgent).mockResolvedValue({
+        content: "Test response",
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+        tool_calls: [],
+      });
+
+      const aiManagerWithLanguage = new AIManager({
+        messageManager: mockMessageManager,
+        toolManager: mockToolManager,
+        logger: mockLogger,
+        workdir: "/test/workdir",
+        getGatewayConfig: () => mockGatewayConfig,
+        getModelConfig: () => mockModelConfig,
+        getMaxInputTokens: () => 96000,
+        getLanguage: () => "Chinese",
+      });
+
+      await aiManagerWithLanguage.sendAIMessage();
+
+      expect(callAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          systemPrompt: expect.stringContaining("# Language"),
+        }),
+      );
+      expect(callAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          systemPrompt: expect.stringContaining("Always respond in Chinese"),
+        }),
+      );
+    });
+
+    it("should NOT inject language prompt when language is undefined", async () => {
+      const { callAgent } = await import("../../src/services/aiService.js");
+      vi.mocked(callAgent).mockResolvedValue({
+        content: "Test response",
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+        tool_calls: [],
+      });
+
+      await aiManager.sendAIMessage();
+
+      expect(callAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          systemPrompt: expect.not.stringContaining("# Language"),
+        }),
+      );
+    });
+
+    it("should preserve technical terms instruction in language prompt", async () => {
+      const { callAgent } = await import("../../src/services/aiService.js");
+      vi.mocked(callAgent).mockResolvedValue({
+        content: "Test response",
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+        tool_calls: [],
+      });
+
+      const aiManagerWithLanguage = new AIManager({
+        messageManager: mockMessageManager,
+        toolManager: mockToolManager,
+        logger: mockLogger,
+        workdir: "/test/workdir",
+        getGatewayConfig: () => mockGatewayConfig,
+        getModelConfig: () => mockModelConfig,
+        getMaxInputTokens: () => 96000,
+        getLanguage: () => "Spanish",
+      });
+
+      await aiManagerWithLanguage.sendAIMessage();
+
+      expect(callAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          systemPrompt: expect.stringContaining(
+            "Technical terms (e.g., code, tool names, file paths) should remain in their original language or English where appropriate.",
+          ),
+        }),
+      );
     });
   });
 
@@ -256,6 +339,7 @@ describe("AIManager", () => {
         getGatewayConfig: () => mockGatewayConfig,
         getModelConfig: () => mockModelConfig,
         getMaxInputTokens: () => 96000,
+        getLanguage: () => undefined,
       });
 
       const { callAgent } = await import("../../src/services/aiService.js");
@@ -292,6 +376,7 @@ describe("AIManager", () => {
         getGatewayConfig: () => mockGatewayConfig,
         getModelConfig: () => mockModelConfig,
         getMaxInputTokens: () => 96000,
+        getLanguage: () => undefined,
       });
 
       const { callAgent } = await import("../../src/services/aiService.js");
@@ -326,6 +411,7 @@ describe("AIManager", () => {
         getGatewayConfig: () => mockGatewayConfig,
         getModelConfig: () => mockModelConfig,
         getMaxInputTokens: () => 96000,
+        getLanguage: () => undefined,
       });
 
       const { callAgent } = await import("../../src/services/aiService.js");

--- a/packages/agent-sdk/tests/managers/aiManager_finishReason.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager_finishReason.test.ts
@@ -89,6 +89,7 @@ describe("AIManager finish reason", () => {
       getGatewayConfig: () => mockGatewayConfig,
       getModelConfig: () => mockModelConfig,
       getMaxInputTokens: () => 96000,
+      getLanguage: () => undefined,
     });
   });
 

--- a/packages/agent-sdk/tests/managers/subagentManager.callbacks.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.callbacks.test.ts
@@ -80,6 +80,7 @@ describe("SubagentManager - Callback Integration", () => {
       getGatewayConfig: () => mockGatewayConfig,
       getModelConfig: () => mockModelConfig,
       getMaxInputTokens: () => 1000,
+      getLanguage: () => undefined,
     });
 
     await subagentManager.initialize();
@@ -457,6 +458,7 @@ describe("SubagentManager - Callback Integration", () => {
         getGatewayConfig: () => mockGatewayConfig,
         getModelConfig: () => mockModelConfig,
         getMaxInputTokens: () => 1000,
+        getLanguage: () => undefined,
       });
 
       await errorSubagentManager.initialize();
@@ -502,6 +504,7 @@ describe("SubagentManager - Callback Integration", () => {
         getGatewayConfig: () => mockGatewayConfig,
         getModelConfig: () => mockModelConfig,
         getMaxInputTokens: () => 1000,
+        getLanguage: () => undefined,
       });
 
       await noCallbackManager.initialize();

--- a/packages/agent-sdk/tests/managers/subagentManager.consistency.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.consistency.test.ts
@@ -72,6 +72,7 @@ describe("SubagentManager Consistency", () => {
         fastModel: "claude-3-haiku",
       }),
       getMaxInputTokens: () => 200000,
+      getLanguage: () => undefined,
     });
 
     // Mock configurations

--- a/packages/agent-sdk/tests/managers/subagentManager.sessions.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.sessions.test.ts
@@ -108,6 +108,7 @@ describe("SubagentManager - Session Functionality", () => {
       getGatewayConfig: () => mockGatewayConfig,
       getModelConfig: () => mockModelConfig,
       getMaxInputTokens: () => 1000,
+      getLanguage: () => undefined,
     });
 
     await subagentManager.initialize();

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -468,6 +468,34 @@ describe("ConfigurationService", () => {
     });
   });
 
+  describe("resolveLanguage", () => {
+    it("should return undefined by default", () => {
+      expect(configService.resolveLanguage()).toBeUndefined();
+    });
+
+    it("should resolve from constructor", () => {
+      expect(configService.resolveLanguage("Spanish")).toBe("Spanish");
+    });
+
+    it("should resolve from current configuration", async () => {
+      const config = { language: "French" };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      await configService.loadMergedConfiguration(tempDir);
+      expect(configService.resolveLanguage()).toBe("French");
+    });
+
+    it("should prioritize constructor over configuration", async () => {
+      const config = { language: "French" };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      await configService.loadMergedConfiguration(tempDir);
+      expect(configService.resolveLanguage("Spanish")).toBe("Spanish");
+    });
+  });
+
   describe("validateEnvironmentConfig", () => {
     it("should validate correct env", () => {
       const result = validateEnvironmentConfig({ KEY: "VAL" });

--- a/packages/agent-sdk/tests/tools/dynamicTool.test.ts
+++ b/packages/agent-sdk/tests/tools/dynamicTool.test.ts
@@ -81,6 +81,7 @@ describe("Dynamic Tool Definitions", () => {
         getModelConfig: () => ({}) as unknown as ModelConfig,
         getMaxInputTokens: () => 1000,
         onUsageAdded: () => {},
+        getLanguage: () => undefined,
       });
 
       // Mock initialization

--- a/specs/055-set-language-setting/checklists/requirements.md
+++ b/specs/055-set-language-setting/checklists/requirements.md
@@ -1,0 +1,31 @@
+# Specification Quality Checklist: Set Language in Settings
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-30
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The specification is complete and ready for planning. No clarifications were needed as the requirements were straightforward and reasonable defaults were assumed for edge cases.

--- a/specs/055-set-language-setting/contracts/configuration-api.md
+++ b/specs/055-set-language-setting/contracts/configuration-api.md
@@ -1,0 +1,29 @@
+# Configuration API Contract (Updated)
+
+## WaveConfiguration Interface
+
+```typescript
+export interface WaveConfiguration {
+  // ... existing fields
+  /** Preferred language for agent communication */
+  language?: string;
+}
+```
+
+## AgentOptions Interface
+
+```typescript
+export interface AgentOptions {
+  // ... existing fields
+  /** Optional preferred language */
+  language?: string;
+}
+```
+
+## ConfigurationService Methods
+
+### `resolveLanguage(constructorLanguage?: string): string | undefined`
+Resolves the language to use based on priority:
+1. `constructorLanguage`
+2. `this.currentConfiguration.language`
+3. Default: `undefined` (no prompt added)

--- a/specs/055-set-language-setting/data-model.md
+++ b/specs/055-set-language-setting/data-model.md
@@ -1,0 +1,24 @@
+# Data Model: Set Language Setting
+
+## Entities
+
+### WaveConfiguration (Updated)
+The root configuration structure for Wave Agent.
+
+| Field | Type | Description | Validation |
+|-------|------|-------------|------------|
+| `language` | `string` (optional) | The preferred language for agent communication. | Must be a string if present. |
+
+## State Transitions
+
+### Language Resolution
+1. **Input**: `AgentOptions.language` (if added), `settings.json` (user/project).
+2. **Process**:
+   - Check `AgentOptions.language` (highest priority).
+   - Check merged `WaveConfiguration.language` from `settings.json`.
+3. **Output**: Resolved language string or `undefined`.
+
+### Prompt Injection
+1. **Input**: Resolved language string.
+2. **Process**: If language is provided, format the language instruction block. If no language is provided, do nothing.
+3. **Output**: Formatted string to be appended to the system prompt, or empty string.

--- a/specs/055-set-language-setting/plan.md
+++ b/specs/055-set-language-setting/plan.md
@@ -1,0 +1,86 @@
+# Implementation Plan: Set Language Setting
+
+**Branch**: `055-set-language-setting` | **Date**: 2026-01-30 | **Spec**: [/specs/055-set-language-setting/spec.md](./spec.md)
+**Input**: Feature specification from `/specs/055-set-language-setting/spec.md`
+
+## Summary
+
+Support setting a preferred language in `settings.json` and injecting a language instruction into the system prompt. This ensures the agent communicates in the user's preferred language while maintaining technical terms in their original form.
+
+## Technical Context
+
+- **Language/Version**: TypeScript 5.x
+- **Primary Dependencies**: `openai`, `agent-sdk`
+- **Storage**: `settings.json`, `settings.local.json` (file-based configuration)
+- **Testing**: Vitest
+- **Target Platform**: CLI / Node.js
+- **Project Type**: Monorepo (agent-sdk, code)
+- **Performance Goals**: Minimal overhead on prompt construction.
+- **Constraints**: No language prompt is added if not specified.
+- **Language Resolution**: Priority: `AgentOptions` > `settings.json` > `undefined`.
+- **Prompt Injection**: Only occurs if a language is explicitly configured.
+- **Scale/Scope**: Affects all agent communications.
+
+## Constitution Check
+
+| Principle | Status | Justification |
+|-----------|--------|---------------|
+| I. Package-First Architecture | ✅ | Changes are within `agent-sdk` and follow existing patterns. |
+| II. TypeScript Excellence | ✅ | All new fields and methods will be strictly typed. |
+| III. Test Alignment | ✅ | Unit tests for `ConfigurationService` and integration tests for `AIManager` prompt injection will be added. |
+| IV. Build Dependencies | ✅ | `pnpm build` will be run after modifying `agent-sdk`. |
+| V. Documentation Minimalism | ✅ | No unnecessary markdown docs created. |
+| VI. Quality Gates | ✅ | `pnpm run type-check` and `pnpm lint` will be run. |
+| VII. Source Code Structure | ✅ | Logic added to appropriate managers and services. |
+| VIII. Test-Driven Development | ✅ | Tests will be written to verify language resolution and prompt injection. |
+| IX. Type System Evolution | ✅ | Existing `WaveConfiguration` and `AgentOptions` will be evolved. |
+| X. Data Model Minimalism | ✅ | Only a single `language` field is added. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/055-set-language-setting/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── configuration-api.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```
+packages/agent-sdk/
+├── src/
+│   ├── agent.ts         # Update AgentOptions and initialization
+│   ├── managers/
+│   │   └── aiManager.ts # Inject language instruction into system prompt
+│   ├── services/
+│   │   └── configurationService.ts # Resolve language from settings/env
+│   ├── types/
+│   │   └── configuration.ts # Add language field to WaveConfiguration
+│   └── constants/
+│       └── prompts.ts   # (Optional) Add language prompt template
+└── tests/
+    ├── services/
+    │   └── configurationService.test.ts
+    └── managers/
+        └── aiManager.test.ts
+```
+
+**Structure Decision**: Single project (agent-sdk) with updates to existing managers and services.
+
+## Complexity Tracking
+
+*No violations detected.*
+
+## Gates
+
+- [x] **Type Safety**: All changes must pass `pnpm run type-check`.
+- [x] **Testing**: New functionality must be covered by unit and integration tests.
+- [x] **Backward Compatibility**: No language prompt is added if not specified.

--- a/specs/055-set-language-setting/quickstart.md
+++ b/specs/055-set-language-setting/quickstart.md
@@ -1,0 +1,42 @@
+# Quickstart: Set Language Setting
+
+## Configuration
+
+### Via settings.json
+To set your preferred language globally or per project, add the `language` field to your `~/.wave/settings.json` or your project's `.wave/settings.json`:
+
+```json
+{
+  "language": "Chinese"
+}
+```
+
+### Via AgentOptions
+If you are using the SDK, you can specify the language when creating the agent:
+
+```typescript
+const agent = await Agent.create({
+  language: "French",
+  // ... other options
+});
+```
+
+## Usage
+
+Once configured, the agent will:
+1. Respond to your queries in the specified language.
+2. Provide explanations and comments in that language.
+3. Keep technical terms (like function names, variable names, and code identifiers) in their original form.
+
+### Example
+
+**Settings:**
+```json
+{
+  "language": "Spanish"
+}
+```
+
+**Interaction:**
+User: "Explain this function."
+Agent: "Esta función `calculateTotal()` calcula la suma de todos los elementos..."

--- a/specs/055-set-language-setting/research.md
+++ b/specs/055-set-language-setting/research.md
@@ -1,0 +1,39 @@
+# Research: Set Language in Settings
+
+## Decision: Implementation Strategy for Language Support
+
+### 1. Configuration Storage
+- **Decision**: Add a `language` field to the `WaveConfiguration` interface in `packages/agent-sdk/src/types/configuration.ts`.
+- **Rationale**: This is the central place for all Wave Agent settings. Adding it here ensures it's properly typed and can be loaded from `settings.json` or `settings.local.json` across user and project scopes.
+- **Alternatives considered**: Using environment variables (e.g., `WAVE_LANGUAGE`). While possible, a dedicated field in the configuration object is more explicit and follows the pattern of other settings like `permissions` and `enabledPlugins`.
+
+### 2. Prompt Injection Point
+- **Decision**: Modify `AIManager.sendAIMessage` in `packages/agent-sdk/src/managers/aiManager.ts` to inject the language instruction into the `effectiveSystemPrompt`.
+- **Rationale**: `AIManager` is responsible for constructing the final system prompt before calling the AI service. It already handles custom system prompts and plan mode reminders. Injecting the language instruction here ensures it's applied consistently.
+- **Alternatives considered**: 
+    - Modifying `buildSystemPrompt` in `prompts.ts`. This would require passing the language to `buildSystemPrompt`, which is currently a pure function focused on tool-based policies.
+    - Modifying `callAgent` in `aiService.ts`. This is too low-level; `AIManager` is a better place for high-level prompt orchestration.
+
+### 3. Language Resolution
+- **Decision**: Add a `resolveLanguage()` method to `ConfigurationService` in `packages/agent-sdk/src/services/configurationService.ts`.
+- **Rationale**: `ConfigurationService` already handles resolution of other settings (gateway, model, tokens) with fallbacks (constructor > settings.json). Adding `resolveLanguage` follows this established pattern.
+- **Default**: There is no default language. If no language is configured, no language instruction will be added to the system prompt.
+
+### 4. Prompt Format
+- **Decision**: Use the exact format requested by the user:
+  ```
+  # Language
+  Always respond in ${A}. Use ${A} for all explanations, comments, and communications with the user. Technical terms and code identifiers should remain in their original form.
+  ```
+- **Rationale**: This format is clear and covers all aspects of the agent's communication.
+
+## Technical Context
+
+- **Settings Management**: `ConfigurationService` loads and merges `settings.json` from multiple locations.
+- **System Prompt**: Built in `AIManager` using `buildSystemPrompt` and additional context.
+- **Types**: `WaveConfiguration` in `packages/agent-sdk/src/types/configuration.ts`.
+
+## Unknowns Resolved
+- **Where is settings.json managed?** `ConfigurationService.ts`.
+- **How is the system prompt constructed?** In `AIManager.ts` using `buildSystemPrompt` and manual appends.
+- **How to access settings in AIManager?** `AIManager` already has access to `ConfigurationService` via getter functions passed from `Agent`. I will add a `getLanguage` getter.

--- a/specs/055-set-language-setting/spec.md
+++ b/specs/055-set-language-setting/spec.md
@@ -1,0 +1,77 @@
+# Feature Specification: Set Language in Settings
+
+**Feature Branch**: `055-set-language-setting`  
+**Created**: 2026-01-30  
+**Status**: Draft  
+**Input**: User description: "support setting language in settings.json, add this to system prompt: `# Language
+Always respond in ${A}. Use ${A} for all explanations, comments, and communications with the user. Technical terms and code identifiers should remain in their original form.`"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Configure Preferred Language (Priority: P1)
+
+As a user, I want to specify my preferred language in the settings file or via agent options so that the agent communicates with me in that language.
+
+**Why this priority**: This is the core functionality requested. It enables non-English speakers or users with specific language preferences to interact with the agent more effectively.
+
+**Independent Test**: Can be tested by setting a language (e.g., "Chinese") in `settings.json` or passing it to `Agent.create()` and verifying that the agent's responses and explanations are in that language.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `settings.json` file with a `language` field set to "Chinese", **When** I ask the agent a question, **Then** the agent responds in Chinese.
+2. **Given** the agent is created with `language: "French"` in options, **When** the agent explains a code change, **Then** the explanation is in French.
+
+---
+
+### User Story 2 - Default Language Behavior (Priority: P2)
+
+As a user, I want the agent to default to English if no language is specified in my settings, ensuring the system remains functional without manual configuration.
+
+**Why this priority**: Ensures backward compatibility and a sensible default for new users.
+
+**Independent Test**: Can be tested by removing the `language` field from `settings.json` and verifying the agent still responds in English.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `settings.json` file without a `language` field, **When** I interact with the agent, **Then** it responds in English (default).
+
+---
+
+### User Story 3 - Preservation of Technical Terms (Priority: P2)
+
+As a user, I want technical terms and code identifiers to remain in their original form even when the agent is responding in my preferred language, so that the technical context remains clear.
+
+**Why this priority**: Essential for technical accuracy and clarity in software engineering tasks.
+
+**Independent Test**: Can be tested by setting the language to "Spanish" and asking for a code explanation, then verifying that variable names and function calls are not translated.
+
+**Acceptance Scenarios**:
+
+1. **Given** the language is set to "Spanish", **When** the agent explains a function `calculateTotal()`, **Then** the explanation is in Spanish but the string `calculateTotal()` remains unchanged.
+
+### Edge Cases
+
+- **Invalid Language Value**: What happens when the `language` field contains an empty string or a nonsensical value? (Assumption: System defaults to English or ignores the setting).
+- **Missing Settings File**: How does the system handle cases where `settings.json` does not exist? (Assumption: System uses default English).
+- **Mixed Language Input**: How does the agent handle a user asking a question in English when the setting is set to another language? (Assumption: Agent follows the setting and responds in the configured language).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST support setting the `language` via `AgentOptions` or `settings.json`.
+- **FR-002**: System MUST inject a language instruction into the system prompt if a language is configured.
+- **FR-003**: The injected instruction MUST follow the format: `# Language\nAlways respond in ${A}. Use ${A} for all explanations, comments, and communications with the user. Technical terms and code identifiers should remain in their original form.` where `${A}` is the configured language.
+- **FR-004**: System MUST NOT inject any language instruction if the `language` setting is missing or invalid.
+- **FR-005**: System MUST ensure that the language instruction is applied to all agent communications, including explanations and comments.
+
+### Key Entities *(include if feature involves data)*
+
+- **Settings**: Represents the user's configuration, now including a `language` attribute.
+- **System Prompt**: The base instructions provided to the AI agent, which will now dynamically include language preferences.
+
+## Assumptions
+
+- The `settings.json` file is the central place for user-specific configurations.
+- The agent has the capability to understand and follow the language instruction provided in the system prompt.
+- "Original form" for technical terms usually means English or the language used in the codebase.

--- a/specs/055-set-language-setting/tasks.md
+++ b/specs/055-set-language-setting/tasks.md
@@ -1,0 +1,155 @@
+# Tasks: Set Language Setting
+
+**Input**: Design documents from `/specs/055-set-language-setting/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: Both unit and integration tests are REQUIRED for all new functionality. Ensure tests are written and failing before implementation.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization and basic structure
+
+- [X] T001 Update `WaveConfiguration` interface to include `language?: string` in `packages/agent-sdk/src/types/configuration.ts`
+- [X] T002 Update `AgentOptions` interface to include `language?: string` in `packages/agent-sdk/src/agent.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before ANY user story can be implemented
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T003 [P] Implement `resolveLanguage(constructorLanguage?: string): string | undefined` in `packages/agent-sdk/src/services/configurationService.ts`
+- [X] T004 [P] Add `getLanguage(): string | undefined` getter to `Agent` class in `packages/agent-sdk/src/agent.ts`
+- [X] T005 [P] Update `AIManagerOptions` and `AIManager` constructor to accept `getLanguage: () => string | undefined` in `packages/agent-sdk/src/managers/aiManager.ts`
+- [X] T006 Update `Agent` constructor to pass `getLanguage` getter to `AIManager` in `packages/agent-sdk/src/agent.ts`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin in parallel
+
+---
+
+## Phase 3: User Story 1 - Configure Preferred Language (Priority: P1) 🎯 MVP
+
+**Goal**: Support setting language via `AgentOptions` or `settings.json` and injecting it into the system prompt.
+
+**Independent Test**: Set `language: "Chinese"` in `Agent.create()` or `settings.json` and verify the system prompt contains the language instruction.
+
+### Tests for User Story 1 (REQUIRED) ⚠️
+
+**NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T007 [P] [US1] Unit test for language resolution in `packages/agent-sdk/tests/services/configurationService.test.ts`
+- [X] T008 [P] [US1] Integration test for prompt injection in `packages/agent-sdk/tests/managers/aiManager.test.ts`
+
+### Implementation for User Story 1
+
+- [X] T009 [US1] Implement language instruction injection in `AIManager.sendAIMessage` within `packages/agent-sdk/src/managers/aiManager.ts`
+- [X] T010 [US1] Update `Agent.resolveAndValidateConfig` to handle language if needed in `packages/agent-sdk/src/agent.ts`
+
+**Checkpoint**: At this point, User Story 1 should be fully functional and testable independently.
+
+---
+
+## Phase 4: User Story 2 - Default Language Behavior (Priority: P2)
+
+**Goal**: Ensure no language instruction is added if no language is configured.
+
+**Independent Test**: Create an agent without any language configuration and verify the system prompt does NOT contain the language instruction.
+
+### Tests for User Story 2 (REQUIRED) ⚠️
+
+- [X] T011 [P] [US2] Unit test for `undefined` language resolution in `packages/agent-sdk/tests/services/configurationService.test.ts`
+- [X] T012 [P] [US2] Integration test for absence of language prompt in `packages/agent-sdk/tests/managers/aiManager.test.ts`
+
+### Implementation for User Story 2
+
+- [X] T013 [US2] Verify `AIManager` correctly handles `undefined` language by not adding the prompt block in `packages/agent-sdk/src/managers/aiManager.ts`
+
+**Checkpoint**: At this point, User Stories 1 AND 2 should both work independently.
+
+---
+
+## Phase 5: User Story 3 - Preservation of Technical Terms (Priority: P2)
+
+**Goal**: Ensure the injected prompt explicitly instructs the AI to preserve technical terms.
+
+**Independent Test**: Verify the injected prompt string matches the required format exactly.
+
+### Tests for User Story 3 (REQUIRED) ⚠️
+
+- [X] T014 [P] [US3] Integration test to verify the exact content of the language instruction in `packages/agent-sdk/tests/managers/aiManager.test.ts`
+
+### Implementation for User Story 3
+
+- [X] T015 [US3] Ensure the prompt template in `AIManager.ts` matches the spec exactly in `packages/agent-sdk/src/managers/aiManager.ts`
+
+**Checkpoint**: All user stories should now be independently functional.
+
+---
+
+## Phase N: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories
+
+- [X] T016 [P] Run `pnpm build` in `packages/agent-sdk`
+- [X] T017 [P] Run `pnpm run type-check` and `pnpm lint` across the workspace
+- [X] T018 [P] Run all tests in `packages/agent-sdk` to ensure no regressions
+- [ ] T019 [P] Validate `quickstart.md` scenarios manually if possible
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3+)**: All depend on Foundational phase completion
+- **Polish (Final Phase)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2)
+- **User Story 2 (P2)**: Can start after Foundational (Phase 2)
+- **User Story 3 (P3)**: Can start after Foundational (Phase 2)
+
+### Parallel Opportunities
+
+- T003, T004, T005 can run in parallel.
+- All test tasks marked [P] can run in parallel.
+- Once Phase 2 is done, US1, US2, and US3 can technically be worked on in parallel as they mostly touch the same logic but different aspects of it.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch all tests for User Story 1 together:
+Task: "Unit test for language resolution in packages/agent-sdk/tests/services/configurationService.test.ts"
+Task: "Integration test for prompt injection in packages/agent-sdk/tests/managers/aiManager.test.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. **STOP and VALIDATE**: Test User Story 1 independently
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Foundation ready
+2. Add User Story 1 → Test independently → MVP!
+3. Add User Story 2 & 3 → Test independently


### PR DESCRIPTION
This PR adds support for a preferred language setting in `settings.json` and `AgentOptions`. When set, a language instruction block is injected into the system prompt to ensure the agent communicates in the desired language while preserving technical terms.