### PR TITLE
feat: implement subagent task sharing via mainSessionId

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -42,6 +42,7 @@ export interface AIManagerOptions {
   workdir: string;
   systemPrompt?: string;
   subagentType?: string; // Optional subagent type for hook context
+  mainSessionId?: string; // Main agent session ID
   reversionManager?: import("./reversionManager.js").ReversionManager;
   /**Whether to use streaming mode for AI responses - defaults to true */
   stream?: boolean;
@@ -67,6 +68,7 @@ export class AIManager {
   private workdir: string;
   private systemPrompt?: string;
   private subagentType?: string; // Store subagent type for hook context
+  private mainSessionId?: string; // Store main agent session ID
   private stream: boolean; // Streaming mode flag
 
   // Configuration properties (replaced with getter function storage)
@@ -87,6 +89,7 @@ export class AIManager {
     this.workdir = options.workdir;
     this.systemPrompt = options.systemPrompt;
     this.subagentType = options.subagentType; // Store subagent type
+    this.mainSessionId = options.mainSessionId; // Store main agent session ID
     this.stream = options.stream ?? true; // Default to true if not specified
     this.callbacks = options.callbacks ?? {};
 
@@ -619,6 +622,7 @@ export class AIManager {
                 workdir: this.workdir,
                 messageId: this.messageManager.getMessages().slice(-1)[0]?.id,
                 sessionId: this.messageManager.getSessionId(),
+                mainSessionId: this.mainSessionId,
               };
 
               // Execute tool

--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -200,6 +200,7 @@ export class SubagentManager {
       workdir: this.workdir,
       systemPrompt: configuration.systemPrompt,
       subagentType: parameters.subagent_type, // Pass subagent type for hook context
+      mainSessionId: this.parentMessageManager.getSessionId(),
       hookManager: this.hookManager,
       permissionManager: this.parentToolManager.getPermissionManager(),
       getGatewayConfig: this.getGatewayConfig,

--- a/packages/agent-sdk/src/managers/toolManager.ts
+++ b/packages/agent-sdk/src/managers/toolManager.ts
@@ -196,6 +196,7 @@ class ToolManager {
       mcpManager: this.mcpManager,
       lspManager: this.lspManager,
       sessionId: context.sessionId,
+      mainSessionId: context.mainSessionId,
     };
 
     this.logger?.debug("Executing tool with enhanced context", {

--- a/packages/agent-sdk/src/tools/taskManagementTools.ts
+++ b/packages/agent-sdk/src/tools/taskManagementTools.ts
@@ -59,7 +59,7 @@ export const taskCreateTool: ToolPlugin = {
     },
   },
   execute: async (args, context: ToolContext): Promise<ToolResult> => {
-    const sessionId = context.sessionId;
+    const sessionId = context.mainSessionId || context.sessionId;
     const taskManager = context.taskManager;
     if (!sessionId) {
       return {
@@ -118,7 +118,7 @@ export const taskGetTool: ToolPlugin = {
     },
   },
   execute: async (args, context: ToolContext): Promise<ToolResult> => {
-    const sessionId = context.sessionId;
+    const sessionId = context.mainSessionId || context.sessionId;
     const taskManager = context.taskManager;
     if (!sessionId) {
       return {
@@ -204,7 +204,7 @@ export const taskUpdateTool: ToolPlugin = {
     },
   },
   execute: async (args, context: ToolContext): Promise<ToolResult> => {
-    const sessionId = context.sessionId;
+    const sessionId = context.mainSessionId || context.sessionId;
     const taskManager = context.taskManager;
     if (!sessionId) {
       return {
@@ -274,7 +274,7 @@ export const taskListTool: ToolPlugin = {
     },
   },
   execute: async (args, context: ToolContext): Promise<ToolResult> => {
-    const sessionId = context.sessionId;
+    const sessionId = context.mainSessionId || context.sessionId;
     const taskManager = context.taskManager;
     if (!sessionId) {
       return {

--- a/packages/agent-sdk/src/tools/types.ts
+++ b/packages/agent-sdk/src/tools/types.ts
@@ -63,4 +63,6 @@ export interface ToolContext {
   taskManager?: import("../services/taskManager.js").TaskManager;
   /** Current session ID */
   sessionId?: string;
+  /** Main agent session ID (for shared resources like tasks) */
+  mainSessionId?: string;
 }

--- a/packages/agent-sdk/tests/integration/subagentTaskSharing.test.ts
+++ b/packages/agent-sdk/tests/integration/subagentTaskSharing.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  taskCreateTool,
+  taskGetTool,
+} from "../../src/tools/taskManagementTools.js";
+import { promises as fs } from "fs";
+import { TaskManager } from "../../src/services/taskManager.js";
+import type { ToolContext } from "../../src/tools/types.js";
+
+// Mock fs/promises
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    promises: {
+      mkdir: vi.fn(),
+      writeFile: vi.fn(),
+      readFile: vi.fn(),
+      readdir: vi.fn(),
+      open: vi.fn(),
+      unlink: vi.fn(),
+    },
+  };
+});
+
+describe("Subagent Task Sharing Integration Tests", () => {
+  const mainSessionId = "main-session-id";
+  const subagentSessionId = "subagent-session-id";
+  let taskManager: TaskManager;
+  let virtualFs: Map<string, string>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    taskManager = new TaskManager();
+    virtualFs = new Map();
+
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+
+    vi.mocked(fs.writeFile).mockImplementation(async (path, data) => {
+      virtualFs.set(path.toString(), data.toString());
+    });
+
+    vi.mocked(fs.readFile).mockImplementation(async (path) => {
+      const content = virtualFs.get(path.toString());
+      if (content === undefined) {
+        const error = new Error("File not found") as NodeJS.ErrnoException;
+        error.code = "ENOENT";
+        throw error;
+      }
+      return content;
+    });
+
+    vi.mocked(fs.readdir).mockImplementation(async (path) => {
+      const dirPath = path.toString();
+      const files = Array.from(virtualFs.keys())
+        .filter((p) => p.startsWith(dirPath))
+        .map((p) => p.replace(dirPath + "/", ""));
+
+      return files as unknown as Awaited<ReturnType<typeof fs.readdir>>;
+    });
+
+    vi.mocked(fs.open).mockImplementation(async (path, flags) => {
+      if (flags === "wx") {
+        if (virtualFs.has(path.toString())) {
+          const error = new Error("File exists") as NodeJS.ErrnoException;
+          error.code = "EEXIST";
+          throw error;
+        }
+        virtualFs.set(path.toString(), "");
+      }
+      return {
+        close: vi.fn().mockResolvedValue(undefined),
+      } as unknown as Awaited<ReturnType<typeof fs.open>>;
+    });
+  });
+
+  it("should share tasks between main agent and subagent using mainSessionId", async () => {
+    const mainContext: ToolContext = {
+      sessionId: mainSessionId,
+      taskManager,
+    } as ToolContext;
+
+    const subagentContext: ToolContext = {
+      sessionId: subagentSessionId,
+      mainSessionId: mainSessionId,
+      taskManager,
+    } as ToolContext;
+
+    // 1. Main agent creates a task
+    const createResult = await taskCreateTool.execute(
+      {
+        subject: "Main Task",
+        description: "Created by main agent",
+      },
+      mainContext,
+    );
+    expect(createResult.success).toBe(true);
+    expect(createResult.content).toContain("Task created with ID: 1");
+
+    // 2. Subagent should be able to get the task using mainSessionId
+    const getResult = await taskGetTool.execute({ id: "1" }, subagentContext);
+    expect(getResult.success).toBe(true);
+    const task = JSON.parse(getResult.content as string);
+    expect(task.subject).toBe("Main Task");
+
+    // 3. Subagent creates a task
+    const subCreateResult = await taskCreateTool.execute(
+      {
+        subject: "Subagent Task",
+        description: "Created by subagent",
+      },
+      subagentContext,
+    );
+    expect(subCreateResult.success).toBe(true);
+    expect(subCreateResult.content).toContain("Task created with ID: 2");
+
+    // 4. Main agent should be able to get the subagent's task
+    const mainGetResult = await taskGetTool.execute({ id: "2" }, mainContext);
+    expect(mainGetResult.success).toBe(true);
+    const subTask = JSON.parse(mainGetResult.content as string);
+    expect(subTask.subject).toBe("Subagent Task");
+  });
+
+  it("should NOT share tasks if mainSessionId is not provided (isolation check)", async () => {
+    const contextA: ToolContext = {
+      sessionId: "session-a",
+      taskManager,
+    } as ToolContext;
+
+    const contextB: ToolContext = {
+      sessionId: "session-b",
+      taskManager,
+    } as ToolContext;
+
+    // 1. Session A creates a task
+    await taskCreateTool.execute(
+      { subject: "Task A", description: "Desc A" },
+      contextA,
+    );
+
+    // 2. Session B should NOT find Task A
+    const getResult = await taskGetTool.execute({ id: "1" }, contextB);
+    expect(getResult.success).toBe(false);
+    expect(getResult.content).toContain("Task with ID 1 not found");
+  });
+});

--- a/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
@@ -44,6 +44,7 @@ describe("SubagentManager - Backgrounding Coverage", () => {
     mockMessageManager = {
       addSubagentBlock: vi.fn(),
       updateSubagentBlock: vi.fn(),
+      getSessionId: vi.fn().mockReturnValue("parent-session-id"),
     } as unknown as MessageManager;
 
     mockToolManager = {

--- a/packages/agent-sdk/tests/managers/subagentManager.consistency.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.consistency.test.ts
@@ -50,6 +50,7 @@ describe("SubagentManager Consistency", () => {
     mockMessageManager = {
       addSubagentBlock: vi.fn(),
       updateSubagentBlock: vi.fn(),
+      getSessionId: vi.fn().mockReturnValue("parent-session-id"),
     } as unknown as MessageManager;
 
     // Mock ToolManager


### PR DESCRIPTION
This PR implements task sharing between main agents and subagents by introducing a `mainSessionId` in the `ToolContext`. Subagents now use the parent's session ID for task storage while maintaining isolated conversation transcripts.