### PR TITLE
refactor: simplify plan mode reminder to one-time entry injection

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -26,7 +26,6 @@ import type { SkillManager } from "./skillManager.js";
 import { buildSystemPrompt } from "../prompts/index.js";
 import {
   buildPlanModeReminder,
-  buildPlanModeSparseReminder,
   buildPlanModeReEntryReminder,
   buildExitedPlanModeReminder,
 } from "../prompts/planModeReminders.js";
@@ -136,6 +135,14 @@ export class AIManager {
 
   private get permissionManager(): PermissionManager | undefined {
     return this.container.get<PermissionManager>("PermissionManager");
+  }
+
+  private get planManager():
+    | import("./planManager.js").PlanManager
+    | undefined {
+    return this.container.get<import("./planManager.js").PlanManager>(
+      "PlanManager",
+    );
   }
 
   private get configurationService(): ConfigurationService {
@@ -253,7 +260,6 @@ export class AIManager {
       this.permissionManager.setNeedsPlanModeExitAttachment(false);
     }
 
-    // Handle plan mode reminders
     if (currentMode !== "plan") return messages;
 
     const planFilePath = this.permissionManager.getPlanFilePath();
@@ -261,83 +267,27 @@ export class AIManager {
 
     const planExists = existsSync(planFilePath);
 
-    // Check for re-entry: flag is set AND plan file exists
-    if (this.permissionManager.hasExitedPlanModeInSession() && planExists) {
-      messages.push({
-        role: "user",
-        content: buildPlanModeReEntryReminder(planFilePath),
-      });
-      this.permissionManager.setHasExitedPlanMode(false); // One-time
-    }
-
-    // Count plan_mode system-reminders in existing messages to determine full vs sparse
-    // and count human turns since last reminder for throttling
-    const recentApiMessages = this.messageManager.getMessages();
-    let planModeReminderCount = 0;
-    let humanTurnsSinceLastReminder = 0;
-    let foundLastReminder = false;
-
-    for (let i = recentApiMessages.length - 1; i >= 0; i--) {
-      const msg = recentApiMessages[i];
-      if (msg.role === "user" && !msg.isMeta) {
-        // Count human turns (non-meta user messages without tool results)
-        const hasToolResult = msg.blocks?.some(
-          (b: { type: string }) => b.type === "tool",
-        );
-        if (!hasToolResult) {
-          if (!foundLastReminder) {
-            humanTurnsSinceLastReminder++;
-          }
-        }
+    // One-time plan entry reminder
+    const planMgr = this.planManager;
+    if (planMgr?.isPlanEntryReminderPending()) {
+      if (this.permissionManager.hasExitedPlanModeInSession() && planExists) {
+        // Re-entry: use small reminder
+        messages.push({
+          role: "user",
+          content: buildPlanModeReEntryReminder(planFilePath),
+        });
+      } else {
+        // First entry: use full reminder
+        messages.push({
+          role: "user",
+          content: buildPlanModeReminder(
+            planFilePath,
+            planExists,
+            !!this.subagentType,
+          ),
+        });
       }
-      // Check for existing plan mode system-reminders
-      if (msg.role === "user" && msg.isMeta) {
-        const textContent = msg.blocks
-          ?.filter((b) => b.type === "text")
-          .map((b) => ("content" in b ? b.content : ""))
-          .join("");
-        if (
-          textContent?.includes("Plan mode is active") ||
-          textContent?.includes("Plan mode still active")
-        ) {
-          planModeReminderCount++;
-          if (!foundLastReminder) {
-            foundLastReminder = true;
-          }
-        }
-      }
-    }
-
-    // Throttle: only inject every 5 human turns (but always inject on first turn)
-    const TURNS_BETWEEN_REMINDERS = 5;
-    const FULL_REMINDER_EVERY_N = 5;
-
-    if (
-      foundLastReminder &&
-      humanTurnsSinceLastReminder < TURNS_BETWEEN_REMINDERS
-    ) {
-      return messages; // Throttled — skip reminder
-    }
-
-    // Determine full vs sparse
-    // Every 5th reminder is full; rest are sparse
-    const reminderNumber = planModeReminderCount + 1;
-    const isFull = reminderNumber % FULL_REMINDER_EVERY_N === 1;
-
-    if (isFull) {
-      messages.push({
-        role: "user",
-        content: buildPlanModeReminder(
-          planFilePath,
-          planExists,
-          !!this.subagentType,
-        ),
-      });
-    } else {
-      messages.push({
-        role: "user",
-        content: buildPlanModeSparseReminder(planFilePath),
-      });
+      planMgr.consumePlanEntryReminder();
     }
 
     return messages;

--- a/packages/agent-sdk/src/managers/planManager.ts
+++ b/packages/agent-sdk/src/managers/planManager.ts
@@ -16,6 +16,7 @@ import { logger } from "../utils/globalLogger.js";
 export class PlanManager {
   private planDir: string;
   private currentPlanFilePath: string | null = null;
+  private planEntryReminderPending: boolean = false;
 
   constructor(private container: Container) {
     this.planDir = path.join(os.homedir(), ".wave", "plans");
@@ -80,6 +81,7 @@ export class PlanManager {
       // Entering plan mode: clear any pending exit attachment
       // (prevents sending both plan_mode and plan_mode_exit on rapid toggle)
       permissionManager?.setNeedsPlanModeExitAttachment(false);
+      this.planEntryReminderPending = true;
 
       this.getOrGeneratePlanFilePath(messageManager?.getRootSessionId())
         .then(({ path }) => {
@@ -94,8 +96,17 @@ export class PlanManager {
       permissionManager?.setHasExitedPlanMode(true);
       permissionManager?.setNeedsPlanModeExitAttachment(true);
       permissionManager?.setPlanFilePath(undefined);
+      this.planEntryReminderPending = false;
     } else {
       permissionManager?.setPlanFilePath(undefined);
     }
+  }
+
+  public isPlanEntryReminderPending(): boolean {
+    return this.planEntryReminderPending;
+  }
+
+  public consumePlanEntryReminder(): void {
+    this.planEntryReminderPending = false;
   }
 }

--- a/packages/agent-sdk/src/prompts/planModeReminders.ts
+++ b/packages/agent-sdk/src/prompts/planModeReminders.ts
@@ -106,26 +106,14 @@ This is critical - your turn should only end with either using the ${ASK_USER_QU
 NOTE: At any point in time through this workflow you should feel free to ask the user questions or clarifications using the ${ASK_USER_QUESTION_TOOL_NAME} tool. Don't make large assumptions about user intent. The goal is to present a well researched plan to the user, and tie any loose ends before implementation begins.`);
 }
 
-export function buildPlanModeSparseReminder(planFilePath: string): string {
-  return wrapInSystemReminder(
-    `Plan mode still active (see full instructions earlier in conversation). Read-only except plan file at ${planFilePath}. End turns with ${ASK_USER_QUESTION_TOOL_NAME} or ${EXIT_PLAN_MODE_TOOL_NAME}.`,
-  );
-}
-
 export function buildPlanModeReEntryReminder(planFilePath: string): string {
   return wrapInSystemReminder(`## Re-entering Plan Mode
 
-You are returning to plan mode after having previously exited it. A plan file exists at ${planFilePath} from your previous planning session.
+You are returning to plan mode. A plan file exists at ${planFilePath} from your previous session.
 
-**Before proceeding with any new planning, you should:**
 1. Read the existing plan file to understand what was previously planned
-2. Evaluate the user's current request against that plan
-3. Decide how to proceed:
-   - **Different task**: If the user's request is for a different task—even if it's similar or related—start fresh by overwriting the existing plan
-   - **Same task, continuing**: If this is explicitly a continuation or refinement of the exact same task, modify the existing plan while cleaning up outdated or irrelevant sections
-4. Continue on with the plan process and most importantly you should always edit the plan file one way or the other before calling ${EXIT_PLAN_MODE_TOOL_NAME}
-
-Treat this as a fresh planning session. Do not assume the existing plan is relevant without evaluating it first.`);
+2. Decide: if the user's request is a different task, start fresh by overwriting the plan; if it's a continuation, modify the existing plan
+3. Edit the plan file as needed, then call ${EXIT_PLAN_MODE_TOOL_NAME}`);
 }
 
 export function buildExitedPlanModeReminder(

--- a/packages/agent-sdk/tests/managers/aiManager.plan.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.plan.test.ts
@@ -9,6 +9,7 @@ import { DEFAULT_SYSTEM_PROMPT } from "../../src/prompts/index.js";
 import type { MessageManager } from "../../src/managers/messageManager.js";
 import type { ToolManager } from "../../src/managers/toolManager.js";
 import type { PermissionManager } from "../../src/managers/permissionManager.js";
+import type { PlanManager } from "../../src/managers/planManager.js";
 
 vi.mock("node:fs/promises");
 vi.mock("node:fs", () => ({
@@ -30,6 +31,7 @@ describe("AIManager Plan Mode Prompt", () => {
   let mockMessageManager: Mocked<MessageManager>;
   let mockToolManager: Mocked<ToolManager>;
   let mockPermissionManager: Mocked<PermissionManager>;
+  let mockPlanManager: Mocked<PlanManager>;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -58,6 +60,11 @@ describe("AIManager Plan Mode Prompt", () => {
       getNeedsPlanModeExitAttachment: vi.fn(() => false),
     } as unknown as Mocked<PermissionManager>;
 
+    mockPlanManager = {
+      isPlanEntryReminderPending: vi.fn(() => true),
+      consumePlanEntryReminder: vi.fn(),
+    } as unknown as Mocked<PlanManager>;
+
     const container = new Container();
     container.register("ConfigurationService", {
       resolveGatewayConfig: vi.fn().mockReturnValue({}),
@@ -76,6 +83,7 @@ describe("AIManager Plan Mode Prompt", () => {
       getAutoMemoryContent: vi.fn().mockResolvedValue(""),
     });
     container.register("PermissionManager", mockPermissionManager);
+    container.register("PlanManager", mockPlanManager);
 
     // Mock SubagentManager and register it
     container.register("SubagentManager", {
@@ -116,7 +124,6 @@ describe("AIManager Plan Mode Prompt", () => {
     await aiManager.sendAIMessage();
 
     const callOptions = vi.mocked(callAgent).mock.calls[0][0];
-    // Plan mode content is now injected as user messages, not in systemPrompt
     const userMessages = (
       callOptions.messages as Array<{ role: string; content: string }>
     ).filter((m) => m.role === "user");
@@ -139,7 +146,6 @@ describe("AIManager Plan Mode Prompt", () => {
     await aiManager.sendAIMessage();
 
     const callOptions = vi.mocked(callAgent).mock.calls[0][0];
-    // Plan mode content is now injected as user messages, not in systemPrompt
     const userMessages = (
       callOptions.messages as Array<{ role: string; content: string }>
     ).filter((m) => m.role === "user");
@@ -152,5 +158,51 @@ describe("AIManager Plan Mode Prompt", () => {
     );
     expect(planMessage!.content).toContain("A plan file already exists");
     expect(planMessage!.content).toContain("using the Edit tool");
+  });
+
+  it("should not add plan reminder on second call (one-time)", async () => {
+    mockPermissionManager.getCurrentEffectiveMode.mockReturnValue("plan");
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(fs.access).mockRejectedValue(new Error("ENOENT"));
+
+    // First call: reminder is pending
+    mockPlanManager.isPlanEntryReminderPending.mockReturnValue(true);
+    await aiManager.sendAIMessage();
+
+    // consumePlanEntryReminder was called, making pending = false
+    expect(mockPlanManager.consumePlanEntryReminder).toHaveBeenCalled();
+
+    // Second call: reminder consumed, no longer pending
+    mockPlanManager.isPlanEntryReminderPending.mockReturnValue(false);
+    await aiManager.sendAIMessage();
+
+    const callOptions = vi.mocked(callAgent).mock.calls[1][0];
+    const userMessages = (
+      callOptions.messages as Array<{ role: string; content: string }>
+    ).filter((m) => m.role === "user");
+    const planMessage = userMessages.find((m) =>
+      m.content?.includes("Plan mode is active"),
+    );
+    expect(planMessage).toBeUndefined();
+  });
+
+  it("should add re-entry reminder when re-entering plan mode", async () => {
+    mockPermissionManager.getCurrentEffectiveMode.mockReturnValue("plan");
+    mockPermissionManager.hasExitedPlanModeInSession.mockReturnValue(true);
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(fs.access).mockResolvedValue(undefined);
+    mockPlanManager.isPlanEntryReminderPending.mockReturnValue(true);
+
+    await aiManager.sendAIMessage();
+
+    const callOptions = vi.mocked(callAgent).mock.calls[0][0];
+    const userMessages = (
+      callOptions.messages as Array<{ role: string; content: string }>
+    ).filter((m) => m.role === "user");
+    const planMessage = userMessages.find((m) =>
+      m.content?.includes("Re-entering Plan Mode"),
+    );
+    expect(planMessage).toBeDefined();
+    expect(planMessage!.content).toContain("returning to plan mode");
   });
 });

--- a/specs/050-plan-mode/data-model.md
+++ b/specs/050-plan-mode/data-model.md
@@ -27,6 +27,12 @@ Represents a plan file created during Plan Mode.
   - `name`: Human-readable name (adjective-noun). This name is deterministic within a session chain, generated using the `rootSessionId` as a seed.
   - `createdAt`: Timestamp of creation.
 
+### PlanEntryReminderPending (Flag in PlanManager)
+Tracks whether a plan entry reminder needs to be injected on the next AI call.
+- **Set to `true`**: When entering plan mode (`handlePlanModeTransition("plan")`).
+- **Consumed (set to `false`)**: After the reminder is injected in `buildPlanModeMessages()`, or when leaving plan mode.
+- **Purpose**: Ensures the plan mode reminder is injected exactly once per entry, not on every turn.
+
 ## State Transitions
 - **default -> acceptEdits**: Triggered by Shift+Tab.
 - **acceptEdits -> plan**: Triggered by Shift+Tab. Determines or reuses a `PlanFile` based on the `rootSessionId`.

--- a/specs/050-plan-mode/spec.md
+++ b/specs/050-plan-mode/spec.md
@@ -128,20 +128,19 @@ As a user who has just approved a plan, I want the agent to be explicitly told i
 
 ---
 
-### User Story 8 - Throttled Plan Mode Reminders (Priority: P2)
+### User Story 8 - One-Time Plan Entry Reminder (Priority: P2)
 
-As a user working in plan mode for an extended session, I want the plan mode reminders to be throttled so they don't waste tokens on every tool round, but I still want periodic full instructions to prevent the agent from forgetting constraints.
+As a user entering plan mode, I want the agent to receive plan mode instructions exactly once when I enter plan mode and send a message, so that tokens are not wasted on repeated reminders.
 
-**Why this priority**: Sending full plan mode instructions on every tool round wastes tokens; throttling reduces cost while maintaining constraint awareness.
+**Why this priority**: The previous throttling mechanism (scanning messages for meta reminders) was broken — reminders were transient and never stored, so throttling never fired and every AI call injected a full ~90-line reminder. The simplified approach fires the reminder exactly once per plan mode entry.
 
-**Independent Test**: Work in plan mode for multiple turns and verify reminders appear every 5 human turns, alternating between full and sparse.
+**Independent Test**: Enter plan mode, send a message, verify the reminder appears. Send another message, verify no reminder. Exit and re-enter plan mode, verify the reminder appears again.
 
 **Acceptance Scenarios**:
 
-1. **Given** plan mode is active and a full reminder was just injected, **When** fewer than 5 human turns have passed, **Then** no plan mode reminder is injected.
-2. **Given** plan mode is active and 5 human turns have passed since the last reminder, **When** the next API call is made, **Then** a plan mode reminder is injected.
-3. **Given** every 5th plan mode reminder injection, **When** the reminder is injected, **Then** it is the full 5-phase workflow instructions.
-4. **Given** a non-5th plan mode reminder injection, **When** the reminder is injected, **Then** it is a short sparse reminder referencing the earlier full instructions.
+1. **Given** the user enters plan mode, **When** the first message is sent, **Then** a full plan mode `<system-reminder>` is injected (including the 5-phase workflow).
+2. **Given** the plan entry reminder was already injected, **When** subsequent messages are sent in the same plan mode session, **Then** no plan mode reminder is injected.
+3. **Given** the user exits plan mode and re-enters, **When** the next message is sent, **Then** a re-entry reminder is injected (small reminder about reading the existing plan file).
 
 ## Requirements *(mandatory)*
 
@@ -188,10 +187,10 @@ As a user working in plan mode for an extended session, I want the plan mode rem
 - **FR-017**: When used via the ACP bridge, `ExitPlanMode` MAY provide a simplified approval process (e.g., "Approve Plan" and "Reject Plan") and automatically transition to `default` mode upon approval.
 - **FR-018**: System MUST track `hasExitedPlanMode` state. When the agent exits plan mode (via ExitPlanMode or mode transition), this flag MUST be set to true.
 - **FR-019**: When entering plan mode and `hasExitedPlanMode` is true and a plan file already exists, the system MUST inject a re-entry `<system-reminder>` message instructing the model to: (a) read the existing plan file, (b) evaluate whether the user's request is a new task or continuation, (c) always edit the plan file before calling ExitPlanMode. The flag MUST be cleared after injection (one-time).
-- **FR-020**: When plan mode is active, the system MUST inject plan mode reminders every 5 human turns (non-meta, non-tool-result user messages), not on every tool round. Every 5th reminder MUST be the full instructions; intermediate reminders MUST be sparse (short reminder referencing earlier full instructions).
+- **FR-020**: When plan mode is active, the system MUST inject a plan mode reminder exactly once per entry — on the first AI call after entering plan mode. The `PlanManager` tracks a `planEntryReminderPending` flag that is set `true` on entering plan mode and consumed (set `false`) after the reminder is injected. No recurring or throttled reminders are injected on subsequent turns.
 - **FR-021**: When exiting plan mode, the system MUST inject a one-time "exited plan mode" `<system-reminder>` message on the next turn, notifying the model it can now make edits and take actions. If the plan file exists, the message MUST include the plan file path for reference.
 - **FR-022**: All plan mode `<system-reminder>` messages MUST use `isMeta: true` and MUST NOT be rendered in the UI.
-- **FR-023**: After compaction, if plan mode is active, the system MUST re-inject the full plan mode reminder so the model retains its instructions.
+- **FR-023**: After compaction, if plan mode is active, the plan mode instructions from the initial reminder are preserved in the compacted summary. No re-injection is needed since the reminder is one-time per entry.
 - **FR-024**: The `hasExitedPlanMode` flag MUST be tracked in `PermissionManager` and persist across mode transitions within the same session.
 - **FR-025**: The "needs plan mode exit attachment" flag (`needsPlanModeExitAttachment`) MUST be set when transitioning away from plan mode and cleared after the exit `<system-reminder>` is injected (one-time).
 


### PR DESCRIPTION
Replace broken throttling mechanism in buildPlanModeMessages() that scanned
transient meta messages (never stored) with a simple one-time reminder via
planEntryReminderPending flag in PlanManager.

- Add planEntryReminderPending flag to PlanManager (set on entry, consumed after injection)
- Replace 100-line throttling logic with ~30-line one-time reminder in aiManager
- Delete buildPlanModeSparseReminder (no longer needed)
- Simplify buildPlanModeReEntryReminder from ~15 lines to ~5 lines
- Update tests: add PlanManager mock, one-time behavior test, re-entry test
- Update spec: US8 throttled→one-time, FR-020/FR-023 updated, data-model updated
