### PR TITLE
feat: add reminder to ExitPlanMode tool result when plan is rejected

### DIFF
--- a/packages/agent-sdk/src/tools/exitPlanMode.ts
+++ b/packages/agent-sdk/src/tools/exitPlanMode.ts
@@ -93,7 +93,7 @@ Ensure your plan is complete and unambiguous:
       if (permissionResult.behavior === "deny") {
         return {
           success: false,
-          content: permissionResult.message || "Plan rejected by user",
+          content: `User feedback: ${permissionResult.message || "Plan rejected by user"}. Please update your proposal accordingly.`,
           error: permissionResult.message ? undefined : "Plan rejected by user",
         };
       }

--- a/packages/agent-sdk/tests/agent/exitPlanMode.integration.test.ts
+++ b/packages/agent-sdk/tests/agent/exitPlanMode.integration.test.ts
@@ -200,7 +200,9 @@ describe("ExitPlanMode Integration", () => {
     ).toolManager.execute("ExitPlanMode", {}, { workdir, taskManager });
 
     expect(result.success).toBe(false);
-    expect(result.content).toBe(feedback);
+    expect(result.content).toBe(
+      `User feedback: ${feedback}. Please update your proposal accordingly.`,
+    );
     expect(agent.getPermissionMode()).toBe("plan");
   });
 });

--- a/packages/agent-sdk/tests/tools/exitPlanMode.test.ts
+++ b/packages/agent-sdk/tests/tools/exitPlanMode.test.ts
@@ -116,7 +116,9 @@ describe("exitPlanModeTool", () => {
     const result = await exitPlanModeTool.execute({}, mockContext);
 
     expect(result.success).toBe(false);
-    expect(result.content).toBe(feedback);
+    expect(result.content).toBe(
+      `User feedback: ${feedback}. Please update your proposal accordingly.`,
+    );
     expect(result.error).toBeUndefined();
   });
 
@@ -133,7 +135,9 @@ describe("exitPlanModeTool", () => {
     const result = await exitPlanModeTool.execute({}, mockContext);
 
     expect(result.success).toBe(false);
-    expect(result.content).toBe("Plan rejected by user");
+    expect(result.content).toBe(
+      "User feedback: Plan rejected by user. Please update your proposal accordingly.",
+    );
     expect(result.error).toBe("Plan rejected by user");
   });
 


### PR DESCRIPTION
This PR adds a guided instruction to the tool result when a user provides feedback during the ExitPlanMode confirmation. This helps the AI understand it needs to revise its plan based on the feedback.