### PR TITLE
fix: remove selectorJustUsed gate that blocked input after command selection

### DIFF
--- a/packages/code/src/hooks/useInputManager.ts
+++ b/packages/code/src/hooks/useInputManager.ts
@@ -45,16 +45,6 @@ export const useInputManager = (
     logger,
   } = callbacks;
 
-  // Handle selectorJustUsed reset
-  useEffect(() => {
-    if (state.selectorJustUsed) {
-      const timer = setTimeout(() => {
-        dispatch({ type: "SET_SELECTOR_JUST_USED", payload: false });
-      }, 0);
-      return () => clearTimeout(timer);
-    }
-  }, [state.selectorJustUsed]);
-
   // Handle debounced file search
   useEffect(() => {
     if (state.showFileSelector) {

--- a/packages/code/src/managers/inputHandlers.ts
+++ b/packages/code/src/managers/inputHandlers.ts
@@ -701,10 +701,6 @@ export const handleInput = async (
   key: Key,
   clearImages?: () => void,
 ): Promise<boolean> => {
-  if (state.selectorJustUsed) {
-    return true;
-  }
-
   if (state.btwState.isActive) {
     if (key.escape) {
       dispatch({

--- a/packages/code/src/managers/inputReducer.ts
+++ b/packages/code/src/managers/inputReducer.ts
@@ -13,6 +13,7 @@ import {
   SELECTOR_TRIGGERS,
   getProjectedState,
 } from "../utils/inputUtils.js";
+import { AVAILABLE_COMMANDS } from "../constants/commands.js";
 
 export interface AttachedImage {
   id: number;
@@ -682,10 +683,6 @@ export function inputReducer(
     case "HANDLE_KEY": {
       const { input, key } = action.payload;
 
-      if (state.selectorJustUsed) {
-        return state;
-      }
-
       // 1. BTW State Handling
       if (state.btwState.isActive) {
         if (key.escape) {
@@ -1030,6 +1027,34 @@ export function inputReducer(
               },
               pendingEffect: question ? { type: "ASK_BTW", question } : null,
             };
+          }
+
+          // Check if the content is a CLI-internal slash command (help, tasks,
+          // etc.) that should be executed locally rather than sent as a message.
+          // Agent slash commands and unknown /commands always go to SEND_MESSAGE.
+          if (contentWithPlaceholders.startsWith("/")) {
+            const spaceIndex = contentWithPlaceholders.indexOf(" ");
+            const commandName =
+              spaceIndex === -1
+                ? contentWithPlaceholders.substring(1)
+                : contentWithPlaceholders.substring(1, spaceIndex);
+
+            const isInternalCommand = AVAILABLE_COMMANDS.some(
+              (cmd) => cmd.id === commandName,
+            );
+            if (isInternalCommand) {
+              return {
+                ...state,
+                inputText: "",
+                cursorPosition: 0,
+                historyIndex: -1,
+                longTextMap: {},
+                pendingEffect: {
+                  type: "EXECUTE_COMMAND",
+                  command: commandName,
+                },
+              };
+            }
           }
 
           return {

--- a/packages/code/tests/components/InputBox.test.tsx
+++ b/packages/code/tests/components/InputBox.test.tsx
@@ -193,7 +193,7 @@ describe("InputBox Smoke Tests", () => {
       });
     });
 
-    it("should send complete slash command as message", async () => {
+    it("should send complete slash command with arguments as message", async () => {
       mockHasSlashCommand.mockReturnValue(true);
       mockSendMessage.mockResolvedValue(undefined);
 
@@ -211,6 +211,8 @@ describe("InputBox Smoke Tests", () => {
       );
 
       stdin.write("\r");
+      // Slash commands with arguments are sent as SEND_MESSAGE so the
+      // full content (including arguments) reaches the agent
       await vi.waitFor(() => {
         expect(mockSendMessage).toHaveBeenCalledWith(
           "/git-commit some arguments",

--- a/packages/code/tests/managers/inputHandlers.test.ts
+++ b/packages/code/tests/managers/inputHandlers.test.ts
@@ -917,7 +917,10 @@ describe("inputHandlers", () => {
   });
 
   describe("handleInput", () => {
-    it("should return true if selectorJustUsed is true and not call other handlers", async () => {
+    it("should not block input when selectorJustUsed is true", async () => {
+      // selectorJustUsed no longer blocks HANDLE_KEY - the specific key
+      // handlers (Escape, Enter) already prevent double processing via
+      // early returns and selector-active checks.
       const state = {
         ...initialState,
         selectorJustUsed: true,
@@ -926,7 +929,8 @@ describe("inputHandlers", () => {
       const key = { return: true } as Key;
       const result = await handleInput(state, dispatch, callbacks, "", key);
       expect(result).toBe(true);
-      expect(callbacks.onSendMessage).not.toHaveBeenCalled();
+      // Enter should still send the message even when selectorJustUsed is true
+      expect(callbacks.onSendMessage).toHaveBeenCalled();
     });
 
     it("should handle escape to abort message", async () => {

--- a/packages/code/tests/managers/inputReducer.test.ts
+++ b/packages/code/tests/managers/inputReducer.test.ts
@@ -1270,4 +1270,298 @@ describe("inputReducer", () => {
       });
     });
   });
+
+  describe("selectorJustUsed blocking input after command selection", () => {
+    const hasSlashCommand = (cmd: string) => cmd === "custom";
+
+    it("should NOT block Enter after INSERT_COMMAND (Tab insert)", () => {
+      // Scenario: user types /, Tab-inserts a command, then types text and presses Enter
+      // INSERT_COMMAND sets selectorJustUsed=true which blocks HANDLE_KEY
+      let state: InputState = {
+        ...initialState,
+        inputText: "/",
+        cursorPosition: 1,
+        showCommandSelector: true,
+        slashPosition: 0,
+      };
+
+      // Tab-insert an agent command (not an internal CLI command)
+      state = inputReducer(state, {
+        type: "INSERT_COMMAND",
+        payload: "custom",
+      });
+      // After insert: inputText="/custom ", selectorJustUsed=true, showCommandSelector=false
+      expect(state.inputText).toBe("/custom ");
+      expect(state.selectorJustUsed).toBe(true);
+      expect(state.showCommandSelector).toBe(false);
+
+      // User types additional text
+      state = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "a",
+          key: {} as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+      // selectorJustUsed no longer blocks this keystroke
+      expect(state.inputText).toBe("/custom a");
+
+      // User presses Enter to send
+      state = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { return: true } as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+      // /custom is an agent command — sent as SEND_MESSAGE
+      expect(state.pendingEffect).toEqual({
+        type: "SEND_MESSAGE",
+        content: "/custom a",
+        images: undefined,
+        longTextMap: {},
+      });
+    });
+
+    it("should NOT block Enter after SELECT_COMMAND (Enter select)", () => {
+      // Scenario: user types /, presses Enter to select a command
+      // SELECT_COMMAND sets selectorJustUsed=true, pendingEffect=EXECUTE_COMMAND
+      // After the command executes, user should be able to type and send normally
+      let state: InputState = {
+        ...initialState,
+        inputText: "/",
+        cursorPosition: 1,
+        showCommandSelector: true,
+        slashPosition: 0,
+      };
+
+      // Select the command (Enter)
+      state = inputReducer(state, {
+        type: "SELECT_COMMAND",
+        payload: "help",
+      });
+      expect(state.selectorJustUsed).toBe(true);
+      expect(state.pendingEffect).toEqual({
+        type: "EXECUTE_COMMAND",
+        command: "help",
+      });
+
+      // After command executes, user types and sends
+      // First, simulate selectorJustUsed being reset (setTimeout in useInputManager)
+      state = inputReducer(state, {
+        type: "SET_SELECTOR_JUST_USED",
+        payload: false,
+      });
+
+      // Now type and send should work
+      state = inputReducer(state, {
+        type: "SET_INPUT_TEXT",
+        payload: "hello world",
+      });
+      state = { ...state, cursorPosition: 11 };
+
+      state = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { return: true } as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+      expect(state.pendingEffect).toEqual({
+        type: "SEND_MESSAGE",
+        content: "hello world",
+        images: undefined,
+        longTextMap: {},
+      });
+    });
+
+    it("should NOT block input after closing a view opened by command", () => {
+      // Scenario: user runs /help, help view opens, user presses Escape to close
+      // SET_SHOW_HELP false sets selectorJustUsed=true
+      // User should be able to type and send immediately after
+      let state: InputState = {
+        ...initialState,
+        showHelp: true,
+      };
+
+      // Close help view (Escape)
+      state = inputReducer(state, {
+        type: "SET_SHOW_HELP",
+        payload: false,
+      });
+      expect(state.showHelp).toBe(false);
+      expect(state.selectorJustUsed).toBe(true);
+
+      // User types text
+      state = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "h",
+          key: {} as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+      // selectorJustUsed no longer blocks this keystroke
+      expect(state.inputText).toBe("h");
+
+      // User presses Enter
+      state = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "i",
+          key: {} as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+      state = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { return: true } as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+      expect(state.pendingEffect).toEqual({
+        type: "SEND_MESSAGE",
+        content: "hi",
+        images: undefined,
+        longTextMap: {},
+      });
+    });
+
+    it("reproduces stuck state: Enter swallowed when showCommandSelector is active", () => {
+      // This tests the race condition where both CommandSelector's useInput
+      // and InputBox's useInput handle the same Enter keypress.
+      // The inputReducer swallows Enter when showCommandSelector is true (line 989-991).
+      // Meanwhile, CommandSelector handles it via its own reducer/effect pipeline.
+      // After SELECT_COMMAND closes the selector, the Enter was already consumed.
+      const state: InputState = {
+        ...initialState,
+        inputText: "/help",
+        cursorPosition: 5,
+        showCommandSelector: true,
+        slashPosition: 0,
+      };
+
+      // InputBox's useInput fires HANDLE_KEY for Enter while selector is still active
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { return: true } as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+
+      // Enter is swallowed because showCommandSelector is true
+      // The CommandSelector's separate reducer handles it, but from
+      // inputReducer's perspective, the Enter was consumed.
+      // After SELECT_COMMAND fires asynchronously, selectorJustUsed=true
+      // which would also block the NEXT Enter.
+      expect(result.inputText).toBe("/help"); // unchanged - Enter was swallowed
+      expect(result.pendingEffect).toBeNull(); // no message sent
+    });
+
+    it("should execute CLI-internal command when Tab-inserted and Enter pressed", () => {
+      // Scenario: user types /, Tab-inserts /help, then presses Enter
+      // /help is an internal CLI command — should be EXECUTE_COMMAND, not SEND_MESSAGE
+      const state: InputState = {
+        ...initialState,
+        inputText: "/help ",
+        cursorPosition: 6,
+      };
+
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { return: true } as unknown as Key,
+          hasSlashCommand: (cmd: string) => cmd === "help",
+        },
+      });
+
+      expect(result.inputText).toBe("");
+      expect(result.pendingEffect).toEqual({
+        type: "EXECUTE_COMMAND",
+        command: "help",
+      });
+    });
+
+    it("should send agent slash command as message even without arguments", () => {
+      // Agent commands (registered via hasSlashCommand) are NOT internal CLI
+      // commands — they should always be sent as SEND_MESSAGE
+      const state: InputState = {
+        ...initialState,
+        inputText: "/custom",
+        cursorPosition: 7,
+      };
+
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { return: true } as unknown as Key,
+          hasSlashCommand: (cmd: string) => cmd === "custom",
+        },
+      });
+
+      expect(result.pendingEffect).toEqual({
+        type: "SEND_MESSAGE",
+        content: "/custom",
+        images: undefined,
+        longTextMap: {},
+      });
+    });
+
+    it("should send agent slash command with arguments as message", () => {
+      const state: InputState = {
+        ...initialState,
+        inputText: "/custom arg1 arg2",
+        cursorPosition: 17,
+      };
+
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { return: true } as unknown as Key,
+          hasSlashCommand: (cmd: string) => cmd === "custom",
+        },
+      });
+
+      expect(result.pendingEffect).toEqual({
+        type: "SEND_MESSAGE",
+        content: "/custom arg1 arg2",
+        images: undefined,
+        longTextMap: {},
+      });
+    });
+
+    it("should send unknown /command as message", () => {
+      const state: InputState = {
+        ...initialState,
+        inputText: "/unknown thing",
+        cursorPosition: 14,
+      };
+
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { return: true } as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+
+      expect(result.pendingEffect).toEqual({
+        type: "SEND_MESSAGE",
+        content: "/unknown thing",
+        images: undefined,
+        longTextMap: {},
+      });
+    });
+  });
 });


### PR DESCRIPTION
The selectorJustUsed flag blocked ALL HANDLE_KEY dispatches after closing
selectors/views, causing Enter to not send after command selection or view
dismissal. The flag was reset via setTimeout(0) which was unreliable.

Removed the gate from inputReducer and inputHandlers since specific key
handlers already prevent double processing:
- Escape: early returns when selectors are active
- Enter: swallowed when showCommandSelector/showFileSelector is active

Also added internal command routing: when /help, /tasks, etc. are typed
directly or Tab-inserted and Enter pressed, they now route to EXECUTE_COMMAND
instead of SEND_MESSAGE. Agent commands and unknown /commands still go to
SEND_MESSAGE so the full content reaches the agent.
