### PR TITLE
feat: add WAVE_SERVER_URL and WAVE_SSO_TOKEN template substitution in MCP config

### DIFF
--- a/packages/agent-sdk/src/managers/mcpManager.ts
+++ b/packages/agent-sdk/src/managers/mcpManager.ts
@@ -34,6 +34,10 @@ export interface McpManagerOptions {
   logger?: Logger;
   /** Pre-configured MCP servers passed from constructor options */
   mcpServers?: Record<string, McpServerConfig>;
+  /** Wave server URL for resolving ${WAVE_SERVER_URL} templates in MCP configs */
+  serverUrl?: string;
+  /** SSO token for resolving ${WAVE_SSO_TOKEN} templates in MCP configs */
+  ssoToken?: string;
 }
 
 /**
@@ -49,13 +53,81 @@ export function expandEnvVars(value: string): string {
 }
 
 /**
- * Walk an MCP config and expand env vars in all string fields.
+ * Context for resolving Wave-specific MCP template variables.
  */
-export function resolveMcpConfig(config: McpConfig): McpConfig {
+export interface McpResolverContext {
+  serverUrl?: string; // resolves ${WAVE_SERVER_URL}
+  ssoToken?: string; // resolves ${WAVE_SSO_TOKEN}
+}
+
+/**
+ * Walk a single McpServerConfig and replace Wave template variables.
+ * Only replaces ${WAVE_SERVER_URL} and ${WAVE_SSO_TOKEN} — does not touch
+ * arbitrary env vars (that is what expandEnvVars handles).
+ */
+export function resolveMcpTemplates(
+  config: McpServerConfig,
+  ctx: McpResolverContext,
+): McpServerConfig {
+  const resolved: McpServerConfig = { ...config };
+
+  const replace = (value: string): string => {
+    let result = value;
+    if (ctx.serverUrl !== undefined) {
+      result = result.replace(/\$\{WAVE_SERVER_URL\}/g, ctx.serverUrl);
+    }
+    if (ctx.ssoToken !== undefined) {
+      result = result.replace(/\$\{WAVE_SSO_TOKEN\}/g, ctx.ssoToken);
+    }
+    return result;
+  };
+
+  if (resolved.command) {
+    resolved.command = replace(resolved.command);
+  }
+
+  if (resolved.args) {
+    resolved.args = resolved.args.map(replace);
+  }
+
+  if (resolved.env) {
+    const resolvedEnv: Record<string, string> = {};
+    for (const [key, val] of Object.entries(resolved.env)) {
+      resolvedEnv[key] = replace(val);
+    }
+    resolved.env = resolvedEnv;
+  }
+
+  if (resolved.url) {
+    resolved.url = replace(resolved.url);
+  }
+
+  if (resolved.headers) {
+    const resolvedHeaders: Record<string, string> = {};
+    for (const [key, val] of Object.entries(resolved.headers)) {
+      resolvedHeaders[key] = replace(val);
+    }
+    resolved.headers = resolvedHeaders;
+  }
+
+  return resolved;
+}
+
+/**
+ * Walk an MCP config and resolve variables in all string fields.
+ * Applies two steps in order:
+ *   1. expandEnvVars — resolves ${VAR} from process.env
+ *   2. resolveMcpTemplates — resolves ${WAVE_SERVER_URL}, ${WAVE_SSO_TOKEN} from context
+ */
+export function resolveMcpConfig(
+  config: McpConfig,
+  ctx?: McpResolverContext,
+): McpConfig {
   const resolved: McpConfig = { mcpServers: {} };
 
   for (const [name, serverConfig] of Object.entries(config.mcpServers)) {
-    const resolvedServer: McpServerConfig = { ...serverConfig };
+    // Step 1: expand env vars from process.env
+    let resolvedServer: McpServerConfig = { ...serverConfig };
 
     if (resolvedServer.command) {
       resolvedServer.command = expandEnvVars(resolvedServer.command);
@@ -83,6 +155,11 @@ export function resolveMcpConfig(config: McpConfig): McpConfig {
         resolvedHeaders[key] = expandEnvVars(val);
       }
       resolvedServer.headers = resolvedHeaders;
+    }
+
+    // Step 2: resolve Wave template variables from context
+    if (ctx) {
+      resolvedServer = resolveMcpTemplates(resolvedServer, ctx);
     }
 
     resolved.mcpServers[name] = resolvedServer;

--- a/packages/agent-sdk/src/services/authService.ts
+++ b/packages/agent-sdk/src/services/authService.ts
@@ -79,11 +79,11 @@ export class AuthService {
     return config.SSO_TOKEN;
   }
 
-  getAiBaseUrl(): string {
-    const url = process.env.WAVE_AI_URL;
+  getServerUrl(): string {
+    const url = process.env.WAVE_SERVER_URL;
     if (!url) {
       throw new Error(
-        "WAVE_AI_URL environment variable is not set. SSO authentication requires this to be configured.",
+        "WAVE_SERVER_URL environment variable is not set. SSO authentication requires this to be configured.",
       );
     }
     return url;
@@ -95,16 +95,16 @@ export class AuthService {
     /** Read authorization code manually (e.g. from stdin). Resolves with code or rejects on cancel. */
     readToken?: () => Promise<string>;
   }): Promise<string> {
-    const aiUrl = this.getAiBaseUrl();
+    const serverUrl = this.getServerUrl();
 
     // Start local server, open browser, wait for callback or manual input
-    const { code } = await this.startLocalAuthServer(aiUrl, {
+    const { code } = await this.startLocalAuthServer(serverUrl, {
       onAuthUrl: options?.onAuthUrl,
       readToken: options?.readToken,
     });
 
     // Exchange authorization code for JWT (includes user info)
-    const { token, user } = await this.exchangeCode(aiUrl, code);
+    const { token, user } = await this.exchangeCode(serverUrl, code);
 
     // Save the token and user info (preserve existing keys)
     const existing = this.loadAuth();
@@ -118,10 +118,10 @@ export class AuthService {
    * Returns both the token and user info.
    */
   private async exchangeCode(
-    aiUrl: string,
+    serverUrl: string,
     code: string,
   ): Promise<{ token: string; user: AuthUser }> {
-    const exchangeUrl = `${aiUrl}/api/auth/exchange`;
+    const exchangeUrl = `${serverUrl}/api/auth/exchange`;
     const response = await fetch(exchangeUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -144,7 +144,7 @@ export class AuthService {
   }
 
   private startLocalAuthServer(
-    aiUrl: string,
+    serverUrl: string,
     options?: {
       onAuthUrl?: (url: string) => void;
       readToken?: () => Promise<string>;
@@ -200,7 +200,7 @@ export class AuthService {
         }
         const port = address.port;
         const callbackUrl = `http://127.0.0.1:${port}`;
-        const authUrl = `${aiUrl}/login?callback_url=${encodeURIComponent(callbackUrl)}`;
+        const authUrl = `${serverUrl}/login?callback_url=${encodeURIComponent(callbackUrl)}`;
 
         // Notify caller of the auth URL
         options?.onAuthUrl?.(authUrl);

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -408,14 +408,14 @@ export class ConfigurationService {
     fetchOptions?: ClientOptions["fetchOptions"],
     fetch?: ClientOptions["fetch"],
   ): GatewayConfig {
-    // Check for SSO token first - if present and AI URL is available, use SSO mode
-    // AI URL resolution: options > process.env
+    // Check for SSO token first - if present and server URL is available, use SSO mode
+    // Server URL resolution: options > process.env
     const ssoToken = this.readSSOToken();
-    const aiUrl = this.options.aiUrl || process.env.WAVE_AI_URL;
-    if (ssoToken && aiUrl) {
+    const serverUrl = this.options.serverUrl || process.env.WAVE_SERVER_URL;
+    if (ssoToken && serverUrl) {
       return {
         apiKey: ssoToken,
-        baseURL: `${aiUrl}/api/v1`,
+        baseURL: `${serverUrl}/api/v1`,
         defaultHeaders:
           Object.keys(defaultHeaders || {}).length > 0
             ? defaultHeaders

--- a/packages/agent-sdk/src/types/agent.ts
+++ b/packages/agent-sdk/src/types/agent.ts
@@ -25,8 +25,8 @@ export interface AgentOptions {
   // Optional configuration with environment fallbacks
   apiKey?: string;
   baseURL?: string;
-  /** Wave AI URL for SSO authentication (fallback to WAVE_AI_URL env var) */
-  aiUrl?: string;
+  /** Wave server URL for SSO authentication (fallback to WAVE_SERVER_URL env var) */
+  serverUrl?: string;
   defaultHeaders?: Record<string, string>;
   fetchOptions?: ClientOptions["fetchOptions"];
   fetch?: ClientOptions["fetch"];

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -38,6 +38,7 @@ import type {
 } from "../types/index.js";
 
 import { logger } from "./globalLogger.js";
+import { authService } from "../services/authService.js";
 
 export interface AgentContainerSetupOptions {
   options: AgentOptions;
@@ -150,6 +151,8 @@ export function setupAgentContainer(
     mcpServers: options.mcpServers as
       | Record<string, McpServerConfig>
       | undefined,
+    serverUrl: options.serverUrl || process.env.WAVE_SERVER_URL,
+    ssoToken: authService.getSSOToken(),
   });
   container.register("McpManager", mcpManager);
 

--- a/packages/agent-sdk/tests/managers/mcpManager.test.ts
+++ b/packages/agent-sdk/tests/managers/mcpManager.test.ts
@@ -3,6 +3,8 @@ import {
   McpManager,
   expandEnvVars,
   resolveMcpConfig,
+  resolveMcpTemplates,
+  type McpResolverContext,
 } from "../../src/managers/mcpManager.js";
 import { Container } from "../../src/utils/container.js";
 import type { McpServerConfig } from "../../src/types/index.js";
@@ -1349,5 +1351,246 @@ describe("resolveMcpConfig", () => {
     };
     resolveMcpConfig(config);
     expect(config.mcpServers.s.url).toBe("${URL}");
+  });
+});
+
+describe("resolveMcpTemplates", () => {
+  const originalEnv = process.env;
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should resolve ${WAVE_SERVER_URL} in command", () => {
+    const config: McpServerConfig = {
+      command: "${WAVE_SERVER_URL}/bin/mcp",
+      args: ["--endpoint", "${WAVE_SERVER_URL}/api"],
+    };
+    const ctx: McpResolverContext = { serverUrl: "https://wave.example.com" };
+    const resolved = resolveMcpTemplates(config, ctx);
+    expect(resolved.command).toBe("https://wave.example.com/bin/mcp");
+    expect(resolved.args).toEqual([
+      "--endpoint",
+      "https://wave.example.com/api",
+    ]);
+  });
+
+  it("should resolve ${WAVE_SERVER_URL} in url", () => {
+    const config: McpServerConfig = {
+      url: "${WAVE_SERVER_URL}/sse",
+    };
+    const ctx: McpResolverContext = { serverUrl: "https://wave.example.com" };
+    const resolved = resolveMcpTemplates(config, ctx);
+    expect(resolved.url).toBe("https://wave.example.com/sse");
+  });
+
+  it("should resolve ${WAVE_SSO_TOKEN} in headers", () => {
+    const config: McpServerConfig = {
+      url: "https://example.com/mcp",
+      headers: { Authorization: "Bearer ${WAVE_SSO_TOKEN}" },
+    };
+    const ctx: McpResolverContext = { ssoToken: "abc123token" };
+    const resolved = resolveMcpTemplates(config, ctx);
+    expect(resolved.headers).toEqual({ Authorization: "Bearer abc123token" });
+  });
+
+  it("should resolve both ${WAVE_SERVER_URL} and ${WAVE_SSO_TOKEN} in the same config", () => {
+    const config: McpServerConfig = {
+      url: "${WAVE_SERVER_URL}/mcp/sse",
+      headers: { Authorization: "Bearer ${WAVE_SSO_TOKEN}" },
+    };
+    const ctx: McpResolverContext = {
+      serverUrl: "https://wave.example.com",
+      ssoToken: "tok_xyz",
+    };
+    const resolved = resolveMcpTemplates(config, ctx);
+    expect(resolved.url).toBe("https://wave.example.com/mcp/sse");
+    expect(resolved.headers).toEqual({ Authorization: "Bearer tok_xyz" });
+  });
+
+  it("should resolve ${WAVE_SERVER_URL} in env values", () => {
+    const config: McpServerConfig = {
+      command: "npx",
+      args: ["mcp-server"],
+      env: {
+        MCP_ENDPOINT: "${WAVE_SERVER_URL}/api/mcp",
+      },
+    };
+    const ctx: McpResolverContext = { serverUrl: "https://wave.local:3000" };
+    const resolved = resolveMcpTemplates(config, ctx);
+    expect(resolved.env).toEqual({
+      MCP_ENDPOINT: "https://wave.local:3000/api/mcp",
+    });
+  });
+
+  it("should leave templates unchanged when context value is missing", () => {
+    const config: McpServerConfig = {
+      command: "${WAVE_SERVER_URL}/bin/mcp",
+      url: "${WAVE_SERVER_URL}/sse",
+      headers: { Authorization: "Bearer ${WAVE_SSO_TOKEN}" },
+    };
+    const ctx: McpResolverContext = {};
+    const resolved = resolveMcpTemplates(config, ctx);
+    expect(resolved.command).toBe("${WAVE_SERVER_URL}/bin/mcp");
+    expect(resolved.url).toBe("${WAVE_SERVER_URL}/sse");
+    expect(resolved.headers).toEqual({
+      Authorization: "Bearer ${WAVE_SSO_TOKEN}",
+    });
+  });
+
+  it("should leave templates unchanged when only partial context is provided", () => {
+    const config: McpServerConfig = {
+      url: "${WAVE_SERVER_URL}/sse",
+      headers: { Authorization: "Bearer ${WAVE_SSO_TOKEN}" },
+    };
+    // Only ssoToken provided — serverUrl template stays untouched
+    const ctx: McpResolverContext = { ssoToken: "my-token" };
+    const resolved = resolveMcpTemplates(config, ctx);
+    expect(resolved.url).toBe("${WAVE_SERVER_URL}/sse");
+    expect(resolved.headers).toEqual({ Authorization: "Bearer my-token" });
+  });
+
+  it("should NOT expand regular env vars from process.env", () => {
+    process.env.HOME = "/home/user";
+    const config: McpServerConfig = {
+      command: "${HOME}/bin/mcp",
+    };
+    const ctx: McpResolverContext = {};
+    const resolved = resolveMcpTemplates(config, ctx);
+    // resolveMcpTemplates only handles WAVE_SERVER_URL and WAVE_SSO_TOKEN
+    expect(resolved.command).toBe("${HOME}/bin/mcp");
+  });
+
+  it("should NOT expand ${WAVE_SERVER_URL} from process.env", () => {
+    process.env.WAVE_SERVER_URL = "https://from-env.com";
+    const config: McpServerConfig = {
+      url: "${WAVE_SERVER_URL}/sse",
+    };
+    const ctx: McpResolverContext = {};
+    const resolved = resolveMcpTemplates(config, ctx);
+    // Template should remain — only context values are used, not process.env
+    expect(resolved.url).toBe("${WAVE_SERVER_URL}/sse");
+  });
+
+  it("should not mutate the original config", () => {
+    const config: McpServerConfig = {
+      url: "${WAVE_SERVER_URL}/sse",
+      headers: { Authorization: "Bearer ${WAVE_SSO_TOKEN}" },
+    };
+    const ctx: McpResolverContext = {
+      serverUrl: "https://resolved.com",
+      ssoToken: "tok",
+    };
+    resolveMcpTemplates(config, ctx);
+    expect(config.url).toBe("${WAVE_SERVER_URL}/sse");
+    expect(config.headers).toEqual({
+      Authorization: "Bearer ${WAVE_SSO_TOKEN}",
+    });
+  });
+});
+
+describe("resolveMcpConfig with context", () => {
+  const originalEnv = process.env;
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should apply both env var expansion AND template resolution", () => {
+    process.env.MCP_PORT = "8080";
+    // Set WAVE_SSO_TOKEN in process.env so expandEnvVars doesn't wipe it;
+    // resolveMcpTemplates then replaces it with the context value
+    process.env.WAVE_SSO_TOKEN = "${WAVE_SSO_TOKEN}";
+    const config = {
+      mcpServers: {
+        s: {
+          url: "http://localhost:${MCP_PORT}/sse",
+          headers: { Authorization: "Bearer ${WAVE_SSO_TOKEN}" },
+        },
+      },
+    };
+    const ctx: McpResolverContext = { ssoToken: "secret-token" };
+    const resolved = resolveMcpConfig(config, ctx);
+    // Step 1: ${MCP_PORT} expanded from process.env; ${WAVE_SSO_TOKEN} replaced
+    //         with literal "${WAVE_SSO_TOKEN}" (from process.env)
+    // Step 2: resolveMcpTemplates replaces "${WAVE_SSO_TOKEN}" with context value
+    expect(resolved.mcpServers.s.url).toBe("http://localhost:8080/sse");
+    expect(resolved.mcpServers.s.headers).toEqual({
+      Authorization: "Bearer secret-token",
+    });
+  });
+
+  it("should apply env var expansion and template resolution to command and args", () => {
+    process.env.MCP_CMD = "npx";
+    // Set WAVE_SERVER_URL so expandEnvVars preserves the template string
+    process.env.WAVE_SERVER_URL = "${WAVE_SERVER_URL}";
+    const config = {
+      mcpServers: {
+        s: {
+          command: "${MCP_CMD}",
+          args: ["--url", "${WAVE_SERVER_URL}/api"],
+        },
+      },
+    };
+    const ctx: McpResolverContext = { serverUrl: "https://wave.test" };
+    const resolved = resolveMcpConfig(config, ctx);
+    expect(resolved.mcpServers.s.command).toBe("npx");
+    expect(resolved.mcpServers.s.args).toEqual([
+      "--url",
+      "https://wave.test/api",
+    ]);
+  });
+
+  it("should verify env var and template var resolution are separate steps", () => {
+    // Set WAVE_SERVER_URL in process.env — expandEnvVars runs first and replaces it
+    // before resolveMcpTemplates gets a chance to use the context value
+    process.env.WAVE_SERVER_URL = "https://from-env.com";
+    const config = {
+      mcpServers: {
+        s: {
+          url: "${WAVE_SERVER_URL}/sse",
+        },
+      },
+    };
+    // Pass a different value via context — it will NOT be used because
+    // expandEnvVars already replaced the template from process.env
+    const ctx: McpResolverContext = { serverUrl: "https://from-context.com" };
+    const resolved = resolveMcpConfig(config, ctx);
+    expect(resolved.mcpServers.s.url).toBe("https://from-env.com/sse");
+  });
+
+  it("should show ${WAVE_SERVER_URL} is NOT expanded from process.env by resolveMcpTemplates alone", () => {
+    // This test uses resolveMcpTemplates directly (not resolveMcpConfig)
+    // to verify that resolveMcpTemplates only uses context, not process.env
+    process.env.WAVE_SERVER_URL = "https://from-env.com";
+    const config: McpServerConfig = {
+      url: "${WAVE_SERVER_URL}/sse",
+    };
+    const ctx: McpResolverContext = { serverUrl: "https://from-context.com" };
+    const resolved = resolveMcpTemplates(config, ctx);
+    // resolveMcpTemplates ignores process.env and uses context
+    expect(resolved.url).toBe("https://from-context.com/sse");
+  });
+
+  it("should not expand template vars when env var is unset and no context provided", () => {
+    // Ensure these are not in process.env
+    delete process.env.WAVE_SERVER_URL;
+    delete process.env.WAVE_SSO_TOKEN;
+    const config = {
+      mcpServers: {
+        s: {
+          url: "${WAVE_SERVER_URL}/sse",
+          headers: { Authorization: "Bearer ${WAVE_SSO_TOKEN}" },
+        },
+      },
+    };
+    // No context passed — expandEnvVars replaces unknown vars with empty string
+    const resolved = resolveMcpConfig(config);
+    // expandEnvVars replaces ${WAVE_SERVER_URL} and ${WAVE_SSO_TOKEN} with ""
+    // since they are not in process.env and no defaults are provided
+    expect(resolved.mcpServers.s.url).toBe("/sse");
+    expect(resolved.mcpServers.s.headers).toEqual({
+      Authorization: "Bearer ",
+    });
   });
 });

--- a/packages/agent-sdk/tests/services/authService.test.ts
+++ b/packages/agent-sdk/tests/services/authService.test.ts
@@ -90,7 +90,7 @@ describe("AuthService", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     resetServiceInstance();
-    delete process.env.WAVE_AI_URL;
+    delete process.env.WAVE_SERVER_URL;
     httpMockState.fireCallback = true;
     httpMockState.code = "fake-auth-code";
     httpMockState.handlers = [];
@@ -266,17 +266,17 @@ describe("AuthService", () => {
     });
   });
 
-  describe("getAiBaseUrl", () => {
-    it("returns WAVE_AI_URL when set", () => {
-      process.env.WAVE_AI_URL = "https://ai.example.com";
+  describe("getServerUrl", () => {
+    it("returns WAVE_SERVER_URL when set", () => {
+      process.env.WAVE_SERVER_URL = "https://server.example.com";
       const service = AuthService.getInstance();
-      expect(service.getAiBaseUrl()).toBe("https://ai.example.com");
+      expect(service.getServerUrl()).toBe("https://server.example.com");
     });
 
-    it("throws when WAVE_AI_URL is not set", () => {
+    it("throws when WAVE_SERVER_URL is not set", () => {
       const service = AuthService.getInstance();
-      expect(() => service.getAiBaseUrl()).toThrow(
-        "WAVE_AI_URL environment variable is not set",
+      expect(() => service.getServerUrl()).toThrow(
+        "WAVE_SERVER_URL environment variable is not set",
       );
     });
   });
@@ -295,7 +295,7 @@ describe("AuthService", () => {
     });
 
     it("opens browser, receives callback code, exchanges for JWT, and saves it", async () => {
-      process.env.WAVE_AI_URL = "https://ai.example.com";
+      process.env.WAVE_SERVER_URL = "https://ai.example.com";
       mockedExists.mockReturnValue(false);
       // exchange code for JWT
       mockFetch.mockResolvedValueOnce({
@@ -328,7 +328,7 @@ describe("AuthService", () => {
     });
 
     it("throws when code exchange fails", async () => {
-      process.env.WAVE_AI_URL = "https://ai.example.com";
+      process.env.WAVE_SERVER_URL = "https://ai.example.com";
       mockedExists.mockReturnValue(false);
       mockFetch.mockResolvedValueOnce({
         ok: false,
@@ -343,7 +343,7 @@ describe("AuthService", () => {
     });
 
     it("preserves existing keys when saving token", async () => {
-      process.env.WAVE_AI_URL = "https://ai.example.com";
+      process.env.WAVE_SERVER_URL = "https://ai.example.com";
       mockedExists.mockReturnValue(true);
       mockedReadFile.mockReturnValue(JSON.stringify({ OTHER_KEY: "value" }));
       mockFetch.mockResolvedValueOnce({
@@ -377,7 +377,7 @@ describe("AuthService", () => {
     });
 
     it("accepts manually provided code via readToken and exchanges for JWT", async () => {
-      process.env.WAVE_AI_URL = "https://ai.example.com";
+      process.env.WAVE_SERVER_URL = "https://ai.example.com";
       mockedExists.mockReturnValue(false);
       // exchange code for JWT
       mockFetch.mockResolvedValueOnce({
@@ -411,7 +411,7 @@ describe("AuthService", () => {
       httpMockState.fireCallback = true;
       httpMockState.code = "callback-wins-code";
 
-      process.env.WAVE_AI_URL = "https://ai.example.com";
+      process.env.WAVE_SERVER_URL = "https://ai.example.com";
       mockedExists.mockReturnValue(false);
       // exchange code for JWT
       mockFetch.mockResolvedValueOnce({
@@ -449,7 +449,7 @@ describe("AuthService", () => {
     });
 
     it("rejects after 5 minutes if no token received", async () => {
-      process.env.WAVE_AI_URL = "https://ai.example.com";
+      process.env.WAVE_SERVER_URL = "https://ai.example.com";
       mockedExists.mockReturnValue(false);
 
       const service = AuthService.getInstance();
@@ -469,7 +469,7 @@ describe("AuthService", () => {
       httpMockState.fireCallback = true;
       httpMockState.code = "early-code";
 
-      process.env.WAVE_AI_URL = "https://ai.example.com";
+      process.env.WAVE_SERVER_URL = "https://ai.example.com";
       mockedExists.mockReturnValue(false);
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/packages/code/src/components/LoginCommand.tsx
+++ b/packages/code/src/components/LoginCommand.tsx
@@ -111,7 +111,7 @@ export const LoginCommand: React.FC<LoginCommandProps> = ({ onCancel }) => {
 
   const isAuthenticated = authService.isSSOAuthenticated();
   const token = authService.getSSOToken();
-  const aiUrl = process.env.WAVE_AI_URL;
+  const serverUrl = process.env.WAVE_SERVER_URL;
 
   const truncatedToken =
     token && token.length > 14
@@ -185,10 +185,10 @@ export const LoginCommand: React.FC<LoginCommandProps> = ({ onCancel }) => {
             <Text color="yellow">Token:</Text>
             <Text color="white"> {truncatedToken}</Text>
           </Box>
-          {aiUrl && (
+          {serverUrl && (
             <Box>
-              <Text color="yellow">AI URL:</Text>
-              <Text color="white"> {aiUrl}</Text>
+              <Text color="yellow">Server URL:</Text>
+              <Text color="white"> {serverUrl}</Text>
             </Box>
           )}
           <Box marginTop={1}>

--- a/packages/code/tests/components/LoginCommand.test.tsx
+++ b/packages/code/tests/components/LoginCommand.test.tsx
@@ -55,17 +55,17 @@ describe("LoginCommand", () => {
     expect(lastFrame()).toContain("Press Enter to logout");
   });
 
-  it("should show AI URL when WAVE_AI_URL is set", () => {
+  it("should show server URL when WAVE_SERVER_URL is set", () => {
     mockAuthService.isSSOAuthenticated.mockReturnValue(true);
     mockAuthService.getSSOToken.mockReturnValue("short-token");
-    process.env.WAVE_AI_URL = "https://ai.example.com";
+    process.env.WAVE_SERVER_URL = "https://server.example.com";
 
     const { lastFrame } = render(<LoginCommand onCancel={vi.fn()} />);
 
-    expect(lastFrame()).toContain("AI URL:");
-    expect(lastFrame()).toContain("https://ai.example.com");
+    expect(lastFrame()).toContain("Server URL:");
+    expect(lastFrame()).toContain("https://server.example.com");
 
-    delete process.env.WAVE_AI_URL;
+    delete process.env.WAVE_SERVER_URL;
   });
 
   it("should call clearAuth when Enter is pressed while authenticated", async () => {

--- a/specs/076-sso-auth/checklists/requirements.md
+++ b/specs/076-sso-auth/checklists/requirements.md
@@ -5,13 +5,13 @@
 - [x] **FR-001**: `/login` and `/logout` slash commands available in CLI
 - [x] **FR-002**: Local HTTP server on `127.0.0.1` with random port for SSO callbacks
 - [x] **FR-002a**: Extracts `code` from callback URL and exchanges via `POST /api/auth/exchange`
-- [x] **FR-003**: Fetches SSO providers from `WAVE_AI_URL/api/auth/sso-providers`
+- [x] **FR-003**: Fetches SSO providers from `WAVE_SERVER_URL/api/auth/sso-providers`
 - [x] **FR-004**: Opens SSO login URL in default browser (`open`/`xdg-open`/`start`)
 - [x] **FR-005**: Accepts manual authorization code input via Ink `useInput` for remote servers, exchanges for JWT
 - [x] **FR-006**: Saves SSO token to `~/.wave/auth.json` with `0o600` permissions
 - [x] **FR-007**: Merges existing config on save (preserves non-SSO_TOKEN fields)
 - [x] **FR-008**: SSO mode prioritized over direct LLM mode in gateway config resolution
-- [x] **FR-009**: Routes LLM API to `${WAVE_AI_URL}/api/v1` in SSO mode
+- [x] **FR-009**: Routes LLM API to `${WAVE_SERVER_URL}/api/v1` in SSO mode
 - [x] **FR-010**: Token not exposed in logs/errors/UI (only truncated display)
 - [x] **FR-011**: Callback server closes after token received or timeout
 - [x] **FR-012**: 5-minute timeout with clear error message

--- a/specs/076-sso-auth/contracts/auth.md
+++ b/specs/076-sso-auth/contracts/auth.md
@@ -16,8 +16,8 @@ class AuthService {
   getSSOToken(): string | undefined;         // Returns SSO_TOKEN or undefined
   isSSOAuthenticated(): boolean;             // Returns true if SSO_TOKEN exists
 
-  // Admin URL
-  getAiBaseUrl(): string;                    // Returns WAVE_AI_URL, throws if unset
+  // Server URL
+  getServerUrl(): string;                    // Returns WAVE_SERVER_URL, throws if unset
 
   // Login flow
   login(options?: {
@@ -44,7 +44,7 @@ When `readSSOToken()` returns a non-empty value:
 ```typescript
 interface GatewayConfig {
   apiKey: string;          // SSO_TOKEN
-  baseURL: string;         // ${WAVE_AI_URL}/api/v1
+  baseURL: string;         // ${WAVE_SERVER_URL}/api/v1
   defaultHeaders?: Record<string, string>;
   fetchOptions?: ClientOptions["fetchOptions"];
   fetch?: ClientOptions["fetch"];

--- a/specs/076-sso-auth/data-model.md
+++ b/specs/076-sso-auth/data-model.md
@@ -28,7 +28,7 @@ When `SSO_TOKEN` is present, `resolveGatewayConfig()` returns:
 | Field | Type | Description |
 |-------|------|-------------|
 | `apiKey` | `string` | The `SSO_TOKEN` value |
-| `baseURL` | `string` | `${WAVE_AI_URL}/api/v1` |
+| `baseURL` | `string` | `${WAVE_SERVER_URL}/api/v1` |
 | `defaultHeaders` | `Record<string, string>?` | Custom headers (if any) |
 | `fetchOptions` | `ClientOptions.fetchOptions?` | Fetch options |
 | `fetch` | `ClientOptions.fetch?` | Custom fetch implementation |
@@ -47,7 +47,7 @@ When `SSO_TOKEN` is present, `resolveGatewayConfig()` returns:
 ## Resolution Priority (Gateway Config)
 
 ```
-1. SSO_TOKEN exists in ~/.wave/auth.json → { apiKey: SSO_TOKEN, baseURL: ${WAVE_AI_URL}/api/v1 }
+1. SSO_TOKEN exists in ~/.wave/auth.json → { apiKey: SSO_TOKEN, baseURL: ${WAVE_SERVER_URL}/api/v1 }
 2. Constructor args (apiKey, baseURL)
 3. AgentOptions (this.options.apiKey, this.options.baseURL)
 4. Settings.json env vars (WAVE_API_KEY, WAVE_BASE_URL)

--- a/specs/076-sso-auth/quickstart.md
+++ b/specs/076-sso-auth/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- `WAVE_AI_URL` environment variable set to your Wave AI instance
+- `WAVE_SERVER_URL` environment variable set to your Wave AI instance
 - Wave AI running with at least one SSO provider configured
 - Browser accessible from the machine running Wave (for local flow)
 
@@ -10,7 +10,7 @@
 
 1. **Set environment variable**:
    ```bash
-   export WAVE_AI_URL=https://wave-ai.example.com
+   export WAVE_SERVER_URL=https://wave-ai.example.com
    ```
 
 2. **Start Wave**:
@@ -73,10 +73,10 @@
 
 ## Troubleshooting
 
-### "WAVE_AI_URL is not set"
+### "WAVE_SERVER_URL is not set"
 Set the environment variable in your shell:
 ```bash
-export WAVE_AI_URL=https://wave-ai.example.com
+export WAVE_SERVER_URL=https://wave-ai.example.com
 ```
 
 ### "No SSO providers available"

--- a/specs/076-sso-auth/spec.md
+++ b/specs/076-sso-auth/spec.md
@@ -12,13 +12,13 @@ As a developer working on a local machine, I want to type `/login` in Wave to au
 
 **Why this priority**: This is the primary authentication flow — most users will have a browser available on their local machine.
 
-**Independent Test**: Set `WAVE_AI_URL`, run Wave, type `/login`, browser opens, complete SSO login, verify token saved and API requests succeed.
+**Independent Test**: Set `WAVE_SERVER_URL`, run Wave, type `/login`, browser opens, complete SSO login, verify token saved and API requests succeed.
 
 **Acceptance Scenarios**:
 
-1. **Given** `WAVE_AI_URL` is set and no existing SSO token, **When** the user types `/login`, **Then** Wave opens a browser to the SSO login page and displays the auth URL in the terminal.
+1. **Given** `WAVE_SERVER_URL` is set and no existing SSO token, **When** the user types `/login`, **Then** Wave opens a browser to the SSO login page and displays the auth URL in the terminal.
 2. **Given** the user completes SSO login in their browser, **When** the browser redirects to the localhost callback URL with `?code={code}`, **Then** Wave exchanges the code for a JWT via `POST /api/auth/exchange`, saves the token to `~/.wave/auth.json`, and displays "Login successful".
-3. **Given** the user is authenticated via SSO, **When** the user sends a message, **Then** all LLM API requests are sent to `WAVE_AI_URL/api/v1` with the SSO token as Bearer auth.
+3. **Given** the user is authenticated via SSO, **When** the user sends a message, **Then** all LLM API requests are sent to `WAVE_SERVER_URL/api/v1` with the SSO token as Bearer auth.
 4. **Given** the user is already authenticated via SSO, **When** the user types `/login`, **Then** Wave shows current auth status (truncated token, AI URL) and offers to logout on Enter.
 5. **Given** the user is authenticated and presses Enter while in the login UI, **When** they confirm logout, **Then** the SSO token is removed from `~/.wave/auth.json` and Wave displays "Logged out successfully".
 
@@ -30,7 +30,7 @@ As a developer working on a remote server via SSH, I want to manually paste the 
 
 **Why this priority**: A significant number of developers use remote servers (SSH, containers, devboxes) where localhost callback cannot reach the CLI. Without this, `/login` is broken for them.
 
-**Independent Test**: SSH to a remote server, set `WAVE_AI_URL`, run Wave, type `/login`, open URL in local browser, complete SSO, copy token from browser URL bar, paste into terminal.
+**Independent Test**: SSH to a remote server, set `WAVE_SERVER_URL`, run Wave, type `/login`, open URL in local browser, complete SSO, copy token from browser URL bar, paste into terminal.
 
 **Acceptance Scenarios**:
 
@@ -47,13 +47,13 @@ As a developer who has authenticated via SSO, I want all LLM API requests to aut
 
 **Why this priority**: This is the core value proposition — SSO authentication should transparently route API traffic through Wave AI without additional configuration.
 
-**Independent Test**: Login via SSO, send a message, verify API request goes to `WAVE_AI_URL/api/v1/chat/completions` with Bearer SSO token.
+**Independent Test**: Login via SSO, send a message, verify API request goes to `WAVE_SERVER_URL/api/v1/chat/completions` with Bearer SSO token.
 
 **Acceptance Scenarios**:
 
-1. **Given** `~/.wave/auth.json` contains a valid `SSO_TOKEN`, **When** the Agent resolves gateway configuration, **Then** it returns `{ apiKey: SSO_TOKEN, baseURL: "${WAVE_AI_URL}/api/v1" }` regardless of `WAVE_API_KEY` or `WAVE_BASE_URL` settings.
+1. **Given** `~/.wave/auth.json` contains a valid `SSO_TOKEN`, **When** the Agent resolves gateway configuration, **Then** it returns `{ apiKey: SSO_TOKEN, baseURL: "${WAVE_SERVER_URL}/api/v1" }` regardless of `WAVE_API_KEY` or `WAVE_BASE_URL` settings.
 2. **Given** no `SSO_TOKEN` exists, **When** the Agent resolves gateway configuration, **Then** it falls back to the existing behavior (reading `WAVE_API_KEY`/`WAVE_BASE_URL`).
-3. **Given** `SSO_TOKEN` exists but `WAVE_AI_URL` is unset, **When** gateway config is resolved, **Then** a configuration error is thrown with a clear message.
+3. **Given** `SSO_TOKEN` exists but `WAVE_SERVER_URL` is unset, **When** gateway config is resolved, **Then** a configuration error is thrown with a clear message.
 
 ---
 
@@ -61,7 +61,7 @@ As a developer who has authenticated via SSO, I want all LLM API requests to aut
 
 - **What happens if the SSO callback server port is already in use?** The server uses `localhost:0` (system-assigned random port), avoiding port collision.
 - **What happens if no SSO providers are configured on Wave AI?** The login fails with a clear error message ("No SSO providers available").
-- **What happens if `WAVE_AI_URL` is not set during login?** The login fails with a clear error instructing the user to set the environment variable.
+- **What happens if `WAVE_SERVER_URL` is not set during login?** The login fails with a clear error instructing the user to set the environment variable.
 - **What happens if the browser cannot be opened (headless server)?** The auth server stays alive, and the user can manually open the URL and paste the authorization code.
 - **What happens if the user saves additional fields in `auth.json` in the future?** The `saveAuth` method merges with existing config, preserving non-SSO_TOKEN fields.
 - **What happens if the token expires (JWT default 8h)?** The API call returns 401; the user must re-run `/login`. Token refresh is out of scope (requires Wave AI changes).
@@ -74,13 +74,13 @@ As a developer who has authenticated via SSO, I want all LLM API requests to aut
 - **FR-001**: System MUST provide `/login` and `/logout` slash commands in the CLI.
 - **FR-002**: System MUST start a local HTTP server on `127.0.0.1` with a random port to receive SSO callbacks.
 - **FR-002a**: System MUST extract the `code` query parameter from the callback URL and exchange it for a JWT via `POST /api/auth/exchange`.
-- **FR-003**: System MUST fetch available SSO providers from `WAVE_AI_URL/api/auth/sso-providers` and use the first provider.
+- **FR-003**: System MUST fetch available SSO providers from `WAVE_SERVER_URL/api/auth/sso-providers` and use the first provider.
 - **FR-004**: System MUST open the SSO login URL in the default browser when available.
 - **FR-005**: System MUST accept manual authorization code input via the CLI when browser callback is unavailable (remote servers), and exchange it for a JWT.
 - **FR-006**: System MUST save the SSO token to `~/.wave/auth.json` with file permissions `0o600`.
 - **FR-007**: System MUST preserve non-SSO_TOKEN fields in `auth.json` when saving (merge, not overwrite).
 - **FR-008**: System MUST prioritize SSO mode over direct LLM mode when resolving gateway configuration.
-- **FR-009**: System MUST route LLM API requests to `${WAVE_AI_URL}/api/v1` when in SSO mode.
+- **FR-009**: System MUST route LLM API requests to `${WAVE_SERVER_URL}/api/v1` when in SSO mode.
 - **FR-010**: System MUST NOT expose the SSO token in logs, error messages, or UI (only show truncated prefix/suffix).
 - **FR-011**: System MUST close the localhost callback server after receiving a token or timing out.
 - **FR-012**: System MUST timeout the login flow after 5 minutes with a clear error message.
@@ -93,4 +93,4 @@ As a developer who has authenticated via SSO, I want all LLM API requests to aut
 - **AuthService**: Singleton service managing SSO authentication lifecycle (login, logout, token storage).
 - **AuthConfig**: Configuration object stored in `~/.wave/auth.json` containing `SSO_TOKEN`.
 - **LoginCommand**: Ink UI component for the `/login` slash command, handling both browser and manual input flows.
-- **GatewayConfig (SSO mode)**: Resolved configuration where `apiKey` is the SSO token and `baseURL` is `${WAVE_AI_URL}/api/v1`.
+- **GatewayConfig (SSO mode)**: Resolved configuration where `apiKey` is the SSO token and `baseURL` is `${WAVE_SERVER_URL}/api/v1`.

--- a/specs/076-sso-auth/tasks.md
+++ b/specs/076-sso-auth/tasks.md
@@ -20,7 +20,7 @@
 - [x] T002 [P] [US1] Export auth types from `packages/agent-sdk/src/types/index.ts`
 - [x] T003 [P] [US1] Create `AuthService` in `packages/agent-sdk/src/services/authService.ts` with:
   - `getAuthPath()`, `loadAuth()`, `saveAuth()`, `clearAuth()`
-  - `getSSOToken()`, `isSSOAuthenticated()`, `getAiBaseUrl()`
+  - `getSSOToken()`, `isSSOAuthenticated()`, `getServerUrl()`
   - `login()` with browser SSO flow
   - `startLocalAuthServer()` with localhost callback
   - `openBrowser()` using `execFile` for security
@@ -35,7 +35,7 @@
 **⚠️ CRITICAL**: This enables API routing — all user stories depend on this
 
 - [x] T005 [US3] Add `readSSOToken()` private method to `ConfigurationService` in `packages/agent-sdk/src/services/configurationService.ts`
-- [x] T006 [US3] Update `resolveGatewayConfig()` to check SSO token first, returning `{ apiKey: SSO_TOKEN, baseURL: ${WAVE_AI_URL}/api/v1 }` when present
+- [x] T006 [US3] Update `resolveGatewayConfig()` to check SSO token first, returning `{ apiKey: SSO_TOKEN, baseURL: ${WAVE_SERVER_URL}/api/v1 }` when present
 - [ ] T007 [US3] Unit tests for SSO mode resolution in `packages/agent-sdk/tests/services/configurationService.test.ts`
 
 **Checkpoint**: SSO API routing works — agent can use SSO token for LLM requests.
@@ -46,7 +46,7 @@
 
 **Goal**: `/login` opens browser, receives callback, saves token.
 
-**Independent Test**: Set `WAVE_AI_URL`, run Wave locally, type `/login`, browser opens, complete SSO, verify token saved.
+**Independent Test**: Set `WAVE_SERVER_URL`, run Wave locally, type `/login`, browser opens, complete SSO, verify token saved.
 
 ### Tests for User Story 1 (REQUIRED) ⚠️
 
@@ -136,3 +136,4 @@
 - T003, T004 (AuthService creation + export)
 - T008, T009, T010, T011 (US1 tests + CLI commands)
 - T015, T016, T017 (US2 tests + AuthService update)
+te)


### PR DESCRIPTION
## Summary

Add support for `${WAVE_SERVER_URL}` and `${WAVE_SSO_TOKEN}` template variables in `.mcp.json` configs, enabling MCP servers to dynamically reference the Wave server URL and SSO token.

## Changes

### `packages/agent-sdk/src/managers/mcpManager.ts`
- Added `McpResolverContext` interface with `serverUrl?` and `ssoToken?`
- Added `resolveMcpTemplates(config, ctx)` function that replaces `${WAVE_SERVER_URL}` and `${WAVE_SSO_TOKEN}` in command, args, env, url, and headers
- Updated `resolveMcpConfig(config, ctx?)` to apply both steps in order:
  1. `expandEnvVars` — resolves `${VAR}` from `process.env`
  2. `resolveMcpTemplates` — resolves Wave template variables from context
- Added `serverUrl?` and `ssoToken?` to `McpManagerOptions`

### `packages/agent-sdk/src/utils/containerSetup.ts`
- Wire `serverUrl: options.serverUrl || process.env.WAVE_SERVER_URL` and `ssoToken: authService.getSSOToken()` into `McpManager`

### Tests
- 10 tests for `resolveMcpTemplates` (command, args, url, headers, env, missing context, no mutation, separation from process.env)
- 5 tests for `resolveMcpConfig` with context (both steps applied, separate steps verification)

All 72 tests pass, type-check and lint clean.