### PR TITLE
feat: persist /model selection to ~/.wave/settings.json

### DIFF
--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -508,7 +508,10 @@ export class ConfigurationService {
   ): ModelConfig {
     // Resolve agent model: override > options > process.env (includes settings.json env)
     const resolvedAgentModel =
-      model || this.options.model || process.env.WAVE_MODEL;
+      model ||
+      this.options.model ||
+      process.env.WAVE_MODEL ||
+      this.currentConfiguration?.model;
 
     // Resolve fast model: override > options > process.env (includes settings.json env)
     const resolvedFastModel =
@@ -696,6 +699,28 @@ export class ConfigurationService {
    */
   setModel(model: string): void {
     this.options.model = model;
+    this.persistModelToSettings(model);
+  }
+
+  private async persistModelToSettings(model: string): Promise<void> {
+    const configPath = getUserConfigPaths()[0]; // ~/.wave/settings.json
+    const configDir = path.dirname(configPath);
+    if (!existsSync(configDir)) {
+      await fs.mkdir(configDir, { recursive: true });
+    }
+
+    let config: WaveConfiguration = {};
+    if (existsSync(configPath)) {
+      try {
+        const content = await fs.readFile(configPath, "utf-8");
+        config = JSON.parse(content);
+      } catch {
+        // Start fresh if corrupted
+      }
+    }
+
+    config.model = model;
+    await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
   }
 
   /**
@@ -708,6 +733,11 @@ export class ConfigurationService {
     const currentModel = this.options.model || process.env.WAVE_MODEL;
     if (currentModel) {
       models.add(currentModel);
+    }
+
+    // Persisted model from settings (includes remote-merged)
+    if (this.currentConfiguration?.model) {
+      models.add(this.currentConfiguration.model);
     }
 
     // Add models from merged configuration
@@ -1139,6 +1169,7 @@ export function loadWaveConfigFromFile(
       permissions: config.permissions || undefined,
       enabledPlugins: config.enabledPlugins || undefined,
       language: config.language || undefined,
+      model: config.model || undefined,
       autoMemoryEnabled:
         config.autoMemoryEnabled !== undefined
           ? config.autoMemoryEnabled
@@ -1268,6 +1299,11 @@ export function loadMergedWaveConfig(
       mergedConfig.language = config.language;
     }
 
+    // Merge model (last one wins)
+    if (config.model !== undefined) {
+      mergedConfig.model = config.model;
+    }
+
     // Merge autoMemoryEnabled (last one wins)
     if (config.autoMemoryEnabled !== undefined) {
       mergedConfig.autoMemoryEnabled = config.autoMemoryEnabled;
@@ -1316,6 +1352,7 @@ export function loadMergedWaveConfig(
         ? mergedConfig.enabledPlugins
         : undefined,
     language: mergedConfig.language,
+    model: mergedConfig.model,
     autoMemoryEnabled: mergedConfig.autoMemoryEnabled,
     marketplaces:
       mergedConfig.marketplaces &&

--- a/packages/agent-sdk/src/services/remoteSettingsService.ts
+++ b/packages/agent-sdk/src/services/remoteSettingsService.ts
@@ -286,6 +286,7 @@ export function mergeRemoteSettings(
 
   // Scalar / last-write-wins fields: remote wins
   if (remote.language !== undefined) result.language = remote.language;
+  if (remote.model !== undefined) result.model = remote.model;
   if (remote.autoMemoryEnabled !== undefined)
     result.autoMemoryEnabled = remote.autoMemoryEnabled;
   if (remote.autoMemoryFrequency !== undefined)

--- a/packages/agent-sdk/src/types/configuration.ts
+++ b/packages/agent-sdk/src/types/configuration.ts
@@ -44,6 +44,8 @@ export interface WaveConfiguration {
   autoMemoryEnabled?: boolean;
   /** Frequency of auto-memory extraction turns */
   autoMemoryFrequency?: number;
+  /** Persisted model selection (from /model command) */
+  model?: string;
   /** Model-specific configuration overrides */
   models?: Record<string, Partial<ModelConfig>>;
   /** Scoped marketplace declarations */

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -602,5 +602,171 @@ describe("ConfigurationService", () => {
       expect(models).toContain("model-b");
       expect(models).not.toContain("gemini-3-flash");
     });
+
+    it("should include currentConfiguration.model in getConfiguredModels", async () => {
+      const config = { model: "persisted-model" };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      const origModel = process.env.WAVE_MODEL;
+      delete process.env.WAVE_MODEL;
+      try {
+        await configService.loadMergedConfiguration(tempDir);
+        const models = configService.getConfiguredModels();
+        expect(models).toContain("persisted-model");
+      } finally {
+        if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
+      }
+    });
+  });
+
+  describe("resolveModelConfig — model priority", () => {
+    it("should fall back to currentConfiguration.model when no param, options, or env var", async () => {
+      const config = { model: "config-model" };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      const origModel = process.env.WAVE_MODEL;
+      const origFastModel = process.env.WAVE_FAST_MODEL;
+      delete process.env.WAVE_MODEL;
+      process.env.WAVE_FAST_MODEL = "fast-model";
+      try {
+        await configService.loadMergedConfiguration(tempDir);
+        configService.setOptions({}); // no options.model
+        const resolved = configService.resolveModelConfig();
+        expect(resolved.model).toBe("config-model");
+      } finally {
+        if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
+        else delete process.env.WAVE_MODEL;
+        if (origFastModel !== undefined)
+          process.env.WAVE_FAST_MODEL = origFastModel;
+        else delete process.env.WAVE_FAST_MODEL;
+      }
+    });
+
+    it("should prioritize options.model over WAVE_MODEL env var and currentConfiguration.model", async () => {
+      const config = { model: "config-model" };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      const origModel = process.env.WAVE_MODEL;
+      const origFastModel = process.env.WAVE_FAST_MODEL;
+      process.env.WAVE_MODEL = "env-model";
+      process.env.WAVE_FAST_MODEL = "fast-model";
+      try {
+        await configService.loadMergedConfiguration(tempDir);
+        configService.setOptions({ model: "options-model" });
+        const resolved = configService.resolveModelConfig();
+        expect(resolved.model).toBe("options-model");
+      } finally {
+        if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
+        else delete process.env.WAVE_MODEL;
+        if (origFastModel !== undefined)
+          process.env.WAVE_FAST_MODEL = origFastModel;
+        else delete process.env.WAVE_FAST_MODEL;
+      }
+    });
+
+    it("should prioritize WAVE_MODEL env var over currentConfiguration.model", async () => {
+      const config = { model: "config-model" };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      const origModel = process.env.WAVE_MODEL;
+      const origFastModel = process.env.WAVE_FAST_MODEL;
+      process.env.WAVE_MODEL = "env-model";
+      process.env.WAVE_FAST_MODEL = "fast-model";
+      try {
+        await configService.loadMergedConfiguration(tempDir);
+        configService.setOptions({}); // no options.model
+        const resolved = configService.resolveModelConfig();
+        expect(resolved.model).toBe("env-model");
+      } finally {
+        if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
+        else delete process.env.WAVE_MODEL;
+        if (origFastModel !== undefined)
+          process.env.WAVE_FAST_MODEL = origFastModel;
+        else delete process.env.WAVE_FAST_MODEL;
+      }
+    });
+
+    it("should prioritize model param over options.model, env var, and currentConfiguration.model", async () => {
+      const config = { model: "config-model" };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      const origModel = process.env.WAVE_MODEL;
+      const origFastModel = process.env.WAVE_FAST_MODEL;
+      process.env.WAVE_MODEL = "env-model";
+      process.env.WAVE_FAST_MODEL = "fast-model";
+      try {
+        await configService.loadMergedConfiguration(tempDir);
+        configService.setOptions({ model: "options-model" });
+        const resolved = configService.resolveModelConfig("param-model");
+        expect(resolved.model).toBe("param-model");
+      } finally {
+        if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
+        else delete process.env.WAVE_MODEL;
+        if (origFastModel !== undefined)
+          process.env.WAVE_FAST_MODEL = origFastModel;
+        else delete process.env.WAVE_FAST_MODEL;
+      }
+    });
+  });
+
+  describe("loadMergedWaveConfig — model field", () => {
+    it("should merge model field with last-write-wins", async () => {
+      const userSettingsPath = path.join(userHome, ".wave", "settings.json");
+      const projectSettingsPath = path.join(tempDir, ".wave", "settings.json");
+
+      const userSettings = { model: "user-model" };
+      const projectSettings = { model: "project-model" };
+
+      mockExistsSync.mockImplementation((p) => {
+        const pathStr = p.toString();
+        return [userSettingsPath, projectSettingsPath].some((expected) =>
+          pathStr.includes(expected),
+        );
+      });
+
+      mockReadFileSync.mockImplementation((p) => {
+        const pathStr = p.toString();
+        if (pathStr.includes(userSettingsPath))
+          return JSON.stringify(userSettings);
+        if (pathStr.includes(projectSettingsPath))
+          return JSON.stringify(projectSettings);
+        return "";
+      });
+
+      const result = loadMergedWaveConfig(tempDir);
+      expect(result?.model).toBe("project-model");
+    });
+
+    it("should use user model when project has no model", async () => {
+      const userSettingsPath = path.join(userHome, ".wave", "settings.json");
+      const projectSettingsPath = path.join(tempDir, ".wave", "settings.json");
+
+      const userSettings = { model: "user-model" };
+      const projectSettings = {};
+
+      mockExistsSync.mockImplementation((p) => {
+        const pathStr = p.toString();
+        return [userSettingsPath, projectSettingsPath].some((expected) =>
+          pathStr.includes(expected),
+        );
+      });
+
+      mockReadFileSync.mockImplementation((p) => {
+        const pathStr = p.toString();
+        if (pathStr.includes(userSettingsPath))
+          return JSON.stringify(userSettings);
+        if (pathStr.includes(projectSettingsPath))
+          return JSON.stringify(projectSettings);
+        return "";
+      });
+
+      const result = loadMergedWaveConfig(tempDir);
+      expect(result?.model).toBe("user-model");
+    });
   });
 });

--- a/packages/agent-sdk/tests/services/remoteSettingsService.test.ts
+++ b/packages/agent-sdk/tests/services/remoteSettingsService.test.ts
@@ -711,6 +711,20 @@ describe("remoteSettingsService", () => {
       const result = mergeRemoteSettings(local, remote);
       expect(result.language).toBe("en");
     });
+
+    it("merges model: remote model overrides local model", () => {
+      const local = { model: "local-model" } as unknown as WaveConfiguration;
+      const remote = { model: "remote-model" } as unknown as WaveConfiguration;
+      const result = mergeRemoteSettings(local, remote);
+      expect(result.model).toBe("remote-model");
+    });
+
+    it("merges model: local model preserved when remote has no model", () => {
+      const local = { model: "local-model" } as unknown as WaveConfiguration;
+      const remote = {} as unknown as WaveConfiguration;
+      const result = mergeRemoteSettings(local, remote);
+      expect(result.model).toBe("local-model");
+    });
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
- Add model?: string to WaveConfiguration type
- persistModelToSettings() writes model to user settings.json on /model
- resolveModelConfig() falls back to currentConfiguration.model
- loadMergedWaveConfig() merges model with last-write-wins
- loadWaveConfigFromFile() returns model field (was missing)
- mergeRemoteSettings() includes model in scalar block (remote overrides local)
- getConfiguredModels() includes persisted model from settings
- Priority: param > options (in-memory) > WAVE_MODEL env > settings file
