### PR TITLE
Align task management tools and TaskList UI with Claude Code

### DIFF
--- a/packages/agent-sdk/src/tools/taskManagementTools.ts
+++ b/packages/agent-sdk/src/tools/taskManagementTools.ts
@@ -7,6 +7,42 @@ import {
   TASK_LIST_TOOL_NAME,
 } from "../constants/tools.js";
 
+/**
+ * Helper to record and commit a reversion snapshot for a task file.
+ */
+async function recordSnapshot(
+  context: ToolContext,
+  taskManager: { getTaskPath: (id: string) => string },
+  taskId: string,
+  operation: "create" | "modify" | "delete",
+): Promise<string | undefined> {
+  if (!context.reversionManager || !context.messageId) return undefined;
+  const snapshotId = await context.reversionManager.recordSnapshot(
+    context.messageId,
+    taskManager.getTaskPath(taskId),
+    operation,
+  );
+  await context.reversionManager.commitSnapshot(snapshotId);
+  return snapshotId;
+}
+
+/**
+ * Helper to update a target task's blocks/blockedBy array and record a reversion snapshot.
+ */
+async function updateTaskField(
+  context: ToolContext,
+  taskManager: {
+    getTaskPath: (id: string) => string;
+    updateTask: (task: Task) => Promise<void>;
+  },
+  targetTask: Task,
+  field: "blocks" | "blockedBy",
+  value: string[],
+): Promise<void> {
+  await recordSnapshot(context, taskManager, targetTask.id, "modify");
+  await taskManager.updateTask({ ...targetTask, [field]: value });
+}
+
 export const taskCreateTool: ToolPlugin = {
   name: TASK_CREATE_TOOL_NAME,
   config: {
@@ -23,31 +59,12 @@ export const taskCreateTool: ToolPlugin = {
           },
           description: {
             type: "string",
-            description: "A detailed description of what needs to be done",
-          },
-          status: {
-            type: "string",
-            enum: ["pending", "in_progress", "completed", "deleted"],
-            description: "Initial status of the task. Defaults to 'pending'.",
+            description: "What needs to be done",
           },
           activeForm: {
             type: "string",
             description:
               'Present continuous form shown in spinner when in_progress (e.g., "Running tests")',
-          },
-          owner: {
-            type: "string",
-            description: "Optional owner of the task.",
-          },
-          blocks: {
-            type: "array",
-            items: { type: "string" },
-            description: "List of task IDs that this task blocks.",
-          },
-          blockedBy: {
-            type: "array",
-            items: { type: "string" },
-            description: "List of task IDs that block this task.",
           },
           metadata: {
             type: "object",
@@ -88,7 +105,7 @@ NOTE that you should not use this tool if there is only one trivial task to do. 
 ## Task Fields
 
 - **subject**: A brief, actionable title in imperative form (e.g., "Fix authentication bug in login flow")
-- **description**: Detailed description of what needs to be done, including context and acceptance criteria
+- **description**: What needs to be done, including context and acceptance criteria
 - **activeForm**: Present continuous form shown in spinner when task is in_progress (e.g., "Fixing authentication bug"). This is displayed to the user while you work on the task.
 
 **IMPORTANT**: Always provide activeForm when creating tasks. The subject should be imperative ("Run tests") while activeForm should be present continuous ("Running tests"). All tasks are created with status \`pending\`.
@@ -102,40 +119,23 @@ NOTE that you should not use this tool if there is only one trivial task to do. 
   execute: async (args, context: ToolContext): Promise<ToolResult> => {
     const taskManager = context.taskManager;
 
-    if (args.status === "deleted") {
-      return {
-        success: true,
-        content: `Task creation skipped because status was set to 'deleted'.`,
-        shortResult: `Skipped deleted task`,
-      };
-    }
-
     const task: Omit<Task, "id"> = {
       subject: args.subject as string,
       description: args.description as string,
-      status: (args.status as TaskStatus) || "pending",
+      status: "pending",
       activeForm: args.activeForm as string,
-      owner: args.owner as string,
-      blocks: (args.blocks as string[]) || [],
-      blockedBy: (args.blockedBy as string[]) || [],
+      owner: undefined,
+      blocks: [],
+      blockedBy: [],
       metadata: (args.metadata as Record<string, unknown>) || {},
     };
 
     const taskId = await taskManager.createTask(task);
-
-    if (context.reversionManager && context.messageId) {
-      const taskPath = taskManager.getTaskPath(taskId);
-      const snapshotId = await context.reversionManager.recordSnapshot(
-        context.messageId,
-        taskPath,
-        "create",
-      );
-      await context.reversionManager.commitSnapshot(snapshotId);
-    }
+    await recordSnapshot(context, taskManager, taskId, "create");
 
     return {
       success: true,
-      content: `Task created with ID: ${taskId}`,
+      content: `Task #${taskId} created successfully: ${task.subject}`,
       shortResult: `Created task ${taskId}: ${task.subject}`,
     };
   },
@@ -189,13 +189,28 @@ Returns full task details:
     if (!task) {
       return {
         success: false,
-        content: `Task with ID ${taskId} not found.`,
+        content: `Task not found`,
       };
+    }
+
+    // Format like Claude Code: structured text instead of raw JSON
+    const lines = [
+      `Task #${task.id}: ${task.subject}`,
+      `Status: ${task.status}`,
+      `Description: ${task.description}`,
+    ];
+    if (task.blockedBy.length > 0) {
+      lines.push(
+        `Blocked by: ${task.blockedBy.map((id) => `#${id}`).join(", ")}`,
+      );
+    }
+    if (task.blocks.length > 0) {
+      lines.push(`Blocks: ${task.blocks.map((id) => `#${id}`).join(", ")}`);
     }
 
     return {
       success: true,
-      content: JSON.stringify(task, null, 2),
+      content: lines.join("\n"),
     };
   },
 };
@@ -339,210 +354,139 @@ Set up task dependencies:
     if (!existingTask) {
       return {
         success: false,
-        content: `Task with ID ${taskId} not found.`,
+        content: `Task #${taskId} not found`,
       };
     }
 
+    // Handle deletion — just delete the task file (like Claude Code)
     if (args.status === "deleted") {
-      // Reciprocal Dependency Cleanup
-      // For each task in the deleted task's blocks list, remove the deleted task's ID from their blockedBy list.
-      for (const targetId of existingTask.blocks) {
-        const targetTask = await taskManager.getTask(targetId);
-        if (targetTask && targetTask.blockedBy.includes(taskId)) {
-          let targetSnapshotId: string | undefined;
-          if (context.reversionManager && context.messageId) {
-            const targetPath = taskManager.getTaskPath(targetId);
-            targetSnapshotId = await context.reversionManager.recordSnapshot(
-              context.messageId,
-              targetPath,
-              "modify",
-            );
-          }
-          await taskManager.updateTask({
-            ...targetTask,
-            blockedBy: targetTask.blockedBy.filter((id) => id !== taskId),
-          });
-          if (context.reversionManager && targetSnapshotId) {
-            await context.reversionManager.commitSnapshot(targetSnapshotId);
-          }
-        }
-      }
-
-      // For each task in the deleted task's blockedBy list, remove the deleted task's ID from their blocks list.
-      for (const targetId of existingTask.blockedBy) {
-        const targetTask = await taskManager.getTask(targetId);
-        if (targetTask && targetTask.blocks.includes(taskId)) {
-          let targetSnapshotId: string | undefined;
-          if (context.reversionManager && context.messageId) {
-            const targetPath = taskManager.getTaskPath(targetId);
-            targetSnapshotId = await context.reversionManager.recordSnapshot(
-              context.messageId,
-              targetPath,
-              "modify",
-            );
-          }
-          await taskManager.updateTask({
-            ...targetTask,
-            blocks: targetTask.blocks.filter((id) => id !== taskId),
-          });
-          if (context.reversionManager && targetSnapshotId) {
-            await context.reversionManager.commitSnapshot(targetSnapshotId);
-          }
-        }
-      }
-
-      // Record delete snapshot for the task itself
-      if (context.reversionManager && context.messageId) {
-        const taskPath = taskManager.getTaskPath(taskId);
-        const deleteSnapshotId = await context.reversionManager.recordSnapshot(
-          context.messageId,
-          taskPath,
-          "delete",
-        );
-        await context.reversionManager.commitSnapshot(deleteSnapshotId);
-      }
-
+      await recordSnapshot(context, taskManager, taskId, "delete");
       await taskManager.deleteTask(taskId);
 
       return {
         success: true,
-        content: `Task #${taskId} deleted and removed from disk.`,
+        content: `Task #${taskId} deleted`,
         shortResult: `Deleted task ${taskId}`,
       };
     }
 
-    let snapshotId: string | undefined;
-    if (context.reversionManager && context.messageId) {
-      const taskPath = taskManager.getTaskPath(taskId);
-      snapshotId = await context.reversionManager.recordSnapshot(
-        context.messageId,
-        taskPath,
-        "modify",
-      );
-    }
-
+    // Build updates object — only include changed fields
     const updatedFields: string[] = [];
-
-    const updatedTask: Task = {
-      ...existingTask,
-    };
+    const updates: {
+      subject?: string;
+      description?: string;
+      activeForm?: string;
+      status?: TaskStatus;
+      owner?: string;
+      metadata?: Record<string, unknown>;
+    } = {};
 
     if (args.subject !== undefined && args.subject !== existingTask.subject) {
-      updatedTask.subject = args.subject as string;
+      updates.subject = args.subject as string;
       updatedFields.push("subject");
     }
     if (
       args.description !== undefined &&
       args.description !== existingTask.description
     ) {
-      updatedTask.description = args.description as string;
+      updates.description = args.description as string;
       updatedFields.push("description");
-    }
-    if (args.status !== undefined && args.status !== existingTask.status) {
-      updatedTask.status = args.status as TaskStatus;
-      updatedFields.push("status");
     }
     if (
       args.activeForm !== undefined &&
       args.activeForm !== existingTask.activeForm
     ) {
-      updatedTask.activeForm = args.activeForm as string;
+      updates.activeForm = args.activeForm as string;
       updatedFields.push("activeForm");
     }
     if (args.owner !== undefined && args.owner !== existingTask.owner) {
-      updatedTask.owner = args.owner as string;
+      updates.owner = args.owner as string;
       updatedFields.push("owner");
     }
+    if (args.status !== undefined && args.status !== existingTask.status) {
+      updates.status = args.status as TaskStatus;
+      updatedFields.push("status");
+    }
 
+    // Merge metadata (null values delete keys)
     if (args.metadata !== undefined) {
-      const newMetadata = { ...(existingTask.metadata || {}) };
+      const merged = { ...(existingTask.metadata ?? {}) };
       for (const [key, value] of Object.entries(
         args.metadata as Record<string, unknown>,
       )) {
         if (value === null) {
-          delete newMetadata[key];
+          delete merged[key];
         } else {
-          newMetadata[key] = value;
+          merged[key] = value;
         }
       }
-      updatedTask.metadata = newMetadata;
+      updates.metadata = merged;
       updatedFields.push("metadata");
     }
 
+    // Apply basic field updates
+    if (Object.keys(updates).length > 0) {
+      await recordSnapshot(context, taskManager, taskId, "modify");
+      await taskManager.updateTask({ ...existingTask, ...updates });
+    }
+
+    // Add blocks: update this task's blocks + reciprocal blockedBy on targets
     if (args.addBlocks !== undefined) {
       const blocksToAdd = (args.addBlocks as string[]).filter(
-        (id) => !updatedTask.blocks.includes(id),
+        (id) => !existingTask.blocks.includes(id),
       );
       if (blocksToAdd.length > 0) {
-        updatedTask.blocks = [...updatedTask.blocks, ...blocksToAdd];
+        await recordSnapshot(context, taskManager, taskId, "modify");
+        await taskManager.updateTask({
+          ...existingTask,
+          ...updates,
+          blocks: [...existingTask.blocks, ...blocksToAdd],
+        });
         updatedFields.push("blocks");
 
-        // Also update the blockedBy of the target tasks
         for (const targetId of blocksToAdd) {
           const targetTask = await taskManager.getTask(targetId);
           if (targetTask && !targetTask.blockedBy.includes(taskId)) {
-            let targetSnapshotId: string | undefined;
-            if (context.reversionManager && context.messageId) {
-              const targetPath = taskManager.getTaskPath(targetId);
-              targetSnapshotId = await context.reversionManager.recordSnapshot(
-                context.messageId,
-                targetPath,
-                "modify",
-              );
-            }
-            await taskManager.updateTask({
-              ...targetTask,
-              blockedBy: [...targetTask.blockedBy, taskId],
-            });
-            if (context.reversionManager && targetSnapshotId) {
-              await context.reversionManager.commitSnapshot(targetSnapshotId);
-            }
+            await updateTaskField(
+              context,
+              taskManager,
+              targetTask,
+              "blockedBy",
+              [...targetTask.blockedBy, taskId],
+            );
           }
         }
       }
     }
 
+    // Add blockedBy: update this task's blockedBy + reciprocal blocks on targets
     if (args.addBlockedBy !== undefined) {
       const blockedByToAdd = (args.addBlockedBy as string[]).filter(
-        (id) => !updatedTask.blockedBy.includes(id),
+        (id) => !existingTask.blockedBy.includes(id),
       );
       if (blockedByToAdd.length > 0) {
-        updatedTask.blockedBy = [...updatedTask.blockedBy, ...blockedByToAdd];
+        await recordSnapshot(context, taskManager, taskId, "modify");
+        await taskManager.updateTask({
+          ...existingTask,
+          ...updates,
+          blockedBy: [...existingTask.blockedBy, ...blockedByToAdd],
+        });
         updatedFields.push("blockedBy");
 
-        // Also update the blocks of the target tasks
         for (const targetId of blockedByToAdd) {
           const targetTask = await taskManager.getTask(targetId);
           if (targetTask && !targetTask.blocks.includes(taskId)) {
-            let targetSnapshotId: string | undefined;
-            if (context.reversionManager && context.messageId) {
-              const targetPath = taskManager.getTaskPath(targetId);
-              targetSnapshotId = await context.reversionManager.recordSnapshot(
-                context.messageId,
-                targetPath,
-                "modify",
-              );
-            }
-            await taskManager.updateTask({
-              ...targetTask,
-              blocks: [...targetTask.blocks, taskId],
-            });
-            if (context.reversionManager && targetSnapshotId) {
-              await context.reversionManager.commitSnapshot(targetSnapshotId);
-            }
+            await updateTaskField(context, taskManager, targetTask, "blocks", [
+              ...targetTask.blocks,
+              taskId,
+            ]);
           }
         }
       }
     }
 
-    await taskManager.updateTask(updatedTask);
-
-    if (context.reversionManager && snapshotId) {
-      await context.reversionManager.commitSnapshot(snapshotId);
-    }
-
     let content = `Updated task #${taskId} ${updatedFields.join(", ")}`;
-    if (updatedTask.status === "completed") {
+    if (updates.status === "completed") {
       content += `\n\nTask completed. Call TaskList now to find your next available task or see if your work unblocked others.`;
     }
 
@@ -563,13 +507,7 @@ export const taskListTool: ToolPlugin = {
       description: "List all tasks in the task list",
       parameters: {
         type: "object",
-        properties: {
-          status: {
-            type: "string",
-            enum: ["pending", "in_progress", "completed", "deleted"],
-            description: "Optional filter by status.",
-          },
-        },
+        properties: {},
       },
     },
   },
@@ -593,26 +531,39 @@ Returns a summary of each task:
 - **blockedBy**: List of open task IDs that must be resolved first (tasks with blockedBy cannot be claimed until dependencies resolve)
 
 Use TaskGet with a specific task ID to view full details including description and comments.`,
-  execute: async (args, context: ToolContext): Promise<ToolResult> => {
+  execute: async (_args, context: ToolContext): Promise<ToolResult> => {
     const taskManager = context.taskManager;
 
-    let tasks = await taskManager.listTasks();
-    if (args.status) {
-      tasks = tasks.filter((t) => t.status === args.status);
-    }
+    // Filter out internal metadata tasks (like Claude Code)
+    const allTasks = (await taskManager.listTasks()).filter(
+      (t) => !(t.metadata as Record<string, unknown>)?._internal,
+    );
 
-    if (tasks.length === 0) {
+    if (allTasks.length === 0) {
       return {
         success: true,
-        content: "No tasks found.",
+        content: "No tasks found",
       };
     }
 
     // Sort by ID numerically
-    tasks.sort((a, b) => parseInt(a.id, 10) - parseInt(b.id, 10));
+    allTasks.sort((a, b) => parseInt(a.id, 10) - parseInt(b.id, 10));
 
-    const content = tasks
-      .map((t) => `[${t.id}] ${t.subject} (${t.status})`)
+    // Filter resolved blockers from blockedBy
+    const completedIds = new Set(
+      allTasks.filter((t) => t.status === "completed").map((t) => t.id),
+    );
+
+    const content = allTasks
+      .map((t) => {
+        const blockedBy = t.blockedBy.filter((id) => !completedIds.has(id));
+        const owner = t.owner ? ` (${t.owner})` : "";
+        const blocked =
+          blockedBy.length > 0
+            ? ` [blocked by ${blockedBy.map((id) => `#${id}`).join(", ")}]`
+            : "";
+        return `#${t.id} [${t.status}] ${t.subject}${owner}${blocked}`;
+      })
       .join("\n");
 
     return {

--- a/packages/agent-sdk/tests/integration/subagentTaskSharing.test.ts
+++ b/packages/agent-sdk/tests/integration/subagentTaskSharing.test.ts
@@ -89,7 +89,7 @@ describe("Subagent Task Sharing Integration Tests", () => {
       mainContext,
     );
     expect(createResult.success).toBe(true);
-    expect(createResult.content).toContain("Task created with ID: 1");
+    expect(createResult.content).toContain("Task #1 created successfully");
 
     // 2. Subagent should be able to get the task using mainSessionId
     const getResult = await taskGetTool.execute(
@@ -97,8 +97,7 @@ describe("Subagent Task Sharing Integration Tests", () => {
       subagentContext,
     );
     expect(getResult.success).toBe(true);
-    const task = JSON.parse(getResult.content as string);
-    expect(task.subject).toBe("Main Task");
+    expect(getResult.content).toContain("Main Task");
 
     // 3. Subagent creates a task
     const subCreateResult = await taskCreateTool.execute(
@@ -109,7 +108,7 @@ describe("Subagent Task Sharing Integration Tests", () => {
       subagentContext,
     );
     expect(subCreateResult.success).toBe(true);
-    expect(subCreateResult.content).toContain("Task created with ID: 2");
+    expect(subCreateResult.content).toContain("Task #2 created successfully");
 
     // 4. Main agent should be able to get the subagent's task
     const mainGetResult = await taskGetTool.execute(
@@ -117,8 +116,7 @@ describe("Subagent Task Sharing Integration Tests", () => {
       mainContext,
     );
     expect(mainGetResult.success).toBe(true);
-    const subTask = JSON.parse(mainGetResult.content as string);
-    expect(subTask.subject).toBe("Subagent Task");
+    expect(mainGetResult.content).toContain("Subagent Task");
   });
 
   it("should NOT share tasks if mainSessionId is not provided (isolation check)", async () => {
@@ -146,6 +144,6 @@ describe("Subagent Task Sharing Integration Tests", () => {
     // 2. Session B should NOT find Task A
     const getResult = await taskGetTool.execute({ taskId: "1" }, contextB);
     expect(getResult.success).toBe(false);
-    expect(getResult.content).toContain("Task with ID 1 not found");
+    expect(getResult.content).toContain("not found");
   });
 });

--- a/packages/agent-sdk/tests/integration/taskManagement.test.ts
+++ b/packages/agent-sdk/tests/integration/taskManagement.test.ts
@@ -92,24 +92,20 @@ describe("Task Management Integration Tests", () => {
     const createArgs = {
       subject: "Integration Task",
       description: "Testing create and get flow",
-      status: "pending",
       metadata: { priority: "high" },
     };
     const createResult = await taskCreateTool.execute(createArgs, context);
     expect(createResult.success).toBe(true);
-    expect(createResult.content).toContain("Task created with ID: 1");
+    expect(createResult.content).toContain("Task #1 created successfully");
 
     // 2. Get the task
     const getResult = await taskGetTool.execute({ taskId: "1" }, context);
     expect(getResult.success).toBe(true);
-    const task = JSON.parse(getResult.content as string);
-    expect(task).toMatchObject({
-      id: "1",
-      subject: "Integration Task",
-      description: "Testing create and get flow",
-      status: "pending",
-      metadata: { priority: "high" },
-    });
+    expect(getResult.content).toContain("Task #1: Integration Task");
+    expect(getResult.content).toContain("Status: pending");
+    expect(getResult.content).toContain(
+      "Description: Testing create and get flow",
+    );
   });
 
   it("Flow 2: Create -> Update -> Get", async () => {
@@ -131,10 +127,8 @@ describe("Task Management Integration Tests", () => {
     // 3. Get and verify
     const getResult = await taskGetTool.execute({ taskId: "1" }, context);
     expect(getResult.success).toBe(true);
-    const task = JSON.parse(getResult.content as string);
-    expect(task.status).toBe("in_progress");
-    expect(task.metadata.progress).toBe(50);
-    expect(task.subject).toBe("Initial Task"); // Should remain unchanged
+    expect(getResult.content).toContain("Status: in_progress");
+    expect(getResult.content).toContain("Initial Task");
   });
 
   it("Flow 3: Create multiple -> List", async () => {
@@ -144,7 +138,7 @@ describe("Task Management Integration Tests", () => {
       context,
     );
     await taskCreateTool.execute(
-      { subject: "Task B", description: "Desc B", status: "completed" },
+      { subject: "Task B", description: "Desc B" },
       context,
     );
     await taskCreateTool.execute(
@@ -152,28 +146,19 @@ describe("Task Management Integration Tests", () => {
       context,
     );
 
-    // 2. List all
+    // 2. List all — all pending since TaskCreate no longer accepts status
     const listAllResult = await taskListTool.execute({}, context);
     expect(listAllResult.success).toBe(true);
-    expect(listAllResult.content).toContain("[1] Task A (pending)");
-    expect(listAllResult.content).toContain("[2] Task B (completed)");
-    expect(listAllResult.content).toContain("[3] Task C (pending)");
-
-    // 3. List with filter
-    const listFilteredResult = await taskListTool.execute(
-      { status: "completed" },
-      context,
-    );
-    expect(listFilteredResult.success).toBe(true);
-    expect(listFilteredResult.content).toBe("[2] Task B (completed)");
-    expect(listFilteredResult.content).not.toContain("Task A");
+    expect(listAllResult.content).toContain("#1 [pending] Task A");
+    expect(listAllResult.content).toContain("#2 [pending] Task B");
+    expect(listAllResult.content).toContain("#3 [pending] Task C");
   });
 
   it("Flow 4: Error cases", async () => {
     // 1. Get non-existent task
     const getResult = await taskGetTool.execute({ taskId: "999" }, context);
     expect(getResult.success).toBe(false);
-    expect(getResult.content).toContain("Task with ID 999 not found");
+    expect(getResult.content).toContain("not found");
 
     // 2. Update non-existent task
     const updateResult = await taskUpdateTool.execute(
@@ -181,6 +166,6 @@ describe("Task Management Integration Tests", () => {
       context,
     );
     expect(updateResult.success).toBe(false);
-    expect(updateResult.content).toContain("Task with ID 999 not found");
+    expect(updateResult.content).toContain("not found");
   });
 });

--- a/packages/agent-sdk/tests/taskManagerConcurrency.test.ts
+++ b/packages/agent-sdk/tests/taskManagerConcurrency.test.ts
@@ -117,7 +117,7 @@ describe("TaskCreate Concurrency", () => {
 
     const taskIds = results.map((r) => {
       if (r.success) {
-        const match = r.content.match(/ID: (\d+)/);
+        const match = r.content.match(/Task #(\d+) created/);
         return match ? match[1] : null;
       }
       return null;

--- a/packages/agent-sdk/tests/tools/taskManagementTools.test.ts
+++ b/packages/agent-sdk/tests/tools/taskManagementTools.test.ts
@@ -65,7 +65,7 @@ describe("Task Management Tools", () => {
       const args = {
         subject: "Test Task",
         description: "Test Description",
-        status: "in_progress",
+        activeForm: "Testing",
       };
       mockTaskManager.createTask.mockResolvedValue("1");
 
@@ -74,15 +74,15 @@ describe("Task Management Tools", () => {
       expect(mockTaskManager.createTask).toHaveBeenCalledWith({
         subject: "Test Task",
         description: "Test Description",
-        status: "in_progress",
-        activeForm: undefined,
+        status: "pending",
+        activeForm: "Testing",
         owner: undefined,
         blocks: [],
         blockedBy: [],
         metadata: {},
       });
       expect(result.success).toBe(true);
-      expect(result.content).toContain("Task created with ID: 1");
+      expect(result.content).toContain("Task #1 created successfully");
     });
 
     it("should use default values when optional arguments are missing", async () => {
@@ -121,20 +121,6 @@ describe("Task Management Tools", () => {
     });
   });
 
-  describe("TaskCreate tool - skip deleted", () => {
-    it("should skip task creation if status is deleted", async () => {
-      const args = {
-        subject: "Deleted Task",
-        description: "Should not be created",
-        status: "deleted",
-      };
-      const result = await taskCreateTool.execute(args, context);
-      expect(mockTaskManager.createTask).not.toHaveBeenCalled();
-      expect(result.success).toBe(true);
-      expect(result.content).toContain("Task creation skipped");
-    });
-  });
-
   describe("TaskGet tool", () => {
     it("should retrieve a task by ID", async () => {
       const task: Task = {
@@ -152,7 +138,9 @@ describe("Task Management Tools", () => {
 
       expect(mockTaskManager.getTask).toHaveBeenCalledWith("1");
       expect(result.success).toBe(true);
-      expect(JSON.parse(result.content as string)).toEqual(task);
+      expect(result.content).toContain("Task #1: Test Task");
+      expect(result.content).toContain("Status: pending");
+      expect(result.content).toContain("Description: Test Description");
     });
 
     it("should return error if task is not found", async () => {
@@ -164,7 +152,7 @@ describe("Task Management Tools", () => {
       );
 
       expect(result.success).toBe(false);
-      expect(result.content).toBe("Task with ID non-existent not found.");
+      expect(result.content).toBe("Task not found");
     });
   });
 
@@ -235,7 +223,7 @@ describe("Task Management Tools", () => {
       const result = await taskUpdateTool.execute({ taskId: "2" }, context);
 
       expect(result.success).toBe(false);
-      expect(result.content).toBe("Task with ID 2 not found.");
+      expect(result.content).toBe("Task #2 not found");
     });
   });
 
@@ -267,47 +255,45 @@ describe("Task Management Tools", () => {
 
       expect(mockTaskManager.listTasks).toHaveBeenCalled();
       expect(result.success).toBe(true);
-      expect(result.content).toBe(
-        "[1] Task 1 (completed)\n[2] Task 2 (pending)",
-      );
+      expect(result.content).toBe("#1 [completed] Task 1\n#2 [pending] Task 2");
     });
 
-    it("should filter tasks by status", async () => {
+    it("should filter out _internal metadata tasks", async () => {
       const tasks: Task[] = [
         {
           id: "1",
-          subject: "Task 1",
-          description: "",
-          status: "completed",
-          blocks: [],
-          blockedBy: [],
-          metadata: {},
-        },
-        {
-          id: "2",
-          subject: "Task 2",
+          subject: "Real Task",
           description: "",
           status: "pending",
           blocks: [],
           blockedBy: [],
           metadata: {},
         },
+        {
+          id: "2",
+          subject: "Internal Task",
+          description: "",
+          status: "pending",
+          blocks: [],
+          blockedBy: [],
+          metadata: { _internal: true },
+        },
       ];
       mockTaskManager.listTasks.mockResolvedValue(tasks);
 
-      const result = await taskListTool.execute({ status: "pending" }, context);
+      const result = await taskListTool.execute({}, context);
 
       expect(result.success).toBe(true);
-      expect(result.content).toBe("[2] Task 2 (pending)");
+      expect(result.content).toBe("#1 [pending] Real Task");
     });
 
-    it("should return 'No tasks found.' if list is empty", async () => {
+    it("should return 'No tasks found' if list is empty", async () => {
       mockTaskManager.listTasks.mockResolvedValue([]);
 
       const result = await taskListTool.execute({}, context);
 
       expect(result.success).toBe(true);
-      expect(result.content).toBe("No tasks found.");
+      expect(result.content).toBe("No tasks found");
     });
   });
 
@@ -429,8 +415,8 @@ describe("Task Management Tools", () => {
     });
   });
 
-  describe("TaskUpdate tool - physical deletion", () => {
-    it("should physically delete task and cleanup reciprocal dependencies", async () => {
+  describe("TaskUpdate tool - deletion", () => {
+    it("should delete task (no reciprocal cleanup, like Claude Code)", async () => {
       const task1: Task = {
         id: "1",
         subject: "Task 1",
@@ -440,31 +426,8 @@ describe("Task Management Tools", () => {
         blockedBy: ["3"],
         metadata: {},
       };
-      const task2: Task = {
-        id: "2",
-        subject: "Task 2",
-        description: "",
-        status: "pending",
-        blocks: [],
-        blockedBy: ["1"],
-        metadata: {},
-      };
-      const task3: Task = {
-        id: "3",
-        subject: "Task 3",
-        description: "",
-        status: "pending",
-        blocks: ["1"],
-        blockedBy: [],
-        metadata: {},
-      };
 
-      mockTaskManager.getTask.mockImplementation(async (id) => {
-        if (id === "1") return task1;
-        if (id === "2") return task2;
-        if (id === "3") return task3;
-        return null;
-      });
+      mockTaskManager.getTask.mockResolvedValue(task1);
 
       const result = await taskUpdateTool.execute(
         { taskId: "1", status: "deleted" },
@@ -472,22 +435,10 @@ describe("Task Management Tools", () => {
       );
 
       expect(mockTaskManager.deleteTask).toHaveBeenCalledWith("1");
-      // Check reciprocal cleanup for task 2 (which was blocked by 1)
-      expect(mockTaskManager.updateTask).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: "2",
-          blockedBy: [],
-        }),
-      );
-      // Check reciprocal cleanup for task 3 (which blocked 1)
-      expect(mockTaskManager.updateTask).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: "3",
-          blocks: [],
-        }),
-      );
+      // No reciprocal cleanup — just delete the task file
+      expect(mockTaskManager.updateTask).not.toHaveBeenCalled();
       expect(result.success).toBe(true);
-      expect(result.content).toContain("deleted and removed from disk");
+      expect(result.content).toContain("Task #1 deleted");
     });
   });
 });

--- a/packages/code/src/components/TaskList.tsx
+++ b/packages/code/src/components/TaskList.tsx
@@ -22,32 +22,71 @@ export const getStatusIcon = (status: TaskStatus): React.ReactNode => {
   }
 };
 
+function byIdAsc(a: Task, b: Task): number {
+  const aNum = parseInt(a.id, 10);
+  const bNum = parseInt(b.id, 10);
+  if (!isNaN(aNum) && !isNaN(bNum)) {
+    return aNum - bNum;
+  }
+  return a.id.localeCompare(b.id);
+}
+
 export function sortTasksByPriority(
   tasks: Task[],
-  recentlyCompleted: Map<string, number>,
+  completionTimestamps: Map<string, number>,
   now: number,
+  needsTruncation: boolean,
 ): Task[] {
-  const getPriority = (task: Task): number => {
-    const completedAt = recentlyCompleted.get(task.id);
-    const isRecentlyCompleted =
-      completedAt !== undefined &&
-      now - completedAt < RECENTLY_COMPLETED_TTL_MS;
+  if (!needsTruncation) {
+    // No truncation needed — sort by ID for stable ordering
+    return [...tasks].sort(byIdAsc);
+  }
 
-    if (isRecentlyCompleted) return 0;
-    if (task.status === "in_progress") return 1;
-    if (task.status === "pending" && task.blockedBy.length === 0) return 2;
-    if (task.status === "pending" && task.blockedBy.length > 0) return 3;
-    if (task.status === "completed") return 4;
-    if (task.status === "deleted") return 5;
-    return 6;
-  };
+  // When truncation is needed, prioritize:
+  // recently completed > in_progress > pending (unblocked first) > older completed > deleted
+  const recentCompleted: Task[] = [];
+  const olderCompleted: Task[] = [];
+  for (const task of tasks.filter((t) => t.status === "completed")) {
+    const ts = completionTimestamps.get(task.id);
+    if (ts && now - ts < RECENTLY_COMPLETED_TTL_MS) {
+      recentCompleted.push(task);
+    } else {
+      olderCompleted.push(task);
+    }
+  }
+  recentCompleted.sort(byIdAsc);
+  olderCompleted.sort(byIdAsc);
 
-  return [...tasks].sort((a, b) => getPriority(a) - getPriority(b));
+  const inProgress = tasks
+    .filter((t) => t.status === "in_progress")
+    .sort(byIdAsc);
+
+  const unresolvedTaskIds = new Set(
+    tasks.filter((t) => t.status !== "completed").map((t) => t.id),
+  );
+  const pending = tasks
+    .filter((t) => t.status === "pending")
+    .sort((a, b) => {
+      const aBlocked = a.blockedBy.some((id) => unresolvedTaskIds.has(id));
+      const bBlocked = b.blockedBy.some((id) => unresolvedTaskIds.has(id));
+      if (aBlocked !== bBlocked) return aBlocked ? 1 : -1;
+      return byIdAsc(a, b);
+    });
+
+  const deleted = tasks.filter((t) => t.status === "deleted").sort(byIdAsc);
+
+  return [
+    ...recentCompleted,
+    ...inProgress,
+    ...pending,
+    ...olderCompleted,
+    ...deleted,
+  ];
 }
 
 function getDisplayLimit(rows: number | undefined): number {
   const available = rows ?? 24;
-  return Math.min(8, Math.max(3, available - 12));
+  return available <= 10 ? 0 : Math.min(10, Math.max(3, available - 14));
 }
 
 export const TaskList: React.FC = () => {
@@ -55,7 +94,8 @@ export const TaskList: React.FC = () => {
   const { isTaskListVisible } = useChat();
   const { stdout } = useStdout();
 
-  const recentlyCompletedRef = React.useRef<Map<string, number>>(new Map());
+  const completionTimestampsRef = React.useRef<Map<string, number>>(new Map());
+  const previousCompletedIdsRef = React.useRef<Set<string> | null>(null);
   const autoHideTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
@@ -65,38 +105,50 @@ export const TaskList: React.FC = () => {
     const active = tasks.filter((t) => t.status !== "deleted");
     return active.length > 0 && active.every((t) => t.status === "completed");
   });
-  const [, setTick] = React.useState(0);
+  const [, forceUpdate] = React.useState(0);
 
   const now = Date.now();
   const activeTasks = tasks.filter((t) => t.status !== "deleted");
 
-  // Track recently completed tasks
-  for (const task of tasks) {
-    if (
-      task.status === "completed" &&
-      !recentlyCompletedRef.current.has(task.id)
-    ) {
-      recentlyCompletedRef.current.set(task.id, now);
+  // Track completion timestamps: only set when a task newly transitions to completed
+  if (previousCompletedIdsRef.current === null) {
+    previousCompletedIdsRef.current = new Set(
+      tasks.filter((t) => t.status === "completed").map((t) => t.id),
+    );
+  }
+  const currentCompletedIds = new Set(
+    tasks.filter((t) => t.status === "completed").map((t) => t.id),
+  );
+  for (const id of currentCompletedIds) {
+    if (!previousCompletedIdsRef.current.has(id)) {
+      completionTimestampsRef.current.set(id, now);
     }
   }
+  for (const id of completionTimestampsRef.current.keys()) {
+    if (!currentCompletedIds.has(id)) {
+      completionTimestampsRef.current.delete(id);
+    }
+  }
+  previousCompletedIdsRef.current = currentCompletedIds;
 
-  // Prune expired entries and force re-render if any expired
-  const needsTick = React.useMemo(() => {
-    let expired = false;
-    for (const [id, ts] of recentlyCompletedRef.current) {
-      if (now - ts >= RECENTLY_COMPLETED_TTL_MS) {
-        recentlyCompletedRef.current.delete(id);
-        expired = true;
+  // Schedule re-render when the next recent completion expires
+  React.useEffect(() => {
+    if (completionTimestampsRef.current.size === 0) return;
+    const currentNow = Date.now();
+    let earliestExpiry = Infinity;
+    for (const ts of completionTimestampsRef.current.values()) {
+      const expiry = ts + RECENTLY_COMPLETED_TTL_MS;
+      if (expiry > currentNow && expiry < earliestExpiry) {
+        earliestExpiry = expiry;
       }
     }
-    return expired;
-  }, [now]);
-
-  React.useEffect(() => {
-    if (needsTick) {
-      setTick((t) => t + 1);
-    }
-  }, [needsTick]);
+    if (earliestExpiry === Infinity) return;
+    const timer = setTimeout(
+      () => forceUpdate((n) => n + 1),
+      earliestExpiry - currentNow,
+    );
+    return () => clearTimeout(timer);
+  }, [tasks]);
 
   // Auto-hide logic: when all active tasks are completed
   const allCompleted =
@@ -125,9 +177,15 @@ export const TaskList: React.FC = () => {
   }
 
   const displayLimit = getDisplayLimit(stdout?.rows);
-  const sorted = sortTasksByPriority(tasks, recentlyCompletedRef.current, now);
-  const displayed = sorted.slice(0, displayLimit);
-  const hidden = sorted.slice(displayLimit);
+  const needsTruncation = tasks.length > displayLimit;
+  const sorted = sortTasksByPriority(
+    tasks,
+    completionTimestampsRef.current,
+    now,
+    needsTruncation,
+  );
+  const displayed = displayLimit > 0 ? sorted.slice(0, displayLimit) : [];
+  const hidden = displayLimit > 0 ? sorted.slice(displayLimit) : sorted;
 
   const doneCount = tasks.filter((t) => t.status === "completed").length;
   const inProgressCount = tasks.filter(
@@ -157,7 +215,12 @@ export const TaskList: React.FC = () => {
       {displayed.map((task) => {
         const isDimmed =
           task.status === "completed" || task.status === "deleted";
-        const isBlocked = task.blockedBy && task.blockedBy.length > 0;
+        const unresolvedTaskIds = new Set(
+          tasks.filter((t) => t.status !== "completed").map((t) => t.id),
+        );
+        const isBlocked =
+          task.blockedBy &&
+          task.blockedBy.some((id) => unresolvedTaskIds.has(id));
         const blockingTaskIds = isBlocked
           ? task.blockedBy.map((id) => `#${id}`)
           : [];
@@ -178,11 +241,8 @@ export const TaskList: React.FC = () => {
           </Box>
         );
       })}
-      {hidden.length > 0 && (
-        <Text dimColor>
-          {" "}
-          +{hidden.length} {summaryParts.join(", ")}
-        </Text>
+      {displayLimit > 0 && hidden.length > 0 && (
+        <Text dimColor> … +{summaryParts.join(", ")}</Text>
       )}
     </Box>
   );

--- a/packages/code/tests/components/TaskList.test.tsx
+++ b/packages/code/tests/components/TaskList.test.tsx
@@ -125,8 +125,6 @@ describe("TaskList", () => {
     const { lastFrame } = render(<TaskList />);
     const output = lastFrame()!;
 
-    // The text should still contain the subject (ink-testing-library may not
-    // actually truncate in test env, but the wrap prop is set)
     expect(output).toContain(longSubject);
   });
 
@@ -157,7 +155,7 @@ describe("TaskList", () => {
 
   it("should limit displayed tasks based on terminal height", () => {
     vi.mocked(useStdout).mockReturnValue({
-      stdout: { rows: 10 },
+      stdout: { rows: 16 },
     } as unknown as ReturnType<typeof useStdout>);
 
     const mockTasks: Task[] = Array.from({ length: 8 }, (_, i) =>
@@ -172,18 +170,37 @@ describe("TaskList", () => {
     const { lastFrame } = render(<TaskList />);
     const output = lastFrame()!;
 
-    // rows=10 → displayLimit = min(8, max(3, 10-12)) = min(8, max(3, -2)) = min(8, 3) = 3
+    // rows=16 → displayLimit = min(10, max(3, 16-14)) = min(10, max(3, 2)) = min(10, 3) = 3
     expect(output).toContain("Task 1");
     expect(output).toContain("Task 2");
     expect(output).toContain("Task 3");
     // Tasks beyond the limit should be in the summary
-    expect(output).toContain("+5 5 pending");
+    expect(output).toMatch(/… \+5 pending/);
+  });
+
+  it("should show nothing when terminal rows <= 10", () => {
+    vi.mocked(useStdout).mockReturnValue({
+      stdout: { rows: 10 },
+    } as unknown as ReturnType<typeof useStdout>);
+
+    const mockTasks: Task[] = [
+      makeTask({ id: "1", subject: "Task 1", status: "pending" }),
+    ];
+    vi.mocked(useTasks).mockReturnValue(mockTasks);
+
+    const { lastFrame } = render(<TaskList />);
+    // displayLimit = 0 when rows <= 10, so no task rows rendered
+    // But header still shows. Actually let's check the component still renders the header.
+    const output = lastFrame()!;
+    expect(output).toContain("1 tasks");
+    // But no task rows displayed
+    expect(output).not.toContain("□ Task 1");
   });
 
   it("should show summary line for hidden tasks", () => {
-    // Use rows=10 → displayLimit=3 to force truncation with mixed statuses
+    // Use rows=16 → displayLimit=3 to force truncation with mixed statuses
     vi.mocked(useStdout).mockReturnValue({
-      stdout: { rows: 10 },
+      stdout: { rows: 16 },
     } as unknown as ReturnType<typeof useStdout>);
 
     const mockTasks: Task[] = [
@@ -198,17 +215,14 @@ describe("TaskList", () => {
     const { lastFrame } = render(<TaskList />);
     const output = lastFrame()!;
 
-    // displayLimit=3: shows "Working", "Done", "Also Done" (recently completed first, then in_progress)
-    // Hidden: 2 pending → summary
-    expect(output).toMatch(/\+2.*2 pending/);
+    // With new sorting: in_progress > pending > older completed (no recently completed since fresh mount)
+    // displayLimit=3: shows "Working", "Pending 1", "Pending 2"
+    // Hidden: 2 completed → summary
+    expect(output).toMatch(/… \+2 completed/);
   });
 
   it("should sort by priority when tasks exceed display limit", () => {
-    vi.mocked(useStdout).mockReturnValue({
-      stdout: { rows: 10 },
-    } as unknown as ReturnType<typeof useStdout>);
-
-    const recentlyCompleted = new Map<string, number>();
+    const completionTimestamps = new Map<string, number>();
     const now = Date.now();
 
     const tasks: Task[] = [
@@ -223,29 +237,68 @@ describe("TaskList", () => {
       makeTask({ id: "4", subject: "Old completed", status: "completed" }),
     ];
 
-    const sorted = sortTasksByPriority(tasks, recentlyCompleted, now);
+    const sorted = sortTasksByPriority(tasks, completionTimestamps, now, true);
 
-    // in_progress first, then pending unblocked, then pending blocked, then completed
+    // in_progress first, then pending unblocked, then pending blocked, then older completed
     expect(sorted[0].subject).toBe("In progress");
     expect(sorted[1].subject).toBe("Pending unblocked");
     expect(sorted[2].subject).toBe("Pending blocked");
     expect(sorted[3].subject).toBe("Old completed");
   });
 
-  it("should sort recently completed tasks before in_progress", () => {
-    const recentlyCompleted = new Map<string, number>();
+  it("should sort recently completed tasks before in_progress when truncating", () => {
+    const completionTimestamps = new Map<string, number>();
     const now = Date.now();
-    recentlyCompleted.set("1", now - 1000); // 1s ago
+    completionTimestamps.set("1", now - 1000); // 1s ago
 
     const tasks: Task[] = [
       makeTask({ id: "1", subject: "Just completed", status: "completed" }),
       makeTask({ id: "2", subject: "In progress", status: "in_progress" }),
     ];
 
-    const sorted = sortTasksByPriority(tasks, recentlyCompleted, now);
+    const sorted = sortTasksByPriority(tasks, completionTimestamps, now, true);
 
     expect(sorted[0].subject).toBe("Just completed");
     expect(sorted[1].subject).toBe("In progress");
+  });
+
+  it("should sort by ID when no truncation needed", () => {
+    const completionTimestamps = new Map<string, number>();
+    const now = Date.now();
+
+    const tasks: Task[] = [
+      makeTask({ id: "3", subject: "Task C", status: "in_progress" }),
+      makeTask({ id: "1", subject: "Task A", status: "pending" }),
+      makeTask({ id: "2", subject: "Task B", status: "completed" }),
+    ];
+
+    const sorted = sortTasksByPriority(tasks, completionTimestamps, now, false);
+
+    // When no truncation, just sort by ID for stable ordering
+    expect(sorted[0].id).toBe("1");
+    expect(sorted[1].id).toBe("2");
+    expect(sorted[2].id).toBe("3");
+  });
+
+  it("should put older completed after pending when truncating", () => {
+    const completionTimestamps = new Map<string, number>();
+    const now = Date.now();
+    // No timestamps → all completed are "older"
+
+    const tasks: Task[] = [
+      makeTask({ id: "1", subject: "Old done 1", status: "completed" }),
+      makeTask({ id: "2", subject: "Old done 2", status: "completed" }),
+      makeTask({ id: "3", subject: "Working", status: "in_progress" }),
+      makeTask({ id: "4", subject: "Waiting", status: "pending" }),
+    ];
+
+    const sorted = sortTasksByPriority(tasks, completionTimestamps, now, true);
+
+    // in_progress > pending > older completed
+    expect(sorted[0].subject).toBe("Working");
+    expect(sorted[1].subject).toBe("Waiting");
+    expect(sorted[2].subject).toBe("Old done 1");
+    expect(sorted[3].subject).toBe("Old done 2");
   });
 
   it("should auto-hide after all tasks completed", () => {


### PR DESCRIPTION
TaskCreate: remove status/owner/blocks/blockedBy params, always create
pending with empty deps; output 'Task #1 created successfully'.

TaskUpdate: deletion just calls deleteTask() (no reciprocal cleanup);
use clean updates object with only changed fields.

TaskList: remove status filter param; filter _internal metadata tasks;
filter resolved blockers from blockedBy; output '#1 [pending] Task'.

TaskGet: structured text output instead of raw JSON; not-found returns
'Task not found'.

TaskList UI (packages/code): port Claude Code's display logic — group
concatenation sort (recentCompleted > inProgress > pending >
olderCompleted) instead of single priority number; display limit formula
min(10, max(3, rows-14)); scheduled re-render timer for TTL expiry;
blocked-by only shows unresolved blockers; '+N more' format matches
Claude Code.
