### PR TITLE
feat(hooks): expose plan_file_path in PreToolUse/PostToolUse hook stdin JSON

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -1688,6 +1688,7 @@ export class AIManager {
         toolInput,
         toolResponse,
         subagentType: this.subagentType, // Include subagent type in hook context
+        planFilePath: this.permissionManager?.getPlanFilePath(),
         env:
           this.container.get<Record<string, string>>("MergedEnv") ||
           (process.env as Record<string, string>),

--- a/packages/agent-sdk/src/services/hook.ts
+++ b/packages/agent-sdk/src/services/hook.ts
@@ -72,6 +72,11 @@ async function buildHookJsonInput(
     jsonInput.user_prompt = context.userPrompt;
   }
 
+  // Add plan_file_path if present
+  if (context.planFilePath !== undefined) {
+    jsonInput.plan_file_path = context.planFilePath;
+  }
+
   // Add subagent_type if present
   if (context.subagentType !== undefined) {
     jsonInput.subagent_type = context.subagentType;

--- a/packages/agent-sdk/src/types/hooks.ts
+++ b/packages/agent-sdk/src/types/hooks.ts
@@ -51,6 +51,7 @@ export interface HookExecutionContext {
   timestamp: Date;
   worktreeName?: string; // Present for WorktreeCreate
   worktreePath?: string; // Present for WorktreeRemove
+  planFilePath?: string; // Present when in plan mode
 }
 
 // Result of hook execution
@@ -183,6 +184,7 @@ export interface HookJsonInput {
   tool_name?: string; // Present for PreToolUse, PostToolUse, PermissionRequest
   tool_input?: unknown; // Present for PreToolUse, PostToolUse, PermissionRequest
   tool_response?: unknown; // Present for PostToolUse only
+  plan_file_path?: string; // Present when in plan mode
   user_prompt?: string; // Present for UserPromptSubmit only
   subagent_type?: string; // Present when hook is executed by a subagent
   name?: string; // Present for WorktreeCreate events


### PR DESCRIPTION
Add planFilePath to HookExecutionContext, ExtendedHookExecutionContext,
and HookJsonInput so hooks can access the plan file path when in plan
mode. The field is omitted when not in plan mode.
