### PR TITLE
fix: forked slash commands leave UI stuck with 'AI is thinking...'

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -67,6 +67,7 @@ export class Agent {
   private hookManager: HookManager; // Add hooks manager instance
   private reversionManager: ReversionManager;
   private notificationQueue: NotificationQueue; // Add notification queue instance
+  private pendingNotificationPromises: Promise<void>[] = []; // Track pending notification processing
   private memoryRuleManager: MemoryRuleManager; // Add memory rule manager instance
   private liveConfigManager: LiveConfigManager; // Add live configuration manager
   private taskManager: TaskManager;
@@ -202,9 +203,15 @@ export class Agent {
     this.notificationQueue.onNotificationsEnqueued = () => {
       // If the AI is NOT loading (idle), trigger a new AI cycle to process notifications
       if (!this.aiManager.isLoading) {
-        this.processPendingNotifications().catch((error) => {
-          this.logger?.error("Failed to process pending notifications:", error);
-        });
+        const pendingPromise = this.processPendingNotifications().catch(
+          (error) => {
+            this.logger?.error(
+              "Failed to process pending notifications:",
+              error,
+            );
+          },
+        );
+        this.pendingNotificationPromises.push(pendingPromise);
       }
     };
 
@@ -533,6 +540,17 @@ export class Agent {
 
   /** Destroy managers, clean up resources */
   public async destroy(): Promise<void> {
+    // Clear notification callback first to prevent any late triggers from
+    // starting async work during teardown
+    this.notificationQueue.onNotificationsEnqueued = undefined;
+
+    // Await any pending notification processing to prevent race conditions
+    // with test teardown (e.g., V8 coverage stream cleanup)
+    if (this.pendingNotificationPromises.length > 0) {
+      await Promise.allSettled(this.pendingNotificationPromises);
+      this.pendingNotificationPromises = [];
+    }
+
     await this.messageManager.saveSession();
     this.abortAIMessage(); // This will abort tools including Agent tool (subagents)
     this.abortBashCommand();

--- a/packages/agent-sdk/src/managers/slashCommandManager.ts
+++ b/packages/agent-sdk/src/managers/slashCommandManager.ts
@@ -266,6 +266,13 @@ export class SlashCommandManager {
                     success: true,
                   });
 
+                  // Set isLoading to false before triggering AI response, because:
+                  // 1. The subagent has its own isolated isLoading state (not linked to parent)
+                  // 2. The parent's isLoading is still true from line above
+                  // 3. sendAIMessage() has an early return if isLoading is true (aiManager.ts:358-360)
+                  // 4. Without this, sendAIMessage() would return immediately without executing
+                  this.aiManager.setIsLoading(false);
+
                   // Trigger AI to process the tool result
                   await this.aiManager.sendAIMessage();
                 } finally {

--- a/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
+++ b/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
@@ -762,5 +762,68 @@ describe("SlashCommandManager", () => {
       const textBlock = lastMessage.blocks[0] as TextBlock;
       expect(textBlock.content).toBe("/test:test-args arg1 arg2");
     });
+
+    it("should set isLoading to false after forked skill completes before calling sendAIMessage", async () => {
+      // Forked slash commands need to reset isLoading before calling sendAIMessage
+      // because sendAIMessage() has an early return guard when isLoading is true
+      const skillMetadata = {
+        name: "fork-skill",
+        description: "Forked skill",
+        userInvocable: true,
+        context: "fork",
+      };
+
+      vi.mocked(mockSkillManager.prepareSkill).mockResolvedValue({
+        content: "Forked skill content",
+        skill: {
+          name: "fork-skill",
+          description: "Forked skill",
+          type: "personal",
+          skillPath: "",
+          context: "fork",
+          content: "",
+          frontmatter: { name: "fork-skill", description: "Forked skill" },
+          isValid: true,
+          errors: [],
+        } as Skill,
+      });
+
+      slashCommandManager.registerSkillCommands([
+        skillMetadata,
+      ] as unknown as SkillMetadata[]);
+
+      const cmd = slashCommandManager.getCommand("fork-skill");
+      await cmd?.handler();
+
+      // Verify setIsLoading is called with both true and false
+      const setIsLoadingCalls = vi.mocked(aiManager.setIsLoading).mock.calls;
+      expect(setIsLoadingCalls).toContainEqual([true]);
+      expect(setIsLoadingCalls).toContainEqual([false]);
+
+      // Verify sendAIMessage was called (proves the early return guard was not hit)
+      expect(aiManager.sendAIMessage).toHaveBeenCalled();
+
+      // Verify setIsLoading(false) was called before sendAIMessage
+      // by checking mock invocation order
+      const setIsLoadingMock = aiManager.setIsLoading as ReturnType<
+        typeof vi.fn
+      >;
+      const sendAIMessageMock = aiManager.sendAIMessage as ReturnType<
+        typeof vi.fn
+      >;
+
+      // Find the order of setIsLoading(false) call
+      const setIsLoadingFalseOrder =
+        setIsLoadingMock.mock.invocationCallOrder.find(
+          (order, i) => setIsLoadingCalls[i]?.[0] === false,
+        );
+
+      // Find the order of sendAIMessage call
+      const sendAIMessageOrder = sendAIMessageMock.mock.invocationCallOrder[0];
+
+      expect(setIsLoadingFalseOrder).toBeDefined();
+      expect(sendAIMessageOrder).toBeDefined();
+      expect(setIsLoadingFalseOrder!).toBeLessThan(sendAIMessageOrder!);
+    });
   });
 });


### PR DESCRIPTION
## Problem

When a forked skill is invoked via slash command (e.g., `/check-and-fix`), the UI gets stuck showing "AI is thinking..." indefinitely, even after the skill completes successfully.

## Root Cause

The parent agent's `isLoading` is set to `true` before the forked subagent runs, but is never reset to `false` before calling `sendAIMessage()`. The `sendAIMessage()` method has an early return guard that skips execution when `isLoading` is true:

```ts
if (recursionDepth === 0 && this.isLoading) {
  return;  // ← Early return, isLoading stays true forever
}
```

The subagent has its own isolated `isLoading` state (not linked to the parent), so when the subagent completes and sets its own `isLoading = false`, the parent's `isLoading` remains `true`.

## Fix

In `packages/agent-sdk/src/managers/slashCommandManager.ts`, set `isLoading` to `false` after the subagent completes but before calling `sendAIMessage()`:

```ts
this.aiManager.setIsLoading(false);
await this.aiManager.sendAIMessage();
```

## Changes

- `packages/agent-sdk/src/managers/slashCommandManager.ts` — Add `setIsLoading(false)` before `sendAIMessage()` call
- `packages/agent-sdk/tests/managers/slashCommandManager.test.ts` — Add test verifying `isLoading` is reset before `sendAIMessage()`