### PR TITLE
feat(bash-tool): add CWD change notification to tool result when cd changes directory

### DIFF
--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -432,18 +432,17 @@ The working directory persists between commands. Try to maintain your current wo
           }
 
           // If CWD changed, call the onCwdChange callback and add notification
-          let cwdResetMessage: string | undefined;
+          let cwdMessage: string | undefined;
           if (newCwd && newCwd !== context.workdir && context.onCwdChange) {
             const isInSafeZone =
               context.permissionManager?.isPathInSafeZone?.(newCwd) ?? true;
 
-            if (isInSafeZone) {
-              context.onCwdChange(newCwd);
-            } else if (context.originalWorkdir) {
+            if (!isInSafeZone && context.originalWorkdir) {
               context.onCwdChange(context.originalWorkdir);
-              cwdResetMessage = `Shell cwd was reset to ${context.originalWorkdir}`;
+              cwdMessage = `Shell cwd was reset to ${context.originalWorkdir}`;
             } else {
               context.onCwdChange(newCwd);
+              cwdMessage = `Shell working directory changed to ${newCwd}`;
             }
           }
 
@@ -451,9 +450,9 @@ The working directory persists between commands. Try to maintain your current wo
           const combinedOutput =
             outputBuffer + (errorBuffer ? "\n" + errorBuffer : "");
 
-          // Prepend CWD reset message to output if present (like Claude Code's stderr approach)
+          // Prepend CWD change message to output if present
           const finalOutput =
-            (cwdResetMessage ? cwdResetMessage + "\n" : "") +
+            (cwdMessage ? cwdMessage + "\n" : "") +
             (combinedOutput || `Command executed with exit code: ${exitCode}`);
           const content = processToolResult(
             finalOutput,


### PR DESCRIPTION
When a bash command changes the working directory, the tool result now
prepends a notification message informing the agent of the new CWD.
This restores the notification behavior from commit cefb1a82 that was
lost when only reset messages were kept.

- Normal CWD change: 'Shell working directory changed to <newCwd>'
- CWD reset (outside safe zone): 'Shell cwd was reset to <originalWorkdir>'
- Simplified branching logic (inverted condition for clarity)
