### PR TITLE
fix(code): prevent queued messages from dequeueing concurrently

### DIFF
--- a/packages/agent-sdk/src/services/interactionService.ts
+++ b/packages/agent-sdk/src/services/interactionService.ts
@@ -49,8 +49,14 @@ export class InteractionService {
           slashCommandManager.parseAndValidateSlashCommand(command);
 
         if (isValid && commandId !== undefined) {
-          // Execute valid slash command
-          await slashCommandManager.executeCommand(commandId, args);
+          // Set loading state to prevent concurrent commands
+          aiManager.setIsLoading(true);
+          try {
+            // Execute valid slash command
+            await slashCommandManager.executeCommand(commandId, args);
+          } finally {
+            aiManager.setIsLoading(false);
+          }
 
           return;
         }

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -499,7 +499,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
 
       if (!hasTextContent && !hasImageAttachments) return;
 
-      if (isLoading || isCommandRunning) {
+      if (agentRef.current?.isLoading || isCommandRunning) {
         setQueuedMessages((prev) => [
           ...prev,
           { content, images, longTextMap },
@@ -539,7 +539,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         console.error("Failed to send message:", error);
       }
     },
-    [isLoading, isCommandRunning],
+    [isCommandRunning],
   );
 
   const askBtw = useCallback(async (question: string) => {
@@ -551,7 +551,11 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
 
   // Process queued messages when idle
   useEffect(() => {
-    if (!isLoading && !isCommandRunning && queuedMessages.length > 0) {
+    if (
+      !agentRef.current?.isLoading &&
+      !isCommandRunning &&
+      queuedMessages.length > 0
+    ) {
       const nextMessage = queuedMessages[0];
       setQueuedMessages((prev) => prev.slice(1));
       sendMessage(

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -1060,10 +1060,11 @@ describe("ChatProvider", () => {
     });
     mockAgent.sendMessage.mockReturnValue(sendMessagePromise);
 
-    // Send first message - agent callback will set isLoading to true
+    // Send first message
     const firstSendMessage = lastValue?.sendMessage("First message");
 
-    // Simulate agent setting isLoading
+    // Simulate agent setting isLoading to true (as the SDK does synchronously)
+    mockAgent.isLoading = true;
     callbacks.onLoadingChange!(true);
 
     await vi.waitFor(() => {
@@ -1087,6 +1088,7 @@ describe("ChatProvider", () => {
     });
 
     // Cleanup
+    mockAgent.isLoading = false;
     callbacks.onLoadingChange!(false);
     resolveSendMessage!();
     await firstSendMessage;
@@ -1192,6 +1194,61 @@ describe("ChatProvider", () => {
     await vi.waitFor(() => {
       expect(writeSpy).toHaveBeenCalledTimes(2);
       expect(lastValue?.remountKey).toBe(initialRemountKey! + 2);
+    });
+  });
+
+  it("dequeue queued messages one at a time, not concurrently", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(lastValue).toBeDefined();
+    });
+
+    const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
+    const callbacks = agentCreateArgs.callbacks!;
+
+    // Mock sendMessage to block until we resolve it
+    let resolveFirst: (value: void) => void;
+    const firstSendPromise = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    mockAgent.sendMessage.mockImplementation(async () => {
+      await firstSendPromise;
+    });
+
+    // Send first message
+    lastValue?.sendMessage("msg1");
+
+    // Simulate what the agent SDK does: set isLoading to true FIRST, then fire callback
+    mockAgent.isLoading = true;
+    callbacks.onLoadingChange!(true);
+
+    // Send second message while isLoading is true - should be queued
+    lastValue?.sendMessage("msg2");
+
+    await vi.waitFor(() => {
+      expect(lastValue?.queuedMessages).toHaveLength(1);
+      expect(lastValue?.queuedMessages[0].content).toBe("msg2");
+    });
+
+    // Only the first message should have been sent
+    expect(mockAgent.sendMessage).toHaveBeenCalledTimes(1);
+
+    // Now simulate the first message completing
+    // Agent SDK: set isLoading to false FIRST, then fire callback
+    mockAgent.isLoading = false;
+    callbacks.onLoadingChange!(false);
+    resolveFirst!();
+
+    // The queued message should now dequeue
+    await vi.waitFor(() => {
+      expect(mockAgent.sendMessage).toHaveBeenCalledTimes(2);
+      expect(mockAgent.sendMessage).toHaveBeenCalledWith("msg2", undefined);
     });
   });
 


### PR DESCRIPTION
## Summary

Fix race condition where multiple queued messages (e.g., skill slash commands) could dequeue simultaneously instead of one at a time.

## Root Cause

React state updates are batched. Both `sendMessage` and the dequeue `useEffect` closed over stale `isLoading = false`, causing concurrent dequeues before React could re-render with the agent SDK's `onLoadingChange(true)` callback.

## Fix

Replace React state `isLoading` checks with `agentRef.current?.isLoading` in:
- `sendMessage` guard (line 502)
- Dequeue `useEffect` guard (line 554)

The SDK sets `aiManager.isLoading = true` synchronously before firing the callback, so reading the property directly bypasses React's batching and stale closures.