### PR TITLE
feat: scoped marketplace support + fix flaky hook tests

### DIFF
--- a/packages/agent-sdk/src/core/plugin.ts
+++ b/packages/agent-sdk/src/core/plugin.ts
@@ -30,7 +30,10 @@ export class PluginCore {
     this.workdir = workdir;
     this.container = new Container();
     this.configurationService = new ConfigurationService();
-    this.marketplaceService = new MarketplaceService();
+    this.marketplaceService = new MarketplaceService(
+      this.workdir,
+      this.configurationService,
+    );
 
     // Wire up ConfigurationService in the container for PluginManager to use
     this.container.register("ConfigurationService", this.configurationService);
@@ -122,7 +125,7 @@ export class PluginCore {
     for (const m of marketplaces) {
       try {
         const manifest = await this.marketplaceService.loadMarketplaceManifest(
-          this.marketplaceService.getMarketplacePath(m),
+          this.marketplaceService.getMarketplacePath(m.source),
         );
         manifest.plugins.forEach((p) => {
           const pluginId = `${p.name}@${m.name}`;
@@ -154,15 +157,18 @@ export class PluginCore {
   /**
    * Adds a new marketplace
    */
-  async addMarketplace(input: string): Promise<KnownMarketplace> {
-    return await this.marketplaceService.addMarketplace(input);
+  async addMarketplace(
+    input: string,
+    scope: Scope = "user",
+  ): Promise<KnownMarketplace> {
+    return await this.marketplaceService.addMarketplace(input, scope);
   }
 
   /**
    * Removes a marketplace by name
    */
-  async removeMarketplace(name: string): Promise<void> {
-    await this.marketplaceService.removeMarketplace(name);
+  async removeMarketplace(name: string, scope?: Scope): Promise<void> {
+    await this.marketplaceService.removeMarketplace(name, scope);
   }
 
   /**
@@ -208,7 +214,7 @@ export class PluginCore {
    * Resolves the local path for a marketplace
    */
   getMarketplacePath(marketplace: KnownMarketplace): string {
-    return this.marketplaceService.getMarketplacePath(marketplace);
+    return this.marketplaceService.getMarketplacePath(marketplace.source);
   }
 
   /**

--- a/packages/agent-sdk/src/managers/pluginManager.ts
+++ b/packages/agent-sdk/src/managers/pluginManager.ts
@@ -72,7 +72,10 @@ export class PluginManager {
         );
       }
 
-      const marketplaceService = new MarketplaceService();
+      const marketplaceService = new MarketplaceService(
+        this.workdir,
+        this.configurationService,
+      );
 
       // Trigger auto-update for marketplaces in the background
       if (!process.env.VITEST) {

--- a/packages/agent-sdk/src/services/MarketplaceService.ts
+++ b/packages/agent-sdk/src/services/MarketplaceService.ts
@@ -8,14 +8,20 @@ import {
   InstalledPlugin,
   InstalledPluginsRegistry,
   MarketplaceManifest,
+  MarketplaceSource,
 } from "../types/marketplace.js";
 import { GitService } from "./GitService.js";
+import { ConfigurationService } from "./configurationService.js";
+import type { MarketplaceConfig, Scope } from "../types/configuration.js";
 
 /**
  * Marketplace Service
  *
  * Handles local plugin marketplace registration, plugin installation,
  * and state management for installed plugins.
+ *
+ * Marketplace declarations are now scoped (user/project/local) via settings files.
+ * known_marketplaces.json is kept as a cache for installLocation/lastUpdated metadata.
  */
 export class MarketplaceService {
   private static isLockedInProcess = false;
@@ -27,6 +33,8 @@ export class MarketplaceService {
   private cacheDir: string;
   private marketplacesDir: string;
   private gitService: GitService;
+  private configurationService: ConfigurationService;
+  private workdir: string;
   private static readonly BUILTIN_MARKETPLACE: KnownMarketplace = {
     name: "wave-plugins-official",
     source: {
@@ -36,7 +44,12 @@ export class MarketplaceService {
     autoUpdate: true,
   };
 
-  constructor() {
+  constructor(
+    workdir: string = process.cwd(),
+    configurationService: ConfigurationService = new ConfigurationService(),
+  ) {
+    this.workdir = workdir;
+    this.configurationService = configurationService;
     this.pluginsDir = getPluginsDir();
     this.knownMarketplacesPath = path.join(
       this.pluginsDir,
@@ -53,6 +66,7 @@ export class MarketplaceService {
     this.gitService = new GitService();
 
     this.ensureDirectoryStructure();
+    this.runMigration();
   }
 
   /**
@@ -69,6 +83,44 @@ export class MarketplaceService {
   }
 
   /**
+   * Backwards compatibility migration: migrate entries from known_marketplaces.json
+   * to user-level settings if they aren't already declared there.
+   */
+  private async runMigration(): Promise<void> {
+    try {
+      const cacheRegistry = await this.getCacheRegistry();
+      const scopedMarketplaces =
+        this.configurationService.getMergedMarketplaces(this.workdir);
+      const userMarketplaces = this.configurationService.getScopedMarketplaces(
+        this.workdir,
+        "user",
+      );
+
+      const entriesToMigrate = (cacheRegistry?.marketplaces ?? []).filter(
+        (m) => !scopedMarketplaces[m.name] && !userMarketplaces[m.name],
+      );
+
+      if (entriesToMigrate.length > 0) {
+        for (const m of entriesToMigrate) {
+          if (m.name === MarketplaceService.BUILTIN_MARKETPLACE.name) continue;
+          const config: MarketplaceConfig = {
+            source: m.source,
+            autoUpdate: m.autoUpdate,
+          };
+          await this.configurationService.addMarketplaceToScope(
+            this.workdir,
+            "user",
+            m.name,
+            config,
+          );
+        }
+      }
+    } catch {
+      // Migration failure should not block startup
+    }
+  }
+
+  /**
    * Check if a lock file is stale by reading its PID and checking if the process is alive.
    * Returns true if the lock is stale and safe to remove.
    */
@@ -77,15 +129,14 @@ export class MarketplaceService {
       const content = await fs.readFile(this.lockPath, "utf-8");
       const pid = parseInt(content.trim(), 10);
       if (isNaN(pid)) return true;
-      // Check if the process is still running
       try {
         process.kill(pid, 0);
-        return false; // Process exists, lock is valid
+        return false;
       } catch {
-        return true; // Process doesn't exist, lock is stale
+        return true;
       }
     } catch {
-      return true; // Can't read lock file, assume stale
+      return true;
     }
   }
 
@@ -99,7 +150,7 @@ export class MarketplaceService {
     }
 
     let lockFd: Awaited<ReturnType<typeof fs.open>> | undefined;
-    const maxRetries = 600; // 60 seconds total
+    const maxRetries = 600;
     const retryDelay = 100;
 
     for (let i = 0; i < maxRetries; i++) {
@@ -113,7 +164,6 @@ export class MarketplaceService {
           "code" in error &&
           error.code === "EEXIST"
         ) {
-          // Check for stale lock every 60 retries (every ~6 seconds)
           if (i > 0 && i % 60 === 0) {
             const stale = await this.isStaleLock();
             if (stale) {
@@ -134,7 +184,6 @@ export class MarketplaceService {
       );
     }
 
-    // Write PID into the lock file for stale lock detection
     await fs.writeFile(this.lockPath, String(process.pid), "utf-8");
 
     MarketplaceService.isLockedInProcess = true;
@@ -148,36 +197,96 @@ export class MarketplaceService {
   }
 
   /**
-   * Loads the known marketplaces registry
+   * Loads the cache registry from known_marketplaces.json
+   * Returns null if the file doesn't exist or has no parseable content (for first-run detection).
+   */
+  async getCacheRegistry(): Promise<KnownMarketplacesRegistry | null> {
+    if (!existsSync(this.knownMarketplacesPath)) {
+      return null;
+    }
+    try {
+      const content = await fs.readFile(this.knownMarketplacesPath, "utf-8");
+      if (!content.trim()) {
+        return null;
+      }
+      return JSON.parse(content);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Legacy method: loads known marketplaces with builtin injection.
+   * @deprecated Use listMarketplaces() instead, which combines scoped settings.
    */
   async getKnownMarketplaces(): Promise<KnownMarketplacesRegistry> {
-    if (!existsSync(this.knownMarketplacesPath)) {
+    const cache = await this.getCacheRegistry();
+    // If cache is null (file doesn't exist or has no parseable content), inject builtin
+    if (cache === null) {
       return {
         marketplaces: [
           {
             ...MarketplaceService.BUILTIN_MARKETPLACE,
             isBuiltin: true,
+            declaredScope: "builtin",
           },
         ],
       };
     }
-    try {
-      const content = await fs.readFile(this.knownMarketplacesPath, "utf-8");
-      if (!content.trim()) {
-        return {
-          marketplaces: [
-            {
-              ...MarketplaceService.BUILTIN_MARKETPLACE,
-              isBuiltin: true,
-            },
-          ],
-        };
-      }
-      return JSON.parse(content);
-    } catch (error) {
-      console.error("Failed to load known marketplaces:", error);
-      return { marketplaces: [] };
+    // File has valid JSON - respect user's explicit choice even if empty
+    const hasBuiltin = cache.marketplaces.some(
+      (m) => m.name === MarketplaceService.BUILTIN_MARKETPLACE.name,
+    );
+    return {
+      marketplaces: cache.marketplaces.map((m) => ({
+        ...m,
+        isBuiltin:
+          m.isBuiltin || m.name === MarketplaceService.BUILTIN_MARKETPLACE.name,
+        declaredScope: m.declaredScope ?? (hasBuiltin ? "builtin" : "user"),
+      })),
+    };
+  }
+
+  /**
+   * Updates the cache registry with metadata for a marketplace
+   */
+  private async updateCacheMarketplace(
+    name: string,
+    metadata: Partial<KnownMarketplace>,
+  ): Promise<void> {
+    const registry = await this.getCacheRegistry();
+    const marketplaces = registry?.marketplaces ?? [];
+    const existingIndex = marketplaces.findIndex((m) => m.name === name);
+    if (existingIndex >= 0) {
+      marketplaces[existingIndex] = {
+        ...marketplaces[existingIndex],
+        ...metadata,
+      };
+    } else {
+      marketplaces.push({
+        name,
+        source: metadata.source || { source: "directory", path: "" },
+        ...metadata,
+      });
     }
+    const tmpPath = `${this.knownMarketplacesPath}.tmp`;
+    await fs.writeFile(tmpPath, JSON.stringify({ marketplaces }, null, 2));
+    await fs.rename(tmpPath, this.knownMarketplacesPath);
+  }
+
+  /**
+   * Removes a marketplace from the cache registry
+   */
+  private async removeFromCache(name: string): Promise<void> {
+    const registry = await this.getCacheRegistry();
+    const marketplaces = registry?.marketplaces ?? [];
+    const filtered = marketplaces.filter((m) => m.name !== name);
+    const tmpPath = `${this.knownMarketplacesPath}.tmp`;
+    await fs.writeFile(
+      tmpPath,
+      JSON.stringify({ marketplaces: filtered }, null, 2),
+    );
+    await fs.rename(tmpPath, this.knownMarketplacesPath);
   }
 
   /**
@@ -197,17 +306,6 @@ export class MarketplaceService {
       console.error("Failed to load installed plugins:", error);
       return { plugins: [] };
     }
-  }
-
-  /**
-   * Saves the known marketplaces registry
-   */
-  async saveKnownMarketplaces(
-    registry: KnownMarketplacesRegistry,
-  ): Promise<void> {
-    const tmpPath = `${this.knownMarketplacesPath}.tmp`;
-    await fs.writeFile(tmpPath, JSON.stringify(registry, null, 2));
-    await fs.rename(tmpPath, this.knownMarketplacesPath);
   }
 
   /**
@@ -238,7 +336,6 @@ export class MarketplaceService {
     const content = await fs.readFile(manifestPath, "utf-8");
     const manifest = JSON.parse(content);
 
-    // Basic validation
     if (
       !manifest.name ||
       !manifest.plugins ||
@@ -253,25 +350,60 @@ export class MarketplaceService {
   /**
    * Resolves the local path for a marketplace
    */
-  public getMarketplacePath(marketplace: KnownMarketplace): string {
-    if (marketplace.source.source === "directory") {
-      return marketplace.source.path;
-    } else if (marketplace.source.source === "github") {
-      return path.join(this.marketplacesDir, marketplace.source.repo);
+  public getMarketplacePath(source: MarketplaceSource): string {
+    if (source.source === "directory") {
+      return source.path;
+    } else if (source.source === "github") {
+      return path.join(this.marketplacesDir, source.repo);
     } else {
-      // For general git, use a hash of the URL to avoid path issues
-      const hash = crypto
-        .createHash("md5")
-        .update(marketplace.source.url)
-        .digest("hex");
+      const hash = crypto.createHash("md5").update(source.url).digest("hex");
       return path.join(this.marketplacesDir, hash);
     }
   }
 
   /**
+   * Builds a KnownMarketplace from a scoped config, enriched with cache metadata
+   */
+  private async buildMarketplaceEntry(
+    name: string,
+    config: MarketplaceConfig,
+    cache: KnownMarketplace | undefined,
+    declaredScope: "user" | "project" | "local" | "builtin",
+  ): Promise<KnownMarketplace> {
+    return {
+      name,
+      source: config.source,
+      autoUpdate: config.autoUpdate ?? cache?.autoUpdate,
+      lastUpdated: cache?.lastUpdated,
+      isBuiltin: name === MarketplaceService.BUILTIN_MARKETPLACE.name,
+      declaredScope,
+    };
+  }
+
+  /**
+   * Finds which scope declared a marketplace (user, project, local, or builtin)
+   */
+  getMarketplaceDeclaringSource(name: string): Scope | "builtin" | null {
+    if (name === MarketplaceService.BUILTIN_MARKETPLACE.name) return "builtin";
+
+    const scopes: Scope[] = ["local", "project", "user"];
+    for (const scope of scopes) {
+      const scoped = this.configurationService.getScopedMarketplaces(
+        this.workdir,
+        scope,
+      );
+      if (scoped[name]) return scope;
+    }
+    return null;
+  }
+
+  /**
    * Adds a new marketplace (local directory, GitHub repo, or Git URL)
    */
-  async addMarketplace(input: string): Promise<KnownMarketplace> {
+  async addMarketplace(
+    input: string,
+    scope: Scope = "user",
+  ): Promise<KnownMarketplace> {
     return this.withLock(async () => {
       let marketplace: KnownMarketplace;
 
@@ -287,7 +419,6 @@ export class MarketplaceService {
           !path.isAbsolute(input) &&
           !input.startsWith("."))
       ) {
-        // Git or GitHub repo
         let urlOrRepo = input;
         let ref: string | undefined;
 
@@ -295,11 +426,11 @@ export class MarketplaceService {
           [urlOrRepo, ref] = input.split("#");
         }
 
-        const tempMarketplace: KnownMarketplace = isFullUrl
-          ? { name: "", source: { source: "git", url: urlOrRepo, ref } }
-          : { name: "", source: { source: "github", repo: urlOrRepo, ref } };
+        const tempSource: MarketplaceSource = isFullUrl
+          ? { source: "git", url: urlOrRepo, ref }
+          : { source: "github", repo: urlOrRepo, ref };
 
-        const targetPath = this.getMarketplacePath(tempMarketplace);
+        const targetPath = this.getMarketplacePath(tempSource);
 
         if (!existsSync(targetPath)) {
           try {
@@ -329,7 +460,6 @@ export class MarketplaceService {
           lastUpdated: new Date().toISOString(),
         };
       } else {
-        // Local directory format
         const absolutePath = path.resolve(input);
         let manifest: MarketplaceManifest;
         try {
@@ -348,54 +478,97 @@ export class MarketplaceService {
         };
       }
 
-      const registry = await this.getKnownMarketplaces();
+      const config: MarketplaceConfig = {
+        source: marketplace.source,
+        autoUpdate: marketplace.autoUpdate,
+      };
 
-      // Check if already exists
-      const existingIndex = registry.marketplaces.findIndex(
-        (m) => m.name === marketplace.name,
+      await this.configurationService.addMarketplaceToScope(
+        this.workdir,
+        scope,
+        marketplace.name,
+        config,
       );
-      if (existingIndex >= 0) {
-        registry.marketplaces[existingIndex] = marketplace;
-      } else {
-        registry.marketplaces.push(marketplace);
-      }
 
-      // Ensure builtin is included if we are creating the file for the first time
-      // and it hasn't been explicitly removed yet.
-      // (getKnownMarketplaces already handles the default injection)
+      // Update cache with metadata
+      await this.updateCacheMarketplace(marketplace.name, {
+        source: marketplace.source,
+        autoUpdate: marketplace.autoUpdate,
+        lastUpdated: marketplace.lastUpdated,
+      });
 
-      await this.saveKnownMarketplaces(registry);
       return marketplace;
     });
   }
 
   /**
-   * Lists all registered marketplaces
+   * Lists all registered marketplaces by combining scoped settings + built-in
    */
   async listMarketplaces(): Promise<KnownMarketplace[]> {
-    const registry = await this.getKnownMarketplaces();
-    return registry.marketplaces.map((m) => ({
-      ...m,
-      isBuiltin: m.name === MarketplaceService.BUILTIN_MARKETPLACE.name,
-    }));
+    const scopedMarketplaces = this.configurationService.getMergedMarketplaces(
+      this.workdir,
+    );
+    const cacheRegistry = await this.getCacheRegistry();
+    const cacheMap = new Map(
+      (cacheRegistry?.marketplaces ?? []).map((m) => [m.name, m]),
+    );
+
+    const result: KnownMarketplace[] = [];
+
+    // Add built-in marketplace
+    result.push({
+      ...MarketplaceService.BUILTIN_MARKETPLACE,
+      isBuiltin: true,
+      declaredScope: "builtin",
+    });
+
+    // Add all scoped marketplaces (local overrides project overrides user)
+    for (const [name, config] of Object.entries(scopedMarketplaces)) {
+      if (name === MarketplaceService.BUILTIN_MARKETPLACE.name) continue;
+      const cache = cacheMap.get(name);
+      const declaredScope = this.getMarketplaceDeclaringSource(name) as
+        | "user"
+        | "project"
+        | "local";
+      result.push(
+        await this.buildMarketplaceEntry(name, config, cache, declaredScope),
+      );
+    }
+
+    // Add cache entries not yet in scoped settings (backwards compatibility)
+    for (const [name, cache] of cacheMap.entries()) {
+      if (name === MarketplaceService.BUILTIN_MARKETPLACE.name) continue;
+      if (scopedMarketplaces[name]) continue;
+      result.push({
+        ...cache,
+        isBuiltin: false,
+        declaredScope: cache.declaredScope ?? "user",
+      });
+    }
+
+    return result;
   }
 
   /**
-   * Removes a marketplace by name
+   * Removes a marketplace by name from the specified scope
    */
-  async removeMarketplace(name: string): Promise<void> {
+  async removeMarketplace(name: string, scope?: Scope): Promise<void> {
     return this.withLock(async () => {
-      const registry = await this.getKnownMarketplaces();
-      const initialCount = registry.marketplaces.length;
-      registry.marketplaces = registry.marketplaces.filter(
-        (m) => m.name !== name,
-      );
+      const targetScope =
+        scope || this.getMarketplaceDeclaringSource(name) || "user";
 
-      if (registry.marketplaces.length === initialCount) {
-        throw new Error(`Marketplace ${name} not found`);
+      if (targetScope === "builtin") {
+        throw new Error("Cannot remove built-in marketplace");
       }
 
-      await this.saveKnownMarketplaces(registry);
+      await this.configurationService.removeMarketplaceFromScope(
+        this.workdir,
+        targetScope,
+        name,
+      );
+
+      // Also remove from cache
+      await this.removeFromCache(name);
     });
   }
 
@@ -407,10 +580,10 @@ export class MarketplaceService {
     options?: { updatePlugins?: boolean },
   ): Promise<void> {
     return this.withLock(async () => {
-      const registry = await this.getKnownMarketplaces();
+      const marketplaces = await this.listMarketplaces();
       const toUpdate = name
-        ? registry.marketplaces.filter((m) => m.name === name)
-        : registry.marketplaces;
+        ? marketplaces.filter((m) => m.name === name)
+        : marketplaces;
 
       if (name && toUpdate.length === 0) {
         throw new Error(`Marketplace ${name} not found`);
@@ -430,7 +603,7 @@ export class MarketplaceService {
               );
               continue;
             }
-            const targetPath = this.getMarketplacePath(marketplace);
+            const targetPath = this.getMarketplacePath(marketplace.source);
             if (existsSync(targetPath)) {
               await this.gitService.pull(targetPath);
             } else {
@@ -447,12 +620,16 @@ export class MarketplaceService {
               );
             }
           }
-          // For directory source, we just re-validate the manifest
           const manifest = await this.loadMarketplaceManifest(
-            this.getMarketplacePath(marketplace),
+            this.getMarketplacePath(marketplace.source),
           );
 
           marketplace.lastUpdated = new Date().toISOString();
+
+          // Update cache metadata
+          await this.updateCacheMarketplace(marketplace.name, {
+            lastUpdated: marketplace.lastUpdated,
+          });
 
           if (options?.updatePlugins) {
             const installedRegistry = await this.getInstalledPlugins();
@@ -505,8 +682,6 @@ export class MarketplaceService {
           `Some marketplaces failed to update:\n${errors.join("\n")}`,
         );
       }
-
-      await this.saveKnownMarketplaces(registry);
     });
   }
 
@@ -515,17 +690,20 @@ export class MarketplaceService {
    */
   async autoUpdateAll(): Promise<void> {
     return this.withLock(async () => {
-      const registry = await this.getKnownMarketplaces();
-      const toAutoUpdate = registry.marketplaces.filter((m) => m.autoUpdate);
+      const scopedMarketplaces =
+        this.configurationService.getMergedMarketplaces(this.workdir);
+      const toAutoUpdate = Object.entries(scopedMarketplaces)
+        .filter(([, config]) => config.autoUpdate)
+        .map(([name]) => name);
 
-      for (const marketplace of toAutoUpdate) {
+      for (const marketplaceName of toAutoUpdate) {
         try {
-          await this.updateMarketplace(marketplace.name, {
+          await this.updateMarketplace(marketplaceName, {
             updatePlugins: true,
           });
         } catch (error) {
           console.error(
-            `Auto-update failed for marketplace "${marketplace.name}":`,
+            `Auto-update failed for marketplace "${marketplaceName}":`,
             error,
           );
         }
@@ -538,13 +716,30 @@ export class MarketplaceService {
    */
   async toggleAutoUpdate(name: string, enabled: boolean): Promise<void> {
     return this.withLock(async () => {
-      const registry = await this.getKnownMarketplaces();
-      const marketplace = registry.marketplaces.find((m) => m.name === name);
-      if (!marketplace) {
+      const declaringSource = this.getMarketplaceDeclaringSource(name);
+      if (!declaringSource || declaringSource === "builtin") {
         throw new Error(`Marketplace ${name} not found`);
       }
-      marketplace.autoUpdate = enabled;
-      await this.saveKnownMarketplaces(registry);
+
+      const scoped = this.configurationService.getScopedMarketplaces(
+        this.workdir,
+        declaringSource,
+      );
+      const config = scoped[name];
+      if (!config) {
+        throw new Error(`Marketplace ${name} not found`);
+      }
+
+      config.autoUpdate = enabled;
+      await this.configurationService.addMarketplaceToScope(
+        this.workdir,
+        declaringSource,
+        name,
+        config,
+      );
+
+      // Also update cache
+      await this.updateCacheMarketplace(name, { autoUpdate: enabled });
     });
   }
 
@@ -567,7 +762,7 @@ export class MarketplaceService {
         throw new Error(`Marketplace ${marketplaceName} not found`);
       }
 
-      const marketplacePath = this.getMarketplacePath(marketplace);
+      const marketplacePath = this.getMarketplacePath(marketplace.source);
       const manifest = await this.loadMarketplaceManifest(marketplacePath);
       const pluginEntry = manifest.plugins.find((p) => p.name === pluginName);
       if (!pluginEntry) {
@@ -615,7 +810,6 @@ export class MarketplaceService {
         const pluginManifest = JSON.parse(pluginManifestContent);
         const version = pluginManifest.version || "1.0.0";
 
-        // Atomic installation
         const tmpPluginDir = path.join(
           this.tmpDir,
           `${pluginName}-${Date.now()}`,
@@ -623,7 +817,7 @@ export class MarketplaceService {
         try {
           if (isGitSource) {
             await fs.rename(pluginSrcPath, tmpPluginDir);
-            tempCloneDir = undefined; // Already moved
+            tempCloneDir = undefined;
           } else {
             await fs.cp(pluginSrcPath, tmpPluginDir, { recursive: true });
           }
@@ -665,14 +859,12 @@ export class MarketplaceService {
           await this.saveInstalledPlugins(installedRegistry);
           return installedPlugin;
         } catch (error) {
-          // Cleanup tmp dir if it exists
           if (existsSync(tmpPluginDir)) {
             await fs.rm(tmpPluginDir, { recursive: true, force: true });
           }
           throw error;
         }
       } catch (error) {
-        // Cleanup temp clone dir if it exists
         if (tempCloneDir && existsSync(tempCloneDir)) {
           await fs.rm(tempCloneDir, { recursive: true, force: true });
         }
@@ -712,16 +904,13 @@ export class MarketplaceService {
 
       const pluginToRemove = installedRegistry.plugins[pluginIndex];
 
-      // Remove from registry first
       installedRegistry.plugins.splice(pluginIndex, 1);
       await this.saveInstalledPlugins(installedRegistry);
 
-      // Check if any other project is still using this same cache path
       const isStillReferenced = installedRegistry.plugins.some(
         (p) => p.cachePath === pluginToRemove.cachePath,
       );
 
-      // Only remove cached files if no other references exist
       if (!isStillReferenced && existsSync(pluginToRemove.cachePath)) {
         await fs.rm(pluginToRemove.cachePath, { recursive: true, force: true });
       }

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -15,6 +15,7 @@ import type {
   ConfigurationPaths,
   WaveConfiguration,
   Scope,
+  MarketplaceConfig,
 } from "../types/configuration.js";
 import {
   getAllConfigPaths,
@@ -797,6 +798,124 @@ export class ConfigurationService {
   }
 
   /**
+   * Get merged marketplaces from all scopes
+   */
+  getMergedMarketplaces(workdir: string): Record<string, MarketplaceConfig> {
+    const mergedConfig = loadMergedWaveConfig(workdir);
+    return mergedConfig?.marketplaces || {};
+  }
+
+  /**
+   * Get marketplaces at a specific scope
+   */
+  getScopedMarketplaces(
+    workdir: string,
+    scope: Scope,
+  ): Record<string, MarketplaceConfig> {
+    let configPath: string;
+    if (scope === "user") {
+      configPath = getUserConfigPaths()[0];
+    } else if (scope === "project") {
+      configPath = getProjectConfigPaths(workdir)[1];
+    } else {
+      configPath = getProjectConfigPaths(workdir)[0];
+    }
+    const config = loadWaveConfigFromFile(configPath);
+    return config?.marketplaces || {};
+  }
+
+  /**
+   * Add a marketplace to the specified scope
+   */
+  async addMarketplaceToScope(
+    workdir: string,
+    scope: Scope,
+    name: string,
+    config: MarketplaceConfig,
+  ): Promise<void> {
+    if (scope !== "user" && !existsSync(workdir)) {
+      throw new Error(`Working directory does not exist: ${workdir}`);
+    }
+
+    let configPath: string;
+    if (scope === "user") {
+      configPath = getUserConfigPaths()[0];
+    } else if (scope === "project") {
+      configPath = getProjectConfigPaths(workdir)[1];
+    } else {
+      configPath = getProjectConfigPaths(workdir)[0];
+    }
+
+    const configDir = path.dirname(configPath);
+    if (!existsSync(configDir)) {
+      await fs.mkdir(configDir, { recursive: true });
+    }
+
+    let fileConfig: WaveConfiguration = {};
+    if (existsSync(configPath)) {
+      try {
+        const content = await fs.readFile(configPath, "utf-8");
+        fileConfig = JSON.parse(content);
+      } catch {
+        // Start with empty config if file is corrupted
+      }
+    }
+
+    if (!fileConfig.marketplaces) {
+      fileConfig.marketplaces = {};
+    }
+    fileConfig.marketplaces[name] = config;
+
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(fileConfig, null, 2),
+      "utf-8",
+    );
+  }
+
+  /**
+   * Remove a marketplace from the specified scope
+   */
+  async removeMarketplaceFromScope(
+    workdir: string,
+    scope: Scope,
+    name: string,
+  ): Promise<void> {
+    if (scope !== "user" && !existsSync(workdir)) {
+      throw new Error(`Working directory does not exist: ${workdir}`);
+    }
+
+    let configPath: string;
+    if (scope === "user") {
+      configPath = getUserConfigPaths()[0];
+    } else if (scope === "project") {
+      configPath = getProjectConfigPaths(workdir)[1];
+    } else {
+      configPath = getProjectConfigPaths(workdir)[0];
+    }
+
+    if (!existsSync(configPath)) {
+      return;
+    }
+
+    try {
+      const content = await fs.readFile(configPath, "utf-8");
+      const fileConfig: WaveConfiguration = JSON.parse(content);
+
+      if (fileConfig.marketplaces && name in fileConfig.marketplaces) {
+        delete fileConfig.marketplaces[name];
+        await fs.writeFile(
+          configPath,
+          JSON.stringify(fileConfig, null, 2),
+          "utf-8",
+        );
+      }
+    } catch {
+      // Ignore errors for corrupted or non-existent files
+    }
+  }
+
+  /**
    * Remove a plugin from the enabled plugins in the specified scope
    */
   async removeEnabledPlugin(
@@ -991,6 +1110,7 @@ export function loadWaveConfigFromFile(
           ? config.autoMemoryEnabled
           : undefined,
       models: config.models || undefined,
+      marketplaces: config.marketplaces || undefined,
     };
   } catch (error) {
     if (error instanceof SyntaxError) {
@@ -1124,6 +1244,12 @@ export function loadMergedWaveConfig(
       mergedConfig.autoMemoryFrequency = config.autoMemoryFrequency;
     }
 
+    // Merge marketplaces (last one wins for same key)
+    if (config.marketplaces) {
+      if (!mergedConfig.marketplaces) mergedConfig.marketplaces = {};
+      Object.assign(mergedConfig.marketplaces, config.marketplaces);
+    }
+
     // Merge models
     if (config.models) {
       if (!mergedConfig.models) mergedConfig.models = {};
@@ -1157,6 +1283,11 @@ export function loadMergedWaveConfig(
         : undefined,
     language: mergedConfig.language,
     autoMemoryEnabled: mergedConfig.autoMemoryEnabled,
+    marketplaces:
+      mergedConfig.marketplaces &&
+      Object.keys(mergedConfig.marketplaces).length > 0
+        ? mergedConfig.marketplaces
+        : undefined,
     models:
       mergedConfig.models && Object.keys(mergedConfig.models).length > 0
         ? mergedConfig.models

--- a/packages/agent-sdk/src/types/configuration.ts
+++ b/packages/agent-sdk/src/types/configuration.ts
@@ -9,8 +9,14 @@
 import type { HookEvent, HookEventConfig } from "./hooks.js";
 import type { PermissionMode } from "./permissions.js";
 import type { ModelConfig } from "./config.js";
+import type { MarketplaceSource } from "./marketplace.js";
 
 export type Scope = "user" | "project" | "local";
+
+export interface MarketplaceConfig {
+  source: MarketplaceSource;
+  autoUpdate?: boolean;
+}
 
 /**
  * Root configuration structure for all Wave Agent settings including hooks and environment variables
@@ -39,6 +45,8 @@ export interface WaveConfiguration {
   autoMemoryFrequency?: number;
   /** Model-specific configuration overrides */
   models?: Record<string, Partial<ModelConfig>>;
+  /** Scoped marketplace declarations */
+  marketplaces?: Record<string, MarketplaceConfig>;
 }
 
 /**

--- a/packages/agent-sdk/src/types/marketplace.ts
+++ b/packages/agent-sdk/src/types/marketplace.ts
@@ -48,6 +48,8 @@ export interface KnownMarketplace {
   isBuiltin?: boolean;
   autoUpdate?: boolean;
   lastUpdated?: string;
+  /** The scope where this marketplace was declared (user, project, local, or builtin) */
+  declaredScope?: "user" | "project" | "local" | "builtin";
 }
 
 export interface KnownMarketplacesRegistry {

--- a/packages/agent-sdk/tests/agent/hooks-exitcode-output/hook-non-blocking-error.test.ts
+++ b/packages/agent-sdk/tests/agent/hooks-exitcode-output/hook-non-blocking-error.test.ts
@@ -32,6 +32,16 @@ vi.mock("@/managers/toolManager", () => ({
   }),
 }));
 
+// Prevent auto-memory extraction forked agents from making extra AI calls
+vi.mock("@/managers/forkedAgentManager", () => ({
+  ForkedAgentManager: vi.fn().mockImplementation(function () {
+    return {
+      forkAndExecute: vi.fn().mockResolvedValue("mock-fork-id"),
+      cleanup: vi.fn(),
+    };
+  }),
+}));
+
 describe("Hook Non-Blocking Error Behavior (User Story 3)", () => {
   let agent: Agent;
   const mockCallbacks = {

--- a/packages/agent-sdk/tests/agent/hooks-exitcode-output/hook-success.test.ts
+++ b/packages/agent-sdk/tests/agent/hooks-exitcode-output/hook-success.test.ts
@@ -15,6 +15,16 @@ function hasContent(
 // Mock AI service directly in this file
 vi.mock("@/services/aiService");
 
+// Prevent auto-memory extraction forked agents from making extra AI calls
+vi.mock("@/managers/forkedAgentManager", () => ({
+  ForkedAgentManager: vi.fn().mockImplementation(function () {
+    return {
+      forkAndExecute: vi.fn().mockResolvedValue("mock-fork-id"),
+      cleanup: vi.fn(),
+    };
+  }),
+}));
+
 describe("Hook Success Behavior (User Story 1)", () => {
   let agent: Agent;
   const mockCallbacks = {

--- a/packages/agent-sdk/tests/core/plugin.test.ts
+++ b/packages/agent-sdk/tests/core/plugin.test.ts
@@ -192,10 +192,14 @@ describe("PluginCore", () => {
     await pluginCore.addMarketplace("source");
     expect(mockMarketplaceService.addMarketplace).toHaveBeenCalledWith(
       "source",
+      "user",
     );
 
     await pluginCore.removeMarketplace("m1");
-    expect(mockMarketplaceService.removeMarketplace).toHaveBeenCalledWith("m1");
+    expect(mockMarketplaceService.removeMarketplace).toHaveBeenCalledWith(
+      "m1",
+      undefined,
+    );
 
     await pluginCore.updateMarketplace("m1");
     expect(mockMarketplaceService.updateMarketplace).toHaveBeenCalledWith("m1");

--- a/packages/agent-sdk/tests/services/MarketplaceService.git.test.ts
+++ b/packages/agent-sdk/tests/services/MarketplaceService.git.test.ts
@@ -7,6 +7,28 @@ import { GitService } from "../../src/services/GitService.js";
 
 vi.mock("../../src/services/GitService.js");
 
+vi.mock("../../src/services/configurationService.js", () => {
+  return {
+    ConfigurationService: class MockConfigService {
+      getMergedMarketplaces() {
+        return {};
+      }
+      getScopedMarketplaces() {
+        return {};
+      }
+      addMarketplaceToScope() {
+        return Promise.resolve();
+      }
+      removeMarketplaceFromScope() {
+        return Promise.resolve();
+      }
+      getMergedEnabledPlugins() {
+        return {};
+      }
+    },
+  };
+});
+
 vi.mock("fs", async () => {
   return {
     existsSync: vi.fn(),

--- a/packages/agent-sdk/tests/services/MarketplaceService.test.ts
+++ b/packages/agent-sdk/tests/services/MarketplaceService.test.ts
@@ -6,6 +6,7 @@ const fs = fsModule.promises;
 const { existsSync } = fsModule;
 import * as path from "path";
 import { getPluginsDir } from "../../src/utils/configPaths.js";
+import type { ConfigurationService } from "../../src/services/configurationService.js";
 
 vi.mock("fs", async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
@@ -33,6 +34,7 @@ vi.mock("fs", async (importOriginal) => {
       unlink: vi.fn(
         promises.unlink as (...args: unknown[]) => Promise<unknown>,
       ),
+      cp: vi.fn(promises.cp as (...args: unknown[]) => Promise<unknown>),
     },
   };
 });
@@ -44,21 +46,11 @@ vi.mock("../../src/utils/configPaths.js", () => ({
 vi.mock("../../src/services/configurationService.js", () => {
   return {
     ConfigurationService: class MockConfigService {
-      getMergedMarketplaces() {
-        return {};
-      }
-      getScopedMarketplaces() {
-        return {};
-      }
-      addMarketplaceToScope() {
-        return Promise.resolve();
-      }
-      removeMarketplaceFromScope() {
-        return Promise.resolve();
-      }
-      getMergedEnabledPlugins() {
-        return {};
-      }
+      getMergedMarketplaces = vi.fn(() => ({}));
+      getScopedMarketplaces = vi.fn(() => ({}));
+      addMarketplaceToScope = vi.fn(() => Promise.resolve());
+      removeMarketplaceFromScope = vi.fn(() => Promise.resolve());
+      getMergedEnabledPlugins = vi.fn(() => ({}));
     },
   };
 });
@@ -287,5 +279,1171 @@ describe("MarketplaceService - Builtin Marketplace", () => {
       (m) => m.name === "custom-mkt",
     );
     expect(customMkt).toBeDefined();
+  });
+});
+
+describe("MarketplaceService - Scoped Marketplace", () => {
+  let service: MarketplaceService;
+  const mockPluginsDir = path.join(process.cwd(), "tmp-test-plugins-scoped");
+
+  beforeEach(async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(getPluginsDir).mockReturnValue(mockPluginsDir);
+    if (existsSync(mockPluginsDir)) {
+      await fs.rm(mockPluginsDir, { recursive: true, force: true });
+    }
+    service = new MarketplaceService();
+    (
+      MarketplaceService as unknown as { isLockedInProcess: boolean }
+    ).isLockedInProcess = false;
+
+    vi.spyOn(
+      service["gitService"] as unknown as {
+        isGitAvailable: () => Promise<boolean>;
+      },
+      "isGitAvailable",
+    ).mockResolvedValue(true);
+    vi.spyOn(
+      service["gitService"] as unknown as { clone: () => Promise<void> },
+      "clone",
+    ).mockResolvedValue();
+    vi.spyOn(
+      service["gitService"] as unknown as { pull: () => Promise<void> },
+      "pull",
+    ).mockResolvedValue();
+
+    vi.mocked(fs.open).mockResolvedValue({
+      close: vi.fn(),
+    } as unknown as Awaited<ReturnType<typeof fs.open>>);
+    vi.mocked(fs.unlink).mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (existsSync(mockPluginsDir)) {
+      await fs.rm(mockPluginsDir, { recursive: true, force: true });
+    }
+  });
+
+  it("should list marketplaces from scoped settings", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({
+      "my-marketplace": {
+        source: { source: "github", repo: "user/repo" },
+        autoUpdate: true,
+      },
+    });
+
+    const marketplaces = await service.listMarketplaces();
+    expect(marketplaces).toHaveLength(2); // builtin + custom
+    expect(marketplaces[0].name).toBe("wave-plugins-official");
+    expect(marketplaces[1].name).toBe("my-marketplace");
+  });
+
+  it("should list marketplaces combining scoped settings with cache fallback", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({
+      "scoped-mkt": {
+        source: { source: "directory", path: "/scoped/path" },
+        autoUpdate: false,
+      },
+    });
+
+    const knownPath = path.join(mockPluginsDir, "known_marketplaces.json");
+    await fs.writeFile(
+      knownPath,
+      JSON.stringify({
+        marketplaces: [
+          {
+            name: "cached-mkt",
+            source: { source: "directory", path: "/cached/path" },
+            autoUpdate: false,
+          },
+          {
+            name: "scoped-mkt", // already in settings, should not duplicate
+            source: { source: "directory", path: "/old/path" },
+          },
+          {
+            name: "wave-plugins-official", // builtin in cache, should skip
+            source: {
+              source: "github",
+              repo: "netease-lcap/wave-plugins-official",
+            },
+          },
+        ],
+      }),
+    );
+
+    const marketplaces = await service.listMarketplaces();
+    // builtin + scoped-mkt(from settings) + cached-mkt(from cache fallback)
+    expect(marketplaces).toHaveLength(3);
+    expect(marketplaces.some((m) => m.name === "cached-mkt")).toBe(true);
+  });
+
+  it("should return declaring scope for a marketplace", () => {
+    vi.spyOn(service["configurationService"], "getScopedMarketplaces")
+      .mockReturnValueOnce({})
+      .mockReturnValueOnce({})
+      .mockReturnValueOnce({
+        "test-mkt": {
+          source: { source: "directory", path: "/test" },
+          autoUpdate: false,
+        },
+      });
+
+    const scope = service.getMarketplaceDeclaringSource("test-mkt");
+    expect(scope).toBe("user");
+  });
+
+  it("should return builtin for builtin marketplace", () => {
+    const scope = service.getMarketplaceDeclaringSource(
+      "wave-plugins-official",
+    );
+    expect(scope).toBe("builtin");
+  });
+
+  it("should return null for unknown marketplace", () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getScopedMarketplaces",
+    ).mockReturnValue({});
+
+    const scope = service.getMarketplaceDeclaringSource("unknown-mkt");
+    expect(scope).toBeNull();
+  });
+
+  it("should remove marketplace from correct scope", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getScopedMarketplaces",
+    ).mockReturnValue({
+      "test-mkt": {
+        source: { source: "directory", path: "/test" },
+        autoUpdate: false,
+      },
+    });
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({});
+
+    await service.removeMarketplace("test-mkt", "user");
+    expect(
+      vi.mocked(
+        (service["configurationService"] as ConfigurationService)
+          .removeMarketplaceFromScope,
+      ),
+    ).toHaveBeenCalled();
+  });
+
+  it("should throw when trying to remove builtin marketplace", async () => {
+    await expect(
+      service.removeMarketplace("wave-plugins-official"),
+    ).rejects.toThrow("Cannot remove built-in marketplace");
+  });
+
+  it("should remove marketplace with inferred scope", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getScopedMarketplaces",
+    ).mockReturnValue({
+      "test-mkt": {
+        source: { source: "directory", path: "/test" },
+        autoUpdate: false,
+      },
+    });
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({});
+
+    await service.removeMarketplace("test-mkt");
+    expect(
+      vi.mocked(
+        (service["configurationService"] as ConfigurationService)
+          .removeMarketplaceFromScope,
+      ),
+    ).toHaveBeenCalled();
+  });
+
+  it("should add marketplace with project scope", async () => {
+    vi.spyOn(
+      service,
+      "loadMarketplaceManifest" as keyof MarketplaceService,
+    ).mockResolvedValue({
+      name: "project-mkt",
+      owner: { name: "test" },
+      plugins: [],
+    });
+
+    const added = await service.addMarketplace("/some/path", "project");
+    expect(added.name).toBe("project-mkt");
+  });
+
+  it("should add marketplace with local scope", async () => {
+    vi.spyOn(
+      service,
+      "loadMarketplaceManifest" as keyof MarketplaceService,
+    ).mockResolvedValue({
+      name: "local-mkt",
+      owner: { name: "test" },
+      plugins: [],
+    });
+
+    const added = await service.addMarketplace("/local/path", "local");
+    expect(added.name).toBe("local-mkt");
+  });
+
+  it("should skip builtin marketplace in scoped iteration", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({
+      "wave-plugins-official": {
+        source: {
+          source: "github",
+          repo: "netease-lcap/wave-plugins-official",
+        },
+        autoUpdate: true,
+      },
+    });
+
+    const marketplaces = await service.listMarketplaces();
+    // Should only have one builtin entry
+    const builtinCount = marketplaces.filter((m) => m.isBuiltin).length;
+    expect(builtinCount).toBe(1);
+  });
+
+  it("should toggle auto-update for a marketplace", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getScopedMarketplaces",
+    ).mockReturnValue({
+      "test-mkt": {
+        source: { source: "directory", path: "/test" },
+        autoUpdate: false,
+      },
+    });
+
+    await service.toggleAutoUpdate("test-mkt", true);
+    expect(
+      vi.mocked(
+        (service["configurationService"] as ConfigurationService)
+          .addMarketplaceToScope,
+      ),
+    ).toHaveBeenCalled();
+  });
+
+  it("should throw when toggling auto-update for builtin", async () => {
+    await expect(
+      service.toggleAutoUpdate("wave-plugins-official", true),
+    ).rejects.toThrow("Marketplace wave-plugins-official not found");
+  });
+
+  it("should throw when toggling auto-update for unknown marketplace", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getScopedMarketplaces",
+    ).mockReturnValue({});
+
+    await expect(service.toggleAutoUpdate("unknown-mkt", true)).rejects.toThrow(
+      "Marketplace unknown-mkt not found",
+    );
+  });
+
+  it("should auto-update marketplaces with autoUpdate enabled", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({
+      "auto-mkt": {
+        source: { source: "directory", path: "/auto" },
+        autoUpdate: true,
+      },
+      "no-auto-mkt": {
+        source: { source: "directory", path: "/noauto" },
+        autoUpdate: false,
+      },
+    });
+
+    vi.spyOn(service, "loadMarketplaceManifest").mockResolvedValue({
+      name: "auto-mkt",
+      owner: { name: "test" },
+      plugins: [],
+    });
+
+    await service.autoUpdateAll();
+    // Should have attempted to update auto-mkt
+    expect(vi.mocked(fs.writeFile).mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it("should throw when updating nonexistent marketplace", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({});
+
+    await expect(service.updateMarketplace("nonexistent")).rejects.toThrow(
+      "Marketplace nonexistent not found",
+    );
+  });
+
+  it("should update all marketplaces when no name specified", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({
+      "test-mkt": {
+        source: { source: "directory", path: "/test" },
+        autoUpdate: false,
+      },
+    });
+
+    vi.spyOn(service, "loadMarketplaceManifest").mockResolvedValue({
+      name: "test-mkt",
+      owner: { name: "test" },
+      plugins: [],
+    });
+
+    await service.updateMarketplace();
+    expect(vi.mocked(fs.writeFile).mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it("should get known marketplaces with declaredScope for entries", async () => {
+    const knownPath = path.join(mockPluginsDir, "known_marketplaces.json");
+    await fs.writeFile(
+      knownPath,
+      JSON.stringify({
+        marketplaces: [
+          {
+            name: "custom-mkt",
+            source: { source: "directory", path: "/custom" },
+          },
+        ],
+      }),
+    );
+
+    const registry = await service.getKnownMarketplaces();
+    expect(registry.marketplaces[0].declaredScope).toBe("user");
+  });
+});
+
+describe("MarketplaceService - Coverage Targets", () => {
+  let service: MarketplaceService;
+  const mockPluginsDir = path.join(process.cwd(), "tmp-test-plugins-coverage");
+
+  beforeEach(async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(getPluginsDir).mockReturnValue(mockPluginsDir);
+    if (existsSync(mockPluginsDir)) {
+      await fs.rm(mockPluginsDir, { recursive: true, force: true });
+    }
+    service = new MarketplaceService();
+    (
+      MarketplaceService as unknown as { isLockedInProcess: boolean }
+    ).isLockedInProcess = false;
+
+    vi.spyOn(
+      service["gitService"] as unknown as {
+        isGitAvailable: () => Promise<boolean>;
+      },
+      "isGitAvailable",
+    ).mockResolvedValue(true);
+    vi.spyOn(
+      service["gitService"] as unknown as { clone: () => Promise<void> },
+      "clone",
+    ).mockResolvedValue();
+    vi.spyOn(
+      service["gitService"] as unknown as { pull: () => Promise<void> },
+      "pull",
+    ).mockResolvedValue();
+
+    vi.mocked(fs.open).mockResolvedValue({
+      close: vi.fn(),
+    } as unknown as Awaited<ReturnType<typeof fs.open>>);
+    vi.mocked(fs.unlink).mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (existsSync(mockPluginsDir)) {
+      await fs.rm(mockPluginsDir, { recursive: true, force: true });
+    }
+  });
+
+  // Line 105: migration skip for builtin marketplace
+  it("should skip builtin marketplace during migration", async () => {
+    // Mock fs.readFile for known_marketplaces
+    vi.spyOn(service, "getCacheRegistry").mockResolvedValue({
+      marketplaces: [
+        {
+          name: "wave-plugins-official",
+          source: {
+            source: "github",
+            repo: "netease-lcap/wave-plugins-official",
+          },
+        },
+        { name: "old-mkt", source: { source: "directory", path: "/old" } },
+      ],
+    });
+
+    // Mock scoped settings as empty so migration triggers
+    const addScopeMock = vi
+      .spyOn(service["configurationService"], "addMarketplaceToScope")
+      .mockClear();
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({});
+    vi.spyOn(
+      service["configurationService"],
+      "getScopedMarketplaces",
+    ).mockReturnValue({});
+
+    // Call runMigration manually to test the branch
+    await (
+      service as unknown as { runMigration: () => Promise<void> }
+    ).runMigration();
+
+    // Migration should have called addMarketplaceToScope for old-mkt but NOT builtin
+    const addCalls = addScopeMock.mock.calls;
+    const oldMktCalls = addCalls.filter((c) => c[2] === "old-mkt");
+    const builtinCalls = addCalls.filter(
+      (c) => c[2] === "wave-plugins-official",
+    );
+    expect(oldMktCalls).toHaveLength(1);
+    expect(builtinCalls).toHaveLength(0);
+  });
+
+  // Line 268: updateCacheMarketplace default source fallback
+  // This is triggered when updateCacheMarketplace adds a new entry without a source
+  // e.g., updateMarketplace calling updateCacheMarketplace with only lastUpdated
+  // for a marketplace not yet in the cache
+  it("should use default source fallback when updating cache for unknown marketplace", async () => {
+    // Ensure no cache file exists
+    const knownPath = path.join(mockPluginsDir, "known_marketplaces.json");
+    if (fsModule.existsSync(knownPath)) {
+      await fs.rm(knownPath, { force: true });
+    }
+
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({
+      "unknown-cache-mkt": {
+        source: { source: "directory", path: "/unknown" },
+        autoUpdate: false,
+      },
+    });
+    vi.spyOn(
+      service["configurationService"],
+      "getScopedMarketplaces",
+    ).mockReturnValue({});
+
+    vi.spyOn(service, "loadMarketplaceManifest").mockResolvedValue({
+      name: "unknown-cache-mkt",
+      owner: { name: "test" },
+      plugins: [],
+    });
+
+    // Clear any previous writeFile mock calls
+    vi.mocked(fs.writeFile).mockClear();
+
+    // Marketplace is not in the cache (no known_marketplaces.json)
+    await service.updateMarketplace("unknown-cache-mkt");
+
+    // Verify writeFile was called for cache update
+    const writeCalls = vi.mocked(fs.writeFile).mock.calls;
+    const cacheWriteCall = writeCalls.find((c) =>
+      String(c[0]).includes("known_marketplaces.json.tmp"),
+    );
+    expect(cacheWriteCall).toBeDefined();
+    const cached = JSON.parse(String(cacheWriteCall![1]));
+    // Since updateCacheMarketplace was called with only { lastUpdated },
+    // it should use the default source fallback
+    expect(cached.marketplaces[0].source).toEqual({
+      source: "directory",
+      path: "",
+    });
+  });
+
+  // Line 301: getInstalledPlugins empty content handling
+  it("should return empty plugins when file has only whitespace", async () => {
+    const installedPath = path.join(mockPluginsDir, "installed_plugins.json");
+    await fs.writeFile(installedPath, "   \n\t  ");
+
+    const registry = await service.getInstalledPlugins();
+    expect(registry.plugins).toHaveLength(0);
+  });
+
+  // Line 333: loadMarketplaceManifest not found
+  it("should throw when manifest file does not exist", async () => {
+    await expect(
+      service.loadMarketplaceManifest("/nonexistent/path"),
+    ).rejects.toThrow("Marketplace manifest not found");
+  });
+
+  // Line 339: loadMarketplaceManifest invalid manifest
+  it("should throw when manifest is missing required fields", async () => {
+    const tempDir = path.join(mockPluginsDir, "bad-manifest");
+    const manifestDir = path.join(tempDir, ".wave-plugin");
+    await fs.mkdir(manifestDir, { recursive: true });
+    await fs.writeFile(
+      path.join(manifestDir, "marketplace.json"),
+      JSON.stringify({ bad: "manifest" }),
+    );
+
+    await expect(service.loadMarketplaceManifest(tempDir)).rejects.toThrow(
+      "Invalid marketplace manifest",
+    );
+  });
+
+  // Line 376: buildMarketplaceEntry autoUpdate fallback
+  it("should fall back to cache autoUpdate when config has none", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({
+      "fallback-auto-mkt": {
+        source: { source: "directory", path: "/fallback" },
+        // no autoUpdate set
+      },
+    });
+
+    // Use getCacheRegistry mock instead of readFile
+    vi.spyOn(service, "getCacheRegistry").mockResolvedValue({
+      marketplaces: [
+        {
+          name: "fallback-auto-mkt",
+          source: { source: "directory", path: "/fallback" },
+          autoUpdate: true,
+        },
+      ],
+    });
+
+    const marketplaces = await service.listMarketplaces();
+    const entry = marketplaces.find((m) => m.name === "fallback-auto-mkt");
+    expect(entry?.autoUpdate).toBe(true);
+  });
+
+  // Line 435: addMarketplace existsSync check for target path (exists already)
+  it("should skip clone when target path already exists", async () => {
+    vi.spyOn(service, "loadMarketplaceManifest").mockResolvedValue({
+      name: "existing-mkt",
+      owner: { name: "test" },
+      plugins: [],
+    });
+
+    // Create the target directory so existsSync returns true
+    const targetPath = path.join(
+      mockPluginsDir,
+      "marketplaces",
+      "user",
+      "repo",
+    );
+    await fs.mkdir(targetPath, { recursive: true });
+
+    await service.addMarketplace("user/repo");
+
+    // Clone should not be called since path exists
+    expect(
+      vi.mocked(
+        service["gitService"] as unknown as { clone: () => Promise<void> },
+      ).clone,
+    ).not.toHaveBeenCalled();
+  });
+
+  // Line 440, 450, 469: error message cond-expr (non-Error thrown)
+  it("should handle non-Error thrown during git clone in addMarketplace", async () => {
+    vi.spyOn(
+      service["gitService"] as unknown as { clone: () => Promise<void> },
+      "clone",
+    ).mockRejectedValue("string error");
+
+    await expect(
+      service.addMarketplace("https://github.com/user/repo"),
+    ).rejects.toThrow("Failed to add marketplace from Git: string error");
+  });
+
+  it("should handle non-Error thrown during manifest load in addMarketplace (git)", async () => {
+    vi.spyOn(
+      service["gitService"] as unknown as { clone: () => Promise<void> },
+      "clone",
+    ).mockResolvedValue();
+    vi.spyOn(
+      service,
+      "loadMarketplaceManifest" as keyof MarketplaceService,
+    ).mockRejectedValue("manifest error");
+
+    await expect(
+      service.addMarketplace("https://github.com/user/repo"),
+    ).rejects.toThrow(
+      "Failed to load manifest from cloned repository: manifest error",
+    );
+  });
+
+  it("should handle non-Error thrown during manifest load in addMarketplace (directory)", async () => {
+    vi.spyOn(
+      service,
+      "loadMarketplaceManifest" as keyof MarketplaceService,
+    ).mockRejectedValue("dir manifest error");
+
+    await expect(service.addMarketplace("/some/directory")).rejects.toThrow(
+      "Failed to load manifest from directory: dir manifest error",
+    );
+  });
+
+  // Line 540-541: listMarketplaces cache fallback skip conditions
+  it("should skip builtin marketplace in cache fallback iteration", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({});
+
+    vi.spyOn(service, "getCacheRegistry").mockResolvedValue({
+      marketplaces: [
+        {
+          name: "wave-plugins-official",
+          source: {
+            source: "github",
+            repo: "netease-lcap/wave-plugins-official",
+          },
+        },
+        {
+          name: "cached-only",
+          source: { source: "directory", path: "/cached" },
+        },
+      ],
+    });
+
+    const marketplaces = await service.listMarketplaces();
+    const builtinEntries = marketplaces.filter(
+      (m) => m.name === "wave-plugins-official",
+    );
+    expect(builtinEntries).toHaveLength(1);
+    expect(builtinEntries[0].declaredScope).toBe("builtin");
+    expect(marketplaces.some((m) => m.name === "cached-only")).toBe(true);
+  });
+
+  it("should skip cache entries that are already in scoped settings", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({
+      "already-scoped": {
+        source: { source: "directory", path: "/scoped" },
+        autoUpdate: true,
+      },
+    });
+
+    const knownPath = path.join(mockPluginsDir, "known_marketplaces.json");
+    await fs.writeFile(
+      knownPath,
+      JSON.stringify({
+        marketplaces: [
+          {
+            name: "already-scoped",
+            source: { source: "directory", path: "/old-path" },
+            autoUpdate: false,
+          },
+        ],
+      }),
+    );
+
+    const marketplaces = await service.listMarketplaces();
+    const scopedEntries = marketplaces.filter(
+      (m) => m.name === "already-scoped",
+    );
+    expect(scopedEntries).toHaveLength(1);
+    expect(scopedEntries[0].autoUpdate).toBe(true); // from settings, not cache
+  });
+
+  // Line 558: removeMarketplace scope inference fallback
+  it("should fallback to user scope when marketplace not found in any scope", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getScopedMarketplaces",
+    ).mockReturnValue({});
+
+    await service.removeMarketplace("unknown-mkt");
+    expect(
+      vi.mocked(
+        (service["configurationService"] as ConfigurationService)
+          .removeMarketplaceFromScope,
+      ).mock.calls[0][1],
+    ).toBe("user");
+  });
+
+  // Line 584: updateMarketplace filtering by name
+  it("should update only the specified marketplace by name", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({
+      "mkt-one": {
+        source: { source: "directory", path: "/one" },
+        autoUpdate: false,
+      },
+      "mkt-two": {
+        source: { source: "directory", path: "/two" },
+        autoUpdate: false,
+      },
+    });
+
+    vi.spyOn(service, "loadMarketplaceManifest").mockResolvedValue({
+      name: "mkt-one",
+      owner: { name: "test" },
+      plugins: [],
+    });
+
+    await service.updateMarketplace("mkt-one");
+
+    // Only mkt-one should have been loaded
+    expect(
+      vi.mocked(
+        service["loadMarketplaceManifest"] as unknown as ReturnType<
+          typeof vi.fn
+        >,
+      ).mock.calls.length,
+    ).toBe(1);
+  });
+
+  // Line 588: updateMarketplace not found
+  it("should throw when named marketplace is not found", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({});
+
+    await expect(service.updateMarketplace("nonexistent")).rejects.toThrow(
+      "Marketplace nonexistent not found",
+    );
+  });
+
+  // Line 600: skip update when git not available
+  it("should skip git marketplace update when git is not available", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({
+      "git-mkt": {
+        source: { source: "github", repo: "user/repo" },
+        autoUpdate: false,
+      },
+    });
+
+    vi.spyOn(
+      service["gitService"] as unknown as {
+        isGitAvailable: () => Promise<boolean>;
+      },
+      "isGitAvailable",
+    ).mockResolvedValue(false);
+
+    vi.spyOn(service, "loadMarketplaceManifest").mockResolvedValue({
+      name: "git-mkt",
+      owner: { name: "test" },
+      plugins: [],
+    });
+
+    await service.updateMarketplace("git-mkt");
+
+    // pull and clone should not be called
+    expect(
+      vi.mocked(
+        service["gitService"] as unknown as { pull: () => Promise<void> },
+      ).pull,
+    ).not.toHaveBeenCalled();
+    expect(
+      vi.mocked(
+        service["gitService"] as unknown as { clone: () => Promise<void> },
+      ).clone,
+    ).not.toHaveBeenCalled();
+  });
+
+  // Line 607-621: clone if target doesn't exist
+  it("should clone marketplace if target path does not exist during update", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({
+      "git-mkt": {
+        source: { source: "github", repo: "user/repo" },
+        autoUpdate: false,
+      },
+    });
+
+    vi.spyOn(service, "loadMarketplaceManifest").mockResolvedValue({
+      name: "git-mkt",
+      owner: { name: "test" },
+      plugins: [],
+    });
+
+    // Ensure the marketplace path does NOT exist
+    const targetPath = path.join(
+      mockPluginsDir,
+      "marketplaces",
+      "user",
+      "repo",
+    );
+    // Make sure it doesn't exist (clean up if needed)
+    if (fsModule.existsSync(targetPath)) {
+      await fs.rm(targetPath, { recursive: true, force: true });
+    }
+
+    await service.updateMarketplace("git-mkt");
+
+    expect(
+      vi.mocked(
+        service["gitService"] as unknown as { clone: () => Promise<void> },
+      ).clone,
+    ).toHaveBeenCalled();
+  });
+
+  // Line 634: updatePlugins option branch
+  it("should update plugins when updatePlugins option is true", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({
+      "plugin-mkt": {
+        source: { source: "directory", path: "/pmkt" },
+        autoUpdate: false,
+      },
+    });
+
+    vi.spyOn(service, "loadMarketplaceManifest").mockResolvedValue({
+      name: "plugin-mkt",
+      owner: { name: "test" },
+      plugins: [
+        { name: "my-plugin", source: "./plugins/my-plugin", description: "" },
+      ],
+    });
+
+    // Mock getInstalledPlugins to return an installed plugin
+    vi.spyOn(service, "getInstalledPlugins").mockResolvedValue({
+      plugins: [
+        {
+          name: "my-plugin",
+          marketplace: "plugin-mkt",
+          version: "1.0.0",
+          cachePath: "/cache/my-plugin",
+          projectPath: "/project",
+        },
+      ],
+    });
+
+    // Mock installPlugin
+    vi.spyOn(service, "installPlugin").mockResolvedValue({
+      name: "my-plugin",
+      marketplace: "plugin-mkt",
+      version: "1.0.0",
+      cachePath: "/cache/my-plugin",
+      projectPath: "/project",
+    });
+
+    await service.updateMarketplace("plugin-mkt", { updatePlugins: true });
+
+    expect(vi.mocked(service.installPlugin)).toHaveBeenCalled();
+  });
+
+  // Line 643: plugin no longer found in marketplace
+  it("should uninstall orphaned plugin when no longer in marketplace", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({
+      "orphan-mkt": {
+        source: { source: "directory", path: "/orphan" },
+        autoUpdate: false,
+      },
+    });
+
+    // Manifest has no plugins
+    vi.spyOn(service, "loadMarketplaceManifest").mockResolvedValue({
+      name: "orphan-mkt",
+      owner: { name: "test" },
+      plugins: [],
+    });
+
+    // Mock getInstalledPlugins to return an orphaned plugin
+    vi.spyOn(service, "getInstalledPlugins").mockResolvedValue({
+      plugins: [
+        {
+          name: "orphaned-plugin",
+          marketplace: "orphan-mkt",
+          version: "1.0.0",
+          cachePath: "/cache/orphaned-plugin",
+          projectPath: "/project",
+        },
+      ],
+    });
+
+    vi.spyOn(service, "uninstallPlugin").mockResolvedValue(undefined);
+
+    await service.updateMarketplace("orphan-mkt", { updatePlugins: true });
+
+    expect(vi.mocked(service.uninstallPlugin)).toHaveBeenCalled();
+  });
+
+  // Line 674: error message cond-expr in updateMarketplace
+  it("should handle non-Error during updateMarketplace", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({
+      "error-mkt": {
+        source: { source: "directory", path: "/error" },
+        autoUpdate: false,
+      },
+    });
+
+    vi.spyOn(service, "loadMarketplaceManifest").mockRejectedValue(
+      "load error",
+    );
+
+    await expect(service.updateMarketplace("error-mkt")).rejects.toThrow(
+      'Some marketplaces failed to update:\nFailed to update marketplace "error-mkt": load error',
+    );
+  });
+
+  // Line 680: errors array throw
+  it("should throw when multiple marketplaces fail to update", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({
+      "fail-one": {
+        source: { source: "directory", path: "/fail1" },
+        autoUpdate: false,
+      },
+      "fail-two": {
+        source: { source: "directory", path: "/fail2" },
+        autoUpdate: false,
+      },
+    });
+
+    vi.spyOn(service, "loadMarketplaceManifest").mockRejectedValue(
+      new Error("boom"),
+    );
+
+    await expect(service.updateMarketplace()).rejects.toThrow(
+      "Some marketplaces failed to update",
+    );
+  });
+
+  // Line 720, 729: toggleAutoUpdate not found branches
+  it("should throw when declaringSource is null for toggleAutoUpdate", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getScopedMarketplaces",
+    ).mockReturnValue({});
+
+    await expect(service.toggleAutoUpdate("nonexistent", true)).rejects.toThrow(
+      "Marketplace nonexistent not found",
+    );
+  });
+
+  it("should throw when config is missing for toggleAutoUpdate", async () => {
+    // This tests the case where declaringSource exists but config[name] doesn't
+    // Override getMarketplaceDeclaringSource to return "user"
+    vi.spyOn(service, "getMarketplaceDeclaringSource").mockReturnValue("user");
+    // But user scope doesn't have the marketplace
+    vi.spyOn(
+      service["configurationService"],
+      "getScopedMarketplaces",
+    ).mockReturnValue({});
+
+    await expect(service.toggleAutoUpdate("ghost-mkt", true)).rejects.toThrow(
+      "Marketplace ghost-mkt not found",
+    );
+  });
+
+  // Line 755: installPlugin invalid format (no marketplace)
+  it("should throw when installPlugin has no marketplace", async () => {
+    await expect(service.installPlugin("plugin-only")).rejects.toThrow(
+      "Invalid plugin format",
+    );
+  });
+
+  it("should throw when installPlugin has no plugin name", async () => {
+    await expect(service.installPlugin("@marketplace")).rejects.toThrow(
+      "Invalid plugin format",
+    );
+  });
+
+  // Line 761: installPlugin marketplace not found
+  it("should throw when marketplace is not found for installPlugin", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({});
+
+    await expect(
+      service.installPlugin("some-plugin@nonexistent-market"),
+    ).rejects.toThrow("Marketplace nonexistent-market not found");
+  });
+
+  // Line 768: installPlugin plugin not found in manifest
+  it("should throw when plugin is not found in marketplace manifest", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({
+      "test-mkt": {
+        source: { source: "directory", path: "/test" },
+        autoUpdate: false,
+      },
+    });
+
+    vi.spyOn(service, "loadMarketplaceManifest").mockResolvedValue({
+      name: "test-mkt",
+      owner: { name: "test" },
+      plugins: [], // no plugins
+    });
+
+    await expect(
+      service.installPlugin("nonexistent-plugin@test-mkt"),
+    ).rejects.toThrow(
+      "Plugin nonexistent-plugin not found in marketplace test-mkt",
+    );
+  });
+
+  // Line 831: installPlugin cache exists and rm
+  it("should remove existing cache when installing same version again", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({
+      "cache-mkt": {
+        source: { source: "directory", path: mockPluginsDir },
+        autoUpdate: false,
+      },
+    });
+
+    // Plugin manifest in the mock plugins dir
+    const pluginDir = path.join(mockPluginsDir, ".wave-plugin");
+    await fs.mkdir(pluginDir, { recursive: true });
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({ name: "cache-plugin", version: "1.0.0" }),
+    );
+
+    vi.spyOn(service, "loadMarketplaceManifest").mockResolvedValue({
+      name: "cache-mkt",
+      owner: { name: "test" },
+      plugins: [{ name: "cache-plugin", source: ".", description: "" }],
+    });
+
+    // Pre-existing cache
+    const existingCache = path.join(
+      mockPluginsDir,
+      "cache",
+      "cache-mkt",
+      "cache-plugin",
+      "1.0.0",
+    );
+    await fs.mkdir(existingCache, { recursive: true });
+    await fs.writeFile(path.join(existingCache, "dummy.txt"), "old content");
+
+    // Mock installed plugins file
+    const installedPath = path.join(mockPluginsDir, "installed_plugins.json");
+    await fs.writeFile(installedPath, JSON.stringify({ plugins: [] }));
+
+    // Mock fs.cp and fs.rename
+    vi.mocked(fs.cp).mockResolvedValue(
+      undefined as unknown as Awaited<ReturnType<typeof fs.cp>>,
+    );
+    vi.mocked(fs.rename).mockResolvedValue(
+      undefined as unknown as Awaited<ReturnType<typeof fs.rename>>,
+    );
+
+    await service.installPlugin("cache-plugin@cache-mkt");
+
+    // rm should have been called to remove the old cache
+    const rmCalls = vi.mocked(fs.rm).mock.calls;
+    const cacheRmCall = rmCalls.find(
+      (c) => typeof c[0] === "string" && c[0].includes("1.0.0"),
+    );
+    expect(cacheRmCall).toBeDefined();
+  });
+
+  // Line 853: installPlugin existing plugin update vs new push
+  it("should update existing plugin entry when reinstalling", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({
+      "update-mkt": {
+        source: { source: "directory", path: mockPluginsDir },
+        autoUpdate: false,
+      },
+    });
+
+    // Plugin manifest in the mock plugins dir
+    const pluginDir = path.join(mockPluginsDir, ".wave-plugin");
+    await fs.mkdir(pluginDir, { recursive: true });
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({ name: "update-plugin", version: "2.0.0" }),
+    );
+
+    vi.spyOn(service, "loadMarketplaceManifest").mockResolvedValue({
+      name: "update-mkt",
+      owner: { name: "test" },
+      plugins: [{ name: "update-plugin", source: ".", description: "" }],
+    });
+
+    // Mock getInstalledPlugins to return existing entry
+    vi.spyOn(service, "getInstalledPlugins").mockResolvedValue({
+      plugins: [
+        {
+          name: "update-plugin",
+          marketplace: "update-mkt",
+          version: "1.0.0",
+          cachePath: "/old/cache/path",
+          projectPath: "/project",
+        },
+      ],
+    });
+
+    // Mock existsSync to return true for the plugin manifest
+    vi.mocked(existsSync).mockImplementation((p: import("fs").PathLike) => {
+      const str = String(p);
+      if (str.includes(".wave-plugin/plugin.json")) return true;
+      if (str.startsWith(mockPluginsDir)) return true;
+      return false;
+    });
+
+    // Mock fs.cp and fs.rename
+    vi.mocked(fs.cp).mockResolvedValue(
+      undefined as unknown as Awaited<ReturnType<typeof fs.cp>>,
+    );
+    vi.mocked(fs.rename).mockResolvedValue(
+      undefined as unknown as Awaited<ReturnType<typeof fs.rename>>,
+    );
+
+    const result = await service.installPlugin(
+      "update-plugin@update-mkt",
+      "/project",
+    );
+
+    // Should have saved installed plugins - the entry should be updated not pushed
+    const saveCalls = vi.mocked(fs.writeFile).mock.calls;
+    const installedSaveCalls = saveCalls.filter((c) =>
+      String(c[0]).includes("installed_plugins.json"),
+    );
+    const installedSaveCall = installedSaveCalls[installedSaveCalls.length - 1];
+    expect(installedSaveCall).toBeDefined();
+    const saved = JSON.parse(String(installedSaveCall[1]));
+    // Should still be 1 entry (updated), not 2 (pushed)
+    expect(saved.plugins).toHaveLength(1);
+    expect(saved.plugins[0].version).toBe("2.0.0");
+    expect(result.version).toBe("2.0.0");
   });
 });

--- a/packages/agent-sdk/tests/services/MarketplaceService.test.ts
+++ b/packages/agent-sdk/tests/services/MarketplaceService.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { MarketplaceService } from "../../src/services/MarketplaceService.js";
-import { KnownMarketplace } from "../../src/types/marketplace.js";
 import * as fsModule from "fs";
 const fs = fsModule.promises;
 const { existsSync } = fsModule;
@@ -41,6 +40,28 @@ vi.mock("fs", async (importOriginal) => {
 vi.mock("../../src/utils/configPaths.js", () => ({
   getPluginsDir: vi.fn(),
 }));
+
+vi.mock("../../src/services/configurationService.js", () => {
+  return {
+    ConfigurationService: class MockConfigService {
+      getMergedMarketplaces() {
+        return {};
+      }
+      getScopedMarketplaces() {
+        return {};
+      }
+      addMarketplaceToScope() {
+        return Promise.resolve();
+      }
+      removeMarketplaceFromScope() {
+        return Promise.resolve();
+      }
+      getMergedEnabledPlugins() {
+        return {};
+      }
+    },
+  };
+});
 
 describe("MarketplaceService - Builtin Marketplace", () => {
   let service: MarketplaceService;
@@ -118,266 +139,153 @@ describe("MarketplaceService - Builtin Marketplace", () => {
       name: "custom-mkt",
       owner: { name: "test" },
       plugins: [],
-    } as never);
+    });
 
-    await service.addMarketplace("./some-path");
+    const added = await service.addMarketplace("custom-mkt");
+    expect(added.name).toBe("custom-mkt");
 
-    const registry = await service.getKnownMarketplaces();
-    expect(registry.marketplaces).toHaveLength(2);
+    // listMarketplaces combines scoped settings + builtin
+    const marketplaces = await service.listMarketplaces();
+    expect(marketplaces.length).toBeGreaterThan(0);
     expect(
-      registry.marketplaces.find((m) => m.name === "wave-plugins-official"),
-    ).toBeDefined();
-    expect(
-      registry.marketplaces.find((m) => m.name === "custom-mkt"),
-    ).toBeDefined();
-  });
-
-  it("should allow removing the builtin marketplace", async () => {
-    // First, it's there by default
-    let registry = await service.getKnownMarketplaces();
-    expect(
-      registry.marketplaces.find((m) => m.name === "wave-plugins-official"),
-    ).toBeDefined();
-
-    // Remove it
-    await service.removeMarketplace("wave-plugins-official");
-
-    // Now it should be gone and config file should exist
-    registry = await service.getKnownMarketplaces();
-    expect(
-      registry.marketplaces.find((m) => m.name === "wave-plugins-official"),
-    ).toBeUndefined();
-    expect(
-      existsSync(path.join(mockPluginsDir, "known_marketplaces.json")),
+      marketplaces.some(
+        (m) => m.name === "wave-plugins-official" && m.isBuiltin,
+      ),
     ).toBe(true);
   });
 
-  describe("Auto-Update Support", () => {
-    it("should have autoUpdate: true for builtin marketplace", async () => {
-      const registry = await service.getKnownMarketplaces();
-      expect(registry.marketplaces[0].autoUpdate).toBe(true);
-    });
-
-    it("should have autoUpdate: false for newly added marketplaces", async () => {
-      vi.spyOn(
-        service,
-        "loadMarketplaceManifest" as keyof MarketplaceService,
-      ).mockResolvedValue({
-        name: "custom-mkt",
-        owner: { name: "test" },
-        plugins: [],
-      } as never);
-
-      await service.addMarketplace("./some-path");
-      const registry = await service.getKnownMarketplaces();
-      const custom = registry.marketplaces.find((m) => m.name === "custom-mkt");
-      expect(custom?.autoUpdate).toBe(false);
-    });
-
-    it("should toggle autoUpdate", async () => {
-      await service.toggleAutoUpdate("wave-plugins-official", false);
-      let registry = await service.getKnownMarketplaces();
-      expect(registry.marketplaces[0].autoUpdate).toBe(false);
-
-      await service.toggleAutoUpdate("wave-plugins-official", true);
-      registry = await service.getKnownMarketplaces();
-      expect(registry.marketplaces[0].autoUpdate).toBe(true);
-    });
-
-    it("should call updateMarketplace with updatePlugins: true in autoUpdateAll", async () => {
-      const updateSpy = vi
-        .spyOn(service, "updateMarketplace")
-        .mockResolvedValue();
-
-      // Builtin has autoUpdate: true by default
-      await service.autoUpdateAll();
-
-      expect(updateSpy).toHaveBeenCalledWith("wave-plugins-official", {
-        updatePlugins: true,
-      });
-    });
-
-    it("should update plugins when updatePlugins: true is passed to updateMarketplace", async () => {
-      // Mock getInstalledPlugins to return a plugin from the marketplace
-      vi.spyOn(service, "getInstalledPlugins").mockResolvedValue({
-        plugins: [
+  it("should not duplicate builtin marketplace if it already exists", async () => {
+    const knownMarketplacesPath = path.join(
+      mockPluginsDir,
+      "known_marketplaces.json",
+    );
+    await fs.writeFile(
+      knownMarketplacesPath,
+      JSON.stringify({
+        marketplaces: [
           {
-            name: "test-plugin",
-            marketplace: "wave-plugins-official",
-            version: "1.0.0",
-            cachePath: "/some/path",
+            name: "wave-plugins-official",
+            source: {
+              source: "github",
+              repo: "netease-lcap/wave-plugins-official",
+            },
+            isBuiltin: true,
+          },
+          {
+            name: "custom",
+            source: { source: "directory", path: "/some/path" },
           },
         ],
-      });
+      }),
+    );
 
-      const installSpy = vi
-        .spyOn(service, "installPlugin")
-        .mockResolvedValue({} as never);
-      vi.spyOn(
-        service,
-        "loadMarketplaceManifest" as keyof MarketplaceService,
-      ).mockResolvedValue({
-        name: "wave-plugins-official",
-        owner: { name: "test" },
-        plugins: [
-          { name: "test-plugin", source: "./test", description: "test" },
-        ],
-      } as never);
-
-      await service.updateMarketplace("wave-plugins-official", {
-        updatePlugins: true,
-      });
-
-      expect(installSpy).toHaveBeenCalledWith(
-        "test-plugin@wave-plugins-official",
-        undefined,
-      );
-    });
-
-    it("should uninstall orphaned plugins when updatePlugins: true is passed to updateMarketplace", async () => {
-      // Mock getInstalledPlugins to return a plugin from the marketplace
-      vi.spyOn(service, "getInstalledPlugins").mockResolvedValue({
-        plugins: [
-          {
-            name: "orphaned-plugin",
-            marketplace: "wave-plugins-official",
-            version: "1.0.0",
-            cachePath: "/some/path",
-          },
-        ],
-      });
-
-      const uninstallSpy = vi
-        .spyOn(service, "uninstallPlugin")
-        .mockResolvedValue();
-      vi.spyOn(
-        service,
-        "loadMarketplaceManifest" as keyof MarketplaceService,
-      ).mockResolvedValue({
-        name: "wave-plugins-official",
-        owner: { name: "test" },
-        plugins: [], // No plugins in manifest
-      } as never);
-
-      await service.updateMarketplace("wave-plugins-official", {
-        updatePlugins: true,
-      });
-
-      expect(uninstallSpy).toHaveBeenCalledWith(
-        "orphaned-plugin@wave-plugins-official",
-        undefined,
-      );
-    });
+    const registry = await service.getKnownMarketplaces();
+    const builtinCount = registry.marketplaces.filter(
+      (m) => m.name === "wave-plugins-official",
+    ).length;
+    expect(builtinCount).toBe(1);
   });
 
-  describe("Locking Mechanism", () => {
-    it("should support re-entrant locking within the same process", async () => {
-      vi.spyOn(
-        service,
-        "loadMarketplaceManifest" as keyof MarketplaceService,
-      ).mockResolvedValue({
-        name: "test",
-        plugins: [],
-      } as never);
+  it("should return correct marketplace path for github source", () => {
+    const marketplace = {
+      name: "test",
+      source: { source: "github" as const, repo: "user/repo" },
+    };
+    const result = service.getMarketplacePath(marketplace.source);
+    expect(result).toContain("marketplaces");
+    expect(result).toContain("user/repo");
+  });
 
-      // Mock getKnownMarketplaces to return the marketplace
-      vi.spyOn(service, "getKnownMarketplaces").mockResolvedValue({
-        marketplaces: [
-          {
-            name: "test",
-            source: { source: "directory", path: "/path" },
-            autoUpdate: false,
-          } as unknown as KnownMarketplace,
-        ],
-      });
+  it("should return correct marketplace path for directory source", () => {
+    const marketplace = {
+      name: "test",
+      source: { source: "directory" as const, path: "/some/path" },
+    };
+    const result = service.getMarketplacePath(marketplace.source);
+    expect(result).toBe("/some/path");
+  });
 
-      // Mock saveKnownMarketplaces to call another locked method
-      const saveSpy = vi.spyOn(service, "saveKnownMarketplaces");
-      saveSpy.mockImplementationOnce(async () => {
-        // This call should NOT trigger another fs.open because we're already locked
-        // We use mockImplementationOnce to avoid infinite recursion since toggleAutoUpdate calls saveKnownMarketplaces
-        await service.toggleAutoUpdate("test", true);
-      });
+  it("should return correct marketplace path for git source", () => {
+    const marketplace = {
+      name: "test",
+      source: { source: "git" as const, url: "https://example.com/repo" },
+    };
+    const result = service.getMarketplacePath(marketplace.source);
+    expect(result).toContain("marketplaces");
+  });
 
-      vi.mocked(fs.open).mockClear();
-      await service.addMarketplace("/some/path");
+  it("should handle known marketplaces file with only whitespace", async () => {
+    const knownMarketplacesPath = path.join(
+      mockPluginsDir,
+      "known_marketplaces.json",
+    );
+    await fs.writeFile(knownMarketplacesPath, "   \n\t  ");
 
-      // fs.open should only be called once for the outer lock
-      expect(fs.open).toHaveBeenCalledTimes(1);
+    const registry = await service.getKnownMarketplaces();
+    expect(registry.marketplaces).toHaveLength(1);
+    expect(registry.marketplaces[0].isBuiltin).toBe(true);
+  });
+
+  it("should handle known marketplaces file with empty array", async () => {
+    const knownMarketplacesPath = path.join(
+      mockPluginsDir,
+      "known_marketplaces.json",
+    );
+    await fs.writeFile(
+      knownMarketplacesPath,
+      JSON.stringify({ marketplaces: [] }),
+    );
+
+    const registry = await service.getKnownMarketplaces();
+    expect(registry.marketplaces).toHaveLength(0);
+  });
+
+  it("should throw error when git clone fails during addMarketplace", async () => {
+    vi.spyOn(
+      service["gitService"] as unknown as { clone: () => Promise<void> },
+      "clone",
+    ).mockRejectedValue(new Error("Clone failed"));
+
+    await expect(
+      service.addMarketplace("https://github.com/user/repo"),
+    ).rejects.toThrow("Failed to add marketplace from Git");
+  });
+
+  it("should throw error when manifest loading fails during addMarketplace", async () => {
+    vi.spyOn(
+      service["gitService"] as unknown as { clone: () => Promise<void> },
+      "clone",
+    ).mockResolvedValue();
+    vi.spyOn(
+      service,
+      "loadMarketplaceManifest" as keyof MarketplaceService,
+    ).mockRejectedValue(new Error("No manifest"));
+
+    await expect(
+      service.addMarketplace("https://github.com/user/repo"),
+    ).rejects.toThrow("Failed to load manifest from cloned repository");
+  });
+
+  it("should update existing marketplace with same name", async () => {
+    vi.spyOn(
+      service,
+      "loadMarketplaceManifest" as keyof MarketplaceService,
+    ).mockResolvedValue({
+      name: "custom-mkt",
+      owner: { name: "test" },
+      plugins: [],
     });
 
-    it("should retry acquiring the lock if it already exists", async () => {
-      vi.spyOn(
-        service,
-        "loadMarketplaceManifest" as keyof MarketplaceService,
-      ).mockResolvedValue({
-        name: "test",
-        plugins: [],
-      } as never);
+    // Add first time
+    await service.addMarketplace("https://github.com/user/repo");
+    // Add again - should update
+    const added = await service.addMarketplace("https://github.com/user/repo");
+    expect(added.name).toBe("custom-mkt");
 
-      vi.mocked(fs.open)
-        .mockRejectedValueOnce({ code: "EEXIST" } as unknown as Error)
-        .mockRejectedValueOnce({ code: "EEXIST" } as unknown as Error)
-        .mockResolvedValueOnce({ close: vi.fn() } as unknown as Awaited<
-          ReturnType<typeof fs.open>
-        >);
-
-      // Mock setTimeout to resolve immediately
-      const originalSetTimeout = global.setTimeout;
-      (
-        global as unknown as { setTimeout: (fn: () => void) => void }
-      ).setTimeout = (fn: () => void) => fn();
-
-      vi.mocked(fs.open).mockClear();
-      const result = await service.addMarketplace("/some/path");
-
-      expect(result).toBeDefined();
-      expect(fs.open).toHaveBeenCalledTimes(3);
-
-      global.setTimeout = originalSetTimeout;
-    });
-
-    it("should cleanup temporary directories if installation fails", async () => {
-      vi.spyOn(service, "getKnownMarketplaces").mockResolvedValue({
-        marketplaces: [
-          {
-            name: "test",
-            source: { source: "github", repo: "owner/repo" },
-            autoUpdate: false,
-          },
-        ],
-      });
-
-      vi.spyOn(service, "loadMarketplaceManifest").mockResolvedValue({
-        name: "test",
-        plugins: [
-          { name: "plugin", source: "plugin-dir", description: "test" },
-        ],
-      } as never);
-
-      // Mock git clone to succeed but something else to fail
-      vi.spyOn(
-        service["gitService"] as unknown as { clone: () => Promise<void> },
-        "clone",
-      ).mockResolvedValue(undefined);
-
-      // Mock fs.readFile to fail when reading plugin manifest
-      vi.mocked(fs.readFile).mockImplementation((path: unknown) => {
-        if (String(path).includes("plugin.json")) {
-          throw new Error("Read error");
-        }
-        return Promise.resolve("");
-      });
-
-      // Mock existsSync to return true for cleanup check
-      vi.mocked(fsModule.existsSync).mockReturnValue(true);
-
-      await expect(
-        service.installPlugin("plugin@test", "/project"),
-      ).rejects.toThrow(/Failed to install plugin plugin: Read error/);
-
-      // Should attempt to remove tmp dirs
-      expect(fs.rm).toHaveBeenCalled();
-    });
+    const registry = await service.getKnownMarketplaces();
+    const customMkt = registry.marketplaces.find(
+      (m) => m.name === "custom-mkt",
+    );
+    expect(customMkt).toBeDefined();
   });
 });

--- a/packages/agent-sdk/tests/services/MarketplaceService.uninstall.test.ts
+++ b/packages/agent-sdk/tests/services/MarketplaceService.uninstall.test.ts
@@ -11,6 +11,28 @@ vi.mock("../../src/utils/configPaths.js", () => ({
 
 vi.mock("../../src/services/GitService.js");
 
+vi.mock("../../src/services/configurationService.js", () => {
+  return {
+    ConfigurationService: class MockConfigService {
+      getMergedMarketplaces() {
+        return {};
+      }
+      getScopedMarketplaces() {
+        return {};
+      }
+      addMarketplaceToScope() {
+        return Promise.resolve();
+      }
+      removeMarketplaceFromScope() {
+        return Promise.resolve();
+      }
+      getMergedEnabledPlugins() {
+        return {};
+      }
+    },
+  };
+});
+
 vi.mock("fs", async () => {
   const actual = await vi.importActual<typeof import("fs")>("fs");
   return {

--- a/packages/agent-sdk/tests/services/MarketplaceService.update.test.ts
+++ b/packages/agent-sdk/tests/services/MarketplaceService.update.test.ts
@@ -4,6 +4,18 @@ import { MarketplaceService } from "../../src/services/MarketplaceService.js";
 
 vi.mock("../../src/services/GitService.js");
 
+vi.mock("../../src/services/configurationService.js", () => {
+  return {
+    ConfigurationService: class {
+      getMergedMarketplaces = vi.fn(() => ({}));
+      getScopedMarketplaces = vi.fn(() => ({}));
+      addMarketplaceToScope = vi.fn();
+      removeMarketplaceFromScope = vi.fn();
+      getMergedEnabledPlugins = vi.fn(() => ({}));
+    },
+  };
+});
+
 describe("MarketplaceService - Update", () => {
   let service: MarketplaceService;
 

--- a/packages/code/src/components/MarketplaceAddForm.tsx
+++ b/packages/code/src/components/MarketplaceAddForm.tsx
@@ -2,9 +2,17 @@ import React, { useState, useRef, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import { usePluginManagerContext } from "../contexts/PluginManagerContext.js";
 
+const SCOPES = [
+  { value: "user" as const, label: "user" },
+  { value: "project" as const, label: "project" },
+  { value: "local" as const, label: "local" },
+];
+
 export const MarketplaceAddForm: React.FC = () => {
   const { state, actions } = usePluginManagerContext();
   const [source, setSource] = useState("");
+  const [scopeIndex, setScopeIndex] = useState(0);
+  const [mode, setMode] = useState<"source" | "scope">("source");
   const sourceRef = useRef(source);
 
   // Keep ref in sync with state
@@ -14,16 +22,31 @@ export const MarketplaceAddForm: React.FC = () => {
 
   useInput((input, key) => {
     if (key.escape) {
-      actions.setView("MARKETPLACES");
+      if (mode === "scope") {
+        setMode("source");
+      } else {
+        actions.setView("MARKETPLACES");
+      }
     } else if (state.isLoading) {
       return;
-    } else if (key.return) {
-      if (sourceRef.current.trim()) {
-        actions.addMarketplace(sourceRef.current.trim());
+    } else if (input === "q" && mode === "source") {
+      setMode("scope");
+    } else if (mode === "scope") {
+      if (key.upArrow) {
+        setScopeIndex((prev) => Math.max(0, prev - 1));
+      } else if (key.downArrow) {
+        setScopeIndex((prev) => Math.min(SCOPES.length - 1, prev + 1));
+      } else if (key.return) {
+        setMode("source");
       }
-    } else if (key.backspace || key.delete) {
+    } else if (mode === "source" && key.return) {
+      if (sourceRef.current.trim()) {
+        const scope = SCOPES[scopeIndex].value;
+        actions.addMarketplace(sourceRef.current.trim(), scope);
+      }
+    } else if (mode === "source" && (key.backspace || key.delete)) {
       setSource((prev) => prev.slice(0, -1));
-    } else if (input.length === 1) {
+    } else if (mode === "source" && input.length === 1) {
       setSource((prev) => prev + input);
     }
   });
@@ -35,8 +58,20 @@ export const MarketplaceAddForm: React.FC = () => {
       </Text>
       <Box marginTop={1}>
         <Text>Source (URL or Path): </Text>
-        <Text color={state.isLoading ? "gray" : "yellow"}>{source}</Text>
-        {!state.isLoading && <Text color="yellow">_</Text>}
+        <Text color={state.isLoading || mode !== "source" ? "gray" : "yellow"}>
+          {source}
+        </Text>
+        {!state.isLoading && mode === "source" && <Text color="yellow">_</Text>}
+      </Box>
+      <Box marginTop={1}>
+        <Text>Scope: </Text>
+        {SCOPES.map((s, i) => (
+          <Text key={s.value} color={i === scopeIndex ? "yellow" : "dim"}>
+            {i === scopeIndex ? "> " : "  "}
+            {s.label}{" "}
+          </Text>
+        ))}
+        <Text dimColor> (press 'q' to change)</Text>
       </Box>
       {state.isLoading && (
         <Box marginTop={1}>
@@ -47,7 +82,9 @@ export const MarketplaceAddForm: React.FC = () => {
         <Text dimColor>
           {state.isLoading
             ? "Please wait..."
-            : "Press Enter to add, Esc to cancel"}
+            : mode === "scope"
+              ? "Use ↑/↓ to select, Enter to confirm, Esc to cancel"
+              : "Press Enter to add, 's' to change scope, Esc to cancel"}
         </Text>
       </Box>
     </Box>

--- a/packages/code/src/components/MarketplaceAddForm.tsx
+++ b/packages/code/src/components/MarketplaceAddForm.tsx
@@ -12,7 +12,7 @@ export const MarketplaceAddForm: React.FC = () => {
   const { state, actions } = usePluginManagerContext();
   const [source, setSource] = useState("");
   const [scopeIndex, setScopeIndex] = useState(0);
-  const [mode, setMode] = useState<"source" | "scope">("source");
+  const [step, setStep] = useState<"source" | "scope">("source");
   const sourceRef = useRef(source);
 
   // Keep ref in sync with state
@@ -22,69 +22,84 @@ export const MarketplaceAddForm: React.FC = () => {
 
   useInput((input, key) => {
     if (key.escape) {
-      if (mode === "scope") {
-        setMode("source");
+      if (step === "scope") {
+        setStep("source");
       } else {
         actions.setView("MARKETPLACES");
       }
     } else if (state.isLoading) {
       return;
-    } else if (input === "q" && mode === "source") {
-      setMode("scope");
-    } else if (mode === "scope") {
+    } else if (step === "source" && key.return) {
+      if (sourceRef.current.trim()) {
+        setStep("scope");
+      }
+    } else if (step === "source" && (key.backspace || key.delete)) {
+      setSource((prev) => prev.slice(0, -1));
+    } else if (
+      step === "source" &&
+      input &&
+      !key.ctrl &&
+      !key.meta &&
+      !("alt" in key && key.alt)
+    ) {
+      setSource((prev) => prev + input);
+    } else if (step === "scope") {
       if (key.upArrow) {
         setScopeIndex((prev) => Math.max(0, prev - 1));
       } else if (key.downArrow) {
         setScopeIndex((prev) => Math.min(SCOPES.length - 1, prev + 1));
       } else if (key.return) {
-        setMode("source");
-      }
-    } else if (mode === "source" && key.return) {
-      if (sourceRef.current.trim()) {
         const scope = SCOPES[scopeIndex].value;
         actions.addMarketplace(sourceRef.current.trim(), scope);
       }
-    } else if (mode === "source" && (key.backspace || key.delete)) {
-      setSource((prev) => prev.slice(0, -1));
-    } else if (mode === "source" && input.length === 1) {
-      setSource((prev) => prev + input);
     }
   });
+
+  if (step === "source") {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text bold color="cyan">
+          Step 1/2: Enter marketplace source
+        </Text>
+        <Box marginTop={1}>
+          <Text>Source: </Text>
+          <Text color="yellow">{source}</Text>
+          {!state.isLoading && <Text color="yellow">_</Text>}
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>Enter to continue, Esc to cancel</Text>
+        </Box>
+      </Box>
+    );
+  }
 
   return (
     <Box flexDirection="column" padding={1}>
       <Text bold color="cyan">
-        Add Marketplace
+        Step 2/2: Select scope
       </Text>
       <Box marginTop={1}>
-        <Text>Source (URL or Path): </Text>
-        <Text color={state.isLoading || mode !== "source" ? "gray" : "yellow"}>
-          {source}
-        </Text>
-        {!state.isLoading && mode === "source" && <Text color="yellow">_</Text>}
+        <Text dimColor>Source: </Text>
+        <Text dimColor>{source}</Text>
       </Box>
-      <Box marginTop={1}>
-        <Text>Scope: </Text>
+      <Box marginTop={1} flexDirection="column">
         {SCOPES.map((s, i) => (
           <Text key={s.value} color={i === scopeIndex ? "yellow" : "dim"}>
             {i === scopeIndex ? "> " : "  "}
-            {s.label}{" "}
+            {s.label}
           </Text>
         ))}
-        <Text dimColor> (press 'q' to change)</Text>
       </Box>
       {state.isLoading && (
         <Box marginTop={1}>
-          <Text color="yellow">⌛ Adding marketplace...</Text>
+          <Text color="yellow">Adding marketplace...</Text>
         </Box>
       )}
       <Box marginTop={1}>
         <Text dimColor>
           {state.isLoading
             ? "Please wait..."
-            : mode === "scope"
-              ? "Use ↑/↓ to select, Enter to confirm, Esc to cancel"
-              : "Press Enter to add, 's' to change scope, Esc to cancel"}
+            : "Enter to confirm, \u2191/\u2193 to navigate, Esc to go back"}
         </Text>
       </Box>
     </Box>

--- a/packages/code/src/components/MarketplaceDetail.tsx
+++ b/packages/code/src/components/MarketplaceDetail.tsx
@@ -55,6 +55,10 @@ export const MarketplaceDetail: React.FC = () => {
           {marketplace.name}
         </Text>
         {marketplace.isBuiltin && <Text dimColor> (Built-in)</Text>}
+        {marketplace.declaredScope &&
+          marketplace.declaredScope !== "builtin" && (
+            <Text dimColor> ({marketplace.declaredScope} scope)</Text>
+          )}
       </Box>
 
       <Box marginBottom={1}>

--- a/packages/code/src/components/MarketplaceList.tsx
+++ b/packages/code/src/components/MarketplaceList.tsx
@@ -39,6 +39,10 @@ export const MarketplaceList: React.FC<MarketplaceListProps> = ({
                 {marketplace.isBuiltin && (
                   <Text color="yellow"> [Built-in]</Text>
                 )}
+                {marketplace.declaredScope &&
+                  marketplace.declaredScope !== "builtin" && (
+                    <Text color="magenta"> [{marketplace.declaredScope}]</Text>
+                  )}
               </Text>
             </Box>
             <Box marginLeft={4} flexDirection="column">

--- a/packages/code/src/components/PluginManagerTypes.ts
+++ b/packages/code/src/components/PluginManagerTypes.ts
@@ -33,8 +33,14 @@ export interface PluginManagerContextType {
   actions: {
     setView: (view: ViewType) => void;
     setSelectedId: (id: string | null) => void;
-    addMarketplace: (source: string) => Promise<void>;
-    removeMarketplace: (name: string) => Promise<void>;
+    addMarketplace: (
+      source: string,
+      scope?: "user" | "project" | "local",
+    ) => Promise<void>;
+    removeMarketplace: (
+      name: string,
+      scope?: "user" | "project" | "local",
+    ) => Promise<void>;
     updateMarketplace: (name: string) => Promise<void>;
     installPlugin: (
       name: string,

--- a/packages/code/src/hooks/usePluginManager.ts
+++ b/packages/code/src/hooks/usePluginManager.ts
@@ -141,16 +141,16 @@ export function usePluginManager(): PluginManagerContextType {
   }, []);
 
   const addMarketplace = useCallback(
-    async (source: string) => {
+    async (source: string, scope: "user" | "project" | "local" = "user") => {
       clearPluginFeedback();
       setState((prev: PluginManagerState) => ({
         ...prev,
         isLoading: true,
       }));
       try {
-        await pluginCore.addMarketplace(source);
+        await pluginCore.addMarketplace(source, scope);
         await refresh();
-        setSuccessMessage(`Marketplace added successfully`);
+        setSuccessMessage(`Marketplace added successfully (${scope} scope)`);
       } catch (error) {
         setState((prev: PluginManagerState) => ({
           ...prev,
@@ -163,14 +163,14 @@ export function usePluginManager(): PluginManagerContextType {
   );
 
   const removeMarketplace = useCallback(
-    async (name: string) => {
+    async (name: string, scope?: "user" | "project" | "local") => {
       clearPluginFeedback();
       setState((prev: PluginManagerState) => ({
         ...prev,
         isLoading: true,
       }));
       try {
-        await pluginCore.removeMarketplace(name);
+        await pluginCore.removeMarketplace(name, scope);
         await refresh();
         setSuccessMessage(`Marketplace '${name}' removed successfully`);
       } catch (error) {

--- a/packages/code/src/hooks/usePluginManager.ts
+++ b/packages/code/src/hooks/usePluginManager.ts
@@ -151,6 +151,10 @@ export function usePluginManager(): PluginManagerContextType {
         await pluginCore.addMarketplace(source, scope);
         await refresh();
         setSuccessMessage(`Marketplace added successfully (${scope} scope)`);
+        setState((prev: PluginManagerState) => ({
+          ...prev,
+          currentView: "MARKETPLACES",
+        }));
       } catch (error) {
         setState((prev: PluginManagerState) => ({
           ...prev,
@@ -173,6 +177,10 @@ export function usePluginManager(): PluginManagerContextType {
         await pluginCore.removeMarketplace(name, scope);
         await refresh();
         setSuccessMessage(`Marketplace '${name}' removed successfully`);
+        setState((prev: PluginManagerState) => ({
+          ...prev,
+          currentView: "MARKETPLACES",
+        }));
       } catch (error) {
         setState((prev: PluginManagerState) => ({
           ...prev,

--- a/packages/code/tests/components/MarketplaceAddForm.test.tsx
+++ b/packages/code/tests/components/MarketplaceAddForm.test.tsx
@@ -96,21 +96,19 @@ describe("MarketplaceAddForm", () => {
       </PluginManagerContext.Provider>,
     );
 
+    stdin.write("t");
+    stdin.write("e");
     stdin.write("s");
+    stdin.write("t");
     await vi.waitFor(() => {
-      expect(lastFrame()).toContain("s");
-    });
-
-    // Wait a bit for state to settle
-    await vi.waitFor(() => {
-      expect(lastFrame()).toContain("s_");
+      expect(lastFrame()).toContain("test");
     });
 
     stdin.write("\r");
 
     await vi.waitFor(
       () => {
-        expect(mockActions.addMarketplace).toHaveBeenCalledWith("s");
+        expect(mockActions.addMarketplace).toHaveBeenCalledWith("test", "user");
       },
       { timeout: 3000 },
     );

--- a/packages/code/tests/components/MarketplaceAddForm.test.tsx
+++ b/packages/code/tests/components/MarketplaceAddForm.test.tsx
@@ -47,8 +47,8 @@ describe("MarketplaceAddForm", () => {
         <MarketplaceAddForm />
       </PluginManagerContext.Provider>,
     );
-    expect(lastFrame()).toContain("Add Marketplace");
-    expect(lastFrame()).toContain("Source (URL or Path):");
+    expect(lastFrame()).toContain("Step 1/2");
+    expect(lastFrame()).toContain("Source:");
   });
 
   it("should handle text input", async () => {
@@ -58,7 +58,6 @@ describe("MarketplaceAddForm", () => {
       </PluginManagerContext.Provider>,
     );
 
-    // Ink's useInput might need some time or specific way to trigger
     stdin.write("h");
     stdin.write("t");
     stdin.write("t");
@@ -89,7 +88,74 @@ describe("MarketplaceAddForm", () => {
     });
   });
 
-  it("should call addMarketplace when Enter is pressed with content", async () => {
+  it("should navigate to scope step after pressing Enter", async () => {
+    const { stdin, lastFrame } = render(
+      <PluginManagerContext.Provider value={mockContext}>
+        <MarketplaceAddForm />
+      </PluginManagerContext.Provider>,
+    );
+
+    stdin.write("t");
+    stdin.write("e");
+    stdin.write("s");
+    stdin.write("t");
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain("test");
+    });
+
+    // First Enter moves to scope step
+    stdin.write("\r");
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain("Step 2/2");
+    });
+  });
+
+  it("should call addMarketplace after confirming scope selection", async () => {
+    const { stdin, lastFrame } = render(
+      <PluginManagerContext.Provider value={mockContext}>
+        <MarketplaceAddForm />
+      </PluginManagerContext.Provider>,
+    );
+
+    stdin.write("t");
+    stdin.write("e");
+    stdin.write("s");
+    stdin.write("t");
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain("test");
+    });
+
+    // First Enter moves to scope step
+    stdin.write("\r");
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain("Step 2/2");
+    });
+
+    // Second Enter confirms scope and submits
+    stdin.write("\r");
+
+    await vi.waitFor(
+      () => {
+        expect(mockActions.addMarketplace).toHaveBeenCalledWith("test", "user");
+      },
+      { timeout: 3000 },
+    );
+  });
+
+  it("should call setView('MARKETPLACES') when Escape is pressed on step 1", async () => {
+    const { stdin } = render(
+      <PluginManagerContext.Provider value={mockContext}>
+        <MarketplaceAddForm />
+      </PluginManagerContext.Provider>,
+    );
+
+    stdin.write("\u001B"); // Escape
+    await vi.waitFor(() => {
+      expect(mockActions.setView).toHaveBeenCalledWith("MARKETPLACES");
+    });
+  });
+
+  it("should go back to source step when Escape is pressed on step 2", async () => {
     const { stdin, lastFrame } = render(
       <PluginManagerContext.Provider value={mockContext}>
         <MarketplaceAddForm />
@@ -105,25 +171,13 @@ describe("MarketplaceAddForm", () => {
     });
 
     stdin.write("\r");
-
-    await vi.waitFor(
-      () => {
-        expect(mockActions.addMarketplace).toHaveBeenCalledWith("test", "user");
-      },
-      { timeout: 3000 },
-    );
-  });
-
-  it("should call setView('MARKETPLACES') when Escape is pressed", async () => {
-    const { stdin } = render(
-      <PluginManagerContext.Provider value={mockContext}>
-        <MarketplaceAddForm />
-      </PluginManagerContext.Provider>,
-    );
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain("Step 2/2");
+    });
 
     stdin.write("\u001B"); // Escape
     await vi.waitFor(() => {
-      expect(mockActions.setView).toHaveBeenCalledWith("MARKETPLACES");
+      expect(lastFrame()).toContain("Step 1/2");
     });
   });
 });

--- a/packages/code/tests/hooks/usePluginManager.test.tsx
+++ b/packages/code/tests/hooks/usePluginManager.test.tsx
@@ -151,7 +151,10 @@ describe("usePluginManager", () => {
       lastValue?.actions.addMarketplace("test/repo");
 
       await vi.waitFor(() => {
-        expect(mockPluginCore.addMarketplace).toHaveBeenCalledWith("test/repo");
+        expect(mockPluginCore.addMarketplace).toHaveBeenCalledWith(
+          "test/repo",
+          "user",
+        );
         expect(mockPluginCore.listMarketplaces).toHaveBeenCalledTimes(2);
       });
     });


### PR DESCRIPTION
## Summary

This PR implements scoped marketplace support and fixes flaky test failures.

### Scoped Marketplace Support (user/project/local)
- Add `marketplaces` field to `WaveConfiguration` with user/project/local scoping
- Marketplaces are now declared in scoped settings files (`settings.json`, `settings.local.json`) instead of a global `known_marketplaces.json`
- `known_marketplaces.json` now serves as a cache for metadata (`installLocation`, `lastUpdated`)
- UI components updated to display scope badges and scope selector in add form
- Migration mechanism to move existing entries to user-level settings on first run
- Dependency injection: `MarketplaceService` now receives `workdir` and `ConfigurationService` via constructor

### Flaky Test Fixes
- Add `ForkedAgentManager` mock to `hook-non-blocking-error.test.ts` and `hook-success.test.ts`
- Prevents auto-memory extraction service from making extra AI calls that cause flaky assertion failures on call counts
