### PR TITLE
Improve message queue: add UP arrow recall, state machine, and conditional abort

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -232,33 +232,17 @@ export class Agent {
     });
 
     // Wire up message queue to process when agent becomes idle
-    this.messageQueue.onMessageEnqueued = () => {
-      // If the AI is NOT loading and command is not running, trigger dequeue
-      if (!this.aiManager.isLoading && !this.isCommandRunning) {
-        this.processQueuedMessage().catch((error) => {
-          this.logger?.error("Failed to process queued message:", error);
-        });
-      }
-    };
+    this.messageQueue.onMessageEnqueued = () => this.tryDequeue();
 
     // Wire up AI loading changes to process queue when AI becomes idle
     this.aiManager.onLoadingChange = (loading: boolean) => {
-      if (!loading && !this.isCommandRunning) {
-        this.processQueuedMessage().catch((error) => {
-          this.logger?.error("Failed to process queued message:", error);
-        });
-      }
+      if (!loading) this.tryDequeue();
     };
 
     // Wire up bang manager callback for command running changes
     this.bangManager.onCommandRunningChange = (running: boolean) => {
       this.options.callbacks?.onCommandRunningChange?.(running);
-      // When command stops and AI is idle, process queue
-      if (!running && !this.aiManager.isLoading) {
-        this.processQueuedMessage().catch((error) => {
-          this.logger?.error("Failed to process queued message:", error);
-        });
-      }
+      if (!running) this.tryDequeue();
     };
 
     // Set initial permission mode if provided
@@ -380,13 +364,59 @@ export class Agent {
   }
 
   /**
+   * Recall the last editable queued message (for inline editing)
+   * @returns The recalled message, or null if no editable message exists
+   */
+  public recallQueuedMessage(): QueuedMessage | null {
+    const msg = this.messageQueue.popLastEditable();
+    if (msg) {
+      this.options.callbacks?.onQueuedMessagesChange?.(this.queuedMessages);
+    }
+    return msg;
+  }
+
+  /**
+   * Remove a queued message by its ID
+   * @param id - The ID of the message to remove
+   * @returns true if the message was removed, false if not found
+   */
+  public removeQueuedMessageById(id: string): boolean {
+    const removed = this.messageQueue.removeById(id);
+    if (removed) {
+      this.options.callbacks?.onQueuedMessagesChange?.(this.queuedMessages);
+    }
+    return removed;
+  }
+
+  /**
+   * Unified dequeue trigger — checks state machine before processing.
+   * Called from onMessageEnqueued, onLoadingChange(false), and
+   * onCommandRunningChange(false).
+   */
+  private tryDequeue(): void {
+    if (this.messageQueue.state !== "idle") return;
+    if (!this.messageQueue.hasPending()) return;
+    if (this.aiManager.isLoading || this.isCommandRunning) return;
+
+    this.messageQueue.transitionTo("dispatching");
+    this.processQueuedMessage()
+      .catch((error) => {
+        this.logger?.error("Failed to process queued message:", error);
+      })
+      .finally(() => {
+        this.messageQueue.transitionTo("idle");
+        this.tryDequeue(); // Re-check after processing
+      });
+  }
+
+  /**
    * Process the next queued message when the agent becomes idle.
-   * Dequeues the next message and handles it based on type.
    */
   private async processQueuedMessage(): Promise<void> {
     const next = this.messageQueue.dequeue();
     if (!next) return;
 
+    this.messageQueue.transitionTo("running");
     this.options.callbacks?.onQueuedMessagesChange?.(this.queuedMessages);
 
     if (next.type === "bang") {
@@ -658,10 +688,13 @@ export class Agent {
 
   /** Unified interrupt method, interrupts both AI messages and command execution */
   public abortMessage(): void {
-    // Clear queue first to prevent processQueuedMessage from dequeuing
-    // when abortAIMessage triggers onLoadingChange(false)
-    this.messageQueue.clear();
-    this.options.callbacks?.onQueuedMessagesChange?.(this.queuedMessages);
+    if (this.aiManager.isLoading || this.isCommandRunning) {
+      // Clear queue first to prevent processQueuedMessage from dequeuing
+      // when abortAIMessage triggers onLoadingChange(false)
+      this.messageQueue.clear();
+      this.options.callbacks?.onQueuedMessagesChange?.(this.queuedMessages);
+    }
+    this.messageQueue.transitionTo("idle"); // Reset state on abort
     this.abortAIMessage(); // This will abort tools including Agent tool (subagents)
     this.abortBashCommand();
     this.abortSlashCommand();
@@ -868,7 +901,10 @@ export class Agent {
         this.slashCommandManager.isImmediateCommand(trimmed);
 
       if (!isImmediate) {
-        this.messageQueue.enqueue({ content, images });
+        this.messageQueue.enqueue({
+          content,
+          images,
+        });
         this.options.callbacks?.onQueuedMessagesChange?.(this.queuedMessages);
         return;
       }

--- a/packages/agent-sdk/src/managers/messageQueue.ts
+++ b/packages/agent-sdk/src/managers/messageQueue.ts
@@ -1,16 +1,42 @@
+export type QueueState = "idle" | "dispatching" | "running";
+
 export interface QueuedMessage {
+  id?: string;
   type?: "message" | "bang";
   content: string;
   images?: Array<{ path: string; mimeType: string }>;
   longTextMap?: Record<string, string>;
+  editable?: boolean; // default true
 }
 
 export class MessageQueue {
   private queue: QueuedMessage[] = [];
+  private nextId = 0;
+  private _state: QueueState = "idle";
   onMessageEnqueued?: () => void;
 
+  get state(): QueueState {
+    return this._state;
+  }
+
+  transitionTo(newState: QueueState): boolean {
+    const valid: Record<QueueState, QueueState[]> = {
+      idle: ["dispatching"],
+      dispatching: ["running", "idle"],
+      running: ["idle"],
+    };
+    if (!valid[this._state].includes(newState)) return false;
+    this._state = newState;
+    return true;
+  }
+
   enqueue(message: QueuedMessage): void {
-    this.queue.push(message);
+    const msg: QueuedMessage = {
+      ...message,
+      id: message.id || `mq-${this.nextId++}`,
+      editable: message.editable ?? true,
+    };
+    this.queue.push(msg);
     this.onMessageEnqueued?.();
   }
 
@@ -20,6 +46,7 @@ export class MessageQueue {
 
   clear(): void {
     this.queue = [];
+    this._state = "idle";
   }
 
   hasPending(): boolean {
@@ -37,5 +64,36 @@ export class MessageQueue {
     this.queue.splice(index, 1);
     this.onMessageEnqueued?.();
     return true;
+  }
+
+  removeById(id: string): boolean {
+    const index = this.queue.findIndex((m) => m.id === id);
+    if (index === -1) return false;
+    this.queue.splice(index, 1);
+    this.onMessageEnqueued?.();
+    return true;
+  }
+
+  popLastEditable(): QueuedMessage | null {
+    for (let i = this.queue.length - 1; i >= 0; i--) {
+      if (this.queue[i].editable !== false) {
+        return this.queue.splice(i, 1)[0] ?? null;
+      }
+    }
+    return null;
+  }
+
+  popAllEditable(): QueuedMessage[] {
+    const editable: QueuedMessage[] = [];
+    const remaining: QueuedMessage[] = [];
+    for (const msg of this.queue) {
+      if (msg.editable !== false) {
+        editable.push(msg);
+      } else {
+        remaining.push(msg);
+      }
+    }
+    this.queue = remaining;
+    return editable;
   }
 }

--- a/packages/agent-sdk/tests/agent/agent.abort.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.abort.test.ts
@@ -459,6 +459,527 @@ describe("Agent - Abort Handling", () => {
     expect(mockCallbacks.onQueuedMessagesChange).toHaveBeenCalledWith([]);
   });
 
+  describe("abortMessage queue behavior", () => {
+    it("should not clear queue when agent is idle", async () => {
+      const mockCallbacks = {
+        onMessagesChange: vi.fn(),
+        onLoadingChange: vi.fn(),
+        onQueuedMessagesChange: vi.fn(),
+      };
+
+      const testAgent = await Agent.create({
+        apiKey: "test-key",
+        workdir: "/tmp/test-abort-queue-idle",
+        callbacks: mockCallbacks,
+      });
+
+      const container = (testAgent as unknown as { container: Container })
+        .container;
+      container.register("ToolManager", mockToolManagerInstance);
+      container.register("McpManager", {
+        isMcpTool: vi.fn().mockReturnValue(false),
+        getMcpToolPlugins: vi.fn().mockReturnValue([]),
+        getMcpToolsConfig: vi.fn().mockReturnValue([]),
+      });
+      container.register("SubagentManager", {
+        getConfigurations: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("SkillManager", {
+        getAvailableSkills: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("ConfigurationService", {
+        resolveGatewayConfig: () => testAgent.getGatewayConfig(),
+        resolveModelConfig: () => testAgent.getModelConfig(),
+        resolveMaxInputTokens: () => testAgent.getMaxInputTokens(),
+        resolveAutoMemoryEnabled: () => true,
+        resolveLanguage: () => testAgent.getLanguage(),
+        getEnvironmentVars: () =>
+          (
+            testAgent as unknown as {
+              configurationService: {
+                getEnvironmentVars: () => Record<string, string>;
+              };
+            }
+          ).configurationService.getEnvironmentVars(),
+      });
+
+      // Disconnect onMessageEnqueued to prevent auto-dequeue during test setup
+      const messageQueue = (
+        testAgent as unknown as {
+          messageQueue: import("@/managers/messageQueue.js").MessageQueue;
+        }
+      ).messageQueue;
+      messageQueue.onMessageEnqueued = undefined;
+
+      // Enqueue messages directly — agent is idle (not loading, no command running)
+      messageQueue.enqueue({ content: "queued msg 1" });
+      messageQueue.enqueue({ content: "queued msg 2" });
+      expect(messageQueue.hasPending()).toBe(true);
+
+      // Spy on messageQueue.clear to verify it is NOT called when idle
+      const clearSpy = vi.spyOn(messageQueue, "clear");
+
+      // Also disconnect onLoadingChange to prevent tryDequeue from draining the queue
+      // after abortAIMessage triggers onLoadingChange(false)
+      const aiManager = (testAgent as unknown as { aiManager: AIManager })
+        .aiManager;
+      aiManager.onLoadingChange = undefined;
+
+      // Call abortMessage while idle
+      testAgent.abortMessage();
+
+      // clear() should NOT have been called because agent was not busy
+      expect(clearSpy).not.toHaveBeenCalled();
+      // Queue should still have messages (not explicitly cleared)
+      expect(messageQueue.hasPending()).toBe(true);
+
+      clearSpy.mockRestore();
+    });
+
+    it("should clear queue when agent is busy (loading)", async () => {
+      const mockCallbacks = {
+        onMessagesChange: vi.fn(),
+        onLoadingChange: vi.fn(),
+        onQueuedMessagesChange: vi.fn(),
+      };
+
+      const testAgent = await Agent.create({
+        apiKey: "test-key",
+        workdir: "/tmp/test-abort-queue-busy",
+        callbacks: mockCallbacks,
+      });
+
+      const container = (testAgent as unknown as { container: Container })
+        .container;
+      container.register("ToolManager", mockToolManagerInstance);
+      container.register("McpManager", {
+        isMcpTool: vi.fn().mockReturnValue(false),
+        getMcpToolPlugins: vi.fn().mockReturnValue([]),
+        getMcpToolsConfig: vi.fn().mockReturnValue([]),
+      });
+      container.register("SubagentManager", {
+        getConfigurations: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("SkillManager", {
+        getAvailableSkills: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("ConfigurationService", {
+        resolveGatewayConfig: () => testAgent.getGatewayConfig(),
+        resolveModelConfig: () => testAgent.getModelConfig(),
+        resolveMaxInputTokens: () => testAgent.getMaxInputTokens(),
+        resolveAutoMemoryEnabled: () => true,
+        resolveLanguage: () => testAgent.getLanguage(),
+        getEnvironmentVars: () =>
+          (
+            testAgent as unknown as {
+              configurationService: {
+                getEnvironmentVars: () => Record<string, string>;
+              };
+            }
+          ).configurationService.getEnvironmentVars(),
+      });
+
+      // Disconnect onMessageEnqueued to prevent auto-dequeue during test setup
+      const messageQueue = (
+        testAgent as unknown as {
+          messageQueue: import("@/managers/messageQueue.js").MessageQueue;
+        }
+      ).messageQueue;
+      messageQueue.onMessageEnqueued = undefined;
+
+      // Enqueue messages
+      messageQueue.enqueue({ content: "queued msg 1" });
+      messageQueue.enqueue({ content: "queued msg 2" });
+      expect(messageQueue.hasPending()).toBe(true);
+
+      // Set agent as busy
+      const aiManager = (testAgent as unknown as { aiManager: AIManager })
+        .aiManager;
+      aiManager.setIsLoading(true);
+
+      // Call abortMessage while busy
+      testAgent.abortMessage();
+
+      // Queue should be cleared
+      expect(messageQueue.hasPending()).toBe(false);
+      expect(messageQueue.getQueue()).toHaveLength(0);
+    });
+
+    it("should reset queue state to idle on abort", async () => {
+      const testAgent = await Agent.create({
+        apiKey: "test-key",
+        workdir: "/tmp/test-abort-queue-state",
+        callbacks: {
+          onMessagesChange: vi.fn(),
+          onLoadingChange: vi.fn(),
+        },
+      });
+
+      const container = (testAgent as unknown as { container: Container })
+        .container;
+      container.register("ToolManager", mockToolManagerInstance);
+      container.register("McpManager", {
+        isMcpTool: vi.fn().mockReturnValue(false),
+        getMcpToolPlugins: vi.fn().mockReturnValue([]),
+        getMcpToolsConfig: vi.fn().mockReturnValue([]),
+      });
+      container.register("SubagentManager", {
+        getConfigurations: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("SkillManager", {
+        getAvailableSkills: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("ConfigurationService", {
+        resolveGatewayConfig: () => testAgent.getGatewayConfig(),
+        resolveModelConfig: () => testAgent.getModelConfig(),
+        resolveMaxInputTokens: () => testAgent.getMaxInputTokens(),
+        resolveAutoMemoryEnabled: () => true,
+        resolveLanguage: () => testAgent.getLanguage(),
+        getEnvironmentVars: () =>
+          (
+            testAgent as unknown as {
+              configurationService: {
+                getEnvironmentVars: () => Record<string, string>;
+              };
+            }
+          ).configurationService.getEnvironmentVars(),
+      });
+
+      const messageQueue = (
+        testAgent as unknown as {
+          messageQueue: import("@/managers/messageQueue.js").MessageQueue;
+        }
+      ).messageQueue;
+
+      // Transition queue to "dispatching" state
+      expect(messageQueue.transitionTo("dispatching")).toBe(true);
+      expect(messageQueue.state).toBe("dispatching");
+
+      // Call abortMessage — should reset queue state to idle
+      testAgent.abortMessage();
+
+      expect(messageQueue.state).toBe("idle");
+    });
+  });
+
+  describe("recallQueuedMessage", () => {
+    it("should recall last editable message from queue", async () => {
+      const mockCallbacks = {
+        onMessagesChange: vi.fn(),
+        onLoadingChange: vi.fn(),
+        onQueuedMessagesChange: vi.fn(),
+      };
+
+      const testAgent = await Agent.create({
+        apiKey: "test-key",
+        workdir: "/tmp/test-recall-queue",
+        callbacks: mockCallbacks,
+      });
+
+      const container = (testAgent as unknown as { container: Container })
+        .container;
+      container.register("ToolManager", mockToolManagerInstance);
+      container.register("McpManager", {
+        isMcpTool: vi.fn().mockReturnValue(false),
+        getMcpToolPlugins: vi.fn().mockReturnValue([]),
+        getMcpToolsConfig: vi.fn().mockReturnValue([]),
+      });
+      container.register("SubagentManager", {
+        getConfigurations: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("SkillManager", {
+        getAvailableSkills: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("ConfigurationService", {
+        resolveGatewayConfig: () => testAgent.getGatewayConfig(),
+        resolveModelConfig: () => testAgent.getModelConfig(),
+        resolveMaxInputTokens: () => testAgent.getMaxInputTokens(),
+        resolveAutoMemoryEnabled: () => true,
+        resolveLanguage: () => testAgent.getLanguage(),
+        getEnvironmentVars: () =>
+          (
+            testAgent as unknown as {
+              configurationService: {
+                getEnvironmentVars: () => Record<string, string>;
+              };
+            }
+          ).configurationService.getEnvironmentVars(),
+      });
+
+      // Disconnect onMessageEnqueued to prevent auto-dequeue
+      const messageQueue = (
+        testAgent as unknown as {
+          messageQueue: import("@/managers/messageQueue.js").MessageQueue;
+        }
+      ).messageQueue;
+      messageQueue.onMessageEnqueued = undefined;
+
+      messageQueue.enqueue({ content: "first" });
+      messageQueue.enqueue({ content: "second" });
+      messageQueue.enqueue({ content: "third" });
+      expect(messageQueue.getQueue()).toHaveLength(3);
+
+      // Recall should return the last editable message
+      const recalled = testAgent.recallQueuedMessage();
+      expect(recalled).not.toBeNull();
+      expect(recalled!.content).toBe("third");
+
+      // Third message should be removed from queue
+      expect(messageQueue.getQueue()).toHaveLength(2);
+      expect(messageQueue.getQueue().map((m) => m.content)).toEqual([
+        "first",
+        "second",
+      ]);
+    });
+
+    it("should return null when queue is empty", async () => {
+      const testAgent = await Agent.create({
+        apiKey: "test-key",
+        workdir: "/tmp/test-recall-empty",
+        callbacks: {
+          onMessagesChange: vi.fn(),
+          onLoadingChange: vi.fn(),
+        },
+      });
+
+      const container = (testAgent as unknown as { container: Container })
+        .container;
+      container.register("ToolManager", mockToolManagerInstance);
+      container.register("McpManager", {
+        isMcpTool: vi.fn().mockReturnValue(false),
+        getMcpToolPlugins: vi.fn().mockReturnValue([]),
+        getMcpToolsConfig: vi.fn().mockReturnValue([]),
+      });
+      container.register("SubagentManager", {
+        getConfigurations: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("SkillManager", {
+        getAvailableSkills: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("ConfigurationService", {
+        resolveGatewayConfig: () => testAgent.getGatewayConfig(),
+        resolveModelConfig: () => testAgent.getModelConfig(),
+        resolveMaxInputTokens: () => testAgent.getMaxInputTokens(),
+        resolveAutoMemoryEnabled: () => true,
+        resolveLanguage: () => testAgent.getLanguage(),
+        getEnvironmentVars: () =>
+          (
+            testAgent as unknown as {
+              configurationService: {
+                getEnvironmentVars: () => Record<string, string>;
+              };
+            }
+          ).configurationService.getEnvironmentVars(),
+      });
+
+      const result = testAgent.recallQueuedMessage();
+      expect(result).toBeNull();
+    });
+
+    it("should fire onQueuedMessagesChange callback", async () => {
+      const mockCallbacks = {
+        onMessagesChange: vi.fn(),
+        onLoadingChange: vi.fn(),
+        onQueuedMessagesChange: vi.fn(),
+      };
+
+      const testAgent = await Agent.create({
+        apiKey: "test-key",
+        workdir: "/tmp/test-recall-callback",
+        callbacks: mockCallbacks,
+      });
+
+      const container = (testAgent as unknown as { container: Container })
+        .container;
+      container.register("ToolManager", mockToolManagerInstance);
+      container.register("McpManager", {
+        isMcpTool: vi.fn().mockReturnValue(false),
+        getMcpToolPlugins: vi.fn().mockReturnValue([]),
+        getMcpToolsConfig: vi.fn().mockReturnValue([]),
+      });
+      container.register("SubagentManager", {
+        getConfigurations: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("SkillManager", {
+        getAvailableSkills: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("ConfigurationService", {
+        resolveGatewayConfig: () => testAgent.getGatewayConfig(),
+        resolveModelConfig: () => testAgent.getModelConfig(),
+        resolveMaxInputTokens: () => testAgent.getMaxInputTokens(),
+        resolveAutoMemoryEnabled: () => true,
+        resolveLanguage: () => testAgent.getLanguage(),
+        getEnvironmentVars: () =>
+          (
+            testAgent as unknown as {
+              configurationService: {
+                getEnvironmentVars: () => Record<string, string>;
+              };
+            }
+          ).configurationService.getEnvironmentVars(),
+      });
+
+      // Disconnect onMessageEnqueued to prevent auto-dequeue
+      const messageQueue = (
+        testAgent as unknown as {
+          messageQueue: import("@/managers/messageQueue.js").MessageQueue;
+        }
+      ).messageQueue;
+      messageQueue.onMessageEnqueued = undefined;
+
+      messageQueue.enqueue({ content: "msg1" });
+      messageQueue.enqueue({ content: "msg2" });
+
+      vi.clearAllMocks();
+
+      testAgent.recallQueuedMessage();
+
+      expect(mockCallbacks.onQueuedMessagesChange).toHaveBeenCalledTimes(1);
+      // The callback should receive the remaining queue (1 message)
+      const calledWith = mockCallbacks.onQueuedMessagesChange.mock.calls[0][0];
+      expect(calledWith).toHaveLength(1);
+      expect(calledWith[0].content).toBe("msg1");
+    });
+  });
+
+  describe("removeQueuedMessageById", () => {
+    it("should remove message by id", async () => {
+      const mockCallbacks = {
+        onMessagesChange: vi.fn(),
+        onLoadingChange: vi.fn(),
+        onQueuedMessagesChange: vi.fn(),
+      };
+
+      const testAgent = await Agent.create({
+        apiKey: "test-key",
+        workdir: "/tmp/test-remove-by-id",
+        callbacks: mockCallbacks,
+      });
+
+      const container = (testAgent as unknown as { container: Container })
+        .container;
+      container.register("ToolManager", mockToolManagerInstance);
+      container.register("McpManager", {
+        isMcpTool: vi.fn().mockReturnValue(false),
+        getMcpToolPlugins: vi.fn().mockReturnValue([]),
+        getMcpToolsConfig: vi.fn().mockReturnValue([]),
+      });
+      container.register("SubagentManager", {
+        getConfigurations: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("SkillManager", {
+        getAvailableSkills: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("ConfigurationService", {
+        resolveGatewayConfig: () => testAgent.getGatewayConfig(),
+        resolveModelConfig: () => testAgent.getModelConfig(),
+        resolveMaxInputTokens: () => testAgent.getMaxInputTokens(),
+        resolveAutoMemoryEnabled: () => true,
+        resolveLanguage: () => testAgent.getLanguage(),
+        getEnvironmentVars: () =>
+          (
+            testAgent as unknown as {
+              configurationService: {
+                getEnvironmentVars: () => Record<string, string>;
+              };
+            }
+          ).configurationService.getEnvironmentVars(),
+      });
+
+      // Disconnect onMessageEnqueued to prevent auto-dequeue
+      const messageQueue = (
+        testAgent as unknown as {
+          messageQueue: import("@/managers/messageQueue.js").MessageQueue;
+        }
+      ).messageQueue;
+      messageQueue.onMessageEnqueued = undefined;
+
+      messageQueue.enqueue({ id: "msg-a", content: "first" });
+      messageQueue.enqueue({ id: "msg-b", content: "second" });
+      messageQueue.enqueue({ id: "msg-c", content: "third" });
+
+      const result = testAgent.removeQueuedMessageById("msg-b");
+      expect(result).toBe(true);
+
+      const remaining = messageQueue.getQueue();
+      expect(remaining).toHaveLength(2);
+      expect(remaining.map((m) => m.content)).toEqual(["first", "third"]);
+    });
+
+    it("should return false for unknown id", async () => {
+      const testAgent = await Agent.create({
+        apiKey: "test-key",
+        workdir: "/tmp/test-remove-unknown-id",
+        callbacks: {
+          onMessagesChange: vi.fn(),
+          onLoadingChange: vi.fn(),
+        },
+      });
+
+      const container = (testAgent as unknown as { container: Container })
+        .container;
+      container.register("ToolManager", mockToolManagerInstance);
+      container.register("McpManager", {
+        isMcpTool: vi.fn().mockReturnValue(false),
+        getMcpToolPlugins: vi.fn().mockReturnValue([]),
+        getMcpToolsConfig: vi.fn().mockReturnValue([]),
+      });
+      container.register("SubagentManager", {
+        getConfigurations: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("SkillManager", {
+        getAvailableSkills: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("ConfigurationService", {
+        resolveGatewayConfig: () => testAgent.getGatewayConfig(),
+        resolveModelConfig: () => testAgent.getModelConfig(),
+        resolveMaxInputTokens: () => testAgent.getMaxInputTokens(),
+        resolveAutoMemoryEnabled: () => true,
+        resolveLanguage: () => testAgent.getLanguage(),
+        getEnvironmentVars: () =>
+          (
+            testAgent as unknown as {
+              configurationService: {
+                getEnvironmentVars: () => Record<string, string>;
+              };
+            }
+          ).configurationService.getEnvironmentVars(),
+      });
+
+      // Disconnect onMessageEnqueued to prevent auto-dequeue
+      const messageQueue = (
+        testAgent as unknown as {
+          messageQueue: import("@/managers/messageQueue.js").MessageQueue;
+        }
+      ).messageQueue;
+      messageQueue.onMessageEnqueued = undefined;
+
+      messageQueue.enqueue({ id: "msg-a", content: "first" });
+
+      const result = testAgent.removeQueuedMessageById("nonexistent");
+      expect(result).toBe(false);
+
+      // Queue should be unchanged
+      expect(messageQueue.getQueue()).toHaveLength(1);
+    });
+  });
+
   it("should not accumulate abort listeners when using same signal multiple times", async () => {
     // Create a shared abort signal to simulate reuse scenario
     const abortController = new AbortController();

--- a/packages/agent-sdk/tests/managers/messageQueue.test.ts
+++ b/packages/agent-sdk/tests/managers/messageQueue.test.ts
@@ -121,4 +121,331 @@ describe("MessageQueue", () => {
       expect(queue.getQueue()).toHaveLength(0);
     });
   });
+
+  describe("auto-assign id in enqueue", () => {
+    it("should auto-assign id like mq-0, mq-1, etc.", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a" });
+      queue.enqueue({ content: "b" });
+      queue.enqueue({ content: "c" });
+
+      const msgs = queue.getQueue();
+      expect(msgs[0].id).toBe("mq-0");
+      expect(msgs[1].id).toBe("mq-1");
+      expect(msgs[2].id).toBe("mq-2");
+    });
+
+    it("should keep explicit id", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a", id: "custom-1" });
+      queue.enqueue({ content: "b" });
+
+      const msgs = queue.getQueue();
+      expect(msgs[0].id).toBe("custom-1");
+      expect(msgs[1].id).toBe("mq-0");
+    });
+
+    it("should keep auto-increment counter independent of explicit ids", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a", id: "custom-1" });
+      queue.enqueue({ content: "b" });
+      queue.enqueue({ content: "c", id: "custom-2" });
+      queue.enqueue({ content: "d" });
+
+      const msgs = queue.getQueue();
+      expect(msgs[0].id).toBe("custom-1");
+      expect(msgs[1].id).toBe("mq-0");
+      expect(msgs[2].id).toBe("custom-2");
+      expect(msgs[3].id).toBe("mq-1");
+    });
+  });
+
+  describe("default editable in enqueue", () => {
+    it("should default editable to true", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a" });
+
+      expect(queue.getQueue()[0].editable).toBe(true);
+    });
+
+    it("should preserve explicit editable false", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a", editable: false });
+
+      expect(queue.getQueue()[0].editable).toBe(false);
+    });
+
+    it("should preserve explicit editable true", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a", editable: true });
+
+      expect(queue.getQueue()[0].editable).toBe(true);
+    });
+  });
+
+  describe("popLastEditable", () => {
+    it("should return the last editable message and remove it", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a", editable: true });
+      queue.enqueue({ content: "b", editable: false });
+      queue.enqueue({ content: "c", editable: true });
+
+      const result = queue.popLastEditable();
+
+      expect(result?.content).toBe("c");
+      expect(queue.getQueue()).toHaveLength(2);
+      expect(queue.getQueue().map((m) => m.content)).toEqual(["a", "b"]);
+    });
+
+    it("should return null if no editable messages", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a", editable: false });
+
+      expect(queue.popLastEditable()).toBeNull();
+      expect(queue.getQueue()).toHaveLength(1);
+    });
+
+    it("should return null on empty queue", () => {
+      const queue = new MessageQueue();
+
+      expect(queue.popLastEditable()).toBeNull();
+    });
+
+    it("should skip messages with editable: false", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a", editable: false });
+      queue.enqueue({ content: "b", editable: false });
+      queue.enqueue({ content: "c", editable: true });
+
+      const result = queue.popLastEditable();
+
+      expect(result?.content).toBe("c");
+      expect(queue.getQueue().map((m) => m.content)).toEqual(["a", "b"]);
+    });
+
+    it("should use default editable (true) when not specified", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a" });
+
+      const result = queue.popLastEditable();
+
+      expect(result?.content).toBe("a");
+      expect(queue.getQueue()).toHaveLength(0);
+    });
+  });
+
+  describe("popAllEditable", () => {
+    it("should return all editable messages and remove them", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a", editable: true });
+      queue.enqueue({ content: "b", editable: false });
+      queue.enqueue({ content: "c", editable: true });
+
+      const result = queue.popAllEditable();
+
+      expect(result.map((m) => m.content)).toEqual(["a", "c"]);
+      expect(queue.getQueue().map((m) => m.content)).toEqual(["b"]);
+    });
+
+    it("should keep non-editable messages in queue", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a", editable: false });
+      queue.enqueue({ content: "b", editable: true });
+      queue.enqueue({ content: "c", editable: false });
+
+      queue.popAllEditable();
+
+      expect(queue.getQueue().map((m) => m.content)).toEqual(["a", "c"]);
+    });
+
+    it("should return empty array if no editable messages", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a", editable: false });
+
+      expect(queue.popAllEditable()).toEqual([]);
+      expect(queue.getQueue()).toHaveLength(1);
+    });
+
+    it("should return empty array for empty queue", () => {
+      const queue = new MessageQueue();
+
+      expect(queue.popAllEditable()).toEqual([]);
+    });
+
+    it("should preserve order of editable messages", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a", editable: true });
+      queue.enqueue({ content: "b", editable: true });
+      queue.enqueue({ content: "c", editable: true });
+
+      const result = queue.popAllEditable();
+
+      expect(result.map((m) => m.content)).toEqual(["a", "b", "c"]);
+    });
+  });
+
+  describe("removeById", () => {
+    it("should remove a message by its id", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a", id: "x1" });
+      queue.enqueue({ content: "b", id: "x2" });
+
+      const result = queue.removeById("x1");
+
+      expect(result).toBe(true);
+      expect(queue.getQueue()).toHaveLength(1);
+      expect(queue.getQueue()[0].id).toBe("x2");
+    });
+
+    it("should return true if found and removed", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a", id: "target" });
+
+      expect(queue.removeById("target")).toBe(true);
+    });
+
+    it("should return false if not found", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a", id: "x1" });
+
+      expect(queue.removeById("nonexistent")).toBe(false);
+      expect(queue.getQueue()).toHaveLength(1);
+    });
+
+    it("should call onMessageEnqueued callback after removal", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a", id: "x1" });
+      const callback = vi.fn();
+      queue.onMessageEnqueued = callback;
+
+      queue.removeById("x1");
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not call onMessageEnqueued when id not found", () => {
+      const queue = new MessageQueue();
+      queue.enqueue({ content: "a", id: "x1" });
+      const callback = vi.fn();
+      queue.onMessageEnqueued = callback;
+
+      queue.removeById("nonexistent");
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("state machine (transitionTo)", () => {
+    it("should transition idle → dispatching", () => {
+      const queue = new MessageQueue();
+      expect(queue.state).toBe("idle");
+
+      expect(queue.transitionTo("dispatching")).toBe(true);
+      expect(queue.state).toBe("dispatching");
+    });
+
+    it("should reject idle → running", () => {
+      const queue = new MessageQueue();
+
+      expect(queue.transitionTo("running")).toBe(false);
+      expect(queue.state).toBe("idle");
+    });
+
+    it("should reject idle → idle", () => {
+      const queue = new MessageQueue();
+
+      expect(queue.transitionTo("idle")).toBe(false);
+      expect(queue.state).toBe("idle");
+    });
+
+    it("should transition dispatching → running", () => {
+      const queue = new MessageQueue();
+      queue.transitionTo("dispatching");
+
+      expect(queue.transitionTo("running")).toBe(true);
+      expect(queue.state).toBe("running");
+    });
+
+    it("should transition dispatching → idle", () => {
+      const queue = new MessageQueue();
+      queue.transitionTo("dispatching");
+
+      expect(queue.transitionTo("idle")).toBe(true);
+      expect(queue.state).toBe("idle");
+    });
+
+    it("should reject dispatching → dispatching", () => {
+      const queue = new MessageQueue();
+      queue.transitionTo("dispatching");
+
+      expect(queue.transitionTo("dispatching")).toBe(false);
+      expect(queue.state).toBe("dispatching");
+    });
+
+    it("should transition running → idle", () => {
+      const queue = new MessageQueue();
+      queue.transitionTo("dispatching");
+      queue.transitionTo("running");
+
+      expect(queue.transitionTo("idle")).toBe(true);
+      expect(queue.state).toBe("idle");
+    });
+
+    it("should reject running → dispatching", () => {
+      const queue = new MessageQueue();
+      queue.transitionTo("dispatching");
+      queue.transitionTo("running");
+
+      expect(queue.transitionTo("dispatching")).toBe(false);
+      expect(queue.state).toBe("running");
+    });
+
+    it("should reject running → running", () => {
+      const queue = new MessageQueue();
+      queue.transitionTo("dispatching");
+      queue.transitionTo("running");
+
+      expect(queue.transitionTo("running")).toBe(false);
+      expect(queue.state).toBe("running");
+    });
+
+    it("should allow full lifecycle idle → dispatching → running → idle", () => {
+      const queue = new MessageQueue();
+
+      expect(queue.transitionTo("dispatching")).toBe(true);
+      expect(queue.transitionTo("running")).toBe(true);
+      expect(queue.transitionTo("idle")).toBe(true);
+      expect(queue.state).toBe("idle");
+    });
+  });
+
+  describe("clear resets state", () => {
+    it("should set state back to idle after clear", () => {
+      const queue = new MessageQueue();
+      queue.transitionTo("dispatching");
+      expect(queue.state).toBe("dispatching");
+
+      queue.clear();
+
+      expect(queue.state).toBe("idle");
+    });
+
+    it("should reset state from running", () => {
+      const queue = new MessageQueue();
+      queue.transitionTo("dispatching");
+      queue.transitionTo("running");
+
+      queue.clear();
+
+      expect(queue.state).toBe("idle");
+    });
+
+    it("should remain idle when clearing from idle", () => {
+      const queue = new MessageQueue();
+
+      queue.clear();
+
+      expect(queue.state).toBe("idle");
+    });
+  });
 });

--- a/packages/code/src/components/InputBox.tsx
+++ b/packages/code/src/components/InputBox.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef, useCallback } from "react";
 import { Box, Text } from "ink";
 import { useInput } from "ink";
 import { FileSelector } from "./FileSelector.js";
@@ -80,7 +80,22 @@ export const InputBox: React.FC<InputBoxProps> = ({
     configuredModels,
     setModel,
     recreateAgent,
+    recallQueuedMessage,
+    queuedMessages,
   } = useChat();
+
+  // Ref to hold setInputText so queue callbacks can access it before useInputManager returns
+  const setInputTextRef = useRef<(text: string) => void>(() => {});
+
+  const hasQueuedMessages = (queuedMessages?.length ?? 0) > 0;
+
+  const onRecallQueuedMessage = useCallback(() => {
+    const msg = recallQueuedMessage();
+    if (msg) {
+      const prefix = msg.type === "bang" ? "!" : "";
+      setInputTextRef.current(prefix + msg.content);
+    }
+  }, [recallQueuedMessage]);
 
   // Input manager with all input state and functionality (including images)
   const {
@@ -135,6 +150,8 @@ export const InputBox: React.FC<InputBoxProps> = ({
     handleInput,
     // Manager ready state
     isManagerReady,
+    // Direct state setters
+    setInputText,
   } = useInputManager({
     onSendMessage: sendMessage,
     onAskBtw: askBtw,
@@ -145,7 +162,14 @@ export const InputBox: React.FC<InputBoxProps> = ({
     sessionId,
     workdir: workingDirectory,
     getFullMessageThread,
+    hasQueuedMessages,
+    onRecallQueuedMessage,
   });
+
+  // Keep setInputText ref updated for queue callbacks
+  useEffect(() => {
+    setInputTextRef.current = setInputText;
+  }, [setInputText]);
 
   // Sync permission mode from useChat to InputManager
   useEffect(() => {

--- a/packages/code/src/components/QueuedMessageList.tsx
+++ b/packages/code/src/components/QueuedMessageList.tsx
@@ -18,15 +18,19 @@ export const QueuedMessageList: React.FC = () => {
         const displayText = prefix + (content || (hasImages ? "[Images]" : ""));
 
         return (
-          <Box key={index}>
+          <Box key={msg.id ?? index}>
+            <Text color="gray">[{index + 1}] </Text>
             <Text color="gray" italic>
-              {displayText.length > 60
-                ? `${displayText.substring(0, 57)}...`
+              {displayText.length > 55
+                ? `${displayText.substring(0, 52)}...`
                 : displayText}
             </Text>
           </Box>
         );
       })}
+      <Text color="gray" dimColor>
+        {"  "}↑ recall
+      </Text>
     </Box>
   );
 };

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -54,6 +54,8 @@ export interface ChatContextType {
   ) => Promise<void>;
   askBtw: (question: string) => Promise<string>;
   abortMessage: () => void;
+  recallQueuedMessage: () => QueuedMessage | null;
+  removeQueuedMessageById: (id: string) => boolean;
   latestTotalTokens: number;
   maxInputTokens: number;
   // Model functionality
@@ -626,6 +628,14 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
     agentRef.current?.abortMessage();
   }, []);
 
+  const recallQueuedMessage = useCallback((): QueuedMessage | null => {
+    return agentRef.current?.recallQueuedMessage() ?? null;
+  }, []);
+
+  const removeQueuedMessageById = useCallback((id: string): boolean => {
+    return agentRef.current?.removeQueuedMessageById(id) ?? false;
+  }, []);
+
   // Permission management methods
   const setPermissionMode = useCallback((mode: PermissionMode) => {
     setPermissionModeState((prev) => {
@@ -815,6 +825,8 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
     sendMessage,
     askBtw,
     abortMessage,
+    recallQueuedMessage,
+    removeQueuedMessageById,
     latestTotalTokens,
     maxInputTokens,
     currentModel,

--- a/packages/code/src/hooks/useInputManager.ts
+++ b/packages/code/src/hooks/useInputManager.ts
@@ -43,6 +43,8 @@ export const useInputManager = (
     workdir,
     getFullMessageThread,
     logger,
+    hasQueuedMessages: hasQueuedMessagesProp,
+    onRecallQueuedMessage,
   } = callbacks;
 
   // Handle debounced file search
@@ -218,6 +220,9 @@ export const useInputManager = (
               }
             }
             break;
+          case "RECALL_QUEUED_MESSAGE":
+            onRecallQueuedMessage?.();
+            break;
         }
       } catch (error) {
         console.error("Effect execution error:", error);
@@ -237,6 +242,7 @@ export const useInputManager = (
     getFullMessageThread,
     logger,
     onHasSlashCommand,
+    onRecallQueuedMessage,
   ]);
 
   useEffect(() => {
@@ -519,10 +525,11 @@ export const useInputManager = (
           input,
           key: {} as Key,
           hasSlashCommand: (cmd) => !!onHasSlashCommand?.(cmd),
+          hasQueuedMessages: hasQueuedMessagesProp ?? false,
         },
       });
     },
-    [onHasSlashCommand],
+    [onHasSlashCommand, hasQueuedMessagesProp],
   );
 
   const handleSubmit = useCallback(async () => {
@@ -532,9 +539,10 @@ export const useInputManager = (
         input: "",
         key: { return: true } as Key,
         hasSlashCommand: (cmd) => !!onHasSlashCommand?.(cmd),
+        hasQueuedMessages: hasQueuedMessagesProp ?? false,
       },
     });
-  }, [onHasSlashCommand]);
+  }, [onHasSlashCommand, hasQueuedMessagesProp]);
 
   const expandLongTextPlaceholders = useCallback(
     (text: string) => {
@@ -565,11 +573,12 @@ export const useInputManager = (
           input,
           key,
           hasSlashCommand: (cmd) => !!onHasSlashCommand?.(cmd),
+          hasQueuedMessages: hasQueuedMessagesProp ?? false,
         },
       });
       return true;
     },
-    [onHasSlashCommand],
+    [onHasSlashCommand, hasQueuedMessagesProp],
   );
 
   return {

--- a/packages/code/src/managers/inputReducer.ts
+++ b/packages/code/src/managers/inputReducer.ts
@@ -41,7 +41,8 @@ export type PendingEffect =
   | { type: "PERMISSION_MODE_CHANGE"; mode: PermissionMode }
   | { type: "FETCH_HISTORY" }
   | { type: "PASTE_IMAGE" }
-  | { type: "EXECUTE_COMMAND"; command: string };
+  | { type: "EXECUTE_COMMAND"; command: string }
+  | { type: "RECALL_QUEUED_MESSAGE" };
 
 export interface InputManagerCallbacks {
   onInputTextChange?: (text: string) => void;
@@ -84,6 +85,8 @@ export interface InputManagerCallbacks {
     sessionIds: string[];
   }>;
   logger?: Logger;
+  hasQueuedMessages?: boolean;
+  onRecallQueuedMessage?: () => void;
 }
 
 export interface InputState {
@@ -227,6 +230,7 @@ export type InputAction =
         input: string;
         key: Key;
         hasSlashCommand: (cmd: string) => boolean;
+        hasQueuedMessages?: boolean;
       };
     };
 
@@ -682,6 +686,7 @@ export function inputReducer(
       return { ...state, pendingEffect: null };
     case "HANDLE_KEY": {
       const { input, key } = action.payload;
+      const hasQueuedMessages = action.payload.hasQueuedMessages ?? false;
 
       // 1. BTW State Handling
       if (state.btwState.isActive) {
@@ -820,6 +825,13 @@ export function inputReducer(
         !state.showFileSelector &&
         !state.showCommandSelector
       ) {
+        // If queue has messages, recall from queue first (before history)
+        if (hasQueuedMessages) {
+          return {
+            ...state,
+            pendingEffect: { type: "RECALL_QUEUED_MESSAGE" },
+          };
+        }
         if (state.history.length === 0) {
           return { ...state, pendingEffect: { type: "FETCH_HISTORY" } };
         }

--- a/packages/code/tests/managers/inputReducer.test.ts
+++ b/packages/code/tests/managers/inputReducer.test.ts
@@ -1540,6 +1540,80 @@ describe("inputReducer", () => {
       });
     });
 
+    describe("UP arrow queue recall", () => {
+      it("should dispatch RECALL_QUEUED_MESSAGE when hasQueuedMessages is true", () => {
+        const result = inputReducer(initialState, {
+          type: "HANDLE_KEY",
+          payload: {
+            input: "",
+            key: { upArrow: true } as unknown as Key,
+            hasSlashCommand: () => false,
+            hasQueuedMessages: true,
+          },
+        });
+        expect(result.pendingEffect).toEqual({
+          type: "RECALL_QUEUED_MESSAGE",
+        });
+      });
+
+      it("should dispatch FETCH_HISTORY when hasQueuedMessages is false and history is empty", () => {
+        const result = inputReducer(initialState, {
+          type: "HANDLE_KEY",
+          payload: {
+            input: "",
+            key: { upArrow: true } as unknown as Key,
+            hasSlashCommand: () => false,
+            hasQueuedMessages: false,
+          },
+        });
+        expect(result.pendingEffect).toEqual({ type: "FETCH_HISTORY" });
+      });
+
+      it("should navigate history when hasQueuedMessages is false and history exists", () => {
+        const state = {
+          ...initialState,
+          history: [
+            { prompt: "first", timestamp: 1000 },
+            { prompt: "second", timestamp: 2000 },
+          ],
+          inputText: "current",
+        };
+        const result = inputReducer(state, {
+          type: "HANDLE_KEY",
+          payload: {
+            input: "",
+            key: { upArrow: true } as unknown as Key,
+            hasSlashCommand: () => false,
+            hasQueuedMessages: false,
+          },
+        });
+        expect(result.historyIndex).toBe(0);
+        expect(result.inputText).toBe("first");
+        expect(result.originalInputText).toBe("current");
+      });
+
+      it("should dispatch RECALL_QUEUED_MESSAGE even when input has content", () => {
+        const state = {
+          ...initialState,
+          inputText: "some existing text",
+          cursorPosition: 18,
+        };
+        const result = inputReducer(state, {
+          type: "HANDLE_KEY",
+          payload: {
+            input: "",
+            key: { upArrow: true } as unknown as Key,
+            hasSlashCommand: () => false,
+            hasQueuedMessages: true,
+          },
+        });
+        // Queue recall takes priority over history navigation, regardless of input content
+        expect(result.pendingEffect).toEqual({
+          type: "RECALL_QUEUED_MESSAGE",
+        });
+      });
+    });
+
     it("should send unknown /command as message", () => {
       const state: InputState = {
         ...initialState,


### PR DESCRIPTION
- Add QueueState state machine (idle/dispatching/running) to prevent
  concurrent dequeue race conditions
- Add unified tryDequeue() replacing 3 separate dequeue triggers
- Add UP arrow queue recall: press ↑ to recall last queued message
  for editing while AI is busy
- Add QueuedMessage id (auto-assigned) and editable fields
- Add recallQueuedMessage/removeQueuedMessageById Agent methods
- Modify abortMessage() to only clear queue when agent is busy
- Add RECALL_QUEUED_MESSAGE pending effect in inputReducer
- Enhance QueuedMessageList with index numbers and ↑ recall hint
- Add 55 new tests across SDK and UI layers
