### PR TITLE
Simplify plugin enable/disable scope management

### DIFF
--- a/packages/agent-sdk/src/managers/pluginScopeManager.ts
+++ b/packages/agent-sdk/src/managers/pluginScopeManager.ts
@@ -1,7 +1,6 @@
 import { ConfigurationService } from "../services/configurationService.js";
 import { PluginManager } from "./pluginManager.js";
 import { Logger } from "../types/index.js";
-import { Scope } from "../types/configuration.js";
 
 export interface PluginScopeManagerOptions {
   workdir: string;
@@ -24,30 +23,38 @@ export class PluginScopeManager {
   }
 
   /**
-   * Enable a plugin in the specified scope
+   * Enable a plugin. It finds the existing scope or defaults to user.
    */
-  async enablePlugin(scope: Scope, pluginId: string): Promise<void> {
+  async enablePlugin(pluginId: string): Promise<void> {
+    const targetScope =
+      this.configurationService.findPluginScope(this.workdir, pluginId) ||
+      "user";
+
     await this.configurationService.updateEnabledPlugin(
       this.workdir,
-      scope,
+      targetScope,
       pluginId,
       true,
     );
-    this.logger?.info(`Enabled plugin ${pluginId} in ${scope} scope`);
+    this.logger?.info(`Enabled plugin ${pluginId} in ${targetScope} scope`);
     this.refreshPluginManager();
   }
 
   /**
-   * Disable a plugin in the specified scope
+   * Disable a plugin. It finds the existing scope or defaults to user.
    */
-  async disablePlugin(scope: Scope, pluginId: string): Promise<void> {
+  async disablePlugin(pluginId: string): Promise<void> {
+    const targetScope =
+      this.configurationService.findPluginScope(this.workdir, pluginId) ||
+      "user";
+
     await this.configurationService.updateEnabledPlugin(
       this.workdir,
-      scope,
+      targetScope,
       pluginId,
       false,
     );
-    this.logger?.info(`Disabled plugin ${pluginId} in ${scope} scope`);
+    this.logger?.info(`Disabled plugin ${pluginId} in ${targetScope} scope`);
     this.refreshPluginManager();
   }
 

--- a/packages/agent-sdk/tests/managers/pluginScopeManager.test.ts
+++ b/packages/agent-sdk/tests/managers/pluginScopeManager.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, Mock } from "vitest";
+import { PluginScopeManager } from "../../src/managers/pluginScopeManager.js";
+import { ConfigurationService } from "../../src/services/configurationService.js";
+import { PluginManager } from "../../src/managers/pluginManager.js";
+
+describe("PluginScopeManager", () => {
+  let scopeManager: PluginScopeManager;
+  let mockConfigService: Record<string, unknown>;
+  let mockPluginManager: Record<string, unknown>;
+  const workdir = "/test/workdir";
+
+  beforeEach(() => {
+    mockConfigService = {
+      updateEnabledPlugin: vi.fn().mockResolvedValue(undefined),
+      getMergedEnabledPlugins: vi.fn().mockReturnValue({}),
+      findPluginScope: vi.fn(),
+    };
+    mockPluginManager = {
+      updateEnabledPlugins: vi.fn(),
+    };
+    scopeManager = new PluginScopeManager({
+      workdir,
+      configurationService:
+        mockConfigService as unknown as ConfigurationService,
+      pluginManager: mockPluginManager as unknown as PluginManager,
+    });
+  });
+
+  describe("enablePlugin", () => {
+    it("should find existing scope", async () => {
+      (mockConfigService.findPluginScope as Mock).mockReturnValue("local");
+      await scopeManager.enablePlugin("test-plugin");
+      expect(mockConfigService.updateEnabledPlugin).toHaveBeenCalledWith(
+        workdir,
+        "local",
+        "test-plugin",
+        true,
+      );
+    });
+
+    it("should default to user scope if not found", async () => {
+      (mockConfigService.findPluginScope as Mock).mockReturnValue(null);
+      await scopeManager.enablePlugin("test-plugin");
+      expect(mockConfigService.updateEnabledPlugin).toHaveBeenCalledWith(
+        workdir,
+        "user",
+        "test-plugin",
+        true,
+      );
+    });
+  });
+
+  describe("disablePlugin", () => {
+    it("should find existing scope", async () => {
+      (mockConfigService.findPluginScope as Mock).mockReturnValue("local");
+      await scopeManager.disablePlugin("test-plugin");
+      expect(mockConfigService.updateEnabledPlugin).toHaveBeenCalledWith(
+        workdir,
+        "local",
+        "test-plugin",
+        false,
+      );
+    });
+
+    it("should default to user scope if not found", async () => {
+      (mockConfigService.findPluginScope as Mock).mockReturnValue(null);
+      await scopeManager.disablePlugin("test-plugin");
+      expect(mockConfigService.updateEnabledPlugin).toHaveBeenCalledWith(
+        workdir,
+        "user",
+        "test-plugin",
+        false,
+      );
+    });
+  });
+});

--- a/packages/agent-sdk/tests/services/configurationService.plugins.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.plugins.test.ts
@@ -209,6 +209,51 @@ describe("ConfigurationService - Plugins", () => {
     });
   });
 
+  describe("findPluginScope", () => {
+    it("should find plugin in local scope", () => {
+      const projectLocalPath = path.join(
+        workdir,
+        ".wave",
+        "settings.local.json",
+      );
+      vi.mocked(existsSync).mockImplementation((p) => p === projectLocalPath);
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify({ enabledPlugins: { "test-plugin": true } }),
+      );
+
+      const scope = configService.findPluginScope(workdir, "test-plugin");
+      expect(scope).toBe("local");
+    });
+
+    it("should find plugin in project scope", () => {
+      const projectJsonPath = path.join(workdir, ".wave", "settings.json");
+      vi.mocked(existsSync).mockImplementation((p) => p === projectJsonPath);
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify({ enabledPlugins: { "test-plugin": true } }),
+      );
+
+      const scope = configService.findPluginScope(workdir, "test-plugin");
+      expect(scope).toBe("project");
+    });
+
+    it("should find plugin in user scope", () => {
+      const userJsonPath = path.join(userHome, ".wave", "settings.json");
+      vi.mocked(existsSync).mockImplementation((p) => p === userJsonPath);
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify({ enabledPlugins: { "test-plugin": true } }),
+      );
+
+      const scope = configService.findPluginScope(workdir, "test-plugin");
+      expect(scope).toBe("user");
+    });
+
+    it("should return null if plugin not found in any scope", () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+      const scope = configService.findPluginScope(workdir, "test-plugin");
+      expect(scope).toBeNull();
+    });
+  });
+
   describe("validateConfiguration", () => {
     it("should validate enabledPlugins correctly", () => {
       const validConfig = {

--- a/packages/code/src/commands/plugin/disable.ts
+++ b/packages/code/src/commands/plugin/disable.ts
@@ -2,13 +2,9 @@ import {
   ConfigurationService,
   PluginManager,
   PluginScopeManager,
-  Scope,
 } from "wave-agent-sdk";
 
-export async function disablePluginCommand(argv: {
-  plugin: string;
-  scope: Scope;
-}) {
+export async function disablePluginCommand(argv: { plugin: string }) {
   const workdir = process.cwd();
   const configurationService = new ConfigurationService();
   const pluginManager = new PluginManager({ workdir });
@@ -19,10 +15,8 @@ export async function disablePluginCommand(argv: {
   });
 
   try {
-    await scopeManager.disablePlugin(argv.scope, argv.plugin);
-    console.log(
-      `Successfully disabled plugin: ${argv.plugin} in ${argv.scope} scope`,
-    );
+    await scopeManager.disablePlugin(argv.plugin);
+    console.log(`Successfully disabled plugin: ${argv.plugin}`);
     process.exit(0);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/packages/code/src/commands/plugin/enable.ts
+++ b/packages/code/src/commands/plugin/enable.ts
@@ -2,13 +2,9 @@ import {
   ConfigurationService,
   PluginManager,
   PluginScopeManager,
-  Scope,
 } from "wave-agent-sdk";
 
-export async function enablePluginCommand(argv: {
-  plugin: string;
-  scope: Scope;
-}) {
+export async function enablePluginCommand(argv: { plugin: string }) {
   const workdir = process.cwd();
   const configurationService = new ConfigurationService();
   const pluginManager = new PluginManager({ workdir });
@@ -19,10 +15,8 @@ export async function enablePluginCommand(argv: {
   });
 
   try {
-    await scopeManager.enablePlugin(argv.scope, argv.plugin);
-    console.log(
-      `Successfully enabled plugin: ${argv.plugin} in ${argv.scope} scope`,
-    );
+    await scopeManager.enablePlugin(argv.plugin);
+    console.log(`Successfully enabled plugin: ${argv.plugin}`);
     process.exit(0);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/packages/code/src/commands/plugin/install.ts
+++ b/packages/code/src/commands/plugin/install.ts
@@ -1,8 +1,6 @@
 import {
   MarketplaceService,
   ConfigurationService,
-  PluginManager,
-  PluginScopeManager,
   Scope,
 } from "wave-agent-sdk";
 
@@ -22,15 +20,13 @@ export async function installPluginCommand(argv: {
 
     if (argv.scope) {
       const configurationService = new ConfigurationService();
-      const pluginManager = new PluginManager({ workdir });
-      const scopeManager = new PluginScopeManager({
-        workdir,
-        configurationService,
-        pluginManager,
-      });
-
       const pluginId = `${installed.name}@${installed.marketplace}`;
-      await scopeManager.enablePlugin(argv.scope, pluginId);
+      await configurationService.updateEnabledPlugin(
+        workdir,
+        argv.scope,
+        pluginId,
+        true,
+      );
       console.log(`Plugin ${pluginId} enabled in ${argv.scope} scope`);
     }
 

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -143,20 +143,12 @@ export async function main() {
           )
           .command(
             "enable <plugin>",
-            "Enable a plugin in a specific scope",
+            "Enable a plugin",
             (yargs) => {
-              return yargs
-                .positional("plugin", {
-                  describe: "Plugin ID (format: name@marketplace)",
-                  type: "string",
-                })
-                .option("scope", {
-                  alias: "s",
-                  describe: "Scope to enable the plugin in",
-                  choices: ["user", "project", "local"],
-                  default: "user",
-                  type: "string",
-                });
+              return yargs.positional("plugin", {
+                describe: "Plugin ID (format: name@marketplace)",
+                type: "string",
+              });
             },
             async (argv) => {
               const { enablePluginCommand } = await import(
@@ -165,27 +157,18 @@ export async function main() {
               await enablePluginCommand(
                 argv as {
                   plugin: string;
-                  scope: Scope;
                 },
               );
             },
           )
           .command(
             "disable <plugin>",
-            "Disable a plugin in a specific scope",
+            "Disable a plugin",
             (yargs) => {
-              return yargs
-                .positional("plugin", {
-                  describe: "Plugin ID (format: name@marketplace)",
-                  type: "string",
-                })
-                .option("scope", {
-                  alias: "s",
-                  describe: "Scope to disable the plugin in",
-                  choices: ["user", "project", "local"],
-                  default: "user",
-                  type: "string",
-                });
+              return yargs.positional("plugin", {
+                describe: "Plugin ID (format: name@marketplace)",
+                type: "string",
+              });
             },
             async (argv) => {
               const { disablePluginCommand } = await import(
@@ -194,7 +177,6 @@ export async function main() {
               await disablePluginCommand(
                 argv as {
                   plugin: string;
-                  scope: Scope;
                 },
               );
             },

--- a/packages/code/tests/commands/plugin/scope.test.ts
+++ b/packages/code/tests/commands/plugin/scope.test.ts
@@ -78,12 +78,12 @@ describe("Plugin Scope Integration Tests", () => {
     await fs.rm(userHome, { recursive: true, force: true });
   });
 
-  it("should enable a plugin in user scope", async () => {
-    await enablePluginCommand({ plugin: "test-plugin@market", scope: "user" });
+  it("should enable a plugin", async () => {
+    await enablePluginCommand({ plugin: "test-plugin@market" });
 
     expect(mockLog).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Successfully enabled plugin: test-plugin@market in user scope",
+        "Successfully enabled plugin: test-plugin@market",
       ),
     );
 
@@ -93,28 +93,34 @@ describe("Plugin Scope Integration Tests", () => {
   });
 
   it("should enable a plugin in project scope", async () => {
+    // Create project config first so it finds it
+    const projectConfigPath = path.join(tempDir, ".wave", "settings.json");
+    await fs.mkdir(path.dirname(projectConfigPath), { recursive: true });
+    await fs.writeFile(
+      projectConfigPath,
+      JSON.stringify({ enabledPlugins: { "test-plugin@market": false } }),
+    );
+
     await enablePluginCommand({
       plugin: "test-plugin@market",
-      scope: "project",
     });
 
     expect(mockLog).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Successfully enabled plugin: test-plugin@market in project scope",
+        "Successfully enabled plugin: test-plugin@market",
       ),
     );
 
-    const projectConfigPath = path.join(tempDir, ".wave", "settings.json");
     const config = JSON.parse(await fs.readFile(projectConfigPath, "utf-8"));
     expect(config.enabledPlugins["test-plugin@market"]).toBe(true);
   });
 
-  it("should disable a plugin in user scope", async () => {
-    await disablePluginCommand({ plugin: "test-plugin@market", scope: "user" });
+  it("should disable a plugin", async () => {
+    await disablePluginCommand({ plugin: "test-plugin@market" });
 
     expect(mockLog).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Successfully disabled plugin: test-plugin@market in user scope",
+        "Successfully disabled plugin: test-plugin@market",
       ),
     );
 
@@ -124,13 +130,19 @@ describe("Plugin Scope Integration Tests", () => {
   });
 
   it("should test priority: Disable in user scope, enable in project scope -> should be enabled", async () => {
-    // 1. Disable in user scope
-    await disablePluginCommand({ plugin: "test-plugin@market", scope: "user" });
+    // 1. Disable in user scope (defaults to user)
+    await disablePluginCommand({ plugin: "test-plugin@market" });
 
-    // 2. Enable in project scope
+    // 2. Enable in project scope (must exist first to be found)
+    const projectConfigPath = path.join(tempDir, ".wave", "settings.json");
+    await fs.mkdir(path.dirname(projectConfigPath), { recursive: true });
+    await fs.writeFile(
+      projectConfigPath,
+      JSON.stringify({ enabledPlugins: { "test-plugin@market": false } }),
+    );
+
     await enablePluginCommand({
       plugin: "test-plugin@market",
-      scope: "project",
     });
 
     // 3. List plugins
@@ -143,13 +155,19 @@ describe("Plugin Scope Integration Tests", () => {
   });
 
   it("should test priority: Enable in user scope, disable in project scope -> should be disabled", async () => {
-    // 1. Enable in user scope
-    await enablePluginCommand({ plugin: "test-plugin@market", scope: "user" });
+    // 1. Enable in user scope (defaults to user)
+    await enablePluginCommand({ plugin: "test-plugin@market" });
 
-    // 2. Disable in project scope
+    // 2. Disable in project scope (must exist first to be found)
+    const projectConfigPath = path.join(tempDir, ".wave", "settings.json");
+    await fs.mkdir(path.dirname(projectConfigPath), { recursive: true });
+    await fs.writeFile(
+      projectConfigPath,
+      JSON.stringify({ enabledPlugins: { "test-plugin@market": true } }),
+    );
+
     await disablePluginCommand({
       plugin: "test-plugin@market",
-      scope: "project",
     });
 
     // 3. List plugins


### PR DESCRIPTION
This PR simplifies plugin management by removing the mandatory scope parameter from enable and disable commands. The system now automatically detects the existing scope or defaults to user scope. Scoped installation is still supported.