### PR TITLE
feat: hide completed tasks in task list UI

### DIFF
--- a/packages/code/src/components/TaskList.tsx
+++ b/packages/code/src/components/TaskList.tsx
@@ -39,9 +39,14 @@ export const TaskList: React.FC = () => {
     return text.slice(0, maxWidth - 3) + "...";
   };
 
+  const visibleTasks = tasks.filter(
+    (task) => task.status !== "completed" && task.status !== "deleted",
+  );
+  const completedCount = tasks.length - visibleTasks.length;
+
   return (
     <Box flexDirection="column">
-      {tasks.map((task) => {
+      {visibleTasks.map((task) => {
         const isDimmed =
           task.status === "completed" || task.status === "deleted";
         const isBlocked = task.blockedBy && task.blockedBy.length > 0;
@@ -65,6 +70,14 @@ export const TaskList: React.FC = () => {
           </Box>
         );
       })}
+      {completedCount > 0 && (
+        <Box gap={1}>
+          <Text color="green">✓</Text>
+          <Text dimColor color="gray">
+            {completedCount} completed {completedCount === 1 ? "task" : "tasks"}
+          </Text>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/packages/code/tests/components/TaskList.test.tsx
+++ b/packages/code/tests/components/TaskList.test.tsx
@@ -93,8 +93,9 @@ describe("TaskList", () => {
 
     expect(output).toContain("○ Pending Task");
     expect(output).toContain("● In Progress Task");
-    expect(output).toContain("✓ Completed Task");
-    expect(output).toContain("✕ Deleted Task");
+    expect(output).toContain("✓ 2 completed tasks");
+    expect(output).not.toContain("Completed Task");
+    expect(output).not.toContain("Deleted Task");
   });
 
   it("should truncate long task subjects", () => {

--- a/packages/code/tests/integration/taskList.test.tsx
+++ b/packages/code/tests/integration/taskList.test.tsx
@@ -102,7 +102,8 @@ describe("TaskList Integration", () => {
       const output = stripAnsiColors(lastFrame() || "");
       expect(output).toContain("○ First Task");
       expect(output).toContain("● Second Task");
-      expect(output).toContain("✓ Third Task");
+      expect(output).toContain("✓ 1 completed task");
+      expect(output).not.toContain("Third Task");
     });
   });
 
@@ -135,7 +136,10 @@ describe("TaskList Integration", () => {
     // Update task status
     onSessionTasksChangeCallback([{ ...mockTasks[0], status: "completed" }]);
     await vi.waitFor(() => {
-      expect(stripAnsiColors(lastFrame() || "")).toContain("✓ First Task");
+      expect(stripAnsiColors(lastFrame() || "")).toContain(
+        "✓ 1 completed task",
+      );
+      expect(stripAnsiColors(lastFrame() || "")).not.toContain("First Task");
     });
 
     // Remove all tasks


### PR DESCRIPTION
This PR reduces the vertical height of the task list by hiding completed and deleted tasks, replacing them with a single summary line (e.g., '✓ 5 completed tasks'). This keeps the UI clean while still providing progress context.