### PR TITLE
feat(agent-sdk): add 'by user' to tool operation denial messages

### DIFF
--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -153,7 +153,7 @@ Usage notes:
           return {
             success: false,
             content: "",
-            error: `${BASH_TOOL_NAME} operation denied, reason: ${permissionResult.message || "No reason provided"}`,
+            error: `${BASH_TOOL_NAME} operation denied by user, reason: ${permissionResult.message || "No reason provided"}`,
           };
         }
       } catch {

--- a/packages/agent-sdk/src/tools/editTool.ts
+++ b/packages/agent-sdk/src/tools/editTool.ts
@@ -182,7 +182,7 @@ Usage:
             return {
               success: false,
               content: "",
-              error: `${EDIT_TOOL_NAME} operation denied, reason: ${permissionResult.message || "No reason provided"}`,
+              error: `${EDIT_TOOL_NAME} operation denied by user, reason: ${permissionResult.message || "No reason provided"}`,
             };
           }
         } catch {

--- a/packages/agent-sdk/src/tools/writeTool.ts
+++ b/packages/agent-sdk/src/tools/writeTool.ts
@@ -123,7 +123,7 @@ Usage:
             return {
               success: false,
               content: "",
-              error: `Write operation denied, reason: ${permissionResult.message || "No reason provided"}`,
+              error: `Write operation denied by user, reason: ${permissionResult.message || "No reason provided"}`,
             };
           }
         } catch {

--- a/packages/agent-sdk/tests/tools/bashTool.test.ts
+++ b/packages/agent-sdk/tests/tools/bashTool.test.ts
@@ -309,7 +309,9 @@ describe("bashTool", () => {
       const result = await bashTool.execute({ command: "ls" }, testContext);
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain("operation denied, reason: No way");
+      expect(result.error).toContain(
+        "operation denied by user, reason: No way",
+      );
     });
 
     it("should handle permission check failure", async () => {

--- a/packages/agent-sdk/tests/tools/editTool.test.ts
+++ b/packages/agent-sdk/tests/tools/editTool.test.ts
@@ -341,7 +341,7 @@ describe("editTool", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain(
-      "Edit operation denied, reason: User denied",
+      "Edit operation denied by user, reason: User denied",
     );
   });
 

--- a/packages/agent-sdk/tests/tools/writeTool.test.ts
+++ b/packages/agent-sdk/tests/tools/writeTool.test.ts
@@ -342,7 +342,7 @@ describe("writeTool", () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain(
-        "Write operation denied, reason: Write denied",
+        "Write operation denied by user, reason: Write denied",
       );
     });
 


### PR DESCRIPTION
This PR updates the error messages for Bash, Write, and Edit tools to clarify that the operation was denied by the user.