### PR TITLE
fix: improve PlanDisplay markdown rendering when collapsed

### DIFF
--- a/packages/code/examples/render-plan.ts
+++ b/packages/code/examples/render-plan.ts
@@ -1,0 +1,33 @@
+import React from "react";
+import { render } from "ink";
+import { PlanDisplay } from "../src/components/PlanDisplay.js";
+import fs from "fs";
+import path from "path";
+
+function run() {
+  const filePath = process.argv[2];
+  if (!filePath) {
+    console.error(
+      "Usage: pnpm exec tsx examples/render-plan.ts <path-to-md-file>",
+    );
+    process.exit(1);
+  }
+
+  const absolutePath = path.resolve(process.cwd(), filePath);
+  if (!fs.existsSync(absolutePath)) {
+    console.error(`File not found: ${absolutePath}`);
+    process.exit(1);
+  }
+
+  const content = fs.readFileSync(absolutePath, "utf-8");
+
+  const element = React.createElement(PlanDisplay, { plan: content });
+  const { unmount } = render(element);
+
+  setTimeout(() => {
+    unmount();
+    process.exit(0);
+  }, 100);
+}
+
+run();

--- a/packages/code/src/components/PlanDisplay.tsx
+++ b/packages/code/src/components/PlanDisplay.tsx
@@ -20,6 +20,24 @@ export const PlanDisplay: React.FC<PlanDisplayProps> = ({
   const lines = useMemo(() => plan.split("\n"), [plan]);
   const isOverflowing = !isExpanded && lines.length > maxHeight;
 
+  const displayedPlan = useMemo(() => {
+    if (isOverflowing) {
+      const slicedLines = lines.slice(0, maxHeight);
+      // If we sliced in the middle of a code block, we should close it
+      let inCodeBlock = false;
+      for (const line of slicedLines) {
+        if (line.trim().startsWith("```")) {
+          inCodeBlock = !inCodeBlock;
+        }
+      }
+      if (inCodeBlock) {
+        slicedLines.push("```");
+      }
+      return slicedLines.join("\n");
+    }
+    return plan;
+  }, [plan, isOverflowing, maxHeight, lines]);
+
   return (
     <Box flexDirection="column" marginTop={1}>
       <Box
@@ -27,7 +45,7 @@ export const PlanDisplay: React.FC<PlanDisplayProps> = ({
         height={isOverflowing ? maxHeight : undefined}
         overflow="hidden"
       >
-        <Markdown>{plan}</Markdown>
+        <Markdown>{displayedPlan}</Markdown>
       </Box>
       {isOverflowing && (
         <Box marginTop={1}>


### PR DESCRIPTION
This PR improves the PlanDisplay component by pre-slicing the markdown content and ensuring code blocks are closed when the display is collapsed. This prevents rendering artifacts and garbled output in the terminal caused by Ink's overflow handling.