### PR TITLE
fix: save user prompts to history on message send

### DIFF
--- a/packages/code/src/hooks/useInputManager.ts
+++ b/packages/code/src/hooks/useInputManager.ts
@@ -119,6 +119,14 @@ export const useInputManager = (
               effect.images,
               effect.longTextMap,
             );
+            PromptHistoryManager.addEntry(
+              effect.content,
+              sessionId,
+              effect.longTextMap,
+              workdir,
+            ).catch((err: unknown) => {
+              logger?.error("Failed to save prompt history", err);
+            });
             break;
           case "ABORT_MESSAGE":
             onAbortMessage?.();
@@ -147,16 +155,6 @@ export const useInputManager = (
             break;
           case "PERMISSION_MODE_CHANGE":
             onPermissionModeChange?.(effect.mode);
-            break;
-          case "SAVE_HISTORY":
-            PromptHistoryManager.addEntry(
-              effect.content,
-              sessionId,
-              effect.longTextMap,
-              workdir,
-            ).catch((err: unknown) => {
-              logger?.error("Failed to save prompt history", err);
-            });
             break;
           case "FETCH_HISTORY": {
             let sessionIds: string[] | undefined = sessionId

--- a/packages/code/src/managers/inputReducer.ts
+++ b/packages/code/src/managers/inputReducer.ts
@@ -38,11 +38,6 @@ export type PendingEffect =
   | { type: "BACKGROUND_CURRENT_TASK" }
   | { type: "ASK_BTW"; question: string }
   | { type: "PERMISSION_MODE_CHANGE"; mode: PermissionMode }
-  | {
-      type: "SAVE_HISTORY";
-      content: string;
-      longTextMap: Record<string, string>;
-    }
   | { type: "FETCH_HISTORY" }
   | { type: "PASTE_IMAGE" }
   | { type: "EXECUTE_COMMAND"; command: string };


### PR DESCRIPTION
## Summary

The SAVE_HISTORY effect was never dispatched during normal message submission, so prompts were sent to the agent but never saved to history.jsonl.

## Changes

- Moved PromptHistoryManager.addEntry() into the SEND_MESSAGE effect handler in useInputManager.ts
- Removed the dead SAVE_HISTORY effect type from inputReducer.ts

## Impact

Users can now find and reuse their previous prompts via Ctrl+R history search.