### PR TITLE
fix: commit snapshots in task management tools for rewind support

### DIFF
--- a/packages/agent-sdk/src/tools/taskManagementTools.ts
+++ b/packages/agent-sdk/src/tools/taskManagementTools.ts
@@ -116,11 +116,12 @@ NOTE that you should not use this tool if there is only one trivial task to do. 
 
     if (context.reversionManager && context.messageId) {
       const taskPath = taskManager.getTaskPath(taskId);
-      await context.reversionManager.recordSnapshot(
+      const snapshotId = await context.reversionManager.recordSnapshot(
         context.messageId,
         taskPath,
         "create",
       );
+      await context.reversionManager.commitSnapshot(snapshotId);
     }
 
     return {
@@ -333,9 +334,10 @@ Set up task dependencies:
       };
     }
 
+    let snapshotId: string | undefined;
     if (context.reversionManager && context.messageId) {
       const taskPath = taskManager.getTaskPath(taskId);
-      await context.reversionManager.recordSnapshot(
+      snapshotId = await context.reversionManager.recordSnapshot(
         context.messageId,
         taskPath,
         "modify",
@@ -402,10 +404,22 @@ Set up task dependencies:
         for (const targetId of blocksToAdd) {
           const targetTask = await taskManager.getTask(targetId);
           if (targetTask && !targetTask.blockedBy.includes(taskId)) {
+            let targetSnapshotId: string | undefined;
+            if (context.reversionManager && context.messageId) {
+              const targetPath = taskManager.getTaskPath(targetId);
+              targetSnapshotId = await context.reversionManager.recordSnapshot(
+                context.messageId,
+                targetPath,
+                "modify",
+              );
+            }
             await taskManager.updateTask({
               ...targetTask,
               blockedBy: [...targetTask.blockedBy, taskId],
             });
+            if (context.reversionManager && targetSnapshotId) {
+              await context.reversionManager.commitSnapshot(targetSnapshotId);
+            }
           }
         }
       }
@@ -423,16 +437,32 @@ Set up task dependencies:
         for (const targetId of blockedByToAdd) {
           const targetTask = await taskManager.getTask(targetId);
           if (targetTask && !targetTask.blocks.includes(taskId)) {
+            let targetSnapshotId: string | undefined;
+            if (context.reversionManager && context.messageId) {
+              const targetPath = taskManager.getTaskPath(targetId);
+              targetSnapshotId = await context.reversionManager.recordSnapshot(
+                context.messageId,
+                targetPath,
+                "modify",
+              );
+            }
             await taskManager.updateTask({
               ...targetTask,
               blocks: [...targetTask.blocks, taskId],
             });
+            if (context.reversionManager && targetSnapshotId) {
+              await context.reversionManager.commitSnapshot(targetSnapshotId);
+            }
           }
         }
       }
     }
 
     await taskManager.updateTask(updatedTask);
+
+    if (context.reversionManager && snapshotId) {
+      await context.reversionManager.commitSnapshot(snapshotId);
+    }
 
     let content = `Updated task #${taskId} ${updatedFields.join(", ")}`;
     if (updatedTask.status === "completed") {

--- a/packages/agent-sdk/tests/tools/taskManagementToolsRewind.test.ts
+++ b/packages/agent-sdk/tests/tools/taskManagementToolsRewind.test.ts
@@ -23,6 +23,7 @@ vi.mock("../../src/services/taskManager.js", () => {
 vi.mock("../../src/managers/reversionManager.js", () => {
   const ReversionManager = vi.fn();
   ReversionManager.prototype.recordSnapshot = vi.fn();
+  ReversionManager.prototype.commitSnapshot = vi.fn();
   return { ReversionManager };
 });
 
@@ -64,6 +65,7 @@ describe("Task Management Tools - Rewind Support", () => {
 
       mockTaskManager.createTask.mockResolvedValue(taskId);
       mockTaskManager.getTaskPath.mockReturnValue(taskPath);
+      mockReversionManager.recordSnapshot.mockResolvedValue("snapshot-1");
 
       const result = await taskCreateTool.execute(args, context);
 
@@ -74,6 +76,7 @@ describe("Task Management Tools - Rewind Support", () => {
         taskPath,
         "create",
       );
+      expect(mockReversionManager.commitSnapshot).toHaveBeenCalled();
     });
 
     it("should not fail if reversionManager is missing", async () => {
@@ -113,6 +116,7 @@ describe("Task Management Tools - Rewind Support", () => {
 
       mockTaskManager.getTask.mockResolvedValue(existingTask);
       mockTaskManager.getTaskPath.mockReturnValue(taskPath);
+      mockReversionManager.recordSnapshot.mockResolvedValue("snapshot-1");
 
       const args = {
         taskId,
@@ -127,12 +131,69 @@ describe("Task Management Tools - Rewind Support", () => {
         taskPath,
         "modify",
       );
+      expect(mockReversionManager.commitSnapshot).toHaveBeenCalled();
       // Ensure snapshot is recorded BEFORE update
       const recordCallOrder =
         mockReversionManager.recordSnapshot.mock.invocationCallOrder[0];
       const updateCallOrder =
         mockTaskManager.updateTask.mock.invocationCallOrder[0];
       expect(recordCallOrder).toBeLessThan(updateCallOrder);
+    });
+
+    it("should record snapshots for other tasks updated via addBlocks", async () => {
+      const taskId = "1";
+      const targetId = "2";
+      const taskPath = "/path/to/task/1.json";
+      const targetPath = "/path/to/task/2.json";
+      const existingTask: Task = {
+        id: taskId,
+        subject: "Task 1",
+        description: "Desc 1",
+        status: "pending",
+        blocks: [],
+        blockedBy: [],
+        metadata: {},
+      };
+      const targetTask: Task = {
+        id: targetId,
+        subject: "Task 2",
+        description: "Desc 2",
+        status: "pending",
+        blocks: [],
+        blockedBy: [],
+        metadata: {},
+      };
+
+      mockTaskManager.getTask.mockImplementation(async (id) => {
+        if (id === taskId) return existingTask;
+        if (id === targetId) return targetTask;
+        return null;
+      });
+      mockTaskManager.getTaskPath.mockImplementation(
+        (id) => `/path/to/task/${id}.json`,
+      );
+      mockReversionManager.recordSnapshot.mockResolvedValue("snapshot-id");
+
+      const args = {
+        taskId,
+        addBlocks: [targetId],
+      };
+
+      const result = await taskUpdateTool.execute(args, context);
+
+      expect(result.success).toBe(true);
+      // Should record snapshot for both tasks
+      expect(mockReversionManager.recordSnapshot).toHaveBeenCalledWith(
+        messageId,
+        taskPath,
+        "modify",
+      );
+      expect(mockReversionManager.recordSnapshot).toHaveBeenCalledWith(
+        messageId,
+        targetPath,
+        "modify",
+      );
+      expect(mockReversionManager.commitSnapshot).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
Fixed the issue where task files were not being reverted after a rewind operation. Added missing commitSnapshot calls in taskCreateTool and taskUpdateTool, and updated tests to verify the fix.