### PR TITLE
feat: add MCP tool result size limiting and shared persistence utility

### DIFF
--- a/packages/agent-sdk/src/constants/toolLimits.ts
+++ b/packages/agent-sdk/src/constants/toolLimits.ts
@@ -1,0 +1,15 @@
+/**
+ * Tool output size limits matching Claude Code patterns.
+ */
+
+/** System-wide default max result size in characters. */
+export const DEFAULT_MAX_RESULT_SIZE_CHARS = 50_000;
+
+/** Per-command cap for bash tool output before persistence. */
+export const BASH_MAX_OUTPUT_CHARS = 30_000;
+
+/** Per-command cap for skill bash substitution (inline/block). */
+export const SKILL_BASH_MAX_OUTPUT_CHARS = 30_000;
+
+/** Preview size in characters when output is persisted to disk. */
+export const PREVIEW_SIZE_BYTES = 2_048;

--- a/packages/agent-sdk/src/managers/mcpManager.ts
+++ b/packages/agent-sdk/src/managers/mcpManager.ts
@@ -429,7 +429,7 @@ export class McpManager {
             } else if (c.type === "resource") {
               textContent.push(`[Resource: ${c.resource?.uri || ""}]`);
             } else {
-              textContent.push(JSON.stringify(c));
+              textContent.push(JSON.stringify(c, null, 2));
             }
           },
         );

--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -1,6 +1,8 @@
 import { spawn, ChildProcess } from "child_process";
 import { logger } from "../utils/globalLogger.js";
 import { stripAnsiColors } from "../utils/stringUtils.js";
+import { processToolResult } from "../utils/toolResultStorage.js";
+import { BASH_MAX_OUTPUT_CHARS } from "../constants/toolLimits.js";
 import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
 import {
   BASH_TOOL_NAME,
@@ -13,7 +15,6 @@ import {
   WRITE_TOOL_NAME,
 } from "../constants/tools.js";
 
-const MAX_OUTPUT_LENGTH = 30000;
 const BASH_DEFAULT_TIMEOUT_MS = 120000;
 
 /**
@@ -49,7 +50,7 @@ Usage notes:
   - The command argument is required.
   - You can specify an optional timeout in milliseconds (up to ${BASH_DEFAULT_TIMEOUT_MS}ms / ${BASH_DEFAULT_TIMEOUT_MS / 60000} minutes). If not specified, commands will timeout after ${BASH_DEFAULT_TIMEOUT_MS}ms (${BASH_DEFAULT_TIMEOUT_MS / 60000} minutes).
   - It is very helpful if you write a clear, concise description of what this command does in 5-10 words.
-  - If the output exceeds ${MAX_OUTPUT_LENGTH} characters, output will be truncated before being returned to you.
+  - If the output exceeds ${BASH_MAX_OUTPUT_CHARS.toLocaleString()} characters, output will be truncated and the full output will be persisted to a file you can read with the Read tool.
   - You can use the \`run_in_background\` parameter to run the command in the background, which allows you to continue working while the command runs. You can monitor the output using the ${BASH_TOOL_NAME} tool as it becomes available. You do not need to use '&' at the end of the command when using this parameter.
   - Avoid using ${BASH_TOOL_NAME} with the \`find\`, \`grep\`, \`cat\`, \`head\`, \`tail\`, \`sed\`, \`awk\`, or \`echo\` commands, unless explicitly instructed or when these commands are truly necessary for the task. Instead, always prefer using the dedicated tools for these commands:
     - File search: Use ${GLOB_TOOL_NAME} (NOT find or ls)
@@ -253,7 +254,12 @@ Usage notes:
 
           resolve({
             success: false,
-            content: outputBuffer + (errorBuffer ? "\n" + errorBuffer : ""),
+            content:
+              processToolResult(
+                outputBuffer + (errorBuffer ? "\n" + errorBuffer : ""),
+                BASH_MAX_OUTPUT_CHARS,
+                "bash",
+              ) || reason,
             error: reason,
           });
         }
@@ -293,14 +299,14 @@ Usage notes:
           const combinedOutput =
             outputBuffer + (errorBuffer ? "\n" + errorBuffer : "");
 
-          // Handle large output by truncation if needed
+          // Handle large output by persisting to file if needed
           const finalOutput =
             combinedOutput || `Command executed with exit code: ${exitCode}`;
-          const content =
-            finalOutput.length > MAX_OUTPUT_LENGTH
-              ? finalOutput.substring(0, MAX_OUTPUT_LENGTH) +
-                "\n\n... (output truncated)"
-              : finalOutput;
+          const content = processToolResult(
+            finalOutput,
+            BASH_MAX_OUTPUT_CHARS,
+            "bash",
+          );
 
           resolve({
             success: exitCode === 0,
@@ -420,11 +426,11 @@ export const bashOutputTool: ToolPlugin = {
     }
 
     const finalContent = content || "No output available";
-    const processedContent =
-      finalContent.length > MAX_OUTPUT_LENGTH
-        ? finalContent.substring(0, MAX_OUTPUT_LENGTH) +
-          "\n\n... (output truncated)"
-        : finalContent;
+    const processedContent = processToolResult(
+      finalContent,
+      BASH_MAX_OUTPUT_CHARS,
+      "bash",
+    );
 
     return {
       success: true,

--- a/packages/agent-sdk/src/utils/mcpUtils.ts
+++ b/packages/agent-sdk/src/utils/mcpUtils.ts
@@ -1,6 +1,8 @@
 import { ChatCompletionFunctionTool } from "openai/resources.js";
 import type { ToolPlugin, ToolResult, ToolContext } from "../tools/types.js";
 import type { McpTool, McpServerStatus } from "../types/index.js";
+import { processToolResult } from "./toolResultStorage.js";
+import { DEFAULT_MAX_RESULT_SIZE_CHARS } from "../constants/toolLimits.js";
 
 /**
  * Recursively clean schema to remove unsupported fields
@@ -86,9 +88,15 @@ export function createMcpToolPlugin(
           // Future: Could pass working directory or other context to MCP tools
         }
         const result = await executeTool(prefixedName, args);
+        const processedContent = processToolResult(
+          result.content || `Executed ${mcpTool.name}`,
+          DEFAULT_MAX_RESULT_SIZE_CHARS,
+          `mcp_${serverName}_${mcpTool.name}`,
+        );
         return {
           success: true,
-          content: result.content || `Executed ${mcpTool.name}`,
+          content: processedContent,
+          images: result.images,
         };
       } catch (error) {
         return {

--- a/packages/agent-sdk/src/utils/toolResultStorage.ts
+++ b/packages/agent-sdk/src/utils/toolResultStorage.ts
@@ -1,0 +1,117 @@
+/**
+ * Shared tool result persistence and truncation logic.
+ *
+ * When a tool result exceeds a size threshold, the full content is saved to a
+ * file in /tmp/wave-tool-results/ and the model receives a <persisted-output>
+ * preview with the file path so it can use the Read tool to access the full output.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import {
+  DEFAULT_MAX_RESULT_SIZE_CHARS,
+  PREVIEW_SIZE_BYTES,
+} from "../constants/toolLimits.js";
+import { logger } from "./globalLogger.js";
+
+const TOOL_RESULTS_DIR = path.join(os.tmpdir(), "wave-tool-results");
+
+/**
+ * Get (and create if needed) the tool-results directory.
+ * Uses /tmp/wave-tool-results/ for simplicity and automatic OS cleanup.
+ */
+export function getToolResultsDir(): string {
+  fs.mkdirSync(TOOL_RESULTS_DIR, { recursive: true });
+  return TOOL_RESULTS_DIR;
+}
+
+/**
+ * Persist full tool output to a file in the tool-results directory.
+ * Returns the file path on success, or undefined on failure.
+ */
+export function persistToolResult(
+  content: string,
+  prefix: string = "tool",
+): string | undefined {
+  try {
+    const dir = getToolResultsDir();
+    const id = `${prefix}_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+    const filePath = path.join(dir, `${id}.txt`);
+    fs.writeFileSync(filePath, content, "utf8");
+    return filePath;
+  } catch (error) {
+    logger?.error("Failed to persist tool result:", error);
+    return undefined;
+  }
+}
+
+/**
+ * Generate a preview from content: first `previewSize` characters with ellipsis.
+ */
+export function generatePreview(
+  content: string,
+  previewSize: number = PREVIEW_SIZE_BYTES,
+): string {
+  if (content.length <= previewSize) return content;
+  return content.substring(0, previewSize) + "\n...";
+}
+
+/**
+ * Build the <persisted-output> wrapper message that the model sees.
+ *
+ * Example output:
+ * <persisted-output>
+ * Output too large (150,000 characters). Full output saved to: /tmp/wave-tool-results/mcp_server_tool_12345.txt
+ * Preview (first 2,048 characters):
+ * {preview content}
+ * ...
+ * </persisted-output>
+ */
+export function buildPersistedOutputMessage(
+  totalChars: number,
+  filePath: string,
+  preview: string,
+): string {
+  return [
+    "<persisted-output>",
+    `Output too large (${totalChars.toLocaleString()} characters). Full output saved to: ${filePath}`,
+    `Preview (first ${PREVIEW_SIZE_BYTES.toLocaleString()} characters):`,
+    preview,
+    "</persisted-output>",
+  ].join("\n");
+}
+
+/**
+ * Process tool result: if content exceeds maxChars, persist to file and return
+ * truncated content with <persisted-output> wrapper. Otherwise return unchanged.
+ *
+ * This is the main entry point for both MCP and bash tools.
+ *
+ * @param content - The tool result content
+ * @param maxChars - Maximum characters before persistence kicks in (defaults to DEFAULT_MAX_RESULT_SIZE_CHARS)
+ * @param prefix - File name prefix for the persisted file (e.g. "bash", "mcp")
+ * @returns The content to send to the model (either original or persisted-output wrapper)
+ */
+export function processToolResult(
+  content: string,
+  maxChars: number = DEFAULT_MAX_RESULT_SIZE_CHARS,
+  prefix: string = "tool",
+): string {
+  if (content.length <= maxChars) {
+    return content;
+  }
+
+  const filePath = persistToolResult(content, prefix);
+
+  if (filePath) {
+    const preview = generatePreview(content);
+    return buildPersistedOutputMessage(content.length, filePath, preview);
+  }
+
+  // Fallback: truncation only (persistence failed)
+  return (
+    content.substring(0, maxChars) +
+    "\n\n... (output truncated, failed to persist full output)"
+  );
+}

--- a/packages/agent-sdk/tests/managers/mcpManager.test.ts
+++ b/packages/agent-sdk/tests/managers/mcpManager.test.ts
@@ -623,7 +623,7 @@ describe("McpManager", () => {
       expect(result).toEqual({
         success: true,
         content:
-          'Known text\n{"type":"unknown_type","data":"some_data","custom_field":"custom_value"}',
+          'Known text\n{\n  "type": "unknown_type",\n  "data": "some_data",\n  "custom_field": "custom_value"\n}',
         serverName: "test-server",
       });
     });

--- a/packages/agent-sdk/tests/utils/mcpUtils.test.ts
+++ b/packages/agent-sdk/tests/utils/mcpUtils.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fs from "fs";
+import {
+  mcpToolToOpenAITool,
+  createMcpToolPlugin,
+  findToolServer,
+} from "../../src/utils/mcpUtils.js";
+import type { McpTool, McpServerStatus } from "../../src/types/index.js";
+import type { ToolContext } from "../../src/tools/types.js";
+import { DEFAULT_MAX_RESULT_SIZE_CHARS } from "../../src/constants/toolLimits.js";
+
+// Mock fs for persistence tests
+vi.mock("fs", async () => {
+  const actual = await vi.importActual("fs");
+  return {
+    ...actual,
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+  };
+});
+
+// Mock os
+vi.mock("os", async () => {
+  const actual = await vi.importActual("os");
+  return {
+    ...actual,
+    tmpdir: vi.fn().mockReturnValue("/tmp"),
+  };
+});
+
+// Mock logger
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe("mcpUtils", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("mcpToolToOpenAITool", () => {
+    it("should convert MCP tool to OpenAI format with prefixed name", () => {
+      const mcpTool: McpTool = {
+        name: "search",
+        description: "Search for items",
+        inputSchema: {
+          type: "object",
+          properties: { query: { type: "string" } },
+        },
+      };
+
+      const result = mcpToolToOpenAITool(mcpTool, "myserver");
+
+      expect(result).toEqual({
+        type: "function",
+        function: {
+          name: "mcp__myserver__search",
+          description: "Search for items (MCP: myserver)",
+          parameters: {
+            type: "object",
+            properties: { query: { type: "string" } },
+          },
+        },
+      });
+    });
+  });
+
+  describe("createMcpToolPlugin", () => {
+    const mcpTool: McpTool = {
+      name: "test_tool",
+      description: "A test tool",
+      inputSchema: { type: "object", properties: {} },
+    };
+
+    it("should pass through small results unchanged", async () => {
+      const executeTool = vi.fn().mockResolvedValue({
+        success: true,
+        content: "small result",
+      });
+
+      const plugin = createMcpToolPlugin(mcpTool, "myserver", executeTool);
+      const result = await plugin.execute(
+        {},
+        undefined as unknown as ToolContext,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.content).toBe("small result");
+    });
+
+    it("should wrap large results in <persisted-output>", async () => {
+      const largeContent = "x".repeat(DEFAULT_MAX_RESULT_SIZE_CHARS + 1000);
+      const executeTool = vi.fn().mockResolvedValue({
+        success: true,
+        content: largeContent,
+      });
+
+      const plugin = createMcpToolPlugin(mcpTool, "myserver", executeTool);
+      const result = await plugin.execute(
+        {},
+        undefined as unknown as ToolContext,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.content).toContain("<persisted-output>");
+      expect(result.content).toContain(
+        "/tmp/wave-tool-results/mcp_myserver_test_tool_",
+      );
+      expect(result.content).toContain("</persisted-output>");
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining("mcp_myserver_test_tool_"),
+        largeContent,
+        "utf8",
+      );
+    });
+
+    it("should preserve images in results", async () => {
+      const images = [{ data: "base64data", mediaType: "image/png" }];
+      const executeTool = vi.fn().mockResolvedValue({
+        success: true,
+        content: "result with image",
+        images,
+      });
+
+      const plugin = createMcpToolPlugin(mcpTool, "myserver", executeTool);
+      const result = await plugin.execute(
+        {},
+        undefined as unknown as ToolContext,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.content).toBe("result with image");
+      expect(result.images).toEqual(images);
+    });
+
+    it("should handle tool execution errors", async () => {
+      const executeTool = vi.fn().mockRejectedValue(new Error("tool failed"));
+
+      const plugin = createMcpToolPlugin(mcpTool, "myserver", executeTool);
+      const result = await plugin.execute(
+        {},
+        undefined as unknown as ToolContext,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("tool failed");
+    });
+
+    it("should use default content when result content is empty", async () => {
+      const executeTool = vi.fn().mockResolvedValue({
+        success: true,
+        content: "",
+      });
+
+      const plugin = createMcpToolPlugin(mcpTool, "myserver", executeTool);
+      const result = await plugin.execute(
+        {},
+        undefined as unknown as ToolContext,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.content).toBe("Executed test_tool");
+    });
+  });
+
+  describe("findToolServer", () => {
+    it("should find the server that owns a tool", () => {
+      const servers: McpServerStatus[] = [
+        {
+          name: "server1",
+          status: "connected",
+          config: { command: "test1" },
+          tools: [{ name: "tool_a" } as McpTool],
+        },
+        {
+          name: "server2",
+          status: "connected",
+          config: { command: "test2" },
+          tools: [{ name: "tool_b" } as McpTool],
+        },
+      ];
+
+      expect(findToolServer("tool_a", servers)?.name).toBe("server1");
+      expect(findToolServer("tool_b", servers)?.name).toBe("server2");
+    });
+
+    it("should return undefined for unknown tool", () => {
+      const servers: McpServerStatus[] = [
+        {
+          name: "server1",
+          status: "connected",
+          config: { command: "test1" },
+          tools: [{ name: "tool_a" } as McpTool],
+        },
+      ];
+
+      expect(findToolServer("tool_c", servers)).toBeUndefined();
+    });
+
+    it("should skip disconnected servers", () => {
+      const servers: McpServerStatus[] = [
+        {
+          name: "server1",
+          status: "disconnected",
+          config: { command: "test1" },
+          tools: [{ name: "tool_a" } as McpTool],
+        },
+      ];
+
+      expect(findToolServer("tool_a", servers)).toBeUndefined();
+    });
+  });
+});

--- a/packages/agent-sdk/tests/utils/toolResultStorage.test.ts
+++ b/packages/agent-sdk/tests/utils/toolResultStorage.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fs from "fs";
+
+// Mock fs
+vi.mock("fs", async () => {
+  const actual = await vi.importActual("fs");
+  return {
+    ...actual,
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+  };
+});
+
+// Mock os
+vi.mock("os", async () => {
+  const actual = await vi.importActual("os");
+  return {
+    ...actual,
+    tmpdir: vi.fn().mockReturnValue("/tmp"),
+  };
+});
+
+// Mock logger
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import {
+  getToolResultsDir,
+  persistToolResult,
+  generatePreview,
+  buildPersistedOutputMessage,
+  processToolResult,
+} from "../../src/utils/toolResultStorage.js";
+import {
+  PREVIEW_SIZE_BYTES,
+  DEFAULT_MAX_RESULT_SIZE_CHARS,
+} from "../../src/constants/toolLimits.js";
+
+describe("toolResultStorage", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("generatePreview", () => {
+    it("should return content unchanged when under preview size", () => {
+      const content = "short content";
+      expect(generatePreview(content)).toBe(content);
+    });
+
+    it("should return content unchanged when exactly at preview size", () => {
+      const content = "a".repeat(PREVIEW_SIZE_BYTES);
+      expect(generatePreview(content)).toBe(content);
+    });
+
+    it("should truncate and append ellipsis when over preview size", () => {
+      const content = "a".repeat(PREVIEW_SIZE_BYTES + 100);
+      const result = generatePreview(content);
+      expect(result).toBe("a".repeat(PREVIEW_SIZE_BYTES) + "\n...");
+      expect(result.length).toBe(PREVIEW_SIZE_BYTES + 4); // +4 for "\n..."
+    });
+
+    it("should use custom preview size", () => {
+      const content = "a".repeat(200);
+      const result = generatePreview(content, 50);
+      expect(result).toBe("a".repeat(50) + "\n...");
+    });
+  });
+
+  describe("buildPersistedOutputMessage", () => {
+    it("should wrap content in persisted-output XML tags with char count, file path, and preview", () => {
+      const result = buildPersistedOutputMessage(
+        150000,
+        "/tmp/wave-tool-results/tool_123.txt",
+        "preview text",
+      );
+
+      expect(result).toBe(
+        "<persisted-output>\n" +
+          "Output too large (150,000 characters). Full output saved to: /tmp/wave-tool-results/tool_123.txt\n" +
+          "Preview (first 2,048 characters):\n" +
+          "preview text\n" +
+          "</persisted-output>",
+      );
+    });
+
+    it("should format char count with locale-specific grouping", () => {
+      const result = buildPersistedOutputMessage(
+        50000,
+        "/tmp/wave-tool-results/bash_456.txt",
+        "data",
+      );
+      expect(result).toContain("50,000 characters");
+    });
+
+    it("should include preview size in the header", () => {
+      const result = buildPersistedOutputMessage(100, "/path", "x");
+      expect(result).toContain(
+        `first ${PREVIEW_SIZE_BYTES.toLocaleString()} characters`,
+      );
+    });
+  });
+
+  describe("getToolResultsDir", () => {
+    it("should create directory with mkdirSync recursive", () => {
+      const dir = getToolResultsDir();
+      expect(dir).toBe("/tmp/wave-tool-results");
+      expect(fs.mkdirSync).toHaveBeenCalledWith("/tmp/wave-tool-results", {
+        recursive: true,
+      });
+    });
+
+    it("should use os.tmpdir() as base path", () => {
+      const dir = getToolResultsDir();
+      expect(dir.startsWith("/tmp/")).toBe(true);
+      expect(dir).toContain("wave-tool-results");
+    });
+  });
+
+  describe("persistToolResult", () => {
+    it("should write content to a file and return the path", () => {
+      const content = "test output";
+      const result = persistToolResult(content, "bash");
+
+      expect(result).toMatch(
+        /\/tmp\/wave-tool-results\/bash_\d+_[a-z0-9]+\.txt$/,
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining("/tmp/wave-tool-results/bash_"),
+        content,
+        "utf8",
+      );
+    });
+
+    it("should use default prefix 'tool' when none provided", () => {
+      const result = persistToolResult("content");
+      expect(result).toMatch(
+        /\/tmp\/wave-tool-results\/tool_\d+_[a-z0-9]+\.txt$/,
+      );
+    });
+
+    it("should return undefined on write failure", () => {
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {
+        throw new Error("disk full");
+      });
+
+      const result = persistToolResult("content", "bash");
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined when mkdirSync fails", () => {
+      vi.mocked(fs.mkdirSync).mockImplementation(() => {
+        throw new Error("permission denied");
+      });
+
+      const result = persistToolResult("content", "bash");
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("processToolResult", () => {
+    it("should return content unchanged when under maxChars", () => {
+      const content = "small result";
+      expect(processToolResult(content, 1000)).toBe(content);
+    });
+
+    it("should return content unchanged when exactly at maxChars", () => {
+      const content = "a".repeat(DEFAULT_MAX_RESULT_SIZE_CHARS);
+      expect(processToolResult(content)).toBe(content);
+    });
+
+    it("should persist and return wrapper when content exceeds maxChars", () => {
+      const content = "x".repeat(100);
+      const result = processToolResult(content, 50, "bash");
+
+      expect(result).toContain("<persisted-output>");
+      expect(result).toContain("100 characters");
+      expect(result).toContain("/tmp/wave-tool-results/bash_");
+      expect(result).toContain("</persisted-output>");
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining("bash_"),
+        content,
+        "utf8",
+      );
+    });
+
+    it("should use default maxChars when not specified", () => {
+      const content = "a".repeat(DEFAULT_MAX_RESULT_SIZE_CHARS + 1);
+      const result = processToolResult(content);
+
+      expect(result).toContain("<persisted-output>");
+      expect(result).toContain(
+        `${(DEFAULT_MAX_RESULT_SIZE_CHARS + 1).toLocaleString()} characters`,
+      );
+    });
+
+    it("should include preview in the wrapper", () => {
+      const content = "a".repeat(100);
+      const result = processToolResult(content, 50, "tool");
+
+      // Preview should be first PREVIEW_SIZE_BYTES chars + "\n..."
+      // But since content is only 100 chars and PREVIEW_SIZE_BYTES is 2048,
+      // the preview will be the full content (under preview size)
+      expect(result).toContain(content);
+    });
+
+    it("should fall back to truncation when persistence fails", () => {
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {
+        throw new Error("write failed");
+      });
+
+      const content = "a".repeat(100);
+      const result = processToolResult(content, 50, "bash");
+
+      expect(result).toContain("a".repeat(50));
+      expect(result).toContain(
+        "... (output truncated, failed to persist full output)",
+      );
+      expect(result).not.toContain("<persisted-output>");
+    });
+
+    it("should use default prefix 'tool' when none provided", () => {
+      const content = "a".repeat(100);
+      processToolResult(content, 50);
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining("/tmp/wave-tool-results/tool_"),
+        content,
+        "utf8",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Port MCP large result handling feature from main (PR #1149) to `feature/sdd`, adapted for the divergent branch architecture.

### New files
- `constants/toolLimits.ts` — Shared size constants (`DEFAULT_MAX_RESULT_SIZE_CHARS=50K`, `BASH_MAX_OUTPUT_CHARS=30K`, `PREVIEW_SIZE_BYTES=2048`)
- `utils/toolResultStorage.ts` — Shared persistence utility: `processToolResult()`, `persistToolResult()`, `generatePreview()`, `buildPersistedOutputMessage()`
- `tests/utils/toolResultStorage.test.ts` — 20 tests
- `tests/utils/mcpUtils.test.ts` — 9 tests (including MCP size limiting)

### Modified files
- `utils/mcpUtils.ts` — `createMcpToolPlugin()` processes results through `processToolResult()` with 50K char threshold, preserves `images` array
- `tools/bashTool.ts` — Replaced inline `MAX_OUTPUT_LENGTH` truncation with `processToolResult()` + `BASH_MAX_OUTPUT_CHARS` constant; large output now persists to file instead of silent truncation
- `managers/mcpManager.ts` — `JSON.stringify(c)` → `JSON.stringify(c, null, 2)` for readable persisted JSON files

### Key behavior changes
- **MCP tools**: results >50K chars persisted to `/tmp/wave-tool-results/` with `<persisted-output>` XML preview
- **Bash tools**: results >30K chars persisted to file (instead of truncation), model can read full output with Read tool
- **MCP JSON content**: pretty-printed so persisted files have proper line breaks

### Adaptations from main
- Kept existing `backgroundBashManager` architecture (main uses `backgroundTaskManager` with CWD tracking)
- Kept existing prompt structure (main uses separate `prompt()` function)
- bashOutputTool truncation also migrated to `processToolResult()`

### Test results
- 56 tests passing across 4 test files
- Type check and lint clean