### PR TITLE
feat: allow forked auto-memory agent to rm files in memory dir

### DIFF
--- a/packages/agent-sdk/src/services/autoMemoryService.ts
+++ b/packages/agent-sdk/src/services/autoMemoryService.ts
@@ -160,6 +160,7 @@ export class AutoMemoryService {
           "Grep",
           `Write(${memoryDir}/**/*)`,
           `Edit(${memoryDir}/**/*)`,
+          `Bash(rm ${memoryDir}/**/*)`,
         ],
         model: "fastModel", // Use fast model for background tasks to reduce latency and cost
         permissionModeOverride: "dontAsk", // Auto-deny out-of-scope writes without prompting user

--- a/specs/018-memory-management/auto-memory-background-agent.md
+++ b/specs/018-memory-management/auto-memory-background-agent.md
@@ -175,6 +175,7 @@ await this.forkedAgentManager.forkAndExecute(
       "Read", "Glob", "Grep",
       `Write(${memoryDir}/**/*)`,
       `Edit(${memoryDir}/**/*)`,
+      `Bash(rm ${memoryDir}/**/*)`,
     ],
     model: "fastModel",
     permissionModeOverride: "dontAsk",


### PR DESCRIPTION
Add Bash(rm ${memoryDir}/**/*) to the allowedTools array for the forked auto-memory extraction agent, enabling it to delete outdated memory files. Also update the spec documentation.