### PR TITLE
feat: use AI-generated description for subagent background tasks

### DIFF
--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -67,6 +67,7 @@ export interface SubagentInstance {
   messages: Message[];
   lastTools: string[]; // Track last two tool names
   subagentType: string; // Store the subagent type for hook context
+  description: string; // Store the AI-generated description
   backgroundTaskId?: string; // ID of the background task if transitioned
   onUpdate?: () => void; // Optional callback for real-time updates
 }
@@ -249,6 +250,7 @@ export class SubagentManager {
       messages: [],
       lastTools: [], // Initialize lastTools
       subagentType: parameters.subagent_type, // Store the subagent type
+      description: parameters.description, // Store the AI-generated description
       onUpdate,
     };
 
@@ -287,7 +289,7 @@ export class SubagentManager {
           type: "subagent",
           status: "running",
           startTime,
-          description: instance.configuration.description,
+          description: instance.description,
           stdout: "",
           stderr: "",
           subagentId: instance.subagentId,
@@ -354,7 +356,7 @@ export class SubagentManager {
       type: "subagent",
       status: "running",
       startTime,
-      description: instance.configuration.description,
+      description: instance.description,
       stdout: "",
       stderr: "",
       subagentId: instance.subagentId,

--- a/packages/agent-sdk/tests/managers/subagentManager.callbacks.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.callbacks.test.ts
@@ -643,7 +643,7 @@ describe("SubagentManager - Callback Integration", () => {
         expect.objectContaining({
           type: "subagent",
           status: "running",
-          description: "Background subagent",
+          description: "Test bg",
         }),
       );
     });


### PR DESCRIPTION
Ensures that the description displayed in the BackgroundTaskManager UI is the specific task description generated by the AI, rather than the static subagent description from the YAML frontmatter.