### PR TITLE
feat: support glob patterns in Bash permissions

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -277,7 +277,7 @@ export class AIManager {
     options: {
       recursionDepth?: number;
       model?: string;
-      /** Rules for automatic tool approval (e.g., "Bash(git status:*)") */
+      /** Rules for automatic tool approval (e.g., "Bash(git status*)") */
       allowedRules?: string[];
       /** List of tools available to the AI (e.g., ["Bash", "Read"]) */
       tools?: string[];

--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -558,7 +558,7 @@ export class PermissionManager {
       return true;
     }
 
-    // 2. Tool with pattern match (e.g., "Bash(rm:*)", "Read(**/*.env)")
+    // 2. Tool with pattern match (e.g., "Bash(rm *)", "Read(**/*.env)")
     const match = rule.match(/^(\w+)\((.*)\)$/);
     if (!match) {
       return false;

--- a/packages/agent-sdk/tests/managers/permissionManager.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.test.ts
@@ -113,7 +113,7 @@ describe("PermissionManager", () => {
       });
 
       it("should allow tool if it does not match any denied rule", async () => {
-        permissionManager.updateDeniedRules(["Bash(rm:*)"]);
+        permissionManager.updateDeniedRules(["Bash(rm *)"]);
 
         const context: ToolPermissionContext = {
           toolName: "Bash",

--- a/packages/code/src/components/Confirmation.tsx
+++ b/packages/code/src/components/Confirmation.tsx
@@ -229,7 +229,7 @@ export const Confirmation: React.FC<ConfirmationProps> = ({
       } else if (state.selectedOption === "auto") {
         if (toolName === BASH_TOOL_NAME) {
           const rule = suggestedPrefix
-            ? `Bash(${suggestedPrefix}:*)`
+            ? `Bash(${suggestedPrefix}*)`
             : `Bash(${toolInput?.command})`;
           onDecision({
             behavior: "allow",

--- a/specs/008-slash-commands-spec/data-model.md
+++ b/specs/008-slash-commands-spec/data-model.md
@@ -66,7 +66,7 @@
 **Fields**:
 - `model?: string` - Preferred AI model for command processing
 - `description?: string` - Custom description overriding auto-generated text
-- `allowedTools?: string[]` - List of tool permission rules (e.g., `Bash(git status:*)`)
+- `allowedTools?: string[]` - List of tool permission rules (e.g., `Bash(git status *)`)
 
 **Validation Rules**:
 - `model` must be supported by AI provider

--- a/specs/008-slash-commands-spec/quickstart.md
+++ b/specs/008-slash-commands-spec/quickstart.md
@@ -105,7 +105,7 @@ Allow specific tools to run without asking permission:
 description: Auto-check git status
 allowed-tools:
   - Bash(git status)
-  - Bash(git diff:*)
+  - Bash(git diff *)
 ---
 
 Check git status and show what changed.

--- a/specs/008-slash-commands-spec/spec.md
+++ b/specs/008-slash-commands-spec/spec.md
@@ -97,8 +97,8 @@ As a user, I want the AI to execute specific tools automatically when I trigger 
 
 **Acceptance Scenarios**:
 
-1. **Given** a slash command defined with `allowed-tools: Bash(git commit:*)`, **When** the user triggers this command and the AI calls `Bash(git commit -m "test")`, **Then** the tool should execute immediately without a confirmation prompt because it matches the prefix.
-2. **Given** a slash command defined with `allowed-tools: Bash(git commit:*)`, **When** the user triggers this command and the AI calls `Bash(git commit -m "test" && rm -rf /)`, **Then** the tool MUST be blocked or require confirmation because the second part of the command chain is not allowed.
+1. **Given** a slash command defined with `allowed-tools: Bash(git commit *)`, **When** the user triggers this command and the AI calls `Bash(git commit -m "test")`, **Then** the tool should execute immediately without a confirmation prompt because it matches the pattern.
+2. **Given** a slash command defined with `allowed-tools: Bash(git commit *)`, **When** the user triggers this command and the AI calls `Bash(git commit -m "test" && rm -rf /)`, **Then** the tool MUST be blocked or require confirmation because the second part of the command chain is not allowed.
 3. **Given** a slash command with `allowed-tools`, **When** the AI calls a tool NOT in the list (e.g., `Write`), **Then** the system MUST prompt the user for confirmation as usual (unless it's already allowed in `settings.json`).
 4. **Given** an active slash command session with `allowed-tools`, **When** the AI finishes its task and the response cycle ends, **Then** all subsequent tool executions MUST require manual confirmation.
 
@@ -155,7 +155,7 @@ As a user, I want the AI to execute specific tools automatically when I trigger 
 - **CustomSlashCommandConfig**: Configuration options including AI model preference and custom description
 - **SlashCommandManager**: Central orchestrator for command registration, discovery, execution, and lifecycle management
 - **CommandSelector**: User interface component for command discovery and selection with search functionality
-- **Allowed Tool Pattern**: A string representing a permitted tool and its allowed argument patterns (e.g., `Bash(git status:*)`).
+- **Allowed Tool Pattern**: A string representing a permitted tool and its allowed argument patterns (e.g., `Bash(git status *)`).
 - **Privileged Session**: The stateful context that tracks whether auto-approval is currently active and which tools are allowed.
 - **Command Path**: The hierarchical path from `.wave/commands/` to the markdown file, converted to colon-separated syntax for command invocation (e.g., `openspec:apply`).
 

--- a/specs/034-permission-prefix-matching/quickstart.md
+++ b/specs/034-permission-prefix-matching/quickstart.md
@@ -22,7 +22,7 @@ To allow any command starting with a prefix, use `:*` at the end:
 ```json
 "permissions": {
   "allow": [
-    "Bash(git commit:*)"
+    "Bash(git commit *)"
   ]
 }
 ```

--- a/specs/034-permission-prefix-matching/research.md
+++ b/specs/034-permission-prefix-matching/research.md
@@ -29,7 +29,7 @@ For each rule in `allowedRules` or `temporaryRules`:
    - Perform an exact match or prefix match against the rule.
 
 ### Example
-Rule: `Bash(git commit:*)`
+Rule: `Bash(git commit *)`
 Action: `Bash(git commit -m "feat: add prefix matching")`
 1. Rule ends with `:*`.
 2. Prefix is `Bash(git commit`.

--- a/specs/034-permission-prefix-matching/tasks.md
+++ b/specs/034-permission-prefix-matching/tasks.md
@@ -34,7 +34,7 @@
 
 **Goal**: Allow a group of related commands by specifying a common prefix using `:*` suffix.
 
-**Independent Test**: Add `Bash(git commit:*)` to `permissions.allow` and verify `Bash(git commit -m "msg")` is allowed while `Bash(git push)` is denied.
+**Independent Test**: Add `Bash(git commit *)` to `permissions.allow` and verify `Bash(git commit -m "msg")` is allowed while `Bash(git push)` is denied.
 
 ### Implementation for User Story 1
 

--- a/specs/037-bash-glob-match/contracts/internal-api.md
+++ b/specs/037-bash-glob-match/contracts/internal-api.md
@@ -15,7 +15,7 @@ Extracts a smart prefix from a bash command.
 *Updated* to support prefix rules.
 
 **Returns:**
-- Array of rules, potentially including `Bash(prefix:*)`.
+- Array of rules, potentially including `Bash(pattern*)`.
 
 ## Confirmation Component (code)
 

--- a/specs/037-bash-glob-match/data-model.md
+++ b/specs/037-bash-glob-match/data-model.md
@@ -8,10 +8,10 @@ Represents a command or prefix that the user has authorized for automatic execut
 **Attributes:**
 - `pattern`: The string pattern to match.
   - Format for exact match: `Bash(command)`
-  - Format for prefix match: `Bash(prefix:*)`
+  - Format for glob match: `Bash(pattern*)`
 - `type`: Derived from the pattern.
-  - `EXACT`: If pattern does not end with `:*)`.
-  - `PREFIX`: If pattern ends with `:*)`.
+  - `EXACT`: If pattern does not include `*`.
+  - `GLOB`: If pattern includes `*`.
 
 **Validation Rules:**
 - Must start with `Bash(`.
@@ -27,8 +27,8 @@ Stored in `settings.local.json` under `permissions.allow`.
   "permissions": {
     "allow": [
       "Bash(ls)",
-      "Bash(npm install:*)",
-      "Bash(git commit:*)"
+      "Bash(npm install*)",
+      "Bash(git commit*)"
     ]
   }
 }

--- a/specs/037-bash-glob-match/quickstart.md
+++ b/specs/037-bash-glob-match/quickstart.md
@@ -20,7 +20,7 @@ The next time Wave wants to run a similar command (e.g., `npm install express`):
 To view or remove trusted prefixes:
 1. Open `.wave/settings.local.json` in your project directory.
 2. Look for the `permissions.allow` array.
-3. You can manually remove entries like `Bash(npm install:*)`.
+3. You can manually remove entries like `Bash(npm install*)`.
 
 ## Security Note
 - Commands like `rm`, `sudo`, and `mv` are blacklisted from prefix matching to prevent accidental data loss or security breaches.

--- a/specs/037-bash-glob-match/research.md
+++ b/specs/037-bash-glob-match/research.md
@@ -25,11 +25,11 @@ A heuristic-based approach is preferred over a full bash parser because it's sim
 ## Decision: Storage Format in `settings.local.json`
 
 ### Rationale
-The existing `PermissionManager` already supports a prefix matching syntax: `Bash(prefix:*)`. Leveraging this minimizes changes to the core permission checking logic.
+The existing `PermissionManager` already supports a glob matching syntax: `Bash(pattern*)`. Leveraging this minimizes changes to the core permission checking logic.
 
 ### Format
 - Exact match: `Bash(npm install lodash)`
-- Prefix match: `Bash(npm install:*)`
+- Glob match: `Bash(npm install*)`
 
 ## Decision: UI Integration in `Confirmation.tsx`
 

--- a/specs/037-bash-glob-match/tasks.md
+++ b/specs/037-bash-glob-match/tasks.md
@@ -21,7 +21,7 @@
 **Independent Test**: Run `npm install lodash`, select "Yes, and don't ask again", then run `npm install express` and verify it executes without prompt.
 
 - [x] T006 [US1] Update `Agent` class in `packages/agent-sdk/src/agent.ts` to handle prefix-based permission rules
-- [x] T007 [US1] Verify `PermissionManager.isAllowedByRule` correctly handles `Bash(prefix:*)` patterns
+- [x] T007 [US1] Verify `PermissionManager.isAllowedByRule` correctly handles `Bash(pattern*)` patterns
 - [x] T008 [US1] Add integration test for prefix matching in `packages/agent-sdk/tests/agent.prefix.test.ts`
 
 ## Phase 4: User Story 2 - Reviewing the Smart Prefix (Priority: P2)

--- a/specs/049-deny-permissions-support/data-model.md
+++ b/specs/049-deny-permissions-support/data-model.md
@@ -31,7 +31,7 @@ export interface PermissionManagerOptions {
 ## Rule Formats
 
 1. **Tool Name**: `Bash`, `Write`, `Read`
-2. **Bash Command**: `Bash(ls -la)`, `Bash(rm:*)`
+2. **Bash Command**: `Bash(ls -la)`, `Bash(rm *)`
 3. **Path-based**: `Read(**/*.env)`, `Write(/etc/**)`, `Delete(/tmp/test.txt)`
    - Format: `ToolName(glob_pattern)`
    - Supported tools: `Read`, `Write`, `Edit`, `MultiEdit`, `Delete`, `LS`

--- a/specs/049-deny-permissions-support/quickstart.md
+++ b/specs/049-deny-permissions-support/quickstart.md
@@ -19,7 +19,7 @@ To prevent the agent from using `rm`:
 ```json
 {
   "permissions": {
-    "deny": ["Bash(rm:*)"]
+    "deny": ["Bash(rm *)"]
   }
 }
 ```
@@ -49,7 +49,7 @@ If you have both allow and deny rules, the deny rule wins:
 {
   "permissions": {
     "allow": ["Bash"],
-    "deny": ["Bash(rm:*)"]
+    "deny": ["Bash(rm *)"]
   }
 }
 ```

--- a/specs/049-deny-permissions-support/research.md
+++ b/specs/049-deny-permissions-support/research.md
@@ -8,7 +8,7 @@ To ensure maximum security, `permissions.deny` must be checked before any other 
 ### Implementation Details
 1. **Rule Matching**:
    - Tool-only rules: `Bash`, `Write`, `Read`, etc.
-   - Command-specific rules: `Bash(rm:*)`.
+   - Command-specific rules: `Bash(rm *)`.
    - Path-based rules: `Read(**/*.env)`, `Write(/etc/**)`, `Delete(/tmp/test.txt)`.
    - The matching logic for `ToolName(path_pattern)` will use the `minimatch` library (which is already a dependency of `agent-sdk`) to match the `path_pattern` against the `file_path` or `target_file` in the tool input.
    - **Rationale for `minimatch` over `glob`**: While `glob` is used for searching the filesystem, `minimatch` is the underlying library used by `glob` for string-to-pattern matching. Since permission checks must work for non-existent files (e.g., `Write` or `Delete` operations) and should not hit the disk for performance reasons, `minimatch` is the appropriate tool for this task.

--- a/specs/049-deny-permissions-support/spec.md
+++ b/specs/049-deny-permissions-support/spec.md
@@ -19,7 +19,7 @@ As a security-conscious user, I want to explicitly forbid the agent from using c
 
 1. **Given** `permissions.deny` contains `["Bash"]`, **When** the agent attempts to run a bash command, **Then** the system MUST block the execution and inform the user/agent that the tool is explicitly denied.
 2. **Given** `permissions.deny` is empty or does not contain `Bash`, **When** the agent attempts to run a bash command (and it's allowed by other rules), **Then** the system SHOULD allow the execution.
-3. **Given** `permissions.deny` contains `["Bash(rm:*)"]`, **When** the agent attempts to run `rm -rf /`, **Then** the system MUST block the execution.
+3. **Given** `permissions.deny` contains `["Bash(rm *)"]`, **When** the agent attempts to run `rm -rf /`, **Then** the system MUST block the execution.
 
 ---
 
@@ -36,7 +36,7 @@ As a user with sensitive data, I want to prevent the agent from accessing specif
 1. **Given** `permissions.deny` contains `["Read(**/.env)"]`, **When** the agent attempts to read a file named `.env` in any directory using the `Read` tool, **Then** the system MUST deny the request.
 2. **Given** `permissions.deny` contains `["Write(/etc/**)"]`, **When** the agent attempts to write to a file in `/etc/` using the `Write` tool, **Then** the system MUST deny the request.
 3. **Given** `permissions.deny` contains `["Delete(/etc/**)"]`, **When** the agent attempts to delete a file in `/etc/`, **Then** the system MUST deny the request.
-4. **Given** `permissions.deny` contains `["Bash(ls /etc:*)"]`, **When** the agent attempts to run `ls /etc/passwd`, **Then** the system MUST deny the request.
+4. **Given** `permissions.deny` contains `["Bash(ls /etc*)"]`, **When** the agent attempts to run `ls /etc/passwd`, **Then** the system MUST deny the request.
 
 ---
 
@@ -65,7 +65,7 @@ As a user, I want to be certain that if I explicitly deny a permission, it canno
 ### Functional Requirements
 
 - **FR-001**: System MUST support a `permissions.deny` field in `settings.json`.
-- **FR-002**: `permissions.deny` MUST support the same rule types and formats as `permissions.allow` (e.g., tool names, `Bash(cmd)`, `Bash(prefix:*)`).
+- **FR-002**: `permissions.deny` MUST support the same rule types and formats as `permissions.allow` (e.g., tool names, `Bash(cmd)`, `Bash(pattern*)`).
 - **FR-003**: System MUST support path-based permission rules in the format `ToolName(path_pattern)` for both `allow` and `deny` lists. This MUST apply to tools that take a single file or directory path as a primary input (e.g., `Read`, `Write`, `Edit`, `MultiEdit`, `Delete`, `LS`). Tools like `Glob` and `Grep` are excluded from this path-based rule format as their path parameter is optional and they often operate on patterns.
 - **FR-004**: If a permission request matches any rule in `permissions.deny`, the system MUST deny the request immediately, even if the tool is not in the `RESTRICTED_TOOLS` list and even if it would otherwise be allowed by `permissions.allow` or auto-accept logic.
 - **FR-005**: `permissions.deny` MUST take precedence over `permissions.allow`. If a request matches both an allow rule and a deny rule, it MUST be denied.

--- a/specs/049-deny-permissions-support/tasks.md
+++ b/specs/049-deny-permissions-support/tasks.md
@@ -70,14 +70,14 @@ description: "Task list for implementing permissions.deny support"
 ### Tests for User Story 2
 
 - [X] T012 [P] [US2] Add unit tests for path-based denial (e.g., `Read(**/*.env)`) in `packages/agent-sdk/tests/managers/permissionManager.test.ts`
-- [X] T013 [P] [US2] Add unit tests for bash command prefix denial (e.g., `Bash(rm:*)`) in `packages/agent-sdk/tests/managers/permissionManager.test.ts`
+- [X] T013 [P] [US2] Add unit tests for bash command glob denial (e.g., `Bash(rm *)`) in `packages/agent-sdk/tests/managers/permissionManager.test.ts`
 
 ### Implementation for User Story 2
 
 - [X] T014 [US2] Update `matchesRule` to handle `ToolName(pattern)` format and extract paths from `toolInput` in `packages/agent-sdk/src/managers/permissionManager.ts`
 - [X] T015 [US2] Update `Read` tool to call `checkPermission` in `packages/agent-sdk/src/tools/readTool.ts`
 - [X] T016 [US2] Update `LS` tool to call `checkPermission` in `packages/agent-sdk/src/tools/lsTool.ts`
-- [X] T017 [US2] Ensure `matchesRule` correctly handles `Bash(prefix:*)` rules in `packages/agent-sdk/src/managers/permissionManager.ts`
+- [X] T017 [US2] Ensure `matchesRule` correctly handles `Bash(pattern*)` rules in `packages/agent-sdk/src/managers/permissionManager.ts`
 
 **Checkpoint**: User Story 2 is functional. Granular path and command denial is supported.
 


### PR DESCRIPTION
This PR upgrades the Bash permission system to support glob patterns using minimatch and removes the legacy :* suffix syntax. It also migrates existing rules and documentation to the new format.