### PR TITLE
feat: add finish_reason auto-recursion and recoverTruncatedJson for truncated AI responses

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -32,6 +32,7 @@ import {
   DEFAULT_SYSTEM_PROMPT,
   buildSystemPrompt,
 } from "../constants/prompts.js";
+import { recoverTruncatedJson } from "../utils/stringUtils.js";
 
 export interface AIManagerCallbacks {
   onCompressionStateChange?: (isCompressing: boolean) => void;
@@ -583,12 +584,6 @@ export class AIManager {
         }
       }
 
-      if (result.finish_reason === "length" && toolCalls.length === 0) {
-        this.messageManager.addErrorBlock(
-          "AI response was truncated due to length limit. Please try to reduce the complexity of your request or split it into smaller parts.",
-        );
-      }
-
       if (toolCalls.length > 0) {
         // Execute all tools in parallel using Promise.all
         const toolExecutionPromises = toolCalls.map(
@@ -606,33 +601,44 @@ export class AIManager {
             const toolName = functionToolCall.function?.name || "";
             // Safely parse tool parameters, handle tools without parameters
             let toolArgs: Record<string, unknown> = {};
+            let jsonRecovered = false;
             const argsString = functionToolCall.function?.arguments?.trim();
 
             if (!argsString || argsString === "") {
               // Tool without parameters, use empty object
               toolArgs = {};
             } else {
+              let recoveredArgs = argsString;
               try {
                 toolArgs = JSON.parse(argsString);
-              } catch (parseError) {
-                // For non-empty but malformed JSON, still throw exception
-                let errorMessage = `Failed to parse tool arguments`;
-                if (result.finish_reason === "length") {
-                  errorMessage +=
-                    " (output truncated, please reduce your output)";
+              } catch {
+                // Attempt to recover truncated JSON (e.g., missing closing braces)
+                recoveredArgs = recoverTruncatedJson(argsString);
+                try {
+                  toolArgs = JSON.parse(recoveredArgs);
+                  jsonRecovered = true;
+                  this.logger?.warn(
+                    `Recovered truncated JSON for tool "${toolName}"`,
+                  );
+                } catch (parseError) {
+                  let errorMessage = `Failed to parse tool arguments`;
+                  if (result.finish_reason === "length") {
+                    errorMessage +=
+                      " (output truncated, please reduce your output)";
+                  }
+                  this.logger?.error(errorMessage, parseError);
+                  this.messageManager.updateToolBlock({
+                    id: toolId,
+                    parameters: argsString,
+                    result: errorMessage,
+                    success: false,
+                    error: errorMessage,
+                    stage: "end",
+                    name: toolName,
+                    compactParams: "",
+                  });
+                  return;
                 }
-                this.logger?.error(errorMessage, parseError);
-                this.messageManager.updateToolBlock({
-                  id: toolId,
-                  parameters: argsString,
-                  result: errorMessage,
-                  success: false,
-                  error: errorMessage,
-                  stage: "end",
-                  name: toolName,
-                  compactParams: "",
-                });
-                return;
               }
             }
 
@@ -683,13 +689,20 @@ export class AIManager {
                 context,
               );
 
+              // Build result content, adding truncation warning if JSON was recovered
+              let toolResultContent =
+                toolResult.content ||
+                (toolResult.error ? `Error: ${toolResult.error}` : "");
+              if (jsonRecovered) {
+                toolResultContent +=
+                  "\n\n⚠️ Tool arguments were truncated (likely exceeded max output tokens). Please reduce your output or split into multiple tool calls.";
+              }
+
               // Update message state - tool execution completed
               this.messageManager.updateToolBlock({
                 id: toolId,
                 parameters: argsString,
-                result:
-                  toolResult.content ||
-                  (toolResult.error ? `Error: ${toolResult.error}` : ""),
+                result: toolResultContent,
                 success: toolResult.success,
                 error: toolResult.error,
                 stage: "end",
@@ -735,13 +748,21 @@ export class AIManager {
         model,
       );
 
-      // Check if there are tool operations, if so automatically initiate next AI service call
-      if (toolCalls.length > 0) {
+      // Check if there are tool operations or response was truncated, if so automatically initiate next AI service call
+      if (toolCalls.length > 0 || result.finish_reason === "length") {
         // Check interruption status
         const isCurrentlyAborted =
           abortController.signal.aborted || toolAbortController.signal.aborted;
 
         if (!isCurrentlyAborted) {
+          // If response was truncated and no tools were called, add a continuation message
+          if (result.finish_reason === "length" && toolCalls.length === 0) {
+            this.messageManager.addUserMessage({
+              content:
+                "Your response was cut off because it exceeded the output token limit. Please break your work into smaller pieces. Continue from where you left off.",
+            });
+          }
+
           // Recursively call AI service, increment recursion depth, and pass same configuration
           await this.sendAIMessage({
             recursionDepth: recursionDepth + 1,

--- a/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
+++ b/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
@@ -1,7 +1,7 @@
 import type { Message } from "../types/index.js";
 import { convertImageToBase64 } from "./messageOperations.js";
 import { ChatCompletionMessageToolCall } from "openai/resources";
-import { stripAnsiColors } from "./stringUtils.js";
+import { recoverTruncatedJson, stripAnsiColors } from "./stringUtils.js";
 import {
   ChatCompletionContentPart,
   ChatCompletionMessageParam,
@@ -9,7 +9,8 @@ import {
 import { logger } from "./globalLogger.js";
 
 /**
- * Safely handle tool call parameters, ensuring a legal JSON string is returned
+ * Safely handle tool call parameters, ensuring a legal JSON string is returned.
+ * Attempts to recover truncated JSON (e.g., missing closing braces).
  * @param args Tool call parameters
  * @returns Legal JSON string
  */
@@ -22,12 +23,18 @@ function safeToolArguments(args: string): string {
     // Try to parse as JSON to validate format
     JSON.parse(args);
     return args;
-  } catch (error) {
-    logger.error(`Invalid tool arguments: ${args}`, error);
-    // If not valid JSON, return a fallback empty object with the original string as a comment or property
-    return JSON.stringify({
-      invalid_arguments: args,
-    });
+  } catch {
+    // Attempt to recover truncated JSON
+    const recovered = recoverTruncatedJson(args);
+    try {
+      JSON.parse(recovered);
+      return recovered;
+    } catch {
+      // Truly malformed JSON — return sanitized fallback
+      return JSON.stringify({
+        invalid_arguments: args,
+      });
+    }
   }
 }
 

--- a/packages/agent-sdk/src/utils/stringUtils.ts
+++ b/packages/agent-sdk/src/utils/stringUtils.ts
@@ -72,6 +72,49 @@ export function parseCustomHeaders(
 }
 
 /**
+ * Attempt to recover truncated JSON (e.g., missing closing braces due to max tokens).
+ * Tracks brace depth and only recovers if there are unclosed `{` braces.
+ * Will NOT recover if there are unclosed `[` brackets (can't guess the content).
+ * @param jsonStr Potentially truncated JSON string
+ * @returns Recovered JSON string, or the original if unrecoverable
+ */
+export function recoverTruncatedJson(jsonStr: string): string {
+  let braceDepth = 0;
+  let bracketDepth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (const ch of jsonStr) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\" && inString) {
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (!inString) {
+      if (ch === "{") braceDepth++;
+      if (ch === "}") braceDepth--;
+      if (ch === "[") bracketDepth++;
+      if (ch === "]") bracketDepth--;
+    }
+  }
+
+  // Build recovery suffix
+  let suffix = "";
+  if (inString) suffix += '"'; // Close unclosed string
+  if (braceDepth > 0 && bracketDepth === 0) {
+    suffix += "}".repeat(braceDepth);
+  }
+  return suffix ? jsonStr + suffix : jsonStr;
+}
+
+/**
  * Function to remove ANSI color codes
  * @param text Text containing ANSI color codes
  * @returns Plain text with color codes removed

--- a/packages/agent-sdk/tests/managers/aiManager.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.test.ts
@@ -53,6 +53,7 @@ describe("AIManager", () => {
       getSessionId: vi.fn().mockReturnValue("test-session-id"),
       getMessages: vi.fn().mockReturnValue([]),
       addAssistantMessage: vi.fn(),
+      addUserMessage: vi.fn(),
       updateCurrentMessageContent: vi.fn(),
       updateToolBlock: vi.fn(),
       mergeAssistantAdditionalFields: vi.fn(),
@@ -186,16 +187,24 @@ describe("AIManager", () => {
       );
     });
 
-    it("should log warning when finish reason is length", async () => {
+    it("should log warning and recurse when finish reason is length", async () => {
       const { callAgent } = await import("../../src/services/aiService.js");
+      vi.mocked(callAgent).mockClear();
       const mockHeaders = { "x-test-header": "test-value" };
-      vi.mocked(callAgent).mockResolvedValue({
-        content: "Truncated response",
-        finish_reason: "length",
-        response_headers: mockHeaders,
-        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
-        tool_calls: [],
-      });
+      vi.mocked(callAgent)
+        .mockResolvedValueOnce({
+          content: "Truncated response",
+          finish_reason: "length",
+          response_headers: mockHeaders,
+          usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+          tool_calls: [],
+        })
+        .mockResolvedValueOnce({
+          content: "Final response",
+          finish_reason: "stop",
+          usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+          tool_calls: [],
+        });
 
       await aiManager.sendAIMessage();
 
@@ -203,6 +212,7 @@ describe("AIManager", () => {
         "AI response truncated due to length limit. Response headers:",
         mockHeaders,
       );
+      expect(callAgent).toHaveBeenCalledTimes(2);
     });
 
     it("should save session during each recursion regardless of tool execution results", async () => {

--- a/packages/agent-sdk/tests/managers/aiManager_finishReason.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager_finishReason.test.ts
@@ -52,6 +52,7 @@ describe("AIManager finish reason", () => {
       getSessionId: vi.fn().mockReturnValue("test-session-id"),
       getMessages: vi.fn().mockReturnValue([]),
       addAssistantMessage: vi.fn(),
+      addUserMessage: vi.fn(),
       updateCurrentMessageContent: vi.fn(),
       updateToolBlock: vi.fn(),
       mergeAssistantAdditionalFields: vi.fn(),
@@ -92,28 +93,44 @@ describe("AIManager finish reason", () => {
     });
   });
 
-  it("should add an error block when finish reason is length and no tools are called", async () => {
+  it("should add a user message and recurse when finish reason is length and no tools are called", async () => {
     const { callAgent } = await import("../../src/services/aiService.js");
-    vi.mocked(callAgent).mockResolvedValue({
-      content: "Truncated response...",
-      finish_reason: "length",
-      tool_calls: [],
-      usage: {
-        prompt_tokens: 10,
-        completion_tokens: 20,
-        total_tokens: 30,
-      },
-    });
+    vi.mocked(callAgent).mockClear();
+    vi.mocked(callAgent)
+      .mockResolvedValueOnce({
+        content: "Truncated response...",
+        finish_reason: "length",
+        tool_calls: [],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30,
+        },
+      })
+      .mockResolvedValueOnce({
+        content: "Final response",
+        finish_reason: "stop",
+        tool_calls: [],
+        usage: {
+          prompt_tokens: 5,
+          completion_tokens: 5,
+          total_tokens: 10,
+        },
+      });
 
     await aiManager.sendAIMessage();
 
-    expect(mockMessageManager.addErrorBlock).toHaveBeenCalledWith(
-      expect.stringContaining("truncated"),
+    expect(mockMessageManager.addUserMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining("cut off"),
+      }),
     );
+    expect(callAgent).toHaveBeenCalledTimes(2);
   });
 
-  it("should NOT add an error block when finish reason is length but tools ARE called", async () => {
+  it("should NOT add a user message but still recurse when finish reason is length and tools ARE called", async () => {
     const { callAgent } = await import("../../src/services/aiService.js");
+    vi.mocked(callAgent).mockClear();
     // First call returns tool calls, second call returns stop to prevent infinite recursion
     vi.mocked(callAgent)
       .mockResolvedValueOnce({
@@ -148,9 +165,9 @@ describe("AIManager finish reason", () => {
 
     await aiManager.sendAIMessage();
 
-    // It should NOT call addErrorBlock directly on AIManager level
-    // (The tool block itself might have an error if it fails to parse, but that's different)
-    expect(mockMessageManager.addErrorBlock).not.toHaveBeenCalled();
+    // It should NOT call addUserMessage because tool results serve as reminder
+    expect(mockMessageManager.addUserMessage).not.toHaveBeenCalled();
+    expect(callAgent).toHaveBeenCalledTimes(2);
   });
 
   it("should NOT add an error block when finish reason is stop", async () => {

--- a/packages/agent-sdk/tests/utils/stringUtils.test.ts
+++ b/packages/agent-sdk/tests/utils/stringUtils.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { parseCustomHeaders } from "@/utils/stringUtils.js";
+import {
+  parseCustomHeaders,
+  recoverTruncatedJson,
+} from "@/utils/stringUtils.js";
 
 describe("parseCustomHeaders", () => {
   it("should parse a single header", () => {
@@ -64,5 +67,54 @@ describe("parseCustomHeaders", () => {
   it("should handle undefined or null input gracefully", () => {
     expect(parseCustomHeaders(undefined as unknown as string)).toEqual({});
     expect(parseCustomHeaders(null as unknown as string)).toEqual({});
+  });
+});
+
+describe("recoverTruncatedJson", () => {
+  it("should return valid JSON unchanged", () => {
+    expect(recoverTruncatedJson('{"a": 1}')).toBe('{"a": 1}');
+  });
+
+  it("should recover JSON missing one closing brace", () => {
+    expect(recoverTruncatedJson('{"a": 1')).toBe('{"a": 1}');
+  });
+
+  it("should recover JSON missing multiple closing braces", () => {
+    expect(recoverTruncatedJson('{"a": {"b": 2')).toBe('{"a": {"b": 2}}');
+  });
+
+  it("should not modify JSON that is already closed", () => {
+    expect(recoverTruncatedJson('{"a": {"b": [1, 2]}}')).toBe(
+      '{"a": {"b": [1, 2]}}',
+    );
+  });
+
+  it("should handle strings containing braces without counting them", () => {
+    expect(recoverTruncatedJson(`{"a": "hello}`)).toBe(`{"a": "hello}"}`);
+  });
+
+  it("should handle escaped quotes inside strings", () => {
+    expect(recoverTruncatedJson(`{"a": "say \\"hi\\"`)).toBe(
+      `{"a": "say \\"hi\\""}`,
+    );
+  });
+
+  it("should return unchanged string for unclosed brackets", () => {
+    // Unclosed brackets cannot be safely recovered
+    expect(recoverTruncatedJson('{"a": [1, 2')).toBe('{"a": [1, 2');
+  });
+
+  it("should close unclosed string before closing braces", () => {
+    expect(recoverTruncatedJson(`{"a": "hello}`)).toBe(`{"a": "hello}"}`);
+  });
+
+  it("should handle empty object missing closing brace", () => {
+    expect(recoverTruncatedJson("{")).toBe("{}");
+  });
+
+  it("should handle deeply nested truncation", () => {
+    expect(recoverTruncatedJson('{"a": {"b": {"c": 3')).toBe(
+      '{"a": {"b": {"c": 3}}}',
+    );
   });
 });


### PR DESCRIPTION
## Summary

Cherry-picks and adapts 4 commits from `main` into `feature/sdd`:

### 1. Auto-recursion on `finish_reason === "length"`
When the AI response is truncated due to output token limit:
- **Removed** the old static error block ("AI response was truncated due to length limit...")
- **Added** automatic recursion: condition changed from `toolCalls.length > 0` to `toolCalls.length > 0 || result.finish_reason === "length"`
- **Added** continuation user message when truncated without tools: "Your response was cut off because it exceeded the output token limit. Please break your work into smaller pieces. Continue from where you left off."

### 2. `recoverTruncatedJson()` utility
- Added `recoverTruncatedJson()` in `stringUtils.ts` — closes unclosed strings and `{` braces in truncated JSON
- Will NOT recover unclosed `[` brackets (can't guess the content)
- Integrated in `aiManager.ts` tool arg parsing: tries recovery before failing, appends truncation warning to tool results
- Integrated in `convertMessagesForAPI.ts` `safeToolArguments`: tries recovery before `invalid_arguments` fallback

### Test Coverage
- 10 new unit tests for `recoverTruncatedJson`
- Updated `aiManager_finishReason.test.ts` and `aiManager.test.ts` to verify new recursion behavior

## Files Changed
| File | Change |
|------|--------|
| `src/utils/stringUtils.ts` | Added `recoverTruncatedJson()` |
| `src/managers/aiManager.ts` | Auto-recursion + recoverTruncatedJson integration |
| `src/utils/convertMessagesForAPI.ts` | recoverTruncatedJson in safeToolArguments |
| `tests/utils/stringUtils.test.ts` | 10 new tests |
| `tests/managers/aiManager.test.ts` | Updated finish_reason test |
| `tests/managers/aiManager_finishReason.test.ts` | Updated to match new behavior |