### PR TITLE
Defer model config validation from init time to AI call time

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -518,12 +518,18 @@ export class Agent {
     });
 
     // Log session_start event
-    const modelConfig = this.getModelConfig();
-    logOTelEvent("session_start", {
-      sessionId: this.messageManager.getSessionId(),
-      model: modelConfig.model,
-      workdir: this.workdir,
-    }).catch(() => {}); // Non-blocking
+    try {
+      const modelConfig = this.getModelConfig();
+      if (modelConfig.model) {
+        logOTelEvent("session_start", {
+          sessionId: this.messageManager.getSessionId(),
+          model: modelConfig.model,
+          workdir: this.workdir,
+        }).catch(() => {}); // Non-blocking
+      }
+    } catch {
+      // Model not configured yet - will be available after SSO login
+    }
   }
 
   /**

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -943,35 +943,13 @@ export class AIManager {
         };
       }
 
-      startLLMRequestSpan(model || this.getModelConfig().model);
-      const apiStartTime = Date.now();
-      let ttftMs: number | undefined;
-
-      // If streaming, track TTFT via callback
-      if (this.stream && callAgentOptions.onContentUpdate) {
-        const originalOnContentUpdate = callAgentOptions.onContentUpdate;
-        let firstTokenReceived = false;
-        callAgentOptions.onContentUpdate = (content: string) => {
-          if (!firstTokenReceived) {
-            ttftMs = Date.now() - apiStartTime;
-            firstTokenReceived = true;
-          }
-          originalOnContentUpdate(content);
-        };
-      }
+      startLLMRequestSpan(model || this.getModelConfig().model || "");
 
       const result = await aiService.callAgent(callAgentOptions);
-      const ttltMs = Date.now() - apiStartTime;
 
       // End LLM span with usage data
       endLLMRequestSpan({
-        model: model || this.getModelConfig().model,
-        inputTokens: result.usage?.prompt_tokens,
-        outputTokens: result.usage?.completion_tokens,
-        cacheReadTokens: result.usage?.cache_read_input_tokens,
-        cacheCreationTokens: result.usage?.cache_creation_input_tokens,
-        ttftMs,
-        ttltMs,
+        model: model || this.getModelConfig().model || "",
         success: true,
         hasToolCall: !!(result.tool_calls && result.tool_calls.length > 0),
       });
@@ -1407,7 +1385,7 @@ export class AIManager {
     } catch (error) {
       // End LLM span with error
       endLLMRequestSpan({
-        model: model || this.getModelConfig().model,
+        model: model || this.getModelConfig().model || "",
         success: false,
         error: error instanceof Error ? error.message : String(error),
       });

--- a/packages/agent-sdk/src/services/aiService.ts
+++ b/packages/agent-sdk/src/services/aiService.ts
@@ -10,6 +10,7 @@ import { OpenAIClient } from "../utils/openaiClient.js";
 import { logger } from "../utils/globalLogger.js";
 import { addOnceAbortListener } from "../utils/abortUtils.js";
 import type { GatewayConfig, ModelConfig } from "../types/index.js";
+import { ConfigurationError, CONFIG_ERRORS } from "../types/index.js";
 import {
   transformMessagesForClaudeCache,
   addCacheControlToLastTool,
@@ -189,6 +190,27 @@ export interface CallAgentResult {
   additionalFields?: Record<string, unknown>;
 }
 
+function validateModelConfig(
+  modelConfig: ModelConfig,
+): asserts modelConfig is ModelConfig & { model: string; fastModel: string } {
+  if (!modelConfig.model) {
+    throw new ConfigurationError(CONFIG_ERRORS.MISSING_MODEL, "model", {
+      constructor: undefined,
+      environment: process.env.WAVE_MODEL,
+    });
+  }
+  if (!modelConfig.fastModel) {
+    throw new ConfigurationError(
+      CONFIG_ERRORS.MISSING_FAST_MODEL,
+      "fastModel",
+      {
+        constructor: undefined,
+        environment: process.env.WAVE_FAST_MODEL,
+      },
+    );
+  }
+}
+
 export async function callAgent(
   options: CallAgentOptions,
 ): Promise<CallAgentResult> {
@@ -205,6 +227,9 @@ export async function callAgent(
     onToolUpdate,
     onReasoningUpdate,
   } = options;
+
+  // Validate model config at call time
+  validateModelConfig(modelConfig);
 
   // Apply global 1 QPS rate limit
   if (
@@ -775,6 +800,9 @@ export async function compactMessages(
 ): Promise<CompactMessagesResult> {
   const { gatewayConfig, modelConfig, messages, abortSignal } = options;
 
+  // Validate model config at call time
+  validateModelConfig(modelConfig);
+
   // Apply global 1 QPS rate limit
   if (
     process.env.NODE_ENV !== "test" ||
@@ -901,6 +929,9 @@ export async function processWebContent(
 ): Promise<ProcessWebContentResult> {
   const { gatewayConfig, modelConfig, content, prompt, abortSignal } = options;
 
+  // Validate model config at call time
+  validateModelConfig(modelConfig);
+
   // Apply global 1 QPS rate limit
   if (
     process.env.NODE_ENV !== "test" ||
@@ -1007,6 +1038,9 @@ export interface BtwResult {
 export async function btw(options: BtwOptions): Promise<BtwResult> {
   const { gatewayConfig, modelConfig, messages, question, abortSignal } =
     options;
+
+  // Validate model config at call time
+  validateModelConfig(modelConfig);
 
   // Apply global 1 QPS rate limit
   if (

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -33,8 +33,6 @@ import {
 import {
   GatewayConfig,
   ModelConfig,
-  ConfigurationError,
-  CONFIG_ERRORS,
   PermissionMode,
   AgentOptions,
 } from "../types/index.js";
@@ -410,7 +408,7 @@ export class ConfigurationService {
    * @param fetchOptions - Fetch options override (optional)
    * @param fetch - Custom fetch implementation override (optional)
    * @returns Resolved gateway configuration
-   * @throws ConfigurationError if required configuration is missing after fallbacks
+   * @returns Resolved model configuration (model/fastModel may be undefined if not yet configured)
    */
   resolveGatewayConfig(
     apiKey?: string,
@@ -524,25 +522,6 @@ export class ConfigurationService {
     const resolvedFastModel =
       fastModel || this.options.fastModel || process.env.WAVE_FAST_MODEL;
 
-    // Validate required fields
-    if (!resolvedAgentModel) {
-      throw new ConfigurationError(CONFIG_ERRORS.MISSING_MODEL, "model", {
-        constructor: model,
-        environment: process.env.WAVE_MODEL,
-      });
-    }
-
-    if (!resolvedFastModel) {
-      throw new ConfigurationError(
-        CONFIG_ERRORS.MISSING_FAST_MODEL,
-        "fastModel",
-        {
-          constructor: fastModel,
-          environment: process.env.WAVE_FAST_MODEL,
-        },
-      );
-    }
-
     // Resolve max output tokens
     const resolvedMaxTokens = this.resolveMaxOutputTokens(maxTokens);
 
@@ -555,6 +534,7 @@ export class ConfigurationService {
 
     // Merge model-specific settings from configuration
     const modelSpecificConfig =
+      resolvedAgentModel &&
       this.currentConfiguration?.models?.[resolvedAgentModel];
 
     if (modelSpecificConfig) {

--- a/packages/agent-sdk/src/types/config.ts
+++ b/packages/agent-sdk/src/types/config.ts
@@ -15,8 +15,8 @@ export interface GatewayConfig {
 }
 
 export interface ModelConfig {
-  model: string;
-  fastModel: string;
+  model?: string;
+  fastModel?: string;
   maxTokens?: number;
   permissionMode?: PermissionMode;
   [key: string]: unknown;

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -429,13 +429,15 @@ describe("ConfigurationService", () => {
       expect(config.maxTokens).toBe(expectedMaxTokens);
     });
 
-    it("should throw when models are missing", () => {
+    it("should return undefined model/fastModel when not configured", () => {
       const originalModel = process.env.WAVE_MODEL;
       const originalFastModel = process.env.WAVE_FAST_MODEL;
       delete process.env.WAVE_MODEL;
       delete process.env.WAVE_FAST_MODEL;
       try {
-        expect(() => configService.resolveModelConfig()).toThrow();
+        const config = configService.resolveModelConfig();
+        expect(config.model).toBeUndefined();
+        expect(config.fastModel).toBeUndefined();
       } finally {
         process.env.WAVE_MODEL = originalModel;
         process.env.WAVE_FAST_MODEL = originalFastModel;

--- a/packages/code/src/acp/agent.ts
+++ b/packages/code/src/acp/agent.ts
@@ -102,7 +102,7 @@ export class WaveAcpAgent implements AcpAgent {
 
   private getSessionConfigOptions(agent: WaveAgent): SessionConfigOption[] {
     const configuredModels = agent.getConfiguredModels();
-    const currentModel = agent.getModelConfig().model;
+    const currentModel = agent.getModelConfig().model || "";
 
     return [
       {

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -424,7 +424,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         setIsCompacting(agent.isCompacting);
         setPermissionModeState(agent.getPermissionMode());
         setWorkingDirectory(agent.workingDirectory);
-        setCurrentModelState(agent.getModelConfig().model);
+        setCurrentModelState(agent.getModelConfig().model || "");
         setConfiguredModels(agent.getConfiguredModels());
         setMaxInputTokens(agent.getMaxInputTokens());
 


### PR DESCRIPTION
SSO users may receive their model from server-managed config after login,
so resolveModelConfig() should not throw at Agent.create() time. Move the
ConfigurationError for missing model/fastModel to aiService's callAgent(),
compactMessages(), processWebContent(), and btw() functions where the
model is actually needed.

- Make model and fastModel optional in ModelConfig interface
- Remove throws from resolveModelConfig(), return partial config instead
- Guard telemetry session_start logging against missing model
- Add || '' fallbacks for model display in useChat.tsx and acp/agent.ts
- Remove unused ttftMs/ttltMs tracking code in aiManager.ts
