### PR TITLE
fix: ensure CLI worktree is cleaned up on exit

### DIFF
--- a/packages/code/src/cli.tsx
+++ b/packages/code/src/cli.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render } from "ink";
 import { App } from "./components/App.js";
 import { cleanupLogs } from "./utils/logger.js";
-import { type WorktreeSession } from "./utils/worktree.js";
+import { type WorktreeSession, removeWorktree } from "./utils/worktree.js";
 
 export interface CliOptions {
   restoreSessionId?: string;
@@ -24,37 +24,15 @@ export async function startCli(options: CliOptions): Promise<void> {
   } = options;
 
   // Continue with ink-based UI for normal mode
-  // Global cleanup tracker
-  let isCleaningUp = false;
-  let appUnmounted = false;
+  let shouldRemoveWorktree = false;
 
-  const cleanup = async () => {
-    if (isCleaningUp) return;
-    isCleaningUp = true;
-
-    try {
-      // Clean up old log files
-      await cleanupLogs().catch((error) => {
-        console.warn("Failed to cleanup old logs:", error);
-      });
-
-      // Unmount the React app to trigger cleanup
-      if (!appUnmounted) {
-        unmount();
-        appUnmounted = true;
-        // Give React time to cleanup
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
-
-      process.exit(0);
-    } catch (error: unknown) {
-      console.error("Error during cleanup:", error);
-      process.exit(1);
-    }
+  const handleExit = (shouldRemove: boolean) => {
+    shouldRemoveWorktree = shouldRemove;
+    unmount();
   };
 
   // Render the application
-  const { unmount } = render(
+  const { unmount, waitUntilExit } = render(
     <App
       restoreSessionId={restoreSessionId}
       continueLastSession={continueLastSession}
@@ -62,21 +40,28 @@ export async function startCli(options: CliOptions): Promise<void> {
       pluginDirs={pluginDirs}
       tools={tools}
       worktreeSession={worktreeSession}
-      onExit={cleanup}
+      onExit={handleExit}
     />,
+    { exitOnCtrlC: false },
   );
 
-  // Store unmount function for cleanup when process exits normally
-  process.on("exit", () => {
-    if (!appUnmounted) {
-      try {
-        unmount();
-      } catch {
-        // Ignore errors during unmount
-      }
-    }
-  });
+  // Wait for the app to finish unmounting
+  await waitUntilExit();
 
-  // Return a promise that never resolves to keep the CLI running
-  return new Promise(() => {});
+  try {
+    // Clean up old log files
+    await cleanupLogs().catch((error) => {
+      console.warn("Failed to cleanup old logs:", error);
+    });
+
+    // Cleanup worktree if requested
+    if (shouldRemoveWorktree && worktreeSession) {
+      removeWorktree(worktreeSession);
+    }
+
+    process.exit(0);
+  } catch (error: unknown) {
+    console.error("Error during cleanup:", error);
+    process.exit(1);
+  }
 }

--- a/packages/code/src/components/App.tsx
+++ b/packages/code/src/components/App.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect, useRef } from "react";
-import { useStdout } from "ink";
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import { useStdout, useInput } from "ink";
 import { ChatInterface } from "./ChatInterface.js";
 import { ChatProvider, useChat } from "../contexts/useChat.js";
 import { AppProvider } from "../contexts/useAppConfig.js";
-import { type WorktreeSession, removeWorktree } from "../utils/worktree.js";
+import { type WorktreeSession } from "../utils/worktree.js";
 import { WorktreeExitPrompt } from "./WorktreeExitPrompt.js";
 import {
   hasUncommittedChanges,
@@ -18,7 +18,7 @@ interface AppProps {
   pluginDirs?: string[];
   tools?: string[];
   worktreeSession?: WorktreeSession;
-  onExit: () => void;
+  onExit: (shouldRemove: boolean) => void;
 }
 
 const AppWithProviders: React.FC<{
@@ -26,7 +26,7 @@ const AppWithProviders: React.FC<{
   pluginDirs?: string[];
   tools?: string[];
   worktreeSession?: WorktreeSession;
-  onExit: () => void;
+  onExit: (shouldRemove: boolean) => void;
 }> = ({ bypassPermissions, pluginDirs, tools, worktreeSession, onExit }) => {
   const [isExiting, setIsExiting] = useState(false);
   const [worktreeStatus, setWorktreeStatus] = useState<{
@@ -34,37 +34,45 @@ const AppWithProviders: React.FC<{
     hasNewCommits: boolean;
   } | null>(null);
 
-  useEffect(() => {
-    const handleSignal = async () => {
-      if (worktreeSession) {
-        const cwd = process.cwd();
-        const baseBranch = getDefaultRemoteBranch(cwd);
-        const hasChanges = hasUncommittedChanges(cwd);
-        const hasCommits = hasNewCommits(cwd, baseBranch);
+  const handleSignal = useCallback(async () => {
+    if (worktreeSession) {
+      const cwd = process.cwd();
+      const baseBranch = getDefaultRemoteBranch(cwd);
+      const hasChanges = hasUncommittedChanges(cwd);
+      const hasCommits = hasNewCommits(cwd, baseBranch);
 
-        if (hasChanges || hasCommits) {
-          setWorktreeStatus({
-            hasUncommittedChanges: hasChanges,
-            hasNewCommits: hasCommits,
-          });
-          setIsExiting(true);
-        } else {
-          removeWorktree(worktreeSession, cwd);
-          onExit();
-        }
+      if (hasChanges || hasCommits) {
+        setWorktreeStatus({
+          hasUncommittedChanges: hasChanges,
+          hasNewCommits: hasCommits,
+        });
+        setIsExiting(true);
       } else {
-        onExit();
+        onExit(true);
       }
-    };
+    } else {
+      onExit(false);
+    }
+  }, [worktreeSession, onExit]);
 
-    process.on("SIGINT", handleSignal);
-    process.on("SIGTERM", handleSignal);
+  useInput((input, key) => {
+    if (input === "c" && key.ctrl) {
+      handleSignal();
+    }
+  });
+
+  useEffect(() => {
+    const onSigInt = () => handleSignal();
+    const onSigTerm = () => handleSignal();
+
+    process.on("SIGINT", onSigInt);
+    process.on("SIGTERM", onSigTerm);
 
     return () => {
-      process.off("SIGINT", handleSignal);
-      process.off("SIGTERM", handleSignal);
+      process.off("SIGINT", onSigInt);
+      process.off("SIGTERM", onSigTerm);
     };
-  }, [worktreeSession, onExit]);
+  }, [handleSignal]);
 
   if (isExiting && worktreeSession && worktreeStatus) {
     return (
@@ -73,11 +81,8 @@ const AppWithProviders: React.FC<{
         path={worktreeSession.path}
         hasUncommittedChanges={worktreeStatus.hasUncommittedChanges}
         hasNewCommits={worktreeStatus.hasNewCommits}
-        onKeep={() => onExit()}
-        onRemove={() => {
-          removeWorktree(worktreeSession, process.cwd());
-          onExit();
-        }}
+        onKeep={() => onExit(false)}
+        onRemove={() => onExit(true)}
         onCancel={() => setIsExiting(false)}
       />
     );

--- a/packages/code/src/print-cli.ts
+++ b/packages/code/src/print-cli.ts
@@ -1,4 +1,10 @@
-import { Agent, AgentCallbacks, hasUncommittedChanges, hasNewCommits, getDefaultRemoteBranch } from "wave-agent-sdk";
+import {
+  Agent,
+  AgentCallbacks,
+  hasUncommittedChanges,
+  hasNewCommits,
+  getDefaultRemoteBranch,
+} from "wave-agent-sdk";
 import { displayUsageSummary } from "./utils/usageSummary.js";
 import { type WorktreeSession, removeWorktree } from "./utils/worktree.js";
 
@@ -175,7 +181,7 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
       const hasCommits = hasNewCommits(cwd, baseBranch);
 
       if (!hasChanges && !hasCommits) {
-        removeWorktree(worktreeSession, cwd);
+        removeWorktree(worktreeSession);
       } else {
         process.stdout.write(
           `\n⚠️ Worktree '${worktreeSession.name}' has changes or commits. Keeping it at: ${worktreeSession.path}\n`,
@@ -211,7 +217,7 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
         const hasCommits = hasNewCommits(cwd, baseBranch);
 
         if (!hasChanges && !hasCommits) {
-          removeWorktree(worktreeSession, cwd);
+          removeWorktree(worktreeSession);
         } else {
           process.stdout.write(
             `\n⚠️ Worktree '${worktreeSession.name}' has changes or commits. Keeping it at: ${worktreeSession.path}\n`,

--- a/packages/code/src/utils/worktree.ts
+++ b/packages/code/src/utils/worktree.ts
@@ -7,6 +7,7 @@ export interface WorktreeSession {
   name: string;
   path: string;
   branch: string;
+  repoRoot: string;
   hasUncommittedChanges: boolean;
   hasNewCommits: boolean;
 }
@@ -38,6 +39,7 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
       name,
       path: worktreePath,
       branch: branchName,
+      repoRoot,
       hasUncommittedChanges: false,
       hasNewCommits: false,
     };
@@ -57,6 +59,7 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
       name,
       path: worktreePath,
       branch: branchName,
+      repoRoot,
       hasUncommittedChanges: false,
       hasNewCommits: false,
     };
@@ -73,6 +76,7 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
           name,
           path: worktreePath,
           branch: branchName,
+          repoRoot,
           hasUncommittedChanges: false,
           hasNewCommits: false,
         };
@@ -91,10 +95,9 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
 /**
  * Remove a git worktree and its associated branch
  * @param session Worktree session details
- * @param cwd Current working directory
  */
-export function removeWorktree(session: WorktreeSession, cwd: string): void {
-  const repoRoot = getGitRepoRoot(cwd);
+export function removeWorktree(session: WorktreeSession): void {
+  const repoRoot = session.repoRoot;
 
   try {
     // Change directory to repo root before removing worktree to avoid "directory in use" errors

--- a/packages/code/tests/components/App.test.tsx
+++ b/packages/code/tests/components/App.test.tsx
@@ -16,7 +16,6 @@ import {
   hasNewCommits,
   getDefaultRemoteBranch,
 } from "wave-agent-sdk";
-import { removeWorktree } from "../../src/utils/worktree.js";
 
 vi.mock("wave-agent-sdk", async () => {
   const actual = await vi.importActual("wave-agent-sdk");
@@ -64,6 +63,7 @@ describe("App Component", () => {
       name: "test-feat",
       path: "/repo/test-feat",
       branch: "worktree-test-feat",
+      repoRoot: "/repo",
       hasUncommittedChanges: false,
       hasNewCommits: false,
     };
@@ -80,11 +80,7 @@ describe("App Component", () => {
     )![1] as () => Promise<void>;
     await handleSignal();
 
-    expect(removeWorktree).toHaveBeenCalledWith(
-      worktreeSession,
-      expect.any(String),
-    );
-    expect(onExit).toHaveBeenCalled();
+    expect(onExit).toHaveBeenCalledWith(true);
   });
 
   it("should show exit prompt on SIGINT if there are changes in worktree", async () => {
@@ -93,6 +89,7 @@ describe("App Component", () => {
       name: "test-feat",
       path: "/repo/test-feat",
       branch: "worktree-test-feat",
+      repoRoot: "/repo",
       hasUncommittedChanges: false,
       hasNewCommits: false,
     };
@@ -120,7 +117,6 @@ describe("App Component", () => {
       );
     });
 
-    expect(removeWorktree).not.toHaveBeenCalled();
     expect(onExit).not.toHaveBeenCalled();
   });
 });

--- a/packages/code/tests/utils/worktree.test.ts
+++ b/packages/code/tests/utils/worktree.test.ts
@@ -37,6 +37,7 @@ describe("worktree utils", () => {
         path.join("/repo/root", ".wave/worktrees/my-feat"),
       );
       expect(session.branch).toBe("worktree-my-feat");
+      expect(session.repoRoot).toBe("/repo/root");
       expect(execSync).toHaveBeenCalledWith(
         expect.stringContaining("git worktree add -b worktree-my-feat"),
         expect.any(Object),
@@ -63,6 +64,7 @@ describe("worktree utils", () => {
       const session = createWorktree("my-feat", "/repo/root");
 
       expect(session.name).toBe("my-feat");
+      expect(session.repoRoot).toBe("/repo/root");
       expect(execSync).toHaveBeenCalledTimes(2);
       expect(execSync).toHaveBeenCalledWith(
         expect.stringMatching(/git worktree add "[^"]+" worktree-my-feat/),
@@ -108,7 +110,6 @@ describe("worktree utils", () => {
 
   describe("removeWorktree", () => {
     it("should remove worktree and branch", () => {
-      vi.mocked(getGitRepoRoot).mockReturnValue("/repo/root");
       const chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
       const cwdSpy = vi
         .spyOn(process, "cwd")
@@ -118,11 +119,12 @@ describe("worktree utils", () => {
         name: "my-feat",
         path: "/repo/root/.wave/worktrees/my-feat",
         branch: "worktree-my-feat",
+        repoRoot: "/repo/root",
         hasUncommittedChanges: false,
         hasNewCommits: false,
       };
 
-      removeWorktree(session, "/repo/root");
+      removeWorktree(session);
 
       expect(chdirSpy).toHaveBeenCalledWith("/repo/root");
       expect(execSync).toHaveBeenCalledWith(
@@ -139,7 +141,6 @@ describe("worktree utils", () => {
     });
 
     it("should log error if removal fails", () => {
-      vi.mocked(getGitRepoRoot).mockReturnValue("/repo/root");
       const consoleSpy = vi
         .spyOn(console, "error")
         .mockImplementation(() => {});
@@ -152,11 +153,12 @@ describe("worktree utils", () => {
         name: "my-feat",
         path: "/repo/root/.wave/worktrees/my-feat",
         branch: "worktree-my-feat",
+        repoRoot: "/repo/root",
         hasUncommittedChanges: false,
         hasNewCommits: false,
       };
 
-      removeWorktree(session, "/repo/root");
+      removeWorktree(session);
 
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining("Failed to remove worktree or branch"),


### PR DESCRIPTION
This PR fixes a bug where the CLI worktree was not being cleaned up correctly on exit. It ensures the process moves out of the worktree directory before removal and handles Ctrl+C signals properly in the Ink application.