### PR TITLE
chore: remove @ts-expect-error and enforce ban via ESLint

### DIFF
--- a/packages/agent-sdk/eslint.config.mjs
+++ b/packages/agent-sdk/eslint.config.mjs
@@ -17,6 +17,15 @@ export default [
   {
     files: ["**/*.{ts,tsx}"],
     rules: {
+      "@typescript-eslint/ban-ts-comment": [
+        "error",
+        {
+          "ts-expect-error": true,
+          "ts-ignore": true,
+          "ts-nocheck": true,
+          "ts-check": false,
+        },
+      ],
       // Prohibit warning comments like TODO, FIXME, eslint-disable
       "no-warning-comments": [
         "error",

--- a/packages/agent-sdk/tests/integration/planMode.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/planMode.integration.test.ts
@@ -72,8 +72,7 @@ describe("Plan Mode Integration", () => {
       finish_reason: "stop",
     });
 
-    // @ts-expect-error - accessing private for testing
-    await agent.aiManager.sendAIMessage();
+    await agent.sendMessage("I will write a plan.");
 
     // Check all calls to callAgent
     const calls = vi.mocked(callAgent).mock.calls;
@@ -134,8 +133,7 @@ describe("Plan Mode Integration", () => {
         finish_reason: "stop",
       });
 
-    // @ts-expect-error - accessing private for testing
-    await agent.aiManager.sendAIMessage();
+    await agent.sendMessage("write to file");
 
     // The assistant message should contain the tool result indicating denial
     const messages = agent.messages;

--- a/packages/agent-sdk/tests/managers/skillManager.test.ts
+++ b/packages/agent-sdk/tests/managers/skillManager.test.ts
@@ -61,13 +61,11 @@ describe("SkillManager", () => {
   });
 
   describe("executeSkill", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       // Mock initialization to make other methods available
-      vi.spyOn(skillManager, "initialize").mockResolvedValue(undefined);
       vi.spyOn(skillManager, "getAvailableSkills").mockReturnValue([]);
       vi.spyOn(skillManager, "loadSkill").mockResolvedValue(null);
-      // @ts-expect-error - accessing private property for testing
-      skillManager.initialized = true;
+      await skillManager.initialize();
     });
 
     it("should execute valid skill successfully", async () => {
@@ -187,9 +185,8 @@ describe("SkillManager", () => {
   });
 
   describe("formatAvailableSkills", () => {
-    beforeEach(() => {
-      // @ts-expect-error - accessing private property for testing
-      skillManager.initialized = true;
+    beforeEach(async () => {
+      await skillManager.initialize();
     });
 
     it("should format skills list correctly when skills exist", async () => {

--- a/packages/code/eslint.config.mjs
+++ b/packages/code/eslint.config.mjs
@@ -28,6 +28,15 @@ export default [
       "react-hooks": pluginReactHooks,
     },
     rules: {
+      "@typescript-eslint/ban-ts-comment": [
+        "error",
+        {
+          "ts-expect-error": true,
+          "ts-ignore": true,
+          "ts-nocheck": true,
+          "ts-check": false,
+        },
+      ],
       ...pluginReact.configs.recommended.rules,
       ...pluginReactHooks.configs.recommended.rules,
       "react/no-unescaped-entities": "off",


### PR DESCRIPTION
This PR removes existing @ts-expect-error directives in tests by using public APIs and configures ESLint to prevent future usage of @ts-expect-error, @ts-ignore, and @ts-nocheck.