### PR TITLE
fix: improve confirmation height calculation

### DIFF
--- a/packages/code/src/components/ChatInterface.tsx
+++ b/packages/code/src/components/ChatInterface.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useLayoutEffect } from "react";
 import { Box, useStdout } from "ink";
 import { MessageList } from "./MessageList.js";
 import { InputBox } from "./InputBox.js";
@@ -12,7 +12,9 @@ import type { PermissionDecision } from "wave-agent-sdk";
 
 export const ChatInterface: React.FC = () => {
   const { stdout } = useStdout();
-  const [isDetailsTooTall, setIsDetailsTooTall] = useState(false);
+  const [detailsHeight, setDetailsHeight] = useState(0);
+  const [selectorHeight, setSelectorHeight] = useState(0);
+  const [isConfirmationTooTall, setIsConfirmationTooTall] = useState(false);
 
   const {
     messages,
@@ -36,39 +38,49 @@ export const ChatInterface: React.FC = () => {
     setWasLastDetailsTooTall,
   } = useChat();
 
-  const handleHeightMeasured = useCallback(
-    (height: number) => {
-      const terminalHeight = stdout?.rows || 24;
-      if (height > terminalHeight - 10) {
-        setIsDetailsTooTall(true);
-      } else {
-        setIsDetailsTooTall(false);
-      }
-    },
-    [stdout?.rows],
-  );
+  const handleDetailsHeightMeasured = useCallback((height: number) => {
+    setDetailsHeight(height);
+  }, []);
+
+  const handleSelectorHeightMeasured = useCallback((height: number) => {
+    setSelectorHeight(height);
+  }, []);
+
+  useLayoutEffect(() => {
+    const terminalHeight = stdout?.rows || 24;
+    const totalHeight = detailsHeight + selectorHeight;
+    if (totalHeight > terminalHeight) {
+      setIsConfirmationTooTall(true);
+    } else {
+      setIsConfirmationTooTall(false);
+    }
+  }, [detailsHeight, selectorHeight, stdout?.rows]);
 
   const handleConfirmationCancel = useCallback(() => {
-    if (isDetailsTooTall) {
+    if (isConfirmationTooTall) {
       setWasLastDetailsTooTall((prev) => prev + 1);
-      setIsDetailsTooTall(false);
+      setIsConfirmationTooTall(false);
     }
     originalHandleConfirmationCancel();
   }, [
-    isDetailsTooTall,
+    isConfirmationTooTall,
     originalHandleConfirmationCancel,
     setWasLastDetailsTooTall,
   ]);
 
   const wrappedHandleConfirmationDecision = useCallback(
     (decision: PermissionDecision) => {
-      if (isDetailsTooTall) {
+      if (isConfirmationTooTall) {
         setWasLastDetailsTooTall((prev) => prev + 1);
-        setIsDetailsTooTall(false);
+        setIsConfirmationTooTall(false);
       }
       handleConfirmationDecision(decision);
     },
-    [isDetailsTooTall, handleConfirmationDecision, setWasLastDetailsTooTall],
+    [
+      isConfirmationTooTall,
+      handleConfirmationDecision,
+      setWasLastDetailsTooTall,
+    ],
   );
 
   if (!sessionId) return null;
@@ -80,7 +92,7 @@ export const ChatInterface: React.FC = () => {
         isLoading={isLoading}
         isCommandRunning={isCommandRunning}
         isExpanded={isExpanded}
-        forceStaticLastMessage={isDetailsTooTall}
+        hideLastMessage={isConfirmationVisible}
       />
 
       {(isLoading || isCommandRunning || isCompressing) &&
@@ -101,7 +113,8 @@ export const ChatInterface: React.FC = () => {
             toolName={confirmingTool!.name}
             toolInput={confirmingTool!.input}
             isExpanded={isExpanded}
-            onHeightMeasured={handleHeightMeasured}
+            onHeightMeasured={handleDetailsHeightMeasured}
+            isStatic={isConfirmationTooTall}
           />
           <ConfirmationSelector
             toolName={confirmingTool!.name}
@@ -112,6 +125,7 @@ export const ChatInterface: React.FC = () => {
             onDecision={wrappedHandleConfirmationDecision}
             onCancel={handleConfirmationCancel}
             onAbort={abortMessage}
+            onHeightMeasured={handleSelectorHeightMeasured}
           />
         </>
       )}

--- a/packages/code/src/components/ConfirmationDetails.tsx
+++ b/packages/code/src/components/ConfirmationDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef, useState } from "react";
+import React, { useLayoutEffect, useRef } from "react";
 import { Box, Text, useStdout, measureElement, Static } from "ink";
 import {
   BASH_TOOL_NAME,
@@ -40,6 +40,7 @@ export interface ConfirmationDetailsProps {
   toolInput?: Record<string, unknown>;
   isExpanded?: boolean;
   onHeightMeasured?: (height: number) => void;
+  isStatic?: boolean;
 }
 
 export const ConfirmationDetails: React.FC<ConfirmationDetailsProps> = ({
@@ -47,21 +48,17 @@ export const ConfirmationDetails: React.FC<ConfirmationDetailsProps> = ({
   toolInput,
   isExpanded = false,
   onHeightMeasured,
+  isStatic = false,
 }) => {
   const { stdout } = useStdout();
-  const [isStatic, setIsStatic] = useState(false);
   const boxRef = useRef(null);
 
   useLayoutEffect(() => {
     if (boxRef.current) {
       const { height } = measureElement(boxRef.current);
-      const terminalHeight = stdout?.rows || 24;
-      if (height > terminalHeight - 10) {
-        setIsStatic(true);
-      }
       onHeightMeasured?.(height);
     }
-  }, [stdout?.rows, onHeightMeasured]);
+  }, [stdout?.rows, onHeightMeasured, toolInput, isExpanded]);
 
   const content = (
     <Box

--- a/packages/code/src/components/ConfirmationSelector.tsx
+++ b/packages/code/src/components/ConfirmationSelector.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { Box, Text, useInput } from "ink";
+import React, { useLayoutEffect, useRef, useState } from "react";
+import { Box, Text, useInput, useStdout, measureElement } from "ink";
 import type { PermissionDecision, AskUserQuestionInput } from "wave-agent-sdk";
 import {
   BASH_TOOL_NAME,
@@ -25,6 +25,7 @@ export interface ConfirmationSelectorProps {
   onDecision: (decision: PermissionDecision) => void;
   onCancel: () => void;
   onAbort: () => void;
+  onHeightMeasured?: (height: number) => void;
 }
 
 interface ConfirmationState {
@@ -43,7 +44,18 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
   onDecision,
   onCancel,
   onAbort,
+  onHeightMeasured,
 }) => {
+  const { stdout } = useStdout();
+  const boxRef = useRef(null);
+
+  useLayoutEffect(() => {
+    if (boxRef.current) {
+      const { height } = measureElement(boxRef.current);
+      onHeightMeasured?.(height);
+    }
+  }, [stdout?.rows, onHeightMeasured, toolName, toolInput, isExpanded]);
+
   const [state, setState] = useState<ConfirmationState>({
     selectedOption: "allow",
     alternativeText: "",
@@ -308,7 +320,7 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
     state.selectedOption === "alternative" && !state.hasUserInput;
 
   return (
-    <Box flexDirection="column">
+    <Box ref={boxRef} flexDirection="column">
       {toolName === ASK_USER_QUESTION_TOOL_NAME &&
         currentQuestion &&
         !isExpanded && (

--- a/packages/code/src/components/MessageList.tsx
+++ b/packages/code/src/components/MessageList.tsx
@@ -9,6 +9,7 @@ export interface MessageListProps {
   isCommandRunning?: boolean;
   isExpanded?: boolean;
   forceStaticLastMessage?: boolean;
+  hideLastMessage?: boolean;
 }
 
 export const MessageList = React.memo(
@@ -18,6 +19,7 @@ export const MessageList = React.memo(
     isCommandRunning = false,
     isExpanded = false,
     forceStaticLastMessage = false,
+    hideLastMessage = false,
   }: MessageListProps) => {
     // Empty message state
     if (messages.length === 0) {
@@ -53,7 +55,7 @@ export const MessageList = React.memo(
       ? displayMessages.slice(0, -1)
       : displayMessages;
     const dynamicMessages =
-      shouldRenderLastDynamic && displayMessages.length > 0
+      !hideLastMessage && shouldRenderLastDynamic && displayMessages.length > 0
         ? [displayMessages[displayMessages.length - 1]]
         : [];
 


### PR DESCRIPTION
This PR improves the accuracy of the 'too tall' condition for the confirmation UI by aggregating the heights of both the details and selector components. It also hides the last message during confirmation to optimize screen space and uses static rendering for long plan details.