### PR TITLE
fix: eliminate stale closures in useInput by refactoring to useReducer

### DIFF
--- a/packages/code/src/components/BackgroundTaskManager.tsx
+++ b/packages/code/src/components/BackgroundTaskManager.tsx
@@ -24,12 +24,25 @@ export const BackgroundTaskManager: React.FC<BackgroundTaskManagerProps> = ({
     viewMode: "list",
     detailTaskId: null,
     detailOutput: null,
+    pendingEffect: null,
   } as BackgroundTaskManagerState);
 
-  const stateRef = React.useRef(state);
+  // Handle pending effects
   useEffect(() => {
-    stateRef.current = state;
-  }, [state]);
+    if (!state.pendingEffect) return;
+
+    const effect = state.pendingEffect;
+    dispatch({ type: "CLEAR_PENDING_EFFECT" });
+
+    switch (effect.type) {
+      case "CANCEL":
+        onCancel();
+        break;
+      case "STOP_TASK":
+        stopBackgroundTask(effect.taskId);
+        break;
+    }
+  }, [state.pendingEffect, onCancel, stopBackgroundTask]);
 
   const { tasks, selectedIndex, viewMode, detailTaskId, detailOutput } = state;
 
@@ -70,10 +83,6 @@ export const BackgroundTaskManager: React.FC<BackgroundTaskManagerProps> = ({
     return new Date(timestamp).toLocaleTimeString();
   };
 
-  const stopTask = (taskId: string) => {
-    stopBackgroundTask(taskId);
-  };
-
   // Calculate visible window
   const startIndex = Math.max(
     0,
@@ -85,58 +94,7 @@ export const BackgroundTaskManager: React.FC<BackgroundTaskManagerProps> = ({
   const visibleTasks = tasks.slice(startIndex, startIndex + MAX_VISIBLE_ITEMS);
 
   useInput((input, key) => {
-    const currentState = stateRef.current;
-    if (currentState.viewMode === "list") {
-      // List mode navigation
-      if (key.return) {
-        dispatch({ type: "SELECT_CURRENT" });
-        return;
-      }
-
-      if (key.escape) {
-        onCancel();
-        return;
-      }
-
-      if (key.upArrow) {
-        dispatch({ type: "MOVE_UP" });
-        return;
-      }
-
-      if (key.downArrow) {
-        dispatch({ type: "MOVE_DOWN" });
-        return;
-      }
-
-      if (input === "k") {
-        if (
-          currentState.tasks.length > 0 &&
-          currentState.selectedIndex < currentState.tasks.length
-        ) {
-          const selectedTask = currentState.tasks[currentState.selectedIndex];
-          if (selectedTask.status === "running") {
-            stopTask(selectedTask.id);
-          }
-        }
-        return;
-      }
-    } else if (currentState.viewMode === "detail") {
-      // Detail mode navigation
-      if (key.escape) {
-        dispatch({ type: "RESET_DETAIL" });
-        return;
-      }
-
-      if (input === "k" && currentState.detailTaskId) {
-        const task = currentState.tasks.find(
-          (t) => t.id === currentState.detailTaskId,
-        );
-        if (task && task.status === "running") {
-          stopTask(currentState.detailTaskId);
-        }
-        return;
-      }
-    }
+    dispatch({ type: "HANDLE_KEY", input, key });
   });
 
   if (viewMode === "detail" && detailTaskId && detailOutput) {

--- a/packages/code/src/components/BackgroundTaskManager.tsx
+++ b/packages/code/src/components/BackgroundTaskManager.tsx
@@ -26,6 +26,11 @@ export const BackgroundTaskManager: React.FC<BackgroundTaskManagerProps> = ({
     detailOutput: null,
   } as BackgroundTaskManagerState);
 
+  const stateRef = React.useRef(state);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
   const { tasks, selectedIndex, viewMode, detailTaskId, detailOutput } = state;
 
   // Convert backgroundTasks to local Task format
@@ -80,14 +85,11 @@ export const BackgroundTaskManager: React.FC<BackgroundTaskManagerProps> = ({
   const visibleTasks = tasks.slice(startIndex, startIndex + MAX_VISIBLE_ITEMS);
 
   useInput((input, key) => {
-    if (viewMode === "list") {
+    const currentState = stateRef.current;
+    if (currentState.viewMode === "list") {
       // List mode navigation
       if (key.return) {
-        if (tasks.length > 0 && selectedIndex < tasks.length) {
-          const selectedTask = tasks[selectedIndex];
-          dispatch({ type: "SET_DETAIL_TASK_ID", id: selectedTask.id });
-          dispatch({ type: "SET_VIEW_MODE", mode: "detail" });
-        }
+        dispatch({ type: "SELECT_CURRENT" });
         return;
       }
 
@@ -97,39 +99,40 @@ export const BackgroundTaskManager: React.FC<BackgroundTaskManagerProps> = ({
       }
 
       if (key.upArrow) {
-        dispatch({
-          type: "SELECT_INDEX",
-          index: Math.max(0, selectedIndex - 1),
-        });
+        dispatch({ type: "MOVE_UP" });
         return;
       }
 
       if (key.downArrow) {
-        dispatch({
-          type: "SELECT_INDEX",
-          index: Math.min(tasks.length - 1, selectedIndex + 1),
-        });
+        dispatch({ type: "MOVE_DOWN" });
         return;
       }
 
-      if (input === "k" && tasks.length > 0 && selectedIndex < tasks.length) {
-        const selectedTask = tasks[selectedIndex];
-        if (selectedTask.status === "running") {
-          stopTask(selectedTask.id);
+      if (input === "k") {
+        if (
+          currentState.tasks.length > 0 &&
+          currentState.selectedIndex < currentState.tasks.length
+        ) {
+          const selectedTask = currentState.tasks[currentState.selectedIndex];
+          if (selectedTask.status === "running") {
+            stopTask(selectedTask.id);
+          }
         }
         return;
       }
-    } else if (viewMode === "detail") {
+    } else if (currentState.viewMode === "detail") {
       // Detail mode navigation
       if (key.escape) {
         dispatch({ type: "RESET_DETAIL" });
         return;
       }
 
-      if (input === "k" && detailTaskId) {
-        const task = tasks.find((t) => t.id === detailTaskId);
+      if (input === "k" && currentState.detailTaskId) {
+        const task = currentState.tasks.find(
+          (t) => t.id === currentState.detailTaskId,
+        );
         if (task && task.status === "running") {
-          stopTask(detailTaskId);
+          stopTask(currentState.detailTaskId);
         }
         return;
       }

--- a/packages/code/src/components/CommandSelector.tsx
+++ b/packages/code/src/components/CommandSelector.tsx
@@ -49,24 +49,26 @@ export const CommandSelector: React.FC<CommandSelectorProps> = ({
     startIndex + MAX_VISIBLE_ITEMS,
   );
 
+  const stateRef = React.useRef({ filteredCommands, selectedIndex });
+  React.useEffect(() => {
+    stateRef.current = { filteredCommands, selectedIndex };
+  }, [filteredCommands, selectedIndex]);
+
   useInput((input, key) => {
+    const { filteredCommands: currentCommands, selectedIndex: currentIndex } =
+      stateRef.current;
+
     if (key.return) {
-      if (
-        filteredCommands.length > 0 &&
-        selectedIndex < filteredCommands.length
-      ) {
-        const selectedCommand = filteredCommands[selectedIndex].id;
+      if (currentCommands.length > 0 && currentIndex < currentCommands.length) {
+        const selectedCommand = currentCommands[currentIndex].id;
         onSelect(selectedCommand);
       }
       return;
     }
 
     if (key.tab && onInsert) {
-      if (
-        filteredCommands.length > 0 &&
-        selectedIndex < filteredCommands.length
-      ) {
-        const selectedCommand = filteredCommands[selectedIndex].id;
+      if (currentCommands.length > 0 && currentIndex < currentCommands.length) {
+        const selectedCommand = currentCommands[currentIndex].id;
         onInsert(selectedCommand);
       }
       return;
@@ -78,14 +80,12 @@ export const CommandSelector: React.FC<CommandSelectorProps> = ({
     }
 
     if (key.upArrow) {
-      setSelectedIndex(Math.max(0, selectedIndex - 1));
+      setSelectedIndex(Math.max(0, currentIndex - 1));
       return;
     }
 
     if (key.downArrow) {
-      setSelectedIndex(
-        Math.min(filteredCommands.length - 1, selectedIndex + 1),
-      );
+      setSelectedIndex(Math.min(currentCommands.length - 1, currentIndex + 1));
       return;
     }
   });

--- a/packages/code/src/components/CommandSelector.tsx
+++ b/packages/code/src/components/CommandSelector.tsx
@@ -1,14 +1,18 @@
-import React, { useState } from "react";
+import React, { useReducer, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import type { SlashCommand } from "wave-agent-sdk";
 import { AVAILABLE_COMMANDS } from "../constants/commands.js";
+import {
+  selectorReducer,
+  type SelectorState,
+} from "../reducers/selectorReducer.js";
 
 export interface CommandSelectorProps {
   searchQuery: string;
   onSelect: (command: string) => void;
-  onInsert?: (command: string) => void; // New: Tab key to insert command into input box
+  onInsert?: (command: string) => void;
   onCancel: () => void;
-  commands?: SlashCommand[]; // New optional command list parameter
+  commands?: SlashCommand[];
 }
 
 export const CommandSelector: React.FC<CommandSelectorProps> = ({
@@ -16,14 +20,19 @@ export const CommandSelector: React.FC<CommandSelectorProps> = ({
   onSelect,
   onInsert,
   onCancel,
-  commands = [], // Default to empty array
+  commands = [],
 }) => {
   const MAX_VISIBLE_ITEMS = 3;
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [state, dispatch] = useReducer(selectorReducer, {
+    selectedIndex: 0,
+    pendingDecision: null,
+  } as SelectorState);
+
+  const { selectedIndex, pendingDecision } = state;
 
   // Reset selected index when search query changes
-  React.useEffect(() => {
-    setSelectedIndex(0);
+  useEffect(() => {
+    dispatch({ type: "RESET_INDEX" });
   }, [searchQuery]);
 
   // Merge agent commands and local commands
@@ -35,6 +44,38 @@ export const CommandSelector: React.FC<CommandSelectorProps> = ({
       !searchQuery ||
       command.id.toLowerCase().includes(searchQuery.toLowerCase()),
   );
+
+  // Handle decisions from reducer
+  useEffect(() => {
+    if (!pendingDecision) return;
+
+    if (pendingDecision === "select") {
+      if (
+        filteredCommands.length > 0 &&
+        selectedIndex < filteredCommands.length
+      ) {
+        onSelect(filteredCommands[selectedIndex].id);
+      }
+    } else if (pendingDecision === "insert" && onInsert) {
+      if (
+        filteredCommands.length > 0 &&
+        selectedIndex < filteredCommands.length
+      ) {
+        onInsert(filteredCommands[selectedIndex].id);
+      }
+    } else if (pendingDecision === "cancel") {
+      onCancel();
+    }
+
+    dispatch({ type: "CLEAR_DECISION" });
+  }, [
+    pendingDecision,
+    selectedIndex,
+    filteredCommands,
+    onSelect,
+    onInsert,
+    onCancel,
+  ]);
 
   // Calculate visible window
   const startIndex = Math.max(
@@ -49,45 +90,13 @@ export const CommandSelector: React.FC<CommandSelectorProps> = ({
     startIndex + MAX_VISIBLE_ITEMS,
   );
 
-  const stateRef = React.useRef({ filteredCommands, selectedIndex });
-  React.useEffect(() => {
-    stateRef.current = { filteredCommands, selectedIndex };
-  }, [filteredCommands, selectedIndex]);
-
   useInput((input, key) => {
-    const { filteredCommands: currentCommands, selectedIndex: currentIndex } =
-      stateRef.current;
-
-    if (key.return) {
-      if (currentCommands.length > 0 && currentIndex < currentCommands.length) {
-        const selectedCommand = currentCommands[currentIndex].id;
-        onSelect(selectedCommand);
-      }
-      return;
-    }
-
-    if (key.tab && onInsert) {
-      if (currentCommands.length > 0 && currentIndex < currentCommands.length) {
-        const selectedCommand = currentCommands[currentIndex].id;
-        onInsert(selectedCommand);
-      }
-      return;
-    }
-
-    if (key.escape) {
-      onCancel();
-      return;
-    }
-
-    if (key.upArrow) {
-      setSelectedIndex(Math.max(0, currentIndex - 1));
-      return;
-    }
-
-    if (key.downArrow) {
-      setSelectedIndex(Math.min(currentCommands.length - 1, currentIndex + 1));
-      return;
-    }
+    dispatch({
+      type: "HANDLE_KEY",
+      key,
+      maxIndex: filteredCommands.length - 1,
+      hasInsert: !!onInsert,
+    });
   });
 
   if (filteredCommands.length === 0) {

--- a/packages/code/src/components/ConfirmationSelector.tsx
+++ b/packages/code/src/components/ConfirmationSelector.tsx
@@ -98,7 +98,21 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
     return "Yes, and auto-accept edits";
   };
 
+  const stateRef = React.useRef(state);
+  const questionStateRef = React.useRef(questionState);
+
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  useEffect(() => {
+    questionStateRef.current = questionState;
+  }, [questionState]);
+
   useInput((input, key) => {
+    const currentState = stateRef.current;
+    const currentQuestionState = questionStateRef.current;
+
     if (key.escape) {
       onCancel();
       return;
@@ -122,12 +136,12 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
 
       if (input === " ") {
         const isOtherFocused =
-          questionState.selectedOptionIndex === options.length - 1;
+          currentQuestionState.selectedOptionIndex === options.length - 1;
         if (
           isMultiSelect &&
           (!isOtherFocused ||
-            !questionState.selectedOptionIndices.has(
-              questionState.selectedOptionIndex,
+            !currentQuestionState.selectedOptionIndices.has(
+              currentQuestionState.selectedOptionIndex,
             ))
         ) {
           questionDispatch({
@@ -199,13 +213,13 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
 
     if (key.return) {
       let decision: PermissionDecision | null = null;
-      if (state.selectedOption === "clear") {
+      if (currentState.selectedOption === "clear") {
         decision = {
           behavior: "allow",
           newPermissionMode: "acceptEdits",
           clearContext: true,
         };
-      } else if (state.selectedOption === "allow") {
+      } else if (currentState.selectedOption === "allow") {
         if (toolName === EXIT_PLAN_MODE_TOOL_NAME) {
           decision = { behavior: "allow", newPermissionMode: "default" };
         } else if (toolName === ENTER_PLAN_MODE_TOOL_NAME) {
@@ -213,7 +227,7 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
         } else {
           decision = { behavior: "allow" };
         }
-      } else if (state.selectedOption === "auto") {
+      } else if (currentState.selectedOption === "auto") {
         if (toolName === BASH_TOOL_NAME) {
           const command = (toolInput?.command as string) || "";
           if (command.trim().startsWith("mkdir")) {
@@ -231,8 +245,11 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
         } else {
           decision = { behavior: "allow", newPermissionMode: "acceptEdits" };
         }
-      } else if (state.alternativeText.trim()) {
-        decision = { behavior: "deny", message: state.alternativeText.trim() };
+      } else if (currentState.alternativeText.trim()) {
+        decision = {
+          behavior: "deny",
+          message: currentState.alternativeText.trim(),
+        };
       } else if (toolName === ENTER_PLAN_MODE_TOOL_NAME) {
         decision = {
           behavior: "deny",
@@ -245,7 +262,7 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
       return;
     }
 
-    if (state.selectedOption === "alternative") {
+    if (currentState.selectedOption === "alternative") {
       if (key.leftArrow) {
         dispatch({ type: "MOVE_CURSOR_LEFT" });
         return;
@@ -263,7 +280,9 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
     availableOptions.push("alternative");
 
     if (key.upArrow) {
-      const currentIndex = availableOptions.indexOf(state.selectedOption);
+      const currentIndex = availableOptions.indexOf(
+        currentState.selectedOption,
+      );
       if (currentIndex > 0) {
         dispatch({
           type: "SELECT_OPTION",
@@ -274,7 +293,9 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
     }
 
     if (key.downArrow) {
-      const currentIndex = availableOptions.indexOf(state.selectedOption);
+      const currentIndex = availableOptions.indexOf(
+        currentState.selectedOption,
+      );
       if (currentIndex < availableOptions.length - 1) {
         dispatch({
           type: "SELECT_OPTION",
@@ -285,7 +306,9 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
     }
 
     if (key.tab) {
-      const currentIndex = availableOptions.indexOf(state.selectedOption);
+      const currentIndex = availableOptions.indexOf(
+        currentState.selectedOption,
+      );
       const direction = key.shift ? -1 : 1;
       let nextIndex = currentIndex + direction;
       if (nextIndex < 0) nextIndex = availableOptions.length - 1;

--- a/packages/code/src/components/ConfirmationSelector.tsx
+++ b/packages/code/src/components/ConfirmationSelector.tsx
@@ -7,10 +7,7 @@ import {
   ENTER_PLAN_MODE_TOOL_NAME,
   ASK_USER_QUESTION_TOOL_NAME,
 } from "wave-agent-sdk";
-import {
-  confirmationReducer,
-  type ConfirmationState,
-} from "../reducers/confirmationReducer.js";
+import { confirmationReducer } from "../reducers/confirmationReducer.js";
 import { questionReducer } from "../reducers/questionReducer.js";
 
 const getHeaderColor = (header: string) => {
@@ -67,12 +64,14 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
   useEffect(() => {
     if (state.decision) {
       onDecision(state.decision);
+      dispatch({ type: "CLEAR_DECISION" });
     }
   }, [state.decision, onDecision]);
 
   useEffect(() => {
     if (questionState.decision) {
       onDecision(questionState.decision);
+      questionDispatch({ type: "CLEAR_DECISION" });
     }
   }, [questionState.decision, onDecision]);
 
@@ -98,236 +97,30 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
     return "Yes, and auto-accept edits";
   };
 
-  const stateRef = React.useRef(state);
-  const questionStateRef = React.useRef(questionState);
-
-  useEffect(() => {
-    stateRef.current = state;
-  }, [state]);
-
-  useEffect(() => {
-    questionStateRef.current = questionState;
-  }, [questionState]);
-
   useInput((input, key) => {
-    const currentState = stateRef.current;
-    const currentQuestionState = questionStateRef.current;
-
     if (key.escape) {
       onCancel();
       return;
     }
 
     if (toolName === ASK_USER_QUESTION_TOOL_NAME) {
-      if (!currentQuestion) return;
-      const options = [...currentQuestion.options, { label: "Other" }];
-      const isMultiSelect = currentQuestion.multiSelect;
-
-      if (key.return) {
-        questionDispatch({
-          type: "CONFIRM_ANSWER",
-          currentQuestion,
-          options,
-          isMultiSelect: !!isMultiSelect,
-          questions,
-        });
-        return;
-      }
-
-      if (input === " ") {
-        const isOtherFocused =
-          currentQuestionState.selectedOptionIndex === options.length - 1;
-        if (
-          isMultiSelect &&
-          (!isOtherFocused ||
-            !currentQuestionState.selectedOptionIndices.has(
-              currentQuestionState.selectedOptionIndex,
-            ))
-        ) {
-          questionDispatch({
-            type: "TOGGLE_MULTI_SELECT",
-            optionsLength: options.length,
-          });
-          return;
-        }
-        // If it's other and focused, we don't return here, allowing the input handler below to handle it
-      }
-
-      if (key.upArrow) {
-        questionDispatch({
-          type: "MOVE_OPTION_UP",
-          maxIndex: options.length - 1,
-        });
-        return;
-      }
-      if (key.downArrow) {
-        questionDispatch({
-          type: "MOVE_OPTION_DOWN",
-          maxIndex: options.length - 1,
-        });
-        return;
-      }
-      if (key.tab) {
-        questionDispatch({
-          type: "CYCLE_QUESTION",
-          shift: key.shift,
-          questionCount: questions.length,
-        });
-        return;
-      }
-
-      // Always dispatch Other actions unconditionally; the reducer checks
-      // isOtherFocused from the latest state, so this works correctly even
-      // when inputs are batched before React re-renders.
-      if (key.leftArrow) {
-        questionDispatch({
-          type: "MOVE_OTHER_LEFT",
-          optionsLength: options.length,
-        });
-        return;
-      }
-      if (key.rightArrow) {
-        questionDispatch({
-          type: "MOVE_OTHER_RIGHT",
-          optionsLength: options.length,
-        });
-        return;
-      }
-      if (key.backspace || key.delete) {
-        questionDispatch({
-          type: "DELETE_OTHER",
-          optionsLength: options.length,
-        });
-        return;
-      }
-      if (input && !key.ctrl && !key.meta) {
-        questionDispatch({
-          type: "INSERT_OTHER",
-          text: input,
-          optionsLength: options.length,
-        });
-        return;
-      }
-      return;
-    }
-
-    if (key.return) {
-      let decision: PermissionDecision | null = null;
-      if (currentState.selectedOption === "clear") {
-        decision = {
-          behavior: "allow",
-          newPermissionMode: "acceptEdits",
-          clearContext: true,
-        };
-      } else if (currentState.selectedOption === "allow") {
-        if (toolName === EXIT_PLAN_MODE_TOOL_NAME) {
-          decision = { behavior: "allow", newPermissionMode: "default" };
-        } else if (toolName === ENTER_PLAN_MODE_TOOL_NAME) {
-          decision = { behavior: "allow", newPermissionMode: "plan" };
-        } else {
-          decision = { behavior: "allow" };
-        }
-      } else if (currentState.selectedOption === "auto") {
-        if (toolName === BASH_TOOL_NAME) {
-          const command = (toolInput?.command as string) || "";
-          if (command.trim().startsWith("mkdir")) {
-            decision = { behavior: "allow", newPermissionMode: "acceptEdits" };
-          } else {
-            const rule = suggestedPrefix
-              ? `Bash(${suggestedPrefix})`
-              : `Bash(${toolInput?.command})`;
-            decision = { behavior: "allow", newPermissionRule: rule };
-          }
-        } else if (toolName === ENTER_PLAN_MODE_TOOL_NAME) {
-          decision = { behavior: "allow", newPermissionMode: "plan" };
-        } else if (toolName.startsWith("mcp__")) {
-          decision = { behavior: "allow", newPermissionRule: toolName };
-        } else {
-          decision = { behavior: "allow", newPermissionMode: "acceptEdits" };
-        }
-      } else if (currentState.alternativeText.trim()) {
-        decision = {
-          behavior: "deny",
-          message: currentState.alternativeText.trim(),
-        };
-      } else if (toolName === ENTER_PLAN_MODE_TOOL_NAME) {
-        decision = {
-          behavior: "deny",
-          message: "User chose not to enter plan mode",
-        };
-      }
-      if (decision) {
-        dispatch({ type: "CONFIRM", decision });
-      }
-      return;
-    }
-
-    if (currentState.selectedOption === "alternative") {
-      if (key.leftArrow) {
-        dispatch({ type: "MOVE_CURSOR_LEFT" });
-        return;
-      }
-      if (key.rightArrow) {
-        dispatch({ type: "MOVE_CURSOR_RIGHT" });
-        return;
-      }
-    }
-
-    const availableOptions: ConfirmationState["selectedOption"][] = [];
-    if (toolName === EXIT_PLAN_MODE_TOOL_NAME) availableOptions.push("clear");
-    availableOptions.push("allow");
-    if (!hidePersistentOption) availableOptions.push("auto");
-    availableOptions.push("alternative");
-
-    if (key.upArrow) {
-      const currentIndex = availableOptions.indexOf(
-        currentState.selectedOption,
-      );
-      if (currentIndex > 0) {
-        dispatch({
-          type: "SELECT_OPTION",
-          option: availableOptions[currentIndex - 1],
-        });
-      }
-      return;
-    }
-
-    if (key.downArrow) {
-      const currentIndex = availableOptions.indexOf(
-        currentState.selectedOption,
-      );
-      if (currentIndex < availableOptions.length - 1) {
-        dispatch({
-          type: "SELECT_OPTION",
-          option: availableOptions[currentIndex + 1],
-        });
-      }
-      return;
-    }
-
-    if (key.tab) {
-      const currentIndex = availableOptions.indexOf(
-        currentState.selectedOption,
-      );
-      const direction = key.shift ? -1 : 1;
-      let nextIndex = currentIndex + direction;
-      if (nextIndex < 0) nextIndex = availableOptions.length - 1;
-      if (nextIndex >= availableOptions.length) nextIndex = 0;
-      dispatch({
-        type: "SELECT_OPTION",
-        option: availableOptions[nextIndex],
+      questionDispatch({
+        type: "HANDLE_KEY",
+        input,
+        key,
+        currentQuestion,
+        questions,
       });
-      return;
-    }
-
-    if (input && !key.ctrl && !key.meta && !("alt" in key && key.alt)) {
-      dispatch({ type: "INSERT_TEXT", text: input });
-      return;
-    }
-
-    if (key.backspace || key.delete) {
-      dispatch({ type: "BACKSPACE" });
-      return;
+    } else {
+      dispatch({
+        type: "HANDLE_KEY",
+        input,
+        key,
+        toolName,
+        toolInput,
+        suggestedPrefix,
+        hidePersistentOption,
+      });
     }
   });
 

--- a/packages/code/src/components/DiscoverView.tsx
+++ b/packages/code/src/components/DiscoverView.tsx
@@ -1,27 +1,37 @@
-import React, { useState } from "react";
+import React, { useReducer, useEffect } from "react";
 import { Box, useInput } from "ink";
 import { usePluginManagerContext } from "../contexts/PluginManagerContext.js";
 import { PluginList } from "./PluginList.js";
+import { selectorReducer } from "../reducers/selectorReducer.js";
 
 export const DiscoverView: React.FC = () => {
   const { discoverablePlugins, actions } = usePluginManagerContext();
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [state, dispatch] = useReducer(selectorReducer, {
+    selectedIndex: 0,
+    pendingDecision: null,
+  });
 
-  useInput((input, key) => {
-    if (key.upArrow) {
-      setSelectedIndex(Math.max(0, selectedIndex - 1));
-    } else if (key.downArrow) {
-      setSelectedIndex(
-        Math.min(discoverablePlugins.length - 1, selectedIndex + 1),
-      );
-    } else if (key.return) {
+  const { selectedIndex, pendingDecision } = state;
+
+  useInput((_input, key) => {
+    dispatch({
+      type: "HANDLE_KEY",
+      key,
+      maxIndex: discoverablePlugins.length - 1,
+      hasInsert: false,
+    });
+  });
+
+  useEffect(() => {
+    if (pendingDecision === "select") {
       const plugin = discoverablePlugins[selectedIndex];
       if (plugin) {
         actions.setSelectedId(`${plugin.name}@${plugin.marketplace}`);
         actions.setView("PLUGIN_DETAIL");
       }
+      dispatch({ type: "CLEAR_DECISION" });
     }
-  });
+  }, [pendingDecision, selectedIndex, discoverablePlugins, actions]);
 
   return (
     <Box flexDirection="column">

--- a/packages/code/src/components/FileSelector.tsx
+++ b/packages/code/src/components/FileSelector.tsx
@@ -21,10 +21,18 @@ export const FileSelector: React.FC<FileSelectorProps> = ({
 }) => {
   const [selectedIndex, setSelectedIndex] = useState(0);
 
+  const stateRef = React.useRef({ files, selectedIndex });
+  React.useEffect(() => {
+    stateRef.current = { files, selectedIndex };
+  }, [files, selectedIndex]);
+
   useInput((input, key) => {
+    const currentFiles = stateRef.current.files;
+    const currentIndex = stateRef.current.selectedIndex;
+
     if (key.return || key.tab) {
-      if (files.length > 0 && selectedIndex < files.length) {
-        onSelect(files[selectedIndex].path);
+      if (currentFiles.length > 0 && currentIndex < currentFiles.length) {
+        onSelect(currentFiles[currentIndex].path);
       }
       return;
     }
@@ -35,12 +43,12 @@ export const FileSelector: React.FC<FileSelectorProps> = ({
     }
 
     if (key.upArrow) {
-      setSelectedIndex(Math.max(0, selectedIndex - 1));
+      setSelectedIndex(Math.max(0, currentIndex - 1));
       return;
     }
 
     if (key.downArrow) {
-      setSelectedIndex(Math.min(files.length - 1, selectedIndex + 1));
+      setSelectedIndex(Math.min(currentFiles.length - 1, currentIndex + 1));
       return;
     }
   });

--- a/packages/code/src/components/FileSelector.tsx
+++ b/packages/code/src/components/FileSelector.tsx
@@ -1,6 +1,10 @@
-import React, { useState } from "react";
+import React, { useReducer, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import type { FileItem } from "wave-agent-sdk";
+import {
+  selectorReducer,
+  type SelectorState,
+} from "../reducers/selectorReducer.js";
 
 export { type FileItem } from "wave-agent-sdk";
 
@@ -19,38 +23,40 @@ export const FileSelector: React.FC<FileSelectorProps> = ({
   onSelect,
   onCancel,
 }) => {
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [state, dispatch] = useReducer(selectorReducer, {
+    selectedIndex: 0,
+    pendingDecision: null,
+  } as SelectorState);
 
-  const stateRef = React.useRef({ files, selectedIndex });
-  React.useEffect(() => {
-    stateRef.current = { files, selectedIndex };
-  }, [files, selectedIndex]);
+  const { selectedIndex, pendingDecision } = state;
+
+  // Reset selected index when files change
+  useEffect(() => {
+    dispatch({ type: "RESET_INDEX" });
+  }, [files]);
+
+  // Handle decisions from reducer
+  useEffect(() => {
+    if (!pendingDecision) return;
+
+    if (pendingDecision === "select" || pendingDecision === "insert") {
+      if (files.length > 0 && selectedIndex < files.length) {
+        onSelect(files[selectedIndex].path);
+      }
+    } else if (pendingDecision === "cancel") {
+      onCancel();
+    }
+
+    dispatch({ type: "CLEAR_DECISION" });
+  }, [pendingDecision, selectedIndex, files, onSelect, onCancel]);
 
   useInput((input, key) => {
-    const currentFiles = stateRef.current.files;
-    const currentIndex = stateRef.current.selectedIndex;
-
-    if (key.return || key.tab) {
-      if (currentFiles.length > 0 && currentIndex < currentFiles.length) {
-        onSelect(currentFiles[currentIndex].path);
-      }
-      return;
-    }
-
-    if (key.escape) {
-      onCancel();
-      return;
-    }
-
-    if (key.upArrow) {
-      setSelectedIndex(Math.max(0, currentIndex - 1));
-      return;
-    }
-
-    if (key.downArrow) {
-      setSelectedIndex(Math.min(currentFiles.length - 1, currentIndex + 1));
-      return;
-    }
+    dispatch({
+      type: "HANDLE_KEY",
+      key,
+      maxIndex: files.length - 1,
+      hasInsert: true, // For FileSelector, Tab is also select
+    });
   });
 
   if (files.length === 0) {
@@ -80,24 +86,15 @@ export const FileSelector: React.FC<FileSelectorProps> = ({
   const maxDisplay = 5;
 
   // Calculate display window start and end positions
-  const getDisplayWindow = () => {
-    const startIndex = Math.max(
-      0,
-      Math.min(
-        selectedIndex - Math.floor(maxDisplay / 2),
-        Math.max(0, files.length - maxDisplay),
-      ),
-    );
-    const endIndex = Math.min(files.length, startIndex + maxDisplay);
-
-    return {
-      startIndex,
-      endIndex,
-      displayFiles: files.slice(startIndex, endIndex),
-    };
-  };
-
-  const { startIndex, displayFiles } = getDisplayWindow();
+  const startIndex = Math.max(
+    0,
+    Math.min(
+      selectedIndex - Math.floor(maxDisplay / 2),
+      Math.max(0, files.length - maxDisplay),
+    ),
+  );
+  const endIndex = Math.min(files.length, startIndex + maxDisplay);
+  const displayFiles = files.slice(startIndex, endIndex);
 
   return (
     <Box

--- a/packages/code/src/components/HelpView.tsx
+++ b/packages/code/src/components/HelpView.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from "react";
+import React, { useReducer, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import type { SlashCommand } from "wave-agent-sdk";
 import { AVAILABLE_COMMANDS } from "../constants/commands.js";
+import { helpSelectorReducer } from "../reducers/helpSelectorReducer.js";
 
 export interface HelpViewProps {
   onCancel: () => void;
@@ -12,10 +13,6 @@ export const HelpView: React.FC<HelpViewProps> = ({
   onCancel,
   commands = [],
 }) => {
-  const [activeTab, setActiveTab] = useState<
-    "general" | "commands" | "custom-commands"
-  >("general");
-  const [selectedIndex, setSelectedIndex] = useState(0);
   const MAX_VISIBLE_ITEMS = 10;
 
   const tabs: ("general" | "commands" | "custom-commands")[] = [
@@ -26,33 +23,45 @@ export const HelpView: React.FC<HelpViewProps> = ({
     tabs.push("custom-commands");
   }
 
-  useInput((_, key) => {
-    if (key.escape) {
+  const [state, dispatch] = useReducer(helpSelectorReducer, {
+    selectedIndex: 0,
+    activeTab: "general",
+    pendingDecision: null,
+  });
+
+  const { selectedIndex, activeTab, pendingDecision } = state;
+
+  // Handle decisions from reducer
+  useEffect(() => {
+    if (pendingDecision === "cancel") {
       onCancel();
-      return;
+      dispatch({ type: "CLEAR_DECISION" });
     }
+  }, [pendingDecision, onCancel]);
 
-    if (key.tab) {
-      setActiveTab((prev) => {
-        const currentIndex = tabs.indexOf(prev);
-        const nextIndex = (currentIndex + 1) % tabs.length;
-        return tabs[nextIndex];
-      });
-      setSelectedIndex(0);
-      return;
-    }
+  const currentCommands =
+    activeTab === "commands" ? AVAILABLE_COMMANDS : commands;
 
-    if (activeTab === "commands" || activeTab === "custom-commands") {
-      const currentCommands =
-        activeTab === "commands" ? AVAILABLE_COMMANDS : commands;
-      if (key.upArrow) {
-        setSelectedIndex((prev) => Math.max(0, prev - 1));
-      } else if (key.downArrow) {
-        setSelectedIndex((prev) =>
-          Math.min(currentCommands.length - 1, prev + 1),
-        );
-      }
-    }
+  // Calculate visible window for commands
+  const startIndex = Math.max(
+    0,
+    Math.min(
+      selectedIndex - Math.floor(MAX_VISIBLE_ITEMS / 2),
+      Math.max(0, currentCommands.length - MAX_VISIBLE_ITEMS),
+    ),
+  );
+  const visibleCommands = currentCommands.slice(
+    startIndex,
+    startIndex + MAX_VISIBLE_ITEMS,
+  );
+
+  useInput((_, key) => {
+    dispatch({
+      type: "HANDLE_KEY",
+      key,
+      maxIndex: activeTab === "general" ? 0 : currentCommands.length - 1,
+      tabs,
+    });
   });
 
   const helpItems = [
@@ -71,21 +80,6 @@ export const HelpView: React.FC<HelpViewProps> = ({
       description: "Interrupt AI or command / Cancel selector / Close help",
     },
   ];
-
-  // Calculate visible window for commands
-  const currentCommands =
-    activeTab === "commands" ? AVAILABLE_COMMANDS : commands;
-  const startIndex = Math.max(
-    0,
-    Math.min(
-      selectedIndex - Math.floor(MAX_VISIBLE_ITEMS / 2),
-      Math.max(0, currentCommands.length - MAX_VISIBLE_ITEMS),
-    ),
-  );
-  const visibleCommands = currentCommands.slice(
-    startIndex,
-    startIndex + MAX_VISIBLE_ITEMS,
-  );
 
   const footerText = [
     "Tab switch",

--- a/packages/code/src/components/HistorySearch.tsx
+++ b/packages/code/src/components/HistorySearch.tsx
@@ -1,6 +1,10 @@
-import React, { useState, useEffect } from "react";
+import React, { useReducer, useEffect, useState } from "react";
 import { Box, Text, useInput } from "ink";
 import { PromptHistoryManager, type PromptEntry } from "wave-agent-sdk";
+import {
+  selectorReducer,
+  type SelectorState,
+} from "../reducers/selectorReducer.js";
 
 export interface HistorySearchProps {
   searchQuery: string;
@@ -14,57 +18,46 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
   onCancel,
 }) => {
   const MAX_VISIBLE_ITEMS = 5;
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [state, dispatch] = useReducer(selectorReducer, {
+    selectedIndex: 0,
+    pendingDecision: null,
+  } as SelectorState);
   const [entries, setEntries] = useState<PromptEntry[]>([]);
 
-  const entriesRef = React.useRef<PromptEntry[]>([]);
-  const selectedIndexRef = React.useRef(0);
-
-  useEffect(() => {
-    entriesRef.current = entries;
-  }, [entries]);
-
-  useEffect(() => {
-    selectedIndexRef.current = selectedIndex;
-  }, [selectedIndex]);
+  const { selectedIndex, pendingDecision } = state;
 
   useEffect(() => {
     const fetchHistory = async () => {
       const results = await PromptHistoryManager.searchHistory(searchQuery);
       const limitedResults = results.slice(0, 20);
-      setEntries(limitedResults); // Limit to 20 results
-      setSelectedIndex(0);
+      setEntries(limitedResults);
+      dispatch({ type: "RESET_INDEX" });
     };
     fetchHistory();
   }, [searchQuery]);
 
-  useInput((input, key) => {
-    if (key.return) {
-      if (
-        entriesRef.current.length > 0 &&
-        selectedIndexRef.current < entriesRef.current.length
-      ) {
-        onSelect(entriesRef.current[selectedIndexRef.current]);
+  // Handle decisions from reducer
+  useEffect(() => {
+    if (!pendingDecision) return;
+
+    if (pendingDecision === "select") {
+      if (entries.length > 0 && selectedIndex < entries.length) {
+        onSelect(entries[selectedIndex]);
       }
-      return;
-    }
-
-    if (key.escape) {
+    } else if (pendingDecision === "cancel") {
       onCancel();
-      return;
     }
 
-    if (key.upArrow) {
-      setSelectedIndex((prev) => Math.max(0, prev - 1));
-      return;
-    }
+    dispatch({ type: "CLEAR_DECISION" });
+  }, [pendingDecision, selectedIndex, entries, onSelect, onCancel]);
 
-    if (key.downArrow) {
-      setSelectedIndex((prev) =>
-        Math.min(entriesRef.current.length - 1, prev + 1),
-      );
-      return;
-    }
+  useInput((input, key) => {
+    dispatch({
+      type: "HANDLE_KEY",
+      key,
+      maxIndex: entries.length - 1,
+      hasInsert: false,
+    });
   });
 
   if (entries.length === 0) {

--- a/packages/code/src/components/InputBox.tsx
+++ b/packages/code/src/components/InputBox.tsx
@@ -138,6 +138,20 @@ export const InputBox: React.FC<InputBoxProps> = ({
 
   // Use the InputManager's unified input handler
   useInput(async (input, key) => {
+    // These views have their own useInput handlers that handle escape and navigation.
+    // If they are active, we should skip InputBox's global input handling to avoid
+    // duplicate dispatches or state update conflicts.
+    if (
+      showRewindManager ||
+      showHelp ||
+      showStatusCommand ||
+      showPluginManager ||
+      showModelSelector ||
+      showBackgroundTaskManager ||
+      showMcpManager
+    ) {
+      return;
+    }
     await handleInput(input, key, attachedImages, clearImages);
   });
 

--- a/packages/code/src/components/InstalledView.tsx
+++ b/packages/code/src/components/InstalledView.tsx
@@ -1,26 +1,36 @@
-import React, { useState } from "react";
+import React, { useReducer, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import { usePluginManagerContext } from "../contexts/PluginManagerContext.js";
+import { selectorReducer } from "../reducers/selectorReducer.js";
 
 export const InstalledView: React.FC = () => {
   const { installedPlugins, actions } = usePluginManagerContext();
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [state, dispatch] = useReducer(selectorReducer, {
+    selectedIndex: 0,
+    pendingDecision: null,
+  });
 
-  useInput((input, key) => {
-    if (key.upArrow) {
-      setSelectedIndex(Math.max(0, selectedIndex - 1));
-    } else if (key.downArrow) {
-      setSelectedIndex(
-        Math.min(installedPlugins.length - 1, selectedIndex + 1),
-      );
-    } else if (key.return) {
+  const { selectedIndex, pendingDecision } = state;
+
+  useInput((_input, key) => {
+    dispatch({
+      type: "HANDLE_KEY",
+      key,
+      maxIndex: installedPlugins.length - 1,
+      hasInsert: false,
+    });
+  });
+
+  useEffect(() => {
+    if (pendingDecision === "select") {
       const plugin = installedPlugins[selectedIndex];
       if (plugin) {
         actions.setSelectedId(`${plugin.name}@${plugin.marketplace}`);
         actions.setView("PLUGIN_DETAIL");
       }
+      dispatch({ type: "CLEAR_DECISION" });
     }
-  });
+  }, [pendingDecision, selectedIndex, installedPlugins, actions]);
 
   if (installedPlugins.length === 0) {
     return (

--- a/packages/code/src/components/MarketplaceDetail.tsx
+++ b/packages/code/src/components/MarketplaceDetail.tsx
@@ -1,34 +1,47 @@
-import React, { useState } from "react";
+import React, { useReducer, useEffect, useMemo } from "react";
 import { Box, Text, useInput } from "ink";
 import { usePluginManagerContext } from "../contexts/PluginManagerContext.js";
+import { selectorReducer } from "../reducers/selectorReducer.js";
 
 export const MarketplaceDetail: React.FC = () => {
   const { state, marketplaces, actions } = usePluginManagerContext();
-  const [selectedActionIndex, setSelectedActionIndex] = useState(0);
+  const [selectorState, dispatch] = useReducer(selectorReducer, {
+    selectedIndex: 0,
+    pendingDecision: null,
+  });
+
+  const { selectedIndex: selectedActionIndex, pendingDecision } = selectorState;
 
   const marketplace = marketplaces.find((m) => m.name === state.selectedId);
 
-  const ACTIONS = [
-    {
-      id: "toggle-auto-update",
-      label: `${marketplace?.autoUpdate ? "Disable" : "Enable"} auto-update`,
-    },
-    { id: "update", label: "Update marketplace" },
-    { id: "remove", label: "Remove marketplace" },
-  ] as const;
+  const ACTIONS = useMemo(
+    () =>
+      [
+        {
+          id: "toggle-auto-update",
+          label: `${marketplace?.autoUpdate ? "Disable" : "Enable"} auto-update`,
+        },
+        { id: "update", label: "Update marketplace" },
+        { id: "remove", label: "Remove marketplace" },
+      ] as const,
+    [marketplace?.autoUpdate],
+  );
 
-  useInput((input, key) => {
-    if (key.escape) {
-      actions.setView("MARKETPLACES");
-    } else if (key.upArrow) {
-      setSelectedActionIndex((prev) =>
-        prev > 0 ? prev - 1 : ACTIONS.length - 1,
-      );
-    } else if (key.downArrow) {
-      setSelectedActionIndex((prev) =>
-        prev < ACTIONS.length - 1 ? prev + 1 : 0,
-      );
-    } else if (key.return && marketplace && !state.isLoading) {
+  useInput((_input, key) => {
+    if (state.isLoading && !key.escape) return;
+
+    dispatch({
+      type: "HANDLE_KEY",
+      key,
+      maxIndex: ACTIONS.length - 1,
+      hasInsert: false,
+    });
+  });
+
+  useEffect(() => {
+    if (!pendingDecision) return;
+
+    if (pendingDecision === "select" && marketplace && !state.isLoading) {
       const action = ACTIONS[selectedActionIndex].id;
       if (action === "toggle-auto-update") {
         actions.toggleAutoUpdate(marketplace.name, !marketplace.autoUpdate);
@@ -37,8 +50,19 @@ export const MarketplaceDetail: React.FC = () => {
       } else {
         actions.removeMarketplace(marketplace.name);
       }
+    } else if (pendingDecision === "cancel") {
+      actions.setView("MARKETPLACES");
     }
-  });
+
+    dispatch({ type: "CLEAR_DECISION" });
+  }, [
+    pendingDecision,
+    selectedActionIndex,
+    marketplace,
+    state.isLoading,
+    actions,
+    ACTIONS,
+  ]);
 
   if (!marketplace) {
     return (

--- a/packages/code/src/components/MarketplaceView.tsx
+++ b/packages/code/src/components/MarketplaceView.tsx
@@ -1,28 +1,43 @@
-import React, { useState } from "react";
+import React, { useReducer, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import { usePluginManagerContext } from "../contexts/PluginManagerContext.js";
+import { selectorReducer } from "../reducers/selectorReducer.js";
 
 import { MarketplaceList } from "./MarketplaceList.js";
 
 export const MarketplaceView: React.FC = () => {
   const { marketplaces, actions } = usePluginManagerContext();
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [state, dispatch] = useReducer(selectorReducer, {
+    selectedIndex: 0,
+    pendingDecision: null,
+  });
+
+  const { selectedIndex, pendingDecision } = state;
 
   useInput((input, key) => {
-    if (key.upArrow) {
-      setSelectedIndex(Math.max(0, selectedIndex - 1));
-    } else if (key.downArrow) {
-      setSelectedIndex(Math.min(marketplaces.length - 1, selectedIndex + 1));
-    } else if (key.return) {
+    if (input === "a") {
+      actions.setView("ADD_MARKETPLACE");
+      return;
+    }
+
+    dispatch({
+      type: "HANDLE_KEY",
+      key,
+      maxIndex: marketplaces.length - 1,
+      hasInsert: false,
+    });
+  });
+
+  useEffect(() => {
+    if (pendingDecision === "select") {
       const mk = marketplaces[selectedIndex];
       if (mk) {
         actions.setSelectedId(mk.name);
         actions.setView("MARKETPLACE_DETAIL");
       }
-    } else if (input === "a") {
-      actions.setView("ADD_MARKETPLACE");
+      dispatch({ type: "CLEAR_DECISION" });
     }
-  });
+  }, [pendingDecision, selectedIndex, marketplaces, actions]);
 
   return (
     <Box flexDirection="column">

--- a/packages/code/src/components/McpManager.tsx
+++ b/packages/code/src/components/McpManager.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer } from "react";
+import React, { useReducer, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import { McpServerStatus } from "wave-agent-sdk";
 import {
@@ -16,6 +16,7 @@ export interface McpManagerProps {
 const initialState: McpManagerState = {
   selectedIndex: 0,
   viewMode: "list",
+  pendingEffect: null,
 };
 
 export const McpManager: React.FC<McpManagerProps> = ({
@@ -25,6 +26,26 @@ export const McpManager: React.FC<McpManagerProps> = ({
   onDisconnectServer,
 }) => {
   const [state, dispatch] = useReducer(mcpManagerReducer, initialState);
+
+  // Handle pending effects
+  useEffect(() => {
+    if (!state.pendingEffect) return;
+
+    const effect = state.pendingEffect;
+    dispatch({ type: "CLEAR_PENDING_EFFECT" });
+
+    switch (effect.type) {
+      case "CANCEL":
+        onCancel();
+        break;
+      case "CONNECT_SERVER":
+        onConnectServer(effect.serverName);
+        break;
+      case "DISCONNECT_SERVER":
+        onDisconnectServer(effect.serverName);
+        break;
+    }
+  }, [state.pendingEffect, onCancel, onConnectServer, onDisconnectServer]);
 
   // Dynamically calculate selectedServer based on selectedIndex and servers
   const selectedServer =
@@ -64,68 +85,14 @@ export const McpManager: React.FC<McpManagerProps> = ({
     }
   };
 
-  const handleConnect = async (serverName: string) => {
-    await onConnectServer(serverName);
-  };
-
-  const handleDisconnect = async (serverName: string) => {
-    await onDisconnectServer(serverName);
-  };
-
-  const stateRef = React.useRef({ state, servers });
-  React.useEffect(() => {
-    stateRef.current = { state, servers };
-  }, [state, servers]);
-
   useInput((input, key) => {
-    const currentState = stateRef.current.state;
-    const currentServers = stateRef.current.servers;
-
-    if (key.return) {
-      if (currentState.viewMode === "list") {
-        dispatch({ type: "SET_VIEW_MODE", viewMode: "detail" });
-      }
-      return;
-    }
-
-    if (key.escape) {
-      if (currentState.viewMode === "detail") {
-        dispatch({ type: "SET_VIEW_MODE", viewMode: "list" });
-      } else {
-        onCancel();
-      }
-      return;
-    }
-
-    if (key.upArrow) {
-      dispatch({ type: "MOVE_UP", serverCount: currentServers.length });
-      return;
-    }
-
-    if (key.downArrow) {
-      dispatch({ type: "MOVE_DOWN", serverCount: currentServers.length });
-      return;
-    }
-
-    // Hotkeys for server actions
-    if (input === "c") {
-      const server = currentServers[currentState.selectedIndex];
-      if (
-        server &&
-        (server.status === "disconnected" || server.status === "error")
-      ) {
-        handleConnect(server.name);
-      }
-      return;
-    }
-
-    if (input === "d") {
-      const server = currentServers[currentState.selectedIndex];
-      if (server && server.status === "connected") {
-        handleDisconnect(server.name);
-      }
-      return;
-    }
+    dispatch({
+      type: "HANDLE_KEY",
+      input,
+      key,
+      serverCount: servers.length,
+      servers: servers.map((s) => ({ name: s.name, status: s.status })),
+    });
   });
 
   if (state.viewMode === "detail" && selectedServer) {

--- a/packages/code/src/components/McpManager.tsx
+++ b/packages/code/src/components/McpManager.tsx
@@ -72,16 +72,24 @@ export const McpManager: React.FC<McpManagerProps> = ({
     await onDisconnectServer(serverName);
   };
 
+  const stateRef = React.useRef({ state, servers });
+  React.useEffect(() => {
+    stateRef.current = { state, servers };
+  }, [state, servers]);
+
   useInput((input, key) => {
+    const currentState = stateRef.current.state;
+    const currentServers = stateRef.current.servers;
+
     if (key.return) {
-      if (state.viewMode === "list") {
+      if (currentState.viewMode === "list") {
         dispatch({ type: "SET_VIEW_MODE", viewMode: "detail" });
       }
       return;
     }
 
     if (key.escape) {
-      if (state.viewMode === "detail") {
+      if (currentState.viewMode === "detail") {
         dispatch({ type: "SET_VIEW_MODE", viewMode: "list" });
       } else {
         onCancel();
@@ -90,18 +98,18 @@ export const McpManager: React.FC<McpManagerProps> = ({
     }
 
     if (key.upArrow) {
-      dispatch({ type: "MOVE_UP", serverCount: servers.length });
+      dispatch({ type: "MOVE_UP", serverCount: currentServers.length });
       return;
     }
 
     if (key.downArrow) {
-      dispatch({ type: "MOVE_DOWN", serverCount: servers.length });
+      dispatch({ type: "MOVE_DOWN", serverCount: currentServers.length });
       return;
     }
 
     // Hotkeys for server actions
     if (input === "c") {
-      const server = servers[state.selectedIndex];
+      const server = currentServers[currentState.selectedIndex];
       if (
         server &&
         (server.status === "disconnected" || server.status === "error")
@@ -112,7 +120,7 @@ export const McpManager: React.FC<McpManagerProps> = ({
     }
 
     if (input === "d") {
-      const server = servers[state.selectedIndex];
+      const server = currentServers[currentState.selectedIndex];
       if (server && server.status === "connected") {
         handleDisconnect(server.name);
       }

--- a/packages/code/src/components/ModelSelector.tsx
+++ b/packages/code/src/components/ModelSelector.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useReducer, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
+import { selectorReducer } from "../reducers/selectorReducer.js";
 
 export interface ModelSelectorProps {
   onCancel: () => void;
@@ -16,37 +17,43 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   configuredModels,
   onSelectModel,
 }) => {
-  const [selectedIndex, setSelectedIndex] = useState(() => {
-    const index = configuredModels.indexOf(currentModel);
-    return index !== -1 ? index : 0;
+  const [state, dispatch] = useReducer(selectorReducer, {
+    selectedIndex:
+      configuredModels.indexOf(currentModel) !== -1
+        ? configuredModels.indexOf(currentModel)
+        : 0,
+    pendingDecision: null,
   });
 
+  const { selectedIndex, pendingDecision } = state;
+
   useInput((_input, key) => {
-    if (key.return) {
+    dispatch({
+      type: "HANDLE_KEY",
+      key,
+      maxIndex: configuredModels.length - 1,
+      hasInsert: false,
+    });
+  });
+
+  useEffect(() => {
+    if (pendingDecision === "select") {
       if (configuredModels.length > 0) {
         onSelectModel(configuredModels[selectedIndex]);
       }
       onCancel();
-      return;
-    }
-
-    if (key.escape) {
+      dispatch({ type: "CLEAR_DECISION" });
+    } else if (pendingDecision === "cancel") {
       onCancel();
-      return;
+      dispatch({ type: "CLEAR_DECISION" });
     }
-
-    if (key.upArrow) {
-      setSelectedIndex((prev) => Math.max(0, prev - 1));
-      return;
-    }
-
-    if (key.downArrow) {
-      setSelectedIndex((prev) =>
-        Math.min(configuredModels.length - 1, prev + 1),
-      );
-      return;
-    }
-  });
+  }, [
+    pendingDecision,
+    selectedIndex,
+    configuredModels,
+    onSelectModel,
+    onCancel,
+  ]);
 
   // Calculate visible window
   const startIndex = Math.max(

--- a/packages/code/src/components/PluginDetail.tsx
+++ b/packages/code/src/components/PluginDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer } from "react";
+import React, { useReducer, useEffect, useMemo } from "react";
 import { Box, Text, useInput } from "ink";
 import { usePluginManagerContext } from "../contexts/PluginManagerContext.js";
 import {
@@ -18,7 +18,11 @@ export const PluginDetail: React.FC = () => {
   const [detailState, dispatch] = useReducer(pluginDetailReducer, {
     selectedScopeIndex: 0,
     selectedActionIndex: 0,
+    pendingDecision: null,
   } as PluginDetailState);
+
+  const { selectedScopeIndex, selectedActionIndex, pendingDecision } =
+    detailState;
 
   const plugin =
     discoverablePlugins.find(
@@ -28,34 +32,35 @@ export const PluginDetail: React.FC = () => {
       (p) => `${p.name}@${p.marketplace}` === state.selectedId,
     );
 
-  const INSTALLED_ACTIONS = [
-    { id: "update", label: "Update plugin (reinstall)" },
-    { id: "uninstall", label: "Uninstall plugin" },
-  ] as const;
+  const INSTALLED_ACTIONS = useMemo(
+    () =>
+      [
+        { id: "update", label: "Update plugin (reinstall)" },
+        { id: "uninstall", label: "Uninstall plugin" },
+      ] as const,
+    [],
+  );
 
   const isInstalledAndEnabled = plugin && "enabled" in plugin && plugin.enabled;
 
-  useInput((input, key) => {
-    if (key.escape) {
-      const isFromDiscover = discoverablePlugins.find(
-        (p) => `${p.name}@${p.marketplace}` === state.selectedId,
-      );
-      actions.setView(isFromDiscover ? "DISCOVER" : "INSTALLED");
-    } else if (key.upArrow) {
-      dispatch({
-        type: "MOVE_ACTION_UP",
-        maxIndex: INSTALLED_ACTIONS.length - 1,
-      });
-      dispatch({ type: "MOVE_SCOPE_UP", maxIndex: SCOPES.length - 1 });
-    } else if (key.downArrow) {
-      dispatch({
-        type: "MOVE_ACTION_DOWN",
-        maxIndex: INSTALLED_ACTIONS.length - 1,
-      });
-      dispatch({ type: "MOVE_SCOPE_DOWN", maxIndex: SCOPES.length - 1 });
-    } else if (key.return && plugin && !state.isLoading) {
+  useInput((_input, key) => {
+    if (state.isLoading && !key.escape) return;
+
+    dispatch({
+      type: "HANDLE_KEY",
+      key,
+      maxIndex: isInstalledAndEnabled
+        ? INSTALLED_ACTIONS.length - 1
+        : SCOPES.length - 1,
+    });
+  });
+
+  useEffect(() => {
+    if (!pendingDecision) return;
+
+    if (pendingDecision === "select" && plugin && !state.isLoading) {
       if (isInstalledAndEnabled) {
-        const action = INSTALLED_ACTIONS[detailState.selectedActionIndex].id;
+        const action = INSTALLED_ACTIONS[selectedActionIndex].id;
         if (action === "uninstall") {
           actions.uninstallPlugin(plugin.name, plugin.marketplace);
         } else {
@@ -65,11 +70,29 @@ export const PluginDetail: React.FC = () => {
         actions.installPlugin(
           plugin.name,
           plugin.marketplace,
-          SCOPES[detailState.selectedScopeIndex].id,
+          SCOPES[selectedScopeIndex].id,
         );
       }
+    } else if (pendingDecision === "cancel") {
+      const isFromDiscover = discoverablePlugins.find(
+        (p) => `${p.name}@${p.marketplace}` === state.selectedId,
+      );
+      actions.setView(isFromDiscover ? "DISCOVER" : "INSTALLED");
     }
-  });
+
+    dispatch({ type: "CLEAR_DECISION" });
+  }, [
+    pendingDecision,
+    selectedActionIndex,
+    selectedScopeIndex,
+    plugin,
+    isInstalledAndEnabled,
+    state.isLoading,
+    discoverablePlugins,
+    state.selectedId,
+    actions,
+    INSTALLED_ACTIONS,
+  ]);
 
   if (!plugin) {
     return (

--- a/packages/code/src/components/RewindCommand.tsx
+++ b/packages/code/src/components/RewindCommand.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from "react";
+import React, { useState, useReducer, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import type { Message } from "wave-agent-sdk";
 import { getMessageContent } from "wave-agent-sdk";
+import { rewindSelectorReducer } from "../reducers/rewindSelectorReducer.js";
 
 export interface RewindCommandProps {
   messages: Message[];
@@ -22,7 +23,7 @@ export const RewindCommand: React.FC<RewindCommandProps> = ({
   const [messages, setMessages] = useState<Message[]>(initialMessages);
   const [isLoading, setIsLoading] = useState(!!getFullMessageThread);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (getFullMessageThread) {
       getFullMessageThread().then(({ messages: fullMessages }) => {
         setMessages(fullMessages);
@@ -37,48 +38,40 @@ export const RewindCommand: React.FC<RewindCommandProps> = ({
     .filter(({ msg }) => msg.role === "user" && !msg.isMeta);
 
   const MAX_VISIBLE_ITEMS = 3;
-  const [selectedIndex, setSelectedIndex] = useState(checkpoints.length - 1);
+
+  const [state, dispatch] = useReducer(rewindSelectorReducer, {
+    selectedIndex: checkpoints.length - 1,
+    pendingDecision: null,
+  });
+
+  const { selectedIndex, pendingDecision } = state;
 
   // Update selectedIndex when checkpoints change (after loading full thread)
-  React.useEffect(() => {
-    setSelectedIndex(checkpoints.length - 1);
+  useEffect(() => {
+    dispatch({ type: "RESET_INDEX", index: checkpoints.length - 1 });
   }, [checkpoints.length]);
 
-  // Calculate visible window
-  const startIndex = Math.max(
-    0,
-    Math.min(
-      selectedIndex - Math.floor(MAX_VISIBLE_ITEMS / 2),
-      Math.max(0, checkpoints.length - MAX_VISIBLE_ITEMS),
-    ),
-  );
-  const visibleCheckpoints = checkpoints.slice(
-    startIndex,
-    startIndex + MAX_VISIBLE_ITEMS,
-  );
+  // Handle decisions from reducer
+  useEffect(() => {
+    if (!pendingDecision) return;
 
-  useInput((input, key) => {
-    if (key.return) {
+    if (pendingDecision === "select") {
       if (checkpoints.length > 0 && selectedIndex >= 0) {
         onSelect(checkpoints[selectedIndex].index);
       }
-      return;
-    }
-
-    if (key.escape) {
+    } else if (pendingDecision === "cancel") {
       onCancel();
-      return;
     }
 
-    if (key.upArrow) {
-      setSelectedIndex(Math.max(0, selectedIndex - 1));
-      return;
-    }
+    dispatch({ type: "CLEAR_DECISION" });
+  }, [pendingDecision, selectedIndex, checkpoints, onSelect, onCancel]);
 
-    if (key.downArrow) {
-      setSelectedIndex(Math.min(checkpoints.length - 1, selectedIndex + 1));
-      return;
-    }
+  useInput((input, key) => {
+    dispatch({
+      type: "HANDLE_KEY",
+      key,
+      maxIndex: checkpoints.length - 1,
+    });
   });
 
   if (isLoading) {
@@ -111,6 +104,19 @@ export const RewindCommand: React.FC<RewindCommandProps> = ({
       </Box>
     );
   }
+
+  // Calculate visible window
+  const startIndex = Math.max(
+    0,
+    Math.min(
+      selectedIndex - Math.floor(MAX_VISIBLE_ITEMS / 2),
+      Math.max(0, checkpoints.length - MAX_VISIBLE_ITEMS),
+    ),
+  );
+  const visibleCheckpoints = checkpoints.slice(
+    startIndex,
+    startIndex + MAX_VISIBLE_ITEMS,
+  );
 
   return (
     <Box

--- a/packages/code/src/components/SessionSelector.tsx
+++ b/packages/code/src/components/SessionSelector.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from "react";
+import React, { useReducer, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import type { SessionMetadata } from "wave-agent-sdk";
+import { selectorReducer } from "../reducers/selectorReducer.js";
 
 export interface SessionSelectorProps {
   sessions: (SessionMetadata & { firstMessage?: string })[];
@@ -13,31 +14,33 @@ export const SessionSelector: React.FC<SessionSelectorProps> = ({
   onSelect,
   onCancel,
 }) => {
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [state, dispatch] = useReducer(selectorReducer, {
+    selectedIndex: 0,
+    pendingDecision: null,
+  });
 
-  useInput((input, key) => {
-    if (key.return) {
+  const { selectedIndex, pendingDecision } = state;
+
+  useInput((_input, key) => {
+    dispatch({
+      type: "HANDLE_KEY",
+      key,
+      maxIndex: sessions.length - 1,
+      hasInsert: false,
+    });
+  });
+
+  useEffect(() => {
+    if (pendingDecision === "select") {
       if (sessions.length > 0 && selectedIndex < sessions.length) {
         onSelect(sessions[selectedIndex].id);
       }
-      return;
-    }
-
-    if (key.escape) {
+      dispatch({ type: "CLEAR_DECISION" });
+    } else if (pendingDecision === "cancel") {
       onCancel();
-      return;
+      dispatch({ type: "CLEAR_DECISION" });
     }
-
-    if (key.upArrow) {
-      setSelectedIndex(Math.max(0, selectedIndex - 1));
-      return;
-    }
-
-    if (key.downArrow) {
-      setSelectedIndex(Math.min(sessions.length - 1, selectedIndex + 1));
-      return;
-    }
-  });
+  }, [pendingDecision, selectedIndex, sessions, onSelect, onCancel]);
 
   if (sessions.length === 0) {
     return (

--- a/packages/code/src/components/WorktreeExitPrompt.tsx
+++ b/packages/code/src/components/WorktreeExitPrompt.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useReducer, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
+import { selectorReducer } from "../reducers/selectorReducer.js";
 
 interface WorktreeExitPromptProps {
   name: string;
@@ -20,26 +21,35 @@ export const WorktreeExitPrompt: React.FC<WorktreeExitPromptProps> = ({
   onRemove,
   onCancel,
 }) => {
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [state, dispatch] = useReducer(selectorReducer, {
+    selectedIndex: 0,
+    pendingDecision: null,
+  });
 
-  useInput((input, key) => {
-    if (key.upArrow) {
-      setSelectedIndex((prev) => (prev === 0 ? 1 : 0));
-    }
-    if (key.downArrow) {
-      setSelectedIndex((prev) => (prev === 1 ? 0 : 1));
-    }
-    if (key.return) {
+  const { selectedIndex, pendingDecision } = state;
+
+  useInput((_input, key) => {
+    dispatch({
+      type: "HANDLE_KEY",
+      key,
+      maxIndex: 1,
+      hasInsert: false,
+    });
+  });
+
+  useEffect(() => {
+    if (pendingDecision === "select") {
       if (selectedIndex === 0) {
         onKeep();
       } else {
         onRemove();
       }
-    }
-    if (key.escape) {
+      dispatch({ type: "CLEAR_DECISION" });
+    } else if (pendingDecision === "cancel") {
       onCancel();
+      dispatch({ type: "CLEAR_DECISION" });
     }
-  });
+  }, [pendingDecision, selectedIndex, onKeep, onRemove, onCancel]);
 
   return (
     <Box flexDirection="column" paddingX={1} marginY={1}>

--- a/packages/code/src/hooks/useInputManager.ts
+++ b/packages/code/src/hooks/useInputManager.ts
@@ -9,6 +9,7 @@ import {
   searchFiles as searchFilesUtil,
   PermissionMode,
   PromptEntry,
+  PromptHistoryManager,
 } from "wave-agent-sdk";
 import * as handlers from "../managers/inputHandlers.js";
 
@@ -89,6 +90,152 @@ export const useInputManager = (
   useEffect(() => {
     callbacksRef.current.onCursorPositionChange?.(state.cursorPosition);
   }, [state.cursorPosition]);
+
+  // Handle pending effects
+  useEffect(() => {
+    if (!state.pendingEffect) return;
+
+    const effect = state.pendingEffect;
+    dispatch({ type: "CLEAR_PENDING_EFFECT" });
+
+    const runEffect = async () => {
+      try {
+        switch (effect.type) {
+          case "SEND_MESSAGE":
+            await callbacksRef.current.onSendMessage?.(
+              effect.content,
+              effect.images,
+              effect.longTextMap,
+            );
+            break;
+          case "ABORT_MESSAGE":
+            callbacksRef.current.onAbortMessage?.();
+            break;
+          case "BACKGROUND_CURRENT_TASK":
+            callbacksRef.current.onBackgroundCurrentTask?.();
+            break;
+          case "ASK_BTW":
+            try {
+              const answer = await callbacksRef.current.onAskBtw?.(
+                effect.question,
+              );
+              dispatch({
+                type: "SET_BTW_STATE",
+                payload: { answer, isLoading: false },
+              });
+            } catch (error) {
+              console.error("Failed to ask side question:", error);
+              dispatch({
+                type: "SET_BTW_STATE",
+                payload: {
+                  answer:
+                    "Error: Failed to get an answer for your side question.",
+                  isLoading: false,
+                },
+              });
+            }
+            break;
+          case "PERMISSION_MODE_CHANGE":
+            callbacksRef.current.onPermissionModeChange?.(effect.mode);
+            break;
+          case "SAVE_HISTORY":
+            PromptHistoryManager.addEntry(
+              effect.content,
+              callbacksRef.current.sessionId,
+              effect.longTextMap,
+              callbacksRef.current.workdir,
+            ).catch((err: unknown) => {
+              callbacksRef.current.logger?.error(
+                "Failed to save prompt history",
+                err,
+              );
+            });
+            break;
+          case "FETCH_HISTORY": {
+            let sessionIds: string[] | undefined = callbacksRef.current
+              .sessionId
+              ? [callbacksRef.current.sessionId]
+              : undefined;
+
+            if (callbacksRef.current.getFullMessageThread) {
+              try {
+                const thread =
+                  await callbacksRef.current.getFullMessageThread();
+                sessionIds = thread.sessionIds;
+              } catch (error) {
+                callbacksRef.current.logger?.error(
+                  "Failed to fetch ancestor session IDs",
+                  error,
+                );
+              }
+            }
+
+            const history = await PromptHistoryManager.getHistory({
+              sessionId: sessionIds,
+              workdir: callbacksRef.current.workdir,
+            });
+            dispatch({ type: "SET_HISTORY_ENTRIES", payload: history });
+            dispatch({ type: "NAVIGATE_HISTORY", payload: "up" });
+            break;
+          }
+          case "PASTE_IMAGE":
+            try {
+              await handlers.handlePasteImage(dispatch);
+            } catch (error) {
+              console.warn("Failed to handle paste image:", error);
+            }
+            break;
+          case "EXECUTE_COMMAND":
+            if (
+              callbacksRef.current.onSendMessage &&
+              callbacksRef.current.onHasSlashCommand?.(effect.command)
+            ) {
+              const fullCommand = `/${effect.command}`;
+              try {
+                await callbacksRef.current.onSendMessage(
+                  fullCommand,
+                  undefined,
+                  {},
+                );
+              } catch (error) {
+                console.error("Failed to execute slash command:", error);
+              }
+            } else {
+              // Internal command handling
+              const command = effect.command;
+              if (command === "tasks") {
+                dispatch({
+                  type: "SET_SHOW_BACKGROUND_TASK_MANAGER",
+                  payload: true,
+                });
+              } else if (command === "mcp") {
+                dispatch({ type: "SET_SHOW_MCP_MANAGER", payload: true });
+              } else if (command === "rewind") {
+                dispatch({ type: "SET_SHOW_REWIND_MANAGER", payload: true });
+              } else if (command === "help") {
+                dispatch({ type: "SET_SHOW_HELP", payload: true });
+              } else if (command === "status") {
+                dispatch({ type: "SET_SHOW_STATUS_COMMAND", payload: true });
+              } else if (command === "plugin") {
+                dispatch({ type: "SET_SHOW_PLUGIN_MANAGER", payload: true });
+              } else if (command === "model") {
+                dispatch({ type: "SET_SHOW_MODEL_SELECTOR", payload: true });
+              } else if (command === "btw") {
+                dispatch({
+                  type: "SET_BTW_STATE",
+                  payload: { isActive: true, question: "", isLoading: false },
+                });
+              }
+            }
+            break;
+        }
+      } catch (error) {
+        console.error("Effect execution error:", error);
+      }
+    };
+
+    runEffect();
+  }, [state.pendingEffect]);
 
   useEffect(() => {
     callbacksRef.current.onFileSelectorStateChange?.(
@@ -218,12 +365,7 @@ export const useInputManager = (
   }, []);
 
   const handleFileSelect = useCallback((filePath: string) => {
-    return handlers.handleFileSelect(
-      stateRef.current,
-      dispatch,
-      callbacksRef.current,
-      filePath,
-    );
+    dispatch({ type: "SELECT_FILE", payload: filePath });
   }, []);
 
   const handleCancelFileSelect = useCallback(() => {
@@ -235,6 +377,8 @@ export const useInputManager = (
   }, []);
 
   const checkForAtDeletion = useCallback((cursorPos: number) => {
+    // This is now largely handled inside HANDLE_KEY,
+    // but kept for external calls if any.
     return handlers.checkForAtDeletion(stateRef.current, dispatch, cursorPos);
   }, []);
 
@@ -243,42 +387,11 @@ export const useInputManager = (
   }, []);
 
   const handleCommandSelect = useCallback((command: string) => {
-    return handlers.handleCommandSelect(
-      stateRef.current,
-      dispatch,
-      callbacksRef.current,
-      command,
-    );
+    dispatch({ type: "SELECT_COMMAND", payload: command });
   }, []);
 
   const handleCommandInsert = useCallback((command: string) => {
-    const currentState = stateRef.current;
-    if (currentState.slashPosition >= 0) {
-      const wordEnd = handlers.getWordEnd(
-        currentState.inputText,
-        currentState.slashPosition,
-      );
-      const beforeSlash = currentState.inputText.substring(
-        0,
-        currentState.slashPosition,
-      );
-      const afterWord = currentState.inputText.substring(wordEnd);
-      const newInput = beforeSlash + `/${command} ` + afterWord;
-      const newCursorPosition = beforeSlash.length + command.length + 2;
-
-      dispatch({ type: "SET_INPUT_TEXT", payload: newInput });
-      dispatch({ type: "SET_CURSOR_POSITION", payload: newCursorPosition });
-      dispatch({ type: "CANCEL_COMMAND_SELECTOR" });
-
-      callbacksRef.current.onInputTextChange?.(newInput);
-      callbacksRef.current.onCursorPositionChange?.(newCursorPosition);
-
-      return { newInput, newCursorPosition };
-    }
-    return {
-      newInput: currentState.inputText,
-      newCursorPosition: currentState.cursorPosition,
-    };
+    dispatch({ type: "INSERT_COMMAND", payload: command });
   }, []);
 
   const handleCancelCommandSelect = useCallback(() => {
@@ -374,27 +487,28 @@ export const useInputManager = (
   }, []);
 
   const handlePasteInput = useCallback((input: string) => {
-    handlers.handlePasteInput(
-      stateRef.current,
-      dispatch,
-      callbacksRef.current,
-      input,
-    );
+    dispatch({
+      type: "HANDLE_KEY",
+      payload: {
+        input,
+        key: {} as Key,
+        hasSlashCommand: (cmd) =>
+          !!callbacksRef.current.onHasSlashCommand?.(cmd),
+      },
+    });
   }, []);
 
-  const handleSubmit = useCallback(
-    async (
-      attachedImages: Array<{ id: number; path: string; mimeType: string }>,
-    ) => {
-      await handlers.handleSubmit(
-        stateRef.current,
-        dispatch,
-        callbacksRef.current,
-        attachedImages,
-      );
-    },
-    [],
-  );
+  const handleSubmit = useCallback(async () => {
+    dispatch({
+      type: "HANDLE_KEY",
+      payload: {
+        input: "",
+        key: { return: true } as Key,
+        hasSlashCommand: (cmd) =>
+          !!callbacksRef.current.onHasSlashCommand?.(cmd),
+      },
+    });
+  }, []);
 
   const expandLongTextPlaceholders = useCallback((text: string) => {
     return handlers.expandLongTextPlaceholders(
@@ -411,17 +525,24 @@ export const useInputManager = (
     async (
       input: string,
       key: Key,
-      attachedImages: Array<{ id: number; path: string; mimeType: string }>,
+      _attachedImages: Array<{ id: number; path: string; mimeType: string }>,
       clearImages?: () => void,
     ) => {
-      return await handlers.handleInput(
-        stateRef.current,
-        dispatch,
-        callbacksRef.current,
-        input,
-        key,
-        clearImages,
-      );
+      // Clear images side effect if return is pressed
+      if (key.return) {
+        clearImages?.();
+      }
+
+      dispatch({
+        type: "HANDLE_KEY",
+        payload: {
+          input,
+          key,
+          hasSlashCommand: (cmd) =>
+            !!callbacksRef.current.onHasSlashCommand?.(cmd),
+        },
+      });
+      return true;
     },
     [],
   );

--- a/packages/code/src/hooks/useInputManager.ts
+++ b/packages/code/src/hooks/useInputManager.ts
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, useCallback, useRef } from "react";
+import { useEffect, useReducer, useCallback } from "react";
 import { Key } from "ink";
 import {
   inputReducer,
@@ -17,17 +17,32 @@ export const useInputManager = (
   callbacks: Partial<InputManagerCallbacks> = {},
 ) => {
   const [state, dispatch] = useReducer(inputReducer, initialState);
-  const callbacksRef = useRef(callbacks);
-  const stateRef = useRef(state);
 
-  // Update refs when they change
-  useEffect(() => {
-    callbacksRef.current = callbacks;
-  }, [callbacks]);
-
-  useEffect(() => {
-    stateRef.current = state;
-  }, [state]);
+  const {
+    onInputTextChange,
+    onCursorPositionChange,
+    onFileSelectorStateChange,
+    onCommandSelectorStateChange,
+    onHistorySearchStateChange,
+    onBackgroundTaskManagerStateChange,
+    onMcpManagerStateChange,
+    onRewindManagerStateChange,
+    onHelpStateChange,
+    onStatusCommandStateChange,
+    onPluginManagerStateChange,
+    onModelSelectorStateChange,
+    onImagesStateChange,
+    onSendMessage,
+    onHasSlashCommand,
+    onAbortMessage,
+    onBackgroundCurrentTask,
+    onPermissionModeChange,
+    onAskBtw,
+    sessionId,
+    workdir,
+    getFullMessageThread,
+    logger,
+  } = callbacks;
 
   // Handle selectorJustUsed reset
   useEffect(() => {
@@ -67,10 +82,7 @@ export const useInputManager = (
         10,
       );
       const timer = setTimeout(() => {
-        const processedInput = stateRef.current.pasteBuffer.replace(
-          /\r/g,
-          "\n",
-        );
+        const processedInput = state.pasteBuffer.replace(/\r/g, "\n");
         dispatch({
           type: "INSERT_TEXT_WITH_PLACEHOLDER",
           payload: processedInput,
@@ -84,12 +96,12 @@ export const useInputManager = (
 
   // Sync state changes with callbacks
   useEffect(() => {
-    callbacksRef.current.onInputTextChange?.(state.inputText);
-  }, [state.inputText]);
+    onInputTextChange?.(state.inputText);
+  }, [state.inputText, onInputTextChange]);
 
   useEffect(() => {
-    callbacksRef.current.onCursorPositionChange?.(state.cursorPosition);
-  }, [state.cursorPosition]);
+    onCursorPositionChange?.(state.cursorPosition);
+  }, [state.cursorPosition, onCursorPositionChange]);
 
   // Handle pending effects
   useEffect(() => {
@@ -102,23 +114,21 @@ export const useInputManager = (
       try {
         switch (effect.type) {
           case "SEND_MESSAGE":
-            await callbacksRef.current.onSendMessage?.(
+            await onSendMessage?.(
               effect.content,
               effect.images,
               effect.longTextMap,
             );
             break;
           case "ABORT_MESSAGE":
-            callbacksRef.current.onAbortMessage?.();
+            onAbortMessage?.();
             break;
           case "BACKGROUND_CURRENT_TASK":
-            callbacksRef.current.onBackgroundCurrentTask?.();
+            onBackgroundCurrentTask?.();
             break;
           case "ASK_BTW":
             try {
-              const answer = await callbacksRef.current.onAskBtw?.(
-                effect.question,
-              );
+              const answer = await onAskBtw?.(effect.question);
               dispatch({
                 type: "SET_BTW_STATE",
                 payload: { answer, isLoading: false },
@@ -136,43 +146,35 @@ export const useInputManager = (
             }
             break;
           case "PERMISSION_MODE_CHANGE":
-            callbacksRef.current.onPermissionModeChange?.(effect.mode);
+            onPermissionModeChange?.(effect.mode);
             break;
           case "SAVE_HISTORY":
             PromptHistoryManager.addEntry(
               effect.content,
-              callbacksRef.current.sessionId,
+              sessionId,
               effect.longTextMap,
-              callbacksRef.current.workdir,
+              workdir,
             ).catch((err: unknown) => {
-              callbacksRef.current.logger?.error(
-                "Failed to save prompt history",
-                err,
-              );
+              logger?.error("Failed to save prompt history", err);
             });
             break;
           case "FETCH_HISTORY": {
-            let sessionIds: string[] | undefined = callbacksRef.current
-              .sessionId
-              ? [callbacksRef.current.sessionId]
+            let sessionIds: string[] | undefined = sessionId
+              ? [sessionId]
               : undefined;
 
-            if (callbacksRef.current.getFullMessageThread) {
+            if (getFullMessageThread) {
               try {
-                const thread =
-                  await callbacksRef.current.getFullMessageThread();
+                const thread = await getFullMessageThread();
                 sessionIds = thread.sessionIds;
               } catch (error) {
-                callbacksRef.current.logger?.error(
-                  "Failed to fetch ancestor session IDs",
-                  error,
-                );
+                logger?.error("Failed to fetch ancestor session IDs", error);
               }
             }
 
             const history = await PromptHistoryManager.getHistory({
               sessionId: sessionIds,
-              workdir: callbacksRef.current.workdir,
+              workdir: workdir,
             });
             dispatch({ type: "SET_HISTORY_ENTRIES", payload: history });
             dispatch({ type: "NAVIGATE_HISTORY", payload: "up" });
@@ -186,17 +188,10 @@ export const useInputManager = (
             }
             break;
           case "EXECUTE_COMMAND":
-            if (
-              callbacksRef.current.onSendMessage &&
-              callbacksRef.current.onHasSlashCommand?.(effect.command)
-            ) {
+            if (onSendMessage && onHasSlashCommand?.(effect.command)) {
               const fullCommand = `/${effect.command}`;
               try {
-                await callbacksRef.current.onSendMessage(
-                  fullCommand,
-                  undefined,
-                  {},
-                );
+                await onSendMessage(fullCommand, undefined, {});
               } catch (error) {
                 console.error("Failed to execute slash command:", error);
               }
@@ -235,10 +230,22 @@ export const useInputManager = (
     };
 
     runEffect();
-  }, [state.pendingEffect]);
+  }, [
+    state.pendingEffect,
+    onSendMessage,
+    onAbortMessage,
+    onBackgroundCurrentTask,
+    onAskBtw,
+    onPermissionModeChange,
+    sessionId,
+    workdir,
+    getFullMessageThread,
+    logger,
+    onHasSlashCommand,
+  ]);
 
   useEffect(() => {
-    callbacksRef.current.onFileSelectorStateChange?.(
+    onFileSelectorStateChange?.(
       state.showFileSelector,
       state.filteredFiles,
       state.fileSearchQuery,
@@ -249,10 +256,11 @@ export const useInputManager = (
     state.filteredFiles,
     state.fileSearchQuery,
     state.atPosition,
+    onFileSelectorStateChange,
   ]);
 
   useEffect(() => {
-    callbacksRef.current.onCommandSelectorStateChange?.(
+    onCommandSelectorStateChange?.(
       state.showCommandSelector,
       state.commandSearchQuery,
       state.slashPosition,
@@ -261,48 +269,51 @@ export const useInputManager = (
     state.showCommandSelector,
     state.commandSearchQuery,
     state.slashPosition,
+    onCommandSelectorStateChange,
   ]);
 
   useEffect(() => {
-    callbacksRef.current.onHistorySearchStateChange?.(
+    onHistorySearchStateChange?.(
       state.showHistorySearch,
       state.historySearchQuery,
     );
-  }, [state.showHistorySearch, state.historySearchQuery]);
+  }, [
+    state.showHistorySearch,
+    state.historySearchQuery,
+    onHistorySearchStateChange,
+  ]);
 
   useEffect(() => {
-    callbacksRef.current.onBackgroundTaskManagerStateChange?.(
-      state.showBackgroundTaskManager,
-    );
-  }, [state.showBackgroundTaskManager]);
+    onBackgroundTaskManagerStateChange?.(state.showBackgroundTaskManager);
+  }, [state.showBackgroundTaskManager, onBackgroundTaskManagerStateChange]);
 
   useEffect(() => {
-    callbacksRef.current.onMcpManagerStateChange?.(state.showMcpManager);
-  }, [state.showMcpManager]);
+    onMcpManagerStateChange?.(state.showMcpManager);
+  }, [state.showMcpManager, onMcpManagerStateChange]);
 
   useEffect(() => {
-    callbacksRef.current.onRewindManagerStateChange?.(state.showRewindManager);
-  }, [state.showRewindManager]);
+    onRewindManagerStateChange?.(state.showRewindManager);
+  }, [state.showRewindManager, onRewindManagerStateChange]);
 
   useEffect(() => {
-    callbacksRef.current.onHelpStateChange?.(state.showHelp);
-  }, [state.showHelp]);
+    onHelpStateChange?.(state.showHelp);
+  }, [state.showHelp, onHelpStateChange]);
 
   useEffect(() => {
-    callbacksRef.current.onStatusCommandStateChange?.(state.showStatusCommand);
-  }, [state.showStatusCommand]);
+    onStatusCommandStateChange?.(state.showStatusCommand);
+  }, [state.showStatusCommand, onStatusCommandStateChange]);
 
   useEffect(() => {
-    callbacksRef.current.onPluginManagerStateChange?.(state.showPluginManager);
-  }, [state.showPluginManager]);
+    onPluginManagerStateChange?.(state.showPluginManager);
+  }, [state.showPluginManager, onPluginManagerStateChange]);
 
   useEffect(() => {
-    callbacksRef.current.onModelSelectorStateChange?.(state.showModelSelector);
-  }, [state.showModelSelector]);
+    onModelSelectorStateChange?.(state.showModelSelector);
+  }, [state.showModelSelector, onModelSelectorStateChange]);
 
   useEffect(() => {
-    callbacksRef.current.onImagesStateChange?.(state.attachedImages);
-  }, [state.attachedImages]);
+    onImagesStateChange?.(state.attachedImages);
+  }, [state.attachedImages, onImagesStateChange]);
 
   // Handle /btw side question
   useEffect(() => {
@@ -313,9 +324,7 @@ export const useInputManager = (
     ) {
       const askBtw = async () => {
         try {
-          const answer = await callbacksRef.current.onAskBtw?.(
-            state.btwState.question,
-          );
+          const answer = await onAskBtw?.(state.btwState.question);
           dispatch({
             type: "SET_BTW_STATE",
             payload: { answer, isLoading: false },
@@ -337,6 +346,7 @@ export const useInputManager = (
     state.btwState.isActive,
     state.btwState.isLoading,
     state.btwState.question,
+    onAskBtw,
   ]);
 
   // Methods
@@ -376,11 +386,14 @@ export const useInputManager = (
     dispatch({ type: "SET_FILE_SEARCH_QUERY", payload: query });
   }, []);
 
-  const checkForAtDeletion = useCallback((cursorPos: number) => {
-    // This is now largely handled inside HANDLE_KEY,
-    // but kept for external calls if any.
-    return handlers.checkForAtDeletion(stateRef.current, dispatch, cursorPos);
-  }, []);
+  const checkForAtDeletion = useCallback(
+    (cursorPos: number) => {
+      // This is now largely handled inside HANDLE_KEY,
+      // but kept for external calls if any.
+      return handlers.checkForAtDeletion(state, dispatch, cursorPos);
+    },
+    [state],
+  );
 
   const activateCommandSelector = useCallback((position: number) => {
     dispatch({ type: "ACTIVATE_COMMAND_SELECTOR", payload: position });
@@ -402,13 +415,12 @@ export const useInputManager = (
     dispatch({ type: "SET_COMMAND_SEARCH_QUERY", payload: query });
   }, []);
 
-  const checkForSlashDeletion = useCallback((cursorPos: number) => {
-    return handlers.checkForSlashDeletion(
-      stateRef.current,
-      dispatch,
-      cursorPos,
-    );
-  }, []);
+  const checkForSlashDeletion = useCallback(
+    (cursorPos: number) => {
+      return handlers.checkForSlashDeletion(state, dispatch, cursorPos);
+    },
+    [state],
+  );
 
   const handleHistorySearchSelect = useCallback((entry: PromptEntry) => {
     dispatch({ type: "SELECT_HISTORY_ENTRY", payload: entry });
@@ -418,9 +430,12 @@ export const useInputManager = (
     dispatch({ type: "CANCEL_HISTORY_SEARCH" });
   }, []);
 
-  const processSelectorInput = useCallback((char: string) => {
-    handlers.processSelectorInput(stateRef.current, dispatch, char);
-  }, []);
+  const processSelectorInput = useCallback(
+    (char: string) => {
+      handlers.processSelectorInput(state, dispatch, char);
+    },
+    [state],
+  );
 
   const setInputText = useCallback((text: string) => {
     dispatch({ type: "SET_INPUT_TEXT", payload: text });
@@ -458,10 +473,13 @@ export const useInputManager = (
     dispatch({ type: "SET_SHOW_MODEL_SELECTOR", payload: show });
   }, []);
 
-  const setPermissionMode = useCallback((mode: PermissionMode) => {
-    dispatch({ type: "SET_PERMISSION_MODE", payload: mode });
-    callbacksRef.current.onPermissionModeChange?.(mode);
-  }, []);
+  const setPermissionMode = useCallback(
+    (mode: PermissionMode) => {
+      dispatch({ type: "SET_PERMISSION_MODE", payload: mode });
+      onPermissionModeChange?.(mode);
+    },
+    [onPermissionModeChange],
+  );
 
   const setBtwState = useCallback(
     (payload: Partial<import("../managers/inputReducer.js").BtwState>) => {
@@ -486,17 +504,19 @@ export const useInputManager = (
     return await handlers.handlePasteImage(dispatch);
   }, []);
 
-  const handlePasteInput = useCallback((input: string) => {
-    dispatch({
-      type: "HANDLE_KEY",
-      payload: {
-        input,
-        key: {} as Key,
-        hasSlashCommand: (cmd) =>
-          !!callbacksRef.current.onHasSlashCommand?.(cmd),
-      },
-    });
-  }, []);
+  const handlePasteInput = useCallback(
+    (input: string) => {
+      dispatch({
+        type: "HANDLE_KEY",
+        payload: {
+          input,
+          key: {} as Key,
+          hasSlashCommand: (cmd) => !!onHasSlashCommand?.(cmd),
+        },
+      });
+    },
+    [onHasSlashCommand],
+  );
 
   const handleSubmit = useCallback(async () => {
     dispatch({
@@ -504,18 +524,17 @@ export const useInputManager = (
       payload: {
         input: "",
         key: { return: true } as Key,
-        hasSlashCommand: (cmd) =>
-          !!callbacksRef.current.onHasSlashCommand?.(cmd),
+        hasSlashCommand: (cmd) => !!onHasSlashCommand?.(cmd),
       },
     });
-  }, []);
+  }, [onHasSlashCommand]);
 
-  const expandLongTextPlaceholders = useCallback((text: string) => {
-    return handlers.expandLongTextPlaceholders(
-      text,
-      stateRef.current.longTextMap,
-    );
-  }, []);
+  const expandLongTextPlaceholders = useCallback(
+    (text: string) => {
+      return handlers.expandLongTextPlaceholders(text, state.longTextMap);
+    },
+    [state.longTextMap],
+  );
 
   const clearLongTextMap = useCallback(() => {
     dispatch({ type: "CLEAR_LONG_TEXT_MAP" });
@@ -538,13 +557,12 @@ export const useInputManager = (
         payload: {
           input,
           key,
-          hasSlashCommand: (cmd) =>
-            !!callbacksRef.current.onHasSlashCommand?.(cmd),
+          hasSlashCommand: (cmd) => !!onHasSlashCommand?.(cmd),
         },
       });
       return true;
     },
-    [],
+    [onHasSlashCommand],
   );
 
   return {

--- a/packages/code/src/managers/inputReducer.ts
+++ b/packages/code/src/managers/inputReducer.ts
@@ -5,6 +5,14 @@ import {
   PromptEntry,
   Message,
 } from "wave-agent-sdk";
+import { Key } from "ink";
+import {
+  getAtSelectorPosition,
+  getSlashSelectorPosition,
+  getWordEnd,
+  SELECTOR_TRIGGERS,
+  getProjectedState,
+} from "../utils/inputUtils.js";
 
 export interface AttachedImage {
   id: number;
@@ -18,6 +26,26 @@ export interface BtwState {
   answer?: string;
   isLoading: boolean;
 }
+
+export type PendingEffect =
+  | {
+      type: "SEND_MESSAGE";
+      content: string;
+      images?: Array<{ path: string; mimeType: string }>;
+      longTextMap: Record<string, string>;
+    }
+  | { type: "ABORT_MESSAGE" }
+  | { type: "BACKGROUND_CURRENT_TASK" }
+  | { type: "ASK_BTW"; question: string }
+  | { type: "PERMISSION_MODE_CHANGE"; mode: PermissionMode }
+  | {
+      type: "SAVE_HISTORY";
+      content: string;
+      longTextMap: Record<string, string>;
+    }
+  | { type: "FETCH_HISTORY" }
+  | { type: "PASTE_IMAGE" }
+  | { type: "EXECUTE_COMMAND"; command: string };
 
 export interface InputManagerCallbacks {
   onInputTextChange?: (text: string) => void;
@@ -95,6 +123,7 @@ export interface InputState {
   originalLongTextMap: Record<string, string>;
   isFileSearching: boolean;
   btwState: BtwState;
+  pendingEffect: PendingEffect | null;
 }
 
 export const initialState: InputState = {
@@ -135,6 +164,7 @@ export const initialState: InputState = {
     question: "",
     isLoading: false,
   },
+  pendingEffect: null,
 };
 
 export type InputAction =
@@ -183,7 +213,19 @@ export type InputAction =
   | { type: "NAVIGATE_HISTORY"; payload: "up" | "down" }
   | { type: "RESET_HISTORY_NAVIGATION" }
   | { type: "SELECT_HISTORY_ENTRY"; payload: PromptEntry }
-  | { type: "SET_BTW_STATE"; payload: Partial<BtwState> };
+  | { type: "SELECT_COMMAND"; payload: string }
+  | { type: "INSERT_COMMAND"; payload: string }
+  | { type: "SELECT_FILE"; payload: string }
+  | { type: "SET_BTW_STATE"; payload: Partial<BtwState> }
+  | { type: "CLEAR_PENDING_EFFECT" }
+  | {
+      type: "HANDLE_KEY";
+      payload: {
+        input: string;
+        key: Key;
+        hasSlashCommand: (cmd: string) => boolean;
+      };
+    };
 
 export function inputReducer(
   state: InputState,
@@ -388,7 +430,7 @@ export function inputReducer(
       const newText = beforeCursor + textToInsert + afterCursor;
       const newCursorPosition = state.cursorPosition + textToInsert.length;
 
-      return {
+      const newState: InputState = {
         ...state,
         inputText: newText,
         cursorPosition: newCursorPosition,
@@ -396,6 +438,34 @@ export function inputReducer(
         longTextMap: newLongTextMap,
         historyIndex: -1,
       };
+
+      // Sync selectors
+      const atPos = getAtSelectorPosition(newText, newCursorPosition);
+      if (atPos !== -1 && !newState.showFileSelector) {
+        newState.showFileSelector = true;
+        newState.atPosition = atPos;
+        newState.isFileSearching = true;
+      }
+
+      const slashPos = getSlashSelectorPosition(newText, newCursorPosition);
+      if (slashPos !== -1 && !newState.showCommandSelector) {
+        newState.showCommandSelector = true;
+        newState.slashPosition = slashPos;
+      }
+
+      if (newState.showFileSelector && newState.atPosition >= 0) {
+        newState.fileSearchQuery = newText.substring(
+          newState.atPosition + 1,
+          newCursorPosition,
+        );
+      } else if (newState.showCommandSelector && newState.slashPosition >= 0) {
+        newState.commandSearchQuery = newText.substring(
+          newState.slashPosition + 1,
+          newCursorPosition,
+        );
+      }
+
+      return newState;
     }
     case "CLEAR_LONG_TEXT_MAP":
       return { ...state, longTextMap: {} };
@@ -519,6 +589,72 @@ export function inputReducer(
         selectorJustUsed: true,
       };
     }
+    case "SELECT_COMMAND": {
+      const command = action.payload;
+      if (state.slashPosition >= 0) {
+        const wordEnd = getWordEnd(state.inputText, state.slashPosition);
+        const beforeSlash = state.inputText.substring(0, state.slashPosition);
+        const afterWord = state.inputText.substring(wordEnd);
+        const newInput = beforeSlash + afterWord;
+        const newCursorPosition = beforeSlash.length;
+
+        return {
+          ...state,
+          inputText: newInput,
+          cursorPosition: newCursorPosition,
+          showCommandSelector: false,
+          slashPosition: -1,
+          commandSearchQuery: "",
+          selectorJustUsed: true,
+          pendingEffect: { type: "EXECUTE_COMMAND", command },
+        };
+      }
+      return state;
+    }
+    case "INSERT_COMMAND": {
+      const command = action.payload;
+      if (state.slashPosition >= 0) {
+        const wordEnd = getWordEnd(state.inputText, state.slashPosition);
+        const beforeSlash = state.inputText.substring(0, state.slashPosition);
+        const afterWord = state.inputText.substring(wordEnd);
+        const newInput = beforeSlash + `/${command} ` + afterWord;
+        const newCursorPosition = beforeSlash.length + command.length + 2;
+
+        return {
+          ...state,
+          inputText: newInput,
+          cursorPosition: newCursorPosition,
+          showCommandSelector: false,
+          slashPosition: -1,
+          commandSearchQuery: "",
+          selectorJustUsed: true,
+        };
+      }
+      return state;
+    }
+    case "SELECT_FILE": {
+      const filePath = action.payload;
+      if (state.atPosition >= 0) {
+        const wordEnd = getWordEnd(state.inputText, state.atPosition);
+        const beforeAt = state.inputText.substring(0, state.atPosition);
+        const afterWord = state.inputText.substring(wordEnd);
+        const newInput = beforeAt + `@${filePath} ` + afterWord;
+        const newCursorPosition = beforeAt.length + filePath.length + 2;
+
+        return {
+          ...state,
+          inputText: newInput,
+          cursorPosition: newCursorPosition,
+          showFileSelector: false,
+          atPosition: -1,
+          fileSearchQuery: "",
+          filteredFiles: [],
+          selectorJustUsed: true,
+          isFileSearching: false,
+        };
+      }
+      return state;
+    }
     case "RESET_HISTORY_NAVIGATION":
       return {
         ...state,
@@ -527,6 +663,548 @@ export function inputReducer(
         originalInputText: "",
         originalLongTextMap: {},
       };
+    case "CLEAR_PENDING_EFFECT":
+      return { ...state, pendingEffect: null };
+    case "HANDLE_KEY": {
+      const { input, key } = action.payload;
+
+      if (state.selectorJustUsed) {
+        return state;
+      }
+
+      // 1. BTW State Handling
+      if (state.btwState.isActive) {
+        if (key.escape) {
+          return {
+            ...state,
+            btwState: {
+              isActive: false,
+              question: "",
+              answer: undefined,
+              isLoading: false,
+            },
+          };
+        }
+
+        if (key.return) {
+          const question = state.inputText.trim();
+          if (question && !state.btwState.isLoading) {
+            return {
+              ...state,
+              inputText: "",
+              cursorPosition: 0,
+              btwState: {
+                ...state.btwState,
+                question,
+                isLoading: true,
+                answer: undefined,
+              },
+              pendingEffect: { type: "ASK_BTW", question },
+            };
+          }
+          return state;
+        }
+      }
+
+      // 2. Escape Handling
+      if (key.escape) {
+        if (state.showFileSelector) {
+          return {
+            ...state,
+            showFileSelector: false,
+            atPosition: -1,
+            fileSearchQuery: "",
+            filteredFiles: [],
+            selectorJustUsed: true,
+            isFileSearching: false,
+          };
+        }
+        if (state.showCommandSelector) {
+          return {
+            ...state,
+            showCommandSelector: false,
+            slashPosition: -1,
+            commandSearchQuery: "",
+            selectorJustUsed: true,
+          };
+        }
+        if (state.showHistorySearch) {
+          return {
+            ...state,
+            showHistorySearch: false,
+            historySearchQuery: "",
+            selectorJustUsed: true,
+          };
+        }
+        if (state.historyIndex !== -1) {
+          return {
+            ...state,
+            historyIndex: -1,
+            inputText: state.originalInputText,
+            longTextMap: state.originalLongTextMap,
+            cursorPosition: state.originalInputText.length,
+            originalInputText: "",
+            originalLongTextMap: {},
+          };
+        }
+        if (
+          !(
+            state.showBackgroundTaskManager ||
+            state.showMcpManager ||
+            state.showRewindManager ||
+            state.showHelp ||
+            state.showStatusCommand ||
+            state.showPluginManager ||
+            state.showModelSelector
+          )
+        ) {
+          return { ...state, pendingEffect: { type: "ABORT_MESSAGE" } };
+        }
+        return state;
+      }
+
+      // 3. Special Shortcuts
+      if (key.tab && key.shift) {
+        const modes: PermissionMode[] = [
+          "default",
+          "acceptEdits",
+          "plan",
+          "bypassPermissions",
+        ];
+        const currentIndex = modes.indexOf(state.permissionMode);
+        const nextIndex =
+          currentIndex === -1 ? 0 : (currentIndex + 1) % modes.length;
+        const nextMode = modes[nextIndex];
+        return {
+          ...state,
+          permissionMode: nextMode,
+          pendingEffect: { type: "PERMISSION_MODE_CHANGE", mode: nextMode },
+        };
+      }
+
+      if (key.ctrl && input === "v") {
+        return { ...state, pendingEffect: { type: "PASTE_IMAGE" } };
+      }
+
+      if (key.ctrl && input === "r") {
+        return {
+          ...state,
+          showHistorySearch: true,
+          historySearchQuery: "",
+        };
+      }
+
+      if (key.ctrl && input === "b") {
+        return {
+          ...state,
+          pendingEffect: { type: "BACKGROUND_CURRENT_TASK" },
+        };
+      }
+
+      // 4. History Navigation
+      if (
+        key.upArrow &&
+        !state.showFileSelector &&
+        !state.showCommandSelector
+      ) {
+        if (state.history.length === 0) {
+          return { ...state, pendingEffect: { type: "FETCH_HISTORY" } };
+        }
+        // If history is already loaded, NAVIGATE_HISTORY logic follows
+        let newIndex = state.historyIndex;
+        let newOriginalInputText = state.originalInputText;
+        let newOriginalLongTextMap = state.originalLongTextMap;
+
+        if (newIndex === -1) {
+          newOriginalInputText = state.inputText;
+          newOriginalLongTextMap = state.longTextMap;
+        }
+        newIndex = Math.min(state.history.length - 1, newIndex + 1);
+        const entry = state.history[newIndex];
+        return {
+          ...state,
+          historyIndex: newIndex,
+          inputText: entry.prompt,
+          longTextMap: entry.longTextMap || {},
+          cursorPosition: entry.prompt.length,
+          originalInputText: newOriginalInputText,
+          originalLongTextMap: newOriginalLongTextMap,
+        };
+      }
+
+      if (
+        key.downArrow &&
+        !state.showFileSelector &&
+        !state.showCommandSelector
+      ) {
+        if (state.historyIndex === -1) return state;
+        const newIndex = state.historyIndex - 1;
+
+        if (newIndex === -1) {
+          return {
+            ...state,
+            historyIndex: -1,
+            inputText: state.originalInputText,
+            longTextMap: state.originalLongTextMap,
+            cursorPosition: state.originalInputText.length,
+            originalInputText: "",
+            originalLongTextMap: {},
+          };
+        } else {
+          const entry = state.history[newIndex];
+          return {
+            ...state,
+            historyIndex: newIndex,
+            inputText: entry.prompt,
+            longTextMap: entry.longTextMap || {},
+            cursorPosition: entry.prompt.length,
+          };
+        }
+      }
+
+      // 5. Active Selector Handling (History Search, File, Command)
+      if (state.showHistorySearch) {
+        if (key.backspace || key.delete) {
+          return {
+            ...state,
+            historySearchQuery: state.historySearchQuery.slice(0, -1),
+          };
+        }
+        if (input && !key.ctrl && !key.meta && !key.return && !key.tab) {
+          return {
+            ...state,
+            historySearchQuery: state.historySearchQuery + input,
+          };
+        }
+        return state;
+      }
+
+      if (state.showFileSelector || state.showCommandSelector) {
+        if (key.backspace || key.delete) {
+          if (state.cursorPosition > 0) {
+            const newCursorPosition = state.cursorPosition - 1;
+            const beforeCursor = state.inputText.substring(
+              0,
+              state.cursorPosition - 1,
+            );
+            const afterCursor = state.inputText.substring(state.cursorPosition);
+            const newInputText = beforeCursor + afterCursor;
+
+            const newState = {
+              ...state,
+              inputText: newInputText,
+              cursorPosition: newCursorPosition,
+              historyIndex: -1,
+            };
+
+            // checkForAtDeletion
+            if (
+              newState.showFileSelector &&
+              newCursorPosition <= newState.atPosition
+            ) {
+              newState.showFileSelector = false;
+              newState.atPosition = -1;
+              newState.fileSearchQuery = "";
+            }
+            // checkForSlashDeletion
+            if (
+              newState.showCommandSelector &&
+              newCursorPosition <= newState.slashPosition
+            ) {
+              newState.showCommandSelector = false;
+              newState.slashPosition = -1;
+              newState.commandSearchQuery = "";
+            }
+
+            // Update queries
+            if (newState.showFileSelector && newState.atPosition >= 0) {
+              newState.fileSearchQuery = newInputText.substring(
+                newState.atPosition + 1,
+                newCursorPosition,
+              );
+            }
+            if (newState.showCommandSelector && newState.slashPosition >= 0) {
+              newState.commandSearchQuery = newInputText.substring(
+                newState.slashPosition + 1,
+                newCursorPosition,
+              );
+            }
+            return newState;
+          }
+        }
+        if (key.leftArrow || key.rightArrow) {
+          const delta = key.leftArrow ? -1 : 1;
+          const newCursorPosition = Math.max(
+            0,
+            Math.min(state.inputText.length, state.cursorPosition + delta),
+          );
+          const newState = { ...state, cursorPosition: newCursorPosition };
+          if (
+            newState.showFileSelector &&
+            newCursorPosition <= newState.atPosition
+          ) {
+            newState.showFileSelector = false;
+            newState.atPosition = -1;
+          }
+          if (
+            newState.showCommandSelector &&
+            newCursorPosition <= newState.slashPosition
+          ) {
+            newState.showCommandSelector = false;
+            newState.slashPosition = -1;
+          }
+          return newState;
+        }
+        if (input === " ") {
+          return {
+            ...state,
+            showFileSelector: false,
+            atPosition: -1,
+            showCommandSelector: false,
+            slashPosition: -1,
+            inputText:
+              state.inputText.substring(0, state.cursorPosition) +
+              " " +
+              state.inputText.substring(state.cursorPosition),
+            cursorPosition: state.cursorPosition + 1,
+          };
+        }
+
+        if (key.return || key.tab || key.upArrow || key.downArrow) {
+          return state;
+        }
+      }
+
+      // 6. Return / Submit
+      if (key.return) {
+        if (state.inputText.trim()) {
+          const imageRegex = /\[Image #(\d+)\]/g;
+          const matches = [...state.inputText.matchAll(imageRegex)];
+          const referencedImages = matches
+            .map((match) => {
+              const imageId = parseInt(match[1], 10);
+              return state.attachedImages.find((img) => img.id === imageId);
+            })
+            .filter((img): img is AttachedImage => img !== undefined)
+            .map((img) => ({ path: img.path, mimeType: img.mimeType }));
+
+          const contentWithPlaceholders = state.inputText
+            .replace(imageRegex, "")
+            .trim();
+
+          if (
+            contentWithPlaceholders === "/btw" ||
+            contentWithPlaceholders.startsWith("/btw ")
+          ) {
+            const question = contentWithPlaceholders.startsWith("/btw ")
+              ? contentWithPlaceholders.substring(5).trim()
+              : "";
+
+            return {
+              ...state,
+              inputText: "",
+              cursorPosition: 0,
+              historyIndex: -1,
+              longTextMap: {},
+              btwState: {
+                isActive: true,
+                question,
+                isLoading: question !== "",
+                answer: undefined,
+              },
+              pendingEffect: question ? { type: "ASK_BTW", question } : null,
+            };
+          }
+
+          return {
+            ...state,
+            inputText: "",
+            cursorPosition: 0,
+            historyIndex: -1,
+            longTextMap: {},
+            pendingEffect: {
+              type: "SEND_MESSAGE",
+              content: contentWithPlaceholders,
+              images:
+                referencedImages.length > 0 ? referencedImages : undefined,
+              longTextMap: state.longTextMap,
+            },
+          };
+        }
+        return state;
+      }
+
+      // 7. Regular Input
+      if (
+        input &&
+        !key.ctrl &&
+        !("alt" in key && key.alt) &&
+        !key.meta &&
+        !key.return &&
+        !key.escape &&
+        !key.leftArrow &&
+        !key.rightArrow &&
+        !("home" in key && key.home) &&
+        !("end" in key && key.end)
+      ) {
+        const isPasteOperation =
+          input.length > 1 || input.includes("\n") || input.includes("\r");
+
+        if (isPasteOperation) {
+          const isNewPaste = !state.pasteBuffer;
+          return {
+            ...state,
+            isPasting: true,
+            pasteBuffer: state.pasteBuffer + input,
+            initialPasteCursorPosition: isNewPaste
+              ? state.cursorPosition
+              : state.initialPasteCursorPosition,
+          };
+        } else {
+          let char = input;
+          if (char === "！" && state.cursorPosition === 0) {
+            char = "!";
+          }
+
+          const { newInputText, newCursorPosition } = getProjectedState(
+            state.inputText,
+            state.cursorPosition,
+            char,
+          );
+
+          const newState = {
+            ...state,
+            inputText: newInputText,
+            cursorPosition: newCursorPosition,
+            historyIndex: -1,
+          };
+
+          // Selector Activation
+          const trigger = SELECTOR_TRIGGERS.find((t) =>
+            t.shouldActivate(
+              char,
+              newCursorPosition,
+              newInputText,
+              state.showFileSelector,
+            ),
+          );
+
+          if (trigger) {
+            if (trigger.type === "ACTIVATE_FILE_SELECTOR") {
+              newState.showFileSelector = true;
+              newState.atPosition = newCursorPosition - 1;
+              newState.fileSearchQuery = "";
+              newState.isFileSearching = true;
+            } else if (trigger.type === "ACTIVATE_COMMAND_SELECTOR") {
+              newState.showCommandSelector = true;
+              newState.slashPosition = newCursorPosition - 1;
+              newState.commandSearchQuery = "";
+            }
+          } else {
+            const atPos = getAtSelectorPosition(
+              newInputText,
+              newCursorPosition,
+            );
+            if (atPos !== -1 && !state.showFileSelector) {
+              newState.showFileSelector = true;
+              newState.atPosition = atPos;
+              newState.fileSearchQuery = "";
+              newState.isFileSearching = true;
+            }
+
+            const slashPos = getSlashSelectorPosition(
+              newInputText,
+              newCursorPosition,
+            );
+            if (slashPos !== -1 && !state.showCommandSelector) {
+              newState.showCommandSelector = true;
+              newState.slashPosition = slashPos;
+              newState.commandSearchQuery = "";
+            }
+          }
+
+          // Update queries
+          if (newState.showFileSelector && newState.atPosition >= 0) {
+            newState.fileSearchQuery = newInputText.substring(
+              newState.atPosition + 1,
+              newCursorPosition,
+            );
+          }
+          if (newState.showCommandSelector && newState.slashPosition >= 0) {
+            newState.commandSearchQuery = newInputText.substring(
+              newState.slashPosition + 1,
+              newCursorPosition,
+            );
+          }
+
+          return newState;
+        }
+      }
+
+      // 8. Backspace / Delete (Normal Mode)
+      if (key.backspace || key.delete) {
+        if (state.cursorPosition > 0) {
+          const newCursorPosition = state.cursorPosition - 1;
+          const beforeCursor = state.inputText.substring(
+            0,
+            state.cursorPosition - 1,
+          );
+          const afterCursor = state.inputText.substring(state.cursorPosition);
+          const newInputText = beforeCursor + afterCursor;
+
+          const newState = {
+            ...state,
+            inputText: newInputText,
+            cursorPosition: newCursorPosition,
+            historyIndex: -1,
+          };
+
+          // Reactivate selectors if cursor is within word
+          const atPos = getAtSelectorPosition(newInputText, newCursorPosition);
+          if (atPos !== -1 && !state.showFileSelector) {
+            newState.showFileSelector = true;
+            newState.atPosition = atPos;
+            newState.isFileSearching = true;
+          }
+
+          const slashPos = getSlashSelectorPosition(
+            newInputText,
+            newCursorPosition,
+          );
+          if (slashPos !== -1 && !state.showCommandSelector) {
+            newState.showCommandSelector = true;
+            newState.slashPosition = slashPos;
+          }
+
+          // Update queries
+          if (newState.showFileSelector && newState.atPosition >= 0) {
+            newState.fileSearchQuery = newInputText.substring(
+              newState.atPosition + 1,
+              newCursorPosition,
+            );
+          }
+          if (newState.showCommandSelector && newState.slashPosition >= 0) {
+            newState.commandSearchQuery = newInputText.substring(
+              newState.slashPosition + 1,
+              newCursorPosition,
+            );
+          }
+          return newState;
+        }
+      }
+
+      // 9. Cursor Movement (Normal Mode)
+      if (key.leftArrow || key.rightArrow) {
+        const delta = key.leftArrow ? -1 : 1;
+        const newCursorPosition = Math.max(
+          0,
+          Math.min(state.inputText.length, state.cursorPosition + delta),
+        );
+        return { ...state, cursorPosition: newCursorPosition };
+      }
+
+      return state;
+    }
     case "SET_BTW_STATE":
       return {
         ...state,

--- a/packages/code/src/reducers/backgroundTaskManagerReducer.ts
+++ b/packages/code/src/reducers/backgroundTaskManagerReducer.ts
@@ -1,3 +1,5 @@
+import { Key } from "ink";
+
 export interface Task {
   id: string;
   type: string;
@@ -16,12 +18,17 @@ export interface DetailOutput {
   outputPath?: string;
 }
 
+export type PendingEffect =
+  | { type: "CANCEL" }
+  | { type: "STOP_TASK"; taskId: string };
+
 export interface BackgroundTaskManagerState {
   tasks: Task[];
   selectedIndex: number;
   viewMode: "list" | "detail";
   detailTaskId: string | null;
   detailOutput: DetailOutput | null;
+  pendingEffect: PendingEffect | null;
 }
 
 export type BackgroundTaskManagerAction =
@@ -33,7 +40,9 @@ export type BackgroundTaskManagerAction =
   | { type: "SET_VIEW_MODE"; mode: "list" | "detail" }
   | { type: "SET_DETAIL_TASK_ID"; id: string | null }
   | { type: "SET_DETAIL_OUTPUT"; output: DetailOutput | null }
-  | { type: "RESET_DETAIL" };
+  | { type: "RESET_DETAIL" }
+  | { type: "HANDLE_KEY"; input: string; key: Key }
+  | { type: "CLEAR_PENDING_EFFECT" };
 
 export function backgroundTaskManagerReducer(
   state: BackgroundTaskManagerState,
@@ -76,6 +85,84 @@ export function backgroundTaskManagerReducer(
         detailTaskId: null,
         detailOutput: null,
       };
+    case "HANDLE_KEY": {
+      const { input, key } = action;
+      if (state.viewMode === "list") {
+        if (key.return) {
+          if (
+            state.tasks.length > 0 &&
+            state.selectedIndex < state.tasks.length
+          ) {
+            return {
+              ...state,
+              detailTaskId: state.tasks[state.selectedIndex].id,
+              viewMode: "detail",
+            };
+          }
+          return state;
+        }
+
+        if (key.escape) {
+          return { ...state, pendingEffect: { type: "CANCEL" } };
+        }
+
+        if (key.upArrow) {
+          return {
+            ...state,
+            selectedIndex: Math.max(0, state.selectedIndex - 1),
+          };
+        }
+
+        if (key.downArrow) {
+          return {
+            ...state,
+            selectedIndex: Math.min(
+              state.tasks.length > 0 ? state.tasks.length - 1 : 0,
+              state.selectedIndex + 1,
+            ),
+          };
+        }
+
+        if (input === "k") {
+          if (
+            state.tasks.length > 0 &&
+            state.selectedIndex < state.tasks.length
+          ) {
+            const selectedTask = state.tasks[state.selectedIndex];
+            if (selectedTask.status === "running") {
+              return {
+                ...state,
+                pendingEffect: { type: "STOP_TASK", taskId: selectedTask.id },
+              };
+            }
+          }
+          return state;
+        }
+      } else if (state.viewMode === "detail") {
+        if (key.escape) {
+          return {
+            ...state,
+            viewMode: "list",
+            detailTaskId: null,
+            detailOutput: null,
+          };
+        }
+
+        if (input === "k" && state.detailTaskId) {
+          const task = state.tasks.find((t) => t.id === state.detailTaskId);
+          if (task && task.status === "running") {
+            return {
+              ...state,
+              pendingEffect: { type: "STOP_TASK", taskId: state.detailTaskId },
+            };
+          }
+          return state;
+        }
+      }
+      return state;
+    }
+    case "CLEAR_PENDING_EFFECT":
+      return { ...state, pendingEffect: null };
     default:
       return state;
   }

--- a/packages/code/src/reducers/backgroundTaskManagerReducer.ts
+++ b/packages/code/src/reducers/backgroundTaskManagerReducer.ts
@@ -27,6 +27,9 @@ export interface BackgroundTaskManagerState {
 export type BackgroundTaskManagerAction =
   | { type: "SET_TASKS"; tasks: Task[] }
   | { type: "SELECT_INDEX"; index: number }
+  | { type: "MOVE_UP" }
+  | { type: "MOVE_DOWN" }
+  | { type: "SELECT_CURRENT" }
   | { type: "SET_VIEW_MODE"; mode: "list" | "detail" }
   | { type: "SET_DETAIL_TASK_ID"; id: string | null }
   | { type: "SET_DETAIL_OUTPUT"; output: DetailOutput | null }
@@ -41,6 +44,25 @@ export function backgroundTaskManagerReducer(
       return { ...state, tasks: action.tasks };
     case "SELECT_INDEX":
       return { ...state, selectedIndex: action.index };
+    case "MOVE_UP":
+      return { ...state, selectedIndex: Math.max(0, state.selectedIndex - 1) };
+    case "MOVE_DOWN":
+      return {
+        ...state,
+        selectedIndex: Math.min(
+          state.tasks.length > 0 ? state.tasks.length - 1 : 0,
+          state.selectedIndex + 1,
+        ),
+      };
+    case "SELECT_CURRENT":
+      if (state.tasks.length > 0 && state.selectedIndex < state.tasks.length) {
+        return {
+          ...state,
+          detailTaskId: state.tasks[state.selectedIndex].id,
+          viewMode: "detail",
+        };
+      }
+      return state;
     case "SET_VIEW_MODE":
       return { ...state, viewMode: action.mode };
     case "SET_DETAIL_TASK_ID":

--- a/packages/code/src/reducers/confirmationReducer.ts
+++ b/packages/code/src/reducers/confirmationReducer.ts
@@ -1,4 +1,10 @@
+import { Key } from "ink";
 import type { PermissionDecision } from "wave-agent-sdk";
+import {
+  BASH_TOOL_NAME,
+  EXIT_PLAN_MODE_TOOL_NAME,
+  ENTER_PLAN_MODE_TOOL_NAME,
+} from "wave-agent-sdk";
 
 export interface ConfirmationState {
   selectedOption: "clear" | "auto" | "allow" | "alternative";
@@ -14,7 +20,17 @@ export type ConfirmationAction =
   | { type: "BACKSPACE" }
   | { type: "MOVE_CURSOR_LEFT" }
   | { type: "MOVE_CURSOR_RIGHT" }
-  | { type: "CONFIRM"; decision: PermissionDecision };
+  | { type: "CONFIRM"; decision: PermissionDecision }
+  | { type: "CLEAR_DECISION" }
+  | {
+      type: "HANDLE_KEY";
+      input: string;
+      key: Key;
+      toolName: string;
+      toolInput?: Record<string, unknown>;
+      suggestedPrefix?: string;
+      hidePersistentOption?: boolean;
+    };
 
 export function confirmationReducer(
   state: ConfirmationState,
@@ -68,6 +84,162 @@ export function confirmationReducer(
       };
     case "CONFIRM":
       return { ...state, decision: action.decision };
+    case "CLEAR_DECISION":
+      return { ...state, decision: null };
+    case "HANDLE_KEY": {
+      const {
+        input,
+        key,
+        toolName,
+        toolInput,
+        suggestedPrefix,
+        hidePersistentOption,
+      } = action;
+
+      if (key.return) {
+        let decision: PermissionDecision | null = null;
+        if (state.selectedOption === "clear") {
+          decision = {
+            behavior: "allow",
+            newPermissionMode: "acceptEdits",
+            clearContext: true,
+          };
+        } else if (state.selectedOption === "allow") {
+          if (toolName === EXIT_PLAN_MODE_TOOL_NAME) {
+            decision = { behavior: "allow", newPermissionMode: "default" };
+          } else if (toolName === ENTER_PLAN_MODE_TOOL_NAME) {
+            decision = { behavior: "allow", newPermissionMode: "plan" };
+          } else {
+            decision = { behavior: "allow" };
+          }
+        } else if (state.selectedOption === "auto") {
+          if (toolName === BASH_TOOL_NAME) {
+            const command = (toolInput?.command as string) || "";
+            if (command.trim().startsWith("mkdir")) {
+              decision = {
+                behavior: "allow",
+                newPermissionMode: "acceptEdits",
+              };
+            } else {
+              const rule = suggestedPrefix
+                ? `Bash(${suggestedPrefix})`
+                : `Bash(${toolInput?.command})`;
+              decision = { behavior: "allow", newPermissionRule: rule };
+            }
+          } else if (toolName === ENTER_PLAN_MODE_TOOL_NAME) {
+            decision = { behavior: "allow", newPermissionMode: "plan" };
+          } else if (toolName.startsWith("mcp__")) {
+            decision = { behavior: "allow", newPermissionRule: toolName };
+          } else {
+            decision = { behavior: "allow", newPermissionMode: "acceptEdits" };
+          }
+        } else if (state.alternativeText.trim()) {
+          decision = {
+            behavior: "deny",
+            message: state.alternativeText.trim(),
+          };
+        } else if (toolName === ENTER_PLAN_MODE_TOOL_NAME) {
+          decision = {
+            behavior: "deny",
+            message: "User chose not to enter plan mode",
+          };
+        }
+
+        if (decision) {
+          return { ...state, decision };
+        }
+        return state;
+      }
+
+      if (state.selectedOption === "alternative") {
+        if (key.leftArrow) {
+          return {
+            ...state,
+            alternativeCursorPosition: Math.max(
+              0,
+              state.alternativeCursorPosition - 1,
+            ),
+          };
+        }
+        if (key.rightArrow) {
+          return {
+            ...state,
+            alternativeCursorPosition: Math.min(
+              state.alternativeText.length,
+              state.alternativeCursorPosition + 1,
+            ),
+          };
+        }
+      }
+
+      const availableOptions: ConfirmationState["selectedOption"][] = [];
+      if (toolName === EXIT_PLAN_MODE_TOOL_NAME) availableOptions.push("clear");
+      availableOptions.push("allow");
+      if (!hidePersistentOption) availableOptions.push("auto");
+      availableOptions.push("alternative");
+
+      if (key.upArrow) {
+        const currentIndex = availableOptions.indexOf(state.selectedOption);
+        if (currentIndex > 0) {
+          return {
+            ...state,
+            selectedOption: availableOptions[currentIndex - 1],
+          };
+        }
+        return state;
+      }
+
+      if (key.downArrow) {
+        const currentIndex = availableOptions.indexOf(state.selectedOption);
+        if (currentIndex < availableOptions.length - 1) {
+          return {
+            ...state,
+            selectedOption: availableOptions[currentIndex + 1],
+          };
+        }
+        return state;
+      }
+
+      if (key.tab) {
+        const currentIndex = availableOptions.indexOf(state.selectedOption);
+        const direction = key.shift ? -1 : 1;
+        let nextIndex = currentIndex + direction;
+        if (nextIndex < 0) nextIndex = availableOptions.length - 1;
+        if (nextIndex >= availableOptions.length) nextIndex = 0;
+        return { ...state, selectedOption: availableOptions[nextIndex] };
+      }
+
+      if (input && !key.ctrl && !key.meta && !("alt" in key && key.alt)) {
+        const nextText =
+          state.alternativeText.slice(0, state.alternativeCursorPosition) +
+          input +
+          state.alternativeText.slice(state.alternativeCursorPosition);
+        return {
+          ...state,
+          selectedOption: "alternative",
+          alternativeText: nextText,
+          alternativeCursorPosition:
+            state.alternativeCursorPosition + input.length,
+          hasUserInput: true,
+        };
+      }
+
+      if (key.backspace || key.delete) {
+        if (state.alternativeCursorPosition <= 0) return state;
+        const nextText =
+          state.alternativeText.slice(0, state.alternativeCursorPosition - 1) +
+          state.alternativeText.slice(state.alternativeCursorPosition);
+        return {
+          ...state,
+          selectedOption: "alternative",
+          alternativeText: nextText,
+          alternativeCursorPosition: state.alternativeCursorPosition - 1,
+          hasUserInput: nextText.length > 0,
+        };
+      }
+
+      return state;
+    }
     default:
       return state;
   }

--- a/packages/code/src/reducers/helpSelectorReducer.ts
+++ b/packages/code/src/reducers/helpSelectorReducer.ts
@@ -1,0 +1,77 @@
+import { Key } from "ink";
+
+export interface SelectorState {
+  selectedIndex: number;
+  activeTab: "general" | "commands" | "custom-commands";
+  pendingDecision: "select" | "insert" | "cancel" | "tab-switch" | null;
+}
+
+export type SelectorAction =
+  | { type: "MOVE_UP" }
+  | { type: "MOVE_DOWN"; maxIndex: number }
+  | { type: "RESET_INDEX" }
+  | { type: "SWITCH_TAB"; tabs: string[] }
+  | { type: "HANDLE_KEY"; key: Key; maxIndex: number; tabs: string[] }
+  | { type: "CLEAR_DECISION" };
+
+export function helpSelectorReducer(
+  state: SelectorState,
+  action: SelectorAction,
+): SelectorState {
+  switch (action.type) {
+    case "MOVE_UP":
+      return { ...state, selectedIndex: Math.max(0, state.selectedIndex - 1) };
+    case "MOVE_DOWN":
+      return {
+        ...state,
+        selectedIndex: Math.min(action.maxIndex, state.selectedIndex + 1),
+      };
+    case "RESET_INDEX":
+      return { ...state, selectedIndex: 0 };
+    case "SWITCH_TAB": {
+      const currentIndex = action.tabs.indexOf(state.activeTab);
+      const nextIndex = (currentIndex + 1) % action.tabs.length;
+      return {
+        ...state,
+        activeTab: action.tabs[nextIndex] as
+          | "general"
+          | "commands"
+          | "custom-commands",
+        selectedIndex: 0,
+      };
+    }
+    case "HANDLE_KEY":
+      if (action.key.upArrow) {
+        return {
+          ...state,
+          selectedIndex: Math.max(0, state.selectedIndex - 1),
+        };
+      }
+      if (action.key.downArrow) {
+        return {
+          ...state,
+          selectedIndex: Math.min(action.maxIndex, state.selectedIndex + 1),
+        };
+      }
+      if (action.key.tab) {
+        const currentIndex = action.tabs.indexOf(state.activeTab);
+        const nextIndex = (currentIndex + 1) % action.tabs.length;
+        return {
+          ...state,
+          activeTab: action.tabs[nextIndex] as
+            | "general"
+            | "commands"
+            | "custom-commands",
+          selectedIndex: 0,
+        };
+      }
+      if (action.key.escape) {
+        return { ...state, pendingDecision: "cancel" };
+      }
+      return state;
+    case "CLEAR_DECISION":
+      return { ...state, pendingDecision: null };
+    default:
+      return state;
+  }
+}

--- a/packages/code/src/reducers/mcpManagerReducer.ts
+++ b/packages/code/src/reducers/mcpManagerReducer.ts
@@ -1,12 +1,28 @@
+import { Key } from "ink";
+
+export type PendingEffect =
+  | { type: "CANCEL" }
+  | { type: "CONNECT_SERVER"; serverName: string }
+  | { type: "DISCONNECT_SERVER"; serverName: string };
+
 export interface McpManagerState {
   selectedIndex: number;
   viewMode: "list" | "detail";
+  pendingEffect: PendingEffect | null;
 }
 
 export type McpManagerAction =
   | { type: "MOVE_UP"; serverCount: number }
   | { type: "MOVE_DOWN"; serverCount: number }
-  | { type: "SET_VIEW_MODE"; viewMode: "list" | "detail" };
+  | { type: "SET_VIEW_MODE"; viewMode: "list" | "detail" }
+  | {
+      type: "HANDLE_KEY";
+      input: string;
+      key: Key;
+      serverCount: number;
+      servers: Array<{ name: string; status: string }>;
+    }
+  | { type: "CLEAR_PENDING_EFFECT" };
 
 export function mcpManagerReducer(
   state: McpManagerState,
@@ -25,6 +41,71 @@ export function mcpManagerReducer(
       };
     case "SET_VIEW_MODE":
       return { ...state, viewMode: action.viewMode };
+    case "HANDLE_KEY": {
+      const { input, key, serverCount, servers } = action;
+
+      if (key.return) {
+        if (state.viewMode === "list") {
+          return { ...state, viewMode: "detail" };
+        }
+        return state;
+      }
+
+      if (key.escape) {
+        if (state.viewMode === "detail") {
+          return { ...state, viewMode: "list" };
+        } else {
+          return { ...state, pendingEffect: { type: "CANCEL" } };
+        }
+      }
+
+      if (key.upArrow) {
+        return {
+          ...state,
+          selectedIndex: Math.max(0, state.selectedIndex - 1),
+        };
+      }
+
+      if (key.downArrow) {
+        return {
+          ...state,
+          selectedIndex: Math.min(serverCount - 1, state.selectedIndex + 1),
+        };
+      }
+
+      // Hotkeys for server actions
+      if (input === "c") {
+        const server = servers[state.selectedIndex];
+        if (
+          server &&
+          (server.status === "disconnected" || server.status === "error")
+        ) {
+          return {
+            ...state,
+            pendingEffect: { type: "CONNECT_SERVER", serverName: server.name },
+          };
+        }
+        return state;
+      }
+
+      if (input === "d") {
+        const server = servers[state.selectedIndex];
+        if (server && server.status === "connected") {
+          return {
+            ...state,
+            pendingEffect: {
+              type: "DISCONNECT_SERVER",
+              serverName: server.name,
+            },
+          };
+        }
+        return state;
+      }
+
+      return state;
+    }
+    case "CLEAR_PENDING_EFFECT":
+      return { ...state, pendingEffect: null };
     default:
       return state;
   }

--- a/packages/code/src/reducers/pluginDetailReducer.ts
+++ b/packages/code/src/reducers/pluginDetailReducer.ts
@@ -1,6 +1,9 @@
+import { Key } from "ink";
+
 export interface PluginDetailState {
   selectedScopeIndex: number;
   selectedActionIndex: number;
+  pendingDecision: "select" | "cancel" | null;
 }
 
 export type PluginDetailAction =
@@ -9,7 +12,9 @@ export type PluginDetailAction =
   | { type: "MOVE_SCOPE_UP"; maxIndex: number }
   | { type: "MOVE_SCOPE_DOWN"; maxIndex: number }
   | { type: "MOVE_ACTION_UP"; maxIndex: number }
-  | { type: "MOVE_ACTION_DOWN"; maxIndex: number };
+  | { type: "MOVE_ACTION_DOWN"; maxIndex: number }
+  | { type: "HANDLE_KEY"; key: Key; maxIndex: number }
+  | { type: "CLEAR_DECISION" };
 
 export function pluginDetailReducer(
   state: PluginDetailState,
@@ -52,6 +57,42 @@ export function pluginDetailReducer(
             ? state.selectedActionIndex + 1
             : 0,
       };
+    case "HANDLE_KEY":
+      if (action.key.upArrow) {
+        return {
+          ...state,
+          selectedScopeIndex:
+            state.selectedScopeIndex > 0
+              ? state.selectedScopeIndex - 1
+              : action.maxIndex,
+          selectedActionIndex:
+            state.selectedActionIndex > 0
+              ? state.selectedActionIndex - 1
+              : action.maxIndex,
+        };
+      }
+      if (action.key.downArrow) {
+        return {
+          ...state,
+          selectedScopeIndex:
+            state.selectedScopeIndex < action.maxIndex
+              ? state.selectedScopeIndex + 1
+              : 0,
+          selectedActionIndex:
+            state.selectedActionIndex < action.maxIndex
+              ? state.selectedActionIndex + 1
+              : 0,
+        };
+      }
+      if (action.key.return) {
+        return { ...state, pendingDecision: "select" };
+      }
+      if (action.key.escape) {
+        return { ...state, pendingDecision: "cancel" };
+      }
+      return state;
+    case "CLEAR_DECISION":
+      return { ...state, pendingDecision: null };
     default:
       return state;
   }

--- a/packages/code/src/reducers/questionReducer.ts
+++ b/packages/code/src/reducers/questionReducer.ts
@@ -1,3 +1,4 @@
+import { Key } from "ink";
 import type { PermissionDecision } from "wave-agent-sdk";
 
 export interface QuestionSavedState {
@@ -40,6 +41,22 @@ export type QuestionAction =
       };
       options: Array<{ label: string }>;
       isMultiSelect: boolean;
+      questions: Array<{
+        question: string;
+        options: Array<{ label: string }>;
+        multiSelect?: boolean;
+      }>;
+    }
+  | { type: "CLEAR_DECISION" }
+  | {
+      type: "HANDLE_KEY";
+      input: string;
+      key: Key;
+      currentQuestion: {
+        question: string;
+        options: Array<{ label: string }>;
+        multiSelect?: boolean;
+      };
       questions: Array<{
         question: string;
         options: Array<{ label: string }>;
@@ -244,6 +261,193 @@ export function questionReducer(
           },
         };
       }
+    }
+    case "CLEAR_DECISION":
+      return { ...state, decision: null };
+    case "HANDLE_KEY": {
+      const { input, key, currentQuestion, questions } = action;
+      if (!currentQuestion) return state;
+
+      const options = [...currentQuestion.options, { label: "Other" }];
+      const isMultiSelect = currentQuestion.multiSelect;
+
+      if (key.return) {
+        const isOtherFocused = state.selectedOptionIndex === options.length - 1;
+        let answer = "";
+        if (isMultiSelect) {
+          const selectedLabels = Array.from(state.selectedOptionIndices)
+            .filter((i) => i < currentQuestion.options.length)
+            .map((i) => currentQuestion.options[i].label);
+          const isOtherChecked = state.selectedOptionIndices.has(
+            options.length - 1,
+          );
+          if (isOtherChecked && state.otherText.trim()) {
+            selectedLabels.push(state.otherText.trim());
+          }
+          answer = selectedLabels.join(", ");
+        } else {
+          if (isOtherFocused) {
+            answer = state.otherText.trim();
+          } else {
+            answer = options[state.selectedOptionIndex].label;
+          }
+        }
+        if (!answer) return state;
+
+        const newAnswers = {
+          ...state.userAnswers,
+          [currentQuestion.question]: answer,
+        };
+
+        if (state.currentQuestionIndex < questions.length - 1) {
+          const nextIndex = state.currentQuestionIndex + 1;
+          const savedStates = {
+            ...state.savedStates,
+            [state.currentQuestionIndex]: {
+              selectedOptionIndex: state.selectedOptionIndex,
+              selectedOptionIndices: state.selectedOptionIndices,
+              otherText: state.otherText,
+              otherCursorPosition: state.otherCursorPosition,
+            },
+          };
+          const nextState = savedStates[nextIndex] || {
+            selectedOptionIndex: 0,
+            selectedOptionIndices: new Set<number>(),
+            otherText: "",
+            otherCursorPosition: 0,
+          };
+          return {
+            ...state,
+            currentQuestionIndex: nextIndex,
+            ...nextState,
+            userAnswers: newAnswers,
+            savedStates,
+          };
+        } else {
+          const finalAnswers = { ...newAnswers };
+          for (const [idxStr, s] of Object.entries(state.savedStates)) {
+            const idx = parseInt(idxStr);
+            const q = questions[idx];
+            if (q && !finalAnswers[q.question]) {
+              const a = buildAnswerFromSavedState(q, s);
+              if (a) finalAnswers[q.question] = a;
+            }
+          }
+          const allAnswered = questions.every((q) => finalAnswers[q.question]);
+          if (!allAnswered) return state;
+          return {
+            ...state,
+            userAnswers: finalAnswers,
+            decision: {
+              behavior: "allow",
+              message: JSON.stringify(finalAnswers),
+            },
+          };
+        }
+      }
+
+      if (input === " ") {
+        const isOtherFocused = state.selectedOptionIndex === options.length - 1;
+        if (
+          isMultiSelect &&
+          (!isOtherFocused ||
+            !state.selectedOptionIndices.has(state.selectedOptionIndex))
+        ) {
+          const nextIndices = new Set(state.selectedOptionIndices);
+          if (nextIndices.has(state.selectedOptionIndex))
+            nextIndices.delete(state.selectedOptionIndex);
+          else nextIndices.add(state.selectedOptionIndex);
+          return { ...state, selectedOptionIndices: nextIndices };
+        }
+      }
+
+      if (key.upArrow) {
+        return {
+          ...state,
+          selectedOptionIndex: Math.max(0, state.selectedOptionIndex - 1),
+        };
+      }
+      if (key.downArrow) {
+        return {
+          ...state,
+          selectedOptionIndex: Math.min(
+            options.length - 1,
+            state.selectedOptionIndex + 1,
+          ),
+        };
+      }
+
+      if (key.tab) {
+        const direction = key.shift ? -1 : 1;
+        let nextIndex = state.currentQuestionIndex + direction;
+        if (nextIndex < 0) nextIndex = questions.length - 1;
+        if (nextIndex >= questions.length) nextIndex = 0;
+        if (nextIndex === state.currentQuestionIndex) return state;
+        const savedStates = {
+          ...state.savedStates,
+          [state.currentQuestionIndex]: {
+            selectedOptionIndex: state.selectedOptionIndex,
+            selectedOptionIndices: state.selectedOptionIndices,
+            otherText: state.otherText,
+            otherCursorPosition: state.otherCursorPosition,
+          },
+        };
+        const nextState = savedStates[nextIndex] || {
+          selectedOptionIndex: 0,
+          selectedOptionIndices: new Set<number>(),
+          otherText: "",
+          otherCursorPosition: 0,
+        };
+        return {
+          ...state,
+          currentQuestionIndex: nextIndex,
+          ...nextState,
+          savedStates,
+        };
+      }
+
+      if (state.selectedOptionIndex === options.length - 1) {
+        if (key.leftArrow) {
+          return {
+            ...state,
+            otherCursorPosition: Math.max(0, state.otherCursorPosition - 1),
+          };
+        }
+        if (key.rightArrow) {
+          return {
+            ...state,
+            otherCursorPosition: Math.min(
+              state.otherText.length,
+              state.otherCursorPosition + 1,
+            ),
+          };
+        }
+        if (key.backspace || key.delete) {
+          if (state.otherCursorPosition > 0) {
+            return {
+              ...state,
+              otherText:
+                state.otherText.slice(0, state.otherCursorPosition - 1) +
+                state.otherText.slice(state.otherCursorPosition),
+              otherCursorPosition: state.otherCursorPosition - 1,
+            };
+          }
+          return state;
+        }
+        if (input && !key.ctrl && !key.meta) {
+          const newText =
+            state.otherText.slice(0, state.otherCursorPosition) +
+            input +
+            state.otherText.slice(state.otherCursorPosition);
+          return {
+            ...state,
+            otherText: newText,
+            otherCursorPosition: state.otherCursorPosition + input.length,
+          };
+        }
+      }
+
+      return state;
     }
     default:
       return state;

--- a/packages/code/src/reducers/rewindSelectorReducer.ts
+++ b/packages/code/src/reducers/rewindSelectorReducer.ts
@@ -1,0 +1,54 @@
+import { Key } from "ink";
+
+export interface SelectorState {
+  selectedIndex: number;
+  pendingDecision: "select" | "cancel" | null;
+}
+
+export type SelectorAction =
+  | { type: "MOVE_UP" }
+  | { type: "MOVE_DOWN"; maxIndex: number }
+  | { type: "RESET_INDEX"; index: number }
+  | { type: "HANDLE_KEY"; key: Key; maxIndex: number }
+  | { type: "CLEAR_DECISION" };
+
+export function rewindSelectorReducer(
+  state: SelectorState,
+  action: SelectorAction,
+): SelectorState {
+  switch (action.type) {
+    case "MOVE_UP":
+      return { ...state, selectedIndex: Math.max(0, state.selectedIndex - 1) };
+    case "MOVE_DOWN":
+      return {
+        ...state,
+        selectedIndex: Math.min(action.maxIndex, state.selectedIndex + 1),
+      };
+    case "RESET_INDEX":
+      return { ...state, selectedIndex: action.index };
+    case "HANDLE_KEY":
+      if (action.key.upArrow) {
+        return {
+          ...state,
+          selectedIndex: Math.max(0, state.selectedIndex - 1),
+        };
+      }
+      if (action.key.downArrow) {
+        return {
+          ...state,
+          selectedIndex: Math.min(action.maxIndex, state.selectedIndex + 1),
+        };
+      }
+      if (action.key.return) {
+        return { ...state, pendingDecision: "select" };
+      }
+      if (action.key.escape) {
+        return { ...state, pendingDecision: "cancel" };
+      }
+      return state;
+    case "CLEAR_DECISION":
+      return { ...state, pendingDecision: null };
+    default:
+      return state;
+  }
+}

--- a/packages/code/src/reducers/selectorReducer.ts
+++ b/packages/code/src/reducers/selectorReducer.ts
@@ -1,0 +1,57 @@
+import { Key } from "ink";
+
+export interface SelectorState {
+  selectedIndex: number;
+  pendingDecision: "select" | "insert" | "cancel" | null;
+}
+
+export type SelectorAction =
+  | { type: "MOVE_UP" }
+  | { type: "MOVE_DOWN"; maxIndex: number }
+  | { type: "RESET_INDEX" }
+  | { type: "HANDLE_KEY"; key: Key; maxIndex: number; hasInsert: boolean }
+  | { type: "CLEAR_DECISION" };
+
+export function selectorReducer(
+  state: SelectorState,
+  action: SelectorAction,
+): SelectorState {
+  switch (action.type) {
+    case "MOVE_UP":
+      return { ...state, selectedIndex: Math.max(0, state.selectedIndex - 1) };
+    case "MOVE_DOWN":
+      return {
+        ...state,
+        selectedIndex: Math.min(action.maxIndex, state.selectedIndex + 1),
+      };
+    case "RESET_INDEX":
+      return { ...state, selectedIndex: 0 };
+    case "HANDLE_KEY":
+      if (action.key.upArrow) {
+        return {
+          ...state,
+          selectedIndex: Math.max(0, state.selectedIndex - 1),
+        };
+      }
+      if (action.key.downArrow) {
+        return {
+          ...state,
+          selectedIndex: Math.min(action.maxIndex, state.selectedIndex + 1),
+        };
+      }
+      if (action.key.return) {
+        return { ...state, pendingDecision: "select" };
+      }
+      if (action.key.tab && action.hasInsert) {
+        return { ...state, pendingDecision: "insert" };
+      }
+      if (action.key.escape) {
+        return { ...state, pendingDecision: "cancel" };
+      }
+      return state;
+    case "CLEAR_DECISION":
+      return { ...state, pendingDecision: null };
+    default:
+      return state;
+  }
+}

--- a/packages/code/src/utils/inputUtils.ts
+++ b/packages/code/src/utils/inputUtils.ts
@@ -1,0 +1,94 @@
+export const expandLongTextPlaceholders = (
+  text: string,
+  longTextMap: Record<string, string>,
+): string => {
+  let expandedText = text;
+  const longTextRegex = /\[LongText#(\d+)\]/g;
+  const matches = [...text.matchAll(longTextRegex)];
+
+  for (const match of matches) {
+    const placeholder = match[0];
+    const originalText = longTextMap[placeholder];
+    if (originalText) {
+      expandedText = expandedText.replace(placeholder, originalText);
+    }
+  }
+
+  return expandedText;
+};
+
+export const getAtSelectorPosition = (
+  text: string,
+  cursorPosition: number,
+): number => {
+  let i = cursorPosition - 1;
+  while (i >= 0 && !/\s/.test(text[i])) {
+    if (text[i] === "@") {
+      if (i === 0 || /\s/.test(text[i - 1])) {
+        return i;
+      }
+      break;
+    }
+    i--;
+  }
+  return -1;
+};
+
+export const getSlashSelectorPosition = (
+  text: string,
+  cursorPosition: number,
+): number => {
+  let i = cursorPosition - 1;
+  while (i >= 0 && !/\s/.test(text[i])) {
+    if (text[i] === "/") {
+      if (i === 0 || /\s/.test(text[i - 1])) {
+        return i;
+      }
+      break;
+    }
+    i--;
+  }
+  return -1;
+};
+
+export const getWordEnd = (text: string, startPos: number): number => {
+  let i = startPos;
+  while (i < text.length && !/\s/.test(text[i])) {
+    i++;
+  }
+  return i;
+};
+
+export const SELECTOR_TRIGGERS = [
+  {
+    char: "@",
+    type: "ACTIVATE_FILE_SELECTOR" as const,
+    shouldActivate: (char: string, pos: number, text: string) =>
+      char === "@" && (pos === 1 || /\s/.test(text[pos - 2])),
+  },
+  {
+    char: "/",
+    type: "ACTIVATE_COMMAND_SELECTOR" as const,
+    shouldActivate: (
+      char: string,
+      pos: number,
+      text: string,
+      showFileSelector: boolean,
+    ) =>
+      char === "/" &&
+      !showFileSelector &&
+      (pos === 1 || /\s/.test(text[pos - 2])),
+  },
+] as const;
+
+export const getProjectedState = (
+  inputText: string,
+  cursorPosition: number,
+  char: string,
+) => {
+  const beforeCursor = inputText.substring(0, cursorPosition);
+  const afterCursor = inputText.substring(cursorPosition);
+  const newInputText = beforeCursor + char + afterCursor;
+  const newCursorPosition = cursorPosition + char.length;
+  return { newInputText, newCursorPosition };
+};

--- a/packages/code/tests/components/BackgroundTaskManager.test.tsx
+++ b/packages/code/tests/components/BackgroundTaskManager.test.tsx
@@ -1,6 +1,13 @@
 import React from "react";
-import { render } from "ink-testing-library";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render as originalRender } from "ink-testing-library";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+let unmounts: Array<() => void> = [];
+const render = (tree: React.ReactElement) => {
+  const result = originalRender(tree);
+  unmounts.push(result.unmount);
+  return result;
+};
 import { BackgroundTaskManager } from "../../src/components/BackgroundTaskManager.js";
 import { ChatProvider } from "../../src/contexts/useChat.js";
 import { AppProvider } from "../../src/contexts/useAppConfig.js";
@@ -137,6 +144,11 @@ describe("BackgroundTaskManager", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(Agent.create).mockResolvedValue(mockAgent as unknown as Agent);
+  });
+
+  afterEach(() => {
+    unmounts.forEach((u) => u());
+    unmounts = [];
   });
 
   it("should render the list of background tasks", async () => {

--- a/packages/code/tests/components/ChatInterface.rewind.test.tsx
+++ b/packages/code/tests/components/ChatInterface.rewind.test.tsx
@@ -99,8 +99,8 @@ describe("ChatInterface Rewind Visibility", () => {
     // Arrow keys should not affect inputbox (handleInput should not be called)
     mockHandleInput.mockClear();
     stdin.write("\u001B[A"); // Up arrow
-    // Verify that handleInput is called
-    expect(mockHandleInput).toHaveBeenCalled();
+    // Verify that handleInput is NOT called
+    expect(mockHandleInput).not.toHaveBeenCalled();
   });
 
   it("should show InputBox when showRewindManager is false", async () => {

--- a/packages/code/tests/components/Confirmation.test.tsx
+++ b/packages/code/tests/components/Confirmation.test.tsx
@@ -869,6 +869,7 @@ describe("Confirmation", () => {
           "> Yes, and auto-accept edits",
         );
       });
+
       stdin.write("\u001b[B"); // Go to alternative
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
@@ -876,7 +877,7 @@ describe("Confirmation", () => {
         );
       });
 
-      stdin.write("\u007f"); // Backspace on empty text
+      stdin.write("\x7f"); // Backspace on empty text
 
       // Should still show placeholder and remain on alternative
       await vi.waitFor(() => {
@@ -884,10 +885,6 @@ describe("Confirmation", () => {
           "> Type here to tell Wave what to change",
         );
       });
-
-      const frame = lastFrame();
-      expect(frame).toContain("> Type here to tell Wave what to change");
-      expect(frame).toContain("Type here to tell Wave what to change");
     });
 
     it("should handle whitespace-only alternative text", async () => {

--- a/packages/code/tests/components/ConfirmationTab.test.tsx
+++ b/packages/code/tests/components/ConfirmationTab.test.tsx
@@ -8,7 +8,19 @@ import {
   afterEach,
   type Mock,
 } from "vitest";
-import { render } from "ink-testing-library";
+import { render as originalRender } from "ink-testing-library";
+
+let unmounts: Array<() => void> = [];
+const render = (tree: React.ReactElement) => {
+  const result = originalRender(tree);
+  unmounts.push(result.unmount);
+  return result;
+};
+
+afterEach(() => {
+  unmounts.forEach((u) => u());
+  unmounts = [];
+});
 import { ConfirmationSelector } from "../../src/components/ConfirmationSelector.js";
 import { stripAnsiColors } from "wave-agent-sdk";
 import type { PermissionDecision } from "wave-agent-sdk";

--- a/packages/code/tests/components/FileSelector.test.tsx
+++ b/packages/code/tests/components/FileSelector.test.tsx
@@ -1,9 +1,12 @@
 import React from "react";
-import { render } from "ink-testing-library";
-import { describe, it, expect, vi } from "vitest";
+import { render, cleanup } from "ink-testing-library";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { FileSelector, FileItem } from "../../src/components/FileSelector.js";
 
 describe("FileSelector", () => {
+  afterEach(() => {
+    cleanup();
+  });
   const mockFiles: FileItem[] = Array.from({ length: 20 }, (_, i) => ({
     path: `file${i + 1}.txt`,
     type: "file",
@@ -113,7 +116,7 @@ describe("FileSelector", () => {
   });
 
   describe("Tab key functionality", () => {
-    it("should trigger onSelect with correct file path when Tab is pressed", () => {
+    it("should trigger onSelect with correct file path when Tab is pressed", async () => {
       const onSelectMock = vi.fn();
       const testProps = { ...mockProps, onSelect: onSelectMock };
       const { stdin } = render(<FileSelector {...testProps} />);
@@ -121,8 +124,10 @@ describe("FileSelector", () => {
       // Press Tab key (should select first file by default)
       stdin.write("\t");
 
-      expect(onSelectMock).toHaveBeenCalledWith("file1.txt");
-      expect(onSelectMock).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => {
+        expect(onSelectMock).toHaveBeenCalledWith("file1.txt");
+        expect(onSelectMock).toHaveBeenCalledTimes(1);
+      });
     });
 
     it("should not call onSelect when Tab is pressed with empty files list", () => {
@@ -141,7 +146,7 @@ describe("FileSelector", () => {
       expect(onSelectMock).not.toHaveBeenCalled();
     });
 
-    it("should work the same way as Enter key - both keys should trigger onSelect", () => {
+    it("should work the same way as Enter key - both keys should trigger onSelect", async () => {
       const onSelectMockTab = vi.fn();
       const onSelectMockEnter = vi.fn();
 
@@ -156,13 +161,15 @@ describe("FileSelector", () => {
       stdinEnter.write("\r");
 
       // Both should call onSelect with the same file (first file by default)
-      expect(onSelectMockTab).toHaveBeenCalledWith("file1.txt");
-      expect(onSelectMockEnter).toHaveBeenCalledWith("file1.txt");
-      expect(onSelectMockTab).toHaveBeenCalledTimes(1);
-      expect(onSelectMockEnter).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => {
+        expect(onSelectMockTab).toHaveBeenCalledWith("file1.txt");
+        expect(onSelectMockEnter).toHaveBeenCalledWith("file1.txt");
+        expect(onSelectMockTab).toHaveBeenCalledTimes(1);
+        expect(onSelectMockEnter).toHaveBeenCalledTimes(1);
+      });
     });
 
-    it("should trigger onSelect with correct file path when Tab is pressed with different files", () => {
+    it("should trigger onSelect with correct file path when Tab is pressed with different files", async () => {
       // Test with a smaller, different set of files to ensure Tab works correctly
       const testFiles: FileItem[] = [
         { path: "README.md", type: "file" },
@@ -181,11 +188,13 @@ describe("FileSelector", () => {
       // Press Tab key (should select first file by default)
       stdin.write("\t");
 
-      expect(onSelectMock).toHaveBeenCalledWith("README.md");
-      expect(onSelectMock).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => {
+        expect(onSelectMock).toHaveBeenCalledWith("README.md");
+        expect(onSelectMock).toHaveBeenCalledTimes(1);
+      });
     });
 
-    it("should handle Tab key with single file", () => {
+    it("should handle Tab key with single file", async () => {
       const singleFile: FileItem[] = [
         { path: "single-file.txt", type: "file" },
       ];
@@ -201,11 +210,13 @@ describe("FileSelector", () => {
       // Press Tab key
       stdin.write("\t");
 
-      expect(onSelectMock).toHaveBeenCalledWith("single-file.txt");
-      expect(onSelectMock).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => {
+        expect(onSelectMock).toHaveBeenCalledWith("single-file.txt");
+        expect(onSelectMock).toHaveBeenCalledTimes(1);
+      });
     });
 
-    it("should handle Tab key correctly with directory files", () => {
+    it("should handle Tab key correctly with directory files", async () => {
       const mixedFiles: FileItem[] = [
         { path: "src/", type: "directory" },
         { path: "components/", type: "directory" },
@@ -223,8 +234,10 @@ describe("FileSelector", () => {
       // Press Tab key (should select first item - directory)
       stdin.write("\t");
 
-      expect(onSelectMock).toHaveBeenCalledWith("src/");
-      expect(onSelectMock).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => {
+        expect(onSelectMock).toHaveBeenCalledWith("src/");
+        expect(onSelectMock).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/packages/code/tests/components/InputBox.test.tsx
+++ b/packages/code/tests/components/InputBox.test.tsx
@@ -297,10 +297,14 @@ describe("InputBox Smoke Tests", () => {
       );
 
       // Cancel rewind
+      await new Promise((resolve) => setTimeout(resolve, 100));
       stdin.write("\u001b"); // Escape
-      await vi.waitFor(() => {
-        expect(lastFrame()).toContain("Type your message");
-      });
+      await vi.waitFor(
+        () => {
+          expect(lastFrame()).toContain("Type your message");
+        },
+        { timeout: 3000 },
+      );
     });
 
     it("should cycle permission mode on Shift+Tab", async () => {
@@ -348,10 +352,14 @@ describe("InputBox Smoke Tests", () => {
       );
 
       // Close help
+      await new Promise((resolve) => setTimeout(resolve, 100));
       stdin.write("\u001b"); // Escape
-      await vi.waitFor(() => {
-        expect(lastFrame()).toContain("Type your message");
-      });
+      await vi.waitFor(
+        () => {
+          expect(lastFrame()).toContain("Type your message");
+        },
+        { timeout: 3000 },
+      );
     });
   });
 });

--- a/packages/code/tests/components/InputBox.test.tsx
+++ b/packages/code/tests/components/InputBox.test.tsx
@@ -1,6 +1,26 @@
 import React from "react";
-import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
-import { render } from "ink-testing-library";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from "vitest";
+import { render as originalRender } from "ink-testing-library";
+
+let unmounts: Array<() => void> = [];
+const render = (tree: React.ReactElement) => {
+  const result = originalRender(tree);
+  unmounts.push(result.unmount);
+  return result;
+};
+
+afterEach(() => {
+  unmounts.forEach((u) => u());
+  unmounts = [];
+});
 import { InputBox } from "../../src/components/InputBox.js";
 import { stripAnsiColors } from "wave-agent-sdk";
 import type { SlashCommand } from "wave-agent-sdk";

--- a/packages/code/tests/components/MarketplaceDetail.test.tsx
+++ b/packages/code/tests/components/MarketplaceDetail.test.tsx
@@ -72,14 +72,16 @@ describe("MarketplaceDetail", () => {
     expect(lastFrame()).toContain("Marketplace not found.");
   });
 
-  it("should call setView('MARKETPLACES') when Escape is pressed", () => {
+  it("should call setView('MARKETPLACES') when Escape is pressed", async () => {
     const { stdin } = render(
       <PluginManagerContext.Provider value={mockContext}>
         <MarketplaceDetail />
       </PluginManagerContext.Provider>,
     );
     stdin.write("\u001B"); // Escape
-    expect(mockActions.setView).toHaveBeenCalledWith("MARKETPLACES");
+    await vi.waitFor(() => {
+      expect(mockActions.setView).toHaveBeenCalledWith("MARKETPLACES");
+    });
   });
 
   it("should navigate actions with up/down arrows", async () => {

--- a/packages/code/tests/components/ModelSelector.test.tsx
+++ b/packages/code/tests/components/ModelSelector.test.tsx
@@ -30,17 +30,21 @@ describe("ModelSelector", () => {
     expect(lastFrame()).toContain("No models configured");
   });
 
-  it("should call onCancel when Escape is pressed", () => {
+  it("should call onCancel when Escape is pressed", async () => {
     const { stdin } = render(<ModelSelector {...defaultProps} />);
     stdin.write("\u001B"); // Escape
-    expect(defaultProps.onCancel).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(defaultProps.onCancel).toHaveBeenCalled();
+    });
   });
 
-  it("should call onSelectModel and onCancel when Enter is pressed", () => {
+  it("should call onSelectModel and onCancel when Enter is pressed", async () => {
     const { stdin } = render(<ModelSelector {...defaultProps} />);
     stdin.write("\r"); // Enter
-    expect(defaultProps.onSelectModel).toHaveBeenCalledWith("model-a");
-    expect(defaultProps.onCancel).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(defaultProps.onSelectModel).toHaveBeenCalledWith("model-a");
+      expect(defaultProps.onCancel).toHaveBeenCalled();
+    });
   });
 
   it("should navigate with arrow keys", async () => {

--- a/packages/code/tests/components/SessionSelector.test.tsx
+++ b/packages/code/tests/components/SessionSelector.test.tsx
@@ -71,24 +71,28 @@ describe("SessionSelector", () => {
     });
   });
 
-  it("should call onSelect when Enter is pressed", () => {
+  it("should call onSelect when Enter is pressed", async () => {
     const onSelect = vi.fn();
     const { stdin } = render(
       <SessionSelector {...mockProps} onSelect={onSelect} />,
     );
 
     stdin.write("\r"); // Enter
-    expect(onSelect).toHaveBeenCalledWith("session-1");
+    await vi.waitFor(() => {
+      expect(onSelect).toHaveBeenCalledWith("session-1");
+    });
   });
 
-  it("should call onCancel when Escape is pressed", () => {
+  it("should call onCancel when Escape is pressed", async () => {
     const onCancel = vi.fn();
     const { stdin } = render(
       <SessionSelector {...mockProps} onCancel={onCancel} />,
     );
 
     stdin.write("\u001B"); // Escape
-    expect(onCancel).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(onCancel).toHaveBeenCalled();
+    });
   });
 
   it("should handle pagination when many sessions exist", () => {

--- a/packages/code/tests/integration/plugin-manager.test.tsx
+++ b/packages/code/tests/integration/plugin-manager.test.tsx
@@ -75,7 +75,9 @@ describe("PluginManager Integration", () => {
 
     // Press Enter to go to detail
     stdin.write("\r");
-    expect(setView).toHaveBeenCalledWith("PLUGIN_DETAIL");
+    await vi.waitFor(() => {
+      expect(setView).toHaveBeenCalledWith("PLUGIN_DETAIL");
+    });
 
     // Rerender with new state (simulating state change in hook)
     rerender(<PluginManagerShell />);
@@ -86,11 +88,13 @@ describe("PluginManager Integration", () => {
 
     // Press Enter to install (default scope)
     stdin.write("\r");
-    expect(mockActions.installPlugin).toHaveBeenCalledWith(
-      "test-plugin",
-      "official",
-      "project",
-    );
+    await vi.waitFor(() => {
+      expect(mockActions.installPlugin).toHaveBeenCalledWith(
+        "test-plugin",
+        "official",
+        "project",
+      );
+    });
   });
 
   it("manages installed plugins", async () => {
@@ -129,7 +133,9 @@ describe("PluginManager Integration", () => {
 
     // Press Enter to go to detail
     stdin.write("\r");
-    expect(setView).toHaveBeenCalledWith("PLUGIN_DETAIL");
+    await vi.waitFor(() => {
+      expect(setView).toHaveBeenCalledWith("PLUGIN_DETAIL");
+    });
 
     // Rerender with new state
     rerender(<PluginManagerShell />);

--- a/packages/code/tests/managers/inputReducer.test.ts
+++ b/packages/code/tests/managers/inputReducer.test.ts
@@ -46,6 +46,7 @@ describe("inputReducer", () => {
         question: "",
         isLoading: false,
       },
+      pendingEffect: null,
     });
   });
 

--- a/packages/code/tests/managers/inputReducer.test.ts
+++ b/packages/code/tests/managers/inputReducer.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { Key } from "ink";
 import {
   inputReducer,
   initialState,
@@ -778,6 +779,493 @@ describe("inputReducer", () => {
       });
       expect(newState.inputText).toBe("first");
       expect(newState.originalInputText).toBe("hi there");
+    });
+  });
+
+  describe("selectors", () => {
+    it("should handle SELECT_COMMAND", () => {
+      const state: InputState = {
+        ...initialState,
+        inputText: "run /cmd",
+        cursorPosition: 8,
+        showCommandSelector: true,
+        slashPosition: 4,
+      };
+      const result = inputReducer(state, {
+        type: "SELECT_COMMAND",
+        payload: "tasks",
+      });
+      expect(result.inputText).toBe("run ");
+      expect(result.cursorPosition).toBe(4);
+      expect(result.showCommandSelector).toBe(false);
+      expect(result.pendingEffect).toEqual({
+        type: "EXECUTE_COMMAND",
+        command: "tasks",
+      });
+    });
+
+    it("should handle INSERT_COMMAND", () => {
+      const state: InputState = {
+        ...initialState,
+        inputText: "run /cmd",
+        cursorPosition: 8,
+        showCommandSelector: true,
+        slashPosition: 4,
+      };
+      const result = inputReducer(state, {
+        type: "INSERT_COMMAND",
+        payload: "help",
+      });
+      expect(result.inputText).toBe("run /help ");
+      expect(result.cursorPosition).toBe(10);
+      expect(result.showCommandSelector).toBe(false);
+    });
+
+    it("should handle SELECT_FILE", () => {
+      const state: InputState = {
+        ...initialState,
+        inputText: "read @fi",
+        cursorPosition: 8,
+        showFileSelector: true,
+        atPosition: 5,
+      };
+      const result = inputReducer(state, {
+        type: "SELECT_FILE",
+        payload: "test.ts",
+      });
+      expect(result.inputText).toBe("read @test.ts ");
+      expect(result.cursorPosition).toBe(14);
+      expect(result.showFileSelector).toBe(false);
+    });
+  });
+
+  describe("HANDLE_KEY", () => {
+    const hasSlashCommand = (cmd: string) => cmd === "custom";
+
+    it("should handle return to send message", () => {
+      const state = { ...initialState, inputText: "hello" };
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { return: true } as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+      expect(result.inputText).toBe("");
+      expect(result.pendingEffect).toEqual({
+        type: "SEND_MESSAGE",
+        content: "hello",
+        images: undefined,
+        longTextMap: {},
+      });
+    });
+
+    it("should handle /btw command", () => {
+      const state = { ...initialState, inputText: "/btw what is life?" };
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { return: true } as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+      expect(result.btwState.isActive).toBe(true);
+      expect(result.btwState.question).toBe("what is life?");
+      expect(result.pendingEffect).toEqual({
+        type: "ASK_BTW",
+        question: "what is life?",
+      });
+    });
+
+    it("should handle escape to clear selectors", () => {
+      const state = { ...initialState, showFileSelector: true, atPosition: 5 };
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { escape: true } as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+      expect(result.showFileSelector).toBe(false);
+      expect(result.selectorJustUsed).toBe(true);
+    });
+
+    it("should handle escape to abort message if no selector", () => {
+      const result = inputReducer(initialState, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { escape: true } as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+      expect(result.pendingEffect).toEqual({ type: "ABORT_MESSAGE" });
+    });
+
+    it("should handle shift+tab to cycle permission mode", () => {
+      const result = inputReducer(initialState, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { tab: true, shift: true } as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+      expect(result.permissionMode).toBe("acceptEdits");
+      expect(result.pendingEffect).toEqual({
+        type: "PERMISSION_MODE_CHANGE",
+        mode: "acceptEdits",
+      });
+    });
+
+    it("should handle ctrl+v to paste image", () => {
+      const result = inputReducer(initialState, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "v",
+          key: { ctrl: true } as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+      expect(result.pendingEffect).toEqual({ type: "PASTE_IMAGE" });
+    });
+
+    it("should handle ctrl+r to search history", () => {
+      const result = inputReducer(initialState, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "r",
+          key: { ctrl: true } as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+      expect(result.showHistorySearch).toBe(true);
+    });
+
+    it("should handle ctrl+b to background task", () => {
+      const result = inputReducer(initialState, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "b",
+          key: { ctrl: true } as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+      expect(result.pendingEffect).toEqual({ type: "BACKGROUND_CURRENT_TASK" });
+    });
+
+    it("should handle regular character input and activate selectors", () => {
+      let state = inputReducer(initialState, {
+        type: "HANDLE_KEY",
+        payload: { input: "@", key: {} as unknown as Key, hasSlashCommand },
+      });
+      expect(state.inputText).toBe("@");
+      expect(state.showFileSelector).toBe(true);
+
+      state = inputReducer(initialState, {
+        type: "HANDLE_KEY",
+        payload: { input: "/", key: {} as unknown as Key, hasSlashCommand },
+      });
+      expect(state.inputText).toBe("/");
+      expect(state.showCommandSelector).toBe(true);
+    });
+
+    it("should handle backspace in normal mode", () => {
+      const state = { ...initialState, inputText: "abc", cursorPosition: 3 };
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { backspace: true } as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+      expect(result.inputText).toBe("ab");
+      expect(result.cursorPosition).toBe(2);
+    });
+
+    it("should handle arrow keys for cursor movement", () => {
+      const state = { ...initialState, inputText: "abc", cursorPosition: 1 };
+      let result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { leftArrow: true } as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+      expect(result.cursorPosition).toBe(0);
+      result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { rightArrow: true } as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+      expect(result.cursorPosition).toBe(2);
+    });
+
+    it("should handle backspace in history search", () => {
+      const state = {
+        ...initialState,
+        showHistorySearch: true,
+        historySearchQuery: "abc",
+      };
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { backspace: true } as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+      expect(result.historySearchQuery).toBe("ab");
+    });
+
+    it("should handle input in history search", () => {
+      const state = {
+        ...initialState,
+        showHistorySearch: true,
+        historySearchQuery: "ab",
+      };
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "c",
+          key: {} as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+      expect(result.historySearchQuery).toBe("abc");
+    });
+
+    it("should handle backspace in file selector", () => {
+      const state = {
+        ...initialState,
+        inputText: "@file",
+        cursorPosition: 5,
+        showFileSelector: true,
+        atPosition: 0,
+      };
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { backspace: true } as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+      expect(result.inputText).toBe("@fil");
+      expect(result.fileSearchQuery).toBe("fil");
+    });
+
+    it("should deactivate file selector if @ is deleted", () => {
+      const state = {
+        ...initialState,
+        inputText: "@",
+        cursorPosition: 1,
+        showFileSelector: true,
+        atPosition: 0,
+      };
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { backspace: true } as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+      expect(result.showFileSelector).toBe(false);
+      expect(result.atPosition).toBe(-1);
+    });
+
+    it("should handle arrow keys in file selector", () => {
+      const state = {
+        ...initialState,
+        inputText: "@file",
+        cursorPosition: 3,
+        showFileSelector: true,
+        atPosition: 0,
+      };
+      let result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { leftArrow: true } as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+      expect(result.cursorPosition).toBe(2);
+
+      result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { rightArrow: true } as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+      expect(result.cursorPosition).toBe(4);
+    });
+
+    it("should handle space in file selector to deactivate it", () => {
+      const state = {
+        ...initialState,
+        inputText: "@file",
+        cursorPosition: 5,
+        showFileSelector: true,
+        atPosition: 0,
+      };
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: " ",
+          key: {} as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+      expect(result.showFileSelector).toBe(false);
+      expect(result.inputText).toBe("@file ");
+    });
+
+    it("should handle return with images", () => {
+      const state = {
+        ...initialState,
+        inputText: "check this [Image #1]",
+        attachedImages: [{ id: 1, path: "test.png", mimeType: "image/png" }],
+      };
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { return: true } as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+      expect(result.pendingEffect).toEqual({
+        type: "SEND_MESSAGE",
+        content: "check this",
+        images: [{ path: "test.png", mimeType: "image/png" }],
+        longTextMap: {},
+      });
+    });
+
+    it("should handle paste operation in HANDLE_KEY", () => {
+      const result = inputReducer(initialState, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "pasted text",
+          key: {} as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+      expect(result.isPasting).toBe(true);
+      expect(result.pasteBuffer).toBe("pasted text");
+    });
+
+    it("should handle ！ character at start of input", () => {
+      const result = inputReducer(initialState, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "！",
+          key: {} as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+      expect(result.inputText).toBe("!");
+    });
+
+    it("should reactivate file selector on backspace", () => {
+      const state = { ...initialState, inputText: "@file ", cursorPosition: 6 };
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { backspace: true } as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+      expect(result.showFileSelector).toBe(true);
+      expect(result.atPosition).toBe(0);
+      expect(result.fileSearchQuery).toBe("file");
+    });
+
+    it("should reactivate command selector on backspace", () => {
+      const state = { ...initialState, inputText: "/cmd ", cursorPosition: 5 };
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { backspace: true } as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+      expect(result.showCommandSelector).toBe(true);
+      expect(result.slashPosition).toBe(0);
+      expect(result.commandSearchQuery).toBe("cmd");
+    });
+
+    it("should handle FETCH_HISTORY when history is empty and upArrow is pressed", () => {
+      const result = inputReducer(initialState, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { upArrow: true } as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+      expect(result.pendingEffect).toEqual({ type: "FETCH_HISTORY" });
+    });
+
+    it("should handle SET_BTW_STATE", () => {
+      const result = inputReducer(initialState, {
+        type: "SET_BTW_STATE",
+        payload: { isActive: true, question: "test?" },
+      });
+      expect(result.btwState.isActive).toBe(true);
+      expect(result.btwState.question).toBe("test?");
+    });
+
+    it("should handle escape in BTW mode", () => {
+      const state = {
+        ...initialState,
+        btwState: { isActive: true, question: "q", isLoading: false },
+      };
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { escape: true } as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+      expect(result.btwState.isActive).toBe(false);
+    });
+
+    it("should handle return in BTW mode", () => {
+      const state = {
+        ...initialState,
+        inputText: "my question",
+        btwState: { isActive: true, question: "", isLoading: false },
+      };
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { return: true } as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+      expect(result.btwState.question).toBe("my question");
+      expect(result.btwState.isLoading).toBe(true);
+      expect(result.pendingEffect).toEqual({
+        type: "ASK_BTW",
+        question: "my question",
+      });
     });
   });
 });

--- a/packages/code/tests/reducers/backgroundTaskManagerReducer.test.ts
+++ b/packages/code/tests/reducers/backgroundTaskManagerReducer.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import {
+  backgroundTaskManagerReducer,
+  BackgroundTaskManagerState,
+  Task,
+  BackgroundTaskManagerAction,
+} from "../../src/reducers/backgroundTaskManagerReducer.js";
+import { Key } from "ink";
+
+describe("backgroundTaskManagerReducer", () => {
+  const mockTasks: Task[] = [
+    { id: "1", type: "shell", status: "running", startTime: 1000 },
+    { id: "2", type: "shell", status: "completed", startTime: 2000 },
+  ];
+
+  const initialState: BackgroundTaskManagerState = {
+    tasks: [],
+    selectedIndex: 0,
+    viewMode: "list",
+    detailTaskId: null,
+    detailOutput: null,
+    pendingEffect: null,
+  };
+
+  it("should handle SET_TASKS", () => {
+    const result = backgroundTaskManagerReducer(initialState, {
+      type: "SET_TASKS",
+      tasks: mockTasks,
+    });
+    expect(result.tasks).toEqual(mockTasks);
+  });
+
+  it("should handle MOVE_UP", () => {
+    const state = { ...initialState, selectedIndex: 1 };
+    const result = backgroundTaskManagerReducer(state, { type: "MOVE_UP" });
+    expect(result.selectedIndex).toBe(0);
+  });
+
+  it("should handle MOVE_DOWN", () => {
+    const state = { ...initialState, tasks: mockTasks };
+    const result = backgroundTaskManagerReducer(state, { type: "MOVE_DOWN" });
+    expect(result.selectedIndex).toBe(1);
+  });
+
+  it("should handle SELECT_CURRENT", () => {
+    const state = { ...initialState, tasks: mockTasks };
+    const result = backgroundTaskManagerReducer(state, {
+      type: "SELECT_CURRENT",
+    });
+    expect(result.viewMode).toBe("detail");
+    expect(result.detailTaskId).toBe("1");
+  });
+
+  describe("HANDLE_KEY", () => {
+    it("should handle return in list mode", () => {
+      const state = { ...initialState, tasks: mockTasks };
+      const result = backgroundTaskManagerReducer(state, {
+        type: "HANDLE_KEY",
+        input: "",
+        key: { return: true } as unknown as Key,
+      });
+      expect(result.viewMode).toBe("detail");
+      expect(result.detailTaskId).toBe("1");
+    });
+
+    it("should handle escape in list mode", () => {
+      const result = backgroundTaskManagerReducer(initialState, {
+        type: "HANDLE_KEY",
+        input: "",
+        key: { escape: true } as unknown as Key,
+      });
+      expect(result.pendingEffect).toEqual({ type: "CANCEL" });
+    });
+
+    it("should handle 'k' in list mode", () => {
+      const state = { ...initialState, tasks: mockTasks };
+      const result = backgroundTaskManagerReducer(state, {
+        type: "HANDLE_KEY",
+        input: "k",
+        key: {} as unknown as Key,
+      });
+      expect(result.pendingEffect).toEqual({ type: "STOP_TASK", taskId: "1" });
+    });
+
+    it("should handle escape in detail mode", () => {
+      const state: BackgroundTaskManagerState = {
+        ...initialState,
+        viewMode: "detail",
+        detailTaskId: "1",
+      };
+      const result = backgroundTaskManagerReducer(state, {
+        type: "HANDLE_KEY",
+        input: "",
+        key: { escape: true } as unknown as Key,
+      });
+      expect(result.viewMode).toBe("list");
+      expect(result.detailTaskId).toBe(null);
+    });
+
+    it("should handle 'k' in detail mode", () => {
+      const state: BackgroundTaskManagerState = {
+        ...initialState,
+        viewMode: "detail",
+        detailTaskId: "1",
+        tasks: mockTasks,
+      };
+      const result = backgroundTaskManagerReducer(state, {
+        type: "HANDLE_KEY",
+        input: "k",
+        key: {} as unknown as Key,
+      });
+      expect(result.pendingEffect).toEqual({ type: "STOP_TASK", taskId: "1" });
+    });
+  });
+
+  it("should handle CLEAR_PENDING_EFFECT", () => {
+    const state: BackgroundTaskManagerState = {
+      ...initialState,
+      pendingEffect: { type: "CANCEL" },
+    };
+    const result = backgroundTaskManagerReducer(state, {
+      type: "CLEAR_PENDING_EFFECT",
+    });
+    expect(result.pendingEffect).toBe(null);
+  });
+
+  it("should return state for unknown action", () => {
+    const result = backgroundTaskManagerReducer(initialState, {
+      type: "UNKNOWN",
+    } as unknown as BackgroundTaskManagerAction);
+    expect(result).toBe(initialState);
+  });
+});

--- a/packages/code/tests/reducers/helpSelectorReducer.test.ts
+++ b/packages/code/tests/reducers/helpSelectorReducer.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import {
+  helpSelectorReducer,
+  type SelectorState,
+  type SelectorAction,
+} from "../../src/reducers/helpSelectorReducer.js";
+import { Key } from "ink";
+
+describe("helpSelectorReducer", () => {
+  const initialState: SelectorState = {
+    selectedIndex: 0,
+    activeTab: "general",
+    pendingDecision: null,
+  };
+
+  it("should handle MOVE_UP", () => {
+    const state = { ...initialState, selectedIndex: 2 };
+    const result = helpSelectorReducer(state, { type: "MOVE_UP" });
+    expect(result.selectedIndex).toBe(1);
+  });
+
+  it("should not MOVE_UP below 0", () => {
+    const result = helpSelectorReducer(initialState, { type: "MOVE_UP" });
+    expect(result.selectedIndex).toBe(0);
+  });
+
+  it("should handle MOVE_DOWN", () => {
+    const result = helpSelectorReducer(initialState, {
+      type: "MOVE_DOWN",
+      maxIndex: 5,
+    });
+    expect(result.selectedIndex).toBe(1);
+  });
+
+  it("should not MOVE_DOWN above maxIndex", () => {
+    const state = { ...initialState, selectedIndex: 5 };
+    const result = helpSelectorReducer(state, {
+      type: "MOVE_DOWN",
+      maxIndex: 5,
+    });
+    expect(result.selectedIndex).toBe(5);
+  });
+
+  it("should handle RESET_INDEX", () => {
+    const state = { ...initialState, selectedIndex: 3 };
+    const result = helpSelectorReducer(state, { type: "RESET_INDEX" });
+    expect(result.selectedIndex).toBe(0);
+  });
+
+  it("should handle SWITCH_TAB", () => {
+    const tabs = ["general", "commands", "custom-commands"];
+    const result = helpSelectorReducer(initialState, {
+      type: "SWITCH_TAB",
+      tabs,
+    });
+    expect(result.activeTab).toBe("commands");
+    expect(result.selectedIndex).toBe(0);
+  });
+
+  it("should handle HANDLE_KEY up/down", () => {
+    const upKey = { upArrow: true } as Key;
+    const downKey = { downArrow: true } as Key;
+
+    let result = helpSelectorReducer(initialState, {
+      type: "HANDLE_KEY",
+      key: downKey,
+      maxIndex: 2,
+      tabs: [],
+    });
+    expect(result.selectedIndex).toBe(1);
+
+    result = helpSelectorReducer(result, {
+      type: "HANDLE_KEY",
+      key: upKey,
+      maxIndex: 2,
+      tabs: [],
+    });
+    expect(result.selectedIndex).toBe(0);
+  });
+
+  it("should handle HANDLE_KEY tab (switch tab)", () => {
+    const tabKey = { tab: true } as Key;
+    const tabs = ["general", "commands"];
+    const result = helpSelectorReducer(initialState, {
+      type: "HANDLE_KEY",
+      key: tabKey,
+      maxIndex: 0,
+      tabs,
+    });
+    expect(result.activeTab).toBe("commands");
+  });
+
+  it("should handle HANDLE_KEY escape (cancel)", () => {
+    const escKey = { escape: true } as Key;
+    const result = helpSelectorReducer(initialState, {
+      type: "HANDLE_KEY",
+      key: escKey,
+      maxIndex: 0,
+      tabs: [],
+    });
+    expect(result.pendingDecision).toBe("cancel");
+  });
+
+  it("should handle CLEAR_DECISION", () => {
+    const state = { ...initialState, pendingDecision: "cancel" as const };
+    const result = helpSelectorReducer(state, { type: "CLEAR_DECISION" });
+    expect(result.pendingDecision).toBe(null);
+  });
+
+  it("should return state for unknown key", () => {
+    const otherKey = { return: true } as Key;
+    const result = helpSelectorReducer(initialState, {
+      type: "HANDLE_KEY",
+      key: otherKey,
+      maxIndex: 0,
+      tabs: [],
+    });
+    expect(result).toBe(initialState);
+  });
+
+  it("should return state for unknown action", () => {
+    const result = helpSelectorReducer(initialState, {
+      type: "UNKNOWN",
+    } as unknown as SelectorAction);
+    expect(result).toBe(initialState);
+  });
+});

--- a/packages/code/tests/reducers/mcpManagerReducer.test.ts
+++ b/packages/code/tests/reducers/mcpManagerReducer.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import {
+  mcpManagerReducer,
+  McpManagerState,
+  McpManagerAction,
+} from "../../src/reducers/mcpManagerReducer.js";
+import { Key } from "ink";
+
+describe("mcpManagerReducer", () => {
+  const initialState: McpManagerState = {
+    selectedIndex: 0,
+    viewMode: "list",
+    pendingEffect: null,
+  };
+
+  it("should handle MOVE_UP", () => {
+    const state: McpManagerState = { ...initialState, selectedIndex: 1 };
+    const result = mcpManagerReducer(state, {
+      type: "MOVE_UP",
+      serverCount: 2,
+    });
+    expect(result.selectedIndex).toBe(0);
+  });
+
+  it("should handle MOVE_DOWN", () => {
+    const result = mcpManagerReducer(initialState, {
+      type: "MOVE_DOWN",
+      serverCount: 2,
+    });
+    expect(result.selectedIndex).toBe(1);
+  });
+
+  it("should handle SET_VIEW_MODE", () => {
+    const result = mcpManagerReducer(initialState, {
+      type: "SET_VIEW_MODE",
+      viewMode: "detail",
+    });
+    expect(result.viewMode).toBe("detail");
+  });
+
+  describe("HANDLE_KEY", () => {
+    const servers = [
+      { name: "server1", status: "connected" },
+      { name: "server2", status: "disconnected" },
+    ];
+
+    it("should handle return in list mode", () => {
+      const result = mcpManagerReducer(initialState, {
+        type: "HANDLE_KEY",
+        input: "",
+        key: { return: true } as unknown as Key,
+        serverCount: 2,
+        servers,
+      });
+      expect(result.viewMode).toBe("detail");
+    });
+
+    it("should handle escape in list mode", () => {
+      const result = mcpManagerReducer(initialState, {
+        type: "HANDLE_KEY",
+        input: "",
+        key: { escape: true } as unknown as Key,
+        serverCount: 2,
+        servers,
+      });
+      expect(result.pendingEffect).toEqual({ type: "CANCEL" });
+    });
+
+    it("should handle escape in detail mode", () => {
+      const state: McpManagerState = { ...initialState, viewMode: "detail" };
+      const result = mcpManagerReducer(state, {
+        type: "HANDLE_KEY",
+        input: "",
+        key: { escape: true } as unknown as Key,
+        serverCount: 2,
+        servers,
+      });
+      expect(result.viewMode).toBe("list");
+    });
+
+    it("should handle upArrow", () => {
+      const state: McpManagerState = { ...initialState, selectedIndex: 1 };
+      const result = mcpManagerReducer(state, {
+        type: "HANDLE_KEY",
+        input: "",
+        key: { upArrow: true } as unknown as Key,
+        serverCount: 2,
+        servers,
+      });
+      expect(result.selectedIndex).toBe(0);
+    });
+
+    it("should handle downArrow", () => {
+      const result = mcpManagerReducer(initialState, {
+        type: "HANDLE_KEY",
+        input: "",
+        key: { downArrow: true } as unknown as Key,
+        serverCount: 2,
+        servers,
+      });
+      expect(result.selectedIndex).toBe(1);
+    });
+
+    it("should handle 'c' for connect", () => {
+      const state: McpManagerState = { ...initialState, selectedIndex: 1 }; // server2 is disconnected
+      const result = mcpManagerReducer(state, {
+        type: "HANDLE_KEY",
+        input: "c",
+        key: {} as unknown as Key,
+        serverCount: 2,
+        servers,
+      });
+      expect(result.pendingEffect).toEqual({
+        type: "CONNECT_SERVER",
+        serverName: "server2",
+      });
+    });
+
+    it("should handle 'd' for disconnect", () => {
+      const result = mcpManagerReducer(initialState, {
+        type: "HANDLE_KEY",
+        input: "d",
+        key: {} as unknown as Key,
+        serverCount: 2,
+        servers,
+      });
+      expect(result.pendingEffect).toEqual({
+        type: "DISCONNECT_SERVER",
+        serverName: "server1",
+      });
+    });
+  });
+
+  it("should handle CLEAR_PENDING_EFFECT", () => {
+    const state: McpManagerState = {
+      ...initialState,
+      pendingEffect: { type: "CANCEL" },
+    };
+    const result = mcpManagerReducer(state, { type: "CLEAR_PENDING_EFFECT" });
+    expect(result.pendingEffect).toBe(null);
+  });
+
+  it("should return state for unknown action", () => {
+    const result = mcpManagerReducer(initialState, {
+      type: "UNKNOWN",
+    } as unknown as McpManagerAction);
+    expect(result).toBe(initialState);
+  });
+});

--- a/packages/code/tests/reducers/pluginDetailReducer.test.ts
+++ b/packages/code/tests/reducers/pluginDetailReducer.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  pluginDetailReducer,
+  type PluginDetailState,
+  type PluginDetailAction,
+} from "../../src/reducers/pluginDetailReducer.js";
+import { Key } from "ink";
+
+describe("pluginDetailReducer", () => {
+  const initialState: PluginDetailState = {
+    selectedScopeIndex: 0,
+    selectedActionIndex: 0,
+    pendingDecision: null,
+  };
+
+  it("should handle MOVE_SCOPE_UP/DOWN", () => {
+    let result = pluginDetailReducer(initialState, {
+      type: "MOVE_SCOPE_DOWN",
+      maxIndex: 2,
+    });
+    expect(result.selectedScopeIndex).toBe(1);
+    result = pluginDetailReducer(result, {
+      type: "MOVE_SCOPE_UP",
+      maxIndex: 2,
+    });
+    expect(result.selectedScopeIndex).toBe(0);
+    // Wrap around
+    result = pluginDetailReducer(initialState, {
+      type: "MOVE_SCOPE_UP",
+      maxIndex: 2,
+    });
+    expect(result.selectedScopeIndex).toBe(2);
+    result = pluginDetailReducer(result, {
+      type: "MOVE_SCOPE_DOWN",
+      maxIndex: 2,
+    });
+    expect(result.selectedScopeIndex).toBe(0);
+  });
+
+  it("should handle MOVE_ACTION_UP/DOWN", () => {
+    let result = pluginDetailReducer(initialState, {
+      type: "MOVE_ACTION_DOWN",
+      maxIndex: 1,
+    });
+    expect(result.selectedActionIndex).toBe(1);
+    result = pluginDetailReducer(result, {
+      type: "MOVE_ACTION_UP",
+      maxIndex: 1,
+    });
+    expect(result.selectedActionIndex).toBe(0);
+    // Wrap around
+    result = pluginDetailReducer(initialState, {
+      type: "MOVE_ACTION_UP",
+      maxIndex: 1,
+    });
+    expect(result.selectedActionIndex).toBe(1);
+    result = pluginDetailReducer(result, {
+      type: "MOVE_ACTION_DOWN",
+      maxIndex: 1,
+    });
+    expect(result.selectedActionIndex).toBe(0);
+  });
+
+  it("should handle HANDLE_KEY up/down (syncs scope and action indices)", () => {
+    const downKey = { downArrow: true } as Key;
+    const upKey = { upArrow: true } as Key;
+
+    let result = pluginDetailReducer(initialState, {
+      type: "HANDLE_KEY",
+      key: downKey,
+      maxIndex: 2,
+    });
+    expect(result.selectedScopeIndex).toBe(1);
+    expect(result.selectedActionIndex).toBe(1);
+
+    result = pluginDetailReducer(result, {
+      type: "HANDLE_KEY",
+      key: upKey,
+      maxIndex: 2,
+    });
+    expect(result.selectedScopeIndex).toBe(0);
+    expect(result.selectedActionIndex).toBe(0);
+  });
+
+  it("should handle HANDLE_KEY return/escape", () => {
+    const returnKey = { return: true } as Key;
+    const escKey = { escape: true } as Key;
+
+    let result = pluginDetailReducer(initialState, {
+      type: "HANDLE_KEY",
+      key: returnKey,
+      maxIndex: 0,
+    });
+    expect(result.pendingDecision).toBe("select");
+
+    result = pluginDetailReducer(initialState, {
+      type: "HANDLE_KEY",
+      key: escKey,
+      maxIndex: 0,
+    });
+    expect(result.pendingDecision).toBe("cancel");
+  });
+
+  it("should handle SELECT_SCOPE_INDEX/SELECT_ACTION_INDEX", () => {
+    let result = pluginDetailReducer(initialState, {
+      type: "SELECT_SCOPE_INDEX",
+      index: 2,
+    });
+    expect(result.selectedScopeIndex).toBe(2);
+    result = pluginDetailReducer(initialState, {
+      type: "SELECT_ACTION_INDEX",
+      index: 1,
+    });
+    expect(result.selectedActionIndex).toBe(1);
+  });
+
+  it("should return state for unknown action", () => {
+    const result = pluginDetailReducer(initialState, {
+      type: "UNKNOWN",
+    } as unknown as PluginDetailAction);
+    expect(result).toBe(initialState);
+  });
+});

--- a/packages/code/tests/reducers/rewindSelectorReducer.test.ts
+++ b/packages/code/tests/reducers/rewindSelectorReducer.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  rewindSelectorReducer,
+  type SelectorState,
+  type SelectorAction,
+} from "../../src/reducers/rewindSelectorReducer.js";
+import { Key } from "ink";
+
+describe("rewindSelectorReducer", () => {
+  const initialState: SelectorState = {
+    selectedIndex: 0,
+    pendingDecision: null,
+  };
+
+  it("should handle HANDLE_KEY up/down", () => {
+    const upKey = { upArrow: true } as Key;
+    const downKey = { downArrow: true } as Key;
+
+    let result = rewindSelectorReducer(initialState, {
+      type: "HANDLE_KEY",
+      key: downKey,
+      maxIndex: 2,
+    });
+    expect(result.selectedIndex).toBe(1);
+
+    result = rewindSelectorReducer(result, {
+      type: "HANDLE_KEY",
+      key: upKey,
+      maxIndex: 2,
+    });
+    expect(result.selectedIndex).toBe(0);
+  });
+
+  it("should handle HANDLE_KEY return (select)", () => {
+    const returnKey = { return: true } as Key;
+    const result = rewindSelectorReducer(initialState, {
+      type: "HANDLE_KEY",
+      key: returnKey,
+      maxIndex: 0,
+    });
+    expect(result.pendingDecision).toBe("select");
+  });
+
+  it("should handle HANDLE_KEY escape (cancel)", () => {
+    const escKey = { escape: true } as Key;
+    const result = rewindSelectorReducer(initialState, {
+      type: "HANDLE_KEY",
+      key: escKey,
+      maxIndex: 0,
+    });
+    expect(result.pendingDecision).toBe("cancel");
+  });
+
+  it("should handle CLEAR_DECISION", () => {
+    const state = { ...initialState, pendingDecision: "select" as const };
+    const result = rewindSelectorReducer(state, { type: "CLEAR_DECISION" });
+    expect(result.pendingDecision).toBe(null);
+  });
+
+  it("should return current state if no key matches", () => {
+    const tabKey = { tab: true } as Key;
+    const result = rewindSelectorReducer(initialState, {
+      type: "HANDLE_KEY",
+      key: tabKey,
+      maxIndex: 10,
+    });
+    expect(result).toBe(initialState);
+  });
+
+  it("should return state for unknown action", () => {
+    const result = rewindSelectorReducer(initialState, {
+      type: "UNKNOWN",
+    } as unknown as SelectorAction);
+    expect(result).toBe(initialState);
+  });
+});

--- a/packages/code/tests/reducers/selectorReducer.test.ts
+++ b/packages/code/tests/reducers/selectorReducer.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import {
+  selectorReducer,
+  type SelectorState,
+  type SelectorAction,
+} from "../../src/reducers/selectorReducer.js";
+import { Key } from "ink";
+
+describe("selectorReducer", () => {
+  const initialState: SelectorState = {
+    selectedIndex: 0,
+    pendingDecision: null,
+  };
+
+  it("should handle HANDLE_KEY up/down", () => {
+    const upKey = { upArrow: true } as Key;
+    const downKey = { downArrow: true } as Key;
+
+    let result = selectorReducer(initialState, {
+      type: "HANDLE_KEY",
+      key: downKey,
+      maxIndex: 2,
+      hasInsert: false,
+    });
+    expect(result.selectedIndex).toBe(1);
+
+    result = selectorReducer(result, {
+      type: "HANDLE_KEY",
+      key: upKey,
+      maxIndex: 2,
+      hasInsert: false,
+    });
+    expect(result.selectedIndex).toBe(0);
+  });
+
+  it("should handle HANDLE_KEY return (select)", () => {
+    const returnKey = { return: true } as Key;
+    const result = selectorReducer(initialState, {
+      type: "HANDLE_KEY",
+      key: returnKey,
+      maxIndex: 0,
+      hasInsert: false,
+    });
+    expect(result.pendingDecision).toBe("select");
+  });
+
+  it("should handle HANDLE_KEY tab (insert) if hasInsert is true", () => {
+    const tabKey = { tab: true } as Key;
+    const result = selectorReducer(initialState, {
+      type: "HANDLE_KEY",
+      key: tabKey,
+      maxIndex: 0,
+      hasInsert: true,
+    });
+    expect(result.pendingDecision).toBe("insert");
+  });
+
+  it("should ignore HANDLE_KEY tab if hasInsert is false", () => {
+    const tabKey = { tab: true } as Key;
+    const result = selectorReducer(initialState, {
+      type: "HANDLE_KEY",
+      key: tabKey,
+      maxIndex: 0,
+      hasInsert: false,
+    });
+    expect(result.pendingDecision).toBe(null);
+  });
+
+  it("should handle HANDLE_KEY escape (cancel)", () => {
+    const escKey = { escape: true } as Key;
+    const result = selectorReducer(initialState, {
+      type: "HANDLE_KEY",
+      key: escKey,
+      maxIndex: 0,
+      hasInsert: false,
+    });
+    expect(result.pendingDecision).toBe("cancel");
+  });
+
+  it("should handle MOVE_UP/MOVE_DOWN actions", () => {
+    let result = selectorReducer(initialState, {
+      type: "MOVE_DOWN",
+      maxIndex: 5,
+    });
+    expect(result.selectedIndex).toBe(1);
+    result = selectorReducer(result, { type: "MOVE_UP" });
+    expect(result.selectedIndex).toBe(0);
+  });
+
+  it("should handle RESET_INDEX", () => {
+    const state = { ...initialState, selectedIndex: 5 };
+    const result = selectorReducer(state, { type: "RESET_INDEX" });
+    expect(result.selectedIndex).toBe(0);
+  });
+
+  it("should return state for unknown action", () => {
+    const result = selectorReducer(initialState, {
+      type: "UNKNOWN",
+    } as unknown as SelectorAction);
+    expect(result).toBe(initialState);
+  });
+});

--- a/packages/code/tests/utils/inputUtils.test.ts
+++ b/packages/code/tests/utils/inputUtils.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import {
+  expandLongTextPlaceholders,
+  getAtSelectorPosition,
+  getSlashSelectorPosition,
+  getWordEnd,
+  getProjectedState,
+  SELECTOR_TRIGGERS,
+} from "../../src/utils/inputUtils.js";
+
+describe("inputUtils", () => {
+  describe("expandLongTextPlaceholders", () => {
+    it("should expand placeholders correctly", () => {
+      const text = "Check this [LongText#1] and [LongText#2]";
+      const longTextMap = {
+        "[LongText#1]": "First long text content",
+        "[LongText#2]": "Second long text content",
+      };
+      const result = expandLongTextPlaceholders(text, longTextMap);
+      expect(result).toBe(
+        "Check this First long text content and Second long text content",
+      );
+    });
+
+    it("should return original text if no placeholders found", () => {
+      const text = "Normal text";
+      const result = expandLongTextPlaceholders(text, {});
+      expect(result).toBe("Normal text");
+    });
+
+    it("should return original text if placeholder mapping is missing", () => {
+      const text = "[LongText#99]";
+      const result = expandLongTextPlaceholders(text, {});
+      expect(result).toBe("[LongText#99]");
+    });
+  });
+
+  describe("getAtSelectorPosition", () => {
+    it("should return position of @ at start of string", () => {
+      expect(getAtSelectorPosition("@file", 1)).toBe(0);
+    });
+
+    it("should return position of @ after space", () => {
+      expect(getAtSelectorPosition("read @file", 6)).toBe(5);
+    });
+
+    it("should return -1 if @ is not preceded by space", () => {
+      expect(getAtSelectorPosition("email@domain", 7)).toBe(-1);
+    });
+
+    it("should return -1 if no @ is found", () => {
+      expect(getAtSelectorPosition("no selector", 5)).toBe(-1);
+    });
+  });
+
+  describe("getSlashSelectorPosition", () => {
+    it("should return position of / at start of string", () => {
+      expect(getSlashSelectorPosition("/cmd", 1)).toBe(0);
+    });
+
+    it("should return position of / after space", () => {
+      expect(getSlashSelectorPosition("exec /cmd", 6)).toBe(5);
+    });
+
+    it("should return -1 if / is not preceded by space", () => {
+      expect(getSlashSelectorPosition("dir/file", 5)).toBe(-1);
+    });
+  });
+
+  describe("getWordEnd", () => {
+    it("should find end of word before space", () => {
+      expect(getWordEnd("hello world", 0)).toBe(5);
+    });
+
+    it("should return length of string if no space", () => {
+      expect(getWordEnd("hello", 0)).toBe(5);
+    });
+  });
+
+  describe("getProjectedState", () => {
+    it("should project new text and cursor position correctly", () => {
+      const { newInputText, newCursorPosition } = getProjectedState(
+        "hello ",
+        6,
+        "@",
+      );
+      expect(newInputText).toBe("hello @");
+      expect(newCursorPosition).toBe(7);
+    });
+
+    it("should handle insertion in middle of text", () => {
+      const { newInputText, newCursorPosition } = getProjectedState(
+        "he world",
+        2,
+        "llo",
+      );
+      expect(newInputText).toBe("hello world");
+      expect(newCursorPosition).toBe(5);
+    });
+  });
+
+  describe("SELECTOR_TRIGGERS", () => {
+    it("should identify @ trigger", () => {
+      const trigger = SELECTOR_TRIGGERS.find((t) => t.char === "@");
+      expect(trigger).toBeDefined();
+      expect(trigger?.shouldActivate("@", 1, "@")).toBe(true);
+      expect(trigger?.shouldActivate("@", 6, "read @")).toBe(true);
+      expect(trigger?.shouldActivate("@", 6, "email@")).toBe(false);
+    });
+
+    it("should identify / trigger", () => {
+      const trigger = SELECTOR_TRIGGERS.find((t) => t.char === "/");
+      expect(trigger).toBeDefined();
+      expect(trigger?.shouldActivate("/", 1, "/", false)).toBe(true);
+      expect(trigger?.shouldActivate("/", 5, "run /", false)).toBe(true);
+      // Should not activate if file selector is already showing
+      expect(trigger?.shouldActivate("/", 5, "run /", true)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
This PR refactors the input handling system and several Ink components from useState to useReducer to eliminate stale closures in useInput hooks. Key changes include:

- Consolidated input handling into a single HANDLE_KEY action in inputReducer.ts.
- Introduced a pendingEffect queue to defer side effects (sending messages, fetching history, pasting images) until the next render cycle, ensuring they use the latest state.
- Extracted shared utility functions into inputUtils.ts.
- Refactored FileSelector, CommandSelector, HistorySearch, ModelSelector, SessionSelector, DiscoverView, InstalledView, and MarketplaceView to use a shared selectorReducer.
- Updated tests to use async vi.waitFor and ensured proper component unmounting to prevent test isolation failures.
- Fixed 5 pre-existing flaky test failures, resulting in 849/849 passing tests.