### PR TITLE
fix: serialize non-safe tool calls and add staleness check for Edit/Write

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -74,6 +74,8 @@ export class AIManager {
   private originalWorkdir: string;
   private consecutiveCompactionFailures: number = 0;
   private readonly maxTurns?: number;
+  /** Tracks file mtime/hash at read time for staleness detection on Edit/Write */
+  private readFileState = new Map<string, { mtime: number; hash: string }>();
   /** Override tool_choice for this AI manager (e.g. for structured output) */
   public toolChoiceOverride?:
     | "auto"
@@ -991,218 +993,52 @@ export class AIManager {
       }
 
       if (toolCalls.length > 0) {
-        // Execute all tools in parallel using Promise.all
-        const toolExecutionPromises = toolCalls.map(
-          async (functionToolCall) => {
-            const toolId = functionToolCall.id || "";
+        // Partition tool calls into batches: consecutive concurrency-safe
+        // tools run in parallel, non-safe tools (Edit, Write, MCP) run one
+        // at a time to prevent read-modify-write races on the same file.
+        const batches: {
+          calls: ChatCompletionMessageFunctionToolCall[];
+          safe: boolean;
+        }[] = [];
+        for (const call of toolCalls) {
+          const toolName = call.function?.name || "";
+          const safe = this.toolManager.isConcurrencySafe(toolName);
+          const lastBatch = batches[batches.length - 1];
+          if (lastBatch && lastBatch.safe && safe) {
+            lastBatch.calls.push(call);
+          } else {
+            batches.push({ calls: [call], safe });
+          }
+        }
 
-            // Check if already interrupted, skip tool execution if so
-            if (
-              abortController.signal.aborted ||
-              toolAbortController.signal.aborted
-            ) {
-              return;
-            }
-
-            const toolName = functionToolCall.function?.name || "";
-            // Safely parse tool parameters, handle tools without parameters
-            let toolArgs: Record<string, unknown> = {};
-            let jsonRecovered = false;
-            const argsString = functionToolCall.function?.arguments?.trim();
-
-            if (!argsString || argsString === "") {
-              // Tool without parameters, use empty object
-              toolArgs = {};
-            } else {
-              let recoveredArgs = argsString;
-              try {
-                toolArgs = JSON.parse(argsString);
-              } catch {
-                // Attempt to recover truncated JSON (e.g., missing closing braces)
-                recoveredArgs = recoverTruncatedJson(argsString);
-                try {
-                  toolArgs = JSON.parse(recoveredArgs);
-                  jsonRecovered = true;
-                  logger.warn(
-                    `Recovered truncated JSON for tool "${toolName}"`,
-                  );
-                } catch (parseError) {
-                  let errorMessage = `Failed to parse tool arguments`;
-                  if (result.finish_reason === "length") {
-                    errorMessage +=
-                      " (output truncated, please reduce your output)";
-                  }
-                  logger?.error(errorMessage, parseError);
-                  this.messageManager.updateToolBlock({
-                    id: toolId,
-                    parameters: argsString,
-                    result: errorMessage,
-                    success: false,
-                    error: errorMessage,
-                    stage: "end",
-                    name: toolName,
-                    compactParams: "",
-                    timestamp: Date.now(),
-                  });
-                  return;
-                }
-              }
-            }
-
-            const compactParams = this.generateCompactParams(
-              toolName,
-              toolArgs,
+        // Execute batches sequentially; within a safe batch, tools run in parallel
+        for (const batch of batches) {
+          if (
+            abortController.signal.aborted ||
+            toolAbortController.signal.aborted
+          ) {
+            break;
+          }
+          if (batch.calls.length === 1) {
+            await this.executeToolCall(
+              batch.calls[0],
+              abortController,
+              toolAbortController,
+              result.finish_reason,
             );
-
-            // Emit start stage for non-streaming tool calls
-            if (!this.stream) {
-              this.messageManager.updateToolBlock({
-                id: toolId,
-                stage: "start",
-                name: toolName,
-                compactParams,
-                parameters: argsString,
-              });
-            }
-
-            // Emit running stage (tool execution about to start)
-            this.messageManager.updateToolBlock({
-              id: toolId,
-              stage: "running",
-              name: toolName,
-              compactParams,
-              parameters: argsString,
-              parametersChunk: "",
-            });
-
-            try {
-              // Execute PreToolUse hooks before tool execution
-              const shouldExecuteTool = await this.executePreToolUseHooks(
-                toolName,
-                toolArgs,
-                toolId,
-              );
-
-              // If PreToolUse hooks blocked execution, skip tool execution
-              if (!shouldExecuteTool) {
-                logger?.info(
-                  `Tool ${toolName} execution blocked by PreToolUse hooks`,
-                );
-                return; // Skip this tool and return from this map function
-              }
-
-              // Create tool execution context
-              const context: ToolContext = {
-                abortSignal: toolAbortController.signal,
-                backgroundTaskManager: this.backgroundTaskManager,
-                workdir: this.getWorkdir(),
-                originalWorkdir: this.originalWorkdir,
-                env: this.container.get<Record<string, string>>("MergedEnv"),
-                messageId: this.messageManager.getMessages().slice(-1)[0]?.id,
-                sessionId: this.messageManager.getSessionId(),
-                toolCallId: toolId,
-                taskManager: this.taskManager,
-                onShortResultUpdate: (shortResult: string) => {
-                  this.messageManager.updateToolBlock({
-                    id: toolId,
-                    shortResult,
-                    stage: "running", // Keep it in running stage while updating shortResult
-                  });
-                },
-                onResultUpdate: (result: string) => {
-                  this.messageManager.updateToolBlock({
-                    id: toolId,
-                    result,
-                    stage: "running", // Keep it in running stage while updating result
-                  });
-                },
-                onCwdChange: async (newCwd: string) => {
-                  const oldCwd = this.getWorkdir();
-                  this.container.register("Workdir", newCwd);
-                  this._onCwdChange?.(newCwd);
-                  if (this.hookManager) {
-                    const sessionId = this.messageManager.getSessionId();
-                    const transcriptPath =
-                      this.messageManager.getTranscriptPath();
-                    const env = Object.fromEntries(
-                      Object.entries(process.env).filter(
-                        (e) => e[1] !== undefined,
-                      ),
-                    ) as Record<string, string>;
-                    await this.hookManager.executeCwdChangedHooks(
-                      oldCwd,
-                      newCwd,
-                      sessionId,
-                      transcriptPath,
-                      env,
-                    );
-                  }
-                },
-              };
-
-              // Execute tool
-              const toolResult = await this.toolManager.execute(
-                functionToolCall.function?.name || "",
-                toolArgs,
-                context,
-              );
-
-              // Build result content, adding truncation warning if JSON was recovered
-              let toolResultContent =
-                toolResult.content ||
-                (toolResult.error ? `Error: ${toolResult.error}` : "");
-              if (jsonRecovered) {
-                toolResultContent +=
-                  "\n\nTool arguments were truncated (likely exceeded max output tokens). Please reduce your output or split into multiple tool calls.";
-              }
-
-              // Update message state - tool execution completed
-              this.messageManager.updateToolBlock({
-                id: toolId,
-                parameters: argsString,
-                result: toolResultContent,
-                success: toolResult.success,
-                error: toolResult.error,
-                stage: "end",
-                name: toolName,
-                compactParams,
-                shortResult: toolResult.shortResult,
-                isManuallyBackgrounded: toolResult.isManuallyBackgrounded,
-                startLineNumber: toolResult.startLineNumber,
-                timestamp: Date.now(),
-              });
-
-              // Execute PostToolUse hooks after successful tool completion
-              await this.executePostToolUseHooks(
-                toolId,
-                toolName,
-                toolArgs,
-                toolResult,
-              );
-            } catch (toolError) {
-              const errorMessage =
-                toolError instanceof Error
-                  ? toolError.message
-                  : String(toolError);
-
-              this.messageManager.updateToolBlock({
-                id: toolId,
-                parameters: JSON.stringify(toolArgs, null, 2),
-                result: `Tool execution failed: ${errorMessage}`,
-                success: false,
-                error: errorMessage,
-                stage: "end",
-                name: toolName,
-                compactParams,
-                isManuallyBackgrounded: false,
-                timestamp: Date.now(),
-              });
-            }
-          },
-        );
-
-        // Wait for all tools to complete execution in parallel
-        await Promise.all(toolExecutionPromises);
+          } else {
+            await Promise.all(
+              batch.calls.map((call) =>
+                this.executeToolCall(
+                  call,
+                  abortController,
+                  toolAbortController,
+                  result.finish_reason,
+                ),
+              ),
+            );
+          }
+        }
       }
 
       // Handle token statistics and message compaction
@@ -1571,6 +1407,207 @@ export class AIManager {
         error,
       );
       return false;
+    }
+  }
+
+  /**
+   * Execute a single tool call: arg parsing, block emission, PreToolUse hooks,
+   * tool execution, PostToolUse hooks, and error handling.
+   */
+  private async executeToolCall(
+    functionToolCall: ChatCompletionMessageFunctionToolCall,
+    abortController: AbortController,
+    toolAbortController: AbortController,
+    finishReason?: string | null,
+  ): Promise<void> {
+    const toolId = functionToolCall.id || "";
+
+    // Check if already interrupted, skip tool execution if so
+    if (abortController.signal.aborted || toolAbortController.signal.aborted) {
+      return;
+    }
+
+    const toolName = functionToolCall.function?.name || "";
+    // Safely parse tool parameters, handle tools without parameters
+    let toolArgs: Record<string, unknown> = {};
+    let jsonRecovered = false;
+    const argsString = functionToolCall.function?.arguments?.trim();
+
+    if (!argsString || argsString === "") {
+      // Tool without parameters, use empty object
+      toolArgs = {};
+    } else {
+      let recoveredArgs = argsString;
+      try {
+        toolArgs = JSON.parse(argsString);
+      } catch {
+        // Attempt to recover truncated JSON (e.g., missing closing braces)
+        recoveredArgs = recoverTruncatedJson(argsString);
+        try {
+          toolArgs = JSON.parse(recoveredArgs);
+          jsonRecovered = true;
+          logger.warn(`Recovered truncated JSON for tool "${toolName}"`);
+        } catch (parseError) {
+          let errorMessage = `Failed to parse tool arguments`;
+          if (finishReason === "length") {
+            errorMessage += " (output truncated, please reduce your output)";
+          }
+          logger?.error(errorMessage, parseError);
+          this.messageManager.updateToolBlock({
+            id: toolId,
+            parameters: argsString,
+            result: errorMessage,
+            success: false,
+            error: errorMessage,
+            stage: "end",
+            name: toolName,
+            compactParams: "",
+            timestamp: Date.now(),
+          });
+          return;
+        }
+      }
+    }
+
+    const compactParams = this.generateCompactParams(toolName, toolArgs);
+
+    // Emit start stage for non-streaming tool calls
+    if (!this.stream) {
+      this.messageManager.updateToolBlock({
+        id: toolId,
+        stage: "start",
+        name: toolName,
+        compactParams,
+        parameters: argsString,
+      });
+    }
+
+    // Emit running stage (tool execution about to start)
+    this.messageManager.updateToolBlock({
+      id: toolId,
+      stage: "running",
+      name: toolName,
+      compactParams,
+      parameters: argsString,
+      parametersChunk: "",
+    });
+
+    try {
+      // Execute PreToolUse hooks before tool execution
+      const shouldExecuteTool = await this.executePreToolUseHooks(
+        toolName,
+        toolArgs,
+        toolId,
+      );
+
+      // If PreToolUse hooks blocked execution, skip tool execution
+      if (!shouldExecuteTool) {
+        logger?.info(`Tool ${toolName} execution blocked by PreToolUse hooks`);
+        return;
+      }
+
+      // Create tool execution context
+      const context: ToolContext = {
+        abortSignal: toolAbortController.signal,
+        backgroundTaskManager: this.backgroundTaskManager,
+        workdir: this.getWorkdir(),
+        originalWorkdir: this.originalWorkdir,
+        env: this.container.get<Record<string, string>>("MergedEnv"),
+        messageId: this.messageManager.getMessages().slice(-1)[0]?.id,
+        sessionId: this.messageManager.getSessionId(),
+        toolCallId: toolId,
+        taskManager: this.taskManager,
+        readFileState: this.readFileState,
+        onShortResultUpdate: (shortResult: string) => {
+          this.messageManager.updateToolBlock({
+            id: toolId,
+            shortResult,
+            stage: "running",
+          });
+        },
+        onResultUpdate: (result: string) => {
+          this.messageManager.updateToolBlock({
+            id: toolId,
+            result,
+            stage: "running",
+          });
+        },
+        onCwdChange: async (newCwd: string) => {
+          const oldCwd = this.getWorkdir();
+          this.container.register("Workdir", newCwd);
+          this._onCwdChange?.(newCwd);
+          if (this.hookManager) {
+            const sessionId = this.messageManager.getSessionId();
+            const transcriptPath = this.messageManager.getTranscriptPath();
+            const env = Object.fromEntries(
+              Object.entries(process.env).filter((e) => e[1] !== undefined),
+            ) as Record<string, string>;
+            await this.hookManager.executeCwdChangedHooks(
+              oldCwd,
+              newCwd,
+              sessionId,
+              transcriptPath,
+              env,
+            );
+          }
+        },
+      };
+
+      // Execute tool
+      const toolResult = await this.toolManager.execute(
+        functionToolCall.function?.name || "",
+        toolArgs,
+        context,
+      );
+
+      // Build result content, adding truncation warning if JSON was recovered
+      let toolResultContent =
+        toolResult.content ||
+        (toolResult.error ? `Error: ${toolResult.error}` : "");
+      if (jsonRecovered) {
+        toolResultContent +=
+          "\n\nTool arguments were truncated (likely exceeded max output tokens). Please reduce your output or split into multiple tool calls.";
+      }
+
+      // Update message state - tool execution completed
+      this.messageManager.updateToolBlock({
+        id: toolId,
+        parameters: argsString,
+        result: toolResultContent,
+        success: toolResult.success,
+        error: toolResult.error,
+        stage: "end",
+        name: toolName,
+        compactParams,
+        shortResult: toolResult.shortResult,
+        isManuallyBackgrounded: toolResult.isManuallyBackgrounded,
+        startLineNumber: toolResult.startLineNumber,
+        timestamp: Date.now(),
+      });
+
+      // Execute PostToolUse hooks after successful tool completion
+      await this.executePostToolUseHooks(
+        toolId,
+        toolName,
+        toolArgs,
+        toolResult,
+      );
+    } catch (toolError) {
+      const errorMessage =
+        toolError instanceof Error ? toolError.message : String(toolError);
+
+      this.messageManager.updateToolBlock({
+        id: toolId,
+        parameters: JSON.stringify(toolArgs, null, 2),
+        result: `Tool execution failed: ${errorMessage}`,
+        success: false,
+        error: errorMessage,
+        stage: "end",
+        name: toolName,
+        compactParams,
+        isManuallyBackgrounded: false,
+        timestamp: Date.now(),
+      });
     }
   }
 

--- a/packages/agent-sdk/src/managers/toolManager.ts
+++ b/packages/agent-sdk/src/managers/toolManager.ts
@@ -409,6 +409,24 @@ class ToolManager {
   }
 
   /**
+   * Check whether a tool is safe to execute in parallel with other tools.
+   * Built-in tools default to safe (parallel); Edit and Write opt out.
+   * MCP tools are conservatively non-safe (can't inspect side effects).
+   */
+  public isConcurrencySafe(name: string): boolean {
+    // MCP tools are conservatively non-safe
+    if (this.mcpManager.isMcpTool(name)) {
+      return false;
+    }
+    const plugin = this.toolsRegistry.get(name);
+    if (plugin) {
+      return plugin.isConcurrencySafe ?? true;
+    }
+    // Unknown tools are conservatively non-safe
+    return false;
+  }
+
+  /**
    * Get the current permission mode
    */
   public getPermissionMode(): PermissionMode {

--- a/packages/agent-sdk/src/tools/editTool.ts
+++ b/packages/agent-sdk/src/tools/editTool.ts
@@ -1,4 +1,5 @@
-import { readFile, writeFile } from "fs/promises";
+import { readFile, writeFile, stat } from "fs/promises";
+import { createHash } from "crypto";
 import { logger } from "../utils/globalLogger.js";
 import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
 import { resolvePath, getDisplayPath } from "../utils/path.js";
@@ -21,6 +22,7 @@ function formatCompactParams(
  */
 export const editTool: ToolPlugin = {
   name: EDIT_TOOL_NAME,
+  isConcurrencySafe: false,
   formatCompactParams,
   prompt: () =>
     `Performs exact string replacements in files.
@@ -137,6 +139,22 @@ Usage:
         };
       }
 
+      // Staleness check: file must not have been modified since last Read
+      if (context.readFileState) {
+        const state = context.readFileState.get(resolvedPath);
+        if (state) {
+          const currentStats = await stat(resolvedPath);
+          if (currentStats.mtime.getTime() !== state.mtime) {
+            return {
+              success: false,
+              content: "",
+              error:
+                "File has been unexpectedly modified since last read. Read it again before editing it.",
+            };
+          }
+        }
+      }
+
       // Normalize line endings for matching
       const normalizedContent = originalContent.replace(/\r\n/g, "\n");
       const normalizedOldString = oldString.replace(/\r\n/g, "\n");
@@ -238,6 +256,16 @@ Usage:
           content: "",
           error: `Failed to write file: ${writeError instanceof Error ? writeError.message : String(writeError)}`,
         };
+      }
+
+      // Update readFileState so subsequent serialized edits see fresh state
+      if (context.readFileState) {
+        const newStats = await stat(resolvedPath);
+        const hash = createHash("sha256").update(newContent).digest("hex");
+        context.readFileState.set(resolvedPath, {
+          mtime: newStats.mtime.getTime(),
+          hash,
+        });
       }
 
       const shortResult = replaceAll

--- a/packages/agent-sdk/src/tools/types.ts
+++ b/packages/agent-sdk/src/tools/types.ts
@@ -31,6 +31,12 @@ export interface ToolPlugin {
     workdir?: string;
     isSubagent?: boolean;
   }) => string;
+  /**
+   * Whether this tool is safe to run in parallel with other tools.
+   * Default (undefined) = true (parallel). Set to false for tools that
+   * perform read-modify-write on shared resources (e.g. Edit, Write).
+   */
+  isConcurrencySafe?: boolean;
 }
 
 export interface ToolResult {

--- a/packages/agent-sdk/src/tools/writeTool.ts
+++ b/packages/agent-sdk/src/tools/writeTool.ts
@@ -1,4 +1,5 @@
-import { readFile, writeFile, mkdir } from "fs/promises";
+import { readFile, writeFile, mkdir, stat } from "fs/promises";
+import { createHash } from "crypto";
 import { dirname } from "path";
 import { logger } from "../utils/globalLogger.js";
 import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
@@ -10,6 +11,7 @@ import { READ_TOOL_NAME } from "../constants/tools.js";
  */
 export const writeTool: ToolPlugin = {
   name: "Write",
+  isConcurrencySafe: false,
   config: {
     type: "function",
     function: {
@@ -162,6 +164,16 @@ Usage:
           content: "",
           error: `Failed to write file: ${writeError instanceof Error ? writeError.message : String(writeError)}`,
         };
+      }
+
+      // Update readFileState so subsequent serialized edits pass staleness check
+      if (context.readFileState) {
+        const newStats = await stat(resolvedPath);
+        const hash = createHash("sha256").update(content).digest("hex");
+        context.readFileState.set(resolvedPath, {
+          mtime: newStats.mtime.getTime(),
+          hash,
+        });
       }
 
       const shortResult = isExistingFile ? "File overwritten" : "File created";

--- a/packages/agent-sdk/tests/agent/hooks-exitcode-output/hook-blocking-error.test.ts
+++ b/packages/agent-sdk/tests/agent/hooks-exitcode-output/hook-blocking-error.test.ts
@@ -24,6 +24,7 @@ vi.mock("@/managers/toolManager", () => ({
       list: vi.fn(() => []),
       getTools: vi.fn(() => []),
       getToolsConfig: vi.fn(() => []),
+      isConcurrencySafe: vi.fn().mockReturnValue(true),
       getPermissionMode: vi.fn(),
       setPermissionMode: vi.fn(),
       initializeBuiltInTools: vi.fn(),

--- a/packages/agent-sdk/tests/agent/hooks-exitcode-output/hook-non-blocking-error.test.ts
+++ b/packages/agent-sdk/tests/agent/hooks-exitcode-output/hook-non-blocking-error.test.ts
@@ -24,6 +24,7 @@ vi.mock("@/managers/toolManager", () => ({
       list: vi.fn(() => []),
       getTools: vi.fn(() => []),
       getToolsConfig: vi.fn(() => []),
+      isConcurrencySafe: vi.fn().mockReturnValue(true),
       getPermissionMode: vi.fn(),
       setPermissionMode: vi.fn(),
       initializeBuiltInTools: vi.fn(),

--- a/packages/agent-sdk/tests/helpers/mockFactories.ts
+++ b/packages/agent-sdk/tests/helpers/mockFactories.ts
@@ -12,6 +12,7 @@ interface MockToolManager {
   setPermissionMode: Mock<ToolManager["setPermissionMode"]>;
   initializeBuiltInTools: Mock<ToolManager["initializeBuiltInTools"]>;
   getPermissionManager: Mock<ToolManager["getPermissionManager"]>;
+  isConcurrencySafe: Mock<ToolManager["isConcurrencySafe"]>;
   instance: ToolManager;
 }
 
@@ -45,6 +46,7 @@ export const createMockToolManager = (): MockToolManager => {
   const setPermissionMode = vi.fn();
   const initializeBuiltInTools = vi.fn();
   const getPermissionManager = vi.fn();
+  const isConcurrencySafe = vi.fn(() => true);
 
   return {
     // Individual mocks for control and assertions
@@ -56,6 +58,7 @@ export const createMockToolManager = (): MockToolManager => {
     setPermissionMode,
     initializeBuiltInTools,
     getPermissionManager,
+    isConcurrencySafe,
 
     // The object that behaves like a ToolManager instance
     instance: {
@@ -67,6 +70,7 @@ export const createMockToolManager = (): MockToolManager => {
       setPermissionMode,
       initializeBuiltInTools,
       getPermissionManager,
+      isConcurrencySafe,
     } as unknown as ToolManager,
   };
 };

--- a/packages/agent-sdk/tests/managers/aiManager.maxTurns.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.maxTurns.test.ts
@@ -148,6 +148,7 @@ describe("AIManager maxTurns", () => {
       execute: vi
         .fn()
         .mockResolvedValue({ success: true, content: "test result" }),
+      isConcurrencySafe: vi.fn().mockReturnValue(true),
     } as unknown as ToolManager;
   });
 

--- a/packages/agent-sdk/tests/managers/aiManager.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.test.ts
@@ -110,6 +110,7 @@ describe("AIManager", () => {
       execute: vi
         .fn()
         .mockResolvedValue({ success: true, content: "test result" }),
+      isConcurrencySafe: vi.fn().mockReturnValue(true),
     } as unknown as ToolManager;
 
     // Create mock Logger
@@ -1140,6 +1141,93 @@ describe("AIManager", () => {
 
       await testAIManager.sendAIMessage();
       expect(mockNotificationQueue.dequeueAll).toHaveBeenCalled();
+    });
+  });
+
+  describe("Tool Call Partitioning and Serialization", () => {
+    it("should run concurrency-safe tools in parallel and non-safe tools serially", async () => {
+      const aiServiceMod = await import("../../src/services/aiService.js");
+
+      let callCount = 0;
+      vi.spyOn(aiServiceMod, "callAgent").mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          // Return 4 tool calls: 2 safe (Read, Grep) then 2 non-safe (Edit, Edit)
+          return {
+            content: "Running tools",
+            usage: {
+              prompt_tokens: 10,
+              completion_tokens: 20,
+              total_tokens: 30,
+            },
+            tool_calls: [
+              {
+                type: "function" as const,
+                id: "call-read",
+                function: { name: "Read", arguments: "{}" },
+              },
+              {
+                type: "function" as const,
+                id: "call-grep",
+                function: { name: "Grep", arguments: "{}" },
+              },
+              {
+                type: "function" as const,
+                id: "call-edit-1",
+                function: { name: "Edit", arguments: "{}" },
+              },
+              {
+                type: "function" as const,
+                id: "call-edit-2",
+                function: { name: "Edit", arguments: "{}" },
+              },
+            ],
+          };
+        }
+        return {
+          content: "Done",
+          usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+          tool_calls: [],
+        };
+      });
+
+      // isConcurrencySafe: Read/Grep = true, Edit = false
+      vi.mocked(mockToolManager.isConcurrencySafe).mockImplementation(
+        (name: string) => name !== "Edit",
+      );
+
+      // Track execution intervals
+      const intervals: { name: string; start: number; end: number }[] = [];
+      vi.mocked(mockToolManager.execute).mockImplementation(
+        async (name: string) => {
+          const start = Date.now();
+          await new Promise((r) => setTimeout(r, 50));
+          const end = Date.now();
+          intervals.push({ name, start, end });
+          return { success: true, content: `${name} done` };
+        },
+      );
+
+      await aiManager.sendAIMessage({ recursionDepth: 0 });
+
+      // 4 tool executions should have occurred
+      expect(intervals).toHaveLength(4);
+
+      // Safe tools (Read, Grep) should overlap (parallel)
+      const readInterval = intervals.find((i) => i.name === "Read")!;
+      const grepInterval = intervals.find((i) => i.name === "Grep")!;
+      expect(readInterval).toBeDefined();
+      expect(grepInterval).toBeDefined();
+      // They overlap if grep starts before read ends
+      expect(grepInterval.start).toBeLessThan(readInterval.end);
+
+      // Non-safe tools (Edit, Edit) should NOT overlap (serial)
+      const editIntervals = intervals.filter((i) => i.name === "Edit");
+      expect(editIntervals).toHaveLength(2);
+      // Second edit starts after first edit ends
+      expect(editIntervals[1].start).toBeGreaterThanOrEqual(
+        editIntervals[0].end,
+      );
     });
   });
 });

--- a/packages/agent-sdk/tests/managers/aiManager_duplicateTool.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager_duplicateTool.test.ts
@@ -55,6 +55,7 @@ describe("AIManager - Duplicate Tool Call Reminder", () => {
       execute: vi
         .fn()
         .mockResolvedValue({ success: true, content: "test result" }),
+      isConcurrencySafe: vi.fn().mockReturnValue(true),
     } as unknown as ToolManager;
 
     const container = new Container();

--- a/packages/agent-sdk/tests/managers/aiManager_finishReason.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager_finishReason.test.ts
@@ -74,6 +74,7 @@ describe("AIManager finish reason", () => {
       execute: vi
         .fn()
         .mockResolvedValue({ success: true, content: "test result" }),
+      isConcurrencySafe: vi.fn().mockReturnValue(true),
     } as unknown as ToolManager;
 
     // Create mock Logger

--- a/packages/agent-sdk/tests/tools/editTool.test.ts
+++ b/packages/agent-sdk/tests/tools/editTool.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { editTool } from "@/tools/editTool.js";
 import { TaskManager } from "@/services/taskManager.js";
-import { readFile, writeFile } from "fs/promises";
+import { readFile, writeFile, stat } from "fs/promises";
 import type { ToolContext } from "@/tools/types.js";
 import { Container } from "@/utils/container.js";
 
@@ -533,5 +533,113 @@ describe("editTool", () => {
     );
 
     expect(result.success).toBe(true);
+  });
+
+  it("should fail with staleness error when file modified since last read", async () => {
+    const mockContent = "some content";
+    vi.mocked(readFile).mockResolvedValue(mockContent);
+
+    // readFileState shows mtime=1000, but current file has mtime=2000
+    const readFileState = new Map<string, { mtime: number; hash: string }>();
+    readFileState.set("/test/file.js", { mtime: 1000, hash: "abc" });
+
+    vi.mocked(stat).mockResolvedValue({
+      mtime: { getTime: () => 2000 } as Date,
+    } as unknown as Awaited<ReturnType<typeof stat>>);
+
+    const result = await editTool.execute(
+      {
+        file_path: "/test/file.js",
+        old_string: "some",
+        new_string: "other",
+      },
+      { ...mockContext, readFileState },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("unexpectedly modified");
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it("should pass staleness check when file mtime matches readFileState", async () => {
+    const mockContent = "some content";
+    vi.mocked(readFile).mockResolvedValue(mockContent);
+    vi.mocked(writeFile).mockResolvedValue(undefined);
+
+    const readFileState = new Map<string, { mtime: number; hash: string }>();
+    readFileState.set("/test/file.js", { mtime: 1000, hash: "abc" });
+
+    // First stat: staleness check (mtime matches)
+    // Second stat: post-write state update
+    vi.mocked(stat)
+      .mockResolvedValueOnce({
+        mtime: { getTime: () => 1000 } as Date,
+      } as unknown as Awaited<ReturnType<typeof stat>>)
+      .mockResolvedValueOnce({
+        mtime: { getTime: () => 2000 } as Date,
+      } as unknown as Awaited<ReturnType<typeof stat>>);
+
+    const result = await editTool.execute(
+      {
+        file_path: "/test/file.js",
+        old_string: "some",
+        new_string: "other",
+      },
+      { ...mockContext, readFileState },
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it("should update readFileState after successful edit", async () => {
+    const mockContent = "some content";
+    vi.mocked(readFile).mockResolvedValue(mockContent);
+    vi.mocked(writeFile).mockResolvedValue(undefined);
+
+    const readFileState = new Map<string, { mtime: number; hash: string }>();
+    readFileState.set("/test/file.js", { mtime: 1000, hash: "abc" });
+
+    // First stat: staleness check (mtime matches readFileState)
+    // Second stat: post-write state update (new mtime)
+    vi.mocked(stat)
+      .mockResolvedValueOnce({
+        mtime: { getTime: () => 1000 } as Date,
+      } as unknown as Awaited<ReturnType<typeof stat>>)
+      .mockResolvedValueOnce({
+        mtime: { getTime: () => 2000 } as Date,
+      } as unknown as Awaited<ReturnType<typeof stat>>);
+
+    const result = await editTool.execute(
+      {
+        file_path: "/test/file.js",
+        old_string: "some",
+        new_string: "other",
+      },
+      { ...mockContext, readFileState },
+    );
+
+    expect(result.success).toBe(true);
+    const updated = readFileState.get("/test/file.js");
+    expect(updated).toBeDefined();
+    expect(updated?.mtime).toBe(2000);
+  });
+
+  it("should skip staleness check when readFileState is not provided", async () => {
+    const mockContent = "some content";
+    vi.mocked(readFile).mockResolvedValue(mockContent);
+    vi.mocked(writeFile).mockResolvedValue(undefined);
+
+    // No readFileState in context — staleness check is skipped entirely
+    const result = await editTool.execute(
+      {
+        file_path: "/test/file.js",
+        old_string: "some",
+        new_string: "other",
+      },
+      mockContext,
+    );
+
+    expect(result.success).toBe(true);
+    expect(stat).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent-sdk/tests/tools/editToolSerialization.test.ts
+++ b/packages/agent-sdk/tests/tools/editToolSerialization.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { readFile, writeFile, stat, unlink, utimes } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { createHash } from "crypto";
+import { editTool } from "@/tools/editTool.js";
+import type { ToolContext } from "@/tools/types.js";
+import { TaskManager } from "@/services/taskManager.js";
+import { Container } from "@/utils/container.js";
+
+/**
+ * Integration tests using real filesystem to verify that serialized Edit
+ * calls (as aiManager does for non-concurrency-safe tools) apply all changes
+ * correctly, and that the staleness check catches external modifications.
+ */
+describe("editTool serialization (real fs)", () => {
+  let tempFile: string;
+  let context: ToolContext;
+
+  beforeEach(async () => {
+    tempFile = join(
+      tmpdir(),
+      `wave-edit-test-${Date.now()}-${Math.random().toString(36).slice(2)}.ts`,
+    );
+    await writeFile(tempFile, "line1\nline2\nline3\nline4\nline5\n", "utf-8");
+
+    // Simulate a prior Read: populate readFileState with current mtime + hash
+    const stats = await stat(tempFile);
+    const content = await readFile(tempFile, "utf-8");
+    const readFileState = new Map<string, { mtime: number; hash: string }>();
+    readFileState.set(tempFile, {
+      mtime: stats.mtime.getTime(),
+      hash: createHash("sha256").update(content).digest("hex"),
+    });
+
+    context = {
+      workdir: tmpdir(),
+      taskManager: new TaskManager(new Container(), "test-session"),
+      readFileState,
+    };
+  });
+
+  afterEach(async () => {
+    try {
+      await unlink(tempFile);
+    } catch {
+      // ignore
+    }
+  });
+
+  it("should apply all edits when called sequentially (serialized)", async () => {
+    // Simulate serialized execution — what aiManager does for non-safe tools
+    await editTool.execute(
+      { file_path: tempFile, old_string: "line1", new_string: "LINE1" },
+      context,
+    );
+    await editTool.execute(
+      { file_path: tempFile, old_string: "line2", new_string: "LINE2" },
+      context,
+    );
+    await editTool.execute(
+      { file_path: tempFile, old_string: "line3", new_string: "LINE3" },
+      context,
+    );
+
+    const content = await readFile(tempFile, "utf-8");
+    expect(content).toBe("LINE1\nLINE2\nLINE3\nline4\nline5\n");
+  });
+
+  it("should fail with staleness error when file modified externally", async () => {
+    // Externally modify the file and bump mtime forward by 10 seconds
+    await writeFile(
+      tempFile,
+      "line1\nline2\nMODIFIED\nline4\nline5\n",
+      "utf-8",
+    );
+    const future = new Date(Date.now() + 10_000);
+    await utimes(tempFile, future, future);
+
+    const result = await editTool.execute(
+      { file_path: tempFile, old_string: "line1", new_string: "LINE1" },
+      context,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("unexpectedly modified");
+  });
+
+  it("should allow subsequent edit after readFileState is updated", async () => {
+    // First edit succeeds and updates readFileState
+    const r1 = await editTool.execute(
+      { file_path: tempFile, old_string: "line1", new_string: "LINE1" },
+      context,
+    );
+    expect(r1.success).toBe(true);
+
+    // Second edit to the same file should also succeed (staleness check passes
+    // because readFileState was updated after the first write)
+    const r2 = await editTool.execute(
+      { file_path: tempFile, old_string: "line2", new_string: "LINE2" },
+      context,
+    );
+    expect(r2.success).toBe(true);
+
+    const content = await readFile(tempFile, "utf-8");
+    expect(content).toContain("LINE1");
+    expect(content).toContain("LINE2");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1256 — parallel Edit calls to the same file silently drop changes.

## Problem

When the AI model issues multiple Edit tool calls to the same file in a single turn, they were all executed in parallel via `Promise.all`. Since each Edit reads the file, applies its change, and writes it back, concurrent edits race against each other — the last writer wins, and all other changes are silently lost.

## Solution

Two-layer approach:

### Layer 1: Tool execution serialization
- Added `isConcurrencySafe?: boolean` to `ToolPlugin` interface
- Added `isConcurrencySafe(name)` method to `ToolManager` — returns `false` for MCP tools, unknown tools, and tools explicitly marked non-safe; `true` otherwise (default safe)
- Marked Edit and Write as `isConcurrencySafe: false`
- Refactored `aiManager.ts`: extracted `executeToolCall` method, replaced flat `Promise.all` with batched execution — consecutive safe tools run in parallel, non-safe tools run sequentially

### Layer 2: Staleness check via readFileState
- `AIManager` maintains a `readFileState: Map<string, { mtime, hash }>` passed via `ToolContext`
- **Read tool** populates the map with file mtime + sha256 hash
- **Edit tool** checks mtime before writing — if the file changed since last Read, it fails with a clear error: `File has been unexpectedly modified since last read. Read it again before editing it.`
- **Edit/Write** update the map after successful write

### Defaults
- All built-in tools default to **safe** (parallel)
- Edit/Write opt out (`isConcurrencySafe: false`)
- MCP tools are conservatively **non-safe** (can't inspect internals)
- Unknown tools are **non-safe**

## Tests
- 4 staleness check tests in `editTool.test.ts`
- 3 real-fs integration tests in `editToolSerialization.test.ts`
- 1 partition/serialization test in `aiManager.test.ts`
- All mock ToolManagers updated with `isConcurrencySafe`
- Full suite: 3071 passed, 1 skipped, 0 failures