### PR TITLE
refactor: compute usedTools from messages; fix subagent log spam

### DIFF
--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -795,46 +795,16 @@ export class SubagentManager {
       },
 
       onToolBlockUpdated: (params: AgentToolBlockUpdateParams) => {
-        // Track last 2 tool calls for display in short result
-        if (params.name) {
-          const instance = this.instances.get(subagentId);
-          if (instance) {
-            // Update existing entry to refresh stage/params, or add new one
-            const existing = instance.usedTools.find(
-              (t) => t.name === params.name,
+        const instance = this.instances.get(subagentId);
+        if (instance) {
+          // Log tool execution to file
+          if (instance.logStream) {
+            const displayParams =
+              params.compactParams ||
+              (params.parameters || "").substring(0, 100);
+            instance.logStream.write(
+              `[${new Date().toISOString()}] ${params.name}${displayParams ? ` ${displayParams}` : ""}\n`,
             );
-            if (existing) {
-              existing.parameters = params.parameters || existing.parameters;
-              if (params.compactParams !== undefined)
-                existing.compactParams = params.compactParams;
-              existing.stage = params.stage;
-              // Move to end to maintain recency
-              const idx = instance.usedTools.indexOf(existing);
-              instance.usedTools.splice(idx, 1);
-              instance.usedTools.push(existing);
-            } else {
-              instance.usedTools.push({
-                name: params.name,
-                parameters: params.parameters || "",
-                compactParams: params.compactParams,
-                stage: params.stage,
-              });
-            }
-            // Keep only last 2
-            if (instance.usedTools.length > 2) {
-              instance.usedTools = instance.usedTools.slice(-2);
-            }
-            instance.onUpdate?.();
-
-            // Log tool execution to file
-            if (instance.logStream) {
-              const displayParams =
-                params.compactParams ||
-                (params.parameters || "").substring(0, 100);
-              instance.logStream.write(
-                `[${new Date().toISOString()}] ${params.name}${displayParams ? ` ${displayParams}` : ""}\n`,
-              );
-            }
           }
         }
 
@@ -849,6 +819,17 @@ export class SubagentManager {
         const instance = this.instances.get(subagentId);
         if (instance) {
           instance.messages = messages;
+          // Compute usedTools from messages (last 2 tool blocks)
+          const toolBlocks = messages.flatMap(
+            (m) => m.blocks?.filter((b) => b.type === "tool") ?? [],
+          );
+          const last2 = toolBlocks.slice(-2);
+          instance.usedTools = last2.map((tb) => ({
+            name: tb.name ?? "",
+            parameters: tb.parameters ?? "",
+            compactParams: tb.compactParams,
+            stage: tb.stage,
+          }));
           // Trigger the onUpdate callback if provided
           instance.onUpdate?.();
           // Forward subagent message changes to parent via callbacks

--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -797,8 +797,8 @@ export class SubagentManager {
       onToolBlockUpdated: (params: AgentToolBlockUpdateParams) => {
         const instance = this.instances.get(subagentId);
         if (instance) {
-          // Log tool execution to file
-          if (instance.logStream) {
+          // Log tool execution to file only when finalized
+          if (instance.logStream && params.stage === "end") {
             const displayParams =
               params.compactParams ||
               (params.parameters || "").substring(0, 100);

--- a/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
@@ -38,6 +38,7 @@ describe("SubagentManager - Backgrounding Coverage", () => {
   let mockToolManager: ToolManager;
   let mockBackgroundTaskManager: BackgroundTaskManager;
   let container: Container;
+  let taskIdCounter = 0;
 
   const testConfig: SubagentConfiguration = {
     name: "TestAgent",
@@ -59,7 +60,7 @@ describe("SubagentManager - Backgrounding Coverage", () => {
     } as unknown as ToolManager;
 
     mockBackgroundTaskManager = {
-      generateId: vi.fn().mockReturnValue("task_123"),
+      generateId: vi.fn().mockImplementation(() => `task_${++taskIdCounter}`),
       addTask: vi.fn(),
       getTask: vi.fn(),
     } as unknown as BackgroundTaskManager;
@@ -235,14 +236,12 @@ describe("SubagentManager - Backgrounding Coverage", () => {
 
     await subagentManager.backgroundInstance(instance.subagentId);
 
-    expect(mockBackgroundTaskManager.addTask).toHaveBeenCalledWith(
-      expect.objectContaining({
-        outputPath: expect.stringContaining("wave-subagent-task_123.log"),
-      }),
-    );
-
     const addTaskMock = vi.mocked(mockBackgroundTaskManager.addTask);
     const outputPath = addTaskMock.mock.calls[0][0].outputPath!;
+
+    expect(outputPath).toContain("wave-subagent-task_");
+    expect(outputPath).toContain(".log");
+
     await vi.waitFor(() => expect(fs.existsSync(outputPath)).toBe(true));
 
     // Capture callbacks passed to MessageManager
@@ -251,10 +250,10 @@ describe("SubagentManager - Backgrounding Coverage", () => {
       MessageManagerMock.mock.calls[MessageManagerMock.mock.calls.length - 1];
     const passedCallbacks = lastCall[1].callbacks;
 
-    // Trigger tool block update
+    // Trigger tool block update (stage "end" to trigger logging)
     passedCallbacks.onToolBlockUpdated?.({
       id: "tool_123",
-      stage: "start",
+      stage: "end",
       name: "Read",
       parameters: JSON.stringify({ file_path: "test.txt" }),
     });

--- a/packages/agent-sdk/tests/managers/subagentManager.coverage.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.coverage.test.ts
@@ -133,12 +133,21 @@ describe("SubagentManager - Recent Changes Coverage", () => {
       onUpdate,
     );
 
-    // Simulate tool block updates
-    instance.messageManager.updateToolBlock({
-      id: "1",
-      name: "ToolA",
-      stage: "start",
-    });
+    // Simulate messages with tool blocks (usedTools is computed from messages)
+    const msg1 = {
+      id: "m1",
+      role: "assistant" as const,
+      blocks: [
+        {
+          type: "tool" as const,
+          id: "1",
+          name: "ToolA",
+          stage: "start" as const,
+          parameters: "",
+        },
+      ],
+    };
+    instance.messageManager.setMessages([msg1]);
     expect(instance.usedTools).toEqual([
       {
         name: "ToolA",
@@ -149,17 +158,33 @@ describe("SubagentManager - Recent Changes Coverage", () => {
     ]);
     expect(onUpdate).toHaveBeenCalled();
 
-    instance.messageManager.updateToolBlock({
-      id: "2",
-      name: "ToolB",
-      stage: "start",
-    });
+    const msg2 = {
+      id: "m2",
+      role: "assistant" as const,
+      blocks: [
+        {
+          type: "tool" as const,
+          id: "1",
+          name: "ToolA",
+          stage: "end" as const,
+          parameters: "",
+        },
+        {
+          type: "tool" as const,
+          id: "2",
+          name: "ToolB",
+          stage: "start" as const,
+          parameters: "",
+        },
+      ],
+    };
+    instance.messageManager.setMessages([msg1, msg2]);
     expect(instance.usedTools).toEqual([
       {
         name: "ToolA",
         parameters: "",
         compactParams: undefined,
-        stage: "start",
+        stage: "end",
       },
       {
         name: "ToolB",
@@ -169,11 +194,20 @@ describe("SubagentManager - Recent Changes Coverage", () => {
       },
     ]);
 
-    instance.messageManager.updateToolBlock({
-      id: "3",
-      name: "ToolC",
-      stage: "start",
-    });
+    const msg3 = {
+      id: "m3",
+      role: "assistant" as const,
+      blocks: [
+        {
+          type: "tool" as const,
+          id: "3",
+          name: "ToolC",
+          stage: "start" as const,
+          parameters: "",
+        },
+      ],
+    };
+    instance.messageManager.setMessages([msg1, msg2, msg3]);
     expect(instance.usedTools).toEqual([
       {
         name: "ToolB",


### PR DESCRIPTION
refactor: compute usedTools from messages in onMessagesChange

## Additional Commits

- refactor: compute usedTools from messages in onMessagesChange

---

## Summary of Changes

$(git log main..HEAD --oneline)
