### PR TITLE
Adjust ExitPlanMode feedback template

### DIFF
--- a/packages/agent-sdk/src/tools/exitPlanMode.ts
+++ b/packages/agent-sdk/src/tools/exitPlanMode.ts
@@ -93,7 +93,7 @@ Ensure your plan is complete and unambiguous:
       if (permissionResult.behavior === "deny") {
         return {
           success: false,
-          content: `User feedback: ${permissionResult.message || "Plan rejected by user"}. Please update your proposal accordingly.`,
+          content: `Please update your proposal based on the following user feedback: ${permissionResult.message || "Plan rejected by user"}`,
           error: permissionResult.message ? undefined : "Plan rejected by user",
         };
       }

--- a/packages/agent-sdk/tests/agent/exitPlanMode.integration.test.ts
+++ b/packages/agent-sdk/tests/agent/exitPlanMode.integration.test.ts
@@ -201,7 +201,7 @@ describe("ExitPlanMode Integration", () => {
 
     expect(result.success).toBe(false);
     expect(result.content).toBe(
-      `User feedback: ${feedback}. Please update your proposal accordingly.`,
+      `Please update your proposal based on the following user feedback: ${feedback}`,
     );
     expect(agent.getPermissionMode()).toBe("plan");
   });

--- a/packages/agent-sdk/tests/tools/exitPlanMode.test.ts
+++ b/packages/agent-sdk/tests/tools/exitPlanMode.test.ts
@@ -122,7 +122,7 @@ describe("exitPlanModeTool", () => {
 
     expect(result.success).toBe(false);
     expect(result.content).toBe(
-      `User feedback: ${feedback}. Please update your proposal accordingly.`,
+      `Please update your proposal based on the following user feedback: ${feedback}`,
     );
     expect(result.error).toBeUndefined();
   });
@@ -141,7 +141,7 @@ describe("exitPlanModeTool", () => {
 
     expect(result.success).toBe(false);
     expect(result.content).toBe(
-      "User feedback: Plan rejected by user. Please update your proposal accordingly.",
+      "Please update your proposal based on the following user feedback: Plan rejected by user",
     );
     expect(result.error).toBe("Plan rejected by user");
   });


### PR DESCRIPTION
Change the feedback message template in ExitPlanMode tool so that the user input is at the end of the message. This avoids awkward punctuation when the user input ends with a question mark.