### PR TITLE
feat: restrict bash write operations via redirections

### DIFF
--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -20,6 +20,7 @@ import {
   splitBashCommand,
   stripEnvVars,
   stripRedirections,
+  hasWriteRedirections,
   getSmartPrefix,
   DANGEROUS_COMMANDS,
 } from "../utils/bashParser.js";
@@ -464,6 +465,9 @@ export class PermissionManager {
       const parts = splitBashCommand(command);
 
       const isDangerous = parts.some((part) => {
+        if (hasWriteRedirections(part)) {
+          return true;
+        }
         const processedPart = stripRedirections(stripEnvVars(part));
         const commandMatch = processedPart.match(/^(\w+)(\s+.*)?$/);
         if (commandMatch) {
@@ -523,7 +527,17 @@ export class PermissionManager {
     // Handle Bash command rules
     if (toolName === BASH_TOOL_NAME) {
       const command = String(context.toolInput?.command || "");
-      const processedPart = stripRedirections(stripEnvVars(command));
+      const hasWriteInPattern = hasWriteRedirections(pattern);
+      const hasWriteInCommand = hasWriteRedirections(command);
+
+      // If the command has write redirections, it must match a pattern that also has write redirections
+      if (hasWriteInCommand && !hasWriteInPattern) {
+        return false;
+      }
+
+      const processedPart = hasWriteInPattern
+        ? stripEnvVars(command)
+        : stripRedirections(stripEnvVars(command));
       // For Bash commands, we want '*' to match everything including slashes and spaces
       // minimatch's default behavior for '*' is to not match across directory separators
       // We use a regex to replace '*' with '.*' (match anything)
@@ -561,6 +575,7 @@ export class PermissionManager {
     const isAllowedByRuleList = (
       ctx: ToolPermissionContext,
       rules: string[],
+      isDefaultRules: boolean = false,
     ) => {
       if (ctx.toolName === BASH_TOOL_NAME && ctx.toolInput?.command) {
         const command = String(ctx.toolInput.command);
@@ -570,53 +585,60 @@ export class PermissionManager {
         const workdir = ctx.toolInput?.workdir as string | undefined;
 
         return parts.every((part) => {
+          const hasWrite = hasWriteRedirections(part);
           const processedPart = stripRedirections(stripEnvVars(part));
 
           // Check for safe commands
-          const commandMatch = processedPart.match(/^(\w+)(\s+.*)?$/);
-          if (commandMatch) {
-            const cmd = commandMatch[1];
-            const args = commandMatch[2]?.trim() || "";
+          if (!hasWrite) {
+            const commandMatch = processedPart.match(/^(\w+)(\s+.*)?$/);
+            if (commandMatch) {
+              const cmd = commandMatch[1];
+              const args = commandMatch[2]?.trim() || "";
 
-            if (SAFE_COMMANDS.includes(cmd)) {
-              if (cmd === "pwd" || cmd === "true" || cmd === "false") {
-                return true;
-              }
-
-              if (workdir) {
-                // For cd and ls, check paths
-                const pathArgs =
-                  (args.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || []).filter(
-                    (arg) => !arg.startsWith("-"),
-                  ) || [];
-
-                if (pathArgs.length === 0) {
-                  // cd or ls without arguments operates on current dir (workdir)
+              if (SAFE_COMMANDS.includes(cmd)) {
+                if (cmd === "pwd" || cmd === "true" || cmd === "false") {
                   return true;
                 }
 
-                const allPathsSafe = pathArgs.every((pathArg) => {
-                  // Remove quotes if present
-                  const cleanPath = pathArg.replace(/^['"](.*)['"]$/, "$1");
-                  const { isInside } = this.isInsideSafeZone(
-                    cleanPath,
-                    workdir,
-                  );
-                  return isInside;
-                });
+                if (workdir) {
+                  // For cd and ls, check paths
+                  const pathArgs =
+                    (args.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || []).filter(
+                      (arg) => !arg.startsWith("-"),
+                    ) || [];
 
-                if (allPathsSafe) {
-                  return true;
+                  if (pathArgs.length === 0) {
+                    // cd or ls without arguments operates on current dir (workdir)
+                    return true;
+                  }
+
+                  const allPathsSafe = pathArgs.every((pathArg) => {
+                    // Remove quotes if present
+                    const cleanPath = pathArg.replace(/^['"](.*)['"]$/, "$1");
+                    const { isInside } = this.isInsideSafeZone(
+                      cleanPath,
+                      workdir,
+                    );
+                    return isInside;
+                  });
+
+                  if (allPathsSafe) {
+                    return true;
+                  }
                 }
               }
             }
           }
 
           // Check if this specific part is allowed by any rule
+          if (hasWrite && isDefaultRules) {
+            return false;
+          }
+
           // We create a temporary context with just this part of the command
           const partContext = {
             ...ctx,
-            toolInput: { ...ctx.toolInput, command: processedPart },
+            toolInput: { ...ctx.toolInput, command: part },
           };
           const allowedByRule = rules.some((rule) => {
             return this.matchesRule(partContext, rule);
@@ -643,7 +665,7 @@ export class PermissionManager {
     }
 
     // Check default allowed rules
-    return isAllowedByRuleList(context, DEFAULT_ALLOWED_RULES);
+    return isAllowedByRuleList(context, DEFAULT_ALLOWED_RULES, true);
   }
 
   /**
@@ -659,13 +681,14 @@ export class PermissionManager {
     const rules: string[] = [];
 
     for (const part of parts) {
+      const hasWrite = hasWriteRedirections(part);
       const processedPart = stripRedirections(stripEnvVars(part));
 
       // Check for safe commands
       const commandMatch = processedPart.match(/^(\w+)(\s+.*)?$/);
       let isSafe = false;
 
-      if (commandMatch) {
+      if (commandMatch && !hasWrite) {
         const cmd = commandMatch[1];
         const args = commandMatch[2]?.trim() || "";
 
@@ -724,11 +747,11 @@ export class PermissionManager {
           }
         }
 
-        const smartPrefix = getSmartPrefix(processedPart);
+        const smartPrefix = hasWrite ? null : getSmartPrefix(processedPart);
         if (smartPrefix) {
           rules.push(`Bash(${smartPrefix}*)`);
         } else {
-          rules.push(`Bash(${processedPart})`);
+          rules.push(`Bash(${hasWrite ? stripEnvVars(part) : processedPart})`);
         }
       }
     }

--- a/packages/agent-sdk/src/utils/bashParser.ts
+++ b/packages/agent-sdk/src/utils/bashParser.ts
@@ -100,8 +100,13 @@ export function splitBashCommand(command: string): string[] {
 
   const finalResult: string[] = [];
   for (const part of parts) {
-    const stripped = stripRedirections(stripEnvVars(part));
-    if (stripped.startsWith("(") && stripped.endsWith(")")) {
+    const envStripped = stripEnvVars(part);
+    const stripped = stripRedirections(envStripped);
+    if (
+      stripped.startsWith("(") &&
+      stripped.endsWith(")") &&
+      stripped === envStripped
+    ) {
       const inner = stripped.substring(1, stripped.length - 1).trim();
       if (inner) {
         finalResult.push(...splitBashCommand(inner));
@@ -284,6 +289,49 @@ export function stripRedirections(command: string): string {
   }
 
   return result.trim();
+}
+
+/**
+ * Checks if a bash command contains any write redirections (>, >>, &>, 2>, >|).
+ */
+export function hasWriteRedirections(command: string): boolean {
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+  let escaped = false;
+
+  for (let i = 0; i < command.length; i++) {
+    const char = command[i];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+
+    if (char === "'" && !inDoubleQuote) {
+      inSingleQuote = !inSingleQuote;
+      continue;
+    }
+
+    if (char === '"' && !inSingleQuote) {
+      inDoubleQuote = !inDoubleQuote;
+      continue;
+    }
+
+    if (inSingleQuote || inDoubleQuote) {
+      continue;
+    }
+
+    if (char === ">") {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**

--- a/packages/agent-sdk/tests/managers/permissionManager.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.test.ts
@@ -1115,14 +1115,14 @@ describe("PermissionManager", () => {
       expect(result.behavior).toBe("deny");
     });
 
-    it("should strip env vars and redirections before checking rules", async () => {
+    it("should strip env vars and read redirections before checking rules", async () => {
       permissionManager.updateAllowedRules(["Bash(ls)", "Bash(echo hello)"]);
 
       const context: ToolPermissionContext = {
         toolName: "Bash",
         permissionMode: "default",
         toolInput: {
-          command: "VAR=val ls > out.txt && echo hello 2> /dev/null",
+          command: "VAR=val ls < in.txt && echo hello",
         },
       };
 
@@ -1330,10 +1330,10 @@ describe("PermissionManager", () => {
       expect(rules).toEqual(["Bash(mkdir test)"]);
     });
 
-    it("should strip env vars and redirections from rules", () => {
+    it("should strip env vars and preserve redirections in rules", () => {
       const command = "VAR=val npm install > out.txt";
       const rules = permissionManager.expandBashRule(command, workdir);
-      expect(rules).toEqual(["Bash(npm install*)"]);
+      expect(rules).toEqual(["Bash(npm install > out.txt)"]);
     });
 
     it("should identify unsafe paths in cd/ls as non-safe and filter them out", () => {
@@ -1377,6 +1377,75 @@ describe("PermissionManager", () => {
       const command = "npm install lodash";
       const rules = permissionManager.expandBashRule(command, workdir);
       expect(rules).toEqual(["Bash(npm install*)"]);
+    });
+  });
+
+  describe("Bash Write Redirections", () => {
+    const workdir = "/home/user/project";
+
+    it("should NOT allow echo with write redirection by default (even if echo* is allowed)", async () => {
+      const context: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command: "echo hi > file.txt", workdir },
+      };
+
+      const result = await permissionManager.checkPermission(context);
+      expect(result.behavior).toBe("deny");
+    });
+
+    it("should set hidePersistentOption for commands with write redirections", () => {
+      const context = permissionManager.createContext(
+        "Bash",
+        "default",
+        undefined,
+        { command: "echo hi > file.txt", workdir },
+      );
+
+      expect(context.hidePersistentOption).toBe(true);
+    });
+
+    it("should NOT treat ls with write redirection as a safe command", async () => {
+      const context: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command: "ls > file.txt", workdir },
+      };
+
+      const result = await permissionManager.checkPermission(context);
+      expect(result.behavior).toBe("deny");
+    });
+
+    it("should allow write redirection if explicitly allowed by a rule with redirection", async () => {
+      permissionManager.updateAllowedRules(["Bash(echo * > *)"]);
+
+      const context: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command: "echo hi > file.txt", workdir },
+      };
+
+      const result = await permissionManager.checkPermission(context);
+      expect(result.behavior).toBe("allow");
+    });
+
+    it("should NOT allow write redirection if rule does NOT have redirection", async () => {
+      permissionManager.updateAllowedRules(["Bash(echo *)"]);
+
+      const context: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command: "echo hi > file.txt", workdir },
+      };
+
+      const result = await permissionManager.checkPermission(context);
+      expect(result.behavior).toBe("deny");
+    });
+
+    it("should preserve redirection in expandBashRule", () => {
+      const command = "echo hi > file.txt";
+      const rules = permissionManager.expandBashRule(command, workdir);
+      expect(rules).toEqual(["Bash(echo hi > file.txt)"]);
     });
   });
 });

--- a/packages/agent-sdk/tests/utils/bashParser.test.ts
+++ b/packages/agent-sdk/tests/utils/bashParser.test.ts
@@ -3,6 +3,7 @@ import {
   splitBashCommand,
   stripEnvVars,
   stripRedirections,
+  hasWriteRedirections,
 } from "../../src/utils/bashParser.js";
 
 describe("bashParser", () => {
@@ -44,10 +45,12 @@ describe("bashParser", () => {
     });
 
     it("should handle subshells with redirections and env vars", () => {
-      expect(splitBashCommand("(echo foo) > out.txt")).toEqual(["echo foo"]);
+      expect(splitBashCommand("(echo foo) > out.txt")).toEqual([
+        "(echo foo) > out.txt",
+      ]);
       expect(
         splitBashCommand("VAR=val (echo foo && echo bar) > out.txt"),
-      ).toEqual(["echo foo", "echo bar"]);
+      ).toEqual(["VAR=val (echo foo && echo bar) > out.txt"]);
     });
 
     it("should handle complex combinations", () => {
@@ -121,6 +124,41 @@ describe("bashParser", () => {
       expect(stripRedirections('echo  "a  b"')).toBe('echo "a  b"');
       expect(stripRedirections("ls    -l")).toBe("ls -l");
       expect(stripRedirections("ls > out.txt  -l")).toBe("ls -l");
+    });
+  });
+
+  describe("hasWriteRedirections", () => {
+    it("should detect simple write redirections", () => {
+      expect(hasWriteRedirections("echo hi > file")).toBe(true);
+      expect(hasWriteRedirections("echo hi >> file")).toBe(true);
+      expect(hasWriteRedirections("ls > file")).toBe(true);
+    });
+
+    it("should detect write redirections with file descriptors", () => {
+      expect(hasWriteRedirections("ls 2> file")).toBe(true);
+      expect(hasWriteRedirections("ls &> file")).toBe(true);
+      expect(hasWriteRedirections("ls >| file")).toBe(true);
+      expect(hasWriteRedirections("ls 2>&1")).toBe(true);
+    });
+
+    it("should NOT detect read redirections", () => {
+      expect(hasWriteRedirections("cat < file")).toBe(false);
+      expect(hasWriteRedirections("cat <<EOF")).toBe(false);
+    });
+
+    it("should NOT detect quoted or escaped redirections", () => {
+      expect(hasWriteRedirections('echo "hi > file"')).toBe(false);
+      expect(hasWriteRedirections("echo 'hi > file'")).toBe(false);
+      expect(hasWriteRedirections("echo hi \\> file")).toBe(false);
+    });
+
+    it("should handle complex commands", () => {
+      expect(hasWriteRedirections("ls && echo hi > file")).toBe(true);
+      expect(hasWriteRedirections("ls > file && echo hi")).toBe(true);
+    });
+
+    it("should detect write redirections on subshells", () => {
+      expect(hasWriteRedirections("(echo hi) > file")).toBe(true);
     });
   });
 });

--- a/specs/036-split-bash-commands/spec.md
+++ b/specs/036-split-bash-commands/spec.md
@@ -5,7 +5,7 @@
 **Status**: Implemented  
 **Input**: User description: "when confirm bash tool with \"cmd1 && cmd2\" or other chain cmd, and user select don't ask, system shall split into multi simple cmds and save to permissions.allow array. if the sample cmd is builtin safe cmd(already implemented) like cd, do not save to permissions.allow array."
 
-## User Scenarios & Testing *(mandatory)*
+## User Scenarios & Testing _(mandatory)_
 
 ### User Story 1 - Allow Chained Commands with Safe Builtins (Priority: P1)
 
@@ -54,10 +54,11 @@ As a user, when I run a chain consisting only of safe commands, I want the syste
 ### Edge Cases
 
 - **What happens when a command has environment variables?** The system should strip environment variables before checking if it's a safe command, but should probably save the original command (or the stripped version depending on existing policy) to the allow list.
-- **How does system handle subshells?** Commands inside subshells `(cmd)` should be split and processed recursively if they contain operators.
+- **How does system handle subshells?** Commands inside subshells `(cmd)` should be split and processed recursively if they contain operators. If a subshell has a redirection (e.g., `(echo hi) > file`), it should be treated as a single command to preserve the redirection.
 - **What if a command is already allowed?** The system should not add duplicate rules to the `permissions.allow` array.
+- **What about redirections?** Redirections should be preserved in the rules to ensure that the permission is granted for the specific operation. Write redirections should never be automatically allowed by default rules.
 
-## Requirements *(mandatory)*
+## Requirements _(mandatory)_
 
 ### Functional Requirements
 
@@ -69,7 +70,7 @@ As a user, when I run a chain consisting only of safe commands, I want the syste
 - **FR-006**: System MUST ensure that subsequent executions of any of the saved simple commands do not prompt the user if they match an entry in the `permissions.allow` list.
 - **FR-007**: System MUST handle nested commands (e.g., in subshells) by splitting them into simple commands.
 
-### Key Entities *(include if feature involves data)*
+### Key Entities _(include if feature involves data)_
 
 - **Command**: A string representing a bash command.
 - **Permission Rule**: A string in the format `ToolName(input)` (e.g., `Bash(ls)`) used to match allowed executions.

--- a/specs/038-bash-confirm-safety/plan.md
+++ b/specs/038-bash-confirm-safety/plan.md
@@ -4,13 +4,15 @@
 
 ## Summary
 
-The primary requirement is to prevent the "Don't ask again" option from appearing in the bash confirmation dialog for dangerous commands or commands that operate outside the project's working directory. 
+The primary requirement is to prevent the "Don't ask again" option from appearing in the bash confirmation dialog for dangerous commands, commands that operate outside the project's working directory, or commands that perform file writes via redirections.
 
 Technical approach:
-1.  Enhance `agent-sdk`'s `PermissionManager` to identify dangerous/out-of-bounds commands.
+
+1.  Enhance `agent-sdk`'s `PermissionManager` to identify dangerous/out-of-bounds commands and write redirections.
 2.  Add a `hidePersistentOption` flag to `ToolPermissionContext`.
 3.  Update the `code` package's `Confirmation` component to respect this flag.
 4.  Enforce safety in `PermissionManager.expandBashRule` to prevent persistence of dangerous rules.
+5.  Update `PermissionManager.isAllowedByRule` and `matchesRule` to handle write redirections securely.
 
 ## Technical Context
 
@@ -25,7 +27,7 @@ Technical approach:
 
 ## Constitution Check
 
-*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
 
 - [x] Package-First Architecture: Changes span `agent-sdk` and `code`.
 - [x] TypeScript Excellence: Strict typing for new context field.
@@ -83,8 +85,8 @@ packages/
 
 ## Complexity Tracking
 
-*Fill ONLY if Constitution Check has violations that must be justified*
+_Fill ONLY if Constitution Check has violations that must be justified_
 
 | Violation | Why Needed | Simpler Alternative Rejected Because |
-|-----------|------------|-------------------------------------|
-| None | | |
+| --------- | ---------- | ------------------------------------ |
+| None      |            |                                      |

--- a/specs/038-bash-confirm-safety/spec.md
+++ b/specs/038-bash-confirm-safety/spec.md
@@ -5,7 +5,7 @@
 **Status**: Implemented  
 **Input**: User description: "for some bash confirm which will never save to permissions.allow array, like cd outside of workdir or other danger cmd, should not display \"Don't ask again\" option"
 
-## User Scenarios & Testing *(mandatory)*
+## User Scenarios & Testing _(mandatory)_
 
 ### User Story 1 - Dangerous Command Confirmation (Priority: P1)
 
@@ -19,6 +19,7 @@ As a user, when I run a command that is considered dangerous or moves outside th
 
 1. **Given** the agent is running in a project directory, **When** I execute a command that attempts to change the directory to one outside the project root (e.g., `cd /tmp`), **Then** the confirmation dialog MUST NOT include a "Don't ask again" option.
 2. **Given** a command is identified as "dangerous" (e.g., system-level modifications), **When** I execute it, **Then** the confirmation dialog MUST NOT include a "Don't ask again" option.
+3. **Given** a bash command contains a write redirection (e.g., `echo "..." > file.txt`), **When** I execute it, **Then** the confirmation dialog MUST NOT include a "Don't ask again" option, as file write operations should use specialized tools like `Write` or `Edit`.
 
 ---
 
@@ -26,8 +27,9 @@ As a user, when I run a command that is considered dangerous or moves outside th
 
 - **What happens when a command is partially outside the workdir?** (e.g., `ls ../other-project`). The system should treat any access outside the workdir as a reason to hide the "Don't ask again" option.
 - **How does the system handle aliases or complex scripts?** The system should analyze the final command to be executed to determine its safety/scope.
+- **What about write redirections in subshells?** Redirections applied to subshells (e.g., `(echo hi) > file`) should also be detected and treated as dangerous.
 
-## Requirements *(mandatory)*
+## Requirements _(mandatory)_
 
 ### Functional Requirements
 
@@ -35,8 +37,10 @@ As a user, when I run a command that is considered dangerous or moves outside th
 - **FR-002**: The system MUST maintain a list or logic to identify "dangerous" commands that should never be permanently authorized.
 - **FR-003**: The confirmation dialog MUST hide the "Don't ask again" option for any command identified in FR-001 or FR-002.
 - **FR-004**: The system MUST ensure that permissions for these "dangerous" or "out-of-bounds" commands are never persisted to the `permissions.allow` configuration.
+- **FR-005**: The system MUST detect write redirections (`>`, `>>`, `&>`, `2>`, `>|`) in bash commands and treat them as dangerous, hiding the "Don't ask again" option.
+- **FR-006**: The system MUST ensure that bash commands with write redirections are not automatically allowed by default rules (e.g., `Bash(echo*)`).
 
-### Key Entities *(include if feature involves data)*
+### Key Entities _(include if feature involves data)_
 
 - **Permission Configuration**: The data structure (e.g., `permissions.allow`) that stores user-authorized commands.
 - **Bash Command**: The command string and its context (working directory, arguments) being evaluated for safety.

--- a/specs/038-bash-confirm-safety/tasks.md
+++ b/specs/038-bash-confirm-safety/tasks.md
@@ -1,19 +1,32 @@
 # Tasks
 
 ## Phase 1: Setup and Infrastructure
-- [X] T001: Build `agent-sdk` to ensure types are up to date and available for `code` package. <!-- id: T001 -->
+
+- [x] T001: Build `agent-sdk` to ensure types are up to date and available for `code` package. <!-- id: T001 -->
 
 ## Phase 2: Foundational Changes (SDK)
-- [X] T002: Add `hidePersistentOption?: boolean` to `ToolPermissionContext` interface in `packages/agent-sdk/src/types/permissions.ts`. <!-- id: T002 -->
-- [X] T003: Extract `DANGEROUS_COMMANDS` blacklist from `getSmartPrefix` to an exported constant in `packages/agent-sdk/src/utils/bashParser.ts`. <!-- id: T003 -->
+
+- [x] T002: Add `hidePersistentOption?: boolean` to `ToolPermissionContext` interface in `packages/agent-sdk/src/types/permissions.ts`. <!-- id: T002 -->
+- [x] T003: Extract `DANGEROUS_COMMANDS` blacklist from `getSmartPrefix` to an exported constant in `packages/agent-sdk/src/utils/bashParser.ts`. <!-- id: T003 -->
 
 ## Phase 3: US1 - Dangerous/Out-of-Bounds Command Safety
-- [X] T004: Add unit tests for dangerous and out-of-bounds command detection in `packages/agent-sdk/tests/managers/permissionManager.test.ts`. <!-- id: T004 -->
-- [X] T005: Add unit tests for `hidePersistentOption` visibility and navigation in `packages/code/tests/components/Confirmation.test.tsx`. <!-- id: T005 -->
-- [X] T006: Implement detection logic in `PermissionManager.createContext` to set `hidePersistentOption` for dangerous or out-of-bounds bash commands in `packages/agent-sdk/src/managers/permissionManager.ts`. <!-- id: T006 -->
-- [X] T007: Update `PermissionManager.expandBashRule` to filter out dangerous or out-of-bounds commands from being expanded into persistent rules in `packages/agent-sdk/src/managers/permissionManager.ts`. <!-- id: T007 -->
-- [X] T008: Update `Confirmation` component to hide the "auto" option and adjust numbering/navigation when `hidePersistentOption` is true in `packages/code/src/components/Confirmation.tsx`. <!-- id: T008 -->
-- [X] T009: Update `useChat` context and `ChatInterface` component to pass `hidePersistentOption` from `ToolPermissionContext` to the `Confirmation` component in `packages/code/src/contexts/useChat.tsx` and `packages/code/src/components/ChatInterface.tsx`. <!-- id: T009 -->
 
-## Phase 4: Verification
-- [X] T010: Run all tests in `agent-sdk` and `code` packages to ensure no regressions and that new functionality works as expected. <!-- id: T010 -->
+- [x] T004: Add unit tests for dangerous and out-of-bounds command detection in `packages/agent-sdk/tests/managers/permissionManager.test.ts`. <!-- id: T004 -->
+- [x] T005: Add unit tests for `hidePersistentOption` visibility and navigation in `packages/code/tests/components/Confirmation.test.tsx`. <!-- id: T005 -->
+- [x] T006: Implement detection logic in `PermissionManager.createContext` to set `hidePersistentOption` for dangerous or out-of-bounds bash commands in `packages/agent-sdk/src/managers/permissionManager.ts`. <!-- id: T006 -->
+- [x] T007: Update `PermissionManager.expandBashRule` to filter out dangerous or out-of-bounds commands from being expanded into persistent rules in `packages/agent-sdk/src/managers/permissionManager.ts`. <!-- id: T007 -->
+- [x] T008: Update `Confirmation` component to hide the "auto" option and adjust numbering/navigation when `hidePersistentOption` is true in `packages/code/src/components/Confirmation.tsx`. <!-- id: T008 -->
+- [x] T009: Update `useChat` context and `ChatInterface` component to pass `hidePersistentOption` from `ToolPermissionContext` to the `Confirmation` component in `packages/code/src/contexts/useChat.tsx` and `packages/code/src/components/ChatInterface.tsx`. <!-- id: T009 -->
+
+## Phase 5: Bash Write Redirection Safety
+
+- [x] T011: Implement `hasWriteRedirections` in `packages/agent-sdk/src/utils/bashParser.ts` to detect write redirections. <!-- id: T011 -->
+- [x] T012: Update `PermissionManager.createContext` to set `hidePersistentOption` for commands with write redirections in `packages/agent-sdk/src/managers/permissionManager.ts`. <!-- id: T012 -->
+- [x] T013: Update `PermissionManager.isAllowedByRule` to skip default rules for commands with write redirections in `packages/agent-sdk/src/managers/permissionManager.ts`. <!-- id: T013 -->
+- [x] T014: Update `PermissionManager.matchesRule` to ensure commands with write redirections only match rules that explicitly include write redirections. <!-- id: T014 -->
+- [x] T015: Update `PermissionManager.expandBashRule` to preserve write redirections in persistent rules. <!-- id: T015 -->
+- [x] T016: Fix `splitBashCommand` to preserve redirections on subshells. <!-- id: T016 -->
+
+## Phase 6: Verification
+
+- [x] T010: Run all tests in `agent-sdk` and `code` packages to ensure no regressions and that new functionality works as expected. <!-- id: T010 -->


### PR DESCRIPTION
- Implement hasWriteRedirections in bashParser.ts to detect write redirections (>, >>, &>, 2>, >|).
- Update PermissionManager to hide "Don't ask again" option for commands with write redirections.
- Update PermissionManager to skip default allowed rules for commands with write redirections.
- Update PermissionManager to ensure commands with write redirections only match rules that explicitly include write redirections.
- Fix splitBashCommand to preserve redirections on subshells.
- Add comprehensive unit tests for write redirection safety.
- Update relevant specification files.