### PR TITLE
feat(sdk): use findUpSync to locate package root for vendor/builtin paths

### DIFF
--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -43,6 +43,7 @@
     "@modelcontextprotocol/sdk": "^1.18.2",
     "chokidar": "^5.0.0",
     "cron-parser": "^5.5.0",
+    "find-up": "^8.0.0",
     "fuzzysort": "^3.1.0",
     "glob": "^13.0.0",
     "lru-cache": "^11.3.5",

--- a/packages/agent-sdk/src/utils/configPaths.ts
+++ b/packages/agent-sdk/src/utils/configPaths.ts
@@ -14,26 +14,41 @@ import { join, dirname } from "path";
 import { homedir } from "os";
 import { existsSync } from "fs";
 import { fileURLToPath } from "url";
+import { findUpSync } from "find-up";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 /**
+ * Resolve the package root directory by finding the nearest package.json.
+ * Works correctly even when bundled (e.g. esbuild into a VS Code extension),
+ * as long as vendor/ and builtin/ remain alongside package.json on disk.
+ */
+let _packageRoot: string | undefined;
+export function getPackageRoot(): string {
+  if (_packageRoot) return _packageRoot;
+  const pkgPath = findUpSync("package.json", { cwd: __dirname });
+  if (pkgPath) {
+    _packageRoot = dirname(pkgPath);
+    return _packageRoot;
+  }
+  // Fallback: relative to this file (works during development)
+  _packageRoot = join(__dirname, "..", "..");
+  return _packageRoot;
+}
+
+/**
  * Get the builtin skills directory path
  */
 export function getBuiltinSkillsDir(): string {
-  // Builtin skills are now in the 'builtin/skills' directory at the root of the package
-  // Relative to this file (src/utils/configPaths.ts), it's ../../builtin/skills
-  return join(__dirname, "..", "..", "builtin", "skills");
+  return join(getPackageRoot(), "builtin", "skills");
 }
 
 /**
  * Get the builtin subagents directory path
  */
 export function getBuiltinSubagentsDir(): string {
-  // Builtin subagents are now in the 'builtin/subagents' directory at the root of the package
-  // Relative to this file (src/utils/configPaths.ts), it's ../../builtin/subagents
-  return join(__dirname, "..", "..", "builtin", "subagents");
+  return join(getPackageRoot(), "builtin", "subagents");
 }
 
 /**

--- a/packages/agent-sdk/src/utils/ripgrep.ts
+++ b/packages/agent-sdk/src/utils/ripgrep.ts
@@ -1,9 +1,6 @@
-import { fileURLToPath } from "url";
 import path from "path";
 import process from "process";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import { getPackageRoot } from "./configPaths.js";
 
 /**
  * Detect the current platform and architecture to find the correct bundled ripgrep binary.
@@ -29,8 +26,10 @@ const binaryName = isWindows ? "rg.exe" : "rg";
 
 /**
  * Path to the ripgrep binary bundled in the vendor directory.
+ * Uses findUpSync to locate the package root, working correctly even
+ * when bundled (e.g. esbuild into a VS Code extension).
  */
-export const rgPath = path.resolve(
-  __dirname,
-  `../../vendor/ripgrep/${platformKey}/${binaryName}`,
+export const rgPath = path.join(
+  getPackageRoot(),
+  `vendor/ripgrep/${platformKey}/${binaryName}`,
 );

--- a/packages/agent-sdk/tests/plugin-loading-integration.test.ts
+++ b/packages/agent-sdk/tests/plugin-loading-integration.test.ts
@@ -8,7 +8,6 @@ import * as fs from "fs";
 vi.mock("../src/services/MarketplaceService.js");
 vi.mock("../src/services/GitService.js");
 vi.mock("../src/services/pluginLoader.js");
-vi.mock("../src/utils/configPaths.js");
 vi.mock("fs");
 
 describe("Agent Plugin Loading Integration", () => {
@@ -51,10 +50,10 @@ describe("Agent Plugin Loading Integration", () => {
     vi.mocked(PluginLoader.loadHooksConfig).mockResolvedValue(undefined);
 
     // Mock config paths
-    vi.mocked(configPaths.getUserConfigPaths).mockReturnValue([
+    vi.spyOn(configPaths, "getUserConfigPaths").mockReturnValue([
       "/user/settings.json",
     ]);
-    vi.mocked(configPaths.getProjectConfigPaths).mockReturnValue([
+    vi.spyOn(configPaths, "getProjectConfigPaths").mockReturnValue([
       "/project/settings.local.json",
       "/project/settings.json",
     ]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       cron-parser:
         specifier: ^5.5.0
         version: 5.5.0
+      find-up:
+        specifier: ^8.0.0
+        version: 8.0.0
       fuzzysort:
         specifier: ^3.1.0
         version: 3.1.0
@@ -1468,6 +1471,10 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
+  find-up@8.0.0:
+    resolution: {integrity: sha512-JGG8pvDi2C+JxidYdIwQDyS/CgcrIdh18cvgxcBge3wSHRQOrooMD3GlFBcmMJAN9M42SAZjDp5zv1dglJjwww==}
+    engines: {node: '>=20'}
+
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
@@ -1892,6 +1899,10 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  locate-path@8.0.0:
+    resolution: {integrity: sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg==}
+    engines: {node: '>=20'}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -2087,9 +2098,17 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-limit@4.0.0:
+    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-locate@6.0.0:
+    resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -2598,6 +2617,10 @@ packages:
     resolution: {integrity: sha512-MJZrkjyd7DeC+uPZh+5/YaMDxFiiEEaDgbUSVMXayofAkDWF1088CDo+2RPg7B1BuS1qf1vgNE7xqwPxE0DuSQ==}
     engines: {node: '>=20.18.1'}
 
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -2783,6 +2806,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
 
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
@@ -4141,6 +4168,11 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
+  find-up@8.0.0:
+    dependencies:
+      locate-path: 8.0.0
+      unicorn-magic: 0.3.0
+
   flat-cache@4.0.1:
     dependencies:
       flatted: 3.3.3
@@ -4614,6 +4646,10 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  locate-path@8.0.0:
+    dependencies:
+      p-locate: 6.0.0
+
   lodash.merge@4.6.2: {}
 
   log-update@6.1.0:
@@ -4793,9 +4829,17 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-limit@4.0.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-locate@6.0.0:
+    dependencies:
+      p-limit: 4.0.0
 
   package-json-from-dist@1.0.1: {}
 
@@ -5375,6 +5419,8 @@ snapshots:
   undici@7.20.0:
     optional: true
 
+  unicorn-magic@0.3.0: {}
+
   unpipe@1.0.0: {}
 
   uri-js@4.4.1:
@@ -5550,6 +5596,8 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.2: {}
 
   yoga-layout@3.2.1: {}
 


### PR DESCRIPTION
Replace hardcoded __dirname relative paths with findUpSync('package.json')
to correctly resolve vendor/ and builtin/ directories even when the SDK
is bundled by esbuild (e.g. into a VS Code extension).

- Add getPackageRoot() with module-level caching in configPaths.ts
- Update getBuiltinSkillsDir/getBuiltinSubagentsDir to use getPackageRoot()
- Update ripgrep.ts rgPath to use getPackageRoot()
- Fix plugin-loading-integration test: remove vi.mock on configPaths,
  use vi.spyOn to preserve unmocked exports
