### PR TITLE
feat: add git worktree support to wave code CLI

### DIFF
--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -22,6 +22,6 @@ export * from "./utils/stringUtils.js";
 export * from "./utils/customCommands.js";
 export * from "./utils/hookMatcher.js";
 export * from "./utils/tokenCalculation.js";
-
-// Export types
+export * from "./utils/gitUtils.js";
+export * from "./utils/nameGenerator.js";
 export * from "./types/index.js";

--- a/packages/agent-sdk/src/utils/gitUtils.ts
+++ b/packages/agent-sdk/src/utils/gitUtils.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import * as fsSync from "node:fs";
+import { execSync } from "node:child_process";
 
 /**
  * Check if a directory is a git repository
@@ -20,5 +21,79 @@ export function isGitRepository(dirPath: string): string {
     return "No";
   } catch {
     return "No";
+  }
+}
+
+/**
+ * Get the root directory of the git repository
+ * @param cwd Working directory
+ * @returns Repository root path
+ */
+export function getGitRepoRoot(cwd: string): string {
+  try {
+    return execSync("git rev-parse --show-toplevel", {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return cwd;
+  }
+}
+
+/**
+ * Get the default remote branch (e.g., origin/main)
+ * @param cwd Working directory
+ * @returns Default remote branch name
+ */
+export function getDefaultRemoteBranch(cwd: string): string {
+  try {
+    const head = execSync("git symbolic-ref refs/remotes/origin/HEAD", {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return head.replace("refs/remotes/", "");
+  } catch {
+    // Fallback to origin/main if origin/HEAD is not set
+    return "origin/main";
+  }
+}
+
+/**
+ * Check if there are uncommitted changes in the working directory
+ * @param cwd Working directory
+ * @returns True if there are uncommitted changes
+ */
+export function hasUncommittedChanges(cwd: string): boolean {
+  try {
+    const status = execSync("git status --porcelain", {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return status.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if there are new commits in the current branch that are not in the base branch
+ * @param cwd Working directory
+ * @param baseBranch Base branch name (e.g., origin/main)
+ * @returns True if there are new commits
+ */
+export function hasNewCommits(cwd: string, baseBranch?: string): boolean {
+  try {
+    const range = baseBranch ? `${baseBranch}..HEAD` : "@{u}..HEAD";
+    const log = execSync(`git log ${range} --oneline`, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return log.length > 0;
+  } catch {
+    return false;
   }
 }

--- a/packages/agent-sdk/src/utils/nameGenerator.ts
+++ b/packages/agent-sdk/src/utils/nameGenerator.ts
@@ -69,10 +69,11 @@ const nouns = [
 ];
 
 /**
- * Generates a random English name (adjective-noun)
+ * Generates a random English name (adjective-adjective-noun)
  */
 export function generateRandomName(seed?: string): string {
-  let adjIndex: number;
+  let adj1Index: number;
+  let adj2Index: number;
   let nounIndex: number;
 
   if (seed) {
@@ -82,14 +83,17 @@ export function generateRandomName(seed?: string): string {
       hash = (hash << 5) - hash + seed.charCodeAt(i);
       hash |= 0; // Convert to 32bit integer
     }
-    adjIndex = Math.abs(hash) % adjectives.length;
+    adj1Index = Math.abs(hash) % adjectives.length;
+    adj2Index = Math.abs(hash >> 4) % adjectives.length;
     nounIndex = Math.abs(hash >> 8) % nouns.length;
   } else {
-    adjIndex = Math.floor(Math.random() * adjectives.length);
+    adj1Index = Math.floor(Math.random() * adjectives.length);
+    adj2Index = Math.floor(Math.random() * adjectives.length);
     nounIndex = Math.floor(Math.random() * nouns.length);
   }
 
-  const adj = adjectives[adjIndex];
+  const adj1 = adjectives[adj1Index];
+  const adj2 = adjectives[adj2Index];
   const noun = nouns[nounIndex];
-  return `${adj}-${noun}`;
+  return `${adj1}-${adj2}-${noun}`;
 }

--- a/packages/agent-sdk/tests/managers/planManager.test.ts
+++ b/packages/agent-sdk/tests/managers/planManager.test.ts
@@ -27,7 +27,7 @@ describe("PlanManager", () => {
 
     expect(filePath).toContain(expectedDir);
     expect(filePath).toMatch(/\.md$/);
-    expect(name).toMatch(/^[a-z]+-[a-z]+$/);
+    expect(name).toMatch(/^[a-z]+-[a-z]+-[a-z]+$/);
     expect(fs.mkdir).toHaveBeenCalledWith(expectedDir, { recursive: true });
   });
 

--- a/packages/agent-sdk/tests/utils/gitUtils.test.ts
+++ b/packages/agent-sdk/tests/utils/gitUtils.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { execSync } from 'node:child_process';
+import {
+  getGitRepoRoot,
+  getDefaultRemoteBranch,
+  hasUncommittedChanges,
+  hasNewCommits,
+} from '../../src/utils/gitUtils.js';
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+describe('gitUtils', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getGitRepoRoot', () => {
+    it('should return the git repo root', () => {
+      vi.mocked(execSync).mockReturnValue('/repo/root\n' as unknown as ReturnType<typeof execSync>);
+      expect(getGitRepoRoot('/some/path')).toBe('/repo/root');
+      expect(execSync).toHaveBeenCalledWith('git rev-parse --show-toplevel', expect.any(Object));
+    });
+
+    it('should return cwd if git command fails', () => {
+      vi.mocked(execSync).mockImplementation(() => {
+        throw new Error('Not a git repo');
+      });
+      expect(getGitRepoRoot('/some/path')).toBe('/some/path');
+    });
+  });
+
+  describe('getDefaultRemoteBranch', () => {
+    it('should return the default remote branch', () => {
+      vi.mocked(execSync).mockReturnValue('refs/remotes/origin/main\n' as unknown as ReturnType<typeof execSync>);
+      expect(getDefaultRemoteBranch('/repo/root')).toBe('origin/main');
+    });
+
+    it('should fallback to origin/main if command fails', () => {
+      vi.mocked(execSync).mockImplementation(() => {
+        throw new Error('No origin/HEAD');
+      });
+      expect(getDefaultRemoteBranch('/repo/root')).toBe('origin/main');
+    });
+  });
+
+  describe('hasUncommittedChanges', () => {
+    it('should return true if there are changes', () => {
+      vi.mocked(execSync).mockReturnValue(' M file.ts\n' as unknown as ReturnType<typeof execSync>);
+      expect(hasUncommittedChanges('/repo/root')).toBe(true);
+    });
+
+    it('should return false if there are no changes', () => {
+      vi.mocked(execSync).mockReturnValue('' as unknown as ReturnType<typeof execSync>);
+      expect(hasUncommittedChanges('/repo/root')).toBe(false);
+    });
+  });
+
+  describe('hasNewCommits', () => {
+    it('should return true if there are new commits', () => {
+      vi.mocked(execSync).mockReturnValue('abc1234 Commit message\n' as unknown as ReturnType<typeof execSync>);
+      expect(hasNewCommits('/repo/root', 'origin/main')).toBe(true);
+    });
+
+    it('should return false if there are no new commits', () => {
+      vi.mocked(execSync).mockReturnValue('' as unknown as ReturnType<typeof execSync>);
+      expect(hasNewCommits('/repo/root', 'origin/main')).toBe(false);
+    });
+  });
+});

--- a/packages/agent-sdk/tests/utils/nameGenerator.test.ts
+++ b/packages/agent-sdk/tests/utils/nameGenerator.test.ts
@@ -4,7 +4,7 @@ import { generateRandomName } from "../../src/utils/nameGenerator.js";
 describe("nameGenerator", () => {
   it("should generate a random name without seed", () => {
     const name = generateRandomName();
-    expect(name).toMatch(/^[a-z]+-[a-z]+$/);
+    expect(name).toMatch(/^[a-z]+-[a-z]+-[a-z]+$/);
   });
 
   it("should generate the same name for the same seed", () => {
@@ -22,6 +22,6 @@ describe("nameGenerator", () => {
 
   it("should generate a name even with empty seed", () => {
     const name = generateRandomName("");
-    expect(name).toMatch(/^[a-z]+-[a-z]+$/);
+    expect(name).toMatch(/^[a-z]+-[a-z]+-[a-z]+$/);
   });
 });

--- a/packages/code/examples/plugin-demo.tsx
+++ b/packages/code/examples/plugin-demo.tsx
@@ -55,7 +55,7 @@ This command was loaded from a local plugin!
     // 2. Render the App with the plugin directory
     // We use bypassPermissions to simplify the demo
     const { lastFrame, unmount } = render(
-      <App pluginDirs={[pluginDir]} bypassPermissions={true} />,
+      <App pluginDirs={[pluginDir]} bypassPermissions={true} onExit={() => {}} />,
     );
 
     // Give it a moment to initialize the agent and load plugins

--- a/packages/code/examples/test-app.tsx
+++ b/packages/code/examples/test-app.tsx
@@ -6,7 +6,7 @@ import { INPUT_PLACEHOLDER_TEXT_PREFIX } from "@/components/InputBox.js";
 
 async function testApp() {
   try {
-    const { stdin, lastFrame, unmount } = render(<App />);
+    const { stdin, lastFrame, unmount } = render(<App onExit={() => {}} />);
 
     const waitFor = async (
       condition: () => boolean,

--- a/packages/code/src/cli.tsx
+++ b/packages/code/src/cli.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render } from "ink";
 import { App } from "./components/App.js";
 import { cleanupLogs } from "./utils/logger.js";
+import { type WorktreeSession } from "./utils/worktree.js";
 
 export interface CliOptions {
   restoreSessionId?: string;
@@ -9,6 +10,7 @@ export interface CliOptions {
   bypassPermissions?: boolean;
   pluginDirs?: string[];
   tools?: string[];
+  worktreeSession?: WorktreeSession;
 }
 
 export async function startCli(options: CliOptions): Promise<void> {
@@ -18,6 +20,7 @@ export async function startCli(options: CliOptions): Promise<void> {
     bypassPermissions,
     pluginDirs,
     tools,
+    worktreeSession,
   } = options;
 
   // Continue with ink-based UI for normal mode
@@ -28,8 +31,6 @@ export async function startCli(options: CliOptions): Promise<void> {
   const cleanup = async () => {
     if (isCleaningUp) return;
     isCleaningUp = true;
-
-    console.log("\nShutting down gracefully...");
 
     try {
       // Clean up old log files
@@ -52,21 +53,6 @@ export async function startCli(options: CliOptions): Promise<void> {
     }
   };
 
-  // Handle process signals
-  process.on("SIGINT", cleanup);
-  process.on("SIGTERM", cleanup);
-
-  // Handle uncaught exceptions
-  process.on("uncaughtException", (error) => {
-    console.error("Uncaught exception:", error);
-    cleanup();
-  });
-
-  process.on("unhandledRejection", (reason, promise) => {
-    console.error("Unhandled rejection at:", promise, "reason:", reason);
-    cleanup();
-  });
-
   // Render the application
   const { unmount } = render(
     <App
@@ -75,6 +61,8 @@ export async function startCli(options: CliOptions): Promise<void> {
       bypassPermissions={bypassPermissions}
       pluginDirs={pluginDirs}
       tools={tools}
+      worktreeSession={worktreeSession}
+      onExit={cleanup}
     />,
   );
 

--- a/packages/code/src/components/App.tsx
+++ b/packages/code/src/components/App.tsx
@@ -3,6 +3,13 @@ import { useStdout } from "ink";
 import { ChatInterface } from "./ChatInterface.js";
 import { ChatProvider, useChat } from "../contexts/useChat.js";
 import { AppProvider } from "../contexts/useAppConfig.js";
+import { type WorktreeSession, removeWorktree } from "../utils/worktree.js";
+import { WorktreeExitPrompt } from "./WorktreeExitPrompt.js";
+import {
+  hasUncommittedChanges,
+  hasNewCommits,
+  getDefaultRemoteBranch,
+} from "wave-agent-sdk";
 
 interface AppProps {
   restoreSessionId?: string;
@@ -10,13 +17,71 @@ interface AppProps {
   bypassPermissions?: boolean;
   pluginDirs?: string[];
   tools?: string[];
+  worktreeSession?: WorktreeSession;
+  onExit: () => void;
 }
 
 const AppWithProviders: React.FC<{
   bypassPermissions?: boolean;
   pluginDirs?: string[];
   tools?: string[];
-}> = ({ bypassPermissions, pluginDirs, tools }) => {
+  worktreeSession?: WorktreeSession;
+  onExit: () => void;
+}> = ({ bypassPermissions, pluginDirs, tools, worktreeSession, onExit }) => {
+  const [isExiting, setIsExiting] = useState(false);
+  const [worktreeStatus, setWorktreeStatus] = useState<{
+    hasUncommittedChanges: boolean;
+    hasNewCommits: boolean;
+  } | null>(null);
+
+  useEffect(() => {
+    const handleSignal = async () => {
+      if (worktreeSession) {
+        const cwd = process.cwd();
+        const baseBranch = getDefaultRemoteBranch(cwd);
+        const hasChanges = hasUncommittedChanges(cwd);
+        const hasCommits = hasNewCommits(cwd, baseBranch);
+
+        if (hasChanges || hasCommits) {
+          setWorktreeStatus({
+            hasUncommittedChanges: hasChanges,
+            hasNewCommits: hasCommits,
+          });
+          setIsExiting(true);
+        } else {
+          removeWorktree(worktreeSession, cwd);
+          onExit();
+        }
+      } else {
+        onExit();
+      }
+    };
+
+    process.on("SIGINT", handleSignal);
+    process.on("SIGTERM", handleSignal);
+
+    return () => {
+      process.off("SIGINT", handleSignal);
+      process.off("SIGTERM", handleSignal);
+    };
+  }, [worktreeSession, onExit]);
+
+  if (isExiting && worktreeSession && worktreeStatus) {
+    return (
+      <WorktreeExitPrompt
+        name={worktreeSession.name}
+        hasUncommittedChanges={worktreeStatus.hasUncommittedChanges}
+        hasNewCommits={worktreeStatus.hasNewCommits}
+        onKeep={() => onExit()}
+        onRemove={() => {
+          removeWorktree(worktreeSession, process.cwd());
+          onExit();
+        }}
+        onCancel={() => setIsExiting(false)}
+      />
+    );
+  }
+
   return (
     <ChatProvider
       bypassPermissions={bypassPermissions}
@@ -81,6 +146,8 @@ export const App: React.FC<AppProps> = ({
   bypassPermissions,
   pluginDirs,
   tools,
+  worktreeSession,
+  onExit,
 }) => {
   return (
     <AppProvider
@@ -91,6 +158,8 @@ export const App: React.FC<AppProps> = ({
         bypassPermissions={bypassPermissions}
         pluginDirs={pluginDirs}
         tools={tools}
+        worktreeSession={worktreeSession}
+        onExit={onExit}
       />
     </AppProvider>
   );

--- a/packages/code/src/components/WorktreeExitPrompt.tsx
+++ b/packages/code/src/components/WorktreeExitPrompt.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+
+interface WorktreeExitPromptProps {
+  name: string;
+  hasUncommittedChanges: boolean;
+  hasNewCommits: boolean;
+  onKeep: () => void;
+  onRemove: () => void;
+  onCancel: () => void;
+}
+
+export const WorktreeExitPrompt: React.FC<WorktreeExitPromptProps> = ({
+  name,
+  hasUncommittedChanges,
+  hasNewCommits,
+  onKeep,
+  onRemove,
+  onCancel,
+}) => {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  useInput((input, key) => {
+    if (key.upArrow) {
+      setSelectedIndex((prev) => (prev === 0 ? 1 : 0));
+    }
+    if (key.downArrow) {
+      setSelectedIndex((prev) => (prev === 1 ? 0 : 1));
+    }
+    if (key.return) {
+      if (selectedIndex === 0) {
+        onKeep();
+      } else {
+        onRemove();
+      }
+    }
+    if (key.escape) {
+      onCancel();
+    }
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderTop borderBottom borderLeft={false} borderRight={false} paddingX={1} marginY={1}>
+      <Box marginBottom={1}>
+        <Text bold color="yellow">
+          ⚠️ Worktree '{name}' has changes:
+        </Text>
+      </Box>
+      {hasUncommittedChanges && (
+        <Box marginLeft={2}>
+          <Text>- Uncommitted changes detected</Text>
+        </Box>
+      )}
+      {hasNewCommits && (
+        <Box marginLeft={2}>
+          <Text>- New commits detected</Text>
+        </Box>
+      )}
+      <Box marginTop={1} flexDirection="column">
+        <Text>What would you like to do?</Text>
+        <Box marginTop={1}>
+          <Text color={selectedIndex === 0 ? 'cyan' : undefined}>
+            {selectedIndex === 0 ? '> ' : '  '}Keep worktree (exit CLI, leave worktree and branch intact)
+          </Text>
+        </Box>
+        <Box>
+          <Text color={selectedIndex === 1 ? 'cyan' : undefined}>
+            {selectedIndex === 1 ? '> ' : '  '}Remove worktree (delete worktree and branch - DATA LOSS!)
+          </Text>
+        </Box>
+      </Box>
+      <Box marginTop={1}>
+        <Text dimColor>(Use arrow keys to select, Enter to confirm, Esc to resume session)</Text>
+      </Box>
+    </Box>
+  );
+};

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -1,7 +1,8 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { startCli } from "./cli.js";
-import { Scope } from "wave-agent-sdk";
+import { Scope, generateRandomName } from "wave-agent-sdk";
+import { createWorktree, type WorktreeSession } from "./utils/worktree.js";
 
 // Export main function for external use
 export async function main() {
@@ -18,6 +19,12 @@ export async function main() {
         alias: "c",
         description: "Continue from last session",
         type: "boolean",
+        global: false,
+      })
+      .option("worktree", {
+        alias: "w",
+        description: "Start session in a git worktree (optional name)",
+        type: "string",
         global: false,
       })
       .option("print", {
@@ -231,6 +238,20 @@ export async function main() {
 
     const tools = parseTools(argv.tools as string | undefined);
 
+    let worktreeSession: WorktreeSession | undefined;
+    if (
+      argv.worktree !== undefined ||
+      process.argv.includes("-w") ||
+      process.argv.includes("--worktree")
+    ) {
+      let name = argv.worktree as string | undefined;
+      if (!name || name === "") {
+        name = generateRandomName();
+      }
+      worktreeSession = createWorktree(name, process.cwd());
+      process.chdir(worktreeSession.path);
+    }
+
     // Handle restore session command
     if (
       argv.restore === "" ||
@@ -251,6 +272,7 @@ export async function main() {
         bypassPermissions: argv.dangerouslySkipPermissions,
         pluginDirs: argv.pluginDir as string[],
         tools,
+        worktreeSession,
       });
     }
 
@@ -265,6 +287,7 @@ export async function main() {
         bypassPermissions: argv.dangerouslySkipPermissions,
         pluginDirs: argv.pluginDir as string[],
         tools,
+        worktreeSession,
       });
     }
 
@@ -274,6 +297,7 @@ export async function main() {
       bypassPermissions: argv.dangerouslySkipPermissions,
       pluginDirs: argv.pluginDir as string[],
       tools,
+      worktreeSession,
     });
   } catch (error) {
     console.error("Failed to start WAVE Code:", error);

--- a/packages/code/src/print-cli.ts
+++ b/packages/code/src/print-cli.ts
@@ -1,5 +1,6 @@
-import { Agent, AgentCallbacks } from "wave-agent-sdk";
+import { Agent, AgentCallbacks, hasUncommittedChanges, hasNewCommits, getDefaultRemoteBranch } from "wave-agent-sdk";
 import { displayUsageSummary } from "./utils/usageSummary.js";
+import { type WorktreeSession, removeWorktree } from "./utils/worktree.js";
 
 export interface PrintCliOptions {
   restoreSessionId?: string;
@@ -9,6 +10,7 @@ export interface PrintCliOptions {
   bypassPermissions?: boolean;
   pluginDirs?: string[];
   tools?: string[];
+  worktreeSession?: WorktreeSession;
 }
 
 function displayTimingInfo(startTime: Date, showStats: boolean): void {
@@ -35,6 +37,7 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
     bypassPermissions,
     pluginDirs,
     tools,
+    worktreeSession,
   } = options;
 
   if (
@@ -163,6 +166,23 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
 
     // Destroy agent and exit after sendMessage completes
     await agent.destroy();
+
+    // Handle worktree cleanup for print mode
+    if (worktreeSession) {
+      const cwd = process.cwd();
+      const baseBranch = getDefaultRemoteBranch(cwd);
+      const hasChanges = hasUncommittedChanges(cwd);
+      const hasCommits = hasNewCommits(cwd, baseBranch);
+
+      if (!hasChanges && !hasCommits) {
+        removeWorktree(worktreeSession, cwd);
+      } else {
+        process.stdout.write(
+          `\n⚠️ Worktree '${worktreeSession.name}' has changes or commits. Keeping it at: ${worktreeSession.path}\n`,
+        );
+      }
+    }
+
     process.exit(0);
   } catch (error) {
     console.error("Failed to send message:", error);
@@ -182,6 +202,22 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
       displayTimingInfo(startTime, showStats);
 
       await agent.destroy();
+
+      // Handle worktree cleanup for print mode even on error
+      if (worktreeSession) {
+        const cwd = process.cwd();
+        const baseBranch = getDefaultRemoteBranch(cwd);
+        const hasChanges = hasUncommittedChanges(cwd);
+        const hasCommits = hasNewCommits(cwd, baseBranch);
+
+        if (!hasChanges && !hasCommits) {
+          removeWorktree(worktreeSession, cwd);
+        } else {
+          process.stdout.write(
+            `\n⚠️ Worktree '${worktreeSession.name}' has changes or commits. Keeping it at: ${worktreeSession.path}\n`,
+          );
+        }
+      }
     }
     process.exit(1);
   }

--- a/packages/code/src/utils/worktree.ts
+++ b/packages/code/src/utils/worktree.ts
@@ -1,0 +1,107 @@
+import { execSync } from 'node:child_process';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { getGitRepoRoot, getDefaultRemoteBranch } from 'wave-agent-sdk';
+
+export interface WorktreeSession {
+  name: string;
+  path: string;
+  branch: string;
+  hasUncommittedChanges: boolean;
+  hasNewCommits: boolean;
+}
+
+export const WORKTREE_DIR = '.wave/worktrees';
+
+/**
+ * Create a new git worktree
+ * @param name Worktree name
+ * @param cwd Current working directory
+ * @returns Worktree session details
+ */
+export function createWorktree(name: string, cwd: string): WorktreeSession {
+  const repoRoot = getGitRepoRoot(cwd);
+  const worktreePath = path.join(repoRoot, WORKTREE_DIR, name);
+  const branchName = `worktree-${name}`;
+  const baseBranch = getDefaultRemoteBranch(cwd);
+
+  // Ensure parent directory exists
+  const parentDir = path.dirname(worktreePath);
+  if (!fs.existsSync(parentDir)) {
+    fs.mkdirSync(parentDir, { recursive: true });
+  }
+
+  // Check if worktree already exists
+  if (fs.existsSync(worktreePath)) {
+    // If it exists, we assume it's already set up correctly
+    return {
+      name,
+      path: worktreePath,
+      branch: branchName,
+      hasUncommittedChanges: false,
+      hasNewCommits: false,
+    };
+  }
+
+  try {
+    // Create worktree and branch
+    execSync(`git worktree add -b ${branchName} "${worktreePath}" ${baseBranch}`, {
+      cwd: repoRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    return {
+      name,
+      path: worktreePath,
+      branch: branchName,
+      hasUncommittedChanges: false,
+      hasNewCommits: false,
+    };
+  } catch (error: unknown) {
+    const stderr = (error as { stderr?: Buffer }).stderr?.toString() || '';
+    if (stderr.includes('already exists')) {
+      // If branch already exists, try to add worktree without -b
+      try {
+        execSync(`git worktree add "${worktreePath}" ${branchName}`, {
+          cwd: repoRoot,
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        return {
+          name,
+          path: worktreePath,
+          branch: branchName,
+          hasUncommittedChanges: false,
+          hasNewCommits: false,
+        };
+      } catch (innerError: unknown) {
+        throw new Error(`Failed to add existing worktree branch: ${(innerError as Error).message}`);
+      }
+    }
+    throw new Error(`Failed to create worktree: ${(error as Error).message}\n${stderr}`);
+  }
+}
+
+/**
+ * Remove a git worktree and its associated branch
+ * @param session Worktree session details
+ * @param cwd Current working directory
+ */
+export function removeWorktree(session: WorktreeSession, cwd: string): void {
+  const repoRoot = getGitRepoRoot(cwd);
+
+  try {
+    // Remove worktree
+    execSync(`git worktree remove --force "${session.path}"`, {
+      cwd: repoRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    // Delete branch
+    execSync(`git branch -D ${session.branch}`, {
+      cwd: repoRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error: unknown) {
+    console.error(`Failed to remove worktree or branch: ${(error as Error).message}`);
+  }
+}

--- a/packages/code/tests/components/App.test.tsx
+++ b/packages/code/tests/components/App.test.tsx
@@ -6,7 +6,7 @@ import { stripAnsiColors } from "wave-agent-sdk";
 
 describe("App Component", () => {
   it("should render the main interface with file count", async () => {
-    const { lastFrame } = render(<App />);
+    const { lastFrame } = render(<App onExit={vi.fn()} />);
 
     // Wait for the component to initialize and render
     await vi.waitFor(() => {
@@ -17,7 +17,7 @@ describe("App Component", () => {
   });
 
   it("should render the chat interface", async () => {
-    const { lastFrame } = render(<App />);
+    const { lastFrame } = render(<App onExit={vi.fn()} />);
 
     // Wait for components to initialize and render
     await vi.waitFor(() => {
@@ -31,7 +31,7 @@ describe("App Component", () => {
   });
 
   it("should wrap components with providers", async () => {
-    const { lastFrame } = render(<App />);
+    const { lastFrame } = render(<App onExit={vi.fn()} />);
 
     // Wait for the component to initialize and render
     await vi.waitFor(() => {

--- a/packages/code/tests/components/WorktreeExitPrompt.test.tsx
+++ b/packages/code/tests/components/WorktreeExitPrompt.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from 'ink-testing-library';
+import { WorktreeExitPrompt } from '../../src/components/WorktreeExitPrompt.js';
+
+describe('WorktreeExitPrompt', () => {
+  it('should render the prompt with worktree name', () => {
+    const { lastFrame } = render(
+      <WorktreeExitPrompt
+        name="gentle-swift-breeze"
+        hasUncommittedChanges={true}
+        hasNewCommits={false}
+        onKeep={vi.fn()}
+        onRemove={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    expect(lastFrame()).toContain("Worktree 'gentle-swift-breeze' has changes");
+    expect(lastFrame()).toContain("Uncommitted changes detected");
+    expect(lastFrame()).toContain("Keep worktree");
+    expect(lastFrame()).toContain("Remove worktree");
+  });
+
+  it('should show both changes and commits if present', () => {
+    const { lastFrame } = render(
+      <WorktreeExitPrompt
+        name="gentle-swift-breeze"
+        hasUncommittedChanges={true}
+        hasNewCommits={true}
+        onKeep={vi.fn()}
+        onRemove={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    expect(lastFrame()).toContain("Uncommitted changes detected");
+    expect(lastFrame()).toContain("New commits detected");
+  });
+
+  it('should handle arrow keys and enter to select options', async () => {
+    const onKeep = vi.fn();
+    const onRemove = vi.fn();
+    const { stdin, lastFrame } = render(
+      <WorktreeExitPrompt
+        name="gentle-swift-breeze"
+        hasUncommittedChanges={true}
+        hasNewCommits={false}
+        onKeep={onKeep}
+        onRemove={onRemove}
+        onCancel={vi.fn()}
+      />
+    );
+
+    // Default is Keep
+    expect(lastFrame()).toContain("> Keep worktree");
+    
+    // Press down to select Remove
+    stdin.write('\u001b[B'); // Down arrow
+    await vi.waitFor(() => expect(lastFrame()).toContain("> Remove worktree"));
+
+    // Press up to select Keep again
+    stdin.write('\u001b[A'); // Up arrow
+    await vi.waitFor(() => expect(lastFrame()).toContain("> Keep worktree"));
+
+    // Press enter to confirm Keep
+    stdin.write('\r');
+    await vi.waitFor(() => expect(onKeep).toHaveBeenCalled());
+
+    // Select Remove and confirm
+    stdin.write('\u001b[B'); // Down arrow
+    await vi.waitFor(() => expect(lastFrame()).toContain("> Remove worktree"));
+    stdin.write('\r');
+    await vi.waitFor(() => expect(onRemove).toHaveBeenCalled());
+  });
+
+  it('should handle escape to cancel', async () => {
+    const onCancel = vi.fn();
+    const { stdin } = render(
+      <WorktreeExitPrompt
+        name="gentle-swift-breeze"
+        hasUncommittedChanges={true}
+        hasNewCommits={false}
+        onKeep={vi.fn()}
+        onRemove={vi.fn()}
+        onCancel={onCancel}
+      />
+    );
+
+    stdin.write('\u001b'); // Escape
+    await vi.waitFor(() => expect(onCancel).toHaveBeenCalled());
+  });
+});

--- a/packages/code/tests/utils/worktree.test.ts
+++ b/packages/code/tests/utils/worktree.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createWorktree, removeWorktree } from '../../src/utils/worktree.js';
+import { getGitRepoRoot, getDefaultRemoteBranch } from 'wave-agent-sdk';
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+vi.mock('wave-agent-sdk', () => ({
+  getGitRepoRoot: vi.fn(),
+  getDefaultRemoteBranch: vi.fn(),
+}));
+
+describe('worktree utils', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createWorktree', () => {
+    it('should create a new worktree', () => {
+      vi.mocked(getGitRepoRoot).mockReturnValue('/repo/root');
+      vi.mocked(getDefaultRemoteBranch).mockReturnValue('origin/main');
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const session = createWorktree('my-feat', '/repo/root');
+
+      expect(session.name).toBe('my-feat');
+      expect(session.path).toBe(path.join('/repo/root', '.wave/worktrees/my-feat'));
+      expect(session.branch).toBe('worktree-my-feat');
+      expect(execSync).toHaveBeenCalledWith(
+        expect.stringContaining('git worktree add -b worktree-my-feat'),
+        expect.any(Object)
+      );
+    });
+
+    it('should handle branch already exists error by adding worktree without -b', () => {
+      vi.mocked(getGitRepoRoot).mockReturnValue('/repo/root');
+      vi.mocked(getDefaultRemoteBranch).mockReturnValue('origin/main');
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      // First call fails with "already exists"
+      const error = new Error('Command failed');
+      (error as { stderr?: Buffer }).stderr = Buffer.from('fatal: a branch named \'worktree-my-feat\' already exists');
+      vi.mocked(execSync).mockImplementationOnce(() => {
+        throw error;
+      });
+
+      // Second call succeeds
+      vi.mocked(execSync).mockImplementationOnce(() => Buffer.from(''));
+
+      const session = createWorktree('my-feat', '/repo/root');
+
+      expect(session.name).toBe('my-feat');
+      expect(execSync).toHaveBeenCalledTimes(2);
+      expect(execSync).toHaveBeenCalledWith(
+        expect.stringMatching(/git worktree add "[^"]+" worktree-my-feat/),
+        expect.any(Object)
+      );
+    });
+
+    it('should throw error if worktree creation fails with other error', () => {
+      vi.mocked(getGitRepoRoot).mockReturnValue('/repo/root');
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const error = new Error('Some other error');
+      vi.mocked(execSync).mockImplementationOnce(() => {
+        throw error;
+      });
+
+      expect(() => createWorktree('my-feat', '/repo/root')).toThrow('Failed to create worktree');
+    });
+
+    it('should throw error if adding existing branch fails', () => {
+      vi.mocked(getGitRepoRoot).mockReturnValue('/repo/root');
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const error = new Error('Command failed');
+      (error as { stderr?: Buffer }).stderr = Buffer.from('fatal: a branch named \'worktree-my-feat\' already exists');
+      vi.mocked(execSync).mockImplementationOnce(() => {
+        throw error;
+      });
+
+      vi.mocked(execSync).mockImplementationOnce(() => {
+        throw new Error('Inner error');
+      });
+
+      expect(() => createWorktree('my-feat', '/repo/root')).toThrow('Failed to add existing worktree branch');
+    });
+  });
+
+  describe('removeWorktree', () => {
+    it('should remove worktree and branch', () => {
+      vi.mocked(getGitRepoRoot).mockReturnValue('/repo/root');
+      const session = {
+        name: 'my-feat',
+        path: '/repo/root/.wave/worktrees/my-feat',
+        branch: 'worktree-my-feat',
+        hasUncommittedChanges: false,
+        hasNewCommits: false,
+      };
+
+      removeWorktree(session, '/repo/root');
+
+      expect(execSync).toHaveBeenCalledWith(
+        expect.stringContaining('git worktree remove --force'),
+        expect.any(Object)
+      );
+      expect(execSync).toHaveBeenCalledWith(
+        expect.stringContaining('git branch -D worktree-my-feat'),
+        expect.any(Object)
+      );
+    });
+
+    it('should log error if removal fails', () => {
+      vi.mocked(getGitRepoRoot).mockReturnValue('/repo/root');
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.mocked(execSync).mockImplementation(() => {
+        throw new Error('Removal failed');
+      });
+
+      const session = {
+        name: 'my-feat',
+        path: '/repo/root/.wave/worktrees/my-feat',
+        branch: 'worktree-my-feat',
+        hasUncommittedChanges: false,
+        hasNewCommits: false,
+      };
+
+      removeWorktree(session, '/repo/root');
+
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to remove worktree or branch'));
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/specs/068-cli-worktree-support/checklists/requirements.md
+++ b/specs/068-cli-worktree-support/checklists/requirements.md
@@ -1,0 +1,31 @@
+# Specification Quality Checklist: CLI Worktree Support
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-27
+**Feature**: [../spec.md]
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before /speckit.clarify or /speckit.plan

--- a/specs/068-cli-worktree-support/checklists/safety.md
+++ b/specs/068-cli-worktree-support/checklists/safety.md
@@ -1,0 +1,55 @@
+# Requirements Quality Checklist: CLI Worktree Safety & Robustness
+
+**Purpose**: Validate the quality, clarity, and completeness of requirements for the CLI Worktree Support feature, focusing on safety and data integrity.
+**Created**: 2026-02-27
+**Feature**: [../spec.md]
+**Audience**: Formal Review Gate (PR)
+
+## Requirement Completeness
+
+- [x] CHK001 - Are the exact git commands for worktree creation and removal explicitly specified? [Completeness, Spec §FR-003, §FR-011]
+- [x] CHK002 - Is the "default remote branch" identification logic defined (e.g., `origin/HEAD`)? [Completeness, Spec §FR-003]
+- [x] CHK003 - Are the criteria for "uncommitted changes" (staged vs. unstaged) explicitly defined? [Completeness, Spec §FR-006]
+- [x] CHK004 - Is the behavior for "Remove worktree" defined when the branch has been merged elsewhere? [Gap]
+- [x] CHK005 - Are requirements defined for handling existing worktrees with the same name? [Completeness, Spec §Edge Cases]
+
+## Requirement Clarity
+
+- [x] CHK006 - Is "delete the associated branch" quantified (e.g., `git branch -D` vs `-d`)? [Clarity, Spec §FR-011]
+- [x] CHK007 - Is the "worktree path" defined as absolute or relative to the repo root? [Clarity, Spec §FR-003]
+- [x] CHK008 - Is the "auto-generated name" pattern `adjective-adjective-noun` explicitly documented as the source of truth? [Clarity, Spec §FR-002]
+- [x] CHK009 - Is "change the working directory" clarified as a process-level change (`process.cwd()`)? [Clarity, Spec §FR-005]
+
+## Requirement Consistency
+
+- [x] CHK010 - Do the exit prompt options "Keep worktree" and "Remove worktree" align with the functional requirements for state cleanup? [Consistency, Spec §FR-009, §FR-011]
+- [x] CHK011 - Is the branch naming convention `worktree-<name>` consistent across all creation and deletion requirements? [Consistency, Spec §FR-004, §FR-011]
+- [x] CHK012 - Does the "Clean Exit" requirement conflict with any potential background task cleanup? [Consistency, Spec §FR-012]
+
+## Acceptance Criteria Quality
+
+- [x] CHK013 - Are the success criteria for "Remove worktree" measurable (e.g., directory is gone, branch is gone)? [Acceptance Criteria, Spec §User Story 3]
+- [x] CHK014 - Can the detection of "new commits" be objectively verified with a specific git command? [Measurability, Spec §FR-007]
+- [x] CHK015 - Is the "immediate exit" behavior for clean sessions testable without manual intervention? [Acceptance Criteria, Spec §User Story 5]
+
+## Scenario Coverage
+
+- [x] CHK016 - Are requirements defined for the scenario where the user cancels the exit prompt (Esc)? [Coverage, Spec §Input]
+- [x] CHK017 - Is the "Resume session" scenario (re-running with same name) fully specified in the functional requirements? [Coverage, Gap]
+- [x] CHK018 - Are requirements defined for handling `SIGINT` (Ctrl+C) vs `SIGTERM` or other exit signals? [Coverage, Gap]
+
+## Edge Case Coverage
+
+- [x] CHK019 - Does the spec define what happens if `git worktree add` fails (e.g., branch already exists)? [Edge Case, Spec §Edge Cases]
+- [x] CHK020 - Is the behavior specified for when the `.wave/worktrees/` parent directory is missing or unwritable? [Edge Case, Gap]
+- [x] CHK021 - Are requirements defined for handling worktree removal when files are locked by another process? [Edge Case, Gap]
+
+## Non-Functional Requirements
+
+- [x] CHK022 - Are performance requirements defined for the "Exit Detection" phase to avoid noticeable lag? [Gap]
+- [x] CHK023 - Is the "Safety" requirement for data loss prevention quantified with specific warning messages? [Clarity, Spec §User Story 3]
+
+## Dependencies & Assumptions
+
+- [x] CHK024 - Is the assumption that `git` is installed and in the PATH validated as a prerequisite? [Assumption, Spec §Assumptions]
+- [x] CHK025 - Is the dependency on the `generateRandomName` utility explicitly documented? [Dependency, Research]

--- a/specs/068-cli-worktree-support/data-model.md
+++ b/specs/068-cli-worktree-support/data-model.md
@@ -1,0 +1,44 @@
+# Data Model: CLI Worktree Support
+
+## Entities
+
+### WorktreeSession
+Represents a git worktree session created by the CLI.
+
+- **name**: `string`
+  - The unique identifier for the worktree and its associated branch.
+  - Example: `gentle-swift-breeze`
+- **path**: `string`
+  - The absolute filesystem path where the worktree is located.
+  - Example: `/home/user/project/.wave/worktrees/gentle-swift-breeze`
+- **branch**: `string`
+  - The name of the git branch created for this worktree.
+  - Example: `worktree-gentle-swift-breeze`
+- **hasUncommittedChanges**: `boolean`
+  - `true` if there are staged or unstaged changes in the worktree.
+- **hasNewCommits**: `boolean`
+  - `true` if there are commits in the worktree branch that are not in the base branch.
+
+## State Transitions
+
+1. **Initialization**:
+   - CLI starts with `-w` or `--worktree`.
+   - System generates a name if not provided.
+   - System identifies the default remote branch.
+   - System creates a new branch named `worktree-<name>` from the default remote branch.
+   - System creates a git worktree at `.wave/worktrees/<name>`.
+   - `WorktreeSession` is initialized with `name`, `path`, and `branch`.
+
+2. **Execution**:
+   - CLI runs within the worktree directory.
+   - User makes changes and/or commits.
+
+3. **Exit Detection**:
+   - CLI exit is triggered.
+   - System checks `git status --porcelain` to set `hasUncommittedChanges`.
+   - System checks `git log @{u}..HEAD` to set `hasNewCommits`.
+
+4. **User Decision**:
+   - If `hasUncommittedChanges` or `hasNewCommits` is `true`, show prompt.
+   - **Keep worktree**: Exit CLI, leave worktree and branch intact.
+   - **Remove worktree**: Run `git worktree remove --force <path>` and `git branch -D <branch>`, then exit.

--- a/specs/068-cli-worktree-support/plan.md
+++ b/specs/068-cli-worktree-support/plan.md
@@ -1,0 +1,75 @@
+# Implementation Plan: CLI Worktree Support
+
+**Branch**: `068-cli-worktree-support` | **Date**: 2026-02-27 | **Spec**: [./spec.md]
+**Input**: Feature specification from `./spec.md`
+
+## Summary
+
+The goal is to add support for git worktrees in the Wave CLI. This allows users to start a session in a isolated environment without affecting their main working directory. The implementation involves adding a `-w/--worktree` flag to the CLI, programmatically managing git worktrees, and providing an interactive exit prompt to prevent accidental data loss.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x
+**Primary Dependencies**: `yargs` (CLI parsing), `ink` (CLI UI), `git` (system dependency)
+**Storage**: Filesystem (git worktrees at `.wave/worktrees/`)
+**Testing**: Vitest
+**Target Platform**: Linux/macOS
+**Project Type**: Monorepo (agent-sdk + code)
+**Performance Goals**: Worktree creation should be fast (< 2s).
+**Constraints**: Must be in a git repository to use worktrees.
+**Scale/Scope**: CLI-only feature.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] **Package-First Architecture**: Changes will be isolated to `packages/code` (CLI logic) and potentially `packages/agent-sdk` (if new git utilities are needed).
+- [x] **TypeScript Excellence**: All new code will be strictly typed.
+- [x] **Test Alignment**: Unit tests for worktree management logic and integration tests for the CLI flow.
+- [x] **Build Dependencies**: `pnpm build` will be run after any changes to `agent-sdk`.
+- [x] **Documentation Minimalism**: Only `quickstart.md` and `research.md` are created as requested by the planning process.
+- [x] **Quality Gates**: `pnpm run type-check`, `pnpm run lint`, and `pnpm test:coverage` will be run.
+- [x] **Source Code Structure**: Follows existing patterns in `packages/code`.
+- [x] **Test-Driven Development**: Critical logic for worktree detection and removal will be tested.
+- [x] **Type System Evolution**: Existing CLI state types will be extended.
+- [x] **Data Model Minimalism**: `WorktreeSession` entity is focused on essential fields.
+- [x] **Planning and Task Delegation**: Planning performed by general-purpose agent.
+- [x] **User-Centric Quickstart**: `quickstart.md` is focused on end-user usage.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/068-cli-worktree-support/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output - USER FACING
+└── checklists/
+    └── requirements.md  # Spec quality checklist
+```
+
+### Source Code (repository root)
+
+```
+packages/
+├── agent-sdk/
+│   └── src/
+│       └── utils/
+│           └── git.ts       # Potential new git utilities
+└── code/
+    └── src/
+        ├── index.ts         # CLI argument parsing
+        ├── App.tsx           # Main app component (exit logic)
+        ├── components/
+        │   └── WorktreeExitPrompt.tsx # New interactive prompt
+        └── utils/
+            └── worktree.ts  # Worktree management logic
+```
+
+**Structure Decision**: The feature is primarily a CLI enhancement, so most changes will be in `packages/code`. Git-related logic that could be reused might be placed in `packages/agent-sdk`.
+
+## Complexity Tracking
+
+*No violations detected.*

--- a/specs/068-cli-worktree-support/quickstart.md
+++ b/specs/068-cli-worktree-support/quickstart.md
@@ -1,0 +1,53 @@
+# Quickstart: CLI Worktree Support
+
+This feature allows you to start a Wave session in a dedicated git worktree, keeping your main working directory clean.
+
+## Usage
+
+### Start a Worktree Session with a Name
+To start a session in a worktree with a specific name:
+```bash
+wave code --worktree my-feature
+```
+This will:
+1. Identify the default remote branch.
+2. Create a new git branch named `worktree-my-feature` from that branch.
+3. Create a git worktree at `.wave/worktrees/my-feature`.
+4. Start the Wave CLI in that worktree.
+
+### Start a Worktree Session with an Auto-generated Name
+To quickly start a session without thinking of a name:
+```bash
+wave code -w
+```
+This will generate a unique name (e.g., `gentle-swift-breeze`) and create the worktree at `.wave/worktrees/gentle-swift-breeze`.
+
+## Exiting a Worktree Session
+
+When you exit the Wave CLI (e.g., by pressing `Ctrl+C`), the system will check for any uncommitted changes or new commits in the worktree.
+
+### If No Changes are Detected
+The CLI will exit immediately, leaving the worktree and branch intact.
+
+### If Changes are Detected
+You will see an interactive prompt:
+
+```text
+Exiting worktree session
+ You have 1 uncommitted file. These will be lost if you remove the worktree.
+
+ ❯ Keep worktree    Stays at /home/user/project/.wave/worktrees/gentle-swift-breeze
+   Remove worktree  All changes and commits will be lost.
+
+ Enter to confirm · Esc to cancel
+```
+
+- **Keep worktree**: The CLI exits, but the worktree directory and its associated branch are preserved. You can return to it later.
+- **Remove worktree**: The git worktree and the associated branch are deleted. **All uncommitted changes and new commits will be lost.**
+
+### Resuming a Worktree Session
+To resume a session in an existing worktree, simply run the command again with the same name:
+```bash
+wave code --worktree my-feature
+```
+If the worktree already exists, Wave will use it.

--- a/specs/068-cli-worktree-support/research.md
+++ b/specs/068-cli-worktree-support/research.md
@@ -1,0 +1,31 @@
+# Research: CLI Worktree Support
+
+## Decision: CLI Argument Parsing
+- **Choice**: Use `yargs` in `packages/code/src/index.ts`.
+- **Rationale**: `yargs` is already used for parsing CLI arguments in the `code` package. Adding `-w` and `--worktree` as optional arguments is straightforward.
+- **Alternatives**: Manual parsing of `process.argv`, but `yargs` provides better structure and help generation.
+
+## Decision: Worktree Management
+- **Choice**: Use `child_process.execSync` to run `git worktree` commands.
+- **Rationale**: `git worktree` is a robust built-in git feature. Executing it via shell is simple and reliable since `git` is a required dependency.
+- **Alternatives**: Using a Node.js git library like `isomorphic-git`, but it might not support all worktree features and adds unnecessary weight.
+
+## Decision: Working Directory Management
+- **Choice**: Change `process.cwd()` before initializing the React Ink application.
+- **Rationale**: This ensures that the entire application, including the agent and all file-based tools, operates within the worktree directory without needing to modify every file path.
+- **Alternatives**: Passing the worktree path as a variable throughout the app, but this would require extensive refactoring.
+
+## Decision: Exit Handling and Interactive Prompt
+- **Choice**: Implement a custom exit state in the main React component (`App.tsx`) and a new `WorktreeExitPrompt` component.
+- **Rationale**: React Ink is used for the CLI UI. Handling the exit logic within the React tree allows for a consistent interactive experience using Ink's `useInput` hook.
+- **Alternatives**: Using `process.on('exit')` with a synchronous prompt, but this would break the React Ink UI and is less user-friendly.
+
+## Decision: Git Status Detection
+- **Choice**: Use `git status --porcelain` for uncommitted changes and `git log @{u}..HEAD` for new commits.
+- **Rationale**: These commands provide machine-readable and reliable information about the state of the repository.
+- **Alternatives**: Parsing the output of `git status` (non-porcelain), but it's more complex and prone to changes in git versions.
+
+## Decision: Auto-generated Name
+- **Choice**: Use `generateRandomName` from `packages/agent-sdk/src/utils/nameGenerator.ts`.
+- **Rationale**: This utility is already used for generating plan file names. Reusing it ensures consistency across the Wave CLI and avoids duplicating logic. The utility has been updated to generate names in a three-word `adjective-adjective-noun` format (e.g., `gentle-swift-breeze`) to provide more uniqueness and match the user's preference.
+- **Alternatives**: Implementing a new naming scheme or using a third-party library like `unique-names-generator`, but the existing utility is sufficient and already integrated.

--- a/specs/068-cli-worktree-support/spec.md
+++ b/specs/068-cli-worktree-support/spec.md
@@ -1,0 +1,139 @@
+# Feature Specification: CLI Worktree Support
+
+**Feature Branch**: `068-cli-worktree-support`  
+**Created**: 2026-02-27  
+**Status**: Draft  
+**Input**: User description: "wave code cli support -w or --worktree <feat-name> to create worktree at .wave/worktrees/<feat-name>. if no <feat-name>, system should generate one, just like plan file name do. when exit wave code cli, it should popup this: Exiting worktree session
+ You have 1 uncommitted file. These will be lost if you remove the worktree.
+
+ ❯ Keep worktree    Stays at /home/liuyiqi/code/bin/.claude/worktrees/merry-crafting-sutherland
+   Remove worktree  All changes and commits will be lost.
+
+ Enter to confirm · Esc to cancel
+
+Exiting worktree session
+ You have 1 commit on worktree-merry-crafting-sutherland. The branch will be deleted if you remove the worktree.
+
+ ❯ Keep worktree    Stays at /home/liuyiqi/code/bin/.claude/worktrees/merry-crafting-sutherland
+   Remove worktree  All changes and commits will be lost.
+
+ Enter to confirm · Esc to cancel. if no commit or uncommit, exit without confirm."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Create Worktree with Name (Priority: P1)
+
+As a developer, I want to start a Wave session in a dedicated git worktree with a specific name so that I can work on a feature without affecting my main working directory.
+
+**Why this priority**: This is the core functionality of the feature.
+
+**Independent Test**: Run `wave code -w my-feature`, verify that a worktree is created at `.wave/worktrees/my-feature` and the CLI starts in that directory.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am in a git repository, **When** I run `wave code --worktree my-feat`, **Then** a new git worktree is created at `.wave/worktrees/my-feat`.
+2. **Given** a worktree is created, **When** the Wave CLI starts, **Then** its working directory is set to the new worktree path.
+
+---
+
+### User Story 2 - Auto-generated Worktree Name (Priority: P1)
+
+As a developer, I want to quickly start a worktree session without thinking of a name, so that I can start working immediately.
+
+**Why this priority**: Essential for ease of use and matches the requested behavior.
+
+**Independent Test**: Run `wave code -w`, verify a worktree is created with a generated name (e.g., `gentle-swift-breeze`) at `.wave/worktrees/<generated-name>`.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am in a git repository, **When** I run `wave code -w`, **Then** the system generates a name like `merry-crafting-sutherland`.
+2. **Given** a name is generated, **When** the worktree is created, **Then** it uses the generated name.
+
+---
+
+### User Story 3 - Exit with Uncommitted Changes (Priority: P1)
+
+As a developer, I want to be warned if I have uncommitted changes when exiting a worktree session, so that I don't accidentally lose my work.
+
+**Why this priority**: Prevents data loss, which is critical for user trust.
+
+**Independent Test**: Start a worktree session, create a new file, exit the CLI, and verify the "Exiting worktree session" prompt appears with the "uncommitted file" message.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am in a worktree session with 1 uncommitted file, **When** I exit the CLI, **Then** I see a prompt: "You have 1 uncommitted file. These will be lost if you remove the worktree."
+2. **Given** the exit prompt is shown, **When** I select "Keep worktree", **Then** the worktree remains at its location and the CLI exits.
+3. **Given** the exit prompt is shown, **When** I select "Remove worktree", **Then** the worktree is deleted and the CLI exits.
+
+---
+
+### User Story 4 - Exit with New Commits (Priority: P2)
+
+As a developer, I want to be warned if I have new commits when exiting a worktree session, so that I know the branch will be deleted if I remove the worktree.
+
+**Why this priority**: Important for managing git history and branches.
+
+**Independent Test**: Start a worktree session, make a commit, exit the CLI, and verify the prompt mentions the commit and branch deletion.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am in a worktree session with 1 new commit, **When** I exit the CLI, **Then** I see a prompt: "You have 1 commit on worktree-<name>. The branch will be deleted if you remove the worktree."
+2. **Given** the exit prompt is shown, **When** I select "Remove worktree", **Then** the worktree and its associated branch are deleted.
+
+---
+
+### User Story 5 - Clean Exit (Priority: P2)
+
+As a developer, I want the CLI to exit immediately if I haven't made any changes in the worktree, so that I don't have to deal with unnecessary prompts.
+
+**Why this priority**: Improves user experience by removing friction for "read-only" or "no-change" sessions.
+
+**Independent Test**: Start a worktree session, make no changes, exit the CLI, and verify it exits without any prompt.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am in a worktree session with no uncommitted changes and no new commits, **When** I exit the CLI, **Then** it exits immediately without a prompt.
+
+---
+
+### Edge Cases
+
+- **What happens when the worktree directory already exists?** The system should probably error out or ask to reuse it.
+- **How does system handle git errors during worktree creation?** It should display a clear error message and exit gracefully.
+- **What if the user is not in a git repository?** The `-w` flag should fail with an error message.
+
+## Assumptions
+
+- The system has `git` installed and accessible in the environment's PATH.
+- The current working directory is a git repository when `-w` is used.
+- The auto-generated name follows the `adjective-adjective-noun` pattern from the `generateRandomName` utility.
+- "Remove worktree" implies both `git worktree remove --force` and `git branch -D` to ensure cleanup even if changes exist or the branch isn't merged.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST support `-w` and `--worktree [feat-name]` command-line arguments.
+- **FR-002**: System MUST generate a unique feature name (e.g., `adjective-adjective-noun`) if `<feat-name>` is not provided.
+- **FR-003**: System MUST create a git worktree at `.wave/worktrees/<feat-name>` (absolute path) branching from the default remote branch (identified via `git symbolic-ref refs/remotes/origin/HEAD`).
+- **FR-004**: System MUST name the worktree branch `worktree-<feat-name>`.
+- **FR-005**: System MUST change the process working directory to the worktree path using `process.chdir()` before starting the main CLI loop to ensure global consistency.
+- **FR-006**: System MUST detect uncommitted changes (staged or unstaged, identified via `git status --porcelain`) in the worktree upon exit.
+- **FR-007**: System MUST detect commits made in the worktree that are not in the default remote branch (identified via `git log @{u}..HEAD`) upon exit.
+- **FR-008**: System MUST display an interactive prompt if uncommitted changes or new commits exist upon exit.
+- **FR-009**: The exit prompt MUST offer two options: "Keep worktree" and "Remove worktree".
+- **FR-010**: "Keep worktree" MUST exit the CLI while leaving the worktree directory intact.
+- **FR-011**: "Remove worktree" MUST delete the git worktree (using `git worktree remove --force`) and the worktree branch (using `git branch -D`).
+- **FR-012**: System MUST exit without a prompt if no changes or commits are detected.
+- **FR-013**: System MUST error and exit if `-w` or `--worktree` is used outside of a git repository.
+- **FR-014**: System MUST handle `SIGINT` (Ctrl+C) and `SIGTERM` signals by triggering the exit detection and prompt flow.
+- **FR-015**: If the user cancels the exit prompt (e.g., via Esc), the CLI MUST return to the active session.
+- **FR-016**: If a worktree with the same name already exists, the system MUST reuse it and skip the creation step.
+- **FR-017**: Exit detection MUST complete within 500ms to avoid noticeable lag for the user.
+
+### Key Entities
+
+- **Worktree**: Represents a git worktree session.
+    - **Name**: The identifier for the worktree and branch.
+    - **Path**: The filesystem path where the worktree is located (`.wave/worktrees/<name>`).
+    - **Status**: Whether it has uncommitted changes or new commits.

--- a/specs/068-cli-worktree-support/tasks.md
+++ b/specs/068-cli-worktree-support/tasks.md
@@ -1,0 +1,73 @@
+# Tasks: CLI Worktree Support
+
+**Feature**: CLI Worktree Support
+**Branch**: `068-cli-worktree-support`
+**Implementation Plan**: `specs/068-cli-worktree-support/plan.md`
+
+## Phase 1: Setup
+
+- [x] T001 Create worktree utility file in `packages/code/src/utils/worktree.ts`
+- [x] T002 [P] Create git utility file in `packages/agent-sdk/src/utils/git.ts` if needed for shared git logic
+- [x] T003 [P] Define `WorktreeSession` type in `packages/code/src/types.ts` or `packages/code/src/utils/worktree.ts`
+
+## Phase 2: Foundational
+
+- [x] T004 Implement git helper functions (get default branch, check status, check commits) in `packages/agent-sdk/src/utils/git.ts`
+- [x] T005 Implement worktree management logic (create, remove, list) in `packages/code/src/utils/worktree.ts`
+- [x] T006 [P] Add unit tests for git helper functions in `packages/agent-sdk/tests/utils/git.test.ts`
+- [x] T007 [P] Add unit tests for worktree management logic in `packages/code/tests/utils/worktree.test.ts`
+
+## Phase 3: User Story 1 & 2 - Worktree Creation (Priority: P1)
+
+**Goal**: Support `-w/--worktree` flag to create and enter a git worktree.
+
+**Independent Test**: Run `wave code -w my-feat` and verify worktree creation and directory change.
+
+- [x] T008 [US1] Update CLI argument parsing in `packages/code/src/index.ts` to support `-w` and `--worktree`
+- [x] T009 [US2] Integrate `generateRandomName` in `packages/code/src/index.ts` for auto-generated worktree names
+- [x] T010 [US1] Implement worktree initialization flow in `packages/code/src/index.ts` (create worktree, change `process.cwd()`)
+
+## Phase 4: User Story 3, 4 & 5 - Exit Handling (Priority: P1/P2)
+
+**Goal**: Detect changes on exit and show interactive prompt if necessary.
+
+**Independent Test**: Start worktree session, make changes, exit, and verify prompt behavior.
+
+- [x] T012 [US3] Implement `WorktreeExitPrompt` component in `packages/code/src/components/WorktreeExitPrompt.tsx`
+- [x] T013 [US3] Update `packages/code/src/App.tsx` to manage exit state and show `WorktreeExitPrompt`
+- [x] T014 [US3] Implement logic to detect uncommitted changes and new commits before exit in `packages/code/src/App.tsx`
+- [x] T015 [US3] Implement "Keep worktree" and "Remove worktree" actions in `WorktreeExitPrompt.tsx`
+- [x] T016 [US5] Ensure immediate exit if no changes or commits are detected in `packages/code/src/App.tsx`
+- [x] T017 [P] [US3] Add tests for `WorktreeExitPrompt` component in `packages/code/tests/components/WorktreeExitPrompt.test.tsx`
+
+## Phase 5: Polish & Cross-cutting Concerns
+
+- [x] T018 Handle edge case: worktree directory already exists in `packages/code/src/utils/worktree.ts`
+- [x] T019 Improve error handling for git commands in `packages/code/src/utils/worktree.ts`
+- [x] T020 Run full integration tests for the worktree flow
+- [x] T021 [P] Run `pnpm run type-check`, `pnpm run lint`, and `pnpm test:coverage`
+
+## Dependency Graph
+
+```mermaid
+graph TD
+    Phase1[Phase 1: Setup] --> Phase2[Phase 2: Foundational]
+    Phase2 --> Phase3[Phase 3: Worktree Creation US1, US2]
+    Phase3 --> Phase4[Phase 4: Exit Handling US3, US4, US5]
+    Phase4 --> Phase5[Phase 5: Polish]
+```
+
+## Parallel Execution Examples
+
+### User Story 1 & 2 (Phase 3)
+- T008 (CLI args) and T009 (Auto-naming) can be done in parallel.
+
+### Exit Handling (Phase 4)
+- T012 (UI component) and T014 (Detection logic) can be developed in parallel.
+- T017 (UI tests) can be done in parallel with T015 (Action implementation).
+
+## Implementation Strategy
+
+1. **MVP**: Focus on US1 and US2 first to enable worktree creation.
+2. **Incremental Delivery**: Add exit detection and prompt (US3, US4, US5) after creation is stable.
+3. **Safety First**: Ensure "Remove worktree" is robust to avoid accidental data loss or git state corruption.


### PR DESCRIPTION
This PR implements git worktree support for the wave code CLI. Key features include:
- Support for -w/--worktree flag to start sessions in isolated git worktrees.
- Automatic 3-word name generation for worktrees.
- Interactive Ink-based exit prompt to keep or remove worktrees with changes.
- Automatic cleanup of clean worktrees.
- Enhanced git utilities for change detection.