### PR TITLE
refactor: replace hideDynamicBlocks with forceStatic in MessageList

### DIFF
--- a/packages/code/src/components/ChatInterface.tsx
+++ b/packages/code/src/components/ChatInterface.tsx
@@ -95,7 +95,7 @@ export const ChatInterface: React.FC = () => {
       <MessageList
         messages={messages}
         isExpanded={isExpanded}
-        hideDynamicBlocks={isConfirmationVisible}
+        forceStatic={isConfirmationVisible && isConfirmationTooTall}
         version={version}
         workdir={workdir}
         model={model}

--- a/packages/code/src/components/MessageList.tsx
+++ b/packages/code/src/components/MessageList.tsx
@@ -7,7 +7,7 @@ import { MessageBlockItem } from "./MessageBlockItem.js";
 export interface MessageListProps {
   messages: Message[];
   isExpanded?: boolean;
-  hideDynamicBlocks?: boolean;
+  forceStatic?: boolean;
   version?: string;
   workdir?: string;
   model?: string;
@@ -17,7 +17,7 @@ export const MessageList = React.memo(
   ({
     messages,
     isExpanded = false,
-    hideDynamicBlocks = false,
+    forceStatic = false,
     version,
     workdir,
     model,
@@ -62,6 +62,7 @@ export const MessageList = React.memo(
     const blocksWithStatus = allBlocks.map((item) => {
       const { block, isLastMessage } = item;
       const isDynamic =
+        !forceStatic &&
         isLastMessage &&
         ((block.type === "tool" && block.stage !== "end") ||
           (block.type === "bang" && block.isRunning));
@@ -69,9 +70,7 @@ export const MessageList = React.memo(
     });
 
     const staticBlocks = blocksWithStatus.filter((b) => !b.isDynamic);
-    const dynamicBlocks = hideDynamicBlocks
-      ? []
-      : blocksWithStatus.filter((b) => b.isDynamic);
+    const dynamicBlocks = blocksWithStatus.filter((b) => b.isDynamic);
 
     const staticItems = [
       { isWelcome: true, key: "welcome", block: undefined, message: undefined },

--- a/packages/code/tests/components/MessageList.test.tsx
+++ b/packages/code/tests/components/MessageList.test.tsx
@@ -176,4 +176,54 @@ describe("MessageList Component", () => {
       expect(output).toContain("Third - Message 3");
     });
   });
+
+  describe("forceStatic prop", () => {
+    it("should render dynamic blocks even when forceStatic is true", () => {
+      const messages: Message[] = [
+        {
+          id: "msg-1",
+          role: "assistant",
+          blocks: [
+            {
+              type: "tool",
+              name: "test-tool",
+              parameters: "{}",
+              stage: "running",
+            },
+          ],
+        },
+      ];
+
+      const { lastFrame } = render(
+        <MessageList messages={messages} forceStatic={true} />,
+      );
+
+      const output = lastFrame();
+      expect(output).toContain("test-tool");
+    });
+
+    it("should render dynamic blocks when forceStatic is false", () => {
+      const messages: Message[] = [
+        {
+          id: "msg-1",
+          role: "assistant",
+          blocks: [
+            {
+              type: "tool",
+              name: "test-tool",
+              parameters: "{}",
+              stage: "running",
+            },
+          ],
+        },
+      ];
+
+      const { lastFrame } = render(
+        <MessageList messages={messages} forceStatic={false} />,
+      );
+
+      const output = lastFrame();
+      expect(output).toContain("test-tool");
+    });
+  });
 });


### PR DESCRIPTION
This PR replaces hideDynamicBlocks with forceStatic in MessageList to ensure tool calls remain visible during confirmation. It also updates ChatInterface to use forceStatic when confirmation is too tall.