### PR TITLE
chore: replace gemini-2.0-flash-exp with gemini-2.5-flash in examples

### DIFF
--- a/.wave/rules/examples.md
+++ b/.wave/rules/examples.md
@@ -6,7 +6,7 @@ paths:
   - need to create temporary directories
   - test by sending real messages using `agent.sendMessage`
   - run example like this: `pnpm -F xxx exec tsx examples/hi.ts`
-  - use `gemini-2.5-flash` or `gemini-2.0-flash-exp` for cheaper and faster testing (pass as `agentModel` in `Agent.create`)
+  - use `gemini-2.5-flash` for cheaper and faster testing (pass as `agentModel` in `Agent.create`)
   - always include a `finally` block that calls `await agent.destroy()` to ensure the process exits
   - never access private properties directly with `(agent as any)`
   - before running any example, always run type-check for `agent-sdk` to ensure types are valid: `pnpm -F wave-agent-sdk run type-check`

--- a/packages/agent-sdk/examples/backgrounding-demo.ts
+++ b/packages/agent-sdk/examples/backgrounding-demo.ts
@@ -16,7 +16,7 @@ async function demonstrateBackgrounding(): Promise<void> {
     // Create agent with bash tool enabled
     agent = await Agent.create({
       workdir,
-      agentModel: "gemini-2.0-flash-exp",
+      agentModel: "gemini-2.5-flash",
       permissionMode: "bypassPermissions", // Ensure tools can run without permission prompts
       callbacks: {
         onAssistantContentUpdated: () => {

--- a/packages/agent-sdk/examples/modular-rules-basic.ts
+++ b/packages/agent-sdk/examples/modular-rules-basic.ts
@@ -71,7 +71,7 @@ paths:
 
     agent = await Agent.create({
       workdir: testDir,
-      agentModel: "gemini-2.0-flash-exp",
+      agentModel: "gemini-2.5-flash",
       logger: {
         debug: (...args: unknown[]) => console.log("[DEBUG]", ...args),
         info: (...args: unknown[]) => console.log("[INFO]", ...args),

--- a/packages/agent-sdk/examples/modular-rules-demo.ts
+++ b/packages/agent-sdk/examples/modular-rules-demo.ts
@@ -175,7 +175,7 @@ async function demoModularRules(): Promise<void> {
 
     agent = await Agent.create({
       workdir: testDir,
-      agentModel: "gemini-2.0-flash-exp",
+      agentModel: "gemini-2.5-flash",
       logger: {
         debug: (...args: unknown[]) => {
           const message = args[0];

--- a/packages/agent-sdk/examples/parallel-execution-demo.ts
+++ b/packages/agent-sdk/examples/parallel-execution-demo.ts
@@ -26,7 +26,7 @@ async function demonstrateParallelExecution(): Promise<void> {
     // Create agent with bash tool enabled and callbacks for timing
     const agent = await Agent.create({
       workdir,
-      agentModel: "gemini-2.0-flash-exp",
+      agentModel: "gemini-2.5-flash",
       callbacks: {
         onAssistantContentUpdated: (chunk: string) => {
           process.stdout.write(chunk);

--- a/packages/agent-sdk/examples/permission-deny-config.ts
+++ b/packages/agent-sdk/examples/permission-deny-config.ts
@@ -36,7 +36,7 @@ async function main() {
 
   // 3. Initialize the agent pointing to the temporary directory
   const agent = await Agent.create({
-    agentModel: "gemini-2.0-flash-exp",
+    agentModel: "gemini-2.5-flash",
     workdir: tempDir,
     callbacks: {
       onToolBlockUpdated: (params) => {


### PR DESCRIPTION
This PR updates the model used in example files and documentation from gemini-2.0-flash-exp to gemini-2.5-flash.