### PR TITLE
fix: gracefully handle missing session during restoration

### DIFF
--- a/packages/agent-sdk/src/services/session.ts
+++ b/packages/agent-sdk/src/services/session.ts
@@ -953,7 +953,12 @@ export async function handleSessionRestoration(
       // Use only JSONL format - no legacy support
       sessionToRestore = await loadSessionFromJsonl(restoreSessionId, workdir);
       if (!sessionToRestore) {
-        throw new Error(`Session not found: ${restoreSessionId}`);
+        // Session doesn't exist on disk (e.g. new project with no messages saved yet).
+        // Gracefully fall back to starting fresh instead of throwing.
+        logger?.warn(
+          `Session ${restoreSessionId} not found on disk, starting fresh session`,
+        );
+        return;
       }
     } else if (continueLastSession) {
       // Use only JSONL format - no legacy support

--- a/packages/agent-sdk/tests/services/session.extra.test.ts
+++ b/packages/agent-sdk/tests/services/session.extra.test.ts
@@ -243,21 +243,23 @@ describe("session service - additional coverage", () => {
       );
     });
 
-    it("should throw if restoreSessionId not found", async () => {
-      const spyError = vi.spyOn(console, "error").mockImplementation(() => {});
+    it("should return undefined if restoreSessionId not found (graceful fallback)", async () => {
+      const spyWarn = vi.spyOn(logger, "warn").mockImplementation(() => {});
 
       vi.mocked(fs.access).mockRejectedValue(new Error("ENOENT"));
 
-      await expect(
-        handleSessionRestoration(validSessionId, false, workdir),
-      ).rejects.toThrow(`Session not found: ${validSessionId}`);
+      const result = await handleSessionRestoration(
+        validSessionId,
+        false,
+        workdir,
+      );
+      expect(result).toBeUndefined();
 
-      expect(spyError).toHaveBeenCalledWith(
-        "Failed to restore session:",
-        expect.any(Error),
+      expect(spyWarn).toHaveBeenCalledWith(
+        `Session ${validSessionId} not found on disk, starting fresh session`,
       );
 
-      spyError.mockRestore();
+      spyWarn.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## Problem

When launching wave-code in a new project and installing a plugin before sending any messages, `recreateAgent()` captures the sessionId, destroys the agent, then calls `initializeAgent(currentSessionId)`. Since no messages have been saved yet, the session file doesn't exist on disk, and `handleSessionRestoration` throws `Session not found`.

## Fix

In `handleSessionRestoration`, when `restoreSessionId` is provided but the session doesn't exist on disk, return `undefined` (starting fresh) instead of throwing. A warning is logged for visibility.

## Changes

- `packages/agent-sdk/src/services/session.ts`: Graceful fallback when session not found
- `packages/agent-sdk/tests/services/session.extra.test.ts`: Update test to verify new behavior