### PR TITLE
chore: downgrade task manager info logs to debug

### DIFF
--- a/packages/agent-sdk/src/services/taskManager.ts
+++ b/packages/agent-sdk/src/services/taskManager.ts
@@ -110,7 +110,7 @@ export class TaskManager extends EventEmitter {
       const content = JSON.stringify(fullTask, null, 2);
       await fs.writeFile(taskPath, content, "utf8");
       this.emit("tasksChange", this.taskListId);
-      logger.info(`Task ${taskId} created in task list ${this.taskListId}`);
+      logger.debug(`Task ${taskId} created in task list ${this.taskListId}`);
       return taskId;
     });
   }
@@ -141,7 +141,7 @@ export class TaskManager extends EventEmitter {
       const content = JSON.stringify(task, null, 2);
       await fs.writeFile(taskPath, content, "utf8");
       this.emit("tasksChange", this.taskListId);
-      logger.info(`Task ${task.id} updated in task list ${this.taskListId}`);
+      logger.debug(`Task ${task.id} updated in task list ${this.taskListId}`);
     });
   }
 


### PR DESCRIPTION
Downgraded task creation and update logs from INFO to DEBUG level to reduce noise in the output.