### PR TITLE
fix(code): clear queued messages on abortMessage

### DIFF
--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -462,6 +462,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
 
   // Unified interrupt method, interrupt both AI messages and command execution
   const abortMessage = useCallback(() => {
+    setQueuedMessages([]);
     agentRef.current?.abortMessage();
   }, []);
 

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -995,4 +995,51 @@ describe("ChatProvider", () => {
       expect(lastValue?.slashCommands).toEqual([]);
     });
   });
+
+  it("clears queuedMessages when abortMessage is called", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(lastValue).toBeDefined();
+    });
+
+    // Mock sendMessage to not resolve immediately
+    let resolveSendMessage: (value: void | PromiseLike<void>) => void;
+    const sendMessagePromise = new Promise<void>((resolve) => {
+      resolveSendMessage = resolve;
+    });
+    mockAgent.sendMessage.mockReturnValue(sendMessagePromise);
+
+    // Send first message to set isLoading to true
+    const firstSendMessage = lastValue?.sendMessage("First message");
+
+    await vi.waitFor(() => {
+      expect(lastValue?.isLoading).toBe(true);
+    });
+
+    // Send second message to queue it
+    lastValue?.sendMessage("Second message");
+
+    await vi.waitFor(() => {
+      expect(lastValue?.queuedMessages).toHaveLength(1);
+      expect(lastValue?.queuedMessages[0].content).toBe("Second message");
+    });
+
+    // Call abortMessage
+    lastValue?.abortMessage();
+
+    await vi.waitFor(() => {
+      expect(lastValue?.queuedMessages).toHaveLength(0);
+      expect(mockAgent.abortMessage).toHaveBeenCalled();
+    });
+
+    // Cleanup
+    resolveSendMessage!();
+    await firstSendMessage;
+  });
 });


### PR DESCRIPTION
This PR ensures that queued messages are cleared when the user interrupts the chat.

- Modified `abortMessage` in `packages/code/src/contexts/useChat.tsx` to clear `queuedMessages`
- Added test case in `packages/code/tests/contexts/useChat.test.tsx` to verify the fix