### PR TITLE
feat(agent-sdk): implement result truncation in lspTool

### DIFF
--- a/packages/agent-sdk/src/tools/lspTool.ts
+++ b/packages/agent-sdk/src/tools/lspTool.ts
@@ -14,6 +14,9 @@ import type {
   LspCallHierarchyOutgoingCall as CallHierarchyOutgoingCall,
 } from "../types/lsp.js";
 
+export const MAX_RESULTS = 1000;
+export const MAX_FILES = 100;
+
 /**
  * Formats an LSP URI into a readable file path
  */
@@ -126,10 +129,16 @@ function formatGoToDefinitionResult(
       return `Defined in ${formatLocation(validLocations[0], workdir)}`;
     }
 
-    const formatted = validLocations
+    const shownLocations = validLocations.slice(0, MAX_RESULTS);
+    const formatted = shownLocations
       .map((loc) => `  ${formatLocation(loc, workdir)}`)
       .join("\n");
-    return `Found ${validLocations.length} definitions:\n${formatted}`;
+
+    let header = `Found ${validLocations.length} definitions:`;
+    if (validLocations.length > MAX_RESULTS) {
+      header += ` (showing first ${MAX_RESULTS})`;
+    }
+    return `${header}\n${formatted}`;
   }
 
   const loc = isLocationLink(result) ? locationLinkToLocation(result) : result;
@@ -157,18 +166,42 @@ function formatFindReferencesResult(
   }
 
   const grouped = groupItemsByUri(validLocations, workdir);
-  const lines = [
-    `Found ${validLocations.length} references across ${grouped.size} files:`,
-  ];
+  const totalResults = validLocations.length;
+  const totalFiles = grouped.size;
+
+  let resultsShown = 0;
+  let filesShown = 0;
+  const lines: string[] = [];
 
   for (const [path, locs] of grouped) {
+    if (resultsShown >= MAX_RESULTS || filesShown >= MAX_FILES) break;
+
+    filesShown++;
+    const remainingResults = MAX_RESULTS - resultsShown;
+    const locsToShow = locs.slice(0, remainingResults);
+    const isTruncated = locsToShow.length < locs.length;
+
     lines.push(`\n${path}:`);
-    for (const loc of locs) {
+    for (const loc of locsToShow) {
       const line = loc.range.start.line + 1;
       const character = loc.range.start.character + 1;
       lines.push(`  Line ${line}:${character}`);
     }
+
+    if (isTruncated) {
+      lines.push(
+        `  ... and ${locs.length - locsToShow.length} more in this file`,
+      );
+    }
+
+    resultsShown += locsToShow.length;
   }
+
+  let header = `Found ${totalResults} references across ${totalFiles} files:`;
+  if (totalResults > resultsShown || totalFiles > filesShown) {
+    header += ` (showing first ${resultsShown} results and ${filesShown} files)`;
+  }
+  lines.unshift(header);
 
   return lines.join("\n");
 }
@@ -243,23 +276,32 @@ function getSymbolKindName(kind: number): string {
 /**
  * Formats a single document symbol recursively
  */
-function formatDocumentSymbol(symbol: DocumentSymbol, depth = 0): string[] {
+function formatDocumentSymbol(
+  symbol: DocumentSymbol,
+  state: { count: number; total: number },
+  depth = 0,
+): string[] {
+  state.total++;
   const results: string[] = [];
-  const indent = "  ".repeat(depth);
-  const kindName = getSymbolKindName(symbol.kind);
-  let line = `${indent}${symbol.name} (${kindName})`;
 
-  if (symbol.detail) {
-    line += ` ${symbol.detail}`;
+  if (state.count < MAX_RESULTS) {
+    const indent = "  ".repeat(depth);
+    const kindName = getSymbolKindName(symbol.kind);
+    let line = `${indent}${symbol.name} (${kindName})`;
+
+    if (symbol.detail) {
+      line += ` ${symbol.detail}`;
+    }
+
+    const startLine = symbol.range.start.line + 1;
+    line += ` - Line ${startLine}`;
+    results.push(line);
+    state.count++;
   }
-
-  const startLine = symbol.range.start.line + 1;
-  line += ` - Line ${startLine}`;
-  results.push(line);
 
   if (symbol.children && symbol.children.length > 0) {
     for (const child of symbol.children) {
-      results.push(...formatDocumentSymbol(child, depth + 1));
+      results.push(...formatDocumentSymbol(child, state, depth + 1));
     }
   }
 
@@ -282,10 +324,18 @@ function formatDocumentSymbolResult(
     return formatWorkspaceSymbolResult(result as SymbolInformation[], workdir);
   }
 
-  const lines = ["Document symbols:"];
+  const state = { count: 0, total: 0 };
+  const lines: string[] = [];
   for (const symbol of result as DocumentSymbol[]) {
-    lines.push(...formatDocumentSymbol(symbol));
+    lines.push(...formatDocumentSymbol(symbol, state));
   }
+
+  let header = "Document symbols:";
+  if (state.total > MAX_RESULTS) {
+    header += ` (showing first ${MAX_RESULTS} of ${state.total})`;
+  }
+  lines.unshift(header);
+
   return lines.join("\n");
 }
 
@@ -305,14 +355,24 @@ function formatWorkspaceSymbolResult(
     return "No symbols found in workspace. This may occur if the workspace is empty, or if the LSP server has not finished indexing the project.";
   }
 
-  const lines = [
-    `Found ${validSymbols.length} symbol${validSymbols.length === 1 ? "" : "s"} in workspace:`,
-  ];
   const grouped = groupItemsByUri(validSymbols, workdir);
+  const totalResults = validSymbols.length;
+  const totalFiles = grouped.size;
+
+  let resultsShown = 0;
+  let filesShown = 0;
+  const lines: string[] = [];
 
   for (const [path, symbols] of grouped) {
+    if (resultsShown >= MAX_RESULTS || filesShown >= MAX_FILES) break;
+
+    filesShown++;
+    const remainingResults = MAX_RESULTS - resultsShown;
+    const symbolsToShow = symbols.slice(0, remainingResults);
+    const isTruncated = symbolsToShow.length < symbols.length;
+
     lines.push(`\n${path}:`);
-    for (const s of symbols) {
+    for (const s of symbolsToShow) {
       const kindName = getSymbolKindName(s.kind);
       const startLine = s.location.range.start.line + 1;
       let line = `  ${s.name} (${kindName}) - Line ${startLine}`;
@@ -321,7 +381,21 @@ function formatWorkspaceSymbolResult(
       }
       lines.push(line);
     }
+
+    if (isTruncated) {
+      lines.push(
+        `  ... and ${symbols.length - symbolsToShow.length} more in this file`,
+      );
+    }
+
+    resultsShown += symbolsToShow.length;
   }
+
+  let header = `Found ${totalResults} symbol${totalResults === 1 ? "" : "s"} in workspace:`;
+  if (totalResults > resultsShown || totalFiles > filesShown) {
+    header += ` (showing first ${resultsShown} results and ${filesShown} files)`;
+  }
+  lines.unshift(header);
 
   return lines.join("\n");
 }
@@ -364,10 +438,18 @@ function formatPrepareCallHierarchyResult(
     return `Call hierarchy item: ${formatCallHierarchyItem(result[0], workdir)}`;
   }
 
-  const lines = [`Found ${result.length} call hierarchy items:`];
-  for (const item of result) {
+  const shownItems = result.slice(0, MAX_RESULTS);
+  const lines: string[] = [];
+  for (const item of shownItems) {
     lines.push(`  ${formatCallHierarchyItem(item, workdir)}`);
   }
+
+  let header = `Found ${result.length} call hierarchy items:`;
+  if (result.length > MAX_RESULTS) {
+    header += ` (showing first ${MAX_RESULTS})`;
+  }
+  lines.unshift(header);
+
   return lines.join("\n");
 }
 
@@ -382,10 +464,8 @@ function formatIncomingCallsResult(
     return "No incoming calls found (nothing calls this function)";
   }
 
-  const lines = [
-    `Found ${result.length} incoming call${result.length === 1 ? "" : "s"}:`,
-  ];
   const grouped = new Map<string, CallHierarchyIncomingCall[]>();
+  const totalResults = result.length;
 
   for (const call of result) {
     if (!call.from) {
@@ -403,9 +483,21 @@ function formatIncomingCallsResult(
     }
   }
 
+  const totalFiles = grouped.size;
+  let resultsShown = 0;
+  let filesShown = 0;
+  const lines: string[] = [];
+
   for (const [path, calls] of grouped) {
+    if (resultsShown >= MAX_RESULTS || filesShown >= MAX_FILES) break;
+
+    filesShown++;
+    const remainingResults = MAX_RESULTS - resultsShown;
+    const callsToShow = calls.slice(0, remainingResults);
+    const isTruncated = callsToShow.length < calls.length;
+
     lines.push(`\n${path}:`);
-    for (const call of calls) {
+    for (const call of callsToShow) {
       if (!call.from) continue;
       const kindName = getSymbolKindName(call.from.kind);
       const startLine = call.from.range.start.line + 1;
@@ -419,7 +511,21 @@ function formatIncomingCallsResult(
       }
       lines.push(line);
     }
+
+    if (isTruncated) {
+      lines.push(
+        `  ... and ${calls.length - callsToShow.length} more in this file`,
+      );
+    }
+
+    resultsShown += callsToShow.length;
   }
+
+  let header = `Found ${totalResults} incoming call${totalResults === 1 ? "" : "s"}:`;
+  if (totalResults > resultsShown || totalFiles > filesShown) {
+    header += ` (showing first ${resultsShown} results and ${filesShown} files)`;
+  }
+  lines.unshift(header);
 
   return lines.join("\n");
 }
@@ -435,10 +541,8 @@ function formatOutgoingCallsResult(
     return "No outgoing calls found (this function calls nothing)";
   }
 
-  const lines = [
-    `Found ${result.length} outgoing call${result.length === 1 ? "" : "s"}:`,
-  ];
   const grouped = new Map<string, CallHierarchyOutgoingCall[]>();
+  const totalResults = result.length;
 
   for (const call of result) {
     if (!call.to) {
@@ -456,9 +560,21 @@ function formatOutgoingCallsResult(
     }
   }
 
+  const totalFiles = grouped.size;
+  let resultsShown = 0;
+  let filesShown = 0;
+  const lines: string[] = [];
+
   for (const [path, calls] of grouped) {
+    if (resultsShown >= MAX_RESULTS || filesShown >= MAX_FILES) break;
+
+    filesShown++;
+    const remainingResults = MAX_RESULTS - resultsShown;
+    const callsToShow = calls.slice(0, remainingResults);
+    const isTruncated = callsToShow.length < calls.length;
+
     lines.push(`\n${path}:`);
-    for (const call of calls) {
+    for (const call of callsToShow) {
       if (!call.to) continue;
       const kindName = getSymbolKindName(call.to.kind);
       const startLine = call.to.range.start.line + 1;
@@ -472,7 +588,21 @@ function formatOutgoingCallsResult(
       }
       lines.push(line);
     }
+
+    if (isTruncated) {
+      lines.push(
+        `  ... and ${calls.length - callsToShow.length} more in this file`,
+      );
+    }
+
+    resultsShown += callsToShow.length;
   }
+
+  let header = `Found ${totalResults} outgoing call${totalResults === 1 ? "" : "s"}:`;
+  if (totalResults > resultsShown || totalFiles > filesShown) {
+    header += ` (showing first ${resultsShown} results and ${filesShown} files)`;
+  }
+  lines.unshift(header);
 
   return lines.join("\n");
 }

--- a/packages/agent-sdk/tests/tools/lspTool.test.ts
+++ b/packages/agent-sdk/tests/tools/lspTool.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { lspTool } from "../../src/tools/lspTool.js";
+import { lspTool, MAX_RESULTS, MAX_FILES } from "../../src/tools/lspTool.js";
 import { TaskManager } from "../../src/services/taskManager.js";
 import { ToolContext } from "../../src/tools/types.js";
 import { Container } from "../../src/utils/container.js";
@@ -555,5 +555,319 @@ describe("lspTool", () => {
 
     expect(result.success).toBe(true);
     expect(result.content).toContain("GlobalSym (Function) - Line 11");
+  });
+
+  describe("truncation", () => {
+    it("should truncate goToDefinition results", async () => {
+      const total = MAX_RESULTS + 10;
+      const mockLspResult = Array.from({ length: total }, (_, i) => ({
+        uri: `file:///test/workdir/src/file${i}.ts`,
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 10 },
+        },
+      }));
+
+      mockLspManager.execute.mockResolvedValue({
+        success: true,
+        content: JSON.stringify(mockLspResult),
+      });
+
+      const result = await lspTool.execute(
+        {
+          operation: "goToDefinition",
+          filePath: "src/main.ts",
+          line: 1,
+          character: 1,
+        },
+        context,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.content).toContain(`Found ${total} definitions:`);
+      expect(result.content).toContain(`(showing first ${MAX_RESULTS})`);
+      const lines = result.content.split("\n");
+      // Header + MAX_RESULTS lines
+      expect(lines.length).toBe(MAX_RESULTS + 1);
+    });
+
+    it("should truncate findReferences results by result count", async () => {
+      const total = MAX_RESULTS + 10;
+      const mockLspResult = Array.from({ length: total }, (_, i) => ({
+        uri: "file:///test/workdir/src/single_file.ts",
+        range: {
+          start: { line: i, character: 0 },
+          end: { line: i, character: 10 },
+        },
+      }));
+
+      mockLspManager.execute.mockResolvedValue({
+        success: true,
+        content: JSON.stringify(mockLspResult),
+      });
+
+      const result = await lspTool.execute(
+        {
+          operation: "findReferences",
+          filePath: "src/main.ts",
+          line: 1,
+          character: 1,
+        },
+        context,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.content).toContain(
+        `Found ${total} references across 1 files:`,
+      );
+      expect(result.content).toContain(
+        `(showing first ${MAX_RESULTS} results and 1 files)`,
+      );
+      expect(result.content).toContain("... and 10 more in this file");
+    });
+
+    it("should truncate findReferences results by file count", async () => {
+      const totalFiles = MAX_FILES + 10;
+      const mockLspResult = Array.from({ length: totalFiles }, (_, i) => ({
+        uri: `file:///test/workdir/src/file${i}.ts`,
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 10 },
+        },
+      }));
+
+      mockLspManager.execute.mockResolvedValue({
+        success: true,
+        content: JSON.stringify(mockLspResult),
+      });
+
+      const result = await lspTool.execute(
+        {
+          operation: "findReferences",
+          filePath: "src/main.ts",
+          line: 1,
+          character: 1,
+        },
+        context,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.content).toContain(
+        `Found ${totalFiles} references across ${totalFiles} files:`,
+      );
+      expect(result.content).toContain(
+        `(showing first ${MAX_FILES} results and ${MAX_FILES} files)`,
+      );
+      // Each file has 1 result, so resultsShown == filesShown == MAX_FILES
+    });
+
+    it("should truncate documentSymbol results", async () => {
+      const total = MAX_RESULTS + 10;
+      const mockLspResult = Array.from({ length: total }, (_, i) => ({
+        name: `Sym${i}`,
+        kind: 12,
+        range: {
+          start: { line: i, character: 0 },
+          end: { line: i, character: 10 },
+        },
+        selectionRange: {
+          start: { line: i, character: 0 },
+          end: { line: i, character: 10 },
+        },
+      }));
+
+      mockLspManager.execute.mockResolvedValue({
+        success: true,
+        content: JSON.stringify(mockLspResult),
+      });
+
+      const result = await lspTool.execute(
+        {
+          operation: "documentSymbol",
+          filePath: "src/main.ts",
+          line: 1,
+          character: 1,
+        },
+        context,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.content).toContain(
+        `Document symbols: (showing first ${MAX_RESULTS} of ${total})`,
+      );
+      const lines = result.content.split("\n");
+      // Header + MAX_RESULTS lines
+      expect(lines.length).toBe(MAX_RESULTS + 1);
+    });
+
+    it("should truncate workspaceSymbol results", async () => {
+      const total = MAX_RESULTS + 10;
+      const mockLspResult = Array.from({ length: total }, (_, i) => ({
+        name: `Sym${i}`,
+        kind: 12,
+        location: {
+          uri: "file:///test/workdir/src/single_file.ts",
+          range: {
+            start: { line: i, character: 0 },
+            end: { line: i, character: 10 },
+          },
+        },
+      }));
+
+      mockLspManager.execute.mockResolvedValue({
+        success: true,
+        content: JSON.stringify(mockLspResult),
+      });
+
+      const result = await lspTool.execute(
+        {
+          operation: "workspaceSymbol",
+          filePath: "",
+          line: 0,
+          character: 0,
+        },
+        context,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.content).toContain(`Found ${total} symbols in workspace:`);
+      expect(result.content).toContain(
+        `(showing first ${MAX_RESULTS} results and 1 files)`,
+      );
+      expect(result.content).toContain("... and 10 more in this file");
+    });
+
+    it("should truncate prepareCallHierarchy results", async () => {
+      const total = MAX_RESULTS + 10;
+      const mockLspResult = Array.from({ length: total }, (_, i) => ({
+        name: `Func${i}`,
+        kind: 12,
+        uri: "file:///test/workdir/src/main.ts",
+        range: {
+          start: { line: i, character: 0 },
+          end: { line: i, character: 10 },
+        },
+        selectionRange: {
+          start: { line: i, character: 0 },
+          end: { line: i, character: 10 },
+        },
+      }));
+
+      mockLspManager.execute.mockResolvedValue({
+        success: true,
+        content: JSON.stringify(mockLspResult),
+      });
+
+      const result = await lspTool.execute(
+        {
+          operation: "prepareCallHierarchy",
+          filePath: "src/main.ts",
+          line: 1,
+          character: 1,
+        },
+        context,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.content).toContain(`Found ${total} call hierarchy items:`);
+      expect(result.content).toContain(`(showing first ${MAX_RESULTS})`);
+      const lines = result.content.split("\n");
+      // Header + MAX_RESULTS lines
+      expect(lines.length).toBe(MAX_RESULTS + 1);
+    });
+
+    it("should truncate incomingCalls results", async () => {
+      const total = MAX_RESULTS + 10;
+      const mockLspResult = Array.from({ length: total }, (_, i) => ({
+        from: {
+          name: `Caller${i}`,
+          kind: 12,
+          uri: "file:///test/workdir/src/single_file.ts",
+          range: {
+            start: { line: i, character: 0 },
+            end: { line: i, character: 10 },
+          },
+          selectionRange: {
+            start: { line: i, character: 0 },
+            end: { line: i, character: 10 },
+          },
+        },
+        fromRanges: [
+          {
+            start: { line: i, character: 5 },
+            end: { line: i, character: 10 },
+          },
+        ],
+      }));
+
+      mockLspManager.execute.mockResolvedValue({
+        success: true,
+        content: JSON.stringify(mockLspResult),
+      });
+
+      const result = await lspTool.execute(
+        {
+          operation: "incomingCalls",
+          filePath: "src/main.ts",
+          line: 1,
+          character: 1,
+        },
+        context,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.content).toContain(`Found ${total} incoming calls:`);
+      expect(result.content).toContain(
+        `(showing first ${MAX_RESULTS} results and 1 files)`,
+      );
+      expect(result.content).toContain("... and 10 more in this file");
+    });
+
+    it("should truncate outgoingCalls results", async () => {
+      const total = MAX_RESULTS + 10;
+      const mockLspResult = Array.from({ length: total }, (_, i) => ({
+        to: {
+          name: `Callee${i}`,
+          kind: 12,
+          uri: "file:///test/workdir/src/single_file.ts",
+          range: {
+            start: { line: i, character: 0 },
+            end: { line: i, character: 10 },
+          },
+          selectionRange: {
+            start: { line: i, character: 0 },
+            end: { line: i, character: 10 },
+          },
+        },
+        fromRanges: [
+          {
+            start: { line: i, character: 5 },
+            end: { line: i, character: 10 },
+          },
+        ],
+      }));
+
+      mockLspManager.execute.mockResolvedValue({
+        success: true,
+        content: JSON.stringify(mockLspResult),
+      });
+
+      const result = await lspTool.execute(
+        {
+          operation: "outgoingCalls",
+          filePath: "src/main.ts",
+          line: 1,
+          character: 1,
+        },
+        context,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.content).toContain(`Found ${total} outgoing calls:`);
+      expect(result.content).toContain(
+        `(showing first ${MAX_RESULTS} results and 1 files)`,
+      );
+      expect(result.content).toContain("... and 10 more in this file");
+    });
   });
 });

--- a/specs/039-lsp-integration-support/spec.md
+++ b/specs/039-lsp-integration-support/spec.md
@@ -54,7 +54,7 @@ As an AI agent, I want to see what functions call a specific method so that I ca
 
 - **No Server Configured**: If a file extension has no mapped LSP server, the tool should return a clear error.
 - **Server Crash**: If the LSP server process dies, the `LspManager` should handle it gracefully and potentially restart it.
-- **Large Responses**: Some LSP responses (like `findReferences`) can be very large; the tool should truncate or format them to fit within the agent's context.
+- **Large Responses**: Some LSP responses (like `findReferences`) can be very large; the tool MUST truncate results to a maximum of 1000 items and 100 files to prevent excessive token usage, while still reporting the total count in the header.
 - **Slow Servers**: Implement timeouts to prevent the agent from waiting indefinitely for a slow language server.
 
 ## Requirements *(mandatory)*

--- a/specs/039-lsp-integration-support/tasks.md
+++ b/specs/039-lsp-integration-support/tasks.md
@@ -98,4 +98,5 @@
 
 - [X] T017 [P] Implement graceful shutdown in `LspManager`
 - [X] T018 [P] Implement response formatting and URI-to-path conversion in `lspTool`
+- [X] T020 [P] Implement result and file count limits in `lspTool` to prevent excessive token usage
 - [X] T019 [P] Final type-check and linting


### PR DESCRIPTION
Implement result and file count limits in lspTool to prevent excessive token usage.

- Added MAX_RESULTS (1000) and MAX_FILES (100) limits.
- Updated formatting for goToDefinition, findReferences, documentSymbol, workspaceSymbol, and call hierarchy operations to support truncation.
- Added unit tests for truncation logic.
- Updated spec and tasks documentation.