### PR TITLE
feat: move queued message queueing from useChat to agent-sdk

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -10,6 +10,7 @@ import { BangManager } from "./managers/bangManager.js";
 import { CronManager } from "./managers/cronManager.js";
 import { BackgroundTaskManager } from "./managers/backgroundTaskManager.js";
 import { NotificationQueue } from "./managers/notificationQueue.js";
+import { MessageQueue, type QueuedMessage } from "./managers/messageQueue.js";
 import { SlashCommandManager } from "./managers/slashCommandManager.js";
 import { PluginManager } from "./managers/pluginManager.js";
 import { HookManager } from "./managers/hookManager.js";
@@ -67,6 +68,7 @@ export class Agent {
   private hookManager: HookManager; // Add hooks manager instance
   private reversionManager: ReversionManager;
   private notificationQueue: NotificationQueue; // Add notification queue instance
+  private messageQueue: MessageQueue; // Add message queue instance
   private pendingNotificationPromises: Promise<void>[] = []; // Track pending notification processing
   private memoryRuleManager: MemoryRuleManager; // Add memory rule manager instance
   private liveConfigManager: LiveConfigManager; // Add live configuration manager
@@ -198,6 +200,7 @@ export class Agent {
     this.bangManager = this.container.get("BangManager")!;
     this.cronManager = this.container.get("CronManager")!;
     this.notificationQueue = this.container.get("NotificationQueue")!;
+    this.messageQueue = this.container.get("MessageQueue")!;
 
     // Wire up notification queue to trigger AI when notifications arrive while idle
     this.notificationQueue.onNotificationsEnqueued = () => {
@@ -220,6 +223,36 @@ export class Agent {
       this.workdir = newCwd;
       this.options.callbacks?.onWorkdirChange?.(newCwd);
     });
+
+    // Wire up message queue to process when agent becomes idle
+    this.messageQueue.onMessageEnqueued = () => {
+      // If the AI is NOT loading and command is not running, trigger dequeue
+      if (!this.aiManager.isLoading && !this.isCommandRunning) {
+        this.processQueuedMessage().catch((error) => {
+          this.logger?.error("Failed to process queued message:", error);
+        });
+      }
+    };
+
+    // Wire up AI loading changes to process queue when AI becomes idle
+    this.aiManager.onLoadingChange = (loading: boolean) => {
+      if (!loading && !this.isCommandRunning) {
+        this.processQueuedMessage().catch((error) => {
+          this.logger?.error("Failed to process queued message:", error);
+        });
+      }
+    };
+
+    // Wire up bang manager callback for command running changes
+    this.bangManager.onCommandRunningChange = (running: boolean) => {
+      this.options.callbacks?.onCommandRunningChange?.(running);
+      // When command stops and AI is idle, process queue
+      if (!running && !this.aiManager.isLoading) {
+        this.processQueuedMessage().catch((error) => {
+          this.logger?.error("Failed to process queued message:", error);
+        });
+      }
+    };
 
     // Set initial permission mode if provided
     if (options.permissionMode) {
@@ -290,6 +323,24 @@ export class Agent {
   /** Get bash command execution status */
   public get isCommandRunning(): boolean {
     return this.bangManager?.isCommandRunning ?? false;
+  }
+
+  /** Get queued messages */
+  public get queuedMessages(): QueuedMessage[] {
+    return this.messageQueue.getQueue();
+  }
+
+  /**
+   * Process the next queued message when the agent becomes idle.
+   * Dequeues the next message and sends it.
+   */
+  private async processQueuedMessage(): Promise<void> {
+    const next = this.messageQueue.dequeue();
+    if (!next) return;
+
+    this.options.callbacks?.onQueuedMessagesChange?.(this.queuedMessages);
+
+    await this.sendMessage(next.content, next.images);
   }
 
   /** Get background bash shell output */
@@ -504,6 +555,8 @@ export class Agent {
     this.abortAIMessage(); // This will abort tools including Agent tool (subagents)
     this.abortBashCommand();
     this.abortSlashCommand();
+    this.messageQueue.clear();
+    this.options.callbacks?.onQueuedMessagesChange?.(this.queuedMessages);
   }
 
   /** Interrupt bash command execution */
@@ -635,6 +688,13 @@ export class Agent {
     content: string,
     images?: Array<{ path: string; mimeType: string }>,
   ): Promise<void> {
+    // If the agent is busy, enqueue the message
+    if (this.aiManager.isLoading || this.isCommandRunning) {
+      this.messageQueue.enqueue({ content, images });
+      this.options.callbacks?.onQueuedMessagesChange?.(this.queuedMessages);
+      return;
+    }
+
     await InteractionService.sendMessage(
       {
         messageManager: this.messageManager,

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -8,6 +8,7 @@ export * from "./constants/tools.js";
 export * from "./agent.js";
 export * from "./core/plugin.js";
 export * from "./managers/cronManager.js";
+export * from "./managers/messageQueue.js";
 
 // Export all utilities
 export * from "./utils/bashParser.js";

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -48,6 +48,7 @@ export interface AIManagerOptions {
 export class AIManager {
   public isLoading: boolean = false;
   private abortController: AbortController | null = null;
+  onLoadingChange?: (loading: boolean) => void;
   private toolAbortController: AbortController | null = null;
   private workdir: string;
   private systemPrompt?: string;
@@ -191,6 +192,7 @@ export class AIManager {
 
   public setIsLoading(isLoading: boolean): void {
     this.isLoading = isLoading;
+    this.onLoadingChange?.(isLoading);
     const options =
       this.container.get<import("../types/agent.js").AgentOptions>(
         "AgentOptions",

--- a/packages/agent-sdk/src/managers/bangManager.ts
+++ b/packages/agent-sdk/src/managers/bangManager.ts
@@ -15,6 +15,7 @@ export class BangManager {
   private workdir: string;
   public isCommandRunning = false;
   private currentProcess: ChildProcess | null = null;
+  onCommandRunningChange?: (running: boolean) => void;
 
   constructor(
     private container: Container,
@@ -29,6 +30,7 @@ export class BangManager {
 
   private setCommandRunning(isRunning: boolean): void {
     this.isCommandRunning = isRunning;
+    this.onCommandRunningChange?.(isRunning);
   }
 
   public async executeCommand(command: string): Promise<number> {

--- a/packages/agent-sdk/src/managers/messageQueue.ts
+++ b/packages/agent-sdk/src/managers/messageQueue.ts
@@ -1,0 +1,31 @@
+export interface QueuedMessage {
+  content: string;
+  images?: Array<{ path: string; mimeType: string }>;
+  longTextMap?: Record<string, string>;
+}
+
+export class MessageQueue {
+  private queue: QueuedMessage[] = [];
+  onMessageEnqueued?: () => void;
+
+  enqueue(message: QueuedMessage): void {
+    this.queue.push(message);
+    this.onMessageEnqueued?.();
+  }
+
+  dequeue(): QueuedMessage | null {
+    return this.queue.shift() ?? null;
+  }
+
+  clear(): void {
+    this.queue = [];
+  }
+
+  hasPending(): boolean {
+    return this.queue.length > 0;
+  }
+
+  getQueue(): QueuedMessage[] {
+    return [...this.queue];
+  }
+}

--- a/packages/agent-sdk/src/types/agent.ts
+++ b/packages/agent-sdk/src/types/agent.ts
@@ -1,4 +1,5 @@
 import type { ClientOptions } from "openai";
+import type { QueuedMessage } from "../managers/messageQueue.js";
 import type {
   Message,
   Logger,
@@ -96,5 +97,7 @@ export interface AgentCallbacks
   onModelChange?: (model: string) => void;
   onConfiguredModelsChange?: (models: string[]) => void;
   onLoadingChange?: (loading: boolean) => void;
+  onCommandRunningChange?: (running: boolean) => void;
   onWorkdirChange?: (newCwd: string) => void;
+  onQueuedMessagesChange?: (messages: QueuedMessage[]) => void;
 }

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -2,6 +2,7 @@ import { Container } from "./container.js";
 import { ForegroundTaskManager } from "../managers/foregroundTaskManager.js";
 import { BackgroundTaskManager } from "../managers/backgroundTaskManager.js";
 import { NotificationQueue } from "../managers/notificationQueue.js";
+import { MessageQueue } from "../managers/messageQueue.js";
 import { TaskManager } from "../services/taskManager.js";
 import { MessageManager } from "../managers/messageManager.js";
 import { AIManager } from "../managers/aiManager.js";
@@ -79,6 +80,9 @@ export function setupAgentContainer(
 
   const notificationQueue = new NotificationQueue();
   container.register("NotificationQueue", notificationQueue);
+
+  const messageQueue = new MessageQueue();
+  container.register("MessageQueue", messageQueue);
 
   const foregroundTaskManager = new ForegroundTaskManager(container);
   container.register("ForegroundTaskManager", foregroundTaskManager);

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -17,6 +17,7 @@ import type {
   SlashCommand,
   PermissionDecision,
   PermissionMode,
+  QueuedMessage,
 } from "wave-agent-sdk";
 import {
   Agent,
@@ -41,11 +42,7 @@ export interface ChatContextType {
   isExpanded: boolean;
   isTaskListVisible: boolean;
   setIsTaskListVisible: (visible: boolean) => void;
-  queuedMessages: Array<{
-    content: string;
-    images?: Array<{ path: string; mimeType: string }>;
-    longTextMap?: Record<string, string>;
-  }>;
+  queuedMessages: QueuedMessage[];
   // AI functionality
   sessionId: string;
   sendMessage: (
@@ -158,18 +155,6 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
 
   const [isTaskListVisible, setIsTaskListVisible] = useState(true);
 
-  const [queuedMessages, setQueuedMessages] = useState<
-    Array<{
-      content: string;
-      images?: Array<{ path: string; mimeType: string }>;
-      longTextMap?: Record<string, string>;
-    }>
-  >([]);
-  const queuedMessagesRef = useRef(queuedMessages);
-  useEffect(() => {
-    queuedMessagesRef.current = queuedMessages;
-  }, [queuedMessages]);
-
   const [messages, setMessages] = useState<Message[]>([]);
 
   const throttledSetMessages = useMemo(
@@ -220,6 +205,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   const [isCompressing, setIsCompressing] = useState(false);
   const [currentModel, setCurrentModelState] = useState("");
   const [configuredModels, setConfiguredModels] = useState<string[]>([]);
+  const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
 
   // MCP State
   const [mcpServers, setMcpServers] = useState<McpServerStatus[]>([]);
@@ -382,6 +368,12 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         onLoadingChange: (loading) => {
           setIsLoading(loading);
         },
+        onCommandRunningChange: (running) => {
+          setIsCommandRunning(running);
+        },
+        onQueuedMessagesChange: (messages) => {
+          setQueuedMessages([...messages]);
+        },
       };
 
       try {
@@ -503,14 +495,6 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
 
       if (!hasTextContent && !hasImageAttachments) return;
 
-      if (agentRef.current?.isLoading || isCommandRunning) {
-        setQueuedMessages((prev) => [
-          ...prev,
-          { content, images, longTextMap },
-        ]);
-        return;
-      }
-
       try {
         const expandedContent = longTextMap
           ? expandLongTextPlaceholders(content, longTextMap)
@@ -543,7 +527,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         console.error("Failed to send message:", error);
       }
     },
-    [isCommandRunning],
+    [],
   );
 
   const askBtw = useCallback(async (question: string) => {
@@ -553,26 +537,8 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
     return await agentRef.current.askBtw(question);
   }, []);
 
-  // Process queued messages when idle - only trigger on loading/command state changes
-  useEffect(() => {
-    if (
-      !isLoading &&
-      !isCommandRunning &&
-      queuedMessagesRef.current.length > 0
-    ) {
-      const nextMessage = queuedMessagesRef.current[0];
-      setQueuedMessages((prev) => prev.slice(1));
-      sendMessage(
-        nextMessage.content,
-        nextMessage.images,
-        nextMessage.longTextMap,
-      );
-    }
-  }, [isLoading, isCommandRunning, sendMessage]);
-
   // Unified interrupt method, interrupt both AI messages and command execution
   const abortMessage = useCallback(() => {
-    setQueuedMessages([]);
     agentRef.current?.abortMessage();
   }, []);
 

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -1053,45 +1053,24 @@ describe("ChatProvider", () => {
     const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
     const callbacks = agentCreateArgs.callbacks!;
 
-    // Mock sendMessage to not resolve immediately
-    let resolveSendMessage: (value: void | PromiseLike<void>) => void;
-    const sendMessagePromise = new Promise<void>((resolve) => {
-      resolveSendMessage = resolve;
-    });
-    mockAgent.sendMessage.mockReturnValue(sendMessagePromise);
-
-    // Send first message
-    const firstSendMessage = lastValue?.sendMessage("First message");
-
-    // Simulate agent setting isLoading to true (as the SDK does synchronously)
-    mockAgent.isLoading = true;
-    callbacks.onLoadingChange!(true);
-
-    await vi.waitFor(() => {
-      expect(lastValue?.isLoading).toBe(true);
-    });
-
-    // Send second message to queue it
-    lastValue?.sendMessage("Second message");
+    // Simulate the SDK enqueueing a message (agent.sendMessage called while busy)
+    callbacks.onQueuedMessagesChange!([{ content: "Second message" }]);
 
     await vi.waitFor(() => {
       expect(lastValue?.queuedMessages).toHaveLength(1);
       expect(lastValue?.queuedMessages[0].content).toBe("Second message");
     });
 
-    // Call abortMessage
+    // Call abortMessage (SDK clears queue and fires onQueuedMessagesChange)
     lastValue?.abortMessage();
+
+    // Simulate the SDK firing the callback after clearing
+    callbacks.onQueuedMessagesChange!([]);
 
     await vi.waitFor(() => {
       expect(lastValue?.queuedMessages).toHaveLength(0);
       expect(mockAgent.abortMessage).toHaveBeenCalled();
     });
-
-    // Cleanup
-    mockAgent.isLoading = false;
-    callbacks.onLoadingChange!(false);
-    resolveSendMessage!();
-    await firstSendMessage;
   });
 
   it("throttles onMessagesChange updates", async () => {
@@ -1197,7 +1176,7 @@ describe("ChatProvider", () => {
     });
   });
 
-  it("dequeue queued messages one at a time, not concurrently", async () => {
+  it("displays queued messages from SDK via onQueuedMessagesChange callback", async () => {
     let lastValue: ChatContextType | undefined;
     const onHookValue = (val: ChatContextType) => {
       lastValue = val;
@@ -1212,43 +1191,19 @@ describe("ChatProvider", () => {
     const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
     const callbacks = agentCreateArgs.callbacks!;
 
-    // Mock sendMessage to block until we resolve it
-    let resolveFirst: (value: void) => void;
-    const firstSendPromise = new Promise<void>((resolve) => {
-      resolveFirst = resolve;
-    });
-    mockAgent.sendMessage.mockImplementation(async () => {
-      await firstSendPromise;
-    });
-
-    // Send first message
-    lastValue?.sendMessage("msg1");
-
-    // Simulate what the agent SDK does: set isLoading to true FIRST, then fire callback
-    mockAgent.isLoading = true;
-    callbacks.onLoadingChange!(true);
-
-    // Send second message while isLoading is true - should be queued
-    lastValue?.sendMessage("msg2");
+    // Simulate the SDK queueing a message (via onQueuedMessagesChange)
+    callbacks.onQueuedMessagesChange!([{ content: "msg2" }]);
 
     await vi.waitFor(() => {
       expect(lastValue?.queuedMessages).toHaveLength(1);
       expect(lastValue?.queuedMessages[0].content).toBe("msg2");
     });
 
-    // Only the first message should have been sent
-    expect(mockAgent.sendMessage).toHaveBeenCalledTimes(1);
+    // Simulate the SDK dequeuing (message sent, queue emptied)
+    callbacks.onQueuedMessagesChange!([]);
 
-    // Now simulate the first message completing
-    // Agent SDK: set isLoading to false FIRST, then fire callback
-    mockAgent.isLoading = false;
-    callbacks.onLoadingChange!(false);
-    resolveFirst!();
-
-    // The queued message should now dequeue
     await vi.waitFor(() => {
-      expect(mockAgent.sendMessage).toHaveBeenCalledTimes(2);
-      expect(mockAgent.sendMessage).toHaveBeenCalledWith("msg2", undefined);
+      expect(lastValue?.queuedMessages).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
Move queued message management from UI layer (useChat.tsx) to agent-sdk, making the SDK self-contained for message queueing.

## Changes

**agent-sdk (new):**
- Create `MessageQueue` class with enqueue/dequeue/clear operations
- Add enqueue logic to `Agent.sendMessage()` when agent is busy
- Add dequeue logic triggered by loading/command state changes
- Add `onCommandRunningChange` and `onQueuedMessagesChange` callbacks
- Wire queue clearing into `Agent.abortMessage()`
- Add `onLoadingChange` callback to `AIManager`
- Add `onCommandRunningChange` callback to `BangManager`

**code (UI layer):**
- Remove local queue state, enqueue logic, and dequeue `useEffect` from `useChat.tsx`
- Read queue state from agent via `onQueuedMessagesChange` callback
- Use `onCommandRunningChange` callback for command state tracking

**Tests:**
- Update tests to work with SDK-level queue callbacks

## Benefits
- Queue logic lives where agent state lives (SDK)
- Other consumers can benefit from the same behavior
- Cleaner separation of concerns