### PR TITLE
ui: remove lock emoji from TaskList

### DIFF
--- a/packages/code/src/components/TaskList.tsx
+++ b/packages/code/src/components/TaskList.tsx
@@ -11,10 +11,7 @@ export const TaskList: React.FC = () => {
     return null;
   }
 
-  const getStatusIcon = (status: string, isBlocked: boolean) => {
-    if (isBlocked) {
-      return <Text color="red">🔒</Text>;
-    }
+  const getStatusIcon = (status: string) => {
     switch (status) {
       case "pending":
         return <Text color="gray">□</Text>;
@@ -48,7 +45,7 @@ export const TaskList: React.FC = () => {
 
         return (
           <Box key={task.id} gap={1}>
-            {getStatusIcon(task.status, isBlocked)}
+            {getStatusIcon(task.status)}
             <Text dimColor={isDimmed}>{fullText}</Text>
           </Box>
         );

--- a/packages/code/tests/components/TaskList.test.tsx
+++ b/packages/code/tests/components/TaskList.test.tsx
@@ -122,7 +122,7 @@ describe("TaskList", () => {
     expect(output).toContain(longSubject);
   });
 
-  it("should render blocked tasks with lock icon and blocking subjects", () => {
+  it("should render blocked tasks with pending icon and blocking subjects", () => {
     const mockTasks: Task[] = [
       {
         id: "1",
@@ -151,6 +151,6 @@ describe("TaskList", () => {
     const { lastFrame } = render(<TaskList />);
     const output = lastFrame();
 
-    expect(output).toContain("🔒 Blocked Task (Blocked by: #1)");
+    expect(output).toContain("□ Blocked Task (Blocked by: #1)");
   });
 });


### PR DESCRIPTION
Removed the lock emoji from the TaskList component as the 'blocked by' hint is sufficient to indicate a blocked task.