### PR TITLE
fix: use user role for compress block in API conversion

### DIFF
--- a/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
+++ b/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
@@ -58,7 +58,7 @@ export function convertMessagesForAPI(
       );
       if (compressBlock && compressBlock.type === "compress") {
         recentMessages.unshift({
-          role: "assistant",
+          role: "user",
           content: compressBlock.content,
         });
       }

--- a/packages/agent-sdk/tests/agent/agent.compression.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.compression.test.ts
@@ -419,7 +419,7 @@ describe("Agent Message Compression Tests", () => {
     // Verify that the previous compressed message should be included as context
     const hasCompressedMessage = compressCall[0].messages.some(
       (msg) =>
-        msg.role === "assistant" &&
+        msg.role === "user" &&
         typeof msg.content === "string" &&
         msg.content.includes(
           "Compressed content: Contains summary of first 6 messages",
@@ -547,8 +547,8 @@ describe("Agent Message Compression Tests", () => {
     expect(messagesPassedToCallAgent.length).toBe(5);
 
     // Verify the structure of messages passed to callAgent
-    // The first message should be the compressed assistant message
-    expect(messagesPassedToCallAgent[0].role).toBe("assistant");
+    // The first message should be the compressed message as user role (matching Claude Code's auto-compact)
+    expect(messagesPassedToCallAgent[0].role).toBe("user");
     expect(messagesPassedToCallAgent[0].content).toContain(
       "Compressed content: This contains summary information of previous multi-round conversations.",
     );

--- a/packages/agent-sdk/tests/utils/convertMessagesForAPI.test.ts
+++ b/packages/agent-sdk/tests/utils/convertMessagesForAPI.test.ts
@@ -307,4 +307,43 @@ describe("convertMessagesForAPI", () => {
       { type: "text", text: "Hidden message" },
     ]);
   });
+
+  it("should convert compress block to user role for API (matching Claude Code auto-compact)", () => {
+    const messages: Message[] = [
+      {
+        id: generateMessageId(),
+        role: "assistant",
+        blocks: [
+          {
+            type: "compress",
+            content:
+              "[Compressed Message Summary] User asked to refactor a function...",
+            sessionId: "test-session",
+          },
+        ],
+      },
+      {
+        id: generateMessageId(),
+        role: "user",
+        blocks: [{ type: "text", content: "Continue refactoring" }],
+      },
+      {
+        id: generateMessageId(),
+        role: "assistant",
+        blocks: [{ type: "text", content: "Here is the refactored code." }],
+      },
+    ];
+
+    const apiMessages = convertMessagesForAPI(messages);
+
+    expect(apiMessages).toHaveLength(3);
+    // The compress block should be converted to a user message
+    expect(apiMessages[0].role).toBe("user");
+    expect(apiMessages[0].content).toBe(
+      "[Compressed Message Summary] User asked to refactor a function...",
+    );
+    // Subsequent messages should retain their original roles
+    expect(apiMessages[1].role).toBe("user");
+    expect(apiMessages[2].role).toBe("assistant");
+  });
 });

--- a/specs/014-message-compression/data-model.md
+++ b/specs/014-message-compression/data-model.md
@@ -3,7 +3,7 @@
 ## Entities
 
 ### CompressBlock
-Used in assistant messages to store the summary of compressed history.
+Used in **user** messages to store the summary of compressed history (matching Claude Code's auto-compact behavior).
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/specs/014-message-compression/research.md
+++ b/specs/014-message-compression/research.md
@@ -20,4 +20,4 @@
 ### Integration Points
 - **AIManager**: Monitors tokens and calls the summarization service.
 - **MessageManager**: Updates the session with the new `compress` block.
-- **API Utilities**: Convert `compress` blocks into system messages for the AI.
+- **API Utilities**: Convert `compress` blocks into user-role messages for the AI (matching Claude Code's auto-compact behavior).

--- a/specs/014-message-compression/spec.md
+++ b/specs/014-message-compression/spec.md
@@ -18,7 +18,7 @@ As an AI agent, when the conversation history becomes too long, I want to automa
 
 1. **Given** the total token count exceeds `getMaxInputTokens()`, **When** the next message is processed, **Then** the agent MUST identify messages to compress.
 2. **Given** messages are identified for compression, **When** the summarization is complete, **Then** the original messages MUST be replaced by a `compress` block followed by the last 2 API rounds of the old message list in the session.
-3. **Given** a `compress` block exists, **When** sending messages to the API, **Then** it MUST be converted to a system message with the prefix `[Compressed Message Summary]`.
+3. **Given** a `compress` block exists, **When** sending messages to the API, **Then** it MUST be converted to a **user** message (matching Claude Code's auto-compact behavior).
 
 ---
 
@@ -86,7 +86,7 @@ As an AI agent, after compression replaces conversation history, I want importan
 - **FR-002**: System MUST replace the conversation history with a single continuation summary and the last 2 API rounds of the old message list when token limits are reached.
 - **FR-003**: System MUST use the AI to generate a summary of messages identified for compression.
 - **FR-004**: System MUST replace compressed messages with a `compress` block in the session history.
-- **FR-005**: System MUST convert `compress` blocks to system messages for API calls.
+- **FR-005**: System MUST convert `compress` blocks to user-role messages for API calls.
 - **FR-006**: System MUST apply microcompact (clear old tool results) before each API call when the time threshold (>30 min) is exceeded.
 - **FR-007**: System MUST skip compression after 3 consecutive compression failures (circuit breaker).
 - **FR-008**: System MUST re-inject post-compact context (recent file reads, working directory, plan mode, skills, background tasks) into the compression summary.


### PR DESCRIPTION
Claude Code's auto-compact sends the summary as a user message, not assistant.

This change aligns our `convertMessagesForAPI` to use `role=user` for compress blocks instead of `role=assistant`, matching Claude Code's behavior. Updates related tests and specs accordingly.