### PR TITLE
docs: replace hardcoded path with generic placeholder in worktree spec

### DIFF
--- a/specs/068-cli-worktree-support/spec.md
+++ b/specs/068-cli-worktree-support/spec.md
@@ -6,7 +6,7 @@
 **Input**: User description: "wave code cli support -w or --worktree <feat-name> to create worktree at .wave/worktrees/<feat-name>. if no <feat-name>, system should generate one, just like plan file name do. when exit wave code cli, it should popup this: Exiting worktree session
  You have 1 uncommitted file. These will be lost if you remove the worktree.
 
- ❯ Keep worktree    Stays at /home/liuyiqi/code/bin/.claude/worktrees/merry-crafting-sutherland
+ ❯ Keep worktree    Stays at /path/to/repo/.wave/worktrees/merry-crafting-sutherland
    Remove worktree  All changes and commits will be lost.
 
  Enter to confirm · Esc to cancel
@@ -14,7 +14,7 @@
 Exiting worktree session
  You have 1 commit on worktree-merry-crafting-sutherland. The branch will be deleted if you remove the worktree.
 
- ❯ Keep worktree    Stays at /home/liuyiqi/code/bin/.claude/worktrees/merry-crafting-sutherland
+ ❯ Keep worktree    Stays at /path/to/repo/.wave/worktrees/merry-crafting-sutherland
    Remove worktree  All changes and commits will be lost.
 
  Enter to confirm · Esc to cancel. if no commit or uncommit, exit without confirm."


### PR DESCRIPTION
Replaces /home/liuyiqi/code/bin/.claude/ with /path/to/repo/.wave/ in the CLI worktree support specification.