### PR TITLE
feat(bash): cancel timeout for background tasks and auto-background on timeout

### DIFF
--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -18,6 +18,17 @@ import {
 
 const BASH_DEFAULT_TIMEOUT_MS = 120000;
 
+// Commands that should not be auto-backgrounded on timeout (e.g. sleep should just be killed)
+const DISALLOWED_AUTO_BACKGROUND_COMMANDS = ["sleep"];
+
+function isAutobackgroundingAllowed(command: string): boolean {
+  const trimmed = command.trim();
+  // Get the first word of the command
+  const baseCommand = trimmed.split(/\s+/)[0];
+  if (!baseCommand) return true;
+  return !DISALLOWED_AUTO_BACKGROUND_COMMANDS.includes(baseCommand);
+}
+
 /**
  * Bash command execution tool - supports both foreground and background execution
  */
@@ -125,9 +136,12 @@ The working directory persists between commands. Try to maintain your current wo
     const runInBackground = args.run_in_background as boolean | undefined;
     const description = args.description as string | undefined;
     // Set default timeout: BASH_DEFAULT_TIMEOUT_MS for foreground, no timeout for background
-    const timeout =
-      (args.timeout as number | undefined) ??
-      (runInBackground ? undefined : BASH_DEFAULT_TIMEOUT_MS);
+    // When run_in_background is explicitly set, cancel any timeout — the intent is to
+    // let the process run to completion (matching Claude Code behavior where background()
+    // clears the timeout via cleanupListeners).
+    const timeout = runInBackground
+      ? undefined
+      : ((args.timeout as number | undefined) ?? BASH_DEFAULT_TIMEOUT_MS);
 
     if (!command || typeof command !== "string") {
       return {
@@ -195,7 +209,7 @@ The working directory persists between commands. Try to maintain your current wo
         };
       }
 
-      const { id: taskId } = backgroundTaskManager.startShell(command, timeout);
+      const { id: taskId } = backgroundTaskManager.startShell(command);
       const task = backgroundTaskManager.getTask(taskId);
       const outputPath = task?.outputPath;
       const backgroundMsg = [
@@ -300,12 +314,47 @@ The working directory persists between commands. Try to maintain your current wo
         });
       }
 
-      // Set up timeout
+      // Set up timeout — auto-background if allowed, otherwise kill
       let timeoutHandle: NodeJS.Timeout | undefined;
+      const shouldAutoBackground =
+        !!context.backgroundTaskManager && isAutobackgroundingAllowed(command);
       if (timeout && timeout > 0) {
         timeoutHandle = setTimeout(() => {
-          if (!isAborted) {
-            handleAbort("Command timed out");
+          if (!isAborted && !isBackgrounded) {
+            if (shouldAutoBackground) {
+              // Auto-background: move the process to background task manager instead of killing it
+              isBackgrounded = true;
+              if (timeoutHandle) {
+                clearTimeout(timeoutHandle);
+              }
+
+              // Unregister foreground task since it's now backgrounded
+              if (context.foregroundTaskManager) {
+                context.foregroundTaskManager.unregisterForegroundTask(
+                  foregroundTaskId,
+                );
+              }
+
+              const backgroundTaskManager = context.backgroundTaskManager!;
+              const taskId = backgroundTaskManager.adoptProcess(
+                child,
+                command,
+                outputBuffer,
+                errorBuffer,
+              );
+              const task = backgroundTaskManager.getTask(taskId);
+              const outputPath = task?.outputPath;
+              logger.info(
+                `[Bash] Command timed out after ${timeout}ms, auto-backgrounded as ${taskId}`,
+              );
+              resolve({
+                success: true,
+                content: `Command timed out after ${timeout / 1000} seconds and was moved to background with ID: ${taskId}.${outputPath ? ` Real-time output: ${outputPath}` : ""}`,
+                shortResult: `Process ${taskId} auto-backgrounded (timeout)`,
+              });
+            } else {
+              handleAbort("Command timed out");
+            }
           }
         }, timeout);
       }

--- a/packages/agent-sdk/tests/tools/bashTool.test.ts
+++ b/packages/agent-sdk/tests/tools/bashTool.test.ts
@@ -275,7 +275,37 @@ describe("bashTool", () => {
       expect(result3).toBe("say hello");
     });
 
-    it("should handle command timeout", async () => {
+    it("should auto-background on timeout for allowed commands", async () => {
+      vi.useFakeTimers();
+      const mockProcess = {
+        pid: 1234,
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+        on: vi.fn(),
+        kill: vi.fn(),
+        killed: false,
+      };
+      mockSpawn.mockReturnValue(mockProcess as unknown as ChildProcess);
+
+      const promise = bashTool.execute(
+        {
+          command: "long-build",
+          timeout: 1000,
+        },
+        context,
+      );
+
+      vi.advanceTimersByTime(1001);
+      const result = await promise;
+
+      expect(result.success).toBe(true);
+      expect(result.content).toContain("timed out after 1 seconds");
+      expect(result.content).toContain("moved to background");
+      expect(result.shortResult).toContain("auto-backgrounded (timeout)");
+      vi.useRealTimers();
+    });
+
+    it("should kill on timeout for sleep commands (not auto-backgrounded)", async () => {
       vi.useFakeTimers();
       const mockProcess = {
         pid: 1234,
@@ -304,7 +334,7 @@ describe("bashTool", () => {
       vi.useRealTimers();
     });
 
-    it("should handle command timeout with existing output", async () => {
+    it("should auto-background on timeout with existing output", async () => {
       vi.useFakeTimers();
       const mockProcess = {
         pid: 1234,
@@ -324,7 +354,7 @@ describe("bashTool", () => {
 
       const promise = bashTool.execute(
         {
-          command: "sleep 10",
+          command: "long-build",
           timeout: 1000,
         },
         context,
@@ -336,9 +366,8 @@ describe("bashTool", () => {
       vi.advanceTimersByTime(1001);
       const result = await promise;
 
-      expect(result.success).toBe(false);
-      expect(result.error).toBe("Command timed out");
-      expect(result.content).toBe("some output\n\nCommand timed out");
+      expect(result.success).toBe(true);
+      expect(result.content).toContain("moved to background");
       vi.useRealTimers();
     });
 

--- a/specs/002-bash-tools/spec.md
+++ b/specs/002-bash-tools/spec.md
@@ -17,7 +17,8 @@ As an AI agent, I want to execute shell commands in the foreground so that I can
 **Acceptance Scenarios**:
 
 1. **Given** a command to execute, **When** the `Bash` tool is called, **Then** it MUST return the command's output (stdout and stderr).
-2. **Given** a command that takes time, **When** it exceeds the timeout, **Then** it MUST be terminated and return a timeout error.
+2. **Given** a foreground command that takes time, **When** it exceeds the timeout, **Then** it MUST be auto-backgrounded (if the command is allowed) or terminated (if not allowed, e.g. `sleep`).
+3. **Given** a foreground command that times out and is auto-backgrounded, **Then** the agent MUST receive a message indicating the process was moved to background with its task ID and output path.
 
 ---
 
@@ -32,8 +33,9 @@ As an AI agent, I want to run long-running commands in the background and retrie
 **Acceptance Scenarios**:
 
 1. **Given** `run_in_background` is true, **When** `Bash` is called, **Then** it MUST return a `bash_id` and an `outputPath` to a real-time log file immediately.
-2. **Given** a running background process, **When** `TaskStop` (formerly `KillBash`) is called with its ID, **Then** the process MUST be terminated.
-3. **Given** a background process started, **When** I read the provided `outputPath` file using the `Read` tool, **Then** I should see the real-time output of the process.
+2. **Given** `run_in_background` is true, **Then** the command MUST run without any timeout — it continues until completion or manual stop.
+3. **Given** a running background process, **When** `TaskStop` (formerly `KillBash`) is called with its ID, **Then** the process MUST be terminated.
+4. **Given** a background process started, **When** I read the provided `outputPath` file using the `Read` tool, **Then** I should see the real-time output of the process.
 
 ---
 
@@ -60,14 +62,17 @@ As an AI agent, I want to see the output of foreground commands in real-time so 
 - **Process Group Termination**: When killing a background process, it should terminate the entire process group to avoid leaving orphan processes.
 - **Invalid Task ID**: Calling `TaskStop` with a non-existent or expired ID should return a clear error message.
 - **Fresh Shell per Command**: Each foreground command spawns a new shell; `cd` and env changes do not persist between calls.
+- **Timeout Auto-Backgrounding**: When a foreground command times out, the system MUST auto-background it (move to `BackgroundTaskManager`) instead of killing it, unless the command starts with `sleep` (which is killed as before).
+- **Background No Timeout**: When `run_in_background` is explicitly `true`, any timeout (default or explicit) MUST be cancelled — the process runs indefinitely until completion or manual stop.
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
 - **FR-001**: System MUST provide a `Bash` tool for executing shell commands.
-- **FR-002**: `Bash` tool MUST support an optional `timeout` parameter (default 120s for foreground).
+- **FR-002**: `Bash` tool MUST support an optional `timeout` parameter (default 120s for foreground). When `run_in_background` is true, the timeout MUST be cancelled (no timeout applied) — background processes run until completion or manual stop.
 - **FR-003**: `Bash` tool MUST support a `run_in_background` parameter.
+- **FR-019**: When a foreground command times out, the system MUST auto-background it (via `adoptProcess`) instead of killing it, unless the command's base command is in `DISALLOWED_AUTO_BACKGROUND_COMMANDS` (currently `["sleep"]`), in which case it MUST be killed as before.
 - **FR-004**: System MUST NOT provide a `TaskOutput` (formerly `BashOutput`) tool; instead, agents SHOULD use the `Read` tool to read the `outputPath`.
 - **FR-006**: System MUST provide a `TaskStop` (formerly `KillBash`) tool to terminate background processes.
 - **FR-007**: All bash output MUST have ANSI color codes stripped.

--- a/specs/061-task-background-execution/spec.md
+++ b/specs/061-task-background-execution/spec.md
@@ -107,13 +107,16 @@ As a user, I want to be automatically notified in the chat when a background tas
 - **Concurrent Access**: Multiple requests for output from the same background task.
 - **Ctrl-B pressed when no tool is running**: The system should ignore the keypress.
 - **Direct user bash commands (`!command`)**: Commands initiated directly by the user using the `!` prefix MUST NOT be affected by Ctrl-B.
+- **Timeout auto-backgrounding**: When a foreground Bash command times out, the process is auto-backgrounded instead of killed (unless the command starts with `sleep`). This preserves long-running work that just needs more time.
+- **Background tasks have no timeout**: Explicitly backgrounded tasks (`run_in_background: true`) ignore both default and explicit timeouts, running until completion or manual stop.
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
 - **FR-001**: The `Task` tool MUST support a `run_in_background` boolean parameter.
-- **FR-002**: When `run_in_background` is true, the system MUST initiate the task asynchronously and return a unique `task_id` and an `outputPath` to a real-time log file immediately.
+- **FR-002**: When `run_in_background` is true, the system MUST initiate the task asynchronously and return a unique `task_id` and an `outputPath` to a real-time log file immediately. The task MUST run without any timeout — background tasks continue until completion or manual stop.
+- **FR-027**: When a foreground Bash command times out, the system MUST auto-background it (via `BackgroundTaskManager.adoptProcess`) instead of killing it, unless the command's base command is in `DISALLOWED_AUTO_BACKGROUND_COMMANDS` (currently `["sleep"]`). Auto-backgrounded tasks receive a completion notification just like explicitly backgrounded tasks.
 - **FR-003**: The system MUST NOT provide a `TaskOutput` tool; instead, agents SHOULD use the `Read` tool to read the `outputPath`.
 - **FR-007**: The system MUST provide a `TaskStop` tool to terminate running background tasks.
 - **FR-008**: `TaskStop` MUST support a `task_id` parameter.

--- a/specs/README.md
+++ b/specs/README.md
@@ -30,16 +30,16 @@ This directory contains feature specifications that serve as the source of truth
 |--------|-------|
 | Specs | 56 |
 | User Stories | 244 |
-| Functional Requirements | 927 |
-| Test Files | 312 |
-| Test Cases | 3,976 |
+| Functional Requirements | 929 |
+| Test Files | 314 |
+| Test Cases | 4,013 |
 
 ## Specs
 
 | Feature | Description | US | FR | Links |
 |---------|-------------|----|----|-------|
 | File System Tools | Read, Write, Edit, Glob, Grep tools for file operations | 3 | 19 | [spec](001-fs-tools/spec.md) · [plan](001-fs-tools/plan.md) |
-| Bash Tools | Bash, BashOutput, KillBash tools for shell command execution | 3 | 17 | [spec](002-bash-tools/spec.md) · [plan](002-bash-tools/plan.md) |
+| Bash Tools | Bash, BashOutput, KillBash tools for shell command execution | 3 | 18 | [spec](002-bash-tools/spec.md) · [plan](002-bash-tools/plan.md) |
 | MCP | Model Context Protocol support for external tools and context sources | 4 | 23 | [spec](003-mcp/spec.md) · [plan](003-mcp/plan.md) |
 | Session Management | Performance-optimized, project-based session management system | 3 | 17 | [spec](004-session-management/spec.md) · [plan](004-session-management/plan.md) |
 | Hooks | Event hooks system for extending Wave behavior | 16 | 62 | [spec](005-hooks/spec.md) · [plan](005-hooks/plan.md) |
@@ -78,7 +78,7 @@ This directory contains feature specifications that serve as the source of truth
 | Rewind Command | `/rewind` to revert conversation to a previous user message, reverting file changes | 3 | 10 | [spec](056-rewind-command/spec.md) · [plan](056-rewind-command/plan.md) |
 | History Search | Ctrl+R history search for reusing previous prompts from `~/.wave/history.jsonl` | 2 | 10 | [spec](057-history-search-prompt/spec.md) · [plan](057-history-search-prompt/plan.md) |
 | General Purpose Agent | Built-in subagent for complex research, code search, and multi-step tasks | 2 | 7 | [spec](058-general-purpose-agent/spec.md) · [plan](058-general-purpose-agent/plan.md) |
-| Task Background Execution | `run_in_background`, `TaskOutput`/`TaskStop` tools, `/tasks` command replacing `/bashes` | 6 | 23 | [spec](061-task-background-execution/spec.md) · [plan](061-task-background-execution/plan.md) |
+| Task Background Execution | `run_in_background`, `TaskOutput`/`TaskStop` tools, `/tasks` command replacing `/bashes` | 6 | 24 | [spec](061-task-background-execution/spec.md) · [plan](061-task-background-execution/plan.md) |
 | Task Management Tools | TaskCreate/TaskGet/TaskUpdate/TaskList with `~/.wave/tasks/` storage and task list UI | 5 | 15 | [spec](063-task-management-tools/spec.md) · [plan](063-task-management-tools/plan.md) |
 | Plan Subagent | Built-in Plan subagent for designing implementation plans before coding | 4 | 16 | [spec](065-plan-subagent/spec.md) · [plan](065-plan-subagent/plan.md) |
 | Bash Subagent | Built-in Bash subagent for executing shell commands | 1 | 7 | [spec](066-bash-subagent/spec.md) · [plan](066-bash-subagent/plan.md) |


### PR DESCRIPTION
- When run_in_background is explicitly set, cancel any timeout (default or
  explicit) so background processes run until completion or manual stop,
  matching Claude Code behavior where background() clears the timeout.
- When a foreground command times out, auto-background it via adoptProcess
  instead of killing it, unless the command starts with 'sleep' (which is
  killed as before, matching Claude Code's DISALLOWED_AUTO_BACKGROUND_COMMANDS).
- Add isAutobackgroundingAllowed() and DISALLOWED_AUTO_BACKGROUND_COMMANDS.
- Update specs 002-bash-tools and 061-task-background-execution.
