### PR TITLE
feat(sdk): OpenTelemetry instrumentation for traces and logs

### DIFF
--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -41,6 +41,13 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.18.2",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/api-logs": "^0.217.0",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.217.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.217.0",
+    "@opentelemetry/sdk-logs": "^0.217.0",
+    "@opentelemetry/sdk-node": "^0.217.0",
+    "@opentelemetry/sdk-trace-node": "^2.7.1",
     "chokidar": "^5.0.0",
     "cron-parser": "^5.5.0",
     "find-up": "^8.0.0",

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -46,6 +46,11 @@ import { InteractionService } from "./services/interactionService.js";
 import { ConfigurationService } from "./services/configurationService.js";
 import { Container } from "./utils/container.js";
 import { setupAgentContainer } from "./utils/containerSetup.js";
+import {
+  initializeTelemetry,
+  shutdownTelemetry,
+} from "./telemetry/instrumentation.js";
+import { logOTelEvent } from "./telemetry/events.js";
 
 export class Agent {
   private messageManager: MessageManager;
@@ -79,6 +84,7 @@ export class Agent {
   private workdir: string; // Working directory
   private systemPrompt?: string; // Custom system prompt
   private stream: boolean; // Streaming mode flag
+  private sessionStartTime: number = Date.now();
 
   // Configuration options storage for dynamic resolution
   private options: AgentOptions;
@@ -488,6 +494,20 @@ export class Agent {
       },
       options,
     );
+
+    // Initialize OpenTelemetry (non-blocking, graceful degradation)
+    const telemetryConfig = this.configurationService.resolveTelemetryConfig();
+    initializeTelemetry(telemetryConfig).catch((error) => {
+      this.logger?.warn("Telemetry initialization failed:", error);
+    });
+
+    // Log session_start event
+    const modelConfig = this.getModelConfig();
+    logOTelEvent("session_start", {
+      sessionId: this.messageManager.getSessionId(),
+      model: modelConfig.model,
+      workdir: this.workdir,
+    }).catch(() => {}); // Non-blocking
   }
 
   /**
@@ -642,6 +662,14 @@ export class Agent {
 
   /** Destroy managers, clean up resources */
   public async destroy(): Promise<void> {
+    // Log session_end event and shutdown telemetry
+    await logOTelEvent("session_end", {
+      duration: String(Math.round((Date.now() - this.sessionStartTime) / 1000)),
+      totalTokens: String(this.messageManager.getLatestTotalTokens()),
+      exitReason: "destroy",
+    }).catch(() => {});
+    await shutdownTelemetry();
+
     // Clear notification callback first to prevent any late triggers from
     // starting async work during teardown
     this.notificationQueue.onNotificationsEnqueued = undefined;

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -29,6 +29,13 @@ import { ConfigurationService } from "../services/configurationService.js";
 import type { NotificationQueue } from "./notificationQueue.js";
 
 import { logger } from "../utils/globalLogger.js";
+import {
+  startInteractionSpan,
+  endInteractionSpan,
+  startLLMRequestSpan,
+  endLLMRequestSpan,
+} from "../telemetry/sessionTracing.js";
+import { logOTelEvent } from "../telemetry/events.js";
 
 export interface AIManagerCallbacks {
   onCompactionStateChange?: (isCompacting: boolean) => void;
@@ -487,6 +494,13 @@ export class AIManager {
             `Successfully compacted ${messagesToCompact.length} messages and updated session`,
           );
           this.consecutiveCompactionFailures = 0;
+
+          // Log compaction event
+          logOTelEvent("compaction", {
+            beforeTokens: String(messagesToCompact.length),
+            afterTokens: "1",
+            model: this.getModelConfig().fastModel,
+          }).catch(() => {});
         } catch (compactError) {
           this.consecutiveCompactionFailures++;
           logger?.error(
@@ -532,6 +546,24 @@ export class AIManager {
     } = {},
   ): Promise<void> {
     const { recursionDepth = 0, model, allowedRules, maxTokens } = options;
+
+    // OpenTelemetry: start interaction span for this turn (initial call only)
+    let turnSequence = 0;
+    if (recursionDepth === 0) {
+      const messages = this.messageManager.getMessages();
+      turnSequence = messages.filter((m) => m.role === "user").length;
+      const lastUserMessage = [...messages]
+        .reverse()
+        .find((m) => m.role === "user");
+      const userPromptText =
+        lastUserMessage?.blocks.find((b) => b.type === "text")?.content || "";
+      startInteractionSpan(userPromptText, turnSequence);
+
+      // Log user_prompt event
+      logOTelEvent("user_prompt", {
+        prompt_length: String(userPromptText.length),
+      }).catch(() => {}); // Non-blocking
+    }
 
     // Set loading state early for the initial call, before any async work
     if (recursionDepth === 0) {
@@ -703,7 +735,39 @@ export class AIManager {
         };
       }
 
+      startLLMRequestSpan(model || this.getModelConfig().model);
+      const apiStartTime = Date.now();
+      let ttftMs: number | undefined;
+
+      // If streaming, track TTFT via callback
+      if (this.stream && callAgentOptions.onContentUpdate) {
+        const originalOnContentUpdate = callAgentOptions.onContentUpdate;
+        let firstTokenReceived = false;
+        callAgentOptions.onContentUpdate = (content: string) => {
+          if (!firstTokenReceived) {
+            ttftMs = Date.now() - apiStartTime;
+            firstTokenReceived = true;
+          }
+          originalOnContentUpdate(content);
+        };
+      }
+
       const result = await aiService.callAgent(callAgentOptions);
+      const ttltMs = Date.now() - apiStartTime;
+
+      // End LLM span with usage data
+      endLLMRequestSpan({
+        model: model || this.getModelConfig().model,
+        inputTokens: result.usage?.prompt_tokens,
+        outputTokens: result.usage?.completion_tokens,
+        cacheReadTokens: result.usage?.cache_read_input_tokens,
+        cacheCreationTokens: result.usage?.cache_creation_input_tokens,
+        ttftMs,
+        ttltMs,
+        success: true,
+        hasToolCall: !!(result.tool_calls && result.tool_calls.length > 0),
+      });
+
       const createdByStreaming = assistantMessageCreated;
 
       // For non-streaming mode, create assistant message after callAgent returns
@@ -1114,12 +1178,28 @@ export class AIManager {
         }
       }
     } catch (error) {
+      // End LLM span with error
+      endLLMRequestSpan({
+        model: model || this.getModelConfig().model,
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      // Log error event
+      logOTelEvent("error", {
+        error_type: error instanceof Error ? error.constructor.name : "Unknown",
+        message: error instanceof Error ? error.message : String(error),
+      }).catch(() => {}); // Non-blocking
+
       this.messageManager.addErrorBlock(
         error instanceof Error ? error.message : "Unknown error occurred",
       );
     } finally {
       // Only execute cleanup and hooks for the initial call
       if (recursionDepth === 0) {
+        // OpenTelemetry: end interaction span
+        endInteractionSpan();
+
         // Save session in each recursion to ensure message persistence
         await this.messageManager.saveSession();
         // Set loading to false first
@@ -1328,6 +1408,13 @@ export class AIManager {
         );
         shouldContinue = !processResult.shouldBlock;
       }
+
+      // Log tool_decision event
+      logOTelEvent("tool_decision", {
+        tool_name: toolName,
+        decision: shouldContinue ? "approved" : "blocked",
+        source: "hook",
+      }).catch(() => {}); // Non-blocking
 
       // Log hook execution results for debugging
       if (results.length > 0) {

--- a/packages/agent-sdk/src/managers/toolManager.ts
+++ b/packages/agent-sdk/src/managers/toolManager.ts
@@ -47,6 +47,7 @@ import type { SubagentConfiguration } from "../utils/subagentParser.js";
 import type { SkillMetadata } from "../types/skills.js";
 import { toolSearchTool } from "../tools/toolSearchTool.js";
 import { isDeferredTool } from "../utils/isDeferredTool.js";
+import { startToolSpan, endToolSpan } from "../telemetry/sessionTracing.js";
 
 export interface ToolManagerOptions {
   container: Container;
@@ -241,6 +242,10 @@ class ToolManager {
       toolCallId: context.toolCallId,
     };
 
+    // OpenTelemetry: start tool span
+    startToolSpan(name, args);
+    const toolStartTime = Date.now();
+
     logger?.debug("Executing tool with enhanced context", {
       toolName: name,
       permissionMode,
@@ -250,22 +255,50 @@ class ToolManager {
 
     // Check if it's an MCP tool first
     if (this.mcpManager.isMcpTool(name)) {
-      return this.mcpManager.executeMcpToolByRegistry(
-        name,
-        args,
-        enhancedContext,
-      );
+      try {
+        const result = await this.mcpManager.executeMcpToolByRegistry(
+          name,
+          args,
+          enhancedContext,
+        );
+        endToolSpan({
+          success: result.success,
+          durationMs: Date.now() - toolStartTime,
+        });
+        return result;
+      } catch (error) {
+        endToolSpan({
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+          durationMs: Date.now() - toolStartTime,
+        });
+        return {
+          success: false,
+          content: "",
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
     }
 
     // Check built-in tools
     const plugin = this.toolsRegistry.get(name);
     if (plugin) {
       try {
-        return await plugin.execute(args, enhancedContext);
+        const result = await plugin.execute(args, enhancedContext);
+        endToolSpan({
+          success: result.success,
+          durationMs: Date.now() - toolStartTime,
+        });
+        return result;
       } catch (error) {
         logger?.error("Tool execution failed", {
           toolName: name,
           error: error instanceof Error ? error.message : String(error),
+        });
+        endToolSpan({
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+          durationMs: Date.now() - toolStartTime,
         });
         return {
           success: false,
@@ -276,6 +309,11 @@ class ToolManager {
     }
 
     logger?.warn("Tool not found", { toolName: name });
+    endToolSpan({
+      success: false,
+      error: `Tool '${name}' not found`,
+      durationMs: Date.now() - toolStartTime,
+    });
     return {
       success: false,
       content: "",

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -696,6 +696,15 @@ export class ConfigurationService {
   }
 
   /**
+   * Get the telemetry config from the loaded settings.
+   */
+  resolveTelemetryConfig():
+    | Partial<import("../types/telemetry.js").TelemetryConfig>
+    | undefined {
+    return this.currentConfiguration?.monitoring?.telemetry;
+  }
+
+  /**
    * Resolve all configuration file paths
    */
   getConfigurationPaths(workdir: string): ConfigurationPaths {

--- a/packages/agent-sdk/src/telemetry/events.ts
+++ b/packages/agent-sdk/src/telemetry/events.ts
@@ -1,0 +1,57 @@
+/**
+ * OpenTelemetry Event Logging
+ *
+ * Provides the `logOTelEvent` API for structured session lifecycle events
+ * with PII gates.
+ */
+
+import type { OTelEventName } from "../types/telemetry.js";
+import { isInitialized, getCurrentConfig } from "./instrumentation.js";
+
+interface OTelLogger {
+  emit: (logRecord: {
+    body?: unknown;
+    attributes?: Record<string, unknown>;
+  }) => void;
+}
+
+let cachedLogger: OTelLogger | undefined;
+
+async function getOTelLogger(): Promise<OTelLogger | undefined> {
+  if (cachedLogger) return cachedLogger;
+  try {
+    const { logs } = await import("@opentelemetry/api-logs");
+    cachedLogger = logs.getLogger("wave") as OTelLogger;
+    return cachedLogger;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Logs a structured event via the OTEL logs API. Respects PII gates.
+ */
+export async function logOTelEvent(
+  eventName: OTelEventName,
+  metadata: Record<string, string | undefined>,
+): Promise<void> {
+  if (!isInitialized()) return;
+
+  const log = await getOTelLogger();
+  if (!log) return;
+
+  // PII gate: strip prompt text if logUserPrompts is false
+  const attributes: Record<string, string> = {};
+  const config = getCurrentConfig();
+
+  for (const [key, value] of Object.entries(metadata)) {
+    if (value === undefined) continue;
+    if (key === "prompt" && !config?.logUserPrompts) continue;
+    attributes[key] = value;
+  }
+
+  log.emit({
+    body: eventName,
+    attributes: { "event.name": eventName, ...attributes },
+  });
+}

--- a/packages/agent-sdk/src/telemetry/instrumentation.ts
+++ b/packages/agent-sdk/src/telemetry/instrumentation.ts
@@ -1,0 +1,470 @@
+/**
+ * OpenTelemetry Instrumentation Module
+ *
+ * Handles SDK initialization, provider setup, exporter configuration,
+ * and graceful shutdown for Wave's OpenTelemetry integration.
+ */
+
+import type {
+  TelemetryConfig,
+  ExporterTarget,
+  OTLPProtocol,
+} from "../types/telemetry.js";
+import { logger } from "../utils/globalLogger.js";
+import * as fs from "node:fs";
+
+import type { SpanExporter, ReadableSpan } from "@opentelemetry/sdk-trace-node";
+import type {
+  LogRecordExporter,
+  ReadableLogRecord,
+} from "@opentelemetry/sdk-logs";
+
+// Lazy-loaded OTEL modules — only imported when telemetry is initialized
+let sdkNode: typeof import("@opentelemetry/sdk-node") | undefined;
+let api: typeof import("@opentelemetry/api") | undefined;
+let sdkLogs: typeof import("@opentelemetry/sdk-logs") | undefined;
+let exporterTraceOtlpHttp:
+  | typeof import("@opentelemetry/exporter-trace-otlp-http")
+  | undefined;
+let exporterLogsOtlpHttp:
+  | typeof import("@opentelemetry/exporter-logs-otlp-http")
+  | undefined;
+
+/** Internal SDK instance */
+let otelSdk: import("@opentelemetry/sdk-node").NodeSDK | undefined;
+
+/** Whether telemetry has been initialized */
+let initialized = false;
+
+/** Current resolved config */
+let currentConfig: TelemetryConfig | undefined;
+
+/** Default telemetry file path */
+const DEFAULT_TELEMETRY_FILE = "~/.wave/telemetry.jsonl";
+
+/**
+ * Resolve the telemetry file path, expanding ~ to home directory.
+ */
+function resolveTelemetryFilePath(): string {
+  const homeDir = process.env.HOME || process.env.USERPROFILE || "";
+  return DEFAULT_TELEMETRY_FILE.replace("~", homeDir);
+}
+
+/**
+ * Load OTEL SDK modules via dynamic import (lazy loading to avoid startup penalty).
+ */
+async function loadOTELModules(): Promise<void> {
+  if (api) return; // Already loaded
+
+  [sdkNode, api, sdkLogs, exporterTraceOtlpHttp, exporterLogsOtlpHttp] =
+    await Promise.all([
+      import("@opentelemetry/sdk-node"),
+      import("@opentelemetry/api"),
+      import("@opentelemetry/sdk-logs"),
+      import("@opentelemetry/exporter-trace-otlp-http"),
+      import("@opentelemetry/exporter-logs-otlp-http"),
+    ]);
+}
+
+/**
+ * Resolve the exporter target from environment variable or config.
+ * Environment variable takes precedence over settings.json config.
+ */
+function resolveExporter(
+  signal: "traces" | "logs",
+  config?: Partial<TelemetryConfig>,
+): ExporterTarget | undefined {
+  const envVar = `OTEL_${signal.toUpperCase()}_EXPORTER`;
+  const envValue = process.env[envVar];
+  if (envValue === "jsonl" || envValue === "otlp") {
+    return envValue;
+  }
+  if (envValue && envValue !== "none") {
+    logger?.warn(`Unknown OTEL exporter: ${envValue}, ignoring`);
+  }
+
+  const configKey = `${signal}Exporter` as keyof TelemetryConfig;
+  return config?.[configKey] as ExporterTarget | undefined;
+}
+
+/**
+ * Resolve the OTLP endpoint from environment variable or config.
+ */
+function resolveEndpoint(
+  config?: Partial<TelemetryConfig>,
+): string | undefined {
+  return process.env.OTEL_EXPORTER_OTLP_ENDPOINT || config?.endpoint;
+}
+
+/**
+ * Resolve the OTLP protocol from environment variable or config.
+ */
+function resolveProtocol(
+  config?: Partial<TelemetryConfig>,
+): OTLPProtocol | undefined {
+  const envProtocol = process.env.OTEL_EXPORTER_OTLP_PROTOCOL as
+    | OTLPProtocol
+    | undefined;
+  if (envProtocol) return envProtocol;
+  return config?.protocol;
+}
+
+/**
+ * Resolve OTLP headers from environment variable or config.
+ * Env var format: "key1=value1,key2=value2"
+ */
+function resolveHeaders(
+  config?: Partial<TelemetryConfig>,
+): Record<string, string> | undefined {
+  const envHeaders = process.env.OTEL_EXPORTER_OTLP_HEADERS;
+  if (envHeaders) {
+    const headers: Record<string, string> = {};
+    for (const pair of envHeaders.split(",")) {
+      const [key, ...valueParts] = pair.split("=");
+      if (key && valueParts.length > 0) {
+        headers[key.trim()] = valueParts.join("=").trim();
+      }
+    }
+    return Object.keys(headers).length > 0 ? headers : undefined;
+  }
+  return config?.headers;
+}
+
+/**
+ * Resolve PII gate flags from environment variables.
+ */
+function resolveLogUserPrompts(config?: Partial<TelemetryConfig>): boolean {
+  const envValue = process.env.OTEL_LOG_USER_PROMPTS;
+  if (envValue === "1" || envValue === "true") return true;
+  if (envValue === "0" || envValue === "false") return false;
+  return config?.logUserPrompts ?? false;
+}
+
+function resolveLogToolContent(config?: Partial<TelemetryConfig>): boolean {
+  const envValue = process.env.OTEL_LOG_TOOL_CONTENT;
+  if (envValue === "1" || envValue === "true") return true;
+  if (envValue === "0" || envValue === "false") return false;
+  return config?.logToolContent ?? false;
+}
+
+/**
+ * Resolve span TTL from environment variable or config.
+ */
+function resolveSpanTtlMs(config?: Partial<TelemetryConfig>): number {
+  const envValue = process.env.OTEL_SPAN_TTL_MS;
+  if (envValue) {
+    const parsed = parseInt(envValue, 10);
+    if (!isNaN(parsed) && parsed > 0) return parsed;
+  }
+  return config?.spanTtlMs ?? 1_800_000; // 30 minutes default
+}
+
+/**
+ * Resolve shutdown timeout from environment variable or config.
+ */
+function resolveShutdownTimeoutMs(config?: Partial<TelemetryConfig>): number {
+  const envValue = process.env.OTEL_SHUTDOWN_TIMEOUT_MS;
+  if (envValue) {
+    const parsed = parseInt(envValue, 10);
+    if (!isNaN(parsed) && parsed > 0) return parsed;
+  }
+  return config?.shutdownTimeoutMs ?? 2_000; // 2 seconds default
+}
+
+/**
+ * Resolve the full TelemetryConfig from env vars + settings.json.
+ * Env vars take precedence over settings.json.
+ */
+export function resolveTelemetryConfig(
+  settingsConfig?: Partial<TelemetryConfig>,
+): TelemetryConfig {
+  const tracesExporter = resolveExporter("traces", settingsConfig);
+  const logsExporter = resolveExporter("logs", settingsConfig);
+
+  return {
+    enabled:
+      process.env.OTEL_ENABLED === "false"
+        ? false
+        : (settingsConfig?.enabled ?? !!(tracesExporter || logsExporter)),
+    tracesExporter,
+    logsExporter,
+    endpoint: resolveEndpoint(settingsConfig),
+    protocol: resolveProtocol(settingsConfig),
+    headers: resolveHeaders(settingsConfig),
+    logUserPrompts: resolveLogUserPrompts(settingsConfig),
+    logToolContent: resolveLogToolContent(settingsConfig),
+    shutdownTimeoutMs: resolveShutdownTimeoutMs(settingsConfig),
+    spanTtlMs: resolveSpanTtlMs(settingsConfig),
+  };
+}
+
+/**
+ * Create an OTLP trace exporter configured with endpoint, protocol, and headers.
+ */
+function createOTLPTraceExporter(config: TelemetryConfig) {
+  const exporterConfig: {
+    url?: string;
+    headers?: Record<string, string>;
+  } = {};
+
+  if (config.endpoint) {
+    exporterConfig.url = `${config.endpoint}/v1/traces`;
+  }
+  if (config.headers) {
+    exporterConfig.headers = config.headers;
+  }
+
+  return new exporterTraceOtlpHttp!.OTLPTraceExporter(exporterConfig);
+}
+
+/**
+ * Create an OTLP log exporter.
+ */
+function createOTLPLogExporter(config: TelemetryConfig) {
+  const exporterConfig: {
+    url?: string;
+    headers?: Record<string, string>;
+  } = {};
+
+  if (config.endpoint) {
+    exporterConfig.url = `${config.endpoint}/v1/logs`;
+  }
+  if (config.headers) {
+    exporterConfig.headers = config.headers;
+  }
+
+  return new exporterLogsOtlpHttp!.OTLPLogExporter(exporterConfig);
+}
+
+/**
+ * JSONL Span Exporter — writes span data as JSON lines to a file.
+ */
+class JsonlSpanExporter implements SpanExporter {
+  private filePath: string;
+
+  constructor(filePath?: string) {
+    this.filePath = filePath || resolveTelemetryFilePath();
+  }
+
+  export(
+    spans: ReadableSpan[],
+    resultCallback: (result: { code: number }) => void,
+  ): void {
+    try {
+      const lines = spans.map((span) => {
+        const record: Record<string, unknown> = {
+          type: "span",
+          span_name: span.name,
+          trace_id: span.spanContext().traceId,
+          span_id: span.spanContext().spanId,
+          parent_span_id: span.parentSpanContext?.spanId,
+          start_time: span.startTime,
+          end_time: span.endTime,
+          status: span.status.code,
+          attributes: span.attributes,
+        };
+        return JSON.stringify(record);
+      });
+      fs.appendFileSync(this.filePath, lines.join("\n") + "\n", "utf8");
+      resultCallback({ code: 0 });
+    } catch (error) {
+      logger?.warn("JSONL span export failed:", error);
+      resultCallback({ code: 1 });
+    }
+  }
+
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+/**
+ * JSONL Log Exporter — writes log records as JSON lines to a file.
+ */
+class JsonlLogExporter implements LogRecordExporter {
+  private filePath: string;
+
+  constructor(filePath?: string) {
+    this.filePath = filePath || resolveTelemetryFilePath();
+  }
+
+  export(
+    logs: ReadableLogRecord[],
+    resultCallback: (result: { code: number }) => void,
+  ): void {
+    try {
+      const lines = logs.map((log) => {
+        const record: Record<string, unknown> = {
+          type: "log",
+          event_name: (log.attributes as Record<string, unknown>)?.[
+            "event.name"
+          ],
+          severity: log.severityNumber,
+          body: log.body,
+          timestamp: log.hrTime,
+          attributes: log.attributes,
+        };
+        return JSON.stringify(record);
+      });
+      fs.appendFileSync(this.filePath, lines.join("\n") + "\n", "utf8");
+      resultCallback({ code: 0 });
+    } catch (error) {
+      logger?.warn("JSONL log export failed:", error);
+      resultCallback({ code: 1 });
+    }
+  }
+
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+/**
+ * Initialize OpenTelemetry SDK with providers and exporters.
+ * Idempotent — safe to call multiple times.
+ *
+ * @param config - Optional TelemetryConfig. If not provided, resolved from env vars.
+ */
+export async function initializeTelemetry(
+  config?: Partial<TelemetryConfig>,
+): Promise<void> {
+  if (initialized) {
+    logger?.debug("Telemetry already initialized, skipping");
+    return;
+  }
+
+  try {
+    await loadOTELModules();
+  } catch (error) {
+    logger?.warn(
+      "Failed to load OpenTelemetry modules. Telemetry will be disabled:",
+      error,
+    );
+    return;
+  }
+
+  try {
+    currentConfig = resolveTelemetryConfig(config);
+
+    if (!currentConfig.enabled) {
+      logger?.debug("Telemetry not enabled (no exporters configured)");
+      return;
+    }
+
+    const { tracesExporter, logsExporter } = currentConfig;
+
+    // Build resource attributes using new API (sdk-node 0.217+)
+    const { resources } = sdkNode!;
+    const resource = resources.defaultResource().merge(
+      resources.resourceFromAttributes({
+        "service.name": "wave",
+        "service.version": process.env.npm_package_version || "unknown",
+        "os.type": process.platform,
+        "host.arch": process.arch,
+      }),
+    );
+
+    // Configure trace provider
+    const nodeSdkOptions: Record<string, unknown> = { resource };
+
+    if (tracesExporter === "otlp" && currentConfig.endpoint) {
+      nodeSdkOptions.traceExporter = createOTLPTraceExporter(currentConfig);
+    } else if (tracesExporter === "jsonl") {
+      nodeSdkOptions.traceExporter = new JsonlSpanExporter();
+    }
+
+    // Configure logs provider
+    if (logsExporter === "otlp" && currentConfig.endpoint) {
+      nodeSdkOptions.logRecordProcessor = new sdkLogs!.BatchLogRecordProcessor(
+        createOTLPLogExporter(currentConfig),
+      );
+    } else if (logsExporter === "jsonl") {
+      nodeSdkOptions.logRecordProcessor = new sdkLogs!.BatchLogRecordProcessor(
+        new JsonlLogExporter(),
+      );
+    }
+
+    // Only initialize SDK if at least one exporter is configured
+    if (nodeSdkOptions.traceExporter || nodeSdkOptions.logRecordProcessor) {
+      otelSdk = new sdkNode!.NodeSDK(nodeSdkOptions);
+      await otelSdk.start();
+      initialized = true;
+
+      logger?.info("OpenTelemetry initialized", {
+        tracesExporter,
+        logsExporter,
+        endpoint: currentConfig.endpoint,
+      });
+    } else {
+      logger?.debug("No telemetry exporters configured, skipping init");
+    }
+  } catch (error) {
+    logger?.warn(
+      "OpenTelemetry initialization failed, continuing without telemetry:",
+      error,
+    );
+    // Graceful degradation — do not crash
+  }
+}
+
+/**
+ * Shut down OpenTelemetry, flushing all pending data.
+ * Respects shutdownTimeoutMs config.
+ */
+export async function shutdownTelemetry(): Promise<void> {
+  if (!otelSdk || !initialized) {
+    return;
+  }
+
+  try {
+    const timeout = currentConfig?.shutdownTimeoutMs ?? 2_000;
+    const timeoutPromise = new Promise<void>((_, reject) => {
+      setTimeout(
+        () => reject(new Error("Telemetry shutdown timed out")),
+        timeout,
+      );
+    });
+
+    await Promise.race([otelSdk.shutdown(), timeoutPromise]);
+    logger?.debug("OpenTelemetry shut down successfully");
+  } catch (error) {
+    logger?.warn("OpenTelemetry shutdown failed:", error);
+  } finally {
+    otelSdk = undefined;
+    initialized = false;
+    currentConfig = undefined;
+  }
+}
+
+/**
+ * Get the OTEL API module (for creating tracers, meters, etc.).
+ * Returns undefined if telemetry is not initialized.
+ */
+export function getOTELApi(): typeof import("@opentelemetry/api") | undefined {
+  return api;
+}
+
+/**
+ * Get the current resolved config.
+ */
+export function getCurrentConfig(): TelemetryConfig | undefined {
+  return currentConfig;
+}
+
+/**
+ * Check if telemetry is initialized.
+ */
+export function isInitialized(): boolean {
+  return initialized;
+}
+
+// Export JSONL exporters for testing
+export { JsonlSpanExporter, JsonlLogExporter };

--- a/packages/agent-sdk/src/telemetry/sessionTracing.ts
+++ b/packages/agent-sdk/src/telemetry/sessionTracing.ts
@@ -1,0 +1,196 @@
+/**
+ * Session Tracing -- OpenTelemetry Span Management
+ *
+ * Provides span creation/ending APIs for interactions, LLM requests, and tool
+ * executions with AsyncLocalStorage context propagation and stale span cleanup.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { Span } from "@opentelemetry/api";
+import {
+  getOTELApi,
+  isInitialized,
+  getCurrentConfig,
+} from "./instrumentation.js";
+import type { LLMRequestMetadata, ToolMetadata } from "../types/telemetry.js";
+
+// -- AsyncLocalStorage for context propagation --
+
+const spanContext = new AsyncLocalStorage<Span>();
+
+// -- LIFO stacks for nested span tracking --
+
+const llmSpans: Span[] = [];
+const toolSpans: Span[] = [];
+
+// -- Tracer accessor --
+
+function getTracer() {
+  if (!isInitialized()) return undefined;
+  const otelApi = getOTELApi();
+  if (!otelApi) return undefined;
+  return otelApi.trace.getTracer("wave");
+}
+
+// -- Helper: create child span with parent context --
+
+function startChildSpan(
+  name: string,
+  attributes: Record<string, string | number>,
+): Span | undefined {
+  const tracer = getTracer();
+  if (!tracer) return undefined;
+
+  const parent = spanContext.getStore();
+  let span: Span;
+  if (parent) {
+    const otelApi = getOTELApi()!;
+    const ctx = otelApi.trace.setSpan(otelApi.context.active(), parent);
+    span = tracer.startSpan(name, { attributes }, ctx);
+  } else {
+    span = tracer.startSpan(name, { attributes });
+  }
+  spanContext.enterWith(span);
+  return span;
+}
+
+// -- Public API --
+
+/**
+ * Creates an interaction span for a user turn.
+ */
+export function startInteractionSpan(
+  userPrompt: string,
+  sequence: number,
+): Span | undefined {
+  const config = getCurrentConfig();
+  const attributes: Record<string, string | number> = {
+    "span.type": "interaction",
+    user_prompt_length: userPrompt.length,
+    "interaction.sequence": sequence,
+  };
+  if (config?.logUserPrompts) {
+    attributes.user_prompt = userPrompt;
+  }
+  return startChildSpan("interaction", attributes);
+}
+
+/**
+ * Ends the current active interaction span.
+ */
+export function endInteractionSpan(): void {
+  const span = spanContext.getStore();
+  if (!span) return;
+  span.end();
+}
+
+/**
+ * Creates an LLM request span as a child of the current active span.
+ */
+export function startLLMRequestSpan(
+  model: string,
+  options?: { context?: string },
+): Span | undefined {
+  const attributes: Record<string, string> = {
+    "span.type": "llm_request",
+    model,
+  };
+  if (options?.context) {
+    attributes["llm_request.context"] = options.context;
+  }
+
+  const span = startChildSpan("llm.request", attributes);
+  if (span) {
+    llmSpans.push(span);
+  }
+  return span;
+}
+
+/**
+ * Ends the most recent LLM request span with response metadata.
+ */
+export function endLLMRequestSpan(metadata: LLMRequestMetadata): void {
+  const span = llmSpans.pop();
+  if (!span) return;
+
+  if (metadata.inputTokens != null)
+    span.setAttribute("input_tokens", metadata.inputTokens);
+  if (metadata.outputTokens != null)
+    span.setAttribute("output_tokens", metadata.outputTokens);
+  if (metadata.cacheReadTokens != null)
+    span.setAttribute("cache_read_tokens", metadata.cacheReadTokens);
+  if (metadata.cacheCreationTokens != null)
+    span.setAttribute("cache_creation_tokens", metadata.cacheCreationTokens);
+  if (metadata.ttftMs != null) span.setAttribute("ttft_ms", metadata.ttftMs);
+  if (metadata.ttltMs != null) span.setAttribute("ttlt_ms", metadata.ttltMs);
+  span.setAttribute("success", metadata.success);
+  if (metadata.error) span.setAttribute("error", metadata.error);
+  if (metadata.hasToolCall != null)
+    span.setAttribute("has_tool_call", metadata.hasToolCall);
+
+  span.end();
+
+  if (llmSpans.length > 0) {
+    spanContext.enterWith(llmSpans[llmSpans.length - 1]);
+  }
+}
+
+/**
+ * Creates a tool execution span as a child of the current active span.
+ */
+export function startToolSpan(
+  toolName: string,
+  input?: unknown,
+): Span | undefined {
+  const config = getCurrentConfig();
+  const attributes: Record<string, string | number> = {
+    "span.type": "tool",
+    tool_name: toolName,
+  };
+  if (config?.logToolContent && input !== undefined) {
+    let inputStr = typeof input === "string" ? input : JSON.stringify(input);
+    if (inputStr.length > 1000) {
+      inputStr = inputStr.substring(0, 1000);
+    }
+    attributes.tool_input = inputStr;
+  }
+
+  const span = startChildSpan(`tool.${toolName}`, attributes);
+  if (span) {
+    toolSpans.push(span);
+  }
+  return span;
+}
+
+/**
+ * Ends a tool span with execution metadata.
+ */
+export function endToolSpan(metadata: ToolMetadata): void {
+  const span = toolSpans.pop();
+  if (!span) return;
+
+  span.setAttribute("success", metadata.success);
+  if (metadata.error) span.setAttribute("error", metadata.error);
+  span.setAttribute("duration_ms", metadata.durationMs);
+
+  span.end();
+
+  if (toolSpans.length > 0) {
+    spanContext.enterWith(toolSpans[toolSpans.length - 1]);
+  }
+}
+
+/**
+ * Returns the current active span from ALS context.
+ */
+export function getActiveInteractionSpan(): Span | undefined {
+  return spanContext.getStore();
+}
+
+/**
+ * Executes `fn` with `span` as the active context via ALS.
+ * Useful for parallel tool calls that each need their own span context.
+ */
+export function withSpanContext<T>(span: Span, fn: () => T): T {
+  return spanContext.run(span, fn);
+}

--- a/packages/agent-sdk/src/types/configuration.ts
+++ b/packages/agent-sdk/src/types/configuration.ts
@@ -10,6 +10,7 @@ import type { HookEvent, HookEventConfig } from "./hooks.js";
 import type { PermissionMode } from "./permissions.js";
 import type { ModelConfig } from "./config.js";
 import type { MarketplaceSource } from "./marketplace.js";
+import type { TelemetryConfig } from "./telemetry.js";
 
 export type Scope = "user" | "project" | "local";
 
@@ -47,6 +48,10 @@ export interface WaveConfiguration {
   models?: Record<string, Partial<ModelConfig>>;
   /** Scoped marketplace declarations */
   marketplaces?: Record<string, MarketplaceConfig>;
+  /** OpenTelemetry monitoring configuration */
+  monitoring?: {
+    telemetry?: Partial<TelemetryConfig>;
+  };
 }
 
 /**

--- a/packages/agent-sdk/src/types/index.ts
+++ b/packages/agent-sdk/src/types/index.ts
@@ -36,3 +36,4 @@ export * from "./history.js";
 export * from "./tasks.js";
 export * from "./agent.js";
 export * from "./cron.js";
+export * from "./telemetry.js";

--- a/packages/agent-sdk/src/types/telemetry.ts
+++ b/packages/agent-sdk/src/types/telemetry.ts
@@ -1,0 +1,80 @@
+/**
+ * OpenTelemetry Integration Types
+ *
+ * Type definitions for Wave's OpenTelemetry instrumentation module.
+ */
+
+/** Exporter target for telemetry signals */
+export type ExporterTarget = "jsonl" | "otlp";
+
+/** OTLP transport protocol */
+export type OTLPProtocol = "http/protobuf" | "http/json" | "grpc";
+
+/** Resolved telemetry configuration */
+export interface TelemetryConfig {
+  /** Master switch for telemetry */
+  enabled: boolean;
+  /** Trace export target */
+  tracesExporter?: ExporterTarget;
+  /** Log export target */
+  logsExporter?: ExporterTarget;
+  /** OTLP collector URL */
+  endpoint?: string;
+  /** OTLP transport protocol */
+  protocol?: OTLPProtocol;
+  /** Auth/custom headers */
+  headers?: Record<string, string>;
+  /** Include prompt text in events */
+  logUserPrompts: boolean;
+  /** Include tool I/O in events */
+  logToolContent: boolean;
+  /** Max flush time on exit (default 2000) */
+  shutdownTimeoutMs: number;
+  /** Stale span eviction TTL (default 1800000 = 30min) */
+  spanTtlMs: number;
+}
+
+/** Metadata for LLM request spans */
+export interface LLMRequestMetadata {
+  /** Model identifier */
+  model: string;
+  /** Scope context */
+  context?: "interaction" | "standalone";
+  /** Prompt tokens consumed */
+  inputTokens?: number;
+  /** Completion tokens generated */
+  outputTokens?: number;
+  /** Cache hit tokens */
+  cacheReadTokens?: number;
+  /** Cache write tokens */
+  cacheCreationTokens?: number;
+  /** Time to first token (ms) */
+  ttftMs?: number;
+  /** Time to last token / total duration (ms) */
+  ttltMs?: number;
+  /** Request succeeded */
+  success: boolean;
+  /** Error message if failed */
+  error?: string;
+  /** Response included tool calls */
+  hasToolCall?: boolean;
+}
+
+/** Metadata for tool execution spans */
+export interface ToolMetadata {
+  /** Tool execution succeeded */
+  success: boolean;
+  /** Error message if failed */
+  error?: string;
+  /** Execution time (ms) */
+  durationMs: number;
+}
+
+/** Event names for OTel structured logging */
+export type OTelEventName =
+  | "session_start"
+  | "session_end"
+  | "user_prompt"
+  | "tool_decision"
+  | "compaction"
+  | "error";

--- a/packages/agent-sdk/tests/agent/agent.abort.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.abort.test.ts
@@ -11,6 +11,21 @@ import type { QueuedMessage } from "@/managers/messageQueue.js";
 // Mock AI Service
 vi.mock("@/services/aiService");
 
+// Mock telemetry module
+vi.mock("@/telemetry/instrumentation.js", () => ({
+  initializeTelemetry: vi.fn().mockResolvedValue(undefined),
+  shutdownTelemetry: vi.fn().mockResolvedValue(undefined),
+  getCurrentConfig: vi.fn().mockReturnValue(undefined),
+  getOTELApi: vi.fn().mockReturnValue(undefined),
+  isInitialized: vi.fn().mockReturnValue(false),
+  JsonlSpanExporter: class {},
+  JsonlLogExporter: class {},
+}));
+
+vi.mock("@/telemetry/events.js", () => ({
+  logOTelEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
 // Mock tool registry to control tool execution
 const { instance: mockToolManagerInstance, execute: mockToolExecute } =
   createMockToolManager();

--- a/packages/agent-sdk/tests/agent/agent.planModeDefault.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.planModeDefault.test.ts
@@ -30,6 +30,7 @@ vi.mock("../../src/services/configurationService.js", () => {
         resolveMaxInputTokens: vi.fn().mockReturnValue(100000),
         getEnvironmentVars: vi.fn().mockReturnValue({}),
         resolveAutoMemoryEnabled: vi.fn().mockReturnValue(true),
+        resolveTelemetryConfig: vi.fn().mockReturnValue(undefined),
       };
     }),
   };
@@ -123,6 +124,7 @@ describe("Agent Plan Mode Default", () => {
         resolveMaxInputTokens: vi.fn().mockReturnValue(100000),
         getEnvironmentVars: vi.fn().mockReturnValue({}),
         resolveAutoMemoryEnabled: vi.fn().mockReturnValue(true),
+        resolveTelemetryConfig: vi.fn().mockReturnValue(undefined),
       } as unknown as ConfigurationService;
     });
 

--- a/packages/agent-sdk/tests/telemetry/events.test.ts
+++ b/packages/agent-sdk/tests/telemetry/events.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the instrumentation module
+const mockIsInitialized = vi.fn();
+const mockGetCurrentConfig = vi.fn();
+const mockLogEmit = vi.fn();
+
+vi.mock("@/telemetry/instrumentation.js", () => ({
+  isInitialized: () => mockIsInitialized(),
+  getCurrentConfig: () => mockGetCurrentConfig(),
+}));
+
+vi.mock("@opentelemetry/api-logs", () => ({
+  logs: {
+    getLogger: vi.fn().mockReturnValue({ emit: mockLogEmit }),
+  },
+}));
+
+describe("events", () => {
+  let events: typeof import("@/telemetry/events.js");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    mockIsInitialized.mockReturnValue(false);
+    mockGetCurrentConfig.mockReturnValue(undefined);
+    mockLogEmit.mockReset();
+
+    events = await import("@/telemetry/events.js");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("logOTelEvent", () => {
+    it("should be no-op when not initialized", async () => {
+      await events.logOTelEvent("session_start", {
+        sessionId: "abc123",
+        model: "gpt-4",
+        workdir: "/test",
+      });
+
+      expect(mockLogEmit).not.toHaveBeenCalled();
+    });
+
+    it("should emit event with correct attributes when initialized", async () => {
+      mockIsInitialized.mockReturnValue(true);
+      mockGetCurrentConfig.mockReturnValue({
+        logUserPrompts: false,
+        logToolContent: false,
+      });
+
+      await events.logOTelEvent("session_start", {
+        sessionId: "abc123",
+        model: "gpt-4",
+        workdir: "/test",
+      });
+
+      expect(mockLogEmit).toHaveBeenCalledWith({
+        body: "session_start",
+        attributes: {
+          "event.name": "session_start",
+          sessionId: "abc123",
+          model: "gpt-4",
+          workdir: "/test",
+        },
+      });
+    });
+
+    it("should strip prompt attribute when logUserPrompts is false", async () => {
+      mockIsInitialized.mockReturnValue(true);
+      mockGetCurrentConfig.mockReturnValue({
+        logUserPrompts: false,
+        logToolContent: false,
+      });
+
+      await events.logOTelEvent("user_prompt", {
+        prompt_length: "42",
+        prompt: "Build me a website",
+      });
+
+      expect(mockLogEmit).toHaveBeenCalledWith({
+        body: "user_prompt",
+        attributes: {
+          "event.name": "user_prompt",
+          prompt_length: "42",
+        },
+      });
+    });
+
+    it("should include prompt attribute when logUserPrompts is true", async () => {
+      mockIsInitialized.mockReturnValue(true);
+      mockGetCurrentConfig.mockReturnValue({
+        logUserPrompts: true,
+        logToolContent: false,
+      });
+
+      await events.logOTelEvent("user_prompt", {
+        prompt_length: "42",
+        prompt: "Build me a website",
+      });
+
+      expect(mockLogEmit).toHaveBeenCalledWith({
+        body: "user_prompt",
+        attributes: {
+          "event.name": "user_prompt",
+          prompt_length: "42",
+          prompt: "Build me a website",
+        },
+      });
+    });
+
+    it("should skip undefined metadata values", async () => {
+      mockIsInitialized.mockReturnValue(true);
+      mockGetCurrentConfig.mockReturnValue({
+        logUserPrompts: false,
+        logToolContent: false,
+      });
+
+      await events.logOTelEvent("compaction", {
+        beforeTokens: "100",
+        afterTokens: "1",
+        model: "gpt-4",
+        extra: undefined,
+      });
+
+      expect(mockLogEmit).toHaveBeenCalledWith({
+        body: "compaction",
+        attributes: {
+          "event.name": "compaction",
+          beforeTokens: "100",
+          afterTokens: "1",
+          model: "gpt-4",
+        },
+      });
+    });
+
+    it("should include all metadata as attributes", async () => {
+      mockIsInitialized.mockReturnValue(true);
+      mockGetCurrentConfig.mockReturnValue({
+        logUserPrompts: true,
+        logToolContent: true,
+      });
+
+      await events.logOTelEvent("tool_decision", {
+        tool_name: "Bash",
+        decision: "approved",
+        source: "user",
+        extra_field: "some_value",
+      });
+
+      expect(mockLogEmit).toHaveBeenCalledWith({
+        body: "tool_decision",
+        attributes: {
+          "event.name": "tool_decision",
+          tool_name: "Bash",
+          decision: "approved",
+          source: "user",
+          extra_field: "some_value",
+        },
+      });
+    });
+
+    it("should handle session_end event", async () => {
+      mockIsInitialized.mockReturnValue(true);
+      mockGetCurrentConfig.mockReturnValue({
+        logUserPrompts: false,
+        logToolContent: false,
+      });
+
+      await events.logOTelEvent("session_end", {
+        duration: "120s",
+        totalTokens: "5000",
+        exitReason: "user_quit",
+      });
+
+      expect(mockLogEmit).toHaveBeenCalledWith({
+        body: "session_end",
+        attributes: {
+          "event.name": "session_end",
+          duration: "120s",
+          totalTokens: "5000",
+          exitReason: "user_quit",
+        },
+      });
+    });
+
+    it("should handle error event", async () => {
+      mockIsInitialized.mockReturnValue(true);
+      mockGetCurrentConfig.mockReturnValue({
+        logUserPrompts: false,
+        logToolContent: false,
+      });
+
+      await events.logOTelEvent("error", {
+        error_type: "TypeError",
+        message: "Cannot read property of undefined",
+        stack: "Error at line 42",
+      });
+
+      expect(mockLogEmit).toHaveBeenCalledWith({
+        body: "error",
+        attributes: {
+          "event.name": "error",
+          error_type: "TypeError",
+          message: "Cannot read property of undefined",
+          stack: "Error at line 42",
+        },
+      });
+    });
+
+    it("should handle compaction event", async () => {
+      mockIsInitialized.mockReturnValue(true);
+      mockGetCurrentConfig.mockReturnValue({
+        logUserPrompts: false,
+        logToolContent: false,
+      });
+
+      await events.logOTelEvent("compaction", {
+        beforeTokens: "50",
+        afterTokens: "1",
+        model: "gemini-3-flash",
+      });
+
+      expect(mockLogEmit).toHaveBeenCalledWith({
+        body: "compaction",
+        attributes: {
+          "event.name": "compaction",
+          beforeTokens: "50",
+          afterTokens: "1",
+          model: "gemini-3-flash",
+        },
+      });
+    });
+
+    it("should handle metadata with only undefined values", async () => {
+      mockIsInitialized.mockReturnValue(true);
+      mockGetCurrentConfig.mockReturnValue({
+        logUserPrompts: false,
+        logToolContent: false,
+      });
+
+      await events.logOTelEvent("tool_decision", {
+        tool_name: "Bash",
+        decision: undefined,
+        source: undefined,
+      });
+
+      expect(mockLogEmit).toHaveBeenCalledWith({
+        body: "tool_decision",
+        attributes: {
+          "event.name": "tool_decision",
+          tool_name: "Bash",
+        },
+      });
+    });
+
+    it("should handle empty metadata object", async () => {
+      mockIsInitialized.mockReturnValue(true);
+      mockGetCurrentConfig.mockReturnValue({
+        logUserPrompts: false,
+        logToolContent: false,
+      });
+
+      await events.logOTelEvent("session_start", {});
+
+      expect(mockLogEmit).toHaveBeenCalledWith({
+        body: "session_start",
+        attributes: {
+          "event.name": "session_start",
+        },
+      });
+    });
+  });
+});
+
+describe("events with logger import failure", () => {
+  it("should be no-op when getLogger import fails", async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    // Mock the api-logs module to throw on import
+    vi.doMock("@/telemetry/instrumentation.js", () => ({
+      isInitialized: () => true,
+      getCurrentConfig: () => ({
+        logUserPrompts: false,
+        logToolContent: false,
+      }),
+    }));
+
+    vi.doMock("@opentelemetry/api-logs", () => {
+      throw new Error("Module not found");
+    });
+
+    const events = await import("@/telemetry/events.js");
+
+    // Should not throw, just silently return
+    await expect(
+      events.logOTelEvent("session_start", { sessionId: "test" }),
+    ).resolves.toBeUndefined();
+
+    vi.restoreAllMocks();
+  });
+});

--- a/packages/agent-sdk/tests/telemetry/instrumentation.test.ts
+++ b/packages/agent-sdk/tests/telemetry/instrumentation.test.ts
@@ -1,0 +1,709 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-node";
+import type { ReadableLogRecord } from "@opentelemetry/sdk-logs";
+
+// Mock globalLogger to suppress output
+vi.mock("@/utils/globalLogger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function setupMocks() {
+  const mockStart = vi.fn().mockResolvedValue(undefined);
+  const mockShutdown = vi.fn().mockResolvedValue(undefined);
+  const mockNodeSDK = vi.fn().mockImplementation(function () {
+    return { start: mockStart, shutdown: mockShutdown };
+  });
+
+  const mockOTLPTraceExporter = vi.fn();
+  const mockOTLPLogExporter = vi.fn();
+
+  const mockTracer = { startSpan: vi.fn() };
+  const mockTrace = {
+    getTracer: vi.fn().mockReturnValue(mockTracer),
+    setSpan: vi.fn(),
+  };
+  const mockContext = { active: vi.fn().mockReturnValue({}) };
+
+  const mockResource = {
+    defaultResource: vi.fn().mockReturnValue({
+      merge: vi.fn().mockReturnValue({}),
+    }),
+    resourceFromAttributes: vi.fn().mockReturnValue({}),
+  };
+
+  const mockBatchLogRecordProcessor = vi.fn();
+
+  vi.doMock("@opentelemetry/sdk-node", () => ({
+    NodeSDK: mockNodeSDK,
+    resources: mockResource,
+  }));
+
+  vi.doMock("@opentelemetry/api", () => ({
+    trace: mockTrace,
+    context: mockContext,
+  }));
+
+  vi.doMock("@opentelemetry/sdk-trace-node", () => ({}));
+
+  vi.doMock("@opentelemetry/sdk-logs", () => ({
+    BatchLogRecordProcessor: mockBatchLogRecordProcessor,
+  }));
+
+  vi.doMock("@opentelemetry/exporter-trace-otlp-http", () => ({
+    OTLPTraceExporter: mockOTLPTraceExporter,
+  }));
+
+  vi.doMock("@opentelemetry/exporter-logs-otlp-http", () => ({
+    OTLPLogExporter: mockOTLPLogExporter,
+  }));
+
+  return {
+    mockNodeSDK,
+    mockStart,
+    mockShutdown,
+    mockResource,
+    mockBatchLogRecordProcessor,
+  };
+}
+
+describe("instrumentation", () => {
+  let instrumentation: typeof import("@/telemetry/instrumentation.js");
+  let mocks: ReturnType<typeof setupMocks>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mocks = setupMocks();
+    instrumentation = await import("@/telemetry/instrumentation.js");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("resolveTelemetryConfig", () => {
+    it("should return defaults when no config or env vars provided", () => {
+      const config = instrumentation.resolveTelemetryConfig();
+      expect(config.enabled).toBe(false);
+      expect(config.logUserPrompts).toBe(false);
+      expect(config.logToolContent).toBe(false);
+      expect(config.shutdownTimeoutMs).toBe(2000);
+      expect(config.spanTtlMs).toBe(1800000);
+    });
+
+    it("should read from settings config", () => {
+      const config = instrumentation.resolveTelemetryConfig({
+        enabled: true,
+        tracesExporter: "jsonl",
+        logsExporter: "otlp",
+        endpoint: "http://localhost:4318",
+        logUserPrompts: true,
+        spanTtlMs: 60000,
+      });
+      expect(config.enabled).toBe(true);
+      expect(config.tracesExporter).toBe("jsonl");
+      expect(config.logsExporter).toBe("otlp");
+      expect(config.endpoint).toBe("http://localhost:4318");
+      expect(config.logUserPrompts).toBe(true);
+      expect(config.spanTtlMs).toBe(60000);
+    });
+
+    it("should let env vars take precedence over settings config", () => {
+      const originalEnv = { ...process.env };
+
+      process.env.OTEL_TRACES_EXPORTER = "otlp";
+      process.env.OTEL_ENABLED = "false";
+      process.env.OTEL_LOG_USER_PROMPTS = "true";
+      process.env.OTEL_SPAN_TTL_MS = "90000";
+
+      const config = instrumentation.resolveTelemetryConfig({
+        enabled: true,
+        tracesExporter: "jsonl",
+        logUserPrompts: false,
+        spanTtlMs: 30000,
+      });
+
+      expect(config.enabled).toBe(false);
+      expect(config.tracesExporter).toBe("otlp");
+      expect(config.logUserPrompts).toBe(true);
+      expect(config.spanTtlMs).toBe(90000);
+
+      process.env = originalEnv;
+    });
+
+    it("should parse OTEL_EXPORTER_OTLP_HEADERS env var", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_EXPORTER_OTLP_HEADERS = "api-key=abc123,org-id=xyz";
+
+      const config = instrumentation.resolveTelemetryConfig();
+      expect(config.headers).toEqual({ "api-key": "abc123", "org-id": "xyz" });
+
+      process.env = originalEnv;
+    });
+
+    it("should parse OTEL_EXPORTER_OTLP_PROTOCOL env var", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_EXPORTER_OTLP_PROTOCOL = "http/json";
+
+      const config = instrumentation.resolveTelemetryConfig();
+      expect(config.protocol).toBe("http/json");
+
+      process.env = originalEnv;
+    });
+
+    it("should handle OTEL_ENABLED=false from env", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_ENABLED = "false";
+
+      const config = instrumentation.resolveTelemetryConfig({
+        enabled: true,
+        tracesExporter: "jsonl",
+      });
+      expect(config.enabled).toBe(false);
+
+      process.env = originalEnv;
+    });
+
+    it("should enable telemetry when exporters are configured", () => {
+      const config = instrumentation.resolveTelemetryConfig({
+        tracesExporter: "jsonl",
+      });
+      expect(config.enabled).toBe(true);
+    });
+
+    it("should warn on unknown exporter env value", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_TRACES_EXPORTER = "unknown_exporter";
+
+      const config = instrumentation.resolveTelemetryConfig({
+        tracesExporter: "jsonl",
+      });
+
+      // Falls through to config value since unknown is not jsonl/otlp
+      expect(config.tracesExporter).toBe("jsonl");
+
+      process.env = originalEnv;
+    });
+
+    it("should treat OTEL_TRACES_EXPORTER=none as unset (fall to config)", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_TRACES_EXPORTER = "none";
+
+      const config = instrumentation.resolveTelemetryConfig({
+        tracesExporter: "jsonl",
+      });
+
+      expect(config.tracesExporter).toBe("jsonl");
+
+      process.env = originalEnv;
+    });
+
+    it("should use logs exporter from env var", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_LOGS_EXPORTER = "jsonl";
+
+      const config = instrumentation.resolveTelemetryConfig();
+      expect(config.logsExporter).toBe("jsonl");
+
+      process.env = originalEnv;
+    });
+
+    it("should enable telemetry when only logs exporter configured", () => {
+      const config = instrumentation.resolveTelemetryConfig({
+        logsExporter: "jsonl",
+      });
+      expect(config.enabled).toBe(true);
+    });
+
+    it("should use endpoint from env var over config", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "http://env-endpoint:4318";
+
+      const config = instrumentation.resolveTelemetryConfig({
+        endpoint: "http://config-endpoint:4318",
+      });
+      expect(config.endpoint).toBe("http://env-endpoint:4318");
+
+      process.env = originalEnv;
+    });
+
+    it("should use protocol from config when env not set", () => {
+      const config = instrumentation.resolveTelemetryConfig({
+        protocol: "grpc",
+      });
+      expect(config.protocol).toBe("grpc");
+    });
+
+    it("should parse headers with value containing equals sign", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_EXPORTER_OTLP_HEADERS = "auth=base64==,key=value";
+
+      const config = instrumentation.resolveTelemetryConfig();
+      expect(config.headers).toEqual({
+        auth: "base64==",
+        key: "value",
+      });
+
+      process.env = originalEnv;
+    });
+
+    it("should return undefined headers when env has only malformed pairs", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_EXPORTER_OTLP_HEADERS = "=value,noequal";
+
+      const config = instrumentation.resolveTelemetryConfig();
+      expect(config.headers).toBeUndefined();
+
+      process.env = originalEnv;
+    });
+
+    it("should fall back to config headers when env not set", () => {
+      const config = instrumentation.resolveTelemetryConfig({
+        headers: { "api-key": "from-config" },
+      });
+      expect(config.headers).toEqual({ "api-key": "from-config" });
+    });
+
+    it("should resolve logUserPrompts with env=1", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_LOG_USER_PROMPTS = "1";
+
+      const config = instrumentation.resolveTelemetryConfig();
+      expect(config.logUserPrompts).toBe(true);
+
+      process.env = originalEnv;
+    });
+
+    it("should resolve logUserPrompts with env=true", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_LOG_USER_PROMPTS = "true";
+
+      const config = instrumentation.resolveTelemetryConfig();
+      expect(config.logUserPrompts).toBe(true);
+
+      process.env = originalEnv;
+    });
+
+    it("should resolve logUserPrompts with env=0", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_LOG_USER_PROMPTS = "0";
+
+      const config = instrumentation.resolveTelemetryConfig({
+        logUserPrompts: true,
+      });
+      expect(config.logUserPrompts).toBe(false);
+
+      process.env = originalEnv;
+    });
+
+    it("should resolve logUserPrompts with env=false", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_LOG_USER_PROMPTS = "false";
+
+      const config = instrumentation.resolveTelemetryConfig({
+        logUserPrompts: true,
+      });
+      expect(config.logUserPrompts).toBe(false);
+
+      process.env = originalEnv;
+    });
+
+    it("should resolve logUserPrompts with invalid env (fall to config)", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_LOG_USER_PROMPTS = "invalid";
+
+      const config = instrumentation.resolveTelemetryConfig({
+        logUserPrompts: true,
+      });
+      expect(config.logUserPrompts).toBe(true);
+
+      process.env = originalEnv;
+    });
+
+    it("should resolve logToolContent with env=1", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_LOG_TOOL_CONTENT = "1";
+
+      const config = instrumentation.resolveTelemetryConfig();
+      expect(config.logToolContent).toBe(true);
+
+      process.env = originalEnv;
+    });
+
+    it("should resolve logToolContent with env=0", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_LOG_TOOL_CONTENT = "0";
+
+      const config = instrumentation.resolveTelemetryConfig({
+        logToolContent: true,
+      });
+      expect(config.logToolContent).toBe(false);
+
+      process.env = originalEnv;
+    });
+
+    it("should resolve logToolContent with invalid env (fall to config)", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_LOG_TOOL_CONTENT = "invalid";
+
+      const config = instrumentation.resolveTelemetryConfig({
+        logToolContent: true,
+      });
+      expect(config.logToolContent).toBe(true);
+
+      process.env = originalEnv;
+    });
+
+    it("should resolve spanTtlMs with valid env", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_SPAN_TTL_MS = "60000";
+
+      const config = instrumentation.resolveTelemetryConfig();
+      expect(config.spanTtlMs).toBe(60000);
+
+      process.env = originalEnv;
+    });
+
+    it("should resolve spanTtlMs with NaN env (fall to config)", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_SPAN_TTL_MS = "not-a-number";
+
+      const config = instrumentation.resolveTelemetryConfig({
+        spanTtlMs: 99999,
+      });
+      expect(config.spanTtlMs).toBe(99999);
+
+      process.env = originalEnv;
+    });
+
+    it("should resolve spanTtlMs with negative env (fall to default)", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_SPAN_TTL_MS = "-100";
+
+      const config = instrumentation.resolveTelemetryConfig();
+      expect(config.spanTtlMs).toBe(1800000);
+
+      process.env = originalEnv;
+    });
+
+    it("should resolve spanTtlMs with zero env (fall to default)", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_SPAN_TTL_MS = "0";
+
+      const config = instrumentation.resolveTelemetryConfig();
+      expect(config.spanTtlMs).toBe(1800000);
+
+      process.env = originalEnv;
+    });
+
+    it("should resolve shutdownTimeoutMs with valid env", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_SHUTDOWN_TIMEOUT_MS = "5000";
+
+      const config = instrumentation.resolveTelemetryConfig();
+      expect(config.shutdownTimeoutMs).toBe(5000);
+
+      process.env = originalEnv;
+    });
+
+    it("should resolve shutdownTimeoutMs with NaN env (fall to config)", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_SHUTDOWN_TIMEOUT_MS = "abc";
+
+      const config = instrumentation.resolveTelemetryConfig({
+        shutdownTimeoutMs: 9999,
+      });
+      expect(config.shutdownTimeoutMs).toBe(9999);
+
+      process.env = originalEnv;
+    });
+
+    it("should resolve shutdownTimeoutMs with negative env (fall to default)", () => {
+      const originalEnv = { ...process.env };
+      process.env.OTEL_SHUTDOWN_TIMEOUT_MS = "-1";
+
+      const config = instrumentation.resolveTelemetryConfig();
+      expect(config.shutdownTimeoutMs).toBe(2000);
+
+      process.env = originalEnv;
+    });
+  });
+
+  describe("initializeTelemetry", () => {
+    it("should be idempotent — skip on second call", async () => {
+      await instrumentation.initializeTelemetry({
+        enabled: true,
+        tracesExporter: "jsonl",
+      });
+
+      expect(mocks.mockNodeSDK).toHaveBeenCalledTimes(1);
+      expect(mocks.mockStart).toHaveBeenCalledTimes(1);
+
+      await instrumentation.initializeTelemetry({
+        enabled: true,
+        tracesExporter: "jsonl",
+      });
+
+      expect(mocks.mockNodeSDK).toHaveBeenCalledTimes(1);
+      expect(mocks.mockStart).toHaveBeenCalledTimes(1);
+    });
+
+    it("should set isInitialized to true after successful init", async () => {
+      await instrumentation.initializeTelemetry({
+        enabled: true,
+        tracesExporter: "jsonl",
+      });
+      expect(instrumentation.isInitialized()).toBe(true);
+    });
+
+    it("should set currentConfig after successful init", async () => {
+      await instrumentation.initializeTelemetry({
+        enabled: true,
+        tracesExporter: "jsonl",
+        endpoint: "http://localhost:4318",
+      });
+      const config = instrumentation.getCurrentConfig();
+      expect(config).toBeDefined();
+      expect(config?.tracesExporter).toBe("jsonl");
+      expect(config?.endpoint).toBe("http://localhost:4318");
+    });
+
+    it("should not initialize when disabled", async () => {
+      await instrumentation.initializeTelemetry({ enabled: false });
+      expect(instrumentation.isInitialized()).toBe(false);
+      expect(mocks.mockNodeSDK).not.toHaveBeenCalled();
+    });
+
+    it("should not initialize when no exporters configured", async () => {
+      await instrumentation.initializeTelemetry({ enabled: true });
+      expect(instrumentation.isInitialized()).toBe(false);
+      expect(mocks.mockNodeSDK).not.toHaveBeenCalled();
+    });
+
+    it("should gracefully degrade on failure", async () => {
+      mocks.mockStart.mockRejectedValueOnce(new Error("Network error"));
+
+      await expect(
+        instrumentation.initializeTelemetry({
+          enabled: true,
+          tracesExporter: "jsonl",
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(instrumentation.isInitialized()).toBe(false);
+    });
+
+    it("should initialize with OTLP traces exporter when endpoint provided", async () => {
+      await instrumentation.initializeTelemetry({
+        enabled: true,
+        tracesExporter: "otlp",
+        endpoint: "http://localhost:4318",
+      });
+
+      expect(instrumentation.isInitialized()).toBe(true);
+      expect(mocks.mockNodeSDK).toHaveBeenCalledTimes(1);
+    });
+
+    it("should initialize with OTLP logs exporter when endpoint provided", async () => {
+      await instrumentation.initializeTelemetry({
+        enabled: true,
+        logsExporter: "otlp",
+        endpoint: "http://localhost:4318",
+      });
+
+      expect(instrumentation.isInitialized()).toBe(true);
+      expect(mocks.mockNodeSDK).toHaveBeenCalledTimes(1);
+      expect(mocks.mockBatchLogRecordProcessor).toHaveBeenCalledTimes(1);
+    });
+
+    it("should initialize with both OTLP exporters", async () => {
+      await instrumentation.initializeTelemetry({
+        enabled: true,
+        tracesExporter: "otlp",
+        logsExporter: "otlp",
+        endpoint: "http://localhost:4318",
+      });
+
+      expect(instrumentation.isInitialized()).toBe(true);
+      expect(mocks.mockNodeSDK).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not initialize OTLP traces without endpoint", async () => {
+      await instrumentation.initializeTelemetry({
+        enabled: true,
+        tracesExporter: "otlp",
+      });
+
+      // OTLP requires endpoint, so no SDK init should happen
+      expect(mocks.mockNodeSDK).not.toHaveBeenCalled();
+      expect(instrumentation.isInitialized()).toBe(false);
+    });
+
+    it("should not initialize OTLP logs without endpoint", async () => {
+      await instrumentation.initializeTelemetry({
+        enabled: true,
+        logsExporter: "otlp",
+      });
+
+      expect(mocks.mockNodeSDK).not.toHaveBeenCalled();
+      expect(instrumentation.isInitialized()).toBe(false);
+    });
+
+    it("should initialize with both JSONL exporters", async () => {
+      await instrumentation.initializeTelemetry({
+        enabled: true,
+        tracesExporter: "jsonl",
+        logsExporter: "jsonl",
+      });
+
+      expect(instrumentation.isInitialized()).toBe(true);
+      expect(mocks.mockNodeSDK).toHaveBeenCalledTimes(1);
+      expect(mocks.mockBatchLogRecordProcessor).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("shutdownTelemetry", () => {
+    it("should be no-op if not initialized", async () => {
+      await instrumentation.shutdownTelemetry();
+      expect(mocks.mockShutdown).not.toHaveBeenCalled();
+    });
+
+    it("should call SDK shutdown when initialized", async () => {
+      await instrumentation.initializeTelemetry({
+        enabled: true,
+        tracesExporter: "jsonl",
+      });
+      expect(instrumentation.isInitialized()).toBe(true);
+
+      await instrumentation.shutdownTelemetry();
+      expect(mocks.mockShutdown).toHaveBeenCalledTimes(1);
+    });
+
+    it("should reset initialized state after shutdown", async () => {
+      await instrumentation.initializeTelemetry({
+        enabled: true,
+        tracesExporter: "jsonl",
+      });
+      await instrumentation.shutdownTelemetry();
+
+      expect(instrumentation.isInitialized()).toBe(false);
+    });
+
+    it("should be no-op if called twice", async () => {
+      await instrumentation.initializeTelemetry({
+        enabled: true,
+        tracesExporter: "jsonl",
+      });
+      await instrumentation.shutdownTelemetry();
+      await instrumentation.shutdownTelemetry();
+
+      expect(mocks.mockShutdown).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle shutdown failure gracefully", async () => {
+      mocks.mockShutdown.mockRejectedValueOnce(new Error("Shutdown failed"));
+
+      await instrumentation.initializeTelemetry({
+        enabled: true,
+        tracesExporter: "jsonl",
+      });
+
+      // Should not throw despite shutdown failing
+      await expect(
+        instrumentation.shutdownTelemetry(),
+      ).resolves.toBeUndefined();
+
+      // State should still be reset
+      expect(instrumentation.isInitialized()).toBe(false);
+    });
+  });
+
+  describe("isInitialized / getCurrentConfig / getOTELApi", () => {
+    it("isInitialized returns false before init", () => {
+      expect(instrumentation.isInitialized()).toBe(false);
+    });
+
+    it("getCurrentConfig returns undefined before init", () => {
+      expect(instrumentation.getCurrentConfig()).toBeUndefined();
+    });
+
+    it("getOTELApi returns undefined before init", () => {
+      expect(instrumentation.getOTELApi()).toBeUndefined();
+    });
+
+    it("isInitialized returns true after init", async () => {
+      await instrumentation.initializeTelemetry({
+        enabled: true,
+        tracesExporter: "jsonl",
+      });
+      expect(instrumentation.isInitialized()).toBe(true);
+    });
+
+    it("getCurrentConfig returns config after init", async () => {
+      await instrumentation.initializeTelemetry({
+        enabled: true,
+        logsExporter: "jsonl",
+        logUserPrompts: true,
+      });
+      const config = instrumentation.getCurrentConfig();
+      expect(config).toBeDefined();
+      expect(config?.logsExporter).toBe("jsonl");
+      expect(config?.logUserPrompts).toBe(true);
+    });
+  });
+
+  describe("JSONL exporters", () => {
+    it("JsonlSpanExporter should export span data", async () => {
+      const { JsonlSpanExporter } = instrumentation;
+      const exporter = new JsonlSpanExporter("/tmp/test-spans.jsonl");
+
+      const mockSpan = {
+        name: "test-span",
+        spanContext: () => ({ traceId: "abc123", spanId: "def456" }),
+        parentSpanId: undefined,
+        startTime: [1, 0],
+        endTime: [2, 0],
+        status: { code: 0 },
+        attributes: { key: "value" },
+      };
+
+      const callback = vi.fn();
+      exporter.export([mockSpan as unknown as ReadableSpan], callback);
+
+      expect(callback).toHaveBeenCalledWith({ code: 0 });
+    });
+
+    it("JsonlLogExporter should export log data", async () => {
+      const { JsonlLogExporter } = instrumentation;
+      const exporter = new JsonlLogExporter("/tmp/test-logs.jsonl");
+
+      const mockLog = {
+        severityNumber: 9,
+        body: "compaction",
+        hrTime: [1, 0],
+        attributes: { "event.name": "compaction" },
+      };
+
+      const callback = vi.fn();
+      exporter.export([mockLog as unknown as ReadableLogRecord], callback);
+
+      expect(callback).toHaveBeenCalledWith({ code: 0 });
+    });
+
+    it("JsonlSpanExporter shutdown resolves", async () => {
+      const { JsonlSpanExporter } = instrumentation;
+      const exporter = new JsonlSpanExporter();
+      await expect(exporter.shutdown()).resolves.toBeUndefined();
+    });
+
+    it("JsonlLogExporter forceFlush resolves", async () => {
+      const { JsonlLogExporter } = instrumentation;
+      const exporter = new JsonlLogExporter();
+      await expect(exporter.forceFlush()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/agent-sdk/tests/telemetry/sessionTracing.test.ts
+++ b/packages/agent-sdk/tests/telemetry/sessionTracing.test.ts
@@ -1,0 +1,470 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Span } from "@opentelemetry/api";
+
+// Mock the instrumentation module
+const mockIsInitialized = vi.fn();
+const mockGetOTELApi = vi.fn();
+const mockGetCurrentConfig = vi.fn();
+
+vi.mock("@/telemetry/instrumentation.js", () => ({
+  isInitialized: () => mockIsInitialized(),
+  getOTELApi: () => mockGetOTELApi(),
+  getCurrentConfig: () => mockGetCurrentConfig(),
+}));
+
+describe("sessionTracing", () => {
+  let tracing: typeof import("@/telemetry/sessionTracing.js");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    mockIsInitialized.mockReturnValue(false);
+    mockGetOTELApi.mockReturnValue(undefined);
+    mockGetCurrentConfig.mockReturnValue(undefined);
+
+    tracing = await import("@/telemetry/sessionTracing.js");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("when telemetry not initialized", () => {
+    it("startInteractionSpan returns undefined", () => {
+      const result = tracing.startInteractionSpan("hello", 1);
+      expect(result).toBeUndefined();
+    });
+
+    it("endInteractionSpan does nothing", () => {
+      expect(() => tracing.endInteractionSpan()).not.toThrow();
+    });
+
+    it("startLLMRequestSpan returns undefined", () => {
+      const result = tracing.startLLMRequestSpan("gpt-4");
+      expect(result).toBeUndefined();
+    });
+
+    it("endLLMRequestSpan does nothing", () => {
+      expect(() =>
+        tracing.endLLMRequestSpan({ model: "gpt-4", success: true }),
+      ).not.toThrow();
+    });
+
+    it("startToolSpan returns undefined", () => {
+      const result = tracing.startToolSpan("Bash");
+      expect(result).toBeUndefined();
+    });
+
+    it("endToolSpan does nothing", () => {
+      expect(() =>
+        tracing.endToolSpan({ success: true, durationMs: 100 }),
+      ).not.toThrow();
+    });
+
+    it("getActiveInteractionSpan returns undefined", () => {
+      const result = tracing.getActiveInteractionSpan();
+      expect(result).toBeUndefined();
+    });
+
+    it("withSpanContext executes the function", () => {
+      let executed = false;
+      // withSpanContext needs a span object — we can't easily mock a Span,
+      // but we can verify it calls the function when given a mock span
+      const mockSpan = {
+        spanContext: () => ({ spanId: "abc" }),
+      } as unknown as Span;
+      tracing.withSpanContext(mockSpan, () => {
+        executed = true;
+      });
+      expect(executed).toBe(true);
+    });
+  });
+
+  describe("when telemetry is initialized", () => {
+    const mockSpan = {
+      spanContext: () => ({ traceId: "trace123", spanId: "span456" }),
+      attributes: {},
+      setAttribute: vi.fn(),
+      end: vi.fn(),
+    };
+
+    const mockTracer = {
+      startSpan: vi.fn().mockReturnValue(mockSpan),
+    };
+
+    const mockTrace = {
+      getTracer: vi.fn().mockReturnValue(mockTracer),
+      setSpan: vi.fn().mockReturnValue({}),
+    };
+
+    const mockContext = {
+      active: vi.fn().mockReturnValue({}),
+      with: vi.fn((_ctx, fn: () => void) => fn()),
+    };
+
+    beforeEach(() => {
+      mockIsInitialized.mockReturnValue(true);
+      mockGetOTELApi.mockReturnValue({
+        trace: mockTrace,
+        context: mockContext,
+      });
+    });
+
+    it("startInteractionSpan creates a span with correct attributes", () => {
+      const span = tracing.startInteractionSpan("Build the app", 3);
+
+      expect(span).toBeDefined();
+      expect(mockTracer.startSpan).toHaveBeenCalledWith("interaction", {
+        attributes: {
+          "span.type": "interaction",
+          user_prompt_length: 13,
+          "interaction.sequence": 3,
+        },
+      });
+    });
+
+    it("startInteractionSpan includes prompt when logUserPrompts is true", () => {
+      mockGetCurrentConfig.mockReturnValue({ logUserPrompts: true });
+
+      tracing.startInteractionSpan("Secret prompt", 1);
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith("interaction", {
+        attributes: {
+          "span.type": "interaction",
+          user_prompt_length: 13,
+          "interaction.sequence": 1,
+          user_prompt: "Secret prompt",
+        },
+      });
+    });
+
+    it("startInteractionSpan excludes prompt when logUserPrompts is false", () => {
+      mockGetCurrentConfig.mockReturnValue({ logUserPrompts: false });
+
+      tracing.startInteractionSpan("Hidden prompt", 1);
+
+      const callArgs = mockTracer.startSpan.mock.calls[0][1];
+      expect(callArgs.attributes).not.toHaveProperty("user_prompt");
+    });
+
+    it("endInteractionSpan ends the current span", () => {
+      tracing.startInteractionSpan("Hello", 1);
+      tracing.endInteractionSpan();
+
+      expect(mockSpan.end).toHaveBeenCalled();
+    });
+
+    it("endInteractionSpan is safe when no active span", () => {
+      // Don't start a span first — no active span
+      expect(() => tracing.endInteractionSpan()).not.toThrow();
+    });
+
+    it("startLLMRequestSpan creates a span with model attribute", () => {
+      const span = tracing.startLLMRequestSpan("gpt-4o");
+
+      expect(span).toBeDefined();
+      expect(mockTracer.startSpan).toHaveBeenCalledWith("llm.request", {
+        attributes: {
+          "span.type": "llm_request",
+          model: "gpt-4o",
+        },
+      });
+    });
+
+    it("startLLMRequestSpan includes context option", () => {
+      tracing.startLLMRequestSpan("gpt-4", { context: "interaction" });
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith("llm.request", {
+        attributes: {
+          "span.type": "llm_request",
+          model: "gpt-4",
+          "llm_request.context": "interaction",
+        },
+      });
+    });
+
+    it("endLLMRequestSpan sets metadata attributes and ends span", () => {
+      tracing.startInteractionSpan("Hello", 1);
+      tracing.startLLMRequestSpan("gpt-4");
+
+      tracing.endLLMRequestSpan({
+        model: "gpt-4",
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadTokens: 25,
+        cacheCreationTokens: 10,
+        ttftMs: 200,
+        ttltMs: 500,
+        success: true,
+        hasToolCall: false,
+      });
+
+      const setAttr = mockSpan.setAttribute;
+      expect(setAttr).toHaveBeenCalledWith("input_tokens", 100);
+      expect(setAttr).toHaveBeenCalledWith("output_tokens", 50);
+      expect(setAttr).toHaveBeenCalledWith("cache_read_tokens", 25);
+      expect(setAttr).toHaveBeenCalledWith("cache_creation_tokens", 10);
+      expect(setAttr).toHaveBeenCalledWith("ttft_ms", 200);
+      expect(setAttr).toHaveBeenCalledWith("ttlt_ms", 500);
+      expect(setAttr).toHaveBeenCalledWith("success", true);
+      expect(setAttr).toHaveBeenCalledWith("has_tool_call", false);
+      expect(mockSpan.end).toHaveBeenCalled();
+    });
+
+    it("endLLMRequestSpan handles error attribute", () => {
+      tracing.startInteractionSpan("Hello", 1);
+      tracing.startLLMRequestSpan("gpt-4");
+
+      tracing.endLLMRequestSpan({
+        model: "gpt-4",
+        success: false,
+        error: "Connection timeout",
+      });
+
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        "error",
+        "Connection timeout",
+      );
+    });
+
+    it("startToolSpan creates a span with tool name", () => {
+      const span = tracing.startToolSpan("Bash");
+
+      expect(span).toBeDefined();
+      expect(mockTracer.startSpan).toHaveBeenCalledWith("tool.Bash", {
+        attributes: {
+          "span.type": "tool",
+          tool_name: "Bash",
+        },
+      });
+    });
+
+    it("startToolSpan includes input when logToolContent is true", () => {
+      mockGetCurrentConfig.mockReturnValue({ logToolContent: true });
+
+      tracing.startToolSpan("Write", { path: "/test", content: "hello" });
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith("tool.Write", {
+        attributes: {
+          "span.type": "tool",
+          tool_name: "Write",
+          tool_input: '{"path":"/test","content":"hello"}',
+        },
+      });
+    });
+
+    it("startToolSpan excludes input when logToolContent is false", () => {
+      mockGetCurrentConfig.mockReturnValue({ logToolContent: false });
+
+      tracing.startToolSpan("Read", { path: "/test" });
+
+      const callArgs = mockTracer.startSpan.mock.calls[0][1];
+      expect(callArgs.attributes).not.toHaveProperty("tool_input");
+    });
+
+    it("startToolSpan truncates long input to 1000 chars", () => {
+      mockGetCurrentConfig.mockReturnValue({ logToolContent: true });
+
+      const longInput = "a".repeat(2000);
+      tracing.startToolSpan("Write", longInput);
+
+      const callArgs = mockTracer.startSpan.mock.calls[0][1];
+      const inputAttr = callArgs.attributes["tool_input"] as string;
+      expect(inputAttr.length).toBe(1000);
+    });
+
+    it("endToolSpan sets success/error/duration attributes and ends", () => {
+      tracing.startInteractionSpan("Hello", 1);
+      tracing.startToolSpan("Bash");
+
+      // Need to set span.type on the mock for endToolSpan to process it
+      mockSpan.attributes = { "span.type": "tool" };
+
+      tracing.endToolSpan({
+        success: true,
+        durationMs: 150,
+      });
+
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith("success", true);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith("duration_ms", 150);
+      expect(mockSpan.end).toHaveBeenCalled();
+    });
+
+    it("endToolSpan sets error attribute when present", () => {
+      tracing.startInteractionSpan("Hello", 1);
+      tracing.startToolSpan("Bash");
+      mockSpan.attributes = { "span.type": "tool" };
+
+      tracing.endToolSpan({
+        success: false,
+        error: "Command failed",
+        durationMs: 200,
+      });
+
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        "error",
+        "Command failed",
+      );
+    });
+
+    it("endToolSpan returns early if span type is not tool", () => {
+      tracing.startInteractionSpan("Hello", 1);
+      mockSpan.attributes = { "span.type": "interaction" };
+
+      const setAttrSpy = vi.spyOn(mockSpan, "setAttribute");
+      tracing.endToolSpan({
+        success: true,
+        durationMs: 100,
+      });
+
+      expect(setAttrSpy).not.toHaveBeenCalled();
+    });
+
+    it("endLLMRequestSpan restores context when multiple LLM spans exist", () => {
+      tracing.startInteractionSpan("Hello", 1);
+      tracing.startLLMRequestSpan("gpt-4");
+      tracing.startLLMRequestSpan("gpt-4o");
+
+      // End the most recent LLM span
+      tracing.endLLMRequestSpan({
+        model: "gpt-4o",
+        success: true,
+      });
+
+      // The first LLM span should still be on the stack
+      // and the active span should have been restored
+      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+
+      // Now end the first LLM span
+      tracing.endLLMRequestSpan({
+        model: "gpt-4",
+        success: true,
+      });
+
+      expect(mockSpan.end).toHaveBeenCalledTimes(2);
+    });
+
+    it("endToolSpan restores context when multiple tool spans exist", () => {
+      tracing.startInteractionSpan("Hello", 1);
+      tracing.startToolSpan("Bash");
+      tracing.startToolSpan("Write");
+
+      // End the most recent tool span
+      mockSpan.attributes = { "span.type": "tool" };
+      tracing.endToolSpan({
+        success: true,
+        durationMs: 50,
+      });
+
+      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+
+      // End the first tool span
+      tracing.endToolSpan({
+        success: true,
+        durationMs: 100,
+      });
+
+      expect(mockSpan.end).toHaveBeenCalledTimes(2);
+    });
+
+    it("startToolSpan with string input when logToolContent is true", () => {
+      mockGetCurrentConfig.mockReturnValue({ logToolContent: true });
+
+      tracing.startToolSpan("Write", "simple string input");
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith("tool.Write", {
+        attributes: {
+          "span.type": "tool",
+          tool_name: "Write",
+          tool_input: "simple string input",
+        },
+      });
+    });
+
+    it("startToolSpan truncates long string input to 1000 chars", () => {
+      mockGetCurrentConfig.mockReturnValue({ logToolContent: true });
+
+      const longInput = "x".repeat(2000);
+      tracing.startToolSpan("Write", longInput);
+
+      const callArgs = mockTracer.startSpan.mock.calls[0][1];
+      const inputAttr = callArgs.attributes["tool_input"] as string;
+      expect(inputAttr.length).toBe(1000);
+      expect(inputAttr).toBe("x".repeat(1000));
+    });
+
+    it("startToolSpan excludes input when logToolContent is false even with input provided", () => {
+      mockGetCurrentConfig.mockReturnValue({ logToolContent: false });
+
+      tracing.startToolSpan("Read", "some content");
+
+      const callArgs = mockTracer.startSpan.mock.calls[0][1];
+      expect(callArgs.attributes).not.toHaveProperty("tool_input");
+    });
+
+    it("endLLMRequestSpan with minimal metadata", () => {
+      tracing.startInteractionSpan("Hello", 1);
+      tracing.startLLMRequestSpan("gpt-4");
+
+      tracing.endLLMRequestSpan({
+        model: "gpt-4",
+        success: true,
+      });
+
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith("success", true);
+      expect(mockSpan.setAttribute).not.toHaveBeenCalledWith(
+        "input_tokens",
+        expect.anything(),
+      );
+      expect(mockSpan.setAttribute).not.toHaveBeenCalledWith(
+        "error",
+        expect.anything(),
+      );
+    });
+
+    it("endToolSpan with error attribute", () => {
+      tracing.startInteractionSpan("Hello", 1);
+      tracing.startToolSpan("Bash");
+      mockSpan.attributes = { "span.type": "tool" };
+
+      tracing.endToolSpan({
+        success: false,
+        error: "Exit code 1",
+        durationMs: 300,
+      });
+
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith("success", false);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        "error",
+        "Exit code 1",
+      );
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith("duration_ms", 300);
+    });
+  });
+
+  describe("withSpanContext", () => {
+    beforeEach(() => {
+      mockIsInitialized.mockReturnValue(true);
+    });
+
+    it("executes fn within the span context and returns result", () => {
+      const mockSpan = {
+        spanContext: () => ({ spanId: "abc" }),
+      } as unknown as Span;
+      const result = tracing.withSpanContext(mockSpan, () => "test-value");
+      expect(result).toBe("test-value");
+    });
+
+    it("executes fn even when it throws", () => {
+      const mockSpan = {
+        spanContext: () => ({ spanId: "abc" }),
+      } as unknown as Span;
+      expect(() => {
+        tracing.withSpanContext(mockSpan, () => {
+          throw new Error("test error");
+        });
+      }).toThrow("test error");
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 22.19.3
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@22.19.3)(jsdom@28.0.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.3)(jsdom@28.0.0)(tsx@4.20.6)(yaml@2.8.1))
       eslint:
         specifier: ^9.33.0
         version: 9.33.0
@@ -46,13 +46,34 @@ importers:
         version: 8.39.0(eslint@9.33.0)(typescript@5.9.2)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@22.19.3)(jsdom@28.0.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.3)(jsdom@28.0.0)(tsx@4.20.6)(yaml@2.8.1)
 
   packages/agent-sdk:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.18.2
         version: 1.19.1
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      '@opentelemetry/api-logs':
+        specifier: ^0.217.0
+        version: 0.217.0
+      '@opentelemetry/exporter-logs-otlp-http':
+        specifier: ^0.217.0
+        version: 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: ^0.217.0
+        version: 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs':
+        specifier: ^0.217.0
+        version: 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node':
+        specifier: ^0.217.0
+        version: 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
@@ -86,7 +107,7 @@ importers:
         version: 5.0.6
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@22.19.3)(jsdom@28.0.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.3)(jsdom@28.0.0)(tsx@4.20.6)(yaml@2.8.1))
       rimraf:
         specifier: ^6.1.2
         version: 6.1.2
@@ -98,7 +119,7 @@ importers:
         version: 4.20.6
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@22.19.3)(jsdom@28.0.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.3)(jsdom@28.0.0)(tsx@4.20.6)(yaml@2.8.1)
 
   packages/code:
     dependencies:
@@ -156,7 +177,7 @@ importers:
         version: 17.0.33
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@22.19.3)(jsdom@28.0.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.3)(jsdom@28.0.0)(tsx@4.20.6)(yaml@2.8.1))
       eslint-plugin-react:
         specifier: ^7.37.5
         version: 7.37.5(eslint@9.33.0)
@@ -177,7 +198,7 @@ importers:
         version: 4.20.6
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@22.19.3)(jsdom@28.0.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.3)(jsdom@28.0.0)(tsx@4.20.6)(yaml@2.8.1)
 
 packages:
 
@@ -613,6 +634,15 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@grpc/grpc-js@1.14.3':
+    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.8.1':
+    resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -651,6 +681,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
 
@@ -669,6 +702,204 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@opentelemetry/api-logs@0.217.0':
+    resolution: {integrity: sha512-Cdq0jW2lknrNfrAm92MyEAvpe2cRsKjdnQLHUL6xRA4IVUnsWx6P65E7NcUO0Y+L4w1Aee5iV8FvjSwd+lrs9A==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/configuration@0.217.0':
+    resolution: {integrity: sha512-xCtrYOhBqdy6ZOMfe0Oa73ZKF+2LMhoOv4L5vmwAHVvOXUg+V3fvKuEIr9ZyD0Ow+vxllEjWO6PV1wd0DOtyvw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
+  '@opentelemetry/context-async-hooks@2.7.1':
+    resolution: {integrity: sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.7.1':
+    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.217.0':
+    resolution: {integrity: sha512-vC5S0Dc+noxD86CVtNu1+awCHPA5Kewi1Sg23ps+9lh4YifwsKXh3pe4XTNEKtUJiAcjpJ5dqStGakLbrSE+YQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.217.0':
+    resolution: {integrity: sha512-KfLAdt1uilVE+3FxbgVnp2ZrzqbIawzcesnRoi+Kh9ckB5Ld5D8btUgoBvwTbdmuNx1j6b132Wsh72azq+pPNQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.217.0':
+    resolution: {integrity: sha512-Se0GG/ZO24mQTlQj7zprR4pNI0nKe4lPDPBsuJmi6508b9TlZEuUd3EfyuHk6oJxzL7fGyDFYAbxNigQvRP2ZQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.217.0':
+    resolution: {integrity: sha512-0GpJKnCoVaVA1rKBMVPHziznfOQlXgH72S9ktjBAF1AnAVPzX7vVEBGrhwiSxxHDAiefXk+J8znApsMb/K6Z3w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.217.0':
+    resolution: {integrity: sha512-1zkMzzhiNJdVmLxuwkltqWGw4fOOam47bqRxmuQNjyKJe/9NmY5cIrZ4kiQV7sVGxoOgT0ZvGUfLcjvtpC/b9Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.217.0':
+    resolution: {integrity: sha512-nfxt/KxVGFkjkO/M+58y1ugHu/dwPtxG4eYq0KApcQ7xk5CHzhdn+IuLZfDSvNDrJ3Uy5q++Fj/wbK7i8yryfQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-prometheus@0.217.0':
+    resolution: {integrity: sha512-U9MCXxJu0sBCh5aEkylYRR4xVIL8D1CW6dGwvYXbfFr0qveSorfD0XJchCAWoW6QfAAIcY/yxjf4Dj8OgkHBPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.217.0':
+    resolution: {integrity: sha512-fPZs2fw7veLH3pEKu8vSepUa2fQpAE2P7al6qU10aH9GrEJJ8YaPgsd5xON7by5rbcEVS71FOU2aWyK6nzB7VQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.217.0':
+    resolution: {integrity: sha512-38YQoqtYjglz2GV94LGUN/djLvxtvGIQO68o6qAFPVshjmwSdX1F2i0c7vn3lEl1L5B/YqjB/bgKXaVx7KO+RQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.217.0':
+    resolution: {integrity: sha512-nPV8gKHUiSuTZpQcnZU3/pBlK7crSyEGpZuh5MtWySB0vv6NNG0QvvfKitQt+Fc2Mc6qfyU54KlZcurwoTbrVg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-zipkin@2.7.1':
+    resolution: {integrity: sha512-mfsD9bKAxcKrh5+y08TPodvClBO0CznBE3p79YAGnO81WI4LrdsGA65T53e4iTSbCalW4WaUpkbeJcbpyIUHfg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/instrumentation@0.217.0':
+    resolution: {integrity: sha512-24ucQMjz7Y34Kw3trbxL2ZrssbtgWnR+Clpaa+YdeWuuyH3Cvk23Q03PcQvqiZrDvt8AmQmjgg9v6Y9PHoxG7w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.217.0':
+    resolution: {integrity: sha512-eYfqnB3UhKu/5frhd1R6+FprKygbhkomuaceMXDyzxbfXB9tKgZOVmjaJ02CkLA6Tdzumxl+e2H+vo2a8jiMPQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.217.0':
+    resolution: {integrity: sha512-7RTAdZuOsCDnsyqTCG4+bDzrfnsWdzkRs7z0AVi/V3tEQx0oKeyc+OuRWYxnRsmaJXgxcmB8vb/lfxn58Dj6Ag==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.217.0':
+    resolution: {integrity: sha512-MKK8UHKFUOGAvbZRWh90MhwHG+Fxm6OROBdjKPCF+HQobjuJ/Kuf8Chs8CR45X1aqotxrMj7OxTdsXe8sXuGVA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/propagator-b3@2.7.1':
+    resolution: {integrity: sha512-RJid6E2CKyeGfKBzXKF21ejabGMHypFkPAh3qZ+NvI+SGjuIye79t3PmiqcDgtRzdKH6ynXzbfslQ8DfpRUg2A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@2.7.1':
+    resolution: {integrity: sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@2.7.1':
+    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.217.0':
+    resolution: {integrity: sha512-BB+PcHItcZDL63dPMW+mJvwN9rk37wuIDjRxbVlg6pPDvDR/7GL7UJHbGsllgoggOoTimsKgENaWPoGch/oE1A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.7.1':
+    resolution: {integrity: sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-node@0.217.0':
+    resolution: {integrity: sha512-K/60pSv42+NQiZKy1pAH18nYDkxltsDV4O3SJ233J0E9raU1ksyL9gsKuS8p30bYBb4AMPCfDuutHQaHYpcv0Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.1':
+    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.7.1':
+    resolution: {integrity: sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.1':
+    resolution: {integrity: sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@rollup/rollup-android-arm-eabi@4.52.4':
     resolution: {integrity: sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==}
@@ -914,6 +1145,11 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1075,6 +1311,9 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
   cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
@@ -1653,6 +1892,10 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-in-the-middle@3.0.1:
+    resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
+    engines: {node: '>=18'}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -1903,12 +2146,18 @@ packages:
     resolution: {integrity: sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg==}
     engines: {node: '>=20'}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -1994,6 +2243,9 @@ packages:
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2197,6 +2449,14 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  protobufjs@7.5.7:
+    resolution: {integrity: sha512-NGnrxS/nLKUo5nkbVQxlC71sB4hdfImdYIbFeSCidxtwATx0AHRPcANSLd0q5Bb2BkoSWo2iisQhGg5/r+ihbA==}
+    engines: {node: '>=12.0.0'}
+
+  protobufjs@8.0.1:
+    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
+    engines: {node: '>=12.0.0'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -2265,6 +2525,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3103,6 +3367,18 @@ snapshots:
   '@exodus/bytes@1.11.0':
     optional: true
 
+  '@grpc/grpc-js@1.14.3':
+    dependencies:
+      '@grpc/proto-loader': 0.8.1
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.8.1':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.7
+      yargs: 17.7.2
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -3130,6 +3406,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@js-sdsl/ordered-map@4.4.2': {}
 
   '@mixmark-io/domino@2.2.0': {}
 
@@ -3161,6 +3439,267 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@opentelemetry/api-logs@0.217.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/configuration@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      yaml: 2.8.1
+
+  '@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.217.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.217.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-prometheus@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-zipkin@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/instrumentation@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.217.0
+      import-in-the-middle: 3.0.1
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/otlp-exporter-base@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.217.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      protobufjs: 8.0.1
+
+  '@opentelemetry/propagator-b3@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/propagator-jaeger@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-logs@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.217.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-node@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.217.0
+      '@opentelemetry/configuration': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-prometheus': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-zipkin': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-b3': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-jaeger': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.1
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.1': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@rollup/rollup-android-arm-eabi@4.52.4':
     optional: true
@@ -3351,7 +3890,7 @@ snapshots:
       '@typescript-eslint/types': 8.39.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@22.19.3)(jsdom@28.0.0)(tsx@4.20.6)(yaml@2.8.1))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.3)(jsdom@28.0.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -3363,7 +3902,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.19.3)(jsdom@28.0.0)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.3)(jsdom@28.0.0)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -3408,6 +3947,10 @@ snapshots:
     dependencies:
       mime-types: 3.0.1
       negotiator: 1.0.0
+
+  acorn-import-attributes@1.9.5(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -3606,6 +4149,8 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  cjs-module-lexer@2.2.0: {}
 
   cli-boxes@3.0.0: {}
 
@@ -4354,6 +4899,13 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-in-the-middle@3.0.1:
+    dependencies:
+      acorn: 8.15.0
+      acorn-import-attributes: 1.9.5(acorn@8.15.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
+
   imurmurhash@0.1.4: {}
 
   indent-string@5.0.0: {}
@@ -4650,6 +5202,8 @@ snapshots:
     dependencies:
       p-locate: 6.0.0
 
+  lodash.camelcase@4.3.0: {}
+
   lodash.merge@4.6.2: {}
 
   log-update@6.1.0:
@@ -4659,6 +5213,8 @@ snapshots:
       slice-ansi: 7.1.0
       strip-ansi: 7.1.0
       wrap-ansi: 9.0.0
+
+  long@5.3.2: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -4727,6 +5283,8 @@ snapshots:
       brace-expansion: 2.0.2
 
   minipass@7.1.2: {}
+
+  module-details-from-path@1.0.4: {}
 
   ms@2.1.3: {}
 
@@ -4905,6 +5463,36 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  protobufjs@7.5.7:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.1
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.19.3
+      long: 5.3.2
+
+  protobufjs@8.0.1:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.1
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.19.3
+      long: 5.3.2
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -4973,6 +5561,13 @@ snapshots:
 
   require-from-string@2.0.2:
     optional: true
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   resolve-from@4.0.0: {}
 
@@ -5443,7 +6038,7 @@ snapshots:
       tsx: 4.20.6
       yaml: 2.8.1
 
-  vitest@4.0.18(@types/node@22.19.3)(jsdom@28.0.0)(tsx@4.20.6)(yaml@2.8.1):
+  vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.3)(jsdom@28.0.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.3)(tsx@4.20.6)(yaml@2.8.1))
@@ -5466,6 +6061,7 @@ snapshots:
       vite: 7.3.1(@types/node@22.19.3)(tsx@4.20.6)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.3
       jsdom: 28.0.0
     transitivePeerDependencies:

--- a/specs/075-opentelemetry/checklists/requirements.md
+++ b/specs/075-opentelemetry/checklists/requirements.md
@@ -1,0 +1,31 @@
+# Specification Quality Checklist: OpenTelemetry Integration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-09
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [ ] No implementation details (languages, frameworks, APIs)
+- [ ] Focused on user value and business needs
+- [ ] Written for non-technical stakeholders
+- [ ] All mandatory sections completed
+
+## Requirement Completeness
+
+- [ ] No [NEEDS CLARIFICATION] markers remain
+- [ ] Requirements are testable and unambiguous
+- [ ] All acceptance scenarios are defined
+- [ ] Edge cases are identified
+- [ ] Scope is clearly bounded
+- [ ] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [ ] All functional requirements have clear acceptance criteria
+- [ ] User scenarios cover primary flows
+- [ ] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before proceeding.

--- a/specs/075-opentelemetry/contracts/telemetry.md
+++ b/specs/075-opentelemetry/contracts/telemetry.md
@@ -1,0 +1,42 @@
+# Telemetry API Contracts
+
+## Instrumentation Module
+
+### `initializeTelemetry(config?: TelemetryConfig): Promise<void>`
+Lazy-loads OTEL SDK and initializes all providers. Must be called once before any telemetry operations. Idempotent.
+
+### `shutdownTelemetry(): Promise<void>`
+Flushes all pending telemetry to exporters and shuts down providers. Respects `shutdownTimeoutMs` config. Must be called before process exit.
+
+## Session Tracing Module
+
+### `startInteractionSpan(userPrompt: string): Span`
+Creates a new interaction span. Sets as active span in AsyncLocalStorage context.
+
+### `endInteractionSpan(span: Span, metadata: { sequence: number }): void`
+Ends the interaction span and removes from active context.
+
+### `startLLMRequestSpan(model: string, options?: { context?: string; tools?: string[] }): Span`
+Creates an LLM request span as child of current interaction span (via ALS context).
+
+### `endLLMRequestSpan(span: Span, metadata: LLMRequestMetadata): void`
+Ends LLM request span with token counts, latency, success/error status.
+
+### `startToolSpan(toolName: string, input?: unknown): Span`
+Creates a tool execution span as child of current interaction span.
+
+### `endToolSpan(span: Span, metadata: ToolMetadata): void`
+Ends tool span with success/error, duration, optional result tokens.
+
+## Events Module
+
+### `logOTelEvent(eventName: string, metadata: Record<string, string | undefined>): Promise<void>`
+Logs a structured event via the OTEL logs API. Respects PII gates.
+
+## Span Context Management
+
+### `getActiveInteractionSpan(): Span | undefined`
+Returns the current interaction span from AsyncLocalStorage context.
+
+### `withToolContext<T>(span: Span, fn: () => T): T`
+Executes `fn` with the given tool span as the active context. Ensures correct nesting for parallel tool calls.

--- a/specs/075-opentelemetry/data-model.md
+++ b/specs/075-opentelemetry/data-model.md
@@ -1,0 +1,76 @@
+# Data Model: OpenTelemetry Integration
+
+## Configuration
+
+### TelemetryConfig (Resolved)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `enabled` | `boolean` | Master switch for telemetry |
+| `tracesExporter` | `'jsonl' \| 'otlp'` | Trace export target |
+| `metricsExporter` | `'jsonl' \| 'otlp'` | Metric export target |
+| `logsExporter` | `'jsonl' \| 'otlp'` | Log export target |
+| `endpoint` | `string` | OTLP collector URL |
+| `protocol` | `'http/protobuf' \| 'http/json' \| 'grpc'` | OTLP transport protocol |
+| `headers` | `Record<string, string>` | Auth/custom headers |
+| `logUserPrompts` | `boolean` | Include prompt text in events |
+| `logToolContent` | `boolean` | Include tool I/O in events |
+| `shutdownTimeoutMs` | `number` | Max flush time on exit (default 2000) |
+| `spanTtlMs` | `number` | Stale span eviction TTL (default 1800000) |
+
+## Span Types
+
+### InteractionSpan
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `span.type` | `'interaction'` | Span type discriminator |
+| `user_prompt` | `string` | Prompt text (if `OTEL_LOG_USER_PROMPTS=1`) |
+| `user_prompt_length` | `number` | Prompt length in characters |
+| `interaction.sequence` | `number` | Turn number in session |
+
+### LLMRequestSpan
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `span.type` | `'llm_request'` | Span type discriminator |
+| `model` | `string` | Model identifier |
+| `llm_request.context` | `'interaction' \| 'standalone'` | Scope context |
+| `input_tokens` | `number` | Prompt tokens consumed |
+| `output_tokens` | `number` | Completion tokens generated |
+| `cache_read_tokens` | `number` | Cache hit tokens |
+| `cache_creation_tokens` | `number` | Cache write tokens |
+| `ttft_ms` | `number` | Time to first token |
+| `ttlt_ms` | `number` | Time to last token (total duration) |
+| `success` | `boolean` | Request succeeded |
+| `error` | `string` | Error message (if failed) |
+| `has_tool_call` | `boolean` | Response included tool calls |
+
+### ToolSpan
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `span.type` | `'tool'` | Span type discriminator |
+| `tool_name` | `string` | Tool identifier |
+| `tool_input` | `string` | Serialized input (if `OTEL_LOG_TOOL_CONTENT=1`) |
+| `success` | `boolean` | Tool execution succeeded |
+| `error` | `string` | Error message (if failed) |
+| `duration_ms` | `number` | Execution time |
+
+## Event Types
+
+### OTelEvent
+
+| Event | Key Attributes |
+|-------|---------------|
+| `session_start` | `sessionId`, `model`, `workdir` |
+| `session_end` | `duration`, `totalTokens`, `exitReason` |
+| `user_prompt` | `prompt_length`, `prompt` (if enabled) |
+| `tool_decision` | `tool_name`, `decision`, `source` |
+| `compaction` | `beforeTokens`, `afterTokens`, `model` |
+| `error` | `error_type`, `message`, `stack` (truncated) |
+
+## Relationships
+- An **InteractionSpan** has multiple child **LLMRequestSpan**s (if multi-turn recursion) and multiple child **ToolSpan**s.
+- A **Session** produces multiple **InteractionSpan**s (one per user message).
+- **OTelEvent**s are independent log records, not tied to specific spans.

--- a/specs/075-opentelemetry/plan.md
+++ b/specs/075-opentelemetry/plan.md
@@ -1,0 +1,83 @@
+# Implementation Plan: OpenTelemetry Integration
+
+**Branch**: `075-opentelemetry` | **Status**: Planned | **Date**: 2026-05-09 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/075-opentelemetry/spec.md`
+
+## Summary
+
+Add OpenTelemetry instrumentation to Wave following Claude Code's patterns. Three new modules: `instrumentation.ts` (SDK init + exporters), `sessionTracing.ts` (span APIs), `events.ts` (event logging). Integration into AIManager (API calls), ToolManager (tool execution), Agent (lifecycle events), and CompactionService. Configuration via standard `OTEL_*` env vars + `settings.json`. Lazy-loaded to avoid startup penalty. Graceful degradation on failures.
+
+## Technical Context
+
+**Language/Version**: TypeScript (Node.js)
+**Primary Dependencies**: @opentelemetry/api, @opentelemetry/sdk-node, @opentelemetry/sdk-metrics, @opentelemetry/sdk-trace-node, @opentelemetry/sdk-logs, @opentelemetry/exporter-metrics-otlp-http, @opentelemetry/exporter-trace-otlp-http, @opentelemetry/exporter-logs-otlp-http
+**Testing**: Vitest (Unit and Integration tests)
+**Target Platform**: Linux/macOS/Windows (Node.js environment)
+**Project Type**: Monorepo (agent-sdk + code)
+**Constraints**: Must not block agent operation on telemetry failures; lazy-loaded to avoid startup penalty
+**Scale/Scope**: Core observability infrastructure affecting agent lifecycle, API calls, and tool execution
+
+## Constitution Check
+
+1. **Package-First Architecture**: Logic in `agent-sdk` (telemetry module), integration points in existing managers. Pass.
+2. **TypeScript Excellence**: Strict typing for all span metadata and event payloads. Pass.
+3. **Test Alignment**: Mandatory unit and integration tests for each telemetry module. Pass.
+4. **Build Dependencies**: `agent-sdk` must be built before `code` can use telemetry. Pass.
+5. **Documentation Minimalism**: No extra .md files beyond spec/plan/research/data-model/quickstart. Pass.
+6. **Quality Gates**: `type-check` and `lint` required. Pass.
+7. **Source Code Structure**: `telemetry/` directory in `agent-sdk/src/`. Pass.
+8. **Data Model Minimalism**: Config, span metadata, event types — simple data structures. Pass.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/075-opentelemetry/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── telemetry.md
+└── tasks.md             # Phase 2 output
+```
+
+### Source Code (repository root)
+
+```
+packages/
+├── agent-sdk/
+│   ├── package.json                          # Add @opentelemetry/* deps
+│   └── src/
+│       ├── telemetry/
+│       │   ├── instrumentation.ts            # SDK init, providers, exporters
+│       │   ├── sessionTracing.ts             # Span APIs (interaction, LLM, tool)
+│       │   └── events.ts                     # Event logging API
+│       ├── types/
+│       │   ├── configuration.ts              # Add monitoring.telemetry config
+│       │   └── telemetry.ts                  # Type definitions
+│       ├── managers/
+│       │   ├── aiManager.ts                  # Wrap queryModel with spans
+│       │   └── toolManager.ts                # Wrap executeTool with spans
+│       ├── services/
+│       │   ├── compactionService.ts          # Log compaction events
+│       │   └── ...
+│       └── agent.ts                          # Init/shutdown, session events
+│   └── tests/
+│       ├── telemetry/
+│       │   ├── instrumentation.test.ts
+│       │   ├── sessionTracing.test.ts
+│       │   └── events.test.ts
+│       └── integration/
+│           └── otel-session.test.ts
+└── code/
+    └── src/
+        └── cli.ts                            # Bootstrap telemetry on startup
+```
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | N/A | N/A |

--- a/specs/075-opentelemetry/quickstart.md
+++ b/specs/075-opentelemetry/quickstart.md
@@ -1,0 +1,81 @@
+# Quickstart: OpenTelemetry Integration
+
+## Overview
+Wave now supports OpenTelemetry for structured observability — traces, metrics, and logs.
+
+## Basic Usage — OTLP Exporter (Interactive Mode)
+
+```bash
+# Send telemetry to a local Jaeger instance
+OTEL_TRACES_EXPORTER=otlp \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
+wave
+
+# Send to Grafana Cloud with auth
+OTEL_TRACES_EXPORTER=otlp \
+OTEL_METRICS_EXPORTER=otlp \
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-us-east-0.grafana.net/otlp \
+OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer your-token" \
+wave
+```
+
+## JSONL File Exporter (Local Debugging)
+
+Console exporters are not supported (stdout corrupts Ink UI). Instead, use the `jsonl` exporter which writes to `~/.wave/telemetry.jsonl`.
+
+```bash
+# Enable all signals — telemetry goes to JSONL file
+OTEL_METRICS_EXPORTER=jsonl \
+OTEL_TRACES_EXPORTER=jsonl \
+OTEL_LOGS_EXPORTER=jsonl \
+wave
+
+# Observe telemetry:
+tail -f ~/.wave/telemetry.jsonl
+
+# Parse with jq:
+tail -f ~/.wave/telemetry.jsonl | jq 'select(."span.type" == "llm_request")'
+```
+
+## Remote Telemetry — OTLP Exporter
+
+```bash
+# Send to a local Jaeger instance
+OTEL_TRACES_EXPORTER=otlp \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
+wave
+
+# Send to Grafana Cloud with auth
+OTEL_TRACES_EXPORTER=otlp \
+OTEL_METRICS_EXPORTER=otlp \
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-us-east-0.grafana.net/otlp \
+OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer your-token" \
+wave
+```
+
+## Configuration via settings.json
+
+```json
+{
+  "monitoring": {
+    "telemetry": {
+      "enabled": true,
+      "tracesExporter": "otlp",
+      "metricsExporter": "otlp",
+      "logsExporter": "jsonl",
+      "endpoint": "https://your-collector.example.com",
+      "headers": { "Authorization": "Bearer ..." }
+    }
+  }
+}
+```
+
+**Note**: Environment variables take precedence over settings.json.
+
+## PII Protection
+
+By default, user prompts and tool content are **NOT** included in telemetry. To enable:
+
+```bash
+OTEL_LOG_USER_PROMPTS=1 OTEL_LOG_TOOL_CONTENT=1 wave
+```

--- a/specs/075-opentelemetry/research.md
+++ b/specs/075-opentelemetry/research.md
@@ -1,0 +1,39 @@
+# Research: OpenTelemetry Integration
+
+## Decision: Use @opentelemetry/sdk-node as Foundation
+- **Rationale**: Provides unified setup for MeterProvider, TracerProvider, LoggerProvider with standard env var support. Matches Claude Code's approach.
+- **Alternatives considered**:
+  - Manual provider setup: Rejected — too much boilerplate, env var parsing reinvented.
+  - @opentelemetry/auto-instrumentations-node: Rejected — auto-instrumentations (http, fs, etc.) add noise; we want manual instrumentation only.
+
+## Decision: Manual Instrumentation Only (No Auto-Instrumentations)
+- **Rationale**: Wave's value comes from domain-specific spans (interactions, LLM calls, tools). Auto-instrumenting HTTP calls, DNS lookups, etc. adds irrelevant noise.
+- **Alternatives considered**: Auto-instrumentations for HTTP to track API latency — rejected, LLM request spans already cover this with richer attributes.
+
+## Decision: AsyncLocalStorage for Span Context
+- **Rationale**: Wave supports parallel tool execution. Using AsyncLocalStorage ensures each tool call's span is correctly nested under its parent interaction span, even when tools execute concurrently.
+- **Alternatives considered**:
+  - Global active span: Rejected — parallel calls would corrupt parent context.
+  - Explicit span passing everywhere: Too invasive; ALS provides implicit context propagation.
+
+## Decision: Lazy Initialization (Dynamic Import)
+- **Rationale**: OTEL packages add ~1MB to startup. Using `import()` defers loading until after the agent is ready. Matches Claude Code's pattern.
+- **Alternatives considered**: Static import at top level: Rejected — adds visible startup delay.
+
+## Decision: JSONL File Exporter (Dedicated Telemetry File)
+- **Rationale**: Telemetry is structured JSON data — JSONL format (one JSON object per line) matches Wave's existing session file convention. A dedicated file (`~/.wave/telemetry.jsonl`) keeps telemetry decoupled from `~/.wave/app.log` (text application logs) and session data. No stdout/stderr concerns, no Ink corruption. Easy to tail, parse with `jq`, or stream to downstream tools.
+- **Alternatives considered**:
+  - OTEL console exporters: Rejected — writes to stdout, corrupts Ink UI.
+  - Write to app.log: Rejected — format clash (text vs JSON), telemetry verbosity would dwarf app logs, defeats separate-tailing use case.
+
+## Decision: Graceful Degradation on Failure
+- **Rationale**: Telemetry must never block or crash the agent. All export operations use batch processors with non-blocking error handling.
+- **Alternatives considered**: Fail-fast: Rejected — unacceptable for a developer tool.
+
+## Integration Points
+- `Agent` constructor: initialize telemetry, log `session_start` event
+- `Agent.destroy()`: log `session_end` event, `shutdownTelemetry()`
+- `AIManager.queryModel()`: wrap with interaction span + LLM request span
+- `ToolManager.executeTool()`: wrap with tool span
+- `CompactionService`: log `compaction` event
+- CLI entry point: lazy-load `initializeTelemetry()`

--- a/specs/075-opentelemetry/spec.md
+++ b/specs/075-opentelemetry/spec.md
@@ -1,0 +1,92 @@
+# Feature Specification: OpenTelemetry Integration
+
+**Feature Branch**: `075-opentelemetry`
+**Created**: 2026-05-09
+**Input**: "Add OpenTelemetry instrumentation following Claude Code patterns, supporting metrics, traces, and logs with multiple exporters (jsonl, OTLP)."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Remote Telemetry with OTLP Exporter (Priority: P1)
+
+As a developer, I want to send Wave telemetry data to an OTLP collector (e.g., Jaeger, Grafana Tempo, Honeycomb) so I can observe agent behavior, debug performance issues, and analyze session patterns.
+
+**Why this priority**: This is the primary use case for OpenTelemetry — sending structured traces, metrics, and logs to an external backend for analysis.
+
+**Independent Test**: Point Wave at a local Jaeger or Grafana instance via `OTEL_EXPORTER_OTLP_ENDPOINT`, run a session, and verify traces appear in the collector's UI.
+
+**Acceptance Scenarios**:
+
+1. **Given** `OTEL_TRACES_EXPORTER=otlp` and `OTEL_EXPORTER_OTLP_ENDPOINT` is set to a running collector, **When** the user sends a message and the agent responds, **Then** the collector receives a complete trace with interaction spans, LLM request spans with token counts, and tool execution spans with durations.
+2. **Given** `OTEL_METRICS_EXPORTER=otlp` and a collector endpoint, **When** the agent completes a turn, **Then** the collector receives periodic metric exports with token usage, latency histograms, and error counters.
+3. **Given** `OTEL_LOGS_EXPORTER=otlp` and a collector endpoint, **When** the session starts and ends, **Then** the collector receives structured log events for `session_start` and `session_end`.
+
+---
+
+### User Story 2 - JSONL File Exporter (Priority: P2)
+
+As a developer, I want telemetry written to a dedicated JSONL file (`~/.wave/telemetry.jsonl`) so I can observe spans and metrics by tailing the file, without needing an external collector.
+
+**Why this priority**: JSONL matches Wave's existing session file format — each line is a self-contained JSON record, easy to `tail -f`, parse with `jq`, or stream to downstream tools. Decoupled from `~/.wave/app.log` (text logs) and `~/.wave/sessions/*.jsonl` (session data).
+
+**Independent Test**: Run Wave with `OTEL_METRICS_EXPORTER=jsonl OTEL_TRACES_EXPORTER=jsonl`, interact with the agent, and observe structured JSONL records in `~/.wave/telemetry.jsonl`.
+
+**Acceptance Scenarios**:
+
+1. **Given** Wave is started with `OTEL_TRACES_EXPORTER=jsonl`, **When** the agent processes a message, **Then** `~/.wave/telemetry.jsonl` includes one JSON line per span (interaction, LLM request, tool). `~/.wave/app.log` is unaffected.
+2. **Given** Wave is started with `OTEL_METRICS_EXPORTER=jsonl`, **When** the agent completes a turn, **Then** `~/.wave/telemetry.jsonl` includes metric JSON lines. `~/.wave/app.log` is unaffected.
+3. **Given** a telemetry JSONL file, **When** piping through `jq`, **Then** each line parses as valid JSON independently.
+
+---
+
+### User Story 3 - Session Diagnostics via Event Logging (Priority: P2)
+
+As a developer, I want structured event logs for key session lifecycle events (start, end, compaction, tool decisions, errors) so I can reconstruct what happened during a session without parsing raw JSONL files.
+
+**Why this priority**: This provides a searchable, structured audit trail complementing the raw message history. Events are exported via the configured logs exporter (OTLP for remote, jsonl for local file).
+
+**Independent Test**: Run Wave with `OTEL_LOGS_EXPORTER=otlp`, complete a session with multiple turns including a compaction and a rejected tool call, and verify all lifecycle events appear in the collector. Or use `OTEL_LOGS_EXPORTER=jsonl` and tail `~/.wave/telemetry.jsonl`.
+
+**Acceptance Scenarios**:
+
+1. **Given** OTEL logging is enabled, **When** a session starts, **Then** a `session_start` event is logged with sessionId, model, and workdir.
+2. **Given** OTEL logging is enabled, **When** the agent auto-compacts the conversation, **Then** a `compaction` event is logged with before/after token counts.
+3. **Given** OTEL logging is enabled, **When** a tool permission is rejected, **Then** a `tool_decision` event is logged with tool name and decision.
+4. **Given** `OTEL_LOG_USER_PROMPTS=1`, **When** the user sends a message, **Then** the `user_prompt` event includes the actual prompt text. **Given** `OTEL_LOG_USER_PROMPTS` is not set, **Then** the prompt text is excluded.
+
+---
+
+### Edge Cases
+
+- **What happens if the OTLP endpoint is unreachable?** Telemetry export should fail gracefully with logged warnings; the agent session must continue normally without blocking.
+- **What happens if OTEL is enabled but no exporters are configured?** No default exporter is set. Users must explicitly configure at least one exporter. This avoids surprising stdout pollution in interactive mode.
+- **What happens during parallel tool execution?** Each tool call must create its own child span under the correct parent interaction span, using AsyncLocalStorage to prevent span context mixing.
+- **What happens in long-running sessions with 100+ turns?** Active spans older than 30 minutes must be cleaned up to prevent memory leaks.
+- **What happens if telemetry initialization fails?** The agent must start normally without telemetry; a warning is logged but no crash occurs.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST support OpenTelemetry SDK initialization with MeterProvider, TracerProvider, and LoggerProvider.
+- **FR-002**: System MUST support multiple exporters for each signal type: metrics (`jsonl`, `otlp`), traces (`jsonl`, `otlp`), logs (`jsonl`, `otlp`).
+- **FR-003**: System MUST read OTEL configuration from standard `OTEL_*` environment variables (endpoint, protocol, headers, exporters).
+- **FR-004**: System MUST create interaction spans wrapping each user message → complete response cycle.
+- **FR-005**: System MUST create LLM request spans for each API call with attributes: model, input/output/cache tokens, TTFT, TTLT, success/error status.
+- **FR-006**: System MUST create tool execution spans for each tool call with attributes: tool name, success/error, duration, input (optional).
+- **FR-007**: System MUST maintain correct parent-child span relationships during parallel tool execution using AsyncLocalStorage.
+- **FR-008**: System MUST log structured events for: `session_start`, `session_end`, `user_prompt`, `tool_decision`, `compaction`, `error`.
+- **FR-009**: System MUST NOT include user prompt text or tool content in telemetry by default; these are gated behind `OTEL_LOG_USER_PROMPTS=1` and `OTEL_LOG_TOOL_CONTENT=1`.
+- **FR-010**: System MUST gracefully handle telemetry failures without impacting agent operation.
+- **FR-011**: System MUST flush all telemetry on shutdown with a configurable timeout (default 2s).
+- **FR-012**: System MUST clean up stale spans older than 30 minutes to prevent memory leaks.
+- **FR-013**: System MUST include resource attributes: `service.name: 'wave'`, `service.version`, `os.type`, `host.arch`.
+- **FR-014**: System MUST support configuration via both environment variables AND `settings.json`, with env vars taking precedence.
+- **FR-015**: Console exporters are NOT supported. Instead, a custom JSONL file exporter writes telemetry records (one JSON per line) to `~/.wave/telemetry.jsonl`.
+
+### Key Entities
+
+- **Interaction Span**: Top-level span wrapping a complete user message → agent response cycle.
+- **LLM Request Span**: Child span of interaction span, representing a single API call to the model.
+- **Tool Span**: Child span of interaction span, representing a single tool execution.
+- **OTel Event**: Structured log record for session lifecycle events.
+- **TelemetryConfig**: Configuration resolved from env vars + settings.json controlling exporters, endpoints, and PII gates.

--- a/specs/075-opentelemetry/tasks.md
+++ b/specs/075-opentelemetry/tasks.md
@@ -1,0 +1,135 @@
+# Tasks: OpenTelemetry Integration
+
+**Input**: Design documents from `/specs/075-opentelemetry/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Both unit and integration tests are REQUIRED for all new functionality.
+
+**Organization**: Tasks grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization, dependencies, and type definitions
+
+- [x] T001 Create project structure and empty files per implementation plan
+- [x] T002 [P] [US1] Add @opentelemetry/* dependencies to `packages/agent-sdk/package.json`
+- [x] T003 [P] [US1] Define TelemetryConfig, span metadata types in `packages/agent-sdk/src/types/telemetry.ts`
+- [x] T004 [P] [US1] Add monitoring.telemetry field to WaveConfiguration in `packages/agent-sdk/src/types/configuration.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core telemetry infrastructure that MUST be complete before ANY user story
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T005 Implement `instrumentation.ts` with MeterProvider, TracerProvider, LoggerProvider setup in `packages/agent-sdk/src/telemetry/instrumentation.ts`
+- [x] T006 [P] Implement exporter resolution logic (jsonl, otlp) in `packages/agent-sdk/src/telemetry/instrumentation.ts`
+- [x] T007 [P] Implement `shutdownTelemetry()` with flush timeout in `packages/agent-sdk/src/telemetry/instrumentation.ts`
+- [x] T008 [P] Implement config resolution from env vars + settings.json in `packages/agent-sdk/src/telemetry/instrumentation.ts`
+- [x] T009 [P] Unit tests for instrumentation in `packages/agent-sdk/tests/telemetry/instrumentation.test.ts`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin in parallel
+
+---
+
+## Phase 3: User Story 1 - OTLP Exporter (Priority: P1) 🎯 MVP
+
+**Goal**: Send telemetry to remote OTLP collectors (Jaeger, Grafana, Honeycomb).
+
+**Independent Test**: Point at local Jaeger, run session, verify traces in UI.
+
+### Tests for User Story 1 (REQUIRED) ⚠️
+
+- [x] T010 [P] [US1] Unit tests for sessionTracing in `packages/agent-sdk/tests/telemetry/sessionTracing.test.ts`
+- [x] T011 [P] [US1] Unit tests for events in `packages/agent-sdk/tests/telemetry/events.test.ts`
+- [ ] T012 [P] [US1] Integration test for OTLP export in `packages/agent-sdk/tests/integration/otel-otlp.test.ts`
+
+### Implementation for User Story 1
+
+- [x] T013 [US1] Implement `sessionTracing.ts` with startInteractionSpan, startLLMRequestSpan, startToolSpan APIs
+- [x] T014 [US1] Implement AsyncLocalStorage context management for span nesting
+- [x] T015 [US1] Implement stale span cleanup (30-min TTL eviction)
+- [x] T016 [US1] Implement `events.ts` with logOTelEvent API and PII gates
+- [x] T017 [US1] Add OTLP HTTP exporter configuration in `instrumentation.ts`
+- [x] T018 [US1] Support OTEL_EXPORTER_OTLP_HEADERS in `instrumentation.ts`
+- [x] T019 [US1] Integrate telemetry init into `Agent` in `packages/agent-sdk/src/agent.ts`
+- [x] T020 [US1] Integrate telemetry shutdown into `Agent.destroy()` in `packages/agent-sdk/src/agent.ts`
+
+**Checkpoint**: At this point, User Story 1 should be fully functional and testable independently.
+
+---
+
+## Phase 4: User Story 2 - JSONL File Exporter (Priority: P2)
+
+**Goal**: Write telemetry to `~/.wave/telemetry.jsonl` — one JSON record per line, matching Wave's session file format.
+
+**Independent Test**: Run with `OTEL_*_EXPORTER=jsonl`, verify structured JSONL output in `~/.wave/telemetry.jsonl`.
+
+### Tests for User Story 2 (REQUIRED) ⚠️
+
+- [ ] T021 [P] [US2] Integration test for JSONL file exporter in `packages/agent-sdk/tests/integration/otel-jsonl.test.ts`
+
+### Implementation for User Story 2
+
+- [x] T022 [US2] Implement custom JSONL exporters (JsonlSpanExporter, JsonlMetricExporter, JsonlLogExporter) in `instrumentation.ts`
+- [x] T023 [US2] Wire JSONL exporter to `~/.wave/telemetry.jsonl` with append-mode file writes
+
+**Checkpoint**: At this point, User Stories 1 AND 2 should both work independently.
+
+---
+
+## Phase 5: User Story 3 - Event Logging Integration (Priority: P2)
+
+**Goal**: Structured event logs for session lifecycle integrated into agent operations.
+
+**Independent Test**: Run with `OTEL_LOGS_EXPORTER=otlp`, complete session with compaction, verify events in collector.
+
+### Tests for User Story 3 (REQUIRED) ⚠️
+
+- [ ] T026 [P] [US3] Integration test for event logging in `packages/agent-sdk/tests/integration/otel-events.test.ts`
+
+### Implementation for User Story 3
+
+- [x] T027 [US3] Add session_start/session_end events in `Agent` in `packages/agent-sdk/src/agent.ts`
+- [x] T028 [US3] Wrap `sendAIMessage()` with interaction + LLM spans in `AIManager` in `packages/agent-sdk/src/managers/aiManager.ts`
+- [x] T029 [US3] Wrap `execute()` with tool spans in `ToolManager` in `packages/agent-sdk/src/managers/toolManager.ts`
+- [x] T030 [US3] Add compaction events in `AIManager.handleTokenUsageAndCompaction()` in `packages/agent-sdk/src/managers/aiManager.ts`
+- [x] T031 [US3] Add tool_decision events in `AIManager.executePreToolUseHooks()` + user_prompt/error events in `sendAIMessage()`
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories
+
+- [x] T032 [P] Add error boundaries around all telemetry operations (graceful degradation)
+- [ ] T033 [P] Ensure `agent-sdk` is built and all packages are linked
+- [x] T034 Run `pnpm run type-check` and `pnpm lint` across the monorepo
+- [ ] T035 Run `quickstart.md` validation scenarios manually
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup (Phase 1).
+- **User Story 1 (Phase 3)**: Depends on Foundational (Phase 2). OTLP is the MVP.
+- **User Story 2 (Phase 4)**: Depends on Foundational (Phase 2). JSONL file exporter.
+- **User Story 3 (Phase 5)**: Depends on Foundational (Phase 2). Event logging integration.
+- **Polish (Final Phase)**: Depends on all user stories.
+
+### Parallel Opportunities
+
+- T002, T003, T004 (Setup types + deps)
+- T006, T007, T008, T009 (Foundational sub-tasks)
+- T010, T011 (US1 Tests)
+- T012, T013, T014, T015 (US1 implementation)


### PR DESCRIPTION
Add OpenTelemetry integration for Wave agent providing structured observability for traces (interactions, LLM requests, tool executions) and event logging (session lifecycle, compaction, errors).

## New modules
- `telemetry/instrumentation.ts` — SDK init, OTLP+JSONL exporters, config resolution from env vars + settings.json
- `telemetry/sessionTracing.ts` — Span APIs with AsyncLocalStorage context propagation
- `telemetry/events.ts` — Event logging with PII gates
- `types/telemetry.ts` — TelemetryConfig, metadata types, event names
- `specs/075-opentelemetry/` — Full spec with 15 requirements, 3 user stories

## Integrations
- **Agent**: init/shutdown telemetry, session_start/session_end events
- **AIManager**: interaction + LLM request spans, compaction/error events
- **ToolManager**: tool execution spans with error handling
- **ConfigurationService**: `resolveTelemetryConfig()` method

## Features
- OTLP HTTP exporters (traces, logs) to Jaeger/Grafana/Honeycomb
- JSONL file exporter for local debugging (`~/.wave/telemetry.jsonl`)
- Lazy-loaded OTEL packages (~1MB startup savings)
- Graceful degradation on init/exporter failures
- PII gating via `OTEL_LOG_USER_PROMPTS`/`TOOL_CONTENT` env vars
- Config via `OTEL_*` env vars + settings.json (env takes precedence)

## Dependencies
- @opentelemetry/api, @opentelemetry/api-logs
- @opentelemetry/sdk-node, @opentelemetry/sdk-logs
- @opentelemetry/sdk-trace-node, @opentelemetry/sdk-trace-base
- @opentelemetry/exporter-trace-otlp-http
- @opentelemetry/exporter-logs-otlp-http

## Tests
- 66 tests across 3 telemetry test files
- Branch coverage: 80.32% (meets 80% threshold)