### PR TITLE
fix(session): assign unique timestamps to batched messages in appendMessages

### DIFF
--- a/packages/agent-sdk/src/services/jsonlHandler.ts
+++ b/packages/agent-sdk/src/services/jsonlHandler.ts
@@ -57,10 +57,14 @@ export class JsonlHandler {
     }
 
     // Convert to SessionMessage format with timestamps
-    const sessionMessages: SessionMessage[] = messages.map((message) => ({
-      ...message,
-      timestamp: new Date().toISOString(),
-    }));
+    const sessionMessages: SessionMessage[] = messages.map((message) => {
+      const { timestamp: _existingTimestamp, ...rest } =
+        message as SessionMessage;
+      return {
+        timestamp: _existingTimestamp || new Date().toISOString(),
+        ...rest,
+      };
+    });
 
     return this.append(filePath, sessionMessages);
   }

--- a/packages/agent-sdk/src/services/session.ts
+++ b/packages/agent-sdk/src/services/session.ts
@@ -228,10 +228,13 @@ export async function appendMessages(
     );
   }
 
-  const messagesWithTimestamp: SessionMessage[] = newMessages.map((msg) => ({
-    timestamp: new Date().toISOString(),
-    ...msg,
-  }));
+  const messagesWithTimestamp: SessionMessage[] = newMessages.map((msg, i) => {
+    const { timestamp: _existingTimestamp, ...rest } = msg as SessionMessage;
+    return {
+      timestamp: _existingTimestamp || new Date(Date.now() + i).toISOString(),
+      ...rest,
+    };
+  });
 
   await jsonlHandler.append(filePath, messagesWithTimestamp, {
     atomic: false,


### PR DESCRIPTION
## Summary

When `appendMessages()` saved a batch of messages (e.g., SessionStart hook outputs + initial user message), all messages received the same timestamp because `new Date().toISOString()` was called once during the synchronous `.map()` operation.

## Fix

Each message now gets its own timestamp, and existing timestamps are preserved instead of being overwritten.

## Changes

- `packages/agent-sdk/src/services/session.ts` — Per-message timestamp assignment in `appendMessages()`