### PR TITLE
fix(code): improve rendering of expanded messages and reasoning blocks

### DIFF
--- a/packages/code/src/components/MessageBlockItem.tsx
+++ b/packages/code/src/components/MessageBlockItem.tsx
@@ -35,8 +35,11 @@ export const MessageBlockItem = ({
               ~{" "}
             </Text>
           )}
-          {message.role === "user" ? (
-            <Text backgroundColor="gray" color="white">
+          {message.role === "user" || isExpanded ? (
+            <Text
+              backgroundColor={message.role === "user" ? "gray" : undefined}
+              color="white"
+            >
               {block.content}
             </Text>
           ) : (
@@ -77,7 +80,9 @@ export const MessageBlockItem = ({
         <CompressDisplay block={block} isExpanded={isExpanded} />
       )}
 
-      {block.type === "reasoning" && <ReasoningDisplay block={block} />}
+      {block.type === "reasoning" && (
+        <ReasoningDisplay block={block} isExpanded={isExpanded} />
+      )}
     </Box>
   );
 };

--- a/packages/code/src/components/ReasoningDisplay.tsx
+++ b/packages/code/src/components/ReasoningDisplay.tsx
@@ -1,14 +1,16 @@
 import React from "react";
-import { Box } from "ink";
+import { Box, Text } from "ink";
 import type { ReasoningBlock } from "wave-agent-sdk";
 import { Markdown } from "./Markdown.js";
 
 interface ReasoningDisplayProps {
   block: ReasoningBlock;
+  isExpanded?: boolean;
 }
 
 export const ReasoningDisplay: React.FC<ReasoningDisplayProps> = ({
   block,
+  isExpanded = false,
 }) => {
   const { content } = block;
 
@@ -26,7 +28,11 @@ export const ReasoningDisplay: React.FC<ReasoningDisplayProps> = ({
       paddingLeft={1}
     >
       <Box flexDirection="column">
-        <Markdown>{content}</Markdown>
+        {isExpanded ? (
+          <Text color="white">{content}</Text>
+        ) : (
+          <Markdown>{content}</Markdown>
+        )}
       </Box>
     </Box>
   );

--- a/packages/code/src/components/ToolDisplay.tsx
+++ b/packages/code/src/components/ToolDisplay.tsx
@@ -129,8 +129,8 @@ export const ToolDisplay: React.FC<ToolDisplayProps> = ({
         </Box>
       )}
 
-      {/* Diff display - only show after tool execution completes and was successful */}
-      {stage === "end" && success && (
+      {/* Diff display - only show after tool execution completes and was successful, and NOT in expanded mode */}
+      {!isExpanded && stage === "end" && success && (
         <DiffDisplay
           toolName={name}
           parameters={parameters}


### PR DESCRIPTION
This PR improves the rendering of messages and reasoning blocks when they are in the expanded state.

Key changes:
- Updated MessageBlockItem to handle isExpanded for user messages and reasoning blocks.
- Added isExpanded prop to ReasoningDisplay to toggle between Text and Markdown.
- Hidden DiffDisplay in ToolDisplay when isExpanded is true.