### PR TITLE
fix: improve forked skill tool block status and AI continuation

### DIFF
--- a/packages/agent-sdk/src/managers/slashCommandManager.ts
+++ b/packages/agent-sdk/src/managers/slashCommandManager.ts
@@ -261,6 +261,7 @@ export class SlashCommandManager {
                     messageId,
                     result,
                     stage: "end",
+                    success: true,
                   });
                 } finally {
                   this.subagentManager.cleanupInstance(instance.subagentId);
@@ -271,6 +272,7 @@ export class SlashCommandManager {
                   id: toolBlockId,
                   messageId,
                   stage: "end",
+                  success: false,
                   error: error instanceof Error ? error.message : String(error),
                 });
                 throw error; // Re-throw to be caught by outer catch for logging/error block

--- a/packages/agent-sdk/src/managers/slashCommandManager.ts
+++ b/packages/agent-sdk/src/managers/slashCommandManager.ts
@@ -248,6 +248,8 @@ export class SlashCommandManager {
                   },
                 );
 
+                // Show loading while subagent runs
+                this.aiManager.setIsLoading(true);
                 try {
                   const result = await this.subagentManager.executeAgent(
                     instance,
@@ -263,6 +265,9 @@ export class SlashCommandManager {
                     stage: "end",
                     success: true,
                   });
+
+                  // Trigger AI to process the tool result
+                  await this.aiManager.sendAIMessage();
                 } finally {
                   this.subagentManager.cleanupInstance(instance.subagentId);
                 }

--- a/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
+++ b/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
@@ -550,11 +550,81 @@ describe("SlashCommandManager", () => {
           messageId,
           result: "Subagent result",
           stage: "end",
+          success: true,
         }),
       );
 
       // Verify that main agent is NOT triggered
       expect(aiManager.sendAIMessage).not.toHaveBeenCalled();
+    });
+
+    it("should set success:true on tool block when forked skill completes", async () => {
+      const skillMetadata = {
+        name: "fork-skill",
+        description: "Forked skill",
+        userInvocable: true,
+        context: "fork",
+      };
+
+      vi.mocked(mockSkillManager.prepareSkill).mockResolvedValue({
+        content: "Forked skill content",
+        skill: {
+          name: "fork-skill",
+          description: "Forked skill",
+          type: "personal",
+          skillPath: "",
+          context: "fork",
+          content: "",
+          frontmatter: { name: "fork-skill", description: "Forked skill" },
+          isValid: true,
+          errors: [],
+        } as Skill,
+      });
+
+      slashCommandManager.registerSkillCommands([
+        skillMetadata,
+      ] as unknown as SkillMetadata[]);
+
+      const cmd = slashCommandManager.getCommand("fork-skill");
+      const updateToolBlockSpy = vi.spyOn(messageManager, "updateToolBlock");
+
+      await cmd?.handler();
+
+      expect(updateToolBlockSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: expect.any(String),
+          result: "Subagent result",
+          stage: "end",
+          success: true,
+        }),
+      );
+    });
+
+    it("should set success:false on tool block when forked skill errors", async () => {
+      const skillMetadata = {
+        name: "fork-skill",
+        context: "fork",
+      };
+      slashCommandManager.registerSkillCommands([
+        skillMetadata,
+      ] as unknown as SkillMetadata[]);
+
+      const cmd = slashCommandManager.getCommand("fork-skill");
+      const updateToolBlockSpy = vi.spyOn(messageManager, "updateToolBlock");
+
+      vi.spyOn(mockSubagentManager, "executeAgent").mockRejectedValue(
+        new Error("Execution failed"),
+      );
+
+      await cmd?.handler();
+
+      expect(updateToolBlockSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: expect.any(String),
+          stage: "end",
+          error: "Execution failed",
+        }),
+      );
     });
 
     it("should handle error when no Agent configuration is found", async () => {
@@ -604,6 +674,7 @@ describe("SlashCommandManager", () => {
         expect.objectContaining({
           id: expect.any(String),
           stage: "end",
+          success: false,
           error: "Creation failed",
         }),
       );
@@ -632,6 +703,7 @@ describe("SlashCommandManager", () => {
         expect.objectContaining({
           id: expect.any(String),
           stage: "end",
+          success: false,
           error: "Execution failed",
         }),
       );

--- a/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
+++ b/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
@@ -58,6 +58,8 @@ describe("SlashCommandManager", () => {
     aiManager = {
       sendAIMessage: vi.fn(),
       abortAIMessage: vi.fn(),
+      setIsLoading: vi.fn(),
+      isLoading: false,
     } as unknown as AIManager;
 
     // Create mock BackgroundTaskManager
@@ -554,8 +556,8 @@ describe("SlashCommandManager", () => {
         }),
       );
 
-      // Verify that main agent is NOT triggered
-      expect(aiManager.sendAIMessage).not.toHaveBeenCalled();
+      // Verify that main agent is triggered to process the tool result
+      expect(aiManager.sendAIMessage).toHaveBeenCalled();
     });
 
     it("should set success:true on tool block when forked skill completes", async () => {


### PR DESCRIPTION
## Summary

Fixes for forked skill execution in the slash command handler.

## Changes

- **fix: set success status on forked skill tool blocks for correct dot color** — Forked skill tool blocks were missing the success field on completion, causing ToolDisplay to render a gray dot instead of green.

- **fix: show loading indicator and continue AI after forked skill completes** — Set isLoading while subagent executes so the loading indicator appears during forked skill execution. After completion, call sendAIMessage to continue the AI conversation with the tool result.