### PR TITLE
feat(code): remove --acp flag and add dedicated wave-acp binary

### DIFF
--- a/packages/code/bin/wave-acp.js
+++ b/packages/code/bin/wave-acp.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+// Import and start the ACP CLI
+import("../dist/acp-cli.js")
+  .then(async ({ runAcp }) => {
+    try {
+      await runAcp();
+    } catch (err) {
+      console.error("Failed to start ACP CLI:", err);
+      process.exit(1);
+    }
+  })
+  .catch((err) => {
+    console.error("Failed to import ACP CLI module:", err);
+    process.exit(1);
+  });

--- a/packages/code/examples/acp/acp-test-client.ts
+++ b/packages/code/examples/acp/acp-test-client.ts
@@ -15,8 +15,7 @@ async function runTest() {
     "tsx",
     "--tsconfig",
     "tsconfig.dev.json",
-    "src/index.ts",
-    "--acp",
+    "src/acp-cli.ts",
   ];
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "acp-test-"));
   console.log(`Using temporary directory: ${tmpDir}`);

--- a/packages/code/examples/acp/acpx-hello.ts
+++ b/packages/code/examples/acp/acpx-hello.ts
@@ -7,7 +7,7 @@ import path from "node:path";
  * Simple hello world using acpx and wave --acp
  */
 async function runHello() {
-  const agentCommand = "tsx --tsconfig tsconfig.dev.json src/index.ts --acp";
+  const agentCommand = "tsx --tsconfig tsconfig.dev.json src/acp-cli.ts";
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "acpx-hello-"));
   console.log(`Using temporary directory: ${tmpDir}`);
   console.log("--- Running acpx hello ---");

--- a/packages/code/examples/acp/acpx-json-demo.ts
+++ b/packages/code/examples/acp/acpx-json-demo.ts
@@ -7,7 +7,7 @@ import path from "node:path";
  * Example of getting JSON output from acpx to interact with wave --acp
  */
 async function runAcpxJsonExample() {
-  const agentCommand = "tsx --tsconfig tsconfig.dev.json src/index.ts --acp";
+  const agentCommand = "tsx --tsconfig tsconfig.dev.json src/acp-cli.ts";
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "acpx-json-"));
   console.log(`Using temporary directory: ${tmpDir}`);
   console.log("--- Running acpx with JSON output ---");

--- a/packages/code/examples/acp/acpx-one-shot.ts
+++ b/packages/code/examples/acp/acpx-one-shot.ts
@@ -7,7 +7,7 @@ import path from "node:path";
  * One-shot command using acpx and wave --acp
  */
 async function runOneShot() {
-  const agentCommand = "tsx --tsconfig tsconfig.dev.json src/index.ts --acp";
+  const agentCommand = "tsx --tsconfig tsconfig.dev.json src/acp-cli.ts";
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "acpx-one-shot-"));
   console.log(`Using temporary directory: ${tmpDir}`);
   console.log("--- Running acpx one-shot: list files ---");

--- a/packages/code/package.json
+++ b/packages/code/package.json
@@ -20,7 +20,8 @@
   "type": "module",
   "bin": {
     "wave-code": "bin/wave-code.js",
-    "wave": "bin/wave-code.js"
+    "wave": "bin/wave-code.js",
+    "wave-acp": "bin/wave-acp.js"
   },
   "files": [
     "dist",
@@ -30,6 +31,7 @@
   ],
   "scripts": {
     "wave": "tsx --tsconfig tsconfig.dev.json src/index.ts",
+    "wave-acp": "tsx --tsconfig tsconfig.dev.json src/acp-cli.ts",
     "build": "rimraf dist && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "type-check": "tsc --noEmit --incremental",
     "watch": "tsc -p tsconfig.build.json --watch & tsc-alias -p tsconfig.build.json --watch",

--- a/packages/code/src/acp-cli.ts
+++ b/packages/code/src/acp-cli.ts
@@ -3,3 +3,10 @@ import { startAcpCli } from "./acp/index.js";
 export async function runAcp() {
   await startAcpCli();
 }
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runAcp().catch((error) => {
+    console.error("Failed to start WAVE ACP:", error);
+    process.exit(1);
+  });
+}

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -70,11 +70,6 @@ export async function main() {
         type: "string",
         global: false,
       })
-      .option("acp", {
-        description: "Run as an ACP bridge",
-        type: "boolean",
-        global: false,
-      })
       .command("plugin", "Manage plugins and marketplaces", (yargs) => {
         return yargs
           .help()
@@ -249,12 +244,6 @@ export async function main() {
 
     if (worktreeSession) {
       process.chdir(workdir);
-    }
-
-    // Handle ACP mode
-    if (argv.acp) {
-      const { runAcp } = await import("./acp-cli.js");
-      return runAcp();
     }
 
     // Handle restore session command


### PR DESCRIPTION
Removes the --acp flag from the main wave CLI and adds a dedicated wave-acp binary to avoid Ink/TTY dependencies in ACP mode.