### PR TITLE
refactor: rename SessionTasks to Tasks and onTasksChange to onBackgroundTasksChange

### DIFF
--- a/packages/agent-sdk/examples/backgrounding-demo.ts
+++ b/packages/agent-sdk/examples/backgrounding-demo.ts
@@ -47,7 +47,7 @@ async function demonstrateBackgrounding(): Promise<void> {
             );
           }
         },
-        onTasksChange: (tasks) => {
+        onBackgroundTasksChange: (tasks) => {
           const runningTasks = tasks.filter((t) => t.status === "running");
           const completedTasks = tasks.filter((t) => t.status === "completed");
           if (runningTasks.length > 0 || completedTasks.length > 0) {

--- a/packages/agent-sdk/examples/subagent-execution.ts
+++ b/packages/agent-sdk/examples/subagent-execution.ts
@@ -67,7 +67,7 @@ This file will be analyzed by the file-analyzer subagent to test the real execut
   agent = await Agent.create({
     workdir: tempDir,
     callbacks: {
-      onTasksChange: (tasks) => {
+      onBackgroundTasksChange: (tasks) => {
         console.log(`📝 Tasks updated! Total: ${tasks.length}`);
         tasks.forEach((task) => {
           console.log(

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -118,8 +118,8 @@ export interface AgentCallbacks
     BackgroundTaskManagerCallbacks,
     McpManagerCallbacks,
     SubagentManagerCallbacks {
-  onTasksChange?: (tasks: BackgroundTask[]) => void;
-  onSessionTasksChange?: (tasks: import("./types/tasks.js").Task[]) => void;
+  onBackgroundTasksChange?: (tasks: BackgroundTask[]) => void;
+  onTasksChange?: (tasks: import("./types/tasks.js").Task[]) => void;
   onPermissionModeChange?: (mode: PermissionMode) => void;
   onSubagentLatestTotalTokensChange?: (
     subagentId: string,
@@ -228,11 +228,11 @@ export class Agent {
       onSessionIdChange: () => {
         this.taskManager.setTaskListId(this.messageManager.getRootSessionId());
       },
-      onSessionTasksChange: (tasks) => {
-        this.options.callbacks?.onSessionTasksChange?.(tasks);
-      },
       onTasksChange: (tasks) => {
         this.options.callbacks?.onTasksChange?.(tasks);
+      },
+      onBackgroundTasksChange: (tasks) => {
+        this.options.callbacks?.onBackgroundTasksChange?.(tasks);
       },
       onPermissionModeChange: (mode) => {
         this.options.callbacks?.onPermissionModeChange?.(mode);
@@ -643,7 +643,7 @@ export class Agent {
 
         // After session is initialized, load tasks for the session
         const tasks = await this.taskManager.listTasks();
-        this.options.callbacks?.onSessionTasksChange?.(tasks);
+        this.options.callbacks?.onTasksChange?.(tasks);
       }
     }
   }
@@ -693,7 +693,7 @@ export class Agent {
 
     // 7. Load tasks for the restored session
     const tasks = await this.taskManager.listTasks();
-    this.options.callbacks?.onSessionTasksChange?.(tasks);
+    this.options.callbacks?.onTasksChange?.(tasks);
   }
 
   public abortAIMessage(): void {
@@ -979,7 +979,9 @@ export class Agent {
   public async truncateHistory(index: number): Promise<void> {
     await this.messageManager.truncateHistory(index, this.reversionManager);
     // After truncating history, the task list might have changed, so refresh it.
-    await this.taskManager.refreshTasks();
+    // We explicitly load tasks and trigger the callback to ensure UI updates immediately and in order.
+    const tasks = await this.taskManager.listTasks();
+    this.options.callbacks?.onTasksChange?.(tasks);
   }
 
   /**

--- a/packages/agent-sdk/src/managers/backgroundTaskManager.ts
+++ b/packages/agent-sdk/src/managers/backgroundTaskManager.ts
@@ -5,7 +5,7 @@ import { logger } from "../utils/globalLogger.js";
 import { Container } from "../utils/container.js";
 
 export interface BackgroundTaskManagerCallbacks {
-  onTasksChange?: (tasks: BackgroundTask[]) => void;
+  onBackgroundTasksChange?: (tasks: BackgroundTask[]) => void;
 }
 
 export interface BackgroundTaskManagerOptions {
@@ -28,7 +28,7 @@ export class BackgroundTaskManager {
   }
 
   private notifyTasksChange(): void {
-    this.callbacks.onTasksChange?.(Array.from(this.tasks.values()));
+    this.callbacks.onBackgroundTasksChange?.(Array.from(this.tasks.values()));
   }
 
   public generateId(): string {

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -42,8 +42,8 @@ export interface AgentContainerSetupOptions {
 
   // Callbacks to Agent methods
   onSessionIdChange: (sessionId: string) => void;
-  onTasksChange: (tasks: BackgroundTask[]) => void;
-  onSessionTasksChange: (tasks: Task[]) => void;
+  onBackgroundTasksChange: (tasks: BackgroundTask[]) => void;
+  onTasksChange: (tasks: Task[]) => void;
   onPermissionModeChange: (mode: PermissionMode) => void;
   handlePlanModeTransition: (mode: PermissionMode) => void;
   setPermissionMode: (mode: PermissionMode) => void;
@@ -67,8 +67,8 @@ export function setupAgentContainer(
     systemPrompt,
     stream,
     onSessionIdChange,
+    onBackgroundTasksChange,
     onTasksChange,
-    onSessionTasksChange,
     onPermissionModeChange,
     handlePlanModeTransition,
     setPermissionMode,
@@ -111,15 +111,15 @@ export function setupAgentContainer(
   container.register("TaskManager", taskManager);
   taskManager.on("tasksChange", async () => {
     const tasks = await taskManager.listTasks();
-    onSessionTasksChange(tasks);
+    onTasksChange(tasks);
   });
 
   const backgroundTaskManager = new BackgroundTaskManager(container, {
     callbacks: {
       ...callbacks,
-      onTasksChange: (tasks) => {
-        onTasksChange(tasks);
-        callbacks.onTasksChange?.(tasks);
+      onBackgroundTasksChange: (tasks) => {
+        onBackgroundTasksChange(tasks);
+        callbacks.onBackgroundTasksChange?.(tasks);
       },
     },
     workdir,

--- a/packages/agent-sdk/tests/agent/agent.taskSessionRestore.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.taskSessionRestore.test.ts
@@ -76,7 +76,7 @@ describe("Agent - Task Session Restoration", () => {
 
     mockHandleSessionRestoration.mockResolvedValue(sessionData);
 
-    const onSessionTasksChange = vi.fn();
+    const onTasksChange = vi.fn();
 
     const agent = await Agent.create({
       apiKey: "test-key",
@@ -84,12 +84,12 @@ describe("Agent - Task Session Restoration", () => {
       restoreSessionId: sessionId,
       workdir: testWorkdir,
       callbacks: {
-        onSessionTasksChange,
+        onTasksChange,
       },
     });
 
     // Verify tasks were fetched and callback was called
-    expect(onSessionTasksChange).toHaveBeenCalledWith(
+    expect(onTasksChange).toHaveBeenCalledWith(
       expect.arrayContaining([
         expect.objectContaining({
           id: "task-1",
@@ -130,24 +130,24 @@ describe("Agent - Task Session Restoration", () => {
       },
     });
 
-    const onSessionTasksChange = vi.fn();
+    const onTasksChange = vi.fn();
 
     const agent = await Agent.create({
       apiKey: "test-key",
       baseURL: "https://test.com",
       workdir: testWorkdir,
       callbacks: {
-        onSessionTasksChange,
+        onTasksChange,
       },
     });
 
     // Clear initial call from Agent.create
-    onSessionTasksChange.mockClear();
+    onTasksChange.mockClear();
 
     await agent.restoreSession(targetSessionId);
 
     // Verify tasks were fetched and callback was called for the target session
-    expect(onSessionTasksChange).toHaveBeenCalledWith(
+    expect(onTasksChange).toHaveBeenCalledWith(
       expect.arrayContaining([
         expect.objectContaining({
           id: "task-1",

--- a/packages/agent-sdk/tests/managers/backgroundTaskManager.test.ts
+++ b/packages/agent-sdk/tests/managers/backgroundTaskManager.test.ts
@@ -5,10 +5,12 @@ import { Container } from "../../src/utils/container.js";
 
 describe("BackgroundTaskManager", () => {
   let manager: BackgroundTaskManager;
-  let mockCallbacks: { onTasksChange: (tasks: BackgroundTask[]) => void };
+  let mockCallbacks: {
+    onBackgroundTasksChange: (tasks: BackgroundTask[]) => void;
+  };
 
   beforeEach(() => {
-    mockCallbacks = { onTasksChange: vi.fn() };
+    mockCallbacks = { onBackgroundTasksChange: vi.fn() };
     const container = new Container();
     manager = new BackgroundTaskManager(container, {
       callbacks: mockCallbacks,
@@ -35,7 +37,7 @@ describe("BackgroundTaskManager", () => {
     manager.addTask(task);
     expect(manager.getTask("task_1")).toEqual(task);
     expect(manager.getAllTasks()).toContain(task);
-    expect(mockCallbacks.onTasksChange).toHaveBeenCalledWith([task]);
+    expect(mockCallbacks.onBackgroundTasksChange).toHaveBeenCalledWith([task]);
   });
 
   it("should start a shell task", async () => {
@@ -88,7 +90,7 @@ describe("BackgroundTaskManager", () => {
     manager.addTask(task);
     manager.cleanup();
     expect(manager.getAllTasks().length).toBe(0);
-    expect(mockCallbacks.onTasksChange).toHaveBeenCalled();
+    expect(mockCallbacks.onBackgroundTasksChange).toHaveBeenCalled();
   });
 
   it("should handle invalid regex filter", () => {

--- a/packages/agent-sdk/tests/rewindTaskListSync.test.ts
+++ b/packages/agent-sdk/tests/rewindTaskListSync.test.ts
@@ -3,6 +3,7 @@ import { TaskManager } from "../src/services/taskManager.js";
 import { Agent } from "../src/agent.js";
 import { MessageManager } from "../src/managers/messageManager.js";
 import { Container } from "../src/utils/container.js";
+import { Task } from "../src/types/tasks.js";
 
 // Mock dependencies
 vi.mock("fs", () => ({
@@ -57,31 +58,34 @@ describe("Rewind Task List Sync", () => {
   });
 
   describe("Agent.truncateHistory", () => {
-    it("should call taskManager.refreshTasks after history truncation", async () => {
+    it("should call onTasksChange after history truncation", async () => {
       // We need to mock MessageManager.prototype.truncateHistory to avoid complex setup
       const truncateHistorySpy = vi
         .spyOn(MessageManager.prototype, "truncateHistory")
         .mockResolvedValue(undefined);
 
-      // Create agent instance
-      // Note: Agent.create is async and does a lot of initialization.
-      // For this test, we can try to mock the necessary parts or use a simplified approach.
+      const onTasksChangeSpy = vi.fn();
 
+      // Create agent instance
       const agent = await Agent.create({
         apiKey: "test-key",
         workdir: "/test/workdir",
+        callbacks: {
+          onTasksChange: onTasksChangeSpy,
+        },
       });
 
-      // Spy on taskManager.refreshTasks
-      const refreshTasksSpy = vi.spyOn(
+      // Mock listTasks to return some tasks
+      const mockTasks = [{ id: "1", subject: "test", status: "pending" }];
+      vi.spyOn(
         (agent as unknown as { taskManager: TaskManager }).taskManager,
-        "refreshTasks",
-      );
+        "listTasks",
+      ).mockResolvedValue(mockTasks as unknown as Task[]);
 
       await agent.truncateHistory(0);
 
       expect(truncateHistorySpy).toHaveBeenCalledWith(0, expect.anything());
-      expect(refreshTasksSpy).toHaveBeenCalled();
+      expect(onTasksChangeSpy).toHaveBeenCalledWith(mockTasks);
     });
   });
 });

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -51,8 +51,8 @@ export interface ChatContextType {
   disconnectMcpServer: (serverName: string) => Promise<boolean>;
   // Background tasks
   backgroundTasks: BackgroundTask[];
-  // Session tasks
-  sessionTasks: Task[];
+  // Tasks
+  tasks: Task[];
   getBackgroundTaskOutput: (
     taskId: string,
   ) => { stdout: string; stderr: string; status: string } | null;
@@ -152,8 +152,8 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
 
   // Background tasks state
   const [backgroundTasks, setBackgroundTasks] = useState<BackgroundTask[]>([]);
-  // Session tasks state
-  const [sessionTasks, setSessionTasks] = useState<Task[]>([]);
+  // Tasks state
+  const [tasks, setTasks] = useState<Task[]>([]);
 
   // Command state
   const [slashCommands, setSlashCommands] = useState<SlashCommand[]>([]);
@@ -264,11 +264,11 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         onCompressionStateChange: (isCompressingState) => {
           setIsCompressing(isCompressingState);
         },
-        onTasksChange: (tasks) => {
+        onBackgroundTasksChange: (tasks) => {
           setBackgroundTasks([...tasks]);
         },
-        onSessionTasksChange: (tasks) => {
-          setSessionTasks([...tasks]);
+        onTasksChange: (tasks) => {
+          setTasks([...tasks]);
         },
         onSubagentMessagesChange: (subagentId: string, messages: Message[]) => {
           logger.debug("onSubagentMessagesChange", subagentId, messages.length);
@@ -621,7 +621,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
     connectMcpServer,
     disconnectMcpServer,
     backgroundTasks,
-    sessionTasks,
+    tasks,
     getBackgroundTaskOutput,
     stopBackgroundTask,
     slashCommands,

--- a/packages/code/src/hooks/useTasks.ts
+++ b/packages/code/src/hooks/useTasks.ts
@@ -1,6 +1,6 @@
 import { useChat } from "../contexts/useChat.js";
 
 export const useTasks = () => {
-  const { sessionTasks } = useChat();
-  return sessionTasks;
+  const { tasks } = useChat();
+  return tasks;
 };

--- a/packages/code/tests/components/BackgroundTaskManager.test.tsx
+++ b/packages/code/tests/components/BackgroundTaskManager.test.tsx
@@ -102,7 +102,9 @@ describe("BackgroundTaskManager", () => {
 
     const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
     const callbacks = agentCreateArgs.callbacks!;
-    callbacks.onTasksChange!(mockTasks as unknown as BackgroundTask[]);
+    callbacks.onBackgroundTasksChange!(
+      mockTasks as unknown as BackgroundTask[],
+    );
 
     await vi.waitFor(() => {
       const output = lastFrame();
@@ -129,7 +131,9 @@ describe("BackgroundTaskManager", () => {
 
     const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
     const callbacks = agentCreateArgs.callbacks!;
-    callbacks.onTasksChange!(mockTasks as unknown as BackgroundTask[]);
+    callbacks.onBackgroundTasksChange!(
+      mockTasks as unknown as BackgroundTask[],
+    );
 
     await vi.waitFor(() => {
       expect(lastFrame()).toContain("[task-1] shell: ls -la");
@@ -170,7 +174,9 @@ describe("BackgroundTaskManager", () => {
 
     const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
     const callbacks = agentCreateArgs.callbacks!;
-    callbacks.onTasksChange!(mockTasks as unknown as BackgroundTask[]);
+    callbacks.onBackgroundTasksChange!(
+      mockTasks as unknown as BackgroundTask[],
+    );
 
     await vi.waitFor(() => {
       expect(onCancel).not.toHaveBeenCalled();
@@ -198,7 +204,9 @@ describe("BackgroundTaskManager", () => {
 
     const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
     const callbacks = agentCreateArgs.callbacks!;
-    callbacks.onTasksChange!(mockTasks as unknown as BackgroundTask[]);
+    callbacks.onBackgroundTasksChange!(
+      mockTasks as unknown as BackgroundTask[],
+    );
 
     await vi.waitFor(() => {
       expect(lastFrame()).toContain("[task-1] shell: ls -la");
@@ -233,7 +241,9 @@ describe("BackgroundTaskManager", () => {
 
     const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
     const callbacks = agentCreateArgs.callbacks!;
-    callbacks.onTasksChange!(mockTasks as unknown as BackgroundTask[]);
+    callbacks.onBackgroundTasksChange!(
+      mockTasks as unknown as BackgroundTask[],
+    );
 
     await vi.waitFor(() => {
       expect(lastFrame()).toContain("[task-1] shell: ls -la");
@@ -280,7 +290,7 @@ describe("BackgroundTaskManager", () => {
 
     const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
     const callbacks = agentCreateArgs.callbacks!;
-    callbacks.onTasksChange!([] as unknown as BackgroundTask[]);
+    callbacks.onBackgroundTasksChange!([] as unknown as BackgroundTask[]);
 
     await vi.waitFor(() => {
       expect(lastFrame()).toContain("No background tasks found");
@@ -326,7 +336,7 @@ describe("BackgroundTaskManager", () => {
 
     const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
     const callbacks = agentCreateArgs.callbacks!;
-    callbacks.onTasksChange!(
+    callbacks.onBackgroundTasksChange!(
       tasksWithDifferentDurations as unknown as BackgroundTask[],
     );
 
@@ -365,7 +375,9 @@ describe("BackgroundTaskManager", () => {
 
     const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
     const callbacks = agentCreateArgs.callbacks!;
-    callbacks.onTasksChange!(mockTasks as unknown as BackgroundTask[]);
+    callbacks.onBackgroundTasksChange!(
+      mockTasks as unknown as BackgroundTask[],
+    );
 
     await vi.waitFor(() => {
       expect(lastFrame()).toContain("[task-1] shell: ls -la");
@@ -379,7 +391,7 @@ describe("BackgroundTaskManager", () => {
     });
 
     // Simulate task being removed
-    callbacks.onTasksChange!([]);
+    callbacks.onBackgroundTasksChange!([]);
 
     await vi.waitFor(() => {
       expect(lastFrame()).toContain("No background tasks found");
@@ -410,7 +422,9 @@ describe("BackgroundTaskManager", () => {
 
     const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
     const callbacks = agentCreateArgs.callbacks!;
-    callbacks.onTasksChange!(taskNoDesc as unknown as BackgroundTask[]);
+    callbacks.onBackgroundTasksChange!(
+      taskNoDesc as unknown as BackgroundTask[],
+    );
 
     await vi.waitFor(() => {
       expect(lastFrame()).toContain("[task-no-desc] shell");
@@ -433,7 +447,9 @@ describe("BackgroundTaskManager", () => {
 
     const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
     const callbacks = agentCreateArgs.callbacks!;
-    callbacks.onTasksChange!(mockTasks as unknown as BackgroundTask[]);
+    callbacks.onBackgroundTasksChange!(
+      mockTasks as unknown as BackgroundTask[],
+    );
 
     await vi.waitFor(() => {
       expect(lastFrame()).toContain("[task-1]");
@@ -472,7 +488,9 @@ describe("BackgroundTaskManager", () => {
 
     const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
     const callbacks = agentCreateArgs.callbacks!;
-    callbacks.onTasksChange!(mockTasks as unknown as BackgroundTask[]);
+    callbacks.onBackgroundTasksChange!(
+      mockTasks as unknown as BackgroundTask[],
+    );
 
     await vi.waitFor(() => {
       expect(lastFrame()).toContain("[task-1]");

--- a/packages/code/tests/components/ChatInterface.rewind.test.tsx
+++ b/packages/code/tests/components/ChatInterface.rewind.test.tsx
@@ -55,7 +55,7 @@ describe("ChatInterface Rewind Visibility", () => {
       handleConfirmationDecision: vi.fn(),
       handleConfirmationCancel: vi.fn(),
       backgroundCurrentTask: vi.fn(),
-      sessionTasks: [],
+      tasks: [],
       isTaskListVisible: true,
       setIsTaskListVisible: vi.fn(),
       getFullMessageThread: vi
@@ -128,7 +128,7 @@ describe("ChatInterface Rewind Visibility", () => {
       handleConfirmationDecision: vi.fn(),
       handleConfirmationCancel: vi.fn(),
       backgroundCurrentTask: vi.fn(),
-      sessionTasks: [],
+      tasks: [],
       isTaskListVisible: true,
       setIsTaskListVisible: vi.fn(),
       getFullMessageThread: vi

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -189,7 +189,7 @@ describe("ChatProvider", () => {
       expect(lastValue?.isCompressing).toBe(true);
     });
 
-    // Test onTasksChange
+    // Test onBackgroundTasksChange
     const newTasks = [
       {
         id: "task1",
@@ -201,7 +201,7 @@ describe("ChatProvider", () => {
         process: {} as unknown as BackgroundShell["process"],
       },
     ];
-    callbacks.onTasksChange!(newTasks);
+    callbacks.onBackgroundTasksChange!(newTasks);
     await vi.waitFor(() => {
       expect(lastValue?.backgroundTasks).toEqual(newTasks);
     });

--- a/packages/code/tests/hooks/useTasks.test.tsx
+++ b/packages/code/tests/hooks/useTasks.test.tsx
@@ -22,7 +22,7 @@ describe("useTasks", () => {
     return null;
   }
 
-  it("should return sessionTasks from useChat", () => {
+  it("should return tasks from useChat", () => {
     const mockTasks: Task[] = [
       {
         id: "1",
@@ -45,7 +45,7 @@ describe("useTasks", () => {
     ];
 
     vi.mocked(useChat).mockReturnValue({
-      sessionTasks: mockTasks,
+      tasks: mockTasks,
     } as unknown as ReturnType<typeof useChat>);
 
     let lastValue: Task[] | undefined;
@@ -60,7 +60,7 @@ describe("useTasks", () => {
 
   it("should return empty array if no tasks", () => {
     vi.mocked(useChat).mockReturnValue({
-      sessionTasks: [],
+      tasks: [],
     } as unknown as ReturnType<typeof useChat>);
 
     let lastValue: Task[] | undefined;

--- a/packages/code/tests/integration/taskList.test.tsx
+++ b/packages/code/tests/integration/taskList.test.tsx
@@ -71,10 +71,10 @@ describe("TaskList Integration", () => {
   });
 
   it("renders tasks from the agent in ChatInterface", async () => {
-    let onSessionTasksChangeCallback: (tasks: Task[]) => void = () => {};
+    let onTasksChangeCallback: (tasks: Task[]) => void = () => {};
 
     vi.mocked(Agent.create).mockImplementation(async (options) => {
-      onSessionTasksChangeCallback = options.callbacks!.onSessionTasksChange!;
+      onTasksChangeCallback = options.callbacks!.onTasksChange!;
       return mockAgent;
     });
 
@@ -95,7 +95,7 @@ describe("TaskList Integration", () => {
     expect(stripAnsiColors(lastFrame() || "")).not.toContain("TASKS");
 
     // Simulate tasks being added/changed in the agent
-    onSessionTasksChangeCallback(mockTasks);
+    onTasksChangeCallback(mockTasks);
 
     // Verify tasks are rendered
     await vi.waitFor(() => {
@@ -107,10 +107,10 @@ describe("TaskList Integration", () => {
   });
 
   it("updates task list when tasks change", async () => {
-    let onSessionTasksChangeCallback: (tasks: Task[]) => void = () => {};
+    let onTasksChangeCallback: (tasks: Task[]) => void = () => {};
 
     vi.mocked(Agent.create).mockImplementation(async (options) => {
-      onSessionTasksChangeCallback = options.callbacks!.onSessionTasksChange!;
+      onTasksChangeCallback = options.callbacks!.onTasksChange!;
       return mockAgent;
     });
 
@@ -127,19 +127,19 @@ describe("TaskList Integration", () => {
     });
 
     // Add initial task
-    onSessionTasksChangeCallback([mockTasks[0]]);
+    onTasksChangeCallback([mockTasks[0]]);
     await vi.waitFor(() => {
       expect(stripAnsiColors(lastFrame() || "")).toContain("First Task");
     });
 
     // Update task status
-    onSessionTasksChangeCallback([{ ...mockTasks[0], status: "completed" }]);
+    onTasksChangeCallback([{ ...mockTasks[0], status: "completed" }]);
     await vi.waitFor(() => {
       expect(stripAnsiColors(lastFrame() || "")).toContain("✓ First Task");
     });
 
     // Remove all tasks
-    onSessionTasksChangeCallback([]);
+    onTasksChangeCallback([]);
     await vi.waitFor(() => {
       expect(stripAnsiColors(lastFrame() || "")).not.toContain("First Task");
     });


### PR DESCRIPTION
This PR renames SessionTasks to Tasks and onTasksChange to onBackgroundTasksChange for better clarity and consistency across the codebase.