### PR TITLE
fix(pathEncoder): always preserve case in session directory names

### DIFF
--- a/packages/agent-sdk/src/utils/pathEncoder.ts
+++ b/packages/agent-sdk/src/utils/pathEncoder.ts
@@ -27,7 +27,6 @@ export interface PathEncodingOptions {
   pathSeparatorReplacement?: string; // Default: '-'
   spaceReplacement?: string; // Default: '_'
   invalidCharReplacement?: string; // Default: '_'
-  preserveCase?: boolean; // Default: false (convert to lowercase)
   hashLength?: number; // Default: 8 characters
 }
 
@@ -65,7 +64,6 @@ export class PathEncoder {
       pathSeparatorReplacement: options.pathSeparatorReplacement ?? "-",
       spaceReplacement: options.spaceReplacement ?? "_",
       invalidCharReplacement: options.invalidCharReplacement ?? "_",
-      preserveCase: options.preserveCase ?? false,
       hashLength: options.hashLength ?? 8,
     };
     this.constraints = this.getFilesystemConstraints();
@@ -109,10 +107,7 @@ export class PathEncoder {
       this.options.invalidCharReplacement,
     );
 
-    // Convert to lowercase unless preserveCase is true
-    if (!this.options.preserveCase) {
-      encoded = encoded.toLowerCase();
-    }
+    // Case is preserved
 
     // Handle length limit with hash
     if (encoded.length > this.options.maxLength) {

--- a/packages/agent-sdk/tests/utils/pathEncoder.test.ts
+++ b/packages/agent-sdk/tests/utils/pathEncoder.test.ts
@@ -40,7 +40,6 @@ describe("PathEncoder", () => {
         pathSeparatorReplacement: "_",
         spaceReplacement: "-",
         invalidCharReplacement: "X",
-        preserveCase: true,
         hashLength: 12,
       };
       const encoder = new PathEncoder(customOptions);
@@ -81,14 +80,8 @@ describe("PathEncoder", () => {
       expect(result).toBe("home-user-my_project");
     });
 
-    it("should convert to lowercase by default", async () => {
-      const result = await pathEncoder.encode("/HOME/USER/PROJECT");
-      expect(result).toBe("home-user-project");
-    });
-
-    it("should preserve case when preserveCase option is true", async () => {
-      const encoder = new PathEncoder({ preserveCase: true });
-      const result = await encoder.encode("/HOME/User/Project");
+    it("should preserve case by default", async () => {
+      const result = await pathEncoder.encode("/HOME/User/Project");
       expect(result).toBe("HOME-User-Project");
     });
 
@@ -117,7 +110,7 @@ describe("PathEncoder", () => {
       // Mock realpath to return the input path directly (no resolution)
       vi.mocked(realpath).mockResolvedValue("C:\\Users\\John\\Project");
       const result = await pathEncoder.encode("C:\\Users\\John\\Project");
-      expect(result).toBe("c:-users-john-project");
+      expect(result).toBe("C:-Users-John-Project");
     });
 
     it("should truncate long paths and add hash", async () => {
@@ -133,7 +126,6 @@ describe("PathEncoder", () => {
         pathSeparatorReplacement: "_",
         spaceReplacement: "-",
         invalidCharReplacement: "X",
-        preserveCase: true,
       });
 
       vi.mocked(realpath).mockResolvedValue("/Home/User/My Project");


### PR DESCRIPTION
Remove the preserveCase option from PathEncodingOptions and always
preserve original path casing when encoding working directory paths
for session directories.
