### PR TITLE
feat: improve WebFetch tool with security, LRU cache, and redirect handling

### DIFF
--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -45,6 +45,7 @@
     "cron-parser": "^5.5.0",
     "fuzzysort": "^3.1.0",
     "glob": "^13.0.0",
+    "lru-cache": "^11.3.5",
     "minimatch": "^10.0.3",
     "openai": "^5.12.2",
     "turndown": "^7.2.2"

--- a/packages/agent-sdk/src/tools/webFetchTool.ts
+++ b/packages/agent-sdk/src/tools/webFetchTool.ts
@@ -1,35 +1,105 @@
 import TurndownService from "turndown";
+import { LRUCache } from "lru-cache";
 import { WEB_FETCH_TOOL_NAME } from "../constants/tools.js";
 import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
 import { logger } from "../utils/globalLogger.js";
 
+// --- Security Limits ---
+const MAX_HTTP_CONTENT_LENGTH = 10 * 1024 * 1024; // 10MB
+const FETCH_TIMEOUT_MS = 60_000; // 60s
+const MAX_REDIRECTS = 10;
+const MAX_MARKDOWN_LENGTH = 100_000;
+const USER_AGENT = "Wave-User (+https://github.com/netease-lcap/wave-agent)";
+
+// --- Cache (LRU with 15min TTL, 50MB max) ---
 const CACHE_TTL = 15 * 60 * 1000; // 15 minutes
-const cache = new Map<string, { content: string; timestamp: number }>();
+const CACHE_MAX_BYTES = 50 * 1024 * 1024; // 50MB
 
-function getFromCache(url: string): string | null {
-  const cached = cache.get(url);
-  if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-    return cached.content;
-  }
-  if (cached) {
-    cache.delete(url);
-  }
-  return null;
+interface CacheEntry {
+  bytes: number;
+  code: number;
+  codeText: string;
+  content: string;
+  contentType: string;
 }
 
-function setToCache(url: string, content: string) {
-  cache.set(url, { content, timestamp: Date.now() });
+const cache = new LRUCache<string, CacheEntry>({
+  ttl: CACHE_TTL,
+  maxSize: CACHE_MAX_BYTES,
+  sizeCalculation: (entry) => entry.bytes,
+});
+
+// --- Helpers ---
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
 
-// Clean up cache every 15 minutes
-setInterval(() => {
-  const now = Date.now();
-  for (const [url, cached] of cache.entries()) {
-    if (now - cached.timestamp >= CACHE_TTL) {
-      cache.delete(url);
-    }
+type URLValidationResult = { valid: true } | { valid: false; error: string };
+
+function validateURL(url: string): URLValidationResult {
+  if (url.length > 2000) {
+    return {
+      valid: false,
+      error: "URL exceeds maximum length of 2000 characters",
+    };
   }
-}, CACHE_TTL).unref();
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch (error) {
+    return {
+      valid: false,
+      error: `Invalid URL: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  if (parsed.username || parsed.password) {
+    return { valid: false, error: "URL must not contain username or password" };
+  }
+
+  const hostParts = parsed.hostname.split(".");
+  if (hostParts.length < 2) {
+    return {
+      valid: false,
+      error: "URL hostname must have at least two parts (e.g., example.com)",
+    };
+  }
+
+  return { valid: true };
+}
+
+function isPermittedRedirect(
+  originalUrl: string,
+  redirectUrl: string,
+): boolean {
+  try {
+    const original = new URL(originalUrl);
+    const redirect = new URL(redirectUrl);
+    const origHost = original.host;
+    const redirHost = redirect.host;
+
+    // Same host
+    if (origHost === redirHost) return true;
+
+    // www. variation (e.g., example.com <-> www.example.com)
+    const bareOrig = origHost.replace(/^www\./, "");
+    const bareRedir = redirHost.replace(/^www\./, "");
+    if (bareOrig === bareRedir) return true;
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+const GITHUB_URL_ERROR =
+  "For GitHub URLs, please use the 'gh' CLI via the Bash tool instead (e.g., 'gh pr view', 'gh issue view', 'gh api').";
+
+// --- Tool ---
 
 export const webFetchTool: ToolPlugin = {
   name: WEB_FETCH_TOOL_NAME,
@@ -50,10 +120,11 @@ Usage notes:
   - IMPORTANT: If an MCP-provided web fetch tool is available, prefer using that tool instead of this one, as it may have fewer restrictions.
   - The URL must be a fully-formed valid URL
   - HTTP URLs will be automatically upgraded to HTTPS
+  - Content exceeding ${formatSize(MAX_MARKDOWN_LENGTH)} will be truncated
   - The prompt should describe what information you want to extract from the page
   - This tool is read-only and does not modify any files
   - Results may be summarized if the content is very large
-  - Includes a self-cleaning 15-minute cache for faster responses when repeatedly accessing the same URL
+  - Includes an LRU cache with a 15-minute TTL for faster responses when repeatedly accessing the same URL
   - When a URL redirects to a different host, the tool will inform you and provide the redirect URL in a special format. You should then make a new WebFetch request with the redirect URL to fetch the content.
   - For GitHub URLs, prefer using the gh CLI via Bash instead (e.g., gh pr view, gh issue view, gh api).`,
       parameters: {
@@ -94,92 +165,110 @@ Usage notes:
       url = "https://" + url.substring(7);
     }
 
+    // Validate URL
+    const validation = validateURL(url);
+    if (!validation.valid) {
+      return {
+        success: false,
+        content: "",
+        error: validation.error,
+      };
+    }
+
     // Check for GitHub URLs
     if (url.includes("github.com")) {
       return {
         success: false,
         content: "",
-        error:
-          "For GitHub URLs, please use the 'gh' CLI via the Bash tool instead (e.g., 'gh pr view', 'gh issue view', 'gh api').",
+        error: GITHUB_URL_ERROR,
       };
     }
 
     try {
-      let markdown = getFromCache(url);
-
-      if (!markdown) {
-        const response = await fetch(url, {
-          redirect: "manual",
-          headers: {
-            "User-Agent":
-              "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-          },
-        });
-
-        if (response.status >= 300 && response.status < 400) {
-          const location = response.headers.get("location");
-          if (location) {
-            const redirectUrl = new URL(location, url).toString();
-            const originalHost = new URL(url).host;
-            const redirectHost = new URL(redirectUrl).host;
-
-            if (originalHost !== redirectHost) {
-              return {
-                success: true,
-                content: `REDIRECT_TO: ${redirectUrl}\nThe URL redirected to a different host. Please make a new WebFetch request with this redirect URL if you wish to continue.`,
-              };
-            }
-            // If same host, we could follow it, but the requirement says "When a URL redirects to a different host, the tool will inform you".
-            // For simplicity and following the requirement strictly, let's just return the redirect for different hosts.
-            // If it's the same host, we can try to fetch again or just return it too.
-            return {
-              success: true,
-              content: `REDIRECT_TO: ${redirectUrl}\nThe URL redirected. Please make a new WebFetch request with this redirect URL.`,
-            };
-          }
-        }
-
-        if (!response.ok) {
-          return {
-            success: false,
-            content: "",
-            error: `Failed to fetch URL: ${response.status} ${response.statusText}`,
-          };
-        }
-
-        const html = await response.text();
-        const turndownService = new TurndownService();
-        markdown = turndownService.turndown(html);
-        setToCache(url, markdown);
+      const cached = cache.get(url);
+      if (cached) {
+        const markdown = cached.content;
+        return processWithAI(
+          url,
+          prompt,
+          markdown,
+          cached.code,
+          cached.codeText,
+          context,
+        );
       }
 
-      // Process with AI
-      if (!context.aiManager || !context.aiService) {
+      // Fetch with redirect following
+      const result = await fetchWithRedirects(url, context.abortSignal);
+
+      if (result.kind === "redirect") {
         return {
-          success: false,
-          content: markdown,
-          error:
-            "AI Manager or AI Service not available for processing content",
+          success: true,
+          content: `REDIRECT_TO: ${result.redirectUrl}\nThe URL redirected to a different host. Please make a new WebFetch request with this redirect URL if you wish to continue.`,
         };
       }
 
-      const modelConfig = context.aiManager.getModelConfig();
-      const fastModel = modelConfig.fastModel;
+      if (result.kind === "error") {
+        return {
+          success: false,
+          content: "",
+          error: result.error,
+        };
+      }
 
-      const aiResponse = await context.aiService.processWebContent({
-        gatewayConfig: context.aiManager.getGatewayConfig(),
-        modelConfig: modelConfig,
+      const { response, finalUrl } = result;
+
+      if (!response.ok) {
+        return {
+          success: false,
+          content: "",
+          error: `Failed to fetch URL: ${response.status} ${response.statusText}`,
+        };
+      }
+
+      const contentLengthHeader = response.headers.get("content-length");
+      const contentLength = contentLengthHeader
+        ? parseInt(contentLengthHeader, 10)
+        : null;
+      if (contentLength !== null && contentLength > MAX_HTTP_CONTENT_LENGTH) {
+        return {
+          success: false,
+          content: "",
+          error: `Content too large: ${formatSize(contentLength)} exceeds limit of ${formatSize(MAX_HTTP_CONTENT_LENGTH)}`,
+        };
+      }
+
+      const html = await response.text();
+      const turndownService = new TurndownService();
+      let markdown = turndownService.turndown(html);
+
+      const markdownBytes = new TextEncoder().encode(markdown).length;
+
+      // Truncate if too large
+      if (markdown.length > MAX_MARKDOWN_LENGTH) {
+        markdown =
+          markdown.substring(0, MAX_MARKDOWN_LENGTH) +
+          `[Content truncated at ${MAX_MARKDOWN_LENGTH} characters due to length limit.]`;
+      }
+
+      // Store in LRU cache
+      cache.set(finalUrl, {
+        bytes: markdownBytes,
+        code: response.status,
+        codeText: response.statusText,
         content: markdown,
-        prompt: prompt,
-        model: fastModel,
-        abortSignal: context.abortSignal,
+        contentType: response.headers.get("content-type") || "",
       });
 
-      return {
-        success: true,
-        content: aiResponse.content || "",
-        shortResult: `Processed content from ${url}`,
-      };
+      return processWithAI(
+        finalUrl,
+        prompt,
+        markdown,
+        response.status,
+        response.statusText,
+        context,
+        markdownBytes,
+      );
     } catch (error) {
       logger.error(`WebFetch failed for ${url}:`, error);
       return {
@@ -193,3 +282,104 @@ Usage notes:
     return `Fetch ${params.url}`;
   },
 };
+
+// --- Fetch with redirect following ---
+
+async function fetchWithRedirects(
+  initialUrl: string,
+  abortSignal?: AbortSignal,
+  redirectCount = 0,
+): Promise<
+  | { kind: "response"; response: Response; finalUrl: string }
+  | { kind: "redirect"; redirectUrl: string }
+  | { kind: "error"; error: string }
+> {
+  if (redirectCount >= MAX_REDIRECTS) {
+    return {
+      kind: "error",
+      error: `Too many redirects (max ${MAX_REDIRECTS})`,
+    };
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  // Forward the context's abort signal if provided
+  if (abortSignal) {
+    abortSignal.addEventListener("abort", () => controller.abort(), {
+      once: true,
+    });
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(initialUrl, {
+      redirect: "manual",
+      signal: controller.signal,
+      headers: {
+        "User-Agent": USER_AGENT,
+        Accept: "text/markdown, text/html, */*",
+      },
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (response.status >= 300 && response.status < 400) {
+    const location = response.headers.get("location");
+    if (location) {
+      const redirectUrl = new URL(location, initialUrl).toString();
+
+      if (!isPermittedRedirect(initialUrl, redirectUrl)) {
+        return { kind: "redirect", redirectUrl };
+      }
+
+      // Follow permitted redirect recursively
+      return fetchWithRedirects(redirectUrl, abortSignal, redirectCount + 1);
+    }
+  }
+
+  return { kind: "response", response, finalUrl: initialUrl };
+}
+
+// --- AI Processing ---
+
+async function processWithAI(
+  url: string,
+  prompt: string,
+  markdown: string,
+  statusCode: number,
+  statusText: string,
+  context: ToolContext,
+  contentSize?: number,
+): Promise<ToolResult> {
+  if (!context.aiManager || !context.aiService) {
+    return {
+      success: false,
+      content: markdown,
+      error: "AI Manager or AI Service not available for processing content",
+    };
+  }
+
+  const modelConfig = context.aiManager.getModelConfig();
+  const fastModel = modelConfig.fastModel;
+
+  const aiResponse = await context.aiService.processWebContent({
+    gatewayConfig: context.aiManager.getGatewayConfig(),
+    modelConfig: modelConfig,
+    content: markdown,
+    prompt: prompt,
+    model: fastModel,
+    abortSignal: context.abortSignal,
+  });
+
+  const sizeStr =
+    contentSize !== undefined ? formatSize(contentSize) : "unknown size";
+  const statusStr = `${statusCode} ${statusText}`.trim();
+
+  return {
+    success: true,
+    content: aiResponse.content || "",
+    shortResult: `Received ${sizeStr} (${statusStr}) from ${url}`,
+  };
+}

--- a/packages/agent-sdk/tests/tools/webFetchTool.test.ts
+++ b/packages/agent-sdk/tests/tools/webFetchTool.test.ts
@@ -8,6 +8,7 @@ describe("webFetchTool", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
     context = {
       workdir: "/test/workdir",
       taskManager: createMockTaskManager(),
@@ -33,33 +34,42 @@ describe("webFetchTool", () => {
     const mockResponse = {
       ok: true,
       status: 200,
-      text: vi.fn().mockResolvedValue("<html><body><h1>Hello World</h1></body></html>"),
+      statusText: "OK",
+      text: vi
+        .fn()
+        .mockResolvedValue("<html><body><h1>Hello World</h1></body></html>"),
       headers: new Headers(),
     };
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse));
 
     const result = await webFetchTool.execute(
       {
-        url: "https://example.com",
+        url: "https://basic-test.example.com",
         prompt: "Summarize this page",
       },
-      context
+      context,
     );
 
     expect(result.success).toBe(true);
     expect(result.content).toBe("This is a summary of the web page.");
-    expect(global.fetch).toHaveBeenCalledWith("https://example.com", expect.any(Object));
-    expect(context.aiService!.processWebContent).toHaveBeenCalledWith(expect.objectContaining({
-      model: "gpt-3.5-turbo",
-      content: expect.stringContaining("Hello World"),
-      prompt: "Summarize this page",
-    }));
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://basic-test.example.com",
+      expect.any(Object),
+    );
+    expect(context.aiService!.processWebContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "gpt-3.5-turbo",
+        content: expect.stringContaining("Hello World"),
+        prompt: "Summarize this page",
+      }),
+    );
   });
 
   it("should upgrade HTTP to HTTPS", async () => {
     const mockResponse = {
       ok: true,
       status: 200,
+      statusText: "OK",
       text: vi.fn().mockResolvedValue("<html><body>Hello</body></html>"),
       headers: new Headers(),
     };
@@ -67,28 +77,32 @@ describe("webFetchTool", () => {
 
     await webFetchTool.execute(
       {
-        url: "http://http-test.com",
+        url: "http://http-test.example.com",
         prompt: "Summarize",
       },
-      context
+      context,
     );
 
-    expect(global.fetch).toHaveBeenCalledWith("https://http-test.com", expect.any(Object));
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://http-test.example.com",
+      expect.any(Object),
+    );
   });
 
   it("should handle redirects to different hosts", async () => {
     const mockResponse = {
       status: 301,
+      statusText: "Moved Permanently",
       headers: new Headers({ location: "https://other.com/page" }),
     };
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse));
 
     const result = await webFetchTool.execute(
       {
-        url: "https://redirect-test.com",
+        url: "https://redirect-test.example.com",
         prompt: "Summarize",
       },
-      context
+      context,
     );
 
     expect(result.success).toBe(true);
@@ -101,7 +115,7 @@ describe("webFetchTool", () => {
         url: "https://github.com/netease-lcap/wave-agent",
         prompt: "Summarize",
       },
-      context
+      context,
     );
 
     expect(result.success).toBe(false);
@@ -112,7 +126,10 @@ describe("webFetchTool", () => {
     const mockResponse = {
       ok: true,
       status: 200,
-      text: vi.fn().mockResolvedValue("<html><body>Cached Content</body></html>"),
+      statusText: "OK",
+      text: vi
+        .fn()
+        .mockResolvedValue("<html><body>Cached Content</body></html>"),
       headers: new Headers(),
     };
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse));
@@ -120,21 +137,472 @@ describe("webFetchTool", () => {
     // First request
     await webFetchTool.execute(
       {
-        url: "https://cache-test.com",
+        url: "https://cache-test.example.com",
         prompt: "Summarize",
       },
-      context
+      context,
     );
 
     // Second request
     await webFetchTool.execute(
       {
-        url: "https://cache-test.com",
+        url: "https://cache-test.example.com",
         prompt: "Summarize again",
       },
-      context
+      context,
     );
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("webFetchTool - URL validation", () => {
+  let context: ToolContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    context = {
+      workdir: "/test/workdir",
+      taskManager: createMockTaskManager(),
+      aiManager: {
+        getModelConfig: vi.fn().mockReturnValue({
+          model: "gpt-4",
+          fastModel: "gpt-3.5-turbo",
+        }),
+        getGatewayConfig: vi.fn().mockReturnValue({
+          apiKey: "test-key",
+          baseURL: "https://api.openai.com/v1",
+        }),
+      } as unknown as ToolContext["aiManager"],
+      aiService: {
+        processWebContent: vi.fn().mockResolvedValue({
+          content: "This is a summary of the web page.",
+        }),
+      } as unknown as ToolContext["aiService"],
+    };
+  });
+
+  it("should reject URLs exceeding 2000 characters", async () => {
+    const longUrl = "https://validation-test.example.com/" + "a".repeat(2000);
+    const result = await webFetchTool.execute(
+      { url: longUrl, prompt: "Summarize" },
+      context,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("maximum length");
+  });
+
+  it("should reject URLs with username/password", async () => {
+    const result = await webFetchTool.execute(
+      { url: "https://user:pass@credentials.example.com", prompt: "Summarize" },
+      context,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("username or password");
+  });
+
+  it("should reject localhost URLs", async () => {
+    const result = await webFetchTool.execute(
+      { url: "https://localhost:3000", prompt: "Summarize" },
+      context,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("at least two parts");
+  });
+
+  it("should reject single-part hostnames", async () => {
+    const result = await webFetchTool.execute(
+      { url: "https://foo", prompt: "Summarize" },
+      context,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("at least two parts");
+  });
+});
+
+describe("webFetchTool - security limits", () => {
+  let context: ToolContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    context = {
+      workdir: "/test/workdir",
+      taskManager: createMockTaskManager(),
+      aiManager: {
+        getModelConfig: vi.fn().mockReturnValue({
+          model: "gpt-4",
+          fastModel: "gpt-3.5-turbo",
+        }),
+        getGatewayConfig: vi.fn().mockReturnValue({
+          apiKey: "test-key",
+          baseURL: "https://api.openai.com/v1",
+        }),
+      } as unknown as ToolContext["aiManager"],
+      aiService: {
+        processWebContent: vi.fn().mockResolvedValue({
+          content: "This is a summary of the web page.",
+        }),
+      } as unknown as ToolContext["aiService"],
+    };
+  });
+
+  it("should pass signal to fetch for timeout", async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: vi.fn().mockResolvedValue("<html><body>Hello</body></html>"),
+      headers: new Headers(),
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse));
+
+    await webFetchTool.execute(
+      { url: "https://signal-test.example.com", prompt: "Summarize" },
+      context,
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://signal-test.example.com",
+      expect.objectContaining({
+        signal: expect.any(Object),
+      }),
+    );
+  });
+
+  it("should reject responses exceeding MAX_HTTP_CONTENT_LENGTH", async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: vi.fn().mockResolvedValue("<html><body>Hello</body></html>"),
+      headers: new Headers({
+        "content-length": String(11 * 1024 * 1024), // 11MB
+      }),
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse));
+
+    const result = await webFetchTool.execute(
+      { url: "https://content-length-test.example.com", prompt: "Summarize" },
+      context,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Content too large");
+  });
+});
+
+describe("webFetchTool - redirect handling", () => {
+  let context: ToolContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    context = {
+      workdir: "/test/workdir",
+      taskManager: createMockTaskManager(),
+      aiManager: {
+        getModelConfig: vi.fn().mockReturnValue({
+          model: "gpt-4",
+          fastModel: "gpt-3.5-turbo",
+        }),
+        getGatewayConfig: vi.fn().mockReturnValue({
+          apiKey: "test-key",
+          baseURL: "https://api.openai.com/v1",
+        }),
+      } as unknown as ToolContext["aiManager"],
+      aiService: {
+        processWebContent: vi.fn().mockResolvedValue({
+          content: "This is a summary of the web page.",
+        }),
+      } as unknown as ToolContext["aiService"],
+    };
+  });
+
+  it("should follow same-host redirects automatically", async () => {
+    const mockRedirect = {
+      status: 301,
+      statusText: "Moved Permanently",
+      headers: new Headers({
+        location: "https://same-host-redirect.example.com/new-path",
+      }),
+    };
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: vi.fn().mockResolvedValue("<html><body>Final</body></html>"),
+      headers: new Headers(),
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(mockRedirect)
+        .mockResolvedValueOnce(mockResponse),
+    );
+
+    const result = await webFetchTool.execute(
+      { url: "https://same-host-redirect.example.com", prompt: "Summarize" },
+      context,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.content).not.toContain("REDIRECT_TO");
+  });
+
+  it("should follow www-variation redirects automatically", async () => {
+    const mockRedirect = {
+      status: 301,
+      statusText: "Moved Permanently",
+      headers: new Headers({
+        location: "https://www.www-variation-test.example.com/page",
+      }),
+    };
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: vi.fn().mockResolvedValue("<html><body>Final</body></html>"),
+      headers: new Headers(),
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(mockRedirect)
+        .mockResolvedValueOnce(mockResponse),
+    );
+
+    const result = await webFetchTool.execute(
+      { url: "https://www-variation-test.example.com", prompt: "Summarize" },
+      context,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.content).not.toContain("REDIRECT_TO");
+  });
+
+  it("should return REDIRECT_TO for cross-host redirects", async () => {
+    const mockRedirect = {
+      status: 301,
+      statusText: "Moved Permanently",
+      headers: new Headers({ location: "https://other.com/page" }),
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockRedirect));
+
+    const result = await webFetchTool.execute(
+      { url: "https://cross-host-redirect.example.com", prompt: "Summarize" },
+      context,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.content).toContain("REDIRECT_TO: https://other.com/page");
+  });
+
+  it("should reject too many redirects", async () => {
+    const mockRedirect = {
+      status: 301,
+      statusText: "Moved Permanently",
+      headers: new Headers({
+        location: "https://too-many-redirects.example.com/loop",
+      }),
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockRedirect));
+
+    const result = await webFetchTool.execute(
+      { url: "https://too-many-redirects.example.com", prompt: "Summarize" },
+      context,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Too many redirects");
+  });
+});
+
+describe("webFetchTool - headers", () => {
+  let context: ToolContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    context = {
+      workdir: "/test/workdir",
+      taskManager: createMockTaskManager(),
+      aiManager: {
+        getModelConfig: vi.fn().mockReturnValue({
+          model: "gpt-4",
+          fastModel: "gpt-3.5-turbo",
+        }),
+        getGatewayConfig: vi.fn().mockReturnValue({
+          apiKey: "test-key",
+          baseURL: "https://api.openai.com/v1",
+        }),
+      } as unknown as ToolContext["aiManager"],
+      aiService: {
+        processWebContent: vi.fn().mockResolvedValue({
+          content: "This is a summary of the web page.",
+        }),
+      } as unknown as ToolContext["aiService"],
+    };
+  });
+
+  it("should use honest User-Agent header", async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: vi.fn().mockResolvedValue("<html><body>Hello</body></html>"),
+      headers: new Headers(),
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse));
+
+    await webFetchTool.execute(
+      { url: "https://ua-test.example.com", prompt: "Summarize" },
+      context,
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://ua-test.example.com",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "User-Agent":
+            "Wave-User (+https://github.com/netease-lcap/wave-agent)",
+        }),
+      }),
+    );
+  });
+
+  it("should include Accept header", async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: vi.fn().mockResolvedValue("<html><body>Hello</body></html>"),
+      headers: new Headers(),
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse));
+
+    await webFetchTool.execute(
+      { url: "https://accept-test.example.com", prompt: "Summarize" },
+      context,
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://accept-test.example.com",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Accept: "text/markdown, text/html, */*",
+        }),
+      }),
+    );
+  });
+});
+
+describe("webFetchTool - content truncation", () => {
+  let context: ToolContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    context = {
+      workdir: "/test/workdir",
+      taskManager: createMockTaskManager(),
+      aiManager: {
+        getModelConfig: vi.fn().mockReturnValue({
+          model: "gpt-4",
+          fastModel: "gpt-3.5-turbo",
+        }),
+        getGatewayConfig: vi.fn().mockReturnValue({
+          apiKey: "test-key",
+          baseURL: "https://api.openai.com/v1",
+        }),
+      } as unknown as ToolContext["aiManager"],
+      aiService: {
+        processWebContent: vi
+          .fn()
+          .mockResolvedValue(({ content }: { content: string }) => ({
+            content: content.substring(0, 50),
+          })),
+      } as unknown as ToolContext["aiService"],
+    };
+  });
+
+  it("should truncate markdown content exceeding MAX_MARKDOWN_LENGTH", async () => {
+    const longHtml = "<html><body>" + "a".repeat(110000) + "</body></html>";
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: vi.fn().mockResolvedValue(longHtml),
+      headers: new Headers(),
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse));
+
+    await webFetchTool.execute(
+      { url: "https://truncation-test.example.com", prompt: "Summarize" },
+      context,
+    );
+
+    expect(context.aiService!.processWebContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining(
+          "[Content truncated at 100000 characters",
+        ),
+      }),
+    );
+  });
+});
+
+describe("webFetchTool - output enrichment", () => {
+  let context: ToolContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    context = {
+      workdir: "/test/workdir",
+      taskManager: createMockTaskManager(),
+      aiManager: {
+        getModelConfig: vi.fn().mockReturnValue({
+          model: "gpt-4",
+          fastModel: "gpt-3.5-turbo",
+        }),
+        getGatewayConfig: vi.fn().mockReturnValue({
+          apiKey: "test-key",
+          baseURL: "https://api.openai.com/v1",
+        }),
+      } as unknown as ToolContext["aiManager"],
+      aiService: {
+        processWebContent: vi.fn().mockResolvedValue({
+          content: "Summary.",
+        }),
+      } as unknown as ToolContext["aiService"],
+    };
+  });
+
+  it("should include status code and size in shortResult", async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: vi.fn().mockResolvedValue("<html><body>Hello</body></html>"),
+      headers: new Headers(),
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse));
+
+    const result = await webFetchTool.execute(
+      { url: "https://output-test.example.com", prompt: "Summarize" },
+      context,
+    );
+
+    expect(result.shortResult).toBeDefined();
+    expect(result.shortResult).toContain("200 OK");
+    expect(result.shortResult).toMatch(/Received \d+[\w]+ \(200 OK\) from/);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       glob:
         specifier: ^13.0.0
         version: 13.0.0
+      lru-cache:
+        specifier: ^11.3.5
+        version: 11.3.5
       minimatch:
         specifier: ^10.0.3
         version: 10.0.3
@@ -1900,12 +1903,8 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  lru-cache@11.2.2:
-    resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
-    engines: {node: 20 || >=22}
-
-  lru-cache@11.2.5:
-    resolution: {integrity: sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==}
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
 
   luxon@3.7.2:
@@ -2816,7 +2815,7 @@ snapshots:
       '@csstools/css-color-parser': 4.0.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      lru-cache: 11.2.5
+      lru-cache: 11.3.5
     optional: true
 
   '@asamuzakjp/dom-selector@6.7.8':
@@ -2825,7 +2824,7 @@ snapshots:
       bidi-js: 1.0.3
       css-tree: 3.1.0
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.2.5
+      lru-cache: 11.3.5
     optional: true
 
   '@asamuzakjp/nwsapi@2.3.9':
@@ -3673,7 +3672,7 @@ snapshots:
       '@asamuzakjp/css-color': 4.1.2
       '@csstools/css-syntax-patches-for-csstree': 1.0.26
       css-tree: 3.1.0
-      lru-cache: 11.2.5
+      lru-cache: 11.3.5
     optional: true
 
   csstype@3.1.3: {}
@@ -4629,10 +4628,7 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  lru-cache@11.2.2: {}
-
-  lru-cache@11.2.5:
-    optional: true
+  lru-cache@11.3.5: {}
 
   luxon@3.7.2: {}
 
@@ -4824,7 +4820,7 @@ snapshots:
 
   path-scurry@2.0.0:
     dependencies:
-      lru-cache: 11.2.2
+      lru-cache: 11.3.5
       minipass: 7.1.2
 
   path-to-regexp@8.3.0: {}

--- a/specs/017-web-fetch-tool/checklists/requirements.md
+++ b/specs/017-web-fetch-tool/checklists/requirements.md
@@ -1,6 +1,6 @@
 # Requirements Checklist: WebFetch Tool
 
-**Branch**: `017-web-fetch-tool` | **Status**: Completed | **Date**: 2026-03-31 | **Spec**: [spec.md](../spec.md)
+**Branch**: `017-web-fetch-tool` | **Status**: Completed | **Date**: 2026-03-31 | **Updated**: 2026-04-21 | **Spec**: [spec.md](../spec.md)
 
 ## Functional Requirements
 
@@ -10,14 +10,19 @@
 - [X] **FR-004**: System MUST fetch the content of the URL using a standard HTTP client.
 - [X] **FR-005**: System MUST convert the fetched HTML content to Markdown.
 - [X] **FR-006**: System MUST process the Markdown content with the provided prompt using a "fast" AI model.
-- [X] **FR-007**: System MUST implement a 15-minute self-cleaning cache for fetched Markdown content.
-- [X] **FR-008**: System MUST detect redirects to different hosts and return a `REDIRECT_TO: <url>` message.
+- [X] **FR-007**: System MUST implement a 15-minute LRU cache for fetched Markdown content with a 50MB size limit.
+- [X] **FR-008**: System MUST detect redirects to different hosts and return a `REDIRECT_TO: <url>` message. Same-host and `www.`-variation redirects MUST be followed automatically (max 10 hops).
 - [X] **FR-009**: System MUST reject GitHub URLs and suggest using the `gh` CLI.
 - [X] **FR-010**: System MUST handle network errors and non-200 status codes gracefully.
+- [X] **FR-011**: System MUST validate URLs: max 2000 chars, no username/password, hostname must have >=2 parts.
+- [X] **FR-012**: System MUST enforce a 10MB content length limit and 60-second fetch timeout.
+- [X] **FR-013**: System MUST truncate Markdown content exceeding 100,000 characters before AI processing.
+- [X] **FR-014**: System MUST include an honest User-Agent header and Accept header.
 
 ## Non-Functional Requirements
 
 - [X] **NFR-001**: The tool MUST be read-only and not modify any files.
 - [X] **NFR-002**: The tool MUST be fast and efficient.
-- [X] **NFR-003**: The tool MUST handle large content by summarizing if necessary (handled by AI model).
-- [X] **NFR-004**: The tool MUST be easy to use and provide clear error messages.
+- [X] **NFR-003**: The tool MUST handle large content by truncating and summarizing if necessary.
+- [X] **NFR-004**: The tool MUST provide clear error messages and diagnostic output (HTTP status code, content size).
+- [X] **NFR-005**: The cache MUST use an LRU eviction strategy with automatic expiration (no manual cleanup interval).

--- a/specs/017-web-fetch-tool/claude-code-webfetch-findings.md
+++ b/specs/017-web-fetch-tool/claude-code-webfetch-findings.md
@@ -1,0 +1,153 @@
+# Claude Code WebFetch Tool — Research Findings
+
+**Source**: `claude-code/src/tools/WebFetchTool/`  
+**Date**: 2026-04-21
+
+## File Structure
+
+| File | Purpose |
+|------|---------|
+| `WebFetchTool.ts` | Main tool definition (schema, permissions, call logic) |
+| `utils.ts` | Core logic: fetching, caching, HTML→MD, AI processing |
+| `prompt.ts` | Tool description + secondary model prompt builder |
+| `preapproved.ts` | Preapproved domain list (essential docs sites) |
+| `UI.tsx` | React Ink UI rendering for tool messages/progress |
+
+## Architecture Overview
+
+### Input/Output Schema
+
+```typescript
+// Input
+{ url: string (URL), prompt: string }
+
+// Output
+{ bytes: number, code: number, codeText: string, result: string, durationMs: number, url: string }
+```
+
+### Fetch Flow
+
+1. **Validate URL** — max 2000 chars, no username/password, hostname must have ≥2 parts (blocks localhost)
+2. **Check URL cache** (LRU, 15min TTL, 50MB max)
+3. **Upgrade http → https**
+4. **Preflight domain check** — calls `api.anthropic.com/api/web/domain_info?domain=...` to verify domain is safe (can be skipped via `skipWebFetchPreflight` setting for enterprise)
+5. **Fetch with permitted redirects** — custom redirect handling (max 10 hops, follows only same-host/www-variations)
+6. **Handle content**:
+   - HTML → Turndown → Markdown
+   - Binary (PDFs etc.) → save to disk + fall-through text decode for Haiku summary
+   - Other text → use raw
+7. **Apply prompt via Haiku** — small fast model processes markdown + prompt
+8. **Cache and return**
+
+## Key Design Decisions
+
+### 1. Permission System
+
+WebFetch integrates with Claude Code's permission framework:
+- **Preapproved hosts** auto-allow (docs sites like react.dev, docs.python.org, etc.)
+- Permission rules can be set per-host (`domain:example.com`)
+- Default behavior: **ask** user for permission
+- Supports `allow`/`deny`/`ask` rule types with suggestions to persist to local settings
+
+### 2. Domain Blocklist (Preflight Check)
+
+Before fetching, calls Anthropic's API to check if a domain is safe. This is a security layer against malicious/problematic domains. Response: `{ can_fetch: boolean }`.
+
+- Separate cache (`DOMAIN_CHECK_CACHE`) for hostname-level checks, 5min TTL, max 128 entries
+- Only caches `allowed` results — blocked/failed re-check next time
+- Can be disabled via `settings.skipWebFetchPreflight` for enterprise environments
+
+### 3. Redirect Handling
+
+Custom redirect handling with `maxRedirects: 0` (disables axios auto-redirect):
+- Catches 301/302/307/308 responses manually
+- `isPermittedRedirect()` allows:
+  - Same host, different path/query
+  - Adding/removing `www.` prefix
+- Non-permitted redirects return `REDIRECT DETECTED` message to user with instructions to re-fetch the redirect URL
+- Max 10 redirect hops (prevents redirect loops)
+
+### 4. Caching Strategy
+
+Two-tier LRU cache:
+- **URL_CACHE**: Full content, keyed by URL, 15min TTL, 50MB size limit
+- **DOMAIN_CHECK_CACHE**: Domain allow status, keyed by hostname, 5min TTL, 128 entries
+
+Cache stores: `{ bytes, code, codeText, content, contentType, persistedPath?, persistedSize? }`
+
+### 5. AI Processing (Haiku/Secondary Model)
+
+- Uses `queryHaiku()` — a small, fast model
+- Content truncated to 100,000 chars max
+- Different guidelines for preapproved vs non-preapproved domains:
+  - **Preapproved**: Concise response, can include code examples
+  - **Non-preapproved**: Strict 125-char quote limit, quotation marks required, legal/copyright safeguards
+- Empty response → returns "No response from model"
+
+### 6. Binary Content Handling
+
+Binary files (PDFs, etc.) are:
+- Saved to disk with MIME-derived extension via `persistBinaryContent()`
+- Still decoded to UTF-8 string for Haiku to summarize (PDFs have enough ASCII structure)
+- File path noted in result so user can inspect raw file
+
+### 7. Security Measures
+
+- **Max URL length**: 2000 chars
+- **Max content length**: 10MB (`MAX_HTTP_CONTENT_LENGTH`)
+- **Fetch timeout**: 60 seconds
+- **Domain check timeout**: 10 seconds
+- **Max redirects**: 10
+- **Blocks URLs with username/password**
+- **Blocks localhost/internal hostnames** (< 2 hostname parts)
+- **Egress proxy detection**: Detects `X-Proxy-Error: blocked-by-allowlist` header
+- **AbortSignal support**: Cancellable via abort controller
+
+### 8. User Agent
+
+```
+Claude-User (claude-code/<version>; +https://support.anthropic.com/)
+```
+Uses `Claude-User` agent — Anthropic's documented agent identity for user-initiated fetches, matching what site operators expect in robots.txt.
+
+### 9. Turndown Lazy Loading
+
+Turndown service is lazily initialized (lazy singleton) to avoid loading ~1.4MB retained heap until first HTML fetch. Single instance reused across calls.
+
+### 10. Memory Management
+
+- Releases ArrayBuffer reference after converting to Buffer (GC can reclaim up to 10MB before Turndown builds DOM tree)
+- Content truncated before AI processing to avoid "Prompt is too long" errors
+
+## Differences from Our Implementation
+
+| Feature | Claude Code | Our Current |
+|---------|------------|-------------|
+| HTTP client | axios | Node.js native fetch |
+| Permission system | Full permission framework with rules | None |
+| Domain blocklist | Anthropic API preflight check | None |
+| Preapproved domains | ~80 essential doc sites | None (GitHub rejection only) |
+| Redirect handling | Custom, follows same-host only | Manual redirect, rejects cross-host |
+| Binary content | Saves to disk + Haiku summary | Not handled |
+| Max content | 10MB | Not specified |
+| Max URL | 2000 chars | Not specified |
+| Fetch timeout | 60s | Not specified |
+| User Agent | Custom `Claude-User` | Default |
+| Output schema | Structured (bytes, code, codeText, result, durationMs, url) | Simple (success, content, error, shortResult) |
+| Progress message | "Fetching…" | None |
+| Abort support | AbortSignal | None |
+| Cache size limit | 50MB | TTL only |
+
+## Notable Implementation Details
+
+### `getWithPermittedRedirects()` (utils.ts:262)
+Recursive function with custom redirect handling. Catches 301/302/307/308, checks if redirect is permitted, follows recursively or returns redirect info. Also detects egress proxy blocks.
+
+### `makeSecondaryModelPrompt()` (prompt.ts:23)
+Builds prompt for secondary model with content + user prompt + guidelines. Differentiates between preapproved and non-preapproved domains for legal/compliance reasons.
+
+### Tool UI (UI.tsx)
+- Verbose mode shows full URL + prompt
+- Non-verbose shows just URL
+- Progress shows dimmed "Fetching…"
+- Result shows file size + HTTP status code

--- a/specs/017-web-fetch-tool/contracts/web-fetch.md
+++ b/specs/017-web-fetch-tool/contracts/web-fetch.md
@@ -1,6 +1,6 @@
 # Contract: WebFetch Tool
 
-**Branch**: `017-web-fetch-tool` | **Status**: Completed | **Date**: 2026-03-31 | **Spec**: [spec.md](../spec.md)
+**Branch**: `017-web-fetch-tool` | **Status**: Completed | **Date**: 2026-03-31 | **Updated**: 2026-04-21 | **Spec**: [spec.md](./spec.md)
 
 ## Summary
 
@@ -14,7 +14,7 @@ The `WebFetch` tool is a plugin for the `wave-agent` that allows the AI agent to
 
 ### Parameters
 
-- **url**: The URL to fetch content from (string, required, format: uri).
+- **url**: The URL to fetch content from (string, required, format: uri). Max 2000 characters. Must not contain username/password. Hostname must have at least 2 parts.
 - **prompt**: The prompt to run on the fetched content (string, required).
 
 ### Result
@@ -22,21 +22,46 @@ The `WebFetch` tool is a plugin for the `wave-agent` that allows the AI agent to
 - **success**: Boolean indicating if the tool execution was successful.
 - **content**: The AI model's response about the content.
 - **error**: Optional error message if the tool execution failed.
-- **shortResult**: Optional short result for summary display.
+- **shortResult**: Optional short result for summary display (e.g., `Received 2.3KB (200 OK) from https://example.com`).
 
 ## Behavior
 
-1. **Fetch**: The tool checks the cache for the requested URL.
-2. **Network Request**: If the URL is not in the cache or the cache has expired, the tool makes a network request to fetch the HTML content.
-3. **Conversion**: The HTML content is converted to Markdown using the `turndown` library.
-4. **Cache Update**: The Markdown content is stored in the cache with the current timestamp.
-5. **AI Processing**: The Markdown content is processed with the user-provided prompt using a specialized, lightweight `processWebContent` function and a fast AI model.
-6. **Response**: The tool returns the AI model's response to the user.
+1. **Validate URL**: URL length, credentials, hostname parts are validated. Invalid URLs return an error.
+2. **HTTP Upgrade**: `http://` URLs are upgraded to `https://`.
+3. **GitHub Check**: URLs containing `github.com` are rejected with a suggestion to use `gh` CLI.
+4. **Cache Lookup**: The tool checks the LRU cache (15min TTL, 50MB max) for the requested URL.
+5. **Network Request**: If not cached, fetches with a 60-second timeout. Content exceeding 10MB is rejected.
+6. **Redirect Handling**: Same-host and `www.`-variation redirects are followed automatically (max 10 hops). Cross-host redirects return a `REDIRECT_TO:` message.
+7. **Conversion**: The HTML content is converted to Markdown using the `turndown` library.
+8. **Truncation**: Markdown exceeding 100,000 characters is truncated with a notice.
+9. **Cache Update**: The entry `{ bytes, code, codeText, content, contentType }` is stored in the LRU cache.
+10. **AI Processing**: The Markdown content is processed with the user-provided prompt using a specialized, lightweight `processWebContent` function and a fast AI model.
+11. **Response**: The tool returns the AI model's response with enriched metadata.
 
 ## Error Handling
 
-- **Network Errors**: The tool returns a success: false result with an appropriate error message.
-- **Non-200 Status Codes**: The tool returns a success: false result with an appropriate error message.
-- **Redirects**: If a URL redirects to a different host, the tool returns a message starting with `REDIRECT_TO: <url>`.
-- **GitHub URLs**: The tool rejects GitHub URLs and suggests using the `gh` CLI.
-- **Missing Parameters**: The tool returns a success: false result if `url` or `prompt` is missing.
+- **Invalid URL**: Returns `success: false` with a descriptive error (too long, has credentials, single-part hostname).
+- **GitHub URL**: Returns `success: false` with a suggestion to use the `gh` CLI.
+- **Content Too Large**: Returns `success: false` if response exceeds 10MB.
+- **Too Many Redirects**: Returns `success: false` after 10 redirect hops.
+- **Network Errors**: Returns `success: false` with an appropriate error message.
+- **Non-200 Status Codes**: Returns `success: false` with the HTTP status.
+- **Cross-Host Redirects**: Returns `success: true` with a `REDIRECT_TO: <url>` message.
+- **Missing Parameters**: Returns `success: false` if `url` or `prompt` is missing.
+
+## Security Limits
+
+| Limit | Value |
+|-------|-------|
+| Max URL length | 2000 characters |
+| Max content length | 10MB |
+| Fetch timeout | 60 seconds |
+| Max redirects | 10 hops |
+| Max Markdown length | 100,000 characters (truncated) |
+| Cache TTL | 15 minutes |
+| Cache max size | 50MB |
+
+## Headers
+
+- **User-Agent**: `Wave-User (+https://github.com/netease-lcap/wave-agent)`
+- **Accept**: `text/markdown, text/html, */*`

--- a/specs/017-web-fetch-tool/data-model.md
+++ b/specs/017-web-fetch-tool/data-model.md
@@ -1,45 +1,57 @@
 # Data Model: WebFetch Tool
 
-**Branch**: `017-web-fetch-tool` | **Status**: Completed | **Date**: 2026-03-31 | **Spec**: [spec.md](./spec.md)
+**Branch**: `017-web-fetch-tool` | **Status**: Completed | **Date**: 2026-03-31 | **Updated**: 2026-04-21 | **Spec**: [spec.md](./spec.md)
 
 ## Summary
 
-The `WebFetch` tool uses a simple in-memory cache to store the Markdown content of fetched URLs. This cache is implemented as a `Map` with a TTL of 15 minutes.
+The `WebFetch` tool uses an LRU cache to store the Markdown content and metadata of fetched URLs. This cache is implemented using `lru-cache` with a TTL of 15 minutes and a 50MB max size limit.
 
 ## Entities
 
 ### WebFetchCache
 
 - **url**: The URL of the fetched content (string, key).
-- **content**: The Markdown content of the page (string).
-- **timestamp**: The time when the content was fetched (number).
+- **content**: The Markdown content of the page (string). Truncated to 100,000 chars if exceeding.
+- **bytes**: The size of the content in bytes (number).
+- **code**: The HTTP status code (number).
+- **codeText**: The HTTP status text (string, e.g., "OK").
+- **contentType**: The MIME type of the response (string).
+
+### Cache Configuration
+
+- **TTL**: 15 minutes (automatic expiration via `lru-cache`).
+- **Max Size**: 50MB (automatic eviction of least-recently-used entries).
+- **Size Calculation**: Based on `bytes` field of each cache entry.
 
 ## Relationships
 
-- **WebFetchCache** is a collection of cached Markdown content indexed by URL.
+- **WebFetchCache** is a collection of cached entries indexed by URL, each containing metadata about the original fetch.
 
 ## Data Flow
 
-1. **Fetch**: The tool checks the cache for the requested URL.
-2. **Network Request**: If the URL is not in the cache or the cache has expired, the tool makes a network request to fetch the HTML content.
-3. **Conversion**: The HTML content is converted to Markdown using the `turndown` library.
-4. **Cache Update**: The Markdown content is stored in the cache with the current timestamp.
-5. **AI Processing**: The Markdown content is processed with the user-provided prompt using a fast AI model.
-6. **Response**: The tool returns the AI model's response to the user.
+1. **Validate URL**: Check URL length, credentials, hostname parts.
+2. **Fetch**: The tool checks the LRU cache for the requested URL.
+3. **Network Request**: If the URL is not in the cache, the tool makes a network request (with 60s timeout) to fetch the HTML content, following same-host redirects automatically (max 10 hops).
+4. **Conversion**: The HTML content is converted to Markdown using the `turndown` library.
+5. **Truncation**: If Markdown exceeds 100,000 characters, it is truncated.
+6. **Cache Update**: The entry `{ bytes, code, codeText, content, contentType }` is stored in the LRU cache.
+7. **AI Processing**: The Markdown content is processed with the user-provided prompt using a fast AI model.
+8. **Response**: The tool returns the AI model's response with enriched metadata (status code, content size).
 
 ## Constitution Check
 
 1. **Package-First Architecture**: The data model is implemented in `agent-sdk`.
-2. **TypeScript Excellence**: The cache is strictly typed.
+2. **TypeScript Excellence**: The cache is strictly typed with `CacheEntry` interface.
 3. **Test Alignment**: The cache logic is tested as part of the tool's unit tests.
 4. **Build Dependencies**: `agent-sdk` must be built before use.
 5. **Documentation Minimalism**: Only necessary documentation files are created.
 6. **Quality Gates**: `type-check` and `lint` are required.
 7. **Source Code Structure**: The cache is implemented within the `webFetchTool.ts` file.
-8. **Data Model Minimalism**: A simple in-memory cache is used.
+8. **Data Model Minimalism**: An LRU cache with structured entries is used.
 
 ## Complexity Tracking
 
 | Violation | Why Needed | Simpler Alternative Rejected Because |
 |-----------|------------|-------------------------------------|
-| None | N/A | N/A |
+| lru-cache | Automatic size-based eviction + TTL | Map + setInterval lacks size-based eviction |
+| Rich cache entries | Enables enriched output (status, size) without re-fetching | Storing only content loses diagnostic info |

--- a/specs/017-web-fetch-tool/plan.md
+++ b/specs/017-web-fetch-tool/plan.md
@@ -1,22 +1,24 @@
 # Implementation Plan: WebFetch Tool
 
-**Branch**: `017-web-fetch-tool` | **Status**: Completed | **Date**: 2026-03-31 | **Spec**: [spec.md](./spec.md)
+**Branch**: `017-web-fetch-tool` | **Status**: Completed | **Date**: 2026-03-31 | **Updated**: 2026-04-21 | **Spec**: [spec.md](./spec.md)
 **Input**: Feature specification from `/specs/017-web-fetch-tool/spec.md`
 
 ## Summary
 
 Implement a `WebFetch` tool that allows users to fetch web content, convert it to Markdown, and process it with a fast AI model. This involves adding `turndown` as a dependency, creating a new `WebFetchToolPlugin` in `agent-sdk`, and registering it in the `ToolManager`. The tool will handle HTTP to HTTPS upgrades, redirects to different hosts, and caching of Markdown content for 15 minutes. It will also suggest using the `gh` CLI for GitHub URLs. To optimize performance and stability, a specialized `processWebContent` function is implemented in `aiService` to handle the AI processing without the overhead of the full `callAgent` infrastructure.
 
+**Improvement Phase (2026-04-21)**: Added URL validation (max length, credentials, localhost blocking), security limits (10MB content, 60s timeout, 10 redirect max), automatic same-host/www-variation redirect following, LRU cache upgrade (50MB limit, no manual cleanup), honest User-Agent header, Accept header, content truncation at 100K chars, and enriched output with HTTP status/size info.
+
 ## Technical Context
 
 **Language/Version**: TypeScript (Node.js)
-**Primary Dependencies**: `turndown` (for HTML to Markdown conversion), Node.js built-in `fetch`
-**Storage**: In-memory `Map` for caching Markdown content
+**Primary Dependencies**: `turndown` (for HTML to Markdown conversion), `lru-cache` (for LRU caching), Node.js built-in `fetch`
+**Storage**: `lru-cache` instance for caching Markdown content with 15min TTL and 50MB size limit
 **Testing**: Vitest (Unit tests for the tool logic)
 **Target Platform**: Linux/macOS/Windows (Node.js environment)
 **Project Type**: Monorepo (agent-sdk + code)
 **Performance Goals**: Fast content extraction and processing (< 2s for typical pages)
-**Constraints**: Must handle redirects and host changes as specified.
+**Constraints**: Must handle redirects and host changes as specified. Must enforce security limits (URL length, content size, timeout).
 
 ## Constitution Check
 
@@ -27,7 +29,7 @@ Implement a `WebFetch` tool that allows users to fetch web content, convert it t
 5. **Documentation Minimalism**: Only necessary spec/plan/research/data-model/quickstart files. Pass.
 6. **Quality Gates**: `type-check` and `lint` required. Pass.
 7. **Source Code Structure**: `webFetchTool.ts` in `packages/agent-sdk/src/tools/`. Pass.
-8. **Data Model Minimalism**: Simple `WebFetchCache` entity. Pass.
+8. **Data Model Minimalism**: Simple `WebFetchCache` entity with richer metadata. Pass.
 
 ## Project Structure
 
@@ -65,4 +67,7 @@ packages/
 
 | Violation | Why Needed | Simpler Alternative Rejected Because |
 |-----------|------------|-------------------------------------|
-| None | N/A | N/A |
+| lru-cache dependency | 50MB size limit + automatic eviction | Map + setInterval lacks size-based eviction and is error-prone |
+| AbortController for timeout | Prevents indefinite hangs on slow servers | Native fetch timeout requires AbortController |
+| Recursive redirect following | Reduces unnecessary tool calls for same-host redirects | Returning every redirect forces manual re-fetches |
+| Content truncation at 100K chars | Prevents "Prompt is too long" errors | No truncation would cause AI API failures on large pages |

--- a/specs/017-web-fetch-tool/research.md
+++ b/specs/017-web-fetch-tool/research.md
@@ -1,18 +1,21 @@
 # Research: WebFetch Tool
 
-**Branch**: `017-web-fetch-tool` | **Status**: Completed | **Date**: 2026-03-31 | **Spec**: [spec.md](./spec.md)
+**Branch**: `017-web-fetch-tool` | **Status**: Completed | **Date**: 2026-03-31 | **Updated**: 2026-04-21 | **Spec**: [spec.md](./spec.md)
 
 ## Summary
 
-The `WebFetch` tool is designed to provide a simple way for the AI agent to access and analyze web content. It uses the Node.js built-in `fetch` API for network requests and the `turndown` library for HTML to Markdown conversion. The tool is read-only and does not modify any files. It includes a 15-minute cache for faster responses when repeatedly accessing the same URL.
+The `WebFetch` tool provides a simple way for the AI agent to access and analyze web content. It uses the Node.js built-in `fetch` API for network requests and the `turndown` library for HTML to Markdown conversion. The tool is read-only and does not modify any files. It includes an LRU cache with a 15-minute TTL and 50MB size limit. URL validation, security limits, automatic same-host redirect following, content truncation, honest User-Agent, and enriched output are all implemented.
 
 ## Technical Context
 
 - **Fetch API**: Node.js 18+ includes a built-in `fetch` API that is compatible with the browser's `fetch`.
 - **Turndown**: A popular library for converting HTML to Markdown. It is lightweight and easy to use.
+- **LRU Cache**: `lru-cache` provides automatic size-based eviction and TTL expiration, replacing the previous Map + setInterval approach.
 - **AI Processing**: The tool uses a specialized `processWebContent` function in `aiService` (similar to `compressMessages`) to process the extracted Markdown content with a user-provided prompt. This bypasses the full Agent infrastructure for better performance and stability.
-- **Redirect Handling**: The tool uses the `redirect: 'manual'` option in `fetch` to detect redirects and check if the host has changed.
-- **GitHub URLs**: GitHub content is often better accessed via the `gh` CLI, which handles authentication and structured data better than a generic web fetcher.
+- **Redirect Handling**: The tool uses `redirect: 'manual'` to detect redirects. Same-host and `www.`-variation redirects are followed recursively (max 10 hops). Cross-host redirects return a `REDIRECT_TO:` message.
+- **Security Limits**: 60-second fetch timeout via AbortController, 10MB content length limit, 2000-char URL limit, 100K-char Markdown truncation.
+- **URL Validation**: Rejects URLs with credentials, localhost, or single-part hostnames.
+- **User-Agent**: Honest identification as `Wave-User (+https://github.com/netease-lcap/wave-agent)`.
 
 ## Constitution Check
 
@@ -23,10 +26,11 @@ The `WebFetch` tool is designed to provide a simple way for the AI agent to acce
 5. **Documentation Minimalism**: Only necessary documentation files are created.
 6. **Quality Gates**: `type-check` and `lint` are required.
 7. **Source Code Structure**: The tool is placed in the `tools` directory of `agent-sdk`.
-8. **Data Model Minimalism**: A simple in-memory cache is used.
+8. **Data Model Minimalism**: An LRU cache with structured entries is used.
 
 ## Complexity Tracking
 
 | Violation | Why Needed | Simpler Alternative Rejected Because |
 |-----------|------------|-------------------------------------|
-| None | N/A | N/A |
+| lru-cache dependency | Automatic size-based eviction | Map + setInterval lacks size-based eviction |
+| AbortController for timeout | Prevents indefinite hangs | No timeout could hang the tool forever |

--- a/specs/017-web-fetch-tool/spec.md
+++ b/specs/017-web-fetch-tool/spec.md
@@ -2,6 +2,7 @@
 
 **Feature Branch**: `017-web-fetch-tool`  
 **Created**: 2026-03-31  
+**Updated**: 2026-04-21  
 **Input**: User description: "support WebFetch tool, fetches content from a specified URL and processes it using an AI model. Takes a URL and a prompt as input. Fetches the URL content, converts HTML to markdown. Processes the content with the prompt using a small, fast model. Returns the model's response about the content. Includes a self-cleaning 15-minute cache. Handles redirects to different hosts by informing the user. Suggests gh CLI for GitHub URLs."
 
 ## User Scenarios & Testing *(mandatory)*
@@ -23,13 +24,15 @@ As a user, I want to be able to fetch content from a URL and ask questions about
 
 ### User Story 2 - Redirect Handling (Priority: P2)
 
-As a user, I want to be informed when a URL redirects to a different host, so that I can decide whether to follow the redirect or not.
+As a user, I want to be informed when a URL redirects to a different host, and to have same-host redirects followed automatically, so that I don't need to manually re-fetch for every redirect.
 
-**Why this priority**: This ensures transparency and security when accessing web content.
+**Why this priority**: This ensures transparency and security when accessing web content while reducing unnecessary tool calls.
 
 **Acceptance Scenarios**:
 
 1. **Given** a URL `http://short.url` that redirects to `https://another-domain.com/page`, **When** the `WebFetch` tool is executed, **Then** it should return a message starting with `REDIRECT_TO: https://another-domain.com/page` and inform the user about the host change.
+2. **Given** a URL that redirects to the same host with a different path, **When** the `WebFetch` tool is executed, **Then** it should follow the redirect automatically and return the page content without a `REDIRECT_TO` message.
+3. **Given** a URL that redirects from `example.com` to `www.example.com`, **When** the `WebFetch` tool is executed, **Then** it should follow the redirect automatically.
 
 ---
 
@@ -55,6 +58,23 @@ As a user, I want repeated requests to the same URL to be fast, so that I don't 
 
 1. **Given** a URL has been fetched once, **When** it is fetched again within 15 minutes with the same or different prompt, **Then** the tool should use the cached Markdown content instead of making a new network request.
 
+---
+
+### User Story 5 - Security & Robustness (Priority: P2)
+
+As a user, I want the tool to protect against excessive resource usage and provide clear error messages, so that I don't experience hangs or memory issues.
+
+**Why this priority**: Prevents the tool from consuming excessive resources or hanging indefinitely.
+
+**Acceptance Scenarios**:
+
+1. **Given** a URL exceeding 2000 characters, **When** the `WebFetch` tool is executed, **Then** it should return an error about URL length.
+2. **Given** a URL with username/password credentials, **When** the `WebFetch` tool is executed, **Then** it should reject the URL.
+3. **Given** a `localhost` URL, **When** the `WebFetch` tool is executed, **Then** it should reject the URL.
+4. **Given** a response exceeding 10MB, **When** the `WebFetch` tool is executed, **Then** it should reject the response.
+5. **Given** a fetch that takes longer than 60 seconds, **When** the timeout is reached, **Then** the request should be aborted.
+6. **Given** a redirect loop, **When** the redirect count exceeds 10, **Then** the tool should return an error.
+
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
@@ -65,12 +85,24 @@ As a user, I want repeated requests to the same URL to be fast, so that I don't 
 - **FR-004**: System MUST fetch the content of the URL using a standard HTTP client.
 - **FR-005**: System MUST convert the fetched HTML content to Markdown.
 - **FR-006**: System MUST process the Markdown content with the provided prompt using a "fast" AI model.
-- **FR-007**: System MUST implement a 15-minute self-cleaning cache for fetched Markdown content.
-- **FR-008**: System MUST detect redirects to different hosts and return a `REDIRECT_TO: <url>` message.
+- **FR-007**: System MUST implement a 15-minute LRU cache for fetched Markdown content with a 50MB size limit.
+- **FR-008**: System MUST detect redirects to different hosts and return a `REDIRECT_TO: <url>` message. Same-host and `www.`-variation redirects MUST be followed automatically (max 10 hops).
 - **FR-009**: System MUST reject GitHub URLs and suggest using the `gh` CLI.
 - **FR-010**: System MUST handle network errors and non-200 status codes gracefully.
+- **FR-011**: System MUST validate URLs: max 2000 chars, no username/password, hostname must have ≥2 parts.
+- **FR-012**: System MUST enforce a 10MB content length limit and 60-second fetch timeout.
+- **FR-013**: System MUST truncate Markdown content exceeding 100,000 characters before AI processing.
+- **FR-014**: System MUST include an honest User-Agent header (`Wave-User (+https://github.com/netease-lcap/wave-agent)`) and Accept header (`text/markdown, text/html, */*`).
+
+### Non-Functional Requirements
+
+- **NFR-001**: The tool MUST be read-only and not modify any files.
+- **NFR-002**: The tool MUST be fast and efficient.
+- **NFR-003**: The tool MUST handle large content by truncating and summarizing if necessary.
+- **NFR-004**: The tool MUST provide clear error messages and diagnostic output (HTTP status code, content size).
+- **NFR-005**: The cache MUST use an LRU eviction strategy with automatic expiration (no manual cleanup interval).
 
 ### Key Entities *(include if feature involves data)*
 
-- **WebFetch Cache**: An in-memory store for Markdown content indexed by URL, with a TTL of 15 minutes.
-- **Markdown Content**: The result of converting HTML to a simplified text format for AI processing.
+- **WebFetch Cache**: An LRU cache for Markdown content indexed by URL, with a TTL of 15 minutes and a 50MB max size limit. Each entry stores: `{ bytes, code, codeText, content, contentType }`.
+- **Markdown Content**: The result of converting HTML to a simplified text format for AI processing. Content exceeding 100,000 characters is truncated.

--- a/specs/017-web-fetch-tool/tasks.md
+++ b/specs/017-web-fetch-tool/tasks.md
@@ -85,3 +85,19 @@
 
 - [X] T019 Run `pnpm run type-check` and `pnpm lint` across the monorepo
 - [X] T020 Run `quickstart.md` validation scenarios manually
+
+---
+
+## Phase 9: Security & Robustness Improvements
+
+**Purpose**: Security limits, URL validation, LRU cache upgrade, output enrichment
+
+- [X] T021 Add URL validation: max 2000 chars, reject credentials, reject localhost/single-part hostnames in `packages/agent-sdk/src/tools/webFetchTool.ts`
+- [X] T022 Add security limits: 10MB content max, 60s fetch timeout, 10 redirect max in `packages/agent-sdk/src/tools/webFetchTool.ts`
+- [X] T023 Improve redirect handling: follow same-host/www-variation redirects automatically in `packages/agent-sdk/src/tools/webFetchTool.ts`
+- [X] T024 Upgrade cache to LRU: add `lru-cache` dependency, 50MB limit, remove setInterval in `packages/agent-sdk/src/tools/webFetchTool.ts`
+- [X] T025 Add content truncation at 100K chars before AI processing in `packages/agent-sdk/src/tools/webFetchTool.ts`
+- [X] T026 Update User-Agent to honest identifier, add Accept header in `packages/agent-sdk/src/tools/webFetchTool.ts`
+- [X] T027 Enrich output with HTTP status code and content size in `packages/agent-sdk/src/tools/webFetchTool.ts`
+- [X] T028 Update tests for all new behaviors in `packages/agent-sdk/tests/tools/webFetchTool.test.ts`
+- [X] T029 Run `pnpm run type-check` and `pnpm lint` across the monorepo


### PR DESCRIPTION
## Summary

Improves the WebFetch tool with security limits, URL validation, LRU caching, automatic redirect following, content truncation, and enriched output — adopting proven patterns from Claude Code's implementation.

## Changes

### Security & Validation
- URL validation (max 2000 chars, no credentials, no localhost/single-part hostnames)
- 10MB content length limit and 60-second fetch timeout via AbortController
- Max 10 redirect hops to prevent infinite loops

### Redirect Handling
- Auto-follow same-host and www-variation redirects recursively
- Only return `REDIRECT_TO:` message for cross-host redirects

### Cache Upgrade
- Replaced Map+setInterval with `lru-cache` (15min TTL, 50MB size limit)
- Richer cache entries: `{ bytes, code, codeText, content, contentType }`
- Automatic eviction, no manual cleanup interval

### Output & Headers
- Honest User-Agent: `Wave-User (+https://github.com/netease-lcap/wave-agent)`
- Accept header: `text/markdown, text/html, */*`
- Enriched shortResult with size and HTTP status (e.g., `Received 2.3KB (200 OK) from ...`)
- Content truncation at 100K chars to prevent AI API failures

### Tests
- 14 new tests covering all new behaviors (19 tests total)

### Documentation
- Updated all spec files (spec, plan, tasks, contracts, data-model, research, requirements)