### PR TITLE
fix: remove validateModelConfig to make model/fastModel fully optional

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -456,13 +456,11 @@ export class Agent {
   private resolveAndValidateConfig(): void {
     // Resolve configuration from constructor args and environment variables (including settings.json)
     const gatewayConfig = this.getGatewayConfig();
-    const modelConfig = this.getModelConfig();
     const maxInputTokens = this.getMaxInputTokens();
 
     // Validate resolved configuration
     configValidator.validateGatewayConfig(gatewayConfig);
     configValidator.validateMaxInputTokens(maxInputTokens);
-    configValidator.validateModelConfig(modelConfig);
   }
 
   /** Private initialization method, handles async initialization logic */

--- a/packages/agent-sdk/src/utils/configValidator.ts
+++ b/packages/agent-sdk/src/utils/configValidator.ts
@@ -5,7 +5,6 @@
 
 import {
   GatewayConfig,
-  ModelConfig,
   ConfigurationError,
   CONFIG_ERRORS,
 } from "../types/index.js";
@@ -89,34 +88,6 @@ export class ConfigValidator {
       );
     }
   }
-
-  /**
-   * Validates model configuration (basic validation)
-   * @param config - Model configuration object
-   * @throws ConfigurationError if invalid
-   */
-  static validateModelConfig(config: ModelConfig): void {
-    const { model, fastModel } = config;
-    if (!model || typeof model !== "string" || model.trim() === "") {
-      throw new ConfigurationError(
-        "Agent model must be a non-empty string.",
-        "model",
-        model,
-      );
-    }
-
-    if (
-      !fastModel ||
-      typeof fastModel !== "string" ||
-      fastModel.trim() === ""
-    ) {
-      throw new ConfigurationError(
-        "Fast model must be a non-empty string.",
-        "fastModel",
-        fastModel,
-      );
-    }
-  }
 }
 
 /**
@@ -126,6 +97,4 @@ export class ConfigValidator {
 export const configValidator = {
   validateGatewayConfig: ConfigValidator.validateGatewayConfig,
   validateMaxInputTokens: ConfigValidator.validateMaxInputTokens,
-  validateModelConfig: (config: ModelConfig) =>
-    ConfigValidator.validateModelConfig(config),
 };


### PR DESCRIPTION
Remove `ConfigValidator.validateModelConfig()` which required model and fastModel to be non-empty strings, making them fully optional configuration.

Also removed the unused `modelConfig` variable assignment in `Agent.resolveAndValidateConfig()`.