### PR TITLE
test: clear WAVE_MAX_INPUT_TOKENS env in compression and config tests

### DIFF
--- a/packages/agent-sdk/tests/agent/agent.compression.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.compression.test.ts
@@ -17,6 +17,9 @@ describe("Agent Message Compression Tests", () => {
     // Disable auto-memory to prevent extra callAgent calls from background tasks
     vi.stubEnv("WAVE_DISABLE_AUTO_MEMORY", "1");
 
+    // Clear WAVE_MAX_INPUT_TOKENS to use default 96000 for compression threshold
+    delete process.env.WAVE_MAX_INPUT_TOKENS;
+
     // Create Agent instance with required parameters
     agent = await Agent.create({
       apiKey: "test-key",

--- a/packages/agent-sdk/tests/agent/agent.usages.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.usages.test.ts
@@ -30,6 +30,7 @@ describe("Agent Usage Tracking", () => {
     process.env.WAVE_MODEL = "gemini-3-flash";
     process.env.WAVE_FAST_MODEL = "gemini-2.5-flash";
     process.env.WAVE_DISABLE_AUTO_MEMORY = "true";
+    delete process.env.WAVE_MAX_INPUT_TOKENS;
 
     // Create mock callbacks that track usage changes
     usagesHistory = [];

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -475,6 +475,18 @@ describe("ConfigurationService", () => {
   });
 
   describe("resolveMaxInputTokens", () => {
+    const originalEnv = process.env.WAVE_MAX_INPUT_TOKENS;
+
+    beforeEach(() => {
+      delete process.env.WAVE_MAX_INPUT_TOKENS;
+    });
+
+    afterEach(() => {
+      if (originalEnv !== undefined) {
+        process.env.WAVE_MAX_INPUT_TOKENS = originalEnv;
+      }
+    });
+
     it("should return default", () => {
       expect(configService.resolveMaxInputTokens()).toBe(
         DEFAULT_WAVE_MAX_INPUT_TOKENS,


### PR DESCRIPTION
The WAVE_MAX_INPUT_TOKENS environment variable (set to 200000 in the test process) was overriding the default 96000 threshold, causing:
- configurationService test to expect 96000 but receive 200000
- compression tests to never trigger (test tokens < 200000 threshold)
- usage tracking test to miss compression usage entry

Clear this env var in the affected test files to ensure tests use the intended default threshold.