### PR TITLE
feat: track original workdir to keep system prompt stable and notify on cd changes

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -51,6 +51,7 @@ export class AIManager {
   onLoadingChange?: (loading: boolean) => void;
   private toolAbortController: AbortController | null = null;
   private workdir: string;
+  private originalWorkdir: string;
   private systemPrompt?: string;
   private subagentType?: string; // Store subagent type for hook context
   private stream: boolean; // Streaming mode flag
@@ -63,6 +64,7 @@ export class AIManager {
     options: AIManagerOptions,
   ) {
     this.workdir = options.workdir;
+    this.originalWorkdir = options.workdir;
     this.systemPrompt = options.systemPrompt;
     this.subagentType = options.subagentType; // Store subagent type
     this.stream = options.stream ?? true; // Default to true if not specified
@@ -165,6 +167,10 @@ export class AIManager {
     return this.workdir;
   }
 
+  public getOriginalWorkdir(): string {
+    return this.originalWorkdir;
+  }
+
   public setOnCwdChange(callback: (newCwd: string) => void): void {
     this._onCwdChange = callback;
   }
@@ -234,6 +240,7 @@ export class AIManager {
       if (toolPlugin?.formatCompactParams) {
         const context: ToolContext = {
           workdir: this.workdir,
+          originalWorkdir: this.originalWorkdir,
           taskManager: this.taskManager,
         };
         return toolPlugin.formatCompactParams(toolArgs, context);
@@ -472,6 +479,7 @@ export class AIManager {
           filteredToolPlugins,
           {
             workdir: this.workdir,
+            originalWorkdir: this.originalWorkdir,
             memory: combinedMemory,
             language: this.getLanguage(),
             isSubagent: !!this.subagentType,
@@ -710,6 +718,7 @@ export class AIManager {
                 abortSignal: toolAbortController.signal,
                 backgroundTaskManager: this.backgroundTaskManager,
                 workdir: this.workdir,
+                originalWorkdir: this.originalWorkdir,
                 messageId: this.messageManager.getMessages().slice(-1)[0]?.id,
                 sessionId: this.messageManager.getSessionId(),
                 toolCallId: toolId,

--- a/packages/agent-sdk/src/prompts/index.ts
+++ b/packages/agent-sdk/src/prompts/index.ts
@@ -214,6 +214,7 @@ export function buildSystemPrompt(
   tools: ToolPlugin[],
   options: {
     workdir?: string;
+    originalWorkdir?: string;
     memory?: string;
     language?: string;
     isSubagent?: boolean;
@@ -251,8 +252,9 @@ export function buildSystemPrompt(
     prompt += `\n\n${buildPlanModePrompt(options.planMode.planFilePath, options.planMode.planExists, options.isSubagent)}`;
   }
 
-  if (options.workdir) {
-    const isGitRepo = isGitRepository(options.workdir);
+  const workdirForPrompt = options.originalWorkdir || options.workdir;
+  if (workdirForPrompt) {
+    const isGitRepo = isGitRepository(workdirForPrompt);
     const platform = os.platform();
     const osVersion = `${os.type()} ${os.release()}`;
     const today = new Date().toISOString().split("T")[0];
@@ -267,7 +269,7 @@ export function buildSystemPrompt(
 
 Here is useful information about the environment you are running in:
 <env>
-Working directory: ${options.workdir}
+Working directory: ${workdirForPrompt}
 Is directory a git repo: ${isGitRepo}
 Platform: ${platform}
 Shell: ${shellName}

--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -139,7 +139,10 @@ Use the gh command via the Bash tool for GitHub-related tasks including working 
 - Do not retry failing commands in a sleep loop — diagnose the root cause.
 - If waiting for a background task you started with \`run_in_background\`, you will be notified when it completes — do not poll.
 - If you must poll an external process, use a check command (e.g. \`gh run view\`) rather than sleeping first.
-- If you must sleep, keep the duration short (1-5 seconds) to avoid blocking the user.`,
+- If you must sleep, keep the duration short (1-5 seconds) to avoid blocking the user.
+
+# CWD management
+Try to maintain your current working directory throughout the session by using absolute paths and avoiding usage of \`cd\`. You may use \`cd\` if the User explicitly requests it. When you use \`cd\`, the shell working directory will be reset to the original working directory after the command completes.`,
   execute: async (
     args: Record<string, unknown>,
     context: ToolContext,
@@ -446,9 +449,13 @@ Use the gh command via the Bash tool for GitHub-related tasks including working 
             }
           }
 
-          // If CWD changed, call the onCwdChange callback
+          // If CWD changed, call the onCwdChange callback and add notification
+          let cwdChangedNotification = "";
           if (newCwd && newCwd !== context.workdir && context.onCwdChange) {
             context.onCwdChange(newCwd);
+            if (context.originalWorkdir && newCwd !== context.originalWorkdir) {
+              cwdChangedNotification = `Shell cwd was reset to ${context.originalWorkdir}\n`;
+            }
           }
 
           const exitCode = code ?? 0;
@@ -457,7 +464,8 @@ Use the gh command via the Bash tool for GitHub-related tasks including working 
 
           // Handle large output by truncation and persistence if needed
           const finalOutput =
-            combinedOutput || `Command executed with exit code: ${exitCode}`;
+            cwdChangedNotification +
+            (combinedOutput || `Command executed with exit code: ${exitCode}`);
           const content = processOutput(finalOutput);
 
           const lines = combinedOutput.trim().split("\n");

--- a/packages/agent-sdk/src/tools/types.ts
+++ b/packages/agent-sdk/src/tools/types.ts
@@ -58,6 +58,7 @@ export interface ToolContext {
   abortSignal?: AbortSignal;
   backgroundTaskManager?: import("../managers/backgroundTaskManager.js").BackgroundTaskManager;
   workdir: string;
+  originalWorkdir?: string;
   /** Permission mode for this tool execution */
   permissionMode?: PermissionMode;
   /** Custom permission callback */


### PR DESCRIPTION
Store originalWorkdir separately from workdir so the system prompt's Working directory remains stable across turns (improving prompt caching).

Changes:
- Track `originalWorkdir` in AIManager, unchanged by `cd` commands
- Pass `originalWorkdir` through ToolContext for tool access
- Use `originalWorkdir` in `buildSystemPrompt` to keep the system prompt stable
- Add cwd change notification in bash tool output (`Shell cwd was reset to ...`)
- Add instruction in bash tool prompt to avoid `cd` and use absolute paths