### PR TITLE
feat(agent-sdk): improve path matching in PermissionManager

### DIFF
--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -577,7 +577,25 @@ export class PermissionManager {
         context.toolInput?.path) as string | undefined;
 
       if (targetPath) {
-        return minimatch(targetPath, pattern, { dot: true });
+        if (minimatch(targetPath, pattern, { dot: true })) {
+          return true;
+        }
+
+        // If direct match fails, try matching relative path if targetPath is absolute and pattern is relative
+        if (
+          path.isAbsolute(targetPath) &&
+          !path.isAbsolute(pattern) &&
+          this.workdir
+        ) {
+          const relativePath = path.relative(this.workdir, targetPath);
+          // Ensure the path is not outside the workdir (doesn't start with ..)
+          if (
+            !relativePath.startsWith("..") &&
+            !path.isAbsolute(relativePath)
+          ) {
+            return minimatch(relativePath, pattern, { dot: true });
+          }
+        }
       }
     }
 

--- a/packages/agent-sdk/tests/managers/permissionManager.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.test.ts
@@ -184,6 +184,74 @@ describe("PermissionManager", () => {
       });
     });
 
+    describe("relative path matching", () => {
+      const workdir = "/home/user/project";
+
+      it("should match absolute path against relative pattern if inside workdir", async () => {
+        const manager = new PermissionManager(container, { workdir });
+        manager.updateDeniedRules(["Read(src/**)"]);
+
+        const context: ToolPermissionContext = {
+          toolName: "Read",
+          permissionMode: "default",
+          toolInput: { file_path: "/home/user/project/src/main.ts" },
+        };
+
+        const result = await manager.checkPermission(context);
+        expect(result.behavior).toBe("deny");
+        expect(result.message).toContain(
+          "explicitly denied by rule: Read(src/**)",
+        );
+      });
+
+      it("should NOT match absolute path against relative pattern if outside workdir", async () => {
+        const manager = new PermissionManager(container, { workdir });
+        manager.updateDeniedRules(["Read(src/**)"]);
+
+        const context: ToolPermissionContext = {
+          toolName: "Read",
+          permissionMode: "default",
+          toolInput: { file_path: "/home/user/other/src/main.ts" },
+        };
+
+        const result = await manager.checkPermission(context);
+        // Read is unrestricted, so it should be allowed if not denied
+        expect(result.behavior).toBe("allow");
+      });
+
+      it("should still match absolute pattern against absolute path", async () => {
+        const manager = new PermissionManager(container, { workdir });
+        const absolutePattern = "/home/user/project/src/**";
+        manager.updateDeniedRules([`Read(${absolutePattern})`]);
+
+        const context: ToolPermissionContext = {
+          toolName: "Read",
+          permissionMode: "default",
+          toolInput: { file_path: "/home/user/project/src/main.ts" },
+        };
+
+        const result = await manager.checkPermission(context);
+        expect(result.behavior).toBe("deny");
+        expect(result.message).toContain(
+          `explicitly denied by rule: Read(${absolutePattern})`,
+        );
+      });
+
+      it("should match relative path against relative pattern", async () => {
+        const manager = new PermissionManager(container, { workdir });
+        manager.updateDeniedRules(["Read(src/**)"]);
+
+        const context: ToolPermissionContext = {
+          toolName: "Read",
+          permissionMode: "default",
+          toolInput: { file_path: "src/main.ts" },
+        };
+
+        const result = await manager.checkPermission(context);
+        expect(result.behavior).toBe("deny");
+      });
+    });
+
     describe("precedence of deny over allow", () => {
       it("should deny if tool is in both allow and deny rules", async () => {
         permissionManager.updateAllowedRules(["Bash"]);

--- a/specs/049-deny-permissions-support/checklists/requirements.md
+++ b/specs/049-deny-permissions-support/checklists/requirements.md
@@ -32,6 +32,6 @@
 - Spec updated after researching current permission implementation in `PermissionManager` and `ConfigurationService`.
 - Confirmed that `permissions.deny` should follow the same pattern as `permissions.allow` for consistency.
 - Added specific requirements for merging and validation.
-- Added support for path-based permission rules like `Read(path)`, `Write(path)`, `Delete(path)`, etc., for both allow and deny lists. This applies to tools that take a single file or directory path as a primary input.
+- Added support for path-based permission rules like `Read(path)`, `Write(path)`, etc., for both allow and deny lists. This applies to tools that take a single file or directory path as a primary input.
 - Excluded `Glob` and `Grep` from path-based rules as their path parameter is optional.
 - Explicitly stated that `deny` rules apply to ALL tools, even those not in the `RESTRICTED_TOOLS` list.

--- a/specs/049-deny-permissions-support/data-model.md
+++ b/specs/049-deny-permissions-support/data-model.md
@@ -32,6 +32,6 @@ export interface PermissionManagerOptions {
 
 1. **Tool Name**: `Bash`, `Write`, `Read`
 2. **Bash Command**: `Bash(ls -la)`, `Bash(rm *)`
-3. **Path-based**: `Read(**/*.env)`, `Write(/etc/**)`, `Delete(/tmp/test.txt)`
+3. **Path-based**: `Read(**/*.env)`, `Write(/etc/**)`
    - Format: `ToolName(glob_pattern)`
    - Supported tools: `Read`, `Write`, `Edit`, ``, `Delete`, `LS`

--- a/specs/049-deny-permissions-support/research.md
+++ b/specs/049-deny-permissions-support/research.md
@@ -11,7 +11,7 @@ To ensure maximum security, `permissions.deny` must be checked before any other 
    - Command-specific rules: `Bash(rm *)`.
    - Path-based rules: `Read(**/*.env)`, `Write(/etc/**)`, `Delete(/tmp/test.txt)`.
    - The matching logic for `ToolName(path_pattern)` will use the `minimatch` library (which is already a dependency of `agent-sdk`) to match the `path_pattern` against the `file_path` or `target_file` in the tool input.
-   - **Rationale for `minimatch` over `glob`**: While `glob` is used for searching the filesystem, `minimatch` is the underlying library used by `glob` for string-to-pattern matching. Since permission checks must work for non-existent files (e.g., `Write` or `Delete` operations) and should not hit the disk for performance reasons, `minimatch` is the appropriate tool for this task.
+   - **Rationale for `minimatch` over `glob`**: While `glob` is used for searching the filesystem, `minimatch` is the underlying library used by `glob` for string-to-pattern matching. Since permission checks must work for non-existent files (e.g., `Write` operations) and should not hit the disk for performance reasons, `minimatch` is the appropriate tool for this task.
    - A new private method `matchesRule(context, rule)` will be implemented in `PermissionManager` to centralize matching logic.
 
 2. **Precedence**:

--- a/specs/049-deny-permissions-support/spec.md
+++ b/specs/049-deny-permissions-support/spec.md
@@ -29,14 +29,13 @@ As a user with sensitive data, I want to prevent the agent from accessing specif
 
 **Why this priority**: Protecting sensitive data is a primary use case for permissions. Deny rules are often easier to manage for "everything except X" or "allow all except Y" scenarios.
 
-**Independent Test**: Can be tested by adding a rule like `Read(**/.env)` or `Delete(/etc/**)` to `permissions.deny` and verifying that the corresponding tool is blocked when attempting to access matching paths.
+**Independent Test**: Can be tested by adding a rule like `Read(**/.env)` to `permissions.deny` and verifying that the corresponding tool is blocked when attempting to access matching paths.
 
 **Acceptance Scenarios**:
 
 1. **Given** `permissions.deny` contains `["Read(**/.env)"]`, **When** the agent attempts to read a file named `.env` in any directory using the `Read` tool, **Then** the system MUST deny the request.
 2. **Given** `permissions.deny` contains `["Write(/etc/**)"]`, **When** the agent attempts to write to a file in `/etc/` using the `Write` tool, **Then** the system MUST deny the request.
-3. **Given** `permissions.deny` contains `["Delete(/etc/**)"]`, **When** the agent attempts to delete a file in `/etc/`, **Then** the system MUST deny the request.
-4. **Given** `permissions.deny` contains `["Bash(ls /etc*)"]`, **When** the agent attempts to run `ls /etc/passwd`, **Then** the system MUST deny the request.
+3. **Given** `permissions.deny` contains `["Bash(ls /etc*)"]`, **When** the agent attempts to run `ls /etc/passwd`, **Then** the system MUST deny the request.
 
 ---
 
@@ -78,3 +77,4 @@ As a user, I want to be certain that if I explicitly deny a permission, it canno
 
 - **Permission Rule**: A string or object defining a capability (tool) or resource (file path) that is subject to access control.
 - **Settings**: The configuration object loaded from `settings.json` which now includes both `allow` and `deny` permission lists.
+

--- a/specs/049-deny-permissions-support/tasks.md
+++ b/specs/049-deny-permissions-support/tasks.md
@@ -158,4 +158,4 @@ description: "Task list for implementing permissions.deny support"
 
 - `minimatch` is used for glob matching in rules.
 - `checkPermission` is the central point for all permission logic.
-- `Read` and `LS` tools are updated to participate in the permission system.
+- `Read` tool is updated to participate in the permission system.


### PR DESCRIPTION
This PR improves the path matching logic in PermissionManager to handle relative patterns against absolute paths when a workdir is provided. It also updates the specifications for deny permissions support.