### PR TITLE
fix(sdk): remove isLoading wrapper blocking skill slash command execution

### DIFF
--- a/packages/agent-sdk/src/services/interactionService.ts
+++ b/packages/agent-sdk/src/services/interactionService.ts
@@ -49,14 +49,11 @@ export class InteractionService {
           slashCommandManager.parseAndValidateSlashCommand(command);
 
         if (isValid && commandId !== undefined) {
-          // Set loading state to prevent concurrent commands
-          aiManager.setIsLoading(true);
-          try {
-            // Execute valid slash command
-            await slashCommandManager.executeCommand(commandId, args);
-          } finally {
-            aiManager.setIsLoading(false);
-          }
+          // Execute valid slash command
+          // Note: executeCommand and its handlers (e.g., skill commands) manage
+          // isLoading internally. Setting it here would cause sendAIMessage() to
+          // return early due to the isLoading guard at aiManager.ts:357.
+          await slashCommandManager.executeCommand(commandId, args);
 
           return;
         }


### PR DESCRIPTION
The previous fix (e43c4177) added setIsLoading(true) before executeCommand in interactionService.ts to prevent concurrent dequeue of queued messages. However, this caused skill slash commands to fail because:

1. interactionService sets isLoading = true before executeCommand
2. Skill handler calls sendAIMessage() internally
3. sendAIMessage() has an early return guard: `if (recursionDepth === 0 && this.isLoading) return;`
4. Since isLoading is already true, the AI message never gets sent — the skill message appears but the agent never runs

This commit removes the redundant setIsLoading wrapper. Skill handlers already manage isLoading internally:
- Non-forked skills: sendAIMessage() sets it at line 363 of aiManager.ts
- Forked skills: setIsLoading(true) at line 252 before executeAgent()

All tests pass (2211 agent-sdk + 42 useChat).