### PR TITLE
feat: show streaming text blocks in MessageList

### DIFF
--- a/packages/code/src/components/MessageList.tsx
+++ b/packages/code/src/components/MessageList.tsx
@@ -43,23 +43,19 @@ export const MessageList = React.memo(
           b.stage === "streaming" ||
           b.stage === "start")) ||
       (b.type === "bang" && b.stage === "running") ||
-      (b.type === "reasoning" && b.stage === "streaming");
+      (b.type === "reasoning" && b.stage === "streaming") ||
+      (b.type === "text" && b.stage === "streaming");
 
     // Flatten messages into blocks with metadata
-    // Filter out streaming text blocks to avoid frequent height changes,
-    // but allow streaming reasoning blocks (rendered as truncated gray text)
+    // Include streaming text blocks (rendered as truncated gray text)
     const allBlocks = visibleMessages.flatMap((message, messageIndex) => {
-      return message.blocks
-        .filter(
-          (block) => !(block.type === "text" && block.stage === "streaming"),
-        )
-        .map((block, blockIndex) => ({
-          block,
-          message,
-          messageIndex,
-          // Unique key for each block to help Static component
-          key: `${message.id}-${blockIndex}`,
-        }));
+      return message.blocks.map((block, blockIndex) => ({
+        block,
+        message,
+        messageIndex,
+        // Unique key for each block to help Static component
+        key: `${message.id}-${blockIndex}`,
+      }));
     });
 
     // Find message indices that have any running/streaming block

--- a/packages/code/tests/components/MessageList.test.tsx
+++ b/packages/code/tests/components/MessageList.test.tsx
@@ -194,5 +194,28 @@ describe("MessageList Component", () => {
       // Should NOT show hidden message
       expect(output).not.toContain("Hidden - Message 2");
     });
+
+    it("should include streaming text blocks instead of filtering them out", () => {
+      const messages: Message[] = [
+        {
+          id: "msg-1",
+          role: "assistant",
+          blocks: [
+            {
+              type: "text",
+              content: "streaming content",
+              stage: "streaming",
+            },
+          ],
+        },
+      ];
+
+      const { lastFrame } = render(<MessageList messages={messages} />);
+
+      const output = lastFrame();
+
+      // Streaming text block should be visible (truncated to last 30 chars)
+      expect(output).toContain("streaming content");
+    });
   });
 });

--- a/specs/027-message-rendering-system/contracts/message-list.md
+++ b/specs/027-message-rendering-system/contracts/message-list.md
@@ -31,7 +31,7 @@ export interface MessageListProps {
 2. **Message Flattening**: Converts the nested `messages -> blocks` structure into a flat list of blocks for rendering.
 3. **Static vs Dynamic Split**:
    - Blocks that are not the last message are typically considered **static**, unless they contain active tool/command executions.
-   - Blocks are considered **dynamic** ONLY IF `forceStatic` is false AND `isExpanded` is false AND they belong to a message with active blocks (e.g., tool in `running`/`streaming`/`start` stage, or `bang` in `running` stage) AND the block itself is not a completed `text` or `reasoning` block (`stage === "end"`).
+   - Blocks are considered **dynamic** ONLY IF `forceStatic` is false AND `isExpanded` is false AND they belong to a message with active blocks (e.g., tool in `running`/`streaming`/`start` stage, `bang` in `running` stage, or text in `streaming` stage) AND the block itself is not a completed `text` or `reasoning` block (`stage === "end"`).
    - When `isExpanded` is true, all blocks (including those in the last message or with active tool calls) become static and are moved into the `<Static>` component. This ensures the view remains "frozen" and performant when expanded.
    - When `isFinished` is true, the entire last message becomes static and is moved into the `<Static>` component.
 4. **Static Rendering**: Uses Ink's `<Static>` component to render static blocks. This ensures they are only rendered once and then "frozen" in the terminal scrollback.

--- a/specs/027-message-rendering-system/data-model.md
+++ b/specs/027-message-rendering-system/data-model.md
@@ -41,6 +41,6 @@ interface BlockWithStatus {
 ```
 
 - **isDynamic**: True if `forceStatic` is false AND `isExpanded` is false AND the message contains at least one active block AND the block is not a completed `text` or `reasoning` block (`stage === "end"`).
-- An active block is a `tool` block in the `running` stage, a `bang` block with `isRunning` set to true, or a `slash` block in the `running` stage.
+- An active block is a `tool` block in the `running`/`streaming`/`start` stage, a `bang` block with `isRunning` set to true, a `text` or `reasoning` block in the `streaming` stage.
 - When `isExpanded` is true, everything is static.
 - **key**: A unique identifier for the block, typically `${message.id}-${blockIndex}`.

--- a/specs/027-message-rendering-system/research.md
+++ b/specs/027-message-rendering-system/research.md
@@ -6,7 +6,7 @@
     - Manual memoization: Rejected because `<Static>` is the idiomatic way in Ink to handle append-only lists that don't change.
 
 ## Decision: Dynamic Rendering for Active Blocks
-- **Rationale**: Active tool calls, running commands, and streaming text need to update their display in real-time. These cannot be rendered inside `<Static>`. We separate them into a "dynamic" section that re-renders normally.
+- **Rationale**: Active tool calls, running commands, and streaming text/reasoning need to update their display in real-time. These cannot be rendered inside `<Static>`. We separate them into a "dynamic" section that re-renders normally.
 - **Alternatives considered**: 
     - Re-rendering the whole list: Rejected due to performance issues with long histories.
 

--- a/specs/027-message-rendering-system/spec.md
+++ b/specs/027-message-rendering-system/spec.md
@@ -68,7 +68,7 @@ As a user, I want different types of content (text, code, errors, images, tool c
 - **FR-002**: System MUST flatten messages into individual `MessageBlock` items for rendering.
 - **FR-003**: System MUST use Ink's `Static` component for rendering historical (non-dynamic) message blocks.
 - **FR-004**: System MUST identify "dynamic" blocks and render them outside the `Static` component.
-- **FR-004.1**: A block is dynamic IF `forceStatic` is false AND `isExpanded` is false AND the block belongs to the last message AND the message contains at least one active block (`tool` in `running`/`streaming`/`start` stage, or `bang` in `running` stage) AND the block itself is not a completed `text` or `reasoning` block (`stage === "end"`).
+- **FR-004.1**: A block is dynamic IF `forceStatic` is false AND `isExpanded` is false AND the block belongs to the last message AND the message contains at least one active block (`tool` in `running`/`streaming`/`start` stage, `bang` in `running` stage, or `text` in `streaming` stage) AND the block itself is not a completed `text` or `reasoning` block (`stage === "end"`).
 - **FR-004.2**: All other blocks MUST be rendered as static content, including text/reasoning blocks with `stage === "end"` even when other blocks in the same message are still active.
 - **FR-004.3**: Blocks not in the last message MUST always be static, regardless of whether their message contains active blocks.
 - **FR-005**: System MUST support a "welcome message" at the top of the message list showing version and environment info.

--- a/specs/027-message-rendering-system/tasks.md
+++ b/specs/027-message-rendering-system/tasks.md
@@ -34,3 +34,8 @@
 
 - [X] T013 Run `pnpm run type-check` and `pnpm lint`
 - [X] T014 Manually verify rendering with various block types and long histories
+
+## Phase 6: Streaming Text Block Visibility
+
+- [X] T016 [P] Update MessageList to include streaming text blocks instead of filtering them out
+- [X] T017 Add test for streaming text block visibility in MessageList


### PR DESCRIPTION
Previously, streaming text blocks were filtered out from rendering. Now they are included and rendered as truncated gray text (last 30 chars) like streaming reasoning blocks.