### PR TITLE
Upgrade pnpm from 9 to 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v5
-        with:
-          version: 9
 
       - uses: actions/setup-node@v6
         with:

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "typescript-eslint": "^8.39.0",
     "vitest": "^4.0.18"
   },
+  "packageManager": "pnpm@11.5.2",
   "engines": {
     "node": ">=22.0.0"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 packages:
   - "packages/*"
+allowBuilds:
+  esbuild: true
+  protobufjs: true


### PR DESCRIPTION
## Changes

- Upgrade pnpm from 9.15.9 to 11.5.2
- Add `packageManager` field to `package.json` to pin the version
- Add `allowBuilds` to `pnpm-workspace.yaml` for esbuild and protobufjs (pnpm 11 requires explicit approval for dependency build scripts)

## Verification

- `pnpm install` succeeds
- `pnpm build` succeeds
- Type-check passes