### PR TITLE
feat(agent-sdk): retry OpenAI requests on network errors (TypeError)

### DIFF
--- a/packages/agent-sdk/src/utils/openaiClient.ts
+++ b/packages/agent-sdk/src/utils/openaiClient.ts
@@ -97,13 +97,29 @@ export class OpenAIClient {
         await new Promise((resolve) => setTimeout(resolve, delay));
       }
 
-      const response = await fetchFn(url, {
-        method: "POST",
-        headers,
-        body: JSON.stringify(params),
-        signal: options?.signal,
-        ...(fetchOptions as RequestInit),
-      });
+      let response: Response;
+      try {
+        response = await fetchFn(url, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(params),
+          signal: options?.signal,
+          ...(fetchOptions as RequestInit),
+        });
+      } catch (e) {
+        if (e instanceof Error && e.name === "AbortError") {
+          throw e;
+        }
+        if (attempt < maxRetries) {
+          logger.warn("OpenAI API network error, retrying...", {
+            attempt: attempt + 1,
+            error: e,
+          });
+          lastError = e as Error;
+          continue;
+        }
+        throw e;
+      }
 
       if (response.ok) {
         if (params.stream) {

--- a/packages/agent-sdk/tests/utils/openaiClient.test.ts
+++ b/packages/agent-sdk/tests/utils/openaiClient.test.ts
@@ -303,5 +303,57 @@ describe("OpenAIClient", () => {
       await expect(promise).rejects.toThrow("Internal Server Error");
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
+
+    it("should retry on network error (TypeError) and eventually succeed", async () => {
+      const mockFetch = vi
+        .fn()
+        .mockRejectedValueOnce(new TypeError("fetch failed"))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{ message: { content: "success" } }],
+          }),
+          headers: new Headers(),
+        });
+
+      const client = new OpenAIClient({
+        baseURL: "https://api.openai.com/v1",
+        apiKey: "test-key",
+        fetch: mockFetch,
+      });
+
+      const promise = client.chat.completions.create({
+        model: "gpt-4",
+        messages: [{ role: "user", content: "hi" }],
+      });
+
+      // First attempt fails with TypeError
+      await vi.runAllTimersAsync();
+
+      const result = await promise;
+      expect(result.choices[0].message.content).toBe("success");
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not retry on AbortError", async () => {
+      const abortError = new Error("The operation was aborted");
+      abortError.name = "AbortError";
+
+      const mockFetch = vi.fn().mockRejectedValue(abortError);
+
+      const client = new OpenAIClient({
+        baseURL: "https://api.openai.com/v1",
+        apiKey: "test-key",
+        fetch: mockFetch,
+      });
+
+      const promise = client.chat.completions.create({
+        model: "gpt-4",
+        messages: [{ role: "user", content: "hi" }],
+      });
+
+      await expect(promise).rejects.toThrow("The operation was aborted");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
This PR improves the `OpenAIClient` retry logic to handle network-level errors (which throw `TypeError`).

Key changes:
- Modified `OpenAIClient._create` to catch and retry on network errors with exponential backoff.
- Explicitly rethrow `AbortError` to avoid retrying on user-initiated cancellations.
- Added test cases to verify retry behavior on `TypeError` and ensure `AbortError` is not retried.