### PR TITLE
feat: substitute WAVE_PLUGIN_ROOT in plugin hooks, MCP, and LSP servers

### DIFF
--- a/packages/agent-sdk/builtin/skills/settings/HOOKS.md
+++ b/packages/agent-sdk/builtin/skills/settings/HOOKS.md
@@ -90,6 +90,31 @@ Hooks can communicate status and control Wave's behavior using exit codes:
 
 Hook configurations support **live reload**. When you modify hooks in `settings.json`, the changes take effect immediately without restarting Wave.
 
+## Plugin Hooks
+
+When hooks are registered via a **plugin**, Wave automatically:
+
+1. Substitutes `${WAVE_PLUGIN_ROOT}` with the plugin's directory path in the command string
+2. Injects `WAVE_PLUGIN_ROOT` as an environment variable into the hook process
+
+```json
+{
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "command": "${WAVE_PLUGIN_ROOT}/scripts/setup-worktree.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The shell also receives `WAVE_PLUGIN_ROOT` as an env var, so `$WAVE_PLUGIN_ROOT` works in the hook script itself.
+
 ## Best Practices
 
 - **Keep hooks fast**: Long-running hooks can slow down your workflow unless they are `async`.

--- a/packages/agent-sdk/builtin/skills/settings/MCP.md
+++ b/packages/agent-sdk/builtin/skills/settings/MCP.md
@@ -63,6 +63,28 @@ For example, if you have a server named `sqlite` with a tool named `query`, it w
 
 By default, MCP tools require user permission before execution. When you grant permission, you can choose to "Allow always" for a specific tool. These persistent rules are stored in your `settings.json` under the `permissions` field.
 
+## Plugin MCP Servers
+
+When MCP servers are registered via a **plugin**, Wave automatically injects the `WAVE_PLUGIN_ROOT` environment variable into the server process. Additionally, `${WAVE_PLUGIN_ROOT}` in the `command`, `args`, and `env` fields is substituted with the plugin's directory path before the server is spawned (matching Claude Code's `${CLAUDE_PLUGIN_ROOT}` behavior).
+
+```json
+{
+  "mcpServers": {
+    "my-plugin-server": {
+      "command": "${WAVE_PLUGIN_ROOT}/bin/mcp-server",
+      "args": ["--config", "${WAVE_PLUGIN_ROOT}/config/server.json"]
+    }
+  }
+}
+```
+
+Your MCP server code can also read `WAVE_PLUGIN_ROOT` as an environment variable:
+
+```ts
+// Inside your MCP server (e.g., a Node.js script)
+const pluginRoot = process.env.WAVE_PLUGIN_ROOT;
+```
+
 ## Troubleshooting
 
 - **Server Connection**: If a server fails to connect, Wave will log an error. You can check the status of MCP servers by asking the agent.

--- a/packages/agent-sdk/builtin/skills/settings/SKILL.md
+++ b/packages/agent-sdk/builtin/skills/settings/SKILL.md
@@ -91,7 +91,10 @@ For detailed guidance on creating skills, see [SKILLS.md](${WAVE_SKILL_DIR}/SKIL
 Delegate tasks to specialized AI personalities.
 For detailed guidance on creating subagents, see [SUBAGENTS.md](${WAVE_SKILL_DIR}/SUBAGENTS.md).
 
-### 9. Other Settings
+### 9. Plugins
+Enable or disable plugins via `enabledPlugins`. Plugin skills, hooks, MCP servers, and LSP servers can reference their parent plugin's directory using the `${WAVE_PLUGIN_ROOT}` placeholder. Wave substitutes `${WAVE_PLUGIN_ROOT}` with the plugin's directory path at load time (same as `${WAVE_SKILL_DIR}`), and also injects `WAVE_PLUGIN_ROOT` as an environment variable into the spawned process.
+
+### 10. Other Settings
 - `language`: Preferred language for agent communication (e.g., `"en"`, `"zh"`).
 - `autoMemoryEnabled`: Enable or disable auto-memory (default: `true`).
 - `autoMemoryFrequency`: Frequency of auto-memory extraction turns (default: `1`).

--- a/packages/agent-sdk/src/managers/hookManager.ts
+++ b/packages/agent-sdk/src/managers/hookManager.ts
@@ -167,6 +167,7 @@ export class HookManager {
             : undefined;
 
           // Build execution context with WAVE_PLUGIN_ROOT if this is a plugin hook
+          let command = hookCommand.command;
           const execContext: typeof context = hookCommand.pluginRoot
             ? {
                 ...context,
@@ -177,28 +178,30 @@ export class HookManager {
               }
             : context;
 
+          // Substitute ${WAVE_PLUGIN_ROOT} in the command string (same pattern as Claude Code)
+          if (hookCommand.pluginRoot) {
+            command = command.replace(
+              /\$\{WAVE_PLUGIN_ROOT\}/g,
+              hookCommand.pluginRoot,
+            );
+          }
+
           if (hookCommand.async) {
             // Execute async command without awaiting
-            executeCommand(hookCommand.command, execContext, options).catch(
-              (error) => {
-                const errorMessage =
-                  error instanceof Error
-                    ? error.message
-                    : "Unknown execution error";
-                logger?.error(
-                  `[HookManager] Async hook command ${commandIndex + 1} failed: ${errorMessage}`,
-                );
-              },
-            );
+            executeCommand(command, execContext, options).catch((error) => {
+              const errorMessage =
+                error instanceof Error
+                  ? error.message
+                  : "Unknown execution error";
+              logger?.error(
+                `[HookManager] Async hook command ${commandIndex + 1} failed: ${errorMessage}`,
+              );
+            });
             // Async hooks are not included in results to prevent blocking
             continue;
           }
 
-          const result = await executeCommand(
-            hookCommand.command,
-            execContext,
-            options,
-          );
+          const result = await executeCommand(command, execContext, options);
           results.push(result);
 
           // Continue with next command even if this one fails

--- a/packages/agent-sdk/src/managers/lspManager.ts
+++ b/packages/agent-sdk/src/managers/lspManager.ts
@@ -91,10 +91,27 @@ export class LspManager implements ILspManager {
 
     try {
       const env = { ...process.env, ...config.env };
+
+      // For plugin servers, substitute ${WAVE_PLUGIN_ROOT} in command/args/env
+      let command = config.command;
+      let args = config.args || [];
       if (config.pluginRoot) {
         env.WAVE_PLUGIN_ROOT = config.pluginRoot;
+        command = command.replace(/\$\{WAVE_PLUGIN_ROOT\}/g, config.pluginRoot);
+        args = args.map((arg) =>
+          arg.replace(/\$\{WAVE_PLUGIN_ROOT\}/g, config.pluginRoot!),
+        );
+        // Also expand WAVE_PLUGIN_ROOT in user-provided env values
+        if (config.env) {
+          for (const [key, value] of Object.entries(config.env)) {
+            env[key] = value.replace(
+              /\$\{WAVE_PLUGIN_ROOT\}/g,
+              config.pluginRoot!,
+            );
+          }
+        }
       }
-      const proc = spawn(config.command, config.args || [], {
+      const proc = spawn(command, args, {
         cwd: config.workspaceFolder || this.workdir,
         env,
         stdio: ["pipe", "pipe", "pipe"],

--- a/packages/agent-sdk/src/managers/mcpManager.ts
+++ b/packages/agent-sdk/src/managers/mcpManager.ts
@@ -352,12 +352,31 @@ export class McpManager {
           ...(process.env as Record<string, string>),
           ...(server.config.env || {}),
         };
+
+        // For plugin servers, substitute ${WAVE_PLUGIN_ROOT} in command/args/env
+        // (same pattern as Claude Code's substitutePluginVariables)
+        let command = server.config.command;
+        let args = server.config.args || [];
         if (server.config.pluginRoot) {
           env.WAVE_PLUGIN_ROOT = server.config.pluginRoot;
+          command = command.replace(
+            /\$\{WAVE_PLUGIN_ROOT\}/g,
+            server.config.pluginRoot,
+          );
+          args = args.map((arg) =>
+            arg.replace(/\$\{WAVE_PLUGIN_ROOT\}/g, server.config.pluginRoot!),
+          );
+          // Also expand WAVE_PLUGIN_ROOT in user-provided env values
+          for (const [key, value] of Object.entries(server.config.env || {})) {
+            env[key] = value.replace(
+              /\$\{WAVE_PLUGIN_ROOT\}/g,
+              server.config.pluginRoot!,
+            );
+          }
         }
         transport = new StdioClientTransport({
-          command: server.config.command,
-          args: server.config.args || [],
+          command,
+          args,
           env,
           cwd: this.workdir, // Use the agent's workdir as the process working directory
           stderr: "pipe", // Pipe stderr to capture it

--- a/packages/agent-sdk/tests/managers/hookManager.coverage.test.ts
+++ b/packages/agent-sdk/tests/managers/hookManager.coverage.test.ts
@@ -553,6 +553,68 @@ describe("HookManager Coverage", () => {
         undefined,
       );
     });
+
+    it("should substitute ${WAVE_PLUGIN_ROOT} in plugin hook command string", async () => {
+      manager.registerPluginHooks("/my/plugin/root", {
+        UserPromptSubmit: [
+          {
+            hooks: [
+              {
+                type: "command" as const,
+                command: "${WAVE_PLUGIN_ROOT}/scripts/hook.sh",
+              },
+            ],
+          },
+        ],
+      });
+
+      const context = {
+        event: "UserPromptSubmit" as const,
+        projectDir: "/test/workdir",
+        timestamp: new Date(),
+      };
+
+      await manager.executeHooks("UserPromptSubmit", context);
+
+      expect(mockExecuteCommand).toHaveBeenCalledWith(
+        "/my/plugin/root/scripts/hook.sh",
+        expect.objectContaining({
+          env: expect.objectContaining({
+            WAVE_PLUGIN_ROOT: "/my/plugin/root",
+          }),
+        }),
+        undefined,
+      );
+    });
+
+    it("should not substitute ${WAVE_PLUGIN_ROOT} for non-plugin hooks", async () => {
+      manager.loadConfiguration({
+        UserPromptSubmit: [
+          {
+            hooks: [
+              {
+                type: "command" as const,
+                command: "${WAVE_PLUGIN_ROOT}/scripts/hook.sh",
+              },
+            ],
+          },
+        ],
+      });
+
+      const context = {
+        event: "UserPromptSubmit" as const,
+        projectDir: "/test/workdir",
+        timestamp: new Date(),
+      };
+
+      await manager.executeHooks("UserPromptSubmit", context);
+
+      expect(mockExecuteCommand).toHaveBeenCalledWith(
+        "${WAVE_PLUGIN_ROOT}/scripts/hook.sh",
+        expect.any(Object),
+        undefined,
+      );
+    });
   });
 
   describe("validateEventConfig", () => {

--- a/packages/agent-sdk/tests/managers/lspManager.test.ts
+++ b/packages/agent-sdk/tests/managers/lspManager.test.ts
@@ -425,4 +425,51 @@ describe("LspManager (Mocked)", () => {
       }),
     );
   });
+
+  it("should substitute ${WAVE_PLUGIN_ROOT} in command/args for plugin-owned LSP servers", async () => {
+    const { stdin, stdout } = setupMockProcess();
+    respondToInitialize(stdin, stdout);
+
+    lspManager.registerServer("typescript", {
+      command: "${WAVE_PLUGIN_ROOT}/bin/typescript-language-server",
+      args: ["--stdio", "--config", "${WAVE_PLUGIN_ROOT}/config.json"],
+      extensionToLanguage: { ".ts": "typescript" },
+      pluginRoot: "/path/to/plugin",
+      env: { CUSTOM_PATH: "${WAVE_PLUGIN_ROOT}/custom" },
+      shutdownTimeout: 1,
+    });
+
+    await lspManager.getProcessForFile("/mock/workdir/test.ts");
+
+    expect(spawn).toHaveBeenCalledWith(
+      "/path/to/plugin/bin/typescript-language-server",
+      ["--stdio", "--config", "/path/to/plugin/config.json"],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          WAVE_PLUGIN_ROOT: "/path/to/plugin",
+          CUSTOM_PATH: "/path/to/plugin/custom",
+        }),
+      }),
+    );
+  });
+
+  it("should not substitute ${WAVE_PLUGIN_ROOT} for non-plugin LSP servers", async () => {
+    const { stdin, stdout } = setupMockProcess();
+    respondToInitialize(stdin, stdout);
+
+    lspManager.registerServer("typescript", {
+      command: "${WAVE_PLUGIN_ROOT}/bin/typescript-language-server",
+      args: ["--stdio"],
+      extensionToLanguage: { ".ts": "typescript" },
+      shutdownTimeout: 1,
+    });
+
+    await lspManager.getProcessForFile("/mock/workdir/test.ts");
+
+    expect(spawn).toHaveBeenCalledWith(
+      "${WAVE_PLUGIN_ROOT}/bin/typescript-language-server",
+      ["--stdio"],
+      expect.any(Object),
+    );
+  });
 });

--- a/packages/agent-sdk/tests/managers/mcpManager.test.ts
+++ b/packages/agent-sdk/tests/managers/mcpManager.test.ts
@@ -445,6 +445,76 @@ describe("McpManager", () => {
         stderr: "pipe",
       });
     });
+
+    it("should substitute ${WAVE_PLUGIN_ROOT} in command for plugin-owned stdio servers", async () => {
+      const pluginConfig: McpServerConfig = {
+        command: "${WAVE_PLUGIN_ROOT}/bin/mcp-server",
+        args: ["--config", "${WAVE_PLUGIN_ROOT}/config.json"],
+        pluginRoot: "/path/to/plugin",
+      };
+      mcpManager.addServer("plugin-server", pluginConfig);
+
+      await mcpManager.connectServer("plugin-server");
+
+      expect(StdioClientTransport).toHaveBeenCalledWith({
+        command: "/path/to/plugin/bin/mcp-server",
+        args: ["--config", "/path/to/plugin/config.json"],
+        env: {
+          ...process.env,
+          WAVE_PLUGIN_ROOT: "/path/to/plugin",
+        },
+        cwd: "/test/workdir",
+        stderr: "pipe",
+      });
+    });
+
+    it("should substitute ${WAVE_PLUGIN_ROOT} in env values for plugin-owned stdio servers", async () => {
+      const pluginConfig: McpServerConfig = {
+        command: "npx",
+        args: ["plugin-mcp"],
+        env: {
+          CONFIG_PATH: "${WAVE_PLUGIN_ROOT}/config/server.json",
+          OTHER_VAR: "static-value",
+        },
+        pluginRoot: "/path/to/plugin",
+      };
+      mcpManager.addServer("plugin-server", pluginConfig);
+
+      await mcpManager.connectServer("plugin-server");
+
+      expect(StdioClientTransport).toHaveBeenCalledWith({
+        command: "npx",
+        args: ["plugin-mcp"],
+        env: {
+          ...process.env,
+          WAVE_PLUGIN_ROOT: "/path/to/plugin",
+          CONFIG_PATH: "/path/to/plugin/config/server.json",
+          OTHER_VAR: "static-value",
+        },
+        cwd: "/test/workdir",
+        stderr: "pipe",
+      });
+    });
+
+    it("should not substitute ${WAVE_PLUGIN_ROOT} for non-plugin stdio servers", async () => {
+      const nonPluginConfig: McpServerConfig = {
+        command: "${WAVE_PLUGIN_ROOT}/bin/mcp-server",
+        args: ["${WAVE_PLUGIN_ROOT}/arg"],
+      };
+      mcpManager.addServer("non-plugin-server", nonPluginConfig);
+
+      await mcpManager.connectServer("non-plugin-server");
+
+      expect(StdioClientTransport).toHaveBeenCalledWith({
+        command: "${WAVE_PLUGIN_ROOT}/bin/mcp-server",
+        args: ["${WAVE_PLUGIN_ROOT}/arg"],
+        env: {
+          ...process.env,
+        },
+        cwd: "/test/workdir",
+        stderr: "pipe",
+      });
+    });
   });
 
   describe("disconnectServer", () => {

--- a/specs/071-builtin-settings-skill/spec.md
+++ b/specs/071-builtin-settings-skill/spec.md
@@ -80,3 +80,8 @@ As a user, I want detailed documentation for complex hook configurations to be a
 - The `settings` skill will be implemented as a builtin skill.
 - The skill will use the existing `ConfigurationService` for reading and writing settings.
 - "Complex hooks config" refers to advanced usage of the `hooks` field in `settings.json`.
+
+### Template Placeholders
+
+- **`${WAVE_SKILL_DIR}`**: Template placeholder resolved to the skill's directory path. Available in all skills (builtin, personal, project, plugin).
+- **`${WAVE_PLUGIN_ROOT}`**: Template placeholder resolved to the plugin's root directory. Available in plugin-originated skills, hooks, MCP servers, and LSP servers. Wave substitutes this at load time, and also injects `WAVE_PLUGIN_ROOT` as a real environment variable into the spawned process.


### PR DESCRIPTION
## Summary

Add template substitution for `${WAVE_PLUGIN_ROOT}` in plugin hooks, MCP servers, and LSP servers, matching Claude Code's `${CLAUDE_PLUGIN_ROOT}` behavior.

## Changes

- **hookManager.ts**: Substitute `${WAVE_PLUGIN_ROOT}` in plugin hook command strings before execution
- **mcpManager.ts**: Substitute `${WAVE_PLUGIN_ROOT}` in command, args, and user-provided env values for plugin MCP servers
- **lspManager.ts**: Same substitution for plugin LSP servers
- **Settings docs**: Update HOOKS.md, MCP.md, and SKILL.md to document `${WAVE_PLUGIN_ROOT}` usage
- **spec.md**: Document template placeholders (`${WAVE_SKILL_DIR}`, `${WAVE_PLUGIN_ROOT}`)
- **Tests**: Add 7 new tests covering substitution and non-substitution cases

Wave now both substitutes the placeholder at load time AND injects `WAVE_PLUGIN_ROOT` as an environment variable into the spawned process.