### PR TITLE
fix: diamond prefix for notifications and flaky test fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,7 @@ Always use `pnpm` as the package manager.
     - Explicitly instruct the subagent to ONLY perform the tasks delegated to them.
     - Instruct them to update their assigned tasks frequently using the task management tools.
 
+## 🐛 Debugging
+
+- **Prefer temporary console.log/console.trace**: When diagnosing bugs, especially race conditions or complex flows, add temporary `console.log` or `console.trace` statements to trace execution rather than overthinking through static analysis. Run the code/tests, observe the actual output, then remove the logs once the issue is identified.
+

--- a/packages/agent-sdk/tests/agent/hooks-exitcode-output/hook-blocking-error.test.ts
+++ b/packages/agent-sdk/tests/agent/hooks-exitcode-output/hook-blocking-error.test.ts
@@ -32,6 +32,15 @@ vi.mock("@/managers/toolManager", () => ({
   }),
 }));
 
+vi.mock("@/managers/forkedAgentManager", () => ({
+  ForkedAgentManager: vi.fn().mockImplementation(function () {
+    return {
+      forkAndExecute: vi.fn().mockResolvedValue("mock-fork-id"),
+      cleanup: vi.fn(),
+    };
+  }),
+}));
+
 describe("Hook Blocking Error Behavior (User Story 2)", () => {
   let agent: Agent;
   const mockCallbacks = {

--- a/packages/code/src/components/TaskNotificationMessage.tsx
+++ b/packages/code/src/components/TaskNotificationMessage.tsx
@@ -20,7 +20,7 @@ export const TaskNotificationMessage = ({
   return (
     <Box flexDirection="column">
       <Box>
-        <Text color={color}>● </Text>
+        <Text color={color}>◆ </Text>
         <Text color="white">{block.summary}</Text>
       </Box>
     </Box>


### PR DESCRIPTION
- style: use diamond prefix (◆) for task notifications
- test: fix flaky hook-blocking-error test by mocking ForkedAgentManager to prevent extra AI call from auto-memory extraction
- docs: add debugging guideline to AGENTS.md (prefer console.log/console.trace)