### PR TITLE
feat: always include bypassPermissions in Shift+Tab cycle, style as red bold

### DIFF
--- a/packages/code/src/components/InputBox.tsx
+++ b/packages/code/src/components/InputBox.tsx
@@ -57,7 +57,6 @@ export const InputBox: React.FC<InputBoxProps> = ({
   const {
     permissionMode: chatPermissionMode,
     setPermissionMode: setChatPermissionMode,
-    allowBypassInCycle: chatAllowBypassInCycle,
     handleRewindSelect,
     backgroundCurrentTask,
     messages,
@@ -114,7 +113,6 @@ export const InputBox: React.FC<InputBoxProps> = ({
     // Permission mode
     permissionMode,
     setPermissionMode,
-    setAllowBypassInCycle,
     // BTW state
     btwState,
     // Main handler
@@ -137,11 +135,6 @@ export const InputBox: React.FC<InputBoxProps> = ({
   useEffect(() => {
     setPermissionMode(chatPermissionMode);
   }, [chatPermissionMode, setPermissionMode]);
-
-  // Sync allowBypassInCycle from useChat to InputManager
-  useEffect(() => {
-    setAllowBypassInCycle(chatAllowBypassInCycle);
-  }, [chatAllowBypassInCycle, setAllowBypassInCycle]);
 
   // Use the InputManager's unified input handler
   useInput(async (input, key) => {

--- a/packages/code/src/components/StatusLine.tsx
+++ b/packages/code/src/components/StatusLine.tsx
@@ -25,7 +25,16 @@ export const StatusLine: React.FC<StatusLineProps> = ({
       ) : (
         <Text color="gray">
           Mode:{" "}
-          <Text color={permissionMode === "plan" ? "yellow" : "cyan"}>
+          <Text
+            color={
+              permissionMode === "plan"
+                ? "yellow"
+                : permissionMode === "bypassPermissions"
+                  ? "red"
+                  : "cyan"
+            }
+            bold={permissionMode === "bypassPermissions"}
+          >
             {permissionMode}
           </Text>{" "}
           (Shift+Tab to cycle)

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -79,7 +79,6 @@ export interface ChatContextType {
   // Permission functionality
   permissionMode: PermissionMode;
   setPermissionMode: (mode: PermissionMode) => void;
-  allowBypassInCycle: boolean;
   // Permission confirmation state
   isConfirmationVisible: boolean;
   hasPendingConfirmations: boolean;
@@ -286,9 +285,6 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
 
   // Status metadata state
   const [workingDirectory, setWorkingDirectory] = useState("");
-
-  const allowBypassInCycle =
-    !!bypassPermissions || initialPermissionMode === "bypassPermissions";
 
   const agentRef = useRef<Agent | null>(null);
 
@@ -750,7 +746,6 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
     hasSlashCommand,
     permissionMode,
     setPermissionMode,
-    allowBypassInCycle,
     isConfirmationVisible,
     hasPendingConfirmations: confirmationQueue.length > 0,
     confirmingTool,

--- a/packages/code/src/hooks/useInputManager.ts
+++ b/packages/code/src/hooks/useInputManager.ts
@@ -350,10 +350,6 @@ export const useInputManager = (
     callbacksRef.current.onPermissionModeChange?.(mode);
   }, []);
 
-  const setAllowBypassInCycle = useCallback((allow: boolean) => {
-    dispatch({ type: "SET_ALLOW_BYPASS_IN_CYCLE", payload: allow });
-  }, []);
-
   const setBtwState = useCallback(
     (payload: Partial<import("../managers/inputReducer.js").BtwState>) => {
       dispatch({ type: "SET_BTW_STATE", payload });
@@ -494,7 +490,6 @@ export const useInputManager = (
     setShowPluginManager,
     setShowModelSelector,
     setPermissionMode,
-    setAllowBypassInCycle,
     setBtwState,
 
     // Image management

--- a/packages/code/src/managers/inputHandlers.ts
+++ b/packages/code/src/managers/inputHandlers.ts
@@ -124,12 +124,8 @@ export const cyclePermissionMode = (
   currentMode: PermissionMode,
   dispatch: React.Dispatch<InputAction>,
   callbacks: Partial<InputManagerCallbacks>,
-  allowBypassInCycle: boolean = false,
 ) => {
-  const modes: PermissionMode[] = ["default", "acceptEdits", "plan"];
-  if (allowBypassInCycle) {
-    modes.push("bypassPermissions");
-  }
+  const modes: PermissionMode[] = ["default", "acceptEdits", "plan", "bypassPermissions"];
   const currentIndex = modes.indexOf(currentMode);
   const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % modes.length;
   const nextMode = modes[nextIndex];
@@ -768,7 +764,6 @@ export const handleInput = async (
       state.permissionMode,
       dispatch,
       callbacks,
-      state.allowBypassInCycle,
     );
     return true;
   }

--- a/packages/code/src/managers/inputReducer.ts
+++ b/packages/code/src/managers/inputReducer.ts
@@ -85,7 +85,6 @@ export interface InputState {
   showPluginManager: boolean;
   showModelSelector: boolean;
   permissionMode: PermissionMode;
-  allowBypassInCycle: boolean;
   selectorJustUsed: boolean;
   isPasting: boolean;
   pasteBuffer: string;
@@ -122,7 +121,6 @@ export const initialState: InputState = {
   showPluginManager: false,
   showModelSelector: false,
   permissionMode: "default",
-  allowBypassInCycle: false,
   selectorJustUsed: false,
   isPasting: false,
   pasteBuffer: "",
@@ -166,7 +164,6 @@ export type InputAction =
   | { type: "SET_SHOW_PLUGIN_MANAGER"; payload: boolean }
   | { type: "SET_SHOW_MODEL_SELECTOR"; payload: boolean }
   | { type: "SET_PERMISSION_MODE"; payload: PermissionMode }
-  | { type: "SET_ALLOW_BYPASS_IN_CYCLE"; payload: boolean }
   | { type: "SET_SELECTOR_JUST_USED"; payload: boolean }
   | { type: "INSERT_TEXT_WITH_PLACEHOLDER"; payload: string }
   | { type: "CLEAR_LONG_TEXT_MAP" }
@@ -372,8 +369,6 @@ export function inputReducer(
       };
     case "SET_PERMISSION_MODE":
       return { ...state, permissionMode: action.payload };
-    case "SET_ALLOW_BYPASS_IN_CYCLE":
-      return { ...state, allowBypassInCycle: action.payload };
     case "SET_SELECTOR_JUST_USED":
       return { ...state, selectorJustUsed: action.payload };
     case "INSERT_TEXT_WITH_PLACEHOLDER": {

--- a/packages/code/tests/components/ChatInterface.loading.test.tsx
+++ b/packages/code/tests/components/ChatInterface.loading.test.tsx
@@ -40,7 +40,6 @@ describe("ChatInterface Loading State", () => {
     slashCommands: [],
     hasSlashCommand: vi.fn(),
     isTaskListVisible: true,
-    allowBypassInCycle: false,
     getModelConfig: vi.fn().mockReturnValue({
       model: "test-model",
       fastModel: "test-fast-model",

--- a/packages/code/tests/components/ChatInterface.rewind.test.tsx
+++ b/packages/code/tests/components/ChatInterface.rewind.test.tsx
@@ -60,7 +60,6 @@ describe("ChatInterface Rewind Visibility", () => {
       tasks: [],
       isTaskListVisible: true,
       setIsTaskListVisible: vi.fn(),
-      allowBypassInCycle: false,
       getModelConfig: vi.fn().mockReturnValue({
         model: "test-model",
         fastModel: "test-fast-model",
@@ -142,7 +141,6 @@ describe("ChatInterface Rewind Visibility", () => {
       tasks: [],
       isTaskListVisible: true,
       setIsTaskListVisible: vi.fn(),
-      allowBypassInCycle: false,
       getModelConfig: vi.fn().mockReturnValue({
         model: "test-model",
         fastModel: "test-fast-model",

--- a/packages/code/tests/managers/inputHandlers.test.ts
+++ b/packages/code/tests/managers/inputHandlers.test.ts
@@ -234,7 +234,7 @@ describe("inputHandlers", () => {
   });
 
   describe("cyclePermissionMode", () => {
-    it("should cycle through modes", () => {
+    it("should cycle through modes including bypassPermissions", () => {
       cyclePermissionMode("default", dispatch, callbacks);
       expect(dispatch).toHaveBeenCalledWith({
         type: "SET_PERMISSION_MODE",
@@ -253,6 +253,12 @@ describe("inputHandlers", () => {
       cyclePermissionMode("plan", dispatch, callbacks);
       expect(dispatch).toHaveBeenCalledWith({
         type: "SET_PERMISSION_MODE",
+        payload: "bypassPermissions",
+      });
+
+      cyclePermissionMode("bypassPermissions", dispatch, callbacks);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: "SET_PERMISSION_MODE",
         payload: "default",
       });
     });
@@ -263,20 +269,6 @@ describe("inputHandlers", () => {
         dispatch,
         callbacks,
       );
-      expect(dispatch).toHaveBeenCalledWith({
-        type: "SET_PERMISSION_MODE",
-        payload: "default",
-      });
-    });
-
-    it("should include bypassPermissions in cycle if allowBypassInCycle is true", () => {
-      cyclePermissionMode("plan", dispatch, callbacks, true);
-      expect(dispatch).toHaveBeenCalledWith({
-        type: "SET_PERMISSION_MODE",
-        payload: "bypassPermissions",
-      });
-
-      cyclePermissionMode("bypassPermissions", dispatch, callbacks, true);
       expect(dispatch).toHaveBeenCalledWith({
         type: "SET_PERMISSION_MODE",
         payload: "default",

--- a/packages/code/tests/managers/inputReducer.test.ts
+++ b/packages/code/tests/managers/inputReducer.test.ts
@@ -32,7 +32,6 @@ describe("inputReducer", () => {
       showStatusCommand: false,
       showModelSelector: false,
       permissionMode: "default",
-      allowBypassInCycle: false,
       selectorJustUsed: false,
       isPasting: false,
       pasteBuffer: "",
@@ -427,13 +426,6 @@ describe("inputReducer", () => {
       payload: "plan",
     });
     expect(state.permissionMode).toBe("plan");
-  });
-  it("should handle SET_ALLOW_BYPASS_IN_CYCLE", () => {
-    const state = inputReducer(initialState, {
-      type: "SET_ALLOW_BYPASS_IN_CYCLE",
-      payload: true,
-    });
-    expect(state.allowBypassInCycle).toBe(true);
   });
 
   it("should handle SET_SELECTOR_JUST_USED", () => {

--- a/specs/024-tool-permission-system/spec.md
+++ b/specs/024-tool-permission-system/spec.md
@@ -139,14 +139,13 @@ As a user, I want the system to ask for my explicit permission before modifying 
 
 ### User Story 16 - CLI Mode Cycling (Priority: P2)
 
-As a CLI user, I want to quickly switch between permission modes during a session using a keyboard shortcut, so that I can easily toggle between manual control, automatic edits, and planning.
+As a CLI user, I want to quickly switch between permission modes during a session using a keyboard shortcut, so that I can easily toggle between manual control, automatic edits, planning, and bypass.
 
 **Acceptance Scenarios**:
 1. **Given** a CLI session is active and in `default` mode, **When** the user presses `Shift+Tab`, **Then** the permission mode changes to `acceptEdits`.
 2. **Given** the CLI is in `acceptEdits` mode, **When** the user presses `Shift+Tab`, **Then** the permission mode changes to `plan`.
-3. **Given** the CLI is in `plan` mode, **When** the user presses `Shift+Tab`, **Then** the permission mode changes back to `default` (unless `bypassPermissions` was enabled at start).
-4. **Given** the CLI was started with `--dangerously-skip-permissions` or `--permission-mode bypassPermissions`, **When** the user cycles through modes, **Then** `bypassPermissions` is included in the cycle (e.g., `plan` -> `bypassPermissions` -> `default`).
-5. **Given** the CLI was NOT started with bypass flags, **When** the user cycles through modes, **Then** `bypassPermissions` is NOT included in the cycle.
+3. **Given** the CLI is in `plan` mode, **When** the user presses `Shift+Tab`, **Then** the permission mode changes to `bypassPermissions`.
+4. **Given** the CLI is in `bypassPermissions` mode, **When** the user presses `Shift+Tab`, **Then** the permission mode changes back to `default`.
 
 ### User Story 17 - Auto-deny unapproved tools (Priority: P1)
 
@@ -181,8 +180,7 @@ As a user, I want the agent to use the dedicated `Write` and `Edit` tools for fi
 - **FR-003**: CLI MUST provide a confirmation component for restricted tools in "default" mode.
 - **FR-004**: Confirmation component MUST support "Yes", "Yes, and don't ask again", "Yes, and auto-accept edits" (for FS tools), and alternative instructions via text input.
 - **FR-005**: System MUST support a `canUseTool` callback in the Agent SDK for custom permission logic.
-- **FR-006**: System MUST support cycling through permission modes (default -> acceptEdits -> plan) via `Shift+Tab`.
-- **FR-006.1**: `bypassPermissions` MUST ONLY be included in the cycle if the session was started with `--dangerously-skip-permissions` or `--permission-mode bypassPermissions`.
+- **FR-006**: System MUST support cycling through permission modes (default -> acceptEdits -> plan -> bypassPermissions) via `Shift+Tab`.
 - **FR-021**: System MUST hide the "Don't ask again" option for commands identified as dangerous or out-of-bounds.
 - **FR-022**: System MUST automatically deny bash commands with heredoc write redirections (`cat <<EOF > file`) and remind the agent to use the dedicated `Write` or `Edit` tools for file modifications.
 - **FR-056**: System MUST detect write redirections (`>`, `>>`, etc.) in bash commands and treat them as dangerous, hiding the "Don't ask again" option.


### PR DESCRIPTION
## Summary

Always include `bypassPermissions` in the Shift+Tab mode cycle and style it as red bold in the status line.

## Changes

### Permission Mode Cycling
- Remove `allowBypassInCycle` state — `bypassPermissions` is now always included in the cycle
- New cycle order: `default` → `acceptEdits` → `plan` → `bypassPermissions` → `default`
- Previously, `bypassPermissions` was only included if the session started with `--dangerously-skip-permissions` or `--permission-mode bypassPermissions`

### StatusLine Styling
- `bypassPermissions` rendered in **red bold** in the status line, matching the `Esc` indicator style in LoadingIndicator

### Spec Updates
- Removed FR-006.1 restriction on conditional bypass inclusion
- Updated FR-006 to reflect new 4-mode cycle
- Updated User Story 16 acceptance scenarios

### Test Updates
- Updated `cyclePermissionMode` tests to cover full 4-mode cycle
- Removed `SET_ALLOW_BYPASS_IN_CYCLE` reducer test
- Removed `allowBypassInCycle` from mock context values