### PR TITLE
feat: Ensure dot and tool name flex-shrink to 0 in ToolDisplay.tsx

### DIFF
--- a/packages/code/src/components/ToolDisplay.tsx
+++ b/packages/code/src/components/ToolDisplay.tsx
@@ -60,8 +60,10 @@ export const ToolDisplay: React.FC<ToolDisplayProps> = ({
   return (
     <Box flexDirection="column">
       <Box>
-        <Text color={getStatusColor()}>● </Text>
-        <Text color="white">{toolName}</Text>
+        <Box flexShrink={0}>
+          <Text color={getStatusColor()}>● </Text>
+          <Text color="white">{toolName}</Text>
+        </Box>
         {/* Display compactParams in collapsed state */}
         {!isExpanded && compactParams && (
           <Text color="gray"> {compactParams}</Text>


### PR DESCRIPTION
This commit ensures that the dot and tool name in ToolDisplay.tsx have flex-shrink: 0, preventing them from being compressed when space is limited.