### PR TITLE
feat: render markdown links with both text and URL

### DIFF
--- a/packages/code/src/components/Markdown.tsx
+++ b/packages/code/src/components/Markdown.tsx
@@ -53,16 +53,21 @@ const InlineRenderer = ({ tokens }: { tokens: Token[] }) => {
                 {unescapeHtml((token as Tokens.Codespan).text)}
               </Text>
             );
-          case "link":
+          case "link": {
+            const t = token as Tokens.Link;
             return (
-              <Text key={index} color="blue" underline>
-                {token.tokens ? (
-                  <InlineRenderer tokens={token.tokens} />
-                ) : (
-                  unescapeHtml((token as Tokens.Link).text)
-                )}
+              <Text key={index}>
+                <Text color="blue" underline>
+                  {t.tokens ? (
+                    <InlineRenderer tokens={t.tokens} />
+                  ) : (
+                    unescapeHtml(t.text)
+                  )}
+                </Text>
+                <Text color="gray"> ({t.href})</Text>
               </Text>
             );
+          }
           case "br":
             return <Text key={index}>{"\n"}</Text>;
           case "del":

--- a/packages/code/tests/components/Markdown.test.tsx
+++ b/packages/code/tests/components/Markdown.test.tsx
@@ -68,3 +68,14 @@ describe("Markdown Component - Code Blocks", () => {
     expect(output).toContain("const x = 1;");
   });
 });
+
+describe("Markdown Component - Links", () => {
+  it("should render links with both text and URL", () => {
+    const markdown = "[GitHub](https://github.com)";
+    const { lastFrame } = render(<Markdown>{markdown}</Markdown>);
+    const output = lastFrame();
+
+    expect(output).toContain("GitHub");
+    expect(output).toContain("(https://github.com)");
+  });
+});

--- a/specs/020-markdown-rendering-system/spec.md
+++ b/specs/020-markdown-rendering-system/spec.md
@@ -55,7 +55,7 @@ As a user, I want to see data tables rendered correctly in my terminal, even if 
 ### Functional Requirements
 
 - **FR-001**: System MUST parse Markdown strings into tokens using the `marked` library.
-- **FR-002**: System MUST render inline elements: text, strong (bold), em (italic), codespan (inline code), link, br (line break), and del (strikethrough).
+- **FR-002**: System MUST render inline elements: text, strong (bold), em (italic), codespan (inline code), link (displaying both text and URL), br (line break), and del (strikethrough).
 - **FR-003**: System MUST render block elements: headings (H1-H6), paragraphs, fenced code blocks, lists (ordered and unordered), blockquotes, and horizontal rules.
 - **FR-004**: System MUST render tables with borders and headers.
 - **FR-005**: System MUST automatically calculate column widths for tables based on content.


### PR DESCRIPTION
This PR updates the Markdown component to render both the link text and the URL. This ensures that users can see and copy the URL directly from the terminal, as terminal emulators often don't support clicking hidden links.