### PR TITLE
refactor: extract confirmation and question reducers for ConfirmationSelector

### DIFF
--- a/packages/code/src/components/ConfirmationSelector.tsx
+++ b/packages/code/src/components/ConfirmationSelector.tsx
@@ -79,11 +79,6 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
     }
   });
 
-  const stateRef = useRef(state);
-  stateRef.current = state;
-  const questionStateRef = useRef(questionState);
-  questionStateRef.current = questionState;
-
   const currentQuestion = questions[questionState.currentQuestionIndex];
 
   const getAutoOptionText = () => {

--- a/packages/code/src/components/ConfirmationSelector.tsx
+++ b/packages/code/src/components/ConfirmationSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useReducer, useRef } from "react";
 import { Box, Text, useInput } from "ink";
 import type { PermissionDecision, AskUserQuestionInput } from "wave-agent-sdk";
 import {
@@ -7,6 +7,11 @@ import {
   ENTER_PLAN_MODE_TOOL_NAME,
   ASK_USER_QUESTION_TOOL_NAME,
 } from "wave-agent-sdk";
+import {
+  confirmationReducer,
+  type ConfirmationState,
+} from "../reducers/confirmationReducer.js";
+import { questionReducer } from "../reducers/questionReducer.js";
 
 const getHeaderColor = (header: string) => {
   const colors = ["red", "green", "blue", "magenta", "cyan"] as const;
@@ -27,13 +32,6 @@ export interface ConfirmationSelectorProps {
   onCancel: () => void;
 }
 
-interface ConfirmationState {
-  selectedOption: "clear" | "auto" | "allow" | "alternative";
-  alternativeText: string;
-  alternativeCursorPosition: number;
-  hasUserInput: boolean;
-}
-
 export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
   toolName,
   toolInput,
@@ -43,29 +41,25 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
   onDecision,
   onCancel,
 }) => {
-  const [state, setState] = useState<ConfirmationState>({
+  const [state, dispatch] = useReducer(confirmationReducer, {
     selectedOption: toolName === EXIT_PLAN_MODE_TOOL_NAME ? "clear" : "allow",
     alternativeText: "",
     alternativeCursorPosition: 0,
     hasUserInput: false,
   });
 
-  const [questionState, setQuestionState] = useState({
+  const questions =
+    (toolInput as unknown as AskUserQuestionInput)?.questions || [];
+
+  const [questionState, questionDispatch] = useReducer(questionReducer, {
     currentQuestionIndex: 0,
     selectedOptionIndex: 0,
     selectedOptionIndices: new Set<number>(),
-    userAnswers: {} as Record<string, string>,
+    userAnswers: {},
     otherText: "",
     otherCursorPosition: 0,
-    savedStates: {} as Record<
-      number,
-      {
-        selectedOptionIndex: number;
-        selectedOptionIndices: Set<number>;
-        otherText: string;
-        otherCursorPosition: number;
-      }
-    >,
+    savedStates: {},
+    decision: null,
   });
 
   const pendingDecisionRef = useRef<PermissionDecision | null>(null);
@@ -78,8 +72,18 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
     }
   });
 
-  const questions =
-    (toolInput as unknown as AskUserQuestionInput)?.questions || [];
+  // Handle question state decision from reducer
+  useEffect(() => {
+    if (questionState.decision) {
+      onDecision(questionState.decision);
+    }
+  });
+
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  const questionStateRef = useRef(questionState);
+  questionStateRef.current = questionState;
+
   const currentQuestion = questions[questionState.currentQuestionIndex];
 
   const getAutoOptionText = () => {
@@ -114,230 +118,90 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
       const isMultiSelect = currentQuestion.multiSelect;
 
       if (key.return) {
-        setQuestionState((prev) => {
-          const isOtherFocused =
-            prev.selectedOptionIndex === options.length - 1;
-          let answer = "";
-          if (isMultiSelect) {
-            const selectedLabels = Array.from(prev.selectedOptionIndices)
-              .filter((i) => i < currentQuestion.options.length)
-              .map((i) => currentQuestion.options[i].label);
-            const isOtherChecked = prev.selectedOptionIndices.has(
-              options.length - 1,
-            );
-            if (isOtherChecked && prev.otherText.trim()) {
-              selectedLabels.push(prev.otherText.trim());
-            }
-            answer = selectedLabels.join(", ");
-          } else {
-            if (isOtherFocused) {
-              answer = prev.otherText.trim();
-            } else {
-              answer = options[prev.selectedOptionIndex].label;
-            }
-          }
-
-          if (!answer) return prev;
-
-          const newAnswers = {
-            ...prev.userAnswers,
-            [currentQuestion.question]: answer,
-          };
-
-          if (prev.currentQuestionIndex < questions.length - 1) {
-            const nextIndex = prev.currentQuestionIndex + 1;
-            const savedStates = {
-              ...prev.savedStates,
-              [prev.currentQuestionIndex]: {
-                selectedOptionIndex: prev.selectedOptionIndex,
-                selectedOptionIndices: prev.selectedOptionIndices,
-                otherText: prev.otherText,
-                otherCursorPosition: prev.otherCursorPosition,
-              },
-            };
-
-            const nextState = savedStates[nextIndex] || {
-              selectedOptionIndex: 0,
-              selectedOptionIndices: new Set<number>(),
-              otherText: "",
-              otherCursorPosition: 0,
-            };
-
-            return {
-              ...prev,
-              currentQuestionIndex: nextIndex,
-              ...nextState,
-              userAnswers: newAnswers,
-              savedStates,
-            };
-          } else {
-            const finalAnswers = { ...newAnswers };
-            // Also collect from savedStates for any questions that were skipped via Tab
-            for (const [idxStr, s] of Object.entries(prev.savedStates)) {
-              const idx = parseInt(idxStr);
-              const q = questions[idx];
-              if (q && !finalAnswers[q.question]) {
-                const opts = [...q.options, { label: "Other" }];
-                let a = "";
-                if (q.multiSelect) {
-                  const selectedLabels = Array.from(s.selectedOptionIndices)
-                    .filter((i) => i < q.options.length)
-                    .map((i) => q.options[i].label);
-                  const isOtherChecked = s.selectedOptionIndices.has(
-                    opts.length - 1,
-                  );
-                  if (isOtherChecked && s.otherText.trim()) {
-                    selectedLabels.push(s.otherText.trim());
-                  }
-                  a = selectedLabels.join(", ");
-                } else {
-                  if (s.selectedOptionIndex === opts.length - 1) {
-                    a = s.otherText.trim();
-                  } else {
-                    a = opts[s.selectedOptionIndex].label;
-                  }
-                }
-                if (a) finalAnswers[q.question] = a;
-              }
-            }
-
-            // Only submit if all questions have been answered
-            const allAnswered = questions.every(
-              (q) => finalAnswers[q.question],
-            );
-            if (!allAnswered) return prev;
-
-            pendingDecisionRef.current = {
-              behavior: "allow",
-              message: JSON.stringify(finalAnswers),
-            };
-            return {
-              ...prev,
-              userAnswers: finalAnswers,
-            };
-          }
+        questionDispatch({
+          type: "CONFIRM_ANSWER",
+          currentQuestion,
+          options,
+          isMultiSelect: !!isMultiSelect,
+          questions,
         });
         return;
       }
 
       if (input === " ") {
-        setQuestionState((prev) => {
-          const isOtherFocused =
-            prev.selectedOptionIndex === options.length - 1;
-          if (
-            isMultiSelect &&
-            (!isOtherFocused ||
-              !prev.selectedOptionIndices.has(prev.selectedOptionIndex))
-          ) {
-            const nextIndices = new Set(prev.selectedOptionIndices);
-            if (nextIndices.has(prev.selectedOptionIndex))
-              nextIndices.delete(prev.selectedOptionIndex);
-            else nextIndices.add(prev.selectedOptionIndex);
-            return {
-              ...prev,
-              selectedOptionIndices: nextIndices,
-            };
-          }
-          return prev;
-        });
+        const isOtherFocused =
+          questionState.selectedOptionIndex === options.length - 1;
+        if (
+          isMultiSelect &&
+          (!isOtherFocused ||
+            !questionState.selectedOptionIndices.has(
+              questionState.selectedOptionIndex,
+            ))
+        ) {
+          questionDispatch({
+            type: "TOGGLE_MULTI_SELECT",
+            optionsLength: options.length,
+          });
+          return;
+        }
         // If it's other and focused, we don't return here, allowing the input handler below to handle it
       }
 
       if (key.upArrow) {
-        setQuestionState((prev) => ({
-          ...prev,
-          selectedOptionIndex: Math.max(0, prev.selectedOptionIndex - 1),
-        }));
+        questionDispatch({
+          type: "MOVE_OPTION_UP",
+          maxIndex: options.length - 1,
+        });
         return;
       }
       if (key.downArrow) {
-        setQuestionState((prev) => ({
-          ...prev,
-          selectedOptionIndex: Math.min(
-            options.length - 1,
-            prev.selectedOptionIndex + 1,
-          ),
-        }));
+        questionDispatch({
+          type: "MOVE_OPTION_DOWN",
+          maxIndex: options.length - 1,
+        });
         return;
       }
       if (key.tab) {
-        setQuestionState((prev) => {
-          const direction = key.shift ? -1 : 1;
-          let nextIndex = prev.currentQuestionIndex + direction;
-          if (nextIndex < 0) nextIndex = questions.length - 1;
-          if (nextIndex >= questions.length) nextIndex = 0;
-
-          if (nextIndex === prev.currentQuestionIndex) return prev;
-
-          const savedStates = {
-            ...prev.savedStates,
-            [prev.currentQuestionIndex]: {
-              selectedOptionIndex: prev.selectedOptionIndex,
-              selectedOptionIndices: prev.selectedOptionIndices,
-              otherText: prev.otherText,
-              otherCursorPosition: prev.otherCursorPosition,
-            },
-          };
-
-          const nextState = savedStates[nextIndex] || {
-            selectedOptionIndex: 0,
-            selectedOptionIndices: new Set<number>(),
-            otherText: "",
-            otherCursorPosition: 0,
-          };
-
-          return {
-            ...prev,
-            currentQuestionIndex: nextIndex,
-            ...nextState,
-            savedStates,
-          };
+        questionDispatch({
+          type: "CYCLE_QUESTION",
+          shift: key.shift,
+          questionCount: questions.length,
         });
         return;
       }
 
-      setQuestionState((prev) => {
-        const isOtherFocused = prev.selectedOptionIndex === options.length - 1;
-        if (isOtherFocused) {
-          if (key.leftArrow) {
-            return {
-              ...prev,
-              otherCursorPosition: Math.max(0, prev.otherCursorPosition - 1),
-            };
-          }
-          if (key.rightArrow) {
-            return {
-              ...prev,
-              otherCursorPosition: Math.min(
-                prev.otherText.length,
-                prev.otherCursorPosition + 1,
-              ),
-            };
-          }
-          if (key.backspace || key.delete) {
-            if (prev.otherCursorPosition > 0) {
-              return {
-                ...prev,
-                otherText:
-                  prev.otherText.slice(0, prev.otherCursorPosition - 1) +
-                  prev.otherText.slice(prev.otherCursorPosition),
-                otherCursorPosition: prev.otherCursorPosition - 1,
-              };
-            }
-          }
-          if (input && !key.ctrl && !key.meta) {
-            return {
-              ...prev,
-              otherText:
-                prev.otherText.slice(0, prev.otherCursorPosition) +
-                input +
-                prev.otherText.slice(prev.otherCursorPosition),
-              otherCursorPosition: prev.otherCursorPosition + input.length,
-            };
-          }
-        }
-        return prev;
-      });
+      // Always dispatch Other actions unconditionally; the reducer checks
+      // isOtherFocused from the latest state, so this works correctly even
+      // when inputs are batched before React re-renders.
+      if (key.leftArrow) {
+        questionDispatch({
+          type: "MOVE_OTHER_LEFT",
+          optionsLength: options.length,
+        });
+        return;
+      }
+      if (key.rightArrow) {
+        questionDispatch({
+          type: "MOVE_OTHER_RIGHT",
+          optionsLength: options.length,
+        });
+        return;
+      }
+      if (key.backspace || key.delete) {
+        questionDispatch({
+          type: "DELETE_OTHER",
+          optionsLength: options.length,
+        });
+        return;
+      }
+      if (input && !key.ctrl && !key.meta) {
+        questionDispatch({
+          type: "INSERT_OTHER",
+          text: input,
+          optionsLength: options.length,
+        });
+        return;
+      }
       return;
     }
 
@@ -387,23 +251,11 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
 
     if (state.selectedOption === "alternative") {
       if (key.leftArrow) {
-        setState((prev) => ({
-          ...prev,
-          alternativeCursorPosition: Math.max(
-            0,
-            prev.alternativeCursorPosition - 1,
-          ),
-        }));
+        dispatch({ type: "MOVE_CURSOR_LEFT" });
         return;
       }
       if (key.rightArrow) {
-        setState((prev) => ({
-          ...prev,
-          alternativeCursorPosition: Math.min(
-            prev.alternativeText.length,
-            prev.alternativeCursorPosition + 1,
-          ),
-        }));
+        dispatch({ type: "MOVE_CURSOR_RIGHT" });
         return;
       }
     }
@@ -417,10 +269,10 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
     if (key.upArrow) {
       const currentIndex = availableOptions.indexOf(state.selectedOption);
       if (currentIndex > 0) {
-        setState((prev) => ({
-          ...prev,
-          selectedOption: availableOptions[currentIndex - 1],
-        }));
+        dispatch({
+          type: "SELECT_OPTION",
+          option: availableOptions[currentIndex - 1],
+        });
       }
       return;
     }
@@ -428,10 +280,10 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
     if (key.downArrow) {
       const currentIndex = availableOptions.indexOf(state.selectedOption);
       if (currentIndex < availableOptions.length - 1) {
-        setState((prev) => ({
-          ...prev,
-          selectedOption: availableOptions[currentIndex + 1],
-        }));
+        dispatch({
+          type: "SELECT_OPTION",
+          option: availableOptions[currentIndex + 1],
+        });
       }
       return;
     }
@@ -442,47 +294,20 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
       let nextIndex = currentIndex + direction;
       if (nextIndex < 0) nextIndex = availableOptions.length - 1;
       if (nextIndex >= availableOptions.length) nextIndex = 0;
-      setState((prev) => ({
-        ...prev,
-        selectedOption: availableOptions[nextIndex],
-      }));
+      dispatch({
+        type: "SELECT_OPTION",
+        option: availableOptions[nextIndex],
+      });
       return;
     }
 
     if (input && !key.ctrl && !key.meta && !("alt" in key && key.alt)) {
-      setState((prev) => {
-        const nextText =
-          prev.alternativeText.slice(0, prev.alternativeCursorPosition) +
-          input +
-          prev.alternativeText.slice(prev.alternativeCursorPosition);
-        return {
-          ...prev,
-          selectedOption: "alternative",
-          alternativeText: nextText,
-          alternativeCursorPosition:
-            prev.alternativeCursorPosition + input.length,
-          hasUserInput: true,
-        };
-      });
+      dispatch({ type: "INSERT_TEXT", text: input });
       return;
     }
 
     if (key.backspace || key.delete) {
-      setState((prev) => {
-        if (prev.alternativeCursorPosition > 0) {
-          const nextText =
-            prev.alternativeText.slice(0, prev.alternativeCursorPosition - 1) +
-            prev.alternativeText.slice(prev.alternativeCursorPosition);
-          return {
-            ...prev,
-            selectedOption: "alternative",
-            alternativeText: nextText,
-            alternativeCursorPosition: prev.alternativeCursorPosition - 1,
-            hasUserInput: nextText.length > 0,
-          };
-        }
-        return prev;
-      });
+      dispatch({ type: "BACKSPACE" });
       return;
     }
   });

--- a/packages/code/src/components/ConfirmationSelector.tsx
+++ b/packages/code/src/components/ConfirmationSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer, useRef } from "react";
+import React, { useEffect, useReducer } from "react";
 import { Box, Text, useInput } from "ink";
 import type { PermissionDecision, AskUserQuestionInput } from "wave-agent-sdk";
 import {
@@ -46,6 +46,7 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
     alternativeText: "",
     alternativeCursorPosition: 0,
     hasUserInput: false,
+    decision: null,
   });
 
   const questions =
@@ -62,22 +63,18 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
     decision: null,
   });
 
-  const pendingDecisionRef = useRef<PermissionDecision | null>(null);
-
+  // Handle decisions from reducers
   useEffect(() => {
-    if (pendingDecisionRef.current) {
-      const decision = pendingDecisionRef.current;
-      pendingDecisionRef.current = null;
-      onDecision(decision);
+    if (state.decision) {
+      onDecision(state.decision);
     }
-  });
+  }, [state.decision, onDecision]);
 
-  // Handle question state decision from reducer
   useEffect(() => {
     if (questionState.decision) {
       onDecision(questionState.decision);
     }
-  });
+  }, [questionState.decision, onDecision]);
 
   const currentQuestion = questions[questionState.currentQuestionIndex];
 
@@ -201,45 +198,49 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
     }
 
     if (key.return) {
+      let decision: PermissionDecision | null = null;
       if (state.selectedOption === "clear") {
-        onDecision({
+        decision = {
           behavior: "allow",
           newPermissionMode: "acceptEdits",
           clearContext: true,
-        });
+        };
       } else if (state.selectedOption === "allow") {
         if (toolName === EXIT_PLAN_MODE_TOOL_NAME) {
-          onDecision({ behavior: "allow", newPermissionMode: "default" });
+          decision = { behavior: "allow", newPermissionMode: "default" };
         } else if (toolName === ENTER_PLAN_MODE_TOOL_NAME) {
-          onDecision({ behavior: "allow", newPermissionMode: "plan" });
+          decision = { behavior: "allow", newPermissionMode: "plan" };
         } else {
-          onDecision({ behavior: "allow" });
+          decision = { behavior: "allow" };
         }
       } else if (state.selectedOption === "auto") {
         if (toolName === BASH_TOOL_NAME) {
           const command = (toolInput?.command as string) || "";
           if (command.trim().startsWith("mkdir")) {
-            onDecision({ behavior: "allow", newPermissionMode: "acceptEdits" });
+            decision = { behavior: "allow", newPermissionMode: "acceptEdits" };
           } else {
             const rule = suggestedPrefix
               ? `Bash(${suggestedPrefix})`
               : `Bash(${toolInput?.command})`;
-            onDecision({ behavior: "allow", newPermissionRule: rule });
+            decision = { behavior: "allow", newPermissionRule: rule };
           }
         } else if (toolName === ENTER_PLAN_MODE_TOOL_NAME) {
-          onDecision({ behavior: "allow", newPermissionMode: "plan" });
+          decision = { behavior: "allow", newPermissionMode: "plan" };
         } else if (toolName.startsWith("mcp__")) {
-          onDecision({ behavior: "allow", newPermissionRule: toolName });
+          decision = { behavior: "allow", newPermissionRule: toolName };
         } else {
-          onDecision({ behavior: "allow", newPermissionMode: "acceptEdits" });
+          decision = { behavior: "allow", newPermissionMode: "acceptEdits" };
         }
       } else if (state.alternativeText.trim()) {
-        onDecision({ behavior: "deny", message: state.alternativeText.trim() });
+        decision = { behavior: "deny", message: state.alternativeText.trim() };
       } else if (toolName === ENTER_PLAN_MODE_TOOL_NAME) {
-        onDecision({
+        decision = {
           behavior: "deny",
           message: "User chose not to enter plan mode",
-        });
+        };
+      }
+      if (decision) {
+        dispatch({ type: "CONFIRM", decision });
       }
       return;
     }

--- a/packages/code/src/reducers/confirmationReducer.ts
+++ b/packages/code/src/reducers/confirmationReducer.ts
@@ -1,0 +1,68 @@
+export interface ConfirmationState {
+  selectedOption: "clear" | "auto" | "allow" | "alternative";
+  alternativeText: string;
+  alternativeCursorPosition: number;
+  hasUserInput: boolean;
+}
+
+export type ConfirmationAction =
+  | { type: "SELECT_OPTION"; option: ConfirmationState["selectedOption"] }
+  | { type: "INSERT_TEXT"; text: string }
+  | { type: "BACKSPACE" }
+  | { type: "MOVE_CURSOR_LEFT" }
+  | { type: "MOVE_CURSOR_RIGHT" };
+
+export function confirmationReducer(
+  state: ConfirmationState,
+  action: ConfirmationAction,
+): ConfirmationState {
+  switch (action.type) {
+    case "SELECT_OPTION":
+      return { ...state, selectedOption: action.option };
+    case "INSERT_TEXT": {
+      const nextText =
+        state.alternativeText.slice(0, state.alternativeCursorPosition) +
+        action.text +
+        state.alternativeText.slice(state.alternativeCursorPosition);
+      return {
+        ...state,
+        selectedOption: "alternative",
+        alternativeText: nextText,
+        alternativeCursorPosition:
+          state.alternativeCursorPosition + action.text.length,
+        hasUserInput: true,
+      };
+    }
+    case "BACKSPACE": {
+      if (state.alternativeCursorPosition <= 0) return state;
+      const nextText =
+        state.alternativeText.slice(0, state.alternativeCursorPosition - 1) +
+        state.alternativeText.slice(state.alternativeCursorPosition);
+      return {
+        ...state,
+        selectedOption: "alternative",
+        alternativeText: nextText,
+        alternativeCursorPosition: state.alternativeCursorPosition - 1,
+        hasUserInput: nextText.length > 0,
+      };
+    }
+    case "MOVE_CURSOR_LEFT":
+      return {
+        ...state,
+        alternativeCursorPosition: Math.max(
+          0,
+          state.alternativeCursorPosition - 1,
+        ),
+      };
+    case "MOVE_CURSOR_RIGHT":
+      return {
+        ...state,
+        alternativeCursorPosition: Math.min(
+          state.alternativeText.length,
+          state.alternativeCursorPosition + 1,
+        ),
+      };
+    default:
+      return state;
+  }
+}

--- a/packages/code/src/reducers/confirmationReducer.ts
+++ b/packages/code/src/reducers/confirmationReducer.ts
@@ -1,8 +1,11 @@
+import type { PermissionDecision } from "wave-agent-sdk";
+
 export interface ConfirmationState {
   selectedOption: "clear" | "auto" | "allow" | "alternative";
   alternativeText: string;
   alternativeCursorPosition: number;
   hasUserInput: boolean;
+  decision: PermissionDecision | null;
 }
 
 export type ConfirmationAction =
@@ -10,7 +13,8 @@ export type ConfirmationAction =
   | { type: "INSERT_TEXT"; text: string }
   | { type: "BACKSPACE" }
   | { type: "MOVE_CURSOR_LEFT" }
-  | { type: "MOVE_CURSOR_RIGHT" };
+  | { type: "MOVE_CURSOR_RIGHT" }
+  | { type: "CONFIRM"; decision: PermissionDecision };
 
 export function confirmationReducer(
   state: ConfirmationState,
@@ -62,6 +66,8 @@ export function confirmationReducer(
           state.alternativeCursorPosition + 1,
         ),
       };
+    case "CONFIRM":
+      return { ...state, decision: action.decision };
     default:
       return state;
   }

--- a/packages/code/src/reducers/questionReducer.ts
+++ b/packages/code/src/reducers/questionReducer.ts
@@ -1,0 +1,251 @@
+import type { PermissionDecision } from "wave-agent-sdk";
+
+export interface QuestionSavedState {
+  selectedOptionIndex: number;
+  selectedOptionIndices: Set<number>;
+  otherText: string;
+  otherCursorPosition: number;
+}
+
+export interface QuestionState {
+  currentQuestionIndex: number;
+  selectedOptionIndex: number;
+  selectedOptionIndices: Set<number>;
+  userAnswers: Record<string, string>;
+  otherText: string;
+  otherCursorPosition: number;
+  savedStates: Record<number, QuestionSavedState>;
+  decision: PermissionDecision | null;
+}
+
+export type QuestionAction =
+  | { type: "SELECT_OPTION"; index: number }
+  | { type: "MOVE_OPTION_UP"; maxIndex: number }
+  | { type: "MOVE_OPTION_DOWN"; maxIndex: number }
+  | {
+      type: "TOGGLE_MULTI_SELECT";
+      optionsLength: number;
+    }
+  | { type: "CYCLE_QUESTION"; shift: boolean; questionCount: number }
+  | { type: "INSERT_OTHER"; text: string; optionsLength: number }
+  | { type: "DELETE_OTHER"; optionsLength: number }
+  | { type: "MOVE_OTHER_LEFT"; optionsLength: number }
+  | { type: "MOVE_OTHER_RIGHT"; optionsLength: number }
+  | {
+      type: "CONFIRM_ANSWER";
+      currentQuestion: {
+        question: string;
+        options: Array<{ label: string }>;
+        multiSelect?: boolean;
+      };
+      options: Array<{ label: string }>;
+      isMultiSelect: boolean;
+      questions: Array<{
+        question: string;
+        options: Array<{ label: string }>;
+        multiSelect?: boolean;
+      }>;
+    };
+
+function buildAnswerFromSavedState(
+  q: {
+    question: string;
+    options: Array<{ label: string }>;
+    multiSelect?: boolean;
+  },
+  s: QuestionSavedState,
+): string {
+  const opts = [...q.options, { label: "Other" }];
+  let a = "";
+  if (q.multiSelect) {
+    const selectedLabels = Array.from(s.selectedOptionIndices)
+      .filter((i) => i < q.options.length)
+      .map((i) => q.options[i].label);
+    const isOtherChecked = s.selectedOptionIndices.has(opts.length - 1);
+    if (isOtherChecked && s.otherText.trim()) {
+      selectedLabels.push(s.otherText.trim());
+    }
+    a = selectedLabels.join(", ");
+  } else {
+    if (s.selectedOptionIndex === opts.length - 1) {
+      a = s.otherText.trim();
+    } else {
+      a = opts[s.selectedOptionIndex].label;
+    }
+  }
+  return a;
+}
+
+export function questionReducer(
+  state: QuestionState,
+  action: QuestionAction,
+): QuestionState {
+  switch (action.type) {
+    case "SELECT_OPTION":
+      return { ...state, selectedOptionIndex: action.index };
+    case "MOVE_OPTION_UP":
+      return {
+        ...state,
+        selectedOptionIndex: Math.max(0, state.selectedOptionIndex - 1),
+      };
+    case "MOVE_OPTION_DOWN":
+      return {
+        ...state,
+        selectedOptionIndex: Math.min(
+          action.maxIndex,
+          state.selectedOptionIndex + 1,
+        ),
+      };
+    case "TOGGLE_MULTI_SELECT": {
+      const nextIndices = new Set(state.selectedOptionIndices);
+      if (nextIndices.has(state.selectedOptionIndex))
+        nextIndices.delete(state.selectedOptionIndex);
+      else nextIndices.add(state.selectedOptionIndex);
+      return { ...state, selectedOptionIndices: nextIndices };
+    }
+    case "CYCLE_QUESTION": {
+      const direction = action.shift ? -1 : 1;
+      let nextIndex = state.currentQuestionIndex + direction;
+      if (nextIndex < 0) nextIndex = action.questionCount - 1;
+      if (nextIndex >= action.questionCount) nextIndex = 0;
+      if (nextIndex === state.currentQuestionIndex) return state;
+      const savedStates = {
+        ...state.savedStates,
+        [state.currentQuestionIndex]: {
+          selectedOptionIndex: state.selectedOptionIndex,
+          selectedOptionIndices: state.selectedOptionIndices,
+          otherText: state.otherText,
+          otherCursorPosition: state.otherCursorPosition,
+        },
+      };
+      const nextState = savedStates[nextIndex] || {
+        selectedOptionIndex: 0,
+        selectedOptionIndices: new Set<number>(),
+        otherText: "",
+        otherCursorPosition: 0,
+      };
+      return {
+        ...state,
+        currentQuestionIndex: nextIndex,
+        ...nextState,
+        savedStates,
+      };
+    }
+    case "INSERT_OTHER": {
+      if (state.selectedOptionIndex !== action.optionsLength - 1) return state;
+      const newText =
+        state.otherText.slice(0, state.otherCursorPosition) +
+        action.text +
+        state.otherText.slice(state.otherCursorPosition);
+      return {
+        ...state,
+        otherText: newText,
+        otherCursorPosition: state.otherCursorPosition + action.text.length,
+      };
+    }
+    case "DELETE_OTHER":
+      if (state.selectedOptionIndex !== action.optionsLength - 1) return state;
+      if (state.otherCursorPosition > 0) {
+        return {
+          ...state,
+          otherText:
+            state.otherText.slice(0, state.otherCursorPosition - 1) +
+            state.otherText.slice(state.otherCursorPosition),
+          otherCursorPosition: state.otherCursorPosition - 1,
+        };
+      }
+      return state;
+    case "MOVE_OTHER_LEFT":
+      if (state.selectedOptionIndex !== action.optionsLength - 1) return state;
+      return {
+        ...state,
+        otherCursorPosition: Math.max(0, state.otherCursorPosition - 1),
+      };
+    case "MOVE_OTHER_RIGHT":
+      if (state.selectedOptionIndex !== action.optionsLength - 1) return state;
+      return {
+        ...state,
+        otherCursorPosition: Math.min(
+          state.otherText.length,
+          state.otherCursorPosition + 1,
+        ),
+      };
+    case "CONFIRM_ANSWER": {
+      const { currentQuestion: cq, options, isMultiSelect, questions } = action;
+      const isOtherFocused = state.selectedOptionIndex === options.length - 1;
+      let answer = "";
+      if (isMultiSelect) {
+        const selectedLabels = Array.from(state.selectedOptionIndices)
+          .filter((i) => i < cq.options.length)
+          .map((i) => cq.options[i].label);
+        const isOtherChecked = state.selectedOptionIndices.has(
+          options.length - 1,
+        );
+        if (isOtherChecked && state.otherText.trim()) {
+          selectedLabels.push(state.otherText.trim());
+        }
+        answer = selectedLabels.join(", ");
+      } else {
+        if (isOtherFocused) {
+          answer = state.otherText.trim();
+        } else {
+          answer = options[state.selectedOptionIndex].label;
+        }
+      }
+      if (!answer) return state;
+
+      const newAnswers = {
+        ...state.userAnswers,
+        [cq.question]: answer,
+      };
+
+      if (state.currentQuestionIndex < questions.length - 1) {
+        const nextIndex = state.currentQuestionIndex + 1;
+        const savedStates = {
+          ...state.savedStates,
+          [state.currentQuestionIndex]: {
+            selectedOptionIndex: state.selectedOptionIndex,
+            selectedOptionIndices: state.selectedOptionIndices,
+            otherText: state.otherText,
+            otherCursorPosition: state.otherCursorPosition,
+          },
+        };
+        const nextState = savedStates[nextIndex] || {
+          selectedOptionIndex: 0,
+          selectedOptionIndices: new Set<number>(),
+          otherText: "",
+          otherCursorPosition: 0,
+        };
+        return {
+          ...state,
+          currentQuestionIndex: nextIndex,
+          ...nextState,
+          userAnswers: newAnswers,
+          savedStates,
+        };
+      } else {
+        const finalAnswers = { ...newAnswers };
+        for (const [idxStr, s] of Object.entries(state.savedStates)) {
+          const idx = parseInt(idxStr);
+          const q = questions[idx];
+          if (q && !finalAnswers[q.question]) {
+            const a = buildAnswerFromSavedState(q, s);
+            if (a) finalAnswers[q.question] = a;
+          }
+        }
+        const allAnswered = questions.every((q) => finalAnswers[q.question]);
+        if (!allAnswered) return state;
+        return {
+          ...state,
+          userAnswers: finalAnswers,
+          decision: {
+            behavior: "allow",
+            message: JSON.stringify(finalAnswers),
+          },
+        };
+      }
+    }
+    default:
+      return state;
+  }
+}

--- a/packages/code/tests/components/ConfirmationSelector.test.tsx
+++ b/packages/code/tests/components/ConfirmationSelector.test.tsx
@@ -1,0 +1,573 @@
+import React from "react";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from "vitest";
+import { render } from "ink-testing-library";
+import { ConfirmationSelector } from "../../src/components/ConfirmationSelector.js";
+import { stripAnsiColors } from "wave-agent-sdk";
+import type { PermissionDecision } from "wave-agent-sdk";
+
+describe("ConfirmationSelector Additional Coverage", () => {
+  let mockOnDecision: Mock<(decision: PermissionDecision) => void>;
+  let mockOnCancel: Mock<() => void>;
+
+  beforeEach(() => {
+    mockOnDecision = vi.fn<(decision: PermissionDecision) => void>();
+    mockOnCancel = vi.fn<() => void>();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("EnterPlanMode Tests", () => {
+    it("should default to 'allow' option for EnterPlanMode", async () => {
+      const { lastFrame } = render(
+        <ConfirmationSelector
+          toolName="EnterPlanMode"
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
+      });
+      const frame = lastFrame();
+      expect(frame).toContain("> Yes, proceed");
+      expect(frame).not.toContain("Yes, clear context");
+    });
+
+    it("should show 'start implementing' placeholder when on alternative option", async () => {
+      const { stdin, lastFrame } = render(
+        <ConfirmationSelector
+          toolName="EnterPlanMode"
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
+      });
+      // Navigate to alternative option
+      stdin.write("\u001b[B"); // Down to auto
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain(
+          "> Yes, and auto-accept edits",
+        );
+      });
+      stdin.write("\u001b[B"); // Down to alternative
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain(
+          "> No, start implementing now",
+        );
+      });
+    });
+
+    it("should allow EnterPlanMode with newPermissionMode: plan", async () => {
+      const { stdin, lastFrame } = render(
+        <ConfirmationSelector
+          toolName="EnterPlanMode"
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
+      });
+      stdin.write("\r");
+      await vi.waitFor(() => {
+        expect(mockOnDecision).toHaveBeenCalledWith({
+          behavior: "allow",
+          newPermissionMode: "plan",
+        });
+      });
+    });
+
+    it("should auto EnterPlanMode with newPermissionMode: plan", async () => {
+      const { stdin, lastFrame } = render(
+        <ConfirmationSelector
+          toolName="EnterPlanMode"
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
+      });
+      stdin.write("\u001b[B"); // Down to auto
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain(
+          "> Yes, and auto-accept edits",
+        );
+      });
+      stdin.write("\r");
+      await vi.waitFor(() => {
+        expect(mockOnDecision).toHaveBeenCalledWith({
+          behavior: "allow",
+          newPermissionMode: "plan",
+        });
+      });
+    });
+
+    it("should deny EnterPlanMode with default message when alternative is empty", async () => {
+      const { stdin, lastFrame } = render(
+        <ConfirmationSelector
+          toolName="EnterPlanMode"
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
+      });
+      // Navigate down twice to reach alternative option
+      stdin.write("\u001b[B"); // Down to auto
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain(
+          "> Yes, and auto-accept edits",
+        );
+      });
+      stdin.write("\u001b[B"); // Down to alternative
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain(
+          "> No, start implementing now",
+        );
+      });
+      stdin.write("\r");
+      await vi.waitFor(() => {
+        expect(mockOnDecision).toHaveBeenCalledWith({
+          behavior: "deny",
+          message: "User chose not to enter plan mode",
+        });
+      });
+    });
+  });
+
+  describe("MCP Tool Tests", () => {
+    it("should show correct auto text for mcp__ tools", async () => {
+      const { lastFrame } = render(
+        <ConfirmationSelector
+          toolName="mcp__github__create_issue"
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain(
+          "Yes, and don't ask again for: mcp__github__create_issue",
+        );
+      });
+    });
+
+    it("should auto-allow mcp__ tool with newPermissionRule", async () => {
+      const { stdin, lastFrame } = render(
+        <ConfirmationSelector
+          toolName="mcp__github__create_issue"
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
+      });
+      stdin.write("\u001b[B"); // Down to auto
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain(
+          "> Yes, and don't ask again",
+        );
+      });
+      stdin.write("\r");
+      await vi.waitFor(() => {
+        expect(mockOnDecision).toHaveBeenCalledWith({
+          behavior: "allow",
+          newPermissionRule: "mcp__github__create_issue",
+        });
+      });
+    });
+  });
+
+  describe("Bash mkdir Tests", () => {
+    it("should show 'auto-accept edits' auto text for mkdir command", async () => {
+      const { lastFrame } = render(
+        <ConfirmationSelector
+          toolName="Bash"
+          toolInput={{ command: "mkdir -p src/components" }}
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain(
+          "Yes, and auto-accept edits",
+        );
+      });
+    });
+
+    it("should auto-allow mkdir with acceptEdits mode", async () => {
+      const { stdin, lastFrame } = render(
+        <ConfirmationSelector
+          toolName="Bash"
+          toolInput={{ command: "mkdir -p src/components" }}
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
+      });
+      stdin.write("\u001b[B"); // Down to auto
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain(
+          "> Yes, and auto-accept edits",
+        );
+      });
+      stdin.write("\r");
+      await vi.waitFor(() => {
+        expect(mockOnDecision).toHaveBeenCalledWith({
+          behavior: "allow",
+          newPermissionMode: "acceptEdits",
+        });
+      });
+    });
+  });
+
+  describe("isExpanded Tests", () => {
+    it("should render nothing for non-AskUserQuestion tools when isExpanded is true", () => {
+      const { lastFrame } = render(
+        <ConfirmationSelector
+          toolName="Edit"
+          isExpanded={true}
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+      const frame = lastFrame();
+      expect(frame).toBe("");
+    });
+
+    it("should render nothing for AskUserQuestion when isExpanded is true", () => {
+      const mockQuestions = {
+        questions: [
+          {
+            question: "What color?",
+            header: "Color",
+            options: [{ label: "Red" }, { label: "Blue" }],
+          },
+        ],
+      };
+      const { lastFrame } = render(
+        <ConfirmationSelector
+          toolName="AskUserQuestion"
+          toolInput={mockQuestions as unknown as Record<string, unknown>}
+          isExpanded={true}
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+      const frame = lastFrame();
+      expect(frame).toBe("");
+    });
+  });
+
+  describe("Ctrl/Meta/Alt key filtering", () => {
+    it("should not capture Ctrl key as text input", async () => {
+      const { stdin, lastFrame } = render(
+        <ConfirmationSelector
+          toolName="Edit"
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
+      });
+
+      // Simulate Ctrl+C (common pattern: input with key.ctrl=true)
+      stdin.write("\u0003");
+
+      // Should not switch to alternative or show text
+      const frame = lastFrame();
+      expect(frame).toContain("> Yes, proceed");
+      expect(frame).not.toContain("\u0003");
+    });
+
+    it("should not capture Alt key as text input", async () => {
+      const { stdin, lastFrame } = render(
+        <ConfirmationSelector
+          toolName="Edit"
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
+      });
+
+      // Simulate Alt+key - ink passes this as input with key.alt=true
+      stdin.write("\u001b"); // Escape prefix for Alt
+
+      // Should remain on allow option
+      await vi.waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain("> Yes, proceed");
+      });
+    });
+  });
+
+  describe("Delete key in alternative text", () => {
+    it("should handle delete key for backward deletion (same as backspace)", async () => {
+      const { stdin, lastFrame } = render(
+        <ConfirmationSelector
+          toolName="Edit"
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain(
+          "Type here to tell Wave what to change",
+        );
+      });
+
+      // Type "ABC"
+      stdin.write("ABC");
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> ABC");
+      });
+
+      // Move cursor left twice (between A and B, position 1)
+      stdin.write("\u001b[D");
+      stdin.write("\u001b[D");
+
+      // Press Delete key - component treats delete same as backspace
+      // Deletes character before cursor (position 0), removing "A"
+      stdin.write("\x1b[3~");
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("BC");
+      });
+    });
+  });
+
+  describe("AskUserQuestion edge cases", () => {
+    it("should submit immediately when there is only one question", async () => {
+      const mockQuestions = {
+        questions: [
+          {
+            question: "Are you sure?",
+            header: "Confirm",
+            options: [{ label: "Yes" }, { label: "No" }],
+          },
+        ],
+      };
+
+      const { stdin, lastFrame } = render(
+        <ConfirmationSelector
+          toolName="AskUserQuestion"
+          toolInput={mockQuestions as unknown as Record<string, unknown>}
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("Are you sure?");
+      });
+
+      stdin.write("\r"); // Select "Yes" and submit (only question)
+      await vi.waitFor(() => {
+        expect(mockOnDecision).toHaveBeenCalled();
+      });
+
+      const call = mockOnDecision.mock.calls[0][0];
+      expect(call.behavior).toBe("allow");
+      const message = JSON.parse(call.message!);
+      expect(message["Are you sure?"]).toBe("Yes");
+    });
+
+    it("should not submit when multi-select has no selections", async () => {
+      const mockQuestions = {
+        questions: [
+          {
+            question: "Pick skills",
+            header: "Skills",
+            multiSelect: true,
+            options: [{ label: "TypeScript" }, { label: "React" }],
+          },
+        ],
+      };
+
+      const { stdin, lastFrame } = render(
+        <ConfirmationSelector
+          toolName="AskUserQuestion"
+          toolInput={mockQuestions as unknown as Record<string, unknown>}
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("Pick skills");
+      });
+
+      // Press Enter without selecting anything - should not submit
+      stdin.write("\r");
+
+      await vi.waitFor(() => {
+        // Verify still on the question, not submitted
+        expect(stripAnsiColors(lastFrame() || "")).toContain("Pick skills");
+      });
+      expect(mockOnDecision).not.toHaveBeenCalled();
+    });
+
+    it("should submit multi-select with Other text combined", async () => {
+      const mockQuestions = {
+        questions: [
+          {
+            question: "Pick skills",
+            header: "Skills",
+            multiSelect: true,
+            options: [{ label: "TypeScript" }],
+          },
+        ],
+      };
+
+      const { stdin, lastFrame } = render(
+        <ConfirmationSelector
+          toolName="AskUserQuestion"
+          toolInput={mockQuestions as unknown as Record<string, unknown>}
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("Pick skills");
+      });
+
+      // Toggle TypeScript (Space on focused option)
+      stdin.write(" ");
+      // Navigate to Other
+      stdin.write("\u001b[B");
+      // Type custom skill and confirm via space toggle
+      stdin.write(" ");
+
+      // Check Other is checked
+      await vi.waitFor(() => {
+        const frame = stripAnsiColors(lastFrame() || "");
+        expect(frame).toContain("[x] Other");
+      });
+
+      // Now type the custom text - in multi-select Other, typing goes into otherText
+      stdin.write("Python");
+
+      // Submit
+      stdin.write("\r");
+
+      await vi.waitFor(() => {
+        expect(mockOnDecision).toHaveBeenCalled();
+      });
+
+      const call = mockOnDecision.mock.calls[0][0];
+      const message = JSON.parse(call.message!);
+      // Both TypeScript (checked via space) and Python (typed in Other)
+      expect(message["Pick skills"]).toContain("TypeScript");
+      expect(message["Pick skills"]).toContain("Python");
+    });
+  });
+
+  describe("getAutoOptionText branches", () => {
+    it("should show 'Yes, and auto-accept edits' for generic tools", async () => {
+      const { lastFrame } = render(
+        <ConfirmationSelector
+          toolName="Write"
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain(
+          "Yes, and auto-accept edits",
+        );
+      });
+    });
+
+    it("should auto-allow generic tools with acceptEdits mode", async () => {
+      const { stdin, lastFrame } = render(
+        <ConfirmationSelector
+          toolName="Write"
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
+      });
+      stdin.write("\u001b[B"); // Down to auto
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain(
+          "> Yes, and auto-accept edits",
+        );
+      });
+      stdin.write("\r");
+      await vi.waitFor(() => {
+        expect(mockOnDecision).toHaveBeenCalledWith({
+          behavior: "allow",
+          newPermissionMode: "acceptEdits",
+        });
+      });
+    });
+  });
+
+  describe("AskUserQuestion with empty questions", () => {
+    it("should not crash when questions array is empty", () => {
+      const mockQuestions = { questions: [] };
+
+      const { lastFrame } = render(
+        <ConfirmationSelector
+          toolName="AskUserQuestion"
+          toolInput={mockQuestions as unknown as Record<string, unknown>}
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+      const frame = lastFrame();
+      // Should render empty since currentQuestion is undefined
+      expect(frame).toBe("");
+    });
+
+    it("should not crash when toolInput has no questions property", () => {
+      const { lastFrame } = render(
+        <ConfirmationSelector
+          toolName="AskUserQuestion"
+          toolInput={{}}
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+      const frame = lastFrame();
+      expect(frame).toBe("");
+    });
+  });
+});

--- a/packages/code/tests/components/confirmationReducer.test.ts
+++ b/packages/code/tests/components/confirmationReducer.test.ts
@@ -10,6 +10,7 @@ const initialState: ConfirmationState = {
   alternativeText: "",
   alternativeCursorPosition: 0,
   hasUserInput: false,
+  decision: null,
 };
 
 describe("confirmationReducer", () => {
@@ -163,6 +164,32 @@ describe("confirmationReducer", () => {
         type: "MOVE_CURSOR_RIGHT",
       });
       expect(result.alternativeCursorPosition).toBe(2);
+    });
+  });
+
+  describe("CONFIRM", () => {
+    it("should set the decision", () => {
+      const result = confirmationReducer(initialState, {
+        type: "CONFIRM",
+        decision: { behavior: "allow" },
+      });
+      expect(result.decision).toEqual({ behavior: "allow" });
+    });
+
+    it("should set decision with newPermissionRule", () => {
+      const result = confirmationReducer(initialState, {
+        type: "CONFIRM",
+        decision: { behavior: "allow", newPermissionRule: "Bash(test)" },
+      });
+      expect(result.decision?.newPermissionRule).toBe("Bash(test)");
+    });
+
+    it("should set decision with deny", () => {
+      const result = confirmationReducer(initialState, {
+        type: "CONFIRM",
+        decision: { behavior: "deny", message: "no" },
+      });
+      expect(result.decision).toEqual({ behavior: "deny", message: "no" });
     });
   });
 

--- a/packages/code/tests/components/confirmationReducer.test.ts
+++ b/packages/code/tests/components/confirmationReducer.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import {
+  confirmationReducer,
+  type ConfirmationAction,
+} from "../../src/reducers/confirmationReducer.js";
+import type { ConfirmationState } from "../../src/reducers/confirmationReducer.js";
+
+const initialState: ConfirmationState = {
+  selectedOption: "allow",
+  alternativeText: "",
+  alternativeCursorPosition: 0,
+  hasUserInput: false,
+};
+
+describe("confirmationReducer", () => {
+  describe("SELECT_OPTION", () => {
+    it("should change selectedOption", () => {
+      const result = confirmationReducer(initialState, {
+        type: "SELECT_OPTION",
+        option: "alternative",
+      });
+      expect(result.selectedOption).toBe("alternative");
+    });
+
+    it("should not affect other fields", () => {
+      const state: ConfirmationState = {
+        ...initialState,
+        alternativeText: "hello",
+        alternativeCursorPosition: 2,
+      };
+      const result = confirmationReducer(state, {
+        type: "SELECT_OPTION",
+        option: "auto",
+      });
+      expect(result.selectedOption).toBe("auto");
+      expect(result.alternativeText).toBe("hello");
+      expect(result.alternativeCursorPosition).toBe(2);
+    });
+  });
+
+  describe("INSERT_TEXT", () => {
+    it("should insert text at cursor position", () => {
+      const state: ConfirmationState = {
+        ...initialState,
+        alternativeText: "ab",
+        alternativeCursorPosition: 1,
+      };
+      const result = confirmationReducer(state, {
+        type: "INSERT_TEXT",
+        text: "X",
+      });
+      expect(result.alternativeText).toBe("aXb");
+      expect(result.alternativeCursorPosition).toBe(2);
+    });
+
+    it("should switch to alternative option", () => {
+      const result = confirmationReducer(initialState, {
+        type: "INSERT_TEXT",
+        text: "a",
+      });
+      expect(result.selectedOption).toBe("alternative");
+    });
+
+    it("should set hasUserInput to true", () => {
+      const result = confirmationReducer(initialState, {
+        type: "INSERT_TEXT",
+        text: "a",
+      });
+      expect(result.hasUserInput).toBe(true);
+    });
+
+    it("should insert multi-char text", () => {
+      const result = confirmationReducer(initialState, {
+        type: "INSERT_TEXT",
+        text: "hello",
+      });
+      expect(result.alternativeText).toBe("hello");
+      expect(result.alternativeCursorPosition).toBe(5);
+    });
+  });
+
+  describe("BACKSPACE", () => {
+    it("should delete character before cursor", () => {
+      const state: ConfirmationState = {
+        ...initialState,
+        alternativeText: "abc",
+        alternativeCursorPosition: 2,
+        hasUserInput: true,
+      };
+      const result = confirmationReducer(state, { type: "BACKSPACE" });
+      expect(result.alternativeText).toBe("ac");
+      expect(result.alternativeCursorPosition).toBe(1);
+    });
+
+    it("should return unchanged state if cursor at 0", () => {
+      const result = confirmationReducer(initialState, { type: "BACKSPACE" });
+      expect(result).toBe(initialState);
+    });
+
+    it("should set hasUserInput to false when text becomes empty", () => {
+      const state: ConfirmationState = {
+        ...initialState,
+        alternativeText: "a",
+        alternativeCursorPosition: 1,
+        hasUserInput: true,
+      };
+      const result = confirmationReducer(state, { type: "BACKSPACE" });
+      expect(result.hasUserInput).toBe(false);
+      expect(result.alternativeText).toBe("");
+    });
+
+    it("should switch to alternative option", () => {
+      const state: ConfirmationState = {
+        ...initialState,
+        alternativeText: "abc",
+        alternativeCursorPosition: 2,
+      };
+      const result = confirmationReducer(state, { type: "BACKSPACE" });
+      expect(result.selectedOption).toBe("alternative");
+    });
+  });
+
+  describe("MOVE_CURSOR_LEFT", () => {
+    it("should decrease cursor position", () => {
+      const state: ConfirmationState = {
+        ...initialState,
+        alternativeCursorPosition: 3,
+      };
+      const result = confirmationReducer(state, {
+        type: "MOVE_CURSOR_LEFT",
+      });
+      expect(result.alternativeCursorPosition).toBe(2);
+    });
+
+    it("should not go below 0", () => {
+      const result = confirmationReducer(initialState, {
+        type: "MOVE_CURSOR_LEFT",
+      });
+      expect(result.alternativeCursorPosition).toBe(0);
+    });
+  });
+
+  describe("MOVE_CURSOR_RIGHT", () => {
+    it("should increase cursor position", () => {
+      const state: ConfirmationState = {
+        ...initialState,
+        alternativeText: "hello",
+        alternativeCursorPosition: 2,
+      };
+      const result = confirmationReducer(state, {
+        type: "MOVE_CURSOR_RIGHT",
+      });
+      expect(result.alternativeCursorPosition).toBe(3);
+    });
+
+    it("should not go beyond text length", () => {
+      const state: ConfirmationState = {
+        ...initialState,
+        alternativeText: "hi",
+        alternativeCursorPosition: 2,
+      };
+      const result = confirmationReducer(state, {
+        type: "MOVE_CURSOR_RIGHT",
+      });
+      expect(result.alternativeCursorPosition).toBe(2);
+    });
+  });
+
+  describe("default action", () => {
+    it("should return state unchanged for unknown action", () => {
+      const result = confirmationReducer(initialState, {
+        type: "UNKNOWN",
+      } as unknown as ConfirmationAction);
+      expect(result).toBe(initialState);
+    });
+  });
+});

--- a/packages/code/tests/components/questionReducer.test.ts
+++ b/packages/code/tests/components/questionReducer.test.ts
@@ -1,0 +1,494 @@
+import { describe, it, expect } from "vitest";
+import {
+  questionReducer,
+  type QuestionAction,
+  type QuestionState,
+} from "../../src/reducers/questionReducer.js";
+
+const initialState: QuestionState = {
+  currentQuestionIndex: 0,
+  selectedOptionIndex: 0,
+  selectedOptionIndices: new Set<number>(),
+  userAnswers: {},
+  otherText: "",
+  otherCursorPosition: 0,
+  savedStates: {},
+  decision: null,
+};
+
+const mockQuestions = [
+  { question: "Q1", options: [{ label: "A" }, { label: "B" }] },
+  { question: "Q2", options: [{ label: "C" }] },
+];
+
+const mockOptions = [{ label: "A" }, { label: "B" }, { label: "Other" }];
+
+describe("questionReducer", () => {
+  describe("SELECT_OPTION", () => {
+    it("should change selectedOptionIndex", () => {
+      const result = questionReducer(initialState, {
+        type: "SELECT_OPTION",
+        index: 2,
+      });
+      expect(result.selectedOptionIndex).toBe(2);
+    });
+  });
+
+  describe("MOVE_OPTION_UP", () => {
+    it("should decrease index", () => {
+      const state: QuestionState = {
+        ...initialState,
+        selectedOptionIndex: 2,
+      };
+      const result = questionReducer(state, {
+        type: "MOVE_OPTION_UP",
+        maxIndex: 2,
+      });
+      expect(result.selectedOptionIndex).toBe(1);
+    });
+
+    it("should not go below 0", () => {
+      const result = questionReducer(initialState, {
+        type: "MOVE_OPTION_UP",
+        maxIndex: 2,
+      });
+      expect(result.selectedOptionIndex).toBe(0);
+    });
+  });
+
+  describe("MOVE_OPTION_DOWN", () => {
+    it("should increase index", () => {
+      const result = questionReducer(initialState, {
+        type: "MOVE_OPTION_DOWN",
+        maxIndex: 2,
+      });
+      expect(result.selectedOptionIndex).toBe(1);
+    });
+
+    it("should not exceed maxIndex", () => {
+      const state: QuestionState = {
+        ...initialState,
+        selectedOptionIndex: 2,
+      };
+      const result = questionReducer(state, {
+        type: "MOVE_OPTION_DOWN",
+        maxIndex: 2,
+      });
+      expect(result.selectedOptionIndex).toBe(2);
+    });
+  });
+
+  describe("TOGGLE_MULTI_SELECT", () => {
+    it("should add option to selected set", () => {
+      const result = questionReducer(initialState, {
+        type: "TOGGLE_MULTI_SELECT",
+        optionsLength: 3,
+      });
+      expect(result.selectedOptionIndices.has(0)).toBe(true);
+    });
+
+    it("should remove option if already selected", () => {
+      const state: QuestionState = {
+        ...initialState,
+        selectedOptionIndices: new Set([0]),
+      };
+      const result = questionReducer(state, {
+        type: "TOGGLE_MULTI_SELECT",
+        optionsLength: 3,
+      });
+      expect(result.selectedOptionIndices.has(0)).toBe(false);
+    });
+
+    it("should remove option if already selected", () => {
+      const state: QuestionState = {
+        ...initialState,
+        selectedOptionIndex: 1,
+        selectedOptionIndices: new Set([1]),
+      };
+      const result = questionReducer(state, {
+        type: "TOGGLE_MULTI_SELECT",
+        optionsLength: 3,
+      });
+      expect(result.selectedOptionIndices).toEqual(new Set<number>());
+    });
+  });
+
+  describe("CYCLE_QUESTION", () => {
+    it("should save current state and restore next question's state", () => {
+      const state: QuestionState = {
+        ...initialState,
+        selectedOptionIndex: 1,
+        otherText: "test",
+        otherCursorPosition: 4,
+        savedStates: {
+          1: {
+            selectedOptionIndex: 0,
+            selectedOptionIndices: new Set<number>(),
+            otherText: "",
+            otherCursorPosition: 0,
+          },
+        },
+      };
+      const result = questionReducer(state, {
+        type: "CYCLE_QUESTION",
+        shift: false,
+        questionCount: 2,
+      });
+      expect(result.currentQuestionIndex).toBe(1);
+      expect(result.selectedOptionIndex).toBe(0);
+      expect(result.otherText).toBe("");
+      // Current state should be saved
+      expect(result.savedStates[0].selectedOptionIndex).toBe(1);
+      expect(result.savedStates[0].otherText).toBe("test");
+    });
+
+    it("should cycle forward with wrap-around", () => {
+      const state: QuestionState = {
+        ...initialState,
+        currentQuestionIndex: 1,
+      };
+      const result = questionReducer(state, {
+        type: "CYCLE_QUESTION",
+        shift: false,
+        questionCount: 2,
+      });
+      expect(result.currentQuestionIndex).toBe(0);
+    });
+
+    it("should cycle backward with Shift", () => {
+      const result = questionReducer(initialState, {
+        type: "CYCLE_QUESTION",
+        shift: true,
+        questionCount: 2,
+      });
+      expect(result.currentQuestionIndex).toBe(1);
+    });
+
+    it("should return state unchanged if only one question", () => {
+      const result = questionReducer(initialState, {
+        type: "CYCLE_QUESTION",
+        shift: false,
+        questionCount: 1,
+      });
+      expect(result.currentQuestionIndex).toBe(0);
+      expect(result).toBe(initialState);
+    });
+  });
+
+  describe("INSERT_OTHER", () => {
+    it("should insert text when Other is focused", () => {
+      const state: QuestionState = {
+        ...initialState,
+        selectedOptionIndex: 2,
+      };
+      const result = questionReducer(state, {
+        type: "INSERT_OTHER",
+        text: "hello",
+        optionsLength: 3,
+      });
+      expect(result.otherText).toBe("hello");
+      expect(result.otherCursorPosition).toBe(5);
+    });
+
+    it("should do nothing when Other is not focused", () => {
+      const result = questionReducer(initialState, {
+        type: "INSERT_OTHER",
+        text: "hello",
+        optionsLength: 3,
+      });
+      expect(result.otherText).toBe("");
+    });
+
+    it("should insert at cursor position", () => {
+      const state: QuestionState = {
+        ...initialState,
+        selectedOptionIndex: 2,
+        otherText: "ac",
+        otherCursorPosition: 1,
+      };
+      const result = questionReducer(state, {
+        type: "INSERT_OTHER",
+        text: "b",
+        optionsLength: 3,
+      });
+      expect(result.otherText).toBe("abc");
+      expect(result.otherCursorPosition).toBe(2);
+    });
+  });
+
+  describe("DELETE_OTHER", () => {
+    it("should delete character before cursor when Other is focused", () => {
+      const state: QuestionState = {
+        ...initialState,
+        selectedOptionIndex: 2,
+        otherText: "abc",
+        otherCursorPosition: 2,
+      };
+      const result = questionReducer(state, {
+        type: "DELETE_OTHER",
+        optionsLength: 3,
+      });
+      expect(result.otherText).toBe("ac");
+      expect(result.otherCursorPosition).toBe(1);
+    });
+
+    it("should do nothing when Other is not focused", () => {
+      const state: QuestionState = {
+        ...initialState,
+        otherText: "abc",
+        otherCursorPosition: 2,
+      };
+      const result = questionReducer(state, {
+        type: "DELETE_OTHER",
+        optionsLength: 3,
+      });
+      expect(result.otherText).toBe("abc");
+    });
+
+    it("should do nothing when cursor at 0", () => {
+      const state: QuestionState = {
+        ...initialState,
+        selectedOptionIndex: 2,
+        otherText: "abc",
+        otherCursorPosition: 0,
+      };
+      const result = questionReducer(state, {
+        type: "DELETE_OTHER",
+        optionsLength: 3,
+      });
+      expect(result.otherText).toBe("abc");
+    });
+  });
+
+  describe("MOVE_OTHER_LEFT", () => {
+    it("should decrease cursor when Other is focused", () => {
+      const state: QuestionState = {
+        ...initialState,
+        selectedOptionIndex: 2,
+        otherCursorPosition: 3,
+      };
+      const result = questionReducer(state, {
+        type: "MOVE_OTHER_LEFT",
+        optionsLength: 3,
+      });
+      expect(result.otherCursorPosition).toBe(2);
+    });
+
+    it("should do nothing when Other is not focused", () => {
+      const state: QuestionState = {
+        ...initialState,
+        otherCursorPosition: 3,
+      };
+      const result = questionReducer(state, {
+        type: "MOVE_OTHER_LEFT",
+        optionsLength: 3,
+      });
+      expect(result.otherCursorPosition).toBe(3);
+    });
+  });
+
+  describe("MOVE_OTHER_RIGHT", () => {
+    it("should increase cursor when Other is focused", () => {
+      const state: QuestionState = {
+        ...initialState,
+        selectedOptionIndex: 2,
+        otherText: "hello",
+        otherCursorPosition: 2,
+      };
+      const result = questionReducer(state, {
+        type: "MOVE_OTHER_RIGHT",
+        optionsLength: 3,
+      });
+      expect(result.otherCursorPosition).toBe(3);
+    });
+
+    it("should not exceed text length", () => {
+      const state: QuestionState = {
+        ...initialState,
+        selectedOptionIndex: 2,
+        otherText: "hi",
+        otherCursorPosition: 2,
+      };
+      const result = questionReducer(state, {
+        type: "MOVE_OTHER_RIGHT",
+        optionsLength: 3,
+      });
+      expect(result.otherCursorPosition).toBe(2);
+    });
+  });
+
+  describe("CONFIRM_ANSWER", () => {
+    it("should advance to next question with saved state", () => {
+      const state: QuestionState = {
+        ...initialState,
+        selectedOptionIndex: 1,
+      };
+      const result = questionReducer(state, {
+        type: "CONFIRM_ANSWER",
+        currentQuestion: mockQuestions[0],
+        options: mockOptions,
+        isMultiSelect: false,
+        questions: mockQuestions,
+      });
+      expect(result.currentQuestionIndex).toBe(1);
+      expect(result.selectedOptionIndex).toBe(0);
+      expect(result.userAnswers["Q1"]).toBe("B");
+      // Current state should be saved
+      expect(result.savedStates[0].selectedOptionIndex).toBe(1);
+    });
+
+    it("should submit decision when on last question with all answers", () => {
+      const state: QuestionState = {
+        ...initialState,
+        currentQuestionIndex: 1,
+        selectedOptionIndex: 0,
+        userAnswers: { Q1: "A" },
+      };
+      const result = questionReducer(state, {
+        type: "CONFIRM_ANSWER",
+        currentQuestion: mockQuestions[1],
+        options: [{ label: "C" }, { label: "Other" }],
+        isMultiSelect: false,
+        questions: mockQuestions,
+      });
+      expect(result.decision).toEqual({
+        behavior: "allow",
+        message: JSON.stringify({ Q1: "A", Q2: "C" }),
+      });
+    });
+
+    it("should return state unchanged if Other answer is empty", () => {
+      const state: QuestionState = {
+        ...initialState,
+        selectedOptionIndex: 2, // Other, but no text
+      };
+      const result = questionReducer(state, {
+        type: "CONFIRM_ANSWER",
+        currentQuestion: mockQuestions[0],
+        options: mockOptions,
+        isMultiSelect: false,
+        questions: mockQuestions,
+      });
+      expect(result).toBe(state);
+    });
+
+    it("should collect savedStates for unanswered questions", () => {
+      // Tab to Q2, answer Q2, Tab back to Q1, answer Q1, then submit
+      const stateAfterQ2: QuestionState = {
+        ...initialState,
+        currentQuestionIndex: 1,
+        selectedOptionIndex: 0,
+        savedStates: {
+          0: {
+            selectedOptionIndex: 1,
+            selectedOptionIndices: new Set<number>(),
+            otherText: "",
+            otherCursorPosition: 0,
+          },
+        },
+      };
+      const result = questionReducer(stateAfterQ2, {
+        type: "CONFIRM_ANSWER",
+        currentQuestion: mockQuestions[1],
+        options: [{ label: "C" }, { label: "Other" }],
+        isMultiSelect: false,
+        questions: mockQuestions,
+      });
+      expect(result.decision).toEqual({
+        behavior: "allow",
+        message: JSON.stringify({ Q2: "C", Q1: "B" }),
+      });
+    });
+
+    it("should handle multi-select answers", () => {
+      const multiSelectQuestions = [
+        {
+          question: "Q1",
+          options: [{ label: "A" }, { label: "B" }],
+          multiSelect: true,
+        },
+      ];
+      const state: QuestionState = {
+        ...initialState,
+        selectedOptionIndices: new Set([0, 1]),
+      };
+      const result = questionReducer(state, {
+        type: "CONFIRM_ANSWER",
+        currentQuestion: multiSelectQuestions[0],
+        options: [...multiSelectQuestions[0].options, { label: "Other" }],
+        isMultiSelect: true,
+        questions: multiSelectQuestions,
+      });
+      expect(result.decision).toEqual({
+        behavior: "allow",
+        message: JSON.stringify({ Q1: "A, B" }),
+      });
+    });
+
+    it("should handle Other text in single-select", () => {
+      const state: QuestionState = {
+        ...initialState,
+        selectedOptionIndex: 2, // Other
+        otherText: "Custom",
+      };
+      const result = questionReducer(state, {
+        type: "CONFIRM_ANSWER",
+        currentQuestion: mockQuestions[0],
+        options: mockOptions,
+        isMultiSelect: false,
+        questions: mockQuestions,
+      });
+      expect(result.currentQuestionIndex).toBe(1);
+      expect(result.userAnswers["Q1"]).toBe("Custom");
+    });
+
+    it("should handle Other text in multi-select", () => {
+      const multiSelectQuestions = [
+        { question: "Q1", options: [{ label: "A" }], multiSelect: true },
+      ];
+      const state: QuestionState = {
+        ...initialState,
+        selectedOptionIndices: new Set([0, 1]),
+        otherText: "Custom",
+      };
+      const result = questionReducer(state, {
+        type: "CONFIRM_ANSWER",
+        currentQuestion: multiSelectQuestions[0],
+        options: [...multiSelectQuestions[0].options, { label: "Other" }],
+        isMultiSelect: true,
+        questions: multiSelectQuestions,
+      });
+      expect(result.decision).toEqual({
+        behavior: "allow",
+        message: JSON.stringify({ Q1: "A, Custom" }),
+      });
+    });
+
+    it("should not submit if not all questions answered", () => {
+      // Start at Q2, answer Q2, but Q1 was never answered
+      const state: QuestionState = {
+        ...initialState,
+        currentQuestionIndex: 1,
+        selectedOptionIndex: 0,
+        savedStates: {}, // No saved state for Q1
+      };
+      const result = questionReducer(state, {
+        type: "CONFIRM_ANSWER",
+        currentQuestion: mockQuestions[1],
+        options: [{ label: "C" }, { label: "Other" }],
+        isMultiSelect: false,
+        questions: mockQuestions,
+      });
+      expect(result.decision).toBeNull();
+    });
+  });
+
+  describe("default action", () => {
+    it("should return state unchanged for unknown action", () => {
+      const result = questionReducer(initialState, {
+        type: "UNKNOWN",
+      } as unknown as QuestionAction);
+      expect(result).toBe(initialState);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Extracted reducers for ConfirmationSelector into dedicated files and eliminated `useRef` for stale closures by passing context in dispatched actions.

## Changes

- **test**: add ConfirmationSelector tests for EnterPlanMode, MCP, mkdir, and edge cases
- **refactor**: extract confirmation and question reducers for better state management
- **refactor**: eliminate stale-closure refs by passing context in dispatched actions
- **refactor**: eliminate pendingDecisionRef by moving decision into reducer state

## Key Improvements

- Extracted `confirmationReducer` and `questionReducer` into individual files under `src/reducers/`
- Eliminated `useRef` for stale closures by passing context in dispatched actions
- Eliminated `pendingDecisionRef` by moving decision logic into reducer state
- Added comprehensive test coverage for extracted reducers