### PR TITLE
docs: remove update agent context related documentation

### DIFF
--- a/.wave/commands/speckit.plan.md
+++ b/.wave/commands/speckit.plan.md
@@ -22,7 +22,6 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Evaluate gates (ERROR if violations unjustified)
    - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md
-   - Phase 1: Update agent context by running the agent script
    - Re-evaluate Constitution Check post-design
 
 4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -65,14 +64,7 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 
-3. **Agent context update**:
-   - Run `.specify/scripts/bash/update-agent-context.sh opencode`
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
-   - Add only new technology from current plan
-   - Preserve manual additions between markers
-
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+**Output**: data-model.md, /contracts/*, quickstart.md
 
 ## Key rules
 

--- a/specs/041-sdk-env-headers/plan.md
+++ b/specs/041-sdk-env-headers/plan.md
@@ -41,7 +41,6 @@
 - [x] All [NEEDS CLARIFICATION] resolved in `research.md`
 - [x] `data-model.md` and `contracts/` generated
 - [x] `quickstart.md` updated
-- [x] Agent context updated
 - [ ] Constitution check passed
 
 ## Phase 0: Outline & Research
@@ -57,9 +56,6 @@
 
 ### API Contracts (`contracts/`)
 - Not applicable for this internal SDK feature, but will document the environment variable format.
-
-	### Agent Context Update
-	- Update agent context manually or via appropriate tools.
 
 ## Phase 2: Implementation Strategy
 


### PR DESCRIPTION
Removed references to updating agent context from speckit plan and SDK env headers plan.