### PR TITLE
fix(agent-sdk): narrow gemini-3 check to gemini-3-flash

### DIFF
--- a/packages/agent-sdk/src/services/aiService.ts
+++ b/packages/agent-sdk/src/services/aiService.ts
@@ -124,7 +124,7 @@ function getModelConfig(
     config.temperature = undefined;
   }
 
-  if (modelName.startsWith("gemini-3")) {
+  if (modelName.startsWith("gemini-3-flash")) {
     config.vertexai = {
       thinking_config: {
         thinking_level: "minimal",


### PR DESCRIPTION
Narrow the model name check from gemini-3 to gemini-3-flash in aiService.ts to avoid incorrect configuration for other gemini-3 models.