### PR TITLE
refactor: use Claude Code hookSpecificOutput format and add plugin docs

### DIFF
--- a/packages/agent-sdk/builtin/skills/settings/HOOKS.md
+++ b/packages/agent-sdk/builtin/skills/settings/HOOKS.md
@@ -99,12 +99,13 @@ Hooks can communicate status and control Wave's behavior using exit codes:
 ### Stdout Processing
 
 Hook stdout is processed as follows:
-- If stdout is valid JSON with `additionalContext` or `initialUserMessage` keys, those values are injected as user messages.
+- If stdout is valid JSON with `hookSpecificOutput.additionalContext` (Claude Code format), that value is injected as additional context.
+- If stdout is valid JSON with `initialUserMessage` at the top level, that value is injected as the initial user message.
 - If stdout is not JSON, the entire output is appended as additional context.
 
 Example hook output:
 ```json
-{"additionalContext": "User prefers concise responses", "initialUserMessage": "Here is my current task..."}
+{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "User prefers concise responses"}, "initialUserMessage": "Here is my current task..."}
 ```
 
 ### Example Configuration
@@ -115,7 +116,7 @@ Example hook output:
       {
         "hooks": [
           {
-            "command": "echo '{\"additionalContext\": \"Project uses pnpm and TypeScript\"}'",
+            "command": "echo '{\"hookSpecificOutput\": {\"hookEventName\": \"SessionStart\", \"additionalContext\": \"Project uses pnpm and TypeScript\"}}'",
             "description": "Inject project context at session start"
           }
         ]

--- a/packages/agent-sdk/builtin/skills/settings/PLUGINS.md
+++ b/packages/agent-sdk/builtin/skills/settings/PLUGINS.md
@@ -1,0 +1,171 @@
+# Wave Plugins & Plugin Marketplaces
+
+This guide covers creating plugins, publishing plugin marketplaces, and installing plugins from marketplaces.
+
+## Plugins
+
+Plugins bundle skills, hooks, MCP servers, LSP servers, and slash commands into a reusable package.
+
+### Creating a Plugin
+
+A plugin is any directory containing a `.wave-plugin/plugin.json` manifest:
+
+```json
+{
+  "name": "my-plugin",
+  "description": "A plugin that adds code review capabilities",
+  "version": "1.0.0",
+  "author": {
+    "name": "Your Name"
+  }
+}
+```
+
+Plugin name must match `^[a-z0-9-]+$` (lowercase letters, numbers, hyphens only).
+
+Place resources in standard directories within the plugin:
+
+| Directory / File | Purpose |
+|-----------------|---------|
+| `skills/` | Skill directories, each containing a `SKILL.md` file |
+| `commands/` | Custom slash command definitions |
+| `hooks/hooks.json` | Hook configuration |
+| `.lsp.json` | LSP server configuration |
+| `.mcp.json` | MCP server configuration |
+
+Only `plugin.json` should exist in `.wave-plugin/` — any other files there will cause a validation error.
+
+### Installing a Plugin Locally
+
+Add a plugin directly in `settings.json`:
+
+```json
+{
+  "plugins": [
+    {
+      "type": "local",
+      "path": "/path/to/my-plugin"
+    }
+  ]
+}
+```
+
+### `${WAVE_PLUGIN_ROOT}` Placeholder
+
+Plugin skills, hooks, MCP servers, and LSP servers can reference their parent plugin's directory using `${WAVE_PLUGIN_ROOT}`. Wave substitutes this placeholder with the plugin's absolute directory path at load time, and also injects `WAVE_PLUGIN_ROOT` as an environment variable into spawned processes.
+
+Example hook command:
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${WAVE_PLUGIN_ROOT}/hooks/session-start\"",
+            "async": false
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Plugin Marketplaces
+
+A plugin marketplace is a git repository containing a `.wave-plugin/marketplace.json` that lists available plugins.
+
+### Marketplace Manifest
+
+```json
+{
+  "name": "my-plugins",
+  "owner": {
+    "name": "Your Name"
+  },
+  "plugins": [
+    {
+      "name": "review-plugin",
+      "description": "Adds a /review command for code reviews",
+      "source": "./plugins/review-plugin"
+    },
+    {
+      "name": "remote-plugin",
+      "description": "Plugin hosted on a remote git repo",
+      "source": "https://github.com/user/remote-plugin.git"
+    }
+  ]
+}
+```
+
+- `source` can be a **relative path** (resolved from the marketplace repo root) or a **git URL** (`https://`, `git@`, `ssh://`) for remote repos.
+- Each plugin at its source path must have its own `.wave-plugin/plugin.json` manifest.
+
+### Registering a Marketplace
+
+Add a marketplace in `settings.json`:
+
+```json
+{
+  "marketplaces": {
+    "my-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "user/my-plugins"
+      }
+    }
+  }
+}
+```
+
+**Source types:**
+
+| Type | Format | Example |
+|------|--------|---------|
+| GitHub | `{ "source": "github", "repo": "owner/repo", "ref": "branch" }` | Clones from `github.com/owner/repo` |
+| Git URL | `{ "source": "git", "url": "https://...", "ref": "branch" }` | Clones from any git remote |
+| Directory | `{ "source": "directory", "path": "/local/path" }` | Uses a local directory |
+
+### Installing from a Marketplace
+
+Install a plugin using the format `plugin-name@marketplace-name`:
+
+```
+/install-plugin my-plugin@my-plugins
+```
+
+Wave clones the marketplace repo, reads the manifest, and copies the plugin to its cache directory.
+
+### Creating a Plugin Marketplace
+
+1. Create a git repository
+2. Add `.wave-plugin/marketplace.json` at the root
+3. Add plugin directories with their own `.wave-plugin/plugin.json`
+4. Register the marketplace in your `settings.json` using a github, git, or directory source
+5. Plugins are cloned to the cache directory on install
+
+### Updating Plugins
+
+Marketplaces with `autoUpdate: true` are checked for updates on startup:
+
+```json
+{
+  "marketplaces": {
+    "my-plugins": {
+      "source": { "source": "github", "repo": "user/my-plugins" },
+      "autoUpdate": true
+    }
+  }
+}
+```
+
+### Marketplace Scopes
+
+Marketplace declarations can be scoped:
+- **User scope**: `~/.wave/settings.json` — available in all projects
+- **Project scope**: `.wave/settings.json` — available in this project only
+- **Local scope**: `.wave/settings.local.json` — not committed to git
+
+Later scopes override earlier ones (local > project > user).

--- a/packages/agent-sdk/builtin/skills/settings/SKILL.md
+++ b/packages/agent-sdk/builtin/skills/settings/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: settings
-description: Manage Wave settings and get guidance on settings.json, hooks, environment variables, permissions, MCP servers, memory rules, skills, and subagents. Use this when the user wants to view, update, or learn how to configure Wave.
+description: Manage Wave settings and get guidance on settings.json, hooks, environment variables, permissions, MCP servers, memory rules, skills, subagents, plugins, and plugin marketplaces. Use this when the user wants to view, update, or learn how to configure Wave.
 ---
 
 # Wave Settings Skill
@@ -92,7 +92,9 @@ Delegate tasks to specialized AI personalities.
 For detailed guidance on creating subagents, see [SUBAGENTS.md](${WAVE_SKILL_DIR}/SUBAGENTS.md).
 
 ### 9. Plugins
-Enable or disable plugins via `enabledPlugins`. Plugin skills, hooks, MCP servers, and LSP servers can reference their parent plugin's directory using the `${WAVE_PLUGIN_ROOT}` placeholder. Wave substitutes `${WAVE_PLUGIN_ROOT}` with the plugin's directory path at load time (same as `${WAVE_SKILL_DIR}`), and also injects `WAVE_PLUGIN_ROOT` as an environment variable into the spawned process.
+
+Plugins bundle skills, hooks, MCP servers, LSP servers, and commands into a reusable package. You can install plugins locally or from a marketplace.
+For detailed guidance on creating plugins and marketplaces, see [PLUGINS.md](${WAVE_SKILL_DIR}/PLUGINS.md).
 
 ### 10. Other Settings
 - `language`: Preferred language for agent communication (e.g., `"en"`, `"zh"`).
@@ -112,5 +114,8 @@ You can ask me to:
 - "How do I define a new subagent?"
 - "How do I set max input tokens?"
 - "How do I change the model?"
+- "How do I create a Wave plugin?"
+- "How do I set up a plugin marketplace?"
+- "How do I install a plugin from a marketplace?"
 
 I will guide you through the process and ensure your configuration is valid.

--- a/packages/agent-sdk/src/managers/hookManager.ts
+++ b/packages/agent-sdk/src/managers/hookManager.ts
@@ -908,10 +908,10 @@ export class HookManager {
         // Try to parse as JSON for structured output
         try {
           const parsed = JSON.parse(trimmed);
-          if (parsed.additionalContext) {
+          if (parsed.hookSpecificOutput?.additionalContext) {
             additionalContext =
               (additionalContext ? additionalContext + "\n" : "") +
-              parsed.additionalContext;
+              parsed.hookSpecificOutput.additionalContext;
           }
           if (parsed.initialUserMessage) {
             initialUserMessage = parsed.initialUserMessage;

--- a/packages/agent-sdk/tests/managers/hookManager.coverage.test.ts
+++ b/packages/agent-sdk/tests/managers/hookManager.coverage.test.ts
@@ -663,7 +663,8 @@ describe("HookManager Coverage", () => {
         duration: 100,
         timedOut: false,
         exitCode: 0,
-        stdout: '{"additionalContext": "Extra context here"}',
+        stdout:
+          '{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "Extra context here"}}',
         stderr: "",
       });
       manager.loadConfiguration({
@@ -678,6 +679,30 @@ describe("HookManager Coverage", () => {
       );
       expect(result.additionalContext).toBe("Extra context here");
       expect(result.initialUserMessage).toBeUndefined();
+    });
+
+    it("should treat top-level additionalContext as plain text (no parsing)", async () => {
+      mockExecuteCommand.mockResolvedValue({
+        success: true,
+        duration: 100,
+        timedOut: false,
+        exitCode: 0,
+        stdout: '{"additionalContext": "SDK format context"}',
+        stderr: "",
+      });
+      manager.loadConfiguration({
+        SessionStart: [
+          { hooks: [{ type: "command" as const, command: "echo json" }] },
+        ],
+      });
+      const result = await manager.executeSessionStartHooks(
+        "startup",
+        "session-123",
+        "/path/to/transcript.json",
+      );
+      // Top-level additionalContext is now ignored (Claude Code format only)
+      // Since it parses as JSON but has no hookSpecificOutput, result is undefined
+      expect(result.additionalContext).toBeUndefined();
     });
 
     it("should parse JSON stdout for initialUserMessage", async () => {
@@ -736,7 +761,8 @@ describe("HookManager Coverage", () => {
             duration: 100,
             timedOut: false,
             exitCode: 0,
-            stdout: '{"additionalContext": "Context from hook 1"}',
+            stdout:
+              '{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "Context from hook 1"}}',
             stderr: "",
           };
         }
@@ -745,7 +771,8 @@ describe("HookManager Coverage", () => {
           duration: 100,
           timedOut: false,
           exitCode: 0,
-          stdout: '{"additionalContext": "Context from hook 2"}',
+          stdout:
+            '{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "Context from hook 2"}}',
           stderr: "",
         };
       });
@@ -776,7 +803,10 @@ describe("HookManager Coverage", () => {
         timedOut: false,
         exitCode: 0,
         stdout: JSON.stringify({
-          additionalContext: "Project rules context",
+          hookSpecificOutput: {
+            hookEventName: "SessionStart",
+            additionalContext: "Project rules context",
+          },
           initialUserMessage: "Start with a plan",
         }),
         stderr: "",
@@ -805,7 +835,8 @@ describe("HookManager Coverage", () => {
             duration: 100,
             timedOut: false,
             exitCode: 1,
-            stdout: '{"additionalContext": "Should be ignored"}',
+            stdout:
+              '{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "Should be ignored"}}',
             stderr: "Hook failed",
           };
         }
@@ -814,7 +845,8 @@ describe("HookManager Coverage", () => {
           duration: 100,
           timedOut: false,
           exitCode: 0,
-          stdout: '{"additionalContext": "Valid context"}',
+          stdout:
+            '{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "Valid context"}}',
           stderr: "",
         };
       });
@@ -846,7 +878,8 @@ describe("HookManager Coverage", () => {
             duration: 100,
             timedOut: false,
             exitCode: 0,
-            stdout: '{"additionalContext": "JSON context"}',
+            stdout:
+              '{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "JSON context"}}',
             stderr: "",
           };
         }
@@ -865,7 +898,8 @@ describe("HookManager Coverage", () => {
           duration: 100,
           timedOut: false,
           exitCode: 0,
-          stdout: '{"additionalContext": "More JSON"}',
+          stdout:
+            '{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "More JSON"}}',
           stderr: "",
         };
       });


### PR DESCRIPTION
## Changes

This PR includes two commits:

### 1. refactor: use Claude Code hookSpecificOutput format for SessionStart hooks

Match Claude Code's hook stdout format by reading additionalContext from hookSpecificOutput instead of top-level, ensuring cross-plugin compatibility with Claude Code plugins.

- Updated hookManager.ts to parse hookSpecificOutput.additionalContext
- Updated HOOKS.md documentation with new format examples
- Updated tests to use hookSpecificOutput format

### 2. docs: add plugin and marketplace guidance to settings skill

Create dedicated PLUGINS.md with comprehensive docs for creating plugins and marketplaces, and update SKILL.md to reference it.

- New PLUGINS.md covering plugin creation, manifest format, marketplace setup, and installation
- Updated SKILL.md plugins section to link to PLUGINS.md
- Added plugin-related examples to 'How to use this skill' section