### PR TITLE
feat(auth): OAuth token expiration handling (#1137)

### DIFF
--- a/packages/agent-sdk/src/services/authService.ts
+++ b/packages/agent-sdk/src/services/authService.ts
@@ -12,6 +12,7 @@ import {
   chmodSync,
   rmSync,
   mkdirSync,
+  statSync,
 } from "fs";
 import * as path from "path";
 import * as os from "os";
@@ -20,7 +21,7 @@ import { createServer, Server } from "http";
 import { URL } from "url";
 import { execFile } from "child_process";
 import { promisify } from "util";
-import type { AuthConfig, AuthUser } from "../types/auth.js";
+import type { AuthConfig, AuthUser, TokenResponse } from "../types/auth.js";
 
 /** Persistent anonymous ID for telemetry fallback when SSO is not authenticated. */
 let _anonymousId: string | undefined;
@@ -32,6 +33,9 @@ export class AuthService {
   private _serverUrl: string | undefined;
   private onAuthChangeCallbacks: Array<(event: "login" | "logout") => void> =
     [];
+  private _refreshPromise: Promise<boolean> | null = null;
+  private _authFileMtime: number = 0;
+  private static readonly REFRESH_BUFFER_MS = 5 * 60 * 1000;
 
   static getInstance(): AuthService {
     if (!AuthService.instance) {
@@ -83,6 +87,12 @@ export class AuthService {
     }
     try {
       const content = readFileSync(authPath, "utf-8");
+      // Best-effort mtime tracking for multi-process detection
+      try {
+        this._authFileMtime = statSync(authPath).mtimeMs;
+      } catch {
+        // ignore stat errors
+      }
       return JSON.parse(content) as AuthConfig;
     } catch {
       return {};
@@ -97,11 +107,19 @@ export class AuthService {
     }
     writeFileSync(authPath, JSON.stringify(config, null, 2), "utf-8");
     chmodSync(authPath, 0o600);
+    // Update mtime after write
+    try {
+      this._authFileMtime = statSync(authPath).mtimeMs;
+    } catch {
+      // ignore stat errors
+    }
   }
 
   clearAuth(): void {
     const config = this.loadAuth();
     delete config.SSO_TOKEN;
+    delete config.SSO_REFRESH_TOKEN;
+    delete config.SSO_TOKEN_EXPIRES_AT;
     if (Object.keys(config).length === 0) {
       const authPath = this.getAuthPath();
       if (existsSync(authPath)) {
@@ -145,11 +163,22 @@ export class AuthService {
     });
 
     // Exchange authorization code for JWT (includes user info)
-    const { token, user } = await this.exchangeCode(serverUrl, code);
+    const { token, refreshToken, expiresIn, user } = await this.exchangeCode(
+      serverUrl,
+      code,
+    );
 
     // Save the token and user info (preserve existing keys)
     const existing = this.loadAuth();
-    this.saveAuth({ ...existing, SSO_TOKEN: token, user });
+    this.saveAuth({
+      ...existing,
+      SSO_TOKEN: token,
+      SSO_REFRESH_TOKEN: refreshToken,
+      SSO_TOKEN_EXPIRES_AT: expiresIn
+        ? Date.now() + expiresIn * 1000
+        : undefined,
+      user,
+    });
 
     this.notifyAuthChange("login");
 
@@ -158,17 +187,17 @@ export class AuthService {
 
   /**
    * Exchange a short-lived authorization code for a JWT token.
-   * Returns both the token and user info.
+   * Returns token, optional refresh token, optional expiresIn, and user info.
    */
   private async exchangeCode(
     serverUrl: string,
     code: string,
-  ): Promise<{ token: string; user: AuthUser }> {
-    const exchangeUrl = `${serverUrl}/api/auth/exchange`;
+  ): Promise<TokenResponse> {
+    const exchangeUrl = `${serverUrl}/api/auth/token`;
     const response = await fetch(exchangeUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ code }),
+      body: JSON.stringify({ grant_type: "authorization_code", code }),
     });
 
     if (!response.ok) {
@@ -176,14 +205,7 @@ export class AuthService {
       throw new Error(`Token exchange failed (${response.status}): ${text}`);
     }
 
-    const data = (await response.json()) as {
-      token: string;
-      user: { id: string; email?: string };
-    };
-    return {
-      token: data.token,
-      user: { id: data.user.id, email: data.user.email },
-    };
+    return (await response.json()) as TokenResponse;
   }
 
   private startLocalAuthServer(
@@ -306,7 +328,115 @@ export class AuthService {
   }
 
   isSSOAuthenticated(): boolean {
-    return this.getSSOToken() !== undefined;
+    const config = this.loadAuth();
+    if (!config.SSO_TOKEN) return false;
+    if (
+      config.SSO_TOKEN_EXPIRES_AT &&
+      Date.now() >= config.SSO_TOKEN_EXPIRES_AT
+    )
+      return false;
+    return true;
+  }
+
+  /**
+   * Check if the current token is expired or within the refresh buffer.
+   * Returns false if no expiry info (backward compat — treated as never-expiring).
+   */
+  isTokenExpired(): boolean {
+    const config = this.loadAuth();
+    if (!config.SSO_TOKEN_EXPIRES_AT) return false;
+    return (
+      Date.now() >= config.SSO_TOKEN_EXPIRES_AT - AuthService.REFRESH_BUFFER_MS
+    );
+  }
+
+  /**
+   * Check if the token needs refresh and refresh it if possible.
+   * Deduplicates concurrent refresh calls (401 dedup).
+   */
+  async checkAndRefreshTokenIfNeeded(): Promise<boolean> {
+    if (!this.isTokenExpired()) return true;
+    // Dedup: if a refresh is already in-flight, reuse the same promise
+    if (this._refreshPromise) return this._refreshPromise;
+    this._refreshPromise = this.refreshToken();
+    try {
+      return await this._refreshPromise;
+    } finally {
+      this._refreshPromise = null;
+    }
+  }
+
+  /**
+   * Refresh the access token using the stored refresh token.
+   * Returns true on success, false on failure.
+   */
+  private async refreshToken(): Promise<boolean> {
+    const config = this.loadAuth();
+    if (!config.SSO_REFRESH_TOKEN) return false;
+
+    const serverUrl = this.getServerUrl();
+    try {
+      const response = await fetch(`${serverUrl}/api/auth/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          grant_type: "refresh_token",
+          refresh_token: config.SSO_REFRESH_TOKEN,
+        }),
+      });
+
+      if (response.status === 400 || response.status === 401) {
+        // Refresh token revoked — clear auth
+        this.clearAuth();
+        return false;
+      }
+
+      if (!response.ok) return false;
+
+      const data = (await response.json()) as TokenResponse;
+      this.saveAuth({
+        ...config,
+        SSO_TOKEN: data.token,
+        SSO_REFRESH_TOKEN: data.refreshToken ?? config.SSO_REFRESH_TOKEN,
+        SSO_TOKEN_EXPIRES_AT: data.expiresIn
+          ? Date.now() + data.expiresIn * 1000
+          : undefined,
+        user: data.user
+          ? { id: data.user.id, email: data.user.email }
+          : config.user,
+      });
+      this.notifyAuthChange("login");
+      return true;
+    } catch {
+      // Network error — don't clear auth (might be transient)
+      return false;
+    }
+  }
+
+  /**
+   * Check if another process has refreshed the token on disk.
+   * Returns true if a fresh token was found and loaded.
+   */
+  /** @internal Check if another process has refreshed the token on disk */
+  tryReadRefreshedTokenFromDisk(): boolean {
+    try {
+      const authPath = this.getAuthPath();
+      if (!existsSync(authPath)) return false;
+      const stat = statSync(authPath);
+      if (stat.mtimeMs <= this._authFileMtime) return false;
+      // File was modified by another process — check if token is fresh
+      const config = this.loadAuth();
+      if (
+        config.SSO_TOKEN_EXPIRES_AT &&
+        Date.now() < config.SSO_TOKEN_EXPIRES_AT
+      ) {
+        this._authFileMtime = stat.mtimeMs;
+        return true;
+      }
+      return false;
+    } catch {
+      return false;
+    }
   }
 
   getAuthUser(): AuthUser | undefined {
@@ -316,6 +446,55 @@ export class AuthService {
 }
 
 export const authService = AuthService.getInstance();
+
+/**
+ * Create a fetch wrapper that handles SSO token refresh transparently.
+ *
+ * 1. Proactive refresh: calls checkAndRefreshTokenIfNeeded() before each request
+ * 2. Updates Authorization header with fresh token
+ * 3. Reactive 401/403 recovery: tries disk refresh then force refresh, retries once
+ */
+export function createAuthAwareFetch(innerFetch: typeof fetch): typeof fetch {
+  return async (input: RequestInfo | URL, init?: RequestInit) => {
+    // Proactive refresh
+    await authService.checkAndRefreshTokenIfNeeded();
+
+    // Update Authorization header with fresh token
+    const freshToken = authService.getSSOToken();
+    const headers = new Headers(init?.headers);
+    if (freshToken) {
+      headers.set("Authorization", `Bearer ${freshToken}`);
+    }
+    const modifiedInit = { ...init, headers };
+
+    const response = await innerFetch(input, modifiedInit);
+
+    // Reactive 401/403 recovery (single retry)
+    if (response.status === 401 || response.status === 403) {
+      // Try disk refresh first (another process may have refreshed)
+      if (authService.tryReadRefreshedTokenFromDisk()) {
+        const retryToken = authService.getSSOToken();
+        const retryHeaders = new Headers(init?.headers);
+        if (retryToken) {
+          retryHeaders.set("Authorization", `Bearer ${retryToken}`);
+        }
+        return innerFetch(input, { ...init, headers: retryHeaders });
+      }
+
+      // Try force refresh
+      if (await authService.checkAndRefreshTokenIfNeeded()) {
+        const retryToken = authService.getSSOToken();
+        if (retryToken) {
+          const retryHeaders = new Headers(init?.headers);
+          retryHeaders.set("Authorization", `Bearer ${retryToken}`);
+          return innerFetch(input, { ...init, headers: retryHeaders });
+        }
+      }
+    }
+
+    return response;
+  };
+}
 
 /**
  * Get or create a persistent anonymous ID for telemetry.

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -48,6 +48,7 @@ import {
   getRemoteSettingsSync,
   mergeRemoteSettings,
 } from "./remoteSettingsService.js";
+import { createAuthAwareFetch } from "./authService.js";
 
 /**
  * Default ConfigurationService implementation
@@ -423,6 +424,12 @@ export class ConfigurationService {
     const ssoToken = this.readSSOToken();
     const serverUrl = this.options.serverUrl || process.env.WAVE_SERVER_URL;
     if (ssoToken && serverUrl) {
+      const baseFetch = fetch ?? this.options.fetch;
+      const authAwareFetch = baseFetch
+        ? (createAuthAwareFetch(
+            baseFetch as typeof globalThis.fetch,
+          ) as ClientOptions["fetch"])
+        : undefined;
       return {
         apiKey: ssoToken,
         baseURL: `${serverUrl}/api/v1`,
@@ -431,7 +438,7 @@ export class ConfigurationService {
             ? defaultHeaders
             : undefined,
         fetchOptions: fetchOptions ?? this.options.fetchOptions,
-        fetch: fetch ?? this.options.fetch,
+        fetch: authAwareFetch,
       };
     }
 

--- a/packages/agent-sdk/src/services/remoteSettingsService.ts
+++ b/packages/agent-sdk/src/services/remoteSettingsService.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import { homedir } from "node:os";
 import * as path from "node:path";
 
-import { authService } from "./authService.js";
+import { authService, createAuthAwareFetch } from "./authService.js";
 import type {
   RemoteSettingsCache,
   RemoteSettingsFetchResult,
@@ -85,7 +85,8 @@ async function fetchRemoteSettings(): Promise<RemoteSettingsFetchResult> {
   }
 
   try {
-    const response = await fetch(`${serverUrl}/api/wave/settings`, {
+    const authFetch = createAuthAwareFetch(globalThis.fetch);
+    const response = await authFetch(`${serverUrl}/api/wave/settings`, {
       method: "GET",
       headers,
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),

--- a/packages/agent-sdk/src/types/auth.ts
+++ b/packages/agent-sdk/src/types/auth.ts
@@ -5,5 +5,15 @@ export interface AuthUser {
 
 export interface AuthConfig {
   SSO_TOKEN?: string;
+  SSO_REFRESH_TOKEN?: string;
+  SSO_TOKEN_EXPIRES_AT?: number; // Unix timestamp (ms) when SSO_TOKEN expires
   user?: AuthUser;
+}
+
+/** Server response from POST /api/auth/token */
+export interface TokenResponse {
+  token: string;
+  refreshToken?: string;
+  expiresIn?: number; // seconds until token expires
+  user: { id: string; email?: string };
 }

--- a/packages/agent-sdk/tests/services/authService.test.ts
+++ b/packages/agent-sdk/tests/services/authService.test.ts
@@ -12,6 +12,7 @@ import {
   chmodSync,
   rmSync,
   mkdirSync,
+  statSync,
 } from "fs";
 import * as os from "os";
 
@@ -77,6 +78,7 @@ const mockedWriteFile = vi.mocked(writeFileSync);
 const mockedChmod = vi.mocked(chmodSync);
 const mockedRm = vi.mocked(rmSync);
 const mockedMkdir = vi.mocked(mkdirSync);
+const mockedStat = vi.mocked(statSync);
 
 function resetServiceInstance() {
   (AuthService as unknown as { instance: AuthService }).instance =
@@ -86,6 +88,7 @@ function resetServiceInstance() {
 // Import after mocks are set up
 import {
   AuthService,
+  createAuthAwareFetch,
   getOrCreateAnonymousId,
   __resetAnonymousIdForTesting,
 } from "../../src/services/authService.js";
@@ -164,12 +167,37 @@ describe("AuthService", () => {
     it("deletes file when SSO_TOKEN is the only key", () => {
       mockedExists.mockReturnValue(true);
       mockedReadFile.mockReturnValue(
-        JSON.stringify({ SSO_TOKEN: "old-token" }),
+        JSON.stringify({
+          SSO_TOKEN: "old-token",
+          SSO_REFRESH_TOKEN: "old-refresh",
+          SSO_TOKEN_EXPIRES_AT: 1234567890,
+        }),
       );
       const service = AuthService.getInstance();
       service.clearAuth();
 
       expect(mockedRm).toHaveBeenCalledWith("/tmp/.wave/auth.json");
+    });
+
+    it("removes SSO_REFRESH_TOKEN and SSO_TOKEN_EXPIRES_AT along with SSO_TOKEN", () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "token",
+          SSO_REFRESH_TOKEN: "refresh-token",
+          SSO_TOKEN_EXPIRES_AT: 1234567890,
+          OTHER_KEY: "value",
+        }),
+      );
+      const service = AuthService.getInstance();
+      service.clearAuth();
+
+      expect(mockedWriteFile).toHaveBeenCalledWith(
+        "/tmp/.wave/auth.json",
+        JSON.stringify({ OTHER_KEY: "value" }, null, 2),
+        "utf-8",
+      );
+      expect(mockedRm).not.toHaveBeenCalled();
     });
 
     it("saves remaining config when other keys exist", () => {
@@ -225,6 +253,30 @@ describe("AuthService", () => {
       mockedExists.mockReturnValue(false);
       const service = AuthService.getInstance();
       expect(service.isSSOAuthenticated()).toBe(false);
+    });
+
+    it("returns false when token is expired (past SSO_TOKEN_EXPIRES_AT)", () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "token",
+          SSO_TOKEN_EXPIRES_AT: Date.now() - 1000,
+        }),
+      );
+      const service = AuthService.getInstance();
+      expect(service.isSSOAuthenticated()).toBe(false);
+    });
+
+    it("returns true when token exists with future expiry", () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "token",
+          SSO_TOKEN_EXPIRES_AT: Date.now() + 60000,
+        }),
+      );
+      const service = AuthService.getInstance();
+      expect(service.isSSOAuthenticated()).toBe(true);
     });
   });
 
@@ -339,7 +391,7 @@ describe("AuthService", () => {
       await service.login({ serverUrl: "https://option.example.com" });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://option.example.com/api/auth/exchange",
+        "https://option.example.com/api/auth/token",
         expect.any(Object),
       );
     });
@@ -359,7 +411,7 @@ describe("AuthService", () => {
       await service.login({ serverUrl: "https://login-option.example.com" });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://login-option.example.com/api/auth/exchange",
+        "https://login-option.example.com/api/auth/token",
         expect.any(Object),
       );
     });
@@ -379,7 +431,7 @@ describe("AuthService", () => {
       await service.login({ serverUrl: "https://option.example.com" });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://option.example.com/api/auth/exchange",
+        "https://option.example.com/api/auth/token",
         expect.any(Object),
       );
     });
@@ -399,7 +451,7 @@ describe("AuthService", () => {
       await service.login();
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://set.example.com/api/auth/exchange",
+        "https://set.example.com/api/auth/token",
         expect.any(Object),
       );
     });
@@ -421,7 +473,7 @@ describe("AuthService", () => {
 
       expect(token).toBe("jwt-no-env");
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://no-env.example.com/api/auth/exchange",
+        "https://no-env.example.com/api/auth/token",
         expect.any(Object),
       );
     });
@@ -462,11 +514,14 @@ describe("AuthService", () => {
       expect(authUrl).toContain("/login?callback_url=");
       // Verify exchange endpoint was called with the code
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://ai.example.com/api/auth/exchange",
+        "https://ai.example.com/api/auth/token",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ code: "callback-auth-code" }),
+          body: JSON.stringify({
+            grant_type: "authorization_code",
+            code: "callback-auth-code",
+          }),
         },
       );
       expect(mockedWriteFile).toHaveBeenCalled();
@@ -544,11 +599,14 @@ describe("AuthService", () => {
 
       expect(token).toBe("manual-exchanged-jwt");
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://ai.example.com/api/auth/exchange",
+        "https://ai.example.com/api/auth/token",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ code: "manual-code-123" }),
+          body: JSON.stringify({
+            grant_type: "authorization_code",
+            code: "manual-code-123",
+          }),
         },
       );
     });
@@ -727,6 +785,406 @@ describe("AuthService", () => {
 
       const id = getOrCreateAnonymousId();
       expect(id).toHaveLength(64);
+    });
+  });
+
+  describe("isTokenExpired", () => {
+    it("returns false when no SSO_TOKEN_EXPIRES_AT (backward compat)", () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(JSON.stringify({ SSO_TOKEN: "token" }));
+      const service = AuthService.getInstance();
+      expect(service.isTokenExpired()).toBe(false);
+    });
+
+    it("returns false when expiry is in the future", () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "token",
+          SSO_TOKEN_EXPIRES_AT: Date.now() + 60 * 60 * 1000,
+        }),
+      );
+      const service = AuthService.getInstance();
+      expect(service.isTokenExpired()).toBe(false);
+    });
+
+    it("returns true when expiry is in the past", () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "token",
+          SSO_TOKEN_EXPIRES_AT: Date.now() - 1000,
+        }),
+      );
+      const service = AuthService.getInstance();
+      expect(service.isTokenExpired()).toBe(true);
+    });
+
+    it("returns true when within 5-minute buffer", () => {
+      mockedExists.mockReturnValue(true);
+      // 3 minutes from now — within 5-min buffer
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "token",
+          SSO_TOKEN_EXPIRES_AT: Date.now() + 3 * 60 * 1000,
+        }),
+      );
+      const service = AuthService.getInstance();
+      expect(service.isTokenExpired()).toBe(true);
+    });
+  });
+
+  describe("checkAndRefreshTokenIfNeeded", () => {
+    const mockFetch = vi.fn();
+
+    beforeEach(() => {
+      vi.stubGlobal("fetch", mockFetch);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("returns true when token is fresh (no refresh needed)", async () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "token",
+          SSO_TOKEN_EXPIRES_AT: Date.now() + 60 * 60 * 1000,
+        }),
+      );
+      const service = AuthService.getInstance();
+      const result = await service.checkAndRefreshTokenIfNeeded();
+      expect(result).toBe(true);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns true when no expiry info (backward compat)", async () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(JSON.stringify({ SSO_TOKEN: "token" }));
+      const service = AuthService.getInstance();
+      const result = await service.checkAndRefreshTokenIfNeeded();
+      expect(result).toBe(true);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("triggers refresh when token is within buffer", async () => {
+      process.env.WAVE_SERVER_URL = "https://ai.example.com";
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "old-token",
+          SSO_REFRESH_TOKEN: "refresh-token",
+          SSO_TOKEN_EXPIRES_AT: Date.now() + 3 * 60 * 1000,
+        }),
+      );
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token: "new-token",
+          refreshToken: "new-refresh",
+          expiresIn: 3600,
+          user: { id: "u1", email: "u@example.com" },
+        }),
+      });
+
+      const service = AuthService.getInstance();
+      const result = await service.checkAndRefreshTokenIfNeeded();
+      expect(result).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://ai.example.com/api/auth/token",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            grant_type: "refresh_token",
+            refresh_token: "refresh-token",
+          }),
+        }),
+      );
+      delete process.env.WAVE_SERVER_URL;
+    });
+
+    it("returns false when no refresh token available", async () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "old-token",
+          SSO_TOKEN_EXPIRES_AT: Date.now() - 1000,
+        }),
+      );
+      const service = AuthService.getInstance();
+      const result = await service.checkAndRefreshTokenIfNeeded();
+      expect(result).toBe(false);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("deduplicates concurrent calls", async () => {
+      process.env.WAVE_SERVER_URL = "https://ai.example.com";
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "old-token",
+          SSO_REFRESH_TOKEN: "refresh-token",
+          SSO_TOKEN_EXPIRES_AT: Date.now() + 3 * 60 * 1000,
+        }),
+      );
+      let resolveRefresh: (value: unknown) => void;
+      const refreshPromise = new Promise((resolve) => {
+        resolveRefresh = resolve;
+      });
+      mockFetch.mockReturnValueOnce(refreshPromise);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token: "new-token",
+          expiresIn: 3600,
+          user: { id: "u1" },
+        }),
+      });
+
+      const service = AuthService.getInstance();
+      const p1 = service.checkAndRefreshTokenIfNeeded();
+      const p2 = service.checkAndRefreshTokenIfNeeded();
+
+      // Both should share the same refresh call
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      resolveRefresh!({
+        ok: true,
+        json: async () => ({
+          token: "new-token",
+          expiresIn: 3600,
+          user: { id: "u1" },
+        }),
+      });
+
+      const [r1, r2] = await Promise.all([p1, p2]);
+      expect(r1).toBe(true);
+      expect(r2).toBe(true);
+      delete process.env.WAVE_SERVER_URL;
+    });
+  });
+
+  describe("refreshToken", () => {
+    const mockFetch = vi.fn();
+
+    beforeEach(() => {
+      vi.stubGlobal("fetch", mockFetch);
+      process.env.WAVE_SERVER_URL = "https://ai.example.com";
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      delete process.env.WAVE_SERVER_URL;
+    });
+
+    it("saves new token fields on success", async () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "old-token",
+          SSO_REFRESH_TOKEN: "old-refresh",
+          SSO_TOKEN_EXPIRES_AT: Date.now() - 1000,
+        }),
+      );
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token: "new-token",
+          refreshToken: "new-refresh",
+          expiresIn: 3600,
+          user: { id: "u1", email: "u@example.com" },
+        }),
+      });
+
+      // Use checkAndRefreshTokenIfNeeded to trigger refreshToken (it's private)
+      const service = AuthService.getInstance();
+      const result = await service.checkAndRefreshTokenIfNeeded();
+      expect(result).toBe(true);
+
+      // Verify saved data
+      const writeCalls = mockedWriteFile.mock.calls;
+      const lastWrite = writeCalls[writeCalls.length - 1];
+      const saved = JSON.parse(lastWrite[1] as string);
+      expect(saved.SSO_TOKEN).toBe("new-token");
+      expect(saved.SSO_REFRESH_TOKEN).toBe("new-refresh");
+      expect(saved.SSO_TOKEN_EXPIRES_AT).toBeGreaterThan(Date.now());
+    });
+
+    it("clears auth on 400 response (refresh token revoked)", async () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "old-token",
+          SSO_REFRESH_TOKEN: "revoked-refresh",
+          SSO_TOKEN_EXPIRES_AT: Date.now() + 3 * 60 * 1000,
+        }),
+      );
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+      });
+
+      const service = AuthService.getInstance();
+      const result = await service.checkAndRefreshTokenIfNeeded();
+      expect(result).toBe(false);
+      // clearAuth should have been called — file deleted or auth cleared
+      expect(mockedRm).toHaveBeenCalled();
+    });
+
+    it("returns false on network error without clearing auth", async () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "old-token",
+          SSO_REFRESH_TOKEN: "refresh-token",
+          SSO_TOKEN_EXPIRES_AT: Date.now() + 3 * 60 * 1000,
+        }),
+      );
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+      const service = AuthService.getInstance();
+      const result = await service.checkAndRefreshTokenIfNeeded();
+      expect(result).toBe(false);
+      // Should NOT clear auth — network error might be transient
+      expect(mockedRm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("createAuthAwareFetch", () => {
+    const mockFetch = vi.fn();
+    const mockInnerFetch = vi.fn();
+
+    beforeEach(() => {
+      vi.stubGlobal("fetch", mockFetch);
+      resetServiceInstance();
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("calls checkAndRefreshTokenIfNeeded before request", async () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "fresh-token",
+          SSO_TOKEN_EXPIRES_AT: Date.now() + 60 * 60 * 1000,
+        }),
+      );
+      mockInnerFetch.mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+      const authFetch = createAuthAwareFetch(mockInnerFetch);
+      await authFetch("https://api.example.com/test");
+
+      // Token was fresh, no refresh needed, but Authorization header should be set
+      expect(mockInnerFetch).toHaveBeenCalledWith(
+        "https://api.example.com/test",
+        expect.objectContaining({
+          headers: expect.any(Headers),
+        }),
+      );
+      const callHeaders = mockInnerFetch.mock.calls[0][1].headers as Headers;
+      expect(callHeaders.get("Authorization")).toBe("Bearer fresh-token");
+    });
+
+    it("retries on 401 after disk refresh", async () => {
+      mockedExists.mockReturnValue(true);
+      // First loadAuth: token expired, triggers refresh
+      mockedReadFile.mockReturnValueOnce(
+        JSON.stringify({
+          SSO_TOKEN: "expired-token",
+          SSO_REFRESH_TOKEN: "refresh-token",
+          SSO_TOKEN_EXPIRES_AT: Date.now() - 1000,
+        }),
+      );
+      // For tryReadRefreshedTokenFromDisk — stat says file was updated
+      mockedStat.mockReturnValueOnce({
+        mtimeMs: Date.now(),
+      } as unknown as Awaited<ReturnType<typeof statSync>>);
+      // After disk read, token is fresh
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "new-from-disk",
+          SSO_TOKEN_EXPIRES_AT: Date.now() + 60 * 60 * 1000,
+        }),
+      );
+      // Refresh call succeeds
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token: "refreshed-token",
+          expiresIn: 3600,
+          user: { id: "u1" },
+        }),
+      });
+
+      mockInnerFetch.mockResolvedValueOnce(
+        new Response("unauthorized", { status: 401 }),
+      );
+      mockInnerFetch.mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+      const authFetch = createAuthAwareFetch(mockInnerFetch);
+      const response = await authFetch("https://api.example.com/test");
+
+      expect(response.status).toBe(200);
+      expect(mockInnerFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns original 401 when both disk and force refresh fail", async () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "expired-token",
+          SSO_TOKEN_EXPIRES_AT: Date.now() - 1000,
+        }),
+      );
+      // No refresh token — refreshToken() returns false
+      mockInnerFetch.mockResolvedValueOnce(
+        new Response("unauthorized", { status: 401 }),
+      );
+
+      const authFetch = createAuthAwareFetch(mockInnerFetch);
+      const response = await authFetch("https://api.example.com/test");
+
+      expect(response.status).toBe(401);
+      expect(mockInnerFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("updates Authorization header with fresh token after refresh", async () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValueOnce(
+        JSON.stringify({
+          SSO_TOKEN: "old-token",
+          SSO_REFRESH_TOKEN: "refresh-token",
+          SSO_TOKEN_EXPIRES_AT: Date.now() + 3 * 60 * 1000,
+        }),
+      );
+      // After refresh, loadAuth returns new token
+      process.env.WAVE_SERVER_URL = "https://ai.example.com";
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token: "refreshed-token",
+          expiresIn: 3600,
+          user: { id: "u1" },
+        }),
+      });
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "refreshed-token",
+          SSO_TOKEN_EXPIRES_AT: Date.now() + 60 * 60 * 1000,
+        }),
+      );
+
+      mockInnerFetch.mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+      const authFetch = createAuthAwareFetch(mockInnerFetch);
+      await authFetch("https://api.example.com/test");
+
+      const callHeaders = mockInnerFetch.mock.calls[0][1].headers as Headers;
+      expect(callHeaders.get("Authorization")).toBe("Bearer refreshed-token");
+      delete process.env.WAVE_SERVER_URL;
     });
   });
 });

--- a/packages/agent-sdk/tests/services/remoteSettingsService.test.ts
+++ b/packages/agent-sdk/tests/services/remoteSettingsService.test.ts
@@ -21,7 +21,9 @@ vi.mock("../../src/services/authService.js", () => ({
     isSSOAuthenticated: vi.fn(),
     getSSOToken: vi.fn(),
     getServerUrl: vi.fn(),
+    checkAndRefreshTokenIfNeeded: vi.fn().mockResolvedValue(true),
   },
+  createAuthAwareFetch: vi.fn((innerFetch: typeof fetch) => innerFetch),
 }));
 
 vi.mock("../../src/utils/globalLogger.js", () => ({

--- a/specs/076-sso-auth/checklists/requirements.md
+++ b/specs/076-sso-auth/checklists/requirements.md
@@ -4,7 +4,7 @@
 
 - [x] **FR-001**: `/login` and `/logout` slash commands available in CLI
 - [x] **FR-002**: Local HTTP server on `127.0.0.1` with random port for SSO callbacks
-- [x] **FR-002a**: Extracts `code` from callback URL and exchanges via `POST /api/auth/exchange`
+- [x] **FR-002a**: Extracts `code` from callback URL and exchanges via `POST /api/auth/token` with `{ grant_type: "authorization_code", code }`
 - [x] **FR-003**: Fetches SSO providers from `WAVE_SERVER_URL/api/auth/sso-providers`
 - [x] **FR-004**: Opens SSO login URL in default browser (`open`/`xdg-open`/`start`)
 - [x] **FR-005**: Accepts manual authorization code input via Ink `useInput` for remote servers, exchanges for JWT
@@ -18,3 +18,12 @@
 - [x] **FR-013**: Escape cancels login flow at any time
 - [x] **FR-014**: `execFile` used for browser opening (prevents command injection)
 - [x] **FR-015**: Removing SSO token restores direct LLM behavior
+- [x] **FR-016**: System proactively refreshes SSO token within 5-min buffer of expiry
+- [x] **FR-017**: System recovers from 401/403 by attempting token refresh and retrying once
+- [x] **FR-018**: System deduplicates concurrent token refresh calls
+- [x] **FR-019**: System detects token refresh by other processes via file mtime
+- [x] **FR-020**: System clears auth on refresh token revocation (400/401), preserves on network errors
+- [x] **FR-021**: Tokens without `SSO_TOKEN_EXPIRES_AT` treated as never-expiring (backward compat)
+- [x] **FR-022**: Code exchange uses `POST /api/auth/token` with `{ grant_type: "authorization_code", code }`
+- [x] **FR-023**: System saves/deletes `SSO_REFRESH_TOKEN` and `SSO_TOKEN_EXPIRES_AT` alongside `SSO_TOKEN`
+- [x] **FR-024**: SSO mode fetch wrapped with `createAuthAwareFetch` for transparent token refresh

--- a/specs/076-sso-auth/contracts/auth.md
+++ b/specs/076-sso-auth/contracts/auth.md
@@ -10,23 +10,40 @@ class AuthService {
   getAuthPath(): string;                     // Returns ~/.wave/auth.json
   loadAuth(): AuthConfig;                    // Reads and parses auth.json
   saveAuth(config: AuthConfig): void;        // Writes auth.json with 0o600 permissions
-  clearAuth(): void;                         // Removes SSO_TOKEN, deletes file if empty
+  clearAuth(): void;                         // Removes SSO_TOKEN, SSO_REFRESH_TOKEN, SSO_TOKEN_EXPIRES_AT, deletes file if empty
 
   // Token access
   getSSOToken(): string | undefined;         // Returns SSO_TOKEN or undefined
-  isSSOAuthenticated(): boolean;             // Returns true if SSO_TOKEN exists
+  isSSOAuthenticated(): boolean;             // Returns true if SSO_TOKEN exists and not past SSO_TOKEN_EXPIRES_AT
+  isTokenExpired(): boolean;                 // Returns true if token is within 5-min buffer of SSO_TOKEN_EXPIRES_AT
+
+  // Token refresh
+  checkAndRefreshTokenIfNeeded(): Promise<boolean>;  // Proactively refreshes token if expired (5-min buffer), deduplicates concurrent calls
+  tryReadRefreshedTokenFromDisk(): boolean;          // @internal — checks if another process refreshed token on disk
 
   // Server URL
   getServerUrl(): string;                    // Returns WAVE_SERVER_URL, throws if unset
+  setServerUrl(url: string): void;           // Sets the server URL
+
+  // Auth change callbacks
+  onAuthChange(callback: () => void): () => void;  // Subscribe to auth state changes, returns unsubscribe fn
+
+  // User info
+  getAuthUser(): AuthUser | undefined;       // Returns authenticated user info
 
   // Login flow
   login(options?: {
     onAuthUrl?: (url: string) => void;       // Called with SSO URL for display
     readToken?: () => Promise<string>;       // Manual token input (remote server fallback)
+    serverUrl?: string;                      // Override server URL for this login
   }): Promise<string>;                       // Resolves with the received token
 }
 
 export const authService: AuthService;       // Singleton instance
+
+// Auth-aware fetch wrapper
+export function createAuthAwareFetch(innerFetch: typeof fetch): typeof fetch;
+// Wraps fetch with proactive token refresh + reactive 401/403 recovery
 ```
 
 ## AuthConfig
@@ -34,6 +51,16 @@ export const authService: AuthService;       // Singleton instance
 ```typescript
 interface AuthConfig {
   SSO_TOKEN?: string;
+  SSO_REFRESH_TOKEN?: string;
+  SSO_TOKEN_EXPIRES_AT?: number;  // Unix ms timestamp
+  user?: AuthUser;
+}
+
+interface TokenResponse {
+  token: string;
+  refreshToken?: string;
+  expiresIn?: number;  // seconds until expiry
+  user: { id: string; email?: string };
 }
 ```
 
@@ -47,7 +74,7 @@ interface GatewayConfig {
   baseURL: string;         // ${WAVE_SERVER_URL}/api/v1
   defaultHeaders?: Record<string, string>;
   fetchOptions?: ClientOptions["fetchOptions"];
-  fetch?: ClientOptions["fetch"];
+  fetch?: ClientOptions["fetch"];  // Wrapped with createAuthAwareFetch for auth-aware requests
 }
 ```
 
@@ -69,11 +96,12 @@ interface GatewayConfig {
 
 **Behavior**: Redirects user to SSO IdP login page. After successful authentication, redirects to `callback_url?code={authorization_code}`.
 
-### POST /api/auth/exchange
+### POST /api/auth/token (Authorization Code Exchange)
 
 **Request**:
 ```json
 {
+  "grant_type": "authorization_code",
   "code": "short_authorization_code"
 }
 ```
@@ -82,11 +110,39 @@ interface GatewayConfig {
 ```json
 {
   "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "refreshToken": "dGhpcyBpcyBhIHJlZnJlc2gg...",
+  "expiresIn": 28800,
   "user": {
-    "username": "user@example.com"
+    "id": "user-uuid",
+    "email": "user@example.com"
   }
 }
 ```
+
+### POST /api/auth/token (Token Refresh)
+
+**Request**:
+```json
+{
+  "grant_type": "refresh_token",
+  "refresh_token": "dGhpcyBpcyBhIHJlZnJlc2gg..."
+}
+```
+
+**Response** (200):
+```json
+{
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "refreshToken": "bmV3IHJlZnJlc2ggdG9rZW4...",
+  "expiresIn": 28800,
+  "user": {
+    "id": "user-uuid",
+    "email": "user@example.com"
+  }
+}
+```
+
+**Error** (400/401): Refresh token revoked — client must clear auth and re-login.
 
 ### Callback URL Response
 
@@ -98,7 +154,13 @@ interface GatewayConfig {
 
 ```json
 {
-  "SSO_TOKEN": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+  "SSO_TOKEN": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "SSO_REFRESH_TOKEN": "dGhpcyBpcyBhIHJlZnJlc2gg...",
+  "SSO_TOKEN_EXPIRES_AT": 1747891234567,
+  "user": {
+    "id": "user-uuid",
+    "email": "user@example.com"
+  }
 }
 ```
 

--- a/specs/076-sso-auth/data-model.md
+++ b/specs/076-sso-auth/data-model.md
@@ -6,7 +6,10 @@
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `SSO_TOKEN` | `string?` | JWT token from Wave AI SSO login |
+| `SSO_TOKEN` | `string?` | JWT access token from Wave AI SSO login |
+| `SSO_REFRESH_TOKEN` | `string?` | Long-lived refresh token for proactive token renewal |
+| `SSO_TOKEN_EXPIRES_AT` | `number?` | Unix timestamp (ms) when SSO_TOKEN expires |
+| `user` | `AuthUser?` | Authenticated user info (`{ id, email? }`) |
 
 ### File Permissions
 
@@ -31,7 +34,16 @@ When `SSO_TOKEN` is present, `resolveGatewayConfig()` returns:
 | `baseURL` | `string` | `${WAVE_SERVER_URL}/api/v1` |
 | `defaultHeaders` | `Record<string, string>?` | Custom headers (if any) |
 | `fetchOptions` | `ClientOptions.fetchOptions?` | Fetch options |
-| `fetch` | `ClientOptions.fetch?` | Custom fetch implementation |
+| `fetch` | `ClientOptions.fetch?` | Auth-aware fetch implementation (wrapped with `createAuthAwareFetch`) |
+
+### TokenResponse (from POST /api/auth/token)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `token` | `string` | JWT access token |
+| `refreshToken` | `string?` | Long-lived refresh token (for future token renewal) |
+| `expiresIn` | `number?` | Seconds until token expires (absent = never expires) |
+| `user` | `{ id: string, email?: string }` | Authenticated user info |
 
 ## LoginCommand UI States
 
@@ -53,4 +65,37 @@ When `SSO_TOKEN` is present, `resolveGatewayConfig()` returns:
 4. Settings.json env vars (WAVE_API_KEY, WAVE_BASE_URL)
 5. process.env (WAVE_API_KEY, WAVE_BASE_URL)
 6. Error (missing baseURL)
+```
+
+## `~/.wave/auth.json` Example
+
+```json
+{
+  "SSO_TOKEN": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "SSO_REFRESH_TOKEN": "dGhpcyBpcyBhIHJlZnJlc2gg...",
+  "SSO_TOKEN_EXPIRES_AT": 1747891234567,
+  "user": {
+    "id": "user-uuid",
+    "email": "user@example.com"
+  }
+}
+```
+
+## Token Refresh Flow
+
+```
+1. Before each API request: isTokenExpired() checks 5-min buffer
+2. If expired → checkAndRefreshTokenIfNeeded() (dedup: shares in-flight promise)
+3. refreshToken() → POST /api/auth/token { grant_type: "refresh_token", refresh_token }
+4. On success: save new SSO_TOKEN, SSO_REFRESH_TOKEN, SSO_TOKEN_EXPIRES_AT
+5. On 400/401 (revoked): clearAuth() → user must re-login
+6. On network error: return false, preserve existing auth
+
+Reactive 401/403 recovery (single retry):
+1. Request returns 401/403
+2. tryReadRefreshedTokenFromDisk() → another process may have refreshed
+3. If disk refresh found → retry with new token
+4. Else checkAndRefreshTokenIfNeeded() → force refresh
+5. If refresh succeeds → retry with new token
+6. Else → return original 401/403 response
 ```

--- a/specs/076-sso-auth/plan.md
+++ b/specs/076-sso-auth/plan.md
@@ -1,10 +1,10 @@
 # Implementation Plan: SSO Authentication
 
-**Branch**: `076-sso-auth` | **Status**: Implemented | **Date**: 2026-05-12 | **Spec**: [spec.md](./spec.md)
+**Branch**: `076-sso-auth` | **Status**: Implemented (incl. token expiration & refresh) | **Date**: 2026-05-12 | **Spec**: [spec.md](./spec.md)
 
 ## Summary
 
-Add `/login` and `/logout` slash commands for SSO authentication via Wave AI. AuthService handles browser-based SSO flow with localhost callback (receives authorization code, exchanges for JWT via `POST /api/auth/exchange`), falls back to manual code input for remote servers. Gateway configuration prioritizes SSO mode when `~/.wave/auth.json` contains `SSO_TOKEN`, routing all LLM API requests through Wave AI's `/api/v1` proxy.
+Add `/login` and `/logout` slash commands for SSO authentication via Wave AI. AuthService handles browser-based SSO flow with localhost callback (receives authorization code, exchanges for JWT via `POST /api/auth/token` with `grant_type: "authorization_code"`), falls back to manual code input for remote servers. Gateway configuration prioritizes SSO mode when `~/.wave/auth.json` contains `SSO_TOKEN`, routing all LLM API requests through Wave AI's `/api/v1` proxy. Token expiration is handled via proactive refresh (5-min buffer), reactive 401/403 recovery with `createAuthAwareFetch`, and multi-process safety via file mtime detection.
 
 ## Technical Context
 
@@ -34,19 +34,35 @@ User types /login → inputReducer → EXECUTE_COMMAND (local)
   → useInputManager → dispatch SET_SHOW_LOGIN_COMMAND
   → InputBox renders <LoginCommand>
     → User presses Enter → AuthService.login()
-    → Browser opens → SSO flow → callback receives code → POST /api/auth/exchange → JWT saved → UI updates
-    → Remote server fallback: user pastes authorization code from browser URL bar → POST /api/auth/exchange → JWT saved
+    → Browser opens → SSO flow → callback receives code → POST /api/auth/token { grant_type: "authorization_code", code } → JWT + refreshToken saved → UI updates
+    → Remote server fallback: user pastes authorization code from browser URL bar → POST /api/auth/token → JWT + refreshToken saved
+
+Token refresh flow:
+  → Before API call: isTokenExpired() checks 5-min buffer
+  → If expired → checkAndRefreshTokenIfNeeded() (dedup: shares in-flight promise)
+  → POST /api/auth/token { grant_type: "refresh_token", refresh_token }
+  → On 400/401 (revoked): clearAuth() → user must re-login
+  → On network error: preserve existing auth, retry on next request
+
+Reactive 401/403 recovery (createAuthAwareFetch):
+  → Request returns 401/403
+  → tryReadRefreshedTokenFromDisk() → another process may have refreshed
+  → If disk refresh found → retry with new token
+  → Else checkAndRefreshTokenIfNeeded() → force refresh
+  → If refresh succeeds → retry with new token
+  → Else → return original 401/403 response
 ```
 
 ## Files Modified
 
 | File | Action |
 |------|--------|
-| `packages/agent-sdk/src/types/auth.ts` | Create |
-| `packages/agent-sdk/src/services/authService.ts` | Create |
+| `packages/agent-sdk/src/types/auth.ts` | Create (incl. `SSO_REFRESH_TOKEN`, `SSO_TOKEN_EXPIRES_AT`, `TokenResponse`) |
+| `packages/agent-sdk/src/services/authService.ts` | Create (incl. token refresh methods, `createAuthAwareFetch`) |
 | `packages/agent-sdk/src/types/index.ts` | Export auth types |
 | `packages/agent-sdk/src/index.ts` | Export AuthService |
-| `packages/agent-sdk/src/services/configurationService.ts` | Add SSO mode to resolveGatewayConfig |
+| `packages/agent-sdk/src/services/configurationService.ts` | Add SSO mode to resolveGatewayConfig + wrap fetch with `createAuthAwareFetch` |
+| `packages/agent-sdk/src/services/remoteSettingsService.ts` | Wrap fetch with `createAuthAwareFetch` |
 | `packages/code/src/constants/commands.ts` | Add login/logout entries |
 | `packages/code/src/managers/inputReducer.ts` | Add showLoginCommand state + action |
 | `packages/code/src/hooks/useInputManager.ts` | Add login/logout handlers + setter |

--- a/specs/076-sso-auth/quickstart.md
+++ b/specs/076-sso-auth/quickstart.md
@@ -89,7 +89,7 @@ SSO_company_sso_CLIENT_SECRET=xxx
 ```
 
 ### Token expired after 8 hours
-Wave AI JWT defaults to 8-hour expiry. Re-run `/login` to get a fresh authorization code and exchange for a new token.
+Wave AI JWT defaults to 8-hour expiry. The system automatically refreshes tokens 5 minutes before expiry using the stored refresh token. If the refresh token is revoked, you'll need to re-run `/login`.
 
 ### "Connection refused" on browser redirect
 Expected on remote servers. Copy the authorization code from the browser URL bar and paste into the terminal.

--- a/specs/076-sso-auth/research.md
+++ b/specs/076-sso-auth/research.md
@@ -19,10 +19,42 @@
 
 ## Decision: Merge Existing Auth Config on Save
 
-**Rationale**: `saveAuth()` reads existing `auth.json` and merges new `SSO_TOKEN` into it, preserving any future fields (e.g., `REFRESH_TOKEN`, `EXPIRES_AT`).
+**Rationale**: `saveAuth()` reads existing `auth.json` and merges new `SSO_TOKEN` into it, preserving any future fields (e.g., `SSO_REFRESH_TOKEN`, `SSO_TOKEN_EXPIRES_AT`).
 
 **Alternatives considered**:
 - Direct overwrite: Rejected — would lose future fields added to `auth.json`.
+
+## Decision: Proactive Token Refresh with 5-Minute Buffer
+
+**Rationale**: Refreshing tokens proactively (5 minutes before expiry) prevents API call failures due to expired tokens. The refresh uses a standard OAuth 2.0 refresh token grant to `POST /api/auth/token`, following the same pattern as Claude Code's token refresh.
+
+**Alternatives considered**:
+- **On-demand refresh only (no buffer)**: Rejected — API calls would fail during the refresh window, causing poor UX.
+- **Timer-based refresh**: Rejected — adds complexity, doesn't handle suspended processes, and doesn't coordinate with multi-process scenarios.
+
+## Decision: File mtime for Multi-Process Token Refresh Detection
+
+**Rationale**: When multiple Wave processes run simultaneously, each would independently detect token expiry and attempt refresh. By tracking `auth.json`'s mtime, a process can detect when another has already refreshed the token and read the fresh token from disk instead of making a redundant network call.
+
+**Alternatives considered**:
+- **File locking (flock)**: Rejected — platform-specific, adds complexity, not reliable on all filesystems.
+- **PID file**: Rejected — doesn't handle crash recovery, stale PID files.
+
+## Decision: Auth-Aware Fetch Wrapper
+
+**Rationale**: Rather than modifying every API call site to handle token refresh, a fetch wrapper (`createAuthAwareFetch`) transparently adds proactive refresh (before request), Authorization header updates (with fresh token), and reactive 401/403 recovery (single retry after refresh). This ensures all API calls through `resolveGatewayConfig` SSO mode and `remoteSettingsService` automatically benefit.
+
+**Alternatives considered**:
+- **Interceptor pattern (like axios)**: Rejected — requires changing the HTTP client library.
+- **Manual refresh at each call site**: Rejected — error-prone, lots of duplicated code.
+
+## Decision: Deduplicate Concurrent Refresh Calls
+
+**Rationale**: Multiple concurrent API calls that all detect token expiry should share a single in-flight refresh promise rather than making N parallel refresh requests. This prevents token churn and race conditions.
+
+**Alternatives considered**:
+- **Lock/mutex**: Rejected — overkill for single-process async dedup, adds complexity.
+- **No dedup**: Rejected — would cause multiple simultaneous refresh requests, potentially revoking tokens used by other in-flight requests.
 
 ## Decision: `execFile` for Browser Opening
 
@@ -37,7 +69,7 @@
 
 ## Decision: Wave-Admin as SSO Mediator
 
-**Rationale**: wave-agent CLI does not connect directly to the company SSO IdP. Instead, Wave AI handles the OIDC/OAuth flow and redirects back to the CLI with a short-lived authorization code. The CLI then exchanges this code for a JWT via `POST /api/auth/exchange`. This two-step flow follows the standard OAuth 2.0 authorization code pattern, keeping the JWT out of the URL bar (only a short-lived code is exposed).
+**Rationale**: wave-agent CLI does not connect directly to the company SSO IdP. Instead, Wave AI handles the OIDC/OAuth flow and redirects back to the CLI with a short-lived authorization code. The CLI then exchanges this code for a JWT via `POST /api/auth/token` with `{ grant_type: "authorization_code", code }`. This two-step flow follows the standard OAuth 2.0 authorization code pattern, keeping the JWT out of the URL bar (only a short-lived code is exposed).
 
 ## Decision: SSO Token Priority Over Direct LLM Config
 

--- a/specs/076-sso-auth/spec.md
+++ b/specs/076-sso-auth/spec.md
@@ -17,7 +17,7 @@ As a developer working on a local machine, I want to type `/login` in Wave to au
 **Acceptance Scenarios**:
 
 1. **Given** `WAVE_SERVER_URL` is set and no existing SSO token, **When** the user types `/login`, **Then** Wave opens a browser to the SSO login page and displays the auth URL in the terminal.
-2. **Given** the user completes SSO login in their browser, **When** the browser redirects to the localhost callback URL with `?code={code}`, **Then** Wave exchanges the code for a JWT via `POST /api/auth/exchange`, saves the token to `~/.wave/auth.json`, and displays "Login successful".
+2. **Given** the user completes SSO login in their browser, **When** the browser redirects to the localhost callback URL with `?code={code}`, **Then** Wave exchanges the code for a JWT via `POST /api/auth/token` with `{ grant_type: "authorization_code", code }`, saves the token and refresh token to `~/.wave/auth.json`, and displays "Login successful".
 3. **Given** the user is authenticated via SSO, **When** the user sends a message, **Then** all LLM API requests are sent to `WAVE_SERVER_URL/api/v1` with the SSO token as Bearer auth.
 4. **Given** the user is already authenticated via SSO, **When** the user types `/login`, **Then** Wave shows current auth status (truncated token, AI URL) and offers to logout on Enter.
 5. **Given** the user is authenticated and presses Enter while in the login UI, **When** they confirm logout, **Then** the SSO token is removed from `~/.wave/auth.json` and Wave displays "Logged out successfully".
@@ -35,7 +35,7 @@ As a developer working on a remote server via SSH, I want to manually paste the 
 **Acceptance Scenarios**:
 
 1. **Given** Wave is running on a remote server, **When** the user types `/login`, **Then** Wave displays the SSO auth URL and prompts "Paste the authorization code from your browser URL bar:".
-2. **Given** the user pastes a valid authorization code and presses Enter, **Then** Wave exchanges the code for a JWT via `POST /api/auth/exchange`, saves the token to `~/.wave/auth.json`, and displays "Login successful".
+2. **Given** the user pastes a valid authorization code and presses Enter, **Then** Wave exchanges the code for a JWT via `POST /api/auth/token` with `{ grant_type: "authorization_code", code }`, saves the token and refresh token to `~/.wave/auth.json`, and displays "Login successful".
 3. **Given** the user pastes an empty line, **Then** Wave clears the input and keeps waiting for token input.
 4. **Given** the user presses Escape during token input, **Then** the login flow is cancelled and Wave returns to the idle state.
 
@@ -64,7 +64,7 @@ As a developer who has authenticated via SSO, I want all LLM API requests to aut
 - **What happens if `WAVE_SERVER_URL` is not set during login?** The login fails with a clear error instructing the user to set the environment variable.
 - **What happens if the browser cannot be opened (headless server)?** The auth server stays alive, and the user can manually open the URL and paste the authorization code.
 - **What happens if the user saves additional fields in `auth.json` in the future?** The `saveAuth` method merges with existing config, preserving non-SSO_TOKEN fields.
-- **What happens if the token expires (JWT default 8h)?** The API call returns 401; the user must re-run `/login`. Token refresh is out of scope (requires Wave AI changes).
+- **What happens if the token expires (JWT default 8h)?** The system proactively refreshes the token 5 minutes before expiry using the stored refresh token. If the refresh token is revoked (400/401), auth is cleared and the user must re-run `/login`. On transient network errors during refresh, the existing token is preserved and the retry happens on the next request.
 - **What happens if the SSO login times out (5 min)?** The auth server closes and an error is displayed. The user can retry `/login`.
 
 ## Requirements *(mandatory)*
@@ -73,7 +73,7 @@ As a developer who has authenticated via SSO, I want all LLM API requests to aut
 
 - **FR-001**: System MUST provide `/login` and `/logout` slash commands in the CLI.
 - **FR-002**: System MUST start a local HTTP server on `127.0.0.1` with a random port to receive SSO callbacks.
-- **FR-002a**: System MUST extract the `code` query parameter from the callback URL and exchange it for a JWT via `POST /api/auth/exchange`.
+- **FR-002a**: System MUST extract the `code` query parameter from the callback URL and exchange it for a JWT via `POST /api/auth/token` with `{ grant_type: "authorization_code", code }`.
 - **FR-003**: System MUST fetch available SSO providers from `WAVE_SERVER_URL/api/auth/sso-providers` and use the first provider.
 - **FR-004**: System MUST open the SSO login URL in the default browser when available.
 - **FR-005**: System MUST accept manual authorization code input via the CLI when browser callback is unavailable (remote servers), and exchange it for a JWT.
@@ -87,10 +87,20 @@ As a developer who has authenticated via SSO, I want all LLM API requests to aut
 - **FR-013**: System MUST allow the user to cancel the login flow at any time by pressing Escape.
 - **FR-014**: System MUST use `execFile` (not `exec`) for browser opening to prevent command injection.
 - **FR-015**: SSO mode and direct LLM mode MUST coexist — removing the SSO token restores direct LLM behavior.
+- **FR-016**: System MUST proactively refresh the SSO token when it is within 5 minutes of expiry, using the stored refresh token via `POST /api/auth/token` with `{ grant_type: "refresh_token", refresh_token }`.
+- **FR-017**: System MUST reactively recover from 401/403 API errors by attempting token refresh and retrying the request once.
+- **FR-018**: System MUST deduplicate concurrent token refresh calls so only one network request is made.
+- **FR-019**: System MUST detect when another process has refreshed the token on disk (via file mtime) and use the fresh token instead of making a redundant refresh request.
+- **FR-020**: System MUST clear auth (logout) when the refresh token is revoked (400/401 response), but preserve auth on transient network errors during refresh.
+- **FR-021**: System MUST treat tokens without `SSO_TOKEN_EXPIRES_AT` as never-expiring (backward compatibility).
+- **FR-022**: System MUST use `POST /api/auth/token` with `{ grant_type: "authorization_code", code }` for the initial code exchange (replaces `POST /api/auth/exchange`).
+- **FR-023**: System MUST save `SSO_REFRESH_TOKEN` and `SSO_TOKEN_EXPIRES_AT` alongside `SSO_TOKEN` in `~/.wave/auth.json`, and delete them on logout.
+- **FR-024**: System MUST wrap fetch with `createAuthAwareFetch` in SSO mode to transparently handle token refresh for all API calls.
 
 ### Key Entities
 
-- **AuthService**: Singleton service managing SSO authentication lifecycle (login, logout, token storage).
-- **AuthConfig**: Configuration object stored in `~/.wave/auth.json` containing `SSO_TOKEN`.
+- **AuthService**: Singleton service managing SSO authentication lifecycle (login, logout, token storage, token refresh, auth-aware fetch).
+- **AuthConfig**: Configuration object stored in `~/.wave/auth.json` containing `SSO_TOKEN`, `SSO_REFRESH_TOKEN`, `SSO_TOKEN_EXPIRES_AT`, and `user`.
 - **LoginCommand**: Ink UI component for the `/login` slash command, handling both browser and manual input flows.
-- **GatewayConfig (SSO mode)**: Resolved configuration where `apiKey` is the SSO token and `baseURL` is `${WAVE_SERVER_URL}/api/v1`.
+- **GatewayConfig (SSO mode)**: Resolved configuration where `apiKey` is the SSO token, `baseURL` is `${WAVE_SERVER_URL}/api/v1`, and `fetch` is wrapped with `createAuthAwareFetch`.
+- **TokenResponse**: Response from `POST /api/auth/token` containing `token`, `refreshToken?`, `expiresIn?`, and `user`.

--- a/specs/076-sso-auth/tasks.md
+++ b/specs/076-sso-auth/tasks.md
@@ -129,6 +129,7 @@
 - **User Story 2 (Phase 4)**: Depends on Setup (Phase 1) and Configuration (Phase 2). Manual token input.
 - **User Story 3 (Phase 5)**: Depends on Configuration Integration (Phase 2). SSO API routing verification.
 - **Polish (Final Phase)**: Depends on all user stories.
+- **Token Expiration (Phase 7)**: Depends on Setup (Phase 1) and Configuration (Phase 2). Proactive refresh + reactive 401 recovery.
 
 ### Parallel Opportunities
 
@@ -136,4 +137,30 @@
 - T003, T004 (AuthService creation + export)
 - T008, T009, T010, T011 (US1 tests + CLI commands)
 - T015, T016, T017 (US2 tests + AuthService update)
-te)
+
+---
+
+## Phase 7: Token Expiration & Refresh (Issue #1137)
+
+**Purpose**: Proactive token refresh, reactive 401 recovery, multi-process safety
+
+- [x] T028 [US3] Extend `AuthConfig` type with `SSO_REFRESH_TOKEN`, `SSO_TOKEN_EXPIRES_AT` and add `TokenResponse` type in `packages/agent-sdk/src/types/auth.ts`
+- [x] T029 [US3] Add token refresh methods to `AuthService` in `packages/agent-sdk/src/services/authService.ts`:
+  - `isTokenExpired()`, `checkAndRefreshTokenIfNeeded()`, `refreshToken()`, `tryReadRefreshedTokenFromDisk()`
+  - `_refreshPromise` (401 dedup), `_authFileMtime` (multi-process), `REFRESH_BUFFER_MS` (5-min)
+  - Update `exchangeCode()` endpoint to `/api/auth/token` with `grant_type`
+  - Update `login()` to save `SSO_REFRESH_TOKEN`, `SSO_TOKEN_EXPIRES_AT`
+  - Update `isSSOAuthenticated()` to check strict expiry
+  - Update `clearAuth()` to delete new fields
+  - Update `saveAuth()`/`loadAuth()` to track mtime
+- [x] T030 [US3] Create `createAuthAwareFetch()` export in `packages/agent-sdk/src/services/authService.ts`
+- [x] T031 [US3] Integrate auth-aware fetch into `resolveGatewayConfig()` SSO branch in `packages/agent-sdk/src/services/configurationService.ts`
+- [x] T032 [US3] Integrate auth-aware fetch into `fetchRemoteSettings()` in `packages/agent-sdk/src/services/remoteSettingsService.ts`
+- [x] T033 [US3] Update and add tests in `packages/agent-sdk/tests/services/authService.test.ts`:
+  - Update exchange endpoint URL/body assertions
+  - `isTokenExpired`, `checkAndRefreshTokenIfNeeded`, `refreshToken`, `clearAuth` new fields
+  - `createAuthAwareFetch` proactive refresh, 401 recovery, header updates
+  - `isSSOAuthenticated` with expiry
+- [x] T034 [US3] Update `remoteSettingsService.test.ts` authService mock with `createAuthAwareFetch` and `checkAndRefreshTokenIfNeeded`
+
+**Checkpoint**: Tokens refresh automatically before expiry, 401 errors are recovered transparently, multi-process safe.


### PR DESCRIPTION
## Summary

Implements proactive token refresh, reactive 401/403 recovery, and multi-process safety for SSO authentication (Issue #1137).

### Core Changes

- **AuthConfig extended**: Added `SSO_REFRESH_TOKEN`, `SSO_TOKEN_EXPIRES_AT` fields + `TokenResponse` type
- **Exchange endpoint migrated**: `POST /api/auth/exchange` → `POST /api/auth/token` with `{ grant_type: "authorization_code", code }`
- **Token refresh methods**: `isTokenExpired()`, `checkAndRefreshTokenIfNeeded()`, `refreshToken()`, `tryReadRefreshedTokenFromDisk()`
- **Proactive refresh**: 5-minute buffer before expiry triggers automatic refresh
- **Reactive 401/403 recovery**: `createAuthAwareFetch()` wrapper retries with fresh token (single retry: disk refresh → force refresh → original response)
- **401 dedup**: Concurrent refresh calls share one in-flight promise
- **Multi-process safety**: File mtime tracking detects when another process has refreshed the token
- **Strict expiry in `isSSOAuthenticated()`**: Returns false if token is past `SSO_TOKEN_EXPIRES_AT`
- **Backward compat**: Tokens without `SSO_TOKEN_EXPIRES_AT` are treated as never-expiring

### Integration

- `configurationService.ts`: SSO branch wraps fetch with `createAuthAwareFetch`
- `remoteSettingsService.ts`: Uses `createAuthAwareFetch(globalThis.fetch)` for settings API calls

### Specs Updated

- Added FR-016 through FR-024 in spec.md and requirements checklist
- Added Phase 7 tasks (T028-T034) in tasks.md
- Updated contracts, data model, quickstart, research, and plan docs

### Verification

- Build: ✅ `pnpm -F wave-agent-sdk build`
- Tests: ✅ 2832 passed (61 in authService.test.ts)
- Type check: ✅ across all packages