### PR TITLE
docs: update compression spec to reflect PR #995 changes

### DIFF
--- a/specs/014-message-compression/claude-code-compact-logic.md
+++ b/specs/014-message-compression/claude-code-compact-logic.md
@@ -422,16 +422,19 @@ User types: /compact [optional custom instructions]
 
 ## Key Differences from Wave's Current Implementation
 
-1. **Microcompact layer**: Wave doesn't have pre-request tool result clearing
+1. **Cached microcompact**: Wave has time-based microcompact but NOT the cache-editing API path (`cache_reference` / `cache_edits`)
 2. **Session Memory compaction**: Wave doesn't have an alternative summary source
 3. **Partial compact**: Wave only has full conversation compaction
 4. **Cache sharing**: Wave doesn't reuse prompt cache for the compact API call
 5. **PTL retry**: Wave doesn't handle prompt-too-long during the compact request itself
-6. **Post-compact context restoration**: Wave's implementation is simpler - no file re-reading, skill attachments, async agent tracking
-7. **Circuit breaker**: Wave doesn't limit consecutive auto-compact failures
-8. **Message grouping by API round**: Wave's spec mentions keeping last 3 messages; Claude groups by API rounds for more precise truncation
+6. **Post-compact context restoration**: Wave now has basic context restoration (recent file reads, working directory, plan mode, skills, background tasks) but Claude's is more extensive (delta attachments, tool re-announcements, file diffing against preserved messages)
+7. **Circuit breaker**: Wave now has a circuit breaker (3 consecutive failures, same as Claude)
+8. **Message grouping by API round**: Wave now groups messages by API rounds using `groupMessagesByApiRound()` (same approach as Claude)
 9. **Reactive compact**: Wave doesn't have a reactive (error-driven) compaction path
-10. **Token estimation**: Claude uses `roughTokenCountEstimation` with 4/3 padding; Wave uses a different estimation method
+10. **Token estimation**: Claude uses `roughTokenCountEstimation` with 4/3 padding; Wave uses ~4 chars per token estimation
+11. **Snip compact**: Wave doesn't have a snip-compact mechanism to drop old compacted segments
+12. **Context collapse**: Wave doesn't have a context-collapse feature
+13. **Post-compact cleanup**: Wave doesn't have a formal post-compact cleanup pipeline (cache resets, state clearing)
 
 ## Related Prompt Files
 

--- a/specs/014-message-compression/plan.md
+++ b/specs/014-message-compression/plan.md
@@ -50,12 +50,29 @@ specs/014-message-compression/
 packages/agent-sdk/
 ├── src/
 │   ├── managers/
-│   │   └── aiManager.ts        # Trigger history compression
+│   │   ├── aiManager.ts        # Trigger history compression, microcompact, circuit breaker
+│   │   └── messageManager.ts   # Compress messages, track file reads, API-round grouping
+│   ├── services/
+│   │   └── aiService.ts        # Compress API call, image stripping
+│   ├── types/
+│   │   └── messaging.ts        # ToolBlock timestamp field
+│   ├── prompts/
+│   │   └── index.ts            # COMPRESS_MESSAGES_SYSTEM_PROMPT
 │   └── utils/
-│       └── messageOperations.ts # Compression logic
+│       ├── groupMessagesByApiRound.ts  # API-round grouping
+│       ├── microcompact.ts             # Time-based tool result clearing
+│       └── messageOperations.ts        # Compression logic
 └── tests/
+    ├── agent/
+    │   ├── agent.compression.test.ts   # Compression + circuit breaker tests
+    │   └── agent.coverage.test.ts
+    ├── integration/
+    │   └── compactionFlow.test.ts      # Full pipeline integration tests
+    ├── managers/
+    │   └── messageManager.coverage.test.ts
     └── utils/
-        └── messageOperations.test.ts
+        ├── groupMessagesByApiRound.test.ts
+        └── microcompact.test.ts
 ```
 
 ## Complexity Tracking

--- a/specs/014-message-compression/spec.md
+++ b/specs/014-message-compression/spec.md
@@ -17,26 +17,91 @@ As an AI agent, when the conversation history becomes too long, I want to automa
 **Acceptance Scenarios**:
 
 1. **Given** the total token count exceeds `getMaxInputTokens()`, **When** the next message is processed, **Then** the agent MUST identify messages to compress.
-2. **Given** messages are identified for compression, **When** the summarization is complete, **Then** the original messages MUST be replaced by a `compress` block followed by the last 3 messages of the old message list in the session.
+2. **Given** messages are identified for compression, **When** the summarization is complete, **Then** the original messages MUST be replaced by a `compress` block followed by the last 2 API rounds of the old message list in the session.
 3. **Given** a `compress` block exists, **When** sending messages to the API, **Then** it MUST be converted to a system message with the prefix `[Compressed Message Summary]`.
+
+---
+
+### User Story 2 - Time-Based Microcompact (Priority: P1)
+
+As an AI agent, before each API call, I want to clear old tool result content that is no longer relevant (e.g., from >30 minutes ago) so that I reduce token usage without AI summarization.
+
+**Why this priority**: Reduces token costs proactively without requiring an extra API call for summarization.
+
+**Independent Test**: Simulate a 30+ minute gap since the last tool result and verify that old tool results are replaced with `[Old tool result content cleared]` while the most recent N results are preserved.
+
+**Acceptance Scenarios**:
+
+1. **Given** the time since the last completed tool result exceeds 30 minutes, **When** preparing messages for an API call, **Then** all but the 3 most recent tool results MUST have their `result` and `shortResult` fields cleared.
+2. **Given** no prior assistant messages with completed tools exist, **When** microcompact runs, **Then** messages MUST remain unchanged.
+3. **Given** the time since the last tool result is within the 30-minute threshold, **When** microcompact runs, **Then** messages MUST remain unchanged.
+
+---
+
+### User Story 3 - Compression Circuit Breaker (Priority: P2)
+
+As an AI agent, when compression repeatedly fails, I want to stop attempting compression so that I avoid wasting API calls on an irrecoverable context state.
+
+**Why this priority**: Prevents cascading failures and unnecessary API costs when the context is corrupted.
+
+**Independent Test**: Simulate 3 consecutive compression failures and verify that the 4th high-token-usage turn skips compression entirely.
+
+**Acceptance Scenarios**:
+
+1. **Given** compression has failed 3 consecutive times, **When** token usage again exceeds the threshold, **Then** compression MUST be skipped and a warning logged.
+2. **Given** compression succeeds, **When** the next compression cycle runs, **Then** the consecutive failure counter MUST be reset to 0.
+
+---
+
+### User Story 4 - Post-Compact Context Restoration (Priority: P2)
+
+As an AI agent, after compression replaces conversation history, I want important context re-injected so that I can continue working without losing track of files, directory, plan mode, skills, and background tasks.
+
+**Why this priority**: Prevents the agent from losing critical environmental context after compression.
+
+**Independent Test**: Verify that after compression, the summary includes sections for recent file reads, working directory, plan mode status, available skills, and background task status.
+
+**Acceptance Scenarios**:
+
+1. **Given** compression produces a summary, **When** the summary is applied, **Then** it MUST be augmented with recent file read contents (up to 5 files, 5000 tokens each).
+2. **Given** compression is applied, **When** context restoration runs, **Then** the current working directory MUST be included.
+3. **Given** the agent is in plan mode, **When** context restoration runs, **Then** the plan file path and existence status MUST be included.
+4. **Given** skills have been invoked, **When** context restoration runs, **Then** available skills (name and description) MUST be listed.
+5. **Given** background tasks are running, **When** context restoration runs, **Then** each agent's description and status MUST be listed.
 
 ---
 
 ### Edge Cases
 
 - **Recursive Compression**: When compressing history that already contains a summary, the entire history (including the old summary) is replaced by a new continuation summary.
-- **Image Handling**: Ensure that image blocks are accounted for during compression, even if their content isn't directly summarized.
+- **Image Handling**: Images MUST be stripped from messages before the compress API call to reduce token usage.
 - **Token Limit Edge**: If the summary itself is too long (unlikely but possible), the system should handle it gracefully.
+- **API Round Boundaries**: Compression MUST never split a tool_use/tool_result pair across the compaction boundary.
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
 - **FR-001**: System MUST monitor token usage after each AI response.
-- **FR-002**: System MUST replace the conversation history with a single continuation summary and the last 3 messages of the old message list when token limits are reached.
+- **FR-002**: System MUST replace the conversation history with a single continuation summary and the last 2 API rounds of the old message list when token limits are reached.
 - **FR-003**: System MUST use the AI to generate a summary of messages identified for compression.
 - **FR-004**: System MUST replace compressed messages with a `compress` block in the session history.
 - **FR-005**: System MUST convert `compress` blocks to system messages for API calls.
+- **FR-006**: System MUST apply microcompact (clear old tool results) before each API call when the time threshold (>30 min) is exceeded.
+- **FR-007**: System MUST skip compression after 3 consecutive compression failures (circuit breaker).
+- **FR-008**: System MUST re-inject post-compact context (recent file reads, working directory, plan mode, skills, background tasks) into the compression summary.
+- **FR-009**: System MUST strip images from messages before the compress API call.
+- **FR-010**: System MUST use the fast model for compression API calls.
+- **FR-011**: System MUST group messages by API round boundaries (not fixed count) when determining which messages to preserve after compression.
+- **FR-012**: System MUST track recent `read` tool results for post-compact context restoration.
+
+### Key Entities *(include if feature involves data)*
+
+- **CompressBlock**: A message block containing a summary.
+    - `type`: "compress"
+    - `content`: The summary text, augmented with `[Context Restoration]` section.
+- **ToolBlock**: Extended with `timestamp` field (Unix ms, set when tool result is finalized).
+- **ApiRound**: A group of messages representing one API call-response cycle, with `messages: Message[]` and `estimatedTokens: number`.
 
 ### Key Entities *(include if feature involves data)*
 
@@ -48,3 +113,5 @@ As an AI agent, when the conversation history becomes too long, I want to automa
 
 - The AI model used for summarization is capable of producing concise and accurate summaries.
 - The token counting utility is reasonably accurate.
+- The fast model is capable of producing adequate compression summaries.
+- Tool result timestamps are set accurately when tools complete execution.

--- a/specs/014-message-compression/tasks.md
+++ b/specs/014-message-compression/tasks.md
@@ -53,7 +53,80 @@
 
 ---
 
-## Phase 4: Polish & Cross-Cutting Concerns
+## Phase 4: API-Round Grouping (US1 Enhancement)
+
+**Goal**: Replace fixed `slice(-3)` cutoff with API-round-based message preservation.
+
+### Tests for API-Round Grouping (REQUIRED) ⚠️
+
+- [X] T020 Write unit tests for `groupMessagesByApiRound()` in `packages/agent-sdk/tests/utils/groupMessagesByApiRound.test.ts`
+- [X] T021 Write unit tests for `getLastApiRounds()` in same file
+
+### Implementation for API-Round Grouping
+
+- [X] T022 Create `groupMessagesByApiRound()` utility in `packages/agent-sdk/src/utils/groupMessagesByApiRound.ts`
+- [X] T023 Update `compressMessagesAndUpdateSession()` to use `getLastApiRounds(messages, 2)` instead of `slice(-3)` in `packages/agent-sdk/src/managers/messageManager.ts`
+
+---
+
+## Phase 5: Time-Based Microcompact (US2)
+
+**Goal**: Clear old tool result content before API calls when inactivity exceeds threshold.
+
+### Tests for Microcompact (REQUIRED) ⚠️
+
+- [X] T030 Write unit tests for `microcompactMessages()` in `packages/agent-sdk/tests/utils/microcompact.test.ts`
+
+### Implementation for Microcompact
+
+- [X] T031 Create `microcompactMessages()` utility in `packages/agent-sdk/src/utils/microcompact.ts`
+- [X] T032 Add `timestamp` field to `ToolBlock` interface in `packages/agent-sdk/src/types/messaging.ts`
+- [X] T033 Set `timestamp` on tool result finalization in `packages/agent-sdk/src/managers/aiManager.ts`
+- [X] T034 Apply `microcompactMessages()` before API calls in `AIManager.sendMessage()`
+
+---
+
+## Phase 6: Compression Circuit Breaker (US3)
+
+**Goal**: Skip compression after consecutive failures to avoid wasting API calls.
+
+### Tests for Circuit Breaker (REQUIRED) ⚠️
+
+- [X] T040 Write tests for circuit breaker behavior in `packages/agent-sdk/tests/agent/agent.compression.test.ts`
+
+### Implementation for Circuit Breaker
+
+- [X] T041 Add `consecutiveCompressionFailures` counter to `AIManager`
+- [X] T042 Implement circuit breaker check before compression in `handleTokenUsageAndCompression()`
+- [X] T043 Reset counter on successful compression, increment on failure
+
+---
+
+## Phase 7: Post-Compact Context Restoration (US4)
+
+**Goal**: Re-inject important context after compression.
+
+### Tests for Context Restoration (REQUIRED) ⚠️
+
+- [X] T050 Verify context restoration sections in compression test in `packages/agent-sdk/tests/agent/agent.compression.test.ts`
+- [X] T051 Write tests for `getRecentFileReads()` in `packages/agent-sdk/tests/managers/messageManager.coverage.test.ts`
+
+### Implementation for Context Restoration
+
+- [X] T052 Add `recentFileReads` tracking and `getRecentFileReads()` method in `packages/agent-sdk/src/managers/messageManager.ts`
+- [X] T053 Build post-compact context restoration (files, working dir, plan mode, skills, background tasks) in `handleTokenUsageAndCompression()`
+- [X] T054 Strip images from messages before compress API call in `packages/agent-sdk/src/services/aiService.ts`
+- [X] T055 Use fast model for compression in `handleTokenUsageAndCompression()`
+
+---
+
+## Phase 8: Integration Tests
+
+- [X] T060 Write integration tests for full compaction pipeline in `packages/agent-sdk/tests/integration/compactionFlow.test.ts`
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
 
 **Purpose**: Improvements that affect multiple user stories
 


### PR DESCRIPTION
## Summary

Updates the message compression specification documents to reflect the features implemented in PR #995.

### Changes

**spec.md**:
- Added 3 new user stories: Time-Based Microcompact (US2), Compression Circuit Breaker (US3), Post-Compact Context Restoration (US4)
- Updated US1 to use "last 2 API rounds" instead of "last 3 messages"
- Added FR-006 through FR-012 covering microcompact, circuit breaker, context restoration, image stripping, fast model usage, API-round grouping, and file read tracking
- Added new key entities: ToolBlock (with timestamp), ApiRound

**tasks.md**:
- Added Phases 4-8 with all implementation tasks marked complete per PR #995

**plan.md**:
- Updated project structure to reflect all new source and test files

**claude-code-compact-logic.md**:
- Updated "Key Differences" section to reflect that Wave now has: time-based microcompact, circuit breaker, API-round grouping, and basic post-compact context restoration