### PR TITLE
Fix /goal status line always showing 0m elapsed time

### DIFF
--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -210,6 +210,25 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
   const [isGoalActive, setIsGoalActive] = useState(false);
   const [goalElapsed, setGoalElapsed] = useState<string | undefined>();
+  const goalStartedAt = useRef<number | null>(null);
+
+  // Update goal elapsed time every 30s while active
+  useEffect(() => {
+    if (!isGoalActive || goalStartedAt.current === null) return;
+    const formatElapsed = (ms: number): string => {
+      const minutes = Math.floor(ms / 60000);
+      if (minutes < 1) return "<1m";
+      if (minutes < 60) return `${minutes}m`;
+      const hours = Math.floor(minutes / 60);
+      const remainingMin = minutes % 60;
+      return `${hours}h${remainingMin}m`;
+    };
+    const update = () =>
+      setGoalElapsed(formatElapsed(Date.now() - goalStartedAt.current!));
+    update();
+    const timer = setInterval(update, 30_000);
+    return () => clearInterval(timer);
+  }, [isGoalActive]);
 
   // MCP State
   const [mcpServerStatuses, setMcpServerStatuses] = useState<McpServerStatus[]>(
@@ -384,6 +403,11 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         },
         onGoalStateChange: (active, _condition, elapsed) => {
           setIsGoalActive(active);
+          if (active) {
+            goalStartedAt.current = Date.now();
+          } else {
+            goalStartedAt.current = null;
+          }
           setGoalElapsed(elapsed);
         },
       };

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -228,6 +228,109 @@ describe("ChatProvider", () => {
     });
   });
 
+  it("updates goal elapsed time via interval when goal is active", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
+    const callbacks = agentCreateArgs.callbacks!;
+
+    // Activate goal
+    callbacks.onGoalStateChange!(true, "fix all bugs", "0m");
+
+    await vi.waitFor(() => {
+      expect(lastValue?.isGoalActive).toBe(true);
+      expect(lastValue?.goalElapsed).toBe("<1m");
+    });
+
+    // Advance 90 seconds — should show 1m
+    vi.advanceTimersByTime(90_000);
+
+    await vi.waitFor(() => {
+      expect(lastValue?.goalElapsed).toBe("1m");
+    });
+
+    // Advance another 2 minutes — should show 3m
+    vi.advanceTimersByTime(120_000);
+
+    await vi.waitFor(() => {
+      expect(lastValue?.goalElapsed).toBe("3m");
+    });
+  });
+
+  it("stops goal elapsed timer when goal is cleared", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
+    const callbacks = agentCreateArgs.callbacks!;
+
+    // Activate goal
+    callbacks.onGoalStateChange!(true, "fix all bugs", "0m");
+
+    await vi.waitFor(() => {
+      expect(lastValue?.isGoalActive).toBe(true);
+    });
+
+    // Clear goal
+    callbacks.onGoalStateChange!(false);
+
+    await vi.waitFor(() => {
+      expect(lastValue?.isGoalActive).toBe(false);
+    });
+
+    // Advance time — elapsed should NOT change (timer was stopped)
+    const elapsedAfterClear = lastValue?.goalElapsed;
+    vi.advanceTimersByTime(120_000);
+    expect(lastValue?.goalElapsed).toBe(elapsedAfterClear);
+  });
+
+  it("formats goal elapsed time with hours", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
+    const callbacks = agentCreateArgs.callbacks!;
+
+    // Activate goal
+    callbacks.onGoalStateChange!(true, "long running task", "0m");
+
+    await vi.waitFor(() => {
+      expect(lastValue?.isGoalActive).toBe(true);
+    });
+
+    // Advance 95 minutes — should show 1h35m
+    vi.advanceTimersByTime(95 * 60_000);
+
+    await vi.waitFor(() => {
+      expect(lastValue?.goalElapsed).toBe("1h35m");
+    });
+  });
+
   it("handles sendMessage for normal AI messages", async () => {
     let lastValue: ChatContextType | undefined;
     const onHookValue = (val: ChatContextType) => {


### PR DESCRIPTION
Add a 30s interval timer that recalculates the goal elapsed display
while a goal is active. The timer starts when onGoalStateChange fires
with active=true and stops when the goal is cleared.
