### PR TITLE
fix: clone marketplace before auto-installing plugin when manifest not found

### DIFF
--- a/packages/agent-sdk/src/managers/pluginManager.ts
+++ b/packages/agent-sdk/src/managers/pluginManager.ts
@@ -138,7 +138,14 @@ export class PluginManager {
                 continue;
               }
             } catch {
-              // Manifest read failed (marketplace not cloned yet?) — fall through to installPlugin
+              // Manifest read failed — marketplace may not be cloned yet, try to clone/update it
+              try {
+                await marketplaceService.updateMarketplace(marketplaceName);
+              } catch (updateError) {
+                logger?.warn(
+                  `Failed to clone/update marketplace ${marketplaceName}: ${updateError instanceof Error ? updateError.message : String(updateError)}`,
+                );
+              }
             }
 
             logger?.info(`Auto-installing missing plugin: ${pluginId}`);


### PR DESCRIPTION
## Problem

When auto-installing a plugin from a marketplace that hasn't been cloned to disk yet, `loadMarketplaceManifest` throws because the manifest file doesn't exist. The empty `catch` block in `pluginManager.ts` previously just fell through to `installPlugin`, which would fail with the same error:

```
Error: Marketplace manifest not found at /root/.wave/plugins/marketplaces/netease-lcap/wave-plugins-official/.wave-plugin/marketplace.json
```

## Fix

When the manifest read fails (catch block at line 140), attempt to clone/update the marketplace via `marketplaceService.updateMarketplace(marketplaceName)` before falling through to `installPlugin`. This ensures the marketplace repo is available on disk so the install can succeed.

If the clone/update also fails, we log a warning and still fall through — `installPlugin` will handle the error appropriately.

## Testing

Let CI verify type checks, lint, and tests pass.