### PR TITLE
feat: implement physical task deletion and stale task list cleanup

### DIFF
--- a/packages/agent-sdk/src/services/taskManager.ts
+++ b/packages/agent-sdk/src/services/taskManager.ts
@@ -161,6 +161,57 @@ export class TaskManager extends EventEmitter {
     });
   }
 
+  async deleteTask(taskId: string): Promise<void> {
+    await this.withLock(async () => {
+      const taskPath = this.getTaskPath(taskId);
+      try {
+        await fs.unlink(taskPath);
+        this.emit("tasksChange", this.taskListId);
+        logger.debug(
+          `Task ${taskId} deleted from task list ${this.taskListId}`,
+        );
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw error;
+        }
+      }
+    });
+  }
+
+  async cleanupOldTaskLists(days: number = 30): Promise<void> {
+    const threshold = Date.now() - days * 24 * 60 * 60 * 1000;
+    try {
+      const dirs = await fs.readdir(this.baseDir);
+      for (const dir of dirs) {
+        if (dir === this.taskListId) continue;
+
+        const dirPath = join(this.baseDir, dir);
+        const stats = await fs.stat(dirPath);
+        if (!stats.isDirectory()) continue;
+
+        // Check mtime of the directory and its contents
+        let latestMtime = stats.mtimeMs;
+        const files = await fs.readdir(dirPath);
+        for (const file of files) {
+          const filePath = join(dirPath, file);
+          const fileStats = await fs.stat(filePath);
+          if (fileStats.mtimeMs > latestMtime) {
+            latestMtime = fileStats.mtimeMs;
+          }
+        }
+
+        if (latestMtime < threshold) {
+          logger.info(`Cleaning up old task list directory: ${dirPath}`);
+          await fs.rm(dirPath, { recursive: true, force: true });
+        }
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        logger.error("Failed to cleanup old task lists:", error);
+      }
+    }
+  }
+
   async listTasks(): Promise<Task[]> {
     const sessionDir = this.getSessionDir();
     try {

--- a/packages/agent-sdk/src/tools/taskManagementTools.ts
+++ b/packages/agent-sdk/src/tools/taskManagementTools.ts
@@ -101,6 +101,15 @@ NOTE that you should not use this tool if there is only one trivial task to do. 
 - Check TaskList first to avoid creating duplicate tasks`,
   execute: async (args, context: ToolContext): Promise<ToolResult> => {
     const taskManager = context.taskManager;
+
+    if (args.status === "deleted") {
+      return {
+        success: true,
+        content: `Task creation skipped because status was set to 'deleted'.`,
+        shortResult: `Skipped deleted task`,
+      };
+    }
+
     const task: Omit<Task, "id"> = {
       subject: args.subject as string,
       description: args.description as string,
@@ -331,6 +340,74 @@ Set up task dependencies:
       return {
         success: false,
         content: `Task with ID ${taskId} not found.`,
+      };
+    }
+
+    if (args.status === "deleted") {
+      // Reciprocal Dependency Cleanup
+      // For each task in the deleted task's blocks list, remove the deleted task's ID from their blockedBy list.
+      for (const targetId of existingTask.blocks) {
+        const targetTask = await taskManager.getTask(targetId);
+        if (targetTask && targetTask.blockedBy.includes(taskId)) {
+          let targetSnapshotId: string | undefined;
+          if (context.reversionManager && context.messageId) {
+            const targetPath = taskManager.getTaskPath(targetId);
+            targetSnapshotId = await context.reversionManager.recordSnapshot(
+              context.messageId,
+              targetPath,
+              "modify",
+            );
+          }
+          await taskManager.updateTask({
+            ...targetTask,
+            blockedBy: targetTask.blockedBy.filter((id) => id !== taskId),
+          });
+          if (context.reversionManager && targetSnapshotId) {
+            await context.reversionManager.commitSnapshot(targetSnapshotId);
+          }
+        }
+      }
+
+      // For each task in the deleted task's blockedBy list, remove the deleted task's ID from their blocks list.
+      for (const targetId of existingTask.blockedBy) {
+        const targetTask = await taskManager.getTask(targetId);
+        if (targetTask && targetTask.blocks.includes(taskId)) {
+          let targetSnapshotId: string | undefined;
+          if (context.reversionManager && context.messageId) {
+            const targetPath = taskManager.getTaskPath(targetId);
+            targetSnapshotId = await context.reversionManager.recordSnapshot(
+              context.messageId,
+              targetPath,
+              "modify",
+            );
+          }
+          await taskManager.updateTask({
+            ...targetTask,
+            blocks: targetTask.blocks.filter((id) => id !== taskId),
+          });
+          if (context.reversionManager && targetSnapshotId) {
+            await context.reversionManager.commitSnapshot(targetSnapshotId);
+          }
+        }
+      }
+
+      // Record delete snapshot for the task itself
+      if (context.reversionManager && context.messageId) {
+        const taskPath = taskManager.getTaskPath(taskId);
+        const deleteSnapshotId = await context.reversionManager.recordSnapshot(
+          context.messageId,
+          taskPath,
+          "delete",
+        );
+        await context.reversionManager.commitSnapshot(deleteSnapshotId);
+      }
+
+      await taskManager.deleteTask(taskId);
+
+      return {
+        success: true,
+        content: `Task #${taskId} deleted and removed from disk.`,
+        shortResult: `Deleted task ${taskId}`,
       };
     }
 

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -116,6 +116,9 @@ export function setupAgentContainer(
     const tasks = await taskManager.listTasks();
     onTasksChange(tasks);
   });
+  taskManager.cleanupOldTaskLists(30).catch((error) => {
+    logger.error("Failed to cleanup old task lists:", error);
+  });
 
   const backgroundTaskManager = new BackgroundTaskManager(container, {
     callbacks: {

--- a/packages/agent-sdk/tests/agent/agent.taskListId.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.taskListId.test.ts
@@ -40,6 +40,7 @@ vi.mock("../../src/services/taskManager.js", () => {
     getTaskListId: vi.fn(),
     setTaskListId: vi.fn(),
     refreshTasks: vi.fn().mockResolvedValue(undefined),
+    cleanupOldTaskLists: vi.fn().mockResolvedValue(undefined),
   };
   return {
     TaskManager: vi.fn().mockImplementation(function (taskListId: string) {

--- a/packages/agent-sdk/tests/agent/agent.taskSessionRestore.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.taskSessionRestore.test.ts
@@ -44,6 +44,7 @@ vi.mock("../../src/services/taskManager.js", () => {
     getTaskListId: vi.fn().mockReturnValue("initial-task-list-id"),
     refreshTasks: vi.fn().mockResolvedValue(undefined),
     syncWithSession: vi.fn().mockResolvedValue(undefined),
+    cleanupOldTaskLists: vi.fn().mockResolvedValue(undefined),
   };
   return {
     TaskManager: vi.fn(function () {

--- a/packages/agent-sdk/tests/services/taskManager.test.ts
+++ b/packages/agent-sdk/tests/services/taskManager.test.ts
@@ -12,6 +12,8 @@ vi.mock("fs", () => ({
     writeFile: vi.fn(),
     readFile: vi.fn(),
     unlink: vi.fn(),
+    stat: vi.fn(),
+    rm: vi.fn(),
   },
 }));
 
@@ -309,6 +311,87 @@ describe("TaskManager", () => {
 
       expect(spy).toHaveBeenCalledWith(sessionId);
       expect(fs.writeFile).toHaveBeenCalled();
+    });
+
+    it("should delete a task", async () => {
+      const mockFileHandle = {
+        close: vi.fn().mockResolvedValue(undefined),
+      };
+      vi.mocked(fs.open).mockResolvedValue(
+        mockFileHandle as unknown as Awaited<ReturnType<typeof fs.open>>,
+      );
+      vi.mocked(fs.unlink).mockResolvedValue(undefined);
+
+      await taskManager.deleteTask("1");
+
+      expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining("1.json"));
+      expect(fs.unlink).toHaveBeenCalledWith(
+        expect.stringMatching(/\/\.lock$/),
+      );
+    });
+
+    it("should cleanup old task lists", async () => {
+      const oldDir = "old-session";
+      const currentDir = sessionId;
+      const otherFile = "not-a-dir";
+
+      vi.mocked(fs.readdir)
+        .mockResolvedValueOnce([
+          oldDir,
+          currentDir,
+          otherFile,
+        ] as unknown as Awaited<ReturnType<typeof fs.readdir>>) // baseDir
+        .mockResolvedValueOnce(["1.json"] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >); // oldDir contents
+
+      const now = Date.now();
+      const thirtyOneDaysAgo = now - 31 * 24 * 60 * 60 * 1000;
+
+      vi.mocked(fs.stat).mockImplementation(async (path: unknown) => {
+        const pathStr = String(path);
+        if (pathStr.endsWith(oldDir)) {
+          return {
+            isDirectory: () => true,
+            mtimeMs: thirtyOneDaysAgo,
+          } as unknown as Awaited<ReturnType<typeof fs.stat>>;
+        }
+        if (pathStr.endsWith(currentDir)) {
+          return {
+            isDirectory: () => true,
+            mtimeMs: now,
+          } as unknown as Awaited<ReturnType<typeof fs.stat>>;
+        }
+        if (pathStr.endsWith(otherFile)) {
+          return {
+            isDirectory: () => false,
+            mtimeMs: now,
+          } as unknown as Awaited<ReturnType<typeof fs.stat>>;
+        }
+        if (pathStr.endsWith("1.json")) {
+          return {
+            isDirectory: () => false,
+            mtimeMs: thirtyOneDaysAgo,
+          } as unknown as Awaited<ReturnType<typeof fs.stat>>;
+        }
+        return {
+          isDirectory: () => false,
+          mtimeMs: now,
+        } as unknown as Awaited<ReturnType<typeof fs.stat>>;
+      });
+
+      vi.mocked(fs.rm).mockResolvedValue(undefined);
+
+      await taskManager.cleanupOldTaskLists(30);
+
+      expect(fs.rm).toHaveBeenCalledWith(expect.stringContaining(oldDir), {
+        recursive: true,
+        force: true,
+      });
+      expect(fs.rm).not.toHaveBeenCalledWith(
+        expect.stringContaining(currentDir),
+        expect.anything(),
+      );
     });
   });
 });

--- a/packages/agent-sdk/tests/tools/taskManagementTools.test.ts
+++ b/packages/agent-sdk/tests/tools/taskManagementTools.test.ts
@@ -18,6 +18,8 @@ vi.mock("../../src/services/taskManager.js", () => {
   TaskManager.prototype.getTask = vi.fn();
   TaskManager.prototype.updateTask = vi.fn();
   TaskManager.prototype.listTasks = vi.fn();
+  TaskManager.prototype.deleteTask = vi.fn();
+  TaskManager.prototype.getTaskPath = vi.fn(() => "/mock/path");
   return { TaskManager };
 });
 
@@ -116,6 +118,20 @@ describe("Task Management Tools", () => {
         workdir: "/test/workdir",
       } as ToolContext);
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe("TaskCreate tool - skip deleted", () => {
+    it("should skip task creation if status is deleted", async () => {
+      const args = {
+        subject: "Deleted Task",
+        description: "Should not be created",
+        status: "deleted",
+      };
+      const result = await taskCreateTool.execute(args, context);
+      expect(mockTaskManager.createTask).not.toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      expect(result.content).toContain("Task creation skipped");
     });
   });
 
@@ -410,6 +426,68 @@ describe("Task Management Tools", () => {
           metadata: { key1: "newVal", key3: "val3" },
         }),
       );
+    });
+  });
+
+  describe("TaskUpdate tool - physical deletion", () => {
+    it("should physically delete task and cleanup reciprocal dependencies", async () => {
+      const task1: Task = {
+        id: "1",
+        subject: "Task 1",
+        description: "",
+        status: "pending",
+        blocks: ["2"],
+        blockedBy: ["3"],
+        metadata: {},
+      };
+      const task2: Task = {
+        id: "2",
+        subject: "Task 2",
+        description: "",
+        status: "pending",
+        blocks: [],
+        blockedBy: ["1"],
+        metadata: {},
+      };
+      const task3: Task = {
+        id: "3",
+        subject: "Task 3",
+        description: "",
+        status: "pending",
+        blocks: ["1"],
+        blockedBy: [],
+        metadata: {},
+      };
+
+      mockTaskManager.getTask.mockImplementation(async (id) => {
+        if (id === "1") return task1;
+        if (id === "2") return task2;
+        if (id === "3") return task3;
+        return null;
+      });
+
+      const result = await taskUpdateTool.execute(
+        { taskId: "1", status: "deleted" },
+        context,
+      );
+
+      expect(mockTaskManager.deleteTask).toHaveBeenCalledWith("1");
+      // Check reciprocal cleanup for task 2 (which was blocked by 1)
+      expect(mockTaskManager.updateTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "2",
+          blockedBy: [],
+        }),
+      );
+      // Check reciprocal cleanup for task 3 (which blocked 1)
+      expect(mockTaskManager.updateTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "3",
+          blocks: [],
+        }),
+      );
+      expect(result.success).toBe(true);
+      expect(result.content).toContain("deleted and removed from disk");
     });
   });
 });


### PR DESCRIPTION
This PR implements physical task deletion and stale task list cleanup.

- Added deleteTask and cleanupOldTaskLists to TaskManager service.
- Updated taskUpdateTool to physically remove task files and perform reciprocal dependency cleanup when status is set to deleted.
- Integrated automatic cleanup of task list directories older than 30 days during agent startup.
- Added unit and integration tests for the new functionality.
- Updated existing agent tests to mock the new cleanup method.