### PR TITLE
fix: deduplicate prompt history and limit history file size

### DIFF
--- a/packages/agent-sdk/src/utils/promptHistory.ts
+++ b/packages/agent-sdk/src/utils/promptHistory.ts
@@ -16,6 +16,8 @@ const ensureDataDirectory = (): void => {
   }
 };
 
+const MAX_HISTORY_ENTRIES = 1000;
+
 export class PromptHistoryManager {
   /**
    * Add a new prompt to history
@@ -32,8 +34,37 @@ export class PromptHistoryManager {
 
       const line = JSON.stringify(entry) + "\n";
       await fs.promises.appendFile(PROMPT_HISTORY_FILE, line, "utf-8");
+
+      // Periodically trim history file to prevent it from growing too large
+      // We do this randomly (1 in 50 chance) to avoid performance hit on every entry
+      if (Math.random() < 0.02) {
+        await this.trimHistory();
+      }
     } catch (error) {
       logger.debug("Failed to add prompt to history:", error);
+    }
+  }
+
+  /**
+   * Trim history file to MAX_HISTORY_ENTRIES
+   */
+  private static async trimHistory(): Promise<void> {
+    try {
+      if (!fs.existsSync(PROMPT_HISTORY_FILE)) return;
+
+      const data = await fs.promises.readFile(PROMPT_HISTORY_FILE, "utf-8");
+      const lines = data.split("\n").filter((line) => line.trim());
+
+      if (lines.length > MAX_HISTORY_ENTRIES * 1.2) {
+        const trimmedLines = lines.slice(-MAX_HISTORY_ENTRIES);
+        await fs.promises.writeFile(
+          PROMPT_HISTORY_FILE,
+          trimmedLines.join("\n") + "\n",
+          "utf-8",
+        );
+      }
+    } catch (error) {
+      logger.debug("Failed to trim prompt history:", error);
     }
   }
 
@@ -60,8 +91,20 @@ export class PromptHistoryManager {
         })
         .filter((entry): entry is PromptEntry => entry !== null);
 
-      // Return newest first
-      return entries.reverse();
+      // Deduplicate by prompt, keeping the most recent one
+      const uniqueEntries: PromptEntry[] = [];
+      const seenPrompts = new Set<string>();
+
+      // Process from newest to oldest
+      for (let i = entries.length - 1; i >= 0; i--) {
+        const entry = entries[i];
+        if (!seenPrompts.has(entry.prompt)) {
+          uniqueEntries.push(entry);
+          seenPrompts.add(entry.prompt);
+        }
+      }
+
+      return uniqueEntries;
     } catch (error) {
       logger.debug("Failed to load prompt history:", error);
       return [];


### PR DESCRIPTION
This PR fixes the issue where duplicated items appeared in the prompt history list and implements a periodic truncation mechanism to prevent the history file from growing too large.