### PR TITLE
feat: remove emojis and improve directory path display in file selector

### DIFF
--- a/packages/agent-sdk/src/utils/fileSearch.ts
+++ b/packages/agent-sdk/src/utils/fileSearch.ts
@@ -6,10 +6,17 @@ import type { FileItem } from "../types/fileSearch.js";
  * Convert Path objects to FileItem objects
  */
 export const convertPathsToFileItems = (paths: Path[]): FileItem[] => {
-  return paths.map((pathObj) => ({
-    path: pathObj.relative(),
-    type: pathObj.isDirectory() ? "directory" : "file",
-  }));
+  return paths.map((pathObj) => {
+    const isDirectory = pathObj.isDirectory();
+    let path = pathObj.relative();
+    if (isDirectory && !path.endsWith("/")) {
+      path += "/";
+    }
+    return {
+      path,
+      type: isDirectory ? "directory" : "file",
+    };
+  });
 };
 
 /**

--- a/packages/code/src/components/FileSelector.tsx
+++ b/packages/code/src/components/FileSelector.tsx
@@ -53,7 +53,7 @@ export const FileSelector: React.FC<FileSelectorProps> = ({
         borderLeft={false}
         borderRight={false}
       >
-        <Text color="yellow">📁 No files found for "{searchQuery}"</Text>
+        <Text color="yellow">No files found for "{searchQuery}"</Text>
         <Text dimColor>Press Escape to cancel</Text>
       </Box>
     );
@@ -92,8 +92,7 @@ export const FileSelector: React.FC<FileSelectorProps> = ({
       borderRight={false}
     >
       <Text color="cyan" bold>
-        📁 Select File/Directory{" "}
-        {searchQuery && `(filtering: "${searchQuery}")`}
+        Select File/Directory {searchQuery && `(filtering: "${searchQuery}")`}
       </Text>
 
       {/* Show hint for more files above */}
@@ -104,7 +103,6 @@ export const FileSelector: React.FC<FileSelectorProps> = ({
       {displayFiles.map((fileItem, displayIndex) => {
         const actualIndex = startIndex + displayIndex;
         const isSelected = actualIndex === selectedIndex;
-        const icon = fileItem.type === "directory" ? "📁" : "📄";
 
         return (
           <Box key={fileItem.path}>
@@ -112,8 +110,7 @@ export const FileSelector: React.FC<FileSelectorProps> = ({
               color={isSelected ? "black" : "white"}
               backgroundColor={isSelected ? "cyan" : undefined}
             >
-              {"  "}
-              {icon} {fileItem.path}
+              {fileItem.path}
             </Text>
           </Box>
         );
@@ -124,12 +121,9 @@ export const FileSelector: React.FC<FileSelectorProps> = ({
         <Text dimColor>... {files.length - endIndex} more files below</Text>
       )}
 
-      <Box marginTop={1}>
+      <Box>
         <Text dimColor>
           Use ↑↓ to navigate, Enter/Tab to select, Escape to cancel
-        </Text>
-        <Text dimColor>
-          , File {selectedIndex + 1} of {files.length}
         </Text>
       </Box>
     </Box>

--- a/packages/code/tests/components/FileSelector.test.tsx
+++ b/packages/code/tests/components/FileSelector.test.tsx
@@ -23,7 +23,6 @@ describe("FileSelector", () => {
     expect(output).toContain("Select File/Directory");
     expect(output).toContain("file1.txt");
     expect(output).toContain("file10.txt");
-    expect(output).toContain(", File 1 of 20");
     expect(output).toContain("... 10 more files below");
   });
 
@@ -41,7 +40,6 @@ describe("FileSelector", () => {
 
     const output = lastFrame();
     expect(output).toContain("Select File/Directory");
-    expect(output).toContain(", File 1 of 25");
     expect(output).toContain("... 15 more files below");
   });
 
@@ -102,10 +100,10 @@ describe("FileSelector", () => {
     expect(windowAt19.endIndex).toBe(20);
   });
 
-  it("should display directory icons correctly", () => {
+  it("should display directory paths correctly", () => {
     const mixedFiles: FileItem[] = [
-      { path: "src", type: "directory" },
-      { path: "src/components", type: "directory" },
+      { path: "src/", type: "directory" },
+      { path: "src/components/", type: "directory" },
       { path: "package.json", type: "file" },
       { path: "README.md", type: "file" },
     ];
@@ -114,10 +112,12 @@ describe("FileSelector", () => {
     const { lastFrame } = render(<FileSelector {...propsWithMixed} />);
 
     const output = lastFrame();
-    expect(output).toContain("📁 src");
-    expect(output).toContain("📁 src/components");
-    expect(output).toContain("📄 package.json");
-    expect(output).toContain("📄 README.md");
+    expect(output).toContain("src/");
+    expect(output).toContain("src/components/");
+    expect(output).toContain("package.json");
+    expect(output).toContain("README.md");
+    expect(output).not.toContain("📁");
+    expect(output).not.toContain("📄");
   });
 
   describe("Tab key functionality", () => {
@@ -215,8 +215,8 @@ describe("FileSelector", () => {
 
     it("should handle Tab key correctly with directory files", () => {
       const mixedFiles: FileItem[] = [
-        { path: "src", type: "directory" },
-        { path: "components", type: "directory" },
+        { path: "src/", type: "directory" },
+        { path: "components/", type: "directory" },
         { path: "index.ts", type: "file" },
       ];
 
@@ -231,7 +231,7 @@ describe("FileSelector", () => {
       // Press Tab key (should select first item - directory)
       stdin.write("\t");
 
-      expect(onSelectMock).toHaveBeenCalledWith("src");
+      expect(onSelectMock).toHaveBeenCalledWith("src/");
       expect(onSelectMock).toHaveBeenCalledTimes(1);
     });
   });


### PR DESCRIPTION
This PR removes emojis from the file selector UI, ensures directory paths end with a trailing slash for better clarity and insertion, and cleans up the UI by removing leading spaces and the file count indicator.