### PR TITLE
feat(agent-sdk): upgrade ripgrep to 14.1.1 and implement vendor bundling strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Thumbs.db
 nohup.out
 .wave/settings.local.json
 .wave/worktrees/
+vendor/

--- a/packages/agent-sdk/bin/rg
+++ b/packages/agent-sdk/bin/rg
@@ -1,0 +1,79 @@
+#!/usr/bin/env dotslash
+
+{
+  "name": "rg",
+  "platforms": {
+    "macos-aarch64": {
+      "size": 1787248,
+      "hash": "blake3",
+      "digest": "8d9942032585ea8ee805937634238d9aee7b210069f4703c88fbe568e26fb78a",
+      "format": "tar.gz",
+      "path": "ripgrep-14.1.1-aarch64-apple-darwin/rg",
+      "providers": [
+        {
+          "url": "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-aarch64-apple-darwin.tar.gz"
+        }
+      ]
+    },
+    "linux-aarch64": {
+      "size": 2047405,
+      "hash": "blake3",
+      "digest": "0b670b8fa0a3df2762af2fc82cc4932f684ca4c02dbd1260d4f3133fd4b2a515",
+      "format": "tar.gz",
+      "path": "ripgrep-14.1.1-aarch64-unknown-linux-gnu/rg",
+      "providers": [
+        {
+          "url": "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-aarch64-unknown-linux-gnu.tar.gz"
+        }
+      ]
+    },
+    "macos-x86_64": {
+      "size": 2082672,
+      "hash": "blake3",
+      "digest": "e9b862fc8da3127f92791f0ff6a799504154ca9d36c98bf3e60a81c6b1f7289e",
+      "format": "tar.gz",
+      "path": "ripgrep-14.1.1-x86_64-apple-darwin/rg",
+      "providers": [
+        {
+          "url": "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-x86_64-apple-darwin.tar.gz"
+        }
+      ]
+    },
+    "linux-x86_64": {
+      "size": 2566310,
+      "hash": "blake3",
+      "digest": "f73cca4e54d78c31f832c7f6e2c0b4db8b04fa3eaa747915727d570893dbee76",
+      "format": "tar.gz",
+      "path": "ripgrep-14.1.1-x86_64-unknown-linux-musl/rg",
+      "providers": [
+        {
+          "url": "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-x86_64-unknown-linux-musl.tar.gz"
+        }
+      ]
+    },
+    "windows-x86_64": {
+      "size": 2058893,
+      "hash": "blake3",
+      "digest": "a8ce1a6fed4f8093ee997e57f33254e94b2cd18e26358b09db599c89882eadbd",
+      "format": "zip",
+      "path": "ripgrep-14.1.1-x86_64-pc-windows-msvc/rg.exe",
+      "providers": [
+        {
+          "url": "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-x86_64-pc-windows-msvc.zip"
+        }
+      ]
+    },
+    "windows-aarch64": {
+      "size": 1667740,
+      "hash": "blake3",
+      "digest": "47b971a8c4fca1d23a4e7c19bd4d88465ebc395598458133139406d3bf85f3fa",
+      "format": "zip",
+      "path": "rg.exe",
+      "providers": [
+        {
+          "url": "https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-aarch64-pc-windows-msvc.zip"
+        }
+      ]
+    }
+  }
+}

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -21,9 +21,12 @@
   "files": [
     "dist",
     "src",
+    "bin",
+    "vendor",
     "README.md"
   ],
   "scripts": {
+    "prepare": "tsx scripts/install_ripgrep.ts",
     "build": "rimraf dist && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "type-check": "tsc --noEmit --incremental",
     "watch": "tsc -p tsconfig.build.json --watch & tsc-alias -p tsconfig.build.json --watch",
@@ -35,7 +38,6 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.18.2",
-    "@vscode/ripgrep": "^1.15.14",
     "chokidar": "^5.0.0",
     "fuzzysort": "^3.1.0",
     "glob": "^13.0.0",

--- a/packages/agent-sdk/scripts/install_ripgrep.ts
+++ b/packages/agent-sdk/scripts/install_ripgrep.ts
@@ -1,0 +1,116 @@
+import fs from "fs";
+import path from "path";
+import { execSync } from "child_process";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const MANIFEST_PATH = path.resolve(__dirname, "../bin/rg");
+const VENDOR_DIR = path.resolve(__dirname, "../vendor/ripgrep");
+
+interface PlatformInfo {
+  size: number;
+  hash: string;
+  digest: string;
+  format: "tar.gz" | "zip";
+  path: string;
+  providers: Array<{ url: string }>;
+}
+
+interface Manifest {
+  name: string;
+  platforms: Record<string, PlatformInfo>;
+}
+
+async function main() {
+  if (!fs.existsSync(MANIFEST_PATH)) {
+    console.error(`Manifest not found: ${MANIFEST_PATH}`);
+    process.exit(1);
+  }
+
+  const manifestContent = fs.readFileSync(MANIFEST_PATH, "utf-8");
+  const jsonContent = manifestContent.replace(/^#!.*\n/, "");
+  const manifest: Manifest = JSON.parse(jsonContent);
+  const platforms = manifest.platforms;
+
+  if (!fs.existsSync(VENDOR_DIR)) {
+    fs.mkdirSync(VENDOR_DIR, { recursive: true });
+  }
+
+  for (const [platform, info] of Object.entries(platforms)) {
+    const platformDir = path.join(VENDOR_DIR, platform);
+    const isWindows = platform.startsWith("windows");
+    const binaryName = isWindows ? "rg.exe" : "rg";
+    const binaryPath = path.join(platformDir, binaryName);
+
+    if (fs.existsSync(binaryPath)) {
+      console.log(`Binary for ${platform} already exists at ${binaryPath}`);
+      continue;
+    }
+
+    console.log(`Installing ripgrep for ${platform}...`);
+    fs.mkdirSync(platformDir, { recursive: true });
+
+    const url = info.providers[0].url;
+    const tempFile = path.join(platformDir, `download.${info.format}`);
+
+    try {
+      // Download using curl
+      console.log(`Downloading ${url}...`);
+      execSync(`curl -L -o "${tempFile}" "${url}"`, { stdio: "inherit" });
+
+      // Extract
+      console.log(`Extracting ${tempFile}...`);
+      if (info.format === "tar.gz") {
+        // Extract specific file from tar.gz
+        const extractDir = path.join(platformDir, "extract");
+        fs.mkdirSync(extractDir, { recursive: true });
+        execSync(`tar -xzf "${tempFile}" -C "${extractDir}"`, {
+          stdio: "inherit",
+        });
+        const extractedBinary = path.join(extractDir, info.path);
+        if (fs.existsSync(extractedBinary)) {
+          fs.renameSync(extractedBinary, binaryPath);
+        } else {
+          throw new Error(`Binary not found in archive: ${info.path}`);
+        }
+        // Clean up extract dir
+        fs.rmSync(extractDir, { recursive: true, force: true });
+      } else if (info.format === "zip") {
+        const extractDir = path.join(platformDir, "extract");
+        fs.mkdirSync(extractDir, { recursive: true });
+        execSync(`unzip -o "${tempFile}" -d "${extractDir}"`, {
+          stdio: "inherit",
+        });
+        const extractedBinary = path.join(extractDir, info.path);
+        if (fs.existsSync(extractedBinary)) {
+          fs.renameSync(extractedBinary, binaryPath);
+        } else {
+          throw new Error(`Binary not found in archive: ${info.path}`);
+        }
+        // Clean up extract dir
+        fs.rmSync(extractDir, { recursive: true, force: true });
+      }
+
+      // Make executable
+      if (!isWindows) {
+        fs.chmodSync(binaryPath, 0o755);
+      }
+
+      console.log(`Successfully installed ripgrep for ${platform}`);
+    } catch (error) {
+      console.error(`Failed to install ripgrep for ${platform}:`, error);
+    } finally {
+      // Clean up temp file
+      if (fs.existsSync(tempFile)) {
+        fs.unlinkSync(tempFile);
+      }
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/agent-sdk/src/tools/globTool.ts
+++ b/packages/agent-sdk/src/tools/globTool.ts
@@ -1,5 +1,5 @@
 import { spawn } from "child_process";
-import { rgPath } from "@vscode/ripgrep";
+import { rgPath } from "../utils/ripgrep.js";
 import { stat } from "fs/promises";
 import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
 import { resolvePath, getDisplayPath } from "../utils/path.js";

--- a/packages/agent-sdk/src/tools/grepTool.ts
+++ b/packages/agent-sdk/src/tools/grepTool.ts
@@ -1,7 +1,7 @@
 import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
 import { spawn } from "child_process";
 import { getAllIgnorePatterns } from "../utils/fileFilter.js";
-import { rgPath } from "@vscode/ripgrep";
+import { rgPath } from "../utils/ripgrep.js";
 import { getDisplayPath } from "../utils/path.js";
 import {
   GREP_TOOL_NAME,

--- a/packages/agent-sdk/src/utils/fileSearch.ts
+++ b/packages/agent-sdk/src/utils/fileSearch.ts
@@ -1,5 +1,5 @@
 import { spawn } from "child_process";
-import { rgPath } from "@vscode/ripgrep";
+import { rgPath } from "./ripgrep.js";
 import fuzzysort from "fuzzysort";
 import { getAllIgnorePatterns } from "./fileFilter.js";
 import type { FileItem } from "../types/fileSearch.js";

--- a/packages/agent-sdk/src/utils/ripgrep.ts
+++ b/packages/agent-sdk/src/utils/ripgrep.ts
@@ -1,0 +1,36 @@
+import { fileURLToPath } from "url";
+import path from "path";
+import process from "process";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * Detect the current platform and architecture to find the correct bundled ripgrep binary.
+ */
+function getPlatformKey(): string {
+  const platform = process.platform;
+  const arch = process.arch;
+
+  if (platform === "darwin") {
+    return arch === "arm64" ? "macos-aarch64" : "macos-x86_64";
+  } else if (platform === "linux") {
+    return arch === "arm64" ? "linux-aarch64" : "linux-x86_64";
+  } else if (platform === "win32") {
+    return arch === "arm64" ? "windows-aarch64" : "windows-x86_64";
+  }
+
+  throw new Error(`Unsupported platform: ${platform}-${arch}`);
+}
+
+const platformKey = getPlatformKey();
+const isWindows = platformKey.startsWith("windows");
+const binaryName = isWindows ? "rg.exe" : "rg";
+
+/**
+ * Path to the ripgrep binary bundled in the vendor directory.
+ */
+export const rgPath = path.resolve(
+  __dirname,
+  `../../vendor/ripgrep/${platformKey}/${binaryName}`,
+);

--- a/packages/agent-sdk/tests/tools/globTool.test.ts
+++ b/packages/agent-sdk/tests/tools/globTool.test.ts
@@ -17,8 +17,8 @@ vi.mock("child_process", () => ({
   spawn: vi.fn(),
 }));
 
-// Mock @vscode/ripgrep
-vi.mock("@vscode/ripgrep", () => ({
+// Mock ripgrep utility
+vi.mock("@/utils/ripgrep.js", () => ({
   rgPath: "/mock/rg",
 }));
 

--- a/packages/agent-sdk/tests/tools/grepTool.test.ts
+++ b/packages/agent-sdk/tests/tools/grepTool.test.ts
@@ -14,7 +14,7 @@ const testContext: ToolContext = {
 vi.mock("child_process");
 
 // Mock ripgrep path
-vi.mock("@vscode/ripgrep", () => ({
+vi.mock("@/utils/ripgrep.js", () => ({
   rgPath: "/mock/rg",
 }));
 

--- a/packages/agent-sdk/tests/utils/fileSearch.test.ts
+++ b/packages/agent-sdk/tests/utils/fileSearch.test.ts
@@ -8,8 +8,8 @@ vi.mock("child_process", () => ({
   spawn: vi.fn(),
 }));
 
-// Mock @vscode/ripgrep
-vi.mock("@vscode/ripgrep", () => ({
+// Mock ripgrep utility
+vi.mock("../../src/utils/ripgrep.js", () => ({
   rgPath: "/mock/path/to/rg",
 }));
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,9 +53,6 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.18.2
         version: 1.19.1
-      '@vscode/ripgrep':
-        specifier: ^1.15.14
-        version: 1.15.14
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
@@ -872,9 +869,6 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
-  '@vscode/ripgrep@1.15.14':
-    resolution: {integrity: sha512-/G1UJPYlm+trBWQ6cMO3sv6b8D1+G16WaJH1/DSqw32JOVlzgZbLkDxRyzIpTpv30AcYGMkCf5tUqGlW6HbDWw==}
-
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -1000,9 +994,6 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
-
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1409,9 +1400,6 @@ packages:
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2104,9 +2092,6 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2154,9 +2139,6 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2748,9 +2730,6 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
-
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -3338,14 +3317,6 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
-  '@vscode/ripgrep@1.15.14':
-    dependencies:
-      https-proxy-agent: 7.0.6
-      proxy-from-env: 1.1.0
-      yauzl: 2.10.0
-    transitivePeerDependencies:
-      - supports-color
-
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.1
@@ -3357,7 +3328,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  agent-base@7.1.4: {}
+  agent-base@7.1.4:
+    optional: true
 
   ajv@6.12.6:
     dependencies:
@@ -3501,8 +3473,6 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
-
-  buffer-crc32@0.2.13: {}
 
   bytes@3.1.2: {}
 
@@ -4079,10 +4049,6 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
-
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
@@ -4271,6 +4237,7 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   husky@9.1.7: {}
 
@@ -4799,8 +4766,6 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  pend@1.2.0: {}
-
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -4837,8 +4802,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 
@@ -5516,11 +5479,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yauzl@2.10.0:
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
Replace @vscode/ripgrep with a custom vendor bundling strategy inspired by OpenAI's Codex.
- Add DotSlash manifest for ripgrep 14.1.1 in packages/agent-sdk/bin/rg.
- Add packages/agent-sdk/scripts/install_ripgrep.ts to download and bundle native binaries for all supported platforms.
- Add packages/agent-sdk/src/utils/ripgrep.ts to resolve the path to the bundled binary at runtime.
- Update tools and tests to use the new rgPath utility.
- Update .gitignore to exclude bundled binaries while including them in the NPM package via package.json.