### PR TITLE
fix: prevent Esc key from aborting AI when manager UIs are open

### DIFF
--- a/packages/code/src/managers/InputManager.ts
+++ b/packages/code/src/managers/InputManager.ts
@@ -997,7 +997,13 @@ export class InputManager {
     }
 
     // Handle interrupt request - use Esc key to interrupt AI request or command
-    if (key.escape && (isLoading || isCommandRunning)) {
+    if (
+      key.escape &&
+      (isLoading || isCommandRunning) &&
+      !this.showBackgroundTaskManager &&
+      !this.showMcpManager &&
+      !this.showRewindManager
+    ) {
       // Unified interrupt for AI message generation and command execution
       this.callbacks.onAbortMessage?.();
       return true;

--- a/packages/code/tests/managers/InputManager.test.ts
+++ b/packages/code/tests/managers/InputManager.test.ts
@@ -622,6 +622,78 @@ describe("InputManager", () => {
       expect(mockCallbacks.onAbortMessage).toHaveBeenCalled();
     });
 
+    it("should NOT handle escape to abort during loading if background task manager is active", async () => {
+      manager.setShowBackgroundTaskManager(true);
+      const mockKey: Key = {
+        escape: true,
+        return: false,
+        upArrow: false,
+        downArrow: false,
+        leftArrow: false,
+        rightArrow: false,
+        ctrl: false,
+        backspace: false,
+        delete: false,
+        pageDown: false,
+        pageUp: false,
+        shift: false,
+        tab: false,
+        meta: false,
+      };
+
+      await manager.handleInput("", mockKey, [], true, false); // isLoading = true
+
+      expect(mockCallbacks.onAbortMessage).not.toHaveBeenCalled();
+    });
+
+    it("should NOT handle escape to abort during loading if MCP manager is active", async () => {
+      manager.setShowMcpManager(true);
+      const mockKey: Key = {
+        escape: true,
+        return: false,
+        upArrow: false,
+        downArrow: false,
+        leftArrow: false,
+        rightArrow: false,
+        ctrl: false,
+        backspace: false,
+        delete: false,
+        pageDown: false,
+        pageUp: false,
+        shift: false,
+        tab: false,
+        meta: false,
+      };
+
+      await manager.handleInput("", mockKey, [], true, false); // isLoading = true
+
+      expect(mockCallbacks.onAbortMessage).not.toHaveBeenCalled();
+    });
+
+    it("should NOT handle escape to abort during loading if Rewind manager is active", async () => {
+      manager.setShowRewindManager(true);
+      const mockKey: Key = {
+        escape: true,
+        return: false,
+        upArrow: false,
+        downArrow: false,
+        leftArrow: false,
+        rightArrow: false,
+        ctrl: false,
+        backspace: false,
+        delete: false,
+        pageDown: false,
+        pageUp: false,
+        shift: false,
+        tab: false,
+        meta: false,
+      };
+
+      await manager.handleInput("", mockKey, [], true, false); // isLoading = true
+
+      expect(mockCallbacks.onAbortMessage).not.toHaveBeenCalled();
+    });
+
     it("should prevent submission when loading", async () => {
       manager.insertTextAtCursor("test");
 


### PR DESCRIPTION
This PR fixes a bug where pressing 'Esc' to close background task, MCP, or Rewind manager UIs would also trigger an AI abort signal if the AI was loading or a command was running. Added unit tests to verify the fix.