### PR TITLE
refactor: centralize active selector check in InputManager

### DIFF
--- a/packages/code/src/managers/InputManager.ts
+++ b/packages/code/src/managers/InputManager.ts
@@ -690,6 +690,19 @@ export class InputManager {
     return this.permissionMode;
   }
 
+  isAnySelectorOrManagerActive(): boolean {
+    return (
+      this.showFileSelector ||
+      this.showCommandSelector ||
+      this.showHistorySearch ||
+      this.showBackgroundTaskManager ||
+      this.showMcpManager ||
+      this.showRewindManager ||
+      this.showHelp ||
+      this.showStatusCommand
+    );
+  }
+
   setPermissionMode(mode: PermissionMode): void {
     this.permissionMode = mode;
   }
@@ -938,10 +951,7 @@ export class InputManager {
     if (
       key.escape &&
       (isLoading || isCommandRunning) &&
-      !this.showBackgroundTaskManager &&
-      !this.showMcpManager &&
-      !this.showRewindManager &&
-      !this.showStatusCommand
+      !this.isAnySelectorOrManagerActive()
     ) {
       // Unified interrupt for AI message generation and command execution
       this.callbacks.onAbortMessage?.();
@@ -956,16 +966,7 @@ export class InputManager {
     }
 
     // Check if any selector is active
-    if (
-      this.showFileSelector ||
-      this.showCommandSelector ||
-      this.showHistorySearch ||
-      this.showBackgroundTaskManager ||
-      this.showMcpManager ||
-      this.showRewindManager ||
-      this.showHelp ||
-      this.showStatusCommand
-    ) {
+    if (this.isAnySelectorOrManagerActive()) {
       if (
         this.showBackgroundTaskManager ||
         this.showMcpManager ||

--- a/packages/code/tests/managers/InputManager.test.ts
+++ b/packages/code/tests/managers/InputManager.test.ts
@@ -641,6 +641,126 @@ describe("InputManager", () => {
       expect(mockCallbacks.onAbortMessage).not.toHaveBeenCalled();
     });
 
+    it("should NOT handle escape to abort during loading if file selector is active", async () => {
+      manager.activateFileSelector(0);
+      const mockKey = {
+        escape: true,
+        return: false,
+        upArrow: false,
+        downArrow: false,
+        leftArrow: false,
+        rightArrow: false,
+        ctrl: false,
+        backspace: false,
+        delete: false,
+        pageDown: false,
+        pageUp: false,
+        shift: false,
+        tab: false,
+        meta: false,
+      } as Key;
+
+      await manager.handleInput("", mockKey, [], true, false); // isLoading = true
+
+      expect(mockCallbacks.onAbortMessage).not.toHaveBeenCalled();
+    });
+
+    it("should NOT handle escape to abort during loading if command selector is active", async () => {
+      manager.activateCommandSelector(0);
+      const mockKey = {
+        escape: true,
+        return: false,
+        upArrow: false,
+        downArrow: false,
+        leftArrow: false,
+        rightArrow: false,
+        ctrl: false,
+        backspace: false,
+        delete: false,
+        pageDown: false,
+        pageUp: false,
+        shift: false,
+        tab: false,
+        meta: false,
+      } as Key;
+
+      await manager.handleInput("", mockKey, [], true, false); // isLoading = true
+
+      expect(mockCallbacks.onAbortMessage).not.toHaveBeenCalled();
+    });
+
+    it("should NOT handle escape to abort during loading if history search is active", async () => {
+      manager.activateHistorySearch();
+      const mockKey = {
+        escape: true,
+        return: false,
+        upArrow: false,
+        downArrow: false,
+        leftArrow: false,
+        rightArrow: false,
+        ctrl: false,
+        backspace: false,
+        delete: false,
+        pageDown: false,
+        pageUp: false,
+        shift: false,
+        tab: false,
+        meta: false,
+      } as Key;
+
+      await manager.handleInput("", mockKey, [], true, false); // isLoading = true
+
+      expect(mockCallbacks.onAbortMessage).not.toHaveBeenCalled();
+    });
+
+    it("should NOT handle escape to abort during loading if help is active", async () => {
+      manager.setShowHelp(true);
+      const mockKey = {
+        escape: true,
+        return: false,
+        upArrow: false,
+        downArrow: false,
+        leftArrow: false,
+        rightArrow: false,
+        ctrl: false,
+        backspace: false,
+        delete: false,
+        pageDown: false,
+        pageUp: false,
+        shift: false,
+        tab: false,
+        meta: false,
+      } as Key;
+
+      await manager.handleInput("", mockKey, [], true, false); // isLoading = true
+
+      expect(mockCallbacks.onAbortMessage).not.toHaveBeenCalled();
+    });
+
+    it("should NOT handle escape to abort during loading if status command is active", async () => {
+      manager.setShowStatusCommand(true);
+      const mockKey = {
+        escape: true,
+        return: false,
+        upArrow: false,
+        downArrow: false,
+        leftArrow: false,
+        rightArrow: false,
+        ctrl: false,
+        backspace: false,
+        delete: false,
+        pageDown: false,
+        pageUp: false,
+        shift: false,
+        tab: false,
+        meta: false,
+      } as Key;
+
+      await manager.handleInput("", mockKey, [], true, false); // isLoading = true
+
+      expect(mockCallbacks.onAbortMessage).not.toHaveBeenCalled();
+    });
+
     it("should prevent submission when loading", async () => {
       manager.insertTextAtCursor("test");
 


### PR DESCRIPTION
Centralized the check for active selectors and managers in InputManager to improve maintainability and ensure consistent behavior when handling escape keys. Added unit tests to verify that escape does not trigger an abort when UI components like the file selector or help menu are active.