### PR TITLE
feat: Improve worktree removal logic

### DIFF
--- a/packages/code/src/utils/worktree.ts
+++ b/packages/code/src/utils/worktree.ts
@@ -104,17 +104,58 @@ export function removeWorktree(session: WorktreeSession): void {
   const repoRoot = session.repoRoot;
 
   try {
+    // Get current branch in worktree before removing it
+    let currentBranch: string | undefined;
+    try {
+      currentBranch = execSync(`git rev-parse --abbrev-ref HEAD`, {
+        cwd: session.path,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+    } catch {
+      // Ignore errors getting current branch
+    }
+
     // Remove worktree
     execSync(`git worktree remove --force "${session.path}"`, {
       cwd: repoRoot,
       stdio: ["ignore", "pipe", "pipe"],
     });
 
-    // Delete branch
-    execSync(`git branch -D ${session.branch}`, {
-      cwd: repoRoot,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    // Delete original branch
+    try {
+      execSync(`git branch -D ${session.branch}`, {
+        cwd: repoRoot,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch {
+      // Ignore errors deleting original branch
+    }
+
+    // Delete current branch if it's different and not a protected branch
+    if (
+      currentBranch &&
+      currentBranch !== session.branch &&
+      currentBranch !== "HEAD"
+    ) {
+      const defaultRemoteBranch = getDefaultRemoteBranch(repoRoot);
+      const defaultBranchName = defaultRemoteBranch.split("/").pop();
+
+      if (
+        currentBranch !== defaultBranchName &&
+        currentBranch !== "main" &&
+        currentBranch !== "master"
+      ) {
+        try {
+          execSync(`git branch -D ${currentBranch}`, {
+            cwd: repoRoot,
+            stdio: ["ignore", "pipe", "pipe"],
+          });
+        } catch {
+          // Ignore errors deleting current branch
+        }
+      }
+    }
   } catch (error: unknown) {
     console.error(
       `Failed to remove worktree or branch: ${(error as Error).message}`,

--- a/packages/code/tests/utils/worktree.test.ts
+++ b/packages/code/tests/utils/worktree.test.ts
@@ -133,6 +133,8 @@ describe("worktree utils", () => {
         isNew: false,
       };
 
+      vi.mocked(execSync).mockReturnValue(Buffer.from("worktree-my-feat\n"));
+
       removeWorktree(session);
 
       expect(execSync).toHaveBeenCalledWith(
@@ -141,6 +143,76 @@ describe("worktree utils", () => {
       );
       expect(execSync).toHaveBeenCalledWith(
         expect.stringContaining("git branch -D worktree-my-feat"),
+        expect.any(Object),
+      );
+    });
+
+    it("should remove worktree, original branch, and current branch if different", () => {
+      const session = {
+        name: "my-feat",
+        path: "/repo/root/.wave/worktrees/my-feat",
+        branch: "worktree-my-feat",
+        repoRoot: "/repo/root",
+        hasUncommittedChanges: false,
+        hasNewCommits: false,
+        isNew: false,
+      };
+
+      vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
+      vi.mocked(execSync).mockImplementation((cmd) => {
+        if (cmd === "git rev-parse --abbrev-ref HEAD") {
+          return "another-branch\n";
+        }
+        return "";
+      });
+
+      removeWorktree(session);
+
+      expect(execSync).toHaveBeenCalledWith(
+        expect.stringContaining("git worktree remove --force"),
+        expect.any(Object),
+      );
+      expect(execSync).toHaveBeenCalledWith(
+        expect.stringContaining("git branch -D worktree-my-feat"),
+        expect.any(Object),
+      );
+      expect(execSync).toHaveBeenCalledWith(
+        expect.stringContaining("git branch -D another-branch"),
+        expect.any(Object),
+      );
+    });
+
+    it("should NOT remove current branch if it is a protected branch", () => {
+      const session = {
+        name: "my-feat",
+        path: "/repo/root/.wave/worktrees/my-feat",
+        branch: "worktree-my-feat",
+        repoRoot: "/repo/root",
+        hasUncommittedChanges: false,
+        hasNewCommits: false,
+        isNew: false,
+      };
+
+      vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
+      vi.mocked(execSync).mockImplementation((cmd) => {
+        if (cmd === "git rev-parse --abbrev-ref HEAD") {
+          return "main\n";
+        }
+        return "";
+      });
+
+      removeWorktree(session);
+
+      expect(execSync).toHaveBeenCalledWith(
+        expect.stringContaining("git worktree remove --force"),
+        expect.any(Object),
+      );
+      expect(execSync).toHaveBeenCalledWith(
+        expect.stringContaining("git branch -D worktree-my-feat"),
+        expect.any(Object),
+      );
+      expect(execSync).not.toHaveBeenCalledWith(
+        expect.stringContaining("git branch -D main"),
         expect.any(Object),
       );
     });


### PR DESCRIPTION
This commit improves the worktree removal logic by:
- Getting the current branch in the worktree before removing it.
- Deleting the original branch.
- Deleting the current branch if it's different from the original and not a protected branch (main, master, or default remote branch).