### PR TITLE
feat: include empty reasoning_content in CallAgentResult if provided by AI

### DIFF
--- a/packages/agent-sdk/src/services/aiService.ts
+++ b/packages/agent-sdk/src/services/aiService.ts
@@ -377,10 +377,7 @@ export async function callAgent(
           result.content = finalContent;
         }
 
-        if (
-          typeof finalReasoningContent === "string" &&
-          finalReasoningContent.length > 0
-        ) {
+        if (typeof finalReasoningContent === "string") {
           result.reasoning_content = finalReasoningContent;
         }
 
@@ -544,6 +541,7 @@ async function processStreamingResponse(
 ): Promise<CallAgentResult> {
   let accumulatedContent = "";
   let accumulatedReasoningContent = "";
+  let hasReasoningContent = false;
   const toolCalls: {
     id: string;
     type: "function";
@@ -618,13 +616,13 @@ async function processStreamingResponse(
         }
       }
 
-      if (
-        typeof reasoning_content === "string" &&
-        reasoning_content.length > 0
-      ) {
-        accumulatedReasoningContent += reasoning_content;
-        if (onReasoningUpdate) {
-          onReasoningUpdate(accumulatedReasoningContent);
+      if (typeof reasoning_content === "string") {
+        hasReasoningContent = true;
+        if (reasoning_content.length > 0) {
+          accumulatedReasoningContent += reasoning_content;
+          if (onReasoningUpdate) {
+            onReasoningUpdate(accumulatedReasoningContent);
+          }
         }
       }
 
@@ -716,7 +714,7 @@ async function processStreamingResponse(
     result.content = accumulatedContent.trim();
   }
 
-  if (accumulatedReasoningContent) {
+  if (hasReasoningContent) {
     result.reasoning_content = accumulatedReasoningContent.trim();
   }
 

--- a/packages/agent-sdk/tests/services/aiService.basic.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.basic.test.ts
@@ -381,5 +381,65 @@ describe("AI Service - Basic CallAgent", () => {
       const callArgs = mockCreate.mock.calls[0][0];
       expect(callArgs).not.toHaveProperty("temperature");
     });
+
+    it("should include reasoning_content in result even if it is an empty string", async () => {
+      const mockWithResponse = vi.fn().mockResolvedValue({
+        data: {
+          choices: [
+            {
+              message: {
+                content: "Test response",
+                reasoning_content: "",
+              },
+              finish_reason: "stop",
+            },
+          ],
+        },
+        response: {
+          headers: new Map(),
+        },
+      });
+      mockCreate.mockReturnValue({ withResponse: mockWithResponse });
+
+      const result = await callAgent({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: TEST_MODEL_CONFIG,
+        messages: [{ role: "user", content: "Test message" }],
+        workdir: "/test/workdir",
+      });
+
+      expect(result.content).toBe("Test response");
+      expect(result.reasoning_content).toBe("");
+    });
+
+    it("should NOT include reasoning_content in result if it is undefined", async () => {
+      const mockWithResponse = vi.fn().mockResolvedValue({
+        data: {
+          choices: [
+            {
+              message: {
+                content: "Test response",
+                // reasoning_content is absent
+              },
+              finish_reason: "stop",
+            },
+          ],
+        },
+        response: {
+          headers: new Map(),
+        },
+      });
+      mockCreate.mockReturnValue({ withResponse: mockWithResponse });
+
+      const result = await callAgent({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: TEST_MODEL_CONFIG,
+        messages: [{ role: "user", content: "Test message" }],
+        workdir: "/test/workdir",
+      });
+
+      expect(result.content).toBe("Test response");
+      expect(result).not.toHaveProperty("reasoning_content");
+    });
   });
 });

--- a/packages/agent-sdk/tests/services/aiService.streaming.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.streaming.test.ts
@@ -500,5 +500,81 @@ describe("AI Service - Streaming", () => {
       const callArgs = mockCreate.mock.calls[0][0];
       expect(callArgs.stream).toBeFalsy();
     });
+
+    it("should include reasoning_content in streaming result even if it is an empty string", async () => {
+      // Mock streaming response with an empty reasoning_content delta
+      const mockStream = (async function* () {
+        yield {
+          choices: [
+            {
+              delta: { reasoning_content: "" },
+            },
+          ],
+        };
+        yield {
+          choices: [
+            {
+              delta: { content: "Test response" },
+              finish_reason: "stop",
+            },
+          ],
+        };
+      })();
+
+      mockCreate.mockReturnValue({
+        withResponse: vi.fn().mockResolvedValue({
+          data: mockStream,
+          response: {
+            headers: new Map(),
+          },
+        }),
+      });
+
+      const result = await callAgent({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: TEST_MODEL_CONFIG,
+        messages: [{ role: "user", content: "Test message" }],
+        workdir: "/test/workdir",
+        onContentUpdate: () => {},
+        onReasoningUpdate: () => {},
+      });
+
+      expect(result.content).toBe("Test response");
+      expect(result.reasoning_content).toBe("");
+    });
+
+    it("should NOT include reasoning_content in streaming result if it was never provided in deltas", async () => {
+      // Mock streaming response without reasoning_content delta
+      const mockStream = (async function* () {
+        yield {
+          choices: [
+            {
+              delta: { content: "Test response" },
+              finish_reason: "stop",
+            },
+          ],
+        };
+      })();
+
+      mockCreate.mockReturnValue({
+        withResponse: vi.fn().mockResolvedValue({
+          data: mockStream,
+          response: {
+            headers: new Map(),
+          },
+        }),
+      });
+
+      const result = await callAgent({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: TEST_MODEL_CONFIG,
+        messages: [{ role: "user", content: "Test message" }],
+        workdir: "/test/workdir",
+        onContentUpdate: () => {},
+      });
+
+      expect(result.content).toBe("Test response");
+      expect(result).not.toHaveProperty("reasoning_content");
+    });
   });
 });


### PR DESCRIPTION
Ensures that reasoning_content is preserved in the final result even if it is an empty string, as long as the AI provided the field. This improves tracking for models that explicitly provide reasoning blocks.

### Changes
- Updated `callAgent` in `aiService.ts` to include `reasoning_content` if it's a string, regardless of length.
- Updated `processStreamingResponse` to track `hasReasoningContent` flag.
- Added comprehensive tests for both streaming and non-streaming modes.