### PR TITLE
Refactor: Move tool-specific prompts to tool descriptions

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -132,7 +132,15 @@ export class AIManager {
    * Get filtered tool configuration based on tools list
    */
   private getFilteredToolsConfig(tools?: string[]) {
-    const allTools = this.toolManager.getToolsConfig();
+    // Get available subagents and skills for dynamic prompts
+    const availableSubagents = this.subagentManager?.getConfigurations();
+    const availableSkills = this.skillManager?.getAvailableSkills();
+
+    const allTools = this.toolManager.getToolsConfig({
+      availableSubagents,
+      availableSkills,
+      workdir: this.workdir,
+    });
 
     // If no tools specified, return all tools
     if (!tools || tools.length === 0) {
@@ -383,10 +391,6 @@ export class AIManager {
         }
       }
 
-      // Get available subagents and skills for dynamic prompts
-      const availableSubagents = this.subagentManager?.getConfigurations();
-      const availableSkills = this.skillManager?.getAvailableSkills();
-
       // Call AI service with streaming callbacks if enabled
       const callAgentOptions: CallAgentOptions = {
         gatewayConfig: this.getGatewayConfig(),
@@ -406,8 +410,6 @@ export class AIManager {
             language: this.getLanguage(),
             isSubagent: !!this.subagentType,
             planMode: planModeOptions,
-            availableSubagents,
-            availableSkills,
           },
         ), // Pass custom system prompt
         maxTokens: maxTokens, // Pass max tokens override

--- a/packages/agent-sdk/src/managers/toolManager.ts
+++ b/packages/agent-sdk/src/managers/toolManager.ts
@@ -37,6 +37,9 @@ import { Container } from "../utils/container.js";
 
 import { logger } from "../utils/globalLogger.js";
 
+import type { SubagentConfiguration } from "../utils/subagentParser.js";
+import type { SkillMetadata } from "../types/skills.js";
+
 export interface ToolManagerOptions {
   container: Container;
   /** Optional list of tool names to enable */
@@ -244,7 +247,11 @@ class ToolManager {
     return [...builtInTools, ...mcpTools];
   }
 
-  getToolsConfig(): ChatCompletionFunctionTool[] {
+  getToolsConfig(options?: {
+    availableSubagents?: SubagentConfiguration[];
+    availableSkills?: SkillMetadata[];
+    workdir?: string;
+  }): ChatCompletionFunctionTool[] {
     const effectivePermissionMode = this.getPermissionMode();
     const builtInToolsConfig = Array.from(this.toolsRegistry.values())
       .filter((tool) => {
@@ -258,7 +265,20 @@ class ToolManager {
         }
         return true;
       })
-      .map((tool) => tool.config);
+      .map((tool) => {
+        // Create a copy of the tool config to avoid modifying the original
+        const config = {
+          ...tool.config,
+          function: {
+            ...tool.config.function,
+          },
+        };
+        // Override description with prompt if available
+        if (tool.prompt) {
+          config.function.description = tool.prompt(options);
+        }
+        return config;
+      });
     const mcpToolsConfig = this.mcpManager.getMcpToolsConfig();
     return [...builtInToolsConfig, ...mcpToolsConfig];
   }

--- a/packages/agent-sdk/src/prompts/index.ts
+++ b/packages/agent-sdk/src/prompts/index.ts
@@ -288,9 +288,6 @@ Any promises made to the user
 Be concise but complete—err on the side of including information that would prevent duplicate work or repeated mistakes. Write in a way that enables immediate resumption of the task.
 Wrap your summary in <summary></summary> tags.`;
 
-import type { SubagentConfiguration } from "../utils/subagentParser.js";
-import type { SkillMetadata } from "../types/skills.js";
-
 export function buildSystemPrompt(
   basePrompt: string | undefined,
   tools: ToolPlugin[],
@@ -303,23 +300,11 @@ export function buildSystemPrompt(
       planFilePath: string;
       planExists: boolean;
     };
-    availableSubagents?: SubagentConfiguration[];
-    availableSkills?: SkillMetadata[];
   } = {},
 ): string {
   let prompt = basePrompt || DEFAULT_SYSTEM_PROMPT;
   if (tools.length > 0) {
     prompt += `\n\n${TOOL_POLICY}`;
-  }
-
-  for (const tool of tools) {
-    if (tool.prompt) {
-      prompt += tool.prompt({
-        availableSubagents: options.availableSubagents,
-        availableSkills: options.availableSkills,
-        workdir: options.workdir,
-      });
-    }
   }
 
   if (options.language) {

--- a/packages/agent-sdk/src/tools/lspTool.ts
+++ b/packages/agent-sdk/src/tools/lspTool.ts
@@ -486,25 +486,7 @@ export const lspTool: ToolPlugin = {
     type: "function",
     function: {
       name: LSP_TOOL_NAME,
-      description: `Interact with Language Server Protocol (LSP) servers to get code intelligence features.
-
-Supported operations:
-- goToDefinition: Find where a symbol is defined
-- findReferences: Find all references to a symbol
-- hover: Get hover information (documentation, type info) for a symbol
-- documentSymbol: Get all symbols (functions, classes, variables) in a document
-- workspaceSymbol: Search for symbols across the entire workspace
-- goToImplementation: Find implementations of an interface or abstract method
-- prepareCallHierarchy: Get call hierarchy item at a position (functions/methods)
-- incomingCalls: Find all functions/methods that call the function at a position
-- outgoingCalls: Find all functions/methods called by the function at a position
-
-All operations require:
-- filePath: The file to operate on
-- line: The line number (1-based, as shown in editors)
-- character: The character offset (1-based, as shown in editors)
-
-Note: LSP servers must be configured for the file type. If no server is available, an error will be returned.`,
+      description: `Interact with Language Server Protocol (LSP) servers to get code intelligence features.`,
       parameters: {
         type: "object",
         properties: {
@@ -540,6 +522,26 @@ Note: LSP servers must be configured for the file type. If no server is availabl
       },
     },
   },
+  prompt:
+    () => `Interact with Language Server Protocol (LSP) servers to get code intelligence features.
+
+Supported operations:
+- goToDefinition: Find where a symbol is defined
+- findReferences: Find all references to a symbol
+- hover: Get hover information (documentation, type info) for a symbol
+- documentSymbol: Get all symbols (functions, classes, variables) in a document
+- workspaceSymbol: Search for symbols across the entire workspace
+- goToImplementation: Find implementations of an interface or abstract method
+- prepareCallHierarchy: Get call hierarchy item at a position (functions/methods)
+- incomingCalls: Find all functions/methods that call the function at a position
+- outgoingCalls: Find all functions/methods called by the function at a position
+
+All operations require:
+- filePath: The file to operate on
+- line: The line number (1-based, as shown in editors)
+- character: The character offset (1-based, as shown in editors)
+
+Note: LSP servers must be configured for the file type. If no server is available, an error will be returned.`,
   execute: async (
     args: Record<string, unknown>,
     context: ToolContext,

--- a/packages/agent-sdk/src/tools/types.ts
+++ b/packages/agent-sdk/src/tools/types.ts
@@ -23,7 +23,7 @@ export interface ToolPlugin {
     context: ToolContext,
   ) => string;
   /**
-   * Optional function to provide a prompt to be added to the system prompt
+   * Function to provide a prompt to be added to the tool description
    */
   prompt?: (args?: {
     availableSubagents?: SubagentConfiguration[];

--- a/packages/agent-sdk/tests/constants/buildSystemPrompt.test.ts
+++ b/packages/agent-sdk/tests/constants/buildSystemPrompt.test.ts
@@ -24,7 +24,7 @@ describe("buildSystemPrompt", () => {
     expect(prompt).not.toContain(TOOL_POLICY);
   });
 
-  it("should include tool-specific prompts when tools are present", () => {
+  it("should NOT include tool-specific prompts when tools are present", () => {
     const tools = [
       {
         name: READ_TOOL_NAME,
@@ -36,19 +36,7 @@ describe("buildSystemPrompt", () => {
       } as unknown as ToolPlugin,
     ];
     const prompt = buildSystemPrompt(DEFAULT_SYSTEM_PROMPT, tools);
-    expect(prompt).toContain("Read for reading files");
-    expect(prompt).toContain("Write for creating files");
-  });
-
-  it("should exclude tool-specific prompts when tools are missing", () => {
-    const tools = [
-      {
-        name: READ_TOOL_NAME,
-        prompt: () => "Read for reading files",
-      } as unknown as ToolPlugin,
-    ];
-    const prompt = buildSystemPrompt(DEFAULT_SYSTEM_PROMPT, tools);
-    expect(prompt).toContain("Read for reading files");
+    expect(prompt).not.toContain("Read for reading files");
     expect(prompt).not.toContain("Write for creating files");
   });
 });


### PR DESCRIPTION
This PR moves tool-specific usage instructions from the system prompt directly into the tool's function description. This simplifies system prompt construction and keeps instructions closer to the tool definitions.