### PR TITLE
Merge component rules into cli.md and add .tsx extension support rule for Grep tool

### DIFF
--- a/.wave/rules/cli.md
+++ b/.wave/rules/cli.md
@@ -1,0 +1,10 @@
+---
+paths:
+  - "packages/code/**/*"
+---
+# CLI & Component Rules
+
+- Use the `Grep` tool for searching. It supports the `.tsx` extension as part of the `ts` (TypeScript) file type.
+- When searching for `.tsx` files, use the `type: "ts"` parameter.
+- `packages/code/src/components` contains Ink components.
+- Do not use side borders (left and right) in components. Use only top and bottom borders if borders are needed.

--- a/.wave/rules/components.md
+++ b/.wave/rules/components.md
@@ -1,6 +1,0 @@
----
-paths:
-  - "packages/code/src/components/**/*"
----
-- `packages/code/src/components` contains Ink components
-- Do not use side borders (left and right) in components. Use only top and bottom borders if borders are needed.


### PR DESCRIPTION
This PR merges the component rules from .wave/rules/components.md into .wave/rules/cli.md and adds a rule for .tsx extension support in the Grep tool.