### PR TITLE
chore: increase default token limits to 128k input and 16k output

### DIFF
--- a/packages/agent-sdk/builtin/skills/settings/SKILLS.md
+++ b/packages/agent-sdk/builtin/skills/settings/SKILLS.md
@@ -42,6 +42,9 @@ When this skill is invoked, follow these steps:
 - `allowed-tools`: (Optional) List of tools the skill can use.
 - `context: fork`: (Optional) Run the skill in a separate subagent.
 - `agent`: (Optional) Specify the subagent type (default: `general-purpose`).
+- `disable-model-invocation`: (Optional, default: `false`) Set to `true` to hide the skill from the AI's available skills list. The skill can still be invoked by users via slash commands.
+- `user-invocable`: (Optional, default: `true`) Set to `false` to hide the skill from the `/` slash command menu. The AI can still invoke it unless `disable-model-invocation` is also set.
+- `model`: (Optional) Override the AI model used for skill execution (e.g., `"gpt-4o"`, `"o3-mini"`).
 
 ## Skill Locations
 

--- a/packages/agent-sdk/src/utils/constants.ts
+++ b/packages/agent-sdk/src/utils/constants.ts
@@ -29,5 +29,5 @@ export const USER_MEMORY_FILE = path.join(DATA_DIRECTORY, "AGENTS.md");
 /**
  * AI related constants
  */
-export const DEFAULT_WAVE_MAX_INPUT_TOKENS = 96000; // Default token limit
-export const DEFAULT_WAVE_MAX_OUTPUT_TOKENS = 8192; // Default output token limit
+export const DEFAULT_WAVE_MAX_INPUT_TOKENS = 128000; // Default token limit
+export const DEFAULT_WAVE_MAX_OUTPUT_TOKENS = 16384; // Default output token limit

--- a/packages/agent-sdk/tests/agent/agent.compaction.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.compaction.test.ts
@@ -17,7 +17,7 @@ describe("Agent Message Compaction Tests", () => {
     // Disable auto-memory to prevent extra callAgent calls from background tasks
     vi.stubEnv("WAVE_DISABLE_AUTO_MEMORY", "1");
 
-    // Clear WAVE_MAX_INPUT_TOKENS to use default 96000 for compaction threshold
+    // Clear WAVE_MAX_INPUT_TOKENS to use default 128000 for compaction threshold
     delete process.env.WAVE_MAX_INPUT_TOKENS;
 
     // Create Agent instance with required parameters
@@ -475,7 +475,7 @@ describe("Agent Message Compaction Tests", () => {
           usage: {
             prompt_tokens: 50000,
             completion_tokens: 20000,
-            total_tokens: 102000, // Exceeds 96000 to trigger compaction
+            total_tokens: 130000, // Exceeds 128000 to trigger compaction
           },
         };
       } else {

--- a/packages/agent-sdk/tests/agent/agent.subagentDynamicConfig.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.subagentDynamicConfig.test.ts
@@ -192,7 +192,7 @@ describe("Subagent Dynamic Configuration Tests", () => {
       expect(modelConfig.fastModel).toBe("parent-fast-model");
 
       // Should inherit token limit from parent (using default since not specified)
-      expect(subagentAIManager.getMaxInputTokens()).toBe(96000); // Default value
+      expect(subagentAIManager.getMaxInputTokens()).toBe(128000); // Default value
 
       // Update parent environment variables
       process.env.WAVE_API_KEY = "updated-parent-token";


### PR DESCRIPTION
- **docs: document missing skill frontmatter fields (model, disable-model-invocation, user-invocable)**
- **chore: increase default token limits to 128k input and 16k output**
