### PR TITLE
fix: ensure terminal clear and remount are properly sequenced

### DIFF
--- a/packages/code/src/components/App.tsx
+++ b/packages/code/src/components/App.tsx
@@ -33,24 +33,25 @@ const ChatInterfaceWithRemount: React.FC = () => {
   const prevSessionId = useRef(sessionId);
 
   useEffect(() => {
-    let newKey = String(isExpanded) + rewindId + wasLastDetailsTooTall;
-
-    const isSessionChanged =
-      prevSessionId.current && sessionId && prevSessionId.current !== sessionId;
-
-    if (isSessionChanged) {
-      newKey += sessionId;
-    }
+    const newKey =
+      String(isExpanded) +
+      rewindId +
+      wasLastDetailsTooTall +
+      (prevSessionId.current && sessionId && prevSessionId.current !== sessionId
+        ? sessionId
+        : "");
 
     if (newKey !== remountKey) {
-      stdout?.write("\u001b[2J\u001b[0;0H", (err?: Error | null) => {
-        if (err) {
-          console.error("Failed to clear terminal:", err);
-        }
-        setTimeout(() => {
+      const timeout = setTimeout(() => {
+        stdout?.write("\u001b[2J\u001b[0;0H", (err?: Error | null) => {
+          if (err) {
+            console.error("Failed to clear terminal:", err);
+          }
           setRemountKey(newKey);
-        }, 100);
-      });
+        });
+      }, 100);
+
+      return () => clearTimeout(timeout);
     }
 
     if (sessionId) {


### PR DESCRIPTION
This PR fixes an issue where the terminal clear and component remount were not properly sequenced, potentially leading to flickering or incorrect rendering. It also adds a cleanup function to the useEffect to prevent memory leaks or race conditions if the effect re-runs before the timeout fires.