### PR TITLE
fix: support custom newPermissionMode in wave/create_plan response

### DIFF
--- a/packages/code/src/acp/agent.ts
+++ b/packages/code/src/acp/agent.ts
@@ -581,7 +581,16 @@ export class WaveAcpAgent implements AcpAgent {
 
       const outcome = (response as { outcome?: string }).outcome;
       if (outcome === "accepted") {
-        return { behavior: "allow", newPermissionMode: "default" };
+        const mode = (response as { mode?: string }).mode;
+        return {
+          behavior: "allow",
+          newPermissionMode: (mode || "default") as
+            | "default"
+            | "acceptEdits"
+            | "plan"
+            | "bypassPermissions"
+            | "dontAsk",
+        };
       }
       if (outcome === "rejected") {
         const reason = (response as { reason?: string }).reason;

--- a/packages/code/tests/acp/agent.test.ts
+++ b/packages/code/tests/acp/agent.test.ts
@@ -2630,6 +2630,39 @@ describe("WaveAcpAgent", () => {
     expect(mockConnection.requestPermission).not.toHaveBeenCalled();
   });
 
+  it("should use custom mode from wave/create_plan response when accepted", async () => {
+    let canUseToolCallback: PermissionCallback;
+    const mockWaveAgent = {
+      sessionId: "session-1",
+      getPermissionMode: vi.fn().mockReturnValue("bypassPermissions"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+    };
+    vi.mocked(WaveAgent.create).mockImplementation((options: AgentOptions) => {
+      canUseToolCallback = options.canUseTool as PermissionCallback;
+      return Promise.resolve(mockWaveAgent as unknown as WaveAgent);
+    });
+
+    await agent.newSession({ cwd: "/test", mcpServers: [] });
+
+    vi.mocked(mockConnection.extMethod).mockResolvedValue({
+      outcome: "accepted",
+      mode: "bypassPermissions",
+    });
+
+    const decision = await canUseToolCallback!({
+      toolName: "ExitPlanMode",
+      toolInput: {},
+      permissionMode: "plan",
+      planContent: "# My Plan\nDo stuff",
+      toolCallId: "plan-tool-1",
+    });
+
+    expect(decision.behavior).toBe("allow");
+    expect(decision.newPermissionMode).toBe("bypassPermissions");
+  });
+
   it("should use wave/create_plan extMethod for ExitPlanMode (rejected)", async () => {
     let canUseToolCallback: PermissionCallback;
     const mockWaveAgent = {


### PR DESCRIPTION
## Summary

When the ACP bridge calls `wave/create_plan` extMethod and the client returns `{ outcome: 'accepted' }`, `handleCreatePlan` previously hardcoded `newPermissionMode: 'default'`.

In scenarios where the initial permission mode is `bypassPermissions` (e.g., wave-ai platform), this caused every subsequent tool call to trigger `requestPermission`, adding unnecessary WS round-trips.

## Changes

- Read optional `mode` field from the `wave/create_plan` response
- Use it as `newPermissionMode`, falling back to `'default'` when not provided
- Added test for custom mode propagation

Fixes #1244