### PR TITLE
feat: support /help command and simplify input placeholder

### DIFF
--- a/packages/code/src/components/CommandSelector.tsx
+++ b/packages/code/src/components/CommandSelector.tsx
@@ -22,6 +22,12 @@ const AVAILABLE_COMMANDS: SlashCommand[] = [
       "Revert conversation and file changes to a previous checkpoint",
     handler: () => {}, // Handler here won't be used, actual processing is in the hook
   },
+  {
+    id: "help",
+    name: "help",
+    description: "Show help and key bindings",
+    handler: () => {}, // Handler here won't be used, actual processing is in the hook
+  },
 ];
 
 export interface CommandSelectorProps {

--- a/packages/code/src/components/HelpView.tsx
+++ b/packages/code/src/components/HelpView.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Box, Text, useInput } from "ink";
+
+export interface HelpViewProps {
+  onCancel: () => void;
+}
+
+export const HelpView: React.FC<HelpViewProps> = ({ onCancel }) => {
+  useInput((_, key) => {
+    if (key.escape || key.return) {
+      onCancel();
+    }
+  });
+
+  const helpItems = [
+    { key: "@", description: "Reference files" },
+    { key: "/", description: "Commands" },
+    { key: "Ctrl+R", description: "Search history" },
+    { key: "Ctrl+O", description: "Expand/collapse messages" },
+    { key: "Ctrl+T", description: "Toggle task list" },
+    { key: "Ctrl+B", description: "Background current task" },
+    { key: "Ctrl+V", description: "Paste image" },
+    { key: "Shift+Tab", description: "Cycle permission mode" },
+    {
+      key: "Esc",
+      description: "Interrupt AI or command / Cancel selector / Close help",
+    },
+  ];
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="single"
+      borderColor="cyan"
+      borderLeft={false}
+      borderRight={false}
+      paddingX={1}
+    >
+      <Box marginBottom={1}>
+        <Text color="cyan" bold underline>
+          Help & Key Bindings
+        </Text>
+      </Box>
+
+      {helpItems.map((item, index) => (
+        <Box key={index}>
+          <Box width={20}>
+            <Text color="yellow">{item.key}</Text>
+          </Box>
+          <Text color="white">{item.description}</Text>
+        </Box>
+      ))}
+
+      <Box marginTop={1}>
+        <Text dimColor>Press Esc or Enter to close</Text>
+      </Box>
+    </Box>
+  );
+};

--- a/packages/code/src/components/InputBox.tsx
+++ b/packages/code/src/components/InputBox.tsx
@@ -7,13 +7,14 @@ import { HistorySearch } from "./HistorySearch.js";
 import { BackgroundTaskManager } from "./BackgroundTaskManager.js";
 import { McpManager } from "./McpManager.js";
 import { RewindCommand } from "./RewindCommand.js";
+import { HelpView } from "./HelpView.js";
 import { useInputManager } from "../hooks/useInputManager.js";
 import { useChat } from "../contexts/useChat.js";
 
 import type { McpServerStatus, SlashCommand } from "wave-agent-sdk";
 
 export const INPUT_PLACEHOLDER_TEXT =
-  "Type your message (use @ to reference files, / for commands, Ctrl+R to search history, Ctrl+O to expand messages, Ctrl+T to toggle tasks)...";
+  "Type your message (use /help for more info)...";
 
 export const INPUT_PLACEHOLDER_TEXT_PREFIX = INPUT_PLACEHOLDER_TEXT.substring(
   0,
@@ -86,9 +87,11 @@ export const InputBox: React.FC<InputBoxProps> = ({
     showBackgroundTaskManager,
     showMcpManager,
     showRewindManager,
+    showHelp,
     setShowBackgroundTaskManager,
     setShowMcpManager,
     setShowRewindManager,
+    setShowHelp,
     // Permission mode
     permissionMode,
     setPermissionMode,
@@ -165,6 +168,10 @@ export const InputBox: React.FC<InputBoxProps> = ({
     );
   }
 
+  if (showHelp) {
+    return <HelpView onCancel={() => setShowHelp(false)} />;
+  }
+
   return (
     <Box flexDirection="column">
       {showFileSelector && (
@@ -209,39 +216,42 @@ export const InputBox: React.FC<InputBoxProps> = ({
         />
       )}
 
-      {showBackgroundTaskManager || showMcpManager || showRewindManager || (
-        <Box flexDirection="column">
-          <Box
-            borderStyle="single"
-            borderColor="gray"
-            borderLeft={false}
-            borderRight={false}
-          >
-            <Text color={isPlaceholder ? "gray" : "white"}>
-              {shouldShowCursor ? (
-                <>
-                  {beforeCursor}
-                  <Text backgroundColor="white" color="black">
-                    {atCursor}
-                  </Text>
-                  {afterCursor}
-                </>
-              ) : (
-                displayText
-              )}
-            </Text>
+      {showBackgroundTaskManager ||
+        showMcpManager ||
+        showRewindManager ||
+        showHelp || (
+          <Box flexDirection="column">
+            <Box
+              borderStyle="single"
+              borderColor="gray"
+              borderLeft={false}
+              borderRight={false}
+            >
+              <Text color={isPlaceholder ? "gray" : "white"}>
+                {shouldShowCursor ? (
+                  <>
+                    {beforeCursor}
+                    <Text backgroundColor="white" color="black">
+                      {atCursor}
+                    </Text>
+                    {afterCursor}
+                  </>
+                ) : (
+                  displayText
+                )}
+              </Text>
+            </Box>
+            <Box paddingRight={1} justifyContent="space-between" width="100%">
+              <Text color="gray">
+                Mode:{" "}
+                <Text color={permissionMode === "plan" ? "yellow" : "cyan"}>
+                  {permissionMode}
+                </Text>{" "}
+                (Shift+Tab to cycle)
+              </Text>
+            </Box>
           </Box>
-          <Box paddingRight={1} justifyContent="space-between" width="100%">
-            <Text color="gray">
-              Mode:{" "}
-              <Text color={permissionMode === "plan" ? "yellow" : "cyan"}>
-                {permissionMode}
-              </Text>{" "}
-              (Shift+Tab to cycle)
-            </Text>
-          </Box>
-        </Box>
-      )}
+        )}
     </Box>
   );
 };

--- a/packages/code/src/hooks/useInputManager.ts
+++ b/packages/code/src/hooks/useInputManager.ts
@@ -37,6 +37,7 @@ export const useInputManager = (
     useState(false);
   const [showMcpManager, setShowMcpManager] = useState(false);
   const [showRewindManager, setShowRewindManager] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
   const [permissionMode, setPermissionModeState] =
     useState<PermissionMode>("default");
   const [attachedImages, setAttachedImages] = useState<AttachedImage[]>([]);
@@ -66,6 +67,9 @@ export const useInputManager = (
         },
         onRewindManagerStateChange: (show) => {
           setShowRewindManager(show);
+        },
+        onHelpStateChange: (show) => {
+          setShowHelp(show);
         },
         onPermissionModeChange: (mode) => {
           setPermissionModeState(mode);
@@ -100,6 +104,9 @@ export const useInputManager = (
         },
         onRewindManagerStateChange: (show) => {
           setShowRewindManager(show);
+        },
+        onHelpStateChange: (show) => {
+          setShowHelp(show);
         },
         onPermissionModeChange: (mode) => {
           setPermissionModeState(mode);
@@ -148,14 +155,6 @@ export const useInputManager = (
 
   const moveCursorRight = useCallback(() => {
     managerRef.current?.moveCursorRight();
-  }, []);
-
-  const moveCursorToStart = useCallback(() => {
-    managerRef.current?.moveCursorToStart();
-  }, []);
-
-  const moveCursorToEnd = useCallback(() => {
-    managerRef.current?.moveCursorToEnd();
   }, []);
 
   // File selector methods
@@ -268,6 +267,7 @@ export const useInputManager = (
     showBackgroundTaskManager,
     showMcpManager,
     showRewindManager,
+    showHelp,
     permissionMode,
     attachedImages,
     isManagerReady,
@@ -278,8 +278,6 @@ export const useInputManager = (
     clearInput,
     moveCursorLeft,
     moveCursorRight,
-    moveCursorToStart,
-    moveCursorToEnd,
 
     // File selector
     activateFileSelector,
@@ -313,6 +311,10 @@ export const useInputManager = (
     setShowRewindManager: useCallback((show: boolean) => {
       managerRef.current?.setShowRewindManager(show);
       setShowRewindManager(show);
+    }, []),
+    setShowHelp: useCallback((show: boolean) => {
+      managerRef.current?.setShowHelp(show);
+      setShowHelp(show);
     }, []),
     setPermissionMode: useCallback((mode: PermissionMode) => {
       setPermissionModeState(mode);

--- a/packages/code/src/managers/InputManager.ts
+++ b/packages/code/src/managers/InputManager.ts
@@ -32,6 +32,7 @@ export interface InputManagerCallbacks {
   onBackgroundTaskManagerStateChange?: (show: boolean) => void;
   onMcpManagerStateChange?: (show: boolean) => void;
   onRewindManagerStateChange?: (show: boolean) => void;
+  onHelpStateChange?: (show: boolean) => void;
   onImagesStateChange?: (images: AttachedImage[]) => void;
   onSendMessage?: (
     content: string,
@@ -84,6 +85,7 @@ export class InputManager {
   private showBackgroundTaskManager: boolean = false;
   private showMcpManager: boolean = false;
   private showRewindManager: boolean = false;
+  private showHelp: boolean = false;
 
   // Permission mode state
   private permissionMode: PermissionMode = "default";
@@ -179,14 +181,6 @@ export class InputManager {
 
   moveCursorRight(): void {
     this.setCursorPosition(this.cursorPosition + 1);
-  }
-
-  moveCursorToStart(): void {
-    this.setCursorPosition(0);
-  }
-
-  moveCursorToEnd(): void {
-    this.setCursorPosition(this.inputText.length);
   }
 
   // File selector methods
@@ -356,6 +350,9 @@ export class InputManager {
             commandExecuted = true;
           } else if (command === "rewind") {
             this.setShowRewindManager(true);
+            commandExecuted = true;
+          } else if (command === "help") {
+            this.setShowHelp(true);
             commandExecuted = true;
           }
         }
@@ -661,6 +658,15 @@ export class InputManager {
     this.callbacks.onRewindManagerStateChange?.(show);
   }
 
+  getShowHelp(): boolean {
+    return this.showHelp;
+  }
+
+  setShowHelp(show: boolean): void {
+    this.showHelp = show;
+    this.callbacks.onHelpStateChange?.(show);
+  }
+
   // Permission mode methods
   getPermissionMode(): PermissionMode {
     return this.permissionMode;
@@ -854,16 +860,6 @@ export class InputManager {
       return true;
     }
 
-    if (("home" in key && key.home) || (key.ctrl && input === "a")) {
-      this.moveCursorToStart();
-      return true;
-    }
-
-    if (("end" in key && key.end) || (key.ctrl && input === "e")) {
-      this.moveCursorToEnd();
-      return true;
-    }
-
     // Handle Ctrl+V for pasting images
     if (key.ctrl && input === "v") {
       this.handlePasteImage().catch((error) => {
@@ -947,14 +943,16 @@ export class InputManager {
       this.showHistorySearch ||
       this.showBackgroundTaskManager ||
       this.showMcpManager ||
-      this.showRewindManager
+      this.showRewindManager ||
+      this.showHelp
     ) {
       if (
         this.showBackgroundTaskManager ||
         this.showMcpManager ||
-        this.showRewindManager
+        this.showRewindManager ||
+        this.showHelp
       ) {
-        // Task manager, MCP manager and Rewind don't need to handle input, handled by component itself
+        // Task manager, MCP manager, Rewind and Help don't need to handle input, handled by component itself
         // Return true to indicate we've "handled" it (by ignoring it) so it doesn't leak to normal input
         return true;
       }

--- a/packages/code/tests/components/HelpView.test.tsx
+++ b/packages/code/tests/components/HelpView.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { HelpView } from "../../src/components/HelpView.js";
+import { stripAnsiColors } from "wave-agent-sdk";
+
+describe("HelpView", () => {
+  it("should render help items", () => {
+    const { lastFrame } = render(<HelpView onCancel={() => {}} />);
+    const output = stripAnsiColors(lastFrame() || "");
+
+    expect(output).toContain("Help & Key Bindings");
+    expect(output).toContain("@");
+    expect(output).toContain("Reference files");
+    expect(output).toContain("/");
+    expect(output).toContain("Commands");
+    expect(output).toContain("Ctrl+R");
+    expect(output).toContain("Search history");
+    expect(output).toContain("Shift+Tab");
+    expect(output).toContain("Cycle permission mode");
+  });
+
+  it("should call onCancel when Escape is pressed", async () => {
+    const onCancel = vi.fn();
+    const { stdin } = render(<HelpView onCancel={onCancel} />);
+
+    stdin.write("\u001b"); // Escape
+
+    await vi.waitFor(() => {
+      expect(onCancel).toHaveBeenCalled();
+    });
+  });
+
+  it("should call onCancel when Enter is pressed", async () => {
+    const onCancel = vi.fn();
+    const { stdin } = render(<HelpView onCancel={onCancel} />);
+
+    stdin.write("\r"); // Enter
+
+    await vi.waitFor(() => {
+      expect(onCancel).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/code/tests/managers/InputManager.test.ts
+++ b/packages/code/tests/managers/InputManager.test.ts
@@ -138,17 +138,6 @@ describe("InputManager", () => {
       manager.moveCursorRight();
       expect(manager.getCursorPosition()).toBe(5);
     });
-
-    it("should move cursor to start", () => {
-      manager.moveCursorToStart();
-      expect(manager.getCursorPosition()).toBe(0);
-    });
-
-    it("should move cursor to end", () => {
-      manager.setCursorPosition(2);
-      manager.moveCursorToEnd();
-      expect(manager.getCursorPosition()).toBe(5);
-    });
   });
 
   describe("File Selector", () => {


### PR DESCRIPTION
This PR adds a /help command to show key bindings and simplifies the input box placeholder. It also removes redundant cursor movement key bindings (Ctrl+A/Home, Ctrl+E/End).