### PR TITLE
feat: implement sessions-index.json for optimized session listing

### DIFF
--- a/packages/agent-sdk/tests/services/session.core.test.ts
+++ b/packages/agent-sdk/tests/services/session.core.test.ts
@@ -12,6 +12,8 @@ vi.mock("fs", () => ({
     stat: vi.fn(),
     unlink: vi.fn(),
     rmdir: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
   },
 }));
 
@@ -22,6 +24,8 @@ vi.mock("fs/promises", () => ({
   stat: vi.fn(),
   unlink: vi.fn(),
   rmdir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
 }));
 
 // Mock fileUtils (used by optimized session.ts)
@@ -208,6 +212,12 @@ describe("Session Core Functionality", () => {
     );
     vi.mocked(fs.promises.rmdir).mockImplementation(
       vi.mocked(fsPromises.rmdir),
+    );
+    vi.mocked(fs.promises.readFile).mockImplementation(
+      vi.mocked(fsPromises.readFile),
+    );
+    vi.mocked(fs.promises.writeFile).mockImplementation(
+      vi.mocked(fsPromises.writeFile),
     );
   });
 

--- a/packages/agent-sdk/tests/services/session.integration.test.ts
+++ b/packages/agent-sdk/tests/services/session.integration.test.ts
@@ -9,6 +9,8 @@ vi.mock("fs", () => ({
     stat: vi.fn(),
     unlink: vi.fn(),
     rmdir: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
   },
 }));
 
@@ -19,6 +21,8 @@ vi.mock("fs/promises", () => ({
   stat: vi.fn(),
   unlink: vi.fn(),
   rmdir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
 }));
 
 // Mock fileUtils (used by optimized session.ts)
@@ -176,6 +180,12 @@ describe("Session Integration Tests", () => {
     );
     vi.mocked(fs.promises.rmdir).mockImplementation(
       vi.mocked(fsPromises.rmdir),
+    );
+    vi.mocked(fs.promises.readFile).mockImplementation(
+      vi.mocked(fsPromises.readFile),
+    );
+    vi.mocked(fs.promises.writeFile).mockImplementation(
+      vi.mocked(fsPromises.writeFile),
     );
   });
 

--- a/packages/agent-sdk/tests/services/session.performance.test.ts
+++ b/packages/agent-sdk/tests/services/session.performance.test.ts
@@ -9,6 +9,8 @@ vi.mock("fs", () => ({
     stat: vi.fn(),
     unlink: vi.fn(),
     rmdir: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
   },
 }));
 
@@ -19,6 +21,8 @@ vi.mock("fs/promises", () => ({
   stat: vi.fn(),
   unlink: vi.fn(),
   rmdir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
 }));
 
 // Mock fileUtils (used by optimized session.ts)
@@ -170,6 +174,12 @@ describe("Session Performance Optimization", () => {
     );
     vi.mocked(fs.promises.rmdir).mockImplementation(
       vi.mocked(fsPromises.rmdir),
+    );
+    vi.mocked(fs.promises.readFile).mockImplementation(
+      vi.mocked(fsPromises.readFile),
+    );
+    vi.mocked(fs.promises.writeFile).mockImplementation(
+      vi.mocked(fsPromises.writeFile),
     );
   });
 

--- a/packages/agent-sdk/tests/services/session.subagent.test.ts
+++ b/packages/agent-sdk/tests/services/session.subagent.test.ts
@@ -11,6 +11,8 @@ vi.mock("fs", () => ({
     stat: vi.fn(),
     unlink: vi.fn(),
     rmdir: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
   },
 }));
 
@@ -21,6 +23,8 @@ vi.mock("fs/promises", () => ({
   stat: vi.fn(),
   unlink: vi.fn(),
   rmdir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
 }));
 
 // Mock fileUtils (used by optimized session.ts)
@@ -175,6 +179,12 @@ describe("Subagent Session Tests", () => {
     );
     vi.mocked(fs.promises.rmdir).mockImplementation(
       vi.mocked(fsPromises.rmdir),
+    );
+    vi.mocked(fs.promises.readFile).mockImplementation(
+      vi.mocked(fsPromises.readFile),
+    );
+    vi.mocked(fs.promises.writeFile).mockImplementation(
+      vi.mocked(fsPromises.writeFile),
     );
   });
 

--- a/specs/004-session-management/plan.md
+++ b/specs/004-session-management/plan.md
@@ -25,3 +25,8 @@ This plan outlines the historical steps taken to implement the current session m
 - [x] Implement `cleanupExpiredSessions` (14-day limit).
 - [x] Implement `cleanupEmptyProjectDirectories`.
 - [x] Add error handling for corrupted JSONL lines.
+
+## Phase 6: Session Indexing & UI Optimization
+- [x] Implement `sessions-index.json` for O(1) listing performance.
+- [x] Cache `firstMessage` content in the index for instant UI summaries.
+- [x] Implement automatic index rebuilding from source-of-truth `.jsonl` files.

--- a/specs/004-session-management/spec.md
+++ b/specs/004-session-management/spec.md
@@ -73,6 +73,9 @@ As a developer using subagents, I want subagent sessions to be clearly identifie
 - **FR-010**: Session listing MUST be optimized to only read the last line of each session file to minimize I/O.
 - **FR-011**: Sessions older than 14 days MUST be automatically cleaned up.
 - **FR-012**: Empty project directories MUST be removed during cleanup.
+- **FR-013**: Each project directory MUST maintain a `sessions-index.json` file for O(1) session listing.
+- **FR-014**: The session index MUST cache the `firstMessage` content for instant UI display.
+- **FR-015**: The system MUST be able to rebuild the session index from `.jsonl` files if it is missing or corrupted.
 
 ### Key Entities *(include if feature involves data)*
 
@@ -82,6 +85,10 @@ As a developer using subagents, I want subagent sessions to be clearly identifie
     - `workdir`: The project directory associated with the session.
     - `lastActiveAt`: Timestamp of the last message.
     - `messages`: List of message objects.
+    - `firstMessage`: (Optional) The content of the first message in the session for display purposes.
+- **SessionIndex**:
+    - `sessions`: A map of session IDs to metadata.
+    - `lastUpdated`: Timestamp of the last index update.
 - **Project Directory**: A container for sessions belonging to a specific path.
     - `path`: Original filesystem path.
     - `encodedPath`: Filesystem-safe name used for the directory.

--- a/specs/004-session-management/tasks.md
+++ b/specs/004-session-management/tasks.md
@@ -13,3 +13,5 @@
 - [x] Ensure backward compatibility with existing JSONL sessions during transition
 - [x] Add timestamp to each message line in JSONL
 - [x] Implement `handleSessionRestoration` logic
+- [x] Implement `sessions-index.json` for O(1) session listing performance
+- [x] Cache `firstMessage` content in session index for instant UI display


### PR DESCRIPTION
This PR introduces a per-project `sessions-index.json` to optimize session listing from O(N) to O(1). It also caches the first message content for instant UI summaries and includes automatic index rebuilding from source-of-truth JSONL files.