### PR TITLE
docs: clarify subagent usage of Task tool in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,5 +41,5 @@ Always use `pnpm` as the package manager.
 
 ## 🤖 Subagent Usage
 
-- **Subagent Usage**: Use specialized agents (typescript-expert, vitest-expert, Explore) for focused tasks (exploration, development, or testing) to reduce context usage.
+- **Subagent Usage**: If you have the `Task` tool, use specialized agents (typescript-expert, vitest-expert, Explore) for focused tasks (exploration, development, or testing) to reduce context usage. Note that subagents typically do not have access to the `Task` tool.
 


### PR DESCRIPTION
This PR updates AGENTS.md to clarify that subagents should be used for focused tasks when the Task tool is available, and notes that subagents typically do not have access to the Task tool.