### PR TITLE
feat: add TaskNotificationBlock for background task completion notifications

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -39,6 +39,7 @@ import { SkillManager } from "./managers/skillManager.js";
 import { TaskManager } from "./services/taskManager.js";
 import { btw } from "./services/aiService.js";
 import { convertMessagesForAPI } from "./utils/convertMessagesForAPI.js";
+import { parseTaskNotificationXml } from "./utils/notificationXml.js";
 import { InitializationService } from "./services/initializationService.js";
 import { InteractionService } from "./services/interactionService.js";
 import { ConfigurationService } from "./services/configurationService.js";
@@ -450,9 +451,16 @@ export class Agent {
     if (notifications.length === 0) return;
 
     for (const notification of notifications) {
-      this.messageManager.addUserMessage({
-        content: notification,
-      });
+      const block = parseTaskNotificationXml(notification);
+      if (block) {
+        this.messageManager.addNotificationMessage({
+          taskId: block.taskId,
+          taskType: block.taskType,
+          status: block.status,
+          summary: block.summary,
+          outputFile: block.outputFile,
+        });
+      }
     }
 
     // Trigger AI to process the notifications

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -16,6 +16,7 @@ export * from "./utils/fileSearch.js";
 export * from "./utils/globalLogger.js";
 export * from "./utils/mcpUtils.js";
 export * from "./utils/messageOperations.js";
+export * from "./utils/notificationXml.js";
 export * from "./utils/path.js";
 export * from "./utils/promptHistory.js";
 export * from "./utils/stringUtils.js";

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -1,6 +1,7 @@
 import { type CallAgentOptions } from "../services/aiService.js";
 import * as aiService from "../services/aiService.js";
 import { convertMessagesForAPI } from "../utils/convertMessagesForAPI.js";
+import { parseTaskNotificationXml } from "../utils/notificationXml.js";
 import { calculateComprehensiveTotalTokens } from "../utils/tokenCalculation.js";
 import * as fs from "node:fs/promises";
 import type {
@@ -912,9 +913,16 @@ export class AIManager {
         if (notificationQueue && notificationQueue.hasPending()) {
           const notifications = notificationQueue.dequeueAll();
           for (const notification of notifications) {
-            this.messageManager.addUserMessage({
-              content: notification,
-            });
+            const block = parseTaskNotificationXml(notification);
+            if (block) {
+              this.messageManager.addNotificationMessage({
+                taskId: block.taskId,
+                taskType: block.taskType,
+                status: block.status,
+                summary: block.summary,
+                outputFile: block.outputFile,
+              });
+            }
           }
           // Recursively process the notifications
           await this.sendAIMessage({

--- a/packages/agent-sdk/src/managers/messageManager.ts
+++ b/packages/agent-sdk/src/managers/messageManager.ts
@@ -9,8 +9,10 @@ import {
   completeBangInMessage,
   removeLastUserMessage,
   addToolBlockToMessageInMessages,
+  addNotificationMessageToMessages,
   UserMessageParams,
   type AgentToolBlockUpdateParams,
+  type AddNotificationMessageParams,
   generateMessageId,
 } from "../utils/messageOperations.js";
 import type { Message, Usage } from "../types/index.js";
@@ -56,6 +58,13 @@ export interface MessageManagerCallbacks {
   onFileHistoryBlockAdded?: (
     snapshots: import("../types/reversion.js").FileSnapshot[],
   ) => void;
+  // Notification callback
+  onNotificationMessageAdded?: (params: {
+    taskId: string;
+    taskType: "shell" | "agent";
+    status: "completed" | "failed" | "killed";
+    summary: string;
+  }) => void;
 }
 
 import { logger } from "../utils/globalLogger.js";
@@ -585,6 +594,22 @@ export class MessageManager {
     });
     this.setMessages(updatedMessages);
     this.callbacks.onCompleteBangMessage?.(command, exitCode);
+  }
+
+  public addNotificationMessage(
+    params: Omit<AddNotificationMessageParams, "messages">,
+  ): void {
+    const newMessages = addNotificationMessageToMessages({
+      messages: this.messages,
+      ...params,
+    });
+    this.setMessages(newMessages);
+    this.callbacks.onNotificationMessageAdded?.({
+      taskId: params.taskId,
+      taskType: params.taskType,
+      status: params.status,
+      summary: params.summary,
+    });
   }
 
   /**

--- a/packages/agent-sdk/src/types/messaging.ts
+++ b/packages/agent-sdk/src/types/messaging.ts
@@ -27,7 +27,8 @@ export type MessageBlock =
   | BangBlock
   | CompressBlock
   | ReasoningBlock
-  | FileHistoryBlock;
+  | FileHistoryBlock
+  | TaskNotificationBlock;
 
 export interface TextBlock {
   type: "text";
@@ -98,4 +99,13 @@ export interface ReasoningBlock {
 export interface FileHistoryBlock {
   type: "file_history";
   snapshots: import("./reversion.js").FileSnapshot[];
+}
+
+export interface TaskNotificationBlock {
+  type: "task_notification";
+  taskId: string;
+  taskType: "shell" | "agent";
+  status: "completed" | "failed" | "killed";
+  summary: string;
+  outputFile?: string;
 }

--- a/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
+++ b/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
@@ -1,5 +1,6 @@
 import type { Message } from "../types/index.js";
 import { convertImageToBase64 } from "./messageOperations.js";
+import { taskNotificationToXml } from "./notificationXml.js";
 import { ChatCompletionMessageToolCall } from "openai/resources";
 import { stripAnsiColors } from "./stringUtils.js";
 import {
@@ -237,6 +238,14 @@ export function convertMessagesForAPI(
           contentParts.push({
             type: "text",
             text: `<local-command-stdout>\n${stripAnsiColors(block.result)}\n</local-command-stdout>`,
+          });
+        }
+
+        // If there is a task notification block, convert it back to XML
+        if (block.type === "task_notification") {
+          contentParts.push({
+            type: "text",
+            text: taskNotificationToXml(block),
           });
         }
       });

--- a/packages/agent-sdk/src/utils/messageOperations.ts
+++ b/packages/agent-sdk/src/utils/messageOperations.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from "crypto";
-import type { Message, Usage, ToolBlock } from "../types/index.js";
+import type {
+  Message,
+  Usage,
+  ToolBlock,
+  TaskNotificationBlock,
+} from "../types/index.js";
 import { MessageSource } from "../types/index.js";
 import { readFileSync } from "fs";
 import { extname } from "path";
@@ -584,3 +589,38 @@ export function getMessageContent(message: Message): string {
 
   return "";
 }
+
+export interface AddNotificationMessageParams {
+  messages: Message[];
+  taskId: string;
+  taskType: "shell" | "agent";
+  status: "completed" | "failed" | "killed";
+  summary: string;
+  outputFile?: string;
+}
+
+export const addNotificationMessageToMessages = ({
+  messages,
+  taskId,
+  taskType,
+  status,
+  summary,
+  outputFile,
+}: AddNotificationMessageParams): Message[] => {
+  const block: TaskNotificationBlock = {
+    type: "task_notification",
+    taskId,
+    taskType,
+    status,
+    summary,
+    ...(outputFile !== undefined && { outputFile }),
+  };
+
+  const notificationMessage: Message = {
+    id: generateMessageId(),
+    role: "user",
+    blocks: [block],
+  };
+
+  return [...messages, notificationMessage];
+};

--- a/packages/agent-sdk/src/utils/notificationXml.ts
+++ b/packages/agent-sdk/src/utils/notificationXml.ts
@@ -1,0 +1,52 @@
+import type { TaskNotificationBlock } from "../types/messaging.js";
+
+export function taskNotificationToXml(block: TaskNotificationBlock): string {
+  let xml = `<task-notification>\n`;
+  xml += `<task-id>${block.taskId}</task-id>\n`;
+  xml += `<task-type>${block.taskType}</task-type>\n`;
+  if (block.outputFile) {
+    xml += `<output-file>${block.outputFile}</output-file>\n`;
+  }
+  xml += `<status>${block.status}</status>\n`;
+  xml += `<summary>${block.summary}</summary>\n`;
+  xml += `</task-notification>`;
+  return xml;
+}
+
+function extractTag(xml: string, tag: string): string | null {
+  const regex = new RegExp(`<${tag}>(.*?)</${tag}>`, "s");
+  const match = xml.match(regex);
+  return match ? match[1] : null;
+}
+
+export function parseTaskNotificationXml(
+  xml: string,
+): TaskNotificationBlock | null {
+  try {
+    const taskId = extractTag(xml, "task-id");
+    const taskType = extractTag(xml, "task-type") as "shell" | "agent" | null;
+    const status = extractTag(xml, "status") as
+      | "completed"
+      | "failed"
+      | "killed"
+      | null;
+    const summary = extractTag(xml, "summary");
+
+    if (!taskId || !taskType || !status || !summary) {
+      return null;
+    }
+
+    const outputFile = extractTag(xml, "output-file") || undefined;
+
+    return {
+      type: "task_notification",
+      taskId,
+      taskType,
+      status,
+      summary,
+      ...(outputFile && { outputFile }),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/packages/agent-sdk/tests/agent/hooks-exitcode-output/hook-blocking-error.test.ts
+++ b/packages/agent-sdk/tests/agent/hooks-exitcode-output/hook-blocking-error.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Agent } from "@/agent.js";
 import * as aiService from "@/services/aiService.js";
 import { HookManager } from "@/managers/hookManager.js";
-import { createMockToolManager } from "../../helpers/mockFactories.js";
 import type { MessageBlock } from "@/types/messaging.js";
 
 // Type guard helper function
@@ -15,12 +14,21 @@ function hasContent(
 // Mock AI service directly in this file
 vi.mock("@/services/aiService");
 
-// Get access to the mocked tool manager
-const { instance: mockToolManagerInstance, execute: mockToolExecute } =
-  createMockToolManager();
+// Create mock functions at module scope for the factory pattern
+const mockToolExecute = vi.fn();
+
 vi.mock("@/managers/toolManager", () => ({
   ToolManager: vi.fn().mockImplementation(function () {
-    return mockToolManagerInstance;
+    return {
+      execute: mockToolExecute,
+      list: vi.fn(() => []),
+      getTools: vi.fn(() => []),
+      getToolsConfig: vi.fn(() => []),
+      getPermissionMode: vi.fn(),
+      setPermissionMode: vi.fn(),
+      initializeBuiltInTools: vi.fn(),
+      getPermissionManager: vi.fn(),
+    };
   }),
 }));
 

--- a/packages/agent-sdk/tests/agent/hooks-exitcode-output/hook-non-blocking-error.test.ts
+++ b/packages/agent-sdk/tests/agent/hooks-exitcode-output/hook-non-blocking-error.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Agent } from "@/agent.js";
 import * as aiService from "@/services/aiService.js";
 import { HookManager } from "@/managers/hookManager.js";
-import { createMockToolManager } from "../../helpers/mockFactories.js";
 import type { MessageBlock } from "@/types/messaging.js";
 
 // Type guard helper function
@@ -15,12 +14,21 @@ function hasContent(
 // Mock AI service directly in this file
 vi.mock("@/services/aiService");
 
-// Get access to the mocked tool manager
-const { instance: mockToolManagerInstance, execute: mockToolExecute } =
-  createMockToolManager();
+// Create mock functions at module scope for the factory pattern
+const mockToolExecute = vi.fn();
+
 vi.mock("@/managers/toolManager", () => ({
   ToolManager: vi.fn().mockImplementation(function () {
-    return mockToolManagerInstance;
+    return {
+      execute: mockToolExecute,
+      list: vi.fn(() => []),
+      getTools: vi.fn(() => []),
+      getToolsConfig: vi.fn(() => []),
+      getPermissionMode: vi.fn(),
+      setPermissionMode: vi.fn(),
+      initializeBuiltInTools: vi.fn(),
+      getPermissionManager: vi.fn(),
+    };
   }),
 }));
 

--- a/packages/code/src/components/MessageBlockItem.tsx
+++ b/packages/code/src/components/MessageBlockItem.tsx
@@ -7,6 +7,7 @@ import { ToolDisplay } from "./ToolDisplay.js";
 import { CompressDisplay } from "./CompressDisplay.js";
 import { ReasoningDisplay } from "./ReasoningDisplay.js";
 import { Markdown } from "./Markdown.js";
+import { TaskNotificationMessage } from "./TaskNotificationMessage.js";
 
 export interface MessageBlockItemProps {
   block: MessageBlock;
@@ -77,6 +78,10 @@ export const MessageBlockItem = ({
 
       {block.type === "reasoning" && (
         <ReasoningDisplay block={block} isExpanded={isExpanded} />
+      )}
+
+      {block.type === "task_notification" && (
+        <TaskNotificationMessage block={block} />
       )}
     </Box>
   );

--- a/packages/code/src/components/TaskNotificationMessage.tsx
+++ b/packages/code/src/components/TaskNotificationMessage.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Box, Text } from "ink";
+import type { TaskNotificationBlock } from "wave-agent-sdk";
+
+export interface TaskNotificationMessageProps {
+  block: TaskNotificationBlock;
+}
+
+const statusColor: Record<TaskNotificationBlock["status"], string> = {
+  completed: "green",
+  failed: "red",
+  killed: "yellow",
+};
+
+export const TaskNotificationMessage = ({
+  block,
+}: TaskNotificationMessageProps) => {
+  const color = statusColor[block.status];
+
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text color={color} bold>
+          {"\u2B24"}
+        </Text>
+        <Text color="white"> {block.summary}</Text>
+      </Box>
+    </Box>
+  );
+};

--- a/specs/061-task-background-execution/contracts/tools.md
+++ b/specs/061-task-background-execution/contracts/tools.md
@@ -24,3 +24,19 @@ Terminates a running background task.
 **Returns:**
 - `success` (boolean): Whether the task was stopped.
 - `message` (string): Status message.
+
+---
+
+## Task Completion Notifications
+
+When a background task completes, fails, or is killed, the system injects a structured notification into the chat.
+
+**Notification Format (as displayed to user):**
+- `⬤ {summary}` with colored dot (green = completed, red = failed, yellow = killed)
+
+**Notification Format (as sent to AI):**
+- XML format matching the serialization in the original notification queue
+
+**Triggered By:**
+- `BackgroundTaskManager`: When shell process exits
+- `SubagentManager`: When subagent AI loop finishes or errors

--- a/specs/061-task-background-execution/data-model.md
+++ b/specs/061-task-background-execution/data-model.md
@@ -27,3 +27,31 @@ Represents any operation running asynchronously in the background.
 ## Validation Rules
 - `task_id` must follow the pattern `task_\d+`.
 - `TaskStop` can only be called on tasks in the `running` state.
+
+## Notification Entities
+
+### TaskNotificationBlock
+Represents a background task completion notification displayed in the chat UI.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `taskId` | `string` | ID of the background task |
+| `taskType` | `'shell' \| 'agent'` | Type of the completed task |
+| `status` | `'completed' \| 'failed' \| 'killed'` | Final state of the task |
+| `summary` | `string` | Human-readable summary message |
+| `outputFile` | `string?` | Path to the task's output log file (shell tasks only) |
+
+### XML Serialization Format
+Task notifications are serialized as XML when sent to the AI:
+
+```xml
+<task-notification>
+<task-id>task_1</task-id>
+<task-type>shell</task-type>
+<output-file>/tmp/task_1_output.log</output-file>
+<status>completed</status>
+<summary>Command "ls -la" completed with exit code 0</summary>
+</task-notification>
+```
+
+The `output-file` tag is only included for shell tasks.

--- a/specs/061-task-background-execution/plan.md
+++ b/specs/061-task-background-execution/plan.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `061-task-background-execution`  
 **Created**: 2026-02-09  
-**Status**: Phase 2 Planning Complete
+**Status**: All phases implemented, tests pending for notifications
 
 ## Technical Context
 
@@ -59,6 +59,16 @@
 - Remove `/bashes` command.
 - Implement Ctrl-B backgrounding logic in `InputManager` and `Agent`.
 - Update UI components in `packages/code` to handle the new task types and show Ctrl-B hint.
+
+### Step 3.5: Task Completion Notifications
+- Add `TaskNotificationBlock` type to `packages/agent-sdk/src/types/messaging.ts`.
+- Create `notificationXml.ts` helpers for XML serialization/parsing.
+- Add `addNotificationMessageToMessages` to `messageOperations.ts`.
+- Add `addNotificationMessage` to `MessageManager` with callback.
+- Update `agent.ts` and `aiManager.ts` to process notifications as structured blocks.
+- Update `convertMessagesForAPI.ts` to convert `TaskNotificationBlock` back to XML.
+- Create `TaskNotificationMessage` component for CLI rendering.
+- Update `MessageBlockItem` to render notification blocks.
 
 ### Step 4: Verification
 - Run `pnpm build` for `agent-sdk`.

--- a/specs/061-task-background-execution/quickstart.md
+++ b/specs/061-task-background-execution/quickstart.md
@@ -41,3 +41,12 @@ List all tasks:
 ```bash
 /tasks
 ```
+
+## Task Completion Notifications
+
+When a background task finishes, you'll see a notification in the chat automatically:
+- ✅ Green dot: Task completed successfully
+- ❌ Red dot: Task failed
+- ⚠️ Yellow dot: Task was killed
+
+No need to poll - the system notifies you when the task is done.

--- a/specs/061-task-background-execution/research.md
+++ b/specs/061-task-background-execution/research.md
@@ -25,7 +25,13 @@ We will implement a unified `BackgroundTaskManager` (or extend `BackgroundBashMa
 - **`/tasks` Command**: Implement in `packages/agent-sdk/src/managers/slashCommandManager.ts` as a built-in command. It will fetch all tasks from the unified manager and format them for display.
 - **`/bashes` Removal**: Remove from `slashCommandManager.ts` (if it exists there) or ensure it's no longer registered.
 
-#### 4. Data Model
+#### 4. Task Completion Notifications
+- When a background task completes, fails, or is killed, the system enqueues an XML notification string.
+- The notification is parsed into a `TaskNotificationBlock` and added as a user message.
+- The block is rendered in the CLI as a compact status line with a colored dot.
+- For the AI, the block is serialized back to XML via `convertMessagesForAPI`.
+
+#### 5. Data Model
 - **`BackgroundTask` Interface**:
   ```typescript
   interface BackgroundTask {

--- a/specs/061-task-background-execution/spec.md
+++ b/specs/061-task-background-execution/spec.md
@@ -81,6 +81,24 @@ As a user running a long-running bash command or a subagent task in the foregrou
 
 ---
 
+### User Story 6 - Task Completion Notifications (Priority: P1)
+
+As a user, I want to be automatically notified in the chat when a background task completes, fails, or is killed, so that I know the result without having to manually check.
+
+**Why this priority**: Without automatic notifications, users must poll for task status or remember to check outputs, defeating the purpose of background execution.
+
+**Independent Test**: Start a background task, wait for it to complete, and verify that a notification appears in the chat showing the task status and summary.
+
+**Acceptance Scenarios**:
+
+1. **Given** a background task is running, **When** the task completes successfully, **Then** a notification should appear in the chat with a green indicator and a summary message.
+2. **Given** a background task is running, **When** the task fails, **Then** a notification should appear in the chat with a red indicator and an error summary.
+3. **Given** a background task is running, **When** the task is killed by the user, **Then** a notification should appear in the chat with a yellow indicator and a summary.
+4. **Given** multiple background tasks complete while the agent is idle, **Then** all notifications should appear in the chat.
+5. **Given** a background task completes while the agent is actively responding, **Then** the notification should be queued and displayed after the current response finishes.
+
+---
+
 ### Edge Cases
 
 - **Invalid Task ID**: How does the system handle `TaskOutput` or `TaskStop` requests with an ID that doesn't exist? (Expected: Error message indicating the task was not found).
@@ -113,8 +131,16 @@ As a user running a long-running bash command or a subagent task in the foregrou
 - **FR-020**: When Ctrl-B is pressed during a Bash or Task tool execution, the system MUST transition the tool's foreground stage to "end" and continue it in the background.
 - **FR-021**: The result of a backgrounded tool MUST be set to "Command was manually backgrounded by user with ID [ID]".
 - **FR-022**: The system MUST NOT background bash commands that were initiated directly by the user using the `!` prefix when Ctrl-B is pressed.
+- **FR-023**: When a background task completes, fails, or is killed, the system MUST enqueue a task completion notification.
+- **FR-024**: Task completion notifications MUST be rendered in the chat as structured blocks (not raw XML), with a colored indicator: green for completed, red for failed, yellow for killed.
+- **FR-025**: The AI MUST receive task completion notifications in the original XML format (`<task-notification>...`) so it can parse and respond to them.
+- **FR-026**: Task completion notifications MUST be processed immediately when the agent is idle, and queued when the agent is busy.
 
 ### Key Entities *(include if feature involves data)*
 
 - **Task**: Represents an execution unit (shell command or agent subtask).
     - Attributes: `task_id` (unique identifier), `status` (pending, running, completed, failed, stopped), `output` (accumulated logs/results), `type` (shell, agent), `outputPath` (optional path to real-time log file).
+- **TaskNotificationBlock**: A structured message block representing a background task completion notification in the chat.
+    - Attributes: `taskId`, `taskType` ("shell" | "agent"), `status` ("completed" | "failed" | "killed"), `summary`, `outputFile?` (for shell tasks).
+    - Serialized as XML (`<task-notification>...</task-notification>`) when sent to the AI API.
+    - Rendered as a compact status line (colored dot + summary) in the CLI UI.

--- a/specs/061-task-background-execution/tasks.md
+++ b/specs/061-task-background-execution/tasks.md
@@ -108,7 +108,35 @@
 
 ---
 
-## Phase 7: Polish & Cross-Cutting Concerns
+## Phase 8: User Story 6 - Task Completion Notifications (Priority: P1)
+
+**Goal**: Notify users in chat when background tasks complete, fail, or are killed
+
+**Independent Test**: Start a background task, wait for it to complete, and verify that a notification appears in the chat with the task status and summary.
+
+### Tests for User Story 6 (REQUIRED) ⚠️
+
+- [ ] T029 [P] [US6] Tests for `taskNotificationToXml` and `parseTaskNotificationXml` in `packages/agent-sdk/tests/utils/notificationXml.test.ts`
+- [ ] T030 [P] [US6] Test for `addNotificationMessageToMessages` in `packages/agent-sdk/tests/utils/messageOperations.test.ts`
+- [ ] T031 [P] [US6] Test for `TaskNotificationMessage` component in `packages/code/tests/components/TaskNotificationMessage.test.tsx`
+
+### Implementation for User Story 6
+
+- [x] T032 [US6] Add `TaskNotificationBlock` type to `packages/agent-sdk/src/types/messaging.ts`
+- [x] T033 [US6] Create `notificationXml.ts` helpers in `packages/agent-sdk/src/utils/notificationXml.ts`
+- [x] T034 [US6] Add `addNotificationMessageToMessages` to `packages/agent-sdk/src/utils/messageOperations.ts`
+- [x] T035 [US6] Add `addNotificationMessage` to `MessageManager` with `onNotificationMessageAdded` callback
+- [x] T036 [US6] Update `agent.ts` `processPendingNotifications()` to use structured blocks
+- [x] T037 [US6] Update `aiManager.ts` notification injection to use structured blocks
+- [x] T038 [US6] Update `convertMessagesForAPI.ts` to convert `task_notification` blocks to XML
+- [x] T039 [US6] Create `TaskNotificationMessage` component in `packages/code/src/components/`
+- [x] T040 [US6] Update `MessageBlockItem` to render `task_notification` blocks
+
+**Checkpoint**: Task completion notifications are displayed in chat with colored status indicators.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
 
 **Purpose**: Improvements that affect multiple user stories
 
@@ -134,6 +162,7 @@
 - **User Story 2 (P1)**: Depends on US1 (needs tasks to get output from)
 - **User Story 3 (P2)**: Depends on US1 (needs tasks to stop)
 - **User Story 4 (P2)**: Depends on US1/US2/US3 for full functionality
+- **User Story 6 (P1)**: Depends on US1 (needs tasks to notify about)
 
 ### Parallel Opportunities
 


### PR DESCRIPTION
## Summary

Adds structured task completion notifications for background tasks, replacing raw XML rendering with colored status indicators in the chat UI.

## Changes

- **SDK Types**: Add `TaskNotificationBlock` type to `messaging.ts`
- **XML Helpers**: New `notificationXml.ts` for serialization/parsing of task notifications
- **Message Operations**: Add `addNotificationMessageToMessages` and `AddNotificationMessageParams`
- **MessageManager**: New `addNotificationMessage` method with `onNotificationMessageAdded` callback
- **Agent**: Update `processPendingNotifications()` to use structured blocks
- **AIManager**: Update notification injection to use structured blocks
- **convertMessagesForAPI**: Convert `task_notification` blocks back to XML for API
- **CLI Component**: New `TaskNotificationMessage` component with colored dots (green/red/yellow)
- **MessageBlockItem**: Render `task_notification` blocks
- **Spec Docs**: Updated User Story 6, FR-023 to FR-026, notification data model
- **Test Fix**: Fixed hook test mocks (`vi.resetAllMocks` clearing module-scope implementations)

## Related

Continues work from previous commits:
- `69d477df` feat: add background task completion XML notification and fix isLoading
- `54e4eea1` test: add coverage for NotificationQueue and onLoadingChange callback
- `c9c37042` test: add coverage for notification queue and background task notifications
- `6e25e638` test: add coverage tests for notification queue branches
- `13993f53` test: add aiManager coverage tests for partially covered branches