### PR TITLE
feat: unique message IDs and MessageList improvements

### DIFF
--- a/packages/agent-sdk/src/managers/messageManager.ts
+++ b/packages/agent-sdk/src/managers/messageManager.ts
@@ -9,6 +9,7 @@ import {
   removeLastUserMessage,
   UserMessageParams,
   type AgentToolBlockUpdateParams,
+  generateMessageId,
 } from "../utils/messageOperations.js";
 import type { Message, Usage, SlashCommand } from "../types/index.js";
 import { join } from "path";
@@ -422,6 +423,7 @@ export class MessageManager {
 
     // Create compressed message
     const compressMessage: Message = {
+      id: generateMessageId(),
       role: "assistant",
       blocks: [
         {

--- a/packages/agent-sdk/src/utils/messageOperations.ts
+++ b/packages/agent-sdk/src/utils/messageOperations.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import type { Message, Usage } from "../types/index.js";
 import { MessageSource } from "../types/index.js";
 import { readFileSync } from "fs";
@@ -113,6 +114,8 @@ export const convertImageToBase64 = (imagePath: string): string => {
   }
 };
 
+export const generateMessageId = (): string => `msg-${randomUUID()}`;
+
 // Add user message
 export const addUserMessageToMessages = ({
   messages,
@@ -142,7 +145,7 @@ export const addUserMessageToMessages = ({
   }
 
   const userMessage: Message = {
-    id: `msg-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+    id: generateMessageId(),
     role: "user",
     blocks,
   };
@@ -179,7 +182,7 @@ export const addAssistantMessageToMessages = (
   }
 
   const initialAssistantMessage: Message = {
-    id: `msg-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+    id: generateMessageId(),
     role: "assistant",
     blocks,
     usage, // Include usage data if provided
@@ -283,6 +286,7 @@ export const addErrorBlockToMessage = ({
   } else {
     // If the last message is not an assistant message, create a new assistant message
     newMessages.push({
+      id: generateMessageId(),
       role: "assistant",
       blocks: [
         {
@@ -302,6 +306,7 @@ export const addBangMessage = ({
   command,
 }: AddBangParams): Message[] => {
   const outputMessage: Message = {
+    id: generateMessageId(),
     role: "user",
     blocks: [
       {

--- a/packages/code/src/components/MessageList.tsx
+++ b/packages/code/src/components/MessageList.tsx
@@ -54,7 +54,7 @@ export const MessageList = React.memo(
         message,
         isLastMessage: messageIndex === messages.length - 1,
         // Unique key for each block to help Static component
-        key: `${message.id || messageIndex}-${blockIndex}`,
+        key: `${message.id}-${blockIndex}`,
       }));
     });
 

--- a/packages/code/tests/components/MessageList.basic.test.tsx
+++ b/packages/code/tests/components/MessageList.basic.test.tsx
@@ -29,6 +29,7 @@ describe("MessageList Component", () => {
     content: string,
     id: number,
   ): Message => ({
+    id: `msg-${id}`,
     role,
     blocks: [
       {
@@ -107,6 +108,7 @@ describe("MessageList Component", () => {
     it("should render error blocks", () => {
       const messages: Message[] = [
         {
+          id: "msg-error",
           role: "assistant",
           blocks: [{ type: "error", content: "Something went wrong" }],
         },
@@ -137,6 +139,7 @@ describe("MessageList Component", () => {
       // Create a message with single image block
       const messagesWithImage: Message[] = [
         {
+          id: "msg-image-1",
           role: "user",
           blocks: [
             { type: "text", content: "Look at this image" },
@@ -163,6 +166,7 @@ describe("MessageList Component", () => {
       // Create a message with multiple image blocks
       const messagesWithImages: Message[] = [
         {
+          id: "msg-image-2",
           role: "user",
           blocks: [
             {
@@ -187,6 +191,7 @@ describe("MessageList Component", () => {
       // Create a message with image block but no imageUrls
       const messagesWithEmptyImage: Message[] = [
         {
+          id: "msg-image-empty",
           role: "user",
           blocks: [
             {
@@ -211,6 +216,7 @@ describe("MessageList Component", () => {
       // Create a message with only image, no text
       const imageOnlyMessage: Message[] = [
         {
+          id: "msg-image-only",
           role: "user",
           blocks: [
             {
@@ -236,6 +242,7 @@ describe("MessageList Component", () => {
     it("should display reasoning block correctly", () => {
       const messagesWithReasoning: Message[] = [
         {
+          id: "msg-reasoning",
           role: "assistant",
           blocks: [
             {
@@ -268,6 +275,7 @@ describe("MessageList Component", () => {
     it("should not display empty reasoning blocks", () => {
       const messagesWithEmptyReasoning: Message[] = [
         {
+          id: "msg-empty-reasoning",
           role: "assistant",
           blocks: [
             {

--- a/packages/code/tests/components/MessageList.expanded-limit.test.tsx
+++ b/packages/code/tests/components/MessageList.expanded-limit.test.tsx
@@ -29,6 +29,7 @@ describe("MessageList Component - Expanded Mode Limit", () => {
     content: string,
     id: number,
   ): Message => ({
+    id: `msg-${id}`,
     role,
     blocks: [
       {

--- a/packages/code/tests/components/MessageList.loading.test.tsx
+++ b/packages/code/tests/components/MessageList.loading.test.tsx
@@ -18,6 +18,7 @@ const createMessage = (
   role: "user" | "assistant",
   content: string,
 ): Message => ({
+  id: `msg-${Math.random()}`,
   role,
   blocks: [{ type: "text", content }],
 });

--- a/packages/code/tests/components/MessageList.static.test.tsx
+++ b/packages/code/tests/components/MessageList.static.test.tsx
@@ -29,6 +29,7 @@ describe("MessageList Static Rendering", () => {
     content: string,
     id: number,
   ): Message => ({
+    id: `msg-${id}`,
     role,
     blocks: [
       {
@@ -228,6 +229,7 @@ describe("MessageList Static Rendering", () => {
 
     it("should handle complex message types with mixed blocks", () => {
       const createComplexMessage = (id: number): Message => ({
+        id: `msg-${id}`,
         role: "assistant",
         blocks: [
           { type: "text", content: `Solution ${id}` },

--- a/packages/code/tests/components/MessageList.test.tsx
+++ b/packages/code/tests/components/MessageList.test.tsx
@@ -29,6 +29,7 @@ describe("MessageList Component", () => {
     content: string,
     id: number,
   ): Message => ({
+    id: `msg-${id}`,
     role,
     blocks: [
       {


### PR DESCRIPTION
This PR introduces unique message IDs and improves the MessageList component.

Changes:
- feat(agent-sdk): generate unique message IDs for all messages
- feat(code): use unique message IDs for Static component keys and increase message limit to 20 when expanded