### PR TITLE
fix(reasoning): show streaming reasoning as truncated gray text

### DIFF
--- a/packages/agent-sdk/src/managers/messageManager.ts
+++ b/packages/agent-sdk/src/managers/messageManager.ts
@@ -654,6 +654,25 @@ export class MessageManager {
     const lastMessage = this.messages[this.messages.length - 1];
     if (lastMessage.role !== "assistant") return;
 
+    // Finalize any streaming reasoning blocks before text content arrives
+    const reasoningIndex = lastMessage.blocks.findIndex(
+      (block) =>
+        block.type === "reasoning" &&
+        (block as { stage?: string }).stage === "streaming",
+    );
+    if (reasoningIndex >= 0) {
+      const reasoningBlock = lastMessage.blocks[reasoningIndex] as {
+        type: "reasoning";
+        content: string;
+        stage?: string;
+      };
+      lastMessage.blocks[reasoningIndex] = {
+        type: "reasoning" as const,
+        content: reasoningBlock.content,
+        stage: "end" as const,
+      };
+    }
+
     // Get the current content to calculate the chunk
     const textBlockIndex = lastMessage.blocks.findIndex(
       (block) => block.type === "text",
@@ -704,6 +723,25 @@ export class MessageManager {
 
     const lastMessage = this.messages[this.messages.length - 1];
     if (lastMessage.role !== "assistant") return;
+
+    // Finalize any streaming text blocks before reasoning content arrives
+    const textIndex = lastMessage.blocks.findIndex(
+      (block) =>
+        block.type === "text" &&
+        (block as { stage?: string }).stage === "streaming",
+    );
+    if (textIndex >= 0) {
+      const textBlock = lastMessage.blocks[textIndex] as {
+        type: "text";
+        content: string;
+        stage?: string;
+      };
+      lastMessage.blocks[textIndex] = {
+        type: "text" as const,
+        content: textBlock.content,
+        stage: "end" as const,
+      };
+    }
 
     // Get the current reasoning content to calculate the chunk
     const reasoningBlockIndex = lastMessage.blocks.findIndex(

--- a/packages/code/src/components/MessageList.tsx
+++ b/packages/code/src/components/MessageList.tsx
@@ -42,18 +42,16 @@ export const MessageList = React.memo(
         (b.stage === "running" ||
           b.stage === "streaming" ||
           b.stage === "start")) ||
-      (b.type === "bang" && b.stage === "running");
+      (b.type === "bang" && b.stage === "running") ||
+      (b.type === "reasoning" && b.stage === "streaming");
 
     // Flatten messages into blocks with metadata
-    // Filter out streaming text/reasoning blocks to avoid frequent height changes
+    // Filter out streaming text blocks to avoid frequent height changes,
+    // but allow streaming reasoning blocks (rendered as truncated gray text)
     const allBlocks = visibleMessages.flatMap((message, messageIndex) => {
       return message.blocks
         .filter(
-          (block) =>
-            !(
-              (block.type === "text" || block.type === "reasoning") &&
-              block.stage === "streaming"
-            ),
+          (block) => !(block.type === "text" && block.stage === "streaming"),
         )
         .map((block, blockIndex) => ({
           block,

--- a/packages/code/src/components/ReasoningDisplay.tsx
+++ b/packages/code/src/components/ReasoningDisplay.tsx
@@ -12,7 +12,7 @@ export const ReasoningDisplay: React.FC<ReasoningDisplayProps> = ({
   block,
   isExpanded = false,
 }) => {
-  const { content } = block;
+  const { content, stage } = block;
 
   if (!content || !content.trim()) {
     return null;
@@ -30,6 +30,13 @@ export const ReasoningDisplay: React.FC<ReasoningDisplayProps> = ({
       <Box flexDirection="column">
         {isExpanded ? (
           <Text color="white">{content}</Text>
+        ) : stage === "streaming" ? (
+          <Text color="gray" wrap="truncate-end">
+            {` ${(() => {
+              const flat = content.replace(/\n/g, "\\n");
+              return flat.length > 30 ? `…${flat.slice(-30)}` : flat;
+            })()}`}
+          </Text>
         ) : (
           <Markdown>{content}</Markdown>
         )}


### PR DESCRIPTION
## Summary

Fix reasoning block streaming display to behave like tool blocks:

### Changes

- **MessageList.tsx**: Allow streaming reasoning blocks through (previously filtered out entirely). Mark reasoning as dynamic when streaming so it re-renders on each token update.

- **ReasoningDisplay.tsx**: Render streaming reasoning as last 30 chars gray truncated text. Full Markdown shown when streaming ends or when expanded.

- **messageManager.ts**: Finalize reasoning stage to 'end' when text content arrives (and vice versa), ensuring proper stage transitions between streaming blocks.

### Verification

- Type check: PASS
- Lint check: PASS