### PR TITLE
fix(code): improve history navigation behavior and persistence

### DIFF
--- a/packages/code/src/managers/inputHandlers.ts
+++ b/packages/code/src/managers/inputHandlers.ts
@@ -286,7 +286,6 @@ export const handlePasteInput = (
       char = "!";
     }
 
-    dispatch({ type: "RESET_HISTORY_NAVIGATION" });
     dispatch({ type: "INSERT_TEXT", payload: char });
 
     processSelectorInput(state, dispatch, char);
@@ -560,7 +559,6 @@ export const handleNormalInput = async (
       const newInputText = beforeCursor + afterCursor;
 
       dispatch({ type: "DELETE_CHAR" });
-      dispatch({ type: "RESET_HISTORY_NAVIGATION" });
 
       checkForAtDeletion(state, dispatch, newCursorPosition);
       checkForSlashDeletion(state, dispatch, newCursorPosition);

--- a/packages/code/src/managers/inputReducer.ts
+++ b/packages/code/src/managers/inputReducer.ts
@@ -430,6 +430,9 @@ export function inputReducer(
         }
         newIndex = Math.min(state.history.length - 1, newIndex + 1);
       } else {
+        if (newIndex === -1) {
+          return state;
+        }
         newIndex = Math.max(-1, newIndex - 1);
       }
 
@@ -440,8 +443,8 @@ export function inputReducer(
           inputText: newOriginalInputText,
           longTextMap: newOriginalLongTextMap,
           cursorPosition: newOriginalInputText.length,
-          originalInputText: newOriginalInputText,
-          originalLongTextMap: newOriginalLongTextMap,
+          originalInputText: "",
+          originalLongTextMap: {},
         };
       } else {
         const entry = state.history[newIndex];

--- a/packages/code/tests/managers/inputHandlers.test.ts
+++ b/packages/code/tests/managers/inputHandlers.test.ts
@@ -443,6 +443,9 @@ describe("inputHandlers", () => {
         type: "INSERT_TEXT",
         payload: "@",
       });
+      expect(dispatch).not.toHaveBeenCalledWith({
+        type: "RESET_HISTORY_NAVIGATION",
+      });
       expect(dispatch).toHaveBeenCalledWith({
         type: "ACTIVATE_FILE_SELECTOR",
         payload: 0,
@@ -726,6 +729,22 @@ describe("inputHandlers", () => {
       expect(dispatch).toHaveBeenCalledWith({
         type: "SET_COMMAND_SEARCH_QUERY",
         payload: "hel",
+      });
+    });
+
+    it("should NOT dispatch RESET_HISTORY_NAVIGATION on backspace", async () => {
+      const state: InputState = {
+        ...initialState,
+        inputText: "hello",
+        cursorPosition: 5,
+        historyIndex: 0,
+      };
+      const key = { backspace: true } as Key;
+      await handleNormalInput(state, dispatch, callbacks, "", key);
+
+      expect(dispatch).toHaveBeenCalledWith({ type: "DELETE_CHAR" });
+      expect(dispatch).not.toHaveBeenCalledWith({
+        type: "RESET_HISTORY_NAVIGATION",
       });
     });
 

--- a/packages/code/tests/managers/inputReducer.test.ts
+++ b/packages/code/tests/managers/inputReducer.test.ts
@@ -608,5 +608,81 @@ describe("inputReducer", () => {
       expect(state.history).toEqual([]);
       expect(state.originalInputText).toBe("");
     });
+
+    it("should not clear input when pressing down at original prompt", () => {
+      const state = {
+        ...initialState,
+        inputText: "hi",
+        historyIndex: -1,
+      };
+      const newState = inputReducer(state, {
+        type: "NAVIGATE_HISTORY",
+        payload: "down",
+      });
+      expect(newState.inputText).toBe("hi");
+      expect(newState.historyIndex).toBe(-1);
+    });
+
+    it("should restore original input when navigating back to index -1", () => {
+      const state = {
+        ...initialState,
+        history: mockHistory,
+        inputText: "hi",
+        historyIndex: -1,
+      };
+
+      // Navigate up to "first"
+      let newState = inputReducer(state, {
+        type: "NAVIGATE_HISTORY",
+        payload: "up",
+      });
+      expect(newState.inputText).toBe("first");
+      expect(newState.originalInputText).toBe("hi");
+
+      // Navigate down back to original
+      newState = inputReducer(newState, {
+        type: "NAVIGATE_HISTORY",
+        payload: "down",
+      });
+      expect(newState.inputText).toBe("hi");
+      expect(newState.historyIndex).toBe(-1);
+      expect(newState.originalInputText).toBe("");
+    });
+
+    it("should save edited original input when navigating up again", () => {
+      const state = {
+        ...initialState,
+        history: mockHistory,
+        inputText: "hi",
+        historyIndex: -1,
+      };
+
+      // Navigate up then down
+      let newState = inputReducer(state, {
+        type: "NAVIGATE_HISTORY",
+        payload: "up",
+      });
+      newState = inputReducer(newState, {
+        type: "NAVIGATE_HISTORY",
+        payload: "down",
+      });
+      expect(newState.inputText).toBe("hi");
+
+      // Edit original input
+      newState = inputReducer(newState, {
+        type: "INSERT_TEXT",
+        payload: " there",
+      });
+      expect(newState.inputText).toBe("hi there");
+      expect(newState.historyIndex).toBe(-1);
+
+      // Navigate up again
+      newState = inputReducer(newState, {
+        type: "NAVIGATE_HISTORY",
+        payload: "up",
+      });
+      expect(newState.inputText).toBe("first");
+      expect(newState.originalInputText).toBe("hi there");
+    });
   });
 });


### PR DESCRIPTION
This PR fixes the input box history navigation behavior.

### Changes:
- **inputReducer.ts**: Prevents clearing the input when pressing the down arrow key at the original prompt. Restores original input text and long text maps when navigating back to the prompt (index -1).
- **inputHandlers.ts**: Removes unnecessary `RESET_HISTORY_NAVIGATION` dispatches during text pasting and backspacing to preserve history navigation state.
- **Tests**: Added comprehensive test cases in `inputHandlers.test.ts` and `inputReducer.test.ts` to verify the correct restoration of original input and ensure history navigation isn't reset unexpectedly.

### Verification:
- All 108 tests in the affected files passed.
- Manual verification steps from the plan were simulated in automated tests.