### PR TITLE
feat(acp): add end-turn usage reporting with usage_update notifications

### DIFF
--- a/packages/code/examples/acp/acp-prompt-usage.ts
+++ b/packages/code/examples/acp/acp-prompt-usage.ts
@@ -1,0 +1,119 @@
+import { spawn } from "node:child_process";
+import { Readable, Writable } from "node:stream";
+import {
+  ClientSideConnection,
+  ndJsonStream,
+  type Client,
+  type SessionNotification,
+} from "@agentclientprotocol/sdk";
+import path from "node:path";
+import os from "node:os";
+import fs from "node:fs";
+
+/**
+ * Demonstrates per-turn token usage and userMessageId echo in ACP mode.
+ *
+ * After each prompt completes, the PromptResponse includes:
+ * - `usage`: per-turn token counts (inputTokens, outputTokens, totalTokens,
+ *   and optionally cachedReadTokens/cachedWriteTokens)
+ * - `userMessageId`: echoes back the messageId provided in the PromptRequest
+ *
+ * This example sends a prompt with a custom messageId and prints the
+ * returned usage breakdown.
+ */
+async function runPromptUsage() {
+  const agentCommand = [
+    "tsx",
+    "--tsconfig",
+    path.join(process.cwd(), "tsconfig.dev.json"),
+    path.join(process.cwd(), "src/index.ts"),
+    "--acp",
+  ];
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "acp-prompt-usage-"));
+  console.log(`Using temporary directory: ${tmpDir}`);
+
+  console.log("Starting agent process...");
+  const agentProcess = spawn(agentCommand[0], [...agentCommand.slice(1)], {
+    stdio: ["pipe", "pipe", "inherit"],
+    env: { ...process.env, NODE_ENV: "integration-test" },
+  });
+
+  const stdin = Writable.toWeb(
+    agentProcess.stdin!,
+  ) as WritableStream<Uint8Array>;
+  const stdout = Readable.toWeb(
+    agentProcess.stdout!,
+  ) as ReadableStream<Uint8Array>;
+
+  const stream = ndJsonStream(stdin, stdout);
+
+  const client: Client = {
+    requestPermission: async () => ({ outcome: "approved" }),
+    sessionUpdate: async (notification: SessionNotification) => {
+      const update = notification.update;
+      if (
+        update.sessionUpdate === "agent_message_chunk" &&
+        update.content.type === "text"
+      ) {
+        process.stdout.write(update.content.text);
+      }
+    },
+  };
+
+  const connection = new ClientSideConnection(() => client, stream);
+
+  try {
+    console.log("Initializing connection...");
+    await connection.initialize({
+      protocolVersion: 1,
+      clientInfo: { name: "prompt-usage-client", version: "1.0.0" },
+    });
+
+    console.log("Creating new session...");
+    const { sessionId } = await connection.newSession({
+      cwd: tmpDir,
+      mcpServers: [],
+    });
+    console.log("New session ID:", sessionId);
+
+    const messageId = "client-msg-001";
+    console.log(`\nSending prompt with messageId="${messageId}"...`);
+    const promptResult = await connection.prompt({
+      sessionId,
+      prompt: [{ type: "text", text: "Say hello in one sentence." }],
+      messageId,
+    });
+
+    console.log("\n\n--- PromptResponse ---");
+    console.log("stopReason:", promptResult.stopReason);
+    console.log("userMessageId:", promptResult.userMessageId);
+    if (promptResult.usage) {
+      const u = promptResult.usage;
+      console.log("usage:");
+      console.log(`  inputTokens:       ${u.inputTokens}`);
+      console.log(`  outputTokens:      ${u.outputTokens}`);
+      console.log(`  totalTokens:       ${u.totalTokens}`);
+      if (u.cachedReadTokens !== undefined) {
+        console.log(`  cachedReadTokens:  ${u.cachedReadTokens}`);
+      }
+      if (u.cachedWriteTokens !== undefined) {
+        console.log(`  cachedWriteTokens: ${u.cachedWriteTokens}`);
+      }
+    } else {
+      console.log("usage: (none reported)");
+    }
+
+    console.log("\nPrompt usage demo completed!");
+  } catch (error) {
+    console.error("Example failed:", error);
+    process.exit(1);
+  } finally {
+    console.log("Cleaning up...");
+    agentProcess.kill();
+    if (fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }
+}
+
+runPromptUsage().catch(console.error);

--- a/packages/code/examples/acp/acp-usage-update.ts
+++ b/packages/code/examples/acp/acp-usage-update.ts
@@ -1,0 +1,117 @@
+import { spawn } from "node:child_process";
+import { Readable, Writable } from "node:stream";
+import {
+  ClientSideConnection,
+  ndJsonStream,
+  type Client,
+  type SessionNotification,
+} from "@agentclientprotocol/sdk";
+import path from "node:path";
+import os from "node:os";
+import fs from "node:fs";
+
+/**
+ * Demonstrates usage_update notifications in ACP mode.
+ *
+ * As the agent processes a prompt, it periodically reports context window
+ * usage via sessionUpdate with sessionUpdate="usage_update". Each update
+ * contains `size` (max context window tokens) and `used` (current tokens).
+ *
+ * This example collects all usage_update notifications during a prompt and
+ * prints the final context window utilization.
+ */
+async function runUsageUpdate() {
+  const agentCommand = [
+    "tsx",
+    "--tsconfig",
+    path.join(process.cwd(), "tsconfig.dev.json"),
+    path.join(process.cwd(), "src/index.ts"),
+    "--acp",
+  ];
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "acp-usage-"));
+  console.log(`Using temporary directory: ${tmpDir}`);
+
+  console.log("Starting agent process...");
+  const agentProcess = spawn(agentCommand[0], [...agentCommand.slice(1)], {
+    stdio: ["pipe", "pipe", "inherit"],
+    env: { ...process.env, NODE_ENV: "integration-test" },
+  });
+
+  const stdin = Writable.toWeb(
+    agentProcess.stdin!,
+  ) as WritableStream<Uint8Array>;
+  const stdout = Readable.toWeb(
+    agentProcess.stdout!,
+  ) as ReadableStream<Uint8Array>;
+
+  const stream = ndJsonStream(stdin, stdout);
+
+  const usageUpdates: Array<{ size: number; used: number }> = [];
+
+  const client: Client = {
+    requestPermission: async () => ({ outcome: "approved" }),
+    sessionUpdate: async (notification: SessionNotification) => {
+      const update = notification.update;
+      if (update.sessionUpdate === "usage_update") {
+        usageUpdates.push({ size: update.size, used: update.used });
+        const pct =
+          update.size > 0
+            ? ((update.used / update.size) * 100).toFixed(1)
+            : "0";
+        console.log(
+          `[Usage Update] ${update.used} / ${update.size} tokens (${pct}%)`,
+        );
+      } else if (
+        update.sessionUpdate === "agent_message_chunk" &&
+        update.content.type === "text"
+      ) {
+        process.stdout.write(update.content.text);
+      }
+    },
+  };
+
+  const connection = new ClientSideConnection(() => client, stream);
+
+  try {
+    console.log("Initializing connection...");
+    await connection.initialize({
+      protocolVersion: 1,
+      clientInfo: { name: "usage-update-client", version: "1.0.0" },
+    });
+
+    console.log("Creating new session...");
+    const { sessionId } = await connection.newSession({
+      cwd: tmpDir,
+      mcpServers: [],
+    });
+    console.log("New session ID:", sessionId);
+
+    console.log('Sending prompt: "Write a short poem about tokens"\n');
+    await connection.prompt({
+      sessionId,
+      prompt: [{ type: "text", text: "Write a short poem about tokens" }],
+    });
+
+    console.log("\n\n--- Usage Update Summary ---");
+    console.log(`Total usage_update notifications: ${usageUpdates.length}`);
+    if (usageUpdates.length > 0) {
+      const last = usageUpdates[usageUpdates.length - 1];
+      console.log(`Final: ${last.used} / ${last.size} tokens`);
+    } else {
+      console.warn("No usage_update notifications received.");
+    }
+
+    console.log("\nUsage update demo completed!");
+  } catch (error) {
+    console.error("Example failed:", error);
+    process.exit(1);
+  } finally {
+    console.log("Cleaning up...");
+    agentProcess.kill();
+    if (fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }
+}
+
+runUsageUpdate().catch(console.error);

--- a/packages/code/src/acp/agent.ts
+++ b/packages/code/src/acp/agent.ts
@@ -21,6 +21,7 @@ import {
   type ReasoningBlock,
   type ToolBlock,
   type CompactBlock,
+  type Usage as SdkUsage,
 } from "wave-agent-sdk";
 import { logger } from "../utils/logger.js";
 import {
@@ -54,6 +55,7 @@ import {
   type EmbeddedResource,
   type ImageContent,
   type McpServer,
+  type Usage,
   AGENT_METHODS,
 } from "@agentclientprotocol/sdk";
 import type { McpServerConfig, McpServerStatus } from "wave-agent-sdk";
@@ -241,6 +243,8 @@ export class WaveAcpAgent implements AcpAgent {
           callbacks.onMcpServersChange?.(servers),
         onSessionIdChange: (newSessionId: string) =>
           callbacks.onSessionIdChange?.(newSessionId),
+        onLatestTotalTokensChange: (tokens: number) =>
+          callbacks.onLatestTotalTokensChange?.(tokens),
       },
     });
 
@@ -391,7 +395,7 @@ export class WaveAcpAgent implements AcpAgent {
   }
 
   async prompt(params: PromptRequest): Promise<PromptResponse> {
-    const { sessionId, prompt } = params;
+    const { sessionId, prompt, messageId } = params;
     logger.info(`Received prompt for session ${sessionId}`);
     logger.debug(`Prompt content for session ${sessionId}:`, prompt);
     const agent = this.agents.get(sessionId);
@@ -426,6 +430,8 @@ export class WaveAcpAgent implements AcpAgent {
 
     const textContent = textBlocks.join("\n");
 
+    const usagesBefore = agent.usages.length;
+
     try {
       await agent.sendMessage(
         textContent,
@@ -434,12 +440,16 @@ export class WaveAcpAgent implements AcpAgent {
       logger.info(`Message sent successfully for session ${sessionId}`);
       return {
         stopReason: "end_turn" as StopReason,
+        ...mapTurnUsage(agent.usages.slice(usagesBefore)),
+        ...(messageId ? { userMessageId: messageId } : {}),
       };
     } catch (error) {
       if (error instanceof Error && error.message.includes("abort")) {
         logger.info(`Message aborted for session ${sessionId}`);
         return {
           stopReason: "cancelled" as StopReason,
+          ...mapTurnUsage(agent.usages.slice(usagesBefore)),
+          ...(messageId ? { userMessageId: messageId } : {}),
         };
       }
       logger.error(`Error sending message for session ${sessionId}:`, error);
@@ -1370,6 +1380,18 @@ export class WaveAcpAgent implements AcpAgent {
             },
           });
         },
+        onLatestTotalTokensChange: (tokens: number) => {
+          const agent = getAgent();
+          const contextWindowSize = agent?.getMaxInputTokens() ?? 0;
+          this.connection.sessionUpdate({
+            sessionId: sessionRef.id as AcpSessionId,
+            update: {
+              sessionUpdate: "usage_update" as const,
+              size: contextWindowSize,
+              used: tokens,
+            },
+          });
+        },
       },
       sessionRef,
     };
@@ -1428,4 +1450,32 @@ function convertHttpHeaders(
     result[entry.name] = entry.value;
   }
   return result;
+}
+
+/**
+ * Map per-turn SDK usages to a single ACP Usage object.
+ * Returns undefined when there are no usage entries.
+ */
+function mapTurnUsage(newUsages: SdkUsage[]): { usage?: Usage } {
+  if (newUsages.length === 0) return {};
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let totalTokens = 0;
+  let cachedReadTokens = 0;
+  let cachedWriteTokens = 0;
+  for (const u of newUsages) {
+    inputTokens += u.prompt_tokens;
+    outputTokens += u.completion_tokens;
+    totalTokens += u.total_tokens;
+    cachedReadTokens += u.cache_read_input_tokens ?? 0;
+    cachedWriteTokens += u.cache_creation_input_tokens ?? 0;
+  }
+  const usage: Usage = {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+  };
+  if (cachedReadTokens > 0) usage.cachedReadTokens = cachedReadTokens;
+  if (cachedWriteTokens > 0) usage.cachedWriteTokens = cachedWriteTokens;
+  return { usage };
 }

--- a/packages/code/tests/acp/agent.test.ts
+++ b/packages/code/tests/acp/agent.test.ts
@@ -738,6 +738,7 @@ describe("WaveAcpAgent", () => {
       sessionId: "session-1",
       sendMessage: vi.fn().mockResolvedValue(undefined),
       saveSession: vi.fn().mockResolvedValue(undefined),
+      usages: [],
       getPermissionMode: vi.fn().mockReturnValue("default"),
       getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
       getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
@@ -1500,6 +1501,7 @@ describe("WaveAcpAgent", () => {
       sessionId: "session-1",
       sendMessage: vi.fn().mockResolvedValue(undefined),
       saveSession: vi.fn().mockResolvedValue(undefined),
+      usages: [],
       getPermissionMode: vi.fn().mockReturnValue("default"),
       getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
       getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
@@ -1535,6 +1537,7 @@ describe("WaveAcpAgent", () => {
       sessionId: "session-1",
       sendMessage: vi.fn().mockRejectedValue(new Error("failed")),
       saveSession: vi.fn().mockResolvedValue(undefined),
+      usages: [],
       getPermissionMode: vi.fn().mockReturnValue("default"),
       getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
       getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
@@ -1565,6 +1568,7 @@ describe("WaveAcpAgent", () => {
       sessionId: "session-1",
       sendMessage: vi.fn().mockRejectedValue(new Error("abort")),
       saveSession: vi.fn().mockResolvedValue(undefined),
+      usages: [],
       getPermissionMode: vi.fn().mockReturnValue("default"),
       getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
       getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
@@ -2136,6 +2140,7 @@ describe("WaveAcpAgent", () => {
       sessionId: "session-1",
       sendMessage: vi.fn().mockResolvedValue(undefined),
       saveSession: vi.fn().mockResolvedValue(undefined),
+      usages: [],
       getPermissionMode: vi.fn().mockReturnValue("default"),
       getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
       getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
@@ -2168,6 +2173,7 @@ describe("WaveAcpAgent", () => {
       sessionId: "session-1",
       sendMessage: vi.fn().mockResolvedValue(undefined),
       saveSession: vi.fn().mockResolvedValue(undefined),
+      usages: [],
       getPermissionMode: vi.fn().mockReturnValue("default"),
       getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
       getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
@@ -2841,6 +2847,7 @@ describe("WaveAcpAgent", () => {
       sessionId: "session-a",
       sendMessage: vi.fn().mockResolvedValue(undefined),
       destroy: vi.fn(),
+      usages: [],
       getPermissionMode: vi.fn().mockReturnValue("default"),
       getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
       getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
@@ -2998,5 +3005,207 @@ describe("WaveAcpAgent", () => {
         }),
       }),
     );
+  });
+
+  it("should send usage_update sessionUpdate on onLatestTotalTokensChange", async () => {
+    let capturedCallbacks: AgentOptions["callbacks"];
+    const mockWaveAgent = {
+      sessionId: "session-1",
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      getPermissionMode: vi.fn().mockReturnValue("default"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+      getMaxInputTokens: vi.fn().mockReturnValue(200000),
+    };
+    vi.mocked(WaveAgent.create).mockImplementation((options: AgentOptions) => {
+      capturedCallbacks = options.callbacks;
+      return Promise.resolve(mockWaveAgent as unknown as WaveAgent);
+    });
+
+    await agent.newSession({ cwd: "/test", mcpServers: [] });
+
+    capturedCallbacks!.onLatestTotalTokensChange!(50000);
+
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          sessionUpdate: "usage_update",
+          size: 200000,
+          used: 50000,
+        }),
+      }),
+    );
+  });
+
+  it("should return per-turn usage in PromptResponse", async () => {
+    const usages: Array<Record<string, number>> = [];
+    const mockWaveAgent = {
+      sessionId: "session-1",
+      sendMessage: vi.fn().mockImplementation(async () => {
+        usages.push({
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
+        });
+      }),
+      getPermissionMode: vi.fn().mockReturnValue("default"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+      get usages() {
+        return usages;
+      },
+    };
+    vi.mocked(WaveAgent.create).mockResolvedValue(
+      mockWaveAgent as unknown as WaveAgent,
+    );
+
+    await agent.newSession({ cwd: "/test", mcpServers: [] });
+
+    const response = await agent.prompt({
+      sessionId: "session-1",
+      prompt: [{ type: "text", text: "hello" }],
+    });
+
+    expect(response.usage).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 150,
+    });
+    expect(response.usage).not.toHaveProperty("cachedReadTokens");
+    expect(response.usage).not.toHaveProperty("cachedWriteTokens");
+  });
+
+  it("should include cache tokens in usage when present", async () => {
+    const usages: Array<Record<string, number>> = [];
+    const mockWaveAgent = {
+      sessionId: "session-1",
+      sendMessage: vi.fn().mockImplementation(async () => {
+        usages.push({
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
+          cache_read_input_tokens: 30,
+          cache_creation_input_tokens: 20,
+        });
+      }),
+      getPermissionMode: vi.fn().mockReturnValue("default"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+      get usages() {
+        return usages;
+      },
+    };
+    vi.mocked(WaveAgent.create).mockResolvedValue(
+      mockWaveAgent as unknown as WaveAgent,
+    );
+
+    await agent.newSession({ cwd: "/test", mcpServers: [] });
+
+    const response = await agent.prompt({
+      sessionId: "session-1",
+      prompt: [{ type: "text", text: "hello" }],
+    });
+
+    expect(response.usage).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 150,
+      cachedReadTokens: 30,
+      cachedWriteTokens: 20,
+    });
+  });
+
+  it("should echo userMessageId from PromptRequest", async () => {
+    const mockWaveAgent = {
+      sessionId: "session-1",
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      getPermissionMode: vi.fn().mockReturnValue("default"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+      usages: [],
+    };
+    vi.mocked(WaveAgent.create).mockResolvedValue(
+      mockWaveAgent as unknown as WaveAgent,
+    );
+
+    await agent.newSession({ cwd: "/test", mcpServers: [] });
+
+    const response = await agent.prompt({
+      sessionId: "session-1",
+      prompt: [{ type: "text", text: "hello" }],
+      messageId: "msg-123",
+    });
+
+    expect(response.userMessageId).toBe("msg-123");
+  });
+
+  it("should omit usage from PromptResponse when no usages tracked", async () => {
+    const mockWaveAgent = {
+      sessionId: "session-1",
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      getPermissionMode: vi.fn().mockReturnValue("default"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+      usages: [],
+    };
+    vi.mocked(WaveAgent.create).mockResolvedValue(
+      mockWaveAgent as unknown as WaveAgent,
+    );
+
+    await agent.newSession({ cwd: "/test", mcpServers: [] });
+
+    const response = await agent.prompt({
+      sessionId: "session-1",
+      prompt: [{ type: "text", text: "hello" }],
+    });
+
+    expect(response.usage).toBeUndefined();
+  });
+
+  it("should sum multiple usage entries for a single turn", async () => {
+    const usages: Array<Record<string, number>> = [];
+    const mockWaveAgent = {
+      sessionId: "session-1",
+      sendMessage: vi.fn().mockImplementation(async () => {
+        usages.push({
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
+        });
+        usages.push({
+          prompt_tokens: 200,
+          completion_tokens: 100,
+          total_tokens: 300,
+        });
+      }),
+      getPermissionMode: vi.fn().mockReturnValue("default"),
+      getConfiguredModels: vi.fn().mockReturnValue(["test-model"]),
+      getModelConfig: vi.fn().mockReturnValue({ model: "test-model" }),
+      getSlashCommands: vi.fn().mockReturnValue([]),
+      get usages() {
+        return usages;
+      },
+    };
+    vi.mocked(WaveAgent.create).mockResolvedValue(
+      mockWaveAgent as unknown as WaveAgent,
+    );
+
+    await agent.newSession({ cwd: "/test", mcpServers: [] });
+
+    const response = await agent.prompt({
+      sessionId: "session-1",
+      prompt: [{ type: "text", text: "hello" }],
+    });
+
+    expect(response.usage).toEqual({
+      inputTokens: 300,
+      outputTokens: 150,
+      totalTokens: 450,
+    });
   });
 });


### PR DESCRIPTION
- Wire onLatestTotalTokensChange callback to send usage_update sessionUpdate
  with context window size and used tokens during agent turns
- Return per-turn token usage (inputTokens, outputTokens, totalTokens,
  cachedReadTokens, cachedWriteTokens) in PromptResponse via mapTurnUsage helper
- Echo client-provided messageId as userMessageId in PromptResponse
- Add 6 tests covering usage_update, per-turn usage, cache tokens,
  userMessageId echo, empty usage omission, and multiple entries summed
- Add 2 examples: acp-usage-update.ts and acp-prompt-usage.ts
