### PR TITLE
feat: limit plugin list views to 3 visible items with scrolling

### DIFF
--- a/packages/code/src/components/InstalledView.tsx
+++ b/packages/code/src/components/InstalledView.tsx
@@ -30,10 +30,23 @@ export const InstalledView: React.FC = () => {
     );
   }
 
+  const MAX_VISIBLE_ITEMS = 3;
+  const startIndex = Math.max(
+    0,
+    Math.min(
+      selectedIndex - Math.floor(MAX_VISIBLE_ITEMS / 2),
+      Math.max(0, installedPlugins.length - MAX_VISIBLE_ITEMS),
+    ),
+  );
+  const visiblePlugins = installedPlugins.slice(
+    startIndex,
+    startIndex + MAX_VISIBLE_ITEMS,
+  );
+
   return (
     <Box flexDirection="column">
-      {installedPlugins.map((plugin, index) => {
-        const isSelected = index === selectedIndex;
+      {visiblePlugins.map((plugin, index) => {
+        const isSelected = index + startIndex === selectedIndex;
         return (
           <Box
             key={`${plugin.name}@${plugin.marketplace}`}

--- a/packages/code/src/components/PluginList.tsx
+++ b/packages/code/src/components/PluginList.tsx
@@ -12,6 +12,8 @@ interface PluginListProps {
   onSelect?: (index: number) => void;
 }
 
+const MAX_VISIBLE_ITEMS = 3;
+
 export const PluginList: React.FC<PluginListProps> = ({
   plugins,
   selectedIndex,
@@ -24,10 +26,22 @@ export const PluginList: React.FC<PluginListProps> = ({
     );
   }
 
+  const startIndex = Math.max(
+    0,
+    Math.min(
+      selectedIndex - Math.floor(MAX_VISIBLE_ITEMS / 2),
+      Math.max(0, plugins.length - MAX_VISIBLE_ITEMS),
+    ),
+  );
+  const visiblePlugins = plugins.slice(
+    startIndex,
+    startIndex + MAX_VISIBLE_ITEMS,
+  );
+
   return (
     <Box flexDirection="column">
-      {plugins.map((plugin, index) => {
-        const isSelected = index === selectedIndex;
+      {visiblePlugins.map((plugin, index) => {
+        const isSelected = index + startIndex === selectedIndex;
         const pluginId = `${plugin.name}@${plugin.marketplace}`;
 
         return (

--- a/packages/code/tests/components/DiscoverView.test.tsx
+++ b/packages/code/tests/components/DiscoverView.test.tsx
@@ -146,4 +146,88 @@ describe("DiscoverView", () => {
       expect(lastFrame()).toContain("> plugin2");
     });
   });
+
+  describe("scrolling", () => {
+    const fivePlugins: PluginManagerContextType["discoverablePlugins"] = [
+      {
+        name: "plugin1",
+        marketplace: "mp1",
+        description: "Description 1",
+        installed: false,
+        version: "1.0.0",
+        source: "source1",
+      },
+      {
+        name: "plugin2",
+        marketplace: "mp2",
+        description: "Description 2",
+        installed: false,
+        version: "2.0.0",
+        source: "source2",
+      },
+      {
+        name: "plugin3",
+        marketplace: "mp3",
+        description: "Description 3",
+        installed: false,
+        version: "3.0.0",
+        source: "source3",
+      },
+      {
+        name: "plugin4",
+        marketplace: "mp4",
+        description: "Description 4",
+        installed: false,
+        version: "4.0.0",
+        source: "source4",
+      },
+      {
+        name: "plugin5",
+        marketplace: "mp5",
+        description: "Description 5",
+        installed: false,
+        version: "5.0.0",
+        source: "source5",
+      },
+    ];
+
+    it("should show max 3 plugins when more than 3 discoverable", () => {
+      const { lastFrame } = render(
+        <PluginManagerContext.Provider value={createMockContext(fivePlugins)}>
+          <DiscoverView />
+        </PluginManagerContext.Provider>,
+      );
+      const frame = lastFrame();
+      expect(frame).toContain("plugin1");
+      expect(frame).toContain("plugin2");
+      expect(frame).toContain("plugin3");
+      expect(frame).not.toContain("plugin4");
+      expect(frame).not.toContain("plugin5");
+    });
+
+    it("should scroll window when navigating down past the third visible plugin", async () => {
+      const { stdin, lastFrame } = render(
+        <PluginManagerContext.Provider value={createMockContext(fivePlugins)}>
+          <DiscoverView />
+        </PluginManagerContext.Provider>,
+      );
+
+      // Navigate Down 4 times to reach index 4, waiting between each
+      stdin.write("\u001B[B");
+      await vi.waitFor(() => expect(lastFrame()).toContain("> plugin2"));
+      stdin.write("\u001B[B");
+      await vi.waitFor(() => expect(lastFrame()).toContain("> plugin3"));
+      stdin.write("\u001B[B");
+      await vi.waitFor(() => expect(lastFrame()).toContain("> plugin4"));
+      stdin.write("\u001B[B");
+      await vi.waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain("> plugin5");
+        expect(frame).not.toContain("plugin1");
+        expect(frame).not.toContain("plugin2");
+        expect(frame).toContain("plugin3");
+        expect(frame).toContain("plugin4");
+      });
+    });
+  });
 });

--- a/packages/code/tests/components/InstalledView.test.tsx
+++ b/packages/code/tests/components/InstalledView.test.tsx
@@ -178,4 +178,123 @@ describe("InstalledView", () => {
       expect(lastFrame()).toContain("> plugin2");
     });
   });
+
+  describe("scrolling", () => {
+    const fiveInstalledPlugins: PluginManagerContextType["installedPlugins"] = [
+      {
+        name: "plugin1",
+        marketplace: "mp1",
+        enabled: true,
+        version: "1.0.0",
+        cachePath: "/tmp/plugin1",
+      },
+      {
+        name: "plugin2",
+        marketplace: "mp2",
+        enabled: true,
+        version: "2.0.0",
+        cachePath: "/tmp/plugin2",
+      },
+      {
+        name: "plugin3",
+        marketplace: "mp3",
+        enabled: true,
+        version: "3.0.0",
+        cachePath: "/tmp/plugin3",
+      },
+      {
+        name: "plugin4",
+        marketplace: "mp4",
+        enabled: true,
+        version: "4.0.0",
+        cachePath: "/tmp/plugin4",
+      },
+      {
+        name: "plugin5",
+        marketplace: "mp5",
+        enabled: true,
+        version: "5.0.0",
+        cachePath: "/tmp/plugin5",
+      },
+    ];
+
+    it("should show max 3 plugins when more than 3 installed", () => {
+      const { lastFrame } = render(
+        <PluginManagerContext.Provider
+          value={createMockContext(fiveInstalledPlugins)}
+        >
+          <InstalledView />
+        </PluginManagerContext.Provider>,
+      );
+      const frame = lastFrame();
+      expect(frame).toContain("plugin1");
+      expect(frame).toContain("plugin2");
+      expect(frame).toContain("plugin3");
+      expect(frame).not.toContain("plugin4");
+      expect(frame).not.toContain("plugin5");
+    });
+
+    it("should scroll window when navigating down past the third visible item", async () => {
+      const { stdin, lastFrame } = render(
+        <PluginManagerContext.Provider
+          value={createMockContext(fiveInstalledPlugins)}
+        >
+          <InstalledView />
+        </PluginManagerContext.Provider>,
+      );
+
+      // Press Down 4 times to reach index 4, waiting between each
+      stdin.write("\u001B[B");
+      await vi.waitFor(() => {
+        expect(lastFrame()).toContain("> plugin2");
+      });
+      stdin.write("\u001B[B");
+      await vi.waitFor(() => {
+        expect(lastFrame()).toContain("> plugin3");
+      });
+      stdin.write("\u001B[B");
+      await vi.waitFor(() => {
+        expect(lastFrame()).toContain("> plugin4");
+      });
+      stdin.write("\u001B[B");
+      await vi.waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain("> plugin5");
+        expect(frame).not.toContain("plugin1");
+        expect(frame).not.toContain("plugin2");
+        expect(frame).toContain("plugin3");
+        expect(frame).toContain("plugin4");
+      });
+    });
+
+    it("should scroll window when navigating back up", async () => {
+      const { stdin, lastFrame } = render(
+        <PluginManagerContext.Provider
+          value={createMockContext(fiveInstalledPlugins)}
+        >
+          <InstalledView />
+        </PluginManagerContext.Provider>,
+      );
+
+      // Navigate to index 4
+      stdin.write("\u001B[B");
+      await vi.waitFor(() => expect(lastFrame()).toContain("> plugin2"));
+      stdin.write("\u001B[B");
+      await vi.waitFor(() => expect(lastFrame()).toContain("> plugin3"));
+      stdin.write("\u001B[B");
+      await vi.waitFor(() => expect(lastFrame()).toContain("> plugin4"));
+      stdin.write("\u001B[B");
+      await vi.waitFor(() => expect(lastFrame()).toContain("> plugin5"));
+
+      // Press Up once - window should shift back
+      stdin.write("\u001B[A");
+      await vi.waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain("> plugin4");
+        expect(frame).not.toContain("plugin1");
+        expect(frame).toContain("plugin3");
+        expect(frame).toContain("plugin5");
+      });
+    });
+  });
 });

--- a/packages/code/tests/components/PluginList.test.tsx
+++ b/packages/code/tests/components/PluginList.test.tsx
@@ -74,4 +74,80 @@ describe("PluginList", () => {
     expect(frame).toContain("no-version-plugin");
     expect(frame).not.toContain("@test v");
   });
+
+  describe("scrolling", () => {
+    const fivePlugins = [
+      {
+        name: "plugin-1",
+        marketplace: "mp1",
+        installed: false,
+        description: "Description 1",
+        source: "source1",
+      },
+      {
+        name: "plugin-2",
+        marketplace: "mp2",
+        installed: false,
+        description: "Description 2",
+        source: "source2",
+      },
+      {
+        name: "plugin-3",
+        marketplace: "mp3",
+        installed: false,
+        description: "Description 3",
+        source: "source3",
+      },
+      {
+        name: "plugin-4",
+        marketplace: "mp4",
+        installed: false,
+        description: "Description 4",
+        source: "source4",
+      },
+      {
+        name: "plugin-5",
+        marketplace: "mp5",
+        installed: false,
+        description: "Description 5",
+        source: "source5",
+      },
+    ];
+
+    it("should show max 3 plugins when more than 3 exist", () => {
+      const { lastFrame } = render(
+        <PluginList plugins={fivePlugins} selectedIndex={0} />,
+      );
+      const frame = lastFrame();
+      expect(frame).toContain("plugin-1");
+      expect(frame).toContain("plugin-2");
+      expect(frame).toContain("plugin-3");
+      expect(frame).not.toContain("plugin-4");
+      expect(frame).not.toContain("plugin-5");
+    });
+
+    it("should scroll window when selectedIndex moves past visible range", () => {
+      const { lastFrame } = render(
+        <PluginList plugins={fivePlugins} selectedIndex={4} />,
+      );
+      const frame = lastFrame();
+      expect(frame).not.toContain("plugin-1");
+      expect(frame).not.toContain("plugin-2");
+      expect(frame).toContain("plugin-3");
+      expect(frame).toContain("plugin-4");
+      expect(frame).toContain("plugin-5");
+    });
+
+    it("should handle selectedIndex 0 with 5 plugins (center window)", () => {
+      const { lastFrame } = render(
+        <PluginList plugins={fivePlugins} selectedIndex={0} />,
+      );
+      const frame = lastFrame();
+      expect(frame).toContain("plugin-1");
+      expect(frame).toContain("plugin-2");
+      expect(frame).toContain("plugin-3");
+      expect(frame).not.toContain("plugin-4");
+      expect(frame).not.toContain("plugin-5");
+    });
+  });
 });


### PR DESCRIPTION
Apply centered-window scrolling pattern (max 3 visible) to PluginList and InstalledView components, matching CommandSelector's behavior. This prevents overflow when many plugins are listed.

## Changes

- **PluginList.tsx**: slice plugins to show max 3 around selectedIndex
- **InstalledView.tsx**: same centered-window rendering pattern
- **Tests**: add 8 new tests across PluginList, InstalledView, DiscoverView

## Tests

All 24 tests pass, type-check and lint are clean.