### PR TITLE
test: add SessionStart additionalContext and initializationService tests

### DIFF
--- a/packages/agent-sdk/tests/managers/hookManager.coverage.test.ts
+++ b/packages/agent-sdk/tests/managers/hookManager.coverage.test.ts
@@ -725,6 +725,170 @@ describe("HookManager Coverage", () => {
       );
       expect(result.additionalContext).toBe("Plain text context");
     });
+
+    it("should concatenate additionalContext from multiple hooks", async () => {
+      let callCount = 0;
+      mockExecuteCommand.mockImplementation(async () => {
+        callCount += 1;
+        if (callCount === 1) {
+          return {
+            success: true,
+            duration: 100,
+            timedOut: false,
+            exitCode: 0,
+            stdout: '{"additionalContext": "Context from hook 1"}',
+            stderr: "",
+          };
+        }
+        return {
+          success: true,
+          duration: 100,
+          timedOut: false,
+          exitCode: 0,
+          stdout: '{"additionalContext": "Context from hook 2"}',
+          stderr: "",
+        };
+      });
+      manager.loadConfiguration({
+        SessionStart: [
+          {
+            hooks: [
+              { type: "command" as const, command: "echo hook1" },
+              { type: "command" as const, command: "echo hook2" },
+            ],
+          },
+        ],
+      });
+      const result = await manager.executeSessionStartHooks(
+        "startup",
+        "session-123",
+        "/path/to/transcript.json",
+      );
+      expect(result.additionalContext).toBe(
+        "Context from hook 1\nContext from hook 2",
+      );
+    });
+
+    it("should parse both additionalContext and initialUserMessage from same hook", async () => {
+      mockExecuteCommand.mockResolvedValue({
+        success: true,
+        duration: 100,
+        timedOut: false,
+        exitCode: 0,
+        stdout: JSON.stringify({
+          additionalContext: "Project rules context",
+          initialUserMessage: "Start with a plan",
+        }),
+        stderr: "",
+      });
+      manager.loadConfiguration({
+        SessionStart: [
+          { hooks: [{ type: "command" as const, command: "echo both" }] },
+        ],
+      });
+      const result = await manager.executeSessionStartHooks(
+        "startup",
+        "session-123",
+        "/path/to/transcript.json",
+      );
+      expect(result.additionalContext).toBe("Project rules context");
+      expect(result.initialUserMessage).toBe("Start with a plan");
+    });
+
+    it("should skip failed hooks when collecting additionalContext", async () => {
+      let callCount = 0;
+      mockExecuteCommand.mockImplementation(async () => {
+        callCount += 1;
+        if (callCount === 1) {
+          return {
+            success: false,
+            duration: 100,
+            timedOut: false,
+            exitCode: 1,
+            stdout: '{"additionalContext": "Should be ignored"}',
+            stderr: "Hook failed",
+          };
+        }
+        return {
+          success: true,
+          duration: 100,
+          timedOut: false,
+          exitCode: 0,
+          stdout: '{"additionalContext": "Valid context"}',
+          stderr: "",
+        };
+      });
+      manager.loadConfiguration({
+        SessionStart: [
+          {
+            hooks: [
+              { type: "command" as const, command: "echo fail" },
+              { type: "command" as const, command: "echo ok" },
+            ],
+          },
+        ],
+      });
+      const result = await manager.executeSessionStartHooks(
+        "startup",
+        "session-123",
+        "/path/to/transcript.json",
+      );
+      expect(result.additionalContext).toBe("Valid context");
+    });
+
+    it("should mix JSON and plain text additionalContext from multiple hooks", async () => {
+      let callCount = 0;
+      mockExecuteCommand.mockImplementation(async () => {
+        callCount += 1;
+        if (callCount === 1) {
+          return {
+            success: true,
+            duration: 100,
+            timedOut: false,
+            exitCode: 0,
+            stdout: '{"additionalContext": "JSON context"}',
+            stderr: "",
+          };
+        }
+        if (callCount === 2) {
+          return {
+            success: true,
+            duration: 100,
+            timedOut: false,
+            exitCode: 0,
+            stdout: "Plain text context",
+            stderr: "",
+          };
+        }
+        return {
+          success: true,
+          duration: 100,
+          timedOut: false,
+          exitCode: 0,
+          stdout: '{"additionalContext": "More JSON"}',
+          stderr: "",
+        };
+      });
+      manager.loadConfiguration({
+        SessionStart: [
+          {
+            hooks: [
+              { type: "command" as const, command: "echo json1" },
+              { type: "command" as const, command: "echo text" },
+              { type: "command" as const, command: "echo json2" },
+            ],
+          },
+        ],
+      });
+      const result = await manager.executeSessionStartHooks(
+        "startup",
+        "session-123",
+        "/path/to/transcript.json",
+      );
+      expect(result.additionalContext).toBe(
+        "JSON context\nPlain text context\nMore JSON",
+      );
+    });
   });
 
   describe("SessionStart in processHookResults", () => {

--- a/packages/agent-sdk/tests/services/initializationService.test.ts
+++ b/packages/agent-sdk/tests/services/initializationService.test.ts
@@ -36,6 +36,8 @@ describe("InitializationService", () => {
     const container = new Container();
     container.register("MemoryService", mockMemoryService);
 
+    const mockAddUserMessage = vi.fn();
+
     context = {
       skillManager: {
         initialize: vi.fn(),
@@ -70,6 +72,7 @@ describe("InitializationService", () => {
         loadConfigurationFromWaveConfig: vi.fn(),
         executeHooks: vi.fn().mockResolvedValue([]),
         processHookResults: vi.fn(),
+        executeSessionStartHooks: vi.fn().mockResolvedValue({ results: [] }),
       } as unknown as InitializationContext["hookManager"],
       messageManager: {
         getSessionId: vi.fn().mockReturnValue("test"),
@@ -77,6 +80,7 @@ describe("InitializationService", () => {
         setMessages: vi.fn(),
         rebuildUsageFromMessages: vi.fn(),
         getWorkdir: vi.fn().mockReturnValue("/test/workdir"),
+        addUserMessage: mockAddUserMessage,
       } as unknown as InitializationContext["messageManager"],
       memoryRuleManager: {
         discoverRules: vi.fn(),
@@ -142,5 +146,79 @@ describe("InitializationService", () => {
     expect(
       vi.mocked(mockMemoryService.ensureAutoMemoryDirectory),
     ).not.toHaveBeenCalled();
+  });
+
+  describe("SessionStart hooks", () => {
+    it("should inject additionalContext as a user message", async () => {
+      vi.mocked(context.hookManager.executeSessionStartHooks).mockResolvedValue(
+        {
+          results: [],
+          additionalContext: "Project context from hook",
+        },
+      );
+
+      await InitializationService.initialize(context);
+
+      expect(context.messageManager.addUserMessage).toHaveBeenCalledWith({
+        content: "Project context from hook",
+      });
+    });
+
+    it("should inject initialUserMessage as a user message", async () => {
+      vi.mocked(context.hookManager.executeSessionStartHooks).mockResolvedValue(
+        {
+          results: [],
+          initialUserMessage: "Hello from the hook",
+        },
+      );
+
+      await InitializationService.initialize(context);
+
+      expect(context.messageManager.addUserMessage).toHaveBeenCalledWith({
+        content: "Hello from the hook",
+      });
+    });
+
+    it("should inject both additionalContext and initialUserMessage", async () => {
+      vi.mocked(context.hookManager.executeSessionStartHooks).mockResolvedValue(
+        {
+          results: [],
+          additionalContext: "Extra context",
+          initialUserMessage: "Initial message",
+        },
+      );
+
+      await InitializationService.initialize(context);
+
+      expect(context.messageManager.addUserMessage).toHaveBeenCalledTimes(2);
+      expect(context.messageManager.addUserMessage).toHaveBeenNthCalledWith(1, {
+        content: "Extra context",
+      });
+      expect(context.messageManager.addUserMessage).toHaveBeenNthCalledWith(2, {
+        content: "Initial message",
+      });
+    });
+
+    it("should not add user messages when hook returns no context", async () => {
+      vi.mocked(context.hookManager.executeSessionStartHooks).mockResolvedValue(
+        {
+          results: [],
+        },
+      );
+
+      await InitializationService.initialize(context);
+
+      expect(context.messageManager.addUserMessage).not.toHaveBeenCalled();
+    });
+
+    it("should continue initialization when SessionStart hooks fail", async () => {
+      vi.mocked(context.hookManager.executeSessionStartHooks).mockRejectedValue(
+        new Error("Hook execution failed"),
+      );
+
+      await expect(
+        InitializationService.initialize(context),
+      ).resolves.not.toThrow();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Add comprehensive tests for SessionStart hook additionalContext handling and InitializationService integration.

## Changes

### HookManager tests (hookManager.coverage.test.ts)
- Multiple hooks concatenating additionalContext with newlines
- Parsing both additionalContext and initialUserMessage from same hook
- Skipping failed hooks when collecting additionalContext
- Mixing JSON and plain text additionalContext sources

### InitializationService tests (initializationService.test.ts)
- Injecting additionalContext as user message
- Injecting initialUserMessage as user message
- Injecting both in correct order (additionalContext first, then initialUserMessage)
- Graceful handling when hooks return no context
- Graceful handling when hooks throw errors

All 50 tests pass.