### PR TITLE
fix: only acquire scheduler lock when durable cron tasks exist

### DIFF
--- a/packages/agent-sdk/src/managers/cronManager.ts
+++ b/packages/agent-sdk/src/managers/cronManager.ts
@@ -44,8 +44,9 @@ export class CronManager {
 
     // Load durable tasks from file (best-effort, resilient to mocked fs in tests)
     const workdir = this.container.get<string>("Workdir") ?? process.cwd();
+    let durableTasks: Awaited<ReturnType<typeof readCronTasks>> = [];
     try {
-      const durableTasks = readCronTasks(workdir);
+      durableTasks = readCronTasks(workdir) ?? [];
       for (const task of durableTasks) {
         // Recalculate runtime fields for loaded tasks
         try {
@@ -77,24 +78,24 @@ export class CronManager {
       logger?.warn("CronManager: failed to load durable tasks from disk:", e);
     }
 
-    // Try to acquire scheduler lock (best-effort)
-    try {
-      this.tryLock(workdir);
-    } catch (e) {
-      logger?.warn("CronManager: failed to acquire scheduler lock:", e);
-    }
-
     this.interval = setInterval(() => this.checkJobs(), 60000);
     this.interval.unref();
 
-    // Register exit cleanup (best-effort)
-    try {
-      this.cleanupSchedulerLock = registerSchedulerLockCleanup({
-        dir: workdir,
-        sessionId: this.sessionId,
-      });
-    } catch (e) {
-      logger?.warn("CronManager: failed to register lock cleanup:", e);
+    // Only acquire scheduler lock and register cleanup when durable tasks exist
+    if (durableTasks.length > 0) {
+      try {
+        this.tryLock(workdir);
+      } catch (e) {
+        logger?.warn("CronManager: failed to acquire scheduler lock:", e);
+      }
+      try {
+        this.cleanupSchedulerLock = registerSchedulerLockCleanup({
+          dir: workdir,
+          sessionId: this.sessionId,
+        });
+      } catch (e) {
+        logger?.warn("CronManager: failed to register lock cleanup:", e);
+      }
     }
   }
 
@@ -116,6 +117,19 @@ export class CronManager {
       .catch((err) => {
         logger?.error("CronManager: failed to acquire scheduler lock:", err);
       });
+  }
+
+  private ensureLock(workdir: string): void {
+    if (this.isOwner) return;
+    this.tryLock(workdir);
+    try {
+      this.cleanupSchedulerLock = registerSchedulerLockCleanup({
+        dir: workdir,
+        sessionId: this.sessionId,
+      });
+    } catch (e) {
+      logger?.warn("CronManager: failed to register lock cleanup:", e);
+    }
   }
 
   private startLockProbe(workdir: string): void {
@@ -208,6 +222,7 @@ export class CronManager {
       try {
         const workdir = this.container.get<string>("Workdir") ?? process.cwd();
         addCronTask(newJob, workdir);
+        this.ensureLock(workdir);
       } catch (e) {
         logger?.warn(
           `CronManager: failed to persist durable job ${id} to disk:`,

--- a/packages/agent-sdk/tests/managers/cronManager.test.ts
+++ b/packages/agent-sdk/tests/managers/cronManager.test.ts
@@ -109,6 +109,39 @@ describe("CronManager", () => {
 
       expect(addCronTask).not.toHaveBeenCalled();
     });
+
+    it("acquires scheduler lock on createJob when durable=true", async () => {
+      vi.mocked(tryAcquireSchedulerLock).mockResolvedValue(true);
+
+      cronManager = new CronManager(container);
+      cronManager.createJob({
+        cron: "*/5 * * * *",
+        prompt: "durable job",
+        recurring: true,
+        durable: true,
+      });
+
+      await vi.waitFor(() => {
+        expect(tryAcquireSchedulerLock).toHaveBeenCalled();
+      });
+    });
+
+    it("does not acquire lock on createJob for session-only jobs", async () => {
+      vi.mocked(tryAcquireSchedulerLock).mockResolvedValue(true);
+
+      cronManager = new CronManager(container);
+      cronManager.createJob({
+        cron: "*/5 * * * *",
+        prompt: "session job",
+        recurring: true,
+        durable: false,
+      });
+
+      // Give async lock acquisition time to potentially fire
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(tryAcquireSchedulerLock).not.toHaveBeenCalled();
+    });
   });
 
   describe("deleteJob", () => {
@@ -220,8 +253,18 @@ describe("CronManager", () => {
       expect(cronManager.listJobs()[0].id).toBe("persisted-1");
     });
 
-    it("acquires scheduler lock on start", async () => {
+    it("acquires scheduler lock on start when durable tasks exist", async () => {
       vi.mocked(tryAcquireSchedulerLock).mockResolvedValue(true);
+      vi.mocked(readCronTasks).mockReturnValue([
+        {
+          id: "task-1",
+          cron: "*/5 * * * *",
+          prompt: "durable task",
+          recurring: true,
+          createdAt: Date.now(),
+          durable: true,
+        } as never,
+      ]);
 
       cronManager = new CronManager(container);
       cronManager.start();
@@ -232,8 +275,18 @@ describe("CronManager", () => {
       });
     });
 
-    it("sets up lock probe when not owner", async () => {
+    it("sets up lock probe when not owner and durable tasks exist", async () => {
       vi.mocked(tryAcquireSchedulerLock).mockResolvedValue(false);
+      vi.mocked(readCronTasks).mockReturnValue([
+        {
+          id: "task-1",
+          cron: "*/5 * * * *",
+          prompt: "durable task",
+          recurring: true,
+          createdAt: Date.now(),
+          durable: true,
+        } as never,
+      ]);
 
       cronManager = new CronManager(container);
       cronManager.start();
@@ -241,6 +294,20 @@ describe("CronManager", () => {
       await vi.waitFor(() => {
         expect(registerSchedulerLockCleanup).toHaveBeenCalled();
       });
+    });
+
+    it("does not acquire scheduler lock on start when no durable tasks", async () => {
+      vi.mocked(tryAcquireSchedulerLock).mockResolvedValue(true);
+      vi.mocked(readCronTasks).mockReturnValue([]);
+
+      cronManager = new CronManager(container);
+      cronManager.start();
+
+      // Give async lock acquisition time to potentially fire
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(tryAcquireSchedulerLock).not.toHaveBeenCalled();
+      expect(registerSchedulerLockCleanup).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
CronManager.start() previously always acquired the scheduler lock and registered cleanup on every agent.create(), even with zero durable tasks.

## Changes

- **start()** now checks `durableTasks.length` before acquiring the scheduler lock
- **ensureLock()** new method acquires lock on-demand when first durable job is created via `createJob()`
- Session-only jobs no longer trigger lock acquisition
- Updated tests to verify lock behavior with/without durable tasks

## Tests

- 22 cronManager tests passing
- 2671 total SDK tests passing