### PR TITLE
fix: add comma and space before file count in FileSelector

### DIFF
--- a/packages/code/src/components/FileSelector.tsx
+++ b/packages/code/src/components/FileSelector.tsx
@@ -131,7 +131,7 @@ export const FileSelector: React.FC<FileSelectorProps> = ({
           Use ↑↓ to navigate, Enter/Tab to select, Escape to cancel
         </Text>
         <Text dimColor>
-          File {selectedIndex + 1} of {files.length}
+          , File {selectedIndex + 1} of {files.length}
         </Text>
       </Box>
     </Box>

--- a/packages/code/tests/components/FileSelector.test.tsx
+++ b/packages/code/tests/components/FileSelector.test.tsx
@@ -23,7 +23,7 @@ describe("FileSelector", () => {
     expect(output).toContain("Select File/Directory");
     expect(output).toContain("file1.txt");
     expect(output).toContain("file10.txt");
-    expect(output).toContain("File 1 of 20");
+    expect(output).toContain(", File 1 of 20");
     expect(output).toContain("... 10 more files below");
   });
 
@@ -41,7 +41,7 @@ describe("FileSelector", () => {
 
     const output = lastFrame();
     expect(output).toContain("Select File/Directory");
-    expect(output).toContain("File 1 of 25");
+    expect(output).toContain(", File 1 of 25");
     expect(output).toContain("... 15 more files below");
   });
 


### PR DESCRIPTION
Adds a comma and space before the 'File X of Y' text in the FileSelector component to improve readability, as requested.