### PR TITLE
fix: eliminate paste chunk loss with single reducer action

### DIFF
--- a/packages/code/src/managers/inputHandlers.ts
+++ b/packages/code/src/managers/inputHandlers.ts
@@ -297,14 +297,12 @@ export const handlePasteInput = (
     inputString.includes("\r");
 
   if (isPasteOperation) {
-    if (!state.isPasting) {
-      dispatch({
-        type: "START_PASTE",
-        payload: { buffer: inputString, cursorPosition: state.cursorPosition },
-      });
-    } else {
-      dispatch({ type: "APPEND_PASTE_BUFFER", payload: inputString });
-    }
+    // Dispatch a single action type; the reducer determines start vs append
+    // by checking pasteBuffer, avoiding stale state issues
+    dispatch({
+      type: "APPEND_PASTE_CHUNK",
+      payload: { chunk: inputString, cursorPosition: state.cursorPosition },
+    });
   } else {
     let char = inputString;
     if (char === "！" && state.cursorPosition === 0) {

--- a/packages/code/src/managers/inputReducer.ts
+++ b/packages/code/src/managers/inputReducer.ts
@@ -173,6 +173,10 @@ export type InputAction =
   | { type: "CLEAR_INPUT" }
   | { type: "START_PASTE"; payload: { buffer: string; cursorPosition: number } }
   | { type: "APPEND_PASTE_BUFFER"; payload: string }
+  | {
+      type: "APPEND_PASTE_CHUNK";
+      payload: { chunk: string; cursorPosition: number };
+    }
   | { type: "END_PASTE" }
   | {
       type: "ADD_IMAGE_AND_INSERT_PLACEHOLDER";
@@ -407,6 +411,21 @@ export function inputReducer(
         cursorPosition: 0,
         historyIndex: -1,
       };
+    case "APPEND_PASTE_CHUNK": {
+      // The reducer determines if this is a new paste or a continuation
+      // by checking if pasteBuffer is already set. This avoids the
+      // handler needing to track isPasting state, which can be stale
+      // when multiple dispatches fire before React state updates.
+      const isNewPaste = !state.pasteBuffer;
+      return {
+        ...state,
+        isPasting: true,
+        pasteBuffer: state.pasteBuffer + action.payload.chunk,
+        initialPasteCursorPosition: isNewPaste
+          ? action.payload.cursorPosition
+          : state.initialPasteCursorPosition,
+      };
+    }
     case "START_PASTE":
       return {
         ...state,

--- a/packages/code/tests/managers/inputHandlers.test.ts
+++ b/packages/code/tests/managers/inputHandlers.test.ts
@@ -447,21 +447,39 @@ describe("inputHandlers", () => {
   });
 
   describe("handlePasteInput", () => {
-    it("should start paste for multi-char input", () => {
+    it("should dispatch APPEND_PASTE_CHUNK for multi-char input", () => {
       const state = { ...initialState, cursorPosition: 0 };
       handlePasteInput(state, dispatch, callbacks, "pasted text");
       expect(dispatch).toHaveBeenCalledWith({
-        type: "START_PASTE",
-        payload: { buffer: "pasted text", cursorPosition: 0 },
+        type: "APPEND_PASTE_CHUNK",
+        payload: { chunk: "pasted text", cursorPosition: 0 },
       });
     });
 
-    it("should append to paste buffer if already pasting", () => {
-      const state = { ...initialState, isPasting: true };
+    it("should dispatch APPEND_PASTE_CHUNK regardless of isPasting state", () => {
+      const state = { ...initialState, isPasting: true, cursorPosition: 5 };
       handlePasteInput(state, dispatch, callbacks, "more text");
       expect(dispatch).toHaveBeenCalledWith({
-        type: "APPEND_PASTE_BUFFER",
-        payload: "more text",
+        type: "APPEND_PASTE_CHUNK",
+        payload: { chunk: "more text", cursorPosition: 5 },
+      });
+    });
+
+    it("should handle paste with newline in single-char-like input", () => {
+      const state = { ...initialState, isPasting: false, cursorPosition: 0 };
+      handlePasteInput(state, dispatch, callbacks, "a\nb");
+      expect(dispatch).toHaveBeenCalledWith({
+        type: "APPEND_PASTE_CHUNK",
+        payload: { chunk: "a\nb", cursorPosition: 0 },
+      });
+    });
+
+    it("should handle paste with carriage return", () => {
+      const state = { ...initialState, isPasting: false, cursorPosition: 0 };
+      handlePasteInput(state, dispatch, callbacks, "a\rb");
+      expect(dispatch).toHaveBeenCalledWith({
+        type: "APPEND_PASTE_CHUNK",
+        payload: { chunk: "a\rb", cursorPosition: 0 },
       });
     });
 

--- a/packages/code/tests/managers/inputReducer.test.ts
+++ b/packages/code/tests/managers/inputReducer.test.ts
@@ -508,6 +508,62 @@ describe("inputReducer", () => {
     expect(state.pasteBuffer).toBe("");
   });
 
+  it("should handle APPEND_PASTE_CHUNK as new paste when buffer is empty", () => {
+    const state = inputReducer(initialState, {
+      type: "APPEND_PASTE_CHUNK",
+      payload: { chunk: "first chunk", cursorPosition: 3 },
+    });
+    expect(state.isPasting).toBe(true);
+    expect(state.pasteBuffer).toBe("first chunk");
+    expect(state.initialPasteCursorPosition).toBe(3);
+  });
+
+  it("should handle APPEND_PASTE_CHUNK as append when buffer is already set", () => {
+    let state = inputReducer(initialState, {
+      type: "APPEND_PASTE_CHUNK",
+      payload: { chunk: "first", cursorPosition: 0 },
+    });
+    state = inputReducer(state, {
+      type: "APPEND_PASTE_CHUNK",
+      payload: { chunk: "second", cursorPosition: 0 },
+    });
+    state = inputReducer(state, {
+      type: "APPEND_PASTE_CHUNK",
+      payload: { chunk: "third", cursorPosition: 5 },
+    });
+
+    expect(state.pasteBuffer).toBe("firstsecondthird");
+    expect(state.initialPasteCursorPosition).toBe(0); // preserved from first chunk
+  });
+
+  it("should accumulate paste chunks through rapid sequential dispatches", () => {
+    let state = inputReducer(initialState, {
+      type: "APPEND_PASTE_CHUNK",
+      payload: { chunk: "chunk1", cursorPosition: 0 },
+    });
+    state = inputReducer(state, {
+      type: "APPEND_PASTE_CHUNK",
+      payload: { chunk: "chunk2", cursorPosition: 0 },
+    });
+    state = inputReducer(state, {
+      type: "APPEND_PASTE_CHUNK",
+      payload: { chunk: "chunk3", cursorPosition: 0 },
+    });
+
+    expect(state.pasteBuffer).toBe("chunk1chunk2chunk3");
+    expect(state.isPasting).toBe(true);
+  });
+
+  it("should handle END_PASTE after APPEND_PASTE_CHUNK", () => {
+    let state = inputReducer(initialState, {
+      type: "APPEND_PASTE_CHUNK",
+      payload: { chunk: "pasted text", cursorPosition: 0 },
+    });
+    state = inputReducer(state, { type: "END_PASTE" });
+    expect(state.isPasting).toBe(false);
+    expect(state.pasteBuffer).toBe("");
+  });
+
   it("should handle ADD_IMAGE_AND_INSERT_PLACEHOLDER", () => {
     const state = inputReducer(initialState, {
       type: "ADD_IMAGE_AND_INSERT_PLACEHOLDER",

--- a/specs/023-long-text-placeholder/data-model.md
+++ b/specs/023-long-text-placeholder/data-model.md
@@ -18,3 +18,10 @@ Used in `InputManager` to track compressed user inputs.
 3. **Submission**: User sends the message.
 4. **Expansion**: Placeholders are replaced with `originalText` before sending to agent.
 5. **Cleanup**: `longTextMap` is cleared.
+
+## Paste Chunking
+
+Terminal paste events fire multiple keyboard events before React state updates.
+To prevent chunk loss, the reducer uses a single `APPEND_PASTE_CHUNK` action
+that determines start vs append by checking if `pasteBuffer` is empty.
+`useReducer` processes dispatches sequentially, ensuring all chunks accumulate.

--- a/specs/023-long-text-placeholder/plan.md
+++ b/specs/023-long-text-placeholder/plan.md
@@ -45,9 +45,13 @@ specs/023-long-text-placeholder/
 ```
 packages/code/
 ├── src/
-│   └── managers/
-│       └── InputManager.ts     # Handle input compression
+│   ├── managers/
+│   │   ├── inputReducer.ts     # Reducer with APPEND_PASTE_CHUNK action
+│   │   └── inputHandlers.ts    # Paste detection and handler delegation
+│   └── hooks/
+│       └── useInputManager.ts  # Paste debounce and reducer integration
 └── tests/
     └── managers/
-        └── InputManager.test.ts
+        ├── inputReducer.test.ts    # Reducer action tests
+        └── inputHandlers.test.ts   # Handler delegation tests
 ```

--- a/specs/023-long-text-placeholder/quickstart.md
+++ b/specs/023-long-text-placeholder/quickstart.md
@@ -12,9 +12,11 @@ This feature manages user input size by replacing long pasted text with placehol
 ## Verification Steps
 
 ### Unit Tests
-Run tests for input placeholders:
+Run tests for paste handling and long text:
 ```bash
-pnpm -F code test tests/managers/InputManager.test.ts
+pnpm -F code test tests/managers/inputHandlers.test.ts
+pnpm -F code test tests/managers/inputReducer.test.ts
+pnpm -F code test tests/components/InputBox.test.tsx
 ```
 
 ### Manual Verification
@@ -24,3 +26,8 @@ pnpm -F code test tests/managers/InputManager.test.ts
 2. Verify it is replaced by a `[LongText#1]` placeholder.
 3. Send the message.
 4. Verify the agent receives and responds to the full content of the pasted text.
+
+#### Large Paste (Edge Case)
+1. Paste a very large block of text (e.g., 10KB+) to verify all chunks are captured.
+2. Verify no text is lost during the paste operation.
+3. Verify a single `[LongText#1]` placeholder appears.

--- a/specs/023-long-text-placeholder/research.md
+++ b/specs/023-long-text-placeholder/research.md
@@ -20,3 +20,15 @@
 ### Integration Points
 - **InputManager**: Manages the `longTextMap` and placeholder replacement.
 - **PromptHistoryManager**: Preserves placeholders and their mappings in history.
+
+### Paste Chunking Issue
+Terminal paste events fire multiple keyboard events in rapid succession.
+React batches state updates asynchronously, so `state.isPasting` can be stale
+when subsequent chunks arrive. The handler would dispatch `START_PASTE` instead
+of `APPEND_PASTE_BUFFER`, overwriting the buffer.
+
+**Solution**: Replace the two-action pattern (`START_PASTE` / `APPEND_PASTE_BUFFER`)
+with a single `APPEND_PASTE_CHUNK` action. The reducer determines start vs append
+by checking if `pasteBuffer` is empty. Since `useReducer` processes dispatches
+sequentially, each dispatch sees the result of the previous one, ensuring
+all chunks accumulate correctly.

--- a/specs/023-long-text-placeholder/tasks.md
+++ b/specs/023-long-text-placeholder/tasks.md
@@ -17,7 +17,7 @@
 
 ## Phase 2: Foundational (Blocking Prerequisites)
 
-- [ ] T004 [P] Create unit test file for `InputManager` paste handling in `packages/code/tests/managers/InputManager.test.ts`
+- [X] T004 [P] Create unit test file for `InputManager` paste handling in `packages/code/tests/managers/InputManager.test.ts`
 
 ---
 
@@ -31,5 +31,6 @@
 
 - [X] T005 [US1] Implement paste detection and placeholder replacement in `packages/code/src/managers/InputManager.ts`
 - [X] T006 [US1] Implement placeholder expansion in `packages/code/src/managers/InputManager.ts`
+- [X] T007 [US1] Fix paste chunk loss with single reducer action (APPEND_PASTE_CHUNK)
 
 **Checkpoint**: User Story 1 is fully functional and testable independently.


### PR DESCRIPTION
When large text is pasted, terminal fires multiple keyboard events before React state updates. The handler checked state.isPasting to decide between START_PASTE and APPEND_PASTE_BUFFER, but state was stale causing chunks to be overwritten.

Replace the two-action pattern with a single APPEND_PASTE_CHUNK action. The reducer determines start vs append by checking if pasteBuffer is empty, eliminating the need for the handler to track paste state. useReducer processes dispatches sequentially, so each call correctly accumulates the buffer regardless of React state batching.