### PR TITLE
feat: trigger SessionStart hooks on /clear and compact events

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -501,6 +501,40 @@ export class AIManager {
             afterTokens: "1",
             model: this.getModelConfig().fastModel,
           }).catch(() => {});
+
+          // Run SessionStart hooks after compaction to restore context
+          if (this.hookManager) {
+            try {
+              const newSessionId = this.messageManager.getSessionId();
+              const sessionStartResult =
+                await this.hookManager.executeSessionStartHooks(
+                  "compact",
+                  newSessionId,
+                  this.messageManager.getTranscriptPath(),
+                  this.subagentType,
+                );
+
+              // Inject additionalContext as a meta user message
+              if (sessionStartResult.additionalContext) {
+                this.messageManager.addUserMessage({
+                  content: `<system-reminder>\nSessionStart hook additional context: ${sessionStartResult.additionalContext}\n</system-reminder>`,
+                  isMeta: true,
+                });
+              }
+
+              // Inject initialUserMessage as a meta user message
+              if (sessionStartResult.initialUserMessage) {
+                this.messageManager.addUserMessage({
+                  content: sessionStartResult.initialUserMessage,
+                  isMeta: true,
+                });
+              }
+            } catch (error) {
+              logger?.warn(
+                `SessionStart hooks on compact failed: ${(error as Error).message}`,
+              );
+            }
+          }
         } catch (compactError) {
           this.consecutiveCompactionFailures++;
           logger?.error(

--- a/packages/agent-sdk/src/managers/hookManager.ts
+++ b/packages/agent-sdk/src/managers/hookManager.ts
@@ -851,7 +851,7 @@ export class HookManager {
    * Collects additionalContext and initialUserMessage from hook stdout.
    */
   async executeSessionStartHooks(
-    source: "startup" | "resume" | "compact",
+    source: "startup" | "resume" | "compact" | "clear",
     sessionId: string,
     transcriptPath: string,
     agentType?: string,

--- a/packages/agent-sdk/src/managers/hookManager.ts
+++ b/packages/agent-sdk/src/managers/hookManager.ts
@@ -851,7 +851,7 @@ export class HookManager {
    * Collects additionalContext and initialUserMessage from hook stdout.
    */
   async executeSessionStartHooks(
-    source: "startup" | "resume" | "compact" | "clear",
+    source: "startup" | "compact" | "clear",
     sessionId: string,
     transcriptPath: string,
     agentType?: string,

--- a/packages/agent-sdk/src/managers/slashCommandManager.ts
+++ b/packages/agent-sdk/src/managers/slashCommandManager.ts
@@ -24,6 +24,7 @@ import type { SkillManager } from "./skillManager.js";
 import type { SkillMetadata } from "../types/skills.js";
 import type { SubagentManager } from "./subagentManager.js";
 import type { MemoryService } from "../services/memory.js";
+import type { HookManager } from "./hookManager.js";
 
 import { logger } from "../utils/globalLogger.js";
 
@@ -86,6 +87,10 @@ export class SlashCommandManager {
     return this.container.get<MemoryService>("MemoryService")!;
   }
 
+  private get hookManager(): HookManager | undefined {
+    return this.container.get<HookManager>("HookManager");
+  }
+
   private initializeBuiltinCommands(): void {
     // Register built-in clear command
     this.registerCommand({
@@ -94,9 +99,63 @@ export class SlashCommandManager {
       description: "Clear conversation history and reset session",
       handler: async () => {
         this.aiManager.abortAIMessage();
+
+        // Capture old session info before clearing
+        const oldSessionId = this.messageManager.getSessionId();
+        const transcriptPath = this.messageManager.getTranscriptPath();
+
+        // Run SessionEnd hooks (cleanup before clear)
+        if (this.hookManager) {
+          try {
+            await this.hookManager.executeSessionEndHooks(
+              "clear",
+              oldSessionId,
+              transcriptPath,
+            );
+          } catch (error) {
+            logger?.warn(
+              `SessionEnd hooks on clear failed: ${(error as Error).message}`,
+            );
+          }
+        }
+
+        // Clear messages and generate new session
         this.messageManager.clearMessages();
         this.memoryService.clearCache();
         await this.taskManager.syncWithSession();
+
+        // Run SessionStart hooks (restore context for new session)
+        if (this.hookManager) {
+          try {
+            const newSessionId = this.messageManager.getSessionId();
+            const sessionStartResult =
+              await this.hookManager.executeSessionStartHooks(
+                "clear",
+                newSessionId,
+                this.messageManager.getTranscriptPath(),
+              );
+
+            // Inject additionalContext as a meta user message
+            if (sessionStartResult.additionalContext) {
+              this.messageManager.addUserMessage({
+                content: `<system-reminder>\nSessionStart hook additional context: ${sessionStartResult.additionalContext}\n</system-reminder>`,
+                isMeta: true,
+              });
+            }
+
+            // Inject initialUserMessage as a meta user message
+            if (sessionStartResult.initialUserMessage) {
+              this.messageManager.addUserMessage({
+                content: sessionStartResult.initialUserMessage,
+                isMeta: true,
+              });
+            }
+          } catch (error) {
+            logger?.warn(
+              `SessionStart hooks on clear failed: ${(error as Error).message}`,
+            );
+          }
+        }
       },
     });
   }

--- a/packages/agent-sdk/src/types/hooks.ts
+++ b/packages/agent-sdk/src/types/hooks.ts
@@ -98,9 +98,9 @@ export class HookConfigurationError extends Error {
   }
 }
 
-export type SessionStartSource = "startup" | "resume" | "compact";
+export type SessionStartSource = "startup" | "resume" | "compact" | "clear";
 
-export type SessionEndSource = "exit" | "stop" | "compact";
+export type SessionEndSource = "exit" | "stop" | "compact" | "clear";
 
 // Type guards for runtime validation
 export function isValidHookEvent(event: string): event is HookEvent {

--- a/packages/agent-sdk/src/types/hooks.ts
+++ b/packages/agent-sdk/src/types/hooks.ts
@@ -98,7 +98,7 @@ export class HookConfigurationError extends Error {
   }
 }
 
-export type SessionStartSource = "startup" | "resume" | "compact" | "clear";
+export type SessionStartSource = "startup" | "compact" | "clear";
 
 export type SessionEndSource = "exit" | "stop" | "compact" | "clear";
 

--- a/packages/agent-sdk/tests/managers/aiManager.compactSessionStart.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.compactSessionStart.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { HookManager } from "../../src/managers/hookManager.js";
+import { Container } from "../../src/utils/container.js";
+import * as hookService from "../../src/services/hook.js";
+
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/services/hook.js", async () => {
+  const actual = (await vi.importActual(
+    "../../src/services/hook.js",
+  )) as Record<string, unknown>;
+  return {
+    ...actual,
+    executeCommand: vi.fn(),
+    isCommandSafe: vi.fn().mockReturnValue(true),
+  };
+});
+const mockExecuteCommand = vi.mocked(hookService.executeCommand);
+
+describe("HookManager - SessionStart hooks", () => {
+  let manager: HookManager;
+
+  beforeEach(() => {
+    const container = new Container();
+    manager = new HookManager(container, "/test/workdir");
+    mockExecuteCommand.mockResolvedValue({
+      success: true,
+      duration: 100,
+      timedOut: false,
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+    });
+    vi.clearAllMocks();
+  });
+
+  describe("executeSessionStartHooks", () => {
+    it("should execute hooks with 'compact' source", async () => {
+      manager.loadConfiguration({
+        SessionStart: [
+          {
+            hooks: [{ type: "command" as const, command: "echo compact-hook" }],
+          },
+        ],
+      });
+
+      const result = await manager.executeSessionStartHooks(
+        "compact",
+        "test-session-id",
+        "/test/transcript.md",
+        "general-purpose",
+      );
+
+      expect(mockExecuteCommand).toHaveBeenCalledWith(
+        expect.stringContaining("echo compact-hook"),
+        expect.objectContaining({
+          event: "SessionStart",
+          source: "compact",
+          agentType: "general-purpose",
+        }),
+        undefined,
+      );
+      expect(result.results).toHaveLength(1);
+    });
+
+    it("should execute hooks with 'clear' source", async () => {
+      manager.loadConfiguration({
+        SessionStart: [
+          { hooks: [{ type: "command" as const, command: "echo clear-hook" }] },
+        ],
+      });
+
+      const result = await manager.executeSessionStartHooks(
+        "clear",
+        "new-session-id",
+        "/test/transcript.md",
+      );
+
+      expect(mockExecuteCommand).toHaveBeenCalledWith(
+        expect.stringContaining("echo clear-hook"),
+        expect.objectContaining({
+          event: "SessionStart",
+          source: "clear",
+        }),
+        undefined,
+      );
+      expect(result.results).toHaveLength(1);
+    });
+
+    it("should parse additionalContext from JSON stdout", async () => {
+      mockExecuteCommand.mockResolvedValue({
+        success: true,
+        duration: 100,
+        timedOut: false,
+        exitCode: 0,
+        stdout: JSON.stringify({
+          hookSpecificOutput: { additionalContext: "Project context" },
+        }),
+        stderr: "",
+      });
+
+      manager.loadConfiguration({
+        SessionStart: [
+          { hooks: [{ type: "command" as const, command: "echo context" }] },
+        ],
+      });
+
+      const result = await manager.executeSessionStartHooks(
+        "compact",
+        "session-id",
+        "/test/transcript.md",
+      );
+
+      expect(result.additionalContext).toBe("Project context");
+    });
+
+    it("should parse initialUserMessage from JSON stdout", async () => {
+      mockExecuteCommand.mockResolvedValue({
+        success: true,
+        duration: 100,
+        timedOut: false,
+        exitCode: 0,
+        stdout: JSON.stringify({ initialUserMessage: "Hello from hook" }),
+        stderr: "",
+      });
+
+      manager.loadConfiguration({
+        SessionStart: [
+          { hooks: [{ type: "command" as const, command: "echo greeting" }] },
+        ],
+      });
+
+      const result = await manager.executeSessionStartHooks(
+        "clear",
+        "session-id",
+        "/test/transcript.md",
+      );
+
+      expect(result.initialUserMessage).toBe("Hello from hook");
+    });
+
+    it("should treat non-JSON stdout as additionalContext", async () => {
+      mockExecuteCommand.mockResolvedValue({
+        success: true,
+        duration: 100,
+        timedOut: false,
+        exitCode: 0,
+        stdout: "Plain text context",
+        stderr: "",
+      });
+
+      manager.loadConfiguration({
+        SessionStart: [
+          { hooks: [{ type: "command" as const, command: "echo context" }] },
+        ],
+      });
+
+      const result = await manager.executeSessionStartHooks(
+        "startup",
+        "session-id",
+        "/test/transcript.md",
+      );
+
+      expect(result.additionalContext).toBe("Plain text context");
+    });
+  });
+});

--- a/packages/agent-sdk/tests/managers/hookManager.coverage.test.ts
+++ b/packages/agent-sdk/tests/managers/hookManager.coverage.test.ts
@@ -720,7 +720,7 @@ describe("HookManager Coverage", () => {
         ],
       });
       const result = await manager.executeSessionStartHooks(
-        "resume",
+        "startup",
         "session-123",
         "/path/to/transcript.json",
         "planner",

--- a/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
+++ b/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
@@ -14,6 +14,7 @@ import type { SubagentManager } from "../../src/managers/subagentManager.js";
 import type { SkillManager } from "../../src/managers/skillManager.js";
 import type { TextBlock } from "../../src/types/index.js";
 import type { MemoryService } from "../../src/services/memory.js";
+import type { HookManager } from "../../src/managers/hookManager.js";
 
 // Mock child_process for bash command execution tests
 const mockExec = vi.hoisted(() => vi.fn());
@@ -171,6 +172,111 @@ describe("SlashCommandManager", () => {
       const result = await slashCommandManager.executeCommand("clear");
       expect(result).toBe(true);
       expect(clearCacheSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("Clear Command Session Hooks", () => {
+    let mockHookManager: HookManager;
+
+    beforeEach(() => {
+      const container = (
+        slashCommandManager as unknown as { container: Container }
+      ).container;
+
+      mockHookManager = {
+        executeSessionEndHooks: vi.fn().mockResolvedValue([]),
+        executeSessionStartHooks: vi.fn().mockResolvedValue({
+          results: [],
+          additionalContext: undefined,
+          initialUserMessage: undefined,
+        }),
+      } as unknown as HookManager;
+
+      container.register("HookManager", mockHookManager);
+    });
+
+    it("should call SessionEnd hooks before clearing messages", async () => {
+      const oldSessionId = messageManager.getSessionId();
+
+      await slashCommandManager.executeCommand("clear");
+
+      expect(mockHookManager.executeSessionEndHooks).toHaveBeenCalledWith(
+        "clear",
+        oldSessionId,
+        expect.any(String),
+      );
+    });
+
+    it("should call SessionStart hooks after clearing messages", async () => {
+      await slashCommandManager.executeCommand("clear");
+
+      expect(mockHookManager.executeSessionStartHooks).toHaveBeenCalledWith(
+        "clear",
+        expect.any(String),
+        expect.any(String),
+      );
+    });
+
+    it("should inject additionalContext as meta user message", async () => {
+      vi.mocked(mockHookManager.executeSessionStartHooks).mockResolvedValue({
+        results: [],
+        additionalContext: "Project context from hook",
+        initialUserMessage: undefined,
+      });
+
+      await slashCommandManager.executeCommand("clear");
+
+      const messages = messageManager.getMessages();
+      const contextMessage = messages.find(
+        (m) =>
+          m.blocks[0]?.type === "text" &&
+          (
+            m.blocks[0] as import("../../src/types/index.js").TextBlock
+          ).content?.includes("SessionStart hook additional context"),
+      );
+      expect(contextMessage).toBeDefined();
+      expect(contextMessage?.isMeta).toBe(true);
+    });
+
+    it("should inject initialUserMessage as meta user message", async () => {
+      vi.mocked(mockHookManager.executeSessionStartHooks).mockResolvedValue({
+        results: [],
+        additionalContext: undefined,
+        initialUserMessage: "Hello from hook",
+      });
+
+      await slashCommandManager.executeCommand("clear");
+
+      const messages = messageManager.getMessages();
+      const hookMessage = messages.find(
+        (m) =>
+          m.blocks[0]?.type === "text" &&
+          (m.blocks[0] as import("../../src/types/index.js").TextBlock)
+            .content === "Hello from hook",
+      );
+      expect(hookMessage).toBeDefined();
+      expect(hookMessage?.isMeta).toBe(true);
+    });
+
+    it("should continue gracefully if SessionEnd hooks fail", async () => {
+      vi.mocked(mockHookManager.executeSessionEndHooks).mockRejectedValue(
+        new Error("SessionEnd hook failed"),
+      );
+
+      const result = await slashCommandManager.executeCommand("clear");
+
+      expect(result).toBe(true);
+      expect(mockHookManager.executeSessionStartHooks).toHaveBeenCalled();
+    });
+
+    it("should continue gracefully if SessionStart hooks fail", async () => {
+      vi.mocked(mockHookManager.executeSessionStartHooks).mockRejectedValue(
+        new Error("SessionStart hook failed"),
+      );
+
+      const result = await slashCommandManager.executeCommand("clear");
+
+      expect(result).toBe(true);
     });
   });
 


### PR DESCRIPTION
Aligns Wave's SessionStart hook behavior with Claude Code.

## Changes

- **SessionStart hooks now fire on `/clear`**: Runs SessionEnd hooks before clearing, then SessionStart hooks after clearing to restore context (e.g., CLAUDE.md/watch paths).
- **SessionStart hooks now fire on compaction**: After context compaction, SessionStart hooks run with source `compact` to restore context files.
- Added `clear` to `SessionEndSource` and `SessionStartSource` types.
- Removed unused `resume` source from `SessionStartSource` to match actual Claude Code behavior (exists in type signature but never called).

## Commits

- 1c6e9be3 feat: trigger SessionStart hooks on /clear and compact events
- 2f03d352 feat: trigger SessionStart hooks on /clear and compact events