### PR TITLE
fix: improve EnterPlanMode tool permission flow and UI

### DIFF
--- a/packages/agent-sdk/src/tools/enterPlanMode.ts
+++ b/packages/agent-sdk/src/tools/enterPlanMode.ts
@@ -65,6 +65,9 @@ export const enterPlanModeTool: ToolPlugin = {
         context.toolCallId,
       );
 
+      // No "allow always" option for plan mode transitions (matching Claude Code behavior)
+      permissionContext.hidePersistentOption = true;
+
       const permissionResult =
         await context.permissionManager.checkPermission(permissionContext);
 

--- a/packages/code/src/acp/agent.ts
+++ b/packages/code/src/acp/agent.ts
@@ -530,9 +530,9 @@ export class WaveAcpAgent implements AcpAgent {
           kind: "allow_once",
         },
         {
-          optionId: "allow_always",
-          name: "Yes, and stay in plan mode for future requests",
-          kind: "allow_always",
+          optionId: "reject_once",
+          name: "No, start implementing now",
+          kind: "reject_once",
         },
       ];
     } else if (context.toolName === ASK_USER_QUESTION_TOOL_NAME) {
@@ -602,9 +602,6 @@ export class WaveAcpAgent implements AcpAgent {
               behavior: "allow",
               newPermissionMode: "acceptEdits",
             };
-          }
-          if (context.toolName === ENTER_PLAN_MODE_TOOL_NAME) {
-            return { behavior: "allow", newPermissionMode: "plan" };
           }
           return {
             behavior: "allow",

--- a/packages/code/src/components/ConfirmationDetails.tsx
+++ b/packages/code/src/components/ConfirmationDetails.tsx
@@ -5,6 +5,7 @@ import {
   EDIT_TOOL_NAME,
   WRITE_TOOL_NAME,
   EXIT_PLAN_MODE_TOOL_NAME,
+  ENTER_PLAN_MODE_TOOL_NAME,
   ASK_USER_QUESTION_TOOL_NAME,
 } from "wave-agent-sdk";
 import { DiffDisplay } from "./DiffDisplay.js";
@@ -29,6 +30,8 @@ const getActionDescription = (
       return `Write to file: ${toolInput.file_path || "unknown file"}`;
     case EXIT_PLAN_MODE_TOOL_NAME:
       return "Review and approve the plan";
+    case ENTER_PLAN_MODE_TOOL_NAME:
+      return "Enter plan mode for complex task planning";
     case ASK_USER_QUESTION_TOOL_NAME:
       return "Answer questions to clarify intent";
     default:
@@ -76,6 +79,7 @@ export const ConfirmationDetails: React.FC<ConfirmationDetailsProps> = ({
       {toolName !== WRITE_TOOL_NAME &&
         toolName !== EDIT_TOOL_NAME &&
         toolName !== EXIT_PLAN_MODE_TOOL_NAME &&
+        toolName !== ENTER_PLAN_MODE_TOOL_NAME &&
         toolName !== ASK_USER_QUESTION_TOOL_NAME &&
         toolName !== BASH_TOOL_NAME &&
         !!toolInput && (

--- a/packages/code/src/components/ConfirmationSelector.tsx
+++ b/packages/code/src/components/ConfirmationSelector.tsx
@@ -4,6 +4,7 @@ import type { PermissionDecision, AskUserQuestionInput } from "wave-agent-sdk";
 import {
   BASH_TOOL_NAME,
   EXIT_PLAN_MODE_TOOL_NAME,
+  ENTER_PLAN_MODE_TOOL_NAME,
   ASK_USER_QUESTION_TOOL_NAME,
 } from "wave-agent-sdk";
 
@@ -353,6 +354,8 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
       } else if (state.selectedOption === "allow") {
         if (toolName === EXIT_PLAN_MODE_TOOL_NAME) {
           onDecision({ behavior: "allow", newPermissionMode: "default" });
+        } else if (toolName === ENTER_PLAN_MODE_TOOL_NAME) {
+          onDecision({ behavior: "allow", newPermissionMode: "plan" });
         } else {
           onDecision({ behavior: "allow" });
         }
@@ -367,6 +370,8 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
               : `Bash(${toolInput?.command})`;
             onDecision({ behavior: "allow", newPermissionRule: rule });
           }
+        } else if (toolName === ENTER_PLAN_MODE_TOOL_NAME) {
+          onDecision({ behavior: "allow", newPermissionMode: "plan" });
         } else if (toolName.startsWith("mcp__")) {
           onDecision({ behavior: "allow", newPermissionRule: toolName });
         } else {
@@ -374,6 +379,11 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
         }
       } else if (state.alternativeText.trim()) {
         onDecision({ behavior: "deny", message: state.alternativeText.trim() });
+      } else if (toolName === ENTER_PLAN_MODE_TOOL_NAME) {
+        onDecision({
+          behavior: "deny",
+          message: "User chose not to enter plan mode",
+        });
       }
       return;
     }
@@ -622,7 +632,11 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
                 bold={state.selectedOption === "alternative"}
               >
                 {state.selectedOption === "alternative" ? "> " : "  "}
-                {showPlaceholder ? (
+                {toolName === ENTER_PLAN_MODE_TOOL_NAME && showPlaceholder ? (
+                  <Text color="gray" dimColor>
+                    No, start implementing now
+                  </Text>
+                ) : showPlaceholder ? (
                   <Text color="gray" dimColor>
                     {placeholderText}
                   </Text>


### PR DESCRIPTION
- Set hidePersistentOption=true to hide 'allow always' option at SDK level
- Fix CLI confirmation to actually set newPermissionMode='plan' when allowing
- Match Claude Code behavior: only show 'Yes' and 'No' options for EnterPlanMode
- Replace allow_always with reject_once ('No, start implementing now')
- Add proper action description in ConfirmationDetails
- Hide empty {} JSON display for EnterPlanMode in confirmation dialog
- Remove unreachable allow_always case in ACP agent switch
