### PR TITLE
feat: filter prompt history by workdir and session thread

### DIFF
--- a/packages/agent-sdk/src/core/session.ts
+++ b/packages/agent-sdk/src/core/session.ts
@@ -2,5 +2,6 @@ export {
   listSessions,
   truncateContent,
   loadSessionFromJsonl,
+  loadFullMessageThread,
 } from "../services/session.js";
 export type { SessionMetadata, SessionData } from "../services/session.js";

--- a/packages/agent-sdk/src/types/history.ts
+++ b/packages/agent-sdk/src/types/history.ts
@@ -2,5 +2,6 @@ export interface PromptEntry {
   prompt: string;
   timestamp: number;
   sessionId?: string;
+  workdir?: string;
   longTextMap?: Record<string, string>;
 }

--- a/packages/agent-sdk/src/utils/promptHistory.ts
+++ b/packages/agent-sdk/src/utils/promptHistory.ts
@@ -26,6 +26,7 @@ export class PromptHistoryManager {
     prompt: string,
     sessionId?: string,
     longTextMap?: Record<string, string>,
+    workdir?: string,
   ): Promise<void> {
     try {
       if (!prompt.trim()) return;
@@ -36,6 +37,7 @@ export class PromptHistoryManager {
         timestamp: Date.now(),
         sessionId,
         longTextMap,
+        workdir,
       };
 
       const line = JSON.stringify(entry) + "\n";
@@ -77,7 +79,10 @@ export class PromptHistoryManager {
   /**
    * Get all history entries
    */
-  static async getHistory(sessionId?: string): Promise<PromptEntry[]> {
+  static async getHistory(options?: {
+    sessionId?: string | string[];
+    workdir?: string;
+  }): Promise<PromptEntry[]> {
     try {
       if (!fs.existsSync(PROMPT_HISTORY_FILE)) {
         return [];
@@ -98,9 +103,22 @@ export class PromptHistoryManager {
         .filter((entry): entry is PromptEntry => entry !== null);
 
       // Filter by sessionId if provided
-      const filteredEntries = sessionId
-        ? entries.filter((entry) => entry.sessionId === sessionId)
-        : entries;
+      let filteredEntries = entries;
+      if (options?.sessionId) {
+        const sessionIds = Array.isArray(options.sessionId)
+          ? options.sessionId
+          : [options.sessionId];
+        filteredEntries = filteredEntries.filter(
+          (entry) => entry.sessionId && sessionIds.includes(entry.sessionId),
+        );
+      }
+
+      // Filter by workdir if provided
+      if (options?.workdir) {
+        filteredEntries = filteredEntries.filter(
+          (entry) => entry.workdir === options.workdir,
+        );
+      }
 
       // Deduplicate by prompt, keeping the most recent one
       const uniqueEntries: PromptEntry[] = [];
@@ -127,10 +145,13 @@ export class PromptHistoryManager {
    */
   static async searchHistory(
     query: string,
-    sessionId?: string,
+    options?: {
+      sessionId?: string | string[];
+      workdir?: string;
+    },
   ): Promise<PromptEntry[]> {
     try {
-      const history = await this.getHistory(sessionId);
+      const history = await this.getHistory(options);
       if (!query.trim()) {
         return history;
       }

--- a/packages/agent-sdk/tests/utils/promptHistory.test.ts
+++ b/packages/agent-sdk/tests/utils/promptHistory.test.ts
@@ -46,9 +46,14 @@ describe("PromptHistoryManager", () => {
         .spyOn(fs.promises, "appendFile")
         .mockResolvedValue(undefined);
 
-      await PromptHistoryManager.addEntry("hello world", "session-1", {
-        "[LongText#1]": "very long text",
-      });
+      await PromptHistoryManager.addEntry(
+        "hello world",
+        "session-1",
+        {
+          "[LongText#1]": "very long text",
+        },
+        "/home/user/project",
+      );
 
       expect(appendFileSpy).toHaveBeenCalledWith(
         "/mock/path/history.jsonl",
@@ -65,6 +70,11 @@ describe("PromptHistoryManager", () => {
         expect.stringContaining(
           '"longTextMap":{"[LongText#1]":"very long text"}',
         ),
+        "utf-8",
+      );
+      expect(appendFileSpy).toHaveBeenCalledWith(
+        "/mock/path/history.jsonl",
+        expect.stringContaining('"workdir":"/home/user/project"'),
         "utf-8",
       );
     });
@@ -126,10 +136,67 @@ describe("PromptHistoryManager", () => {
 
       vi.spyOn(fs.promises, "readFile").mockResolvedValue(mockData);
 
-      const history = await PromptHistoryManager.getHistory("s1");
+      const history = await PromptHistoryManager.getHistory({
+        sessionId: "s1",
+      });
       expect(history).toHaveLength(2);
       expect(history[0].prompt).toBe("session1-b");
       expect(history[1].prompt).toBe("session1-a");
+    });
+
+    it("should filter by multiple sessionIds if provided", async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      const mockData =
+        JSON.stringify({
+          prompt: "s1-a",
+          timestamp: 1000,
+          sessionId: "s1",
+        }) +
+        "\n" +
+        JSON.stringify({
+          prompt: "s2-a",
+          timestamp: 2000,
+          sessionId: "s2",
+        }) +
+        "\n" +
+        JSON.stringify({
+          prompt: "s3-a",
+          timestamp: 3000,
+          sessionId: "s3",
+        }) +
+        "\n";
+
+      vi.spyOn(fs.promises, "readFile").mockResolvedValue(mockData);
+
+      const history = await PromptHistoryManager.getHistory({
+        sessionId: ["s1", "s2"],
+      });
+      expect(history).toHaveLength(2);
+      expect(history[0].prompt).toBe("s2-a");
+      expect(history[1].prompt).toBe("s1-a");
+    });
+
+    it("should filter by workdir if provided", async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      const mockData =
+        JSON.stringify({
+          prompt: "w1-a",
+          timestamp: 1000,
+          workdir: "w1",
+        }) +
+        "\n" +
+        JSON.stringify({
+          prompt: "w2-a",
+          timestamp: 2000,
+          workdir: "w2",
+        }) +
+        "\n";
+
+      vi.spyOn(fs.promises, "readFile").mockResolvedValue(mockData);
+
+      const history = await PromptHistoryManager.getHistory({ workdir: "w1" });
+      expect(history).toHaveLength(1);
+      expect(history[0].prompt).toBe("w1-a");
     });
   });
 

--- a/packages/code/src/components/HistorySearch.tsx
+++ b/packages/code/src/components/HistorySearch.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import { PromptHistoryManager, type PromptEntry } from "wave-agent-sdk";
+import { useChat } from "../contexts/useChat.js";
 
 export interface HistorySearchProps {
   searchQuery: string;
@@ -28,15 +29,33 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
     selectedIndexRef.current = selectedIndex;
   }, [selectedIndex]);
 
+  const { workingDirectory, getFullMessageThread, sessionId } = useChat();
+
   useEffect(() => {
     const fetchHistory = async () => {
-      const results = await PromptHistoryManager.searchHistory(searchQuery);
+      let sessionIds: string[] | undefined = sessionId
+        ? [sessionId]
+        : undefined;
+
+      if (getFullMessageThread) {
+        try {
+          const thread = await getFullMessageThread();
+          sessionIds = thread.sessionIds;
+        } catch {
+          // Ignore error
+        }
+      }
+
+      const results = await PromptHistoryManager.searchHistory(searchQuery, {
+        sessionId: sessionIds,
+        workdir: workingDirectory,
+      });
       const limitedResults = results.slice(0, 20);
       setEntries(limitedResults); // Limit to 20 results
       setSelectedIndex(0);
     };
     fetchHistory();
-  }, [searchQuery]);
+  }, [searchQuery, workingDirectory, getFullMessageThread, sessionId]);
 
   useInput((input, key) => {
     if (key.return) {

--- a/packages/code/src/components/InputBox.tsx
+++ b/packages/code/src/components/InputBox.tsx
@@ -58,6 +58,7 @@ export const InputBox: React.FC<InputBoxProps> = ({
     getFullMessageThread,
     clearMessages,
     sessionId,
+    workingDirectory,
   } = useChat();
 
   // Input manager with all input state and functionality (including images)
@@ -111,6 +112,8 @@ export const InputBox: React.FC<InputBoxProps> = ({
     onPermissionModeChange: setChatPermissionMode,
     onClearMessages: clearMessages,
     sessionId,
+    workdir: workingDirectory,
+    getFullMessageThread,
   });
 
   // Sync permission mode from useChat to InputManager

--- a/packages/code/src/managers/inputHandlers.ts
+++ b/packages/code/src/managers/inputHandlers.ts
@@ -63,6 +63,7 @@ export const handleSubmit = async (
       contentWithPlaceholders,
       callbacks.sessionId,
       state.longTextMap,
+      callbacks.workdir,
     ).catch((err: unknown) => {
       callbacks.logger?.error("Failed to save prompt history", err);
     });
@@ -511,9 +512,26 @@ export const handleNormalInput = async (
 
   if (key.upArrow) {
     if (state.history.length === 0) {
-      const history = await PromptHistoryManager.getHistory(
-        callbacks.sessionId,
-      );
+      let sessionIds: string[] | undefined = callbacks.sessionId
+        ? [callbacks.sessionId]
+        : undefined;
+
+      if (callbacks.getFullMessageThread) {
+        try {
+          const thread = await callbacks.getFullMessageThread();
+          sessionIds = thread.sessionIds;
+        } catch (error) {
+          callbacks.logger?.error(
+            "Failed to fetch ancestor session IDs",
+            error,
+          );
+        }
+      }
+
+      const history = await PromptHistoryManager.getHistory({
+        sessionId: sessionIds,
+        workdir: callbacks.workdir,
+      });
       dispatch({ type: "SET_HISTORY_ENTRIES", payload: history });
     }
     dispatch({ type: "NAVIGATE_HISTORY", payload: "up" });

--- a/packages/code/src/managers/inputReducer.ts
+++ b/packages/code/src/managers/inputReducer.ts
@@ -1,4 +1,10 @@
-import { FileItem, PermissionMode, Logger, PromptEntry } from "wave-agent-sdk";
+import {
+  FileItem,
+  PermissionMode,
+  Logger,
+  PromptEntry,
+  Message,
+} from "wave-agent-sdk";
 
 export interface AttachedImage {
   id: number;
@@ -37,6 +43,11 @@ export interface InputManagerCallbacks {
   onBackgroundCurrentTask?: () => void;
   onPermissionModeChange?: (mode: PermissionMode) => void;
   sessionId?: string;
+  workdir?: string;
+  getFullMessageThread?: () => Promise<{
+    messages: Message[];
+    sessionIds: string[];
+  }>;
   logger?: Logger;
 }
 

--- a/packages/code/tests/components/HistorySearch.test.tsx
+++ b/packages/code/tests/components/HistorySearch.test.tsx
@@ -3,6 +3,11 @@ import { render } from "ink-testing-library";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { HistorySearch } from "../../src/components/HistorySearch.js";
 import { PromptHistoryManager, stripAnsiColors } from "wave-agent-sdk";
+import { useChat, ChatContextType } from "../../src/contexts/useChat.js";
+
+vi.mock("../../src/contexts/useChat.js", () => ({
+  useChat: vi.fn(),
+}));
 
 vi.mock("wave-agent-sdk", async () => {
   const actual = (await vi.importActual("wave-agent-sdk")) as object;
@@ -28,6 +33,11 @@ describe("HistorySearch", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useChat).mockReturnValue({
+      workingDirectory: "/mock/workdir",
+      getFullMessageThread: vi.fn().mockResolvedValue({ sessionIds: ["s1"] }),
+      sessionId: "s1",
+    } as unknown as ChatContextType);
     vi.mocked(PromptHistoryManager.searchHistory).mockResolvedValue(
       mockEntries,
     );

--- a/packages/code/tests/managers/inputHandlers.test.ts
+++ b/packages/code/tests/managers/inputHandlers.test.ts
@@ -145,6 +145,7 @@ describe("inputHandlers", () => {
         longTextMap: { "[LongText#1]": "world" },
       };
       callbacks.sessionId = "session-1";
+      callbacks.workdir = "/home/user/project";
       await handleSubmit(state, dispatch, callbacks);
 
       expect(callbacks.onSendMessage).toHaveBeenCalledWith(
@@ -160,6 +161,7 @@ describe("inputHandlers", () => {
         "hello [LongText#1]",
         "session-1",
         { "[LongText#1]": "world" },
+        "/home/user/project",
       );
     });
 
@@ -185,6 +187,7 @@ describe("inputHandlers", () => {
         longTextMap: { "[LongText#1]": "Expanded content" },
       };
       callbacks.sessionId = "session-1";
+      callbacks.workdir = "/home/user/project";
       await handleSubmit(state, dispatch, callbacks);
 
       expect(callbacks.onSendMessage).toHaveBeenCalledWith(
@@ -195,6 +198,7 @@ describe("inputHandlers", () => {
         "Check this: [LongText#1]",
         "session-1",
         { "[LongText#1]": "Expanded content" },
+        "/home/user/project",
       );
     });
   });
@@ -729,10 +733,19 @@ describe("inputHandlers", () => {
       const mockHistory = [{ prompt: "prev", timestamp: 1000 }];
       vi.mocked(PromptHistoryManager.getHistory).mockResolvedValue(mockHistory);
       callbacks.sessionId = "session-1";
+      callbacks.workdir = "/home/user/project";
+      callbacks.getFullMessageThread = vi.fn().mockResolvedValue({
+        messages: [],
+        sessionIds: ["session-0", "session-1"],
+      });
 
       // First up arrow - fetch history
       await handleNormalInput(initialState, dispatch, callbacks, "", key);
-      expect(PromptHistoryManager.getHistory).toHaveBeenCalledWith("session-1");
+      expect(callbacks.getFullMessageThread).toHaveBeenCalled();
+      expect(PromptHistoryManager.getHistory).toHaveBeenCalledWith({
+        sessionId: ["session-0", "session-1"],
+        workdir: "/home/user/project",
+      });
       expect(dispatch).toHaveBeenCalledWith({
         type: "SET_HISTORY_ENTRIES",
         payload: mockHistory,


### PR DESCRIPTION
This PR enhances the prompt history management by:
- Adding workdir field to PromptEntry to allow filtering history by the current working directory.
- Supporting multiple sessionIds in history queries, enabling history retrieval across a full message thread.
- Updating HistorySearch and InputBox components to utilize these new filtering capabilities.
- Adding comprehensive tests for the new functionality in both agent-sdk and code packages.