### PR TITLE
fix(plugin): resolve env vars in plugin MCP config

### DIFF
--- a/packages/agent-sdk/src/services/pluginLoader.ts
+++ b/packages/agent-sdk/src/services/pluginLoader.ts
@@ -10,6 +10,7 @@ import {
 } from "../types/index.js";
 import { scanCommandsDirectory } from "../utils/customCommands.js";
 import { parseSkillFile } from "../utils/skillParser.js";
+import { resolveMcpConfig } from "../managers/mcpManager.js";
 
 export class PluginLoader {
   /**
@@ -136,7 +137,7 @@ export class PluginLoader {
     const mcpPath = path.join(pluginPath, ".mcp.json");
     try {
       const content = await fs.readFile(mcpPath, "utf-8");
-      return JSON.parse(content) as McpConfig;
+      return resolveMcpConfig(JSON.parse(content)) as McpConfig;
     } catch {
       return undefined;
     }

--- a/packages/agent-sdk/tests/services/pluginLoader.test.ts
+++ b/packages/agent-sdk/tests/services/pluginLoader.test.ts
@@ -5,11 +5,31 @@ import { PluginLoader } from "../../src/services/pluginLoader.js";
 import { scanCommandsDirectory } from "../../src/utils/customCommands.js";
 import { CustomSlashCommand } from "../../src/types/index.js";
 import { parseSkillFile } from "../../src/utils/skillParser.js";
+import { resolveMcpConfig } from "../../src/managers/mcpManager.js";
 
 vi.mock("fs/promises");
 vi.mock("path");
 vi.mock("../../src/utils/customCommands.js");
 vi.mock("../../src/utils/skillParser.js");
+vi.mock("../../src/managers/mcpManager.js", () => ({
+  resolveMcpConfig: vi.fn((config) => {
+    // Simulate env var expansion for headers
+    const result = JSON.parse(JSON.stringify(config));
+    for (const server of Object.values(result.mcpServers) as Array<{
+      headers?: Record<string, string>;
+    }>) {
+      if (server.headers) {
+        for (const [key, value] of Object.entries(server.headers)) {
+          server.headers[key] = value.replace(
+            /\$\{([^}]+)\}/g,
+            (_match, varName) => process.env[varName] ?? "",
+          );
+        }
+      }
+    }
+    return result;
+  }),
+}));
 
 describe("PluginLoader", () => {
   const mockPluginPath = "/mock/plugin/path";
@@ -240,6 +260,7 @@ describe("PluginLoader", () => {
       const result = await PluginLoader.loadMcpConfig(mockPluginPath);
 
       expect(result).toEqual(mockConfig);
+      expect(resolveMcpConfig).toHaveBeenCalledWith(mockConfig);
     });
 
     it("should return undefined if .mcp.json does not exist", async () => {
@@ -248,6 +269,32 @@ describe("PluginLoader", () => {
       const result = await PluginLoader.loadMcpConfig(mockPluginPath);
 
       expect(result).toBeUndefined();
+    });
+
+    it("should resolve environment variables in MCP config", async () => {
+      const mockConfig = {
+        mcpServers: {
+          tavily: {
+            url: "https://mcp.tavily.com/mcp/",
+            headers: {
+              Authorization: "Bearer ${TAVILY_API_KEY}",
+            },
+          },
+        },
+      };
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(mockConfig));
+
+      // Set env var so mock resolver can pick it up
+      process.env.TAVILY_API_KEY = "test-api-key-123";
+
+      const result = await PluginLoader.loadMcpConfig(mockPluginPath);
+
+      expect(resolveMcpConfig).toHaveBeenCalledWith(mockConfig);
+      expect(result?.mcpServers?.tavily?.headers?.Authorization).toBe(
+        "Bearer test-api-key-123",
+      );
+
+      delete process.env.TAVILY_API_KEY;
     });
   });
 


### PR DESCRIPTION
PluginLoader.loadMcpConfig was not calling resolveMcpConfig,
so environment variables like ${TAVILY_API_KEY} in plugin
.mcp.json files were sent as literal strings instead of being
expanded, causing authentication failures.
