### PR TITLE
feat: add --model flag to specify AI model from CLI

### DIFF
--- a/packages/code/src/cli.tsx
+++ b/packages/code/src/cli.tsx
@@ -20,6 +20,7 @@ export async function startCli(options: CliOptions): Promise<void> {
     worktreeSession,
     workdir,
     version,
+    model,
   } = options;
 
   // Continue with ink-based UI for normal mode
@@ -41,6 +42,7 @@ export async function startCli(options: CliOptions): Promise<void> {
       worktreeSession={worktreeSession}
       workdir={workdir}
       version={version}
+      model={model}
       onExit={handleExit}
     />,
     { exitOnCtrlC: false },

--- a/packages/code/src/components/App.tsx
+++ b/packages/code/src/components/App.tsx
@@ -28,6 +28,7 @@ const AppWithProviders: React.FC<AppWithProvidersProps> = ({
   worktreeSession,
   workdir,
   version,
+  model,
   onExit,
 }) => {
   const [isExiting, setIsExiting] = useState(false);
@@ -98,6 +99,7 @@ const AppWithProviders: React.FC<AppWithProvidersProps> = ({
       workdir={workdir}
       worktreeSession={worktreeSession}
       version={version}
+      model={model}
     >
       <ChatInterfaceWithRemount />
     </ChatProvider>
@@ -160,6 +162,7 @@ export const App: React.FC<AppProps> = ({
   worktreeSession,
   workdir,
   version,
+  model,
   onExit,
 }) => {
   return (
@@ -174,6 +177,7 @@ export const App: React.FC<AppProps> = ({
         worktreeSession={worktreeSession}
         workdir={workdir}
         version={version}
+        model={model}
         onExit={onExit}
       />
     </AppProvider>

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -124,6 +124,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   workdir,
   worktreeSession,
   version,
+  model,
 }) => {
   const { restoreSessionId, continueLastSession } = useAppConfig();
 
@@ -330,6 +331,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
           workdir,
           worktreeName: worktreeSession?.name,
           isNewWorktree: worktreeSession?.isNew,
+          model,
         });
 
         agentRef.current = agent;

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -65,6 +65,11 @@ export async function main() {
         type: "string",
         global: false,
       })
+      .option("model", {
+        description: "Specify the AI model to use",
+        type: "string",
+        global: false,
+      })
       .command(
         "plugin",
         "Manage plugins and marketplaces",
@@ -294,6 +299,7 @@ export async function main() {
         worktreeSession,
         workdir,
         version,
+        model: argv.model as string | undefined,
       });
     }
 
@@ -301,28 +307,32 @@ export async function main() {
     if (argv.print !== undefined) {
       const { startPrintCli } = await import("./print-cli.js");
       return startPrintCli({
-        restoreSessionId: argv.restore,
-        continueLastSession: argv.continue,
+        restoreSessionId: argv.restore as string | undefined,
+        continueLastSession: argv.continue as boolean | undefined,
         message: argv.print,
-        showStats: argv.showStats,
-        bypassPermissions: argv.dangerouslySkipPermissions,
+        showStats: argv.showStats as boolean | undefined,
+        bypassPermissions: argv.dangerouslySkipPermissions as
+          | boolean
+          | undefined,
         pluginDirs,
         tools,
         worktreeSession,
         workdir,
         version,
+        model: argv.model as string | undefined,
       });
     }
 
     await startCli({
-      restoreSessionId: argv.restore,
-      continueLastSession: argv.continue,
-      bypassPermissions: argv.dangerouslySkipPermissions,
+      restoreSessionId: argv.restore as string | undefined,
+      continueLastSession: argv.continue as boolean | undefined,
+      bypassPermissions: argv.dangerouslySkipPermissions as boolean | undefined,
       pluginDirs,
       tools,
       worktreeSession,
       workdir,
       version,
+      model: argv.model as string | undefined,
     });
   } catch (error) {
     console.error("Failed to start WAVE Code:", error);

--- a/packages/code/src/print-cli.ts
+++ b/packages/code/src/print-cli.ts
@@ -42,6 +42,7 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
     tools,
     worktreeSession,
     workdir,
+    model,
   } = options;
 
   if (
@@ -147,6 +148,7 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
       plugins: pluginDirs?.map((path) => ({ type: "local", path })),
       tools,
       workdir,
+      model,
       // 保持流式模式以获得更好的命令行用户体验
     });
 

--- a/packages/code/src/types.ts
+++ b/packages/code/src/types.ts
@@ -7,4 +7,5 @@ export interface BaseAppProps {
   worktreeSession?: WorktreeSession;
   workdir?: string;
   version?: string;
+  model?: string;
 }


### PR DESCRIPTION
This PR adds a new `--model` flag to the CLI, allowing users to override the default AI model from the command line.

Key changes:
- Updated `BaseAppProps` to include `model`.
- Added `--model` option to `yargs` in `packages/code/src/index.ts`.
- Propagated the `model` option through `startCli`, `App`, and `ChatProvider`.
- Updated `startPrintCli` to support the `model` option.