### PR TITLE
refactor: remove unused context argument from ToolPlugin.prompt

### DIFF
--- a/packages/agent-sdk/src/constants/prompts.ts
+++ b/packages/agent-sdk/src/constants/prompts.ts
@@ -1,4 +1,4 @@
-import { ToolPlugin, ToolContext } from "../tools/types.js";
+import { ToolPlugin } from "../tools/types.js";
 import {
   ASK_USER_QUESTION_TOOL_NAME,
   BASH_TOOL_NAME,
@@ -212,12 +212,7 @@ export function buildSystemPrompt(
 
   for (const tool of tools) {
     if (tool.prompt) {
-      const toolContext: ToolContext = {
-        workdir: options.workdir || "",
-        taskManager:
-          undefined as unknown as import("../services/taskManager.js").TaskManager, // Context might not be fully available here
-      };
-      prompt += tool.prompt(toolContext);
+      prompt += tool.prompt();
     }
   }
 

--- a/packages/agent-sdk/src/tools/types.ts
+++ b/packages/agent-sdk/src/tools/types.ts
@@ -22,7 +22,7 @@ export interface ToolPlugin {
   /**
    * Optional function to provide a prompt to be added to the system prompt
    */
-  prompt?: (context: ToolContext) => string;
+  prompt?: () => string;
 }
 
 export interface ToolResult {

--- a/packages/agent-sdk/tests/tools/askUserQuestion.test.ts
+++ b/packages/agent-sdk/tests/tools/askUserQuestion.test.ts
@@ -6,10 +6,8 @@ describe("AskUserQuestion Tool", () => {
   it("should have correct tool configuration", () => {
     expect(askUserQuestionTool.name).toBe("AskUserQuestion");
     expect(askUserQuestionTool.config.function.name).toBe("AskUserQuestion");
-    expect(askUserQuestionTool.prompt?.({} as ToolContext)).toBeDefined();
-    expect(typeof askUserQuestionTool.prompt?.({} as ToolContext)).toBe(
-      "string",
-    );
+    expect(askUserQuestionTool.prompt?.()).toBeDefined();
+    expect(typeof askUserQuestionTool.prompt?.()).toBe("string");
   });
 
   it("should execute successfully when user provides answers", async () => {

--- a/packages/agent-sdk/tests/tools/exitPlanMode.test.ts
+++ b/packages/agent-sdk/tests/tools/exitPlanMode.test.ts
@@ -47,7 +47,7 @@ describe("exitPlanModeTool", () => {
       "Prompts the user to exit plan mode and start coding",
     );
     expect(exitPlanModeTool.config.type).toBe("function");
-    expect(exitPlanModeTool.prompt?.(mockContext)).toContain(
+    expect(exitPlanModeTool.prompt?.()).toContain(
       "Use this tool when you are in plan mode",
     );
   });

--- a/packages/agent-sdk/tests/tools/taskManagementTools.test.ts
+++ b/packages/agent-sdk/tests/tools/taskManagementTools.test.ts
@@ -30,19 +30,19 @@ describe("Task Management Tools", () => {
   let context: ToolContext;
 
   it("should have correct tool configurations and prompts", () => {
-    expect(taskCreateTool.prompt?.(context)).toContain(
+    expect(taskCreateTool.prompt?.()).toContain(
       "Use this tool to create a structured task list",
     );
 
-    expect(taskGetTool.prompt?.(context)).toContain(
+    expect(taskGetTool.prompt?.()).toContain(
       "Use this tool to retrieve a task by its ID",
     );
 
-    expect(taskUpdateTool.prompt?.(context)).toContain(
+    expect(taskUpdateTool.prompt?.()).toContain(
       "Use this tool to update a task in the task list",
     );
 
-    expect(taskListTool.prompt?.(context)).toContain(
+    expect(taskListTool.prompt?.()).toContain(
       "Use this tool to list all tasks in the task list",
     );
   });

--- a/packages/agent-sdk/tests/tools/taskOutputTool.abort.test.ts
+++ b/packages/agent-sdk/tests/tools/taskOutputTool.abort.test.ts
@@ -15,8 +15,8 @@ describe("TaskOutput Tool Abort Handling", () => {
 
   it("should have correct tool configuration and prompt", () => {
     expect(taskOutputTool.name).toBe("TaskOutput");
-    expect(taskOutputTool.prompt?.(context)).toBeDefined();
-    expect(typeof taskOutputTool.prompt?.(context)).toBe("string");
+    expect(taskOutputTool.prompt?.()).toBeDefined();
+    expect(typeof taskOutputTool.prompt?.()).toBe("string");
   });
 
   beforeEach(() => {

--- a/packages/agent-sdk/tests/tools/taskTool.test.ts
+++ b/packages/agent-sdk/tests/tools/taskTool.test.ts
@@ -46,8 +46,8 @@ describe("Task Tool Background Execution", () => {
   });
 
   it("should support run_in_background parameter", async () => {
-    expect(taskTool.prompt?.(mockToolContext)).toBeDefined();
-    expect(typeof taskTool.prompt?.(mockToolContext)).toBe("string");
+    expect(taskTool.prompt?.()).toBeDefined();
+    expect(typeof taskTool.prompt?.()).toBe("string");
     const mockInstance = { subagentId: "gp-test-id" };
 
     vi.mocked(mockSubagentManager.findSubagent).mockResolvedValue(gpConfig);


### PR DESCRIPTION
Removed the unused `context: ToolContext` argument from the `prompt()` function in the `ToolPlugin` interface and updated all callers and tests.