### PR TITLE
feat: make prompt history search global

### DIFF
--- a/packages/code/src/components/HistorySearch.tsx
+++ b/packages/code/src/components/HistorySearch.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import { PromptHistoryManager, type PromptEntry } from "wave-agent-sdk";
-import { useChat } from "../contexts/useChat.js";
 
 export interface HistorySearchProps {
   searchQuery: string;
@@ -29,33 +28,15 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
     selectedIndexRef.current = selectedIndex;
   }, [selectedIndex]);
 
-  const { workingDirectory, getFullMessageThread, sessionId } = useChat();
-
   useEffect(() => {
     const fetchHistory = async () => {
-      let sessionIds: string[] | undefined = sessionId
-        ? [sessionId]
-        : undefined;
-
-      if (getFullMessageThread) {
-        try {
-          const thread = await getFullMessageThread();
-          sessionIds = thread.sessionIds;
-        } catch {
-          // Ignore error
-        }
-      }
-
-      const results = await PromptHistoryManager.searchHistory(searchQuery, {
-        sessionId: sessionIds,
-        workdir: workingDirectory,
-      });
+      const results = await PromptHistoryManager.searchHistory(searchQuery);
       const limitedResults = results.slice(0, 20);
       setEntries(limitedResults); // Limit to 20 results
       setSelectedIndex(0);
     };
     fetchHistory();
-  }, [searchQuery, workingDirectory, getFullMessageThread, sessionId]);
+  }, [searchQuery]);
 
   useInput((input, key) => {
     if (key.return) {

--- a/packages/code/tests/components/HistorySearch.test.tsx
+++ b/packages/code/tests/components/HistorySearch.test.tsx
@@ -3,11 +3,6 @@ import { render } from "ink-testing-library";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { HistorySearch } from "../../src/components/HistorySearch.js";
 import { PromptHistoryManager, stripAnsiColors } from "wave-agent-sdk";
-import { useChat, ChatContextType } from "../../src/contexts/useChat.js";
-
-vi.mock("../../src/contexts/useChat.js", () => ({
-  useChat: vi.fn(),
-}));
 
 vi.mock("wave-agent-sdk", async () => {
   const actual = (await vi.importActual("wave-agent-sdk")) as object;
@@ -33,14 +28,17 @@ describe("HistorySearch", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useChat).mockReturnValue({
-      workingDirectory: "/mock/workdir",
-      getFullMessageThread: vi.fn().mockResolvedValue({ sessionIds: ["s1"] }),
-      sessionId: "s1",
-    } as unknown as ChatContextType);
     vi.mocked(PromptHistoryManager.searchHistory).mockResolvedValue(
       mockEntries,
     );
+  });
+
+  it("should call searchHistory without filters", async () => {
+    render(<HistorySearch {...mockProps} />);
+
+    await vi.waitFor(() => {
+      expect(PromptHistoryManager.searchHistory).toHaveBeenCalledWith("");
+    });
   });
 
   it("should render history entries", async () => {


### PR DESCRIPTION
The prompt history search (triggered by Ctrl+R) now searches through all prompt history, regardless of the session ID or working directory.

- Removed session and working directory filters from HistorySearch component.
- Updated tests to reflect the removal of filters.
- Verified that searchHistory is called without filters.