### PR TITLE
fix: prevent crash on unknown markdown code block languages

### DIFF
--- a/packages/code/src/components/Markdown.tsx
+++ b/packages/code/src/components/Markdown.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { Box, Text, useStdout } from "ink";
 import { marked, type Token, type Tokens } from "marked";
-import { highlight } from "cli-highlight";
+import { highlight, supportsLanguage } from "cli-highlight";
 
 export interface MarkdownProps {
   children: string;
@@ -225,7 +225,8 @@ const BlockRenderer = ({ tokens }: { tokens: Token[] }) => {
               const content = lines.slice(1, -1).join("\n");
               const highlighted = content
                 ? highlight(unescapeHtml(content), {
-                    language: t.lang,
+                    language:
+                      t.lang && supportsLanguage(t.lang) ? t.lang : undefined,
                     ignoreIllegals: true,
                   })
                 : "";

--- a/packages/code/tests/components/Markdown.test.tsx
+++ b/packages/code/tests/components/Markdown.test.tsx
@@ -340,6 +340,14 @@ describe("Markdown Component - Additional Branch Coverage", () => {
     expect(output).toContain("no language code");
   });
 
+  it("should not crash when an unknown language is specified", () => {
+    const markdown = "```unknownlang\nconst x = 1;\n```";
+    const { lastFrame } = render(<Markdown>{markdown}</Markdown>);
+    const output = lastFrame();
+    expect(output).toContain("const x = 1;");
+    expect(output).toContain(chalk.gray("```unknownlang"));
+  });
+
   it("should render list items with complex content", () => {
     const markdown = "- item with\n  multiple\n  lines";
     const { lastFrame } = render(<Markdown>{markdown}</Markdown>);


### PR DESCRIPTION
This PR fixes a crash in the Markdown component when encountering an unknown language in a code block (e.g., 'regex'). It now uses `supportsLanguage` from `cli-highlight` to verify language support before highlighting, falling back to auto-detection if the language is unsupported.