### PR TITLE
feat: add maxTurns limit to auto-memory forked agent

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -45,6 +45,8 @@ export interface AIManagerOptions {
   stream?: boolean;
   /**Optional model override (e.g. for subagents) */
   modelOverride?: string;
+  /**Optional max turns limit to prevent runaway recursion (e.g. for auto-memory extraction) */
+  maxTurns?: number;
 }
 
 export class AIManager {
@@ -60,6 +62,7 @@ export class AIManager {
   private modelOverride?: string;
   private _onCwdChange?: (newCwd: string) => void; // Store callback for CWD changes
   private consecutiveCompactionFailures: number = 0;
+  private readonly maxTurns?: number;
 
   // Service overrides
   constructor(
@@ -74,6 +77,7 @@ export class AIManager {
     this.callbacks = options.callbacks ?? {};
     this.modelOverride = options.modelOverride;
     this._onCwdChange = options.callbacks?.onCwdChange; // Initialize onCwdChange
+    this.maxTurns = options.maxTurns;
   }
 
   private get toolManager(): ToolManager {
@@ -1020,108 +1024,116 @@ export class AIManager {
 
       // Check if there are tool operations or response was truncated, if so automatically initiate next AI service call
       if (toolCalls.length > 0 || result.finish_reason === "length") {
-        // Record committed snapshots to message history
-        if (this.reversionManager) {
-          const snapshots =
-            this.reversionManager.getAndClearCommittedSnapshots();
-          if (snapshots.length > 0) {
-            this.messageManager.addFileHistoryBlock(snapshots);
-          }
-        }
-
-        // Check interruption status
-        const isCurrentlyAborted =
-          abortController.signal.aborted || toolAbortController.signal.aborted;
-
-        // Check if all tools were manually backgrounded
-        const lastMessage =
-          this.messageManager.getMessages()[
-            this.messageManager.getMessages().length - 1
-          ];
-        const toolBlocks =
-          lastMessage?.blocks.filter(
-            (block): block is import("../types/messaging.js").ToolBlock =>
-              block.type === "tool",
-          ) || [];
-        const hasBackgrounded =
-          toolBlocks.length > 0 &&
-          toolBlocks.some((block) => block.isManuallyBackgrounded);
-
-        if (hasBackgrounded) {
-          logger?.info(
-            "Some tools were manually backgrounded, stopping recursion.",
+        // Check maxTurns limit before recursing
+        if (this.maxTurns && recursionDepth + 1 >= this.maxTurns) {
+          logger?.debug(
+            `Max turns (${this.maxTurns}) reached, stopping recursion.`,
           );
-        } else if (!isCurrentlyAborted) {
-          // If response was truncated, add a hidden continuation message
-          if (result.finish_reason === "length") {
-            this.messageManager.addUserMessage({
-              content:
-                "Output token limit hit. Resume directly — no apology, no recap of what you were doing. Pick up mid-thought if that is where the cut happened. Break remaining work into smaller pieces.",
-              isMeta: true,
-            });
+        } else {
+          // Record committed snapshots to message history
+          if (this.reversionManager) {
+            const snapshots =
+              this.reversionManager.getAndClearCommittedSnapshots();
+            if (snapshots.length > 0) {
+              this.messageManager.addFileHistoryBlock(snapshots);
+            }
           }
 
-          // Duplicate Tool Call Detection
-          if (toolCalls.length > 0) {
-            const messages = this.messageManager.getMessages();
-            // Find the most recent assistant message BEFORE the current one that has tool blocks
-            // The current assistant message is messages[messages.length - 1]
-            let previousAssistantWithTools: Message | undefined;
-            for (let i = messages.length - 2; i >= 0; i--) {
-              const msg = messages[i];
-              if (
-                msg.role === "assistant" &&
-                msg.blocks.some((b) => b.type === "tool")
-              ) {
-                previousAssistantWithTools = msg;
-                break;
-              }
+          // Check interruption status
+          const isCurrentlyAborted =
+            abortController.signal.aborted ||
+            toolAbortController.signal.aborted;
+
+          // Check if all tools were manually backgrounded
+          const lastMessage =
+            this.messageManager.getMessages()[
+              this.messageManager.getMessages().length - 1
+            ];
+          const toolBlocks =
+            lastMessage?.blocks.filter(
+              (block): block is import("../types/messaging.js").ToolBlock =>
+                block.type === "tool",
+            ) || [];
+          const hasBackgrounded =
+            toolBlocks.length > 0 &&
+            toolBlocks.some((block) => block.isManuallyBackgrounded);
+
+          if (hasBackgrounded) {
+            logger?.info(
+              "Some tools were manually backgrounded, stopping recursion.",
+            );
+          } else if (!isCurrentlyAborted) {
+            // If response was truncated, add a hidden continuation message
+            if (result.finish_reason === "length") {
+              this.messageManager.addUserMessage({
+                content:
+                  "Output token limit hit. Resume directly — no apology, no recap of what you were doing. Pick up mid-thought if that is where the cut happened. Break remaining work into smaller pieces.",
+                isMeta: true,
+              });
             }
 
-            if (previousAssistantWithTools) {
-              const previousToolBlocks =
-                previousAssistantWithTools.blocks.filter(
-                  (b): b is import("../types/messaging.js").ToolBlock =>
-                    b.type === "tool",
-                );
+            // Duplicate Tool Call Detection
+            if (toolCalls.length > 0) {
+              const messages = this.messageManager.getMessages();
+              // Find the most recent assistant message BEFORE the current one that has tool blocks
+              // The current assistant message is messages[messages.length - 1]
+              let previousAssistantWithTools: Message | undefined;
+              for (let i = messages.length - 2; i >= 0; i--) {
+                const msg = messages[i];
+                if (
+                  msg.role === "assistant" &&
+                  msg.blocks.some((b) => b.type === "tool")
+                ) {
+                  previousAssistantWithTools = msg;
+                  break;
+                }
+              }
 
-              for (const currentToolCall of toolCalls) {
-                const currentName = currentToolCall.function?.name;
-                const currentArgs = currentToolCall.function?.arguments;
-
-                const isDuplicate = previousToolBlocks.some(
-                  (prevBlock) =>
-                    prevBlock.name === currentName &&
-                    prevBlock.parameters === currentArgs,
-                );
-
-                if (isDuplicate && currentName) {
-                  const toolId = currentToolCall.id;
-                  const lastMessage = messages[messages.length - 1];
-                  const toolBlock = lastMessage.blocks.find(
+              if (previousAssistantWithTools) {
+                const previousToolBlocks =
+                  previousAssistantWithTools.blocks.filter(
                     (b): b is import("../types/messaging.js").ToolBlock =>
-                      b.type === "tool" && b.id === toolId,
+                      b.type === "tool",
                   );
-                  if (toolBlock) {
-                    const warning = `\n\nNote: You just called this tool with the same arguments in the previous turn. Please ensure you are not in a loop and consider if you need to change your approach.`;
-                    this.messageManager.updateToolBlock({
-                      id: toolId,
-                      result: (toolBlock.result || "") + warning,
-                      stage: "end",
-                    });
+
+                for (const currentToolCall of toolCalls) {
+                  const currentName = currentToolCall.function?.name;
+                  const currentArgs = currentToolCall.function?.arguments;
+
+                  const isDuplicate = previousToolBlocks.some(
+                    (prevBlock) =>
+                      prevBlock.name === currentName &&
+                      prevBlock.parameters === currentArgs,
+                  );
+
+                  if (isDuplicate && currentName) {
+                    const toolId = currentToolCall.id;
+                    const lastMessage = messages[messages.length - 1];
+                    const toolBlock = lastMessage.blocks.find(
+                      (b): b is import("../types/messaging.js").ToolBlock =>
+                        b.type === "tool" && b.id === toolId,
+                    );
+                    if (toolBlock) {
+                      const warning = `\n\nNote: You just called this tool with the same arguments in the previous turn. Please ensure you are not in a loop and consider if you need to change your approach.`;
+                      this.messageManager.updateToolBlock({
+                        id: toolId,
+                        result: (toolBlock.result || "") + warning,
+                        stage: "end",
+                      });
+                    }
                   }
                 }
               }
             }
-          }
 
-          // Recursively call AI service, increment recursion depth, and pass same configuration
-          await this.sendAIMessage({
-            recursionDepth: recursionDepth + 1,
-            model,
-            allowedRules,
-            maxTokens,
-          });
+            // Recursively call AI service, increment recursion depth, and pass same configuration
+            await this.sendAIMessage({
+              recursionDepth: recursionDepth + 1,
+              model,
+              allowedRules,
+              maxTokens,
+            });
+          }
         }
       }
     } catch (error) {

--- a/packages/agent-sdk/src/managers/forkedAgentManager.ts
+++ b/packages/agent-sdk/src/managers/forkedAgentManager.ts
@@ -47,6 +47,7 @@ export class ForkedAgentManager {
       allowedTools?: string[];
       model?: string;
       permissionModeOverride?: PermissionMode;
+      maxTurns?: number;
     },
     prompt: string,
   ): Promise<string> {
@@ -84,6 +85,7 @@ export class ForkedAgentManager {
       allowedTools?: string[];
       model?: string;
       permissionModeOverride?: PermissionMode;
+      maxTurns?: number;
     },
     prompt: string,
   ): Promise<void> {
@@ -103,6 +105,7 @@ export class ForkedAgentManager {
           allowedTools: parameters.allowedTools,
           model: parameters.model,
           permissionModeOverride: parameters.permissionModeOverride,
+          maxTurns: parameters.maxTurns,
         },
         false,
       );

--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -251,6 +251,7 @@ export class SubagentManager {
       model?: string;
       stream?: boolean;
       permissionModeOverride?: PermissionMode;
+      maxTurns?: number;
     },
     runInBackground?: boolean,
     onUpdate?: () => void,
@@ -356,6 +357,7 @@ export class SubagentManager {
       subagentType: parameters.subagent_type, // Pass subagent type for hook context
       modelOverride: parameters.model || configuration.model, // Pass model override
       stream: parameters.stream ?? this.stream, // Pass streaming mode flag
+      maxTurns: parameters.maxTurns, // Pass maxTurns limit
       callbacks: {
         onUsageAdded: this.onUsageAdded,
       },

--- a/packages/agent-sdk/src/services/autoMemoryService.ts
+++ b/packages/agent-sdk/src/services/autoMemoryService.ts
@@ -164,6 +164,7 @@ export class AutoMemoryService {
         ],
         model: "fastModel", // Use fast model for background tasks to reduce latency and cost
         permissionModeOverride: "dontAsk", // Auto-deny out-of-scope writes without prompting user
+        maxTurns: 5, // Limit turns to prevent verification rabbit-holes
       },
       `${prompt}\n\nThe memory directory for this project is: ${memoryDir}`,
     );

--- a/packages/agent-sdk/tests/managers/aiManager.maxTurns.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.maxTurns.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Container } from "../../src/utils/container.js";
+import { TaskManager } from "../../src/services/taskManager.js";
+import { AIManager } from "../../src/managers/aiManager.js";
+import type { MessageManager } from "../../src/managers/messageManager.js";
+import type { ToolManager } from "../../src/managers/toolManager.js";
+import type { GatewayConfig, ModelConfig } from "../../src/types/index.js";
+import * as aiService from "../../src/services/aiService.js";
+import { logger } from "../../src/utils/globalLogger.js";
+
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock("../../src/utils/gitUtils.js", () => ({
+  isGitRepository: vi.fn(),
+}));
+
+vi.mock("../../src/services/aiService.js", () => ({
+  callAgent: vi.fn().mockImplementation(async (options) => {
+    if (options.onContentUpdate) options.onContentUpdate("Test response");
+    return {
+      content: "Test response",
+      usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+      tool_calls: [],
+    };
+  }),
+  compactMessages: vi.fn().mockResolvedValue({
+    content: "Compacted content",
+    usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+  }),
+  isClaudeModel: vi.fn().mockReturnValue(false),
+  transformMessagesForClaudeCache: vi.fn((m) => m),
+  addCacheControlToLastTool: vi.fn((t) => t),
+  extendUsageWithCacheMetrics: vi.fn((u) => u),
+}));
+
+vi.mock("../../src/services/memory.js", () => ({
+  MemoryService: vi.fn().mockImplementation(() => ({
+    getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+    getAutoMemoryDirectory: vi.fn().mockReturnValue("/mock/auto-memory"),
+    ensureAutoMemoryDirectory: vi.fn().mockResolvedValue(undefined),
+    getAutoMemoryContent: vi.fn().mockResolvedValue(""),
+  })),
+  getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+}));
+
+vi.mock("../../src/utils/messageOperations.js", () => ({}));
+
+vi.mock("../../src/utils/convertMessagesForAPI.js", () => ({
+  convertMessagesForAPI: vi.fn().mockReturnValue([]),
+}));
+
+describe("AIManager maxTurns", () => {
+  let mockMessageManager: MessageManager;
+  let mockToolManager: ToolManager;
+
+  const mockGatewayConfig: GatewayConfig = {
+    apiKey: "test-api-key",
+    baseURL: "https://test-gateway.com",
+  };
+
+  const mockModelConfig: ModelConfig = {
+    model: "test-agent-model",
+    fastModel: "test-fast-model",
+  };
+
+  function createContainer() {
+    const container = new Container();
+    container.register("ConfigurationService", {
+      setOptions: vi.fn(),
+      resolveGatewayConfig: vi.fn().mockReturnValue(mockGatewayConfig),
+      resolveModelConfig: vi.fn().mockReturnValue(mockModelConfig),
+      resolveMaxInputTokens: vi.fn().mockReturnValue(96000),
+      resolveAutoMemoryEnabled: vi.fn().mockReturnValue(true),
+      resolveLanguage: vi.fn().mockReturnValue(undefined),
+      getEnvironmentVars: vi.fn().mockReturnValue({}),
+    });
+    container.register("MessageManager", mockMessageManager);
+    container.register("ToolManager", mockToolManager);
+    container.register("TaskManager", {
+      on: vi.fn(),
+      listTasks: vi.fn().mockResolvedValue([]),
+    } as unknown as TaskManager);
+    container.register("MemoryService", {
+      getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+      getAutoMemoryDirectory: vi.fn().mockReturnValue("/mock/auto-memory"),
+      ensureAutoMemoryDirectory: vi.fn().mockResolvedValue(undefined),
+      getAutoMemoryContent: vi.fn().mockResolvedValue(""),
+    });
+    container.register("PermissionManager", {
+      getCurrentEffectiveMode: vi.fn().mockReturnValue("normal"),
+      clearTemporaryRules: vi.fn(),
+      getPlanFilePath: vi.fn().mockReturnValue(undefined),
+    } as unknown as Record<string, unknown>);
+    container.register("SubagentManager", {
+      getConfigurations: vi.fn().mockReturnValue([]),
+    });
+    container.register("SkillManager", {
+      getAvailableSkills: vi.fn().mockReturnValue([]),
+    });
+    container.register("NotificationQueue", {
+      hasPending: vi.fn().mockReturnValue(false),
+    });
+    return container;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockMessageManager = {
+      getSessionId: vi.fn().mockReturnValue("test-session-id"),
+      getMessages: vi.fn().mockReturnValue([]),
+      addAssistantMessage: vi.fn(),
+      addUserMessage: vi.fn(),
+      updateCurrentMessageContent: vi.fn(),
+      updateToolBlock: vi.fn(),
+      mergeAssistantAdditionalFields: vi.fn(),
+      setMessages: vi.fn(),
+      getLatestTotalTokens: vi.fn().mockReturnValue(0),
+      getCombinedMemory: vi.fn().mockResolvedValue(""),
+      addErrorBlock: vi.fn(),
+      setlatestTotalTokens: vi.fn(),
+      saveSession: vi.fn().mockResolvedValue(undefined),
+      compactMessagesAndUpdateSession: vi.fn(),
+      getTranscriptPath: vi.fn().mockReturnValue("/test/transcript.md"),
+      touchFile: vi.fn(),
+      finalizeStreamingBlocks: vi.fn(),
+    } as unknown as MessageManager;
+
+    mockToolManager = {
+      getToolsConfig: vi.fn().mockReturnValue([]),
+      getTools: vi.fn().mockReturnValue([]),
+      list: vi.fn().mockReturnValue([]),
+      execute: vi
+        .fn()
+        .mockResolvedValue({ success: true, content: "test result" }),
+    } as unknown as ToolManager;
+  });
+
+  it("should stop recursion when maxTurns is reached", async () => {
+    let callCount = 0;
+    vi.mocked(aiService.callAgent).mockImplementation(async () => {
+      callCount++;
+      // Always return tool_calls to trigger infinite recursion
+      return {
+        content: "Tool response",
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+        tool_calls: [
+          {
+            type: "function" as const,
+            id: `call-${callCount}`,
+            function: { name: "test-tool", arguments: "{}" },
+          },
+        ],
+      };
+    });
+
+    const container = createContainer();
+    const aiManager = new AIManager(container, {
+      workdir: "/test/workdir",
+      stream: false,
+      maxTurns: 2,
+    });
+
+    await aiManager.sendAIMessage({ recursionDepth: 0 });
+
+    // maxTurns: 2 means depth 0 + depth 1 = 2 calls, then stopped
+    expect(aiService.callAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it("should not affect behavior when maxTurns is unset", async () => {
+    let callCount = 0;
+    vi.mocked(aiService.callAgent).mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        // First call returns tool_calls (triggers recursion)
+        return {
+          content: "Tool response",
+          usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+          tool_calls: [
+            {
+              type: "function" as const,
+              id: "call-1",
+              function: { name: "test-tool", arguments: "{}" },
+            },
+          ],
+        };
+      }
+      // Second call returns no tool_calls (stops recursion naturally)
+      return {
+        content: "Final response",
+        usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+        tool_calls: [],
+      };
+    });
+
+    const container = createContainer();
+    const aiManager = new AIManager(container, {
+      workdir: "/test/workdir",
+      stream: false,
+      // No maxTurns specified
+    });
+
+    await aiManager.sendAIMessage({ recursionDepth: 0 });
+
+    // Normal recursion: 2 calls
+    expect(aiService.callAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it("should stop at exact maxTurns boundary (maxTurns: 1)", async () => {
+    vi.mocked(aiService.callAgent).mockImplementation(async () => {
+      // Always return tool_calls to trigger recursion
+      return {
+        content: "Tool response",
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+        tool_calls: [
+          {
+            type: "function" as const,
+            id: "call-1",
+            function: { name: "test-tool", arguments: "{}" },
+          },
+        ],
+      };
+    });
+
+    const container = createContainer();
+    const aiManager = new AIManager(container, {
+      workdir: "/test/workdir",
+      stream: false,
+      maxTurns: 1,
+    });
+
+    await aiManager.sendAIMessage({ recursionDepth: 0 });
+
+    // maxTurns: 1 means only the initial call, no recursion
+    expect(aiService.callAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("should log when maxTurns stops recursion", async () => {
+    vi.mocked(aiService.callAgent).mockImplementation(async () => {
+      // Always return tool_calls to trigger recursion
+      return {
+        content: "Tool response",
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+        tool_calls: [
+          {
+            type: "function" as const,
+            id: "call-1",
+            function: { name: "test-tool", arguments: "{}" },
+          },
+        ],
+      };
+    });
+
+    const container = createContainer();
+    const aiManager = new AIManager(container, {
+      workdir: "/test/workdir",
+      stream: false,
+      maxTurns: 2,
+    });
+
+    await aiManager.sendAIMessage({ recursionDepth: 0 });
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining("Max turns"),
+    );
+  });
+});

--- a/packages/agent-sdk/tests/managers/forkedAgentManager.test.ts
+++ b/packages/agent-sdk/tests/managers/forkedAgentManager.test.ts
@@ -293,4 +293,21 @@ describe("ForkedAgentManager", () => {
     expect(forkedAgentManager.getActiveForks()).toHaveLength(1);
     expect(forkedAgentManager.getActiveForks()[0].id).toBe(id2);
   });
+
+  it("should pass maxTurns through forkAndExecute to createInstance", async () => {
+    await forkedAgentManager.forkAndExecute(
+      "general-purpose",
+      mockMessages,
+      { ...mockParameters, maxTurns: 5 },
+      mockPrompt,
+    );
+
+    await vi.waitFor(() => {
+      expect(mockSubagentManager.createInstance).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ maxTurns: 5 }),
+        false,
+      );
+    });
+  });
 });

--- a/packages/agent-sdk/tests/services/autoMemoryService.test.ts
+++ b/packages/agent-sdk/tests/services/autoMemoryService.test.ts
@@ -173,4 +173,19 @@ describe("AutoMemoryService", () => {
     await autoMemoryService.onTurnEnd("/workdir");
     expect(mockForkedAgentManager.forkAndExecute).toHaveBeenCalledTimes(2);
   });
+
+  it("should pass maxTurns: 5 to forkAndExecute", async () => {
+    mockMessageManager.getMessages.mockReturnValue([
+      { id: "msg1", role: "user", blocks: [] },
+    ]);
+
+    await autoMemoryService.onTurnEnd("/workdir");
+
+    expect(mockForkedAgentManager.forkAndExecute).toHaveBeenCalledWith(
+      "general-purpose",
+      expect.any(Array),
+      expect.objectContaining({ maxTurns: 5 }),
+      expect.any(String),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Thread `maxTurns` through the call chain to prevent runaway recursion in auto-memory extraction forked agents, matching Claude Code's pattern (`maxTurns: 5`) for preventing verification rabbit-holes.

## Changes

### Source files
- **aiManager.ts** — Add `maxTurns` option to `AIManagerOptions`, store it, and check before recursive `sendAIMessage` call
- **subagentManager.ts** — Thread `maxTurns` through `createInstance` parameters to `AIManager` constructor
- **forkedAgentManager.ts** — Thread `maxTurns` through `forkAndExecute`/`executeFork` to `createInstance`
- **autoMemoryService.ts** — Add `maxTurns: 5` to `forkAndExecute` call

### Tests
- **aiManager.maxTurns.test.ts** (new) — 4 test cases: stops at maxTurns, no effect when unset, boundary at 1, logs on stop
- **forkedAgentManager.test.ts** — 1 test case: passes maxTurns through
- **autoMemoryService.test.ts** — 1 test case: passes maxTurns: 5

## Verification

- Build succeeds
- All 2408 tests pass
