### PR TITLE
docs: remove # trigger and update global memory path in 018-memory-management-spec

### DIFF
--- a/specs/018-memory-management-spec/data-model.md
+++ b/specs/018-memory-management-spec/data-model.md
@@ -11,20 +11,9 @@ A single piece of persisted information.
 | `type` | 'project' \| 'user' | Whether it's stored in `AGENTS.md` or global memory. |
 | `source` | string | The absolute path to the storage file. |
 
-### MemorySelectorState
-The state of the memory type selection UI.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `isActive` | boolean | Whether the selection UI is visible. |
-| `message` | string | The memory content to be saved (typed after `#`). |
-| `selectedIndex` | number | The currently highlighted option (Project/User). |
-
 ## State Transitions
 
 1. **Idle**: Normal input mode.
-2. **Triggered**: User submits a message starting with `#`.
-3. **Selecting**: `MemoryTypeSelector` is shown, user chooses storage type.
-4. **Saving**: The entry is written to the selected file.
-5. **Persisted**: The entry is now available for future AI requests.
-6. **Cancelled**: User cancels the selection, memory is not saved.
+2. **Triggered**: User asks the agent to remember something.
+3. **Saving**: The entry is written to the appropriate file (AGENTS.md, global memory, or auto-memory).
+4. **Persisted**: The entry is now available for future AI requests.

--- a/specs/018-memory-management-spec/plan.md
+++ b/specs/018-memory-management-spec/plan.md
@@ -5,13 +5,13 @@
 
 ## Summary
 
-Implement a Memory Management system that allows the agent to persist information across conversations. Triggered by `#`, it allows saving to "Project" (`AGENTS.md`) or "User" (global) storage. Memory is injected into the AI's system prompt.
+Implement a Memory Management system that allows the agent to persist information across conversations. It allows saving to "Project" (`AGENTS.md`), "User" (global), or "Auto-Memory" storage. Memory is injected into the AI's system prompt.
 
 ## Technical Context
 
 **Language/Version**: TypeScript 5.x
 **Primary Dependencies**: agent-sdk, code (Ink, React)
-**Storage**: Markdown files (`AGENTS.md`, `~/.wave/memory.md`)
+**Storage**: Markdown files (`AGENTS.md`, `~/.wave/AGENTS.md`)
 **Testing**: Vitest
 **Target Platform**: CLI (Node.js)
 **Project Type**: Monorepo (agent-sdk + code)
@@ -59,13 +59,10 @@ packages/agent-sdk/
 
 packages/code/
 ├── src/
-│   ├── managers/
-│   │   └── InputManager.ts     # Handle # trigger and state
-│   └── components/
-│       └── MemoryTypeSelector.tsx # UI component
+│   └── managers/
+│       └── InputManager.ts     # Handle input state
 └── tests/
     └── components/
-        └── MemoryTypeSelector.test.tsx
 ```
 
 ## Complexity Tracking

--- a/specs/018-memory-management-spec/spec.md
+++ b/specs/018-memory-management-spec/spec.md
@@ -9,31 +9,30 @@
 
 ### User Story 1 - Save Project-Specific Memory (Priority: P1)
 
-As a user, I want to save project-specific rules or context by typing `#` so the agent remembers them for this project.
+As a user, I want the agent to save project-specific rules or context so it remembers them for this project.
 
 **Why this priority**: This is the core functionality that allows the agent to adapt to different project requirements and styles.
 
-**Independent Test**: Type `# Use pnpm instead of npm` in a project directory, select "Project" memory, and verify it's saved to `AGENTS.md`.
+**Independent Test**: Ask the agent to remember a project-specific rule (e.g., "always use pnpm") and verify it's saved to `AGENTS.md`.
 
 **Acceptance Scenarios**:
 
-1. **Given** the user types a message starting with `#`, **When** they press `Enter`, **Then** a memory type selector MUST appear.
-2. **Given** the selector is open, **When** the user selects "Project", **Then** the message MUST be saved to `AGENTS.md` in the current directory.
-3. **Given** information is saved in `AGENTS.md`, **When** the agent is asked a related question, **Then** it MUST use that information in its response.
+1. **Given** the user asks the agent to remember something for the project, **When** the agent identifies it as a project rule, **Then** it MUST be saved to `AGENTS.md` in the current directory.
+2. **Given** information is saved in `AGENTS.md`, **When** the agent is asked a related question, **Then** it MUST use that information in its response.
 
 ---
 
 ### User Story 2 - Save Global User Memory (Priority: P1)
 
-As a user, I want to save global preferences that follow me across all projects so I don't have to repeat them.
+As a user, I want the agent to save global preferences that follow me across all projects so I don't have to repeat them.
 
 **Why this priority**: Essential for a personalized experience across different workspaces.
 
-**Independent Test**: Type `# My name is Alice`, select "User" memory, and verify it's saved to the global memory file (e.g., `~/.wave/memory.md`).
+**Independent Test**: Ask the agent to remember a global preference (e.g., "my name is Alice") and verify it's saved to the global memory file (e.g., `~/.wave/AGENTS.md`).
 
 **Acceptance Scenarios**:
 
-1. **Given** the memory type selector is open, **When** the user selects "User", **Then** the message MUST be saved to the global user memory file.
+1. **Given** the user asks the agent to remember something globally, **When** the agent identifies it as a user preference, **Then** it MUST be saved to the global user memory file.
 2. **Given** information is saved in global memory, **When** the agent is used in ANY project, **Then** it MUST have access to that information.
 
 ---
@@ -82,10 +81,10 @@ As a user, I want the agent to automatically remember important information acro
 
 ### Functional Requirements
 
-- **FR-001**: System MUST trigger memory saving when a message starts with `#`.
-- **FR-002**: System MUST provide a UI to choose between "Project" and "User" memory.
+- **FR-001**: System MUST allow the agent to save memory when requested by the user.
+- **FR-002**: System SHOULD provide a way for the agent to distinguish between "Project" and "User" memory.
 - **FR-003**: Project memory MUST be stored in `AGENTS.md` in the current working directory.
-- **FR-004**: User memory MUST be stored in a global file (e.g., `~/.wave/memory.md`).
+- **FR-004**: User memory MUST be stored in a global file (e.g., `~/.wave/AGENTS.md`).
 - **FR-005**: Memory entries MUST be stored in Markdown bullet point format.
 - **FR-006**: System MUST combine project, user, and auto-memory and include it in the AI's system prompt for every request.
 - **FR-007**: System SHOULD provide a way to deduplicate memory entries.
@@ -102,9 +101,6 @@ As a user, I want the agent to automatically remember important information acro
     - `content`: The text of the memory.
     - `type`: "Project" or "User".
     - `source`: The file path where it's stored.
-- **MemorySelectorState**: The state of the memory type selector in `InputManager`.
-    - `isActive`: Whether the selector is visible.
-    - `message`: The memory content to be saved.
 
 ## Assumptions
 

--- a/specs/018-memory-management-spec/tasks.md
+++ b/specs/018-memory-management-spec/tasks.md
@@ -18,7 +18,7 @@
 
 - [X] T001 Research existing memory service and manager logic
 - [X] T002 Document Project vs. User memory distinction in spec.md
-- [X] T003 Document the `#` trigger and saving flow in spec.md
+- [X] T003 Document the memory saving flow in spec.md
 - [X] T004 Define data models and storage formats in data-model.md
 
 ---
@@ -28,7 +28,6 @@
 **Purpose**: Core infrastructure that MUST be complete before ANY user story can be implemented
 
 - [X] T005 [P] Create unit test file for memory service in `packages/agent-sdk/tests/services/memory.test.ts`
-- [ ] T006 [P] Create unit test file for `MemoryTypeSelector` component in `packages/code/tests/components/MemoryTypeSelector.test.tsx`
 
 **Checkpoint**: Foundation ready - user story implementation can now begin in parallel
 
@@ -36,21 +35,20 @@
 
 ## Phase 3: User Story 1 & 2 - Save Memory (Priority: P1) 🎯 MVP
 
-**Goal**: Enable saving project and user memory via `#` trigger.
+**Goal**: Enable saving project and user memory.
 
-**Independent Test**: Type `# test memory` and verify it can be saved to either project or user storage.
+**Independent Test**: Ask the agent to remember something and verify it can be saved to either project or user storage.
 
 ### Tests for User Story 1 & 2 (REQUIRED) ⚠️
 
-- [X] T007 [US1,US2] Write failing tests for `#` trigger detection
+- [X] T007 [US1,US2] Write failing tests for memory saving detection
 - [X] T008 [US1,US2] Write failing tests for file writing (Project vs User)
 
 ### Implementation for User Story 1 & 2
 
-- [X] T009 [US1,US2] Implement `#` trigger detection in `packages/code/src/managers/InputManager.ts`
-- [X] T010 [US1,US2] Implement `MemoryTypeSelector` component in `packages/code/src/components/MemoryTypeSelector.tsx`
-- [X] T011 [US1,US2] Implement memory saving logic in `packages/agent-sdk/src/services/memory.ts`
-- [X] T012 [US1,US2] Integrate memory retrieval into `packages/agent-sdk/src/managers/aiManager.ts`
+- [X] T009 [US1,US2] Implement memory saving detection in `packages/agent-sdk/src/prompts/autoMemory.ts`
+- [X] T010 [US1,US2] Implement memory saving logic in `packages/agent-sdk/src/services/memory.ts`
+- [X] T011 [US1,US2] Integrate memory retrieval into `packages/agent-sdk/src/managers/aiManager.ts`
 
 **Checkpoint**: User Stories 1 and 2 are fully functional and testable independently.
 


### PR DESCRIPTION
This PR updates the 018-memory-management-spec to reflect changes in the implementation plan:
- Removed the '#' trigger requirement.
- Removed the MemoryTypeSelector UI component.
- Updated the global memory path to ~/.wave/AGENTS.md.
- Updated tasks and data models accordingly.