### PR TITLE
fix: allow /dev/null redirections in bash command safety check

### DIFF
--- a/packages/agent-sdk/src/utils/bashParser.ts
+++ b/packages/agent-sdk/src/utils/bashParser.ts
@@ -327,6 +327,60 @@ export function hasWriteRedirections(command: string): boolean {
     }
 
     if (char === ">") {
+      // Check if this is a redirection to /dev/null
+      let j = i + 1;
+      // Handle >> or >|
+      if (j < command.length && (command[j] === ">" || command[j] === "|")) {
+        j++;
+      }
+
+      // Skip whitespace after operator
+      while (j < command.length && /\s/.test(command[j])) {
+        j++;
+      }
+
+      // Extract the target word, handling quotes and escapes
+      let target = "";
+      let targetEscaped = false;
+      let targetInSingleQuote = false;
+      let targetInDoubleQuote = false;
+      let k = j;
+      while (k < command.length) {
+        const c = command[k];
+        if (targetEscaped) {
+          targetEscaped = false;
+          target += c;
+          k++;
+          continue;
+        }
+        if (c === "\\") {
+          targetEscaped = true;
+          k++;
+          continue;
+        }
+        if (c === "'" && !targetInDoubleQuote) {
+          targetInSingleQuote = !targetInSingleQuote;
+          k++;
+          continue;
+        }
+        if (c === '"' && !targetInSingleQuote) {
+          targetInDoubleQuote = !targetInDoubleQuote;
+          k++;
+          continue;
+        }
+        if (!targetInSingleQuote && !targetInDoubleQuote && /\s/.test(c)) {
+          break;
+        }
+        target += c;
+        k++;
+      }
+
+      // If the target is exactly /dev/null, we ignore this redirection
+      if (target === "/dev/null") {
+        i = k - 1; // Move the main loop index to the end of the target
+        continue;
+      }
+
       return true;
     }
   }

--- a/packages/agent-sdk/tests/utils/bashParser.test.ts
+++ b/packages/agent-sdk/tests/utils/bashParser.test.ts
@@ -161,6 +161,24 @@ describe("bashParser", () => {
     it("should detect write redirections on subshells", () => {
       expect(hasWriteRedirections("(echo hi) > file")).toBe(true);
     });
+
+    it("should ignore redirections to /dev/null", () => {
+      expect(hasWriteRedirections("ls > /dev/null")).toBe(false);
+      expect(hasWriteRedirections("ls 2> /dev/null")).toBe(false);
+      expect(hasWriteRedirections("ls >> /dev/null")).toBe(false);
+      expect(hasWriteRedirections("ls &> /dev/null")).toBe(false);
+      expect(hasWriteRedirections("ls >| /dev/null")).toBe(false);
+      expect(hasWriteRedirections("ls >/dev/null")).toBe(false);
+      expect(hasWriteRedirections("ls 2>/dev/null")).toBe(false);
+      expect(hasWriteRedirections('ls > "/dev/null"')).toBe(false);
+      expect(hasWriteRedirections("ls > '/dev/null'")).toBe(false);
+    });
+
+    it("should still detect other write redirections when /dev/null is present", () => {
+      expect(hasWriteRedirections("ls > /dev/null > file")).toBe(true);
+      expect(hasWriteRedirections("ls > file 2> /dev/null")).toBe(true);
+      expect(hasWriteRedirections("ls > /dev/null 2>&1")).toBe(true); // 2>&1 is still considered a write redirection
+    });
   });
 
   describe("getSmartPrefix", () => {


### PR DESCRIPTION
This PR modifies the `hasWriteRedirections` function in `bashParser.ts` to ignore redirections to `/dev/null`. This ensures that safe commands like `ls` with `2>/dev/null` do not trigger a confirmation prompt.