### PR TITLE
fix: remove onAbort call from Esc handler in ConfirmationSelector

### DIFF
--- a/packages/code/examples/Confirmation.tsx
+++ b/packages/code/examples/Confirmation.tsx
@@ -25,18 +25,12 @@ const ExampleApp: React.FC = () => {
   );
   const [cancelled, setCancelled] = React.useState(false);
 
-  const [aborted, setAborted] = React.useState(false);
-
   const handleDecision = (decision: PermissionDecision) => {
     setDecision(decision);
   };
 
   const handleCancel = () => {
     setCancelled(true);
-  };
-
-  const handleAbort = () => {
-    setAborted(true);
   };
 
   if (decision) {
@@ -51,10 +45,10 @@ const ExampleApp: React.FC = () => {
     );
   }
 
-  if (cancelled || aborted) {
+  if (cancelled) {
     return (
       <Box padding={1}>
-        <Text color="red">Operation {cancelled ? "cancelled" : "aborted"}</Text>
+        <Text color="red">Operation cancelled</Text>
       </Box>
     );
   }
@@ -70,7 +64,6 @@ const ExampleApp: React.FC = () => {
           toolName="Edit"
           onDecision={handleDecision}
           onCancel={handleCancel}
-          onAbort={handleAbort}
         />
       </Box>
     </Box>

--- a/packages/code/src/components/ChatInterface.tsx
+++ b/packages/code/src/components/ChatInterface.tsx
@@ -133,7 +133,6 @@ export const ChatInterface: React.FC = () => {
             isExpanded={isExpanded}
             onDecision={handleConfirmationDecision}
             onCancel={handleConfirmationCancel}
-            onAbort={abortMessage}
           />
         </>
       )}

--- a/packages/code/src/components/ConfirmationSelector.tsx
+++ b/packages/code/src/components/ConfirmationSelector.tsx
@@ -25,7 +25,6 @@ export interface ConfirmationSelectorProps {
   isExpanded?: boolean;
   onDecision: (decision: PermissionDecision) => void;
   onCancel: () => void;
-  onAbort: () => void;
 }
 
 interface ConfirmationState {
@@ -43,7 +42,6 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
   isExpanded = false,
   onDecision,
   onCancel,
-  onAbort,
 }) => {
   const [state, setState] = useState<ConfirmationState>({
     selectedOption: toolName === EXIT_PLAN_MODE_TOOL_NAME ? "clear" : "allow",
@@ -107,7 +105,6 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
   useInput((input, key) => {
     if (key.escape) {
       onCancel();
-      onAbort();
       return;
     }
 

--- a/packages/code/tests/components/Confirmation.border.test.tsx
+++ b/packages/code/tests/components/Confirmation.border.test.tsx
@@ -24,12 +24,10 @@ const Confirmation = (
 describe("Confirmation Border", () => {
   let mockOnDecision: Mock<(decision: PermissionDecision) => void>;
   let mockOnCancel: Mock<() => void>;
-  let mockOnAbort: Mock<() => void>;
 
   beforeEach(() => {
     mockOnDecision = vi.fn<(decision: PermissionDecision) => void>();
     mockOnCancel = vi.fn<() => void>();
-    mockOnAbort = vi.fn<() => void>();
     vi.clearAllMocks();
   });
 
@@ -39,7 +37,6 @@ describe("Confirmation Border", () => {
         toolName="Edit"
         onDecision={mockOnDecision}
         onCancel={mockOnCancel}
-        onAbort={mockOnAbort}
       />,
     );
 
@@ -72,7 +69,6 @@ describe("Confirmation Border", () => {
         planContent="**Test** Plan Content"
         onDecision={mockOnDecision}
         onCancel={mockOnCancel}
-        onAbort={mockOnAbort}
       />,
     );
 

--- a/packages/code/tests/components/Confirmation.dynamic.test.tsx
+++ b/packages/code/tests/components/Confirmation.dynamic.test.tsx
@@ -26,7 +26,6 @@ const Confirmation = (
 describe("Confirmation Dynamic Actions", () => {
   const mockOnDecision = vi.fn();
   const mockOnCancel = vi.fn();
-  const mockOnAbort = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -39,7 +38,6 @@ describe("Confirmation Dynamic Actions", () => {
         toolInput={{ command: "pwd", description: "Show current directory" }}
         onDecision={mockOnDecision}
         onCancel={mockOnCancel}
-        onAbort={mockOnAbort}
       />,
     );
 
@@ -59,7 +57,6 @@ describe("Confirmation Dynamic Actions", () => {
         }}
         onDecision={mockOnDecision}
         onCancel={mockOnCancel}
-        onAbort={mockOnAbort}
       />,
     );
 
@@ -78,7 +75,6 @@ describe("Confirmation Dynamic Actions", () => {
         }}
         onDecision={mockOnDecision}
         onCancel={mockOnCancel}
-        onAbort={mockOnAbort}
       />,
     );
 
@@ -94,7 +90,6 @@ describe("Confirmation Dynamic Actions", () => {
         toolInput={{ some_param: "value" }}
         onDecision={mockOnDecision}
         onCancel={mockOnCancel}
-        onAbort={mockOnAbort}
       />,
     );
 
@@ -109,7 +104,6 @@ describe("Confirmation Dynamic Actions", () => {
         toolName="Bash"
         onDecision={mockOnDecision}
         onCancel={mockOnCancel}
-        onAbort={mockOnAbort}
       />,
     );
 
@@ -125,7 +119,6 @@ describe("Confirmation Dynamic Actions", () => {
         toolInput={{ old_string: "old", new_string: "new" }}
         onDecision={mockOnDecision}
         onCancel={mockOnCancel}
-        onAbort={mockOnAbort}
       />,
     );
 

--- a/packages/code/tests/components/Confirmation.test.tsx
+++ b/packages/code/tests/components/Confirmation.test.tsx
@@ -23,13 +23,11 @@ import type { PermissionDecision } from "wave-agent-sdk";
 describe("Confirmation", () => {
   let mockOnDecision: Mock<(decision: PermissionDecision) => void>;
   let mockOnCancel: Mock<() => void>;
-  let mockOnAbort: Mock<() => void>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     mockOnDecision = vi.fn<(decision: PermissionDecision) => void>();
     mockOnCancel = vi.fn<() => void>();
-    mockOnAbort = vi.fn<() => void>();
 
     // Mock console methods to suppress output during testing
     consoleSpy = vi.spyOn(console, "log").mockImplementation(function () {});
@@ -60,7 +58,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -80,7 +77,6 @@ describe("Confirmation", () => {
           toolName="Write"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -101,7 +97,6 @@ describe("Confirmation", () => {
           toolName="Write"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -121,7 +116,6 @@ describe("Confirmation", () => {
           toolName="Bash"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -142,7 +136,6 @@ describe("Confirmation", () => {
           toolInput={{ command: "ls -la" }}
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -169,7 +162,6 @@ describe("Confirmation", () => {
           hidePersistentOption={true}
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -190,7 +182,6 @@ describe("Confirmation", () => {
           toolInput={{ arg1: "val1", arg2: 42 }}
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -215,7 +206,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -249,7 +239,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -293,7 +282,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -317,7 +305,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -341,7 +328,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -371,7 +357,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -406,7 +391,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -445,7 +429,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -490,7 +473,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -525,7 +507,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -556,7 +537,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -609,7 +589,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -632,7 +611,6 @@ describe("Confirmation", () => {
           toolName="Write"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -658,13 +636,12 @@ describe("Confirmation", () => {
       } as PermissionDecision);
     });
 
-    it("should call onCancel and onAbort callbacks on ESC", async () => {
+    it("should call onCancel callback on ESC without calling onDecision", async () => {
       const { stdin, lastFrame } = render(
         <Confirmation
           toolName="Write"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -676,7 +653,6 @@ describe("Confirmation", () => {
       await vi.waitFor(() => {
         expect(mockOnCancel).toHaveBeenCalledTimes(1);
       });
-      expect(mockOnAbort).toHaveBeenCalledTimes(1);
       expect(mockOnDecision).not.toHaveBeenCalled();
     });
 
@@ -686,7 +662,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -722,7 +697,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -759,7 +733,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -792,7 +765,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -831,7 +803,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -858,7 +829,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -883,7 +853,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -927,7 +896,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -963,7 +931,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -986,7 +953,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -1025,7 +991,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -1071,7 +1036,6 @@ describe("Confirmation", () => {
           toolInput={mockQuestions as unknown as Record<string, unknown>}
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -1093,7 +1057,6 @@ describe("Confirmation", () => {
           toolInput={mockQuestions as unknown as Record<string, unknown>}
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -1126,7 +1089,6 @@ describe("Confirmation", () => {
           toolInput={mockQuestions as unknown as Record<string, unknown>}
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -1171,7 +1133,6 @@ describe("Confirmation", () => {
           toolInput={mockQuestions as unknown as Record<string, unknown>}
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -1220,7 +1181,6 @@ describe("Confirmation", () => {
           toolInput={mockQuestions as unknown as Record<string, unknown>}
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -1268,7 +1228,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -1304,7 +1263,6 @@ describe("Confirmation", () => {
           planContent="My Plan"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -1323,7 +1281,6 @@ describe("Confirmation", () => {
           planContent="My Plan"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -1350,7 +1307,6 @@ describe("Confirmation", () => {
           planContent="My Plan"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
       stdin2.write("\u001b[B"); // Down to manually approve
@@ -1376,7 +1332,6 @@ describe("Confirmation", () => {
           planContent="My Plan"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
       stdin3.write("\u001b[B"); // Down to manually approve
@@ -1410,7 +1365,6 @@ describe("Confirmation", () => {
           suggestedPrefix="ls"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -1429,7 +1383,6 @@ describe("Confirmation", () => {
           suggestedPrefix="ls"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -1461,7 +1414,6 @@ describe("Confirmation", () => {
           toolInput={{ command: "ls -la" }}
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -1492,7 +1444,6 @@ describe("Confirmation", () => {
           toolName="Edit"
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -1541,7 +1492,6 @@ describe("Confirmation", () => {
           hidePersistentOption={true}
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 
@@ -1584,7 +1534,6 @@ describe("Confirmation", () => {
           toolInput={localMockQuestions as unknown as Record<string, unknown>}
           onDecision={mockOnDecision}
           onCancel={mockOnCancel}
-          onAbort={mockOnAbort}
         />,
       );
 

--- a/packages/code/tests/components/ConfirmationTab.test.tsx
+++ b/packages/code/tests/components/ConfirmationTab.test.tsx
@@ -16,13 +16,11 @@ import type { PermissionDecision } from "wave-agent-sdk";
 describe("Confirmation Tab Navigation", () => {
   let mockOnDecision: Mock<(decision: PermissionDecision) => void>;
   let mockOnCancel: Mock<() => void>;
-  let mockOnAbort: Mock<() => void>;
 
   beforeEach(() => {
     vi.useFakeTimers();
     mockOnDecision = vi.fn<(decision: PermissionDecision) => void>();
     mockOnCancel = vi.fn<() => void>();
-    mockOnAbort = vi.fn<() => void>();
     vi.clearAllMocks();
   });
 
@@ -36,7 +34,6 @@ describe("Confirmation Tab Navigation", () => {
         toolName="Edit"
         onDecision={mockOnDecision}
         onCancel={mockOnCancel}
-        onAbort={mockOnAbort}
       />,
     );
 
@@ -54,7 +51,6 @@ describe("Confirmation Tab Navigation", () => {
         toolName="Edit"
         onDecision={mockOnDecision}
         onCancel={mockOnCancel}
-        onAbort={mockOnAbort}
       />,
     );
 
@@ -96,7 +92,6 @@ describe("Confirmation Tab Navigation", () => {
         toolInput={mockQuestions as unknown as Record<string, unknown>}
         onDecision={mockOnDecision}
         onCancel={mockOnCancel}
-        onAbort={mockOnAbort}
       />,
     );
 
@@ -134,7 +129,6 @@ describe("Confirmation Tab Navigation", () => {
         toolInput={mockQuestions as unknown as Record<string, unknown>}
         onDecision={mockOnDecision}
         onCancel={mockOnCancel}
-        onAbort={mockOnAbort}
       />,
     );
 
@@ -174,7 +168,6 @@ describe("Confirmation Tab Navigation", () => {
         toolInput={mockQuestions as unknown as Record<string, unknown>}
         onDecision={mockOnDecision}
         onCancel={mockOnCancel}
-        onAbort={mockOnAbort}
       />,
     );
 
@@ -215,7 +208,6 @@ describe("Confirmation Tab Navigation", () => {
         toolInput={mockQuestions as unknown as Record<string, unknown>}
         onDecision={mockOnDecision}
         onCancel={mockOnCancel}
-        onAbort={mockOnAbort}
       />,
     );
 
@@ -258,7 +250,6 @@ describe("Confirmation Tab Navigation", () => {
         toolInput={mockQuestions as unknown as Record<string, unknown>}
         onDecision={mockOnDecision}
         onCancel={mockOnCancel}
-        onAbort={mockOnAbort}
       />,
     );
 
@@ -277,7 +268,6 @@ describe("Confirmation Tab Navigation", () => {
         toolName="Edit"
         onDecision={mockOnDecision}
         onCancel={mockOnCancel}
-        onAbort={mockOnAbort}
       />,
     );
 
@@ -305,7 +295,6 @@ describe("Confirmation Tab Navigation", () => {
         toolInput={mockQuestions as unknown as Record<string, unknown>}
         onDecision={mockOnDecision}
         onCancel={mockOnCancel}
-        onAbort={mockOnAbort}
       />,
     );
 

--- a/packages/code/tests/integration/ConfirmationSelectorEsc.test.tsx
+++ b/packages/code/tests/integration/ConfirmationSelectorEsc.test.tsx
@@ -1,0 +1,302 @@
+import { render } from "ink-testing-library";
+import React, { useEffect } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  ChatProvider,
+  useChat,
+  ChatContextType,
+} from "../../src/contexts/useChat.js";
+import { Agent } from "wave-agent-sdk";
+import { AppProvider } from "../../src/contexts/useAppConfig.js";
+import { useInput } from "ink";
+import {
+  ConfirmationDetails,
+  type ConfirmationDetailsProps,
+} from "../../src/components/ConfirmationDetails.js";
+import {
+  ConfirmationSelector,
+  type ConfirmationSelectorProps,
+} from "../../src/components/ConfirmationSelector.js";
+import { stripAnsiColors } from "wave-agent-sdk";
+
+// Mock ink
+vi.mock("ink", async () => {
+  const actual = await vi.importActual<typeof import("ink")>("ink");
+  return {
+    ...actual,
+    useInput: vi.fn(),
+    useStdout: vi.fn(() => ({
+      stdout: {
+        write: (_data: string, callback?: () => void) => {
+          callback?.();
+        },
+      },
+    })),
+  };
+});
+
+// Mock wave-agent-sdk
+vi.mock("wave-agent-sdk", async () => {
+  const actual = await vi.importActual("wave-agent-sdk");
+  return {
+    ...actual,
+    Agent: {
+      create: vi.fn(),
+    },
+  };
+});
+
+// Mock useAppConfig
+vi.mock("../../src/contexts/useAppConfig.js", async () => {
+  const actual = await vi.importActual("../../src/contexts/useAppConfig.js");
+  return {
+    ...actual,
+    useAppConfig: vi.fn(() => ({
+      restoreSessionId: undefined,
+      continueLastSession: false,
+    })),
+  };
+});
+
+// Mock logger
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock usageSummary
+vi.mock("../../src/utils/usageSummary.js", () => ({
+  displayUsageSummary: vi.fn(),
+}));
+
+const Confirmation = (
+  props: ConfirmationSelectorProps & ConfirmationDetailsProps,
+) => (
+  <>
+    <ConfirmationDetails {...props} />
+    <ConfirmationSelector {...props} />
+  </>
+);
+
+// Component that renders ConfirmationSelector when confirmation is visible
+function ConfirmationView() {
+  const {
+    isConfirmationVisible,
+    confirmingTool,
+    handleConfirmationDecision,
+    handleConfirmationCancel,
+  } = useChat();
+
+  if (!isConfirmationVisible || !confirmingTool) {
+    return null;
+  }
+
+  return (
+    <Confirmation
+      toolName={confirmingTool.name}
+      toolInput={confirmingTool.input}
+      planContent={confirmingTool.planContent}
+      onDecision={handleConfirmationDecision}
+      onCancel={handleConfirmationCancel}
+    />
+  );
+}
+
+function TestComponent({
+  onHookValue,
+}: {
+  onHookValue: (value: ChatContextType) => void;
+}) {
+  const hookValue = useChat();
+  useEffect(() => {
+    onHookValue(hookValue);
+  }, [hookValue, onHookValue]);
+  return null;
+}
+
+describe("ConfirmationSelector Esc Integration", () => {
+  const mockAgent = {
+    sessionId: "test-session",
+    messages: [],
+    isLoading: false,
+    latestTotalTokens: 0,
+    isCommandRunning: false,
+    isCompressing: false,
+    userInputHistory: [],
+    getPermissionMode: vi.fn(() => "default"),
+    getMcpServers: vi.fn(() => []),
+    getSlashCommands: vi.fn(() => []),
+    sendMessage: vi.fn(),
+    bang: vi.fn(),
+    abortMessage: vi.fn(),
+    connectMcpServer: vi.fn(),
+    disconnectMcpServer: vi.fn(),
+    getBackgroundTaskOutput: vi.fn(),
+    stopBackgroundTask: vi.fn(),
+    hasSlashCommand: vi.fn(),
+    truncateHistory: vi.fn(),
+    backgroundCurrentTask: vi.fn(),
+    destroy: vi.fn(),
+    setPermissionMode: vi.fn(),
+    askBtw: vi.fn(),
+    usages: [],
+    sessionFilePath: "test-path",
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    vi.mocked(Agent.create).mockResolvedValue(mockAgent as unknown as Agent);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const renderWithProvider = (
+    onHookValue: (value: ChatContextType) => void,
+    props = {},
+  ) => {
+    return render(
+      <AppProvider>
+        <ChatProvider {...props}>
+          <TestComponent onHookValue={onHookValue} />
+          <ConfirmationView />
+        </ChatProvider>
+      </AppProvider>,
+    );
+  };
+
+  /**
+   * Get the ConfirmationSelector's useInput handler.
+   * ChatProvider registers one handler (Ctrl+O).
+   * ConfirmationSelector registers a second handler (handles Esc, arrows, Enter, etc).
+   * We want the ConfirmationSelector handler since that's where the Esc->onCancel flow lives.
+   */
+  function getConfirmationSelectorInputHandler() {
+    const useInputMock = vi.mocked(useInput);
+    const handlers = useInputMock.mock.calls;
+    // The last registered handler should be from ConfirmationSelector
+    if (handlers.length === 0) return undefined;
+    return handlers[handlers.length - 1][0];
+  }
+
+  it("Esc on ConfirmationSelector should cancel but NOT call abortMessage", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    const { lastFrame } = renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    // Show a confirmation prompt
+    const decisionPromise = lastValue?.showConfirmation("Bash", {
+      command: "ls -la",
+    });
+
+    await vi.waitFor(() => {
+      expect(lastValue?.isConfirmationVisible).toBe(true);
+      expect(lastValue?.confirmingTool?.name).toBe("Bash");
+    });
+
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
+    });
+
+    // Simulate Esc via ConfirmationSelector's useInput handler
+    const handler = getConfirmationSelectorInputHandler()!;
+    handler!("", { escape: true } as Parameters<typeof handler>[1]);
+
+    // Catch the rejection to avoid unhandled promise rejection warnings
+    await decisionPromise!.catch(() => {
+      // Expected: the promise rejects when confirmation is cancelled
+    });
+
+    await vi.waitFor(() => {
+      expect(lastValue?.isConfirmationVisible).toBe(false);
+    });
+
+    // CRITICAL: Esc cancel must not affect background bash processes
+    expect(mockAgent.abortMessage).not.toHaveBeenCalled();
+  });
+
+  it("Esc on ExitPlanMode ConfirmationSelector should only cancel, not abort", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    const { lastFrame } = renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    const decisionPromise = lastValue?.showConfirmation("ExitPlanMode", {});
+
+    await vi.waitFor(() => {
+      expect(lastValue?.isConfirmationVisible).toBe(true);
+    });
+
+    await vi.waitFor(() => {
+      expect(stripAnsiColors(lastFrame() || "")).toContain(
+        "> Yes, clear context",
+      );
+    });
+
+    const handler = getConfirmationSelectorInputHandler()!;
+    handler!("", { escape: true } as Parameters<typeof handler>[1]);
+
+    await decisionPromise!.catch(() => {
+      // Expected: the promise rejects when confirmation is cancelled
+    });
+
+    await vi.waitFor(() => {
+      expect(lastValue?.isConfirmationVisible).toBe(false);
+    });
+
+    expect(mockAgent.abortMessage).not.toHaveBeenCalled();
+  });
+
+  it("Confirming via handleConfirmationDecision should NOT call abortMessage", async () => {
+    // This verifies the full confirmation flow (Enter key on "Yes, proceed")
+    // goes through handleConfirmationDecision which should not trigger abortMessage.
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    const decisionPromise = lastValue?.showConfirmation("Bash", {
+      command: "pwd",
+    });
+
+    await vi.waitFor(() => {
+      expect(lastValue?.isConfirmationVisible).toBe(true);
+    });
+
+    // Simulate confirming (same as pressing Enter on "Yes, proceed")
+    lastValue?.handleConfirmationDecision({ behavior: "allow" });
+
+    await vi.waitFor(() => {
+      expect(lastValue?.isConfirmationVisible).toBe(false);
+    });
+
+    const decision = await decisionPromise!;
+    expect(decision).toEqual({ behavior: "allow" });
+    expect(mockAgent.abortMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Pressing Esc on a permission prompt was incorrectly calling `onAbort()` which triggered `abortMessage()` → aborting `toolAbortController` and killing all running background bash tools. Now Esc only cancels the pending confirmation via `onCancel()`.

## Changes

### Fix
- **`ConfirmationSelector.tsx`** — Removed `onAbort()` call from Esc handler, removed `onAbort` from props interface and destructuring

### Consumer Updates
- **`ChatInterface.tsx`** — Removed `onAbort={abortMessage}` prop from `ConfirmationSelector`
- **`examples/Confirmation.tsx`** — Removed `onAbort` state/handler/prop

### Test Updates
- **`Confirmation.test.tsx`** — Updated ESC test to only expect `onCancel`, removed all `onAbort` props
- **`Confirmation.dynamic.test.tsx`** — Removed all `onAbort` props
- **`Confirmation.border.test.tsx`** — Removed all `onAbort` props
- **`ConfirmationTab.test.tsx`** — Removed all `onAbort` props

### New Integration Test
- **`tests/integration/ConfirmationSelectorEsc.test.tsx`** — 3 tests:
  1. Esc on Bash ConfirmationSelector cancels but does NOT call `abortMessage`
  2. Esc on ExitPlanMode ConfirmationSelector cancels but does NOT call `abortMessage`
  3. Confirming via `handleConfirmationDecision` does NOT call `abortMessage`

## Verification
- All 763 tests pass (69 test files)
- Type-check passes cleanly