### PR TITLE
feat: add anonymous ID fallback for telemetry when SSO not authenticated

### DIFF
--- a/packages/agent-sdk/src/services/authService.ts
+++ b/packages/agent-sdk/src/services/authService.ts
@@ -15,11 +15,15 @@ import {
 } from "fs";
 import * as path from "path";
 import * as os from "os";
+import { randomBytes } from "crypto";
 import { createServer, Server } from "http";
 import { URL } from "url";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import type { AuthConfig, AuthUser } from "../types/auth.js";
+
+/** Persistent anonymous ID for telemetry fallback when SSO is not authenticated. */
+let _anonymousId: string | undefined;
 
 const execFileAsync = promisify(execFile);
 
@@ -312,3 +316,55 @@ export class AuthService {
 }
 
 export const authService = AuthService.getInstance();
+
+/**
+ * Get or create a persistent anonymous ID for telemetry.
+ *
+ * Stored in ~/.wave/config.json as { anonymousId: "..." }.
+ * Generated once on first run (32-byte random hex) and reused thereafter.
+ * Falls back to an in-memory ID if file I/O fails.
+ */
+export function getOrCreateAnonymousId(): string {
+  if (_anonymousId) return _anonymousId;
+
+  try {
+    const configPath = path.join(os.homedir(), ".wave", "config.json");
+    if (existsSync(configPath)) {
+      const content = readFileSync(configPath, "utf-8");
+      const config = JSON.parse(content) as { anonymousId?: string };
+      if (config.anonymousId) {
+        _anonymousId = config.anonymousId;
+        return _anonymousId;
+      }
+    }
+
+    // Generate and persist
+    _anonymousId = randomBytes(32).toString("hex");
+    const waveDir = path.dirname(configPath);
+    if (!existsSync(waveDir)) {
+      mkdirSync(waveDir, { recursive: true });
+    }
+    const existing = existsSync(configPath)
+      ? (JSON.parse(readFileSync(configPath, "utf-8")) as Record<
+          string,
+          unknown
+        >)
+      : {};
+    writeFileSync(
+      configPath,
+      JSON.stringify({ ...existing, anonymousId: _anonymousId }, null, 2),
+      "utf-8",
+    );
+    chmodSync(configPath, 0o600);
+  } catch {
+    // File I/O failed — use in-memory fallback
+    _anonymousId = randomBytes(32).toString("hex");
+  }
+
+  return _anonymousId;
+}
+
+/** @internal — reset anonymous ID cache for testing only */
+export function __resetAnonymousIdForTesting(): void {
+  _anonymousId = undefined;
+}

--- a/packages/agent-sdk/src/telemetry/instrumentation.ts
+++ b/packages/agent-sdk/src/telemetry/instrumentation.ts
@@ -18,7 +18,10 @@ import type {
   LogRecordExporter,
   ReadableLogRecord,
 } from "@opentelemetry/sdk-logs";
-import { AuthService } from "../services/authService.js";
+import {
+  AuthService,
+  getOrCreateAnonymousId,
+} from "../services/authService.js";
 
 // Lazy-loaded OTEL modules — only imported when telemetry is initialized
 let sdkNode: typeof import("@opentelemetry/sdk-node") | undefined;
@@ -471,8 +474,11 @@ export function isInitialized(): boolean {
 export { JsonlSpanExporter, JsonlLogExporter };
 
 /**
- * Get telemetry attributes based on the authenticated SSO user.
- * Returns user.id and user.email when SSO authenticated, empty object otherwise.
+ * Get telemetry attributes for the current session.
+ *
+ * Priority:
+ * 1. SSO authenticated → server-provided user.id + user.email
+ * 2. Not authenticated → persistent anonymous ID from ~/.wave/config.json
  */
 export function getTelemetryAttributes(): Record<string, string> {
   try {
@@ -487,5 +493,7 @@ export function getTelemetryAttributes(): Record<string, string> {
   } catch {
     // AuthService not available or not authenticated
   }
-  return {};
+
+  // Fallback to anonymous ID
+  return { "user.id": getOrCreateAnonymousId() };
 }

--- a/packages/agent-sdk/tests/services/authService.test.ts
+++ b/packages/agent-sdk/tests/services/authService.test.ts
@@ -84,7 +84,11 @@ function resetServiceInstance() {
 }
 
 // Import after mocks are set up
-import { AuthService } from "../../src/services/authService.js";
+import {
+  AuthService,
+  getOrCreateAnonymousId,
+  __resetAnonymousIdForTesting,
+} from "../../src/services/authService.js";
 
 describe("AuthService", () => {
   beforeEach(() => {
@@ -637,6 +641,92 @@ describe("AuthService", () => {
       const s1 = AuthService.getInstance();
       const s2 = AuthService.getInstance();
       expect(s1).toBe(s2);
+    });
+  });
+
+  describe("getOrCreateAnonymousId", () => {
+    beforeEach(() => {
+      __resetAnonymousIdForTesting();
+      vi.resetAllMocks();
+    });
+
+    it("reads anonymousId from existing config.json", () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({ anonymousId: "persisted-id-123" }),
+      );
+
+      const id = getOrCreateAnonymousId();
+      expect(id).toBe("persisted-id-123");
+      expect(mockedReadFile).toHaveBeenCalledWith(
+        expect.stringContaining("config.json"),
+        "utf-8",
+      );
+    });
+
+    it("generates and persists anonymousId when config.json does not exist", () => {
+      mockedExists.mockReturnValue(false);
+
+      const id = getOrCreateAnonymousId();
+
+      expect(id).toHaveLength(64); // 32 bytes hex = 64 chars
+      expect(mockedMkdir).toHaveBeenCalledWith(
+        expect.stringContaining(".wave"),
+        { recursive: true },
+      );
+      expect(mockedWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining("config.json"),
+        expect.stringContaining('"anonymousId"'),
+        "utf-8",
+      );
+      expect(mockedChmod).toHaveBeenCalledWith(
+        expect.stringContaining("config.json"),
+        0o600,
+      );
+    });
+
+    it("preserves existing config fields when writing anonymousId", () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({ someSetting: true, theme: "dark" }),
+      );
+
+      const id = getOrCreateAnonymousId();
+
+      expect(id).toHaveLength(64);
+      const written = mockedWriteFile.mock.calls.find((c) =>
+        (c[1] as string)?.includes("anonymousId"),
+      )?.[1] as string;
+      expect(written).toContain("someSetting");
+      expect(written).toContain("anonymousId");
+    });
+
+    it("generates anonymousId when config exists but has no anonymousId field", () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(JSON.stringify({ otherKey: "value" }));
+
+      const id = getOrCreateAnonymousId();
+      expect(id).toHaveLength(64);
+    });
+
+    it("returns same ID on repeated calls (caching)", () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({ anonymousId: "cached-id" }),
+      );
+
+      const id1 = getOrCreateAnonymousId();
+      const id2 = getOrCreateAnonymousId();
+      expect(id1).toBe(id2);
+    });
+
+    it("falls back to in-memory ID when file I/O fails", () => {
+      mockedExists.mockImplementation(() => {
+        throw new Error("I/O error");
+      });
+
+      const id = getOrCreateAnonymousId();
+      expect(id).toHaveLength(64);
     });
   });
 });

--- a/packages/agent-sdk/tests/telemetry/telemetryAttributes.test.ts
+++ b/packages/agent-sdk/tests/telemetry/telemetryAttributes.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for getTelemetryAttributes — user identity resolution for OTEL.
+ *
+ * Covers SSO authenticated → server user.id, fallback → anonymous ID.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetAuthUser = vi.fn().mockReturnValue(undefined);
+const mockGetOrCreateAnonymousId = vi.fn().mockReturnValue("anon-id-fallback");
+
+vi.mock("../../src/services/authService.js", () => ({
+  AuthService: {
+    getInstance: () => ({ getAuthUser: mockGetAuthUser }),
+  },
+  getOrCreateAnonymousId: () => mockGetOrCreateAnonymousId(),
+  __resetAnonymousIdForTesting: vi.fn(),
+}));
+
+vi.mock("@/utils/globalLogger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { getTelemetryAttributes } from "../../src/telemetry/instrumentation.js";
+
+describe("getTelemetryAttributes", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockGetAuthUser.mockReturnValue(undefined);
+    mockGetOrCreateAnonymousId.mockReturnValue("anon-id-fallback");
+  });
+
+  it("returns user.id and user.email when SSO authenticated", () => {
+    mockGetAuthUser.mockReturnValue({
+      id: "auth-user-id",
+      email: "user@example.com",
+    });
+
+    const attrs = getTelemetryAttributes();
+    expect(attrs).toEqual({
+      "user.id": "auth-user-id",
+      "user.email": "user@example.com",
+    });
+    expect(mockGetOrCreateAnonymousId).not.toHaveBeenCalled();
+  });
+
+  it("returns only user.id when email is absent", () => {
+    mockGetAuthUser.mockReturnValue({
+      id: "auth-user-id",
+    });
+
+    const attrs = getTelemetryAttributes();
+    expect(attrs).toEqual({ "user.id": "auth-user-id" });
+    expect(mockGetOrCreateAnonymousId).not.toHaveBeenCalled();
+  });
+
+  it("falls back to anonymousId when SSO not authenticated", () => {
+    mockGetAuthUser.mockReturnValue(undefined);
+
+    const attrs = getTelemetryAttributes();
+    expect(attrs).toEqual({ "user.id": "anon-id-fallback" });
+    expect(mockGetOrCreateAnonymousId).toHaveBeenCalled();
+  });
+
+  it("falls back to anonymousId when AuthService throws", () => {
+    mockGetAuthUser.mockImplementation(() => {
+      throw new Error("AuthService not initialized");
+    });
+
+    const attrs = getTelemetryAttributes();
+    expect(attrs).toEqual({ "user.id": "anon-id-fallback" });
+    expect(mockGetOrCreateAnonymousId).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a persistent anonymous ID fallback for OpenTelemetry `user.id` when SSO is not authenticated, enabling user-level telemetry correlation even without login.

Following Claude Code's pattern (stored in `~/.claude/.claude.json` as `userID`), Wave now generates a 32-byte random hex ID stored in `~/.wave/config.json` as `anonymousId`.

## Changes

- **`authService.ts`** — Add `getOrCreateAnonymousId()` with file I/O fallback and `__resetAnonymousIdForTesting()` for test isolation
- **`instrumentation.ts`** — Update `getTelemetryAttributes()` to return anonymous ID as fallback instead of empty object
- **Tests** — 10 new tests covering read, generate, preserve, caching, I/O fallback, SSO auth, and error fallback