### PR TITLE
fix: only activate command selector when / is at the start of input

### DIFF
--- a/packages/code/src/managers/InputManager.ts
+++ b/packages/code/src/managers/InputManager.ts
@@ -577,8 +577,13 @@ export class InputManager {
   handleSpecialCharInput(char: string): void {
     if (char === "@") {
       this.activateFileSelector(this.cursorPosition - 1);
-    } else if (char === "/" && !this.showFileSelector) {
+    } else if (
+      char === "/" &&
+      !this.showFileSelector &&
+      this.cursorPosition === 1
+    ) {
       // Don't activate command selector when file selector is active
+      // Only activate command selector if '/' is at the start of input
       this.activateCommandSelector(this.cursorPosition - 1);
     } else if (char === "#" && this.cursorPosition === 1) {
       // Memory message detection will be handled in submit

--- a/packages/code/tests/managers/InputManager.test.ts
+++ b/packages/code/tests/managers/InputManager.test.ts
@@ -629,7 +629,7 @@ describe("InputManager", () => {
       );
     });
 
-    it("should activate command selector on /", () => {
+    it("should activate command selector on / at start", () => {
       manager.insertTextAtCursor("/");
       manager.handleSpecialCharInput("/");
 
@@ -638,6 +638,13 @@ describe("InputManager", () => {
         "",
         0,
       );
+    });
+
+    it("should NOT activate command selector on / NOT at start", () => {
+      manager.insertTextAtCursor("text /");
+      manager.handleSpecialCharInput("/");
+
+      expect(mockCallbacks.onCommandSelectorStateChange).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
This PR ensures that the command selector is only triggered when the '/' character is entered at the beginning of the input line, preventing accidental triggers during normal text entry.