### PR TITLE
fix(sdk): remove isLoading guard and set early for slash commands

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -355,11 +355,6 @@ export class AIManager {
   ): Promise<void> {
     const { recursionDepth = 0, model, allowedRules, maxTokens } = options;
 
-    // Only check isLoading for the initial call (recursionDepth === 0)
-    if (recursionDepth === 0 && this.isLoading) {
-      return;
-    }
-
     // Set loading state early for the initial call, before any async work
     if (recursionDepth === 0) {
       this.setIsLoading(true);

--- a/packages/agent-sdk/src/managers/slashCommandManager.ts
+++ b/packages/agent-sdk/src/managers/slashCommandManager.ts
@@ -286,6 +286,7 @@ export class SlashCommandManager {
             }
 
             // Non-forked skill: execute and trigger AI response
+            this.aiManager.setIsLoading(true);
             const result = await this.skillManager.executeSkill({
               skill_name: skill.name,
               args,
@@ -303,10 +304,9 @@ export class SlashCommandManager {
               allowedRules: result.allowedTools,
             });
           } catch (error) {
-            logger?.error(
-              `Failed to execute skill command '${skill.name}':`,
-              error,
-            );
+            this.aiManager.setIsLoading(false);
+
+            logger?.error(error);
             this.messageManager.addErrorBlock(
               `Failed to execute skill command '${skill.name}': ${
                 error instanceof Error ? error.message : String(error)

--- a/packages/agent-sdk/src/managers/slashCommandManager.ts
+++ b/packages/agent-sdk/src/managers/slashCommandManager.ts
@@ -266,13 +266,6 @@ export class SlashCommandManager {
                     success: true,
                   });
 
-                  // Set isLoading to false before triggering AI response, because:
-                  // 1. The subagent has its own isolated isLoading state (not linked to parent)
-                  // 2. The parent's isLoading is still true from line above
-                  // 3. sendAIMessage() has an early return if isLoading is true (aiManager.ts:358-360)
-                  // 4. Without this, sendAIMessage() would return immediately without executing
-                  this.aiManager.setIsLoading(false);
-
                   // Trigger AI to process the tool result
                   await this.aiManager.sendAIMessage();
                 } finally {
@@ -504,6 +497,9 @@ export class SlashCommandManager {
     args?: string,
   ): Promise<void> {
     try {
+      // Set loading early so UI shows feedback during bash execution
+      this.aiManager.setIsLoading(true);
+
       // Parse bash commands from the content
       const { commands, processedContent } = parseBashCommands(content);
 
@@ -533,6 +529,8 @@ export class SlashCommandManager {
         allowedRules: config?.allowedTools,
       });
     } catch (error) {
+      this.aiManager.setIsLoading(false);
+
       logger?.error(
         `Failed to execute custom command '${commandName}':`,
         error,

--- a/packages/agent-sdk/src/services/interactionService.ts
+++ b/packages/agent-sdk/src/services/interactionService.ts
@@ -50,9 +50,9 @@ export class InteractionService {
 
         if (isValid && commandId !== undefined) {
           // Execute valid slash command
-          // Note: executeCommand and its handlers (e.g., skill commands) manage
-          // isLoading internally. Setting it here would cause sendAIMessage() to
-          // return early due to the isLoading guard at aiManager.ts:357.
+          // Note: executeCommand sets isLoading early (e.g., custom commands set it
+          // before bash execution). sendAIMessage() no longer guards against isLoading,
+          // so callers can safely set it early without blocking subsequent AI calls.
           await slashCommandManager.executeCommand(commandId, args);
 
           return;

--- a/packages/agent-sdk/tests/builtin-skills/loop/execution.test.ts
+++ b/packages/agent-sdk/tests/builtin-skills/loop/execution.test.ts
@@ -24,6 +24,7 @@ describe("/loop execution integration", () => {
 
     aiManager = {
       sendAIMessage: vi.fn().mockResolvedValue(undefined),
+      setIsLoading: vi.fn(),
       abortAIMessage: vi.fn(),
     } as unknown as AIManager;
 

--- a/packages/agent-sdk/tests/managers/aiManager.coverage.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.coverage.test.ts
@@ -135,14 +135,15 @@ describe("AIManager - Coverage", () => {
     vi.clearAllMocks();
   });
 
-  it("should early return when isLoading at depth 0", async () => {
+  it("should not early return when isLoading at depth 0", async () => {
     const aiManager = new AIManager(makeContainer(), {
       workdir: "/test",
       stream: false,
     });
     (aiManager as unknown as { isLoading: boolean }).isLoading = true;
     await aiManager.sendAIMessage();
-    expect(aiService.callAgent).not.toHaveBeenCalled();
+    // sendAIMessage no longer guards against isLoading - it proceeds regardless
+    expect(aiService.callAgent).toHaveBeenCalled();
   });
 
   it("should handle reversionManager with snapshots", async () => {
@@ -328,14 +329,12 @@ describe("AIManager - Coverage", () => {
 
   it("should handle user message with file mention", async () => {
     const mm = mockMsgManager({
-      getMessages: vi
-        .fn()
-        .mockReturnValue([
-          {
-            role: "user",
-            blocks: [{ type: "text", content: "@src/index.ts" }],
-          },
-        ]),
+      getMessages: vi.fn().mockReturnValue([
+        {
+          role: "user",
+          blocks: [{ type: "text", content: "@src/index.ts" }],
+        },
+      ]),
     });
     const aiManager = new AIManager(makeContainer({ MessageManager: mm }), {
       workdir: "/test",

--- a/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
+++ b/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
@@ -795,35 +795,12 @@ describe("SlashCommandManager", () => {
       const cmd = slashCommandManager.getCommand("fork-skill");
       await cmd?.handler();
 
-      // Verify setIsLoading is called with both true and false
+      // Verify setIsLoading was called with true
       const setIsLoadingCalls = vi.mocked(aiManager.setIsLoading).mock.calls;
       expect(setIsLoadingCalls).toContainEqual([true]);
-      expect(setIsLoadingCalls).toContainEqual([false]);
 
-      // Verify sendAIMessage was called (proves the early return guard was not hit)
+      // Verify sendAIMessage was called (no early return due to isLoading guard)
       expect(aiManager.sendAIMessage).toHaveBeenCalled();
-
-      // Verify setIsLoading(false) was called before sendAIMessage
-      // by checking mock invocation order
-      const setIsLoadingMock = aiManager.setIsLoading as ReturnType<
-        typeof vi.fn
-      >;
-      const sendAIMessageMock = aiManager.sendAIMessage as ReturnType<
-        typeof vi.fn
-      >;
-
-      // Find the order of setIsLoading(false) call
-      const setIsLoadingFalseOrder =
-        setIsLoadingMock.mock.invocationCallOrder.find(
-          (order, i) => setIsLoadingCalls[i]?.[0] === false,
-        );
-
-      // Find the order of sendAIMessage call
-      const sendAIMessageOrder = sendAIMessageMock.mock.invocationCallOrder[0];
-
-      expect(setIsLoadingFalseOrder).toBeDefined();
-      expect(sendAIMessageOrder).toBeDefined();
-      expect(setIsLoadingFalseOrder!).toBeLessThan(sendAIMessageOrder!);
     });
   });
 });

--- a/packages/agent-sdk/tests/managers/slashCommandManager_model.test.ts
+++ b/packages/agent-sdk/tests/managers/slashCommandManager_model.test.ts
@@ -20,6 +20,7 @@ describe("SlashCommandManager model override", () => {
 
     aiManager = {
       sendAIMessage: vi.fn(),
+      setIsLoading: vi.fn(),
       abortAIMessage: vi.fn(),
     } as unknown as AIManager;
 


### PR DESCRIPTION
## Summary

- Remove the early-return guard in `sendAIMessage()` that bailed out when `isLoading === true`, allowing callers to set loading state early without blocking subsequent AI calls.
- Set `isLoading(true)` before bash execution in custom slash commands so the UI shows loading feedback immediately.
- Set `isLoading(true)` before non-forked skill execution for the same reason.
- Add `isLoading(false)` in catch blocks for both paths to ensure loading is cleared on error.

### Files changed
- `packages/agent-sdk/src/managers/aiManager.ts`
- `packages/agent-sdk/src/managers/slashCommandManager.ts`
- `packages/agent-sdk/src/services/interactionService.ts`
- Test files updated accordingly