### PR TITLE
feat(sdk): add mcpServers option to Agent constructor

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -414,6 +414,7 @@ export class Agent {
    * @param options.messages - Optional initial messages for testing convenience
    * @param options.workdir - Working directory (defaults to process.cwd())
    * @param options.systemPrompt - Optional custom system prompt
+   * @param options.mcpServers - Optional MCP server configs to connect at startup
    * @returns Promise that resolves to initialized Agent instance
    *
    * @example

--- a/packages/agent-sdk/src/managers/mcpManager.ts
+++ b/packages/agent-sdk/src/managers/mcpManager.ts
@@ -32,6 +32,8 @@ import { logger } from "../utils/globalLogger.js";
 export interface McpManagerOptions {
   callbacks?: McpManagerCallbacks;
   logger?: Logger;
+  /** Pre-configured MCP servers passed from constructor options */
+  mcpServers?: Record<string, McpServerConfig>;
 }
 
 /**
@@ -96,12 +98,14 @@ export class McpManager {
   private configPath: string = "";
   private workdir: string = "";
   private callbacks: McpManagerCallbacks;
+  private mcpServers: Record<string, McpServerConfig> | undefined;
 
   constructor(
     private container: Container,
     options: McpManagerOptions = {},
   ) {
     this.callbacks = options.callbacks || {};
+    this.mcpServers = options.mcpServers;
   }
 
   /**
@@ -113,6 +117,13 @@ export class McpManager {
   ): Promise<void> {
     this.configPath = join(workdir, ".mcp.json");
     this.workdir = workdir;
+
+    // Register constructor-provided servers before loading .mcp.json
+    if (this.mcpServers) {
+      for (const [name, config] of Object.entries(this.mcpServers)) {
+        this.addServer(name, config);
+      }
+    }
 
     if (autoConnect) {
       logger?.debug("Initializing MCP servers...");
@@ -168,13 +179,17 @@ export class McpManager {
       const configContent = await fs.readFile(this.configPath, "utf-8");
       const workspaceConfig = resolveMcpConfig(JSON.parse(configContent));
 
-      // Merge workspace config with any existing config (e.g., from plugins)
-      // Workspace servers take precedence for duplicate names
+      // Merge workspace config with any existing config (e.g., from plugins or constructor)
+      // Constructor-provided servers take precedence, then workspace config, then existing config
       const merged: McpConfig = { mcpServers: {} };
       if (this.config) {
         Object.assign(merged.mcpServers, this.config.mcpServers);
       }
       Object.assign(merged.mcpServers, workspaceConfig.mcpServers);
+      // Constructor-provided servers override both for same names
+      if (this.mcpServers) {
+        Object.assign(merged.mcpServers, this.mcpServers);
+      }
       this.config = merged;
 
       // Initialize server statuses (preserve existing status for already known servers)

--- a/packages/agent-sdk/src/types/agent.ts
+++ b/packages/agent-sdk/src/types/agent.ts
@@ -8,6 +8,7 @@ import type {
   ILspManager,
   PluginConfig,
   BackgroundTask,
+  McpServerConfig,
 } from "./index.js";
 import type { MessageManagerCallbacks } from "../managers/messageManager.js";
 import type { BackgroundTaskManagerCallbacks } from "../managers/backgroundTaskManager.js";
@@ -78,6 +79,11 @@ export interface AgentOptions {
    * These rules follow the standard permission rule syntax: `ToolName` or `ToolName(pattern)`.
    */
   disallowedTools?: string[];
+  /**
+   * Optional MCP server configs to connect at startup.
+   * Overrides .mcp.json for specified server names.
+   */
+  mcpServers?: Record<string, McpServerConfig>;
   [key: string]: unknown;
 }
 

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -28,7 +28,7 @@ import { MemoryService } from "../services/memory.js";
 import { AutoMemoryService } from "../services/autoMemoryService.js";
 import { getGitMainRepoRoot } from "./gitUtils.js";
 import { USER_MEMORY_FILE } from "./constants.js";
-import type { AgentOptions } from "../types/index.js";
+import type { AgentOptions, McpServerConfig } from "../types/index.js";
 import type {
   PermissionMode,
   Usage,
@@ -145,7 +145,12 @@ export function setupAgentContainer(
   });
   container.register("BackgroundTaskManager", backgroundTaskManager);
 
-  const mcpManager = new McpManager(container, { callbacks });
+  const mcpManager = new McpManager(container, {
+    callbacks,
+    mcpServers: options.mcpServers as
+      | Record<string, McpServerConfig>
+      | undefined,
+  });
   container.register("McpManager", mcpManager);
 
   const lspManager = options.lspManager || new LspManager(container);

--- a/packages/agent-sdk/tests/managers/mcpManager.test.ts
+++ b/packages/agent-sdk/tests/managers/mcpManager.test.ts
@@ -351,6 +351,90 @@ describe("McpManager", () => {
     });
   });
 
+  describe("constructor mcpServers option", () => {
+    it("should register constructor-provided servers before file load", async () => {
+      const container = new Container();
+      const manager = new McpManager(container, {
+        mcpServers: {
+          "constructor-server": { command: "constructor-mcp" },
+        },
+      });
+      await manager.initialize("/test/workdir", false);
+
+      // Server should be registered even without loading .mcp.json
+      const servers = manager.getAllServers();
+      expect(servers).toHaveLength(1);
+      expect(servers[0].name).toBe("constructor-server");
+      expect(servers[0].config.command).toBe("constructor-mcp");
+
+      await manager.cleanup();
+    });
+
+    it("should have constructor servers available before loadConfig runs", async () => {
+      const { promises: fs } = await import("fs");
+      const container = new Container();
+      const manager = new McpManager(container, {
+        mcpServers: {
+          "ctor-server": { command: "ctor-mcp" },
+        },
+      });
+      await manager.initialize("/test/workdir", false);
+
+      // Verify constructor server is registered
+      expect(manager.getServer("ctor-server")).toBeDefined();
+
+      // Now load .mcp.json
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          mcpServers: {
+            "file-server": { command: "file-mcp" },
+          },
+        }),
+      );
+      await manager.loadConfig();
+
+      // Both servers should be present
+      expect(manager.getServer("ctor-server")).toBeDefined();
+      expect(manager.getServer("file-server")).toBeDefined();
+
+      const config = manager.getConfig();
+      expect(config?.mcpServers).toHaveProperty("ctor-server");
+      expect(config?.mcpServers).toHaveProperty("file-server");
+
+      await manager.cleanup();
+    });
+
+    it("should let constructor-provided servers override .mcp.json for same-named servers", async () => {
+      const { promises: fs } = await import("fs");
+      const container = new Container();
+      const manager = new McpManager(container, {
+        mcpServers: {
+          "shared-server": { command: "ctor-command", args: ["--ctor"] },
+        },
+      });
+      await manager.initialize("/test/workdir", false);
+
+      // .mcp.json has a server with the same name but different config
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          mcpServers: {
+            "shared-server": { command: "file-command", args: ["--file"] },
+          },
+        }),
+      );
+      await manager.loadConfig();
+
+      // Constructor config should win for same-named server
+      const config = manager.getConfig();
+      expect(config?.mcpServers["shared-server"]).toEqual({
+        command: "ctor-command",
+        args: ["--ctor"],
+      });
+
+      await manager.cleanup();
+    });
+  });
+
   describe("server management", () => {
     beforeEach(async () => {
       const { promises: fs } = await import("fs");

--- a/packages/code/src/cli.tsx
+++ b/packages/code/src/cli.tsx
@@ -24,6 +24,7 @@ export async function startCli(options: CliOptions): Promise<void> {
     workdir,
     version,
     model,
+    mcpServers,
   } = options;
 
   // Continue with ink-based UI for normal mode
@@ -49,6 +50,7 @@ export async function startCli(options: CliOptions): Promise<void> {
       workdir={workdir}
       version={version}
       model={model}
+      mcpServers={mcpServers}
       onExit={handleExit}
     />,
     { exitOnCtrlC: false },

--- a/packages/code/src/components/App.tsx
+++ b/packages/code/src/components/App.tsx
@@ -32,6 +32,7 @@ const AppWithProviders: React.FC<AppWithProvidersProps> = ({
   workdir,
   version,
   model,
+  mcpServers,
   onExit,
 }) => {
   const [isExiting, setIsExiting] = useState(false);
@@ -106,6 +107,7 @@ const AppWithProviders: React.FC<AppWithProvidersProps> = ({
       worktreeSession={worktreeSession}
       version={version}
       model={model}
+      mcpServers={mcpServers}
     >
       <ChatInterface />
     </ChatProvider>
@@ -125,6 +127,7 @@ export const App: React.FC<AppProps> = ({
   workdir,
   version,
   model,
+  mcpServers,
   onExit,
 }) => {
   return (
@@ -143,6 +146,7 @@ export const App: React.FC<AppProps> = ({
         workdir={workdir}
         version={version}
         model={model}
+        mcpServers={mcpServers}
         onExit={onExit}
       />
     </AppProvider>

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -147,6 +147,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   worktreeSession,
   version,
   model,
+  mcpServers,
 }) => {
   const { restoreSessionId, continueLastSession } = useAppConfig();
   const { stdout } = useStdout();
@@ -198,7 +199,9 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
 
   // MCP State
-  const [mcpServers, setMcpServers] = useState<McpServerStatus[]>([]);
+  const [mcpServerStatuses, setMcpServerStatuses] = useState<McpServerStatus[]>(
+    [],
+  );
 
   // Background tasks state
   const [backgroundTasks, setBackgroundTasks] = useState<BackgroundTask[]>([]);
@@ -329,7 +332,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
           throttledSetMessages();
         },
         onServersChange: (servers) => {
-          setMcpServers([...servers]);
+          setMcpServerStatuses([...servers]);
         },
         onSessionIdChange: (sessionId) => {
           setSessionId(sessionId);
@@ -403,6 +406,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
           worktreeName: worktreeSession?.name,
           isNewWorktree: worktreeSession?.isNew,
           model,
+          mcpServers,
         });
 
         agentRef.current = agent;
@@ -420,8 +424,8 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         setConfiguredModels(agent.getConfiguredModels());
 
         // Get initial MCP servers state
-        const mcpServers = agent.getMcpServers?.() || [];
-        setMcpServers(mcpServers);
+        const initialMcpServers = agent.getMcpServers?.() || [];
+        setMcpServerStatuses(initialMcpServers);
 
         // Get initial commands
         const agentSlashCommands = agent.getSlashCommands?.() || [];
@@ -444,6 +448,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
       model,
       initialPermissionMode,
       throttledSetMessages,
+      mcpServers,
     ],
   );
 
@@ -459,7 +464,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
     }
     agentRef.current = null;
     setMessages([]);
-    setMcpServers([]);
+    setMcpServerStatuses([]);
     setSlashCommands([]);
     setSessionId("");
     setIsLoading(false);
@@ -737,7 +742,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
     getConfiguredModels,
     setModel,
     isCompacting,
-    mcpServers,
+    mcpServers: mcpServerStatuses,
     connectMcpServer,
     disconnectMcpServer,
     backgroundTasks,

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -94,6 +94,12 @@ export async function main() {
         type: "string",
         global: false,
       })
+      .option("mcp-config", {
+        description:
+          "MCP server configuration as JSON string (same format as .mcp.json)",
+        type: "string",
+        global: false,
+      })
       .option("acp", {
         description: "Run as an ACP bridge",
         type: "boolean",
@@ -284,6 +290,20 @@ export async function main() {
       argv.disallowedTools as string | undefined,
     );
 
+    // Parse MCP server configuration from --mcp-config JSON string
+    let mcpServers:
+      | Record<string, import("wave-agent-sdk").McpServerConfig>
+      | undefined;
+    if (argv.mcpConfig) {
+      try {
+        const parsed = JSON.parse(argv.mcpConfig as string);
+        mcpServers = parsed.mcpServers || parsed;
+      } catch {
+        console.error("Failed to parse --mcp-config as JSON");
+        process.exit(1);
+      }
+    }
+
     // Resolve plugin directories to absolute paths before any worktree logic
     const pluginDirs = (argv.pluginDir as string[] | undefined)?.map((dir) =>
       path.resolve(originalCwd, dir),
@@ -341,6 +361,7 @@ export async function main() {
         workdir,
         version,
         model: argv.model as string | undefined,
+        mcpServers,
       });
     }
 
@@ -364,6 +385,7 @@ export async function main() {
         workdir,
         version,
         model: argv.model as string | undefined,
+        mcpServers,
       });
     }
 
@@ -380,6 +402,7 @@ export async function main() {
       workdir,
       version,
       model: argv.model as string | undefined,
+      mcpServers,
     });
   } catch (error) {
     console.error("Failed to start WAVE Code:", error);

--- a/packages/code/src/print-cli.ts
+++ b/packages/code/src/print-cli.ts
@@ -14,6 +14,8 @@ export interface PrintCliOptions extends BaseAppProps {
   continueLastSession?: boolean;
   message?: string;
   showStats?: boolean;
+  /** MCP server config parsed from --mcp-config CLI argument */
+  mcpServers?: Record<string, import("wave-agent-sdk").McpServerConfig>;
 }
 
 function displayTimingInfo(startTime: Date, showStats: boolean): void {
@@ -46,6 +48,7 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
     worktreeSession,
     workdir,
     model,
+    mcpServers,
   } = options;
 
   if (
@@ -158,6 +161,7 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
       disallowedTools,
       workdir,
       model,
+      mcpServers,
       // 保持流式模式以获得更好的命令行用户体验
     });
 

--- a/packages/code/src/types.ts
+++ b/packages/code/src/types.ts
@@ -1,5 +1,5 @@
 import { WorktreeSession } from "./utils/worktree.js";
-import { PermissionMode } from "wave-agent-sdk";
+import { PermissionMode, McpServerConfig } from "wave-agent-sdk";
 
 export interface BaseAppProps {
   bypassPermissions?: boolean;
@@ -12,4 +12,6 @@ export interface BaseAppProps {
   workdir?: string;
   version?: string;
   model?: string;
+  /** Optional MCP server configs to pass to Agent.create() */
+  mcpServers?: Record<string, McpServerConfig>;
 }


### PR DESCRIPTION
## Summary

Add `mcpServers` field to `AgentOptions` so callers can pass MCP server configs directly at construction time, bypassing `.mcp.json` file.

## Changes

### SDK (packages/agent-sdk)
- **AgentOptions**: add `mcpServers?: Record<string, McpServerConfig>`
- **McpManagerOptions**: accept `mcpServers`, register servers before `loadConfig()`
- **loadConfig**: constructor-provided servers override `.mcp.json` for same-named servers
- **containerSetup.ts**: pass `mcpServers` to `McpManager` constructor

### CLI (packages/code)
- **useChat.tsx**: accept `mcpServers` prop and pass to `Agent.create()`
- **print-cli.ts**: accept `mcpServers` in `PrintCliOptions`
- **index.ts**: add `--mcp-config` CLI argument, parse JSON, thread through
- **cli.tsx**, **App.tsx**: thread `mcpServers` through component tree
- **types.ts**: add `mcpServers` to `BaseAppProps`

### Tests
- 3 new McpManager tests covering constructor server registration, coexistence with file config, and override precedence

## Verification
- Type check passes
- All 3378 tests pass (2428 SDK + 950 code)