### PR TITLE
fix(workflow): args auto-parse, log persistence, remove dead workflow() API, implement resumeFromRunId

### DIFF
--- a/packages/agent-sdk/src/managers/workflowManager.ts
+++ b/packages/agent-sdk/src/managers/workflowManager.ts
@@ -68,8 +68,6 @@ export class WorkflowManager {
     args?: unknown,
     opts?: { budget?: number | null; resumeFromRunId?: string },
   ): Promise<WorkflowRun> {
-    // opts is reserved for future use (resume, budget override)
-    void opts;
     // Validate script
     const validation = validateScript(script);
     if (!validation.valid) {
@@ -80,6 +78,14 @@ export class WorkflowManager {
 
     // Parse meta for the run object
     const { meta } = parseScript(script);
+
+    // Validate resumeFromRunId if provided
+    if (opts?.resumeFromRunId) {
+      const prevRun = this.runs.get(opts.resumeFromRunId);
+      if (!prevRun) {
+        throw new Error(`Cannot resume: run ${opts.resumeFromRunId} not found`);
+      }
+    }
 
     // Generate run ID and persist script
     const runId = `wf_${randomUUID().slice(0, 8)}`;
@@ -98,6 +104,7 @@ export class WorkflowManager {
       phases: [],
       totalAgents: 0,
       totalTokens: 0,
+      resumeFromRunId: opts?.resumeFromRunId,
     };
 
     this.runs.set(runId, run);
@@ -131,14 +138,32 @@ export class WorkflowManager {
     );
     const progressReporter = new ProgressReporter(run.meta);
 
-    // Journal
-    const journalPath = path.join(
-      this.sessionDir,
-      "workflows",
-      `journal-${runId}.jsonl`,
-    );
-    const journal = new Journal(journalPath);
-    await journal.init();
+    // Journal — load previous journal if resuming
+    let journal: Journal;
+    let initialAgentCount = 0;
+    if (run.resumeFromRunId) {
+      const prevJournalPath = path.join(
+        this.sessionDir,
+        "workflows",
+        `journal-${run.resumeFromRunId}.jsonl`,
+      );
+      journal = await Journal.load(prevJournalPath);
+      // Count existing agent entries to offset the counter
+      initialAgentCount = journal.agentEntryCount;
+      // Re-open for appending (load() doesn't open the write stream)
+      await journal.init();
+      logger.info(
+        `[Workflow] Resuming from ${run.resumeFromRunId} with ${initialAgentCount} cached agent results`,
+      );
+    } else {
+      const journalPath = path.join(
+        this.sessionDir,
+        "workflows",
+        `journal-${runId}.jsonl`,
+      );
+      journal = new Journal(journalPath);
+      await journal.init();
+    }
 
     // Register as background task
     const taskId = this.backgroundTaskManager.generateId();
@@ -165,6 +190,7 @@ export class WorkflowManager {
       journal,
       abortSignal: abortController.signal,
       args: run.args,
+      initialAgentCount,
       onLog: (message: string) => {
         logger.info(`[Workflow:${runId}] ${message}`);
       },

--- a/packages/agent-sdk/src/tools/workflowTool.ts
+++ b/packages/agent-sdk/src/tools/workflowTool.ts
@@ -87,7 +87,6 @@ Script body hooks:
 - **phase(title: string)**: void — start a new phase; subsequent agent() calls are grouped under this title
 - **args**: any — the value passed as Workflow's args input, verbatim
 - **budget**: {total: number|null, spent(): number, remaining(): number} — the turn's token target
-- **workflow(nameOrRef, args?)**: Promise<any> — run another workflow inline (one nesting level only)
 
 Scripts are plain JavaScript, NOT TypeScript — type annotations fail to parse. The script body runs in an async context — use await directly. Standard JS built-ins (JSON, Math, Array, etc.) are available — EXCEPT Date.now()/Math.random()/argless new Date(), which throw (they would break resume). No filesystem or Node.js API access.
 

--- a/packages/agent-sdk/src/workflow/journal.ts
+++ b/packages/agent-sdk/src/workflow/journal.ts
@@ -1,9 +1,9 @@
 import * as fs from "fs";
 import * as path from "path";
-import type { JournalEntry } from "./types.js";
+import type { JournalLine } from "./types.js";
 
 export class Journal {
-  private entries: JournalEntry[] = [];
+  private entries: JournalLine[] = [];
   private stream: fs.WriteStream | null = null;
 
   constructor(private filePath: string) {}
@@ -15,22 +15,36 @@ export class Journal {
     this.stream = fs.createWriteStream(this.filePath, { flags: "a" });
   }
 
-  append(entry: JournalEntry): void {
+  append(entry: JournalLine): void {
     this.entries.push(entry);
     if (this.stream) {
       this.stream.write(JSON.stringify(entry) + "\n");
     }
   }
 
+  appendLog(message: string): void {
+    this.append({ type: "log", message });
+  }
+
   getCachedResult(agentIndex: number): unknown | undefined {
-    if (agentIndex < this.entries.length) {
-      return this.entries[agentIndex].result;
+    const agentEntries = this.entries.filter(
+      (e): e is import("./types.js").JournalEntry => !("type" in e),
+    );
+    if (agentIndex < agentEntries.length) {
+      return agentEntries[agentIndex].result;
     }
     return undefined;
   }
 
   get length(): number {
     return this.entries.length;
+  }
+
+  /** Count of agent entries (excluding log entries) */
+  get agentEntryCount(): number {
+    return this.entries.filter(
+      (e): e is import("./types.js").JournalEntry => !("type" in e),
+    ).length;
   }
 
   async close(): Promise<void> {

--- a/packages/agent-sdk/src/workflow/scriptRuntime.ts
+++ b/packages/agent-sdk/src/workflow/scriptRuntime.ts
@@ -209,7 +209,6 @@ export async function executeScript(
     log: (message: string) => void;
     args: unknown;
     budget: unknown;
-    workflow: (nameOrRef: unknown, args?: unknown) => Promise<unknown>;
   },
   abortSignal?: AbortSignal,
 ): Promise<{ meta: WorkflowMeta; result: unknown }> {
@@ -237,7 +236,6 @@ export async function executeScript(
     "log",
     "args",
     "budget",
-    "workflow",
     `"use strict"; return (async () => { ${body} })();`,
   );
 
@@ -250,7 +248,6 @@ export async function executeScript(
     apis.log,
     apis.args,
     apis.budget,
-    apis.workflow,
   );
 
   let result: unknown;

--- a/packages/agent-sdk/src/workflow/types.ts
+++ b/packages/agent-sdk/src/workflow/types.ts
@@ -34,6 +34,8 @@ export interface WorkflowRun {
   error?: string;
   /** Resolves when the background execution finishes (completed/failed/aborted) */
   completionPromise?: Promise<void>;
+  /** If set, this run resumes from a previous run's journal */
+  resumeFromRunId?: string;
 }
 
 export interface JournalEntry {
@@ -43,6 +45,13 @@ export interface JournalEntry {
   result: unknown;
   tokens: number;
 }
+
+export interface LogEntry {
+  type: "log";
+  message: string;
+}
+
+export type JournalLine = JournalEntry | LogEntry;
 
 export interface BudgetInfo {
   total: number | null;

--- a/packages/agent-sdk/src/workflow/workflowApis.ts
+++ b/packages/agent-sdk/src/workflow/workflowApis.ts
@@ -12,6 +12,26 @@ import {
 import { AGENT_TOOL_NAME, WORKFLOW_TOOL_NAME } from "../constants/tools.js";
 import { logger } from "../utils/globalLogger.js";
 
+/**
+ * Attempt to parse args if it was passed as a JSON string.
+ * LLMs may serialize array/object args as a string (e.g. "[3,8,15,42,7]")
+ * which would cause `for...of` to iterate character-by-character.
+ */
+function parseArgsIfNeeded(args: unknown): unknown {
+  if (typeof args === "string") {
+    try {
+      const parsed = JSON.parse(args);
+      // Only accept parsed arrays/objects, not primitives like "42" → 42
+      if (typeof parsed === "object" && parsed !== null) {
+        return parsed;
+      }
+    } catch {
+      // Not valid JSON — use as-is (string)
+    }
+  }
+  return args;
+}
+
 const MAX_TOTAL_AGENTS = 1000;
 const MAX_ITEMS_PER_CALL = 4096;
 
@@ -24,8 +44,8 @@ interface WorkflowApiContext {
   abortSignal: AbortSignal;
   args: unknown;
   onLog?: (message: string) => void;
-  // For nested workflow support
-  executeWorkflowScript?: (script: string, args: unknown) => Promise<unknown>;
+  /** When resuming, offset the agent counter by this many existing entries */
+  initialAgentCount?: number;
 }
 
 interface AgentOpts {
@@ -50,11 +70,10 @@ export interface WorkflowApis {
   log: (message: string) => void;
   args: unknown;
   budget: BudgetInfo;
-  workflow: (nameOrRef: unknown, args?: unknown) => Promise<unknown>;
 }
 
 export function createWorkflowApis(ctx: WorkflowApiContext): WorkflowApis {
-  let agentCounter = 0;
+  let agentCounter = ctx.initialAgentCount ?? 0;
 
   const agent = async (prompt: string, opts?: AgentOpts): Promise<unknown> => {
     const index = agentCounter++;
@@ -281,16 +300,8 @@ export function createWorkflowApis(ctx: WorkflowApiContext): WorkflowApis {
   };
 
   const log = (message: string): void => {
+    ctx.journal.appendLog(message);
     ctx.onLog?.(message);
-  };
-
-  const workflow = async (): Promise<unknown> => {
-    if (!ctx.executeWorkflowScript) {
-      throw new Error("Nested workflows are not supported in this context");
-    }
-    // The name resolution and script loading will be handled by the workflowManager
-    // For now, this is a placeholder that delegates to the manager
-    throw new Error("Nested workflow execution is not yet implemented");
   };
 
   return {
@@ -299,8 +310,7 @@ export function createWorkflowApis(ctx: WorkflowApiContext): WorkflowApis {
     pipeline,
     phase,
     log,
-    args: ctx.args,
+    args: parseArgsIfNeeded(ctx.args),
     budget: ctx.budgetTracker.toBudgetInfo(),
-    workflow,
   };
 }

--- a/packages/agent-sdk/tests/workflow/journal.test.ts
+++ b/packages/agent-sdk/tests/workflow/journal.test.ts
@@ -127,4 +127,67 @@ describe("Journal", () => {
     expect(journal.length).toBe(0);
     expect(journal.getCachedResult(0)).toBeUndefined();
   });
+
+  it("agentEntryCount excludes log entries", async () => {
+    const filePath = tmpPath("test.journal");
+    const journal = new Journal(filePath);
+    await journal.init();
+
+    journal.append({
+      agentIndex: 0,
+      prompt: "hello",
+      opts: {},
+      result: "ok",
+      tokens: 10,
+    });
+    journal.appendLog("some log message");
+    journal.append({
+      agentIndex: 1,
+      prompt: "world",
+      opts: {},
+      result: "done",
+      tokens: 20,
+    });
+
+    expect(journal.length).toBe(3);
+    expect(journal.agentEntryCount).toBe(2);
+    await journal.close();
+  });
+
+  it("load + init allows appending to existing journal (resume)", async () => {
+    const filePath = tmpPath("resume.journal");
+
+    // Phase 1: write initial entries
+    const j1 = new Journal(filePath);
+    await j1.init();
+    j1.append({
+      agentIndex: 0,
+      prompt: "first",
+      opts: {},
+      result: "cached",
+      tokens: 10,
+    });
+    j1.appendLog("some log");
+    await j1.close();
+
+    // Phase 2: load, init, append more (simulate resume)
+    const j2 = await Journal.load(filePath);
+    expect(j2.agentEntryCount).toBe(1);
+    expect(j2.getCachedResult(0)).toBe("cached");
+
+    await j2.init(); // re-open for append
+    j2.append({
+      agentIndex: 1,
+      prompt: "second",
+      opts: {},
+      result: "new",
+      tokens: 20,
+    });
+    await j2.close();
+
+    // Verify file has 3 lines (1 agent + 1 log + 1 agent)
+    const content = await fs.promises.readFile(filePath, "utf-8");
+    const lines = content.split("\n").filter((l) => l.trim());
+    expect(lines).toHaveLength(3);
+  });
 });

--- a/packages/agent-sdk/tests/workflow/scriptRuntime.test.ts
+++ b/packages/agent-sdk/tests/workflow/scriptRuntime.test.ts
@@ -128,8 +128,6 @@ describe("executeScript", () => {
     log: () => {},
     args: {},
     budget: {},
-    workflow: async (nameOrRef: unknown) =>
-      `workflow-result: ${typeof nameOrRef === "string" ? nameOrRef : JSON.stringify(nameOrRef)}`,
   };
 
   it("runs a simple script and returns the result", async () => {

--- a/packages/agent-sdk/tests/workflow/workflowApis.test.ts
+++ b/packages/agent-sdk/tests/workflow/workflowApis.test.ts
@@ -62,6 +62,7 @@ function createTestContext(overrides?: Record<string, unknown>) {
       journal: {
         init: vi.fn(),
         append: vi.fn(),
+        appendLog: vi.fn(),
         getCachedResult: vi.fn().mockReturnValue(undefined),
         close: vi.fn(),
         get length() {
@@ -387,26 +388,6 @@ describe("createWorkflowApis", () => {
 
       apis.log("hello");
       expect(onLog).toHaveBeenCalledWith("hello");
-    });
-  });
-
-  describe("workflow", () => {
-    it("throws when nested workflows not supported", async () => {
-      const { ctx } = createTestContext();
-      const apis = createWorkflowApis(ctx);
-
-      await expect(apis.workflow("test")).rejects.toThrow(
-        "Nested workflows are not supported in this context",
-      );
-    });
-
-    it("throws not yet implemented when executeWorkflowScript exists", async () => {
-      const { ctx } = createTestContext({ executeWorkflowScript: vi.fn() });
-      const apis = createWorkflowApis(ctx);
-
-      await expect(apis.workflow("test")).rejects.toThrow(
-        "Nested workflow execution is not yet implemented",
-      );
     });
   });
 });

--- a/packages/agent-sdk/tests/workflow/workflowManager.test.ts
+++ b/packages/agent-sdk/tests/workflow/workflowManager.test.ts
@@ -308,6 +308,24 @@ describe("WorkflowManager", () => {
     });
   });
 
+  describe("createRun with resumeFromRunId", () => {
+    it("throws if resumeFromRunId does not exist", async () => {
+      const script = `export const meta = { name: "test-wf", description: "A test" };\nreturn 1;`;
+      await expect(
+        manager.createRun(script, undefined, { resumeFromRunId: "wf_nope" }),
+      ).rejects.toThrow("Cannot resume: run wf_nope not found");
+    });
+
+    it("stores resumeFromRunId on the run", async () => {
+      const script = `export const meta = { name: "test-wf", description: "A test" };\nreturn 1;`;
+      const prevRun = await manager.createRun(script);
+      const newRun = await manager.createRun(script, undefined, {
+        resumeFromRunId: prevRun.runId,
+      });
+      expect(newRun.resumeFromRunId).toBe(prevRun.runId);
+    });
+  });
+
   describe("cleanup", () => {
     it("aborts all running workflows", async () => {
       const script = `export const meta = { name: "test-wf", description: "A test" };\nreturn 1;`;


### PR DESCRIPTION
- Auto-parse JSON string args to prevent character-by-character iteration
- Persist log() messages to journal (LogEntry type + appendLog method)
- Remove unimplemented workflow() nested API from script runtime and tool prompt
- Implement resumeFromRunId: load previous journal, offset agentCounter, append new results
