### PR TITLE
docs: update 042-plugin specs to match implementation

### DIFF
--- a/specs/042-plugin/checklists/requirements.md
+++ b/specs/042-plugin/checklists/requirements.md
@@ -15,6 +15,7 @@ This checklist ensures that the plugin support system and marketplace meet all r
 - [x] `PluginLoader` MUST load LSP, MCP, and Hooks configurations.
 - [x] `PluginManager` MUST store and manage loaded plugins.
 - [x] `PluginManager` MUST orchestrate loading and registration of all component types.
+- [x] `PluginManager.loadPlugins()` MUST load explicit configs first, then marketplace-installed plugins.
 
 ## 3. Plugin Management
 - [x] `--plugin-dir` flag MUST load local plugins.
@@ -22,30 +23,40 @@ This checklist ensures that the plugin support system and marketplace meet all r
 - [x] `plugin disable` command MUST disable a plugin in the specified scope.
 - [x] `plugin install` command MUST support scoped installation and auto-enable.
 - [x] `PluginManager` MUST filter loaded plugins by `enabledPlugins` across all scopes.
+- [x] `PluginCore` MUST provide a unified high-level API for all plugin and marketplace operations.
 
 ## 4. Scope Management
 - [x] `PluginScopeManager` MUST manage plugin installation scopes (`user`, `project`, `local`).
 - [x] `WaveConfiguration` MUST include `enabledPlugins: Record<string, boolean>`.
 - [x] `getMergedEnabledPlugins` MUST merge `enabledPlugins` across all scopes.
 - [x] Scope priority MUST be `local` > `project` > `user`.
+- [x] Enabled state MUST be tracked via `enabledPlugins` in settings, not on `InstalledPlugin`.
 
 ## 5. Dynamic Tools
 - [x] `Skill` and `Task` tools MUST use getters for their `config` property.
 - [x] Tools MUST reflect plugins loaded after initial tool registration.
 
-## 6. General
+## 6. Remote Fetching
+- [x] All remote fetching MUST use `git clone --depth 1` (no direct HTTP download).
+- [x] `GitService` MUST support GitHub shorthand, full Git URLs, and local paths.
+- [x] `GitService` MUST enforce configurable timeout (default 120s via `WAVE_PLUGIN_GIT_TIMEOUT_MS`).
+- [x] Plugin entries with Git URL sources MUST be cloned individually during install.
+- [x] Plugin entries with relative path sources MUST be copied from marketplace checkout.
+- [x] `MarketplaceSource` MUST use discriminated union with optional `ref` for branch/tag.
+
+## 7. General
 - [x] All "Claude" references MUST be replaced with "Agent".
 - [x] Plugin IDs MUST follow the `name@marketplace` format.
 - [x] `pnpm build` MUST succeed.
 - [x] `pnpm run type-check` and `pnpm lint` MUST pass.
 
-## 7. Content Quality (Marketplace)
+## 8. Content Quality (Marketplace)
 - [x] No implementation details (languages, frameworks, APIs)
 - [x] Focused on user value and business needs
 - [x] Written for non-technical stakeholders
 - [x] All mandatory sections completed
 
-## 8. Requirement Completeness (Marketplace)
+## 9. Requirement Completeness (Marketplace)
 - [x] No [NEEDS CLARIFICATION] markers remain
 - [x] Requirements are testable and unambiguous
 - [x] All acceptance scenarios are defined
@@ -53,7 +64,7 @@ This checklist ensures that the plugin support system and marketplace meet all r
 - [x] Scope is clearly bounded
 - [x] Dependencies and assumptions identified
 
-## 9. Feature Readiness (Marketplace)
+## 10. Feature Readiness (Marketplace)
 - [x] All functional requirements have clear acceptance criteria
 - [x] User scenarios cover primary flows
 - [x] No implementation details leak into specification

--- a/specs/042-plugin/contracts/internal-api.md
+++ b/specs/042-plugin/contracts/internal-api.md
@@ -14,32 +14,48 @@ export async function startPluginManagerCli(): Promise<void>;
 
 ## Service Hooks
 
-The UI will use a custom hook to interact with `agent-sdk` services.
+The UI uses a custom hook to interact with `PluginCore` services.
 
 ```typescript
 interface UsePluginManager {
   // Data
   marketplaces: KnownMarketplace[];
   installedPlugins: InstalledPlugin[];
-  discoverablePlugins: Plugin[];
+  discoverablePlugins: MarketplacePluginStatus[];
+  mergedEnabled: Record<string, boolean>;
   
-  // Actions
-  addMarketplace(source: string): Promise<void>;
-  removeMarketplace(name: string): Promise<void>;
-  updateMarketplace(name: string): Promise<void>;
+  // Marketplace actions
+  addMarketplace(source: string, scope?: Scope): Promise<void>;
+  removeMarketplace(name: string, scope?: Scope): Promise<void>;
+  updateMarketplace(name?: string): Promise<void>;
   
-  installPlugin(plugin: Plugin, scope: 'user' | 'project' | 'local'): Promise<void>;
-  uninstallPlugin(name: string, marketplace: string): Promise<void>;
-  togglePlugin(name: string, marketplace: string, enabled: boolean): Promise<void>;
+  // Plugin actions
+  installPlugin(pluginId: string, scope?: Scope): Promise<InstalledPlugin>;
+  uninstallPlugin(pluginId: string): Promise<void>;
+  enablePlugin(pluginId: string, scope?: Scope): Promise<Scope>;
+  disablePlugin(pluginId: string, scope?: Scope): Promise<Scope>;
+  updatePlugin(pluginId: string): Promise<InstalledPlugin>;
 }
 ```
 
 ## Marketplace Source Parsing
-The UI must handle various input formats for marketplaces:
+The UI handles various input formats for marketplaces:
 
 | Input Format | Parsed Source |
 |--------------|---------------|
 | `owner/repo` | `{ source: "github", repo: "owner/repo" }` |
-| `git@github.com:owner/repo.git` | `{ source: "git", url: "..." }` |
-| `./path/to/dir` | `{ source: "directory", path: "..." }` |
-```
+| `owner/repo#branch` | `{ source: "github", repo: "owner/repo", ref: "branch" }` |
+| `https://example.com/repo.git` | `{ source: "git", url: "https://example.com/repo.git" }` |
+| `git@github.com:owner/repo.git` | `{ source: "git", url: "git@github.com:owner/repo.git" }` |
+| `ssh://git@example.com/repo.git` | `{ source: "git", url: "ssh://git@example.com/repo.git" }` |
+| `./path/to/dir` | `{ source: "directory", path: "./path/to/dir" }` |
+
+## Plugin Install Source Handling
+When installing a plugin, the `source` field in `marketplace.json` determines how the plugin is fetched:
+
+| Source Format | Fetch Method |
+|---------------|-------------|
+| `./plugins/review-plugin` | Copy from marketplace checkout directory |
+| `https://github.com/user/plugin.git` | `git clone --depth 1` into temp dir, then move to cache |
+| `git@github.com:user/plugin.git` | `git clone --depth 1` into temp dir, then move to cache |
+| `ssh://git@example.com/plugin.git` | `git clone --depth 1` into temp dir, then move to cache |

--- a/specs/042-plugin/contracts/marketplace-manifest.json
+++ b/specs/042-plugin/contracts/marketplace-manifest.json
@@ -18,7 +18,10 @@
         "properties": {
           "name": { "type": "string" },
           "description": { "type": "string" },
-          "source": { "type": "string" }
+          "source": {
+            "type": "string",
+            "description": "Relative path within marketplace (e.g., './plugins/review-plugin') or Git URL (http://, https://, git@, ssh://)"
+          }
         },
         "required": ["name", "source", "description"]
       }

--- a/specs/042-plugin/contracts/marketplace-service.md
+++ b/specs/042-plugin/contracts/marketplace-service.md
@@ -1,26 +1,112 @@
 # API Contracts: Marketplace Management
 
-The following "contracts" describe the internal service methods in `MarketplaceService` that will be affected or added.
+The following contracts describe the internal service methods in `MarketplaceService` and the high-level `PluginCore` API.
 
 ## MarketplaceService
 
+### `listMarketplaces(): Promise<KnownMarketplace[]>`
+Returns the list of all registered marketplaces, including the builtin one.
+
 ### `getKnownMarketplaces(): Promise<KnownMarketplacesRegistry>`
-Returns the list of all registered marketplaces, including the builtin one if applicable.
+**@deprecated** — Use `listMarketplaces()` instead. Returns the full registry object.
 
-### `addMarketplace(input: string): Promise<void>`
-Adds a new marketplace. Parses input to create a new `KnownMarketplace` (local, GitHub, or Git). Sets the `lastUpdated` timestamp to the current time.
+### `addMarketplace(input: string, scope?: Scope): Promise<KnownMarketplace>`
+Adds a new marketplace. Parses input to create a new `KnownMarketplace` (local, GitHub, or Git). The `scope` parameter determines which settings file to persist the marketplace config to. Returns the created marketplace.
 
-### `removeMarketplace(name: string): Promise<void>`
-Removes a marketplace by name.
+### `removeMarketplace(name: string, scope?: Scope): Promise<void>`
+Removes a marketplace by name from the specified scope's settings.
 
-### `updateMarketplace(name: string): Promise<void>`
-Updates the local cache of a specific marketplace. Sets the `lastUpdated` timestamp to the current time upon success.
+### `updateMarketplace(name?: string, options?: { updatePlugins?: boolean }): Promise<void>`
+Updates the local cache of a specific marketplace (or all if name is omitted). The `updatePlugins` option triggers re-installation of outdated plugins. Sets the `lastUpdated` timestamp on success.
 
-### `updateAllMarketplaces(): Promise<void>`
-Updates all registered marketplaces. Sets the `lastUpdated` timestamp for each successfully updated marketplace.
+### `autoUpdateAll(): Promise<void>`
+Updates all registered marketplaces that have `autoUpdate: true`. Called in the background during startup.
 
-### `installPlugin(plugin: Plugin, scope: 'user' | 'project' | 'local'): Promise<void>`
-Installs a plugin from a marketplace into the specified scope.
+### `installPlugin(pluginAtMarketplace: string, projectPath?: string): Promise<InstalledPlugin>`
+Installs a plugin from a marketplace. Takes a `name@marketplace` compound identifier (not a Plugin object). The `projectPath` parameter is used for project-scoped installs. Returns the installed plugin record.
 
-### `uninstallPlugin(name: string, marketplace: string): Promise<void>`
-Uninstalls a plugin.
+**Git URL source handling**: If the plugin entry's `source` in `marketplace.json` starts with `http://`, `https://`, `git@`, or `ssh://`, the individual plugin repo is cloned into a temp directory, then moved to the cache. Otherwise, the source is treated as a relative path within the marketplace checkout.
+
+### `uninstallPlugin(pluginAtMarketplace: string, projectPath?: string): Promise<void>`
+Uninstalls a plugin. Takes a `name@marketplace` compound identifier.
+
+### `updatePlugin(pluginAtMarketplace: string): Promise<InstalledPlugin>`
+Updates a plugin by uninstalling and re-installing it. Takes a `name@marketplace` compound identifier.
+
+### `toggleAutoUpdate(name: string, enabled: boolean): Promise<void>`
+Enables or disables auto-update for a marketplace.
+
+### `loadMarketplaceManifest(marketplacePath: string): Promise<MarketplaceManifest>`
+Reads and validates a `marketplace.json` from the given path.
+
+### `getMarketplacePath(source: MarketplaceSource): string`
+Resolves the local filesystem path for a marketplace source.
+
+### `getInstalledPlugins(): Promise<InstalledPluginsRegistry>`
+Returns the installed plugins registry.
+
+### `getCacheRegistry(): Promise<KnownMarketplacesRegistry | null>`
+Returns the known marketplaces registry, or null if not yet initialized.
+
+## GitService
+
+### `isGitAvailable(): Promise<boolean>`
+Checks if `git` is installed and available by running `git --version`.
+
+### `clone(urlOrRepo: string, targetPath: string, ref?: string): Promise<void>`
+Clones a repository using `git clone --depth 1`. If `urlOrRepo` is in `owner/repo` format, resolves to `https://github.com/owner/repo.git`. If `ref` is provided, adds `-b <ref>` flag. Timeout: configurable via `WAVE_PLUGIN_GIT_TIMEOUT_MS` (default 120s).
+
+### `pull(targetPath: string): Promise<void>`
+Runs `git pull` in the specified directory. Same timeout as `clone`.
+
+### Error Handling
+Returns descriptive errors for: timeout, not-found, auth failure, rate limit, and not-a-repo.
+
+## PluginCore
+
+High-level API that orchestrates `PluginManager`, `PluginScopeManager`, `MarketplaceService`, and `ConfigurationService`.
+
+### `installPlugin(pluginId: string, scope?: Scope): Promise<InstalledPlugin>`
+Install a plugin by `name@marketplace` ID and optionally enable it in the given scope.
+
+### `uninstallPlugin(pluginId: string): Promise<void>`
+Uninstall a plugin and remove it from all enabled scopes.
+
+### `enablePlugin(pluginId: string, scope?: Scope): Promise<Scope>`
+Enable a plugin in the specified scope. Returns the scope where it was enabled.
+
+### `disablePlugin(pluginId: string, scope?: Scope): Promise<Scope>`
+Disable a plugin in the specified scope.
+
+### `updatePlugin(pluginId: string): Promise<InstalledPlugin>`
+Update a plugin by uninstalling and re-installing.
+
+### `listPlugins(): Promise<{ plugins: MarketplacePluginStatus[]; mergedEnabled: Record<string, boolean> }>`
+List all plugins from all marketplaces with their installation and enabled status.
+
+### `addMarketplace(input: string, scope?: Scope): Promise<KnownMarketplace>`
+Add a marketplace (GitHub shorthand, Git URL, or local path).
+
+### `removeMarketplace(name: string, scope?: Scope): Promise<void>`
+Remove a marketplace from the specified scope.
+
+### `updateMarketplace(name?: string): Promise<void>`
+Update a specific marketplace or all marketplaces.
+
+### `listMarketplaces(): Promise<KnownMarketplace[]>`
+List all registered marketplaces.
+
+### `toggleAutoUpdate(name: string, enabled: boolean): Promise<void>`
+Toggle auto-update for a marketplace.
+
+### `getInstalledPlugins(): Promise<InstalledPluginsRegistry>`
+Get the installed plugins registry.
+
+### `getMergedEnabledPlugins(): Record<string, boolean>`
+Get the merged enabled plugins map across all scopes.
+
+### `findPluginScope(pluginId: string): Scope | null`
+Find which scope a plugin is enabled in.
+
+### `removeEnabledPlugin(scope: Scope, pluginId: string): Promise<void>`
+Remove a plugin from the enabled list in a specific scope.

--- a/specs/042-plugin/contracts/marketplace.ts
+++ b/specs/042-plugin/contracts/marketplace.ts
@@ -5,8 +5,17 @@ export interface MarketplaceOwner {
 
 export interface MarketplacePluginEntry {
   name: string;
-  source: string;
+  source: string; // Relative path (e.g., "./plugins/review-plugin") or Git URL (http://, https://, git@, ssh://)
   description: string;
+}
+
+export interface MarketplacePluginStatus extends MarketplacePluginEntry {
+  marketplace: string;
+  installed: boolean;
+  version?: string;
+  cachePath?: string;
+  projectPath?: string;
+  scope?: Scope;
 }
 
 export interface MarketplaceManifest {
@@ -15,20 +24,19 @@ export interface MarketplaceManifest {
   plugins: MarketplacePluginEntry[];
 }
 
-export type MarketplaceSourceType = 'directory' | 'github' | 'git';
-
-export interface MarketplaceSource {
-  source: MarketplaceSourceType;
-  path?: string; // for 'directory'
-  repo?: string; // for 'github'
-  url?: string;  // for 'git'
-}
+// Discriminated union for type safety
+export type MarketplaceSource =
+  | { source: "directory"; path: string }
+  | { source: "github"; repo: string; ref?: string }
+  | { source: "git"; url: string; ref?: string };
 
 export interface KnownMarketplace {
   name: string;
   source: MarketplaceSource;
   isBuiltin?: boolean;
   autoUpdate?: boolean;
+  lastUpdated?: string;
+  declaredScope?: "user" | "project" | "local" | "builtin";
 }
 
 export interface KnownMarketplacesRegistry {
@@ -40,10 +48,12 @@ export interface InstalledPlugin {
   marketplace: string;
   version: string;
   cachePath: string;
-  scope: 'user' | 'project' | 'local';
-  isEnabled: boolean;
+  scope?: Scope; // Optional — scope is tracked via enabledPlugins in settings
+  projectPath?: string;
 }
 
 export interface InstalledPluginsRegistry {
   plugins: InstalledPlugin[];
 }
+
+export type Scope = "user" | "project" | "local";

--- a/specs/042-plugin/contracts/plugin-management.md
+++ b/specs/042-plugin/contracts/plugin-management.md
@@ -3,19 +3,20 @@
 This document defines the interfaces and behaviors for managing plugins in Wave.
 
 ## 1. Plugin Scope Manager
-The `PluginScopeManager` manages plugin installation scopes (`user`, `project`, `local`).
+The `PluginScopeManager` manages plugin enable/disable state across scopes via `ConfigurationService`.
 
 ```typescript
 export interface PluginScopeManager {
-  getPluginPath(scope: Scope): string;
-  getPluginPaths(): string[];
-  installPlugin(pluginUrl: string, scope: Scope): Promise<void>;
-  uninstallPlugin(pluginName: string, scope: Scope): Promise<void>;
+  enablePlugin(scope: Scope, pluginId: string): Promise<Scope>;
+  disablePlugin(scope: Scope, pluginId: string): Promise<Scope>;
+  findPluginScope(pluginId: string): Scope | null;
+  removePluginFromAllScopes(pluginId: string): Promise<void>;
+  getMergedEnabledPlugins(): Record<string, boolean>;
 }
 ```
 
 ## 2. Configuration Service
-The `ConfigurationService` manages the `enabledPlugins` configuration across all scopes.
+The `ConfigurationService` manages the `enabledPlugins` and `marketplaces` configuration across all scopes.
 
 ```typescript
 export interface ConfigurationService {
@@ -34,17 +35,40 @@ wave plugin enable <plugin-id> [--scope <scope>]
 # Disable a plugin
 wave plugin disable <plugin-id> [--scope <scope>]
 
-# Install a plugin
-wave plugin install <plugin-url> [--scope <scope>]
+# Install a plugin from a marketplace
+wave plugin install <plugin-name>@<marketplace-name>
+
+# Uninstall a plugin
+wave plugin uninstall <plugin-name>@<marketplace-name>
+
+# Update a plugin
+wave plugin update <plugin-name>@<marketplace-name>
 
 # List installed plugins
 wave plugin list
 ```
 
-## 4. Scope Priority
+## 4. Marketplace Commands
+```bash
+# Add a marketplace
+wave plugin marketplace add <source> [--scope <scope>]
+
+# List marketplaces
+wave plugin marketplace list
+
+# Update a marketplace (or all if name omitted)
+wave plugin marketplace update [name]
+
+# Remove a marketplace
+wave plugin marketplace remove <name>
+```
+
+## 5. Scope Priority
 The system enforces a strict priority for enabled plugins: `local` > `project` > `user`.
 
 - **Local**: `.wave/settings.local.json`
 - **Project**: `.wave/settings.json`
 - **User**: `~/.wave/settings.json`
-```
+
+## 6. Plugin ID Format
+Plugins are identified using the `name@marketplace` compound format (e.g., `review-plugin@wave-plugins-official`). This format is used for all enable, disable, install, uninstall, and update operations.

--- a/specs/042-plugin/contracts/plugin-manifest.schema.json
+++ b/specs/042-plugin/contracts/plugin-manifest.schema.json
@@ -5,7 +5,8 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "The unique name of the plugin."
+      "description": "The unique name of the plugin. Lowercase, alphanumeric + hyphens.",
+      "pattern": "^[a-z0-9-]+$"
     },
     "description": {
       "type": "string",
@@ -13,15 +14,13 @@
     },
     "version": {
       "type": "string",
-      "description": "The semantic version of the plugin."
+      "description": "The semantic version of the plugin.",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+"
     },
     "author": {
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
-        },
-        "email": {
           "type": "string"
         }
       },

--- a/specs/042-plugin/contracts/plugin-system.md
+++ b/specs/042-plugin/contracts/plugin-system.md
@@ -3,59 +3,104 @@
 This document defines the core interfaces and behaviors of the plugin system.
 
 ## 1. Plugin Interface
-The `Plugin` interface represents a loaded plugin in the system.
+The `Plugin` interface represents a loaded plugin. It extends `PluginManifest`, merging manifest fields flat (no nested `components` wrapper).
 
 ```typescript
-export interface Plugin {
+export interface Plugin extends PluginManifest {
+  path: string;
+  commands: CustomSlashCommand[];
+  skills: Skill[];
+  agents: SubagentConfiguration[];
+  lspConfig?: LspConfig;
+  mcpConfig?: McpConfig;
+  hooksConfig?: PartialHookConfiguration;
+}
+```
+
+## 2. PluginManifest
+```typescript
+export interface PluginManifest {
   name: string;
   description: string;
   version: string;
-  author?: {
-    name: string;
-    email?: string;
-  };
+  author?: { name: string };
+}
+```
+
+## 3. PluginConfig
+Configuration for loading a plugin via `AgentOptions.plugins`.
+
+```typescript
+export interface PluginConfig {
+  type: "local";
   path: string;
-  manifest: PluginManifest;
-  components: {
-    commands?: SlashCommand[];
-    skills?: Skill[];
-    hooks?: Hook[];
-    agents?: Agent[];
-    lsp?: LspConfig;
-    mcp?: McpConfig;
-  };
 }
 ```
 
-## 2. Plugin Loader
-The `PluginLoader` is responsible for reading and validating plugins from the filesystem.
+## 4. Plugin Loader
+`PluginLoader` is a static utility class for reading and validating plugins from the filesystem.
 
 ```typescript
-export interface PluginLoader {
-  loadPlugin(pluginPath: string): Promise<Plugin>;
-  loadPlugins(pluginPaths: string[]): Promise<Plugin[]>;
+export class PluginLoader {
+  static loadManifest(pluginPath: string): PluginManifest;
+  static loadCommands(pluginPath: string): CustomSlashCommand[];
+  static loadSkills(pluginPath: string): Skill[];
+  static loadAgents(pluginPath: string): SubagentConfiguration[];
+  static loadLspConfig(pluginPath: string): LspConfig | undefined;
+  static loadMcpConfig(pluginPath: string): McpConfig | undefined;
+  static loadHooksConfig(pluginPath: string): PartialHookConfiguration | undefined;
 }
 ```
 
-## 3. Plugin Manager
-The `PluginManager` stores and manages loaded plugins.
+## 5. Plugin Manager
+`PluginManager` stores and manages loaded plugins. Uses DI via `Container`.
 
 ```typescript
-export interface PluginManager {
-  plugins: Plugin[];
-  loadPlugins(pluginPaths: string[]): Promise<void>;
+export interface PluginManagerOptions {
+  workdir: string;
+  enabledPlugins?: Record<string, boolean>;
+}
+
+export class PluginManager {
+  constructor(container: Container, options: PluginManagerOptions);
+
+  // Load explicitly configured plugins, then marketplace-installed plugins
+  loadPlugins(configs: PluginConfig[]): Promise<void>;
+
+  // Push updated enabledPlugins from ConfigurationService
+  updateEnabledPlugins(enabledPlugins: Record<string, boolean>): void;
+
+  // Returns all loaded plugins (enabled + disabled)
+  getPlugins(): Plugin[];
+
+  // Find a plugin by name
   getPlugin(name: string): Plugin | undefined;
-  getEnabledPlugins(): Plugin[];
 }
 ```
 
-## 4. Component Registration
-Each component type (Commands, Skills, Hooks, Agents, LSP, MCP) MUST have a corresponding manager or service that handles its registration and execution.
+### loadPlugins Flow
+1. Iterates `configs[]`, loads each `PluginConfig` via `loadSinglePlugin(absolutePath)`.
+2. Calls `loadInstalledPlugins()` which:
+   - Refreshes `enabledPlugins` from `ConfigurationService.getMergedEnabledPlugins()`
+   - Triggers background `autoUpdateAll()` on marketplace repos with `autoUpdate: true`
+   - Auto-installs any enabled but missing plugins from known marketplaces
+   - Loads each installed+enabled plugin via `loadSinglePlugin(cachePath)`
+
+### loadSinglePlugin Registration
+Each plugin's components are registered with their respective managers:
+- `slashCommandManager.registerPluginCommands(name, commands)`
+- `skillManager.registerPluginSkills(name, skills)`
+- `lspManager.registerServer(language, configWithPluginRoot)`
+- `mcpManager.addServer(name, configWithPluginRoot)`
+- `hookManager.registerPluginHooks(path, hooksConfig)`
+- `subagentManager.registerPluginAgents(name, agents)`
+
+## 6. Component Registration
+Each component type has a corresponding manager or service:
 
 - **SlashCommandManager**: Registers and executes slash commands. Plugin commands MUST be namespaced using the plugin name and a colon (e.g., `plugin-name:command-name`).
 - **SkillManager**: Registers and executes skills. Plugin skills MUST be namespaced using the plugin name and a colon (e.g., `plugin-name:skill-name`).
 - **HookManager**: Registers and executes hooks.
-- **AgentManager**: Registers and executes agents.
-- **LspService**: Manages LSP configurations.
-- **McpService**: Manages MCP configurations.
-```
+- **SubagentManager**: Registers and executes agents.
+- **LspManager**: Manages LSP configurations.
+- **McpManager**: Manages MCP configurations.

--- a/specs/042-plugin/data-model.md
+++ b/specs/042-plugin/data-model.md
@@ -5,73 +5,110 @@ This document defines the entities and data structures for the plugin support sy
 ## Entities
 
 ### 1. Plugin
-Represents a loaded plugin in the system.
+Represents a loaded plugin in the system. Extends `PluginManifest` (fields are flat, no nested `components` wrapper).
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `name` | `string` | Unique identifier, used for namespacing. |
-| `description` | `string` | Brief description of the plugin. |
-| `version` | `string` | Semantic version. |
-| `author` | `object` (Optional) | Information about the plugin author. |
+| `name` | `string` | Inherited from `PluginManifest`. Unique identifier, used for namespacing. |
+| `description` | `string` | Inherited from `PluginManifest`. |
+| `version` | `string` | Inherited from `PluginManifest`. Semantic version. |
+| `author` | `{ name: string }` (Optional) | Inherited from `PluginManifest`. Information about the plugin author. |
 | `path` | `string` | Absolute path to the plugin directory. |
-| `manifest` | `PluginManifest` | The static definition of the plugin. |
-| `components` | `object` | List of components provided by the plugin. |
-| `skills` | `Skill[]` | List of skills provided by the plugin. |
+| `commands` | `CustomSlashCommand[]` | Slash commands provided by the plugin. |
+| `skills` | `Skill[]` | Skills provided by the plugin. |
+| `agents` | `SubagentConfiguration[]` | Subagent definitions provided by the plugin. |
+| `lspConfig` | `LspConfig` (Optional) | LSP server configuration. |
+| `mcpConfig` | `McpConfig` (Optional) | MCP server configuration. |
+| `hooksConfig` | `PartialHookConfiguration` (Optional) | Hook event handlers. |
 
 ### 2. PluginManifest
 The structure of the `.wave-plugin/plugin.json` file.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `name` | `string` | Required. |
+| `name` | `string` | Required. Lowercase, alphanumeric + hyphens. |
 | `description` | `string` | Required. |
 | `version` | `string` | Required. |
-| `author` | `object` (Optional) | Information about the plugin author. |
+| `author` | `{ name: string }` (Optional) | Information about the plugin author. |
 
-### 3. WaveConfiguration (Updated)
-The existing `WaveConfiguration` interface will be updated to include `enabledPlugins`.
+### 3. PluginConfig
+Configuration for loading a plugin, passed via `AgentOptions.plugins`.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `type` | `"local"` | Currently only local plugins are supported. |
+| `path` | `string` | Filesystem path to the plugin directory. |
+
+### 4. WaveConfiguration (Updated)
+The existing `WaveConfiguration` interface includes plugin-related fields.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `enabledPlugins` | `Record<string, boolean>` | A mapping of plugin IDs (`name@marketplace`) to their enabled state. |
+| `marketplaces` | `Record<string, MarketplaceConfig>` | Registered marketplaces with their source and settings. |
 
-### 4. Scope
+### 5. MarketplaceConfig
+Configuration for a marketplace entry in `WaveConfiguration`.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `source` | `MarketplaceSource` | The marketplace source (directory, GitHub, or Git). |
+| `autoUpdate` | `boolean` (Optional) | Whether auto-update is enabled. |
+
+### 6. Scope
 | Value | Description |
 | :--- | :--- |
 | `user` | Global configuration in `~/.wave/settings.json`. |
 | `project` | Project-specific configuration in `.wave/settings.json`. |
 | `local` | Local override configuration in `.wave/settings.local.json`. |
 
-### 5. KnownMarketplace (Internal)
-Stored in `~/.wave/plugins/known_marketplaces.json`.
+### 7. MarketplaceSource (Discriminated Union)
+The location of a marketplace. Uses discriminated union for type safety.
 
-| Field | Type | Description |
+| Variant | Fields | Description |
 | :--- | :--- | :--- |
-| `name` | `string` | Unique name of the marketplace. |
-| `source` | `MarketplaceSource` | Union type defining the location (GitHub, Git, or local directory). |
-| `isBuiltin` | `boolean` (Optional) | Flag to indicate if this marketplace is provided by the system. |
-| `autoUpdate` | `boolean` | Whether auto-update is enabled for this marketplace. |
-| `lastUpdated` | `string` | ISO date string of the last successful update. |
+| `directory` | `{ source: "directory"; path: string }` | Local filesystem path. |
+| `github` | `{ source: "github"; repo: string; ref?: string }` | GitHub `owner/repo` shorthand. Optional `ref` for branch/tag. |
+| `git` | `{ source: "git"; url: string; ref?: string }` | Full Git repository URL. Optional `ref` for branch/tag. |
 
-### 6. MarketplaceSource
-| Field | Type | Description |
-| :--- | :--- | :--- |
-| `source` | `'directory' \| 'github' \| 'git'` | The type of source. |
-| `path` | `string` (for `directory`) | Absolute path to the marketplace root. |
-| `repo` | `string` (for `github`) | The `owner/repo` string for GitHub marketplaces. |
-| `url` | `string` (for `git`) | Full Git repository URL. |
-
-### 7. MarketplacePluginEntry (External)
+### 8. MarketplacePluginEntry (External)
 Represents a plugin entry within a `marketplace.json` manifest.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `name` | `string` | Name of the plugin. |
-| `source` | `string` | Relative path to plugin source (e.g., `"./plugins/commit-commands"`). |
+| `source` | `string` | Relative path to plugin source (e.g., `"./plugins/commit-commands"`) **or** a Git URL (`http://`, `https://`, `git@`, `ssh://`). |
 | `description` | `string` | Brief description of the plugin. |
 
-### 8. InstalledPlugin (Internal)
-Stored in `~/.wave/plugins/installed_plugins.json`.
+### 9. MarketplacePluginStatus
+Aggregates a `MarketplacePluginEntry` with installation status for UI display.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `name` | `string` | Inherited from `MarketplacePluginEntry`. |
+| `source` | `string` | Inherited from `MarketplacePluginEntry`. |
+| `description` | `string` | Inherited from `MarketplacePluginEntry`. |
+| `marketplace` | `string` | Name of the marketplace. |
+| `installed` | `boolean` | Whether the plugin is currently installed. |
+| `version` | `string` (Optional) | Installed version. |
+| `cachePath` | `string` (Optional) | Path to cached plugin files. |
+| `projectPath` | `string` (Optional) | Project path for project-scoped installs. |
+| `scope` | `Scope` (Optional) | Installation scope. |
+
+### 10. KnownMarketplace (Internal)
+Stored in `~/.wave/plugins/known_marketplaces.json`.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `name` | `string` | Unique name of the marketplace. |
+| `source` | `MarketplaceSource` | Discriminated union defining the location. |
+| `isBuiltin` | `boolean` (Optional) | Flag to indicate if this marketplace is provided by the system. |
+| `autoUpdate` | `boolean` (Optional) | Whether auto-update is enabled. |
+| `lastUpdated` | `string` (Optional) | ISO date string of the last successful update. |
+| `declaredScope` | `"user" \| "project" \| "local" \| "builtin"` (Optional) | Which scope declared this marketplace. |
+
+### 11. InstalledPlugin (Internal)
+Stored in `~/.wave/plugins/installed_plugins.json`. Enabled state is tracked separately via `enabledPlugins` in settings, not on this record.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
@@ -79,10 +116,10 @@ Stored in `~/.wave/plugins/installed_plugins.json`.
 | `marketplace` | `string` | Name of the marketplace it was installed from. |
 | `version` | `string` | Version of the plugin at the time of installation. |
 | `cachePath` | `string` | Absolute path to the cached plugin files in `~/.wave/plugins/cache/`. |
-| `scope` | `'user' \| 'project' \| 'local'` | Installation scope. |
-| `isEnabled` | `boolean` | Whether the plugin is enabled in the current scope. |
+| `scope` | `Scope` (Optional) | Installation scope. |
+| `projectPath` | `string` (Optional) | Project path for project-scoped installs. |
 
-### 9. Lock File (Internal)
+### 12. Lock File (Internal)
 Located at `~/.wave/plugins/.lock`.
 
 Used to synchronize access to `known_marketplaces.json` and `installed_plugins.json` across multiple `wave-agent` processes. It is a re-entrant file-based lock.
@@ -98,6 +135,19 @@ interface PluginManagerState {
 }
 ```
 
+## Disk Layout
+```
+~/.wave/plugins/
+├── installed_plugins.json       # InstalledPlugin registry
+├── known_marketplaces.json      # KnownMarketplace registry
+├── .lock                        # File-based lock
+├── cache/                       # Cached plugin files
+│   └── <marketplace>/<plugin>/<version>/
+├── marketplaces/                # Cloned marketplace repos
+│   └── <owner>/<repo>/
+└── tmp/                         # Temporary clone directories
+```
+
 ## Validation Rules
 1. **Manifest Location**: MUST be at `.wave-plugin/plugin.json`.
 2. **Component Location**: All component directories (`commands/`, `skills/`, `hooks/`, `agents/`) and config files (`.lsp.json`, `.mcp.json`) MUST be at the plugin root level.
@@ -106,8 +156,9 @@ interface PluginManagerState {
 5. **Namespacing**: Both slash commands and agent skills provided by plugins MUST be namespaced using the plugin name and a colon (e.g., `plugin-name:component-name`).
 6. **Scope Priority**: `local` > `project` > `user`.
 7. **Marketplace Name**: Must be alphanumeric and unique among added marketplaces.
-8. **Plugin Name**: Must be alphanumeric and unique within a marketplace.
-9. **Source Path**: Must be a valid relative path within the marketplace directory.
+8. **Plugin Name**: Must be lowercase, alphanumeric + hyphens, unique within a marketplace.
+9. **Source Path**: Relative paths must be valid within the marketplace directory. Git URL sources must start with `http://`, `https://`, `git@`, or `ssh://`.
 10. **Version**: Must follow semantic versioning (e.g., `1.0.0`).
 11. **Marketplace Source**: Must be a valid GitHub shorthand (`owner/repo`), a valid Git URL, or an existing local directory path.
 12. **Installation Scope**: Must be one of the three supported scopes.
+13. **Remote Fetching**: All remote fetching uses `git clone --depth 1`; no direct HTTP file download.

--- a/specs/042-plugin/plan.md
+++ b/specs/042-plugin/plan.md
@@ -1,7 +1,7 @@
 # Implementation Plan: Plugin Support and Marketplace
 
 **Branch**: `042-plugin`
-**Status**: Unified Implementation Plan
+**Status**: Complete
 
 ## Summary
 The goal is to provide a unified plugin support system and marketplace for Wave. This includes support for local plugins, expanded plugin capabilities (Skills, LSP, MCP, Hooks, Agents), plugin scope management, and a marketplace ecosystem for discovery and installation. The technical approach involves:
@@ -12,16 +12,19 @@ The goal is to provide a unified plugin support system and marketplace for Wave.
 5.  Defining a directory structure in `~/.wave` for marketplace metadata and installed plugin snapshots.
 6.  Implementing core services in `agent-sdk` for marketplace and plugin management.
 7.  Injecting a builtin marketplace (`wave-plugins-official`) by default.
-8.  Supporting GitHub and Git-based marketplaces using `git clone` and `git pull`.
-9.  Providing an interactive Ink-based CLI interface for discovery, installation, and management.
+8.  Supporting GitHub and Git-based marketplaces using `git clone --depth 1` and `git pull`. No direct HTTP file download.
+9.  Providing a `PluginCore` high-level API for all plugin and marketplace operations.
+10. Providing an interactive Ink-based CLI interface for discovery, installation, and management.
 
 ## Technical Context
 - **Language/Version**: TypeScript (Strict mode)
 - **Primary Dependencies**: `agent-sdk`, `code` (CLI), `git` CLI, `pnpm`, `vitest`
 - **Storage**: Local filesystem (plugin directories, `.wave-plugin/plugin.json`, `settings.json`, `~/.wave/plugins/`)
+- **Remote Fetching**: All via `git clone --depth 1` (shallow clone). GitHub shorthand resolved to `https://github.com/owner/repo.git`. No direct HTTP download.
 - **Testing**: Vitest (unit and integration tests)
 - **Target Platform**: Linux/macOS/Windows (Node.js environment)
 - **Performance Goals**: Fast plugin loading and command execution (<100ms). Plugin installation and command discovery should be near-instant (< 500ms).
+- **Git Timeout**: Default 120s, configurable via `WAVE_PLUGIN_GIT_TIMEOUT_MS`.
 
 ## Constitution Check
 1.  **Package-First Architecture**: Logic in `agent-sdk`, CLI in `code`.
@@ -50,9 +53,10 @@ specs/042-plugin/
 packages/
 ├── agent-sdk/
 │   ├── src/
-│   │   ├── managers/    # PluginManager, SkillManager, HookManager
-│   │   ├── services/    # PluginLoader, ConfigurationService, MarketplaceService, GitService
-│   │   └── types/       # Plugin types, WaveConfiguration, Marketplace types
+│   │   ├── core/        # PluginCore — high-level API for all plugin/marketplace operations
+│   │   ├── managers/    # PluginManager, PluginScopeManager, SkillManager, HookManager
+│   │   ├── services/    # PluginLoader, ConfigurationService, MarketplaceService, GitService, InitializationService
+│   │   └── types/       # Plugin types, WaveConfiguration, Marketplace types (discriminated union)
 └── code/
     ├── src/
     │   ├── cli.tsx      # --plugin-dir flag

--- a/specs/042-plugin/quickstart.md
+++ b/specs/042-plugin/quickstart.md
@@ -14,8 +14,7 @@ cat <<EOF > my-plugin/.wave-plugin/plugin.json
   "description": "A sample plugin for Wave.",
   "version": "1.0.0",
   "author": {
-    "name": "Your Name",
-    "email": "your.email@example.com"
+    "name": "Your Name"
   }
 }
 EOF
@@ -51,17 +50,23 @@ wave --plugin-dir ./my-plugin
 ```
 
 ## 4. Manage Plugins (CLI)
-Use the `plugin` command to enable, disable, or install plugins.
+Use the `plugin` command to enable, disable, install, or update plugins.
 
 ```bash
+# Install a plugin from a marketplace
+wave plugin install my-plugin@wave-plugins-official
+
 # Enable a plugin
-wave plugin enable my-plugin@local
+wave plugin enable my-plugin@wave-plugins-official --scope project
 
 # Disable a plugin
-wave plugin disable my-plugin@local
+wave plugin disable my-plugin@wave-plugins-official --scope project
 
-# Install a plugin from GitHub
-wave plugin install https://github.com/user/repo.git
+# Update a plugin
+wave plugin update my-plugin@wave-plugins-official
+
+# Uninstall a plugin
+wave plugin uninstall my-plugin@wave-plugins-official
 ```
 
 ## 5. Plugin Structure
@@ -76,7 +81,7 @@ my-plugin/
 ├── skills/              # Optional: Skills
 │   └── SKILL.md
 ├── hooks/               # Optional: Hooks
-│   └── HOOK.md
+│   └── hooks.json
 ├── agents/              # Optional: Agents
 │   └── AGENT.md
 ├── .lsp.json            # Optional: LSP configuration
@@ -113,6 +118,7 @@ In the "Marketplaces" view, you can add, update, or remove marketplace sources.
 1. Select "Add Marketplace".
 2. Enter a source:
    - **GitHub**: `owner/repo` (e.g., `netease-lcap/wave-plugins-official`)
+   - **GitHub with branch**: `owner/repo#branch`
    - **Git**: Full URL (e.g., `https://github.com/owner/repo.git`)
    - **Local**: Path to directory (e.g., `./my-marketplace`)
 
@@ -125,10 +131,23 @@ wave plugin marketplace update [name]
 ## 10. Builtin Marketplace
 The `wave-plugins-official` marketplace is available by default. You can discover and install official plugins immediately after installation.
 
-## 11. CLI Commands for Marketplace
-While the interactive UI is recommended, you can also use CLI commands:
-- `wave plugin install <plugin-name>@<marketplace-name>`
-- `wave plugin marketplace add <source>`
-- `wave plugin marketplace list`
-- `wave plugin marketplace update [name]`
-- `wave plugin marketplace remove <name>`
+## 11. Remote Plugin Fetching
+All remote fetching uses `git clone --depth 1` (shallow clone). There is no direct HTTP file download. Plugin entries in `marketplace.json` can reference:
+- **Relative paths** (e.g., `./plugins/review-plugin`) — copied from marketplace checkout
+- **Git URLs** (e.g., `https://github.com/user/plugin.git`) — cloned individually
+
+## 12. CLI Commands Reference
+
+| Command | Description |
+|---------|-------------|
+| `wave plugin` | Open interactive UI |
+| `wave plugin list` | List installed plugins |
+| `wave plugin install <name>@<marketplace>` | Install a plugin |
+| `wave plugin uninstall <name>@<marketplace>` | Uninstall a plugin |
+| `wave plugin update <name>@<marketplace>` | Update a plugin |
+| `wave plugin enable <name>@<marketplace> [--scope]` | Enable a plugin |
+| `wave plugin disable <name>@<marketplace> [--scope]` | Disable a plugin |
+| `wave plugin marketplace add <source> [--scope]` | Add a marketplace |
+| `wave plugin marketplace list` | List marketplaces |
+| `wave plugin marketplace update [name]` | Update marketplace(s) |
+| `wave plugin marketplace remove <name>` | Remove a marketplace |

--- a/specs/042-plugin/research.md
+++ b/specs/042-plugin/research.md
@@ -4,14 +4,14 @@ This document consolidates research findings and technical decisions for the plu
 
 ## 1. Plugin Structure and Loading Mechanism
 - **Decision**: A plugin will be a directory containing:
-    - `.wave-plugin/plugin.json`: Manifest file with `name`, `description`, `version`, and optional `author`.
+    - `.wave-plugin/plugin.json`: Manifest file with `name`, `description`, `version`, and optional `author` (with `name` only, no `email`).
     - `commands/`: Directory containing Markdown files for slash commands.
     - `skills/`: Directory containing Agent Skills with `SKILL.md` files.
     - `agents/`: Directory containing custom agent definitions.
     - `hooks/`: Directory containing event handlers in `hooks.json`.
     - `.lsp.json`: LSP server configuration.
     - `.mcp.json`: MCP server configuration.
-- **Rationale**: Standardized directory structure for all plugin-provided functionality.
+- **Implementation**: `Plugin` extends `PluginManifest`, merging manifest fields flat. There is no nested `components` wrapper. Component fields are top-level: `commands`, `skills`, `agents`, `lspConfig?`, `mcpConfig?`, `hooksConfig?`.
 
 ## 2. Component Discovery Rules
 - **Decision**: All components must be located at the plugin root level, except for `plugin.json` which must be in `.wave-plugin/`.
@@ -21,6 +21,7 @@ This document consolidates research findings and technical decisions for the plu
 - **Decision**: Add an optional `enabledPlugins` property of type `Record<string, boolean>` to the `WaveConfiguration` interface.
 - **Rationale**: Using a record allows for explicit disabling (`false`) which can override an enabled state from a lower-priority scope.
 - **Scope Priority**: `local` > `project` > `user`.
+- **Implementation**: Enabled state is tracked via `enabledPlugins` in settings files, not on the `InstalledPlugin` record. `PluginScopeManager` handles enable/disable via `ConfigurationService`.
 
 ## 4. Dynamic Tool Definitions
 - **Decision**: Tools that depend on a dynamic list of components (like `Skill` and `Task` tools) will use getters for their `config` property.
@@ -37,41 +38,66 @@ This document consolidates research findings and technical decisions for the plu
 - **Decision**: Use native `fs` module for file operations.
 - **Mechanism**:
     1. Create a unique temporary directory in `~/.wave/plugins/tmp/`.
-    2. Copy the plugin source to the temporary directory using `fs.cpSync(src, dest, { recursive: true })`.
+    2. Clone (for Git sources) or copy (for local sources) the plugin to the temporary directory.
     3. Validate the `plugin.json` in the temporary directory.
     4. Move/Rename the temporary directory to the final destination in `~/.wave/plugins/cache/[marketplace]/[plugin]/[version]` using `fs.renameSync`.
-- **Rationale**: Native `fs.cpSync` is available in modern Node.js versions and reduces external dependencies. The "copy-then-rename" pattern ensures that a failed installation doesn't leave a partially copied plugin in the active cache.
+- **Rationale**: Native `fs.cpSync` is available in modern Node.js versions and reduces external dependencies. The "copy/clone-then-rename" pattern ensures that a failed installation doesn't leave a partially copied plugin in the active cache.
 
 ## 8. GitHub and Git Integration Strategy
-- **Mechanism**: Use `git clone --depth 1 [url]` to clone the repository.
+- **Mechanism**: Use `git clone --depth 1 [url]` to clone the repository. GitHub shorthand (`owner/repo`) is automatically resolved to `https://github.com/owner/repo.git`.
 - **Local Storage**: Clone to `~/.wave/plugins/marketplaces/[owner]/[repo]`.
-- **Registry Update**: Update `known_marketplaces.json` to use a structured `source` object:
+- **Branch/Tag Support**: `MarketplaceSource` includes an optional `ref` field on `github` and `git` variants. GitService passes `-b <ref>` to `git clone`.
+- **Timeout**: Default 120s, configurable via `WAVE_PLUGIN_GIT_TIMEOUT_MS`.
+- **Registry Update**: Update `known_marketplaces.json` with structured `MarketplaceSource` (discriminated union):
   ```json
   {
     "name": "official",
-    "source": {
-      "source": "github",
-      "repo": "owner/repo"
-    }
+    "source": { "source": "github", "repo": "owner/repo" },
+    "autoUpdate": true
   }
   ```
-- **Rationale**: Leveraging `git clone` and `git pull` provides a robust way to manage remote content and updates.
+- **Rationale**: Leveraging `git clone` and `git pull` provides a robust way to manage remote content and updates. Discriminated union provides better type safety than optional fields.
 
-## 9. Inject Builtin Marketplace in MarketplaceService
-- **Decision**: The builtin marketplace `wave-plugins-official` will be injected at the service level in `packages/agent-sdk/src/services/MarketplaceService.ts`.
+## 9. Remote Plugin Fetching (No Direct HTTP Download)
+- **Decision**: All remote plugin and marketplace fetching uses `git clone --depth 1`. There is no direct HTTP file download mechanism.
+- **Implementation**:
+    1. **Marketplace registration**: `git clone` the marketplace repo into `~/.wave/plugins/marketplaces/<repo>/`.
+    2. **Plugin install from relative path**: Copy from the marketplace checkout directory.
+    3. **Plugin install from Git URL**: If a `MarketplacePluginEntry.source` starts with `http://`, `https://`, `git@`, or `ssh://`, clone the individual plugin repo into `~/.wave/plugins/tmp/clone-<timestamp>`, then move to cache.
+- **Rationale**: Git provides version tracking, branch support, and authentication out of the box.
+
+## 10. Inject Builtin Marketplace in MarketplaceService
+- **Decision**: The builtin marketplace `wave-plugins-official` (netease-lcap/wave-plugins-official) will be injected at the service level in `packages/agent-sdk/src/services/MarketplaceService.ts`.
 - **Rationale**: Centralized logic ensures all CLI commands and internal services see the builtin marketplace.
 
-## 10. Marketplace State Management
+## 11. Marketplace State Management
 - **Decision**: Maintain two JSON files in `~/.wave/plugins/`:
-    - `known_marketplaces.json`: List of added marketplace paths and names.
-    - `installed_plugins.json`: Registry of installed plugins, their versions, and their local cache paths.
+    - `known_marketplaces.json`: List of added marketplaces with `MarketplaceSource`, `lastUpdated`, and `declaredScope`.
+    - `installed_plugins.json`: Registry of installed plugins with their versions, cache paths, and optional scope/projectPath.
 - **Rationale**: Simple, human-readable, and easy to manage without a full database.
+- **Note**: Enabled state is NOT stored in `installed_plugins.json`. It is tracked via `enabledPlugins` in the scoped `settings.json` files.
 
-## 11. Ink-based UI Navigation
+## 12. Ink-based UI Navigation
 - **Decision**: Implement a standalone Ink-based CLI interface triggered by `wave plugin`.
 - **Navigation**: Use `Tab` and `Shift+Tab` for main navigation areas (Discover, Installed, Marketplaces).
 - **Rationale**: Provides a modern, interactive experience for managing plugins.
 
-## 12. Plugin Loading Logic
-- **Decision**: `PluginManager` will be updated to automatically scan `~/.wave/plugins/installed_plugins.json` and load plugins from their cached paths.
-- **Rationale**: This allows installed plugins to be available across all sessions without explicit `--plugin-dir` flags.
+## 13. Plugin Loading Logic
+- **Decision**: `PluginManager.loadPlugins()` loads in two phases:
+    1. Explicitly configured plugins from `AgentOptions.plugins` (higher priority).
+    2. Marketplace-installed plugins from `installed_plugins.json`, filtered by `enabledPlugins` across all scopes.
+- **Auto-install**: If a plugin is enabled in settings but not found in cache, `loadInstalledPlugins()` will attempt to auto-install it from a known marketplace.
+- **Background auto-update**: During `loadInstalledPlugins()`, `MarketplaceService.autoUpdateAll()` runs in the background for marketplaces with `autoUpdate: true`.
+- **Rationale**: This allows installed plugins to be available across all sessions without explicit `--plugin-dir` flags, and keeps marketplaces up-to-date automatically.
+
+## 14. PluginCore High-Level API
+- **Decision**: `PluginCore` (in `packages/agent-sdk/src/core/plugin.ts`) provides a unified API for all plugin and marketplace operations.
+- **Methods**: `installPlugin`, `uninstallPlugin`, `enablePlugin`, `disablePlugin`, `updatePlugin`, `listPlugins`, `addMarketplace`, `removeMarketplace`, `updateMarketplace`, `listMarketplaces`, `toggleAutoUpdate`, `getInstalledPlugins`, `getMergedEnabledPlugins`, `findPluginScope`, `removeEnabledPlugin`.
+- **Rationale**: Single entry point simplifies both CLI commands and UI hooks. Orchestrates `PluginManager`, `PluginScopeManager`, `MarketplaceService`, and `ConfigurationService`.
+
+## 15. Initialization Flow
+- **Decision**: Plugin loading is triggered during `Agent.create()` via `InitializationService.initialize()`.
+- **Flow**:
+    1. `pluginManager.loadPlugins(agentOptions.plugins)` — loads explicit + installed plugins
+    2. After configuration is resolved: `pluginManager.updateEnabledPlugins(config.enabledPlugins)` — pushes scoped enabled state
+- **Rationale**: Ensures plugins are loaded before the agent session starts, and configuration-driven enable/disable is applied after settings are resolved.

--- a/specs/042-plugin/spec.md
+++ b/specs/042-plugin/spec.md
@@ -5,6 +5,15 @@
 ## Context
 This specification merges and unifies the requirements for local plugin support, expanded plugin capabilities (Skills, LSP, MCP, Hooks, Agents), plugin scope management, and the plugin marketplace ecosystem (including local, GitHub, and builtin marketplace support, as well as the interactive CLI management interface). It provides a single source of truth for how plugins are discovered, installed, and managed within the Wave ecosystem.
 
+## Remote Plugin Fetching
+
+All remote plugin/marketplace fetching uses **`git clone --depth 1`** via `GitService`. There is no direct HTTP file download. The fetch flow:
+
+1. **Marketplace registration** → `git clone` of the marketplace repo (HTTP/HTTPS/SSH) into `~/.wave/plugins/marketplaces/<repo>/`
+2. **Plugin install** → If the plugin entry's `source` in `marketplace.json` is a Git URL (`http://`, `https://`, `git@`, `ssh://`), the individual plugin repo is cloned into a temp directory, then moved to cache. If `source` is a relative path, it is resolved from the marketplace checkout directory.
+3. **Plugin loading** → `PluginLoader` reads `.wave-plugin/plugin.json` and component subdirectories from the cached local copy.
+4. **Plugin activation** → `PluginManager.loadSinglePlugin()` registers commands, skills, hooks, etc. with the respective managers.
+
 ## User Scenarios & Testing
 
 ### User Story 1 - Developer creates a local plugin (Priority: P1)
@@ -77,9 +86,9 @@ As a user, I want to add and manage marketplace sources so that I can access plu
 - **FR-011**: System MUST support a `--plugin-dir` flag to load a plugin from a specific directory.
 - **FR-012**: System MUST provide a standalone Ink-based CLI interface triggered by `wave plugin`.
 - **FR-013**: System MUST support three main navigation areas: Discover, Installed, and Marketplaces.
-- **FR-014**: System MUST allow adding marketplaces via GitHub shorthand (`owner/repo`), Git URLs (with fragments for refs), and local filesystem paths.
+- **FR-014**: System MUST allow adding marketplaces via GitHub shorthand (`owner/repo`), Git URLs (with optional `ref` for branch/tag), and local filesystem paths.
 - **FR-015**: System MUST include `wave-plugins-official` (netease-lcap/wave-plugins-official on github) as a default registered marketplace.
-- **FR-016**: System MUST support plugin sources defined as relative paths in `marketplace.json`.
+- **FR-016**: System MUST support plugin sources defined as relative paths or Git URLs in `marketplace.json`.
 - **FR-017**: System MUST cache marketplace manifests locally to avoid redundant network requests.
 - **FR-018**: System MUST support updating marketplaces via `wave plugin marketplace update [name]` or the UI.
 - **FR-019**: System MUST support auto-update for registered marketplaces (enabled by default for builtin).
@@ -87,21 +96,31 @@ As a user, I want to add and manage marketplace sources so that I can access plu
 - **FR-021**: System MUST track and display the last update time for each registered marketplace.
 - **FR-022**: System MUST perform marketplace auto-updates in the background during startup to avoid blocking the CLI.
 - **FR-023**: System MUST implement a file-based locking mechanism to ensure safe concurrent access to plugin registries and cache.
-- **FR-024**: System MUST enforce a timeout (default 120s) for all Git operations to prevent hanging on slow networks or large repositories.
+- **FR-024**: System MUST enforce a timeout (default 120s, configurable via `WAVE_PLUGIN_GIT_TIMEOUT_MS`) for all Git operations to prevent hanging on slow networks or large repositories.
+- **FR-025**: System MUST fetch remote plugins and marketplaces exclusively via `git clone --depth 1` (shallow clone). There is no direct HTTP file download mechanism.
+- **FR-026**: Plugin entries in `marketplace.json` with Git URL sources (`http://`, `https://`, `git@`, `ssh://`) MUST be cloned individually during install, not copied from the marketplace checkout.
+- **FR-027**: `PluginManager.loadPlugins()` MUST load explicitly configured plugins first (from `AgentOptions.plugins`), then load marketplace-installed plugins from `installed_plugins.json`.
+- **FR-028**: `PluginCore` MUST provide a unified high-level API for all plugin and marketplace operations (install, uninstall, enable, disable, update, list, add/remove marketplace, toggle auto-update).
 
 ### Key Entities
-- **Plugin**: A self-contained directory containing metadata and functionality extensions.
-- **Plugin Manifest**: A JSON file (`.wave-plugin/plugin.json`) containing the plugin's identity and metadata.
+- **Plugin**: A self-contained directory containing metadata and functionality extensions. Extends `PluginManifest` with component fields at the top level (no nested `components` wrapper).
+- **Plugin Manifest**: A JSON file (`.wave-plugin/plugin.json`) containing the plugin's identity and metadata (`name`, `description`, `version`, optional `author`).
+- **PluginConfig**: Configuration for loading a plugin. Currently supports `type: "local"` with a `path` field.
 - **Skill**: A model-invoked capability defined by a `SKILL.md` file.
 - **Scope**: A configuration level (user, project, or local) that determines where settings are stored and their precedence.
-- **Marketplace**: A source of plugins. Attributes include name, source URL/path, and a list of available plugins.
-- **Installation**: Represents the state of a plugin on the user's system. Attributes include scope (User/Project/Local) and status (Enabled/Disabled).
+- **Marketplace**: A source of plugins. Attributes include name, source (directory, GitHub, or Git URL), and a list of available plugins.
+- **MarketplaceSource**: A discriminated union type: `{ source: "directory"; path }` | `{ source: "github"; repo; ref? }` | `{ source: "git"; url; ref? }`.
+- **MarketplacePluginEntry**: A plugin listing in `marketplace.json` with `name`, `source` (relative path or Git URL), and `description`.
+- **InstalledPlugin**: Records an installed plugin with `name`, `marketplace`, `version`, `cachePath`, optional `scope`, and optional `projectPath`.
+- **Installation**: Represents the state of a plugin on the user's system. Enabled state is tracked via `enabledPlugins` in settings, not on the `InstalledPlugin` record itself.
 
 ## Assumptions
 - **A-001**: Installed plugins are **DISABLED** by default if they are not explicitly mentioned in any `enabledPlugins` configuration.
 - **A-002**: The `enabledPlugins` setting in `settings.json` takes precedence over the mere presence of the plugin in the cache.
 - **A-003**: Users MUST use the `name@marketplace` format to uniquely identify plugins for scope management.
-- **A-004**: The underlying plugin installation logic is handled by SDK services.
-- **A-005**: "Project scope" installation involves modifying a file typically committed to version control (e.g., `.wave/config.json`).
+- **A-004**: The underlying plugin installation logic is handled by SDK services via `PluginCore` high-level API.
+- **A-005**: "Project scope" installation involves modifying a file typically committed to version control (e.g., `.wave/settings.json`).
 - **A-006**: The system should have `git` installed to use GitHub or Git-based marketplaces.
 - **A-007**: Local marketplaces are stored on the same filesystem as the `wave` installation.
+- **A-008**: All remote fetching uses `git clone` — there is no direct HTTP download of plugin files.
+- **A-009**: GitHub shorthand (`owner/repo`) is resolved to `https://github.com/owner/repo.git` automatically.


### PR DESCRIPTION
Updates all spec documentation in `specs/042-plugin/` to reflect the actual implementation:

- **Remote fetching**: Document `git clone --depth 1` as sole remote fetch mechanism (no direct HTTP download)
- **Plugin type**: Flat structure extending PluginManifest (no nested `components` wrapper)
- **MarketplaceSource**: Discriminated union with optional `ref` for branch/tag
- **New contracts**: MarketplacePluginStatus, PluginConfig, PluginCore API, GitService
- **InstalledPlugin**: Optional scope, no `isEnabled`, added `projectPath`
- **KnownMarketplace**: Added `lastUpdated` and `declaredScope`
- **Two-phase loading**: Explicit configs first, then marketplace-installed plugins
- **Method signatures**: Updated all MarketplaceService/PluginManager signatures to match implementation
- **Quickstart**: Updated to `name@marketplace` format with full CLI reference table
- **Checklists**: Added remote fetching validation rules and items