### PR TITLE
feat: inject WAVE_PLUGIN_ROOT env var for plugin hooks, MCP, and LSP servers

### DIFF
--- a/packages/agent-sdk/src/managers/hookManager.ts
+++ b/packages/agent-sdk/src/managers/hookManager.ts
@@ -166,9 +166,20 @@ export class HookManager {
             ? { timeout: hookCommand.timeout * 1000 }
             : undefined;
 
+          // Build execution context with WAVE_PLUGIN_ROOT if this is a plugin hook
+          const execContext: typeof context = hookCommand.pluginRoot
+            ? {
+                ...context,
+                env: {
+                  ...("env" in context ? (context.env ?? {}) : {}),
+                  WAVE_PLUGIN_ROOT: hookCommand.pluginRoot,
+                },
+              }
+            : context;
+
           if (hookCommand.async) {
             // Execute async command without awaiting
-            executeCommand(hookCommand.command, context, options).catch(
+            executeCommand(hookCommand.command, execContext, options).catch(
               (error) => {
                 const errorMessage =
                   error instanceof Error
@@ -185,7 +196,7 @@ export class HookManager {
 
           const result = await executeCommand(
             hookCommand.command,
-            context,
+            execContext,
             options,
           );
           results.push(result);
@@ -810,11 +821,24 @@ export class HookManager {
   /**
    * Register hooks provided by a plugin
    */
-  registerPluginHooks(hooks: PartialHookConfiguration): void {
+  registerPluginHooks(
+    pluginRoot: string,
+    hooks: PartialHookConfiguration,
+  ): void {
     if (!this.configuration) {
       this.configuration = {};
     }
 
-    this.mergeHooksConfiguration(this.configuration, hooks);
+    // Stamp pluginRoot on each hook command
+    const stampedHooks: PartialHookConfiguration = {};
+    for (const [event, configs] of Object.entries(hooks)) {
+      if (!isValidHookEvent(event)) continue;
+      stampedHooks[event] = configs.map((config) => ({
+        ...config,
+        hooks: config.hooks.map((cmd) => ({ ...cmd, pluginRoot })),
+      }));
+    }
+
+    this.mergeHooksConfiguration(this.configuration, stampedHooks);
   }
 }

--- a/packages/agent-sdk/src/managers/lspManager.ts
+++ b/packages/agent-sdk/src/managers/lspManager.ts
@@ -90,9 +90,13 @@ export class LspManager implements ILspManager {
     );
 
     try {
+      const env = { ...process.env, ...config.env };
+      if (config.pluginRoot) {
+        env.WAVE_PLUGIN_ROOT = config.pluginRoot;
+      }
       const proc = spawn(config.command, config.args || [], {
         cwd: config.workspaceFolder || this.workdir,
-        env: { ...process.env, ...config.env },
+        env,
         stdio: ["pipe", "pipe", "pipe"],
       });
 

--- a/packages/agent-sdk/src/managers/mcpManager.ts
+++ b/packages/agent-sdk/src/managers/mcpManager.ts
@@ -348,13 +348,17 @@ export class McpManager {
           logger?.info(`Connected to MCP server ${name} using SSE (fallback)`);
         }
       } else if (server.config.command) {
+        const env: Record<string, string> = {
+          ...(process.env as Record<string, string>),
+          ...(server.config.env || {}),
+        };
+        if (server.config.pluginRoot) {
+          env.WAVE_PLUGIN_ROOT = server.config.pluginRoot;
+        }
         transport = new StdioClientTransport({
           command: server.config.command,
           args: server.config.args || [],
-          env: {
-            ...(process.env as Record<string, string>),
-            ...(server.config.env || {}),
-          },
+          env,
           cwd: this.workdir, // Use the agent's workdir as the process working directory
           stderr: "pipe", // Pipe stderr to capture it
         });

--- a/packages/agent-sdk/src/managers/pluginManager.ts
+++ b/packages/agent-sdk/src/managers/pluginManager.ts
@@ -171,7 +171,8 @@ export class PluginManager {
 
       if (this.lspManager && plugin.lspConfig) {
         for (const [language, config] of Object.entries(plugin.lspConfig)) {
-          this.lspManager.registerServer(language, config);
+          const configWithPluginRoot = { ...config, pluginRoot: plugin.path };
+          this.lspManager.registerServer(language, configWithPluginRoot);
         }
       }
 
@@ -179,12 +180,13 @@ export class PluginManager {
         for (const [name, config] of Object.entries(
           plugin.mcpConfig.mcpServers,
         )) {
-          this.mcpManager.addServer(name, config);
+          const configWithPluginRoot = { ...config, pluginRoot: plugin.path };
+          this.mcpManager.addServer(name, configWithPluginRoot);
         }
       }
 
       if (this.hookManager && plugin.hooksConfig) {
-        this.hookManager.registerPluginHooks(plugin.hooksConfig);
+        this.hookManager.registerPluginHooks(plugin.path, plugin.hooksConfig);
       }
 
       this.plugins.set(manifest.name, plugin);

--- a/packages/agent-sdk/src/managers/skillManager.ts
+++ b/packages/agent-sdk/src/managers/skillManager.ts
@@ -443,6 +443,14 @@ export class SkillManager extends EventEmitter {
     // 2. Substitute ${WAVE_SKILL_DIR} with the skill's directory path
     mainContent = mainContent.replace(/\$\{WAVE_SKILL_DIR\}/g, skill.skillPath);
 
+    // 3. Substitute ${WAVE_PLUGIN_ROOT} with the skill's plugin root path
+    if (skill.pluginRoot) {
+      mainContent = mainContent.replace(
+        /\$\{WAVE_PLUGIN_ROOT\}/g,
+        skill.pluginRoot,
+      );
+    }
+
     return header + description + skillPath + mainContent;
   }
 
@@ -493,6 +501,7 @@ export class SkillManager extends EventEmitter {
         disableModelInvocation: skill.disableModelInvocation,
         userInvocable: skill.userInvocable,
         pluginName,
+        pluginRoot: skill.pluginRoot,
       };
       // Update the skill object itself to have the namespaced name
       skill.name = namespacedName;

--- a/packages/agent-sdk/src/services/pluginLoader.ts
+++ b/packages/agent-sdk/src/services/pluginLoader.ts
@@ -95,6 +95,7 @@ export class PluginLoader {
               skills.push({
                 ...parsed.skillMetadata,
                 type: "project", // Plugin skills are treated as project skills
+                pluginRoot: pluginPath,
                 content: parsed.content,
                 frontmatter: parsed.frontmatter,
                 isValid: parsed.isValid,

--- a/packages/agent-sdk/src/types/hooks.ts
+++ b/packages/agent-sdk/src/types/hooks.ts
@@ -29,6 +29,7 @@ export interface HookCommand {
   command: string;
   async?: boolean;
   timeout?: number; // seconds
+  pluginRoot?: string; // Plugin directory path for plugin-originated hooks
 }
 
 // Hook event configuration with optional pattern matching
@@ -127,6 +128,10 @@ export function isValidHookCommand(cmd: unknown): cmd is HookCommand {
   }
 
   if ("timeout" in hookCmd && typeof hookCmd.timeout !== "number") {
+    return false;
+  }
+
+  if ("pluginRoot" in hookCmd && typeof hookCmd.pluginRoot !== "string") {
     return false;
   }
 

--- a/packages/agent-sdk/src/types/lsp.ts
+++ b/packages/agent-sdk/src/types/lsp.ts
@@ -15,6 +15,8 @@ export interface LspServerConfig {
   shutdownTimeout?: number;
   restartOnCrash?: boolean;
   maxRestarts?: number;
+  /** Internal: plugin directory path when the server is registered by a plugin */
+  pluginRoot?: string;
 }
 
 export interface LspConfig {

--- a/packages/agent-sdk/src/types/mcp.ts
+++ b/packages/agent-sdk/src/types/mcp.ts
@@ -9,6 +9,8 @@ export interface McpServerConfig {
   env?: Record<string, string>;
   url?: string;
   headers?: Record<string, string>;
+  /** Internal: plugin directory path when the server is registered by a plugin */
+  pluginRoot?: string;
 }
 
 export interface McpConfig {

--- a/packages/agent-sdk/src/types/skills.ts
+++ b/packages/agent-sdk/src/types/skills.ts
@@ -15,6 +15,7 @@ export interface SkillMetadata {
   disableModelInvocation?: boolean;
   userInvocable?: boolean;
   pluginName?: string;
+  pluginRoot?: string;
 }
 
 export interface Skill extends SkillMetadata {

--- a/packages/agent-sdk/tests/managers/hookManager.coverage.test.ts
+++ b/packages/agent-sdk/tests/managers/hookManager.coverage.test.ts
@@ -503,7 +503,7 @@ describe("HookManager Coverage", () => {
 
   describe("registerPluginHooks", () => {
     it("should initialize configuration if it doesn't exist", () => {
-      manager.registerPluginHooks({
+      manager.registerPluginHooks("/test/plugin", {
         UserPromptSubmit: [
           {
             hooks: [{ type: "command" as const, command: "echo plugin-hook" }],
@@ -511,6 +511,47 @@ describe("HookManager Coverage", () => {
         ],
       });
       expect(manager.getConfiguration()?.UserPromptSubmit).toHaveLength(1);
+    });
+
+    it("should stamp pluginRoot on hook commands", () => {
+      manager.registerPluginHooks("/my/plugin/root", {
+        PreToolUse: [
+          {
+            hooks: [{ type: "command" as const, command: "echo test" }],
+          },
+        ],
+      });
+      const config = manager.getConfiguration();
+      const hook = config?.PreToolUse?.[0]?.hooks?.[0];
+      expect(hook?.pluginRoot).toBe("/my/plugin/root");
+    });
+
+    it("should pass WAVE_PLUGIN_ROOT in env to executeCommand for plugin hooks", async () => {
+      manager.registerPluginHooks("/my/plugin/root", {
+        UserPromptSubmit: [
+          {
+            hooks: [{ type: "command" as const, command: "echo plugin" }],
+          },
+        ],
+      });
+
+      const context = {
+        event: "UserPromptSubmit" as const,
+        projectDir: "/test/workdir",
+        timestamp: new Date(),
+      };
+
+      await manager.executeHooks("UserPromptSubmit", context);
+
+      expect(mockExecuteCommand).toHaveBeenCalledWith(
+        "echo plugin",
+        expect.objectContaining({
+          env: expect.objectContaining({
+            WAVE_PLUGIN_ROOT: "/my/plugin/root",
+          }),
+        }),
+        undefined,
+      );
     });
   });
 

--- a/packages/agent-sdk/tests/managers/lspManager.test.ts
+++ b/packages/agent-sdk/tests/managers/lspManager.test.ts
@@ -400,4 +400,29 @@ describe("LspManager (Mocked)", () => {
     expect(result.success).toBe(true);
     expect(JSON.parse(result.content)).toEqual({ uri: "file://test" });
   });
+
+  it("should inject WAVE_PLUGIN_ROOT into env for plugin-owned LSP servers", async () => {
+    const { stdin, stdout } = setupMockProcess();
+    respondToInitialize(stdin, stdout);
+
+    lspManager.registerServer("typescript", {
+      command: "typescript-language-server",
+      args: ["--stdio"],
+      extensionToLanguage: { ".ts": "typescript" },
+      pluginRoot: "/path/to/plugin",
+      shutdownTimeout: 1,
+    });
+
+    await lspManager.getProcessForFile("/mock/workdir/test.ts");
+
+    expect(spawn).toHaveBeenCalledWith(
+      "typescript-language-server",
+      ["--stdio"],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          WAVE_PLUGIN_ROOT: "/path/to/plugin",
+        }),
+      }),
+    );
+  });
 });

--- a/packages/agent-sdk/tests/managers/mcpManager.test.ts
+++ b/packages/agent-sdk/tests/managers/mcpManager.test.ts
@@ -417,6 +417,34 @@ describe("McpManager", () => {
 
       expect(result).toBe(false);
     });
+
+    it("should inject WAVE_PLUGIN_ROOT into env for plugin-owned stdio servers", async () => {
+      const pluginConfig = {
+        mcpServers: {
+          "plugin-server": {
+            command: "npx",
+            args: ["plugin-mcp"],
+            pluginRoot: "/path/to/plugin",
+          },
+        },
+      };
+      const { promises: fs } = await import("fs");
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(pluginConfig));
+      await mcpManager.loadConfig();
+
+      await mcpManager.connectServer("plugin-server");
+
+      expect(StdioClientTransport).toHaveBeenCalledWith({
+        command: "npx",
+        args: ["plugin-mcp"],
+        env: {
+          ...process.env,
+          WAVE_PLUGIN_ROOT: "/path/to/plugin",
+        },
+        cwd: "/test/workdir",
+        stderr: "pipe",
+      });
+    });
   });
 
   describe("disconnectServer", () => {

--- a/packages/agent-sdk/tests/managers/pluginManager.test.ts
+++ b/packages/agent-sdk/tests/managers/pluginManager.test.ts
@@ -149,15 +149,16 @@ describe("PluginManager", () => {
         "test-plugin",
         skills,
       );
-      expect(mockLspManager.registerServer).toHaveBeenCalledWith(
-        "go",
-        lspConfig.go,
-      );
-      expect(mockMcpManager.addServer).toHaveBeenCalledWith(
-        "test",
-        mcpConfig.mcpServers.test,
-      );
+      expect(mockLspManager.registerServer).toHaveBeenCalledWith("go", {
+        ...lspConfig.go,
+        pluginRoot: "/test/workdir/plugins/test-plugin",
+      });
+      expect(mockMcpManager.addServer).toHaveBeenCalledWith("test", {
+        ...mcpConfig.mcpServers.test,
+        pluginRoot: "/test/workdir/plugins/test-plugin",
+      });
       expect(mockHookManager.registerPluginHooks).toHaveBeenCalledWith(
+        "/test/workdir/plugins/test-plugin",
         hooksConfig,
       );
 

--- a/packages/agent-sdk/tests/managers/skillManager.test.ts
+++ b/packages/agent-sdk/tests/managers/skillManager.test.ts
@@ -367,6 +367,30 @@ describe("SkillManager", () => {
       expect(metadata?.pluginName).toBe("test-plugin");
     });
 
+    it("should preserve pluginRoot from plugin skills", async () => {
+      vi.mocked(readdir).mockResolvedValue([]);
+      await skillManager.initialize();
+
+      const pluginSkill: Skill = {
+        name: "plugin-skill",
+        description: "from plugin",
+        type: "personal",
+        skillPath: "/plugin/root/skills/my-skill",
+        pluginRoot: "/plugin/root",
+        content: "content",
+        frontmatter: { name: "plugin-skill", description: "from plugin" },
+        isValid: true,
+        errors: [],
+      };
+
+      skillManager.registerPluginSkills("test-plugin", [pluginSkill]);
+
+      const metadata = skillManager.getSkillMetadata(
+        "test-plugin:plugin-skill",
+      );
+      expect(metadata?.pluginRoot).toBe("/plugin/root");
+    });
+
     it("should namespace skill names from plugins", async () => {
       // Initialize first
       vi.mocked(readdir).mockResolvedValue([]);
@@ -550,6 +574,31 @@ describe("SkillManager", () => {
       });
 
       expect(result.content).toContain("Skill is at /path/to/skill");
+    });
+
+    it("should substitute ${WAVE_PLUGIN_ROOT} with the skill's plugin root path", async () => {
+      const mockSkill: Skill = {
+        name: "plugin-skill",
+        description: "A plugin skill",
+        type: "personal",
+        skillPath: "/plugin/root/skills/plugin-skill",
+        pluginRoot: "/plugin/root",
+        content:
+          "---\nname: plugin-skill\ndescription: A plugin skill\n---\n\nPlugin root is ${WAVE_PLUGIN_ROOT}",
+        frontmatter: { name: "plugin-skill", description: "A plugin skill" },
+        isValid: true,
+        errors: [],
+      };
+
+      vi.mocked(readdir).mockResolvedValue([]);
+      await skillManager.initialize();
+      skillManager.registerPluginSkills("test-plugin", [mockSkill]);
+
+      const result = await skillManager.executeSkill({
+        skill_name: "test-plugin:plugin-skill",
+      });
+
+      expect(result.content).toContain("Plugin root is /plugin/root");
     });
   });
 

--- a/packages/agent-sdk/tests/services/pluginLoader.test.ts
+++ b/packages/agent-sdk/tests/services/pluginLoader.test.ts
@@ -222,6 +222,31 @@ describe("PluginLoader", () => {
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe("skill1");
       expect(result[0].type).toBe("project");
+      expect(result[0].pluginRoot).toBe(mockPluginPath);
+    });
+
+    it("should set pluginRoot on loaded skills", async () => {
+      vi.mocked(fs.readdir).mockResolvedValue([
+        { name: "skill1", isDirectory: () => true },
+      ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+      vi.mocked(fs.stat).mockResolvedValue(
+        {} as unknown as Awaited<ReturnType<typeof fs.stat>>,
+      );
+      vi.mocked(parseSkillFile).mockReturnValue({
+        isValid: true,
+        skillMetadata: {
+          name: "skill1",
+          description: "Skill 1",
+          skillPath: "/my/plugin/skills/skill1",
+        },
+        content: "content",
+        frontmatter: { name: "skill1", description: "Skill 1" },
+        validationErrors: [],
+      } as unknown as ReturnType<typeof parseSkillFile>);
+
+      const result = await PluginLoader.loadSkills("/my/plugin");
+
+      expect(result[0].pluginRoot).toBe("/my/plugin");
     });
 
     it("should return empty array if skills directory does not exist", async () => {


### PR DESCRIPTION
Add WAVE_PLUGIN_ROOT support so plugin skills, hooks, MCP servers, and LSP servers can reference their parent plugin's directory.

## Changes

- Add `pluginRoot` field to `SkillMetadata`, `HookCommand`, `LspServerConfig`, `McpServerConfig`
- Set `pluginRoot` when loading plugin skills in `pluginLoader`
- Substitute `${WAVE_PLUGIN_ROOT}` in skill content (same pattern as `${WAVE_SKILL_DIR}`)
- Preserve `pluginRoot` when registering plugin skills
- Inject `WAVE_PLUGIN_ROOT` env var for plugin-originated hook commands
- Inject `WAVE_PLUGIN_ROOT` env var for plugin-owned MCP servers (`StdioClientTransport`)
- Inject `WAVE_PLUGIN_ROOT` env var for plugin-owned LSP servers (`spawn`)
- Add 7 tests covering all injection points

## Verification

- All 2218 tests pass
- Type checking passes for both packages