### PR TITLE
fix: always provide permission callback to support mode switching

### DIFF
--- a/packages/agent-sdk/tests/managers/permissionManager.acceptEdits.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.acceptEdits.test.ts
@@ -73,6 +73,52 @@ describe("PermissionManager - acceptEdits mode", () => {
     });
   });
 
+  describe("mode switching from bypassPermissions to acceptEdits", () => {
+    it("should use callback for Bash when mode changes from bypassPermissions to acceptEdits", async () => {
+      const mockCallback = vi.fn().mockResolvedValue({
+        behavior: "allow",
+      }) as unknown as PermissionCallback;
+
+      // In bypassPermissions mode, Bash is allowed regardless of callback
+      const bypassContext: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "bypassPermissions",
+        canUseToolCallback: mockCallback,
+      };
+      const bypassResult =
+        await permissionManager.checkPermission(bypassContext);
+      expect(bypassResult).toEqual({ behavior: "allow" });
+      // Callback should NOT be called in bypassPermissions mode
+      expect(vi.mocked(mockCallback)).not.toHaveBeenCalled();
+
+      // After switching to acceptEdits mode, Bash is not auto-accepted,
+      // so the callback should be invoked
+      vi.mocked(mockCallback).mockClear();
+      const acceptEditsContext: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "acceptEdits",
+        canUseToolCallback: mockCallback,
+      };
+      const acceptEditsResult =
+        await permissionManager.checkPermission(acceptEditsContext);
+      expect(acceptEditsResult).toEqual({ behavior: "allow" });
+      expect(vi.mocked(mockCallback)).toHaveBeenCalled();
+    });
+
+    it("should deny Bash in acceptEdits mode when callback is not provided", async () => {
+      // Without a callback, acceptEdits mode falls through to deny with a warning
+      const context: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "acceptEdits",
+        // canUseToolCallback is undefined
+      };
+
+      const result = await permissionManager.checkPermission(context);
+      expect(result.behavior).toBe("deny");
+      expect(result.message).toContain("requires permission approval");
+    });
+  });
+
   describe("resolveEffectivePermissionMode with acceptEdits", () => {
     it("should correctly resolve effective mode when acceptEdits is set as configured default", () => {
       const manager = new PermissionManager(container, {

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -378,27 +378,25 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
 
       try {
         // Create the permission callback inside the try block to access showConfirmation
-        const permissionCallback = bypassPermissions
-          ? undefined
-          : async (
-              context: ToolPermissionContext,
-            ): Promise<PermissionDecision> => {
-              try {
-                return await showConfirmation(
-                  context.toolName,
-                  context.toolInput,
-                  context.suggestedPrefix,
-                  context.hidePersistentOption,
-                  context.planContent,
-                );
-              } catch {
-                // If confirmation was cancelled or failed, deny the operation
-                return {
-                  behavior: "deny",
-                  message: OPERATION_CANCELLED_BY_USER,
-                };
-              }
+        const permissionCallback = async (
+          context: ToolPermissionContext,
+        ): Promise<PermissionDecision> => {
+          try {
+            return await showConfirmation(
+              context.toolName,
+              context.toolInput,
+              context.suggestedPrefix,
+              context.hidePersistentOption,
+              context.planContent,
+            );
+          } catch {
+            // If confirmation was cancelled or failed, deny the operation
+            return {
+              behavior: "deny",
+              message: OPERATION_CANCELLED_BY_USER,
             };
+          }
+        };
 
         const agent = await Agent.create({
           callbacks,

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -437,7 +437,10 @@ describe("ChatProvider", () => {
   });
 
   it("handles bypassPermissions prop", async () => {
-    const onHookValue = () => {};
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
 
     renderWithProvider(onHookValue, { bypassPermissions: true });
 
@@ -445,10 +448,51 @@ describe("ChatProvider", () => {
       expect(Agent.create).toHaveBeenCalledWith(
         expect.objectContaining({
           permissionMode: "bypassPermissions",
-          canUseTool: undefined,
         }),
       );
     });
+
+    // canUseTool callback should still be provided so it can be used
+    // when the user switches to another permission mode
+    const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
+    expect(agentCreateArgs.canUseTool).toBeDefined();
+    expect(lastValue?.permissionMode).toBe("bypassPermissions");
+  });
+
+  it("provides canUseTool callback when started with bypassPermissions so mode switching works", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue, { bypassPermissions: true });
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    // Verify callback is defined even when bypassPermissions is true
+    const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
+    const canUseTool = agentCreateArgs.canUseTool;
+    expect(canUseTool).toBeDefined();
+
+    // Simulate calling the callback as would happen when permissionMode is
+    // changed from bypassPermissions to acceptEdits and a restricted tool
+    // (Bash) needs confirmation
+    const decisionPromise = canUseTool!({
+      toolName: "Bash",
+      toolInput: { command: "ls -la" },
+      permissionMode: "acceptEdits",
+    });
+
+    await vi.waitFor(() => {
+      expect(lastValue?.isConfirmationVisible).toBe(true);
+    });
+
+    // Accept the confirmation to resolve the promise
+    lastValue?.handleConfirmationDecision({ behavior: "allow" });
+    const decision = await decisionPromise;
+    expect(decision).toEqual({ behavior: "allow" });
   });
 
   it("handles pluginDirs prop", async () => {


### PR DESCRIPTION
## Problem

When starting wave-code with `--dangerously-skip-permissions`, the `permissionCallback` was set to `undefined`. If the user later switched to another mode (e.g., `acceptEdits`), restricted tools like Bash would fail with:

```
[WARN] No permission callback provided for restricted tool in default mode {"toolName":"Bash"}
```

This happened because `acceptEdits` only auto-accepts `Edit` and `Write`. For other restricted tools, it falls through to the callback, which was `undefined`.

## Fix

Always provide the permission callback to `Agent.create()`, regardless of `bypassPermissions`. In `bypassPermissions` mode the callback is never invoked (`PermissionManager` returns `allow` before reaching it), but it becomes available when the user switches to another permission mode.

## Tests

- Updated `useChat.test.tsx`: verify callback is provided even when `bypassPermissions: true`
- Added test: simulates calling callback after mode switch from `bypassPermissions` to `acceptEdits`
- Added tests in `permissionManager.acceptEdits.test.ts`: verify callback behavior during mode switching