### PR TITLE
feat: add '...' to Task tool short result when tool count > 2

### DIFF
--- a/packages/agent-sdk/src/tools/taskTool.ts
+++ b/packages/agent-sdk/src/tools/taskTool.ts
@@ -138,6 +138,9 @@ export function createTaskTool(subagentManager: SubagentManager): ToolPlugin {
               });
 
               let shortResult = "";
+              if (toolCount > 2) {
+                shortResult += "... ";
+              }
               if (lastTools.length > 0) {
                 shortResult += `${lastTools.join(", ")} `;
               }

--- a/packages/agent-sdk/tests/tools/taskTool.test.ts
+++ b/packages/agent-sdk/tests/tools/taskTool.test.ts
@@ -89,6 +89,96 @@ describe("Task Tool Background Execution", () => {
     expect(result.shortResult).toBe("Task started in background: task_12345");
   });
 
+  it("should add '...' to shortResult when toolCount > 2", async () => {
+    const mockInstance = {
+      subagentId: "gp-test-id",
+      lastTools: ["Read", "Write"],
+      messageManager: {
+        getMessages: vi.fn(() => [
+          { blocks: [{ type: "tool" }, { type: "tool" }] },
+          { blocks: [{ type: "tool" }] },
+        ]),
+        getlatestTotalTokens: vi.fn(() => 1000),
+      },
+    };
+
+    let capturedShortResult = "";
+    const contextWithCallback: ToolContext = {
+      ...mockToolContext,
+      onShortResultUpdate: (sr) => {
+        capturedShortResult = sr;
+      },
+    };
+
+    vi.mocked(mockSubagentManager.findSubagent).mockResolvedValue(gpConfig);
+    vi.mocked(mockSubagentManager.createInstance).mockImplementation(
+      async (config, args, background, updateShortResult) => {
+        // Simulate the callback being called
+        setTimeout(() => updateShortResult?.(), 0);
+        return mockInstance as unknown as SubagentInstance;
+      },
+    );
+    vi.mocked(mockSubagentManager.executeTask).mockResolvedValue("done");
+
+    await taskTool.execute(
+      {
+        description: "Test",
+        prompt: "Test",
+        subagent_type: "general-purpose",
+      },
+      contextWithCallback,
+    );
+
+    await vi.waitFor(() => {
+      expect(capturedShortResult).toBe(
+        "... Read, Write (3 tools | 1,000 tokens)",
+      );
+    });
+  });
+
+  it("should NOT add '...' to shortResult when toolCount <= 2", async () => {
+    const mockInstance = {
+      subagentId: "gp-test-id",
+      lastTools: ["Read", "Write"],
+      messageManager: {
+        getMessages: vi.fn(() => [
+          { blocks: [{ type: "tool" }, { type: "tool" }] },
+        ]),
+        getlatestTotalTokens: vi.fn(() => 1000),
+      },
+    };
+
+    let capturedShortResult = "";
+    const contextWithCallback: ToolContext = {
+      ...mockToolContext,
+      onShortResultUpdate: (sr) => {
+        capturedShortResult = sr;
+      },
+    };
+
+    vi.mocked(mockSubagentManager.findSubagent).mockResolvedValue(gpConfig);
+    vi.mocked(mockSubagentManager.createInstance).mockImplementation(
+      async (config, args, background, updateShortResult) => {
+        setTimeout(() => updateShortResult?.(), 0);
+        return mockInstance as unknown as SubagentInstance;
+      },
+    );
+    vi.mocked(mockSubagentManager.executeTask).mockResolvedValue("done");
+
+    await taskTool.execute(
+      {
+        description: "Test",
+        prompt: "Test",
+        subagent_type: "general-purpose",
+      },
+      contextWithCallback,
+    );
+
+    await vi.waitFor(() => {
+      expect(capturedShortResult).toBe("Read, Write (2 tools | 1,000 tokens)");
+    });
+  });
+
   it("should handle missing parameters", async () => {
     const result = await taskTool.execute({}, mockToolContext);
     expect(result.success).toBe(false);


### PR DESCRIPTION
This PR adds an ellipsis to the start of the Task tool's short result summary when more than two tools have been executed by a subagent. This provides better visual feedback for long-running tasks with multiple tool calls.