### PR TITLE
feat: remove existing plan file on first entry and preserve on re-entry

### DIFF
--- a/packages/agent-sdk/src/managers/planManager.ts
+++ b/packages/agent-sdk/src/managers/planManager.ts
@@ -9,6 +9,7 @@ import type { Logger } from "../types/core.js";
  */
 export class PlanManager {
   private planDir: string;
+  private currentPlanFilePath: string | null = null;
 
   constructor(private logger?: Logger) {
     this.planDir = path.join(os.homedir(), ".wave", "plans");
@@ -32,6 +33,24 @@ export class PlanManager {
     }
     const name = generateRandomName(seed);
     const filePath = path.join(this.planDir, `${name}.md`);
+
+    if (this.currentPlanFilePath !== filePath) {
+      try {
+        await fs.unlink(filePath);
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          (error as Error & { code?: string }).code !== "ENOENT"
+        ) {
+          this.logger?.error(
+            `Failed to remove existing plan file: ${filePath}`,
+            error,
+          );
+        }
+      }
+      this.currentPlanFilePath = filePath;
+    }
+
     this.logger?.info(`Generated plan file path: ${filePath}`);
     return { path: filePath, name };
   }

--- a/packages/agent-sdk/tests/managers/planManager.test.ts
+++ b/packages/agent-sdk/tests/managers/planManager.test.ts
@@ -59,4 +59,31 @@ describe("PlanManager", () => {
     expect(result1.path).not.toBe(result2.path);
     expect(result1.name).not.toBe(result2.name);
   });
+
+  it("should remove existing plan file on first generation but not on re-entry", async () => {
+    const planManager = new PlanManager();
+    const seed = "test-seed";
+
+    // First call
+    await planManager.getOrGeneratePlanFilePath(seed);
+    expect(fs.unlink).toHaveBeenCalledTimes(1);
+
+    // Second call (re-entry)
+    await planManager.getOrGeneratePlanFilePath(seed);
+    expect(fs.unlink).toHaveBeenCalledTimes(1); // Still 1
+
+    // Different seed
+    await planManager.getOrGeneratePlanFilePath("different-seed");
+    expect(fs.unlink).toHaveBeenCalledTimes(2);
+  });
+
+  it("should ignore ENOENT when removing existing plan file", async () => {
+    const planManager = new PlanManager();
+    vi.mocked(fs.unlink).mockRejectedValueOnce({ code: "ENOENT" });
+
+    await expect(
+      planManager.getOrGeneratePlanFilePath(),
+    ).resolves.toBeDefined();
+    expect(fs.unlink).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
This PR adds logic to PlanManager to remove an existing plan file when entering plan mode for the first time in a session, while preserving it when re-entering with the same path. This ensures a clean state for new plans while preventing data loss during session transitions.