### PR TITLE
feat: unify scope type across agent-sdk and wave-code

### DIFF
--- a/packages/agent-sdk/src/managers/liveConfigManager.ts
+++ b/packages/agent-sdk/src/managers/liveConfigManager.ts
@@ -10,6 +10,7 @@
 import { existsSync } from "fs";
 import type { Logger } from "../types/index.js";
 import type { PermissionMode } from "../types/permissions.js";
+import type { Scope } from "../types/configuration.js";
 import {
   FileWatcherService,
   type FileWatchEvent,
@@ -452,7 +453,7 @@ export class LiveConfigManager {
 
   private async handleFileChange(
     event: FileWatchEvent,
-    source: "user" | "project",
+    source: Scope,
   ): Promise<void> {
     this.logger?.debug(
       `Live Config: File ${event.type} detected for ${source} config: ${event.path}`,

--- a/packages/agent-sdk/src/managers/pluginScopeManager.ts
+++ b/packages/agent-sdk/src/managers/pluginScopeManager.ts
@@ -1,6 +1,7 @@
 import { ConfigurationService } from "../services/configurationService.js";
 import { PluginManager } from "./pluginManager.js";
 import { Logger } from "../types/index.js";
+import { Scope } from "../types/configuration.js";
 
 export interface PluginScopeManagerOptions {
   workdir: string;
@@ -25,10 +26,7 @@ export class PluginScopeManager {
   /**
    * Enable a plugin in the specified scope
    */
-  async enablePlugin(
-    scope: "user" | "project" | "local",
-    pluginId: string,
-  ): Promise<void> {
+  async enablePlugin(scope: Scope, pluginId: string): Promise<void> {
     await this.configurationService.updateEnabledPlugin(
       this.workdir,
       scope,
@@ -42,10 +40,7 @@ export class PluginScopeManager {
   /**
    * Disable a plugin in the specified scope
    */
-  async disablePlugin(
-    scope: "user" | "project" | "local",
-    pluginId: string,
-  ): Promise<void> {
+  async disablePlugin(scope: Scope, pluginId: string): Promise<void> {
     await this.configurationService.updateEnabledPlugin(
       this.workdir,
       scope,

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -13,6 +13,7 @@ import type {
   ValidationResult,
   ConfigurationPaths,
   WaveConfiguration,
+  Scope,
 } from "../types/configuration.js";
 import {
   getAllConfigPaths,
@@ -597,7 +598,7 @@ export class ConfigurationService {
    */
   async updateEnabledPlugin(
     workdir: string,
-    scope: "user" | "project" | "local",
+    scope: Scope,
     pluginId: string,
     enabled: boolean,
   ): Promise<void> {

--- a/packages/agent-sdk/src/types/configuration.ts
+++ b/packages/agent-sdk/src/types/configuration.ts
@@ -9,6 +9,8 @@
 import type { HookEvent, HookEventConfig } from "./hooks.js";
 import type { PermissionMode } from "./permissions.js";
 
+export type Scope = "user" | "project" | "local";
+
 /**
  * Root configuration structure for all Wave Agent settings including hooks and environment variables
  */

--- a/packages/agent-sdk/src/types/environment.ts
+++ b/packages/agent-sdk/src/types/environment.ts
@@ -1,3 +1,5 @@
+import type { Scope } from "./configuration.js";
+
 /**
  * Environment Variable System Types
  *
@@ -100,5 +102,5 @@ export interface EnvironmentConflict {
   /** Final resolved value (which source won) */
   resolvedValue: string;
   /** Which source provided the final value */
-  source: "user" | "project";
+  source: Scope;
 }

--- a/packages/code/src/commands/plugin/disable.ts
+++ b/packages/code/src/commands/plugin/disable.ts
@@ -2,11 +2,12 @@ import {
   ConfigurationService,
   PluginManager,
   PluginScopeManager,
+  Scope,
 } from "wave-agent-sdk";
 
 export async function disablePluginCommand(argv: {
   plugin: string;
-  scope: "user" | "project" | "local";
+  scope: Scope;
 }) {
   const workdir = process.cwd();
   const configurationService = new ConfigurationService();

--- a/packages/code/src/commands/plugin/enable.ts
+++ b/packages/code/src/commands/plugin/enable.ts
@@ -2,11 +2,12 @@ import {
   ConfigurationService,
   PluginManager,
   PluginScopeManager,
+  Scope,
 } from "wave-agent-sdk";
 
 export async function enablePluginCommand(argv: {
   plugin: string;
-  scope: "user" | "project" | "local";
+  scope: Scope;
 }) {
   const workdir = process.cwd();
   const configurationService = new ConfigurationService();

--- a/packages/code/src/commands/plugin/install.ts
+++ b/packages/code/src/commands/plugin/install.ts
@@ -3,11 +3,12 @@ import {
   ConfigurationService,
   PluginManager,
   PluginScopeManager,
+  Scope,
 } from "wave-agent-sdk";
 
 export async function installPluginCommand(argv: {
   plugin: string;
-  scope?: "user" | "project" | "local";
+  scope?: Scope;
 }) {
   const marketplaceService = new MarketplaceService();
   const workdir = process.cwd();

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -5,6 +5,7 @@ import {
   listSessions,
   getSessionFilePath,
   getFirstMessageContent,
+  Scope,
 } from "wave-agent-sdk";
 
 // Export main function for external use
@@ -134,7 +135,7 @@ export async function main() {
               await installPluginCommand(
                 argv as {
                   plugin: string;
-                  scope?: "user" | "project" | "local";
+                  scope?: Scope;
                 },
               );
             },
@@ -174,7 +175,7 @@ export async function main() {
               await enablePluginCommand(
                 argv as {
                   plugin: string;
-                  scope: "user" | "project" | "local";
+                  scope: Scope;
                 },
               );
             },
@@ -203,7 +204,7 @@ export async function main() {
               await disablePluginCommand(
                 argv as {
                   plugin: string;
-                  scope: "user" | "project" | "local";
+                  scope: Scope;
                 },
               );
             },


### PR DESCRIPTION
This PR introduces a centralized `Scope` type in `agent-sdk` and updates all occurrences of `"user" | "project" | "local"` to use it. This ensures consistency across configuration management and plugin commands.