### PR TITLE
chore: remove duplicated debug logs in PermissionManager

### DIFF
--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -237,13 +237,7 @@ export class PermissionManager {
    * Get the current effective permission mode for tool execution context
    */
   getCurrentEffectiveMode(cliPermissionMode?: PermissionMode): PermissionMode {
-    const mode = this.resolveEffectivePermissionMode(cliPermissionMode);
-    this.logger?.debug("getCurrentEffectiveMode", {
-      cliPermissionMode,
-      configuredDefaultMode: this.configuredDefaultMode,
-      resolvedMode: mode,
-    });
-    return mode;
+    return this.resolveEffectivePermissionMode(cliPermissionMode);
   }
 
   /**


### PR DESCRIPTION
Simplified getCurrentEffectiveMode to remove redundant debug logging that was causing duplication in logs.