### PR TITLE
fix: add detached:true to spawn to prevent orphan child processes

### DIFF
--- a/packages/agent-sdk/examples/reproduce-orphan-bash.ts
+++ b/packages/agent-sdk/examples/reproduce-orphan-bash.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests that BackgroundTaskManager cleanup kills child process trees.
+ *
+ * Spawns a shell that forks a long-running grandchild (`sleep 300`),
+ * then calls cleanup(). Verifies all descendants are killed.
+ *
+ * Expected BEFORE fix: "FAIL - orphaned processes still alive"
+ * Expected AFTER fix:  "PASS - all child processes were killed"
+ */
+
+import { execSync } from "child_process";
+import { Container } from "../src/utils/container.js";
+import { BackgroundTaskManager } from "../src/managers/backgroundTaskManager.js";
+
+/**
+ * Check if a PID is alive (works on Linux/macOS).
+ */
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Find all descendant PIDs of a given parent PID.
+ */
+function getChildPids(ppid: number): number[] {
+  try {
+    const output = execSync(`pgrep -P ${ppid} 2>/dev/null || true`, {
+      encoding: "utf8",
+    });
+    return output.trim().split("\n").filter(Boolean).map(Number);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Recursively collect ALL descendant PIDs (children, grandchildren, etc.).
+ */
+function getAllDescendantPids(ppid: number): Set<number> {
+  const result = new Set<number>();
+  const queue = [ppid];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const children = getChildPids(current);
+    for (const c of children) {
+      if (c > 0 && !result.has(c)) {
+        result.add(c);
+        queue.push(c);
+      }
+    }
+  }
+
+  return result;
+}
+
+async function main() {
+  const workdir = process.cwd();
+  const container = new Container();
+
+  const manager = new BackgroundTaskManager(container, { workdir });
+
+  // sh -c "sleep 300 & echo SLEEP_PID=$! && wait"
+  //   - `&` forks sleep into background
+  //   - `wait` keeps the shell alive
+  //   - When we kill the shell, sleep should die too (with detached + pgid kill)
+  const command = 'sh -c "sleep 300 & echo SLEEP_PID=$! && wait"';
+
+  console.log(`Starting: ${command}`);
+
+  const { id, child } = manager.startShell(command);
+  const shellPid = child.pid!;
+
+  // Wait for the shell to print the grandchild PID
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  // Parse the grandchild PID from stdout
+  const task = manager.getTask(id);
+  const pidMatch = task?.stdout?.match(/SLEEP_PID=(\d+)/);
+  let grandchildPid: number | undefined;
+  if (pidMatch) {
+    grandchildPid = parseInt(pidMatch[1], 10);
+  }
+
+  // Fallback: scan descendants
+  const descendants = getAllDescendantPids(shellPid);
+  if (!grandchildPid && descendants.size > 0) {
+    grandchildPid = descendants.values().next().value;
+  }
+
+  console.log(`Shell PID:  ${shellPid}`);
+  console.log(`Grandchild (sleep) PID: ${grandchildPid ?? "(unknown)"}`);
+
+  // Simulate agent destroy → cleanup
+  console.log("\nCalling manager.cleanup() ...");
+  manager.cleanup();
+
+  // Wait for kill to take effect
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  // Check results
+  const shellAlive = isProcessAlive(shellPid);
+  const grandchildAlive = grandchildPid ? isProcessAlive(grandchildPid) : false;
+
+  // Also scan for any remaining descendants
+  const remainingDescendants = getAllDescendantPids(shellPid);
+
+  console.log(`\n--- Results ---`);
+  console.log(`Shell alive after cleanup:      ${shellAlive}`);
+  console.log(`Grandchild (sleep) alive:        ${grandchildAlive}`);
+  console.log(
+    `Remaining descendant PIDs:      ${[...remainingDescendants].join(", ") || "none"}`,
+  );
+
+  if (grandchildAlive || remainingDescendants.size > 0) {
+    console.log("\nFAIL - orphaned child processes still alive!");
+    console.log("  spawn() is missing `detached: true`");
+    process.exitCode = 1;
+  } else {
+    console.log("\nPASS - all child processes were killed correctly.");
+    process.exitCode = 0;
+  }
+}
+
+main().catch((err) => {
+  console.error("Error:", err);
+  process.exit(1);
+});

--- a/packages/agent-sdk/src/managers/backgroundTaskManager.ts
+++ b/packages/agent-sdk/src/managers/backgroundTaskManager.ts
@@ -66,6 +66,7 @@ export class BackgroundTaskManager {
     const child = spawn(command, {
       shell: true,
       stdio: "pipe",
+      detached: true,
       cwd: this.workdir,
       env: {
         ...process.env,

--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -66,6 +66,9 @@ export interface SubagentInstance {
   aiManager: AIManager;
   messageManager: MessageManager;
   toolManager: ToolManager;
+  permissionManager: PermissionManager;
+  backgroundTaskManager: BackgroundTaskManager;
+  notificationQueue: NotificationQueue;
   status: "initializing" | "active" | "completed" | "error" | "aborted";
   messages: Message[];
   usedTools: {
@@ -92,7 +95,6 @@ export interface SubagentManagerOptions {
 
 export class SubagentManager {
   private instances = new Map<string, SubagentInstance>();
-  private subagentPermissionManagers = new Map<string, PermissionManager>();
   private cachedConfigurations: SubagentConfiguration[] | null = null;
 
   private workdir: string;
@@ -154,10 +156,12 @@ export class SubagentManager {
     const parentPm = this.container.get<PermissionManager>("PermissionManager");
     if (!parentPm) return;
 
-    for (const [, pm] of this.subagentPermissionManagers) {
-      pm.updateAllowedRules(parentPm.getAllowedRules());
-      pm.updateDeniedRules(parentPm.getDeniedRules());
-      pm.updateAdditionalDirectories(parentPm.getAdditionalDirectories());
+    for (const instance of this.instances.values()) {
+      instance.permissionManager.updateAllowedRules(parentPm.getAllowedRules());
+      instance.permissionManager.updateDeniedRules(parentPm.getDeniedRules());
+      instance.permissionManager.updateAdditionalDirectories(
+        parentPm.getAdditionalDirectories(),
+      );
     }
   }
 
@@ -324,9 +328,6 @@ export class SubagentManager {
       );
     }
 
-    // Track this subagent's PermissionManager for rule sync
-    this.subagentPermissionManagers.set(subagentId, subagentPermissionManager);
-
     // Add temporary permission rules if provided
     if (parameters.allowedTools) {
       logger.debug(
@@ -391,6 +392,9 @@ export class SubagentManager {
       aiManager,
       messageManager,
       toolManager,
+      permissionManager: subagentPermissionManager,
+      backgroundTaskManager: subagentBackgroundTaskManager,
+      notificationQueue: subagentNotificationQueue,
       status: "initializing",
       messages: [],
       usedTools: [], // Initialize usedTools
@@ -732,7 +736,6 @@ export class SubagentManager {
         instance.status === "aborted")
     ) {
       this.instances.delete(subagentId);
-      this.subagentPermissionManagers.delete(subagentId);
     }
   }
 
@@ -750,6 +753,10 @@ export class SubagentManager {
    * Clean up all instances (for session end)
    */
   cleanup(): void {
+    for (const instance of this.instances.values()) {
+      instance.aiManager.abortAIMessage();
+      instance.backgroundTaskManager.cleanup();
+    }
     this.instances.clear();
   }
 

--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -240,6 +240,7 @@ Use the gh command via the Bash tool for GitHub-related tasks including working 
       const child: ChildProcess = spawn(command, {
         shell: true,
         stdio: "pipe",
+        detached: true,
         cwd: context.workdir,
         env: {
           ...process.env,

--- a/packages/agent-sdk/tests/managers/forkedAgentManager.test.ts
+++ b/packages/agent-sdk/tests/managers/forkedAgentManager.test.ts
@@ -63,6 +63,12 @@ describe("ForkedAgentManager", () => {
       } as unknown as import("@/managers/messageManager.js").MessageManager,
       toolManager:
         {} as unknown as import("@/managers/toolManager.js").ToolManager,
+      permissionManager:
+        {} as unknown as import("@/managers/permissionManager.js").PermissionManager,
+      backgroundTaskManager:
+        {} as unknown as import("@/managers/backgroundTaskManager.js").BackgroundTaskManager,
+      notificationQueue:
+        {} as unknown as import("@/managers/notificationQueue.js").NotificationQueue,
       status: "active",
       messages: [],
       usedTools: [],

--- a/packages/agent-sdk/tests/managers/subagentManager.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.test.ts
@@ -4,6 +4,7 @@ import { SubagentManager } from "../../src/managers/subagentManager.js";
 import { NotificationQueue } from "../../src/managers/notificationQueue.js";
 import type { BackgroundTaskManager } from "../../src/managers/backgroundTaskManager.js";
 import type { BackgroundTask } from "../../src/types/processes.js";
+import type { SubagentInstance } from "../../src/managers/subagentManager.js";
 
 vi.mock("../../src/utils/subagentParser.js", () => ({
   loadSubagentConfigurations: vi.fn().mockResolvedValue([
@@ -370,5 +371,72 @@ describe("SubagentManager registerPluginAgents", () => {
     // plugin-a:agent-z should come before plugin-b:agent-a (same priority, alphabetical by namespaced name)
     expect(pluginAgents[0].name).toBe("plugin-a:agent-z");
     expect(pluginAgents[1].name).toBe("plugin-b:agent-a");
+  });
+});
+
+describe("SubagentManager.cleanup()", () => {
+  let container: Container;
+  let subagentManager: SubagentManager;
+  let mockAbortAIMessage: ReturnType<typeof vi.fn>;
+  let mockBackgroundTaskManagerCleanup: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    container = new Container();
+
+    mockAbortAIMessage = vi.fn();
+    mockBackgroundTaskManagerCleanup = vi.fn();
+
+    const mockBackgroundTaskManager: Partial<BackgroundTaskManager> = {
+      generateId: vi.fn().mockReturnValue("task_1"),
+      cleanup: mockBackgroundTaskManagerCleanup as unknown as () => void,
+    };
+    container.register(
+      "BackgroundTaskManager",
+      mockBackgroundTaskManager as unknown as BackgroundTaskManager,
+    );
+
+    container.register("ToolManager", {
+      initializeBuiltInTools: vi.fn(),
+    });
+
+    subagentManager = new SubagentManager(container, {
+      workdir: "/tmp/test",
+      stream: false,
+    });
+  });
+
+  it("should abort AI and cleanup background tasks for all active instances", async () => {
+    // Create two mock instances directly to simulate active subagents
+    const mockInstance1 = {
+      subagentId: "id-1",
+      status: "active" as const,
+      aiManager: { abortAIMessage: mockAbortAIMessage },
+      backgroundTaskManager: {
+        cleanup: mockBackgroundTaskManagerCleanup,
+      },
+    } as unknown as SubagentInstance;
+    const mockInstance2 = {
+      subagentId: "id-2",
+      status: "active" as const,
+      aiManager: { abortAIMessage: mockAbortAIMessage },
+      backgroundTaskManager: {
+        cleanup: mockBackgroundTaskManagerCleanup,
+      },
+    } as unknown as SubagentInstance;
+
+    // Access private instances map to inject mocks
+    const instances = (
+      subagentManager as unknown as { instances: Map<string, SubagentInstance> }
+    ).instances;
+    instances.set("id-1", mockInstance1);
+    instances.set("id-2", mockInstance2);
+
+    subagentManager.cleanup();
+
+    expect(mockAbortAIMessage).toHaveBeenCalledTimes(2);
+    expect(mockBackgroundTaskManagerCleanup).toHaveBeenCalledTimes(2);
+    expect(instances.size).toBe(0);
   });
 });


### PR DESCRIPTION
### Changes

- **02abc2a3** fix: add detached:true to spawn to prevent orphan child processes
- **686bf059** fix: properly terminate subagent resources in SubagentManager.cleanup()
  - Add permissionManager, backgroundTaskManager, notificationQueue to SubagentInstance
  - Remove redundant subagentPermissionManagers Map (eliminating memory leak)
  - Update syncPermissionRulesToSubagents() to iterate instances directly
  - Fix cleanup() to abort AI and cleanup background tasks per instance
  - Update forkedAgentManager and subagentManager tests for new interface