### PR TITLE
fix: bypass throttled requestRemount in Ctrl+O handler

### DIFF
--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -702,7 +702,6 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   // Listen for Ctrl+O hotkey to toggle collapse/expand state and ESC to cancel confirmation
   useInput((input, key) => {
     if (key.ctrl && input === "o") {
-      // Clear terminal screen when expanded state changes
       // Use ref to get the current value to avoid stale closure
       const nextExpanded = !isExpandedRef.current;
       setIsExpanded(nextExpanded);
@@ -720,8 +719,12 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
           setLatestTotalTokens(extractLatestTotalTokens(msgs));
         }
       }
-      // Force remount to re-render Static items with new isExpanded state
-      requestRemount();
+      // Force remount directly (bypass throttle) to ensure Static items re-render
+      // The throttled requestRemount can be dropped if pressed too quickly after
+      // a previous remount, leaving the UI stuck without a visual update
+      stdout?.write("\u001b[2J\u001b[3J\u001b[0;0H", () => {
+        setRemountKey((prev) => prev + 1);
+      });
     }
 
     if (key.ctrl && input === "t") {


### PR DESCRIPTION
The throttled requestRemount (1000ms, leading-only) could be silently
dropped if Ctrl+O was pressed within 1s of a previous remount, leaving
the UI stuck without a visual update even though isExpanded state
changed correctly. Directly clear screen and increment remountKey instead.
