### PR TITLE
align language prompt wording with Claude Code

### DIFF
--- a/packages/agent-sdk/src/prompts/index.ts
+++ b/packages/agent-sdk/src/prompts/index.ts
@@ -275,7 +275,7 @@ export function buildSystemPrompt(
   }
 
   if (options.language) {
-    prompt += `\n\n# Language\nAlways respond in ${options.language}. Technical terms (e.g., code, tool names, file paths) should remain in their original language or English where appropriate.`;
+    prompt += `\n\n# Language\nAlways respond in ${options.language}. Use ${options.language} for all explanations, comments, and communications with the user. Technical terms and code identifiers should remain in their original form.`;
   }
 
   if (options.planMode) {

--- a/packages/agent-sdk/tests/managers/aiManager.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.test.ts
@@ -338,7 +338,7 @@ describe("AIManager", () => {
       expect(aiService.callAgent).toHaveBeenCalledWith(
         expect.objectContaining({
           systemPrompt: expect.stringContaining(
-            "Technical terms (e.g., code, tool names, file paths) should remain in their original language or English where appropriate.",
+            "Use Spanish for all explanations, comments, and communications with the user. Technical terms and code identifiers should remain in their original form.",
           ),
         }),
       );


### PR DESCRIPTION
Update the # Language section in buildSystemPrompt() to match Claude Code's
phrasing: adds 'Use X for all explanations, comments, and communications'
and shortens technical terms guidance.
