### PR TITLE
Change message update debounce to throttle in useChat

### DIFF
--- a/.wave/rules/examples.md
+++ b/.wave/rules/examples.md
@@ -5,8 +5,8 @@ paths:
 - `packages/*/examples` directories contain real test ts or tsx files that are hard to mock:
   - need to create temporary directories
   - test by sending real messages using `agent.sendMessage`
-  - run example like this: `pnpm -F xxx exec tsx examples/hi.ts`
+  - run example like this: `cd packages/xxx && pnpm exec tsx examples/hi.ts`
   - use `gemini-2.5-flash` for cheaper and faster testing (pass as `agentModel` in `Agent.create`)
   - always include a `finally` block that calls `await agent.destroy()` to ensure the process exits
   - never access private properties directly with `(agent as any)`
-  - before running any example, always run type-check for `agent-sdk` to ensure types are valid: `pnpm -F wave-agent-sdk run type-check`
+  - before running any example, always run type-check for `agent-sdk` to ensure types are valid: `cd packages/agent-sdk && pnpm run type-check`

--- a/.wave/rules/testing.md
+++ b/.wave/rules/testing.md
@@ -5,7 +5,7 @@ paths:
 - `packages/*/tests` directories contain test files that are easy to mock, can run locally and on CI/CD
   - Task vitest-expert to write tests
   - Testing framework is vitest
-  - Run test use `pnpm -F xxx test test_file`
+  - Run test use `cd packages/xxx && pnpm test test_file`
   - Use HookTester to test hooks
   - Use `vi.waitFor` to wait for UI changes in Ink components
   - Use `as unknown as` `Awaited<>` `ReturnType<>` `typeof` to simplify type check, for example: 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This is a pnpm monorepo focused on AI-powered development tools.
 
 ### Key Dependencies
 - `packages/code` depends on `packages/agent-sdk`.
-- **Important**: After modifying `agent-sdk`, you MUST rebuild it (`pnpm -F wave-agent-sdk build`) before the changes are available to `packages/code`.
+- **Important**: After modifying `agent-sdk`, you MUST rebuild it (`cd packages/agent-sdk && pnpm build`) before the changes are available to `packages/code`.
 
 ## 🛠 Development Commands
 
@@ -21,13 +21,13 @@ Always use `pnpm` as the package manager.
 
 ### Build & Type-Check
 - **Build all**: `pnpm build`
-    - **Build specific package**: `pnpm -F <package-name> build` (e.g., `pnpm -F wave-agent-sdk build` or `pnpm -F wave-code build`)
+    - **Build specific package**: `cd packages/<package-name> && pnpm build` (e.g., `cd packages/agent-sdk && pnpm build` or `cd packages/code && pnpm build`)
 - **Type-check all**: `pnpm run type-check`
 
 ### Testing
 - **Run all tests**: `pnpm test`
-    - **Run tests for a package**: `pnpm -F <package-name> test` (e.g., `pnpm -F wave-agent-sdk test`)
-    - **Run a single test file**: `pnpm -F <package-name> test <path/to/test>` (e.g., `pnpm -F wave-agent-sdk test tests/agent.test.ts`)
+    - **Run tests for a package**: `cd packages/<package-name> && pnpm test` (e.g., `cd packages/agent-sdk && pnpm test`)
+    - **Run a single test file**: `cd packages/<package-name> && pnpm test <path/to/test>` (e.g., `cd packages/agent-sdk && pnpm test tests/agent.test.ts`)
 - **Testing Framework**: Vitest.
 
 ### Linting

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -229,15 +229,16 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   useEffect(() => {
     const initializeAgent = async () => {
       const callbacks: AgentCallbacks = {
-        onMessagesChange: (newMessages) => {
+        onMessagesChange: () => {
           if (!isExpandedRef.current) {
-            if (messagesUpdateTimerRef.current) {
-              clearTimeout(messagesUpdateTimerRef.current);
+            if (!messagesUpdateTimerRef.current) {
+              messagesUpdateTimerRef.current = setTimeout(() => {
+                if (agentRef.current) {
+                  setMessages([...agentRef.current.messages]);
+                }
+                messagesUpdateTimerRef.current = null;
+              }, 50);
             }
-            messagesUpdateTimerRef.current = setTimeout(() => {
-              setMessages([...newMessages]);
-              messagesUpdateTimerRef.current = null;
-            }, 50);
           }
         },
         onServersChange: (servers) => {
@@ -353,6 +354,9 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   // Cleanup on unmount
   useEffect(() => {
     return () => {
+      if (messagesUpdateTimerRef.current) {
+        clearTimeout(messagesUpdateTimerRef.current);
+      }
       if (agentRef.current) {
         try {
           // Display usage summary before cleanup
@@ -538,6 +542,10 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
       setIsExpanded((prev) => {
         const newExpanded = !prev;
         if (newExpanded) {
+          if (messagesUpdateTimerRef.current) {
+            clearTimeout(messagesUpdateTimerRef.current);
+            messagesUpdateTimerRef.current = null;
+          }
           // Transitioning to EXPANDED: Freeze the current view
           // Deep copy the last message to ensure it doesn't update if the agent is still writing to it
           setMessages((currentMessages) => {

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -152,6 +152,7 @@ describe("ChatProvider", () => {
         blocks: [{ type: "text" as const, content: "test" }],
       },
     ];
+    Object.assign(mockAgent, { messages: newMessages });
     callbacks.onMessagesChange!(newMessages);
     await vi.waitFor(() => {
       expect(lastValue?.messages).toEqual(newMessages);
@@ -762,6 +763,51 @@ describe("ChatProvider", () => {
 
     // Simulate Ctrl+O
     inputCallback("o", { ctrl: true } as Parameters<typeof inputCallback>[1]);
+  });
+
+  it("clears throttle timer when expanding", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
+    const callbacks = agentCreateArgs.callbacks!;
+
+    // Trigger onMessagesChange to start a timer
+    const newMessages = [
+      {
+        role: "user" as const,
+        blocks: [{ type: "text" as const, content: "test" }],
+      },
+    ];
+    Object.assign(mockAgent, { messages: newMessages });
+
+    // Use fake timers to control the throttle timer
+    vi.useFakeTimers();
+
+    callbacks.onMessagesChange!(newMessages);
+
+    // Get the useInput callback
+    const useInputMock = vi.mocked(useInput);
+    const inputCallback =
+      useInputMock.mock.calls[useInputMock.mock.calls.length - 1][0];
+
+    // Simulate Ctrl+O to expand
+    inputCallback("o", { ctrl: true } as Parameters<typeof inputCallback>[1]);
+
+    // Advance time - the timer should have been cleared, so messages should NOT be updated to newMessages
+    vi.advanceTimersByTime(100);
+
+    expect(lastValue?.messages).toEqual([]);
+
+    vi.useRealTimers();
   });
 
   it("cancels confirmation with ESC key", async () => {


### PR DESCRIPTION
This PR replaces the debounce mechanism for message updates in useChat.tsx with a throttle mechanism. This ensures that the UI updates at least every 50ms during rapid message streaming, providing a smoother and more responsive user experience. It also includes updates to the expansion logic to clear pending timers and ensures proper cleanup on unmount.