### PR TITLE
Simplify diff display and remove truncation

### DIFF
--- a/packages/code/src/components/Confirmation.tsx
+++ b/packages/code/src/components/Confirmation.tsx
@@ -399,11 +399,7 @@ export const Confirmation: React.FC<ConfirmationProps> = ({
       </Text>
       <Text color="yellow">{getActionDescription(toolName, toolInput)}</Text>
 
-      <DiffDisplay
-        toolName={toolName}
-        parameters={JSON.stringify(toolInput)}
-        isExpanded={isExpanded}
-      />
+      <DiffDisplay toolName={toolName} parameters={JSON.stringify(toolInput)} />
 
       {toolName === ASK_USER_QUESTION_TOOL_NAME &&
         currentQuestion &&

--- a/packages/code/src/components/DiffDisplay.tsx
+++ b/packages/code/src/components/DiffDisplay.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { Box, Text, useStdout } from "ink";
+import { Box, Text } from "ink";
 import {
   WRITE_TOOL_NAME,
   EDIT_TOOL_NAME,
@@ -11,19 +11,12 @@ import { diffLines, diffWords } from "diff";
 interface DiffDisplayProps {
   toolName?: string;
   parameters?: string;
-  isExpanded?: boolean;
 }
 
 export const DiffDisplay: React.FC<DiffDisplayProps> = ({
   toolName,
   parameters,
-  isExpanded = false,
 }) => {
-  const { stdout } = useStdout();
-  const maxHeight = useMemo(() => {
-    return Math.max(5, (stdout?.rows || 24) - 20);
-  }, [stdout?.rows]);
-
   const showDiff =
     toolName &&
     [WRITE_TOOL_NAME, EDIT_TOOL_NAME, MULTI_EDIT_TOOL_NAME].includes(toolName);
@@ -230,21 +223,7 @@ export const DiffDisplay: React.FC<DiffDisplayProps> = ({
         }
       });
 
-      const isTruncated = !isExpanded && allElements.length > maxHeight;
-      const displayElements = isTruncated
-        ? allElements.slice(0, maxHeight - 1)
-        : allElements;
-
-      return (
-        <Box flexDirection="column">
-          {displayElements}
-          {isTruncated && (
-            <Text color="yellow" dimColor>
-              ... (truncated {allElements.length - (maxHeight - 1)} more lines)
-            </Text>
-          )}
-        </Box>
-      );
+      return <Box flexDirection="column">{allElements}</Box>;
     } catch (error) {
       console.warn("Error rendering expanded diff:", error);
       return (

--- a/packages/code/tests/components/DiffDisplay.test.tsx
+++ b/packages/code/tests/components/DiffDisplay.test.tsx
@@ -76,7 +76,7 @@ describe("DiffDisplay", () => {
     // we just verify the basic structure is correct.
   });
 
-  it("should truncate long diffs when not expanded", () => {
+  it("should not truncate long diffs", () => {
     const longContent = Array.from(
       { length: 30 },
       (_, i) => `line ${i + 1}`,
@@ -86,30 +86,7 @@ describe("DiffDisplay", () => {
       file_path: "test.txt",
     });
     const { lastFrame } = render(
-      <DiffDisplay
-        toolName={WRITE_TOOL_NAME}
-        parameters={params}
-        isExpanded={false}
-      />,
-    );
-    expect(lastFrame()).toContain("truncated");
-  });
-
-  it("should not truncate when expanded", () => {
-    const longContent = Array.from(
-      { length: 30 },
-      (_, i) => `line ${i + 1}`,
-    ).join("\n");
-    const params = JSON.stringify({
-      content: longContent,
-      file_path: "test.txt",
-    });
-    const { lastFrame } = render(
-      <DiffDisplay
-        toolName={WRITE_TOOL_NAME}
-        parameters={params}
-        isExpanded={true}
-      />,
+      <DiffDisplay toolName={WRITE_TOOL_NAME} parameters={params} />,
     );
     expect(lastFrame()).not.toContain("truncated");
     expect(lastFrame()).toContain("+line 30");


### PR DESCRIPTION
This PR simplifies the diff display by disabling word-level highlighting for multi-line changes and removing the max height/truncation logic to always show the full diff.