### PR TITLE
fix: add validation and schema reminder to AskUserQuestion tool

### DIFF
--- a/packages/agent-sdk/src/tools/askUserQuestion.ts
+++ b/packages/agent-sdk/src/tools/askUserQuestion.ts
@@ -106,6 +106,15 @@ Plan mode note: In plan mode, use this tool to clarify requirements or choose be
       metadata,
     } = args as unknown as AskUserQuestionInput;
 
+    if (!questions || !Array.isArray(questions) || questions.length === 0) {
+      return {
+        success: false,
+        content: "",
+        error:
+          "The 'questions' parameter is missing or empty. Please use the correct schema: { questions: [{ question, header, options, multiSelect? }] }",
+      };
+    }
+
     if (!context.permissionManager) {
       throw new Error(
         `Permission manager is required for ${ASK_USER_QUESTION_TOOL_NAME} tool`,

--- a/packages/agent-sdk/tests/tools/askUserQuestion.test.ts
+++ b/packages/agent-sdk/tests/tools/askUserQuestion.test.ts
@@ -127,4 +127,26 @@ describe("AskUserQuestion Tool", () => {
       },
     });
   });
+
+  it("should return error when questions parameter is missing or empty", async () => {
+    const context = {
+      permissionManager: {},
+    } as unknown as ToolContext;
+
+    const args = {
+      question: "What is your name?",
+      header: "Name",
+      options: [{ label: "Alice" }, { label: "Bob" }],
+    };
+
+    const result = await askUserQuestionTool.execute(
+      args as unknown as Record<string, unknown>,
+      context,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(
+      "The 'questions' parameter is missing or empty. Please use the correct schema: { questions: [{ question, header, options, multiSelect? }] }",
+    );
+  });
 });


### PR DESCRIPTION
This PR adds validation to the AskUserQuestion tool to ensure the 'questions' parameter is present and correctly formatted. It also provides a helpful error message reminding the AI to use the correct schema if it attempts to use the older single-question format.