### PR TITLE
feat(agent-sdk): redesign rewind storage architecture

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -1107,12 +1107,18 @@ export class Agent {
       const typeLabel = type === "project" ? "Project Memory" : "User Memory";
       const storagePath = "AGENTS.md";
 
-      this.messageManager.addMemoryBlock(
-        `${typeLabel}: ${memoryText}`,
-        true,
-        type,
-        storagePath,
-      );
+      const messages = this.messageManager.getMessages();
+      const lastMessage = messages[messages.length - 1];
+      if (lastMessage && lastMessage.role === "assistant") {
+        lastMessage.blocks.push({
+          type: "memory",
+          content: `${typeLabel}: ${memoryText}`,
+          isSuccess: true,
+          memoryType: type,
+          storagePath,
+        });
+        this.messageManager.setMessages(messages);
+      }
     } catch (error) {
       // Add failed MemoryBlock to the last assistant message
       const memoryText = message.substring(1).trim();
@@ -1121,12 +1127,18 @@ export class Agent {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
 
-      this.messageManager.addMemoryBlock(
-        `${typeLabel}: ${memoryText} - Error: ${errorMessage}`,
-        false,
-        type,
-        storagePath,
-      );
+      const messages = this.messageManager.getMessages();
+      const lastMessage = messages[messages.length - 1];
+      if (lastMessage && lastMessage.role === "assistant") {
+        lastMessage.blocks.push({
+          type: "memory",
+          content: `${typeLabel}: ${memoryText} - Error: ${errorMessage}`,
+          isSuccess: false,
+          memoryType: type,
+          storagePath,
+        });
+        this.messageManager.setMessages(messages);
+      }
     }
   }
 

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -684,6 +684,15 @@ export class AIManager {
 
       // Check if there are tool operations, if so automatically initiate next AI service call
       if (toolCalls.length > 0) {
+        // Record committed snapshots to message history
+        if (this.reversionManager) {
+          const snapshots =
+            this.reversionManager.getAndClearCommittedSnapshots();
+          if (snapshots.length > 0) {
+            this.messageManager.addFileHistoryBlock(snapshots);
+          }
+        }
+
         // Check interruption status
         const isCurrentlyAborted =
           abortController.signal.aborted || toolAbortController.signal.aborted;
@@ -723,6 +732,15 @@ export class AIManager {
           abortController.signal.aborted || toolAbortController.signal.aborted;
 
         if (!isCurrentlyAborted) {
+          // Record committed snapshots to message history for the final turn
+          if (this.reversionManager) {
+            const snapshots =
+              this.reversionManager.getAndClearCommittedSnapshots();
+            if (snapshots.length > 0) {
+              this.messageManager.addFileHistoryBlock(snapshots);
+            }
+          }
+
           const shouldContinue = await this.executeStopHooks();
 
           // If Stop/SubagentStop hooks indicate we should continue (due to blocking errors),

--- a/packages/agent-sdk/src/types/messaging.ts
+++ b/packages/agent-sdk/src/types/messaging.ts
@@ -28,7 +28,8 @@ export type MessageBlock =
   | CompressBlock
   | MemoryBlock
   | SubagentBlock
-  | ReasoningBlock;
+  | ReasoningBlock
+  | FileHistoryBlock;
 
 export interface TextBlock {
   type: "text";
@@ -107,4 +108,9 @@ export interface SubagentBlock {
 export interface ReasoningBlock {
   type: "reasoning";
   content: string;
+}
+
+export interface FileHistoryBlock {
+  type: "file_history";
+  snapshots: import("./reversion.js").FileSnapshot[];
 }

--- a/packages/agent-sdk/src/types/reversion.ts
+++ b/packages/agent-sdk/src/types/reversion.ts
@@ -6,8 +6,8 @@ export interface FileSnapshot {
   messageId: string;
   /** Absolute path to the file. */
   filePath: string;
-  /** The content of the file before the operation. null if the file did not exist. */
-  content: string | null;
+  /** Path to the stored snapshot file. */
+  snapshotPath?: string;
   /** When the snapshot was taken. */
   timestamp: number;
   /** The operation that triggered this snapshot. */

--- a/packages/agent-sdk/tests/integration/rewind_history.test.ts
+++ b/packages/agent-sdk/tests/integration/rewind_history.test.ts
@@ -52,10 +52,10 @@ describe("MessageManager History Truncation Integration", () => {
 
     expect(messageManager.getMessages()).toHaveLength(1);
     expect(messageManager.getMessages()[0].id).toBe("msg1");
-    expect(mockReversionManager.revertTo).toHaveBeenCalledWith([
-      "msg2",
-      "msg3",
-    ]);
+    expect(mockReversionManager.revertTo).toHaveBeenCalledWith(
+      ["msg2", "msg3"],
+      expect.any(Array),
+    );
     expect(fs.writeFile).toHaveBeenCalled();
   });
 

--- a/specs/056-rewind-command/data-model.md
+++ b/specs/056-rewind-command/data-model.md
@@ -9,9 +9,17 @@ Represents the state of a file before an agent operation.
 |-------|------|-------------|
 | `messageId` | `string` | The ID of the message/turn this snapshot is associated with. |
 | `filePath` | `string` | Absolute path to the file. |
-| `content` | `string \| null` | The content of the file before the operation. `null` if the file did not exist. |
+| `snapshotPath` | `string` | Path to the stored snapshot file in `~/.wave/file-history/`. |
 | `timestamp` | `number` | When the snapshot was taken. |
 | `operation` | `'create' \| 'modify' \| 'delete'` | The operation that triggered this snapshot. |
+
+### FileHistoryBlock (Message Block)
+A new message block type to record file history in the session JSONL. Not displayed in UI.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `'file_history'` | The block type. |
+| `snapshots` | `FileSnapshot[]` | List of snapshots taken in this turn. |
 
 ### Checkpoint
 A point in the conversation history that can be reverted to.

--- a/specs/056-rewind-command/plan.md
+++ b/specs/056-rewind-command/plan.md
@@ -5,13 +5,13 @@
 
 ## Summary
 
-Implement a `/rewind` builtin command that allows users to revert the conversation to a specific user message checkpoint. This involves deleting the selected message and all subsequent messages, and sequentially reverting all file operations (create, modify, delete) performed by the agent during those turns. The technical approach involves a new `ReversionManager` in `agent-sdk` to track file snapshots and a UI component in `code` for message selection.
+Implement a `/rewind` builtin command that allows users to revert the conversation to a specific user message checkpoint. This involves deleting the selected message and all subsequent messages, and sequentially reverting all file operations (create, modify, delete) performed by the agent during those turns. The technical approach involves a new `ReversionManager` in `agent-sdk` to track file snapshots. Snapshots are stored in `~/.wave/file-history/(sessionid)/(filepathhash)/v(num)` and recorded in the session JSONL as `file_history` blocks (not displayed in UI).
 
 ## Technical Context
 
 **Language/Version**: TypeScript (Node.js)
 **Primary Dependencies**: Ink (for CLI UI), fs/promises (for file I/O)
-**Storage**: JSONL for session messages, `.reversion.jsonl` for file snapshots
+**Storage**: JSONL for session messages, `~/.wave/file-history/` for file snapshots
 **Testing**: Vitest (Unit and Integration tests)
 **Target Platform**: Linux/macOS/Windows (Node.js environment)
 **Project Type**: Monorepo (agent-sdk + code)

--- a/specs/056-rewind-command/tasks.md
+++ b/specs/056-rewind-command/tasks.md
@@ -29,7 +29,7 @@
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
 - [X] T004 Implement `ReversionManager` with atomic snapshot buffering in `packages/agent-sdk/src/managers/reversionManager.ts`
-- [X] T005 [P] Implement `ReversionService` for JSONL persistence in `packages/agent-sdk/src/services/reversionService.ts`
+- [X] T005 [P] Implement `ReversionService` for directory-based versioned storage in `packages/agent-sdk/src/services/reversionService.ts`
 - [X] T006 [P] Add `truncateHistory` method to `MessageManager` in `packages/agent-sdk/src/managers/messageManager.ts`
 - [X] T007 [P] Register `/rewind` command in `packages/agent-sdk/src/managers/slashCommandManager.ts`
 - [X] T008 [P] Unit tests for `ReversionManager` in `packages/agent-sdk/tests/managers/reversionManager.test.ts`


### PR DESCRIPTION
This PR refactors the /rewind command storage system:
- Moves file snapshots from a sidecar JSONL to a hashed directory structure: ~/.wave/file-history/(sessionid)/(filepathhash)/v(num)
- Stores snapshot metadata directly in the session JSONL using a new 'file_history' message block type (hidden from UI)
- Implements LIFO restoration for robust file reversion
- Updates ReversionService and ReversionManager to handle the new storage model
- Fixes atomic file deletion for 'create' operations during rewind