### PR TITLE
refactor: rename agentModel to model

### DIFF
--- a/packages/agent-sdk/examples/agent-config-validation.ts
+++ b/packages/agent-sdk/examples/agent-config-validation.ts
@@ -19,7 +19,7 @@ async function validateAgentConfiguration() {
     const agent = await Agent.create({
       apiKey: "test-api-key-here",
       baseURL: "https://test-gateway.com",
-      agentModel: "gemini-3-flash",
+      model: "gemini-3-flash",
       fastModel: "gemini-2.5-flash",
       maxInputTokens: 50000,
       workdir: "./project",
@@ -77,7 +77,7 @@ async function validateAgentConfiguration() {
   try {
     const agent = await Agent.create({
       apiKey: "explicit-key", // Overrides WAVE_API_KEY
-      agentModel: "custom-model", // Overrides WAVE_MODEL
+      model: "custom-model", // Overrides WAVE_MODEL
       maxInputTokens: 32000, // Overrides WAVE_MAX_INPUT_TOKENS
       workdir: "./project",
     });
@@ -98,7 +98,7 @@ async function validateAgentConfiguration() {
     const testAgent = await Agent.create({
       apiKey: "test-api-key",
       baseURL: "http://localhost:3000/mock-ai",
-      agentModel: "test-model",
+      model: "test-model",
       fastModel: "test-fast-model",
       maxInputTokens: 1000,
       messages: [],
@@ -213,7 +213,7 @@ async function validateAgentConfiguration() {
     const agent = await Agent.create({
       apiKey: "constructor-key", // Should override env
       baseURL: "https://constructor-url.com", // Should override env
-      // agentModel should use environment variable
+      // model should use environment variable
     });
     // Verify configuration precedence works
     if (agent) {
@@ -235,7 +235,7 @@ async function validateAgentConfiguration() {
         process.env.NODE_ENV === "production"
           ? "https://prod-gateway.com"
           : "https://dev-gateway.com",
-      agentModel:
+      model:
         process.env.NODE_ENV === "production"
           ? "gemini-3-flash"
           : "gemini-2.5-flash",

--- a/packages/agent-sdk/examples/backgrounding-demo.ts
+++ b/packages/agent-sdk/examples/backgrounding-demo.ts
@@ -16,7 +16,7 @@ async function demonstrateBackgrounding(): Promise<void> {
     // Create agent with bash tool enabled
     agent = await Agent.create({
       workdir,
-      agentModel: "gemini-2.5-flash",
+      model: "gemini-2.5-flash",
       permissionMode: "bypassPermissions", // Ensure tools can run without permission prompts
       callbacks: {
         onAssistantContentUpdated: () => {

--- a/packages/agent-sdk/examples/general-purpose-agent.ts
+++ b/packages/agent-sdk/examples/general-purpose-agent.ts
@@ -3,7 +3,7 @@ import { Agent } from "../src/agent.js";
 async function main() {
   const agent = await Agent.create({
     workdir: process.cwd(),
-    agentModel: "gemini-2.5-flash",
+    model: "gemini-2.5-flash",
     callbacks: {
       onSubagentAssistantMessageAdded: (subagentId) => {
         const instance = agent.getSubagentInstance(subagentId);

--- a/packages/agent-sdk/examples/hook-exitcode-blocking.ts
+++ b/packages/agent-sdk/examples/hook-exitcode-blocking.ts
@@ -209,7 +209,7 @@ async function demonstrateBlockingErrors(): Promise<void> {
     // Create Agent instance
     const agent = await Agent.create({
       workdir: hookDir,
-      agentModel: "gemini-2.5-flash",
+      model: "gemini-2.5-flash",
       logger: console,
       callbacks: {
         onAssistantContentUpdated: (chunk: string) => {

--- a/packages/agent-sdk/examples/hook-exitcode-nonblocking.ts
+++ b/packages/agent-sdk/examples/hook-exitcode-nonblocking.ts
@@ -223,7 +223,7 @@ async function demonstrateNonBlockingErrors(): Promise<void> {
     // Create Agent instance
     const agent = await Agent.create({
       workdir: hookDir,
-      agentModel: "gemini-2.5-flash",
+      model: "gemini-2.5-flash",
       logger: console,
       callbacks: {
         onAssistantContentUpdated: (chunk: string) => {

--- a/packages/agent-sdk/examples/hook-exitcode-success.ts
+++ b/packages/agent-sdk/examples/hook-exitcode-success.ts
@@ -157,7 +157,7 @@ async function demonstrateSuccessExitCodes(): Promise<void> {
     // Create Agent instance
     const agent = await Agent.create({
       workdir: hookDir,
-      agentModel: "gemini-2.5-flash",
+      model: "gemini-2.5-flash",
       logger: console,
       callbacks: {
         onAssistantContentUpdated: (chunk: string) => {

--- a/packages/agent-sdk/examples/modular-rules-basic.ts
+++ b/packages/agent-sdk/examples/modular-rules-basic.ts
@@ -71,7 +71,7 @@ paths:
 
     agent = await Agent.create({
       workdir: testDir,
-      agentModel: "gemini-2.5-flash",
+      model: "gemini-2.5-flash",
       logger: {
         debug: (...args: unknown[]) => console.log("[DEBUG]", ...args),
         info: (...args: unknown[]) => console.log("[INFO]", ...args),

--- a/packages/agent-sdk/examples/modular-rules-demo.ts
+++ b/packages/agent-sdk/examples/modular-rules-demo.ts
@@ -175,7 +175,7 @@ async function demoModularRules(): Promise<void> {
 
     agent = await Agent.create({
       workdir: testDir,
-      agentModel: "gemini-2.5-flash",
+      model: "gemini-2.5-flash",
       logger: {
         debug: (...args: unknown[]) => {
           const message = args[0];

--- a/packages/agent-sdk/examples/parallel-execution-demo.ts
+++ b/packages/agent-sdk/examples/parallel-execution-demo.ts
@@ -26,7 +26,7 @@ async function demonstrateParallelExecution(): Promise<void> {
     // Create agent with bash tool enabled and callbacks for timing
     const agent = await Agent.create({
       workdir,
-      agentModel: "gemini-2.5-flash",
+      model: "gemini-2.5-flash",
       callbacks: {
         onAssistantContentUpdated: (chunk: string) => {
           process.stdout.write(chunk);

--- a/packages/agent-sdk/examples/permission-deny-config.ts
+++ b/packages/agent-sdk/examples/permission-deny-config.ts
@@ -36,7 +36,7 @@ async function main() {
 
   // 3. Initialize the agent pointing to the temporary directory
   const agent = await Agent.create({
-    agentModel: "gemini-2.5-flash",
+    model: "gemini-2.5-flash",
     workdir: tempDir,
     callbacks: {
       onToolBlockUpdated: (params) => {

--- a/packages/agent-sdk/examples/read-image-demo.ts
+++ b/packages/agent-sdk/examples/read-image-demo.ts
@@ -45,7 +45,7 @@ async function runDemo() {
 
     // Create Agent
     agent = await Agent.create({
-      agentModel: "gemini-2.5-flash",
+      model: "gemini-2.5-flash",
       callbacks: {
         onToolBlockUpdated: (params) => {
           if (params.stage === "start") {

--- a/packages/agent-sdk/examples/read-tool-image-test.ts
+++ b/packages/agent-sdk/examples/read-tool-image-test.ts
@@ -108,7 +108,7 @@ async function testWithAgent() {
   }> = [];
 
   agent = await Agent.create({
-    agentModel: "gemini-2.5-flash",
+    model: "gemini-2.5-flash",
     callbacks: {
       onToolBlockUpdated: (params) => {
         if (params.stage === "start") {

--- a/packages/agent-sdk/examples/simple-cache-test.ts
+++ b/packages/agent-sdk/examples/simple-cache-test.ts
@@ -5,7 +5,7 @@ import { Agent } from "../src/agent.js";
 // Create Agent instance with Gemini model to test cache control
 const agent = await Agent.create({
   // Use Gemini model to enable cache control features
-  agentModel: "gemini-3-flash",
+  model: "gemini-3-flash",
 
   callbacks: {
     onUsagesChange: (usages) => {

--- a/packages/agent-sdk/examples/task-management-demo.ts
+++ b/packages/agent-sdk/examples/task-management-demo.ts
@@ -7,7 +7,7 @@ import { Agent } from "../src/agent.js";
 async function main() {
   // 1. Create Agent instance
   const agent = await Agent.create({
-    agentModel: "gemini-2.5-flash", // Use a fast model for testing
+    model: "gemini-2.5-flash", // Use a fast model for testing
     callbacks: {
       onAssistantContentUpdated: (chunk) => {
         process.stdout.write(chunk);

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -72,7 +72,7 @@ export interface AgentOptions {
   defaultHeaders?: Record<string, string>;
   fetchOptions?: ClientOptions["fetchOptions"];
   fetch?: ClientOptions["fetch"];
-  agentModel?: string;
+  model?: string;
   fastModel?: string;
   maxInputTokens?: number;
   maxTokens?: number;
@@ -177,7 +177,7 @@ export class Agent {
 
   public getModelConfig(): ModelConfig {
     return this.configurationService.resolveModelConfig(
-      this.options.agentModel,
+      this.options.model,
       this.options.fastModel,
       this.options.maxTokens,
       this.getPermissionMode(),
@@ -450,7 +450,7 @@ export class Agent {
     configValidator.validateGatewayConfig(gatewayConfig);
     configValidator.validateMaxInputTokens(maxInputTokens);
     configValidator.validateModelConfig(
-      modelConfig.agentModel,
+      modelConfig.model,
       modelConfig.fastModel,
     );
   }

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -241,7 +241,7 @@ export class AIManager {
               prompt_tokens: compressionResult.usage.prompt_tokens,
               completion_tokens: compressionResult.usage.completion_tokens,
               total_tokens: compressionResult.usage.total_tokens,
-              model: model || this.getModelConfig().agentModel,
+              model: model || this.getModelConfig().model,
               operation_type: "compress",
             };
           }
@@ -512,7 +512,7 @@ export class AIManager {
           prompt_tokens: result.usage.prompt_tokens,
           completion_tokens: result.usage.completion_tokens,
           total_tokens: result.usage.total_tokens,
-          model: model || this.getModelConfig().agentModel,
+          model: model || this.getModelConfig().model,
           operation_type: "agent",
           // Preserve cache fields if present
           ...(result.usage.cache_read_input_tokens !== undefined && {

--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -202,8 +202,8 @@ export class SubagentManager {
         let modelToUse: string;
 
         if (!configuration.model || configuration.model === "inherit") {
-          // Use parent's agentModel for "inherit" or undefined
-          modelToUse = parentModelConfig.agentModel;
+          // Use parent's model for "inherit" or undefined
+          modelToUse = parentModelConfig.model;
         } else if (configuration.model === "fastModel") {
           // Use parent's fastModel for special "fastModel" value
           modelToUse = parentModelConfig.fastModel;
@@ -214,7 +214,7 @@ export class SubagentManager {
 
         return {
           ...parentModelConfig,
-          agentModel: modelToUse,
+          model: modelToUse,
         };
       },
       getMaxInputTokens: this.getMaxInputTokens,

--- a/packages/agent-sdk/src/services/aiService.ts
+++ b/packages/agent-sdk/src/services/aiService.ts
@@ -203,7 +203,7 @@ export async function callAgent(
   // Apply global 1 QPS rate limit
   if (
     process.env.NODE_ENV !== "test" ||
-    modelConfig.agentModel === "rate-limit-test"
+    modelConfig.model === "rate-limit-test"
   ) {
     await acquireSlot(abortSignal);
   }
@@ -239,7 +239,7 @@ export async function callAgent(
     openaiMessages = [systemMessage, ...messages];
 
     // Apply cache control for Claude models
-    const currentModel = model || modelConfig.agentModel;
+    const currentModel = model || modelConfig.model;
     const resolvedMaxTokens = options.maxTokens ?? modelConfig.maxTokens;
 
     processedTools = tools;
@@ -257,7 +257,7 @@ export async function callAgent(
     }
 
     // Get model configuration - use injected modelConfig with optional override
-    const openaiModelConfig = getModelConfig(model || modelConfig.agentModel, {
+    const openaiModelConfig = getModelConfig(model || modelConfig.model, {
       temperature: 0,
       max_tokens: resolvedMaxTokens,
     });
@@ -421,7 +421,7 @@ export async function callAgent(
         const debugData: DebugData = {
           originalMessages: messages,
           timestamp: new Date().toISOString(),
-          model: model || modelConfig.agentModel,
+          model: model || modelConfig.model,
           workdir,
           sessionId: options.sessionId,
           gatewayConfig: {
@@ -760,7 +760,7 @@ export async function compressMessages(
   // Apply global 1 QPS rate limit
   if (
     process.env.NODE_ENV !== "test" ||
-    modelConfig.agentModel === "rate-limit-test"
+    modelConfig.model === "rate-limit-test"
   ) {
     await acquireSlot(abortSignal);
   }
@@ -775,13 +775,10 @@ export async function compressMessages(
   });
 
   // Get model configuration - use injected agent model
-  const openaiModelConfig = getModelConfig(
-    options.model || modelConfig.agentModel,
-    {
-      temperature: 0.1,
-      max_tokens: 2048,
-    },
-  );
+  const openaiModelConfig = getModelConfig(options.model || modelConfig.model, {
+    temperature: 0.1,
+    max_tokens: 2048,
+  });
 
   try {
     const response = await openai.chat.completions.create(

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -444,13 +444,13 @@ export class ConfigurationService {
   /**
    * Resolves model configuration with fallbacks
    * Resolution priority: options > env (from settings.json) > process.env > default
-   * @param agentModel - Agent model from constructor (optional)
+   * @param model - Agent model from constructor (optional)
    * @param fastModel - Fast model from constructor (optional)
    * @param maxTokens - Max output tokens from constructor (optional)
    * @returns Resolved model configuration with defaults
    */
   resolveModelConfig(
-    agentModel?: string,
+    model?: string,
     fastModel?: string,
     maxTokens?: number,
     permissionMode?: PermissionMode,
@@ -460,7 +460,7 @@ export class ConfigurationService {
     const DEFAULT_FAST_MODEL = "gemini-2.5-flash";
 
     // Resolve agent model: constructor > env (settings.json) > process.env > default
-    let resolvedAgentModel = agentModel || this.env.WAVE_MODEL;
+    let resolvedAgentModel = model || this.env.WAVE_MODEL;
 
     if (!resolvedAgentModel && this.currentConfiguration?.env?.WAVE_MODEL) {
       resolvedAgentModel = this.currentConfiguration.env.WAVE_MODEL;
@@ -481,7 +481,7 @@ export class ConfigurationService {
     const resolvedMaxTokens = this.resolveMaxOutputTokens(maxTokens);
 
     return {
-      agentModel: resolvedAgentModel,
+      model: resolvedAgentModel,
       fastModel: resolvedFastModel,
       maxTokens: resolvedMaxTokens,
       permissionMode,

--- a/packages/agent-sdk/src/types/config.ts
+++ b/packages/agent-sdk/src/types/config.ts
@@ -15,7 +15,7 @@ export interface GatewayConfig {
 }
 
 export interface ModelConfig {
-  agentModel: string;
+  model: string;
   fastModel: string;
   maxTokens?: number;
   permissionMode?: PermissionMode;

--- a/packages/agent-sdk/src/utils/configValidator.ts
+++ b/packages/agent-sdk/src/utils/configValidator.ts
@@ -89,20 +89,16 @@ export class ConfigValidator {
 
   /**
    * Validates model configuration (basic validation)
-   * @param agentModel - Agent model string
+   * @param model - Agent model string
    * @param fastModel - Fast model string
    * @throws ConfigurationError if invalid
    */
-  static validateModelConfig(agentModel: string, fastModel: string): void {
-    if (
-      !agentModel ||
-      typeof agentModel !== "string" ||
-      agentModel.trim() === ""
-    ) {
+  static validateModelConfig(model: string, fastModel: string): void {
+    if (!model || typeof model !== "string" || model.trim() === "") {
       throw new ConfigurationError(
         "Agent model must be a non-empty string.",
-        "agentModel",
-        agentModel,
+        "model",
+        model,
       );
     }
 

--- a/packages/agent-sdk/tests/agent/agent.planModeDefault.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.planModeDefault.test.ts
@@ -23,7 +23,7 @@ vi.mock("../../src/services/configurationService.js", () => {
           baseURL: "https://test.api",
         }),
         resolveModelConfig: vi.fn().mockReturnValue({
-          agentModel: "test-model",
+          model: "test-model",
           fastModel: "test-fast-model",
         }),
         resolveMaxInputTokens: vi.fn().mockReturnValue(100000),
@@ -95,7 +95,7 @@ describe("Agent Plan Mode Default", () => {
           baseURL: "https://test.api",
         }),
         resolveModelConfig: vi.fn().mockReturnValue({
-          agentModel: "test-model",
+          model: "test-model",
           fastModel: "test-fast-model",
         }),
         resolveMaxInputTokens: vi.fn().mockReturnValue(100000),

--- a/packages/agent-sdk/tests/agent/agent.subagentDynamicConfig.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.subagentDynamicConfig.test.ts
@@ -100,9 +100,7 @@ describe("Subagent Dynamic Configuration Tests", () => {
         baseURL: "https://parent.url",
       });
 
-      expect(subagentAIManager.getModelConfig().agentModel).toBe(
-        "parent-model",
-      );
+      expect(subagentAIManager.getModelConfig().model).toBe("parent-model");
       expect(subagentAIManager.getMaxInputTokens()).toBe(40000);
 
       // Update parent environment variables
@@ -117,7 +115,7 @@ describe("Subagent Dynamic Configuration Tests", () => {
         baseURL: "https://updated-parent.url",
       });
 
-      expect(subagentAIManager.getModelConfig().agentModel).toBe(
+      expect(subagentAIManager.getModelConfig().model).toBe(
         "updated-parent-model",
       );
       expect(subagentAIManager.getMaxInputTokens()).toBe(50000);
@@ -172,7 +170,7 @@ describe("Subagent Dynamic Configuration Tests", () => {
 
       // Should use override model, but inherit fastModel from parent
       const modelConfig = subagentAIManager.getModelConfig();
-      expect(modelConfig.agentModel).toBe("specific-subagent-model");
+      expect(modelConfig.model).toBe("specific-subagent-model");
       expect(modelConfig.fastModel).toBe("parent-fast-model");
 
       // Should inherit token limit from parent (using default since not specified)
@@ -184,7 +182,7 @@ describe("Subagent Dynamic Configuration Tests", () => {
 
       // Verify subagent still uses override model but gets updated inherited values
       const updatedModelConfig = subagentAIManager.getModelConfig();
-      expect(updatedModelConfig.agentModel).toBe("specific-subagent-model"); // Still overridden
+      expect(updatedModelConfig.model).toBe("specific-subagent-model"); // Still overridden
       expect(updatedModelConfig.fastModel).toBe("updated-parent-fast-model"); // Inherited dynamically
 
       expect(subagentAIManager.getGatewayConfig().apiKey).toBe(
@@ -247,12 +245,8 @@ describe("Subagent Dynamic Configuration Tests", () => {
       expect(subagent1.aiManager.getGatewayConfig().apiKey).toBe("multi-token");
       expect(subagent2.aiManager.getGatewayConfig().apiKey).toBe("multi-token");
 
-      expect(subagent1.aiManager.getModelConfig().agentModel).toBe(
-        "multi-model",
-      );
-      expect(subagent2.aiManager.getModelConfig().agentModel).toBe(
-        "custom-model",
-      );
+      expect(subagent1.aiManager.getModelConfig().model).toBe("multi-model");
+      expect(subagent2.aiManager.getModelConfig().model).toBe("custom-model");
 
       // Update environment
       process.env.WAVE_API_KEY = "multi-updated-token";
@@ -266,12 +260,10 @@ describe("Subagent Dynamic Configuration Tests", () => {
         "multi-updated-token",
       );
 
-      expect(subagent1.aiManager.getModelConfig().agentModel).toBe(
+      expect(subagent1.aiManager.getModelConfig().model).toBe(
         "multi-updated-model",
       );
-      expect(subagent2.aiManager.getModelConfig().agentModel).toBe(
-        "custom-model",
-      ); // Still overridden
+      expect(subagent2.aiManager.getModelConfig().model).toBe("custom-model"); // Still overridden
     });
   });
 });

--- a/packages/agent-sdk/tests/integration/subagentPlanMode.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/subagentPlanMode.integration.test.ts
@@ -117,7 +117,7 @@ describe("Subagent Plan Mode Integration", () => {
       workdir: "/test/project",
       getGatewayConfig: () => ({ apiKey: "test", baseURL: "test" }),
       getModelConfig: () => ({
-        agentModel: "test-model",
+        model: "test-model",
         fastModel: "test-fast-model",
         permissionMode: "plan",
       }),

--- a/packages/agent-sdk/tests/managers/aiManager.latestTotalTokens.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.latestTotalTokens.test.ts
@@ -40,7 +40,7 @@ describe("AIManager - latestTotalTokens calculation", () => {
   };
 
   const mockModelConfig: ModelConfig = {
-    agentModel: "test-agent-model",
+    model: "test-agent-model",
     fastModel: "test-fast-model",
   };
 

--- a/packages/agent-sdk/tests/managers/aiManager.plan.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.plan.test.ts
@@ -62,7 +62,7 @@ describe("AIManager Plan Mode Prompt", () => {
     aiManager = new AIManager(container, {
       workdir: "/test/workdir",
       getGatewayConfig: () => ({}) as GatewayConfig,
-      getModelConfig: () => ({ agentModel: "gpt-4" }) as ModelConfig,
+      getModelConfig: () => ({ model: "gpt-4" }) as ModelConfig,
       getMaxInputTokens: () => 1000,
       getLanguage: () => undefined,
       stream: false,

--- a/packages/agent-sdk/tests/managers/aiManager.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.test.ts
@@ -70,7 +70,7 @@ describe("AIManager", () => {
   };
 
   const mockModelConfig: ModelConfig = {
-    agentModel: "test-agent-model",
+    model: "test-agent-model",
     fastModel: "test-fast-model",
   };
 

--- a/packages/agent-sdk/tests/managers/aiManager_finishReason.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager_finishReason.test.ts
@@ -35,7 +35,7 @@ describe("AIManager finish reason", () => {
   };
 
   const mockModelConfig: ModelConfig = {
-    agentModel: "test-agent-model",
+    model: "test-agent-model",
     fastModel: "test-fast-model",
   };
 

--- a/packages/agent-sdk/tests/managers/subagentManager.abort.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.abort.test.ts
@@ -69,7 +69,7 @@ describe("SubagentManager - Abort Logic", () => {
       workdir: "/test",
       getGatewayConfig: () => ({ apiKey: "test", baseURL: "test" }),
       getModelConfig: () => ({
-        agentModel: "test-model",
+        model: "test-model",
         fastModel: "test-fast-model",
       }),
       getMaxInputTokens: () => 1000,

--- a/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
@@ -66,7 +66,7 @@ describe("SubagentManager - Backgrounding Coverage", () => {
       workdir: "/test",
       getGatewayConfig: () => ({ apiKey: "test", baseURL: "test" }),
       getModelConfig: () => ({
-        agentModel: "test-model",
+        model: "test-model",
         fastModel: "test-fast-model",
       }),
       getMaxInputTokens: () => 1000,
@@ -78,7 +78,7 @@ describe("SubagentManager - Backgrounding Coverage", () => {
     const managerNoBG = new SubagentManager(container, {
       workdir: "/test",
       getGatewayConfig: () => ({ apiKey: "test", baseURL: "test" }),
-      getModelConfig: () => ({ agentModel: "m", fastModel: "f" }),
+      getModelConfig: () => ({ model: "m", fastModel: "f" }),
       getMaxInputTokens: () => 1000,
       getLanguage: () => "en",
     });
@@ -185,7 +185,7 @@ describe("SubagentManager - Backgrounding Coverage", () => {
       workdir: "/test",
       callbacks: { onSubagentAssistantReasoningUpdated },
       getGatewayConfig: () => ({ apiKey: "test", baseURL: "test" }),
-      getModelConfig: () => ({ agentModel: "m", fastModel: "f" }),
+      getModelConfig: () => ({ model: "m", fastModel: "f" }),
       getMaxInputTokens: () => 1000,
       getLanguage: () => "en",
     });

--- a/packages/agent-sdk/tests/managers/subagentManager.callbacks.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.callbacks.test.ts
@@ -89,7 +89,7 @@ describe("SubagentManager - Callback Integration", () => {
     };
 
     mockModelConfig = {
-      agentModel: "claude-3-sonnet",
+      model: "claude-3-sonnet",
       fastModel: "claude-3-haiku",
     };
 

--- a/packages/agent-sdk/tests/managers/subagentManager.consistency.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.consistency.test.ts
@@ -66,7 +66,7 @@ describe("SubagentManager Consistency", () => {
       workdir: "/test",
       getGatewayConfig: () => ({ apiKey: "test", baseURL: "test" }),
       getModelConfig: () => ({
-        agentModel: "claude-3-5-sonnet",
+        model: "claude-3-5-sonnet",
         fastModel: "claude-3-haiku",
       }),
       getMaxInputTokens: () => 200000,

--- a/packages/agent-sdk/tests/managers/subagentManager.coverage.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.coverage.test.ts
@@ -68,7 +68,7 @@ describe("SubagentManager - Recent Changes Coverage", () => {
       baseURL: "https://api.anthropic.com",
     };
     mockModelConfig = {
-      agentModel: "claude-3-sonnet",
+      model: "claude-3-sonnet",
       fastModel: "claude-3-haiku",
     };
 

--- a/packages/agent-sdk/tests/managers/subagentManager.sessions.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.sessions.test.ts
@@ -103,7 +103,7 @@ describe("SubagentManager - Session Functionality", () => {
     };
 
     mockModelConfig = {
-      agentModel: "claude-3-5-sonnet-20241022",
+      model: "claude-3-5-sonnet-20241022",
       fastModel: "claude-3-haiku-20240307",
     };
 

--- a/packages/agent-sdk/tests/services/aiService.basic.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.basic.test.ts
@@ -10,7 +10,7 @@ const TEST_GATEWAY_CONFIG: GatewayConfig = {
 };
 
 const TEST_MODEL_CONFIG: ModelConfig = {
-  agentModel: "gemini-3-flash",
+  model: "gemini-3-flash",
   fastModel: "gemini-2.5-flash",
 };
 

--- a/packages/agent-sdk/tests/services/aiService.cacheControl.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.cacheControl.test.ts
@@ -11,13 +11,13 @@ const TEST_GATEWAY_CONFIG: GatewayConfig = {
 
 // Claude-specific model config for cache control testing
 const CLAUDE_MODEL_CONFIG: ModelConfig = {
-  agentModel: "claude-3-sonnet-20240229",
+  model: "claude-3-sonnet-20240229",
   fastModel: "gemini-2.5-flash",
 };
 
 // Non-Claude model config for compatibility testing
 const NON_CLAUDE_MODEL_CONFIG: ModelConfig = {
-  agentModel: "gpt-4o",
+  model: "gpt-4o",
   fastModel: "gpt-4o-mini",
 };
 
@@ -1328,19 +1328,19 @@ describe("AI Service - Claude Cache Control", () => {
       const nonClaudeModels = [
         {
           name: "OpenAI GPT-4o",
-          config: { agentModel: "gpt-4o", fastModel: "gpt-4o-mini" },
+          config: { model: "gpt-4o", fastModel: "gpt-4o-mini" },
         },
         {
           name: "OpenAI GPT-3.5",
-          config: { agentModel: "gpt-3.5-turbo", fastModel: "gpt-3.5-turbo" },
+          config: { model: "gpt-3.5-turbo", fastModel: "gpt-3.5-turbo" },
         },
         {
           name: "Google Gemini",
-          config: { agentModel: "gemini-pro", fastModel: "gemini-flash" },
+          config: { model: "gemini-pro", fastModel: "gemini-flash" },
         },
         {
           name: "Meta Llama",
-          config: { agentModel: "llama2-70b", fastModel: "llama2-7b" },
+          config: { model: "llama2-70b", fastModel: "llama2-7b" },
         },
       ];
 
@@ -1410,7 +1410,7 @@ describe("AI Service - Claude Cache Control", () => {
           const result = await callAgent({
             gatewayConfig: TEST_GATEWAY_CONFIG,
             modelConfig: {
-              agentModel: testCase.modelName,
+              model: testCase.modelName,
               fastModel: "gpt-4o-mini",
             },
             messages: [{ role: "user", content: "Test message" }],
@@ -1436,7 +1436,7 @@ describe("AI Service - Claude Cache Control", () => {
       it("should maintain standard usage tracking for non-Claude models", async () => {
         const result = await callAgent({
           gatewayConfig: TEST_GATEWAY_CONFIG,
-          modelConfig: { agentModel: "gpt-4o", fastModel: "gpt-4o-mini" },
+          modelConfig: { model: "gpt-4o", fastModel: "gpt-4o-mini" },
           messages: [{ role: "user", content: "Test message" }],
           workdir: "/test/workdir",
         });

--- a/packages/agent-sdk/tests/services/aiService.compress.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.compress.test.ts
@@ -9,7 +9,7 @@ const TEST_GATEWAY_CONFIG: GatewayConfig = {
 };
 
 const TEST_MODEL_CONFIG: ModelConfig = {
-  agentModel: "gemini-3-flash",
+  model: "gemini-3-flash",
   fastModel: "gemini-2.5-flash",
 };
 
@@ -95,7 +95,7 @@ describe("AI Service - CompressMessages", () => {
       const callArgs = mockCreate.mock.calls[0][0];
 
       // Verify model configuration
-      expect(callArgs.model).toBe(TEST_MODEL_CONFIG.agentModel);
+      expect(callArgs.model).toBe(TEST_MODEL_CONFIG.model);
       expect(callArgs.temperature).toBe(0.1);
       expect(callArgs.max_tokens).toBe(2048);
       expect(callArgs.stream).toBe(false);

--- a/packages/agent-sdk/tests/services/aiService.coverage.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.coverage.test.ts
@@ -46,7 +46,7 @@ describe("AI Service - Branch Coverage", () => {
   };
 
   const TEST_MODEL_CONFIG = {
-    agentModel: "gpt-4o",
+    model: "gpt-4o",
     fastModel: "gpt-4o-mini",
   };
 

--- a/packages/agent-sdk/tests/services/aiService.rateLimit.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.rateLimit.test.ts
@@ -12,7 +12,7 @@ const TEST_GATEWAY_CONFIG: GatewayConfig = {
 };
 
 const TEST_MODEL_CONFIG: ModelConfig = {
-  agentModel: "rate-limit-test",
+  model: "rate-limit-test",
   fastModel: "gemini-2.5-flash",
 };
 

--- a/packages/agent-sdk/tests/services/aiService.streaming.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.streaming.test.ts
@@ -9,7 +9,7 @@ const TEST_GATEWAY_CONFIG: GatewayConfig = {
 };
 
 const TEST_MODEL_CONFIG: ModelConfig = {
-  agentModel: "gemini-3-flash",
+  model: "gemini-3-flash",
   fastModel: "gemini-2.5-flash",
 };
 

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -440,7 +440,7 @@ describe("ConfigurationService", () => {
       const expectedAgentModel = process.env.WAVE_MODEL || "gemini-3-flash";
       const expectedFastModel =
         process.env.WAVE_FAST_MODEL || "gemini-2.5-flash";
-      expect(config.agentModel).toBe(expectedAgentModel);
+      expect(config.model).toBe(expectedAgentModel);
       expect(config.fastModel).toBe(expectedFastModel);
       expect(config.maxTokens).toBe(DEFAULT_WAVE_MAX_OUTPUT_TOKENS);
     });
@@ -452,7 +452,7 @@ describe("ConfigurationService", () => {
         WAVE_MAX_OUTPUT_TOKENS: "1000",
       });
       const config = configService.resolveModelConfig();
-      expect(config.agentModel).toBe("custom-agent");
+      expect(config.model).toBe("custom-agent");
       expect(config.fastModel).toBe("custom-fast");
       expect(config.maxTokens).toBe(1000);
     });

--- a/packages/code/src/components/ChatInterface.tsx
+++ b/packages/code/src/components/ChatInterface.tsx
@@ -41,7 +41,7 @@ export const ChatInterface: React.FC = () => {
     getModelConfig,
   } = useChat();
 
-  const model = getModelConfig().agentModel;
+  const model = getModelConfig().model;
 
   const handleDetailsHeightMeasured = useCallback((height: number) => {
     setDetailsHeight(height);

--- a/packages/code/src/components/StatusCommand.tsx
+++ b/packages/code/src/components/StatusCommand.tsx
@@ -83,7 +83,7 @@ export const StatusCommand: React.FC<StatusCommandProps> = ({ onCancel }) => {
         <Box width={20}>
           <Text color="yellow">Model:</Text>
         </Box>
-        <Text color="white">{modelConfig.agentModel}</Text>
+        <Text color="white">{modelConfig.model}</Text>
       </Box>
 
       <Box marginTop={1}>

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -561,7 +561,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
 
   const getModelConfig = useCallback(() => {
     if (!agentRef.current) {
-      return { agentModel: "", fastModel: "" };
+      return { model: "", fastModel: "" };
     }
     return agentRef.current.getModelConfig();
   }, []);

--- a/packages/code/tests/components/ChatInterface.loading.test.tsx
+++ b/packages/code/tests/components/ChatInterface.loading.test.tsx
@@ -39,12 +39,10 @@ describe("ChatInterface Loading State", () => {
     slashCommands: [],
     hasSlashCommand: vi.fn(),
     isTaskListVisible: true,
-    getModelConfig: vi
-      .fn()
-      .mockReturnValue({
-        agentModel: "test-model",
-        fastModel: "test-fast-model",
-      }),
+    getModelConfig: vi.fn().mockReturnValue({
+      model: "test-model",
+      fastModel: "test-fast-model",
+    }),
   } as unknown as ChatContextType;
 
   const mockInputManager = {

--- a/packages/code/tests/components/ChatInterface.rewind.test.tsx
+++ b/packages/code/tests/components/ChatInterface.rewind.test.tsx
@@ -58,12 +58,10 @@ describe("ChatInterface Rewind Visibility", () => {
       tasks: [],
       isTaskListVisible: true,
       setIsTaskListVisible: vi.fn(),
-      getModelConfig: vi
-        .fn()
-        .mockReturnValue({
-          agentModel: "test-model",
-          fastModel: "test-fast-model",
-        }),
+      getModelConfig: vi.fn().mockReturnValue({
+        model: "test-model",
+        fastModel: "test-fast-model",
+      }),
       getFullMessageThread: vi
         .fn()
         .mockResolvedValue({ messages: [], sessionIds: [] }),
@@ -137,12 +135,10 @@ describe("ChatInterface Rewind Visibility", () => {
       tasks: [],
       isTaskListVisible: true,
       setIsTaskListVisible: vi.fn(),
-      getModelConfig: vi
-        .fn()
-        .mockReturnValue({
-          agentModel: "test-model",
-          fastModel: "test-fast-model",
-        }),
+      getModelConfig: vi.fn().mockReturnValue({
+        model: "test-model",
+        fastModel: "test-fast-model",
+      }),
       getFullMessageThread: vi
         .fn()
         .mockResolvedValue({ messages: [], sessionIds: [] }),

--- a/packages/code/tests/components/StatusCommand.test.tsx
+++ b/packages/code/tests/components/StatusCommand.test.tsx
@@ -14,7 +14,7 @@ describe("StatusCommand", () => {
     sessionId: "test-session-id",
     workingDirectory: "/test/cwd",
     getGatewayConfig: vi.fn().mockReturnValue({ baseURL: "https://test.api" }),
-    getModelConfig: vi.fn().mockReturnValue({ agentModel: "test-model" }),
+    getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
   };
 
   beforeEach(() => {

--- a/packages/code/tests/integration/taskList.test.tsx
+++ b/packages/code/tests/integration/taskList.test.tsx
@@ -65,12 +65,10 @@ describe("TaskList Integration", () => {
       getMcpServers: vi.fn().mockReturnValue([]),
       getSlashCommands: vi.fn().mockReturnValue([]),
       getGatewayConfig: vi.fn().mockReturnValue({ baseURL: "" }),
-      getModelConfig: vi
-        .fn()
-        .mockReturnValue({
-          agentModel: "test-model",
-          fastModel: "test-fast-model",
-        }),
+      getModelConfig: vi.fn().mockReturnValue({
+        model: "test-model",
+        fastModel: "test-fast-model",
+      }),
       destroy: vi.fn(),
     } as unknown as Agent;
 

--- a/specs/007-agent-constructor-config/contracts/typescript-interfaces.md
+++ b/specs/007-agent-constructor-config/contracts/typescript-interfaces.md
@@ -7,7 +7,7 @@ export interface AgentOptions {
   // Optional configuration with environment fallbacks
   apiKey?: string;
   baseURL?: string;
-  agentModel?: string;
+  model?: string;
   fastModel?: string;
   maxInputTokens?: number;
   
@@ -27,7 +27,7 @@ export interface GatewayConfig {
 }
 
 export interface ModelConfig {
-  agentModel: string;
+  model: string;
   fastModel: string;
 }
 ```
@@ -84,11 +84,11 @@ export interface ConfigurationResolver {
   
   /**
    * Resolves model configuration with fallbacks
-   * @param agentModel - Agent model from constructor (optional)
+   * @param model - Agent model from constructor (optional)
    * @param fastModel - Fast model from constructor (optional)
    * @returns Resolved model configuration with defaults
    */
-  resolveModelConfig(agentModel?: string, fastModel?: string): ModelConfig;
+  resolveModelConfig(model?: string, fastModel?: string): ModelConfig;
   
   /**
    * Resolves token limit with fallbacks

--- a/specs/007-agent-constructor-config/data-model.md
+++ b/specs/007-agent-constructor-config/data-model.md
@@ -11,7 +11,7 @@ Extended interface for Agent constructor parameters.
 **Fields**:
 - `apiKey?: string` - Gateway API key (optional, fallback to WAVE_API_KEY)
 - `baseURL?: string` - Gateway endpoint URL (optional, fallback to WAVE_BASE_URL)
-- `agentModel?: string` - Model ID for main operations (optional, fallback to WAVE_MODEL)
+- `model?: string` - Model ID for main operations (optional, fallback to WAVE_MODEL)
 - `fastModel?: string` - Model ID for fast operations (optional, fallback to WAVE_FAST_MODEL)
 - `maxInputTokens?: number` - Token limit for compression (optional, fallback to WAVE_MAX_INPUT_TOKENS, default: 96000)
 - `callbacks?: AgentCallbacks` - Existing callback handlers
@@ -48,7 +48,7 @@ Resolved configuration for gateway service connection.
 Resolved configuration for model selection.
 
 **Fields**:
-- `agentModel: string` - Model ID for main operations (resolved from constructor, env, or default)
+- `model: string` - Model ID for main operations (resolved from constructor, env, or default)
 - `fastModel: string` - Model ID for compression and fast operations (resolved from constructor, env, or default)
 
 **Validation Rules**:
@@ -56,7 +56,7 @@ Resolved configuration for model selection.
 - No format validation (service validates model availability)
 
 **Default Values**:
-- `agentModel`: "gemini-3-flash"
+- `model`: "gemini-3-flash"
 - `fastModel`: "gemini-2.5-flash"
 
 **Relationships**:
@@ -71,14 +71,14 @@ Configuration values resolved in this order:
 1. **Constructor Parameters** (highest precedence)
    - `AgentOptions.apiKey`
    - `AgentOptions.baseURL`
-   - `AgentOptions.agentModel`
+   - `AgentOptions.model`
    - `AgentOptions.fastModel`
    - `AgentOptions.maxInputTokens`
 
 2. **Environment Variables** (fallback)
    - `process.env.WAVE_API_KEY` → `apiKey`
    - `process.env.WAVE_BASE_URL` → `baseURL`
-   - `process.env.WAVE_MODEL` → `agentModel`
+   - `process.env.WAVE_MODEL` → `model`
    - `process.env.WAVE_FAST_MODEL` → `fastModel`
    - `process.env.WAVE_MAX_INPUT_TOKENS` → `maxInputTokens`
 

--- a/specs/007-agent-constructor-config/quickstart.md
+++ b/specs/007-agent-constructor-config/quickstart.md
@@ -9,7 +9,7 @@ import { Agent } from 'wave-agent-sdk';
 const agent = await Agent.create({
   apiKey: 'your-api-key-here',
   baseURL: 'https://your-gateway.com',
-  agentModel: 'gemini-3-flash',
+  model: 'gemini-3-flash',
   fastModel: 'gemini-2.5-flash',
   maxInputTokens:50000,
   workdir: './project'
@@ -37,7 +37,7 @@ const agent = await Agent.create({
 const agent = await Agent.create({
   apiKey: 'explicit-key',        // Overrides WAVE_API_KEY
   // baseURL uses WAVE_BASE_URL environment variable
-  agentModel: 'custom-model',    // Overrides WAVE_MODEL
+  model: 'custom-model',    // Overrides WAVE_MODEL
   // fastModel uses WAVE_FAST_MODEL or default
   maxInputTokens:32000,             // Overrides WAVE_MAX_INPUT_TOKENS
   workdir: './project'
@@ -53,7 +53,7 @@ import { Agent } from 'wave-agent-sdk';
 const testAgent = await Agent.create({
   apiKey: 'test-api-key',
   baseURL: 'http://localhost:3000/mock-ai',
-  agentModel: 'test-model',
+  model: 'test-model',
   fastModel: 'test-fast-model',
   maxInputTokens:1000, // Lower limit for testing
   messages: [], // Start with empty messages
@@ -126,7 +126,7 @@ const modernAgent = await Agent.create({
 const agent1 = await Agent.create({
   apiKey: 'constructor-key',     // Uses constructor value
   baseURL: 'constructor-url',    // Uses constructor value
-  // agentModel uses WAVE_MODEL from environment
+  // model uses WAVE_MODEL from environment
 });
 
 // Partial override example  
@@ -152,7 +152,7 @@ const agent = await Agent.create({
   baseURL: process.env.NODE_ENV === 'production' 
     ? 'https://prod-gateway.com'
     : 'https://dev-gateway.com',
-  agentModel: process.env.NODE_ENV === 'production'
+  model: process.env.NODE_ENV === 'production'
     ? 'gemini-3-flash'
     : 'gemini-2.5-flash', // Cheaper model for development
   fastModel: 'gemini-2.5-flash',

--- a/specs/007-agent-constructor-config/research.md
+++ b/specs/007-agent-constructor-config/research.md
@@ -21,7 +21,7 @@ interface AgentOptions {
   // Flattened configuration parameters
   apiKey?: string;
   baseURL?: string;
-  agentModel?: string;
+  model?: string;
   fastModel?: string;
   maxInputTokens?: number;
 }
@@ -43,7 +43,7 @@ interface AgentOptions {
   // All optional configuration with env fallbacks
   apiKey?: string;
   baseURL?: string;
-  agentModel?: string;
+  model?: string;
   fastModel?: string;
   maxInputTokens?: number;
   // ... existing options
@@ -115,7 +115,7 @@ function validateGatewayConfig(apiKey?: string, baseURL?: string): void {
 **Environment Variable Mapping**:
 - `apiKey` ↔ `process.env.WAVE_API_KEY`
 - `baseURL` ↔ `process.env.WAVE_BASE_URL`
-- `agentModel` ↔ `process.env.WAVE_MODEL`
+- `model` ↔ `process.env.WAVE_MODEL`
 - `fastModel` ↔ `process.env.WAVE_FAST_MODEL`
 - `maxInputTokens` ↔ `process.env.WAVE_MAX_INPUT_TOKENS`
 

--- a/specs/007-agent-constructor-config/spec.md
+++ b/specs/007-agent-constructor-config/spec.md
@@ -63,7 +63,7 @@ Developers need to specify default AI models (agent model and fast model) throug
 
 - **FR-001**: Agent constructor MUST accept optional `apiKey` string parameter with fallback to WAVE_API_KEY environment variable
 - **FR-002**: Agent constructor MUST accept optional `baseURL` string parameter with fallback to WAVE_BASE_URL environment variable
-- **FR-003**: Agent constructor MUST accept optional `agentModel` string parameter with fallback to WAVE_MODEL environment variable
+- **FR-003**: Agent constructor MUST accept optional `model` string parameter with fallback to WAVE_MODEL environment variable
 - **FR-004**: Agent constructor MUST accept optional `fastModel` string parameter with fallback to WAVE_FAST_MODEL environment variable
 - **FR-005**: Agent constructor MUST accept optional `maxInputTokens` number parameter with fallback to WAVE_MAX_INPUT_TOKENS environment variable
 - **FR-006**: System MUST validate resolved configuration and throw clear errors for missing/invalid values
@@ -74,7 +74,7 @@ Developers need to specify default AI models (agent model and fast model) throug
 
 ### Key Entities *(include if feature involves data)*
 
-- **AgentConfig**: Flattened configuration parameters directly in AgentOptions (apiKey, baseURL, agentModel, fastModel, maxInputTokens)
+- **AgentConfig**: Flattened configuration parameters directly in AgentOptions (apiKey, baseURL, model, fastModel, maxInputTokens)
 - **GatewayConfig**: Resolved configuration for gateway service including authentication and endpoint details
 - **ModelConfig**: Resolved model selection configuration specifying which models to use for different operations
 

--- a/specs/007-agent-constructor-config/tasks.md
+++ b/specs/007-agent-constructor-config/tasks.md
@@ -85,7 +85,7 @@
 
 **Goal**: Enable developers to specify AI models (agent model and fast model) through Agent constructor instead of environment variables
 
-**Independent Test**: Create Agent with custom agentModel and fastModel, verify specified models are used for AI operations instead of environment variables or defaults
+**Independent Test**: Create Agent with custom model and fastModel, verify specified models are used for AI operations instead of environment variables or defaults
 
 ### Implementation for User Story 3
 

--- a/specs/021-prompt-cache-control/quickstart.md
+++ b/specs/021-prompt-cache-control/quickstart.md
@@ -64,10 +64,10 @@ export interface CacheControl {
 
 ```typescript
 // Add before createParams construction (line ~195)
-if (isClaudeModel(model || modelConfig.agentModel)) {
+if (isClaudeModel(model || modelConfig.model)) {
   openaiMessages = transformMessagesForClaudeCache(
     openaiMessages,
-    model || modelConfig.agentModel,
+    model || modelConfig.model,
     tools
   );
   
@@ -81,7 +81,7 @@ if (isClaudeModel(model || modelConfig.agentModel)) {
 
 ```typescript
 // Extend usage object for Claude models
-if (response.usage && isClaudeModel(model || modelConfig.agentModel)) {
+if (response.usage && isClaudeModel(model || modelConfig.model)) {
   totalUsage = extendUsageWithCacheMetrics(response.usage, responseHeaders);
 }
 ```

--- a/specs/021-prompt-cache-control/tasks.md
+++ b/specs/021-prompt-cache-control/tasks.md
@@ -171,10 +171,10 @@ export function addCacheControlToContent(
 #### T009: System Message Integration
 ```typescript
 // Integration point in aiService.ts after line 183
-if (isClaudeModel(model || modelConfig.agentModel)) {
+if (isClaudeModel(model || modelConfig.model)) {
   openaiMessages = transformMessagesForClaudeCache(
     openaiMessages,
-    model || modelConfig.agentModel
+    model || modelConfig.model
   );
 }
 ```

--- a/specs/069-add-status-command/research.md
+++ b/specs/069-add-status-command/research.md
@@ -18,7 +18,7 @@ The version will be read from `packages/code/package.json`. Since we are using E
 - **Session ID**: Available via `agent.sessionId`.
 - **CWD**: Available via `agent.workingDirectory`.
 - **Base URL**: Available via `agent.getGatewayConfig().baseURL`.
-- **Model**: Available via `agent.getModelConfig().agentModel`.
+- **Model**: Available via `agent.getModelConfig().model`.
 
 #### 3. UI Implementation
 - **Component**: `StatusCommand.tsx` in `packages/code/src/components`.


### PR DESCRIPTION
Renamed 'agentModel' to 'model' in AgentOptions, ModelConfig, and throughout the codebase for better consistency.