### PR TITLE
feat: add WAVE_PLUGIN_ROOT support for plugin agent .md files

### DIFF
--- a/packages/agent-sdk/builtin/skills/settings/SKILL.md
+++ b/packages/agent-sdk/builtin/skills/settings/SKILL.md
@@ -93,7 +93,7 @@ For detailed guidance on creating subagents, see [SUBAGENTS.md](${WAVE_SKILL_DIR
 
 ### 9. Plugins
 
-Plugins bundle skills, hooks, MCP servers, LSP servers, and commands into a reusable package. You can install plugins locally or from a marketplace.
+Plugins bundle skills, hooks, MCP servers, LSP servers, commands, and subagents into a reusable package. You can install plugins locally or from a marketplace.
 For detailed guidance on creating plugins and marketplaces, see [PLUGINS.md](${WAVE_SKILL_DIR}/PLUGINS.md).
 
 ### 10. Other Settings

--- a/packages/agent-sdk/builtin/skills/settings/SUBAGENTS.md
+++ b/packages/agent-sdk/builtin/skills/settings/SUBAGENTS.md
@@ -39,12 +39,31 @@ You are a specialized subagent for a specific task. Your goal is to:
 
 ## Subagent Locations
 
-Wave looks for subagents in two locations:
+Wave looks for subagents in three locations:
 
 1.  **User Subagents**: `~/.wave/agents/` (Available in all projects)
 2.  **Project Subagents**: `.wave/agents/` (Specific to the current project)
+3.  **Plugin Agents**: `agents/` within an installed plugin directory (Scoped to the plugin)
 
-Project subagents take precedence over user subagents with the same name.
+Project subagents take precedence over user subagents with the same name. Plugin agents are namespaced with the plugin name (e.g., `pluginName:agentName`) to avoid collisions.
+
+## Plugin Agents
+
+Plugins can define their own subagents in an `agents/` directory within the plugin. These agents can reference their parent plugin's directory using the `${WAVE_PLUGIN_ROOT}` template variable, which is substituted at load time.
+
+For example, a plugin at `/path/to/my-plugin/` with `agents/researcher.md`:
+
+```markdown
+---
+name: researcher
+description: A research agent that uses the plugin's knowledge base
+tools: ["Read", "Glob"]
+---
+
+You are a research assistant. Access plugin resources at ${WAVE_PLUGIN_ROOT}/data.
+```
+
+After loading, `${WAVE_PLUGIN_ROOT}` is replaced with `/path/to/my-plugin/`, and the agent is registered as `my-plugin:researcher`.
 
 ## Delegating to Subagents
 

--- a/packages/agent-sdk/examples/plugin-agent-demo.ts
+++ b/packages/agent-sdk/examples/plugin-agent-demo.ts
@@ -1,0 +1,155 @@
+/**
+ * Verifies that plugin agents are loaded correctly and ${WAVE_PLUGIN_ROOT}
+ * is substituted in agent system prompts.
+ */
+import { PluginManager } from "../src/managers/pluginManager.js";
+import { SkillManager } from "../src/managers/skillManager.js";
+import { HookManager } from "../src/managers/hookManager.js";
+import { LspManager } from "../src/managers/lspManager.js";
+import { McpManager } from "../src/managers/mcpManager.js";
+import { SlashCommandManager } from "../src/managers/slashCommandManager.js";
+import { SubagentManager } from "../src/managers/subagentManager.js";
+import { TaskManager } from "../src/services/taskManager.js";
+import { MessageManager } from "../src/managers/messageManager.js";
+import { AIManager } from "../src/managers/aiManager.js";
+import { HookMatcher } from "../src/utils/hookMatcher.js";
+import { BackgroundTaskManager } from "../src/managers/backgroundTaskManager.js";
+import { NotificationQueue } from "../src/managers/notificationQueue.js";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { Container } from "../src/utils/container.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pluginDir = path.resolve(__dirname, "plugin-agent-demo");
+const workdir = path.resolve(__dirname);
+
+async function verify() {
+  const container = new Container();
+
+  const skillManager = new SkillManager(container, { workdir });
+  const hookManager = new HookManager(container, workdir, new HookMatcher());
+  const lspManager = new LspManager(container);
+  const mcpManager = new McpManager(container);
+  const subagentManager = new SubagentManager(container, {
+    workdir,
+    stream: false,
+  });
+
+  // Initialize SubagentManager to load and cache configurations
+  await subagentManager.initialize();
+
+  const messageManager = {
+    addUserMessage: console.log,
+    addErrorBlock: console.error,
+    clearMessages: () => {},
+    triggerSlashCommandsChange: () => {},
+  } as unknown as MessageManager;
+  const aiManager = {
+    sendAIMessage: async () => {},
+    abortAIMessage: () => {},
+  } as unknown as AIManager;
+  const backgroundTaskManager = {
+    getAllTasks: () => [],
+  } as unknown as BackgroundTaskManager;
+  const taskManager = new TaskManager(container, "test-task-list");
+  const notificationQueue = new NotificationQueue();
+
+  container.register("MessageManager", messageManager);
+  container.register("AIManager", aiManager);
+  container.register("BackgroundTaskManager", backgroundTaskManager);
+  container.register("TaskManager", taskManager);
+  container.register("SkillManager", skillManager);
+  container.register("HookManager", hookManager);
+  container.register("LspManager", lspManager);
+  container.register("McpManager", mcpManager);
+  container.register("SubagentManager", subagentManager);
+  container.register("NotificationQueue", notificationQueue);
+
+  const slashCommandManager = new SlashCommandManager(container, {
+    workdir,
+  });
+  container.register("SlashCommandManager", slashCommandManager);
+
+  const pluginManager = new PluginManager(container, {
+    workdir,
+  });
+
+  console.log("Loading plugin-agent-demo plugin...");
+  await pluginManager.loadPlugins([{ type: "local", path: pluginDir }]);
+
+  const plugins = pluginManager.getPlugins();
+  console.log(`Loaded ${plugins.length} plugins`);
+
+  if (plugins.length === 0) {
+    throw new Error("Failed to load plugin");
+  }
+
+  const plugin = plugins[0];
+  console.log(`Plugin: ${plugin.name}`);
+  console.log(`- Agents: ${plugin.agents.length}`);
+
+  if (plugin.agents.length === 0) {
+    throw new Error("Plugin agents not loaded");
+  }
+
+  // Verify agent was loaded from the agents/ directory
+  const researcher = plugin.agents.find((a) => a.name === "researcher");
+  if (!researcher) {
+    throw new Error("researcher agent not found");
+  }
+  console.log(`- Agent name: ${researcher.name}`);
+  console.log(`- Agent scope: ${researcher.scope}`);
+  console.log(`- Agent pluginRoot: ${researcher.pluginRoot}`);
+
+  // Verify ${WAVE_PLUGIN_ROOT} was substituted at parse time
+  if (researcher.systemPrompt.includes("${WAVE_PLUGIN_ROOT}")) {
+    throw new Error(
+      "WAVE_PLUGIN_ROOT was not substituted in agent systemPrompt",
+    );
+  }
+  const expectedPath = plugin.path + "/data";
+  if (!researcher.systemPrompt.includes(expectedPath)) {
+    throw new Error(
+      `Expected systemPrompt to contain "${expectedPath}" but got: ${researcher.systemPrompt}`,
+    );
+  }
+  console.log(`- System prompt contains correct path: ${expectedPath}`);
+
+  // Verify agent is registered in SubagentManager with namespaced name
+  const configs = subagentManager.getConfigurations();
+  const namespacedAgent = configs.find(
+    (c) => c.name === "plugin-agent-demo:researcher",
+  );
+  if (!namespacedAgent) {
+    throw new Error("Plugin agent not found in SubagentManager configurations");
+  }
+  console.log(
+    `✅ SubagentManager has namespaced agent: ${namespacedAgent.name}`,
+  );
+
+  // Verify WAVE_PLUGIN_ROOT substitution safety net in SubagentManager
+  if (namespacedAgent.systemPrompt.includes("${WAVE_PLUGIN_ROOT}")) {
+    throw new Error("WAVE_PLUGIN_ROOT not substituted in SubagentManager");
+  }
+  console.log(`✅ WAVE_PLUGIN_ROOT correctly substituted in SubagentManager`);
+
+  // Verify findSubagent can find the plugin agent
+  const found = await subagentManager.findSubagent(
+    "plugin-agent-demo:researcher",
+  );
+  if (!found) {
+    throw new Error("findSubagent could not find plugin agent");
+  }
+  console.log(`✅ findSubagent found: ${found.name}`);
+
+  console.log("\nAll verifications passed!");
+}
+
+verify()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error("Verification failed:", err);
+    process.exit(1);
+  });

--- a/packages/agent-sdk/examples/plugin-agent-demo/.wave-plugin/plugin.json
+++ b/packages/agent-sdk/examples/plugin-agent-demo/.wave-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "plugin-agent-demo",
+  "description": "Demo plugin with agent definitions using WAVE_PLUGIN_ROOT",
+  "version": "1.0.0",
+  "author": {
+    "name": "wave-agent"
+  }
+}

--- a/packages/agent-sdk/examples/plugin-agent-demo/agents/researcher.md
+++ b/packages/agent-sdk/examples/plugin-agent-demo/agents/researcher.md
@@ -1,0 +1,7 @@
+---
+name: researcher
+description: A research agent that reads files from the plugin directory
+tools: ["Read", "Glob"]
+---
+
+You are a research assistant. You can access plugin resources at ${WAVE_PLUGIN_ROOT}/data.

--- a/packages/agent-sdk/src/managers/pluginManager.ts
+++ b/packages/agent-sdk/src/managers/pluginManager.ts
@@ -7,6 +7,7 @@ import { HookManager } from "./hookManager.js";
 import { LspManager } from "./lspManager.js";
 import { McpManager } from "./mcpManager.js";
 import { SlashCommandManager } from "./slashCommandManager.js";
+import { SubagentManager } from "./subagentManager.js";
 import { MarketplaceService } from "../services/MarketplaceService.js";
 import { ConfigurationService } from "../services/configurationService.js";
 import { Container } from "../utils/container.js";
@@ -51,6 +52,10 @@ export class PluginManager {
 
   private get configurationService(): ConfigurationService | undefined {
     return this.container.get<ConfigurationService>("ConfigurationService");
+  }
+
+  private get subagentManager(): SubagentManager | undefined {
+    return this.container.get<SubagentManager>("SubagentManager");
   }
 
   /**
@@ -155,6 +160,7 @@ export class PluginManager {
         path: absolutePath,
         commands: PluginLoader.loadCommands(absolutePath),
         skills: await PluginLoader.loadSkills(absolutePath),
+        agents: await PluginLoader.loadAgents(absolutePath),
         lspConfig: await PluginLoader.loadLspConfig(absolutePath),
         mcpConfig: await PluginLoader.loadMcpConfig(absolutePath),
         hooksConfig: await PluginLoader.loadHooksConfig(absolutePath),
@@ -190,6 +196,10 @@ export class PluginManager {
 
       if (this.hookManager && plugin.hooksConfig) {
         this.hookManager.registerPluginHooks(plugin.path, plugin.hooksConfig);
+      }
+
+      if (this.subagentManager && plugin.agents.length > 0) {
+        this.subagentManager.registerPluginAgents(plugin.name, plugin.agents);
       }
 
       this.plugins.set(manifest.name, plugin);

--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -187,8 +187,55 @@ export class SubagentManager {
    * Find subagent by exact name match
    */
   async findSubagent(name: string) {
+    // Check cached configurations first (includes plugin agents)
+    if (this.cachedConfigurations !== null) {
+      const cached = this.cachedConfigurations.find(
+        (config) => config.name === name,
+      );
+      if (cached) return cached;
+    }
+    // Fall back to filesystem scan for non-plugin agents
     const { findSubagentByName } = await import("../utils/subagentParser.js");
     return findSubagentByName(name, this.workdir);
+  }
+
+  /**
+   * Register plugin agents into the cached configurations.
+   * Names each agent as `pluginName:agentName` to avoid collisions.
+   */
+  registerPluginAgents(
+    pluginName: string,
+    agents: SubagentConfiguration[],
+  ): void {
+    if (this.cachedConfigurations === null) {
+      // Should not happen if initialization order is correct
+      this.cachedConfigurations = [];
+    }
+
+    // Remove any previously registered agents for this plugin (by name prefix)
+    this.cachedConfigurations = this.cachedConfigurations.filter(
+      (config) => !config.name.startsWith(`${pluginName}:`),
+    );
+
+    for (const agent of agents) {
+      const namespacedName = `${pluginName}:${agent.name}`;
+      const namespacedAgent: SubagentConfiguration = {
+        ...agent,
+        name: namespacedName,
+        // Safety net: substitute any remaining ${WAVE_PLUGIN_ROOT} placeholders
+        systemPrompt: agent.systemPrompt.replace(
+          /\$\{WAVE_PLUGIN_ROOT\}/g,
+          agent.pluginRoot ?? "",
+        ),
+      };
+      this.cachedConfigurations!.push(namespacedAgent);
+    }
+
+    // Re-sort by priority then name
+    this.cachedConfigurations!.sort((a, b) => {
+      if (a.priority !== b.priority) return a.priority - b.priority;
+      return a.name.localeCompare(b.name);
+    });
   }
 
   /**

--- a/packages/agent-sdk/src/services/pluginLoader.ts
+++ b/packages/agent-sdk/src/services/pluginLoader.ts
@@ -10,7 +10,12 @@ import {
 } from "../types/index.js";
 import { scanCommandsDirectory } from "../utils/customCommands.js";
 import { parseSkillFile } from "../utils/skillParser.js";
+import {
+  parseAgentFile,
+  type SubagentConfiguration,
+} from "../utils/subagentParser.js";
 import { resolveMcpConfig } from "../managers/mcpManager.js";
+import { logger } from "../utils/globalLogger.js";
 
 export class PluginLoader {
   /**
@@ -163,6 +168,38 @@ export class PluginLoader {
     } catch {
       return undefined;
     }
+  }
+
+  /**
+   * Load agent configurations from a plugin's agents directory
+   */
+  static async loadAgents(
+    pluginPath: string,
+  ): Promise<SubagentConfiguration[]> {
+    const agentsPath = path.join(pluginPath, "agents");
+    const agents: SubagentConfiguration[] = [];
+
+    try {
+      const entries = await fs.readdir(agentsPath, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isFile() && entry.name.endsWith(".md")) {
+          const agentFilePath = path.join(agentsPath, entry.name);
+          try {
+            const config = parseAgentFile(agentFilePath, "plugin", pluginPath);
+            agents.push(config);
+          } catch (parseError) {
+            // Log error but continue with other files
+            logger?.warn(
+              `Warning: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
+            );
+          }
+        }
+      }
+    } catch {
+      // agents directory might not exist
+    }
+
+    return agents;
   }
 
   /**

--- a/packages/agent-sdk/src/types/plugins.ts
+++ b/packages/agent-sdk/src/types/plugins.ts
@@ -3,6 +3,7 @@ import { Skill } from "./skills.js";
 import { LspConfig } from "./lsp.js";
 import { McpConfig } from "./mcp.js";
 import { PartialHookConfiguration } from "./configuration.js";
+import { SubagentConfiguration } from "../utils/subagentParser.js";
 
 /**
  * Plugin manifest structure (.wave-plugin/plugin.json)
@@ -31,6 +32,7 @@ export interface Plugin extends PluginManifest {
   path: string;
   commands: CustomSlashCommand[];
   skills: Skill[];
+  agents: SubagentConfiguration[];
   lspConfig?: LspConfig;
   mcpConfig?: McpConfig;
   hooksConfig?: PartialHookConfiguration;

--- a/packages/agent-sdk/src/utils/subagentParser.ts
+++ b/packages/agent-sdk/src/utils/subagentParser.ts
@@ -10,8 +10,10 @@ export interface SubagentConfiguration {
   model?: string;
   systemPrompt: string;
   filePath: string;
-  scope: "project" | "user" | "builtin";
+  scope: "project" | "user" | "builtin" | "plugin";
   priority: number;
+  /** Plugin root directory path, set when scope is "plugin" */
+  pluginRoot?: string;
 }
 
 interface SubagentFrontmatter {
@@ -119,11 +121,12 @@ function validateConfiguration(
 }
 
 /**
- * Parse a single subagent markdown file
+ * Parse a single subagent markdown file with optional pluginRoot support
  */
 function parseSubagentFile(
   filePath: string,
-  scope: "project" | "user" | "builtin",
+  scope: "project" | "user" | "builtin" | "plugin",
+  pluginRoot?: string,
 ): SubagentConfiguration {
   try {
     const content = readFileSync(filePath, "utf-8");
@@ -143,22 +146,46 @@ function parseSubagentFile(
     let priority = 1;
     if (scope === "user") priority = 2;
     if (scope === "builtin") priority = 3;
+    if (scope === "plugin") priority = 2; // Same priority as user-level
+
+    let systemPrompt = body;
+
+    // Substitute ${WAVE_PLUGIN_ROOT} for plugin scope at parse time
+    if (scope === "plugin" && pluginRoot) {
+      systemPrompt = systemPrompt.replace(
+        /\$\{WAVE_PLUGIN_ROOT\}/g,
+        pluginRoot,
+      );
+    }
 
     return {
       name: frontmatter.name!,
       description: frontmatter.description!,
       tools: frontmatter.tools,
       model: frontmatter.model,
-      systemPrompt: body,
+      systemPrompt,
       filePath,
       scope,
       priority,
+      pluginRoot: scope === "plugin" ? pluginRoot : undefined,
     };
   } catch (error) {
     throw new Error(
       `Failed to parse subagent file ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
+}
+
+/**
+ * Parse a plugin agent markdown file.
+ * Exposed as a public API for PluginLoader to use.
+ */
+export function parseAgentFile(
+  filePath: string,
+  scope: "plugin",
+  pluginRoot: string,
+): SubagentConfiguration {
+  return parseSubagentFile(filePath, scope, pluginRoot);
 }
 
 /**

--- a/packages/agent-sdk/tests/agent/agent.subagentMessagesCallback.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.subagentMessagesCallback.test.ts
@@ -8,17 +8,19 @@ import { Agent } from "@/agent.js";
 import type { AgentCallbacks } from "@/types/index.js";
 import type { SubagentConfiguration } from "@/utils/subagentParser.js";
 
-// Mock subagent configurations
-const mockSubagentConfig: SubagentConfiguration = {
-  name: "test-subagent",
-  description: "A test subagent",
-  systemPrompt: "You are a test subagent",
-  tools: ["Read", "Write"],
-  model: "inherit",
-  filePath: "/tmp/test-subagent.md",
-  scope: "project",
-  priority: 1,
-};
+// Mock subagent configurations - hoisted to top for vi.mock usage
+const { mockSubagentConfig } = vi.hoisted(() => ({
+  mockSubagentConfig: {
+    name: "test-subagent",
+    description: "A test subagent",
+    systemPrompt: "You are a test subagent",
+    tools: ["Read", "Write"],
+    model: "inherit",
+    filePath: "/tmp/test-subagent.md",
+    scope: "project",
+    priority: 1,
+  } as SubagentConfiguration,
+}));
 
 // Mock AI Service - we'll mock this to control subagent responses
 vi.mock("@/services/aiService", () => ({

--- a/packages/agent-sdk/tests/managers/cronManager.test.ts
+++ b/packages/agent-sdk/tests/managers/cronManager.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CronManager } from "@/managers/cronManager.js";
+import { Container } from "@/utils/container.js";
+import type { AIManager } from "@/managers/aiManager.js";
+import type { MessageManager } from "@/managers/messageManager.js";
+
+describe("CronManager", () => {
+  let container: Container;
+  let cronManager: CronManager;
+  let mockAiManager: Partial<AIManager>;
+  let mockMessageManager: Partial<MessageManager>;
+
+  beforeEach(() => {
+    container = new Container();
+    mockAiManager = {
+      isLoading: false,
+      sendAIMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    mockMessageManager = {
+      addUserMessage: vi.fn(),
+    };
+    container.register("AIManager", mockAiManager as AIManager);
+    container.register("MessageManager", mockMessageManager as MessageManager);
+    cronManager = new CronManager(container);
+  });
+
+  afterEach(() => {
+    cronManager.stop();
+  });
+
+  describe("createJob", () => {
+    it("creates a one-shot job", () => {
+      const job = cronManager.createJob({
+        cron: "0 12 * * *",
+        prompt: "test prompt",
+        recurring: false,
+      });
+
+      expect(job.id).toBeDefined();
+      expect(job.cron).toBe("0 12 * * *");
+      expect(job.prompt).toBe("test prompt");
+      expect(job.recurring).toBe(false);
+      expect(job.createdAt).toBeDefined();
+      expect(job.nextRun).toBeDefined();
+      expect(job.periodMs).toBe(24 * 60 * 60 * 1000);
+    });
+
+    it("creates a recurring job", () => {
+      const job = cronManager.createJob({
+        cron: "* * * * *",
+        prompt: "recurring prompt",
+        recurring: true,
+      });
+
+      expect(job.recurring).toBe(true);
+      expect(job.periodMs).toBe(60 * 1000);
+    });
+  });
+
+  describe("deleteJob", () => {
+    it("deletes an existing job", () => {
+      const job = cronManager.createJob({
+        cron: "0 12 * * *",
+        prompt: "test",
+        recurring: false,
+      });
+
+      const result = cronManager.deleteJob(job.id);
+      expect(result).toBe(true);
+      expect(cronManager.listJobs()).toHaveLength(0);
+    });
+
+    it("returns false for non-existent job", () => {
+      const result = cronManager.deleteJob("nonexistent");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("listJobs", () => {
+    it("returns all jobs", () => {
+      cronManager.createJob({
+        cron: "0 12 * * *",
+        prompt: "job1",
+        recurring: false,
+      });
+      cronManager.createJob({
+        cron: "0 13 * * *",
+        prompt: "job2",
+        recurring: false,
+      });
+
+      expect(cronManager.listJobs()).toHaveLength(2);
+    });
+
+    it("returns empty array when no jobs", () => {
+      expect(cronManager.listJobs()).toHaveLength(0);
+    });
+  });
+
+  describe("start/stop", () => {
+    it("starts the interval", () => {
+      cronManager.start();
+      cronManager.start();
+    });
+
+    it("stops the interval", () => {
+      cronManager.start();
+      cronManager.stop();
+      cronManager.stop();
+    });
+  });
+});

--- a/packages/agent-sdk/tests/managers/subagentManager.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.test.ts
@@ -215,3 +215,160 @@ describe("SubagentManager background notification deduplication", () => {
     expect(killedNotifications.length).toBe(0);
   });
 });
+
+describe("SubagentManager registerPluginAgents", () => {
+  let container: Container;
+  let subagentManager: SubagentManager;
+
+  beforeEach(() => {
+    container = new Container();
+
+    const mockBackgroundTaskManager: Partial<BackgroundTaskManager> = {
+      generateId: vi.fn().mockReturnValue("task_1"),
+    };
+    container.register(
+      "BackgroundTaskManager",
+      mockBackgroundTaskManager as unknown as BackgroundTaskManager,
+    );
+
+    subagentManager = new SubagentManager(container, {
+      workdir: "/tmp/test",
+      stream: false,
+    });
+  });
+
+  it("should namespace agent names with pluginName:agentName", async () => {
+    await subagentManager.loadConfigurations();
+    subagentManager.registerPluginAgents("my-plugin", [
+      {
+        name: "test-agent",
+        description: "Test Agent",
+        systemPrompt: "You are a test agent",
+        filePath: "/plugin/agents/test-agent.md",
+        scope: "plugin",
+        priority: 2,
+        pluginRoot: "/plugin",
+      },
+    ]);
+
+    const configs = subagentManager.getConfigurations();
+    const pluginAgent = configs.find((c) => c.name.includes("my-plugin"));
+    expect(pluginAgent).toBeDefined();
+    expect(pluginAgent!.name).toBe("my-plugin:test-agent");
+  });
+
+  it("should substitute WAVE_PLUGIN_ROOT in systemPrompt as safety net", () => {
+    subagentManager.registerPluginAgents("my-plugin", [
+      {
+        name: "test-agent",
+        description: "Test Agent",
+        systemPrompt: "Read files from ${WAVE_PLUGIN_ROOT}/data",
+        filePath: "/plugin/agents/test-agent.md",
+        scope: "plugin",
+        priority: 2,
+        pluginRoot: "/plugin",
+      },
+    ]);
+
+    const configs = subagentManager.getConfigurations();
+    const pluginAgent = configs.find((c) => c.name === "my-plugin:test-agent");
+    expect(pluginAgent).toBeDefined();
+    expect(pluginAgent!.systemPrompt).toBe("Read files from /plugin/data");
+  });
+
+  it("should handle agents without WAVE_PLUGIN_ROOT in systemPrompt", () => {
+    subagentManager.registerPluginAgents("my-plugin", [
+      {
+        name: "test-agent",
+        description: "Test Agent",
+        systemPrompt: "You are a test agent",
+        filePath: "/plugin/agents/test-agent.md",
+        scope: "plugin",
+        priority: 2,
+      },
+    ]);
+
+    const configs = subagentManager.getConfigurations();
+    const pluginAgent = configs.find((c) => c.name === "my-plugin:test-agent");
+    expect(pluginAgent).toBeDefined();
+    expect(pluginAgent!.systemPrompt).toBe("You are a test agent");
+  });
+
+  it("should re-register agents with updated content on duplicate plugin registration", async () => {
+    await subagentManager.loadConfigurations();
+
+    subagentManager.registerPluginAgents("my-plugin", [
+      {
+        name: "test-agent",
+        description: "Test Agent v1",
+        systemPrompt: "v1 prompt",
+        filePath: "/plugin/agents/test-agent.md",
+        scope: "plugin",
+        priority: 2,
+        pluginRoot: "/plugin",
+      },
+    ]);
+
+    const firstConfigs = subagentManager.getConfigurations();
+    const firstAgent = firstConfigs.find(
+      (c) => c.name === "my-plugin:test-agent",
+    );
+    expect(firstAgent!.description).toBe("Test Agent v1");
+
+    // Re-register with updated content
+    subagentManager.registerPluginAgents("my-plugin", [
+      {
+        name: "test-agent",
+        description: "Test Agent v2",
+        systemPrompt: "v2 prompt",
+        filePath: "/plugin/agents/test-agent.md",
+        scope: "plugin",
+        priority: 2,
+        pluginRoot: "/plugin",
+      },
+    ]);
+
+    const secondConfigs = subagentManager.getConfigurations();
+    const secondAgent = secondConfigs.find(
+      (c) => c.name === "my-plugin:test-agent",
+    );
+    expect(secondAgent!.description).toBe("Test Agent v2");
+    expect(
+      secondConfigs.filter((c) => c.name === "my-plugin:test-agent"),
+    ).toHaveLength(1);
+  });
+
+  it("should sort configurations by priority then name after registration", async () => {
+    await subagentManager.loadConfigurations();
+
+    subagentManager.registerPluginAgents("plugin-a", [
+      {
+        name: "agent-z",
+        description: "Agent Z",
+        systemPrompt: "Prompt",
+        filePath: "/plugin-a/agents/agent-z.md",
+        scope: "plugin",
+        priority: 2,
+        pluginRoot: "/plugin-a",
+      },
+    ]);
+
+    subagentManager.registerPluginAgents("plugin-b", [
+      {
+        name: "agent-a",
+        description: "Agent A",
+        systemPrompt: "Prompt",
+        filePath: "/plugin-b/agents/agent-a.md",
+        scope: "plugin",
+        priority: 2,
+        pluginRoot: "/plugin-b",
+      },
+    ]);
+
+    const configs = subagentManager.getConfigurations();
+    const pluginAgents = configs.filter((c) => c.scope === "plugin");
+    // plugin-a:agent-z should come before plugin-b:agent-a (same priority, alphabetical by namespaced name)
+    expect(pluginAgents[0].name).toBe("plugin-a:agent-z");
+    expect(pluginAgents[1].name).toBe("plugin-b:agent-a");
+  });
+});

--- a/packages/agent-sdk/tests/plugin-loading-integration.test.ts
+++ b/packages/agent-sdk/tests/plugin-loading-integration.test.ts
@@ -45,6 +45,7 @@ describe("Agent Plugin Loading Integration", () => {
     });
     vi.mocked(PluginLoader.loadCommands).mockReturnValue([]);
     vi.mocked(PluginLoader.loadSkills).mockResolvedValue([]);
+    vi.mocked(PluginLoader.loadAgents).mockResolvedValue([]);
     vi.mocked(PluginLoader.loadLspConfig).mockResolvedValue(undefined);
     vi.mocked(PluginLoader.loadMcpConfig).mockResolvedValue(undefined);
     vi.mocked(PluginLoader.loadHooksConfig).mockResolvedValue(undefined);

--- a/packages/agent-sdk/tests/services/pluginLoader.test.ts
+++ b/packages/agent-sdk/tests/services/pluginLoader.test.ts
@@ -5,12 +5,14 @@ import { PluginLoader } from "../../src/services/pluginLoader.js";
 import { scanCommandsDirectory } from "../../src/utils/customCommands.js";
 import { CustomSlashCommand } from "../../src/types/index.js";
 import { parseSkillFile } from "../../src/utils/skillParser.js";
+import { parseAgentFile } from "../../src/utils/subagentParser.js";
 import { resolveMcpConfig } from "../../src/managers/mcpManager.js";
 
 vi.mock("fs/promises");
 vi.mock("path");
 vi.mock("../../src/utils/customCommands.js");
 vi.mock("../../src/utils/skillParser.js");
+vi.mock("../../src/utils/subagentParser.js");
 vi.mock("../../src/managers/mcpManager.js", () => ({
   resolveMcpConfig: vi.fn((config) => {
     // Simulate env var expansion for headers
@@ -350,6 +352,126 @@ describe("PluginLoader", () => {
       const result = await PluginLoader.loadHooksConfig(mockPluginPath);
 
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe("loadAgents", () => {
+    it("should load agents from the agents directory", async () => {
+      vi.mocked(fs.readdir).mockResolvedValue([
+        { name: "agent1.md", isFile: () => true, isDirectory: () => false },
+        { name: "agent2.md", isFile: () => true, isDirectory: () => false },
+        { name: "not-a-dir", isFile: () => false, isDirectory: () => true },
+      ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+
+      vi.mocked(parseAgentFile)
+        .mockImplementationOnce((filePath: string) => ({
+          name: "agent1",
+          description: "Agent 1",
+          systemPrompt: "System prompt",
+          filePath,
+          scope: "plugin",
+          priority: 2,
+          pluginRoot: mockPluginPath,
+        }))
+        .mockImplementationOnce((filePath: string) => ({
+          name: "agent2",
+          description: "Agent 2",
+          systemPrompt: "System prompt",
+          filePath,
+          scope: "plugin",
+          priority: 2,
+          pluginRoot: mockPluginPath,
+        }));
+
+      const result = await PluginLoader.loadAgents(mockPluginPath);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe("agent1");
+      expect(result[1].name).toBe("agent2");
+      expect(result[0].scope).toBe("plugin");
+      expect(result[0].pluginRoot).toBe(mockPluginPath);
+      expect(parseAgentFile).toHaveBeenCalledWith(
+        `${mockPluginPath}/agents/agent1.md`,
+        "plugin",
+        mockPluginPath,
+      );
+    });
+
+    it("should set pluginRoot on loaded agents", async () => {
+      vi.mocked(fs.readdir).mockResolvedValue([
+        { name: "test-agent.md", isFile: () => true, isDirectory: () => false },
+      ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+
+      vi.mocked(parseAgentFile).mockReturnValue({
+        name: "test-agent",
+        description: "Test Agent",
+        systemPrompt: "Use ${WAVE_PLUGIN_ROOT} for files",
+        filePath: "/my/plugin/agents/test-agent.md",
+        scope: "plugin",
+        priority: 2,
+        pluginRoot: "/my/plugin",
+      });
+
+      const result = await PluginLoader.loadAgents("/my/plugin");
+
+      expect(result[0].pluginRoot).toBe("/my/plugin");
+    });
+
+    it("should return empty array if agents directory does not exist", async () => {
+      vi.mocked(fs.readdir).mockRejectedValue(new Error("ENOENT"));
+
+      const result = await PluginLoader.loadAgents(mockPluginPath);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should skip invalid agent files and continue", async () => {
+      vi.mocked(fs.readdir).mockResolvedValue([
+        { name: "valid.md", isFile: () => true, isDirectory: () => false },
+        { name: "invalid.md", isFile: () => true, isDirectory: () => false },
+      ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+
+      vi.mocked(parseAgentFile)
+        .mockImplementationOnce(() => ({
+          name: "valid",
+          description: "Valid Agent",
+          systemPrompt: "Valid prompt",
+          filePath: "/mock/agents/valid.md",
+          scope: "plugin",
+          priority: 2,
+          pluginRoot: mockPluginPath,
+        }))
+        .mockImplementationOnce(() => {
+          throw new Error("Parse error");
+        });
+
+      const result = await PluginLoader.loadAgents(mockPluginPath);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe("valid");
+    });
+
+    it("should only load .md files", async () => {
+      vi.mocked(fs.readdir).mockResolvedValue([
+        { name: "agent.md", isFile: () => true, isDirectory: () => false },
+        { name: "readme.txt", isFile: () => true, isDirectory: () => false },
+        { name: "subdir", isFile: () => false, isDirectory: () => true },
+      ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+
+      vi.mocked(parseAgentFile).mockReturnValue({
+        name: "agent",
+        description: "Agent",
+        systemPrompt: "Prompt",
+        filePath: "/mock/agents/agent.md",
+        scope: "plugin",
+        priority: 2,
+        pluginRoot: mockPluginPath,
+      });
+
+      const result = await PluginLoader.loadAgents(mockPluginPath);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe("agent");
     });
   });
 });


### PR DESCRIPTION
## Summary

Implement plugin agent loading from `agents/` directory within plugins, following the existing pattern used by skills/hooks/MCP/LSP.

## Changes

### Core Implementation
- **`subagentParser.ts`**: Extended `SubagentConfiguration` with `pluginRoot` field and `plugin` scope. Added `parseAgentFile()` exported helper that performs `${WAVE_PLUGIN_ROOT}` substitution at parse time.
- **`plugins.ts`**: Added `agents: SubagentConfiguration[]` to the `Plugin` interface.
- **`pluginLoader.ts`**: Added `loadAgents()` method scanning `{pluginPath}/agents/` for `.md` files.
- **`subagentManager.ts`**: Added `registerPluginAgents()` — namespaces agent names as `pluginName:agentName`, substitutes remaining `${WAVE_PLUGIN_ROOT}` as safety net, merges into cached configs, re-sorts. Updated `findSubagent()` to check cache first.
- **`pluginManager.ts`**: Added `SubagentManager` import/getter, loads agents during `loadSinglePlugin()`, registers them.

### Documentation
- **`SUBAGENTS.md`**: Added plugin agents as a third subagent location with `${WAVE_PLUGIN_ROOT}` example.
- **`SKILL.md`**: Updated plugins description to mention subagents.

### Tests
- 5 test cases for `loadAgents()` (directory scanning, pluginRoot, missing directory, error handling, file filtering)
- 5 test cases for `registerPluginAgents()` (namespacing, WAVE_PLUGIN_ROOT substitution, collision handling, sorting)
- 2 test fixes: mock for `loadAgents` in integration test, `vi.hoisted` fix for subagentMessagesCallback test

### Example
- `plugin-agent-demo.ts` — end-to-end verification of plugin agent loading and WAVE_PLUGIN_ROOT substitution.

## Initialization Order (verified)
1. `subagentManager.initialize()` → caches configs
2. `pluginManager.loadPlugins()` → calls `registerPluginAgents()` which merges into cache

The cache is ready before plugin agents are registered.