### PR TITLE
chore: reduce log verbosity in ripgrep installation scripts

### DIFF
--- a/packages/agent-sdk/scripts/install_ripgrep.js
+++ b/packages/agent-sdk/scripts/install_ripgrep.js
@@ -31,12 +31,14 @@ async function main() {
     const binaryPath = path.join(platformDir, binaryName);
 
     if (fs.existsSync(binaryPath)) {
-      console.log(`Binary for ${platform} already exists at ${binaryPath}`);
       if (!isWindows) {
-        try {
-          fs.chmodSync(binaryPath, 0o755);
-        } catch (e) {
-          console.warn(`Failed to set permissions for ${binaryPath}: ${e}`);
+        const stats = fs.statSync(binaryPath);
+        if ((stats.mode & 0o777) !== 0o755) {
+          try {
+            fs.chmodSync(binaryPath, 0o755);
+          } catch (e) {
+            console.warn(`Failed to set permissions for ${binaryPath}: ${e}`);
+          }
         }
       }
       continue;

--- a/packages/agent-sdk/scripts/postinstall.js
+++ b/packages/agent-sdk/scripts/postinstall.js
@@ -19,13 +19,16 @@ function chmodRecursive(dir) {
       chmodRecursive(fullPath);
     } else if (file === "rg" || file === "rg.exe") {
       if (process.platform !== "win32") {
-        try {
-          fs.chmodSync(fullPath, 0o755);
-          console.log(`Set execution permission for ${fullPath}`);
-        } catch (e) {
-          console.warn(
-            `Failed to set execution permission for ${fullPath}: ${e.message}`,
-          );
+        const currentMode = stats.mode & 0o777;
+        if (currentMode !== 0o755) {
+          try {
+            fs.chmodSync(fullPath, 0o755);
+            console.log(`Set execution permission for ${fullPath}`);
+          } catch (e) {
+            console.warn(
+              `Failed to set execution permission for ${fullPath}: ${e.message}`,
+            );
+          }
         }
       }
     }


### PR DESCRIPTION
This PR reduces the log verbosity of the ripgrep installation and post-installation scripts by only logging when actions are actually taken (e.g., downloading a binary or changing permissions).