### PR TITLE
feat: integrate task list state into rewind functionality

### DIFF
--- a/packages/agent-sdk/src/services/taskManager.ts
+++ b/packages/agent-sdk/src/services/taskManager.ts
@@ -27,7 +27,7 @@ export class TaskManager extends EventEmitter {
     return join(this.baseDir, this.taskListId);
   }
 
-  private getTaskPath(taskId: string): string {
+  public getTaskPath(taskId: string): string {
     return join(this.getSessionDir(), `${taskId}.json`);
   }
 

--- a/packages/agent-sdk/src/tools/taskManagementTools.ts
+++ b/packages/agent-sdk/src/tools/taskManagementTools.ts
@@ -114,6 +114,15 @@ NOTE that you should not use this tool if there is only one trivial task to do. 
 
     const taskId = await taskManager.createTask(task);
 
+    if (context.reversionManager && context.messageId) {
+      const taskPath = taskManager.getTaskPath(taskId);
+      await context.reversionManager.recordSnapshot(
+        context.messageId,
+        taskPath,
+        "create",
+      );
+    }
+
     return {
       success: true,
       content: `Task created with ID: ${taskId}`,
@@ -322,6 +331,15 @@ Set up task dependencies:
         success: false,
         content: `Task with ID ${taskId} not found.`,
       };
+    }
+
+    if (context.reversionManager && context.messageId) {
+      const taskPath = taskManager.getTaskPath(taskId);
+      await context.reversionManager.recordSnapshot(
+        context.messageId,
+        taskPath,
+        "modify",
+      );
     }
 
     const updatedFields: string[] = [];

--- a/packages/agent-sdk/tests/managers/reversionManager.test.ts
+++ b/packages/agent-sdk/tests/managers/reversionManager.test.ts
@@ -153,4 +153,32 @@ describe("ReversionManager", () => {
 
     expect(fs.rm).toHaveBeenCalledWith("/newfile", { force: true });
   });
+
+  it("should handle absolute paths for task files and track affected task list IDs", async () => {
+    const taskFilePath = "/home/user/.wave/tasks/session123/1.json";
+    const snapshots = [
+      {
+        messageId: "msg1",
+        filePath: taskFilePath,
+        snapshotPath: undefined,
+        timestamp: 100,
+        operation: "create",
+      },
+    ];
+
+    const messages = [
+      {
+        id: "msg1",
+        blocks: [{ type: "file_history", snapshots: [snapshots[0]] }],
+      },
+    ];
+
+    const count = await reversionManager.revertTo(
+      ["msg1"],
+      messages as unknown as import("../../src/types/index.js").Message[],
+    );
+
+    expect(count).toBe(1);
+    expect(fs.rm).toHaveBeenCalledWith(taskFilePath, { force: true });
+  });
 });

--- a/packages/agent-sdk/tests/tools/taskManagementToolsRewind.test.ts
+++ b/packages/agent-sdk/tests/tools/taskManagementToolsRewind.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, type Mocked } from "vitest";
+import {
+  taskCreateTool,
+  taskUpdateTool,
+} from "../../src/tools/taskManagementTools.js";
+import { TaskManager } from "../../src/services/taskManager.js";
+import { Task } from "../../src/types/tasks.js";
+import type { ToolContext } from "../../src/tools/types.js";
+import { ReversionService } from "../../src/services/reversionService.js";
+import { ReversionManager } from "../../src/managers/reversionManager.js";
+
+// Mock TaskManager
+vi.mock("../../src/services/taskManager.js", () => {
+  const TaskManager = vi.fn();
+  TaskManager.prototype.createTask = vi.fn();
+  TaskManager.prototype.getTask = vi.fn();
+  TaskManager.prototype.updateTask = vi.fn();
+  TaskManager.prototype.getTaskPath = vi.fn();
+  return { TaskManager };
+});
+
+// Mock ReversionManager
+vi.mock("../../src/managers/reversionManager.js", () => {
+  const ReversionManager = vi.fn();
+  ReversionManager.prototype.recordSnapshot = vi.fn();
+  return { ReversionManager };
+});
+
+describe("Task Management Tools - Rewind Support", () => {
+  const sessionId = "test-session-id";
+  const messageId = "test-message-id";
+  let context: ToolContext;
+  let mockTaskManager: Mocked<TaskManager>;
+  let mockReversionManager: Mocked<ReversionManager>;
+  let mockReversionService: Mocked<ReversionService>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTaskManager = new TaskManager(sessionId) as Mocked<TaskManager>;
+    mockReversionService = new ReversionService(
+      sessionId,
+    ) as Mocked<ReversionService>;
+    mockReversionManager = new ReversionManager(
+      mockReversionService,
+    ) as Mocked<ReversionManager>;
+
+    context = {
+      sessionId,
+      messageId,
+      taskManager: mockTaskManager,
+      reversionManager: mockReversionManager,
+      workdir: "/test/workdir",
+    } as ToolContext;
+  });
+
+  describe("TaskCreate tool rewind support", () => {
+    it("should record a 'create' snapshot when a task is created", async () => {
+      const args = {
+        subject: "Test Task",
+        description: "Test Description",
+      };
+      const taskId = "1";
+      const taskPath = "/path/to/task/1.json";
+
+      mockTaskManager.createTask.mockResolvedValue(taskId);
+      mockTaskManager.getTaskPath.mockReturnValue(taskPath);
+
+      const result = await taskCreateTool.execute(args, context);
+
+      expect(result.success).toBe(true);
+      expect(mockTaskManager.createTask).toHaveBeenCalled();
+      expect(mockReversionManager.recordSnapshot).toHaveBeenCalledWith(
+        messageId,
+        taskPath,
+        "create",
+      );
+    });
+
+    it("should not fail if reversionManager is missing", async () => {
+      const args = {
+        subject: "Test Task",
+        description: "Test Description",
+      };
+      mockTaskManager.createTask.mockResolvedValue("1");
+
+      const contextWithoutReversion = {
+        ...context,
+        reversionManager: undefined,
+      };
+      const result = await taskCreateTool.execute(
+        args,
+        contextWithoutReversion,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockTaskManager.createTask).toHaveBeenCalled();
+    });
+  });
+
+  describe("TaskUpdate tool rewind support", () => {
+    it("should record a 'modify' snapshot before a task is updated", async () => {
+      const taskId = "1";
+      const taskPath = "/path/to/task/1.json";
+      const existingTask: Task = {
+        id: taskId,
+        subject: "Old Subject",
+        description: "Old Description",
+        status: "pending",
+        blocks: [],
+        blockedBy: [],
+        metadata: {},
+      };
+
+      mockTaskManager.getTask.mockResolvedValue(existingTask);
+      mockTaskManager.getTaskPath.mockReturnValue(taskPath);
+
+      const args = {
+        taskId,
+        subject: "New Subject",
+      };
+
+      const result = await taskUpdateTool.execute(args, context);
+
+      expect(result.success).toBe(true);
+      expect(mockReversionManager.recordSnapshot).toHaveBeenCalledWith(
+        messageId,
+        taskPath,
+        "modify",
+      );
+      // Ensure snapshot is recorded BEFORE update
+      const recordCallOrder =
+        mockReversionManager.recordSnapshot.mock.invocationCallOrder[0];
+      const updateCallOrder =
+        mockTaskManager.updateTask.mock.invocationCallOrder[0];
+      expect(recordCallOrder).toBeLessThan(updateCallOrder);
+    });
+  });
+});

--- a/packages/code/src/components/RewindCommand.tsx
+++ b/packages/code/src/components/RewindCommand.tsx
@@ -143,7 +143,7 @@ export const RewindCommand: React.FC<RewindCommandProps> = ({
       <Box>
         <Text color="red" dimColor>
           ⚠️ Warning: This will delete all subsequent messages and revert file
-          changes.
+          and task list changes.
         </Text>
       </Box>
     </Box>


### PR DESCRIPTION
This PR ensures that the task list state is correctly reverted during a rewind operation.

Key changes:
- Updated `ReversionManager` to handle absolute paths for task files and implement hard deletion for tasks created after the rewind point.
- Modified `TaskCreate` and `TaskUpdate` tools to record snapshots of task files before any modifications.
- Updated the Rewind UI warning message to explicitly mention task list reversion.
- Improved type safety by making `getTaskPath` public in `TaskManager` and fixing ESLint errors.
- Added comprehensive tests to verify the new functionality.