### PR TITLE
fix(permissionManager): anchor Safe Zone to original workdir

### DIFF
--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -277,7 +277,7 @@ export class PermissionManager {
    * Update the additional directories (e.g., when configuration reloads)
    */
   updateAdditionalDirectories(directories: string[]): void {
-    const workdir = this.getWorkdir();
+    const workdir = this.originalWorkdir;
     this.additionalDirectories = directories.map((dir) => {
       if (workdir && !path.isAbsolute(dir)) {
         return path.resolve(workdir, dir);
@@ -290,7 +290,7 @@ export class PermissionManager {
    * Add a system-level additional directory that is persistent across configuration reloads
    */
   public addSystemAdditionalDirectory(directory: string): void {
-    const workdir = this.getWorkdir();
+    const workdir = this.originalWorkdir;
     const resolvedPath =
       workdir && !path.isAbsolute(directory)
         ? path.resolve(workdir, directory)
@@ -322,7 +322,7 @@ export class PermissionManager {
     targetPath: string,
     workdir?: string,
   ): { isInside: boolean; resolvedPath: string } {
-    const effectiveWorkdir = workdir || this.getWorkdir();
+    const effectiveWorkdir = this.originalWorkdir || workdir;
 
     // Resolve the target path relative to effectiveWorkdir if it's not absolute
     const absolutePath =

--- a/packages/agent-sdk/tests/managers/permissionManager.safeZone.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.safeZone.test.ts
@@ -1,205 +1,142 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import fs from "node:fs";
-import path from "node:path";
 import { PermissionManager } from "../../src/managers/permissionManager.js";
-import type { ToolPermissionContext } from "../../src/types/permissions.js";
 import { Container } from "../../src/utils/container.js";
+import type { ToolPermissionContext } from "../../src/types/permissions.js";
 
-describe("PermissionManager Safe Zone", () => {
-  let permissionManager: PermissionManager;
-  let container: Container;
-  const workdir = "/home/user/project";
-  const additionalDir = "/home/user/other";
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
 
+function createContainer(workdir?: string): Container {
+  const c = new Container();
+  if (workdir) {
+    c.register("Workdir", workdir);
+  }
+  return c;
+}
+
+describe("PermissionManager - Safe Zone anchored to original workdir", () => {
   beforeEach(() => {
-    container = new Container();
-    container.register("Workdir", workdir);
-
-    permissionManager = new PermissionManager(container, {
-      additionalDirectories: [additionalDir],
-    });
-
-    // Mock fs.realpathSync for path safety checks
-    vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
-      const pathStr = p.toString();
-      if (pathStr.startsWith(workdir)) return pathStr;
-      if (pathStr.startsWith(additionalDir)) return pathStr;
-      if (pathStr.startsWith("/tmp")) return pathStr;
-      return pathStr;
-    });
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
-  describe("checkPermission with Safe Zone", () => {
-    const fileTools = ["Write", "Edit"];
+  describe("isInsideSafeZone after workdir changes", () => {
+    it("should keep files in original workdir inside safe zone after cd to subdirectory", async () => {
+      const container = createContainer("/a");
+      const manager = new PermissionManager(container);
 
-    for (const toolName of fileTools) {
-      describe(`${toolName} tool`, () => {
-        it("should allow operation inside workdir when acceptEdits is ON", async () => {
-          const filePath = path.join(workdir, "test.txt");
-          const context: ToolPermissionContext = {
-            toolName,
-            permissionMode: "acceptEdits",
-            toolInput: { file_path: filePath },
-          };
+      // Simulate cd to subdirectory
+      container.register("Workdir", "/a/frontend");
 
-          const result = await permissionManager.checkPermission(context);
-          expect(result.behavior).toBe("allow");
-        });
-
-        it("should allow operation inside additionalDirectories when acceptEdits is ON", async () => {
-          const filePath = path.join(additionalDir, "test.txt");
-          const context: ToolPermissionContext = {
-            toolName,
-            permissionMode: "acceptEdits",
-            toolInput: { file_path: filePath },
-          };
-
-          const result = await permissionManager.checkPermission(context);
-          expect(result.behavior).toBe("allow");
-        });
-
-        it("should NOT auto-allow operation outside Safe Zone even if acceptEdits is ON", async () => {
-          const filePath = "/tmp/test.txt";
-          const context: ToolPermissionContext = {
-            toolName,
-            permissionMode: "acceptEdits",
-            toolInput: { file_path: filePath },
-          };
-
-          const result = await permissionManager.checkPermission(context);
-          // It should fall through to default behavior which is deny without callback
-          expect(result.behavior).toBe("deny");
-          expect(result.message).toContain("requires permission approval");
-        });
-
-        it("should deny operation inside Safe Zone if acceptEdits is OFF", async () => {
-          const filePath = path.join(workdir, "test.txt");
-          const context: ToolPermissionContext = {
-            toolName,
-            permissionMode: "default",
-            toolInput: { file_path: filePath },
-          };
-
-          const result = await permissionManager.checkPermission(context);
-          expect(result.behavior).toBe("deny");
-        });
-      });
-    }
-
-    it("should handle relative paths correctly", async () => {
+      // File in original workdir should still be safe
       const context: ToolPermissionContext = {
         toolName: "Write",
         permissionMode: "acceptEdits",
-        toolInput: { file_path: "src/index.ts", workdir },
+        toolInput: { file_path: "/a/README.md" },
       };
 
-      const result = await permissionManager.checkPermission(context);
+      const result = await manager.checkPermission(context);
       expect(result.behavior).toBe("allow");
     });
 
-    it("should handle symlinks correctly", async () => {
-      const symlinkPath = path.join(workdir, "link.txt");
-      const realPath = "/tmp/real.txt";
+    it("should keep sibling directories of original workdir inside safe zone after cd", async () => {
+      const container = createContainer("/a");
+      const manager = new PermissionManager(container);
 
-      vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
-        if (p.toString() === symlinkPath) return realPath;
-        return p.toString();
-      });
+      // Simulate cd to subdirectory
+      container.register("Workdir", "/a/frontend");
 
+      // File in sibling directory should still be safe
       const context: ToolPermissionContext = {
         toolName: "Write",
         permissionMode: "acceptEdits",
-        toolInput: { file_path: symlinkPath },
+        toolInput: { file_path: "/a/backend/server.ts" },
       };
 
-      const result = await permissionManager.checkPermission(context);
-      expect(result.behavior).toBe("deny");
-      expect(result.message).toContain("requires permission approval");
+      const result = await manager.checkPermission(context);
+      expect(result.behavior).toBe("allow");
+    });
+
+    it("should deny files outside original workdir even if inside current workdir", async () => {
+      const container = createContainer("/a");
+      const manager = new PermissionManager(container);
+
+      // Simulate cd to subdirectory
+      container.register("Workdir", "/a/frontend");
+
+      // File outside original workdir should be denied (falls back to manual confirmation)
+      const context: ToolPermissionContext = {
+        toolName: "Write",
+        permissionMode: "acceptEdits",
+        toolInput: { file_path: "/b/outside.txt" },
+      };
+
+      const result = await manager.checkPermission(context);
+      // Should not be auto-allowed since it's outside the safe zone
+      expect(result.behavior).not.toBe("allow");
     });
   });
 
-  describe("Bash out-of-bounds with Safe Zone", () => {
-    it("should allow 'ls' in additionalDirectory", () => {
-      const context = permissionManager.createContext(
-        "Bash",
-        "default",
-        undefined,
-        {
-          command: `ls ${additionalDir}`,
-          workdir,
-        },
-      );
+  describe("additionalDirectories resolved against original workdir", () => {
+    it("should resolve relative additional directories against original workdir after workdir changes", () => {
+      const container = createContainer("/a");
+      const manager = new PermissionManager(container);
 
-      expect(context.hidePersistentOption).toBeFalsy();
+      manager.updateAdditionalDirectories(["./config", "./data"]);
+
+      expect(manager.getAdditionalDirectories()).toContain("/a/config");
+      expect(manager.getAdditionalDirectories()).toContain("/a/data");
+
+      // Change workdir
+      container.register("Workdir", "/a/frontend");
+
+      // Update additional directories - should still resolve against /a
+      manager.updateAdditionalDirectories(["./shared"]);
+      expect(manager.getAdditionalDirectories()).toContain("/a/shared");
     });
 
-    it("should NOT set hidePersistentOption for 'ls' outside Safe Zone", () => {
-      const context = permissionManager.createContext(
-        "Bash",
-        "default",
-        undefined,
-        {
-          command: "ls /tmp",
-          workdir,
-        },
-      );
+    it("should consider files in additional directories as safe after workdir changes", async () => {
+      const container = createContainer("/a");
+      const manager = new PermissionManager(container);
 
-      expect(context.hidePersistentOption).toBeFalsy();
+      manager.updateAdditionalDirectories(["./shared"]);
+
+      // Change workdir
+      container.register("Workdir", "/a/frontend");
+
+      // File in additional directory should still be safe
+      const context: ToolPermissionContext = {
+        toolName: "Write",
+        permissionMode: "acceptEdits",
+        toolInput: { file_path: "/a/shared/config.json" },
+      };
+
+      const result = await manager.checkPermission(context);
+      expect(result.behavior).toBe("allow");
     });
+  });
 
-    it("should allow 'cd' into additionalDirectory", () => {
-      const context = permissionManager.createContext(
-        "Bash",
-        "default",
-        undefined,
-        {
-          command: `cd ${additionalDir}`,
-          workdir,
-        },
-      );
+  describe("systemAdditionalDirectories resolved against original workdir", () => {
+    it("should resolve relative system additional directories against original workdir after workdir changes", () => {
+      const container = createContainer("/a");
+      const manager = new PermissionManager(container);
 
-      expect(context.hidePersistentOption).toBeFalsy();
-    });
+      manager.addSystemAdditionalDirectory("./system-config");
 
-    it("should set hidePersistentOption for 'cd' outside Safe Zone", () => {
-      const context = permissionManager.createContext(
-        "Bash",
-        "default",
-        undefined,
-        {
-          command: "cd /tmp",
-          workdir,
-        },
-      );
+      // Change workdir
+      container.register("Workdir", "/a/frontend");
 
-      expect(context.hidePersistentOption).toBe(true);
-    });
-    it("should set hidePersistentOption for file operations outside Safe Zone", () => {
-      const context = permissionManager.createContext(
-        "Write",
-        "acceptEdits",
-        undefined,
-        {
-          file_path: "/tmp/test.txt",
-          workdir,
-        },
-      );
+      manager.addSystemAdditionalDirectory("./system-data");
 
-      expect(context.hidePersistentOption).toBe(true);
-    });
-
-    it("should NOT set hidePersistentOption for file operations inside Safe Zone", () => {
-      const context = permissionManager.createContext(
-        "Write",
-        "acceptEdits",
-        undefined,
-        {
-          file_path: path.join(workdir, "test.txt"),
-          workdir,
-        },
-      );
-
-      expect(context.hidePersistentOption).toBeFalsy();
+      const dirs = manager.getSystemAdditionalDirectories();
+      expect(dirs).toContain("/a/system-config");
+      expect(dirs).toContain("/a/system-data");
     });
   });
 });

--- a/packages/agent-sdk/tests/managers/permissionManager.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.test.ts
@@ -2500,7 +2500,7 @@ describe("PermissionManager", () => {
       });
     });
 
-    it("should use current workdir in isInsideSafeZone after dynamic change", async () => {
+    it("should keep original workdir as safe zone after dynamic workdir change", async () => {
       const workdir = "/a";
       const container = createContainer(workdir);
       const manager = new PermissionManager(container, {
@@ -2521,7 +2521,7 @@ describe("PermissionManager", () => {
       // Update workdir to /c
       container.register("Workdir", "/c");
 
-      // File /a/test.txt should no longer be inside workdir safe zone
+      // File /a/test.txt should still be inside safe zone (anchored to original workdir)
       const context2: ToolPermissionContext = {
         toolName: "Write",
         permissionMode: "acceptEdits",
@@ -2529,10 +2529,10 @@ describe("PermissionManager", () => {
       };
 
       expect(await manager.checkPermission(context2)).toMatchObject({
-        behavior: "deny",
+        behavior: "allow",
       });
 
-      // File /c/test.txt should be inside the new safe zone
+      // File /c/test.txt should NOT be inside safe zone (not in original workdir)
       const context3: ToolPermissionContext = {
         toolName: "Write",
         permissionMode: "acceptEdits",
@@ -2540,7 +2540,7 @@ describe("PermissionManager", () => {
       };
 
       expect(await manager.checkPermission(context3)).toMatchObject({
-        behavior: "allow",
+        behavior: "deny",
       });
     });
 
@@ -2558,7 +2558,7 @@ describe("PermissionManager", () => {
       expect(childContainer.get<string>("Workdir")).toBe("/b");
     });
 
-    it("should update additionalDirectories resolution when workdir changes", () => {
+    it("should resolve additionalDirectories against original workdir even when workdir changes", () => {
       const workdir = "/a";
       const container = createContainer(workdir);
       const manager = new PermissionManager(container);
@@ -2566,15 +2566,15 @@ describe("PermissionManager", () => {
       // Add relative additional directory
       manager.updateAdditionalDirectories(["./config"]);
 
-      // Should resolve relative to /a
+      // Should resolve relative to /a (original workdir)
       expect(manager.getAdditionalDirectories()).toContain("/a/config");
 
       // Change workdir
       container.register("Workdir", "/b");
 
-      // Add another relative directory - should now resolve to /b
+      // Add another relative directory - should still resolve to /a (original workdir)
       manager.updateAdditionalDirectories(["./data"]);
-      expect(manager.getAdditionalDirectories()).toContain("/b/data");
+      expect(manager.getAdditionalDirectories()).toContain("/a/data");
     });
   });
 


### PR DESCRIPTION
## Summary

Fix three places in PermissionManager that used the dynamic workdir instead of the original workdir:

1. **isInsideSafeZone** — safe zone now stays anchored to original workdir, so sibling dirs like `./backend` remain safe after `cd ./frontend`
2. **updateAdditionalDirectories** — relative config paths (e.g. `./backend`) resolve against original workdir, preventing wrong paths on config reload
3. **addSystemAdditionalDirectory** — same fix for system-level additional directories

## Tests

- Updated existing test to expect original-workdir resolution
- Added 6 new tests in `permissionManager.safeZone.test.ts` covering safe zone behavior after workdir changes