### PR TITLE
feat: change default max input tokens from 128000 to 200000

### DIFF
--- a/packages/agent-sdk/builtin/skills/settings/ENV.md
+++ b/packages/agent-sdk/builtin/skills/settings/ENV.md
@@ -27,7 +27,7 @@ Wave uses several environment variables to control its core functionality.
 | `WAVE_CUSTOM_HEADERS` | Custom HTTP headers for the AI gateway. Newline-separated `Key: Value` pairs (e.g., `"X-Foo: bar\nAuthorization: Bearer xxx"`). | - |
 | `WAVE_MODEL` | The primary AI model to use for the agent. | `gemini-3-flash` |
 | `WAVE_FAST_MODEL` | The fast AI model to use for quick tasks. | `gemini-2.5-flash` |
-| `WAVE_MAX_INPUT_TOKENS` | Maximum number of input tokens allowed. | `128000` |
+| `WAVE_MAX_INPUT_TOKENS` | Maximum number of input tokens allowed. | `200000` |
 | `WAVE_MAX_OUTPUT_TOKENS` | Maximum number of output tokens allowed. | `16384` |
 | `WAVE_DISABLE_AUTO_MEMORY` | Set to `1` or `true` to disable the auto-memory feature. | `false` |
 | `WAVE_AUTO_MEMORY_FREQUENCY` | Auto memory update frequency. `1` = every turn, `2` = every 2 turns, etc. | `1` |

--- a/packages/agent-sdk/src/utils/constants.ts
+++ b/packages/agent-sdk/src/utils/constants.ts
@@ -29,5 +29,5 @@ export const USER_MEMORY_FILE = path.join(DATA_DIRECTORY, "AGENTS.md");
 /**
  * AI related constants
  */
-export const DEFAULT_WAVE_MAX_INPUT_TOKENS = 128000; // Default token limit
+export const DEFAULT_WAVE_MAX_INPUT_TOKENS = 200000; // Default token limit
 export const DEFAULT_WAVE_MAX_OUTPUT_TOKENS = 16384; // Default output token limit

--- a/packages/agent-sdk/tests/agent/agent.compaction.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.compaction.test.ts
@@ -483,7 +483,7 @@ describe("Agent Message Compaction Tests", () => {
           usage: {
             prompt_tokens: 50000,
             completion_tokens: 20000,
-            total_tokens: 130000, // Exceeds 128000 to trigger compaction
+            total_tokens: DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000, // Exceeds default limit to trigger compaction
           },
         };
       } else {

--- a/packages/agent-sdk/tests/agent/agent.subagentDynamicConfig.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.subagentDynamicConfig.test.ts
@@ -192,7 +192,7 @@ describe("Subagent Dynamic Configuration Tests", () => {
       expect(modelConfig.fastModel).toBe("parent-fast-model");
 
       // Should inherit token limit from parent (using default since not specified)
-      expect(subagentAIManager.getMaxInputTokens()).toBe(128000); // Default value
+      expect(subagentAIManager.getMaxInputTokens()).toBe(200000); // Default value
 
       // Update parent environment variables
       process.env.WAVE_API_KEY = "updated-parent-token";

--- a/packages/code/src/components/InputBox.tsx
+++ b/packages/code/src/components/InputBox.tsx
@@ -62,7 +62,7 @@ export const InputBox: React.FC<InputBoxProps> = ({
   slashCommands = [],
   hasSlashCommand = () => false,
   latestTotalTokens = 0,
-  maxInputTokens = 128000,
+  maxInputTokens = 200000,
   isGoalActive,
   goalElapsed,
 }) => {

--- a/packages/code/src/components/StatusLine.tsx
+++ b/packages/code/src/components/StatusLine.tsx
@@ -16,7 +16,7 @@ export const StatusLine: React.FC<StatusLineProps> = ({
   isGoalActive,
   goalElapsed,
   latestTotalTokens = 0,
-  maxInputTokens = 128000,
+  maxInputTokens = 200000,
 }) => {
   const percentage =
     latestTotalTokens > 0

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -176,7 +176,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
 
   const [messages, setMessages] = useState<Message[]>([]);
   const [latestTotalTokens, setLatestTotalTokens] = useState(0);
-  const [maxInputTokens, setMaxInputTokens] = useState(128000);
+  const [maxInputTokens, setMaxInputTokens] = useState(200000);
 
   const throttledSetMessages = useMemo(
     () =>
@@ -537,7 +537,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
     setSessionId("");
     setIsLoading(false);
     setLatestTotalTokens(0);
-    setMaxInputTokens(128000);
+    setMaxInputTokens(200000);
     setIsCommandRunning(false);
     setIsCompacting(false);
     if (currentSessionId) {

--- a/specs/030-status-line/data-model.md
+++ b/specs/030-status-line/data-model.md
@@ -11,7 +11,7 @@ The interface defining the properties passed to the `StatusLine` component.
 | `isShellCommand` | `boolean` | Whether the current input is a shell command (starts with `!`). |
 | `isBtwActive` | `boolean` | Whether BTW (by-the-way) mode is active. |
 | `latestTotalTokens` | `number?` | Total input tokens consumed so far (default: 0). |
-| `maxInputTokens` | `number?` | Maximum context window size in tokens (default: 128000). |
+| `maxInputTokens` | `number?` | Maximum context window size in tokens (default: 200000). |
 
 ### LoadingIndicatorProps
 The interface defining the properties passed to the `LoadingIndicator` component.
@@ -22,4 +22,4 @@ The interface defining the properties passed to the `LoadingIndicator` component
 | `isCommandRunning` | `boolean?` | Whether a shell command is running. |
 | `isCompacting` | `boolean?` | Whether message compaction is in progress. |
 | `latestTotalTokens` | `number?` | Total input tokens consumed so far (default: 0). |
-| `maxInputTokens` | `number?` | Maximum context window size in tokens (default: 128000). |
+| `maxInputTokens` | `number?` | Maximum context window size in tokens (default: 200000). |

--- a/specs/030-status-line/research.md
+++ b/specs/030-status-line/research.md
@@ -20,7 +20,7 @@ The status line logic is currently inline in `InputBox.tsx` (lines 271-285). It 
 - `calculateComprehensiveTotalTokens()` — `packages/agent-sdk/src/utils/tokenCalculation.ts`
 - `extractLatestTotalTokens()` — `packages/agent-sdk/src/utils/tokenCalculation.ts`
 - `Agent.getMaxInputTokens()` — `packages/agent-sdk/src/agent.ts`
-- `DEFAULT_WAVE_MAX_INPUT_TOKENS = 128000` — `packages/agent-sdk/src/utils/constants.ts`
+- `DEFAULT_WAVE_MAX_INPUT_TOKENS = 200000` — `packages/agent-sdk/src/utils/constants.ts`
 
 ## Risks and Mitigations
 - **Risk**: UI regression.


### PR DESCRIPTION
## Summary

Change the default max input tokens from 128000 to 200000 across the codebase.

## Changes

- `DEFAULT_WAVE_MAX_INPUT_TOKENS` constant in `packages/agent-sdk/src/utils/constants.ts`
- Hardcoded fallback defaults in `useChat.tsx`, `StatusLine.tsx`, `InputBox.tsx`
- `ENV.md` settings documentation
- `specs/030-status-line` research and data-model docs
- Test assertions updated to match new default (subagent dynamic config, compaction threshold)