### PR TITLE
feat: support WorktreeCreate hook event

### DIFF
--- a/.wave/settings.json
+++ b/.wave/settings.json
@@ -18,5 +18,17 @@
   },
   "enabledPlugins": {
     "typescript-lsp@wave-plugins-official": true
+  },
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm install && pnpm build"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -107,6 +107,10 @@ export interface AgentOptions {
    * - string[]: Enable only the tools with the specified names.
    */
   tools?: string[];
+  /**Optional worktree name */
+  worktreeName?: string;
+  /**Whether this is a newly created worktree */
+  isNewWorktree?: boolean;
 }
 
 export interface AgentCallbacks
@@ -512,6 +516,37 @@ export class Agent {
     } catch (error) {
       this.logger?.error("Failed to initialize hooks system:", error);
       // Don't throw error to prevent app startup failure
+    }
+
+    // Trigger WorktreeCreate hook if this is a new worktree
+    if (this.options.isNewWorktree && this.hookManager) {
+      try {
+        this.logger?.info(
+          `Triggering WorktreeCreate hook for ${this.options.worktreeName}...`,
+        );
+        const hookResults = await this.hookManager.executeHooks(
+          "WorktreeCreate",
+          {
+            event: "WorktreeCreate",
+            projectDir: this.workdir,
+            timestamp: new Date(),
+            sessionId: this.sessionId,
+            transcriptPath: this.messageManager.getTranscriptPath(),
+            cwd: this.workdir,
+            worktreeName: this.options.worktreeName,
+            env: this.configurationService.getEnvironmentVars(),
+          },
+        );
+
+        // Process hook results
+        this.hookManager.processHookResults(
+          "WorktreeCreate",
+          hookResults,
+          this.messageManager,
+        );
+      } catch (error) {
+        this.logger?.warn("WorktreeCreate hooks execution failed:", error);
+      }
     }
 
     // Resolve and validate configuration after loading settings.json

--- a/packages/agent-sdk/src/managers/hookManager.ts
+++ b/packages/agent-sdk/src/managers/hookManager.ts
@@ -378,6 +378,11 @@ export class HookManager {
         });
         return { shouldBlock: true, errorMessage };
 
+      case "WorktreeCreate":
+        // Non-blocking for now, just show error in error block
+        messageManager.addErrorBlock(errorMessage);
+        return { shouldBlock: false };
+
       default:
         return { shouldBlock: false };
     }
@@ -577,7 +582,8 @@ export class HookManager {
       (event === "UserPromptSubmit" ||
         event === "Stop" ||
         event === "Notification" ||
-        event === "SubagentStop") &&
+        event === "SubagentStop" ||
+        event === "WorktreeCreate") &&
       context.toolName !== undefined
     ) {
       logger?.warn(
@@ -653,7 +659,8 @@ export class HookManager {
       event === "UserPromptSubmit" ||
       event === "Stop" ||
       event === "Notification" ||
-      event === "SubagentStop"
+      event === "SubagentStop" ||
+      event === "WorktreeCreate"
     ) {
       return true;
     }
@@ -704,7 +711,8 @@ export class HookManager {
       (event === "UserPromptSubmit" ||
         event === "Stop" ||
         event === "Notification" ||
-        event === "SubagentStop") &&
+        event === "SubagentStop" ||
+        event === "WorktreeCreate") &&
       config.matcher
     ) {
       errors.push(`${prefix}: Event ${event} should not have a matcher`);
@@ -743,6 +751,7 @@ export class HookManager {
           Stop: 0,
           SubagentStop: 0,
           Notification: 0,
+          WorktreeCreate: 0,
         },
       };
     }
@@ -754,6 +763,7 @@ export class HookManager {
       Stop: 0,
       SubagentStop: 0,
       Notification: 0,
+      WorktreeCreate: 0,
     };
 
     let totalConfigs = 0;

--- a/packages/agent-sdk/src/services/hook.ts
+++ b/packages/agent-sdk/src/services/hook.ts
@@ -83,6 +83,13 @@ async function buildHookJsonInput(
     }
   }
 
+  // Add name field for WorktreeCreate events
+  if (context.event === "WorktreeCreate") {
+    if (context.worktreeName !== undefined) {
+      jsonInput.name = context.worktreeName;
+    }
+  }
+
   return jsonInput;
 }
 

--- a/packages/agent-sdk/src/types/hooks.ts
+++ b/packages/agent-sdk/src/types/hooks.ts
@@ -19,7 +19,8 @@ export type HookEvent =
   | "UserPromptSubmit"
   | "Stop"
   | "SubagentStop"
-  | "Notification";
+  | "Notification"
+  | "WorktreeCreate";
 
 // Individual hook command configuration
 export interface HookCommand {
@@ -98,6 +99,7 @@ export function isValidHookEvent(event: string): event is HookEvent {
     "Stop",
     "SubagentStop",
     "Notification",
+    "WorktreeCreate",
   ].includes(event);
 }
 
@@ -146,6 +148,7 @@ export interface HookJsonInput {
   subagent_type?: string; // Present when hook is executed by a subagent
   message?: string; // Present for Notification events
   notification_type?: string; // Present for Notification events
+  name?: string; // Present for WorktreeCreate events
 }
 
 // Extended context interface for passing additional data to hook executor
@@ -160,6 +163,7 @@ export interface ExtendedHookExecutionContext extends HookExecutionContext {
   subagentType?: string; // Subagent type when hook is executed by a subagent
   message?: string; // Notification message (Notification only)
   notificationType?: string; // Notification type (Notification only)
+  worktreeName?: string; // Worktree name (WorktreeCreate only)
 }
 
 // Environment variables injected into hook processes

--- a/packages/agent-sdk/tests/agent/agent.worktree.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.worktree.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Agent } from "@/agent.js";
+import { HookManager } from "@/managers/hookManager.js";
+import { MessageManager } from "@/managers/messageManager.js";
+import * as fs from "fs/promises";
+import { homedir } from "os";
+
+// Mock AI service
+vi.mock("@/services/aiService");
+// Mock fs/promises to avoid actual file operations
+vi.mock("fs/promises");
+// Mock os to avoid actual homedir access
+vi.mock("os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("os")>();
+  return {
+    ...actual,
+    homedir: vi.fn(() => "/home/testuser"),
+    platform: vi.fn(() => "linux"),
+  };
+});
+
+describe("Agent WorktreeCreate Hook", () => {
+  const mockCallbacks = {
+    onMessagesChange: vi.fn(),
+    onLoadingChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.readFile).mockResolvedValue("");
+    vi.mocked(homedir).mockReturnValue("/home/testuser");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should trigger WorktreeCreate hook when isNewWorktree is true during initialization", async () => {
+    // We need to spy on HookManager.prototype.executeHooks because it's created during Agent.create
+    const executeHooksSpy = vi.spyOn(HookManager.prototype, "executeHooks");
+    const processHookResultsSpy = vi.spyOn(
+      HookManager.prototype,
+      "processHookResults",
+    );
+
+    executeHooksSpy.mockResolvedValue([]);
+
+    const agent = await Agent.create({
+      callbacks: mockCallbacks,
+      workdir: "/tmp/test-workdir",
+      isNewWorktree: true,
+      worktreeName: "test-worktree",
+    });
+
+    expect(executeHooksSpy).toHaveBeenCalledWith(
+      "WorktreeCreate",
+      expect.objectContaining({
+        event: "WorktreeCreate",
+        worktreeName: "test-worktree",
+      }),
+    );
+    expect(processHookResultsSpy).toHaveBeenCalledWith(
+      "WorktreeCreate",
+      [],
+      expect.any(MessageManager),
+    );
+
+    await agent.destroy();
+  });
+
+  it("should handle errors during WorktreeCreate hook execution gracefully", async () => {
+    const executeHooksSpy = vi.spyOn(HookManager.prototype, "executeHooks");
+    executeHooksSpy.mockRejectedValue(new Error("Hook execution failed"));
+
+    // Should not throw
+    const agent = await Agent.create({
+      callbacks: mockCallbacks,
+      workdir: "/tmp/test-workdir",
+      isNewWorktree: true,
+    });
+
+    expect(executeHooksSpy).toHaveBeenCalledWith(
+      "WorktreeCreate",
+      expect.anything(),
+    );
+
+    await agent.destroy();
+  });
+
+  it("should NOT trigger WorktreeCreate hook when isNewWorktree is false", async () => {
+    const executeHooksSpy = vi.spyOn(HookManager.prototype, "executeHooks");
+
+    const agent = await Agent.create({
+      callbacks: mockCallbacks,
+      workdir: "/tmp/test-workdir",
+      isNewWorktree: false,
+    });
+
+    // Check if WorktreeCreate was called
+    const worktreeCreateCalls = executeHooksSpy.mock.calls.filter(
+      (call) => call[0] === "WorktreeCreate",
+    );
+    expect(worktreeCreateCalls.length).toBe(0);
+
+    await agent.destroy();
+  });
+
+  describe("HookManager.processHookResults for WorktreeCreate", () => {
+    it("should add an error block when a WorktreeCreate hook returns exit code 2", async () => {
+      // We can test this by calling processHookResults on a real HookManager instance
+      // but we need a MessageManager mock
+      const mockMessageManager = {
+        addErrorBlock: vi.fn(),
+      } as unknown as MessageManager;
+
+      // Create a HookManager instance (we need a container but we can mock it)
+      const mockContainer = {
+        get: vi.fn(),
+      } as unknown as import("@/utils/container.js").Container;
+      const hookManager = new HookManager(mockContainer, "/tmp/test-workdir");
+
+      const results = [
+        {
+          success: false,
+          exitCode: 2,
+          stderr: "Worktree creation failed critically",
+          duration: 100,
+          timedOut: false,
+        },
+      ];
+
+      const processResult = hookManager.processHookResults(
+        "WorktreeCreate",
+        results,
+        mockMessageManager,
+      );
+
+      expect(mockMessageManager.addErrorBlock).toHaveBeenCalledWith(
+        "Worktree creation failed critically",
+      );
+      expect(processResult.shouldBlock).toBe(false); // WorktreeCreate is non-blocking for now
+    });
+
+    it("should add an error block for non-zero exit codes other than 2", async () => {
+      const mockMessageManager = {
+        addErrorBlock: vi.fn(),
+      } as unknown as MessageManager;
+
+      const mockContainer = {
+        get: vi.fn(),
+      } as unknown as import("@/utils/container.js").Container;
+      const hookManager = new HookManager(mockContainer, "/tmp/test-workdir");
+
+      const results = [
+        {
+          success: false,
+          exitCode: 1,
+          stderr: "Minor hook failure",
+          duration: 50,
+          timedOut: false,
+        },
+      ];
+
+      hookManager.processHookResults(
+        "WorktreeCreate",
+        results,
+        mockMessageManager,
+      );
+
+      expect(mockMessageManager.addErrorBlock).toHaveBeenCalledWith(
+        "Minor hook failure",
+      );
+    });
+
+    it("should NOT add an error block for exit code 0", async () => {
+      const mockMessageManager = {
+        addErrorBlock: vi.fn(),
+        addUserMessage: vi.fn(),
+      } as unknown as MessageManager;
+
+      const mockContainer = {
+        get: vi.fn(),
+      } as unknown as import("@/utils/container.js").Container;
+      const hookManager = new HookManager(mockContainer, "/tmp/test-workdir");
+
+      const results = [
+        {
+          success: true,
+          exitCode: 0,
+          stdout: "Hook success",
+          stderr: "",
+          duration: 50,
+          timedOut: false,
+        },
+      ];
+
+      hookManager.processHookResults(
+        "WorktreeCreate",
+        results,
+        mockMessageManager,
+      );
+
+      expect(mockMessageManager.addErrorBlock).not.toHaveBeenCalled();
+      // WorktreeCreate doesn't inject stdout even on success
+      expect(mockMessageManager.addUserMessage).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/agent-sdk/tests/services/hook.test.ts
+++ b/packages/agent-sdk/tests/services/hook.test.ts
@@ -22,7 +22,17 @@ import {
   executeCommands,
   isCommandSafe,
 } from "../../src/services/hook.js";
-import type { HookExecutionContext } from "../../src/types/hooks.js";
+import type {
+  HookExecutionContext,
+  ExtendedHookExecutionContext,
+} from "../../src/types/hooks.js";
+
+// Mock session service
+vi.mock("../../src/services/session.js", () => ({
+  generateSessionFilePath: vi
+    .fn()
+    .mockResolvedValue("/path/to/transcript.json"),
+}));
 
 // Mock child_process module
 vi.mock("child_process", () => ({
@@ -580,6 +590,82 @@ describe("Hook Services", () => {
       expect(parsedInput.cwd).toBe("/test/cwd");
       expect(parsedInput.hook_event_name).toBe("PostToolUse");
       expect(parsedInput.subagent_type).toBeUndefined(); // Verify subagent_type is not included
+    });
+  });
+
+  describe("WorktreeCreate hook", () => {
+    it("should NOT inject HOOK_WORKTREE_NAME and HOOK_WORKTREE_PATH environment variables", async () => {
+      const mockProcess = new MockChildProcess();
+      mockProcess.stdin = new MockStdin();
+      let spawnEnv: NodeJS.ProcessEnv | undefined;
+
+      mockSpawn.mockImplementation((command, args, options) => {
+        spawnEnv = options?.env;
+        return mockProcess;
+      });
+
+      const worktreeContext: ExtendedHookExecutionContext = {
+        event: "WorktreeCreate",
+        projectDir: "/test/worktree-path",
+        timestamp: new Date(),
+        sessionId: "test-session-123",
+        worktreeName: "test-worktree",
+      };
+
+      const resultPromise = executeCommand("echo test", worktreeContext);
+
+      setImmediate(() => {
+        mockProcess.emit("close", 0);
+      });
+
+      await resultPromise;
+
+      expect(spawnEnv).toBeDefined();
+      expect(spawnEnv!.HOOK_EVENT).toBe("WorktreeCreate");
+      expect(spawnEnv!.HOOK_WORKTREE_NAME).toBeUndefined();
+      expect(spawnEnv!.HOOK_WORKTREE_PATH).toBeUndefined();
+      expect(spawnEnv!.WAVE_PROJECT_DIR).toBe("/test/worktree-path");
+    });
+
+    it("should include 'name' field in JSON input and NOT include 'worktree_name' or 'worktree_path'", async () => {
+      const mockProcess = new MockChildProcess();
+      const mockStdin = new MockStdin();
+      let stdinData = "";
+
+      vi.spyOn(mockStdin, "write").mockImplementation(
+        (_data?: string | Buffer | Uint8Array) => {
+          if (_data) {
+            stdinData += _data.toString();
+          }
+          return true;
+        },
+      );
+
+      mockProcess.stdin = mockStdin;
+      mockSpawn.mockReturnValue(mockProcess);
+
+      const worktreeContext: ExtendedHookExecutionContext = {
+        event: "WorktreeCreate",
+        projectDir: "/test/worktree-path",
+        timestamp: new Date(),
+        sessionId: "test-session-123",
+        worktreeName: "test-worktree",
+      };
+
+      const resultPromise = executeCommand("echo test", worktreeContext);
+
+      setImmediate(() => {
+        mockProcess.emit("close", 0);
+      });
+
+      await resultPromise;
+
+      expect(stdinData).toBeTruthy();
+      const parsedInput = JSON.parse(stdinData);
+      expect(parsedInput.name).toBe("test-worktree");
+      expect(parsedInput.worktree_name).toBeUndefined();
+      expect(parsedInput.worktree_path).toBeUndefined();
+      expect(parsedInput.hook_event_name).toBe("WorktreeCreate");
     });
   });
 });

--- a/packages/code/src/components/App.tsx
+++ b/packages/code/src/components/App.tsx
@@ -103,6 +103,7 @@ const AppWithProviders: React.FC<{
       pluginDirs={pluginDirs}
       tools={tools}
       workdir={workdir}
+      worktreeSession={worktreeSession}
     >
       <ChatInterfaceWithRemount />
     </ChatProvider>

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -22,6 +22,7 @@ import {
   AgentCallbacks,
   type ToolPermissionContext,
 } from "wave-agent-sdk";
+import { WorktreeSession } from "../utils/worktree.js";
 import { logger } from "../utils/logger.js";
 import { displayUsageSummary } from "../utils/usageSummary.js";
 
@@ -110,6 +111,7 @@ export interface ChatProviderProps {
   pluginDirs?: string[];
   tools?: string[];
   workdir?: string;
+  worktreeSession?: WorktreeSession;
 }
 
 export const ChatProvider: React.FC<ChatProviderProps> = ({
@@ -118,6 +120,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   pluginDirs,
   tools,
   workdir,
+  worktreeSession,
 }) => {
   const { restoreSessionId, continueLastSession } = useAppConfig();
 
@@ -319,6 +322,8 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
           plugins: pluginDirs?.map((path) => ({ type: "local", path })),
           tools,
           workdir,
+          worktreeName: worktreeSession?.name,
+          isNewWorktree: worktreeSession?.isNew,
         });
 
         agentRef.current = agent;
@@ -353,6 +358,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
     pluginDirs,
     tools,
     workdir,
+    worktreeSession,
   ]);
 
   // Cleanup on unmount

--- a/packages/code/src/utils/worktree.ts
+++ b/packages/code/src/utils/worktree.ts
@@ -10,6 +10,7 @@ export interface WorktreeSession {
   repoRoot: string;
   hasUncommittedChanges: boolean;
   hasNewCommits: boolean;
+  isNew: boolean;
 }
 
 export const WORKTREE_DIR = ".wave/worktrees";
@@ -42,6 +43,7 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
       repoRoot,
       hasUncommittedChanges: false,
       hasNewCommits: false,
+      isNew: false,
     };
   }
 
@@ -62,6 +64,7 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
       repoRoot,
       hasUncommittedChanges: false,
       hasNewCommits: false,
+      isNew: true,
     };
   } catch (error: unknown) {
     const stderr = (error as { stderr?: Buffer }).stderr?.toString() || "";
@@ -79,6 +82,7 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
           repoRoot,
           hasUncommittedChanges: false,
           hasNewCommits: false,
+          isNew: true,
         };
       } catch (innerError: unknown) {
         throw new Error(

--- a/packages/code/tests/components/App.test.tsx
+++ b/packages/code/tests/components/App.test.tsx
@@ -66,6 +66,7 @@ describe("App Component", () => {
       repoRoot: "/repo",
       hasUncommittedChanges: false,
       hasNewCommits: false,
+      isNew: false,
     };
 
     vi.mocked(hasUncommittedChanges).mockReturnValue(false);
@@ -92,6 +93,7 @@ describe("App Component", () => {
       repoRoot: "/repo",
       hasUncommittedChanges: false,
       hasNewCommits: false,
+      isNew: false,
     };
 
     vi.mocked(hasUncommittedChanges).mockReturnValue(true);

--- a/packages/code/tests/utils/worktree.test.ts
+++ b/packages/code/tests/utils/worktree.test.ts
@@ -38,10 +38,22 @@ describe("worktree utils", () => {
       );
       expect(session.branch).toBe("worktree-my-feat");
       expect(session.repoRoot).toBe("/repo/root");
+      expect(session.isNew).toBe(true);
       expect(execSync).toHaveBeenCalledWith(
         expect.stringContaining("git worktree add -b worktree-my-feat"),
         expect.any(Object),
       );
+    });
+
+    it("should reuse an existing worktree", () => {
+      vi.mocked(getGitRepoRoot).mockReturnValue("/repo/root");
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+
+      const session = createWorktree("my-feat", "/repo/root");
+
+      expect(session.name).toBe("my-feat");
+      expect(session.isNew).toBe(false);
+      expect(execSync).not.toHaveBeenCalled();
     });
 
     it("should handle branch already exists error by adding worktree without -b", () => {
@@ -65,6 +77,7 @@ describe("worktree utils", () => {
 
       expect(session.name).toBe("my-feat");
       expect(session.repoRoot).toBe("/repo/root");
+      expect(session.isNew).toBe(true);
       expect(execSync).toHaveBeenCalledTimes(2);
       expect(execSync).toHaveBeenCalledWith(
         expect.stringMatching(/git worktree add "[^"]+" worktree-my-feat/),
@@ -117,6 +130,7 @@ describe("worktree utils", () => {
         repoRoot: "/repo/root",
         hasUncommittedChanges: false,
         hasNewCommits: false,
+        isNew: false,
       };
 
       removeWorktree(session);
@@ -146,6 +160,7 @@ describe("worktree utils", () => {
         repoRoot: "/repo/root",
         hasUncommittedChanges: false,
         hasNewCommits: false,
+        isNew: false,
       };
 
       removeWorktree(session);

--- a/specs/068-cli-worktree-support/data-model.md
+++ b/specs/068-cli-worktree-support/data-model.md
@@ -18,6 +18,9 @@ Represents a git worktree session created by the CLI.
   - `true` if there are staged or unstaged changes in the worktree.
 - **hasNewCommits**: `boolean`
   - `true` if there are commits in the worktree branch that are not in the base branch.
+- **isNew**: `boolean`
+  - `true` if the worktree was newly created in the current session.
+  - `false` if an existing worktree was reused.
 
 ## State Transitions
 
@@ -30,6 +33,7 @@ Represents a git worktree session created by the CLI.
    - `WorktreeSession` is initialized with `name`, `path`, and `branch`.
 
 2. **Execution**:
+   - If `isNew` is `true`, trigger `WorktreeCreate` hook event.
    - Agent operates within the worktree directory.
    - User makes changes and/or commits.
 

--- a/specs/068-cli-worktree-support/spec.md
+++ b/specs/068-cli-worktree-support/spec.md
@@ -130,6 +130,9 @@ As a developer, I want the CLI to automatically clean up the worktree if I haven
 - **FR-015**: If the user cancels the exit prompt (e.g., via Esc), the CLI MUST return to the active session.
 - **FR-016**: If a worktree with the same name already exists, the system MUST reuse it and skip the creation step.
 - **FR-017**: Exit detection MUST complete within 500ms to avoid noticeable lag for the user.
+- **FR-018**: System MUST trigger a `WorktreeCreate` hook event when a new worktree is created.
+- **FR-019**: The `WorktreeCreate` hook MUST provide a JSON input via stdin containing a `name` field. The hook MUST execute in the newly created worktree directory.
+- **FR-020**: The `WorktreeCreate` hook MUST NOT be triggered when reusing an existing worktree.
 
 ### Key Entities
 

--- a/specs/068-cli-worktree-support/tasks.md
+++ b/specs/068-cli-worktree-support/tasks.md
@@ -47,6 +47,7 @@
 - [x] T019 Improve error handling for git commands in `packages/code/src/utils/worktree.ts`
 - [x] T020 Run full integration tests for the worktree flow
 - [x] T021 [P] Run `pnpm run type-check`, `pnpm run lint`, and `pnpm test:coverage`
+- [x] T022 Implement `WorktreeCreate` hook event support in `agent-sdk` and `code` packages.
 
 ## Dependency Graph
 


### PR DESCRIPTION
This PR implements the WorktreeCreate hook event, allowing users to run automated tasks (like pnpm install) when a new git worktree is created.

Key changes:
- Added WorktreeCreate to HookEvent types in agent-sdk.
- Updated HookManager and HookExecutionService to support the new event and its environment variables.
- Modified Agent to trigger the hook during initialization for new worktrees.
- Updated worktree utilities and UI components in packages/code to track and pass worktree session state.
- Updated specifications and added a default hook to .wave/settings.json.