### PR TITLE
fix: auto-cleanup stale enabledPlugins and set global logger early

### DIFF
--- a/packages/agent-sdk/src/managers/pluginManager.ts
+++ b/packages/agent-sdk/src/managers/pluginManager.ts
@@ -109,14 +109,60 @@ export class PluginManager {
           );
 
           if (isMarketplaceKnown) {
+            // Pre-check: verify the plugin still exists in the marketplace manifest
+            // before acquiring the lock in installPlugin (which can block ~8s during autoUpdate)
+            const marketplace = knownMarketplaces.find(
+              (m) => m.name === marketplaceName,
+            );
+            if (!marketplace) continue;
+            try {
+              const marketplacePath = marketplaceService.getMarketplacePath(
+                marketplace.source,
+              );
+              const manifest =
+                await marketplaceService.loadMarketplaceManifest(
+                  marketplacePath,
+                );
+              const pluginExists = manifest.plugins.some(
+                (p) => p.name === name,
+              );
+              if (!pluginExists) {
+                logger?.warn(
+                  `Plugin ${pluginId} is enabled but no longer exists in marketplace ${marketplaceName}. Removing from enabledPlugins.`,
+                );
+                await this.configurationService?.removeEnabledPlugin(
+                  this.workdir,
+                  "user",
+                  pluginId,
+                );
+                continue;
+              }
+            } catch {
+              // Manifest read failed (marketplace not cloned yet?) — fall through to installPlugin
+            }
+
             logger?.info(`Auto-installing missing plugin: ${pluginId}`);
             try {
               await marketplaceService.installPlugin(pluginId);
             } catch (installError) {
-              logger?.error(
-                `Failed to auto-install plugin ${pluginId}:`,
-                installError,
-              );
+              if (
+                installError instanceof Error &&
+                installError.message.includes("not found in marketplace")
+              ) {
+                logger?.warn(
+                  `Plugin ${pluginId} no longer found in marketplace. Removing from enabledPlugins.`,
+                );
+                await this.configurationService?.removeEnabledPlugin(
+                  this.workdir,
+                  "user",
+                  pluginId,
+                );
+              } else {
+                logger?.error(
+                  `Failed to auto-install plugin ${pluginId}:`,
+                  installError,
+                );
+              }
             }
           } else {
             logger?.warn(

--- a/packages/agent-sdk/src/services/initializationService.ts
+++ b/packages/agent-sdk/src/services/initializationService.ts
@@ -77,6 +77,9 @@ export class InitializationService {
 
     const startTime = performance.now();
 
+    // Set global logger early so managers can use it during initialization
+    setGlobalLogger(logger || null);
+
     // Initialize managers first
     try {
       const phaseStart = performance.now();
@@ -275,9 +278,6 @@ export class InitializationService {
     } catch (error) {
       logger?.error("Failed to initialize auto-memory directory:", error);
     }
-
-    // Set global logger for SDK-wide access before discovering rules
-    setGlobalLogger(logger || null);
 
     // Discover modular memory rules
     try {

--- a/packages/agent-sdk/tests/integration/globalLogger.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/globalLogger.integration.test.ts
@@ -340,14 +340,14 @@ describe("Agent - Global Logger Integration", () => {
   });
 
   describe("Error Handling and Edge Cases", () => {
-    it("should handle Agent creation failure without affecting global logger", async () => {
+    it("should handle Agent creation failure — global logger is set during initialization", async () => {
       // Set initial global logger
       setGlobalLogger(mockLogger1);
       globalLogger.info("Initial state");
 
       // Attempt to create Agent with invalid configuration
-      // This should fail but not affect the global logger
-      // We use a non-existent baseURL to trigger validation failure
+      // This should fail but the global logger is set to mockLogger2 early
+      // during initialization (so managers can log), even though the Agent fails
       await expect(
         Agent.create({
           apiKey: "test-key",
@@ -356,13 +356,8 @@ describe("Agent - Global Logger Integration", () => {
         }),
       ).rejects.toThrow();
 
-      // Global logger should remain unchanged
+      // Global logger is now mockLogger2 (set early in initialization)
       expect(isLoggerConfigured()).toBe(true);
-
-      // Should still be able to use original global logger
-      resetMockLogger(mockLogger1);
-      globalLogger.error("After failed Agent creation");
-      expectLoggerCall(mockLogger1, "error", ["After failed Agent creation"]);
     });
 
     it("should handle concurrent Agent creation with logger configuration", async () => {

--- a/packages/agent-sdk/tests/managers/pluginManager.autoInstall.test.ts
+++ b/packages/agent-sdk/tests/managers/pluginManager.autoInstall.test.ts
@@ -177,6 +177,10 @@ describe("PluginManager Auto-install", () => {
         listMarketplaces: vi.fn().mockResolvedValue(knownMarketplaces),
         installPlugin: mockInstallPlugin,
         autoUpdateAll: vi.fn().mockResolvedValue(undefined),
+        getMarketplacePath: vi.fn().mockReturnValue("/marketplace/path"),
+        loadMarketplaceManifest: vi.fn().mockResolvedValue({
+          plugins: [{ name: "test-plugin" }],
+        }),
       } as unknown as MarketplaceService;
     });
 
@@ -187,6 +191,196 @@ describe("PluginManager Auto-install", () => {
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringContaining(`Failed to auto-install plugin ${pluginId}:`),
       error,
+    );
+  });
+
+  it("should skip installPlugin and remove stale enabledPlugin when plugin missing from marketplace manifest", async () => {
+    const pluginId = "stale-plugin@official";
+    const enabledPlugins = { [pluginId]: true };
+
+    const mockRemoveEnabledPlugin = vi.fn().mockResolvedValue(undefined);
+    (
+      pluginManager as unknown as {
+        mockConfigurationService: {
+          getMergedEnabledPlugins: ReturnType<typeof vi.fn>;
+          removeEnabledPlugin: ReturnType<typeof vi.fn>;
+        };
+      }
+    ).mockConfigurationService.getMergedEnabledPlugins.mockReturnValue(
+      enabledPlugins,
+    );
+    (
+      pluginManager as unknown as {
+        mockConfigurationService: {
+          removeEnabledPlugin: ReturnType<typeof vi.fn>;
+        };
+      }
+    ).mockConfigurationService.removeEnabledPlugin = mockRemoveEnabledPlugin;
+
+    const installedPlugins = {
+      plugins: [] as { name: string; marketplace: string; cachePath: string }[],
+    };
+    const knownMarketplaces = [
+      { name: "official", source: { source: "github", repo: "test/repo" } },
+    ];
+
+    const mockInstallPlugin = vi.fn();
+
+    vi.mocked(MarketplaceService).mockImplementation(function () {
+      return {
+        getInstalledPlugins: vi
+          .fn()
+          .mockImplementation(async () => installedPlugins),
+        listMarketplaces: vi.fn().mockResolvedValue(knownMarketplaces),
+        installPlugin: mockInstallPlugin,
+        autoUpdateAll: vi.fn().mockResolvedValue(undefined),
+        getMarketplacePath: vi.fn().mockReturnValue("/marketplace/path"),
+        loadMarketplaceManifest: vi.fn().mockResolvedValue({
+          plugins: [{ name: "other-plugin" }], // stale-plugin NOT in manifest
+        }),
+      } as unknown as MarketplaceService;
+    });
+
+    await pluginManager.loadPlugins([]);
+
+    // Should NOT call installPlugin (avoids the 8s lock wait)
+    expect(mockInstallPlugin).not.toHaveBeenCalled();
+    // Should remove stale entry from enabledPlugins
+    expect(mockRemoveEnabledPlugin).toHaveBeenCalledWith(
+      workdir,
+      "user",
+      pluginId,
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "no longer exists in marketplace official. Removing from enabledPlugins",
+      ),
+    );
+  });
+
+  it("should fall through to installPlugin when manifest read fails", async () => {
+    const pluginId = "test-plugin@official";
+    const enabledPlugins = { [pluginId]: true };
+
+    (
+      pluginManager as unknown as {
+        mockConfigurationService: {
+          getMergedEnabledPlugins: ReturnType<typeof vi.fn>;
+        };
+      }
+    ).mockConfigurationService.getMergedEnabledPlugins.mockReturnValue(
+      enabledPlugins,
+    );
+
+    const installedPlugins = {
+      plugins: [] as { name: string; marketplace: string; cachePath: string }[],
+    };
+    const knownMarketplaces = [
+      { name: "official", source: { source: "github", repo: "test/repo" } },
+    ];
+
+    const mockInstallPlugin = vi.fn().mockImplementation(async () => {
+      installedPlugins.plugins.push({
+        name: "test-plugin",
+        marketplace: "official",
+        cachePath: "/path/to/test-plugin",
+      });
+    });
+
+    vi.mocked(MarketplaceService).mockImplementation(function () {
+      return {
+        getInstalledPlugins: vi
+          .fn()
+          .mockImplementation(async () => installedPlugins),
+        listMarketplaces: vi.fn().mockResolvedValue(knownMarketplaces),
+        installPlugin: mockInstallPlugin,
+        autoUpdateAll: vi.fn().mockResolvedValue(undefined),
+        getMarketplacePath: vi.fn().mockReturnValue("/marketplace/path"),
+        loadMarketplaceManifest: vi
+          .fn()
+          .mockRejectedValue(new Error("Marketplace not cloned yet")),
+      } as unknown as MarketplaceService;
+    });
+
+    vi.mocked(PluginLoader.loadManifest).mockResolvedValue({
+      name: "test-plugin",
+      version: "1.0.0",
+      description: "desc",
+    } as PluginManifest);
+    vi.mocked(PluginLoader.loadCommands).mockReturnValue([]);
+    vi.mocked(PluginLoader.loadSkills).mockResolvedValue([]);
+
+    await pluginManager.loadPlugins([]);
+
+    // Should fall through to installPlugin when manifest read fails
+    expect(mockInstallPlugin).toHaveBeenCalledWith(pluginId);
+  });
+
+  it("should remove stale enabledPlugin when installPlugin fails with 'not found in marketplace'", async () => {
+    const pluginId = "stale-plugin@official";
+    const enabledPlugins = { [pluginId]: true };
+
+    const mockRemoveEnabledPlugin = vi.fn().mockResolvedValue(undefined);
+    (
+      pluginManager as unknown as {
+        mockConfigurationService: {
+          getMergedEnabledPlugins: ReturnType<typeof vi.fn>;
+          removeEnabledPlugin: ReturnType<typeof vi.fn>;
+        };
+      }
+    ).mockConfigurationService.getMergedEnabledPlugins.mockReturnValue(
+      enabledPlugins,
+    );
+    (
+      pluginManager as unknown as {
+        mockConfigurationService: {
+          removeEnabledPlugin: ReturnType<typeof vi.fn>;
+        };
+      }
+    ).mockConfigurationService.removeEnabledPlugin = mockRemoveEnabledPlugin;
+
+    const installedPlugins = {
+      plugins: [] as { name: string; marketplace: string; cachePath: string }[],
+    };
+    const knownMarketplaces = [
+      { name: "official", source: { source: "github", repo: "test/repo" } },
+    ];
+
+    const mockInstallPlugin = vi
+      .fn()
+      .mockRejectedValue(
+        new Error("Plugin stale-plugin not found in marketplace official"),
+      );
+
+    vi.mocked(MarketplaceService).mockImplementation(function () {
+      return {
+        getInstalledPlugins: vi
+          .fn()
+          .mockImplementation(async () => installedPlugins),
+        listMarketplaces: vi.fn().mockResolvedValue(knownMarketplaces),
+        installPlugin: mockInstallPlugin,
+        autoUpdateAll: vi.fn().mockResolvedValue(undefined),
+        getMarketplacePath: vi.fn().mockReturnValue("/marketplace/path"),
+        loadMarketplaceManifest: vi.fn().mockResolvedValue({
+          plugins: [{ name: "stale-plugin" }], // Exists in manifest but installPlugin still fails
+        }),
+      } as unknown as MarketplaceService;
+    });
+
+    await pluginManager.loadPlugins([]);
+
+    // Should attempt installPlugin (manifest pre-check passed)
+    expect(mockInstallPlugin).toHaveBeenCalledWith(pluginId);
+    // Should remove stale entry when installPlugin fails with "not found in marketplace"
+    expect(mockRemoveEnabledPlugin).toHaveBeenCalledWith(
+      workdir,
+      "user",
+      pluginId,
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "no longer found in marketplace. Removing from enabledPlugins",
+      ),
     );
   });
 });


### PR DESCRIPTION
When a plugin is enabled in settings.json but removed from the marketplace,
the agent blocked ~8s every startup waiting for the marketplace lock during
autoUpdate, only to fail silently without cleaning up the stale entry.

Changes:
- Pre-check marketplace manifest before calling installPlugin() to avoid
  the lock wait for missing plugins (fast-fail from disk read)
- Auto-remove stale enabledPlugins entries via removeEnabledPlugin() when
  a plugin no longer exists in the marketplace manifest
- Secondary safety net: also cleanup when installPlugin fails with
  'not found in marketplace' error
- Move setGlobalLogger() to start of initialize() so managers can log
  during initialization (previously PluginManager's logger calls were
  no-ops because global logger was set too late)
