### PR TITLE
fix(auth): add setServerUrl and serverUrl option to AuthService.login()

### DIFF
--- a/packages/agent-sdk/src/services/authService.ts
+++ b/packages/agent-sdk/src/services/authService.ts
@@ -25,12 +25,21 @@ const execFileAsync = promisify(execFile);
 
 export class AuthService {
   private static instance: AuthService;
+  private _serverUrl: string | undefined;
 
   static getInstance(): AuthService {
     if (!AuthService.instance) {
       AuthService.instance = new AuthService();
     }
     return AuthService.instance;
+  }
+
+  /**
+   * Set server URL programmatically (e.g. from AgentOptions.serverUrl).
+   * Takes priority over WAVE_SERVER_URL environment variable.
+   */
+  setServerUrl(url: string): void {
+    this._serverUrl = url;
   }
 
   getAuthPath(): string {
@@ -80,7 +89,7 @@ export class AuthService {
   }
 
   getServerUrl(): string {
-    const url = process.env.WAVE_SERVER_URL;
+    const url = this._serverUrl || process.env.WAVE_SERVER_URL;
     if (!url) {
       throw new Error(
         "WAVE_SERVER_URL environment variable is not set. SSO authentication requires this to be configured.",
@@ -94,8 +103,10 @@ export class AuthService {
     onAuthUrl?: (url: string) => void;
     /** Read authorization code manually (e.g. from stdin). Resolves with code or rejects on cancel. */
     readToken?: () => Promise<string>;
+    /** Server URL override. Falls back to setServerUrl() or WAVE_SERVER_URL env var. */
+    serverUrl?: string;
   }): Promise<string> {
-    const serverUrl = this.getServerUrl();
+    const serverUrl = options?.serverUrl || this.getServerUrl();
 
     // Start local server, open browser, wait for callback or manual input
     const { code } = await this.startLocalAuthServer(serverUrl, {

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -148,6 +148,9 @@ export function setupAgentContainer(
 
   const ssoToken = authService.getSSOToken();
   const serverUrl = options.serverUrl || process.env.WAVE_SERVER_URL;
+  if (options.serverUrl) {
+    authService.setServerUrl(options.serverUrl);
+  }
   const mcpManager = new McpManager(container, {
     callbacks,
     mcpServers: options.mcpServers as

--- a/packages/agent-sdk/tests/services/authService.test.ts
+++ b/packages/agent-sdk/tests/services/authService.test.ts
@@ -279,6 +279,148 @@ describe("AuthService", () => {
         "WAVE_SERVER_URL environment variable is not set",
       );
     });
+
+    it("returns _serverUrl when set via setServerUrl", () => {
+      process.env.WAVE_SERVER_URL = "https://env.example.com";
+      const service = AuthService.getInstance();
+      service.setServerUrl("https://programmatic.example.com");
+      expect(service.getServerUrl()).toBe("https://programmatic.example.com");
+    });
+
+    it("_serverUrl takes priority over WAVE_SERVER_URL env var", () => {
+      process.env.WAVE_SERVER_URL = "https://env.example.com";
+      const service = AuthService.getInstance();
+      service.setServerUrl("https://options.example.com");
+      expect(service.getServerUrl()).toBe("https://options.example.com");
+    });
+
+    it("falls back to env var when _serverUrl is not set", () => {
+      process.env.WAVE_SERVER_URL = "https://fallback.example.com";
+      const service = AuthService.getInstance();
+      expect(service.getServerUrl()).toBe("https://fallback.example.com");
+    });
+
+    it("throws when neither _serverUrl nor env var is set", () => {
+      const service = AuthService.getInstance();
+      expect(() => service.getServerUrl()).toThrow(
+        "WAVE_SERVER_URL environment variable is not set",
+      );
+    });
+  });
+
+  describe("login with serverUrl option", () => {
+    const mockFetch = vi.fn();
+
+    beforeEach(() => {
+      vi.stubGlobal("fetch", mockFetch);
+      httpMockState.fireCallback = true;
+      httpMockState.code = "auth-code";
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("uses serverUrl option when provided", async () => {
+      mockedExists.mockReturnValue(false);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token: "jwt",
+          user: { id: "u1", email: "u@example.com" },
+        }),
+      });
+
+      const service = AuthService.getInstance();
+      await service.login({ serverUrl: "https://option.example.com" });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://option.example.com/api/auth/exchange",
+        expect.any(Object),
+      );
+    });
+
+    it("serverUrl option takes priority over setServerUrl", async () => {
+      mockedExists.mockReturnValue(false);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token: "jwt",
+          user: { id: "u1", email: "u@example.com" },
+        }),
+      });
+
+      const service = AuthService.getInstance();
+      service.setServerUrl("https://set.example.com");
+      await service.login({ serverUrl: "https://login-option.example.com" });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://login-option.example.com/api/auth/exchange",
+        expect.any(Object),
+      );
+    });
+
+    it("serverUrl option takes priority over env var", async () => {
+      process.env.WAVE_SERVER_URL = "https://env.example.com";
+      mockedExists.mockReturnValue(false);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token: "jwt",
+          user: { id: "u1", email: "u@example.com" },
+        }),
+      });
+
+      const service = AuthService.getInstance();
+      await service.login({ serverUrl: "https://option.example.com" });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://option.example.com/api/auth/exchange",
+        expect.any(Object),
+      );
+    });
+
+    it("falls back to setServerUrl when option not provided", async () => {
+      mockedExists.mockReturnValue(false);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token: "jwt",
+          user: { id: "u1", email: "u@example.com" },
+        }),
+      });
+
+      const service = AuthService.getInstance();
+      service.setServerUrl("https://set.example.com");
+      await service.login();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://set.example.com/api/auth/exchange",
+        expect.any(Object),
+      );
+    });
+
+    it("succeeds with setServerUrl even without env var", async () => {
+      // No WAVE_SERVER_URL set
+      mockedExists.mockReturnValue(false);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token: "jwt-no-env",
+          user: { id: "u1", email: "u@example.com" },
+        }),
+      });
+
+      const service = AuthService.getInstance();
+      service.setServerUrl("https://no-env.example.com");
+      const token = await service.login();
+
+      expect(token).toBe("jwt-no-env");
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://no-env.example.com/api/auth/exchange",
+        expect.any(Object),
+      );
+    });
   });
 
   describe("login (callback flow)", () => {

--- a/packages/code/src/components/LoginCommand.tsx
+++ b/packages/code/src/components/LoginCommand.tsx
@@ -111,7 +111,12 @@ export const LoginCommand: React.FC<LoginCommandProps> = ({ onCancel }) => {
 
   const isAuthenticated = authService.isSSOAuthenticated();
   const token = authService.getSSOToken();
-  const serverUrl = process.env.WAVE_SERVER_URL;
+  let serverUrl: string | undefined;
+  try {
+    serverUrl = authService.getServerUrl();
+  } catch {
+    // serverUrl not configured, skip display
+  }
 
   const truncatedToken =
     token && token.length > 14

--- a/packages/code/tests/components/LoginCommand.test.tsx
+++ b/packages/code/tests/components/LoginCommand.test.tsx
@@ -8,6 +8,7 @@ const { mockAuthService } = vi.hoisted(() => ({
   mockAuthService: {
     isSSOAuthenticated: vi.fn<() => boolean>(() => false),
     getSSOToken: vi.fn<() => string | undefined>(() => undefined),
+    getServerUrl: vi.fn<() => string | undefined>(() => undefined),
     clearAuth: vi.fn<() => void>(),
     login: vi.fn(),
   },
@@ -22,6 +23,7 @@ describe("LoginCommand", () => {
     vi.clearAllMocks();
     mockAuthService.isSSOAuthenticated.mockReturnValue(false);
     mockAuthService.getSSOToken.mockReturnValue(undefined);
+    mockAuthService.getServerUrl.mockReturnValue(undefined);
     mockAuthService.login.mockReset();
   });
 
@@ -55,17 +57,15 @@ describe("LoginCommand", () => {
     expect(lastFrame()).toContain("Press Enter to logout");
   });
 
-  it("should show server URL when WAVE_SERVER_URL is set", () => {
+  it("should show server URL when getServerUrl returns a value", () => {
     mockAuthService.isSSOAuthenticated.mockReturnValue(true);
     mockAuthService.getSSOToken.mockReturnValue("short-token");
-    process.env.WAVE_SERVER_URL = "https://server.example.com";
+    mockAuthService.getServerUrl.mockReturnValue("https://server.example.com");
 
     const { lastFrame } = render(<LoginCommand onCancel={vi.fn()} />);
 
     expect(lastFrame()).toContain("Server URL:");
     expect(lastFrame()).toContain("https://server.example.com");
-
-    delete process.env.WAVE_SERVER_URL;
   });
 
   it("should call clearAuth when Enter is pressed while authenticated", async () => {


### PR DESCRIPTION
AuthService.login() now accepts optional serverUrl param with priority:
login({serverUrl}) → authService.setServerUrl() → WAVE_SERVER_URL env var

Fixes SSO login failing when only AgentOptions.serverUrl is set without the WAVE_SERVER_URL environment variable.

## Changes

- Add AuthService.setServerUrl() method for programmatic URL config
- Modify getServerUrl() to check _serverUrl before env var fallback
- Add serverUrl option to login() params
- Wire up setServerUrl in containerSetup.ts from AgentOptions
- Update LoginCommand to use authService.getServerUrl()
- Add 9 new test cases for priority resolution