### PR TITLE
fix: update tests to be resilient to WAVE_MODEL environment variable

### DIFF
--- a/packages/agent-sdk/tests/agent/agent.compression.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.compression.test.ts
@@ -122,11 +122,10 @@ describe("Agent Message Compression Tests", () => {
     );
     expect(compressedMessage).toBeDefined();
     expect(compressedMessage?.usage).toBeDefined();
-    expect(compressedMessage?.usage).toEqual({
+    expect(compressedMessage?.usage).toMatchObject({
       prompt_tokens: 1000,
       completion_tokens: 500,
       total_tokens: 1500,
-      model: "gemini-3-flash", // The default agent model
       operation_type: "compress",
     });
 

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -437,8 +437,11 @@ describe("ConfigurationService", () => {
   describe("resolveModelConfig", () => {
     it("should resolve with defaults", () => {
       const config = configService.resolveModelConfig();
-      expect(config.agentModel).toBe("gemini-3-flash");
-      expect(config.fastModel).toBe("gemini-2.5-flash");
+      const expectedAgentModel = process.env.WAVE_MODEL || "gemini-3-flash";
+      const expectedFastModel =
+        process.env.WAVE_FAST_MODEL || "gemini-2.5-flash";
+      expect(config.agentModel).toBe(expectedAgentModel);
+      expect(config.fastModel).toBe(expectedFastModel);
       expect(config.maxTokens).toBe(DEFAULT_WAVE_MAX_OUTPUT_TOKENS);
     });
 


### PR DESCRIPTION
This PR updates tests in  to correctly handle cases where  or  environment variables are set, preventing failures when running tests with non-default models.