### PR TITLE
feat(session): skip meta messages in firstMessage for session index

### DIFF
--- a/packages/agent-sdk/src/services/session.ts
+++ b/packages/agent-sdk/src/services/session.ts
@@ -803,12 +803,13 @@ export async function sessionExistsInJsonl(
 }
 
 /**
- * Get the content of the first message in a session
+ * Get the content of the first non-meta message in a session
  * For user role: get text block content
  * For assistant role: get compact block content
+ * Skips meta messages (isMeta: true) to find the first meaningful message
  * @param sessionId - Session ID to get first message from
  * @param workdir - Working directory for session operations
- * @returns Promise that resolves to the first message content or null if not found
+ * @returns Promise that resolves to the first non-meta message content or null if not found
  */
 export async function getFirstMessageContent(
   sessionId: string,
@@ -821,25 +822,29 @@ export async function getFirstMessageContent(
     const projectDir = await encoder.getProjectDirectory(workdir, baseDir);
     const filePath = join(projectDir.encodedPath, `${sessionId}.jsonl`);
 
-    // Read the first line of the file
-    const { readFirstLine } = await import("../utils/fileUtils.js");
-    const firstLine = await readFirstLine(filePath);
+    // Read first N lines to skip meta messages
+    const { readFirstNLines } = await import("../utils/fileUtils.js");
+    const lines = await readFirstNLines(filePath, 10);
 
-    if (!firstLine) {
-      return null;
+    for (const line of lines) {
+      try {
+        const message = JSON.parse(line) as Message;
+
+        // Skip meta messages
+        if (message.isMeta) {
+          continue;
+        }
+
+        const content = getMessageContent(message);
+        if (content) {
+          return content;
+        }
+      } catch (error) {
+        logger.warn(`Failed to parse message in session ${sessionId}:`, error);
+      }
     }
 
-    try {
-      const message = JSON.parse(firstLine) as Message;
-
-      return getMessageContent(message) || null;
-    } catch (error) {
-      logger.warn(
-        `Failed to parse first message in session ${sessionId}:`,
-        error,
-      );
-      return null;
-    }
+    return null;
   } catch (error) {
     logger.warn(
       `Failed to get first message content for session ${sessionId}:`,

--- a/packages/agent-sdk/src/utils/fileUtils.ts
+++ b/packages/agent-sdk/src/utils/fileUtils.ts
@@ -38,6 +38,46 @@ export async function readFirstLine(filePath: string): Promise<string> {
 }
 
 /**
+ * Reads up to N lines from a file using Node.js readline.
+ *
+ * @param {string} filePath - The path to the file.
+ * @param {number} maxLines - Maximum number of non-empty lines to read.
+ * @return {Promise<string[]>} - Array of non-empty lines (up to maxLines).
+ */
+export async function readFirstNLines(
+  filePath: string,
+  maxLines: number,
+): Promise<string[]> {
+  const { createInterface } = await import("node:readline");
+
+  const fileStream = createReadStream(filePath);
+  const rl = createInterface({
+    input: fileStream,
+    crlfDelay: Infinity,
+  });
+
+  const lines: string[] = [];
+
+  try {
+    for await (const line of rl) {
+      const trimmedLine = line.trim();
+      if (trimmedLine.length > 0) {
+        lines.push(trimmedLine);
+        if (lines.length >= maxLines) {
+          break;
+        }
+      }
+    }
+    return lines;
+  } catch {
+    return lines;
+  } finally {
+    rl.close();
+    fileStream.destroy();
+  }
+}
+
+/**
  * Reads a file from the end and returns the last non-empty line.
  *
  * This version supports files that end with:

--- a/packages/agent-sdk/tests/services/session.extra.test.ts
+++ b/packages/agent-sdk/tests/services/session.extra.test.ts
@@ -38,6 +38,7 @@ vi.mock("../../src/utils/pathEncoder.js", () => ({
 
 vi.mock("../../src/utils/fileUtils.js", () => ({
   readFirstLine: vi.fn(),
+  readFirstNLines: vi.fn(),
 }));
 
 vi.mock("../../src/utils/globalLogger.js", () => ({
@@ -86,11 +87,11 @@ describe("session service - additional coverage", () => {
 
     it("should return text content from first message", async () => {
       const fileUtils = await import("../../src/utils/fileUtils.js");
-      vi.mocked(fileUtils.readFirstLine).mockResolvedValue(
+      vi.mocked(fileUtils.readFirstNLines).mockResolvedValue([
         JSON.stringify({
           blocks: [{ type: "text", content: "hello" }],
         }),
-      );
+      ]);
 
       const content = await getFirstMessageContent(sessionId, workdir);
       expect(content).toBe("hello");
@@ -98,11 +99,11 @@ describe("session service - additional coverage", () => {
 
     it("should return command from bang block", async () => {
       const fileUtils = await import("../../src/utils/fileUtils.js");
-      vi.mocked(fileUtils.readFirstLine).mockResolvedValue(
+      vi.mocked(fileUtils.readFirstNLines).mockResolvedValue([
         JSON.stringify({
           blocks: [{ type: "bang", command: "ls" }],
         }),
-      );
+      ]);
 
       const content = await getFirstMessageContent(sessionId, workdir);
       expect(content).toBe("!ls");
@@ -110,7 +111,7 @@ describe("session service - additional coverage", () => {
 
     it("should return content from compact block", async () => {
       const fileUtils = await import("../../src/utils/fileUtils.js");
-      vi.mocked(fileUtils.readFirstLine).mockResolvedValue(
+      vi.mocked(fileUtils.readFirstNLines).mockResolvedValue([
         JSON.stringify({
           blocks: [
             {
@@ -120,7 +121,7 @@ describe("session service - additional coverage", () => {
             },
           ],
         }),
-      );
+      ]);
 
       const content = await getFirstMessageContent(sessionId, workdir);
       expect(content).toBe("compacted");
@@ -128,7 +129,7 @@ describe("session service - additional coverage", () => {
 
     it("should return text block content", async () => {
       const fileUtils = await import("../../src/utils/fileUtils.js");
-      vi.mocked(fileUtils.readFirstLine).mockResolvedValue(
+      vi.mocked(fileUtils.readFirstNLines).mockResolvedValue([
         JSON.stringify({
           blocks: [
             {
@@ -137,7 +138,7 @@ describe("session service - additional coverage", () => {
             },
           ],
         }),
-      );
+      ]);
 
       const content = await getFirstMessageContent(sessionId, workdir);
       expect(content).toBe("Hello world");
@@ -145,11 +146,11 @@ describe("session service - additional coverage", () => {
 
     it("should return null if no recognized blocks", async () => {
       const fileUtils = await import("../../src/utils/fileUtils.js");
-      vi.mocked(fileUtils.readFirstLine).mockResolvedValue(
+      vi.mocked(fileUtils.readFirstNLines).mockResolvedValue([
         JSON.stringify({
           blocks: [{ type: "other" }],
         }),
-      );
+      ]);
 
       const content = await getFirstMessageContent(sessionId, workdir);
       expect(content).toBeNull();
@@ -157,11 +158,75 @@ describe("session service - additional coverage", () => {
 
     it("should return null on parse error", async () => {
       const fileUtils = await import("../../src/utils/fileUtils.js");
-      vi.mocked(fileUtils.readFirstLine).mockResolvedValue("invalid json");
+      vi.mocked(fileUtils.readFirstNLines).mockResolvedValue(["invalid json"]);
 
       const content = await getFirstMessageContent(sessionId, workdir);
       expect(content).toBeNull();
       expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it("should skip meta message and return second message", async () => {
+      const fileUtils = await import("../../src/utils/fileUtils.js");
+      vi.mocked(fileUtils.readFirstNLines).mockResolvedValue([
+        JSON.stringify({
+          isMeta: true,
+          blocks: [{ type: "text", content: "system init" }],
+        }),
+        JSON.stringify({
+          blocks: [{ type: "text", content: "hello" }],
+        }),
+      ]);
+
+      const content = await getFirstMessageContent(sessionId, workdir);
+      expect(content).toBe("hello");
+    });
+
+    it("should skip multiple consecutive meta messages", async () => {
+      const fileUtils = await import("../../src/utils/fileUtils.js");
+      vi.mocked(fileUtils.readFirstNLines).mockResolvedValue([
+        JSON.stringify({
+          isMeta: true,
+          blocks: [{ type: "text", content: "hook1" }],
+        }),
+        JSON.stringify({
+          isMeta: true,
+          blocks: [{ type: "text", content: "hook2" }],
+        }),
+        JSON.stringify({
+          isMeta: true,
+          blocks: [{ type: "text", content: "hook3" }],
+        }),
+        JSON.stringify({
+          blocks: [{ type: "text", content: "real user message" }],
+        }),
+      ]);
+
+      const content = await getFirstMessageContent(sessionId, workdir);
+      expect(content).toBe("real user message");
+    });
+
+    it("should return null if all messages are meta", async () => {
+      const fileUtils = await import("../../src/utils/fileUtils.js");
+      const metaLines = Array(10)
+        .fill(null)
+        .map((_, i) =>
+          JSON.stringify({
+            isMeta: true,
+            blocks: [{ type: "text", content: `meta ${i}` }],
+          }),
+        );
+      vi.mocked(fileUtils.readFirstNLines).mockResolvedValue(metaLines);
+
+      const content = await getFirstMessageContent(sessionId, workdir);
+      expect(content).toBeNull();
+    });
+
+    it("should handle empty file gracefully", async () => {
+      const fileUtils = await import("../../src/utils/fileUtils.js");
+      vi.mocked(fileUtils.readFirstNLines).mockResolvedValue([]);
+
+      const content = await getFirstMessageContent(sessionId, workdir);
+      expect(content).toBeNull();
     });
   });
 

--- a/specs/004-session-management/spec.md
+++ b/specs/004-session-management/spec.md
@@ -77,6 +77,7 @@ As a developer using subagents, I want subagent sessions to be clearly identifie
 - **FR-013**: Each project directory MUST maintain a `sessions-index.json` file for O(1) session listing.
 - **FR-014**: The session index MUST cache the `firstMessage` content for instant UI display.
 - **FR-015**: The system MUST be able to rebuild the session index from `.jsonl` files if it is missing or corrupted.
+- **FR-016**: The `firstMessage` field MUST skip meta messages (`isMeta: true`) and capture the first non-meta message content for display in session listings.
 
 ### Key Entities *(include if feature involves data)*
 


### PR DESCRIPTION
## Summary

getFirstMessageContent() now iterates through first 10 lines of JSONL and skips messages with `isMeta: true` to find the first meaningful user message for display in session listings.

Previously, when a session started with SessionStart hook output or other meta messages, the session list preview would show system content like `<system-reminder> SessionStart hook additional context...` instead of the actual user's first message.

## Changes

- **fileUtils.ts**: Added `readFirstNLines(filePath, maxLines)` utility
- **session.ts**: Updated `getFirstMessageContent()` to skip meta messages (`isMeta: true`) and return first non-meta message content
- **session.extra.test.ts**: Updated 6 existing tests, added 4 new test cases for meta skipping
- **spec.md**: Added FR-016 requirement

## Verification

- All 63 session tests pass
- Verified against real sessions in `/home/liuyiqi/gitlab/wave-admin` — session index rebuild correctly skips meta content