### PR TITLE
feat: show last 30 chars for streaming text blocks

### DIFF
--- a/packages/code/src/components/MessageBlockItem.tsx
+++ b/packages/code/src/components/MessageBlockItem.tsx
@@ -38,6 +38,13 @@ export const MessageBlockItem = ({
             >
               {block.content}
             </Text>
+          ) : block.stage === "streaming" ? (
+            <Text color="gray" wrap="truncate-end">
+              {(() => {
+                const flat = block.content.replace(/\n/g, "\\n");
+                return flat.length > 30 ? `…${flat.slice(-30)}` : flat;
+              })()}
+            </Text>
           ) : (
             <Markdown>{block.content}</Markdown>
           )}

--- a/packages/code/tests/components/MessageBlockItem.test.tsx
+++ b/packages/code/tests/components/MessageBlockItem.test.tsx
@@ -135,4 +135,110 @@ describe("MessageBlockItem Component", () => {
       expect(lastFrame()).toContain("MOCKED_REASONING");
     });
   });
+
+  describe("Text Block Streaming", () => {
+    const createAssistantMessage = (): Message => ({
+      id: "test-id",
+      role: "assistant",
+      blocks: [],
+    });
+
+    it("should show last 30 chars with ellipsis when streaming and content is long", () => {
+      const message: Message = createAssistantMessage();
+      const block: MessageBlock = {
+        type: "text",
+        content:
+          "This is a very long streaming message that should be truncated",
+        stage: "streaming",
+      };
+      const { lastFrame } = render(
+        <MessageBlockItem block={block} message={message} isExpanded={false} />,
+      );
+      const frame = lastFrame();
+      expect(frame).toContain("…");
+      expect(frame).toContain("that should be truncated");
+    });
+
+    it("should show full content when streaming and content is short", () => {
+      const message: Message = createAssistantMessage();
+      const block: MessageBlock = {
+        type: "text",
+        content: "short",
+        stage: "streaming",
+      };
+      const { lastFrame } = render(
+        <MessageBlockItem block={block} message={message} isExpanded={false} />,
+      );
+      expect(lastFrame()).toContain("short");
+    });
+
+    it("should flatten newlines when streaming", () => {
+      const message: Message = createAssistantMessage();
+      const block: MessageBlock = {
+        type: "text",
+        content: "line1\nline2\nline3\nthis is the end of the stream",
+        stage: "streaming",
+      };
+      const { lastFrame } = render(
+        <MessageBlockItem block={block} message={message} isExpanded={false} />,
+      );
+      const frame = lastFrame();
+      // Newlines should be replaced with literal \n in the displayed text
+      expect(frame).toContain("end of the stream");
+      expect(frame).toContain("…");
+    });
+
+    it("should use Markdown when stage is not streaming", () => {
+      const message: Message = createAssistantMessage();
+      const block: MessageBlock = {
+        type: "text",
+        content: "**bold** text",
+        stage: "end",
+      };
+      const { lastFrame } = render(
+        <MessageBlockItem block={block} message={message} isExpanded={false} />,
+      );
+      expect(lastFrame()).toContain("**bold** text");
+    });
+
+    it("should use Markdown when stage is undefined", () => {
+      const message: Message = createAssistantMessage();
+      const block: MessageBlock = {
+        type: "text",
+        content: "**bold** text",
+      };
+      const { lastFrame } = render(
+        <MessageBlockItem block={block} message={message} isExpanded={false} />,
+      );
+      expect(lastFrame()).toContain("**bold** text");
+    });
+
+    it("should show full content when user message is streaming", () => {
+      const message: Message = { id: "test-id", role: "user", blocks: [] };
+      const block: MessageBlock = {
+        type: "text",
+        content: "user streaming content that is very long",
+        stage: "streaming",
+      };
+      const { lastFrame } = render(
+        <MessageBlockItem block={block} message={message} isExpanded={false} />,
+      );
+      expect(lastFrame()).toContain("user streaming content that is very long");
+    });
+
+    it("should show full content when expanded and streaming", () => {
+      const message: Message = createAssistantMessage();
+      const block: MessageBlock = {
+        type: "text",
+        content: "expanded streaming content that is very long",
+        stage: "streaming",
+      };
+      const { lastFrame } = render(
+        <MessageBlockItem block={block} message={message} isExpanded={true} />,
+      );
+      expect(lastFrame()).toContain(
+        "expanded streaming content that is very long",
+      );
+    });
+  });
 });

--- a/specs/027-message-rendering-system/contracts/message-block-item.md
+++ b/specs/027-message-rendering-system/contracts/message-block-item.md
@@ -23,6 +23,7 @@ The component switches on `block.type` to render the appropriate UI:
 
 - **text**:
   - If `message.role === "user"` or `isExpanded`, renders as plain text (with background for user messages).
+  - If `block.stage === "streaming"` (assistant, collapsed), shows last 30 characters with gray color and truncation (matching tool/reasoning streaming behavior).
   - Otherwise, renders using the `Markdown` component.
   - Supports `HOOK` source prefix (`~ `).
 - **slash**: Delegates to `SlashDisplay`.

--- a/specs/027-message-rendering-system/quickstart.md
+++ b/specs/027-message-rendering-system/quickstart.md
@@ -13,7 +13,7 @@ The top-level component that renders the entire conversation.
 
 ### MessageBlockItem
 A dispatcher component that renders individual blocks based on their type:
-- **Text**: Rendered as Markdown or plain text.
+- **Text**: Rendered as Markdown when complete, last 30 chars with gray color when streaming (matching tool/reasoning behavior), or plain text for user messages.
 - **Tool**: Displays tool parameters and results.
 - **Bang**: Displays shell command output.
 - **Error**: Displays error messages in red.

--- a/specs/027-message-rendering-system/spec.md
+++ b/specs/027-message-rendering-system/spec.md
@@ -45,10 +45,12 @@ As a user, I want different types of content (text, code, errors, images, tool c
 **Independent Test**: Render a message containing one of each block type and verify they all display correctly.
 
 **Acceptance Scenarios**:
-1. **Given** a text block, **When** rendered, **Then** it is displayed as markdown or plain text depending on the context.
-2. **Given** an error block, **When** rendered, **Then** it is displayed in red with an "Error:" prefix.
-3. **Given** a tool block, **When** rendered, **Then** it uses a specialized `ToolDisplay` component.
-4. **Given** an image block, **When** rendered, **Then** it shows a placeholder or summary of the image.
+1. **Given** a text block with `stage === "streaming"`, **When** rendered in collapsed mode, **Then** it shows the last 30 characters with gray color and truncation (matching tool and reasoning block streaming behavior).
+2. **Given** a text block with `stage !== "streaming"` (e.g., `end` or undefined), **When** rendered, **Then** it is displayed using Markdown rendering.
+3. **Given** a text block in a user message, **When** rendered, **Then** it shows full content regardless of stage.
+4. **Given** an error block, **When** rendered, **Then** it is displayed in red with an "Error:" prefix.
+5. **Given** a tool block, **When** rendered, **Then** it uses a specialized `ToolDisplay` component.
+6. **Given** an image block, **When** rendered, **Then** it shows a placeholder or summary of the image.
 
 ---
 


### PR DESCRIPTION
Text blocks now display the last 30 characters with gray color and truncate-end wrap when streaming, matching the behavior of ToolDisplay and ReasoningDisplay for UI consistency.

- Add streaming stage check in MessageBlockItem text rendering
- Flatten newlines to literal \n for compact display
- Add 7 test cases covering streaming, user messages, and expanded state
- Update spec, contract, and quickstart documentation