### PR TITLE
feat: show descriptions in <available-deferred-tools>

### DIFF
--- a/packages/agent-sdk/src/prompts/index.ts
+++ b/packages/agent-sdk/src/prompts/index.ts
@@ -260,11 +260,15 @@ export function buildSystemPrompt(
     prompt += `\n\n${TOOL_POLICY}`;
   }
 
-  // List available deferred tool names so the model knows they exist
-  // Matching Claude Code: deferred tools appear by name, not loaded until fetched.
-  const deferredToolNames = tools.filter(isDeferredTool).map((t) => t.name);
-  if (deferredToolNames.length > 0) {
-    prompt += `\n\n<available-deferred-tools>${deferredToolNames.join(" ")}\nThese tools are NOT loaded yet — call ${TOOL_SEARCH_TOOL_NAME} first to discover their schemas before invoking them.</available-deferred-tools>`;
+  // List available deferred tool names with descriptions so the model knows they exist
+  // and can decide which ones to discover via ToolSearch
+  const deferredTools = tools.filter(isDeferredTool);
+  if (deferredTools.length > 0) {
+    const lines = deferredTools.map((t) => {
+      const desc = t.config.function?.description;
+      return desc ? `${t.name} - ${desc}` : t.name;
+    });
+    prompt += `\n\n<available-deferred-tools>\n${lines.join("\n")}\nThese tools are NOT loaded yet — call ${TOOL_SEARCH_TOOL_NAME} first to discover their schemas before invoking them.</available-deferred-tools>`;
   }
 
   prompt += `\n\n${OUTPUT_EFFICIENCY_PROMPT}`;

--- a/packages/agent-sdk/src/tools/toolSearchTool.ts
+++ b/packages/agent-sdk/src/tools/toolSearchTool.ts
@@ -127,7 +127,7 @@ export const toolSearchTool: ToolPlugin = {
       name: TOOL_SEARCH_TOOL_NAME,
       description: `Fetches full schema definitions for deferred tools so they can be called.
 
-Deferred tools appear by name in <available-deferred-tools> messages. Until fetched, only the name is known — there is no parameter schema, so the tool cannot be invoked. This tool takes a query, matches it against the deferred tool list, and returns the matched tools' complete JSONSchema definitions inside a <functions> block. Once a tool's schema appears in that result, it is callable exactly like any tool defined at the top of the prompt.
+Deferred tools appear by name and description in <available-deferred-tools> messages. The full parameter schema is NOT loaded yet — use this tool to fetch it before invoking a deferred tool. This tool takes a query, matches it against the deferred tool list, and returns the matched tools' complete JSONSchema definitions inside a <functions> block. Once a tool's schema appears in that result, it is callable exactly like any tool defined at the top of the prompt.
 
 Result format: each matched tool appears as one <function>{"description": "...", "name": "...", "parameters": {...}}`,
       parameters: {


### PR DESCRIPTION
Include tool descriptions alongside names in the deferred tools list so the model can decide which tools to discover without a ToolSearch round-trip.

## Changes
- `prompts/index.ts`: Format deferred tools as `Name - Description` (one per line) instead of space-separated names
- `toolSearchTool.ts`: Update prompt description to reflect that descriptions are now visible upfront