### PR TITLE
feat: set session selector width to 100% and show full session info

### DIFF
--- a/packages/code/src/components/SessionSelector.tsx
+++ b/packages/code/src/components/SessionSelector.tsx
@@ -48,6 +48,7 @@ export const SessionSelector: React.FC<SessionSelectorProps> = ({
         borderLeft={false}
         borderRight={false}
         paddingX={1}
+        width="100%"
       >
         <Text color="yellow">No sessions found.</Text>
         <Text dimColor>Press Escape to cancel</Text>
@@ -74,6 +75,7 @@ export const SessionSelector: React.FC<SessionSelectorProps> = ({
       borderColor="cyan"
       borderLeft={false}
       borderRight={false}
+      width="100%"
     >
       <Box>
         <Text color="cyan" bold>
@@ -88,18 +90,18 @@ export const SessionSelector: React.FC<SessionSelectorProps> = ({
           const lastActiveAt = new Date(session.lastActiveAt).toLocaleString();
 
           return (
-            <Box key={session.id} flexDirection="column">
-              <Box>
+            <Box key={session.id} flexDirection="column" width="100%">
+              <Box width="100%">
                 <Text
                   color={isSelected ? "black" : "white"}
                   backgroundColor={isSelected ? "cyan" : undefined}
                 >
                   {isSelected ? "▶ " : "  "}
-                  {session.id.substring(0, 8)}... | {lastActiveAt} |{" "}
-                  {session.latestTotalTokens} tokens
+                  {session.id} | {lastActiveAt} | {session.latestTotalTokens}{" "}
+                  tokens
                 </Text>
               </Box>
-              <Box marginLeft={4}>
+              <Box marginLeft={4} width="100%">
                 <Text dimColor italic>
                   {session.firstMessage}
                 </Text>

--- a/packages/code/src/session-selector-cli.tsx
+++ b/packages/code/src/session-selector-cli.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, Box } from "ink";
-import { listSessions, truncateContent } from "wave-agent-sdk";
+import { listSessions } from "wave-agent-sdk";
 import { SessionSelector } from "./components/SessionSelector.js";
 
 export async function startSessionSelectorCli(): Promise<string | null> {
@@ -14,9 +14,7 @@ export async function startSessionSelectorCli(): Promise<string | null> {
 
   const sessionsWithContent = sessions.map((s) => ({
     ...s,
-    firstMessage: s.firstMessage
-      ? truncateContent(s.firstMessage, 60)
-      : "No content",
+    firstMessage: s.firstMessage || "No content",
   }));
 
   return new Promise((resolve) => {


### PR DESCRIPTION
This PR updates the session selector to use 100% of the terminal width and removes manual truncation of session IDs and messages to allow them to use available space.