### PR TITLE
feat: auto-delete worktree and branch on clean exit

### DIFF
--- a/packages/code/src/components/App.tsx
+++ b/packages/code/src/components/App.tsx
@@ -70,6 +70,7 @@ const AppWithProviders: React.FC<{
     return (
       <WorktreeExitPrompt
         name={worktreeSession.name}
+        path={worktreeSession.path}
         hasUncommittedChanges={worktreeStatus.hasUncommittedChanges}
         hasNewCommits={worktreeStatus.hasNewCommits}
         onKeep={() => onExit()}

--- a/packages/code/src/components/WorktreeExitPrompt.tsx
+++ b/packages/code/src/components/WorktreeExitPrompt.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
-import { Box, Text, useInput } from 'ink';
+import React, { useState } from "react";
+import { Box, Text, useInput } from "ink";
 
 interface WorktreeExitPromptProps {
   name: string;
+  path: string;
   hasUncommittedChanges: boolean;
   hasNewCommits: boolean;
   onKeep: () => void;
@@ -12,6 +13,7 @@ interface WorktreeExitPromptProps {
 
 export const WorktreeExitPrompt: React.FC<WorktreeExitPromptProps> = ({
   name,
+  path: worktreePath,
   hasUncommittedChanges,
   hasNewCommits,
   onKeep,
@@ -40,37 +42,44 @@ export const WorktreeExitPrompt: React.FC<WorktreeExitPromptProps> = ({
   });
 
   return (
-    <Box flexDirection="column" borderStyle="single" borderTop borderBottom borderLeft={false} borderRight={false} paddingX={1} marginY={1}>
+    <Box flexDirection="column" paddingX={1} marginY={1}>
       <Box marginBottom={1}>
-        <Text bold color="yellow">
-          ⚠️ Worktree '{name}' has changes:
-        </Text>
+        <Text bold>Exiting worktree session</Text>
       </Box>
-      {hasUncommittedChanges && (
-        <Box marginLeft={2}>
-          <Text>- Uncommitted changes detected</Text>
-        </Box>
-      )}
-      {hasNewCommits && (
-        <Box marginLeft={2}>
-          <Text>- New commits detected</Text>
-        </Box>
-      )}
-      <Box marginTop={1} flexDirection="column">
-        <Text>What would you like to do?</Text>
-        <Box marginTop={1}>
-          <Text color={selectedIndex === 0 ? 'cyan' : undefined}>
-            {selectedIndex === 0 ? '> ' : '  '}Keep worktree (exit CLI, leave worktree and branch intact)
+      <Box marginBottom={1}>
+        {hasUncommittedChanges && hasNewCommits ? (
+          <Text>
+            You have uncommitted changes and new commits. These will be lost if
+            you remove the worktree.
+          </Text>
+        ) : hasUncommittedChanges ? (
+          <Text>
+            You have uncommitted changes. These will be lost if you remove the
+            worktree.
+          </Text>
+        ) : (
+          <Text>
+            You have new commits on worktree-{name}. The branch will be deleted
+            if you remove the worktree.
+          </Text>
+        )}
+      </Box>
+      <Box flexDirection="column">
+        <Box>
+          <Text color={selectedIndex === 0 ? "cyan" : undefined}>
+            {selectedIndex === 0 ? "❯ " : "  "}Keep worktree Stays at{" "}
+            {worktreePath}
           </Text>
         </Box>
         <Box>
-          <Text color={selectedIndex === 1 ? 'cyan' : undefined}>
-            {selectedIndex === 1 ? '> ' : '  '}Remove worktree (delete worktree and branch - DATA LOSS!)
+          <Text color={selectedIndex === 1 ? "cyan" : undefined}>
+            {selectedIndex === 1 ? "❯ " : "  "}Remove worktree All changes and
+            commits will be lost.
           </Text>
         </Box>
       </Box>
       <Box marginTop={1}>
-        <Text dimColor>(Use arrow keys to select, Enter to confirm, Esc to resume session)</Text>
+        <Text dimColor>Enter to confirm · Esc to cancel</Text>
       </Box>
     </Box>
   );

--- a/packages/code/src/utils/worktree.ts
+++ b/packages/code/src/utils/worktree.ts
@@ -1,7 +1,7 @@
-import { execSync } from 'node:child_process';
-import * as path from 'node:path';
-import * as fs from 'node:fs';
-import { getGitRepoRoot, getDefaultRemoteBranch } from 'wave-agent-sdk';
+import { execSync } from "node:child_process";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { getGitRepoRoot, getDefaultRemoteBranch } from "wave-agent-sdk";
 
 export interface WorktreeSession {
   name: string;
@@ -11,7 +11,7 @@ export interface WorktreeSession {
   hasNewCommits: boolean;
 }
 
-export const WORKTREE_DIR = '.wave/worktrees';
+export const WORKTREE_DIR = ".wave/worktrees";
 
 /**
  * Create a new git worktree
@@ -45,10 +45,13 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
 
   try {
     // Create worktree and branch
-    execSync(`git worktree add -b ${branchName} "${worktreePath}" ${baseBranch}`, {
-      cwd: repoRoot,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
+    execSync(
+      `git worktree add -b ${branchName} "${worktreePath}" ${baseBranch}`,
+      {
+        cwd: repoRoot,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
 
     return {
       name,
@@ -58,13 +61,13 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
       hasNewCommits: false,
     };
   } catch (error: unknown) {
-    const stderr = (error as { stderr?: Buffer }).stderr?.toString() || '';
-    if (stderr.includes('already exists')) {
+    const stderr = (error as { stderr?: Buffer }).stderr?.toString() || "";
+    if (stderr.includes("already exists")) {
       // If branch already exists, try to add worktree without -b
       try {
         execSync(`git worktree add "${worktreePath}" ${branchName}`, {
           cwd: repoRoot,
-          stdio: ['ignore', 'pipe', 'pipe'],
+          stdio: ["ignore", "pipe", "pipe"],
         });
         return {
           name,
@@ -74,10 +77,14 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
           hasNewCommits: false,
         };
       } catch (innerError: unknown) {
-        throw new Error(`Failed to add existing worktree branch: ${(innerError as Error).message}`);
+        throw new Error(
+          `Failed to add existing worktree branch: ${(innerError as Error).message}`,
+        );
       }
     }
-    throw new Error(`Failed to create worktree: ${(error as Error).message}\n${stderr}`);
+    throw new Error(
+      `Failed to create worktree: ${(error as Error).message}\n${stderr}`,
+    );
   }
 }
 
@@ -90,18 +97,25 @@ export function removeWorktree(session: WorktreeSession, cwd: string): void {
   const repoRoot = getGitRepoRoot(cwd);
 
   try {
+    // Change directory to repo root before removing worktree to avoid "directory in use" errors
+    if (process.cwd().startsWith(session.path)) {
+      process.chdir(repoRoot);
+    }
+
     // Remove worktree
     execSync(`git worktree remove --force "${session.path}"`, {
       cwd: repoRoot,
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: ["ignore", "pipe", "pipe"],
     });
 
     // Delete branch
     execSync(`git branch -D ${session.branch}`, {
       cwd: repoRoot,
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: ["ignore", "pipe", "pipe"],
     });
   } catch (error: unknown) {
-    console.error(`Failed to remove worktree or branch: ${(error as Error).message}`);
+    console.error(
+      `Failed to remove worktree or branch: ${(error as Error).message}`,
+    );
   }
 }

--- a/packages/code/tests/components/App.test.tsx
+++ b/packages/code/tests/components/App.test.tsx
@@ -1,10 +1,52 @@
 import React from "react";
 import { render } from "ink-testing-library";
-import { describe, it, expect, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type MockInstance,
+} from "vitest";
 import { App } from "../../src/components/App.js";
-import { stripAnsiColors } from "wave-agent-sdk";
+import {
+  stripAnsiColors,
+  hasUncommittedChanges,
+  hasNewCommits,
+  getDefaultRemoteBranch,
+} from "wave-agent-sdk";
+import { removeWorktree } from "../../src/utils/worktree.js";
+
+vi.mock("wave-agent-sdk", async () => {
+  const actual = await vi.importActual("wave-agent-sdk");
+  return {
+    ...actual,
+    hasUncommittedChanges: vi.fn(),
+    hasNewCommits: vi.fn(),
+    getDefaultRemoteBranch: vi.fn(),
+  };
+});
+
+vi.mock("../../src/utils/worktree.js", () => ({
+  removeWorktree: vi.fn(),
+}));
 
 describe("App Component", () => {
+  let processOnSpy: MockInstance<typeof process.on>;
+  let processOffSpy: MockInstance<typeof process.off>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    processOnSpy = vi.spyOn(process, "on").mockImplementation(() => process);
+    processOffSpy = vi.spyOn(process, "off").mockImplementation(() => process);
+  });
+
+  afterEach(() => {
+    processOnSpy.mockRestore();
+    processOffSpy.mockRestore();
+  });
+
   it("should render the main interface with file count", async () => {
     const { lastFrame } = render(<App onExit={vi.fn()} />);
 
@@ -16,29 +58,69 @@ describe("App Component", () => {
     });
   });
 
-  it("should render the chat interface", async () => {
-    const { lastFrame } = render(<App onExit={vi.fn()} />);
+  it("should handle SIGINT and exit directly if no changes in worktree", async () => {
+    const onExit = vi.fn();
+    const worktreeSession = {
+      name: "test-feat",
+      path: "/repo/test-feat",
+      branch: "worktree-test-feat",
+      hasUncommittedChanges: false,
+      hasNewCommits: false,
+    };
 
-    // Wait for components to initialize and render
-    await vi.waitFor(() => {
-      expect(stripAnsiColors(lastFrame() || "")).toContain("Type your message");
-    });
+    vi.mocked(hasUncommittedChanges).mockReturnValue(false);
+    vi.mocked(hasNewCommits).mockReturnValue(false);
+    vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
 
-    // ChatInterface renders MessageList and InputBox, test overall rendering here
-    expect(lastFrame()).toBeTruthy();
-    // Can test whether it contains UI elements like input box borders
-    expect(lastFrame()).toMatch(/[┌┐└┘│─]/); // Check if there are border characters
+    render(<App onExit={onExit} worktreeSession={worktreeSession} />);
+
+    // Simulate SIGINT
+    const handleSignal = processOnSpy.mock.calls.find(
+      (call) => call[0] === "SIGINT",
+    )![1] as () => Promise<void>;
+    await handleSignal();
+
+    expect(removeWorktree).toHaveBeenCalledWith(
+      worktreeSession,
+      expect.any(String),
+    );
+    expect(onExit).toHaveBeenCalled();
   });
 
-  it("should wrap components with providers", async () => {
-    const { lastFrame } = render(<App onExit={vi.fn()} />);
+  it("should show exit prompt on SIGINT if there are changes in worktree", async () => {
+    const onExit = vi.fn();
+    const worktreeSession = {
+      name: "test-feat",
+      path: "/repo/test-feat",
+      branch: "worktree-test-feat",
+      hasUncommittedChanges: false,
+      hasNewCommits: false,
+    };
 
-    // Wait for the component to initialize and render
+    vi.mocked(hasUncommittedChanges).mockReturnValue(true);
+    vi.mocked(hasNewCommits).mockReturnValue(false);
+    vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
+
+    const { lastFrame } = render(
+      <App onExit={onExit} worktreeSession={worktreeSession} />,
+    );
+
+    // Simulate SIGINT
+    const handleSignal = processOnSpy.mock.calls.find(
+      (call) => call[0] === "SIGINT",
+    )![1] as () => Promise<void>;
+    await handleSignal();
+
     await vi.waitFor(() => {
-      expect(stripAnsiColors(lastFrame() || "")).toContain("Type your message");
+      expect(stripAnsiColors(lastFrame() || "")).toContain(
+        "Exiting worktree session",
+      );
+      expect(stripAnsiColors(lastFrame() || "")).toContain(
+        "You have uncommitted changes",
+      );
     });
 
-    // Verify that the component renders without errors
-    expect(lastFrame()).toBeTruthy();
+    expect(removeWorktree).not.toHaveBeenCalled();
+    expect(onExit).not.toHaveBeenCalled();
   });
 });

--- a/packages/code/tests/components/WorktreeExitPrompt.test.tsx
+++ b/packages/code/tests/components/WorktreeExitPrompt.test.tsx
@@ -1,93 +1,101 @@
-import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
-import { render } from 'ink-testing-library';
-import { WorktreeExitPrompt } from '../../src/components/WorktreeExitPrompt.js';
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { WorktreeExitPrompt } from "../../src/components/WorktreeExitPrompt.js";
 
-describe('WorktreeExitPrompt', () => {
-  it('should render the prompt with worktree name', () => {
+describe("WorktreeExitPrompt", () => {
+  it("should render the prompt with worktree name", () => {
     const { lastFrame } = render(
       <WorktreeExitPrompt
         name="gentle-swift-breeze"
+        path="/repo/root/.wave/worktrees/gentle-swift-breeze"
         hasUncommittedChanges={true}
         hasNewCommits={false}
         onKeep={vi.fn()}
         onRemove={vi.fn()}
         onCancel={vi.fn()}
-      />
+      />,
     );
 
-    expect(lastFrame()).toContain("Worktree 'gentle-swift-breeze' has changes");
-    expect(lastFrame()).toContain("Uncommitted changes detected");
+    expect(lastFrame()).toContain("Exiting worktree session");
+    expect(lastFrame()).toContain("You have uncommitted changes");
     expect(lastFrame()).toContain("Keep worktree");
     expect(lastFrame()).toContain("Remove worktree");
+    expect(lastFrame()).toContain(
+      "/repo/root/.wave/worktrees/gentle-swift-breeze",
+    );
   });
 
-  it('should show both changes and commits if present', () => {
+  it("should show both changes and commits if present", () => {
     const { lastFrame } = render(
       <WorktreeExitPrompt
         name="gentle-swift-breeze"
+        path="/repo/root/.wave/worktrees/gentle-swift-breeze"
         hasUncommittedChanges={true}
         hasNewCommits={true}
         onKeep={vi.fn()}
         onRemove={vi.fn()}
         onCancel={vi.fn()}
-      />
+      />,
     );
 
-    expect(lastFrame()).toContain("Uncommitted changes detected");
-    expect(lastFrame()).toContain("New commits detected");
+    expect(lastFrame()).toContain(
+      "You have uncommitted changes and new commits",
+    );
   });
 
-  it('should handle arrow keys and enter to select options', async () => {
+  it("should handle arrow keys and enter to select options", async () => {
     const onKeep = vi.fn();
     const onRemove = vi.fn();
     const { stdin, lastFrame } = render(
       <WorktreeExitPrompt
         name="gentle-swift-breeze"
+        path="/repo/root/.wave/worktrees/gentle-swift-breeze"
         hasUncommittedChanges={true}
         hasNewCommits={false}
         onKeep={onKeep}
         onRemove={onRemove}
         onCancel={vi.fn()}
-      />
+      />,
     );
 
     // Default is Keep
-    expect(lastFrame()).toContain("> Keep worktree");
-    
+    expect(lastFrame()).toContain("❯ Keep worktree");
+
     // Press down to select Remove
-    stdin.write('\u001b[B'); // Down arrow
-    await vi.waitFor(() => expect(lastFrame()).toContain("> Remove worktree"));
+    stdin.write("\u001b[B"); // Down arrow
+    await vi.waitFor(() => expect(lastFrame()).toContain("❯ Remove worktree"));
 
     // Press up to select Keep again
-    stdin.write('\u001b[A'); // Up arrow
-    await vi.waitFor(() => expect(lastFrame()).toContain("> Keep worktree"));
+    stdin.write("\u001b[A"); // Up arrow
+    await vi.waitFor(() => expect(lastFrame()).toContain("❯ Keep worktree"));
 
     // Press enter to confirm Keep
-    stdin.write('\r');
+    stdin.write("\r");
     await vi.waitFor(() => expect(onKeep).toHaveBeenCalled());
 
     // Select Remove and confirm
-    stdin.write('\u001b[B'); // Down arrow
-    await vi.waitFor(() => expect(lastFrame()).toContain("> Remove worktree"));
-    stdin.write('\r');
+    stdin.write("\u001b[B"); // Down arrow
+    await vi.waitFor(() => expect(lastFrame()).toContain("❯ Remove worktree"));
+    stdin.write("\r");
     await vi.waitFor(() => expect(onRemove).toHaveBeenCalled());
   });
 
-  it('should handle escape to cancel', async () => {
+  it("should handle escape to cancel", async () => {
     const onCancel = vi.fn();
     const { stdin } = render(
       <WorktreeExitPrompt
         name="gentle-swift-breeze"
+        path="/repo/root/.wave/worktrees/gentle-swift-breeze"
         hasUncommittedChanges={true}
         hasNewCommits={false}
         onKeep={vi.fn()}
         onRemove={vi.fn()}
         onCancel={onCancel}
-      />
+      />,
     );
 
-    stdin.write('\u001b'); // Escape
+    stdin.write("\u001b"); // Escape
     await vi.waitFor(() => expect(onCancel).toHaveBeenCalled());
   });
 });

--- a/packages/code/tests/utils/worktree.test.ts
+++ b/packages/code/tests/utils/worktree.test.ts
@@ -1,143 +1,168 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { execSync } from 'node:child_process';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import { createWorktree, removeWorktree } from '../../src/utils/worktree.js';
-import { getGitRepoRoot, getDefaultRemoteBranch } from 'wave-agent-sdk';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createWorktree, removeWorktree } from "../../src/utils/worktree.js";
+import { getGitRepoRoot, getDefaultRemoteBranch } from "wave-agent-sdk";
 
-vi.mock('node:child_process', () => ({
+vi.mock("node:child_process", () => ({
   execSync: vi.fn(),
 }));
 
-vi.mock('node:fs', () => ({
+vi.mock("node:fs", () => ({
   existsSync: vi.fn(),
   mkdirSync: vi.fn(),
 }));
 
-vi.mock('wave-agent-sdk', () => ({
+vi.mock("wave-agent-sdk", () => ({
   getGitRepoRoot: vi.fn(),
   getDefaultRemoteBranch: vi.fn(),
 }));
 
-describe('worktree utils', () => {
+describe("worktree utils", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  describe('createWorktree', () => {
-    it('should create a new worktree', () => {
-      vi.mocked(getGitRepoRoot).mockReturnValue('/repo/root');
-      vi.mocked(getDefaultRemoteBranch).mockReturnValue('origin/main');
+  describe("createWorktree", () => {
+    it("should create a new worktree", () => {
+      vi.mocked(getGitRepoRoot).mockReturnValue("/repo/root");
+      vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
-      const session = createWorktree('my-feat', '/repo/root');
+      const session = createWorktree("my-feat", "/repo/root");
 
-      expect(session.name).toBe('my-feat');
-      expect(session.path).toBe(path.join('/repo/root', '.wave/worktrees/my-feat'));
-      expect(session.branch).toBe('worktree-my-feat');
+      expect(session.name).toBe("my-feat");
+      expect(session.path).toBe(
+        path.join("/repo/root", ".wave/worktrees/my-feat"),
+      );
+      expect(session.branch).toBe("worktree-my-feat");
       expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining('git worktree add -b worktree-my-feat'),
-        expect.any(Object)
+        expect.stringContaining("git worktree add -b worktree-my-feat"),
+        expect.any(Object),
       );
     });
 
-    it('should handle branch already exists error by adding worktree without -b', () => {
-      vi.mocked(getGitRepoRoot).mockReturnValue('/repo/root');
-      vi.mocked(getDefaultRemoteBranch).mockReturnValue('origin/main');
+    it("should handle branch already exists error by adding worktree without -b", () => {
+      vi.mocked(getGitRepoRoot).mockReturnValue("/repo/root");
+      vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
       // First call fails with "already exists"
-      const error = new Error('Command failed');
-      (error as { stderr?: Buffer }).stderr = Buffer.from('fatal: a branch named \'worktree-my-feat\' already exists');
+      const error = new Error("Command failed");
+      (error as { stderr?: Buffer }).stderr = Buffer.from(
+        "fatal: a branch named 'worktree-my-feat' already exists",
+      );
       vi.mocked(execSync).mockImplementationOnce(() => {
         throw error;
       });
 
       // Second call succeeds
-      vi.mocked(execSync).mockImplementationOnce(() => Buffer.from(''));
+      vi.mocked(execSync).mockImplementationOnce(() => Buffer.from(""));
 
-      const session = createWorktree('my-feat', '/repo/root');
+      const session = createWorktree("my-feat", "/repo/root");
 
-      expect(session.name).toBe('my-feat');
+      expect(session.name).toBe("my-feat");
       expect(execSync).toHaveBeenCalledTimes(2);
       expect(execSync).toHaveBeenCalledWith(
         expect.stringMatching(/git worktree add "[^"]+" worktree-my-feat/),
-        expect.any(Object)
+        expect.any(Object),
       );
     });
 
-    it('should throw error if worktree creation fails with other error', () => {
-      vi.mocked(getGitRepoRoot).mockReturnValue('/repo/root');
+    it("should throw error if worktree creation fails with other error", () => {
+      vi.mocked(getGitRepoRoot).mockReturnValue("/repo/root");
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
-      const error = new Error('Some other error');
+      const error = new Error("Some other error");
       vi.mocked(execSync).mockImplementationOnce(() => {
         throw error;
       });
 
-      expect(() => createWorktree('my-feat', '/repo/root')).toThrow('Failed to create worktree');
+      expect(() => createWorktree("my-feat", "/repo/root")).toThrow(
+        "Failed to create worktree",
+      );
     });
 
-    it('should throw error if adding existing branch fails', () => {
-      vi.mocked(getGitRepoRoot).mockReturnValue('/repo/root');
+    it("should throw error if adding existing branch fails", () => {
+      vi.mocked(getGitRepoRoot).mockReturnValue("/repo/root");
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
-      const error = new Error('Command failed');
-      (error as { stderr?: Buffer }).stderr = Buffer.from('fatal: a branch named \'worktree-my-feat\' already exists');
+      const error = new Error("Command failed");
+      (error as { stderr?: Buffer }).stderr = Buffer.from(
+        "fatal: a branch named 'worktree-my-feat' already exists",
+      );
       vi.mocked(execSync).mockImplementationOnce(() => {
         throw error;
       });
 
       vi.mocked(execSync).mockImplementationOnce(() => {
-        throw new Error('Inner error');
+        throw new Error("Inner error");
       });
 
-      expect(() => createWorktree('my-feat', '/repo/root')).toThrow('Failed to add existing worktree branch');
+      expect(() => createWorktree("my-feat", "/repo/root")).toThrow(
+        "Failed to add existing worktree branch",
+      );
     });
   });
 
-  describe('removeWorktree', () => {
-    it('should remove worktree and branch', () => {
-      vi.mocked(getGitRepoRoot).mockReturnValue('/repo/root');
+  describe("removeWorktree", () => {
+    it("should remove worktree and branch", () => {
+      vi.mocked(getGitRepoRoot).mockReturnValue("/repo/root");
+      const chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
+      const cwdSpy = vi
+        .spyOn(process, "cwd")
+        .mockReturnValue("/repo/root/.wave/worktrees/my-feat");
+
       const session = {
-        name: 'my-feat',
-        path: '/repo/root/.wave/worktrees/my-feat',
-        branch: 'worktree-my-feat',
+        name: "my-feat",
+        path: "/repo/root/.wave/worktrees/my-feat",
+        branch: "worktree-my-feat",
         hasUncommittedChanges: false,
         hasNewCommits: false,
       };
 
-      removeWorktree(session, '/repo/root');
+      removeWorktree(session, "/repo/root");
 
+      expect(chdirSpy).toHaveBeenCalledWith("/repo/root");
       expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining('git worktree remove --force'),
-        expect.any(Object)
+        expect.stringContaining("git worktree remove --force"),
+        expect.any(Object),
       );
       expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining('git branch -D worktree-my-feat'),
-        expect.any(Object)
+        expect.stringContaining("git branch -D worktree-my-feat"),
+        expect.any(Object),
       );
+
+      chdirSpy.mockRestore();
+      cwdSpy.mockRestore();
     });
 
-    it('should log error if removal fails', () => {
-      vi.mocked(getGitRepoRoot).mockReturnValue('/repo/root');
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    it("should log error if removal fails", () => {
+      vi.mocked(getGitRepoRoot).mockReturnValue("/repo/root");
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      vi.spyOn(process, "chdir").mockImplementation(() => {});
       vi.mocked(execSync).mockImplementation(() => {
-        throw new Error('Removal failed');
+        throw new Error("Removal failed");
       });
 
       const session = {
-        name: 'my-feat',
-        path: '/repo/root/.wave/worktrees/my-feat',
-        branch: 'worktree-my-feat',
+        name: "my-feat",
+        path: "/repo/root/.wave/worktrees/my-feat",
+        branch: "worktree-my-feat",
         hasUncommittedChanges: false,
         hasNewCommits: false,
       };
 
-      removeWorktree(session, '/repo/root');
+      removeWorktree(session, "/repo/root");
 
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to remove worktree or branch'));
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to remove worktree or branch"),
+      );
       consoleSpy.mockRestore();
+      vi.restoreAllMocks();
     });
   });
 });

--- a/specs/068-cli-worktree-support/data-model.md
+++ b/specs/068-cli-worktree-support/data-model.md
@@ -40,5 +40,6 @@ Represents a git worktree session created by the CLI.
 
 4. **User Decision**:
    - If `hasUncommittedChanges` or `hasNewCommits` is `true`, show prompt.
-   - **Keep worktree**: Exit CLI, leave worktree and branch intact.
-   - **Remove worktree**: Run `git worktree remove --force <path>` and `git branch -D <branch>`, then exit.
+     - **Keep worktree**: Exit CLI, leave worktree and branch intact.
+     - **Remove worktree**: Run `git worktree remove --force <path>` and `git branch -D <branch>`, then exit.
+   - If both are `false`, automatically run `git worktree remove --force <path>` and `git branch -D <branch>`, then exit.

--- a/specs/068-cli-worktree-support/quickstart.md
+++ b/specs/068-cli-worktree-support/quickstart.md
@@ -27,10 +27,10 @@ This will generate a unique name (e.g., `gentle-swift-breeze`) and create the wo
 When you exit the Wave CLI (e.g., by pressing `Ctrl+C`), the system will check for any uncommitted changes or new commits in the worktree.
 
 ### If No Changes are Detected
-The CLI will exit immediately, leaving the worktree and branch intact.
+The CLI will exit immediately, and the git worktree and its associated branch will be deleted automatically. This keeps your environment clean.
 
 ### If Changes are Detected
-You will see an interactive prompt:
+If you have uncommitted changes or new commits, you will see an interactive prompt:
 
 ```text
 Exiting worktree session

--- a/specs/068-cli-worktree-support/spec.md
+++ b/specs/068-cli-worktree-support/spec.md
@@ -84,15 +84,15 @@ As a developer, I want to be warned if I have new commits when exiting a worktre
 
 ### User Story 5 - Clean Exit (Priority: P2)
 
-As a developer, I want the CLI to exit immediately if I haven't made any changes in the worktree, so that I don't have to deal with unnecessary prompts.
+As a developer, I want the CLI to automatically clean up the worktree if I haven't made any changes, so that I don't have to manually delete empty worktrees.
 
-**Why this priority**: Improves user experience by removing friction for "read-only" or "no-change" sessions.
+**Why this priority**: Improves user experience by automating cleanup for "read-only" or "no-change" sessions.
 
-**Independent Test**: Start a worktree session, make no changes, exit the CLI, and verify it exits without any prompt.
+**Independent Test**: Start a worktree session, make no changes, exit the CLI, and verify it exits immediately and the worktree directory and branch are deleted.
 
 **Acceptance Scenarios**:
 
-1. **Given** I am in a worktree session with no uncommitted changes and no new commits, **When** I exit the CLI, **Then** it exits immediately without a prompt.
+1. **Given** I am in a worktree session with no uncommitted changes and no new commits, **When** I exit the CLI, **Then** it exits immediately, and the git worktree and its associated branch are deleted.
 
 ---
 
@@ -124,7 +124,7 @@ As a developer, I want the CLI to exit immediately if I haven't made any changes
 - **FR-009**: The exit prompt MUST offer two options: "Keep worktree" and "Remove worktree".
 - **FR-010**: "Keep worktree" MUST exit the CLI while leaving the worktree directory intact.
 - **FR-011**: "Remove worktree" MUST delete the git worktree (using `git worktree remove --force`) and the worktree branch (using `git branch -D`).
-- **FR-012**: System MUST exit without a prompt if no changes or commits are detected.
+- **FR-012**: System MUST exit without a prompt AND delete the git worktree and branch if no changes or commits are detected.
 - **FR-013**: System MUST error and exit if `-w` or `--worktree` is used outside of a git repository.
 - **FR-014**: System MUST handle `SIGINT` (Ctrl+C) and `SIGTERM` signals by triggering the exit detection and prompt flow.
 - **FR-015**: If the user cancels the exit prompt (e.g., via Esc), the CLI MUST return to the active session.

--- a/specs/068-cli-worktree-support/tasks.md
+++ b/specs/068-cli-worktree-support/tasks.md
@@ -37,7 +37,7 @@
 - [x] T013 [US3] Update `packages/code/src/App.tsx` to manage exit state and show `WorktreeExitPrompt`
 - [x] T014 [US3] Implement logic to detect uncommitted changes and new commits before exit in `packages/code/src/App.tsx`
 - [x] T015 [US3] Implement "Keep worktree" and "Remove worktree" actions in `WorktreeExitPrompt.tsx`
-- [x] T016 [US5] Ensure immediate exit if no changes or commits are detected in `packages/code/src/App.tsx`
+- [x] T016 [US5] Ensure immediate exit AND delete worktree and branch if no changes or commits are detected in `packages/code/src/App.tsx`
 - [x] T017 [P] [US3] Add tests for `WorktreeExitPrompt` component in `packages/code/tests/components/WorktreeExitPrompt.test.tsx`
 
 ## Phase 5: Polish & Cross-cutting Concerns


### PR DESCRIPTION
This PR implements automatic cleanup of git worktrees and branches when exiting a Wave CLI session if no changes or commits were made. It also updates the exit prompt UI to match the specification and improves the robustness of worktree removal by ensuring the process working directory is changed before deletion.