### PR TITLE
refactor: remove (expected) and (actual) suffixes from edit mismatch report

### DIFF
--- a/packages/agent-sdk/src/utils/editUtils.ts
+++ b/packages/agent-sdk/src/utils/editUtils.ts
@@ -77,12 +77,8 @@ export function analyzeEditMismatch(
     if (actualLine === expectedLine) {
       reportLines.push(`${lineNum.toString().padStart(4)} | ${actualLine}`);
     } else {
-      reportLines.push(
-        `${lineNum.toString().padStart(4)} | - ${expectedLine} (expected)`,
-      );
-      reportLines.push(
-        `${lineNum.toString().padStart(4)} | + ${actualLine} (actual)`,
-      );
+      reportLines.push(`${lineNum.toString().padStart(4)} | - ${expectedLine}`);
+      reportLines.push(`${lineNum.toString().padStart(4)} | + ${actualLine}`);
     }
   }
 

--- a/packages/agent-sdk/tests/utils/mismatchAnalysis.test.ts
+++ b/packages/agent-sdk/tests/utils/mismatchAnalysis.test.ts
@@ -18,8 +18,8 @@ describe("analyzeEditMismatch", () => {
 
     expect(result).toContain("Best partial match found at line 1:");
     expect(result).toContain("   1 | const x = 1;");
-    expect(result).toContain("   2 | - const y = 2; (expected)");
-    expect(result).toContain("   2 | + const y = 3; (actual)");
+    expect(result).toContain("   2 | - const y = 2;");
+    expect(result).toContain("   2 | + const y = 3;");
     expect(result).toContain("   3 | return x + y;");
   });
 
@@ -38,7 +38,7 @@ describe("analyzeEditMismatch", () => {
     const search = "const x = 1;";
     const result = analyzeEditMismatch(content, search);
 
-    expect(result).toContain("- const x = 1; (expected)");
-    expect(result).toContain("+   const x = 1; (actual)");
+    expect(result).toContain("- const x = 1;");
+    expect(result).toContain("+   const x = 1;");
   });
 });


### PR DESCRIPTION
This PR removes the redundant `(expected)` and `(actual)` suffixes from the best partial match report generated when an edit fails, making the output cleaner and more standard.