### PR TITLE
fix: remove duplicate useEffect causing /btw to be called twice

### DIFF
--- a/packages/code/src/components/BtwDisplay.tsx
+++ b/packages/code/src/components/BtwDisplay.tsx
@@ -8,7 +8,7 @@ interface BtwDisplayProps {
 }
 
 export const BtwDisplay: React.FC<BtwDisplayProps> = ({ btwState }) => {
-  if (!btwState.isActive) {
+  if (!btwState.question) {
     return null;
   }
 

--- a/packages/code/src/components/InputBox.tsx
+++ b/packages/code/src/components/InputBox.tsx
@@ -328,53 +328,47 @@ export const InputBox: React.FC<InputBoxProps> = ({
         <WorkflowManager onCancel={() => setShowWorkflowManager(false)} />
       )}
 
-      {showBackgroundTaskManager ||
-        showMcpManager ||
-        showRewindManager ||
-        showHelp ||
-        showStatusCommand ||
-        showLoginCommand ||
-        showPluginManager ||
-        showWorkflowManager || (
-          <Box flexDirection="column">
-            <Box
-              borderStyle="single"
-              borderColor={btwState.isActive ? "cyan" : "gray"}
-              borderLeft={false}
-              borderRight={false}
-            >
-              <Text color={isPlaceholder ? "gray" : "white"}>
-                {btwState.isActive && isPlaceholder ? (
-                  <>
-                    <Text backgroundColor="white" color="black">
-                      {" "}
-                    </Text>
-                    <Text color="cyan">Type your side question...</Text>
-                  </>
-                ) : shouldShowCursor ? (
-                  <>
-                    {beforeCursor}
-                    <Text backgroundColor="white" color="black">
-                      {atCursor}
-                    </Text>
-                    {afterCursor}
-                  </>
-                ) : (
-                  displayText
-                )}
-              </Text>
+      {btwState.question
+        ? null
+        : showBackgroundTaskManager ||
+          showMcpManager ||
+          showRewindManager ||
+          showHelp ||
+          showStatusCommand ||
+          showLoginCommand ||
+          showPluginManager ||
+          showWorkflowManager || (
+            <Box flexDirection="column">
+              <Box
+                borderStyle="single"
+                borderColor="gray"
+                borderLeft={false}
+                borderRight={false}
+              >
+                <Text color={isPlaceholder ? "gray" : "white"}>
+                  {shouldShowCursor ? (
+                    <>
+                      {beforeCursor}
+                      <Text backgroundColor="white" color="black">
+                        {atCursor}
+                      </Text>
+                      {afterCursor}
+                    </>
+                  ) : (
+                    displayText
+                  )}
+                </Text>
+              </Box>
+              <StatusLine
+                permissionMode={permissionMode}
+                isShellCommand={isShellCommand}
+                isGoalActive={isGoalActive}
+                goalElapsed={goalElapsed}
+                latestTotalTokens={latestTotalTokens}
+                maxInputTokens={maxInputTokens}
+              />
             </Box>
-            <StatusLine
-              permissionMode={permissionMode}
-              isShellCommand={isShellCommand}
-              isBtwActive={btwState.isActive}
-              isGoalActive={isGoalActive}
-              goalElapsed={goalElapsed}
-              latestTotalTokens={latestTotalTokens}
-              maxInputTokens={maxInputTokens}
-            />
-          </Box>
-        )}
+          )}
     </Box>
   );
 };

--- a/packages/code/src/components/StatusLine.tsx
+++ b/packages/code/src/components/StatusLine.tsx
@@ -4,7 +4,6 @@ import { Box, Text } from "ink";
 export interface StatusLineProps {
   permissionMode: string;
   isShellCommand: boolean;
-  isBtwActive: boolean;
   isGoalActive?: boolean;
   goalElapsed?: string;
   latestTotalTokens?: number;
@@ -14,7 +13,6 @@ export interface StatusLineProps {
 export const StatusLine: React.FC<StatusLineProps> = ({
   permissionMode,
   isShellCommand,
-  isBtwActive,
   isGoalActive,
   goalElapsed,
   latestTotalTokens = 0,
@@ -30,11 +28,7 @@ export const StatusLine: React.FC<StatusLineProps> = ({
 
   return (
     <Box paddingRight={1} justifyContent="space-between" width="100%">
-      {isBtwActive ? (
-        <Text color="gray">
-          Mode: <Text color="cyan">BTW</Text> (ESC to dismiss)
-        </Text>
-      ) : isShellCommand ? (
+      {isShellCommand ? (
         <Text color="gray">
           Shell: <Text color="yellow">Run shell command</Text>
         </Text>

--- a/packages/code/src/hooks/useInputManager.ts
+++ b/packages/code/src/hooks/useInputManager.ts
@@ -212,11 +212,6 @@ export const useInputManager = (
                 dispatch({ type: "SET_SHOW_MODEL_SELECTOR", payload: true });
               } else if (command === "workflows") {
                 dispatch({ type: "SET_SHOW_WORKFLOW_MANAGER", payload: true });
-              } else if (command === "btw") {
-                dispatch({
-                  type: "SET_BTW_STATE",
-                  payload: { isActive: true, question: "", isLoading: false },
-                });
               }
             }
             break;

--- a/packages/code/src/hooks/useInputManager.ts
+++ b/packages/code/src/hooks/useInputManager.ts
@@ -320,39 +320,7 @@ export const useInputManager = (
     onImagesStateChange?.(state.attachedImages);
   }, [state.attachedImages, onImagesStateChange]);
 
-  // Handle /btw side question
-  useEffect(() => {
-    if (
-      state.btwState.isActive &&
-      state.btwState.isLoading &&
-      state.btwState.question
-    ) {
-      const askBtw = async () => {
-        try {
-          const answer = await onAskBtw?.(state.btwState.question);
-          dispatch({
-            type: "SET_BTW_STATE",
-            payload: { answer, isLoading: false },
-          });
-        } catch (error) {
-          console.error("Failed to ask side question:", error);
-          dispatch({
-            type: "SET_BTW_STATE",
-            payload: {
-              answer: "Error: Failed to get an answer for your side question.",
-              isLoading: false,
-            },
-          });
-        }
-      };
-      askBtw();
-    }
-  }, [
-    state.btwState.isActive,
-    state.btwState.isLoading,
-    state.btwState.question,
-    onAskBtw,
-  ]);
+  // /btw side question is handled via pendingEffect "ASK_BTW" above
 
   // Methods
   const insertTextAtCursor = useCallback((text: string) => {

--- a/packages/code/src/managers/inputHandlers.ts
+++ b/packages/code/src/managers/inputHandlers.ts
@@ -373,11 +373,6 @@ export const handleCommandSelect = (
           dispatch({ type: "SET_SHOW_MODEL_SELECTOR", payload: true });
         } else if (command === "workflows") {
           dispatch({ type: "SET_SHOW_WORKFLOW_MANAGER", payload: true });
-        } else if (command === "btw") {
-          dispatch({
-            type: "SET_BTW_STATE",
-            payload: { isActive: true, question: "", isLoading: false },
-          });
         }
       }
     })();
@@ -701,46 +696,6 @@ export const handleInput = async (
   key: Key,
   clearImages?: () => void,
 ): Promise<boolean> => {
-  if (state.btwState.isActive) {
-    if (key.escape) {
-      dispatch({
-        type: "SET_BTW_STATE",
-        payload: {
-          isActive: false,
-          question: "",
-          answer: undefined,
-          isLoading: false,
-        },
-      });
-      return true;
-    }
-
-    if (key.return) {
-      if (state.inputText.trim() && !state.btwState.isLoading) {
-        dispatch({
-          type: "SET_BTW_STATE",
-          payload: {
-            question: state.inputText.trim(),
-            isLoading: true,
-            answer: undefined,
-          },
-        });
-        dispatch({ type: "CLEAR_INPUT" });
-      }
-      return true;
-    }
-
-    // Handle normal input for the question
-    return await handleNormalInput(
-      state,
-      dispatch,
-      callbacks,
-      input,
-      key,
-      clearImages,
-    );
-  }
-
   if (key.escape) {
     if (
       !(
@@ -754,8 +709,7 @@ export const handleInput = async (
         state.showStatusCommand ||
         state.showPluginManager ||
         state.showModelSelector ||
-        state.showWorkflowManager ||
-        state.btwState.isActive
+        state.showWorkflowManager
       )
     ) {
       callbacks.onAbortMessage?.();
@@ -779,8 +733,7 @@ export const handleInput = async (
     state.showStatusCommand ||
     state.showPluginManager ||
     state.showModelSelector ||
-    state.showWorkflowManager ||
-    state.btwState.isActive
+    state.showWorkflowManager
   ) {
     if (
       state.showBackgroundTaskManager ||
@@ -790,8 +743,7 @@ export const handleInput = async (
       state.showStatusCommand ||
       state.showPluginManager ||
       state.showModelSelector ||
-      state.showWorkflowManager ||
-      state.btwState.isActive
+      state.showWorkflowManager
     ) {
       return true;
     }

--- a/packages/code/src/managers/inputReducer.ts
+++ b/packages/code/src/managers/inputReducer.ts
@@ -22,7 +22,6 @@ export interface AttachedImage {
 }
 
 export interface BtwState {
-  isActive: boolean;
   question: string;
   answer?: string;
   isLoading: boolean;
@@ -164,7 +163,6 @@ export const initialState: InputState = {
   originalLongTextMap: {},
   isFileSearching: false,
   btwState: {
-    isActive: false,
     question: "",
     isLoading: false,
   },
@@ -688,41 +686,7 @@ export function inputReducer(
       const { input, key } = action.payload;
       const hasQueuedMessages = action.payload.hasQueuedMessages ?? false;
 
-      // 1. BTW State Handling
-      if (state.btwState.isActive) {
-        if (key.escape) {
-          return {
-            ...state,
-            btwState: {
-              isActive: false,
-              question: "",
-              answer: undefined,
-              isLoading: false,
-            },
-          };
-        }
-
-        if (key.return) {
-          const question = state.inputText.trim();
-          if (question && !state.btwState.isLoading) {
-            return {
-              ...state,
-              inputText: "",
-              cursorPosition: 0,
-              btwState: {
-                ...state.btwState,
-                question,
-                isLoading: true,
-                answer: undefined,
-              },
-              pendingEffect: { type: "ASK_BTW", question },
-            };
-          }
-          return state;
-        }
-      }
-
-      // 2. Escape Handling
+      // 1. Escape Handling
       if (key.escape) {
         if (state.showFileSelector) {
           return {
@@ -1017,13 +981,12 @@ export function inputReducer(
             .replace(imageRegex, "")
             .trim();
 
-          if (
-            contentWithPlaceholders === "/btw" ||
-            contentWithPlaceholders.startsWith("/btw ")
-          ) {
-            const question = contentWithPlaceholders.startsWith("/btw ")
-              ? contentWithPlaceholders.substring(5).trim()
-              : "";
+          if (contentWithPlaceholders.startsWith("/btw ")) {
+            const question = contentWithPlaceholders.substring(5).trim();
+            if (!question) {
+              // Bare /btw with no question text — ignore
+              return state;
+            }
 
             return {
               ...state,
@@ -1032,13 +995,17 @@ export function inputReducer(
               historyIndex: -1,
               longTextMap: {},
               btwState: {
-                isActive: true,
                 question,
-                isLoading: question !== "",
+                isLoading: true,
                 answer: undefined,
               },
-              pendingEffect: question ? { type: "ASK_BTW", question } : null,
+              pendingEffect: { type: "ASK_BTW", question },
             };
+          }
+
+          if (contentWithPlaceholders === "/btw") {
+            // Bare /btw — ignore
+            return state;
           }
 
           // Check if the content is a CLI-internal slash command (help, tasks,

--- a/packages/code/tests/components/ChatInterface.loading.test.tsx
+++ b/packages/code/tests/components/ChatInterface.loading.test.tsx
@@ -49,7 +49,7 @@ describe("ChatInterface Loading State", () => {
   const mockInputManager = {
     isManagerReady: true,
     showRewindManager: false,
-    btwState: { isActive: false, question: "", isLoading: false },
+    btwState: { question: "", isLoading: false },
     setPermissionMode: vi.fn(),
     setAllowBypassInCycle: vi.fn(),
   };

--- a/packages/code/tests/components/ChatInterface.rewind.test.tsx
+++ b/packages/code/tests/components/ChatInterface.rewind.test.tsx
@@ -77,7 +77,7 @@ describe("ChatInterface Rewind Visibility", () => {
       handleInput: mockHandleInput,
       setPermissionMode: vi.fn(),
       setAllowBypassInCycle: vi.fn(),
-      btwState: { isActive: false, question: "", isLoading: false },
+      btwState: { question: "", isLoading: false },
       isManagerReady: true,
       showRewindManager: true, // Rewind is visible
     } as unknown as ReturnType<typeof useInputManager>);
@@ -158,7 +158,7 @@ describe("ChatInterface Rewind Visibility", () => {
       handleInput: mockHandleInput,
       setPermissionMode: vi.fn(),
       setAllowBypassInCycle: vi.fn(),
-      btwState: { isActive: false, question: "", isLoading: false },
+      btwState: { question: "", isLoading: false },
       isManagerReady: true,
       showRewindManager: false, // Rewind is NOT visible
     } as unknown as ReturnType<typeof useInputManager>);

--- a/packages/code/tests/managers/inputHandlers.test.ts
+++ b/packages/code/tests/managers/inputHandlers.test.ts
@@ -541,26 +541,6 @@ describe("inputHandlers", () => {
         );
       });
     });
-
-    it("should handle btw command by activating btwState", async () => {
-      const state: InputState = {
-        ...initialState,
-        slashPosition: 0,
-        inputText: "/btw",
-        cursorPosition: 4,
-      };
-      vi.mocked(callbacks.onHasSlashCommand!).mockReturnValue(false);
-
-      handleCommandSelect(state, dispatch, callbacks, "btw");
-
-      expect(dispatch).toHaveBeenCalledWith({
-        type: "SET_BTW_STATE",
-        payload: { isActive: true, question: "", isLoading: false },
-      });
-      expect(dispatch).toHaveBeenCalledWith({
-        type: "CANCEL_COMMAND_SELECTOR",
-      });
-    });
   });
 
   describe("handleFileSelect", () => {
@@ -1005,48 +985,6 @@ describe("inputHandlers", () => {
       const result = await handleInput(state, dispatch, callbacks, "", key);
       expect(result).toBe(true);
       expect(dispatch).toHaveBeenCalledWith({ type: "CANCEL_HISTORY_SEARCH" });
-    });
-
-    it("should handle input when btwState is active", async () => {
-      const state = {
-        ...initialState,
-        btwState: { isActive: true, question: "", isLoading: false },
-        inputText: "What is the time?",
-      };
-      const key = { return: true } as Key;
-      const result = await handleInput(state, dispatch, callbacks, "", key);
-
-      expect(result).toBe(true);
-      expect(dispatch).toHaveBeenCalledWith({
-        type: "SET_BTW_STATE",
-        payload: {
-          question: "What is the time?",
-          isLoading: true,
-          answer: undefined,
-        },
-      });
-      expect(dispatch).toHaveBeenCalledWith({ type: "CLEAR_INPUT" });
-    });
-
-    it("should handle escape to dismiss btwState", async () => {
-      const state = {
-        ...initialState,
-        btwState: { isActive: true, question: "", isLoading: false },
-      };
-      const key = { escape: true } as Key;
-      const result = await handleInput(state, dispatch, callbacks, "", key);
-
-      expect(result).toBe(true);
-      expect(dispatch).toHaveBeenCalledWith({
-        type: "SET_BTW_STATE",
-        payload: {
-          isActive: false,
-          question: "",
-          answer: undefined,
-          isLoading: false,
-        },
-      });
-      expect(callbacks.onAbortMessage).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/code/tests/managers/inputReducer.test.ts
+++ b/packages/code/tests/managers/inputReducer.test.ts
@@ -45,7 +45,6 @@ describe("inputReducer", () => {
       originalLongTextMap: {},
       isFileSearching: false,
       btwState: {
-        isActive: false,
         question: "",
         isLoading: false,
       },
@@ -873,8 +872,8 @@ describe("inputReducer", () => {
           hasSlashCommand,
         },
       });
-      expect(result.btwState.isActive).toBe(true);
       expect(result.btwState.question).toBe("what is life?");
+      expect(result.btwState.isLoading).toBe(true);
       expect(result.pendingEffect).toEqual({
         type: "ASK_BTW",
         question: "what is life?",
@@ -1226,34 +1225,13 @@ describe("inputReducer", () => {
     it("should handle SET_BTW_STATE", () => {
       const result = inputReducer(initialState, {
         type: "SET_BTW_STATE",
-        payload: { isActive: true, question: "test?" },
+        payload: { question: "test?" },
       });
-      expect(result.btwState.isActive).toBe(true);
       expect(result.btwState.question).toBe("test?");
     });
 
-    it("should handle escape in BTW mode", () => {
-      const state = {
-        ...initialState,
-        btwState: { isActive: true, question: "q", isLoading: false },
-      };
-      const result = inputReducer(state, {
-        type: "HANDLE_KEY",
-        payload: {
-          input: "",
-          key: { escape: true } as unknown as Key,
-          hasSlashCommand: () => false,
-        },
-      });
-      expect(result.btwState.isActive).toBe(false);
-    });
-
-    it("should handle return in BTW mode", () => {
-      const state = {
-        ...initialState,
-        inputText: "my question",
-        btwState: { isActive: true, question: "", isLoading: false },
-      };
+    it("should ignore bare /btw without question", () => {
+      const state = { ...initialState, inputText: "/btw" };
       const result = inputReducer(state, {
         type: "HANDLE_KEY",
         payload: {
@@ -1262,12 +1240,7 @@ describe("inputReducer", () => {
           hasSlashCommand: () => false,
         },
       });
-      expect(result.btwState.question).toBe("my question");
-      expect(result.btwState.isLoading).toBe(true);
-      expect(result.pendingEffect).toEqual({
-        type: "ASK_BTW",
-        question: "my question",
-      });
+      expect(result).toBe(state);
     });
   });
 


### PR DESCRIPTION
The /btw side question was triggering two parallel API calls due to
both pendingEffect 'ASK_BTW' and a separate btwState watcher useEffect
firing on the same state change. Removed the redundant btwState watcher.
