### PR TITLE
feat(agent-sdk): handle truncated AI responses with automatic recursion

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -557,12 +557,6 @@ export class AIManager {
         }
       }
 
-      if (result.finish_reason === "length" && toolCalls.length === 0) {
-        this.messageManager.addErrorBlock(
-          "AI response was truncated due to length limit. Please try to reduce the complexity of your request or split it into smaller parts.",
-        );
-      }
-
       if (toolCalls.length > 0) {
         // Execute all tools in parallel using Promise.all
         const toolExecutionPromises = toolCalls.map(
@@ -720,8 +714,8 @@ export class AIManager {
         model,
       );
 
-      // Check if there are tool operations, if so automatically initiate next AI service call
-      if (toolCalls.length > 0) {
+      // Check if there are tool operations or response was truncated, if so automatically initiate next AI service call
+      if (toolCalls.length > 0 || result.finish_reason === "length") {
         // Record committed snapshots to message history
         if (this.reversionManager) {
           const snapshots =
@@ -754,6 +748,14 @@ export class AIManager {
             "Some tools were manually backgrounded, stopping recursion.",
           );
         } else if (!isCurrentlyAborted) {
+          // If response was truncated and no tools were called, add a continuation message
+          if (result.finish_reason === "length" && toolCalls.length === 0) {
+            this.messageManager.addUserMessage({
+              content:
+                "Your response was cut off because it exceeded the output token limit. Please break your work into smaller pieces. Continue from where you left off.",
+            });
+          }
+
           // Recursively call AI service, increment recursion depth, and pass same configuration
           await this.sendAIMessage({
             recursionDepth: recursionDepth + 1,

--- a/packages/agent-sdk/tests/managers/aiManager.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.test.ts
@@ -323,16 +323,23 @@ describe("AIManager", () => {
       );
     });
 
-    it("should log warning when finish reason is length", async () => {
+    it("should log warning and recurse when finish reason is length", async () => {
       const aiService = await import("../../src/services/aiService.js");
       const mockHeaders = { "x-test-header": "test-value" };
-      vi.spyOn(aiService, "callAgent").mockResolvedValue({
-        content: "Truncated response",
-        finish_reason: "length",
-        response_headers: mockHeaders,
-        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
-        tool_calls: [],
-      });
+      vi.spyOn(aiService, "callAgent")
+        .mockResolvedValueOnce({
+          content: "Truncated response",
+          finish_reason: "length",
+          response_headers: mockHeaders,
+          usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+          tool_calls: [],
+        })
+        .mockResolvedValueOnce({
+          content: "Final response",
+          finish_reason: "stop",
+          usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+          tool_calls: [],
+        });
 
       await aiManager.sendAIMessage();
 
@@ -340,6 +347,12 @@ describe("AIManager", () => {
         "AI response truncated due to length limit. Response headers:",
         mockHeaders,
       );
+      expect(mockMessageManager.addUserMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining("cut off"),
+        }),
+      );
+      expect(aiService.callAgent).toHaveBeenCalledTimes(2);
     });
 
     it("should save session during each recursion regardless of tool execution results", async () => {

--- a/packages/agent-sdk/tests/managers/aiManager_finishReason.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager_finishReason.test.ts
@@ -39,12 +39,13 @@ describe("AIManager finish reason", () => {
     fastModel: "test-fast-model",
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // Create mock MessageManager
     mockMessageManager = {
       getSessionId: vi.fn().mockReturnValue("test-session-id"),
       getMessages: vi.fn().mockReturnValue([]),
       addAssistantMessage: vi.fn(),
+      addUserMessage: vi.fn(),
       updateCurrentMessageContent: vi.fn(),
       updateToolBlock: vi.fn(),
       mergeAssistantAdditionalFields: vi.fn(),
@@ -98,29 +99,47 @@ describe("AIManager finish reason", () => {
       getLanguage: () => undefined,
       stream: false,
     });
+
+    // Clear mocks
+    const { callAgent } = await import("../../src/services/aiService.js");
+    vi.mocked(callAgent).mockClear();
   });
 
-  it("should add an error block when finish reason is length and no tools are called", async () => {
+  it("should add a user message and recurse when finish reason is length and no tools are called", async () => {
     const { callAgent } = await import("../../src/services/aiService.js");
-    vi.mocked(callAgent).mockResolvedValue({
-      content: "Truncated response...",
-      finish_reason: "length",
-      tool_calls: [],
-      usage: {
-        prompt_tokens: 10,
-        completion_tokens: 20,
-        total_tokens: 30,
-      },
-    });
+    vi.mocked(callAgent)
+      .mockResolvedValueOnce({
+        content: "Truncated response...",
+        finish_reason: "length",
+        tool_calls: [],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30,
+        },
+      })
+      .mockResolvedValueOnce({
+        content: "Final response",
+        finish_reason: "stop",
+        tool_calls: [],
+        usage: {
+          prompt_tokens: 5,
+          completion_tokens: 5,
+          total_tokens: 10,
+        },
+      });
 
     await aiManager.sendAIMessage();
 
-    expect(mockMessageManager.addErrorBlock).toHaveBeenCalledWith(
-      expect.stringContaining("truncated"),
+    expect(mockMessageManager.addUserMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining("cut off"),
+      }),
     );
+    expect(callAgent).toHaveBeenCalledTimes(2);
   });
 
-  it("should NOT add an error block when finish reason is length but tools ARE called", async () => {
+  it("should NOT add a user message but still recurse when finish reason is length and tools ARE called", async () => {
     const { callAgent } = await import("../../src/services/aiService.js");
     // First call returns tool calls, second call returns stop to prevent infinite recursion
     vi.mocked(callAgent)
@@ -156,9 +175,9 @@ describe("AIManager finish reason", () => {
 
     await aiManager.sendAIMessage();
 
-    // It should NOT call addErrorBlock directly on AIManager level
-    // (The tool block itself might have an error if it fails to parse, but that's different)
-    expect(mockMessageManager.addErrorBlock).not.toHaveBeenCalled();
+    // It should NOT call addUserMessage because tool results serve as reminder
+    expect(mockMessageManager.addUserMessage).not.toHaveBeenCalled();
+    expect(callAgent).toHaveBeenCalledTimes(2);
   });
 
   it("should NOT add an error block when finish reason is stop", async () => {

--- a/specs/013-ai-error-handling/data-model.md
+++ b/specs/013-ai-error-handling/data-model.md
@@ -1,0 +1,24 @@
+# Data Model: AI Error Handling
+
+## AI Response
+The AI response is the primary data structure involved in this feature. It is returned by the `aiService.callAgent` method.
+
+### Attributes:
+- `content`: The text content of the response.
+- `tool_calls`: A list of tool calls initiated by the AI.
+- `finish_reason`: The reason why the AI stopped generating content. Possible values include `"stop"`, `"length"`, `"tool_calls"`, etc.
+- `usage`: Token usage statistics for the response.
+
+## Message History
+The message history is managed by the `MessageManager` and stores the conversation between the user and the agent.
+
+### Attributes:
+- `role`: The role of the message sender (`"user"`, `"assistant"`, or `"system"`).
+- `blocks`: A list of message blocks (text, tool, error, etc.).
+- `usage`: Token usage statistics for the message.
+
+## Continuation Prompt
+The continuation prompt is a new user message added to the message history when a response is truncated.
+
+### Content:
+"Your response was cut off because it exceeded the output token limit. Please break your work into smaller pieces. Continue from where you left off."

--- a/specs/013-ai-error-handling/plan.md
+++ b/specs/013-ai-error-handling/plan.md
@@ -1,0 +1,20 @@
+# Plan: AI Error Handling
+
+## Implementation Strategy
+
+### 1. Core Logic Changes
+Modify `packages/agent-sdk/src/managers/aiManager.ts`:
+- **Remove Error Block**: Delete the logic that adds an error block when `finish_reason === "length"` and `toolCalls.length === 0`.
+- **Update Recursion Condition**: Change the condition for recursive `sendAIMessage` calls to include `result.finish_reason === "length"`.
+- **Add Continuation Prompt**: Just before the recursive call, if `finish_reason === "length"` AND `toolCalls.length === 0`, add a user message: `"Your response was cut off because it exceeded the output token limit. Please break your work into smaller pieces. Continue from where you left off."`. If `toolCalls.length > 0`, the tool results will serve as the reminder for the AI to continue, so no extra user message is needed.
+
+### 2. Test Updates
+- **`packages/agent-sdk/tests/managers/aiManager_finishReason.test.ts`**:
+    - Update `should add an error block when finish reason is length and no tools are called` to expect `addUserMessage` and recursion instead of `addErrorBlock`.
+    - Update other related tests to reflect the new behavior.
+- **`packages/agent-sdk/tests/managers/aiManager.test.ts`**:
+    - Update `should log warning when finish reason is length` to also verify `addUserMessage` and recursion.
+
+## Verification Plan
+1. **Unit Tests**: Run the updated tests using `pnpm test packages/agent-sdk/tests/managers/aiManager_finishReason.test.ts` and `pnpm test packages/agent-sdk/tests/managers/aiManager.test.ts`.
+2. **Manual Verification**: (If possible in this environment) Simulate a truncated response and verify that the agent automatically adds the continuation message and makes another AI call.

--- a/specs/013-ai-error-handling/quickstart.md
+++ b/specs/013-ai-error-handling/quickstart.md
@@ -1,0 +1,23 @@
+# Quickstart: AI Error Handling
+
+## Overview
+This feature improves the agent's behavior when its response is truncated due to the output token limit. Instead of showing an error message and stopping, the agent now automatically adds a continuation prompt and makes another AI call to finish its response.
+
+## How it Works
+1. The AI service returns a response with `finish_reason: "length"`.
+2. The `AIManager` detects this truncation.
+3. If no tools were called, the `AIManager` adds a user message: "Your response was cut off because it exceeded the output token limit. Please break your work into smaller pieces. Continue from where you left off."
+4. The `AIManager` then automatically initiates a recursive `sendAIMessage` call.
+5. If tools were called, the `AIManager` still initiates the recursive call after tool execution, but without adding the extra user message.
+
+## Testing
+To test this feature, you can simulate a truncated response in a unit test:
+```typescript
+vi.mocked(callAgent).mockResolvedValueOnce({
+  content: "Truncated response...",
+  finish_reason: "length",
+  tool_calls: [],
+  usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+});
+```
+Verify that `addUserMessage` is called with the continuation prompt and that `callAgent` is called again.

--- a/specs/013-ai-error-handling/research.md
+++ b/specs/013-ai-error-handling/research.md
@@ -1,0 +1,17 @@
+# Research: AI Error Handling
+
+## Current Implementation
+The current implementation of AI error handling for truncated responses is located in `packages/agent-sdk/src/managers/aiManager.ts`.
+When the `finish_reason` is `"length"`, the system logs a warning and, if no tools were called, adds an error block with a static message.
+
+## Proposed Change
+The proposed change is to replace the static error block with an automatic continuation mechanism.
+This involves:
+1. Detecting the truncation.
+2. Adding a user message to prompt the AI to continue.
+3. Automatically recursing the `sendAIMessage` call.
+
+## Considerations
+- **Recursion Depth**: The system already has a `recursionDepth` parameter in `sendAIMessage`. This should be incremented for each recursive call, whether triggered by tool calls or truncation.
+- **Tool Calls**: If tools were called, the tool results themselves serve as a reminder for the AI to continue. Adding an extra user message in this case might be redundant or confusing.
+- **User Control**: The system must still respect abort signals and backgrounded tools to ensure the user remains in control.

--- a/specs/013-ai-error-handling/spec.md
+++ b/specs/013-ai-error-handling/spec.md
@@ -1,0 +1,62 @@
+# Feature Specification: AI Error Handling
+
+**Feature Branch**: `013-ai-error-handling`  
+**Created**: 2026-03-03  
+**Status**: Draft  
+**Input**: User description: "remove 'AI response was truncated due to length limit. Please try to reduce the complexity of your request or split it into smaller parts.', instead, add a user role msg like this and continue: 'Your response was cut off because it exceeded the output token limit. Please break your work into smaller pieces. Continue from where you left off.'"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Automatic Continuation on Truncation (Priority: P1)
+
+As a user, I want the agent to automatically continue its response when it is cut off by the output token limit, so that I don't have to manually prompt it to finish its work.
+
+**Why this priority**: This is the core functionality requested. It improves the user experience by making the agent more autonomous and reducing manual intervention.
+
+**Independent Test**: Can be tested by simulating an AI response with `finish_reason: "length"` and verifying that the agent adds the continuation message and recurses.
+
+**Acceptance Scenarios**:
+
+1. **Given** the AI response is truncated due to length limit and no tools were called, **When** the agent processes the response, **Then** it should add a user message: "Your response was cut off because it exceeded the output token limit. Please break your work into smaller pieces. Continue from where you left off." and automatically initiate a new AI call.
+2. **Given** the AI response is truncated due to length limit and tools WERE called, **When** the agent processes the response, **Then** it should NOT add the extra user message (as tool results serve as the reminder) but it SHOULD still automatically initiate a new AI call.
+
+---
+
+### User Story 2 - Error Block Removal (Priority: P2)
+
+As a user, I want to remove the static error block that was previously shown when a response was truncated, as it is now replaced by the automatic continuation mechanism.
+
+**Why this priority**: Cleans up the UI and reflects the new, more helpful behavior.
+
+**Independent Test**: Verify that the string "AI response was truncated due to length limit" no longer appears in the UI when a truncation occurs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a truncated AI response, **When** the agent handles it, **Then** no error block with the old truncation message should be added to the message history.
+
+---
+
+### Edge Cases
+
+- **Infinite Recursion**: What happens if the AI keeps getting truncated?
+  - *Assumption*: The existing recursion depth limit (if any) or the user's ability to abort should handle this.
+- **Interruption**: What happens if the user aborts the session during a truncated response?
+  - *Assumption*: The agent should respect the abort signal and stop recursion.
+- **Backgrounded Tools**: What happens if a tool is backgrounded during a truncated response?
+  - *Assumption*: The agent should stop recursion as it does for normal tool calls.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST detect when an AI response is truncated due to the output token limit (`finish_reason: "length"`).
+- **FR-002**: If a response is truncated and no tools were called, the system MUST add a user message: "Your response was cut off because it exceeded the output token limit. Please break your work into smaller pieces. Continue from where you left off."
+- **FR-003**: If a response is truncated, the system MUST automatically initiate a recursive AI call to continue the response.
+- **FR-004**: If a response is truncated and tools were called, the system MUST NOT add the extra user message, but MUST still recurse after tool execution.
+- **FR-005**: The system MUST NOT show the old error message: "AI response was truncated due to length limit. Please try to reduce the complexity of your request or split it into smaller parts."
+- **FR-006**: The system MUST respect abort signals and backgrounded tools, stopping recursion even if a truncation occurred.
+
+### Key Entities *(include if feature involves data)*
+
+- **AI Response**: The result from the AI service, including content, tool calls, and the finish reason.
+- **Message History**: The list of messages in the current session, which now includes automatic continuation prompts.

--- a/specs/013-ai-error-handling/tasks.md
+++ b/specs/013-ai-error-handling/tasks.md
@@ -1,0 +1,10 @@
+# Tasks: AI Error Handling
+
+- [x] Find truncation message implementation
+- [x] Design implementation for AI response continuation on truncation
+- [x] Remove old error block logic in `AIManager.ts`
+- [x] Update recursion condition in `AIManager.ts` to include `finish_reason === "length"`
+- [x] Add continuation user message in `AIManager.ts` when truncated and no tools were called
+- [x] Update tests in `packages/agent-sdk/tests/managers/aiManager_finishReason.test.ts`
+- [x] Update tests in `packages/agent-sdk/tests/managers/aiManager.test.ts`
+- [x] Verify all tests pass


### PR DESCRIPTION
This PR updates AIManager to automatically recurse when the AI response is truncated due to length limits (finish_reason: 'length'). If no tools were called, it adds a user message prompting the AI to continue. If tools were called, it proceeds with tool execution and recursion as usual.