### PR TITLE
fix: prevent expandEnvVars from eating Wave template variables

### DIFF
--- a/packages/agent-sdk/src/managers/mcpManager.ts
+++ b/packages/agent-sdk/src/managers/mcpManager.ts
@@ -44,10 +44,16 @@ export interface McpManagerOptions {
  * Expand environment variables in a string value.
  * Supports ${VAR} and ${VAR:-default} patterns.
  */
+const WAVE_TEMPLATE_VARS = ["WAVE_SERVER_URL", "WAVE_SSO_TOKEN"];
+
 export function expandEnvVars(value: string): string {
   return value.replace(/\$\{([^}]+)\}/g, (_match, expr: string) => {
     const [varName, ...rest] = expr.split(":-");
     const defaultValue = rest.join(":-");
+    // Skip Wave-specific template variables — they are handled by resolveMcpTemplates
+    if (WAVE_TEMPLATE_VARS.includes(varName)) {
+      return _match; // return original ${...} string untouched
+    }
     return process.env[varName] ?? defaultValue;
   });
 }
@@ -177,12 +183,18 @@ export class McpManager {
   private callbacks: McpManagerCallbacks;
   private mcpServers: Record<string, McpServerConfig> | undefined;
 
+  private resolverCtx: McpResolverContext | undefined;
+
   constructor(
     private container: Container,
     options: McpManagerOptions = {},
   ) {
     this.callbacks = options.callbacks || {};
     this.mcpServers = options.mcpServers;
+    this.resolverCtx = {
+      serverUrl: options.serverUrl,
+      ssoToken: options.ssoToken,
+    };
   }
 
   /**
@@ -254,7 +266,10 @@ export class McpManager {
 
     try {
       const configContent = await fs.readFile(this.configPath, "utf-8");
-      const workspaceConfig = resolveMcpConfig(JSON.parse(configContent));
+      const workspaceConfig = resolveMcpConfig(
+        JSON.parse(configContent),
+        this.resolverCtx,
+      );
 
       // Merge workspace config with any existing config (e.g., from plugins or constructor)
       // Constructor-provided servers take precedence, then workspace config, then existing config

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -146,13 +146,15 @@ export function setupAgentContainer(
   });
   container.register("BackgroundTaskManager", backgroundTaskManager);
 
+  const ssoToken = authService.getSSOToken();
+  const serverUrl = options.serverUrl || process.env.WAVE_SERVER_URL;
   const mcpManager = new McpManager(container, {
     callbacks,
     mcpServers: options.mcpServers as
       | Record<string, McpServerConfig>
       | undefined,
-    serverUrl: options.serverUrl || process.env.WAVE_SERVER_URL,
-    ssoToken: authService.getSSOToken(),
+    serverUrl,
+    ssoToken,
   });
   container.register("McpManager", mcpManager);
 

--- a/packages/agent-sdk/tests/managers/mcpManager.test.ts
+++ b/packages/agent-sdk/tests/managers/mcpManager.test.ts
@@ -1541,9 +1541,9 @@ describe("resolveMcpConfig with context", () => {
     ]);
   });
 
-  it("should verify env var and template var resolution are separate steps", () => {
-    // Set WAVE_SERVER_URL in process.env — expandEnvVars runs first and replaces it
-    // before resolveMcpTemplates gets a chance to use the context value
+  it("should skip Wave templates in expandEnvVars and let resolveMcpTemplates handle them", () => {
+    // Set WAVE_SERVER_URL in process.env — expandEnvVars now skips Wave templates
+    // so resolveMcpTemplates (Step 2) uses the context value instead
     process.env.WAVE_SERVER_URL = "https://from-env.com";
     const config = {
       mcpServers: {
@@ -1552,11 +1552,10 @@ describe("resolveMcpConfig with context", () => {
         },
       },
     };
-    // Pass a different value via context — it will NOT be used because
-    // expandEnvVars already replaced the template from process.env
     const ctx: McpResolverContext = { serverUrl: "https://from-context.com" };
     const resolved = resolveMcpConfig(config, ctx);
-    expect(resolved.mcpServers.s.url).toBe("https://from-env.com/sse");
+    // Context value is used since expandEnvVars skips Wave templates
+    expect(resolved.mcpServers.s.url).toBe("https://from-context.com/sse");
   });
 
   it("should show ${WAVE_SERVER_URL} is NOT expanded from process.env by resolveMcpTemplates alone", () => {
@@ -1572,7 +1571,7 @@ describe("resolveMcpConfig with context", () => {
     expect(resolved.url).toBe("https://from-context.com/sse");
   });
 
-  it("should not expand template vars when env var is unset and no context provided", () => {
+  it("should preserve template vars when no context provided (expandEnvVars skips them)", () => {
     // Ensure these are not in process.env
     delete process.env.WAVE_SERVER_URL;
     delete process.env.WAVE_SSO_TOKEN;
@@ -1584,13 +1583,11 @@ describe("resolveMcpConfig with context", () => {
         },
       },
     };
-    // No context passed — expandEnvVars replaces unknown vars with empty string
+    // No context passed — expandEnvVars skips Wave templates, so they stay
     const resolved = resolveMcpConfig(config);
-    // expandEnvVars replaces ${WAVE_SERVER_URL} and ${WAVE_SSO_TOKEN} with ""
-    // since they are not in process.env and no defaults are provided
-    expect(resolved.mcpServers.s.url).toBe("/sse");
+    expect(resolved.mcpServers.s.url).toBe("${WAVE_SERVER_URL}/sse");
     expect(resolved.mcpServers.s.headers).toEqual({
-      Authorization: "Bearer ",
+      Authorization: "Bearer ${WAVE_SSO_TOKEN}",
     });
   });
 });


### PR DESCRIPTION
The expandEnvVars regex matches ${WAVE_SSO_TOKEN} and ${WAVE_SERVER_URL} as generic env vars, replacing them with empty strings before resolveMcpTemplates (Step 2) could use the context values.

## Problem

MCP servers configured with template variables received `Bearer ` instead of `Bearer <actual-token>`, causing 401 errors:

```json
{
  "mcpServers": {
    "wave_requirements": {
      "url": "${WAVE_SERVER_URL}/mcp",
      "headers": {
        "Authorization": "Bearer ${WAVE_SSO_TOKEN}"
      }
    }
  }
}
```

Result: `SSE error: Non-200 status code (401)`

## Changes

- **skip Wave template variables in `expandEnvVars`** — preserves ${WAVE_SERVER_URL} and ${WAVE_SSO_TOKEN} for Step 2 resolution
- **store `resolverCtx` as instance field in `McpManager`** — so serverUrl and ssoToken from containerSetup are available in loadConfig()
- **pass `resolverCtx` to `resolveMcpConfig()`** — was previously ignored
- **update tests** — to reflect the corrected two-step resolution behavior