### PR TITLE
Make baseURL and WAVE_ADMIN_URL optional, add adminUrl to AgentOptions

### DIFF
--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -408,9 +408,10 @@ export class ConfigurationService {
     fetchOptions?: ClientOptions["fetchOptions"],
     fetch?: ClientOptions["fetch"],
   ): GatewayConfig {
-    // Check for SSO token first - if present and WAVE_ADMIN_URL is set, use SSO mode
+    // Check for SSO token first - if present and admin URL is available, use SSO mode
+    // Admin URL resolution: options > process.env
     const ssoToken = this.readSSOToken();
-    const adminUrl = process.env.WAVE_ADMIN_URL;
+    const adminUrl = this.options.adminUrl || process.env.WAVE_ADMIN_URL;
     if (ssoToken && adminUrl) {
       return {
         apiKey: ssoToken,

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -408,17 +408,10 @@ export class ConfigurationService {
     fetchOptions?: ClientOptions["fetchOptions"],
     fetch?: ClientOptions["fetch"],
   ): GatewayConfig {
-    // Check for SSO token first - if present, use SSO mode
+    // Check for SSO token first - if present and WAVE_ADMIN_URL is set, use SSO mode
     const ssoToken = this.readSSOToken();
-    if (ssoToken) {
-      const adminUrl = process.env.WAVE_ADMIN_URL;
-      if (!adminUrl) {
-        throw new ConfigurationError(
-          CONFIG_ERRORS.MISSING_BASE_URL,
-          "baseURL",
-          "WAVE_ADMIN_URL is required for SSO authentication",
-        );
-      }
+    const adminUrl = process.env.WAVE_ADMIN_URL;
+    if (ssoToken && adminUrl) {
       return {
         apiKey: ssoToken,
         baseURL: `${adminUrl}/api/v1`,
@@ -444,13 +437,13 @@ export class ConfigurationService {
 
     // Resolve base URL: override > options > env (settings.json) > process.env
     // Note: Explicitly provided empty strings should be treated as invalid, not fall back to env
-    let resolvedBaseURL: string;
+    let resolvedBaseURL: string | undefined;
     if (baseURL !== undefined) {
       resolvedBaseURL = baseURL;
     } else if (this.options.baseURL !== undefined) {
       resolvedBaseURL = this.options.baseURL;
     } else {
-      resolvedBaseURL = process.env.WAVE_BASE_URL || "";
+      resolvedBaseURL = process.env.WAVE_BASE_URL;
     }
 
     // Fallback to process.env if still not resolved (for dynamic updates in tests)
@@ -458,23 +451,12 @@ export class ConfigurationService {
       resolvedApiKey = process.env.WAVE_API_KEY;
     }
     if (!resolvedBaseURL) {
-      resolvedBaseURL = process.env.WAVE_BASE_URL || "";
+      resolvedBaseURL = process.env.WAVE_BASE_URL;
     }
 
-    if (!resolvedBaseURL && baseURL === undefined) {
-      throw new ConfigurationError(CONFIG_ERRORS.MISSING_BASE_URL, "baseURL", {
-        constructor: baseURL,
-        environment: process.env.WAVE_BASE_URL,
-        settings: process.env.WAVE_BASE_URL,
-      });
-    }
-
-    if (resolvedBaseURL.trim() === "") {
-      throw new ConfigurationError(
-        CONFIG_ERRORS.EMPTY_BASE_URL,
-        "baseURL",
-        resolvedBaseURL,
-      );
+    // Treat empty string as not provided
+    if (resolvedBaseURL?.trim() === "") {
+      resolvedBaseURL = undefined;
     }
 
     // Resolve custom headers from environment: env (settings.json) > process.env

--- a/packages/agent-sdk/src/types/agent.ts
+++ b/packages/agent-sdk/src/types/agent.ts
@@ -25,6 +25,8 @@ export interface AgentOptions {
   // Optional configuration with environment fallbacks
   apiKey?: string;
   baseURL?: string;
+  /** Wave admin URL for SSO authentication (fallback to WAVE_ADMIN_URL env var) */
+  adminUrl?: string;
   defaultHeaders?: Record<string, string>;
   fetchOptions?: ClientOptions["fetchOptions"];
   fetch?: ClientOptions["fetch"];

--- a/packages/agent-sdk/src/types/config.ts
+++ b/packages/agent-sdk/src/types/config.ts
@@ -8,7 +8,7 @@ import { PermissionMode } from "./permissions.js";
 
 export interface GatewayConfig {
   apiKey?: string;
-  baseURL: string;
+  baseURL?: string;
   defaultHeaders?: Record<string, string>;
   fetchOptions?: OpenAI["fetchOptions"];
   fetch?: OpenAI["fetch"];

--- a/packages/agent-sdk/src/types/core.ts
+++ b/packages/agent-sdk/src/types/core.ts
@@ -96,8 +96,6 @@ export class ConfigurationError extends Error {
 
 // Standard error messages
 export const CONFIG_ERRORS = {
-  MISSING_BASE_URL:
-    "Gateway configuration requires baseURL. Provide via constructor or WAVE_BASE_URL environment variable.",
   MISSING_MODEL:
     "Agent configuration requires model. Provide via constructor or WAVE_MODEL environment variable.",
   MISSING_FAST_MODEL:

--- a/packages/agent-sdk/src/utils/configValidator.ts
+++ b/packages/agent-sdk/src/utils/configValidator.ts
@@ -28,32 +28,34 @@ export class ConfigValidator {
       }
     }
 
-    // Validate base URL
-    if (!config.baseURL || typeof config.baseURL !== "string") {
-      throw new ConfigurationError(
-        CONFIG_ERRORS.EMPTY_BASE_URL,
-        "baseURL",
-        config.baseURL,
-      );
-    }
+    // Validate base URL if provided
+    if (config.baseURL) {
+      if (typeof config.baseURL !== "string") {
+        throw new ConfigurationError(
+          "Base URL must be a string if provided.",
+          "baseURL",
+          config.baseURL,
+        );
+      }
 
-    if (config.baseURL.trim() === "") {
-      throw new ConfigurationError(
-        CONFIG_ERRORS.EMPTY_BASE_URL,
-        "baseURL",
-        config.baseURL,
-      );
-    }
+      if (config.baseURL.trim() === "") {
+        throw new ConfigurationError(
+          CONFIG_ERRORS.EMPTY_BASE_URL,
+          "baseURL",
+          config.baseURL,
+        );
+      }
 
-    // Basic URL format validation
-    try {
-      new URL(config.baseURL);
-    } catch {
-      throw new ConfigurationError(
-        `Base URL must be a valid URL format. Received: ${config.baseURL}`,
-        "baseURL",
-        config.baseURL,
-      );
+      // Basic URL format validation
+      try {
+        new URL(config.baseURL);
+      } catch {
+        throw new ConfigurationError(
+          `Base URL must be a valid URL format. Received: ${config.baseURL}`,
+          "baseURL",
+          config.baseURL,
+        );
+      }
     }
   }
 

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -398,8 +398,9 @@ describe("ConfigurationService", () => {
       expect(config.baseURL).toBe("http://env-base.com");
     });
 
-    it("should throw on missing baseURL", () => {
-      expect(() => configService.resolveGatewayConfig()).toThrow();
+    it("should allow missing baseURL", () => {
+      const config = configService.resolveGatewayConfig();
+      expect(config.baseURL).toBeUndefined();
     });
 
     it("should parse custom headers from env", () => {


### PR DESCRIPTION
## Summary

- **baseURL is now optional**: Removed validation error when `WAVE_BASE_URL` is not set. SSO-authenticated sessions use `WAVE_ADMIN_URL` instead.
- **WAVE_ADMIN_URL is now optional**: SSO mode only activates when both token and admin URL are present; otherwise falls through to standard API key resolution.
- **adminUrl via AgentOptions**: Added `adminUrl` field to `AgentOptions`, allowing SSO configuration through `Agent.create({ adminUrl: '...' })` instead of only via environment variable.

### Changed files
- `packages/agent-sdk/src/types/config.ts`: Made `baseURL` optional in `GatewayConfig`
- `packages/agent-sdk/src/types/core.ts`: Removed `MISSING_BASE_URL` error constant
- `packages/agent-sdk/src/types/agent.ts`: Added `adminUrl` to `AgentOptions`
- `packages/agent-sdk/src/services/configurationService.ts`: Updated SSO flow to check both token and admin URL; admin URL resolves from options or env; removed missing baseURL throws
- `packages/agent-sdk/src/utils/configValidator.ts`: Only validates baseURL if provided
- `packages/agent-sdk/tests/services/configurationService.test.ts`: Updated test to expect missing baseURL to be allowed
