### PR TITLE
feat: implement plugin skill namespacing and update specifications

### DIFF
--- a/packages/agent-sdk/src/managers/pluginManager.ts
+++ b/packages/agent-sdk/src/managers/pluginManager.ts
@@ -164,7 +164,7 @@ export class PluginManager {
       }
 
       if (this.skillManager && plugin.skills.length > 0) {
-        this.skillManager.registerPluginSkills(plugin.skills);
+        this.skillManager.registerPluginSkills(plugin.name, plugin.skills);
       }
 
       if (this.lspManager && plugin.lspConfig) {

--- a/packages/agent-sdk/src/managers/skillManager.ts
+++ b/packages/agent-sdk/src/managers/skillManager.ts
@@ -356,10 +356,11 @@ export class SkillManager {
   /**
    * Register skills provided by a plugin
    */
-  registerPluginSkills(skills: Skill[]): void {
+  registerPluginSkills(pluginName: string, skills: Skill[]): void {
     for (const skill of skills) {
+      const namespacedName = `${pluginName}:${skill.name}`;
       const metadata: SkillMetadata = {
-        name: skill.name,
+        name: namespacedName,
         description: skill.description,
         type: skill.type,
         skillPath: skill.skillPath,
@@ -369,12 +370,16 @@ export class SkillManager {
         model: skill.model,
         disableModelInvocation: skill.disableModelInvocation,
         userInvocable: skill.userInvocable,
+        pluginName,
       };
-      this.skillMetadata.set(skill.name, metadata);
-      this.skillContent.set(skill.name, skill);
+      // Update the skill object itself to have the namespaced name
+      skill.name = namespacedName;
+
+      this.skillMetadata.set(namespacedName, metadata);
+      this.skillContent.set(namespacedName, skill);
     }
     logger?.debug(
-      `Registered ${skills.length} plugin skills. Total skills: ${this.skillMetadata.size}`,
+      `Registered ${skills.length} plugin skills from ${pluginName}. Total skills: ${this.skillMetadata.size}`,
     );
   }
 }

--- a/packages/agent-sdk/src/types/skills.ts
+++ b/packages/agent-sdk/src/types/skills.ts
@@ -14,6 +14,7 @@ export interface SkillMetadata {
   model?: string;
   disableModelInvocation?: boolean;
   userInvocable?: boolean;
+  pluginName?: string;
 }
 
 export interface Skill extends SkillMetadata {

--- a/packages/agent-sdk/tests/managers/pluginManager.test.ts
+++ b/packages/agent-sdk/tests/managers/pluginManager.test.ts
@@ -146,6 +146,7 @@ describe("PluginManager", () => {
         mockSlashCommandManager.registerPluginCommands,
       ).toHaveBeenCalledWith("test-plugin", commands);
       expect(mockSkillManager.registerPluginSkills).toHaveBeenCalledWith(
+        "test-plugin",
         skills,
       );
       expect(mockLspManager.registerServer).toHaveBeenCalledWith(

--- a/packages/agent-sdk/tests/managers/skillManager.test.ts
+++ b/packages/agent-sdk/tests/managers/skillManager.test.ts
@@ -265,12 +265,14 @@ describe("SkillManager", () => {
         errors: [],
       };
 
-      skillManager.registerPluginSkills([pluginSkill]);
+      skillManager.registerPluginSkills("test-plugin", [pluginSkill]);
 
       const skills = skillManager.getAvailableSkills();
-      expect(skills.find((s) => s.name === "plugin-skill")).toBeDefined();
+      expect(
+        skills.find((s) => s.name === "test-plugin:plugin-skill"),
+      ).toBeDefined();
       expect(logger.debug).toHaveBeenCalledWith(
-        expect.stringContaining("Registered 1 plugin skills"),
+        expect.stringContaining("Registered 1 plugin skills from test-plugin"),
       );
     });
 
@@ -301,15 +303,48 @@ describe("SkillManager", () => {
         userInvocable: false,
       };
 
-      skillManager.registerPluginSkills([pluginSkill]);
+      skillManager.registerPluginSkills("test-plugin", [pluginSkill]);
 
-      const metadata = skillManager.getSkillMetadata("plugin-skill");
+      const metadata = skillManager.getSkillMetadata(
+        "test-plugin:plugin-skill",
+      );
       expect(metadata).toBeDefined();
       expect(metadata?.context).toBe("fork");
       expect(metadata?.agent).toBe("general-purpose");
       expect(metadata?.model).toBe("gpt-4");
       expect(metadata?.disableModelInvocation).toBe(true);
       expect(metadata?.userInvocable).toBe(false);
+      expect(metadata?.pluginName).toBe("test-plugin");
+    });
+
+    it("should namespace skill names from plugins", async () => {
+      // Initialize first
+      vi.mocked(readdir).mockResolvedValue([]);
+      await skillManager.initialize();
+
+      const pluginSkill: Skill = {
+        name: "my-skill",
+        description: "from plugin",
+        type: "personal",
+        skillPath: "/plugin/path",
+        content: "content",
+        frontmatter: { name: "my-skill", description: "from plugin" },
+        isValid: true,
+        errors: [],
+      };
+
+      skillManager.registerPluginSkills("my-plugin", [pluginSkill]);
+
+      const skills = skillManager.getAvailableSkills();
+      const namespacedSkill = skills.find(
+        (s) => s.name === "my-plugin:my-skill",
+      );
+      expect(namespacedSkill).toBeDefined();
+      expect(namespacedSkill?.pluginName).toBe("my-plugin");
+      expect(pluginSkill.name).toBe("my-plugin:my-skill");
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("Registered 1 plugin skills from my-plugin"),
+      );
     });
   });
 
@@ -372,13 +407,15 @@ describe("SkillManager", () => {
 
       vi.mocked(readdir).mockResolvedValue([]);
       await skillManager.initialize();
-      skillManager.registerPluginSkills([mockSkill]);
+      skillManager.registerPluginSkills("test-plugin", [mockSkill]);
 
       const result = await skillManager.executeSkill({
-        skill_name: "test-skill",
+        skill_name: "test-plugin:test-skill",
       });
 
-      expect(result.content).toContain("🧠 **test-skill** (personal skill)");
+      expect(result.content).toContain(
+        "🧠 **test-plugin:test-skill** (personal skill)",
+      );
       expect(result.content).toContain("*A test skill*");
       expect(result.content).toContain("📁 Skill location: `/path/to/skill`");
       expect(result.content).toContain("# Actual Content");
@@ -405,13 +442,15 @@ describe("SkillManager", () => {
 
       vi.mocked(readdir).mockResolvedValue([]);
       await skillManager.initialize();
-      skillManager.registerPluginSkills([mockSkill]);
+      skillManager.registerPluginSkills("test-plugin", [mockSkill]);
 
       const result = await skillManager.executeSkill({
-        skill_name: "fork-skill",
+        skill_name: "test-plugin:fork-skill",
       });
 
-      expect(result.content).toContain("🧠 **fork-skill** (personal skill)");
+      expect(result.content).toContain(
+        "🧠 **test-plugin:fork-skill** (personal skill)",
+      );
       expect(result.content).not.toContain("🔄 Context: `fork`");
       expect(result.content).toContain("# Actual Content");
     });
@@ -430,10 +469,10 @@ describe("SkillManager", () => {
 
       vi.mocked(readdir).mockResolvedValue([]);
       await skillManager.initialize();
-      skillManager.registerPluginSkills([mockSkill]);
+      skillManager.registerPluginSkills("test-plugin", [mockSkill]);
 
       const result = await skillManager.executeSkill({
-        skill_name: "test-skill",
+        skill_name: "test-plugin:test-skill",
       });
 
       expect(result.content).toContain("# Just Content");
@@ -454,10 +493,10 @@ describe("SkillManager", () => {
 
       vi.mocked(readdir).mockResolvedValue([]);
       await skillManager.initialize();
-      skillManager.registerPluginSkills([mockSkill]);
+      skillManager.registerPluginSkills("test-plugin", [mockSkill]);
 
       const result = await skillManager.executeSkill({
-        skill_name: "path-skill",
+        skill_name: "test-plugin:path-skill",
       });
 
       expect(result.content).toContain("Skill is at /path/to/skill");

--- a/packages/agent-sdk/tests/managers/skillManager_args.test.ts
+++ b/packages/agent-sdk/tests/managers/skillManager_args.test.ts
@@ -57,10 +57,10 @@ describe("SkillManager with Arguments and Bash", () => {
       errors: [],
     };
 
-    skillManager.registerPluginSkills([mockSkill]);
+    skillManager.registerPluginSkills("test-plugin", [mockSkill]);
 
     const result = await skillManager.executeSkill({
-      skill_name: "test-skill",
+      skill_name: "test-plugin:test-skill",
       args: "World 'and friends'",
     });
 
@@ -79,10 +79,10 @@ describe("SkillManager with Arguments and Bash", () => {
       errors: [],
     };
 
-    skillManager.registerPluginSkills([mockSkill]);
+    skillManager.registerPluginSkills("test-plugin", [mockSkill]);
 
     const result = await skillManager.executeSkill({
-      skill_name: "bash-skill",
+      skill_name: "test-plugin:bash-skill",
     });
 
     expect(result.content).toContain(
@@ -102,10 +102,10 @@ describe("SkillManager with Arguments and Bash", () => {
       errors: [],
     };
 
-    skillManager.registerPluginSkills([mockSkill]);
+    skillManager.registerPluginSkills("test-plugin", [mockSkill]);
 
     const result = await skillManager.executeSkill({
-      skill_name: "mixed-skill",
+      skill_name: "test-plugin:mixed-skill",
       args: "User",
     });
 

--- a/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
+++ b/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
@@ -263,6 +263,43 @@ describe("SlashCommandManager", () => {
       });
     });
 
+    it("should register namespaced skill commands", async () => {
+      const mockSkillManager = {
+        executeSkill: vi.fn().mockResolvedValue({
+          content: "Skill content",
+        }),
+      };
+
+      const container = (
+        slashCommandManager as unknown as { container: Container }
+      ).container;
+      container.register("SkillManager", mockSkillManager);
+
+      const skills = [
+        {
+          name: "my-plugin:my-skill",
+          description: "Test skill description",
+          type: "personal",
+          skillPath: "/path/to/skill",
+          pluginName: "my-plugin",
+        },
+      ];
+
+      slashCommandManager.registerSkillCommands(
+        skills as unknown as SkillMetadata[],
+      );
+
+      expect(slashCommandManager.hasCommand("my-plugin:my-skill")).toBe(true);
+
+      const cmd = slashCommandManager.getCommand("my-plugin:my-skill");
+      await cmd?.handler("test args");
+
+      expect(mockSkillManager.executeSkill).toHaveBeenCalledWith({
+        skill_name: "my-plugin:my-skill",
+        args: "test args",
+      });
+    });
+
     it("should NOT substitute ${WAVE_SKILL_DIR} in regular slash commands", async () => {
       const pluginName = "test-plugin";
       const commands = [

--- a/specs/006-agent-skills-support/contracts/type-definitions.md
+++ b/specs/006-agent-skills-support/contracts/type-definitions.md
@@ -18,6 +18,10 @@ export interface SkillMetadata {
   allowedTools?: string[];         // Optional list of allowed tools
   context?: 'fork';                // Optional execution context
   agent?: string;                  // Optional agent type for fork context
+  model?: string;                  // Optional model override
+  disableModelInvocation?: boolean; // Optional flag to disable AI invocation
+  userInvocable?: boolean;         // Optional flag to control slash command visibility
+  pluginName?: string;             // Optional name of the plugin providing the skill
 }
 
 /**

--- a/specs/042-plugin-support/contracts/plugin-system.md
+++ b/specs/042-plugin-support/contracts/plugin-system.md
@@ -52,8 +52,8 @@ export interface PluginManager {
 ## 4. Component Registration
 Each component type (Commands, Skills, Hooks, Agents, LSP, MCP) MUST have a corresponding manager or service that handles its registration and execution.
 
-- **SlashCommandManager**: Registers and executes slash commands.
-- **SkillManager**: Registers and executes skills.
+- **SlashCommandManager**: Registers and executes slash commands. Plugin commands MUST be namespaced using the plugin name and a colon (e.g., `plugin-name:command-name`).
+- **SkillManager**: Registers and executes skills. Plugin skills MUST be namespaced using the plugin name and a colon (e.g., `plugin-name:skill-name`).
 - **HookManager**: Registers and executes hooks.
 - **AgentManager**: Registers and executes agents.
 - **LspService**: Manages LSP configurations.

--- a/specs/042-plugin-support/data-model.md
+++ b/specs/042-plugin-support/data-model.md
@@ -16,6 +16,7 @@ Represents a loaded plugin in the system.
 | `path` | `string` | Absolute path to the plugin directory. |
 | `manifest` | `PluginManifest` | The static definition of the plugin. |
 | `components` | `object` | List of components provided by the plugin. |
+| `skills` | `Skill[]` | List of skills provided by the plugin. |
 
 ### 2. PluginManifest
 The structure of the `.wave-plugin/plugin.json` file.
@@ -46,4 +47,5 @@ The existing `WaveConfiguration` interface will be updated to include `enabledPl
 2. **Component Location**: All component directories (`commands/`, `skills/`, `hooks/`, `agents/`) and config files (`.lsp.json`, `.mcp.json`) MUST be at the plugin root level.
 3. **Misplacement Check**: Component directories MUST NOT be inside `.wave-plugin/`.
 4. **Plugin ID Format**: Plugin IDs MUST follow the `name@marketplace` format for scope management.
-5. **Scope Priority**: `local` > `project` > `user`.
+5. **Namespacing**: Both slash commands and agent skills provided by plugins MUST be namespaced using the plugin name and a colon (e.g., `plugin-name:component-name`).
+6. **Scope Priority**: `local` > `project` > `user`.

--- a/specs/042-plugin-support/spec.md
+++ b/specs/042-plugin-support/spec.md
@@ -45,6 +45,7 @@ As a developer, I want the system to warn me if I put component directories (lik
     - `.mcp.json`: MCP server configurations.
 - **FR-005**: System MUST enforce that only `plugin.json` is located inside the `.wave-plugin/` directory.
 - **FR-006**: Slash commands MUST be namespaced using the plugin name and a colon (e.g., `/plugin-name:command-name`).
+- **FR-011**: Agent Skills provided by plugins MUST be namespaced using the plugin name and a colon (e.g., `/plugin-name:skill-name`).
 - **FR-007**: System MUST support three installation scopes: `user` (global), `project` (shared via repo), and `local` (user-specific to repo).
 - **FR-008**: Plugin loading logic MUST aggregate `enabledPlugins` from all applicable scopes and apply them in priority order: `local` > `project` > `user`.
 - **FR-009**: `wave plugin install` MUST automatically add the plugin to `enabledPlugins` in the specified scope.


### PR DESCRIPTION
This PR implements namespacing for skills provided by plugins, ensuring they are registered as `[pluginName]:[skillName]`. It also updates the `SkillMetadata` type and relevant specification documents to reflect these changes.

Key changes:
- Added `pluginName` to `SkillMetadata`.
- Updated `SkillManager.registerPluginSkills` to require `pluginName` and handle namespacing.
- Updated `PluginManager` to pass the plugin name during skill registration.
- Updated automated tests for `SkillManager`, `PluginManager`, and `SlashCommandManager`.
- Updated specifications in `specs/` to include namespacing requirements and updated type definitions.