### PR TITLE
refactor: consolidate session exports in agent-sdk core

### DIFF
--- a/packages/agent-sdk/src/core/session.ts
+++ b/packages/agent-sdk/src/core/session.ts
@@ -1,0 +1,6 @@
+export {
+  listSessions,
+  truncateContent,
+  loadSessionFromJsonl,
+} from "../services/session.js";
+export type { SessionMetadata, SessionData } from "../services/session.js";

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -1,9 +1,5 @@
 // Export all services
-export * from "./services/aiService.js";
-export * from "./services/memory.js";
-export * from "./services/session.js";
-export * from "./services/hook.js";
-export * from "./services/jsonlHandler.js";
+export * from "./core/session.js";
 
 // Export constants
 export * from "./constants/tools.js";


### PR DESCRIPTION
Consolidate session-related SDK APIs into core/session.ts and remove direct service exports from index.ts.