### PR TITLE
feat: implement async hook execution and custom timeouts

### DIFF
--- a/.wave/settings.json
+++ b/.wave/settings.json
@@ -28,7 +28,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pnpm install && pnpm build"
+            "command": "pnpm install && pnpm build",
+            "async": true
           }
         ]
       }

--- a/packages/agent-sdk/examples/hooks/async-hook-settings.json
+++ b/packages/agent-sdk/examples/hooks/async-hook-settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'Starting background task...' && sleep 5 && echo 'Background task finished' > background_task.log",
+            "async": true,
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/agent-sdk/examples/hooks/test-async-hook.ts
+++ b/packages/agent-sdk/examples/hooks/test-async-hook.ts
@@ -1,0 +1,103 @@
+import { Agent } from "../../src/agent.js";
+import * as fs from "fs/promises";
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectDir = path.resolve(__dirname, "..");
+const logFile = path.join(projectDir, "background_task.log");
+
+async function main() {
+  console.log("Starting Async Hook Example...");
+
+  // Ensure log file doesn't exist
+  try {
+    await fs.unlink(logFile);
+  } catch {
+    // Ignore
+  }
+
+  const agent = await Agent.create({
+    model: "gemini-2.0-flash",
+    workdir: projectDir,
+    // We'll manually trigger the hook by simulating an Edit tool use
+  });
+
+  try {
+    console.log("Simulating PostToolUse hook for 'Edit' tool...");
+
+    // The HookManager is internal to the Agent, but we can trigger hooks
+    // by using the agent's internal hook manager if we had access,
+    // or by performing an action that triggers it.
+    // Since we want to test the ASYNC nature, we'll use the hookManager directly if possible
+    // or simulate the event.
+
+    const hookManager = (
+      agent as unknown as {
+        hookManager: {
+          loadConfiguration: (
+            userHooks: unknown,
+            projectHooks: unknown,
+          ) => void;
+          executeHooks: (event: string, context: unknown) => Promise<unknown[]>;
+        };
+      }
+    ).hookManager;
+
+    // Manually load the configuration for this test
+    const settingsPath = path.join(__dirname, "async-hook-settings.json");
+    const settings = JSON.parse(await fs.readFile(settingsPath, "utf-8"));
+    hookManager.loadConfiguration(undefined, settings.hooks);
+
+    const context = {
+      event: "PostToolUse",
+      toolName: "Edit",
+      projectDir: projectDir,
+      timestamp: new Date(),
+      sessionId: "test-session",
+    };
+
+    const startTime = Date.now();
+    console.log("Executing hooks...");
+    const results = await hookManager.executeHooks("PostToolUse", context);
+    const duration = Date.now() - startTime;
+
+    console.log(`Hook execution returned in ${duration}ms`);
+    console.log(
+      `Results length: ${results.length} (should be 0 for async hooks)`,
+    );
+
+    if (duration > 1000) {
+      console.error("FAIL: Hook execution blocked for too long!");
+    } else {
+      console.log("SUCCESS: Hook execution was non-blocking.");
+    }
+
+    console.log("Waiting 6 seconds for background task to complete...");
+    await new Promise((resolve) => setTimeout(resolve, 6000));
+
+    try {
+      const logContent = await fs.readFile(logFile, "utf-8");
+      console.log(`Log file content: ${logContent.trim()}`);
+      if (logContent.includes("Background task finished")) {
+        console.log("SUCCESS: Background task completed successfully.");
+      } else {
+        console.error("FAIL: Background task output not found in log.");
+      }
+    } catch {
+      console.error(
+        "FAIL: Log file was not created. Background task might have failed.",
+      );
+    }
+  } finally {
+    await agent.destroy();
+    // Cleanup
+    try {
+      await fs.unlink(logFile);
+    } catch {
+      // Ignore
+    }
+  }
+}
+
+main().catch(console.error);

--- a/packages/agent-sdk/src/managers/hookManager.ts
+++ b/packages/agent-sdk/src/managers/hookManager.ts
@@ -162,10 +162,31 @@ export class HookManager {
         const hookCommand = config.hooks[commandIndex];
 
         try {
+          const options = hookCommand.timeout
+            ? { timeout: hookCommand.timeout * 1000 }
+            : undefined;
+
+          if (hookCommand.async) {
+            // Execute async command without awaiting
+            executeCommand(hookCommand.command, context, options).catch(
+              (error) => {
+                const errorMessage =
+                  error instanceof Error
+                    ? error.message
+                    : "Unknown execution error";
+                logger?.error(
+                  `[HookManager] Async hook command ${commandIndex + 1} failed: ${errorMessage}`,
+                );
+              },
+            );
+            // Async hooks are not included in results to prevent blocking
+            continue;
+          }
+
           const result = await executeCommand(
             hookCommand.command,
             context,
-            undefined,
+            options,
           );
           results.push(result);
 

--- a/packages/agent-sdk/src/services/hook.ts
+++ b/packages/agent-sdk/src/services/hook.ts
@@ -101,8 +101,8 @@ export async function executeCommand(
   context: HookExecutionContext | ExtendedHookExecutionContext,
   options?: HookExecutionOptions,
 ): Promise<HookExecutionResult> {
-  const defaultTimeout = 10000; // 10 seconds
-  const maxTimeout = 300000; // 5 minutes
+  const defaultTimeout = 600000; // 10 minutes
+  const maxTimeout = 600000; // 10 minutes
   const skipExecution =
     process.env.NODE_ENV === "test" &&
     process.env.TEST_HOOK_EXECUTION !== "true";

--- a/packages/agent-sdk/src/types/hooks.ts
+++ b/packages/agent-sdk/src/types/hooks.ts
@@ -26,6 +26,8 @@ export type HookEvent =
 export interface HookCommand {
   type: "command";
   command: string;
+  async?: boolean;
+  timeout?: number; // seconds
 }
 
 // Hook event configuration with optional pattern matching
@@ -104,15 +106,29 @@ export function isValidHookEvent(event: string): event is HookEvent {
 }
 
 export function isValidHookCommand(cmd: unknown): cmd is HookCommand {
-  return (
-    typeof cmd === "object" &&
-    cmd !== null &&
-    "type" in cmd &&
-    cmd.type === "command" &&
-    "command" in cmd &&
-    typeof cmd.command === "string" &&
-    cmd.command.length > 0
-  );
+  if (
+    typeof cmd !== "object" ||
+    cmd === null ||
+    !("type" in cmd) ||
+    cmd.type !== "command" ||
+    !("command" in cmd) ||
+    typeof cmd.command !== "string" ||
+    cmd.command.length === 0
+  ) {
+    return false;
+  }
+
+  const hookCmd = cmd as Record<string, unknown>;
+
+  if ("async" in hookCmd && typeof hookCmd.async !== "boolean") {
+    return false;
+  }
+
+  if ("timeout" in hookCmd && typeof hookCmd.timeout !== "number") {
+    return false;
+  }
+
+  return true;
 }
 
 export function isValidHookEventConfig(

--- a/packages/agent-sdk/tests/managers/hookManager.test.ts
+++ b/packages/agent-sdk/tests/managers/hookManager.test.ts
@@ -146,6 +146,45 @@ describe("HookManager", () => {
       expect(results[0].success).toBe(true);
     });
 
+    it("should execute async hooks without awaiting", async () => {
+      const waveConfig: WaveConfiguration = {
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: "Edit",
+              hooks: [
+                {
+                  type: "command",
+                  command: "async-hook",
+                  async: true,
+                  timeout: 5,
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      manager.loadConfigurationFromWaveConfig(waveConfig);
+
+      const context: HookExecutionContext = {
+        event: "PostToolUse",
+        projectDir: "/test",
+        timestamp: new Date(),
+        toolName: "Edit",
+      };
+
+      const results = await manager.executeHooks("PostToolUse", context);
+
+      // Async hooks should not be in results
+      expect(results).toHaveLength(0);
+
+      // executeCommand should have been called with correct options
+      expect(mockExecuteCommand).toHaveBeenCalledWith("async-hook", context, {
+        timeout: 5000,
+      });
+    });
+
     it("should return empty array when no hooks configured", async () => {
       const context: HookExecutionContext = {
         event: "UserPromptSubmit", // Use event that doesn't require toolName

--- a/packages/agent-sdk/tests/services/hook.test.ts
+++ b/packages/agent-sdk/tests/services/hook.test.ts
@@ -231,6 +231,41 @@ describe("Hook Services", () => {
       expect(result.timedOut).toBe(true);
       vi.useRealTimers();
     });
+
+    it("should use new default timeout of 10 minutes", async () => {
+      vi.useFakeTimers();
+      const mockProcess = new MockChildProcess();
+      mockProcess.stdin = new MockStdin();
+      mockSpawn.mockReturnValue(mockProcess);
+
+      const resultPromise = executeCommand("sleep 601", mockContext);
+
+      // Advance by 10 minutes (600,000 ms)
+      vi.advanceTimersByTime(600001);
+
+      const result = await resultPromise;
+
+      expect(result.timedOut).toBe(true);
+      vi.useRealTimers();
+    });
+
+    it("should cap timeout at 10 minutes", async () => {
+      vi.useFakeTimers();
+      const mockProcess = new MockChildProcess();
+      mockProcess.stdin = new MockStdin();
+      mockSpawn.mockReturnValue(mockProcess);
+
+      const resultPromise = executeCommand("sleep 1000", mockContext, {
+        timeout: 1200000, // 20 minutes
+      });
+
+      vi.advanceTimersByTime(600001);
+
+      const result = await resultPromise;
+
+      expect(result.timedOut).toBe(true);
+      vi.useRealTimers();
+    });
   });
 
   describe("command safety validation", () => {

--- a/specs/005-hooks-support/contracts/hooks-api.md
+++ b/specs/005-hooks-support/contracts/hooks-api.md
@@ -17,6 +17,8 @@ type HookEvent = 'PreToolUse' | 'PostToolUse' | 'UserPromptSubmit' | 'Stop';
 interface HookCommand {
   type: 'command';
   command: string;
+  async?: boolean;
+  timeout?: number; // seconds
 }
 
 // Hook event configuration
@@ -80,7 +82,7 @@ interface HookExecutionResult {
 
 // Hook execution options
 interface HookExecutionOptions {
-  timeout?: number; // milliseconds, default 10000
+  timeout?: number; // milliseconds, default 600000 (10 minutes)
   cwd?: string; // working directory, defaults to projectDir
 }
 ```

--- a/specs/005-hooks-support/data-model.md
+++ b/specs/005-hooks-support/data-model.md
@@ -46,6 +46,8 @@
 **Fields**:
 - `type: "command"` - Command type (currently only "command" supported)  
 - `command: string` - Bash command to execute
+- `async?: boolean` - Whether to execute in background (default: false)
+- `timeout?: number` - Custom timeout in seconds (default: 600)
 
 **Validation Rules**:
 - type must be "command"

--- a/specs/005-hooks-support/quickstart.md
+++ b/specs/005-hooks-support/quickstart.md
@@ -26,6 +26,8 @@ export type HookEvent = 'PreToolUse' | 'PostToolUse' | 'UserPromptSubmit' | 'Sto
 export interface HookCommand {
   type: 'command';
   command: string;
+  async?: boolean;
+  timeout?: number; // seconds
 }
 
 export interface HookEventConfig {
@@ -171,6 +173,27 @@ export class Agent {
           {
             "type": "command",
             "command": "\"$WAVE_PROJECT_DIR\"/.wave/hooks/cleanup.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Async Background Hook
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npm test",
+            "async": true,
+            "timeout": 300
           }
         ]
       }

--- a/specs/005-hooks-support/spec.md
+++ b/specs/005-hooks-support/spec.md
@@ -128,6 +128,22 @@ A developer creates a Stop hook to perform cleanup actions when a session ends. 
 
 ---
 
+### User Story 9 - Async Hook Execution (Priority: P2)
+
+As a developer, I want to run long-running tasks like tests or background analysis as hooks without blocking Wave's response, so that I can continue my interaction while the tasks execute in the background.
+
+**Why this priority**: Enables powerful background workflows without sacrificing the responsiveness of the AI agent.
+
+**Independent Test**: Can be tested by configuring an async hook with a `sleep` command and verifying that Wave continues immediately without waiting for the sleep to complete.
+
+**Acceptance Scenarios**:
+
+1. **Given** an async hook is configured with `async: true`, **When** the triggering event occurs, **Then** the hook command starts executing in the background and Wave continues its workflow immediately.
+2. **Given** an async hook with a custom `timeout`, **When** the hook executes, **Then** it is allowed to run up to the specified timeout before being terminated.
+3. **Given** an async hook produces output, **When** it completes, **Then** its output is logged but not delivered to the conversation.
+
+---
+
 ### Edge Cases
 
 - What happens when a hook command fails or times out?
@@ -163,6 +179,9 @@ A developer creates a Stop hook to perform cleanup actions when a session ends. 
 - **FR-019**: System MUST maintain backward compatibility with existing hooks that don't expect JSON input
 - **FR-020**: System MUST organize hook components according to Constitution VII: HookManager in managers/, executor and settings as functions in services/hook.ts, matcher in utils/hookMatcher.ts, and types in types/hooks.ts.
 - **FR-021**: System MUST ensure test file structure mirrors the source code structure.
+- **FR-022**: System MUST support `async` field in hook configuration to allow background execution.
+- **FR-023**: System MUST support `timeout` field (in seconds) in hook configuration to override the default 10-minute timeout.
+- **FR-024**: System MUST NOT deliver stdout/stderr from async hooks to the conversation to prevent unexpected message injections from background tasks.
 
 ### Key Entities
 


### PR DESCRIPTION
This PR implements async hook execution and custom timeouts for hooks.

Key changes:
- Support for 'async' field in hook configuration for background execution.
- Support for 'timeout' field (in seconds) to override default hook timeout.
- Increased default and max hook timeout to 10 minutes.
- Updated HookManager to handle async execution without blocking.
- Updated documentation and specifications.
- Added examples and tests.