### PR TITLE
feat(code): handle long task lists with terminal-adaptive display, priority sorting, and auto-hide

### DIFF
--- a/packages/code/src/components/TaskList.tsx
+++ b/packages/code/src/components/TaskList.tsx
@@ -1,34 +1,157 @@
 import React from "react";
 import { useChat } from "../contexts/useChat.js";
-import { Box, Text } from "ink";
+import { Box, Text, useStdout } from "ink";
 import { useTasks } from "../hooks/useTasks.js";
+import type { Task, TaskStatus } from "wave-agent-sdk";
+
+const RECENTLY_COMPLETED_TTL_MS = 30_000;
+const AUTO_HIDE_DELAY_MS = 5_000;
+
+export const getStatusIcon = (status: TaskStatus): React.ReactNode => {
+  switch (status) {
+    case "pending":
+      return <Text color="gray">□</Text>;
+    case "in_progress":
+      return <Text color="yellow">■</Text>;
+    case "completed":
+      return <Text color="green">✓</Text>;
+    case "deleted":
+      return <Text color="red">✕</Text>;
+    default:
+      return <Text color="gray">?</Text>;
+  }
+};
+
+export function sortTasksByPriority(
+  tasks: Task[],
+  recentlyCompleted: Map<string, number>,
+  now: number,
+): Task[] {
+  const getPriority = (task: Task): number => {
+    const completedAt = recentlyCompleted.get(task.id);
+    const isRecentlyCompleted =
+      completedAt !== undefined &&
+      now - completedAt < RECENTLY_COMPLETED_TTL_MS;
+
+    if (isRecentlyCompleted) return 0;
+    if (task.status === "in_progress") return 1;
+    if (task.status === "pending" && task.blockedBy.length === 0) return 2;
+    if (task.status === "pending" && task.blockedBy.length > 0) return 3;
+    if (task.status === "completed") return 4;
+    if (task.status === "deleted") return 5;
+    return 6;
+  };
+
+  return [...tasks].sort((a, b) => getPriority(a) - getPriority(b));
+}
+
+function getDisplayLimit(rows: number | undefined): number {
+  const available = rows ?? 24;
+  return Math.min(8, Math.max(3, available - 12));
+}
 
 export const TaskList: React.FC = () => {
   const tasks = useTasks();
   const { isTaskListVisible } = useChat();
+  const { stdout } = useStdout();
 
-  if (tasks.length === 0 || !isTaskListVisible) {
+  const recentlyCompletedRef = React.useRef<Map<string, number>>(new Map());
+  const autoHideTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const [autoHidden, setAutoHidden] = React.useState(false);
+  const [, setTick] = React.useState(0);
+
+  const now = Date.now();
+  const activeTasks = tasks.filter((t) => t.status !== "deleted");
+
+  // Track recently completed tasks
+  for (const task of tasks) {
+    if (
+      task.status === "completed" &&
+      !recentlyCompletedRef.current.has(task.id)
+    ) {
+      recentlyCompletedRef.current.set(task.id, now);
+    }
+  }
+
+  // Prune expired entries and force re-render if any expired
+  const needsTick = React.useMemo(() => {
+    let expired = false;
+    for (const [id, ts] of recentlyCompletedRef.current) {
+      if (now - ts >= RECENTLY_COMPLETED_TTL_MS) {
+        recentlyCompletedRef.current.delete(id);
+        expired = true;
+      }
+    }
+    return expired;
+  }, [now]);
+
+  React.useEffect(() => {
+    if (needsTick) {
+      setTick((t) => t + 1);
+    }
+  }, [needsTick]);
+
+  // Auto-hide logic: when all active tasks are completed
+  const allCompleted =
+    activeTasks.length > 0 &&
+    activeTasks.every((t) => t.status === "completed");
+
+  React.useEffect(() => {
+    if (allCompleted && !autoHidden) {
+      autoHideTimerRef.current = setTimeout(() => {
+        setAutoHidden(true);
+      }, AUTO_HIDE_DELAY_MS);
+    }
+    if (!allCompleted && autoHidden) {
+      setAutoHidden(false);
+    }
+    return () => {
+      if (autoHideTimerRef.current) {
+        clearTimeout(autoHideTimerRef.current);
+        autoHideTimerRef.current = null;
+      }
+    };
+  }, [allCompleted, autoHidden]);
+
+  if (tasks.length === 0 || !isTaskListVisible || autoHidden) {
     return null;
   }
 
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case "pending":
-        return <Text color="gray">□</Text>;
-      case "in_progress":
-        return <Text color="yellow">■</Text>;
-      case "completed":
-        return <Text color="green">✓</Text>;
-      case "deleted":
-        return <Text color="red">✕</Text>;
-      default:
-        return <Text color="gray">?</Text>;
-    }
-  };
+  const displayLimit = getDisplayLimit(stdout?.rows);
+  const sorted = sortTasksByPriority(tasks, recentlyCompletedRef.current, now);
+  const displayed = sorted.slice(0, displayLimit);
+  const hidden = sorted.slice(displayLimit);
+
+  const doneCount = tasks.filter((t) => t.status === "completed").length;
+  const inProgressCount = tasks.filter(
+    (t) => t.status === "in_progress",
+  ).length;
+  const openCount = tasks.filter(
+    (t) => t.status === "pending" || t.status === "in_progress",
+  ).length;
+
+  // Summary parts for hidden tasks
+  const hiddenInProgress = hidden.filter(
+    (t) => t.status === "in_progress",
+  ).length;
+  const hiddenPending = hidden.filter((t) => t.status === "pending").length;
+  const hiddenCompleted = hidden.filter((t) => t.status === "completed").length;
+
+  const summaryParts: string[] = [];
+  if (hiddenInProgress > 0)
+    summaryParts.push(`${hiddenInProgress} in progress`);
+  if (hiddenPending > 0) summaryParts.push(`${hiddenPending} pending`);
+  if (hiddenCompleted > 0) summaryParts.push(`${hiddenCompleted} completed`);
 
   return (
     <Box flexDirection="column">
-      {tasks.map((task) => {
+      <Text dimColor>
+        {tasks.length} tasks ({doneCount} done, {inProgressCount} in progress,{" "}
+        {openCount} open)
+      </Text>
+      {displayed.map((task) => {
         const isDimmed =
           task.status === "completed" || task.status === "deleted";
         const isBlocked = task.blockedBy && task.blockedBy.length > 0;
@@ -46,10 +169,18 @@ export const TaskList: React.FC = () => {
         return (
           <Box key={task.id} gap={1}>
             {getStatusIcon(task.status)}
-            <Text dimColor={isDimmed}>{fullText}</Text>
+            <Text dimColor={isDimmed} wrap="truncate-end">
+              {fullText}
+            </Text>
           </Box>
         );
       })}
+      {hidden.length > 0 && (
+        <Text dimColor>
+          {" "}
+          +{hidden.length} {summaryParts.join(", ")}
+        </Text>
+      )}
     </Box>
   );
 };

--- a/packages/code/tests/components/TaskList.test.tsx
+++ b/packages/code/tests/components/TaskList.test.tsx
@@ -1,9 +1,14 @@
 import { render } from "ink-testing-library";
 import React from "react";
-import { describe, it, expect, vi } from "vitest";
-import { TaskList } from "../../src/components/TaskList.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  TaskList,
+  getStatusIcon,
+  sortTasksByPriority,
+} from "../../src/components/TaskList.js";
 import { useTasks } from "../../src/hooks/useTasks.js";
 import { ChatContextType, useChat } from "../../src/contexts/useChat.js";
+import { useStdout } from "ink";
 import type { Task } from "wave-agent-sdk";
 
 vi.mock("../../src/hooks/useTasks.js", () => ({
@@ -14,29 +19,44 @@ vi.mock("../../src/contexts/useChat.js", () => ({
   useChat: vi.fn(),
 }));
 
+vi.mock("ink", async () => {
+  const actual = await vi.importActual("ink");
+  return {
+    ...actual,
+    useStdout: vi.fn(() => ({ stdout: { rows: 24 } })),
+  };
+});
+
+function makeTask(overrides: Partial<Task> & { id: string }): Task {
+  return {
+    subject: `Task ${overrides.id}`,
+    status: "pending" as const,
+    description: "",
+    blocks: [],
+    blockedBy: [],
+    metadata: {},
+    ...overrides,
+  };
+}
+
 describe("TaskList", () => {
-  it("should render nothing when there are no tasks", () => {
+  beforeEach(() => {
     vi.mocked(useTasks).mockReturnValue([]);
     vi.mocked(useChat).mockReturnValue({
       isTaskListVisible: true,
     } as unknown as ChatContextType);
+  });
+
+  it("should render nothing when there are no tasks", () => {
+    vi.mocked(useTasks).mockReturnValue([]);
     const { lastFrame } = render(<TaskList />);
     expect(lastFrame()).toBeFalsy();
   });
 
   it("should render nothing when isTaskListVisible is false", () => {
-    const mockTasks: Task[] = [
-      {
-        id: "1",
-        subject: "Task 1",
-        status: "pending",
-        description: "",
-        blocks: [],
-        blockedBy: [],
-        metadata: {},
-      },
-    ];
-    vi.mocked(useTasks).mockReturnValue(mockTasks);
+    vi.mocked(useTasks).mockReturnValue([
+      makeTask({ id: "1", subject: "Task 1" }),
+    ]);
     vi.mocked(useChat).mockReturnValue({
       isTaskListVisible: false,
     } as unknown as ChatContextType);
@@ -46,50 +66,15 @@ describe("TaskList", () => {
 
   it("should render tasks with correct icons and subjects", () => {
     const mockTasks: Task[] = [
-      {
-        id: "1",
-        subject: "Pending Task",
-        status: "pending",
-        description: "",
-        blocks: [],
-        blockedBy: [],
-        metadata: {},
-      },
-      {
-        id: "2",
-        subject: "In Progress Task",
-        status: "in_progress",
-        description: "",
-        blocks: [],
-        blockedBy: [],
-        metadata: {},
-      },
-      {
-        id: "3",
-        subject: "Completed Task",
-        status: "completed",
-        description: "",
-        blocks: [],
-        blockedBy: [],
-        metadata: {},
-      },
-      {
-        id: "4",
-        subject: "Deleted Task",
-        status: "deleted",
-        description: "",
-        blocks: [],
-        blockedBy: [],
-        metadata: {},
-      },
+      makeTask({ id: "1", subject: "Pending Task", status: "pending" }),
+      makeTask({ id: "2", subject: "In Progress Task", status: "in_progress" }),
+      makeTask({ id: "3", subject: "Completed Task", status: "completed" }),
+      makeTask({ id: "4", subject: "Deleted Task", status: "deleted" }),
     ];
     vi.mocked(useTasks).mockReturnValue(mockTasks);
-    vi.mocked(useChat).mockReturnValue({
-      isTaskListVisible: true,
-    } as unknown as ChatContextType);
 
     const { lastFrame } = render(<TaskList />);
-    const output = lastFrame();
+    const output = lastFrame()!;
 
     expect(output).toContain("□ Pending Task");
     expect(output).toContain("■ In Progress Task");
@@ -97,60 +82,208 @@ describe("TaskList", () => {
     expect(output).toContain("✕ Deleted Task");
   });
 
-  it("should not truncate long task subjects by default", () => {
-    const longSubject =
-      "This is a very long task subject that should not be truncated by default";
+  it("should show header with task counts", () => {
     const mockTasks: Task[] = [
-      {
-        id: "1",
-        subject: longSubject,
-        status: "pending",
-        description: "",
-        blocks: [],
-        blockedBy: [],
-        metadata: {},
-      },
+      makeTask({ id: "1", subject: "Pending Task", status: "pending" }),
+      makeTask({ id: "2", subject: "In Progress Task", status: "in_progress" }),
+      makeTask({ id: "3", subject: "Completed Task", status: "completed" }),
+      makeTask({ id: "4", subject: "Completed Task 2", status: "completed" }),
     ];
     vi.mocked(useTasks).mockReturnValue(mockTasks);
-    vi.mocked(useChat).mockReturnValue({
-      isTaskListVisible: true,
-    } as unknown as ChatContextType);
 
     const { lastFrame } = render(<TaskList />);
-    const output = lastFrame();
+    const output = lastFrame()!;
 
+    expect(output).toContain("4 tasks (2 done, 1 in progress, 2 open)");
+  });
+
+  it("should truncate long task subjects with wrap=truncate-end", () => {
+    const longSubject =
+      "This is a very long task subject that should be truncated with wrap";
+    vi.mocked(useTasks).mockReturnValue([
+      makeTask({ id: "1", subject: longSubject }),
+    ]);
+
+    const { lastFrame } = render(<TaskList />);
+    const output = lastFrame()!;
+
+    // The text should still contain the subject (ink-testing-library may not
+    // actually truncate in test env, but the wrap prop is set)
     expect(output).toContain(longSubject);
   });
 
   it("should render blocked tasks with pending icon and blocking subjects", () => {
     const mockTasks: Task[] = [
-      {
+      makeTask({
         id: "1",
         subject: "Blocking Task",
         status: "pending",
-        description: "",
         blocks: ["2"],
         blockedBy: [],
-        metadata: {},
-      },
-      {
+      }),
+      makeTask({
         id: "2",
         subject: "Blocked Task",
         status: "pending",
-        description: "",
         blocks: [],
         blockedBy: ["1"],
-        metadata: {},
-      },
+      }),
     ];
     vi.mocked(useTasks).mockReturnValue(mockTasks);
-    vi.mocked(useChat).mockReturnValue({
-      isTaskListVisible: true,
-    } as unknown as ChatContextType);
 
     const { lastFrame } = render(<TaskList />);
-    const output = lastFrame();
+    const output = lastFrame()!;
 
     expect(output).toContain("□ Blocked Task (Blocked by: #1)");
+  });
+
+  it("should limit displayed tasks based on terminal height", () => {
+    vi.mocked(useStdout).mockReturnValue({
+      stdout: { rows: 10 },
+    } as unknown as ReturnType<typeof useStdout>);
+
+    const mockTasks: Task[] = Array.from({ length: 8 }, (_, i) =>
+      makeTask({
+        id: String(i + 1),
+        subject: `Task ${i + 1}`,
+        status: "pending",
+      }),
+    );
+    vi.mocked(useTasks).mockReturnValue(mockTasks);
+
+    const { lastFrame } = render(<TaskList />);
+    const output = lastFrame()!;
+
+    // rows=10 → displayLimit = min(8, max(3, 10-12)) = min(8, max(3, -2)) = min(8, 3) = 3
+    expect(output).toContain("Task 1");
+    expect(output).toContain("Task 2");
+    expect(output).toContain("Task 3");
+    // Tasks beyond the limit should be in the summary
+    expect(output).toContain("+5 5 pending");
+  });
+
+  it("should show summary line for hidden tasks", () => {
+    // Use rows=10 → displayLimit=3 to force truncation with mixed statuses
+    vi.mocked(useStdout).mockReturnValue({
+      stdout: { rows: 10 },
+    } as unknown as ReturnType<typeof useStdout>);
+
+    const mockTasks: Task[] = [
+      makeTask({ id: "1", subject: "Working", status: "in_progress" }),
+      makeTask({ id: "2", subject: "Done", status: "completed" }),
+      makeTask({ id: "3", subject: "Also Done", status: "completed" }),
+      makeTask({ id: "4", subject: "Pending 1", status: "pending" }),
+      makeTask({ id: "5", subject: "Pending 2", status: "pending" }),
+    ];
+    vi.mocked(useTasks).mockReturnValue(mockTasks);
+
+    const { lastFrame } = render(<TaskList />);
+    const output = lastFrame()!;
+
+    // displayLimit=3: shows "Working", "Done", "Also Done" (recently completed first, then in_progress)
+    // Hidden: 2 pending → summary
+    expect(output).toMatch(/\+2.*2 pending/);
+  });
+
+  it("should sort by priority when tasks exceed display limit", () => {
+    vi.mocked(useStdout).mockReturnValue({
+      stdout: { rows: 10 },
+    } as unknown as ReturnType<typeof useStdout>);
+
+    const recentlyCompleted = new Map<string, number>();
+    const now = Date.now();
+
+    const tasks: Task[] = [
+      makeTask({
+        id: "1",
+        subject: "Pending blocked",
+        status: "pending",
+        blockedBy: ["2"],
+      }),
+      makeTask({ id: "2", subject: "Pending unblocked", status: "pending" }),
+      makeTask({ id: "3", subject: "In progress", status: "in_progress" }),
+      makeTask({ id: "4", subject: "Old completed", status: "completed" }),
+    ];
+
+    const sorted = sortTasksByPriority(tasks, recentlyCompleted, now);
+
+    // in_progress first, then pending unblocked, then pending blocked, then completed
+    expect(sorted[0].subject).toBe("In progress");
+    expect(sorted[1].subject).toBe("Pending unblocked");
+    expect(sorted[2].subject).toBe("Pending blocked");
+    expect(sorted[3].subject).toBe("Old completed");
+  });
+
+  it("should sort recently completed tasks before in_progress", () => {
+    const recentlyCompleted = new Map<string, number>();
+    const now = Date.now();
+    recentlyCompleted.set("1", now - 1000); // 1s ago
+
+    const tasks: Task[] = [
+      makeTask({ id: "1", subject: "Just completed", status: "completed" }),
+      makeTask({ id: "2", subject: "In progress", status: "in_progress" }),
+    ];
+
+    const sorted = sortTasksByPriority(tasks, recentlyCompleted, now);
+
+    expect(sorted[0].subject).toBe("Just completed");
+    expect(sorted[1].subject).toBe("In progress");
+  });
+
+  it("should auto-hide after all tasks completed", () => {
+    vi.useFakeTimers();
+    const mockTasks: Task[] = [
+      makeTask({ id: "1", subject: "Done 1", status: "completed" }),
+      makeTask({ id: "2", subject: "Done 2", status: "completed" }),
+    ];
+    vi.mocked(useTasks).mockReturnValue(mockTasks);
+
+    const { lastFrame, rerender } = render(<TaskList />);
+    expect(lastFrame()).toBeTruthy();
+
+    vi.advanceTimersByTime(5000);
+    rerender(<TaskList />);
+    expect(lastFrame()).toBeFalsy();
+
+    vi.useRealTimers();
+  });
+
+  it("should reappear when new task added after auto-hide", () => {
+    vi.useFakeTimers();
+    const completedTasks: Task[] = [
+      makeTask({ id: "1", subject: "Done 1", status: "completed" }),
+      makeTask({ id: "2", subject: "Done 2", status: "completed" }),
+    ];
+    vi.mocked(useTasks).mockReturnValue(completedTasks);
+
+    const { lastFrame, rerender, unmount } = render(<TaskList />);
+    expect(lastFrame()).toBeTruthy();
+
+    vi.advanceTimersByTime(5000);
+    // Rerender to pick up the state change from the timer
+    rerender(<TaskList />);
+    expect(lastFrame()).toBeFalsy();
+    unmount();
+
+    // Add a new pending task and mount fresh
+    vi.mocked(useTasks).mockReturnValue([
+      ...completedTasks,
+      makeTask({ id: "3", subject: "New Task", status: "pending" }),
+    ]);
+    const { lastFrame: lastFrame2 } = render(<TaskList />);
+    expect(lastFrame2()).toBeTruthy();
+    expect(lastFrame2()).toContain("New Task");
+
+    vi.useRealTimers();
+  });
+});
+
+describe("getStatusIcon", () => {
+  it("returns correct icons for each status", () => {
+    // Just verify it returns non-null JSX for each status
+    expect(getStatusIcon("pending")).toBeTruthy();
+    expect(getStatusIcon("in_progress")).toBeTruthy();
+    expect(getStatusIcon("completed")).toBeTruthy();
+    expect(getStatusIcon("deleted")).toBeTruthy();
   });
 });

--- a/specs/063-task-management-tools/spec.md
+++ b/specs/063-task-management-tools/spec.md
@@ -84,7 +84,7 @@ As a system maintainer, I want to remove the legacy TodoWrite tool so that the a
 - **What happens when a task ID does not exist?** TaskGet and TaskUpdate should return a clear error message indicating the task was not found.
 - **How does the system handle invalid status transitions?** The system should validate that the provided status is one of the allowed values.
 - **What happens if the storage directory is not writable?** The tools should handle filesystem errors gracefully.
-- **What happens when there are many tasks?** The UI should handle a large number of tasks gracefully (e.g., by using a compact format).
+- **What happens when there are many tasks?** The TaskList component handles long task lists with terminal-adaptive display limits, priority sorting, collapsed summaries, and auto-hide of completed tasks.
 
 ## Requirements *(mandatory)*
 
@@ -105,6 +105,13 @@ As a system maintainer, I want to remove the legacy TodoWrite tool so that the a
 - **FR-013**: Each task in the list MUST show its current status and subject.
 - **FR-014**: The task list MUST update automatically when tasks are created or updated.
 - **FR-015**: The task list MUST be distinct from "background tasks" (running processes).
+- **FR-016**: The TaskList component MUST display a header line showing total task count and breakdown: `N tasks (N done, N in progress, N open)`.
+- **FR-017**: The TaskList component MUST use a terminal-adaptive display limit: `Math.min(8, Math.max(3, rows - 12))`, where `rows` comes from Ink's `useStdout()`.
+- **FR-018**: When tasks exceed the display limit, the component MUST sort by priority: recently completed (<30s) → in_progress → pending (unblocked first) → pending blocked → older completed → deleted.
+- **FR-019**: When tasks are hidden by the display limit, the component MUST show a collapsed summary line: `+N in progress, M pending, K completed`.
+- **FR-020**: The TaskList component MUST auto-hide 5 seconds after all active tasks are completed, and reappear when a new non-completed task is added.
+- **FR-021**: Task subject text MUST use `wrap="truncate-end"` to handle long subjects gracefully.
+- **FR-022**: The component MUST track recently completed tasks (within 30s) via a ref map of taskId → completion timestamp, with expired entries pruned to trigger re-render.
 
 ### Key Entities *(include if feature involves data)*
 


### PR DESCRIPTION
- Add header line with task counts (N done, N in progress, N open)
- Terminal-adaptive display limit: min(8, max(3, rows-12)) via useStdout()
- Priority sort when truncated: recently completed <30s → in_progress →
  pending unblocked → pending blocked → older completed → deleted
- Collapsed summary line for hidden tasks
- Auto-hide 5s after all tasks completed, reappear on new task
- Subject truncation via wrap='truncate-end'
- Extract getStatusIcon and sortTasksByPriority for testability
- Add 7 new functional requirements (FR-016–FR-022) to spec
