### PR TITLE
feat(code): add loading state to file selector

### DIFF
--- a/packages/code/src/components/FileSelector.tsx
+++ b/packages/code/src/components/FileSelector.tsx
@@ -7,6 +7,7 @@ export { type FileItem } from "wave-agent-sdk";
 export interface FileSelectorProps {
   files: FileItem[];
   searchQuery: string;
+  isLoading?: boolean;
   onSelect: (filePath: string) => void;
   onCancel: () => void;
 }
@@ -14,6 +15,7 @@ export interface FileSelectorProps {
 export const FileSelector: React.FC<FileSelectorProps> = ({
   files,
   searchQuery,
+  isLoading = false,
   onSelect,
   onCancel,
 }) => {
@@ -48,13 +50,21 @@ export const FileSelector: React.FC<FileSelectorProps> = ({
       <Box
         flexDirection="column"
         borderStyle="single"
-        borderColor="yellow"
+        borderColor={isLoading ? "cyan" : "yellow"}
         borderBottom={false}
         borderLeft={false}
         borderRight={false}
       >
-        <Text color="yellow">No files found for "{searchQuery}"</Text>
-        <Text dimColor>Press Escape to cancel</Text>
+        {isLoading ? (
+          <Text color="cyan" bold>
+            Select File/Directory...
+          </Text>
+        ) : (
+          <>
+            <Text color="yellow">No files found for "{searchQuery}"</Text>
+            <Text dimColor>Press Escape to cancel</Text>
+          </>
+        )}
       </Box>
     );
   }

--- a/packages/code/src/components/InputBox.tsx
+++ b/packages/code/src/components/InputBox.tsx
@@ -71,6 +71,7 @@ export const InputBox: React.FC<InputBoxProps> = ({
     showFileSelector,
     filteredFiles,
     fileSearchQuery: searchQuery,
+    isFileSearching,
     handleFileSelect,
     handleCancelFileSelect,
     // Command selector
@@ -185,6 +186,7 @@ export const InputBox: React.FC<InputBoxProps> = ({
         <FileSelector
           files={filteredFiles}
           searchQuery={searchQuery}
+          isLoading={isFileSearching}
           onSelect={handleFileSelect}
           onCancel={handleCancelFileSelect}
         />

--- a/packages/code/src/hooks/useInputManager.ts
+++ b/packages/code/src/hooks/useInputManager.ts
@@ -41,10 +41,10 @@ export const useInputManager = (
   // Handle debounced file search
   useEffect(() => {
     if (state.showFileSelector) {
-      const debounceDelay = parseInt(
-        process.env.FILE_SELECTOR_DEBOUNCE_MS || "300",
-        10,
-      );
+      const debounceDelay =
+        state.fileSearchQuery === ""
+          ? 0
+          : parseInt(process.env.FILE_SELECTOR_DEBOUNCE_MS || "300", 10);
       const timer = setTimeout(async () => {
         try {
           const fileItems = await searchFilesUtil(state.fileSearchQuery);
@@ -372,6 +372,7 @@ export const useInputManager = (
     showFileSelector: state.showFileSelector,
     filteredFiles: state.filteredFiles,
     fileSearchQuery: state.fileSearchQuery,
+    isFileSearching: state.isFileSearching,
     atPosition: state.atPosition,
     showCommandSelector: state.showCommandSelector,
     commandSearchQuery: state.commandSearchQuery,

--- a/packages/code/src/managers/inputReducer.ts
+++ b/packages/code/src/managers/inputReducer.ts
@@ -70,6 +70,7 @@ export interface InputState {
   historyIndex: number;
   originalInputText: string;
   originalLongTextMap: Record<string, string>;
+  isFileSearching: boolean;
 }
 
 export const initialState: InputState = {
@@ -102,6 +103,7 @@ export const initialState: InputState = {
   historyIndex: -1,
   originalInputText: "",
   originalLongTextMap: {},
+  isFileSearching: false,
 };
 
 export type InputAction =
@@ -208,11 +210,20 @@ export function inputReducer(
         atPosition: action.payload,
         fileSearchQuery: "",
         filteredFiles: [],
+        isFileSearching: true,
       };
     case "SET_FILE_SEARCH_QUERY":
-      return { ...state, fileSearchQuery: action.payload };
+      return {
+        ...state,
+        fileSearchQuery: action.payload,
+        isFileSearching: true,
+      };
     case "SET_FILTERED_FILES":
-      return { ...state, filteredFiles: action.payload };
+      return {
+        ...state,
+        filteredFiles: action.payload,
+        isFileSearching: false,
+      };
     case "CANCEL_FILE_SELECTOR":
       return {
         ...state,
@@ -221,6 +232,7 @@ export function inputReducer(
         fileSearchQuery: "",
         filteredFiles: [],
         selectorJustUsed: true,
+        isFileSearching: false,
       };
     case "ACTIVATE_COMMAND_SELECTOR":
       return {

--- a/packages/code/tests/managers/inputReducer.test.ts
+++ b/packages/code/tests/managers/inputReducer.test.ts
@@ -38,6 +38,7 @@ describe("inputReducer", () => {
       historyIndex: -1,
       originalInputText: "",
       originalLongTextMap: {},
+      isFileSearching: false,
     });
   });
 
@@ -155,6 +156,7 @@ describe("inputReducer", () => {
     expect(state.atPosition).toBe(5);
     expect(state.fileSearchQuery).toBe("");
     expect(state.filteredFiles).toEqual([]);
+    expect(state.isFileSearching).toBe(true);
   });
 
   it("should handle SET_FILE_SEARCH_QUERY", () => {
@@ -163,15 +165,20 @@ describe("inputReducer", () => {
       payload: "test",
     });
     expect(state.fileSearchQuery).toBe("test");
+    expect(state.isFileSearching).toBe(true);
   });
 
   it("should handle SET_FILTERED_FILES", () => {
     const files: FileItem[] = [{ path: "test.ts", type: "file" }];
-    const state = inputReducer(initialState, {
-      type: "SET_FILTERED_FILES",
-      payload: files,
-    });
+    const state = inputReducer(
+      { ...initialState, isFileSearching: true },
+      {
+        type: "SET_FILTERED_FILES",
+        payload: files,
+      },
+    );
     expect(state.filteredFiles).toEqual(files);
+    expect(state.isFileSearching).toBe(false);
   });
 
   it("should handle CANCEL_FILE_SELECTOR", () => {
@@ -181,6 +188,7 @@ describe("inputReducer", () => {
       atPosition: 5,
       fileSearchQuery: "test",
       filteredFiles: [{ path: "test.ts", type: "file" }],
+      isFileSearching: true,
     };
     const state = inputReducer(stateWithSelector, {
       type: "CANCEL_FILE_SELECTOR",
@@ -190,6 +198,7 @@ describe("inputReducer", () => {
     expect(state.fileSearchQuery).toBe("");
     expect(state.filteredFiles).toEqual([]);
     expect(state.selectorJustUsed).toBe(true);
+    expect(state.isFileSearching).toBe(false);
   });
 
   it("should handle ACTIVATE_COMMAND_SELECTOR", () => {


### PR DESCRIPTION
This PR introduces a loading state to the file selector component in packages/code.

Key changes:
- Added isFileSearching state to inputReducer.
- Updated FileSelector to display a loading indicator when isLoading is true.
- Optimized useInputManager to skip debounce when the file search query is empty.
- Updated tests to cover the new state transitions.