### PR TITLE
fix: print-cli waits for background tasks before exiting

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -894,4 +894,16 @@ export class Agent {
   public get taskListId(): string {
     return this.taskManager.getTaskListId();
   }
+
+  /**
+   * Check if there are any running background tasks or active subagents
+   */
+  public get hasRunningBackgroundWork(): boolean {
+    const runningTasks = this.backgroundTaskManager
+      .getAllTasks()
+      .some((t) => t.status === "running");
+    const activeSubagents =
+      this.subagentManager.getActiveInstances().length > 0;
+    return runningTasks || activeSubagents;
+  }
 }

--- a/packages/code/src/print-cli.ts
+++ b/packages/code/src/print-cli.ts
@@ -167,6 +167,11 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
       process.stdout.write("\n");
     }
 
+    // Wait for running background tasks and subagents to complete
+    while (agent.hasRunningBackgroundWork) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+
     // Display usage summary before exit
     if (showStats) {
       try {


### PR DESCRIPTION
## Summary

Add `hasRunningBackgroundWork` getter to Agent class that checks for running background shell tasks and active subagent instances. Print-cli now polls this after `sendMessage` completes and before `destroy`, preventing orphaned background processes or lost output.

## Changes

- **packages/agent-sdk/src/agent.ts**: Added `hasRunningBackgroundWork` getter that returns true if any background tasks have `running` status or if there are active subagent instances.
- **packages/code/src/print-cli.ts**: Added polling loop after `sendMessage` that waits for all background work to complete before destroying the agent and exiting.