### PR TITLE
feat: call process.chdir to worktree in CLI

### DIFF
--- a/packages/code/src/cli.tsx
+++ b/packages/code/src/cli.tsx
@@ -59,6 +59,7 @@ export async function startCli(options: CliOptions): Promise<void> {
 
     // Cleanup worktree if requested
     if (shouldRemoveWorktree && worktreeSession) {
+      process.chdir(worktreeSession.repoRoot);
       removeWorktree(worktreeSession);
     }
 

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -260,6 +260,10 @@ export async function main() {
 
     const workdir = worktreeSession?.path || originalCwd;
 
+    if (worktreeSession) {
+      process.chdir(workdir);
+    }
+
     // Handle restore session command
     if (
       argv.restore === "" ||

--- a/packages/code/tests/cli.test.tsx
+++ b/packages/code/tests/cli.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { startCli } from "../src/cli.js";
+import { render } from "ink";
+import { removeWorktree } from "../src/utils/worktree.js";
+
+vi.mock("ink", () => ({
+  render: vi.fn().mockReturnValue({
+    unmount: vi.fn(),
+    waitUntilExit: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock("../src/utils/worktree.js", () => ({
+  removeWorktree: vi.fn(),
+}));
+
+vi.mock("../src/utils/logger.js", () => ({
+  cleanupLogs: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("startCli", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should call process.chdir to repoRoot before removing worktree", async () => {
+    const chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+
+    const worktreeSession = {
+      name: "test",
+      path: "/repo/root/.wave/worktrees/test",
+      branch: "worktree-test",
+      repoRoot: "/repo/root",
+      hasUncommittedChanges: false,
+      hasNewCommits: false,
+      isNew: true,
+    };
+
+    // Mock render to call onExit with true
+    vi.mocked(render).mockImplementationOnce((element: unknown) => {
+      const { onExit } = (
+        element as { props: { onExit: (shouldRemove: boolean) => void } }
+      ).props;
+      return {
+        unmount: vi.fn(),
+        waitUntilExit: async () => {
+          onExit(true);
+        },
+      } as unknown as ReturnType<typeof render>;
+    });
+
+    await expect(startCli({ worktreeSession })).rejects.toThrow(
+      "process.exit called",
+    );
+
+    expect(chdirSpy).toHaveBeenCalledWith("/repo/root");
+    expect(removeWorktree).toHaveBeenCalledWith(worktreeSession);
+
+    chdirSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});

--- a/packages/code/tests/index.test.ts
+++ b/packages/code/tests/index.test.ts
@@ -290,6 +290,7 @@ describe("main", () => {
 
   it("should handle --worktree argument", async () => {
     process.argv = ["node", "index.js", "--worktree", "test-worktree"];
+    const chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
     await main();
     expect(cli.startCli).toHaveBeenCalledWith({
       restoreSessionId: undefined,
@@ -300,6 +301,10 @@ describe("main", () => {
       worktreeSession: expect.objectContaining({ name: "test-worktree" }),
       workdir: expect.stringContaining("test-worktree"),
     });
+    expect(chdirSpy).toHaveBeenCalledWith(
+      expect.stringContaining("test-worktree"),
+    );
+    chdirSpy.mockRestore();
   });
 
   describe("plugin commands", () => {

--- a/specs/068-cli-worktree-support/spec.md
+++ b/specs/068-cli-worktree-support/spec.md
@@ -117,7 +117,7 @@ As a developer, I want the CLI to automatically clean up the worktree if I haven
 - **FR-002**: System MUST generate a unique feature name (e.g., `adjective-adjective-noun`) if `<feat-name>` is not provided.
 - **FR-003**: System MUST create a git worktree at `.wave/worktrees/<feat-name>` (absolute path) branching from the default remote branch (identified via `git symbolic-ref refs/remotes/origin/HEAD`).
 - **FR-004**: System MUST name the worktree branch `worktree-<feat-name>`.
-- **FR-005**: System MUST pass the worktree path as the working directory to the agent and relevant utilities, instead of using `process.chdir()`, to avoid issues with relative paths and other side effects.
+- **FR-005**: System MUST call `process.chdir()` to the worktree path to ensure the process's working directory matches the worktree, facilitating tmux and other window-copying features.
 - **FR-006**: System MUST detect uncommitted changes (staged or unstaged, identified via `git status --porcelain`) in the worktree upon exit.
 - **FR-007**: System MUST detect commits made in the worktree that are not in the default remote branch (identified via `git log @{u}..HEAD`) upon exit.
 - **FR-008**: System MUST display an interactive prompt if uncommitted changes or new commits exist upon exit.


### PR DESCRIPTION
Update CLI to call process.chdir to the worktree directory when a worktree is used, facilitating tmux window copying and other features that rely on the process's current working directory.