### PR TITLE
fix: update too tall logic in ChatInterface to leave 3 lines buffer

### DIFF
--- a/packages/code/src/components/ChatInterface.tsx
+++ b/packages/code/src/components/ChatInterface.tsx
@@ -72,7 +72,7 @@ export const ChatInterface: React.FC = () => {
 
     const terminalHeight = stdout?.rows || 24;
     const totalHeight = detailsHeight + selectorHeight + dynamicBlocksHeight;
-    if (totalHeight > terminalHeight) {
+    if (totalHeight > terminalHeight - 3) {
       setIsConfirmationTooTall(true);
     }
   }, [


### PR DESCRIPTION
Update the 'too tall' logic in ChatInterface to move ConfirmationDetails to the static area if the total height exceeds the terminal height minus 3 lines. This ensures a small buffer at the bottom of the terminal.