### PR TITLE
feat: reset task list and IDs on /clear command

### DIFF
--- a/packages/agent-sdk/examples/verify-complex-plugin.ts
+++ b/packages/agent-sdk/examples/verify-complex-plugin.ts
@@ -4,6 +4,7 @@ import { HookManager } from "../src/managers/hookManager.js";
 import { LspManager } from "../src/managers/lspManager.js";
 import { McpManager } from "../src/managers/mcpManager.js";
 import { SlashCommandManager } from "../src/managers/slashCommandManager.js";
+import { TaskManager } from "../src/services/taskManager.js";
 import { MessageManager } from "../src/managers/messageManager.js";
 import { AIManager } from "../src/managers/aiManager.js";
 import { Logger, LspConfig, McpServerStatus } from "../src/types/index.js";
@@ -35,6 +36,7 @@ async function verify() {
     backgroundTaskManager: {
       getAllTasks: () => [],
     } as unknown as BackgroundTaskManager,
+    taskManager: new TaskManager("test-task-list"),
     workdir,
     logger,
   });

--- a/packages/agent-sdk/examples/verify-plugin.ts
+++ b/packages/agent-sdk/examples/verify-plugin.ts
@@ -4,6 +4,7 @@ import { HookManager } from "../src/managers/hookManager.js";
 import { LspManager } from "../src/managers/lspManager.js";
 import { McpManager } from "../src/managers/mcpManager.js";
 import { SlashCommandManager } from "../src/managers/slashCommandManager.js";
+import { TaskManager } from "../src/services/taskManager.js";
 import { MessageManager } from "../src/managers/messageManager.js";
 import { AIManager } from "../src/managers/aiManager.js";
 import { HookMatcher } from "../src/utils/hookMatcher.js";
@@ -40,6 +41,7 @@ async function verify() {
     backgroundTaskManager: {
       getAllTasks: () => [],
     } as unknown as BackgroundTaskManager,
+    taskManager: new TaskManager("test-task-list"),
     workdir,
     logger,
   });

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -419,6 +419,7 @@ export class Agent {
       messageManager: this.messageManager,
       aiManager: this.aiManager,
       backgroundTaskManager: this.backgroundTaskManager,
+      taskManager: this.taskManager,
       workdir: this.workdir,
       logger: this.logger,
     });

--- a/packages/agent-sdk/src/managers/messageManager.ts
+++ b/packages/agent-sdk/src/managers/messageManager.ts
@@ -279,6 +279,7 @@ export class MessageManager {
   public clearMessages(): void {
     this.setMessages([]);
     this.setSessionId(generateSessionId());
+    this.rootSessionId = this.sessionId;
     this.setlatestTotalTokens(0);
     this.savedMessageCount = 0; // Reset saved message count
   }

--- a/packages/agent-sdk/src/managers/slashCommandManager.ts
+++ b/packages/agent-sdk/src/managers/slashCommandManager.ts
@@ -1,6 +1,7 @@
 import type { MessageManager } from "./messageManager.js";
 import type { AIManager } from "./aiManager.js";
 import type { BackgroundTaskManager } from "./backgroundTaskManager.js";
+import type { TaskManager } from "../services/taskManager.js";
 import type {
   SlashCommand,
   CustomSlashCommand,
@@ -28,6 +29,7 @@ export interface SlashCommandManagerOptions {
   messageManager: MessageManager;
   aiManager: AIManager;
   backgroundTaskManager: BackgroundTaskManager;
+  taskManager: TaskManager;
   workdir: string;
   logger?: Logger;
 }
@@ -38,6 +40,7 @@ export class SlashCommandManager {
   private messageManager: MessageManager;
   private aiManager: AIManager;
   private backgroundTaskManager: BackgroundTaskManager;
+  private taskManager: TaskManager;
   private workdir: string;
   private logger?: Logger;
 
@@ -45,6 +48,7 @@ export class SlashCommandManager {
     this.messageManager = options.messageManager;
     this.aiManager = options.aiManager;
     this.backgroundTaskManager = options.backgroundTaskManager;
+    this.taskManager = options.taskManager;
     this.workdir = options.workdir;
     this.logger = options.logger;
 
@@ -61,6 +65,13 @@ export class SlashCommandManager {
       handler: () => {
         // Clear chat messages
         this.messageManager.clearMessages();
+
+        // Reset task list if WAVE_TASK_LIST_ID is not set
+        if (!process.env.WAVE_TASK_LIST_ID) {
+          const newTaskListId = this.messageManager.getRootSessionId();
+          this.taskManager.setTaskListId(newTaskListId);
+          this.taskManager.emit("tasksChange", newTaskListId);
+        }
       },
     });
 

--- a/packages/agent-sdk/tests/managers/slashCommandManager.clear.test.ts
+++ b/packages/agent-sdk/tests/managers/slashCommandManager.clear.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { SlashCommandManager } from "../../src/managers/slashCommandManager.js";
+import { MessageManager } from "../../src/managers/messageManager.js";
+import { TaskManager } from "../../src/services/taskManager.js";
+import { AIManager } from "../../src/managers/aiManager.js";
+import { BackgroundTaskManager } from "../../src/managers/backgroundTaskManager.js";
+
+describe("SlashCommandManager /clear reset", () => {
+  let slashCommandManager: SlashCommandManager;
+  let messageManager: MessageManager;
+  let taskManager: TaskManager;
+  let aiManager: AIManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    messageManager = new MessageManager({
+      callbacks: {},
+      workdir: "/test/workdir",
+    });
+
+    taskManager = new TaskManager("initial-task-list-id");
+    vi.spyOn(taskManager, "setTaskListId");
+    vi.spyOn(taskManager, "emit");
+
+    aiManager = {} as AIManager;
+
+    slashCommandManager = new SlashCommandManager({
+      messageManager,
+      aiManager,
+      backgroundTaskManager: {} as BackgroundTaskManager,
+      taskManager,
+      workdir: "/test/workdir",
+    });
+  });
+
+  it("should reset task list ID and emit tasksChange when /clear is called and WAVE_TASK_LIST_ID is not set", async () => {
+    const initialRootSessionId = messageManager.getRootSessionId();
+    expect(taskManager.getTaskListId()).toBe("initial-task-list-id");
+
+    await slashCommandManager.executeCommand("clear");
+
+    const newRootSessionId = messageManager.getRootSessionId();
+    expect(newRootSessionId).not.toBe(initialRootSessionId);
+    expect(taskManager.setTaskListId).toHaveBeenCalledWith(newRootSessionId);
+    expect(taskManager.emit).toHaveBeenCalledWith(
+      "tasksChange",
+      newRootSessionId,
+    );
+    expect(taskManager.getTaskListId()).toBe(newRootSessionId);
+  });
+
+  it("should NOT reset task list ID when /clear is called and WAVE_TASK_LIST_ID is set", async () => {
+    process.env.WAVE_TASK_LIST_ID = "fixed-task-list-id";
+
+    // Re-initialize to pick up env var if needed, but our implementation checks it at runtime
+    const initialRootSessionId = messageManager.getRootSessionId();
+
+    await slashCommandManager.executeCommand("clear");
+
+    const newRootSessionId = messageManager.getRootSessionId();
+    expect(newRootSessionId).not.toBe(initialRootSessionId);
+
+    expect(taskManager.setTaskListId).not.toHaveBeenCalled();
+    expect(taskManager.emit).not.toHaveBeenCalledWith(
+      "tasksChange",
+      expect.any(String),
+    );
+    expect(taskManager.getTaskListId()).toBe("initial-task-list-id");
+
+    delete process.env.WAVE_TASK_LIST_ID;
+  });
+});

--- a/packages/agent-sdk/tests/managers/slashCommandManager.nested.test.ts
+++ b/packages/agent-sdk/tests/managers/slashCommandManager.nested.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { SlashCommandManager } from "../../src/managers/slashCommandManager.js";
 import { MessageManager } from "../../src/managers/messageManager.js";
+import { TaskManager } from "../../src/services/taskManager.js";
 import { AIManager } from "../../src/managers/aiManager.js";
 import { BackgroundTaskManager } from "../../src/managers/backgroundTaskManager.js";
 import { existsSync, readdirSync, statSync } from "fs";
@@ -167,6 +168,7 @@ describe("SlashCommandManager Nested Command Integration", () => {
       aiManager,
       backgroundTaskManager:
         backgroundTaskManager as unknown as BackgroundTaskManager,
+      taskManager: new TaskManager("test-task-list"),
       workdir: mockWorkdir,
     });
   }

--- a/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
+++ b/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { SlashCommandManager } from "../../src/managers/slashCommandManager.js";
 import { MessageManager } from "../../src/managers/messageManager.js";
+import { TaskManager } from "../../src/services/taskManager.js";
 import { AIManager } from "../../src/managers/aiManager.js";
 import { BackgroundTaskManager } from "../../src/managers/backgroundTaskManager.js";
 import { CustomSlashCommand, TextBlock } from "../../src/types/index.js";
@@ -47,6 +48,7 @@ describe("SlashCommandManager", () => {
       aiManager,
       backgroundTaskManager:
         backgroundTaskManager as unknown as BackgroundTaskManager,
+      taskManager: new TaskManager("test-task-list"),
       workdir: "/test/workdir",
     });
   });

--- a/specs/063-task-management-tools/spec.md
+++ b/specs/063-task-management-tools/spec.md
@@ -91,8 +91,11 @@ As a system maintainer, I want to remove the legacy TodoWrite tool so that the a
 - **FR-011**: The system MUST update internal documentation and system prompts to remove references to `TodoWrite`.
 - **FR-012**: The system MUST determine `taskListId` using the following priority:
   1. Value of `WAVE_TASK_LIST_ID` environment variable.
-  2. Fallback to the initial `sessionId` provided by the `MessageManager` at agent initialization.
+  2. Fallback to the `rootSessionId` provided by the `MessageManager`.
 - **FR-013**: The `taskListId` MUST remain stable for the lifetime of the session chain. This is achieved by using the `rootSessionId` (the ID of the first session in the chain) as the default `taskListId`. Even if the `sessionId` changes (e.g., due to message compression), the `taskListId` MUST NOT change.
+- **FR-017**: When the `/clear` command is executed:
+  - If `WAVE_TASK_LIST_ID` is NOT set, the `rootSessionId` MUST be reset to the new `sessionId`, and the `taskListId` MUST be updated to this new `rootSessionId`. This effectively starts a fresh task list for the new session.
+  - If `WAVE_TASK_LIST_ID` IS set, the `taskListId` MUST NOT be changed, and the existing task list MUST be preserved.
 - **FR-014**: The `ToolPlugin` interface MUST support a `prompt` function to allow tools to contribute dynamically to the system prompt.
 - **FR-015**: Task management tools MUST provide detailed behavioral instructions via the `ToolPlugin.prompt` property.
 - **FR-016**: `TaskUpdate` MUST support merging metadata, where setting a key to `null` deletes it.


### PR DESCRIPTION
This PR modifies the `/clear` command to reset the task list and task IDs, ensuring a fresh start for new sessions while respecting the `WAVE_TASK_LIST_ID` environment variable override.

Key changes:
- Updated `MessageManager.clearMessages()` to reset `rootSessionId`.
- Updated `SlashCommandManager` to handle task list reset in the `/clear` handler.
- Updated `Agent` to pass `taskManager` to `SlashCommandManager`.
- Added comprehensive tests for the new `/clear` behavior.
- Updated feature specification in `specs/063-task-management-tools/spec.md`.