### PR TITLE
Move /clear slash command from SDK to CLI

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -225,9 +225,6 @@ export class Agent {
       configurationService: this.configurationService,
       systemPrompt: this.systemPrompt,
       stream: this.stream,
-      onSessionIdChange: () => {
-        this.taskManager.setTaskListId(this.messageManager.getRootSessionId());
-      },
       onTasksChange: (tasks) => {
         this.options.callbacks?.onTasksChange?.(tasks);
       },

--- a/packages/agent-sdk/src/managers/messageManager.ts
+++ b/packages/agent-sdk/src/managers/messageManager.ts
@@ -266,8 +266,9 @@ export class MessageManager {
    */
   public clearMessages(): void {
     this.setMessages([]);
-    this.setSessionId(generateSessionId());
-    this.rootSessionId = this.sessionId;
+    const newSessionId = generateSessionId();
+    this.rootSessionId = newSessionId;
+    this.setSessionId(newSessionId);
     this.setlatestTotalTokens(0);
     this.savedMessageCount = 0; // Reset saved message count
   }

--- a/packages/agent-sdk/src/managers/slashCommandManager.ts
+++ b/packages/agent-sdk/src/managers/slashCommandManager.ts
@@ -62,24 +62,6 @@ export class SlashCommandManager {
   }
 
   private initializeBuiltinCommands(): void {
-    // Register built-in clear command
-    this.registerCommand({
-      id: "clear",
-      name: "clear",
-      description: "Clear the chat session and terminal",
-      handler: () => {
-        // Clear chat messages
-        this.messageManager.clearMessages();
-
-        // Reset task list if WAVE_TASK_LIST_ID is not set
-        if (!process.env.WAVE_TASK_LIST_ID) {
-          const newTaskListId = this.messageManager.getRootSessionId();
-          this.taskManager.setTaskListId(newTaskListId);
-          this.taskManager.emit("tasksChange", newTaskListId);
-        }
-      },
-    });
-
     // Register built-in init command
     this.registerCommand({
       id: "init",

--- a/packages/agent-sdk/src/services/taskManager.ts
+++ b/packages/agent-sdk/src/services/taskManager.ts
@@ -5,6 +5,7 @@ import { EventEmitter } from "events";
 import { Task } from "../types/tasks.js";
 import { logger } from "../utils/globalLogger.js";
 import { Container } from "../utils/container.js";
+import type { MessageManager } from "../managers/messageManager.js";
 
 export class TaskManager extends EventEmitter {
   private readonly baseDir: string;
@@ -25,6 +26,21 @@ export class TaskManager extends EventEmitter {
 
   public setTaskListId(taskListId: string): void {
     this.taskListId = taskListId;
+  }
+
+  /**
+   * Syncs the task list ID with the current session's root session ID.
+   * This is typically called when the session is cleared or compressed.
+   */
+  public async syncWithSession(): Promise<void> {
+    const messageManager = this.container.get<MessageManager>("MessageManager");
+    if (!messageManager) return;
+
+    const rootSessionId = messageManager.getRootSessionId();
+    if (this.taskListId !== rootSessionId && !process.env.WAVE_TASK_LIST_ID) {
+      this.setTaskListId(rootSessionId);
+      await this.refreshTasks();
+    }
   }
 
   private getSessionDir(): string {

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -41,7 +41,6 @@ export interface AgentContainerSetupOptions {
   stream: boolean;
 
   // Callbacks to Agent methods
-  onSessionIdChange: (sessionId: string) => void;
   onBackgroundTasksChange: (tasks: BackgroundTask[]) => void;
   onTasksChange: (tasks: Task[]) => void;
   onPermissionModeChange: (mode: PermissionMode) => void;
@@ -66,7 +65,6 @@ export function setupAgentContainer(
     configurationService,
     systemPrompt,
     stream,
-    onSessionIdChange,
     onBackgroundTasksChange,
     onTasksChange,
     onPermissionModeChange,
@@ -94,7 +92,12 @@ export function setupAgentContainer(
     callbacks: {
       ...callbacks,
       onSessionIdChange: (sessionId) => {
-        onSessionIdChange(sessionId);
+        const taskManager = container.get<TaskManager>("TaskManager");
+        if (taskManager) {
+          taskManager.syncWithSession().catch((error) => {
+            logger.error("Failed to sync task list with session:", error);
+          });
+        }
         callbacks.onSessionIdChange?.(sessionId);
       },
     },

--- a/packages/agent-sdk/tests/agent/agent.taskListId.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.taskListId.test.ts
@@ -39,6 +39,7 @@ vi.mock("../../src/services/taskManager.js", () => {
     listTasks: vi.fn().mockResolvedValue([]),
     getTaskListId: vi.fn(),
     setTaskListId: vi.fn(),
+    refreshTasks: vi.fn().mockResolvedValue(undefined),
   };
   return {
     TaskManager: vi.fn().mockImplementation(function (taskListId: string) {

--- a/packages/agent-sdk/tests/agent/agent.taskSessionRestore.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.taskSessionRestore.test.ts
@@ -41,6 +41,9 @@ vi.mock("../../src/services/taskManager.js", () => {
       },
     ]),
     setTaskListId: vi.fn(),
+    getTaskListId: vi.fn().mockReturnValue("initial-task-list-id"),
+    refreshTasks: vi.fn().mockResolvedValue(undefined),
+    syncWithSession: vi.fn().mockResolvedValue(undefined),
   };
   return {
     TaskManager: vi.fn(function () {

--- a/packages/agent-sdk/tests/agent/exitPlanMode.clearContext.test.ts
+++ b/packages/agent-sdk/tests/agent/exitPlanMode.clearContext.test.ts
@@ -18,6 +18,23 @@ interface AgentInternal {
 // Mock fs/promises
 vi.mock("fs/promises");
 
+// Mock AI Service
+vi.mock("@/services/aiService", () => ({
+  createChatCompletion: vi.fn().mockImplementation(async () => {
+    return {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "Test response",
+          },
+          finish_reason: "stop",
+        },
+      ],
+    };
+  }),
+}));
+
 describe("ExitPlanMode Clear Context", () => {
   const originalEnv = process.env;
   let mockStdout: typeof process.stdout.write;

--- a/packages/agent-sdk/tests/helpers/mockFactories.ts
+++ b/packages/agent-sdk/tests/helpers/mockFactories.ts
@@ -24,6 +24,9 @@ export const createMockTaskManager = (): TaskManager => {
     getTask: vi.fn(),
     updateTask: vi.fn(),
     listTasks: vi.fn(),
+    getTaskListId: vi.fn().mockReturnValue("test-task-list"),
+    refreshTasks: vi.fn().mockResolvedValue(undefined),
+    syncWithSession: vi.fn().mockResolvedValue(undefined),
     on: vi.fn(),
     emit: vi.fn(),
   } as unknown as TaskManager;

--- a/packages/agent-sdk/tests/managers/slashCommandManager.clear.test.ts
+++ b/packages/agent-sdk/tests/managers/slashCommandManager.clear.test.ts
@@ -1,77 +1,11 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
-import { SlashCommandManager } from "../../src/managers/slashCommandManager.js";
-import { MessageManager } from "../../src/managers/messageManager.js";
-import { TaskManager } from "../../src/services/taskManager.js";
-import { AIManager } from "../../src/managers/aiManager.js";
-import { BackgroundTaskManager } from "../../src/managers/backgroundTaskManager.js";
-import { Container } from "../../src/utils/container.js";
+import { describe, it } from "vitest";
 
 describe("SlashCommandManager /clear reset", () => {
-  let slashCommandManager: SlashCommandManager;
-  let messageManager: MessageManager;
-  let taskManager: TaskManager;
-  let aiManager: AIManager;
-  const container = new Container();
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-
-    messageManager = new MessageManager(container, {
-      callbacks: {},
-      workdir: "/test/workdir",
-    });
-
-    taskManager = new TaskManager(container, "initial-task-list-id");
-    vi.spyOn(taskManager, "setTaskListId");
-    vi.spyOn(taskManager, "emit");
-
-    aiManager = {} as AIManager;
-
-    container.register("MessageManager", messageManager);
-    container.register("AIManager", aiManager);
-    container.register("BackgroundTaskManager", {} as BackgroundTaskManager);
-    container.register("TaskManager", taskManager);
-
-    slashCommandManager = new SlashCommandManager(container, {
-      workdir: "/test/workdir",
-    });
-    slashCommandManager.initialize();
+  it.skip("should reset task list ID and emit tasksChange when /clear is called and WAVE_TASK_LIST_ID is not set", async () => {
+    // This test is no longer relevant as /clear has been moved to CLI
   });
 
-  it("should reset task list ID and emit tasksChange when /clear is called and WAVE_TASK_LIST_ID is not set", async () => {
-    const initialRootSessionId = messageManager.getRootSessionId();
-    expect(taskManager.getTaskListId()).toBe("initial-task-list-id");
-
-    await slashCommandManager.executeCommand("clear");
-
-    const newRootSessionId = messageManager.getRootSessionId();
-    expect(newRootSessionId).not.toBe(initialRootSessionId);
-    expect(taskManager.setTaskListId).toHaveBeenCalledWith(newRootSessionId);
-    expect(taskManager.emit).toHaveBeenCalledWith(
-      "tasksChange",
-      newRootSessionId,
-    );
-    expect(taskManager.getTaskListId()).toBe(newRootSessionId);
-  });
-
-  it("should NOT reset task list ID when /clear is called and WAVE_TASK_LIST_ID is set", async () => {
-    process.env.WAVE_TASK_LIST_ID = "fixed-task-list-id";
-
-    // Re-initialize to pick up env var if needed, but our implementation checks it at runtime
-    const initialRootSessionId = messageManager.getRootSessionId();
-
-    await slashCommandManager.executeCommand("clear");
-
-    const newRootSessionId = messageManager.getRootSessionId();
-    expect(newRootSessionId).not.toBe(initialRootSessionId);
-
-    expect(taskManager.setTaskListId).not.toHaveBeenCalled();
-    expect(taskManager.emit).not.toHaveBeenCalledWith(
-      "tasksChange",
-      expect.any(String),
-    );
-    expect(taskManager.getTaskListId()).toBe("initial-task-list-id");
-
-    delete process.env.WAVE_TASK_LIST_ID;
+  it.skip("should NOT reset task list ID when /clear is called and WAVE_TASK_LIST_ID is set", async () => {
+    // This test is no longer relevant as /clear has been moved to CLI
   });
 });

--- a/packages/agent-sdk/tests/managers/slashCommandManager.nested.test.ts
+++ b/packages/agent-sdk/tests/managers/slashCommandManager.nested.test.ts
@@ -202,8 +202,8 @@ describe("SlashCommandManager Nested Command Integration", () => {
 
       const commands = slashCommandManager.getCommands();
 
-      // Should have built-in clear, init + 6 custom commands
-      expect(commands).toHaveLength(8);
+      // Should have built-in init + 6 custom commands
+      expect(commands).toHaveLength(7);
 
       // Check that both flat and nested commands are registered
       expect(slashCommandManager.hasCommand("help")).toBe(true);
@@ -422,9 +422,9 @@ describe("SlashCommandManager Nested Command Integration", () => {
       // Should include built-in commands + custom commands
       expect(commands.length).toBeGreaterThan(0);
 
-      // Built-in clear command should still be there
-      const clearCommand = commands.find((cmd) => cmd.id === "clear");
-      expect(clearCommand).toBeDefined();
+      // Built-in init command should still be there
+      const initCommand = commands.find((cmd) => cmd.id === "init");
+      expect(initCommand).toBeDefined();
 
       // Custom flat commands should be there
       const helpCommand = commands.find((cmd) => cmd.id === "help");

--- a/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
+++ b/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
@@ -59,41 +59,6 @@ describe("SlashCommandManager", () => {
   });
 
   describe("Basic Command Management", () => {
-    it("should have a built-in clear command", () => {
-      const commands = slashCommandManager.getCommands();
-
-      const clearCommand = commands.find((cmd) => cmd.id === "clear");
-      expect(clearCommand).toBeDefined();
-      expect(clearCommand?.name).toBe("clear");
-      expect(clearCommand?.description).toBe(
-        "Clear the chat session and terminal",
-      );
-    });
-
-    it("should be able to check if clear command exists", () => {
-      expect(slashCommandManager.hasCommand("clear")).toBe(true);
-      expect(slashCommandManager.hasCommand("nonexistent")).toBe(false);
-    });
-
-    it("should be able to execute clear command", async () => {
-      const result = await slashCommandManager.executeCommand("clear");
-      expect(result).toBe(true);
-    });
-
-    it("should return false when executing non-existent command", async () => {
-      const result = await slashCommandManager.executeCommand("nonexistent");
-      expect(result).toBe(false);
-    });
-
-    it("should return correct command by id", () => {
-      const clearCommand = slashCommandManager.getCommand("clear");
-      expect(clearCommand).toBeDefined();
-      expect(clearCommand?.id).toBe("clear");
-
-      const nonExistentCommand = slashCommandManager.getCommand("nonexistent");
-      expect(nonExistentCommand).toBeUndefined();
-    });
-
     it("should have a built-in init command", () => {
       const commands = slashCommandManager.getCommands();
 
@@ -103,6 +68,30 @@ describe("SlashCommandManager", () => {
       expect(initCommand?.description).toBe(
         "Initialize repository for AI agents by generating AGENTS.md",
       );
+    });
+
+    it("should be able to check if init command exists", () => {
+      expect(slashCommandManager.hasCommand("init")).toBe(true);
+      expect(slashCommandManager.hasCommand("nonexistent")).toBe(false);
+    });
+
+    it("should be able to execute init command", async () => {
+      const result = await slashCommandManager.executeCommand("init");
+      expect(result).toBe(true);
+    });
+
+    it("should return false when executing non-existent command", async () => {
+      const result = await slashCommandManager.executeCommand("nonexistent");
+      expect(result).toBe(false);
+    });
+
+    it("should return correct command by id", () => {
+      const initCommand = slashCommandManager.getCommand("init");
+      expect(initCommand).toBeDefined();
+      expect(initCommand?.id).toBe("init");
+
+      const nonExistentCommand = slashCommandManager.getCommand("nonexistent");
+      expect(nonExistentCommand).toBeUndefined();
     });
   });
 
@@ -118,10 +107,10 @@ describe("SlashCommandManager", () => {
     });
 
     it("should validate existing slash commands correctly", () => {
-      const result = slashCommandManager.parseAndValidateSlashCommand("/clear");
+      const result = slashCommandManager.parseAndValidateSlashCommand("/init");
 
       expect(result.isValid).toBe(true);
-      expect(result.commandId).toBe("clear");
+      expect(result.commandId).toBe("init");
       expect(result.args).toBeUndefined();
     });
 
@@ -160,10 +149,10 @@ describe("SlashCommandManager", () => {
 
     it("should handle command with empty args correctly", () => {
       const result =
-        slashCommandManager.parseAndValidateSlashCommand("/clear   ");
+        slashCommandManager.parseAndValidateSlashCommand("/init   ");
 
       expect(result.isValid).toBe(true);
-      expect(result.commandId).toBe("clear");
+      expect(result.commandId).toBe("init");
       expect(result.args).toBeUndefined(); // Empty args should be undefined
     });
 

--- a/packages/agent-sdk/tests/managers/subagentManager.abort.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.abort.test.ts
@@ -58,6 +58,7 @@ describe("SubagentManager - Abort Logic", () => {
     const taskManager = {
       on: vi.fn(),
       listTasks: vi.fn().mockResolvedValue([]),
+      getTaskListId: vi.fn().mockReturnValue("test-task-list"),
     } as unknown as TaskManager;
 
     container = new Container();

--- a/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
@@ -55,6 +55,7 @@ describe("SubagentManager - Backgrounding Coverage", () => {
     const taskManager = {
       on: vi.fn(),
       listTasks: vi.fn().mockResolvedValue([]),
+      getTaskListId: vi.fn().mockReturnValue("test-task-list"),
     } as unknown as TaskManager;
 
     container = new Container();

--- a/packages/agent-sdk/tests/managers/toolManager.public.test.ts
+++ b/packages/agent-sdk/tests/managers/toolManager.public.test.ts
@@ -44,6 +44,7 @@ describe("ToolManager.initializeBuiltInTools", () => {
 
     const mockTaskManager = {
       listTasks: vi.fn().mockResolvedValue([]),
+      getTaskListId: vi.fn().mockReturnValue("test-task-list"),
     } as unknown as import("@/services/taskManager.js").TaskManager;
 
     const mockReversionManager =

--- a/packages/code/src/components/CommandSelector.tsx
+++ b/packages/code/src/components/CommandSelector.tsx
@@ -34,6 +34,12 @@ const AVAILABLE_COMMANDS: SlashCommand[] = [
     description: "Show agent status and configuration",
     handler: () => {}, // Handler here won't be used, actual processing is in the hook
   },
+  {
+    id: "clear",
+    name: "clear",
+    description: "Clear the chat session and terminal",
+    handler: () => {}, // Handler here won't be used, actual processing is in the hook
+  },
 ];
 
 export interface CommandSelectorProps {

--- a/packages/code/src/components/HelpView.tsx
+++ b/packages/code/src/components/HelpView.tsx
@@ -22,6 +22,7 @@ export const HelpView: React.FC<HelpViewProps> = ({ onCancel }) => {
     { key: "Ctrl+V", description: "Paste image" },
     { key: "Shift+Tab", description: "Cycle permission mode" },
     { key: "/status", description: "Show agent status and configuration" },
+    { key: "/clear", description: "Clear the chat session and terminal" },
     {
       key: "Esc",
       description: "Interrupt AI or command / Cancel selector / Close help",

--- a/packages/code/src/components/InputBox.tsx
+++ b/packages/code/src/components/InputBox.tsx
@@ -58,6 +58,7 @@ export const InputBox: React.FC<InputBoxProps> = ({
     backgroundCurrentTask,
     messages,
     getFullMessageThread,
+    clearMessages,
   } = useChat();
 
   // Input manager with all input state and functionality (including images)
@@ -108,6 +109,7 @@ export const InputBox: React.FC<InputBoxProps> = ({
     onAbortMessage: abortMessage,
     onBackgroundCurrentTask: backgroundCurrentTask,
     onPermissionModeChange: setChatPermissionMode,
+    onClearMessages: clearMessages,
   });
 
   // Sync permission mode from useChat to InputManager

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -45,6 +45,7 @@ export interface ChatContextType {
   ) => Promise<void>;
   abortMessage: () => void;
   latestTotalTokens: number;
+  clearMessages: () => void;
   // MCP functionality
   mcpServers: McpServerStatus[];
   connectMcpServer: (serverName: string) => Promise<boolean>;
@@ -450,6 +451,10 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
     agentRef.current?.abortMessage();
   }, []);
 
+  const clearMessages = useCallback(() => {
+    agentRef.current?.clearMessages();
+  }, []);
+
   // Permission management methods
   const setPermissionMode = useCallback((mode: PermissionMode) => {
     setPermissionModeState((prev) => {
@@ -617,6 +622,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
     sessionId,
     sendMessage,
     abortMessage,
+    clearMessages,
     latestTotalTokens,
     isCompressing,
     mcpServers,

--- a/packages/code/src/managers/InputManager.ts
+++ b/packages/code/src/managers/InputManager.ts
@@ -41,6 +41,7 @@ export interface InputManagerCallbacks {
   ) => void | Promise<void>;
   onHasSlashCommand?: (commandId: string) => boolean;
   onAbortMessage?: () => void;
+  onClearMessages?: () => void;
   onBackgroundCurrentTask?: () => void;
   onResetHistoryNavigation?: () => void;
   onPermissionModeChange?: (mode: PermissionMode) => void;
@@ -358,6 +359,9 @@ export class InputManager {
             commandExecuted = true;
           } else if (command === "status") {
             this.setShowStatusCommand(true);
+            commandExecuted = true;
+          } else if (command === "clear") {
+            this.callbacks.onClearMessages?.();
             commandExecuted = true;
           }
         }


### PR DESCRIPTION
Moves /clear command to CLI for better terminal handling and adds TaskManager session sync.