### PR TITLE
fix: use dontAsk mode for auto-memory forked agent

### DIFF
--- a/packages/agent-sdk/src/services/autoMemoryService.ts
+++ b/packages/agent-sdk/src/services/autoMemoryService.ts
@@ -157,7 +157,7 @@ export class AutoMemoryService {
           `Edit(${memoryDir}/**/*)`,
         ],
         model: "fastModel", // Use fast model for background tasks to reduce latency and cost
-        permissionModeOverride: "default", // Force default mode to prevent acceptEdits bypass
+        permissionModeOverride: "dontAsk", // Auto-deny out-of-scope writes without prompting user
       },
     );
 


### PR DESCRIPTION
## Summary

Switch `permissionModeOverride` from `'default'` to `'dontAsk'` in the auto-memory forked agent.

## Problem

When the auto-memory forked agent tries to write files outside the memory directory, the permission check falls through to the parent's `CanUseToolCallback` (inherited via child container), which prompts the user for confirmation.

## Solution

Using `'dontAsk'` mode, the `PermissionManager`'s internal logic auto-denies out-of-scope restricted tools without ever reaching the callback that prompts the user.