### PR TITLE
Fix: Allow multi-line command matching in permission regex

### DIFF
--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -499,7 +499,7 @@ export class PermissionManager {
       const regexPattern = pattern
         .replace(/[.+^${}()|[\]\\?]/g, "\\$&") // Escape regex special chars including ?
         .replace(/\*/g, ".*"); // Replace * with .*
-      const regex = new RegExp(`^${regexPattern}$`);
+      const regex = new RegExp(`^${regexPattern}$`, "s");
       const matched = regex.test(processedPart);
       return matched;
     }

--- a/packages/agent-sdk/tests/managers/permissionManager.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.test.ts
@@ -745,6 +745,20 @@ describe("PermissionManager", () => {
           (await permissionManager.checkPermission(context)).behavior,
         ).toBe("deny");
       });
+
+      it("should match multi-line commands with *", async () => {
+        permissionManager.updateAllowedRules(["Bash(git commit*)"]);
+        const context: ToolPermissionContext = {
+          toolName: "Bash",
+          permissionMode: "default",
+          toolInput: {
+            command: 'git commit -m "line1\nline2"',
+          },
+        };
+        expect(
+          (await permissionManager.checkPermission(context)).behavior,
+        ).toBe("allow");
+      });
     });
 
     it("should return true for restricted tools", () => {


### PR DESCRIPTION
Fix: Allow multi-line command matching in permission regex