### PR TITLE
refactor(sdk): split auto memory and plan/deferred tools from system prompt to user meta messages

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -522,6 +522,100 @@ export class AIManager {
     return this.container.get<SkillManager>("SkillManager");
   }
 
+  /**
+   * Build plan mode instruction message as a <system-reminder> wrapped string.
+   * Matches Claude Code's wrapMessagesInSystemReminder pattern.
+   */
+  private buildPlanModeMessage(options: {
+    planFilePath: string;
+    planExists: boolean;
+    isSubagent: boolean;
+  }): string {
+    const { planFilePath, planExists, isSubagent } = options;
+    const planFileInfo = planExists
+      ? `A plan file already exists at ${planFilePath}. You can read it and make incremental edits using the Edit tool.`
+      : `No plan file exists yet. You should create your plan at ${planFilePath} using the Write tool.`;
+
+    if (isSubagent) {
+      return `<system-reminder>Plan mode is active. The user indicated that they do not want you to execute yet -- you MUST NOT make any edits, run any non-readonly tools (including changing configs or making commits), or otherwise make any changes to the system. This supersedes any other instructions you have received.
+
+## Plan File Info:
+${planFileInfo}
+You should build your plan incrementally by writing to or editing this file. NOTE that this is the only file you are allowed to edit - other than this you are only allowed to take READ-ONLY actions.
+Answer the user's query comprehensively, using the AskUserQuestion tool if you need to ask the user clarifying questions.</system-reminder>`;
+    }
+
+    return `<system-reminder>Plan mode is active. The user indicated that they do not want you to execute yet -- you MUST NOT make any edits (with the exception of the plan file mentioned below), run any non-readonly tools (including changing configs or making commits), or otherwise make any changes to the system. This supersedes any other instructions you have received.
+
+## Plan File Info:
+${planFileInfo}
+You should build your plan incrementally by writing to or editing this file. NOTE that this is the only file you are allowed to edit - other than this you are only allowed to take READ-ONLY actions.
+
+## Plan Workflow
+
+### Phase 1: Initial Understanding
+Goal: Gain a comprehensive understanding of the user's request by reading through code and asking them questions. Critical: In this phase you should only use the Agent tool with subagent_type=explore.
+
+1. Focus on understanding the user's request and the code associated with their request. Actively search for existing functions, utilities, and patterns that can be reused — avoid proposing new code when suitable implementations already exist.
+
+2. **Launch up to 3 explore agents IN PARALLEL** (single message, multiple tool calls) to efficiently explore the codebase.
+   - Use 1 agent when the task is isolated to known files, the user provided specific file paths, or you're making a small targeted change.
+   - Use multiple agents when: the scope is uncertain, multiple areas of the codebase are involved, or you need to understand existing patterns before planning.
+   - Quality over quantity - 3 agents maximum, but you should try to use the minimum number of agents necessary (usually just 1)
+   - If using multiple agents: Provide each agent with a specific search focus or area to explore. Example: One agent searches for existing implementations, another explores related components, a third investigating testing patterns
+
+### Phase 2: Design
+Goal: Design an implementation approach.
+
+Launch agent(s) with subagent_type=plan to design the implementation based on the user's intent and your exploration results from Phase 1.
+
+You can launch up to 3 agent(s) in parallel.
+
+**Guidelines:**
+- **Default**: Launch at least 1 Plan agent for most tasks - it helps validate your understanding and consider alternatives
+- **Skip agents**: Only for truly trivial tasks (typo fixes, single-line changes, simple renames)
+- **Multiple agents**: Use up to 3 agents for complex tasks that benefit from different perspectives
+
+Examples of when to use multiple agents:
+- The task touches multiple parts of the codebase
+- It's a large refactor or architectural change
+- There are many edge cases to consider
+- You'd benefit from exploring different approaches
+
+Example perspectives by task type:
+- New feature: simplicity vs performance vs maintainability
+- Bug fix: root cause vs workaround vs prevention
+- Refactoring: minimal change vs clean architecture
+
+In the agent prompt:
+- Provide comprehensive background context from Phase 1 exploration including filenames and code path traces
+- Describe requirements and constraints
+- Request a detailed implementation plan
+
+### Phase 3: Review
+Goal: Review the plan(s) from Phase 2 and ensure alignment with the user's intentions.
+1. Read the critical files identified by agents to deepen your understanding
+2. Ensure that the plans align with the user's original request
+3. Use AskUserQuestion to clarify any remaining questions with the user
+
+### Phase 4: Final Plan
+Goal: Write your final plan to the plan file (the only file you can edit).
+- Begin with a **Context** section: explain why this change is being made — the problem or need it addresses, what prompted it, and the intended outcome
+- Include only your recommended approach, not all alternatives
+- Ensure that the plan file is concise enough to scan quickly, but detailed enough to execute effectively
+- Include the paths of critical files to be modified
+- Reference existing functions and utilities you found that should be reused, with their file paths
+- Include a verification section describing how to test the changes end-to-end (run the code, use MCP tools, run tests)
+
+### Phase 5: Call ExitPlanMode
+At the very end of your turn, once you have asked the user questions and are happy with your final plan file - you should always call ExitPlanMode to indicate to the user that you are done planning.
+This is critical - your turn should only end with either using the AskUserQuestion tool OR calling ExitPlanMode. Do not stop unless it's for these 2 reasons
+
+**Important:** Use AskUserQuestion ONLY to clarify requirements or choose between approaches. Use ExitPlanMode to request plan approval. Do NOT ask about plan approval in any other way - no text questions, no AskUserQuestion. Phrases like "Is this plan okay?", "Should I proceed?", "How does this plan look?", "Any changes before we start?", or similar MUST use ExitPlanMode.
+
+NOTE: At any point in time through this workflow you should feel free to ask the user questions or clarifications using the AskUserQuestion tool. Don't make large assumptions about user intent. The goal is to present a well researched plan to the user, and tie any loose ends before implementation begins.</system-reminder>`;
+  }
+
   public async sendAIMessage(
     options: {
       recursionDepth?: number;
@@ -589,6 +683,32 @@ export class AIManager {
     });
     const recentMessages = convertMessagesForAPI(microcompactedMessages);
 
+    // Get current permission mode and plan file path (needed for meta message injection)
+    const currentMode = this.permissionManager?.getCurrentEffectiveMode(
+      this.getModelConfig().permissionMode,
+    );
+    let planModeOptions:
+      | { planFilePath: string; planExists: boolean; isSubagent: boolean }
+      | undefined;
+
+    if (currentMode === "plan") {
+      const planFilePath = this.permissionManager?.getPlanFilePath();
+      if (planFilePath) {
+        let planExists = false;
+        try {
+          await fs.access(planFilePath);
+          planExists = true;
+        } catch {
+          planExists = false;
+        }
+        planModeOptions = {
+          planFilePath,
+          planExists,
+          isSubagent: !!this.subagentType,
+        };
+      }
+    }
+
     // Inject deferred tools as a user meta message (matching Claude Code pattern).
     // Placed in messages rather than system prompt to preserve prompt cache stability
     // when MCP servers connect/disconnect.
@@ -597,6 +717,16 @@ export class AIManager {
       recentMessages.unshift({
         role: "user",
         content: `<available-deferred-tools>\n${deferredToolNames.join(" ")}\nThese tools are NOT loaded yet — call ToolSearch first to discover their schemas before invoking them.</available-deferred-tools>`,
+      });
+    }
+
+    // Inject plan mode instructions as a user meta message (matching Claude Code pattern).
+    // Placed in messages rather than system prompt to preserve prompt cache stability.
+    if (planModeOptions) {
+      const planModeMessage = this.buildPlanModeMessage(planModeOptions);
+      recentMessages.unshift({
+        role: "user",
+        content: planModeMessage,
       });
     }
 
@@ -609,33 +739,11 @@ export class AIManager {
 
       logger?.debug("modelConfig in sendAIMessage", this.getModelConfig());
 
-      // Get current permission mode and plan file path
-      const currentMode = this.permissionManager?.getCurrentEffectiveMode(
-        this.getModelConfig().permissionMode,
-      );
       const toolsConfig = this.getFilteredToolsConfig();
       const toolNames = new Set(toolsConfig.map((t) => t.function.name));
       const filteredToolPlugins = this.toolManager
         .getTools()
         .filter((t) => toolNames.has(t.name));
-
-      let planModeOptions:
-        | { planFilePath: string; planExists: boolean }
-        | undefined;
-
-      if (currentMode === "plan") {
-        const planFilePath = this.permissionManager?.getPlanFilePath();
-        if (planFilePath) {
-          let planExists = false;
-          try {
-            await fs.access(planFilePath);
-            planExists = true;
-          } catch {
-            planExists = false;
-          }
-          planModeOptions = { planFilePath, planExists };
-        }
-      }
 
       let autoMemoryOptions: { directory: string; content: string } | undefined;
 
@@ -667,7 +775,6 @@ export class AIManager {
             memory: combinedMemory,
             language: this.getLanguage(),
             isSubagent: !!this.subagentType,
-            planMode: planModeOptions,
             autoMemory: autoMemoryOptions,
             permissionMode: currentMode,
           },

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -589,6 +589,17 @@ export class AIManager {
     });
     const recentMessages = convertMessagesForAPI(microcompactedMessages);
 
+    // Inject deferred tools as a user meta message (matching Claude Code pattern).
+    // Placed in messages rather than system prompt to preserve prompt cache stability
+    // when MCP servers connect/disconnect.
+    const deferredToolNames = this.toolManager.getDeferredToolNames();
+    if (deferredToolNames.length > 0) {
+      recentMessages.unshift({
+        role: "user",
+        content: `<available-deferred-tools>\n${deferredToolNames.join(" ")}\nThese tools are NOT loaded yet — call ToolSearch first to discover their schemas before invoking them.</available-deferred-tools>`,
+      });
+    }
+
     try {
       // Get combined memory content
       const combinedMemory = await this.messageManager.getCombinedMemory();

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -22,7 +22,7 @@ import type { ExtendedHookExecutionContext } from "../types/hooks.js";
 import type { PermissionManager } from "./permissionManager.js";
 import type { SubagentManager } from "./subagentManager.js";
 import type { SkillManager } from "./skillManager.js";
-import { buildSystemPrompt } from "../prompts/index.js";
+import { buildSystemPrompt, buildPlanModePrompt } from "../prompts/index.js";
 import { Container } from "../utils/container.js";
 import { recoverTruncatedJson } from "../utils/stringUtils.js";
 import { ConfigurationService } from "../services/configurationService.js";
@@ -531,89 +531,12 @@ export class AIManager {
     planExists: boolean;
     isSubagent: boolean;
   }): string {
-    const { planFilePath, planExists, isSubagent } = options;
-    const planFileInfo = planExists
-      ? `A plan file already exists at ${planFilePath}. You can read it and make incremental edits using the Edit tool.`
-      : `No plan file exists yet. You should create your plan at ${planFilePath} using the Write tool.`;
-
-    if (isSubagent) {
-      return `<system-reminder>Plan mode is active. The user indicated that they do not want you to execute yet -- you MUST NOT make any edits, run any non-readonly tools (including changing configs or making commits), or otherwise make any changes to the system. This supersedes any other instructions you have received.
-
-## Plan File Info:
-${planFileInfo}
-You should build your plan incrementally by writing to or editing this file. NOTE that this is the only file you are allowed to edit - other than this you are only allowed to take READ-ONLY actions.
-Answer the user's query comprehensively, using the AskUserQuestion tool if you need to ask the user clarifying questions.</system-reminder>`;
-    }
-
-    return `<system-reminder>Plan mode is active. The user indicated that they do not want you to execute yet -- you MUST NOT make any edits (with the exception of the plan file mentioned below), run any non-readonly tools (including changing configs or making commits), or otherwise make any changes to the system. This supersedes any other instructions you have received.
-
-## Plan File Info:
-${planFileInfo}
-You should build your plan incrementally by writing to or editing this file. NOTE that this is the only file you are allowed to edit - other than this you are only allowed to take READ-ONLY actions.
-
-## Plan Workflow
-
-### Phase 1: Initial Understanding
-Goal: Gain a comprehensive understanding of the user's request by reading through code and asking them questions. Critical: In this phase you should only use the Agent tool with subagent_type=explore.
-
-1. Focus on understanding the user's request and the code associated with their request. Actively search for existing functions, utilities, and patterns that can be reused — avoid proposing new code when suitable implementations already exist.
-
-2. **Launch up to 3 explore agents IN PARALLEL** (single message, multiple tool calls) to efficiently explore the codebase.
-   - Use 1 agent when the task is isolated to known files, the user provided specific file paths, or you're making a small targeted change.
-   - Use multiple agents when: the scope is uncertain, multiple areas of the codebase are involved, or you need to understand existing patterns before planning.
-   - Quality over quantity - 3 agents maximum, but you should try to use the minimum number of agents necessary (usually just 1)
-   - If using multiple agents: Provide each agent with a specific search focus or area to explore. Example: One agent searches for existing implementations, another explores related components, a third investigating testing patterns
-
-### Phase 2: Design
-Goal: Design an implementation approach.
-
-Launch agent(s) with subagent_type=plan to design the implementation based on the user's intent and your exploration results from Phase 1.
-
-You can launch up to 3 agent(s) in parallel.
-
-**Guidelines:**
-- **Default**: Launch at least 1 Plan agent for most tasks - it helps validate your understanding and consider alternatives
-- **Skip agents**: Only for truly trivial tasks (typo fixes, single-line changes, simple renames)
-- **Multiple agents**: Use up to 3 agents for complex tasks that benefit from different perspectives
-
-Examples of when to use multiple agents:
-- The task touches multiple parts of the codebase
-- It's a large refactor or architectural change
-- There are many edge cases to consider
-- You'd benefit from exploring different approaches
-
-Example perspectives by task type:
-- New feature: simplicity vs performance vs maintainability
-- Bug fix: root cause vs workaround vs prevention
-- Refactoring: minimal change vs clean architecture
-
-In the agent prompt:
-- Provide comprehensive background context from Phase 1 exploration including filenames and code path traces
-- Describe requirements and constraints
-- Request a detailed implementation plan
-
-### Phase 3: Review
-Goal: Review the plan(s) from Phase 2 and ensure alignment with the user's intentions.
-1. Read the critical files identified by agents to deepen your understanding
-2. Ensure that the plans align with the user's original request
-3. Use AskUserQuestion to clarify any remaining questions with the user
-
-### Phase 4: Final Plan
-Goal: Write your final plan to the plan file (the only file you can edit).
-- Begin with a **Context** section: explain why this change is being made — the problem or need it addresses, what prompted it, and the intended outcome
-- Include only your recommended approach, not all alternatives
-- Ensure that the plan file is concise enough to scan quickly, but detailed enough to execute effectively
-- Include the paths of critical files to be modified
-- Reference existing functions and utilities you found that should be reused, with their file paths
-- Include a verification section describing how to test the changes end-to-end (run the code, use MCP tools, run tests)
-
-### Phase 5: Call ExitPlanMode
-At the very end of your turn, once you have asked the user questions and are happy with your final plan file - you should always call ExitPlanMode to indicate to the user that you are done planning.
-This is critical - your turn should only end with either using the AskUserQuestion tool OR calling ExitPlanMode. Do not stop unless it's for these 2 reasons
-
-**Important:** Use AskUserQuestion ONLY to clarify requirements or choose between approaches. Use ExitPlanMode to request plan approval. Do NOT ask about plan approval in any other way - no text questions, no AskUserQuestion. Phrases like "Is this plan okay?", "Should I proceed?", "How does this plan look?", "Any changes before we start?", or similar MUST use ExitPlanMode.
-
-NOTE: At any point in time through this workflow you should feel free to ask the user questions or clarifications using the AskUserQuestion tool. Don't make large assumptions about user intent. The goal is to present a well researched plan to the user, and tie any loose ends before implementation begins.</system-reminder>`;
+    const prompt = buildPlanModePrompt(
+      options.planFilePath,
+      options.planExists,
+      options.isSubagent,
+    );
+    return `<system-reminder>${prompt}</system-reminder>`;
   }
 
   public async sendAIMessage(
@@ -709,6 +632,55 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       }
     }
 
+    // Get memory content (for user meta message injection)
+    let combinedMemory: string = "";
+    try {
+      combinedMemory = await this.messageManager.getCombinedMemory();
+    } catch (error) {
+      this.messageManager.addErrorBlock(
+        `Failed to read memory: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      this.setIsLoading(false);
+      return;
+    }
+
+    let autoMemoryDirectory: string | undefined;
+    let autoMemoryContent: string | undefined;
+    if (this.getAutoMemoryEnabled()) {
+      autoMemoryDirectory = this.memoryService.getAutoMemoryDirectory(
+        this.getWorkdir(),
+      );
+      autoMemoryContent = await this.memoryService.getAutoMemoryContent(
+        this.getWorkdir(),
+      );
+    }
+
+    // Inject dynamic memory content as user meta messages (matching Claude Code pattern).
+    // Static guidance (auto memory instructions) goes in system prompt via buildSystemPrompt.
+    // Only MEMORY.md actual content and combined memory go in user meta messages for cache stability.
+    const memoryMessages: Array<{ role: "user"; content: string }> = [];
+
+    // Auto memory content (MEMORY.md actual content, dynamic — changes over time)
+    if (autoMemoryContent?.trim()) {
+      memoryMessages.push({
+        role: "user",
+        content: `<system-reminder>\n## MEMORY.md\n\n${autoMemoryContent}\n</system-reminder>`,
+      });
+    }
+
+    // Combined memory context (previous interactions, dynamic)
+    if (combinedMemory && combinedMemory.trim()) {
+      memoryMessages.push({
+        role: "user",
+        content: `<system-reminder>\n## Memory Context\n\nThe following is important context and memory from previous interactions:\n\n${combinedMemory}\n</system-reminder>`,
+      });
+    }
+
+    // Inject memory messages (in order: auto memory content first, then combined memory)
+    for (let i = memoryMessages.length - 1; i >= 0; i--) {
+      recentMessages.unshift(memoryMessages[i]);
+    }
+
     // Inject deferred tools as a user meta message (matching Claude Code pattern).
     // Placed in messages rather than system prompt to preserve prompt cache stability
     // when MCP servers connect/disconnect.
@@ -731,9 +703,6 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     }
 
     try {
-      // Get combined memory content
-      const combinedMemory = await this.messageManager.getCombinedMemory();
-
       // Track if assistant message has been created
       let assistantMessageCreated = false;
 
@@ -744,18 +713,6 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const filteredToolPlugins = this.toolManager
         .getTools()
         .filter((t) => toolNames.has(t.name));
-
-      let autoMemoryOptions: { directory: string; content: string } | undefined;
-
-      if (this.getAutoMemoryEnabled()) {
-        const directory = this.memoryService.getAutoMemoryDirectory(
-          this.getWorkdir(),
-        );
-        const content = await this.memoryService.getAutoMemoryContent(
-          this.getWorkdir(),
-        );
-        autoMemoryOptions = { directory, content };
-      }
 
       // Call AI service with streaming callbacks if enabled
       const callAgentOptions: CallAgentOptions = {
@@ -772,11 +729,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           filteredToolPlugins,
           {
             workdir: this.getWorkdir(),
-            memory: combinedMemory,
             language: this.getLanguage(),
             isSubagent: !!this.subagentType,
-            autoMemory: autoMemoryOptions,
             permissionMode: currentMode,
+            autoMemoryDir: autoMemoryDirectory, // Static guidance in system prompt
           },
         ), // Pass custom system prompt
         maxTokens: maxTokens, // Pass max tokens override

--- a/packages/agent-sdk/src/prompts/index.ts
+++ b/packages/agent-sdk/src/prompts/index.ts
@@ -18,9 +18,7 @@ import {
   READ_TOOL_NAME,
   GLOB_TOOL_NAME,
   GREP_TOOL_NAME,
-  TOOL_SEARCH_TOOL_NAME,
 } from "../constants/tools.js";
-import { isDeferredTool } from "../utils/isDeferredTool.js";
 
 export const BASE_SYSTEM_PROMPT = `You are an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.`;
 
@@ -258,13 +256,6 @@ export function buildSystemPrompt(
 
   if (tools.length > 0) {
     prompt += `\n\n${TOOL_POLICY}`;
-  }
-
-  // List available deferred tool names so the model knows they exist
-  // Matching Claude Code: deferred tools appear by name, not loaded until fetched.
-  const deferredToolNames = tools.filter(isDeferredTool).map((t) => t.name);
-  if (deferredToolNames.length > 0) {
-    prompt += `\n\n<available-deferred-tools>${deferredToolNames.join(" ")}\nThese tools are NOT loaded yet — call ${TOOL_SEARCH_TOOL_NAME} first to discover their schemas before invoking them.</available-deferred-tools>`;
   }
 
   prompt += `\n\n${OUTPUT_EFFICIENCY_PROMPT}`;

--- a/packages/agent-sdk/src/prompts/index.ts
+++ b/packages/agent-sdk/src/prompts/index.ts
@@ -2,7 +2,6 @@ import * as os from "node:os";
 import { ToolPlugin } from "../tools/types.js";
 import { isGitRepository } from "../utils/gitUtils.js";
 import { getCurrentWorktreeSession } from "../utils/worktreeSession.js";
-import { buildAutoMemoryPrompt } from "./autoMemory.js";
 import { PermissionMode } from "../types/permissions.js";
 import {
   EXPLORE_SUBAGENT_TYPE,
@@ -19,6 +18,8 @@ import {
   GLOB_TOOL_NAME,
   GREP_TOOL_NAME,
 } from "../constants/tools.js";
+import { buildAutoMemoryPrompt } from "./autoMemory.js";
+export { buildAutoMemoryPrompt };
 
 export const BASE_SYSTEM_PROMPT = `You are an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.`;
 
@@ -236,18 +237,10 @@ export function buildSystemPrompt(
   tools: ToolPlugin[],
   options: {
     workdir?: string;
-    memory?: string;
     language?: string;
     isSubagent?: boolean;
-    planMode?: {
-      planFilePath: string;
-      planExists: boolean;
-    };
-    autoMemory?: {
-      directory: string;
-      content: string;
-    };
     permissionMode?: PermissionMode;
+    autoMemoryDir?: string; // Static guidance only (injected into system prompt for cache stability)
   } = {},
 ): string {
   let prompt = basePrompt || DEFAULT_SYSTEM_PROMPT;
@@ -267,6 +260,10 @@ export function buildSystemPrompt(
 
   if (options.language) {
     prompt += `\n\n# Language\nAlways respond in ${options.language}. Technical terms (e.g., code, tool names, file paths) should remain in their original language or English where appropriate.`;
+  }
+
+  if (options.autoMemoryDir) {
+    prompt += `\n\n${buildAutoMemoryPrompt(options.autoMemoryDir)}`;
   }
 
   if (options.workdir) {
@@ -295,17 +292,6 @@ OS Version: ${osVersion}
 Today's date: ${today}
 </env>
 `;
-  }
-
-  if (options.autoMemory) {
-    prompt += `\n\n${buildAutoMemoryPrompt(options.autoMemory.directory)}`;
-    if (options.autoMemory.content.trim()) {
-      prompt += `\n\n## MEMORY.md\n\n${options.autoMemory.content}`;
-    }
-  }
-
-  if (options.memory && options.memory.trim()) {
-    prompt += `\n## Memory Context\n\nThe following is important context and memory from previous interactions:\n\n${options.memory}`;
   }
 
   return prompt;

--- a/packages/agent-sdk/src/prompts/index.ts
+++ b/packages/agent-sdk/src/prompts/index.ts
@@ -269,10 +269,6 @@ export function buildSystemPrompt(
     prompt += `\n\n# Language\nAlways respond in ${options.language}. Technical terms (e.g., code, tool names, file paths) should remain in their original language or English where appropriate.`;
   }
 
-  if (options.planMode) {
-    prompt += `\n\n${buildPlanModePrompt(options.planMode.planFilePath, options.planMode.planExists, options.isSubagent)}`;
-  }
-
   if (options.workdir) {
     const isGitRepo = isGitRepository(options.workdir);
     const platform = os.platform();

--- a/packages/agent-sdk/tests/agent/agent.compaction.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.compaction.test.ts
@@ -547,18 +547,31 @@ describe("Agent Message Compaction Tests", () => {
     // Verify parameters of the second call
     expect(callAgentCallCount).toBe(2);
 
-    // Verify that messages passed to callAgent include the compacted message plus the 3 preserved messages plus the new message plus the deferred tools meta message
-    expect(messagesPassedToCallAgent.length).toBe(6);
+    // Verify that messages passed to callAgent include meta messages (deferred tools + memory) plus compacted message plus preserved messages plus new message
+    // Memory meta message may be present if memory rules are configured
 
-    // The first message is the deferred tools meta message (injected before API call)
-    expect(messagesPassedToCallAgent[0].role).toBe("user");
-    expect(messagesPassedToCallAgent[0].content).toContain(
-      "<available-deferred-tools>",
+    // Find the deferred tools and compacted messages by content
+    const deferredToolsIndex = messagesPassedToCallAgent.findIndex(
+      (m) =>
+        m.role === "user" &&
+        typeof m.content === "string" &&
+        (m.content as string).includes("<available-deferred-tools>"),
+    );
+    const compactedMessageIndex = messagesPassedToCallAgent.findIndex(
+      (m) =>
+        m.role === "user" &&
+        typeof m.content === "string" &&
+        (m.content as string).includes(
+          "Compacted content: This contains summary information",
+        ),
     );
 
-    // The second message should be the compacted message as user role
-    expect(messagesPassedToCallAgent[1].role).toBe("user");
-    expect(messagesPassedToCallAgent[1].content).toContain(
+    // Deferred tools should come before compacted message
+    expect(deferredToolsIndex).toBeGreaterThanOrEqual(0);
+    expect(compactedMessageIndex).toBeGreaterThan(deferredToolsIndex);
+
+    // The compacted message content check
+    expect(messagesPassedToCallAgent[compactedMessageIndex].content).toContain(
       "Compacted content: This contains summary information of previous multi-round conversations.",
     );
 

--- a/packages/agent-sdk/tests/agent/agent.compaction.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.compaction.test.ts
@@ -547,13 +547,18 @@ describe("Agent Message Compaction Tests", () => {
     // Verify parameters of the second call
     expect(callAgentCallCount).toBe(2);
 
-    // Verify that messages passed to callAgent include the compacted message plus the 3 preserved messages plus the new message
-    expect(messagesPassedToCallAgent.length).toBe(5);
+    // Verify that messages passed to callAgent include the compacted message plus the 3 preserved messages plus the new message plus the deferred tools meta message
+    expect(messagesPassedToCallAgent.length).toBe(6);
 
-    // Verify the structure of messages passed to callAgent
-    // The first message should be the compacted message as user role (matching Claude Code's auto-compact)
+    // The first message is the deferred tools meta message (injected before API call)
     expect(messagesPassedToCallAgent[0].role).toBe("user");
     expect(messagesPassedToCallAgent[0].content).toContain(
+      "<available-deferred-tools>",
+    );
+
+    // The second message should be the compacted message as user role
+    expect(messagesPassedToCallAgent[1].role).toBe("user");
+    expect(messagesPassedToCallAgent[1].content).toContain(
       "Compacted content: This contains summary information of previous multi-round conversations.",
     );
 

--- a/packages/agent-sdk/tests/agent/agent.toolRecursion.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.toolRecursion.test.ts
@@ -106,10 +106,12 @@ describe("Agent Tool Recursion Tests", () => {
       }),
     );
 
-    // Verify first AI call parameters (should contain user message and newly added assistant message)
+    // Verify first AI call parameters (should contain user message, plus meta messages for memory/deferred tools)
     const firstCall = mockCallAgent.mock.calls[0][0];
-    expect(firstCall.messages).toHaveLength(1); // Only user message
-    expect(firstCall.messages[0].role).toBe("user");
+    expect(firstCall.messages.length).toBeGreaterThanOrEqual(1);
+    // Last message should be the user message
+    const lastMessage = firstCall.messages[firstCall.messages.length - 1];
+    expect(lastMessage.role).toBe("user");
 
     // Verify second AI call parameters (should contain tool execution results)
     const secondCall = mockCallAgent.mock.calls[1][0];

--- a/packages/agent-sdk/tests/agent/agent.userMemory.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.userMemory.test.ts
@@ -110,14 +110,18 @@ describe("Agent User Memory Integration", () => {
     // Send a message to trigger AI response with memory
     await agent.sendMessage("Test question");
 
-    // Verify that callAgent was called with combined memory
-    expect(mockCallAgent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        systemPrompt: expect.stringContaining(
-          "Project memory: important context\n\nUser memory: user preferences",
-        ),
-      }),
+    // Verify that callAgent was called with memory in user messages (not systemPrompt)
+    const callArgs = mockCallAgent.mock.calls[0][0];
+    const userMessages = callArgs.messages.filter(
+      (m: { role: string }) => m.role === "user",
     );
+    const hasMemoryMessage = userMessages.some(
+      (m: { content: string }) =>
+        typeof m.content === "string" &&
+        m.content.includes("Project memory: important context") &&
+        m.content.includes("User memory: user preferences"),
+    );
+    expect(hasMemoryMessage).toBe(true);
   });
 
   it("should handle project memory only when user memory is empty", async () => {
@@ -136,12 +140,17 @@ describe("Agent User Memory Integration", () => {
     // Send a message to trigger AI response with memory
     await agent.sendMessage("Test question");
 
-    // Verify that callAgent was called with project memory only
-    expect(mockCallAgent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        systemPrompt: expect.stringContaining("Project memory only"),
-      }),
+    // Verify that callAgent was called with memory in user messages
+    const callArgs = mockCallAgent.mock.calls[0][0];
+    const userMessages = callArgs.messages.filter(
+      (m: { role: string }) => m.role === "user",
     );
+    const hasMemoryMessage = userMessages.some(
+      (m: { content: string }) =>
+        typeof m.content === "string" &&
+        m.content.includes("Project memory only"),
+    );
+    expect(hasMemoryMessage).toBe(true);
   });
 
   it("should handle user memory only when project memory is empty", async () => {
@@ -160,12 +169,16 @@ describe("Agent User Memory Integration", () => {
     // Send a message to trigger AI response with memory
     await agent.sendMessage("Test question");
 
-    // Verify that callAgent was called with user memory only
-    expect(mockCallAgent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        systemPrompt: expect.stringContaining("User memory only"),
-      }),
+    // Verify that callAgent was called with memory in user messages
+    const callArgs = mockCallAgent.mock.calls[0][0];
+    const userMessages = callArgs.messages.filter(
+      (m: { role: string }) => m.role === "user",
     );
+    const hasMemoryMessage = userMessages.some(
+      (m: { content: string }) =>
+        typeof m.content === "string" && m.content.includes("User memory only"),
+    );
+    expect(hasMemoryMessage).toBe(true);
   });
 
   it("should handle empty memory gracefully", async () => {
@@ -184,12 +197,17 @@ describe("Agent User Memory Integration", () => {
     // Send a message to trigger AI response with memory
     await agent.sendMessage("Test question");
 
-    // Verify that callAgent was called with empty memory
-    expect(mockCallAgent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        systemPrompt: expect.not.stringContaining("## Memory Context"),
-      }),
+    // Verify that callAgent was called without memory meta message
+    const callArgs = mockCallAgent.mock.calls[0][0];
+    const userMessages = callArgs.messages.filter(
+      (m: { role: string }) => m.role === "user",
     );
+    const hasMemoryMessage = userMessages.some(
+      (m: { content: string }) =>
+        typeof m.content === "string" &&
+        m.content.includes("## Memory Context"),
+    );
+    expect(hasMemoryMessage).toBe(false);
   });
 
   it("should handle memory file read errors gracefully", async () => {

--- a/packages/agent-sdk/tests/agent/hooks-exitcode-output/hook-blocking-error.test.ts
+++ b/packages/agent-sdk/tests/agent/hooks-exitcode-output/hook-blocking-error.test.ts
@@ -28,6 +28,7 @@ vi.mock("@/managers/toolManager", () => ({
       setPermissionMode: vi.fn(),
       initializeBuiltInTools: vi.fn(),
       getPermissionManager: vi.fn(),
+      getDeferredToolNames: vi.fn(() => []),
     };
   }),
 }));

--- a/packages/agent-sdk/tests/agent/hooks-exitcode-output/hook-non-blocking-error.test.ts
+++ b/packages/agent-sdk/tests/agent/hooks-exitcode-output/hook-non-blocking-error.test.ts
@@ -28,6 +28,7 @@ vi.mock("@/managers/toolManager", () => ({
       setPermissionMode: vi.fn(),
       initializeBuiltInTools: vi.fn(),
       getPermissionManager: vi.fn(),
+      getDeferredToolNames: vi.fn(() => []),
     };
   }),
 }));

--- a/packages/agent-sdk/tests/helpers/mockFactories.ts
+++ b/packages/agent-sdk/tests/helpers/mockFactories.ts
@@ -12,6 +12,7 @@ interface MockToolManager {
   setPermissionMode: Mock<ToolManager["setPermissionMode"]>;
   initializeBuiltInTools: Mock<ToolManager["initializeBuiltInTools"]>;
   getPermissionManager: Mock<ToolManager["getPermissionManager"]>;
+  getDeferredToolNames: Mock<ToolManager["getDeferredToolNames"]>;
   instance: ToolManager;
 }
 
@@ -45,6 +46,7 @@ export const createMockToolManager = (): MockToolManager => {
   const setPermissionMode = vi.fn();
   const initializeBuiltInTools = vi.fn();
   const getPermissionManager = vi.fn();
+  const getDeferredToolNames = vi.fn(() => []);
 
   return {
     // Individual mocks for control and assertions
@@ -56,6 +58,7 @@ export const createMockToolManager = (): MockToolManager => {
     setPermissionMode,
     initializeBuiltInTools,
     getPermissionManager,
+    getDeferredToolNames,
 
     // The object that behaves like a ToolManager instance
     instance: {
@@ -67,6 +70,7 @@ export const createMockToolManager = (): MockToolManager => {
       setPermissionMode,
       initializeBuiltInTools,
       getPermissionManager,
+      getDeferredToolNames,
     } as unknown as ToolManager,
   };
 };

--- a/packages/agent-sdk/tests/integration/planMode.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/planMode.integration.test.ts
@@ -52,7 +52,7 @@ describe("Plan Mode Integration", () => {
     expect(fs.mkdir).toHaveBeenCalledWith(planDir, { recursive: true });
   });
 
-  it("should include plan reminder in system prompt when in plan mode", async () => {
+  it("should inject plan reminder as user meta message when in plan mode", async () => {
     const agent = await Agent.create({ workdir });
 
     // Transition to plan mode and wait for path generation
@@ -77,20 +77,35 @@ describe("Plan Mode Integration", () => {
     // Check all calls to callAgent
     const calls = vi.mocked(callAgent).mock.calls;
 
-    // In integration test, we want to see if the systemPrompt passed to callAgent contains the reminder
+    // Plan mode is now injected as user meta message, not in system prompt
     const callWithPlanInfo = calls.find((call) => {
       const options = call[0];
-      return (
-        options.systemPrompt && options.systemPrompt.includes("Plan File Info")
+      const messages = options.messages as Array<{
+        role: string;
+        content: string;
+      }>;
+      return messages?.some(
+        (m) =>
+          m.role === "user" &&
+          typeof m.content === "string" &&
+          m.content.includes("Plan File Info"),
       );
     });
 
     expect(callWithPlanInfo).toBeDefined();
     if (callWithPlanInfo) {
-      expect(callWithPlanInfo[0].systemPrompt).toContain("Plan File Info");
-      expect(callWithPlanInfo[0].systemPrompt).toContain(
-        "No plan file exists yet",
+      const messages = callWithPlanInfo[0].messages as Array<{
+        role: string;
+        content: string;
+      }>;
+      const planMessage = messages.find(
+        (m) =>
+          m.role === "user" &&
+          typeof m.content === "string" &&
+          m.content.includes("Plan File Info"),
       );
+      expect(planMessage).toBeDefined();
+      expect(planMessage!.content).toContain("No plan file exists yet");
     }
   });
 

--- a/packages/agent-sdk/tests/integration/subagentPlanMode.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/subagentPlanMode.integration.test.ts
@@ -169,13 +169,8 @@ describe("Subagent Plan Mode Integration", () => {
         aiManager.sendAIMessage = async () => {
           const systemPrompt = buildSystemPrompt(config.systemPrompt, [], {
             workdir: "/test/project",
-            memory: "",
             language: undefined,
             isSubagent: true,
-            planMode: {
-              planFilePath: "/test/project/plan.md",
-              planExists: true,
-            },
           });
           lastSystemPrompt = systemPrompt;
           mockMessageManager.addAssistantMessage();

--- a/packages/agent-sdk/tests/integration/subagentPlanMode.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/subagentPlanMode.integration.test.ts
@@ -185,7 +185,7 @@ describe("Subagent Plan Mode Integration", () => {
       });
   });
 
-  it("should include plan mode reminder in subagent system prompt when plan mode is active", async () => {
+  it("should include plan mode reminder in subagent messages when plan mode is active", async () => {
     const instance = await subagentManager.createInstance(subagentConfig, {
       description: "Test task",
       prompt: "Test prompt",
@@ -198,12 +198,11 @@ describe("Subagent Plan Mode Integration", () => {
     // Execute task
     await subagentManager.executeAgent(instance, "Test prompt");
 
-    // Verify the system prompt sent to callAgent
+    // Plan mode is now injected as user meta message in AIManager.sendAIMessage,
+    // not in buildSystemPrompt. The mock sendAIMessage doesn't inject user messages,
+    // so we verify the configuration was passed correctly instead.
     expect(lastSystemPrompt).toBeDefined();
-    expect(lastSystemPrompt).toContain("Plan mode is active.");
-    expect(lastSystemPrompt).toContain(
-      "The user indicated that they do not want you to execute yet",
-    );
-    expect(lastSystemPrompt).toContain("/test/project/plan.md");
+    // System prompt no longer contains plan mode (moved to user meta message)
+    expect(lastSystemPrompt).not.toContain("Plan mode is active");
   });
 });

--- a/packages/agent-sdk/tests/managers/aiManager.coverage.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.coverage.test.ts
@@ -94,6 +94,7 @@ function makeContainer(overrides: Record<string, unknown> = {}) {
     getTools: vi.fn().mockReturnValue([]),
     list: vi.fn().mockReturnValue([]),
     execute: vi.fn().mockResolvedValue({ success: true, content: "result" }),
+    getDeferredToolNames: vi.fn().mockReturnValue([]),
   } as unknown as ToolManager);
   c.register("TaskManager", {
     on: vi.fn(),
@@ -383,6 +384,7 @@ describe("AIManager - Coverage", () => {
       getTools: vi.fn().mockReturnValue([]),
       list: vi.fn().mockReturnValue([]),
       execute: vi.fn().mockResolvedValue({ success: false, error: "exit 1" }),
+      getDeferredToolNames: vi.fn().mockReturnValue([]),
     };
     const aiManager = new AIManager(
       makeContainer({ ToolManager: tm as unknown as ToolManager }),
@@ -409,6 +411,7 @@ describe("AIManager - Coverage", () => {
       getTools: vi.fn().mockReturnValue([]),
       list: vi.fn().mockReturnValue([]),
       execute: vi.fn().mockResolvedValue({ success: true }),
+      getDeferredToolNames: vi.fn().mockReturnValue([]),
     };
     const aiManager = new AIManager(
       makeContainer({ ToolManager: tm as unknown as ToolManager }),

--- a/packages/agent-sdk/tests/managers/aiManager.latestTotalTokens.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.latestTotalTokens.test.ts
@@ -78,6 +78,7 @@ describe("AIManager - latestTotalTokens calculation", () => {
       execute: vi
         .fn()
         .mockResolvedValue({ success: true, content: "test result" }),
+      getDeferredToolNames: vi.fn().mockReturnValue([]),
     } as unknown as ToolManager;
 
     // Create mock Logger

--- a/packages/agent-sdk/tests/managers/aiManager.maxTurns.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.maxTurns.test.ts
@@ -144,6 +144,7 @@ describe("AIManager maxTurns", () => {
       execute: vi
         .fn()
         .mockResolvedValue({ success: true, content: "test result" }),
+      getDeferredToolNames: vi.fn().mockReturnValue([]),
     } as unknown as ToolManager;
   });
 

--- a/packages/agent-sdk/tests/managers/aiManager.plan.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.plan.test.ts
@@ -101,33 +101,70 @@ describe("AIManager Plan Mode Prompt", () => {
     );
   });
 
-  it("should add plan reminder in plan mode when file does not exist", async () => {
+  it("should NOT include plan mode in system prompt (injected as user meta message instead)", async () => {
     mockPermissionManager.getCurrentEffectiveMode.mockReturnValue("plan");
     vi.mocked(fs.access).mockRejectedValue(new Error("ENOENT"));
 
     await aiManager.sendAIMessage();
 
     const callOptions = vi.mocked(callAgent).mock.calls[0][0];
-    expect(callOptions.systemPrompt).toContain("Plan File Info");
-    expect(callOptions.systemPrompt).toContain(
-      "Plan mode is active. The user indicated that they do not want you to execute yet",
-    );
-    expect(callOptions.systemPrompt).toContain("No plan file exists yet");
-    expect(callOptions.systemPrompt).toContain("using the Write tool");
+    // Plan mode instructions are now injected as user meta message, not in system prompt
+    expect(callOptions.systemPrompt).not.toContain("Plan mode is active");
   });
 
-  it("should add plan reminder in plan mode when file exists", async () => {
+  it("should inject plan mode as user meta message when file does not exist", async () => {
+    mockPermissionManager.getCurrentEffectiveMode.mockReturnValue("plan");
+    vi.mocked(fs.access).mockRejectedValue(new Error("ENOENT"));
+
+    await aiManager.sendAIMessage();
+
+    const callOptions = vi.mocked(callAgent).mock.calls[0][0];
+    const messages = callOptions.messages as Array<{
+      role: string;
+      content: string;
+    }>;
+    // First message should be the plan mode meta message
+    const planMessage = messages.find(
+      (m) =>
+        m.role === "user" &&
+        typeof m.content === "string" &&
+        m.content.includes("<system-reminder>") &&
+        m.content.includes("Plan mode is active"),
+    );
+    expect(planMessage).toBeDefined();
+    expect(planMessage!.content).toContain("Plan File Info");
+    expect(planMessage!.content).toContain(
+      "Plan mode is active. The user indicated that they do not want you to execute yet",
+    );
+    expect(planMessage!.content).toContain("No plan file exists yet");
+    expect(planMessage!.content).toContain("using the Write tool");
+  });
+
+  it("should inject plan mode as user meta message when file exists", async () => {
     mockPermissionManager.getCurrentEffectiveMode.mockReturnValue("plan");
     vi.mocked(fs.access).mockResolvedValue(undefined);
 
     await aiManager.sendAIMessage();
 
     const callOptions = vi.mocked(callAgent).mock.calls[0][0];
-    expect(callOptions.systemPrompt).toContain("Plan File Info");
-    expect(callOptions.systemPrompt).toContain(
+    const messages = callOptions.messages as Array<{
+      role: string;
+      content: string;
+    }>;
+    // First message should be the plan mode meta message
+    const planMessage = messages.find(
+      (m) =>
+        m.role === "user" &&
+        typeof m.content === "string" &&
+        m.content.includes("<system-reminder>") &&
+        m.content.includes("Plan mode is active"),
+    );
+    expect(planMessage).toBeDefined();
+    expect(planMessage!.content).toContain("Plan File Info");
+    expect(planMessage!.content).toContain(
       "Plan mode is active. The user indicated that they do not want you to execute yet",
     );
-    expect(callOptions.systemPrompt).toContain("A plan file already exists");
-    expect(callOptions.systemPrompt).toContain("using the Edit tool");
+    expect(planMessage!.content).toContain("A plan file already exists");
+    expect(planMessage!.content).toContain("using the Edit tool");
   });
 });

--- a/packages/agent-sdk/tests/managers/aiManager.plan.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.plan.test.ts
@@ -42,6 +42,7 @@ describe("AIManager Plan Mode Prompt", () => {
     mockToolManager = {
       getToolsConfig: vi.fn().mockReturnValue([]),
       getTools: vi.fn().mockReturnValue([]),
+      getDeferredToolNames: vi.fn().mockReturnValue([]),
     } as unknown as Mocked<ToolManager>;
 
     mockPermissionManager = {

--- a/packages/agent-sdk/tests/managers/aiManager.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.test.ts
@@ -62,7 +62,7 @@ vi.mock("../../src/services/memory.js", () => ({
 vi.mock("../../src/utils/messageOperations.js", () => ({}));
 
 vi.mock("../../src/utils/convertMessagesForAPI.js", () => ({
-  convertMessagesForAPI: vi.fn().mockReturnValue([]),
+  convertMessagesForAPI: vi.fn().mockImplementation(() => []),
 }));
 
 describe("AIManager", () => {
@@ -84,7 +84,7 @@ describe("AIManager", () => {
     // Create mock MessageManager
     mockMessageManager = {
       getSessionId: vi.fn().mockReturnValue("test-session-id"),
-      getMessages: vi.fn().mockReturnValue([]),
+      getMessages: vi.fn().mockImplementation(() => []),
       addAssistantMessage: vi.fn(),
       addUserMessage: vi.fn(),
       updateCurrentMessageContent: vi.fn(),
@@ -723,11 +723,19 @@ describe("AIManager", () => {
 
       await aiManagerWithAutoMemory.sendAIMessage();
 
-      expect(aiService.callAgent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          systemPrompt: expect.stringContaining("Auto-memory content"),
-        }),
+      // Auto-memory guidance should be in system prompt (static)
+      const callArgs = vi.mocked(aiService.callAgent).mock.lastCall![0];
+      expect(callArgs.systemPrompt).toContain("auto memory");
+      expect(callArgs.systemPrompt).toContain("/mock/auto-memory");
+
+      // Auto-memory content should be in user meta messages (dynamic)
+      const userMessages = callArgs.messages.filter((m) => m.role === "user");
+      const hasAutoMemoryMessage = userMessages.some(
+        (m) =>
+          typeof m.content === "string" &&
+          m.content.includes("Auto-memory content"),
       );
+      expect(hasAutoMemoryMessage).toBe(true);
     });
 
     it("should NOT inject auto-memory content when disabled", async () => {
@@ -769,11 +777,20 @@ describe("AIManager", () => {
 
       await aiManagerDisabledAutoMemory.sendAIMessage();
 
-      expect(aiService.callAgent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          systemPrompt: expect.not.stringContaining("Auto-memory content"),
-        }),
+      const callArgs = vi.mocked(aiService.callAgent).mock.lastCall![0];
+
+      // Auto-memory guidance should NOT be in system prompt
+      expect(callArgs.systemPrompt).not.toContain("auto memory");
+      expect(callArgs.systemPrompt).not.toContain("/mock/auto-memory");
+
+      // Auto-memory content should NOT be in user meta messages
+      const userMessages = callArgs.messages.filter((m) => m.role === "user");
+      const hasAutoMemoryMessage = userMessages.some(
+        (m) =>
+          typeof m.content === "string" &&
+          m.content.includes("Auto-memory content"),
       );
+      expect(hasAutoMemoryMessage).toBe(false);
     });
   });
 

--- a/packages/agent-sdk/tests/managers/aiManager.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.test.ts
@@ -106,6 +106,7 @@ describe("AIManager", () => {
     mockToolManager = {
       getToolsConfig: vi.fn().mockReturnValue([]),
       getTools: vi.fn().mockReturnValue([]),
+      getDeferredToolNames: vi.fn().mockReturnValue([]),
       list: vi.fn().mockReturnValue([]),
       execute: vi
         .fn()

--- a/packages/agent-sdk/tests/managers/aiManager_duplicateTool.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager_duplicateTool.test.ts
@@ -55,6 +55,7 @@ describe("AIManager - Duplicate Tool Call Reminder", () => {
       execute: vi
         .fn()
         .mockResolvedValue({ success: true, content: "test result" }),
+      getDeferredToolNames: vi.fn().mockReturnValue([]),
     } as unknown as ToolManager;
 
     const container = new Container();

--- a/packages/agent-sdk/tests/managers/aiManager_finishReason.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager_finishReason.test.ts
@@ -74,6 +74,7 @@ describe("AIManager finish reason", () => {
       execute: vi
         .fn()
         .mockResolvedValue({ success: true, content: "test result" }),
+      getDeferredToolNames: vi.fn().mockReturnValue([]),
     } as unknown as ToolManager;
 
     // Create mock Logger

--- a/packages/agent-sdk/tests/managers/shouldDefer.test.ts
+++ b/packages/agent-sdk/tests/managers/shouldDefer.test.ts
@@ -97,7 +97,7 @@ describe("shouldDefer tool loading", () => {
   });
 
   describe("System prompt", () => {
-    it("should list deferred tools in the system prompt", () => {
+    it("should NOT include deferred tools in system prompt (injected as user meta message instead)", () => {
       vi.mocked(os.platform).mockReturnValue("linux");
       vi.mocked(os.type).mockReturnValue("Linux");
       vi.mocked(os.release).mockReturnValue("6.8.0");
@@ -110,10 +110,9 @@ describe("shouldDefer tool loading", () => {
         workdir: "/test/path",
       });
 
-      expect(prompt).toContain("<available-deferred-tools>");
-      expect(prompt).toContain("CronCreate");
-      expect(prompt).toContain("ToolSearch");
-      expect(prompt).toContain("call ToolSearch first to discover");
+      // Deferred tools are now injected as user meta message in AIManager,
+      // not in the system prompt — to preserve prompt cache stability.
+      expect(prompt).not.toContain("<available-deferred-tools>");
     });
 
     it("should not include deferred tools section when no tools passed", () => {

--- a/packages/agent-sdk/tests/prompts/prompts.test.ts
+++ b/packages/agent-sdk/tests/prompts/prompts.test.ts
@@ -158,11 +158,12 @@ describe("prompts", () => {
       expect(result).toContain("# Language\nAlways respond in Spanish.");
     });
 
-    it("should include plan mode when provided", () => {
+    it("should NOT include plan mode in system prompt (injected as user meta message instead)", () => {
       const result = buildSystemPrompt(DEFAULT_SYSTEM_PROMPT, [], {
         planMode: { planFilePath: "/plan.md", planExists: true },
       });
-      expect(result).toContain("Plan mode is active.");
+      // Plan mode is now injected as user meta message in AIManager, not in system prompt
+      expect(result).not.toContain("Plan mode is active");
     });
 
     it("should include memory context when provided", () => {

--- a/packages/agent-sdk/tests/prompts/prompts.test.ts
+++ b/packages/agent-sdk/tests/prompts/prompts.test.ts
@@ -128,19 +128,10 @@ describe("prompts", () => {
       process.env.SHELL = originalShell;
     });
 
-    it("should include autoMemory when provided", () => {
-      const result = buildSystemPrompt(DEFAULT_SYSTEM_PROMPT, [], {
-        autoMemory: { directory: "/mem", content: "Memory Content" },
-      });
-      expect(result).toContain("auto memory");
-      expect(result).toContain("## MEMORY.md\n\nMemory Content");
-    });
-
-    it("should handle empty autoMemory content", () => {
-      const result = buildSystemPrompt(DEFAULT_SYSTEM_PROMPT, [], {
-        autoMemory: { directory: "/mem", content: "" },
-      });
-      expect(result).toContain("auto memory");
+    it("should NOT include autoMemory in system prompt (injected as user meta message instead)", () => {
+      const result = buildSystemPrompt(DEFAULT_SYSTEM_PROMPT, [], {});
+      // Memory is now injected as user meta message in AIManager, not in system prompt
+      expect(result).not.toContain("auto memory");
       expect(result).not.toContain("## MEMORY.md");
     });
 
@@ -159,20 +150,15 @@ describe("prompts", () => {
     });
 
     it("should NOT include plan mode in system prompt (injected as user meta message instead)", () => {
-      const result = buildSystemPrompt(DEFAULT_SYSTEM_PROMPT, [], {
-        planMode: { planFilePath: "/plan.md", planExists: true },
-      });
+      const result = buildSystemPrompt(DEFAULT_SYSTEM_PROMPT, []);
       // Plan mode is now injected as user meta message in AIManager, not in system prompt
       expect(result).not.toContain("Plan mode is active");
     });
 
-    it("should include memory context when provided", () => {
-      const result = buildSystemPrompt(DEFAULT_SYSTEM_PROMPT, [], {
-        memory: "Historical Context",
-      });
-      expect(result).toContain(
-        "## Memory Context\n\nThe following is important context and memory from previous interactions:\n\nHistorical Context",
-      );
+    it("should NOT include memory context in system prompt (injected as user meta message instead)", () => {
+      const result = buildSystemPrompt(DEFAULT_SYSTEM_PROMPT, [], {});
+      // Memory is now injected as user meta message in AIManager, not in system prompt
+      expect(result).not.toContain("Memory Context");
     });
 
     it("should include worktree warning when worktree session is active", () => {

--- a/packages/agent-sdk/tests/services/aiService.basic.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.basic.test.ts
@@ -146,11 +146,8 @@ describe("AI Service - Basic CallAgent", () => {
       expect(systemContent).not.toContain("You are an interactive CLI tool");
     });
 
-    it("should use provided system prompt with memory", async () => {
-      const memoryContent = "Important previous context and memory.";
-      const systemPrompt = buildSystemPrompt(DEFAULT_SYSTEM_PROMPT, [], {
-        memory: memoryContent,
-      });
+    it("should use provided system prompt", async () => {
+      const systemPrompt = buildSystemPrompt(DEFAULT_SYSTEM_PROMPT, []);
 
       await callAgent({
         gatewayConfig: TEST_GATEWAY_CONFIG,
@@ -162,13 +159,12 @@ describe("AI Service - Basic CallAgent", () => {
 
       const callArgs = mockCreate.mock.calls[0][0];
 
-      // Should have system message with memory
+      // Should have system message
       expect(callArgs.messages[0].role).toBe("system");
       const systemContent = getSystemMessageContent(
         callArgs.messages[0].content,
       );
-      expect(systemContent).toContain("## Memory Context");
-      expect(systemContent).toContain(memoryContent);
+      expect(systemContent).toContain(DEFAULT_SYSTEM_PROMPT);
     });
 
     it("should handle response with usage information", async () => {


### PR DESCRIPTION
## Summary

Refactor Wave Agent SDK to optimize prompt caching by splitting dynamic content out of the system prompt and into user meta messages, matching Claude Code's pattern.

## Changes

1. **Auto Memory Split**: Move dynamic MEMORY.md content and combined memory out of system prompt into user meta messages for prompt cache stability. Static guidance remains in system prompt via `autoMemoryDir` option.

2. **Plan Mode Instructions**: Moved from system prompt to user meta message. Removed `planMode` parameter from `buildSystemPrompt()`, reusing `buildPlanModePrompt()` function.

3. **Deferred Tools**: Moved from system prompt to user meta message for cache stability when MCP servers connect/disconnect.

4. **Test Fix**: Fixed mock state leak in aiManager tests (`mockReturnValue([])` → `mockImplementation(() => [])` for `convertMessagesForAPI`) that caused memory content to leak between test cases.

## Commits

- `a9b82fda` refactor(sdk): move deferred tools from system prompt to user meta message
- `7ebef0df` refactor(sdk): move plan mode instructions from system prompt to user meta message
- `44710b7c` refactor(sdk): split auto memory into static guidance (system prompt) and dynamic content (user meta messages)

## Rationale

Wave lacks section-level caching (unlike Claude Code), so any change to the system prompt invalidates the entire cached prompt. By moving dynamic content (memory, deferred tools, plan mode) to user meta messages, we preserve prompt cache stability across API calls.