### PR TITLE
feat: allow removing built-in marketplace

### DIFF
--- a/packages/agent-sdk/src/services/MarketplaceService.ts
+++ b/packages/agent-sdk/src/services/MarketplaceService.ts
@@ -217,33 +217,20 @@ export class MarketplaceService {
   }
 
   /**
-   * Legacy method: loads known marketplaces with builtin injection.
+   * Legacy method: loads known marketplaces from cache.
    * @deprecated Use listMarketplaces() instead, which combines scoped settings.
    */
   async getKnownMarketplaces(): Promise<KnownMarketplacesRegistry> {
     const cache = await this.getCacheRegistry();
-    // If cache is null (file doesn't exist or has no parseable content), inject builtin
     if (cache === null) {
-      return {
-        marketplaces: [
-          {
-            ...MarketplaceService.BUILTIN_MARKETPLACE,
-            isBuiltin: true,
-            declaredScope: "builtin",
-          },
-        ],
-      };
+      return { marketplaces: [] };
     }
-    // File has valid JSON - respect user's explicit choice even if empty
-    const hasBuiltin = cache.marketplaces.some(
-      (m) => m.name === MarketplaceService.BUILTIN_MARKETPLACE.name,
-    );
     return {
       marketplaces: cache.marketplaces.map((m) => ({
         ...m,
         isBuiltin:
           m.isBuiltin || m.name === MarketplaceService.BUILTIN_MARKETPLACE.name,
-        declaredScope: m.declaredScope ?? (hasBuiltin ? "builtin" : "user"),
+        declaredScope: m.declaredScope ?? "user",
       })),
     };
   }
@@ -385,8 +372,6 @@ export class MarketplaceService {
    * Finds which scope declared a marketplace (user, project, local, or builtin)
    */
   getMarketplaceDeclaringSource(name: string): Scope | "builtin" | null {
-    if (name === MarketplaceService.BUILTIN_MARKETPLACE.name) return "builtin";
-
     const scopes: Scope[] = ["local", "project", "user"];
     for (const scope of scopes) {
       const scoped = this.configurationService.getScopedMarketplaces(
@@ -395,6 +380,7 @@ export class MarketplaceService {
       );
       if (scoped[name]) return scope;
     }
+    if (name === MarketplaceService.BUILTIN_MARKETPLACE.name) return "builtin";
     return null;
   }
 
@@ -503,7 +489,7 @@ export class MarketplaceService {
   }
 
   /**
-   * Lists all registered marketplaces by combining scoped settings + built-in
+   * Lists all registered marketplaces by combining scoped settings + cache
    */
   async listMarketplaces(): Promise<KnownMarketplace[]> {
     const scopedMarketplaces = this.configurationService.getMergedMarketplaces(
@@ -516,16 +502,8 @@ export class MarketplaceService {
 
     const result: KnownMarketplace[] = [];
 
-    // Add built-in marketplace
-    result.push({
-      ...MarketplaceService.BUILTIN_MARKETPLACE,
-      isBuiltin: true,
-      declaredScope: "builtin",
-    });
-
     // Add all scoped marketplaces (local overrides project overrides user)
     for (const [name, config] of Object.entries(scopedMarketplaces)) {
-      if (name === MarketplaceService.BUILTIN_MARKETPLACE.name) continue;
       const cache = cacheMap.get(name);
       const declaredScope = this.getMarketplaceDeclaringSource(name) as
         | "user"
@@ -538,12 +516,12 @@ export class MarketplaceService {
 
     // Add cache entries not yet in scoped settings (backwards compatibility)
     for (const [name, cache] of cacheMap.entries()) {
-      if (name === MarketplaceService.BUILTIN_MARKETPLACE.name) continue;
       if (scopedMarketplaces[name]) continue;
+      const isBuiltin = name === MarketplaceService.BUILTIN_MARKETPLACE.name;
       result.push({
         ...cache,
-        isBuiltin: false,
-        declaredScope: cache.declaredScope ?? "user",
+        isBuiltin,
+        declaredScope: cache.declaredScope ?? (isBuiltin ? "builtin" : "user"),
       });
     }
 
@@ -558,15 +536,13 @@ export class MarketplaceService {
       const targetScope =
         scope || this.getMarketplaceDeclaringSource(name) || "user";
 
-      if (targetScope === "builtin") {
-        throw new Error("Cannot remove built-in marketplace");
+      if (targetScope !== "builtin") {
+        await this.configurationService.removeMarketplaceFromScope(
+          this.workdir,
+          targetScope,
+          name,
+        );
       }
-
-      await this.configurationService.removeMarketplaceFromScope(
-        this.workdir,
-        targetScope,
-        name,
-      );
 
       // Also remove from cache
       await this.removeFromCache(name);

--- a/packages/agent-sdk/tests/services/MarketplaceService.test.ts
+++ b/packages/agent-sdk/tests/services/MarketplaceService.test.ts
@@ -101,11 +101,9 @@ describe("MarketplaceService - Builtin Marketplace", () => {
     }
   });
 
-  it("should return the builtin marketplace when no config file exists", async () => {
+  it("should return empty list when no config file exists", async () => {
     const registry = await service.getKnownMarketplaces();
-    expect(registry.marketplaces).toHaveLength(1);
-    expect(registry.marketplaces[0].name).toBe("wave-plugins-official");
-    expect(registry.marketplaces[0].isBuiltin).toBe(true);
+    expect(registry.marketplaces).toHaveLength(0);
   });
 
   it("should return empty list if builtin is explicitly removed (config file exists but empty)", async () => {
@@ -122,7 +120,7 @@ describe("MarketplaceService - Builtin Marketplace", () => {
     expect(registry.marketplaces).toHaveLength(0);
   });
 
-  it("should persist builtin marketplace when adding a custom one for the first time", async () => {
+  it("should persist custom marketplace when adding for the first time", async () => {
     // Mock git clone and manifest loading
     vi.spyOn(
       service,
@@ -136,14 +134,10 @@ describe("MarketplaceService - Builtin Marketplace", () => {
     const added = await service.addMarketplace("custom-mkt");
     expect(added.name).toBe("custom-mkt");
 
-    // listMarketplaces combines scoped settings + builtin
+    // listMarketplaces returns the custom marketplace
     const marketplaces = await service.listMarketplaces();
     expect(marketplaces.length).toBeGreaterThan(0);
-    expect(
-      marketplaces.some(
-        (m) => m.name === "wave-plugins-official" && m.isBuiltin,
-      ),
-    ).toBe(true);
+    expect(marketplaces.some((m) => m.name === "custom-mkt")).toBe(true);
   });
 
   it("should not duplicate builtin marketplace if it already exists", async () => {
@@ -214,8 +208,7 @@ describe("MarketplaceService - Builtin Marketplace", () => {
     await fs.writeFile(knownMarketplacesPath, "   \n\t  ");
 
     const registry = await service.getKnownMarketplaces();
-    expect(registry.marketplaces).toHaveLength(1);
-    expect(registry.marketplaces[0].isBuiltin).toBe(true);
+    expect(registry.marketplaces).toHaveLength(0);
   });
 
   it("should handle known marketplaces file with empty array", async () => {
@@ -338,9 +331,8 @@ describe("MarketplaceService - Scoped Marketplace", () => {
     });
 
     const marketplaces = await service.listMarketplaces();
-    expect(marketplaces).toHaveLength(2); // builtin + custom
-    expect(marketplaces[0].name).toBe("wave-plugins-official");
-    expect(marketplaces[1].name).toBe("my-marketplace");
+    expect(marketplaces).toHaveLength(1);
+    expect(marketplaces[0].name).toBe("my-marketplace");
   });
 
   it("should list marketplaces combining scoped settings with cache fallback", async () => {
@@ -369,7 +361,7 @@ describe("MarketplaceService - Scoped Marketplace", () => {
             source: { source: "directory", path: "/old/path" },
           },
           {
-            name: "wave-plugins-official", // builtin in cache, should skip
+            name: "wave-plugins-official", // builtin in cache
             source: {
               source: "github",
               repo: "netease-lcap/wave-plugins-official",
@@ -380,9 +372,12 @@ describe("MarketplaceService - Scoped Marketplace", () => {
     );
 
     const marketplaces = await service.listMarketplaces();
-    // builtin + scoped-mkt(from settings) + cached-mkt(from cache fallback)
+    // scoped-mkt(from settings) + cached-mkt(from cache) + wave-plugins-official(from cache)
     expect(marketplaces).toHaveLength(3);
     expect(marketplaces.some((m) => m.name === "cached-mkt")).toBe(true);
+    expect(marketplaces.some((m) => m.name === "wave-plugins-official")).toBe(
+      true,
+    );
   });
 
   it("should return declaring scope for a marketplace", () => {
@@ -441,10 +436,38 @@ describe("MarketplaceService - Scoped Marketplace", () => {
     ).toHaveBeenCalled();
   });
 
-  it("should throw when trying to remove builtin marketplace", async () => {
-    await expect(
-      service.removeMarketplace("wave-plugins-official"),
-    ).rejects.toThrow("Cannot remove built-in marketplace");
+  it("should remove builtin marketplace from cache", async () => {
+    // Pre-populate cache with builtin marketplace
+    const registry = {
+      marketplaces: [
+        {
+          name: "wave-plugins-official",
+          source: {
+            source: "github",
+            repo: "netease-lcap/wave-plugins-official",
+          },
+          isBuiltin: true,
+          declaredScope: "builtin",
+        },
+      ],
+    };
+    vi.spyOn(
+      service as unknown as {
+        getCacheRegistry: () => Promise<typeof registry>;
+      },
+      "getCacheRegistry",
+    ).mockResolvedValue(registry);
+    const removeFromCacheSpy = vi
+      .spyOn(
+        service as unknown as {
+          removeFromCache: (name: string) => Promise<void>;
+        },
+        "removeFromCache",
+      )
+      .mockResolvedValue(undefined);
+
+    await service.removeMarketplace("wave-plugins-official");
+    expect(removeFromCacheSpy).toHaveBeenCalledWith("wave-plugins-official");
   });
 
   it("should remove marketplace with inferred scope", async () => {
@@ -726,11 +749,8 @@ describe("MarketplaceService - Coverage Targets", () => {
   // e.g., updateMarketplace calling updateCacheMarketplace with only lastUpdated
   // for a marketplace not yet in the cache
   it("should use default source fallback when updating cache for unknown marketplace", async () => {
-    // Ensure no cache file exists
-    const knownPath = path.join(mockPluginsDir, "known_marketplaces.json");
-    if (fsModule.existsSync(knownPath)) {
-      await fs.rm(knownPath, { force: true });
-    }
+    // Mock getCacheRegistry to return null (no cache)
+    vi.spyOn(service, "getCacheRegistry").mockResolvedValue(null);
 
     vi.spyOn(
       service["configurationService"],
@@ -899,8 +919,8 @@ describe("MarketplaceService - Coverage Targets", () => {
     );
   });
 
-  // Line 540-541: listMarketplaces cache fallback skip conditions
-  it("should skip builtin marketplace in cache fallback iteration", async () => {
+  // listMarketplaces cache fallback: builtin gets isBuiltin and declaredScope from cache
+  it("should handle builtin marketplace in cache fallback iteration", async () => {
     vi.spyOn(
       service["configurationService"],
       "getMergedMarketplaces",


### PR DESCRIPTION
## Summary

Allow users to permanently delete the built-in `wave-plugins-official` marketplace, matching Claude Code's non-hardcoded list pattern.

## Changes

### `MarketplaceService.ts`
- **`removeMarketplace()`** — removed the `throw "Cannot remove built-in marketplace"`; when scope is "builtin", skips `removeMarketplaceFromScope()` but still calls `removeFromCache()`
- **`listMarketplaces()`** — removed hardcoded `result.push(BUILTIN_MARKETPLACE)` and both `if (name === BUILTIN_MARKETPLACE.name) continue;` guards; builtin now appears naturally from cache if present
- **`getKnownMarketplaces()`** — returns empty list when no cache file, no longer injects builtin
- **`getMarketplaceDeclaringSource()`** — moved builtin name check after scope checks (fallback to "builtin" only if not in any scope's settings)

### Test Updates
- Replaced "should throw when trying to remove builtin marketplace" with "should remove builtin marketplace from cache"
- Updated tests that depended on hardcoded builtin in `listMarketplaces()`

## Behavior
- Built-in marketplace can be permanently deleted
- No auto-restore on startup
- User can manually restore via `wave plugin marketplace add netease-lcap/wave-plugins-official`
- UI layer already has "Remove marketplace" option, no changes needed

## Testing
- All 3080 agent-sdk tests pass
- E2E verified: list → remove → list (empty) → verify cache