### PR TITLE
fix: preserve plugin skills when refreshSkills is triggered by file watcher

### DIFF
--- a/packages/agent-sdk/src/managers/skillManager.ts
+++ b/packages/agent-sdk/src/managers/skillManager.ts
@@ -34,6 +34,8 @@ export class SkillManager extends EventEmitter {
 
   private skillMetadata = new Map<string, SkillMetadata>();
   private skillContent = new Map<string, Skill>();
+  private pluginSkillMetadata = new Map<string, SkillMetadata>();
+  private pluginSkillContent = new Map<string, Skill>();
   private initialized = false;
   private fileWatcher: FileWatcherService | null = null;
   private watchEnabled: boolean;
@@ -77,7 +79,7 @@ export class SkillManager extends EventEmitter {
    * Refresh skills by re-discovering them
    */
   private async refreshSkills(): Promise<void> {
-    // Clear existing data before discovery
+    // Clear only discovered skills (builtin/personal/project), preserve plugin skills
     this.skillMetadata.clear();
     this.skillContent.clear();
 
@@ -92,6 +94,14 @@ export class SkillManager extends EventEmitter {
     });
     discovery.projectSkills.forEach((skill, name) => {
       this.skillMetadata.set(name, skill);
+    });
+
+    // Restore plugin skills
+    this.pluginSkillMetadata.forEach((metadata, name) => {
+      this.skillMetadata.set(name, metadata);
+    });
+    this.pluginSkillContent.forEach((skill, name) => {
+      this.skillContent.set(name, skill);
     });
 
     // Log any discovery errors
@@ -506,6 +516,9 @@ export class SkillManager extends EventEmitter {
 
       this.skillMetadata.set(namespacedName, metadata);
       this.skillContent.set(namespacedName, skill);
+      // Also store in plugin-specific maps so they survive refreshSkills()
+      this.pluginSkillMetadata.set(namespacedName, metadata);
+      this.pluginSkillContent.set(namespacedName, skill);
     }
     logger?.debug(
       `Registered ${skills.length} plugin skills from ${pluginName}. Total skills: ${this.skillMetadata.size}`,

--- a/packages/agent-sdk/tests/managers/skillManager.test.ts
+++ b/packages/agent-sdk/tests/managers/skillManager.test.ts
@@ -901,5 +901,74 @@ describe("SkillManager", () => {
 
       expect(mockFileWatcher.cleanup).toHaveBeenCalled();
     });
+
+    it("should preserve plugin skills when refreshSkills is triggered by file watcher", async () => {
+      const manager = new SkillManager(container, {
+        workdir: "/test/workdir",
+        watch: true,
+      });
+      container.register("SkillManager", manager);
+
+      const slashCommandManager = new SlashCommandManager(container, {
+        workdir: "/test/workdir",
+      });
+      slashCommandManager.initialize();
+
+      // Initialize with no discovered skills
+      vi.mocked(readdir).mockResolvedValue([]);
+      await manager.initialize();
+
+      // Register plugin skills
+      const pluginSkill: Skill = {
+        name: "commit-push-mr",
+        description: "Commit and push MR",
+        type: "personal",
+        skillPath: "/path/to/plugin/skills/commit-push-mr",
+        content: "---\nname: commit-push-mr\n---\nTask content",
+        frontmatter: {
+          name: "commit-push-mr",
+          description: "Commit and push MR",
+        },
+        isValid: true,
+        errors: [],
+        pluginRoot: "/path/to/plugin",
+      };
+      manager.registerPluginSkills("commit-skills", [pluginSkill]);
+
+      // Verify plugin skill is available
+      let skills = manager.getAvailableSkills();
+      expect(
+        skills.find((s) => s.name === "commit-skills:commit-push-mr"),
+      ).toBeDefined();
+
+      // Register skill commands after plugin registration
+      slashCommandManager.registerSkillCommands(manager.getAvailableSkills());
+      expect(
+        slashCommandManager.hasCommand("commit-skills:commit-push-mr"),
+      ).toBe(true);
+
+      // Get the file watcher callback
+      const onEventCallback = mockFileWatcher.watchFile.mock.calls[0][1];
+
+      // Trigger refreshSkills via file watcher (simulating a SKILL.md change)
+      await onEventCallback({
+        type: "change",
+        path: "/test/workdir/.wave/skills/some-skill/SKILL.md",
+        timestamp: Date.now(),
+      });
+
+      // Plugin skills should still be available after refresh
+      skills = manager.getAvailableSkills();
+      expect(
+        skills.find((s) => s.name === "commit-skills:commit-push-mr"),
+      ).toBeDefined();
+
+      // Plugin skill slash commands should still be registered
+      expect(
+        slashCommandManager.hasCommand("commit-skills:commit-push-mr"),
+      ).toBe(true);
+
+      await manager.destroy();
+    });
   });
 });


### PR DESCRIPTION
## Problem

When a SKILL.md file change triggers `refreshSkills()` via the file watcher, all skills including plugin skills were cleared and lost. Since `discoverSkills()` only rediscovers builtin/personal/project skills, plugin skill slash commands (e.g. `/commit-skills:commit-push-mr`) became unregistered.

## Root Cause

`SkillManager.refreshSkills()` calls `skillMetadata.clear()` + `skillContent.clear()` which removes ALL skills. Plugin skills registered via `registerPluginSkills()` are stored in the same maps but not re-discovered by `discoverSkills()`.

## Fix

Store plugin skills in separate `pluginSkillMetadata`/`pluginSkillContent` maps. After `refreshSkills()` clears and re-discovers disk-based skills, plugin skills are restored from the plugin-specific maps.

## Test

Added test verifying plugin skills and their slash commands survive a file watcher triggered refresh.