### PR TITLE
feat(agent-sdk): update bash tool to show last 3 lines in short result update

### DIFF
--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -197,8 +197,23 @@ Usage notes:
 
       let outputBuffer = "";
       let errorBuffer = "";
+      let shortResultBuffer = "";
       let isAborted = false;
       let isBackgrounded = false;
+
+      const updateShortResult = (chunk: string) => {
+        if (!chunk) return;
+        shortResultBuffer += chunk;
+        if (shortResultBuffer.length > MAX_OUTPUT_LENGTH) {
+          shortResultBuffer = shortResultBuffer.slice(-MAX_OUTPUT_LENGTH);
+        }
+        const lastLines = shortResultBuffer
+          .trim()
+          .split("\n")
+          .slice(-3)
+          .join("\n");
+        context.onShortResultUpdate?.(lastLines || "");
+      };
 
       const foregroundTaskId = `bash_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 
@@ -309,7 +324,7 @@ Usage notes:
         if (!isAborted && !isBackgrounded && !runInBackground) {
           const chunk = stripAnsiColors(data.toString());
           outputBuffer += chunk;
-          context.onShortResultUpdate?.(chunk.trim().split("\n").pop() || "");
+          updateShortResult(chunk);
         }
       });
 
@@ -317,7 +332,7 @@ Usage notes:
         if (!isAborted && !isBackgrounded && !runInBackground) {
           const chunk = stripAnsiColors(data.toString());
           errorBuffer += chunk;
-          context.onShortResultUpdate?.(chunk.trim().split("\n").pop() || "");
+          updateShortResult(chunk);
         }
       });
 

--- a/packages/agent-sdk/tests/tools/bashTool.test.ts
+++ b/packages/agent-sdk/tests/tools/bashTool.test.ts
@@ -392,6 +392,57 @@ describe("bashTool", () => {
       expect(result.success).toBe(false);
       expect(result.error).toBe("Failed to execute command: spawn failed");
     });
+
+    it("should show last 3 lines of interleaved output in onShortResultUpdate", async () => {
+      const onShortResultUpdate = vi.fn();
+      const testContext = { ...context, onShortResultUpdate };
+
+      const mockProcess = {
+        pid: 1234,
+        stdout: {
+          on: vi.fn(),
+        },
+        stderr: {
+          on: vi.fn(),
+        },
+        on: vi.fn((event, callback) => {
+          if (event === "exit") {
+            setTimeout(() => callback(0), 50);
+          }
+        }),
+        kill: vi.fn(),
+        killed: false,
+      };
+      mockSpawn.mockReturnValue(mockProcess as unknown as ChildProcess);
+
+      const executePromise = bashTool.execute({ command: "test" }, testContext);
+
+      // Simulate interleaved output
+      const stdoutCallback = vi
+        .mocked(mockProcess.stdout.on)
+        .mock.calls.find((c) => c[0] === "data")![1];
+      const stderrCallback = vi
+        .mocked(mockProcess.stderr.on)
+        .mock.calls.find((c) => c[0] === "data")![1];
+
+      stdoutCallback(Buffer.from("line 1\n"));
+      expect(onShortResultUpdate).toHaveBeenLastCalledWith("line 1");
+
+      stderrCallback(Buffer.from("line 2\n"));
+      expect(onShortResultUpdate).toHaveBeenLastCalledWith("line 1\nline 2");
+
+      stdoutCallback(Buffer.from("line 3\n"));
+      expect(onShortResultUpdate).toHaveBeenLastCalledWith(
+        "line 1\nline 2\nline 3",
+      );
+
+      stderrCallback(Buffer.from("line 4\n"));
+      expect(onShortResultUpdate).toHaveBeenLastCalledWith(
+        "line 2\nline 3\nline 4",
+      );
+
+      await executePromise;
+    });
   });
 
   describe("TaskOutput tool", () => {


### PR DESCRIPTION
Updates the bash tool to maintain a buffer of the last 3 lines of output (interleaved stdout and stderr) and provide them to the onShortResultUpdate callback. This provides better context for long-running commands.