### PR TITLE
feat: implement real-time skill discovery and slash command refresh

### DIFF
--- a/packages/agent-sdk/examples/skill-watcher-demo.ts
+++ b/packages/agent-sdk/examples/skill-watcher-demo.ts
@@ -1,0 +1,165 @@
+#!/usr/bin/env tsx
+
+import { SkillManager } from "../src/managers/skillManager.js";
+import { SlashCommandManager } from "../src/managers/slashCommandManager.js";
+import { Container } from "../src/utils/container.js";
+import { Agent } from "../src/agent.js";
+import { tmpdir } from "os";
+import { join } from "path";
+import { mkdir, writeFile, rm } from "fs/promises";
+
+/**
+ * This example demonstrates the real-time skill discovery and slash command refresh.
+ * It shows how SkillManager watches for file system changes and notifies SlashCommandManager
+ * to update available commands without a restart.
+ */
+async function main() {
+  const tempDir = join(tmpdir(), `skill-watcher-demo-${Date.now()}`);
+  const skillsDir = join(tempDir, ".wave", "skills");
+
+  try {
+    // Setup temp skills directory
+    await mkdir(skillsDir, { recursive: true });
+    console.log(`📁 Created temp skills directory: ${skillsDir}`);
+
+    // --- Part 1: Demonstrating the Mechanism ---
+    console.log("\n🔍 Part 1: Demonstrating the Mechanism");
+
+    // Initialize container and managers
+    const container = new Container();
+
+    // 1. Initialize SkillManager with watch: true
+    const skillManager = new SkillManager(container, {
+      workdir: tempDir,
+      watch: true,
+    });
+    container.register("SkillManager", skillManager);
+
+    // 2. Initialize SlashCommandManager (it will listen to SkillManager's 'refreshed' event)
+    const slashCommandManager = new SlashCommandManager(container, {
+      workdir: tempDir,
+    });
+    slashCommandManager.initialize();
+
+    // 3. Initialize SkillManager
+    await skillManager.initialize();
+    console.log("🚀 SkillManager initialized with watcher.");
+
+    // Helper to wait for a refresh event with a timeout
+    const waitForRefresh = (label: string) =>
+      new Promise<void>((resolve) => {
+        const timeout = setTimeout(() => {
+          console.log(
+            `⚠️ Timeout waiting for refresh event (${label}), checking manually...`,
+          );
+          resolve();
+        }, 5000);
+        skillManager.once("refreshed", () => {
+          clearTimeout(timeout);
+          console.log(`✅ SkillManager refreshed (${label})!`);
+          resolve();
+        });
+      });
+
+    // --- Step 1: Add a new skill ---
+    console.log("\n✨ Step 1: Adding a new skill...");
+    const skillPath = join(skillsDir, "dynamic-skill");
+
+    // Wait for the 'refreshed' event from SkillManager
+    const refreshedPromise1 = waitForRefresh("Step 1");
+
+    await mkdir(skillPath, { recursive: true });
+    // Small delay to ensure directory is recognized
+    await new Promise((r) => setTimeout(r, 500));
+
+    await writeFile(
+      join(skillPath, "SKILL.md"),
+      `---
+name: dynamic-skill
+description: A skill added at runtime
+---
+Initial content`,
+    );
+
+    // Wait for the event
+    await refreshedPromise1;
+
+    // If it timed out, wait a bit more and check again
+    if (!skillManager.getSkillMetadata("dynamic-skill")) {
+      console.log("⏳ Still waiting for skill to be discovered...");
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+
+    let skills = skillManager.getAvailableSkills();
+    let commands = slashCommandManager.getCommands();
+    console.log(`Found ${skills.length} skills.`);
+    console.log(`Slash commands: ${commands.map((c) => c.id).join(", ")}`);
+
+    if (commands.some((c) => c.id === "dynamic-skill")) {
+      console.log("🎯 Success: dynamic-skill is available as a slash command!");
+    } else {
+      console.log("❌ dynamic-skill is NOT available as a slash command yet.");
+    }
+
+    // --- Step 2: Modify the skill ---
+    console.log("\n📝 Step 2: Modifying the skill...");
+    const refreshedPromise2 = waitForRefresh("Step 2");
+
+    await writeFile(
+      join(skillPath, "SKILL.md"),
+      `---
+name: dynamic-skill
+description: An UPDATED skill added at runtime
+---
+Updated content`,
+    );
+
+    await refreshedPromise2;
+    // Give a tiny bit of time for SlashCommandManager to process the event
+    await new Promise((r) => setTimeout(r, 100));
+
+    const updatedSkill = skillManager.getSkillMetadata("dynamic-skill");
+    console.log(`Updated description: ${updatedSkill?.description}`);
+
+    // --- Step 3: Deleting the skill ---
+    console.log("\n🗑️ Step 3: Deleting the skill...");
+    const refreshedPromise3 = waitForRefresh("Step 3");
+
+    await rm(skillPath, { recursive: true, force: true });
+
+    await refreshedPromise3;
+    // Give a tiny bit of time for SlashCommandManager to process the event
+    await new Promise((r) => setTimeout(r, 100));
+
+    skills = skillManager.getAvailableSkills();
+    commands = slashCommandManager.getCommands();
+    console.log(`Found ${skills.length} skills.`);
+    if (!commands.some((c) => c.id === "dynamic-skill")) {
+      console.log("🎯 Success: dynamic-skill was removed from slash commands!");
+    }
+
+    // Cleanup watcher
+    await skillManager.destroy();
+
+    // --- Part 2: Real-world usage with Agent ---
+    console.log("\n🤖 Part 2: Real-world usage with Agent");
+    const agent = await Agent.create({
+      workdir: tempDir,
+      watchSkills: true, // Enabled by default
+    });
+
+    console.log("Agent initialized with skill watching enabled.");
+    console.log(
+      "Any changes to .wave/skills will be automatically picked up by the agent.",
+    );
+
+    await agent.destroy();
+  } catch (error) {
+    console.error("❌ Demo failed:", error);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+    console.log("\n🧹 Demo complete");
+  }
+}
+
+main().catch(console.error);

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -470,6 +470,8 @@ export class Agent {
     }
     // Cleanup subagent manager
     this.subagentManager.cleanup();
+    // Cleanup skill manager
+    await this.skillManager.destroy();
     // Cleanup live configuration reload
     try {
       await this.liveConfigManager.shutdown();

--- a/packages/agent-sdk/src/managers/skillManager.ts
+++ b/packages/agent-sdk/src/managers/skillManager.ts
@@ -1,6 +1,8 @@
 import { readdir, stat } from "fs/promises";
 import { join } from "path";
 import { homedir } from "os";
+import { EventEmitter } from "events";
+import { FileWatcherService } from "../services/fileWatcher.js";
 import type {
   SkillManagerOptions,
   SkillMetadata,
@@ -24,7 +26,7 @@ import { logger } from "../utils/globalLogger.js";
 /**
  * Manages skill discovery and loading
  */
-export class SkillManager {
+export class SkillManager extends EventEmitter {
   private personalSkillsPath: string;
   private scanTimeout: number;
   private workdir: string;
@@ -32,15 +34,19 @@ export class SkillManager {
   private skillMetadata = new Map<string, SkillMetadata>();
   private skillContent = new Map<string, Skill>();
   private initialized = false;
+  private fileWatcher: FileWatcherService | null = null;
+  private watchEnabled: boolean;
 
   constructor(
     private container: Container,
     options: SkillManagerOptions = {},
   ) {
+    super();
     this.personalSkillsPath =
       options.personalSkillsPath || join(homedir(), ".wave", "skills");
     this.scanTimeout = options.scanTimeout || 5000;
     this.workdir = options.workdir || process.cwd();
+    this.watchEnabled = options.watch ?? false;
   }
 
   /**
@@ -50,26 +56,10 @@ export class SkillManager {
     logger?.debug("Initializing SkillManager...");
 
     try {
-      // Clear existing data before discovery
-      this.skillMetadata.clear();
-      this.skillContent.clear();
+      await this.refreshSkills();
 
-      const discovery = await this.discoverSkills();
-
-      // Store discovered skill metadata
-      discovery.personalSkills.forEach((skill, name) => {
-        this.skillMetadata.set(name, skill);
-      });
-      discovery.projectSkills.forEach((skill, name) => {
-        this.skillMetadata.set(name, skill);
-      });
-
-      // Log any discovery errors
-      if (discovery.errors.length > 0) {
-        logger?.warn(`Found ${discovery.errors.length} skill discovery errors`);
-        discovery.errors.forEach((error) => {
-          logger?.warn(`Skill error in ${error.skillPath}: ${error.message}`);
-        });
+      if (this.watchEnabled && !this.fileWatcher) {
+        await this.setupWatcher();
       }
 
       this.initialized = true;
@@ -79,6 +69,82 @@ export class SkillManager {
     } catch (error) {
       logger?.error("Failed to initialize SkillManager:", error);
       throw error;
+    }
+  }
+
+  /**
+   * Refresh skills by re-discovering them
+   */
+  private async refreshSkills(): Promise<void> {
+    // Clear existing data before discovery
+    this.skillMetadata.clear();
+    this.skillContent.clear();
+
+    const discovery = await this.discoverSkills();
+
+    // Store discovered skill metadata
+    discovery.personalSkills.forEach((skill, name) => {
+      this.skillMetadata.set(name, skill);
+    });
+    discovery.projectSkills.forEach((skill, name) => {
+      this.skillMetadata.set(name, skill);
+    });
+
+    // Log any discovery errors
+    if (discovery.errors.length > 0) {
+      logger?.warn(`Found ${discovery.errors.length} skill discovery errors`);
+      discovery.errors.forEach((error) => {
+        logger?.warn(`Skill error in ${error.skillPath}: ${error.message}`);
+      });
+    }
+
+    this.emit("refreshed", Array.from(this.skillMetadata.values()));
+  }
+
+  /**
+   * Setup file watcher for skill directories
+   */
+  private async setupWatcher(): Promise<void> {
+    if (this.fileWatcher) {
+      await this.fileWatcher.cleanup();
+    }
+
+    this.fileWatcher = new FileWatcherService(logger);
+
+    const pathsToWatch = [
+      this.personalSkillsPath,
+      join(this.workdir, ".wave", "skills"),
+    ];
+
+    logger?.debug(`Setting up skill watcher for: ${pathsToWatch.join(", ")}`);
+
+    for (const pathToWatch of pathsToWatch) {
+      await this.fileWatcher.watchFile(pathToWatch, async (event) => {
+        if (
+          event.path.endsWith("SKILL.md") ||
+          event.type === "delete" ||
+          event.type === "create"
+        ) {
+          logger?.debug(
+            `Skill change detected (${event.type}): ${event.path}. Refreshing skills...`,
+          );
+          try {
+            await this.refreshSkills();
+          } catch (error) {
+            logger?.error("Failed to refresh skills after change:", error);
+          }
+        }
+      });
+    }
+  }
+
+  /**
+   * Cleanup resources
+   */
+  async destroy(): Promise<void> {
+    if (this.fileWatcher) {
+      await this.fileWatcher.cleanup();
+      this.fileWatcher = null;
     }
   }
 

--- a/packages/agent-sdk/src/managers/slashCommandManager.ts
+++ b/packages/agent-sdk/src/managers/slashCommandManager.ts
@@ -42,6 +42,14 @@ export class SlashCommandManager {
   public initialize(): void {
     this.initializeBuiltinCommands();
     this.loadCustomCommands();
+
+    // Listen for skill refreshes and update skill commands
+    const skillManager = this.container.get<SkillManager>("SkillManager");
+    if (skillManager) {
+      skillManager.on("refreshed", (skills: SkillMetadata[]) => {
+        this.registerSkillCommands(skills);
+      });
+    }
   }
 
   private get messageManager(): MessageManager {

--- a/packages/agent-sdk/src/services/fileWatcher.ts
+++ b/packages/agent-sdk/src/services/fileWatcher.ts
@@ -95,7 +95,7 @@ export class FileWatcherService extends EventEmitter {
       await this.initializeWatcher(entry);
     } catch (error) {
       this.logger?.error(
-        `Live Config: Failed to watch file ${path}: ${(error as Error).message}`,
+        `FileWatcher: Failed to watch file ${path}: ${(error as Error).message}`,
       );
       throw error;
     }
@@ -117,7 +117,7 @@ export class FileWatcherService extends EventEmitter {
       this.watchers.delete(path);
     } catch (error) {
       this.logger?.warn(
-        `Live Config: Error unwatching file ${path}: ${(error as Error).message}`,
+        `FileWatcher: Error unwatching file ${path}: ${(error as Error).message}`,
       );
     }
   }
@@ -204,7 +204,7 @@ export class FileWatcherService extends EventEmitter {
       entry.lastError = (error as Error).message;
 
       this.logger?.error(
-        `Live Config: Failed to initialize watcher for ${entry.path}: ${(error as Error).message}`,
+        `FileWatcher: Failed to initialize watcher for ${entry.path}: ${(error as Error).message}`,
       );
 
       // Try fallback polling if not already using it
@@ -241,9 +241,17 @@ export class FileWatcherService extends EventEmitter {
       this.handleFileEvent("delete", filePath);
     });
 
+    this.globalWatcher.on("addDir", (dirPath: string) => {
+      this.handleFileEvent("create", dirPath);
+    });
+
+    this.globalWatcher.on("unlinkDir", (dirPath: string) => {
+      this.handleFileEvent("delete", dirPath);
+    });
+
     this.globalWatcher.on("error", (err: unknown) => {
       const error = err instanceof Error ? err : new Error(String(err));
-      this.logger?.error(`Live Config: File watcher error: ${error.message}`);
+      this.logger?.error(`FileWatcher: File watcher error: ${error.message}`);
       this.emit("watcherError", error);
     });
   }
@@ -253,9 +261,6 @@ export class FileWatcherService extends EventEmitter {
     filePath: string,
     stats?: { size?: number },
   ): void {
-    const entry = this.watchers.get(filePath);
-    if (!entry) return;
-
     const event: FileWatchEvent = {
       type,
       path: filePath,
@@ -263,16 +268,27 @@ export class FileWatcherService extends EventEmitter {
       size: stats?.size,
     };
 
-    entry.lastEvent = event.timestamp;
+    // Notify all watchers that match the path or are parents of the path
+    for (const [watchedPath, entry] of this.watchers.entries()) {
+      if (
+        filePath === watchedPath ||
+        filePath.startsWith(watchedPath + "/") ||
+        // Handle cases where the watched path might be a file and we get an event for it
+        // (already covered by filePath === watchedPath)
+        false
+      ) {
+        entry.lastEvent = event.timestamp;
 
-    // Notify all callbacks for this file
-    for (const callback of entry.callbacks) {
-      try {
-        callback(event);
-      } catch (error) {
-        this.logger?.error(
-          `Live Config: Error in file watch callback for ${filePath}: ${(error as Error).message}`,
-        );
+        // Notify all callbacks for this watcher
+        for (const callback of entry.callbacks) {
+          try {
+            callback(event);
+          } catch (error) {
+            this.logger?.error(
+              `FileWatcher: Error in file watch callback for ${watchedPath} (event on ${filePath}): ${(error as Error).message}`,
+            );
+          }
+        }
       }
     }
   }

--- a/packages/agent-sdk/src/types/agent.ts
+++ b/packages/agent-sdk/src/types/agent.ts
@@ -65,6 +65,8 @@ export interface AgentOptions {
   worktreeName?: string;
   /**Whether this is a newly created worktree */
   isNewWorktree?: boolean;
+  /**Whether to watch for skill changes - defaults to true */
+  watchSkills?: boolean;
 }
 
 export interface AgentCallbacks

--- a/packages/agent-sdk/src/types/skills.ts
+++ b/packages/agent-sdk/src/types/skills.ts
@@ -73,6 +73,7 @@ export interface SkillManagerOptions {
   personalSkillsPath?: string;
   scanTimeout?: number;
   workdir?: string;
+  watch?: boolean;
 }
 
 export interface ParsedSkillFile {

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -147,7 +147,10 @@ export function setupAgentContainer(
   const hookManager = new HookManager(container, workdir);
   container.register("HookManager", hookManager);
 
-  const skillManager = new SkillManager(container, { workdir });
+  const skillManager = new SkillManager(container, {
+    workdir,
+    watch: options.watchSkills ?? true,
+  });
   container.register("SkillManager", skillManager);
 
   container.register(

--- a/packages/agent-sdk/tests/managers/skillManager.test.ts
+++ b/packages/agent-sdk/tests/managers/skillManager.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { SkillManager } from "../../src/managers/skillManager.js";
+import { SlashCommandManager } from "../../src/managers/slashCommandManager.js";
 import { Container } from "../../src/utils/container.js";
 import type {
   SkillManagerOptions,
@@ -8,6 +9,7 @@ import type {
 } from "../../src/types/index.js";
 import { readdir, stat } from "fs/promises";
 import { logger } from "../../src/utils/globalLogger.js";
+import { FileWatcherService } from "../../src/services/fileWatcher.js";
 
 vi.mock("../../src/utils/globalLogger.js", () => ({
   logger: {
@@ -24,6 +26,7 @@ import {
 } from "../../src/utils/skillParser.js";
 
 vi.mock("fs/promises");
+vi.mock("../../src/services/fileWatcher.js");
 vi.mock("../../src/utils/skillParser.js", async () => {
   const actual = await vi.importActual("../../src/utils/skillParser.js");
   return {
@@ -36,14 +39,34 @@ vi.mock("../../src/utils/skillParser.js", async () => {
 describe("SkillManager", () => {
   let skillManager: SkillManager;
   let container: Container;
+  let mockFileWatcher: {
+    watchFile: ReturnType<typeof vi.fn>;
+    cleanup: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
+
+    mockFileWatcher = {
+      watchFile: vi.fn().mockResolvedValue(undefined),
+      cleanup: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn().mockReturnThis(),
+    };
+    vi.mocked(FileWatcherService).mockImplementation(function () {
+      return mockFileWatcher;
+    } as unknown as typeof FileWatcherService);
 
     container = new Container();
     skillManager = new SkillManager(container, {
       workdir: "/test/workdir",
     });
+  });
+
+  afterEach(async () => {
+    if (skillManager) {
+      await skillManager.destroy();
+    }
   });
 
   describe("constructor", () => {
@@ -696,6 +719,113 @@ describe("SkillManager", () => {
 
       expect(result.content).toContain("• No skills available");
       expect(result.content).toContain("Wave Skills documentation");
+    });
+  });
+
+  describe("Watcher", () => {
+    it("should initialize watcher when watch option is true", async () => {
+      const manager = new SkillManager(container, {
+        workdir: "/test/workdir",
+        watch: true,
+      });
+      vi.mocked(readdir).mockResolvedValue([]);
+
+      await manager.initialize();
+
+      expect(FileWatcherService).toHaveBeenCalled();
+      expect(mockFileWatcher.watchFile).toHaveBeenCalledWith(
+        expect.stringContaining(".wave/skills"),
+        expect.any(Function),
+      );
+      expect(mockFileWatcher.watchFile).toHaveBeenCalledWith(
+        expect.stringContaining("/test/workdir/.wave/skills"),
+        expect.any(Function),
+      );
+    });
+
+    it("should not initialize watcher when watch option is false", async () => {
+      const manager = new SkillManager(container, {
+        workdir: "/test/workdir",
+        watch: false,
+      });
+      vi.mocked(readdir).mockResolvedValue([]);
+
+      await manager.initialize();
+
+      expect(FileWatcherService).not.toHaveBeenCalled();
+    });
+
+    it("should refresh skills and update slash commands when a change is detected", async () => {
+      const manager = new SkillManager(container, {
+        workdir: "/test/workdir",
+        watch: true,
+      });
+      container.register("SkillManager", manager);
+
+      const slashCommandManager = new SlashCommandManager(container, {
+        workdir: "/test/workdir",
+      });
+      slashCommandManager.initialize();
+
+      vi.mocked(readdir).mockResolvedValue([]);
+      await manager.initialize();
+
+      // Get the callback passed to watchFile
+      const onEventCallback = mockFileWatcher.watchFile.mock.calls[0][1];
+
+      // Mock readdir to return a new skill after refresh
+      vi.mocked(readdir).mockImplementation(async (path) => {
+        if (path.toString().includes(".wave/skills")) {
+          return [
+            { name: "new-skill", isDirectory: () => true },
+          ] as unknown as Awaited<ReturnType<typeof readdir>>;
+        }
+        return [] as unknown as Awaited<ReturnType<typeof readdir>>;
+      });
+      vi.mocked(stat).mockResolvedValue(
+        {} as unknown as Awaited<ReturnType<typeof stat>>,
+      );
+      vi.mocked(parseSkillFile).mockReturnValue({
+        isValid: true,
+        skillMetadata: {
+          name: "new-skill",
+          description: "new desc",
+          type: "personal",
+          skillPath: "/path/to/new-skill",
+        },
+        content: "content",
+        frontmatter: { name: "new-skill" },
+        validationErrors: [],
+      } as unknown as ReturnType<typeof parseSkillFile>);
+
+      // Trigger the callback
+      await onEventCallback({
+        type: "change",
+        path: "/test/workdir/.wave/skills/new-skill/SKILL.md",
+        timestamp: Date.now(),
+      });
+
+      // Check if skills were refreshed
+      const skills = manager.getAvailableSkills();
+      expect(skills).toHaveLength(1);
+      expect(skills[0].name).toBe("new-skill");
+
+      // Check if slash commands were updated
+      const commands = slashCommandManager.getCommands();
+      expect(commands.find((c) => c.id === "new-skill")).toBeDefined();
+    });
+
+    it("should cleanup watcher when destroyed", async () => {
+      const manager = new SkillManager(container, {
+        workdir: "/test/workdir",
+        watch: true,
+      });
+      vi.mocked(readdir).mockResolvedValue([]);
+      await manager.initialize();
+
+      await manager.destroy();
+
+      expect(mockFileWatcher.cleanup).toHaveBeenCalled();
     });
   });
 });

--- a/specs/006-agent-skills/tasks.md
+++ b/specs/006-agent-skills/tasks.md
@@ -150,6 +150,9 @@
 - [x] T044 [P] [US8] Create unit tests for new flags in packages/agent-sdk/tests/utils/skillParser_flags.test.ts, packages/agent-sdk/tests/tools/skillTool_flags.test.ts, and packages/agent-sdk/tests/managers/slashCommandManager_flags.test.ts
 - [x] T045 [US5] Implement automatic argument appending when no placeholders are present in skills and slash commands
 - [x] T046 [US5] Implement `${WAVE_SKILL_DIR}` placeholder substitution in skills
+- [x] T047 [US4] Implement real-time skill discovery using FileWatcherService in packages/agent-sdk/src/managers/skillManager.ts
+- [x] T048 [US4] Update SlashCommandManager to refresh commands on skill changes in packages/agent-sdk/src/managers/slashCommandManager.ts
+- [x] T049 [US4] Add unit tests for real-time skill discovery and slash command refresh
 
 ---
 

--- a/specs/008-slash-commands/tasks.md
+++ b/specs/008-slash-commands/tasks.md
@@ -27,7 +27,7 @@
 - [X] T017 Update `executeCustomCommandInMainAgent` in `SlashCommandManager` to pass `config.allowedTools` to `aiManager.sendAIMessage` in `packages/agent-sdk/src/managers/slashCommandManager.ts`
 - [X] T018 Implement `finally` block logic in `sendAIMessage` to call `permissionManager.clearTemporaryRules` when `recursionDepth === 0` in `packages/agent-sdk/src/managers/aiManager.ts`
 
-## Phase 3: Automatic Argument Appending
+## Phase 4: Real-time Skill Refresh
 
-- [X] T034 Implement automatic argument appending when no placeholders are present in slash commands and skills in `packages/agent-sdk/src/managers/slashCommandManager.ts`
+- [X] T035 Update `SlashCommandManager` to listen for `refreshed` events from `SkillManager` and update available commands in `packages/agent-sdk/src/managers/slashCommandManager.ts`
 


### PR DESCRIPTION
This PR implements real-time discovery and availability of agent skills.

Key changes:
- **SkillManager**: Refactored to extend `EventEmitter` and use `FileWatcherService` to monitor skill directories. It now emits a `refreshed` event when skills are re-scanned.
- **SlashCommandManager**: Updated to listen for the `refreshed` event from `SkillManager` and re-register skill-based commands automatically.
- **FileWatcherService**: Enhanced to support directory watching, recursive event notification, and handling of `addDir`/`unlinkDir` events.
- **Agent**: Added `watchSkills` option (defaulting to `true`) and ensured proper cleanup of file watchers on destruction.
- **Testing**: Added comprehensive unit tests in `packages/agent-sdk/tests/managers/skillManager.test.ts` and a new example script `packages/agent-sdk/examples/skill-watcher-demo.ts` for real-world verification.
- **Specs**: Updated task lists in `specs/006-agent-skills/tasks.md` and `specs/008-slash-commands/tasks.md`.