### PR TITLE
feat: extract cache tokens from prompt_tokens_details for non-Claude models

### DIFF
--- a/packages/agent-sdk/src/services/aiService.ts
+++ b/packages/agent-sdk/src/services/aiService.ts
@@ -358,7 +358,6 @@ export async function callAgent(
         onReasoningUpdate,
         abortSignal,
         responseHeaders,
-        currentModel,
       );
     } else {
       // Handle non-streaming response
@@ -386,8 +385,8 @@ export async function callAgent(
           }
         : undefined;
 
-      // Extend usage with cache metrics for Claude models
-      if (totalUsage && supportsPromptCaching(currentModel) && response.usage) {
+      // Extend usage with cache metrics (Claude top-level + OpenAI prompt_tokens_details)
+      if (totalUsage && response.usage) {
         totalUsage = extendUsageWithCacheMetrics(
           totalUsage,
           response.usage as Partial<ClaudeUsage>,
@@ -557,7 +556,6 @@ export async function callAgent(
  * @param onToolUpdate Callback for tool updates
  * @param abortSignal Optional abort signal
  * @param responseHeaders Response headers from the initial request
- * @param modelName Model name for cache control processing
  * @returns Final result with accumulated content and tool calls
  */
 async function processStreamingResponse(
@@ -573,7 +571,6 @@ async function processStreamingResponse(
   onReasoningUpdate?: (content: string) => void,
   abortSignal?: AbortSignal,
   responseHeaders?: Record<string, string>,
-  modelName?: string,
 ): Promise<CallAgentResult> {
   let accumulatedContent = "";
   let accumulatedReasoningContent = "";
@@ -605,13 +602,11 @@ async function processStreamingResponse(
           total_tokens: chunk.usage.total_tokens,
         };
 
-        // Extend usage with cache metrics for Claude models
-        if (modelName && supportsPromptCaching(modelName)) {
-          chunkUsage = extendUsageWithCacheMetrics(
-            chunkUsage,
-            chunk.usage as Partial<ClaudeUsage>,
-          );
-        }
+        // Extend usage with cache metrics (Claude top-level + OpenAI prompt_tokens_details)
+        chunkUsage = extendUsageWithCacheMetrics(
+          chunkUsage,
+          chunk.usage as Partial<ClaudeUsage>,
+        );
 
         usage = chunkUsage;
       }

--- a/packages/agent-sdk/src/types/core.ts
+++ b/packages/agent-sdk/src/types/core.ts
@@ -27,8 +27,8 @@ export interface Usage {
   model?: string; // Model used for the operation (e.g., "gpt-4", "gpt-3.5-turbo")
   operation_type?: "agent" | "compact" | "goal_evaluation"; // Type of operation that generated usage
 
-  // Cache-related tokens (Claude models only)
-  cache_read_input_tokens?: number; // Tokens read from cache
+  // Cache-related tokens (Claude top-level + OpenAI prompt_tokens_details)
+  cache_read_input_tokens?: number; // Tokens read from cache (Claude) or cached_tokens (OpenAI prompt_tokens_details)
   cache_creation_input_tokens?: number; // Tokens used to create cache entries
   cache_creation?: {
     ephemeral_5m_input_tokens: number; // Tokens cached for 5 minutes

--- a/packages/agent-sdk/src/utils/cacheControlUtils.ts
+++ b/packages/agent-sdk/src/utils/cacheControlUtils.ts
@@ -48,20 +48,33 @@ export interface ClaudeChatCompletionFunctionTool
 }
 
 /**
- * Enhanced usage metrics including Claude cache information
+ * Extended prompt_tokens_details with cache_creation_input_tokens
+ * Some models (e.g. Gemini, DeepSeek) return this field inside prompt_tokens_details
+ */
+export interface ExtendedPromptTokensDetails
+  extends CompletionUsage.PromptTokensDetails {
+  cache_creation_input_tokens?: number;
+}
+
+/**
+ * Enhanced usage metrics including cache information
+ * Supports both Claude-specific top-level fields and OpenAI-standard prompt_tokens_details
  */
 export interface ClaudeUsage extends CompletionUsage {
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
 
-  // Claude cache extensions
-  cache_read_input_tokens?: number;
-  cache_creation_input_tokens?: number;
+  // Cache extensions (from Claude top-level or OpenAI prompt_tokens_details)
+  cache_read_input_tokens?: number; // Claude: cache_read_input_tokens / OpenAI: prompt_tokens_details.cached_tokens
+  cache_creation_input_tokens?: number; // Claude: cache_creation_input_tokens / OpenAI: prompt_tokens_details.cache_creation_input_tokens
   cache_creation?: {
     ephemeral_5m_input_tokens: number;
     ephemeral_1h_input_tokens: number;
   };
+
+  // Override prompt_tokens_details to include cache_creation_input_tokens
+  prompt_tokens_details?: ExtendedPromptTokensDetails;
 }
 
 // ============================================================================
@@ -410,8 +423,10 @@ export function transformMessagesForClaudeCache(
 
 /**
  * Extends standard usage with cache metrics
+ * Extracts cache tokens from both Claude-specific top-level fields and
+ * OpenAI-standard prompt_tokens_details (used by Gemini, DeepSeek, etc.)
  * @param standardUsage - OpenAI usage response
- * @param cacheMetrics - Additional cache metrics from Claude
+ * @param cacheMetrics - Additional cache metrics from the API response
  * @returns Extended usage with cache information
  */
 export function extendUsageWithCacheMetrics(
@@ -424,30 +439,45 @@ export function extendUsageWithCacheMetrics(
     total_tokens: standardUsage.total_tokens,
   };
 
-  // Add cache metrics if provided
-  if (cacheMetrics) {
-    if (typeof cacheMetrics.cache_read_input_tokens === "number") {
-      baseUsage.cache_read_input_tokens = cacheMetrics.cache_read_input_tokens;
-    }
+  if (!cacheMetrics) {
+    return baseUsage;
+  }
 
-    if (typeof cacheMetrics.cache_creation_input_tokens === "number") {
-      baseUsage.cache_creation_input_tokens =
-        cacheMetrics.cache_creation_input_tokens;
-    }
+  // Extract cache_read_input_tokens from Claude top-level field
+  if (typeof cacheMetrics.cache_read_input_tokens === "number") {
+    baseUsage.cache_read_input_tokens = cacheMetrics.cache_read_input_tokens;
+  }
+  // Fallback to prompt_tokens_details.cached_tokens (OpenAI standard)
+  else if (cacheMetrics.prompt_tokens_details?.cached_tokens != null) {
+    baseUsage.cache_read_input_tokens =
+      cacheMetrics.prompt_tokens_details.cached_tokens;
+  }
 
-    if (
-      cacheMetrics.cache_creation &&
-      typeof cacheMetrics.cache_creation.ephemeral_5m_input_tokens ===
-        "number" &&
-      typeof cacheMetrics.cache_creation.ephemeral_1h_input_tokens === "number"
-    ) {
-      baseUsage.cache_creation = {
-        ephemeral_5m_input_tokens:
-          cacheMetrics.cache_creation.ephemeral_5m_input_tokens,
-        ephemeral_1h_input_tokens:
-          cacheMetrics.cache_creation.ephemeral_1h_input_tokens,
-      };
-    }
+  // Extract cache_creation_input_tokens from Claude top-level field
+  if (typeof cacheMetrics.cache_creation_input_tokens === "number") {
+    baseUsage.cache_creation_input_tokens =
+      cacheMetrics.cache_creation_input_tokens;
+  }
+  // Fallback to prompt_tokens_details.cache_creation_input_tokens
+  else if (
+    cacheMetrics.prompt_tokens_details?.cache_creation_input_tokens != null
+  ) {
+    baseUsage.cache_creation_input_tokens =
+      cacheMetrics.prompt_tokens_details.cache_creation_input_tokens;
+  }
+
+  // Extract cache_creation breakdown (Claude-specific)
+  if (
+    cacheMetrics.cache_creation &&
+    typeof cacheMetrics.cache_creation.ephemeral_5m_input_tokens === "number" &&
+    typeof cacheMetrics.cache_creation.ephemeral_1h_input_tokens === "number"
+  ) {
+    baseUsage.cache_creation = {
+      ephemeral_5m_input_tokens:
+        cacheMetrics.cache_creation.ephemeral_5m_input_tokens,
+      ephemeral_1h_input_tokens:
+        cacheMetrics.cache_creation.ephemeral_1h_input_tokens,
+    };
   }
 
   return baseUsage;

--- a/packages/agent-sdk/tests/services/aiService.cacheControl.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.cacheControl.test.ts
@@ -1568,6 +1568,127 @@ describe("AI Service - Claude Cache Control", () => {
       });
     });
 
+    describe("prompt_tokens_details cache extraction", () => {
+      it("should extract cached_tokens from prompt_tokens_details for non-Claude models", async () => {
+        const mockWithResponse = vi.fn().mockResolvedValue({
+          data: {
+            choices: [
+              {
+                message: { content: "Test response" },
+                finish_reason: "stop",
+              },
+            ],
+            usage: {
+              prompt_tokens: 100,
+              completion_tokens: 50,
+              total_tokens: 150,
+              prompt_tokens_details: {
+                cached_tokens: 80,
+              },
+            },
+          },
+          response: {
+            headers: new Map([["x-request-id", "req-12345"]]),
+          },
+        });
+        mockCreate.mockReturnValue({ withResponse: mockWithResponse });
+
+        const result = await callAgent({
+          gatewayConfig: TEST_GATEWAY_CONFIG,
+          modelConfig: { model: "gpt-4o", fastModel: "gpt-4o-mini" },
+          messages: [{ role: "user", content: "Test message" }],
+          workdir: "/test/workdir",
+        });
+
+        expect(result).toBeDefined();
+        expect(result.usage).toBeDefined();
+        expect(result.usage?.prompt_tokens).toBe(100);
+        expect(result.usage?.completion_tokens).toBe(50);
+        expect(result.usage?.total_tokens).toBe(150);
+        expect(result.usage?.cache_read_input_tokens).toBe(80);
+      });
+
+      it("should extract cache_creation_input_tokens from prompt_tokens_details", async () => {
+        const mockWithResponse = vi.fn().mockResolvedValue({
+          data: {
+            choices: [
+              {
+                message: { content: "Test response" },
+                finish_reason: "stop",
+              },
+            ],
+            usage: {
+              prompt_tokens: 200,
+              completion_tokens: 50,
+              total_tokens: 250,
+              prompt_tokens_details: {
+                cached_tokens: 120,
+                cache_creation_input_tokens: 40,
+              },
+            },
+          },
+          response: {
+            headers: new Map([["x-request-id", "req-12345"]]),
+          },
+        });
+        mockCreate.mockReturnValue({ withResponse: mockWithResponse });
+
+        const result = await callAgent({
+          gatewayConfig: TEST_GATEWAY_CONFIG,
+          modelConfig: {
+            model: "gemini-2.5-pro",
+            fastModel: "gemini-2.5-flash",
+          },
+          messages: [{ role: "user", content: "Test message" }],
+          workdir: "/test/workdir",
+        });
+
+        expect(result).toBeDefined();
+        expect(result.usage?.cache_read_input_tokens).toBe(120);
+        expect(result.usage?.cache_creation_input_tokens).toBe(40);
+      });
+
+      it("should prefer Claude top-level fields over prompt_tokens_details when both present", async () => {
+        const mockWithResponse = vi.fn().mockResolvedValue({
+          data: {
+            choices: [
+              {
+                message: { content: "Test response" },
+                finish_reason: "stop",
+              },
+            ],
+            usage: {
+              prompt_tokens: 100,
+              completion_tokens: 50,
+              total_tokens: 150,
+              cache_read_input_tokens: 30,
+              cache_creation_input_tokens: 70,
+              prompt_tokens_details: {
+                cached_tokens: 999,
+                cache_creation_input_tokens: 888,
+              },
+            },
+          },
+          response: {
+            headers: new Map([["x-request-id", "req-12345"]]),
+          },
+        });
+        mockCreate.mockReturnValue({ withResponse: mockWithResponse });
+
+        const result = await callAgent({
+          gatewayConfig: TEST_GATEWAY_CONFIG,
+          modelConfig: CLAUDE_MODEL_CONFIG,
+          messages: [{ role: "user", content: "Test message" }],
+          workdir: "/test/workdir",
+        });
+
+        expect(result).toBeDefined();
+        // Claude top-level fields take priority
+        expect(result.usage?.cache_read_input_tokens).toBe(30);
+        expect(result.usage?.cache_creation_input_tokens).toBe(70);
+      });
+    });
+
     describe("Edge Cases", () => {
       it("should handle empty conversation gracefully", async () => {
         const result = await callAgent({

--- a/specs/021-prompt-cache-control/checklists/requirements.md
+++ b/specs/021-prompt-cache-control/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: Prompt Cache Control for Claude Models
+# Specification Quality Checklist: Prompt Cache Control
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2025-12-02

--- a/specs/021-prompt-cache-control/contracts/cache-control-api.md
+++ b/specs/021-prompt-cache-control/contracts/cache-control-api.md
@@ -121,7 +121,7 @@ const isClaudeModel: typeof supportsPromptCaching;
 - Example: `WAVE_PROMPT_CACHE_REGEX="claude|qwen"` matches both claude and qwen models
 - Invalid regex patterns fall back to simple "claude" matching
 
-**Note**: While `supportsPromptCaching` controls cache_control marker injection (only for Claude-like models), cache token extraction from usage applies to ALL models. Non-Claude models (Gemini, DeepSeek) return cache data via `prompt_tokens_details` which is an OpenAI-standard field.
+**Scope of `supportsPromptCaching`**: This function gates ONLY cache_control marker injection (adding `cache_control: {type: "ephemeral"}` to messages and tool definitions). It does NOT gate cache token extraction from usage responses — that applies to ALL models, since `prompt_tokens_details` is an OpenAI-standard field returned by Gemini, DeepSeek, and others.
 
 ### Cache Control Application
 

--- a/specs/021-prompt-cache-control/contracts/cache-control-api.md
+++ b/specs/021-prompt-cache-control/contracts/cache-control-api.md
@@ -59,28 +59,38 @@ type ClaudeMessageContent = string | Array<
 
 ```typescript
 /**
- * Extended usage metrics including Claude cache information
+ * Extended prompt_tokens_details with cache_creation_input_tokens
+ * Some models (e.g. Gemini, DeepSeek) return this field inside prompt_tokens_details
+ */
+interface ExtendedPromptTokensDetails extends CompletionUsage.PromptTokensDetails {
+  cache_creation_input_tokens?: number;
+}
+
+/**
+ * Extended usage metrics including cache information
+ * Supports both Claude-specific top-level fields and OpenAI-standard prompt_tokens_details
  */
 interface ClaudeUsage extends CompletionUsage {
   // Standard OpenAI fields
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
-  
-  // Claude cache extensions
-  /** Tokens read from existing cache (cost savings) */
+
+  // Cache extensions (from Claude top-level OR OpenAI prompt_tokens_details)
+  /** Tokens read from cache. Claude: cache_read_input_tokens / OpenAI: prompt_tokens_details.cached_tokens */
   cache_read_input_tokens?: number;
-  
-  /** Tokens used to create new cache entries */
+
+  /** Tokens used to create cache. Claude: cache_creation_input_tokens / OpenAI: prompt_tokens_details.cache_creation_input_tokens */
   cache_creation_input_tokens?: number;
-  
-  /** Detailed breakdown of cache creation */
+
+  /** Detailed breakdown of cache creation (Claude-specific) */
   cache_creation?: {
-    /** Tokens cached for 5 minutes */
     ephemeral_5m_input_tokens: number;
-    /** Tokens cached for 1 hour */
     ephemeral_1h_input_tokens: number;
   };
+
+  /** Override to include cache_creation_input_tokens in prompt_tokens_details */
+  prompt_tokens_details?: ExtendedPromptTokensDetails;
 }
 ```
 
@@ -110,6 +120,8 @@ const isClaudeModel: typeof supportsPromptCaching;
 - `WAVE_PROMPT_CACHE_REGEX`: Regex pattern for matching model names (default: "claude")
 - Example: `WAVE_PROMPT_CACHE_REGEX="claude|qwen"` matches both claude and qwen models
 - Invalid regex patterns fall back to simple "claude" matching
+
+**Note**: While `supportsPromptCaching` controls cache_control marker injection (only for Claude-like models), cache token extraction from usage applies to ALL models. Non-Claude models (Gemini, DeepSeek) return cache data via `prompt_tokens_details` which is an OpenAI-standard field.
 
 ### Cache Control Application
 
@@ -181,8 +193,13 @@ function addCacheControlToLastToolCall(
 ```typescript
 /**
  * Extends standard usage with cache metrics
+ * Extracts cache tokens from both Claude-specific top-level fields and
+ * OpenAI-standard prompt_tokens_details (used by Gemini, DeepSeek, etc.)
+ *
+ * Priority: Claude top-level fields > prompt_tokens_details fallback
+ *
  * @param standardUsage - OpenAI usage response
- * @param cacheMetrics - Additional cache metrics from Claude
+ * @param cacheMetrics - Additional cache metrics from the API response
  * @returns Extended usage with cache information
  */
 function extendUsageWithCacheMetrics(

--- a/specs/021-prompt-cache-control/contracts/cache-control-types.ts
+++ b/specs/021-prompt-cache-control/contracts/cache-control-types.ts
@@ -1,8 +1,10 @@
 /**
- * TypeScript Interface Definitions for Claude Cache Control
- * 
+ * TypeScript Interface Definitions for Cache Control
+ *
  * This file contains the core type definitions that will be implemented
- * in the agent-sdk package for Claude cache control functionality.
+ * in the agent-sdk package for cache control functionality.
+ * Supports both Claude-specific top-level cache fields and OpenAI-standard
+ * prompt_tokens_details for cross-model cache token tracking.
  */
 
 import type { 
@@ -71,7 +73,17 @@ export type ClaudeMessageContent = string | Array<
 // ============================================================================
 
 /**
- * Extended usage metrics including Claude cache information
+ * Extended prompt_tokens_details with cache_creation_input_tokens
+ * Some models (e.g. Gemini, DeepSeek) return this field inside prompt_tokens_details
+ */
+export interface ExtendedPromptTokensDetails extends CompletionUsage.PromptTokensDetails {
+  /** Cache creation tokens (non-standard, used by some models via prompt_tokens_details) */
+  cache_creation_input_tokens?: number;
+}
+
+/**
+ * Extended usage metrics including cache information
+ * Supports both Claude-specific top-level fields and OpenAI-standard prompt_tokens_details
  * Backward compatible with standard OpenAI CompletionUsage
  */
 export interface ClaudeUsage extends CompletionUsage {
@@ -79,22 +91,24 @@ export interface ClaudeUsage extends CompletionUsage {
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
-  
-  // Claude-specific cache extensions
-  /** 
+
+  // Cache extensions (from Claude top-level OR OpenAI prompt_tokens_details)
+  /**
    * Number of tokens read from existing cache
-   * Indicates cost savings from cache hits
+   * Claude: usage.cache_read_input_tokens
+   * OpenAI: usage.prompt_tokens_details.cached_tokens
    */
   cache_read_input_tokens?: number;
-  
-  /** 
+
+  /**
    * Number of tokens used to create new cache entries
-   * Investment in future cache hits
+   * Claude: usage.cache_creation_input_tokens
+   * OpenAI: usage.prompt_tokens_details.cache_creation_input_tokens
    */
   cache_creation_input_tokens?: number;
-  
-  /** 
-   * Detailed breakdown of cache creation by duration
+
+  /**
+   * Detailed breakdown of cache creation by duration (Claude-specific)
    */
   cache_creation?: {
     /** Tokens cached for 5 minute duration */
@@ -102,6 +116,9 @@ export interface ClaudeUsage extends CompletionUsage {
     /** Tokens cached for 1 hour duration */
     ephemeral_1h_input_tokens: number;
   };
+
+  // Override prompt_tokens_details to include cache_creation_input_tokens
+  prompt_tokens_details?: ExtendedPromptTokensDetails;
 }
 
 // ============================================================================

--- a/specs/021-prompt-cache-control/data-model.md
+++ b/specs/021-prompt-cache-control/data-model.md
@@ -106,9 +106,9 @@ interface ModelCacheConfig {
   - `"claude|qwen3\\.6-plus"` - matches "claude" or exact "qwen3.6-plus"
 
 **Relationships**:
-- Determines cache control application for entire request
+- Determines cache_control marker injection for the request (messages and tools)
+- Does NOT gate cache token extraction from usage — that applies to all models
 - Affects message transformation and tool processing
-- Influences usage tracking structure
 
 **Legacy Support**:
 - `isClaudeModel()` is deprecated alias for `supportsPromptCaching()`
@@ -173,7 +173,10 @@ Request 2+: cache_creation_input_tokens = 0, cache_read_input_tokens > 0 (cache 
 ### Model Detection Flow
 
 ```
-ModelName -> isClaudeModel() -> shouldApplyCache -> Message Transformation
+ModelName -> supportsPromptCaching() -> shouldInjectCacheControlMarkers -> Message Transformation
+
+Note: Cache token extraction from usage is NOT gated by supportsPromptCaching.
+All models' usage responses are checked for cache tokens (Claude top-level + prompt_tokens_details).
 ```
 
 ## Data Flow Patterns

--- a/specs/021-prompt-cache-control/data-model.md
+++ b/specs/021-prompt-cache-control/data-model.md
@@ -1,4 +1,4 @@
-# Data Model: Prompt Cache Control for Claude Models
+# Data Model: Prompt Cache Control
 
 **Date**: 2025-12-02  
 **Feature**: 021-prompt-cache-control  
@@ -29,31 +29,49 @@ interface CacheControl {
 
 ### Enhanced Usage Metrics
 
-**Purpose**: Extended usage tracking including cache-related token counts
+**Purpose**: Extended usage tracking including cache-related token counts from both Claude top-level fields and OpenAI-standard `prompt_tokens_details`
 
 **Structure**:
 ```typescript
+interface ExtendedPromptTokensDetails extends CompletionUsage.PromptTokensDetails {
+  // Standard OpenAI fields (inherited): audio_tokens, cached_tokens
+  // Extended field for models that return cache creation via prompt_tokens_details
+  cache_creation_input_tokens?: number;
+}
+
 interface ClaudeUsage extends CompletionUsage {
   // Standard OpenAI usage fields (unchanged)
   prompt_tokens: number;
-  completion_tokens: number; 
+  completion_tokens: number;
   total_tokens: number;
-  
-  // Claude cache-specific extensions
+
+  // Cache extensions (from Claude top-level OR OpenAI prompt_tokens_details)
+  // Claude: usage.cache_read_input_tokens / OpenAI: usage.prompt_tokens_details.cached_tokens
   cache_read_input_tokens?: number;
+  // Claude: usage.cache_creation_input_tokens / OpenAI: usage.prompt_tokens_details.cache_creation_input_tokens
   cache_creation_input_tokens?: number;
   cache_creation?: {
     ephemeral_5m_input_tokens: number;
     ephemeral_1h_input_tokens: number;
   };
+
+  // Override to include cache_creation_input_tokens in prompt_tokens_details
+  prompt_tokens_details?: ExtendedPromptTokensDetails;
 }
 ```
 
 **Validation Rules**:
 - All cache fields are optional (only present when cache is used)
-- `cache_creation_input_tokens` equals sum of ephemeral cache tokens
+- `cache_creation_input_tokens` equals sum of ephemeral cache tokens (Claude-specific)
 - `cache_read_input_tokens` indicates tokens served from existing cache
+- When both Claude top-level and `prompt_tokens_details` cache fields are present, top-level takes priority
 - All token counts must be non-negative integers
+
+**Extraction Priority**:
+1. Claude top-level `cache_read_input_tokens` → used directly
+2. OpenAI `prompt_tokens_details.cached_tokens` → mapped to `cache_read_input_tokens` as fallback
+3. Claude top-level `cache_creation_input_tokens` → used directly
+4. OpenAI `prompt_tokens_details.cache_creation_input_tokens` → mapped to `cache_creation_input_tokens` as fallback
 
 **Relationships**:
 - Extends existing `CompletionUsage` from OpenAI SDK
@@ -202,9 +220,9 @@ When applying cache control at an interval position:
 ### Usage Tracking Extension
 
 1. **Input**: Standard OpenAI usage response
-2. **Detection**: Presence of cache-related fields
-3. **Extension**: Add cache metrics to existing usage object
-4. **Integration**: Maintain compatibility with existing usage tracking
+2. **Detection**: Presence of cache-related fields (Claude top-level OR prompt_tokens_details)
+3. **Extension**: Add cache metrics to existing usage object, extracting from both sources with priority
+4. **Integration**: Maintain compatibility with existing usage tracking; extraction applies to all models (not just Claude)
 5. **Output**: Enhanced usage object with cache information
 
 ## Validation Schema

--- a/specs/021-prompt-cache-control/plan.md
+++ b/specs/021-prompt-cache-control/plan.md
@@ -1,4 +1,4 @@
-# Implementation Plan: Prompt Cache Control for Claude Models
+# Implementation Plan: Prompt Cache Control
 
 **Branch**: `021-prompt-cache-control` | **Date**: 2025-12-02 | **Spec**: [spec.md](spec.md)
 **Input**: Feature specification from `/specs/021-prompt-cache-control/spec.md`
@@ -7,7 +7,7 @@
 
 ## Summary
 
-Implement cache_control functionality for Claude models in the OpenAI provider to optimize token usage and reduce costs. The feature adds ephemeral cache markers to the first system message, messages at 20-message intervals, and the last tool definition when the model matches the configurable `WAVE_PROMPT_CACHE_REGEX` pattern (default: "claude"). Cache control is applied only at the block level (content blocks and tool definitions), never at the message level. This includes extending usage tracking to capture cache-related metrics (cache_read_input_tokens, cache_creation_input_tokens) and maintaining backward compatibility with existing message processing.
+Implement cache_control functionality for Claude models in the OpenAI provider to optimize token usage and reduce costs. The feature adds ephemeral cache markers to the first system message, messages at 20-message intervals, and the last tool definition when the model matches the configurable `WAVE_PROMPT_CACHE_REGEX` pattern (default: "claude"). Cache control is applied only at the block level (content blocks and tool definitions), never at the message level. This includes extending usage tracking to capture cache-related metrics from both Claude top-level fields (cache_read_input_tokens, cache_creation_input_tokens) and OpenAI-standard prompt_tokens_details (cached_tokens, cache_creation_input_tokens), with Claude top-level fields taking priority. This ensures cache token tracking works across Claude, Gemini, DeepSeek, and other models that return cache data.
 
 ## Technical Context
 

--- a/specs/021-prompt-cache-control/quickstart.md
+++ b/specs/021-prompt-cache-control/quickstart.md
@@ -71,8 +71,12 @@ export interface CacheControl {
 
 **Integration Point**: After line 183 (`openaiMessages` construction)
 
+> **Important**: Cache control has two distinct concerns:
+> 1. **Marker injection** (adding `cache_control: {type: "ephemeral"}` to messages/tools) — gated by `supportsPromptCaching`, only for Claude-like models
+> 2. **Cache token extraction** (reading cache metrics from usage responses) — NOT gated, applies to all models
+
 ```typescript
-// Add before createParams construction (line ~195)
+// Marker injection: gated by supportsPromptCaching
 if (supportsPromptCaching(model || modelConfig.model)) {
   openaiMessages = transformMessagesForClaudeCache(
     openaiMessages,
@@ -86,7 +90,7 @@ if (supportsPromptCaching(model || modelConfig.model)) {
 }
 ```
 
-**Usage Extension**: Modify usage processing to extract cache metrics from all models
+**Usage Extension**: Cache token extraction applies to all models (no gate)
 
 ```typescript
 // Extend usage object with cache metrics (Claude top-level + OpenAI prompt_tokens_details)

--- a/specs/021-prompt-cache-control/quickstart.md
+++ b/specs/021-prompt-cache-control/quickstart.md
@@ -1,4 +1,4 @@
-# Quickstart: Claude Cache Control Implementation
+# Quickstart: Cache Control Implementation
 
 **Feature**: Prompt Cache Control for Claude Models  
 **Date**: 2025-12-02  
@@ -86,12 +86,15 @@ if (supportsPromptCaching(model || modelConfig.model)) {
 }
 ```
 
-**Usage Extension**: Modify usage processing (lines 246-252 and 484-486)
+**Usage Extension**: Modify usage processing to extract cache metrics from all models
 
 ```typescript
-// Extend usage object for Claude models
-if (response.usage && supportsPromptCaching(model || modelConfig.model)) {
-  totalUsage = extendUsageWithCacheMetrics(response.usage, responseHeaders);
+// Extend usage object with cache metrics (Claude top-level + OpenAI prompt_tokens_details)
+if (totalUsage && response.usage) {
+  totalUsage = extendUsageWithCacheMetrics(
+    totalUsage,
+    response.usage as Partial<ClaudeUsage>,
+  );
 }
 ```
 
@@ -223,10 +226,10 @@ describe('Claude Cache Control', () => {
 // Standard OpenAI usage
 { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 }
 
-// Extended Claude usage  
+// Extended Claude usage (cache from Claude top-level fields)
 {
   prompt_tokens: 100,
-  completion_tokens: 50, 
+  completion_tokens: 50,
   total_tokens: 150,
   cache_read_input_tokens: 0,
   cache_creation_input_tokens: 80,
@@ -234,6 +237,16 @@ describe('Claude Cache Control', () => {
     ephemeral_5m_input_tokens: 80,
     ephemeral_1h_input_tokens: 0
   }
+}
+
+// Extended usage from non-Claude models (cache from prompt_tokens_details)
+// Input: { prompt_tokens: 200, total_tokens: 250, prompt_tokens_details: { cached_tokens: 120 } }
+// Output:
+{
+  prompt_tokens: 200,
+  completion_tokens: 50,
+  total_tokens: 250,
+  cache_read_input_tokens: 120,  // extracted from prompt_tokens_details.cached_tokens
 }
 ```
 

--- a/specs/021-prompt-cache-control/research.md
+++ b/specs/021-prompt-cache-control/research.md
@@ -30,7 +30,8 @@
 
 **Alternatives considered**:
 - Custom cache duration: Not supported by Claude API
-- Universal caching: Rejected due to cost and limited benefit for non-Claude models
+- Universal cache_control marker injection: Rejected due to cost and limited benefit for non-Claude models (only Claude API supports `cache_control: {type: "ephemeral"}` markers)
+- Universal cache token extraction: Accepted — `prompt_tokens_details` is an OpenAI-standard field; extracting cache metrics from all models' usage is zero-cost and provides visibility
 - Image content caching: Not supported by Claude API
 
 ## Implementation Architecture Research

--- a/specs/021-prompt-cache-control/research.md
+++ b/specs/021-prompt-cache-control/research.md
@@ -1,4 +1,4 @@
-# Research: Prompt Cache Control for Claude Models
+# Research: Prompt Cache Control
 
 **Date**: 2025-12-02  
 **Feature**: 021-prompt-cache-control  
@@ -85,34 +85,44 @@
 
 ## Extended Usage Tracking Schema
 
-**Decision**: Extend existing usage tracking with cache-specific metrics
+**Decision**: Extend existing usage tracking with cache-specific metrics from both Claude top-level fields and OpenAI-standard `prompt_tokens_details`
 
 **Rationale**:
 ```typescript
+interface ExtendedPromptTokensDetails extends CompletionUsage.PromptTokensDetails {
+  cache_creation_input_tokens?: number;  // Used by some non-Claude models
+}
+
 interface ClaudeUsage extends CompletionUsage {
   // Standard fields unchanged
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
-  
-  // New cache fields  
-  cache_read_input_tokens?: number;        // Cost savings indicator
-  cache_creation_input_tokens?: number;    // Cache investment indicator
+
+  // Cache fields (from Claude top-level OR OpenAI prompt_tokens_details)
+  cache_read_input_tokens?: number;        // Claude: top-level / OpenAI: prompt_tokens_details.cached_tokens
+  cache_creation_input_tokens?: number;    // Claude: top-level / OpenAI: prompt_tokens_details.cache_creation_input_tokens
   cache_creation?: {
-    ephemeral_5m_input_tokens: number;     // Short-term cache
-    ephemeral_1h_input_tokens: number;     // Extended cache
+    ephemeral_5m_input_tokens: number;     // Short-term cache (Claude-specific)
+    ephemeral_1h_input_tokens: number;     // Extended cache (Claude-specific)
   };
+
+  prompt_tokens_details?: ExtendedPromptTokensDetails;  // Override to include cache_creation_input_tokens
 }
 ```
 
 **Field Relationships**:
-- `cache_creation_input_tokens = ephemeral_5m_input_tokens + ephemeral_1h_input_tokens`
+- `cache_creation_input_tokens = ephemeral_5m_input_tokens + ephemeral_1h_input_tokens` (Claude-specific)
+- Claude top-level fields take priority over `prompt_tokens_details` when both are present
+- `prompt_tokens_details.cached_tokens` maps to `cache_read_input_tokens` as fallback
+- `prompt_tokens_details.cache_creation_input_tokens` maps to `cache_creation_input_tokens` as fallback
 - Backward compatibility maintained for existing usage tracking consumers
 
 **Alternatives considered**:
 - Separate cache usage object: Rejected for API consistency and complexity
 - Simplified cache metrics: Rejected due to insufficient cost tracking granularity
 - Breaking usage interface changes: Rejected for backward compatibility requirements
+- Only support Claude top-level fields: Rejected because non-Claude models (Gemini, DeepSeek) return cache data via `prompt_tokens_details`
 
 ## System Prompt Stability: CWD Changes
 

--- a/specs/021-prompt-cache-control/spec.md
+++ b/specs/021-prompt-cache-control/spec.md
@@ -1,4 +1,4 @@
-# Feature Specification: Prompt Cache Control for Claude Models
+# Feature Specification: Prompt Cache Control
 
 **Feature Branch**: `021-prompt-cache-control`  
 **Created**: 2025-12-02  
@@ -56,18 +56,20 @@ Tool definitions (function schemas) should be cached for Claude models since the
 
 ### User Story 4 - Comprehensive Token Tracking for Cache-Enabled Models (Priority: P1)
 
-When using Claude models with cache control, developers need accurate token tracking that includes all cache-related costs (cache reads, cache creation) in addition to the base prompt and completion tokens to understand the true cost and token usage of their requests.
+When using cache-enabled models (Claude or others like Gemini/DeepSeek that return cache tokens), developers need accurate token tracking that includes all cache-related costs (cache reads, cache creation) in addition to the base prompt and completion tokens to understand the true cost and token usage of their requests.
 
 **Why this priority**: Accurate cost tracking is critical for developers to understand the financial impact of caching and make informed decisions about their usage patterns. Without comprehensive token tracking, cache benefits might appear misleading.
 
-**Independent Test**: Can be fully tested by making cached requests with Claude models and verifying that the displayed token count includes prompt_tokens + completion_tokens + cache_read_input_tokens + cache_creation_input_tokens.
+**Independent Test**: Can be fully tested by making cached requests with any cache-enabled model and verifying that the displayed token count includes prompt_tokens + completion_tokens + cache_read_input_tokens + cache_creation_input_tokens.
 
 **Acceptance Scenarios**:
 
-1. **Given** a Claude model request with cache creation, **When** the response includes cache_creation_input_tokens, **Then** latestTotalTokens shows total_tokens + cache_creation_input_tokens
-2. **Given** a Claude model request with cache hits, **When** the response includes cache_read_input_tokens, **Then** latestTotalTokens shows total_tokens + cache_read_input_tokens
-3. **Given** a Claude model request with both cache creation and reads, **When** the response includes both token types, **Then** latestTotalTokens shows total_tokens + cache_read_input_tokens + cache_creation_input_tokens
-4. **Given** a non-cached request or non-Claude model, **When** no cache tokens are present, **Then** latestTotalTokens shows only total_tokens as before
+1. **Given** a Claude model request with cache creation, **When** the response includes cache_creation_input_tokens (at the usage top level), **Then** latestTotalTokens shows total_tokens + cache_creation_input_tokens
+2. **Given** a Claude model request with cache hits, **When** the response includes cache_read_input_tokens (at the usage top level), **Then** latestTotalTokens shows total_tokens + cache_read_input_tokens
+3. **Given** a non-Claude model request (e.g., Gemini, DeepSeek), **When** the response includes prompt_tokens_details.cached_tokens, **Then** cache_read_input_tokens is populated from cached_tokens and latestTotalTokens includes it
+4. **Given** a non-Claude model request, **When** the response includes prompt_tokens_details.cache_creation_input_tokens, **Then** cache_creation_input_tokens is populated from that field and latestTotalTokens includes it
+5. **Given** a model response with both Claude top-level cache fields and prompt_tokens_details, **When** both are present, **Then** the Claude top-level fields take priority
+6. **Given** a non-cached request or model with no cache tokens, **When** no cache tokens are present, **Then** latestTotalTokens shows only total_tokens as before
 
 ---
 
@@ -109,7 +111,7 @@ As a user who switches between permission modes (e.g., default → plan → acce
 - **FR-005**: System MUST maintain cache markers at the most recent multiple-of-20 message position (sliding window)
 - **FR-006**: System MUST include cached messages in the context provided to the AI agent
 - **FR-007**: System MUST not add cache_control markers when using non-Claude models
-- **FR-008**: System MUST extend usage tracking to include cache-related metrics (cache_read_input_tokens, cache_creation_input_tokens, cache_creation object)
+- **FR-008**: System MUST extend usage tracking to include cache-related metrics. Cache tokens are extracted from two sources with priority ordering: (1) Claude top-level fields (cache_read_input_tokens, cache_creation_input_tokens, cache_creation object) take priority, (2) OpenAI-standard prompt_tokens_details fields (cached_tokens → cache_read_input_tokens, cache_creation_input_tokens → cache_creation_input_tokens) serve as fallback for non-Claude models that return cache data via prompt_tokens_details
 - **FR-009**: System MUST apply cache_control markers identically for both streaming and non-streaming requests during message preparation phase
 - **FR-010**: System MUST maintain backward compatibility with existing message processing logic (except for the cache strategy itself which is a breaking change)
 - **FR-011**: System MUST support caching for different message roles at interval positions, applying cache_control only at block level:

--- a/specs/021-prompt-cache-control/spec.md
+++ b/specs/021-prompt-cache-control/spec.md
@@ -93,7 +93,7 @@ As a user who switches between permission modes (e.g., default → plan → acce
 
 ### Edge Cases
 
-- **Edge Case 1**: Model name detection MUST be case-insensitive ("Claude-3-Sonnet" and "claude-3-sonnet" both trigger caching)
+- **Edge Case 1**: Model name detection MUST be case-insensitive ("Claude-3-Sonnet" and "claude-3-sonnet" both trigger cache_control marker injection). Cache token extraction from usage applies regardless of model name.
 - **Edge Case 2**: Mixed content messages MUST apply cache_control only to text content parts, preserving images unchanged
 - **Edge Case 3**: Empty conversation history MUST skip user message caching, apply system message caching only
 - **Edge Case 4**: Streaming and non-streaming requests MUST apply identical cache_control transformation logic
@@ -104,14 +104,14 @@ As a user who switches between permission modes (e.g., default → plan → acce
 
 ### Functional Requirements
 
-- **FR-001**: System MUST detect cache-supporting models using the `WAVE_PROMPT_CACHE_REGEX` environment variable (default: "claude"), which allows configurable regex patterns for model matching
+- **FR-001**: System MUST detect cache-supporting models for cache_control marker injection using the `WAVE_PROMPT_CACHE_REGEX` environment variable (default: "claude"), which allows configurable regex patterns for model matching. This gate controls ONLY the injection of `cache_control: {type: "ephemeral"}` markers into messages and tool definitions — it does NOT gate cache token extraction from usage responses, which applies to all models.
 - **FR-002**: System MUST add cache_control markers with type "ephemeral" to the first system message when using Claude models. This ensures core instructions are always cached even if reminders are added later. The system prompt MUST remain constant across plan mode transitions — plan mode instructions are injected as `<system-reminder>` user messages rather than system prompt changes to preserve the cached system prompt prefix. The `<env>` section's `Primary working directory` field MUST use the immutable `originalWorkdir` (set once at session start) rather than the dynamic `workdir` (which tracks `cd` changes), so that CWD changes do not invalidate the cached system prompt.
 - **FR-003**: System MUST create a cache marker when total message count reaches multiples of 20 (20, 40, 60, etc.)
 - **FR-004**: System MUST NOT create cache markers when total message count is below 20 or not a multiple of 20
 - **FR-005**: System MUST maintain cache markers at the most recent multiple-of-20 message position (sliding window)
 - **FR-006**: System MUST include cached messages in the context provided to the AI agent
-- **FR-007**: System MUST not add cache_control markers when using non-Claude models
-- **FR-008**: System MUST extend usage tracking to include cache-related metrics. Cache tokens are extracted from two sources with priority ordering: (1) Claude top-level fields (cache_read_input_tokens, cache_creation_input_tokens, cache_creation object) take priority, (2) OpenAI-standard prompt_tokens_details fields (cached_tokens → cache_read_input_tokens, cache_creation_input_tokens → cache_creation_input_tokens) serve as fallback for non-Claude models that return cache data via prompt_tokens_details
+- **FR-007**: System MUST NOT add cache_control markers when using non-Claude models (as determined by `WAVE_PROMPT_CACHE_REGEX`). However, cache token extraction from usage (FR-008) applies to all models regardless of this gate.
+- **FR-008**: System MUST extend usage tracking to include cache-related metrics for ALL models (not gated by `supportsPromptCaching`). Cache tokens are extracted from two sources with priority ordering: (1) Claude top-level fields (cache_read_input_tokens, cache_creation_input_tokens, cache_creation object) take priority, (2) OpenAI-standard prompt_tokens_details fields (cached_tokens → cache_read_input_tokens, cache_creation_input_tokens → cache_creation_input_tokens) serve as fallback for non-Claude models that return cache data via prompt_tokens_details
 - **FR-009**: System MUST apply cache_control markers identically for both streaming and non-streaming requests during message preparation phase
 - **FR-010**: System MUST maintain backward compatibility with existing message processing logic (except for the cache strategy itself which is a breaking change)
 - **FR-011**: System MUST support caching for different message roles at interval positions, applying cache_control only at block level:
@@ -126,5 +126,5 @@ As a user who switches between permission modes (e.g., default → plan → acce
 - **Cache Marker**: Represents a point in the conversation where messages are preserved for context, containing the message position and associated conversation content
 - **Message Context**: Represents the combination of system prompt, tools, and cached messages that provide context for AI agent responses
 - **Enhanced Usage Metrics**: Extended usage object including cache-related token counts and creation breakdown
-- **Claude Model Detection**: Boolean determination based on case-insensitive model name matching
+- **Claude Model Detection**: Boolean determination based on case-insensitive model name matching. Gates cache_control marker injection only — cache token extraction applies to all models.
 - **Structured Message Content**: Array-based message content format supporting cache_control on individual content parts

--- a/specs/021-prompt-cache-control/tasks.md
+++ b/specs/021-prompt-cache-control/tasks.md
@@ -1,4 +1,4 @@
-# Implementation Tasks: Prompt Cache Optimization for Claude Models
+# Implementation Tasks: Prompt Cache Optimization
 
 **Feature**: Prompt Cache Control for Claude Models  
 **Branch**: `021-prompt-cache-control`  


### PR DESCRIPTION
- Add ExtendedPromptTokensDetails interface extending OpenAI's PromptTokensDetails
  with cache_creation_input_tokens field
- Update ClaudeUsage to override prompt_tokens_details with extended type
- Update extendUsageWithCacheMetrics to extract cache tokens from
  prompt_tokens_details.cached_tokens and prompt_tokens_details.cache_creation_input_tokens
  as fallback when Claude top-level fields are absent (Claude top-level takes priority)
- Remove supportsPromptCaching gate from aiService cache extraction —
  prompt_tokens_details is OpenAI-standard, applicable to all models
- Remove unused modelName param from processStreamingResponse
- Update Usage type comment to reflect dual-source cache fields
- Add 3 test cases for prompt_tokens_details extraction
- Update spec 021 docs to reflect cross-model cache token tracking
