### PR TITLE
feat: Add space after prefixes for slash commands and hooks

### DIFF
--- a/packages/code/src/components/MessageItem.tsx
+++ b/packages/code/src/components/MessageItem.tsx
@@ -25,14 +25,10 @@ export const MessageItem = ({ message, isExpanded }: MessageItemProps) => {
             {block.type === "text" && block.content.trim() && (
               <Box>
                 {block.customCommandContent && (
-                  <Text color="cyan" bold>
-                    $
-                  </Text>
+                  <Text color="cyan" bold>$ </Text>
                 )}
                 {block.source === MessageSource.HOOK && (
-                  <Text color="magenta" bold>
-                    ~
-                  </Text>
+                  <Text color="magenta" bold>~ </Text>
                 )}
                 {message.role === "user" ? (
                   <Text backgroundColor="gray" color="white">


### PR DESCRIPTION
This PR adds a space after the `$` prefix for slash commands and the `~` prefix for hook messages in `MessageItem.tsx` to improve readability and consistency.