### PR TITLE
feat(code): refactor HelpView to support tabs and command navigation

### DIFF
--- a/packages/code/src/components/CommandSelector.tsx
+++ b/packages/code/src/components/CommandSelector.tsx
@@ -1,46 +1,7 @@
 import React, { useState } from "react";
 import { Box, Text, useInput } from "ink";
 import type { SlashCommand } from "wave-agent-sdk";
-
-const AVAILABLE_COMMANDS: SlashCommand[] = [
-  {
-    id: "clear",
-    name: "clear",
-    description: "Clear the chat session and terminal",
-    handler: () => {}, // Handler here won't be used, actual processing is in the hook
-  },
-  {
-    id: "tasks",
-    name: "tasks",
-    description: "View and manage background tasks (shells and subagents)",
-    handler: () => {}, // Handler here won't be used, actual processing is in the hook
-  },
-  {
-    id: "mcp",
-    name: "mcp",
-    description: "View and manage MCP servers",
-    handler: () => {}, // Handler here won't be used, actual processing is in the hook
-  },
-  {
-    id: "rewind",
-    name: "rewind",
-    description:
-      "Revert conversation and file changes to a previous checkpoint",
-    handler: () => {}, // Handler here won't be used, actual processing is in the hook
-  },
-  {
-    id: "help",
-    name: "help",
-    description: "Show help and key bindings",
-    handler: () => {}, // Handler here won't be used, actual processing is in the hook
-  },
-  {
-    id: "status",
-    name: "status",
-    description: "Show agent status and configuration",
-    handler: () => {}, // Handler here won't be used, actual processing is in the hook
-  },
-];
+import { AVAILABLE_COMMANDS } from "../constants/commands.js";
 
 export interface CommandSelectorProps {
   searchQuery: string;

--- a/packages/code/src/components/HelpView.tsx
+++ b/packages/code/src/components/HelpView.tsx
@@ -1,14 +1,57 @@
-import React from "react";
+import React, { useState } from "react";
 import { Box, Text, useInput } from "ink";
+import type { SlashCommand } from "wave-agent-sdk";
+import { AVAILABLE_COMMANDS } from "../constants/commands.js";
 
 export interface HelpViewProps {
   onCancel: () => void;
+  commands?: SlashCommand[];
 }
 
-export const HelpView: React.FC<HelpViewProps> = ({ onCancel }) => {
+export const HelpView: React.FC<HelpViewProps> = ({
+  onCancel,
+  commands = [],
+}) => {
+  const [activeTab, setActiveTab] = useState<
+    "general" | "commands" | "custom-commands"
+  >("general");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const MAX_VISIBLE_ITEMS = 10;
+
+  const tabs: ("general" | "commands" | "custom-commands")[] = [
+    "general",
+    "commands",
+  ];
+  if (commands.length > 0) {
+    tabs.push("custom-commands");
+  }
+
   useInput((_, key) => {
-    if (key.escape || key.return) {
+    if (key.escape) {
       onCancel();
+      return;
+    }
+
+    if (key.tab) {
+      setActiveTab((prev) => {
+        const currentIndex = tabs.indexOf(prev);
+        const nextIndex = (currentIndex + 1) % tabs.length;
+        return tabs[nextIndex];
+      });
+      setSelectedIndex(0);
+      return;
+    }
+
+    if (activeTab === "commands" || activeTab === "custom-commands") {
+      const currentCommands =
+        activeTab === "commands" ? AVAILABLE_COMMANDS : commands;
+      if (key.upArrow) {
+        setSelectedIndex((prev) => Math.max(0, prev - 1));
+      } else if (key.downArrow) {
+        setSelectedIndex((prev) =>
+          Math.min(currentCommands.length - 1, prev + 1),
+        );
+      }
     }
   });
 
@@ -21,13 +64,34 @@ export const HelpView: React.FC<HelpViewProps> = ({ onCancel }) => {
     { key: "Ctrl+B", description: "Background current task" },
     { key: "Ctrl+V", description: "Paste image" },
     { key: "Shift+Tab", description: "Cycle permission mode" },
-    { key: "/status", description: "Show agent status and configuration" },
-    { key: "/clear", description: "Clear the chat session and terminal" },
     {
       key: "Esc",
       description: "Interrupt AI or command / Cancel selector / Close help",
     },
   ];
+
+  // Calculate visible window for commands
+  const currentCommands =
+    activeTab === "commands" ? AVAILABLE_COMMANDS : commands;
+  const startIndex = Math.max(
+    0,
+    Math.min(
+      selectedIndex - Math.floor(MAX_VISIBLE_ITEMS / 2),
+      Math.max(0, currentCommands.length - MAX_VISIBLE_ITEMS),
+    ),
+  );
+  const visibleCommands = currentCommands.slice(
+    startIndex,
+    startIndex + MAX_VISIBLE_ITEMS,
+  );
+
+  const footerText = [
+    "Tab switch",
+    activeTab !== "general" && "↑↓ navigate",
+    "Esc close",
+  ]
+    .filter(Boolean)
+    .join(" • ");
 
   return (
     <Box
@@ -37,24 +101,73 @@ export const HelpView: React.FC<HelpViewProps> = ({ onCancel }) => {
       borderLeft={false}
       borderRight={false}
       paddingX={1}
+      width="100%"
     >
-      <Box marginBottom={1}>
-        <Text color="cyan" bold underline>
-          Help & Key Bindings
+      <Box marginBottom={1} gap={2}>
+        <Text
+          color={activeTab === "general" ? "cyan" : "gray"}
+          bold
+          underline={activeTab === "general"}
+        >
+          General
         </Text>
+        <Text
+          color={activeTab === "commands" ? "cyan" : "gray"}
+          bold
+          underline={activeTab === "commands"}
+        >
+          Commands
+        </Text>
+        {commands.length > 0 && (
+          <Text
+            color={activeTab === "custom-commands" ? "cyan" : "gray"}
+            bold
+            underline={activeTab === "custom-commands"}
+          >
+            Custom Commands
+          </Text>
+        )}
       </Box>
 
-      {helpItems.map((item, index) => (
-        <Box key={index}>
-          <Box width={20}>
-            <Text color="yellow">{item.key}</Text>
-          </Box>
-          <Text color="white">{item.description}</Text>
+      {activeTab === "general" ? (
+        <Box flexDirection="column">
+          {helpItems.map((item, index) => (
+            <Box key={index}>
+              <Box width={20}>
+                <Text color="yellow">{item.key}</Text>
+              </Box>
+              <Text color="white">{item.description}</Text>
+            </Box>
+          ))}
         </Box>
-      ))}
+      ) : (
+        <Box flexDirection="column">
+          {visibleCommands.map((command, index) => {
+            const actualIndex = startIndex + index;
+            const isSelected = actualIndex === selectedIndex;
+            return (
+              <Box key={command.id} flexDirection="column">
+                <Text
+                  color={isSelected ? "black" : "white"}
+                  backgroundColor={isSelected ? "cyan" : undefined}
+                >
+                  {isSelected ? "▶ " : "  "}/{command.id}
+                </Text>
+                {isSelected && (
+                  <Box marginLeft={4}>
+                    <Text color="gray" dimColor>
+                      {command.description}
+                    </Text>
+                  </Box>
+                )}
+              </Box>
+            );
+          })}
+        </Box>
+      )}
 
       <Box marginTop={1}>
-        <Text dimColor>Press Esc or Enter to close</Text>
+        <Text dimColor>{footerText}</Text>
       </Box>
     </Box>
   );

--- a/packages/code/src/components/InputBox.tsx
+++ b/packages/code/src/components/InputBox.tsx
@@ -174,7 +174,9 @@ export const InputBox: React.FC<InputBoxProps> = ({
   }
 
   if (showHelp) {
-    return <HelpView onCancel={() => setShowHelp(false)} />;
+    return (
+      <HelpView onCancel={() => setShowHelp(false)} commands={slashCommands} />
+    );
   }
 
   if (showStatusCommand) {

--- a/packages/code/src/constants/commands.ts
+++ b/packages/code/src/constants/commands.ts
@@ -1,0 +1,41 @@
+import type { SlashCommand } from "wave-agent-sdk";
+
+export const AVAILABLE_COMMANDS: SlashCommand[] = [
+  {
+    id: "clear",
+    name: "clear",
+    description: "Clear the chat session and terminal",
+    handler: () => {}, // Handler here won't be used, actual processing is in the hook
+  },
+  {
+    id: "tasks",
+    name: "tasks",
+    description: "View and manage background tasks (shells and subagents)",
+    handler: () => {}, // Handler here won't be used, actual processing is in the hook
+  },
+  {
+    id: "mcp",
+    name: "mcp",
+    description: "View and manage MCP servers",
+    handler: () => {}, // Handler here won't be used, actual processing is in the hook
+  },
+  {
+    id: "rewind",
+    name: "rewind",
+    description:
+      "Revert conversation and file changes to a previous checkpoint",
+    handler: () => {}, // Handler here won't be used, actual processing is in the hook
+  },
+  {
+    id: "help",
+    name: "help",
+    description: "Show help and key bindings",
+    handler: () => {}, // Handler here won't be used, actual processing is in the hook
+  },
+  {
+    id: "status",
+    name: "status",
+    description: "Show agent status and configuration",
+    handler: () => {}, // Handler here won't be used, actual processing is in the hook
+  },
+];

--- a/packages/code/tests/components/HelpView.test.tsx
+++ b/packages/code/tests/components/HelpView.test.tsx
@@ -2,14 +2,14 @@ import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render } from "ink-testing-library";
 import { HelpView } from "../../src/components/HelpView.js";
-import { stripAnsiColors } from "wave-agent-sdk";
+import { stripAnsiColors, type SlashCommand } from "wave-agent-sdk";
 
 describe("HelpView", () => {
   it("should render help items", () => {
     const { lastFrame } = render(<HelpView onCancel={() => {}} />);
     const output = stripAnsiColors(lastFrame() || "");
-
-    expect(output).toContain("Help & Key Bindings");
+    expect(output).toContain("General");
+    expect(output).toContain("Commands");
     expect(output).toContain("@");
     expect(output).toContain("Reference files");
     expect(output).toContain("/");
@@ -31,14 +31,83 @@ describe("HelpView", () => {
     });
   });
 
-  it("should call onCancel when Enter is pressed", async () => {
+  it("should not call onCancel when Enter is pressed", async () => {
     const onCancel = vi.fn();
     const { stdin } = render(<HelpView onCancel={onCancel} />);
 
     stdin.write("\r"); // Enter
 
+    // Wait a bit to ensure it's NOT called
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("should switch tabs when Tab is pressed", async () => {
+    const { lastFrame, stdin } = render(<HelpView onCancel={() => {}} />);
+
+    // Initially on General tab
+    expect(stripAnsiColors(lastFrame() || "")).toContain("Reference files");
+
+    // Press Tab to switch to Commands tab
+    stdin.write("\t");
+
     await vi.waitFor(() => {
-      expect(onCancel).toHaveBeenCalled();
+      const output = stripAnsiColors(lastFrame() || "");
+      expect(output).toContain("/clear");
+      expect(output).not.toContain("Reference files");
     });
+
+    // Press Tab again to switch back to General tab
+    stdin.write("\t");
+
+    await vi.waitFor(() => {
+      const output = stripAnsiColors(lastFrame() || "");
+      expect(output).toContain("Reference files");
+      expect(output).not.toContain("/clear");
+    });
+  });
+
+  it("should show Custom Commands tab when custom commands are provided", async () => {
+    const customCommands = [
+      {
+        id: "custom",
+        name: "custom",
+        description: "Custom command description",
+        handler: async () => {},
+      },
+    ];
+    const { lastFrame, stdin } = render(
+      <HelpView
+        onCancel={() => {}}
+        commands={customCommands as SlashCommand[]}
+      />,
+    );
+
+    expect(stripAnsiColors(lastFrame() || "")).toContain("Custom Commands");
+
+    // Press Tab to switch to Commands tab
+    stdin.write("\t");
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("/clear");
+    });
+
+    // Press Tab again to switch to Custom Commands tab
+    stdin.write("\t");
+    await vi.waitFor(() => {
+      const output = stripAnsiColors(lastFrame() || "");
+      expect(output).toContain("/custom");
+      expect(output).toContain("Custom command description");
+    });
+
+    // Press Tab again to switch back to General tab
+    stdin.write("\t");
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("Reference files");
+    });
+  });
+
+  it("should not show Custom Commands tab when no custom commands are provided", () => {
+    const { lastFrame } = render(<HelpView onCancel={() => {}} />);
+    expect(stripAnsiColors(lastFrame() || "")).not.toContain("Custom Commands");
   });
 });

--- a/packages/code/tests/components/InputBox.test.tsx
+++ b/packages/code/tests/components/InputBox.test.tsx
@@ -370,7 +370,8 @@ describe("InputBox Smoke Tests", () => {
       await vi.waitFor(
         () => {
           const output = stripAnsiColors(lastFrame() || "");
-          expect(output).toContain("Help & Key Bindings");
+          expect(output).toContain("General");
+          expect(output).toContain("Commands");
         },
         { timeout: 2000 },
       );


### PR DESCRIPTION
This PR refactors the HelpView component to support multiple tabs (General, Commands, and Custom Commands) and adds navigation for commands. It also extracts available commands into a constant file for better maintainability.