### PR TITLE
chore: set WAVE_MODEL to gemini-2.5-flash and refactor wave:debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "packages/*"
   ],
   "scripts": {
-    "wave": "tsx --tsconfig packages/code/tsconfig.dev.json packages/code/src/index.ts",
-    "wave:debug": "LOG_LEVEL=DEBUG tsx --tsconfig packages/code/tsconfig.dev.json packages/code/src/index.ts",
+    "wave": "WAVE_MODEL=gemini-2.5-flash tsx --tsconfig packages/code/tsconfig.dev.json packages/code/src/index.ts",
+    "wave:debug": "LOG_LEVEL=DEBUG pnpm run wave",
     "watch": "pnpm -r --parallel watch",
     "build": "pnpm -r build",
     "type-check": "pnpm -r type-check",


### PR DESCRIPTION
This PR updates the wave script to use gemini-2.5-flash by default and refactors wave:debug to reuse the wave script.