### PR TITLE
fix: use compactParams in background agent tool log format

### DIFF
--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -684,12 +684,11 @@ export class SubagentManager {
 
             // Log tool execution to file
             if (instance.logStream) {
-              const compactParams = (params.parameters || "{}").substring(
-                0,
-                100,
-              );
+              const displayParams =
+                params.compactParams ||
+                (params.parameters || "{}").substring(0, 100);
               instance.logStream.write(
-                `[${new Date().toISOString()}] Running tool: ${params.name} with params: ${compactParams}${compactParams.length >= 100 ? "..." : ""}\n`,
+                `[${new Date().toISOString()}] ${params.name}${displayParams ? ` ${displayParams}` : ""}\n`,
               );
             }
           }

--- a/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
@@ -263,7 +263,7 @@ describe("SubagentManager - Backgrounding Coverage", () => {
     await new Promise((resolve) => setTimeout(resolve, 100));
 
     const content = fs.readFileSync(outputPath, "utf8");
-    expect(content).toContain("Running tool: Read");
+    expect(content).toContain("Read");
     expect(content).toContain("test.txt");
 
     // Cleanup


### PR DESCRIPTION
Replace verbose 'Running tool: name with params: ...' format with concise 'name compactParams' format, matching ToolDisplay.tsx style. Falls back to truncated parameters when compactParams is unavailable.