### PR TITLE
fix: truncate first message in session list display

### DIFF
--- a/packages/code/src/session-selector-cli.tsx
+++ b/packages/code/src/session-selector-cli.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, Box } from "ink";
-import { listSessions } from "wave-agent-sdk";
+import { listSessions, truncateContent } from "wave-agent-sdk";
 import { SessionSelector } from "./components/SessionSelector.js";
 
 export async function startSessionSelectorCli(): Promise<string | null> {
@@ -14,7 +14,7 @@ export async function startSessionSelectorCli(): Promise<string | null> {
 
   const sessionsWithContent = sessions.map((s) => ({
     ...s,
-    firstMessage: s.firstMessage || "No content",
+    firstMessage: truncateContent(s.firstMessage || "No content", 80),
   }));
 
   return new Promise((resolve) => {


### PR DESCRIPTION
## Changes

- Import `truncateContent` utility from wave-agent-sdk
- Apply 80-character truncation to `firstMessage` in session selector
- Prevents excessively long messages from breaking layout in `wave -r` output

## Testing

- Built agent-sdk and wave-code successfully
- The existing `truncateContent` function adds "..." suffix when content exceeds max length