### PR TITLE
feat(agent-sdk): limit glob tool results to 1000 files

### DIFF
--- a/packages/agent-sdk/src/tools/globTool.ts
+++ b/packages/agent-sdk/src/tools/globTool.ts
@@ -6,6 +6,11 @@ import { getGlobIgnorePatterns } from "../utils/fileFilter.js";
 import { GLOB_TOOL_NAME } from "../constants/tools.js";
 
 /**
+ * Maximum number of files returned by glob tool
+ */
+const MAX_GLOB_RESULTS = 1000;
+
+/**
  * Glob Tool Plugin - Fast file pattern matching
  */
 export const globTool: ToolPlugin = {
@@ -109,15 +114,23 @@ export const globTool: ToolPlugin = {
         .sort((a, b) => b.mtime.getTime() - a.mtime.getTime()) // Most recently modified files first
         .map((item) => item.path);
 
+      const totalCount = sortedFiles.length;
+      const finalFiles = sortedFiles.slice(0, MAX_GLOB_RESULTS);
+
       // Format output
-      const output = sortedFiles
+      const output = finalFiles
         .map((file, index) => `${index + 1}. ${file}`)
         .join("\n");
+
+      const isTruncated = totalCount > MAX_GLOB_RESULTS;
+      const shortResult = isTruncated
+        ? `Found ${totalCount} files (showing first ${MAX_GLOB_RESULTS})`
+        : `Found ${totalCount} file${totalCount === 1 ? "" : "s"}`;
 
       return {
         success: true,
         content: output,
-        shortResult: `Found ${sortedFiles.length} file${sortedFiles.length === 1 ? "" : "s"}`,
+        shortResult,
       };
     } catch (error) {
       return {

--- a/packages/agent-sdk/tests/tools/globTool.test.ts
+++ b/packages/agent-sdk/tests/tools/globTool.test.ts
@@ -340,4 +340,31 @@ describe("globTool", () => {
     expect(result.success).toBe(true);
     expect(result.content).toContain("nested/deep/file.ts");
   });
+
+  it("should limit the number of results to 1000", async () => {
+    const manyFiles = Array.from(
+      { length: 1005 },
+      (_, i) => `/test/workdir/file${i}.txt`,
+    );
+    mockGlob.mockResolvedValueOnce(manyFiles);
+
+    // Mock stat for all files - make them progressively newer
+    manyFiles.forEach((_, i) => {
+      mockStat.mockResolvedValueOnce(
+        createMockStats(new Date(2023, 0, 1, 0, 0, i)),
+      );
+    });
+
+    const result = await globTool.execute({ pattern: "**/*.txt" }, testContext);
+
+    expect(result.success).toBe(true);
+    const lines = result.content.split("\n");
+    expect(lines.length).toBe(1000);
+    expect(result.shortResult).toBe("Found 1005 files (showing first 1000)");
+    // Verify it shows the most recent ones (the ones with higher index in our mock)
+    // file1004.txt is the newest, so it should be first
+    expect(lines[0]).toContain("file1004.txt");
+    // file5.txt should be the last one (1005 - 1000 = 5)
+    expect(lines[999]).toContain("file5.txt");
+  });
 });


### PR DESCRIPTION
Implement internal file count limit to globTool to prevent excessive token usage in large codebases. Added MAX_GLOB_RESULTS = 1000 and updated tests to verify truncation and sorting.