### PR TITLE
Remove max parallel tool calls limit from prompt

### DIFF
--- a/packages/agent-sdk/src/prompts/index.ts
+++ b/packages/agent-sdk/src/prompts/index.ts
@@ -19,8 +19,6 @@ import {
   GREP_TOOL_NAME,
 } from "../constants/tools.js";
 
-export const MAX_PARALLEL_TOOL_CALLS = 3;
-
 export const BASE_SYSTEM_PROMPT = `You are an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.`;
 
 export const DOING_TASKS_PROMPT = `# Doing tasks
@@ -60,7 +58,6 @@ export const TOOL_POLICY = `# Using your tools
   - To search the content of files, use ${GREP_TOOL_NAME} instead of grep or rg
   - Reserve using the ${BASH_TOOL_NAME} exclusively for system commands and terminal operations that require shell execution. If you are unsure and there is a relevant dedicated tool, default to using the dedicated tool and only fallback on using the ${BASH_TOOL_NAME} tool for these if it is absolutely necessary.
 - You can call multiple tools in a single response. If you intend to call multiple tools and there are no dependencies between them, make all independent tool calls in parallel. Maximize use of parallel tool calls where possible to increase efficiency.
-- **Limit**: You MUST NOT call more than ${MAX_PARALLEL_TOOL_CALLS} tools in parallel in a single response.
 - However, if some tool calls depend on previous calls to inform dependent values, do NOT call these tools in parallel and instead call them sequentially. For instance, if one operation must complete before another starts, run these operations sequentially instead. Never use placeholders or guess missing parameters in tool calls.
 - If the user specifies that they want you to run tools "in parallel", you MUST send a single message with multiple tool use content blocks.`;
 

--- a/specs/022-prompt-engineering/spec.md
+++ b/specs/022-prompt-engineering/spec.md
@@ -51,8 +51,7 @@ As a developer, I want to provide dynamic tool descriptions based on the current
 - **FR-004**: System MUST support prompt versioning and A/B testing.
 - **FR-005**: System MUST provide a way to validate prompts against token limits.
 - **FR-006**: System MUST support prompt templates with variable substitution.
-- **FR-007**: System MUST include a maximum tool calls limit in the prompt for parallel tool execution.
-- **FR-008**: System MUST incorporate best practices from Claude Code (e.g., action safety, collaborator mindset, concise output).
+- **FR-007**: System MUST incorporate best practices from Claude Code (e.g., action safety, collaborator mindset, concise output).
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/022-prompt-engineering/tasks.md
+++ b/specs/022-prompt-engineering/tasks.md
@@ -10,7 +10,6 @@
 - [X] Refactor `packages/agent-sdk/src/prompts/index.ts` to use modular constants and improved content from Claude Code
 - [ ] Update `ToolManager` to use the registry for tool descriptions
 - [ ] Implement prompt template substitution logic
-- [X] Add max tool calls limit to parallel tool calls prompt
 - [X] Improve prompt content based on Claude Code (refining "Doing Tasks", adding "Executing actions with care", etc.)
 
 ## Phase 3: Testing & Validation


### PR DESCRIPTION
## Summary

- Remove `MAX_PARALLEL_TOOL_CALLS` constant from `packages/agent-sdk/src/prompts/index.ts`
- Remove the `Limit` restriction from `TOOL_POLICY` allowing the model to call unlimited tools in parallel
- Remove FR-007 requirement from `specs/022-prompt-engineering/spec.md`
- Remove completed task from `specs/022-prompt-engineering/tasks.md`

## Why

The artificial limit of 3 parallel tool calls was constraining the model unnecessarily. Removing it allows more efficient parallel execution for independent tool calls.