### PR TITLE
fix: prioritize settings.json model field over env.WAVE_MODEL in resolveModelConfig

### DIFF
--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -511,12 +511,14 @@ export class ConfigurationService {
     maxTokens?: number,
     permissionMode?: PermissionMode,
   ): ModelConfig {
-    // Resolve agent model: override > options > process.env (includes settings.json env)
+    // Resolve agent model: override > options > currentConfiguration (settings.json model, possibly remote-merged) > process.env
+    // Priority: user's explicit model field > admin's env.WAVE_MODEL default.
+    // If admin wants hard enforcement, they set the `model` scalar field (overwrites local in mergeRemoteSettings).
     const resolvedAgentModel =
       model ||
       this.options.model ||
-      process.env.WAVE_MODEL ||
-      this.currentConfiguration?.model;
+      this.currentConfiguration?.model ||
+      process.env.WAVE_MODEL;
 
     // Resolve fast model: override > options > process.env (includes settings.json env)
     const resolvedFastModel =

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -667,7 +667,7 @@ describe("ConfigurationService", () => {
       }
     });
 
-    it("should prioritize WAVE_MODEL env var over currentConfiguration.model", async () => {
+    it("should prioritize currentConfiguration.model over WAVE_MODEL env var", async () => {
       const config = { model: "config-model" };
       mockExistsSync.mockReturnValue(true);
       mockReadFileSync.mockReturnValue(JSON.stringify(config));
@@ -680,7 +680,7 @@ describe("ConfigurationService", () => {
         await configService.loadMergedConfiguration(tempDir);
         configService.setOptions({}); // no options.model
         const resolved = configService.resolveModelConfig();
-        expect(resolved.model).toBe("env-model");
+        expect(resolved.model).toBe("config-model");
       } finally {
         if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
         else delete process.env.WAVE_MODEL;

--- a/specs/033-model-command/data-model.md
+++ b/specs/033-model-command/data-model.md
@@ -33,9 +33,10 @@ A model entry for display in the selector UI.
 ### Model Resolution Priority (highest to lowest)
 
 1. In-memory override (set during current session via `/model`)
-2. `WAVE_MODEL` environment variable
-3. `settings.json` `model` field (local or remote managed)
-4. Provider default
+2. `settings.json` `model` field (user's explicit choice; overrides admin's `env.WAVE_MODEL` default)
+3. Remote managed `model` scalar field (admin enforces — overwrites local via `mergeRemoteSettings`)
+4. `WAVE_MODEL` environment variable (admin default via `env.WAVE_MODEL`, or shell fallback)
+5. Provider default
 
 ## Validation Rules
 - Model IDs must be non-empty strings.

--- a/specs/033-model-command/spec.md
+++ b/specs/033-model-command/spec.md
@@ -62,5 +62,4 @@ As a CLI user, I want to see which models are available from my configuration so
 - **FR-010**: The `Agent` MUST expose `getConfiguredModels()` to provide the list of selectable models.
 - **FR-011**: The `StatusCommand` MUST display the active model name under the "Model:" field.
 - **FR-012**: System MUST persist the selected model to `~/.wave/settings.json` when the user selects a model via `/model`.
-- **FR-013**: Model resolution priority MUST be: in-memory override > `WAVE_MODEL` env var > `settings.json` persisted model. Remote managed settings override local settings.
-e active model name under the "Model:" field.
+- **FR-013**: Model resolution priority MUST be: in-memory override > `settings.json` persisted model > `WAVE_MODEL` env var. Remote managed `model` scalar field overrides local in merge; remote `env.WAVE_MODEL` serves as admin default that user's `settings.json` `model` field can override.

--- a/specs/078-server-managed-config/data-model.md
+++ b/specs/078-server-managed-config/data-model.md
@@ -40,10 +40,12 @@ Stored in: `~/.wave/managed-settings-cache.json`
 
 | Priority | Source | Override Power |
 |----------|--------|---------------|
-| 1 (highest) | Environment variables | Always wins |
-| 2 | Remote managed settings | Overrides local settings |
-| 3 | User-level `settings.json` | Standard local config |
-| 4 (lowest) | Project-level `settings.json` | Project defaults |
+| 1 (highest) | In-memory override (`/model` command) | Always wins |
+| 2 | User `settings.json` `model` field | Overrides admin's env default |
+| 3 | Remote managed `model` field (scalar) | Overrides local `model` in mergeRemoteSettings (admin enforces) |
+| 3 | Remote managed `env.WAVE_MODEL` | Admin default; user `settings.json` `model` field overrides this |
+| 4 | Shell `WAVE_MODEL` env var | System fallback |
+| 5 (lowest) | Project-level `settings.json` | Project defaults |
 
 ### Merge Rules
 

--- a/specs/078-server-managed-config/quickstart.md
+++ b/specs/078-server-managed-config/quickstart.md
@@ -27,7 +27,7 @@ On the Wave AI server, an admin configures managed settings:
 }
 ```
 
-When a team member starts Wave, the Bash tool is disabled and the model is set to `gpt-4o`, regardless of their local `settings.json`.
+When a team member starts Wave, the Bash tool is disabled and the model is set to `gpt-4o`, regardless of their local `settings.json` (because the `model` scalar field overrides local in the merge). If the admin instead uses `env.WAVE_MODEL`, the user can override it by setting `"model"` in their local `settings.json`.
 
 ## Fallback Behavior
 

--- a/specs/078-server-managed-config/research.md
+++ b/specs/078-server-managed-config/research.md
@@ -14,12 +14,13 @@
   - Always download: Rejected — wasteful for teams where settings rarely change.
   - Time-based caching (TTL): Rejected — doesn't guarantee freshness; checksum is more reliable.
 
-## Decision: Merge Priority — Managed > Local
+## Decision: Merge Priority — Model field vs env.WAVE_MODEL
 
-- **Rationale**: The purpose of managed settings is organizational policy enforcement. If local settings could override managed settings, the feature would be useless for security/compliance. This matches Claude Code's merge priority (priority 1 = highest = server-managed).
+- **Rationale**: Admin should be able to set a default model via `env.WAVE_MODEL` while allowing users to override it via their `settings.json` `model` field. If admin wants hard enforcement, they use the `model` scalar field (which overwrites the local value during `mergeRemoteSettings`). This differs from Claude Code where `ANTHROPIC_MODEL` env var always beats `settings.model`, but Wave's model is more flexible: admin gets a soft default by default, hard enforcement when explicitly chosen.
+- **Priority**: in-memory override > user `settings.json` `model` field > remote `model` scalar (admin enforces) / remote `env.WAVE_MODEL` (admin default) > shell env var
 - **Alternatives considered**:
-  - Local overrides managed: Rejected — defeats the purpose of centralized management.
-  - Per-key priority: Rejected — too complex; a simpler model where managed wins for any key it includes is easier to reason about.
+  - Env var always wins (Claude Code model): Rejected — prevents user from overriding admin's default.
+  - Managed always wins: Rejected — admin cannot offer a soft default that users can customize.
 
 ## Decision: Graceful Degradation on Network Errors
 

--- a/specs/078-server-managed-config/spec.md
+++ b/specs/078-server-managed-config/spec.md
@@ -18,7 +18,7 @@ As an organization admin, I want to push managed settings (allowed tools, model 
 
 1. **Given** the user is authenticated via SSO and the server has managed settings, **When** Wave initializes, **Then** it downloads managed settings from `WAVE_SERVER_URL/api/v1/managed-settings` and applies them.
 2. **Given** the user is not authenticated via SSO, **When** Wave initializes, **Then** no managed settings are downloaded and local-only settings are used.
-3. **Given** managed settings include a `model` field, **When** settings are resolved, **Then** the managed model takes precedence over the local `settings.json` model.
+3. **Given** managed settings include a `model` scalar field, **When** settings are resolved, **Then** the managed model takes precedence over the local `settings.json` model (admin enforces). **Given** managed settings include `env.WAVE_MODEL` but no `model` field, **When** the user has a `model` field in `settings.json`, **Then** the user's model takes precedence (user overrides admin's default).
 
 ---
 
@@ -58,7 +58,7 @@ As an organization admin, I want my managed settings to override local user sett
 - **What happens if the managed settings endpoint is unreachable?** Wave MUST proceed with cached settings if available, or local-only settings if not. A warning is logged but startup is not blocked.
 - **What happens if managed settings contain invalid JSON?** Wave MUST log an error and fall back to local-only settings.
 - **What happens if the user logs out of SSO?** Managed settings are no longer downloaded on subsequent startups, but previously cached managed settings remain in effect until overwritten by local changes.
-- **What happens if managed settings conflict with environment variables?** Environment variables (e.g., `WAVE_MODEL`) still override managed settings. Managed settings only override local `settings.json` values, not env vars.
+- **What happens if managed settings conflict with environment variables?** User's `settings.json` `model` field overrides admin's `env.WAVE_MODEL` default. If admin wants hard enforcement, they use the `model` scalar field which overwrites the local value during merge. Shell env vars (set before Wave starts) are the lowest priority fallback.
 - **What happens during a settings reload (file watcher)?** Managed settings are NOT re-downloaded on file change — they are only downloaded during initialization.
 
 ## Requirements *(mandatory)*
@@ -69,7 +69,7 @@ As an organization admin, I want my managed settings to override local user sett
 - **FR-002**: System MUST include the SSO token as Bearer auth in the managed settings download request.
 - **FR-003**: System MUST cache the checksum (ETag or response header) of the last downloaded settings to avoid redundant downloads on subsequent startups.
 - **FR-004**: System MUST store cached managed settings and their checksum locally (in `~/.wave/` directory).
-- **FR-005**: System MUST merge remote managed settings with local settings using priority: remote managed > local user settings > local project settings. Environment variables always override managed settings.
+- **FR-005**: System MUST merge remote managed settings with local settings using priority: in-memory override > user `settings.json` `model` field > remote managed `model` scalar (admin enforces) / remote `env.WAVE_MODEL` (admin default, user can override) > shell env vars > local project settings.
 - **FR-006**: System MUST NOT override local-only settings (hooks, env vars not present in managed settings) with empty values from managed settings — managed settings only override keys they explicitly include.
 - **FR-007**: System MUST handle network errors gracefully — if the download fails, use cached managed settings if available, otherwise proceed with local-only settings.
 - **FR-008**: System MUST log a warning when managed settings download fails but NOT block agent startup.

--- a/specs/078-server-managed-config/tasks.md
+++ b/specs/078-server-managed-config/tasks.md
@@ -35,7 +35,8 @@
 - [ ] T007 [US3] Implement `mergeWithLocal(local, managed)` with priority: managed > local
   - Array fields: managed replaces local entirely
   - Env field: managed overrides matching keys, preserves non-overlapping local keys
-  - Other fields: managed value wins
+  - `model` scalar field: managed overwrites local (admin enforces)
+  - Note: `env.WAVE_MODEL` is a lower-priority default — user's `settings.json` `model` field overrides it in `resolveModelConfig()`
 - [ ] T008 [US3] Integrate managed settings into `ConfigurationService.resolveSettings()` merge pipeline
 
 ## Phase 4: Error Handling & Polish


### PR DESCRIPTION
User's explicit  field in settings.json now takes precedence over
 env var (including remote-pushed env.WAVE_MODEL). This allows
admin to set a soft default via env.WAVE_MODEL while users can override it.
If admin wants hard enforcement, they use the  scalar field which
overwrites local in mergeRemoteSettings.

Priority: /model command > settings.json model > remote model scalar (admin
enforces) / env.WAVE_MODEL (admin default) > shell env var

Updates specs/033-model-command and specs/078-server-managed-config to reflect
the new priority model.
