### PR TITLE
feat: add /status command

### DIFF
--- a/packages/code/src/components/CommandSelector.tsx
+++ b/packages/code/src/components/CommandSelector.tsx
@@ -28,6 +28,12 @@ const AVAILABLE_COMMANDS: SlashCommand[] = [
     description: "Show help and key bindings",
     handler: () => {}, // Handler here won't be used, actual processing is in the hook
   },
+  {
+    id: "status",
+    name: "status",
+    description: "Show agent status and configuration",
+    handler: () => {}, // Handler here won't be used, actual processing is in the hook
+  },
 ];
 
 export interface CommandSelectorProps {

--- a/packages/code/src/components/HelpView.tsx
+++ b/packages/code/src/components/HelpView.tsx
@@ -21,6 +21,7 @@ export const HelpView: React.FC<HelpViewProps> = ({ onCancel }) => {
     { key: "Ctrl+B", description: "Background current task" },
     { key: "Ctrl+V", description: "Paste image" },
     { key: "Shift+Tab", description: "Cycle permission mode" },
+    { key: "/status", description: "Show agent status and configuration" },
     {
       key: "Esc",
       description: "Interrupt AI or command / Cancel selector / Close help",

--- a/packages/code/src/components/InputBox.tsx
+++ b/packages/code/src/components/InputBox.tsx
@@ -8,6 +8,7 @@ import { BackgroundTaskManager } from "./BackgroundTaskManager.js";
 import { McpManager } from "./McpManager.js";
 import { RewindCommand } from "./RewindCommand.js";
 import { HelpView } from "./HelpView.js";
+import { StatusCommand } from "./StatusCommand.js";
 import { useInputManager } from "../hooks/useInputManager.js";
 import { useChat } from "../contexts/useChat.js";
 
@@ -88,10 +89,12 @@ export const InputBox: React.FC<InputBoxProps> = ({
     showMcpManager,
     showRewindManager,
     showHelp,
+    showStatusCommand,
     setShowBackgroundTaskManager,
     setShowMcpManager,
     setShowRewindManager,
     setShowHelp,
+    setShowStatusCommand,
     // Permission mode
     permissionMode,
     setPermissionMode,
@@ -172,6 +175,10 @@ export const InputBox: React.FC<InputBoxProps> = ({
     return <HelpView onCancel={() => setShowHelp(false)} />;
   }
 
+  if (showStatusCommand) {
+    return <StatusCommand onCancel={() => setShowStatusCommand(false)} />;
+  }
+
   return (
     <Box flexDirection="column">
       {showFileSelector && (
@@ -219,7 +226,8 @@ export const InputBox: React.FC<InputBoxProps> = ({
       {showBackgroundTaskManager ||
         showMcpManager ||
         showRewindManager ||
-        showHelp || (
+        showHelp ||
+        showStatusCommand || (
           <Box flexDirection="column">
             <Box
               borderStyle="single"

--- a/packages/code/src/components/StatusCommand.tsx
+++ b/packages/code/src/components/StatusCommand.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { Box, Text, useInput } from "ink";
+import { useChat } from "../contexts/useChat.js";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export interface StatusCommandProps {
+  onCancel: () => void;
+}
+
+export const StatusCommand: React.FC<StatusCommandProps> = ({ onCancel }) => {
+  const { sessionId, workingDirectory, getGatewayConfig, getModelConfig } =
+    useChat();
+
+  useInput((_, key) => {
+    if (key.escape) {
+      onCancel();
+    }
+  });
+
+  const gatewayConfig = getGatewayConfig();
+  const modelConfig = getModelConfig();
+
+  let version = "unknown";
+  try {
+    const pkgPath = path.resolve(__dirname, "../../package.json");
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+    version = pkg.version;
+  } catch {
+    // Fallback if package.json cannot be read
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="cyan"
+      borderLeft={false}
+      borderRight={false}
+      paddingX={1}
+    >
+      <Box marginBottom={1}>
+        <Text color="cyan" bold underline>
+          Agent Status
+        </Text>
+      </Box>
+
+      <Box>
+        <Box width={20}>
+          <Text color="yellow">Version:</Text>
+        </Box>
+        <Text color="white">{version}</Text>
+      </Box>
+
+      <Box>
+        <Box width={20}>
+          <Text color="yellow">Session ID:</Text>
+        </Box>
+        <Text color="white">{sessionId}</Text>
+      </Box>
+
+      <Box>
+        <Box width={20}>
+          <Text color="yellow">cwd:</Text>
+        </Box>
+        <Text color="white" wrap="wrap">
+          {workingDirectory}
+        </Text>
+      </Box>
+
+      <Box>
+        <Box width={20}>
+          <Text color="yellow">Wave base URL:</Text>
+        </Box>
+        <Text color="white">{gatewayConfig.baseURL}</Text>
+      </Box>
+
+      <Box>
+        <Box width={20}>
+          <Text color="yellow">Model:</Text>
+        </Box>
+        <Text color="white">{modelConfig.agentModel}</Text>
+      </Box>
+
+      <Box marginTop={1}>
+        <Text dimColor>Esc to cancel</Text>
+      </Box>
+    </Box>
+  );
+};

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -93,6 +93,10 @@ export interface ChatContextType {
   }>;
   wasLastDetailsTooTall: number;
   setWasLastDetailsTooTall: React.Dispatch<React.SetStateAction<number>>;
+  // Status metadata
+  getGatewayConfig: () => import("wave-agent-sdk").GatewayConfig;
+  getModelConfig: () => import("wave-agent-sdk").ModelConfig;
+  workingDirectory: string;
 }
 
 const ChatContext = createContext<ChatContextType | null>(null);
@@ -199,6 +203,9 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
 
   // Rewind state
   const [rewindId, setRewindId] = useState(0);
+
+  // Status metadata state
+  const [workingDirectory, setWorkingDirectory] = useState("");
 
   // Confirmation too tall state
   const [wasLastDetailsTooTall, setWasLastDetailsTooTall] = useState(0);
@@ -336,6 +343,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         setIsCommandRunning(agent.isCommandRunning);
         setIsCompressing(agent.isCompressing);
         setPermissionModeState(agent.getPermissionMode());
+        setWorkingDirectory(agent.workingDirectory);
 
         // Get initial MCP servers state
         const mcpServers = agent.getMcpServers?.() || [];
@@ -545,6 +553,20 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
     return { messages: [], sessionIds: [] };
   }, []);
 
+  const getGatewayConfig = useCallback(() => {
+    if (!agentRef.current) {
+      return { baseURL: "" };
+    }
+    return agentRef.current.getGatewayConfig();
+  }, []);
+
+  const getModelConfig = useCallback(() => {
+    if (!agentRef.current) {
+      return { agentModel: "", fastModel: "" };
+    }
+    return agentRef.current.getModelConfig();
+  }, []);
+
   // Listen for Ctrl+O hotkey to toggle collapse/expand state and ESC to cancel confirmation
   useInput((input, key) => {
     if (key.ctrl && input === "o") {
@@ -621,6 +643,9 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
     getFullMessageThread,
     wasLastDetailsTooTall,
     setWasLastDetailsTooTall,
+    getGatewayConfig,
+    getModelConfig,
+    workingDirectory,
   };
 
   return (

--- a/packages/code/src/contracts/status.ts
+++ b/packages/code/src/contracts/status.ts
@@ -1,0 +1,7 @@
+export interface AgentStatus {
+  version: string;
+  sessionId: string;
+  cwd: string;
+  baseURL: string;
+  model: string;
+}

--- a/packages/code/src/hooks/useInputManager.ts
+++ b/packages/code/src/hooks/useInputManager.ts
@@ -38,6 +38,7 @@ export const useInputManager = (
   const [showMcpManager, setShowMcpManager] = useState(false);
   const [showRewindManager, setShowRewindManager] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
+  const [showStatusCommand, setShowStatusCommand] = useState(false);
   const [permissionMode, setPermissionModeState] =
     useState<PermissionMode>("default");
   const [attachedImages, setAttachedImages] = useState<AttachedImage[]>([]);
@@ -70,6 +71,9 @@ export const useInputManager = (
         },
         onHelpStateChange: (show) => {
           setShowHelp(show);
+        },
+        onStatusCommandStateChange: (show) => {
+          setShowStatusCommand(show);
         },
         onPermissionModeChange: (mode) => {
           setPermissionModeState(mode);
@@ -107,6 +111,9 @@ export const useInputManager = (
         },
         onHelpStateChange: (show) => {
           setShowHelp(show);
+        },
+        onStatusCommandStateChange: (show) => {
+          setShowStatusCommand(show);
         },
         onPermissionModeChange: (mode) => {
           setPermissionModeState(mode);
@@ -268,6 +275,7 @@ export const useInputManager = (
     showMcpManager,
     showRewindManager,
     showHelp,
+    showStatusCommand,
     permissionMode,
     attachedImages,
     isManagerReady,
@@ -315,6 +323,10 @@ export const useInputManager = (
     setShowHelp: useCallback((show: boolean) => {
       managerRef.current?.setShowHelp(show);
       setShowHelp(show);
+    }, []),
+    setShowStatusCommand: useCallback((show: boolean) => {
+      managerRef.current?.setShowStatusCommand(show);
+      setShowStatusCommand(show);
     }, []),
     setPermissionMode: useCallback((mode: PermissionMode) => {
       setPermissionModeState(mode);

--- a/packages/code/src/managers/InputManager.ts
+++ b/packages/code/src/managers/InputManager.ts
@@ -33,6 +33,7 @@ export interface InputManagerCallbacks {
   onMcpManagerStateChange?: (show: boolean) => void;
   onRewindManagerStateChange?: (show: boolean) => void;
   onHelpStateChange?: (show: boolean) => void;
+  onStatusCommandStateChange?: (show: boolean) => void;
   onImagesStateChange?: (images: AttachedImage[]) => void;
   onSendMessage?: (
     content: string,
@@ -86,6 +87,7 @@ export class InputManager {
   private showMcpManager: boolean = false;
   private showRewindManager: boolean = false;
   private showHelp: boolean = false;
+  private showStatusCommand: boolean = false;
 
   // Permission mode state
   private permissionMode: PermissionMode = "default";
@@ -353,6 +355,9 @@ export class InputManager {
             commandExecuted = true;
           } else if (command === "help") {
             this.setShowHelp(true);
+            commandExecuted = true;
+          } else if (command === "status") {
+            this.setShowStatusCommand(true);
             commandExecuted = true;
           }
         }
@@ -667,6 +672,15 @@ export class InputManager {
     this.callbacks.onHelpStateChange?.(show);
   }
 
+  getShowStatusCommand(): boolean {
+    return this.showStatusCommand;
+  }
+
+  setShowStatusCommand(show: boolean): void {
+    this.showStatusCommand = show;
+    this.callbacks.onStatusCommandStateChange?.(show);
+  }
+
   // Permission mode methods
   getPermissionMode(): PermissionMode {
     return this.permissionMode;
@@ -922,7 +936,8 @@ export class InputManager {
       (isLoading || isCommandRunning) &&
       !this.showBackgroundTaskManager &&
       !this.showMcpManager &&
-      !this.showRewindManager
+      !this.showRewindManager &&
+      !this.showStatusCommand
     ) {
       // Unified interrupt for AI message generation and command execution
       this.callbacks.onAbortMessage?.();
@@ -944,15 +959,17 @@ export class InputManager {
       this.showBackgroundTaskManager ||
       this.showMcpManager ||
       this.showRewindManager ||
-      this.showHelp
+      this.showHelp ||
+      this.showStatusCommand
     ) {
       if (
         this.showBackgroundTaskManager ||
         this.showMcpManager ||
         this.showRewindManager ||
-        this.showHelp
+        this.showHelp ||
+        this.showStatusCommand
       ) {
-        // Task manager, MCP manager, Rewind and Help don't need to handle input, handled by component itself
+        // Task manager, MCP manager, Rewind, Help and Status don't need to handle input, handled by component itself
         // Return true to indicate we've "handled" it (by ignoring it) so it doesn't leak to normal input
         return true;
       }

--- a/packages/code/tests/components/StatusCommand.test.tsx
+++ b/packages/code/tests/components/StatusCommand.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "ink-testing-library";
+import { StatusCommand } from "../../src/components/StatusCommand.js";
+import { useChat } from "../../src/contexts/useChat.js";
+import { stripAnsiColors } from "wave-agent-sdk";
+
+vi.mock("../../src/contexts/useChat.js", () => ({
+  useChat: vi.fn(),
+}));
+
+describe("StatusCommand", () => {
+  const mockChatContext = {
+    sessionId: "test-session-id",
+    workingDirectory: "/test/cwd",
+    getGatewayConfig: vi.fn().mockReturnValue({ baseURL: "https://test.api" }),
+    getModelConfig: vi.fn().mockReturnValue({ agentModel: "test-model" }),
+  };
+
+  beforeEach(() => {
+    vi.mocked(useChat).mockReturnValue(
+      mockChatContext as unknown as ReturnType<typeof useChat>,
+    );
+  });
+
+  it("should render status information", () => {
+    const { lastFrame } = render(<StatusCommand onCancel={() => {}} />);
+    const output = stripAnsiColors(lastFrame() || "");
+
+    expect(output).toContain("Agent Status");
+    expect(output).toContain("Version:");
+    expect(output).toContain("Session ID:");
+    expect(output).toContain("test-session-id");
+    expect(output).toContain("cwd:");
+    expect(output).toContain("/test/cwd");
+    expect(output).toContain("Wave base URL:");
+    expect(output).toContain("https://test.api");
+    expect(output).toContain("Model:");
+    expect(output).toContain("test-model");
+  });
+
+  it("should call onCancel when Escape is pressed", async () => {
+    const onCancel = vi.fn();
+    const { stdin } = render(<StatusCommand onCancel={onCancel} />);
+
+    stdin.write("\u001b"); // Escape
+
+    await vi.waitFor(() => {
+      expect(onCancel).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/code/tests/managers/InputManager.status.test.ts
+++ b/packages/code/tests/managers/InputManager.status.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { InputManager } from "../../src/managers/InputManager.js";
+
+describe("InputManager Status Command", () => {
+  it("should handle status command", async () => {
+    const onStatusCommandStateChange = vi.fn();
+    const manager = new InputManager({
+      onStatusCommandStateChange,
+    });
+
+    manager.setInputText("/status");
+    manager.setCursorPosition(7);
+    manager.activateCommandSelector(0);
+
+    manager.handleCommandSelect("status");
+
+    await vi.waitFor(() => {
+      expect(onStatusCommandStateChange).toHaveBeenCalledWith(true);
+    });
+
+    expect(manager.getShowStatusCommand()).toBe(true);
+
+    manager.setShowStatusCommand(false);
+    expect(onStatusCommandStateChange).toHaveBeenCalledWith(false);
+    expect(manager.getShowStatusCommand()).toBe(false);
+  });
+
+  it("should block input when status command is shown", async () => {
+    const manager = new InputManager();
+    manager.setShowStatusCommand(true);
+
+    // handleInput should return true (handled) but not change input
+    const handled = await manager.handleInput(
+      "a",
+      { name: "a" } as unknown as import("ink").Key,
+      [],
+    );
+    expect(handled).toBe(true);
+    expect(manager.getInputText()).toBe("");
+  });
+});

--- a/specs/069-add-status-command/checklists/requirements.md
+++ b/specs/069-add-status-command/checklists/requirements.md
@@ -1,0 +1,31 @@
+# Specification Quality Checklist: Status Command
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-27
+**Feature**: [../spec.md]
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/069-add-status-command/contracts/status.ts
+++ b/specs/069-add-status-command/contracts/status.ts
@@ -1,0 +1,7 @@
+export interface AgentStatus {
+  version: string;
+  sessionId: string;
+  cwd: string;
+  baseURL: string;
+  model: string;
+}

--- a/specs/069-add-status-command/data-model.md
+++ b/specs/069-add-status-command/data-model.md
@@ -1,0 +1,25 @@
+# Data Model: Status Command
+
+## Entity: AgentStatus
+
+Represents the current state and configuration of the Wave Agent.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | `string` | The version of the `wave-code` package. |
+| `sessionId` | `string` | The unique ID of the current session. |
+| `cwd` | `string` | The absolute path of the current working directory. |
+| `baseURL` | `string` | The Wave base URL configured for the agent. |
+| `model` | `string` | The name of the active AI model. |
+
+## Validation Rules
+- `version` must be a valid semver string.
+- `sessionId` must be a valid UUID.
+- `cwd` must be an absolute path.
+- `baseURL` must be a valid URL.
+- `model` must be a non-empty string.
+
+## State Transitions
+- **Hidden**: The default state.
+- **Visible**: Triggered by the `/status` command.
+- **Dismissed**: Triggered by the `Escape` key, returning to the previous state.

--- a/specs/069-add-status-command/plan.md
+++ b/specs/069-add-status-command/plan.md
@@ -1,0 +1,89 @@
+# Implementation Plan: Status Command
+
+**Branch**: `069-add-status-command` | **Date**: 2026-02-27 | **Spec**: [./spec.md](./spec.md)
+**Input**: Feature specification from `./spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+The goal is to add a `/status` command to the Wave CLI that displays current session metadata, including the version, session ID, current working directory, Wave base URL, and active AI model. This will be implemented as a local CLI command that triggers a React Ink overlay component.
+
+Research has confirmed that all necessary metadata is accessible from the `Agent` instance, and the UI can be implemented using the existing overlay pattern in `packages/code`.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, Node.js 22+
+**Primary Dependencies**: React 19, Ink 6, wave-agent-sdk
+**Storage**: N/A (reads from memory and configuration)
+**Testing**: Vitest
+**Target Platform**: CLI (Linux/macOS/Windows)
+**Project Type**: Monorepo (packages/code, packages/agent-sdk)
+**Performance Goals**: Instant display of status information (<100ms)
+**Constraints**: Must handle long paths gracefully; must be dismissible with Esc; input box must be hidden when status is shown.
+**Scale/Scope**: Small feature addition to the CLI interface.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] **Package-First Architecture**: Feature is split between `agent-sdk` (data retrieval) and `code` (UI).
+- [x] **TypeScript Excellence**: Strict typing will be used for all new components and logic.
+- [x] **Test Alignment**: Unit tests for the new component and integration tests for command handling.
+- [x] **Build Dependencies**: `agent-sdk` will be built before testing `code`.
+- [x] **Documentation Minimalism**: No extra markdown docs except those required by the spec.
+- [x] **Quality Gates**: `pnpm run type-check`, `pnpm run lint`, and `pnpm test:coverage` will be run.
+- [x] **Source Code Structure**: Follows existing patterns in `packages/code/src/components` and `packages/code/src/managers`.
+- [x] **Test-Driven Development**: Tests will be written alongside implementation.
+- [x] **Type System Evolution**: Existing types will be extended if necessary.
+- [x] **Data Model Minimalism**: Only essential session metadata will be displayed.
+- [x] **Planning and Task Delegation**: General-purpose agent used for planning; subagents for implementation.
+- [x] **User-Centric Quickstart**: `quickstart.md` will focus on how to use the `/status` command.
+
+**REQUIRED**: All planning phases MUST be performed using the **general-purpose agent** to ensure technical accuracy and codebase alignment. Always use general-purpose agent for every phrase during planning. All changes MUST maintain or improve test coverage; run `pnpm test:coverage` to validate.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/069-add-status-command/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output - USER FACING
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output
+```
+
+**Note on quickstart.md**: This file MUST be written for the end-user (CLI/SDK user). Do not include developer-specific setup instructions. Focus on "How to use this feature".
+
+### Source Code (repository root)
+
+```
+packages/
+├── agent-sdk/
+│   └── src/
+│       └── services/
+│           └── session.ts       # Session metadata retrieval
+└── code/
+    └── src/
+        ├── components/
+        │   └── StatusCommand.tsx # New UI component
+        ├── managers/
+        │   └── InputManager.ts   # Command handling logic
+        └── hooks/
+            └── useInputManager.ts # State management
+```
+
+**Structure Decision**: Monorepo structure with UI in `packages/code` and core logic in `packages/agent-sdk`.
+
+## Complexity Tracking
+
+*Fill ONLY if Constitution Check has violations that must be justified*
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |
+

--- a/specs/069-add-status-command/quickstart.md
+++ b/specs/069-add-status-command/quickstart.md
@@ -1,0 +1,33 @@
+# Quickstart: Status Command
+
+The `/status` command allows you to quickly view the current configuration and session details of the Wave Agent.
+
+## Usage
+
+1. Start the Wave CLI:
+   ```bash
+   wave
+   ```
+
+2. Type `/status` in the input box and press `Enter`.
+
+3. A status overlay will appear showing:
+   - **Version**: The current version of the Wave CLI.
+   - **Session ID**: The unique identifier for your current session.
+   - **cwd**: The current working directory the agent is operating in.
+   - **Wave base URL**: The API endpoint the agent is communicating with.
+   - **Model**: The AI model currently being used.
+
+4. Press `Esc` to dismiss the status overlay and return to your chat.
+
+## Example Output
+
+```text
+Version: 0.7.1
+Session ID: 083e4351-f98e-4ee2-afce-ec9b689473e3
+cwd: /home/user/project
+Wave base URL: https://aigw.netease.com
+Model: gemini-3-flash
+
+Esc to cancel
+```

--- a/specs/069-add-status-command/research.md
+++ b/specs/069-add-status-command/research.md
@@ -1,0 +1,44 @@
+# Research: Status Command Implementation
+
+## Decision: Implementation Strategy for /status
+
+The `/status` command will be implemented as a local CLI command in `packages/code`. It will trigger a React Ink overlay component that displays session metadata retrieved from the `Agent` instance via `ChatContext`.
+
+### Rationale
+- **Local Command**: Implementing it as a local command (handled in `InputManager.ts`) ensures it works even if the AI is busy or offline, and provides instant feedback.
+- **Overlay UI**: Using an overlay (similar to `HelpView`) provides a clean, non-intrusive way to view status without cluttering the chat history. The input box will be hidden when the status view is active to focus the user's attention.
+- **Context Integration**: Exposing status data through `ChatContext` follows the existing pattern for sharing agent state with UI components.
+
+### Findings
+
+#### 1. Version Retrieval
+The version will be read from `packages/code/package.json`. Since we are using ESM and TypeScript, we can import it directly if configured, or use `fs` to read it at runtime. Given the build process, reading it from `package.json` at the root of the `code` package is most reliable.
+
+#### 2. Session Metadata
+- **Session ID**: Available via `agent.sessionId`.
+- **CWD**: Available via `agent.workingDirectory`.
+- **Base URL**: Available via `agent.getGatewayConfig().baseURL`.
+- **Model**: Available via `agent.getModelConfig().agentModel`.
+
+#### 3. UI Implementation
+- **Component**: `StatusCommand.tsx` in `packages/code/src/components`.
+- **Template**: `HelpView.tsx` or `BackgroundTaskManager.tsx`.
+- **Styling**: Use `Box` with `borderStyle="round"`, `borderLeft={false}`, `borderRight={false}` as per constitution/memory.
+- **Dismissal**: Use `useInput` hook to listen for `Escape` key.
+
+### Alternatives Considered
+
+#### 1. Agent-side Slash Command
+- **Pros**: Could be implemented once in `agent-sdk` and work across different frontends.
+- **Cons**: Would add a message to the chat history (unless specially handled), and might be slower as it goes through the agent's command dispatcher.
+- **Decision**: Rejected in favor of local CLI command for better UX and "instant" feel.
+
+#### 2. Persistent Status Bar
+- **Pros**: Always visible.
+- **Cons**: Takes up vertical space in the terminal, which is limited.
+- **Decision**: Rejected as the user specifically asked for a `/status` command.
+
+## NEEDS CLARIFICATION Resolved
+- **Version**: Use `packages/code/package.json`.
+- **Metadata Source**: All data is accessible from the `Agent` instance.
+- **UI Pattern**: Use the existing overlay pattern.

--- a/specs/069-add-status-command/spec.md
+++ b/specs/069-add-status-command/spec.md
@@ -1,0 +1,53 @@
+# Feature Specification: Status Command
+
+**Feature Branch**: `069-add-status-command`  
+**Created**: 2026-02-27  
+**Status**: Draft  
+**Input**: User description: "add /status to show sth like:   Version: 2.1.62
+  Session ID: 083e4351-f98e-4ee2-afce-ec9b689473e3
+  cwd: /home/liuyiqi/personal-projects/wave-agent
+  Wave base URL: https://aigw.netease.com
+  Model: xxx
+
+  Esc to cancel"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - View Agent Status (Priority: P1)
+
+As a user, I want to quickly see the current configuration and session details of the agent so that I can verify the environment I am working in.
+
+**Why this priority**: This is the core functionality requested. It provides transparency into the agent's state and helps in troubleshooting or verifying settings.
+
+**Independent Test**: Can be fully tested by typing `/status` in the CLI and verifying that the displayed information (Version, Session ID, cwd, Wave base URL, Model) is accurate and formatted correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** the agent is in an interactive state, **When** the user types `/status`, **Then** the agent displays a status overlay containing the version, session ID, current working directory, Wave base URL, and current model, and the input box is hidden.
+2. **Given** the status information is displayed, **When** the user presses `Esc`, **Then** the status display is dismissed, the input box is restored, and the user returns to the previous interactive state.
+
+---
+
+### Edge Cases
+
+- **Missing Information**: If certain metadata (like the model name) is not yet initialized or available, the system should display a placeholder (e.g., "Unknown" or "Not set") rather than crashing or showing blank space.
+- **Long Paths**: If the current working directory path is extremely long, the display should handle it gracefully (e.g., by wrapping or truncating with an ellipsis) to avoid breaking the UI layout.
+- **Rapid Invocation**: If the user types `/status` multiple times rapidly, the system should handle it without creating multiple overlapping status views.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST recognize the `/status` command in the interactive CLI.
+- **FR-002**: System MUST display the current version of the agent software.
+- **FR-003**: System MUST display the unique Session ID associated with the current execution.
+- **FR-004**: System MUST display the absolute path of the current working directory (cwd).
+- **FR-005**: System MUST display the Wave base URL configured for the agent.
+- **FR-006**: System MUST display the name of the AI model currently active in the session.
+- **FR-007**: System MUST display a hint "Esc to cancel" to inform the user how to dismiss the view.
+- **FR-008**: System MUST dismiss the status view and return to the previous state when the `Esc` key is pressed.
+- **FR-009**: System MUST hide the input box when the status view is active.
+
+### Key Entities
+
+- **Session Metadata**: A collection of attributes describing the current state and configuration of the agent (Version, Session ID, CWD, Base URL, Model).

--- a/specs/069-add-status-command/tasks.md
+++ b/specs/069-add-status-command/tasks.md
@@ -1,0 +1,53 @@
+# Tasks: Status Command
+
+**Feature**: Status Command
+**Branch**: `069-add-status-command`
+**Status**: Draft
+
+## Phase 1: Setup
+
+- [X] T001 Verify project structure and design documents in `specs/069-add-status-command/`
+
+## Phase 2: Foundational
+
+- [X] T002 [P] Expose `getGatewayConfig` and `getModelConfig` in `packages/agent-sdk/src/agent.ts` if not already public
+- [X] T003 [P] Update `ChatContextType` to include `getGatewayConfig`, `getModelConfig`, and `workingDirectory` in `packages/code/src/contexts/useChat.tsx`
+- [X] T004 Update `ChatProvider` to provide the new metadata from the agent in `packages/code/src/contexts/useChat.tsx`
+
+## Phase 3: User Story 1 - View Agent Status (Priority: P1)
+
+**Goal**: Implement the `/status` command and its overlay UI.
+**Independent Test**: Type `/status` in the CLI. Verify the overlay appears with correct metadata and the input box is hidden. Press `Esc` to dismiss.
+
+- [X] T005 [P] [US1] Create `AgentStatus` interface in `packages/code/src/contracts/status.ts` (as defined in design)
+- [X] T006 [P] [US1] Implement `StatusCommand.tsx` overlay component in `packages/code/src/components/StatusCommand.tsx`
+- [X] T007 [US1] Add `showStatusCommand` state and `setShowStatusCommand` to `InputManager` in `packages/code/src/managers/InputManager.ts`
+- [X] T008 [US1] Update `handleCommandSelect` in `packages/code/src/managers/InputManager.ts` to handle the "status" command
+- [X] T009 [US1] Update `useInputManager` hook to expose `showStatusCommand` in `packages/code/src/hooks/useInputManager.ts`
+- [X] T010 [US1] Integrate `StatusCommand` into `packages/code/src/components/InputBox.tsx` and ensure it conditionally renders
+- [X] T011 [US1] Implement logic to hide the input box when `showStatusCommand` is true in `packages/code/src/components/InputBox.tsx`
+- [X] T012 [US1] Add unit tests for `StatusCommand.tsx` in `packages/code/tests/components/StatusCommand.test.tsx`
+- [X] T013 [US1] Add integration tests for `/status` command handling in `packages/code/tests/managers/InputManager.status.test.ts`
+
+## Phase 4: Polish & Cross-cutting Concerns
+
+- [X] T014 [P] Ensure long paths in `cwd` are handled gracefully (e.g., wrapping or truncation) in `packages/code/src/components/StatusCommand.tsx`
+- [X] T015 Run `pnpm run type-check` and `pnpm run lint` across the monorepo
+- [X] T016 Run `pnpm test:coverage` and ensure coverage is maintained or improved
+
+## Dependencies
+
+- Phase 2 must be completed before Phase 3.
+- T006, T007, T008 can be worked on in parallel.
+- T010 depends on T006 and T009.
+
+## Parallel Execution Examples
+
+- **User Story 1**:
+  - Developer A: T006 (UI Component)
+  - Developer B: T007, T008, T009 (Command Logic)
+
+## Implementation Strategy
+
+- **MVP**: Implement the basic `/status` command that shows the overlay with hardcoded or partial data to verify the UI flow.
+- **Incremental**: Connect the real metadata from `agent-sdk` and refine the UI styling and edge case handling.


### PR DESCRIPTION
Implements /status command to display session metadata (version, session ID, cwd, base URL, and active model) in an overlay.