### PR TITLE
fix: reorder permission cycle to place bypassPermissions after acceptEdits

### DIFF
--- a/packages/code/src/managers/inputHandlers.ts
+++ b/packages/code/src/managers/inputHandlers.ts
@@ -125,7 +125,12 @@ export const cyclePermissionMode = (
   dispatch: React.Dispatch<InputAction>,
   callbacks: Partial<InputManagerCallbacks>,
 ) => {
-  const modes: PermissionMode[] = ["default", "acceptEdits", "plan", "bypassPermissions"];
+  const modes: PermissionMode[] = [
+    "default",
+    "acceptEdits",
+    "bypassPermissions",
+    "plan",
+  ];
   const currentIndex = modes.indexOf(currentMode);
   const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % modes.length;
   const nextMode = modes[nextIndex];
@@ -760,11 +765,7 @@ export const handleInput = async (
   }
 
   if (key.tab && key.shift) {
-    cyclePermissionMode(
-      state.permissionMode,
-      dispatch,
-      callbacks,
-    );
+    cyclePermissionMode(state.permissionMode, dispatch, callbacks);
     return true;
   }
 

--- a/packages/code/tests/managers/inputHandlers.test.ts
+++ b/packages/code/tests/managers/inputHandlers.test.ts
@@ -236,7 +236,7 @@ describe("inputHandlers", () => {
   describe("cyclePermissionMode", () => {
     it("should cycle through modes including bypassPermissions", () => {
       cyclePermissionMode("default", dispatch, callbacks);
-      expect(dispatch).toHaveBeenCalledWith({
+      expect(dispatch).toHaveBeenNthCalledWith(1, {
         type: "SET_PERMISSION_MODE",
         payload: "acceptEdits",
       });
@@ -245,19 +245,19 @@ describe("inputHandlers", () => {
       );
 
       cyclePermissionMode("acceptEdits", dispatch, callbacks);
-      expect(dispatch).toHaveBeenCalledWith({
-        type: "SET_PERMISSION_MODE",
-        payload: "plan",
-      });
-
-      cyclePermissionMode("plan", dispatch, callbacks);
-      expect(dispatch).toHaveBeenCalledWith({
+      expect(dispatch).toHaveBeenNthCalledWith(2, {
         type: "SET_PERMISSION_MODE",
         payload: "bypassPermissions",
       });
 
       cyclePermissionMode("bypassPermissions", dispatch, callbacks);
-      expect(dispatch).toHaveBeenCalledWith({
+      expect(dispatch).toHaveBeenNthCalledWith(3, {
+        type: "SET_PERMISSION_MODE",
+        payload: "plan",
+      });
+
+      cyclePermissionMode("plan", dispatch, callbacks);
+      expect(dispatch).toHaveBeenNthCalledWith(4, {
         type: "SET_PERMISSION_MODE",
         payload: "default",
       });


### PR DESCRIPTION
Reorder the Shift+Tab permission mode cycle from:

`default → acceptEdits → plan → bypassPermissions → default`

to:

`default → acceptEdits → bypassPermissions → plan → default`

Also updated test assertions to use `toHaveBeenNthCalledWith` for proper sequential verification.