### PR TITLE
fix: include args in custom slash command content field

### DIFF
--- a/packages/agent-sdk/src/managers/slashCommandManager.ts
+++ b/packages/agent-sdk/src/managers/slashCommandManager.ts
@@ -350,6 +350,7 @@ export class SlashCommandManager {
             namespacedName,
             processedContent,
             command.config,
+            args,
           );
         },
       });
@@ -486,6 +487,7 @@ export class SlashCommandManager {
     commandName: string,
     content: string,
     config?: { model?: string; allowedTools?: string[] },
+    args?: string,
   ): Promise<void> {
     try {
       // Parse bash commands from the content
@@ -493,7 +495,7 @@ export class SlashCommandManager {
 
       // Add user message immediately so text block shows before bash execution
       const messageId = this.messageManager.addUserMessage({
-        content: `/${commandName}`,
+        content: `/${commandName}${args ? ` ${args}` : ""}`,
         customCommandContent: processedContent,
       });
 

--- a/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
+++ b/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
@@ -667,5 +667,26 @@ describe("SlashCommandManager", () => {
 
       expect(mockSubagentManager.cleanupInstance).toHaveBeenCalled();
     });
+
+    it("should include args in content field for custom command execution", async () => {
+      // Register a custom command
+      const customCommand = {
+        id: "test-args",
+        name: "test-args",
+        content: "Test content",
+      };
+
+      slashCommandManager.registerPluginCommands("test", [
+        customCommand,
+      ] as CustomSlashCommand[]);
+
+      const cmd = slashCommandManager.getCommand("test:test-args");
+      await cmd?.handler("arg1 arg2");
+
+      const messages = messageManager.getMessages();
+      const lastMessage = messages[messages.length - 1];
+      const textBlock = lastMessage.blocks[0] as TextBlock;
+      expect(textBlock.content).toBe("/test:test-args arg1 arg2");
+    });
   });
 });


### PR DESCRIPTION
When executing a custom slash command with arguments, the content field in the user message only showed the command name without args, while skill commands correctly included them. This change makes custom commands consistent with skill commands by including args in the content field.