### PR TITLE
fix: suppress redundant tool argument error logging and recover truncated JSON

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -24,6 +24,7 @@ import type { SubagentManager } from "./subagentManager.js";
 import type { SkillManager } from "./skillManager.js";
 import { buildSystemPrompt } from "../prompts/index.js";
 import { Container } from "../utils/container.js";
+import { recoverTruncatedJson } from "../utils/stringUtils.js";
 import { ConfigurationService } from "../services/configurationService.js";
 import type { NotificationQueue } from "./notificationQueue.js";
 
@@ -814,34 +815,45 @@ export class AIManager {
             const toolName = functionToolCall.function?.name || "";
             // Safely parse tool parameters, handle tools without parameters
             let toolArgs: Record<string, unknown> = {};
+            let jsonRecovered = false;
             const argsString = functionToolCall.function?.arguments?.trim();
 
             if (!argsString || argsString === "") {
               // Tool without parameters, use empty object
               toolArgs = {};
             } else {
+              let recoveredArgs = argsString;
               try {
                 toolArgs = JSON.parse(argsString);
-              } catch (parseError) {
-                // For non-empty but malformed JSON, still throw exception
-                let errorMessage = `Failed to parse tool arguments`;
-                if (result.finish_reason === "length") {
-                  errorMessage +=
-                    " (output truncated, please reduce your output)";
+              } catch {
+                // Attempt to recover truncated JSON (e.g., missing closing braces)
+                recoveredArgs = recoverTruncatedJson(argsString);
+                try {
+                  toolArgs = JSON.parse(recoveredArgs);
+                  jsonRecovered = true;
+                  logger.warn(
+                    `Recovered truncated JSON for tool "${toolName}"`,
+                  );
+                } catch (parseError) {
+                  let errorMessage = `Failed to parse tool arguments`;
+                  if (result.finish_reason === "length") {
+                    errorMessage +=
+                      " (output truncated, please reduce your output)";
+                  }
+                  logger?.error(errorMessage, parseError);
+                  this.messageManager.updateToolBlock({
+                    id: toolId,
+                    parameters: argsString,
+                    result: errorMessage,
+                    success: false,
+                    error: errorMessage,
+                    stage: "end",
+                    name: toolName,
+                    compactParams: "",
+                    timestamp: Date.now(),
+                  });
+                  return;
                 }
-                logger?.error(errorMessage, parseError);
-                this.messageManager.updateToolBlock({
-                  id: toolId,
-                  parameters: argsString,
-                  result: errorMessage,
-                  success: false,
-                  error: errorMessage,
-                  stage: "end",
-                  name: toolName,
-                  compactParams: "",
-                  timestamp: Date.now(),
-                });
-                return;
               }
             }
 
@@ -942,13 +954,20 @@ export class AIManager {
                 context,
               );
 
+              // Build result content, adding truncation warning if JSON was recovered
+              let toolResultContent =
+                toolResult.content ||
+                (toolResult.error ? `Error: ${toolResult.error}` : "");
+              if (jsonRecovered) {
+                toolResultContent +=
+                  "\n\n⚠️ Tool arguments were truncated (likely exceeded max output tokens). Please reduce your output or split into multiple tool calls.";
+              }
+
               // Update message state - tool execution completed
               this.messageManager.updateToolBlock({
                 id: toolId,
                 parameters: argsString,
-                result:
-                  toolResult.content ||
-                  (toolResult.error ? `Error: ${toolResult.error}` : ""),
+                result: toolResultContent,
                 success: toolResult.success,
                 error: toolResult.error,
                 stage: "end",

--- a/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
+++ b/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
@@ -2,7 +2,7 @@ import type { Message } from "../types/index.js";
 import { convertImageToBase64 } from "./messageOperations.js";
 import { taskNotificationToXml } from "./notificationXml.js";
 import { ChatCompletionMessageToolCall } from "openai/resources";
-import { stripAnsiColors } from "./stringUtils.js";
+import { recoverTruncatedJson, stripAnsiColors } from "./stringUtils.js";
 import {
   ChatCompletionContentPart,
   ChatCompletionMessageParam,
@@ -10,7 +10,8 @@ import {
 import { logger } from "./globalLogger.js";
 
 /**
- * Safely handle tool call parameters, ensuring a legal JSON string is returned
+ * Safely handle tool call parameters, ensuring a legal JSON string is returned.
+ * Attempts to recover truncated JSON (e.g., missing closing braces).
  * @param args Tool call parameters
  * @returns Legal JSON string
  */
@@ -24,11 +25,17 @@ function safeToolArguments(args: string): string {
     JSON.parse(args);
     return args;
   } catch {
-    // Malformed JSON was already logged when the tool block was created.
-    // Return a sanitized fallback without re-logging on every API call.
-    return JSON.stringify({
-      invalid_arguments: args,
-    });
+    // Attempt to recover truncated JSON
+    const recovered = recoverTruncatedJson(args);
+    try {
+      JSON.parse(recovered);
+      return recovered;
+    } catch {
+      // Truly malformed JSON — return sanitized fallback
+      return JSON.stringify({
+        invalid_arguments: args,
+      });
+    }
   }
 }
 

--- a/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
+++ b/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
@@ -23,9 +23,9 @@ function safeToolArguments(args: string): string {
     // Try to parse as JSON to validate format
     JSON.parse(args);
     return args;
-  } catch (error) {
-    logger.error(`Invalid tool arguments: ${args}`, error);
-    // If not valid JSON, return a fallback empty object with the original string as a comment or property
+  } catch {
+    // Malformed JSON was already logged when the tool block was created.
+    // Return a sanitized fallback without re-logging on every API call.
     return JSON.stringify({
       invalid_arguments: args,
     });

--- a/packages/agent-sdk/src/utils/stringUtils.ts
+++ b/packages/agent-sdk/src/utils/stringUtils.ts
@@ -93,6 +93,49 @@ export function formatLineNumberPrefix(lineNumber: number): string {
 }
 
 /**
+ * Attempt to recover truncated JSON (e.g., missing closing braces due to max tokens).
+ * Tracks brace depth and only recovers if there are unclosed `{` braces.
+ * Will NOT recover if there are unclosed `[` brackets (can't guess the content).
+ * @param jsonStr Potentially truncated JSON string
+ * @returns Recovered JSON string, or the original if unrecoverable
+ */
+export function recoverTruncatedJson(jsonStr: string): string {
+  let braceDepth = 0;
+  let bracketDepth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (const ch of jsonStr) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\" && inString) {
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (!inString) {
+      if (ch === "{") braceDepth++;
+      if (ch === "}") braceDepth--;
+      if (ch === "[") bracketDepth++;
+      if (ch === "]") bracketDepth--;
+    }
+  }
+
+  // Build recovery suffix
+  let suffix = "";
+  if (inString) suffix += '"'; // Close unclosed string
+  if (braceDepth > 0 && bracketDepth === 0) {
+    suffix += "}".repeat(braceDepth);
+  }
+  return suffix ? jsonStr + suffix : jsonStr;
+}
+
+/**
  * Efficiently get the last N lines of a string without splitting the whole string.
  */
 export function getLastLines(text: string, count: number): string {

--- a/packages/agent-sdk/tests/utils/stringUtils.test.ts
+++ b/packages/agent-sdk/tests/utils/stringUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   getLastLines,
   parseCustomHeaders,
+  recoverTruncatedJson,
   removeCodeBlockWrappers,
 } from "@/utils/stringUtils.js";
 
@@ -144,5 +145,54 @@ describe("parseCustomHeaders", () => {
   it("should handle undefined or null input gracefully", () => {
     expect(parseCustomHeaders(undefined as unknown as string)).toEqual({});
     expect(parseCustomHeaders(null as unknown as string)).toEqual({});
+  });
+});
+
+describe("recoverTruncatedJson", () => {
+  it("should return valid JSON unchanged", () => {
+    expect(recoverTruncatedJson('{"a": 1}')).toBe('{"a": 1}');
+  });
+
+  it("should recover JSON missing one closing brace", () => {
+    expect(recoverTruncatedJson('{"a": 1')).toBe('{"a": 1}');
+  });
+
+  it("should recover JSON missing multiple closing braces", () => {
+    expect(recoverTruncatedJson('{"a": {"b": 2')).toBe('{"a": {"b": 2}}');
+  });
+
+  it("should not modify JSON that is already closed", () => {
+    expect(recoverTruncatedJson('{"a": {"b": [1, 2]}}')).toBe(
+      '{"a": {"b": [1, 2]}}',
+    );
+  });
+
+  it("should handle strings containing braces without counting them", () => {
+    expect(recoverTruncatedJson(`{"a": "hello}`)).toBe(`{"a": "hello}"}`);
+  });
+
+  it("should handle escaped quotes inside strings", () => {
+    expect(recoverTruncatedJson(`{"a": "say \\"hi\\"`)).toBe(
+      `{"a": "say \\"hi\\""}`,
+    );
+  });
+
+  it("should return unchanged string for unclosed brackets", () => {
+    // Unclosed brackets cannot be safely recovered
+    expect(recoverTruncatedJson('{"a": [1, 2')).toBe('{"a": [1, 2');
+  });
+
+  it("should close unclosed string before closing braces", () => {
+    expect(recoverTruncatedJson(`{"a": "hello}`)).toBe(`{"a": "hello}"}`);
+  });
+
+  it("should handle empty object missing closing brace", () => {
+    expect(recoverTruncatedJson("{")).toBe("{}");
+  });
+
+  it("should handle deeply nested truncation", () => {
+    expect(recoverTruncatedJson('{"a": {"b": {"c": 3')).toBe(
+      '{"a": {"b": {"c": 3}}}',
+    );
   });
 });


### PR DESCRIPTION
## Summary

Two fixes for tool argument JSON handling in `convertMessagesForAPI` and `aiManager`:

### Commit 1: Suppress redundant error logging
- Removed `logger.error()` from `safeToolArguments()` in `convertMessagesForAPI.ts`
- The malformed JSON is already logged once when the tool block is created in aiManager
- `safeToolArguments` was re-logging the same error on every subsequent API call, spamming app.log

### Commit 2: Recover truncated tool arguments JSON
- Added `recoverTruncatedJson()` in `stringUtils.ts` — counts unclosed braces while properly handling strings and escaped quotes
- When AI output exceeds max tokens and tool call JSON is truncated (e.g., missing closing braces), attempts to recover before giving up
- Recovered JSON allows the tool to still execute, with a warning appended to the result reminding the AI to reduce output
- `safeToolArguments` also uses recovery to avoid returning `invalid_arguments` for recoverable truncation
- 10 test cases added for `recoverTruncatedJson`

### Why this matters
- Reduces log spam from repeated error logging on each API round
- Enables tools to execute even when AI output is truncated by max tokens, rather than failing outright