### PR TITLE
feat: restore worktree auto-deny for Write/Edit tools

### DIFF
--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -34,6 +34,7 @@ import {
 } from "../constants/tools.js";
 import { Container } from "../utils/container.js";
 import { ConfigurationService } from "../services/configurationService.js";
+import { getCurrentWorktreeSession } from "../utils/worktreeSession.js";
 
 const SAFE_COMMANDS = [
   "cd",
@@ -129,6 +130,8 @@ export class PermissionManager {
   private systemAdditionalDirectories: string[] = [];
   private planFilePath?: string;
   private workdir?: string;
+  private worktreeName?: string;
+  private mainRepoRoot?: string;
   private onConfiguredPermissionModeChange?: (mode: PermissionMode) => void;
   private _logger?: Logger;
 
@@ -149,6 +152,8 @@ export class PermissionManager {
     }
 
     this.workdir = this.container.get<string>("Workdir");
+    this.worktreeName = this.container.get<string | undefined>("WorktreeName");
+    this.mainRepoRoot = this.container.get<string | undefined>("MainRepoRoot");
   }
 
   /**
@@ -419,6 +424,68 @@ export class PermissionManager {
     // 1. If bypassPermissions mode, always allow
     if (context.permissionMode === "bypassPermissions") {
       return { behavior: "allow" };
+    }
+
+    // 1.0 Check worktree safety for Write and Edit tools
+    // Support both CLI -w sessions (container-registered) and EnterWorktree mid-session (module-level)
+    const worktreeSession = getCurrentWorktreeSession();
+    const effectiveWorktreeName =
+      this.worktreeName || worktreeSession?.worktreeName;
+    const effectiveWorkdir = this.workdir || worktreeSession?.worktreePath;
+    const effectiveMainRepoRoot =
+      this.mainRepoRoot || worktreeSession?.repoRoot;
+
+    if (
+      effectiveWorktreeName &&
+      effectiveMainRepoRoot &&
+      effectiveWorkdir &&
+      (context.toolName === WRITE_TOOL_NAME ||
+        context.toolName === EDIT_TOOL_NAME)
+    ) {
+      const targetPath = context.toolInput?.file_path as string | undefined;
+      if (targetPath) {
+        const absoluteTargetPath = path.resolve(effectiveWorkdir, targetPath);
+        const isInsideMainRepo = isPathInside(
+          absoluteTargetPath,
+          effectiveMainRepoRoot,
+        );
+        const isInsideWorktree = isPathInside(
+          absoluteTargetPath,
+          effectiveWorkdir,
+        );
+
+        // Allow the plan file even if outside worktree
+        if (this.planFilePath) {
+          const absolutePlanPath = path.resolve(this.planFilePath);
+          if (absoluteTargetPath === absolutePlanPath) {
+            // Fall through — plan file is allowed
+          } else if (isInsideMainRepo && !isInsideWorktree) {
+            logger?.warn("Worktree safety violation", {
+              toolName: context.toolName,
+              targetPath,
+              worktreeName: effectiveWorktreeName,
+              mainRepoRoot: effectiveMainRepoRoot,
+              workdir: effectiveWorkdir,
+            });
+            return {
+              behavior: "deny",
+              message: `Access denied: You are currently in a worktree session ("${effectiveWorktreeName}"). Modifying files in the main repository (outside the worktree) is not allowed. Please only modify files within the worktree directory: ${effectiveWorkdir}`,
+            };
+          }
+        } else if (isInsideMainRepo && !isInsideWorktree) {
+          logger?.warn("Worktree safety violation", {
+            toolName: context.toolName,
+            targetPath,
+            worktreeName: effectiveWorktreeName,
+            mainRepoRoot: effectiveMainRepoRoot,
+            workdir: effectiveWorkdir,
+          });
+          return {
+            behavior: "deny",
+            message: `Access denied: You are currently in a worktree session ("${effectiveWorktreeName}"). Modifying files in the main repository (outside the worktree) is not allowed. Please only modify files within the worktree directory: ${effectiveWorkdir}`,
+          };
+        }
+      }
     }
 
     // 1.1 If acceptEdits mode, allow Edit, Write, and mkdir in safe zone

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -27,6 +27,7 @@ import { ReversionService } from "../services/reversionService.js";
 import { MemoryService } from "../services/memory.js";
 import { AutoMemoryService } from "../services/autoMemoryService.js";
 import { USER_MEMORY_FILE } from "./constants.js";
+import { getGitMainRepoRoot } from "./gitUtils.js";
 import type { AgentOptions, McpServerConfig } from "../types/index.js";
 import type {
   PermissionMode,
@@ -77,6 +78,11 @@ export function setupAgentContainer(
   const container = new Container();
   container.register("AgentOptions", options);
   container.register("Workdir", workdir);
+
+  if (options.worktreeName) {
+    container.register("WorktreeName", options.worktreeName);
+    container.register("MainRepoRoot", getGitMainRepoRoot(workdir));
+  }
 
   const notificationQueue = new NotificationQueue();
   container.register("NotificationQueue", notificationQueue);

--- a/packages/agent-sdk/tests/managers/permissionManager.worktree.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.worktree.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import path from "node:path";
+import { PermissionManager } from "../../src/managers/permissionManager.js";
+import type { ToolPermissionContext } from "../../src/types/permissions.js";
+import { Container } from "../../src/utils/container.js";
+import { setCurrentWorktreeSession } from "../../src/utils/worktreeSession.js";
+
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("PermissionManager Worktree Safety", () => {
+  const workdir = "/home/user/project/worktrees/feat-1";
+  const mainRepoRoot = "/home/user/project";
+  const worktreeName = "feat-1";
+
+  function createWorktreeContainer(): Container {
+    const c = new Container();
+    c.register("Workdir", workdir);
+    c.register("WorktreeName", worktreeName);
+    c.register("MainRepoRoot", mainRepoRoot);
+    return c;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setCurrentWorktreeSession(null);
+  });
+
+  afterEach(() => {
+    setCurrentWorktreeSession(null);
+  });
+
+  it("should allow Write to a file inside the worktree", async () => {
+    const container = createWorktreeContainer();
+    const manager = new PermissionManager(container);
+    const context: ToolPermissionContext = {
+      toolName: "Write",
+      permissionMode: "acceptEdits",
+      toolInput: { file_path: path.join(workdir, "test.txt") },
+    };
+
+    const result = await manager.checkPermission(context);
+    expect(result.behavior).toBe("allow");
+  });
+
+  it("should auto-deny Write to a file in the main repo (outside worktree)", async () => {
+    const container = createWorktreeContainer();
+    const manager = new PermissionManager(container);
+    const context: ToolPermissionContext = {
+      toolName: "Write",
+      permissionMode: "acceptEdits",
+      toolInput: { file_path: path.join(mainRepoRoot, "main-file.txt") },
+    };
+
+    const result = await manager.checkPermission(context);
+    expect(result.behavior).toBe("deny");
+    expect(result.message).toContain(
+      "Access denied: You are currently in a worktree session",
+    );
+    expect(result.message).toContain(worktreeName);
+  });
+
+  it("should auto-deny Edit to a file in the main repo (outside worktree)", async () => {
+    const container = createWorktreeContainer();
+    const manager = new PermissionManager(container);
+    const context: ToolPermissionContext = {
+      toolName: "Edit",
+      permissionMode: "acceptEdits",
+      toolInput: { file_path: path.join(mainRepoRoot, "main-file.txt") },
+    };
+
+    const result = await manager.checkPermission(context);
+    expect(result.behavior).toBe("deny");
+    expect(result.message).toContain(
+      "Access denied: You are currently in a worktree session",
+    );
+  });
+
+  it("should allow Write to the plan file outside the main repo in plan mode", async () => {
+    const planFilePath = "/home/user/.wave/plans/plan.md";
+    const container = createWorktreeContainer();
+    const manager = new PermissionManager(container, { planFilePath });
+    const context: ToolPermissionContext = {
+      toolName: "Write",
+      permissionMode: "plan",
+      toolInput: { file_path: planFilePath },
+    };
+
+    const result = await manager.checkPermission(context);
+    expect(result.behavior).toBe("allow");
+  });
+
+  it("should auto-deny Write to a non-plan file in the main repo in plan mode", async () => {
+    const planFilePath = path.join(mainRepoRoot, "plan.md");
+    const container = createWorktreeContainer();
+    const manager = new PermissionManager(container, { planFilePath });
+    const context: ToolPermissionContext = {
+      toolName: "Write",
+      permissionMode: "plan",
+      toolInput: { file_path: path.join(mainRepoRoot, "other.md") },
+    };
+
+    const result = await manager.checkPermission(context);
+    expect(result.behavior).toBe("deny");
+    expect(result.message).toContain(
+      "Access denied: You are currently in a worktree session",
+    );
+  });
+
+  it("should deny Write to a file outside the main repo (Safe Zone check applies)", async () => {
+    const container = createWorktreeContainer();
+    const manager = new PermissionManager(container);
+    const context: ToolPermissionContext = {
+      toolName: "Write",
+      permissionMode: "acceptEdits",
+      toolInput: { file_path: "/tmp/test.txt" },
+    };
+
+    const result = await manager.checkPermission(context);
+    // /tmp is not in the Safe Zone (worktree dir), so falls through to normal check
+    expect(result.behavior).toBe("deny");
+    expect(result.message).not.toContain("worktree session");
+  });
+
+  it("should not auto-deny if not in a worktree session", async () => {
+    const container = new Container();
+    container.register("Workdir", mainRepoRoot);
+    const manager = new PermissionManager(container);
+    const context: ToolPermissionContext = {
+      toolName: "Write",
+      permissionMode: "acceptEdits",
+      toolInput: { file_path: path.join(mainRepoRoot, "main-file.txt") },
+    };
+
+    const result = await manager.checkPermission(context);
+    expect(result.behavior).toBe("allow");
+  });
+});
+
+describe("PermissionManager Worktree Safety — EnterWorktree mid-session", () => {
+  const originalCwd = "/home/user/project/src";
+  const worktreePath = "/home/user/project/worktrees/feat-mid";
+  const mainRepoRoot = "/home/user/project";
+  const worktreeName = "feat-mid";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setCurrentWorktreeSession({
+      originalCwd,
+      worktreePath,
+      worktreeBranch: "worktree-feat-mid",
+      worktreeName,
+      isNew: true,
+      repoRoot: mainRepoRoot,
+      originalHeadCommit: "abc123",
+    });
+  });
+
+  afterEach(() => {
+    setCurrentWorktreeSession(null);
+  });
+
+  it("should auto-deny Write to main repo via module-level session (EnterWorktree path)", async () => {
+    // Container has no WorktreeName/MainRepoRoot — simulates EnterWorktree mid-session
+    const container = new Container();
+    container.register("Workdir", worktreePath);
+    const manager = new PermissionManager(container);
+    const context: ToolPermissionContext = {
+      toolName: "Write",
+      permissionMode: "acceptEdits",
+      toolInput: { file_path: path.join(mainRepoRoot, "main-file.txt") },
+    };
+
+    const result = await manager.checkPermission(context);
+    expect(result.behavior).toBe("deny");
+    expect(result.message).toContain(
+      "Access denied: You are currently in a worktree session",
+    );
+    expect(result.message).toContain(worktreeName);
+  });
+
+  it("should allow Write inside worktree via module-level session", async () => {
+    const container = new Container();
+    container.register("Workdir", worktreePath);
+    const manager = new PermissionManager(container);
+    const context: ToolPermissionContext = {
+      toolName: "Write",
+      permissionMode: "acceptEdits",
+      toolInput: { file_path: path.join(worktreePath, "test.txt") },
+    };
+
+    const result = await manager.checkPermission(context);
+    expect(result.behavior).toBe("allow");
+  });
+
+  it("should not auto-deny after module-level session is cleared", async () => {
+    setCurrentWorktreeSession(null);
+    const container = new Container();
+    container.register("Workdir", mainRepoRoot);
+    const manager = new PermissionManager(container);
+    const context: ToolPermissionContext = {
+      toolName: "Write",
+      permissionMode: "acceptEdits",
+      toolInput: { file_path: path.join(mainRepoRoot, "main-file.txt") },
+    };
+
+    const result = await manager.checkPermission(context);
+    expect(result.behavior).toBe("allow");
+  });
+});

--- a/specs/068-worktree/checklists/safety.md
+++ b/specs/068-worktree/checklists/safety.md
@@ -53,5 +53,7 @@
 
 - [x] CHK024 - Is the assumption that `git` is installed and in the PATH validated as a prerequisite? [Assumption, Spec §Assumptions]
 - [x] CHK025 - Is the dependency on the `generateRandomName` utility explicitly documented? [Dependency, Research]
-- [x] CHK026 - Is the system prompt guidance for worktree isolation specified? [Safety, Spec §FR-021]
-- [x] CHK027 - Does the prompt guidance include worktree path and original CWD for path translation? [Safety, Spec §FR-022]
+- [x] CHK026 - Is the auto-deny mechanism for main repository modifications during worktree sessions specified? [Safety, Spec §FR-021]
+- [x] CHK027 - Does the auto-deny mechanism allow modifications to the plan file? [Safety, Spec §FR-023]
+- [x] CHK028 - Is the system prompt guidance for worktree isolation specified? [Safety, Spec §FR-024]
+- [x] CHK029 - Does the prompt guidance include worktree path and original CWD for path translation? [Safety, Spec §FR-025]

--- a/specs/068-worktree/spec.md
+++ b/specs/068-worktree/spec.md
@@ -169,22 +169,25 @@ As a developer using Wave, I want to exit a worktree mid-session by asking the A
 - **FR-018**: System MUST trigger a `WorktreeCreate` hook event when a new worktree is created.
 - **FR-019**: The `WorktreeCreate` hook MUST provide a JSON input via stdin containing a `name` field. The hook MUST execute in the newly created worktree directory.
 - **FR-020**: The `WorktreeCreate` hook MUST NOT be triggered when reusing an existing worktree.
-- **FR-021**: System MUST include worktree isolation guidance in the system prompt during a worktree session, warning the agent that it is working in an isolated git worktree and that files outside the worktree should not be modified.
-- **FR-022**: The system prompt guidance MUST include the worktree path, original CWD path, and branch name so the agent can translate absolute paths from prior context.
-- **FR-023**: The `-w` CLI flag MUST register the worktree session state (via `setCurrentWorktreeSession`) so the prompt guidance is included in the system prompt.
-- **FR-024**: System MUST provide an `EnterWorktree` tool that creates a git worktree and switches the session's working directory to it.
-- **FR-025**: The `EnterWorktree` tool MUST accept an optional `name` parameter. If not provided, a random name MUST be generated.
-- **FR-026**: The `EnterWorktree` tool MUST validate the worktree name to prevent path traversal and invalid characters (max 64 chars, only letters, digits, dots, underscores, dashes, and `/` for nesting).
-- **FR-027**: The `EnterWorktree` tool MUST fail if already in an active worktree session (module-level state).
-- **FR-028**: The `EnterWorktree` tool MUST fail if not in a git repository, with an error message suggesting WorktreeCreate/WorktreeRemove hooks.
-- **FR-029**: The `EnterWorktree` tool MUST update the session's working directory via `AIManager.setWorkdir()` (which updates the DI container and calls `process.chdir()`).
-- **FR-030**: System MUST provide an `ExitWorktree` tool that exits a worktree session and restores the original working directory.
-- **FR-031**: The `ExitWorktree` tool MUST accept a required `action` parameter: `"keep"` (preserve worktree) or `"remove"` (delete worktree).
-- **FR-032**: The `ExitWorktree` tool MUST accept an optional `discard_changes` parameter (default `false`). When `action` is `"remove"` and the worktree has uncommitted files or new commits, the tool MUST refuse unless `discard_changes: true`.
-- **FR-033**: The `ExitWorktree` tool MUST be a no-op if no active EnterWorktree session exists (no filesystem changes).
-- **FR-034**: The `ExitWorktree` tool MUST restore the session's working directory to the original CWD via `AIManager.setWorkdir()`.
-- **FR-035**: When `action` is `"remove"`, the system MUST delete the worktree directory using `git worktree remove --force` and the associated branch using `git branch -D`.
-- **FR-036**: The `EnterWorktree` tool MUST NOT trigger the `WorktreeCreate` hook event (hook support is out of scope for mid-session tools).
+- **FR-021**: System MUST automatically deny `Write` and `Edit` tool operations that attempt to modify files in the main repository (outside the current worktree) during a worktree session.
+- **FR-022**: The auto-deny mechanism MUST provide a descriptive error message explaining that modifications to the main repository are restricted while in a worktree session.
+- **FR-023**: The auto-deny mechanism MUST NOT restrict modifications to the current plan file, even if it is located outside the worktree.
+- **FR-024**: System MUST include worktree isolation guidance in the system prompt during a worktree session, warning the agent that it is working in an isolated git worktree and that files outside the worktree should not be modified.
+- **FR-025**: The system prompt guidance MUST include the worktree path, original CWD path, and branch name so the agent can translate absolute paths from prior context.
+- **FR-026**: The `-w` CLI flag MUST register the worktree session state (via `setCurrentWorktreeSession`) so the prompt guidance is included in the system prompt.
+- **FR-027**: System MUST provide an `EnterWorktree` tool that creates a git worktree and switches the session's working directory to it.
+- **FR-028**: The `EnterWorktree` tool MUST accept an optional `name` parameter. If not provided, a random name MUST be generated.
+- **FR-029**: The `EnterWorktree` tool MUST validate the worktree name to prevent path traversal and invalid characters (max 64 chars, only letters, digits, dots, underscores, dashes, and `/` for nesting).
+- **FR-030**: The `EnterWorktree` tool MUST fail if already in an active worktree session (module-level state).
+- **FR-031**: The `EnterWorktree` tool MUST fail if not in a git repository, with an error message suggesting WorktreeCreate/WorktreeRemove hooks.
+- **FR-032**: The `EnterWorktree` tool MUST update the session's working directory via `AIManager.setWorkdir()` (which updates the DI container and calls `process.chdir()`).
+- **FR-033**: System MUST provide an `ExitWorktree` tool that exits a worktree session and restores the original working directory.
+- **FR-034**: The `ExitWorktree` tool MUST accept a required `action` parameter: `"keep"` (preserve worktree) or `"remove"` (delete worktree).
+- **FR-035**: The `ExitWorktree` tool MUST accept an optional `discard_changes` parameter (default `false`). When `action` is `"remove"` and the worktree has uncommitted files or new commits, the tool MUST refuse unless `discard_changes: true`.
+- **FR-036**: The `ExitWorktree` tool MUST be a no-op if no active EnterWorktree session exists (no filesystem changes).
+- **FR-037**: The `ExitWorktree` tool MUST restore the session's working directory to the original CWD via `AIManager.setWorkdir()`.
+- **FR-038**: When `action` is `"remove"`, the system MUST delete the worktree directory using `git worktree remove --force` and the associated branch using `git branch -D`.
+- **FR-039**: The `EnterWorktree` tool MUST NOT trigger the `WorktreeCreate` hook event (hook support is out of scope for mid-session tools).
 
 ### Key Entities
 


### PR DESCRIPTION
Reintroduce hard enforcement that blocks Write and Edit tool operations from modifying files in the main repository during a worktree session. Some models are not smart enough to follow soft prompt guidance alone.

## Changes

- **PermissionManager** checks both container-registered (CLI -w) and module-level (EnterWorktree mid-session) worktree session state
- Auto-denies Write/Edit targeting main repo files outside the worktree
- Exempts the plan file so plan mode continues to work
- **containerSetup.ts** registers WorktreeName/MainRepoRoot for CLI -w sessions
- Restored FR-021/FR-022/FR-023 in spec 068-worktree
- Added 10 test cases covering both CLI and mid-session paths