### PR TITLE
fix(mcp): store originalUrl to prevent sensitive URL exposure in UI

### DIFF
--- a/packages/agent-sdk/src/managers/mcpManager.ts
+++ b/packages/agent-sdk/src/managers/mcpManager.ts
@@ -44,7 +44,11 @@ export interface McpManagerOptions {
  * Expand environment variables in a string value.
  * Supports ${VAR} and ${VAR:-default} patterns.
  */
-const WAVE_TEMPLATE_VARS = ["WAVE_SERVER_URL", "WAVE_SSO_TOKEN"];
+const WAVE_TEMPLATE_VARS = [
+  "WAVE_SERVER_URL",
+  "WAVE_SSO_TOKEN",
+  "WAVE_PLUGIN_ROOT",
+];
 
 export function expandEnvVars(value: string): string {
   return value.replace(/\$\{([^}]+)\}/g, (_match, expr: string) => {
@@ -268,10 +272,14 @@ export class McpManager {
 
     try {
       const configContent = await fs.readFile(this.configPath, "utf-8");
-      const workspaceConfig = resolveMcpConfig(
-        JSON.parse(configContent),
-        this.resolverCtx,
-      );
+      const rawConfig: McpConfig = JSON.parse(configContent);
+      const workspaceConfig = resolveMcpConfig(rawConfig, this.resolverCtx);
+
+      // Extract original (pre-resolution) URLs for safe display
+      const originalUrls: Record<string, string | undefined> = {};
+      for (const [name, serverConfig] of Object.entries(rawConfig.mcpServers)) {
+        originalUrls[name] = serverConfig.url;
+      }
 
       // Merge workspace config with any existing config (e.g., from plugins or constructor)
       // Constructor-provided servers take precedence, then workspace config, then existing config
@@ -296,12 +304,14 @@ export class McpManager {
             this.servers.set(name, {
               ...existingServer,
               config, // Update config in case it changed
+              originalUrl: originalUrls[name] ?? existingServer.originalUrl,
             });
           } else {
             // New server, initialize with disconnected status
             this.servers.set(name, {
               name,
               config,
+              originalUrl: originalUrls[name],
               status: "disconnected",
             });
           }
@@ -355,15 +365,45 @@ export class McpManager {
       return false;
     }
 
-    // Resolve template variables before storing
-    const resolvedConfig = resolveMcpTemplates(
-      config,
+    // Capture original URL before any resolution for safe display
+    const originalUrl = config.url;
+
+    // Step 1: expand env vars from process.env (e.g. ${TAVILY_API_KEY})
+    let resolvedConfig: McpServerConfig = { ...config };
+    if (resolvedConfig.command) {
+      resolvedConfig.command = expandEnvVars(resolvedConfig.command);
+    }
+    if (resolvedConfig.args) {
+      resolvedConfig.args = resolvedConfig.args.map(expandEnvVars);
+    }
+    if (resolvedConfig.env) {
+      const resolvedEnv: Record<string, string> = {};
+      for (const [key, val] of Object.entries(resolvedConfig.env)) {
+        resolvedEnv[key] = expandEnvVars(val);
+      }
+      resolvedConfig.env = resolvedEnv;
+    }
+    if (resolvedConfig.url) {
+      resolvedConfig.url = expandEnvVars(resolvedConfig.url);
+    }
+    if (resolvedConfig.headers) {
+      const resolvedHeaders: Record<string, string> = {};
+      for (const [key, val] of Object.entries(resolvedConfig.headers)) {
+        resolvedHeaders[key] = expandEnvVars(val);
+      }
+      resolvedConfig.headers = resolvedHeaders;
+    }
+
+    // Step 2: resolve Wave template variables (e.g. ${WAVE_SERVER_URL}, ${WAVE_SSO_TOKEN})
+    resolvedConfig = resolveMcpTemplates(
+      resolvedConfig,
       this.resolverCtx ?? { serverUrl: undefined, ssoToken: undefined },
     );
 
     const newServer: McpServerStatus = {
       name,
       config: resolvedConfig,
+      originalUrl,
       status: "disconnected",
     };
 
@@ -846,7 +886,7 @@ export class McpManager {
         this.resolverCtx,
       );
 
-      // Update the stored config
+      // Update the stored config, preserving originalUrl
       this.servers.set(name, {
         ...server,
         config: resolvedConfig,

--- a/packages/agent-sdk/src/services/pluginLoader.ts
+++ b/packages/agent-sdk/src/services/pluginLoader.ts
@@ -14,7 +14,6 @@ import {
   parseAgentFile,
   type SubagentConfiguration,
 } from "../utils/subagentParser.js";
-import { resolveMcpConfig } from "../managers/mcpManager.js";
 import { logger } from "../utils/globalLogger.js";
 
 export class PluginLoader {
@@ -143,7 +142,8 @@ export class PluginLoader {
     const mcpPath = path.join(pluginPath, ".mcp.json");
     try {
       const content = await fs.readFile(mcpPath, "utf-8");
-      return resolveMcpConfig(JSON.parse(content)) as McpConfig;
+      // Return raw config — let McpManager resolve templates and capture originalUrl
+      return JSON.parse(content) as McpConfig;
     } catch {
       return undefined;
     }

--- a/packages/agent-sdk/src/types/mcp.ts
+++ b/packages/agent-sdk/src/types/mcp.ts
@@ -26,6 +26,8 @@ export interface McpTool {
 export interface McpServerStatus {
   name: string;
   config: McpServerConfig;
+  /** Pre-resolution URL with template variables (e.g. ${WAVE_SSO_TOKEN}) preserved for safe display */
+  originalUrl?: string;
   status: "disconnected" | "connected" | "connecting" | "error";
   tools?: McpTool[];
   toolCount?: number;

--- a/packages/agent-sdk/tests/services/pluginLoader.test.ts
+++ b/packages/agent-sdk/tests/services/pluginLoader.test.ts
@@ -6,32 +6,12 @@ import { scanCommandsDirectory } from "../../src/utils/customCommands.js";
 import { CustomSlashCommand } from "../../src/types/index.js";
 import { parseSkillFile } from "../../src/utils/skillParser.js";
 import { parseAgentFile } from "../../src/utils/subagentParser.js";
-import { resolveMcpConfig } from "../../src/managers/mcpManager.js";
 
 vi.mock("fs/promises");
 vi.mock("path");
 vi.mock("../../src/utils/customCommands.js");
 vi.mock("../../src/utils/skillParser.js");
 vi.mock("../../src/utils/subagentParser.js");
-vi.mock("../../src/managers/mcpManager.js", () => ({
-  resolveMcpConfig: vi.fn((config) => {
-    // Simulate env var expansion for headers
-    const result = JSON.parse(JSON.stringify(config));
-    for (const server of Object.values(result.mcpServers) as Array<{
-      headers?: Record<string, string>;
-    }>) {
-      if (server.headers) {
-        for (const [key, value] of Object.entries(server.headers)) {
-          server.headers[key] = value.replace(
-            /\$\{([^}]+)\}/g,
-            (_match, varName) => process.env[varName] ?? "",
-          );
-        }
-      }
-    }
-    return result;
-  }),
-}));
 
 describe("PluginLoader", () => {
   const mockPluginPath = "/mock/plugin/path";
@@ -287,7 +267,6 @@ describe("PluginLoader", () => {
       const result = await PluginLoader.loadMcpConfig(mockPluginPath);
 
       expect(result).toEqual(mockConfig);
-      expect(resolveMcpConfig).toHaveBeenCalledWith(mockConfig);
     });
 
     it("should return undefined if .mcp.json does not exist", async () => {
@@ -298,7 +277,7 @@ describe("PluginLoader", () => {
       expect(result).toBeUndefined();
     });
 
-    it("should resolve environment variables in MCP config", async () => {
+    it("should return raw config without resolving variables", async () => {
       const mockConfig = {
         mcpServers: {
           tavily: {
@@ -311,15 +290,13 @@ describe("PluginLoader", () => {
       };
       vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(mockConfig));
 
-      // Set env var so mock resolver can pick it up
+      // Set env var — loadMcpConfig should NOT resolve it
       process.env.TAVILY_API_KEY = "test-api-key-123";
 
       const result = await PluginLoader.loadMcpConfig(mockPluginPath);
 
-      expect(resolveMcpConfig).toHaveBeenCalledWith(mockConfig);
-      expect(result?.mcpServers?.tavily?.headers?.Authorization).toBe(
-        "Bearer test-api-key-123",
-      );
+      // Returns raw config — resolution happens in McpManager
+      expect(result).toEqual(mockConfig);
 
       delete process.env.TAVILY_API_KEY;
     });

--- a/packages/code/src/components/McpManager.tsx
+++ b/packages/code/src/components/McpManager.tsx
@@ -127,6 +127,13 @@ export const McpManager: React.FC<McpManagerProps> = ({
               <Text color="blue">Command:</Text> {selectedServer.config.command}
             </Text>
           </Box>
+          {selectedServer.originalUrl && (
+            <Box>
+              <Text>
+                <Text color="blue">URL:</Text> {selectedServer.originalUrl}
+              </Text>
+            </Box>
+          )}
           {selectedServer.config.args && (
             <Box>
               <Text>
@@ -259,10 +266,16 @@ export const McpManager: React.FC<McpManagerProps> = ({
           </Text>
           {index === state.selectedIndex && (
             <Box marginLeft={4} flexDirection="column">
-              <Text color="gray" dimColor>
-                {server.config.command}
-                {server.config.args ? ` ${server.config.args.join(" ")}` : ""}
-              </Text>
+              {server.config.command ? (
+                <Text color="gray" dimColor>
+                  {server.config.command}
+                  {server.config.args ? ` ${server.config.args.join(" ")}` : ""}
+                </Text>
+              ) : server.originalUrl ? (
+                <Text color="gray" dimColor>
+                  {server.originalUrl}
+                </Text>
+              ) : null}
               {server.lastConnected && (
                 <Text color="gray" dimColor>
                   Last connected: {formatTime(server.lastConnected)}


### PR DESCRIPTION
McpServerStatus.config.url was storing fully resolved URLs where template variables like `${WAVE_SSO_TOKEN}` and `${TAVILY_API_KEY}` were replaced with actual values, causing API keys to leak in the MCP manager UI.

## Changes

- Add `originalUrl` field to `McpServerStatus` type for pre-resolution URL
- `PluginLoader.loadMcpConfig()` now returns raw config (no `resolveMcpConfig`) so resolution happens in `McpManager` where `originalUrl` can be captured
- `McpManager.addServer()` captures `originalUrl` before `expandEnvVars()` and `resolveMcpTemplates()` run
- `McpManager.loadConfig()` extracts original URLs from raw JSON
- UI displays `originalUrl` instead of resolved `config.url`
- Add `WAVE_PLUGIN_ROOT` to `WAVE_TEMPLATE_VARS` to prevent premature expansion

## Verification

- All 2757 tests pass
- Type checks pass
- MCP manager UI shows `${TAVILY_API_KEY}` instead of resolved API key