### PR TITLE
feat(acp): add wave/ask_question and wave/create_plan extension methods

### DIFF
--- a/packages/code/examples/acp/acp-ask-user-question.ts
+++ b/packages/code/examples/acp/acp-ask-user-question.ts
@@ -68,6 +68,24 @@ async function runAskUserQuestionExample() {
         },
       };
     },
+    extMethod: async (method, params) => {
+      if (method === "wave/ask_question") {
+        console.log("wave/ask_question:", JSON.stringify(params, null, 2));
+        const questions = (params as Record<string, unknown>)
+          .questions as Array<{
+          id: string;
+          options: Array<{ id: string }>;
+        }>;
+        return {
+          outcome: "answered",
+          answers: questions.map((q) => ({
+            questionId: q.id,
+            selectedOptionIds: [q.options[0].id],
+          })),
+        };
+      }
+      throw new Error(`Unknown method: ${method}`);
+    },
     sessionUpdate: async (notification: SessionNotification) => {
       if (notification.update.sessionUpdate === "tool_call") {
         console.log(

--- a/packages/code/examples/acp/acp-exit-plan-mode.ts
+++ b/packages/code/examples/acp/acp-exit-plan-mode.ts
@@ -71,6 +71,13 @@ async function runExitPlanModeExample() {
         },
       };
     },
+    extMethod: async (method, params) => {
+      if (method === "wave/create_plan") {
+        console.log("wave/create_plan:", JSON.stringify(params, null, 2));
+        return { outcome: "accepted" };
+      }
+      throw new Error(`Unknown method: ${method}`);
+    },
     sessionUpdate: async (notification: SessionNotification) => {
       if (notification.update.sessionUpdate === "current_mode_update") {
         console.log("Mode updated to:", notification.update.currentModeId);

--- a/packages/code/src/acp/agent.ts
+++ b/packages/code/src/acp/agent.ts
@@ -58,9 +58,31 @@ import {
 } from "@agentclientprotocol/sdk";
 import type { McpServerConfig, McpServerStatus } from "wave-agent-sdk";
 
+interface WaveAskQuestionRequest {
+  toolCallId: string;
+  title?: string;
+  questions: Array<{
+    id: string;
+    prompt: string;
+    options: Array<{ id: string; label: string; description?: string }>;
+    allowMultiple?: boolean;
+  }>;
+}
+
+interface WaveCreatePlanRequest {
+  toolCallId: string;
+  plan: string;
+  todos?: Array<{
+    id: string;
+    content: string;
+    status: "pending" | "in_progress" | "completed";
+  }>;
+}
+
 export class WaveAcpAgent implements AcpAgent {
   private agents: Map<string, WaveAgent> = new Map();
   private connection: AgentSideConnection;
+  private taskCache = new Map<string, Task[]>();
 
   constructor(connection: AgentSideConnection) {
     this.connection = connection;
@@ -458,6 +480,124 @@ export class WaveAcpAgent implements AcpAgent {
     return "Allow Always";
   }
 
+  private async handleAskQuestion(
+    sessionId: string,
+    toolCallId: string,
+    context: ToolPermissionContext,
+  ): Promise<PermissionDecision | null> {
+    try {
+      const questions =
+        (context.toolInput?.questions as Array<{
+          question: string;
+          header?: string;
+          options: Array<{ label: string; description?: string }>;
+          multiSelect?: boolean;
+        }>) || [];
+
+      const request: WaveAskQuestionRequest = {
+        toolCallId,
+        title: questions.length === 1 ? questions[0].header : undefined,
+        questions: questions.map((q, qi) => ({
+          id: `q${qi}`,
+          prompt: q.question,
+          options: q.options.map((opt, oi) => ({
+            id: String(oi),
+            label: opt.label,
+            description: opt.description,
+          })),
+          allowMultiple: q.multiSelect,
+        })),
+      };
+
+      const response = await this.connection.extMethod(
+        "wave/ask_question",
+        request as unknown as Record<string, unknown>,
+      );
+
+      const outcome = (response as { outcome?: string }).outcome;
+      if (outcome === "cancelled") {
+        return { behavior: "deny", message: "Cancelled by user" };
+      }
+
+      // outcome === "answered"
+      const answers =
+        (
+          response as {
+            answers?: Array<{
+              questionId: string;
+              selectedOptionIds: string[];
+            }>;
+          }
+        ).answers || [];
+      const answerMap: Record<string, string> = {};
+      for (const answer of answers) {
+        const qIndex = parseInt(answer.questionId.replace("q", ""), 10);
+        const question = questions[qIndex];
+        if (!question) continue;
+        const selectedLabels = answer.selectedOptionIds
+          .map((id) => question.options[parseInt(id, 10)]?.label)
+          .filter(Boolean);
+        answerMap[question.question] = selectedLabels.join(", ");
+      }
+
+      return { behavior: "allow", message: JSON.stringify(answerMap) };
+    } catch (error) {
+      logger.warn(
+        "wave/ask_question extMethod failed, falling back to requestPermission",
+        { error },
+      );
+      return null;
+    }
+  }
+
+  private async handleCreatePlan(
+    sessionId: string,
+    toolCallId: string,
+    context: ToolPermissionContext,
+  ): Promise<PermissionDecision | null> {
+    try {
+      const cachedTasks = this.taskCache.get(sessionId) || [];
+      const request: WaveCreatePlanRequest = {
+        toolCallId,
+        plan: context.planContent || "",
+        todos: cachedTasks
+          .filter((t) => t.status !== "deleted")
+          .map((t) => ({
+            id: t.id,
+            content: t.subject,
+            status:
+              t.status === "completed"
+                ? ("completed" as const)
+                : t.status === "in_progress"
+                  ? ("in_progress" as const)
+                  : ("pending" as const),
+          })),
+      };
+
+      const response = await this.connection.extMethod(
+        "wave/create_plan",
+        request as unknown as Record<string, unknown>,
+      );
+
+      const outcome = (response as { outcome?: string }).outcome;
+      if (outcome === "accepted") {
+        return { behavior: "allow", newPermissionMode: "default" };
+      }
+      if (outcome === "rejected") {
+        const reason = (response as { reason?: string }).reason;
+        return { behavior: "deny", message: reason || "Plan rejected" };
+      }
+      // cancelled or unknown outcome
+      return { behavior: "deny", message: "Cancelled by user" };
+    } catch (error) {
+      logger.warn(
+        "wave/create_plan extMethod failed, falling back to requestPermission",
+        { error },
+      );
+      return null;
+    }
+  }
+
   private async handlePermissionRequest(
     sessionId: string,
     context: ToolPermissionContext,
@@ -572,6 +712,27 @@ export class WaveAcpAgent implements AcpAgent {
     const kind = context.toolName
       ? this.getToolKind(context.toolName)
       : undefined;
+
+    // Try extension methods first, fall back to requestPermission
+    if (context.toolName === ASK_USER_QUESTION_TOOL_NAME) {
+      const extResult = await this.handleAskQuestion(
+        sessionId,
+        toolCallId,
+        context,
+      );
+      if (extResult !== null) return extResult;
+      // Fall through to existing requestPermission logic
+    }
+
+    if (context.toolName === EXIT_PLAN_MODE_TOOL_NAME) {
+      const extResult = await this.handleCreatePlan(
+        sessionId,
+        toolCallId,
+        context,
+      );
+      if (extResult !== null) return extResult;
+      // Fall through to existing requestPermission logic
+    }
 
     try {
       const response = await this.connection.requestPermission({
@@ -1081,20 +1242,23 @@ export class WaveAcpAgent implements AcpAgent {
         }
       },
       onTasksChange: (tasks) => {
+        this.taskCache.set(sessionId, tasks);
         this.connection.sessionUpdate({
           sessionId: sessionId as AcpSessionId,
           update: {
             sessionUpdate: "plan",
-            entries: tasks.map((task) => ({
-              content: task.subject,
-              status:
-                task.status === "completed"
-                  ? "completed"
-                  : task.status === "in_progress"
-                    ? "in_progress"
-                    : "pending",
-              priority: "medium",
-            })),
+            entries: tasks
+              .filter((t) => t.status !== "deleted")
+              .map((task) => ({
+                content: task.subject,
+                status:
+                  task.status === "completed"
+                    ? "completed"
+                    : task.status === "in_progress"
+                      ? "in_progress"
+                      : "pending",
+                priority: "medium" as const,
+              })),
           },
         });
       },

--- a/packages/code/tests/acp/agent.test.ts
+++ b/packages/code/tests/acp/agent.test.ts
@@ -40,6 +40,7 @@ describe("WaveAcpAgent", () => {
     closed: Promise<void>;
     requestPermission: ReturnType<typeof vi.fn>;
     sessionUpdate: ReturnType<typeof vi.fn>;
+    extMethod: ReturnType<typeof vi.fn>;
   };
   let agent: WaveAcpAgent;
 
@@ -48,6 +49,7 @@ describe("WaveAcpAgent", () => {
       closed: new Promise(() => {}),
       requestPermission: vi.fn(),
       sessionUpdate: vi.fn(),
+      extMethod: vi.fn(),
     };
     agent = new WaveAcpAgent(mockConnection as unknown as AgentSideConnection);
   });
@@ -2488,6 +2490,319 @@ describe("WaveAcpAgent", () => {
             },
           ],
         }),
+      }),
+    );
+  });
+
+  it("should use wave/ask_question extMethod for AskUserQuestion", async () => {
+    let canUseToolCallback: PermissionCallback;
+    const mockWaveAgent = {
+      sessionId: "session-1",
+      getPermissionMode: vi.fn().mockReturnValue("default"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+    };
+    vi.mocked(WaveAgent.create).mockImplementation((options: AgentOptions) => {
+      canUseToolCallback = options.canUseTool as PermissionCallback;
+      return Promise.resolve(mockWaveAgent as unknown as WaveAgent);
+    });
+
+    await agent.newSession({ cwd: "/test", mcpServers: [] });
+
+    vi.mocked(mockConnection.extMethod).mockResolvedValue({
+      outcome: "answered",
+      answers: [{ questionId: "q0", selectedOptionIds: ["0"] }],
+    });
+
+    const decision = await canUseToolCallback!({
+      toolName: "AskUserQuestion",
+      toolInput: {
+        questions: [
+          {
+            question: "Which library?",
+            header: "Library choice",
+            options: [
+              { label: "date-fns", description: "Lightweight" },
+              { label: "moment", description: "Legacy" },
+            ],
+          },
+        ],
+      },
+      permissionMode: "default",
+      toolCallId: "tool-call-1",
+    });
+
+    expect(decision.behavior).toBe("allow");
+    expect(JSON.parse(decision.message!)).toEqual({
+      "Which library?": "date-fns",
+    });
+    expect(mockConnection.extMethod).toHaveBeenCalledWith(
+      "wave/ask_question",
+      expect.objectContaining({
+        toolCallId: "tool-call-1",
+        questions: expect.arrayContaining([
+          expect.objectContaining({
+            id: "q0",
+            prompt: "Which library?",
+          }),
+        ]),
+      }),
+    );
+    expect(mockConnection.requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("should fall back to requestPermission when wave/ask_question extMethod fails", async () => {
+    let canUseToolCallback: PermissionCallback;
+    const mockWaveAgent = {
+      sessionId: "session-1",
+      getPermissionMode: vi.fn().mockReturnValue("default"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+    };
+    vi.mocked(WaveAgent.create).mockImplementation((options: AgentOptions) => {
+      canUseToolCallback = options.canUseTool as PermissionCallback;
+      return Promise.resolve(mockWaveAgent as unknown as WaveAgent);
+    });
+
+    await agent.newSession({ cwd: "/test", mcpServers: [] });
+
+    vi.mocked(mockConnection.extMethod).mockRejectedValue(
+      new Error("not implemented"),
+    );
+    vi.mocked(mockConnection.requestPermission).mockResolvedValue({
+      outcome: { outcome: "selected", optionId: "allow_once" },
+      message: JSON.stringify({ "Which?": "A" }),
+    } as unknown as RequestPermissionResponse);
+
+    const decision = await canUseToolCallback!({
+      toolName: "AskUserQuestion",
+      toolInput: {
+        questions: [
+          { question: "Which?", header: "h", options: [{ label: "A" }] },
+        ],
+      },
+      permissionMode: "default",
+    });
+
+    expect(decision.behavior).toBe("allow");
+    expect(mockConnection.requestPermission).toHaveBeenCalled();
+  });
+
+  it("should use wave/create_plan extMethod for ExitPlanMode (accepted)", async () => {
+    let canUseToolCallback: PermissionCallback;
+    const mockWaveAgent = {
+      sessionId: "session-1",
+      getPermissionMode: vi.fn().mockReturnValue("default"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+    };
+    vi.mocked(WaveAgent.create).mockImplementation((options: AgentOptions) => {
+      canUseToolCallback = options.canUseTool as PermissionCallback;
+      return Promise.resolve(mockWaveAgent as unknown as WaveAgent);
+    });
+
+    await agent.newSession({ cwd: "/test", mcpServers: [] });
+
+    vi.mocked(mockConnection.extMethod).mockResolvedValue({
+      outcome: "accepted",
+    });
+
+    const decision = await canUseToolCallback!({
+      toolName: "ExitPlanMode",
+      toolInput: {},
+      permissionMode: "plan",
+      planContent: "# My Plan\nDo stuff",
+      toolCallId: "plan-tool-1",
+    });
+
+    expect(decision.behavior).toBe("allow");
+    expect(decision.newPermissionMode).toBe("default");
+    expect(mockConnection.extMethod).toHaveBeenCalledWith(
+      "wave/create_plan",
+      expect.objectContaining({
+        toolCallId: "plan-tool-1",
+        plan: "# My Plan\nDo stuff",
+      }),
+    );
+    expect(mockConnection.requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("should use wave/create_plan extMethod for ExitPlanMode (rejected)", async () => {
+    let canUseToolCallback: PermissionCallback;
+    const mockWaveAgent = {
+      sessionId: "session-1",
+      getPermissionMode: vi.fn().mockReturnValue("default"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+    };
+    vi.mocked(WaveAgent.create).mockImplementation((options: AgentOptions) => {
+      canUseToolCallback = options.canUseTool as PermissionCallback;
+      return Promise.resolve(mockWaveAgent as unknown as WaveAgent);
+    });
+
+    await agent.newSession({ cwd: "/test", mcpServers: [] });
+
+    vi.mocked(mockConnection.extMethod).mockResolvedValue({
+      outcome: "rejected",
+      reason: "too complex",
+    });
+
+    const decision = await canUseToolCallback!({
+      toolName: "ExitPlanMode",
+      toolInput: {},
+      permissionMode: "plan",
+      planContent: "# Plan",
+    });
+
+    expect(decision.behavior).toBe("deny");
+    expect(decision.message).toBe("too complex");
+  });
+
+  it("should fall back to requestPermission when wave/create_plan extMethod fails", async () => {
+    let canUseToolCallback: PermissionCallback;
+    const mockWaveAgent = {
+      sessionId: "session-1",
+      getPermissionMode: vi.fn().mockReturnValue("default"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+    };
+    vi.mocked(WaveAgent.create).mockImplementation((options: AgentOptions) => {
+      canUseToolCallback = options.canUseTool as PermissionCallback;
+      return Promise.resolve(mockWaveAgent as unknown as WaveAgent);
+    });
+
+    await agent.newSession({ cwd: "/test", mcpServers: [] });
+
+    vi.mocked(mockConnection.extMethod).mockRejectedValue(
+      new Error("not implemented"),
+    );
+    vi.mocked(mockConnection.requestPermission).mockResolvedValue({
+      outcome: { outcome: "selected", optionId: "allow_once" },
+    } as unknown as RequestPermissionResponse);
+
+    const decision = await canUseToolCallback!({
+      toolName: "ExitPlanMode",
+      toolInput: {},
+      permissionMode: "plan",
+      planContent: "# Plan",
+    });
+
+    expect(decision.behavior).toBe("allow");
+    expect(decision.newPermissionMode).toBe("default");
+    expect(mockConnection.requestPermission).toHaveBeenCalled();
+  });
+
+  it("should populate taskCache and filter deleted tasks in onTasksChange", async () => {
+    let capturedCallbacks: AgentOptions["callbacks"];
+    const mockWaveAgent = {
+      sessionId: "session-1",
+      getPermissionMode: vi.fn().mockReturnValue("default"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+    };
+    vi.mocked(WaveAgent.create).mockImplementation((options: AgentOptions) => {
+      capturedCallbacks = options.callbacks;
+      return Promise.resolve(mockWaveAgent as unknown as WaveAgent);
+    });
+
+    await agent.newSession({ cwd: "/test", mcpServers: [] });
+
+    capturedCallbacks!.onTasksChange!([
+      {
+        id: "t1",
+        subject: "Task 1",
+        description: "",
+        status: "completed",
+        blocks: [],
+        blockedBy: [],
+        metadata: {},
+      },
+      {
+        id: "t2",
+        subject: "Task 2",
+        description: "",
+        status: "deleted",
+        blocks: [],
+        blockedBy: [],
+        metadata: {},
+      },
+      {
+        id: "t3",
+        subject: "Task 3",
+        description: "",
+        status: "in_progress",
+        blocks: [],
+        blockedBy: [],
+        metadata: {},
+      },
+      {
+        id: "t4",
+        subject: "Task 4",
+        description: "",
+        status: "pending",
+        blocks: [],
+        blockedBy: [],
+        metadata: {},
+      },
+    ]);
+
+    // Verify plan session update excludes deleted task
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          sessionUpdate: "plan",
+          entries: [
+            { content: "Task 1", status: "completed", priority: "medium" },
+            { content: "Task 3", status: "in_progress", priority: "medium" },
+            { content: "Task 4", status: "pending", priority: "medium" },
+          ],
+        }),
+      }),
+    );
+
+    // Verify taskCache is populated (test via handleCreatePlan using the cache)
+    vi.mocked(mockConnection.extMethod).mockResolvedValue({
+      outcome: "accepted",
+    });
+
+    let canUseToolCallback: PermissionCallback;
+    vi.mocked(WaveAgent.create).mockImplementation((options: AgentOptions) => {
+      canUseToolCallback = options.canUseTool as PermissionCallback;
+      return Promise.resolve(mockWaveAgent as unknown as WaveAgent);
+    });
+    await agent.newSession({ cwd: "/test", mcpServers: [] });
+
+    // Trigger onTasksChange again for the new session
+    capturedCallbacks!.onTasksChange!([
+      {
+        id: "t1",
+        subject: "Cached Task",
+        description: "",
+        status: "pending",
+        blocks: [],
+        blockedBy: [],
+        metadata: {},
+      },
+    ]);
+
+    const decision = await canUseToolCallback!({
+      toolName: "ExitPlanMode",
+      toolInput: {},
+      permissionMode: "plan",
+      planContent: "test plan",
+    });
+
+    expect(decision.behavior).toBe("allow");
+    expect(mockConnection.extMethod).toHaveBeenCalledWith(
+      "wave/create_plan",
+      expect.objectContaining({
+        todos: [{ id: "t1", content: "Cached Task", status: "pending" }],
       }),
     );
   });

--- a/specs/070-acp-bridge/data-model.md
+++ b/specs/070-acp-bridge/data-model.md
@@ -23,6 +23,47 @@ Tracks the state of a tool call for ACP reporting.
 | `parameters` | `object` | The input parameters for the tool. |
 | `result` | `any` | The output of the tool call. |
 
+## Entity: TaskCache
+
+Per-session cache of the latest task list, populated by `onTasksChange` and consumed by `wave/create_plan`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sessionId` | `string` | The session ID (Map key). |
+| `tasks` | `Task[]` | Current task list including deleted tasks (filtered at consumption time). |
+
+## Extension Method Payloads
+
+### `wave/ask_question` Request
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `toolCallId` | `string` | The tool call ID. |
+| `title` | `string?` | Optional title from the question header. |
+| `questions` | `Array` | Structured questions with id, prompt, options, allowMultiple. |
+
+### `wave/ask_question` Response
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `outcome` | `string` | `"answered"` or `"cancelled"`. |
+| `answers` | `Array` | When answered: array of `{ questionId, selectedOptionIds }`. |
+
+### `wave/create_plan` Request
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `toolCallId` | `string` | The tool call ID. |
+| `plan` | `string` | The plan content. |
+| `todos` | `Array` | Current tasks with id, content, status (excluding deleted). |
+
+### `wave/create_plan` Response
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `outcome` | `string` | `"accepted"`, `"rejected"`, or `"cancelled"`. |
+| `reason` | `string?` | When rejected: optional rejection reason. |
+
 ## State Transitions
 
 - **Initializing**: Connection established, waiting for `initialize` request.

--- a/specs/070-acp-bridge/quickstart.md
+++ b/specs/070-acp-bridge/quickstart.md
@@ -68,3 +68,42 @@ The ACP (Agent Control Protocol) bridge allows you to connect external clients, 
   }
 }
 ```
+
+## Extension Methods
+
+ACP clients can optionally implement `extMethod` to receive structured requests from the agent:
+
+### `wave/ask_question`
+
+Sent when the agent calls `AskUserQuestion`. Provides structured questions with options instead of empty permission options.
+
+**Client handler example:**
+```typescript
+extMethod: async (method, params) => {
+  if (method === "wave/ask_question") {
+    // Render questions UI and collect answers
+    return {
+      outcome: "answered",
+      answers: [{ questionId: "q0", selectedOptionIds: ["0"] }],
+    };
+  }
+  throw new Error(`Unknown method: ${method}`);
+},
+```
+
+### `wave/create_plan`
+
+Sent when the agent calls `ExitPlanMode`. Provides plan content and current task list for approval.
+
+**Client handler example:**
+```typescript
+extMethod: async (method, params) => {
+  if (method === "wave/create_plan") {
+    // Render plan approval UI
+    return { outcome: "accepted" };
+  }
+  throw new Error(`Unknown method: ${method}`);
+},
+```
+
+If the client does not implement `extMethod`, the agent falls back to the standard `requestPermission` mechanism.

--- a/specs/070-acp-bridge/research.md
+++ b/specs/070-acp-bridge/research.md
@@ -25,6 +25,13 @@ The bridge will implement the `canUseTool` callback in `WaveAgent.create`. When 
 #### 4. Streaming Updates
 The bridge will use the `callbacks` in `WaveAgent.create` to listen for assistant content chunks, reasoning chunks, and tool call updates. These will be forwarded to the client as `sessionUpdate` notifications.
 
+#### 5. Extension Methods
+The ACP SDK's `AgentSideConnection.extMethod()` API allows the agent to send custom requests to the client. Following Cursor's `cursor/` prefix convention, Wave uses `wave/`-prefixed extension methods:
+- `wave/ask_question`: Structured multi-choice questions for `AskUserQuestion` tool.
+- `wave/create_plan`: Plan approval with accept/reject for `ExitPlanMode` tool.
+
+Both methods gracefully fall back to the standard `requestPermission` mechanism if the client does not implement the `extMethod` handler, ensuring backwards compatibility with existing ACP clients.
+
 ### Alternatives Considered
 
 #### 1. MCP (Model Context Protocol)

--- a/specs/070-acp-bridge/spec.md
+++ b/specs/070-acp-bridge/spec.md
@@ -61,6 +61,20 @@ As an ACP client, I want to provide MCP server configurations when creating or l
 
 ---
 
+### User Story 5 - Extension Methods for Structured Interactions (Priority: P2)
+
+As an ACP client developer, I want to receive structured extension method calls for questions and plan approvals so that I can render proper UI instead of parsing permission options.
+
+**Why this priority**: Improves the client developer experience and enables richer UI interactions beyond the generic permission request mechanism.
+
+**Acceptance Scenarios**:
+
+1. **Given** the agent calls `AskUserQuestion`, **When** the client supports `wave/ask_question`, **Then** the client receives structured questions with options and returns selected answers.
+2. **Given** the agent calls `ExitPlanMode`, **When** the client supports `wave/create_plan`, **Then** the client receives plan content with todos and returns accept/reject.
+3. **Given** the client does not support an extension method, **When** the agent calls it, **Then** the agent falls back to the standard `requestPermission` mechanism.
+
+---
+
 ### Edge Cases
 
 - **Connection Closure**: If the ACP connection (stdio) is closed, the agent should clean up all active sessions and resources.

--- a/specs/070-acp-bridge/tasks.md
+++ b/specs/070-acp-bridge/tasks.md
@@ -30,3 +30,11 @@
 - [x] **Task 17**: Implement `resource_link` and `resource` block handling in `prompt` method.
 - [x] **Task 18**: Advertise `image` and `embeddedContext` in `promptCapabilities` during initialization.
 - [x] **Task 19**: Improve block joining in `prompt` method to preserve inline spacing.
+
+## Phase 5: Extension Methods (Completed)
+
+- [x] **Task 20**: Implement `wave/ask_question` extension method for `AskUserQuestion` tool calls with `requestPermission` fallback.
+- [x] **Task 21**: Implement `wave/create_plan` extension method for `ExitPlanMode` tool calls with `requestPermission` fallback.
+- [x] **Task 22**: Add task cache to `onTasksChange` and fix plan mapping bug (filter out deleted tasks).
+- [x] **Task 23**: Update ACP examples with `extMethod` client handlers.
+- [x] **Task 24**: Add tests for extension methods and fallback behavior.


### PR DESCRIPTION
Replace hacky requestPermission usage for AskUserQuestion and ExitPlanMode
with dedicated ACP extension methods using connection.extMethod() API.

- wave/ask_question: structured multi-choice questions with graceful fallback
- wave/create_plan: plan approval with accept/reject and task list
- Add taskCache populated by onTasksChange for create_plan context
- Fix plan mapping bug: filter out deleted tasks from session updates
- Update examples with extMethod client handlers
- Add 6 tests covering success, fallback, and cache behavior
- Update specs/070-acp-bridge docs (spec, tasks, research, data-model, quickstart)
