### PR TITLE
fix: eliminate excessive newlines in wave -p mode

### DIFF
--- a/packages/code/src/print-cli.ts
+++ b/packages/code/src/print-cli.ts
@@ -71,18 +71,21 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
       isReasoning = false;
       isContent = false;
       // Assistant message started - no content to output yet
-      process.stdout.write("\n");
     },
     onAssistantReasoningUpdated: (chunk: string) => {
       if (!isReasoning) {
-        process.stdout.write("💭 Reasoning:\n");
+        process.stdout.write("\n💭 Reasoning:\n");
         isReasoning = true;
       }
       process.stdout.write(chunk);
     },
     onAssistantContentUpdated: (chunk: string) => {
-      if (isReasoning && !isContent) {
-        process.stdout.write("\n\n📝 Response:\n");
+      if (!isContent) {
+        if (isReasoning) {
+          process.stdout.write("\n\n📝 Response:\n");
+        } else {
+          process.stdout.write("\n");
+        }
         isContent = true;
       }
       // FR-001: Stream content updates for real-time display - output only the new chunk
@@ -93,24 +96,24 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
     onSubagentAssistantMessageAdded: (subagentId: string) => {
       subagentReasoningStates.set(subagentId, false);
       subagentContentStates.set(subagentId, false);
-      process.stdout.write("\n   ");
     },
     onSubagentAssistantReasoningUpdated: (
       subagentId: string,
       chunk: string,
     ) => {
       if (!subagentReasoningStates.get(subagentId)) {
-        process.stdout.write("💭 Reasoning: ");
+        process.stdout.write("\n   💭 Reasoning: ");
         subagentReasoningStates.set(subagentId, true);
       }
       process.stdout.write(chunk);
     },
     onSubagentAssistantContentUpdated: (subagentId: string, chunk: string) => {
-      if (
-        subagentReasoningStates.get(subagentId) &&
-        !subagentContentStates.get(subagentId)
-      ) {
-        process.stdout.write("\n   📝 Response: ");
+      if (!subagentContentStates.get(subagentId)) {
+        if (subagentReasoningStates.get(subagentId)) {
+          process.stdout.write("\n   📝 Response: ");
+        } else {
+          process.stdout.write("\n   ");
+        }
         subagentContentStates.set(subagentId, true);
       }
       process.stdout.write(chunk);
@@ -161,6 +164,7 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
     // Send message if provided and not empty
     if (typeof message === "string" && message.trim() !== "") {
       await agent.sendMessage(message);
+      process.stdout.write("\n");
     }
 
     // Display usage summary before exit

--- a/packages/code/tests/print-cli.test.ts
+++ b/packages/code/tests/print-cli.test.ts
@@ -260,9 +260,12 @@ test("subagent content callbacks output correctly", async () => {
 
   await startPrintCli({ message: "test message" });
 
+  stdoutSpy.mockClear();
+
   // Test onSubagentAssistantMessageAdded callback (starts subagent response)
+  // This callback only initializes state, no output
   capturedCallbacks?.onSubagentAssistantMessageAdded?.("test-subagent-123");
-  expect(stdoutSpy).toHaveBeenCalledWith("\n   ");
+  expect(stdoutSpy).not.toHaveBeenCalled();
 
   // Test onSubagentAssistantContentUpdated callback (streams subagent content)
   capturedCallbacks?.onSubagentAssistantContentUpdated?.(
@@ -270,6 +273,7 @@ test("subagent content callbacks output correctly", async () => {
     "Hello from subagent",
     "Hello from subagent",
   );
+  expect(stdoutSpy).toHaveBeenCalledWith("\n   ");
   expect(stdoutSpy).toHaveBeenCalledWith("Hello from subagent");
 
   // Test onErrorBlockAdded callback
@@ -407,7 +411,7 @@ test("reasoning callbacks output correctly", async () => {
     "Thinking...",
     "Thinking...",
   );
-  expect(stdoutSpy).toHaveBeenCalledWith("💭 Reasoning:\n");
+  expect(stdoutSpy).toHaveBeenCalledWith("\n💭 Reasoning:\n");
   expect(stdoutSpy).toHaveBeenCalledWith("Thinking...");
 
   // Verify header is not printed again
@@ -416,7 +420,7 @@ test("reasoning callbacks output correctly", async () => {
     " more thinking",
     "Thinking... more thinking",
   );
-  expect(stdoutSpy).not.toHaveBeenCalledWith("💭 Reasoning:\n");
+  expect(stdoutSpy).not.toHaveBeenCalledWith("\n💭 Reasoning:\n");
   expect(stdoutSpy).toHaveBeenCalledWith(" more thinking");
 
   // 2. Trigger onAssistantContentUpdated after reasoning and verify the "📝 Response:" header
@@ -438,7 +442,7 @@ test("reasoning callbacks output correctly", async () => {
     "Sub thinking...",
     "Sub thinking...",
   );
-  expect(stdoutSpy).toHaveBeenCalledWith("💭 Reasoning: ");
+  expect(stdoutSpy).toHaveBeenCalledWith("\n   💭 Reasoning: ");
   expect(stdoutSpy).toHaveBeenCalledWith("Sub thinking...");
 
   // Verify header is not printed again
@@ -448,7 +452,7 @@ test("reasoning callbacks output correctly", async () => {
     " more sub thinking",
     "Sub thinking... more sub thinking",
   );
-  expect(stdoutSpy).not.toHaveBeenCalledWith("💭 Reasoning: ");
+  expect(stdoutSpy).not.toHaveBeenCalledWith("\n   💭 Reasoning: ");
   expect(stdoutSpy).toHaveBeenCalledWith(" more sub thinking");
 
   // 4. Trigger onSubagentAssistantContentUpdated after subagent reasoning and verify the "📝 Response:" header


### PR DESCRIPTION
Eliminate excessive newline output in wave -p (print) mode for cleaner terminal output.