### PR TITLE
feat: change worktree location to .wave/worktrees inside repo

### DIFF
--- a/packages/code/src/utils/worktree.ts
+++ b/packages/code/src/utils/worktree.ts
@@ -21,13 +21,7 @@ export interface WorktreeSession {
  */
 export function createWorktree(name: string, cwd: string): WorktreeSession {
   const repoRoot = getGitMainRepoRoot(cwd);
-  const projectName = path.basename(repoRoot);
-  const worktreePath = path.join(
-    repoRoot,
-    "..",
-    `${projectName}.worktrees`,
-    name,
-  );
+  const worktreePath = path.join(repoRoot, ".wave", "worktrees", name);
   const branchName = `worktree-${name}`;
   const baseBranch = getDefaultRemoteBranch(cwd);
 

--- a/packages/code/tests/utils/worktree.test.ts
+++ b/packages/code/tests/utils/worktree.test.ts
@@ -32,7 +32,7 @@ describe("worktree utils", () => {
       const session = createWorktree("my-feat", "/repo/root");
 
       expect(session.name).toBe("my-feat");
-      expect(session.path).toBe("/repo/root.worktrees/my-feat");
+      expect(session.path).toBe("/repo/root/.wave/worktrees/my-feat");
       expect(session.branch).toBe("worktree-my-feat");
       expect(session.repoRoot).toBe("/repo/root");
       expect(session.isNew).toBe(true);
@@ -122,7 +122,7 @@ describe("worktree utils", () => {
     it("should remove worktree and branch", () => {
       const session = {
         name: "my-feat",
-        path: "/repo/root.worktrees/my-feat",
+        path: "/repo/root/.wave/worktrees/my-feat",
         branch: "worktree-my-feat",
         repoRoot: "/repo/root",
         hasUncommittedChanges: false,
@@ -147,7 +147,7 @@ describe("worktree utils", () => {
     it("should remove worktree, original branch, and current branch if different", () => {
       const session = {
         name: "my-feat",
-        path: "/repo/root.worktrees/my-feat",
+        path: "/repo/root/.wave/worktrees/my-feat",
         branch: "worktree-my-feat",
         repoRoot: "/repo/root",
         hasUncommittedChanges: false,
@@ -182,7 +182,7 @@ describe("worktree utils", () => {
     it("should NOT remove current branch if it is a protected branch", () => {
       const session = {
         name: "my-feat",
-        path: "/repo/root.worktrees/my-feat",
+        path: "/repo/root/.wave/worktrees/my-feat",
         branch: "worktree-my-feat",
         repoRoot: "/repo/root",
         hasUncommittedChanges: false,
@@ -224,7 +224,7 @@ describe("worktree utils", () => {
 
       const session = {
         name: "my-feat",
-        path: "/repo/root.worktrees/my-feat",
+        path: "/repo/root/.wave/worktrees/my-feat",
         branch: "worktree-my-feat",
         repoRoot: "/repo/root",
         hasUncommittedChanges: false,


### PR DESCRIPTION
Move worktrees from sibling directory ({repo}/../{project}.worktrees/) to inside the repo under .wave/worktrees/ for better organization.

## Changes

- **packages/code/src/utils/worktree.ts**: Updated `createWorktree()` to create worktrees at `{repoRoot}/.wave/worktrees/{name}` instead of `{repoRoot}/../{projectName}.worktrees/{name}`
- **packages/code/tests/utils/worktree.test.ts**: Updated all path assertions to match new location

All 9 tests pass.