### PR TITLE
fix(sdk): restore missing parameters schema in ToolSearchTool

### DIFF
--- a/packages/agent-sdk/src/tools/toolSearchTool.ts
+++ b/packages/agent-sdk/src/tools/toolSearchTool.ts
@@ -130,6 +130,23 @@ export const toolSearchTool: ToolPlugin = {
 Deferred tools appear by name in <available-deferred-tools> messages. Until fetched, only the name is known — there is no parameter schema, so the tool cannot be invoked. This tool takes a query, matches it against the deferred tool list, and returns the matched tools' complete JSONSchema definitions inside a <functions> block. Once a tool's schema appears in that result, it is callable exactly like any tool defined at the top of the prompt.
 
 Result format: each matched tool appears as one <function>{"description": "...", "name": "...", "parameters": {...}}`,
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description:
+              'Search query for finding deferred tools. Supports: "select:ToolName" for direct lookup, or keyword search like "notebook jupyter". Use "+term" to require a term (e.g. "+slack send").',
+          },
+          max_results: {
+            type: "number",
+            description:
+              "Maximum number of results to return for keyword search (default: 5).",
+          },
+        },
+        required: ["query"],
+        additionalProperties: false,
+      },
     },
   },
   shouldDefer: false, // Always available


### PR DESCRIPTION
## Summary

In commit a3394511 ("align ToolSearch with Claude Code deferred tool patterns"), the `parameters` block was accidentally removed when rewriting the description. This caused the API to receive an empty schema (`properties: {}`, `required: []`), resulting in **"Missing required 'query' parameter"** errors when the model attempted to call ToolSearch.

## Root Cause

The `a3394511` commit diff shows:
```diff
-      description: "...",
-      parameters: { ... query, max_results ... },
+      description: `Fetches full schema definitions...`,
```

The entire parameters definition was deleted alongside the old description.

## Fix

Restored the `parameters` schema with:
- `query` (required): Search query supporting `select:ToolName`, keyword search, and `+term` required prefixes
- `max_results` (optional): Max results for keyword search (default: 5)

## Why It Escaped Detection

1. **No schema structure tests** — Existing tests only verified `execute()` logic, not that `config.function.parameters` contains required fields
2. **TypeScript allows it** — `parameters` is optional in `ChatCompletionFunctionTool`
3. **CI passed** — Type-check, lint, and all existing tests passed since the code was syntactically valid