### PR TITLE
fix: always create authAwareFetch for SSO requests

### DIFF
--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -424,12 +424,10 @@ export class ConfigurationService {
     const ssoToken = this.readSSOToken();
     const serverUrl = this.options.serverUrl || process.env.WAVE_SERVER_URL;
     if (ssoToken && serverUrl) {
-      const baseFetch = fetch ?? this.options.fetch;
-      const authAwareFetch = baseFetch
-        ? (createAuthAwareFetch(
-            baseFetch as typeof globalThis.fetch,
-          ) as ClientOptions["fetch"])
-        : undefined;
+      const baseFetch = fetch ?? this.options.fetch ?? globalThis.fetch;
+      const authAwareFetch = createAuthAwareFetch(
+        baseFetch as typeof globalThis.fetch,
+      ) as ClientOptions["fetch"];
       return {
         apiKey: ssoToken,
         baseURL: `${serverUrl}/api/v1`,


### PR DESCRIPTION
When resolveGatewayConfig() was called without a fetch argument
(which is the common path from agent.ts and aiManager.ts),
authAwareFetch was undefined, causing OpenAI client to use native
fetch without token refresh or 401 recovery. This made SSO tokens
expire without automatic renewal. Now always falls back to
globalThis.fetch as the base for createAuthAwareFetch.
