### PR TITLE
feat(agent-sdk): auto-install missing enabled plugins

### DIFF
--- a/packages/agent-sdk/src/managers/pluginManager.ts
+++ b/packages/agent-sdk/src/managers/pluginManager.ts
@@ -73,7 +73,45 @@ export class PluginManager {
       }
 
       const marketplaceService = new MarketplaceService();
-      const installedRegistry = await marketplaceService.getInstalledPlugins();
+      let installedRegistry = await marketplaceService.getInstalledPlugins();
+      const knownMarketplaces = await marketplaceService.listMarketplaces();
+
+      // Identify missing enabled plugins and auto-install them if marketplace is known
+      for (const pluginId of Object.keys(this.enabledPlugins)) {
+        if (this.enabledPlugins[pluginId] !== true) continue;
+
+        const [name, marketplaceName] = pluginId.split("@");
+        if (!name || !marketplaceName) continue;
+
+        const isInstalled = installedRegistry.plugins.some(
+          (p) => p.name === name && p.marketplace === marketplaceName,
+        );
+
+        if (!isInstalled) {
+          const isMarketplaceKnown = knownMarketplaces.some(
+            (m) => m.name === marketplaceName,
+          );
+
+          if (isMarketplaceKnown) {
+            logger?.info(`Auto-installing missing plugin: ${pluginId}`);
+            try {
+              await marketplaceService.installPlugin(pluginId);
+            } catch (installError) {
+              logger?.error(
+                `Failed to auto-install plugin ${pluginId}:`,
+                installError,
+              );
+            }
+          } else {
+            logger?.warn(
+              `Plugin ${pluginId} is enabled but marketplace ${marketplaceName} is unknown. Skipping auto-install.`,
+            );
+          }
+        }
+      }
+
+      // Refresh registry after potential auto-installs
+      installedRegistry = await marketplaceService.getInstalledPlugins();
 
       for (const p of installedRegistry.plugins) {
         const pluginId = `${p.name}@${p.marketplace}`;

--- a/packages/agent-sdk/tests/managers/pluginManager.autoInstall.test.ts
+++ b/packages/agent-sdk/tests/managers/pluginManager.autoInstall.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PluginManager } from "../../src/managers/pluginManager.js";
+import { Container } from "../../src/utils/container.js";
+import { PluginLoader } from "../../src/services/pluginLoader.js";
+import { PluginManifest } from "../../src/types/index.js";
+import { MarketplaceService } from "../../src/services/MarketplaceService.js";
+import { logger } from "../../src/utils/globalLogger.js";
+
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/services/pluginLoader.js");
+vi.mock("../../src/services/MarketplaceService.js");
+
+describe("PluginManager Auto-install", () => {
+  let pluginManager: PluginManager;
+  let container: Container;
+  const workdir = "/test/workdir";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    const mockConfigurationService = {
+      getMergedEnabledPlugins: vi.fn().mockReturnValue({}),
+    };
+
+    container = new Container();
+    container.register(
+      "ConfigurationService",
+      mockConfigurationService as unknown as Record<string, unknown>,
+    );
+
+    pluginManager = new PluginManager(container, {
+      workdir,
+    });
+    // Expose mockConfigurationService for tests
+    (
+      pluginManager as unknown as {
+        mockConfigurationService: typeof mockConfigurationService;
+      }
+    ).mockConfigurationService = mockConfigurationService;
+  });
+
+  it("should auto-install missing enabled plugins if marketplace is known", async () => {
+    const pluginId = "test-plugin@official";
+    const enabledPlugins = { [pluginId]: true };
+
+    (
+      pluginManager as unknown as {
+        mockConfigurationService: {
+          getMergedEnabledPlugins: ReturnType<typeof vi.fn>;
+        };
+      }
+    ).mockConfigurationService.getMergedEnabledPlugins.mockReturnValue(
+      enabledPlugins,
+    );
+
+    const installedPlugins = {
+      plugins: [] as { name: string; marketplace: string; cachePath: string }[],
+    };
+    const knownMarketplaces = [{ name: "official" }];
+
+    const mockInstallPlugin = vi.fn().mockImplementation(async () => {
+      installedPlugins.plugins.push({
+        name: "test-plugin",
+        marketplace: "official",
+        cachePath: "/path/to/test-plugin",
+      });
+    });
+
+    vi.mocked(MarketplaceService).mockImplementation(function () {
+      return {
+        getInstalledPlugins: vi
+          .fn()
+          .mockImplementation(async () => installedPlugins),
+        listMarketplaces: vi.fn().mockResolvedValue(knownMarketplaces),
+        installPlugin: mockInstallPlugin,
+      } as unknown as MarketplaceService;
+    });
+
+    vi.mocked(PluginLoader.loadManifest).mockResolvedValue({
+      name: "test-plugin",
+      version: "1.0.0",
+      description: "desc",
+    } as PluginManifest);
+    vi.mocked(PluginLoader.loadCommands).mockReturnValue([]);
+    vi.mocked(PluginLoader.loadSkills).mockResolvedValue([]);
+
+    await pluginManager.loadPlugins([]);
+
+    expect(mockInstallPlugin).toHaveBeenCalledWith(pluginId);
+    expect(pluginManager.getPlugins()).toHaveLength(1);
+    expect(pluginManager.getPlugin("test-plugin")).toBeDefined();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining(`Auto-installing missing plugin: ${pluginId}`),
+    );
+  });
+
+  it("should NOT auto-install if marketplace is unknown", async () => {
+    const pluginId = "test-plugin@unknown";
+    const enabledPlugins = { [pluginId]: true };
+
+    (
+      pluginManager as unknown as {
+        mockConfigurationService: {
+          getMergedEnabledPlugins: ReturnType<typeof vi.fn>;
+        };
+      }
+    ).mockConfigurationService.getMergedEnabledPlugins.mockReturnValue(
+      enabledPlugins,
+    );
+
+    const installedPlugins = {
+      plugins: [] as { name: string; marketplace: string; cachePath: string }[],
+    };
+    const knownMarketplaces = [{ name: "official" }];
+
+    const mockInstallPlugin = vi.fn();
+
+    vi.mocked(MarketplaceService).mockImplementation(function () {
+      return {
+        getInstalledPlugins: vi
+          .fn()
+          .mockImplementation(async () => installedPlugins),
+        listMarketplaces: vi.fn().mockResolvedValue(knownMarketplaces),
+        installPlugin: mockInstallPlugin,
+      } as unknown as MarketplaceService;
+    });
+
+    await pluginManager.loadPlugins([]);
+
+    expect(mockInstallPlugin).not.toHaveBeenCalled();
+    expect(pluginManager.getPlugins()).toHaveLength(0);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `marketplace unknown is unknown. Skipping auto-install.`,
+      ),
+    );
+  });
+
+  it("should handle installation errors gracefully", async () => {
+    const pluginId = "test-plugin@official";
+    const enabledPlugins = { [pluginId]: true };
+
+    (
+      pluginManager as unknown as {
+        mockConfigurationService: {
+          getMergedEnabledPlugins: ReturnType<typeof vi.fn>;
+        };
+      }
+    ).mockConfigurationService.getMergedEnabledPlugins.mockReturnValue(
+      enabledPlugins,
+    );
+
+    const installedPlugins = {
+      plugins: [] as { name: string; marketplace: string; cachePath: string }[],
+    };
+    const knownMarketplaces = [{ name: "official" }];
+
+    const error = new Error("Network error");
+    const mockInstallPlugin = vi.fn().mockRejectedValue(error);
+
+    vi.mocked(MarketplaceService).mockImplementation(function () {
+      return {
+        getInstalledPlugins: vi
+          .fn()
+          .mockImplementation(async () => installedPlugins),
+        listMarketplaces: vi.fn().mockResolvedValue(knownMarketplaces),
+        installPlugin: mockInstallPlugin,
+      } as unknown as MarketplaceService;
+    });
+
+    await pluginManager.loadPlugins([]);
+
+    expect(mockInstallPlugin).toHaveBeenCalledWith(pluginId);
+    expect(pluginManager.getPlugins()).toHaveLength(0);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(`Failed to auto-install plugin ${pluginId}:`),
+      error,
+    );
+  });
+});

--- a/packages/agent-sdk/tests/managers/pluginManager.test.ts
+++ b/packages/agent-sdk/tests/managers/pluginManager.test.ts
@@ -75,6 +75,7 @@ describe("PluginManager", () => {
     vi.mocked(MarketplaceService).mockImplementation(function () {
       return {
         getInstalledPlugins: vi.fn().mockResolvedValue({ plugins: [] }),
+        listMarketplaces: vi.fn().mockResolvedValue([]),
       } as unknown as MarketplaceService;
     });
 
@@ -234,6 +235,7 @@ describe("PluginManager", () => {
           getInstalledPlugins: vi
             .fn()
             .mockResolvedValue({ plugins: installedPlugins }),
+          listMarketplaces: vi.fn().mockResolvedValue([]),
         } as unknown as MarketplaceService;
       });
 
@@ -315,6 +317,7 @@ describe("PluginManager", () => {
           getInstalledPlugins: vi
             .fn()
             .mockResolvedValue({ plugins: installedPlugins }),
+          listMarketplaces: vi.fn().mockResolvedValue([]),
         } as unknown as MarketplaceService;
       });
 

--- a/packages/agent-sdk/tests/plugin-loading-integration.test.ts
+++ b/packages/agent-sdk/tests/plugin-loading-integration.test.ts
@@ -30,6 +30,7 @@ describe("Agent Plugin Loading Integration", () => {
             { name: "plugin-none", marketplace: "m1", cachePath: "/path/none" },
           ],
         }),
+        listMarketplaces: vi.fn().mockResolvedValue([]),
       } as unknown as MarketplaceService;
     });
 


### PR DESCRIPTION
This PR implements auto-installation for missing enabled plugins in the PluginManager. When a plugin is enabled but not found in the installed registry, it will now be automatically installed if its marketplace is known.

Changes:
- Added auto-installation logic to `PluginManager.initialize()`
- Updated `MarketplaceService` mocks in tests
- Added integration tests for auto-installation