### PR TITLE
feat(permissions): Add default allowed rules for git and safe commands

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -650,9 +650,19 @@ export class Agent {
   }
 
   /**
-   * Get all currently allowed rules (for testing and UI)
+   * Get all currently allowed rules (user-defined and default)
    */
   public getAllowedRules(): string[] {
+    return [
+      ...this.permissionManager.getAllowedRules(),
+      ...this.permissionManager.getDefaultAllowedRules(),
+    ];
+  }
+
+  /**
+   * Get only user-defined allowed rules
+   */
+  public getUserAllowedRules(): string[] {
     return this.permissionManager.getAllowedRules();
   }
 

--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -36,6 +36,29 @@ import { ConfigurationService } from "../services/configurationService.js";
 
 const SAFE_COMMANDS = ["cd", "ls", "pwd", "true", "false"];
 
+const DEFAULT_ALLOWED_RULES = [
+  "Bash(git status*)",
+  "Bash(git diff*)",
+  "Bash(git log*)",
+  "Bash(git show*)",
+  "Bash(git branch*)",
+  "Bash(git tag*)",
+  "Bash(git remote*)",
+  "Bash(git ls-files*)",
+  "Bash(git rev-parse*)",
+  "Bash(git config --list*)",
+  "Bash(git config -l*)",
+  "Bash(git cat-file*)",
+  "Bash(git count-objects*)",
+  "Bash(echo*)",
+  "Bash(which*)",
+  "Bash(type*)",
+  "Bash(hostname*)",
+  "Bash(whoami*)",
+  "Bash(date*)",
+  "Bash(uptime*)",
+];
+
 import { logger } from "../utils/globalLogger.js";
 
 export interface PermissionManagerOptions {
@@ -113,7 +136,7 @@ export class PermissionManager {
   }
 
   /**
-   * Get all currently allowed rules
+   * Get all currently allowed rules (user-defined)
    */
   public getAllowedRules(): string[] {
     return [...this.allowedRules];
@@ -131,6 +154,13 @@ export class PermissionManager {
    */
   public getAdditionalDirectories(): string[] {
     return [...this.additionalDirectories];
+  }
+
+  /**
+   * Get all default allowed rules
+   */
+  public getDefaultAllowedRules(): string[] {
+    return [...DEFAULT_ALLOWED_RULES];
   }
 
   /**
@@ -608,7 +638,12 @@ export class PermissionManager {
     }
 
     // Check persistent allowed rules
-    return isAllowedByRuleList(context, this.allowedRules);
+    if (isAllowedByRuleList(context, this.allowedRules)) {
+      return true;
+    }
+
+    // Check default allowed rules
+    return isAllowedByRuleList(context, DEFAULT_ALLOWED_RULES);
   }
 
   /**
@@ -725,7 +760,11 @@ export class PermissionManager {
     for (const ruleToAdd of rulesToAdd) {
       // 2. Update PermissionManager state
       const currentRules = this.getAllowedRules();
-      if (!currentRules.includes(ruleToAdd)) {
+      const defaultRules = this.getDefaultAllowedRules();
+      if (
+        !currentRules.includes(ruleToAdd) &&
+        !defaultRules.includes(ruleToAdd)
+      ) {
         this.updateAllowedRules([...currentRules, ruleToAdd]);
 
         // 3. Persist to settings.local.json

--- a/packages/agent-sdk/src/services/initializationService.ts
+++ b/packages/agent-sdk/src/services/initializationService.ts
@@ -23,6 +23,7 @@ import type { MessageManager } from "../managers/messageManager.js";
 import type { MemoryRuleManager } from "../managers/MemoryRuleManager.js";
 import type { LiveConfigManager } from "../managers/liveConfigManager.js";
 import type { TaskManager } from "./taskManager.js";
+import type { PermissionManager } from "../managers/permissionManager.js";
 
 export interface InitializationContext {
   skillManager: SkillManager;
@@ -131,6 +132,29 @@ export class InitializationService {
         pluginManager.updateEnabledPlugins(
           configResult.configuration.enabledPlugins,
         );
+      }
+
+      // Initialize permission manager with loaded rules
+      if (configResult.configuration?.permissions) {
+        const permissionManager =
+          context.container.get<PermissionManager>("PermissionManager");
+        if (permissionManager) {
+          if (configResult.configuration.permissions.allow) {
+            permissionManager.updateAllowedRules(
+              configResult.configuration.permissions.allow,
+            );
+          }
+          if (configResult.configuration.permissions.deny) {
+            permissionManager.updateDeniedRules(
+              configResult.configuration.permissions.deny,
+            );
+          }
+          if (configResult.configuration.permissions.defaultMode) {
+            permissionManager.updateConfiguredDefaultMode(
+              configResult.configuration.permissions.defaultMode,
+            );
+          }
+        }
       }
 
       logger?.debug("Hooks system initialized successfully");

--- a/packages/agent-sdk/tests/agent/agent.autoAccept.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.autoAccept.test.ts
@@ -70,7 +70,7 @@ describe("Agent Auto-Accept Permissions Integration", () => {
     // 2. Test persistent rule
     mockCallback.mockResolvedValueOnce({
       behavior: "allow",
-      newPermissionRule: "Bash(whoami)",
+      newPermissionRule: "Bash(npm install)",
     });
 
     // Switch back to default mode to test rule matching
@@ -78,7 +78,7 @@ describe("Agent Auto-Accept Permissions Integration", () => {
 
     await toolManager.execute(
       "Bash",
-      { command: "whoami" },
+      { command: "npm install" },
       { workdir: tempDir, taskManager },
     );
 
@@ -87,13 +87,13 @@ describe("Agent Auto-Accept Permissions Integration", () => {
     const configContent = await fs.readFile(configPath, "utf-8");
     const config = JSON.parse(configContent);
 
-    expect(config.permissions.allow).toContain("Bash(whoami)");
+    expect(config.permissions.allow).toContain("Bash(npm install*)");
 
     // 3. Test that the rule actually allows the command without calling the callback
     mockCallback.mockClear();
     await toolManager.execute(
       "Bash",
-      { command: "whoami" },
+      { command: "npm install" },
       { workdir: tempDir, taskManager },
     );
     expect(mockCallback).not.toHaveBeenCalled();

--- a/packages/agent-sdk/tests/agentAllowedRules.test.ts
+++ b/packages/agent-sdk/tests/agentAllowedRules.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Agent } from "../src/agent.js";
+import * as fs from "fs/promises";
+
+vi.mock("fs/promises");
+vi.mock("./services/session.js");
+
+describe("Agent Allowed Rules", () => {
+  const workdir = "/test/workdir";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.readFile).mockResolvedValue("");
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+  });
+
+  it("should return both user and default rules in getAllowedRules", async () => {
+    const agent = await Agent.create({
+      workdir,
+      permissionMode: "default",
+    });
+
+    await agent.addPermissionRule("Bash(npm install lodash)");
+
+    const rules = agent.getAllowedRules();
+    expect(rules).toContain("Bash(npm install*)");
+    expect(rules).toContain("Bash(git status*)");
+  });
+
+  it("should return only user rules in getUserAllowedRules", async () => {
+    const agent = await Agent.create({
+      workdir,
+      permissionMode: "default",
+    });
+
+    await agent.addPermissionRule("Bash(npm install lodash)");
+
+    const rules = agent.getUserAllowedRules();
+    expect(rules).toContain("Bash(npm install*)");
+    expect(rules).not.toContain("Bash(git status*)");
+  });
+
+  it("should NOT add a rule if it's already in default rules", async () => {
+    const agent = await Agent.create({
+      workdir,
+      permissionMode: "default",
+    });
+
+    await agent.addPermissionRule("Bash(git status)");
+
+    const userRules = agent.getUserAllowedRules();
+    expect(userRules).not.toContain("Bash(git status*)");
+    expect(userRules).not.toContain("Bash(git status)");
+  });
+});

--- a/packages/agent-sdk/tests/defaultGitRules.test.ts
+++ b/packages/agent-sdk/tests/defaultGitRules.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Agent } from "../src/agent.js";
+import * as fs from "fs/promises";
+
+vi.mock("fs/promises");
+vi.mock("./services/session.js");
+
+describe("Default Allowed Git Rules", () => {
+  const workdir = "/test/workdir";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.readFile).mockResolvedValue("");
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+  });
+
+  it("should allow read-only git commands by default", async () => {
+    const agent = await Agent.create({
+      workdir,
+      permissionMode: "default",
+    });
+
+    const gitCommands = [
+      "git status",
+      "git diff",
+      "git log",
+      "git show",
+      "git branch",
+      "git tag",
+      "git remote",
+      "git ls-files",
+      "git rev-parse",
+      "git config --list",
+      "git config -l",
+      "git cat-file -p HEAD",
+      "git count-objects",
+    ];
+
+    for (const command of gitCommands) {
+      const decision = await agent.checkPermission({
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command, workdir },
+      });
+      expect(decision.behavior).toBe("allow");
+    }
+  });
+
+  it("should NOT allow destructive git commands by default", async () => {
+    const agent = await Agent.create({
+      workdir,
+      permissionMode: "default",
+    });
+
+    const destructiveGitCommands = [
+      "git reset --hard",
+      "git clean -fd",
+      "git commit -m 'test'",
+      "git push",
+      "git pull",
+      "git checkout main",
+    ];
+
+    for (const command of destructiveGitCommands) {
+      const decision = await agent.checkPermission({
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command, workdir },
+      });
+      expect(decision.behavior).toBe("deny");
+    }
+  });
+
+  it("should allow safe commands by default", async () => {
+    const agent = await Agent.create({
+      workdir,
+      permissionMode: "default",
+    });
+
+    const safeCommands = [
+      "echo hello",
+      "which node",
+      "type ls",
+      "hostname",
+      "whoami",
+      "date",
+      "uptime",
+    ];
+
+    for (const command of safeCommands) {
+      const decision = await agent.checkPermission({
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command, workdir },
+      });
+      expect(decision.behavior).toBe("allow");
+    }
+  });
+});

--- a/specs/024-tool-permission-system/data-model.md
+++ b/specs/024-tool-permission-system/data-model.md
@@ -57,6 +57,8 @@
 - `toolName`: string
 - `permissionMode`: PermissionMode
 - `canUseToolCallback?`: PermissionCallback
+- `allowedRules?`: string[]
+- `defaultAllowedRules?`: string[]
 
 **Validation Rules**:
 - `toolName` must match registered tool name
@@ -81,6 +83,7 @@
 - `selectedOption` must be one of two allowed values
 - `alternativeText` can be empty string
 - `hasUserInput` tracks whether user has typed (to hide placeholder)
+- `defaultAllowedRules`: Array<string> (hardcoded read-only git and safe commands)
 - `toolName` must be non-empty when `isVisible` is true
 
 **State Transitions**:

--- a/specs/024-tool-permission-system/plan.md
+++ b/specs/024-tool-permission-system/plan.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-Add permission system to Wave Agent SDK with "default" and "bypassPermissions" modes. In default mode, system prompts for confirmation before executing destructive tools (Edit, Delete, Bash). Users can bypass with `--dangerously-skip-permissions` CLI flag. System implements `canUseTool` callback in Agent SDK for custom authorization and adds confirmation component to CLI. **Updated**: System supports multiple tool calls with individual sequential confirmations, allowing granular user control per tool while batching results back to AI.
+Add permission system to Wave Agent SDK with "default" and "bypassPermissions" modes. In default mode, system prompts for confirmation before executing destructive tools (Edit, Delete, Bash). Users can bypass with `--dangerously-skip-permissions` CLI flag. System implements `canUseTool` callback in Agent SDK for custom authorization and adds confirmation component to CLI. **Updated**: System supports multiple tool calls with individual sequential confirmations, allowing granular user control per tool while batching results back to AI. **Updated**: System now includes hardcoded default allowed rules for read-only `git` operations and common safe commands in `default` mode to reduce manual confirmation overhead.
 
 ## Technical Context
 

--- a/specs/024-tool-permission-system/quickstart.md
+++ b/specs/024-tool-permission-system/quickstart.md
@@ -6,16 +6,25 @@ This guide shows how to use the new tool permission system in Wave Agent SDK.
 
 ### Default Safe Mode (Recommended)
 
-By default, Wave will prompt for confirmation before executing potentially dangerous operations:
+By default, Wave will prompt for confirmation before executing potentially dangerous operations. However, common read-only `git` operations and safe commands are automatically allowed to reduce overhead:
 
 ```bash
-# Normal mode - prompts for confirmation
+# Normal mode - prompts for confirmation for destructive tools
 wave
 
-# Agent attempts to edit a file
+# Agent attempts to run 'git status'
+# → Automatically allowed (no prompt)
+
+# Agent attempts to run 'git reset --hard'
 # → Shows confirmation: "Do you want to proceed?"
 # → User can approve or provide alternative instructions
 ```
+
+### Default Allowed Commands
+
+The following commands are automatically allowed in `default` mode:
+- **Git (Read-only)**: `status`, `diff`, `log`, `show`, `branch`, `tag`, `remote`, `ls-files`, `rev-parse`, `config --list`, `cat-file`, `count-objects`.
+- **Safe Utilities**: `echo`, `which`, `type`, `hostname`, `whoami`, `date`, `uptime`.
 
 ### Bypass Mode (Advanced Users)
 

--- a/specs/024-tool-permission-system/spec.md
+++ b/specs/024-tool-permission-system/spec.md
@@ -105,6 +105,8 @@ A developer integrating Wave's agent SDK can provide custom permission handling 
 - **FR-018**: When one tool call is denied in a sequence of multiple tool calls, system MUST continue processing remaining tool calls with individual confirmations for each restricted tool
 - **FR-019**: When user provides alternative instructions for one tool call in a sequence, system MUST continue with remaining tool calls and return all tool results (including alternative instructions in tool result field) to the AI after all confirmations are complete
 - **FR-020**: System MUST implement queue-based sequential confirmation for multiple tool calls, processing confirmations one at a time with proper state management
+- **FR-021**: System MUST automatically allow a set of default read-only `git` commands in `default` mode without requiring manual confirmation.
+- **FR-022**: System MUST automatically allow a set of common safe commands (e.g., `echo`, `which`, `hostname`) in `default` mode without requiring manual confirmation.
 
 ### Key Entities
 

--- a/specs/024-tool-permission-system/tasks.md
+++ b/specs/024-tool-permission-system/tasks.md
@@ -102,6 +102,9 @@
 - [X] T031 [US3] Add callback integration tests in packages/agent-sdk/tests/managers/permissionManager.test.ts
 - [X] T032 [US3] Add Agent SDK callback examples to packages/agent-sdk/examples/ directory
 - [X] T033 [US3] Validate callback return value format and error handling
+- [X] T041 [US1] Implement hardcoded default allowed rules for read-only git operations and safe commands in PermissionManager.ts
+- [X] T042 [US1] Update Agent.ts to handle combined user-defined and default allowed rules
+- [X] T043 [US1] Add tests for default allowed git and safe commands
 
 **Checkpoint**: All user stories should now be independently functional - default mode prompts, bypass mode skips, custom callbacks work
 


### PR DESCRIPTION
This commit introduces default allowed rules for common read-only git operations and safe commands within the permission system. This reduces the need for manual confirmation for these frequently used, non-destructive actions, improving the agent's workflow.

- Implemented  and  in  to differentiate between user-defined and default rules.
- Added  in  for read-only git commands and safe utilities like , , HIH-D-25849, etc.
- Updated  to check both user-defined and default allowed rules when determining tool permissions.
- Updated relevant spec files (, , , , ) to reflect the new default allowed rules and their impact on the permission system.
- Added new test files  and  to cover the new functionality.