### PR TITLE
fix: suppress stack trace for OpenAI AbortError and log as INFO

### DIFF
--- a/packages/agent-sdk/src/services/aiService.ts
+++ b/packages/agent-sdk/src/services/aiService.ts
@@ -399,6 +399,7 @@ export async function callAgent(
     }
   } catch (error) {
     if ((error as Error).name === "AbortError") {
+      logger.info("OpenAI request aborted");
       throw new Error("Request was aborted");
     }
 
@@ -818,6 +819,7 @@ export async function compressMessages(
     };
   } catch (error) {
     if ((error as Error).name === "AbortError") {
+      logger.info("Compression request was aborted");
       throw new Error("Compression request was aborted");
     }
     logger.error("Failed to compress messages:", error);

--- a/packages/agent-sdk/src/utils/openaiClient.ts
+++ b/packages/agent-sdk/src/utils/openaiClient.ts
@@ -52,7 +52,9 @@ export class OpenAIClient {
             >;
           // Prevent unhandled rejection if only withResponse() is used
           promise.catch((e) => {
-            logger.error("Unhandled OpenAI promise rejection:", e);
+            if (!(e instanceof Error && e.name === "AbortError")) {
+              logger.error("Unhandled OpenAI promise rejection:", e);
+            }
           });
           return promise;
         },


### PR DESCRIPTION
This PR updates the AI service and OpenAI client to handle AbortErrors more gracefully by logging them as INFO instead of ERROR and suppressing the stack trace.