### PR TITLE
fix: align bypassPermissions tool visibility with Claude Code

### DIFF
--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -31,6 +31,7 @@ import {
   EDIT_TOOL_NAME,
   WRITE_TOOL_NAME,
   READ_TOOL_NAME,
+  ASK_USER_QUESTION_TOOL_NAME,
 } from "../constants/tools.js";
 import { Container } from "../utils/container.js";
 import { ConfigurationService } from "../services/configurationService.js";
@@ -440,8 +441,14 @@ export class PermissionManager {
     }
 
     // 1. If bypassPermissions mode, always allow
+    // Exception: tools that require user interaction (e.g. AskUserQuestion)
+    // must still prompt the user, matching Claude Code's requiresUserInteraction behavior.
     if (context.permissionMode === "bypassPermissions") {
-      return { behavior: "allow" };
+      const requiresUserInteraction =
+        context.toolName === ASK_USER_QUESTION_TOOL_NAME;
+      if (!requiresUserInteraction) {
+        return { behavior: "allow" };
+      }
     }
 
     // 1.0 Check worktree safety for Write and Edit tools

--- a/packages/agent-sdk/src/managers/toolManager.ts
+++ b/packages/agent-sdk/src/managers/toolManager.ts
@@ -364,11 +364,7 @@ class ToolManager {
           return false;
         }
         if (effectivePermissionMode === "bypassPermissions") {
-          if (
-            tool.name === "ExitPlanMode" ||
-            tool.name === "AskUserQuestion" ||
-            tool.name === "EnterPlanMode"
-          ) {
+          if (tool.name === "ExitPlanMode") {
             return false;
           }
         }
@@ -376,10 +372,7 @@ class ToolManager {
           return effectivePermissionMode === "plan";
         }
         if (tool.name === "EnterPlanMode") {
-          return (
-            effectivePermissionMode !== "plan" &&
-            effectivePermissionMode !== "bypassPermissions"
-          );
+          return effectivePermissionMode !== "plan";
         }
         return true;
       })

--- a/packages/agent-sdk/tests/managers/permissionManager.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.test.ts
@@ -545,8 +545,25 @@ describe("PermissionManager", () => {
 
           const result = await permissionManager.checkPermission(context);
 
-          expect(result).toEqual({ behavior: "allow" });
+          // AskUserQuestion requires user interaction, so it's not auto-approved
+          if (toolName === "AskUserQuestion") {
+            expect(result.behavior).toBe("deny");
+          } else {
+            expect(result).toEqual({ behavior: "allow" });
+          }
         }
+      });
+
+      it("should not auto-approve AskUserQuestion in bypassPermissions mode", async () => {
+        const context: ToolPermissionContext = {
+          toolName: "AskUserQuestion",
+          permissionMode: "bypassPermissions",
+        };
+
+        const result = await permissionManager.checkPermission(context);
+
+        // AskUserQuestion requires user interaction, falls through to deny without callback
+        expect(result.behavior).toBe("deny");
       });
 
       it("should allow mkdir in bypassPermissions mode", async () => {

--- a/packages/agent-sdk/tests/managers/toolManager.coverage.test.ts
+++ b/packages/agent-sdk/tests/managers/toolManager.coverage.test.ts
@@ -123,7 +123,7 @@ describe("ToolManager - Additional Coverage", () => {
     ).toBeUndefined();
     expect(
       config.find((c) => c.function.name === "AskUserQuestion"),
-    ).toBeUndefined();
+    ).toBeDefined();
     expect(config.find((c) => c.function.name === "NormalTool")).toBeDefined();
   });
 });

--- a/packages/agent-sdk/tests/managers/toolManager.public.test.ts
+++ b/packages/agent-sdk/tests/managers/toolManager.public.test.ts
@@ -119,7 +119,7 @@ describe("ToolManager.initializeBuiltInTools", () => {
 });
 
 describe("ToolManager bypassPermissions mode", () => {
-  it("should exclude ExitPlanMode and AskUserQuestion in bypassPermissions mode", async () => {
+  it("should exclude ExitPlanMode but include EnterPlanMode and AskUserQuestion in bypassPermissions mode", async () => {
     const mockMcpManager = {
       getMcpToolsConfig: vi.fn().mockReturnValue([]),
     } as unknown as McpManager;
@@ -152,7 +152,8 @@ describe("ToolManager bypassPermissions mode", () => {
     const names = toolsConfig.map((t) => t.function.name);
 
     expect(names).not.toContain("ExitPlanMode");
-    expect(names).not.toContain("AskUserQuestion");
+    expect(names).toContain("EnterPlanMode");
+    expect(names).toContain("AskUserQuestion");
     expect(names).toContain("Bash");
     expect(names).toContain("Read");
   });


### PR DESCRIPTION
- Show EnterPlanMode and AskUserQuestion in bypassPermissions mode
- Add requiresUserInteraction check to prevent auto-approving AskUserQuestion
- Matches Claude Code's behavior where bypassPermissions still prompts for user interaction tools
