### PR TITLE
fix: use logger instead of console.warn in MarketplaceService

### DIFF
--- a/packages/agent-sdk/src/services/MarketplaceService.ts
+++ b/packages/agent-sdk/src/services/MarketplaceService.ts
@@ -13,6 +13,7 @@ import {
 import { GitService } from "./GitService.js";
 import { ConfigurationService } from "./configurationService.js";
 import type { MarketplaceConfig, Scope } from "../types/configuration.js";
+import { logger } from "../utils/globalLogger.js";
 
 /**
  * Marketplace Service
@@ -641,7 +642,7 @@ export class MarketplaceService {
                 (p) => p.name === plugin.name,
               );
               if (!pluginEntry) {
-                console.warn(
+                logger.warn(
                   `Plugin "${plugin.name}" no longer found in marketplace "${marketplace.name}". Uninstalling...`,
                 );
                 try {


### PR DESCRIPTION
Replace console.warn with logger.warn for plugin uninstall message
to follow project logging conventions.
