### PR TITLE
feat: persist plan mode reminder as meta message instead of transient injection

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -4,7 +4,6 @@ import { convertMessagesForAPI } from "../utils/convertMessagesForAPI.js";
 import { microcompactMessages } from "../utils/microcompact.js";
 import { parseTaskNotificationXml } from "../utils/notificationXml.js";
 import { calculateComprehensiveTotalTokens } from "../utils/tokenCalculation.js";
-import * as fs from "node:fs/promises";
 import { existsSync } from "node:fs";
 import type {
   GatewayConfig,
@@ -238,32 +237,29 @@ export class AIManager {
   }
 
   /**
-   * Build plan mode system-reminder messages to inject into the API message stream.
-   * These are transient messages not stored in the message history.
-   * This preserves prompt caching by keeping the system prompt constant.
+   * Add plan mode reminder as a persistent meta message to the message manager.
+   * Called before getMessages() so the stored message is included in the API call.
    */
-  private buildPlanModeMessages(
+  private maybeAddPlanModeMessage(
     currentMode: PermissionMode | undefined,
-  ): import("openai/resources.js").ChatCompletionMessageParam[] {
-    const messages: import("openai/resources.js").ChatCompletionMessageParam[] =
-      [];
-    if (!this.permissionManager) return messages;
+  ): void {
+    if (!this.permissionManager) return;
 
     // Handle exit notification (one-time after leaving plan mode)
     if (this.permissionManager.getNeedsPlanModeExitAttachment()) {
       const planFilePath = this.permissionManager.getPlanFilePath();
       const planExists = planFilePath ? existsSync(planFilePath) : false;
-      messages.push({
-        role: "user",
+      this.messageManager.addUserMessage({
         content: buildExitedPlanModeReminder(planFilePath, planExists),
+        isMeta: true,
       });
       this.permissionManager.setNeedsPlanModeExitAttachment(false);
     }
 
-    if (currentMode !== "plan") return messages;
+    if (currentMode !== "plan") return;
 
     const planFilePath = this.permissionManager.getPlanFilePath();
-    if (!planFilePath) return messages;
+    if (!planFilePath) return;
 
     const planExists = existsSync(planFilePath);
 
@@ -272,25 +268,23 @@ export class AIManager {
     if (planMgr?.isPlanEntryReminderPending()) {
       if (this.permissionManager.hasExitedPlanModeInSession() && planExists) {
         // Re-entry: use small reminder
-        messages.push({
-          role: "user",
+        this.messageManager.addUserMessage({
           content: buildPlanModeReEntryReminder(planFilePath),
+          isMeta: true,
         });
       } else {
         // First entry: use full reminder
-        messages.push({
-          role: "user",
+        this.messageManager.addUserMessage({
           content: buildPlanModeReminder(
             planFilePath,
             planExists,
             !!this.subagentType,
           ),
+          isMeta: true,
         });
       }
       planMgr.consumePlanEntryReminder();
     }
-
-    return messages;
   }
 
   public setIsLoading(isLoading: boolean): void {
@@ -470,6 +464,25 @@ export class AIManager {
         compactUsage,
       );
 
+      // Re-add plan mode reminder as persistent meta message after compaction
+      const postCompactMode = this.permissionManager?.getCurrentEffectiveMode(
+        this.getModelConfig().permissionMode,
+      );
+      if (postCompactMode === "plan") {
+        const planFilePath = this.permissionManager?.getPlanFilePath();
+        if (planFilePath) {
+          const planExists = existsSync(planFilePath);
+          this.messageManager.addUserMessage({
+            content: buildPlanModeReminder(
+              planFilePath,
+              planExists,
+              !!this.subagentType,
+            ),
+            isMeta: true,
+          });
+        }
+      }
+
       // 8. Track usage
       if (compactUsage && this.callbacks?.onUsageAdded) {
         this.callbacks.onUsageAdded(compactUsage);
@@ -567,26 +580,6 @@ export class AIManager {
       contextParts.push(`\n\n## ${file.path}\n\`\`\`\n${file.content}\n\`\`\``);
       if (contextParts.length >= POST_COMPACT_MAX_FILES_TO_RESTORE) break;
       if (usedTokens >= POST_COMPACT_TOKEN_BUDGET) break;
-    }
-
-    // 2. Plan mode context
-    const currentMode = this.permissionManager?.getCurrentEffectiveMode(
-      this.getModelConfig().permissionMode,
-    );
-    if (currentMode === "plan") {
-      const planFilePath = this.permissionManager?.getPlanFilePath();
-      if (planFilePath) {
-        let planExists = false;
-        try {
-          await fs.access(planFilePath);
-          planExists = true;
-        } catch {
-          // Plan file doesn't exist yet
-        }
-        contextParts.push(
-          `\n\n${buildPlanModeReminder(planFilePath, planExists, !!this.subagentType)}`,
-        );
-      }
     }
 
     // 4. Invoked skills context (with token budget, matching Claude Code)
@@ -784,6 +777,14 @@ export class AIManager {
       toolAbortController = this.toolAbortController!;
     }
 
+    // Get current permission mode
+    const currentMode = this.permissionManager?.getCurrentEffectiveMode(
+      this.getModelConfig().permissionMode,
+    );
+
+    // Add plan mode reminder as persistent meta message before getting messages
+    this.maybeAddPlanModeMessage(currentMode);
+
     // Get recent message history with microcompact applied
     const rawMessages = this.messageManager.getMessages();
     const microcompactedMessages = microcompactMessages(rawMessages, {
@@ -801,22 +802,11 @@ export class AIManager {
 
       logger?.debug("modelConfig in sendAIMessage", this.getModelConfig());
 
-      // Get current permission mode and plan file path
-      const currentMode = this.permissionManager?.getCurrentEffectiveMode(
-        this.getModelConfig().permissionMode,
-      );
       const toolsConfig = this.getFilteredToolsConfig();
       const toolNames = new Set(toolsConfig.map((t) => t.function.name));
       const filteredToolPlugins = this.toolManager
         .getTools()
         .filter((t) => toolNames.has(t.name));
-
-      // Inject plan mode system-reminder messages (not system prompt)
-      // This preserves prompt caching by keeping the system prompt constant
-      const planModeMessages = this.buildPlanModeMessages(currentMode);
-      if (planModeMessages.length > 0) {
-        recentMessages.push(...planModeMessages);
-      }
 
       let autoMemoryOptions: { directory: string; content: string } | undefined;
 

--- a/packages/agent-sdk/src/managers/messageManager.ts
+++ b/packages/agent-sdk/src/managers/messageManager.ts
@@ -308,14 +308,6 @@ export class MessageManager {
         return;
       }
 
-      // Filter out meta messages
-      const meaningfulMessages = unsavedMessages.filter((m) => !m.isMeta);
-
-      if (meaningfulMessages.length === 0) {
-        // No meaningful messages to save
-        return;
-      }
-
       // Create session if needed (only when we have messages to save)
       if (this.savedMessageCount === 0) {
         // This is the first time saving messages, so create the session
@@ -325,7 +317,7 @@ export class MessageManager {
       // Use JSONL format for new sessions
       await appendMessages(
         this.sessionId,
-        meaningfulMessages, // Only append meaningful messages
+        unsavedMessages,
         this.workdir,
         this.sessionType,
         this.rootSessionId,

--- a/packages/agent-sdk/tests/integration/planMode.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/planMode.integration.test.ts
@@ -78,25 +78,43 @@ describe("Plan Mode Integration", () => {
     const calls = vi.mocked(callAgent).mock.calls;
 
     // Plan mode content is now injected as user messages, not in systemPrompt
+    // convertMessagesForAPI converts user content to content parts arrays
+    const getText = (content: unknown): string => {
+      if (typeof content === "string") return content;
+      if (Array.isArray(content))
+        return content
+          .map((p: { type: string; text?: string }) =>
+            p.type === "text" ? (p.text ?? "") : "",
+          )
+          .join("");
+      return "";
+    };
     const callWithPlanInfo = calls.find((call) => {
       const options = call[0];
       const userMessages =
-        (options.messages as Array<{ role: string; content: string }>)?.filter(
+        (options.messages as Array<{ role: string; content: unknown }>)?.filter(
           (m) => m.role === "user",
         ) ?? [];
-      return userMessages.some((m) => m.content?.includes("Plan File Info"));
+      return userMessages.some((m) =>
+        getText(m.content).includes("Plan File Info"),
+      );
     });
 
     expect(callWithPlanInfo).toBeDefined();
     if (callWithPlanInfo) {
       const userMessages = (
-        callWithPlanInfo[0].messages as Array<{ role: string; content: string }>
+        callWithPlanInfo[0].messages as Array<{
+          role: string;
+          content: unknown;
+        }>
       ).filter((m) => m.role === "user");
       const planMessage = userMessages.find((m) =>
-        m.content?.includes("Plan File Info"),
+        getText(m.content).includes("Plan File Info"),
       );
       expect(planMessage).toBeDefined();
-      expect(planMessage!.content).toContain("No plan file exists yet");
+      expect(getText(planMessage!.content)).toContain(
+        "No plan file exists yet",
+      );
     }
   });
 

--- a/packages/agent-sdk/tests/managers/aiManager.plan.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.plan.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect, vi, beforeEach, type Mocked } from "vitest";
 import { Container } from "../../src/utils/container.js";
 import { TaskManager } from "../../src/services/taskManager.js";
 import { AIManager } from "../../src/managers/aiManager.js";
-import fs from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { callAgent } from "../../src/services/aiService.js";
+import { callAgent, compactMessages } from "../../src/services/aiService.js";
 import { DEFAULT_SYSTEM_PROMPT } from "../../src/prompts/index.js";
 import type { MessageManager } from "../../src/managers/messageManager.js";
 import type { ToolManager } from "../../src/managers/toolManager.js";
 import type { PermissionManager } from "../../src/managers/permissionManager.js";
 import type { PlanManager } from "../../src/managers/planManager.js";
+import type { Message } from "../../src/types/index.js";
 
 vi.mock("node:fs/promises");
 vi.mock("node:fs", () => ({
@@ -26,24 +26,66 @@ vi.mock("../../src/services/memory.js", () => ({
   getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
 }));
 
+/** Extract text from API message content (string or content parts array). */
+function extractText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((p: { type: string; text?: string }) =>
+        p.type === "text" ? (p.text ?? "") : "",
+      )
+      .join("");
+  }
+  return "";
+}
+
 describe("AIManager Plan Mode Prompt", () => {
   let aiManager: AIManager;
   let mockMessageManager: Mocked<MessageManager>;
   let mockToolManager: Mocked<ToolManager>;
   let mockPermissionManager: Mocked<PermissionManager>;
   let mockPlanManager: Mocked<PlanManager>;
+  let mockMessages: Message[];
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockMessages = [];
+
     mockMessageManager = {
       getSessionId: vi.fn().mockReturnValue("test-session"),
-      getMessages: vi.fn().mockReturnValue([]),
+      getMessages: vi.fn(() => [...mockMessages]),
       saveSession: vi.fn().mockResolvedValue(undefined),
-      addAssistantMessage: vi.fn(),
+      addAssistantMessage: vi.fn(() => {
+        mockMessages.push({
+          id: `assistant-${mockMessages.length}`,
+          role: "assistant",
+          blocks: [{ type: "text", content: "hello" }],
+          timestamp: new Date().toISOString(),
+        } as Message);
+      }),
+      addUserMessage: vi.fn((params: { content: string; isMeta?: boolean }) => {
+        mockMessages.push({
+          id: `user-${mockMessages.length}`,
+          role: "user",
+          blocks: [{ type: "text", content: params.content }],
+          timestamp: new Date().toISOString(),
+          isMeta: params.isMeta,
+        } as Message);
+      }),
       updateCurrentMessageContent: vi.fn(),
       setlatestTotalTokens: vi.fn(),
       getCombinedMemory: vi.fn().mockResolvedValue(""),
       addErrorBlock: vi.fn(),
+      touchFile: vi.fn(),
+      getTranscriptPath: vi.fn().mockReturnValue("/test/transcript.jsonl"),
+      getRecentFileReads: vi.fn().mockReturnValue([]),
+      getInvokedSkillNames: vi.fn().mockReturnValue([]),
+      setMessages: vi.fn((msgs: Message[]) => {
+        mockMessages = [...msgs];
+      }),
+      finalizeStreamingBlocks: vi.fn(),
+      mergeAssistantAdditionalFields: vi.fn(),
+      compactMessagesAndUpdateSession: vi.fn(),
     } as unknown as Mocked<MessageManager>;
     mockToolManager = {
       getToolsConfig: vi.fn().mockReturnValue([]),
@@ -104,6 +146,14 @@ describe("AIManager Plan Mode Prompt", () => {
       content: "hello",
       finish_reason: "stop",
     });
+    vi.mocked(compactMessages).mockResolvedValue({
+      content: "compacted summary",
+      usage: {
+        prompt_tokens: 100,
+        completion_tokens: 50,
+        total_tokens: 150,
+      },
+    });
   });
 
   it("should use default system prompt in default mode", async () => {
@@ -119,90 +169,130 @@ describe("AIManager Plan Mode Prompt", () => {
   it("should add plan reminder in plan mode when file does not exist", async () => {
     mockPermissionManager.getCurrentEffectiveMode.mockReturnValue("plan");
     vi.mocked(existsSync).mockReturnValue(false);
-    vi.mocked(fs.access).mockRejectedValue(new Error("ENOENT"));
 
     await aiManager.sendAIMessage();
 
     const callOptions = vi.mocked(callAgent).mock.calls[0][0];
     const userMessages = (
-      callOptions.messages as Array<{ role: string; content: string }>
+      callOptions.messages as Array<{ role: string; content: unknown }>
     ).filter((m) => m.role === "user");
     const planMessage = userMessages.find((m) =>
-      m.content?.includes("Plan File Info"),
+      extractText(m.content).includes("Plan File Info"),
     );
     expect(planMessage).toBeDefined();
-    expect(planMessage!.content).toContain(
+    expect(extractText(planMessage!.content)).toContain(
       "Plan mode is active. The user indicated that they do not want you to execute yet",
     );
-    expect(planMessage!.content).toContain("No plan file exists yet");
-    expect(planMessage!.content).toContain("using the Write tool");
+    expect(extractText(planMessage!.content)).toContain(
+      "No plan file exists yet",
+    );
+    expect(extractText(planMessage!.content)).toContain("using the Write tool");
   });
 
   it("should add plan reminder in plan mode when file exists", async () => {
     mockPermissionManager.getCurrentEffectiveMode.mockReturnValue("plan");
     vi.mocked(existsSync).mockReturnValue(true);
-    vi.mocked(fs.access).mockResolvedValue(undefined);
 
     await aiManager.sendAIMessage();
 
     const callOptions = vi.mocked(callAgent).mock.calls[0][0];
     const userMessages = (
-      callOptions.messages as Array<{ role: string; content: string }>
+      callOptions.messages as Array<{ role: string; content: unknown }>
     ).filter((m) => m.role === "user");
     const planMessage = userMessages.find((m) =>
-      m.content?.includes("Plan File Info"),
+      extractText(m.content).includes("Plan File Info"),
     );
     expect(planMessage).toBeDefined();
-    expect(planMessage!.content).toContain(
+    expect(extractText(planMessage!.content)).toContain(
       "Plan mode is active. The user indicated that they do not want you to execute yet",
     );
-    expect(planMessage!.content).toContain("A plan file already exists");
-    expect(planMessage!.content).toContain("using the Edit tool");
+    expect(extractText(planMessage!.content)).toContain(
+      "A plan file already exists",
+    );
+    expect(extractText(planMessage!.content)).toContain("using the Edit tool");
   });
 
-  it("should not add plan reminder on second call (one-time)", async () => {
+  it("should persist plan reminder across calls (one-time injection)", async () => {
     mockPermissionManager.getCurrentEffectiveMode.mockReturnValue("plan");
     vi.mocked(existsSync).mockReturnValue(false);
-    vi.mocked(fs.access).mockRejectedValue(new Error("ENOENT"));
 
     // First call: reminder is pending
     mockPlanManager.isPlanEntryReminderPending.mockReturnValue(true);
     await aiManager.sendAIMessage();
 
     // consumePlanEntryReminder was called, making pending = false
-    expect(mockPlanManager.consumePlanEntryReminder).toHaveBeenCalled();
+    expect(mockPlanManager.consumePlanEntryReminder).toHaveBeenCalledTimes(1);
+
+    // First call: plan message is present
+    const firstCallOptions = vi.mocked(callAgent).mock.calls[0][0];
+    const firstUserMessages = (
+      firstCallOptions.messages as Array<{ role: string; content: unknown }>
+    ).filter((m) => m.role === "user");
+    const firstPlanMessage = firstUserMessages.find((m) =>
+      extractText(m.content).includes("Plan mode is active"),
+    );
+    expect(firstPlanMessage).toBeDefined();
 
     // Second call: reminder consumed, no longer pending
     mockPlanManager.isPlanEntryReminderPending.mockReturnValue(false);
     await aiManager.sendAIMessage();
 
-    const callOptions = vi.mocked(callAgent).mock.calls[1][0];
-    const userMessages = (
-      callOptions.messages as Array<{ role: string; content: string }>
+    // consumePlanEntryReminder should NOT be called again
+    expect(mockPlanManager.consumePlanEntryReminder).toHaveBeenCalledTimes(1);
+
+    // Second call: plan message is STILL present (persistent in messageManager)
+    const secondCallOptions = vi.mocked(callAgent).mock.calls[1][0];
+    const secondUserMessages = (
+      secondCallOptions.messages as Array<{ role: string; content: unknown }>
     ).filter((m) => m.role === "user");
-    const planMessage = userMessages.find((m) =>
-      m.content?.includes("Plan mode is active"),
+    const secondPlanMessage = secondUserMessages.find((m) =>
+      extractText(m.content).includes("Plan mode is active"),
     );
-    expect(planMessage).toBeUndefined();
+    expect(secondPlanMessage).toBeDefined();
   });
 
   it("should add re-entry reminder when re-entering plan mode", async () => {
     mockPermissionManager.getCurrentEffectiveMode.mockReturnValue("plan");
     mockPermissionManager.hasExitedPlanModeInSession.mockReturnValue(true);
     vi.mocked(existsSync).mockReturnValue(true);
-    vi.mocked(fs.access).mockResolvedValue(undefined);
     mockPlanManager.isPlanEntryReminderPending.mockReturnValue(true);
 
     await aiManager.sendAIMessage();
 
     const callOptions = vi.mocked(callAgent).mock.calls[0][0];
     const userMessages = (
-      callOptions.messages as Array<{ role: string; content: string }>
+      callOptions.messages as Array<{ role: string; content: unknown }>
     ).filter((m) => m.role === "user");
     const planMessage = userMessages.find((m) =>
-      m.content?.includes("Re-entering Plan Mode"),
+      extractText(m.content).includes("Re-entering Plan Mode"),
     );
     expect(planMessage).toBeDefined();
-    expect(planMessage!.content).toContain("returning to plan mode");
+    expect(extractText(planMessage!.content)).toContain(
+      "returning to plan mode",
+    );
+  });
+
+  it("should re-add plan mode reminder after compaction", async () => {
+    mockPermissionManager.getCurrentEffectiveMode.mockReturnValue("plan");
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    // Need messages to compact (compactConversation skips if empty)
+    mockMessages.push({
+      id: "existing",
+      role: "user",
+      blocks: [{ type: "text", content: "hello" }],
+      timestamp: new Date().toISOString(),
+    } as Message);
+
+    await aiManager.compactConversation();
+
+    // After compaction, a plan mode meta message should have been added
+    const addUserMessageCalls = vi.mocked(mockMessageManager.addUserMessage)
+      .mock.calls;
+    const planMetaCall = addUserMessageCalls.find((call) =>
+      call[0]?.content?.includes("Plan mode is active"),
+    );
+    expect(planMetaCall).toBeDefined();
+    expect(planMetaCall![0].isMeta).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Plan mode reminders (containing the plan file path) were previously injected transiently into the API message stream and lost after each call. This caused the agent to lose track of the plan file path during multi-turn exploration, leading to writes to wrong files.

## Changes

- **Replace  (transient) with ** — stores as persistent  user message via 
- **Move reminder injection before ** in  so the stored message is included in the API call
- **Remove plan mode section from ** — no longer needed since reminder is a persistent message
- **Add post-compaction re-injection** in  — re-adds the plan reminder after messages are cleared
- **Remove meta message filter in ** — meta messages now persist to disk
- **Replace async  with sync ** — remove unused  import
- **Update tests** — verify persistent behavior across calls, re-addition after compaction, and handle  content parts array format

## Test Results

- agent-sdk: 3063 passed, 1 skipped (232 files)
- wave-code: 1045 passed (83 files)