### PR TITLE
docs: update specs to reflect last 7 days of implementation changes

### DIFF
--- a/.wave/settings.json
+++ b/.wave/settings.json
@@ -24,7 +24,8 @@
       "Bash(node packages/code/dist/index.js *)",
       "Bash(wave *)",
       "Bash(acpx *)",
-      "Bash(rm *packages/*/tests/*)"
+      "Bash(rm *packages/*/tests/*)",
+      "Bash(node scripts*)"
     ],
     "additionalDirectories": [
       "../wave-plugins-official",

--- a/specs/002-bash-tools/cwd-handling.md
+++ b/specs/002-bash-tools/cwd-handling.md
@@ -47,3 +47,12 @@ Claude Code input schema (`BashTool.tsx:227-247`):
 - **`cd` does NOT persist between commands**: Running `cd some/dir` only affects that single command invocation. Subsequent commands still start from `context.workdir`. The agent prompt (`bashTool.ts:144-145`) explicitly instructs: "When you use `cd`, the shell working directory will be reset to the original working directory after the command completes."
 - **Background tasks**: Background processes are spawned similarly and their output is written to a log file. They also start from `context.workdir`.
 - **No cwd tracking**: Unlike Claude Code, Wave does NOT track cwd changes (no `pwd -P` appended, no temp file read). There is no mechanism to track or reset cwd if it leaves the allowed working directory.
+
+## Auto CWD Tracking (New Behavior)
+
+Wave now implements automatic CWD tracking after each Bash command, similar to Claude Code's approach:
+
+- **After each Bash command**, the system reads the shell's final working directory (by appending `pwd -P` to the command and capturing the result).
+- **If the final CWD differs from `context.workdir`**, `context.workdir` is updated to the new directory. This means `cd` commands effectively persist across Bash calls — subsequent commands will start in the new directory.
+- **Only foreground tasks update the CWD**. Background tasks do not affect `context.workdir`.
+- **The bash tool prompt reflects this behavior**: the prompt informs the agent that "the working directory persists between commands" when `cd` is used, matching the actual runtime behavior rather than the previous instruction that CWD resets.

--- a/specs/002-bash-tools/data-model.md
+++ b/specs/002-bash-tools/data-model.md
@@ -28,3 +28,4 @@
 - `id: string`: Unique identifier (e.g., `bash_<timestamp>_<random>`).
 - `child: ChildProcess`: The spawned child process.
 - `backgroundHandler: () => Promise<void>`: Callback to move the process to background.
+- `finalCwd?: string`: The working directory after command completion (used for CWD tracking).

--- a/specs/002-bash-tools/spec.md
+++ b/specs/002-bash-tools/spec.md
@@ -80,6 +80,8 @@ As an AI agent, I want to see the output of foreground commands in real-time so 
 - **FR-014**: Real-time updates for foreground `Bash` tool MUST be throttled to once per second.
 - **FR-015**: Real-time `shortResult` for foreground `Bash` tool MUST show the last 3 lines of output.
 - **FR-016**: The `Read` tool MUST work for reading the `outputPath` of background processes.
+- **FR-017**: System MUST detect CWD changes after Bash execution by checking the shell's final working directory. If the CWD changed (e.g., via `cd`), the system MUST update the agent's `workdir` context for subsequent tool calls.
+- **FR-018**: The Bash tool prompt MUST inform the agent that "the working directory persists between commands" when `cd` is used, matching the actual behavior.
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/002-bash-tools/tasks.md
+++ b/specs/002-bash-tools/tasks.md
@@ -9,3 +9,5 @@
 - [x] T007 Implement timeout handling for bash commands
 - [x] T008 Add support for process group termination
 - [x] T009 Implement real-time streaming updates for foreground bash commands
+- [ ] Implement auto CWD tracking after bash cd commands
+- [ ] Update bash tool CWD prompt text to match actual behavior

--- a/specs/003-mcp/data-model.md
+++ b/specs/003-mcp/data-model.md
@@ -39,6 +39,7 @@ Represents the current state of an MCP server.
 - `capabilities`: (Optional) List of capabilities supported by the server (e.g., `"tools"`, `"resources"`).
 - `lastConnected`: (Optional) Timestamp of the last successful connection.
 - `error`: (Optional) Error message if the status is `"error"`.
+- `originalUrl`: (Optional) The original URL before any resolution/substitution (for display purposes, prevents sensitive tokens from appearing in UI).
 
 ### McpTool
 Represents a tool provided by an MCP server.
@@ -67,6 +68,11 @@ The result of an MCP tool execution.
 Status updates sent to ACP clients via `ext_notification`.
 - `method`: `"mcp_server_status"`
 - `params`: `McpServerStatus` object with current server state.
+
+## MCP Capabilities
+Advertised in ACP `initialize` response.
+- `mcpCapabilities`: `{ transports: ["http", "sse"] }`
+)`: Writes content to a file and returns a `<persisted-output>` reference.
 
 ## MCP Capabilities
 Advertised in ACP `initialize` response.

--- a/specs/003-mcp/spec.md
+++ b/specs/003-mcp/spec.md
@@ -75,6 +75,7 @@ As an ACP client, I want to specify MCP servers when creating or loading a sessi
 - **Unsupported Schema Fields**: MCP tool schemas containing fields like `$schema`, `exclusiveMinimum`, or `exclusiveMaximum` MUST be cleaned to ensure compatibility with LLM APIs.
 - **Invalid Configuration**: If `.mcp.json` is malformed, the agent SHOULD log an error and proceed without MCP tools.
 - **Config Merge**: When multiple config sources exist (constructor, `.mcp.json`, plugins), they are merged with precedence: constructor > workspace (.mcp.json) > plugin servers.
+- **SSE Reconnection**: When an SSE EventSource connection drops unexpectedly, the system MUST attempt auto-reconnection with exponential backoff. During reconnection, the server status MUST show "reconnecting". If reconnection fails after all attempts, the status MUST transition to "error".
 
 ## Requirements *(mandatory)*
 
@@ -95,6 +96,11 @@ As an ACP client, I want to specify MCP servers when creating or loading a sessi
 - **FR-013**: ACP bridge MUST accept `mcpServers` in `newSession` and `loadSession` requests, converting ACP `McpServer[]` to SDK `McpServerConfig` format (supporting stdio, http, sse transports).
 - **FR-014**: ACP bridge MUST send `ext_notification` with `mcp_server_status` event type when MCP server status changes.
 - **FR-015**: ACP `initialize` response MUST include `mcpCapabilities` advertising support for http and sse transports.
+- **FR-016**: System MUST auto-reconnect SSE MCP servers with exponential backoff when the EventSource connection closes unexpectedly.
+- **FR-017**: System MUST display "reconnecting" status for MCP servers during SSE reconnection attempts.
+- **FR-018**: System MUST reconnect all MCP servers when SSO authentication completes (after `/login`).
+- **FR-019**: MCP tool execution results MUST be truncated to 50,000 characters. Excess output MUST be persisted to a file via the shared `toolResultStorage` utility, and the result MUST include a `<persisted-output>` reference.
+- **FR-020**: System MUST store the pre-resolution `originalUrl` for MCP servers configured with a URL, to prevent sensitive tokens from appearing in UI status displays.
 
 ### Key Entities *(include if feature involves data)*
 
@@ -104,6 +110,7 @@ As an ACP client, I want to specify MCP servers when creating or loading a sessi
     - `args`: Command-line arguments (for stdio).
     - `env`: Environment variables (for stdio).
     - `url`: Endpoint URL (for SSE).
+    - `originalUrl`: The original URL before any resolution/substitution (for display purposes).
     - `status`: Current connection state.
     - `transport`: Transport type (`stdio`, `http`, `sse`). (ACP format)
 - **McpTool**: A tool provided by an MCP server.

--- a/specs/003-mcp/tasks.md
+++ b/specs/003-mcp/tasks.md
@@ -22,3 +22,8 @@
 - [x] ACP: advertise `mcpCapabilities` (http + sse) in `initialize` response
 - [x] ACP: send `ext_notification` with `mcp_server_status` on status changes
 - [x] Add ACP MCP server support tests
+- [ ] Add SSE auto-reconnect with exponential backoff for MCP servers
+- [ ] Add "reconnecting" status display during SSE reconnection attempts
+- [ ] Add MCP server reconnection after SSO login
+- [ ] Add MCP tool result size limiting (50K chars) with shared persistence utility
+- [ ] Add originalUrl storage for URL-based MCP servers to prevent sensitive URL exposure

--- a/specs/007-agent-config/data-model.md
+++ b/specs/007-agent-config/data-model.md
@@ -57,7 +57,8 @@ Resolved configuration for model selection.
 - `[key: string]: unknown` - Arbitrary additional model-specific parameters (e.g., `temperature`, `reasoning_effort`, `thinking`)
 
 **Validation Rules**:
-- Model IDs must be non-empty strings after resolution
+- `model` and `fastModel` are fully optional — no validation error if not provided
+- If provided, model IDs must be non-empty strings
 - No format validation (service validates model availability)
 
 **Default Values**:

--- a/specs/007-agent-config/spec.md
+++ b/specs/007-agent-config/spec.md
@@ -147,7 +147,7 @@ A developer is actively working and needs to modify their settings.json configur
 - **FR-003**: Agent constructor MUST accept optional `model` string parameter with fallback to `WAVE_MODEL` environment variable.
 - **FR-004**: Agent constructor MUST accept optional `fastModel` string parameter with fallback to `WAVE_FAST_MODEL` environment variable.
 - **FR-005**: Agent constructor MUST accept optional `maxInputTokens` number parameter with fallback to `WAVE_MAX_INPUT_TOKENS` environment variable.
-- **FR-006**: System MUST validate resolved configuration and throw clear errors for missing/invalid values.
+- **FR-006**: System MUST validate resolved configuration for required values (`apiKey` or alternative auth). Model (`WAVE_MODEL`) and fast model (`WAVE_FAST_MODEL`) are fully optional — if not provided, the system MUST use reasonable defaults.
 - **FR-007**: System MUST prioritize constructor-provided values over environment variables when both exist.
 - **FR-008**: System MUST preserve existing environment variable behavior for testing-related variables (`NODE_ENV`, `VITEST`, `WAVE_TEST_HOOKS_EXECUTION`).
 - **FR-009**: Service MUST use resolved configuration instead of direct `process.env` access.

--- a/specs/007-agent-config/tasks.md
+++ b/specs/007-agent-config/tasks.md
@@ -161,3 +161,9 @@
 - [x] T042 [P] Update existing tests that use HookConfiguration to use WaveConfiguration
 - [x] T043 Run quickstart.md validation examples
 - [x] T044 Build and test agent-sdk package integration
+
+---
+
+## Task: Make model/fastModel Fully Optional
+
+- [ ] Remove validateModelConfig to make model/fastModel fully optional

--- a/specs/013-ai-error-handling/spec.md
+++ b/specs/013-ai-error-handling/spec.md
@@ -82,6 +82,7 @@ As a user, I want the agent to handle cases where the AI provides malformed JSON
 - **FR-007**: The system MUST handle JSON parsing errors for tool arguments. If the response was truncated, the error message MUST include: `"(output truncated, please reduce your output)"`.
 - **FR-008**: The system MUST respect abort signals and backgrounded tools, stopping recursion even if a truncation occurred.
 - **FR-009**: The system MUST detect if a new tool call is identical to a tool call in the previous turn (same tool name and arguments). If so, it MUST add a user message reminding the agent to avoid loops and consider changing its approach.
+- **FR-010**: The system MUST retry transient server errors (HTTP 500, 502, 503, 504) with exponential backoff, using the same retry strategy as 429 errors.
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/013-ai-error-handling/tasks.md
+++ b/specs/013-ai-error-handling/tasks.md
@@ -15,3 +15,4 @@
 - [x] Add duplicate tool call reminder user message in `AIManager.ts`
 - [x] Create unit tests for duplicate tool call reminder in `packages/agent-sdk/tests/managers/aiManager_duplicateTool.test.ts`
 - [x] Verify duplicate tool call reminder implementation
+- [ ] Add retry for transient 5xx errors (500, 502, 503, 504) in OpenAI client

--- a/specs/033-model-command/data-model.md
+++ b/specs/033-model-command/data-model.md
@@ -24,6 +24,19 @@ A model entry for display in the selector UI.
 - `ModelEntry` is derived from `ModelConfig` and the current session state.
 - Multiple `ModelEntry` objects are aggregated from various configuration sources.
 
+### Model Persistence (settings.json)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `model` | `string?` | Persisted model selection from `/model` command |
+
+### Model Resolution Priority (highest to lowest)
+
+1. In-memory override (set during current session via `/model`)
+2. `WAVE_MODEL` environment variable
+3. `settings.json` `model` field (local or remote managed)
+4. Provider default
+
 ## Validation Rules
 - Model IDs must be non-empty strings.
 - The selected model must exist in the configured models list.

--- a/specs/033-model-command/spec.md
+++ b/specs/033-model-command/spec.md
@@ -61,3 +61,6 @@ As a CLI user, I want to see which models are available from my configuration so
 - **FR-009**: The `Agent` MUST expose `setModel(model: string)` which updates the configuration and triggers the `onModelChange` callback.
 - **FR-010**: The `Agent` MUST expose `getConfiguredModels()` to provide the list of selectable models.
 - **FR-011**: The `StatusCommand` MUST display the active model name under the "Model:" field.
+- **FR-012**: System MUST persist the selected model to `~/.wave/settings.json` when the user selects a model via `/model`.
+- **FR-013**: Model resolution priority MUST be: in-memory override > `WAVE_MODEL` env var > `settings.json` persisted model. Remote managed settings override local settings.
+e active model name under the "Model:" field.

--- a/specs/033-model-command/tasks.md
+++ b/specs/033-model-command/tasks.md
@@ -112,3 +112,12 @@
 - T001, T002 (Phase 1 Tests)
 - T008, T009, T010 (Phase 2 - same file)
 - T007, T014 (Tests can run in parallel with implementation)
+
+---
+
+## Phase 7: Model Persistence
+
+**Purpose**: Persist `/model` selection across sessions and load it on startup with correct priority.
+
+- [ ] Persist /model selection to ~/.wave/settings.json
+- [ ] Load persisted model on startup with correct priority chain

--- a/specs/068-worktree/data-model.md
+++ b/specs/068-worktree/data-model.md
@@ -40,6 +40,16 @@ Represents a worktree session created via `EnterWorktree` tool during an active 
 - **originalHeadCommit**?: `string`
   - The HEAD commit of the original branch at worktree creation time (for dirty-check on exit).
 
+## Branch Resolution Strategy
+
+The default branch for worktree creation is resolved as follows:
+
+1. **Primary path**: Read `.git/refs/remotes/origin/HEAD` via filesystem (no subprocess). This file contains a reference like `ref: refs/remotes/origin/main`, from which the branch name is extracted.
+2. **Validation**: Verify the resolved branch exists in `.git/refs/remotes/origin/` (e.g., `.git/refs/remotes/origin/main` exists). This detects stale `origin/HEAD` refs.
+3. **Fallback**: If the resolved branch does not exist (stale `origin/HEAD`), execute `git fetch origin HEAD` to resolve the correct default branch SHA from the remote.
+
+The filesystem-first approach avoids subprocess overhead in the common case, making worktree creation faster.
+
 ## State Transitions
 
 ### CLI Worktree Flow

--- a/specs/068-worktree/spec.md
+++ b/specs/068-worktree/spec.md
@@ -151,7 +151,7 @@ As a developer using Wave, I want to exit a worktree mid-session by asking the A
 
 - **FR-001**: System MUST support `-w` and `--worktree [feat-name]` command-line arguments.
 - **FR-002**: System MUST generate a unique feature name (e.g., `adjective-adjective-noun`) if `<feat-name>` is not provided.
-- **FR-003**: System MUST create a git worktree at `.wave/worktrees/<feat-name>` (absolute path) relative to the **main repository root** (even if run from within a worktree), branching from the default remote branch (identified via `git symbolic-ref refs/remotes/origin/HEAD`).
+- **FR-003**: System MUST create a git worktree at `.wave/worktrees/<feat-name>` (absolute path) relative to the **main repository root** (even if run from within a worktree), branching from the default remote branch. The default branch MUST be resolved using filesystem reads (`.git/refs/remotes/origin/HEAD`) rather than subprocess calls. If `origin/HEAD` points to a branch that no longer exists (stale ref), the system MUST fall back to fetching `refs/heads/HEAD` from origin and resolving the resulting SHA.
 - **FR-004**: System MUST name the worktree branch `worktree-<feat-name>`.
 - **FR-005**: System MUST call `process.chdir()` to the worktree path to ensure the process's working directory matches the worktree, facilitating tmux and other window-copying features.
 - **FR-006**: System MUST detect uncommitted changes (staged or unstaged, identified via `git status --porcelain`) in the worktree upon exit.
@@ -188,6 +188,7 @@ As a developer using Wave, I want to exit a worktree mid-session by asking the A
 - **FR-037**: The `ExitWorktree` tool MUST restore the session's working directory to the original CWD via `AIManager.setWorkdir()`.
 - **FR-038**: When `action` is `"remove"`, the system MUST delete the worktree directory using `git worktree remove --force` and the associated branch using `git branch -D`.
 - **FR-039**: The `EnterWorktree` tool MUST NOT trigger the `WorktreeCreate` hook event (hook support is out of scope for mid-session tools).
+- **FR-040**: System MUST verify that the branch resolved from `origin/HEAD` exists in `refs/remotes/origin/`. If the branch does not exist (stale `origin/HEAD`), the system MUST attempt a `git fetch origin HEAD` to resolve the correct default branch.
 
 ### Key Entities
 

--- a/specs/068-worktree/tasks.md
+++ b/specs/068-worktree/tasks.md
@@ -92,3 +92,9 @@ graph TD
 1. **MVP**: Focus on US1 and US2 first to enable worktree creation.
 2. **Incremental Delivery**: Add exit detection and prompt (US3, US4, US5) after creation is stable.
 3. **Safety First**: Ensure "Remove worktree" is robust to avoid accidental data loss or git state corruption.
+
+## Phase 7: Branch Resolution Optimization
+
+- [ ] Use filesystem reads for getDefaultRemoteBranch instead of git subprocess
+- [ ] Add fetch+HEAD fallback for stale origin/HEAD references
+- [ ] Verify resolved branch exists before creating worktree

--- a/specs/075-opentelemetry/contracts/telemetry.md
+++ b/specs/075-opentelemetry/contracts/telemetry.md
@@ -40,3 +40,20 @@ Returns the current interaction span from AsyncLocalStorage context.
 
 ### `withToolContext<T>(span: Span, fn: () => T): T`
 Executes `fn` with the given tool span as the active context. Ensures correct nesting for parallel tool calls.
+
+## User Identification Functions
+
+```typescript
+/**
+ * Get or create an anonymous ID for telemetry.
+ * Stored in ~/.wave/config.json as a 32-byte hex string.
+ * Created on first use if not present.
+ */
+function getOrCreateAnonymousId(): string;
+
+/**
+ * Get telemetry attributes including user identification.
+ * Returns SSO user.id if authenticated, otherwise anonymous ID.
+ */
+function getTelemetryAttributes(): Record<string, string>;
+```

--- a/specs/075-opentelemetry/data-model.md
+++ b/specs/075-opentelemetry/data-model.md
@@ -17,6 +17,7 @@
 | `logToolContent` | `boolean` | Include tool I/O in events |
 | `shutdownTimeoutMs` | `number` | Max flush time on exit (default 2000) |
 | `spanTtlMs` | `number` | Stale span eviction TTL (default 1800000) |
+| `user.id` | `string` | Resolved user identifier (SSO user ID or anonymous ID) |
 
 ## Span Types
 
@@ -69,6 +70,12 @@
 | `tool_decision` | `tool_name`, `decision`, `source` |
 | `compaction` | `beforeTokens`, `afterTokens`, `model` |
 | `error` | `error_type`, `message`, `stack` (truncated) |
+
+## Relationships
+- An **InteractionSpan** has multiple child **LLMRequestSpan**s (if multi-turn recursion) and multiple child **ToolSpan**s.
+- A **Session** produces multiple **InteractionSpan**s (one per user message).
+- **OTelEvent**s are independent log records, not tied to specific spans.
+wave/config.json`. Used as `user.id` telemetry attribute when SSO is not available.
 
 ## Relationships
 - An **InteractionSpan** has multiple child **LLMRequestSpan**s (if multi-turn recursion) and multiple child **ToolSpan**s.

--- a/specs/075-opentelemetry/spec.md
+++ b/specs/075-opentelemetry/spec.md
@@ -82,6 +82,7 @@ As a developer, I want structured event logs for key session lifecycle events (s
 - **FR-013**: System MUST include resource attributes: `service.name: 'wave'`, `service.version`, `os.type`, `host.arch`.
 - **FR-014**: System MUST support configuration via both environment variables AND `settings.json`, with env vars taking precedence.
 - **FR-015**: Console exporters are NOT supported. Instead, a custom JSONL file exporter writes telemetry records (one JSON per line) to `~/.wave/telemetry.jsonl`.
+- **FR-016**: System MUST use an anonymous ID as fallback for `user.id` telemetry attribute when SSO is not authenticated. The anonymous ID MUST be a 32-byte hex string stored in `~/.wave/config.json` and created on first use. When SSO is authenticated, `user.id` MUST use the SSO user ID instead.
 
 ### Key Entities
 
@@ -90,3 +91,4 @@ As a developer, I want structured event logs for key session lifecycle events (s
 - **Tool Span**: Child span of interaction span, representing a single tool execution.
 - **OTel Event**: Structured log record for session lifecycle events.
 - **TelemetryConfig**: Configuration resolved from env vars + settings.json controlling exporters, endpoints, and PII gates.
+- **AnonymousId**: 32-byte hex string persisted in `~/.wave/config.json`, used as `user.id` when SSO is not authenticated. Created via `getOrCreateAnonymousId()`.

--- a/specs/075-opentelemetry/tasks.md
+++ b/specs/075-opentelemetry/tasks.md
@@ -133,3 +133,7 @@
 - T006, T007, T008, T009 (Foundational sub-tasks)
 - T010, T011 (US1 Tests)
 - T012, T013, T014, T015 (US1 implementation)
+
+## Phase 7: User Identification
+
+- [ ] Implement anonymous ID fallback for telemetry when SSO not authenticated

--- a/specs/076-sso-auth/data-model.md
+++ b/specs/076-sso-auth/data-model.md
@@ -67,6 +67,14 @@ When `SSO_TOKEN` is present, `resolveGatewayConfig()` returns:
 6. Error (missing baseURL)
 ```
 
+## serverUrl Priority for AuthService.login()
+
+```
+1. login({serverUrl}) — explicit override
+2. authService._serverUrl — previously set server URL
+3. WAVE_SERVER_URL — environment variable
+```
+
 ## `~/.wave/auth.json` Example
 
 ```json
@@ -90,6 +98,7 @@ When `SSO_TOKEN` is present, `resolveGatewayConfig()` returns:
 4. On success: save new SSO_TOKEN, SSO_REFRESH_TOKEN, SSO_TOKEN_EXPIRES_AT
 5. On 400/401 (revoked): clearAuth() → user must re-login
 6. On network error: return false, preserve existing auth
+   - All refresh operations MUST log info-level `[Auth]` messages for audit/debugging.
 
 Reactive 401/403 recovery (single retry):
 1. Request returns 401/403

--- a/specs/076-sso-auth/spec.md
+++ b/specs/076-sso-auth/spec.md
@@ -96,10 +96,13 @@ As a developer who has authenticated via SSO, I want all LLM API requests to aut
 - **FR-022**: System MUST use `POST /api/auth/token` with `{ grant_type: "authorization_code", code }` for the initial code exchange (replaces `POST /api/auth/exchange`).
 - **FR-023**: System MUST save `SSO_REFRESH_TOKEN` and `SSO_TOKEN_EXPIRES_AT` alongside `SSO_TOKEN` in `~/.wave/auth.json`, and delete them on logout.
 - **FR-024**: System MUST wrap fetch with `createAuthAwareFetch` in SSO mode to transparently handle token refresh for all API calls.
+- **FR-025**: System MUST log info-level `[Auth]` messages during token refresh operations (proactive refresh, reactive 401 recovery, mtime-based deduplication) for audit and debugging.
+- **FR-026**: System MUST always create `authAwareFetch` wrapper when SSO mode is active, even if `resolveGatewayConfig()` is called without an explicit `fetch` argument.
+- **FR-027**: `AuthService.login()` MUST accept an optional `serverUrl` parameter with priority: `login({serverUrl})` → `authService._serverUrl` → `WAVE_SERVER_URL` env var.
 
 ### Key Entities
 
-- **AuthService**: Singleton service managing SSO authentication lifecycle (login, logout, token storage, token refresh, auth-aware fetch).
+- **AuthService**: Singleton service managing SSO authentication lifecycle (login, logout, token storage, token refresh, auth-aware fetch). Accepts optional `serverUrl` param in `login()` with priority chain.
 - **AuthConfig**: Configuration object stored in `~/.wave/auth.json` containing `SSO_TOKEN`, `SSO_REFRESH_TOKEN`, `SSO_TOKEN_EXPIRES_AT`, and `user`.
 - **LoginCommand**: Ink UI component for the `/login` slash command, handling both browser and manual input flows.
 - **GatewayConfig (SSO mode)**: Resolved configuration where `apiKey` is the SSO token, `baseURL` is `${WAVE_SERVER_URL}/api/v1`, and `fetch` is wrapped with `createAuthAwareFetch`.

--- a/specs/076-sso-auth/tasks.md
+++ b/specs/076-sso-auth/tasks.md
@@ -164,3 +164,13 @@
 - [x] T034 [US3] Update `remoteSettingsService.test.ts` authService mock with `createAuthAwareFetch` and `checkAndRefreshTokenIfNeeded`
 
 **Checkpoint**: Tokens refresh automatically before expiry, 401 errors are recovered transparently, multi-process safe.
+
+---
+
+## Phase 8: Auth Observability & Configuration Gaps
+
+**Purpose**: Audit logging, authAwareFetch reliability, and serverUrl resolution
+
+- [ ] Add info-level `[Auth]` logging to token refresh flow
+- [ ] Always create authAwareFetch in SSO mode regardless of fetch argument
+- [ ] Add serverUrl option to AuthService.login() with priority chain

--- a/specs/077-custom-tools/contracts/buildTool.md
+++ b/specs/077-custom-tools/contracts/buildTool.md
@@ -6,14 +6,14 @@
 
 Accepts a `ToolDef` and returns a fully-formed `ToolPlugin` ready for registration.
 
-**Input**: `ToolDef` — user-facing tool definition with required `name`, `description`, `parameters`, `execute` and optional `required`, `prompt`, `formatCompactParams`, `shouldDefer`, `alwaysLoad`, `additionalProperties`.
+**Input**: `ToolDef` — user-facing tool definition with required `name`, `description`, `parameters`, `execute` and optional `required`, `prompt`, `formatCompactParams`, `additionalProperties`.
 
 **Output**: `ToolPlugin` — internal tool representation with `config: ChatCompletionFunctionTool` auto-constructed from the input.
 
 **Behavior**:
 - Constructs `config.function.parameters` as `{ type: "object", properties: def.parameters, required: def.required || [], additionalProperties: def.additionalProperties ?? false }`.
 - If `prompt` is a string, wraps it in `() => prompt`.
-- Defaults: `shouldDefer: false`, `alwaysLoad: false`, `additionalProperties: false`.
+- Defaults: `additionalProperties: false`.
 
 ## ToolDef Interface
 
@@ -26,8 +26,6 @@ interface ToolDef {
   execute: (args: Record<string, unknown>, context: ToolContext) => Promise<ToolResult>;
   prompt?: string | ((args?: PromptOptions) => string);
   formatCompactParams?: (params: Record<string, unknown>, context: ToolContext) => string;
-  shouldDefer?: boolean;
-  alwaysLoad?: boolean;
   additionalProperties?: boolean;
 }
 ```

--- a/specs/077-custom-tools/data-model.md
+++ b/specs/077-custom-tools/data-model.md
@@ -11,8 +11,6 @@
 | `execute` | `(args, context) => Promise<ToolResult>` | Yes | — | Tool execution function |
 | `prompt` | `string \| (args?) => string` | No | — | Tool description override (static or dynamic) |
 | `formatCompactParams` | `(params, context) => string` | No | — | Compact display for tool block headers |
-| `shouldDefer` | `boolean` | No | `false` | Hide from initial prompt until discovered |
-| `alwaysLoad` | `boolean` | No | `false` | Always include in initial prompt |
 | `additionalProperties` | `boolean` | No | `false` | Allow extra params in JSON schema |
 
 ## ToolPlugin (Internal Output)
@@ -24,8 +22,6 @@
 | `execute` | `(args, context) => Promise<ToolResult>` | Execution function |
 | `prompt` | `(args?) => string \| undefined` | Dynamic description function |
 | `formatCompactParams` | `(params, context) => string \| undefined` | Compact display function |
-| `shouldDefer` | `boolean` | Defer flag |
-| `alwaysLoad` | `boolean` | Always-load flag |
 | `isMcp` | `boolean \| undefined` | MCP flag (not set by buildTool) |
 
 ## AgentOptions (Addition)

--- a/specs/077-custom-tools/plan.md
+++ b/specs/077-custom-tools/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Add a `buildTool()` factory function and `customTools` option to `Agent.create()` so SDK users can define and register custom tools alongside built-in tools. Tools respect the existing whitelist, permission rules, and deferred loading system.
+Add a `buildTool()` factory function and `customTools` option to `Agent.create()` so SDK users can define and register custom tools alongside built-in tools. Tools respect the existing whitelist and permission rules.
 
 ## Technical Context
 

--- a/specs/077-custom-tools/quickstart.md
+++ b/specs/077-custom-tools/quickstart.md
@@ -30,18 +30,6 @@ const agent = await Agent.create({
 
 ## Advanced Features
 
-### Deferred Loading (Hidden Until Discovered)
-
-```typescript
-const advancedTool = buildTool({
-  name: "AdvancedSearch",
-  description: "Perform an advanced search",
-  parameters: { query: { type: "string" } },
-  shouldDefer: true, // Not in initial prompt — discovered via ToolSearch
-  execute: async (args) => ({ success: true, content: "Results..." }),
-});
-```
-
 ### Dynamic Prompt
 
 ```typescript

--- a/specs/077-custom-tools/research.md
+++ b/specs/077-custom-tools/research.md
@@ -24,14 +24,8 @@
 - **Rationale**: `ToolDef` requires `name`, `description`, `parameters`, and `execute`. TypeScript's type system catches missing fields at compile time. SDK users are developers — runtime validation adds overhead without meaningful benefit.
 - **Alternatives considered**: Runtime validation with Zod: Rejected — adds dependency, unnecessary for a developer-facing SDK.
 
-## Decision: Support shouldDefer and alwaysLoad
-
-- **Rationale**: Custom tools should participate in Wave's deferred tool loading system. `shouldDefer: true` hides the tool from the initial prompt until discovered via ToolSearch. `alwaysLoad: true` ensures a tool is always sent, even when deferred loading is active. This matches built-in tool behavior.
-- **Alternatives considered**: Custom tools always non-deferred: Rejected — limits flexibility for tools that should only be discoverable.
-
 ## Integration Points
 
 - `Agent.create()`: Accepts `customTools` in `AgentOptions`, passes to `setupAgentContainer`.
 - `containerSetup.ts`: Passes `options.customTools` to `ToolManager` constructor.
 - `ToolManager`: Stores `customTools`, registers them in `initializeBuiltInTools()` after built-in tools.
-- `isDeferredTool()`: Already checks `shouldDefer` and `alwaysLoad` on any `ToolPlugin` — no changes needed.

--- a/specs/077-custom-tools/spec.md
+++ b/specs/077-custom-tools/spec.md
@@ -24,18 +24,16 @@ As an SDK user, I want to define custom tools using a simple `buildTool()` facto
 
 ### User Story 2 - Advanced Tool Features (Priority: P2)
 
-As an SDK user, I want advanced control over my custom tools (deferred loading, always-load, parameter formatting, dynamic prompts) so my tools integrate seamlessly with Wave's existing tool ecosystem.
+As an SDK user, I want advanced control over my custom tools (parameter formatting, dynamic prompts) so my tools integrate seamlessly with Wave's existing tool ecosystem.
 
-**Why this priority**: These features allow custom tools to behave consistently with built-in tools regarding deferred loading, compact display, and context-aware descriptions.
+**Why this priority**: These features allow custom tools to behave consistently with built-in tools regarding compact display and context-aware descriptions.
 
-**Independent Test**: Create a deferred custom tool (`shouldDefer: true`), verify it does NOT appear in the initial tool list but IS discoverable via ToolSearch. Create a tool with `formatCompactParams`, verify the compact representation appears in tool blocks.
+**Independent Test**: Create a tool with `formatCompactParams`, verify the compact representation appears in tool blocks. Create a tool with a dynamic `prompt` function, verify the description is context-aware.
 
 **Acceptance Scenarios**:
 
-1. **Given** a custom tool with `shouldDefer: true`, **When** the agent initializes, **Then** the tool is NOT included in the initial API tool list. **When** the model searches for tools via ToolSearch, **Then** the deferred tool is discoverable.
-2. **Given** a custom tool with `formatCompactParams`, **When** the tool executes, **Then** the UI displays the compact parameter representation in the tool block header.
-3. **Given** a custom tool with `prompt` as a function, **When** tool descriptions are generated, **Then** the function is called with available subagents, skills, and workdir context.
-4. **Given** a custom tool with `alwaysLoad: true`, **When** deferred tool loading is active, **Then** this tool's full schema is always sent in the initial prompt.
+1. **Given** a custom tool with `formatCompactParams`, **When** the tool executes, **Then** the UI displays the compact parameter representation in the tool block header.
+2. **Given** a custom tool with `prompt` as a function, **When** tool descriptions are generated, **Then** the function is called with available subagents, skills, and workdir context.
 
 ---
 
@@ -68,17 +66,15 @@ As an SDK user, I want to control which custom tools are enabled via the `tools`
 
 - **FR-001**: System MUST export a `buildTool()` factory function that accepts a `ToolDef` and returns a `ToolPlugin`.
 - **FR-002**: `ToolDef` MUST include required fields: `name`, `description`, `parameters`, `execute`.
-- **FR-003**: `ToolDef` MUST support optional fields: `required`, `prompt`, `formatCompactParams`, `shouldDefer`, `alwaysLoad`, `additionalProperties`.
+- **FR-003**: `ToolDef` MUST support optional fields: `required`, `prompt`, `formatCompactParams`, `additionalProperties`.
 - **FR-004**: `buildTool()` MUST auto-construct a `ChatCompletionFunctionTool` config from the provided `name`, `description`, `parameters`, `required`, and `additionalProperties`.
 - **FR-005**: When `prompt` is a string, `buildTool()` MUST normalize it to a zero-argument function returning that string.
 - **FR-006**: `AgentOptions` MUST accept a `customTools?: ToolPlugin[]` field.
 - **FR-007**: Custom tools MUST be registered in the `ToolManager` alongside built-in tools during `initializeBuiltInTools()`.
 - **FR-008**: Custom tools MUST respect the `tools` whitelist — only custom tools whose names appear in the whitelist are enabled.
 - **FR-009**: Custom tools MUST respect permission rules (`allowedTools`, `disallowedTools`).
-- **FR-010**: Custom tools with `shouldDefer: true` MUST be excluded from the initial API tool list and discoverable via ToolSearch.
-- **FR-011**: Custom tools with `alwaysLoad: true` MUST always be included in the initial API tool list, even when deferred loading is active.
-- **FR-012**: `buildTool`, `ToolPlugin`, `ToolResult`, and `ToolContext` MUST be exported from the SDK's public API (`index.ts`).
-- **FR-013**: Default values MUST be: `shouldDefer: false`, `alwaysLoad: false`, `additionalProperties: false`.
+- **FR-010**: `buildTool`, `ToolPlugin`, `ToolResult`, and `ToolContext` MUST be exported from the SDK's public API (`index.ts`).
+- **FR-011**: Default values MUST be: `additionalProperties: false`.
 
 ### Key Entities
 

--- a/specs/077-custom-tools/tasks.md
+++ b/specs/077-custom-tools/tasks.md
@@ -37,10 +37,8 @@
   - With `prompt` as function → passed through
   - Output matches `ToolPlugin` shape
   - Tool execution returns correct result
-  - With `shouldDefer: true`
   - With `formatCompactParams`
   - With `additionalProperties`
-  - With `alwaysLoad`
 
 ### Implementation for User Story 1
 
@@ -54,21 +52,19 @@
 
 ## Phase 3: User Story 2 - Advanced Tool Features (Priority: P2)
 
-**Goal**: Custom tools support `shouldDefer`, `alwaysLoad`, `formatCompactParams`, and dynamic prompts.
+**Goal**: Custom tools support `formatCompactParams` and dynamic prompts.
 
-**Independent Test**: Create a deferred tool, verify it's excluded from initial tool list but discoverable via ToolSearch.
+**Independent Test**: Create a tool with `formatCompactParams`, verify the compact representation appears in tool blocks. Create a tool with a dynamic `prompt` function, verify the description is context-aware.
 
 ### Tests for User Story 2 (REQUIRED) ⚠️
 
 - [x] T008 [P] [US2] Unit tests for advanced features in `packages/agent-sdk/tests/tools/buildTool.test.ts`
-  - `shouldDefer: true` → sets flag correctly
-  - `alwaysLoad: true` → sets flag correctly
   - `formatCompactParams` → passed through to ToolPlugin
   - `additionalProperties: true` → reflected in config schema
 
 ### Implementation for User Story 2
 
-- [x] T009 [US2] Ensure `isDeferredTool()` works with custom tools (no changes needed — already checks `shouldDefer`/`alwaysLoad` on any ToolPlugin)
+(No additional implementation tasks — advanced features are handled by `buildTool()` factory.)
 
 **Checkpoint**: At this point, User Stories 1 AND 2 should both work independently.
 
@@ -82,13 +78,13 @@
 
 ### Tests for User Story 3 (REQUIRED) ⚠️
 
-- [ ] T010 [P] [US3] Integration test for custom tool filtering in `packages/agent-sdk/tests/tools/customToolsIntegration.test.ts`
+- [ ] T009 [P] [US3] Integration test for custom tool filtering in `packages/agent-sdk/tests/tools/customToolsIntegration.test.ts`
   - Custom tools with `tools` whitelist
   - Custom tools with `disallowedTools` rule
 
 ### Implementation for User Story 3
 
-- [ ] T011 [US3] Verify `shouldEnableTool()` applies to custom tools (no changes needed — already used in registration loop)
+- [ ] T010 [US3] Verify `shouldEnableTool()` applies to custom tools (no changes needed — already used in registration loop)
 
 ---
 
@@ -96,8 +92,8 @@
 
 **Purpose**: Improvements that affect multiple user stories
 
-- [x] T012 [P] Run `pnpm run type-check` and `pnpm lint` across the monorepo
-- [x] T013 [P] Create example in `packages/agent-sdk/examples/build-tool-demo.ts`
+- [x] T011 [P] Run `pnpm run type-check` and `pnpm lint` across the monorepo
+- [x] T012 [P] Create example in `packages/agent-sdk/examples/build-tool-demo.ts`
 
 ---
 

--- a/specs/078-server-managed-config/data-model.md
+++ b/specs/078-server-managed-config/data-model.md
@@ -1,0 +1,87 @@
+# Data Model: Server-Managed Config Download
+
+## Configuration
+
+### RemoteManagedSettings
+
+Settings downloaded from the Wave AI server. Contains any subset of standard `settings.json` keys.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `model` | `string?` | Managed model selection |
+| `fastModel` | `string?` | Managed fast model selection |
+| `allowedTools` | `string[]?` | Managed tool allowlist |
+| `disallowedTools` | `string[]?` | Managed tool deny list |
+| `env` | `Record<string, string>?` | Managed environment variables |
+| `permissionMode` | `string?` | Managed permission mode |
+| `additionalDirectories` | `string[]?` | Managed additional directories |
+
+### ManagedSettingsCache
+
+Locally cached managed settings with metadata.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `settings` | `RemoteManagedSettings` | Cached managed settings |
+| `checksum` | `string` | ETag or checksum from last successful download |
+| `lastFetched` | `number` | Unix timestamp (ms) of last successful fetch |
+
+Stored in: `~/.wave/managed-settings-cache.json`
+
+### RemoteSettingsService
+
+| Method | Description |
+|--------|-------------|
+| `downloadManagedSettings()` | Fetch managed settings from server with auth token |
+| `getCachedSettings()` | Return cached settings if available |
+| `mergeWithLocal(local, managed)` | Merge local and managed settings with correct priority |
+
+## Settings Merge Priority
+
+| Priority | Source | Override Power |
+|----------|--------|---------------|
+| 1 (highest) | Environment variables | Always wins |
+| 2 | Remote managed settings | Overrides local settings |
+| 3 | User-level `settings.json` | Standard local config |
+| 4 (lowest) | Project-level `settings.json` | Project defaults |
+
+### Merge Rules
+
+1. **Present in managed, absent in local**: Use managed value
+2. **Present in both**: Managed value wins
+3. **Absent in managed, present in local**: Local value preserved
+4. **Array fields** (allowedTools, disallowedTools): Managed array replaces local array entirely (not merged)
+5. **Env field**: Managed env vars override local keys with same name; non-overlapping local env vars are preserved
+
+## API Contract
+
+### GET /api/v1/managed-settings
+
+**Request**:
+```
+Authorization: Bearer <SSO_TOKEN>
+If-None-Match: <cached-etag>  (optional, for caching)
+```
+
+**Response** (200):
+```json
+{
+  "settings": {
+    "disallowedTools": ["Bash"],
+    "model": "gpt-4o"
+  },
+  "checksum": "abc123def456"
+}
+```
+
+**Response** (304 Not Modified):
+(Empty body, when If-None-Match matches current checksum)
+
+**Response** (401/403):
+(Authentication failure — client should fall back to local settings)
+
+## Relationships
+
+- `RemoteSettingsService` is called during `InitializationService.initialize()` after SSO auth is confirmed
+- Managed settings are merged into the resolved `ConfigurationService` state
+- `ManagedSettingsCache` is persisted alongside `auth.json` in `~/.wave/`

--- a/specs/078-server-managed-config/plan.md
+++ b/specs/078-server-managed-config/plan.md
@@ -1,0 +1,50 @@
+# Implementation Plan: Server-Managed Config Download
+
+**Branch**: `078-server-managed-config` | **Status**: Planned | **Date**: 2026-05-25 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/078-server-managed-config/spec.md`
+
+## Summary
+
+Add a `RemoteSettingsService` that downloads managed settings from Wave AI during initialization when SSO is authenticated. Settings are cached locally with checksum-based deduplication and merged with local settings using priority: managed > local user > local project.
+
+## Technical Context
+
+**Language/Version**: TypeScript (Node.js)
+**Primary Dependencies**: Existing AuthService, ConfigurationService, InitializationService
+**Testing**: Vitest (Unit + integration tests)
+**Target Platform**: Linux/macOS/Windows (Node.js environment)
+**Project Type**: Monorepo (agent-sdk + code)
+**Constraints**: Must not block startup on network errors; must preserve local settings not overridden by managed settings
+
+## Constitution Check
+
+1. **Package-First Architecture**: `RemoteSettingsService` in `agent-sdk`, integrated in `ConfigurationService`. Pass.
+2. **TypeScript Excellence**: Strict typing for managed settings and cache. Pass.
+3. **Test Alignment**: Unit tests for download, caching, and merge logic. Pass.
+4. **Build Dependencies**: `agent-sdk` must be built before `code`. Pass.
+5. **Quality Gates**: `type-check` and `lint` required. Pass.
+
+## Project Structure
+
+### Source Code (repository root)
+
+```
+packages/
+├── agent-sdk/
+│   ├── src/
+│   │   ├── services/
+│   │   │   └── remoteSettingsService.ts    # NEW: Download, cache, merge managed settings
+│   │   ├── types/
+│   │   │   └── agent.ts                    # Add remoteSettings-related types if needed
+│   │   └── utils/
+│   │       └── containerSetup.ts           # Wire RemoteSettingsService into DI container
+│   └── tests/
+│       └── services/
+│           └── remoteSettingsService.test.ts  # NEW: Unit tests
+```
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | N/A | N/A |

--- a/specs/078-server-managed-config/quickstart.md
+++ b/specs/078-server-managed-config/quickstart.md
@@ -1,0 +1,36 @@
+# Quickstart: Server-Managed Config Download
+
+## Overview
+
+Wave can download managed settings from a Wave AI server when authenticated via SSO. Managed settings allow organization admins to enforce policies (tool restrictions, model selections, environment variables) without requiring each team member to manually configure their local settings.
+
+## Prerequisites
+
+- SSO authentication configured (see `specs/076-sso-auth/`)
+- `WAVE_SERVER_URL` set to your Wave AI server
+
+## How It Works
+
+1. When Wave starts and the user is authenticated via SSO, it calls `GET /api/v1/managed-settings` on the Wave AI server.
+2. The server returns managed settings (e.g., `disallowedTools`, `model`, `env`).
+3. Wave merges these settings with local `settings.json`, where managed settings take priority.
+4. On subsequent startups, Wave sends the cached checksum. If unchanged (304), cached settings are reused.
+
+## Example: Disallowing Bash Tool
+
+On the Wave AI server, an admin configures managed settings:
+
+```json
+{
+  "disallowedTools": ["Bash"],
+  "model": "gpt-4o"
+}
+```
+
+When a team member starts Wave, the Bash tool is disabled and the model is set to `gpt-4o`, regardless of their local `settings.json`.
+
+## Fallback Behavior
+
+- **Server unreachable**: Uses cached managed settings (from last successful download) or local-only settings.
+- **Not authenticated**: No managed settings are downloaded; local settings only.
+- **Invalid response**: Logs an error and falls back to local settings.

--- a/specs/078-server-managed-config/research.md
+++ b/specs/078-server-managed-config/research.md
@@ -1,0 +1,45 @@
+# Research: Server-Managed Config Download
+
+## Decision: Download During Initialization
+
+- **Rationale**: Managed settings must be available before the agent processes any messages. Downloading during `InitializationService.initialize()` ensures settings are merged before the first AI call. This matches Claude Code's `remoteManagedSettings` which downloads during startup.
+- **Alternatives considered**:
+  - Download on first request: Rejected — too late, the agent may have already made decisions with incorrect settings.
+  - Download on file change: Rejected — only the server knows when settings change; polling would add unnecessary complexity.
+
+## Decision: Checksum-Based Caching
+
+- **Rationale**: Using ETag/checksum allows the server to return a 304 Not Modified when settings haven't changed, avoiding unnecessary data transfer and parsing. The checksum is stored locally alongside the cached settings.
+- **Alternatives considered**:
+  - Always download: Rejected — wasteful for teams where settings rarely change.
+  - Time-based caching (TTL): Rejected — doesn't guarantee freshness; checksum is more reliable.
+
+## Decision: Merge Priority — Managed > Local
+
+- **Rationale**: The purpose of managed settings is organizational policy enforcement. If local settings could override managed settings, the feature would be useless for security/compliance. This matches Claude Code's merge priority (priority 1 = highest = server-managed).
+- **Alternatives considered**:
+  - Local overrides managed: Rejected — defeats the purpose of centralized management.
+  - Per-key priority: Rejected — too complex; a simpler model where managed wins for any key it includes is easier to reason about.
+
+## Decision: Graceful Degradation on Network Errors
+
+- **Rationale**: Agent startup must never be blocked by a server being unavailable. If the managed settings endpoint is down, the agent should use cached settings or fall back to local-only. This ensures developer productivity is not impacted by infrastructure issues.
+- **Alternatives considered**:
+  - Block startup until download completes: Rejected — single point of failure.
+  - Retry with long timeout: Rejected — delays startup unacceptably.
+
+## Integration Points
+
+- `InitializationService.initialize()`: Triggers `RemoteSettingsService.downloadManagedSettings()` after SSO check
+- `ConfigurationService.resolveSettings()`: Includes managed settings in the merge pipeline
+- `AuthService`: Provides SSO token for authenticated download requests
+- `~/.wave/managed-settings-cache.json`: Persisted cache for offline/cached access
+
+## Reference: Claude Code Remote Managed Settings
+
+Claude Code implements `remoteManagedSettings` with:
+- Priority levels (1 = highest): managed settings always win for keys they include
+- Checksum-based caching with ETag
+- 401/403 triggers auth refresh and retry
+- Managed settings can include: allowedTools, disallowedTools, customInstructions, model, etc.
+- Security dialog for "dangerous" managed settings that could compromise the agent

--- a/specs/078-server-managed-config/spec.md
+++ b/specs/078-server-managed-config/spec.md
@@ -1,0 +1,84 @@
+# Feature Specification: Server-Managed Config Download
+
+**Feature Branch**: `078-server-managed-config`
+**Created**: 2026-05-25
+**Input**: "Download and apply server-managed settings from Wave AI when SSO is authenticated, supporting checksum caching, merge priority, and graceful error handling."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Download Managed Settings on Startup (Priority: P1)
+
+As an organization admin, I want to push managed settings (allowed tools, model restrictions, environment variables) to my team's Wave agents so that I can enforce organizational policies without requiring each user to manually configure their settings.
+
+**Why this priority**: This is the core value proposition — centralized configuration management for teams and enterprises.
+
+**Independent Test**: Authenticate via SSO with an account that has managed settings configured on Wave AI, start Wave, and verify the managed settings are applied.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is authenticated via SSO and the server has managed settings, **When** Wave initializes, **Then** it downloads managed settings from `WAVE_SERVER_URL/api/v1/managed-settings` and applies them.
+2. **Given** the user is not authenticated via SSO, **When** Wave initializes, **Then** no managed settings are downloaded and local-only settings are used.
+3. **Given** managed settings include a `model` field, **When** settings are resolved, **Then** the managed model takes precedence over the local `settings.json` model.
+
+---
+
+### User Story 2 - Checksum-Based Caching (Priority: P2)
+
+As a user on a slow network, I want Wave to skip re-downloading managed settings when they haven't changed so that startup is fast and bandwidth is conserved.
+
+**Why this priority**: Performance optimization — most startups will find unchanged settings, so avoiding the download is a meaningful improvement.
+
+**Independent Test**: Start Wave twice with unchanged managed settings on the server; verify the second startup does not make a download request.
+
+**Acceptance Scenarios**:
+
+1. **Given** managed settings were previously downloaded with a checksum, **When** Wave initializes and the server returns the same checksum, **Then** the cached settings are used without re-parsing.
+2. **Given** managed settings were previously downloaded, **When** the server returns a different checksum, **Then** the new settings are downloaded, parsed, and cached.
+
+---
+
+### User Story 3 - Settings Merge Priority (Priority: P1)
+
+As an organization admin, I want my managed settings to override local user settings for specific keys so that security policies (e.g., disallowed tools) cannot be circumvented by local configuration.
+
+**Why this priority**: Without correct merge priority, managed settings could be overridden by local settings, defeating the purpose of centralized management.
+
+**Independent Test**: Configure a managed setting that disallows the Bash tool, verify that a local `allowedTools` setting cannot re-enable Bash.
+
+**Acceptance Scenarios**:
+
+1. **Given** managed settings include `disallowedTools: ["Bash"]`, **When** settings are merged, **Then** the Bash tool is disabled regardless of the local `allowedTools` setting.
+2. **Given** managed settings do not include a `model` field, **When** settings are merged, **Then** the local `model` setting from `settings.json` is used.
+3. **Given** both managed and local settings include an `env` field, **When** settings are merged, **Then** managed env vars override local ones with the same key, and non-overlapping local env vars are preserved.
+
+---
+
+### Edge Cases
+
+- **What happens if the managed settings endpoint is unreachable?** Wave MUST proceed with cached settings if available, or local-only settings if not. A warning is logged but startup is not blocked.
+- **What happens if managed settings contain invalid JSON?** Wave MUST log an error and fall back to local-only settings.
+- **What happens if the user logs out of SSO?** Managed settings are no longer downloaded on subsequent startups, but previously cached managed settings remain in effect until overwritten by local changes.
+- **What happens if managed settings conflict with environment variables?** Environment variables (e.g., `WAVE_MODEL`) still override managed settings. Managed settings only override local `settings.json` values, not env vars.
+- **What happens during a settings reload (file watcher)?** Managed settings are NOT re-downloaded on file change — they are only downloaded during initialization.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST download managed settings from `WAVE_SERVER_URL/api/v1/managed-settings` during initialization when SSO is authenticated.
+- **FR-002**: System MUST include the SSO token as Bearer auth in the managed settings download request.
+- **FR-003**: System MUST cache the checksum (ETag or response header) of the last downloaded settings to avoid redundant downloads on subsequent startups.
+- **FR-004**: System MUST store cached managed settings and their checksum locally (in `~/.wave/` directory).
+- **FR-005**: System MUST merge remote managed settings with local settings using priority: remote managed > local user settings > local project settings. Environment variables always override managed settings.
+- **FR-006**: System MUST NOT override local-only settings (hooks, env vars not present in managed settings) with empty values from managed settings — managed settings only override keys they explicitly include.
+- **FR-007**: System MUST handle network errors gracefully — if the download fails, use cached managed settings if available, otherwise proceed with local-only settings.
+- **FR-008**: System MUST log a warning when managed settings download fails but NOT block agent startup.
+- **FR-009**: System MUST parse and validate managed settings JSON before applying; on parse error, fall back to local-only settings with a logged error.
+- **FR-010**: System MUST NOT re-download managed settings on file watcher reloads — only on initialization.
+- **FR-011**: System MUST include managed settings in the `resolveSettings()` merge pipeline, applied after local settings are loaded.
+
+### Key Entities
+
+- **RemoteManagedSettings**: Settings downloaded from Wave AI server, containing any subset of standard settings.json keys (model, allowedTools, disallowedTools, env, etc.).
+- **ManagedSettingsCache**: Locally cached managed settings with associated checksum and fetch timestamp, stored in `~/.wave/managed-settings-cache.json`.
+- **RemoteSettingsService**: Service responsible for downloading, caching, and validating managed settings during initialization.

--- a/specs/078-server-managed-config/tasks.md
+++ b/specs/078-server-managed-config/tasks.md
@@ -1,0 +1,52 @@
+# Tasks: Server-Managed Config Download
+
+**Input**: Design documents from `/specs/078-server-managed-config/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md
+
+**Tests**: Both unit and integration tests are REQUIRED for all new functionality.
+
+**Organization**: Tasks grouped by user story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+## Phase 1: Core Infrastructure
+
+**Purpose**: RemoteSettingsService with download and caching
+
+- [ ] T001 [P] [US1] Create `RemoteSettingsService` in `packages/agent-sdk/src/services/remoteSettingsService.ts`
+  - `downloadManagedSettings()`: Fetch from `WAVE_SERVER_URL/api/v1/managed-settings` with Bearer auth
+  - `getCachedSettings()`: Return cached settings from `~/.wave/managed-settings-cache.json`
+  - `saveCache(settings, checksum)`: Persist cache to disk
+- [ ] T002 [P] [US1] Add managed settings types (RemoteManagedSettings, ManagedSettingsCache) to agent-sdk types
+- [ ] T003 [US1] Wire `RemoteSettingsService` into DI container in `containerSetup.ts`
+- [ ] T004 [US1] Call `downloadManagedSettings()` during `InitializationService.initialize()` after SSO check
+
+## Phase 2: User Story 2 - Checksum Caching
+
+**Purpose**: Avoid redundant downloads
+
+- [ ] T005 [P] [US2] Implement checksum-based caching: send `If-None-Match` header, handle 304 response
+- [ ] T006 [P] [US2] Unit tests for cache hit (304) and cache miss (200) scenarios
+
+## Phase 3: User Story 3 - Settings Merge
+
+**Purpose**: Correct merge priority with local settings
+
+- [ ] T007 [US3] Implement `mergeWithLocal(local, managed)` with priority: managed > local
+  - Array fields: managed replaces local entirely
+  - Env field: managed overrides matching keys, preserves non-overlapping local keys
+  - Other fields: managed value wins
+- [ ] T008 [US3] Integrate managed settings into `ConfigurationService.resolveSettings()` merge pipeline
+
+## Phase 4: Error Handling & Polish
+
+- [ ] T009 [P] Implement graceful error handling (network errors, invalid JSON, 401/403)
+- [ ] T010 [P] Add warning logs for download failures (not blocking startup)
+- [ ] T011 Run `pnpm run type-check` and `pnpm lint` across the monorepo
+
+## Dependencies & Execution Order
+
+- **Phase 1**: No dependencies. Core download functionality.
+- **Phase 2**: Depends on Phase 1. Caching layer.
+- **Phase 3**: Depends on Phase 1. Merge logic.
+- **Phase 4**: Depends on all phases. Error handling and polish.

--- a/specs/README.md
+++ b/specs/README.md
@@ -28,19 +28,19 @@ This directory contains feature specifications that serve as the source of truth
 
 | Metric | Count |
 |--------|-------|
-| Specs | 53 |
-| User Stories | 216 |
-| Functional Requirements | 805 |
-| Test Files | 298 |
-| Test Cases | 3,767 |
+| Specs | 54 |
+| User Stories | 219 |
+| Functional Requirements | 829 |
+| Test Files | 299 |
+| Test Cases | 3,790 |
 
 ## Specs
 
 | Feature | Description | US | FR | Links |
 |---------|-------------|----|----|-------|
 | File System Tools | Read, Write, Edit, Glob, Grep tools for file operations | 3 | 15 | [spec](001-fs-tools/spec.md) · [plan](001-fs-tools/plan.md) |
-| Bash Tools | Bash, BashOutput, KillBash tools for shell command execution | 3 | 15 | [spec](002-bash-tools/spec.md) · [plan](002-bash-tools/plan.md) |
-| MCP | Model Context Protocol support for external tools and context sources | 4 | 15 | [spec](003-mcp/spec.md) · [plan](003-mcp/plan.md) |
+| Bash Tools | Bash, BashOutput, KillBash tools for shell command execution | 3 | 17 | [spec](002-bash-tools/spec.md) · [plan](002-bash-tools/plan.md) |
+| MCP | Model Context Protocol support for external tools and context sources | 4 | 20 | [spec](003-mcp/spec.md) · [plan](003-mcp/plan.md) |
 | Session Management | Performance-optimized, project-based session management system | 3 | 17 | [spec](004-session-management/spec.md) · [plan](004-session-management/plan.md) |
 | Hooks | Event hooks system for extending Wave behavior | 13 | 52 | [spec](005-hooks/spec.md) · [plan](005-hooks/plan.md) |
 | Agent Skills | Discoverable skill packages with SKILL.md files for model-invoked capabilities | 8 | 25 | [spec](006-agent-skills/spec.md) · [plan](006-agent-skills/plan.md) |
@@ -49,7 +49,7 @@ This directory contains feature specifications that serve as the source of truth
 | Subagent | Subagent support for delegating tasks to pre-configured AI personalities | 5 | 23 | [spec](009-subagent/spec.md) · [plan](009-subagent/plan.md) |
 | Usage Tracking | SDK usage tracking callbacks (`onUsagesChange`) for AI calls and compression | 4 | 15 | [spec](010-usage-tracking-callback/spec.md) · [plan](010-usage-tracking-callback/plan.md) |
 | Streaming | Real-time content streaming for assistant messages and tool parameters | 5 | 22 | [spec](012-stream-content-updates/spec.md) · [plan](012-stream-content-updates/plan.md) |
-| AI Error Handling | Handle output token limit exceeded by prompting agent to break work into smaller pieces | 5 | 9 | [spec](013-ai-error-handling/spec.md) · [plan](013-ai-error-handling/plan.md) |
+| AI Error Handling | Handle output token limit exceeded by prompting agent to break work into smaller pieces | 5 | 10 | [spec](013-ai-error-handling/spec.md) · [plan](013-ai-error-handling/plan.md) |
 | Message Compression | Conversation history and user input size management | 4 | 12 | [spec](014-message-compression/spec.md) · [plan](014-message-compression/plan.md) |
 | Image Pasting | Paste images from clipboard into chat input with placeholder and attachment | 3 | 10 | [spec](015-image-pasting/spec.md) · [plan](015-image-pasting/plan.md) |
 | File Selector | Quick file/directory selector UI component | 3 | 8 | [spec](016-file-selector/spec.md) · [plan](016-file-selector/plan.md) |
@@ -68,7 +68,7 @@ This directory contains feature specifications that serve as the source of truth
 | Status Line | Extracted StatusLine component for mode and shell command status display | 1 | 4 | [spec](030-status-line/spec.md) |
 | Update Command | `wave update` / `wave-code update` to update to latest version | 2 | 7 | [spec](031-update-command/spec.md) · [plan](031-update-command/plan.md) |
 | BTW Command | `/btw` for side questions bypassing the main message queue | 3 | 10 | [spec](032-btw-command/spec.md) |
-| Model Command | `/model` interactive UI to switch between configured AI models | 3 | 11 | [spec](033-model-command/spec.md) |
+| Model Command | `/model` interactive UI to switch between configured AI models | 3 | 13 | [spec](033-model-command/spec.md) |
 | Confirm UI | Confirmation dialog UI components for tool permission approvals | 5 | 13 | [spec](034-confirm-ui/spec.md) · [plan](034-confirm-ui/plan.md) |
 | LSP Integration | Language Server Protocol for code intelligence (definitions, references, hover) | 3 | 8 | [spec](039-lsp-integration/spec.md) · [plan](039-lsp-integration/plan.md) |
 | Plugin | Plugin system with marketplace, scopes, Skills, LSP, MCP, Hooks, Agents | 6 | 28 | [spec](042-plugin/spec.md) · [plan](042-plugin/plan.md) |
@@ -83,9 +83,12 @@ This directory contains feature specifications that serve as the source of truth
 | Plan Subagent | Built-in Plan subagent for designing implementation plans before coding | 4 | 15 | [spec](065-plan-subagent/spec.md) · [plan](065-plan-subagent/plan.md) |
 | Bash Subagent | Built-in Bash subagent for executing shell commands | 1 | 7 | [spec](066-bash-subagent/spec.md) · [plan](066-bash-subagent/plan.md) |
 | Tools Selection | CLI `--tools` flag to restrict agent to a specific tool set | 4 | 8 | [spec](067-tools-selection/spec.md) · [plan](067-tools-selection/plan.md) |
-| CLI Worktree | `-w/--worktree` for isolated git worktrees at `.wave/worktrees/` with safe exit | 7 | 39 | [spec](068-cli-worktree/spec.md) · [plan](068-cli-worktree/plan.md) |
+| CLI Worktree | `-w/--worktree` for isolated git worktrees at `.wave/worktrees/` with safe exit | 7 | 40 | [spec](068-cli-worktree/spec.md) · [plan](068-cli-worktree/plan.md) |
 | Status Command | `/status` showing version, session ID, cwd, model, and runtime info | 1 | 9 | [spec](069-status-command/spec.md) · [plan](069-status-command/plan.md) |
 | ACP Bridge | Agent Communication Protocol bridge for connecting external clients | 4 | 17 | [spec](070-acp-bridge/spec.md) · [plan](070-acp-bridge/plan.md) |
 | Builtin Settings Skill | Guide users on `settings.json`, hooks config, and Wave settings management | 3 | 8 | [spec](071-builtin-settings-skill/spec.md) · [plan](071-builtin-settings-skill/plan.md) |
 | Loop Command | `/loop` for scheduling recurring prompts via cron (e.g., `/loop 5m check the build`). Includes durable persistence and multi-session scheduler lock. | 2 | 10 | [spec](072-loop-slash-command/spec.md) · [plan](072-loop-slash-command/plan.md) |
-| OpenTelemetry Integration | OpenTelemetry instrumentation for metrics, traces, and logs with multiple exporters (jsonl, OTLP) | 3 | 15 | [spec](075-opentelemetry/spec.md) · [plan](075-opentelemetry/plan.md) |
+| OpenTelemetry Integration | OpenTelemetry instrumentation for metrics, traces, and logs with multiple exporters (jsonl, OTLP) | 3 | 16 | [spec](075-opentelemetry/spec.md) · [plan](075-opentelemetry/plan.md) |
+| SSO Authentication | /login for browser-based SSO, token storage, auto API proxy routing | 3 | 27 | [spec](076-sso-auth/spec.md) · [plan](076-sso-auth/plan.md) |
+| Custom Tools via buildTool() | buildTool() factory for SDK users to define custom tools | 3 | 11 | [spec](077-custom-tools/spec.md) · [plan](077-custom-tools/plan.md) |
+| Server-Managed Config | Download and apply managed settings from Wave AI with checksum caching and merge priority | 3 | 11 | [spec](078-server-managed-config/spec.md) · [plan](078-server-managed-config/plan.md) |


### PR DESCRIPTION
- 003-mcp: +5 FRs (SSE auto-reconnect, reconnecting status, reconnect after SSO login, tool result size limiting, originalUrl for URL protection)
- 076-sso-auth: +3 FRs (auth logging, always-create authAwareFetch, serverUrl in login)
- 033-model-command: +2 FRs (persist /model to settings.json, model resolution priority)
- 002-bash-tools: +2 FRs (auto CWD tracking after cd, CWD prompt text), update FR-010, update cwd-handling.md
- 075-opentelemetry: +1 FR (anonymous ID fallback for telemetry), update data-model and contracts
- 007-agent-config: update FR-006 (model/fastModel fully optional)
- 068-worktree: update FR-003 (filesystem reads for branch resolution), +1 FR (stale origin/HEAD)
- 013-ai-error-handling: update FR-005 (5xx retry), +1 FR (transient server error retry)
- 077-custom-tools: remove all shouldDefer/alwaysLoad/ToolSearch refs (deferred tool loading removed)
- 078-server-managed-config: NEW spec (3 US, 11 FRs for server-managed config download)
- README.md: add rows for 076, 077, 078; update stats
