### PR TITLE
docs: update AGENTS.md to refer to Agent tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,5 +41,5 @@ Always use `pnpm` as the package manager.
 
 ## 🤖 Subagent Usage
 
-- **Subagent Usage**: If you have the `Task` tool, use specialized agents (typescript-expert, vitest-expert, Explore) for focused tasks (exploration, development, or testing) to reduce context usage. Note that subagents typically do not have access to the `Task` tool.
+- **Subagent Usage**: If you have the `Agent` tool, use specialized agents (typescript-expert, vitest-expert, Explore) for focused tasks (exploration, development, or testing) to reduce context usage. Note that subagents typically do not have access to the `Agent` tool.
 


### PR DESCRIPTION
Updates AGENTS.md to correctly refer to the Agent tool instead of the Task tool in the Subagent Usage section.