### PR TITLE
feat: enable bang command enqueue support

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -332,7 +332,7 @@ export class Agent {
 
   /**
    * Process the next queued message when the agent becomes idle.
-   * Dequeues the next message and sends it.
+   * Dequeues the next message and handles it based on type.
    */
   private async processQueuedMessage(): Promise<void> {
     const next = this.messageQueue.dequeue();
@@ -340,7 +340,12 @@ export class Agent {
 
     this.options.callbacks?.onQueuedMessagesChange?.(this.queuedMessages);
 
-    await this.sendMessage(next.content, next.images);
+    if (next.type === "bang") {
+      await this.bangManager?.executeCommand(next.content);
+      await this.messageManager.saveSession();
+    } else {
+      await this.sendMessage(next.content, next.images);
+    }
   }
 
   /** Get background bash shell output */
@@ -542,6 +547,13 @@ export class Agent {
 
   /** Execute bash command (bang command) */
   public async bang(command: string): Promise<void> {
+    // If the agent is busy, enqueue the bang command
+    if (this.aiManager.isLoading || this.isCommandRunning) {
+      this.messageQueue.enqueue({ type: "bang", content: command });
+      this.options.callbacks?.onQueuedMessagesChange?.(this.queuedMessages);
+      return;
+    }
+
     await this.bangManager?.executeCommand(command);
     await this.messageManager.saveSession();
   }

--- a/packages/agent-sdk/src/managers/messageQueue.ts
+++ b/packages/agent-sdk/src/managers/messageQueue.ts
@@ -1,4 +1,5 @@
 export interface QueuedMessage {
+  type?: "message" | "bang";
   content: string;
   images?: Array<{ path: string; mimeType: string }>;
   longTextMap?: Record<string, string>;

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -508,12 +508,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         ) {
           const command = expandedContent.substring(1).trim();
           if (command) {
-            setIsCommandRunning(true);
-            try {
-              await agentRef.current?.bang(command);
-            } finally {
-              setIsCommandRunning(false);
-            }
+            await agentRef.current?.bang(command);
             return;
           }
         }


### PR DESCRIPTION
- Add optional 'type' field to QueuedMessage interface ('message' | 'bang')
- Modify bang() to enqueue when agent is busy (loading or command running)
- Update processQueuedMessage() to handle both bang and message types
- Simplify UI bang handler by removing manual setIsCommandRunning wrapper
