### PR TITLE
perf(test): speed up streaming and logger integration tests

### DIFF
--- a/packages/agent-sdk/tests/agent/agent.streaming.content.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.streaming.content.test.ts
@@ -15,6 +15,16 @@ import type { TextBlock } from "@/types/messaging.js";
 // Mock AI Service
 vi.mock("@/services/aiService");
 
+// Prevent auto-memory extraction forked agents from making extra AI calls
+vi.mock("@/managers/forkedAgentManager", () => ({
+  ForkedAgentManager: vi.fn().mockImplementation(function () {
+    return {
+      forkAndExecute: vi.fn().mockResolvedValue("mock-fork-id"),
+      cleanup: vi.fn(),
+    };
+  }),
+}));
+
 describe("Agent Content Streaming Tests", () => {
   let agent: Agent;
   let mockCallAgent: ReturnType<typeof vi.fn>;
@@ -23,10 +33,6 @@ describe("Agent Content Streaming Tests", () => {
   };
 
   beforeEach(async () => {
-    // Wait for any leaked async calls from previous test's forked agents to settle
-    // (auto-memory extraction continues after agent.destroy() via fire-and-forget)
-    await new Promise((r) => setTimeout(r, 100));
-
     // Clear mock to remove any leaked calls from previous test
     mockCallAgent = vi.mocked(aiService.callAgent);
     mockCallAgent.mockClear();

--- a/packages/agent-sdk/tests/agent/agent.streaming.tools.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.streaming.tools.test.ts
@@ -25,6 +25,16 @@ vi.mock("@/managers/toolManager", () => ({
   }),
 }));
 
+// Prevent auto-memory extraction forked agents from making extra AI calls
+vi.mock("@/managers/forkedAgentManager", () => ({
+  ForkedAgentManager: vi.fn().mockImplementation(function () {
+    return {
+      forkAndExecute: vi.fn().mockResolvedValue("mock-fork-id"),
+      cleanup: vi.fn(),
+    };
+  }),
+}));
+
 describe("Agent Tool Streaming Tests", () => {
   let agent: Agent;
   let mockCallAgent: ReturnType<typeof vi.fn>;
@@ -33,10 +43,6 @@ describe("Agent Tool Streaming Tests", () => {
   };
 
   beforeEach(async () => {
-    // Wait for any leaked async calls from previous test's forked agents to settle
-    // (auto-memory extraction continues after agent.destroy() via fire-and-forget)
-    await new Promise((r) => setTimeout(r, 100));
-
     // Clear mock to remove any leaked calls from previous test
     mockCallAgent = vi.mocked(aiService.callAgent);
     mockCallAgent.mockClear();

--- a/packages/agent-sdk/tests/integration/globalLogger.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/globalLogger.integration.test.ts
@@ -432,12 +432,9 @@ describe("Agent - Global Logger Integration", () => {
   });
 
   describe("User Story 2: Utility Functions Use Global Logger", () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       // Ensure we're in test environment
       process.env.NODE_ENV = "test";
-
-      // Clear all module cache to ensure fresh imports
-      vi.resetModules();
     });
 
     describe("Utility functions log when global logger is configured", () => {


### PR DESCRIPTION
## Summary

Replace `setTimeout(100)` delays and unnecessary `vi.resetModules()` in test files to reduce total wall time from ~29s to ~27s.

## Changes

### agent.streaming.tools.test.ts & agent.streaming.content.test.ts
- Removed `setTimeout(100)` in `beforeEach` (11 tests × 100ms = ~1.1s wasted)
- Added `ForkedAgentManager` mock to prevent auto-memory extraction forked agents from making extra AI calls
- Streaming tests alone: **6.8s → 1.6s (75% reduction)**

### globalLogger.integration.test.ts
- Removed unnecessary `vi.resetModules()` from "User Story 2" describe block (20+ tests)
- Module reloads were not needed since tests only use the already-imported `globalLogger`
- Saved ~0.8s

## Results

| File | Before | After | Savings |
|------|--------|-------|---------|
| agent.streaming.tools.test.ts | 2764ms | ~800ms | -1964ms |
| agent.streaming.content.test.ts | 982ms | ~500ms | -482ms |
| globalLogger.integration.test.ts | 2035ms | ~1180ms | -855ms |
| **Total suite** | ~29s | ~27s | **-2s** |

All 2664 tests pass.