### PR TITLE
fix: disable shortResult updates for background tasks

### DIFF
--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -306,7 +306,7 @@ Usage notes:
       }
 
       child.stdout?.on("data", (data) => {
-        if (!isAborted && !isBackgrounded) {
+        if (!isAborted && !isBackgrounded && !runInBackground) {
           const chunk = stripAnsiColors(data.toString());
           outputBuffer += chunk;
           context.onShortResultUpdate?.(chunk.trim().split("\n").pop() || "");
@@ -314,7 +314,7 @@ Usage notes:
       });
 
       child.stderr?.on("data", (data) => {
-        if (!isAborted && !isBackgrounded) {
+        if (!isAborted && !isBackgrounded && !runInBackground) {
           const chunk = stripAnsiColors(data.toString());
           errorBuffer += chunk;
           context.onShortResultUpdate?.(chunk.trim().split("\n").pop() || "");

--- a/packages/agent-sdk/src/tools/taskTool.ts
+++ b/packages/agent-sdk/src/tools/taskTool.ts
@@ -121,8 +121,13 @@ export function createTaskTool(subagentManager: SubagentManager): ToolPlugin {
               });
             }
 
+            let isBackgrounded = false;
+
             // Set up callback to update shortResult with tool names, tool count and tokens
             const updateShortResult = () => {
+              // Do not update shortResult if it is running in background
+              if (run_in_background || isBackgrounded) return;
+
               const messages = instance.messageManager.getMessages();
               const tokens = instance.messageManager.getlatestTotalTokens();
               const lastTools = instance.lastTools;
@@ -168,8 +173,6 @@ export function createTaskTool(subagentManager: SubagentManager): ToolPlugin {
 
             // Initial update
             updateShortResult();
-
-            let isBackgrounded = false;
 
             // Register for backgrounding if not already in background
             if (!run_in_background && context.foregroundTaskManager) {

--- a/specs/002-bash-tools-spec/contracts/bash-tools-api.md
+++ b/specs/002-bash-tools-spec/contracts/bash-tools-api.md
@@ -58,6 +58,6 @@ interface BackgroundShell {
 
 ## Execution Flow
 1. **Foreground**: `Bash` tool spawns a process, waits for completion or timeout, and returns the combined output.
-2. **Background**: `Bash` tool registers the command with `BackgroundBashManager`, which spawns the process and returns a `bash_id`.
+2. **Background**: `Bash` tool registers the command with `BackgroundBashManager`, which spawns the process and returns a `bash_id`. Background tasks do not update their `shortResult` while running to avoid UI "unknown" blocks.
 3. **Monitoring**: `BashOutput` tool queries `BackgroundBashManager` for accumulated output of a specific `bash_id`.
 4. **Termination**: `KillBash` tool requests `BackgroundBashManager` to terminate a specific `shell_id`.

--- a/specs/002-bash-tools-spec/spec.md
+++ b/specs/002-bash-tools-spec/spec.md
@@ -57,7 +57,8 @@ As an AI agent, I want to run long-running commands in the background and retrie
 - **FR-006**: System MUST provide a `KillBash` tool to terminate background processes.
 - **FR-007**: All bash output MUST have ANSI color codes stripped.
 - **FR-008**: Foreground bash output MUST be truncated if it exceeds 30,000 characters.
-- **FR-009**: The system MUST maintain environment variables across sequential `Bash` calls (persistent session behavior).
+- **FR-009**: Background bash tasks MUST NOT update their `shortResult` while running to prevent unnecessary message updates and "unknown" tool blocks in the UI.
+- **FR-010**: The system MUST maintain environment variables across sequential `Bash` calls (persistent session behavior).
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/061-task-background-execution/contracts/tools.md
+++ b/specs/061-task-background-execution/contracts/tools.md
@@ -11,7 +11,7 @@ Delegates a task to a subagent, now with background support.
 
 **Returns:**
 - If `run_in_background: false`: The subagent's text response.
-- If `run_in_background: true`: A message containing the `task_id`.
+- If `run_in_background: true`: A message containing the `task_id`. Background tasks do not update their `shortResult` while running to avoid UI "unknown" blocks.
 
 ---
 

--- a/specs/061-task-background-execution/spec.md
+++ b/specs/061-task-background-execution/spec.md
@@ -87,9 +87,11 @@ As a user, I want to use a `/tasks` command in the CLI to list and manage all ba
 - **FR-008**: `TaskStop` MUST support a `task_id` parameter.
 - **FR-009**: The `BashOutput` and `KillBash` tools MUST be removed/deprecated in favor of the unified `TaskOutput` and `TaskStop` tools.
 - **FR-010**: `TaskOutput` MUST work for both background shell tasks and async agent tasks.
-- **FR-011**: The CLI MUST implement a `/tasks` command to list all active and recently completed tasks.
-- **FR-012**: The legacy `/bashes` command MUST be removed from the CLI.
-- **FR-013**: The `/tasks` command output MUST include task IDs, status, and task type.
+- **FR-011**: Background tasks MUST NOT update their `shortResult` while running to prevent unnecessary message updates and "unknown" tool blocks in the UI.
+- **FR-012**: The CLI MUST implement a `/tasks` command to list all active and recently completed tasks.
+- **FR-012**: The CLI MUST implement a `/tasks` command to list all active and recently completed tasks.
+- **FR-013**: The legacy `/bashes` command MUST be removed from the CLI.
+- **FR-014**: The `/tasks` command output MUST include task IDs, status, and task type.
 
 ### Key Entities *(include if feature involves data)*
 


### PR DESCRIPTION
This PR disables shortResult updates for backgrounded Task and Bash tools. This prevents the creation of redundant 'unknown' tool blocks in the UI when the main agent has moved on to a new assistant message while background tasks are still running.