### PR TITLE
fix: close prompt history selector after selection

### DIFF
--- a/packages/code/src/managers/inputReducer.ts
+++ b/packages/code/src/managers/inputReducer.ts
@@ -434,6 +434,9 @@ export function inputReducer(
         history: [],
         originalInputText: "",
         originalLongTextMap: {},
+        showHistorySearch: false,
+        historySearchQuery: "",
+        selectorJustUsed: true,
       };
     }
     case "RESET_HISTORY_NAVIGATION":

--- a/packages/code/tests/managers/inputReducer.test.ts
+++ b/packages/code/tests/managers/inputReducer.test.ts
@@ -579,6 +579,9 @@ describe("inputReducer", () => {
       expect(state.longTextMap).toEqual({ "[LongText#1]": "selected long" });
       expect(state.historyIndex).toBe(-1);
       expect(state.history).toEqual([]);
+      expect(state.showHistorySearch).toBe(false);
+      expect(state.historySearchQuery).toBe("");
+      expect(state.selectorJustUsed).toBe(true);
     });
 
     it("should handle RESET_HISTORY_NAVIGATION", () => {


### PR DESCRIPTION
When a user selects a prompt from the history search (Ctrl+R) by pressing Enter, the prompt is inserted into the input field, but the history selector remains open. This commit updates the inputReducer to correctly close the selector and reset its state upon selection.

- Set showHistorySearch: false
- Clear historySearchQuery
- Set selectorJustUsed: true to prevent immediate message submission

Updated tests to verify these state changes.