### PR TITLE
chore: update plan markdown max height calculation

### DIFF
--- a/packages/code/src/components/PlanDisplay.tsx
+++ b/packages/code/src/components/PlanDisplay.tsx
@@ -14,7 +14,7 @@ export const PlanDisplay: React.FC<PlanDisplayProps> = ({
   const { stdout } = useStdout();
   const maxHeight = useMemo(() => {
     // Similar to DiffDisplay.tsx maxHeight calculation
-    return Math.max(5, (stdout?.rows || 24) - 20);
+    return Math.max(5, (stdout?.rows || 24) - 25);
   }, [stdout?.rows]);
 
   const lines = useMemo(() => plan.split("\n"), [plan]);


### PR DESCRIPTION
Updated the maxHeight calculation in PlanDisplay.tsx from -20 to -25 to provide more space in the terminal UI.