### PR TITLE
fix: MCP JSON formatting and Read tool token-level validation

### DIFF
--- a/packages/agent-sdk/src/managers/mcpManager.ts
+++ b/packages/agent-sdk/src/managers/mcpManager.ts
@@ -798,7 +798,7 @@ export class McpManager {
             } else if (c.type === "resource") {
               textContent.push(`[Resource: ${c.resource?.uri || ""}]`);
             } else {
-              textContent.push(JSON.stringify(c));
+              textContent.push(JSON.stringify(c, null, 2));
             }
           },
         );

--- a/packages/agent-sdk/src/tools/readTool.ts
+++ b/packages/agent-sdk/src/tools/readTool.ts
@@ -145,7 +145,7 @@ Usage:
 - The file_path parameter must be an absolute path, not a relative path
 - By default, it reads up to 2000 lines starting from the beginning of the file
 - You can optionally specify a line offset and limit (especially handy for long files), but it's recommended to read the whole file by not providing these parameters
-- Any lines longer than 2000 characters will be truncated
+- If the file content exceeds the token limit, use offset and limit parameters to read specific portions of the file, or use Bash with grep/jq to extract specific content
 - Results are returned using cat -n format, with line numbers starting at 1
 - This tool allows Agent to read images (eg PNG, JPG, etc). When reading an image file the contents are presented visually as Agent is a multimodal LLM.
 - You have the capability to call multiple tools in a single response. It is always better to speculatively read multiple files as a batch that are potentially useful.
@@ -341,12 +341,30 @@ Usage:
       const formattedContent = selectedLines
         .map((line, index) => {
           const lineNumber = startLine + index;
-          // Truncate overly long lines
-          const truncatedLine =
-            line.length > 2000 ? line.substring(0, 2000) + "..." : line;
-          return `${formatLineNumberPrefix(lineNumber)}${truncatedLine}`;
+          return `${formatLineNumberPrefix(lineNumber)}${line}`;
         })
         .join("\n");
+
+      // Token-level validation: estimate tokens and reject if over limit
+      const maxTokens = context.fileReadingLimits?.maxTokens ?? 25000; // Default 25000 tokens
+      const ext = extname(actualFilePath).toLowerCase().slice(1);
+      const bytesPerToken =
+        ext === "json" || ext === "jsonl" || ext === "jsonc" ? 2 : 4;
+      const estimatedTokens = Math.ceil(
+        formattedContent.length / bytesPerToken,
+      );
+      if (estimatedTokens > maxTokens) {
+        return {
+          success: false,
+          content: "",
+          error: `File content (~${estimatedTokens.toLocaleString()} tokens) exceeds maximum allowed tokens (${maxTokens.toLocaleString()}). Use offset and limit parameters to read specific portions of the file, or use Bash with grep/jq to search within it for specific content.`,
+          metadata: {
+            type: "error_token_limit_exceeded",
+            estimatedTokens,
+            maxTokens,
+          },
+        };
+      }
 
       // Add file information header
       let content = `File: ${filePath}\n`;

--- a/packages/agent-sdk/tests/managers/mcpManager.test.ts
+++ b/packages/agent-sdk/tests/managers/mcpManager.test.ts
@@ -1154,7 +1154,7 @@ describe("McpManager", () => {
       expect(result).toEqual({
         success: true,
         content:
-          'Known text\n{"type":"unknown_type","data":"some_data","custom_field":"custom_value"}',
+          'Known text\n{\n  "type": "unknown_type",\n  "data": "some_data",\n  "custom_field": "custom_value"\n}',
         serverName: "test-server",
       });
     });

--- a/packages/agent-sdk/tests/tools/readTool.test.ts
+++ b/packages/agent-sdk/tests/tools/readTool.test.ts
@@ -54,9 +54,6 @@ Line 5`,
     (_, i) => `Line ${i + 1}`,
   ).join("\n"),
   "/test/workdir/empty.txt": "",
-  "/test/workdir/long-lines.txt": `Short line
-${"x".repeat(2500)}
-Another short line`,
   "/test/workdir/unicode.txt": `Hello 世界
 Emoji: 🚀 🌟 ✨
 Multi-byte: café naïve résumé`,
@@ -175,17 +172,6 @@ describe("readTool", () => {
     expect(result.content).toContain("     1\tLine 1");
     expect(result.content).toContain("    10\tLine 10");
     expect(result.content).not.toContain("Line 11");
-  });
-
-  it("should truncate long lines", async () => {
-    const filePath = "/test/workdir/long-lines.txt";
-    const result = await readTool.execute({ file_path: filePath }, testContext);
-
-    expect(result.success).toBe(true);
-    expect(result.content).toContain("Short line");
-    expect(result.content).toContain("Another short line");
-    // Long lines should be truncated and "..." added
-    expect(result.content).toContain("...");
   });
 
   it("should handle empty file", async () => {
@@ -669,8 +655,8 @@ describe("readTool", () => {
   });
 
   describe("Edge Cases", () => {
-    it("should handle very large files without content truncation at 100KB", async () => {
-      const largeContent = "a".repeat(150 * 1024); // 150KB
+    it("should reject very large single-line files that exceed token limit", async () => {
+      const largeContent = "a".repeat(150 * 1024); // 150KB single line
       mockReadFile.mockResolvedValue(largeContent);
 
       const result = await readTool.execute(
@@ -678,10 +664,9 @@ describe("readTool", () => {
         testContext,
       );
 
-      expect(result.success).toBe(true);
-      expect(result.content).not.toContain("Content truncated at 102400 bytes");
-      // It should still truncate the line itself if it's too long
-      expect(result.content).toContain("...");
+      // 150KB / 4 bytesPerToken = ~38400 tokens, exceeds default 25000 limit
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("exceeds maximum allowed tokens");
     });
 
     it("should be able to read lines beyond the first 100KB", async () => {

--- a/specs/001-fs-tools/contracts/read-image-interfaces.md
+++ b/specs/001-fs-tools/contracts/read-image-interfaces.md
@@ -197,6 +197,11 @@ interface TextFileProcessingContract {
     withOffset: number;
     withLimit: number;
   };
+  tokenValidation: {
+    maxTokens: 25000;           // from context.fileReadingLimits.maxTokens
+    bytesPerToken: 2 | 4;       // 2 for JSON/JSONL/JSONC, 4 for other files
+    errorMessage: string;       // Suggests offset/limit or grep/jq
+  };
   contentTruncation: {
     maxBytes: 100 * 1024;       // 100KB for text
     indicator: string;          // "... more lines not shown"

--- a/specs/001-fs-tools/research.md
+++ b/specs/001-fs-tools/research.md
@@ -13,8 +13,8 @@
 **Rationale**: `ripgrep` is significantly faster than native Node.js implementations for large codebases and is a standard tool in the VS Code ecosystem.
 
 ## Large File Handling
-**Decision**: Implement `offset` and `limit` in the `Read` tool, and truncate long lines.
-**Rationale**: LLMs have context window limits. Reading entire large files or extremely long lines can exhaust tokens or cause performance issues.
+**Decision**: Implement `offset` and `limit` in the `Read` tool, and enforce token-level validation.
+**Rationale**: LLMs have context window limits. Reading entire large files can exhaust tokens. Token-level validation (estimated tokens must not exceed `maxTokens`) prevents oversized content from being returned, with a clear error suggesting offset/limit or grep/jq.
 
 ## Search Feedback
 **Decision**: Suggest specifying the `path` field when `Grep` returns no matches.

--- a/specs/001-fs-tools/spec.md
+++ b/specs/001-fs-tools/spec.md
@@ -57,7 +57,7 @@ As an AI agent, I want to search for patterns using glob patterns or regex so th
 
 ### Edge Cases
 
-- **Large Files**: Reading files that exceed memory limits or token windows. Handled via `offset` and `limit`.
+- **Large Files**: Reading files that exceed memory limits or token windows. Handled via `offset` and `limit`. If estimated tokens exceed `maxTokens`, the tool returns an error suggesting offset/limit or grep/jq.
 - **Binary Documents**: Attempting to read PDF, DOCX, or other unsupported binary formats. The tool MUST prevent this and return an error.
 - **Mismatch Analysis**: `Edit` tool must provide detailed mismatch reports when `old_string` is not found, highlighting exactly which lines differ.
 - **File Permissions**: Attempting to write to read-only files or directories without proper permissions.
@@ -67,7 +67,7 @@ As an AI agent, I want to search for patterns using glob patterns or regex so th
 ### Functional Requirements
 
 - **FR-001**: System MUST provide a `Read` tool that supports text, images (PNG, JPEG, GIF, WebP), and Jupyter notebooks.
-- **FR-002**: `Read` tool MUST support pagination via `offset` and `limit`, truncate long lines for text files, and provide structured metadata.
+- **FR-002**: `Read` tool MUST support pagination via `offset` and `limit`, enforce token-level validation (estimated tokens must not exceed `maxTokens`, default 25000, from `context.fileReadingLimits.maxTokens`; bytesPerToken is 2 for JSON/JSONL/JSONC and 4 for other files), and provide structured metadata.
 - **FR-018**: `Read` tool MUST support deduplication by checking file modification time and returning a minimal response if unchanged.
 - **FR-019**: `Read` tool MUST enforce resource limits (e.g., 1MB default) for full file reads.
 - **FR-015**: `Read` tool MUST detect image files by extension case-insensitively and convert content to base64 encoding.

--- a/specs/001-fs-tools/tasks.md
+++ b/specs/001-fs-tools/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: File System Tools
 
-- [x] T001 Implement `Read` tool with line numbering and truncation support
+- [x] T001 Implement `Read` tool with line numbering and token-level validation
 - [x] T002 Implement `Write` tool with directory auto-creation
 - [x] T003 Implement `Edit` tool with detailed mismatch analysis
 - [x] T007 Implement `Glob` tool for pattern-based file discovery


### PR DESCRIPTION
- Format MCP non-standard content with JSON indentation (`JSON.stringify(c, null, 2)`) to prevent persisted files from being single-line, which causes Read tool to truncate at 2000 chars\n- Replace Read tool 2000-char per-line truncation with token-level validation (default 25000 tokens, bytesPerToken 2 for JSON/4 for others); oversized content returns error suggesting offset/limit or grep/jq instead of silently truncating