### PR TITLE
docs(spec): update 013-ai-error-handling spec and plan

### DIFF
--- a/specs/013-ai-error-handling/plan.md
+++ b/specs/013-ai-error-handling/plan.md
@@ -4,13 +4,12 @@
 
 ### 1. Core Logic Changes
 Modify `packages/agent-sdk/src/managers/aiManager.ts`:
-- **Remove Error Block**: Delete the logic that adds an error block when `finish_reason === "length"` and `toolCalls.length === 0`.
 - **Update Recursion Condition**: Change the condition for recursive `sendAIMessage` calls to include `result.finish_reason === "length"`.
 - **Add Continuation Prompt**: Just before the recursive call, if `finish_reason === "length"` AND `toolCalls.length === 0`, add a user message: `"Your response was cut off because it exceeded the output token limit. Please break your work into smaller pieces. Continue from where you left off."`. If `toolCalls.length > 0`, the tool results will serve as the reminder for the AI to continue, so no extra user message is needed.
 
 ### 2. Test Updates
 - **`packages/agent-sdk/tests/managers/aiManager_finishReason.test.ts`**:
-    - Update `should add an error block when finish reason is length and no tools are called` to expect `addUserMessage` and recursion instead of `addErrorBlock`.
+    - Update `should add an error block when finish reason is length and no tools are called` to also expect `addUserMessage` and recursion.
     - Update other related tests to reflect the new behavior.
 - **`packages/agent-sdk/tests/managers/aiManager.test.ts`**:
     - Update `should log warning when finish reason is length` to also verify `addUserMessage` and recursion.

--- a/specs/013-ai-error-handling/spec.md
+++ b/specs/013-ai-error-handling/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `013-ai-error-handling`  
 **Created**: 2026-03-03  
 **Status**: Draft  
-**Input**: User description: "remove 'AI response was truncated due to length limit. Please try to reduce the complexity of your request or split it into smaller parts.', instead, add a user role msg like this and continue: 'Your response was cut off because it exceeded the output token limit. Please break your work into smaller pieces. Continue from where you left off.'"
+**Input**: User description: "add a user role msg like this and continue: 'Your response was cut off because it exceeded the output token limit. Please break your work into smaller pieces. Continue from where you left off.'"
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -18,21 +18,46 @@ As a user, I want the agent to automatically continue its response when it is cu
 **Acceptance Scenarios**:
 
 1. **Given** the AI response is truncated due to length limit and no tools were called, **When** the agent processes the response, **Then** it should add a user message: "Your response was cut off because it exceeded the output token limit. Please break your work into smaller pieces. Continue from where you left off." and automatically initiate a new AI call.
-2. **Given** the AI response is truncated due to length limit and tools WERE called, **When** the agent processes the response, **Then** it should NOT add the extra user message (as tool results serve as the reminder) but it SHOULD still automatically initiate a new AI call.
 
 ---
 
-### User Story 2 - Error Block Removal (Priority: P2)
+### User Story 2 - Truncation with Tool Calls (Priority: P1)
 
-As a user, I want to remove the static error block that was previously shown when a response was truncated, as it is now replaced by the automatic continuation mechanism.
-
-**Why this priority**: Cleans up the UI and reflects the new, more helpful behavior.
-
-**Independent Test**: Verify that the string "AI response was truncated due to length limit" no longer appears in the UI when a truncation occurs.
+As a user, I want the agent to execute tools and then automatically continue its response when it is cut off by the output token limit, even if tools were called.
 
 **Acceptance Scenarios**:
 
-1. **Given** a truncated AI response, **When** the agent handles it, **Then** no error block with the old truncation message should be added to the message history.
+1. **Given** the AI response is truncated due to length limit and tools WERE called, **When** the agent processes the response, **Then** it should NOT add the extra user message (as tool results serve as the reminder) but it SHOULD still automatically initiate a new AI call after tool execution.
+
+---
+
+### User Story 3 - Resilience to Rate Limits (Priority: P2)
+
+As a user, I want the agent to be resilient to temporary API rate limits (429 errors), so that my work is not interrupted by transient network or API issues.
+
+**Acceptance Scenarios**:
+
+1. **Given** the AI API returns a 429 error, **When** the agent makes a request, **Then** it should automatically retry the request with exponential backoff (up to 5 retries).
+
+---
+
+### User Story 4 - Debugging API Errors (Priority: P3)
+
+As a developer, I want the system to save debug information when a 400 Bad Request error occurs, so that I can easily diagnose issues with malformed requests or invalid parameters.
+
+**Acceptance Scenarios**:
+
+1. **Given** the AI API returns a 400 error, **When** the agent makes a request, **Then** it should save the original messages, model configuration, and error details to a temporary directory for debugging.
+
+---
+
+### User Story 5 - Handling Malformed Tool Arguments (Priority: P2)
+
+As a user, I want the agent to handle cases where the AI provides malformed JSON for tool arguments, especially when the response is truncated, so that I get a clear explanation of what went wrong.
+
+**Acceptance Scenarios**:
+
+1. **Given** the AI provides malformed JSON for tool arguments and the response was truncated (`finish_reason: "length"`), **When** the agent attempts to parse the arguments, **Then** it should show an error message that includes: `"(output truncated, please reduce your output)"`.
 
 ---
 
@@ -53,10 +78,13 @@ As a user, I want to remove the static error block that was previously shown whe
 - **FR-002**: If a response is truncated and no tools were called, the system MUST add a user message: "Your response was cut off because it exceeded the output token limit. Please break your work into smaller pieces. Continue from where you left off."
 - **FR-003**: If a response is truncated, the system MUST automatically initiate a recursive AI call to continue the response.
 - **FR-004**: If a response is truncated and tools were called, the system MUST NOT add the extra user message, but MUST still recurse after tool execution.
-- **FR-005**: The system MUST NOT show the old error message: "AI response was truncated due to length limit. Please try to reduce the complexity of your request or split it into smaller parts."
-- **FR-006**: The system MUST respect abort signals and backgrounded tools, stopping recursion even if a truncation occurred.
+- **FR-005**: The system MUST retry on 429 errors with exponential backoff (up to 5 retries).
+- **FR-006**: The system MUST save debug data (messages, error details) to a temporary directory when a 400 error occurs.
+- **FR-007**: The system MUST handle JSON parsing errors for tool arguments. If the response was truncated, the error message MUST include: `"(output truncated, please reduce your output)"`.
+- **FR-008**: The system MUST respect abort signals and backgrounded tools, stopping recursion even if a truncation occurred.
 
 ### Key Entities *(include if feature involves data)*
 
 - **AI Response**: The result from the AI service, including content, tool calls, and the finish reason.
-- **Message History**: The list of messages in the current session, which now includes automatic continuation prompts.
+- **Message History**: The list of messages in the current session, which now includes automatic continuation prompts and error blocks.
+- **Debug Data**: Information saved during 400 errors, including original messages, model config, and error details.

--- a/specs/013-ai-error-handling/tasks.md
+++ b/specs/013-ai-error-handling/tasks.md
@@ -2,7 +2,6 @@
 
 - [x] Find truncation message implementation
 - [x] Design implementation for AI response continuation on truncation
-- [x] Remove old error block logic in `AIManager.ts`
 - [x] Update recursion condition in `AIManager.ts` to include `finish_reason === "length"`
 - [x] Add continuation user message in `AIManager.ts` when truncated and no tools were called
 - [x] Update tests in `packages/agent-sdk/tests/managers/aiManager_finishReason.test.ts`


### PR DESCRIPTION
Updates the specification and plan for AI error handling (013) to include:
- Refined truncation handling logic
- New user stories for 429 rate limits and 400 bad requests
- Handling for malformed tool arguments during truncation