### PR TITLE
fix: resolve workdir from DI container to keep permissions in sync

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -221,6 +221,7 @@ export class Agent {
     // Wire up CWD change callback from AIManager to sync Agent's workdir
     this.aiManager.setOnCwdChange((newCwd) => {
       this.workdir = newCwd;
+      this.container.register("Workdir", newCwd);
       this.options.callbacks?.onWorkdirChange?.(newCwd);
     });
 
@@ -292,6 +293,7 @@ export class Agent {
    */
   public setWorkdir(newCwd: string): void {
     this.workdir = newCwd;
+    this.container.register("Workdir", newCwd);
     this.options.callbacks?.onWorkdirChange?.(newCwd);
   }
 

--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -113,8 +113,6 @@ export interface PermissionManagerOptions {
   additionalDirectories?: string[];
   /** System additional directories (persistent across reloads) */
   systemAdditionalDirectories?: string[];
-  /** The main working directory */
-  workdir?: string;
   /** Path to the current plan file */
   planFilePath?: string;
   /** Optional logger */
@@ -130,7 +128,6 @@ export class PermissionManager {
   private temporaryRules: string[] = [];
   private additionalDirectories: string[] = [];
   private systemAdditionalDirectories: string[] = [];
-  private workdir?: string;
   private planFilePath?: string;
   private worktreeName?: string;
   private mainRepoRoot?: string;
@@ -146,7 +143,6 @@ export class PermissionManager {
     this.deniedRules = options.deniedRules || [];
     this.instanceAllowedRules = options.instanceAllowedRules || [];
     this.instanceDeniedRules = options.instanceDeniedRules || [];
-    this.workdir = options.workdir;
     this.planFilePath = options.planFilePath;
     this._logger = options.logger;
     this.updateAdditionalDirectories(options.additionalDirectories || []);
@@ -156,6 +152,13 @@ export class PermissionManager {
 
     this.worktreeName = this.container.get<string>("WorktreeName");
     this.mainRepoRoot = this.container.get<string>("MainRepoRoot");
+  }
+
+  /**
+   * Resolve the working directory from the DI container
+   */
+  private getWorkdir(): string | undefined {
+    return this.container.get<string>("Workdir");
   }
 
   /**
@@ -272,9 +275,10 @@ export class PermissionManager {
    * Update the additional directories (e.g., when configuration reloads)
    */
   updateAdditionalDirectories(directories: string[]): void {
+    const workdir = this.getWorkdir();
     this.additionalDirectories = directories.map((dir) => {
-      if (this.workdir && !path.isAbsolute(dir)) {
-        return path.resolve(this.workdir, dir);
+      if (workdir && !path.isAbsolute(dir)) {
+        return path.resolve(workdir, dir);
       }
       return path.resolve(dir);
     });
@@ -284,21 +288,15 @@ export class PermissionManager {
    * Add a system-level additional directory that is persistent across configuration reloads
    */
   public addSystemAdditionalDirectory(directory: string): void {
+    const workdir = this.getWorkdir();
     const resolvedPath =
-      this.workdir && !path.isAbsolute(directory)
-        ? path.resolve(this.workdir, directory)
+      workdir && !path.isAbsolute(directory)
+        ? path.resolve(workdir, directory)
         : path.resolve(directory);
 
     if (!this.systemAdditionalDirectories.includes(resolvedPath)) {
       this.systemAdditionalDirectories.push(resolvedPath);
     }
-  }
-
-  /**
-   * Update the working directory
-   */
-  updateWorkdir(workdir: string): void {
-    this.workdir = workdir;
   }
 
   /**
@@ -322,7 +320,7 @@ export class PermissionManager {
     targetPath: string,
     workdir?: string,
   ): { isInside: boolean; resolvedPath: string } {
-    const effectiveWorkdir = workdir || this.workdir;
+    const effectiveWorkdir = workdir || this.getWorkdir();
 
     // Resolve the target path relative to effectiveWorkdir if it's not absolute
     const absolutePath =
@@ -432,21 +430,25 @@ export class PermissionManager {
     }
 
     // 0. Check worktree safety for Write and Edit tools
+    const currentWorkdir = this.getWorkdir();
     if (
       this.worktreeName &&
       this.mainRepoRoot &&
-      this.workdir &&
+      currentWorkdir &&
       (context.toolName === WRITE_TOOL_NAME ||
         context.toolName === EDIT_TOOL_NAME)
     ) {
       const targetPath = context.toolInput?.file_path as string | undefined;
       if (targetPath) {
-        const absoluteTargetPath = path.resolve(this.workdir, targetPath);
+        const absoluteTargetPath = path.resolve(currentWorkdir, targetPath);
         const isInsideMainRepo = isPathInside(
           absoluteTargetPath,
           this.mainRepoRoot,
         );
-        const isInsideWorktree = isPathInside(absoluteTargetPath, this.workdir);
+        const isInsideWorktree = isPathInside(
+          absoluteTargetPath,
+          currentWorkdir,
+        );
 
         // If it's inside the main repo but NOT inside the current worktree
         if (isInsideMainRepo && !isInsideWorktree) {
@@ -455,11 +457,11 @@ export class PermissionManager {
             targetPath,
             worktreeName: this.worktreeName,
             mainRepoRoot: this.mainRepoRoot,
-            workdir: this.workdir,
+            workdir: currentWorkdir,
           });
           return {
             behavior: "deny",
-            message: `Access denied: You are currently in a worktree session ("${this.worktreeName}"). Modifying files in the main repository (outside the worktree) is not allowed. Please only modify files within the worktree directory: ${this.workdir}`,
+            message: `Access denied: You are currently in a worktree session ("${this.worktreeName}"). Modifying files in the main repository (outside the worktree) is not allowed. Please only modify files within the worktree directory: ${currentWorkdir}`,
           };
         }
       }
@@ -808,12 +810,13 @@ export class PermissionManager {
         }
 
         // If direct match fails, try matching relative path if targetPath is absolute and pattern is relative
+        const currentWorkdir = this.getWorkdir();
         if (
           path.isAbsolute(targetPath) &&
           !path.isAbsolute(pattern) &&
-          this.workdir
+          currentWorkdir
         ) {
-          const relativePath = path.relative(this.workdir, targetPath);
+          const relativePath = path.relative(currentWorkdir, targetPath);
           // Ensure the path is not outside the workdir (doesn't start with ..)
           if (
             !relativePath.startsWith("..") &&
@@ -1056,7 +1059,8 @@ export class PermissionManager {
    * @param rule - The rule to add (e.g., "Bash(ls)")
    */
   public async addPermissionRule(rule: string): Promise<void> {
-    if (!this.workdir) {
+    const workdir = this.getWorkdir();
+    if (!workdir) {
       throw new Error("Working directory not set in PermissionManager");
     }
 
@@ -1065,7 +1069,7 @@ export class PermissionManager {
     const bashMatch = rule.match(/^Bash\((.*)\)$/);
     if (bashMatch) {
       const command = bashMatch[1];
-      rulesToAdd = this.expandBashRule(command, this.workdir);
+      rulesToAdd = this.expandBashRule(command, workdir);
     }
 
     const configurationService = this.container.get<ConfigurationService>(
@@ -1085,7 +1089,7 @@ export class PermissionManager {
         // 3. Persist to settings.local.json
         try {
           if (configurationService) {
-            await configurationService.addAllowedRule(this.workdir, ruleToAdd);
+            await configurationService.addAllowedRule(workdir, ruleToAdd);
             this._logger?.debug("Persistent permission rule added", {
               rule: ruleToAdd,
             });

--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -243,7 +243,6 @@ export class SubagentManager {
     const parentPermissionManager =
       this.container.get<PermissionManager>("PermissionManager");
     const subagentPermissionManager = new PermissionManager(subagentContainer, {
-      workdir: this.workdir,
       configuredPermissionMode:
         parameters.permissionModeOverride ??
         parentPermissionManager?.getConfiguredPermissionMode(),

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -77,6 +77,7 @@ export function setupAgentContainer(
   const callbacks = options.callbacks || {};
   const container = new Container();
   container.register("AgentOptions", options);
+  container.register("Workdir", workdir);
 
   const notificationQueue = new NotificationQueue();
   container.register("NotificationQueue", notificationQueue);
@@ -151,7 +152,6 @@ export function setupAgentContainer(
   container.register("LspManager", lspManager);
 
   const permissionManager = new PermissionManager(container, {
-    workdir,
     instanceAllowedRules: options.allowedTools,
     instanceDeniedRules: options.disallowedTools,
   });

--- a/packages/agent-sdk/tests/integration/subagentPermission.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/subagentPermission.integration.test.ts
@@ -45,6 +45,8 @@ describe("Subagent Permission Integration", () => {
       resolveLanguage: () => undefined,
     });
 
+    container.register("Workdir", "/tmp/test");
+
     subagentManager = new SubagentManager(container, {
       workdir: "/tmp/test",
       stream: false,
@@ -101,9 +103,7 @@ describe("Subagent Permission Integration", () => {
   });
 
   it("should verify that subagent's PermissionManager is isolated from parent", async () => {
-    const parentPermissionManager = new PermissionManager(container, {
-      workdir: "/tmp/test",
-    });
+    const parentPermissionManager = new PermissionManager(container, {});
     container.register("PermissionManager", parentPermissionManager);
 
     const mockConfig: SubagentConfiguration = {
@@ -147,7 +147,6 @@ describe("Subagent Permission Integration", () => {
 
   it("should inherit all permission settings from parent PermissionManager", async () => {
     const parentPermissionManager = new PermissionManager(container, {
-      workdir: "/tmp/test",
       configuredPermissionMode: "acceptEdits",
       allowedRules: ["git:*"],
       deniedRules: ["Bash(rm *)"],
@@ -194,7 +193,6 @@ describe("Subagent Permission Integration", () => {
 
   it("should inherit instance-specific permission rules from parent PermissionManager", async () => {
     const parentPermissionManager = new PermissionManager(container, {
-      workdir: "/tmp/test",
       instanceAllowedRules: ["Bash(ls)"],
       instanceDeniedRules: ["Bash(rm *)"],
     });

--- a/packages/agent-sdk/tests/integration/subagentPermissionSync.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/subagentPermissionSync.integration.test.ts
@@ -58,9 +58,8 @@ describe("Subagent Permission Sync", () => {
 
     // Register parent PermissionManager BEFORE initializing SubagentManager
     // so the hook can wrap its methods
-    parentPermissionManager = new PermissionManager(container, {
-      workdir: "/tmp/test",
-    });
+    container.register("Workdir", "/tmp/test");
+    parentPermissionManager = new PermissionManager(container);
     container.register("PermissionManager", parentPermissionManager);
 
     subagentManager = new SubagentManager(container, {

--- a/packages/agent-sdk/tests/managers/permissionManager.acceptEdits.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.acceptEdits.test.ts
@@ -20,9 +20,9 @@ describe("PermissionManager - acceptEdits mode", () => {
     it("should automatically allow 'Edit', 'Write' tools inside Safe Zone", async () => {
       const autoAcceptedTools = ["Edit", "Write"];
       const workdir = "/home/user/project";
-      const manager = new PermissionManager(container, {
-        workdir,
-      });
+      const container = new Container();
+      container.register("Workdir", workdir);
+      const manager = new PermissionManager(container);
 
       for (const toolName of autoAcceptedTools) {
         const context: ToolPermissionContext = {

--- a/packages/agent-sdk/tests/managers/permissionManager.plan.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.plan.test.ts
@@ -9,9 +9,9 @@ describe("PermissionManager Plan Mode", () => {
 
   beforeEach(() => {
     container = new Container();
+    container.register("Workdir", "/home/user/project");
     permissionManager = new PermissionManager(container, {
       planFilePath,
-      workdir: "/home/user/project",
     });
   });
 

--- a/packages/agent-sdk/tests/managers/permissionManager.safeZone.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.safeZone.test.ts
@@ -13,10 +13,10 @@ describe("PermissionManager Safe Zone", () => {
 
   beforeEach(() => {
     container = new Container();
+    container.register("Workdir", workdir);
 
     permissionManager = new PermissionManager(container, {
       additionalDirectories: [additionalDir],
-      workdir,
     });
 
     // Mock fs.realpathSync for path safety checks

--- a/packages/agent-sdk/tests/managers/permissionManager.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.test.ts
@@ -21,11 +21,20 @@ vi.mock("../../src/utils/globalLogger.js", () => ({
   },
 }));
 
+function createContainer(workdir?: string): Container {
+  const c = new Container();
+  if (workdir) {
+    c.register("Workdir", workdir);
+  }
+  return c;
+}
+
 describe("PermissionManager", () => {
   let permissionManager: PermissionManager;
   const container = new Container();
 
   beforeEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
     // Create mock Logger
 
@@ -246,9 +255,8 @@ describe("PermissionManager", () => {
       it("should allow file operations in auto-memory directory (Safe Zone)", async () => {
         const workdir = "/home/user/project";
         const autoMemoryDir = "/home/user/.wave/projects/encoded/memory";
-        const container = new Container();
+        const container = createContainer(workdir);
         const manager = new PermissionManager(container, {
-          workdir,
           additionalDirectories: [autoMemoryDir],
         });
 
@@ -265,10 +273,8 @@ describe("PermissionManager", () => {
       it("should allow file operations in system additional directories", async () => {
         const workdir = "/home/user/project";
         const systemDir = "/home/user/system-safe";
-        const container = new Container();
-        const manager = new PermissionManager(container, {
-          workdir,
-        });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
 
         manager.addSystemAdditionalDirectory(systemDir);
 
@@ -284,10 +290,8 @@ describe("PermissionManager", () => {
 
       it("should deny file operations outside Safe Zone in acceptEdits mode", async () => {
         const workdir = "/home/user/project";
-        const container = new Container();
-        const manager = new PermissionManager(container, {
-          workdir,
-        });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
 
         const context: ToolPermissionContext = {
           toolName: "Write",
@@ -483,7 +487,8 @@ describe("PermissionManager", () => {
       const workdir = "/home/user/project";
 
       it("should match absolute path against relative pattern if inside workdir", async () => {
-        const manager = new PermissionManager(container, { workdir });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
         manager.updateDeniedRules(["Read(src/**)"]);
 
         const context: ToolPermissionContext = {
@@ -500,7 +505,8 @@ describe("PermissionManager", () => {
       });
 
       it("should NOT match absolute path against relative pattern if outside workdir", async () => {
-        const manager = new PermissionManager(container, { workdir });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
         manager.updateDeniedRules(["Read(src/**)"]);
 
         const context: ToolPermissionContext = {
@@ -515,7 +521,8 @@ describe("PermissionManager", () => {
       });
 
       it("should still match absolute pattern against absolute path", async () => {
-        const manager = new PermissionManager(container, { workdir });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
         const absolutePattern = "/home/user/project/src/**";
         manager.updateDeniedRules([`Read(${absolutePattern})`]);
 
@@ -533,7 +540,8 @@ describe("PermissionManager", () => {
       });
 
       it("should match relative path against relative pattern", async () => {
-        const manager = new PermissionManager(container, { workdir });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
         manager.updateDeniedRules(["Read(src/**)"]);
 
         const context: ToolPermissionContext = {
@@ -653,10 +661,8 @@ describe("PermissionManager", () => {
       it("should allow file tools in acceptEdits mode inside Safe Zone", async () => {
         const fileTools = ["Edit", "Write"];
         const workdir = "/home/user/project";
-        const container = new Container();
-        const manager = new PermissionManager(container, {
-          workdir,
-        });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
 
         for (const toolName of fileTools) {
           const context: ToolPermissionContext = {
@@ -686,10 +692,8 @@ describe("PermissionManager", () => {
 
       it("should allow mkdir in acceptEdits mode inside Safe Zone", async () => {
         const workdir = "/home/user/project";
-        const container = new Container();
-        const manager = new PermissionManager(container, {
-          workdir,
-        });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
 
         const context: ToolPermissionContext = {
           toolName: "Bash",
@@ -703,10 +707,8 @@ describe("PermissionManager", () => {
 
       it("should allow mkdir with multiple paths in acceptEdits mode inside Safe Zone", async () => {
         const workdir = "/home/user/project";
-        const container = new Container();
-        const manager = new PermissionManager(container, {
-          workdir,
-        });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
 
         const context: ToolPermissionContext = {
           toolName: "Bash",
@@ -720,10 +722,8 @@ describe("PermissionManager", () => {
 
       it("should allow mkdir -p in acceptEdits mode inside Safe Zone", async () => {
         const workdir = "/home/user/project";
-        const container = new Container();
-        const manager = new PermissionManager(container, {
-          workdir,
-        });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
 
         const context: ToolPermissionContext = {
           toolName: "Bash",
@@ -737,10 +737,8 @@ describe("PermissionManager", () => {
 
       it("should allow mkdir --parents in acceptEdits mode inside Safe Zone", async () => {
         const workdir = "/home/user/project";
-        const container = new Container();
-        const manager = new PermissionManager(container, {
-          workdir,
-        });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
 
         const context: ToolPermissionContext = {
           toolName: "Bash",
@@ -754,10 +752,8 @@ describe("PermissionManager", () => {
 
       it("should allow mkdir with multiple flags in acceptEdits mode inside Safe Zone", async () => {
         const workdir = "/home/user/project";
-        const container = new Container();
-        const manager = new PermissionManager(container, {
-          workdir,
-        });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
 
         const context: ToolPermissionContext = {
           toolName: "Bash",
@@ -771,10 +767,8 @@ describe("PermissionManager", () => {
 
       it("should allow mkdir with quoted paths in acceptEdits mode inside Safe Zone", async () => {
         const workdir = "/home/user/project";
-        const container = new Container();
-        const manager = new PermissionManager(container, {
-          workdir,
-        });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
 
         const context: ToolPermissionContext = {
           toolName: "Bash",
@@ -791,10 +785,8 @@ describe("PermissionManager", () => {
 
       it("should allow mkdir with mixed quoted and unquoted paths in acceptEdits mode inside Safe Zone", async () => {
         const workdir = "/home/user/project";
-        const container = new Container();
-        const manager = new PermissionManager(container, {
-          workdir,
-        });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
 
         const context: ToolPermissionContext = {
           toolName: "Bash",
@@ -808,10 +800,8 @@ describe("PermissionManager", () => {
 
       it("should allow mkdir with flags and mixed quoted/unquoted paths in acceptEdits mode inside Safe Zone", async () => {
         const workdir = "/home/user/project";
-        const container = new Container();
-        const manager = new PermissionManager(container, {
-          workdir,
-        });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
 
         const context: ToolPermissionContext = {
           toolName: "Bash",
@@ -825,10 +815,8 @@ describe("PermissionManager", () => {
 
       it("should allow mkdir with flags, quoted paths and .. in acceptEdits mode inside Safe Zone", async () => {
         const workdir = "/home/user/project";
-        const container = new Container();
-        const manager = new PermissionManager(container, {
-          workdir,
-        });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
 
         const context: ToolPermissionContext = {
           toolName: "Bash",
@@ -842,10 +830,8 @@ describe("PermissionManager", () => {
 
       it("should deny mkdir in acceptEdits mode outside Safe Zone", async () => {
         const workdir = "/home/user/project";
-        const container = new Container();
-        const manager = new PermissionManager(container, {
-          workdir,
-        });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
 
         const context: ToolPermissionContext = {
           toolName: "Bash",
@@ -860,9 +846,8 @@ describe("PermissionManager", () => {
       it("should allow mkdir in acceptEdits mode inside additionalDirectories", async () => {
         const workdir = "/home/user/project";
         const additionalDir = "/home/user/additional";
-        const container = new Container();
+        const container = createContainer(workdir);
         const manager = new PermissionManager(container, {
-          workdir,
           additionalDirectories: [additionalDir],
         });
 
@@ -879,10 +864,8 @@ describe("PermissionManager", () => {
       it("should allow mkdir in acceptEdits mode inside systemAdditionalDirectories", async () => {
         const workdir = "/home/user/project";
         const systemDir = "/home/user/system";
-        const container = new Container();
-        const manager = new PermissionManager(container, {
-          workdir,
-        });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
         manager.addSystemAdditionalDirectory(systemDir);
 
         const context: ToolPermissionContext = {
@@ -898,9 +881,8 @@ describe("PermissionManager", () => {
       it("should allow mkdir in acceptEdits mode inside autoMemoryDir", async () => {
         const workdir = "/home/user/project";
         const autoMemoryDir = "/home/user/.wave/projects/encoded/memory";
-        const container = new Container();
+        const container = createContainer(workdir);
         const manager = new PermissionManager(container, {
-          workdir,
           additionalDirectories: [autoMemoryDir],
         });
 
@@ -916,10 +898,8 @@ describe("PermissionManager", () => {
 
       it("should allow mkdir in acceptEdits mode inside workdir", async () => {
         const workdir = "/home/user/project";
-        const container = new Container();
-        const manager = new PermissionManager(container, {
-          workdir,
-        });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
 
         const context: ToolPermissionContext = {
           toolName: "Bash",
@@ -933,10 +913,8 @@ describe("PermissionManager", () => {
 
       it("should allow mkdir in acceptEdits mode inside workdir with relative path", async () => {
         const workdir = "/home/user/project";
-        const container = new Container();
-        const manager = new PermissionManager(container, {
-          workdir,
-        });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
 
         const context: ToolPermissionContext = {
           toolName: "Bash",
@@ -950,10 +928,8 @@ describe("PermissionManager", () => {
 
       it("should allow mkdir in acceptEdits mode inside workdir with .. path", async () => {
         const workdir = "/home/user/project";
-        const container = new Container();
-        const manager = new PermissionManager(container, {
-          workdir,
-        });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
 
         const context: ToolPermissionContext = {
           toolName: "Bash",
@@ -967,10 +943,8 @@ describe("PermissionManager", () => {
 
       it("should deny mkdir in acceptEdits mode outside workdir with .. path", async () => {
         const workdir = "/home/user/project";
-        const container = new Container();
-        const manager = new PermissionManager(container, {
-          workdir,
-        });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
 
         const context: ToolPermissionContext = {
           toolName: "Bash",
@@ -984,10 +958,8 @@ describe("PermissionManager", () => {
 
       it("should deny mkdir in acceptEdits mode if any path is outside Safe Zone", async () => {
         const workdir = "/home/user/project";
-        const container = new Container();
-        const manager = new PermissionManager(container, {
-          workdir,
-        });
+        const container = createContainer(workdir);
+        const manager = new PermissionManager(container);
 
         const context: ToolPermissionContext = {
           toolName: "Bash",
@@ -2455,6 +2427,153 @@ describe("PermissionManager", () => {
       const workdir = "/home/user/project";
       const rules = permissionManager.expandBashRule("sort file.txt", workdir);
       expect(rules).toEqual([]);
+    });
+  });
+
+  describe("dynamic workdir changes", () => {
+    it("should match previously granted relative rule after workdir changes and returns to original", async () => {
+      const workdir = "/a";
+      const container = createContainer(workdir);
+      const manager = new PermissionManager(container);
+      manager.updateDeniedRules(["Read(src/**)"]);
+
+      // Verify rule matches with initial workdir
+      const context1: ToolPermissionContext = {
+        toolName: "Read",
+        permissionMode: "default",
+        toolInput: { file_path: "/a/src/main.ts" },
+      };
+
+      expect(await manager.checkPermission(context1)).toMatchObject({
+        behavior: "deny",
+      });
+
+      // Change workdir to /a/b
+      container.register("Workdir", "/a/b");
+
+      // Change back to /a
+      container.register("Workdir", "/a");
+
+      // Permission for src/main.ts should still be remembered
+      const context2: ToolPermissionContext = {
+        toolName: "Read",
+        permissionMode: "default",
+        toolInput: { file_path: "/a/src/main.ts" },
+      };
+
+      expect(await manager.checkPermission(context2)).toMatchObject({
+        behavior: "deny",
+      });
+    });
+
+    it("should resolve relative paths against current workdir, not initial workdir", async () => {
+      const workdir = "/a";
+      const container = createContainer(workdir);
+      const manager = new PermissionManager(container);
+      manager.updateDeniedRules(["Read(src/**)"]);
+
+      // Change workdir to /b
+      container.register("Workdir", "/b");
+
+      // Read(/b/src/main.ts) should be denied (matches rule with current workdir)
+      const context1: ToolPermissionContext = {
+        toolName: "Read",
+        permissionMode: "default",
+        toolInput: { file_path: "/b/src/main.ts" },
+      };
+
+      expect(await manager.checkPermission(context1)).toMatchObject({
+        behavior: "deny",
+      });
+
+      // Read(/a/src/main.ts) should be allowed (no longer inside workdir, unrestricted)
+      const context2: ToolPermissionContext = {
+        toolName: "Read",
+        permissionMode: "default",
+        toolInput: { file_path: "/a/src/main.ts" },
+      };
+
+      // Read is unrestricted, so outside workdir it should be allowed
+      expect(await manager.checkPermission(context2)).toMatchObject({
+        behavior: "allow",
+      });
+    });
+
+    it("should use current workdir in isInsideSafeZone after dynamic change", async () => {
+      const workdir = "/a";
+      const container = createContainer(workdir);
+      const manager = new PermissionManager(container, {
+        configuredPermissionMode: "acceptEdits",
+      });
+
+      // File /a/test.txt is inside safe zone
+      const context1: ToolPermissionContext = {
+        toolName: "Write",
+        permissionMode: "acceptEdits",
+        toolInput: { file_path: "/a/test.txt" },
+      };
+
+      expect(await manager.checkPermission(context1)).toMatchObject({
+        behavior: "allow",
+      });
+
+      // Update workdir to /c
+      container.register("Workdir", "/c");
+
+      // File /a/test.txt should no longer be inside workdir safe zone
+      const context2: ToolPermissionContext = {
+        toolName: "Write",
+        permissionMode: "acceptEdits",
+        toolInput: { file_path: "/a/test.txt" },
+      };
+
+      expect(await manager.checkPermission(context2)).toMatchObject({
+        behavior: "deny",
+      });
+
+      // File /c/test.txt should be inside the new safe zone
+      const context3: ToolPermissionContext = {
+        toolName: "Write",
+        permissionMode: "acceptEdits",
+        toolInput: { file_path: "/c/test.txt" },
+      };
+
+      expect(await manager.checkPermission(context3)).toMatchObject({
+        behavior: "allow",
+      });
+    });
+
+    it("should resolve workdir from parent container in subagent PermissionManager", () => {
+      const parentContainer = createContainer("/a");
+
+      // Child container should resolve Workdir from parent
+      const childContainer = parentContainer.createChild();
+      expect(childContainer.get<string>("Workdir")).toBe("/a");
+
+      // Parent updates Workdir to /b
+      parentContainer.register("Workdir", "/b");
+
+      // Child container should resolve Workdir=/b
+      expect(childContainer.get<string>("Workdir")).toBe("/b");
+    });
+
+    it("should update additionalDirectories resolution when workdir changes", () => {
+      const workdir = "/a";
+      const container = createContainer(workdir);
+      const manager = new PermissionManager(container);
+
+      // Add relative additional directory
+      manager.updateAdditionalDirectories(["./config"]);
+
+      // Should resolve relative to /a
+      expect(manager.getAdditionalDirectories()).toContain("/a/config");
+
+      // Change workdir
+      container.register("Workdir", "/b");
+
+      // Add another relative directory - should now resolve to /b
+      manager.updateAdditionalDirectories(["./data"]);
+      expect(manager.getAdditionalDirectories()).toContain("/b/data");
     });
   });
 });

--- a/packages/agent-sdk/tests/managers/permissionManager.worktree.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.worktree.test.ts
@@ -13,6 +13,14 @@ vi.mock("../../src/utils/globalLogger.js", () => ({
   },
 }));
 
+function createContainer(workdir?: string): Container {
+  const c = new Container();
+  if (workdir) {
+    c.register("Workdir", workdir);
+  }
+  return c;
+}
+
 describe("PermissionManager Worktree Safety", () => {
   let container: Container;
   const workdir = "/home/user/project/worktrees/feat-1";
@@ -21,13 +29,13 @@ describe("PermissionManager Worktree Safety", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    container = new Container();
+    container = createContainer(workdir);
     container.register("WorktreeName", worktreeName);
     container.register("MainRepoRoot", mainRepoRoot);
   });
 
   it("should allow Write to a file inside the worktree", async () => {
-    const manager = new PermissionManager(container, { workdir });
+    const manager = new PermissionManager(container);
     const context: ToolPermissionContext = {
       toolName: "Write",
       permissionMode: "acceptEdits",
@@ -39,7 +47,7 @@ describe("PermissionManager Worktree Safety", () => {
   });
 
   it("should auto-deny Write to a file in the main repo (outside worktree)", async () => {
-    const manager = new PermissionManager(container, { workdir });
+    const manager = new PermissionManager(container);
     const context: ToolPermissionContext = {
       toolName: "Write",
       permissionMode: "acceptEdits",
@@ -55,7 +63,7 @@ describe("PermissionManager Worktree Safety", () => {
   });
 
   it("should auto-deny Edit to a file in the main repo (outside worktree)", async () => {
-    const manager = new PermissionManager(container, { workdir });
+    const manager = new PermissionManager(container);
     const context: ToolPermissionContext = {
       toolName: "Edit",
       permissionMode: "acceptEdits",
@@ -71,7 +79,7 @@ describe("PermissionManager Worktree Safety", () => {
 
   it("should allow Write to the plan file outside the main repo in plan mode", async () => {
     const planFilePath = "/home/user/.wave/plans/plan.md";
-    const manager = new PermissionManager(container, { workdir, planFilePath });
+    const manager = new PermissionManager(container, { planFilePath });
     const context: ToolPermissionContext = {
       toolName: "Write",
       permissionMode: "plan",
@@ -84,7 +92,7 @@ describe("PermissionManager Worktree Safety", () => {
 
   it("should auto-deny Write to a non-plan file in the main repo in plan mode", async () => {
     const planFilePath = path.join(mainRepoRoot, "plan.md");
-    const manager = new PermissionManager(container, { workdir, planFilePath });
+    const manager = new PermissionManager(container, { planFilePath });
     const context: ToolPermissionContext = {
       toolName: "Write",
       permissionMode: "plan",
@@ -101,7 +109,7 @@ describe("PermissionManager Worktree Safety", () => {
   });
 
   it("should allow Write to a file outside the main repo (normal Safe Zone check applies)", async () => {
-    const manager = new PermissionManager(container, { workdir });
+    const manager = new PermissionManager(container);
     const context: ToolPermissionContext = {
       toolName: "Write",
       permissionMode: "acceptEdits",
@@ -115,10 +123,8 @@ describe("PermissionManager Worktree Safety", () => {
   });
 
   it("should not auto-deny if not in a worktree session", async () => {
-    const emptyContainer = new Container();
-    const manager = new PermissionManager(emptyContainer, {
-      workdir: mainRepoRoot,
-    });
+    const emptyContainer = createContainer(mainRepoRoot);
+    const manager = new PermissionManager(emptyContainer);
     const context: ToolPermissionContext = {
       toolName: "Write",
       permissionMode: "acceptEdits",


### PR DESCRIPTION
When the working directory changes (e.g., `/a` → `/a/b` → `../` back to `/a`), the PermissionManager's internal `workdir` was never updated. Since permission rules use `path.relative(this.workdir, targetPath)` for matching, a stale `workdir` caused previously granted permissions to fail matching.

## Root Cause

`Agent.workdir` is updated in two places, but neither called `permissionManager.updateWorkdir(newCwd)`. The `PermissionManager` stored its own copy of `workdir` that went stale.

## Solution

Remove `PermissionManager`'s internal `workdir` state. Instead, register `Workdir` in the DI Container and resolve it dynamically via `container.get('Workdir')`. When `Agent.setWorkdir()` fires, it updates the container's `Workdir` registration. Subagents inherit via child container resolution.

## Changes

- **`src/managers/permissionManager.ts`** — Remove `workdir` field from options and internal state. Add `getWorkdir()` method resolving from DI container. Replace all 13 references. Remove `updateWorkdir()` method.
- **`src/utils/containerSetup.ts`** — Register `"Workdir"` in container. Remove `workdir` from PermissionManager constructor options.
- **`src/agent.ts`** — Update container's `"Workdir"` registration on CWD changes (`setOnCwdChange` and `setWorkdir()`).
- **`src/managers/subagentManager.ts`** — Remove `workdir` from subagent PermissionManager constructor (inherits via child container).
- **Tests** — Updated all 7 test files to use `createContainer(workdir)` helper. Added `vi.restoreAllMocks()` to prevent `realpathSync` mock leakage. Added 5 new test cases for dynamic workdir changes.

## New Test Cases

- Relative rule matching after workdir changes and returns to original
- Relative path resolution uses current workdir, not initial workdir
- Safe zone check uses current workdir after dynamic change
- Subagent inherits updated workdir from parent container
- Additional directories resolution updates when workdir changes