### PR TITLE
Simplify Plugin Management

### DIFF
--- a/packages/code/src/components/InstalledView.tsx
+++ b/packages/code/src/components/InstalledView.tsx
@@ -18,11 +18,6 @@ export const InstalledView: React.FC = () => {
       if (plugin) {
         actions.uninstallPlugin(plugin.name, plugin.marketplace);
       }
-    } else if (input === "t") {
-      const plugin = installedPlugins[selectedIndex];
-      if (plugin) {
-        actions.togglePlugin(plugin.name, plugin.marketplace, !plugin.enabled);
-      }
     }
   });
 
@@ -49,14 +44,11 @@ export const InstalledView: React.FC = () => {
                 {isSelected ? "> " : "  "}
                 <Text bold>{plugin.name}</Text>
                 <Text dimColor> @{plugin.marketplace}</Text>
-                <Text color={plugin.enabled ? "green" : "red"}>
-                  {plugin.enabled ? " [Enabled]" : " [Disabled]"}
-                </Text>
               </Text>
             </Box>
             {isSelected && (
               <Box marginLeft={4}>
-                <Text dimColor>Press 't' to toggle, 'u' to uninstall</Text>
+                <Text dimColor>Press 'u' to uninstall</Text>
               </Box>
             )}
           </Box>

--- a/packages/code/src/components/PluginDetail.tsx
+++ b/packages/code/src/components/PluginDetail.tsx
@@ -3,8 +3,8 @@ import { Box, Text, useInput } from "ink";
 import { usePluginManagerContext } from "../contexts/PluginManagerContext.js";
 
 const SCOPES = [
-  { id: "user", label: "Install for you (user scope)" },
   { id: "project", label: "Install for all collaborators (project scope)" },
+  { id: "user", label: "Install for you (user scope)" },
   { id: "local", label: "Install for you, in this repo only (local scope)" },
 ] as const;
 

--- a/packages/code/src/components/PluginManagerTypes.ts
+++ b/packages/code/src/components/PluginManagerTypes.ts
@@ -40,11 +40,6 @@ export interface PluginManagerContextType {
       scope?: "user" | "project" | "local",
     ) => Promise<void>;
     uninstallPlugin: (name: string, marketplace: string) => Promise<void>;
-    togglePlugin: (
-      name: string,
-      marketplace: string,
-      enabled: boolean,
-    ) => Promise<void>;
     refresh: () => Promise<void>;
   };
 }

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -150,62 +150,6 @@ export async function main() {
             },
           )
           .command(
-            "enable <plugin>",
-            "Enable a plugin in a specific scope",
-            (yargs) => {
-              return yargs
-                .positional("plugin", {
-                  describe: "Plugin ID (format: name@marketplace)",
-                  type: "string",
-                })
-                .option("scope", {
-                  alias: "s",
-                  describe: "Scope to enable the plugin in",
-                  choices: ["user", "project", "local"],
-                  type: "string",
-                });
-            },
-            async (argv) => {
-              const { enablePluginCommand } = await import(
-                "./commands/plugin/enable.js"
-              );
-              await enablePluginCommand(
-                argv as {
-                  plugin: string;
-                  scope?: Scope;
-                },
-              );
-            },
-          )
-          .command(
-            "disable <plugin>",
-            "Disable a plugin in a specific scope",
-            (yargs) => {
-              return yargs
-                .positional("plugin", {
-                  describe: "Plugin ID (format: name@marketplace)",
-                  type: "string",
-                })
-                .option("scope", {
-                  alias: "s",
-                  describe: "Scope to disable the plugin in",
-                  choices: ["user", "project", "local"],
-                  type: "string",
-                });
-            },
-            async (argv) => {
-              const { disablePluginCommand } = await import(
-                "./commands/plugin/disable.js"
-              );
-              await disablePluginCommand(
-                argv as {
-                  plugin: string;
-                  scope?: Scope;
-                },
-              );
-            },
-          )
-          .command(
             "uninstall <plugin>",
             "Uninstall a plugin",
             (yargs) => {

--- a/packages/code/tests/integration/plugin-manager.test.tsx
+++ b/packages/code/tests/integration/plugin-manager.test.tsx
@@ -86,7 +86,7 @@ describe("PluginManager Integration", () => {
     expect(mockActions.installPlugin).toHaveBeenCalledWith(
       "test-plugin",
       "official",
-      "user",
+      "project",
     );
   });
 
@@ -111,15 +111,6 @@ describe("PluginManager Integration", () => {
     const { stdin, lastFrame } = render(<PluginManagerShell />);
 
     expect(stripAnsiColors(lastFrame() || "")).toContain("installed-plugin");
-    expect(stripAnsiColors(lastFrame() || "")).toContain("[Enabled]");
-
-    // Press 't' to toggle
-    stdin.write("t");
-    expect(mockActions.togglePlugin).toHaveBeenCalledWith(
-      "installed-plugin",
-      "official",
-      false,
-    );
 
     // Press 'u' to uninstall
     stdin.write("u");

--- a/specs/045-plugin-scope-management/spec.md
+++ b/specs/045-plugin-scope-management/spec.md
@@ -3,23 +3,22 @@
 **Feature Branch**: `045-plugin-scope-management`  
 **Created**: 2026-01-13  
 **Status**: Implemented  
-**Input**: User description: "wave plugin should support disable enable, and each should support  -s, --scope <scope>  Installation scope: user, project, or local (default: \"user\"). plus, plugin install should support -s --scope too. after install, related settings.json should be added like :   \"enabledPlugins\": { \"review-plugin@my-plugins\": true }. refer to specs/044-local-plugin-marketplace to learn current spec"
+**Input**: User description: "wave plugin should support disable enable, and each should support  -s, --scope <scope>  Installation scope: user, project, or local (default: \"project\"). plus, plugin install should support -s --scope too. after install, related settings.json should be added like :   \"enabledPlugins\": { \"review-plugin@my-plugins\": true }. refer to specs/044-local-plugin-marketplace to learn current spec"
 
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Contextual Plugin Control (Priority: P1)
 
-As a developer working on multiple projects, I want to enable certain plugins globally for my user account but disable them or enable different ones for specific projects or directories.
+As a developer working on multiple projects, I want to install plugins for specific projects or directories.
 
 **Why this priority**: This is the core requirement. It allows users to manage their toolset based on the context of their work, preventing command clutter and ensuring project-specific tools are available where needed.
 
-**Independent Test**: Can be tested by installing a plugin, then using `wave plugin disable <plugin> -s project` in a specific directory and verifying that the plugin's commands are not available in that directory but remain available elsewhere.
+**Independent Test**: Can be tested by installing a plugin in a specific directory and verifying that the plugin's commands are available in that directory but not available elsewhere.
 
 **Acceptance Scenarios**:
 
-1. **Given** a plugin is installed globally, **When** I run `wave plugin disable <plugin> -s project` in a project directory, **Then** the plugin is disabled for that project and its commands are no longer available there.
-2. **Given** a plugin is installed but not enabled, **When** I run `wave plugin enable <plugin> -s local` in the current directory, **Then** the plugin is enabled only for the current directory.
-3. **Given** multiple scopes have conflicting settings for a plugin, **When** the system loads plugins, **Then** it MUST respect the priority: `local` > `project` > `user`.
+1. **Given** a plugin is installed in a project directory, **Then** its commands are available there.
+2. **Given** multiple scopes have conflicting settings for a plugin, **When** the system loads plugins, **Then** it MUST respect the priority: `local` > `project` > `user`.
 
 ---
 
@@ -34,7 +33,7 @@ As a user, I want to install a plugin and have it automatically enabled at a spe
 **Acceptance Scenarios**:
 
 1. **Given** a registered marketplace, **When** I run `wave plugin install <plugin>@<marketplace> -s user`, **Then** the plugin is installed and enabled in the user-level `settings.json`.
-2. **Given** a registered marketplace, **When** I run `wave plugin install <plugin>@<marketplace>` (without scope), **Then** it defaults to the `user` scope.
+2. **Given** a registered marketplace, **When** I run `wave plugin install <plugin>@<marketplace>` (without scope), **Then** it defaults to the `project` scope.
 
 ---
 
@@ -55,19 +54,16 @@ As a user, I want to install a plugin and have it automatically enabled at a spe
 
 ### Functional Requirements
 
-- **FR-001**: System MUST support `wave plugin enable <plugin-id>` command.
-- **FR-002**: System MUST support `wave plugin disable <plugin-id>` command.
-- **FR-003**: `enable`, `disable`, and `install` commands MUST support `-s, --scope <scope>` option.
-- **FR-004**: Supported scopes MUST be `user`, `project`, and `local`.
-- **FR-005**: Default scope for all commands MUST be `user`.
-- **FR-006**: `user` scope MUST refer to `~/.wave/settings.json`.
-- **FR-007**: `project` scope MUST refer to `.wave/settings.json` in the current project directory.
-- **FR-008**: `local` scope MUST refer to `.wave/settings.local.json` in the current project directory.
-- **FR-009**: Enabling a plugin MUST set its value to `true` in the `enabledPlugins` object of the target `settings.json`.
-- **FR-010**: Disabling a plugin MUST set its value to `false` in the `enabledPlugins` object of the target `settings.json`.
-- **FR-011**: `wave plugin install` MUST automatically add the plugin to `enabledPlugins` with a value of `true` in the specified scope.
-- **FR-012**: Plugin loading logic MUST aggregate `enabledPlugins` from all applicable scopes and apply them in priority order: `local` > `project` > `user`.
-- **FR-013**: If a plugin is marked `false` in a higher-priority scope, it MUST be disabled even if marked `true` in a lower-priority scope.
+- **FR-001**: `install` and `uninstall` commands MUST support `-s, --scope <scope>` option.
+- **FR-002**: Supported scopes MUST be `user`, `project`, and `local`.
+- **FR-003**: Default scope for all commands MUST be `project`.
+- **FR-004**: `user` scope MUST refer to `~/.wave/settings.json`.
+- **FR-005**: `project` scope MUST refer to `.wave/settings.json` in the current project directory.
+- **FR-006**: `local` scope MUST refer to `.wave/settings.local.json` in the current project directory.
+- **FR-007**: `wave plugin install` MUST automatically add the plugin to `enabledPlugins` with a value of `true` in the specified scope.
+- **FR-008**: `wave plugin uninstall` MUST remove the plugin from the `enabledPlugins` object in the specified scope.
+- **FR-009**: Plugin loading logic MUST aggregate `enabledPlugins` from all applicable scopes and apply them in priority order: `local` > `project` > `user`.
+- **FR-010**: If a plugin is marked `false` in a higher-priority scope (e.g. via manual config edit), it MUST be disabled even if marked `true` in a lower-priority scope.
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/060-plugin-management-ui/spec.md
+++ b/specs/060-plugin-management-ui/spec.md
@@ -17,10 +17,10 @@ As a user, I want to browse available plugins from marketplaces and install them
 
 **Acceptance Scenarios**:
 
-1. **Given** the user is in the "Discover" section, **When** they select a plugin, **Then** they should see details and three installation options: User, Project, and Local. They can navigate these options using Up/Down arrows and press Enter to install.
-2. **Given** a plugin is selected, **When** "Install for you (user scope)" is chosen via arrow keys and Enter, **Then** the plugin is installed globally for the current user.
-3. **Given** a plugin is selected, **When** "Install for all collaborators (project scope)" is chosen via arrow keys and Enter, **Then** the plugin is added to the repository configuration.
-4. **Given** a plugin is selected, **When** "Install for you, in this repo only (local scope)" is chosen via arrow keys and Enter, **Then** the plugin is installed for the user but only active in the current repository.
+1. **Given** the user is in the "Discover" section, **When** they select a plugin, **Then** they should see details and three installation options: Project (default), User, and Local. They can navigate these options using Up/Down arrows and press Enter to install.
+2. **Given** a plugin is selected, **When** "Install for all collaborators (project scope)" is chosen (default), **Then** the plugin is downloaded and automatically enabled in the repository configuration.
+3. **Given** a plugin is selected, **When** "Install for you (user scope)" is chosen, **Then** the plugin is downloaded and automatically enabled globally for the current user.
+4. **Given** a plugin is selected, **When** "Install for you, in this repo only (local scope)" is chosen, **Then** the plugin is downloaded and automatically enabled for the user but only active in the current repository.
 
 ---
 
@@ -34,9 +34,8 @@ As a user, I want to see which plugins I have installed and be able to toggle th
 
 **Acceptance Scenarios**:
 
-1. **Given** the user is in the "Installed" section, **When** they select a plugin, **Then** they should see options to Enable, Disable, or Uninstall.
-2. **Given** an enabled plugin, **When** "Disable" is selected, **Then** the plugin remains installed but its functionality is deactivated.
-3. **Given** a plugin, **When** "Uninstall" is selected, **Then** the plugin is removed from the system/repository.
+1. **Given** the user is in the "Installed" section, **When** they select a plugin, **Then** they should see the option to Uninstall.
+2. **Given** a plugin, **When** "Uninstall" is selected, **Then** the plugin is removed from the current scope's configuration, but the files remain in the global cache to avoid breaking other projects.
 
 ---
 
@@ -70,7 +69,7 @@ As a user, I want to add and manage marketplace sources so that I can access plu
 - **FR-003**: System MUST support three installation scopes: User (global), Project (shared via repo), and Local (user-specific to repo).
 - **FR-004**: System MUST allow adding marketplaces via GitHub shorthand (`owner/repo`), SSH URLs, and local filesystem paths.
 - **FR-005**: System MUST persist marketplace configurations and plugin installation states.
-- **FR-006**: System MUST provide visual feedback for plugin status (Enabled/Disabled/Installing).
+- **FR-006**: System MUST provide visual feedback for plugin status (Installing/Installed).
 - **FR-007**: System MUST allow updating marketplace metadata to discover new or updated plugins.
 - **FR-008**: System MUST allow users to remove a marketplace from their configuration.
 
@@ -84,4 +83,4 @@ As a user, I want to add and manage marketplace sources so that I can access plu
 
 - **A-001**: The underlying plugin installation logic (downloading, file placement) is handled by existing SDK services; this feature focuses on the UI and orchestration.
 - **A-002**: "Project scope" installation involves modifying a file that is typically committed to version control (e.g., `.wave/config.json`).
-- **A-003**: The "Discover" list aggregates plugins from all configured marketplaces.
+- **A-003**: The "Discover" list aggregates plugins from all configured marketplaces that are NOT currently installed.


### PR DESCRIPTION
This PR simplifies the plugin management flow to be more npm-like:
- Removes redundant enable/disable commands and UI toggles.
- Defaults installation to project scope.
- Automatically enables plugins upon installation.
- Filters out installed plugins from the Discover list.
- Updates specifications (045 and 060) to reflect these changes.