### PR TITLE
fix(test): mock Agent.create in App.test.tsx to prevent lock file creation

### DIFF
--- a/packages/code/tests/components/App.test.tsx
+++ b/packages/code/tests/components/App.test.tsx
@@ -21,6 +21,23 @@ vi.mock("wave-agent-sdk", async () => {
   const actual = await vi.importActual("wave-agent-sdk");
   return {
     ...actual,
+    Agent: {
+      create: vi.fn().mockResolvedValue({
+        destroy: vi.fn(),
+        abortMessage: vi.fn(),
+        sessionId: "test-session-id",
+        messages: [],
+        isLoading: false,
+        isCommandRunning: false,
+        isCompacting: false,
+        workingDirectory: process.cwd(),
+        getPermissionMode: vi.fn().mockReturnValue("default"),
+        getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+        getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+        getMcpServers: vi.fn().mockReturnValue([]),
+        getSlashCommands: vi.fn().mockReturnValue([]),
+      }),
+    },
     hasUncommittedChanges: vi.fn(),
     hasNewCommits: vi.fn(),
     getDefaultRemoteBranch: vi.fn(),


### PR DESCRIPTION
Mock Agent.create in App.test.tsx to prevent real Agent instantiation during UI tests.

**Problem:** App.test.tsx triggers Agent.create() → CronManager.start() → tryAcquireSchedulerLock(), leaving a stale .wave/scheduled_tasks.lock file after tests since vitest keeps the process alive and process.on('exit') cleanup never fires.

**Fix:** Mock Agent.create in the SDK mock to return a minimal stub with destroy and abortMessage methods.