### PR TITLE
fix: preserve plugin hooks after loading Wave config

### DIFF
--- a/packages/agent-sdk/examples/verify-superpowers-hooks.ts
+++ b/packages/agent-sdk/examples/verify-superpowers-hooks.ts
@@ -172,11 +172,34 @@ async function main() {
     );
   }
 
+  // Step 6: Verify InitializationService pipeline - inject as meta user messages
+  console.log(
+    "\n📬 Verifying InitializationService message injection pipeline...",
+  );
+
+  // Simulate what InitializationService.initialize() does at lines 191-204
+  if (sessionStartResult.additionalContext) {
+    messageManager.addUserMessage({
+      content: `<system-reminder>\nSessionStart hook additional context: ${sessionStartResult.additionalContext}\n</system-reminder>`,
+      isMeta: true,
+    });
+    console.log("   ✅ additionalContext injected as meta user message");
+  }
+
+  if (sessionStartResult.initialUserMessage) {
+    messageManager.addUserMessage({
+      content: sessionStartResult.initialUserMessage,
+      isMeta: true,
+    });
+    console.log("   ✅ initialUserMessage injected as meta user message");
+  }
+
   // Final summary
   console.log("\n" + "=".repeat(50));
   const allSuccess = sessionStartResult.results.every((r) => r.success);
   if (allSuccess && sessionStartResult.additionalContext) {
     console.log("✅ All superpowers hooks verified successfully!");
+    console.log("✅ Message injection pipeline verified!");
     process.exit(0);
   } else if (allSuccess) {
     console.log("⚠️  Hooks executed but no additionalContext produced");

--- a/packages/agent-sdk/src/managers/hookManager.ts
+++ b/packages/agent-sdk/src/managers/hookManager.ts
@@ -81,9 +81,8 @@ export class HookManager {
    */
   loadConfigurationFromWaveConfig(waveConfig: WaveConfiguration | null): void {
     try {
-      this.configuration = waveConfig?.hooks || undefined;
-
-      // Validate the loaded configuration if it exists
+      // Merge Wave configuration hooks with existing plugin hooks
+      // (plugin hooks were registered earlier via registerPluginHooks)
       if (waveConfig?.hooks) {
         const validation = this.validatePartialConfiguration(waveConfig.hooks);
         if (!validation.valid) {
@@ -92,17 +91,18 @@ export class HookManager {
             validation.errors,
           );
         }
+        if (!this.configuration) {
+          this.configuration = {};
+        }
+        this.mergeHooksConfiguration(this.configuration, waveConfig.hooks);
       }
     } catch (error) {
-      // If loading fails, start with undefined configuration (no hooks)
-      this.configuration = undefined;
-
       // Re-throw configuration errors, but handle other errors gracefully
       if (error instanceof HookConfigurationError) {
         throw error;
       } else {
         logger?.warn(
-          `[HookManager] Failed to load configuration, continuing with no hooks: ${(error as Error).message}`,
+          `[HookManager] Failed to load configuration, continuing with existing hooks: ${(error as Error).message}`,
         );
       }
     }

--- a/packages/agent-sdk/tests/managers/hookManager.test.ts
+++ b/packages/agent-sdk/tests/managers/hookManager.test.ts
@@ -271,4 +271,100 @@ describe("HookManager", () => {
       expect(manager.getConfiguration()).toBeUndefined();
     });
   });
+
+  describe("Plugin Hooks Preservation", () => {
+    it("should preserve plugin hooks when Wave config has no hooks", () => {
+      const pluginHooks = {
+        SessionStart: [
+          {
+            hooks: [
+              { type: "command" as const, command: "plugin-session-start" },
+            ],
+          },
+        ],
+      };
+
+      manager.registerPluginHooks("/plugin/root", pluginHooks);
+      expect(manager.hasHooks("SessionStart")).toBe(true);
+
+      // Wave config with no hooks key (like settings.local.json with only permissions/enabledPlugins)
+      manager.loadConfigurationFromWaveConfig({});
+
+      // Plugin hooks should still be present (regression: was being wiped out)
+      expect(manager.hasHooks("SessionStart")).toBe(true);
+    });
+
+    it("should preserve plugin hooks when Wave config is null", () => {
+      const pluginHooks = {
+        SessionStart: [
+          {
+            hooks: [
+              { type: "command" as const, command: "plugin-session-start" },
+            ],
+          },
+        ],
+      };
+
+      manager.registerPluginHooks("/plugin/root", pluginHooks);
+      manager.loadConfigurationFromWaveConfig(null);
+
+      expect(manager.hasHooks("SessionStart")).toBe(true);
+    });
+
+    it("should merge Wave config hooks with existing plugin hooks", () => {
+      const pluginHooks = {
+        SessionStart: [
+          {
+            hooks: [{ type: "command" as const, command: "plugin-hook" }],
+          },
+        ],
+      };
+      manager.registerPluginHooks("/plugin/root", pluginHooks);
+
+      const waveConfig: WaveConfiguration = {
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: "Edit",
+              hooks: [{ type: "command", command: "wave-hook" }],
+            },
+          ],
+        },
+      };
+      manager.loadConfigurationFromWaveConfig(waveConfig);
+
+      // Both plugin and Wave hooks should be present
+      expect(manager.hasHooks("SessionStart")).toBe(true);
+      expect(manager.hasHooks("PostToolUse", "Edit")).toBe(true);
+    });
+
+    it("should allow Wave config hooks to override plugin hooks for same event", () => {
+      const pluginHooks = {
+        PostToolUse: [
+          {
+            matcher: "Read",
+            hooks: [{ type: "command" as const, command: "plugin-read-hook" }],
+          },
+        ],
+      };
+      manager.registerPluginHooks("/plugin/root", pluginHooks);
+
+      const waveConfig: WaveConfiguration = {
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: "Edit",
+              hooks: [{ type: "command", command: "wave-edit-hook" }],
+            },
+          ],
+        },
+      };
+      manager.loadConfigurationFromWaveConfig(waveConfig);
+
+      // Wave config replaces plugin hooks for same event (per merge design)
+      const config = manager.getConfiguration();
+      expect(config?.PostToolUse).toHaveLength(1);
+      expect(config?.PostToolUse?.[0].hooks[0].command).toBe("wave-edit-hook");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixed a bug where `HookManager.loadConfigurationFromWaveConfig()` was replacing the entire configuration, wiping out plugin hooks registered via `registerPluginHooks()`.

When `settings.local.json` has no 'hooks' key (only `permissions` and `enabledPlugins`), plugin SessionStart hooks (e.g., superpowers) were completely lost.

## Root Cause

`loadConfigurationFromWaveConfig` did:
```ts
this.configuration = waveConfig?.hooks || undefined;
```

This replaced all existing configuration, including plugin hooks that were registered earlier during `InitializationService.initialize()`.

## Fix

Changed to **merge** Wave config hooks with existing plugin hooks instead of replacing:
- If Wave config has hooks, merge them into the existing configuration
- If Wave config has no hooks key, preserve existing plugin hooks unchanged

## Changes

- **packages/agent-sdk/src/managers/hookManager.ts**: Changed `loadConfigurationFromWaveConfig` to merge instead of replace
- **packages/agent-sdk/tests/managers/hookManager.test.ts**: Added 4 test cases for plugin hooks preservation
- **packages/agent-sdk/examples/verify-superpowers-hooks.ts**: Updated to test the message injection pipeline