### PR TITLE
feat(agent-sdk): implement manual backgrounding (Ctrl+B) for task tool

### DIFF
--- a/packages/agent-sdk/src/tools/taskTool.ts
+++ b/packages/agent-sdk/src/tools/taskTool.ts
@@ -162,68 +162,77 @@ ${subagentList || "No subagents configured"}
         },
       );
 
-      // Register for backgrounding if not already in background
-      if (!run_in_background && context.foregroundTaskManager) {
-        context.foregroundTaskManager.registerForegroundTask({
-          id: instance.subagentId,
-          backgroundHandler: async () => {
-            isBackgrounded = true;
-            await subagentManager.backgroundInstance(instance.subagentId);
-          },
-        });
-      }
+      return new Promise<ToolResult>((resolve) => {
+        (async () => {
+          // Register for backgrounding if not already in background
+          if (!run_in_background && context.foregroundTaskManager) {
+            context.foregroundTaskManager.registerForegroundTask({
+              id: instance.subagentId,
+              backgroundHandler: async () => {
+                isBackgrounded = true;
+                await subagentManager.backgroundInstance(instance.subagentId);
+                resolve({
+                  success: true,
+                  content: "Task backgrounded",
+                  shortResult: "Task backgrounded",
+                  isManuallyBackgrounded: true,
+                });
+              },
+            });
+          }
 
-      try {
-        const result = await subagentManager.executeTask(
-          instance,
-          prompt,
-          context.abortSignal,
-          run_in_background,
-        );
+          try {
+            const result = await subagentManager.executeTask(
+              instance,
+              prompt,
+              context.abortSignal,
+              run_in_background,
+            );
 
-        if (isBackgrounded) {
-          // If it was backgrounded during execution, the backgroundHandler already returned/will return
-          // But wait, the backgroundHandler is async and returns a ToolResult.
-          // In the current ToolManager/AIManager implementation, the backgroundHandler's return value
-          // is what's used when backgrounding happens.
-          // However, executeTask might still be running.
-          // We should return a special value or just let it be.
-          return {
-            success: true,
-            content: "Task backgrounded",
-            shortResult: "Task backgrounded",
-            isManuallyBackgrounded: true,
-          };
-        }
+            if (isBackgrounded) {
+              return;
+            }
 
-        if (run_in_background) {
-          return {
-            success: true,
-            content: `Task started in background with ID: ${result}`,
-            shortResult: `Task started in background: ${result}`,
-          };
-        }
+            if (run_in_background) {
+              resolve({
+                success: true,
+                content: `Task started in background with ID: ${result}`,
+                shortResult: `Task started in background: ${result}`,
+              });
+              return;
+            }
 
-        // Cleanup subagent instance after task completion
-        subagentManager.cleanupInstance(instance.subagentId);
+            // Cleanup subagent instance after task completion
+            subagentManager.cleanupInstance(instance.subagentId);
 
-        const messages = instance.messageManager.getMessages();
-        const tokens = instance.messageManager.getlatestTotalTokens();
-        const toolCount = countToolBlocks(messages);
-        const summary = formatToolTokenSummary(toolCount, tokens);
+            const messages = instance.messageManager.getMessages();
+            const tokens = instance.messageManager.getlatestTotalTokens();
+            const toolCount = countToolBlocks(messages);
+            const summary = formatToolTokenSummary(toolCount, tokens);
 
-        return {
-          success: true,
-          content: result,
-          shortResult: `Task completed${summary ? ` ${summary}` : ""}`,
-        };
-      } finally {
-        if (!run_in_background && context.foregroundTaskManager) {
-          context.foregroundTaskManager.unregisterForegroundTask(
-            instance.subagentId,
-          );
-        }
-      }
+            resolve({
+              success: true,
+              content: result,
+              shortResult: `Task completed${summary ? ` ${summary}` : ""}`,
+            });
+          } catch (error) {
+            if (!isBackgrounded) {
+              resolve({
+                success: false,
+                content: "",
+                error: `Task delegation failed: ${error instanceof Error ? error.message : String(error)}`,
+                shortResult: "Delegation error",
+              });
+            }
+          } finally {
+            if (!run_in_background && context.foregroundTaskManager) {
+              context.foregroundTaskManager.unregisterForegroundTask(
+                instance.subagentId,
+              );
+            }
+          }
+        })();
+      });
     } catch (error) {
       return {
         success: false,


### PR DESCRIPTION
# Fix Task Tool Backgrounding with Ctrl+B

## Context
The `task` tool (subagent delegation) could not be backgrounded by pressing `Ctrl+B`, even though the `bash` tool worked correctly. The issue was that `taskTool.execute` awaited `subagentManager.executeTask` and didn't return immediately when the backgrounding hotkey was pressed. While the subagent task was moved to the background system, the main agent remained blocked awaiting the tool's completion.

## Proposed Changes

### `packages/agent-sdk`

#### `packages/agent-sdk/src/tools/taskTool.ts`
- Refactored the `execute` function to wrap the subagent execution in a `Promise`.
- In the `backgroundHandler` of the registered foreground task, called `resolve()` with a `ToolResult` that has `isManuallyBackgrounded: true`.
- This allows the `execute` function to return immediately to the `Agent` (via `AIManager`), unblocking the UI.
- Used an IIFE (Immediately Invoked Function Expression) inside the `Promise` constructor to handle the asynchronous execution of `subagentManager.executeTask` while adhering to ESLint's `no-async-promise-executor` rule.
- Ensured that normal completion of `subagentManager.executeTask` also resolves the promise with the appropriate result.

## Verification Plan

### Automated Tests
- Ran existing tests for `taskTool`: `cd packages/agent-sdk && pnpm test tests/tools/taskTool.test.ts` (Passed)
- Ran agent foreground tests: `cd packages/agent-sdk && pnpm test tests/agent/agent.foreground.test.ts` (Passed)