### PR TITLE
fix: remove side effects from state updaters

### DIFF
--- a/packages/code/src/components/ConfirmationSelector.tsx
+++ b/packages/code/src/components/ConfirmationSelector.tsx
@@ -102,57 +102,55 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
       const isMultiSelect = currentQuestion.multiSelect;
 
       if (key.return) {
-        setQuestionState((prev) => {
-          const isOtherFocused =
-            prev.selectedOptionIndex === options.length - 1;
-          let answer = "";
-          if (isMultiSelect) {
-            const selectedLabels = Array.from(prev.selectedOptionIndices)
-              .filter((i) => i < currentQuestion.options.length)
-              .map((i) => currentQuestion.options[i].label);
-            const isOtherChecked = prev.selectedOptionIndices.has(
-              options.length - 1,
-            );
-            if (isOtherChecked && prev.otherText.trim()) {
-              selectedLabels.push(prev.otherText.trim());
-            }
-            answer = selectedLabels.join(", ");
-          } else {
-            if (isOtherFocused) {
-              answer = prev.otherText.trim();
-            } else {
-              answer = options[prev.selectedOptionIndex].label;
-            }
+        const isOtherFocused =
+          questionState.selectedOptionIndex === options.length - 1;
+        let answer = "";
+        if (isMultiSelect) {
+          const selectedLabels = Array.from(questionState.selectedOptionIndices)
+            .filter((i) => i < currentQuestion.options.length)
+            .map((i) => currentQuestion.options[i].label);
+          const isOtherChecked = questionState.selectedOptionIndices.has(
+            options.length - 1,
+          );
+          if (isOtherChecked && questionState.otherText.trim()) {
+            selectedLabels.push(questionState.otherText.trim());
           }
-
-          if (!answer) return prev;
-
-          const newAnswers = {
-            ...prev.userAnswers,
-            [currentQuestion.question]: answer,
-          };
-
-          if (prev.currentQuestionIndex < questions.length - 1) {
-            return {
-              ...prev,
-              currentQuestionIndex: prev.currentQuestionIndex + 1,
-              selectedOptionIndex: 0,
-              selectedOptionIndices: new Set(),
-              userAnswers: newAnswers,
-              otherText: "",
-              otherCursorPosition: 0,
-            };
+          answer = selectedLabels.join(", ");
+        } else {
+          if (isOtherFocused) {
+            answer = questionState.otherText.trim();
           } else {
-            onDecision({
-              behavior: "allow",
-              message: JSON.stringify(newAnswers),
-            });
-            return {
-              ...prev,
-              userAnswers: newAnswers,
-            };
+            answer = options[questionState.selectedOptionIndex].label;
           }
-        });
+        }
+
+        if (!answer) return;
+
+        const newAnswers = {
+          ...questionState.userAnswers,
+          [currentQuestion.question]: answer,
+        };
+
+        if (questionState.currentQuestionIndex < questions.length - 1) {
+          setQuestionState({
+            ...questionState,
+            currentQuestionIndex: questionState.currentQuestionIndex + 1,
+            selectedOptionIndex: 0,
+            selectedOptionIndices: new Set(),
+            userAnswers: newAnswers,
+            otherText: "",
+            otherCursorPosition: 0,
+          });
+        } else {
+          onDecision({
+            behavior: "allow",
+            message: JSON.stringify(newAnswers),
+          });
+          setQuestionState({
+            ...questionState,
+            userAnswers: newAnswers,
+          });
+        }
         return;
       }
 

--- a/packages/code/src/components/HistorySearch.tsx
+++ b/packages/code/src/components/HistorySearch.tsx
@@ -33,15 +33,10 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
 
   useInput((input, key) => {
     if (key.return) {
-      setState((prev) => {
-        if (
-          prev.entries.length > 0 &&
-          prev.selectedIndex < prev.entries.length
-        ) {
-          onSelect(prev.entries[prev.selectedIndex].prompt);
-        }
-        return prev;
-      });
+      const selectedEntry = state.entries[state.selectedIndex];
+      if (selectedEntry) {
+        onSelect(selectedEntry.prompt);
+      }
       return;
     }
 

--- a/packages/code/src/components/SessionSelector.tsx
+++ b/packages/code/src/components/SessionSelector.tsx
@@ -17,12 +17,9 @@ export const SessionSelector: React.FC<SessionSelectorProps> = ({
 
   useInput((input, key) => {
     if (key.return) {
-      setSelectedIndex((prev) => {
-        if (sessions.length > 0 && prev < sessions.length) {
-          onSelect(sessions[prev].id);
-        }
-        return prev;
-      });
+      if (sessions.length > 0 && selectedIndex < sessions.length) {
+        onSelect(sessions[selectedIndex].id);
+      }
       return;
     }
 

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -433,13 +433,10 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
 
   // Permission management methods
   const setPermissionMode = useCallback((mode: PermissionMode) => {
-    setPermissionModeState((prev) => {
-      if (prev === mode) return prev;
-      if (agentRef.current && agentRef.current.getPermissionMode() !== mode) {
-        agentRef.current.setPermissionMode(mode);
-      }
-      return mode;
-    });
+    setPermissionModeState(mode);
+    if (agentRef.current && agentRef.current.getPermissionMode() !== mode) {
+      agentRef.current.setPermissionMode(mode);
+    }
   }, []);
 
   // MCP management methods - delegate to Agent


### PR DESCRIPTION
Fixed 'Cannot update a component while rendering a different component' warnings by moving callbacks and side effects out of setState updater functions in HistorySearch, ConfirmationSelector, SessionSelector, and useChat.