### PR TITLE
chore: update wave scripts to use tsconfig.dev.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "packages/*"
   ],
   "scripts": {
-    "wave": "tsx packages/code/src/index.ts",
-    "wave:debug": "LOG_LEVEL=DEBUG tsx packages/code/src/index.ts",
+    "wave": "tsx --tsconfig packages/code/tsconfig.dev.json packages/code/src/index.ts",
+    "wave:debug": "LOG_LEVEL=DEBUG tsx --tsconfig packages/code/tsconfig.dev.json packages/code/src/index.ts",
     "watch": "pnpm -r --parallel watch",
     "build": "pnpm -r build",
     "type-check": "pnpm -r type-check",

--- a/packages/code/package.json
+++ b/packages/code/package.json
@@ -29,7 +29,7 @@
     "README.md"
   ],
   "scripts": {
-    "wave": "tsx src/index.ts",
+    "wave": "tsx --tsconfig tsconfig.dev.json src/index.ts",
     "build": "rimraf dist && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "type-check": "tsc --noEmit --incremental",
     "watch": "tsc -p tsconfig.build.json --watch & tsc-alias -p tsconfig.build.json --watch",

--- a/packages/code/tsconfig.dev.json
+++ b/packages/code/tsconfig.dev.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "wave-agent-sdk": ["../agent-sdk/src/index.ts"],
+      "wave-agent-sdk/*": ["../agent-sdk/src/*"],
+      "@/*": ["src/*", "../agent-sdk/src/*"]
+    }
+  }
+}


### PR DESCRIPTION
This PR updates the wave and wave:debug scripts in package.json and packages/code/package.json to use the new tsconfig.dev.json for development.