### PR TITLE
refactor(subagent): replace lastTools with usedTools for streaming short result

### DIFF
--- a/packages/agent-sdk/src/managers/slashCommandManager.ts
+++ b/packages/agent-sdk/src/managers/slashCommandManager.ts
@@ -224,20 +224,39 @@ export class SlashCommandManager {
                       const messages = subagent.messages;
                       const tokens =
                         subagent.messageManager.getLatestTotalTokens();
-                      const lastTools = subagent.lastTools;
+                      const usedTools = subagent.usedTools;
 
                       const toolCount = countToolBlocks(messages);
                       const summary = formatToolTokenSummary(toolCount, tokens);
+
+                      const getDisplayParam = (t: {
+                        name: string;
+                        parameters: string;
+                        compactParams?: string;
+                        stage?: string;
+                      }) => {
+                        if (
+                          (t.stage === "end" || t.stage === "running") &&
+                          t.compactParams
+                        ) {
+                          return t.compactParams;
+                        }
+                        const flat = t.parameters.replace(/\n/g, "\\n");
+                        return flat.length > 30 ? `…${flat.slice(-30)}` : flat;
+                      };
 
                       let shortResult = "";
                       if (toolCount > 2) {
                         shortResult += "... ";
                       }
-                      if (lastTools.length > 0) {
-                        shortResult += `${lastTools.join(", ")} `;
-                      }
-
                       shortResult += summary;
+                      if (usedTools.length > 0) {
+                        shortResult +=
+                          "\n" +
+                          usedTools
+                            .map((t) => `${t.name} ${getDisplayParam(t)}`)
+                            .join("\n");
+                      }
 
                       this.messageManager.updateToolBlock({
                         id: toolBlockId,

--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -68,7 +68,12 @@ export interface SubagentInstance {
   toolManager: ToolManager;
   status: "initializing" | "active" | "completed" | "error" | "aborted";
   messages: Message[];
-  lastTools: string[]; // Track last two tool names
+  usedTools: {
+    name: string;
+    parameters: string;
+    compactParams?: string;
+    stage?: string;
+  }[]; // Track tools with display info
   subagentType: string; // Store the subagent type for hook context
   description: string; // Store the AI-generated description
   allowedTools?: string[]; // Optional permission rules (e.g. git:*)
@@ -388,7 +393,7 @@ export class SubagentManager {
       toolManager,
       status: "initializing",
       messages: [],
-      lastTools: [], // Initialize lastTools
+      usedTools: [], // Initialize usedTools
       subagentType: parameters.subagent_type, // Store the subagent type
       description: parameters.description, // Store the AI-generated description
       allowedTools: parameters.allowedTools, // Store optional permission rules
@@ -790,15 +795,34 @@ export class SubagentManager {
       },
 
       onToolBlockUpdated: (params: AgentToolBlockUpdateParams) => {
-        // Track last two tool names when a tool starts running
-        if (params.stage === "running" && params.name) {
+        // Track last 2 tool calls for display in short result
+        if (params.name) {
           const instance = this.instances.get(subagentId);
           if (instance) {
-            // Add to lastTools if it's different from the last one or we want to show duplicates
-            // Based on "ToolA, ToolB" requirement, we'll just keep the last two
-            instance.lastTools.push(params.name);
-            if (instance.lastTools.length > 2) {
-              instance.lastTools.shift();
+            // Update existing entry to refresh stage/params, or add new one
+            const existing = instance.usedTools.find(
+              (t) => t.name === params.name,
+            );
+            if (existing) {
+              existing.parameters = params.parameters || existing.parameters;
+              if (params.compactParams !== undefined)
+                existing.compactParams = params.compactParams;
+              existing.stage = params.stage;
+              // Move to end to maintain recency
+              const idx = instance.usedTools.indexOf(existing);
+              instance.usedTools.splice(idx, 1);
+              instance.usedTools.push(existing);
+            } else {
+              instance.usedTools.push({
+                name: params.name,
+                parameters: params.parameters || "",
+                compactParams: params.compactParams,
+                stage: params.stage,
+              });
+            }
+            // Keep only last 2
+            if (instance.usedTools.length > 2) {
+              instance.usedTools = instance.usedTools.slice(-2);
             }
             instance.onUpdate?.();
 
@@ -806,7 +830,7 @@ export class SubagentManager {
             if (instance.logStream) {
               const displayParams =
                 params.compactParams ||
-                (params.parameters || "{}").substring(0, 100);
+                (params.parameters || "").substring(0, 100);
               instance.logStream.write(
                 `[${new Date().toISOString()}] ${params.name}${displayParams ? ` ${displayParams}` : ""}\n`,
               );

--- a/packages/agent-sdk/src/tools/agentTool.ts
+++ b/packages/agent-sdk/src/tools/agentTool.ts
@@ -159,20 +159,39 @@ When using the Agent tool, you must specify a subagent_type parameter to select 
 
           const messages = instance.messageManager.getMessages();
           const tokens = instance.messageManager.getLatestTotalTokens();
-          const lastTools = instance.lastTools;
+          const usedTools = instance.usedTools;
 
           const toolCount = countToolBlocks(messages);
           const summary = formatToolTokenSummary(toolCount, tokens);
+
+          const getDisplayParam = (t: {
+            name: string;
+            parameters: string;
+            compactParams?: string;
+            stage?: string;
+          }) => {
+            if (
+              (t.stage === "end" || t.stage === "running") &&
+              t.compactParams
+            ) {
+              return t.compactParams;
+            }
+            const flat = t.parameters.replace(/\n/g, "\\n");
+            return flat.length > 30 ? `…${flat.slice(-30)}` : flat;
+          };
 
           let shortResult = "";
           if (toolCount > 2) {
             shortResult += "... ";
           }
-          if (lastTools.length > 0) {
-            shortResult += `${lastTools.join(", ")} `;
-          }
-
           shortResult += summary;
+          if (usedTools.length > 0) {
+            shortResult +=
+              "\n" +
+              usedTools
+                .map((t) => `${t.name} ${getDisplayParam(t)}`)
+                .join("\n");
+          }
 
           context.onShortResultUpdate?.(shortResult);
         },

--- a/packages/agent-sdk/src/tools/skillTool.ts
+++ b/packages/agent-sdk/src/tools/skillTool.ts
@@ -148,19 +148,39 @@ export const skillTool: ToolPlugin = {
             // Update shortResult
             const messages = instance.messageManager.getMessages();
             const tokens = instance.messageManager.getLatestTotalTokens();
-            const lastTools = instance.lastTools;
+            const usedTools = instance.usedTools;
 
             const toolCount = countToolBlocks(messages);
             const summary = formatToolTokenSummary(toolCount, tokens);
+
+            const getDisplayParam = (t: {
+              name: string;
+              parameters: string;
+              compactParams?: string;
+              stage?: string;
+            }) => {
+              if (
+                (t.stage === "end" || t.stage === "running") &&
+                t.compactParams
+              ) {
+                return t.compactParams;
+              }
+              const flat = t.parameters.replace(/\n/g, "\\n");
+              return flat.length > 30 ? `…${flat.slice(-30)}` : flat;
+            };
 
             let shortResult = "";
             if (toolCount > 2) {
               shortResult += "... ";
             }
-            if (lastTools.length > 0) {
-              shortResult += `${lastTools.join(", ")} `;
-            }
             shortResult += summary;
+            if (usedTools.length > 0) {
+              shortResult +=
+                "\n" +
+                usedTools
+                  .map((t) => `${t.name} ${getDisplayParam(t)}`)
+                  .join("\n");
+            }
 
             context.onShortResultUpdate?.(shortResult);
           },

--- a/packages/agent-sdk/tests/integration/agentTool.builtin.test.ts
+++ b/packages/agent-sdk/tests/integration/agentTool.builtin.test.ts
@@ -95,7 +95,7 @@ describe("Agent Tool Integration with Built-in Subagents", () => {
     it("should find and execute Explore subagent successfully", async () => {
       const mockInstance = {
         subagentId: "test-id",
-        lastTools: [],
+        usedTools: [],
         messageManager: {
           getMessages: vi.fn(() => []),
           getLatestTotalTokens: vi.fn(() => 0),
@@ -168,7 +168,7 @@ describe("Agent Tool Integration with Built-in Subagents", () => {
     it("should find and execute general-purpose subagent successfully", async () => {
       const mockInstance = {
         subagentId: "gp-test-id",
-        lastTools: [],
+        usedTools: [],
         messageManager: {
           getMessages: vi.fn(() => []),
           getLatestTotalTokens: vi.fn(() => 0),
@@ -203,7 +203,7 @@ describe("Agent Tool Integration with Built-in Subagents", () => {
     it("should handle fastModel configuration correctly", async () => {
       const mockInstance = {
         subagentId: "test-id",
-        lastTools: [],
+        usedTools: [],
         messageManager: {
           getMessages: vi.fn(() => []),
           getLatestTotalTokens: vi.fn(() => 0),
@@ -260,7 +260,7 @@ describe("Agent Tool Integration with Built-in Subagents", () => {
     it("should find and execute Plan subagent successfully", async () => {
       const mockInstance = {
         subagentId: "plan-test-id",
-        lastTools: [],
+        usedTools: [],
         messageManager: {
           getMessages: vi.fn(() => []),
           getLatestTotalTokens: vi.fn(() => 0),
@@ -313,7 +313,7 @@ describe("Agent Tool Integration with Built-in Subagents", () => {
     it("should handle inherit model configuration correctly", async () => {
       const mockInstance = {
         subagentId: "plan-test-id",
-        lastTools: [],
+        usedTools: [],
         messageManager: {
           getMessages: vi.fn(() => []),
           getLatestTotalTokens: vi.fn(() => 0),
@@ -346,7 +346,7 @@ describe("Agent Tool Integration with Built-in Subagents", () => {
     it("should verify Plan subagent has read-only tools", async () => {
       const mockInstance = {
         subagentId: "plan-test-id",
-        lastTools: [],
+        usedTools: [],
         messageManager: {
           getMessages: vi.fn(() => []),
           getLatestTotalTokens: vi.fn(() => 0),

--- a/packages/agent-sdk/tests/integration/subagentPermission.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/subagentPermission.integration.test.ts
@@ -247,7 +247,7 @@ describe("Subagent Permission Integration", () => {
           getMessages: vi.fn(() => []),
           getLatestTotalTokens: vi.fn(() => 0),
         },
-        lastTools: [],
+        usedTools: [],
       }),
       executeAgent: vi.fn().mockResolvedValue("task result"),
       cleanupInstance: vi.fn(),

--- a/packages/agent-sdk/tests/managers/forkedAgentManager.test.ts
+++ b/packages/agent-sdk/tests/managers/forkedAgentManager.test.ts
@@ -64,7 +64,7 @@ describe("ForkedAgentManager", () => {
         {} as unknown as import("@/managers/toolManager.js").ToolManager,
       status: "active",
       messages: [],
-      lastTools: [],
+      usedTools: [],
       subagentType: "general-purpose",
       description: "",
     };

--- a/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
@@ -254,7 +254,7 @@ describe("SubagentManager - Backgrounding Coverage", () => {
     // Trigger tool block update
     passedCallbacks.onToolBlockUpdated?.({
       id: "tool_123",
-      stage: "running",
+      stage: "start",
       name: "Read",
       parameters: JSON.stringify({ file_path: "test.txt" }),
     });

--- a/packages/agent-sdk/tests/managers/subagentManager.coverage.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.coverage.test.ts
@@ -137,24 +137,57 @@ describe("SubagentManager - Recent Changes Coverage", () => {
     instance.messageManager.updateToolBlock({
       id: "1",
       name: "ToolA",
-      stage: "running",
+      stage: "start",
     });
-    expect(instance.lastTools).toEqual(["ToolA"]);
+    expect(instance.usedTools).toEqual([
+      {
+        name: "ToolA",
+        parameters: "",
+        compactParams: undefined,
+        stage: "start",
+      },
+    ]);
     expect(onUpdate).toHaveBeenCalled();
 
     instance.messageManager.updateToolBlock({
       id: "2",
       name: "ToolB",
-      stage: "running",
+      stage: "start",
     });
-    expect(instance.lastTools).toEqual(["ToolA", "ToolB"]);
+    expect(instance.usedTools).toEqual([
+      {
+        name: "ToolA",
+        parameters: "",
+        compactParams: undefined,
+        stage: "start",
+      },
+      {
+        name: "ToolB",
+        parameters: "",
+        compactParams: undefined,
+        stage: "start",
+      },
+    ]);
 
     instance.messageManager.updateToolBlock({
       id: "3",
       name: "ToolC",
-      stage: "running",
+      stage: "start",
     });
-    expect(instance.lastTools).toEqual(["ToolB", "ToolC"]); // Should only keep last two
+    expect(instance.usedTools).toEqual([
+      {
+        name: "ToolB",
+        parameters: "",
+        compactParams: undefined,
+        stage: "start",
+      },
+      {
+        name: "ToolC",
+        parameters: "",
+        compactParams: undefined,
+        stage: "start",
+      },
+    ]); // Should only keep last 2
   });
 
   it("should cleanup subagent instance on completion (7b412d33)", async () => {
@@ -253,8 +286,12 @@ describe("SubagentManager - Recent Changes Coverage", () => {
       (i) => i.configuration.name === "short-result-test",
     )!;
 
-    // Simulate tool updates
-    instance.lastTools.push("ToolA");
+    // Simulate tool updates via the callback (which pushes to usedTools)
+    instance.messageManager.updateToolBlock({
+      id: "1",
+      name: "ToolA",
+      stage: "running",
+    });
     instance.messageManager.addAssistantMessage("Thinking", [
       {
         id: "1",
@@ -267,7 +304,7 @@ describe("SubagentManager - Recent Changes Coverage", () => {
     instance.onUpdate?.();
 
     expect(onShortResultUpdate).toHaveBeenCalledWith(
-      expect.stringContaining("ToolA (1 tools"),
+      expect.stringContaining("(1 tools"),
     );
   });
 

--- a/packages/agent-sdk/tests/tools/agentTool.test.ts
+++ b/packages/agent-sdk/tests/tools/agentTool.test.ts
@@ -55,7 +55,7 @@ describe("Agent Tool Background Execution", () => {
     );
     const mockInstance = {
       subagentId: "gp-test-id",
-      lastTools: [],
+      usedTools: [],
       messageManager: {
         getMessages: vi.fn(() => []),
         getLatestTotalTokens: vi.fn(() => 0),
@@ -96,7 +96,20 @@ describe("Agent Tool Background Execution", () => {
   it("should add '...' to shortResult when toolCount > 2", async () => {
     const mockInstance = {
       subagentId: "gp-test-id",
-      lastTools: ["Read", "Write"],
+      usedTools: [
+        {
+          name: "Read",
+          parameters: '{"file_path":"file1.txt"}',
+          compactParams: "file1.txt",
+          stage: "running",
+        },
+        {
+          name: "Write",
+          parameters: '{"file_path":"file2.txt"}',
+          compactParams: "file2.txt",
+          stage: "running",
+        },
+      ],
       messageManager: {
         getMessages: vi.fn(() => [
           { blocks: [{ type: "tool" }, { type: "tool" }] },
@@ -135,7 +148,7 @@ describe("Agent Tool Background Execution", () => {
 
     await vi.waitFor(() => {
       expect(capturedShortResult).toBe(
-        "... Read, Write (3 tools | 1,000 tokens)",
+        "... (3 tools | 1,000 tokens)\nRead file1.txt\nWrite file2.txt",
       );
     });
   });
@@ -143,7 +156,20 @@ describe("Agent Tool Background Execution", () => {
   it("should NOT add '...' to shortResult when toolCount <= 2", async () => {
     const mockInstance = {
       subagentId: "gp-test-id",
-      lastTools: ["Read", "Write"],
+      usedTools: [
+        {
+          name: "Read",
+          parameters: '{"file_path":"file1.txt"}',
+          compactParams: "file1.txt",
+          stage: "running",
+        },
+        {
+          name: "Write",
+          parameters: '{"file_path":"file2.txt"}',
+          compactParams: "file2.txt",
+          stage: "running",
+        },
+      ],
       messageManager: {
         getMessages: vi.fn(() => [
           { blocks: [{ type: "tool" }, { type: "tool" }] },
@@ -179,7 +205,9 @@ describe("Agent Tool Background Execution", () => {
     );
 
     await vi.waitFor(() => {
-      expect(capturedShortResult).toBe("Read, Write (2 tools | 1,000 tokens)");
+      expect(capturedShortResult).toBe(
+        "(2 tools | 1,000 tokens)\nRead file1.txt\nWrite file2.txt",
+      );
     });
   });
 

--- a/packages/agent-sdk/tests/tools/agentTool_completion.test.ts
+++ b/packages/agent-sdk/tests/tools/agentTool_completion.test.ts
@@ -49,7 +49,7 @@ describe("Agent Tool Completion shortResult", () => {
   it("should include tool count and tokens in shortResult on completion", async () => {
     const mockInstance = {
       subagentId: "gp-test-id",
-      lastTools: ["Read", "Write"],
+      usedTools: [],
       messageManager: {
         getMessages: vi.fn(() => [
           { blocks: [{ type: "tool" }, { type: "tool" }] },
@@ -81,7 +81,7 @@ describe("Agent Tool Completion shortResult", () => {
   it("should show only tool count if tokens is 0", async () => {
     const mockInstance = {
       subagentId: "gp-test-id",
-      lastTools: ["Read"],
+      usedTools: [],
       messageManager: {
         getMessages: vi.fn(() => [{ blocks: [{ type: "tool" }] }]),
         getLatestTotalTokens: vi.fn(() => 0),
@@ -109,7 +109,7 @@ describe("Agent Tool Completion shortResult", () => {
   it("should show only 'Agent completed' if tool count is 0", async () => {
     const mockInstance = {
       subagentId: "gp-test-id",
-      lastTools: [],
+      usedTools: [],
       messageManager: {
         getMessages: vi.fn(() => []),
         getLatestTotalTokens: vi.fn(() => 0),

--- a/packages/agent-sdk/tests/tools/skillTool_fork.test.ts
+++ b/packages/agent-sdk/tests/tools/skillTool_fork.test.ts
@@ -140,7 +140,7 @@ describe("skillTool fork", () => {
         getMessages: vi.fn().mockReturnValue([]),
         getLatestTotalTokens: vi.fn().mockReturnValue(100),
       },
-      lastTools: [],
+      usedTools: [],
     };
 
     const mockSubagentManager = {

--- a/packages/agent-sdk/tests/tools/skillTool_model.test.ts
+++ b/packages/agent-sdk/tests/tools/skillTool_model.test.ts
@@ -37,7 +37,7 @@ describe("skillTool model override", () => {
           getMessages: vi.fn().mockReturnValue([]),
           getLatestTotalTokens: vi.fn().mockReturnValue(0),
         },
-        lastTools: [],
+        usedTools: [],
       }),
       executeAgent: vi.fn().mockResolvedValue("Task result"),
       cleanupInstance: vi.fn(),


### PR DESCRIPTION
Replace flat lastTools string array with structured usedTools tracking (name, parameters, compactParams, stage). Short result now displays each tool on its own line with compactParams (when running/end stage) or last 30 chars of parameters (otherwise), matching ToolDisplay.tsx behavior. Limited to last 2 tool calls.