### PR TITLE
fix: MCP server auto-reconnect after SSO login and SSE disconnect

### DIFF
--- a/packages/agent-sdk/src/managers/mcpManager.ts
+++ b/packages/agent-sdk/src/managers/mcpManager.ts
@@ -184,6 +184,8 @@ export class McpManager {
   private mcpServers: Record<string, McpServerConfig> | undefined;
 
   private resolverCtx: McpResolverContext | undefined;
+  private reconnectTimers: Map<string, NodeJS.Timeout> = new Map();
+  private reconnectAttempts: Map<string, number> = new Map();
 
   constructor(
     private container: Container,
@@ -560,6 +562,10 @@ export class McpManager {
           tools: [],
           toolCount: 0,
         });
+        // Auto-reconnect with exponential backoff (not triggered by explicit disconnect)
+        if (!this.reconnectTimers.has(name)) {
+          this.scheduleReconnect(name);
+        }
       };
 
       // Store connection
@@ -591,7 +597,53 @@ export class McpManager {
     }
   }
 
+  /**
+   * Schedule auto-reconnect with exponential backoff.
+   * Delays: 1s, 2s, 4s, 8s, 16s, 30s, 30s, ...
+   */
+  private scheduleReconnect(name: string): void {
+    const attempts = this.reconnectAttempts.get(name) ?? 0;
+    const delay = Math.min(1000 * Math.pow(2, attempts), 30000);
+    this.reconnectAttempts.set(name, attempts + 1);
+
+    logger?.info(
+      `Scheduling MCP server ${name} reconnect in ${delay}ms (attempt ${attempts + 1})`,
+    );
+
+    const timer = setTimeout(() => {
+      this.reconnectTimers.delete(name);
+      logger?.debug(`Auto-reconnecting MCP server: ${name}`);
+      this.connectServer(name)
+        .then((success) => {
+          if (success) {
+            logger?.info(`Auto-reconnected MCP server: ${name}`);
+            this.reconnectAttempts.delete(name);
+          } else {
+            logger?.warn(`Auto-reconnect failed for MCP server: ${name}`);
+            // Will be retried via onclose handler
+          }
+        })
+        .catch((error) => {
+          logger?.error(`Auto-reconnect error for MCP server ${name}:`, error);
+        });
+    }, delay);
+
+    this.reconnectTimers.set(name, timer);
+  }
+
+  private cancelReconnect(name: string): void {
+    const timer = this.reconnectTimers.get(name);
+    if (timer) {
+      clearTimeout(timer);
+      this.reconnectTimers.delete(name);
+    }
+    this.reconnectAttempts.delete(name);
+  }
+
   async disconnectServer(name: string): Promise<boolean> {
+    // Cancel any pending reconnect attempts
+    this.cancelReconnect(name);
+
     const connection = this.connections.get(name);
     if (!connection) return false;
 
@@ -755,6 +807,10 @@ export class McpManager {
 
   // Cleanup all connections
   async cleanup(): Promise<void> {
+    // Cancel all pending reconnect timers
+    for (const name of this.reconnectTimers.keys()) {
+      this.cancelReconnect(name);
+    }
     const disconnectPromises = Array.from(this.connections.keys()).map((name) =>
       this.disconnectServer(name),
     );

--- a/packages/agent-sdk/src/managers/mcpManager.ts
+++ b/packages/agent-sdk/src/managers/mcpManager.ts
@@ -353,9 +353,15 @@ export class McpManager {
       return false;
     }
 
+    // Resolve template variables before storing
+    const resolvedConfig = resolveMcpTemplates(
+      config,
+      this.resolverCtx ?? { serverUrl: undefined, ssoToken: undefined },
+    );
+
     const newServer: McpServerStatus = {
       name,
-      config,
+      config: resolvedConfig,
       status: "disconnected",
     };
 
@@ -363,10 +369,10 @@ export class McpManager {
 
     // Update config
     if (this.config) {
-      this.config.mcpServers[name] = config;
+      this.config.mcpServers[name] = resolvedConfig;
     } else {
       this.config = {
-        mcpServers: { [name]: config },
+        mcpServers: { [name]: resolvedConfig },
       };
     }
 
@@ -753,6 +759,82 @@ export class McpManager {
       this.disconnectServer(name),
     );
     await Promise.all(disconnectPromises);
+  }
+
+  /**
+   * Update credentials and reconnect MCP servers that use template variables.
+   * Called after SSO login to refresh ${WAVE_SSO_TOKEN} and ${WAVE_SERVER_URL}.
+   */
+  async refreshCredentials(
+    serverUrl?: string,
+    ssoToken?: string,
+  ): Promise<void> {
+    // Update resolver context
+    this.resolverCtx = {
+      serverUrl: serverUrl ?? this.resolverCtx?.serverUrl,
+      ssoToken: ssoToken ?? this.resolverCtx?.ssoToken,
+    };
+
+    logger?.info(
+      `MCP refreshCredentials: serverUrl=${serverUrl}, hasToken=${!!ssoToken}`,
+    );
+
+    // Collect servers that need reconnection
+    const serversToReconnect: string[] = [];
+
+    for (const [name, server] of this.servers) {
+      // Re-resolve config with new credentials
+      const originalConfig = server.config;
+      const resolvedConfig = resolveMcpTemplates(
+        originalConfig,
+        this.resolverCtx,
+      );
+
+      // Update the stored config
+      this.servers.set(name, {
+        ...server,
+        config: resolvedConfig,
+      });
+
+      if (this.config && this.config.mcpServers[name]) {
+        this.config.mcpServers[name] = resolvedConfig;
+      }
+
+      // Determine if reconnection is needed
+      const wasConnected = this.connections.has(name);
+      const wasDisconnected =
+        server.status === "disconnected" || server.status === "error";
+
+      if (wasConnected) {
+        // Disconnect first, then reconnect with new resolved config
+        await this.disconnectServer(name);
+        serversToReconnect.push(name);
+      } else if (wasDisconnected) {
+        // Was disconnected or errored — try to reconnect now that we have credentials
+        serversToReconnect.push(name);
+      }
+    }
+
+    // Reconnect servers
+    for (const name of serversToReconnect) {
+      logger?.debug(
+        `Reconnecting MCP server after credential refresh: ${name}`,
+      );
+      this.connectServer(name)
+        .then((success) => {
+          if (success) {
+            logger?.info(`Successfully reconnected MCP server: ${name}`);
+          } else {
+            logger?.warn(`Failed to reconnect MCP server: ${name}`);
+          }
+        })
+        .catch((error) => {
+          logger?.error(`Reconnection to MCP server ${name} failed:`, error);
+        });
+    }
+
+    // Trigger state change callback
+    this.callbacks.onMcpServersChange?.(this.getAllServers());
   }
 
   // ========== Tools Registry Methods ==========

--- a/packages/agent-sdk/src/services/authService.ts
+++ b/packages/agent-sdk/src/services/authService.ts
@@ -26,6 +26,8 @@ const execFileAsync = promisify(execFile);
 export class AuthService {
   private static instance: AuthService;
   private _serverUrl: string | undefined;
+  private onAuthChangeCallbacks: Array<(event: "login" | "logout") => void> =
+    [];
 
   static getInstance(): AuthService {
     if (!AuthService.instance) {
@@ -40,6 +42,29 @@ export class AuthService {
    */
   setServerUrl(url: string): void {
     this._serverUrl = url;
+  }
+
+  /**
+   * Register a callback for auth state changes.
+   * Returns an unsubscribe function.
+   */
+  onAuthChange(callback: (event: "login" | "logout") => void): () => void {
+    this.onAuthChangeCallbacks.push(callback);
+    return () => {
+      this.onAuthChangeCallbacks = this.onAuthChangeCallbacks.filter(
+        (cb) => cb !== callback,
+      );
+    };
+  }
+
+  private notifyAuthChange(event: "login" | "logout"): void {
+    for (const cb of this.onAuthChangeCallbacks) {
+      try {
+        cb(event);
+      } catch {
+        // Don't let callback errors break auth flow
+      }
+    }
   }
 
   getAuthPath(): string {
@@ -81,6 +106,7 @@ export class AuthService {
     } else {
       this.saveAuth(config);
     }
+    this.notifyAuthChange("logout");
   }
 
   getSSOToken(): string | undefined {
@@ -120,6 +146,8 @@ export class AuthService {
     // Save the token and user info (preserve existing keys)
     const existing = this.loadAuth();
     this.saveAuth({ ...existing, SSO_TOKEN: token, user });
+
+    this.notifyAuthChange("login");
 
     return token;
   }

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -161,6 +161,15 @@ export function setupAgentContainer(
   });
   container.register("McpManager", mcpManager);
 
+  // Wire up auth change callback to reconnect MCP servers after SSO login
+  authService.onAuthChange((event) => {
+    if (event === "login") {
+      const newServerUrl = options.serverUrl || process.env.WAVE_SERVER_URL;
+      const newToken = authService.getSSOToken();
+      mcpManager.refreshCredentials(newServerUrl, newToken);
+    }
+  });
+
   const lspManager = options.lspManager || new LspManager(container);
   container.register("LspManager", lspManager);
 


### PR DESCRIPTION
## Changes

1. **feat: reconnect MCP servers after SSO login** (e5bc0157)
   - Added `onAuthChange` callback system to `AuthService` to notify listeners of login/logout events
   - Added `refreshCredentials()` method to `McpManager` that re-resolves ${WAVE_SSO_TOKEN} and ${WAVE_SERVER_URL} templates and reconnects affected servers
   - Wired up auth change callback in `containerSetup.ts` so MCP servers auto-reconnect after user logs in via SSO

2. **fix: add SSE auto-reconnect with exponential backoff for MCP servers** (28a2416b)
   - The MCP SDK's SSE transport does not auto-reconnect when the connection is terminated by the server or proxy
   - Added exponential backoff auto-reconnect (1s → 2s → 4s → ... → 30s cap) in `transport.onclose`
   - Proper cleanup: cancels pending reconnect timers on explicit disconnect and agent shutdown

## Problem
- MCP servers using ${WAVE_SSO_TOKEN} templates remained broken after user logged in via SSO because credentials were captured once at startup
- SSE connections would permanently disconnect with `TypeError: terminated` when the server or proxy closed the stream