### PR TITLE
fix: immediate slash commands bypass queue + StatusLine goal rendering

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -852,11 +852,22 @@ export class Agent {
     content: string,
     images?: Array<{ path: string; mimeType: string }>,
   ): Promise<void> {
-    // If the agent is busy, enqueue the message
+    // If the agent is busy, enqueue the message — unless it's an immediate
+    // slash command (e.g., /goal clear, /clear, /compact) that should execute
+    // right away even while AI is processing
     if (this.aiManager.isLoading || this.isCommandRunning) {
-      this.messageQueue.enqueue({ content, images });
-      this.options.callbacks?.onQueuedMessagesChange?.(this.queuedMessages);
-      return;
+      const trimmed = content.trim();
+      const isImmediate =
+        trimmed.startsWith("/") &&
+        trimmed !== "/" &&
+        this.slashCommandManager.isImmediateCommand(trimmed);
+
+      if (!isImmediate) {
+        this.messageQueue.enqueue({ content, images });
+        this.options.callbacks?.onQueuedMessagesChange?.(this.queuedMessages);
+        return;
+      }
+      // Immediate slash command: fall through to InteractionService
     }
 
     await InteractionService.sendMessage(

--- a/packages/agent-sdk/src/managers/slashCommandManager.ts
+++ b/packages/agent-sdk/src/managers/slashCommandManager.ts
@@ -102,6 +102,7 @@ export class SlashCommandManager {
       id: "clear",
       name: "clear",
       description: "Clear conversation history and reset session",
+      immediate: true,
       handler: async () => {
         this.aiManager.abortAIMessage();
 
@@ -172,6 +173,7 @@ export class SlashCommandManager {
       id: "compact",
       name: "compact",
       description: "Compact conversation history to reduce context usage",
+      immediate: true,
       handler: async (args?: string, signal?: AbortSignal) => {
         this.aiManager.abortAIMessage();
 
@@ -189,6 +191,13 @@ export class SlashCommandManager {
       id: "goal",
       name: "goal",
       description: "Set, check, or clear an autonomous goal for the session",
+      immediate: (args?: string) => {
+        const trimmed = args?.trim() ?? "";
+        return (
+          !trimmed ||
+          ["clear", "stop", "off", "reset", "none", "cancel"].includes(trimmed)
+        );
+      },
       handler: async (args?: string) => {
         const goalManager = this.goalManager;
         if (!goalManager) {
@@ -670,6 +679,18 @@ export class SlashCommandManager {
    */
   public hasCommand(commandId: string): boolean {
     return this.commands.has(commandId);
+  }
+
+  /**
+   * Check if a slash command should bypass the message queue when AI is busy.
+   * Returns true for commands marked as immediate (boolean or function).
+   */
+  public isImmediateCommand(input: string): boolean {
+    const { command: commandId, args } = parseSlashCommandInput(input);
+    const command = this.commands.get(commandId);
+    if (!command?.immediate) return false;
+    if (typeof command.immediate === "boolean") return command.immediate;
+    return command.immediate(args);
   }
 
   /**

--- a/packages/agent-sdk/src/types/commands.ts
+++ b/packages/agent-sdk/src/types/commands.ts
@@ -8,6 +8,10 @@ export interface SlashCommand {
   name: string;
   description: string;
   handler: (args?: string, signal?: AbortSignal) => Promise<void> | void;
+  /** Whether this command should bypass the message queue when AI is busy.
+   * - `true`: always immediate
+   * - Function: receives args, returns true for immediate variants */
+  immediate?: boolean | ((args?: string) => boolean);
 }
 
 export interface CustomSlashCommandConfig {

--- a/packages/code/src/components/StatusLine.tsx
+++ b/packages/code/src/components/StatusLine.tsx
@@ -39,28 +39,30 @@ export const StatusLine: React.FC<StatusLineProps> = ({
           Shell: <Text color="yellow">Run shell command</Text>
         </Text>
       ) : (
-        <Text color="gray">
+        <Box>
           {isGoalActive && (
-            <>
+            <Text color="gray">
               <Text color="cyan">◎ /goal</Text> active{" "}
               {goalElapsed && <Text>({goalElapsed})</Text>} |{" "}
-            </>
+            </Text>
           )}
-          Mode:{" "}
-          <Text
-            color={
-              permissionMode === "plan"
-                ? "yellow"
-                : permissionMode === "bypassPermissions"
-                  ? "red"
-                  : "cyan"
-            }
-            bold={permissionMode === "bypassPermissions"}
-          >
-            {permissionMode}
-          </Text>{" "}
-          (Shift+Tab to cycle)
-        </Text>
+          <Text color="gray">
+            Mode:{" "}
+            <Text
+              color={
+                permissionMode === "plan"
+                  ? "yellow"
+                  : permissionMode === "bypassPermissions"
+                    ? "red"
+                    : "cyan"
+              }
+              bold={permissionMode === "bypassPermissions"}
+            >
+              {permissionMode}
+            </Text>{" "}
+            (Shift+Tab to cycle)
+          </Text>
+        </Box>
       )}
       {percentage > 0 && (
         <Text color={contextColor}>{percentage}% context</Text>


### PR DESCRIPTION
- Allow immediate slash commands (/clear, /compact, /goal status/clear) to bypass the message queue when AI is busy, following Claude Code's immediate flag pattern. /goal <condition> stays queued since it triggers AI.
- Fix StatusLine not rendering mode text when goal is active - split single Text with fragment into Box with sibling Text elements to avoid Ink rendering bug.

Commits:
- f6fae371 fix: allow immediate slash commands to bypass message queue when AI is busy
- 36ae30e5 fix: render mode text in StatusLine when goal is active