### PR TITLE
Remove hard block on github.com URLs in WebFetch tool

### DIFF
--- a/packages/agent-sdk/src/tools/webFetchTool.ts
+++ b/packages/agent-sdk/src/tools/webFetchTool.ts
@@ -96,9 +96,6 @@ function isPermittedRedirect(
   }
 }
 
-const GITHUB_URL_ERROR =
-  "For GitHub URLs, please use the 'gh' CLI via the Bash tool instead (e.g., 'gh pr view', 'gh issue view', 'gh api').";
-
 // --- Tool ---
 
 export const webFetchTool: ToolPlugin = {
@@ -172,15 +169,6 @@ Usage notes:
         success: false,
         content: "",
         error: validation.error,
-      };
-    }
-
-    // Check for GitHub URLs
-    if (url.includes("github.com")) {
-      return {
-        success: false,
-        content: "",
-        error: GITHUB_URL_ERROR,
       };
     }
 

--- a/packages/agent-sdk/tests/tools/webFetchTool.test.ts
+++ b/packages/agent-sdk/tests/tools/webFetchTool.test.ts
@@ -109,17 +109,32 @@ describe("webFetchTool", () => {
     expect(result.content).toContain("REDIRECT_TO: https://other.com/page");
   });
 
-  it("should reject GitHub URLs and suggest gh CLI", async () => {
+  it("should allow GitHub URLs (no hard block, only prompt-level suggestion)", async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: vi
+        .fn()
+        .mockResolvedValue("<html><body>GitHub Page Content</body></html>"),
+      headers: new Headers(),
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse));
+
     const result = await webFetchTool.execute(
       {
-        url: "https://github.com/netease-lcap/wave-agent",
+        url: "https://github.com/netese-lcap/wave-agent",
         prompt: "Summarize",
       },
       context,
     );
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("use the 'gh' CLI");
+    // GitHub URLs are no longer hard-blocked; only a prompt-level suggestion exists
+    expect(result.success).toBe(true);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://github.com/netese-lcap/wave-agent",
+      expect.any(Object),
+    );
   });
 
   it("should use cache for repeated requests", async () => {


### PR DESCRIPTION
Align with Claude Code's approach: keep GitHub URL guidance as a
prompt-level suggestion in the tool description rather than a code-level
block. The hard block prevented fetching docs.github.com and other public
GitHub pages that have no gh CLI equivalent.
