### PR TITLE
feat: Claude Code ecosystem compatibility (.claude/ fallback support)

### DIFF
--- a/packages/agent-sdk/src/managers/MemoryRuleManager.ts
+++ b/packages/agent-sdk/src/managers/MemoryRuleManager.ts
@@ -39,23 +39,26 @@ export class MemoryRuleManager {
    * Scans .wave/rules and ~/.wave/rules for memory rule files.
    */
   async discoverRules(): Promise<void> {
-    const projectRulesDir = path.join(this.workdir, ".wave", "rules");
-    const userRulesDir = path.join(os.homedir(), ".wave", "rules");
+    const projectWaveRulesDir = path.join(this.workdir, ".wave", "rules");
+    const projectClaudeRulesDir = path.join(this.workdir, ".claude", "rules");
+    const userWaveRulesDir = path.join(os.homedir(), ".wave", "rules");
+    const userClaudeRulesDir = path.join(os.homedir(), ".claude", "rules");
 
     logger.debug(`Scanning for modular memory rules...`);
-    logger.debug(`  User rules directory: ${userRulesDir}`);
-    logger.debug(`  Project rules directory: ${projectRulesDir}`);
+    logger.debug(`  User rules directory: ${userWaveRulesDir}`);
+    logger.debug(`  Project rules directory: ${projectWaveRulesDir}`);
 
     const newRules: Record<string, MemoryRule> = {};
 
-    // Discover user rules first, then project rules so project rules can override if needed
-    // (though IDs are based on file path, so they shouldn't collide unless same path)
-    await this.scanDirectory(userRulesDir, "user", newRules);
-    await this.scanDirectory(projectRulesDir, "project", newRules);
+    // Scan order: userClaude → userWave → projectClaude → projectWave
+    // Later writes override, so .wave takes priority over .claude
+    await this.scanDirectory(userClaudeRulesDir, "user", newRules);
+    await this.scanDirectory(userWaveRulesDir, "user", newRules);
+    await this.scanDirectory(projectClaudeRulesDir, "project", newRules);
+    await this.scanDirectory(projectWaveRulesDir, "project", newRules);
 
     this.state.rules = newRules;
     const ruleCount = Object.keys(newRules).length;
-    // Removed verbose logging of all discovered rules
     logger.debug(`Discovered ${ruleCount} modular memory rules`);
   }
 
@@ -124,11 +127,23 @@ export class MemoryRuleManager {
     try {
       const content = await fs.readFile(filePath, "utf-8");
       const rule = this.service.parseRule(content, filePath, source);
-      // Use relative path from rules root as ID to allow project rules to override user rules
-      const rulesRoot =
-        source === "project"
-          ? path.join(this.workdir, ".wave", "rules")
-          : path.join(os.homedir(), ".wave", "rules");
+
+      // Determine rulesRoot dynamically based on actual file path
+      let rulesRoot: string;
+      if (source === "project") {
+        if (filePath.includes(path.join(".claude", "rules"))) {
+          rulesRoot = path.join(this.workdir, ".claude", "rules");
+        } else {
+          rulesRoot = path.join(this.workdir, ".wave", "rules");
+        }
+      } else {
+        if (filePath.includes(path.join(".claude", "rules"))) {
+          rulesRoot = path.join(os.homedir(), ".claude", "rules");
+        } else {
+          rulesRoot = path.join(os.homedir(), ".wave", "rules");
+        }
+      }
+
       const relativeId = path.relative(rulesRoot, filePath);
       rule.id = relativeId;
       registry[rule.id] = rule;

--- a/packages/agent-sdk/src/managers/hookManager.ts
+++ b/packages/agent-sdk/src/managers/hookManager.ts
@@ -183,14 +183,19 @@ export class HookManager {
                 env: {
                   ...("env" in context ? (context.env ?? {}) : {}),
                   WAVE_PLUGIN_ROOT: hookCommand.pluginRoot,
+                  CLAUDE_PLUGIN_ROOT: hookCommand.pluginRoot,
                 },
               }
             : context;
 
-          // Substitute ${WAVE_PLUGIN_ROOT} in the command string (same pattern as Claude Code)
+          // Substitute ${WAVE_PLUGIN_ROOT} and ${CLAUDE_PLUGIN_ROOT} in the command string
           if (hookCommand.pluginRoot) {
             command = command.replace(
               /\$\{WAVE_PLUGIN_ROOT\}/g,
+              hookCommand.pluginRoot,
+            );
+            command = command.replace(
+              /\$\{CLAUDE_PLUGIN_ROOT\}/g,
               hookCommand.pluginRoot,
             );
           }

--- a/packages/agent-sdk/src/managers/lspManager.ts
+++ b/packages/agent-sdk/src/managers/lspManager.ts
@@ -92,22 +92,40 @@ export class LspManager implements ILspManager {
     try {
       const env = { ...process.env, ...config.env };
 
-      // For plugin servers, substitute ${WAVE_PLUGIN_ROOT} in command/args/env
+      // For plugin servers, substitute ${WAVE_PLUGIN_ROOT} and ${CLAUDE_PLUGIN_ROOT}
       let command = config.command;
       let args = config.args || [];
       if (config.pluginRoot) {
         env.WAVE_PLUGIN_ROOT = config.pluginRoot;
+        env.CLAUDE_PLUGIN_ROOT = config.pluginRoot;
         command = command.replace(/\$\{WAVE_PLUGIN_ROOT\}/g, config.pluginRoot);
-        args = args.map((arg) =>
-          arg.replace(/\$\{WAVE_PLUGIN_ROOT\}/g, config.pluginRoot!),
+        command = command.replace(
+          /\$\{CLAUDE_PLUGIN_ROOT\}/g,
+          config.pluginRoot,
         );
-        // Also expand WAVE_PLUGIN_ROOT in user-provided env values
+        args = args.map((arg) => {
+          let result = arg.replace(
+            /\$\{WAVE_PLUGIN_ROOT\}/g,
+            config.pluginRoot!,
+          );
+          result = result.replace(
+            /\$\{CLAUDE_PLUGIN_ROOT\}/g,
+            config.pluginRoot!,
+          );
+          return result;
+        });
+        // Also expand plugin root in user-provided env values
         if (config.env) {
           for (const [key, value] of Object.entries(config.env)) {
-            env[key] = value.replace(
+            let expanded = value.replace(
               /\$\{WAVE_PLUGIN_ROOT\}/g,
               config.pluginRoot!,
             );
+            expanded = expanded.replace(
+              /\$\{CLAUDE_PLUGIN_ROOT\}/g,
+              config.pluginRoot!,
+            );
+            env[key] = expanded;
           }
         }
       }

--- a/packages/agent-sdk/src/managers/mcpManager.ts
+++ b/packages/agent-sdk/src/managers/mcpManager.ts
@@ -40,7 +40,7 @@ export interface McpManagerOptions {
  * Expand environment variables in a string value.
  * Supports ${VAR} and ${VAR:-default} patterns.
  */
-const WAVE_TEMPLATE_VARS = ["WAVE_PLUGIN_ROOT"];
+const WAVE_TEMPLATE_VARS = ["WAVE_PLUGIN_ROOT", "CLAUDE_PLUGIN_ROOT"];
 
 export function expandEnvVars(value: string): string {
   return value.replace(/\$\{([^}]+)\}/g, (_match, expr: string) => {
@@ -440,25 +440,42 @@ export class McpManager {
           ...(server.config.env || {}),
         };
 
-        // For plugin servers, substitute ${WAVE_PLUGIN_ROOT} in command/args/env
-        // (same pattern as Claude Code's substitutePluginVariables)
+        // For plugin servers, substitute ${WAVE_PLUGIN_ROOT} and ${CLAUDE_PLUGIN_ROOT}
         let command = server.config.command;
         let args = server.config.args || [];
         if (server.config.pluginRoot) {
           env.WAVE_PLUGIN_ROOT = server.config.pluginRoot;
+          env.CLAUDE_PLUGIN_ROOT = server.config.pluginRoot;
           command = command.replace(
             /\$\{WAVE_PLUGIN_ROOT\}/g,
             server.config.pluginRoot,
           );
-          args = args.map((arg) =>
-            arg.replace(/\$\{WAVE_PLUGIN_ROOT\}/g, server.config.pluginRoot!),
+          command = command.replace(
+            /\$\{CLAUDE_PLUGIN_ROOT\}/g,
+            server.config.pluginRoot,
           );
-          // Also expand WAVE_PLUGIN_ROOT in user-provided env values
-          for (const [key, value] of Object.entries(server.config.env || {})) {
-            env[key] = value.replace(
+          args = args.map((arg) => {
+            let result = arg.replace(
               /\$\{WAVE_PLUGIN_ROOT\}/g,
               server.config.pluginRoot!,
             );
+            result = result.replace(
+              /\$\{CLAUDE_PLUGIN_ROOT\}/g,
+              server.config.pluginRoot!,
+            );
+            return result;
+          });
+          // Also expand plugin root in user-provided env values
+          for (const [key, value] of Object.entries(server.config.env || {})) {
+            let expanded = value.replace(
+              /\$\{WAVE_PLUGIN_ROOT\}/g,
+              server.config.pluginRoot!,
+            );
+            expanded = expanded.replace(
+              /\$\{CLAUDE_PLUGIN_ROOT\}/g,
+              server.config.pluginRoot!,
+            );
+            env[key] = expanded;
           }
         }
         transport = new StdioClientTransport({

--- a/packages/agent-sdk/src/managers/skillManager.ts
+++ b/packages/agent-sdk/src/managers/skillManager.ts
@@ -29,6 +29,7 @@ import { logger } from "../utils/globalLogger.js";
  */
 export class SkillManager extends EventEmitter {
   private personalSkillsPath: string;
+  private personalClaudeSkillsPath: string;
   private scanTimeout: number;
   private workdir: string;
 
@@ -47,6 +48,8 @@ export class SkillManager extends EventEmitter {
     super();
     this.personalSkillsPath =
       options.personalSkillsPath || join(homedir(), ".wave", "skills");
+    this.personalClaudeSkillsPath =
+      options.personalClaudeSkillsPath || join(homedir(), ".claude", "skills");
     this.scanTimeout = options.scanTimeout || 5000;
     this.workdir = options.workdir || process.cwd();
     this.watchEnabled = options.watch ?? false;
@@ -127,7 +130,9 @@ export class SkillManager extends EventEmitter {
 
     const pathsToWatch = [
       this.personalSkillsPath,
+      this.personalClaudeSkillsPath,
       join(this.workdir, ".wave", "skills"),
+      join(this.workdir, ".claude", "skills"),
     ];
 
     logger?.debug(`Setting up skill watcher for: ${pathsToWatch.join(", ")}`);
@@ -220,6 +225,11 @@ export class SkillManager extends EventEmitter {
       "builtin",
     );
 
+    const personalClaudeCollection = await this.discoverSkillCollection(
+      this.personalClaudeSkillsPath,
+      "personal",
+    );
+
     const personalCollection = await this.discoverSkillCollection(
       this.personalSkillsPath,
       "personal",
@@ -232,10 +242,14 @@ export class SkillManager extends EventEmitter {
 
     return {
       builtinSkills: builtinCollection.skills,
-      personalSkills: personalCollection.skills,
+      personalSkills: new Map([
+        ...personalClaudeCollection.skills,
+        ...personalCollection.skills, // .wave overrides .claude
+      ]),
       projectSkills: projectCollection.skills,
       errors: [
         ...builtinCollection.errors,
+        ...personalClaudeCollection.errors,
         ...personalCollection.errors,
         ...projectCollection.errors,
       ],
@@ -256,77 +270,88 @@ export class SkillManager extends EventEmitter {
       errors: [],
     };
 
-    let skillsPath: string;
-    if (type === "personal") {
-      skillsPath = basePath;
-    } else if (type === "builtin") {
-      skillsPath = basePath;
+    if (type === "project") {
+      // Scan .claude/skills first, then .wave/skills (wave overrides)
+      const claudePath = join(basePath, ".claude", "skills");
+      const wavePath = join(basePath, ".wave", "skills");
+      await this.scanSkillPath(claudePath, collection);
+      await this.scanSkillPath(wavePath, collection);
     } else {
-      skillsPath = join(basePath, ".wave", "skills");
+      await this.scanSkillPath(basePath, collection);
     }
 
+    return collection;
+  }
+
+  private async scanSkillPath(
+    skillsPath: string,
+    collection: SkillCollection,
+  ): Promise<void> {
     try {
       const skillDirs = await this.findSkillDirectories(skillsPath);
       logger?.debug(
         `Found ${skillDirs.length} potential skill directories in ${skillsPath}`,
       );
-
-      for (const skillDir of skillDirs) {
-        try {
-          const skillFilePath = join(skillDir, "SKILL.md");
-
-          // Check if SKILL.md exists
-          try {
-            await stat(skillFilePath);
-          } catch {
-            continue; // Skip directories without SKILL.md
-          }
-
-          const parsed = parseSkillFile(skillFilePath, {
-            basePath: skillDir,
-            validateMetadata: true,
-          });
-
-          if (parsed.isValid) {
-            // Override the skill type with the collection type
-            const skillMetadata: SkillMetadata = {
-              ...parsed.skillMetadata,
-              type,
-            };
-
-            // Create full skill object with content
-            const skill: Skill = {
-              ...skillMetadata,
-              content: parsed.content,
-              frontmatter: parsed.frontmatter,
-              isValid: parsed.isValid,
-              errors: parsed.validationErrors,
-            };
-
-            collection.skills.set(skillMetadata.name, skillMetadata);
-            // Store the full skill content in the manager's skillContent map
-            this.skillContent.set(skillMetadata.name, skill);
-          } else {
-            collection.errors.push({
-              skillPath: skillDir,
-              message: parsed.validationErrors.join("; "),
-            });
-          }
-        } catch (error) {
-          collection.errors.push({
-            skillPath: skillDir,
-            message: `Failed to process skill: ${error instanceof Error ? error.message : String(error)}`,
-          });
-        }
-      }
+      await this.processSkillDirs(skillDirs, collection);
     } catch (error) {
       logger?.debug(
         `Could not scan ${skillsPath}: ${error instanceof Error ? error.message : String(error)}`,
       );
-      // Not an error - the directory might not exist yet
     }
+  }
 
-    return collection;
+  private async processSkillDirs(
+    skillDirs: string[],
+    collection: SkillCollection,
+  ): Promise<void> {
+    for (const skillDir of skillDirs) {
+      try {
+        const skillFilePath = join(skillDir, "SKILL.md");
+
+        // Check if SKILL.md exists
+        try {
+          await stat(skillFilePath);
+        } catch {
+          continue; // Skip directories without SKILL.md
+        }
+
+        const parsed = parseSkillFile(skillFilePath, {
+          basePath: skillDir,
+          validateMetadata: true,
+        });
+
+        if (parsed.isValid) {
+          // Override the skill type with the collection type
+          const skillMetadata: SkillMetadata = {
+            ...parsed.skillMetadata,
+            type: collection.type,
+          };
+
+          // Create full skill object with content
+          const skill: Skill = {
+            ...skillMetadata,
+            content: parsed.content,
+            frontmatter: parsed.frontmatter,
+            isValid: parsed.isValid,
+            errors: parsed.validationErrors,
+          };
+
+          collection.skills.set(skillMetadata.name, skillMetadata);
+          // Store the full skill content in the manager's skillContent map
+          this.skillContent.set(skillMetadata.name, skill);
+        } else {
+          collection.errors.push({
+            skillPath: skillDir,
+            message: parsed.validationErrors.join("; "),
+          });
+        }
+      } catch (error) {
+        collection.errors.push({
+          skillPath: skillDir,
+          message: `Failed to process skill: ${error instanceof Error ? error.message : String(error)}`,
+        });
+      }
+    }
   }
 
   /**
@@ -450,13 +475,21 @@ export class SkillManager extends EventEmitter {
     // 1. Substitute parameters ($1, $ARGUMENTS, etc.)
     mainContent = substituteCommandParameters(mainContent, argsString);
 
-    // 2. Substitute ${WAVE_SKILL_DIR} with the skill's directory path
+    // 2. Substitute ${WAVE_SKILL_DIR} and ${CLAUDE_SKILL_DIR}
     mainContent = mainContent.replace(/\$\{WAVE_SKILL_DIR\}/g, skill.skillPath);
+    mainContent = mainContent.replace(
+      /\$\{CLAUDE_SKILL_DIR\}/g,
+      skill.skillPath,
+    );
 
-    // 3. Substitute ${WAVE_PLUGIN_ROOT} with the skill's plugin root path
+    // 3. Substitute ${WAVE_PLUGIN_ROOT} and ${CLAUDE_PLUGIN_ROOT}
     if (skill.pluginRoot) {
       mainContent = mainContent.replace(
         /\$\{WAVE_PLUGIN_ROOT\}/g,
+        skill.pluginRoot,
+      );
+      mainContent = mainContent.replace(
+        /\$\{CLAUDE_PLUGIN_ROOT\}/g,
         skill.pluginRoot,
       );
     }

--- a/packages/agent-sdk/src/services/MarketplaceService.ts
+++ b/packages/agent-sdk/src/services/MarketplaceService.ts
@@ -390,13 +390,21 @@ export class MarketplaceService {
   async loadMarketplaceManifest(
     marketplacePath: string,
   ): Promise<MarketplaceManifest> {
-    const manifestPath = path.join(
+    let manifestPath = path.join(
       marketplacePath,
       ".wave-plugin",
       "marketplace.json",
     );
     if (!existsSync(manifestPath)) {
-      throw new Error(`Marketplace manifest not found at ${manifestPath}`);
+      // Fallback to .claude-plugin/marketplace.json
+      manifestPath = path.join(
+        marketplacePath,
+        ".claude-plugin",
+        "marketplace.json",
+      );
+      if (!existsSync(manifestPath)) {
+        throw new Error(`Marketplace manifest not found at ${manifestPath}`);
+      }
     }
     const content = await fs.readFile(manifestPath, "utf-8");
     const manifest = JSON.parse(content);
@@ -899,13 +907,23 @@ export class MarketplaceService {
           pluginSrcPath = path.resolve(marketplacePath, pluginEntry.source);
         }
 
-        const pluginManifestPath = path.join(
+        let pluginManifestPath = path.join(
           pluginSrcPath,
           ".wave-plugin",
           "plugin.json",
         );
         if (!existsSync(pluginManifestPath)) {
-          throw new Error(`Plugin manifest not found at ${pluginManifestPath}`);
+          // Fallback to .claude-plugin/plugin.json
+          pluginManifestPath = path.join(
+            pluginSrcPath,
+            ".claude-plugin",
+            "plugin.json",
+          );
+          if (!existsSync(pluginManifestPath)) {
+            throw new Error(
+              `Plugin manifest not found at ${pluginManifestPath}`,
+            );
+          }
         }
 
         const pluginManifestContent = await fs.readFile(

--- a/packages/agent-sdk/src/services/memory.ts
+++ b/packages/agent-sdk/src/services/memory.ts
@@ -130,6 +130,27 @@ export class MemoryService {
         userMemoryFile: USER_MEMORY_FILE,
         contentLength: content.length,
       });
+
+      // If the file is still the default empty template, fallback to ~/.claude/AGENTS.md
+      const defaultTemplate =
+        "# User Memory\n\nThis is the user-level memory file, recording important information and context across projects.\n\n";
+      if (content === defaultTemplate) {
+        const claudeMemoryPath = path.join(homedir(), ".claude", "AGENTS.md");
+        try {
+          const claudeContent = await fs.readFile(claudeMemoryPath, "utf-8");
+          logger.debug(
+            "User memory content read from ~/.claude/AGENTS.md fallback",
+            {
+              claudeMemoryPath,
+              contentLength: claudeContent.length,
+            },
+          );
+          return claudeContent;
+        } catch {
+          // CLAUDE.md doesn't exist or can't be read, return the default template
+        }
+      }
+
       return content;
     } catch (error) {
       logger.error("Failed to read user memory:", error);
@@ -139,8 +160,6 @@ export class MemoryService {
 
   async readMemoryFile(workdir: string): Promise<string> {
     const memoryFilePath = path.join(workdir, "AGENTS.md");
-
-    // Direct file access
     try {
       const content = await fs.readFile(memoryFilePath, "utf-8");
       logger.debug("Memory file read successfully via direct file access", {
@@ -150,10 +169,28 @@ export class MemoryService {
       return content;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-        logger.debug("Memory file does not exist, returning empty content", {
-          memoryFilePath,
-        });
-        return "";
+        // Fallback to CLAUDE.md
+        const claudeMemoryPath = path.join(workdir, "CLAUDE.md");
+        try {
+          const content = await fs.readFile(claudeMemoryPath, "utf-8");
+          logger.debug("Memory file read from CLAUDE.md fallback", {
+            memoryFilePath: claudeMemoryPath,
+            contentLength: content.length,
+          });
+          return content;
+        } catch (claudeError) {
+          if ((claudeError as NodeJS.ErrnoException).code === "ENOENT") {
+            logger.debug("Neither AGENTS.md nor CLAUDE.md found", {
+              memoryFilePath,
+            });
+            return "";
+          }
+          logger.error("Failed to read CLAUDE.md fallback", {
+            memoryFilePath: claudeMemoryPath,
+            error: claudeError,
+          });
+          return "";
+        }
       }
       logger.error("Failed to read memory file", { memoryFilePath, error });
       return "";

--- a/packages/agent-sdk/src/services/pluginLoader.ts
+++ b/packages/agent-sdk/src/services/pluginLoader.ts
@@ -23,11 +23,13 @@ export class PluginLoader {
    */
   static async loadManifest(pluginPath: string): Promise<PluginManifest> {
     const dotWavePluginPath = path.join(pluginPath, ".wave-plugin");
-    const manifestPath = path.join(dotWavePluginPath, "plugin.json");
 
-    // T018: Ensure plugin.json is the only file in .wave-plugin/
+    // Check if .wave-plugin/ directory exists
+    let wavePluginDirExists = false;
     try {
       const entries = await fs.readdir(dotWavePluginPath);
+      wavePluginDirExists = true;
+      // T018: Ensure plugin.json is the only file in .wave-plugin/
       const misplaced = entries.filter((e) => e !== "plugin.json");
       if (misplaced.length > 0) {
         throw new Error(
@@ -39,15 +41,39 @@ export class PluginLoader {
         error instanceof Error &&
         (error as { code?: string }).code === "ENOENT"
       ) {
-        throw new Error(
-          `Plugin manifest directory not found at ${dotWavePluginPath}`,
-        );
+        // .wave-plugin/ doesn't exist, will try .claude-plugin/ fallback below
+      } else {
+        throw error;
       }
-      throw error;
     }
 
+    if (wavePluginDirExists) {
+      const manifestPath = path.join(dotWavePluginPath, "plugin.json");
+      try {
+        const content = await fs.readFile(manifestPath, "utf-8");
+        const manifest = JSON.parse(content) as PluginManifest;
+        this.validateManifest(manifest);
+        return manifest;
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          (error as { code?: string }).code === "ENOENT"
+        ) {
+          throw new Error(`Plugin manifest not found at ${manifestPath}`);
+        }
+        throw new Error(
+          `Failed to load plugin manifest at ${manifestPath}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+
+    // Fallback to .claude-plugin/
+    const dotClaudePluginPath = path.join(pluginPath, ".claude-plugin");
+    const claudeManifestPath = path.join(dotClaudePluginPath, "plugin.json");
     try {
-      const content = await fs.readFile(manifestPath, "utf-8");
+      const content = await fs.readFile(claudeManifestPath, "utf-8");
       const manifest = JSON.parse(content) as PluginManifest;
       this.validateManifest(manifest);
       return manifest;
@@ -56,10 +82,12 @@ export class PluginLoader {
         error instanceof Error &&
         (error as { code?: string }).code === "ENOENT"
       ) {
-        throw new Error(`Plugin manifest not found at ${manifestPath}`);
+        throw new Error(
+          `Plugin manifest not found at ${dotWavePluginPath} or ${dotClaudePluginPath}`,
+        );
       }
       throw new Error(
-        `Failed to load plugin manifest at ${manifestPath}: ${
+        `Failed to load plugin manifest at ${claudeManifestPath}: ${
           error instanceof Error ? error.message : String(error)
         }`,
       );

--- a/packages/agent-sdk/src/types/skills.ts
+++ b/packages/agent-sdk/src/types/skills.ts
@@ -73,6 +73,7 @@ export interface SkillToolArgs {
 
 export interface SkillManagerOptions {
   personalSkillsPath?: string;
+  personalClaudeSkillsPath?: string;
   scanTimeout?: number;
   workdir?: string;
   watch?: boolean;

--- a/packages/agent-sdk/src/utils/customCommands.ts
+++ b/packages/agent-sdk/src/utils/customCommands.ts
@@ -70,21 +70,26 @@ export function scanCommandsDirectory(dirPath: string): CustomSlashCommand[] {
  * Load all custom slash commands from both project and user directories
  */
 export function loadCustomSlashCommands(workdir: string): CustomSlashCommand[] {
-  const projectCommands = scanCommandsDirectory(getProjectCommandsDir(workdir));
-  const userCommands = scanCommandsDirectory(getUserCommandsDir());
+  const userClaudeCommands = scanCommandsDirectory(
+    join(homedir(), ".claude", "commands"),
+  );
+  const userWaveCommands = scanCommandsDirectory(getUserCommandsDir());
+  const projectClaudeCommands = scanCommandsDirectory(
+    join(workdir, ".claude", "commands"),
+  );
+  const projectWaveCommands = scanCommandsDirectory(
+    getProjectCommandsDir(workdir),
+  );
 
-  // Project commands take precedence over user commands with the same name
   const commandMap = new Map<string, CustomSlashCommand>();
-
-  // Add user commands first
-  for (const command of userCommands) {
+  // Write in priority order: lowest first, highest last (overwrites)
+  for (const command of [
+    ...userClaudeCommands,
+    ...userWaveCommands,
+    ...projectClaudeCommands,
+    ...projectWaveCommands,
+  ]) {
     commandMap.set(command.id, command);
   }
-
-  // Add project commands (will overwrite user commands with same name)
-  for (const command of projectCommands) {
-    commandMap.set(command.id, command);
-  }
-
   return Array.from(commandMap.values());
 }

--- a/packages/agent-sdk/src/utils/skillParser.ts
+++ b/packages/agent-sdk/src/utils/skillParser.ts
@@ -55,7 +55,9 @@ export function parseSkillFile(
     const skillPath = basePath || dirname(filePath);
     const skillType =
       skillPath.includes("/.wave/skills") ||
-      skillPath.includes("\\.wave\\skills")
+      skillPath.includes("\\.wave\\skills") ||
+      skillPath.includes("/.claude/skills") ||
+      skillPath.includes("\\.claude\\skills")
         ? "project"
         : "personal";
 

--- a/packages/agent-sdk/src/utils/subagentParser.ts
+++ b/packages/agent-sdk/src/utils/subagentParser.ts
@@ -230,20 +230,34 @@ function scanSubagentDirectory(
 export async function loadSubagentConfigurations(
   workdir: string,
 ): Promise<SubagentConfiguration[]> {
-  const projectDir = join(workdir, ".wave", "agents");
-  const userDir = join(process.env.HOME || "~", ".wave", "agents");
+  const projectWaveDir = join(workdir, ".wave", "agents");
+  const projectClaudeDir = join(workdir, ".claude", "agents");
+  const userWaveDir = join(process.env.HOME || "~", ".wave", "agents");
+  const userClaudeDir = join(process.env.HOME || "~", ".claude", "agents");
   const builtinDir = getBuiltinSubagentsDir();
 
   // Load configurations from all sources
   const builtinConfigs = scanSubagentDirectory(builtinDir, "builtin");
-  const projectConfigs = scanSubagentDirectory(projectDir, "project");
-  const userConfigs = scanSubagentDirectory(userDir, "user");
+  const userClaudeConfigs = scanSubagentDirectory(userClaudeDir, "user");
+  const userWaveConfigs = scanSubagentDirectory(userWaveDir, "user");
+  const projectClaudeConfigs = scanSubagentDirectory(
+    projectClaudeDir,
+    "project",
+  );
+  const projectWaveConfigs = scanSubagentDirectory(projectWaveDir, "project");
 
-  // Merge configurations, with project configs taking highest precedence
+  // Merge configurations, with .wave taking priority over .claude
   const configMap = new Map<string, SubagentConfiguration>();
 
-  // Process in reverse priority order (built-in first, then user, then project)
-  for (const config of [...builtinConfigs, ...userConfigs, ...projectConfigs]) {
+  // Merge order: builtin → userClaude → userWave → projectClaude → projectWave
+  // Later writes override earlier ones, so .wave takes priority over .claude
+  for (const config of [
+    ...builtinConfigs,
+    ...userClaudeConfigs,
+    ...userWaveConfigs,
+    ...projectClaudeConfigs,
+    ...projectWaveConfigs,
+  ]) {
     configMap.set(config.name, config);
   }
 

--- a/packages/agent-sdk/tests/MemoryRuleManager.test.ts
+++ b/packages/agent-sdk/tests/MemoryRuleManager.test.ts
@@ -171,5 +171,102 @@ describe("MemoryRuleManager", () => {
 
       parseRuleSpy.mockRestore();
     });
+
+    it("should discover rules from .claude/rules at project and user level", async () => {
+      const projectClaudeRulesDir = path.join(workdir, ".claude", "rules");
+      const userClaudeRulesDir = path.join(homedir, ".claude", "rules");
+
+      vi.mocked(fs.readdir).mockImplementation(async (dir) => {
+        if (dir === userClaudeRulesDir) {
+          return [
+            { isFile: () => true, name: "claude-user-rule.md" },
+          ] as unknown as Awaited<ReturnType<typeof fs.readdir>>;
+        }
+        if (dir === projectClaudeRulesDir) {
+          return [
+            { isFile: () => true, name: "claude-project-rule.md" },
+          ] as unknown as Awaited<ReturnType<typeof fs.readdir>>;
+        }
+        return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>;
+      });
+
+      vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
+        if (
+          typeof filePath === "string" &&
+          filePath.includes("claude-user-rule.md")
+        ) {
+          return "User claude rule content";
+        }
+        if (
+          typeof filePath === "string" &&
+          filePath.includes("claude-project-rule.md")
+        ) {
+          return "Project claude rule content";
+        }
+        return "";
+      });
+
+      await manager.discoverRules();
+
+      const rules = manager.getActiveRules([]);
+      expect(rules).toHaveLength(2);
+
+      const userRule = rules.find((r) => r.source === "user");
+      expect(userRule?.content).toBe("User claude rule content");
+
+      const projectRule = rules.find((r) => r.source === "project");
+      expect(projectRule?.content).toBe("Project claude rule content");
+    });
+
+    it("should let .wave/rules override .claude/rules for same-named rule", async () => {
+      const projectClaudeRulesDir = path.join(workdir, ".claude", "rules");
+      const projectWaveRulesDir = path.join(workdir, ".wave", "rules");
+
+      vi.mocked(fs.readdir).mockImplementation(async (dir) => {
+        if (dir === projectClaudeRulesDir || dir === projectWaveRulesDir) {
+          return [
+            { isFile: () => true, name: "common.md" },
+          ] as unknown as Awaited<ReturnType<typeof fs.readdir>>;
+        }
+        return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>;
+      });
+
+      vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
+        if (
+          typeof filePath === "string" &&
+          filePath.includes(projectClaudeRulesDir)
+        )
+          return "Claude version";
+        if (
+          typeof filePath === "string" &&
+          filePath.includes(projectWaveRulesDir)
+        )
+          return "Wave version";
+        return "";
+      });
+
+      const { MemoryRuleService } = await import(
+        "../src/services/MemoryRuleService.js"
+      );
+      const parseRuleSpy = vi.spyOn(MemoryRuleService.prototype, "parseRule");
+      parseRuleSpy.mockImplementation((content, filePath, source) => {
+        return {
+          id: "common.md",
+          content: content.trim(),
+          metadata: {},
+          source,
+          filePath,
+        };
+      });
+
+      await manager.discoverRules();
+
+      const rules = manager.getActiveRules([]);
+      expect(rules).toHaveLength(1);
+      expect(rules[0].source).toBe("project");
+      expect(rules[0].content).toBe("Wave version");
+
+      parseRuleSpy.mockRestore();
+    });
   });
 });

--- a/packages/agent-sdk/tests/managers/mcpManager.test.ts
+++ b/packages/agent-sdk/tests/managers/mcpManager.test.ts
@@ -836,6 +836,7 @@ describe("McpManager", () => {
         env: {
           ...process.env,
           WAVE_PLUGIN_ROOT: "/path/to/plugin",
+          CLAUDE_PLUGIN_ROOT: "/path/to/plugin",
         },
         cwd: "/test/workdir",
         stderr: "pipe",
@@ -858,6 +859,7 @@ describe("McpManager", () => {
         env: {
           ...process.env,
           WAVE_PLUGIN_ROOT: "/path/to/plugin",
+          CLAUDE_PLUGIN_ROOT: "/path/to/plugin",
         },
         cwd: "/test/workdir",
         stderr: "pipe",
@@ -884,6 +886,7 @@ describe("McpManager", () => {
         env: {
           ...process.env,
           WAVE_PLUGIN_ROOT: "/path/to/plugin",
+          CLAUDE_PLUGIN_ROOT: "/path/to/plugin",
           CONFIG_PATH: "/path/to/plugin/config/server.json",
           OTHER_VAR: "static-value",
         },

--- a/packages/agent-sdk/tests/managers/skillManager.test.ts
+++ b/packages/agent-sdk/tests/managers/skillManager.test.ts
@@ -971,4 +971,171 @@ describe("SkillManager", () => {
       await manager.destroy();
     });
   });
+
+  describe("Claude ecosystem compatibility", () => {
+    it("should discover skills from .claude/skills at project level", async () => {
+      const manager = new SkillManager(container, {
+        workdir: "/test/workdir",
+      });
+
+      vi.mocked(readdir).mockImplementation(async (path) => {
+        const p = path.toString();
+        if (p === "/test/workdir/.claude/skills") {
+          return [
+            { name: "claude-skill", isDirectory: () => true },
+          ] as unknown as Awaited<ReturnType<typeof readdir>>;
+        }
+        return [] as unknown as Awaited<ReturnType<typeof readdir>>;
+      });
+
+      vi.mocked(stat).mockResolvedValue(
+        {} as unknown as Awaited<ReturnType<typeof stat>>,
+      );
+
+      vi.mocked(parseSkillFile).mockReturnValue({
+        isValid: true,
+        skillMetadata: {
+          name: "claude-skill",
+          description: "from claude",
+          type: "project",
+          skillPath: "/test/workdir/.claude/skills/claude-skill",
+        },
+        content: "---\nname: claude-skill\n---\ncontent",
+        frontmatter: { name: "claude-skill" },
+        validationErrors: [],
+      } as unknown as ReturnType<typeof parseSkillFile>);
+
+      await manager.initialize();
+
+      const skills = manager.getAvailableSkills();
+      expect(skills.find((s) => s.name === "claude-skill")).toBeDefined();
+
+      await manager.destroy();
+    });
+
+    it("should discover skills from .claude/skills at personal level", async () => {
+      const manager = new SkillManager(container, {
+        workdir: "/test/workdir",
+        personalClaudeSkillsPath: "/home/user/.claude/skills",
+      });
+
+      vi.mocked(readdir).mockImplementation(async (path) => {
+        const p = path.toString();
+        if (p === "/home/user/.claude/skills") {
+          return [
+            { name: "personal-claude-skill", isDirectory: () => true },
+          ] as unknown as Awaited<ReturnType<typeof readdir>>;
+        }
+        return [] as unknown as Awaited<ReturnType<typeof readdir>>;
+      });
+
+      vi.mocked(stat).mockResolvedValue(
+        {} as unknown as Awaited<ReturnType<typeof stat>>,
+      );
+
+      vi.mocked(parseSkillFile).mockReturnValue({
+        isValid: true,
+        skillMetadata: {
+          name: "personal-claude-skill",
+          description: "from personal claude",
+          type: "personal",
+          skillPath: "/home/user/.claude/skills/personal-claude-skill",
+        },
+        content: "---\nname: personal-claude-skill\n---\ncontent",
+        frontmatter: { name: "personal-claude-skill" },
+        validationErrors: [],
+      } as unknown as ReturnType<typeof parseSkillFile>);
+
+      await manager.initialize();
+
+      const skills = manager.getAvailableSkills();
+      expect(
+        skills.find((s) => s.name === "personal-claude-skill"),
+      ).toBeDefined();
+
+      await manager.destroy();
+    });
+
+    it("should let .wave/skills override .claude/skills for same-named skill at project level", async () => {
+      const manager = new SkillManager(container, {
+        workdir: "/test/workdir",
+      });
+
+      vi.mocked(readdir).mockImplementation(async (path) => {
+        const p = path.toString();
+        if (
+          p === "/test/workdir/.claude/skills" ||
+          p === "/test/workdir/.wave/skills"
+        ) {
+          return [
+            { name: "override-skill", isDirectory: () => true },
+          ] as unknown as Awaited<ReturnType<typeof readdir>>;
+        }
+        return [] as unknown as Awaited<ReturnType<typeof readdir>>;
+      });
+
+      vi.mocked(stat).mockResolvedValue(
+        {} as unknown as Awaited<ReturnType<typeof stat>>,
+      );
+
+      vi.mocked(parseSkillFile).mockImplementation((filePath) => {
+        const p = filePath as string;
+        if (p.includes(".claude/skills")) {
+          return {
+            isValid: true,
+            skillMetadata: {
+              name: "override-skill",
+              description: "claude version",
+              type: "project",
+              skillPath: p,
+            },
+            content: "claude content",
+            frontmatter: { name: "override-skill" },
+            validationErrors: [],
+          } as unknown as ReturnType<typeof parseSkillFile>;
+        }
+        return {
+          isValid: true,
+          skillMetadata: {
+            name: "override-skill",
+            description: "wave version",
+            type: "project",
+            skillPath: p,
+          },
+          content: "wave content",
+          frontmatter: { name: "override-skill" },
+          validationErrors: [],
+        } as unknown as ReturnType<typeof parseSkillFile>;
+      });
+
+      await manager.initialize();
+
+      const skills = manager.getAvailableSkills();
+      const skill = skills.find((s) => s.name === "override-skill");
+      expect(skill).toBeDefined();
+      expect(skill?.description).toBe("wave version");
+
+      await manager.destroy();
+    });
+
+    it("should include .claude/skills paths in watched paths", async () => {
+      const manager = new SkillManager(container, {
+        workdir: "/test/workdir",
+        watch: true,
+        personalClaudeSkillsPath: "/home/user/.claude/skills",
+      });
+      vi.mocked(readdir).mockResolvedValue([]);
+
+      await manager.initialize();
+
+      const watchedPaths = mockFileWatcher.watchFile.mock.calls.map(
+        (call: unknown[]) => call[0] as string,
+      );
+
+      expect(watchedPaths).toContain("/test/workdir/.claude/skills");
+      expect(watchedPaths).toContain("/home/user/.claude/skills");
+
+      await manager.destroy();
+    });
+  });
 });

--- a/packages/agent-sdk/tests/services/MarketplaceService.test.ts
+++ b/packages/agent-sdk/tests/services/MarketplaceService.test.ts
@@ -1370,6 +1370,48 @@ describe("MarketplaceService - Coverage Targets", () => {
     );
   });
 
+  // Claude Code ecosystem compatibility: .claude-plugin fallback for plugin.json
+  it("should fallback to .claude-plugin/plugin.json when .wave-plugin/plugin.json does not exist", async () => {
+    vi.spyOn(
+      service["configurationService"],
+      "getMergedMarketplaces",
+    ).mockReturnValue({
+      "compat-mkt": {
+        source: { source: "directory", path: mockPluginsDir },
+        autoUpdate: false,
+      },
+    });
+
+    // Create plugin manifest ONLY in .claude-plugin (not .wave-plugin)
+    const claudePluginDir = path.join(mockPluginsDir, ".claude-plugin");
+    await fs.mkdir(claudePluginDir, { recursive: true });
+    await fs.writeFile(
+      path.join(claudePluginDir, "plugin.json"),
+      JSON.stringify({ name: "compat-plugin", version: "3.0.0" }),
+    );
+
+    vi.spyOn(service, "loadMarketplaceManifest").mockResolvedValue({
+      name: "compat-mkt",
+      owner: { name: "test" },
+      plugins: [{ name: "compat-plugin", source: ".", description: "" }],
+    });
+
+    // Mock installed plugins file
+    const installedPath = path.join(mockPluginsDir, "installed_plugins.json");
+    await fs.writeFile(installedPath, JSON.stringify({ plugins: [] }));
+
+    // Mock fs.cp and fs.rename
+    vi.mocked(fs.cp).mockResolvedValue(
+      undefined as unknown as Awaited<ReturnType<typeof fs.cp>>,
+    );
+    vi.mocked(fs.rename).mockResolvedValue(
+      undefined as unknown as Awaited<ReturnType<typeof fs.rename>>,
+    );
+
+    const result = await service.installPlugin("compat-plugin@compat-mkt");
+    expect(result.version).toBe("3.0.0");
+  });
+
   // Line 831: installPlugin cache exists and rm
   it("should remove existing cache when installing same version again", async () => {
     vi.spyOn(

--- a/packages/agent-sdk/tests/services/memory.test.ts
+++ b/packages/agent-sdk/tests/services/memory.test.ts
@@ -150,6 +150,28 @@ describe("MemoryService", () => {
       );
       expect(result).toBe("User memory content");
     });
+
+    it("should use ~/.claude/AGENTS.md content when ~/.wave/AGENTS.md is the default empty template", async () => {
+      const defaultTemplate =
+        "# User Memory\n\nThis is the user-level memory file, recording important information and context across projects.\n\n";
+      const claudeContent = "# Claude User Memory\n\nCustom claude memory data";
+
+      vi.mocked(fsPromises.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fsPromises.access).mockResolvedValue(undefined);
+      // USER_MEMORY_FILE (~/.wave/AGENTS.md) returns the default template
+      const readImpl = async (filePath: unknown): Promise<string> => {
+        const p = String(filePath);
+        if (p.includes(".claude")) return claudeContent;
+        return defaultTemplate;
+      };
+      vi.mocked(fsPromises.readFile).mockImplementation(
+        readImpl as typeof fsPromises.readFile,
+      );
+
+      const result = await memoryService.getUserMemoryContent();
+
+      expect(result).toBe(claudeContent);
+    });
   });
 
   describe("ensureUserMemoryFile", () => {
@@ -200,6 +222,46 @@ describe("MemoryService", () => {
         expect.stringContaining("AGENTS.md"),
         "utf-8",
       );
+    });
+
+    it("should fallback to CLAUDE.md when AGENTS.md does not exist", async () => {
+      // First call for AGENTS.md fails with ENOENT, second call for CLAUDE.md succeeds
+      vi.mocked(fsPromises.readFile)
+        .mockRejectedValueOnce({ code: "ENOENT" })
+        .mockResolvedValueOnce("# Claude Memory\n\nClaude memory data");
+
+      const result = await memoryService.readMemoryFile("/mock/workdir");
+
+      expect(result).toBe("# Claude Memory\n\nClaude memory data");
+      expect(vi.mocked(fsPromises.readFile)).toHaveBeenCalledWith(
+        path.join("/mock/workdir", "CLAUDE.md"),
+        "utf-8",
+      );
+    });
+
+    it("should prefer AGENTS.md over CLAUDE.md when both exist", async () => {
+      vi.mocked(fsPromises.readFile).mockResolvedValue(
+        "# Agents Memory\n\nAgents content",
+      );
+
+      const result = await memoryService.readMemoryFile("/mock/workdir");
+
+      expect(result).toBe("# Agents Memory\n\nAgents content");
+      // Should only read AGENTS.md, not CLAUDE.md
+      expect(vi.mocked(fsPromises.readFile)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(fsPromises.readFile)).toHaveBeenCalledWith(
+        path.join("/mock/workdir", "AGENTS.md"),
+        "utf-8",
+      );
+    });
+
+    it("should return empty string when neither AGENTS.md nor CLAUDE.md exists", async () => {
+      vi.mocked(fsPromises.readFile).mockRejectedValue({ code: "ENOENT" });
+
+      const result = await memoryService.readMemoryFile("/mock/workdir");
+
+      expect(result).toBe("");
+      expect(vi.mocked(fsPromises.readFile)).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/agent-sdk/tests/services/pluginLoader.test.ts
+++ b/packages/agent-sdk/tests/services/pluginLoader.test.ts
@@ -48,9 +48,31 @@ describe("PluginLoader", () => {
       const error = new Error("Directory not found");
       (error as Error & { code?: string }).code = "ENOENT";
       vi.mocked(fs.readdir).mockRejectedValue(error);
+      vi.mocked(fs.readFile).mockRejectedValue(error);
 
       await expect(PluginLoader.loadManifest(mockPluginPath)).rejects.toThrow(
-        `Plugin manifest directory not found at /mock/plugin/path/.wave-plugin`,
+        `Plugin manifest not found at /mock/plugin/path/.wave-plugin or /mock/plugin/path/.claude-plugin`,
+      );
+    });
+
+    it("should fallback to .claude-plugin/ when .wave-plugin/ does not exist", async () => {
+      const error = new Error("Directory not found");
+      (error as Error & { code?: string }).code = "ENOENT";
+      vi.mocked(fs.readdir).mockRejectedValue(error);
+
+      const mockManifest = {
+        name: "test-plugin",
+        description: "A test plugin",
+        version: "1.0.0",
+      };
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(mockManifest));
+
+      const result = await PluginLoader.loadManifest(mockPluginPath);
+
+      expect(result).toEqual(mockManifest);
+      expect(fs.readFile).toHaveBeenCalledWith(
+        "/mock/plugin/path/.claude-plugin/plugin.json",
+        "utf-8",
       );
     });
 

--- a/packages/agent-sdk/tests/utils/customCommands.description.test.ts
+++ b/packages/agent-sdk/tests/utils/customCommands.description.test.ts
@@ -106,4 +106,100 @@ This is a test command without description.`;
     expect(testCommand?.description).toBeUndefined();
     expect(testCommand?.config).toBeUndefined();
   });
+
+  describe("Claude ecosystem compatibility", () => {
+    it("should load commands from .claude/commands directories", () => {
+      const claudeUserDir = "/mock/home/.claude/commands";
+      const claudeProjectDir = "/mock/tmp/wave-test-123/.claude/commands";
+
+      vi.mocked(fs.existsSync).mockImplementation((p) => {
+        const path = p.toString();
+        return path === claudeUserDir || path === claudeProjectDir;
+      });
+
+      vi.mocked(fs.readdirSync).mockImplementation((dirPath) => {
+        const dir = dirPath.toString();
+        if (dir === claudeUserDir) {
+          return ["user-claude-cmd.md"] as unknown as ReturnType<
+            typeof fs.readdirSync
+          >;
+        }
+        if (dir === claudeProjectDir) {
+          return ["project-claude-cmd.md"] as unknown as ReturnType<
+            typeof fs.readdirSync
+          >;
+        }
+        return [] as unknown as ReturnType<typeof fs.readdirSync>;
+      });
+
+      vi.mocked(fs.readFileSync).mockImplementation((filePath) => {
+        const p = filePath.toString();
+        if (p.includes("user-claude-cmd.md")) {
+          return `---
+description: User Claude command
+---
+User claude command content`;
+        }
+        if (p.includes("project-claude-cmd.md")) {
+          return `---
+description: Project Claude command
+---
+Project claude command content`;
+        }
+        return "";
+      });
+
+      const commands = loadCustomSlashCommands(mockTestDir);
+
+      expect(commands.find((c) => c.name === "user-claude-cmd")).toBeDefined();
+      expect(
+        commands.find((c) => c.name === "project-claude-cmd"),
+      ).toBeDefined();
+    });
+
+    it("should let .wave/commands override .claude/commands for same-named command", () => {
+      const claudeProjectDir = "/mock/tmp/wave-test-123/.claude/commands";
+      const waveProjectDir = "/mock/tmp/wave-test-123/.wave/commands";
+
+      vi.mocked(fs.existsSync).mockImplementation((p) => {
+        const path = p.toString();
+        return path === claudeProjectDir || path === waveProjectDir;
+      });
+
+      vi.mocked(fs.readdirSync).mockImplementation((dirPath) => {
+        const dir = dirPath.toString();
+        if (dir === claudeProjectDir || dir === waveProjectDir) {
+          return ["shared-cmd.md"] as unknown as ReturnType<
+            typeof fs.readdirSync
+          >;
+        }
+        return [] as unknown as ReturnType<typeof fs.readdirSync>;
+      });
+
+      vi.mocked(fs.readFileSync).mockImplementation((filePath) => {
+        const p = filePath.toString();
+        if (p.includes(".claude/commands") && p.includes("shared-cmd.md")) {
+          return `---
+description: Claude version
+---
+Claude content`;
+        }
+        if (p.includes(".wave/commands") && p.includes("shared-cmd.md")) {
+          return `---
+description: Wave version
+---
+Wave content`;
+        }
+        return "";
+      });
+
+      const commands = loadCustomSlashCommands(mockTestDir);
+
+      // Same command name from both dirs should result in one entry (wave wins)
+      const matching = commands.filter((c) => c.name === "shared-cmd");
+      expect(matching).toHaveLength(1);
+      expect(matching[0].description).toBe("Wave version");
+      expect(matching[0].content).toBe("Wave content");
+    });
+  });
 });

--- a/packages/agent-sdk/tests/utils/skillParser.test.ts
+++ b/packages/agent-sdk/tests/utils/skillParser.test.ts
@@ -145,6 +145,24 @@ description: A project skill
       expect(result.skillMetadata.type).toBe("project");
     });
 
+    it("should detect project skills from .claude/skills path (Claude Code compatibility)", () => {
+      const mockContent = `---
+name: claude-project-skill
+description: A Claude Code compatible project skill
+---
+
+# Claude Project Skill`;
+
+      mockReadFileSync.mockReturnValue(mockContent);
+
+      const result = parseSkillFile(
+        "/project/.claude/skills/claude-project-skill/SKILL.md",
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(result.skillMetadata.type).toBe("project");
+    });
+
     it("should handle file read errors", () => {
       mockReadFileSync.mockImplementation(() => {
         throw new Error("File not found");

--- a/packages/agent-sdk/tests/utils/subagentParser.test.ts
+++ b/packages/agent-sdk/tests/utils/subagentParser.test.ts
@@ -190,5 +190,114 @@ Custom system prompt for user override`;
         "Custom system prompt for user override",
       );
     });
+
+    it("should load subagents from .claude/agents directories", async () => {
+      const mockFs = await import("fs");
+      const originalHome = process.env.HOME;
+      process.env.HOME = "/home/testuser";
+
+      vi.mocked(mockFs.readdirSync).mockImplementation((dirPath) => {
+        if (dirPath === "/home/testuser/.claude/agents") {
+          return ["claude-agent.md"] as unknown as ReturnType<
+            typeof import("fs").readdirSync
+          >;
+        }
+        if (dirPath === "/test/workdir/.claude/agents") {
+          return ["project-claude-agent.md"] as unknown as ReturnType<
+            typeof import("fs").readdirSync
+          >;
+        }
+        return [] as unknown as ReturnType<typeof import("fs").readdirSync>;
+      });
+
+      vi.mocked(mockFs.statSync).mockReturnValue({
+        isFile: () => true,
+      } as import("fs").Stats);
+
+      vi.mocked(mockFs.readFileSync).mockImplementation((filePath) => {
+        if (filePath === "/home/testuser/.claude/agents/claude-agent.md") {
+          return `---
+description: User-level Claude agent
+---
+Claude agent system prompt`;
+        }
+        if (
+          filePath === "/test/workdir/.claude/agents/project-claude-agent.md"
+        ) {
+          return `---
+description: Project-level Claude agent
+---
+Project Claude agent system prompt`;
+        }
+        return "";
+      });
+
+      const configs = await loadSubagentConfigurations("/test/workdir");
+
+      process.env.HOME = originalHome;
+
+      const userClaudeAgent = configs.find((c) => c.name === "claude-agent");
+      expect(userClaudeAgent).toBeDefined();
+      expect(userClaudeAgent?.scope).toBe("user");
+      expect(userClaudeAgent?.description).toBe("User-level Claude agent");
+
+      const projectClaudeAgent = configs.find(
+        (c) => c.name === "project-claude-agent",
+      );
+      expect(projectClaudeAgent).toBeDefined();
+      expect(projectClaudeAgent?.scope).toBe("project");
+      expect(projectClaudeAgent?.description).toBe(
+        "Project-level Claude agent",
+      );
+    });
+
+    it("should let .wave/agents override .claude/agents for same-named agent", async () => {
+      const mockFs = await import("fs");
+      const originalHome = process.env.HOME;
+      process.env.HOME = "/home/testuser";
+
+      vi.mocked(mockFs.readdirSync).mockImplementation((dirPath) => {
+        if (
+          dirPath === "/home/testuser/.claude/agents" ||
+          dirPath === "/home/testuser/.wave/agents"
+        ) {
+          return ["shared-agent.md"] as unknown as ReturnType<
+            typeof import("fs").readdirSync
+          >;
+        }
+        return [] as unknown as ReturnType<typeof import("fs").readdirSync>;
+      });
+
+      vi.mocked(mockFs.statSync).mockReturnValue({
+        isFile: () => true,
+      } as import("fs").Stats);
+
+      vi.mocked(mockFs.readFileSync).mockImplementation((filePath) => {
+        if (filePath === "/home/testuser/.claude/agents/shared-agent.md") {
+          return `---
+name: shared-agent
+description: Claude version
+---
+Claude version prompt`;
+        }
+        if (filePath === "/home/testuser/.wave/agents/shared-agent.md") {
+          return `---
+name: shared-agent
+description: Wave version
+---
+Wave version prompt`;
+        }
+        return "";
+      });
+
+      const configs = await loadSubagentConfigurations("/test/workdir");
+
+      process.env.HOME = originalHome;
+
+      const agent = configs.find((c) => c.name === "shared-agent");
+      expect(agent).toBeDefined();
+      expect(agent?.description).toBe("Wave version");
+      expect(agent?.systemPrompt).toBe("Wave version prompt");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Make Wave compatible with the Claude Code ecosystem by reading `.claude/` and `.claude-plugin/` directories as fallbacks when their `.wave/` equivalents don't exist.

## Changes

### Plugin & Marketplace (Steps 1-2)
- **pluginLoader.ts**: Fallback to `.claude-plugin/plugin.json` when `.wave-plugin/` directory doesn't exist
- **MarketplaceService.ts**: Fallback to `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` in 2 sites

### Memory & Skills (Steps 3-5)
- **memory.ts**: `CLAUDE.md` fallback for `AGENTS.md` at project level; `~/.claude/AGENTS.md` fallback for user memory when `~/.wave/AGENTS.md` is default template
- **skillParser.ts**: Detect `.claude/skills` path as "project" type skill
- **skillManager.ts**: Discover `.claude/skills` at project and personal level, merge with `.wave` taking priority, add watcher paths

### Discovery Merge (Steps 6-8)
- **subagentParser.ts**: Scan `.claude/agents` — merge order: builtin → userClaude → userWave → projectClaude → projectWave
- **customCommands.ts**: Scan `.claude/commands` — merge order: userClaude → userWave → projectClaude → projectWave
- **MemoryRuleManager.ts**: Scan `.claude/rules` with dynamic rulesRoot detection — `.wave` same-name overrides `.claude`

### Environment Variables (Step 9)
- **hookManager.ts**, **mcpManager.ts**, **lspManager.ts**, **skillManager.ts**: Add `CLAUDE_PLUGIN_ROOT` and `CLAUDE_SKILL_DIR` alongside existing `WAVE_` equivalents

### Tests (Step 10)
- 17 new tests across 9 test files covering all fallback paths and merge priorities

## Verification
- Type check: passes
- Build: passes
- Tests: 3109 passing (+17 new), 2 pre-existing timeout failures unrelated to changes