### PR TITLE
chore: run WorktreeCreate hooks in background

### DIFF
--- a/.wave/settings.json
+++ b/.wave/settings.json
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pnpm install && pnpm build"
+            "command": "pnpm install && pnpm build &"
           }
         ]
       }


### PR DESCRIPTION
Update .wave/settings.json to run WorktreeCreate hooks in background