### PR TITLE
fix(agent-sdk): handle EPIPE error in hook execution

### DIFF
--- a/packages/agent-sdk/src/services/hook.ts
+++ b/packages/agent-sdk/src/services/hook.ts
@@ -155,6 +155,14 @@ export async function executeCommand(
       },
     });
 
+    // Handle stdin errors (e.g. EPIPE if the process closes stdin early)
+    if (childProcess.stdin) {
+      childProcess.stdin.on("error", () => {
+        // Ignore stdin errors as they just mean the process closed stdin early
+        // or doesn't want to read from it.
+      });
+    }
+
     // Set up timeout
     const timeoutHandle = setTimeout(() => {
       timedOut = true;
@@ -173,6 +181,9 @@ export async function executeCommand(
       childProcess.stdout.on("data", (data: Buffer) => {
         stdout += data.toString();
       });
+      childProcess.stdout.on("error", () => {
+        // Ignore stdout errors
+      });
     }
 
     // Handle stderr
@@ -180,17 +191,20 @@ export async function executeCommand(
       childProcess.stderr.on("data", (data: Buffer) => {
         stderr += data.toString();
       });
+      childProcess.stderr.on("error", () => {
+        // Ignore stderr errors
+      });
     }
 
     // Send JSON input to stdin if we have prepared it
-    if (childProcess.stdin && jsonInput) {
+    if (childProcess.stdin && childProcess.stdin.writable && jsonInput) {
       try {
         childProcess.stdin.write(jsonInput);
         childProcess.stdin.end();
       } catch {
         // Continue execution even if JSON input fails
       }
-    } else if (childProcess.stdin) {
+    } else if (childProcess.stdin && childProcess.stdin.writable) {
       childProcess.stdin.end();
     }
 

--- a/packages/agent-sdk/tests/services/hook.test.ts
+++ b/packages/agent-sdk/tests/services/hook.test.ts
@@ -65,10 +65,12 @@ class MockChildProcess extends EventEmitter {
 
 // Mock stdin that can be written to and ended
 class MockStdin extends EventEmitter {
+  writable = true;
   write() {
     return true;
   }
   end() {
+    this.writable = false;
     return;
   }
 }


### PR DESCRIPTION
This PR fixes an unhandled 'error' event (EPIPE) that occurs when writing to the stdin of a hook process that has already closed its stdin or exited.

Changes:
- Added error listeners to stdin, stdout, and stderr of the spawned hook process to catch and ignore asynchronous stream errors.
- Added a check for `childProcess.stdin.writable` before attempting to write JSON input or end the stream.
- Updated `MockStdin` in tests to support the `writable` property check.