### PR TITLE
feat: clear context on plan exit and UI improvements

### DIFF
--- a/.wave/rules/testing.md
+++ b/.wave/rules/testing.md
@@ -15,4 +15,5 @@ paths:
   - MUST not write `mkdtemp` in test, use mocking instead
   - Mock stdout and stderr to suppress output during testing and restore mocks after tests
   - Avoid unnecessary `setTimeout` or `sleep` in tests to keep them fast; prefer awaiting promises or using `vi.waitFor` if needed
+  - Note: `logger` in `packages/code` appends to log files instead of printing to stdout/stderr to avoid interfering with the Ink UI. Do not use `logger` to debug in tests. Use temporary `console.log` to debug and remove them after.
 - While writing tests about `Agent`, always use `await Agent.create` instead of `new Agent`

--- a/packages/agent-sdk/src/managers/toolManager.ts
+++ b/packages/agent-sdk/src/managers/toolManager.ts
@@ -164,12 +164,14 @@ class ToolManager {
       : permissionMode || "default";
 
     // Enhance context with permission-related fields
+    const canUseToolCallback = this.container.has("CanUseToolCallback")
+      ? this.container.get<PermissionCallback>("CanUseToolCallback")
+      : undefined;
+
     const enhancedContext: ToolContext = {
       ...context,
       permissionMode: effectivePermissionMode,
-      canUseToolCallback: this.container.has("CanUseToolCallback")
-        ? this.container.get<PermissionCallback>("CanUseToolCallback")
-        : undefined,
+      canUseToolCallback,
       permissionManager,
       taskManager:
         this.container.get<import("../services/taskManager.js").TaskManager>(

--- a/packages/agent-sdk/src/types/permissions.ts
+++ b/packages/agent-sdk/src/types/permissions.ts
@@ -33,6 +33,8 @@ export interface PermissionDecision {
   newPermissionMode?: PermissionMode;
   /** Signal to persist a new allowed rule */
   newPermissionRule?: string;
+  /** Signal to clear the conversation context and proceed with the plan */
+  clearContext?: boolean;
 }
 
 /** Callback function for custom permission logic */

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -1,3 +1,4 @@
+import * as fs from "fs/promises";
 import { Container } from "./container.js";
 import { ForegroundTaskManager } from "../managers/foregroundTaskManager.js";
 import { BackgroundTaskManager } from "../managers/backgroundTaskManager.js";
@@ -178,12 +179,31 @@ export function setupAgentContainer(
 
         const decision = await options.canUseTool!(context);
 
+        const planFilePath = permissionManager.getPlanFilePath();
+
         if (decision.newPermissionMode) {
           setPermissionMode(decision.newPermissionMode);
         }
 
         if (decision.newPermissionRule) {
           await addPermissionRule(decision.newPermissionRule);
+        }
+
+        if (decision.clearContext) {
+          messageManager.clearMessages();
+          if (planFilePath) {
+            try {
+              const planContent = await fs.readFile(planFilePath, "utf-8");
+              messageManager.addUserMessage({
+                content: `Implement the following plan:\n\n${planContent}`,
+              });
+            } catch (error) {
+              logger.warn("Failed to read plan file for context clearing", {
+                planFilePath,
+                error: error instanceof Error ? error.message : String(error),
+              });
+            }
+          }
         }
 
         return decision;
@@ -197,6 +217,9 @@ export function setupAgentContainer(
   container.register("ToolManager", toolManager);
 
   container.register("PermissionMode", options.permissionMode);
+  logger.info("Registering CanUseToolCallback", {
+    hasCallback: !!canUseToolWithNotification,
+  });
   container.register("CanUseToolCallback", canUseToolWithNotification);
 
   const liveConfigManager = new LiveConfigManager(container, { workdir });

--- a/packages/agent-sdk/tests/agent/exitPlanMode.clearContext.test.ts
+++ b/packages/agent-sdk/tests/agent/exitPlanMode.clearContext.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TaskManager } from "@/services/taskManager.js";
+import { Agent } from "@/agent.js";
+import { readFile } from "fs/promises";
+import type { PermissionCallback } from "@/types/permissions.js";
+import type { ToolManager } from "@/managers/toolManager.js";
+import type { MessageManager } from "@/managers/messageManager.js";
+import type { PermissionManager } from "@/managers/permissionManager.js";
+import type { TextBlock } from "@/types/messaging.js";
+
+interface AgentInternal {
+  messageManager: MessageManager;
+  permissionManager: PermissionManager;
+  taskManager: TaskManager;
+  toolManager: ToolManager;
+}
+
+// Mock fs/promises
+vi.mock("fs/promises");
+
+describe("ExitPlanMode Clear Context", () => {
+  const originalEnv = process.env;
+  let mockStdout: typeof process.stdout.write;
+  let mockStderr: typeof process.stderr.write;
+  let originalStdoutWrite: typeof process.stdout.write;
+  let originalStderrWrite: typeof process.stderr.write;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    process.env.WAVE_API_KEY = "test-api-key";
+    process.env.WAVE_BASE_URL = "https://test-gateway.com/api";
+
+    originalStdoutWrite = process.stdout.write;
+    originalStderrWrite = process.stderr.write;
+    mockStdout = vi.fn() as typeof process.stdout.write;
+    mockStderr = vi.fn() as typeof process.stderr.write;
+    process.stdout.write = mockStdout;
+    process.stderr.write = mockStderr;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    vi.restoreAllMocks();
+  });
+
+  it("should clear context and add plan as user message when clearContext is true", async () => {
+    const workdir = "/test/workdir";
+    const planContent = "My plan content";
+
+    const mockCallback = vi.fn().mockResolvedValue({
+      behavior: "allow",
+      newPermissionMode: "acceptEdits",
+      clearContext: true,
+    });
+
+    const agent = await Agent.create({
+      workdir,
+      permissionMode: "plan",
+      canUseTool: mockCallback as PermissionCallback,
+    });
+
+    // Add some initial messages
+    agent.sendMessage("Initial message");
+    expect(agent.messages.length).toBeGreaterThan(0);
+
+    // Wait for plan file path generation
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    vi.mocked(readFile).mockResolvedValue(planContent);
+
+    // Execute ExitPlanMode tool
+    const taskManager = (agent as unknown as AgentInternal).taskManager;
+    const result = await (
+      agent as unknown as AgentInternal
+    ).toolManager.execute("ExitPlanMode", {}, { workdir, taskManager });
+
+    expect(result.success).toBe(true);
+    expect(agent.getPermissionMode()).toBe("acceptEdits");
+
+    // Verify messages are cleared and plan is added
+    expect(agent.messages.length).toBe(1);
+    expect(agent.messages[0].role).toBe("user");
+    const textBlock = agent.messages[0].blocks.find(
+      (b) => b.type === "text",
+    ) as TextBlock;
+    expect(textBlock).toBeDefined();
+    const content = textBlock.content;
+    expect(content).toContain(planContent);
+    expect(content).toContain("Implement the following plan:");
+  });
+
+  it("should NOT clear context if ExitPlanMode fails before permission check", async () => {
+    const workdir = "/test/workdir";
+
+    const mockCallback = vi.fn().mockResolvedValue({
+      behavior: "allow",
+      newPermissionMode: "acceptEdits",
+      clearContext: true,
+    });
+
+    const agent = await Agent.create({
+      workdir,
+      permissionMode: "plan",
+      canUseTool: mockCallback as PermissionCallback,
+    });
+
+    // Add some initial messages
+    await agent.sendMessage("Initial message");
+    const initialMessageCount = agent.messages.length;
+    expect(initialMessageCount).toBeGreaterThan(0);
+
+    // Wait for plan file path generation
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    vi.mocked(readFile).mockRejectedValue(new Error("Read error"));
+
+    // Execute ExitPlanMode tool
+    const taskManager = (agent as unknown as AgentInternal).taskManager;
+    const result = await (
+      agent as unknown as AgentInternal
+    ).toolManager.execute("ExitPlanMode", {}, { workdir, taskManager });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Failed to read plan file");
+
+    // Messages should NOT be cleared because checkPermission was never called
+    expect(agent.messages.length).toBe(initialMessageCount);
+  });
+
+  it("should clear messages but not add plan if reading plan file fails during context clearing", async () => {
+    const workdir = "/test/workdir";
+    const planContent = "My plan content";
+
+    const mockCallback = vi.fn().mockResolvedValue({
+      behavior: "allow",
+      newPermissionMode: "acceptEdits",
+      clearContext: true,
+    });
+
+    const agent = await Agent.create({
+      workdir,
+      permissionMode: "plan",
+      canUseTool: mockCallback as PermissionCallback,
+    });
+
+    // Add some initial messages
+    await agent.sendMessage("Initial message");
+    expect(agent.messages.length).toBeGreaterThan(0);
+
+    // Wait for plan file path generation
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // First call (in ExitPlanMode) succeeds, second call (in setupAgentContainer) fails
+    vi.mocked(readFile)
+      .mockResolvedValueOnce(planContent)
+      .mockRejectedValueOnce(new Error("Read error during clearing"));
+
+    // Execute ExitPlanMode tool
+    const taskManager = (agent as unknown as AgentInternal).taskManager;
+    const result = await (
+      agent as unknown as AgentInternal
+    ).toolManager.execute("ExitPlanMode", {}, { workdir, taskManager });
+
+    expect(result.success).toBe(true);
+
+    // Messages should be cleared (because clearMessages() is called before readFile())
+    // but plan should not be added because readFile() failed
+    expect(agent.messages.length).toBe(0);
+  });
+
+  it("should clear messages but not add plan if planFilePath is undefined", async () => {
+    const workdir = "/test/workdir";
+
+    const mockCallback = vi.fn().mockResolvedValue({
+      behavior: "allow",
+      newPermissionMode: "acceptEdits",
+      clearContext: true,
+    });
+
+    const agent = await Agent.create({
+      workdir,
+      permissionMode: "plan",
+      canUseTool: mockCallback as PermissionCallback,
+    });
+
+    // Add some initial messages
+    await agent.sendMessage("Initial message");
+    expect(agent.messages.length).toBeGreaterThan(0);
+
+    // Manually clear plan file path in permission manager
+    (agent as unknown as AgentInternal).permissionManager.setPlanFilePath(
+      undefined,
+    );
+
+    // Execute ExitPlanMode tool - it will fail because planFilePath is missing
+    const taskManager = (agent as unknown as AgentInternal).taskManager;
+    const result = await (
+      agent as unknown as AgentInternal
+    ).toolManager.execute("ExitPlanMode", {}, { workdir, taskManager });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Plan file path is not set");
+
+    // Messages should NOT be cleared because ExitPlanMode failed before checkPermission
+    expect(agent.messages.length).toBeGreaterThan(0);
+  });
+
+  it("should handle newPermissionMode and newPermissionRule in decision", async () => {
+    const workdir = "/test/workdir";
+    const planContent = "My plan content";
+
+    const mockCallback = vi.fn().mockResolvedValue({
+      behavior: "allow",
+      newPermissionMode: "acceptEdits",
+      newPermissionRule: "Bash(cat)",
+    });
+
+    const agent = await Agent.create({
+      workdir,
+      permissionMode: "plan",
+      canUseTool: mockCallback as PermissionCallback,
+    });
+
+    // Wait for plan file path generation
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    vi.mocked(readFile).mockResolvedValue(planContent);
+
+    // Execute ExitPlanMode tool
+    const taskManager = (agent as unknown as AgentInternal).taskManager;
+    const result = await (
+      agent as unknown as AgentInternal
+    ).toolManager.execute("ExitPlanMode", {}, { workdir, taskManager });
+
+    expect(result.success).toBe(true);
+    expect(agent.getPermissionMode()).toBe("acceptEdits");
+    // The rule might be expanded or slightly different depending on how expandBashRule works
+    const allowedRules = agent.getAllowedRules();
+    expect(allowedRules.some((r) => r.includes("Bash(cat"))).toBe(true);
+  });
+
+  it("should clear messages but not add plan if planFilePath is undefined during tool execution", async () => {
+    const workdir = "/test/workdir";
+
+    const mockCallback = vi.fn().mockResolvedValue({
+      behavior: "allow",
+      clearContext: true,
+    });
+
+    const agent = await Agent.create({
+      workdir,
+      permissionMode: "default",
+      canUseTool: mockCallback as PermissionCallback,
+    });
+
+    // Add some initial messages
+    await agent.sendMessage("Initial message");
+    expect(agent.messages.length).toBeGreaterThan(0);
+
+    // Ensure plan file path is undefined
+    (agent as unknown as AgentInternal).permissionManager.setPlanFilePath(
+      undefined,
+    );
+
+    vi.mocked(readFile).mockResolvedValue("some content");
+
+    const messageManager = (agent as unknown as AgentInternal).messageManager;
+    const clearSpy = vi.spyOn(messageManager, "clearMessages");
+
+    // Execute Write tool (which is restricted and doesn't use spawn)
+    const taskManager = (agent as unknown as AgentInternal).taskManager;
+    const result = await (
+      agent as unknown as AgentInternal
+    ).toolManager.execute(
+      "Write",
+      { file_path: "test.txt", content: "test" },
+      { workdir, taskManager },
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockCallback).toHaveBeenCalled();
+    expect(clearSpy).toHaveBeenCalled();
+
+    // Messages should be cleared but plan not added
+    expect(agent.messages.length).toBe(0);
+  });
+});

--- a/packages/agent-sdk/tests/managers/permissionManager.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.test.ts
@@ -646,6 +646,24 @@ describe("PermissionManager", () => {
           });
         }
       });
+
+      it("should handle clearContext in decision", async () => {
+        const mockCallback: PermissionCallback = vi.fn().mockResolvedValue({
+          behavior: "allow",
+          clearContext: true,
+        });
+
+        const context: ToolPermissionContext = {
+          toolName: "ExitPlanMode",
+          permissionMode: "default",
+          canUseToolCallback: mockCallback,
+        };
+
+        const result = await permissionManager.checkPermission(context);
+
+        expect(result.behavior).toBe("allow");
+        expect(result.clearContext).toBe(true);
+      });
     });
 
     describe("default mode with restricted tools without callback", () => {

--- a/packages/code/src/components/ConfirmationSelector.tsx
+++ b/packages/code/src/components/ConfirmationSelector.tsx
@@ -29,7 +29,7 @@ export interface ConfirmationSelectorProps {
 }
 
 interface ConfirmationState {
-  selectedOption: "allow" | "auto" | "alternative";
+  selectedOption: "clear" | "auto" | "allow" | "alternative";
   alternativeText: string;
   alternativeCursorPosition: number;
   hasUserInput: boolean;
@@ -57,7 +57,7 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
   }, [stdout?.rows, onHeightMeasured, toolName, toolInput, isExpanded]);
 
   const [state, setState] = useState<ConfirmationState>({
-    selectedOption: "allow",
+    selectedOption: toolName === EXIT_PLAN_MODE_TOOL_NAME ? "clear" : "allow",
     alternativeText: "",
     alternativeCursorPosition: 0,
     hasUserInput: false,
@@ -78,7 +78,7 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
 
   const getAutoOptionText = () => {
     if (toolName === EXIT_PLAN_MODE_TOOL_NAME) {
-      return "Yes, and auto-accept edits";
+      return "Yes, auto-accept edits";
     }
     if (toolName === BASH_TOOL_NAME) {
       if (suggestedPrefix) {
@@ -205,7 +205,13 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
     }
 
     if (key.return) {
-      if (state.selectedOption === "allow") {
+      if (state.selectedOption === "clear") {
+        onDecision({
+          behavior: "allow",
+          newPermissionMode: "acceptEdits",
+          clearContext: true,
+        });
+      } else if (state.selectedOption === "allow") {
         if (toolName === EXIT_PLAN_MODE_TOOL_NAME) {
           onDecision({ behavior: "allow", newPermissionMode: "default" });
         } else {
@@ -249,31 +255,31 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
       }
     }
 
+    const availableOptions: ConfirmationState["selectedOption"][] = [];
+    if (toolName === EXIT_PLAN_MODE_TOOL_NAME) availableOptions.push("clear");
+    if (!hidePersistentOption) availableOptions.push("auto");
+    availableOptions.push("allow");
+    availableOptions.push("alternative");
+
     if (key.upArrow) {
-      setState((prev) => {
-        if (prev.selectedOption === "alternative")
-          return {
-            ...prev,
-            selectedOption: hidePersistentOption ? "allow" : "auto",
-          };
-        if (prev.selectedOption === "auto")
-          return { ...prev, selectedOption: "allow" };
-        return prev;
-      });
+      const currentIndex = availableOptions.indexOf(state.selectedOption);
+      if (currentIndex > 0) {
+        setState((prev) => ({
+          ...prev,
+          selectedOption: availableOptions[currentIndex - 1],
+        }));
+      }
       return;
     }
 
     if (key.downArrow) {
-      setState((prev) => {
-        if (prev.selectedOption === "allow")
-          return {
-            ...prev,
-            selectedOption: hidePersistentOption ? "alternative" : "auto",
-          };
-        if (prev.selectedOption === "auto")
-          return { ...prev, selectedOption: "alternative" };
-        return prev;
-      });
+      const currentIndex = availableOptions.indexOf(state.selectedOption);
+      if (currentIndex < availableOptions.length - 1) {
+        setState((prev) => ({
+          ...prev,
+          selectedOption: availableOptions[currentIndex + 1],
+        }));
+      }
       return;
     }
 
@@ -315,7 +321,7 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
     }
   });
 
-  const placeholderText = "Type here to tell Wave what to do differently";
+  const placeholderText = "Type here to tell Wave what to change";
   const showPlaceholder =
     state.selectedOption === "alternative" && !state.hasUserInput;
 
@@ -395,20 +401,20 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
             <Text>Do you want to proceed?</Text>
           </Box>
           <Box marginTop={1} flexDirection="column">
-            <Box key="allow-option">
-              <Text
-                color={state.selectedOption === "allow" ? "black" : "white"}
-                backgroundColor={
-                  state.selectedOption === "allow" ? "yellow" : undefined
-                }
-                bold={state.selectedOption === "allow"}
-              >
-                {state.selectedOption === "allow" ? "> " : "  "}
-                {toolName === EXIT_PLAN_MODE_TOOL_NAME
-                  ? "Yes, proceed with default mode"
-                  : "Yes"}
-              </Text>
-            </Box>
+            {toolName === EXIT_PLAN_MODE_TOOL_NAME && (
+              <Box key="clear-option">
+                <Text
+                  color={state.selectedOption === "clear" ? "black" : "white"}
+                  backgroundColor={
+                    state.selectedOption === "clear" ? "yellow" : undefined
+                  }
+                  bold={state.selectedOption === "clear"}
+                >
+                  {state.selectedOption === "clear" ? "> " : "  "}
+                  Yes, clear context and auto-accept edits
+                </Text>
+              </Box>
+            )}
             {!hidePersistentOption && (
               <Box key="auto-option">
                 <Text
@@ -423,6 +429,20 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
                 </Text>
               </Box>
             )}
+            <Box key="allow-option">
+              <Text
+                color={state.selectedOption === "allow" ? "black" : "white"}
+                backgroundColor={
+                  state.selectedOption === "allow" ? "yellow" : undefined
+                }
+                bold={state.selectedOption === "allow"}
+              >
+                {state.selectedOption === "allow" ? "> " : "  "}
+                {toolName === EXIT_PLAN_MODE_TOOL_NAME
+                  ? "Yes, manually approve edits"
+                  : "Yes, proceed"}
+              </Text>
+            </Box>
             <Box key="alternative-option">
               <Text
                 color={
@@ -456,7 +476,7 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
                         )}
                       </>
                     ) : (
-                      "Type here to tell Wave what to do differently"
+                      "Type here to tell Wave what to change"
                     )}
                   </Text>
                 )}

--- a/packages/code/src/components/HistorySearch.tsx
+++ b/packages/code/src/components/HistorySearch.tsx
@@ -147,6 +147,7 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
                   backgroundColor={isSelected ? "blue" : undefined}
                   wrap="truncate-end"
                 >
+                  {isSelected ? "> " : "  "}
                   {entry.prompt.replace(/\n/g, " ")}
                 </Text>
               </Box>

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -131,6 +131,8 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
 
   // AI State
   const [messages, setMessages] = useState<Message[]>([]);
+  const messagesUpdateTimerRef = useRef<NodeJS.Timeout | null>(null);
+
   const [isLoading, setIsLoading] = useState(false);
   const [latestTotalTokens, setlatestTotalTokens] = useState(0);
   const [sessionId, setSessionId] = useState("");
@@ -229,7 +231,13 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
       const callbacks: AgentCallbacks = {
         onMessagesChange: (newMessages) => {
           if (!isExpandedRef.current) {
-            setMessages([...newMessages]);
+            if (messagesUpdateTimerRef.current) {
+              clearTimeout(messagesUpdateTimerRef.current);
+            }
+            messagesUpdateTimerRef.current = setTimeout(() => {
+              setMessages([...newMessages]);
+              messagesUpdateTimerRef.current = null;
+            }, 50);
           }
         },
         onServersChange: (servers) => {

--- a/packages/code/tests/components/CommandOutputDisplay.test.tsx
+++ b/packages/code/tests/components/CommandOutputDisplay.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render } from "ink-testing-library";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { CommandOutputDisplay } from "../../src/components/CommandOutputDisplay.js";
 import { CommandOutputBlock } from "wave-agent-sdk";
 
@@ -50,12 +50,12 @@ describe("CommandOutputDisplay", () => {
     );
 
     // Wait for useEffect to run and update state
-    await new Promise((resolve) => setTimeout(resolve, 100));
-
-    const frame = lastFrame();
-    expect(frame).not.toContain("Content truncated");
-    expect(frame).not.toContain("line 1\n");
-    expect(frame).toContain("line 20");
+    await vi.waitFor(() => {
+      const frame = lastFrame();
+      expect(frame).not.toContain("Content truncated");
+      expect(frame).not.toContain("line 1\n");
+      expect(frame).toContain("line 20");
+    });
   });
 
   it("should not truncate output when expanded", () => {

--- a/packages/code/tests/components/Confirmation.test.tsx
+++ b/packages/code/tests/components/Confirmation.test.tsx
@@ -85,16 +85,14 @@ describe("Confirmation", () => {
       );
 
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain("Yes, proceed");
       });
 
       const frame = lastFrame();
       // First option should be selected by default
-      expect(frame).toContain("> Yes");
+      expect(frame).toContain("> Yes, proceed");
       expect(frame).toContain("  Yes, and auto-accept edits");
-      expect(frame).toContain(
-        "  Type here to tell Wave what to do differently",
-      );
+      expect(frame).toContain("  Type here to tell Wave what to change");
     });
 
     it("should display placeholder text correctly", async () => {
@@ -109,12 +107,12 @@ describe("Confirmation", () => {
 
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "Type here to tell Wave what to do differently",
+          "Type here to tell Wave what to change",
         );
       });
 
       const frame = lastFrame();
-      expect(frame).toContain("Type here to tell Wave what to do differently");
+      expect(frame).toContain("Type here to tell Wave what to change");
     });
 
     it("should show keyboard navigation instructions", async () => {
@@ -176,13 +174,13 @@ describe("Confirmation", () => {
       );
 
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain("Yes, proceed");
       });
 
       const frame = lastFrame();
-      expect(frame).toContain("Yes");
+      expect(frame).toContain("Yes, proceed");
       expect(frame).not.toContain("Yes, and don't ask again");
-      expect(frame).toContain("Type here to tell Wave what to do differently");
+      expect(frame).toContain("Type here to tell Wave what to change");
     });
   });
 
@@ -198,7 +196,7 @@ describe("Confirmation", () => {
       );
 
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
       });
 
       // Press down arrow twice to select alternative option
@@ -207,15 +205,13 @@ describe("Confirmation", () => {
 
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "> Type here to tell Wave what to do differently",
+          "> Type here to tell Wave what to change",
         );
       });
 
       const frame = lastFrame();
-      expect(frame).toContain("  Yes"); // First option not selected
-      expect(frame).toContain(
-        "> Type here to tell Wave what to do differently",
-      ); // Third option selected
+      expect(frame).toContain("  Yes, proceed"); // First option not selected
+      expect(frame).toContain("> Type here to tell Wave what to change"); // Third option selected
     });
 
     it("should handle up arrow key navigation", async () => {
@@ -229,7 +225,7 @@ describe("Confirmation", () => {
       );
 
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
       });
 
       // Go down then up
@@ -237,21 +233,19 @@ describe("Confirmation", () => {
       stdin.write("\u001b[B"); // Down arrow
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "> Type here to tell Wave what to do differently",
+          "> Type here to tell Wave what to change",
         );
       });
 
       stdin.write("\u001b[A"); // Up arrow
       stdin.write("\u001b[A"); // Up arrow
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
       });
 
       const frame = lastFrame();
-      expect(frame).toContain("> Yes"); // Back to first option
-      expect(frame).not.toContain(
-        "> Type here to tell Wave what to do differently",
-      ); // Third option not selected
+      expect(frame).toContain("> Yes, proceed"); // Back to first option
+      expect(frame).not.toContain("> Type here to tell Wave what to change"); // Third option not selected
     });
 
     it("should handle Enter key confirmation for allow option", async () => {
@@ -265,7 +259,7 @@ describe("Confirmation", () => {
       );
 
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
       });
 
       // Press Enter to confirm allow
@@ -289,7 +283,7 @@ describe("Confirmation", () => {
       );
 
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
       });
 
       // Press ESC to cancel
@@ -314,7 +308,7 @@ describe("Confirmation", () => {
 
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "Type here to tell Wave what to do differently",
+          "Type here to tell Wave what to change",
         );
       });
 
@@ -329,9 +323,7 @@ describe("Confirmation", () => {
       const frame = lastFrame();
       expect(frame).toContain(alternativeText);
       expect(frame).toContain(`> ${alternativeText}`); // Should auto-select alternative option
-      expect(frame).not.toContain(
-        "Type here to tell Wave what to do differently",
-      ); // Placeholder should be hidden
+      expect(frame).not.toContain("Type here to tell Wave what to change"); // Placeholder should be hidden
     });
 
     it("should handle Enter key with alternative text", async () => {
@@ -346,7 +338,7 @@ describe("Confirmation", () => {
 
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "Type here to tell Wave what to do differently",
+          "Type here to tell Wave what to change",
         );
       });
 
@@ -388,7 +380,7 @@ describe("Confirmation", () => {
       stdin.write("\u001b[B"); // Down arrow
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "> Type here to tell Wave what to do differently",
+          "> Type here to tell Wave what to change",
         );
       });
 
@@ -415,29 +407,27 @@ describe("Confirmation", () => {
 
       // Verify initial state
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
       });
-      expect(lastFrame()).toContain("> Yes");
+      expect(lastFrame()).toContain("> Yes, proceed");
 
       // Change to alternative
       stdin.write("\u001b[B");
       stdin.write("\u001b[B");
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "> Type here to tell Wave what to do differently",
+          "> Type here to tell Wave what to change",
         );
       });
-      expect(lastFrame()).toContain(
-        "> Type here to tell Wave what to do differently",
-      );
+      expect(lastFrame()).toContain("> Type here to tell Wave what to change");
 
       // Back to allow
       stdin.write("\u001b[A");
       stdin.write("\u001b[A");
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
       });
-      expect(lastFrame()).toContain("> Yes");
+      expect(lastFrame()).toContain("> Yes, proceed");
     });
 
     it("should update alternativeText state on text input", async () => {
@@ -452,7 +442,7 @@ describe("Confirmation", () => {
 
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "Type here to tell Wave what to do differently",
+          "Type here to tell Wave what to change",
         );
       });
 
@@ -488,7 +478,7 @@ describe("Confirmation", () => {
       // Initially should show placeholder
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "Type here to tell Wave what to do differently",
+          "Type here to tell Wave what to change",
         );
       });
 
@@ -502,7 +492,7 @@ describe("Confirmation", () => {
       const frameWithText = lastFrame();
       expect(frameWithText).toContain("test");
       expect(frameWithText).not.toContain(
-        "Type here to tell Wave what to do differently",
+        "Type here to tell Wave what to change",
       );
     });
 
@@ -519,7 +509,7 @@ describe("Confirmation", () => {
       // Placeholder should be visible when on alternative option with no input
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "Type here to tell Wave what to do differently",
+          "Type here to tell Wave what to change",
         );
       });
 
@@ -527,25 +517,23 @@ describe("Confirmation", () => {
       stdin.write("\u001b[B"); // Go to alternative option
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "> Type here to tell Wave what to do differently",
+          "> Type here to tell Wave what to change",
         );
       });
 
       // Placeholder should still be visible
-      expect(lastFrame()).toContain(
-        "Type here to tell Wave what to do differently",
-      );
+      expect(lastFrame()).toContain("Type here to tell Wave what to change");
 
       // Switch back to allow option
       stdin.write("\u001b[A");
       stdin.write("\u001b[A");
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
       });
 
       // Placeholder should not be visible for allow option
       const allowFrame = lastFrame();
-      expect(allowFrame).toContain("> Yes");
+      expect(allowFrame).toContain("> Yes, proceed");
       // The placeholder text might still be in the DOM but not visible on allow option
     });
   });
@@ -562,7 +550,7 @@ describe("Confirmation", () => {
       );
 
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
       });
 
       stdin.write("\r");
@@ -586,7 +574,7 @@ describe("Confirmation", () => {
 
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "Type here to tell Wave what to do differently",
+          "Type here to tell Wave what to change",
         );
       });
 
@@ -617,7 +605,7 @@ describe("Confirmation", () => {
       );
 
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
       });
 
       stdin.write("\u001b"); // ESC key
@@ -640,7 +628,7 @@ describe("Confirmation", () => {
 
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "Type here to tell Wave what to do differently",
+          "Type here to tell Wave what to change",
         );
       });
 
@@ -676,7 +664,7 @@ describe("Confirmation", () => {
 
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "Type here to tell Wave what to do differently",
+          "Type here to tell Wave what to change",
         );
       });
 
@@ -685,7 +673,7 @@ describe("Confirmation", () => {
       stdin.write("\u001b[B");
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "> Type here to tell Wave what to do differently",
+          "> Type here to tell Wave what to change",
         );
       });
 
@@ -709,7 +697,7 @@ describe("Confirmation", () => {
       // Start with the placeholder visible
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "Type here to tell Wave what to do differently",
+          "Type here to tell Wave what to change",
         );
       });
 
@@ -741,7 +729,7 @@ describe("Confirmation", () => {
 
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "Type here to tell Wave what to do differently",
+          "Type here to tell Wave what to change",
         );
       });
 
@@ -759,9 +747,7 @@ describe("Confirmation", () => {
 
       // Wait a bit for the state to update
       await vi.waitFor(() => {
-        expect(lastFrame()).toContain(
-          "Type here to tell Wave what to do differently",
-        );
+        expect(lastFrame()).toContain("Type here to tell Wave what to change");
       });
 
       stdin.write("tes");
@@ -782,7 +768,7 @@ describe("Confirmation", () => {
 
       // Start with allow selected
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
       });
 
       // Type a regular character - this should work based on other passing tests
@@ -808,7 +794,7 @@ describe("Confirmation", () => {
       );
 
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
       });
 
       // Rapidly switch between options
@@ -816,10 +802,10 @@ describe("Confirmation", () => {
 
       // Should end up on allow option
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
       });
 
-      expect(lastFrame()).toContain("> Yes");
+      expect(lastFrame()).toContain("> Yes, proceed");
     });
 
     it("should handle backspace on empty text correctly", async () => {
@@ -834,7 +820,7 @@ describe("Confirmation", () => {
 
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "Type here to tell Wave what to do differently",
+          "Type here to tell Wave what to change",
         );
       });
 
@@ -843,7 +829,7 @@ describe("Confirmation", () => {
       stdin.write("\u001b[B"); // Go to alternative
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "> Type here to tell Wave what to do differently",
+          "> Type here to tell Wave what to change",
         );
       });
 
@@ -852,15 +838,13 @@ describe("Confirmation", () => {
       // Should still show placeholder and remain on alternative
       await vi.waitFor(() => {
         expect(lastFrame()).toContain(
-          "> Type here to tell Wave what to do differently",
+          "> Type here to tell Wave what to change",
         );
       });
 
       const frame = lastFrame();
-      expect(frame).toContain(
-        "> Type here to tell Wave what to do differently",
-      );
-      expect(frame).toContain("Type here to tell Wave what to do differently");
+      expect(frame).toContain("> Type here to tell Wave what to change");
+      expect(frame).toContain("Type here to tell Wave what to change");
     });
 
     it("should handle whitespace-only alternative text", async () => {
@@ -875,21 +859,20 @@ describe("Confirmation", () => {
 
       // Start with allow selected
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
       });
 
       // Type only spaces to switch to alternative option
       stdin.write("   ");
 
       // Wait for text and selection to update
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      // Verify we're on alternative option and placeholder is gone
-      const frameAfterSpaces = lastFrame();
-      expect(frameAfterSpaces).not.toContain(
-        "Type here to tell Wave what to do differently",
-      );
-      expect(frameAfterSpaces).toContain(">");
+      await vi.waitFor(() => {
+        const frameAfterSpaces = lastFrame();
+        expect(frameAfterSpaces).not.toContain(
+          "Type here to tell Wave what to change",
+        );
+        expect(frameAfterSpaces).toContain(">");
+      });
 
       // Try to confirm - should not call onDecision because trimmed text is empty
       stdin.write("\r");
@@ -918,11 +901,9 @@ describe("Confirmation", () => {
 
       const frame = lastFrame();
       expect(frame).toContain("Use ↑↓ to navigate • ESC to cancel");
-      expect(frame).toContain("> Yes"); // Visual indicator of selection
+      expect(frame).toContain("> Yes, proceed"); // Visual indicator of selection
       expect(frame).toContain("  Yes, and auto-accept edits"); // Visual indicator of non-selection
-      expect(frame).toContain(
-        "  Type here to tell Wave what to do differently",
-      ); // Visual indicator of non-selection
+      expect(frame).toContain("  Type here to tell Wave what to change"); // Visual indicator of non-selection
     });
 
     it("should provide clear visual feedback for option selection", async () => {
@@ -936,31 +917,27 @@ describe("Confirmation", () => {
       );
 
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
       });
 
       // Check initial selection visual feedback
       let frame = lastFrame();
-      expect(frame).toContain("> Yes"); // Selected indicator
+      expect(frame).toContain("> Yes, proceed"); // Selected indicator
       expect(frame).toContain("  Yes, and auto-accept edits"); // Non-selected indicator
-      expect(frame).toContain(
-        "  Type here to tell Wave what to do differently",
-      ); // Non-selected indicator
+      expect(frame).toContain("  Type here to tell Wave what to change"); // Non-selected indicator
 
       // Change selection and check visual feedback
       stdin.write("\u001b[B");
       stdin.write("\u001b[B");
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "> Type here to tell Wave what to do differently",
+          "> Type here to tell Wave what to change",
         );
       });
 
       frame = lastFrame();
-      expect(frame).toContain("  Yes"); // Non-selected indicator
-      expect(frame).toContain(
-        "> Type here to tell Wave what to do differently",
-      ); // Selected indicator
+      expect(frame).toContain("  Yes, proceed"); // Non-selected indicator
+      expect(frame).toContain("> Type here to tell Wave what to change"); // Selected indicator
     });
 
     it("should automatically focus alternative option when user starts typing", async () => {
@@ -975,7 +952,7 @@ describe("Confirmation", () => {
 
       // Start on allow option
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
       });
 
       // Type a character - should auto-focus alternative
@@ -987,7 +964,7 @@ describe("Confirmation", () => {
       const frame = lastFrame();
       expect(frame).toContain("> x"); // Should auto-select alternative
       expect(frame).toContain("x"); // Should contain the typed character
-      expect(frame).toContain("  Yes"); // Allow should no longer be selected
+      expect(frame).toContain("  Yes, proceed"); // Allow should no longer be selected
     });
   });
 
@@ -1100,7 +1077,9 @@ describe("Confirmation", () => {
       // Toggle React (Option 2) using Space key
       // First navigate to it
       stdin.write("\u001b[B"); // Down arrow
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> [ ] React");
+      });
       stdin.write(" ");
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain("[x] React");
@@ -1215,6 +1194,8 @@ describe("Confirmation", () => {
 
       // Move left and type "X" -> "ABXC"
       stdin.write("\u001b[D"); // Left arrow
+      // Wait for the cursor to move. Since we can't see the cursor in stripAnsiColors,
+      // we just wait for a tick to ensure the input was processed.
       await new Promise((resolve) => setTimeout(resolve, 50));
       stdin.write("X");
       await vi.waitFor(() => {
@@ -1282,8 +1263,9 @@ describe("Confirmation", () => {
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain("My Plan");
       });
-      expect(lastFrame()).toContain("Yes, proceed with default mode");
-      expect(lastFrame()).toContain("Yes, and auto-accept edits");
+      expect(lastFrame()).toContain("Yes, clear context and auto-accept edits");
+      expect(lastFrame()).toContain("Yes, auto-accept edits");
+      expect(lastFrame()).toContain("Yes, manually approve edits");
     });
 
     it("should handle EXIT_PLAN_MODE_TOOL_NAME decisions", async () => {
@@ -1301,19 +1283,20 @@ describe("Confirmation", () => {
         expect(stripAnsiColors(lastFrame() || "")).toContain("My Plan");
       });
 
-      // Confirm default
+      // Confirm default (clear context)
       stdin.write("\r");
       await vi.waitFor(() => {
         expect(mockOnDecision).toHaveBeenCalledWith(
           expect.objectContaining({
             behavior: "allow",
-            newPermissionMode: "default",
+            newPermissionMode: "acceptEdits",
+            clearContext: true,
           }),
         );
       });
 
       // Test auto-accept for ExitPlanMode
-      const { stdin: stdin2 } = render(
+      const { stdin: stdin2, lastFrame: lastFrame2 } = render(
         <Confirmation
           toolName="ExitPlanMode"
           toolInput={{ plan_content: "My Plan" }}
@@ -1322,14 +1305,50 @@ describe("Confirmation", () => {
           onAbort={mockOnAbort}
         />,
       );
-      stdin2.write("\u001b[B"); // Down to auto
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      stdin2.write("\u001b[B"); // Down to auto-accept
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame2() || "")).toContain(
+          "> Yes, auto-accept edits",
+        );
+      });
       stdin2.write("\r");
       await vi.waitFor(() => {
         expect(mockOnDecision).toHaveBeenLastCalledWith(
           expect.objectContaining({
             behavior: "allow",
             newPermissionMode: "acceptEdits",
+          }),
+        );
+      });
+
+      // Test manually approve for ExitPlanMode
+      const { stdin: stdin3, lastFrame: lastFrame3 } = render(
+        <Confirmation
+          toolName="ExitPlanMode"
+          toolInput={{ plan_content: "My Plan" }}
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+          onAbort={mockOnAbort}
+        />,
+      );
+      stdin3.write("\u001b[B"); // Down to auto-accept
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame3() || "")).toContain(
+          "> Yes, auto-accept edits",
+        );
+      });
+      stdin3.write("\u001b[B"); // Down to manually approve
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame3() || "")).toContain(
+          "> Yes, manually approve edits",
+        );
+      });
+      stdin3.write("\r");
+      await vi.waitFor(() => {
+        expect(mockOnDecision).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            behavior: "allow",
+            newPermissionMode: "default",
           }),
         );
       });
@@ -1370,8 +1389,12 @@ describe("Confirmation", () => {
         expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
       });
 
-      stdin.write("\u001b[B"); // Down to auto
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      stdin.write("\u001b[A"); // Up to auto
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain(
+          "> Yes, and don't ask again for: ls",
+        );
+      });
       stdin.write("\r");
       await vi.waitFor(() => {
         expect(mockOnDecision).toHaveBeenCalledWith(
@@ -1398,8 +1421,12 @@ describe("Confirmation", () => {
         expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
       });
 
-      stdin.write("\u001b[B"); // Down to auto
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      stdin.write("\u001b[A"); // Up to auto
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain(
+          "> Yes, and don't ask again for this command",
+        );
+      });
       stdin.write("\r");
       await vi.waitFor(() => {
         expect(mockOnDecision).toHaveBeenCalledWith(
@@ -1422,20 +1449,39 @@ describe("Confirmation", () => {
       );
 
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
+      });
+
+      stdin.write("\u001b[A"); // Up to auto
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain(
+          "> Yes, and auto-accept edits",
+        );
       });
 
       stdin.write("\u001b[A"); // Up at top
       await vi.waitFor(() => {
-        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes");
+        expect(stripAnsiColors(lastFrame() || "")).toContain(
+          "> Yes, and auto-accept edits",
+        );
       });
 
-      stdin.write("\u001b[B"); // Down to auto
+      stdin.write("\u001b[B"); // Down to allow
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
+      });
+
       stdin.write("\u001b[B"); // Down to alternative
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain(
+          "> Type here to tell Wave what to change",
+        );
+      });
+
       stdin.write("\u001b[B"); // Down at bottom
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "> Type here to tell Wave what to do differently",
+          "> Type here to tell Wave what to change",
         );
       });
     });
@@ -1458,7 +1504,7 @@ describe("Confirmation", () => {
       stdin.write("\u001b[B"); // Down to alternative
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "> Type here to tell Wave what to do differently",
+          "> Type here to tell Wave what to change",
         );
       });
 

--- a/packages/code/tests/components/HistorySearch.test.tsx
+++ b/packages/code/tests/components/HistorySearch.test.tsx
@@ -40,8 +40,8 @@ describe("HistorySearch", () => {
     await vi.waitFor(() => {
       const output = stripAnsiColors(lastFrame() || "");
       expect(output).toContain("Prompt History");
-      expect(output).toContain("first prompt");
-      expect(output).toContain("second prompt");
+      expect(output).toContain("> first prompt");
+      expect(output).toContain("  second prompt");
     });
   });
 
@@ -49,7 +49,7 @@ describe("HistorySearch", () => {
     const { lastFrame, rerender } = render(<HistorySearch {...mockProps} />);
 
     await vi.waitFor(() => {
-      expect(stripAnsiColors(lastFrame() || "")).toContain("first prompt");
+      expect(stripAnsiColors(lastFrame() || "")).toContain("> first prompt");
     });
 
     vi.mocked(PromptHistoryManager.searchHistory).mockResolvedValue([
@@ -60,7 +60,7 @@ describe("HistorySearch", () => {
     await vi.waitFor(() => {
       const output = stripAnsiColors(lastFrame() || "");
       expect(output).toContain('filtering: "second"');
-      expect(output).toContain("second prompt");
+      expect(output).toContain("> second prompt");
       expect(output).not.toContain("first prompt");
     });
   });
@@ -72,7 +72,7 @@ describe("HistorySearch", () => {
     );
 
     await vi.waitFor(() => {
-      expect(stripAnsiColors(lastFrame() || "")).toContain("first prompt");
+      expect(stripAnsiColors(lastFrame() || "")).toContain("> first prompt");
     });
 
     stdin.write("\r");
@@ -88,7 +88,7 @@ describe("HistorySearch", () => {
     );
 
     await vi.waitFor(() => {
-      expect(stripAnsiColors(lastFrame() || "")).toContain("first prompt");
+      expect(stripAnsiColors(lastFrame() || "")).toContain("> first prompt");
     });
 
     stdin.write("\u001B"); // Escape
@@ -104,21 +104,17 @@ describe("HistorySearch", () => {
     );
 
     await vi.waitFor(() => {
-      expect(stripAnsiColors(lastFrame() || "")).toContain("first prompt");
+      expect(stripAnsiColors(lastFrame() || "")).toContain("> first prompt");
     });
 
     stdin.write("\u001B[B"); // Down arrow
 
     // Wait for selection to change in UI
     await vi.waitFor(() => {
-      const output = lastFrame() || "";
-      // In Ink, the selected item has a blue background.
-      // We check if the second prompt is rendered (it should be).
-      expect(stripAnsiColors(output)).toContain("second prompt");
+      const output = stripAnsiColors(lastFrame() || "");
+      expect(output).toContain("> second prompt");
+      expect(output).toContain("  first prompt");
     });
-
-    // Give it a few more ticks to ensure the index state and ref are updated
-    await new Promise((resolve) => setTimeout(resolve, 50));
 
     stdin.write("\r");
     await vi.waitFor(() => {

--- a/packages/code/tests/managers/InputManager.test.ts
+++ b/packages/code/tests/managers/InputManager.test.ts
@@ -179,9 +179,9 @@ describe("InputManager", () => {
       manager.updateFileSearchQuery("test");
 
       // Wait for debounced search
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      expect(mockSearchFiles).toHaveBeenCalledWith("test");
+      await vi.waitFor(() =>
+        expect(mockSearchFiles).toHaveBeenCalledWith("test"),
+      );
     });
 
     it("should detect @ deletion", () => {


### PR DESCRIPTION
This PR implements the ability to clear conversation context when exiting plan mode, re-inserting the plan content as a fresh starting point. It also improves UI feedback in ConfirmationSelector and HistorySearch, and updates tests to be more robust.