### PR TITLE
fix(code): cancel command selector on space input

### DIFF
--- a/packages/code/src/managers/inputHandlers.ts
+++ b/packages/code/src/managers/inputHandlers.ts
@@ -459,8 +459,12 @@ export const handleSelectorInput = (
     return true;
   }
 
-  if (input === " " && state.showFileSelector) {
-    dispatch({ type: "CANCEL_FILE_SELECTOR" });
+  if (input === " ") {
+    if (state.showFileSelector) {
+      dispatch({ type: "CANCEL_FILE_SELECTOR" });
+    } else if (state.showCommandSelector) {
+      dispatch({ type: "CANCEL_COMMAND_SELECTOR" });
+    }
   }
 
   if (

--- a/packages/code/tests/managers/inputHandlers.test.ts
+++ b/packages/code/tests/managers/inputHandlers.test.ts
@@ -636,6 +636,23 @@ describe("inputHandlers", () => {
       expect(result).toBe(true);
       expect(dispatch).toHaveBeenCalledWith({ type: "CANCEL_FILE_SELECTOR" });
     });
+
+    it("should cancel command selector on space input", () => {
+      const state: InputState = {
+        ...initialState,
+        showCommandSelector: true,
+        slashPosition: 0,
+        inputText: "/",
+        cursorPosition: 1,
+      };
+      const key = {} as Key;
+      const result = handleSelectorInput(state, dispatch, callbacks, " ", key);
+
+      expect(result).toBe(true);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: "CANCEL_COMMAND_SELECTOR",
+      });
+    });
   });
 
   describe("handleNormalInput", () => {


### PR DESCRIPTION
Cancel the command selector when the space key is pressed, matching the behavior of the file selector.