### PR TITLE
feat(acp): add MCP server support via ACP

### DIFF
--- a/packages/code/src/acp/agent.ts
+++ b/packages/code/src/acp/agent.ts
@@ -211,6 +211,7 @@ export class WaveAcpAgent implements AcpAgent {
           callbacks.onPermissionModeChange?.(mode),
         onModelChange: (model) => callbacks.onModelChange?.(model),
         onUserMessageAdded: (params) => callbacks.onUserMessageAdded?.(params),
+        onServersChange: (servers) => callbacks.onServersChange?.(servers),
       },
     });
 

--- a/packages/code/src/acp/agent.ts
+++ b/packages/code/src/acp/agent.ts
@@ -49,8 +49,10 @@ import {
   type ResourceLink,
   type EmbeddedResource,
   type ImageContent,
+  type McpServer,
   AGENT_METHODS,
 } from "@agentclientprotocol/sdk";
+import type { McpServerConfig, McpServerStatus } from "wave-agent-sdk";
 
 export class WaveAcpAgent implements AcpAgent {
   private agents: Map<string, WaveAgent> = new Map();
@@ -150,6 +152,7 @@ export class WaveAcpAgent implements AcpAgent {
       },
       agentCapabilities: {
         loadSession: true,
+        mcpCapabilities: { http: true, sse: true },
         sessionCapabilities: {
           list: {},
           close: {},
@@ -169,14 +172,20 @@ export class WaveAcpAgent implements AcpAgent {
   private async createAgent(
     sessionId: string | undefined,
     cwd: string,
+    mcpServers?: McpServer[],
   ): Promise<WaveAgent> {
     const callbacks: AgentOptions["callbacks"] = {};
     const agentRef: { instance?: WaveAgent } = {};
+
+    const sdkMcpServers = mcpServers
+      ? convertAcpMcpServers(mcpServers)
+      : undefined;
 
     const agent = await WaveAgent.create({
       workdir: cwd,
       restoreSessionId: sessionId,
       stream: true,
+      mcpServers: sdkMcpServers,
       canUseTool: (context) => {
         if (!agentRef.instance) {
           throw new Error("Agent instance not yet initialized");
@@ -234,9 +243,9 @@ export class WaveAcpAgent implements AcpAgent {
   }
 
   async newSession(params: NewSessionRequest): Promise<NewSessionResponse> {
-    const { cwd } = params;
+    const { cwd, mcpServers } = params;
     logger.info(`Creating new session in ${cwd}`);
-    const agent = await this.createAgent(undefined, cwd);
+    const agent = await this.createAgent(undefined, cwd, mcpServers);
     logger.info(`New session created with ID: ${agent.sessionId}`);
 
     return {
@@ -247,9 +256,9 @@ export class WaveAcpAgent implements AcpAgent {
   }
 
   async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
-    const { sessionId, cwd } = params;
+    const { sessionId, cwd, mcpServers } = params;
     logger.info(`Loading session: ${sessionId} in ${cwd}`);
-    const agent = await this.createAgent(sessionId, cwd);
+    const agent = await this.createAgent(sessionId, cwd, mcpServers);
 
     return {
       modes: this.getSessionModeState(agent),
@@ -1002,6 +1011,75 @@ export class WaveAcpAgent implements AcpAgent {
           },
         });
       },
+      onServersChange: (servers: McpServerStatus[]) => {
+        for (const server of servers) {
+          this.connection.sessionUpdate({
+            sessionId: sessionId as AcpSessionId,
+            update: {
+              sessionUpdate: "ext_notification" as const,
+              method: "mcp_server_status",
+              params: {
+                name: server.name,
+                status: server.status,
+                toolCount: server.toolCount,
+                error: server.error,
+              },
+            },
+          });
+        }
+      },
     };
   }
+}
+
+/**
+ * Convert ACP McpServer[] to SDK Record<string, McpServerConfig>.
+ */
+function convertAcpMcpServers(
+  servers: McpServer[],
+): Record<string, McpServerConfig> {
+  const result: Record<string, McpServerConfig> = {};
+  for (const server of servers) {
+    const config: McpServerConfig = {};
+    if ("type" in server && server.type === "http") {
+      config.url = server.url;
+      config.headers = convertHttpHeaders(server.headers);
+    } else if ("type" in server && server.type === "sse") {
+      config.url = server.url;
+      config.headers = convertHttpHeaders(server.headers);
+    } else {
+      // stdio (no type discriminator)
+      config.command = server.command;
+      config.args = server.args;
+      config.env = convertEnvVariables(server.env);
+    }
+    result[server.name] = config;
+  }
+  return result;
+}
+
+/**
+ * Convert ACP EnvVariable[] to SDK Record<string, string>.
+ */
+function convertEnvVariables(
+  env: Array<{ name: string; value: string }>,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const entry of env) {
+    result[entry.name] = entry.value;
+  }
+  return result;
+}
+
+/**
+ * Convert ACP HttpHeader[] to SDK Record<string, string>.
+ */
+function convertHttpHeaders(
+  headers: Array<{ name: string; value: string }>,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const entry of headers) {
+    result[entry.name] = entry.value;
+  }
+  return result;
 }

--- a/packages/code/tests/acp/agent.test.ts
+++ b/packages/code/tests/acp/agent.test.ts
@@ -1940,6 +1940,183 @@ describe("WaveAcpAgent", () => {
     );
   });
 
+  it("should pass mcpServers to WaveAgent.create for newSession", async () => {
+    let capturedOptions: AgentOptions;
+    const mockWaveAgent = {
+      sessionId: "session-mcp-1",
+      getPermissionMode: vi.fn().mockReturnValue("default"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+    };
+    vi.mocked(WaveAgent.create).mockImplementation((options: AgentOptions) => {
+      capturedOptions = options;
+      return Promise.resolve(mockWaveAgent as unknown as WaveAgent);
+    });
+
+    await agent.newSession({
+      cwd: "/test",
+      mcpServers: [
+        {
+          name: "filesystem",
+          command: "/path/to/mcp-server",
+          args: ["--stdio"],
+          env: [{ name: "API_KEY", value: "secret" }],
+        },
+      ],
+    });
+
+    expect(capturedOptions!.mcpServers).toEqual({
+      filesystem: {
+        command: "/path/to/mcp-server",
+        args: ["--stdio"],
+        env: { API_KEY: "secret" },
+      },
+    });
+  });
+
+  it("should convert HTTP mcpServers to SDK format", async () => {
+    let capturedOptions: AgentOptions;
+    const mockWaveAgent = {
+      sessionId: "session-http-1",
+      getPermissionMode: vi.fn().mockReturnValue("default"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+    };
+    vi.mocked(WaveAgent.create).mockImplementation((options: AgentOptions) => {
+      capturedOptions = options;
+      return Promise.resolve(mockWaveAgent as unknown as WaveAgent);
+    });
+
+    await agent.newSession({
+      cwd: "/test",
+      mcpServers: [
+        {
+          type: "http",
+          name: "api-server",
+          url: "https://api.example.com/mcp",
+          headers: [{ name: "Authorization", value: "Bearer token123" }],
+        },
+      ],
+    });
+
+    expect(capturedOptions!.mcpServers).toEqual({
+      "api-server": {
+        url: "https://api.example.com/mcp",
+        headers: { Authorization: "Bearer token123" },
+      },
+    });
+  });
+
+  it("should convert SSE mcpServers to SDK format", async () => {
+    let capturedOptions: AgentOptions;
+    const mockWaveAgent = {
+      sessionId: "session-sse-1",
+      getPermissionMode: vi.fn().mockReturnValue("default"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+    };
+    vi.mocked(WaveAgent.create).mockImplementation((options: AgentOptions) => {
+      capturedOptions = options;
+      return Promise.resolve(mockWaveAgent as unknown as WaveAgent);
+    });
+
+    await agent.newSession({
+      cwd: "/test",
+      mcpServers: [
+        {
+          type: "sse",
+          name: "event-stream",
+          url: "https://events.example.com/mcp",
+          headers: [{ name: "X-API-Key", value: "apikey456" }],
+        },
+      ],
+    });
+
+    expect(capturedOptions!.mcpServers).toEqual({
+      "event-stream": {
+        url: "https://events.example.com/mcp",
+        headers: { "X-API-Key": "apikey456" },
+      },
+    });
+  });
+
+  it("should forward onServersChange callback as ext_notification", async () => {
+    let capturedCallbacks: AgentOptions["callbacks"];
+    const mockWaveAgent = {
+      sessionId: "session-servers-1",
+      getPermissionMode: vi.fn().mockReturnValue("default"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+    };
+    vi.mocked(WaveAgent.create).mockImplementation((options: AgentOptions) => {
+      capturedCallbacks = options.callbacks;
+      return Promise.resolve(mockWaveAgent as unknown as WaveAgent);
+    });
+
+    await agent.newSession({ cwd: "/test", mcpServers: [] });
+
+    const callbacks = capturedCallbacks as unknown as Record<string, unknown>;
+    expect(typeof callbacks.onServersChange).toBe("function");
+
+    const onServersChange = callbacks.onServersChange as (
+      servers: import("wave-agent-sdk").McpServerStatus[],
+    ) => void;
+    onServersChange([
+      {
+        name: "filesystem",
+        status: "connected",
+        config: { command: "/path/to/server", args: [] },
+        toolCount: 5,
+      },
+      {
+        name: "api-server",
+        status: "error",
+        config: { url: "https://api.example.com" },
+        error: "Connection refused",
+      },
+    ]);
+
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          sessionUpdate: "ext_notification",
+          method: "mcp_server_status",
+          params: expect.objectContaining({
+            name: "filesystem",
+            status: "connected",
+            toolCount: 5,
+          }),
+        }),
+      }),
+    );
+
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          sessionUpdate: "ext_notification",
+          method: "mcp_server_status",
+          params: expect.objectContaining({
+            name: "api-server",
+            status: "error",
+            error: "Connection refused",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("should advertise mcpCapabilities in initialize response", async () => {
+    const response = await agent.initialize();
+    expect(response.agentCapabilities?.mcpCapabilities).toEqual({
+      http: true,
+      sse: true,
+    });
+  });
+
   it("should include raw JSON content for MCP tools", async () => {
     let capturedCallbacks: AgentOptions["callbacks"];
     const mockWaveAgent = {

--- a/specs/070-acp-bridge/contracts/acp.ts
+++ b/specs/070-acp-bridge/contracts/acp.ts
@@ -38,3 +38,10 @@ export interface AcpPlanUpdate {
     priority: "low" | "medium" | "high";
   }>;
 }
+
+export interface AcpMcpServerStatus {
+  name: string;
+  status: "disconnected" | "connected" | "connecting" | "error";
+  toolCount?: number;
+  error?: string;
+}

--- a/specs/070-acp-bridge/spec.md
+++ b/specs/070-acp-bridge/spec.md
@@ -49,6 +49,19 @@ As a user, I want to see the agent's current task list and plan in my external c
 
 ---
 
+### User Story 4 - MCP Server Support via ACP (Priority: P2)
+
+As an ACP client, I want to provide MCP server configurations when creating or loading a session so that the agent can use external tools from those servers.
+
+**Why this priority**: Enables ACP clients to programmatically configure MCP servers without relying on `.mcp.json` files on disk.
+
+**Acceptance Scenarios**:
+
+1. **Given** the agent is initialized, **When** a client sends a `newSession` request with `mcpServers`, **Then** the agent connects to those MCP servers and makes their tools available.
+2. **Given** an active session with MCP servers, **When** an MCP server's connection status changes, **Then** the agent sends an `mcp_server_status` update via `sessionUpdate` to the client.
+
+---
+
 ### Edge Cases
 
 - **Connection Closure**: If the ACP connection (stdio) is closed, the agent should clean up all active sessions and resources.
@@ -81,6 +94,9 @@ As a user, I want to see the agent's current task list and plan in my external c
 - **FR-012**: System MUST support `resource_link` and `resource` blocks in the `prompt` method, formatting them as markdown-like links `[name](uri)` or `[Resource](uri)` to provide context to the agent.
 - **FR-013**: System MUST join prompt content blocks using a newline to separate different content blocks (text, resource_link, resource).
 - **FR-014**: System MUST advertise support for `image` and `embeddedContext` in `promptCapabilities` during initialization.
+- **FR-015**: System MUST advertise `mcpCapabilities` (http + sse) in the `initialize` response to inform clients of supported MCP transport types.
+- **FR-016**: System MUST accept `mcpServers` in `newSession` and `loadSession` requests, convert them from ACP format to SDK `McpServerConfig`, and pass them to `Agent.create()`.
+- **FR-017**: System MUST send `mcp_server_status` updates via `sessionUpdate` when MCP server status changes (connected, disconnected, connecting, error).
 
 ### Key Entities
 


### PR DESCRIPTION
## Summary

Implements MCP (Model Context Protocol) server support in the ACP bridge, allowing ACP clients to programmatically configure MCP servers when creating or loading sessions.

## Changes

### Spec Update (`specs/070-acp-bridge/spec.md`)
- Added User Story 4 for MCP Server Support via ACP (P2)
- Added **FR-015**: Advertise `mcpCapabilities` (http + sse) in `initialize` response
- Added **FR-016**: Accept `mcpServers` in `newSession` and `loadSession`, convert from ACP format to SDK `McpServerConfig`
- Added **FR-017**: Send `mcp_server_status` updates via `sessionUpdate` when MCP server status changes

### Contract Update (`specs/070-acp-bridge/contracts/acp.ts`)
- Added `AcpMcpServerStatus` interface for MCP server status tracking

### Implementation (`packages/code/src/acp/agent.ts`)
- **Advertise MCP capabilities**: Added `mcpCapabilities: { http: true, sse: true }` to `initialize()` response
- **Convert ACP McpServer to SDK format**: Added `convertAcpMcpServers()` helper that handles all three transport types:
  - Stdio: `{ command, args, env }` (array-based `env`/headers → `Record`)
  - HTTP: `{ url, headers }`
  - SSE: `{ url, headers }`
- **Pass to Agent.create()**: `mcpServers` parameter forwarded to `WaveAgent.create()` for auto-connection
- **Status updates**: Registered `onServersChange` callback to send `ext_notification` with `mcp_server_status` method for each server status change

## Verification

- ✅ `pnpm run type-check` — No type errors
- ✅ `pnpm lint` — No lint errors  
- ✅ `pnpm test` — All 3378 tests pass (2428 SDK + 950 code)
