### PR TITLE
fix(cli): use synchronous agent loading state for message queue check

### DIFF
--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -499,7 +499,11 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
 
       if (!hasTextContent && !hasImageAttachments) return;
 
-      if (isLoading || isCommandRunning) {
+      // Check agent's actual loading state synchronously to avoid race condition
+      // React state (isLoading) updates asynchronously, so rapid messages bypass the queue
+      const isAgentBusy =
+        agentRef.current?.isLoading || agentRef.current?.isCommandRunning;
+      if (isAgentBusy) {
         setQueuedMessages((prev) => [
           ...prev,
           { content, images, longTextMap },
@@ -539,7 +543,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         console.error("Failed to send message:", error);
       }
     },
-    [isLoading, isCommandRunning],
+    [],
   );
 
   const askBtw = useCallback(async (question: string) => {

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -1060,10 +1060,13 @@ describe("ChatProvider", () => {
     });
     mockAgent.sendMessage.mockReturnValue(sendMessagePromise);
 
-    // Send first message - agent callback will set isLoading to true
+    // Send first message
     const firstSendMessage = lastValue?.sendMessage("First message");
 
-    // Simulate agent setting isLoading
+    // Set mock agent isLoading so subsequent messages get queued
+    mockAgent.isLoading = true;
+
+    // Simulate agent setting isLoading (for React state sync)
     callbacks.onLoadingChange!(true);
 
     await vi.waitFor(() => {


### PR DESCRIPTION
When sending messages rapidly, React state (isLoading) hadn't updated yet
by the time the second message arrived, so both bypassed the queue and
got batched into a single AI cycle.

Use agentRef.current?.isLoading (synchronous getter) instead of the
async React isLoading state to correctly detect if the agent is busy.
