### PR TITLE
refactor: rename wave-admin to Wave AI

### DIFF
--- a/packages/agent-sdk/src/services/authService.ts
+++ b/packages/agent-sdk/src/services/authService.ts
@@ -79,11 +79,11 @@ export class AuthService {
     return config.SSO_TOKEN;
   }
 
-  getAdminBaseUrl(): string {
-    const url = process.env.WAVE_ADMIN_URL;
+  getAiBaseUrl(): string {
+    const url = process.env.WAVE_AI_URL;
     if (!url) {
       throw new Error(
-        "WAVE_ADMIN_URL environment variable is not set. SSO authentication requires this to be configured.",
+        "WAVE_AI_URL environment variable is not set. SSO authentication requires this to be configured.",
       );
     }
     return url;
@@ -95,16 +95,16 @@ export class AuthService {
     /** Read authorization code manually (e.g. from stdin). Resolves with code or rejects on cancel. */
     readToken?: () => Promise<string>;
   }): Promise<string> {
-    const adminUrl = this.getAdminBaseUrl();
+    const aiUrl = this.getAiBaseUrl();
 
     // Start local server, open browser, wait for callback or manual input
-    const { code } = await this.startLocalAuthServer(adminUrl, {
+    const { code } = await this.startLocalAuthServer(aiUrl, {
       onAuthUrl: options?.onAuthUrl,
       readToken: options?.readToken,
     });
 
     // Exchange authorization code for JWT (includes user info)
-    const { token, user } = await this.exchangeCode(adminUrl, code);
+    const { token, user } = await this.exchangeCode(aiUrl, code);
 
     // Save the token and user info (preserve existing keys)
     const existing = this.loadAuth();
@@ -118,10 +118,10 @@ export class AuthService {
    * Returns both the token and user info.
    */
   private async exchangeCode(
-    adminUrl: string,
+    aiUrl: string,
     code: string,
   ): Promise<{ token: string; user: AuthUser }> {
-    const exchangeUrl = `${adminUrl}/api/auth/exchange`;
+    const exchangeUrl = `${aiUrl}/api/auth/exchange`;
     const response = await fetch(exchangeUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -144,7 +144,7 @@ export class AuthService {
   }
 
   private startLocalAuthServer(
-    adminUrl: string,
+    aiUrl: string,
     options?: {
       onAuthUrl?: (url: string) => void;
       readToken?: () => Promise<string>;
@@ -200,7 +200,7 @@ export class AuthService {
         }
         const port = address.port;
         const callbackUrl = `http://127.0.0.1:${port}`;
-        const authUrl = `${adminUrl}/login?callback_url=${encodeURIComponent(callbackUrl)}`;
+        const authUrl = `${aiUrl}/login?callback_url=${encodeURIComponent(callbackUrl)}`;
 
         // Notify caller of the auth URL
         options?.onAuthUrl?.(authUrl);

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -408,14 +408,14 @@ export class ConfigurationService {
     fetchOptions?: ClientOptions["fetchOptions"],
     fetch?: ClientOptions["fetch"],
   ): GatewayConfig {
-    // Check for SSO token first - if present and admin URL is available, use SSO mode
-    // Admin URL resolution: options > process.env
+    // Check for SSO token first - if present and AI URL is available, use SSO mode
+    // AI URL resolution: options > process.env
     const ssoToken = this.readSSOToken();
-    const adminUrl = this.options.adminUrl || process.env.WAVE_ADMIN_URL;
-    if (ssoToken && adminUrl) {
+    const aiUrl = this.options.aiUrl || process.env.WAVE_AI_URL;
+    if (ssoToken && aiUrl) {
       return {
         apiKey: ssoToken,
-        baseURL: `${adminUrl}/api/v1`,
+        baseURL: `${aiUrl}/api/v1`,
         defaultHeaders:
           Object.keys(defaultHeaders || {}).length > 0
             ? defaultHeaders

--- a/packages/agent-sdk/src/types/agent.ts
+++ b/packages/agent-sdk/src/types/agent.ts
@@ -25,8 +25,8 @@ export interface AgentOptions {
   // Optional configuration with environment fallbacks
   apiKey?: string;
   baseURL?: string;
-  /** Wave admin URL for SSO authentication (fallback to WAVE_ADMIN_URL env var) */
-  adminUrl?: string;
+  /** Wave AI URL for SSO authentication (fallback to WAVE_AI_URL env var) */
+  aiUrl?: string;
   defaultHeaders?: Record<string, string>;
   fetchOptions?: ClientOptions["fetchOptions"];
   fetch?: ClientOptions["fetch"];

--- a/packages/agent-sdk/tests/services/authService.test.ts
+++ b/packages/agent-sdk/tests/services/authService.test.ts
@@ -90,7 +90,7 @@ describe("AuthService", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     resetServiceInstance();
-    delete process.env.WAVE_ADMIN_URL;
+    delete process.env.WAVE_AI_URL;
     httpMockState.fireCallback = true;
     httpMockState.code = "fake-auth-code";
     httpMockState.handlers = [];
@@ -266,17 +266,17 @@ describe("AuthService", () => {
     });
   });
 
-  describe("getAdminBaseUrl", () => {
-    it("returns WAVE_ADMIN_URL when set", () => {
-      process.env.WAVE_ADMIN_URL = "https://admin.example.com";
+  describe("getAiBaseUrl", () => {
+    it("returns WAVE_AI_URL when set", () => {
+      process.env.WAVE_AI_URL = "https://ai.example.com";
       const service = AuthService.getInstance();
-      expect(service.getAdminBaseUrl()).toBe("https://admin.example.com");
+      expect(service.getAiBaseUrl()).toBe("https://ai.example.com");
     });
 
-    it("throws when WAVE_ADMIN_URL is not set", () => {
+    it("throws when WAVE_AI_URL is not set", () => {
       const service = AuthService.getInstance();
-      expect(() => service.getAdminBaseUrl()).toThrow(
-        "WAVE_ADMIN_URL environment variable is not set",
+      expect(() => service.getAiBaseUrl()).toThrow(
+        "WAVE_AI_URL environment variable is not set",
       );
     });
   });
@@ -295,7 +295,7 @@ describe("AuthService", () => {
     });
 
     it("opens browser, receives callback code, exchanges for JWT, and saves it", async () => {
-      process.env.WAVE_ADMIN_URL = "https://admin.example.com";
+      process.env.WAVE_AI_URL = "https://ai.example.com";
       mockedExists.mockReturnValue(false);
       // exchange code for JWT
       mockFetch.mockResolvedValueOnce({
@@ -316,7 +316,7 @@ describe("AuthService", () => {
       expect(authUrl).toContain("/login?callback_url=");
       // Verify exchange endpoint was called with the code
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://admin.example.com/api/auth/exchange",
+        "https://ai.example.com/api/auth/exchange",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -328,7 +328,7 @@ describe("AuthService", () => {
     });
 
     it("throws when code exchange fails", async () => {
-      process.env.WAVE_ADMIN_URL = "https://admin.example.com";
+      process.env.WAVE_AI_URL = "https://ai.example.com";
       mockedExists.mockReturnValue(false);
       mockFetch.mockResolvedValueOnce({
         ok: false,
@@ -343,7 +343,7 @@ describe("AuthService", () => {
     });
 
     it("preserves existing keys when saving token", async () => {
-      process.env.WAVE_ADMIN_URL = "https://admin.example.com";
+      process.env.WAVE_AI_URL = "https://ai.example.com";
       mockedExists.mockReturnValue(true);
       mockedReadFile.mockReturnValue(JSON.stringify({ OTHER_KEY: "value" }));
       mockFetch.mockResolvedValueOnce({
@@ -377,7 +377,7 @@ describe("AuthService", () => {
     });
 
     it("accepts manually provided code via readToken and exchanges for JWT", async () => {
-      process.env.WAVE_ADMIN_URL = "https://admin.example.com";
+      process.env.WAVE_AI_URL = "https://ai.example.com";
       mockedExists.mockReturnValue(false);
       // exchange code for JWT
       mockFetch.mockResolvedValueOnce({
@@ -398,7 +398,7 @@ describe("AuthService", () => {
 
       expect(token).toBe("manual-exchanged-jwt");
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://admin.example.com/api/auth/exchange",
+        "https://ai.example.com/api/auth/exchange",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -411,7 +411,7 @@ describe("AuthService", () => {
       httpMockState.fireCallback = true;
       httpMockState.code = "callback-wins-code";
 
-      process.env.WAVE_ADMIN_URL = "https://admin.example.com";
+      process.env.WAVE_AI_URL = "https://ai.example.com";
       mockedExists.mockReturnValue(false);
       // exchange code for JWT
       mockFetch.mockResolvedValueOnce({
@@ -449,7 +449,7 @@ describe("AuthService", () => {
     });
 
     it("rejects after 5 minutes if no token received", async () => {
-      process.env.WAVE_ADMIN_URL = "https://admin.example.com";
+      process.env.WAVE_AI_URL = "https://ai.example.com";
       mockedExists.mockReturnValue(false);
 
       const service = AuthService.getInstance();
@@ -469,7 +469,7 @@ describe("AuthService", () => {
       httpMockState.fireCallback = true;
       httpMockState.code = "early-code";
 
-      process.env.WAVE_ADMIN_URL = "https://admin.example.com";
+      process.env.WAVE_AI_URL = "https://ai.example.com";
       mockedExists.mockReturnValue(false);
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/packages/code/src/components/LoginCommand.tsx
+++ b/packages/code/src/components/LoginCommand.tsx
@@ -111,7 +111,7 @@ export const LoginCommand: React.FC<LoginCommandProps> = ({ onCancel }) => {
 
   const isAuthenticated = authService.isSSOAuthenticated();
   const token = authService.getSSOToken();
-  const adminUrl = process.env.WAVE_ADMIN_URL;
+  const aiUrl = process.env.WAVE_AI_URL;
 
   const truncatedToken =
     token && token.length > 14
@@ -185,10 +185,10 @@ export const LoginCommand: React.FC<LoginCommandProps> = ({ onCancel }) => {
             <Text color="yellow">Token:</Text>
             <Text color="white"> {truncatedToken}</Text>
           </Box>
-          {adminUrl && (
+          {aiUrl && (
             <Box>
-              <Text color="yellow">Admin URL:</Text>
-              <Text color="white"> {adminUrl}</Text>
+              <Text color="yellow">AI URL:</Text>
+              <Text color="white"> {aiUrl}</Text>
             </Box>
           )}
           <Box marginTop={1}>

--- a/packages/code/tests/components/LoginCommand.test.tsx
+++ b/packages/code/tests/components/LoginCommand.test.tsx
@@ -55,17 +55,17 @@ describe("LoginCommand", () => {
     expect(lastFrame()).toContain("Press Enter to logout");
   });
 
-  it("should show admin URL when WAVE_ADMIN_URL is set", () => {
+  it("should show AI URL when WAVE_AI_URL is set", () => {
     mockAuthService.isSSOAuthenticated.mockReturnValue(true);
     mockAuthService.getSSOToken.mockReturnValue("short-token");
-    process.env.WAVE_ADMIN_URL = "https://admin.example.com";
+    process.env.WAVE_AI_URL = "https://ai.example.com";
 
     const { lastFrame } = render(<LoginCommand onCancel={vi.fn()} />);
 
-    expect(lastFrame()).toContain("Admin URL:");
-    expect(lastFrame()).toContain("https://admin.example.com");
+    expect(lastFrame()).toContain("AI URL:");
+    expect(lastFrame()).toContain("https://ai.example.com");
 
-    delete process.env.WAVE_ADMIN_URL;
+    delete process.env.WAVE_AI_URL;
   });
 
   it("should call clearAuth when Enter is pressed while authenticated", async () => {
@@ -92,7 +92,7 @@ describe("LoginCommand", () => {
     mockAuthService.login.mockImplementation(
       async ({ onAuthUrl }: { onAuthUrl?: (url: string) => void }) => {
         onAuthUrl?.(
-          "https://admin.example.com/api/auth/sso/netease?callback_url=http://127.0.0.1:12345",
+          "https://ai.example.com/api/auth/sso/netease?callback_url=http://127.0.0.1:12345",
         );
         return new Promise<string>(() => {});
       },

--- a/specs/076-sso-auth/checklists/requirements.md
+++ b/specs/076-sso-auth/checklists/requirements.md
@@ -5,13 +5,13 @@
 - [x] **FR-001**: `/login` and `/logout` slash commands available in CLI
 - [x] **FR-002**: Local HTTP server on `127.0.0.1` with random port for SSO callbacks
 - [x] **FR-002a**: Extracts `code` from callback URL and exchanges via `POST /api/auth/exchange`
-- [x] **FR-003**: Fetches SSO providers from `WAVE_ADMIN_URL/api/auth/sso-providers`
+- [x] **FR-003**: Fetches SSO providers from `WAVE_AI_URL/api/auth/sso-providers`
 - [x] **FR-004**: Opens SSO login URL in default browser (`open`/`xdg-open`/`start`)
 - [x] **FR-005**: Accepts manual authorization code input via Ink `useInput` for remote servers, exchanges for JWT
 - [x] **FR-006**: Saves SSO token to `~/.wave/auth.json` with `0o600` permissions
 - [x] **FR-007**: Merges existing config on save (preserves non-SSO_TOKEN fields)
 - [x] **FR-008**: SSO mode prioritized over direct LLM mode in gateway config resolution
-- [x] **FR-009**: Routes LLM API to `${WAVE_ADMIN_URL}/api/v1` in SSO mode
+- [x] **FR-009**: Routes LLM API to `${WAVE_AI_URL}/api/v1` in SSO mode
 - [x] **FR-010**: Token not exposed in logs/errors/UI (only truncated display)
 - [x] **FR-011**: Callback server closes after token received or timeout
 - [x] **FR-012**: 5-minute timeout with clear error message

--- a/specs/076-sso-auth/contracts/auth.md
+++ b/specs/076-sso-auth/contracts/auth.md
@@ -17,7 +17,7 @@ class AuthService {
   isSSOAuthenticated(): boolean;             // Returns true if SSO_TOKEN exists
 
   // Admin URL
-  getAdminBaseUrl(): string;                 // Returns WAVE_ADMIN_URL, throws if unset
+  getAiBaseUrl(): string;                    // Returns WAVE_AI_URL, throws if unset
 
   // Login flow
   login(options?: {
@@ -44,14 +44,14 @@ When `readSSOToken()` returns a non-empty value:
 ```typescript
 interface GatewayConfig {
   apiKey: string;          // SSO_TOKEN
-  baseURL: string;         // ${WAVE_ADMIN_URL}/api/v1
+  baseURL: string;         // ${WAVE_AI_URL}/api/v1
   defaultHeaders?: Record<string, string>;
   fetchOptions?: ClientOptions["fetchOptions"];
   fetch?: ClientOptions["fetch"];
 }
 ```
 
-## wave-admin API Contracts
+## Wave AI API Contracts
 
 ### GET /api/auth/sso-providers
 

--- a/specs/076-sso-auth/data-model.md
+++ b/specs/076-sso-auth/data-model.md
@@ -6,7 +6,7 @@
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `SSO_TOKEN` | `string?` | JWT token from wave-admin SSO login |
+| `SSO_TOKEN` | `string?` | JWT token from Wave AI SSO login |
 
 ### File Permissions
 
@@ -28,7 +28,7 @@ When `SSO_TOKEN` is present, `resolveGatewayConfig()` returns:
 | Field | Type | Description |
 |-------|------|-------------|
 | `apiKey` | `string` | The `SSO_TOKEN` value |
-| `baseURL` | `string` | `${WAVE_ADMIN_URL}/api/v1` |
+| `baseURL` | `string` | `${WAVE_AI_URL}/api/v1` |
 | `defaultHeaders` | `Record<string, string>?` | Custom headers (if any) |
 | `fetchOptions` | `ClientOptions.fetchOptions?` | Fetch options |
 | `fetch` | `ClientOptions.fetch?` | Custom fetch implementation |
@@ -38,7 +38,7 @@ When `SSO_TOKEN` is present, `resolveGatewayConfig()` returns:
 | State | Conditions | Display |
 |-------|-----------|---------|
 | Idle (not authenticated) | `!isSSOAuthenticated()` | "Not logged in", "Press Enter to login" |
-| Idle (authenticated) | `isSSOAuthenticated()` && `!isLoading` | Truncated token, admin URL, "Press Enter to logout" |
+| Idle (authenticated) | `isSSOAuthenticated()` && `!isLoading` | Truncated token, AI URL, "Press Enter to logout" |
 | Loading | `isLoading` && `!message` | "Starting authentication..." |
 | Auth URL shown | `isLoading` && `authUrl` | Auth URL + "Paste the authorization code from your browser URL bar:" + code input field |
 | Success | `!isLoading` && `message === "Login successful"` | "Login successful" |
@@ -47,7 +47,7 @@ When `SSO_TOKEN` is present, `resolveGatewayConfig()` returns:
 ## Resolution Priority (Gateway Config)
 
 ```
-1. SSO_TOKEN exists in ~/.wave/auth.json → { apiKey: SSO_TOKEN, baseURL: ${WAVE_ADMIN_URL}/api/v1 }
+1. SSO_TOKEN exists in ~/.wave/auth.json → { apiKey: SSO_TOKEN, baseURL: ${WAVE_AI_URL}/api/v1 }
 2. Constructor args (apiKey, baseURL)
 3. AgentOptions (this.options.apiKey, this.options.baseURL)
 4. Settings.json env vars (WAVE_API_KEY, WAVE_BASE_URL)

--- a/specs/076-sso-auth/plan.md
+++ b/specs/076-sso-auth/plan.md
@@ -4,7 +4,7 @@
 
 ## Summary
 
-Add `/login` and `/logout` slash commands for SSO authentication via wave-admin. AuthService handles browser-based SSO flow with localhost callback (receives authorization code, exchanges for JWT via `POST /api/auth/exchange`), falls back to manual code input for remote servers. Gateway configuration prioritizes SSO mode when `~/.wave/auth.json` contains `SSO_TOKEN`, routing all LLM API requests through wave-admin's `/api/v1` proxy.
+Add `/login` and `/logout` slash commands for SSO authentication via Wave AI. AuthService handles browser-based SSO flow with localhost callback (receives authorization code, exchanges for JWT via `POST /api/auth/exchange`), falls back to manual code input for remote servers. Gateway configuration prioritizes SSO mode when `~/.wave/auth.json` contains `SSO_TOKEN`, routing all LLM API requests through Wave AI's `/api/v1` proxy.
 
 ## Technical Context
 

--- a/specs/076-sso-auth/quickstart.md
+++ b/specs/076-sso-auth/quickstart.md
@@ -2,15 +2,15 @@
 
 ## Prerequisites
 
-- `WAVE_ADMIN_URL` environment variable set to your wave-admin instance
-- wave-admin running with at least one SSO provider configured
+- `WAVE_AI_URL` environment variable set to your Wave AI instance
+- Wave AI running with at least one SSO provider configured
 - Browser accessible from the machine running Wave (for local flow)
 
 ## Local Machine Flow
 
 1. **Set environment variable**:
    ```bash
-   export WAVE_ADMIN_URL=https://wave-admin.example.com
+   export WAVE_AI_URL=https://wave-ai.example.com
    ```
 
 2. **Start Wave**:
@@ -23,13 +23,13 @@
    /login
    ```
 
-4. **Browser opens** → Complete SSO login on wave-admin
+4. **Browser opens** → Complete SSO login on Wave AI
 
 5. **Browser redirects** to `http://127.0.0.1:{port}?code=...` → Wave exchanges code for JWT automatically
 
 6. **Verify**:
    ```
-   /status    # Should show wave-admin URL as the API endpoint
+   /status    # Should show Wave AI URL as the API endpoint
    ```
 
 7. **Logout**:
@@ -58,7 +58,7 @@
 
 4. **Copy the displayed URL** and open it in your **local** browser
 
-5. **Complete SSO login** on wave-admin
+5. **Complete SSO login** on Wave AI
 
 6. **Browser redirects** to `http://127.0.0.1:{port}?code=abc123` — the page shows "Connection refused" but **the authorization code is visible in the URL bar**
 
@@ -68,19 +68,19 @@
 
 9. **Verify**:
    ```
-   /status    # Should show wave-admin URL
+   /status    # Should show Wave AI URL
    ```
 
 ## Troubleshooting
 
-### "WAVE_ADMIN_URL is not set"
+### "WAVE_AI_URL is not set"
 Set the environment variable in your shell:
 ```bash
-export WAVE_ADMIN_URL=https://wave-admin.example.com
+export WAVE_AI_URL=https://wave-ai.example.com
 ```
 
 ### "No SSO providers available"
-Configure SSO providers in wave-admin via environment variables:
+Configure SSO providers in Wave AI via environment variables:
 ```bash
 SSO_PROVIDERS=company-sso
 SSO_company_sso_ISSUER_URL=https://sso.example.com
@@ -89,7 +89,7 @@ SSO_company_sso_CLIENT_SECRET=xxx
 ```
 
 ### Token expired after 8 hours
-wave-admin JWT defaults to 8-hour expiry. Re-run `/login` to get a fresh authorization code and exchange for a new token.
+Wave AI JWT defaults to 8-hour expiry. Re-run `/login` to get a fresh authorization code and exchange for a new token.
 
 ### "Connection refused" on browser redirect
 Expected on remote servers. Copy the authorization code from the browser URL bar and paste into the terminal.

--- a/specs/076-sso-auth/research.md
+++ b/specs/076-sso-auth/research.md
@@ -5,9 +5,9 @@
 **Rationale**: The primary flow uses a localhost HTTP server to receive the SSO callback (standard OAuth/PKCE pattern). For remote servers where the callback cannot reach the CLI (SSH without port forwarding), a manual token input fallback is provided using Ink's `useInput` for terminal text capture.
 
 **Alternatives considered**:
-- **Device code flow (RFC 8628)**: Used by GitHub CLI, Azure CLI. Requires server-side endpoint changes on wave-admin. Rejected — adds server complexity, we can solve this client-side.
+- **Device code flow (RFC 8628)**: Used by GitHub CLI, Azure CLI. Requires server-side endpoint changes on Wave AI. Rejected — adds server complexity, we can solve this client-side.
 - **SSH port forwarding documentation**: Document `ssh -L port:127.0.0.1:port` workaround. Rejected — manual setup each session is poor UX.
-- **Polling endpoint on wave-admin**: CLI gets session ID, polls server for token. Rejected — requires new server endpoint.
+- **Polling endpoint on Wave AI**: CLI gets session ID, polls server for token. Rejected — requires new server endpoint.
 
 ## Decision: `127.0.0.1` (IPv4) for Localhost Server
 
@@ -37,11 +37,11 @@
 
 ## Decision: Wave-Admin as SSO Mediator
 
-**Rationale**: wave-agent CLI does not connect directly to the company SSO IdP. Instead, wave-admin handles the OIDC/OAuth flow and redirects back to the CLI with a short-lived authorization code. The CLI then exchanges this code for a JWT via `POST /api/auth/exchange`. This two-step flow follows the standard OAuth 2.0 authorization code pattern, keeping the JWT out of the URL bar (only a short-lived code is exposed).
+**Rationale**: wave-agent CLI does not connect directly to the company SSO IdP. Instead, Wave AI handles the OIDC/OAuth flow and redirects back to the CLI with a short-lived authorization code. The CLI then exchanges this code for a JWT via `POST /api/auth/exchange`. This two-step flow follows the standard OAuth 2.0 authorization code pattern, keeping the JWT out of the URL bar (only a short-lived code is exposed).
 
 ## Decision: SSO Token Priority Over Direct LLM Config
 
-**Rationale**: When `~/.wave/auth.json` contains `SSO_TOKEN`, gateway configuration resolution prioritizes SSO mode. This ensures authenticated users automatically use wave-admin's API proxy without needing to unset `WAVE_API_KEY`.
+**Rationale**: When `~/.wave/auth.json` contains `SSO_TOKEN`, gateway configuration resolution prioritizes SSO mode. This ensures authenticated users automatically use Wave AI's API proxy without needing to unset `WAVE_API_KEY`.
 
 **Priority order**: SSO_TOKEN → constructor args → options → env (settings.json) → process.env → error.
 

--- a/specs/076-sso-auth/spec.md
+++ b/specs/076-sso-auth/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `076-sso-auth`
 **Created**: 2026-05-12
-**Input**: "Add /login slash command for SSO authentication via wave-admin, supporting browser-based SSO flow, token storage, and automatic API proxy routing."
+**Input**: "Add /login slash command for SSO authentication via Wave AI, supporting browser-based SSO flow, token storage, and automatic API proxy routing."
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -12,14 +12,14 @@ As a developer working on a local machine, I want to type `/login` in Wave to au
 
 **Why this priority**: This is the primary authentication flow — most users will have a browser available on their local machine.
 
-**Independent Test**: Set `WAVE_ADMIN_URL`, run Wave, type `/login`, browser opens, complete SSO login, verify token saved and API requests succeed.
+**Independent Test**: Set `WAVE_AI_URL`, run Wave, type `/login`, browser opens, complete SSO login, verify token saved and API requests succeed.
 
 **Acceptance Scenarios**:
 
-1. **Given** `WAVE_ADMIN_URL` is set and no existing SSO token, **When** the user types `/login`, **Then** Wave opens a browser to the SSO login page and displays the auth URL in the terminal.
+1. **Given** `WAVE_AI_URL` is set and no existing SSO token, **When** the user types `/login`, **Then** Wave opens a browser to the SSO login page and displays the auth URL in the terminal.
 2. **Given** the user completes SSO login in their browser, **When** the browser redirects to the localhost callback URL with `?code={code}`, **Then** Wave exchanges the code for a JWT via `POST /api/auth/exchange`, saves the token to `~/.wave/auth.json`, and displays "Login successful".
-3. **Given** the user is authenticated via SSO, **When** the user sends a message, **Then** all LLM API requests are sent to `WAVE_ADMIN_URL/api/v1` with the SSO token as Bearer auth.
-4. **Given** the user is already authenticated via SSO, **When** the user types `/login`, **Then** Wave shows current auth status (truncated token, admin URL) and offers to logout on Enter.
+3. **Given** the user is authenticated via SSO, **When** the user sends a message, **Then** all LLM API requests are sent to `WAVE_AI_URL/api/v1` with the SSO token as Bearer auth.
+4. **Given** the user is already authenticated via SSO, **When** the user types `/login`, **Then** Wave shows current auth status (truncated token, AI URL) and offers to logout on Enter.
 5. **Given** the user is authenticated and presses Enter while in the login UI, **When** they confirm logout, **Then** the SSO token is removed from `~/.wave/auth.json` and Wave displays "Logged out successfully".
 
 ---
@@ -30,7 +30,7 @@ As a developer working on a remote server via SSH, I want to manually paste the 
 
 **Why this priority**: A significant number of developers use remote servers (SSH, containers, devboxes) where localhost callback cannot reach the CLI. Without this, `/login` is broken for them.
 
-**Independent Test**: SSH to a remote server, set `WAVE_ADMIN_URL`, run Wave, type `/login`, open URL in local browser, complete SSO, copy token from browser URL bar, paste into terminal.
+**Independent Test**: SSH to a remote server, set `WAVE_AI_URL`, run Wave, type `/login`, open URL in local browser, complete SSO, copy token from browser URL bar, paste into terminal.
 
 **Acceptance Scenarios**:
 
@@ -43,28 +43,28 @@ As a developer working on a remote server via SSH, I want to manually paste the 
 
 ### User Story 3 - Automatic SSO API Routing (Priority: P1)
 
-As a developer who has authenticated via SSO, I want all LLM API requests to automatically use the wave-admin proxy so I don't need to configure `WAVE_API_KEY` or `WAVE_BASE_URL`.
+As a developer who has authenticated via SSO, I want all LLM API requests to automatically use the Wave AI proxy so I don't need to configure `WAVE_API_KEY` or `WAVE_BASE_URL`.
 
-**Why this priority**: This is the core value proposition — SSO authentication should transparently route API traffic through wave-admin without additional configuration.
+**Why this priority**: This is the core value proposition — SSO authentication should transparently route API traffic through Wave AI without additional configuration.
 
-**Independent Test**: Login via SSO, send a message, verify API request goes to `WAVE_ADMIN_URL/api/v1/chat/completions` with Bearer SSO token.
+**Independent Test**: Login via SSO, send a message, verify API request goes to `WAVE_AI_URL/api/v1/chat/completions` with Bearer SSO token.
 
 **Acceptance Scenarios**:
 
-1. **Given** `~/.wave/auth.json` contains a valid `SSO_TOKEN`, **When** the Agent resolves gateway configuration, **Then** it returns `{ apiKey: SSO_TOKEN, baseURL: "${WAVE_ADMIN_URL}/api/v1" }` regardless of `WAVE_API_KEY` or `WAVE_BASE_URL` settings.
+1. **Given** `~/.wave/auth.json` contains a valid `SSO_TOKEN`, **When** the Agent resolves gateway configuration, **Then** it returns `{ apiKey: SSO_TOKEN, baseURL: "${WAVE_AI_URL}/api/v1" }` regardless of `WAVE_API_KEY` or `WAVE_BASE_URL` settings.
 2. **Given** no `SSO_TOKEN` exists, **When** the Agent resolves gateway configuration, **Then** it falls back to the existing behavior (reading `WAVE_API_KEY`/`WAVE_BASE_URL`).
-3. **Given** `SSO_TOKEN` exists but `WAVE_ADMIN_URL` is unset, **When** gateway config is resolved, **Then** a configuration error is thrown with a clear message.
+3. **Given** `SSO_TOKEN` exists but `WAVE_AI_URL` is unset, **When** gateway config is resolved, **Then** a configuration error is thrown with a clear message.
 
 ---
 
 ### Edge Cases
 
 - **What happens if the SSO callback server port is already in use?** The server uses `localhost:0` (system-assigned random port), avoiding port collision.
-- **What happens if no SSO providers are configured on wave-admin?** The login fails with a clear error message ("No SSO providers available").
-- **What happens if `WAVE_ADMIN_URL` is not set during login?** The login fails with a clear error instructing the user to set the environment variable.
+- **What happens if no SSO providers are configured on Wave AI?** The login fails with a clear error message ("No SSO providers available").
+- **What happens if `WAVE_AI_URL` is not set during login?** The login fails with a clear error instructing the user to set the environment variable.
 - **What happens if the browser cannot be opened (headless server)?** The auth server stays alive, and the user can manually open the URL and paste the authorization code.
 - **What happens if the user saves additional fields in `auth.json` in the future?** The `saveAuth` method merges with existing config, preserving non-SSO_TOKEN fields.
-- **What happens if the token expires (JWT default 8h)?** The API call returns 401; the user must re-run `/login`. Token refresh is out of scope (requires wave-admin changes).
+- **What happens if the token expires (JWT default 8h)?** The API call returns 401; the user must re-run `/login`. Token refresh is out of scope (requires Wave AI changes).
 - **What happens if the SSO login times out (5 min)?** The auth server closes and an error is displayed. The user can retry `/login`.
 
 ## Requirements *(mandatory)*
@@ -74,13 +74,13 @@ As a developer who has authenticated via SSO, I want all LLM API requests to aut
 - **FR-001**: System MUST provide `/login` and `/logout` slash commands in the CLI.
 - **FR-002**: System MUST start a local HTTP server on `127.0.0.1` with a random port to receive SSO callbacks.
 - **FR-002a**: System MUST extract the `code` query parameter from the callback URL and exchange it for a JWT via `POST /api/auth/exchange`.
-- **FR-003**: System MUST fetch available SSO providers from `WAVE_ADMIN_URL/api/auth/sso-providers` and use the first provider.
+- **FR-003**: System MUST fetch available SSO providers from `WAVE_AI_URL/api/auth/sso-providers` and use the first provider.
 - **FR-004**: System MUST open the SSO login URL in the default browser when available.
 - **FR-005**: System MUST accept manual authorization code input via the CLI when browser callback is unavailable (remote servers), and exchange it for a JWT.
 - **FR-006**: System MUST save the SSO token to `~/.wave/auth.json` with file permissions `0o600`.
 - **FR-007**: System MUST preserve non-SSO_TOKEN fields in `auth.json` when saving (merge, not overwrite).
 - **FR-008**: System MUST prioritize SSO mode over direct LLM mode when resolving gateway configuration.
-- **FR-009**: System MUST route LLM API requests to `${WAVE_ADMIN_URL}/api/v1` when in SSO mode.
+- **FR-009**: System MUST route LLM API requests to `${WAVE_AI_URL}/api/v1` when in SSO mode.
 - **FR-010**: System MUST NOT expose the SSO token in logs, error messages, or UI (only show truncated prefix/suffix).
 - **FR-011**: System MUST close the localhost callback server after receiving a token or timing out.
 - **FR-012**: System MUST timeout the login flow after 5 minutes with a clear error message.
@@ -93,4 +93,4 @@ As a developer who has authenticated via SSO, I want all LLM API requests to aut
 - **AuthService**: Singleton service managing SSO authentication lifecycle (login, logout, token storage).
 - **AuthConfig**: Configuration object stored in `~/.wave/auth.json` containing `SSO_TOKEN`.
 - **LoginCommand**: Ink UI component for the `/login` slash command, handling both browser and manual input flows.
-- **GatewayConfig (SSO mode)**: Resolved configuration where `apiKey` is the SSO token and `baseURL` is `${WAVE_ADMIN_URL}/api/v1`.
+- **GatewayConfig (SSO mode)**: Resolved configuration where `apiKey` is the SSO token and `baseURL` is `${WAVE_AI_URL}/api/v1`.

--- a/specs/076-sso-auth/tasks.md
+++ b/specs/076-sso-auth/tasks.md
@@ -20,7 +20,7 @@
 - [x] T002 [P] [US1] Export auth types from `packages/agent-sdk/src/types/index.ts`
 - [x] T003 [P] [US1] Create `AuthService` in `packages/agent-sdk/src/services/authService.ts` with:
   - `getAuthPath()`, `loadAuth()`, `saveAuth()`, `clearAuth()`
-  - `getSSOToken()`, `isSSOAuthenticated()`, `getAdminBaseUrl()`
+  - `getSSOToken()`, `isSSOAuthenticated()`, `getAiBaseUrl()`
   - `login()` with browser SSO flow
   - `startLocalAuthServer()` with localhost callback
   - `openBrowser()` using `execFile` for security
@@ -35,7 +35,7 @@
 **⚠️ CRITICAL**: This enables API routing — all user stories depend on this
 
 - [x] T005 [US3] Add `readSSOToken()` private method to `ConfigurationService` in `packages/agent-sdk/src/services/configurationService.ts`
-- [x] T006 [US3] Update `resolveGatewayConfig()` to check SSO token first, returning `{ apiKey: SSO_TOKEN, baseURL: ${WAVE_ADMIN_URL}/api/v1 }` when present
+- [x] T006 [US3] Update `resolveGatewayConfig()` to check SSO token first, returning `{ apiKey: SSO_TOKEN, baseURL: ${WAVE_AI_URL}/api/v1 }` when present
 - [ ] T007 [US3] Unit tests for SSO mode resolution in `packages/agent-sdk/tests/services/configurationService.test.ts`
 
 **Checkpoint**: SSO API routing works — agent can use SSO token for LLM requests.
@@ -46,7 +46,7 @@
 
 **Goal**: `/login` opens browser, receives callback, saves token.
 
-**Independent Test**: Set `WAVE_ADMIN_URL`, run Wave locally, type `/login`, browser opens, complete SSO, verify token saved.
+**Independent Test**: Set `WAVE_AI_URL`, run Wave locally, type `/login`, browser opens, complete SSO, verify token saved.
 
 ### Tests for User Story 1 (REQUIRED) ⚠️
 
@@ -61,7 +61,7 @@
 - [x] T013 [US1] Integrate `LoginCommand` into `InputBox` in `packages/code/src/components/InputBox.tsx`
 - [x] T014 [US1] Update `inputReducer.test.ts` to include `showLoginCommand` in initial state
 
-**Checkpoint**: At this point, `/login` opens browser, saves token, and API routes through wave-admin.
+**Checkpoint**: At this point, `/login` opens browser, saves token, and API routes through Wave AI.
 
 ---
 
@@ -88,9 +88,9 @@
 
 ## Phase 5: User Story 3 - Automatic SSO API Routing (Priority: P1)
 
-**Goal**: SSO token automatically routes API requests through wave-admin proxy.
+**Goal**: SSO token automatically routes API requests through Wave AI proxy.
 
-**Independent Test**: Login via SSO, send message, verify API goes to wave-admin.
+**Independent Test**: Login via SSO, send message, verify API goes to Wave AI.
 
 **Note**: Most implementation for US3 was completed in Phase 2 (T005-T006). This phase verifies integration.
 


### PR DESCRIPTION
## Summary

Renamed the "wave admin" service to **Wave AI** across the entire codebase.

## Changes

### Environment Variable
- `WAVE_ADMIN_URL` → `WAVE_AI_URL`

### Code
- `adminUrl` AgentOptions property → `aiUrl`
- `getAdminBaseUrl()` → `getAiBaseUrl()`
- All internal variable names updated (`adminUrl` → `aiUrl`)
- UI label updated from "Admin URL:" to "AI URL:"

### Documentation & Specs
- All references in `specs/076-sso-auth/` updated (7 files)
- `wave-admin` → `Wave AI` throughout

## Tests
- All 2693 agent-sdk tests pass
- All 967 code tests pass
- Type checking passes

## Rationale

Wave AI better reflects the service's role as an enterprise platform (SSO, org management, gateway routing) similar to Claude.ai Enterprise, rather than a pure API billing console.