### PR TITLE
feat: render last message statically if all tools are in end stage

### DIFF
--- a/packages/code/src/components/MessageList.tsx
+++ b/packages/code/src/components/MessageList.tsx
@@ -42,8 +42,24 @@ export const MessageList = React.memo(
       : 0;
 
     // Compute which messages to render statically vs dynamically
+    const lastMessage = displayMessages[displayMessages.length - 1];
+    const hasNonEndTool = lastMessage?.blocks.some(
+      (block) => block.type === "tool" && block.stage !== "end",
+    );
+    const hasRunningCommand = lastMessage?.blocks.some(
+      (block) => block.type === "command_output" && block.isRunning,
+    );
+    const hasActiveSubagent = lastMessage?.blocks.some(
+      (block) => block.type === "subagent" && block.status === "active",
+    );
+
     const shouldRenderLastDynamic =
-      !forceStaticLastMessage && (isLoading || isCommandRunning);
+      !forceStaticLastMessage &&
+      (isLoading ||
+        isCommandRunning ||
+        hasNonEndTool ||
+        hasRunningCommand ||
+        hasActiveSubagent);
     const staticMessages = shouldRenderLastDynamic
       ? displayMessages.slice(0, -1)
       : displayMessages;


### PR DESCRIPTION
This PR updates the MessageList component to ensure that the last message is rendered statically if it only contains completed tool calls, commands, and subagents. This improves performance and UI stability by allowing Ink's Static component to handle messages as soon as they are no longer active.