### PR TITLE
fix: handle CRLF line endings and Windows path separators in skill/plugin loading

### DIFF
--- a/packages/agent-sdk/src/managers/skillManager.ts
+++ b/packages/agent-sdk/src/managers/skillManager.ts
@@ -442,7 +442,9 @@ export class SkillManager extends EventEmitter {
     const skillPath = `Base directory for this skill: ${skill.skillPath}\n\n`;
 
     // Extract content after frontmatter
-    const contentMatch = skill.content.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
+    const contentMatch = skill.content.match(
+      /^---\r?\n[\s\S]*?\r?\n---\r?\n([\s\S]*)$/,
+    );
     let mainContent = contentMatch ? contentMatch[1].trim() : skill.content;
 
     // 1. Substitute parameters ($1, $ARGUMENTS, etc.)

--- a/packages/agent-sdk/src/services/fileWatcher.ts
+++ b/packages/agent-sdk/src/services/fileWatcher.ts
@@ -281,12 +281,11 @@ export class FileWatcherService extends EventEmitter {
 
     // Notify all watchers that match the path or are parents of the path
     for (const [watchedPath, entry] of this.watchers.entries()) {
+      const normalizedFilePath = filePath.replace(/\\/g, "/");
+      const normalizedWatchedPath = watchedPath.replace(/\\/g, "/");
       if (
-        filePath === watchedPath ||
-        filePath.startsWith(watchedPath + "/") ||
-        // Handle cases where the watched path might be a file and we get an event for it
-        // (already covered by filePath === watchedPath)
-        false
+        normalizedFilePath === normalizedWatchedPath ||
+        normalizedFilePath.startsWith(normalizedWatchedPath + "/")
       ) {
         entry.lastEvent = event.timestamp;
 

--- a/packages/agent-sdk/src/utils/commandPathResolver.ts
+++ b/packages/agent-sdk/src/utils/commandPathResolver.ts
@@ -26,7 +26,9 @@ export function generateCommandId(filePath: string, rootDir: string): string {
     throw new Error("Command filename cannot be empty");
   }
 
-  const segments = relativePath.split("/").filter((segment) => segment !== "");
+  const segments = relativePath
+    .split(/[\\/]/)
+    .filter((segment) => segment !== "");
 
   // Remove .md extension from the last segment
   const lastSegment = segments[segments.length - 1];

--- a/packages/agent-sdk/src/utils/skillParser.ts
+++ b/packages/agent-sdk/src/utils/skillParser.ts
@@ -35,7 +35,7 @@ export function parseSkillFile(
     result.content = content;
 
     // Parse YAML frontmatter
-    const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
     if (!frontmatterMatch) {
       result.validationErrors.push("Missing YAML frontmatter");
       return result;
@@ -53,9 +53,11 @@ export function parseSkillFile(
 
     // Determine skill type and path
     const skillPath = basePath || dirname(filePath);
-    const skillType = skillPath.includes("/.wave/skills")
-      ? "project"
-      : "personal";
+    const skillType =
+      skillPath.includes("/.wave/skills") ||
+      skillPath.includes("\\.wave\\skills")
+        ? "project"
+        : "personal";
 
     // Extract allowed tools
     let allowedTools: string[] | undefined;

--- a/packages/agent-sdk/src/utils/subagentParser.ts
+++ b/packages/agent-sdk/src/utils/subagentParser.ts
@@ -30,7 +30,8 @@ function parseFrontmatter(content: string): {
   frontmatter: SubagentFrontmatter;
   body: string;
 } {
-  const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/;
+  const frontmatterRegex =
+    /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n([\s\S]*)$/;
   const match = content.match(frontmatterRegex);
 
   if (!match) {


### PR DESCRIPTION
## Problem

On Windows, plugin skills (from the marketplace) silently fail to appear in the slash command list after installation. The user has to restart, and even then some plugins never show up.

## Root Cause

The YAML frontmatter regex in `skillParser.ts` (`/^---\n/)`) only matches LF line endings. On Windows, `git checkout` with `core.autocrlf=true` (the default) converts LF → CRLF in working tree files. When a plugin's `SKILL.md` has CRLF endings, frontmatter parsing fails → skill is marked invalid → silently skipped → never registered as a slash command.

Whether a plugin is affected depends on whether its repo has `.gitattributes` forcing LF — explaining why only *some* plugins are impacted.

## Fixes

### CRLF frontmatter parsing (primary fix)
- **`skillParser.ts:38`** — Frontmatter regex: `/^---\n/` → `/^---\r?\n/`
- **`skillManager.ts:445`** — Content extraction regex: same CRLF fix
- **`subagentParser.ts:33`** — Frontmatter regex: `\s*` → `[ \t]*` + `\r?\n` (also fixes \s matching \r greedily)

### Windows path separator fixes (secondary)
- **`skillParser.ts:56`** — Skill type detection now also checks `\.wave\skills` for Windows paths
- **`fileWatcher.ts:286`** — Normalize both paths to `/` before comparison (chokidar uses `/` but `path.join()` produces `\` on Windows)
- **`commandPathResolver.ts:29`** — Split on `/[\\/]/` instead of `"/"` for cross-platform path handling

## Testing
- All 3080 existing tests pass
- Verified CRLF regex fix with manual test: LF regex + CRLF content → NO MATCH; CRLF-tolerant regex → MATCH