### PR TITLE
chore: add .wave/worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Thumbs.db
 .idea/
 nohup.out
 .wave/settings.local.json
+.wave/worktrees/


### PR DESCRIPTION
Add .wave/worktrees/ to .gitignore.