### PR TITLE
fix: duplicate task notifications for background agent tasks

### DIFF
--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -399,6 +399,7 @@ export class SubagentManager {
         instance.backgroundTaskId = taskId;
 
         // Execute in background
+        // Note: notification enqueueing is handled by internalExecute when instance.backgroundTaskId is set
         (async () => {
           try {
             const result = await this.internalExecute(
@@ -413,17 +414,6 @@ export class SubagentManager {
               task.endTime = Date.now();
               task.runtime = task.endTime - startTime;
             }
-
-            // Enqueue completion notification
-            const notificationQueue = this.container.has("NotificationQueue")
-              ? this.container.get<NotificationQueue>("NotificationQueue")
-              : undefined;
-            if (notificationQueue) {
-              const summary = `Agent task "${instance.description}" completed`;
-              notificationQueue.enqueue(
-                `<task-notification>\n<task-id>${taskId}</task-id>\n<task-type>agent</task-type>\n<status>completed</status>\n<summary>${summary}</summary>\n</task-notification>`,
-              );
-            }
           } catch (error) {
             const task = backgroundTaskManager?.getTask(taskId);
             if (task) {
@@ -432,19 +422,6 @@ export class SubagentManager {
                 error instanceof Error ? error.message : String(error);
               task.endTime = Date.now();
               task.runtime = task.endTime - startTime;
-            }
-
-            // Enqueue error notification
-            const notificationQueue = this.container.has("NotificationQueue")
-              ? this.container.get<NotificationQueue>("NotificationQueue")
-              : undefined;
-            if (notificationQueue) {
-              const errorMsg =
-                error instanceof Error ? error.message : String(error);
-              const summary = `Agent task "${instance.description}" failed: ${errorMsg}`;
-              notificationQueue.enqueue(
-                `<task-notification>\n<task-id>${taskId}</task-id>\n<task-type>agent</task-type>\n<status>failed</status>\n<summary>${summary}</summary>\n</task-notification>`,
-              );
             }
           }
         })();

--- a/packages/agent-sdk/tests/managers/subagentManager.notification.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.notification.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskManager } from "../../src/services/taskManager.js";
+import { SubagentManager } from "../../src/managers/subagentManager.js";
+import { ToolManager } from "../../src/managers/toolManager.js";
+import { BackgroundTaskManager } from "../../src/managers/backgroundTaskManager.js";
+import { AIManager } from "../../src/managers/aiManager.js";
+import { NotificationQueue } from "../../src/managers/notificationQueue.js";
+import { Container } from "../../src/utils/container.js";
+import type { SubagentConfiguration } from "../../src/utils/subagentParser.js";
+
+// Mock dependencies
+vi.mock("../../src/managers/messageManager.js");
+vi.mock("../../src/managers/toolManager.js");
+vi.mock("../../src/managers/backgroundTaskManager.js");
+vi.mock("../../src/managers/aiManager.js", () => ({
+  AIManager: vi.fn().mockImplementation(function () {
+    return {
+      sendAIMessage: vi.fn().mockResolvedValue("Test response"),
+      abortAIMessage: vi.fn(),
+    };
+  }),
+}));
+
+// Mock the memory service
+vi.mock("../../src/services/memory.js", () => ({
+  MemoryService: vi.fn().mockImplementation(() => ({
+    getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+    getAutoMemoryDirectory: vi.fn().mockReturnValue("/mock/auto-memory"),
+    ensureAutoMemoryDirectory: vi.fn().mockResolvedValue(undefined),
+    getAutoMemoryContent: vi.fn().mockResolvedValue(""),
+  })),
+  getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+}));
+
+describe("SubagentManager - Notification Deduplication", () => {
+  let subagentManager: SubagentManager;
+  let mockToolManager: ToolManager;
+  let mockBackgroundTaskManager: BackgroundTaskManager;
+  let notificationQueue: NotificationQueue;
+  let container: Container;
+
+  const testConfig: SubagentConfiguration = {
+    name: "TestAgent",
+    description: "Test agent",
+    systemPrompt: "System prompt",
+    tools: ["Read"],
+    model: "inherit",
+    filePath: "/test/agent.md",
+    scope: "user",
+    priority: 1,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockToolManager = {
+      list: vi.fn(() => [{ name: "Read" }]),
+      getPermissionManager: vi.fn(),
+    } as unknown as ToolManager;
+
+    mockBackgroundTaskManager = {
+      generateId: vi.fn().mockReturnValue("task_123"),
+      addTask: vi.fn(),
+      getTask: vi.fn(),
+    } as unknown as BackgroundTaskManager;
+
+    notificationQueue = new NotificationQueue();
+
+    const taskManager = {
+      on: vi.fn(),
+      listTasks: vi.fn().mockResolvedValue([]),
+      getTaskListId: vi.fn().mockReturnValue("test-task-list"),
+    } as unknown as TaskManager;
+
+    container = new Container();
+    container.register("ToolManager", mockToolManager);
+    container.register("TaskManager", taskManager);
+    container.register("BackgroundTaskManager", mockBackgroundTaskManager);
+    container.register("NotificationQueue", notificationQueue);
+
+    container.register("ConfigurationService", {
+      resolveGatewayConfig: () => ({ apiKey: "test", baseURL: "test" }),
+      resolveModelConfig: () => ({
+        model: "test-model",
+        fastModel: "test-fast-model",
+      }),
+      resolveMaxInputTokens: () => 1000,
+      resolveAutoMemoryEnabled: () => true,
+      resolveLanguage: () => "en",
+    });
+
+    subagentManager = new SubagentManager(container, {
+      workdir: "/test",
+      stream: false,
+    });
+  });
+
+  it("should enqueue exactly ONE completion notification for backgroundInstance path", async () => {
+    const enqueueSpy = vi.spyOn(notificationQueue, "enqueue");
+
+    const instance = await subagentManager.createInstance(testConfig, {
+      description: "Test background task",
+      prompt: "p",
+      subagent_type: "t",
+    });
+
+    const mockTask = {
+      id: "task_123",
+      status: "running",
+      startTime: Date.now(),
+      stdout: "",
+      endTime: 0,
+      runtime: 0,
+    };
+    vi.mocked(mockBackgroundTaskManager.getTask).mockReturnValue(
+      mockTask as unknown as ReturnType<
+        typeof mockBackgroundTaskManager.getTask
+      >,
+    );
+
+    await subagentManager.backgroundInstance(instance.subagentId);
+
+    vi.mocked(instance.messageManager.getMessages).mockReturnValue([
+      { role: "assistant", blocks: [{ type: "text", content: "Done" }] },
+    ] as unknown as ReturnType<typeof instance.messageManager.getMessages>);
+
+    await subagentManager.executeAgent(instance, "test prompt");
+
+    // Wait for async operations to settle
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Should enqueue exactly one notification, not two
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledWith(
+      expect.stringContaining("<status>completed</status>"),
+    );
+    expect(enqueueSpy).toHaveBeenCalledWith(
+      expect.stringContaining("task_123"),
+    );
+  });
+
+  it("should enqueue exactly ONE error notification for backgroundInstance path", async () => {
+    const enqueueSpy = vi.spyOn(notificationQueue, "enqueue");
+
+    const instance = await subagentManager.createInstance(testConfig, {
+      description: "Failing background task",
+      prompt: "p",
+      subagent_type: "t",
+    });
+
+    const mockTask = {
+      id: "task_123",
+      status: "running",
+      startTime: Date.now(),
+      stderr: "",
+      endTime: 0,
+      runtime: 0,
+    };
+    vi.mocked(mockBackgroundTaskManager.getTask).mockReturnValue(
+      mockTask as unknown as ReturnType<
+        typeof mockBackgroundTaskManager.getTask
+      >,
+    );
+
+    await subagentManager.backgroundInstance(instance.subagentId);
+
+    const aiManager = (instance as unknown as { aiManager: AIManager })
+      .aiManager;
+    vi.spyOn(aiManager, "sendAIMessage").mockRejectedValue(
+      new Error("Build failed"),
+    );
+    vi.mocked(instance.messageManager.getMessages).mockReturnValue([]);
+
+    await expect(
+      subagentManager.executeAgent(instance, "test prompt"),
+    ).rejects.toThrow("Build failed");
+
+    // Wait for async operations to settle
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Should enqueue exactly one error notification, not two
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledWith(
+      expect.stringContaining("<status>failed</status>"),
+    );
+    expect(enqueueSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Build failed"),
+    );
+  });
+
+  it("should enqueue exactly ONE completion notification for executeAgent with runInBackground", async () => {
+    const enqueueSpy = vi.spyOn(notificationQueue, "enqueue");
+
+    const instance = await subagentManager.createInstance(testConfig, {
+      description: "Test background task",
+      prompt: "p",
+      subagent_type: "t",
+    });
+
+    // Mock getMessages to return a successful response before executeAgent runs
+    vi.mocked(instance.messageManager.getMessages).mockReturnValue([
+      { role: "assistant", blocks: [{ type: "text", content: "Done" }] },
+    ] as unknown as ReturnType<typeof instance.messageManager.getMessages>);
+
+    const taskId = await subagentManager.executeAgent(
+      instance,
+      "test prompt",
+      undefined,
+      true,
+    );
+
+    // Wait for the background async IIFE to complete
+    await vi.waitFor(() => expect(enqueueSpy).toHaveBeenCalled());
+
+    // Should enqueue exactly one notification, not two
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledWith(
+      expect.stringContaining("<status>completed</status>"),
+    );
+    expect(enqueueSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`<task-id>${String(taskId)}</task-id>`),
+    );
+  });
+
+  it("should enqueue exactly ONE error notification for executeAgent with runInBackground", async () => {
+    const enqueueSpy = vi.spyOn(notificationQueue, "enqueue");
+
+    const instance = await subagentManager.createInstance(testConfig, {
+      description: "Failing background task",
+      prompt: "p",
+      subagent_type: "t",
+    });
+
+    const aiManager = (instance as unknown as { aiManager: AIManager })
+      .aiManager;
+    vi.spyOn(aiManager, "sendAIMessage").mockRejectedValue(
+      new Error("AI failure"),
+    );
+
+    await subagentManager.executeAgent(
+      instance,
+      "test prompt",
+      undefined,
+      true,
+    );
+
+    // Wait for the background async IIFE to complete with error
+    await vi.waitFor(() => expect(enqueueSpy).toHaveBeenCalled());
+
+    // Should enqueue exactly one error notification, not two
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledWith(
+      expect.stringContaining("<status>failed</status>"),
+    );
+    expect(enqueueSpy).toHaveBeenCalledWith(
+      expect.stringContaining("AI failure"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixed duplicate task completion notifications appearing in the message list when background agent tasks complete or fail.

## Root Cause

When executeAgent runs with runInBackground, the notification was enqueued twice:
1. In the async IIFE wrapper within executeAgent
2. In internalExecute (which already handles notifications when instance.backgroundTaskId is set)

## Changes

- **packages/agent-sdk/src/managers/subagentManager.ts**: Removed redundant notification enqueue calls from the executeAgent async IIFE wrapper. The internalExecute method already handles this.
- **packages/agent-sdk/tests/managers/subagentManager.notification.test.ts**: Added 4 tests verifying exactly ONE notification is enqueued for both backgroundInstance and runInBackground paths (success and error cases).