### PR TITLE
fix: suppress diff display when tool execution fails

### DIFF
--- a/packages/code/src/components/ToolResultDisplay.tsx
+++ b/packages/code/src/components/ToolResultDisplay.tsx
@@ -135,8 +135,8 @@ export const ToolResultDisplay: React.FC<ToolResultDisplayProps> = ({
         </Box>
       )}
 
-      {/* Diff display - only show after tool execution completes */}
-      {stage === "end" && (
+      {/* Diff display - only show after tool execution completes and was successful */}
+      {stage === "end" && success && (
         <DiffDisplay toolName={name} parameters={parameters} />
       )}
     </Box>

--- a/packages/code/tests/components/ToolResultDisplay.test.tsx
+++ b/packages/code/tests/components/ToolResultDisplay.test.tsx
@@ -282,6 +282,7 @@ describe("ToolResultDisplay Component", () => {
         type: "tool",
         name: "Edit",
         stage: "end",
+        success: true,
         parameters: JSON.stringify({
           file_path: "test.txt",
           old_string: "old",
@@ -298,6 +299,30 @@ describe("ToolResultDisplay Component", () => {
       const output = lastFrame();
 
       expect(output).toContain("Diff:");
+    });
+
+    it("should NOT show diff display when stage is end but success is false", () => {
+      const toolBlock: ToolBlock = {
+        type: "tool",
+        name: "Edit",
+        stage: "end",
+        success: false,
+        parameters: JSON.stringify({
+          file_path: "test.txt",
+          old_string: "old",
+          new_string: "new",
+        }),
+      };
+
+      // We need to mock transformToolBlockToChanges to return something for this test
+      vi.mocked(transformToolBlockToChanges).mockReturnValue([
+        { oldContent: "old", newContent: "new" },
+      ]);
+
+      const { lastFrame } = render(<ToolResultDisplay block={toolBlock} />);
+      const output = lastFrame();
+
+      expect(output).not.toContain("Diff:");
     });
   });
 });


### PR DESCRIPTION
This PR ensures that the diff display is only shown when a tool execution is successful. It also adds a test case to verify this behavior.