### PR TITLE
Refactor: Remove excessive debug logging in agent-sdk

### DIFF
--- a/packages/agent-sdk/src/managers/hookManager.ts
+++ b/packages/agent-sdk/src/managers/hookManager.ts
@@ -80,10 +80,6 @@ export class HookManager {
    */
   loadConfigurationFromWaveConfig(waveConfig: WaveConfiguration | null): void {
     try {
-      logger?.debug(
-        `[HookManager] Loading hooks configuration from pre-loaded config...`,
-      );
-
       this.configuration = waveConfig?.hooks || undefined;
 
       // Validate the loaded configuration if it exists
@@ -96,10 +92,6 @@ export class HookManager {
           );
         }
       }
-
-      logger?.debug(
-        `[HookManager] Hooks configuration loaded successfully with ${Object.keys(waveConfig?.hooks || {}).length} event types`,
-      );
     } catch (error) {
       // If loading fails, start with undefined configuration (no hooks)
       this.configuration = undefined;
@@ -139,24 +131,15 @@ export class HookManager {
     }
 
     if (!this.configuration) {
-      logger?.debug(
-        `[HookManager] No configuration loaded, skipping ${event} hooks`,
-      );
       return [];
     }
 
     const eventConfigs = this.configuration[event];
     if (!eventConfigs || eventConfigs.length === 0) {
-      logger?.debug(`[HookManager] No hooks configured for ${event} event`);
       return [];
     }
 
-    logger?.debug(
-      `[HookManager] Starting ${event} hook execution with ${eventConfigs.length} configurations`,
-    );
-
     const results: HookExecutionResult[] = [];
-    const startTime = Date.now();
 
     for (
       let configIndex = 0;
@@ -167,15 +150,8 @@ export class HookManager {
 
       // Check if this config applies to the current context
       if (!this.configApplies(config, event, context.toolName)) {
-        logger?.debug(
-          `[HookManager] Skipping configuration ${configIndex + 1}: matcher '${config.matcher}' does not match tool '${context.toolName}'`,
-        );
         continue;
       }
-
-      logger?.debug(
-        `[HookManager] Executing configuration ${configIndex + 1} with ${config.hooks.length} commands (matcher: ${config.matcher || "any"})`,
-      );
 
       // Execute all commands for this configuration
       for (
@@ -186,27 +162,12 @@ export class HookManager {
         const hookCommand = config.hooks[commandIndex];
 
         try {
-          logger?.debug(
-            `[HookManager] Executing command ${commandIndex + 1}/${config.hooks.length} in configuration ${configIndex + 1}`,
-          );
-
           const result = await executeCommand(
             hookCommand.command,
             context,
             undefined,
           );
           results.push(result);
-
-          // Report individual command result
-          if (result.success) {
-            logger?.debug(
-              `[HookManager] Command ${commandIndex + 1} completed successfully in ${result.duration}ms`,
-            );
-          } else {
-            logger?.debug(
-              `[HookManager] Command ${commandIndex + 1} failed in ${result.duration}ms (exit code: ${result.exitCode}, timed out: ${result.timedOut})`,
-            );
-          }
 
           // Continue with next command even if this one fails
           // This allows for non-critical hooks to fail without stopping the workflow
@@ -227,15 +188,6 @@ export class HookManager {
         }
       }
     }
-
-    // Generate execution summary
-    const totalDuration = Date.now() - startTime;
-    const summary = this.generateExecutionSummary(
-      event,
-      results,
-      totalDuration,
-    );
-    logger?.debug(`[HookManager] ${event} execution summary: ${summary}`);
 
     return results;
   }
@@ -797,9 +749,5 @@ export class HookManager {
     }
 
     this.mergeHooksConfiguration(this.configuration, hooks);
-
-    logger?.debug(
-      `Registered plugin hooks. Total event types: ${Object.keys(this.configuration).length}`,
-    );
   }
 }

--- a/packages/agent-sdk/src/managers/liveConfigManager.ts
+++ b/packages/agent-sdk/src/managers/liveConfigManager.ts
@@ -83,8 +83,6 @@ export class LiveConfigManager {
     projectPaths?: string[],
   ): Promise<void> {
     try {
-      logger?.debug("Live Config: Initializing configuration watching...");
-
       this.userConfigPaths = userPaths;
       this.projectConfigPaths = projectPaths;
 
@@ -94,15 +92,8 @@ export class LiveConfigManager {
       // Start watching user configs that exist
       for (const userPath of userPaths) {
         if (existsSync(userPath)) {
-          logger?.debug(
-            `Live Config: Starting to watch user config: ${userPath}`,
-          );
           await this.fileWatcher.watchFile(userPath, (event) =>
             this.handleFileChange(event, "user"),
-          );
-        } else {
-          logger?.debug(
-            `Live Config: User config file does not exist: ${userPath}`,
           );
         }
       }
@@ -114,24 +105,14 @@ export class LiveConfigManager {
             if (projectPath.endsWith("settings.local.json")) {
               await ensureGlobalGitIgnore("**/.wave/settings.local.json");
             }
-            logger?.debug(
-              `Live Config: Starting to watch project config: ${projectPath}`,
-            );
             await this.fileWatcher.watchFile(projectPath, (event) =>
               this.handleFileChange(event, "project"),
-            );
-          } else {
-            logger?.debug(
-              `Live Config: Project config file does not exist: ${projectPath}`,
             );
           }
         }
       }
 
       this.isWatching = true;
-      logger?.debug(
-        "Live Config: Configuration watching initialized successfully",
-      );
     } catch (error) {
       const errorMessage = `Failed to initialize configuration watching: ${(error as Error).message}`;
       logger?.error(`Live Config: ${errorMessage}`);
@@ -151,7 +132,6 @@ export class LiveConfigManager {
    */
   async initialize(): Promise<void> {
     if (this.isInitialized) {
-      logger?.debug("Already initialized");
       return;
     }
 
@@ -163,9 +143,6 @@ export class LiveConfigManager {
       await this.initializeWatching(userPaths, projectPaths);
 
       this.isInitialized = true;
-      logger?.debug(
-        "Live configuration management initialized with file watching",
-      );
     } catch (error) {
       logger?.error(`Failed to initialize: ${(error as Error).message}`);
       throw error;
@@ -181,8 +158,6 @@ export class LiveConfigManager {
     }
 
     try {
-      logger?.debug("Live Config: Shutting down configuration manager...");
-
       this.isWatching = false;
 
       // Cleanup file watcher
@@ -193,7 +168,6 @@ export class LiveConfigManager {
       this.lastValidConfiguration = null;
 
       this.isInitialized = false;
-      logger?.debug("Live configuration management shutdown completed");
     } catch (error) {
       logger?.error(`Error during shutdown: ${(error as Error).message}`);
       throw error;
@@ -206,15 +180,12 @@ export class LiveConfigManager {
    */
   private async reloadConfiguration(): Promise<WaveConfiguration> {
     if (this.reloadInProgress) {
-      logger?.debug("Live Config: Reload already in progress, skipping");
       return this.currentConfiguration || {};
     }
 
     this.reloadInProgress = true;
 
     try {
-      logger?.debug("Live Config: Reloading configuration from files...");
-
       // Load merged configuration using ConfigurationService
       const loadResult: ConfigurationLoadResult =
         await this.configurationService.loadMergedConfiguration(this.workdir);
@@ -237,9 +208,6 @@ export class LiveConfigManager {
 
         // Use fallback configuration if available
         if (this.lastValidConfiguration) {
-          logger?.debug(
-            "Live Config: Using previous valid configuration due to loading errors",
-          );
           this.currentConfiguration = this.lastValidConfiguration;
 
           // Apply environment variables to configuration service if configured
@@ -266,24 +234,6 @@ export class LiveConfigManager {
         }
       }
 
-      // Log success with detailed information
-      if (newConfig) {
-        logger?.debug(
-          `Live Config: Configuration loaded successfully from ${loadResult.sourcePath || "merged sources"}`,
-        );
-
-        // Log detailed configuration info
-        const hookCount = Object.keys(newConfig.hooks || {}).length;
-        const envCount = Object.keys(newConfig.env || {}).length;
-        logger?.debug(
-          `Live Config: Loaded ${hookCount} hook events and ${envCount} environment variables`,
-        );
-      } else {
-        logger?.debug(
-          "Live Config: No configuration found (using empty configuration)",
-        );
-      }
-
       // Log warnings from successful loading
       if (loadResult.warnings && loadResult.warnings.length > 0) {
         logger?.warn(
@@ -300,9 +250,6 @@ export class LiveConfigManager {
 
           // Use previous valid configuration for error recovery
           if (this.lastValidConfiguration) {
-            logger?.debug(
-              "Live Config: Using previous valid configuration due to validation errors",
-            );
             this.currentConfiguration = this.lastValidConfiguration;
 
             // Apply environment variables to configuration service if configured
@@ -339,9 +286,6 @@ export class LiveConfigManager {
       // Save as last valid configuration if it's valid and not empty
       if (newConfig && (newConfig.hooks || newConfig.env)) {
         this.lastValidConfiguration = { ...newConfig };
-        logger?.debug(
-          "Live Config: Saved current configuration as last valid backup",
-        );
       }
 
       // Note: Environment variables are already applied by loadMergedConfiguration()
@@ -378,10 +322,6 @@ export class LiveConfigManager {
         }
       }
 
-      logger?.debug(
-        `Live Config: Configuration reload completed successfully with ${Object.keys(newConfig?.hooks || {}).length} event types and ${Object.keys(newConfig?.env || {}).length} environment variables`,
-      );
-
       return this.currentConfiguration;
     } catch (error) {
       const errorMessage = `Configuration reload failed with exception: ${(error as Error).message}`;
@@ -389,9 +329,6 @@ export class LiveConfigManager {
 
       // Use previous valid configuration for error recovery
       if (this.lastValidConfiguration) {
-        logger?.debug(
-          "Live Config: Using previous valid configuration due to reload exception",
-        );
         this.currentConfiguration = this.lastValidConfiguration;
 
         // Apply environment variables to configuration service if configured
@@ -424,7 +361,6 @@ export class LiveConfigManager {
    * Reload configuration from files (public method)
    */
   async reload(): Promise<WaveConfiguration> {
-    logger?.debug("Manually reloading configuration...");
     return await this.reloadConfiguration();
   }
 
@@ -464,16 +400,9 @@ export class LiveConfigManager {
     event: FileWatchEvent,
     source: Scope,
   ): Promise<void> {
-    logger?.debug(
-      `Live Config: File ${event.type} detected for ${source} config: ${event.path}`,
-    );
-
     try {
       // Handle file deletion
       if (event.type === "delete") {
-        logger?.debug(
-          `Live Config: ${source} config file deleted: ${event.path}`,
-        );
         // Reload configuration without the deleted file
         await this.reloadConfiguration();
         return;
@@ -481,10 +410,6 @@ export class LiveConfigManager {
 
       // Handle file creation or modification
       if (event.type === "change" || event.type === "create") {
-        logger?.debug(
-          `Live Config: ${source} config file ${event.type}: ${event.path}`,
-        );
-
         if (
           source === "project" &&
           event.path.endsWith("settings.local.json") &&

--- a/packages/agent-sdk/src/services/fileWatcher.ts
+++ b/packages/agent-sdk/src/services/fileWatcher.ts
@@ -115,7 +115,6 @@ export class FileWatcherService extends EventEmitter {
       }
 
       this.watchers.delete(path);
-      this.logger?.debug(`Live Config: Stopped watching file: ${path}`);
     } catch (error) {
       this.logger?.warn(
         `Live Config: Error unwatching file ${path}: ${(error as Error).message}`,
@@ -199,8 +198,6 @@ export class FileWatcherService extends EventEmitter {
       entry.watcher = this.globalWatcher;
       entry.isActive = true;
       entry.errorCount = 0;
-
-      this.logger?.debug(`Live Config: Started watching file: ${entry.path}`);
     } catch (error) {
       entry.errorCount++;
       entry.isActive = false;
@@ -215,9 +212,6 @@ export class FileWatcherService extends EventEmitter {
         !entry.config.fallbackPolling &&
         entry.errorCount < entry.config.maxRetries
       ) {
-        this.logger?.debug(
-          `Live Config: Attempting polling fallback for ${entry.path}`,
-        );
         entry.config.fallbackPolling = true;
         await this.initializeWatcher(entry);
       } else {
@@ -281,7 +275,5 @@ export class FileWatcherService extends EventEmitter {
         );
       }
     }
-
-    this.logger?.debug(`Live Config: File ${type} event for ${filePath}`);
   }
 }

--- a/packages/agent-sdk/src/services/initializationService.ts
+++ b/packages/agent-sdk/src/services/initializationService.ts
@@ -121,7 +121,6 @@ export class InitializationService {
     // Initialize hooks configuration
     try {
       // Load hooks configuration using ConfigurationService
-      logger?.debug("Loading hooks configuration...");
       const configResult =
         await configurationService.loadMergedConfiguration(workdir);
 
@@ -156,8 +155,6 @@ export class InitializationService {
           }
         }
       }
-
-      logger?.debug("Hooks system initialized successfully");
     } catch (error) {
       logger?.error("Failed to initialize hooks system:", error);
       // Don't throw error to prevent app startup failure
@@ -206,9 +203,7 @@ export class InitializationService {
 
     // Initialize live configuration reload
     try {
-      logger?.debug("Initializing live configuration reload...");
       await liveConfigManager.initialize();
-      logger?.debug("Live configuration reload initialized successfully");
     } catch (error) {
       logger?.error("Failed to initialize live configuration reload:", error);
       // Don't throw error to prevent app startup failure - continue without live reload
@@ -216,8 +211,6 @@ export class InitializationService {
 
     // Load memory files during initialization
     try {
-      logger?.debug("Loading memory files...");
-
       // Load project memory from AGENTS.md (bypass memory store for direct file access)
       try {
         const projectMemoryPath = path.join(workdir, "AGENTS.md");
@@ -226,13 +219,9 @@ export class InitializationService {
           "utf-8",
         );
         setProjectMemory(projectMemoryContent);
-        logger?.debug("Project memory loaded successfully");
       } catch (error) {
+        logger?.warn("Failed to load project memory file:", error);
         setProjectMemory("");
-        logger?.debug(
-          "Project memory file not found or unreadable, using empty content:",
-          error instanceof Error ? error.message : String(error),
-        );
       }
 
       // Load user memory (bypass memory store for direct file access)
@@ -240,16 +229,10 @@ export class InitializationService {
         const userMemoryPath = path.join(os.homedir(), ".wave", "AGENTS.md");
         const userMemoryContent = await fs.readFile(userMemoryPath, "utf-8");
         setUserMemory(userMemoryContent);
-        logger?.debug("User memory loaded successfully");
       } catch (error) {
+        logger?.warn("Failed to load user memory file:", error);
         setUserMemory("");
-        logger?.debug(
-          "User memory file not found or unreadable, using empty content:",
-          error instanceof Error ? error.message : String(error),
-        );
       }
-
-      logger?.debug("Memory initialization completed");
     } catch (error) {
       // Ensure memory is always initialized even if loading fails
       setProjectMemory("");

--- a/packages/agent-sdk/tests/managers/hookManager.coverage.test.ts
+++ b/packages/agent-sdk/tests/managers/hookManager.coverage.test.ts
@@ -165,11 +165,6 @@ describe("HookManager Coverage", () => {
         context as unknown as Parameters<HookManager["executeHooks"]>[1],
       );
       expect(results).toHaveLength(0);
-      expect(logger.debug).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "matcher 'other-tool' does not match tool 'my-tool'",
-        ),
-      );
     });
 
     it("should handle unexpected error during command execution", async () => {

--- a/packages/agent-sdk/tests/managers/liveConfigManager.test.ts
+++ b/packages/agent-sdk/tests/managers/liveConfigManager.test.ts
@@ -324,11 +324,6 @@ describe("LiveConfigManager - Configuration Management", () => {
 
       await liveConfigManager.reload();
       expect(liveConfigManager.getCurrentConfiguration()).toEqual(validConfig);
-      expect(logger.debug).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "Using previous valid configuration due to loading errors",
-        ),
-      );
     });
 
     it("should handle exceptions during reload gracefully", async () => {


### PR DESCRIPTION
This PR removes numerous logger.debug calls across agent-sdk to reduce log noise and improves error reporting for memory loading failures by using logger.warn instead of debug/silent failure.