### PR TITLE
fix: prevent duplicate notification when killed shell task exits

### DIFF
--- a/packages/agent-sdk/src/managers/backgroundTaskManager.ts
+++ b/packages/agent-sdk/src/managers/backgroundTaskManager.ts
@@ -153,22 +153,27 @@ export class BackgroundTaskManager {
       if (logStream.writable) {
         logStream.end();
       }
-      shell.status = code === 0 ? "completed" : "failed";
+      const wasKilled = shell.status === "killed";
+      if (!wasKilled) {
+        shell.status = code === 0 ? "completed" : "failed";
+      }
       shell.exitCode = code ?? 0;
       shell.endTime = Date.now();
       shell.runtime = shell.endTime - startTime;
       this.notifyTasksChange();
 
-      // Enqueue completion notification
-      const notificationQueue = this.container.has("NotificationQueue")
-        ? this.container.get<NotificationQueue>("NotificationQueue")
-        : undefined;
-      if (notificationQueue) {
-        const statusStr = shell.status;
-        const summary = `Command "${command}" ${statusStr} with exit code ${code ?? 0}`;
-        notificationQueue.enqueue(
-          `<task-notification>\n<task-id>${id}</task-id>\n<task-type>shell</task-type>\n<output-file>${logPath}</output-file>\n<status>${statusStr}</status>\n<summary>${summary}</summary>\n</task-notification>`,
-        );
+      // Skip notification if task was manually killed (user/agent-initiated stop)
+      if (!wasKilled) {
+        const notificationQueue = this.container.has("NotificationQueue")
+          ? this.container.get<NotificationQueue>("NotificationQueue")
+          : undefined;
+        if (notificationQueue) {
+          const statusStr = shell.status;
+          const summary = `Command "${command}" ${statusStr} with exit code ${code ?? 0}`;
+          notificationQueue.enqueue(
+            `<task-notification>\n<task-id>${id}</task-id>\n<task-type>shell</task-type>\n<output-file>${logPath}</output-file>\n<status>${statusStr}</status>\n<summary>${summary}</summary>\n</task-notification>`,
+          );
+        }
       }
     };
 
@@ -301,22 +306,27 @@ export class BackgroundTaskManager {
       if (logStream.writable) {
         logStream.end();
       }
-      shell.status = code === 0 ? "completed" : "failed";
+      const wasKilled = shell.status === "killed";
+      if (!wasKilled) {
+        shell.status = code === 0 ? "completed" : "failed";
+      }
       shell.exitCode = code ?? 0;
       shell.endTime = Date.now();
       shell.runtime = shell.endTime - startTime;
       this.notifyTasksChange();
 
-      // Enqueue completion notification
-      const notificationQueue = this.container.has("NotificationQueue")
-        ? this.container.get<NotificationQueue>("NotificationQueue")
-        : undefined;
-      if (notificationQueue) {
-        const statusStr = shell.status;
-        const summary = `Command "${command}" ${statusStr} with exit code ${code ?? 0}`;
-        notificationQueue.enqueue(
-          `<task-notification>\n<task-id>${id}</task-id>\n<task-type>shell</task-type>\n<output-file>${logPath}</output-file>\n<status>${statusStr}</status>\n<summary>${summary}</summary>\n</task-notification>`,
-        );
+      // Skip notification if task was manually killed (user/agent-initiated stop)
+      if (!wasKilled) {
+        const notificationQueue = this.container.has("NotificationQueue")
+          ? this.container.get<NotificationQueue>("NotificationQueue")
+          : undefined;
+        if (notificationQueue) {
+          const statusStr = shell.status;
+          const summary = `Command "${command}" ${statusStr} with exit code ${code ?? 0}`;
+          notificationQueue.enqueue(
+            `<task-notification>\n<task-id>${id}</task-id>\n<task-type>shell</task-type>\n<output-file>${logPath}</output-file>\n<status>${statusStr}</status>\n<summary>${summary}</summary>\n</task-notification>`,
+          );
+        }
       }
     });
 

--- a/packages/agent-sdk/tests/managers/backgroundTaskManager.notification.test.ts
+++ b/packages/agent-sdk/tests/managers/backgroundTaskManager.notification.test.ts
@@ -152,4 +152,43 @@ describe("BackgroundTaskManager - Notification Queue", () => {
     const updatedTasks = noNotifyManager.getAllTasks();
     expect(updatedTasks[0].status).toBe("killed");
   });
+
+  it("should NOT enqueue notification when killed task exits (race condition)", () => {
+    // This tests the race condition: stopTask() sets status to "killed",
+    // then the onExit handler fires from the SIGTERM signal.
+    manager.startShell("sleep 999");
+    const tasks = manager.getAllTasks();
+    const taskId = tasks[0].id;
+
+    // Stop the task (sets status to "killed", sends SIGTERM via onStop)
+    manager.stopTask(taskId);
+
+    expect(notificationQueue.hasPending()).toBe(false);
+
+    // Simulate onExit firing after SIGTERM — this should NOT enqueue a notification
+    const exitHandler = handlers.get("exit");
+    exitHandler?.(143); // SIGTERM exit code
+
+    // Status should remain "killed", not be overwritten to "failed"
+    expect(tasks[0].status).toBe("killed");
+    // No notification should be enqueued
+    expect(notificationQueue.hasPending()).toBe(false);
+  });
+
+  it("should preserve killed status when onExit fires after stopTask", () => {
+    manager.startShell("sleep 999");
+    const tasks = manager.getAllTasks();
+    const taskId = tasks[0].id;
+
+    manager.stopTask(taskId);
+    expect(tasks[0].status).toBe("killed");
+
+    // Exit handler fires with exit code 0 (e.g. SIGTERM caught as exit 0)
+    const exitHandler = handlers.get("exit");
+    exitHandler?.(0);
+
+    // Status must remain "killed", not overwritten to "completed"
+    expect(tasks[0].status).toBe("killed");
+    expect(notificationQueue.hasPending()).toBe(false);
+  });
 });


### PR DESCRIPTION
## Problem

When a background shell task was stopped via `TaskStopTool` or the UI `k` shortcut, a notification would still appear showing the command completed/failed. This was caused by a race condition:

1. `stopTask()` sets the task status to `killed` and calls `onStop()` to send SIGTERM
2. The process exits, triggering the `onExit` handler
3. The `onExit` handler was **overwriting** the `killed` status to `completed` or `failed` based on exit code
4. The `onExit` handler **always** enqueued a notification regardless of how the task ended

## Fix

In both `startShell` and `adoptProcess` `onExit` handlers in `backgroundTaskManager.ts`:
- Check if `shell.status` is already `killed` (set by `stopTask()`)
- If killed: skip status overwrite and skip notification enqueue
- If not killed: set normal completed/failed status and enqueue notification

## Tests

Added two new tests covering the race condition:
- `should NOT enqueue notification when killed task exits (race condition)`
- `should preserve killed status when onExit fires after stopTask`

All 15 tests pass (13 existing + 2 new).