### PR TITLE
Implement user message queuing during AI thinking

### DIFF
--- a/packages/code/src/components/ChatInterface.tsx
+++ b/packages/code/src/components/ChatInterface.tsx
@@ -4,6 +4,7 @@ import { MessageList } from "./MessageList.js";
 import { InputBox } from "./InputBox.js";
 import { LoadingIndicator } from "./LoadingIndicator.js";
 import { TaskList } from "./TaskList.js";
+import { QueuedMessageList } from "./QueuedMessageList.js";
 import { ConfirmationDetails } from "./ConfirmationDetails.js";
 import { ConfirmationSelector } from "./ConfirmationSelector.js";
 
@@ -160,17 +161,20 @@ export const ChatInterface: React.FC = () => {
       )}
 
       {!isConfirmationVisible && !isExpanded && (
-        <InputBox
-          isLoading={isLoading}
-          isCommandRunning={isCommandRunning}
-          sendMessage={sendMessage}
-          abortMessage={abortMessage}
-          mcpServers={mcpServers}
-          connectMcpServer={connectMcpServer}
-          disconnectMcpServer={disconnectMcpServer}
-          slashCommands={slashCommands}
-          hasSlashCommand={hasSlashCommand}
-        />
+        <>
+          <QueuedMessageList />
+          <InputBox
+            isLoading={isLoading}
+            isCommandRunning={isCommandRunning}
+            sendMessage={sendMessage}
+            abortMessage={abortMessage}
+            mcpServers={mcpServers}
+            connectMcpServer={connectMcpServer}
+            disconnectMcpServer={disconnectMcpServer}
+            slashCommands={slashCommands}
+            hasSlashCommand={hasSlashCommand}
+          />
+        </>
       )}
     </Box>
   );

--- a/packages/code/src/components/InputBox.tsx
+++ b/packages/code/src/components/InputBox.tsx
@@ -41,8 +41,6 @@ export interface InputBoxProps {
 }
 
 export const InputBox: React.FC<InputBoxProps> = ({
-  isLoading = false,
-  isCommandRunning = false,
   sendMessage = () => {},
   abortMessage = () => {},
   mcpServers = [],
@@ -119,14 +117,7 @@ export const InputBox: React.FC<InputBoxProps> = ({
 
   // Use the InputManager's unified input handler
   useInput(async (input, key) => {
-    await handleInput(
-      input,
-      key,
-      attachedImages,
-      isLoading,
-      isCommandRunning,
-      clearImages,
-    );
+    await handleInput(input, key, attachedImages, clearImages);
   });
 
   const handleRewindCancel = () => {

--- a/packages/code/src/components/QueuedMessageList.tsx
+++ b/packages/code/src/components/QueuedMessageList.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { useChat } from "../contexts/useChat.js";
+import { Box, Text } from "ink";
+
+export const QueuedMessageList: React.FC = () => {
+  const { queuedMessages = [], isTaskListVisible } = useChat();
+
+  if (queuedMessages.length === 0 || !isTaskListVisible) {
+    return null;
+  }
+
+  return (
+    <Box flexDirection="column">
+      {queuedMessages.map((msg, index) => {
+        const content = msg.content.trim();
+        const hasImages = msg.images && msg.images.length > 0;
+        const displayText = content || (hasImages ? "[Images]" : "");
+
+        return (
+          <Box key={index}>
+            <Text color="gray" italic>
+              {displayText.length > 60
+                ? `${displayText.substring(0, 57)}...`
+                : displayText}
+            </Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+};

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -37,6 +37,10 @@ export interface ChatContextType {
   isExpanded: boolean;
   isTaskListVisible: boolean;
   setIsTaskListVisible: (visible: boolean) => void;
+  queuedMessages: Array<{
+    content: string;
+    images?: Array<{ path: string; mimeType: string }>;
+  }>;
   // AI functionality
   sessionId: string;
   sendMessage: (
@@ -138,6 +142,13 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   }, [isExpanded]);
 
   const [isTaskListVisible, setIsTaskListVisible] = useState(true);
+
+  const [queuedMessages, setQueuedMessages] = useState<
+    Array<{
+      content: string;
+      images?: Array<{ path: string; mimeType: string }>;
+    }>
+  >([]);
 
   // AI State
   const [messages, setMessages] = useState<Message[]>([]);
@@ -393,6 +404,11 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
 
       if (!hasTextContent && !hasImageAttachments) return;
 
+      if (isLoading || isCommandRunning) {
+        setQueuedMessages((prev) => [...prev, { content, images }]);
+        return;
+      }
+
       try {
         // Handle bash mode - check if it's a bash command (starts with ! and only one line)
         if (content.startsWith("!") && !content.includes("\n")) {
@@ -432,8 +448,17 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         // Loading state will be automatically updated by the useEffect that watches messages
       }
     },
-    [],
+    [isLoading, isCommandRunning],
   );
+
+  // Process queued messages when idle
+  useEffect(() => {
+    if (!isLoading && !isCommandRunning && queuedMessages.length > 0) {
+      const nextMessage = queuedMessages[0];
+      setQueuedMessages((prev) => prev.slice(1));
+      sendMessage(nextMessage.content, nextMessage.images);
+    }
+  }, [isLoading, isCommandRunning, queuedMessages, sendMessage]);
 
   // Unified interrupt method, interrupt both AI messages and command execution
   const abortMessage = useCallback(() => {
@@ -441,6 +466,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   }, []);
 
   const clearMessages = useCallback(() => {
+    setQueuedMessages([]);
     agentRef.current?.clearMessages();
   }, []);
 
@@ -604,6 +630,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
     isExpanded,
     isTaskListVisible,
     setIsTaskListVisible,
+    queuedMessages,
     sessionId,
     sendMessage,
     abortMessage,

--- a/packages/code/src/hooks/useInputManager.ts
+++ b/packages/code/src/hooks/useInputManager.ts
@@ -326,15 +326,11 @@ export const useInputManager = (
   const handleSubmit = useCallback(
     async (
       attachedImages: Array<{ id: number; path: string; mimeType: string }>,
-      isLoading: boolean = false,
-      isCommandRunning: boolean = false,
     ) => {
       await handlers.handleSubmit(
         stateRef.current,
         dispatch,
         callbacksRef.current,
-        isLoading,
-        isCommandRunning,
         attachedImages,
       );
     },
@@ -357,8 +353,6 @@ export const useInputManager = (
       input: string,
       key: Key,
       attachedImages: Array<{ id: number; path: string; mimeType: string }>,
-      isLoading: boolean = false,
-      isCommandRunning: boolean = false,
       clearImages?: () => void,
     ) => {
       return await handlers.handleInput(
@@ -367,8 +361,6 @@ export const useInputManager = (
         callbacksRef.current,
         input,
         key,
-        isLoading,
-        isCommandRunning,
         clearImages,
       );
     },

--- a/packages/code/src/managers/inputHandlers.ts
+++ b/packages/code/src/managers/inputHandlers.ts
@@ -30,18 +30,12 @@ export const handleSubmit = async (
   state: InputState,
   dispatch: React.Dispatch<InputAction>,
   callbacks: Partial<InputManagerCallbacks>,
-  isLoading: boolean = false,
-  isCommandRunning: boolean = false,
   attachedImagesOverride?: Array<{
     id: number;
     path: string;
     mimeType: string;
   }>,
 ): Promise<void> => {
-  if (isLoading || isCommandRunning) {
-    return;
-  }
-
   if (state.inputText.trim()) {
     const imageRegex = /\[Image #(\d+)\]/g;
     const matches = [...state.inputText.matchAll(imageRegex)];
@@ -390,12 +384,10 @@ export const handleNormalInput = async (
   callbacks: Partial<InputManagerCallbacks>,
   input: string,
   key: Key,
-  isLoading: boolean = false,
-  isCommandRunning: boolean = false,
   clearImages?: () => void,
 ): Promise<boolean> => {
   if (key.return) {
-    await handleSubmit(state, dispatch, callbacks, isLoading, isCommandRunning);
+    await handleSubmit(state, dispatch, callbacks);
     clearImages?.();
     return true;
   }
@@ -475,8 +467,6 @@ export const handleInput = async (
   callbacks: Partial<InputManagerCallbacks>,
   input: string,
   key: Key,
-  isLoading: boolean = false,
-  isCommandRunning: boolean = false,
   clearImages?: () => void,
 ): Promise<boolean> => {
   if (state.selectorJustUsed) {
@@ -485,7 +475,6 @@ export const handleInput = async (
 
   if (key.escape) {
     if (
-      (isLoading || isCommandRunning) &&
       !(
         state.showFileSelector ||
         state.showCommandSelector ||
@@ -559,8 +548,6 @@ export const handleInput = async (
       callbacks,
       input,
       key,
-      isLoading,
-      isCommandRunning,
       clearImages,
     );
   }

--- a/packages/code/tests/managers/inputHandlers.test.ts
+++ b/packages/code/tests/managers/inputHandlers.test.ts
@@ -80,14 +80,6 @@ describe("inputHandlers", () => {
   });
 
   describe("handleSubmit", () => {
-    it("should not submit if loading or command is running", async () => {
-      await handleSubmit(initialState, dispatch, callbacks, true, false);
-      expect(callbacks.onSendMessage).not.toHaveBeenCalled();
-
-      await handleSubmit(initialState, dispatch, callbacks, false, true);
-      expect(callbacks.onSendMessage).not.toHaveBeenCalled();
-    });
-
     it("should submit text and clear input", async () => {
       const state: InputState = { ...initialState, inputText: "hello world" };
       await handleSubmit(state, dispatch, callbacks);
@@ -452,8 +444,6 @@ describe("inputHandlers", () => {
         callbacks,
         "",
         key,
-        false,
-        false,
         clearImages,
       );
 
@@ -538,17 +528,10 @@ describe("inputHandlers", () => {
       expect(callbacks.onSendMessage).not.toHaveBeenCalled();
     });
 
-    it("should handle escape to abort message when loading", async () => {
+    it("should handle escape to abort message", async () => {
       const state = { ...initialState };
       const key = { escape: true } as Key;
-      const result = await handleInput(
-        state,
-        dispatch,
-        callbacks,
-        "",
-        key,
-        true,
-      );
+      const result = await handleInput(state, dispatch, callbacks, "", key);
       expect(result).toBe(true);
       expect(callbacks.onAbortMessage).toHaveBeenCalled();
     });


### PR DESCRIPTION
This PR implements user message queuing during AI thinking.

Key changes:
- Add queuedMessages state and processing logic to useChat.tsx.
- Modify inputHandlers.ts to allow message submission while AI is busy.
- Create QueuedMessageList.tsx to display pending messages above the input box.
- Update ChatInterface.tsx to integrate the new queued message list.
- Refactor useInputManager.ts and InputBox.tsx to simplify input handling.
- Update unit tests in inputHandlers.test.ts.