### PR TITLE
fix: remove notification injection from InteractionService.sendMessage

### DIFF
--- a/packages/agent-sdk/src/services/interactionService.ts
+++ b/packages/agent-sdk/src/services/interactionService.ts
@@ -7,7 +7,6 @@ import type { ConfigurationService } from "./configurationService.js";
 import type { AIManager } from "../managers/aiManager.js";
 import type { SubagentManager } from "../managers/subagentManager.js";
 import type { TaskManager } from "./taskManager.js";
-import type { NotificationQueue } from "../managers/notificationQueue.js";
 
 export interface InteractionContext {
   messageManager: MessageManager;
@@ -60,23 +59,6 @@ export class InteractionService {
 
         // If command doesn't exist, continue as normal message processing
         // Don't add to history, let normal message processing logic below handle it
-      }
-
-      // Inject pending notifications from background tasks
-      const notificationQueue = context.aiManager["container"].has(
-        "NotificationQueue",
-      )
-        ? context.aiManager["container"].get<NotificationQueue>(
-            "NotificationQueue",
-          )
-        : undefined;
-      if (notificationQueue && notificationQueue.hasPending()) {
-        const notifications = notificationQueue.dequeueAll();
-        for (const notification of notifications) {
-          messageManager.addUserMessage({
-            content: notification,
-          });
-        }
       }
 
       // Handle normal AI message


### PR DESCRIPTION
Notifications were being bundled with user messages in the same AI turn
via InteractionService.sendMessage() (Path B), causing background task
notifications and queued messages to be sent together unexpectedly.

Notifications are now exclusively handled through the proper Path A
mechanisms: aiManager.ts finally block and Agent.processPendingNotifications(),
which process them as structured task_notification blocks in their own turn.
