### PR TITLE
feat: implement word-level diff improvements for multi-line changes

### DIFF
--- a/packages/code/src/components/DiffDisplay.tsx
+++ b/packages/code/src/components/DiffDisplay.tsx
@@ -154,27 +154,58 @@ export const DiffDisplay: React.FC<DiffDisplayProps> = ({
 
           // Process line diffs
           const diffElements: React.ReactNode[] = [];
-          lineDiffs.forEach((part, partIndex) => {
+          for (let i = 0; i < lineDiffs.length; i++) {
+            const part = lineDiffs[i];
             const lines = part.value.split("\n");
             // diffLines might return a trailing empty string if the content ends with a newline
             if (lines[lines.length - 1] === "") {
               lines.pop();
             }
 
-            if (part.added) {
-              lines.forEach((line, lineIndex) => {
-                diffElements.push(
-                  renderLine(
-                    null,
-                    newLineNum++,
-                    "+",
-                    line,
-                    "green",
-                    `add-${changeIndex}-${partIndex}-${lineIndex}`,
-                  ),
-                );
-              });
-            } else if (part.removed) {
+            if (part.removed) {
+              // Look ahead for an added block
+              if (i + 1 < lineDiffs.length && lineDiffs[i + 1].added) {
+                const nextPart = lineDiffs[i + 1];
+                const addedLines = nextPart.value.split("\n");
+                if (addedLines[addedLines.length - 1] === "") {
+                  addedLines.pop();
+                }
+
+                if (lines.length === addedLines.length) {
+                  // Word-level diffing
+                  lines.forEach((line, lineIndex) => {
+                    const { removedParts, addedParts } = renderWordLevelDiff(
+                      line,
+                      addedLines[lineIndex],
+                      `word-${changeIndex}-${i}-${lineIndex}`,
+                    );
+                    diffElements.push(
+                      renderLine(
+                        oldLineNum++,
+                        null,
+                        "-",
+                        removedParts,
+                        "red",
+                        `remove-${changeIndex}-${i}-${lineIndex}`,
+                      ),
+                    );
+                    diffElements.push(
+                      renderLine(
+                        null,
+                        newLineNum++,
+                        "+",
+                        addedParts,
+                        "green",
+                        `add-${changeIndex}-${i}-${lineIndex}`,
+                      ),
+                    );
+                  });
+                  i++; // Skip the added block
+                  continue;
+                }
+              }
+
+              // Fallback to standard removed rendering
               lines.forEach((line, lineIndex) => {
                 diffElements.push(
                   renderLine(
@@ -183,14 +214,27 @@ export const DiffDisplay: React.FC<DiffDisplayProps> = ({
                     "-",
                     line,
                     "red",
-                    `remove-${changeIndex}-${partIndex}-${lineIndex}`,
+                    `remove-${changeIndex}-${i}-${lineIndex}`,
+                  ),
+                );
+              });
+            } else if (part.added) {
+              lines.forEach((line, lineIndex) => {
+                diffElements.push(
+                  renderLine(
+                    null,
+                    newLineNum++,
+                    "+",
+                    line,
+                    "green",
+                    `add-${changeIndex}-${i}-${lineIndex}`,
                   ),
                 );
               });
             } else {
               // Context lines - show unchanged content
-              const isFirstBlock = partIndex === 0;
-              const isLastBlock = partIndex === lineDiffs.length - 1;
+              const isFirstBlock = i === 0;
+              const isLastBlock = i === lineDiffs.length - 1;
 
               let linesToDisplay = lines;
               let showEllipsisTop = false;
@@ -221,7 +265,7 @@ export const DiffDisplay: React.FC<DiffDisplayProps> = ({
 
               if (showEllipsisTop) {
                 diffElements.push(
-                  <Box key={`ellipsis-top-${changeIndex}-${partIndex}`}>
+                  <Box key={`ellipsis-top-${changeIndex}-${i}`}>
                     <Text color="gray">{" ".repeat(maxDigits * 2 + 2)}...</Text>
                   </Box>,
                 );
@@ -239,7 +283,7 @@ export const DiffDisplay: React.FC<DiffDisplayProps> = ({
                   oldLineNum += skipCount;
                   newLineNum += skipCount;
                   diffElements.push(
-                    <Box key={`ellipsis-mid-${changeIndex}-${partIndex}`}>
+                    <Box key={`ellipsis-mid-${changeIndex}-${i}`}>
                       <Text color="gray">
                         {" ".repeat(maxDigits * 2 + 2)}...
                       </Text>
@@ -254,7 +298,7 @@ export const DiffDisplay: React.FC<DiffDisplayProps> = ({
                     " ",
                     line,
                     "white",
-                    `context-${changeIndex}-${partIndex}-${lineIndex}`,
+                    `context-${changeIndex}-${i}-${lineIndex}`,
                   ),
                 );
               });
@@ -266,62 +310,14 @@ export const DiffDisplay: React.FC<DiffDisplayProps> = ({
                 oldLineNum += skipCount;
                 newLineNum += skipCount;
                 diffElements.push(
-                  <Box key={`ellipsis-bottom-${changeIndex}-${partIndex}`}>
+                  <Box key={`ellipsis-bottom-${changeIndex}-${i}`}>
                     <Text color="gray">{" ".repeat(maxDigits * 2 + 2)}...</Text>
                   </Box>,
                 );
               }
             }
-          });
-
-          // If it's a single line change (one removed, one added), use word-level diff
-          if (
-            diffElements.length === 2 &&
-            React.isValidElement(diffElements[0]) &&
-            React.isValidElement(diffElements[1]) &&
-            typeof diffElements[0].key === "string" &&
-            diffElements[0].key.includes("remove-") &&
-            typeof diffElements[1].key === "string" &&
-            diffElements[1].key.includes("add-")
-          ) {
-            const removedText = extractTextFromElement(diffElements[0]);
-            const addedText = extractTextFromElement(diffElements[1]);
-            const oldLineNumVal = extractOldLineNumFromElement(diffElements[0]);
-            const newLineNumVal = extractNewLineNumFromElement(diffElements[1]);
-
-            if (removedText && addedText) {
-              const { removedParts, addedParts } = renderWordLevelDiff(
-                removedText,
-                addedText,
-                `word-${changeIndex}`,
-              );
-
-              allElements.push(
-                renderLine(
-                  oldLineNumVal,
-                  null,
-                  "-",
-                  removedParts,
-                  "red",
-                  `word-diff-removed-${changeIndex}`,
-                ),
-              );
-              allElements.push(
-                renderLine(
-                  null,
-                  newLineNumVal,
-                  "+",
-                  addedParts,
-                  "green",
-                  `word-diff-added-${changeIndex}`,
-                ),
-              );
-            } else {
-              allElements.push(...diffElements);
-            }
-          } else {
-            allElements.push(...diffElements);
           }
+          allElements.push(...diffElements);
         } catch (error) {
           console.warn(
             `Error rendering diff for change ${changeIndex}:`,
@@ -360,72 +356,4 @@ export const DiffDisplay: React.FC<DiffDisplayProps> = ({
       </Box>
     </Box>
   );
-};
-
-// Helper function to extract text content from a React element
-const extractTextFromElement = (element: React.ReactNode): string | null => {
-  if (!React.isValidElement(element)) return null;
-
-  // Navigate through Box -> Text structure
-  // Our new structure is: Box -> Text (old), Text (new), Text (|), Text (prefix), Text (content)
-  const children = (
-    element.props as unknown as { children?: React.ReactNode[] }
-  ).children;
-  if (Array.isArray(children) && children.length >= 5) {
-    const textElement = children[4]; // Fifth child should be the Text with content
-    if (React.isValidElement(textElement)) {
-      const textChildren = (textElement.props as Record<string, unknown>)
-        .children;
-      return Array.isArray(textChildren)
-        ? textChildren.join("")
-        : String(textChildren || "");
-    }
-  }
-  return null;
-};
-
-const extractOldLineNumFromElement = (
-  element: React.ReactNode,
-): number | null => {
-  if (!React.isValidElement(element)) return null;
-  const children = (
-    element.props as unknown as { children?: React.ReactNode[] }
-  ).children;
-  if (Array.isArray(children) && children.length >= 1) {
-    const textElement = children[0];
-    if (React.isValidElement(textElement)) {
-      const textChildren = (textElement.props as Record<string, unknown>)
-        .children;
-      const val = (
-        Array.isArray(textChildren)
-          ? textChildren.join("")
-          : String(textChildren || "")
-      ).trim();
-      return val ? parseInt(val, 10) : null;
-    }
-  }
-  return null;
-};
-
-const extractNewLineNumFromElement = (
-  element: React.ReactNode,
-): number | null => {
-  if (!React.isValidElement(element)) return null;
-  const children = (
-    element.props as unknown as { children?: React.ReactNode[] }
-  ).children;
-  if (Array.isArray(children) && children.length >= 2) {
-    const textElement = children[1];
-    if (React.isValidElement(textElement)) {
-      const textChildren = (textElement.props as Record<string, unknown>)
-        .children;
-      const val = (
-        Array.isArray(textChildren)
-          ? textChildren.join("")
-          : String(textChildren || "")
-      ).trim();
-      return val ? parseInt(val, 10) : null;
-    }
-  }
-  return null;
 };

--- a/packages/code/tests/components/DiffDisplay.test.tsx
+++ b/packages/code/tests/components/DiffDisplay.test.tsx
@@ -54,7 +54,7 @@ describe("DiffDisplay", () => {
     expect(frame).toContain("brown fox");
   });
 
-  it("should not use word-level diff for multi-line changes", () => {
+  it("should use word-level diff for multi-line changes with matching line counts", () => {
     const params = JSON.stringify({
       old_string: "line 1\nline 2",
       new_string: "line 1 modified\nline 2 modified",
@@ -63,15 +63,21 @@ describe("DiffDisplay", () => {
     const { lastFrame } = render(
       <DiffDisplay toolName={EDIT_TOOL_NAME} parameters={params} />,
     );
-    const frame = lastFrame();
-    // In multi-line, it should just show the lines with +/-
+    const frame = lastFrame() || "";
+    // In multi-line with matching line counts, it should show alternating lines
     expect(frame).toContain("-line 1");
-    expect(frame).toContain("-line 2");
     expect(frame).toContain("+line 1 modified");
+    expect(frame).toContain("-line 2");
     expect(frame).toContain("+line 2 modified");
-    // It should NOT have the word-level highlighting (which uses background colors)
-    // Since we can't easily check background colors in the text output here,
-    // we just verify the basic structure is correct.
+
+    const minusLine1Index = frame.indexOf("-line 1");
+    const plusLine1Index = frame.indexOf("+line 1 modified");
+    const minusLine2Index = frame.indexOf("-line 2");
+    const plusLine2Index = frame.indexOf("+line 2 modified");
+
+    expect(minusLine1Index).toBeLessThan(plusLine1Index);
+    expect(plusLine1Index).toBeLessThan(minusLine2Index);
+    expect(minusLine2Index).toBeLessThan(plusLine2Index);
   });
 
   it("should not truncate long diffs", () => {

--- a/specs/001-fs-tools/spec.md
+++ b/specs/001-fs-tools/spec.md
@@ -34,6 +34,7 @@ As an AI agent, I want to modify files using exact string replacements so that I
 
 1. **Given** a file has been read, **When** the agent calls `Edit` with a unique `old_string`, **Then** the file MUST be updated with `new_string`.
 3. **Given** the `old_string` is not unique, **When** the agent calls `Edit` without `replace_all`, **Then** the operation MUST fail.
+4. **Given** an `Edit` tool call, **When** the diff is displayed, **Then** it MUST show word-level highlights for changed parts when the number of removed and added lines match.
 
 ---
 
@@ -73,6 +74,7 @@ As an AI agent, I want to search for patterns and list files using glob patterns
 - **FR-009**: System MUST provide a `Glob` tool for fast pattern matching. It MUST NOT respect `.gitignore` (but MUST always ignore the `.git` directory) and limit results to 100.
 - **FR-010**: System MUST provide a `Grep` tool based on ripgrep for powerful text searching. It MUST respect `.gitignore` and common ignore patterns.
 - **FR-011**: All tools MUST integrate with the `PermissionManager` for authorization.
+- **FR-012**: System MUST provide a visual diff display with word-level highlights for line-by-line changes.
 
 ### Key Entities *(include if feature involves data)*
 


### PR DESCRIPTION
This PR improves the diff display in `packages/code` by enabling word-level highlights for multi-line changes where the number of removed and added lines match.

Key changes:
- Refactored `renderExpandedDiff` in `DiffDisplay.tsx` to use a lookahead mechanism for pairing removed and added lines.
- Enabled line-by-line word-level diffing for paired blocks.
- Cleaned up unused helper functions and restrictive post-processing logic.
- Updated `specs/001-fs-tools/spec.md` with new functional requirements and acceptance scenarios.
- Updated integration tests to verify the new alternating line display for multi-line word-level diffs.