### PR TITLE
fix(agent-sdk): suppress proposal update prefix on exitPlanMode cancellation

### DIFF
--- a/packages/agent-sdk/src/tools/exitPlanMode.ts
+++ b/packages/agent-sdk/src/tools/exitPlanMode.ts
@@ -2,6 +2,7 @@ import { readFile } from "fs/promises";
 import { logger } from "../utils/globalLogger.js";
 import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
 import { EXIT_PLAN_MODE_TOOL_NAME } from "../constants/tools.js";
+import { OPERATION_CANCELLED_BY_USER } from "../types/permissions.js";
 
 /**
  * Exit Plan Mode Tool Plugin
@@ -91,6 +92,12 @@ Ensure your plan is complete and unambiguous:
         await context.permissionManager.checkPermission(permissionContext);
 
       if (permissionResult.behavior === "deny") {
+        if (permissionResult.message === OPERATION_CANCELLED_BY_USER) {
+          return {
+            success: false,
+            content: OPERATION_CANCELLED_BY_USER,
+          };
+        }
         return {
           success: false,
           content: `Please update your proposal based on the following user feedback: ${permissionResult.message || "Plan rejected by user"}`,

--- a/packages/agent-sdk/src/types/permissions.ts
+++ b/packages/agent-sdk/src/types/permissions.ts
@@ -70,4 +70,6 @@ export const RESTRICTED_TOOLS = [
 /** Type for restricted tool names */
 export type RestrictedTool = (typeof RESTRICTED_TOOLS)[number];
 
+export const OPERATION_CANCELLED_BY_USER = "Operation cancelled by user";
+
 export type { AskUserQuestion, AskUserQuestionInput, AskUserQuestionOption };

--- a/packages/agent-sdk/tests/tools/exitPlanMode.test.ts
+++ b/packages/agent-sdk/tests/tools/exitPlanMode.test.ts
@@ -5,6 +5,7 @@ import { readFile } from "fs/promises";
 import type { ToolContext } from "@/tools/types.js";
 import { PermissionManager } from "@/managers/permissionManager.js";
 import { Container } from "@/utils/container.js";
+import { OPERATION_CANCELLED_BY_USER } from "@/types/permissions.js";
 
 // Mock fs/promises
 vi.mock("fs/promises");
@@ -144,6 +145,24 @@ describe("exitPlanModeTool", () => {
       "Please update your proposal based on the following user feedback: Plan rejected by user",
     );
     expect(result.error).toBe("Plan rejected by user");
+  });
+
+  it("should return cancellation message without prefix if cancelled by user", async () => {
+    mockPermissionManager.getPlanFilePath.mockReturnValue("/test/plan.md");
+    vi.mocked(readFile).mockResolvedValue("plan");
+    mockPermissionManager.createContext.mockReturnValue({
+      toolName: "ExitPlanMode",
+    });
+    mockPermissionManager.checkPermission.mockResolvedValue({
+      behavior: "deny",
+      message: OPERATION_CANCELLED_BY_USER,
+    });
+
+    const result = await exitPlanModeTool.execute({}, mockContext);
+
+    expect(result.success).toBe(false);
+    expect(result.content).toBe(OPERATION_CANCELLED_BY_USER);
+    expect(result.error).toBeUndefined();
   });
 
   it("should handle unexpected errors in execute", async () => {

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -21,6 +21,7 @@ import {
   Agent,
   AgentCallbacks,
   type ToolPermissionContext,
+  OPERATION_CANCELLED_BY_USER,
 } from "wave-agent-sdk";
 import { logger } from "../utils/logger.js";
 import { displayUsageSummary } from "../utils/usageSummary.js";
@@ -317,7 +318,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
                 // If confirmation was cancelled or failed, deny the operation
                 return {
                   behavior: "deny",
-                  message: "Operation cancelled by user",
+                  message: OPERATION_CANCELLED_BY_USER,
                 };
               }
             };


### PR DESCRIPTION
Fix ExitPlanMode result message on Esc by suppressing the 'Please update your proposal' prefix when the user cancels the confirmation dialog. Added a shared constant OPERATION_CANCELLED_BY_USER for consistency between SDK and CLI.