### PR TITLE
feat(code): allow slash command selector after space

### DIFF
--- a/packages/code/src/managers/inputHandlers.ts
+++ b/packages/code/src/managers/inputHandlers.ts
@@ -123,7 +123,10 @@ const SELECTOR_TRIGGERS = [
       pos: number,
       text: string,
       state: InputState,
-    ) => char === "/" && !state.showFileSelector && pos === 1,
+    ) =>
+      char === "/" &&
+      !state.showFileSelector &&
+      (pos === 1 || /\s/.test(text[pos - 2])),
   },
 ] as const;
 
@@ -157,14 +160,16 @@ export const getSlashSelectorPosition = (
   text: string,
   cursorPosition: number,
 ): number => {
-  if (text.startsWith("/") && cursorPosition > 0) {
-    let i = 0;
-    while (i < text.length && !/\s/.test(text[i])) {
-      i++;
+  let i = cursorPosition - 1;
+  while (i >= 0 && !/\s/.test(text[i])) {
+    if (text[i] === "/") {
+      // Check if this / is at the start or preceded by whitespace
+      if (i === 0 || /\s/.test(text[i - 1])) {
+        return i;
+      }
+      break;
     }
-    if (cursorPosition <= i) {
-      return 0;
-    }
+    i--;
   }
   return -1;
 };

--- a/packages/code/tests/managers/inputHandlers.test.ts
+++ b/packages/code/tests/managers/inputHandlers.test.ts
@@ -128,8 +128,12 @@ describe("inputHandlers", () => {
       expect(getSlashSelectorPosition("/help ", 6)).toBe(-1);
     });
 
-    it("should return -1 if / is not at start of input", () => {
-      expect(getSlashSelectorPosition("test /help", 7)).toBe(-1);
+    it("should return position if / is preceded by space", () => {
+      expect(getSlashSelectorPosition("test /help", 10)).toBe(5);
+    });
+
+    it("should return -1 if / is not at start of word", () => {
+      expect(getSlashSelectorPosition("test/help", 7)).toBe(-1);
     });
   });
 
@@ -317,8 +321,17 @@ describe("inputHandlers", () => {
       });
     });
 
-    it("should not activate command selector on / if not at start", () => {
+    it("should activate command selector on / after space", () => {
       const state = { ...initialState, inputText: "test ", cursorPosition: 5 };
+      processSelectorInput(state, dispatch, "/");
+      expect(dispatch).toHaveBeenCalledWith({
+        type: "ACTIVATE_COMMAND_SELECTOR",
+        payload: 5,
+      });
+    });
+
+    it("should not activate command selector on / after non-whitespace char", () => {
+      const state = { ...initialState, inputText: "test", cursorPosition: 4 };
       processSelectorInput(state, dispatch, "/");
       expect(dispatch).not.toHaveBeenCalledWith({
         type: "ACTIVATE_COMMAND_SELECTOR",


### PR DESCRIPTION
Enable command selector activation at any position in the input, provided it's at the start or preceded by a space. Updated activation logic and position detection in inputHandlers.ts and added corresponding tests.