### PR TITLE
feat(sso): OAuth 2.0 authorization code exchange flow

### DIFF
--- a/packages/agent-sdk/src/services/authService.ts
+++ b/packages/agent-sdk/src/services/authService.ts
@@ -92,7 +92,7 @@ export class AuthService {
   async login(options?: {
     /** Callback to receive the auth URL (for display in CLI). */
     onAuthUrl?: (url: string) => void;
-    /** Read token manually (e.g. from stdin). Resolves with token or rejects on cancel. */
+    /** Read authorization code manually (e.g. from stdin). Resolves with code or rejects on cancel. */
     readToken?: () => Promise<string>;
   }): Promise<string> {
     const adminUrl = this.getAdminBaseUrl();
@@ -114,16 +114,42 @@ export class AuthService {
     const provider = providers[0].provider;
 
     // Step 2-5: Start local server, open browser, wait for callback or manual input
-    const token = await this.startLocalAuthServer(adminUrl, provider, {
+    const code = await this.startLocalAuthServer(adminUrl, provider, {
       onAuthUrl: options?.onAuthUrl,
       readToken: options?.readToken,
     });
+
+    // Exchange authorization code for JWT
+    const token = await this.exchangeCode(adminUrl, code);
 
     // Save the token (preserve existing keys)
     const existing = this.loadAuth();
     this.saveAuth({ ...existing, SSO_TOKEN: token });
 
     return token;
+  }
+
+  /**
+   * Exchange a short-lived authorization code for a JWT token.
+   */
+  private async exchangeCode(adminUrl: string, code: string): Promise<string> {
+    const exchangeUrl = `${adminUrl}/api/auth/exchange`;
+    const response = await fetch(exchangeUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Token exchange failed (${response.status}): ${text}`);
+    }
+
+    const data = (await response.json()) as {
+      token: string;
+      user: { username: string };
+    };
+    return data.token;
   }
 
   private startLocalAuthServer(
@@ -139,17 +165,37 @@ export class AuthService {
       const server: Server = createServer((req, res) => {
         if (req.url) {
           const parsedUrl = new URL(req.url, `http://127.0.0.1`);
-          const token = parsedUrl.searchParams.get("token");
+          const code = parsedUrl.searchParams.get("code");
+          const error = parsedUrl.searchParams.get("error");
+
+          if (error) {
+            res.writeHead(200, { "Content-Type": "text/html" });
+            res.end(
+              `<html><body><h1>Authentication failed</h1><p>${parsedUrl.searchParams.get("error_description") || error}</p></body></html>`,
+            );
+            if (!settled) {
+              settled = true;
+              server.close();
+              reject(new Error(`SSO login failed: ${error}`));
+            }
+            return;
+          }
+
+          if (!code) {
+            res.writeHead(404, { "Content-Type": "text/html" });
+            res.end("<html><body><h1>Not Found</h1></body></html>");
+            return;
+          }
 
           res.writeHead(200, { "Content-Type": "text/html" });
           res.end(
             "<html><body><h1>Authentication successful, you can close this window</h1></body></html>",
           );
 
-          if (token && !settled) {
+          if (!settled) {
             settled = true;
             server.close();
-            resolve(token);
+            resolve(code);
           }
         }
       });
@@ -177,14 +223,14 @@ export class AuthService {
         }
       });
 
-      // If manual token reading is provided, race between server callback and user input
+      // If manual code reading is provided, race between server callback and user input
       if (options?.readToken) {
         options.readToken().then(
-          (token) => {
+          (code) => {
             if (!settled) {
               settled = true;
               server.close();
-              resolve(token);
+              resolve(code);
             }
           },
           () => {

--- a/packages/agent-sdk/tests/services/authService.test.ts
+++ b/packages/agent-sdk/tests/services/authService.test.ts
@@ -23,11 +23,11 @@ interface MockResponse {
 
 const httpMockState: {
   fireCallback: boolean;
-  token: string;
+  code: string;
   handlers: Array<(req: { url: string }, res: MockResponse) => void>;
 } = {
   fireCallback: true,
-  token: "fake-jwt-token",
+  code: "fake-auth-code",
   handlers: [],
 };
 
@@ -42,7 +42,7 @@ vi.mock("http", () => ({
             setTimeout(
               () =>
                 handler(
-                  { url: `/?token=${httpMockState.token}` },
+                  { url: `/?code=${httpMockState.code}` },
                   { writeHead: () => {}, end: () => {} },
                 ),
               10,
@@ -92,7 +92,7 @@ describe("AuthService", () => {
     resetServiceInstance();
     delete process.env.WAVE_ADMIN_URL;
     httpMockState.fireCallback = true;
-    httpMockState.token = "fake-jwt-token";
+    httpMockState.code = "fake-auth-code";
     httpMockState.handlers = [];
   });
 
@@ -245,27 +245,45 @@ describe("AuthService", () => {
     beforeEach(() => {
       vi.stubGlobal("fetch", mockFetch);
       httpMockState.fireCallback = true;
-      httpMockState.token = "callback-jwt";
+      httpMockState.code = "callback-auth-code";
     });
 
     afterEach(() => {
       vi.unstubAllGlobals();
     });
 
-    it("fetches providers, opens browser, receives callback token, and saves it", async () => {
+    it("fetches providers, opens browser, receives callback code, exchanges for JWT, and saves it", async () => {
       process.env.WAVE_ADMIN_URL = "https://admin.example.com";
       mockedExists.mockReturnValue(false);
+      // 1st: fetch providers
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => [{ provider: "netease", displayName: "NetEase SSO" }],
+      });
+      // 2nd: exchange code for JWT
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token: "exchanged-jwt",
+          user: { username: "user" },
+        }),
       });
 
       const service = AuthService.getInstance();
       const onAuthUrl = vi.fn();
       const token = await service.login({ onAuthUrl });
 
-      expect(token).toBe("callback-jwt");
+      expect(token).toBe("exchanged-jwt");
       expect(onAuthUrl).toHaveBeenCalled();
+      // Verify exchange endpoint was called with the code
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://admin.example.com/api/auth/exchange",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ code: "callback-auth-code" }),
+        },
+      );
       expect(mockedWriteFile).toHaveBeenCalled();
       expect(mockedChmod).toHaveBeenCalled();
     });
@@ -294,6 +312,25 @@ describe("AuthService", () => {
       );
     });
 
+    it("throws when code exchange fails", async () => {
+      process.env.WAVE_ADMIN_URL = "https://admin.example.com";
+      mockedExists.mockReturnValue(false);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ provider: "netease", displayName: "NetEase SSO" }],
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: async () => "Invalid or expired code",
+      });
+
+      const service = AuthService.getInstance();
+      await expect(service.login()).rejects.toThrow(
+        "Token exchange failed (400): Invalid or expired code",
+      );
+    });
+
     it("preserves existing keys when saving token", async () => {
       process.env.WAVE_ADMIN_URL = "https://admin.example.com";
       mockedExists.mockReturnValue(true);
@@ -303,6 +340,10 @@ describe("AuthService", () => {
         json: async () => [
           { provider: "provider1", displayName: "Provider 1" },
         ],
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ token: "jwt-token", user: { username: "user" } }),
       });
 
       const service = AuthService.getInstance();
@@ -315,7 +356,7 @@ describe("AuthService", () => {
     });
   });
 
-  describe("login with manual token input", () => {
+  describe("login with manual code input", () => {
     const mockFetch = vi.fn();
 
     beforeEach(() => {
@@ -327,34 +368,60 @@ describe("AuthService", () => {
       vi.unstubAllGlobals();
     });
 
-    it("accepts manually provided token via readToken", async () => {
+    it("accepts manually provided code via readToken and exchanges for JWT", async () => {
       process.env.WAVE_ADMIN_URL = "https://admin.example.com";
       mockedExists.mockReturnValue(false);
+      // 1st: fetch providers
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => [{ provider: "netease", displayName: "NetEase SSO" }],
+      });
+      // 2nd: exchange code for JWT
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token: "manual-exchanged-jwt",
+          user: { username: "user" },
+        }),
       });
 
       const service = AuthService.getInstance();
       const token = await service.login({
         readToken: async () => {
           await new Promise((r) => setTimeout(r, 10));
-          return "manual-token-123";
+          return "manual-code-123";
         },
       });
 
-      expect(token).toBe("manual-token-123");
+      expect(token).toBe("manual-exchanged-jwt");
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://admin.example.com/api/auth/exchange",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ code: "manual-code-123" }),
+        },
+      );
     });
 
     it("continues waiting for callback when readToken is cancelled", async () => {
       httpMockState.fireCallback = true;
-      httpMockState.token = "callback-wins";
+      httpMockState.code = "callback-wins-code";
 
       process.env.WAVE_ADMIN_URL = "https://admin.example.com";
       mockedExists.mockReturnValue(false);
+      // 1st: fetch providers
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => [{ provider: "netease", displayName: "NetEase SSO" }],
+      });
+      // 2nd: exchange code for JWT
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token: "callback-wins-jwt",
+          user: { username: "user" },
+        }),
       });
 
       const service = AuthService.getInstance();
@@ -365,7 +432,7 @@ describe("AuthService", () => {
         },
       });
 
-      expect(token).toBe("callback-wins");
+      expect(token).toBe("callback-wins-jwt");
     });
   });
 
@@ -406,13 +473,17 @@ describe("AuthService", () => {
 
     it("can be cancelled before timeout", async () => {
       httpMockState.fireCallback = true;
-      httpMockState.token = "early-token";
+      httpMockState.code = "early-code";
 
       process.env.WAVE_ADMIN_URL = "https://admin.example.com";
       mockedExists.mockReturnValue(false);
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => [{ provider: "netease", displayName: "NetEase SSO" }],
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ token: "early-jwt", user: { username: "user" } }),
       });
 
       const service = AuthService.getInstance();
@@ -422,7 +493,7 @@ describe("AuthService", () => {
       await vi.advanceTimersByTimeAsync(50);
 
       const token = await loginPromise;
-      expect(token).toBe("early-token");
+      expect(token).toBe("early-jwt");
     });
   });
 

--- a/packages/code/src/components/LoginCommand.tsx
+++ b/packages/code/src/components/LoginCommand.tsx
@@ -91,7 +91,7 @@ export const LoginCommand: React.FC<LoginCommandProps> = ({ onCancel }) => {
       await authService.login({
         onAuthUrl: (url: string) => {
           setAuthUrl(url);
-          setMessage("Paste the token from your browser URL bar:");
+          setMessage("Paste the authorization code from your browser URL bar:");
         },
         readToken,
       });
@@ -155,10 +155,10 @@ export const LoginCommand: React.FC<LoginCommandProps> = ({ onCancel }) => {
         </Box>
       )}
 
-      {/* Token input field */}
+      {/* Authorization code input field */}
       {isLoading && (
         <Box marginBottom={1}>
-          <Text color="cyan">Token: </Text>
+          <Text color="cyan">Code: </Text>
           <Text color="white">{tokenInput || "..."}</Text>
         </Box>
       )}

--- a/packages/code/tests/components/LoginCommand.test.tsx
+++ b/packages/code/tests/components/LoginCommand.test.tsx
@@ -106,16 +106,16 @@ describe("LoginCommand", () => {
     // onAuthUrl replaces the initial message
     await vi.waitFor(() =>
       expect(lastFrame()).toContain(
-        "Paste the token from your browser URL bar:",
+        "Paste the authorization code from your browser URL bar:",
       ),
     );
     await vi.waitFor(() =>
       expect(lastFrame()).toContain("Open this URL in your browser:"),
     );
-    await vi.waitFor(() => expect(lastFrame()).toContain("Token:"));
+    await vi.waitFor(() => expect(lastFrame()).toContain("Code:"));
   });
 
-  it("should show token input field when loading", async () => {
+  it("should show code input field when loading", async () => {
     let resolveLogin: (value: string) => void;
     mockAuthService.login.mockImplementation(
       () =>
@@ -128,13 +128,13 @@ describe("LoginCommand", () => {
 
     stdin.write("\r");
 
-    await vi.waitFor(() => expect(lastFrame()).toContain("Token:"));
+    await vi.waitFor(() => expect(lastFrame()).toContain("Code:"));
     await vi.waitFor(() => expect(lastFrame()).toContain("..."));
 
     resolveLogin!("done");
   });
 
-  it("should accumulate token input characters", async () => {
+  it("should accumulate code input characters", async () => {
     mockAuthService.login.mockImplementation(
       ({ readToken }: { readToken: () => Promise<string> }) =>
         new Promise<string>((resolve) => {
@@ -146,22 +146,22 @@ describe("LoginCommand", () => {
 
     stdin.write("\r");
 
-    await vi.waitFor(() => expect(lastFrame()).toContain("Token:"));
+    await vi.waitFor(() => expect(lastFrame()).toContain("Code:"));
 
-    // Type some token characters
+    // Type some code characters
     stdin.write("abc");
     await vi.waitFor(() => expect(lastFrame()).toContain("abc"));
 
     stdin.write("def");
     await vi.waitFor(() => expect(lastFrame()).toContain("abcdef"));
 
-    // Submit token
+    // Submit code
     stdin.write("\r");
 
     await vi.waitFor(() => expect(mockAuthService.login).toHaveBeenCalled());
   });
 
-  it("should handle backspace in token input", async () => {
+  it("should handle backspace in code input", async () => {
     mockAuthService.login.mockImplementation(
       ({ readToken }: { readToken: () => Promise<string> }) =>
         new Promise<string>((resolve) => {
@@ -172,7 +172,7 @@ describe("LoginCommand", () => {
     const { stdin, lastFrame } = render(<LoginCommand onCancel={vi.fn()} />);
 
     stdin.write("\r");
-    await vi.waitFor(() => expect(lastFrame()).toContain("Token:"));
+    await vi.waitFor(() => expect(lastFrame()).toContain("Code:"));
 
     stdin.write("abcd");
     await vi.waitFor(() => expect(lastFrame()).toContain("abcd"));
@@ -181,7 +181,7 @@ describe("LoginCommand", () => {
     stdin.write("\u007f");
     await vi.waitFor(() => expect(lastFrame()).toContain("abc"));
 
-    // Submit empty token clears input
+    // Submit empty code clears input
     stdin.write("\r");
     await vi.waitFor(() => expect(lastFrame()).toContain("..."));
 
@@ -202,7 +202,7 @@ describe("LoginCommand", () => {
     const { stdin, lastFrame } = render(<LoginCommand onCancel={onCancel} />);
 
     stdin.write("\r");
-    await vi.waitFor(() => expect(lastFrame()).toContain("Token:"));
+    await vi.waitFor(() => expect(lastFrame()).toContain("Code:"));
 
     stdin.write("\u001b");
     await vi.waitFor(() => expect(onCancel).toHaveBeenCalled());

--- a/specs/076-sso-auth/checklists/requirements.md
+++ b/specs/076-sso-auth/checklists/requirements.md
@@ -4,9 +4,10 @@
 
 - [x] **FR-001**: `/login` and `/logout` slash commands available in CLI
 - [x] **FR-002**: Local HTTP server on `127.0.0.1` with random port for SSO callbacks
+- [x] **FR-002a**: Extracts `code` from callback URL and exchanges via `POST /api/auth/exchange`
 - [x] **FR-003**: Fetches SSO providers from `WAVE_ADMIN_URL/api/auth/sso-providers`
 - [x] **FR-004**: Opens SSO login URL in default browser (`open`/`xdg-open`/`start`)
-- [x] **FR-005**: Accepts manual token input via Ink `useInput` for remote servers
+- [x] **FR-005**: Accepts manual authorization code input via Ink `useInput` for remote servers, exchanges for JWT
 - [x] **FR-006**: Saves SSO token to `~/.wave/auth.json` with `0o600` permissions
 - [x] **FR-007**: Merges existing config on save (preserves non-SSO_TOKEN fields)
 - [x] **FR-008**: SSO mode prioritized over direct LLM mode in gateway config resolution

--- a/specs/076-sso-auth/contracts/auth.md
+++ b/specs/076-sso-auth/contracts/auth.md
@@ -67,11 +67,30 @@ interface GatewayConfig {
 
 ### GET /api/auth/sso/{provider}?callback_url={url}
 
-**Behavior**: Redirects user to SSO IdP login page. After successful authentication, redirects to `callback_url?token={jwt}`.
+**Behavior**: Redirects user to SSO IdP login page. After successful authentication, redirects to `callback_url?code={authorization_code}`.
+
+### POST /api/auth/exchange
+
+**Request**:
+```json
+{
+  "code": "short_authorization_code"
+}
+```
+
+**Response** (200):
+```json
+{
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "user": {
+    "username": "user@example.com"
+  }
+}
+```
 
 ### Callback URL Response
 
-**Expected**: `GET http://127.0.0.1:{port}?token={jwt}`
+**Expected**: `GET http://127.0.0.1:{port}?code={code}`
 
 **Server responds with**: 200 HTML page "Authentication successful, you can close this window"
 

--- a/specs/076-sso-auth/data-model.md
+++ b/specs/076-sso-auth/data-model.md
@@ -40,7 +40,7 @@ When `SSO_TOKEN` is present, `resolveGatewayConfig()` returns:
 | Idle (not authenticated) | `!isSSOAuthenticated()` | "Not logged in", "Press Enter to login" |
 | Idle (authenticated) | `isSSOAuthenticated()` && `!isLoading` | Truncated token, admin URL, "Press Enter to logout" |
 | Loading | `isLoading` && `!message` | "Starting authentication..." |
-| Auth URL shown | `isLoading` && `authUrl` | Auth URL + "Paste the token from your browser URL bar:" + token input field |
+| Auth URL shown | `isLoading` && `authUrl` | Auth URL + "Paste the authorization code from your browser URL bar:" + code input field |
 | Success | `!isLoading` && `message === "Login successful"` | "Login successful" |
 | Error | `!isLoading` && `error` | Error message in red |
 

--- a/specs/076-sso-auth/plan.md
+++ b/specs/076-sso-auth/plan.md
@@ -4,7 +4,7 @@
 
 ## Summary
 
-Add `/login` and `/logout` slash commands for SSO authentication via wave-admin. AuthService handles browser-based SSO flow with localhost callback, falls back to manual token input for remote servers. Gateway configuration prioritizes SSO mode when `~/.wave/auth.json` contains `SSO_TOKEN`, routing all LLM API requests through wave-admin's `/api/v1` proxy.
+Add `/login` and `/logout` slash commands for SSO authentication via wave-admin. AuthService handles browser-based SSO flow with localhost callback (receives authorization code, exchanges for JWT via `POST /api/auth/exchange`), falls back to manual code input for remote servers. Gateway configuration prioritizes SSO mode when `~/.wave/auth.json` contains `SSO_TOKEN`, routing all LLM API requests through wave-admin's `/api/v1` proxy.
 
 ## Technical Context
 
@@ -34,8 +34,8 @@ User types /login → inputReducer → EXECUTE_COMMAND (local)
   → useInputManager → dispatch SET_SHOW_LOGIN_COMMAND
   → InputBox renders <LoginCommand>
     → User presses Enter → AuthService.login()
-    → Browser opens → SSO flow → token saved → UI updates
-    → Remote server fallback: user pastes token from browser URL bar
+    → Browser opens → SSO flow → callback receives code → POST /api/auth/exchange → JWT saved → UI updates
+    → Remote server fallback: user pastes authorization code from browser URL bar → POST /api/auth/exchange → JWT saved
 ```
 
 ## Files Modified

--- a/specs/076-sso-auth/quickstart.md
+++ b/specs/076-sso-auth/quickstart.md
@@ -25,7 +25,7 @@
 
 4. **Browser opens** → Complete SSO login on wave-admin
 
-5. **Browser redirects** to `http://127.0.0.1:{port}?token=...` → Wave receives token automatically
+5. **Browser redirects** to `http://127.0.0.1:{port}?code=...` → Wave exchanges code for JWT automatically
 
 6. **Verify**:
    ```
@@ -60,11 +60,11 @@
 
 5. **Complete SSO login** on wave-admin
 
-6. **Browser redirects** to `http://127.0.0.1:{port}?token=eyJ...` — the page shows "Connection refused" but **the token is visible in the URL bar**
+6. **Browser redirects** to `http://127.0.0.1:{port}?code=abc123` — the page shows "Connection refused" but **the authorization code is visible in the URL bar**
 
-7. **Copy the token** from the URL bar (the `token=` parameter value)
+7. **Copy the authorization code** from the URL bar (the `code=` parameter value)
 
-8. **Paste the token** into the terminal where Wave is running → Press Enter
+8. **Paste the code** into the terminal where Wave is running → Press Enter → Wave exchanges it for a JWT
 
 9. **Verify**:
    ```
@@ -89,7 +89,7 @@ SSO_company_sso_CLIENT_SECRET=xxx
 ```
 
 ### Token expired after 8 hours
-wave-admin JWT defaults to 8-hour expiry. Re-run `/login` to get a fresh token.
+wave-admin JWT defaults to 8-hour expiry. Re-run `/login` to get a fresh authorization code and exchange for a new token.
 
 ### "Connection refused" on browser redirect
-Expected on remote servers. Copy the token from the browser URL bar and paste into the terminal.
+Expected on remote servers. Copy the authorization code from the browser URL bar and paste into the terminal.

--- a/specs/076-sso-auth/research.md
+++ b/specs/076-sso-auth/research.md
@@ -37,7 +37,7 @@
 
 ## Decision: Wave-Admin as SSO Mediator
 
-**Rationale**: wave-agent CLI does not connect directly to the company SSO IdP. Instead, wave-admin handles the OIDC/OAuth flow and redirects back to the CLI with a JWT. This keeps the CLI simple and centralized authentication in wave-admin.
+**Rationale**: wave-agent CLI does not connect directly to the company SSO IdP. Instead, wave-admin handles the OIDC/OAuth flow and redirects back to the CLI with a short-lived authorization code. The CLI then exchanges this code for a JWT via `POST /api/auth/exchange`. This two-step flow follows the standard OAuth 2.0 authorization code pattern, keeping the JWT out of the URL bar (only a short-lived code is exposed).
 
 ## Decision: SSO Token Priority Over Direct LLM Config
 

--- a/specs/076-sso-auth/spec.md
+++ b/specs/076-sso-auth/spec.md
@@ -17,7 +17,7 @@ As a developer working on a local machine, I want to type `/login` in Wave to au
 **Acceptance Scenarios**:
 
 1. **Given** `WAVE_ADMIN_URL` is set and no existing SSO token, **When** the user types `/login`, **Then** Wave opens a browser to the SSO login page and displays the auth URL in the terminal.
-2. **Given** the user completes SSO login in their browser, **When** the browser redirects to the localhost callback URL, **Then** Wave receives the token, saves it to `~/.wave/auth.json`, and displays "Login successful".
+2. **Given** the user completes SSO login in their browser, **When** the browser redirects to the localhost callback URL with `?code={code}`, **Then** Wave exchanges the code for a JWT via `POST /api/auth/exchange`, saves the token to `~/.wave/auth.json`, and displays "Login successful".
 3. **Given** the user is authenticated via SSO, **When** the user sends a message, **Then** all LLM API requests are sent to `WAVE_ADMIN_URL/api/v1` with the SSO token as Bearer auth.
 4. **Given** the user is already authenticated via SSO, **When** the user types `/login`, **Then** Wave shows current auth status (truncated token, admin URL) and offers to logout on Enter.
 5. **Given** the user is authenticated and presses Enter while in the login UI, **When** they confirm logout, **Then** the SSO token is removed from `~/.wave/auth.json` and Wave displays "Logged out successfully".
@@ -34,8 +34,8 @@ As a developer working on a remote server via SSH, I want to manually paste the 
 
 **Acceptance Scenarios**:
 
-1. **Given** Wave is running on a remote server, **When** the user types `/login`, **Then** Wave displays the SSO auth URL and prompts "Paste the token from your browser URL bar:".
-2. **Given** the user pastes a valid JWT token and presses Enter, **Then** Wave saves the token to `~/.wave/auth.json` and displays "Login successful".
+1. **Given** Wave is running on a remote server, **When** the user types `/login`, **Then** Wave displays the SSO auth URL and prompts "Paste the authorization code from your browser URL bar:".
+2. **Given** the user pastes a valid authorization code and presses Enter, **Then** Wave exchanges the code for a JWT via `POST /api/auth/exchange`, saves the token to `~/.wave/auth.json`, and displays "Login successful".
 3. **Given** the user pastes an empty line, **Then** Wave clears the input and keeps waiting for token input.
 4. **Given** the user presses Escape during token input, **Then** the login flow is cancelled and Wave returns to the idle state.
 
@@ -62,7 +62,7 @@ As a developer who has authenticated via SSO, I want all LLM API requests to aut
 - **What happens if the SSO callback server port is already in use?** The server uses `localhost:0` (system-assigned random port), avoiding port collision.
 - **What happens if no SSO providers are configured on wave-admin?** The login fails with a clear error message ("No SSO providers available").
 - **What happens if `WAVE_ADMIN_URL` is not set during login?** The login fails with a clear error instructing the user to set the environment variable.
-- **What happens if the browser cannot be opened (headless server)?** The auth server stays alive, and the user can manually open the URL and paste the token.
+- **What happens if the browser cannot be opened (headless server)?** The auth server stays alive, and the user can manually open the URL and paste the authorization code.
 - **What happens if the user saves additional fields in `auth.json` in the future?** The `saveAuth` method merges with existing config, preserving non-SSO_TOKEN fields.
 - **What happens if the token expires (JWT default 8h)?** The API call returns 401; the user must re-run `/login`. Token refresh is out of scope (requires wave-admin changes).
 - **What happens if the SSO login times out (5 min)?** The auth server closes and an error is displayed. The user can retry `/login`.
@@ -73,9 +73,10 @@ As a developer who has authenticated via SSO, I want all LLM API requests to aut
 
 - **FR-001**: System MUST provide `/login` and `/logout` slash commands in the CLI.
 - **FR-002**: System MUST start a local HTTP server on `127.0.0.1` with a random port to receive SSO callbacks.
+- **FR-002a**: System MUST extract the `code` query parameter from the callback URL and exchange it for a JWT via `POST /api/auth/exchange`.
 - **FR-003**: System MUST fetch available SSO providers from `WAVE_ADMIN_URL/api/auth/sso-providers` and use the first provider.
 - **FR-004**: System MUST open the SSO login URL in the default browser when available.
-- **FR-005**: System MUST accept manual token input via the CLI when browser callback is unavailable (remote servers).
+- **FR-005**: System MUST accept manual authorization code input via the CLI when browser callback is unavailable (remote servers), and exchange it for a JWT.
 - **FR-006**: System MUST save the SSO token to `~/.wave/auth.json` with file permissions `0o600`.
 - **FR-007**: System MUST preserve non-SSO_TOKEN fields in `auth.json` when saving (merge, not overwrite).
 - **FR-008**: System MUST prioritize SSO mode over direct LLM mode when resolving gateway configuration.


### PR DESCRIPTION
## Summary

Update SSO login from direct JWT callback to OAuth 2.0 authorization code flow, matching the wave-admin implementation in `sso-chat-demo.js`.

## Changes

### Source Code
- **authService.ts**: Callback server extracts `code` param instead of `token`; exchanges via `POST /api/auth/exchange` for JWT; added error handling for SSO provider error responses
- **LoginCommand.tsx**: UI labels updated from "token" to "authorization code"
- **Tests**: Updated all mocks for code exchange flow; added exchange failure test case

### Specs
- **spec.md**: Updated acceptance scenarios and FR-002a/FR-005 for code exchange
- **contracts/auth.md**: Added `POST /api/auth/exchange` endpoint contract
- **quickstart.md**: Updated local and remote flow instructions
- **data-model.md**: Updated UI state descriptions
- **plan.md**: Updated architecture diagram
- **research.md**: Updated Wave-Admin mediator decision rationale
- **checklists/requirements.md**: Added FR-002a, updated FR-005

## Key Difference

**Before**: Callback received `?token={jwt}` directly
**After**: Callback receives `?code={code}`, then exchanges via `POST /api/auth/exchange` → `{ token, user }`

This follows the standard OAuth 2.0 authorization code pattern, keeping the JWT out of the URL bar.