### PR TITLE
feat: implement server-managed config download (remote settings)

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -51,6 +51,7 @@ import {
   shutdownTelemetry,
 } from "./telemetry/instrumentation.js";
 import { logOTelEvent } from "./telemetry/events.js";
+import { remoteSettingsService } from "./services/remoteSettingsService.js";
 
 export class Agent {
   private messageManager: MessageManager;
@@ -720,6 +721,8 @@ export class Agent {
         error,
       );
     }
+    // Cleanup remote settings polling
+    remoteSettingsService.shutdown();
     // Cleanup memory store
   }
 

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -44,6 +44,10 @@ import {
 } from "../utils/constants.js";
 import { ClientOptions } from "openai";
 import { parseCustomHeaders } from "../utils/stringUtils.js";
+import {
+  getRemoteSettingsSync,
+  mergeRemoteSettings,
+} from "./remoteSettingsService.js";
 
 /**
  * Default ConfigurationService implementation
@@ -101,19 +105,25 @@ export class ConfigurationService {
         };
       }
 
+      // Merge remote settings (highest priority: Remote > Local > Project > User)
+      const remoteSettings = getRemoteSettingsSync();
+      const finalConfig = remoteSettings
+        ? mergeRemoteSettings(mergedConfig, remoteSettings)
+        : mergedConfig;
+
       // Success case
-      this.currentConfiguration = mergedConfig;
+      this.currentConfiguration = finalConfig;
 
       // Set environment variables from merged config and inject system variables
       const env = {
-        ...(mergedConfig.env || {}),
+        ...(finalConfig.env || {}),
         WAVE_PROJECT_DIR: workdir,
       };
       this.setEnvironmentVars(env);
-      mergedConfig.env = env;
+      finalConfig.env = env;
 
       return {
-        configuration: mergedConfig,
+        configuration: finalConfig,
         success: true,
         sourcePath: "merged configuration",
         warnings: validation.warnings,

--- a/packages/agent-sdk/src/services/initializationService.ts
+++ b/packages/agent-sdk/src/services/initializationService.ts
@@ -22,6 +22,7 @@ import type { MemoryRuleManager } from "../managers/MemoryRuleManager.js";
 import type { LiveConfigManager } from "../managers/liveConfigManager.js";
 import type { TaskManager } from "./taskManager.js";
 import type { PermissionManager } from "../managers/permissionManager.js";
+import { remoteSettingsService } from "./remoteSettingsService.js";
 
 export interface InitializationContext {
   skillManager: SkillManager;
@@ -286,6 +287,18 @@ export class InitializationService {
     } catch (error) {
       logger?.error("Failed to initialize live configuration reload:", error);
       // Don't throw error to prevent app startup failure - continue without live reload
+    }
+
+    // Initialize remote settings (fetch server-managed config)
+    try {
+      const phaseStart = performance.now();
+      await remoteSettingsService.initialize();
+      logger?.debug(
+        `Initialization Phase [Remote Settings] took ${(performance.now() - phaseStart).toFixed(2)}ms`,
+      );
+    } catch (error) {
+      logger?.error("Failed to initialize remote settings:", error);
+      // Don't throw error to prevent app startup failure - continue without remote settings
     }
 
     // Memory is lazy-cached on first getCombinedMemoryContent call

--- a/packages/agent-sdk/src/services/remoteSettingsService.ts
+++ b/packages/agent-sdk/src/services/remoteSettingsService.ts
@@ -1,0 +1,313 @@
+import * as fs from "node:fs";
+import { homedir } from "node:os";
+import * as path from "node:path";
+
+import { authService } from "./authService.js";
+import type {
+  RemoteSettingsCache,
+  RemoteSettingsFetchResult,
+  RemoteSettingsResponse,
+} from "../types/configuration.js";
+import type { WaveConfiguration } from "../types/configuration.js";
+import type { HookEvent, HookEventConfig } from "../types/hooks.js";
+import { logger } from "../utils/globalLogger.js";
+
+const CACHE_FILE = path.join(homedir(), ".wave", "remote-settings.json");
+const POLLING_INTERVAL_MS = 60 * 60 * 1000; // 60 minutes
+const FETCH_TIMEOUT_MS = 10_000;
+
+let _cachedSettings: RemoteSettingsCache | null = null;
+let _pollingTimer: ReturnType<typeof setInterval> | null = null;
+
+function loadCacheFromDisk(): void {
+  try {
+    if (!fs.existsSync(CACHE_FILE)) {
+      return;
+    }
+    const raw = fs.readFileSync(CACHE_FILE, "utf-8");
+    const parsed: RemoteSettingsCache = JSON.parse(raw);
+    _cachedSettings = parsed;
+    logger.debug("remoteSettings: loaded cache from disk", {
+      checksum: parsed.checksum,
+    });
+  } catch (err) {
+    logger.debug("remoteSettings: failed to load cache from disk", { err });
+  }
+}
+
+function writeCacheToDisk(): void {
+  if (!_cachedSettings) {
+    return;
+  }
+  try {
+    const dir = path.dirname(CACHE_FILE);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(CACHE_FILE, JSON.stringify(_cachedSettings, null, 2), {
+      mode: 0o600,
+    });
+    logger.debug("remoteSettings: wrote cache to disk", {
+      checksum: _cachedSettings.checksum,
+    });
+  } catch (err) {
+    logger.debug("remoteSettings: failed to write cache to disk", { err });
+  }
+}
+
+function removeCacheFromDisk(): void {
+  try {
+    if (fs.existsSync(CACHE_FILE)) {
+      fs.unlinkSync(CACHE_FILE);
+    }
+  } catch (err) {
+    logger.debug("remoteSettings: failed to remove cache file", { err });
+  }
+}
+
+async function fetchRemoteSettings(): Promise<RemoteSettingsFetchResult> {
+  if (!authService.isSSOAuthenticated()) {
+    logger.debug("remoteSettings: skipping fetch — not SSO authenticated");
+    return { success: false, error: "Not SSO authenticated" };
+  }
+
+  const token = authService.getSSOToken();
+  const serverUrl = authService.getServerUrl();
+  if (!token || !serverUrl) {
+    return { success: false, error: "Missing SSO token or server URL" };
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+  };
+  if (_cachedSettings?.checksum) {
+    headers["If-None-Match"] = _cachedSettings.checksum;
+  }
+
+  try {
+    const response = await fetch(`${serverUrl}/api/wave/settings`, {
+      method: "GET",
+      headers,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+
+    if (response.status === 304) {
+      logger.debug("remoteSettings: 304 unchanged", {
+        checksum: _cachedSettings?.checksum,
+      });
+      return {
+        success: true,
+        settings: _cachedSettings!.settings,
+        checksum: _cachedSettings!.checksum,
+      };
+    }
+
+    if (response.status === 404) {
+      logger.debug("remoteSettings: 404 not configured — clearing stale cache");
+      _cachedSettings = null;
+      removeCacheFromDisk();
+      return { success: true, notConfigured: true, settings: null };
+    }
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      logger.debug("remoteSettings: fetch failed", {
+        status: response.status,
+        body: body.slice(0, 200),
+      });
+      return {
+        success: false,
+        error: `HTTP ${response.status}`,
+        settings: _cachedSettings?.settings ?? null,
+      };
+    }
+
+    const data = (await response.json()) as RemoteSettingsResponse;
+    _cachedSettings = {
+      uuid: data.uuid,
+      checksum: data.checksum,
+      settings: data.settings,
+      fetchedAt: new Date().toISOString(),
+    };
+    writeCacheToDisk();
+    logger.debug("remoteSettings: fetched new settings", {
+      checksum: data.checksum,
+    });
+    return {
+      success: true,
+      settings: data.settings,
+      checksum: data.checksum,
+    };
+  } catch (err) {
+    logger.debug("remoteSettings: network error, using cache", { err });
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+      settings: _cachedSettings?.settings ?? null,
+    };
+  }
+}
+
+function startPolling(): void {
+  if (_pollingTimer) {
+    return;
+  }
+  _pollingTimer = setInterval(async () => {
+    try {
+      await fetchRemoteSettings();
+    } catch (err) {
+      logger.debug("remoteSettings: polling fetch error", { err });
+    }
+  }, POLLING_INTERVAL_MS);
+  _pollingTimer.unref();
+}
+
+export function initialize(): void {
+  loadCacheFromDisk();
+  // Fire-and-forget the initial fetch, then start background polling
+  fetchRemoteSettings()
+    .then(() => startPolling())
+    .catch((err) => {
+      logger.debug("remoteSettings: initial fetch failed", { err });
+      startPolling();
+    });
+}
+
+export function getRemoteSettingsSync(): WaveConfiguration | null {
+  return _cachedSettings?.settings ?? null;
+}
+
+export async function refresh(): Promise<RemoteSettingsFetchResult> {
+  // Clear in-memory so we force a fresh fetch
+  _cachedSettings = null;
+  removeCacheFromDisk();
+  return fetchRemoteSettings();
+}
+
+export function clear(): void {
+  _cachedSettings = null;
+  removeCacheFromDisk();
+  if (_pollingTimer) {
+    clearInterval(_pollingTimer);
+    _pollingTimer = null;
+  }
+}
+
+export function shutdown(): void {
+  if (_pollingTimer) {
+    clearInterval(_pollingTimer);
+    _pollingTimer = null;
+  }
+}
+
+function dedupe(arr: string[]): string[] {
+  return [...new Set(arr)];
+}
+
+function mergeHooks(
+  local: Partial<Record<HookEvent, HookEventConfig[]>> | undefined,
+  remote: Partial<Record<HookEvent, HookEventConfig[]>> | undefined,
+): Partial<Record<HookEvent, HookEventConfig[]>> | undefined {
+  if (!remote && !local) {
+    return undefined;
+  }
+  if (!remote) {
+    return local;
+  }
+  if (!local) {
+    return remote;
+  }
+  const merged: Partial<Record<HookEvent, HookEventConfig[]>> = { ...local };
+  for (const [event, remoteHooks] of Object.entries(remote)) {
+    const localHooks = merged[event as HookEvent] ?? [];
+    // Concatenate + dedupe by JSON serialization
+    const combined = [...localHooks, ...(remoteHooks ?? [])];
+    const seen = new Set<string>();
+    merged[event as HookEvent] = combined.filter((h) => {
+      const key = JSON.stringify(h);
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    });
+  }
+  return merged;
+}
+
+export function mergeRemoteSettings(
+  localMerged: WaveConfiguration,
+  remote: WaveConfiguration,
+): WaveConfiguration {
+  const result: WaveConfiguration = { ...localMerged };
+
+  // env: merge by key, remote wins per-key
+  if (remote.env || localMerged.env) {
+    result.env = { ...localMerged.env, ...remote.env };
+  }
+
+  // permissions
+  if (remote.permissions || localMerged.permissions) {
+    const lp = localMerged.permissions ?? {};
+    const rp = remote.permissions ?? {};
+    result.permissions = {
+      // allow: concatenate + dedupe
+      allow:
+        lp.allow || rp.allow
+          ? dedupe([...(lp.allow ?? []), ...(rp.allow ?? [])])
+          : undefined,
+      // deny: concatenate + dedupe
+      deny:
+        lp.deny || rp.deny
+          ? dedupe([...(lp.deny ?? []), ...(rp.deny ?? [])])
+          : undefined,
+      // permissionMode: remote wins (scalar)
+      permissionMode: rp.permissionMode ?? lp.permissionMode,
+      // additionalDirectories: concatenate + dedupe
+      additionalDirectories:
+        lp.additionalDirectories || rp.additionalDirectories
+          ? dedupe([
+              ...(lp.additionalDirectories ?? []),
+              ...(rp.additionalDirectories ?? []),
+            ])
+          : undefined,
+    };
+    // Clean up undefined keys
+    if (!result.permissions.allow) delete result.permissions.allow;
+    if (!result.permissions.deny) delete result.permissions.deny;
+    if (!result.permissions.permissionMode)
+      delete result.permissions.permissionMode;
+    if (!result.permissions.additionalDirectories)
+      delete result.permissions.additionalDirectories;
+  }
+
+  // hooks: concatenate per-event
+  result.hooks = mergeHooks(localMerged.hooks, remote.hooks);
+
+  // Scalar / last-write-wins fields: remote wins
+  if (remote.language !== undefined) result.language = remote.language;
+  if (remote.autoMemoryEnabled !== undefined)
+    result.autoMemoryEnabled = remote.autoMemoryEnabled;
+  if (remote.autoMemoryFrequency !== undefined)
+    result.autoMemoryFrequency = remote.autoMemoryFrequency;
+  if (remote.models !== undefined) result.models = remote.models;
+  if (remote.marketplaces !== undefined)
+    result.marketplaces = remote.marketplaces;
+  if (remote.enabledPlugins !== undefined)
+    result.enabledPlugins = remote.enabledPlugins;
+
+  return result;
+}
+
+/**
+ * Singleton object for consumers that prefer a namespace-style import.
+ * Usage: import { remoteSettingsService } from "./remoteSettingsService.js"
+ */
+export const remoteSettingsService = {
+  initialize,
+  getRemoteSettingsSync,
+  refresh,
+  clear,
+  shutdown,
+  mergeRemoteSettings,
+} as const;

--- a/packages/agent-sdk/src/types/configuration.ts
+++ b/packages/agent-sdk/src/types/configuration.ts
@@ -138,3 +138,24 @@ interface Logger {
   info: (...args: unknown[]) => void;
   debug: (...args: unknown[]) => void;
 }
+
+export interface RemoteSettingsResponse {
+  uuid: string;
+  checksum: string;
+  settings: WaveConfiguration;
+}
+
+export interface RemoteSettingsCache {
+  uuid: string;
+  checksum: string;
+  settings: WaveConfiguration;
+  fetchedAt: string;
+}
+
+export interface RemoteSettingsFetchResult {
+  success: boolean;
+  settings?: WaveConfiguration | null;
+  checksum?: string;
+  error?: string;
+  notConfigured?: boolean;
+}

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -39,6 +39,7 @@ import type {
 
 import { logger } from "./globalLogger.js";
 import { authService } from "../services/authService.js";
+import { remoteSettingsService } from "../services/remoteSettingsService.js";
 
 export interface AgentContainerSetupOptions {
   options: AgentOptions;
@@ -167,6 +168,15 @@ export function setupAgentContainer(
       const newServerUrl = options.serverUrl || process.env.WAVE_SERVER_URL;
       const newToken = authService.getSSOToken();
       mcpManager.refreshCredentials(newServerUrl, newToken);
+    }
+  });
+
+  // Wire up auth change callback to refresh/clear remote settings
+  authService.onAuthChange((event) => {
+    if (event === "login") {
+      remoteSettingsService.refresh();
+    } else if (event === "logout") {
+      remoteSettingsService.clear();
     }
   });
 

--- a/packages/agent-sdk/tests/services/remoteSettingsService.test.ts
+++ b/packages/agent-sdk/tests/services/remoteSettingsService.test.ts
@@ -1,0 +1,886 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Mock } from "vitest";
+import type { WaveConfiguration } from "../../src/types/configuration.js";
+
+// Mock node:os before importing the module under test
+vi.mock("node:os", () => ({
+  homedir: () => "/home/testuser",
+}));
+
+// Mock node:fs
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  unlinkSync: vi.fn(),
+}));
+
+vi.mock("../../src/services/authService.js", () => ({
+  authService: {
+    isSSOAuthenticated: vi.fn(),
+    getSSOToken: vi.fn(),
+    getServerUrl: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import * as fs from "node:fs";
+import { authService } from "../../src/services/authService.js";
+import {
+  mergeRemoteSettings,
+  getRemoteSettingsSync,
+  clear,
+  shutdown,
+  refresh,
+  initialize,
+  remoteSettingsService,
+} from "../../src/services/remoteSettingsService.js";
+
+describe("remoteSettingsService", () => {
+  beforeEach(() => {
+    // Reset module-level state by calling clear
+    clear();
+    // Reset fs mocks
+    (fs.existsSync as Mock).mockReturnValue(false);
+    (fs.readFileSync as Mock).mockReturnValue("");
+    (fs.writeFileSync as Mock).mockImplementation(() => {});
+    (fs.mkdirSync as Mock).mockImplementation(() => "");
+    (fs.unlinkSync as Mock).mockImplementation(() => {});
+    // Reset auth mocks
+    (authService.isSSOAuthenticated as Mock).mockReturnValue(false);
+    (authService.getSSOToken as Mock).mockReturnValue(null);
+    (authService.getServerUrl as Mock).mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    clear();
+  });
+
+  // ---------------------------------------------------------------------------
+  // getRemoteSettingsSync
+  // ---------------------------------------------------------------------------
+  describe("getRemoteSettingsSync()", () => {
+    it("returns null when no cache is loaded", () => {
+      expect(getRemoteSettingsSync()).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchRemoteSettings (tested via refresh which calls it)
+  // ---------------------------------------------------------------------------
+  describe("fetchRemoteSettings()", () => {
+    it("skips fetch when not SSO authenticated", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(false);
+      const result = await refresh();
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Not SSO authenticated");
+    });
+
+    it("returns error when SSO authenticated but token missing", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue(null);
+      (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
+      const result = await refresh();
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Missing SSO token or server URL");
+    });
+
+    it("returns error when SSO authenticated but serverUrl missing", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue("token123");
+      (authService.getServerUrl as Mock).mockReturnValue(null);
+      const result = await refresh();
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Missing SSO token or server URL");
+    });
+
+    it("handles 200 response and saves cache", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue("token123");
+      (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
+
+      const settings = { language: "en" };
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          status: 200,
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              uuid: "u1",
+              checksum: "abc",
+              settings,
+            }),
+        }),
+      );
+
+      const result = await refresh();
+      expect(result.success).toBe(true);
+      expect(result.settings).toEqual(settings);
+      expect(result.checksum).toBe("abc");
+      expect(fs.writeFileSync).toHaveBeenCalled();
+      expect(getRemoteSettingsSync()).toEqual(settings);
+    });
+
+    it("sends If-None-Match header when cached checksum exists", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue("token123");
+      (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
+
+      // First fetch to populate cache with a checksum
+      const settings1 = { language: "en" };
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          status: 200,
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              uuid: "u1",
+              checksum: "etag123",
+              settings: settings1,
+            }),
+        }),
+      );
+      await refresh();
+
+      // Now cache is populated. Trigger another fetch via initialize (doesn't clear cache).
+      const fetchSpy = vi.mocked(fetch);
+      fetchSpy.mockResolvedValue({
+        status: 304,
+      } as Response);
+
+      initialize();
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Verify If-None-Match was sent
+      const calls = fetchSpy.mock.calls;
+      // Find the call that had If-None-Match
+      const withEtag = calls.find(
+        (call) =>
+          (call[1] as RequestInit)?.headers?.[
+            "If-None-Match" as keyof HeadersInit
+          ],
+      );
+      expect(withEtag).toBeDefined();
+      expect((withEtag![1] as RequestInit).headers).toHaveProperty(
+        "If-None-Match",
+        "etag123",
+      );
+
+      clear();
+    });
+
+    it("handles 304 response — returns cached settings", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue("token123");
+      (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
+
+      // Populate cache via disk
+      const settings = { language: "en" };
+      (fs.existsSync as Mock).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockReturnValue(
+        JSON.stringify({
+          uuid: "u1",
+          checksum: "etag123",
+          settings,
+          fetchedAt: "2024-01-01T00:00:00.000Z",
+        }),
+      );
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          status: 304,
+        }),
+      );
+
+      // initialize loads cache from disk, then fetches
+      initialize();
+      await new Promise((r) => setTimeout(r, 50));
+
+      // After initialize + 304, settings should still be available
+      expect(getRemoteSettingsSync()).toEqual(settings);
+
+      clear();
+    });
+
+    it("handles 404 response — clears stale cache", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue("token123");
+      (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          status: 404,
+        }),
+      );
+
+      const result = await refresh();
+      expect(result.success).toBe(true);
+      expect(result.notConfigured).toBe(true);
+      expect(result.settings).toBeNull();
+      expect(fs.unlinkSync).toHaveBeenCalled();
+    });
+
+    it("handles non-200/non-304/non-404 response", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue("token123");
+      (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          status: 500,
+          ok: false,
+          text: () => Promise.resolve("server error"),
+        }),
+      );
+
+      const result = await refresh();
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("HTTP 500");
+      expect(result.settings).toBeNull();
+    });
+
+    it("handles non-200 response with cached settings available", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue("token123");
+      (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
+
+      // Populate cache via disk
+      const settings = { language: "de" };
+      (fs.existsSync as Mock).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockReturnValue(
+        JSON.stringify({
+          uuid: "u1",
+          checksum: "abc",
+          settings,
+          fetchedAt: "2024-01-01T00:00:00.000Z",
+        }),
+      );
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          status: 500,
+          ok: false,
+          text: () => Promise.resolve("error body"),
+        }),
+      );
+
+      // initialize loads cache from disk, then fetches
+      initialize();
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Should fall back to cached settings
+      expect(getRemoteSettingsSync()).toEqual(settings);
+
+      clear();
+    });
+
+    it("handles network error — uses cache", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue("token123");
+      (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
+
+      // Populate cache via disk
+      const settings = { language: "ja" };
+      (fs.existsSync as Mock).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockReturnValue(
+        JSON.stringify({
+          uuid: "u1",
+          checksum: "abc",
+          settings,
+          fetchedAt: "2024-01-01T00:00:00.000Z",
+        }),
+      );
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockRejectedValue(new Error("Network failure")),
+      );
+
+      initialize();
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(getRemoteSettingsSync()).toEqual(settings);
+      clear();
+    });
+
+    it("handles network error with non-Error thrown", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue("token123");
+      (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
+
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue("string error"));
+
+      const result = await refresh();
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("string error");
+    });
+
+    it("handles response.text() rejection in non-ok path", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue("token123");
+      (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          status: 503,
+          ok: false,
+          text: () => Promise.reject(new Error("cannot read body")),
+        }),
+      );
+
+      const result = await refresh();
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("HTTP 503");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // initialize
+  // ---------------------------------------------------------------------------
+  describe("initialize()", () => {
+    it("loads from disk, fetches, and starts polling", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue("token123");
+      (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
+
+      const cachedSettings = { language: "zh" };
+      (fs.existsSync as Mock).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockReturnValue(
+        JSON.stringify({
+          uuid: "u1",
+          checksum: "old",
+          settings: cachedSettings,
+          fetchedAt: "2024-01-01T00:00:00.000Z",
+        }),
+      );
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          status: 200,
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              uuid: "u2",
+              checksum: "new",
+              settings: { language: "en" },
+            }),
+        }),
+      );
+
+      initialize();
+
+      // Synchronous: cache loaded from disk
+      expect(getRemoteSettingsSync()).toEqual(cachedSettings);
+
+      // Wait for async fetch to complete
+      await new Promise((r) => setTimeout(r, 50));
+
+      // After fetch, settings should be updated
+      expect(getRemoteSettingsSync()).toEqual({ language: "en" });
+
+      clear();
+    });
+
+    it("starts polling even if initial fetch fails", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue("token123");
+      (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockRejectedValue(new Error("Network error")),
+      );
+
+      initialize();
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Polling should still be started (no crash)
+      shutdown();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // refresh
+  // ---------------------------------------------------------------------------
+  describe("refresh()", () => {
+    it("clears in-memory and disk cache then fetches fresh", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue("token123");
+      (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
+
+      const newSettings = { language: "ko" };
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          status: 200,
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              uuid: "u1",
+              checksum: "fresh",
+              settings: newSettings,
+            }),
+        }),
+      );
+
+      const result = await refresh();
+      expect(result.success).toBe(true);
+      expect(result.settings).toEqual(newSettings);
+      expect(fs.unlinkSync).toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // clear
+  // ---------------------------------------------------------------------------
+  describe("clear()", () => {
+    it("removes cache from memory and disk, stops polling", () => {
+      clear();
+      expect(getRemoteSettingsSync()).toBeNull();
+    });
+
+    it("removes cache file when it exists", () => {
+      (fs.existsSync as Mock).mockReturnValue(true);
+      clear();
+      expect(fs.unlinkSync).toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // shutdown
+  // ---------------------------------------------------------------------------
+  describe("shutdown()", () => {
+    it("stops polling timer", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue("token123");
+      (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          status: 200,
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              uuid: "u1",
+              checksum: "abc",
+              settings: { language: "en" },
+            }),
+        }),
+      );
+
+      initialize();
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Should not throw
+      shutdown();
+
+      // Calling shutdown again should be safe (no timer to clear)
+      shutdown();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // mergeRemoteSettings
+  // ---------------------------------------------------------------------------
+  describe("mergeRemoteSettings()", () => {
+    it("merges env: remote wins per-key, local preserved", () => {
+      const local = { env: { A: "local-a", B: "local-b" } };
+      const remote = { env: { B: "remote-b", C: "remote-c" } };
+      const result = mergeRemoteSettings(local, remote);
+      expect(result.env).toEqual({
+        A: "local-a",
+        B: "remote-b",
+        C: "remote-c",
+      });
+    });
+
+    it("merges env when only local has env", () => {
+      const local = { env: { A: "a" } };
+      const remote = {};
+      const result = mergeRemoteSettings(local, remote);
+      expect(result.env).toEqual({ A: "a" });
+    });
+
+    it("merges env when only remote has env", () => {
+      const local = {};
+      const remote = { env: { A: "a" } };
+      const result = mergeRemoteSettings(local, remote);
+      expect(result.env).toEqual({ A: "a" });
+    });
+
+    it("merges permissions.allow: concatenate + dedupe", () => {
+      const local = { permissions: { allow: ["a", "b"] } };
+      const remote = { permissions: { allow: ["b", "c"] } };
+      const result = mergeRemoteSettings(local, remote);
+      expect(result.permissions!.allow).toEqual(["a", "b", "c"]);
+    });
+
+    it("merges permissions.deny: concatenate + dedupe", () => {
+      const local = { permissions: { deny: ["x"] } };
+      const remote = { permissions: { deny: ["x", "y"] } };
+      const result = mergeRemoteSettings(local, remote);
+      expect(result.permissions!.deny).toEqual(["x", "y"]);
+    });
+
+    it("merges permissions.permissionMode: remote wins", () => {
+      const local = { permissions: { permissionMode: "default" as const } };
+      const remote = { permissions: { permissionMode: "plan" as const } };
+      const result = mergeRemoteSettings(local, remote);
+      expect(result.permissions!.permissionMode).toBe("plan");
+    });
+
+    it("merges permissions.permissionMode: falls back to local when remote undefined", () => {
+      const local = { permissions: { permissionMode: "default" as const } };
+      const remote = { permissions: {} };
+      const result = mergeRemoteSettings(local, remote);
+      expect(result.permissions!.permissionMode).toBe("default");
+    });
+
+    it("merges permissions.additionalDirectories: concatenate + dedupe", () => {
+      const local = { permissions: { additionalDirectories: ["/a", "/b"] } };
+      const remote = { permissions: { additionalDirectories: ["/b", "/c"] } };
+      const result = mergeRemoteSettings(local, remote);
+      expect(result.permissions!.additionalDirectories).toEqual([
+        "/a",
+        "/b",
+        "/c",
+      ]);
+    });
+
+    it("merges permissions when only local has permissions", () => {
+      const local = { permissions: { allow: ["a"] } };
+      const remote = {};
+      const result = mergeRemoteSettings(local, remote);
+      expect(result.permissions!.allow).toEqual(["a"]);
+    });
+
+    it("merges permissions when only remote has permissions", () => {
+      const local = {};
+      const remote = { permissions: { deny: ["x"] } };
+      const result = mergeRemoteSettings(local, remote);
+      expect(result.permissions!.deny).toEqual(["x"]);
+    });
+
+    it("cleans up undefined permission keys", () => {
+      const local = { permissions: { allow: ["a"] } };
+      const remote = { permissions: { allow: ["b"] } };
+      const result = mergeRemoteSettings(local, remote);
+      expect(result.permissions).not.toHaveProperty("deny");
+      expect(result.permissions).not.toHaveProperty("permissionMode");
+      expect(result.permissions).not.toHaveProperty("additionalDirectories");
+    });
+
+    it("merges hooks: concatenate per-event + dedupe", () => {
+      const hook1 = {
+        matcher: "Bash",
+        hooks: [{ command: "echo hello", type: "command" as const }],
+      };
+      const hook2 = {
+        matcher: "Read",
+        hooks: [{ command: "echo bye", type: "command" as const }],
+      };
+      const hook1dup = {
+        matcher: "Bash",
+        hooks: [{ command: "echo hello", type: "command" as const }],
+      };
+
+      const local = { hooks: { PreToolUse: [hook1] } };
+      const remote = { hooks: { PreToolUse: [hook1dup, hook2] } };
+      const result = mergeRemoteSettings(local, remote);
+      expect(result.hooks!.PreToolUse).toHaveLength(2);
+      expect(result.hooks!.PreToolUse![0]).toEqual(hook1);
+      expect(result.hooks!.PreToolUse![1]).toEqual(hook2);
+    });
+
+    it("merges hooks when only local has hooks", () => {
+      const hook = {
+        hooks: [{ command: "echo", type: "command" as const }],
+      };
+      const local = { hooks: { PreToolUse: [hook] } };
+      const remote = {};
+      const result = mergeRemoteSettings(local, remote);
+      expect(result.hooks).toEqual({ PreToolUse: [hook] });
+    });
+
+    it("merges hooks when only remote has hooks", () => {
+      const hook = {
+        hooks: [{ command: "echo", type: "command" as const }],
+      };
+      const local = {};
+      const remote = { hooks: { PostToolUse: [hook] } };
+      const result = mergeRemoteSettings(local, remote);
+      expect(result.hooks).toEqual({ PostToolUse: [hook] });
+    });
+
+    it("returns undefined hooks when both are undefined", () => {
+      const local = {};
+      const remote = {};
+      const result = mergeRemoteSettings(local, remote);
+      expect(result.hooks).toBeUndefined();
+    });
+
+    it("merges scalar fields: remote wins when defined", () => {
+      const local = {
+        language: "en",
+        autoMemoryEnabled: true,
+        autoMemoryFrequency: 5,
+        models: { model: { maxTokens: 50 } },
+        marketplaces: { m1: { source: "url" as const } },
+        enabledPlugins: { p1: true },
+      };
+      const remote = {
+        language: "ja",
+        autoMemoryEnabled: false,
+        autoMemoryFrequency: 10,
+        models: { model: { maxTokens: 100 } },
+        marketplaces: { m2: { source: "url" as const } },
+        enabledPlugins: { p2: true },
+      };
+      const result = mergeRemoteSettings(
+        local as unknown as WaveConfiguration,
+        remote as unknown as WaveConfiguration,
+      );
+      expect(result.language).toBe("ja");
+      expect(result.autoMemoryEnabled).toBe(false);
+      expect(result.autoMemoryFrequency).toBe(10);
+      expect(result.models).toEqual({ model: { maxTokens: 100 } });
+      expect(result.marketplaces).toEqual({ m2: { source: "url" } });
+      expect(result.enabledPlugins).toEqual({ p2: true });
+    });
+
+    it("preserves local scalar fields when remote doesn't define them", () => {
+      const local = {
+        language: "en",
+        autoMemoryEnabled: true,
+        autoMemoryFrequency: 5,
+        models: { model: { maxTokens: 50 } },
+        marketplaces: { m1: { source: "url" as const } },
+        enabledPlugins: { p1: true },
+      };
+      const remote = {};
+      const result = mergeRemoteSettings(
+        local as unknown as WaveConfiguration,
+        remote as unknown as WaveConfiguration,
+      );
+      expect(result.language).toBe("en");
+      expect(result.autoMemoryEnabled).toBe(true);
+      expect(result.autoMemoryFrequency).toBe(5);
+      expect(result.models).toEqual({ model: { maxTokens: 50 } });
+      expect(result.marketplaces).toEqual({ m1: { source: "url" } });
+      expect(result.enabledPlugins).toEqual({ p1: true });
+    });
+
+    it("handles both empty objects", () => {
+      const result = mergeRemoteSettings({}, {});
+      expect(result).toEqual({});
+    });
+
+    it("handles empty local with remote data", () => {
+      const remote = {
+        language: "ja",
+        env: { X: "1" },
+        permissions: { allow: ["a"] },
+      };
+      const result = mergeRemoteSettings({}, remote);
+      expect(result.language).toBe("ja");
+      expect(result.env).toEqual({ X: "1" });
+      expect(result.permissions!.allow).toEqual(["a"]);
+    });
+
+    it("handles remote with undefined scalar values (should not overwrite)", () => {
+      const local = { language: "en" };
+      const remote = { language: undefined };
+      const result = mergeRemoteSettings(local, remote);
+      expect(result.language).toBe("en");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // remoteSettingsService namespace object
+  // ---------------------------------------------------------------------------
+  describe("remoteSettingsService namespace", () => {
+    it("exposes all expected methods", () => {
+      expect(remoteSettingsService.initialize).toBeTypeOf("function");
+      expect(remoteSettingsService.getRemoteSettingsSync).toBeTypeOf(
+        "function",
+      );
+      expect(remoteSettingsService.refresh).toBeTypeOf("function");
+      expect(remoteSettingsService.clear).toBeTypeOf("function");
+      expect(remoteSettingsService.shutdown).toBeTypeOf("function");
+      expect(remoteSettingsService.mergeRemoteSettings).toBeTypeOf("function");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // loadCacheFromDisk edge cases
+  // ---------------------------------------------------------------------------
+  describe("loadCacheFromDisk edge cases", () => {
+    it("skips loading when cache file does not exist", async () => {
+      (fs.existsSync as Mock).mockReturnValue(false);
+      initialize();
+      await new Promise((r) => setTimeout(r, 50));
+      clear();
+    });
+
+    it("handles corrupt cache file gracefully", async () => {
+      (fs.existsSync as Mock).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockReturnValue("not valid json {{{");
+
+      initialize();
+      await new Promise((r) => setTimeout(r, 50));
+      clear();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // writeCacheToDisk edge cases
+  // ---------------------------------------------------------------------------
+  describe("writeCacheToDisk edge cases", () => {
+    it("creates directory if it doesn't exist", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue("token123");
+      (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
+
+      // existsSync returns false for both cache file and directory checks
+      (fs.existsSync as Mock).mockReturnValue(false);
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          status: 200,
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              uuid: "u1",
+              checksum: "abc",
+              settings: { language: "en" },
+            }),
+        }),
+      );
+
+      await refresh();
+      expect(fs.mkdirSync).toHaveBeenCalled();
+    });
+
+    it("handles write failure gracefully", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue("token123");
+      (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
+
+      (fs.writeFileSync as Mock).mockImplementation(() => {
+        throw new Error("disk full");
+      });
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          status: 200,
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              uuid: "u1",
+              checksum: "abc",
+              settings: { language: "en" },
+            }),
+        }),
+      );
+
+      const result = await refresh();
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // removeCacheFromDisk edge cases
+  // ---------------------------------------------------------------------------
+  describe("removeCacheFromDisk edge cases", () => {
+    it("does nothing when cache file doesn't exist", () => {
+      (fs.existsSync as Mock).mockReturnValue(false);
+      (fs.unlinkSync as Mock).mockClear();
+      clear();
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
+    });
+
+    it("handles unlink error gracefully", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue("token123");
+      (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
+
+      // Populate cache
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          status: 200,
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              uuid: "u1",
+              checksum: "abc",
+              settings: { language: "en" },
+            }),
+        }),
+      );
+      await refresh();
+
+      (fs.existsSync as Mock).mockReturnValue(true);
+      (fs.unlinkSync as Mock).mockImplementation(() => {
+        throw new Error("permission denied");
+      });
+
+      // Should not throw
+      clear();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // startPolling — second call is no-op
+  // ---------------------------------------------------------------------------
+  describe("startPolling idempotency", () => {
+    it("does not start duplicate timers on multiple initialize calls", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue("token123");
+      (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          status: 200,
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              uuid: "u1",
+              checksum: "abc",
+              settings: { language: "en" },
+            }),
+        }),
+      );
+
+      initialize();
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Call initialize again — should not create a second timer
+      initialize();
+      await new Promise((r) => setTimeout(r, 50));
+
+      clear();
+    });
+  });
+});


### PR DESCRIPTION
Add client-side remote settings service that fetches org-managed
configuration from GET /api/wave/settings with SSO auth, ETag-based
caching (If-None-Match/304), and 60-minute background polling.

Merge priority: Remote > Local > Project > User

- Add RemoteSettingsResponse/Cache/FetchResult types
- Create remoteSettingsService singleton module (fetch, cache, poll)
- Merge remote settings in ConfigurationService.loadMergedConfiguration()
- Wire auth change callbacks (refresh on login, clear on logout)
- Add remote settings init phase in InitializationService
- Add shutdown() call in Agent.destroy()

Closes #1127
