### PR TITLE
Align skill content format with Claude Code

### DIFF
--- a/packages/agent-sdk/src/managers/skillManager.ts
+++ b/packages/agent-sdk/src/managers/skillManager.ts
@@ -382,7 +382,7 @@ export class SkillManager extends EventEmitter {
     } catch (error) {
       logger?.error(`Failed to execute skill '${skill_name}':`, error);
       return {
-        content: `❌ **Error executing skill**: ${error instanceof Error ? error.message : String(error)}`,
+        content: `**Error executing skill**: ${error instanceof Error ? error.message : String(error)}`,
       };
     }
   }
@@ -404,14 +404,14 @@ export class SkillManager extends EventEmitter {
 
       if (!skill) {
         return {
-          content: `❌ **Skill not found**: "${skill_name}"\n\nAvailable skills:\n${this.formatAvailableSkills()}`,
+          content: `**Skill not found**: "${skill_name}"\n\nAvailable skills:\n${this.formatAvailableSkills()}`,
         };
       }
 
       if (!skill.isValid) {
         const errorMsg = formatSkillError(skill.skillPath, skill.errors);
         return {
-          content: `❌ **Skill validation failed**:\n\n\`\`\`\n${errorMsg}\n\`\`\``,
+          content: `**Skill validation failed**:\n\n\`\`\`\n${errorMsg}\n\`\`\``,
         };
       }
 
@@ -420,7 +420,7 @@ export class SkillManager extends EventEmitter {
     } catch (error) {
       logger?.error(`Failed to prepare skill '${skill_name}':`, error);
       return {
-        content: `❌ **Error preparing skill**: ${error instanceof Error ? error.message : String(error)}`,
+        content: `**Error preparing skill**: ${error instanceof Error ? error.message : String(error)}`,
       };
     }
   }
@@ -429,9 +429,7 @@ export class SkillManager extends EventEmitter {
    * Prepare skill content with arguments but without bash execution
    */
   private prepareSkillContent(skill: Skill, argsString: string): string {
-    const header = `🧠 **${skill.name}** (${skill.type} skill)\n\n`;
-    const description = `*${skill.description}*\n\n`;
-    const skillPath = `📁 Skill location: \`${skill.skillPath}\`\n\n`;
+    const skillPath = `Base directory for this skill: ${skill.skillPath}\n\n`;
 
     // Extract content after frontmatter
     const contentMatch = skill.content.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
@@ -451,7 +449,7 @@ export class SkillManager extends EventEmitter {
       );
     }
 
-    return header + description + skillPath + mainContent;
+    return skillPath + mainContent;
   }
 
   /**

--- a/packages/agent-sdk/tests/managers/skillManager.test.ts
+++ b/packages/agent-sdk/tests/managers/skillManager.test.ts
@@ -488,10 +488,8 @@ describe("SkillManager", () => {
       });
 
       expect(result.content).toContain(
-        "🧠 **test-plugin:test-skill** (personal skill)",
+        "Base directory for this skill: /path/to/skill",
       );
-      expect(result.content).toContain("*A test skill*");
-      expect(result.content).toContain("📁 Skill location: `/path/to/skill`");
       expect(result.content).toContain("# Actual Content");
       expect(result.content).not.toContain("---");
     });
@@ -523,9 +521,9 @@ describe("SkillManager", () => {
       });
 
       expect(result.content).toContain(
-        "🧠 **test-plugin:fork-skill** (personal skill)",
+        "Base directory for this skill: /path/to/skill",
       );
-      expect(result.content).not.toContain("🔄 Context: `fork`");
+      expect(result.content).not.toContain("fork");
       expect(result.content).toContain("# Actual Content");
     });
 
@@ -629,9 +627,9 @@ describe("SkillManager", () => {
         skill_name: "test-skill",
       });
 
-      expect(result.content).toContain("🧠 **test-skill**");
-      expect(result.content).toContain("personal skill");
-      expect(result.content).toContain("A test skill");
+      expect(result.content).toContain(
+        "Base directory for this skill: /path/to/skill",
+      );
       expect(result.content).toContain("# Test Content");
       expect(result.context).toEqual({ skillName: "test-skill" });
     });
@@ -681,7 +679,7 @@ describe("SkillManager", () => {
       });
 
       expect(result.content).toContain(
-        '❌ **Skill not found**: "nonexistent-skill"',
+        '**Skill not found**: "nonexistent-skill"',
       );
       expect(result.content).toContain("Available skills:");
       expect(result.content).toContain("available-skill");
@@ -710,7 +708,7 @@ describe("SkillManager", () => {
         skill_name: "invalid-skill",
       });
 
-      expect(result.content).toContain("❌ **Skill validation failed**");
+      expect(result.content).toContain("**Skill validation failed**");
       expect(result.content).toContain("Formatted Error");
     });
 
@@ -724,7 +722,7 @@ describe("SkillManager", () => {
       });
 
       expect(result.content).toContain(
-        "❌ **Error preparing skill**: Loading failed",
+        "**Error preparing skill**: Loading failed",
       );
       expect(logger.error).toHaveBeenCalledWith(
         "Failed to prepare skill 'error-skill':",


### PR DESCRIPTION
- Remove emoji prefix (🧠, 📁, ❌) from skill output
- Remove redundant name/type/description header (already in skill listing)
- Use 'Base directory for this skill:' instead of '📁 Skill location:'
- Matches Claude Code's skill content format
