### PR TITLE
Show final markdown result and hide tools in completed SubagentBlock

### DIFF
--- a/packages/code/src/components/SubagentBlock.tsx
+++ b/packages/code/src/components/SubagentBlock.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Box, Text } from "ink";
 import type { SubagentBlock as SubagentBlockType } from "wave-agent-sdk";
 import { useChat } from "../contexts/useChat.js";
+import { Markdown } from "./Markdown.js";
 
 interface SubagentBlockProps {
   block: SubagentBlockType;
@@ -59,6 +60,26 @@ export const SubagentBlock: React.FC<SubagentBlockProps> = ({ block }) => {
 
   const { tools: lastTwoTools, totalToolCount } = getLastTwoTools();
 
+  // Get the last text message content if completed
+  const getLastTextMessage = () => {
+    if (block.status !== "completed") return null;
+
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+      if (message.role === "assistant") {
+        for (let j = message.blocks.length - 1; j >= 0; j--) {
+          const messageBlock = message.blocks[j];
+          if (messageBlock.type === "text" && messageBlock.content) {
+            return messageBlock.content;
+          }
+        }
+      }
+    }
+    return null;
+  };
+
+  const lastTextMessage = getLastTextMessage();
+
   return (
     <Box
       borderRight={false}
@@ -86,8 +107,15 @@ export const SubagentBlock: React.FC<SubagentBlockProps> = ({ block }) => {
         </Box>
       </Box>
 
+      {/* Last Text Message Section */}
+      {lastTextMessage && (
+        <Box marginTop={1}>
+          <Markdown>{lastTextMessage}</Markdown>
+        </Box>
+      )}
+
       {/* Tool Names Section - Vertical List */}
-      {lastTwoTools.length > 0 && (
+      {block.status !== "completed" && lastTwoTools.length > 0 && (
         <Box flexDirection="column" marginTop={1} gap={1}>
           {totalToolCount > 2 && (
             <Text color="gray" dimColor>

--- a/packages/code/tests/components/SubagentBlock.test.tsx
+++ b/packages/code/tests/components/SubagentBlock.test.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { render } from "ink-testing-library";
+import { describe, it, expect, vi } from "vitest";
+import { SubagentBlock } from "../../src/components/SubagentBlock.js";
+import type { SubagentBlock as SubagentBlockType } from "wave-agent-sdk";
+
+// Mock useChat context
+const mockSubagentMessages = {
+  "sub-1": [
+    {
+      role: "assistant",
+      blocks: [
+        { type: "text", content: "Thinking..." },
+        { type: "tool", name: "ls", compactParams: "." },
+      ],
+    },
+    {
+      role: "assistant",
+      blocks: [{ type: "text", content: "Final result from subagent" }],
+    },
+  ],
+};
+
+vi.mock("../../src/contexts/useChat.js", () => ({
+  useChat: () => ({
+    subagentMessages: mockSubagentMessages,
+  }),
+}));
+
+describe("SubagentBlock Component", () => {
+  it("should show the last text message when completed", () => {
+    const block: SubagentBlockType = {
+      subagentId: "sub-1",
+      subagentName: "Test Subagent",
+      status: "completed",
+      type: "subagent",
+      sessionId: "session-1",
+      configuration: {
+        name: "test",
+        description: "test",
+        systemPrompt: "test",
+        filePath: "test",
+        scope: "project",
+        priority: 1,
+      },
+    };
+
+    const { lastFrame } = render(<SubagentBlock block={block} />);
+    const output = lastFrame();
+
+    expect(output).toContain("🤖 Test Subagent");
+    expect(output).toContain("✅");
+    expect(output).toContain("Final result from subagent");
+    expect(output).not.toContain("🔧 ls");
+  });
+
+  it("should NOT show the last text message when active", () => {
+    const block: SubagentBlockType = {
+      subagentId: "sub-1",
+      subagentName: "Test Subagent",
+      status: "active",
+      type: "subagent",
+      sessionId: "session-1",
+      configuration: {
+        name: "test",
+        description: "test",
+        systemPrompt: "test",
+        filePath: "test",
+        scope: "project",
+        priority: 1,
+      },
+    };
+
+    const { lastFrame } = render(<SubagentBlock block={block} />);
+    const output = lastFrame();
+
+    expect(output).toContain("🤖 Test Subagent");
+    expect(output).toContain("🔄");
+    expect(output).not.toContain("Final result from subagent");
+    expect(output).toContain("🔧 ls");
+  });
+});

--- a/specs/009-subagent-support/contracts/subagent-block-component.md
+++ b/specs/009-subagent-support/contracts/subagent-block-component.md
@@ -23,7 +23,9 @@ interface SubagentBlockProps {
 
 ### Collapsed State (when `isExpanded` is false)
 - Shows header with subagent name and status
-- Displays **up to 2 most recent** subagent messages
+- Displays **up to 2 most recent** subagent tool executions when active
+- Displays the **final text result** rendered with markdown when completed
+- Tool executions are **hidden** when completed
 - Messages shown in compact format (similar to ToolResultDisplay shortResult)
 - Border color: `magenta` to differentiate from regular messages
 

--- a/specs/009-subagent-support/spec.md
+++ b/specs/009-subagent-support/spec.md
@@ -98,10 +98,11 @@ As a user, I want subagent conversations to be displayed as expandable blocks wi
 **Acceptance Scenarios**:
 
 1. **Given** a subagent is triggered, **When** it processes a task, **Then** an expandable message block appears in the vertical message list with distinctive border and subagent name/icon header
-2. **Given** a subagent block is collapsed, **When** I view the message list, **Then** I see up to 2 most recent subagent messages in the preview
-3. **Given** a subagent has only 1 message, **When** the block is collapsed, **Then** I see that single message in the preview
-4. **Given** a subagent block is expanded, **When** I view it, **Then** I see all subagent messages in the conversation
-5. **Given** a subagent block is in the message list, **When** I compare it to regular messages, **Then** it is clearly distinguishable through visual indicators
+2. **Given** a subagent block is collapsed, **When** I view the message list, **Then** I see up to 2 most recent subagent tools being executed
+3. **Given** a subagent has only 1 tool execution, **When** the block is collapsed, **Then** I see that single tool in the preview
+4. **Given** a subagent task is completed, **When** the block is collapsed, **Then** I see the final text result rendered with markdown, and tool executions are hidden
+5. **Given** a subagent block is expanded, **When** I view it, **Then** I see all subagent messages in the conversation
+6. **Given** a subagent block is in the message list, **When** I compare it to regular messages, **Then** it is clearly distinguishable through visual indicators
 
 ---
 
@@ -131,7 +132,8 @@ As a user, I want subagent conversations to be displayed as expandable blocks wi
 - **FR-009**: System MUST support configurable models per subagent, with fallback to system default if not specified
 - **FR-010**: System MUST provide clear feedback about which subagent is handling a task
 - **FR-016**: System MUST display subagent messages as expandable blocks within the vertical message list
-- **FR-017**: System MUST show up to 2 most recent subagent messages when the subagent block is collapsed
+- **FR-017**: System MUST show up to 2 most recent subagent tool executions when the subagent block is collapsed and active
+- **FR-022**: System MUST show the final text result rendered with markdown when the subagent block is completed, and hide tool executions
 - **FR-018**: System MUST show all subagent messages when the subagent block is expanded
 - **FR-020**: System MUST display subagent message blocks with distinctive borders and subagent name/icon headers to differentiate from regular messages
 - **FR-011**: System MUST handle subagent task completion and return results to the main conversation context


### PR DESCRIPTION
This PR updates the SubagentBlock component to display the final text result using Markdown when a subagent task is completed, while hiding the tool execution history for a cleaner view. It also updates the related specifications and adds a unit test.