### PR TITLE
fix(code): prevent text truncation in Markdown component

### DIFF
--- a/packages/code/src/components/Markdown.tsx
+++ b/packages/code/src/components/Markdown.tsx
@@ -205,13 +205,10 @@ const BlockRenderer = ({ tokens }: { tokens: Token[] }) => {
           case "paragraph": {
             const t = token as Tokens.Paragraph;
             return (
-              <Box
-                key={index}
-                marginBottom={1}
-                flexDirection="row"
-                flexWrap="wrap"
-              >
-                <InlineRenderer tokens={t.tokens} />
+              <Box key={index} marginBottom={1} flexDirection="row">
+                <Text>
+                  <InlineRenderer tokens={t.tokens} />
+                </Text>
               </Box>
             );
           }
@@ -276,14 +273,12 @@ const BlockRenderer = ({ tokens }: { tokens: Token[] }) => {
                           if (itemToken.type === "text") {
                             const it = itemToken as Tokens.Text;
                             return (
-                              <Box
-                                key={itemIndex}
-                                flexDirection="row"
-                                flexWrap="wrap"
-                              >
-                                <InlineRenderer
-                                  tokens={it.tokens || [itemToken]}
-                                />
+                              <Box key={itemIndex} flexDirection="row">
+                                <Text>
+                                  <InlineRenderer
+                                    tokens={it.tokens || [itemToken]}
+                                  />
+                                </Text>
                               </Box>
                             );
                           }


### PR DESCRIPTION
This PR fixes an issue where words and text were being truncated in the Markdown component by wrapping inline content in a single Text component instead of relying on Box wrapping.