### PR TITLE
feat(sdk): add subagentHeaders option to AgentOptions

### DIFF
--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -287,6 +287,10 @@ export class SubagentManager {
     if (parentOptions) {
       const subagentOptions: import("../types/agent.js").AgentOptions = {
         ...parentOptions,
+        defaultHeaders: {
+          ...parentOptions.defaultHeaders,
+          ...parentOptions.subagentHeaders?.[parameters.subagent_type],
+        },
         callbacks: {
           ...parentOptions.callbacks,
           onLoadingChange: undefined,

--- a/packages/agent-sdk/src/types/agent.ts
+++ b/packages/agent-sdk/src/types/agent.ts
@@ -30,6 +30,8 @@ export interface AgentOptions {
   /** Wave server URL for SSO authentication (fallback to WAVE_SERVER_URL env var) */
   serverUrl?: string;
   defaultHeaders?: Record<string, string>;
+  /** Per-subagent-type headers, merged into defaultHeaders for matching subagents */
+  subagentHeaders?: Record<string, Record<string, string>>;
   fetchOptions?: ClientOptions["fetchOptions"];
   fetch?: ClientOptions["fetch"];
   model?: string;

--- a/packages/agent-sdk/tests/managers/subagentManager.headers.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.headers.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Container } from "../../src/utils/container.js";
+import { SubagentManager } from "../../src/managers/subagentManager.js";
+import type { AgentOptions } from "../../src/types/agent.js";
+
+vi.mock("../../src/utils/subagentParser.js", () => ({
+  loadSubagentConfigurations: vi.fn().mockResolvedValue([
+    {
+      name: "test-agent",
+      description: "Test agent",
+      systemPrompt: "You are a test agent",
+      tools: [],
+      model: "test-model",
+    },
+  ]),
+  findSubagentByName: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../../src/managers/messageManager.js", () => ({
+  MessageManager: vi.fn().mockImplementation(function () {
+    return {
+      addUserMessage: vi.fn(),
+      getMessages: vi
+        .fn()
+        .mockReturnValue([
+          { role: "assistant", blocks: [{ type: "text", content: "done" }] },
+        ]),
+    };
+  }),
+}));
+
+vi.mock("../../src/managers/toolManager.js", () => ({
+  ToolManager: vi.fn().mockImplementation(function () {
+    return {
+      initializeBuiltInTools: vi.fn(),
+    };
+  }),
+}));
+
+vi.mock("../../src/services/configurationService.js", () => ({
+  ConfigurationService: vi.fn().mockImplementation(function () {
+    return {};
+  }),
+}));
+
+vi.mock("../../src/managers/permissionManager.js", () => ({
+  PermissionManager: vi.fn().mockImplementation(function () {
+    return {
+      getAllowedRules: vi.fn().mockReturnValue([]),
+      getDeniedRules: vi.fn().mockReturnValue(["agent"]),
+      getInstanceDeniedRules: vi.fn().mockReturnValue([]),
+      getInstanceAllowedRules: vi.fn().mockReturnValue([]),
+      getAdditionalDirectories: vi.fn().mockReturnValue([]),
+      getSystemAdditionalDirectories: vi.fn().mockReturnValue([]),
+      getConfiguredPermissionMode: vi.fn().mockReturnValue("ask"),
+      addTemporaryRules: vi.fn(),
+    };
+  }),
+}));
+
+// Capture the child container from AIManager constructor
+let capturedContainer: Container | undefined;
+
+vi.mock("../../src/managers/aiManager.js", () => ({
+  AIManager: vi.fn().mockImplementation(function (container: Container) {
+    capturedContainer = container;
+    return {
+      abortAIMessage: vi.fn(),
+      sendAIMessage: vi.fn().mockResolvedValue(undefined),
+    };
+  }),
+}));
+
+function getSubagentDefaultHeaders(): Record<string, string> | undefined {
+  if (!capturedContainer) return undefined;
+  const opts = capturedContainer.get<AgentOptions>("AgentOptions");
+  return opts?.defaultHeaders;
+}
+
+describe("SubagentManager subagentHeaders", () => {
+  let container: Container;
+  let subagentManager: SubagentManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedContainer = undefined;
+    container = new Container();
+    container.register("ToolManager", {
+      initializeBuiltInTools: vi.fn(),
+    });
+
+    subagentManager = new SubagentManager(container, {
+      workdir: "/tmp/test",
+      stream: false,
+    });
+  });
+
+  it("should merge subagentHeaders into subagent defaultHeaders", async () => {
+    const parentOptions: AgentOptions = {
+      defaultHeaders: { "X-Agent-Type": "main" },
+      subagentHeaders: {
+        Explore: { "X-Subagent-Type": "Explore" },
+      },
+    };
+    container.register("AgentOptions", parentOptions);
+
+    const config = (await subagentManager.loadConfigurations())[0];
+    await subagentManager.createInstance(config, {
+      description: "Test task",
+      prompt: "Explore something",
+      subagent_type: "Explore",
+    });
+
+    const headers = getSubagentDefaultHeaders();
+    expect(headers).toEqual({
+      "X-Agent-Type": "main",
+      "X-Subagent-Type": "Explore",
+    });
+  });
+
+  it("should not affect main agent defaultHeaders", async () => {
+    const parentOptions: AgentOptions = {
+      defaultHeaders: { "X-Agent-Type": "main" },
+      subagentHeaders: {
+        Explore: { "X-Subagent-Type": "Explore" },
+      },
+    };
+    container.register("AgentOptions", parentOptions);
+
+    // Parent options should not be modified
+    expect(parentOptions.defaultHeaders).toEqual({ "X-Agent-Type": "main" });
+  });
+
+  it("should override parent defaultHeaders with subagentHeaders", async () => {
+    const parentOptions: AgentOptions = {
+      defaultHeaders: { "X-Shared": "base" },
+      subagentHeaders: {
+        Explore: { "X-Shared": "explore-override" },
+      },
+    };
+    container.register("AgentOptions", parentOptions);
+
+    const config = (await subagentManager.loadConfigurations())[0];
+    await subagentManager.createInstance(config, {
+      description: "Test task",
+      prompt: "Explore something",
+      subagent_type: "Explore",
+    });
+
+    const headers = getSubagentDefaultHeaders();
+    expect(headers).toEqual({ "X-Shared": "explore-override" });
+  });
+
+  it("should not add extra headers for unknown subagent type", async () => {
+    const parentOptions: AgentOptions = {
+      defaultHeaders: { "X-Shared": "base" },
+      subagentHeaders: {
+        Explore: { "X-Subagent-Type": "Explore" },
+      },
+    };
+    container.register("AgentOptions", parentOptions);
+
+    const config = (await subagentManager.loadConfigurations())[0];
+    await subagentManager.createInstance(config, {
+      description: "Test task",
+      prompt: "Plan something",
+      subagent_type: "Plan",
+    });
+
+    // Plan is not in subagentHeaders, so subagent should only get parent defaultHeaders
+    const headers = getSubagentDefaultHeaders();
+    expect(headers).toEqual({ "X-Shared": "base" });
+  });
+
+  it("should make merged headers available for customFetch", async () => {
+    const parentOptions: AgentOptions = {
+      defaultHeaders: { "X-Agent-Type": "main" },
+      subagentHeaders: {
+        Explore: {
+          "X-Agent-Type": "subagent",
+          "X-Subagent-Type": "Explore",
+        },
+      },
+      fetch: vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ choices: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    };
+    container.register("AgentOptions", parentOptions);
+
+    const config = (await subagentManager.loadConfigurations())[0];
+    await subagentManager.createInstance(config, {
+      description: "Test task",
+      prompt: "Explore something",
+      subagent_type: "Explore",
+    });
+
+    // Verify subagent's defaultHeaders are merged correctly
+    const headers = getSubagentDefaultHeaders();
+    expect(headers).toEqual({
+      "X-Agent-Type": "subagent",
+      "X-Subagent-Type": "Explore",
+    });
+
+    // customFetch is passed through to subagent options
+    const opts = capturedContainer?.get<AgentOptions>("AgentOptions");
+    expect(opts?.fetch).toBe(parentOptions.fetch);
+  });
+});

--- a/specs/007-agent-config/data-model.md
+++ b/specs/007-agent-config/data-model.md
@@ -24,6 +24,7 @@ Extended interface for Agent constructor parameters.
 - `workdir?: string` - Existing working directory
 - `systemPrompt?: string` - Existing custom system prompt
 - `env?: Record<string, string>` - Per-agent environment variables, merged on top of process.env for bash, MCP, and hooks
+- `subagentHeaders?: Record<string, Record<string, string>>` - Per-subagent-type headers, merged into defaultHeaders when that subagent type is instantiated
 - `[key: string]: unknown` - Arbitrary additional model-specific parameters (e.g., `temperature`, `reasoning_effort`, `thinking`)
 
 **Validation Rules**:

--- a/specs/007-agent-config/spec.md
+++ b/specs/007-agent-config/spec.md
@@ -144,6 +144,23 @@ SDK users need per-agent-instance environment variables. Currently all subproces
 
 ---
 
+### User Story 10 - Per-Subagent-Type Headers (Priority: P2)
+
+SDK users need to configure different HTTP headers per subagent type so that `customFetch` can distinguish main agent calls from subagent calls, enabling request-level routing, rate-limiting, and observability.
+
+**Why this priority**: Important for multi-agent observability and routing but secondary to core configuration.
+
+**Independent Test**: Create an Agent with `subagentHeaders: { "Explore": { "X-Subagent-Type": "Explore" } }`, spawn an Explore subagent, and verify the subagent's `defaultHeaders` includes the type-specific header.
+
+**Acceptance Scenarios**:
+
+1. **Given** an Agent with `subagentHeaders: { "Explore": { "X-Subagent-Type": "Explore" } }`, **When** an Explore subagent is created, **Then** the subagent's `defaultHeaders` includes `X-Subagent-Type: Explore`
+2. **Given** an Agent with `subagentHeaders` configured, **When** a subagent type not in `subagentHeaders` is created, **Then** the subagent only receives parent `defaultHeaders` without extra keys
+3. **Given** an Agent with `defaultHeaders: { "X-Shared": "base" }` and `subagentHeaders: { "Explore": { "X-Shared": "explore-override" } }`, **When** an Explore subagent is created, **Then** the subagent receives `X-Shared: explore-override`
+4. **Given** an Agent with `subagentHeaders` configured, **When** `customFetch` is called for a subagent request, **Then** `init.headers` contains the merged type-specific headers
+
+---
+
 ### Edge Cases
 
 - What happens when partial configuration is provided (e.g., apiKey but no baseURL)?
@@ -197,6 +214,9 @@ SDK users need per-agent-instance environment variables. Currently all subproces
 - **FR-036**: Hook execution contexts (SessionStart, SessionEnd, PreToolUse, PostToolUse, PermissionRequest, Stop) MUST use `MergedEnv` instead of raw `process.env`
 - **FR-037**: `ToolContext` MUST include an `env` field containing `MergedEnv` for tool implementations to access
 - **FR-038**: When no `env` option is provided, system behavior MUST be identical to before (backwards compatible)
+- **FR-039**: `AgentOptions` MUST accept an optional `subagentHeaders?: Record<string, Record<string, string>>` parameter, keyed by subagent type name
+- **FR-040**: When a subagent is created, its `defaultHeaders` MUST be the merge of parent `defaultHeaders` with `subagentHeaders[type]` (type-specific values override parent)
+- **FR-041**: Merged subagent headers MUST be available in `customFetch` via `init.headers`, enabling request-level routing/rate-limiting/observability
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/009-subagent/spec.md
+++ b/specs/009-subagent/spec.md
@@ -140,6 +140,7 @@ As a user, I want to see subagent activity reflected within the main conversatio
 - **FR-014**: System MUST validate that specified tools in subagent configurations exist and are available
 - **FR-015**: System MUST gracefully handle cases where no subagent matches a task and fall back to main agent processing
 - **FR-023**: System MUST NOT store subagent message history in the CLI layer's persistent state after task completion (OOM protection)
+- **FR-024**: Subagent instances MUST receive merged `defaultHeaders` from parent `subagentHeaders[type]`, with type-specific headers overriding parent `defaultHeaders`
 
 ### Key Entities
 


### PR DESCRIPTION
Add  to AgentOptions,
keyed by subagent type. When a subagent is created, its type-specific headers
are merged into defaultHeaders, flowing through to GatewayConfig and customFetch.

This enables customFetch to distinguish main agent from subagent calls for
request-level routing, rate-limiting, and observability.

Updates:
- AgentOptions: add subagentHeaders field after defaultHeaders
- SubagentManager.createInstance(): merge subagentHeaders[type] into defaultHeaders
- specs/007-agent-config: add US10 (Per-Subagent-Type Headers) + FR-039/040/041
- specs/007-agent-config/data-model: add subagentHeaders to AgentOptions fields
- specs/009-subagent: add FR-024 for merged defaultHeaders in subagent instances
- Tests: 5 cases covering merge, no-effect-on-main, override, unknown-type, customFetch
