### PR TITLE
feat(agent-sdk): improve getDefaultRemoteBranch robustness and add print-bin script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:coverage": "pnpm -r test:coverage",
     "lint": "pnpm -r lint",
     "format": "prettier --write .",
+    "print-bin": "echo $(pwd)/packages/code/bin/wave-code.js",
     "ci": "pnpm type-check && pnpm lint && pnpm test:coverage",
     "release:patch": "node scripts/release.js patch",
     "release:minor": "node scripts/release.js minor",

--- a/packages/agent-sdk/src/utils/gitUtils.ts
+++ b/packages/agent-sdk/src/utils/gitUtils.ts
@@ -47,6 +47,7 @@ export function getGitRepoRoot(cwd: string): string {
  * @returns Default remote branch name
  */
 export function getDefaultRemoteBranch(cwd: string): string {
+  // 1. Try git symbolic-ref refs/remotes/origin/HEAD
   try {
     const head = execSync("git symbolic-ref refs/remotes/origin/HEAD", {
       cwd,
@@ -55,9 +56,55 @@ export function getDefaultRemoteBranch(cwd: string): string {
     }).trim();
     return head.replace("refs/remotes/", "");
   } catch {
-    // Fallback to origin/main if origin/HEAD is not set
-    return "origin/main";
+    // Ignore error and proceed to next step
   }
+
+  // 2. Check if origin/main exists
+  try {
+    execSync("git rev-parse --verify origin/main", {
+      cwd,
+      stdio: "ignore",
+    });
+    return "origin/main";
+  } catch {
+    // Ignore error and proceed to next step
+  }
+
+  // 3. Check if origin/master exists
+  try {
+    execSync("git rev-parse --verify origin/master", {
+      cwd,
+      stdio: "ignore",
+    });
+    return "origin/master";
+  } catch {
+    // Ignore error and proceed to next step
+  }
+
+  // 4. Try to get the current branch's upstream
+  try {
+    return execSync("git rev-parse --abbrev-ref --symbolic-full-name @{u}", {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    // Ignore error and proceed to next step
+  }
+
+  // 5. Try to get the current branch name
+  try {
+    return execSync("git rev-parse --abbrev-ref HEAD", {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    // Ignore error and proceed to next step
+  }
+
+  // 6. Fallback to origin/main
+  return "origin/main";
 }
 
 /**

--- a/packages/agent-sdk/tests/utils/gitUtils.test.ts
+++ b/packages/agent-sdk/tests/utils/gitUtils.test.ts
@@ -1,71 +1,165 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { execSync } from 'node:child_process';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { execSync } from "node:child_process";
 import {
   getGitRepoRoot,
   getDefaultRemoteBranch,
   hasUncommittedChanges,
   hasNewCommits,
-} from '../../src/utils/gitUtils.js';
+} from "../../src/utils/gitUtils.js";
 
-vi.mock('node:child_process', () => ({
+vi.mock("node:child_process", () => ({
   execSync: vi.fn(),
 }));
 
-describe('gitUtils', () => {
+describe("gitUtils", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  describe('getGitRepoRoot', () => {
-    it('should return the git repo root', () => {
-      vi.mocked(execSync).mockReturnValue('/repo/root\n' as unknown as ReturnType<typeof execSync>);
-      expect(getGitRepoRoot('/some/path')).toBe('/repo/root');
-      expect(execSync).toHaveBeenCalledWith('git rev-parse --show-toplevel', expect.any(Object));
+  describe("getGitRepoRoot", () => {
+    it("should return the git repo root", () => {
+      vi.mocked(execSync).mockReturnValue(
+        "/repo/root\n" as unknown as ReturnType<typeof execSync>,
+      );
+      expect(getGitRepoRoot("/some/path")).toBe("/repo/root");
+      expect(execSync).toHaveBeenCalledWith(
+        "git rev-parse --show-toplevel",
+        expect.any(Object),
+      );
     });
 
-    it('should return cwd if git command fails', () => {
+    it("should return cwd if git command fails", () => {
       vi.mocked(execSync).mockImplementation(() => {
-        throw new Error('Not a git repo');
+        throw new Error("Not a git repo");
       });
-      expect(getGitRepoRoot('/some/path')).toBe('/some/path');
+      expect(getGitRepoRoot("/some/path")).toBe("/some/path");
     });
   });
 
-  describe('getDefaultRemoteBranch', () => {
-    it('should return the default remote branch', () => {
-      vi.mocked(execSync).mockReturnValue('refs/remotes/origin/main\n' as unknown as ReturnType<typeof execSync>);
-      expect(getDefaultRemoteBranch('/repo/root')).toBe('origin/main');
+  describe("getDefaultRemoteBranch", () => {
+    it("should return the default remote branch from symbolic-ref (Step 1)", () => {
+      vi.mocked(execSync).mockImplementation((cmd) => {
+        if (cmd === "git symbolic-ref refs/remotes/origin/HEAD") {
+          return "refs/remotes/origin/main\n" as unknown as ReturnType<
+            typeof execSync
+          >;
+        }
+        throw new Error("Command failed");
+      });
+      expect(getDefaultRemoteBranch("/repo/root")).toBe("origin/main");
     });
 
-    it('should fallback to origin/main if command fails', () => {
+    it("should fallback to origin/main if it exists (Step 2)", () => {
+      vi.mocked(execSync).mockImplementation((cmd) => {
+        if (cmd === "git symbolic-ref refs/remotes/origin/HEAD") {
+          throw new Error("Command failed");
+        }
+        if (cmd === "git rev-parse --verify origin/main") {
+          return "" as unknown as ReturnType<typeof execSync>;
+        }
+        throw new Error("Command failed");
+      });
+      expect(getDefaultRemoteBranch("/repo/root")).toBe("origin/main");
+    });
+
+    it("should fallback to origin/master if it exists (Step 3)", () => {
+      vi.mocked(execSync).mockImplementation((cmd) => {
+        if (cmd === "git symbolic-ref refs/remotes/origin/HEAD") {
+          throw new Error("Command failed");
+        }
+        if (cmd === "git rev-parse --verify origin/main") {
+          throw new Error("Command failed");
+        }
+        if (cmd === "git rev-parse --verify origin/master") {
+          return "" as unknown as ReturnType<typeof execSync>;
+        }
+        throw new Error("Command failed");
+      });
+      expect(getDefaultRemoteBranch("/repo/root")).toBe("origin/master");
+    });
+
+    it("should fallback to upstream branch (Step 4)", () => {
+      vi.mocked(execSync).mockImplementation((cmd) => {
+        if (cmd === "git symbolic-ref refs/remotes/origin/HEAD") {
+          throw new Error("Command failed");
+        }
+        if (cmd === "git rev-parse --verify origin/main") {
+          throw new Error("Command failed");
+        }
+        if (cmd === "git rev-parse --verify origin/master") {
+          throw new Error("Command failed");
+        }
+        if (cmd === "git rev-parse --abbrev-ref --symbolic-full-name @{u}") {
+          return "origin/feature-branch\n" as unknown as ReturnType<
+            typeof execSync
+          >;
+        }
+        throw new Error("Command failed");
+      });
+      expect(getDefaultRemoteBranch("/repo/root")).toBe(
+        "origin/feature-branch",
+      );
+    });
+
+    it("should fallback to current branch name (Step 5)", () => {
+      vi.mocked(execSync).mockImplementation((cmd) => {
+        if (cmd === "git symbolic-ref refs/remotes/origin/HEAD") {
+          throw new Error("Command failed");
+        }
+        if (cmd === "git rev-parse --verify origin/main") {
+          throw new Error("Command failed");
+        }
+        if (cmd === "git rev-parse --verify origin/master") {
+          throw new Error("Command failed");
+        }
+        if (cmd === "git rev-parse --abbrev-ref --symbolic-full-name @{u}") {
+          throw new Error("Command failed");
+        }
+        if (cmd === "git rev-parse --abbrev-ref HEAD") {
+          return "main\n" as unknown as ReturnType<typeof execSync>;
+        }
+        throw new Error("Command failed");
+      });
+      expect(getDefaultRemoteBranch("/repo/root")).toBe("main");
+    });
+
+    it("should fallback to origin/main if all else fails (Step 6)", () => {
       vi.mocked(execSync).mockImplementation(() => {
-        throw new Error('No origin/HEAD');
+        throw new Error("Command failed");
       });
-      expect(getDefaultRemoteBranch('/repo/root')).toBe('origin/main');
+      expect(getDefaultRemoteBranch("/repo/root")).toBe("origin/main");
     });
   });
 
-  describe('hasUncommittedChanges', () => {
-    it('should return true if there are changes', () => {
-      vi.mocked(execSync).mockReturnValue(' M file.ts\n' as unknown as ReturnType<typeof execSync>);
-      expect(hasUncommittedChanges('/repo/root')).toBe(true);
+  describe("hasUncommittedChanges", () => {
+    it("should return true if there are changes", () => {
+      vi.mocked(execSync).mockReturnValue(
+        " M file.ts\n" as unknown as ReturnType<typeof execSync>,
+      );
+      expect(hasUncommittedChanges("/repo/root")).toBe(true);
     });
 
-    it('should return false if there are no changes', () => {
-      vi.mocked(execSync).mockReturnValue('' as unknown as ReturnType<typeof execSync>);
-      expect(hasUncommittedChanges('/repo/root')).toBe(false);
+    it("should return false if there are no changes", () => {
+      vi.mocked(execSync).mockReturnValue(
+        "" as unknown as ReturnType<typeof execSync>,
+      );
+      expect(hasUncommittedChanges("/repo/root")).toBe(false);
     });
   });
 
-  describe('hasNewCommits', () => {
-    it('should return true if there are new commits', () => {
-      vi.mocked(execSync).mockReturnValue('abc1234 Commit message\n' as unknown as ReturnType<typeof execSync>);
-      expect(hasNewCommits('/repo/root', 'origin/main')).toBe(true);
+  describe("hasNewCommits", () => {
+    it("should return true if there are new commits", () => {
+      vi.mocked(execSync).mockReturnValue(
+        "abc1234 Commit message\n" as unknown as ReturnType<typeof execSync>,
+      );
+      expect(hasNewCommits("/repo/root", "origin/main")).toBe(true);
     });
 
-    it('should return false if there are no new commits', () => {
-      vi.mocked(execSync).mockReturnValue('' as unknown as ReturnType<typeof execSync>);
-      expect(hasNewCommits('/repo/root', 'origin/main')).toBe(false);
+    it("should return false if there are no new commits", () => {
+      vi.mocked(execSync).mockReturnValue(
+        "" as unknown as ReturnType<typeof execSync>,
+      );
+      expect(hasNewCommits("/repo/root", "origin/main")).toBe(false);
     });
   });
 });


### PR DESCRIPTION
This PR improves the robustness of `getDefaultRemoteBranch` in `agent-sdk` by implementing a multi-step fallback strategy (symbolic-ref, origin/main, origin/master, upstream, current branch). It also adds a `print-bin` script to the root `package.json` to help locate the wave-code binary.