### PR TITLE
fix(bash-tools): remove misleading persistent shell / CWD prompt, update specs

### DIFF
--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -80,7 +80,7 @@ export const bashTool: ToolPlugin = {
     },
   },
   prompt: () => `
-Executes a given bash command in a persistent shell session with optional timeout, ensuring proper handling and security measures.
+Executes a given bash command with optional timeout, ensuring proper handling and security measures. Each invocation runs in a fresh shell process starting from the project root.
 
 IMPORTANT: This tool is for terminal operations like git, npm, docker, etc. DO NOT use it for file operations (reading, writing, editing, searching, finding files) - use the specialized tools for this instead.
 
@@ -139,10 +139,7 @@ Use the gh command via the Bash tool for GitHub-related tasks including working 
 - Do not retry failing commands in a sleep loop — diagnose the root cause.
 - If waiting for a background task you started with \`run_in_background\`, you will be notified when it completes — do not poll.
 - If you must poll an external process, use a check command (e.g. \`gh run view\`) rather than sleeping first.
-- If you must sleep, keep the duration short (1-5 seconds) to avoid blocking the user.
-
-# CWD management
-Try to maintain your current working directory throughout the session by using absolute paths and avoiding usage of \`cd\`. You may use \`cd\` if the User explicitly requests it. When you use \`cd\`, the shell working directory will be reset to the original working directory after the command completes.`,
+- If you must sleep, keep the duration short (1-5 seconds) to avoid blocking the user.`,
   execute: async (
     args: Record<string, unknown>,
     context: ToolContext,

--- a/specs/002-bash-tools/contracts/bash-tools-api.md
+++ b/specs/002-bash-tools/contracts/bash-tools-api.md
@@ -1,6 +1,6 @@
 # Bash Tools API Contract
 
-**Version**: 1.0.0
+**Version**: 2.0.0
 **Feature**: Bash Tools
 
 ## TypeScript Interface Definitions
@@ -15,49 +15,34 @@ interface BashArgs {
 }
 ```
 
-### Bash Output Tool Arguments
-```typescript
-interface BashOutputArgs {
-  bash_id: string;
-  filter?: string;
-}
-```
-
-### Kill Bash Tool Arguments
-```typescript
-interface KillBashArgs {
-  shell_id: string;
-}
-```
-
-## Background Bash Manager API
+## Background Task Manager API
 
 ```typescript
-interface BackgroundBashManager {
-  startShell(command: string, timeout?: number): string; // returns shellId
-  getOutput(shellId: string, filter?: string): {
-    stdout: string;
-    stderr: string;
-    status: string;
-  } | null;
-  getShell(shellId: string): BackgroundShell | null;
-  killShell(shellId: string): boolean;
+interface BackgroundTaskManager {
+  startShell(command: string, timeout?: number): { id: string }; // returns taskId
+  getTask(taskId: string): BackgroundTask | null;
+  stopTask(taskId: string): boolean;
 }
 
-interface BackgroundShell {
+interface BackgroundTask {
   id: string;
   command: string;
   status: "running" | "completed" | "failed" | "killed";
-  stdout: string;
-  stderr: string;
+  outputPath: string;   // path to real-time log file
   exitCode?: number;
-  startTime: number;
-  endTime?: number;
+}
+```
+
+## Foreground Task Manager API
+
+```typescript
+interface ForegroundTaskManager {
+  registerForegroundTask(task: { id: string; backgroundHandler: () => Promise<void> }): void;
+  unregisterForegroundTask(id: string): void;
 }
 ```
 
 ## Execution Flow
-1. **Foreground**: `Bash` tool spawns a process, waits for completion or timeout, and returns the combined output.
-2. **Background**: `Bash` tool registers the command with `BackgroundBashManager`, which spawns the process and returns a `bash_id`. Background tasks do not update their `shortResult` while running to avoid UI "unknown" blocks.
-3. **Monitoring**: `BashOutput` tool queries `BackgroundBashManager` for accumulated output of a specific `bash_id`.
-4. **Termination**: `KillBash` tool requests `BackgroundBashManager` to terminate a specific `shell_id`.
+1. **Foreground**: `Bash` tool spawns a fresh shell process via `spawn(command, { shell: true, cwd: context.workdir })`, streams output via `onResultUpdate`/`onShortResultUpdate` callbacks, and returns combined stdout+stderr on completion.
+2. **Background**: `Bash` tool calls `BackgroundTaskManager.startShell()` which spawns the process and pipes output to a log file. Returns `taskId` and `outputPath` immediately. Agents use the `Read` tool to monitor output.
+3. **Termination**: `TaskStop` tool calls `BackgroundTaskManager.stopTask()` to terminate a background process (SIGTERM → SIGKILL on process group).

--- a/specs/002-bash-tools/cwd-handling.md
+++ b/specs/002-bash-tools/cwd-handling.md
@@ -4,6 +4,12 @@
 
 Both Wave's and Claude Code's bash tools do NOT expose a `cwd` argument in the tool schema. The working directory is determined by the application's tracked cwd.
 
+Wave input schema (`bashTool.ts:52-80`):
+- `command` (required)
+- `timeout`
+- `description`
+- `run_in_background`
+
 Claude Code input schema (`BashTool.tsx:227-247`):
 - `command` (required)
 - `timeout`
@@ -36,7 +42,8 @@ Claude Code input schema (`BashTool.tsx:227-247`):
 
 ## Wave's current approach
 
-- Wave uses a **persistent shell session** (single long-lived process).
-- The cwd is passed via `context.workdir` to `spawn()` (`bashTool.ts:245`).
-- Since it's a persistent shell, `cd` commands naturally change the shell's working directory for subsequent commands within the same session — no explicit cwd tracking or temp file needed.
-- However, Wave does NOT have a mechanism to track or reset the cwd if it leaves the allowed working directory.
+- **Fresh shell per command**: Wave spawns a new shell process for each foreground command via `spawn(command, { shell: true, cwd: context.workdir })` (`bashTool.ts:243-250`).
+- **Cwd is fixed to `context.workdir`**: Every command starts from the same working directory passed in via `context.workdir`. The shell working directory is reset to this original directory after each command completes.
+- **`cd` does NOT persist between commands**: Running `cd some/dir` only affects that single command invocation. Subsequent commands still start from `context.workdir`. The agent prompt (`bashTool.ts:144-145`) explicitly instructs: "When you use `cd`, the shell working directory will be reset to the original working directory after the command completes."
+- **Background tasks**: Background processes are spawned similarly and their output is written to a log file. They also start from `context.workdir`.
+- **No cwd tracking**: Unlike Claude Code, Wave does NOT track cwd changes (no `pwd -P` appended, no temp file read). There is no mechanism to track or reset cwd if it leaves the allowed working directory.

--- a/specs/002-bash-tools/data-model.md
+++ b/specs/002-bash-tools/data-model.md
@@ -9,27 +9,22 @@
 **Purpose**: Arguments for the `Bash` tool.
 **Fields**:
 - `command: string`: The shell command to execute.
-- `timeout?: number`: Maximum execution time in milliseconds.
-- `description?: string`: Brief description of the command.
+- `timeout?: number`: Maximum execution time in milliseconds (max 600000).
+- `description?: string`: Brief description of what the command does (5-10 words).
 - `run_in_background?: boolean`: Whether to run the command in the background.
 
-### BashOutputArguments
-**Purpose**: Arguments for the `BashOutput` tool.
+### BackgroundTask
+**Purpose**: Internal state for background processes (managed by `BackgroundTaskManager`).
 **Fields**:
-- `bash_id: string`: The ID of the background process.
-- `filter?: string`: Regex to filter output lines.
-
-### KillBashArguments
-**Purpose**: Arguments for the `KillBash` tool.
-**Fields**:
-- `shell_id: string`: The ID of the background process to kill.
-
-### BackgroundShell
-**Purpose**: Internal state for background processes.
-**Fields**:
-- `id: string`: Unique identifier.
+- `id: string`: Unique identifier (e.g., `shell_<timestamp>_<random>`).
 - `command: string`: The command being run.
 - `status: "running" | "completed" | "failed" | "killed"`: Current status.
-- `stdout: string`: Accumulated standard output.
-- `stderr: string`: Accumulated standard error.
-- `exitCode?: number`: Process exit code.
+- `outputPath: string`: Path to a real-time log file for stdout/stderr.
+- `exitCode?: number`: Process exit code (set when completed).
+
+### ForegroundTask
+**Purpose**: Tracks running foreground commands for streaming and backgrounding (managed by `ForegroundTaskManager`).
+**Fields**:
+- `id: string`: Unique identifier (e.g., `bash_<timestamp>_<random>`).
+- `child: ChildProcess`: The spawned child process.
+- `backgroundHandler: () => Promise<void>`: Callback to move the process to background.

--- a/specs/002-bash-tools/plan.md
+++ b/specs/002-bash-tools/plan.md
@@ -12,12 +12,13 @@ Implement tools for executing shell commands, supporting both foreground and bac
 - **Platform**: Cross-platform (Node.js)
 
 ## Project Structure
-- `packages/agent-sdk/src/tools/bashTool.ts`: Implementation of `Bash`, `BashOutput`, and `KillBash`.
-- `packages/agent-sdk/src/managers/backgroundBashManager.ts`: Management of background processes.
+- `packages/agent-sdk/src/tools/bashTool.ts`: Implementation of `Bash` tool (foreground + background via `run_in_background`).
+- `packages/agent-sdk/src/managers/backgroundTaskManager.ts`: Management of background shell tasks.
+- `packages/agent-sdk/src/managers/foregroundTaskManager.ts`: Management of foreground streaming tasks.
 
 ## Implementation Phases
 1. **Phase 1: Foreground Execution**: Implement basic `Bash` tool with timeout and output capture.
-2. **Phase 2: Background Support**: Implement `run_in_background` and `BackgroundBashManager`.
-3. **Phase 3: Process Monitoring**: Implement `BashOutput` for retrieving background output.
-4. **Phase 4: Process Control**: Implement `KillBash` for terminating background tasks.
-5. **Phase 5: Safety & UX**: Add ANSI color stripping, output truncation, and permission checks.
+2. **Phase 2: Background Support**: Implement `run_in_background` and `BackgroundTaskManager`.
+3. **Phase 3: Process Monitoring**: Background output written to log file; agents use `Read` tool instead of separate `BashOutput` tool.
+4. **Phase 4: Process Control**: Implement `TaskStop` (replaced `KillBash`) for terminating background tasks.
+5. **Phase 5: Safety & UX**: Add ANSI color stripping, output truncation, permission checks, and real-time streaming updates.

--- a/specs/002-bash-tools/quickstart.md
+++ b/specs/002-bash-tools/quickstart.md
@@ -1,7 +1,7 @@
 # Bash Tools Quickstart
 
 ## Overview
-Bash tools allow the agent to execute terminal commands.
+Bash tools allow the agent to execute terminal commands. Each command spawns a fresh shell process — `cd` and environment changes do NOT persist between calls.
 
 ## Usage Examples
 
@@ -21,27 +21,26 @@ const result = await bashTool.execute({
   command: "pnpm start",
   run_in_background: true
 }, context);
-// Returns a bash_id
+// Returns a taskId and outputPath
 ```
 
-### Checking Background Output
+### Reading Background Output
 ```typescript
-// Retrieve output from a background process
-const result = await bashOutputTool.execute({
-  bash_id: "shell_123",
-  filter: "Error"
+// Use the Read tool to monitor a background process's log file
+const output = await readTool.execute({
+  file_path: "/tmp/bash_task_123.log"
 }, context);
 ```
 
-### Killing a Background Process
+### Stopping a Background Process
 ```typescript
 // Terminate a background process
-const result = await killBashTool.execute({
-  shell_id: "shell_123"
+const result = await taskStopTool.execute({
+  task_id: "shell_123"
 }, context);
 ```
 
 ## Key Implementation Details
-- **Persistent Shell**: While each call uses `spawn`, the environment is maintained via the `ToolContext`.
-- **Process Groups**: Background processes are killed using process group IDs to ensure all child processes are terminated.
-- **Output Management**: Output is buffered and can be filtered via `BashOutput`.
+- **Fresh Shell per Command**: Each call uses `spawn(command, { shell: true, cwd: context.workdir })`. The working directory resets to `context.workdir` after each command.
+- **Process Groups**: Background processes are killed using process group IDs (SIGTERM → SIGKILL) to ensure all child processes are terminated.
+- **Output Management**: Foreground output streams via callbacks. Background output is piped to a log file readable via the `Read` tool.

--- a/specs/002-bash-tools/research.md
+++ b/specs/002-bash-tools/research.md
@@ -1,21 +1,25 @@
 # Research: Bash Tools Implementation
 
 ## Execution Model
-**Decision**: Use `child_process.spawn` with `shell: true`.
-**Rationale**: Provides the most flexible way to execute shell commands across different platforms while allowing for pipe and redirection support.
+**Decision**: Use `child_process.spawn` with `shell: true` — fresh shell per command.
+**Rationale**: Each command spawns a new shell process with `cwd: context.workdir`. The shell working directory resets after each command, so `cd` does not persist between calls. The agent prompt instructs use of absolute paths.
 
 ## Background Execution
-**Decision**: Implement a `BackgroundBashManager` to track long-running processes.
-**Rationale**: Agents often need to start servers or long-running tests and continue working. A manager allows for asynchronous monitoring and control.
+**Decision**: Implement `BackgroundTaskManager` to track long-running processes via log files.
+**Rationale**: Agents often need to start servers or long-running tests and continue working. Background output is piped to a log file that the agent reads via the `Read` tool.
 
 ## Output Handling
 **Decision**: Strip ANSI color codes and truncate output at 30,000 characters.
-**Rationale**: ANSI codes clutter the LLM's context and are not useful for reasoning. Truncation prevents context window overflow.
+**Rationale**: ANSI codes clutter the LLM's context and are not useful for reasoning. Truncation prevents context window overflow. Excess output is persisted to a temp file with the path returned.
+
+## Real-time Streaming
+**Decision**: Foreground commands stream updates to both `shortResult` (last 3 lines) and full `result` via `onShortResultUpdate` and `onResultUpdate` callbacks.
+**Rationale**: Provides responsive feedback for long-running commands without blocking the agent.
 
 ## Process Termination
-**Decision**: Use negative PID (e.g., `process.kill(-pid)`) for termination.
+**Decision**: Use negative PID (e.g., `process.kill(-pid)`) for termination, with SIGTERM followed by SIGKILL fallback.
 **Rationale**: This ensures that the entire process group (including any sub-processes started by the command) is killed, preventing zombie processes.
 
 ## Security
 **Decision**: Integrate with `PermissionManager` and discourage use for file operations.
-**Rationale**: Bash is a powerful tool that requires strict oversight. Encouraging specialized FS tools reduces the risk of accidental or malicious system damage.
+**Rationale**: Bash is a powerful tool that requires strict oversight. Encouraging specialized FS tools (Read, Write, Edit, Glob, Grep) reduces the risk of accidental or malicious system damage.

--- a/specs/002-bash-tools/spec.md
+++ b/specs/002-bash-tools/spec.md
@@ -55,10 +55,11 @@ As an AI agent, I want to see the output of foreground commands in real-time so 
 
 ### Edge Cases
 
-- **Output Truncation**: If a command produces massive output (e.g., > 30,000 characters), the system must truncate it to prevent overwhelming the LLM.
+- **Output Truncation**: If a command produces massive output (e.g., > 30,000 characters), the system must truncate it to prevent overwhelming the LLM. Excess output is persisted to a temp file.
 - **ANSI Color Codes**: Output containing ANSI escape sequences for colors should be stripped to ensure the LLM can read the text clearly.
 - **Process Group Termination**: When killing a background process, it should terminate the entire process group to avoid leaving orphan processes.
-- **Invalid Bash ID**: Calling `BashOutput` or `KillBash` with a non-existent or expired ID should return a clear error message.
+- **Invalid Task ID**: Calling `TaskStop` with a non-existent or expired ID should return a clear error message.
+- **Fresh Shell per Command**: Each foreground command spawns a new shell; `cd` and env changes do not persist between calls.
 
 ## Requirements *(mandatory)*
 
@@ -72,7 +73,7 @@ As an AI agent, I want to see the output of foreground commands in real-time so 
 - **FR-007**: All bash output MUST have ANSI color codes stripped.
 - **FR-008**: Foreground bash output MUST be truncated if it exceeds 30,000 characters.
 - **FR-009**: Background bash tasks MUST NOT update their `shortResult` while running to prevent unnecessary message updates and "unknown" tool blocks in the UI.
-- **FR-010**: The system MUST maintain environment variables across sequential `Bash` calls (persistent session behavior).
+- **FR-010**: Each `Bash` call spawns a fresh shell process with `cwd: context.workdir` and a copy of `process.env`. Environment variables set in one command do NOT persist to subsequent commands.
 - **FR-011**: When `run_in_background` is true, the system MUST return an `outputPath` to a real-time log file.
 - **FR-012**: The system MUST pipe `stdout` and `stderr` to the `outputPath` log file in real-time.
 - **FR-013**: Foreground `Bash` tool MUST support real-time streaming updates to both `shortResult` and the full `result` content.
@@ -82,9 +83,9 @@ As an AI agent, I want to see the output of foreground commands in real-time so 
 
 ### Key Entities *(include if feature involves data)*
 
-- **Bash Session**: Represents a shell execution context.
-- **Bash ID**: A unique identifier for a background process.
-- **Command Output**: The combined stdout and stderr from a command execution.
+- **Foreground Command**: A single shell execution via `spawn()` with `cwd: context.workdir`; fresh shell per call.
+- **Background Task**: A long-running shell process managed by `BackgroundTaskManager`, output piped to a log file.
+- **Command Output**: The combined stdout and stderr from a command execution, ANSI-stripped and potentially truncated.
 
 ## Assumptions
 

--- a/specs/002-bash-tools/tasks.md
+++ b/specs/002-bash-tools/tasks.md
@@ -1,9 +1,9 @@
 # Tasks: Bash Tools
 
 - [x] T001 Implement `Bash` tool for foreground command execution
-- [x] T002 Implement background execution support in `Bash` tool
-- [x] T003 Implement `BashOutput` tool for monitoring background processes
-- [x] T004 Implement `KillBash` tool for process termination
+- [x] T002 Implement background execution support via `run_in_background` parameter
+- [x] T003 Background output piped to log file (agents use `Read` tool instead of separate `BashOutput` tool)
+- [x] T004 Implement `TaskStop` tool for background process termination (replaced `KillBash`)
 - [x] T005 Implement output truncation and ANSI color stripping
 - [x] T006 Integrate `Bash` tool with `PermissionManager`
 - [x] T007 Implement timeout handling for bash commands


### PR DESCRIPTION
## Summary

Removes misleading text from the Bash tool prompt and updates all spec documentation to reflect the actual implementation.

## Changes

### bashTool.ts
- **Removed** `persistent shell session` from the description (each call spawns a fresh shell process)
- **Removed** entire `# CWD management` section that instructed the agent to "maintain current working directory" — this was misleading since the working directory resets to the project root after every command

### Spec documentation (specs/002-bash-tools/)
- **spec.md**: Updated FR-010 to document fresh shell behavior; added fresh shell edge case
- **cwd-handling.md**: Corrected "persistent shell session" claim; documented that `cd` does NOT persist between commands
- **plan.md**: Updated file references to current managers (BackgroundTaskManager, ForegroundTaskManager)
- **data-model.md**: Replaced deprecated BashOutputArguments/KillBashArguments with BackgroundTask/ForegroundTask entities
- **research.md**: Updated execution model, manager names, added streaming section
- **contracts/bash-tools-api.md**: Bumped to v2.0.0; updated APIs to match current implementation
- **quickstart.md**: Updated examples to use Read tool and TaskStop
- **tasks.md**: Updated task descriptions to reflect current tool names