### PR TITLE
fix: range-aware Read tool dedup with clearer message

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -75,7 +75,10 @@ export class AIManager {
   private consecutiveCompactionFailures: number = 0;
   private readonly maxTurns?: number;
   /** Tracks file mtime/hash at read time for staleness detection on Edit/Write */
-  private readFileState = new Map<string, { mtime: number; hash: string }>();
+  private readFileState = new Map<
+    string,
+    { mtime: number; hash: string; offset?: number; limit?: number }
+  >();
   /** Override tool_choice for this AI manager (e.g. for structured output) */
   public toolChoiceOverride?:
     | "auto"

--- a/packages/agent-sdk/src/tools/editTool.ts
+++ b/packages/agent-sdk/src/tools/editTool.ts
@@ -265,6 +265,8 @@ Usage:
         context.readFileState.set(resolvedPath, {
           mtime: newStats.mtime.getTime(),
           hash,
+          offset: undefined,
+          limit: undefined,
         });
       }
 

--- a/packages/agent-sdk/src/tools/readTool.ts
+++ b/packages/agent-sdk/src/tools/readTool.ts
@@ -244,18 +244,26 @@ Usage:
 
       const stats = await stat(actualFilePath);
 
-      // Deduplication
+      // Deduplication: only dedup if the exact same range was read before
       if (context.readFileState) {
         const state = context.readFileState.get(actualFilePath);
-        if (state && state.mtime === stats.mtime.getTime()) {
-          return {
-            success: true,
-            content: `File ${filePath} has not changed since last read.`,
-            shortResult: "File unchanged",
-            metadata: {
-              type: "file_unchanged",
-            },
-          };
+        // Only dedup entries from a prior Read with explicit offset (not Edit/Write entries)
+        if (
+          state &&
+          state.mtime === stats.mtime.getTime() &&
+          state.offset !== undefined
+        ) {
+          const rangeMatch = state.offset === offset && state.limit === limit;
+          if (rangeMatch) {
+            return {
+              success: true,
+              content: `File ${filePath} has not changed since last read. The content from the earlier Read tool_result in this conversation is still current — refer to that instead of re-reading.`,
+              shortResult: "File unchanged",
+              metadata: {
+                type: "file_unchanged",
+              },
+            };
+          }
         }
       }
 
@@ -287,6 +295,8 @@ Usage:
         context.readFileState.set(actualFilePath, {
           mtime: stats.mtime.getTime(),
           hash,
+          offset, // undefined for full reads
+          limit, // undefined for full reads
         });
       }
 

--- a/packages/agent-sdk/src/tools/types.ts
+++ b/packages/agent-sdk/src/tools/types.ts
@@ -110,7 +110,15 @@ export interface ToolContext {
     maxTokens: number;
   };
   /** State of files read in the current session for deduplication */
-  readFileState?: Map<string, { mtime: number; hash: string }>;
+  readFileState?: Map<
+    string,
+    {
+      mtime: number;
+      hash: string;
+      offset?: number; // undefined = full read or Edit/Write entry (never dedup)
+      limit?: number;
+    }
+  >;
   /** Hook manager instance for executing hooks */
   hookManager?: import("../managers/hookManager.js").HookManager;
   /** Callback to notify when the current working directory changes */

--- a/packages/agent-sdk/src/tools/writeTool.ts
+++ b/packages/agent-sdk/src/tools/writeTool.ts
@@ -173,6 +173,8 @@ Usage:
         context.readFileState.set(resolvedPath, {
           mtime: newStats.mtime.getTime(),
           hash,
+          offset: undefined,
+          limit: undefined,
         });
       }
 

--- a/packages/agent-sdk/tests/tools/editTool.test.ts
+++ b/packages/agent-sdk/tests/tools/editTool.test.ts
@@ -540,7 +540,10 @@ describe("editTool", () => {
     vi.mocked(readFile).mockResolvedValue(mockContent);
 
     // readFileState shows mtime=1000, but current file has mtime=2000
-    const readFileState = new Map<string, { mtime: number; hash: string }>();
+    const readFileState = new Map<
+      string,
+      { mtime: number; hash: string; offset?: number; limit?: number }
+    >();
     readFileState.set("/test/file.js", { mtime: 1000, hash: "abc" });
 
     vi.mocked(stat).mockResolvedValue({
@@ -566,7 +569,10 @@ describe("editTool", () => {
     vi.mocked(readFile).mockResolvedValue(mockContent);
     vi.mocked(writeFile).mockResolvedValue(undefined);
 
-    const readFileState = new Map<string, { mtime: number; hash: string }>();
+    const readFileState = new Map<
+      string,
+      { mtime: number; hash: string; offset?: number; limit?: number }
+    >();
     readFileState.set("/test/file.js", { mtime: 1000, hash: "abc" });
 
     // First stat: staleness check (mtime matches)
@@ -596,7 +602,10 @@ describe("editTool", () => {
     vi.mocked(readFile).mockResolvedValue(mockContent);
     vi.mocked(writeFile).mockResolvedValue(undefined);
 
-    const readFileState = new Map<string, { mtime: number; hash: string }>();
+    const readFileState = new Map<
+      string,
+      { mtime: number; hash: string; offset?: number; limit?: number }
+    >();
     readFileState.set("/test/file.js", { mtime: 1000, hash: "abc" });
 
     // First stat: staleness check (mtime matches readFileState)

--- a/packages/agent-sdk/tests/tools/editToolSerialization.test.ts
+++ b/packages/agent-sdk/tests/tools/editToolSerialization.test.ts
@@ -27,7 +27,10 @@ describe("editTool serialization (real fs)", () => {
     // Simulate a prior Read: populate readFileState with current mtime + hash
     const stats = await stat(tempFile);
     const content = await readFile(tempFile, "utf-8");
-    const readFileState = new Map<string, { mtime: number; hash: string }>();
+    const readFileState = new Map<
+      string,
+      { mtime: number; hash: string; offset?: number; limit?: number }
+    >();
     readFileState.set(tempFile, {
       mtime: stats.mtime.getTime(),
       hash: createHash("sha256").update(content).digest("hex"),

--- a/packages/agent-sdk/tests/tools/readTool.test.ts
+++ b/packages/agent-sdk/tests/tools/readTool.test.ts
@@ -708,27 +708,79 @@ describe("readTool", () => {
       expect(result.error).toContain("Failed to read file: String error");
     });
 
-    it("should support deduplication using readFileState", async () => {
-      const readFileState = new Map<string, { mtime: number; hash: string }>();
-      const filePath = "/test/workdir/small.txt";
+    it("should dedup when the same partial range is read twice", async () => {
+      const readFileState = new Map<
+        string,
+        { mtime: number; hash: string; offset?: number; limit?: number }
+      >();
+      const filePath = "/test/workdir/medium.txt";
 
-      // First read
+      // First read with explicit offset/limit
       const result1 = await readTool.execute(
-        { file_path: filePath },
+        { file_path: filePath, offset: 10, limit: 5 },
         { ...testContext, readFileState },
       );
       expect(result1.success).toBe(true);
       expect(result1.metadata?.type).toBe("text");
       expect(readFileState.has(filePath)).toBe(true);
 
-      // Second read (unchanged)
+      // Second read of the same range (unchanged) — should dedup
       const result2 = await readTool.execute(
-        { file_path: filePath },
+        { file_path: filePath, offset: 10, limit: 5 },
         { ...testContext, readFileState },
       );
       expect(result2.success).toBe(true);
       expect(result2.metadata?.type).toBe("file_unchanged");
       expect(result2.content).toContain("has not changed");
+    });
+
+    it("should NOT dedup a full read (offset=undefined) on second read", async () => {
+      const readFileState = new Map<
+        string,
+        { mtime: number; hash: string; offset?: number; limit?: number }
+      >();
+      const filePath = "/test/workdir/small.txt";
+
+      // First full read
+      const result1 = await readTool.execute(
+        { file_path: filePath },
+        { ...testContext, readFileState },
+      );
+      expect(result1.success).toBe(true);
+      expect(result1.metadata?.type).toBe("text");
+
+      // Second full read — should return content, not "unchanged"
+      const result2 = await readTool.execute(
+        { file_path: filePath },
+        { ...testContext, readFileState },
+      );
+      expect(result2.success).toBe(true);
+      expect(result2.metadata?.type).toBe("text");
+      expect(result2.content).toContain("Line 1");
+    });
+
+    it("should NOT dedup a partial read after a full read (different range)", async () => {
+      const readFileState = new Map<
+        string,
+        { mtime: number; hash: string; offset?: number; limit?: number }
+      >();
+      const filePath = "/test/workdir/medium.txt";
+
+      // First: full read (offset=undefined)
+      const result1 = await readTool.execute(
+        { file_path: filePath },
+        { ...testContext, readFileState },
+      );
+      expect(result1.success).toBe(true);
+
+      // Second: partial read — should return content, not "unchanged"
+      const result2 = await readTool.execute(
+        { file_path: filePath, offset: 10, limit: 5 },
+        { ...testContext, readFileState },
+      );
+      expect(result2.success).toBe(true);
+      expect(result2.metadata?.type).toBe("text");
+      expect(result2.content).toContain("Line 10");
     });
 
     it("should enforce resource limits", async () => {


### PR DESCRIPTION
## Problem

The Read tool's deduplication only checked file `mtime`, ignoring the requested `offset`/`limit`. After a full read, any subsequent read of a different portion returned "File has not changed since last read" instead of actual content — forcing the model to fall back to `sed -n` via Bash.

The dedup message ("File X has not changed since last read") was also ambiguous — the model didn't know whether it could still read the file or what to do next.

## Changes

- **`types.ts`**: Extended `readFileState` value type with optional `offset?`/`limit?` fields
- **`aiManager.ts`**: Updated the private Map type to match
- **`readTool.ts`**: Range-aware dedup — only deduplicates when `state.offset !== undefined` (a prior partial Read) AND the exact same `offset`/`limit` is requested. Full reads (`offset=undefined`) are never deduped. Improved message to clarify prior content is still current.
- **`editTool.ts`** / **`writeTool.ts`**: Set `offset: undefined, limit: undefined` so the `state.offset !== undefined` guard prevents dedup against post-edit entries
- **Tests**: Replaced the single dedup test with three range-aware tests (same partial range deduped; full read not deduped; partial-after-full not deduped). Updated Map types in `editTool.test.ts` (3 occurrences) and `editToolSerialization.test.ts`.

## Verification

- 68/68 tests pass (`readTool.test.ts`, `editTool.test.ts`, `editToolSerialization.test.ts`)
- Build succeeds (`pnpm -F wave-agent-sdk build`)
- Type-check passes across all packages (`pnpm run type-check`)