### PR TITLE
docs(specs): update 003-mcp spec and rename onServersChange callback

### DIFF
--- a/packages/agent-sdk/src/managers/mcpManager.ts
+++ b/packages/agent-sdk/src/managers/mcpManager.ts
@@ -24,7 +24,7 @@ interface McpConnection {
 }
 
 export interface McpManagerCallbacks {
-  onServersChange?: (servers: McpServerStatus[]) => void;
+  onMcpServersChange?: (servers: McpServerStatus[]) => void;
 }
 
 import { logger } from "../utils/globalLogger.js";
@@ -158,7 +158,7 @@ export class McpManager {
 
       logger?.debug("MCP servers initialization started in background");
       // Trigger state change callback after starting initialization
-      this.callbacks.onServersChange?.(this.getAllServers());
+      this.callbacks.onMcpServersChange?.(this.getAllServers());
     }
   }
 
@@ -252,7 +252,7 @@ export class McpManager {
     if (server) {
       this.servers.set(name, { ...server, ...updates });
       // Trigger state change callback
-      this.callbacks.onServersChange?.(this.getAllServers());
+      this.callbacks.onMcpServersChange?.(this.getAllServers());
     }
   }
 

--- a/packages/agent-sdk/tests/managers/mcpManager.test.ts
+++ b/packages/agent-sdk/tests/managers/mcpManager.test.ts
@@ -78,7 +78,7 @@ describe("McpManager", () => {
       const mockCallback = vi.fn();
       const container = new Container();
       const manager = new McpManager(container, {
-        callbacks: { onServersChange: mockCallback },
+        callbacks: { onMcpServersChange: mockCallback },
       });
       expect(manager).toBeInstanceOf(McpManager);
     });

--- a/packages/code/src/acp/agent.ts
+++ b/packages/code/src/acp/agent.ts
@@ -211,7 +211,7 @@ export class WaveAcpAgent implements AcpAgent {
           callbacks.onPermissionModeChange?.(mode),
         onModelChange: (model) => callbacks.onModelChange?.(model),
         onUserMessageAdded: (params) => callbacks.onUserMessageAdded?.(params),
-        onServersChange: (servers) => callbacks.onServersChange?.(servers),
+        onMcpServersChange: (servers) => callbacks.onMcpServersChange?.(servers),
       },
     });
 
@@ -1012,7 +1012,7 @@ export class WaveAcpAgent implements AcpAgent {
           },
         });
       },
-      onServersChange: (servers: McpServerStatus[]) => {
+      onMcpServersChange: (servers: McpServerStatus[]) => {
         for (const server of servers) {
           this.connection.sessionUpdate({
             sessionId: sessionId as AcpSessionId,

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -331,7 +331,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         onMessagesChange: () => {
           throttledSetMessages();
         },
-        onServersChange: (servers) => {
+        onMcpServersChange: (servers) => {
           setMcpServerStatuses([...servers]);
         },
         onSessionIdChange: (sessionId) => {

--- a/packages/code/tests/acp/agent.test.ts
+++ b/packages/code/tests/acp/agent.test.ts
@@ -2043,7 +2043,7 @@ describe("WaveAcpAgent", () => {
     });
   });
 
-  it("should forward onServersChange callback as ext_notification", async () => {
+  it("should forward onMcpServersChange callback as ext_notification", async () => {
     let capturedCallbacks: AgentOptions["callbacks"];
     const mockWaveAgent = {
       sessionId: "session-servers-1",
@@ -2060,12 +2060,12 @@ describe("WaveAcpAgent", () => {
     await agent.newSession({ cwd: "/test", mcpServers: [] });
 
     const callbacks = capturedCallbacks as unknown as Record<string, unknown>;
-    expect(typeof callbacks.onServersChange).toBe("function");
+    expect(typeof callbacks.onMcpServersChange).toBe("function");
 
-    const onServersChange = callbacks.onServersChange as (
+    const onMcpServersChange = callbacks.onMcpServersChange as (
       servers: import("wave-agent-sdk").McpServerStatus[],
     ) => void;
-    onServersChange([
+    onMcpServersChange([
       {
         name: "filesystem",
         status: "connected",

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -175,7 +175,7 @@ describe("ChatProvider", () => {
     Object.assign(mockAgent, { messages: newMessages });
     callbacks.onMessagesChange!(newMessages);
 
-    // Test onServersChange
+    // Test onMcpServersChange
     const newServers = [
       {
         name: "test-server",
@@ -183,7 +183,7 @@ describe("ChatProvider", () => {
         config: { command: "test" },
       },
     ];
-    callbacks.onServersChange!(newServers);
+    callbacks.onMcpServersChange!(newServers);
 
     // Test onSessionIdChange
     callbacks.onSessionIdChange!("new-session");

--- a/specs/003-mcp/contracts/mcp-interfaces.md
+++ b/specs/003-mcp/contracts/mcp-interfaces.md
@@ -52,7 +52,7 @@ export interface McpServerStatus {
 
 ```typescript
 export interface McpManagerCallbacks {
-  onServersChange?: (servers: McpServerStatus[]) => void;
+  onMcpServersChange?: (servers: McpServerStatus[]) => void;
 }
 ```
 

--- a/specs/003-mcp/contracts/mcp-interfaces.md
+++ b/specs/003-mcp/contracts/mcp-interfaces.md
@@ -1,16 +1,29 @@
 # MCP Interfaces
 
-## Configuration
+## SDK Configuration
 
 ```typescript
 export interface McpServerConfig {
-  command: string;
+  command?: string;
   args?: string[];
   env?: Record<string, string>;
+  url?: string;
 }
 
 export interface McpConfig {
   mcpServers: Record<string, McpServerConfig>;
+}
+```
+
+## ACP McpServer (Input from ACP Clients)
+
+```typescript
+export interface McpServer {
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  transport?: "stdio" | "http" | "sse";
 }
 ```
 
@@ -40,5 +53,36 @@ export interface McpServerStatus {
 ```typescript
 export interface McpManagerCallbacks {
   onServersChange?: (servers: McpServerStatus[]) => void;
+}
+```
+
+## Agent Options
+
+```typescript
+export interface AgentOptions {
+  // ... other options
+  mcpServers?: Record<string, McpServerConfig>;
+}
+```
+
+## McpManager Options
+
+```typescript
+export interface McpManagerOptions {
+  callbacks?: McpManagerCallbacks;
+  logger?: Logger;
+  mcpServers?: Record<string, McpServerConfig>;
+}
+```
+
+## ACP Capabilities (in initialize response)
+
+```typescript
+{
+  capabilities: {
+    mcpCapabilities: {
+      transports: ["http", "sse"];
+    }
+  }
 }
 ```

--- a/specs/003-mcp/data-model.md
+++ b/specs/003-mcp/data-model.md
@@ -7,10 +7,25 @@ The root configuration object for MCP.
 - `mcpServers`: A record of server names to their configurations.
 
 ### McpServerConfig
-Configuration for an individual MCP server.
-- `command`: The executable to run.
+Configuration for an individual MCP server (SDK format).
+- `command`: The executable to run (for stdio transport).
 - `args`: (Optional) Arguments for the command.
 - `env`: (Optional) Environment variables for the child process.
+- `url`: (Optional) Endpoint URL (for http/sse transport).
+
+### ACP McpServer (ACP format)
+Configuration from ACP clients, converted to `McpServerConfig`.
+- `command` / `args` / `env`: For stdio transport.
+- `url`: For http or sse transport.
+- `transport`: One of `"stdio"`, `"http"`, `"sse"`.
+
+### Config Merge Precedence
+When multiple config sources exist, they are merged with the following precedence (highest to lowest):
+1. **Constructor `mcpServers`**: Passed via `AgentOptions.mcpServers` or ACP session setup.
+2. **Workspace `.mcp.json`**: Read from the working directory.
+3. **Plugin servers**: Added by plugins at agent creation time.
+
+Constructor-provided servers take precedence for duplicate names; workspace servers are appended if not already present; plugin servers form the base.
 
 ## Runtime State
 
@@ -36,8 +51,8 @@ Represents a tool provided by an MCP server.
 ### McpConnection
 Internal representation of an active connection.
 - `client`: The MCP SDK `Client` instance.
-- `transport`: The `StdioClientTransport` instance.
-- `process`: Currently `null` as `StdioClientTransport` manages the process internally.
+- `transport`: The `StdioClientTransport` or `SSEClientTransport` instance.
+- `process`: Currently `null` as transports manage the process internally.
 
 ## Tool Execution Results
 The result of an MCP tool execution.
@@ -47,3 +62,12 @@ The result of an MCP tool execution.
 - `images`: (Optional) Array of image data objects.
   - `data`: Base64 encoded image data.
   - `mediaType`: MIME type of the image.
+
+## ACP Notification
+Status updates sent to ACP clients via `ext_notification`.
+- `method`: `"mcp_server_status"`
+- `params`: `McpServerStatus` object with current server state.
+
+## MCP Capabilities
+Advertised in ACP `initialize` response.
+- `mcpCapabilities`: `{ transports: ["http", "sse"] }`

--- a/specs/003-mcp/plan.md
+++ b/specs/003-mcp/plan.md
@@ -24,5 +24,15 @@
 2.  **Examples**:
     - Create an example showing how to use MCP with Chrome in `packages/agent-sdk/examples/chrome-mcp.ts`.
 
-## Phase 4: UI Support (Optional/Future)
-1.  **McpManager Component**: Create an Ink component to display and manage MCP server status in the CLI.
+## Phase 4: Constructor & Config Merge Support
+1. **Constructor mcpServers**: Add `mcpServers` field to `AgentOptions` and `McpManagerOptions` so callers can pass server configs at construction time.
+2. **Config Merge**: Implement merge logic in `loadConfig()` where constructor servers > workspace `.mcp.json` > plugin servers.
+3. **CLI Support**: Add `--mcp-config` JSON argument for print and interactive modes.
+
+## Phase 5: ACP MCP Support
+1. **ACP Session Setup**: Accept `mcpServers` in `newSession`/`loadSession` and convert ACP format (stdio/http/sse) to SDK `McpServerConfig`.
+2. **Capabilities**: Advertise `mcpCapabilities` (http + sse) in `initialize` response.
+3. **Status Notifications**: Register `onServersChange` callback to send `ext_notification` with `mcp_server_status` events to ACP clients.
+
+## Phase 6: UI Support (Optional/Future)
+1. **McpManager Component**: Create an Ink component to display and manage MCP server status in the CLI.

--- a/specs/003-mcp/plan.md
+++ b/specs/003-mcp/plan.md
@@ -32,7 +32,7 @@
 ## Phase 5: ACP MCP Support
 1. **ACP Session Setup**: Accept `mcpServers` in `newSession`/`loadSession` and convert ACP format (stdio/http/sse) to SDK `McpServerConfig`.
 2. **Capabilities**: Advertise `mcpCapabilities` (http + sse) in `initialize` response.
-3. **Status Notifications**: Register `onServersChange` callback to send `ext_notification` with `mcp_server_status` events to ACP clients.
+3. **Status Notifications**: Register `onMcpServersChange` callback to send `ext_notification` with `mcp_server_status` events to ACP clients.
 
 ## Phase 6: UI Support (Optional/Future)
 1. **McpManager Component**: Create an Ink component to display and manage MCP server status in the CLI.

--- a/specs/003-mcp/quickstart.md
+++ b/specs/003-mcp/quickstart.md
@@ -26,6 +26,23 @@ const agent = await Agent.create({
 });
 ```
 
+### Alternative: Pass MCP Servers via Constructor
+You can also pass MCP server configurations directly without a `.mcp.json` file:
+
+```typescript
+const agent = await Agent.create({
+  workdir: process.cwd(),
+  mcpServers: {
+    "everything": {
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-everything"]
+    }
+  }
+});
+```
+
+Constructor-provided servers take precedence over `.mcp.json` for duplicate names.
+
 ## 3. Use MCP Tools
 The AI can now use tools from the connected MCP servers. You can also manually interact with MCP servers via the agent API:
 

--- a/specs/003-mcp/spec.md
+++ b/specs/003-mcp/spec.md
@@ -37,12 +37,44 @@ As a user, I want to manually connect or disconnect MCP servers and check their 
 
 ---
 
+### User Story 3 - Pass MCP Servers via Agent Constructor (Priority: P2)
+
+As a developer integrating the SDK, I want to pass MCP server configurations directly to the `Agent` constructor so that I can configure servers programmatically without relying on a `.mcp.json` file.
+
+**Why this priority**: Enables programmatic MCP configuration for SDK consumers (e.g., ACP bridge, custom integrations).
+
+**Independent Test**: Create an `Agent` with `mcpServers` in options and verify servers connect without a `.mcp.json` file.
+
+**Acceptance Scenarios**:
+
+1. **Given** `mcpServers` is passed to `Agent.create()`, **When** the agent initializes, **Then** those servers MUST be registered and connected automatically.
+2. **Given** both constructor `mcpServers` and a `.mcp.json` file exist, **When** the agent loads config, **Then** constructor-provided servers MUST take precedence for duplicate names.
+
+---
+
+### User Story 4 - ACP Clients Configure MCP Servers (Priority: P2)
+
+As an ACP client, I want to specify MCP servers when creating or loading a session so that the agent connects to my configured servers automatically.
+
+**Why this priority**: Enables ACP protocol users (e.g., external IDEs) to manage MCP servers through the session lifecycle.
+
+**Independent Test**: Create an ACP session with `mcpServers` in `newSession` and verify the agent connects and reports status via `ext_notification`.
+
+**Acceptance Scenarios**:
+
+1. **Given** an ACP `newSession` request includes `mcpServers`, **When** the session starts, **Then** the agent MUST convert the ACP server formats (stdio/http/sse) and connect them.
+2. **Given** a connected MCP server, **When** server status changes, **Then** the ACP bridge MUST send an `ext_notification` with `mcp_server_status` to the client.
+3. **Given** the agent initializes with MCP support, **When** it responds to `initialize`, **Then** it MUST advertise `mcpCapabilities` (http + sse).
+
+---
+
 ### Edge Cases
 
 - **Server Crash**: If an MCP server process terminates unexpectedly, the `McpManager` MUST detect the transport error and update the server status to `error`.
 - **Tool Name Collisions**: Tools with the same name from different servers are handled by prefixing them with `mcp__[serverName]__[toolName]`.
 - **Unsupported Schema Fields**: MCP tool schemas containing fields like `$schema`, `exclusiveMinimum`, or `exclusiveMaximum` MUST be cleaned to ensure compatibility with LLM APIs.
 - **Invalid Configuration**: If `.mcp.json` is malformed, the agent SHOULD log an error and proceed without MCP tools.
+- **Config Merge**: When multiple config sources exist (constructor, `.mcp.json`, plugins), they are merged with precedence: constructor > workspace (.mcp.json) > plugin servers.
 
 ## Requirements *(mandatory)*
 
@@ -58,6 +90,11 @@ As a user, I want to manually connect or disconnect MCP servers and check their 
 - **FR-007**: MCP tool execution results MUST support text, images, and resources.
 - **FR-008**: MCP tools MUST trigger permission requests before execution, consistent with built-in restricted tools.
 - **FR-009**: System MUST support persistent "Allow always" rules for MCP tools, stored in the format `mcp__[serverName]__[toolName]`.
+- **FR-011**: `AgentOptions` MUST accept an optional `mcpServers` field to pass MCP server configurations directly at construction time.
+- **FR-012**: When multiple config sources exist (constructor `mcpServers`, `.mcp.json`, plugin-added servers), they MUST be merged with precedence: constructor > workspace > plugin.
+- **FR-013**: ACP bridge MUST accept `mcpServers` in `newSession` and `loadSession` requests, converting ACP `McpServer[]` to SDK `McpServerConfig` format (supporting stdio, http, sse transports).
+- **FR-014**: ACP bridge MUST send `ext_notification` with `mcp_server_status` event type when MCP server status changes.
+- **FR-015**: ACP `initialize` response MUST include `mcpCapabilities` advertising support for http and sse transports.
 
 ### Key Entities *(include if feature involves data)*
 
@@ -68,6 +105,7 @@ As a user, I want to manually connect or disconnect MCP servers and check their 
     - `env`: Environment variables (for stdio).
     - `url`: Endpoint URL (for SSE).
     - `status`: Current connection state.
+    - `transport`: Transport type (`stdio`, `http`, `sse`). (ACP format)
 - **McpTool**: A tool provided by an MCP server.
     - `name`: Original tool name.
     - `registryName`: Prefixed name used in the agent (`mcp__[serverName]__[toolName]`).
@@ -75,6 +113,7 @@ As a user, I want to manually connect or disconnect MCP servers and check their 
 
 ## Assumptions
 
-- MCP servers are local processes communicating via stdio.
+- MCP servers can be local processes (stdio) or remote endpoints (http/sse).
 - The agent has sufficient permissions to execute the commands specified in `.mcp.json`.
 - The `.mcp.json` file is located in the agent's working directory.
+- MCP server configs can be provided via multiple sources: constructor options, workspace `.mcp.json`, plugin configuration, or ACP session setup.

--- a/specs/003-mcp/tasks.md
+++ b/specs/003-mcp/tasks.md
@@ -15,3 +15,10 @@
 - [x] Integrate MCP tools into the permission system
     - [x] Ensure MCP tools trigger permission requests
     - [x] Support persistent "Allow always" rules for MCP tools
+- [x] Add `mcpServers` option to `AgentOptions` for constructor-time configuration
+- [x] Implement config merge: constructor > workspace `.mcp.json` > plugin servers
+- [x] Add CLI `--mcp-config` JSON argument for print and interactive modes
+- [x] ACP: accept `mcpServers` in `newSession`/`loadSession` with stdio/http/sse conversion
+- [x] ACP: advertise `mcpCapabilities` (http + sse) in `initialize` response
+- [x] ACP: send `ext_notification` with `mcp_server_status` on status changes
+- [x] Add ACP MCP server support tests


### PR DESCRIPTION
## Changes

### docs: update 003-mcp spec based on recent commits

Updated `specs/003-mcp/` to reflect recent MCP-related commits:
- **User Story 3**: Constructor `mcpServers` option (19434d05)
- **Config merge precedence**: constructor > workspace > plugin (c3f175af)
- **User Story 4**: ACP MCP server support via newSession/loadSession (a8785801)
- New **FR-011 through FR-015** for constructor config, merge, ACP capabilities
- Updated interfaces: ACP McpServer, mcpCapabilities, AgentOptions
- Updated data model: config merge precedence, ACP notifications
- Updated plan: added Phase 4 (constructor/config) and Phase 5 (ACP)
- Updated tasks: marked constructor and ACP items complete
- Updated quickstart: added constructor `mcpServers` example

### refactor: rename onServersChange to onMcpServersChange for clarity

Renamed `onServersChange` → `onMcpServersChange` across 8 files (source, tests, specs) for better clarity that this is an MCP-specific callback.