### PR TITLE
feat: implement shared session storage across git worktrees

### DIFF
--- a/packages/agent-sdk/src/utils/gitUtils.ts
+++ b/packages/agent-sdk/src/utils/gitUtils.ts
@@ -108,6 +108,41 @@ export function getDefaultRemoteBranch(cwd: string): string {
 }
 
 /**
+ * Get the main repository root if the current directory is part of a git worktree.
+ * @param cwd Working directory
+ * @returns Main repository root path if in a worktree, null otherwise
+ */
+export function getGitProjectRoot(cwd: string): string | null {
+  try {
+    const toplevel = execSync("git rev-parse --show-toplevel", {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+
+    const commonDir = execSync("git rev-parse --git-common-dir", {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+
+    const absoluteToplevel = path.resolve(cwd, toplevel);
+    const absoluteCommonDir = path.resolve(cwd, commonDir);
+    const mainRepoRoot = path.dirname(absoluteCommonDir);
+
+    if (absoluteToplevel !== mainRepoRoot) {
+      // It's a worktree. Map the current path to the main repo.
+      const absoluteCwd = path.resolve(cwd);
+      const relativePath = path.relative(absoluteToplevel, absoluteCwd);
+      return path.resolve(mainRepoRoot, relativePath);
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Check if there are uncommitted changes in the working directory
  * @param cwd Working directory
  * @returns True if there are uncommitted changes

--- a/packages/agent-sdk/src/utils/pathEncoder.ts
+++ b/packages/agent-sdk/src/utils/pathEncoder.ts
@@ -7,6 +7,7 @@ import { resolve, join } from "path";
 import { createHash } from "crypto";
 import { realpath, mkdir } from "fs/promises";
 import { homedir, platform } from "os";
+import { getGitProjectRoot } from "./gitUtils.js";
 
 /**
  * Project directory information
@@ -77,7 +78,8 @@ export class PathEncoder {
   async encode(originalPath: string): Promise<string> {
     // Resolve symbolic links and normalize path
     const resolvedPath = await this.resolvePath(originalPath);
-    return this.encodeSync(resolvedPath);
+    const projectRoot = getGitProjectRoot(resolvedPath);
+    return this.encodeSync(projectRoot ?? resolvedPath);
   }
 
   /**
@@ -212,13 +214,15 @@ export class PathEncoder {
     }
 
     // Encode the resolved path
-    const encodedName = await this.encode(resolvedPath);
+    const projectRoot = getGitProjectRoot(resolvedPath);
+    const encodedName = await this.encode(projectRoot ?? resolvedPath);
     const encodedPath = join(baseSessionDir, encodedName);
 
     // Generate hash if encoding resulted in truncation
     let pathHash: string | undefined;
-    if (resolvedPath.length > this.options.maxLength) {
-      pathHash = this.generateHash(resolvedPath, this.options.hashLength);
+    const pathToHash = projectRoot ?? resolvedPath;
+    if (pathToHash.length > this.options.maxLength) {
+      pathHash = this.generateHash(pathToHash, this.options.hashLength);
     }
 
     return {

--- a/packages/agent-sdk/tests/utils/pathEncoder.test.ts
+++ b/packages/agent-sdk/tests/utils/pathEncoder.test.ts
@@ -3,6 +3,7 @@ import {
   PathEncoder,
   type PathEncodingOptions,
 } from "../../src/utils/pathEncoder.js";
+import { getGitProjectRoot } from "../../src/utils/gitUtils.js";
 import { realpath, mkdir } from "fs/promises";
 import { homedir, platform } from "os";
 
@@ -11,6 +12,9 @@ vi.mock("fs/promises");
 
 // Mock os
 vi.mock("os");
+
+// Mock gitUtils
+vi.mock("../../src/utils/gitUtils.js");
 
 describe("PathEncoder", () => {
   let pathEncoder: PathEncoder;
@@ -721,6 +725,63 @@ describe("PathEncoder", () => {
         // On other platforms, these characters should be replaced
         expect(encoded).not.toMatch(/[<>:|?*]/);
       }
+    });
+  });
+
+  describe("git worktree support", () => {
+    it("should use main repo root for encoding when in a worktree root", async () => {
+      const mainRepoRoot = "/home/user/main-repo";
+      const worktreeRoot = "/home/user/main-repo/.wave/worktrees/my-feature";
+
+      // Mock getGitProjectRoot to return mainRepoRoot when called with worktreeRoot
+      vi.mocked(getGitProjectRoot).mockImplementation((path) => {
+        if (path === worktreeRoot) return mainRepoRoot;
+        return null;
+      });
+
+      vi.mocked(realpath).mockImplementation((path) =>
+        Promise.resolve(path as string),
+      );
+
+      const result = await pathEncoder.encode(worktreeRoot);
+      expect(result).toBe("home-user-main-repo");
+      expect(getGitProjectRoot).toHaveBeenCalledWith(worktreeRoot);
+    });
+
+    it("should use main repo subdir for encoding when in a worktree subdir", async () => {
+      const mainRepoRoot = "/home/user/main-repo";
+      const worktreeRoot = "/home/user/main-repo/.wave/worktrees/my-feature";
+      const worktreeSubdir = `${worktreeRoot}/subdir`;
+      const mainRepoSubdir = `${mainRepoRoot}/subdir`;
+
+      // Mock getGitProjectRoot to return mainRepoSubdir when called with worktreeSubdir
+      vi.mocked(getGitProjectRoot).mockImplementation((path) => {
+        if (path === worktreeSubdir) return mainRepoSubdir;
+        return null;
+      });
+
+      vi.mocked(realpath).mockImplementation((path) =>
+        Promise.resolve(path as string),
+      );
+
+      const result = await pathEncoder.encode(worktreeSubdir);
+      expect(result).toBe("home-user-main-repo-subdir");
+      expect(getGitProjectRoot).toHaveBeenCalledWith(worktreeSubdir);
+    });
+
+    it("should use actual path for encoding when NOT in a worktree", async () => {
+      const mainRepoRoot = "/home/user/main-repo";
+
+      // Mock getGitProjectRoot to return null for main repo root
+      vi.mocked(getGitProjectRoot).mockReturnValue(null);
+
+      vi.mocked(realpath).mockImplementation((path) =>
+        Promise.resolve(path as string),
+      );
+
+      const result = await pathEncoder.encode(mainRepoRoot);
+      expect(result).toBe("home-user-main-repo");
+      expect(getGitProjectRoot).toHaveBeenCalledWith(mainRepoRoot);
     });
   });
 });

--- a/specs/004-session-management/spec.md
+++ b/specs/004-session-management/spec.md
@@ -64,7 +64,7 @@ As a developer using subagents, I want subagent sessions to be clearly identifie
 
 - **FR-001**: All session data MUST be stored in `~/.wave/projects`.
 - **FR-002**: Sessions MUST be grouped into subdirectories based on an encoded version of the project's working directory path.
-- **FR-003**: Working directory paths MUST be encoded to be filesystem-safe, resolving symbolic links and handling special characters.
+- **FR-003**: Working directory paths MUST be encoded to be filesystem-safe, resolving symbolic links and handling special characters. For git repositories, the project ID MUST be derived from the main repository root, ensuring that all git worktrees share the same session storage.
 - **FR-004**: Encoded directory names MUST be limited to 200 characters, using a hash suffix for longer paths.
 - **FR-005**: Sessions MUST be stored in JSONL (JSON Lines) format, with one JSON object per line representing a message.
 - **FR-006**: Main session files MUST be named using a UUID. The first session ID in a chain MUST be designated as the `rootSessionId` and persisted in the `SessionIndex`.

--- a/specs/068-cli-worktree-support/spec.md
+++ b/specs/068-cli-worktree-support/spec.md
@@ -133,6 +133,7 @@ As a developer, I want the CLI to automatically clean up the worktree if I haven
 - **FR-018**: System MUST trigger a `WorktreeCreate` hook event when a new worktree is created.
 - **FR-019**: The `WorktreeCreate` hook MUST provide a JSON input via stdin containing a `name` field. The hook MUST execute in the newly created worktree directory.
 - **FR-020**: The `WorktreeCreate` hook MUST NOT be triggered when reusing an existing worktree.
+- **FR-021**: All git worktrees MUST share the same session storage as the main repository. The project ID for session organization MUST be derived from the main repository root path.
 
 ### Key Entities
 


### PR DESCRIPTION
Implement shared session storage across git worktrees by using the main repository's root path as the basis for the project ID. This ensures that all worktrees of the same repository share the same session history. Updated gitUtils, pathEncoder, and relevant specifications. Added tests to verify the mapping of worktree paths to the main repository.