### PR TITLE
worktree calm loud mountain

### DIFF
--- a/packages/agent-sdk/src/utils/gitUtils.ts
+++ b/packages/agent-sdk/src/utils/gitUtils.ts
@@ -82,79 +82,144 @@ export function getGitMainRepoRoot(cwd: string): string {
 }
 
 /**
- * Get the default remote branch (e.g., origin/main)
+ * Resolve the git directory for a repository by walking up from `cwd`.
+ * Handles both normal repos (.git is a directory) and worktrees
+ * (.git is a file pointing to the main repo's worktree git dir).
+ * For worktrees, reads the `commondir` file to find the common git dir.
+ * @param cwd Working directory to start searching from
+ * @returns Absolute path to the git directory, or null if not found
+ */
+export function resolveGitDir(cwd: string): string | null {
+  let currentPath = path.resolve(cwd);
+  while (currentPath !== path.dirname(currentPath)) {
+    const gitPath = path.join(currentPath, ".git");
+    if (fsSync.existsSync(gitPath)) {
+      const stat = fsSync.statSync(gitPath);
+      if (stat.isDirectory()) {
+        // Normal repo: .git is a directory
+        return gitPath;
+      }
+      // Worktree: .git is a file containing "gitdir: <path>"
+      try {
+        const content = fsSync.readFileSync(gitPath, "utf8").trim();
+        const prefix = "gitdir: ";
+        if (content.startsWith(prefix)) {
+          const worktreeGitDir = content.substring(prefix.length);
+          // Read commondir to find the common git dir
+          const commondirPath = path.join(worktreeGitDir, "commondir");
+          if (fsSync.existsSync(commondirPath)) {
+            const commondirRel = fsSync
+              .readFileSync(commondirPath, "utf8")
+              .trim();
+            return path.resolve(worktreeGitDir, commondirRel);
+          }
+          // Fallback: resolve ../.. from the worktree git dir
+          return path.resolve(worktreeGitDir, "..", "..");
+        }
+      } catch {
+        return null;
+      }
+    }
+    currentPath = path.dirname(currentPath);
+  }
+  return null;
+}
+
+/**
+ * Read a symbolic ref file in the git directory.
+ * If the file content starts with "ref: ", returns the target ref path.
+ * Symbolic refs are never packed in packed-refs, so only loose refs are checked.
+ * @param gitDir Absolute path to the git directory
+ * @param refPath Relative path to the ref file (e.g., "refs/remotes/origin/HEAD")
+ * @returns The symbolic ref target, or null if not a symbolic ref or on error
+ */
+function readSymref(gitDir: string, refPath: string): string | null {
+  try {
+    const fullPath = path.join(gitDir, refPath);
+    const content = fsSync.readFileSync(fullPath, "utf8").trim();
+    if (content.startsWith("ref: ")) {
+      return content.substring("ref: ".length);
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if a git ref exists, checking both loose refs and packed-refs.
+ * @param gitDir Absolute path to the git directory
+ * @param refPath Relative path to the ref (e.g., "refs/remotes/origin/main")
+ * @returns True if the ref exists, false otherwise
+ */
+function refExists(gitDir: string, refPath: string): boolean {
+  // 1. Check loose ref
+  const loosePath = path.join(gitDir, refPath);
+  if (fsSync.existsSync(loosePath)) {
+    return true;
+  }
+  // 2. Check packed-refs
+  try {
+    const packedRefsPath = path.join(gitDir, "packed-refs");
+    const content = fsSync.readFileSync(packedRefsPath, "utf8");
+    for (const line of content.split("\n")) {
+      // Skip comments and peeled lines
+      if (line.startsWith("#") || line.startsWith("^")) {
+        continue;
+      }
+      // Format: <sha> <refPath>
+      const parts = line.split(" ");
+      if (parts.length >= 2 && parts[1] === refPath) {
+        return true;
+      }
+    }
+  } catch {
+    // packed-refs doesn't exist or can't be read
+  }
+  return false;
+}
+
+/**
+ * Get the default remote branch (e.g., origin/main) using filesystem reads.
+ * No subprocess calls — matches Claude Code's approach.
+ *
+ * Priority:
+ * 1. Read refs/remotes/origin/HEAD symref → extract branch name (verify it exists)
+ * 2. Check if refs/remotes/origin/main ref exists
+ * 3. Check if refs/remotes/origin/master ref exists
+ * 4. Hardcoded "main" fallback
+ *
  * @param cwd Working directory
  * @returns Default remote branch name
  */
 export function getDefaultRemoteBranch(cwd: string): string {
-  // 1. Try git symbolic-ref refs/remotes/origin/HEAD
-  try {
-    const head = execSync("git symbolic-ref refs/remotes/origin/HEAD", {
-      cwd,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-    const branch = head.replace("refs/remotes/", "");
+  const gitDir = resolveGitDir(cwd);
+  if (!gitDir) {
+    return "main";
+  }
+
+  // 1. Try reading origin/HEAD symref
+  const symref = readSymref(gitDir, "refs/remotes/origin/HEAD");
+  if (symref) {
+    const branch = symref.replace("refs/remotes/", "");
     // Verify the resolved branch actually exists (origin/HEAD can be stale)
-    try {
-      execSync(`git rev-parse --verify ${branch}`, {
-        cwd,
-        stdio: "ignore",
-      });
+    if (refExists(gitDir, symref)) {
       return branch;
-    } catch {
-      // Stale ref, continue to next step
     }
-  } catch {
-    // Ignore error and proceed to next step
   }
 
   // 2. Check if origin/main exists
-  try {
-    execSync("git rev-parse --verify origin/main", {
-      cwd,
-      stdio: "ignore",
-    });
+  if (refExists(gitDir, "refs/remotes/origin/main")) {
     return "origin/main";
-  } catch {
-    // Ignore error and proceed to next step
   }
 
   // 3. Check if origin/master exists
-  try {
-    execSync("git rev-parse --verify origin/master", {
-      cwd,
-      stdio: "ignore",
-    });
+  if (refExists(gitDir, "refs/remotes/origin/master")) {
     return "origin/master";
-  } catch {
-    // Ignore error and proceed to next step
   }
 
-  // 4. Try to get the current branch's upstream
-  try {
-    return execSync("git rev-parse --abbrev-ref --symbolic-full-name @{u}", {
-      cwd,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-  } catch {
-    // Ignore error and proceed to next step
-  }
-
-  // 5. Try to get the current branch name
-  try {
-    return execSync("git rev-parse --abbrev-ref HEAD", {
-      cwd,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-  } catch {
-    // Ignore error and proceed to next step
-  }
-
-  // 6. Fallback to origin/main
-  return "origin/main";
+  // 4. Hardcoded fallback
+  return "main";
 }
 
 /**

--- a/packages/agent-sdk/src/utils/gitUtils.ts
+++ b/packages/agent-sdk/src/utils/gitUtils.ts
@@ -94,7 +94,17 @@ export function getDefaultRemoteBranch(cwd: string): string {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();
-    return head.replace("refs/remotes/", "");
+    const branch = head.replace("refs/remotes/", "");
+    // Verify the resolved branch actually exists (origin/HEAD can be stale)
+    try {
+      execSync(`git rev-parse --verify ${branch}`, {
+        cwd,
+        stdio: "ignore",
+      });
+      return branch;
+    } catch {
+      // Stale ref, continue to next step
+    }
   } catch {
     // Ignore error and proceed to next step
   }

--- a/packages/agent-sdk/src/utils/worktreeUtils.ts
+++ b/packages/agent-sdk/src/utils/worktreeUtils.ts
@@ -174,6 +174,69 @@ export function createWorktree(name: string, cwd: string): WorktreeInfo {
         );
       }
     }
+    if (
+      stderr.includes("not a valid object name") ||
+      stderr.includes("unknown revision")
+    ) {
+      // Base branch not fetched yet — try fetching then retrying
+      const branchNameOnly = baseBranch.split("/").pop()!;
+      try {
+        execSync(`git fetch origin ${branchNameOnly}`, {
+          cwd: repoRoot,
+          stdio: ["ignore", "pipe", "pipe"],
+          env: {
+            ...process.env,
+            GIT_TERMINAL_PROMPT: "0",
+            GIT_ASKPASS: "",
+          },
+        });
+        execSync(
+          `git worktree add -b ${branchName} "${worktreePath}" ${baseBranch}`,
+          {
+            cwd: repoRoot,
+            stdio: ["ignore", "pipe", "pipe"],
+            env: {
+              ...process.env,
+              GIT_TERMINAL_PROMPT: "0",
+              GIT_ASKPASS: "",
+            },
+          },
+        );
+        return {
+          name,
+          path: worktreePath,
+          branch: branchName,
+          repoRoot,
+          isNew: true,
+          originalHeadCommit,
+        };
+      } catch {
+        // Fetch or retry failed — fall back to HEAD
+        try {
+          execSync(`git worktree add -b ${branchName} "${worktreePath}" HEAD`, {
+            cwd: repoRoot,
+            stdio: ["ignore", "pipe", "pipe"],
+            env: {
+              ...process.env,
+              GIT_TERMINAL_PROMPT: "0",
+              GIT_ASKPASS: "",
+            },
+          });
+          return {
+            name,
+            path: worktreePath,
+            branch: branchName,
+            repoRoot,
+            isNew: true,
+            originalHeadCommit,
+          };
+        } catch {
+          throw new Error(
+            `Failed to create worktree: ${(error as Error).message}\n${stderr}`,
+          );
+        }
+      }
+    }
     throw new Error(
       `Failed to create worktree: ${(error as Error).message}\n${stderr}`,
     );

--- a/packages/agent-sdk/tests/utils/gitUtils.test.ts
+++ b/packages/agent-sdk/tests/utils/gitUtils.test.ts
@@ -1,15 +1,26 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { execSync } from "node:child_process";
+import * as fsSync from "node:fs";
+import * as path from "node:path";
 import {
   getGitRepoRoot,
   getGitMainRepoRoot,
   getDefaultRemoteBranch,
+  resolveGitDir,
   hasUncommittedChanges,
   hasNewCommits,
 } from "../../src/utils/gitUtils.js";
 
 vi.mock("node:child_process", () => ({
   execSync: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  statSync: vi.fn(),
+  readdirSync: vi.fn(),
+  mkdirSync: vi.fn(),
 }));
 
 describe("gitUtils", () => {
@@ -78,117 +89,155 @@ describe("gitUtils", () => {
     });
   });
 
+  describe("resolveGitDir", () => {
+    it("should find .git directory for a normal repo", () => {
+      vi.mocked(fsSync.existsSync).mockImplementation(
+        (p) => p === "/repo/root/.git",
+      );
+      vi.mocked(fsSync.statSync).mockReturnValue({
+        isDirectory: () => true,
+      } as unknown as fsSync.Stats);
+      expect(resolveGitDir("/repo/root")).toBe("/repo/root/.git");
+    });
+
+    it("should resolve worktree git dir via commondir", () => {
+      const worktreeGitDir = "/repo/main/.git/worktrees/wt1";
+      vi.mocked(fsSync.existsSync).mockImplementation(
+        (p) =>
+          p === "/repo/worktree/.git" ||
+          p === path.join(worktreeGitDir, "commondir"),
+      );
+      vi.mocked(fsSync.statSync).mockReturnValue({
+        isDirectory: () => false,
+      } as unknown as fsSync.Stats);
+      vi.mocked(fsSync.readFileSync).mockImplementation((p) => {
+        if (p === "/repo/worktree/.git") return `gitdir: ${worktreeGitDir}`;
+        if (p === path.join(worktreeGitDir, "commondir")) return "../..\n";
+        throw new Error("Not found");
+      });
+      expect(resolveGitDir("/repo/worktree")).toBe("/repo/main/.git");
+    });
+
+    it("should return null if no .git found", () => {
+      vi.mocked(fsSync.existsSync).mockReturnValue(false);
+      expect(resolveGitDir("/some/path")).toBeNull();
+    });
+  });
+
   describe("getDefaultRemoteBranch", () => {
-    it("should return the default remote branch from symbolic-ref (Step 1)", () => {
-      vi.mocked(execSync).mockImplementation((cmd) => {
-        if (cmd === "git symbolic-ref refs/remotes/origin/HEAD") {
-          return "refs/remotes/origin/main\n" as unknown as ReturnType<
-            typeof execSync
-          >;
-        }
-        if (cmd === "git rev-parse --verify origin/main") {
-          return "" as unknown as ReturnType<typeof execSync>;
-        }
-        throw new Error("Command failed");
+    const gitDir = "/repo/root/.git";
+
+    function mockGitDirFound() {
+      vi.mocked(fsSync.existsSync).mockImplementation(
+        (p) =>
+          p === "/repo/root/.git" ||
+          p === path.join(gitDir, "refs/remotes/origin/main") ||
+          p === path.join(gitDir, "refs/remotes/origin/master") ||
+          p === path.join(gitDir, "refs/remotes/origin/HEAD"),
+      );
+      vi.mocked(fsSync.statSync).mockReturnValue({
+        isDirectory: () => true,
+      } as unknown as fsSync.Stats);
+    }
+
+    it("should return branch from origin/HEAD symref (Step 1)", () => {
+      mockGitDirFound();
+      vi.mocked(fsSync.readFileSync).mockImplementation((p) => {
+        if (p === path.join(gitDir, "refs/remotes/origin/HEAD"))
+          return "ref: refs/remotes/origin/main\n";
+        throw new Error("Not found");
       });
+      // refs/remotes/origin/main exists (already in existsSync mock)
       expect(getDefaultRemoteBranch("/repo/root")).toBe("origin/main");
     });
 
-    it("should skip stale origin/HEAD and fallback if resolved branch does not exist (Step 1 stale)", () => {
-      vi.mocked(execSync).mockImplementation((cmd) => {
-        if (cmd === "git symbolic-ref refs/remotes/origin/HEAD") {
-          return "refs/remotes/origin/master\n" as unknown as ReturnType<
-            typeof execSync
-          >;
-        }
-        if (cmd === "git rev-parse --verify origin/master") {
-          throw new Error("Command failed");
-        }
-        if (cmd === "git rev-parse --verify origin/main") {
-          return "" as unknown as ReturnType<typeof execSync>;
-        }
-        throw new Error("Command failed");
+    it("should skip stale origin/HEAD and fallback (Step 1 stale)", () => {
+      vi.mocked(fsSync.existsSync).mockImplementation(
+        (p) =>
+          p === "/repo/root/.git" ||
+          p === path.join(gitDir, "refs/remotes/origin/HEAD") ||
+          p === path.join(gitDir, "refs/remotes/origin/main"),
+      );
+      vi.mocked(fsSync.statSync).mockReturnValue({
+        isDirectory: () => true,
+      } as unknown as fsSync.Stats);
+      vi.mocked(fsSync.readFileSync).mockImplementation((p) => {
+        if (p === path.join(gitDir, "refs/remotes/origin/HEAD"))
+          return "ref: refs/remotes/origin/master\n";
+        throw new Error("Not found");
       });
+      // origin/master ref doesn't exist, but origin/main does
       expect(getDefaultRemoteBranch("/repo/root")).toBe("origin/main");
     });
 
-    it("should fallback to origin/main if it exists (Step 2)", () => {
-      vi.mocked(execSync).mockImplementation((cmd) => {
-        if (cmd === "git symbolic-ref refs/remotes/origin/HEAD") {
-          throw new Error("Command failed");
-        }
-        if (cmd === "git rev-parse --verify origin/main") {
-          return "" as unknown as ReturnType<typeof execSync>;
-        }
-        throw new Error("Command failed");
-      });
+    it("should fallback to origin/main if ref exists (Step 2)", () => {
+      vi.mocked(fsSync.existsSync).mockImplementation(
+        (p) =>
+          p === "/repo/root/.git" ||
+          p === path.join(gitDir, "refs/remotes/origin/main"),
+      );
+      vi.mocked(fsSync.statSync).mockReturnValue({
+        isDirectory: () => true,
+      } as unknown as fsSync.Stats);
+      // No origin/HEAD file, but origin/main exists
       expect(getDefaultRemoteBranch("/repo/root")).toBe("origin/main");
     });
 
-    it("should fallback to origin/master if it exists (Step 3)", () => {
-      vi.mocked(execSync).mockImplementation((cmd) => {
-        if (cmd === "git symbolic-ref refs/remotes/origin/HEAD") {
-          throw new Error("Command failed");
-        }
-        if (cmd === "git rev-parse --verify origin/main") {
-          throw new Error("Command failed");
-        }
-        if (cmd === "git rev-parse --verify origin/master") {
-          return "" as unknown as ReturnType<typeof execSync>;
-        }
-        throw new Error("Command failed");
-      });
+    it("should fallback to origin/master if ref exists (Step 3)", () => {
+      vi.mocked(fsSync.existsSync).mockImplementation(
+        (p) =>
+          p === "/repo/root/.git" ||
+          p === path.join(gitDir, "refs/remotes/origin/master"),
+      );
+      vi.mocked(fsSync.statSync).mockReturnValue({
+        isDirectory: () => true,
+      } as unknown as fsSync.Stats);
       expect(getDefaultRemoteBranch("/repo/root")).toBe("origin/master");
     });
 
-    it("should fallback to upstream branch (Step 4)", () => {
-      vi.mocked(execSync).mockImplementation((cmd) => {
-        if (cmd === "git symbolic-ref refs/remotes/origin/HEAD") {
-          throw new Error("Command failed");
-        }
-        if (cmd === "git rev-parse --verify origin/main") {
-          throw new Error("Command failed");
-        }
-        if (cmd === "git rev-parse --verify origin/master") {
-          throw new Error("Command failed");
-        }
-        if (cmd === "git rev-parse --abbrev-ref --symbolic-full-name @{u}") {
-          return "origin/feature-branch\n" as unknown as ReturnType<
-            typeof execSync
-          >;
-        }
-        throw new Error("Command failed");
-      });
-      expect(getDefaultRemoteBranch("/repo/root")).toBe(
-        "origin/feature-branch",
+    it("should return 'main' as hardcoded fallback (Step 4)", () => {
+      vi.mocked(fsSync.existsSync).mockImplementation(
+        (p) => p === "/repo/root/.git",
       );
-    });
-
-    it("should fallback to current branch name (Step 5)", () => {
-      vi.mocked(execSync).mockImplementation((cmd) => {
-        if (cmd === "git symbolic-ref refs/remotes/origin/HEAD") {
-          throw new Error("Command failed");
-        }
-        if (cmd === "git rev-parse --verify origin/main") {
-          throw new Error("Command failed");
-        }
-        if (cmd === "git rev-parse --verify origin/master") {
-          throw new Error("Command failed");
-        }
-        if (cmd === "git rev-parse --abbrev-ref --symbolic-full-name @{u}") {
-          throw new Error("Command failed");
-        }
-        if (cmd === "git rev-parse --abbrev-ref HEAD") {
-          return "main\n" as unknown as ReturnType<typeof execSync>;
-        }
-        throw new Error("Command failed");
-      });
+      vi.mocked(fsSync.statSync).mockReturnValue({
+        isDirectory: () => true,
+      } as unknown as fsSync.Stats);
       expect(getDefaultRemoteBranch("/repo/root")).toBe("main");
     });
 
-    it("should fallback to origin/main if all else fails (Step 6)", () => {
-      vi.mocked(execSync).mockImplementation(() => {
-        throw new Error("Command failed");
+    it("should return 'main' if no git dir found", () => {
+      vi.mocked(fsSync.existsSync).mockReturnValue(false);
+      expect(getDefaultRemoteBranch("/some/path")).toBe("main");
+    });
+
+    it("should find ref in packed-refs", () => {
+      vi.mocked(fsSync.existsSync).mockImplementation(
+        (p) =>
+          p === "/repo/root/.git" || p === path.join(gitDir, "packed-refs"),
+      );
+      vi.mocked(fsSync.statSync).mockReturnValue({
+        isDirectory: () => true,
+      } as unknown as fsSync.Stats);
+      vi.mocked(fsSync.readFileSync).mockImplementation((p) => {
+        if (p === path.join(gitDir, "packed-refs"))
+          return "abc123 refs/remotes/origin/main\n";
+        throw new Error("Not found");
+      });
+      expect(getDefaultRemoteBranch("/repo/root")).toBe("origin/main");
+    });
+
+    it("should skip comments and peeled lines in packed-refs", () => {
+      vi.mocked(fsSync.existsSync).mockImplementation(
+        (p) =>
+          p === "/repo/root/.git" || p === path.join(gitDir, "packed-refs"),
+      );
+      vi.mocked(fsSync.statSync).mockReturnValue({
+        isDirectory: () => true,
+      } as unknown as fsSync.Stats);
+      vi.mocked(fsSync.readFileSync).mockImplementation((p) => {
+        if (p === path.join(gitDir, "packed-refs"))
+          return "# pack-refs\n^def456\nabc123 refs/remotes/origin/main\n";
+        throw new Error("Not found");
       });
       expect(getDefaultRemoteBranch("/repo/root")).toBe("origin/main");
     });

--- a/packages/agent-sdk/tests/utils/gitUtils.test.ts
+++ b/packages/agent-sdk/tests/utils/gitUtils.test.ts
@@ -86,6 +86,27 @@ describe("gitUtils", () => {
             typeof execSync
           >;
         }
+        if (cmd === "git rev-parse --verify origin/main") {
+          return "" as unknown as ReturnType<typeof execSync>;
+        }
+        throw new Error("Command failed");
+      });
+      expect(getDefaultRemoteBranch("/repo/root")).toBe("origin/main");
+    });
+
+    it("should skip stale origin/HEAD and fallback if resolved branch does not exist (Step 1 stale)", () => {
+      vi.mocked(execSync).mockImplementation((cmd) => {
+        if (cmd === "git symbolic-ref refs/remotes/origin/HEAD") {
+          return "refs/remotes/origin/master\n" as unknown as ReturnType<
+            typeof execSync
+          >;
+        }
+        if (cmd === "git rev-parse --verify origin/master") {
+          throw new Error("Command failed");
+        }
+        if (cmd === "git rev-parse --verify origin/main") {
+          return "" as unknown as ReturnType<typeof execSync>;
+        }
         throw new Error("Command failed");
       });
       expect(getDefaultRemoteBranch("/repo/root")).toBe("origin/main");

--- a/packages/agent-sdk/tests/utils/worktreeUtils.test.ts
+++ b/packages/agent-sdk/tests/utils/worktreeUtils.test.ts
@@ -140,6 +140,102 @@ describe("worktreeUtils", () => {
 
       expect(result.isNew).toBe(true);
     });
+
+    it("should fetch default branch when not found locally, then create worktree", () => {
+      let callCount = 0;
+      vi.mocked(execSync).mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // getHeadCommit
+          return "abc123\n";
+        }
+        if (callCount === 2) {
+          // First git worktree add -b fails — branch not fetched
+          const err = new Error("git error") as Error & {
+            stderr?: Buffer;
+          };
+          err.stderr = Buffer.from("not a valid object name");
+          throw err;
+        }
+        if (callCount === 3) {
+          // git fetch origin main succeeds
+          return "";
+        }
+        // Retry git worktree add -b succeeds
+        return "";
+      });
+
+      const result = worktreeUtils.createWorktree("feat", "/test");
+
+      expect(result.isNew).toBe(true);
+      expect(result.originalHeadCommit).toBe("abc123");
+      expect(execSync).toHaveBeenCalledWith(
+        expect.stringContaining("git fetch origin main"),
+        expect.anything(),
+      );
+    });
+
+    it("should fall back to HEAD when fetch also fails", () => {
+      let callCount = 0;
+      vi.mocked(execSync).mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // getHeadCommit
+          return "abc123\n";
+        }
+        if (callCount === 2) {
+          // First git worktree add -b fails
+          const err = new Error("git error") as Error & {
+            stderr?: Buffer;
+          };
+          err.stderr = Buffer.from("not a valid object name");
+          throw err;
+        }
+        if (callCount === 3) {
+          // git fetch origin main fails
+          throw new Error("fetch failed");
+        }
+        // git worktree add -b ... HEAD succeeds
+        return "";
+      });
+
+      const result = worktreeUtils.createWorktree("feat", "/test");
+
+      expect(result.isNew).toBe(true);
+      expect(execSync).toHaveBeenCalledWith(
+        expect.stringMatching(/git worktree add -b worktree-feat ".*" HEAD/),
+        expect.anything(),
+      );
+    });
+
+    it("should throw when both fetch and HEAD fallback fail", () => {
+      let callCount = 0;
+      vi.mocked(execSync).mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // getHeadCommit
+          return "abc123\n";
+        }
+        if (callCount === 2) {
+          // First git worktree add -b fails
+          const err = new Error("git error") as Error & {
+            stderr?: Buffer;
+          };
+          err.stderr = Buffer.from("not a valid object name");
+          throw err;
+        }
+        if (callCount === 3) {
+          // git fetch origin main fails
+          throw new Error("fetch failed");
+        }
+        // git worktree add -b ... HEAD also fails
+        throw new Error("HEAD fallback failed");
+      });
+
+      expect(() => worktreeUtils.createWorktree("feat", "/test")).toThrow(
+        "Failed to create worktree",
+      );
+    });
   });
 
   describe("removeWorktree", () => {

--- a/packages/code/src/utils/worktree.ts
+++ b/packages/code/src/utils/worktree.ts
@@ -88,6 +88,56 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
         );
       }
     }
+    if (
+      stderr.includes("not a valid object name") ||
+      stderr.includes("unknown revision")
+    ) {
+      // Base branch not fetched yet — try fetching then retrying
+      const branchNameOnly = baseBranch.split("/").pop()!;
+      try {
+        execSync(`git fetch origin ${branchNameOnly}`, {
+          cwd: repoRoot,
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        execSync(
+          `git worktree add -b ${branchName} "${worktreePath}" ${baseBranch}`,
+          {
+            cwd: repoRoot,
+            stdio: ["ignore", "pipe", "pipe"],
+          },
+        );
+        return {
+          name,
+          path: worktreePath,
+          branch: branchName,
+          repoRoot,
+          hasUncommittedChanges: false,
+          hasNewCommits: false,
+          isNew: true,
+        };
+      } catch {
+        // Fetch or retry failed — fall back to HEAD
+        try {
+          execSync(`git worktree add -b ${branchName} "${worktreePath}" HEAD`, {
+            cwd: repoRoot,
+            stdio: ["ignore", "pipe", "pipe"],
+          });
+          return {
+            name,
+            path: worktreePath,
+            branch: branchName,
+            repoRoot,
+            hasUncommittedChanges: false,
+            hasNewCommits: false,
+            isNew: true,
+          };
+        } catch {
+          throw new Error(
+            `Failed to create worktree: ${(error as Error).message}\n${stderr}`,
+          );
+        }
+      }
+    }
     throw new Error(
       `Failed to create worktree: ${(error as Error).message}\n${stderr}`,
     );

--- a/packages/code/tests/utils/worktree.test.ts
+++ b/packages/code/tests/utils/worktree.test.ts
@@ -116,6 +116,95 @@ describe("worktree utils", () => {
         "Failed to add existing worktree branch",
       );
     });
+
+    it("should fetch default branch when not found locally, then create worktree", () => {
+      vi.mocked(getGitMainRepoRoot).mockReturnValue("/repo/root");
+      vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      // First git worktree add -b fails — branch not fetched
+      const error = new Error("Command failed");
+      (error as { stderr?: Buffer }).stderr = Buffer.from(
+        "not a valid object name",
+      );
+      vi.mocked(execSync).mockImplementationOnce(() => {
+        throw error;
+      });
+
+      // git fetch origin main succeeds
+      vi.mocked(execSync).mockImplementationOnce(() => Buffer.from(""));
+
+      // Retry git worktree add -b succeeds
+      vi.mocked(execSync).mockImplementationOnce(() => Buffer.from(""));
+
+      const session = createWorktree("my-feat", "/repo/root");
+
+      expect(session.isNew).toBe(true);
+      expect(execSync).toHaveBeenCalledWith(
+        expect.stringContaining("git fetch origin main"),
+        expect.any(Object),
+      );
+    });
+
+    it("should fall back to HEAD when fetch also fails", () => {
+      vi.mocked(getGitMainRepoRoot).mockReturnValue("/repo/root");
+      vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      // First git worktree add -b fails
+      const error = new Error("Command failed");
+      (error as { stderr?: Buffer }).stderr = Buffer.from(
+        "not a valid object name",
+      );
+      vi.mocked(execSync).mockImplementationOnce(() => {
+        throw error;
+      });
+
+      // git fetch origin main fails
+      vi.mocked(execSync).mockImplementationOnce(() => {
+        throw new Error("fetch failed");
+      });
+
+      // git worktree add -b ... HEAD succeeds
+      vi.mocked(execSync).mockImplementationOnce(() => Buffer.from(""));
+
+      const session = createWorktree("my-feat", "/repo/root");
+
+      expect(session.isNew).toBe(true);
+      expect(execSync).toHaveBeenCalledWith(
+        expect.stringMatching(/git worktree add -b worktree-my-feat ".*" HEAD/),
+        expect.any(Object),
+      );
+    });
+
+    it("should throw when both fetch and HEAD fallback fail", () => {
+      vi.mocked(getGitMainRepoRoot).mockReturnValue("/repo/root");
+      vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      // First git worktree add -b fails
+      const error = new Error("Command failed");
+      (error as { stderr?: Buffer }).stderr = Buffer.from(
+        "not a valid object name",
+      );
+      vi.mocked(execSync).mockImplementationOnce(() => {
+        throw error;
+      });
+
+      // git fetch origin main fails
+      vi.mocked(execSync).mockImplementationOnce(() => {
+        throw new Error("fetch failed");
+      });
+
+      // git worktree add -b ... HEAD also fails
+      vi.mocked(execSync).mockImplementationOnce(() => {
+        throw new Error("HEAD fallback failed");
+      });
+
+      expect(() => createWorktree("my-feat", "/repo/root")).toThrow(
+        "Failed to create worktree",
+      );
+    });
   });
 
   describe("removeWorktree", () => {


### PR DESCRIPTION
- **fix: verify origin/HEAD resolved branch exists to handle stale refs**
- **refactor: use filesystem reads for getDefaultRemoteBranch and add fetch+HEAD fallback in worktree creation**
