### PR TITLE
feat: support tab to cycle in confirmation UI

### DIFF
--- a/packages/code/src/components/ConfirmationSelector.tsx
+++ b/packages/code/src/components/ConfirmationSelector.tsx
@@ -70,6 +70,15 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
     userAnswers: {} as Record<string, string>,
     otherText: "",
     otherCursorPosition: 0,
+    savedStates: {} as Record<
+      number,
+      {
+        selectedOptionIndex: number;
+        selectedOptionIndices: Set<number>;
+        otherText: string;
+        otherCursorPosition: number;
+      }
+    >,
   });
 
   const questions =
@@ -133,23 +142,75 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
           };
 
           if (prev.currentQuestionIndex < questions.length - 1) {
-            return {
-              ...prev,
-              currentQuestionIndex: prev.currentQuestionIndex + 1,
+            const nextIndex = prev.currentQuestionIndex + 1;
+            const savedStates = {
+              ...prev.savedStates,
+              [prev.currentQuestionIndex]: {
+                selectedOptionIndex: prev.selectedOptionIndex,
+                selectedOptionIndices: prev.selectedOptionIndices,
+                otherText: prev.otherText,
+                otherCursorPosition: prev.otherCursorPosition,
+              },
+            };
+
+            const nextState = savedStates[nextIndex] || {
               selectedOptionIndex: 0,
-              selectedOptionIndices: new Set(),
-              userAnswers: newAnswers,
+              selectedOptionIndices: new Set<number>(),
               otherText: "",
               otherCursorPosition: 0,
             };
+
+            return {
+              ...prev,
+              currentQuestionIndex: nextIndex,
+              ...nextState,
+              userAnswers: newAnswers,
+              savedStates,
+            };
           } else {
+            const finalAnswers = { ...newAnswers };
+            // Also collect from savedStates for any questions that were skipped via Tab
+            for (const [idxStr, s] of Object.entries(prev.savedStates)) {
+              const idx = parseInt(idxStr);
+              const q = questions[idx];
+              if (q && !finalAnswers[q.question]) {
+                const opts = [...q.options, { label: "Other" }];
+                let a = "";
+                if (q.multiSelect) {
+                  const selectedLabels = Array.from(s.selectedOptionIndices)
+                    .filter((i) => i < q.options.length)
+                    .map((i) => q.options[i].label);
+                  const isOtherChecked = s.selectedOptionIndices.has(
+                    opts.length - 1,
+                  );
+                  if (isOtherChecked && s.otherText.trim()) {
+                    selectedLabels.push(s.otherText.trim());
+                  }
+                  a = selectedLabels.join(", ");
+                } else {
+                  if (s.selectedOptionIndex === opts.length - 1) {
+                    a = s.otherText.trim();
+                  } else {
+                    a = opts[s.selectedOptionIndex].label;
+                  }
+                }
+                if (a) finalAnswers[q.question] = a;
+              }
+            }
+
+            // Only submit if all questions have been answered
+            const allAnswered = questions.every(
+              (q) => finalAnswers[q.question],
+            );
+            if (!allAnswered) return prev;
+
             onDecision({
               behavior: "allow",
-              message: JSON.stringify(newAnswers),
+              message: JSON.stringify(finalAnswers),
             });
             return {
               ...prev,
-              userAnswers: newAnswers,
+              userAnswers: finalAnswers,
             };
           }
         });
@@ -194,6 +255,41 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
             prev.selectedOptionIndex + 1,
           ),
         }));
+        return;
+      }
+      if (key.tab) {
+        setQuestionState((prev) => {
+          const direction = key.shift ? -1 : 1;
+          let nextIndex = prev.currentQuestionIndex + direction;
+          if (nextIndex < 0) nextIndex = questions.length - 1;
+          if (nextIndex >= questions.length) nextIndex = 0;
+
+          if (nextIndex === prev.currentQuestionIndex) return prev;
+
+          const savedStates = {
+            ...prev.savedStates,
+            [prev.currentQuestionIndex]: {
+              selectedOptionIndex: prev.selectedOptionIndex,
+              selectedOptionIndices: prev.selectedOptionIndices,
+              otherText: prev.otherText,
+              otherCursorPosition: prev.otherCursorPosition,
+            },
+          };
+
+          const nextState = savedStates[nextIndex] || {
+            selectedOptionIndex: 0,
+            selectedOptionIndices: new Set<number>(),
+            otherText: "",
+            otherCursorPosition: 0,
+          };
+
+          return {
+            ...prev,
+            currentQuestionIndex: nextIndex,
+            ...nextState,
+            savedStates,
+          };
+        });
         return;
       }
 
@@ -321,6 +417,19 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
       return;
     }
 
+    if (key.tab) {
+      const currentIndex = availableOptions.indexOf(state.selectedOption);
+      const direction = key.shift ? -1 : 1;
+      let nextIndex = currentIndex + direction;
+      if (nextIndex < 0) nextIndex = availableOptions.length - 1;
+      if (nextIndex >= availableOptions.length) nextIndex = 0;
+      setState((prev) => ({
+        ...prev,
+        selectedOption: availableOptions[nextIndex],
+      }));
+      return;
+    }
+
     if (input && !key.ctrl && !key.meta && !("alt" in key && key.alt)) {
       setState((prev) => {
         const nextText =
@@ -436,7 +545,7 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
                 Question {questionState.currentQuestionIndex + 1} of{" "}
                 {questions.length} •
                 {currentQuestion.multiSelect ? " Space to toggle •" : ""} Use ↑↓
-                to navigate • Enter to confirm
+                or Tab to navigate • Enter to confirm
               </Text>
             </Box>
           </Box>
@@ -531,7 +640,7 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
             </Box>
           </Box>
           <Box marginTop={1}>
-            <Text dimColor>Use ↑↓ to navigate • ESC to cancel</Text>
+            <Text dimColor>Use ↑↓ or Tab to navigate • ESC to cancel</Text>
           </Box>
         </>
       )}

--- a/packages/code/tests/components/Confirmation.test.tsx
+++ b/packages/code/tests/components/Confirmation.test.tsx
@@ -127,12 +127,12 @@ describe("Confirmation", () => {
 
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "Use ↑↓ to navigate • ESC to cancel",
+          "Use ↑↓ or Tab to navigate • ESC to cancel",
         );
       });
 
       const frame = lastFrame();
-      expect(frame).toContain("Use ↑↓ to navigate • ESC to cancel");
+      expect(frame).toContain("Use ↑↓ or Tab to navigate • ESC to cancel");
     });
 
     it("should show correct auto-accept text for Bash without repeating command", async () => {
@@ -945,12 +945,12 @@ describe("Confirmation", () => {
 
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "Use ↑↓ to navigate • ESC to cancel",
+          "Use ↑↓ or Tab to navigate • ESC to cancel",
         );
       });
 
       const frame = lastFrame();
-      expect(frame).toContain("Use ↑↓ to navigate • ESC to cancel");
+      expect(frame).toContain("Use ↑↓ or Tab to navigate • ESC to cancel");
       expect(frame).toContain("> Yes, proceed"); // Visual indicator of selection
       expect(frame).toContain("  Yes, and auto-accept edits"); // Visual indicator of non-selection
       expect(frame).toContain("  Type here to tell Wave what to change"); // Visual indicator of non-selection

--- a/packages/code/tests/components/ConfirmationTab.test.tsx
+++ b/packages/code/tests/components/ConfirmationTab.test.tsx
@@ -1,0 +1,408 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { render } from "ink-testing-library";
+import { ConfirmationSelector } from "../../src/components/ConfirmationSelector.js";
+import { stripAnsiColors } from "wave-agent-sdk";
+import type { PermissionDecision } from "wave-agent-sdk";
+
+describe("Confirmation Tab Navigation", () => {
+  let mockOnDecision: Mock<(decision: PermissionDecision) => void>;
+  let mockOnCancel: Mock<() => void>;
+  let mockOnAbort: Mock<() => void>;
+
+  beforeEach(() => {
+    mockOnDecision = vi.fn<(decision: PermissionDecision) => void>();
+    mockOnCancel = vi.fn<() => void>();
+    mockOnAbort = vi.fn<() => void>();
+    vi.clearAllMocks();
+  });
+
+  it("should handle Tab key navigation for normal tools", async () => {
+    const { stdin, lastFrame } = render(
+      <ConfirmationSelector
+        toolName="Edit"
+        onDecision={mockOnDecision}
+        onCancel={mockOnCancel}
+        onAbort={mockOnAbort}
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
+    });
+
+    // Press Tab to go to next option
+    stdin.write("\t");
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain(
+        "> Yes, and auto-accept edits",
+      );
+    });
+
+    // Press Tab again to go to alternative option
+    stdin.write("\t");
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain(
+        "> Type here to tell Wave what to change",
+      );
+    });
+
+    // Press Tab again to cycle back to first option
+    stdin.write("\t");
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
+    });
+  });
+
+  it("should handle Shift+Tab key navigation for normal tools", async () => {
+    const { stdin, lastFrame } = render(
+      <ConfirmationSelector
+        toolName="Edit"
+        onDecision={mockOnDecision}
+        onCancel={mockOnCancel}
+        onAbort={mockOnAbort}
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
+    });
+
+    // Press Shift+Tab to cycle backwards to last option
+    stdin.write("\u001b[Z"); // Shift+Tab
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain(
+        "> Type here to tell Wave what to change",
+      );
+    });
+
+    // Press Shift+Tab again
+    stdin.write("\u001b[Z");
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain(
+        "> Yes, and auto-accept edits",
+      );
+    });
+  });
+
+  it("should handle Tab key navigation for AskUserQuestion (cycling questions)", async () => {
+    const mockQuestions = {
+      questions: [
+        {
+          question: "Question 1",
+          header: "Q1",
+          options: [{ label: "A" }, { label: "B" }],
+        },
+        {
+          question: "Question 2",
+          header: "Q2",
+          options: [{ label: "C" }, { label: "D" }],
+        },
+      ],
+    };
+
+    const { stdin, lastFrame } = render(
+      <ConfirmationSelector
+        toolName="AskUserQuestion"
+        toolInput={mockQuestions as unknown as Record<string, unknown>}
+        onDecision={mockOnDecision}
+        onCancel={mockOnCancel}
+        onAbort={mockOnAbort}
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("Question 1");
+    });
+
+    // Select B
+    stdin.write("\u001b[B");
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("> B");
+    });
+
+    // Press Tab to go to Question 2
+    stdin.write("\t");
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("Question 2");
+    });
+
+    // Press Tab to cycle back to Question 1
+    stdin.write("\t");
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("Question 1");
+    });
+
+    // Verify B is still selected
+    expect(stripAnsiColors(lastFrame() || "")).toContain("> B");
+  });
+
+  it("should preserve 'Other' text when cycling questions", async () => {
+    const mockQuestions = {
+      questions: [
+        {
+          question: "Question 1",
+          header: "Q1",
+          options: [{ label: "A" }],
+        },
+        {
+          question: "Question 2",
+          header: "Q2",
+          options: [{ label: "B" }],
+        },
+      ],
+    };
+
+    const { stdin, lastFrame } = render(
+      <ConfirmationSelector
+        toolName="AskUserQuestion"
+        toolInput={mockQuestions as unknown as Record<string, unknown>}
+        onDecision={mockOnDecision}
+        onCancel={mockOnCancel}
+        onAbort={mockOnAbort}
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("Question 1");
+    });
+
+    // Select Other and type "Custom"
+    stdin.write("\u001b[B"); // Down to Other
+    stdin.write("Custom");
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("Custom");
+    });
+
+    // Tab to Q2
+    stdin.write("\t");
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("Question 2");
+    });
+
+    // Tab back to Q1
+    stdin.write("\t");
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("Question 1");
+    });
+
+    // Verify "Custom" is still there
+    expect(stripAnsiColors(lastFrame() || "")).toContain("Custom");
+  });
+
+  it("should preserve multi-select state when cycling questions", async () => {
+    const mockQuestions = {
+      questions: [
+        {
+          question: "Question 1",
+          header: "Q1",
+          multiSelect: true,
+          options: [{ label: "A" }, { label: "B" }],
+        },
+        {
+          question: "Question 2",
+          header: "Q2",
+          options: [{ label: "C" }],
+        },
+      ],
+    };
+
+    const { stdin, lastFrame } = render(
+      <ConfirmationSelector
+        toolName="AskUserQuestion"
+        toolInput={mockQuestions as unknown as Record<string, unknown>}
+        onDecision={mockOnDecision}
+        onCancel={mockOnCancel}
+        onAbort={mockOnAbort}
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("Question 1");
+    });
+
+    // Toggle A and B
+    stdin.write(" "); // Toggle A
+    stdin.write("\u001b[B"); // Down to B
+    stdin.write(" "); // Toggle B
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("[x] A");
+      expect(stripAnsiColors(lastFrame() || "")).toContain("[x] B");
+    });
+
+    // Tab to Q2
+    stdin.write("\t");
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("Question 2");
+    });
+
+    // Tab back to Q1
+    stdin.write("\t");
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("Question 1");
+    });
+
+    // Verify A and B are still checked
+    expect(stripAnsiColors(lastFrame() || "")).toContain("[x] A");
+    expect(stripAnsiColors(lastFrame() || "")).toContain("[x] B");
+  });
+
+  it("should collect all answers when Enter is pressed on the last question after cycling", async () => {
+    const mockQuestions = {
+      questions: [
+        {
+          question: "Question 1",
+          header: "Q1",
+          options: [{ label: "A" }],
+        },
+        {
+          question: "Question 2",
+          header: "Q2",
+          options: [{ label: "B" }],
+        },
+      ],
+    };
+
+    const { stdin, lastFrame } = render(
+      <ConfirmationSelector
+        toolName="AskUserQuestion"
+        toolInput={mockQuestions as unknown as Record<string, unknown>}
+        onDecision={mockOnDecision}
+        onCancel={mockOnCancel}
+        onAbort={mockOnAbort}
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("Question 1");
+    });
+
+    // Tab to Q2
+    stdin.write("\t");
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("Question 2");
+    });
+
+    // Select B and press Enter
+    stdin.write("\r");
+
+    // Should NOT submit yet because Q1 is unanswered
+    await vi.waitFor(() => {
+      expect(mockOnDecision).not.toHaveBeenCalled();
+    });
+
+    // Tab back to Q1
+    stdin.write("\t");
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("Question 1");
+    });
+
+    // Select A and press Enter
+    stdin.write("\r");
+
+    // Now it should move to Q2 (since Q1 was answered)
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("Question 2");
+    });
+
+    // Press Enter on Q2
+    stdin.write("\r");
+
+    // Now it should submit both
+    await vi.waitFor(() => {
+      expect(mockOnDecision).toHaveBeenCalled();
+    });
+    const call = mockOnDecision.mock.calls[0][0];
+    const message = JSON.parse(call.message!);
+    expect(message["Question 1"]).toBe("A");
+    expect(message["Question 2"]).toBe("B");
+  });
+
+  it("should handle Shift+Tab key navigation for AskUserQuestion (cycling questions)", async () => {
+    const mockQuestions = {
+      questions: [
+        {
+          question: "Question 1",
+          header: "Q1",
+          options: [{ label: "A" }, { label: "B" }],
+        },
+        {
+          question: "Question 2",
+          header: "Q2",
+          options: [{ label: "C" }, { label: "D" }],
+        },
+      ],
+    };
+
+    const { stdin, lastFrame } = render(
+      <ConfirmationSelector
+        toolName="AskUserQuestion"
+        toolInput={mockQuestions as unknown as Record<string, unknown>}
+        onDecision={mockOnDecision}
+        onCancel={mockOnCancel}
+        onAbort={mockOnAbort}
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("Question 1");
+    });
+
+    // Press Shift+Tab to cycle backwards to Question 2
+    stdin.write("\u001b[Z");
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("Question 2");
+    });
+
+    // Press Shift+Tab again to Question 1
+    stdin.write("\u001b[Z");
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("Question 1");
+    });
+  });
+
+  it("should show updated help text", async () => {
+    const { lastFrame } = render(
+      <ConfirmationSelector
+        toolName="Edit"
+        onDecision={mockOnDecision}
+        onCancel={mockOnCancel}
+        onAbort={mockOnAbort}
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain(
+        "Use ↑↓ or Tab to navigate • ESC to cancel",
+      );
+    });
+  });
+
+  it("should show updated help text for AskUserQuestion", async () => {
+    const mockQuestions = {
+      questions: [
+        {
+          question: "What is your favorite color?",
+          header: "Color",
+          options: [{ label: "Red" }, { label: "Blue" }],
+        },
+      ],
+    };
+
+    const { lastFrame } = render(
+      <ConfirmationSelector
+        toolName="AskUserQuestion"
+        toolInput={mockQuestions as unknown as Record<string, unknown>}
+        onDecision={mockOnDecision}
+        onCancel={mockOnCancel}
+        onAbort={mockOnAbort}
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain(
+        "Use ↑↓ or Tab to navigate • Enter to confirm",
+      );
+    });
+  });
+});


### PR DESCRIPTION
This PR adds support for using Tab and Shift+Tab to cycle through options and questions in the confirmation UI.

Key changes:
- Standard tools: Tab/Shift+Tab cycles through available options.
- AskUserQuestion: Tab/Shift+Tab cycles through questions, preserving the state of each question.
- Updated help text to include Tab navigation.
- Added comprehensive tests for the new functionality.