### PR TITLE
fix: reorder shift-tab permission cycle to place bypassPermissions before plan

### DIFF
--- a/packages/code/src/managers/inputReducer.ts
+++ b/packages/code/src/managers/inputReducer.ts
@@ -763,8 +763,8 @@ export function inputReducer(
         const modes: PermissionMode[] = [
           "default",
           "acceptEdits",
-          "plan",
           "bypassPermissions",
+          "plan",
         ];
         const currentIndex = modes.indexOf(state.permissionMode);
         const nextIndex =


### PR DESCRIPTION
Reorder the Shift+Tab permission mode cycling sequence so that `bypassPermissions` comes before `plan`, matching user workflow preference.

**Change:**
- `default → acceptEdits → bypassPermissions → plan` (was: `default → acceptEdits → plan → bypassPermissions`)