### PR TITLE
feat: show full compression block and remove prefix in API conversion

### DIFF
--- a/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
+++ b/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
@@ -58,7 +58,7 @@ export function convertMessagesForAPI(
       if (compressBlock && compressBlock.type === "compress") {
         recentMessages.unshift({
           role: "assistant",
-          content: `[Compressed Message Summary] ${compressBlock.content}`,
+          content: compressBlock.content,
         });
       }
       break;

--- a/packages/agent-sdk/tests/agent/agent.compression.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.compression.test.ts
@@ -501,7 +501,7 @@ describe("Agent Message Compression Tests", () => {
     // The first message should be the compressed assistant message
     expect(messagesPassedToCallAgent[0].role).toBe("assistant");
     expect(messagesPassedToCallAgent[0].content).toContain(
-      "[Compressed Message Summary]",
+      "Compressed content: This contains summary information of previous multi-round conversations.",
     );
 
     // The last message should be the second user message we added

--- a/packages/code/src/components/CompressDisplay.tsx
+++ b/packages/code/src/components/CompressDisplay.tsx
@@ -7,25 +7,16 @@ interface CompressDisplayProps {
   isExpanded?: boolean;
 }
 
-export const CompressDisplay: React.FC<CompressDisplayProps> = ({
-  block,
-  isExpanded = false,
-}) => {
+export const CompressDisplay: React.FC<CompressDisplayProps> = ({ block }) => {
   const { content } = block;
-  const MAX_LINES = 3; // Set maximum display lines for compressed content
 
-  const { displayContent, isOverflowing } = useMemo(() => {
+  const { displayContent } = useMemo(() => {
     if (!content) {
-      return { displayContent: "", isOverflowing: false };
+      return { displayContent: "" };
     }
 
-    const lines = content.split("\n");
-    const overflow = !isExpanded && lines.length > MAX_LINES;
-
-    const display = overflow ? lines.slice(0, MAX_LINES).join("\n") : content;
-
-    return { displayContent: display, isOverflowing: overflow };
-  }, [content, isExpanded]);
+    return { displayContent: content };
+  }, [content]);
 
   return (
     <Box flexDirection="column">
@@ -43,14 +34,6 @@ export const CompressDisplay: React.FC<CompressDisplayProps> = ({
           >
             <Text color="white">{displayContent}</Text>
           </Box>
-          {isOverflowing && (
-            <Box paddingLeft={2} marginTop={1}>
-              <Text color="yellow" dimColor>
-                Content truncated ({content.split("\n").length} lines total,
-                showing first {MAX_LINES} lines. Press Ctrl+O to expand.
-              </Text>
-            </Box>
-          )}
         </Box>
       )}
     </Box>

--- a/packages/code/tests/components/CompressDisplay.test.tsx
+++ b/packages/code/tests/components/CompressDisplay.test.tsx
@@ -11,38 +11,19 @@ describe("CompressDisplay", () => {
       sessionId: "test-session",
     };
     const { lastFrame } = render(<CompressDisplay block={block} />);
-    expect(lastFrame()).toContain("📦 Compressed Messages");
-    expect(lastFrame()).toContain("Compressed content");
-  });
-
-  it("should truncate content when not expanded", () => {
-    const longContent = "line 1\nline 2\nline 3\nline 4\nline 5";
-    const block = {
-      type: "compress" as const,
-      content: longContent,
-      sessionId: "test-session",
-    };
-    const { lastFrame } = render(
-      <CompressDisplay block={block} isExpanded={false} />,
-    );
     const frame = lastFrame();
-    expect(frame).toContain("Content truncated");
-    expect(frame).toContain("5 lines total");
-    expect(frame).toContain("showing first 3 lines");
-    expect(frame).toContain("line 1");
-    expect(frame).not.toContain("line 4");
+    expect(frame).toContain("📦 Compressed Messages");
+    expect(frame).toContain("Compressed content");
   });
 
-  it("should not truncate when expanded", () => {
+  it("should show full content and not truncate", () => {
     const longContent = "line 1\nline 2\nline 3\nline 4\nline 5";
     const block = {
       type: "compress" as const,
       content: longContent,
       sessionId: "test-session",
     };
-    const { lastFrame } = render(
-      <CompressDisplay block={block} isExpanded={true} />,
-    );
+    const { lastFrame } = render(<CompressDisplay block={block} />);
     const frame = lastFrame();
     expect(frame).not.toContain("Content truncated");
     expect(frame).toContain("line 1");


### PR DESCRIPTION
This PR improves the compression block display by showing it in full height and removes the '[Compressed Message Summary]' prefix when converting messages for the API.