### PR TITLE
fix: prevent text block double-rendering in forked skill messages

### DIFF
--- a/packages/agent-sdk/src/utils/messageOperations.ts
+++ b/packages/agent-sdk/src/utils/messageOperations.ts
@@ -140,6 +140,7 @@ export const addUserMessageToMessages = ({
   const textBlock = {
     type: "text" as const,
     content,
+    stage: "end" as const,
     ...(customCommandContent && { customCommandContent }),
     ...(source && { source }),
   };


### PR DESCRIPTION
## Summary

Fixed a rendering issue in the CLI where text blocks in user messages were displayed twice when paired with a running tool block (e.g., forked skill commands like `/check-and-fix`).

## Root Cause

In `MessageList.tsx`, when a user message contains both a text block and a tool block with `stage: "running"`, the entire message was treated as dynamic. The text block was initially rendered as static, then re-rendered as dynamic, causing both versions to remain visible.

## Fix

- `packages/agent-sdk/src/utils/messageOperations.ts`: Added `stage: "end"` to text blocks when created via `addUserMessage`
- This ensures text blocks are immediately classified as static, preventing double rendering while tool blocks remain dynamic