### PR TITLE
fix: replace hardcoded gemini-2.5-flash with WAVE_FAST_MODEL in examples

### DIFF
--- a/.wave/rules/examples.md
+++ b/.wave/rules/examples.md
@@ -6,7 +6,7 @@ paths:
   - need to create temporary directories
   - test by sending real messages using `agent.sendMessage`
   - run example like this: `cd packages/xxx && pnpm exec tsx examples/hi.ts`
-  - use `gemini-2.5-flash` for cheaper and faster testing (pass as `agentModel` in `Agent.create`)
+  - use `process.env.WAVE_FAST_MODEL` for cheaper and faster testing (pass as `model` in `Agent.create`)
   - always include a `finally` block that calls `await agent.destroy()` followed by `process.exit(0)` to ensure the process exits cleanly
   - never access private properties directly with `(agent as any)`
   - before running any example, always run type-check for `agent-sdk` to ensure types are valid: `cd packages/agent-sdk && pnpm run type-check`

--- a/packages/agent-sdk/examples/agent-config-validation.ts
+++ b/packages/agent-sdk/examples/agent-config-validation.ts
@@ -20,7 +20,7 @@ async function validateAgentConfiguration() {
       apiKey: "test-api-key-here",
       baseURL: "https://test-gateway.com",
       model: "gemini-3-flash",
-      fastModel: "gemini-2.5-flash",
+      fastModel: process.env.WAVE_FAST_MODEL,
       maxInputTokens: 50000,
       workdir: "./project",
     });
@@ -245,8 +245,8 @@ async function validateAgentConfiguration() {
       model:
         process.env.NODE_ENV === "production"
           ? "gemini-3-flash"
-          : "gemini-2.5-flash",
-      fastModel: "gemini-2.5-flash",
+          : process.env.WAVE_FAST_MODEL,
+      fastModel: process.env.WAVE_FAST_MODEL,
       maxInputTokens: process.env.NODE_ENV === "production" ? 96000 : 10000,
       workdir: process.cwd(),
     });

--- a/packages/agent-sdk/examples/auto-memory-demo.ts
+++ b/packages/agent-sdk/examples/auto-memory-demo.ts
@@ -24,7 +24,7 @@ async function main() {
 
     const agent = await Agent.create({
       workdir: tempDir,
-      model: "gemini-2.5-flash",
+      model: process.env.WAVE_FAST_MODEL,
       logger: {
         debug: (message: unknown, ...args: unknown[]) => {
           console.debug(`[DEBUG] ${message}`, ...args);

--- a/packages/agent-sdk/examples/backgrounding-demo.ts
+++ b/packages/agent-sdk/examples/backgrounding-demo.ts
@@ -16,7 +16,7 @@ async function demonstrateBackgrounding(): Promise<void> {
     // Create agent with bash tool enabled
     agent = await Agent.create({
       workdir,
-      model: "gemini-2.5-flash",
+      model: process.env.WAVE_FAST_MODEL,
       permissionMode: "bypassPermissions", // Ensure tools can run without permission prompts
       callbacks: {
         onAssistantContentUpdated: () => {

--- a/packages/agent-sdk/examples/btw-command-demo.ts
+++ b/packages/agent-sdk/examples/btw-command-demo.ts
@@ -8,7 +8,7 @@ async function main() {
   // Initialize the agent with a cheap model for testing
   const agent = await Agent.create({
     workdir: process.cwd(),
-    model: "gemini-2.5-flash",
+    model: process.env.WAVE_FAST_MODEL,
     permissionMode: "bypassPermissions", // Allow memory access to keep history clean
     callbacks: {
       onAssistantContentUpdated: (chunk) => {

--- a/packages/agent-sdk/examples/chrome-mcp.ts
+++ b/packages/agent-sdk/examples/chrome-mcp.ts
@@ -10,7 +10,7 @@ console.log("🌐 Testing Chrome MCP screenshot functionality...\n");
 let tempDir: string;
 let agent: Agent;
 
-process.env.WAVE_MODEL = "gemini-2.5-flash";
+process.env.WAVE_MODEL = process.env.WAVE_FAST_MODEL;
 
 async function setupTest() {
   // Create temporary directory

--- a/packages/agent-sdk/examples/custom-tools.ts
+++ b/packages/agent-sdk/examples/custom-tools.ts
@@ -10,7 +10,7 @@ console.log("🔢 Testing Custom Tools MCP - Simple Example...\n");
 let tempDir: string;
 let agent: Agent;
 
-process.env.WAVE_MODEL = "gemini-2.5-flash";
+process.env.WAVE_MODEL = process.env.WAVE_FAST_MODEL;
 
 async function setupTest() {
   // Create temporary directory

--- a/packages/agent-sdk/examples/general-purpose-agent.ts
+++ b/packages/agent-sdk/examples/general-purpose-agent.ts
@@ -3,7 +3,7 @@ import { Agent } from "../src/agent.js";
 async function main() {
   const agent = await Agent.create({
     workdir: process.cwd(),
-    model: "gemini-2.5-flash",
+    model: process.env.WAVE_FAST_MODEL,
     callbacks: {
       onSubagentAssistantMessageAdded: (subagentId) => {
         const instance = agent.getSubagentInstance(subagentId);

--- a/packages/agent-sdk/examples/hook-exitcode-blocking.ts
+++ b/packages/agent-sdk/examples/hook-exitcode-blocking.ts
@@ -209,7 +209,7 @@ async function demonstrateBlockingErrors(): Promise<void> {
     // Create Agent instance
     const agent = await Agent.create({
       workdir: hookDir,
-      model: "gemini-2.5-flash",
+      model: process.env.WAVE_FAST_MODEL,
       logger: console,
       callbacks: {
         onAssistantContentUpdated: (chunk: string) => {

--- a/packages/agent-sdk/examples/hook-exitcode-nonblocking.ts
+++ b/packages/agent-sdk/examples/hook-exitcode-nonblocking.ts
@@ -223,7 +223,7 @@ async function demonstrateNonBlockingErrors(): Promise<void> {
     // Create Agent instance
     const agent = await Agent.create({
       workdir: hookDir,
-      model: "gemini-2.5-flash",
+      model: process.env.WAVE_FAST_MODEL,
       logger: console,
       callbacks: {
         onAssistantContentUpdated: (chunk: string) => {

--- a/packages/agent-sdk/examples/hook-exitcode-success.ts
+++ b/packages/agent-sdk/examples/hook-exitcode-success.ts
@@ -157,7 +157,7 @@ async function demonstrateSuccessExitCodes(): Promise<void> {
     // Create Agent instance
     const agent = await Agent.create({
       workdir: hookDir,
-      model: "gemini-2.5-flash",
+      model: process.env.WAVE_FAST_MODEL,
       logger: console,
       callbacks: {
         onAssistantContentUpdated: (chunk: string) => {

--- a/packages/agent-sdk/examples/hooks/test-async-hook.ts
+++ b/packages/agent-sdk/examples/hooks/test-async-hook.ts
@@ -18,7 +18,7 @@ async function main() {
   }
 
   const agent = await Agent.create({
-    model: "gemini-2.5-flash",
+    model: process.env.WAVE_FAST_MODEL,
     workdir: projectDir,
     // We'll manually trigger the hook by simulating an Edit tool use
   });

--- a/packages/agent-sdk/examples/loop-command-demo.ts
+++ b/packages/agent-sdk/examples/loop-command-demo.ts
@@ -18,7 +18,7 @@ async function main() {
   // 1. Create Agent instance
   const agent = await Agent.create({
     workdir: tempDir,
-    model: "gemini-2.5-flash", // Use a supported model
+    model: process.env.WAVE_FAST_MODEL, // Use a supported model
     callbacks: {
       onAssistantContentUpdated: (chunk) => {
         process.stdout.write(chunk);

--- a/packages/agent-sdk/examples/modular-rules-basic.ts
+++ b/packages/agent-sdk/examples/modular-rules-basic.ts
@@ -71,7 +71,7 @@ paths:
 
     agent = await Agent.create({
       workdir: testDir,
-      model: "gemini-2.5-flash",
+      model: process.env.WAVE_FAST_MODEL,
       logger: {
         debug: (...args: unknown[]) => console.log("[DEBUG]", ...args),
         info: (...args: unknown[]) => console.log("[INFO]", ...args),

--- a/packages/agent-sdk/examples/modular-rules-demo.ts
+++ b/packages/agent-sdk/examples/modular-rules-demo.ts
@@ -175,7 +175,7 @@ async function demoModularRules(): Promise<void> {
 
     agent = await Agent.create({
       workdir: testDir,
-      model: "gemini-2.5-flash",
+      model: process.env.WAVE_FAST_MODEL,
       logger: {
         debug: (...args: unknown[]) => {
           const message = args[0];

--- a/packages/agent-sdk/examples/parallel-execution-demo.ts
+++ b/packages/agent-sdk/examples/parallel-execution-demo.ts
@@ -26,7 +26,7 @@ async function demonstrateParallelExecution(): Promise<void> {
     // Create agent with bash tool enabled and callbacks for timing
     const agent = await Agent.create({
       workdir,
-      model: "gemini-2.5-flash",
+      model: process.env.WAVE_FAST_MODEL,
       callbacks: {
         onAssistantContentUpdated: (chunk: string) => {
           process.stdout.write(chunk);

--- a/packages/agent-sdk/examples/permission-deny-config.ts
+++ b/packages/agent-sdk/examples/permission-deny-config.ts
@@ -36,7 +36,7 @@ async function main() {
 
   // 3. Initialize the agent pointing to the temporary directory
   const agent = await Agent.create({
-    model: "gemini-2.5-flash",
+    model: process.env.WAVE_FAST_MODEL,
     workdir: tempDir,
     callbacks: {
       onToolBlockUpdated: (params) => {

--- a/packages/agent-sdk/examples/read-image-demo.ts
+++ b/packages/agent-sdk/examples/read-image-demo.ts
@@ -45,7 +45,7 @@ async function runDemo() {
 
     // Create Agent
     agent = await Agent.create({
-      model: "gemini-2.5-flash",
+      model: process.env.WAVE_FAST_MODEL,
       callbacks: {
         onToolBlockUpdated: (params) => {
           if (params.stage === "start") {

--- a/packages/agent-sdk/examples/read-tool-image-test.ts
+++ b/packages/agent-sdk/examples/read-tool-image-test.ts
@@ -108,7 +108,7 @@ async function testWithAgent() {
   }> = [];
 
   agent = await Agent.create({
-    model: "gemini-2.5-flash",
+    model: process.env.WAVE_FAST_MODEL,
     callbacks: {
       onToolBlockUpdated: (params) => {
         if (params.stage === "start") {

--- a/packages/agent-sdk/examples/should-defer-demo.ts
+++ b/packages/agent-sdk/examples/should-defer-demo.ts
@@ -7,8 +7,8 @@ import { Agent } from "../src/agent.js";
 
 const agent = await Agent.create({
   permissionMode: "bypassPermissions",
-  model: "gemini-2.5-flash",
-  fastModel: "gemini-2.5-flash",
+  model: process.env.WAVE_FAST_MODEL,
+  fastModel: process.env.WAVE_FAST_MODEL,
   callbacks: {
     onToolBlockUpdated: (params) => {
       if (params.stage === "start") {

--- a/packages/agent-sdk/examples/skill-args-bash.ts
+++ b/packages/agent-sdk/examples/skill-args-bash.ts
@@ -47,7 +47,7 @@ This skill was invoked with arguments and executed bash commands.
     );
 
     agent = await Agent.create({
-      model: "gemini-2.5-flash", // Using a fast model as suggested
+      model: process.env.WAVE_FAST_MODEL, // Using a fast model as suggested
       workdir: tempDir,
       callbacks: {
         onAssistantContentUpdated: (chunk: string) => {

--- a/packages/agent-sdk/examples/subagent-execution.ts
+++ b/packages/agent-sdk/examples/subagent-execution.ts
@@ -34,11 +34,11 @@ async function setupTest() {
   const agentsDir = path.join(tempDir, ".wave", "agents");
   await fs.mkdir(agentsDir, { recursive: true });
 
-  // Create a simple subagent configuration in markdown format with gemini-2.5-flash model
+  // Create a simple subagent configuration in markdown format with WAVE_FAST_MODEL
   const subagentContent = `---
 name: file-analyzer
 description: Analyzes files and provides summaries
-model: gemini-2.5-flash
+model: ${process.env.WAVE_FAST_MODEL}
 tools: [Read, Glob]
 ---
 

--- a/packages/agent-sdk/examples/task-management-demo.ts
+++ b/packages/agent-sdk/examples/task-management-demo.ts
@@ -7,7 +7,7 @@ import { Agent } from "../src/agent.js";
 async function main() {
   // 1. Create Agent instance
   const agent = await Agent.create({
-    model: "gemini-2.5-flash", // Use a fast model for testing
+    model: process.env.WAVE_FAST_MODEL, // Use a fast model for testing
     callbacks: {
       onAssistantContentUpdated: (chunk) => {
         process.stdout.write(chunk);

--- a/packages/agent-sdk/examples/tavily-mcp-example.ts
+++ b/packages/agent-sdk/examples/tavily-mcp-example.ts
@@ -47,7 +47,7 @@ async function main() {
     agent = await Agent.create({
       workdir: workDir,
       name: "tavily-test-agent",
-      model: "gemini-2.5-flash", // Using a fast model for the demo
+      model: process.env.WAVE_FAST_MODEL, // Using a fast model for the demo
       permissionMode: "bypassPermissions", // Bypass permissions for the demo to allow tool usage
       systemPrompt:
         "You are a helpful assistant. When asked to search, use the tavily_search tool. Answer briefly.",

--- a/packages/agent-sdk/examples/web-fetch-demo.ts
+++ b/packages/agent-sdk/examples/web-fetch-demo.ts
@@ -10,8 +10,8 @@ console.log("🌐 Testing WebFetch Tool - Example...\n");
 let tempDir: string;
 let agent: Agent;
 
-// Use gemini-2.5-flash for cheaper and faster testing
-process.env.WAVE_MODEL = "gemini-2.5-flash";
+// Use WAVE_FAST_MODEL for cheaper and faster testing
+process.env.WAVE_MODEL = process.env.WAVE_FAST_MODEL;
 
 async function setupTest() {
   // Create temporary directory


### PR DESCRIPTION
## Summary

Replaced all hardcoded `gemini-2.5-flash` model strings with `process.env.WAVE_FAST_MODEL` across 22 example files and updated the examples memory rule.

## Changes

- **22 example files**: Replaced `model: "gemini-2.5-flash"` and `fastModel: "gemini-2.5-flash"` with `process.env.WAVE_FAST_MODEL`
- **`.wave/rules/examples.md`**: Updated documentation to use `process.env.WAVE_FAST_MODEL` and deprecated `agentModel` → `model`
- Verified working by running `btw-command-demo.ts` successfully

## Files Modified

- `.wave/rules/examples.md`
- `packages/agent-sdk/examples/agent-config-validation.ts`
- `packages/agent-sdk/examples/auto-memory-demo.ts`
- `packages/agent-sdk/examples/backgrounding-demo.ts`
- `packages/agent-sdk/examples/btw-command-demo.ts`
- `packages/agent-sdk/examples/chrome-mcp.ts`
- `packages/agent-sdk/examples/custom-tools.ts`
- `packages/agent-sdk/examples/general-purpose-agent.ts`
- `packages/agent-sdk/examples/hook-exitcode-blocking.ts`
- `packages/agent-sdk/examples/hook-exitcode-nonblocking.ts`
- `packages/agent-sdk/examples/hook-exitcode-success.ts`
- `packages/agent-sdk/examples/hooks/test-async-hook.ts`
- `packages/agent-sdk/examples/loop-command-demo.ts`
- `packages/agent-sdk/examples/modular-rules-basic.ts`
- `packages/agent-sdk/examples/modular-rules-demo.ts`
- `packages/agent-sdk/examples/parallel-execution-demo.ts`
- `packages/agent-sdk/examples/permission-deny-config.ts`
- `packages/agent-sdk/examples/read-image-demo.ts`
- `packages/agent-sdk/examples/read-tool-image-test.ts`
- `packages/agent-sdk/examples/should-defer-demo.ts`
- `packages/agent-sdk/examples/skill-args-bash.ts`
- `packages/agent-sdk/examples/subagent-execution.ts`
- `packages/agent-sdk/examples/task-management-demo.ts`
- `packages/agent-sdk/examples/tavily-mcp-example.ts`
- `packages/agent-sdk/examples/web-fetch-demo.ts`