### PR TITLE
feat(telemetry): add user.id and user.email to OpenTelemetry attributes

### DIFF
--- a/packages/agent-sdk/src/services/authService.ts
+++ b/packages/agent-sdk/src/services/authService.ts
@@ -19,7 +19,7 @@ import { createServer, Server } from "http";
 import { URL } from "url";
 import { execFile } from "child_process";
 import { promisify } from "util";
-import type { AuthConfig } from "../types/auth.js";
+import type { AuthConfig, AuthUser } from "../types/auth.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -97,42 +97,30 @@ export class AuthService {
   }): Promise<string> {
     const adminUrl = this.getAdminBaseUrl();
 
-    // Step 1: Fetch available SSO providers
-    const providersResponse = await fetch(`${adminUrl}/api/auth/sso-providers`);
-    if (!providersResponse.ok) {
-      throw new Error(
-        `Failed to fetch SSO providers: ${providersResponse.status} ${providersResponse.statusText}`,
-      );
-    }
-    const providers = (await providersResponse.json()) as {
-      provider: string;
-      displayName: string;
-    }[];
-    if (!providers || providers.length === 0) {
-      throw new Error("No SSO providers available");
-    }
-    const provider = providers[0].provider;
-
-    // Step 2-5: Start local server, open browser, wait for callback or manual input
-    const code = await this.startLocalAuthServer(adminUrl, provider, {
+    // Start local server, open browser, wait for callback or manual input
+    const { code } = await this.startLocalAuthServer(adminUrl, {
       onAuthUrl: options?.onAuthUrl,
       readToken: options?.readToken,
     });
 
-    // Exchange authorization code for JWT
-    const token = await this.exchangeCode(adminUrl, code);
+    // Exchange authorization code for JWT (includes user info)
+    const { token, user } = await this.exchangeCode(adminUrl, code);
 
-    // Save the token (preserve existing keys)
+    // Save the token and user info (preserve existing keys)
     const existing = this.loadAuth();
-    this.saveAuth({ ...existing, SSO_TOKEN: token });
+    this.saveAuth({ ...existing, SSO_TOKEN: token, user });
 
     return token;
   }
 
   /**
    * Exchange a short-lived authorization code for a JWT token.
+   * Returns both the token and user info.
    */
-  private async exchangeCode(adminUrl: string, code: string): Promise<string> {
+  private async exchangeCode(
+    adminUrl: string,
+    code: string,
+  ): Promise<{ token: string; user: AuthUser }> {
     const exchangeUrl = `${adminUrl}/api/auth/exchange`;
     const response = await fetch(exchangeUrl, {
       method: "POST",
@@ -147,19 +135,21 @@ export class AuthService {
 
     const data = (await response.json()) as {
       token: string;
-      user: { username: string };
+      user: { id: string; email?: string };
     };
-    return data.token;
+    return {
+      token: data.token,
+      user: { id: data.user.id, email: data.user.email },
+    };
   }
 
   private startLocalAuthServer(
     adminUrl: string,
-    provider: string,
     options?: {
       onAuthUrl?: (url: string) => void;
       readToken?: () => Promise<string>;
     },
-  ): Promise<string> {
+  ): Promise<{ code: string; user: AuthUser }> {
     return new Promise((resolve, reject) => {
       let settled = false;
       const server: Server = createServer((req, res) => {
@@ -195,7 +185,7 @@ export class AuthService {
           if (!settled) {
             settled = true;
             server.close();
-            resolve(code);
+            resolve({ code, user: { id: "", email: undefined } });
           }
         }
       });
@@ -210,7 +200,7 @@ export class AuthService {
         }
         const port = address.port;
         const callbackUrl = `http://127.0.0.1:${port}`;
-        const authUrl = `${adminUrl}/api/auth/sso/${provider}?callback_url=${encodeURIComponent(callbackUrl)}`;
+        const authUrl = `${adminUrl}/login?callback_url=${encodeURIComponent(callbackUrl)}`;
 
         // Notify caller of the auth URL
         options?.onAuthUrl?.(authUrl);
@@ -230,7 +220,7 @@ export class AuthService {
             if (!settled) {
               settled = true;
               server.close();
-              resolve(code);
+              resolve({ code, user: { id: "", email: undefined } });
             }
           },
           () => {
@@ -274,6 +264,11 @@ export class AuthService {
 
   isSSOAuthenticated(): boolean {
     return this.getSSOToken() !== undefined;
+  }
+
+  getAuthUser(): AuthUser | undefined {
+    const config = this.loadAuth();
+    return config.user;
   }
 }
 

--- a/packages/agent-sdk/src/telemetry/events.ts
+++ b/packages/agent-sdk/src/telemetry/events.ts
@@ -6,7 +6,11 @@
  */
 
 import type { OTelEventName } from "../types/telemetry.js";
-import { isInitialized, getCurrentConfig } from "./instrumentation.js";
+import {
+  isInitialized,
+  getCurrentConfig,
+  getTelemetryAttributes,
+} from "./instrumentation.js";
 
 interface OTelLogger {
   emit: (logRecord: {
@@ -52,6 +56,10 @@ export async function logOTelEvent(
 
   log.emit({
     body: eventName,
-    attributes: { "event.name": eventName, ...attributes },
+    attributes: {
+      "event.name": eventName,
+      ...getTelemetryAttributes(),
+      ...attributes,
+    },
   });
 }

--- a/packages/agent-sdk/src/telemetry/instrumentation.ts
+++ b/packages/agent-sdk/src/telemetry/instrumentation.ts
@@ -18,6 +18,7 @@ import type {
   LogRecordExporter,
   ReadableLogRecord,
 } from "@opentelemetry/sdk-logs";
+import { AuthService } from "../services/authService.js";
 
 // Lazy-loaded OTEL modules — only imported when telemetry is initialized
 let sdkNode: typeof import("@opentelemetry/sdk-node") | undefined;
@@ -468,3 +469,23 @@ export function isInitialized(): boolean {
 
 // Export JSONL exporters for testing
 export { JsonlSpanExporter, JsonlLogExporter };
+
+/**
+ * Get telemetry attributes based on the authenticated SSO user.
+ * Returns user.id and user.email when SSO authenticated, empty object otherwise.
+ */
+export function getTelemetryAttributes(): Record<string, string> {
+  try {
+    const user = AuthService.getInstance().getAuthUser();
+    if (user) {
+      const attrs: Record<string, string> = { "user.id": user.id };
+      if (user.email) {
+        attrs["user.email"] = user.email;
+      }
+      return attrs;
+    }
+  } catch {
+    // AuthService not available or not authenticated
+  }
+  return {};
+}

--- a/packages/agent-sdk/src/types/auth.ts
+++ b/packages/agent-sdk/src/types/auth.ts
@@ -1,3 +1,9 @@
+export interface AuthUser {
+  id: string;
+  email?: string;
+}
+
 export interface AuthConfig {
   SSO_TOKEN?: string;
+  user?: AuthUser;
 }

--- a/packages/agent-sdk/tests/services/authService.test.ts
+++ b/packages/agent-sdk/tests/services/authService.test.ts
@@ -224,6 +224,48 @@ describe("AuthService", () => {
     });
   });
 
+  describe("getAuthUser", () => {
+    it("returns user when present in auth.json", () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "my-token",
+          user: { id: "user-uuid", email: "user@example.com" },
+        }),
+      );
+      const service = AuthService.getInstance();
+      expect(service.getAuthUser()).toEqual({
+        id: "user-uuid",
+        email: "user@example.com",
+      });
+    });
+
+    it("returns user without email when email is absent", () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "my-token",
+          user: { id: "user-uuid" },
+        }),
+      );
+      const service = AuthService.getInstance();
+      expect(service.getAuthUser()).toEqual({ id: "user-uuid" });
+    });
+
+    it("returns undefined when no user in auth.json", () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(JSON.stringify({ SSO_TOKEN: "token" }));
+      const service = AuthService.getInstance();
+      expect(service.getAuthUser()).toBeUndefined();
+    });
+
+    it("returns undefined when file does not exist", () => {
+      mockedExists.mockReturnValue(false);
+      const service = AuthService.getInstance();
+      expect(service.getAuthUser()).toBeUndefined();
+    });
+  });
+
   describe("getAdminBaseUrl", () => {
     it("returns WAVE_ADMIN_URL when set", () => {
       process.env.WAVE_ADMIN_URL = "https://admin.example.com";
@@ -252,20 +294,15 @@ describe("AuthService", () => {
       vi.unstubAllGlobals();
     });
 
-    it("fetches providers, opens browser, receives callback code, exchanges for JWT, and saves it", async () => {
+    it("opens browser, receives callback code, exchanges for JWT, and saves it", async () => {
       process.env.WAVE_ADMIN_URL = "https://admin.example.com";
       mockedExists.mockReturnValue(false);
-      // 1st: fetch providers
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => [{ provider: "netease", displayName: "NetEase SSO" }],
-      });
-      // 2nd: exchange code for JWT
+      // exchange code for JWT
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
           token: "exchanged-jwt",
-          user: { username: "user" },
+          user: { id: "user-uuid", email: "user@example.com" },
         }),
       });
 
@@ -275,6 +312,8 @@ describe("AuthService", () => {
 
       expect(token).toBe("exchanged-jwt");
       expect(onAuthUrl).toHaveBeenCalled();
+      const authUrl = onAuthUrl.mock.calls[0][0] as string;
+      expect(authUrl).toContain("/login?callback_url=");
       // Verify exchange endpoint was called with the code
       expect(mockFetch).toHaveBeenCalledWith(
         "https://admin.example.com/api/auth/exchange",
@@ -288,37 +327,9 @@ describe("AuthService", () => {
       expect(mockedChmod).toHaveBeenCalled();
     });
 
-    it("throws when provider fetch fails", async () => {
-      process.env.WAVE_ADMIN_URL = "https://admin.example.com";
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        statusText: "Internal Error",
-      });
-
-      const service = AuthService.getInstance();
-      await expect(service.login()).rejects.toThrow(
-        "Failed to fetch SSO providers: 500 Internal Error",
-      );
-    });
-
-    it("throws when no providers available", async () => {
-      process.env.WAVE_ADMIN_URL = "https://admin.example.com";
-      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => [] });
-
-      const service = AuthService.getInstance();
-      await expect(service.login()).rejects.toThrow(
-        "No SSO providers available",
-      );
-    });
-
     it("throws when code exchange fails", async () => {
       process.env.WAVE_ADMIN_URL = "https://admin.example.com";
       mockedExists.mockReturnValue(false);
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => [{ provider: "netease", displayName: "NetEase SSO" }],
-      });
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 400,
@@ -337,13 +348,10 @@ describe("AuthService", () => {
       mockedReadFile.mockReturnValue(JSON.stringify({ OTHER_KEY: "value" }));
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => [
-          { provider: "provider1", displayName: "Provider 1" },
-        ],
-      });
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ token: "jwt-token", user: { username: "user" } }),
+        json: async () => ({
+          token: "jwt-token",
+          user: { id: "user-uuid", email: "user@example.com" },
+        }),
       });
 
       const service = AuthService.getInstance();
@@ -371,17 +379,12 @@ describe("AuthService", () => {
     it("accepts manually provided code via readToken and exchanges for JWT", async () => {
       process.env.WAVE_ADMIN_URL = "https://admin.example.com";
       mockedExists.mockReturnValue(false);
-      // 1st: fetch providers
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => [{ provider: "netease", displayName: "NetEase SSO" }],
-      });
-      // 2nd: exchange code for JWT
+      // exchange code for JWT
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
           token: "manual-exchanged-jwt",
-          user: { username: "user" },
+          user: { id: "user-uuid", email: "user@example.com" },
         }),
       });
 
@@ -410,17 +413,12 @@ describe("AuthService", () => {
 
       process.env.WAVE_ADMIN_URL = "https://admin.example.com";
       mockedExists.mockReturnValue(false);
-      // 1st: fetch providers
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => [{ provider: "netease", displayName: "NetEase SSO" }],
-      });
-      // 2nd: exchange code for JWT
+      // exchange code for JWT
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
           token: "callback-wins-jwt",
-          user: { username: "user" },
+          user: { id: "user-uuid", email: "user@example.com" },
         }),
       });
 
@@ -453,10 +451,6 @@ describe("AuthService", () => {
     it("rejects after 5 minutes if no token received", async () => {
       process.env.WAVE_ADMIN_URL = "https://admin.example.com";
       mockedExists.mockReturnValue(false);
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => [{ provider: "netease", displayName: "NetEase SSO" }],
-      });
 
       const service = AuthService.getInstance();
 
@@ -479,11 +473,10 @@ describe("AuthService", () => {
       mockedExists.mockReturnValue(false);
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => [{ provider: "netease", displayName: "NetEase SSO" }],
-      });
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ token: "early-jwt", user: { username: "user" } }),
+        json: async () => ({
+          token: "early-jwt",
+          user: { id: "user-uuid", email: "user@example.com" },
+        }),
       });
 
       const service = AuthService.getInstance();

--- a/packages/agent-sdk/tests/telemetry/events.test.ts
+++ b/packages/agent-sdk/tests/telemetry/events.test.ts
@@ -3,11 +3,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 // Mock the instrumentation module
 const mockIsInitialized = vi.fn();
 const mockGetCurrentConfig = vi.fn();
+const mockGetTelemetryAttributes = vi.fn().mockReturnValue({});
 const mockLogEmit = vi.fn();
 
 vi.mock("@/telemetry/instrumentation.js", () => ({
   isInitialized: () => mockIsInitialized(),
   getCurrentConfig: () => mockGetCurrentConfig(),
+  getTelemetryAttributes: () => mockGetTelemetryAttributes(),
 }));
 
 vi.mock("@opentelemetry/api-logs", () => ({
@@ -25,6 +27,7 @@ describe("events", () => {
 
     mockIsInitialized.mockReturnValue(false);
     mockGetCurrentConfig.mockReturnValue(undefined);
+    mockGetTelemetryAttributes.mockReturnValue({});
     mockLogEmit.mockReset();
 
     events = await import("@/telemetry/events.js");
@@ -288,6 +291,7 @@ describe("events with logger import failure", () => {
         logUserPrompts: false,
         logToolContent: false,
       }),
+      getTelemetryAttributes: () => ({}),
     }));
 
     vi.doMock("@opentelemetry/api-logs", () => {


### PR DESCRIPTION
## Summary

Add user identity attributes (`user.id`, `user.email`) to OpenTelemetry events when authenticated via SSO.

## Changes

- **`types/auth.ts`** — Add `AuthUser` interface with `id` and optional `email`; add `user?` to `AuthConfig`
- **`services/authService.ts`** —
  - Remove SSO provider fetching (use unified `/login` endpoint)
  - Extract `user` info from `/api/auth/exchange` response
  - Save both token and user to `auth.json`
  - Add `getAuthUser()` method
- **`telemetry/instrumentation.ts`** — Add `getTelemetryAttributes()` returning `user.id` and `user.email` for SSO sessions
- **`telemetry/events.ts`** — Merge telemetry attributes into every OTEL event via `logOTelEvent`
- **Tests** — Updated auth flow tests (removed provider fetch mocks) and added `getAuthUser` test cases

## Context

Aligns Wave agent with Claude Code's OpenTelemetry user reporting (`user.id`, `user.email`). Wave-admin already includes `email` in JWT claims and exchange response.