### PR TITLE
feat: reset bash CWD when outside allowed directories

### DIFF
--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -316,6 +316,13 @@ export class PermissionManager {
   }
 
   /**
+   * Public wrapper for isInsideSafeZone to check if a path is in the safe zone
+   */
+  public isPathInSafeZone(targetPath: string): boolean {
+    return this.isInsideSafeZone(targetPath).isInside;
+  }
+
+  /**
    * Check if a path is inside the Safe Zone (workdir + additionalDirectories)
    */
   private isInsideSafeZone(

--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -452,9 +452,16 @@ Try to maintain your current working directory throughout the session by using a
           // If CWD changed, call the onCwdChange callback and add notification
           let cwdChangedNotification = "";
           if (newCwd && newCwd !== context.workdir && context.onCwdChange) {
-            context.onCwdChange(newCwd);
-            if (context.originalWorkdir && newCwd !== context.originalWorkdir) {
+            const isInSafeZone =
+              context.permissionManager?.isPathInSafeZone?.(newCwd) ?? true;
+
+            if (isInSafeZone) {
+              context.onCwdChange(newCwd);
+            } else if (context.originalWorkdir) {
+              context.onCwdChange(context.originalWorkdir);
               cwdChangedNotification = `Shell cwd was reset to ${context.originalWorkdir}\n`;
+            } else {
+              context.onCwdChange(newCwd);
             }
           }
 

--- a/packages/agent-sdk/tests/tools/bashTool.test.ts
+++ b/packages/agent-sdk/tests/tools/bashTool.test.ts
@@ -17,6 +17,11 @@ vi.mock("fs", async () => {
   return {
     ...actual,
     writeFileSync: vi.fn(),
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    accessSync: vi.fn(),
+    constants: { F_OK: 0 },
   };
 });
 
@@ -504,6 +509,139 @@ describe("bashTool", () => {
 
       expect(result.success).toBe(true);
       expect(result.shortResult).toBe("... +2 lines\nline3\nline4\nline5");
+    });
+  });
+
+  describe("CWD reset when outside safe zone", () => {
+    const createMockProcess = (exitCode: number, newCwd: string) => {
+      const mockProcess = {
+        pid: 1234,
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+        on: vi.fn((event: string, callback: (code: number) => void) => {
+          if (event === "exit") {
+            setTimeout(() => {
+              // Simulate the temp CWD file being written
+              vi.mocked(fs.existsSync).mockReturnValue(true);
+              vi.mocked(fs.readFileSync).mockReturnValue(newCwd + "\n");
+              callback(exitCode);
+            }, 10);
+          }
+        }),
+        kill: vi.fn(),
+        killed: false,
+      };
+      return mockProcess;
+    };
+
+    it("should accept CWD when inside safe zone", async () => {
+      const mockOnCwdChange = vi.fn();
+      const mockPermissionManager = {
+        createContext: vi.fn().mockReturnValue({}),
+        checkPermission: vi.fn().mockResolvedValue({ behavior: "allow" }),
+        isPathInSafeZone: vi.fn().mockReturnValue(true),
+      };
+      const testContext: ToolContext = {
+        ...context,
+        onCwdChange: mockOnCwdChange,
+        originalWorkdir: "/test/workdir",
+        permissionManager:
+          mockPermissionManager as unknown as ToolContext["permissionManager"],
+      };
+
+      mockSpawn.mockReturnValue(
+        createMockProcess(0, "/test/workdir/subdir") as unknown as ChildProcess,
+      );
+
+      const result = await bashTool.execute(
+        { command: "cd subdir" },
+        testContext,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockOnCwdChange).toHaveBeenCalledWith("/test/workdir/subdir");
+      expect(result.content).not.toContain("Shell cwd was reset to");
+    });
+
+    it("should reset CWD to originalWorkdir when outside safe zone", async () => {
+      const mockOnCwdChange = vi.fn();
+      const mockPermissionManager = {
+        createContext: vi.fn().mockReturnValue({}),
+        checkPermission: vi.fn().mockResolvedValue({ behavior: "allow" }),
+        isPathInSafeZone: vi.fn().mockReturnValue(false),
+      };
+      const testContext: ToolContext = {
+        ...context,
+        onCwdChange: mockOnCwdChange,
+        originalWorkdir: "/test/workdir",
+        permissionManager:
+          mockPermissionManager as unknown as ToolContext["permissionManager"],
+      };
+
+      mockSpawn.mockReturnValue(
+        createMockProcess(
+          0,
+          "/home/liuyiqi/other-dir",
+        ) as unknown as ChildProcess,
+      );
+
+      const result = await bashTool.execute(
+        { command: "cd /home/liuyiqi/other-dir" },
+        testContext,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockOnCwdChange).toHaveBeenCalledWith("/test/workdir");
+      expect(result.content).toContain("Shell cwd was reset to /test/workdir");
+    });
+
+    it("should accept CWD when no permissionManager (backward compatible)", async () => {
+      const mockOnCwdChange = vi.fn();
+      const testContext: ToolContext = {
+        ...context,
+        onCwdChange: mockOnCwdChange,
+        originalWorkdir: "/test/workdir",
+      };
+
+      mockSpawn.mockReturnValue(
+        createMockProcess(0, "/test/workdir/subdir") as unknown as ChildProcess,
+      );
+
+      const result = await bashTool.execute(
+        { command: "cd subdir" },
+        testContext,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockOnCwdChange).toHaveBeenCalledWith("/test/workdir/subdir");
+    });
+
+    it("should accept CWD when outside safe zone but no originalWorkdir", async () => {
+      const mockOnCwdChange = vi.fn();
+      const mockPermissionManager = {
+        createContext: vi.fn().mockReturnValue({}),
+        checkPermission: vi.fn().mockResolvedValue({ behavior: "allow" }),
+        isPathInSafeZone: vi.fn().mockReturnValue(false),
+      };
+      const testContext: ToolContext = {
+        ...context,
+        onCwdChange: mockOnCwdChange,
+        permissionManager:
+          mockPermissionManager as unknown as ToolContext["permissionManager"],
+      };
+
+      mockSpawn.mockReturnValue(
+        createMockProcess(0, "/some/other/dir") as unknown as ChildProcess,
+      );
+
+      const result = await bashTool.execute(
+        { command: "cd /some/other/dir" },
+        testContext,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockOnCwdChange).toHaveBeenCalledWith("/some/other/dir");
+      expect(result.content).not.toContain("Shell cwd was reset to");
     });
   });
 


### PR DESCRIPTION
Adds isPathInSafeZone public method to PermissionManager and updates bashTool to check if the new CWD is within safe zones (workdir + additional directories). If outside, resets CWD back to originalWorkdir with a notification. Includes backward-compatible fallback when no permissionManager or originalWorkdir is available, plus 4 test cases.