### PR TITLE
feat(agent-sdk): support 429 retry with exponential backoff in OpenAIClient

### DIFF
--- a/packages/agent-sdk/tests/utils/openaiClient.test.ts
+++ b/packages/agent-sdk/tests/utils/openaiClient.test.ts
@@ -1,7 +1,15 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { OpenAIClient } from "../../src/utils/openaiClient.js";
 
 describe("OpenAIClient", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("should correctly handle SSE data lines with and without a space after the colon", async () => {
     const mockLines = [
       'data: {"choices": [{"delta": {"content": "hello"}}]}\n\n',
@@ -131,5 +139,161 @@ describe("OpenAIClient", () => {
 
     expect(chunks).toHaveLength(1);
     expect(chunks[0].choices[0].delta.content).toBe("hello");
+  });
+
+  describe("Retry logic", () => {
+    it("should retry on 429 status code and eventually succeed", async () => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          statusText: "Too Many Requests",
+          headers: new Headers(),
+          text: async () =>
+            JSON.stringify({ error: { message: "Rate limit reached" } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{ message: { content: "success" } }],
+          }),
+          headers: new Headers(),
+        });
+
+      const client = new OpenAIClient({
+        baseURL: "https://api.openai.com/v1",
+        apiKey: "test-key",
+        fetch: mockFetch,
+      });
+
+      const promise = client.chat.completions.create({
+        model: "gpt-4",
+        messages: [{ role: "user", content: "hi" }],
+      });
+
+      // First attempt fails with 429
+      await vi.runAllTimersAsync();
+
+      const result = await promise;
+      expect(result.choices[0].message.content).toBe("success");
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("should use exponential backoff", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        statusText: "Too Many Requests",
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({ error: { message: "Rate limit reached" } }),
+      });
+
+      const client = new OpenAIClient({
+        baseURL: "https://api.openai.com/v1",
+        apiKey: "test-key",
+        fetch: mockFetch,
+      });
+
+      const promise = client.chat.completions.create({
+        model: "gpt-4",
+        messages: [{ role: "user", content: "hi" }],
+      });
+
+      // Initial attempt
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // First retry after 1000ms
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      // Second retry after 2000ms
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+
+      // Third retry after 4000ms
+      await vi.advanceTimersByTimeAsync(4000);
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+
+      await expect(promise).rejects.toThrow("Rate limit reached");
+    });
+
+    it("should eventually fail after max retries (3 retries)", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        statusText: "Too Many Requests",
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({ error: { message: "Rate limit reached" } }),
+      });
+
+      const client = new OpenAIClient({
+        baseURL: "https://api.openai.com/v1",
+        apiKey: "test-key",
+        fetch: mockFetch,
+      });
+
+      const promise = client.chat.completions.create({
+        model: "gpt-4",
+        messages: [{ role: "user", content: "hi" }],
+      });
+
+      await vi.runAllTimersAsync();
+
+      await expect(promise).rejects.toThrow("Rate limit reached");
+      expect(mockFetch).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+    });
+
+    it("should not retry on other error status codes (e.g., 400)", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({ error: { message: "Invalid request" } }),
+      });
+
+      const client = new OpenAIClient({
+        baseURL: "https://api.openai.com/v1",
+        apiKey: "test-key",
+        fetch: mockFetch,
+      });
+
+      const promise = client.chat.completions.create({
+        model: "gpt-4",
+        messages: [{ role: "user", content: "hi" }],
+      });
+
+      await expect(promise).rejects.toThrow("Invalid request");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not retry on 500 status code", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: new Headers(),
+        text: async () => "Internal Server Error",
+      });
+
+      const client = new OpenAIClient({
+        baseURL: "https://api.openai.com/v1",
+        apiKey: "test-key",
+        fetch: mockFetch,
+      });
+
+      const promise = client.chat.completions.create({
+        model: "gpt-4",
+        messages: [{ role: "user", content: "hi" }],
+      });
+
+      await expect(promise).rejects.toThrow("Internal Server Error");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
This PR implements 429 (Too Many Requests) retry logic with exponential backoff in the OpenAIClient.

Key changes:
- Added a retry loop in `OpenAIClient._create` with a maximum of 3 retries.
- Implemented exponential backoff (1s, 2s, 4s).
- Added comprehensive tests to verify retry behavior, backoff timing, and error handling.
- Added logging for retry attempts.