### PR TITLE
feat: optimize CLI session selector with cached index

### DIFF
--- a/packages/code/src/session-selector-cli.tsx
+++ b/packages/code/src/session-selector-cli.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 import { render, Box } from "ink";
-import {
-  listSessions,
-  getFirstMessageContent,
-  truncateContent,
-} from "wave-agent-sdk";
+import { listSessions, truncateContent } from "wave-agent-sdk";
 import { SessionSelector } from "./components/SessionSelector.js";
 
 export async function startSessionSelectorCli(): Promise<string | null> {
@@ -16,15 +12,12 @@ export async function startSessionSelectorCli(): Promise<string | null> {
     return null;
   }
 
-  const sessionsWithContent = await Promise.all(
-    sessions.map(async (s) => {
-      const content = await getFirstMessageContent(s.id, s.workdir);
-      return {
-        ...s,
-        firstMessage: content ? truncateContent(content, 60) : "No content",
-      };
-    }),
-  );
+  const sessionsWithContent = sessions.map((s) => ({
+    ...s,
+    firstMessage: s.firstMessage
+      ? truncateContent(s.firstMessage, 60)
+      : "No content",
+  }));
 
   return new Promise((resolve) => {
     const { unmount } = render(

--- a/specs/004-session-management/plan.md
+++ b/specs/004-session-management/plan.md
@@ -30,3 +30,4 @@ This plan outlines the historical steps taken to implement the current session m
 - [x] Implement `sessions-index.json` for O(1) listing performance.
 - [x] Cache `firstMessage` content in the index for instant UI summaries.
 - [x] Implement automatic index rebuilding from source-of-truth `.jsonl` files.
+- [x] Refactor CLI (`session-selector-cli.tsx`) to use cached index data, eliminating per-session file reads.

--- a/specs/004-session-management/spec.md
+++ b/specs/004-session-management/spec.md
@@ -28,11 +28,12 @@ As a user with hundreds of historical sessions, I want the session list to load 
 
 **Why this priority**: Essential for a good user experience as the number of sessions grows.
 
-**Independent Test**: Generate 100 large session files and measure the time to list them; it should be near-instant because only the last line is read.
+**Independent Test**: Generate 100 large session files and measure the time to list them; it should be near-instant because the system reads from a single `sessions-index.json` file.
 
 **Acceptance Scenarios**:
 
-1. **Given** multiple session files, **When** listing sessions, **Then** the system MUST only read the last line of each file to extract metadata.
+1. **Given** multiple session files, **When** listing sessions, **Then** the system MUST read from `sessions-index.json` to achieve O(1) performance.
+2. **Given** a missing or corrupted index, **When** listing sessions, **Then** the system MUST fallback to reading the last line of each file and rebuild the index.
 
 ---
 
@@ -70,7 +71,7 @@ As a developer using subagents, I want subagent sessions to be clearly identifie
 - **FR-007**: Subagent session files MUST be prefixed with `subagent-`.
 - **FR-008**: Each message line MUST include a `timestamp` field in ISO 8601 format.
 - **FR-009**: Session metadata MUST be derived from the filename, directory structure, and the last message line.
-- **FR-010**: Session listing MUST be optimized to only read the last line of each session file to minimize I/O.
+- **FR-010**: Session listing MUST be optimized to use `sessions-index.json` to achieve O(1) performance, minimizing I/O.
 - **FR-011**: Sessions older than 14 days MUST be automatically cleaned up.
 - **FR-012**: Empty project directories MUST be removed during cleanup.
 - **FR-013**: Each project directory MUST maintain a `sessions-index.json` file for O(1) session listing.

--- a/specs/004-session-management/tasks.md
+++ b/specs/004-session-management/tasks.md
@@ -15,3 +15,4 @@
 - [x] Implement `handleSessionRestoration` logic
 - [x] Implement `sessions-index.json` for O(1) session listing performance
 - [x] Cache `firstMessage` content in session index for instant UI display
+- [x] Remove redundant `getFirstMessageContent` calls from CLI to fully leverage index


### PR DESCRIPTION
This PR refactors the CLI session selector to use the newly implemented session index, eliminating redundant file reads and improving startup performance for 'wave -r'.