### PR TITLE
fix: improve tag description generation in scripts/version.js

### DIFF
--- a/scripts/version.js
+++ b/scripts/version.js
@@ -84,6 +84,8 @@ if (results.length > 0) {
       // Get the most recent tag that is reachable from HEAD
       const lastTag = execSync('git tag --list "v*" --sort=-v:refname | head -n 1', { encoding: 'utf8' }).trim();
       if (lastTag) {
+        // Use --merges or other flags if needed, but for now just ensure we don't include the last tag itself
+        // git log tag..HEAD includes commits AFTER tag up to HEAD
         changelog = execSync(`git log ${lastTag}..HEAD --pretty=format:"- %s (%h)"`, { encoding: 'utf8' }).trim();
       } else {
         changelog = execSync('git log --pretty=format:"- %s (%h)"', { encoding: 'utf8' }).trim();
@@ -93,6 +95,10 @@ if (results.length > 0) {
     }
 
     execSync(`git commit -m "${commitMsg}" --no-verify`, { stdio: 'inherit' });
+    // Add the current bump commit to the top of the changelog manually
+    const currentCommitHash = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
+    changelog = `- ${commitMsg} (${currentCommitHash})${changelog ? '\n' + changelog : ''}`;
+
     execSync(`git tag -a ${tagName} -m "${commitMsg.replace(/"/g, '\\"')}\n\n${changelog.replace(/"/g, '\\"')}"`, { stdio: 'inherit' });
     console.log(`Created tag: ${tagName}`);
     console.log(`\nChangelog:\n${changelog}\n`);


### PR DESCRIPTION
This PR improves the changelog generation in  by:
1. Generating the changelog before the version bump commit to avoid range issues.
2. Manually prepending the new bump commit to the changelog.
3. Avoiding brittle string filtering for 'chore: bump' commits.

This ensures the tag description contains all changes since the last tag plus the current version bump, without including the previous version's bump commit.