### PR TITLE
fix: reconcile phase-by-phase execution with parallel user story support

### DIFF
--- a/.wave/commands/speckit.implement.md
+++ b/.wave/commands/speckit.implement.md
@@ -97,8 +97,8 @@ You **MUST** consider the user input before proceeding (if not empty).
    - **Execution flow**: Order and dependency requirements
 
 6. Execute implementation following the task plan:
-   - **Phase-by-phase execution**: Complete each phase before moving to the next
-   - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together  
+   - **Phase-by-phase execution**: Complete each phase before moving to the next. After the Foundational phase (Phase 2), user story phases (Phase 3+) may be executed sequentially in priority order (P1 → P2 → P3) or in parallel if resources allow (per tasks-template.md "Parallel Team Strategy").
+   - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together. User stories depend on Foundational phase completion but are otherwise independent.
    - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
    - **File-based coordination**: Tasks affecting the same files must run sequentially
    - **Validation checkpoints**: Verify each phase completion before proceeding


### PR DESCRIPTION
Reconcile conflicting guidance between speckit.implement.md and tasks-template.md regarding phase execution order.

- Clarify that Setup (Phase 1) and Foundational (Phase 2) must be completed sequentially
- User story phases (Phase 3+) may now run sequentially (P1 → P2 → P3) or in parallel if resources allow
- Align with tasks-template.md's 'Parallel Team Strategy' for independent user story execution