### PR TITLE
fix: suppress ESRCH error log when force-killing already-exited process

### DIFF
--- a/packages/agent-sdk/src/managers/backgroundTaskManager.ts
+++ b/packages/agent-sdk/src/managers/backgroundTaskManager.ts
@@ -96,8 +96,14 @@ export class BackgroundTaskManager {
               if (child.pid && !child.killed) {
                 try {
                   process.kill(-child.pid, "SIGKILL");
-                } catch (error) {
-                  logger.error("Failed to force kill process:", error);
+                } catch (error: unknown) {
+                  // ESRCH means the process already exited — not an error
+                  if (
+                    !(error instanceof Error) ||
+                    (error as NodeJS.ErrnoException).code !== "ESRCH"
+                  ) {
+                    logger.error("Failed to force kill process:", error);
+                  }
                 }
               }
             }, 1000);
@@ -267,8 +273,14 @@ export class BackgroundTaskManager {
               if (child.pid && !child.killed) {
                 try {
                   process.kill(-child.pid, "SIGKILL");
-                } catch (error) {
-                  logger.error("Failed to force kill process:", error);
+                } catch (error: unknown) {
+                  // ESRCH means the process already exited — not an error
+                  if (
+                    !(error instanceof Error) ||
+                    (error as NodeJS.ErrnoException).code !== "ESRCH"
+                  ) {
+                    logger.error("Failed to force kill process:", error);
+                  }
                 }
               }
             }, 1000);

--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -379,8 +379,14 @@ The working directory persists between commands. Try to maintain your current wo
                 if (child.pid && !child.killed) {
                   try {
                     process.kill(-child.pid, "SIGKILL");
-                  } catch (killError) {
-                    logger.error("Failed to force kill process:", killError);
+                  } catch (killError: unknown) {
+                    // ESRCH means the process already exited — not an error
+                    if (
+                      !(killError instanceof Error) ||
+                      (killError as NodeJS.ErrnoException).code !== "ESRCH"
+                    ) {
+                      logger.error("Failed to force kill process:", killError);
+                    }
                   }
                 }
               }, 1000);

--- a/packages/agent-sdk/tests/managers/backgroundTaskManager.test.ts
+++ b/packages/agent-sdk/tests/managers/backgroundTaskManager.test.ts
@@ -3,6 +3,22 @@ import { Container } from "../../src/utils/container.js";
 import { BackgroundTaskManager } from "../../src/managers/backgroundTaskManager.js";
 import { NotificationQueue } from "../../src/managers/notificationQueue.js";
 import type { BackgroundSubagent } from "../../src/types/processes.js";
+import type { ChildProcess } from "child_process";
+
+// Mock globalLogger so we can assert on logger.error
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+  setGlobalLogger: vi.fn(),
+  clearGlobalLogger: vi.fn(),
+  isLoggerConfigured: vi.fn(),
+}));
+
+import { logger } from "../../src/utils/globalLogger.js";
 
 describe("BackgroundTaskManager notification deduplication", () => {
   let container: Container;
@@ -147,6 +163,99 @@ describe("BackgroundTaskManager notification deduplication", () => {
       expect(completedTask.status).toBe("completed");
       const notifications = notificationQueue.dequeueAll();
       expect(notifications.length).toBe(0);
+    });
+  });
+
+  describe("ESRCH handling in onStop callback (adoptProcess)", () => {
+    let mockKill: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      mockKill = vi.spyOn(process, "kill").mockReturnValue(true as never);
+    });
+
+    afterEach(() => {
+      mockKill.mockRestore();
+    });
+
+    it("should not log error when SIGKILL throws ESRCH (process already exited)", () => {
+      mockKill.mockImplementation(((pid: number, signal?: string | number) => {
+        if (signal === "SIGKILL") {
+          const error: NodeJS.ErrnoException = new Error("kill ESRCH");
+          error.code = "ESRCH";
+          throw error;
+        }
+        return true;
+      }) as never);
+
+      const mockChild = {
+        pid: 12345,
+        killed: false,
+        kill: vi.fn(),
+        stdout: { on: vi.fn(), off: vi.fn() },
+        stderr: { on: vi.fn(), off: vi.fn() },
+        on: vi.fn(),
+        off: vi.fn(),
+      } as unknown as ChildProcess;
+
+      manager.adoptProcess(mockChild, "test-command");
+      const taskId = manager.getAllTasks()[0].id;
+
+      manager.stopTask(taskId);
+      vi.advanceTimersByTime(1000);
+
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it("should log error when SIGKILL throws a non-ESRCH error", () => {
+      mockKill.mockImplementation(((pid: number, signal?: string | number) => {
+        if (signal === "SIGKILL") {
+          const error: NodeJS.ErrnoException = new Error("kill EPERM");
+          error.code = "EPERM";
+          throw error;
+        }
+        return true;
+      }) as never);
+
+      const mockChild = {
+        pid: 12345,
+        killed: false,
+        kill: vi.fn(),
+        stdout: { on: vi.fn(), off: vi.fn() },
+        stderr: { on: vi.fn(), off: vi.fn() },
+        on: vi.fn(),
+        off: vi.fn(),
+      } as unknown as ChildProcess;
+
+      manager.adoptProcess(mockChild, "test-command");
+      const taskId = manager.getAllTasks()[0].id;
+
+      manager.stopTask(taskId);
+      vi.advanceTimersByTime(1000);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        "Failed to force kill process:",
+        expect.objectContaining({ code: "EPERM" }),
+      );
+    });
+
+    it("should not log error when SIGKILL succeeds (no throw)", () => {
+      const mockChild = {
+        pid: 12345,
+        killed: false,
+        kill: vi.fn(),
+        stdout: { on: vi.fn(), off: vi.fn() },
+        stderr: { on: vi.fn(), off: vi.fn() },
+        on: vi.fn(),
+        off: vi.fn(),
+      } as unknown as ChildProcess;
+
+      manager.adoptProcess(mockChild, "test-command");
+      const taskId = manager.getAllTasks()[0].id;
+
+      manager.stopTask(taskId);
+      vi.advanceTimersByTime(1000);
+
+      expect(logger.error).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/agent-sdk/tests/tools/bashTool.test.ts
+++ b/packages/agent-sdk/tests/tools/bashTool.test.ts
@@ -34,7 +34,7 @@ vi.mock("os", async () => {
   };
 });
 
-// Mock logger
+// Mock logger (legacy path — may not intercept actual globalLogger import)
 vi.mock("../../utils/logger", () => ({
   logger: {
     error: vi.fn(),
@@ -43,7 +43,21 @@ vi.mock("../../utils/logger", () => ({
   },
 }));
 
+// Mock globalLogger — the actual module used by bashTool.ts
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+  setGlobalLogger: vi.fn(),
+  clearGlobalLogger: vi.fn(),
+  isLoggerConfigured: vi.fn(),
+}));
+
 import { spawn } from "child_process";
+import { logger } from "../../src/utils/globalLogger.js";
 const mockSpawn = vi.mocked(spawn);
 
 describe("bashTool", () => {
@@ -790,6 +804,142 @@ describe("bashTool", () => {
       const params = { task_id: "task_1" };
       const result = taskStopTool.formatCompactParams?.(params, context);
       expect(result).toBe("task_1");
+    });
+  });
+
+  describe("ESRCH handling in force-kill timeout (abort path)", () => {
+    let mockKill: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      mockKill = vi.spyOn(process, "kill").mockReturnValue(true as never);
+    });
+
+    afterEach(() => {
+      mockKill.mockRestore();
+    });
+
+    it("should not log error when SIGKILL throws ESRCH after abort (process already exited)", async () => {
+      vi.useFakeTimers();
+
+      mockKill.mockImplementation(((pid: number, signal?: string | number) => {
+        if (signal === "SIGKILL") {
+          const error: NodeJS.ErrnoException = new Error("kill ESRCH");
+          error.code = "ESRCH";
+          throw error;
+        }
+        return true;
+      }) as never);
+
+      const mockProcess = {
+        pid: 1234,
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+        on: vi.fn(),
+        kill: vi.fn(),
+        killed: false,
+      };
+      mockSpawn.mockReturnValue(mockProcess as unknown as ChildProcess);
+
+      const abortController = new AbortController();
+      const testContext: ToolContext = {
+        abortSignal: abortController.signal,
+        backgroundTaskManager,
+        workdir: "/test/workdir",
+        taskManager: createMockTaskManager(),
+      };
+
+      const promise = bashTool.execute({ command: "sleep 10" }, testContext);
+
+      // Abort triggers the force-kill path
+      abortController.abort();
+
+      // Advance past the 1-second force-kill timeout
+      vi.advanceTimersByTime(1000);
+
+      const result = await promise;
+      expect(result.success).toBe(false);
+      expect(logger.error).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it("should log error when SIGKILL throws a non-ESRCH error after abort", async () => {
+      vi.useFakeTimers();
+
+      mockKill.mockImplementation(((pid: number, signal?: string | number) => {
+        if (signal === "SIGKILL") {
+          const error: NodeJS.ErrnoException = new Error("kill EPERM");
+          error.code = "EPERM";
+          throw error;
+        }
+        return true;
+      }) as never);
+
+      const mockProcess = {
+        pid: 1234,
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+        on: vi.fn(),
+        kill: vi.fn(),
+        killed: false,
+      };
+      mockSpawn.mockReturnValue(mockProcess as unknown as ChildProcess);
+
+      const abortController = new AbortController();
+      const testContext: ToolContext = {
+        abortSignal: abortController.signal,
+        backgroundTaskManager,
+        workdir: "/test/workdir",
+        taskManager: createMockTaskManager(),
+      };
+
+      const promise = bashTool.execute({ command: "sleep 10" }, testContext);
+
+      abortController.abort();
+      vi.advanceTimersByTime(1000);
+
+      await promise;
+
+      expect(logger.error).toHaveBeenCalledWith(
+        "Failed to force kill process:",
+        expect.objectContaining({ code: "EPERM" }),
+      );
+
+      vi.useRealTimers();
+    });
+
+    it("should not log error when SIGKILL succeeds after abort (no throw)", async () => {
+      vi.useFakeTimers();
+
+      // Default mock — no throw, SIGKILL succeeds
+      const mockProcess = {
+        pid: 1234,
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+        on: vi.fn(),
+        kill: vi.fn(),
+        killed: false,
+      };
+      mockSpawn.mockReturnValue(mockProcess as unknown as ChildProcess);
+
+      const abortController = new AbortController();
+      const testContext: ToolContext = {
+        abortSignal: abortController.signal,
+        backgroundTaskManager,
+        workdir: "/test/workdir",
+        taskManager: createMockTaskManager(),
+      };
+
+      const promise = bashTool.execute({ command: "sleep 10" }, testContext);
+
+      abortController.abort();
+      vi.advanceTimersByTime(1000);
+
+      const result = await promise;
+      expect(result.success).toBe(false);
+      expect(logger.error).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
     });
   });
 });


### PR DESCRIPTION
After SIGTERM, a 1-second timeout attempts SIGKILL. If the process
already exited, process.kill throws ESRCH which was logged as ERROR.
This is a normal race condition — filter ESRCH so only genuine errors
are logged.

Affected: backgroundTaskManager.ts (2 sites), bashTool.ts (1 site)
Tests: 6 new cases (ESRCH suppressed, non-ESRCH logged, success)
