### PR TITLE
fix(acp): remove bash command text content from tool call updates

### DIFF
--- a/packages/code/src/acp/agent.ts
+++ b/packages/code/src/acp/agent.ts
@@ -679,17 +679,6 @@ export class WaveAcpAgent implements AcpAgent {
           oldText: parameters.old_string,
           newText: parameters.new_string,
         });
-      } else if (
-        name === BASH_TOOL_NAME &&
-        typeof parameters.command === "string"
-      ) {
-        contents.push({
-          type: "content",
-          content: {
-            type: "text",
-            text: "**Command:**\n```bash\n" + parameters.command + "\n```",
-          },
-        });
       } else if (name === EXIT_PLAN_MODE_TOOL_NAME && planContent) {
         contents.push({
           type: "content",

--- a/packages/code/tests/acp/agent.test.ts
+++ b/packages/code/tests/acp/agent.test.ts
@@ -1982,7 +1982,7 @@ describe("WaveAcpAgent", () => {
     );
   });
 
-  it("should include formatted bash command in tool call content", async () => {
+  it("should not include bash command text in tool call content", async () => {
     let capturedCallbacks: AgentOptions["callbacks"];
     const mockWaveAgent = {
       sessionId: "session-1",
@@ -2012,15 +2012,7 @@ describe("WaveAcpAgent", () => {
         update: expect.objectContaining({
           sessionUpdate: "tool_call",
           toolCallId: "1",
-          content: [
-            {
-              type: "content",
-              content: {
-                type: "text",
-                text: "**Command:**\n```bash\nls -la\n```",
-              },
-            },
-          ],
+          content: undefined,
         }),
       }),
     );


### PR DESCRIPTION
Bash tool now only shows shortResult (output) as text content.
The command input is still available via rawInput in the tool call.

- Removed Bash branch from getToolContent() that formatted command as markdown
- Updated test to expect undefined content at start stage
