### PR TITLE
fix(acp): notify client on session ID change and fix replay after compact

### DIFF
--- a/packages/agent-sdk/src/managers/messageManager.ts
+++ b/packages/agent-sdk/src/managers/messageManager.ts
@@ -548,11 +548,6 @@ export class MessageManager {
     this.setSessionId(generateSessionId());
     this.parentSessionId = oldSessionId;
 
-    // Trigger task list update if this is the main session to ensure continuity
-    if (this.sessionType === "main") {
-      this.callbacks.onSessionIdChange?.(this.sessionId);
-    }
-
     // Set new message list
     this.setMessages(newMessages);
 

--- a/packages/code/src/acp/agent.ts
+++ b/packages/code/src/acp/agent.ts
@@ -17,10 +17,10 @@ import {
   ASK_USER_QUESTION_TOOL_NAME,
   AskUserQuestion,
   AskUserQuestionOption,
-  type Message,
   type TextBlock,
   type ReasoningBlock,
   type ToolBlock,
+  type CompactBlock,
 } from "wave-agent-sdk";
 import { logger } from "../utils/logger.js";
 import {
@@ -239,6 +239,8 @@ export class WaveAcpAgent implements AcpAgent {
         onUserMessageAdded: (params) => callbacks.onUserMessageAdded?.(params),
         onMcpServersChange: (servers) =>
           callbacks.onMcpServersChange?.(servers),
+        onSessionIdChange: (newSessionId: string) =>
+          callbacks.onSessionIdChange?.(newSessionId),
       },
     });
 
@@ -247,7 +249,8 @@ export class WaveAcpAgent implements AcpAgent {
     this.agents.set(actualSessionId, agent);
 
     // Update the callbacks object with the correct sessionId
-    Object.assign(callbacks, this.createCallbacks(actualSessionId));
+    const { callbacks: cb } = this.createCallbacks(actualSessionId);
+    Object.assign(callbacks, cb);
 
     // Send initial available commands after agent creation
     // Use setImmediate to ensure the client receives the session response before the update
@@ -959,14 +962,7 @@ export class WaveAcpAgent implements AcpAgent {
   private async replayConversationHistory(agent: WaveAgent): Promise<void> {
     const sessionId = agent.sessionId as AcpSessionId;
 
-    let history: Message[];
-    try {
-      const thread = await agent.getFullMessageThread();
-      history = thread.messages;
-    } catch {
-      // Fallback to in-memory messages if full thread fails
-      history = agent.messages;
-    }
+    const history = agent.messages;
 
     for (const message of history) {
       if (message.isMeta) continue;
@@ -1079,14 +1075,28 @@ export class WaveAcpAgent implements AcpAgent {
               rawInput: parsedParameters,
             },
           });
+        } else if (block.type === "compact") {
+          const compactBlock = block as CompactBlock;
+          this.connection.sessionUpdate({
+            sessionId,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: compactBlock.content },
+              messageId,
+            },
+          });
         }
-        // Skip: image, bang, compact, error, file_history, task_notification blocks
+        // Skip: image, bang, error, file_history, task_notification blocks
       }
     }
   }
 
-  private createCallbacks(sessionId: string): AgentOptions["callbacks"] {
-    const getAgent = () => this.agents.get(sessionId);
+  private createCallbacks(sessionId: string): {
+    callbacks: AgentOptions["callbacks"];
+    sessionRef: { id: string };
+  } {
+    const sessionRef = { id: sessionId };
+    const getAgent = () => this.agents.get(sessionRef.id);
     const toolStates = new Map<
       string,
       {
@@ -1097,228 +1107,262 @@ export class WaveAcpAgent implements AcpAgent {
       }
     >();
     return {
-      onAssistantContentUpdated: (chunk: string) => {
-        this.connection.sessionUpdate({
-          sessionId: sessionId as AcpSessionId,
-          update: {
-            sessionUpdate: "agent_message_chunk",
-            content: {
-              type: "text",
-              text: chunk,
-            },
-          },
-        });
-      },
-      onAssistantReasoningUpdated: (chunk: string) => {
-        this.connection.sessionUpdate({
-          sessionId: sessionId as AcpSessionId,
-          update: {
-            sessionUpdate: "agent_thought_chunk",
-            content: {
-              type: "text",
-              text: chunk,
-            },
-          },
-        });
-      },
-      onToolBlockUpdated: (params: AgentToolBlockUpdateParams) => {
-        const {
-          id,
-          name,
-          stage,
-          success,
-          error,
-          result,
-          parameters,
-          compactParams,
-          shortResult,
-          startLineNumber,
-        } = params;
-
-        let state = toolStates.get(id);
-        if (!state) {
-          state = {};
-          toolStates.set(id, state);
-        }
-        if (name) state.name = name;
-        if (compactParams) state.compactParams = compactParams;
-        if (shortResult) state.shortResult = shortResult;
-        if (startLineNumber !== undefined)
-          state.startLineNumber = startLineNumber;
-
-        const effectiveName = state.name || name;
-        const effectiveCompactParams = state.compactParams || compactParams;
-        const effectiveShortResult = state.shortResult || shortResult;
-        const effectiveStartLineNumber =
-          state.startLineNumber !== undefined
-            ? state.startLineNumber
-            : startLineNumber;
-
-        const displayTitle =
-          effectiveName && effectiveCompactParams
-            ? `${effectiveName}: ${effectiveCompactParams}`
-            : effectiveName || "Tool Call";
-
-        let parsedParameters: Record<string, unknown> | undefined = undefined;
-        if (parameters) {
-          try {
-            const parsed = JSON.parse(parameters);
-            parsedParameters = Array.isArray(parsed)
-              ? { args: parsed }
-              : parsed;
-          } catch {
-            // Ignore parse errors during streaming
-          }
-        }
-
-        const content =
-          effectiveName && (parsedParameters || effectiveShortResult)
-            ? this.getToolContent(
-                effectiveName,
-                parsedParameters,
-                effectiveShortResult,
-              )
-            : undefined;
-        const locations =
-          effectiveName && parsedParameters
-            ? this.getToolLocations(
-                effectiveName,
-                parsedParameters,
-                effectiveStartLineNumber,
-              )
-            : undefined;
-        const kind = effectiveName
-          ? this.getToolKind(effectiveName)
-          : undefined;
-
-        if (stage === "start") {
+      callbacks: {
+        onAssistantContentUpdated: (chunk: string) => {
           this.connection.sessionUpdate({
-            sessionId: sessionId as AcpSessionId,
+            sessionId: sessionRef.id as AcpSessionId,
             update: {
-              sessionUpdate: "tool_call",
+              sessionUpdate: "agent_message_chunk",
+              content: {
+                type: "text",
+                text: chunk,
+              },
+            },
+          });
+        },
+        onAssistantReasoningUpdated: (chunk: string) => {
+          this.connection.sessionUpdate({
+            sessionId: sessionRef.id as AcpSessionId,
+            update: {
+              sessionUpdate: "agent_thought_chunk",
+              content: {
+                type: "text",
+                text: chunk,
+              },
+            },
+          });
+        },
+        onToolBlockUpdated: (params: AgentToolBlockUpdateParams) => {
+          const {
+            id,
+            name,
+            stage,
+            success,
+            error,
+            result,
+            parameters,
+            compactParams,
+            shortResult,
+            startLineNumber,
+          } = params;
+
+          let state = toolStates.get(id);
+          if (!state) {
+            state = {};
+            toolStates.set(id, state);
+          }
+          if (name) state.name = name;
+          if (compactParams) state.compactParams = compactParams;
+          if (shortResult) state.shortResult = shortResult;
+          if (startLineNumber !== undefined)
+            state.startLineNumber = startLineNumber;
+
+          const effectiveName = state.name || name;
+          const effectiveCompactParams = state.compactParams || compactParams;
+          const effectiveShortResult = state.shortResult || shortResult;
+          const effectiveStartLineNumber =
+            state.startLineNumber !== undefined
+              ? state.startLineNumber
+              : startLineNumber;
+
+          const displayTitle =
+            effectiveName && effectiveCompactParams
+              ? `${effectiveName}: ${effectiveCompactParams}`
+              : effectiveName || "Tool Call";
+
+          let parsedParameters: Record<string, unknown> | undefined = undefined;
+          if (parameters) {
+            try {
+              const parsed = JSON.parse(parameters);
+              parsedParameters = Array.isArray(parsed)
+                ? { args: parsed }
+                : parsed;
+            } catch {
+              // Ignore parse errors during streaming
+            }
+          }
+
+          const content =
+            effectiveName && (parsedParameters || effectiveShortResult)
+              ? this.getToolContent(
+                  effectiveName,
+                  parsedParameters,
+                  effectiveShortResult,
+                )
+              : undefined;
+          const locations =
+            effectiveName && parsedParameters
+              ? this.getToolLocations(
+                  effectiveName,
+                  parsedParameters,
+                  effectiveStartLineNumber,
+                )
+              : undefined;
+          const kind = effectiveName
+            ? this.getToolKind(effectiveName)
+            : undefined;
+
+          if (stage === "start") {
+            this.connection.sessionUpdate({
+              sessionId: sessionRef.id as AcpSessionId,
+              update: {
+                sessionUpdate: "tool_call",
+                toolCallId: id,
+                title: displayTitle,
+                status: "pending",
+                content,
+                locations,
+                kind,
+                rawInput: parsedParameters,
+              },
+            });
+            return;
+          }
+
+          if (stage === "streaming") {
+            // We don't support streaming tool arguments in ACP yet
+            return;
+          }
+
+          const status: ToolCallStatus =
+            stage === "end"
+              ? success
+                ? "completed"
+                : "failed"
+              : stage === "running"
+                ? "in_progress"
+                : "pending";
+
+          this.connection.sessionUpdate({
+            sessionId: sessionRef.id as AcpSessionId,
+            update: {
+              sessionUpdate: "tool_call_update",
               toolCallId: id,
+              status,
               title: displayTitle,
-              status: "pending",
+              rawOutput: result || error,
               content,
               locations,
               kind,
               rawInput: parsedParameters,
             },
           });
-          return;
-        }
 
-        if (stage === "streaming") {
-          // We don't support streaming tool arguments in ACP yet
-          return;
-        }
-
-        const status: ToolCallStatus =
-          stage === "end"
-            ? success
-              ? "completed"
-              : "failed"
-            : stage === "running"
-              ? "in_progress"
-              : "pending";
-
-        this.connection.sessionUpdate({
-          sessionId: sessionId as AcpSessionId,
-          update: {
-            sessionUpdate: "tool_call_update",
-            toolCallId: id,
-            status,
-            title: displayTitle,
-            rawOutput: result || error,
-            content,
-            locations,
-            kind,
-            rawInput: parsedParameters,
-          },
-        });
-
-        if (stage === "end") {
-          toolStates.delete(id);
-        }
-      },
-      onTasksChange: (tasks) => {
-        this.taskCache.set(sessionId, tasks);
-        this.connection.sessionUpdate({
-          sessionId: sessionId as AcpSessionId,
-          update: {
-            sessionUpdate: "plan",
-            entries: tasks
-              .filter((t) => t.status !== "deleted")
-              .map((task) => ({
-                content: task.subject,
-                status:
-                  task.status === "completed"
-                    ? "completed"
-                    : task.status === "in_progress"
-                      ? "in_progress"
-                      : "pending",
-                priority: "medium" as const,
-              })),
-          },
-        });
-      },
-      onPermissionModeChange: (mode) => {
-        this.connection.sessionUpdate({
-          sessionId: sessionId as AcpSessionId,
-          update: {
-            sessionUpdate: "current_mode_update",
-            currentModeId: mode,
-          },
-        });
-        const agent = getAgent();
-        if (agent) {
+          if (stage === "end") {
+            toolStates.delete(id);
+          }
+        },
+        onTasksChange: (tasks) => {
+          this.taskCache.set(sessionRef.id, tasks);
           this.connection.sessionUpdate({
-            sessionId: sessionId as AcpSessionId,
+            sessionId: sessionRef.id as AcpSessionId,
             update: {
-              sessionUpdate: "config_option_update",
-              configOptions: this.getSessionConfigOptions(agent),
+              sessionUpdate: "plan",
+              entries: tasks
+                .filter((t) => t.status !== "deleted")
+                .map((task) => ({
+                  content: task.subject,
+                  status:
+                    task.status === "completed"
+                      ? "completed"
+                      : task.status === "in_progress"
+                        ? "in_progress"
+                        : "pending",
+                  priority: "medium" as const,
+                })),
             },
           });
-        }
-      },
-      onModelChange: () => {
-        const agent = getAgent();
-        if (agent) {
+        },
+        onPermissionModeChange: (mode) => {
           this.connection.sessionUpdate({
-            sessionId: sessionId as AcpSessionId,
+            sessionId: sessionRef.id as AcpSessionId,
             update: {
-              sessionUpdate: "config_option_update",
-              configOptions: this.getSessionConfigOptions(agent),
+              sessionUpdate: "current_mode_update",
+              currentModeId: mode,
             },
           });
-        }
-      },
-      onUserMessageAdded: (params) => {
-        this.connection.sessionUpdate({
-          sessionId: sessionId as AcpSessionId,
-          update: {
-            sessionUpdate: "user_message_chunk",
-            content: { type: "text", text: params.content },
-          },
-        });
-      },
-      onMcpServersChange: (servers: McpServerStatus[]) => {
-        for (const server of servers) {
+          const agent = getAgent();
+          if (agent) {
+            this.connection.sessionUpdate({
+              sessionId: sessionRef.id as AcpSessionId,
+              update: {
+                sessionUpdate: "config_option_update",
+                configOptions: this.getSessionConfigOptions(agent),
+              },
+            });
+          }
+        },
+        onModelChange: () => {
+          const agent = getAgent();
+          if (agent) {
+            this.connection.sessionUpdate({
+              sessionId: sessionRef.id as AcpSessionId,
+              update: {
+                sessionUpdate: "config_option_update",
+                configOptions: this.getSessionConfigOptions(agent),
+              },
+            });
+          }
+        },
+        onUserMessageAdded: (params) => {
           this.connection.sessionUpdate({
-            sessionId: sessionId as AcpSessionId,
+            sessionId: sessionRef.id as AcpSessionId,
+            update: {
+              sessionUpdate: "user_message_chunk",
+              content: { type: "text", text: params.content },
+            },
+          });
+        },
+        onMcpServersChange: (servers: McpServerStatus[]) => {
+          for (const server of servers) {
+            this.connection.sessionUpdate({
+              sessionId: sessionRef.id as AcpSessionId,
+              update: {
+                sessionUpdate: "ext_notification" as const,
+                method: "mcp_server_status",
+                params: {
+                  name: server.name,
+                  status: server.status,
+                  toolCount: server.toolCount,
+                  error: server.error,
+                },
+              },
+            });
+          }
+        },
+        onSessionIdChange: (newSessionId: string) => {
+          const oldSessionId = sessionRef.id;
+          if (oldSessionId === newSessionId) return;
+
+          // Update agents Map key
+          const agent = this.agents.get(oldSessionId);
+          if (agent) {
+            this.agents.delete(oldSessionId);
+            this.agents.set(newSessionId, agent);
+          }
+
+          // Update taskCache key
+          const tasks = this.taskCache.get(oldSessionId);
+          if (tasks) {
+            this.taskCache.delete(oldSessionId);
+            this.taskCache.set(newSessionId, tasks);
+          }
+
+          // Update ref so all subsequent callbacks use new ID
+          sessionRef.id = newSessionId;
+
+          // Notify ACP client
+          this.connection.sessionUpdate({
+            sessionId: oldSessionId as AcpSessionId,
             update: {
               sessionUpdate: "ext_notification" as const,
-              method: "mcp_server_status",
-              params: {
-                name: server.name,
-                status: server.status,
-                toolCount: server.toolCount,
-                error: server.error,
-              },
+              method: "session_id_change",
+              params: { oldSessionId, newSessionId },
             },
           });
-        }
+        },
       },
+      sessionRef,
     };
   }
 }

--- a/packages/code/tests/acp/agent.test.ts
+++ b/packages/code/tests/acp/agent.test.ts
@@ -136,7 +136,7 @@ describe("WaveAcpAgent", () => {
           handler: vi.fn(),
         },
       ]),
-      getFullMessageThread: vi.fn().mockResolvedValue({ messages: [] }),
+      messages: [],
     };
     vi.mocked(WaveAgent.create).mockResolvedValue(
       mockWaveAgent as unknown as WaveAgent,
@@ -175,43 +175,41 @@ describe("WaveAcpAgent", () => {
       getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
       getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
       getSlashCommands: vi.fn().mockReturnValue([]),
-      getFullMessageThread: vi.fn().mockResolvedValue({
-        messages: [
-          {
-            id: "msg-1",
-            role: "user",
-            blocks: [{ type: "text", content: "Hello" }],
-            timestamp: new Date().toISOString(),
-          },
-          {
-            id: "msg-2",
-            role: "assistant",
-            blocks: [
-              { type: "reasoning", content: "Thinking..." },
-              { type: "text", content: "Hi there!" },
-              {
-                type: "tool",
-                id: "tool-1",
-                name: "Read",
-                compactParams: "file.txt",
-                stage: "end",
-                success: true,
-                parameters: JSON.stringify({ file_path: "/test/file.txt" }),
-                result: "file contents",
-                shortResult: "file contents",
-              },
-            ],
-            timestamp: new Date().toISOString(),
-          },
-          {
-            id: "msg-3",
-            role: "user",
-            blocks: [{ type: "text", content: "Thanks" }],
-            timestamp: new Date().toISOString(),
-            isMeta: true,
-          },
-        ],
-      }),
+      messages: [
+        {
+          id: "msg-1",
+          role: "user",
+          blocks: [{ type: "text", content: "Hello" }],
+          timestamp: new Date().toISOString(),
+        },
+        {
+          id: "msg-2",
+          role: "assistant",
+          blocks: [
+            { type: "reasoning", content: "Thinking..." },
+            { type: "text", content: "Hi there!" },
+            {
+              type: "tool",
+              id: "tool-1",
+              name: "Read",
+              compactParams: "file.txt",
+              stage: "end",
+              success: true,
+              parameters: JSON.stringify({ file_path: "/test/file.txt" }),
+              result: "file contents",
+              shortResult: "file contents",
+            },
+          ],
+          timestamp: new Date().toISOString(),
+        },
+        {
+          id: "msg-3",
+          role: "user",
+          blocks: [{ type: "text", content: "Thanks" }],
+          timestamp: new Date().toISOString(),
+          isMeta: true,
+        },
+      ],
     };
     vi.mocked(WaveAgent.create).mockResolvedValue(
       mockWaveAgent as unknown as WaveAgent,
@@ -343,68 +341,65 @@ describe("WaveAcpAgent", () => {
       getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
       getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
       getSlashCommands: vi.fn().mockReturnValue([]),
-      getFullMessageThread: vi.fn().mockResolvedValue({
-        messages: [
-          {
-            id: "msg-tool-edges",
-            role: "assistant",
-            blocks: [
-              // Tool without id — should generate a replay- prefixed id
-              {
-                type: "tool",
-                name: "Bash",
-                stage: "running",
-                parameters: JSON.stringify({ command: "ls" }),
-              },
-              // Tool with failed stage
-              {
-                type: "tool",
-                id: "tool-fail",
-                name: "Edit",
-                compactParams: "file.ts",
-                stage: "end",
-                success: false,
-                error: "edit failed",
-                parameters: JSON.stringify({
-                  file_path: "/test/file.ts",
-                  old_string: "a",
-                  new_string: "b",
-                }),
-              },
-              // Tool without name — should use "Tool" fallback
-              {
-                type: "tool",
-                id: "tool-no-name",
-                stage: "end",
-                success: true,
-                result: "ok",
-              },
-              // Tool with unparseable parameters
-              {
-                type: "tool",
-                id: "tool-bad-json",
-                name: "Bash",
-                stage: "end",
-                success: true,
-                parameters: "not-json",
-                result: "done",
-              },
-              // Skipped block types (image, bang, compact, error, file_history, task_notification)
-              { type: "image", imageUrls: ["file.png"] },
-              {
-                type: "bang",
-                command: "ls",
-                output: "",
-                stage: "end" as const,
-                exitCode: 0,
-              },
-              { type: "compact", content: "summary", sessionId: "old" },
-              { type: "error", content: "err" },
-            ],
-            timestamp: new Date().toISOString(),
-          },
-        ],
-      }),
+      messages: [
+        {
+          id: "msg-tool-edges",
+          role: "assistant",
+          blocks: [
+            // Tool without id — should generate a replay- prefixed id
+            {
+              type: "tool",
+              name: "Bash",
+              stage: "running",
+              parameters: JSON.stringify({ command: "ls" }),
+            },
+            // Tool with failed stage
+            {
+              type: "tool",
+              id: "tool-fail",
+              name: "Edit",
+              compactParams: "file.ts",
+              stage: "end",
+              success: false,
+              error: "edit failed",
+              parameters: JSON.stringify({
+                file_path: "/test/file.ts",
+                old_string: "a",
+                new_string: "b",
+              }),
+            },
+            // Tool without name — should use "Tool" fallback
+            {
+              type: "tool",
+              id: "tool-no-name",
+              stage: "end",
+              success: true,
+              result: "ok",
+            },
+            // Tool with unparseable parameters
+            {
+              type: "tool",
+              id: "tool-bad-json",
+              name: "Bash",
+              stage: "end",
+              success: true,
+              parameters: "not-json",
+              result: "done",
+            },
+            // Skipped block types (image, bang, error, file_history, task_notification)
+            { type: "image", imageUrls: ["file.png"] },
+            {
+              type: "bang",
+              command: "ls",
+              output: "",
+              stage: "end" as const,
+              exitCode: 0,
+            },
+            { type: "error", content: "err" },
+          ],
+          timestamp: new Date().toISOString(),
+        },
+      ],
     };
     vi.mocked(WaveAgent.create).mockResolvedValue(
       mockWaveAgent as unknown as WaveAgent,
@@ -2803,6 +2798,171 @@ describe("WaveAcpAgent", () => {
       "wave/create_plan",
       expect.objectContaining({
         todos: [{ id: "t1", content: "Cached Task", status: "pending" }],
+      }),
+    );
+  });
+
+  it("should handle session ID change via onSessionIdChange callback", async () => {
+    let capturedCallbacks: AgentOptions["callbacks"];
+    const mockWaveAgent = {
+      sessionId: "session-a",
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      destroy: vi.fn(),
+      getPermissionMode: vi.fn().mockReturnValue("default"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+      messages: [],
+    };
+    vi.mocked(WaveAgent.create).mockImplementation((options: AgentOptions) => {
+      capturedCallbacks = options.callbacks;
+      return Promise.resolve(mockWaveAgent as unknown as WaveAgent);
+    });
+
+    await agent.newSession({ cwd: "/test", mcpServers: [] });
+
+    // onSessionIdChange should be available in the wrapper callbacks
+    const callbacks = capturedCallbacks as unknown as Record<string, unknown>;
+    expect(typeof callbacks.onSessionIdChange).toBe("function");
+
+    const onSessionIdChange = callbacks.onSessionIdChange as (
+      newSessionId: string,
+    ) => void;
+
+    // Trigger session ID change
+    onSessionIdChange("session-b");
+
+    // Verify ext_notification was sent with session_id_change
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "session-a",
+        update: expect.objectContaining({
+          sessionUpdate: "ext_notification",
+          method: "session_id_change",
+          params: { oldSessionId: "session-a", newSessionId: "session-b" },
+        }),
+      }),
+    );
+
+    // Verify the agent is now accessible under the new session ID
+    // by successfully calling prompt with the new ID
+    const response = await agent.prompt({
+      sessionId: "session-b",
+      prompt: [{ type: "text", text: "hello" }],
+    });
+    expect(response.stopReason).toBe("end_turn");
+    expect(mockWaveAgent.sendMessage).toHaveBeenCalledWith("hello", undefined);
+
+    // Old session ID should no longer work
+    await expect(
+      agent.prompt({
+        sessionId: "session-a",
+        prompt: [{ type: "text", text: "hello" }],
+      }),
+    ).rejects.toThrow("Session session-a not found");
+  });
+
+  it("should be a no-op when onSessionIdChange receives the same ID", async () => {
+    let capturedCallbacks: AgentOptions["callbacks"];
+    const mockWaveAgent = {
+      sessionId: "session-same",
+      destroy: vi.fn(),
+      getPermissionMode: vi.fn().mockReturnValue("default"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+      messages: [],
+    };
+    vi.mocked(WaveAgent.create).mockImplementation((options: AgentOptions) => {
+      capturedCallbacks = options.callbacks;
+      return Promise.resolve(mockWaveAgent as unknown as WaveAgent);
+    });
+
+    await agent.newSession({ cwd: "/test", mcpServers: [] });
+    vi.mocked(mockConnection.sessionUpdate).mockClear();
+
+    const callbacks = capturedCallbacks as unknown as Record<string, unknown>;
+    const onSessionIdChange = callbacks.onSessionIdChange as (
+      newSessionId: string,
+    ) => void;
+
+    // Same ID should be a no-op
+    onSessionIdChange("session-same");
+
+    // No ext_notification should be sent
+    const sessionUpdateCalls = vi.mocked(mockConnection.sessionUpdate).mock
+      .calls;
+    const sessionIdChangeCalls = sessionUpdateCalls.filter(
+      (call) =>
+        (call[0] as { update: { method?: string } }).update.method ===
+        "session_id_change",
+    );
+    expect(sessionIdChangeCalls).toHaveLength(0);
+  });
+
+  it("should replay compact block content as agent_message_chunk", async () => {
+    const mockWaveAgent = {
+      sessionId: "compact-replay-session",
+      destroy: vi.fn(),
+      getPermissionMode: vi.fn().mockReturnValue("default"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+      messages: [
+        {
+          id: "msg-compact",
+          role: "assistant",
+          blocks: [
+            {
+              type: "compact",
+              content: "Summary of previous conversation",
+              sessionId: "old-session",
+            },
+          ],
+          timestamp: new Date().toISOString(),
+        },
+        {
+          id: "msg-after",
+          role: "user",
+          blocks: [{ type: "text", content: "Continue from summary" }],
+          timestamp: new Date().toISOString(),
+        },
+      ],
+    };
+    vi.mocked(WaveAgent.create).mockResolvedValue(
+      mockWaveAgent as unknown as WaveAgent,
+    );
+
+    await agent.loadSession({
+      sessionId: "compact-replay-session",
+      cwd: "/test",
+      mcpServers: [],
+    });
+
+    // Compact block should be replayed as agent_message_chunk
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "compact-replay-session",
+        update: expect.objectContaining({
+          sessionUpdate: "agent_message_chunk",
+          content: {
+            type: "text",
+            text: "Summary of previous conversation",
+          },
+          messageId: "msg-compact",
+        }),
+      }),
+    );
+
+    // User message after compact should also be replayed
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "compact-replay-session",
+        update: expect.objectContaining({
+          sessionUpdate: "user_message_chunk",
+          content: { type: "text", text: "Continue from summary" },
+          messageId: "msg-after",
+        }),
       }),
     );
   });


### PR DESCRIPTION
## Problem

When compact or clear commands execute, the agent's internal session ID changes. The ACP bridge had two problems:

1. **No notification**: ACP didn't register `onSessionIdChange`, so the client never learned the new session ID. If the connection dropped and the client reconnected with the old ID, it restored the stale session.
2. **Replay mismatch**: `replayConversationHistory` used `getFullMessageThread()` which followed the `parentSessionId` chain to reconstruct full pre-compact history. But the agent's actual context after compact is just `[compactSummary, last3Messages]`. The client saw detailed old messages that the agent no longer has.

## Changes

- **Remove duplicate `onSessionIdChange` fire** in `messageManager.compactMessagesAndUpdateSession` — `setSessionId()` already triggers it internally
- **Mutable sessionRef** in ACP `createCallbacks` so all callbacks track the current session ID after changes
- **Register `onSessionIdChange` callback** that updates agents Map key, taskCache key, and sends `ext_notification` (`session_id_change`) to ACP client
- **Add `onSessionIdChange` wrapper** in `createAgent` callbacks passed to `WaveAgent.create`
- **Fix `replayConversationHistory`** to use `agent.messages` instead of `getFullMessageThread()`, matching the agent's actual post-compact context
- **Handle compact blocks in replay** as `agent_message_chunk` instead of skipping
- **Add tests** for session ID change notification, dedup, and compact block replay

## Files Modified

| File | Change |
|------|--------|
| `packages/agent-sdk/src/managers/messageManager.ts` | Remove duplicate onSessionIdChange |
| `packages/code/src/acp/agent.ts` | Mutable sessionRef + onSessionIdChange + replay fix + compact block handling |
| `packages/code/tests/acp/agent.test.ts` | 3 new tests + fix 3 existing tests for new replay behavior |