### PR TITLE
feat: support WAVE_TASK_LIST_ID env var for task management

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -223,7 +223,13 @@ export class Agent {
       memoryRuleManager: this.memoryRuleManager,
     });
 
-    this.taskManager = new TaskManager(this.messageManager.getSessionId());
+    // Resolve taskListId once during construction to ensure stability
+    const resolvedTaskListId =
+      this.configurationService.getEnvironmentVars().WAVE_TASK_LIST_ID ||
+      process.env.WAVE_TASK_LIST_ID ||
+      this.messageManager.getSessionId();
+
+    this.taskManager = new TaskManager(resolvedTaskListId);
     this.taskManager.on("tasksChange", async () => {
       const tasks = await this.taskManager.listTasks();
       this.options.callbacks?.onSessionTasksChange?.(tasks);
@@ -1301,5 +1307,12 @@ export class Agent {
     } else {
       this.permissionManager.setPlanFilePath(undefined);
     }
+  }
+
+  /**
+   * Get the current task list ID
+   */
+  public get taskListId(): string {
+    return this.taskManager.getTaskListId();
   }
 }

--- a/packages/agent-sdk/src/services/taskManager.ts
+++ b/packages/agent-sdk/src/services/taskManager.ts
@@ -15,6 +15,10 @@ export class TaskManager extends EventEmitter {
     this.baseDir = join(homedir(), ".wave", "tasks");
   }
 
+  public getTaskListId(): string {
+    return this.taskListId;
+  }
+
   private getSessionDir(): string {
     return join(this.baseDir, this.taskListId);
   }

--- a/packages/agent-sdk/tests/agent/agent.taskListId.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.taskListId.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Agent } from "../../src/agent.js";
+import { TaskManager } from "../../src/services/taskManager.js";
+
+// Mock dependencies to prevent real I/O operations
+vi.mock("@/services/aiService", () => ({
+  createChatCompletion: vi.fn(),
+}));
+
+vi.mock("../../src/services/session.js", () => ({
+  generateSessionId: vi.fn(() => "mock-session-id"),
+  loadSessionFromJsonl: vi.fn(),
+  appendMessages: vi.fn(),
+  getLatestSessionFromJsonl: vi.fn(),
+  listSessionsFromJsonl: vi.fn(),
+  deleteSessionFromJsonl: vi.fn(),
+  sessionExistsInJsonl: vi.fn(),
+  cleanupExpiredSessionsFromJsonl: vi.fn(() => Promise.resolve(0)),
+  getSessionFilePath: vi.fn(),
+  ensureSessionDir: vi.fn(),
+  listSessions: vi.fn(),
+  cleanupEmptyProjectDirectories: vi.fn(),
+  handleSessionRestoration: vi.fn().mockResolvedValue({
+    id: "mock-session-id",
+    messages: [],
+    metadata: {
+      workdir: "/mock",
+      lastActiveAt: new Date().toISOString(),
+      latestTotalTokens: 0,
+    },
+  }),
+  SESSION_DIR: "/mock/session/dir",
+}));
+
+// Mock TaskManager to capture the taskListId passed to it
+vi.mock("../../src/services/taskManager.js", () => {
+  const mockTaskManager = {
+    on: vi.fn(),
+    listTasks: vi.fn().mockResolvedValue([]),
+    getTaskListId: vi.fn(),
+  };
+  return {
+    TaskManager: vi.fn().mockImplementation(function (taskListId: string) {
+      (mockTaskManager as { taskListId?: string }).taskListId = taskListId; // Expose for verification
+      mockTaskManager.getTaskListId.mockReturnValue(taskListId);
+      return mockTaskManager;
+    }),
+  };
+});
+
+describe("Agent - Task List ID Resolution", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should use WAVE_TASK_LIST_ID from environment if set", async () => {
+    process.env.WAVE_TASK_LIST_ID = "custom-task-list-id";
+
+    const agent = await Agent.create({
+      apiKey: "test-key",
+      workdir: "/mock",
+    });
+
+    expect(TaskManager).toHaveBeenCalledWith("custom-task-list-id");
+    expect(agent.taskListId).toBe("custom-task-list-id");
+
+    await agent.destroy();
+  });
+
+  it("should fallback to sessionId if WAVE_TASK_LIST_ID is not set", async () => {
+    delete process.env.WAVE_TASK_LIST_ID;
+
+    const agent = await Agent.create({
+      apiKey: "test-key",
+      workdir: "/mock",
+    });
+
+    // The mock session ID is "mock-session-id"
+    expect(TaskManager).toHaveBeenCalledWith("mock-session-id");
+    expect(agent.taskListId).toBe("mock-session-id");
+
+    await agent.destroy();
+  });
+
+  it("should maintain stable taskListId even if sessionId changes", async () => {
+    delete process.env.WAVE_TASK_LIST_ID;
+
+    const agent = await Agent.create({
+      apiKey: "test-key",
+      workdir: "/mock",
+    });
+
+    const initialTaskListId = agent.taskListId;
+    expect(initialTaskListId).toBe("mock-session-id");
+
+    // Simulate sessionId change (e.g. via messageManager internal state change)
+    // Since we can't easily trigger compression in a unit test, we verify that
+    // TaskManager was only initialized once and agent.taskListId returns the stable value.
+
+    // We check that TaskManager was called with the initial ID
+    expect(TaskManager).toHaveBeenCalledWith("mock-session-id");
+
+    // Even if we were to mock messageManager.getSessionId to return something else now,
+    // the agent's taskListId logic in constructor has already run.
+
+    await agent.destroy();
+  });
+});

--- a/specs/063-task-management-tools/spec.md
+++ b/specs/063-task-management-tools/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `063-task-management-tools`  
 **Created**: 2026-02-11  
 **Status**: Draft  
-**Input**: User description: "support tools: - TaskCreate: For creating new tasks - TaskGet: For retrieving task details - TaskUpdate: For updating task status and adding comments - TaskList: For listing all tasks, you can refer to tmp.js . all tasks should be stored in ~/.wave/tasks/{sessionId}/{taskId}.json, similar like ~/.claude/tasks, you can look for that. Also remove current todowrite tool."
+**Input**: User description: "support tools: - TaskCreate: For creating new tasks - TaskGet: For retrieving task details - TaskUpdate: For updating task status and adding comments - TaskList: For listing all tasks, you can refer to tmp.js . all tasks should be stored in ~/.wave/tasks/{taskListId}/{taskId}.json, similar like ~/.claude/tasks, you can look for that. Also remove current todowrite tool. task list id should be set by agent sdk and env var WAVE_TASK_LIST_ID"
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -17,7 +17,7 @@ As a user, I want to create a new task so that I can track my progress on a spec
 
 **Acceptance Scenarios**:
 
-1. **Given** a session is active, **When** I call TaskCreate with a subject and description, **Then** a new task is created with a unique ID and stored in `~/.wave/tasks/{sessionId}/{taskId}.json`.
+1. **Given** a session is active, **When** I call TaskCreate with a subject and description, **Then** a new task is created with a unique ID and stored in `~/.wave/tasks/{taskListId}/{taskId}.json`.
 2. **Given** a task has been created, **When** I call TaskGet with the taskId, **Then** I receive the full details of that task.
 
 ---
@@ -47,7 +47,7 @@ As a user, I want to see a list of all tasks for my current session so that I ca
 
 **Acceptance Scenarios**:
 
-1. **Given** multiple tasks exist for the current session, **When** I call TaskList, **Then** I receive a summary list of all tasks including their IDs, subjects, and current statuses.
+1. **Given** multiple tasks exist for the current task list, **When** I call TaskList, **Then** I receive a summary list of all tasks including their IDs, subjects, and current statuses.
 
 ---
 
@@ -79,16 +79,20 @@ As a system maintainer, I want to remove the legacy TodoWrite tool so that the a
 ### Functional Requirements
 
 - **FR-001**: System MUST provide a `TaskCreate` tool that accepts `subject`, `description`, `activeForm`, and optional `metadata`.
-- **FR-002**: System MUST store tasks as JSON files in `~/.wave/tasks/{sessionId}/{taskId}.json`.
+- **FR-002**: System MUST store tasks as JSON files in `~/.wave/tasks/{taskListId}/{taskId}.json`.
 - **FR-003**: System MUST provide a `TaskGet` tool that retrieves all information for a specific `taskId`.
 - **FR-004**: System MUST provide a `TaskUpdate` tool that allows updating `status`, `subject`, `description`, `activeForm`, `owner`, and `metadata`.
 - **FR-005**: System MUST allow managing task dependencies via `addBlocks` and `addBlockedBy` in `TaskUpdate`.
-- **FR-006**: System MUST provide a `TaskList` tool that returns all tasks associated with the current `sessionId`.
+- **FR-006**: System MUST provide a `TaskList` tool that returns all tasks associated with the current `taskListId`.
 - **FR-007**: Tasks MUST include fields: `id`, `subject`, `description`, `status`, `activeForm`, `owner`, `blocks`, `blockedBy`, and `metadata`.
 - **FR-008**: The system MUST automatically create the necessary directory structure if it does not exist.
 - **FR-009**: The system MUST remove the `TodoWrite` tool definition from the agent's tool registry.
 - **FR-010**: The system MUST remove any code implementation specifically tied to the `TodoWrite` tool.
 - **FR-011**: The system MUST update internal documentation and system prompts to remove references to `TodoWrite`.
+- **FR-012**: The system MUST determine `taskListId` using the following priority:
+  1. Value of `WAVE_TASK_LIST_ID` environment variable.
+  2. Fallback to the initial `sessionId` provided by the `MessageManager` at agent initialization.
+- **FR-013**: The `taskListId` MUST remain stable for the lifetime of the agent instance. Even if the `sessionId` changes (e.g., due to message compression), the `taskListId` MUST NOT change.
 
 ### Key Entities *(include if feature involves data)*
 
@@ -102,5 +106,5 @@ As a system maintainer, I want to remove the legacy TodoWrite tool so that the a
   - **blocks**: List of task IDs that depend on this task (array of strings).
   - **blockedBy**: List of task IDs that this task depends on (array of strings).
   - **metadata**: Arbitrary key-value pairs (object).
-- **Session**: A grouping mechanism for tasks, identified by `sessionId`.
+- **Task List**: A grouping mechanism for tasks, identified by `taskListId`.
 - **Agent Tool Registry**: The collection of tools available to the agent.


### PR DESCRIPTION
This PR adds support for the WAVE_TASK_LIST_ID environment variable to determine the task list storage directory. It also ensures that the task list ID remains stable throughout the agent's lifecycle, even if the session ID changes due to compression.