### PR TITLE
feat: group multiple tool blocks in a container with left border

### DIFF
--- a/packages/code/src/components/MessageItem.tsx
+++ b/packages/code/src/components/MessageItem.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Box, Text } from "ink";
-import type { Message } from "wave-agent-sdk";
+import type { Message, MessageBlock } from "wave-agent-sdk";
 import { MessageSource } from "wave-agent-sdk";
 import { CommandOutputDisplay } from "./CommandOutputDisplay.js";
 import { ToolResultDisplay } from "./ToolResultDisplay.js";
@@ -22,6 +22,114 @@ export const MessageItem = ({
   shouldShowHeader,
 }: MessageItemProps) => {
   if (message.blocks.length === 0) return null;
+  const renderBlock = (block: MessageBlock, blockIndex: number) => (
+    <Box key={blockIndex}>
+      {block.type === "text" && block.content.trim() && (
+        <Box>
+          {block.customCommandContent && (
+            <Text color="cyan" bold>
+              ⚡{" "}
+            </Text>
+          )}
+          {block.source === MessageSource.HOOK && (
+            <Text color="magenta" bold>
+              🔗{" "}
+            </Text>
+          )}
+          <Markdown>{block.content}</Markdown>
+        </Box>
+      )}
+
+      {block.type === "error" && (
+        <Box>
+          <Text color="red">❌ Error: {block.content}</Text>
+        </Box>
+      )}
+
+      {block.type === "command_output" && (
+        <CommandOutputDisplay block={block} isExpanded={isExpanded} />
+      )}
+
+      {block.type === "tool" && (
+        <ToolResultDisplay block={block} isExpanded={isExpanded} />
+      )}
+
+      {block.type === "image" && (
+        <Box>
+          <Text color="magenta" bold>
+            📷 Image
+          </Text>
+          {block.imageUrls && block.imageUrls.length > 0 && (
+            <Text color="gray" dimColor>
+              {" "}
+              ({block.imageUrls.length})
+            </Text>
+          )}
+        </Box>
+      )}
+
+      {block.type === "memory" && <MemoryDisplay block={block} />}
+
+      {block.type === "compress" && (
+        <CompressDisplay block={block} isExpanded={isExpanded} />
+      )}
+
+      {block.type === "subagent" && <SubagentBlock block={block} />}
+
+      {block.type === "reasoning" && <ReasoningDisplay block={block} />}
+    </Box>
+  );
+
+  const renderedBlocks: React.ReactNode[] = [];
+  let currentToolGroup: React.ReactNode[] = [];
+
+  message.blocks.forEach((block, index) => {
+    if (
+      block.type === "tool" &&
+      message.blocks.filter((b) => b.type === "tool").length > 1
+    ) {
+      currentToolGroup.push(renderBlock(block, index));
+    } else {
+      if (currentToolGroup.length > 0) {
+        renderedBlocks.push(
+          <Box
+            key={`tool-group-${index}`}
+            flexDirection="column"
+            gap={1}
+            borderRight={false}
+            borderTop={false}
+            borderBottom={false}
+            borderStyle="classic"
+            borderColor="gray"
+            paddingLeft={1}
+          >
+            {currentToolGroup}
+          </Box>,
+        );
+        currentToolGroup = [];
+      }
+      renderedBlocks.push(renderBlock(block, index));
+    }
+  });
+
+  if (currentToolGroup.length > 0) {
+    renderedBlocks.push(
+      <Box
+        key="tool-group-final"
+        flexDirection="column"
+        gap={1}
+        borderRight={false}
+        borderTop={false}
+        borderBottom={false}
+        borderStyle="classic"
+        borderColor="gray"
+        paddingLeft={1}
+      >
+        {currentToolGroup}
+      </Box>,
+    );
+  }
+
   return (
     <Box flexDirection="column" gap={1} marginTop={1}>
       {shouldShowHeader && (
@@ -33,63 +141,7 @@ export const MessageItem = ({
       )}
 
       <Box flexDirection="column" gap={1}>
-        {message.blocks.map((block, blockIndex) => (
-          <Box key={blockIndex}>
-            {block.type === "text" && block.content.trim() && (
-              <Box>
-                {block.customCommandContent && (
-                  <Text color="cyan" bold>
-                    ⚡{" "}
-                  </Text>
-                )}
-                {block.source === MessageSource.HOOK && (
-                  <Text color="magenta" bold>
-                    🔗{" "}
-                  </Text>
-                )}
-                <Markdown>{block.content}</Markdown>
-              </Box>
-            )}
-
-            {block.type === "error" && (
-              <Box>
-                <Text color="red">❌ Error: {block.content}</Text>
-              </Box>
-            )}
-
-            {block.type === "command_output" && (
-              <CommandOutputDisplay block={block} isExpanded={isExpanded} />
-            )}
-
-            {block.type === "tool" && (
-              <ToolResultDisplay block={block} isExpanded={isExpanded} />
-            )}
-
-            {block.type === "image" && (
-              <Box>
-                <Text color="magenta" bold>
-                  📷 Image
-                </Text>
-                {block.imageUrls && block.imageUrls.length > 0 && (
-                  <Text color="gray" dimColor>
-                    {" "}
-                    ({block.imageUrls.length})
-                  </Text>
-                )}
-              </Box>
-            )}
-
-            {block.type === "memory" && <MemoryDisplay block={block} />}
-
-            {block.type === "compress" && (
-              <CompressDisplay block={block} isExpanded={isExpanded} />
-            )}
-
-            {block.type === "subagent" && <SubagentBlock block={block} />}
-
-            {block.type === "reasoning" && <ReasoningDisplay block={block} />}
-          </Box>
-        ))}
+        {renderedBlocks}
       </Box>
     </Box>
   );


### PR DESCRIPTION
This PR updates MessageItem.tsx to wrap consecutive tool blocks in a single container with a left border when there are multiple tool blocks in a message, similar to ReasoningDisplay styling.