### PR TITLE
revert: remove thinking_level control for gemini-3-flash

### DIFF
--- a/packages/agent-sdk/src/services/aiService.ts
+++ b/packages/agent-sdk/src/services/aiService.ts
@@ -69,13 +69,7 @@ interface ErrorData {
 type OpenAIModelConfig = Omit<
   ChatCompletionCreateParamsNonStreaming,
   "messages"
-> & {
-  vertexai?: {
-    thinking_config: {
-      thinking_level: string;
-    };
-  };
-};
+>;
 
 /**
  * Get specific configuration parameters based on model name
@@ -97,14 +91,6 @@ function getModelConfig(
   if (modelName.includes("gpt-5-codex")) {
     // gpt-5-codex model sets temperature to undefined
     config.temperature = undefined;
-  }
-
-  if (modelName.startsWith("gemini-3-flash")) {
-    config.vertexai = {
-      thinking_config: {
-        thinking_level: "minimal",
-      },
-    };
   }
 
   return config;

--- a/packages/agent-sdk/tests/services/aiService.coverage.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.coverage.test.ts
@@ -90,7 +90,7 @@ describe("AI Service - Branch Coverage", () => {
       });
 
       const callArgs = mockCreate.mock.calls[0][0];
-      expect(callArgs.vertexai.thinking_config.thinking_level).toBe("minimal");
+      expect(callArgs.vertexai).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
This PR removes the thinking_level configuration for Gemini 3 models in the agent-sdk package, as it is no longer needed.