### PR TITLE
feat: reset permissions to empty arrays on live config reload

### DIFF
--- a/packages/agent-sdk/src/managers/liveConfigManager.ts
+++ b/packages/agent-sdk/src/managers/liveConfigManager.ts
@@ -258,26 +258,18 @@ export class LiveConfigManager {
 
       // Update permission manager if available
       if (this.permissionManager) {
-        if (this.currentConfiguration.permissions?.defaultMode) {
-          this.permissionManager.updateConfiguredDefaultMode(
-            this.currentConfiguration.permissions.defaultMode,
-          );
-        }
-        if (this.currentConfiguration.permissions?.allow) {
-          this.permissionManager.updateAllowedRules(
-            this.currentConfiguration.permissions.allow,
-          );
-        }
-        if (this.currentConfiguration.permissions?.deny) {
-          this.permissionManager.updateDeniedRules(
-            this.currentConfiguration.permissions.deny,
-          );
-        }
-        if (this.currentConfiguration.permissions?.additionalDirectories) {
-          this.permissionManager.updateAdditionalDirectories(
-            this.currentConfiguration.permissions.additionalDirectories,
-          );
-        }
+        this.permissionManager.updateConfiguredDefaultMode(
+          this.currentConfiguration.permissions?.defaultMode,
+        );
+        this.permissionManager.updateAllowedRules(
+          this.currentConfiguration.permissions?.allow || [],
+        );
+        this.permissionManager.updateDeniedRules(
+          this.currentConfiguration.permissions?.deny || [],
+        );
+        this.permissionManager.updateAdditionalDirectories(
+          this.currentConfiguration.permissions?.additionalDirectories || [],
+        );
       }
 
       return this.currentConfiguration;

--- a/packages/agent-sdk/tests/managers/liveConfigManager.test.ts
+++ b/packages/agent-sdk/tests/managers/liveConfigManager.test.ts
@@ -11,6 +11,7 @@ import { Container } from "../../src/utils/container.js";
 import type { HookManager } from "../../src/managers/hookManager.js";
 import { ConfigurationService } from "../../src/services/configurationService.js";
 import { FileWatcherService } from "../../src/services/fileWatcher.js";
+import { PermissionManager } from "../../src/managers/permissionManager.js";
 import * as configPaths from "../../src/utils/configPaths.js";
 import { ensureGlobalGitIgnore } from "../../src/utils/fileUtils.js";
 import type { WaveConfiguration } from "../../src/types/configuration.js";
@@ -40,6 +41,7 @@ describe("LiveConfigManager - Configuration Management", () => {
   let liveConfigManager: LiveConfigManager;
   let container: Container;
   let mockHookManager: HookManager;
+  let mockPermissionManager: PermissionManager;
   let mockConfigurationService: ConfigurationService;
   let mockFileWatcherService: FileWatcherService;
   let workdir: string;
@@ -51,6 +53,14 @@ describe("LiveConfigManager - Configuration Management", () => {
     mockHookManager = {
       loadConfigurationFromWaveConfig: vi.fn(),
     } as Partial<HookManager> as HookManager;
+
+    // Mock permission manager
+    mockPermissionManager = {
+      updateConfiguredDefaultMode: vi.fn(),
+      updateAllowedRules: vi.fn(),
+      updateDeniedRules: vi.fn(),
+      updateAdditionalDirectories: vi.fn(),
+    } as Partial<PermissionManager> as PermissionManager;
 
     // Mock file watcher service
     mockFileWatcherService = {
@@ -79,6 +89,7 @@ describe("LiveConfigManager - Configuration Management", () => {
     // Setup container
     container = new Container();
     container.register("HookManager", mockHookManager);
+    container.register("PermissionManager", mockPermissionManager);
     container.register("ConfigurationService", mockConfigurationService);
 
     // Mock config paths
@@ -476,6 +487,70 @@ describe("LiveConfigManager - Configuration Management", () => {
       });
 
       expect(ensureGlobalGitIgnore).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Permission Reload", () => {
+    it("should reset permissions to empty arrays when they are missing in the new configuration", async () => {
+      const initialConfig: WaveConfiguration = {
+        permissions: {
+          allow: ["Bash(ls)"],
+          deny: ["Bash(rm *)"],
+          additionalDirectories: ["/tmp"],
+          defaultMode: "default",
+        },
+      };
+
+      const emptyConfig: WaveConfiguration = {
+        permissions: {},
+      };
+
+      const initialResult: ConfigurationLoadResult = {
+        success: true,
+        configuration: initialConfig,
+        sourcePath: "/mock/project/.wave/settings.json",
+        warnings: [],
+      };
+
+      const emptyResult: ConfigurationLoadResult = {
+        success: true,
+        configuration: emptyConfig,
+        sourcePath: "/mock/project/.wave/settings.json",
+        warnings: [],
+      };
+
+      vi.mocked(mockConfigurationService.loadMergedConfiguration)
+        .mockResolvedValueOnce(initialResult)
+        .mockResolvedValueOnce(emptyResult);
+
+      // Initial load
+      await liveConfigManager.initialize();
+
+      expect(mockPermissionManager.updateAllowedRules).toHaveBeenCalledWith([
+        "Bash(ls)",
+      ]);
+      expect(mockPermissionManager.updateDeniedRules).toHaveBeenCalledWith([
+        "Bash(rm *)",
+      ]);
+      expect(
+        mockPermissionManager.updateAdditionalDirectories,
+      ).toHaveBeenCalledWith(["/tmp"]);
+      expect(
+        mockPermissionManager.updateConfiguredDefaultMode,
+      ).toHaveBeenCalledWith("default");
+
+      // Reload with empty permissions
+      await liveConfigManager.reload();
+
+      // These should be called with empty arrays/undefined if they are missing in the new config
+      expect(mockPermissionManager.updateAllowedRules).toHaveBeenCalledWith([]);
+      expect(mockPermissionManager.updateDeniedRules).toHaveBeenCalledWith([]);
+      expect(
+        mockPermissionManager.updateAdditionalDirectories,
+      ).toHaveBeenCalledWith([]);
+      expect(
+        mockPermissionManager.updateConfiguredDefaultMode,
+      ).toHaveBeenCalledWith(undefined);
     });
   });
 });

--- a/specs/019-live-config-reload/spec.md
+++ b/specs/019-live-config-reload/spec.md
@@ -59,6 +59,7 @@ A developer is actively working and needs to modify their settings.json configur
 - **FR-007**: File watchers MUST handle file deletion, creation, and modification events
 - **FR-008**: Environment variables from env field MUST be available to hook processes and agent execution context
 - **FR-009**: System MUST handle file watcher initialization failures by throwing descriptive error and preventing SDK startup
+- **FR-010**: System MUST reset permissions (allow, deny, additionalDirectories) to empty arrays and defaultMode to undefined when they are missing in the new configuration during reload
 
 ### Key Entities
 

--- a/specs/019-live-config-reload/tasks.md
+++ b/specs/019-live-config-reload/tasks.md
@@ -83,6 +83,7 @@
 - [x] T027 [US2] Pass logger from Agent constructor to ConfigurationWatcher for structured logging in packages/agent-sdk/src/services/configurationWatcher.ts
 - [x] T028 [US2] Add structured logging for reload events with Live Config prefix in packages/agent-sdk/src/services/configurationWatcher.ts
 - [x] T029 [US2] Implement file watcher initialization failure handling with descriptive errors in packages/agent-sdk/src/services/fileWatcher.ts
+- [x] T030 [US2] Reset permissions to empty arrays and defaultMode to undefined when missing in new configuration during reload in packages/agent-sdk/src/managers/liveConfigManager.ts
 
 **Checkpoint**: At this point, User Stories 1 AND 2 should both work independently
 


### PR DESCRIPTION
This PR implements the requirement to reset permissions to empty arrays and defaultMode to undefined when they are missing in the new configuration during a live reload.

- Update LiveConfigManager to reset allow, deny, and additionalDirectories to [] if missing in new config.
- Update LiveConfigManager to reset defaultMode to undefined if missing in new config.
- Add test case to liveConfigManager.test.ts to verify permission reset.
- Update specs/019-live-config-reload/spec.md and tasks.md with the new requirement and task.