### PR TITLE
feat: add removeAt method to MessageQueue

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -333,6 +333,19 @@ export class Agent {
   }
 
   /**
+   * Remove a queued message by index
+   * @param index - The index of the message to remove
+   * @returns true if the message was removed, false if the index was out of bounds
+   */
+  public removeQueuedMessage(index: number): boolean {
+    const removed = this.messageQueue.removeAt(index);
+    if (removed) {
+      this.options.callbacks?.onQueuedMessagesChange?.(this.queuedMessages);
+    }
+    return removed;
+  }
+
+  /**
    * Process the next queued message when the agent becomes idle.
    * Dequeues the next message and handles it based on type.
    */

--- a/packages/agent-sdk/src/managers/messageQueue.ts
+++ b/packages/agent-sdk/src/managers/messageQueue.ts
@@ -29,4 +29,13 @@ export class MessageQueue {
   getQueue(): QueuedMessage[] {
     return [...this.queue];
   }
+
+  removeAt(index: number): boolean {
+    if (index < 0 || index >= this.queue.length) {
+      return false;
+    }
+    this.queue.splice(index, 1);
+    this.onMessageEnqueued?.();
+    return true;
+  }
 }

--- a/packages/agent-sdk/tests/managers/messageQueue.test.ts
+++ b/packages/agent-sdk/tests/managers/messageQueue.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from "vitest";
+import { MessageQueue } from "../../src/managers/messageQueue.js";
+
+describe("MessageQueue", () => {
+  describe("removeAt", () => {
+    it("should remove a message at a valid index", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "msg1" });
+      queue.enqueue({ content: "msg2" });
+      queue.enqueue({ content: "msg3" });
+
+      const result = queue.removeAt(1);
+
+      expect(result).toBe(true);
+      expect(queue.getQueue()).toHaveLength(2);
+      expect(queue.getQueue()[0].content).toBe("msg1");
+      expect(queue.getQueue()[1].content).toBe("msg3");
+    });
+
+    it("should return false for negative index", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "msg1" });
+
+      const result = queue.removeAt(-1);
+
+      expect(result).toBe(false);
+      expect(queue.getQueue()).toHaveLength(1);
+    });
+
+    it("should return false for index >= length", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "msg1" });
+
+      const result = queue.removeAt(1);
+
+      expect(result).toBe(false);
+      expect(queue.getQueue()).toHaveLength(1);
+    });
+
+    it("should call onMessageEnqueued callback after removal", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "msg1" });
+      queue.enqueue({ content: "msg2" });
+
+      const callback = vi.fn();
+      queue.onMessageEnqueued = callback;
+
+      queue.removeAt(0);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle removal from single-element queue", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "only" });
+
+      const result = queue.removeAt(0);
+
+      expect(result).toBe(true);
+      expect(queue.getQueue()).toHaveLength(0);
+    });
+
+    it("should return correct state after removal", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a" });
+      queue.enqueue({ content: "b" });
+      queue.enqueue({ content: "c" });
+      queue.enqueue({ content: "d" });
+
+      queue.removeAt(2);
+
+      const remaining = queue.getQueue();
+      expect(remaining.map((m: { content: string }) => m.content)).toEqual([
+        "a",
+        "b",
+        "d",
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Add removeAt(index) to MessageQueue for removing queued messages by index.
Expose removeQueuedMessage(index) on the Agent public API.
Include tests for valid removal, bounds checking, callback firing, and state.