### PR TITLE
fix: improve message compression failure handling and increase max tokens

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -285,6 +285,9 @@ export class AIManager {
           );
         } catch (compressError) {
           logger?.error("Failed to compress messages:", compressError);
+          this.messageManager.addErrorBlock(
+            `Failed to compress conversation history: ${compressError instanceof Error ? compressError.message : String(compressError)}. You may encounter context limit issues.`,
+          );
         } finally {
           this.setIsCompressing(false);
         }

--- a/packages/agent-sdk/src/services/aiService.ts
+++ b/packages/agent-sdk/src/services/aiService.ts
@@ -778,7 +778,7 @@ export async function compressMessages(
   // Get model configuration - use injected agent model
   const openaiModelConfig = getModelConfig(options.model || modelConfig.model, {
     temperature: 0.1,
-    max_tokens: 2048,
+    max_tokens: 8192,
   });
 
   try {
@@ -802,9 +802,12 @@ export async function compressMessages(
       },
     );
 
-    const content =
-      response.choices[0]?.message?.content?.trim() ||
-      "Failed to compress conversation history";
+    const content = response.choices[0]?.message?.content?.trim();
+    if (!content) {
+      throw new Error(
+        "Failed to compress conversation history: Empty response from AI",
+      );
+    }
     const usage = response.usage
       ? {
           prompt_tokens: response.usage.prompt_tokens,
@@ -823,9 +826,6 @@ export async function compressMessages(
       throw new Error("Compression request was aborted");
     }
     logger.error("Failed to compress messages:", error);
-    return {
-      content: "Failed to compress conversation history",
-      usage: undefined,
-    };
+    throw error;
   }
 }

--- a/packages/agent-sdk/tests/agent/agent.compression.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.compression.test.ts
@@ -229,6 +229,8 @@ describe("Agent Message Compression Tests", () => {
       messages: [...messages, newUserMessage],
     });
 
+    const initialSessionId = agent.sessionId;
+
     // Mock AI service
     const mockCallAgent = vi.mocked(aiService.callAgent);
     const mockCompressMessages = vi.mocked(aiService.compressMessages);
@@ -254,8 +256,29 @@ describe("Agent Message Compression Tests", () => {
     expect(mockCallAgent).toHaveBeenCalledTimes(1);
     expect(mockCompressMessages).toHaveBeenCalledTimes(1);
 
-    // Verify even if compression fails, AI call still succeeds (no exception thrown)
-    // If no exception thrown here, error handling is correct
+    // Verify that an error block was added to the messages
+    const lastMessage = agent.messages[agent.messages.length - 1];
+    expect(lastMessage.blocks.some((block) => block.type === "error")).toBe(
+      true,
+    );
+    const errorBlock = lastMessage.blocks.find(
+      (block) => block.type === "error",
+    ) as {
+      type: "error";
+      content: string;
+    };
+    expect(errorBlock.content).toContain(
+      "Failed to compress conversation history: Compression failed",
+    );
+
+    // Verify session ID remains unchanged (no reset)
+    expect(agent.sessionId).toBe(initialSessionId);
+
+    // Verify no "compress" block was added
+    const hasCompressBlock = agent.messages.some((msg) =>
+      msg.blocks.some((block) => block.type === "compress"),
+    );
+    expect(hasCompressBlock).toBe(false);
   });
 
   it("should compress all messages when session already contains compression", async () => {

--- a/packages/agent-sdk/tests/services/aiService.compress.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.compress.test.ts
@@ -74,7 +74,7 @@ describe("AI Service - CompressMessages", () => {
       compressMessages = aiService.compressMessages;
     });
 
-    it("should use max_tokens of 2048 and temperature of 0.1", async () => {
+    it("should use max_tokens of 8192 and temperature of 0.1", async () => {
       const messages = [
         {
           role: "user" as const,
@@ -97,7 +97,7 @@ describe("AI Service - CompressMessages", () => {
       // Verify model configuration
       expect(callArgs.model).toBe(TEST_MODEL_CONFIG.model);
       expect(callArgs.temperature).toBe(0.1);
-      expect(callArgs.max_tokens).toBe(2048);
+      expect(callArgs.max_tokens).toBe(8192);
       expect(callArgs.stream).toBe(false);
     });
 
@@ -207,7 +207,7 @@ describe("AI Service - CompressMessages", () => {
       expect(callOptions.signal).toBe(abortController.signal);
     });
 
-    it("should return fallback message when API response is empty", async () => {
+    it("should throw error when API response is empty", async () => {
       mockCreate.mockResolvedValueOnce({
         choices: [
           {
@@ -225,17 +225,20 @@ describe("AI Service - CompressMessages", () => {
         },
       ];
 
-      const result = await compressMessages({
-        gatewayConfig: TEST_GATEWAY_CONFIG,
-        modelConfig: TEST_MODEL_CONFIG,
-        messages,
-      });
-
-      expect(result.content).toBe("Failed to compress conversation history");
+      await expect(
+        compressMessages({
+          gatewayConfig: TEST_GATEWAY_CONFIG,
+          modelConfig: TEST_MODEL_CONFIG,
+          messages,
+        }),
+      ).rejects.toThrow(
+        "Failed to compress conversation history: Empty response from AI",
+      );
     });
 
-    it("should handle API errors gracefully", async () => {
-      mockCreate.mockRejectedValueOnce(new Error("API Error"));
+    it("should throw API errors", async () => {
+      const apiError = new Error("API Error");
+      mockCreate.mockRejectedValueOnce(apiError);
 
       const messages = [
         {
@@ -244,13 +247,13 @@ describe("AI Service - CompressMessages", () => {
         },
       ];
 
-      const result = await compressMessages({
-        gatewayConfig: TEST_GATEWAY_CONFIG,
-        modelConfig: TEST_MODEL_CONFIG,
-        messages,
-      });
-
-      expect(result.content).toBe("Failed to compress conversation history");
+      await expect(
+        compressMessages({
+          gatewayConfig: TEST_GATEWAY_CONFIG,
+          modelConfig: TEST_MODEL_CONFIG,
+          messages,
+        }),
+      ).rejects.toThrow("API Error");
     });
 
     it("should handle abort errors", async () => {

--- a/packages/agent-sdk/tests/services/aiService.coverage.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.coverage.test.ts
@@ -174,16 +174,17 @@ describe("AI Service - Branch Coverage", () => {
   });
 
   describe("compressMessages", () => {
-    it("should return default message on failure", async () => {
+    it("should throw error on failure", async () => {
       mockCreate.mockRejectedValue(new Error("API Error"));
 
-      const result = await compressMessages({
-        gatewayConfig: TEST_GATEWAY_CONFIG,
-        modelConfig: TEST_MODEL_CONFIG,
-        messages: [],
-      });
+      await expect(
+        compressMessages({
+          gatewayConfig: TEST_GATEWAY_CONFIG,
+          modelConfig: TEST_MODEL_CONFIG,
+          messages: [],
+        }),
+      ).rejects.toThrow("API Error");
 
-      expect(result.content).toBe("Failed to compress conversation history");
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining("Failed to compress messages"),
         expect.any(Error),

--- a/packages/agent-sdk/tests/services/aiService.rateLimit.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.rateLimit.test.ts
@@ -48,7 +48,7 @@ describe("AI Service - Rate Limiting", () => {
 
     // Reset mock and set default behavior
     mockCreate.mockReset();
-    const mockWithResponse = vi.fn().mockResolvedValue({
+    const mockResponse = {
       data: {
         choices: [
           { message: { content: "Test response" }, finish_reason: "stop" },
@@ -56,8 +56,11 @@ describe("AI Service - Rate Limiting", () => {
         usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
       },
       response: { headers: new Map() },
+    };
+    mockCreate.mockReturnValue({
+      withResponse: vi.fn().mockResolvedValue(mockResponse),
+      then: (resolve: (value: unknown) => void) => resolve(mockResponse.data),
     });
-    mockCreate.mockReturnValue({ withResponse: mockWithResponse });
 
     const aiService = await import("@/services/aiService.js");
     callAgent = aiService.callAgent;
@@ -102,11 +105,13 @@ describe("AI Service - Rate Limiting", () => {
     const callTimes: number[] = [];
     mockCreate.mockImplementation(() => {
       callTimes.push(Date.now());
+      const mockResponse = {
+        data: { choices: [] },
+        response: { headers: new Map() },
+      };
       return {
-        withResponse: vi.fn().mockResolvedValue({
-          data: { choices: [] },
-          response: { headers: new Map() },
-        }),
+        withResponse: vi.fn().mockResolvedValue(mockResponse),
+        then: (resolve: (value: unknown) => void) => resolve(mockResponse.data),
       };
     });
 


### PR DESCRIPTION
This PR improves the robustness of message compression:
- Increases max_tokens for compression from 2048 to 8192.
- Changes compressMessages to throw errors on failure or empty responses instead of returning a fallback string.
- Updates AIManager to catch these errors and add an error block to the conversation history, informing the user of potential context limit issues.
- Updates relevant tests to verify error handling and the new token limit.