### PR TITLE
feat: add wc -l * to built-in allow permission rules

### DIFF
--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -69,6 +69,7 @@ const DEFAULT_ALLOWED_RULES = [
   "Bash(whoami*)",
   "Bash(date*)",
   "Bash(uptime*)",
+  "Bash(wc -l*)",
 ];
 
 import { logger } from "../utils/globalLogger.js";

--- a/packages/agent-sdk/tests/managers/permissionManager.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.test.ts
@@ -1569,4 +1569,28 @@ describe("PermissionManager", () => {
       expect(rules).toEqual(["Bash(echo hi > file.txt)"]);
     });
   });
+
+  describe("Default Allowed Rules", () => {
+    it("should allow 'wc -l *' by default", async () => {
+      const context: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command: "wc -l *" },
+      };
+
+      const result = await permissionManager.checkPermission(context);
+      expect(result.behavior).toBe("allow");
+    });
+
+    it("should allow 'wc -l file.txt' by default", async () => {
+      const context: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command: "wc -l file.txt" },
+      };
+
+      const result = await permissionManager.checkPermission(context);
+      expect(result.behavior).toBe("allow");
+    });
+  });
 });

--- a/specs/024-tool-permission-system/tasks.md
+++ b/specs/024-tool-permission-system/tasks.md
@@ -37,3 +37,6 @@
 - [x] T022 Comprehensive unit tests for all matching logic.
 - [x] T023 Integration tests for Agent permission flows.
 - [x] T024 Documentation and Quickstart updates.
+
+## Phase 7: Additional Built-in Rules
+- [x] T025 Add `wc -l *` to the built-in allow permission rules.


### PR DESCRIPTION
This PR adds `wc -l *` to the built-in allow permission rules in `PermissionManager`. This allows the command to be executed without explicit permission prompts in default mode.

Changes:
- Added `Bash(wc -l*)` to `DEFAULT_ALLOWED_RULES` in `packages/agent-sdk/src/managers/permissionManager.ts`.
- Added unit tests in `packages/agent-sdk/tests/managers/permissionManager.test.ts`.
- Updated `specs/024-tool-permission-system/tasks.md`.