### PR TITLE
refactor: update read tool and edit mismatch format

### DIFF
--- a/packages/agent-sdk/src/tools/readTool.ts
+++ b/packages/agent-sdk/src/tools/readTool.ts
@@ -3,6 +3,7 @@ import { extname } from "path";
 import { logger } from "../utils/globalLogger.js";
 import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
 import { resolvePath, getDisplayPath } from "../utils/path.js";
+import { formatLineNumberPrefix } from "../utils/stringUtils.js";
 import {
   isBinaryDocument,
   getBinaryDocumentError,
@@ -293,7 +294,7 @@ Usage:
           // Truncate overly long lines
           const truncatedLine =
             line.length > 2000 ? line.substring(0, 2000) + "..." : line;
-          return `${lineNumber.toString().padStart(6)}\t${truncatedLine}`;
+          return `${formatLineNumberPrefix(lineNumber)}${truncatedLine}`;
         })
         .join("\n");
 

--- a/packages/agent-sdk/src/utils/editUtils.ts
+++ b/packages/agent-sdk/src/utils/editUtils.ts
@@ -1,6 +1,7 @@
 /**
  * Utility functions for file editing tools
  */
+import { formatLineNumberPrefix } from "./stringUtils.js";
 
 /**
  * Escape regular expression special characters
@@ -75,10 +76,10 @@ export function analyzeEditMismatch(
     const expectedLine = searchLines[j];
 
     if (actualLine === expectedLine) {
-      reportLines.push(`${lineNum.toString().padStart(6)}\t${actualLine}`);
+      reportLines.push(`${formatLineNumberPrefix(lineNum)}${actualLine}`);
     } else {
-      reportLines.push(`${lineNum.toString().padStart(6)}\t- ${expectedLine}`);
-      reportLines.push(`${lineNum.toString().padStart(6)}\t+ ${actualLine}`);
+      reportLines.push(`${formatLineNumberPrefix(lineNum)}- ${expectedLine}`);
+      reportLines.push(`${formatLineNumberPrefix(lineNum)}+ ${actualLine}`);
     }
   }
 

--- a/packages/agent-sdk/src/utils/stringUtils.ts
+++ b/packages/agent-sdk/src/utils/stringUtils.ts
@@ -82,3 +82,12 @@ export const stripAnsiColors = (text: string): string => {
   const ansiEscapeRegex = new RegExp(`${escapeChar}\\[[0-9;]*[a-zA-Z]`, "g");
   return text.replace(ansiEscapeRegex, "");
 };
+
+/**
+ * Format a line number prefix in cat -n style (padStart(6) + tab)
+ * @param lineNumber The line number
+ * @returns Formatted line number prefix
+ */
+export function formatLineNumberPrefix(lineNumber: number): string {
+  return `${lineNumber.toString().padStart(6)}\t`;
+}

--- a/packages/agent-sdk/tests/utils/mismatchAnalysis.test.ts
+++ b/packages/agent-sdk/tests/utils/mismatchAnalysis.test.ts
@@ -17,10 +17,10 @@ describe("analyzeEditMismatch", () => {
     const result = analyzeEditMismatch(content, search);
 
     expect(result).toContain("Best partial match found at line 1:");
-    expect(result).toContain("   1 | const x = 1;");
-    expect(result).toContain("   2 | - const y = 2;");
-    expect(result).toContain("   2 | + const y = 3;");
-    expect(result).toContain("   3 | return x + y;");
+    expect(result).toContain("     1\tconst x = 1;");
+    expect(result).toContain("     2\t- const y = 2;");
+    expect(result).toContain("     2\t+ const y = 3;");
+    expect(result).toContain("     3\treturn x + y;");
   });
 
   it("should find the best match among multiple candidates", () => {
@@ -29,8 +29,8 @@ describe("analyzeEditMismatch", () => {
     const result = analyzeEditMismatch(content, search);
 
     expect(result).toContain("Best partial match found at line 2:");
-    expect(result).toContain("   2 | line A");
-    expect(result).toContain("   3 | line B");
+    expect(result).toContain("     2\tline A");
+    expect(result).toContain("     3\tline B");
   });
 
   it("should handle indentation mismatches explicitly", () => {


### PR DESCRIPTION
This PR removes Jupyter notebook mention from readTool and updates analyzeEditMismatch to use the standard cat -n format (padStart(6) + tab) for consistency with editTool prompt.