### PR TITLE
fix: remove killed notification from stopTask

### DIFF
--- a/packages/agent-sdk/src/managers/backgroundTaskManager.ts
+++ b/packages/agent-sdk/src/managers/backgroundTaskManager.ts
@@ -2,11 +2,7 @@ import { spawn, type ChildProcess } from "child_process";
 import * as os from "os";
 import * as fs from "fs";
 import * as path from "path";
-import {
-  BackgroundTask,
-  BackgroundShell,
-  BackgroundSubagent,
-} from "../types/processes.js";
+import { BackgroundTask, BackgroundShell } from "../types/processes.js";
 import { stripAnsiColors } from "../utils/stringUtils.js";
 import { logger } from "../utils/globalLogger.js";
 import { Container } from "../utils/container.js";
@@ -427,21 +423,6 @@ export class BackgroundTaskManager {
     task.runtime = task.endTime - task.startTime;
     this.notifyTasksChange();
 
-    // Enqueue killed notification
-    const notificationQueue = this.container.has("NotificationQueue")
-      ? this.container.get<NotificationQueue>("NotificationQueue")
-      : undefined;
-    if (notificationQueue) {
-      const description = (task as BackgroundSubagent).description || "";
-      const command = (task as BackgroundShell).command || "";
-      const summary =
-        task.type === "subagent"
-          ? `Agent task "${description}" was stopped`
-          : `Command "${command}" was stopped`;
-      notificationQueue.enqueue(
-        `<task-notification>\n<task-id>${id}</task-id>\n<task-type>${task.type}</task-type>\n<status>killed</status>\n<summary>${summary}</summary>\n</task-notification>`,
-      );
-    }
     return true;
   }
 

--- a/packages/agent-sdk/tests/managers/backgroundTaskManager.notification.test.ts
+++ b/packages/agent-sdk/tests/managers/backgroundTaskManager.notification.test.ts
@@ -84,16 +84,14 @@ describe("BackgroundTaskManager - Notification Queue", () => {
     expect(notifications[0]).toContain("spawn error");
   });
 
-  it("should enqueue notification when task is killed", () => {
+  it("should NOT enqueue notification when task is killed", () => {
     manager.startShell("sleep 999");
     const tasks = manager.getAllTasks();
     const taskId = tasks[0].id;
 
     manager.stopTask(taskId);
 
-    expect(notificationQueue.hasPending()).toBe(true);
-    const notifications = notificationQueue.dequeueAll();
-    expect(notifications[0]).toContain("<status>killed</status>");
+    expect(notificationQueue.hasPending()).toBe(false);
   });
 
   it("should not enqueue notification when NotificationQueue is not available", () => {

--- a/packages/agent-sdk/tests/managers/backgroundTaskManager.test.ts
+++ b/packages/agent-sdk/tests/managers/backgroundTaskManager.test.ts
@@ -27,7 +27,7 @@ describe("BackgroundTaskManager notification deduplication", () => {
   });
 
   describe("stopTask", () => {
-    it("should enqueue a killed notification for a running subagent task", () => {
+    it("should NOT enqueue a killed notification for a running subagent task", () => {
       const task: BackgroundSubagent = {
         id: "task_1",
         type: "subagent",
@@ -42,10 +42,9 @@ describe("BackgroundTaskManager notification deduplication", () => {
       const result = manager.stopTask("task_1");
 
       expect(result).toBe(true);
+      expect(task.status).toBe("killed");
       const notifications = notificationQueue.dequeueAll();
-      expect(notifications.length).toBe(1);
-      expect(notifications[0]).toContain("was stopped");
-      expect(notifications[0]).toContain("status>killed");
+      expect(notifications.length).toBe(0);
     });
 
     it("should not enqueue a killed notification for a task already stopped", () => {
@@ -105,7 +104,7 @@ describe("BackgroundTaskManager notification deduplication", () => {
   });
 
   describe("cleanup", () => {
-    it("should stop all running tasks and enqueue killed notifications", () => {
+    it("should stop all running tasks without enqueueing killed notifications", () => {
       const task1: BackgroundSubagent = {
         id: "task_1",
         type: "subagent",
@@ -143,9 +142,11 @@ describe("BackgroundTaskManager notification deduplication", () => {
 
       manager.cleanup();
 
+      expect(task1.status).toBe("killed");
+      expect(task2.status).toBe("killed");
+      expect(completedTask.status).toBe("completed");
       const notifications = notificationQueue.dequeueAll();
-      expect(notifications.length).toBe(2);
-      expect(notifications.every((n) => n.includes("was stopped"))).toBe(true);
+      expect(notifications.length).toBe(0);
     });
   });
 });


### PR DESCRIPTION
Remove the killed notification from `BackgroundTaskManager.stopTask()` since it was always redundant: the agent receives a tool result and the user sees the UI update. Notifications should only be for asynchronous completion events.

- Removed killed notification enqueue logic from `stopTask()`
- Updated test to verify no notification is enqueued on stop
- Removed unused `BackgroundSubagent` import