### PR TITLE
fix: stop AI recursion when all tools are manually backgrounded

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -640,7 +640,7 @@ export class AIManager {
                 stage: "end",
                 name: toolName,
                 shortResult: toolResult.shortResult,
-                isManuallyBackgrounded: toolResult.isManuallyBackgrounded,
+                isManuallyBackgrounded: !!toolResult.isManuallyBackgrounded,
               });
 
               // Execute PostToolUse hooks after successful tool completion
@@ -709,7 +709,7 @@ export class AIManager {
           ) || [];
         const allBackgrounded =
           toolBlocks.length > 0 &&
-          toolBlocks.every((block) => block.isManuallyBackgrounded);
+          toolBlocks.every((block) => !!block.isManuallyBackgrounded);
 
         if (allBackgrounded) {
           this.logger?.info(

--- a/packages/agent-sdk/src/managers/messageManager.ts
+++ b/packages/agent-sdk/src/managers/messageManager.ts
@@ -402,17 +402,7 @@ export class MessageManager {
   public updateToolBlock(params: AgentToolBlockUpdateParams): void {
     const newMessages = updateToolBlockInMessage({
       messages: this.messages,
-      id: params.id,
-      parameters: params.parameters,
-      result: params.result,
-      success: params.success,
-      error: params.error,
-      stage: params.stage,
-      name: params.name,
-      shortResult: params.shortResult,
-      images: params.images,
-      compactParams: params.compactParams,
-      parametersChunk: params.parametersChunk,
+      ...params,
     });
     this.setMessages(newMessages);
     this.callbacks.onToolBlockUpdated?.(params);

--- a/packages/agent-sdk/src/utils/messageOperations.ts
+++ b/packages/agent-sdk/src/utils/messageOperations.ts
@@ -218,21 +218,10 @@ export const addAssistantMessageToMessages = (
 };
 
 // Update Tool Block of the last assistant message
-export const updateToolBlockInMessage = ({
-  messages,
-  id,
-  parameters,
-  result,
-  success,
-  error,
-  stage,
-  name,
-  shortResult,
-  images,
-  compactParams,
-  parametersChunk,
-  isManuallyBackgrounded,
-}: UpdateToolBlockParams): Message[] => {
+export const updateToolBlockInMessage = (
+  params: UpdateToolBlockParams,
+): Message[] => {
+  const { messages, id, ...updates } = params;
   const newMessages = [...messages];
   // Find the last assistant message
   for (let i = newMessages.length - 1; i >= 0; i--) {
@@ -244,37 +233,20 @@ export const updateToolBlockInMessage = ({
       if (toolBlockIndex !== -1) {
         const toolBlock = newMessages[i].blocks[toolBlockIndex];
         if (toolBlock.type === "tool") {
-          toolBlock.parameters = parameters;
-          if (result !== undefined) toolBlock.result = result;
-          if (shortResult !== undefined) toolBlock.shortResult = shortResult;
-          toolBlock.images = images; // Add image data update
-          if (success !== undefined) toolBlock.success = success;
-          if (error !== undefined) toolBlock.error = error;
-          if (stage !== undefined) toolBlock.stage = stage;
-          if (compactParams !== undefined)
-            toolBlock.compactParams = compactParams;
-          if (parametersChunk !== undefined)
-            toolBlock.parametersChunk = parametersChunk;
-          if (isManuallyBackgrounded !== undefined)
-            toolBlock.isManuallyBackgrounded = isManuallyBackgrounded;
+          // Apply all updates from params
+          Object.assign(toolBlock, updates);
         }
       } else {
         // If existing block not found, create new one
         // This handles cases where we're streaming tool parameters before execution
         newMessages[i].blocks.push({
           type: "tool",
-          parameters: parameters,
-          result: result || "",
-          shortResult: shortResult,
-          images: images, // Add image data
           id: id,
-          name: name || "unknown",
-          success: success,
-          error: error,
-          stage: stage ?? "start",
-          compactParams: compactParams,
-          parametersChunk: parametersChunk,
-          isManuallyBackgrounded: isManuallyBackgrounded,
+          name: updates.name || "unknown",
+          ...updates,
+          parameters: updates.parameters || "",
+          result: updates.result || "",
+          stage: updates.stage ?? "start",
         });
       }
       break;

--- a/packages/agent-sdk/tests/agent/agent.backgroundRecursion.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.backgroundRecursion.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Agent } from "@/agent.js";
+import * as aiService from "@/services/aiService.js";
+import { Logger } from "@/types/index.js";
+import { createMockToolManager } from "../helpers/mockFactories.js";
+
+// Mock AI Service
+vi.mock("@/services/aiService");
+
+// Mock tool registry to control tool execution
+const { instance: mockToolManagerInstance, execute: mockToolExecute } =
+  createMockToolManager();
+vi.mock("@/managers/toolManager", () => ({
+  ToolManager: vi.fn().mockImplementation(function () {
+    return mockToolManagerInstance;
+  }),
+}));
+
+describe("Agent Backgrounding Recursion Tests", () => {
+  let agent: Agent;
+
+  beforeEach(async () => {
+    // Create mock callbacks
+    const mockCallbacks = {
+      onMessagesChange: vi.fn(),
+      onLoadingChange: vi.fn(),
+    };
+
+    const mockLogger: Logger = {
+      info: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+    };
+
+    // Create Agent instance
+    agent = await Agent.create({
+      callbacks: mockCallbacks,
+      logger: mockLogger,
+    });
+
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should stop recursion when ALL tools are manually backgrounded", async () => {
+    const mockCallAgent = vi.mocked(aiService.callAgent);
+    let aiServiceCallCount = 0;
+
+    mockCallAgent.mockImplementation(async () => {
+      aiServiceCallCount++;
+      if (aiServiceCallCount === 1) {
+        return {
+          tool_calls: [
+            {
+              id: "call_bg_1",
+              type: "function" as const,
+              index: 0,
+              function: {
+                name: "bash",
+                arguments: JSON.stringify({ command: "sleep 100" }),
+              },
+            },
+            {
+              id: "call_bg_2",
+              type: "function" as const,
+              index: 1,
+              function: {
+                name: "bash",
+                arguments: JSON.stringify({ command: "sleep 200" }),
+              },
+            },
+          ],
+        };
+      }
+      return { content: "Should not be called" };
+    });
+
+    // Mock tool execution to simulate manual backgrounding for BOTH tools
+    mockToolExecute.mockImplementation(async () => {
+      return {
+        success: true,
+        content: "Command moved to background",
+        isManuallyBackgrounded: true,
+      };
+    });
+
+    // Call sendMessage
+    await agent.sendMessage("Run two long commands");
+
+    // Verify AI service was called only once
+    expect(mockCallAgent).toHaveBeenCalledTimes(1);
+    expect(aiServiceCallCount).toBe(1);
+  });
+
+  it("should NOT stop recursion when only SOME tools are manually backgrounded", async () => {
+    const mockCallAgent = vi.mocked(aiService.callAgent);
+    let aiServiceCallCount = 0;
+
+    mockCallAgent.mockImplementation(async () => {
+      aiServiceCallCount++;
+      if (aiServiceCallCount === 1) {
+        return {
+          tool_calls: [
+            {
+              id: "call_bg",
+              type: "function" as const,
+              index: 0,
+              function: {
+                name: "bash",
+                arguments: JSON.stringify({ command: "sleep 100" }),
+              },
+            },
+            {
+              id: "call_normal",
+              type: "function" as const,
+              index: 1,
+              function: {
+                name: "ls",
+                arguments: JSON.stringify({ path: "." }),
+              },
+            },
+          ],
+        };
+      }
+      return { content: "Final response" };
+    });
+
+    // Mock tool execution: one backgrounded, one normal
+    mockToolExecute.mockImplementation(async (name) => {
+      if (name === "bash") {
+        return {
+          success: true,
+          content: "Command moved to background",
+          isManuallyBackgrounded: true,
+        };
+      }
+      return {
+        success: true,
+        content: "file1.txt",
+        isManuallyBackgrounded: false,
+      };
+    });
+
+    // Call sendMessage
+    await agent.sendMessage("Run one long and one short command");
+
+    // Verify AI service was called twice (recursion continued)
+    expect(mockCallAgent).toHaveBeenCalledTimes(2);
+    expect(aiServiceCallCount).toBe(2);
+  });
+});


### PR DESCRIPTION
This PR fixes a bug where the AI agent would continue to recurse even after the user backgrounded all active tasks using Ctrl+B. It also refactors the tool block update logic to be more maintainable by automatically handling new fields.