### PR TITLE
fix: restrict forked agent memory writes to auto memory directory

### DIFF
--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -21,6 +21,7 @@ import {
 
 import { Container } from "../utils/container.js";
 import type { PermissionManager } from "./permissionManager.js";
+import type { PermissionMode } from "../types/permissions.js";
 import { ConfigurationService } from "../services/configurationService.js";
 
 export interface SubagentManagerCallbacks {
@@ -159,6 +160,7 @@ export class SubagentManager {
       allowedTools?: string[];
       model?: string;
       stream?: boolean;
+      permissionModeOverride?: PermissionMode;
     },
     runInBackground?: boolean,
     onUpdate?: () => void,
@@ -183,6 +185,7 @@ export class SubagentManager {
     const subagentPermissionManager = new PermissionManager(subagentContainer, {
       workdir: this.workdir,
       configuredPermissionMode:
+        parameters.permissionModeOverride ??
         parentPermissionManager?.getConfiguredPermissionMode(),
       allowedRules: parentPermissionManager?.getAllowedRules(),
       deniedRules: parentPermissionManager?.getDeniedRules(),
@@ -273,6 +276,7 @@ export class SubagentManager {
       description: string;
       allowedTools?: string[];
       model?: string;
+      permissionModeOverride?: PermissionMode;
     },
     onUpdate?: () => void,
   ): Promise<SubagentInstance> {

--- a/packages/agent-sdk/src/services/autoMemoryService.ts
+++ b/packages/agent-sdk/src/services/autoMemoryService.ts
@@ -157,6 +157,7 @@ export class AutoMemoryService {
           `Edit(${memoryDir}/**/*)`,
         ],
         model: "fastModel", // Use fast model for background tasks to reduce latency and cost
+        permissionModeOverride: "default", // Force default mode to prevent acceptEdits bypass
       },
     );
 


### PR DESCRIPTION
When auto-memory extraction runs via a forked agent, it inherits the parent's permission mode. If the parent is in 'acceptEdits' mode, Write/Edit operations are auto-allowed for any path in the workdir's safe zone, bypassing the intended Write(memoryDir/**/*) restriction.

## Changes

- Add `permissionModeOverride` parameter to `createInstance` and `forkAgent` in `SubagentManager`
- Pass `'default'` mode for auto-memory extraction to ensure the rule check is properly evaluated
- Forked agents can now only write to the auto memory directory, not anywhere in the workdir