### PR TITLE
refactor: simplify analyzeEditMismatch to return generic error message

### DIFF
--- a/packages/agent-sdk/src/tools/editTool.ts
+++ b/packages/agent-sdk/src/tools/editTool.ts
@@ -136,7 +136,7 @@ Usage:
         return {
           success: false,
           content: "",
-          error: analyzeEditMismatch(originalContent, oldString),
+          error: analyzeEditMismatch(),
         };
       }
 

--- a/packages/agent-sdk/src/utils/editUtils.ts
+++ b/packages/agent-sdk/src/utils/editUtils.ts
@@ -1,7 +1,6 @@
 /**
  * Utility functions for file editing tools
  */
-import { formatLineNumberPrefix } from "./stringUtils.js";
 
 /**
  * Escape regular expression special characters
@@ -11,77 +10,8 @@ export function escapeRegExp(string: string): string {
 }
 
 /**
- * Analyze why an edit failed by finding the best partial match and highlighting mismatches.
+ * Returns a generic error message when old_string is not found.
  */
-export function analyzeEditMismatch(
-  content: string,
-  searchString: string,
-): string {
-  const contentLines = content.split("\n");
-  const searchLines = searchString.split("\n");
-
-  if (searchLines.length === 0 || contentLines.length === 0) {
-    return "old_string not found in file (empty search or content)";
-  }
-
-  let bestMatchIndex = -1;
-  let bestMatchScore = -1;
-
-  // Sliding window to find the best partial match
-  for (let i = 0; i <= contentLines.length - searchLines.length; i++) {
-    let currentScore = 0;
-    for (let j = 0; j < searchLines.length; j++) {
-      if (contentLines[i + j] === searchLines[j]) {
-        currentScore++;
-      }
-    }
-
-    // Heuristic: prioritize matches where first or last lines match
-    if (contentLines[i] === searchLines[0]) currentScore += 0.5;
-    if (
-      contentLines[i + searchLines.length - 1] ===
-      searchLines[searchLines.length - 1]
-    )
-      currentScore += 0.5;
-
-    // Also consider trimmed matches to catch indentation issues
-    for (let j = 0; j < searchLines.length; j++) {
-      if (
-        contentLines[i + j].trim() === searchLines[j].trim() &&
-        contentLines[i + j] !== searchLines[j]
-      ) {
-        currentScore += 0.1;
-      }
-    }
-
-    if (currentScore > bestMatchScore) {
-      bestMatchScore = currentScore;
-      bestMatchIndex = i;
-    }
-  }
-
-  // If no decent match found (score <= 0), return generic message
-  if (bestMatchScore <= 0) {
-    return "old_string not found in file (no similar block found)";
-  }
-
-  // Generate detailed report
-  const reportLines: string[] = [
-    `old_string not found in file. Best partial match found at line ${bestMatchIndex + 1}:`,
-  ];
-
-  for (let j = 0; j < searchLines.length; j++) {
-    const lineNum = bestMatchIndex + j + 1;
-    const actualLine = contentLines[bestMatchIndex + j];
-    const expectedLine = searchLines[j];
-
-    if (actualLine === expectedLine) {
-      reportLines.push(`${formatLineNumberPrefix(lineNum)}${actualLine}`);
-    } else {
-      reportLines.push(`${formatLineNumberPrefix(lineNum)}- ${expectedLine}`);
-      reportLines.push(`${formatLineNumberPrefix(lineNum)}+ ${actualLine}`);
-    }
-  }
-
-  return reportLines.join("\n");
+export function analyzeEditMismatch(): string {
+  return "old_string not found in file";
 }

--- a/packages/agent-sdk/tests/utils/mismatchAnalysis.test.ts
+++ b/packages/agent-sdk/tests/utils/mismatchAnalysis.test.ts
@@ -2,43 +2,7 @@ import { describe, it, expect } from "vitest";
 import { analyzeEditMismatch } from "../../src/utils/editUtils.js";
 
 describe("analyzeEditMismatch", () => {
-  it("should return generic message if no similarity found", () => {
-    const content = "line 1\nline 2\nline 3";
-    const search = "completely\ndifferent";
-    const result = analyzeEditMismatch(content, search);
-    expect(result).toBe(
-      "old_string not found in file (no similar block found)",
-    );
-  });
-
-  it("should highlight a single line mismatch", () => {
-    const content = "const x = 1;\nconst y = 3;\nreturn x + y;";
-    const search = "const x = 1;\nconst y = 2;\nreturn x + y;";
-    const result = analyzeEditMismatch(content, search);
-
-    expect(result).toContain("Best partial match found at line 1:");
-    expect(result).toContain("     1\tconst x = 1;");
-    expect(result).toContain("     2\t- const y = 2;");
-    expect(result).toContain("     2\t+ const y = 3;");
-    expect(result).toContain("     3\treturn x + y;");
-  });
-
-  it("should find the best match among multiple candidates", () => {
-    const content = "block 1\nline A\nline B\n\nblock 2\nline A\nline C";
-    const search = "line A\nline B";
-    const result = analyzeEditMismatch(content, search);
-
-    expect(result).toContain("Best partial match found at line 2:");
-    expect(result).toContain("     2\tline A");
-    expect(result).toContain("     3\tline B");
-  });
-
-  it("should handle indentation mismatches explicitly", () => {
-    const content = "  const x = 1;";
-    const search = "const x = 1;";
-    const result = analyzeEditMismatch(content, search);
-
-    expect(result).toContain("- const x = 1;");
-    expect(result).toContain("+   const x = 1;");
+  it("should return generic message", () => {
+    expect(analyzeEditMismatch()).toBe("old_string not found in file");
   });
 });


### PR DESCRIPTION
## Summary

Simplified the `analyzeEditMismatch` utility function to return a generic error message instead of performing detailed partial match analysis with line-by-line diff output.

## Changes

- **`packages/agent-sdk/src/utils/editUtils.ts`**: Replaced the sliding-window partial match algorithm and detailed mismatch report with a simple return of `"old_string not found in file"`. Removed unused `formatLineNumberPrefix` import.
- **`packages/agent-sdk/src/tools/editTool.ts`**: Updated call site to match simplified function signature.
- **`packages/agent-sdk/tests/utils/mismatchAnalysis.test.ts`**: Consolidated 4 detailed mismatch tests into a single test verifying the generic error message.

## Rationale

The detailed partial match analysis (finding best-matching line ranges, computing similarity scores, and rendering diff-style output) added significant complexity and code size without providing proportional value. A concise error message is sufficient for the AI to understand the edit failed and retry.