### PR TITLE
feat: add acpx examples and update allowed commands

### DIFF
--- a/.wave/settings.json
+++ b/.wave/settings.json
@@ -16,7 +16,9 @@
       "Bash(gh pr view*)",
       "Bash(gh pr checks*)",
       "Bash(gh pr diff*)",
-      "Bash(node packages/code/dist/index.js *)"
+      "Bash(node packages/code/dist/index.js *)",
+      "Bash(wave *)",
+      "Bash(acpx *)"
     ],
     "additionalDirectories": [
       "../wave-plugins-official",

--- a/packages/code/examples/acpx-hello.ts
+++ b/packages/code/examples/acpx-hello.ts
@@ -1,0 +1,21 @@
+import { execSync } from "node:child_process";
+
+/**
+ * Simple hello world using acpx and wave --acp
+ */
+async function runHello() {
+  console.log("--- Running acpx hello ---");
+  try {
+    const output = execSync(
+      'acpx --agent "wave --acp" --approve-all exec "hello"',
+      { encoding: "utf8" },
+    );
+    console.log(output);
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error("Error running acpx hello:", error.message);
+    }
+  }
+}
+
+runHello().catch(console.error);

--- a/packages/code/examples/acpx-json-demo.ts
+++ b/packages/code/examples/acpx-json-demo.ts
@@ -1,0 +1,30 @@
+import { execSync } from "node:child_process";
+
+/**
+ * Example of getting JSON output from acpx to interact with wave --acp
+ */
+async function runAcpxJsonExample() {
+  console.log("--- Running acpx with JSON output ---");
+  try {
+    const output = execSync(
+      'acpx --agent "wave --acp" --approve-all --format json exec "hello"',
+      { encoding: "utf8" },
+    );
+    const lines = output.trim().split("\n");
+    const jsonObjects = lines.map((line) => JSON.parse(line));
+    console.log(
+      "Parsed JSON output (first 3 objects):",
+      JSON.stringify(jsonObjects.slice(0, 3), null, 2),
+    );
+
+    // Find the final result
+    const finalResult = jsonObjects.find((obj) => obj.id === 2 && obj.result);
+    console.log("Final result:", JSON.stringify(finalResult, null, 2));
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error("Error running acpx with JSON:", error.message);
+    }
+  }
+}
+
+runAcpxJsonExample().catch(console.error);

--- a/packages/code/examples/acpx-one-shot.ts
+++ b/packages/code/examples/acpx-one-shot.ts
@@ -1,0 +1,21 @@
+import { execSync } from "node:child_process";
+
+/**
+ * One-shot command using acpx and wave --acp
+ */
+async function runOneShot() {
+  console.log("--- Running acpx one-shot: list files ---");
+  try {
+    const output = execSync(
+      'acpx --agent "wave --acp" --approve-all exec "list files in the current directory"',
+      { encoding: "utf8" },
+    );
+    console.log(output);
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error("Error running acpx one-shot:", error.message);
+    }
+  }
+}
+
+runOneShot().catch(console.error);


### PR DESCRIPTION
This PR adds several TypeScript examples demonstrating how to use acpx with wave --acp and updates .wave/settings.json to allow wave and acpx commands.