### PR TITLE
feat: append tool count and tokens to Task tool short result on completion

### DIFF
--- a/packages/agent-sdk/src/tools/taskTool.ts
+++ b/packages/agent-sdk/src/tools/taskTool.ts
@@ -2,6 +2,37 @@ import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
 import { EXPLORE_SUBAGENT_TYPE } from "../constants/subagents.js";
 import { TASK_TOOL_NAME } from "../constants/tools.js";
 import type { SubagentConfiguration } from "../utils/subagentParser.js";
+import type { Message } from "../types/index.js";
+
+/**
+ * Helper to count tool blocks in messages
+ */
+function countToolBlocks(messages: Message[]): number {
+  let toolCount = 0;
+  messages.forEach((msg) => {
+    msg.blocks.forEach((block) => {
+      if (block.type === "tool") {
+        toolCount++;
+      }
+    });
+  });
+  return toolCount;
+}
+
+/**
+ * Helper to format tool and token summary
+ */
+function formatToolTokenSummary(toolCount: number, tokens: number): string {
+  if (toolCount === 0) {
+    return "";
+  }
+  let summary = `(${toolCount} tools`;
+  if (tokens > 0) {
+    summary += ` | ${tokens.toLocaleString()} tokens`;
+  }
+  summary += ")";
+  return summary;
+}
 
 /**
  * Task tool plugin for delegating tasks to specialized subagents
@@ -141,15 +172,8 @@ ${subagentList || "No subagents configured"}
           const tokens = instance.messageManager.getlatestTotalTokens();
           const lastTools = instance.lastTools;
 
-          // Count tool blocks in messages
-          let toolCount = 0;
-          messages.forEach((msg) => {
-            msg.blocks.forEach((block) => {
-              if (block.type === "tool") {
-                toolCount++;
-              }
-            });
-          });
+          const toolCount = countToolBlocks(messages);
+          const summary = formatToolTokenSummary(toolCount, tokens);
 
           let shortResult = "";
           if (toolCount > 2) {
@@ -159,11 +183,7 @@ ${subagentList || "No subagents configured"}
             shortResult += `${lastTools.join(", ")} `;
           }
 
-          shortResult += `(${toolCount} tools`;
-          if (tokens > 0) {
-            shortResult += ` | ${tokens.toLocaleString()} tokens`;
-          }
-          shortResult += ")";
+          shortResult += summary;
 
           context.onShortResultUpdate?.(shortResult);
         },
@@ -214,10 +234,15 @@ ${subagentList || "No subagents configured"}
         // Cleanup subagent instance after task completion
         subagentManager.cleanupInstance(instance.subagentId);
 
+        const messages = instance.messageManager.getMessages();
+        const tokens = instance.messageManager.getlatestTotalTokens();
+        const toolCount = countToolBlocks(messages);
+        const summary = formatToolTokenSummary(toolCount, tokens);
+
         return {
           success: true,
           content: result,
-          shortResult: `Task completed by ${configuration.name}`,
+          shortResult: `Task completed${summary ? ` ${summary}` : ""}`,
         };
       } finally {
         if (!run_in_background && context.foregroundTaskManager) {

--- a/packages/agent-sdk/tests/integration/taskTool.builtin.test.ts
+++ b/packages/agent-sdk/tests/integration/taskTool.builtin.test.ts
@@ -140,7 +140,7 @@ describe("Task Tool Integration with Built-in Subagents", () => {
       expect(result).toEqual({
         success: true,
         content: "Search completed successfully",
-        shortResult: "Task completed by Explore",
+        shortResult: "Task completed",
       });
     });
 
@@ -197,7 +197,7 @@ describe("Task Tool Integration with Built-in Subagents", () => {
       );
       expect(result.success).toBe(true);
       expect(result.content).toBe("Research completed");
-      expect(result.shortResult).toBe("Task completed by general-purpose");
+      expect(result.shortResult).toBe("Task completed");
     });
 
     it("should handle fastModel configuration correctly", async () => {
@@ -304,7 +304,7 @@ describe("Task Tool Integration with Built-in Subagents", () => {
         success: true,
         content:
           "Plan completed successfully\n\n### Critical Files for Implementation\n- src/main.ts",
-        shortResult: "Task completed by Plan",
+        shortResult: "Task completed",
       });
     });
 

--- a/packages/agent-sdk/tests/tools/taskTool_completion.test.ts
+++ b/packages/agent-sdk/tests/tools/taskTool_completion.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { taskTool } from "../../src/tools/taskTool.js";
+import { TaskManager } from "../../src/services/taskManager.js";
+import {
+  SubagentManager,
+  type SubagentInstance,
+} from "../../src/managers/subagentManager.js";
+import type { SubagentConfiguration } from "../../src/utils/subagentParser.js";
+import type { ToolContext } from "../../src/tools/types.js";
+import { Container } from "../../src/utils/container.js";
+
+// Mock the subagent manager
+vi.mock("../../src/managers/subagentManager.js");
+
+describe("Task Tool Completion shortResult", () => {
+  let mockSubagentManager: SubagentManager;
+  const mockToolContext: ToolContext = {
+    abortSignal: new AbortController().signal,
+    workdir: "/test/workdir",
+    taskManager: new TaskManager(new Container(), "test-session"),
+  };
+
+  const gpConfig: SubagentConfiguration = {
+    name: "general-purpose",
+    description: "General-purpose agent",
+    systemPrompt: "You are an agent...",
+    model: "fastModel",
+    filePath: "<builtin:general-purpose>",
+    scope: "builtin",
+    priority: 3,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Create mock subagent manager
+    mockSubagentManager = {
+      getConfigurations: vi.fn(() => [gpConfig]),
+      findSubagent: vi.fn(),
+      createInstance: vi.fn(),
+      executeTask: vi.fn(),
+      cleanupInstance: vi.fn(),
+    } as unknown as SubagentManager;
+
+    // Set the mock manager in the context
+    mockToolContext.subagentManager = mockSubagentManager;
+  });
+
+  it("should include tool count and tokens in shortResult on completion", async () => {
+    const mockInstance = {
+      subagentId: "gp-test-id",
+      lastTools: ["Read", "Write"],
+      messageManager: {
+        getMessages: vi.fn(() => [
+          { blocks: [{ type: "tool" }, { type: "tool" }] },
+          { blocks: [{ type: "tool" }] },
+        ]),
+        getlatestTotalTokens: vi.fn(() => 1234),
+      },
+    };
+
+    vi.mocked(mockSubagentManager.findSubagent).mockResolvedValue(gpConfig);
+    vi.mocked(mockSubagentManager.createInstance).mockResolvedValue(
+      mockInstance as unknown as SubagentInstance,
+    );
+    vi.mocked(mockSubagentManager.executeTask).mockResolvedValue("done");
+
+    const result = await taskTool.execute(
+      {
+        description: "Test task",
+        prompt: "Test prompt",
+        subagent_type: "general-purpose",
+      },
+      mockToolContext,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.shortResult).toBe("Task completed (3 tools | 1,234 tokens)");
+  });
+
+  it("should show only tool count if tokens is 0", async () => {
+    const mockInstance = {
+      subagentId: "gp-test-id",
+      lastTools: ["Read"],
+      messageManager: {
+        getMessages: vi.fn(() => [{ blocks: [{ type: "tool" }] }]),
+        getlatestTotalTokens: vi.fn(() => 0),
+      },
+    };
+
+    vi.mocked(mockSubagentManager.findSubagent).mockResolvedValue(gpConfig);
+    vi.mocked(mockSubagentManager.createInstance).mockResolvedValue(
+      mockInstance as unknown as SubagentInstance,
+    );
+    vi.mocked(mockSubagentManager.executeTask).mockResolvedValue("done");
+
+    const result = await taskTool.execute(
+      {
+        description: "Test task",
+        prompt: "Test prompt",
+        subagent_type: "general-purpose",
+      },
+      mockToolContext,
+    );
+
+    expect(result.shortResult).toBe("Task completed (1 tools)");
+  });
+
+  it("should show only 'Task completed' if tool count is 0", async () => {
+    const mockInstance = {
+      subagentId: "gp-test-id",
+      lastTools: [],
+      messageManager: {
+        getMessages: vi.fn(() => []),
+        getlatestTotalTokens: vi.fn(() => 0),
+      },
+    };
+
+    vi.mocked(mockSubagentManager.findSubagent).mockResolvedValue(gpConfig);
+    vi.mocked(mockSubagentManager.createInstance).mockResolvedValue(
+      mockInstance as unknown as SubagentInstance,
+    );
+    vi.mocked(mockSubagentManager.executeTask).mockResolvedValue("done");
+
+    const result = await taskTool.execute(
+      {
+        description: "Test task",
+        prompt: "Test prompt",
+        subagent_type: "general-purpose",
+      },
+      mockToolContext,
+    );
+
+    expect(result.shortResult).toBe("Task completed");
+  });
+});


### PR DESCRIPTION
This PR updates the Task tool to include tool count and token usage in the short result upon completion, providing more detailed feedback to the user.