### PR TITLE
feat(sessions): use timestamp-prefixed session IDs for sortable JSONL files

### DIFF
--- a/packages/agent-sdk/src/services/jsonlHandler.ts
+++ b/packages/agent-sdk/src/services/jsonlHandler.ts
@@ -229,7 +229,19 @@ export class JsonlHandler {
     // Extract filename from path
     const filename = filePath.split("/").pop() || "";
 
-    // Check if it's a subagent session
+    // New timestamp-prefixed format
+    const newSubagentMatch = filename.match(
+      /^subagent-(\d{14}-[0-9a-f]{8})\.jsonl$/,
+    );
+    if (newSubagentMatch) {
+      return { sessionId: newSubagentMatch[1], sessionType: "subagent" };
+    }
+    const newMainMatch = filename.match(/^(\d{14}-[0-9a-f]{8})\.jsonl$/);
+    if (newMainMatch) {
+      return { sessionId: newMainMatch[1], sessionType: "main" };
+    }
+
+    // Old UUID format (backward compat)
     const subagentMatch = filename.match(
       /^subagent-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/,
     );
@@ -240,7 +252,6 @@ export class JsonlHandler {
       };
     }
 
-    // Check if it's a main session
     const mainMatch = filename.match(
       /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/,
     );
@@ -260,18 +271,26 @@ export class JsonlHandler {
    * @returns True if valid, false otherwise
    */
   isValidSessionFilename(filename: string): boolean {
-    // UUID validation patterns
+    // New timestamp-prefixed format patterns
+    const newFormatPattern = /^(\d{14}-[0-9a-f]{8})\.jsonl$/;
+    const newSubagentPattern = /^subagent-(\d{14}-[0-9a-f]{8})\.jsonl$/;
+    // Old UUID format patterns (backward compat)
     const uuidPattern =
       /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/;
     const subagentPattern =
       /^subagent-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/;
 
-    return uuidPattern.test(filename) || subagentPattern.test(filename);
+    return (
+      newFormatPattern.test(filename) ||
+      newSubagentPattern.test(filename) ||
+      uuidPattern.test(filename) ||
+      subagentPattern.test(filename)
+    );
   }
 
   /**
    * Generate simple filename for sessions
-   * @param sessionId - UUID session identifier
+   * @param sessionId - Session identifier (timestamp-prefixed or legacy UUID format)
    * @param sessionType - Type of session ("main" or "subagent")
    * @returns Generated filename
    */
@@ -279,10 +298,11 @@ export class JsonlHandler {
     sessionId: string,
     sessionType: "main" | "subagent",
   ): string {
-    // Validate sessionId is a valid UUID
+    // Validate sessionId is either new timestamp-prefixed format or legacy UUID
+    const newFormatPattern = /^\d{14}-[0-9a-f]{8}$/;
     const uuidPattern =
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-    if (!uuidPattern.test(sessionId)) {
+    if (!newFormatPattern.test(sessionId) && !uuidPattern.test(sessionId)) {
       throw new Error(`Invalid session ID format: ${sessionId}`);
     }
 

--- a/packages/agent-sdk/src/services/session.ts
+++ b/packages/agent-sdk/src/services/session.ts
@@ -59,11 +59,22 @@ export interface SessionIndex {
 }
 
 /**
- * Generate a new session ID using Node.js native crypto.randomUUID()
- * @returns UUID string for session identification
+ * Generate a new session ID with a timestamp prefix for sortability
+ * Format: {YYYYMMDDHHmmss}-{8hex} (e.g. 20260527143025-a1b2c3d4)
+ * @returns Timestamp-prefixed session ID string
  */
 export function generateSessionId(): string {
-  return randomUUID();
+  const now = new Date();
+  const ts = [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, "0"),
+    String(now.getDate()).padStart(2, "0"),
+    String(now.getHours()).padStart(2, "0"),
+    String(now.getMinutes()).padStart(2, "0"),
+    String(now.getSeconds()).padStart(2, "0"),
+  ].join("");
+  const shortId = randomUUID().slice(0, 8);
+  return `${ts}-${shortId}`;
 }
 
 /**
@@ -472,15 +483,17 @@ export async function listSessionsFromJsonl(
       try {
         const filePath = join(projectDir.encodedPath, file);
 
-        // Validate main session filename format (UUID.jsonl)
+        // Validate main session filename format (new timestamp format or legacy UUID)
+        const newFormatMatch = file.match(/^(\d{14}-[0-9a-f]{8})\.jsonl$/);
         const uuidMatch = file.match(
           /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/,
         );
-        if (!uuidMatch) {
+        const match = newFormatMatch || uuidMatch;
+        if (!match) {
           continue; // Skip invalid filenames
         }
 
-        const sessionId = uuidMatch[1];
+        const sessionId = match[1];
 
         // PERFORMANCE OPTIMIZATION: Only read the last message for timestamps and tokens
         const jsonlHandler = new JsonlHandler();
@@ -667,17 +680,24 @@ export async function cleanupExpiredSessionsFromJsonl(
             );
             const indexContent = await fs.readFile(indexPath, "utf8");
             const index = JSON.parse(indexContent) as SessionIndex;
+            // New timestamp-prefixed format patterns
+            const newMainMatch = file.match(/^(\d{14}-[0-9a-f]{8})\.jsonl$/);
+            const newSubagentMatch = file.match(
+              /^subagent-(\d{14}-[0-9a-f]{8})\.jsonl$/,
+            );
+            // Old UUID format patterns (backward compat)
             const uuidMatch = file.match(
-              /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/,
+              /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/,
             );
             const subagentMatch = file.match(
-              /^subagent-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/,
+              /^subagent-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/,
             );
-            const sessionId = uuidMatch
-              ? uuidMatch[1]
-              : subagentMatch
-                ? subagentMatch[1]
-                : null;
+            const sessionId =
+              newMainMatch?.[1] ??
+              newSubagentMatch?.[1] ??
+              uuidMatch?.[1] ??
+              subagentMatch?.[1] ??
+              null;
 
             if (sessionId && index.sessions[sessionId]) {
               delete index.sessions[sessionId];

--- a/packages/agent-sdk/tests/services/jsonlHandler.test.ts
+++ b/packages/agent-sdk/tests/services/jsonlHandler.test.ts
@@ -555,7 +555,7 @@ describe("JsonlHandler.createSession() - TDD Tests for User Story 1", () => {
   describe("Session creation without metadata header", () => {
     it("should create session file without metadata header", async () => {
       // Create session using the NEW simplified API
-      const sessionId = "12345678-1234-1234-1234-123456789abc";
+      const sessionId = "20260527143025-a1b2c3d4";
       const sessionType = "main";
       const filePath = `/test/sessions/${handler.generateSessionFilename(sessionId, sessionType)}`;
 
@@ -572,7 +572,7 @@ describe("JsonlHandler.createSession() - TDD Tests for User Story 1", () => {
     });
 
     it("should create session file that is initially empty and ready for messages", async () => {
-      const sessionId = "12345678-1234-1234-1234-123456789abc";
+      const sessionId = "20260527143025-a1b2c3d4";
       const filePath = `/test/sessions/${handler.generateSessionFilename(sessionId, "main")}`;
 
       await handler.createSession(filePath);
@@ -589,7 +589,7 @@ describe("JsonlHandler.createSession() - TDD Tests for User Story 1", () => {
     });
 
     it("should create subagent session file without metadata header", async () => {
-      const sessionId = "87654321-4321-4321-4321-abcdef123456";
+      const sessionId = "20260527143025-a1b2c3d4";
       const filePath = `/test/sessions/${handler.generateSessionFilename(sessionId, "subagent")}`;
 
       await handler.createSession(filePath);
@@ -602,7 +602,7 @@ describe("JsonlHandler.createSession() - TDD Tests for User Story 1", () => {
 
   describe("Session file contains only messages after creation", () => {
     it("should contain only messages after creation and adding messages", async () => {
-      const sessionId = "11111111-2222-3333-4444-555555555555";
+      const sessionId = "20260527143025-a1b2c3d4";
       const filePath = `/test/sessions/${handler.generateSessionFilename(sessionId, "main")}`;
 
       // Create session
@@ -675,7 +675,7 @@ describe("JsonlHandler.createSession() - TDD Tests for User Story 1", () => {
 
   describe("Error handling in new session creation", () => {
     it("should handle directory creation errors gracefully", async () => {
-      const sessionId = "12345678-1234-1234-1234-123456789abc";
+      const sessionId = "20260527143025-a1b2c3d4";
       const filePath = `/test/sessions/${handler.generateSessionFilename(sessionId, "main")}`;
 
       // Mock mkdir to fail with permission error
@@ -687,7 +687,7 @@ describe("JsonlHandler.createSession() - TDD Tests for User Story 1", () => {
     });
 
     it("should handle file creation errors gracefully", async () => {
-      const sessionId = "12345678-1234-1234-1234-123456789abc";
+      const sessionId = "20260527143025-a1b2c3d4";
       const filePath = `/test/sessions/${handler.generateSessionFilename(sessionId, "main")}`;
 
       // Mock writeFile to fail
@@ -743,6 +743,28 @@ describe("JsonlHandler filename utilities", () => {
           sessionType: "main",
         });
       });
+
+      it("should parse new timestamp-prefixed main session filename", () => {
+        const result = handler.parseSessionFilename(
+          "/path/to/20260527143025-a1b2c3d4.jsonl",
+        );
+
+        expect(result).toEqual({
+          sessionId: "20260527143025-a1b2c3d4",
+          sessionType: "main",
+        });
+      });
+
+      it("should parse new timestamp-prefixed main session from just filename", () => {
+        const result = handler.parseSessionFilename(
+          "20260101000000-deadbeef.jsonl",
+        );
+
+        expect(result).toEqual({
+          sessionId: "20260101000000-deadbeef",
+          sessionType: "main",
+        });
+      });
     });
 
     describe("Subagent session filename parsing", () => {
@@ -775,6 +797,28 @@ describe("JsonlHandler filename utilities", () => {
 
         expect(result).toEqual({
           sessionId: "11111111-2222-3333-4444-555555555555",
+          sessionType: "subagent",
+        });
+      });
+
+      it("should parse new timestamp-prefixed subagent session filename", () => {
+        const result = handler.parseSessionFilename(
+          "/path/to/subagent-20260527143025-a1b2c3d4.jsonl",
+        );
+
+        expect(result).toEqual({
+          sessionId: "20260527143025-a1b2c3d4",
+          sessionType: "subagent",
+        });
+      });
+
+      it("should parse new timestamp-prefixed subagent session from just filename", () => {
+        const result = handler.parseSessionFilename(
+          "subagent-20260101000000-deadbeef.jsonl",
+        );
+
+        expect(result).toEqual({
+          sessionId: "20260101000000-deadbeef",
           sessionType: "subagent",
         });
       });
@@ -822,6 +866,9 @@ describe("JsonlHandler filename utilities", () => {
           "abcdef12-3456-789a-bcde-f123456789ab.jsonl",
           "11111111-2222-3333-4444-555555555555.jsonl",
           "ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb.jsonl",
+          // New timestamp-prefixed format
+          "20260527143025-a1b2c3d4.jsonl",
+          "20260101000000-deadbeef.jsonl",
         ];
 
         validMainFilenames.forEach((filename) => {
@@ -835,6 +882,9 @@ describe("JsonlHandler filename utilities", () => {
           "subagent-abcdef12-3456-789a-bcde-f123456789ab.jsonl",
           "subagent-11111111-2222-3333-4444-555555555555.jsonl",
           "subagent-ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb.jsonl",
+          // New timestamp-prefixed format
+          "subagent-20260527143025-a1b2c3d4.jsonl",
+          "subagent-20260101000000-deadbeef.jsonl",
         ];
 
         validSubagentFilenames.forEach((filename) => {
@@ -857,18 +907,21 @@ describe("JsonlHandler filename utilities", () => {
         });
       });
 
-      it("should reject filenames with invalid UUID formats", () => {
-        const invalidUuidFilenames = [
+      it("should reject filenames with invalid session ID formats", () => {
+        const invalidFilenames = [
           "invalid-uuid.jsonl",
-          "12345678-1234-1234-1234.jsonl", // Too short
-          "12345678-1234-1234-1234-123456789abcd.jsonl", // Too long
+          "12345678-1234-1234-1234.jsonl", // Too short for UUID
+          "12345678-1234-1234-1234-123456789abcd.jsonl", // Too long for UUID
           "12345678-1234-1234-1234-123456789abg.jsonl", // Invalid hex char
           "12345678123412341234123456789abc.jsonl", // Missing hyphens
           "subagent-invalid-uuid.jsonl",
           "subagent-12345678-1234-1234-1234.jsonl", // Too short
+          "20260527-a1b2c3d4.jsonl", // Not enough timestamp digits
+          "20260527143025-a1b2c3d4e5f6.jsonl", // Too many hex chars
+          "subagent-2026052-a1b2c3d4.jsonl", // Not enough timestamp digits
         ];
 
-        invalidUuidFilenames.forEach((filename) => {
+        invalidFilenames.forEach((filename) => {
           expect(handler.isValidSessionFilename(filename)).toBe(false);
         });
       });
@@ -907,6 +960,9 @@ describe("JsonlHandler filename utilities", () => {
           "12345678-1234-1234-1234-123456789abc",
           "abcdef12-3456-789a-bcde-f123456789ab",
           "11111111-2222-3333-4444-555555555555",
+          // New timestamp-prefixed format
+          "20260527143025-a1b2c3d4",
+          "20260101000000-deadbeef",
         ];
 
         sessionIds.forEach((sessionId) => {
@@ -937,7 +993,7 @@ describe("JsonlHandler filename utilities", () => {
 
   describe("generateSessionFilename() - TDD Tests for User Story 1", () => {
     describe("Main session filename generation", () => {
-      it("should generate correct main session filename format", () => {
+      it("should generate correct main session filename format (UUID)", () => {
         const sessionId = "12345678-1234-1234-1234-123456789abc";
         const result = handler.generateSessionFilename(sessionId, "main");
 
@@ -946,6 +1002,14 @@ describe("JsonlHandler filename utilities", () => {
         expect(result).toMatch(
           /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
         );
+      });
+
+      it("should generate correct main session filename format (new timestamp-prefixed)", () => {
+        const sessionId = "20260527143025-a1b2c3d4";
+        const result = handler.generateSessionFilename(sessionId, "main");
+
+        expect(result).toBe("20260527143025-a1b2c3d4.jsonl");
+        expect(result).toMatch(/^\d{14}-[0-9a-f]{8}\.jsonl$/);
       });
 
       it("should generate unique filenames for different session IDs", () => {
@@ -961,7 +1025,12 @@ describe("JsonlHandler filename utilities", () => {
       });
 
       it("should validate session ID format for main sessions", () => {
-        // Valid UUID formats should work
+        // Valid new timestamp-prefixed formats should work
+        expect(() => {
+          handler.generateSessionFilename("20260527143025-a1b2c3d4", "main");
+        }).not.toThrow();
+
+        // Valid legacy UUID formats should also work
         expect(() => {
           handler.generateSessionFilename(
             "12345678-1234-1234-1234-123456789abc",
@@ -985,7 +1054,7 @@ describe("JsonlHandler filename utilities", () => {
     });
 
     describe("Subagent session filename generation", () => {
-      it("should generate correct subagent session filename format", () => {
+      it("should generate correct subagent session filename format (UUID)", () => {
         const sessionId = "87654321-4321-4321-4321-abcdef123456";
         const result = handler.generateSessionFilename(sessionId, "subagent");
 
@@ -996,6 +1065,14 @@ describe("JsonlHandler filename utilities", () => {
         expect(result).toMatch(
           /^subagent-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
         );
+      });
+
+      it("should generate correct subagent session filename format (new timestamp-prefixed)", () => {
+        const sessionId = "20260527143025-a1b2c3d4";
+        const result = handler.generateSessionFilename(sessionId, "subagent");
+
+        expect(result).toBe("subagent-20260527143025-a1b2c3d4.jsonl");
+        expect(result).toMatch(/^subagent-\d{14}-[0-9a-f]{8}\.jsonl$/);
       });
 
       it("should generate unique filenames for different subagent session IDs", () => {
@@ -1015,7 +1092,15 @@ describe("JsonlHandler filename utilities", () => {
       });
 
       it("should validate session ID format for subagent sessions", () => {
-        // Valid UUID formats should work
+        // Valid new timestamp-prefixed formats should work
+        expect(() => {
+          handler.generateSessionFilename(
+            "20260527143025-a1b2c3d4",
+            "subagent",
+          );
+        }).not.toThrow();
+
+        // Valid legacy UUID formats should also work
         expect(() => {
           handler.generateSessionFilename(
             "12345678-1234-1234-1234-123456789abc",
@@ -1032,7 +1117,7 @@ describe("JsonlHandler filename utilities", () => {
 
     describe("Session type differentiation", () => {
       it("should generate different filenames for main vs subagent with same session ID", () => {
-        const sessionId = "12345678-1234-1234-1234-123456789abc";
+        const sessionId = "20260527143025-a1b2c3d4";
 
         const mainFilename = handler.generateSessionFilename(sessionId, "main");
         const subagentFilename = handler.generateSessionFilename(
@@ -1040,15 +1125,13 @@ describe("JsonlHandler filename utilities", () => {
           "subagent",
         );
 
-        expect(mainFilename).toBe("12345678-1234-1234-1234-123456789abc.jsonl");
-        expect(subagentFilename).toBe(
-          "subagent-12345678-1234-1234-1234-123456789abc.jsonl",
-        );
+        expect(mainFilename).toBe("20260527143025-a1b2c3d4.jsonl");
+        expect(subagentFilename).toBe("subagent-20260527143025-a1b2c3d4.jsonl");
         expect(mainFilename).not.toBe(subagentFilename);
       });
 
       it("should enable session type identification from filename alone", () => {
-        const sessionId = "99999999-9999-9999-9999-999999999999";
+        const sessionId = "20260527143025-99999999";
 
         const mainFilename = handler.generateSessionFilename(sessionId, "main");
         const subagentFilename = handler.generateSessionFilename(
@@ -1071,7 +1154,15 @@ describe("JsonlHandler filename utilities", () => {
     });
 
     describe("Edge cases and validation", () => {
-      it("should handle mixed case UUID properly", () => {
+      it("should handle mixed case in new format (lowercase hex)", () => {
+        // New format uses lowercase hex in the 8-char suffix
+        const sessionId = "20260527143025-a1b2c3d4";
+
+        const result = handler.generateSessionFilename(sessionId, "main");
+        expect(result).toBe("20260527143025-a1b2c3d4.jsonl");
+      });
+
+      it("should handle mixed case UUID properly (legacy format)", () => {
         const mixedCaseId = "AbCdEf12-3456-789A-BcDe-F123456789AB";
         const lowercaseId = mixedCaseId.toLowerCase();
 
@@ -1080,13 +1171,16 @@ describe("JsonlHandler filename utilities", () => {
         expect(result).toBe("abcdef12-3456-789a-bcde-f123456789ab.jsonl");
       });
 
-      it("should reject non-UUID strings", () => {
+      it("should reject non-session-ID strings", () => {
         const invalidIds = [
-          "not-a-uuid",
-          "12345678-1234-1234-1234-123456789abg", // Invalid hex character
-          "12345678-1234-1234-1234-123456789ab", // Too short
-          "12345678-1234-1234-1234-123456789abcd", // Too long
-          "12345678123412341234123456789abc", // Missing hyphens
+          "not-a-session-id",
+          "12345678-1234-1234-1234-123456789abg", // Invalid hex character (UUID)
+          "12345678-1234-1234-1234-123456789ab", // Too short (UUID)
+          "12345678-1234-1234-1234-123456789abcd", // Too long (UUID)
+          "12345678123412341234123456789abc", // Missing hyphens (UUID)
+          "20260527-a1b2c3d4", // Not enough timestamp digits
+          "20260527143025-a1b2c3d4e5f6", // Too many hex chars
+          "20260527143025-ABCDEF12", // Uppercase hex not allowed in new format
         ];
 
         invalidIds.forEach((invalidId) => {
@@ -1101,35 +1195,29 @@ describe("JsonlHandler filename utilities", () => {
   describe("TDD Tests for User Story 2: Subagent Filename Generation - T019", () => {
     describe("Subagent filename generation tests", () => {
       it("should generate subagent filename with correct prefix format", () => {
-        const sessionId = "12345678-1234-1234-1234-123456789abc";
+        const sessionId = "20260527143025-a1b2c3d4";
         const result = handler.generateSessionFilename(sessionId, "subagent");
 
         // Should follow pattern: subagent-{sessionId}.jsonl
-        expect(result).toBe(
-          "subagent-12345678-1234-1234-1234-123456789abc.jsonl",
-        );
+        expect(result).toBe("subagent-20260527143025-a1b2c3d4.jsonl");
         expect(result.startsWith("subagent-")).toBe(true);
         expect(result.endsWith(".jsonl")).toBe(true);
       });
 
       it("should generate different subagent filenames for different session IDs", () => {
-        const sessionId1 = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
-        const sessionId2 = "11111111-2222-3333-4444-555555555555";
+        const sessionId1 = "20260527143025-aaaaaaaa";
+        const sessionId2 = "20260527143026-bbbbbbbb";
 
         const result1 = handler.generateSessionFilename(sessionId1, "subagent");
         const result2 = handler.generateSessionFilename(sessionId2, "subagent");
 
-        expect(result1).toBe(
-          "subagent-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl",
-        );
-        expect(result2).toBe(
-          "subagent-11111111-2222-3333-4444-555555555555.jsonl",
-        );
+        expect(result1).toBe("subagent-20260527143025-aaaaaaaa.jsonl");
+        expect(result2).toBe("subagent-20260527143026-bbbbbbbb.jsonl");
         expect(result1).not.toBe(result2);
       });
 
       it("should maintain consistency between main and subagent filename generation", () => {
-        const sessionId = "87654321-4321-4321-4321-abcdef123456";
+        const sessionId = "20260527143025-a1b2c3d4";
 
         const mainFilename = handler.generateSessionFilename(sessionId, "main");
         const subagentFilename = handler.generateSessionFilename(
@@ -1146,8 +1234,16 @@ describe("JsonlHandler filename utilities", () => {
         expect(handler.isValidSessionFilename(subagentFilename)).toBe(true);
       });
 
-      it("should validate UUID format for subagent session generation", () => {
-        // Valid UUID should work
+      it("should validate session ID format for subagent session generation", () => {
+        // Valid new timestamp-prefixed format should work
+        expect(() => {
+          handler.generateSessionFilename(
+            "20260527143025-a1b2c3d4",
+            "subagent",
+          );
+        }).not.toThrow();
+
+        // Valid legacy UUID should also work
         expect(() => {
           handler.generateSessionFilename(
             "12345678-1234-1234-1234-123456789abc",
@@ -1155,11 +1251,11 @@ describe("JsonlHandler filename utilities", () => {
           );
         }).not.toThrow();
 
-        // Invalid UUIDs should throw
+        // Invalid IDs should throw
         const invalidIds = [
           "invalid-subagent-id",
-          "12345678-1234-1234-1234", // Too short
-          "12345678-1234-1234-1234-123456789abcd", // Too long
+          "12345678-1234-1234-1234", // Too short for UUID
+          "12345678-1234-1234-1234-123456789abcd", // Too long for UUID
           "12345678123412341234123456789abc", // Missing hyphens
           "",
         ];
@@ -1176,25 +1272,23 @@ describe("JsonlHandler filename utilities", () => {
       it("should parse subagent filename correctly", () => {
         const testCases = [
           {
-            filePath:
-              "/path/to/subagent-12345678-1234-1234-1234-123456789abc.jsonl",
+            filePath: "/path/to/subagent-20260527143025-a1b2c3d4.jsonl",
             expected: {
-              sessionId: "12345678-1234-1234-1234-123456789abc",
+              sessionId: "20260527143025-a1b2c3d4",
               sessionType: "subagent" as const,
             },
           },
           {
-            filePath:
-              "sessions/subagent-87654321-4321-4321-4321-abcdef123456.jsonl",
+            filePath: "sessions/subagent-20260101000000-deadbeef.jsonl",
             expected: {
-              sessionId: "87654321-4321-4321-4321-abcdef123456",
+              sessionId: "20260101000000-deadbeef",
               sessionType: "subagent" as const,
             },
           },
           {
-            filePath: "subagent-ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb.jsonl",
+            filePath: "subagent-20260527143025-ffffffff.jsonl",
             expected: {
-              sessionId: "ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb",
+              sessionId: "20260527143025-ffffffff",
               sessionType: "subagent" as const,
             },
           },
@@ -1207,7 +1301,7 @@ describe("JsonlHandler filename utilities", () => {
       });
 
       it("should parse main vs subagent filename formats correctly", () => {
-        const sessionId = "12345678-1234-1234-1234-123456789abc";
+        const sessionId = "20260527143025-a1b2c3d4";
 
         const mainResult = handler.parseSessionFilename(`${sessionId}.jsonl`);
         const subagentResult = handler.parseSessionFilename(
@@ -1228,9 +1322,9 @@ describe("JsonlHandler filename utilities", () => {
       it("should handle parsing edge cases and invalid formats", () => {
         const invalidFilenames = [
           "agent-12345678-1234-1234-1234-123456789abc.jsonl", // Wrong prefix
-          "subagent-invalid-uuid.jsonl", // Invalid UUID
-          "subagent-12345678-1234-1234-1234.jsonl", // Too short UUID
-          "subagent-.jsonl", // Empty UUID
+          "subagent-invalid-uuid.jsonl", // Invalid session ID
+          "subagent-12345678-1234-1234-1234.jsonl", // Too short for both formats
+          "subagent-.jsonl", // Empty session ID
           "subagent-12345678-1234-1234-1234-123456789abc.txt", // Wrong extension
         ];
 
@@ -1249,6 +1343,9 @@ describe("JsonlHandler filename utilities", () => {
           "subagent-87654321-4321-4321-4321-abcdef123456.jsonl",
           "subagent-ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb.jsonl",
           "subagent-00000000-0000-0000-0000-000000000000.jsonl",
+          // New timestamp-prefixed format
+          "subagent-20260527143025-a1b2c3d4.jsonl",
+          "subagent-20260101000000-deadbeef.jsonl",
         ];
 
         validSubagentFilenames.forEach((filename) => {
@@ -1260,13 +1357,15 @@ describe("JsonlHandler filename utilities", () => {
         const invalidSubagentFilenames = [
           "agent-12345678-1234-1234-1234-123456789abc.jsonl", // Wrong prefix
           "sub-12345678-1234-1234-1234-123456789abc.jsonl", // Wrong prefix
-          "subagent-invalid-uuid.jsonl", // Invalid UUID
-          "subagent-12345678-1234-1234-1234.jsonl", // UUID too short
+          "subagent-invalid-uuid.jsonl", // Invalid session ID
+          "subagent-12345678-1234-1234-1234.jsonl", // Too short for both formats
           "subagent-12345678-1234-1234-1234-123456789abcd.jsonl", // UUID too long
           "subagent-12345678-1234-1234-1234-123456789abg.jsonl", // Invalid hex char
           "subagent-12345678123412341234123456789abc.jsonl", // Missing hyphens
           "subagent-12345678-1234-1234-1234-123456789abc.txt", // Wrong extension
           "subagent-12345678-1234-1234-1234-123456789abc", // Missing extension
+          "subagent-20260527-a1b2c3d4.jsonl", // Not enough timestamp digits
+          "subagent-20260527143025-a1b2c3d4e5f6.jsonl", // Too many hex chars
         ];
 
         invalidSubagentFilenames.forEach((filename) => {
@@ -1280,6 +1379,9 @@ describe("JsonlHandler filename utilities", () => {
           "87654321-4321-4321-4321-abcdef123456",
           "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
           "ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb",
+          // New timestamp-prefixed format
+          "20260527143025-a1b2c3d4",
+          "20260101000000-deadbeef",
         ];
 
         sessionIds.forEach((sessionId) => {
@@ -1304,15 +1406,24 @@ describe("JsonlHandler filename utilities", () => {
       it("should identify session type from filename pattern alone", () => {
         const testFilenames = [
           {
-            filename: "12345678-1234-1234-1234-123456789abc.jsonl",
+            filename: "20260527143025-a1b2c3d4.jsonl",
             expectedType: "main",
           },
           {
-            filename: "subagent-12345678-1234-1234-1234-123456789abc.jsonl",
+            filename: "subagent-20260527143025-a1b2c3d4.jsonl",
             expectedType: "subagent",
           },
           {
-            filename: "87654321-4321-4321-4321-abcdef123456.jsonl",
+            filename: "20260101000000-deadbeef.jsonl",
+            expectedType: "main",
+          },
+          {
+            filename: "subagent-20260101000000-deadbeef.jsonl",
+            expectedType: "subagent",
+          },
+          // Legacy UUID format (backward compat)
+          {
+            filename: "12345678-1234-1234-1234-123456789abc.jsonl",
             expectedType: "main",
           },
           {
@@ -1335,11 +1446,14 @@ describe("JsonlHandler filename utilities", () => {
 
       it("should enable efficient session filtering by filename patterns", () => {
         const mixedSessionFiles = [
+          "20260527143025-a1b2c3d4.jsonl", // main (new format)
+          "subagent-20260527143025-a1b2c3d4.jsonl", // subagent (new format)
+          "20260101000000-deadbeef.jsonl", // main (new format)
+          "subagent-20260101000000-deadbeef.jsonl", // subagent (new format)
+          "20260527143026-11111111.jsonl", // main (new format)
+          // Legacy UUID format (backward compat)
           "12345678-1234-1234-1234-123456789abc.jsonl", // main
           "subagent-87654321-4321-4321-4321-abcdef123456.jsonl", // subagent
-          "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl", // main
-          "subagent-ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb.jsonl", // subagent
-          "11111111-2222-3333-4444-555555555555.jsonl", // main
         ];
 
         // Filter main sessions using filename pattern (no file reading needed)
@@ -1356,8 +1470,8 @@ describe("JsonlHandler filename utilities", () => {
             filename.startsWith("subagent-"),
         );
 
-        expect(mainSessions).toHaveLength(3);
-        expect(subagentSessions).toHaveLength(2);
+        expect(mainSessions).toHaveLength(4);
+        expect(subagentSessions).toHaveLength(3);
 
         // Verify correct categorization
         mainSessions.forEach((filename) => {
@@ -1375,12 +1489,15 @@ describe("JsonlHandler filename utilities", () => {
 
       it("should support session discovery without content inspection", () => {
         const sessionFiles = [
-          "12345678-1234-1234-1234-123456789abc.jsonl",
-          "subagent-87654321-4321-4321-4321-abcdef123456.jsonl",
+          "20260527143025-a1b2c3d4.jsonl",
+          "subagent-20260527143025-a1b2c3d4.jsonl",
           "invalid-filename.jsonl",
           "not-a-session.txt",
-          "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl",
-          "subagent-ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb.jsonl",
+          "20260101000000-deadbeef.jsonl",
+          "subagent-20260101000000-deadbeef.jsonl",
+          // Legacy UUID format
+          "12345678-1234-1234-1234-123456789abc.jsonl",
+          "subagent-87654321-4321-4321-4321-abcdef123456.jsonl",
         ];
 
         const discoveredSessions = sessionFiles
@@ -1394,10 +1511,10 @@ describe("JsonlHandler filename utilities", () => {
           })
           .filter((session) => session !== null);
 
-        // Should discover 4 valid sessions
-        expect(discoveredSessions).toHaveLength(4);
+        // Should discover 6 valid sessions
+        expect(discoveredSessions).toHaveLength(6);
 
-        // Should have 2 main and 2 subagent sessions
+        // Should have 3 main and 3 subagent sessions
         const mainCount = discoveredSessions.filter(
           (s) => s!.sessionType === "main",
         ).length;
@@ -1405,8 +1522,8 @@ describe("JsonlHandler filename utilities", () => {
           (s) => s!.sessionType === "subagent",
         ).length;
 
-        expect(mainCount).toBe(2);
-        expect(subagentCount).toBe(2);
+        expect(mainCount).toBe(3);
+        expect(subagentCount).toBe(3);
       });
     });
   });

--- a/packages/agent-sdk/tests/services/session.core.test.ts
+++ b/packages/agent-sdk/tests/services/session.core.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
-import { randomUUID } from "crypto";
 import { join } from "path";
 import { homedir } from "os";
 
@@ -254,20 +253,18 @@ describe("Session Core Functionality", () => {
     );
   });
 
-  describe("T016: crypto.randomUUID() Generation and Validation", () => {
-    it("should generate valid UUID format", () => {
+  describe("T016: generateSessionId() Generation and Validation", () => {
+    it("should generate valid timestamp-prefixed format", () => {
       const sessionId = generateSessionId();
 
-      // UUID v4 format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
-      // where y is 8, 9, A, or B (variant bits)
-      const uuidRegex =
-        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      // Timestamp-prefixed format: {YYYYMMDDHHmmss}-{8hex}
+      const timestampPrefixRegex = /^\d{14}-[0-9a-f]{8}$/;
 
-      expect(sessionId).toMatch(uuidRegex);
+      expect(sessionId).toMatch(timestampPrefixRegex);
       expect(sessionId).toBe(sessionId.toLowerCase());
     });
 
-    it("should generate different UUIDs on multiple calls", () => {
+    it("should generate different session IDs on multiple calls", () => {
       const id1 = generateSessionId();
       const id2 = generateSessionId();
       const id3 = generateSessionId();
@@ -277,59 +274,53 @@ describe("Session Core Functionality", () => {
       expect(id1).not.toBe(id3);
     });
 
-    it("should generate unique UUIDs", () => {
+    it("should generate unique session IDs", () => {
       const ids: string[] = [];
 
-      // Generate multiple UUIDs
+      // Generate multiple session IDs
       for (let i = 0; i < 10; i++) {
         ids.push(generateSessionId());
       }
 
-      // All UUIDs should be unique
+      // All session IDs should be unique
       const uniqueIds = new Set(ids);
       expect(uniqueIds.size).toBe(10);
 
-      // All should be valid UUID format
-      const uuidRegex =
-        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      // All should be valid timestamp-prefixed format
+      const timestampPrefixRegex = /^\d{14}-[0-9a-f]{8}$/;
       ids.forEach((id) => {
-        expect(id).toMatch(uuidRegex);
+        expect(id).toMatch(timestampPrefixRegex);
       });
     });
 
-    it("should validate UUID format using Node.js crypto", () => {
+    it("should validate session ID format correctly", () => {
       const validId = generateSessionId();
       const invalidIds = [
         "invalid-uuid",
-        "12345678-1234-6678-9abc-123456789012", // v6 format (we now use v4)
-        "12345678-1234-5678-9abc-123456789012", // v5 format
+        "12345678-1234-6678-9abc-123456789012", // Old UUID format (not new format)
+        "12345678-1234-5678-9abc-123456789012", // Old UUID format
         "",
-        "not-a-uuid-at-all",
+        "not-a-session-id-at-all",
+        "20260527143025-a1b2c3d4e5f6", // Too many hex chars
+        "20260527-a1b2c3d4", // Not enough digits
       ];
 
-      // Valid UUID should pass format validation
-      const uuidRegex =
-        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      // Valid session ID should pass format validation
+      const timestampPrefixRegex = /^\d{14}-[0-9a-f]{8}$/;
 
-      expect(validId).toMatch(uuidRegex);
-      expect(validId.length).toBe(36);
-      expect(() => randomUUID()).not.toThrow();
-      expect(validId).toBeTruthy();
-      expect(() => randomUUID()).not.toThrow();
+      expect(validId).toMatch(timestampPrefixRegex);
       expect(validId).toBeTruthy();
       expect(typeof validId).toBe("string");
 
-      // Invalid UUIDs should be rejected
+      // Invalid IDs should be rejected
       invalidIds.forEach((id) => {
-        expect(id).not.toMatch(
-          /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
-        );
+        expect(id).not.toMatch(/^\d{14}-[0-9a-f]{8}$/);
       });
     });
   });
 
   describe("T017: Integration test for session file naming", () => {
-    it("should create session files with clean UUID names", async () => {
+    it("should create session files with clean timestamp-prefixed names", async () => {
       const sessionId = generateSessionId();
       const filePath = await getSessionFilePath(sessionId, testWorkdir);
 
@@ -337,9 +328,7 @@ describe("Session Core Functionality", () => {
       // The session ID itself should not have session- or wave- prefixes
       expect(sessionId).not.toContain("session-");
       expect(sessionId).not.toContain("wave-");
-      expect(filePath).toMatch(
-        /[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.jsonl$/i,
-      );
+      expect(filePath).toMatch(/\d{14}-[0-9a-f]{8}\.jsonl$/);
     });
 
     it("should use .jsonl file extension", async () => {

--- a/packages/agent-sdk/tests/services/session.errors.test.ts
+++ b/packages/agent-sdk/tests/services/session.errors.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
-import { randomUUID } from "crypto";
 
 // Mock fs/promises (used by session.ts)
 vi.mock("fs", () => ({
@@ -54,6 +53,7 @@ vi.mock("@/utils/pathEncoder.js", () => ({
 }));
 
 import {
+  generateSessionId,
   listSessionsFromJsonl,
   getLatestSessionFromJsonl,
   loadSessionFromJsonl,
@@ -244,8 +244,8 @@ describe("Session Error Handling and Edge Cases", () => {
     });
 
     it("should handle getLatestSessionFromJsonl with directory separation based on last active time", async () => {
-      const olderMainSessionId = randomUUID();
-      const newerMainSessionId = randomUUID();
+      const olderMainSessionId = generateSessionId();
+      const newerMainSessionId = generateSessionId();
 
       // Create different timestamps - older session has more recent activity
       // Note: timestamps are used to simulate file creation order in this test
@@ -308,7 +308,7 @@ describe("Session Error Handling and Edge Cases", () => {
     });
 
     it("should support loading subagent sessions", async () => {
-      const subagentSessionId = randomUUID();
+      const subagentSessionId = generateSessionId();
 
       const messages = [
         {

--- a/packages/agent-sdk/tests/services/session.subagent.test.ts
+++ b/packages/agent-sdk/tests/services/session.subagent.test.ts
@@ -224,7 +224,7 @@ describe("Subagent Session Tests", () => {
     describe("generateSubagentFilename function (to be implemented)", () => {
       it("should generate subagent filename with correct prefix", () => {
         // This test validates expected functionality that should be implemented
-        const sessionId = "12345678-1234-1234-1234-123456789abc";
+        const sessionId = "20260527143025-a1b2c3d4";
 
         // Mock the expected generateSubagentFilename function call
         const expectedResult = `subagent-${sessionId}.jsonl`;
@@ -238,8 +238,8 @@ describe("Subagent Session Tests", () => {
       });
 
       it("should generate unique subagent filenames for different session IDs", () => {
-        const sessionId1 = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
-        const sessionId2 = "11111111-2222-3333-4444-555555555555";
+        const sessionId1 = "20260527143025-aaaaaaaa";
+        const sessionId2 = "20260527143026-bbbbbbbb";
 
         const result1 = mockJsonlHandler.generateSessionFilename(
           sessionId1,
@@ -256,20 +256,19 @@ describe("Subagent Session Tests", () => {
       });
 
       it("should validate session ID format for subagent filename generation", () => {
-        // Test with valid UUID
+        // Test with valid new format session ID
         expect(() => {
           mockJsonlHandler.generateSessionFilename(
-            "12345678-1234-1234-1234-123456789abc",
+            "20260527143025-a1b2c3d4",
             "subagent",
           );
         }).not.toThrow();
 
-        // Mock implementation should validate UUID format
+        // Mock implementation should validate timestamp-prefixed format
         mockJsonlHandler.generateSessionFilename.mockImplementation(
           (sessionId: string, sessionType: "main" | "subagent" = "main") => {
-            const uuidPattern =
-              /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-            if (!uuidPattern.test(sessionId)) {
+            const newFormatPattern = /^\d{14}-[0-9a-f]{8}$/;
+            if (!newFormatPattern.test(sessionId)) {
               throw new Error(`Invalid session ID format: ${sessionId}`);
             }
             return sessionType === "main"
@@ -278,10 +277,10 @@ describe("Subagent Session Tests", () => {
           },
         );
 
-        // Test with invalid UUIDs
+        // Test with invalid session IDs
         const invalidIds = [
           "invalid-id",
-          "12345678-1234-1234-1234", // Too short
+          "12345678-1234-1234-1234", // Too short for both formats
           "12345678-1234-1234-1234-123456789abcd", // Too long
           "",
         ];
@@ -316,7 +315,7 @@ describe("Subagent Session Tests", () => {
       });
 
       it("should distinguish subagent sessions from main sessions by filename", async () => {
-        const sessionId = "87654321-4321-4321-4321-abcdef123456";
+        const sessionId = "20260527143025-a1b2c3d4";
 
         // Test filename generation distinguishes session types
         const mainFilename = mockJsonlHandler.generateSessionFilename(
@@ -430,17 +429,21 @@ describe("Subagent Session Tests", () => {
 
       it("should support session filtering by type using filename patterns", () => {
         const sessionFiles = [
-          "12345678-1234-1234-1234-123456789abc.jsonl", // main
-          "subagent-87654321-4321-4321-4321-abcdef123456.jsonl", // subagent
-          "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl", // main
-          "subagent-ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb.jsonl", // subagent
+          "20260527143025-a1b2c3d4.jsonl", // main (new format)
+          "subagent-20260527143025-a1b2c3d4.jsonl", // subagent (new format)
+          "20260101000000-deadbeef.jsonl", // main (new format)
+          "subagent-20260101000000-deadbeef.jsonl", // subagent (new format)
+          "12345678-1234-1234-1234-123456789abc.jsonl", // main (legacy UUID format)
+          "subagent-87654321-4321-4321-4321-abcdef123456.jsonl", // subagent (legacy UUID format)
           "invalid-file.txt", // invalid
         ];
 
         // Filter sessions by type using filename patterns (no file reading)
         const mainSessionFiles = sessionFiles.filter((filename) => {
-          // Mock isValidSessionFilename behavior
+          // Mock isValidSessionFilename behavior - both new and legacy formats
           const validPatterns = [
+            /^\d{14}-[0-9a-f]{8}\.jsonl$/,
+            /^subagent-\d{14}-[0-9a-f]{8}\.jsonl$/,
             /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
             /^subagent-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
           ];
@@ -452,13 +455,15 @@ describe("Subagent Session Tests", () => {
         });
 
         const subagentSessionFiles = sessionFiles.filter((filename) => {
-          const validSubagentPattern =
-            /^subagent-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/;
-          return validSubagentPattern.test(filename);
+          const validSubagentPatterns = [
+            /^subagent-\d{14}-[0-9a-f]{8}\.jsonl$/,
+            /^subagent-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
+          ];
+          return validSubagentPatterns.some((p) => p.test(filename));
         });
 
-        expect(mainSessionFiles).toHaveLength(2);
-        expect(subagentSessionFiles).toHaveLength(2);
+        expect(mainSessionFiles).toHaveLength(3);
+        expect(subagentSessionFiles).toHaveLength(3);
 
         // Verify correct categorization
         mainSessionFiles.forEach((filename) => {
@@ -500,6 +505,8 @@ describe("Subagent Session Tests", () => {
         mockJsonlHandler.isValidSessionFilename.mockImplementation(
           (filename: string) => {
             const validPatterns = [
+              /^\d{14}-[0-9a-f]{8}\.jsonl$/,
+              /^subagent-\d{14}-[0-9a-f]{8}\.jsonl$/,
               /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
               /^subagent-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
             ];
@@ -550,15 +557,19 @@ describe("Subagent Session Tests", () => {
 
         // Filter using filename patterns (simulating efficient filtering)
         const mainSessions = sessionFiles.filter((filename) => {
-          const mainPattern =
-            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/;
-          return mainPattern.test(filename);
+          const mainPatterns = [
+            /^\d{14}-[0-9a-f]{8}\.jsonl$/,
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
+          ];
+          return mainPatterns.some((pattern) => pattern.test(filename));
         });
 
         const subagentSessions = sessionFiles.filter((filename) => {
-          const subagentPattern =
-            /^subagent-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/;
-          return subagentPattern.test(filename);
+          const subagentPatterns = [
+            /^subagent-\d{14}-[0-9a-f]{8}\.jsonl$/,
+            /^subagent-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
+          ];
+          return subagentPatterns.some((pattern) => pattern.test(filename));
         });
 
         // Verify filtering worked correctly
@@ -585,9 +596,9 @@ describe("Subagent Session Tests", () => {
 
         // Create test session files
         const sessionFiles = [
-          "12345678-1234-1234-1234-123456789abc.jsonl", // main
-          "subagent-87654321-4321-4321-4321-abcdef123456.jsonl", // subagent
-          "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl", // main
+          "20260527143025-a1b2c3d4.jsonl", // main (new format)
+          "subagent-20260527143025-a1b2c3d4.jsonl", // subagent (new format)
+          "20260101000000-deadbeef.jsonl", // main (new format)
         ];
 
         vi.mocked(fs.readdir).mockResolvedValue(
@@ -604,6 +615,8 @@ describe("Subagent Session Tests", () => {
         const validSessions = sessionFiles
           .filter((filename) => {
             const validPatterns = [
+              /^\d{14}-[0-9a-f]{8}\.jsonl$/,
+              /^subagent-\d{14}-[0-9a-f]{8}\.jsonl$/,
               /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
               /^subagent-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
             ];


### PR DESCRIPTION
Change session ID format from UUID to {YYYYMMDDHHmmss}-{8hex} so that
JSONL files sort chronologically in directory listings. Example:
20260527143025-a1b2c3d4.jsonl instead of
550e8400-e29b-41d4-a716-446655440000.jsonl

- Update generateSessionId() to produce timestamp-prefixed IDs
- Update regex patterns in session.ts and jsonlHandler.ts to match
  both new and legacy UUID formats for backward compatibility
- Update parseSessionFilename(), isValidSessionFilename(),
  generateSessionFilename() to handle both formats
- Update all related tests to validate new format while preserving
  backward compat tests for legacy UUID filenames
