### PR TITLE
Fix: Ensure Agent tool parameters persist when expanded

### DIFF
--- a/packages/agent-sdk/src/utils/messageOperations.ts
+++ b/packages/agent-sdk/src/utils/messageOperations.ts
@@ -220,12 +220,12 @@ export const updateToolBlockInMessage = ({
       if (toolBlockIndex !== -1) {
         const toolBlock = newMessages[i].blocks[toolBlockIndex];
         if (toolBlock.type === "tool") {
-          toolBlock.parameters = parameters;
+          if (parameters !== undefined) toolBlock.parameters = parameters;
           if (result !== undefined) toolBlock.result = result;
           if (shortResult !== undefined) toolBlock.shortResult = shortResult;
           if (startLineNumber !== undefined)
             toolBlock.startLineNumber = startLineNumber;
-          toolBlock.images = images; // Add image data update
+          if (images !== undefined) toolBlock.images = images; // Add image data update
           if (success !== undefined) toolBlock.success = success;
           if (error !== undefined) toolBlock.error = error;
           if (stage !== undefined) toolBlock.stage = stage;


### PR DESCRIPTION
The updateToolBlockInMessage function was incorrectly overwriting parameters and images with undefined during status updates. This caused the Agent tool's parameters (like the prompt) to disappear in the UI when expanded with Ctrl+O while the tool was still running. Modified packages/agent-sdk/src/utils/messageOperations.ts to only update these fields if they are explicitly provided.