### PR TITLE
Refactor TaskManager for stable task persistence

### DIFF
--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -69,6 +69,7 @@ export interface SubagentManagerOptions {
   workdir: string;
   parentToolManager: ToolManager;
   parentMessageManager: MessageManager;
+  taskManager: import("../services/taskManager.js").TaskManager;
   callbacks?: SubagentManagerCallbacks; // Use SubagentManagerCallbacks instead of parentCallbacks
   logger?: Logger;
   getGatewayConfig: () => GatewayConfig;
@@ -88,6 +89,7 @@ export class SubagentManager {
   private workdir: string;
   private parentToolManager: ToolManager;
   private parentMessageManager: MessageManager;
+  private taskManager: import("../services/taskManager.js").TaskManager;
   private callbacks?: SubagentManagerCallbacks; // Use SubagentManagerCallbacks instead of parentCallbacks
   private logger?: Logger;
   private getGatewayConfig: () => GatewayConfig;
@@ -103,6 +105,7 @@ export class SubagentManager {
     this.workdir = options.workdir;
     this.parentToolManager = options.parentToolManager;
     this.parentMessageManager = options.parentMessageManager;
+    this.taskManager = options.taskManager;
     this.callbacks = options.callbacks; // Store SubagentManagerCallbacks
     this.logger = options.logger;
     this.getGatewayConfig = options.getGatewayConfig;
@@ -196,11 +199,11 @@ export class SubagentManager {
     const aiManager = new AIManager({
       messageManager,
       toolManager,
+      taskManager: this.taskManager,
       logger: this.logger,
       workdir: this.workdir,
       systemPrompt: configuration.systemPrompt,
       subagentType: parameters.subagent_type, // Pass subagent type for hook context
-      mainSessionId: this.parentMessageManager.getSessionId(),
       hookManager: this.hookManager,
       permissionManager: this.parentToolManager.getPermissionManager(),
       getGatewayConfig: this.getGatewayConfig,
@@ -616,6 +619,7 @@ export class SubagentManager {
         const aiManager = new AIManager({
           messageManager,
           toolManager,
+          taskManager: this.taskManager,
           logger: this.logger,
           workdir: this.workdir,
           systemPrompt: configuration.systemPrompt,

--- a/packages/agent-sdk/src/managers/toolManager.ts
+++ b/packages/agent-sdk/src/managers/toolManager.ts
@@ -189,14 +189,13 @@ class ToolManager {
       permissionMode: effectivePermissionMode,
       canUseToolCallback: this.canUseToolCallback,
       permissionManager: this.permissionManager,
-      taskManager: this.taskManager,
+      taskManager: this.taskManager!,
       reversionManager: this.reversionManager,
       backgroundTaskManager: this.backgroundTaskManager,
       foregroundTaskManager: this.foregroundTaskManager,
       mcpManager: this.mcpManager,
       lspManager: this.lspManager,
       sessionId: context.sessionId,
-      mainSessionId: context.mainSessionId,
     };
 
     this.logger?.debug("Executing tool with enhanced context", {
@@ -292,6 +291,15 @@ class ToolManager {
    */
   public getPermissionManager(): PermissionManager | undefined {
     return this.permissionManager;
+  }
+
+  /**
+   * Get the task manager
+   */
+  public getTaskManager():
+    | import("../services/taskManager.js").TaskManager
+    | undefined {
+    return this.taskManager;
   }
 }
 

--- a/packages/agent-sdk/src/tools/taskManagementTools.ts
+++ b/packages/agent-sdk/src/tools/taskManagementTools.ts
@@ -59,22 +59,7 @@ export const taskCreateTool: ToolPlugin = {
     },
   },
   execute: async (args, context: ToolContext): Promise<ToolResult> => {
-    const sessionId = context.mainSessionId || context.sessionId;
     const taskManager = context.taskManager;
-    if (!sessionId) {
-      return {
-        success: false,
-        content: "Session ID not found in context.",
-      };
-    }
-
-    if (!taskManager) {
-      return {
-        success: false,
-        content: "TaskManager not found in context.",
-      };
-    }
-
     const task: Omit<Task, "id"> = {
       subject: args.subject as string,
       description: args.description as string,
@@ -86,7 +71,7 @@ export const taskCreateTool: ToolPlugin = {
       metadata: (args.metadata as Record<string, unknown>) || {},
     };
 
-    const taskId = await taskManager.createTask(sessionId, task);
+    const taskId = await taskManager.createTask(task);
 
     return {
       success: true,
@@ -116,23 +101,9 @@ export const taskGetTool: ToolPlugin = {
     },
   },
   execute: async (args, context: ToolContext): Promise<ToolResult> => {
-    const sessionId = context.mainSessionId || context.sessionId;
     const taskManager = context.taskManager;
-    if (!sessionId) {
-      return {
-        success: false,
-        content: "Session ID not found in context.",
-      };
-    }
 
-    if (!taskManager) {
-      return {
-        success: false,
-        content: "TaskManager not found in context.",
-      };
-    }
-
-    const task = await taskManager.getTask(sessionId, args.id as string);
+    const task = await taskManager.getTask(args.id as string);
     if (!task) {
       return {
         success: false,
@@ -202,26 +173,9 @@ export const taskUpdateTool: ToolPlugin = {
     },
   },
   execute: async (args, context: ToolContext): Promise<ToolResult> => {
-    const sessionId = context.mainSessionId || context.sessionId;
     const taskManager = context.taskManager;
-    if (!sessionId) {
-      return {
-        success: false,
-        content: "Session ID not found in context.",
-      };
-    }
 
-    if (!taskManager) {
-      return {
-        success: false,
-        content: "TaskManager not found in context.",
-      };
-    }
-
-    const existingTask = await taskManager.getTask(
-      sessionId,
-      args.id as string,
-    );
+    const existingTask = await taskManager.getTask(args.id as string);
     if (!existingTask) {
       return {
         success: false,
@@ -242,7 +196,7 @@ export const taskUpdateTool: ToolPlugin = {
         (args.metadata as Record<string, unknown>) ?? existingTask.metadata,
     };
 
-    await taskManager.updateTask(sessionId, updatedTask);
+    await taskManager.updateTask(updatedTask);
 
     return {
       success: true,
@@ -272,23 +226,9 @@ export const taskListTool: ToolPlugin = {
     },
   },
   execute: async (args, context: ToolContext): Promise<ToolResult> => {
-    const sessionId = context.mainSessionId || context.sessionId;
     const taskManager = context.taskManager;
-    if (!sessionId) {
-      return {
-        success: false,
-        content: "Session ID not found in context.",
-      };
-    }
 
-    if (!taskManager) {
-      return {
-        success: false,
-        content: "TaskManager not found in context.",
-      };
-    }
-
-    let tasks = await taskManager.listTasks(sessionId);
+    let tasks = await taskManager.listTasks();
     if (args.status) {
       tasks = tasks.filter((t) => t.status === args.status);
     }

--- a/packages/agent-sdk/src/tools/types.ts
+++ b/packages/agent-sdk/src/tools/types.ts
@@ -60,9 +60,7 @@ export interface ToolContext {
   /** Foreground task manager for backgrounding tasks */
   foregroundTaskManager?: import("../types/processes.js").IForegroundTaskManager;
   /** Task manager instance for task management */
-  taskManager?: import("../services/taskManager.js").TaskManager;
+  taskManager: import("../services/taskManager.js").TaskManager;
   /** Current session ID */
   sessionId?: string;
-  /** Main agent session ID (for shared resources like tasks) */
-  mainSessionId?: string;
 }

--- a/packages/agent-sdk/tests/agent/agent.autoAccept.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.autoAccept.test.ts
@@ -10,6 +10,7 @@ vi.mock("os", async () => {
   };
 });
 
+import { TaskManager } from "../../src/services/taskManager.js";
 import { Agent } from "@/agent.js";
 import { ToolManager } from "../../src/managers/toolManager.js";
 import type { PermissionCallback } from "../../src/types/permissions.js";
@@ -55,11 +56,13 @@ describe("Agent Auto-Accept Permissions Integration", () => {
     // We'll use the toolManager directly.
     const toolManager = (agent as unknown as { toolManager: ToolManager })
       .toolManager;
+    const taskManager = (agent as unknown as { taskManager: TaskManager })
+      .taskManager;
 
     await toolManager.execute(
       "Bash",
       { command: "rm test.txt" },
-      { workdir: tempDir },
+      { workdir: tempDir, taskManager },
     );
 
     expect(agent.getPermissionMode()).toBe("acceptEdits");
@@ -76,7 +79,7 @@ describe("Agent Auto-Accept Permissions Integration", () => {
     await toolManager.execute(
       "Bash",
       { command: "whoami" },
-      { workdir: tempDir },
+      { workdir: tempDir, taskManager },
     );
 
     // Check if rule was persisted to settings.local.json
@@ -91,7 +94,7 @@ describe("Agent Auto-Accept Permissions Integration", () => {
     await toolManager.execute(
       "Bash",
       { command: "whoami" },
-      { workdir: tempDir },
+      { workdir: tempDir, taskManager },
     );
     expect(mockCallback).not.toHaveBeenCalled();
   });
@@ -121,10 +124,12 @@ describe("Agent Auto-Accept Permissions Integration", () => {
     // 3. Verify rule is loaded and applied
     const toolManager = (agent as unknown as { toolManager: ToolManager })
       .toolManager;
+    const taskManager = (agent as unknown as { taskManager: TaskManager })
+      .taskManager;
     await toolManager.execute(
       "Bash",
       { command: "rm -rf /tmp/test" },
-      { workdir: tempDir },
+      { workdir: tempDir, taskManager },
     );
     expect(mockCallback).not.toHaveBeenCalled();
   });
@@ -175,18 +180,20 @@ describe("Agent Auto-Accept Permissions Integration", () => {
     // 4. Verify both rules are applied
     const toolManager = (agent as unknown as { toolManager: ToolManager })
       .toolManager;
+    const taskManager = (agent as unknown as { taskManager: TaskManager })
+      .taskManager;
 
     await toolManager.execute(
       "Bash",
       { command: "global" },
-      { workdir: tempDir },
+      { workdir: tempDir, taskManager },
     );
     expect(mockCallback).not.toHaveBeenCalled();
 
     await toolManager.execute(
       "Bash",
       { command: "local" },
-      { workdir: tempDir },
+      { workdir: tempDir, taskManager },
     );
     expect(mockCallback).not.toHaveBeenCalled();
 
@@ -203,6 +210,8 @@ describe("Agent Auto-Accept Permissions Integration", () => {
 
     const toolManager = (agent as unknown as { toolManager: ToolManager })
       .toolManager;
+    const taskManager = (agent as unknown as { taskManager: TaskManager })
+      .taskManager;
 
     // 1. Trigger permission check for a chained command
     mockCallback.mockResolvedValueOnce({
@@ -216,7 +225,7 @@ describe("Agent Auto-Accept Permissions Integration", () => {
     await toolManager.execute(
       "Bash",
       { command: "mkdir -p test && cd test" },
-      { workdir: tempDir },
+      { workdir: tempDir, taskManager },
     );
 
     // 2. Check if rules were split and filtered in settings.local.json
@@ -236,7 +245,7 @@ describe("Agent Auto-Accept Permissions Integration", () => {
     await toolManager.execute(
       "Bash",
       { command: "mkdir -p test" },
-      { workdir: tempDir },
+      { workdir: tempDir, taskManager },
     );
     expect(mockCallback).not.toHaveBeenCalled();
   });

--- a/packages/agent-sdk/tests/agent/agent.coverage.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.coverage.test.ts
@@ -6,7 +6,16 @@ import * as fs from "fs/promises";
 
 // Mock dependencies
 vi.mock("@/services/aiService");
-vi.mock("@/services/session");
+vi.mock("@/services/session", async () => {
+  const actual = await vi.importActual("@/services/session");
+  return {
+    ...actual,
+    generateSessionId: vi.fn(() => "test-session-id"),
+    handleSessionRestoration: vi.fn(),
+    loadSessionFromJsonl: vi.fn(),
+    appendMessages: vi.fn(),
+  };
+});
 vi.mock("fs/promises");
 
 const { instance: mockToolManagerInstance } = createMockToolManager();

--- a/packages/agent-sdk/tests/agent/agent.subagentSessionRestore.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.subagentSessionRestore.test.ts
@@ -17,22 +17,26 @@ vi.mock("@/managers/toolManager", () => ({
 }));
 
 // Mock session service functions
-vi.mock("../../src/services/session.js", () => ({
-  generateSessionId: vi.fn(),
-  loadSessionFromJsonl: vi.fn(),
-  appendMessages: vi.fn(),
-  getLatestSessionFromJsonl: vi.fn(),
-  listSessionsFromJsonl: vi.fn(),
-  deleteSessionFromJsonl: vi.fn(),
-  sessionExistsInJsonl: vi.fn(),
-  cleanupExpiredSessionsFromJsonl: vi.fn(() => Promise.resolve(0)),
-  getSessionFilePath: vi.fn(),
-  ensureSessionDir: vi.fn(),
-  listSessions: vi.fn(),
-  cleanupEmptyProjectDirectories: vi.fn(),
-  handleSessionRestoration: vi.fn(),
-  SESSION_DIR: "/mock/session/dir",
-}));
+vi.mock("../../src/services/session.js", async () => {
+  const actual = await vi.importActual("../../src/services/session.js");
+  return {
+    ...actual,
+    generateSessionId: vi.fn(() => "test-session-id"),
+    loadSessionFromJsonl: vi.fn(),
+    appendMessages: vi.fn(),
+    getLatestSessionFromJsonl: vi.fn(),
+    listSessionsFromJsonl: vi.fn(),
+    deleteSessionFromJsonl: vi.fn(),
+    sessionExistsInJsonl: vi.fn(),
+    cleanupExpiredSessionsFromJsonl: vi.fn(() => Promise.resolve(0)),
+    getSessionFilePath: vi.fn(),
+    ensureSessionDir: vi.fn(),
+    listSessions: vi.fn(),
+    cleanupEmptyProjectDirectories: vi.fn(),
+    handleSessionRestoration: vi.fn(),
+    SESSION_DIR: "/mock/session/dir",
+  };
+});
 
 // Type for accessing private members in tests
 interface AgentWithPrivates {

--- a/packages/agent-sdk/tests/agent/exitPlanMode.integration.test.ts
+++ b/packages/agent-sdk/tests/agent/exitPlanMode.integration.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TaskManager } from "@/services/taskManager.js";
 import { Agent } from "@/agent.js";
 import { readFile } from "fs/promises";
 import type { PermissionCallback } from "@/types/permissions.js";
@@ -123,9 +124,11 @@ describe("ExitPlanMode Integration", () => {
     vi.mocked(readFile).mockResolvedValue(planContent);
 
     // Execute ExitPlanMode tool
+    const taskManager = (agent as unknown as { taskManager: TaskManager })
+      .taskManager;
     const result = await (
       agent as unknown as AgentInternal
-    ).toolManager.execute("ExitPlanMode", {}, { workdir });
+    ).toolManager.execute("ExitPlanMode", {}, { workdir, taskManager });
 
     expect(result.success).toBe(true);
     expect(agent.getPermissionMode()).toBe("default");
@@ -158,9 +161,11 @@ describe("ExitPlanMode Integration", () => {
     vi.mocked(readFile).mockResolvedValue(planContent);
 
     // Execute ExitPlanMode tool
+    const taskManager = (agent as unknown as { taskManager: TaskManager })
+      .taskManager;
     const result = await (
       agent as unknown as AgentInternal
-    ).toolManager.execute("ExitPlanMode", {}, { workdir });
+    ).toolManager.execute("ExitPlanMode", {}, { workdir, taskManager });
 
     expect(result.success).toBe(true);
     expect(agent.getPermissionMode()).toBe("acceptEdits");
@@ -188,9 +193,11 @@ describe("ExitPlanMode Integration", () => {
     vi.mocked(readFile).mockResolvedValue(planContent);
 
     // Execute ExitPlanMode tool
+    const taskManager = (agent as unknown as { taskManager: TaskManager })
+      .taskManager;
     const result = await (
       agent as unknown as AgentInternal
-    ).toolManager.execute("ExitPlanMode", {}, { workdir });
+    ).toolManager.execute("ExitPlanMode", {}, { workdir, taskManager });
 
     expect(result.success).toBe(false);
     expect(result.content).toBe(feedback);

--- a/packages/agent-sdk/tests/helpers/mockFactories.ts
+++ b/packages/agent-sdk/tests/helpers/mockFactories.ts
@@ -1,6 +1,7 @@
 import { vi, type Mock } from "vitest";
 import type { ToolManager } from "../../src/managers/toolManager.js";
 import type { PermissionMode } from "../../src/types/permissions.js";
+import type { TaskManager } from "../../src/services/taskManager.js";
 
 interface MockToolManager {
   execute: Mock<ToolManager["execute"]>;
@@ -12,6 +13,20 @@ interface MockToolManager {
   getPermissionManager: Mock<ToolManager["getPermissionManager"]>;
   instance: ToolManager;
 }
+
+/**
+ * Creates a mock TaskManager instance.
+ */
+export const createMockTaskManager = (): TaskManager => {
+  return {
+    createTask: vi.fn(),
+    getTask: vi.fn(),
+    updateTask: vi.fn(),
+    listTasks: vi.fn(),
+    on: vi.fn(),
+    emit: vi.fn(),
+  } as unknown as TaskManager;
+};
 
 /**
  * Creates a mock ToolManager instance and its associated mock functions.

--- a/packages/agent-sdk/tests/integration/subagentPlanMode.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/subagentPlanMode.integration.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskManager } from "../../src/services/taskManager.js";
 import { SubagentManager } from "../../src/managers/subagentManager.js";
 import { MessageManager } from "../../src/managers/messageManager.js";
 import { ToolManager } from "../../src/managers/toolManager.js";
@@ -91,6 +92,9 @@ describe("Subagent Plan Mode Integration", () => {
       workdir: "/test/project",
       parentToolManager: mockToolManager,
       parentMessageManager: mockMessageManager,
+      taskManager: {
+        listTasks: vi.fn().mockResolvedValue([]),
+      } as unknown as TaskManager,
       getGatewayConfig: () => ({ apiKey: "test", baseURL: "test" }),
       getModelConfig: () => ({
         agentModel: "test-model",

--- a/packages/agent-sdk/tests/integration/subagentTaskSharing.test.ts
+++ b/packages/agent-sdk/tests/integration/subagentTaskSharing.test.ts
@@ -31,7 +31,7 @@ describe("Subagent Task Sharing Integration Tests", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    taskManager = new TaskManager();
+    taskManager = new TaskManager(mainSessionId);
     virtualFs = new Map();
 
     vi.mocked(fs.mkdir).mockResolvedValue(undefined);
@@ -68,12 +68,14 @@ describe("Subagent Task Sharing Integration Tests", () => {
     const mainContext: ToolContext = {
       sessionId: mainSessionId,
       taskManager,
+      workdir: "/test/workdir",
     } as ToolContext;
 
     const subagentContext: ToolContext = {
       sessionId: subagentSessionId,
       mainSessionId: mainSessionId,
       taskManager,
+      workdir: "/test/workdir",
     } as ToolContext;
 
     // 1. Main agent creates a task
@@ -112,14 +114,19 @@ describe("Subagent Task Sharing Integration Tests", () => {
   });
 
   it("should NOT share tasks if mainSessionId is not provided (isolation check)", async () => {
+    const taskManagerA = new TaskManager("session-a");
+    const taskManagerB = new TaskManager("session-b");
+
     const contextA: ToolContext = {
       sessionId: "session-a",
-      taskManager,
+      taskManager: taskManagerA,
+      workdir: "/test/workdir",
     } as ToolContext;
 
     const contextB: ToolContext = {
       sessionId: "session-b",
-      taskManager,
+      taskManager: taskManagerB,
+      workdir: "/test/workdir",
     } as ToolContext;
 
     // 1. Session A creates a task

--- a/packages/agent-sdk/tests/integration/taskManagement.test.ts
+++ b/packages/agent-sdk/tests/integration/taskManagement.test.ts
@@ -33,8 +33,12 @@ describe("Task Management Integration Tests", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    taskManager = new TaskManager();
-    context = { sessionId, taskManager } as ToolContext;
+    taskManager = new TaskManager(sessionId);
+    context = {
+      sessionId,
+      taskManager,
+      workdir: "/test/workdir",
+    } as ToolContext;
     virtualFs = new Map();
 
     vi.mocked(fs.mkdir).mockResolvedValue(undefined);

--- a/packages/agent-sdk/tests/integration/taskTool.builtin.test.ts
+++ b/packages/agent-sdk/tests/integration/taskTool.builtin.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskManager } from "../../src/services/taskManager.js";
 import { createTaskTool } from "../../src/tools/taskTool.js";
 import {
   SubagentManager,
@@ -16,6 +17,10 @@ describe("Task Tool Integration with Built-in Subagents", () => {
   const mockToolContext: ToolContext = {
     abortSignal: new AbortController().signal,
     workdir: "/test/workdir",
+    taskManager: {
+      on: vi.fn(),
+      listTasks: vi.fn().mockResolvedValue([]),
+    } as unknown as TaskManager,
   };
 
   const exploreConfig: SubagentConfiguration = {

--- a/packages/agent-sdk/tests/managers/aiManager.latestTotalTokens.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.latestTotalTokens.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskManager } from "../../src/services/taskManager.js";
 import { AIManager } from "../../src/managers/aiManager.js";
 import type { MessageManager } from "../../src/managers/messageManager.js";
 import type { ToolManager } from "../../src/managers/toolManager.js";
@@ -88,6 +89,7 @@ describe("AIManager - latestTotalTokens calculation", () => {
     aiManager = new AIManager({
       messageManager: mockMessageManager,
       toolManager: mockToolManager,
+      taskManager: {} as unknown as TaskManager,
       logger: mockLogger,
       workdir: "/test/workdir",
       getGatewayConfig: () => mockGatewayConfig,

--- a/packages/agent-sdk/tests/managers/aiManager.plan.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.plan.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, type Mocked } from "vitest";
+import { TaskManager } from "../../src/services/taskManager.js";
 import { AIManager } from "../../src/managers/aiManager.js";
 import fs from "node:fs/promises";
 import { callAgent } from "../../src/services/aiService.js";
@@ -42,6 +43,7 @@ describe("AIManager Plan Mode Prompt", () => {
     aiManager = new AIManager({
       messageManager: mockMessageManager,
       toolManager: mockToolManager,
+      taskManager: {} as unknown as TaskManager,
       permissionManager: mockPermissionManager,
       workdir: "/test/workdir",
       getGatewayConfig: () => ({}) as GatewayConfig,

--- a/packages/agent-sdk/tests/managers/aiManager.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskManager } from "../../src/services/taskManager.js";
 import { AIManager } from "../../src/managers/aiManager.js";
 import type { MessageManager } from "../../src/managers/messageManager.js";
 import type { ToolManager } from "../../src/managers/toolManager.js";
@@ -83,10 +84,16 @@ describe("AIManager", () => {
       error: vi.fn(),
     } as unknown as Logger;
 
+    const taskManager = {
+      on: vi.fn(),
+      listTasks: vi.fn().mockResolvedValue([]),
+    } as unknown as TaskManager;
+
     // Create AIManager instance
     aiManager = new AIManager({
       messageManager: mockMessageManager,
       toolManager: mockToolManager,
+      taskManager,
       logger: mockLogger,
       workdir: "/test/workdir",
       getGatewayConfig: () => mockGatewayConfig,
@@ -105,9 +112,15 @@ describe("AIManager", () => {
         tool_calls: [],
       });
 
+      const taskManager = {
+        on: vi.fn(),
+        listTasks: vi.fn().mockResolvedValue([]),
+      } as unknown as TaskManager;
+
       const aiManagerWithLanguage = new AIManager({
         messageManager: mockMessageManager,
         toolManager: mockToolManager,
+        taskManager,
         logger: mockLogger,
         workdir: "/test/workdir",
         getGatewayConfig: () => mockGatewayConfig,
@@ -155,9 +168,15 @@ describe("AIManager", () => {
         tool_calls: [],
       });
 
+      const taskManager = {
+        on: vi.fn(),
+        listTasks: vi.fn().mockResolvedValue([]),
+      } as unknown as TaskManager;
+
       const aiManagerWithLanguage = new AIManager({
         messageManager: mockMessageManager,
         toolManager: mockToolManager,
+        taskManager,
         logger: mockLogger,
         workdir: "/test/workdir",
         getGatewayConfig: () => mockGatewayConfig,
@@ -331,9 +350,15 @@ describe("AIManager", () => {
         clearTemporaryRules: vi.fn(),
       };
 
+      const taskManager = {
+        on: vi.fn(),
+        listTasks: vi.fn().mockResolvedValue([]),
+      } as unknown as TaskManager;
+
       const aiManagerWithPermissions = new AIManager({
         messageManager: mockMessageManager,
         toolManager: mockToolManager,
+        taskManager,
         logger: mockLogger,
         permissionManager:
           mockPermissionManager as unknown as PermissionManager,
@@ -368,9 +393,15 @@ describe("AIManager", () => {
         clearTemporaryRules: vi.fn(),
       };
 
+      const taskManager = {
+        on: vi.fn(),
+        listTasks: vi.fn().mockResolvedValue([]),
+      } as unknown as TaskManager;
+
       const aiManagerWithPermissions = new AIManager({
         messageManager: mockMessageManager,
         toolManager: mockToolManager,
+        taskManager,
         logger: mockLogger,
         permissionManager:
           mockPermissionManager as unknown as PermissionManager,
@@ -403,9 +434,15 @@ describe("AIManager", () => {
         clearTemporaryRules: vi.fn(),
       };
 
+      const taskManager = {
+        on: vi.fn(),
+        listTasks: vi.fn().mockResolvedValue([]),
+      } as unknown as TaskManager;
+
       const aiManagerWithPermissions = new AIManager({
         messageManager: mockMessageManager,
         toolManager: mockToolManager,
+        taskManager,
         logger: mockLogger,
         permissionManager:
           mockPermissionManager as unknown as PermissionManager,

--- a/packages/agent-sdk/tests/managers/aiManager_finishReason.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager_finishReason.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskManager } from "../../src/services/taskManager.js";
 import { AIManager } from "../../src/managers/aiManager.js";
 import type { MessageManager } from "../../src/managers/messageManager.js";
 import type { ToolManager } from "../../src/managers/toolManager.js";
@@ -86,6 +87,7 @@ describe("AIManager finish reason", () => {
     aiManager = new AIManager({
       messageManager: mockMessageManager,
       toolManager: mockToolManager,
+      taskManager: {} as unknown as TaskManager,
       logger: mockLogger,
       workdir: "/test/workdir",
       getGatewayConfig: () => mockGatewayConfig,

--- a/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskManager } from "../../src/services/taskManager.js";
 import { SubagentManager } from "../../src/managers/subagentManager.js";
 import { MessageManager } from "../../src/managers/messageManager.js";
 import { ToolManager } from "../../src/managers/toolManager.js";
@@ -58,10 +59,16 @@ describe("SubagentManager - Backgrounding Coverage", () => {
       getTask: vi.fn(),
     } as unknown as BackgroundTaskManager;
 
+    const taskManager = {
+      on: vi.fn(),
+      listTasks: vi.fn().mockResolvedValue([]),
+    } as unknown as TaskManager;
+
     subagentManager = new SubagentManager({
       workdir: "/test",
       parentToolManager: mockToolManager,
       parentMessageManager: mockMessageManager,
+      taskManager,
       backgroundTaskManager: mockBackgroundTaskManager,
       getGatewayConfig: () => ({ apiKey: "test", baseURL: "test" }),
       getModelConfig: () => ({
@@ -80,10 +87,16 @@ describe("SubagentManager - Backgrounding Coverage", () => {
   });
 
   it("should handle backgroundInstance error when backgroundTaskManager is missing", async () => {
+    const taskManager = {
+      on: vi.fn(),
+      listTasks: vi.fn().mockResolvedValue([]),
+    } as unknown as TaskManager;
+
     const managerNoBG = new SubagentManager({
       workdir: "/test",
       parentToolManager: mockToolManager,
       parentMessageManager: mockMessageManager,
+      taskManager,
       getGatewayConfig: () => ({ apiKey: "test", baseURL: "test" }),
       getModelConfig: () => ({ agentModel: "m", fastModel: "f" }),
       getMaxInputTokens: () => 1000,
@@ -182,10 +195,16 @@ describe("SubagentManager - Backgrounding Coverage", () => {
       info: vi.fn(),
       debug: vi.fn(),
     } as unknown as Logger;
+    const taskManager = {
+      on: vi.fn(),
+      listTasks: vi.fn().mockResolvedValue([]),
+    } as unknown as TaskManager;
+
     const manager = new SubagentManager({
       workdir: "/test",
       parentToolManager: mockToolManager,
       parentMessageManager: mockMessageManager,
+      taskManager,
       getGatewayConfig: () => ({ apiKey: "test", baseURL: "test" }),
       getModelConfig: () => ({ agentModel: "m", fastModel: "f" }),
       getMaxInputTokens: () => 1000,
@@ -214,10 +233,16 @@ describe("SubagentManager - Backgrounding Coverage", () => {
 
   it("should cover createSubagentCallbacks reasoning update", async () => {
     const onSubagentAssistantReasoningUpdated = vi.fn();
+    const taskManager = {
+      on: vi.fn(),
+      listTasks: vi.fn().mockResolvedValue([]),
+    } as unknown as TaskManager;
+
     const manager = new SubagentManager({
       workdir: "/test",
       parentToolManager: mockToolManager,
       parentMessageManager: mockMessageManager,
+      taskManager,
       callbacks: { onSubagentAssistantReasoningUpdated },
       getGatewayConfig: () => ({ apiKey: "test", baseURL: "test" }),
       getModelConfig: () => ({ agentModel: "m", fastModel: "f" }),

--- a/packages/agent-sdk/tests/managers/subagentManager.callbacks.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.callbacks.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TaskManager } from "../../src/services/taskManager.js";
 import { SubagentManager } from "../../src/managers/subagentManager.js";
 import { MessageManager } from "../../src/managers/messageManager.js";
 import { ToolManager } from "../../src/managers/toolManager.js";
@@ -76,6 +77,7 @@ describe("SubagentManager - Callback Integration", () => {
       workdir: "/tmp/test",
       parentToolManager,
       parentMessageManager,
+      taskManager: {} as unknown as TaskManager,
       callbacks,
       getGatewayConfig: () => mockGatewayConfig,
       getModelConfig: () => mockModelConfig,
@@ -454,6 +456,7 @@ describe("SubagentManager - Callback Integration", () => {
         workdir: "/tmp/test",
         parentToolManager,
         parentMessageManager,
+        taskManager: {} as unknown as TaskManager,
         callbacks: errorCallbacks,
         getGatewayConfig: () => mockGatewayConfig,
         getModelConfig: () => mockModelConfig,
@@ -500,6 +503,7 @@ describe("SubagentManager - Callback Integration", () => {
         workdir: "/tmp/test",
         parentToolManager,
         parentMessageManager,
+        taskManager: {} as unknown as TaskManager,
         // No callbacks provided
         getGatewayConfig: () => mockGatewayConfig,
         getModelConfig: () => mockModelConfig,
@@ -620,6 +624,7 @@ describe("SubagentManager - Callback Integration", () => {
         workdir: "/tmp/test",
         parentToolManager,
         parentMessageManager,
+        taskManager: {} as unknown as TaskManager,
         backgroundTaskManager,
         getGatewayConfig: () => mockGatewayConfig,
         getModelConfig: () => mockModelConfig,

--- a/packages/agent-sdk/tests/managers/subagentManager.consistency.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.consistency.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskManager } from "../../src/services/taskManager.js";
 import { SubagentManager } from "../../src/managers/subagentManager.js";
 import { MessageManager } from "../../src/managers/messageManager.js";
 import { ToolManager } from "../../src/managers/toolManager.js";
@@ -69,6 +70,7 @@ describe("SubagentManager Consistency", () => {
       workdir: "/test",
       parentToolManager: mockToolManager,
       parentMessageManager: mockMessageManager,
+      taskManager: {} as unknown as TaskManager,
       getGatewayConfig: () => ({ apiKey: "test", baseURL: "test" }),
       getModelConfig: () => ({
         agentModel: "claude-3-5-sonnet",

--- a/packages/agent-sdk/tests/managers/subagentManager.sessions.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.sessions.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { SubagentManager } from "../../src/managers/subagentManager.js";
 import { MessageManager } from "../../src/managers/messageManager.js";
 import { ToolManager } from "../../src/managers/toolManager.js";
+import { TaskManager } from "../../src/services/taskManager.js";
 import type { SubagentConfiguration } from "../../src/utils/subagentParser.js";
 import type { GatewayConfig, ModelConfig } from "../../src/types/index.js";
 
@@ -105,6 +106,7 @@ describe("SubagentManager - Session Functionality", () => {
       workdir: "/tmp/test",
       parentToolManager,
       parentMessageManager,
+      taskManager: new TaskManager("test-session"),
       getGatewayConfig: () => mockGatewayConfig,
       getModelConfig: () => mockModelConfig,
       getMaxInputTokens: () => 1000,

--- a/packages/agent-sdk/tests/taskManagerConcurrency.test.ts
+++ b/packages/agent-sdk/tests/taskManagerConcurrency.test.ts
@@ -34,7 +34,7 @@ describe("TaskCreate Concurrency", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    taskManager = new TaskManager();
+    taskManager = new TaskManager(sessionId);
   });
 
   it("should result in unique IDs when TaskCreate is called concurrently", async () => {
@@ -94,6 +94,7 @@ describe("TaskCreate Concurrency", () => {
     const context: ToolContext = {
       sessionId,
       taskManager,
+      workdir: "/test/workdir",
     } as unknown as ToolContext;
 
     // Trigger multiple concurrent task creations

--- a/packages/agent-sdk/tests/tools/bashTool.test.ts
+++ b/packages/agent-sdk/tests/tools/bashTool.test.ts
@@ -5,6 +5,7 @@ import { taskStopTool } from "../../src/tools/taskStopTool.js";
 import { BackgroundTaskManager } from "../../src/managers/backgroundTaskManager.js";
 import type { ToolContext } from "../../src/tools/types.js";
 import type { ChildProcess } from "child_process";
+import { createMockTaskManager } from "../helpers/mockFactories.js";
 
 // Mock child_process
 vi.mock("child_process");
@@ -33,6 +34,7 @@ describe("bashTool", () => {
     context = {
       backgroundTaskManager,
       workdir: "/test/workdir",
+      taskManager: createMockTaskManager(),
     };
   });
 
@@ -195,6 +197,7 @@ describe("bashTool", () => {
         abortSignal: abortController.signal,
         backgroundTaskManager,
         workdir: "/test/workdir",
+        taskManager: createMockTaskManager(),
       };
 
       // Start the command execution

--- a/packages/agent-sdk/tests/tools/deleteFileTool.test.ts
+++ b/packages/agent-sdk/tests/tools/deleteFileTool.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { deleteFileTool } from "@/tools/deleteFileTool.js";
 import type { ToolResult, ToolContext } from "@/tools/types.js";
+import { TaskManager } from "@/services/taskManager.js";
 
-const testContext: ToolContext = { workdir: "/test/workdir" };
+const testContext: ToolContext = {
+  workdir: "/test/workdir",
+  taskManager: new TaskManager("test-session"),
+};
 
 // Mock fs/promises module
 vi.mock("fs/promises", async (importOriginal) => {

--- a/packages/agent-sdk/tests/tools/dynamicTool.test.ts
+++ b/packages/agent-sdk/tests/tools/dynamicTool.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SkillManager } from "../../src/managers/skillManager.js";
+import { TaskManager } from "../../src/services/taskManager.js";
 import { createSkillTool } from "../../src/tools/skillTool.js";
 import { SubagentManager } from "../../src/managers/subagentManager.js";
 import { createTaskTool } from "../../src/tools/taskTool.js";
@@ -74,6 +75,7 @@ describe("Dynamic Tool Definitions", () => {
     it("should dynamically reflect subagents added after tool creation", async () => {
       const subagentManager = new SubagentManager({
         workdir: "/test/workdir",
+        taskManager: new TaskManager("test-session"),
         parentToolManager: {} as unknown as ToolManager,
         parentMessageManager: {} as unknown as MessageManager,
         logger: mockLogger,

--- a/packages/agent-sdk/tests/tools/editTool.test.ts
+++ b/packages/agent-sdk/tests/tools/editTool.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { editTool } from "@/tools/editTool.js";
+import { TaskManager } from "@/services/taskManager.js";
 import { readFile, writeFile } from "fs/promises";
 import type { ToolContext } from "@/tools/types.js";
 
@@ -17,6 +18,7 @@ describe("editTool", () => {
     mockContext = {
       abortSignal: new AbortController().signal,
       workdir: "/test/workdir",
+      taskManager: new TaskManager("test-session"),
     };
   });
 

--- a/packages/agent-sdk/tests/tools/exitPlanMode.test.ts
+++ b/packages/agent-sdk/tests/tools/exitPlanMode.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { exitPlanModeTool } from "@/tools/exitPlanMode.js";
+import { TaskManager } from "@/services/taskManager.js";
 import { readFile } from "fs/promises";
 import type { ToolContext } from "@/tools/types.js";
 import { PermissionManager } from "@/managers/permissionManager.js";
@@ -24,6 +25,7 @@ describe("exitPlanModeTool", () => {
 
     mockContext = {
       workdir: "/test/workdir",
+      taskManager: new TaskManager("test-session"),
       permissionManager: mockPermissionManager as unknown as PermissionManager,
       permissionMode: "plan",
       canUseToolCallback: vi.fn(),
@@ -48,7 +50,10 @@ describe("exitPlanModeTool", () => {
   });
 
   it("should fail if permission manager is not available", async () => {
-    const result = await exitPlanModeTool.execute({}, { workdir: "/test" });
+    const result = await exitPlanModeTool.execute(
+      {},
+      { workdir: "/test", taskManager: new TaskManager("test-session") },
+    );
     expect(result.success).toBe(false);
     expect(result.error).toBe("Permission manager is not available");
   });

--- a/packages/agent-sdk/tests/tools/globTool.test.ts
+++ b/packages/agent-sdk/tests/tools/globTool.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { globTool } from "@/tools/globTool.js";
+import { TaskManager } from "@/services/taskManager.js";
 import type { ToolContext } from "@/tools/types.js";
 import type { Stats } from "fs";
 
-const testContext: ToolContext = { workdir: "/test/workdir" };
+const testContext: ToolContext = {
+  workdir: "/test/workdir",
+  taskManager: new TaskManager("test-session"),
+};
 
 // Mock glob
 vi.mock("glob", () => ({
@@ -72,7 +76,10 @@ describe("globTool", () => {
 
     const result = await globTool.execute(
       { pattern: "**/*.ts" },
-      { workdir: "/test/workdir" },
+      {
+        workdir: "/test/workdir",
+        taskManager: new TaskManager("test-session"),
+      },
     );
 
     expect(result.success).toBe(true);
@@ -97,7 +104,10 @@ describe("globTool", () => {
 
     const result = await globTool.execute(
       { pattern: "**/*" },
-      { workdir: "/test/workdir" },
+      {
+        workdir: "/test/workdir",
+        taskManager: new TaskManager("test-session"),
+      },
     );
 
     expect(result.success).toBe(true);
@@ -119,7 +129,10 @@ describe("globTool", () => {
 
     const result = await globTool.execute(
       { pattern: "src/*" },
-      { workdir: "/test/workdir" },
+      {
+        workdir: "/test/workdir",
+        taskManager: new TaskManager("test-session"),
+      },
     );
 
     expect(result.success).toBe(true);
@@ -133,7 +146,10 @@ describe("globTool", () => {
 
     const result = await globTool.execute(
       { pattern: "**/*.nonexistent" },
-      { workdir: "/test/workdir" },
+      {
+        workdir: "/test/workdir",
+        taskManager: new TaskManager("test-session"),
+      },
     );
 
     expect(result.success).toBe(true);
@@ -202,7 +218,10 @@ describe("globTool", () => {
 
     const result = await globTool.execute(
       { pattern: "file*.txt" },
-      { workdir: "/test/workdir" },
+      {
+        workdir: "/test/workdir",
+        taskManager: new TaskManager("test-session"),
+      },
     );
 
     expect(result.success).toBe(true);
@@ -222,7 +241,10 @@ describe("globTool", () => {
 
     const result = await globTool.execute(
       { pattern: "**/*.js" },
-      { workdir: "/test/workdir" },
+      {
+        workdir: "/test/workdir",
+        taskManager: new TaskManager("test-session"),
+      },
     );
 
     expect(result.success).toBe(true);
@@ -245,7 +267,10 @@ describe("globTool", () => {
 
     const result = await globTool.execute(
       { pattern: "file*.txt" },
-      { workdir: "/test/workdir" },
+      {
+        workdir: "/test/workdir",
+        taskManager: new TaskManager("test-session"),
+      },
     );
 
     expect(result.success).toBe(true);
@@ -259,7 +284,10 @@ describe("globTool", () => {
 
     const result = await globTool.execute(
       { pattern: "[invalid" },
-      { workdir: "/test/workdir" },
+      {
+        workdir: "/test/workdir",
+        taskManager: new TaskManager("test-session"),
+      },
     );
 
     expect(result.success).toBe(false);
@@ -280,7 +308,10 @@ describe("globTool", () => {
 
     const result = await globTool.execute(
       { pattern: "**/*.{ts,tsx,js}" },
-      { workdir: "/test/workdir" },
+      {
+        workdir: "/test/workdir",
+        taskManager: new TaskManager("test-session"),
+      },
     );
 
     expect(result.success).toBe(true);
@@ -296,7 +327,10 @@ describe("globTool", () => {
 
     const result = await globTool.execute(
       { pattern: "**/file.ts" },
-      { workdir: "/test/workdir" },
+      {
+        workdir: "/test/workdir",
+        taskManager: new TaskManager("test-session"),
+      },
     );
 
     expect(result.success).toBe(true);

--- a/packages/agent-sdk/tests/tools/grepTool.test.ts
+++ b/packages/agent-sdk/tests/tools/grepTool.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { grepTool } from "@/tools/grepTool.js";
 import type { ToolContext } from "@/tools/types.js";
+import { TaskManager } from "@/services/taskManager.js";
 import type { ChildProcess } from "child_process";
 
-const testContext: ToolContext = { workdir: "/test/workdir" };
+const testContext: ToolContext = {
+  workdir: "/test/workdir",
+  taskManager: new TaskManager("test-session"),
+};
 
 // Mock child_process
 vi.mock("child_process");
@@ -118,7 +122,7 @@ describe("grepTool", () => {
         pattern: "export",
         output_mode: "files_with_matches",
       },
-      { workdir: "/test/workdir" },
+      testContext,
     );
 
     expect(result.success).toBe(true);
@@ -138,7 +142,7 @@ src/utils.ts:1:export const logger = {};
         pattern: "export const",
         output_mode: "content",
       },
-      { workdir: "/test/workdir" },
+      testContext,
     );
 
     expect(result.success).toBe(true);
@@ -159,7 +163,7 @@ src/utils.ts:3
         pattern: "export",
         output_mode: "count",
       },
-      { workdir: "/test/workdir" },
+      testContext,
     );
 
     expect(result.success).toBe(true);
@@ -180,7 +184,7 @@ src/utils.ts:1:export const logger = {};
         output_mode: "content",
         "-n": true,
       },
-      { workdir: "/test/workdir" },
+      testContext,
     );
 
     expect(result.success).toBe(true);
@@ -198,7 +202,7 @@ src/utils.ts:1:export const logger = {};
         "-i": true,
         output_mode: "files_with_matches",
       },
-      { workdir: "/test/workdir" },
+      testContext,
     );
 
     expect(result.success).toBe(true);
@@ -222,7 +226,7 @@ src/utils.ts:1:export const logger = {};
         type: "ts",
         output_mode: "files_with_matches",
       },
-      { workdir: "/test/workdir" },
+      testContext,
     );
 
     expect(result.success).toBe(true);
@@ -248,7 +252,7 @@ src/utils.ts:1:export const logger = {};
         glob: "*.ts",
         output_mode: "files_with_matches",
       },
-      { workdir: "/test/workdir" },
+      testContext,
     );
 
     expect(result.success).toBe(true);
@@ -277,7 +281,7 @@ src/index.ts-3-  return new Application();
         output_mode: "content",
         "-C": 2,
       },
-      { workdir: "/test/workdir" },
+      testContext,
     );
 
     expect(result.success).toBe(true);
@@ -305,7 +309,7 @@ src/index.ts:2:export function createApp() {
         output_mode: "content",
         "-B": 1,
       },
-      { workdir: "/test/workdir" },
+      testContext,
     );
 
     expect(result.success).toBe(true);
@@ -325,7 +329,7 @@ src/index.ts-3-  return new Application();
         output_mode: "content",
         "-A": 1,
       },
-      { workdir: "/test/workdir" },
+      testContext,
     );
 
     expect(result.success).toBe(true);
@@ -343,7 +347,7 @@ src/index.ts-3-  return new Application();
         output_mode: "files_with_matches",
         head_limit: 1,
       },
-      { workdir: "/test/workdir" },
+      testContext,
     );
 
     expect(result.success).toBe(true);
@@ -362,7 +366,7 @@ src/index.ts-3-  return new Application();
         multiline: true,
         output_mode: "files_with_matches",
       },
-      { workdir: "/test/workdir" },
+      testContext,
     );
 
     expect(result.success).toBe(true);
@@ -388,7 +392,7 @@ src/index.ts-3-  return new Application();
         path: "src",
         output_mode: "files_with_matches",
       },
-      { workdir: "/test/workdir" },
+      testContext,
     );
 
     expect(result.success).toBe(true);
@@ -411,7 +415,7 @@ src/index.ts-3-  return new Application();
       {
         pattern: "NONEXISTENT_PATTERN_12345",
       },
-      { workdir: "/test/workdir" },
+      testContext,
     );
 
     expect(result.success).toBe(true);
@@ -465,7 +469,7 @@ src/index.ts-3-  return new Application();
         glob: "**/*.{ts,tsx,js,jsx}",
         output_mode: "files_with_matches",
       },
-      { workdir: "/test/workdir" },
+      testContext,
     );
 
     expect(result.success).toBe(true);
@@ -483,7 +487,7 @@ src/index.ts-3-  return new Application();
         pattern: "function\\s+\\w+",
         output_mode: "files_with_matches",
       },
-      { workdir: "/test/workdir" },
+      testContext,
     );
 
     expect(result.success).toBe(true);
@@ -503,7 +507,7 @@ tasks.md:4:- [ ] Create API endpoints
         output_mode: "content",
         "-n": true,
       },
-      { workdir: "/test/workdir" },
+      testContext,
     );
 
     expect(result.success).toBe(true);
@@ -522,7 +526,7 @@ tasks.md:4:- [ ] Create API endpoints
         pattern: "--verbose",
         output_mode: "files_with_matches",
       },
-      { workdir: "/test/workdir" },
+      testContext,
     );
 
     expect(result.success).toBe(true);
@@ -553,7 +557,7 @@ tasks.md:4:- [ ] Create API endpoints
       {
         pattern: "test",
       },
-      { workdir: "/test/workdir" },
+      testContext,
     );
 
     expect(result.success).toBe(false);

--- a/packages/agent-sdk/tests/tools/lsTool.test.ts
+++ b/packages/agent-sdk/tests/tools/lsTool.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { lsTool } from "@/tools/lsTool.js";
+import { TaskManager } from "@/services/taskManager.js";
 import type { ToolContext } from "@/tools/types.js";
 import type { Stats, Dirent } from "fs";
 
-const testContext: ToolContext = { workdir: "/test/workdir" };
+const testContext: ToolContext = {
+  workdir: "/test/workdir",
+  taskManager: new TaskManager("test-session"),
+};
 
 // Mock fs/promises
 vi.mock("fs", () => ({

--- a/packages/agent-sdk/tests/tools/lspTool.test.ts
+++ b/packages/agent-sdk/tests/tools/lspTool.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { lspTool } from "../../src/tools/lspTool.js";
+import { TaskManager } from "../../src/services/taskManager.js";
 import { ToolContext } from "../../src/tools/types.js";
 
 describe("lspTool", () => {
@@ -9,6 +10,7 @@ describe("lspTool", () => {
 
   const context: ToolContext = {
     workdir: "/test/workdir",
+    taskManager: new TaskManager("test-session"),
     lspManager: mockLspManager as unknown as ToolContext["lspManager"],
   };
 

--- a/packages/agent-sdk/tests/tools/mcpTools.test.ts
+++ b/packages/agent-sdk/tests/tools/mcpTools.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { TaskManager } from "../../src/services/taskManager.js";
 import { ToolContext, ToolPlugin } from "../../src/tools/types.js";
 import { ChatCompletionFunctionTool } from "openai/resources.js";
 
@@ -180,7 +181,10 @@ describe("McpManager - Tools Registry", () => {
         mockResult,
       );
 
-      const context: ToolContext = { workdir: "/test/workdir" };
+      const context: ToolContext = {
+        workdir: "/test/workdir",
+        taskManager: new TaskManager("test-session"),
+      };
       const result = await mcpManager.executeMcpToolByRegistry(
         "server1_tool1",
         { param: "test" },

--- a/packages/agent-sdk/tests/tools/multiEditTool.test.ts
+++ b/packages/agent-sdk/tests/tools/multiEditTool.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { multiEditTool } from "@/tools/multiEditTool.js";
+import { TaskManager } from "@/services/taskManager.js";
 import { readFile, writeFile } from "fs/promises";
 import type { ToolContext } from "@/tools/types.js";
 
@@ -17,6 +18,7 @@ describe("multiEditTool", () => {
     mockContext = {
       abortSignal: new AbortController().signal,
       workdir: "/test/workdir",
+      taskManager: new TaskManager("test-session"),
     };
   });
 

--- a/packages/agent-sdk/tests/tools/readTool.test.ts
+++ b/packages/agent-sdk/tests/tools/readTool.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { readTool } from "@/tools/readTool.js";
+import { TaskManager } from "@/services/taskManager.js";
 import { readFile, stat } from "fs/promises";
 import type { ToolContext } from "@/tools/types.js";
 
@@ -31,7 +32,10 @@ vi.mock("@/utils/fileFormat.js", () => ({
   getBinaryDocumentError: vi.fn(() => "Binary document error"),
 }));
 
-const testContext: ToolContext = { workdir: "/test/workdir" };
+const testContext: ToolContext = {
+  workdir: "/test/workdir",
+  taskManager: new TaskManager("test-session"),
+};
 
 // Mock file contents for different test scenarios
 const mockFiles: Record<string, string> = {
@@ -219,7 +223,10 @@ describe("readTool", () => {
       {
         file_path: "small.txt",
       },
-      { workdir: "/test/workdir" },
+      {
+        workdir: "/test/workdir",
+        taskManager: new TaskManager("test-session"),
+      },
     );
 
     expect(result.success).toBe(true);

--- a/packages/agent-sdk/tests/tools/skillTool.test.ts
+++ b/packages/agent-sdk/tests/tools/skillTool.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Stats } from "fs";
+import { TaskManager } from "../../src/services/taskManager.js";
 import { SkillManager } from "../../src/managers/skillManager.js";
 import { createSkillTool } from "../../src/tools/skillTool.js";
 import type { Logger } from "../../src/types/index.js";
@@ -88,7 +89,10 @@ describe("createSkillTool", () => {
   it("should format compact params correctly", async () => {
     await skillManager.initialize();
     const tool = createSkillTool(skillManager);
-    const context = { workdir: "/test" };
+    const context = {
+      workdir: "/test",
+      taskManager: new TaskManager("test-session"),
+    };
 
     const params = { skill_name: "test-skill" };
     const formatted = tool.formatCompactParams?.(params, context);
@@ -99,7 +103,10 @@ describe("createSkillTool", () => {
   it("should handle missing skill_name parameter in formatCompactParams", async () => {
     await skillManager.initialize();
     const tool = createSkillTool(skillManager);
-    const context = { workdir: "/test" };
+    const context = {
+      workdir: "/test",
+      taskManager: new TaskManager("test-session"),
+    };
 
     const params = {};
     const formatted = tool.formatCompactParams?.(params, context);
@@ -110,7 +117,10 @@ describe("createSkillTool", () => {
   it("should validate skill_name parameter", async () => {
     await skillManager.initialize();
     const tool = createSkillTool(skillManager);
-    const context = { workdir: "/test" };
+    const context = {
+      workdir: "/test",
+      taskManager: new TaskManager("test-session"),
+    };
 
     const result = await tool.execute({}, context);
 
@@ -130,7 +140,10 @@ describe("createSkillTool", () => {
     });
 
     const tool = createSkillTool(skillManager);
-    const context = { workdir: "/test" };
+    const context = {
+      workdir: "/test",
+      taskManager: new TaskManager("test-session"),
+    };
 
     const result = await tool.execute({ skill_name: "test-skill" }, context);
 
@@ -148,7 +161,10 @@ describe("createSkillTool", () => {
     );
 
     const tool = createSkillTool(skillManager);
-    const context = { workdir: "/test" };
+    const context = {
+      workdir: "/test",
+      taskManager: new TaskManager("test-session"),
+    };
 
     const result = await tool.execute({ skill_name: "test" }, context);
 

--- a/packages/agent-sdk/tests/tools/taskManagementTools.test.ts
+++ b/packages/agent-sdk/tests/tools/taskManagementTools.test.ts
@@ -21,7 +21,9 @@ vi.mock("../../src/services/taskManager.js", () => {
 });
 
 // Get the mocked instance
-const mockTaskManager = new TaskManager() as Mocked<TaskManager>;
+const mockTaskManager = new TaskManager(
+  "test-session-id",
+) as Mocked<TaskManager>;
 
 describe("Task Management Tools", () => {
   const sessionId = "test-session-id";
@@ -47,7 +49,7 @@ describe("Task Management Tools", () => {
 
       const result = await taskCreateTool.execute(args, context);
 
-      expect(mockTaskManager.createTask).toHaveBeenCalledWith(sessionId, {
+      expect(mockTaskManager.createTask).toHaveBeenCalledWith({
         subject: "Test Task",
         description: "Test Description",
         status: "in_progress",
@@ -70,7 +72,7 @@ describe("Task Management Tools", () => {
 
       const result = await taskCreateTool.execute(args, context);
 
-      expect(mockTaskManager.createTask).toHaveBeenCalledWith(sessionId, {
+      expect(mockTaskManager.createTask).toHaveBeenCalledWith({
         subject: "Minimal Task",
         description: "Minimal Description",
         status: "pending",
@@ -83,13 +85,17 @@ describe("Task Management Tools", () => {
       expect(result.success).toBe(true);
     });
 
-    it("should return error if sessionId is missing", async () => {
-      const result = await taskCreateTool.execute({}, {
+    it("should work without sessionId in context", async () => {
+      const args = {
+        subject: "Test Task",
+        description: "Test Description",
+      };
+      mockTaskManager.createTask.mockResolvedValue("1");
+      const result = await taskCreateTool.execute(args, {
         taskManager: mockTaskManager,
         workdir: "/test/workdir",
       } as ToolContext);
-      expect(result.success).toBe(false);
-      expect(result.content).toBe("Session ID not found in context.");
+      expect(result.success).toBe(true);
     });
   });
 
@@ -108,7 +114,7 @@ describe("Task Management Tools", () => {
 
       const result = await taskGetTool.execute({ id: "1" }, context);
 
-      expect(mockTaskManager.getTask).toHaveBeenCalledWith(sessionId, "1");
+      expect(mockTaskManager.getTask).toHaveBeenCalledWith("1");
       expect(result.success).toBe(true);
       expect(JSON.parse(result.content as string)).toEqual(task);
     });
@@ -144,8 +150,8 @@ describe("Task Management Tools", () => {
 
       const result = await taskUpdateTool.execute(args, context);
 
-      expect(mockTaskManager.getTask).toHaveBeenCalledWith(sessionId, "1");
-      expect(mockTaskManager.updateTask).toHaveBeenCalledWith(sessionId, {
+      expect(mockTaskManager.getTask).toHaveBeenCalledWith("1");
+      expect(mockTaskManager.updateTask).toHaveBeenCalledWith({
         ...existingTask,
         subject: "New Subject",
         status: "completed",
@@ -190,7 +196,7 @@ describe("Task Management Tools", () => {
 
       const result = await taskListTool.execute({}, context);
 
-      expect(mockTaskManager.listTasks).toHaveBeenCalledWith(sessionId);
+      expect(mockTaskManager.listTasks).toHaveBeenCalled();
       expect(result.success).toBe(true);
       expect(result.content).toBe(
         "[1] Task 1 (completed)\n[2] Task 2 (pending)",

--- a/packages/agent-sdk/tests/tools/taskOutputTool.abort.test.ts
+++ b/packages/agent-sdk/tests/tools/taskOutputTool.abort.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { taskOutputTool } from "../../src/tools/taskOutputTool.js";
+import { TaskManager } from "../../src/services/taskManager.js";
 import { BackgroundTaskManager } from "../../src/managers/backgroundTaskManager.js";
 import type { ToolContext } from "../../src/tools/types.js";
 import type { BackgroundTask } from "../../src/types/processes.js";
@@ -18,6 +19,7 @@ describe("TaskOutput Tool Abort Handling", () => {
     context = {
       backgroundTaskManager,
       workdir: "/test/workdir",
+      taskManager: new TaskManager("test-session"),
       abortSignal: abortController.signal,
     };
   });

--- a/packages/agent-sdk/tests/tools/taskTool.test.ts
+++ b/packages/agent-sdk/tests/tools/taskTool.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createTaskTool } from "../../src/tools/taskTool.js";
+import { TaskManager } from "../../src/services/taskManager.js";
 import {
   SubagentManager,
   type SubagentInstance,
@@ -16,6 +17,7 @@ describe("Task Tool Background Execution", () => {
   const mockToolContext: ToolContext = {
     abortSignal: new AbortController().signal,
     workdir: "/test/workdir",
+    taskManager: new TaskManager("test-session"),
   };
 
   const gpConfig: SubagentConfiguration = {

--- a/packages/agent-sdk/tests/tools/writeTool.test.ts
+++ b/packages/agent-sdk/tests/tools/writeTool.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { writeTool } from "@/tools/writeTool.js";
+import { TaskManager } from "@/services/taskManager.js";
 import { readFile, writeFile, mkdir } from "fs/promises";
 import type { ToolContext } from "@/tools/types.js";
 
-const testContext: ToolContext = { workdir: "/test/workdir" };
+const testContext: ToolContext = {
+  workdir: "/test/workdir",
+  taskManager: new TaskManager("test-session"),
+};
 
 // Mock fs/promises
 vi.mock("fs/promises");
@@ -15,6 +19,7 @@ describe("writeTool", () => {
     mockContext = {
       abortSignal: new AbortController().signal,
       workdir: "/test/workdir",
+      taskManager: new TaskManager("test-session"),
     };
   });
 


### PR DESCRIPTION
This PR refactors the TaskManager to use a stable taskListId (derived from the initial sessionId) instead of the volatile sessionId. This ensures that tasks are persisted correctly even after session compression.

Key changes:
- TaskManager now accepts taskListId in constructor.
- Removed sessionId from TaskManager method signatures.
- Propagated TaskManager instance through Agent, AIManager, and SubagentManager.
- Updated ToolContext to require TaskManager.
- Fixed all affected tests and resolved ESLint/TypeScript issues.