### PR TITLE
feat(code): show ellipsis between non-contiguous edits in MultiEdit diff

### DIFF
--- a/packages/code/src/components/DiffDisplay.tsx
+++ b/packages/code/src/components/DiffDisplay.tsx
@@ -109,6 +109,15 @@ export const DiffDisplay: React.FC<DiffDisplayProps> = ({
 
       changes.forEach((change, changeIndex) => {
         try {
+          // Add ellipsis between non-contiguous edits in MultiEdit
+          if (toolName === MULTI_EDIT_TOOL_NAME && changeIndex > 0) {
+            allElements.push(
+              <Box key={`multi-edit-separator-${changeIndex}`}>
+                <Text color="gray">...</Text>
+              </Box>,
+            );
+          }
+
           // Get line-level diff to understand the structure
           const lineDiffs = diffLines(
             change.oldContent || "",


### PR DESCRIPTION
This PR adds a '...' separator between non-contiguous edits in the MultiEdit diff display to improve readability and provide better context.