### PR TITLE
feat: restore automatic CWD tracking after bash cd commands

### DIFF
--- a/packages/agent-sdk/examples/cwd-tracking.ts
+++ b/packages/agent-sdk/examples/cwd-tracking.ts
@@ -1,0 +1,192 @@
+#!/usr/bin/env tsx
+
+/**
+ * Dynamic CWD Tracking Example
+ *
+ * Demonstrates that the agent's working directory is automatically updated
+ * after a `cd` command via the bash tool, and that subsequent file operations
+ * resolve relative paths against the new directory.
+ */
+
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+import { Agent } from "../src/agent.js";
+
+console.log("📁 Testing Dynamic CWD Tracking...\n");
+
+let tempDir: string;
+let agent: Agent;
+
+async function setupTest() {
+  // Create temporary directory with a subdirectory
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "wave-cwd-test-"));
+  const subDir = path.join(tempDir, "src");
+  await fs.mkdir(subDir);
+  await fs.writeFile(
+    path.join(tempDir, "root.txt"),
+    "I am in the root directory.",
+  );
+  await fs.writeFile(path.join(subDir, "index.txt"), "I am in src/index.txt.");
+
+  console.log(`📁 Created temp directory: ${tempDir}`);
+  console.log(`📁 Created subdirectory: ${subDir}`);
+  console.log(`📄 root.txt: "I am in the root directory."`);
+  console.log(`📄 src/index.txt: "I am in src/index.txt."\n`);
+
+  // Track workdir changes
+  const workdirChanges: string[] = [];
+
+  agent = await Agent.create({
+    workdir: tempDir,
+    permissionMode: "bypassPermissions",
+    callbacks: {
+      onWorkdirChange: (newCwd: string) => {
+        console.log(`🔄 workdir changed to: ${newCwd}`);
+        workdirChanges.push(newCwd);
+      },
+      onToolBlockUpdated: (params) => {
+        if (params.stage === "running") {
+          console.log(`🔧 Running: ${params.name}`);
+        } else if (params.stage === "end") {
+          console.log(
+            `✅ ${params.name} completed (success: ${params.success})`,
+          );
+          if (params.result) {
+            const preview =
+              params.result.length > 100
+                ? params.result.substring(0, 100) + "..."
+                : params.result;
+            console.log(`   Result: ${preview}`);
+          }
+          if (params.error) {
+            console.log(`   Error: ${params.error}`);
+          }
+        }
+      },
+      onAssistantContentUpdated: (chunk: string) => {
+        process.stdout.write(chunk);
+      },
+    },
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: (msg) => console.error(`❌ ${msg}`),
+    },
+  });
+
+  console.log(
+    `\n🤖 Agent created, initial workdir: ${agent.workingDirectory}\n`,
+  );
+}
+
+async function runTests() {
+  console.log(`\n=== Test 1: cd command changes workdir ===`);
+  console.log(`Current workdir: ${agent.workingDirectory}`);
+
+  await agent.sendMessage(
+    "Run the command: cd src. Just execute it, no other commands.",
+  );
+
+  console.log(`After cd src, workdir: ${agent.workingDirectory}`);
+  const endsWithSrc = agent.workingDirectory.endsWith("src");
+  console.log(
+    `✅ Test 1 ${endsWithSrc ? "PASSED" : "FAILED"}: workdir ${endsWithSrc ? "changed to src" : "did NOT change to src"}\n`,
+  );
+
+  console.log(`\n=== Test 2: Read resolves relative to new workdir ===`);
+  await agent.sendMessage('Read the file "index.txt" using the Read tool.');
+
+  // Search ALL assistant messages for a successful Read tool block
+  const messages = agent.messages;
+  const allAssistantMsgs = messages.filter((m) => m.role === "assistant");
+  let readSuccess = false;
+  for (const msg of allAssistantMsgs) {
+    const toolBlocks = msg.blocks.filter((b) => b.type === "tool");
+    for (const block of toolBlocks) {
+      if (block.name === "Read" && block.success === true) {
+        readSuccess = true;
+        break;
+      }
+    }
+    if (readSuccess) break;
+  }
+  console.log(
+    `✅ Test 2 ${readSuccess ? "PASSED" : "FAILED"}: Read tool ${readSuccess ? "found index.txt in src/" : "failed to find index.txt"}\n`,
+  );
+
+  console.log(`\n=== Test 3: Failed cd does NOT change workdir ===`);
+  const prevWorkdir = agent.workingDirectory;
+  await agent.sendMessage(
+    "Run the command: cd nonexistent-directory-that-does-not-exist. Just execute it.",
+  );
+  const stillSame = agent.workingDirectory === prevWorkdir;
+  console.log(`After failed cd, workdir: ${agent.workingDirectory}`);
+  console.log(
+    `✅ Test 3 ${stillSame ? "PASSED" : "FAILED"}: workdir ${stillSame ? "did NOT change" : "changed unexpectedly"}\n`,
+  );
+
+  console.log(`\n=== Test 4: Background cd does NOT change workdir ===`);
+  const bgWorkdirBefore = agent.workingDirectory;
+  await agent.sendMessage(
+    'Run "cd src" in the background using run_in_background=true.',
+  );
+  const bgWorkdirAfter = agent.workingDirectory;
+  const bgUnchanged = bgWorkdirBefore === bgWorkdirAfter;
+  console.log(
+    `✅ Test 4 ${bgUnchanged ? "PASSED" : "FAILED"}: background cd ${bgUnchanged ? "did NOT change workdir" : "changed workdir unexpectedly"}\n`,
+  );
+}
+
+async function cleanup() {
+  console.log("\n🧹 Cleaning up...");
+  try {
+    if (agent) {
+      await agent.destroy();
+      console.log("✅ Agent cleaned up");
+    }
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      console.log(`🗑️ Cleaned up temp directory`);
+    }
+  } catch (cleanupError) {
+    console.error("❌ Cleanup failed:", cleanupError);
+  }
+}
+
+async function main() {
+  try {
+    await setupTest();
+    await runTests();
+
+    console.log("\n🎉 CWD TRACKING TEST SUMMARY:");
+  } catch (error) {
+    console.error("❌ Test failed:", error);
+  } finally {
+    await cleanup();
+    console.log("👋 Done!");
+    process.exit(0);
+  }
+}
+
+process.on("SIGINT", async () => {
+  console.log("\n\n🛑 Received SIGINT, cleaning up...");
+  await cleanup();
+  process.exit(0);
+});
+
+process.on("SIGTERM", async () => {
+  console.log("\n\n🛑 Received SIGTERM, cleaning up...");
+  await cleanup();
+  process.exit(0);
+});
+
+// Timeout guard
+setTimeout(async () => {
+  console.log("\n⏰ Test timeout, cleaning up...");
+  await cleanup();
+  process.exit(0);
+}, 60000);
+
+main();

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -221,6 +221,13 @@ export class Agent {
       }
     };
 
+    // Wire up CWD change callback from AIManager to sync Agent's workdir
+    this.aiManager.setOnCwdChange((newCwd) => {
+      this.workdir = newCwd;
+      this.container.register("Workdir", newCwd);
+      this.options.callbacks?.onWorkdirChange?.(newCwd);
+    });
+
     // Wire up message queue to process when agent becomes idle
     this.messageQueue.onMessageEnqueued = () => {
       // If the AI is NOT loading and command is not running, trigger dequeue
@@ -281,6 +288,16 @@ export class Agent {
   /** Get working directory */
   public get workingDirectory(): string {
     return this.workdir;
+  }
+
+  /**
+   * Set the working directory
+   * @param newCwd - The new working directory
+   */
+  public setWorkdir(newCwd: string): void {
+    this.workdir = newCwd;
+    this.container.register("Workdir", newCwd);
+    this.options.callbacks?.onWorkdirChange?.(newCwd);
   }
 
   /** Get project memory content */

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -40,6 +40,7 @@ import { logOTelEvent } from "../telemetry/events.js";
 export interface AIManagerCallbacks {
   onCompactionStateChange?: (isCompacting: boolean) => void;
   onUsageAdded?: (usage: Usage) => void;
+  onCwdChange?: (newCwd: string) => void;
 }
 
 export interface AIManagerOptions {
@@ -64,6 +65,8 @@ export class AIManager {
   private subagentType?: string; // Store subagent type for hook context
   private stream: boolean; // Streaming mode flag
   private modelOverride?: string;
+  private _onCwdChange?: (newCwd: string) => void; // Store callback for CWD changes
+  private originalWorkdir: string;
   private consecutiveCompactionFailures: number = 0;
   private readonly maxTurns?: number;
 
@@ -77,6 +80,8 @@ export class AIManager {
     this.stream = options.stream ?? true; // Default to true if not specified
     this.callbacks = options.callbacks ?? {};
     this.modelOverride = options.modelOverride;
+    this._onCwdChange = options.callbacks?.onCwdChange; // Initialize onCwdChange
+    this.originalWorkdir = options.workdir;
     this.maxTurns = options.maxTurns;
   }
 
@@ -174,6 +179,10 @@ export class AIManager {
     return this.container.get<string>("Workdir") ?? process.cwd();
   }
 
+  public getOriginalWorkdir(): string {
+    return this.originalWorkdir;
+  }
+
   /**
    * Update the working directory mid-session (e.g., when entering/exiting a worktree).
    * Also updates process.chdir() so bash commands use the new directory.
@@ -181,6 +190,10 @@ export class AIManager {
   public setWorkdir(newWorkdir: string): void {
     this.container.register("Workdir", newWorkdir);
     process.chdir(newWorkdir);
+  }
+
+  public setOnCwdChange(callback: (newCwd: string) => void): void {
+    this._onCwdChange = callback;
   }
 
   private isCompacting: boolean = false;
@@ -248,6 +261,7 @@ export class AIManager {
       if (toolPlugin?.formatCompactParams) {
         const context: ToolContext = {
           workdir: this.getWorkdir(),
+          originalWorkdir: this.originalWorkdir,
           taskManager: this.taskManager,
         };
         return toolPlugin.formatCompactParams(toolArgs, context);
@@ -998,6 +1012,7 @@ export class AIManager {
                 abortSignal: toolAbortController.signal,
                 backgroundTaskManager: this.backgroundTaskManager,
                 workdir: this.getWorkdir(),
+                originalWorkdir: this.originalWorkdir,
                 messageId: this.messageManager.getMessages().slice(-1)[0]?.id,
                 sessionId: this.messageManager.getSessionId(),
                 toolCallId: toolId,
@@ -1015,6 +1030,28 @@ export class AIManager {
                     result,
                     stage: "running", // Keep it in running stage while updating result
                   });
+                },
+                onCwdChange: async (newCwd: string) => {
+                  const oldCwd = this.getWorkdir();
+                  this.container.register("Workdir", newCwd);
+                  this._onCwdChange?.(newCwd);
+                  if (this.hookManager) {
+                    const sessionId = this.messageManager.getSessionId();
+                    const transcriptPath =
+                      this.messageManager.getTranscriptPath();
+                    const env = Object.fromEntries(
+                      Object.entries(process.env).filter(
+                        (e) => e[1] !== undefined,
+                      ),
+                    ) as Record<string, string>;
+                    await this.hookManager.executeCwdChangedHooks(
+                      oldCwd,
+                      newCwd,
+                      sessionId,
+                      transcriptPath,
+                      env,
+                    );
+                  }
                 },
               };
 

--- a/packages/agent-sdk/src/managers/hookManager.ts
+++ b/packages/agent-sdk/src/managers/hookManager.ts
@@ -676,6 +676,7 @@ export class HookManager {
       event === "SubagentStop" ||
       event === "WorktreeCreate" ||
       event === "WorktreeRemove" ||
+      event === "CwdChanged" ||
       event === "SessionStart" ||
       event === "SessionEnd"
     ) {
@@ -781,6 +782,7 @@ export class HookManager {
           PermissionRequest: 0,
           WorktreeCreate: 0,
           WorktreeRemove: 0,
+          CwdChanged: 0,
           SessionStart: 0,
           SessionEnd: 0,
         },
@@ -796,6 +798,7 @@ export class HookManager {
       PermissionRequest: 0,
       WorktreeCreate: 0,
       WorktreeRemove: 0,
+      CwdChanged: 0,
       SessionStart: 0,
       SessionEnd: 0,
     };
@@ -820,6 +823,35 @@ export class HookManager {
       totalCommands,
       eventBreakdown,
     };
+  }
+
+  /**
+   * Execute CwdChanged hooks.
+   */
+  async executeCwdChangedHooks(
+    oldCwd: string,
+    newCwd: string,
+    sessionId: string,
+    transcriptPath: string,
+    env: Record<string, string>,
+  ): Promise<HookExecutionResult[]> {
+    const context: ExtendedHookExecutionContext = {
+      event: "CwdChanged",
+      projectDir: this.workdir,
+      timestamp: new Date(),
+      sessionId,
+      transcriptPath,
+      cwd: newCwd,
+      oldCwd,
+      newCwd,
+      env,
+    };
+    const results = await this.executeHooks("CwdChanged", context);
+    if (results.length > 0) {
+      // For CwdChanged hooks, we don't block, just log errors
+      this.processHookResults("CwdChanged", results);
+    }
+    return results;
   }
 
   /**

--- a/packages/agent-sdk/src/services/hook.ts
+++ b/packages/agent-sdk/src/services/hook.ts
@@ -278,6 +278,21 @@ export async function executeCommands(
 }
 
 /**
+ * Execute a CwdChanged hook
+ */
+export async function executeCwdChangedHooks(
+  oldCwd: string,
+  newCwd: string,
+  context: ExtendedHookExecutionContext,
+): Promise<HookExecutionResult[]> {
+  // CwdChanged hooks are executed through HookManager.executeCwdChangedHooks()
+  void context;
+  void oldCwd;
+  void newCwd;
+  return [];
+}
+
+/**
  * Validate command safety (basic checks)
  */
 export function isCommandSafe(command: string): boolean {

--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -139,7 +139,10 @@ Use the gh command via the Bash tool for GitHub-related tasks including working 
 - Do not retry failing commands in a sleep loop — diagnose the root cause.
 - If waiting for a background task you started with \`run_in_background\`, you will be notified when it completes — do not poll.
 - If you must poll an external process, use a check command (e.g. \`gh run view\`) rather than sleeping first.
-- If you must sleep, keep the duration short (1-5 seconds) to avoid blocking the user.`,
+- If you must sleep, keep the duration short (1-5 seconds) to avoid blocking the user.
+
+# CWD management
+Try to maintain your current working directory throughout the session by using absolute paths and avoiding usage of \`cd\`. You may use \`cd\` if the User explicitly requests it. When you use \`cd\`, the shell working directory will be reset to the original working directory after the command completes.`,
   execute: async (
     args: Record<string, unknown>,
     context: ToolContext,
@@ -237,7 +240,14 @@ Use the gh command via the Bash tool for GitHub-related tasks including working 
 
     // Foreground execution (original behavior)
     return new Promise((resolve) => {
-      const child: ChildProcess = spawn(command, {
+      // Create a temporary file to store the CWD
+      const tempCwdFile = path.join(
+        os.tmpdir(),
+        `wave_cwd_${Date.now()}_${Math.random().toString(36).substring(2, 11)}.tmp`,
+      );
+      const wrappedCommand = `${command} && pwd -P >| ${tempCwdFile}`;
+
+      const child: ChildProcess = spawn(wrappedCommand, {
         shell: true,
         stdio: "pipe",
         detached: true,
@@ -422,13 +432,55 @@ Use the gh command via the Bash tool for GitHub-related tasks including working 
             clearTimeout(timeoutHandle);
           }
 
+          // Read the new CWD from the temporary file
+          let newCwd: string | undefined;
+          try {
+            if (fs.existsSync(tempCwdFile)) {
+              newCwd = fs.readFileSync(tempCwdFile, "utf8").trim();
+              // Validate the path exists before calling the callback
+              fs.accessSync(newCwd, fs.constants.F_OK);
+            }
+          } catch (fileError) {
+            logger.warn(
+              `Could not read or validate new CWD from temp file ${tempCwdFile}:`,
+              fileError,
+            );
+            newCwd = undefined;
+          } finally {
+            // Ensure temp file is cleaned up even if reading fails
+            try {
+              if (fs.existsSync(tempCwdFile)) {
+                fs.unlinkSync(tempCwdFile);
+              }
+            } catch (fileError) {
+              logger.error("Failed to clean up temp CWD file:", fileError);
+            }
+          }
+
+          // If CWD changed, call the onCwdChange callback and add notification
+          let cwdChangedNotification = "";
+          if (newCwd && newCwd !== context.workdir && context.onCwdChange) {
+            const isInSafeZone =
+              context.permissionManager?.isPathInSafeZone?.(newCwd) ?? true;
+
+            if (isInSafeZone) {
+              context.onCwdChange(newCwd);
+            } else if (context.originalWorkdir) {
+              context.onCwdChange(context.originalWorkdir);
+              cwdChangedNotification = `Shell cwd was reset to ${context.originalWorkdir}\n`;
+            } else {
+              context.onCwdChange(newCwd);
+            }
+          }
+
           const exitCode = code ?? 0;
           const combinedOutput =
             outputBuffer + (errorBuffer ? "\n" + errorBuffer : "");
 
           // Handle large output by truncation and persistence if needed
           const finalOutput =
-            combinedOutput || `Command executed with exit code: ${exitCode}`;
+            cwdChangedNotification +
+            (combinedOutput || `Command executed with exit code: ${exitCode}`);
           const content = processOutput(finalOutput);
 
           const lines = combinedOutput.trim().split("\n");

--- a/packages/agent-sdk/src/tools/types.ts
+++ b/packages/agent-sdk/src/tools/types.ts
@@ -107,4 +107,8 @@ export interface ToolContext {
   readFileState?: Map<string, { mtime: number; hash: string }>;
   /** Hook manager instance for executing hooks */
   hookManager?: import("../managers/hookManager.js").HookManager;
+  /** Callback to notify when the current working directory changes */
+  onCwdChange?: (newCwd: string) => void;
+  /** Original working directory (before any cd changes) for CWD reset */
+  originalWorkdir?: string;
 }

--- a/packages/agent-sdk/src/types/agent.ts
+++ b/packages/agent-sdk/src/types/agent.ts
@@ -109,5 +109,6 @@ export interface AgentCallbacks
   onConfiguredModelsChange?: (models: string[]) => void;
   onLoadingChange?: (loading: boolean) => void;
   onCommandRunningChange?: (running: boolean) => void;
+  onWorkdirChange?: (newCwd: string) => void;
   onQueuedMessagesChange?: (messages: QueuedMessage[]) => void;
 }

--- a/packages/agent-sdk/src/types/hooks.ts
+++ b/packages/agent-sdk/src/types/hooks.ts
@@ -22,6 +22,7 @@ export type HookEvent =
   | "PermissionRequest"
   | "WorktreeCreate"
   | "WorktreeRemove"
+  | "CwdChanged"
   | "SessionStart"
   | "SessionEnd";
 
@@ -113,6 +114,7 @@ export function isValidHookEvent(event: string): event is HookEvent {
     "PermissionRequest",
     "WorktreeCreate",
     "WorktreeRemove",
+    "CwdChanged",
     "SessionStart",
     "SessionEnd",
   ].includes(event);
@@ -171,7 +173,7 @@ export interface HookJsonInput {
   session_id: string; // Format: "wave_session_{uuid}_{shortId}"
   transcript_path: string; // Format: "~/.wave/sessions/session_{shortId}.json"
   cwd: string; // Absolute path to current working directory
-  hook_event_name: HookEvent; // "PreToolUse" | "PostToolUse" | "UserPromptSubmit" | "Stop" | "SubagentStop" | "PermissionRequest" | "WorktreeCreate" | "SessionStart"
+  hook_event_name: HookEvent; // "PreToolUse" | "PostToolUse" | "UserPromptSubmit" | "Stop" | "SubagentStop" | "PermissionRequest" | "WorktreeCreate" | "CwdChanged" | "SessionStart"
 
   // Optional fields based on event type
   tool_name?: string; // Present for PreToolUse, PostToolUse, PermissionRequest
@@ -180,6 +182,8 @@ export interface HookJsonInput {
   user_prompt?: string; // Present for UserPromptSubmit only
   subagent_type?: string; // Present when hook is executed by a subagent
   name?: string; // Present for WorktreeCreate events
+  old_cwd?: string; // Present for CwdChanged events
+  new_cwd?: string; // Present for CwdChanged events
   source?: SessionStartSource; // Present for SessionStart events
   agent_type?: string; // Present for SessionStart events
   end_source?: SessionEndSource; // Present for SessionEnd events
@@ -196,6 +200,8 @@ export interface ExtendedHookExecutionContext extends HookExecutionContext {
   userPrompt?: string; // User prompt text (UserPromptSubmit only)
   subagentType?: string; // Subagent type when hook is executed by a subagent
   worktreeName?: string; // Worktree name (WorktreeCreate only)
+  oldCwd?: string; // Previous working directory (CwdChanged only)
+  newCwd?: string; // New working directory (CwdChanged only)
   source?: SessionStartSource; // Session start source (SessionStart only)
   agentType?: string; // Agent type identifier (SessionStart only)
   endSource?: SessionEndSource; // Session end source (SessionEnd only)

--- a/packages/agent-sdk/tests/tools/bashTool.test.ts
+++ b/packages/agent-sdk/tests/tools/bashTool.test.ts
@@ -106,6 +106,7 @@ describe("bashTool", () => {
       const spawnCallArgs = mockSpawn.mock.calls[0];
       expect(typeof spawnCallArgs[0]).toBe("string");
       expect(spawnCallArgs[0]).toContain("echo hello");
+      expect(spawnCallArgs[0]).toContain("pwd -P");
       expect(spawnCallArgs[1]).toMatchObject({
         shell: true,
         stdio: "pipe",
@@ -508,6 +509,139 @@ describe("bashTool", () => {
 
       expect(result.success).toBe(true);
       expect(result.shortResult).toBe("... +2 lines\nline3\nline4\nline5");
+    });
+  });
+
+  describe("CWD reset when outside safe zone", () => {
+    const createMockProcess = (exitCode: number, newCwd: string) => {
+      const mockProcess = {
+        pid: 1234,
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+        on: vi.fn((event: string, callback: (code: number) => void) => {
+          if (event === "exit") {
+            setTimeout(() => {
+              // Simulate the temp CWD file being written
+              vi.mocked(fs.existsSync).mockReturnValue(true);
+              vi.mocked(fs.readFileSync).mockReturnValue(newCwd + "\n");
+              callback(exitCode);
+            }, 10);
+          }
+        }),
+        kill: vi.fn(),
+        killed: false,
+      };
+      return mockProcess;
+    };
+
+    it("should accept CWD when inside safe zone", async () => {
+      const mockOnCwdChange = vi.fn();
+      const mockPermissionManager = {
+        createContext: vi.fn().mockReturnValue({}),
+        checkPermission: vi.fn().mockResolvedValue({ behavior: "allow" }),
+        isPathInSafeZone: vi.fn().mockReturnValue(true),
+      };
+      const testContext: ToolContext = {
+        ...context,
+        onCwdChange: mockOnCwdChange,
+        originalWorkdir: "/test/workdir",
+        permissionManager:
+          mockPermissionManager as unknown as ToolContext["permissionManager"],
+      };
+
+      mockSpawn.mockReturnValue(
+        createMockProcess(0, "/test/workdir/subdir") as unknown as ChildProcess,
+      );
+
+      const result = await bashTool.execute(
+        { command: "cd subdir" },
+        testContext,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockOnCwdChange).toHaveBeenCalledWith("/test/workdir/subdir");
+      expect(result.content).not.toContain("Shell cwd was reset to");
+    });
+
+    it("should reset CWD to originalWorkdir when outside safe zone", async () => {
+      const mockOnCwdChange = vi.fn();
+      const mockPermissionManager = {
+        createContext: vi.fn().mockReturnValue({}),
+        checkPermission: vi.fn().mockResolvedValue({ behavior: "allow" }),
+        isPathInSafeZone: vi.fn().mockReturnValue(false),
+      };
+      const testContext: ToolContext = {
+        ...context,
+        onCwdChange: mockOnCwdChange,
+        originalWorkdir: "/test/workdir",
+        permissionManager:
+          mockPermissionManager as unknown as ToolContext["permissionManager"],
+      };
+
+      mockSpawn.mockReturnValue(
+        createMockProcess(
+          0,
+          "/home/liuyiqi/other-dir",
+        ) as unknown as ChildProcess,
+      );
+
+      const result = await bashTool.execute(
+        { command: "cd /home/liuyiqi/other-dir" },
+        testContext,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockOnCwdChange).toHaveBeenCalledWith("/test/workdir");
+      expect(result.content).toContain("Shell cwd was reset to /test/workdir");
+    });
+
+    it("should accept CWD when no permissionManager (backward compatible)", async () => {
+      const mockOnCwdChange = vi.fn();
+      const testContext: ToolContext = {
+        ...context,
+        onCwdChange: mockOnCwdChange,
+        originalWorkdir: "/test/workdir",
+      };
+
+      mockSpawn.mockReturnValue(
+        createMockProcess(0, "/test/workdir/subdir") as unknown as ChildProcess,
+      );
+
+      const result = await bashTool.execute(
+        { command: "cd subdir" },
+        testContext,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockOnCwdChange).toHaveBeenCalledWith("/test/workdir/subdir");
+    });
+
+    it("should accept CWD when outside safe zone but no originalWorkdir", async () => {
+      const mockOnCwdChange = vi.fn();
+      const mockPermissionManager = {
+        createContext: vi.fn().mockReturnValue({}),
+        checkPermission: vi.fn().mockResolvedValue({ behavior: "allow" }),
+        isPathInSafeZone: vi.fn().mockReturnValue(false),
+      };
+      const testContext: ToolContext = {
+        ...context,
+        onCwdChange: mockOnCwdChange,
+        permissionManager:
+          mockPermissionManager as unknown as ToolContext["permissionManager"],
+      };
+
+      mockSpawn.mockReturnValue(
+        createMockProcess(0, "/some/other/dir") as unknown as ChildProcess,
+      );
+
+      const result = await bashTool.execute(
+        { command: "cd /some/other/dir" },
+        testContext,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockOnCwdChange).toHaveBeenCalledWith("/some/other/dir");
+      expect(result.content).not.toContain("Shell cwd was reset to");
     });
   });
 


### PR DESCRIPTION
Revert the removal of CWD tracking (commit fa96d48c) and restore
the bash tool prompt text (commit a49d6257 partially).

Changes restored:
- bashTool wraps foreground commands with 'pwd -P' to detect CWD changes
- AIManager updates workdir via container.register on CWD change
- Agent.sync via onWorkdirChange callback and setWorkdir() method
- CwdChanged hook event with old_cwd/new_cwd fields
- HookManager.executeCwdChangedHooks() for CwdChanged event support
- CWD reset to originalWorkdir when outside safe zone
- onCwdChange callback in ToolContext
- originalWorkdir field in ToolContext and AIManager
- cwd-tracking.ts example restored
- CWD management prompt section restored in bashTool

Conflict resolution:
- WorktreeRemove was added after the removal; kept both WorktreeRemove
  and CwdChanged alongside each other
- Adapted this.workdir references to use this.getWorkdir() /
  this.container.register() since AIManager was refactored to use DI
