### PR TITLE
feat: auto-deny find and sed in Bash tool

### DIFF
--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -36,6 +36,11 @@ import { ConfigurationService } from "../services/configurationService.js";
 
 const SAFE_COMMANDS = ["cd", "ls", "pwd", "true", "false"];
 
+const FORBIDDEN_COMMAND_MESSAGES: Record<string, string> = {
+  find: "use glob tool instead",
+  sed: "use read or edit tool instead",
+};
+
 const DEFAULT_ALLOWED_RULES = [
   "Bash(git status*)",
   "Bash(git diff*)",
@@ -323,6 +328,32 @@ export class PermissionManager {
   async checkPermission(
     context: ToolPermissionContext,
   ): Promise<PermissionDecision> {
+    // 0. Check for forbidden commands in Bash tool
+    if (context.toolName === BASH_TOOL_NAME && context.toolInput?.command) {
+      const command = String(context.toolInput.command);
+      const parts = splitBashCommand(command);
+
+      for (const part of parts) {
+        let stripped = stripRedirections(stripEnvVars(part));
+
+        // Handle sudo
+        if (stripped.startsWith("sudo ")) {
+          stripped = stripped.substring(5).trim();
+        }
+
+        const tokens = stripped.split(/\s+/);
+        const exe = tokens[0];
+
+        const forbiddenMessage = FORBIDDEN_COMMAND_MESSAGES[exe];
+        if (forbiddenMessage) {
+          return {
+            behavior: "deny",
+            message: forbiddenMessage,
+          };
+        }
+      }
+    }
+
     // 0. Check denied rules first - Deny always takes precedence
     for (const rule of this.deniedRules) {
       if (this.matchesRule(context, rule)) {

--- a/packages/agent-sdk/src/utils/bashParser.ts
+++ b/packages/agent-sdk/src/utils/bashParser.ts
@@ -351,6 +351,8 @@ export const DANGEROUS_COMMANDS = [
   "apt-get",
   "yum",
   "dnf",
+  "find",
+  "sed",
 ];
 
 /**

--- a/packages/agent-sdk/tests/managers/permissionManager.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.test.ts
@@ -1593,4 +1593,82 @@ describe("PermissionManager", () => {
       expect(result.behavior).toBe("allow");
     });
   });
+
+  describe("Forbidden Commands (find, sed)", () => {
+    const workdir = "/home/user/project";
+
+    it("should deny 'find' command with specific message", async () => {
+      const context: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command: "find . -name '*.ts'", workdir },
+      };
+
+      const result = await permissionManager.checkPermission(context);
+      expect(result.behavior).toBe("deny");
+      expect(result.message).toBe("use glob tool instead");
+    });
+
+    it("should deny 'sed' command with specific message", async () => {
+      const context: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command: "sed -i 's/foo/bar/g' file.txt", workdir },
+      };
+
+      const result = await permissionManager.checkPermission(context);
+      expect(result.behavior).toBe("deny");
+      expect(result.message).toBe("use read or edit tool instead");
+    });
+
+    it("should deny 'sudo find' command", async () => {
+      const context: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command: "sudo find / -name secret", workdir },
+      };
+
+      const result = await permissionManager.checkPermission(context);
+      expect(result.behavior).toBe("deny");
+      expect(result.message).toBe("use glob tool instead");
+    });
+
+    it("should deny 'find' within a pipe", async () => {
+      const context: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command: "ls | find .", workdir },
+      };
+
+      const result = await permissionManager.checkPermission(context);
+      expect(result.behavior).toBe("deny");
+      expect(result.message).toBe("use glob tool instead");
+    });
+
+    it("should deny 'sed' within a pipe", async () => {
+      const context: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command: "cat file.txt | sed 's/a/b/'", workdir },
+      };
+
+      const result = await permissionManager.checkPermission(context);
+      expect(result.behavior).toBe("deny");
+      expect(result.message).toBe("use read or edit tool instead");
+    });
+
+    it("should deny even if explicitly allowed by rule", async () => {
+      permissionManager.updateAllowedRules(["Bash(find *)"]);
+
+      const context: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command: "find .", workdir },
+      };
+
+      const result = await permissionManager.checkPermission(context);
+      expect(result.behavior).toBe("deny");
+      expect(result.message).toBe("use glob tool instead");
+    });
+  });
 });

--- a/specs/002-bash-tools/spec.md
+++ b/specs/002-bash-tools/spec.md
@@ -61,6 +61,7 @@ As an AI agent, I want to run long-running commands in the background and retrie
 - **FR-010**: The system MUST maintain environment variables across sequential `Bash` calls (persistent session behavior).
 - **FR-011**: When `run_in_background` is true, the system MUST return an `outputPath` to a real-time log file.
 - **FR-012**: The system MUST pipe `stdout` and `stderr` to the `outputPath` log file in real-time.
+- **FR-013**: The system MUST NOT allow the use of `find` and `sed` commands in the `Bash` tool, and MUST return a specific denial message suggesting the use of specialized tools (`Glob`, `Grep`, `Read`, `Edit`).
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/024-tool-permission-system/spec.md
+++ b/specs/024-tool-permission-system/spec.md
@@ -105,6 +105,7 @@ As a user, I want common safe commands (like `cd`) to be automatically permitted
 #### Built-in Safe Commands
 - **FR-018**: System MUST maintain a built-in list of safe commands (`cd`, `ls`, `pwd`) that are permitted if they operate within the CWD or its subdirectories.
 - **FR-019**: Built-in safe commands attempting to access paths outside the CWD (e.g., `cd ..`, `ls /etc`) MUST require explicit permission.
+- **FR-020**: System MUST NOT allow the use of `find` and `sed` commands in the `Bash` tool, and MUST return a specific denial message suggesting the use of specialized tools (`Glob`, `Grep`, `Read`, `Edit`).
 
 ## Key Entities
 

--- a/specs/038-bash-confirm-safety/spec.md
+++ b/specs/038-bash-confirm-safety/spec.md
@@ -38,6 +38,7 @@ As a user, when I run a command that is considered dangerous or moves outside th
 - **FR-004**: The system MUST ensure that permissions for these "dangerous" or "out-of-bounds" commands are never persisted to the `permissions.allow` configuration.
 - **FR-005**: The system MUST detect write redirections (`>`, `>>`, `&>`, `2>`, `>|`) in bash commands and treat them as dangerous, hiding the "Don't ask again" option.
 - **FR-006**: The system MUST ensure that bash commands with write redirections are not automatically allowed by default rules (e.g., `Bash(echo*)`).
+- **FR-007**: The system MUST include `find` and `sed` in the list of dangerous commands that should never be permanently authorized, and MUST return a specific denial message suggesting the use of specialized tools (`Glob`, `Grep`, `Read`, `Edit`).
 
 ### Key Entities _(include if feature involves data)_
 


### PR DESCRIPTION
This PR implements the auto-denial of 'find' and 'sed' commands in the Bash tool to encourage the use of specialized tools like Glob, Grep, Read, and Edit.

Key changes:
- Added 'find' and 'sed' to DANGEROUS_COMMANDS in bashParser.ts.
- Updated PermissionManager to intercept and deny 'find' and 'sed' with specific helpful messages.
- Updated specifications (002, 024, 038) to reflect these restrictions.
- Added comprehensive tests in permissionManager.test.ts.