### PR TITLE
Add spec-count script and migrate 3 specs to standard template

### DIFF
--- a/scripts/spec-count.js
+++ b/scripts/spec-count.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const specsDir = path.join(__dirname, "..", "specs");
+
+const specDirs = fs
+  .readdirSync(specsDir, { withFileTypes: true })
+  .filter((d) => d.isDirectory())
+  .map((d) => d.name)
+  .sort();
+
+let totalSpecs = 0;
+let totalUS = 0;
+let totalFR = 0;
+
+for (const dir of specDirs) {
+  const specFile = path.join(specsDir, dir, "spec.md");
+  if (!fs.existsSync(specFile)) continue;
+
+  totalSpecs++;
+  const content = fs.readFileSync(specFile, "utf-8");
+
+  const usMatches = content.match(/^### User Story \d+/gm);
+  const usCount = usMatches ? usMatches.length : 0;
+  totalUS += usCount;
+
+  const frMatches = content.match(/^- \*\*FR-\d+\*\*/gm);
+  const frCount = frMatches ? frMatches.length : 0;
+  totalFR += frCount;
+
+  console.log(`${dir}  US: ${usCount}  FR: ${frCount}`);
+}
+
+console.log("---");
+console.log(`Specs: ${totalSpecs}  User Stories: ${totalUS}  Functional Requirements: ${totalFR}`);

--- a/specs/026-clear-command/spec.md
+++ b/specs/026-clear-command/spec.md
@@ -1,31 +1,44 @@
-# Spec: Clear Command in SDK
+# Feature Specification: Clear Command
 
-## Overview
-The `clear` command is a core feature that resets the conversation history and session. It is implemented as a built-in slash command in the `SlashCommandManager` within `packages/agent-sdk`.
+**Feature Branch**: `026-clear-command`
+**Created**: 2026-04-01
+**Input**: "Provide a built-in /clear slash command that resets conversation history and session state."
 
-## Goals
-- Provide a consistent way to clear messages and sync the task list via the SDK.
-- Ensure the CLI can react to session resets (e.g., by clearing the terminal).
-- Make the `clear` command available to all consumers of the SDK.
-- Ensure programmatic calls to `clearMessages()` have the same effect as typing `/clear`.
+## User Scenarios & Testing *(mandatory)*
 
-## Architecture
-The `clear` command is registered as a built-in slash command in the SDK. When executed, it performs the following actions:
-1. Aborts any ongoing AI message processing.
-2. Clears the conversation history and generates a new session ID.
-3. Synchronizes the task list with the new session ID.
+### User Story 1 - Clear conversation via slash command (Priority: P1)
 
-The CLI (packages/code) reacts to the `sessionId` change by clearing the terminal screen and remounting the chat interface.
+As a CLI user, I want to type `/clear` to reset my conversation history so I can start a fresh session without restarting the application.
 
-## Components
+**Acceptance Scenarios**:
 
-### SDK (agent-sdk)
-- **SlashCommandManager**: Registers the `clear` command and handles its execution.
-- **Agent**: Provides an async `clearMessages()` method that delegates to the `clear` slash command.
+1. **Given** an active conversation with messages, **When** the user types `/clear`, **Then** the conversation history is cleared, a new session ID is generated, and the terminal screen is cleared.
+2. **Given** an ongoing AI response is being processed, **When** the user types `/clear`, **Then** the ongoing AI processing is aborted before the conversation is cleared.
+3. **Given** the task list has items from the current session, **When** `/clear` is executed, **Then** the task list is synchronized with the new session ID.
 
-### CLI (code)
-- **App Component**: Reacts to `sessionId` changes to clear the terminal.
+---
 
-## User Experience
-- Typing `/clear` in the CLI resets the conversation and clears the screen.
-- Programmatic calls to `agent.clearMessages()` in the SDK perform the same reset.
+### User Story 2 - Programmatic clear via SDK (Priority: P1)
+
+As an SDK consumer, I want to call `agent.clearMessages()` to reset the conversation so my application can programmatically start a new session.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active agent session with messages, **When** `agent.clearMessages()` is called, **Then** the conversation history is cleared and a new session ID is generated, producing the same effect as typing `/clear`.
+
+---
+
+### Edge Cases
+
+- **What happens if `/clear` is called while no conversation exists?** A new session ID is generated anyway; no error is thrown.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The SDK MUST register a `clear` built-in slash command in the `SlashCommandManager`.
+- **FR-002**: Executing `/clear` MUST abort any ongoing AI message processing.
+- **FR-003**: Executing `/clear` MUST clear the conversation history and generate a new session ID.
+- **FR-004**: Executing `/clear` MUST synchronize the task list with the new session ID.
+- **FR-005**: The `Agent` class MUST expose an async `clearMessages()` method that delegates to the `clear` slash command.
+- **FR-006**: The CLI MUST react to session ID changes by clearing the terminal screen and remounting the chat interface.

--- a/specs/032-btw-command/spec.md
+++ b/specs/032-btw-command/spec.md
@@ -1,38 +1,62 @@
-# BTW Command Spec
+# Feature Specification: BTW Command
 
-The `/btw <question>` command allows users to ask side questions to the AI without using tools. The answer is displayed in a special component at the bottom of the chat interface, and the main input box is disabled while the side question is active. A key feature of this command is that it bypasses the main message queue, allowing it to be processed immediately even if the AI is busy with another task.
+**Feature Branch**: `032-btw-command`
+**Created**: 2026-04-15
+**Input**: "Allow users to ask side questions via /btw without triggering tools, processed immediately even while the AI is busy."
 
-## Goals
+## User Scenarios & Testing *(mandatory)*
 
-- Provide a way to ask quick questions without triggering tool executions.
-- Keep the side question context separate from the main conversation flow.
-- Allow users to dismiss the side question view easily.
-- Ensure side questions are processed immediately, bypassing the main message queue.
-- Prevent side questions from being added to the main chat history or user input history.
+### User Story 1 - Ask a side question (Priority: P1)
 
-## User Experience
+As a CLI user, I want to type `/btw <question>` to ask a quick side question so I can get an answer without triggering tool executions or interrupting the main conversation.
 
-1. User types `/btw <question>` and presses Enter, or just types `/btw` and presses Enter to enter "BTW mode".
-2. The main input box shows a cyan border and "Type your side question..." placeholder in cyan if empty. A cursor is displayed before the placeholder.
-3. The status line shows `Mode: BTW (ESC to dismiss)` where "BTW" is in cyan.
-4. A `BtwDisplay` component appears above the task list and loading indicator.
-5. The `BtwDisplay` shows a status dot (yellow when loading, green when finished) followed by the question as `/btw <question>` in italic gray.
-6. Once the AI responds, the answer is displayed in the `BtwDisplay`.
-7. The user can press **ESC** to dismiss the `BtwDisplay` and return to the main conversation mode.
+**Acceptance Scenarios**:
 
-## Implementation Details
+1. **Given** the user is in the main conversation mode, **When** the user types `/btw <question>` and presses Enter, **Then** a `BtwDisplay` component appears showing the question and a loading indicator, and the AI responds without calling any tools.
+2. **Given** the AI is currently processing another task, **When** the user types `/btw <question>`, **Then** the side question bypasses the main message queue and is processed immediately.
+3. **Given** the AI has responded to the side question, **When** the user presses **ESC**, **Then** the `BtwDisplay` is dismissed and the user returns to the main conversation mode.
 
-### Agent SDK
+---
 
-- **`AiService`**: Added `btw` method that uses a specialized system prompt (`BTW_SYSTEM_PROMPT`) to prevent tool calling.
-- **`Agent`**: Added `askBtw` method to call the AI service.
+### User Story 2 - Enter BTW mode interactively (Priority: P2)
 
-### Code Package
+As a CLI user, I want to type `/btw` without a question to enter BTW mode so I can type my side question in a dedicated input state.
 
-- **`inputReducer`**: Added `btwState` to track `isActive`, `question`, `answer`, and `isLoading`.
-- **`inputHandlers`**: Intercepts `/btw` command and handles the **ESC** key to dismiss the side question.
-- **`useInputManager`**: Manages the lifecycle of the side question and calls the `onAskBtw` callback.
-- **`useChat`**: Provides the `askBtw` implementation and manages the `btwState` in the chat context.
-- **`BtwDisplay`**: A compact Ink component to render the side question and answer. It displays the question as `/btw <question>` in italic gray.
-- **`InputBox`**: Updated to show a cyan border and a cursor before the placeholder text when `btwState.isActive` is true.
-- **`StatusLine`**: Updated to prioritize displaying `Mode: BTW (ESC to dismiss)` when `btwState.isActive` is true.
+**Acceptance Scenarios**:
+
+1. **Given** the user is in the main conversation mode, **When** the user types `/btw` and presses Enter, **Then** the input box enters BTW mode with a cyan border and "Type your side question..." placeholder.
+2. **Given** the input is in BTW mode, **When** the user types a question and presses Enter, **Then** the side question is submitted and the `BtwDisplay` appears.
+3. **Given** the input is in BTW mode, **When** the user presses **ESC**, **Then** BTW mode is dismissed without submitting a question.
+
+---
+
+### User Story 3 - Visual feedback during BTW (Priority: P2)
+
+As a CLI user, I want clear visual indicators when a side question is active so I can distinguish it from the main conversation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a side question is loading, **Then** the `BtwDisplay` shows a yellow status dot and the status line shows `Mode: BTW (ESC to dismiss)`.
+2. **Given** a side question has been answered, **Then** the `BtwDisplay` shows a green status dot and the answer content.
+
+---
+
+### Edge Cases
+
+- **What happens if the user asks a `/btw` question that would normally trigger a tool?** The specialized `BTW_SYSTEM_PROMPT` prevents tool calling; the AI answers using only its knowledge.
+- **Side questions are NOT added to the main chat history or user input history.**
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The SDK MUST provide an `AiService.btw()` method that calls the AI with a specialized system prompt preventing tool use.
+- **FR-002**: The `Agent` class MUST expose an `askBtw()` method that delegates to `AiService.btw()`.
+- **FR-003**: The `/btw` command MUST bypass the main message queue and be processed immediately.
+- **FR-004**: Side questions and answers MUST NOT be added to the main chat history or user input history.
+- **FR-005**: The CLI MUST render a `BtwDisplay` component showing the question with a status dot (yellow while loading, green when done).
+- **FR-006**: When BTW mode is active, the input box MUST display a cyan border and "Type your side question..." placeholder.
+- **FR-007**: The status line MUST display `Mode: BTW (ESC to dismiss)` when a side question is active.
+- **FR-008**: Pressing **ESC** MUST dismiss the `BtwDisplay` or exit BTW input mode.
+- **FR-009**: The `inputReducer` MUST track `btwState` with `isActive`, `question`, `answer`, and `isLoading` fields.
+- **FR-010**: The `inputHandlers` MUST intercept `/btw` commands and the **ESC** key for BTW state management.

--- a/specs/033-model-command/spec.md
+++ b/specs/033-model-command/spec.md
@@ -1,52 +1,63 @@
-# /model Command Spec
+# Feature Specification: /model Command
 
-The `/model` command allows users to interactively switch between configured AI models within the CLI. It opens a dedicated UI component (Model Selector) that lists available models, allowing the user to select one using keyboard navigation.
+**Feature Branch**: `033-model-command`
+**Created**: 2026-04-16
+**Input**: "Allow users to interactively switch AI models via /model command with a visual selector UI."
 
-## Goals
+## User Scenarios & Testing *(mandatory)*
 
-- Provide an interactive, visual way to switch AI models.
-- Support models configured in `settings.json` (user and project levels).
-- Ensure the selected model is used for subsequent AI interactions in the current session.
-- Provide clear feedback in the UI about the currently active model.
+### User Story 1 - Switch model interactively (Priority: P1)
 
-## User Experience
+As a CLI user, I want to type `/model` and select a different AI model from a list so I can change the model for subsequent interactions without restarting.
 
-1. User types `/model` and presses Enter, or selects `model` from the slash command menu.
-2. A `ModelSelector` UI component appears at the bottom of the interface.
-3. The component displays a list of available models:
-    - The currently active model is marked with `(current)` in green.
-    - A cursor `▶` indicates the currently focused item.
-4. User navigates the list using **Up/Down Arrow** keys.
-5. User confirms the selection by pressing **Enter**.
-6. User can cancel and close the selector by pressing **Escape**.
-7. Upon selection:
-    - The selector closes.
-    - The active model for the session is updated.
-    - The change is reflected in the `/status` command output.
+**Acceptance Scenarios**:
 
-## Implementation Details
+1. **Given** the user types `/model` and presses Enter, **Then** a `ModelSelector` UI component appears listing all configured models.
+2. **Given** the model list is displayed, **When** the user navigates with Up/Down arrows and presses Enter, **Then** the selected model becomes the active model and the selector closes.
+3. **Given** the model list is displayed, **When** the user presses Escape, **Then** the selector closes without changing the model.
+4. **Given** the model list is displayed, **Then** the currently active model is marked with `(current)` in green and a cursor `▶` indicates the focused item.
 
-### Agent SDK (`packages/agent-sdk`)
+---
 
-- **`AgentCallbacks`**: 
-    - Added `onModelChange?: (model: string) => void` to notify the UI of model updates.
-    - Added `onConfiguredModelsChange?: (models: string[]) => void` to notify the UI when configured models list changes (e.g., after config reload).
-- **`ConfigurationService`**: 
-    - Added `setModel(model: string)` to update the session's active model in the internal options.
-    - Added `getConfiguredModels(): string[]` to aggregate models from `settings.json`, environment variables, and defaults.
-- **`Agent`**:
-    - Exposed `setModel(model: string)` which updates the configuration and triggers the `onModelChange` callback.
-    - Exposed `getConfiguredModels()` to provide the list of selectable models to the UI.
+### User Story 2 - Model selection persists in session (Priority: P1)
 
-### CLI UI (`packages/code`)
+As a CLI user, I want the selected model to remain active for the rest of the session so all subsequent AI interactions use my chosen model.
 
-- **`inputReducer`**: Added `showModelSelector: boolean` to `InputState` to control the visibility of the selector.
-- **`inputHandlers`**: Intercepts the `model` slash command to set `showModelSelector` to `true`.
-- **`useInputManager`**: Exposes `showModelSelector` and `setShowModelSelector` for component consumption.
-- **`useChat`**: 
-    - Tracks `currentModel` and `configuredModels` state.
-    - Implements the `onModelChange` callback during agent initialization to sync state.
-    - Provides `setModel` and `getConfiguredModels` methods to components.
-- **`ModelSelector`**: A new Ink component that renders the model list and handles keyboard navigation (`Up`, `Down`, `Enter`, `Esc`).
-- **`InputBox`**: Updated to render `ModelSelector` when `showModelSelector` is active, following the pattern of other managers (MCP, Background Tasks).
-- **`StatusCommand`**: Displays the active model name under the "Model:" field.
+**Acceptance Scenarios**:
+
+1. **Given** the user has selected a new model via `/model`, **Then** the `ConfigurationService` updates the active model and subsequent AI calls use the new model.
+2. **Given** the user has selected a new model, **Then** the `onModelChange` callback fires so the UI and status line reflect the updated model.
+
+---
+
+### User Story 3 - Discover available models (Priority: P2)
+
+As a CLI user, I want to see which models are available from my configuration so I know what options I can switch to.
+
+**Acceptance Scenarios**:
+
+1. **Given** models are configured in `settings.json` (user and project levels) and environment variables, **Then** `getConfiguredModels()` aggregates all sources and the `ModelSelector` displays them.
+2. **Given** the configured models list changes (e.g., after config reload), **Then** the `onConfiguredModelsChange` callback fires and the model list is refreshed.
+
+---
+
+### Edge Cases
+
+- **What happens if only one model is configured?** The selector still opens but shows a single item.
+- **What happens if no models are configured?** The selector shows an empty list or a message indicating no models are available.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The CLI MUST provide a `/model` slash command that opens a `ModelSelector` UI component.
+- **FR-002**: The `ModelSelector` MUST display all models returned by `ConfigurationService.getConfiguredModels()`.
+- **FR-003**: The `ModelSelector` MUST highlight the currently active model with `(current)` in green and show a cursor `▶` on the focused item.
+- **FR-004**: The user MUST be able to navigate the model list with Up/Down arrow keys and confirm with Enter.
+- **FR-005**: Pressing Escape MUST close the `ModelSelector` without changing the model.
+- **FR-006**: Upon model selection, `ConfigurationService.setModel()` MUST update the active model for the session.
+- **FR-007**: The `AgentCallbacks` MUST include `onModelChange?: (model: string) => void` to notify the UI of model updates.
+- **FR-008**: The `AgentCallbacks` MUST include `onConfiguredModelsChange?: (models: string[]) => void` to notify the UI when the model list changes.
+- **FR-009**: The `Agent` MUST expose `setModel(model: string)` which updates the configuration and triggers the `onModelChange` callback.
+- **FR-010**: The `Agent` MUST expose `getConfiguredModels()` to provide the list of selectable models.
+- **FR-011**: The `StatusCommand` MUST display the active model name under the "Model:" field.

--- a/specs/README.md
+++ b/specs/README.md
@@ -24,6 +24,16 @@ This directory contains feature specifications that serve as the source of truth
 5. Break down into tasks (`tasks.md`)
 6. Implement against the spec
 
+## Stats
+
+| Metric | Count |
+|--------|-------|
+| Specs | 53 |
+| User Stories | 216 |
+| Functional Requirements | 792 |
+| Test Files | 298 |
+| Test Cases | 3,784 |
+
 ## Specs
 
 | Feature | Description | Links |


### PR DESCRIPTION
- Add scripts/spec-count.js to count specs, user stories, and FRs
- Migrate 026-clear-command, 032-btw-command, 033-model-command
  from free-form format to User Story + FR template
- Add Stats table to specs/README.md (53 specs, 216 US, 792 FR, 298 test files, 3784 test cases)
