### PR TITLE
fix: save prompts with placeholders to history to improve readability

### DIFF
--- a/packages/code/src/managers/inputHandlers.ts
+++ b/packages/code/src/managers/inputHandlers.ts
@@ -51,11 +51,16 @@ export const handleSubmit = async (
       )
       .map((img) => ({ path: img.path, mimeType: img.mimeType }));
 
-    let cleanContent = state.inputText.replace(imageRegex, "").trim();
-    cleanContent = expandLongTextPlaceholders(cleanContent, state.longTextMap);
+    const contentWithPlaceholders = state.inputText
+      .replace(imageRegex, "")
+      .trim();
+    const cleanContent = expandLongTextPlaceholders(
+      contentWithPlaceholders,
+      state.longTextMap,
+    );
 
     PromptHistoryManager.addEntry(
-      cleanContent,
+      contentWithPlaceholders,
       callbacks.sessionId,
       state.longTextMap,
     ).catch((err: unknown) => {

--- a/packages/code/tests/components/HistorySearch.test.tsx
+++ b/packages/code/tests/components/HistorySearch.test.tsx
@@ -122,6 +122,21 @@ describe("HistorySearch", () => {
     });
   });
 
+  it("should render history entries with placeholders", async () => {
+    const entriesWithPlaceholders = [
+      { prompt: "Check this: [LongText#1]", timestamp: 1000 },
+    ];
+    vi.mocked(PromptHistoryManager.searchHistory).mockResolvedValue(
+      entriesWithPlaceholders,
+    );
+    const { lastFrame } = render(<HistorySearch {...mockProps} />);
+
+    await vi.waitFor(() => {
+      const output = stripAnsiColors(lastFrame() || "");
+      expect(output).toContain("> Check this: [LongText#1]");
+    });
+  });
+
   it("should show empty state when no results", async () => {
     vi.mocked(PromptHistoryManager.searchHistory).mockResolvedValue([]);
     const { lastFrame } = render(

--- a/packages/code/tests/managers/inputHandlers.test.ts
+++ b/packages/code/tests/managers/inputHandlers.test.ts
@@ -141,8 +141,8 @@ describe("inputHandlers", () => {
     it("should submit text and clear input", async () => {
       const state: InputState = {
         ...initialState,
-        inputText: "hello world",
-        longTextMap: { "[LongText#1]": "long" },
+        inputText: "hello [LongText#1]",
+        longTextMap: { "[LongText#1]": "world" },
       };
       callbacks.sessionId = "session-1";
       await handleSubmit(state, dispatch, callbacks);
@@ -157,9 +157,9 @@ describe("inputHandlers", () => {
         type: "RESET_HISTORY_NAVIGATION",
       });
       expect(PromptHistoryManager.addEntry).toHaveBeenCalledWith(
-        "hello world",
+        "hello [LongText#1]",
         "session-1",
-        { "[LongText#1]": "long" },
+        { "[LongText#1]": "world" },
       );
     });
 
@@ -184,11 +184,17 @@ describe("inputHandlers", () => {
         inputText: "Check this: [LongText#1]",
         longTextMap: { "[LongText#1]": "Expanded content" },
       };
+      callbacks.sessionId = "session-1";
       await handleSubmit(state, dispatch, callbacks);
 
       expect(callbacks.onSendMessage).toHaveBeenCalledWith(
         "Check this: Expanded content",
         undefined,
+      );
+      expect(PromptHistoryManager.addEntry).toHaveBeenCalledWith(
+        "Check this: [LongText#1]",
+        "session-1",
+        { "[LongText#1]": "Expanded content" },
       );
     });
   });


### PR DESCRIPTION
Fix prompt history display compression for long pasted text

- Update handleSubmit in inputHandlers.ts to save prompts with placeholders to history.
- Ensure longTextMap is preserved in history entries for restoration.
- Update tests to verify placeholder saving and display.
- Fixes issue where long pasted text made history search hard to read.