### PR TITLE
fix: decouple background subagent lifecycle from parent abort signal

### DIFF
--- a/packages/agent-sdk/src/managers/backgroundTaskManager.ts
+++ b/packages/agent-sdk/src/managers/backgroundTaskManager.ts
@@ -283,6 +283,16 @@ export class BackgroundTaskManager {
       // Subagent termination logic will be handled by aborting the AI loop
       // which is already managed by the SubagentManager and AIManager.
       // Here we just update the status.
+      const subagentId = task.subagentId;
+      if (subagentId) {
+        const subagentManager = task.subagentManager;
+        if (subagentManager) {
+          const instance = subagentManager.getInstance(subagentId);
+          if (instance) {
+            instance.aiManager.abortAIMessage();
+          }
+        }
+      }
       task.status = "killed";
       task.endTime = Date.now();
       task.runtime = task.endTime - task.startTime;

--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -303,6 +303,8 @@ export class SubagentManager {
           description: instance.configuration.description,
           stdout: "",
           stderr: "",
+          subagentId: instance.subagentId,
+          subagentManager: this,
         });
 
         instance.backgroundTaskId = taskId;
@@ -368,6 +370,8 @@ export class SubagentManager {
       description: instance.configuration.description,
       stdout: "",
       stderr: "",
+      subagentId: instance.subagentId,
+      subagentManager: this,
     });
 
     instance.backgroundTaskId = taskId;
@@ -387,7 +391,8 @@ export class SubagentManager {
   ): Promise<string> {
     // Set up consolidated abort handler to prevent listener accumulation
     let abortCleanup: (() => void) | undefined;
-    if (abortSignal) {
+    // Only link to parent abort signal if NOT running in background
+    if (abortSignal && !instance.backgroundTaskId) {
       abortCleanup = addConsolidatedAbortListener(abortSignal, [
         () => {
           // Update status to aborted
@@ -444,7 +449,7 @@ export class SubagentManager {
       });
 
       // If we have an abort signal, race against it using utilities to prevent listener accumulation
-      if (abortSignal) {
+      if (abortSignal && !instance.backgroundTaskId) {
         await Promise.race([
           executeAI,
           createAbortPromise(abortSignal, "Task was aborted"),

--- a/packages/agent-sdk/src/types/processes.ts
+++ b/packages/agent-sdk/src/types/processes.ts
@@ -12,7 +12,7 @@ export type BackgroundTaskStatus =
   | "killed";
 export type BackgroundTaskType = "shell" | "subagent";
 
-export interface BackgroundTask {
+export interface BackgroundTaskBase {
   id: string;
   type: BackgroundTaskType;
   status: BackgroundTaskStatus;
@@ -26,19 +26,28 @@ export interface BackgroundTask {
   runtime?: number;
 }
 
-export interface BackgroundShell extends BackgroundTask {
+export interface BackgroundShell extends BackgroundTaskBase {
   type: "shell";
   process: ChildProcess;
 }
 
+export interface BackgroundSubagent extends BackgroundTaskBase {
+  type: "subagent";
+  subagentId: string;
+  subagentManager: {
+    getInstance: (subagentId: string) => {
+      aiManager: {
+        abortAIMessage: () => void;
+      };
+    } | null;
+  };
+}
+
+export type BackgroundTask = BackgroundShell | BackgroundSubagent;
+
 export interface ForegroundTask {
   id: string;
   backgroundHandler: () => Promise<void>;
-}
-
-export interface IForegroundTaskManager {
-  registerForegroundTask(task: ForegroundTask): void;
-  unregisterForegroundTask(id: string): void;
 }
 
 export interface IForegroundTaskManager {

--- a/packages/agent-sdk/tests/managers/backgroundTaskManager.test.ts
+++ b/packages/agent-sdk/tests/managers/backgroundTaskManager.test.ts
@@ -29,6 +29,8 @@ describe("BackgroundTaskManager", () => {
       startTime: Date.now(),
       stdout: "",
       stderr: "",
+      subagentId: "sub_1",
+      subagentManager: { getInstance: vi.fn() },
     };
     manager.addTask(task);
     expect(manager.getTask("task_1")).toEqual(task);
@@ -52,6 +54,8 @@ describe("BackgroundTaskManager", () => {
       startTime: Date.now(),
       stdout: "",
       stderr: "",
+      subagentId: "sub_1",
+      subagentManager: { getInstance: vi.fn() },
     };
     manager.addTask(task);
     const result = manager.stopTask("task_1");
@@ -67,6 +71,8 @@ describe("BackgroundTaskManager", () => {
       startTime: Date.now(),
       stdout: "line1\nline2\nmatch",
       stderr: "error1\nerror2",
+      subagentId: "sub_1",
+      subagentManager: { getInstance: vi.fn() },
     };
     manager.addTask(task);
     const output = manager.getOutput("task_1", "match");
@@ -82,6 +88,8 @@ describe("BackgroundTaskManager", () => {
       startTime: Date.now(),
       stdout: "",
       stderr: "",
+      subagentId: "sub_1",
+      subagentManager: { getInstance: vi.fn() },
     };
     manager.addTask(task);
     manager.cleanup();
@@ -97,6 +105,8 @@ describe("BackgroundTaskManager", () => {
       startTime: Date.now(),
       stdout: "test",
       stderr: "",
+      subagentId: "sub_1",
+      subagentManager: { getInstance: vi.fn() },
     };
     manager.addTask(task);
     const output = manager.getOutput("task_1", "["); // Invalid regex
@@ -119,6 +129,8 @@ describe("BackgroundTaskManager", () => {
       startTime: Date.now(),
       stdout: "",
       stderr: "",
+      subagentId: "sub_1",
+      subagentManager: { getInstance: vi.fn() },
     };
     manager.addTask(task);
     expect(manager.stopTask("task_1")).toBe(false);

--- a/packages/agent-sdk/tests/managers/subagentManager.abort.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.abort.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskManager } from "../../src/services/taskManager.js";
+import { SubagentManager } from "../../src/managers/subagentManager.js";
+import { MessageManager } from "../../src/managers/messageManager.js";
+import { ToolManager } from "../../src/managers/toolManager.js";
+import { BackgroundTaskManager } from "../../src/managers/backgroundTaskManager.js";
+import type { SubagentConfiguration } from "../../src/utils/subagentParser.js";
+
+// Mock dependencies
+vi.mock("../../src/managers/messageManager.js");
+vi.mock("../../src/managers/toolManager.js");
+vi.mock("../../src/managers/backgroundTaskManager.js");
+vi.mock("../../src/managers/aiManager.js", () => ({
+  AIManager: vi.fn().mockImplementation(function () {
+    return {
+      sendAIMessage: vi.fn().mockImplementation(async () => {
+        // Simulate some work
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        return "Test response";
+      }),
+      abortAIMessage: vi.fn(),
+    };
+  }),
+}));
+
+describe("SubagentManager - Abort Logic", () => {
+  let subagentManager: SubagentManager;
+  let mockMessageManager: MessageManager;
+  let mockToolManager: ToolManager;
+  let mockBackgroundTaskManager: BackgroundTaskManager;
+
+  const testConfig: SubagentConfiguration = {
+    name: "TestAgent",
+    description: "Test agent",
+    systemPrompt: "System prompt",
+    tools: ["Read"],
+    model: "inherit",
+    filePath: "/test/agent.md",
+    scope: "user",
+    priority: 1,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockMessageManager = {
+      addSubagentBlock: vi.fn(),
+      updateSubagentBlock: vi.fn(),
+      getSessionId: vi.fn().mockReturnValue("parent-session-id"),
+      addUserMessage: vi.fn(),
+      getMessages: vi
+        .fn()
+        .mockReturnValue([
+          { role: "assistant", blocks: [{ type: "text", content: "Done" }] },
+        ]),
+    } as unknown as MessageManager;
+
+    mockToolManager = {
+      list: vi.fn(() => [{ name: "Read" }]),
+      getPermissionManager: vi.fn(),
+    } as unknown as ToolManager;
+
+    mockBackgroundTaskManager = {
+      generateId: vi.fn().mockReturnValue("task_123"),
+      addTask: vi.fn(),
+      getTask: vi.fn(),
+      stopTask: vi.fn(),
+    } as unknown as BackgroundTaskManager;
+
+    const taskManager = {
+      on: vi.fn(),
+      listTasks: vi.fn().mockResolvedValue([]),
+    } as unknown as TaskManager;
+
+    subagentManager = new SubagentManager({
+      workdir: "/test",
+      parentToolManager: mockToolManager,
+      parentMessageManager: mockMessageManager,
+      taskManager,
+      backgroundTaskManager: mockBackgroundTaskManager,
+      getGatewayConfig: () => ({ apiKey: "test", baseURL: "test" }),
+      getModelConfig: () => ({
+        agentModel: "test-model",
+        fastModel: "test-fast-model",
+      }),
+      getMaxInputTokens: () => 1000,
+      getLanguage: () => "en",
+    });
+  });
+
+  it("should abort subagent when NOT in background and parent aborts", async () => {
+    const instance = await subagentManager.createInstance(testConfig, {
+      description: "d",
+      prompt: "p",
+      subagent_type: "t",
+    });
+
+    const abortController = new AbortController();
+
+    const executePromise = subagentManager.executeTask(
+      instance,
+      "test prompt",
+      abortController.signal,
+      false,
+    );
+
+    // Abort immediately
+    abortController.abort();
+
+    await expect(executePromise).rejects.toThrow("Task was aborted");
+
+    const aiManager = instance.aiManager;
+    expect(aiManager.abortAIMessage).toHaveBeenCalled();
+    expect(mockMessageManager.updateSubagentBlock).toHaveBeenCalledWith(
+      instance.subagentId,
+      {
+        status: "aborted",
+      },
+    );
+  });
+
+  it("should NOT abort subagent when in background and parent aborts", async () => {
+    const instance = await subagentManager.createInstance(testConfig, {
+      description: "d",
+      prompt: "p",
+      subagent_type: "t",
+    });
+
+    const abortController = new AbortController();
+
+    // Execute in background
+    const taskId = await subagentManager.executeTask(
+      instance,
+      "test prompt",
+      abortController.signal,
+      true,
+    );
+    expect(taskId).toBe("task_123");
+
+    // Abort the parent signal
+    abortController.abort();
+
+    // Wait a bit to ensure any async listeners would have fired
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const aiManager = instance.aiManager;
+    // Should NOT have been called because it's in background
+    expect(aiManager.abortAIMessage).not.toHaveBeenCalled();
+
+    // Status should NOT be aborted in parent block
+    // Note: updateSubagentBlock might have been called with status: 'active' earlier
+    const abortedCalls = vi
+      .mocked(mockMessageManager.updateSubagentBlock)
+      .mock.calls.filter((call) => call[1].status === "aborted");
+    expect(abortedCalls.length).toBe(0);
+  });
+
+  it("should abort subagent when stopTask is called on background task", async () => {
+    const instance = await subagentManager.createInstance(testConfig, {
+      description: "d",
+      prompt: "p",
+      subagent_type: "t",
+    });
+
+    // Mock background task manager to actually store and retrieve the task
+    const tasks = new Map();
+    vi.mocked(mockBackgroundTaskManager.addTask).mockImplementation((task) => {
+      tasks.set(task.id, task);
+    });
+    vi.mocked(mockBackgroundTaskManager.getTask).mockImplementation((id) =>
+      tasks.get(id),
+    );
+
+    // Real BackgroundTaskManager for stopTask logic
+    // Adopt the mock's behavior for stopTask
+    vi.mocked(mockBackgroundTaskManager.stopTask).mockImplementation((id) => {
+      const task = tasks.get(id);
+      if (task && task.type === "subagent") {
+        const subagentId = task.subagentId;
+        const subagentManager = task.subagentManager;
+        const instance = subagentManager.getInstance(subagentId);
+        if (instance) {
+          instance.aiManager.abortAIMessage();
+        }
+        task.status = "killed";
+        return true;
+      }
+      return false;
+    });
+
+    await subagentManager.executeTask(instance, "test prompt", undefined, true);
+
+    // Wait for background task to start
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    mockBackgroundTaskManager.stopTask("task_123");
+
+    const aiManager = instance.aiManager;
+    expect(aiManager.abortAIMessage).toHaveBeenCalled();
+    expect(tasks.get("task_123").status).toBe("killed");
+  });
+});

--- a/packages/agent-sdk/tests/tools/taskOutputTool.abort.test.ts
+++ b/packages/agent-sdk/tests/tools/taskOutputTool.abort.test.ts
@@ -3,7 +3,10 @@ import { taskOutputTool } from "../../src/tools/taskOutputTool.js";
 import { TaskManager } from "../../src/services/taskManager.js";
 import { BackgroundTaskManager } from "../../src/managers/backgroundTaskManager.js";
 import type { ToolContext } from "../../src/tools/types.js";
-import type { BackgroundTask } from "../../src/types/processes.js";
+import type {
+  BackgroundTask,
+  BackgroundShell,
+} from "../../src/types/processes.js";
 
 describe("TaskOutput Tool Abort Handling", () => {
   let backgroundTaskManager: BackgroundTaskManager;
@@ -38,6 +41,7 @@ describe("TaskOutput Tool Abort Handling", () => {
       command: "sleep 100",
       stdout: "",
       stderr: "",
+      process: { kill: vi.fn() } as unknown as BackgroundShell["process"],
     });
 
     const executePromise = taskOutputTool.execute(
@@ -70,6 +74,7 @@ describe("TaskOutput Tool Abort Handling", () => {
       command: "sleep 100",
       stdout: "",
       stderr: "",
+      process: { kill: vi.fn() } as unknown as BackgroundShell["process"],
     });
 
     abortController.abort();
@@ -96,6 +101,7 @@ describe("TaskOutput Tool Abort Handling", () => {
       command: "echo hello",
       stdout: "hello",
       stderr: "",
+      process: { kill: vi.fn() } as unknown as BackgroundShell["process"],
     };
     backgroundTaskManager.addTask(task);
 
@@ -136,6 +142,7 @@ describe("TaskOutput Tool Abort Handling", () => {
       command: "sleep 100",
       stdout: "",
       stderr: "",
+      process: { kill: vi.fn() } as unknown as BackgroundShell["process"],
     });
 
     const removeEventListenerSpy = vi.spyOn(

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -238,14 +238,17 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         onSessionTasksChange: (tasks) => {
           setSessionTasks([...tasks]);
         },
-        onSubagentMessagesChange: (subagentId, messages) => {
+        onSubagentMessagesChange: (subagentId: string, messages: Message[]) => {
           logger.debug("onSubagentMessagesChange", subagentId, messages.length);
           setSubagentMessages((prev) => ({
             ...prev,
             [subagentId]: [...messages],
           }));
         },
-        onSubagentLatestTotalTokensChange: (subagentId, tokens) => {
+        onSubagentLatestTotalTokensChange: (
+          subagentId: string,
+          tokens: number,
+        ) => {
           setSubagentLatestTokens((prev) => ({
             ...prev,
             [subagentId]: tokens,

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -6,7 +6,7 @@ import {
   useChat,
   ChatContextType,
 } from "../../src/contexts/useChat.js";
-import { Agent } from "wave-agent-sdk";
+import { Agent, BackgroundShell } from "wave-agent-sdk";
 import { AppProvider } from "../../src/contexts/useAppConfig.js";
 import { useInput } from "ink";
 
@@ -203,6 +203,7 @@ describe("ChatProvider", () => {
         stdout: "",
         stderr: "",
         startTime: 0,
+        process: {} as unknown as BackgroundShell["process"],
       },
     ];
     callbacks.onTasksChange!(newTasks);


### PR DESCRIPTION
This PR ensures that background subagents are not terminated when the parent message is aborted (e.g., via ESC key). It also enables explicit termination of background subagents through the Background Task Manager.