### PR TITLE
feat: omit tool policy from system prompt when no tools are available

### DIFF
--- a/packages/agent-sdk/src/prompts/index.ts
+++ b/packages/agent-sdk/src/prompts/index.ts
@@ -305,8 +305,9 @@ export function buildSystemPrompt(
   } = {},
 ): string {
   let prompt = basePrompt || DEFAULT_SYSTEM_PROMPT;
-
-  prompt += `\n\n${TOOL_POLICY}`;
+  if (tools.length > 0) {
+    prompt += `\n\n${TOOL_POLICY}`;
+  }
 
   for (const tool of tools) {
     if (tool.prompt) {

--- a/packages/agent-sdk/tests/constants/buildSystemPrompt.test.ts
+++ b/packages/agent-sdk/tests/constants/buildSystemPrompt.test.ts
@@ -2,11 +2,28 @@ import { describe, it, expect } from "vitest";
 import {
   buildSystemPrompt,
   DEFAULT_SYSTEM_PROMPT,
+  TOOL_POLICY,
 } from "../../src/prompts/index.js";
 import { READ_TOOL_NAME, WRITE_TOOL_NAME } from "../../src/constants/tools.js";
 import { ToolPlugin } from "../../src/tools/types.js";
 
 describe("buildSystemPrompt", () => {
+  it("should include tool policy when tools are present", () => {
+    const tools = [
+      {
+        name: READ_TOOL_NAME,
+        prompt: () => "Read for reading files",
+      } as unknown as ToolPlugin,
+    ];
+    const prompt = buildSystemPrompt(DEFAULT_SYSTEM_PROMPT, tools);
+    expect(prompt).toContain(TOOL_POLICY);
+  });
+
+  it("should exclude tool policy when no tools are present", () => {
+    const prompt = buildSystemPrompt(DEFAULT_SYSTEM_PROMPT, []);
+    expect(prompt).not.toContain(TOOL_POLICY);
+  });
+
   it("should include tool-specific prompts when tools are present", () => {
     const tools = [
       {

--- a/specs/067-cli-tool-selection/spec.md
+++ b/specs/067-cli-tool-selection/spec.md
@@ -84,6 +84,7 @@ As a user, I want to use the `--tools` flag with the `--print` (or `-p`) option 
 - **FR-005**: The Agent SDK MUST be updated to accept a `tools` argument, which can be a `string[]` or `undefined`.
 - **FR-006**: The CLI MUST parse the `--tools` string into a `string[]` before passing it to the Agent SDK.
 - **FR-007**: If the `--tools` argument is omitted, the system MUST default to the "default" tool set.
+- **FR-008**: If no tools are available (e.g., `--tools ""`), the system prompt MUST NOT include the "Tool usage policy" section.
 
 ### Key Entities *(include if feature involves data)*
 


### PR DESCRIPTION
This PR implements the logic to omit the tool usage policy from the system prompt when no tools are provided, as specified in spec FR-008.