### PR TITLE
feat(sdk): pass back reasoning content in API messages

### DIFF
--- a/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
+++ b/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
@@ -145,6 +145,20 @@ export function convertMessagesForAPI(
           .join("\n");
       }
 
+      // Extract reasoning content from reasoning blocks
+      const reasoningBlocks = message.blocks.filter(
+        (block) =>
+          block.type === "reasoning" &&
+          block.content &&
+          block.content.trim().length > 0,
+      );
+      let reasoning_content: string | undefined;
+      if (reasoningBlocks.length > 0) {
+        reasoning_content = reasoningBlocks
+          .map((block) => (block.type === "reasoning" ? block.content : ""))
+          .join("\n");
+      }
+
       // Construct tool calls from tool blocks
       if (toolBlocks.length > 0) {
         tool_calls = toolBlocks
@@ -176,8 +190,9 @@ export function convertMessagesForAPI(
           role: "assistant",
           content: hasContent ? content : undefined,
           tool_calls,
+          ...(reasoning_content ? { reasoning_content } : {}),
           ...(message.additionalFields ? { ...message.additionalFields } : {}),
-        };
+        } as ChatCompletionMessageParam;
 
         recentMessages.unshift(assistantMessage);
       }

--- a/packages/agent-sdk/tests/utils/convertMessagesForAPI.test.ts
+++ b/packages/agent-sdk/tests/utils/convertMessagesForAPI.test.ts
@@ -308,6 +308,104 @@ describe("convertMessagesForAPI", () => {
     ]);
   });
 
+  it("should include reasoning content in assistant messages for API", () => {
+    const messages: Message[] = [
+      {
+        id: generateMessageId(),
+        role: "user",
+        blocks: [{ type: "text", content: "What is 2+2?" }],
+      },
+      {
+        id: generateMessageId(),
+        role: "assistant",
+        blocks: [
+          {
+            type: "reasoning",
+            content: "Let me think about this...",
+          },
+          { type: "text", content: "The answer is 4." },
+        ],
+      },
+    ];
+
+    const apiMessages = convertMessagesForAPI(messages);
+
+    expect(apiMessages).toHaveLength(2);
+
+    expect(apiMessages[0].role).toBe("user");
+    expect(apiMessages[0].content).toEqual([
+      { type: "text", text: "What is 2+2?" },
+    ]);
+
+    expect(apiMessages[1].role).toBe("assistant");
+    const assistantMessage = apiMessages[1] as ChatCompletionMessageParam & {
+      reasoning_content?: string;
+    };
+    expect(assistantMessage.content).toBe("The answer is 4.");
+    expect(assistantMessage.reasoning_content).toBe(
+      "Let me think about this...",
+    );
+  });
+
+  it("should join multiple reasoning blocks in assistant messages", () => {
+    const messages: Message[] = [
+      {
+        id: generateMessageId(),
+        role: "user",
+        blocks: [{ type: "text", content: "Explain quantum computing" }],
+      },
+      {
+        id: generateMessageId(),
+        role: "assistant",
+        blocks: [
+          {
+            type: "reasoning",
+            content: "First, define qubits.",
+          },
+          { type: "text", content: "Quantum computing uses qubits." },
+          {
+            type: "reasoning",
+            content: "Then explain superposition.",
+          },
+        ],
+      },
+    ];
+
+    const apiMessages = convertMessagesForAPI(messages);
+
+    expect(apiMessages).toHaveLength(2);
+
+    const assistantMessage = apiMessages[1] as ChatCompletionMessageParam & {
+      reasoning_content?: string;
+    };
+    expect(assistantMessage.reasoning_content).toBe(
+      "First, define qubits.\nThen explain superposition.",
+    );
+  });
+
+  it("should not include reasoning_content when there are no reasoning blocks", () => {
+    const messages: Message[] = [
+      {
+        id: generateMessageId(),
+        role: "user",
+        blocks: [{ type: "text", content: "Hello" }],
+      },
+      {
+        id: generateMessageId(),
+        role: "assistant",
+        blocks: [{ type: "text", content: "Hi there!" }],
+      },
+    ];
+
+    const apiMessages = convertMessagesForAPI(messages);
+
+    expect(apiMessages).toHaveLength(2);
+    const assistantMessage = apiMessages[1] as ChatCompletionMessageParam & {
+      reasoning_content?: string;
+    };
+    expect(assistantMessage.reasoning_content).toBeUndefined();
+  });
+
   it("should convert compact block to user role for API (matching Claude Code auto-compact)", () => {
     const messages: Message[] = [
       {


### PR DESCRIPTION
## Summary

When assistant messages are converted back to API format for subsequent AI calls, reasoning blocks were being ignored. This meant the model's reasoning/thinking was lost in conversation history.

## Changes

- **Extract reasoning content** from `message.blocks` in `convertMessagesForAPI`
- **Join multiple reasoning blocks** with newlines
- **Add `reasoning_content` field** to assistant message object (enables model continuity for reasoning/thinking chains)
- **Add 3 test cases** covering single block, multiple blocks, and absence scenarios

## Files Modified

- `packages/agent-sdk/src/utils/convertMessagesForAPI.ts`
- `packages/agent-sdk/tests/utils/convertMessagesForAPI.test.ts`