### PR TITLE
fix: use fastModel-specific hyperparams for fast model calls

### DIFF
--- a/packages/agent-sdk/src/services/aiService.ts
+++ b/packages/agent-sdk/src/services/aiService.ts
@@ -845,6 +845,7 @@ export async function compactMessages(
     fastModel: _fastModel,
     maxTokens: _maxTokens,
     permissionMode: _permissionMode,
+    fastModelConfig: _fastModelConfig,
     ...extraParams
   } = modelConfig;
   void _model;
@@ -852,10 +853,16 @@ export async function compactMessages(
   void _maxTokens;
   void _permissionMode;
 
+  // When a fast model override is provided, use the fast model's hyperparams
+  // (if configured); otherwise fall back to the agent model's extraParams.
+  const activeExtraParams = options.model
+    ? _fastModelConfig || {}
+    : extraParams;
+
   const openaiModelConfig = getModelConfig(options.model || modelConfig.model, {
     temperature: 0.1,
     max_tokens: 8192,
-    ...extraParams,
+    ...activeExtraParams,
   });
 
   try {
@@ -961,6 +968,7 @@ export async function processWebContent(
     fastModel: _fastModel,
     maxTokens: _maxTokens,
     permissionMode: _permissionMode,
+    fastModelConfig: _fastModelConfig,
     ...extraParams
   } = modelConfig;
   void _model;
@@ -968,10 +976,16 @@ export async function processWebContent(
   void _maxTokens;
   void _permissionMode;
 
+  // When a fast model override is provided, use the fast model's hyperparams
+  // (if configured); otherwise fall back to the agent model's extraParams.
+  const activeExtraParams = options.model
+    ? _fastModelConfig || {}
+    : extraParams;
+
   const openaiModelConfig = getModelConfig(options.model || modelConfig.model, {
     temperature: 0.1,
     max_tokens: 4096,
-    ...extraParams,
+    ...activeExtraParams,
   });
 
   try {
@@ -1177,17 +1191,20 @@ export async function evaluateGoal(
     fastModel: _fastModel,
     maxTokens: _maxTokens,
     permissionMode: _permissionMode,
-    ...extraParams
+    fastModelConfig: _fastModelConfig,
   } = modelConfig;
   void _model;
   void _fastModel;
   void _maxTokens;
   void _permissionMode;
 
+  // evaluateGoal always uses the fast model; use its hyperparams if configured.
+  const activeExtraParams = _fastModelConfig || {};
+
   const openaiModelConfig = getModelConfig(model, {
     temperature: 0,
     max_tokens: 200,
-    ...extraParams,
+    ...activeExtraParams,
   });
 
   // Strip images from messages to reduce token usage (same as compact)

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -532,6 +532,27 @@ export class ConfigurationService {
       permissionMode: permissionMode ?? this.options.permissionMode,
     };
 
+    // Resolve fast model hyperparams from models[fastModel], stripping
+    // structural fields so only hyperparameters remain. Set on baseConfig
+    // before the modelSpecificConfig spread so it isn't overwritten.
+    const fastModelConfigSource =
+      resolvedFastModel &&
+      this.currentConfiguration?.models?.[resolvedFastModel];
+    if (fastModelConfigSource) {
+      const {
+        model: _fm,
+        fastModel: _ffm,
+        maxTokens: _fmt,
+        permissionMode: _fpm,
+        ...fastHyperparams
+      } = fastModelConfigSource;
+      void _fm;
+      void _ffm;
+      void _fmt;
+      void _fpm;
+      baseConfig.fastModelConfig = fastHyperparams;
+    }
+
     // Merge model-specific settings from configuration
     const modelSpecificConfig =
       resolvedAgentModel &&

--- a/packages/agent-sdk/src/types/config.ts
+++ b/packages/agent-sdk/src/types/config.ts
@@ -19,5 +19,6 @@ export interface ModelConfig {
   fastModel?: string;
   maxTokens?: number;
   permissionMode?: PermissionMode;
+  fastModelConfig?: Record<string, unknown>;
   [key: string]: unknown;
 }

--- a/packages/agent-sdk/tests/services/aiService.compact.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.compact.test.ts
@@ -299,5 +299,181 @@ describe("AI Service - CompactMessages", () => {
       expect(callArgs.temperature).toBe(0.7);
       expect(callArgs.reasoning_effort).toBe("high");
     });
+
+    it("should use fastModelConfig hyperparams when model option is provided", async () => {
+      const messages = [
+        {
+          role: "user" as const,
+          content: "Test message",
+        },
+      ];
+
+      await compactMessages({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: {
+          ...TEST_MODEL_CONFIG,
+          temperature: 0.7, // agent model hyperparam
+          fastModelConfig: { temperature: 0.2, top_p: 0.9 }, // fast model hyperparams
+        },
+        messages,
+        model: "fast-model",
+      });
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.model).toBe("fast-model");
+      expect(callArgs.temperature).toBe(0.2);
+      expect(callArgs.top_p).toBe(0.9);
+    });
+
+    it("should fall back to agent model extraParams when model option is not provided", async () => {
+      const messages = [
+        {
+          role: "user" as const,
+          content: "Test message",
+        },
+      ];
+
+      await compactMessages({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: {
+          ...TEST_MODEL_CONFIG,
+          temperature: 0.7,
+          fastModelConfig: { temperature: 0.2 },
+        },
+        messages,
+        // no model option — uses agent model
+      });
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.model).toBe(TEST_MODEL_CONFIG.model);
+      expect(callArgs.temperature).toBe(0.7);
+    });
+
+    it("should use no extra hyperparams when model option is provided but fastModelConfig is undefined", async () => {
+      const messages = [
+        {
+          role: "user" as const,
+          content: "Test message",
+        },
+      ];
+
+      await compactMessages({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: {
+          ...TEST_MODEL_CONFIG,
+          temperature: 0.7, // agent model hyperparam — should NOT be used
+        },
+        messages,
+        model: "fast-model",
+      });
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.model).toBe("fast-model");
+      expect(callArgs.temperature).toBe(0.1); // function default, not agent model's 0.7
+    });
+  });
+
+  describe("processWebContent — fastModelConfig", () => {
+    let processWebContent: (
+      options: import("@/services/aiService.js").ProcessWebContentOptions,
+    ) => Promise<import("@/services/aiService.js").ProcessWebContentResult>;
+
+    beforeEach(async () => {
+      const aiService = await import("@/services/aiService.js");
+      processWebContent = aiService.processWebContent;
+    });
+
+    it("should use fastModelConfig hyperparams when model option is provided", async () => {
+      await processWebContent({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: {
+          ...TEST_MODEL_CONFIG,
+          temperature: 0.7,
+          fastModelConfig: { temperature: 0.2, top_p: 0.9 },
+        },
+        content: "web content",
+        prompt: "summarize",
+        model: "fast-model",
+      });
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.model).toBe("fast-model");
+      expect(callArgs.temperature).toBe(0.2);
+      expect(callArgs.top_p).toBe(0.9);
+    });
+
+    it("should fall back to agent model extraParams when model option is not provided", async () => {
+      await processWebContent({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: {
+          ...TEST_MODEL_CONFIG,
+          temperature: 0.7,
+          fastModelConfig: { temperature: 0.2 },
+        },
+        content: "web content",
+        prompt: "summarize",
+      });
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.model).toBe(TEST_MODEL_CONFIG.model);
+      expect(callArgs.temperature).toBe(0.7);
+    });
+  });
+
+  describe("evaluateGoal — fastModelConfig", () => {
+    let evaluateGoal: (
+      options: import("@/services/aiService.js").EvaluateGoalOptions,
+    ) => Promise<import("@/services/aiService.js").EvaluateGoalResult>;
+
+    beforeEach(async () => {
+      const aiService = await import("@/services/aiService.js");
+      evaluateGoal = aiService.evaluateGoal;
+    });
+
+    it("should use fastModelConfig hyperparams", async () => {
+      await evaluateGoal({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: {
+          ...TEST_MODEL_CONFIG,
+          temperature: 0.7,
+          fastModelConfig: { temperature: 0, top_p: 0.95 },
+        },
+        model: "fast-model",
+        goalCondition: "task is done",
+        messages: [
+          {
+            role: "user" as const,
+            content: "test",
+          },
+        ],
+      });
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.model).toBe("fast-model");
+      expect(callArgs.temperature).toBe(0);
+      expect(callArgs.top_p).toBe(0.95);
+    });
+
+    it("should use no extra hyperparams when fastModelConfig is undefined", async () => {
+      await evaluateGoal({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: {
+          ...TEST_MODEL_CONFIG,
+          temperature: 0.7, // agent model hyperparam — should NOT be used
+        },
+        model: "fast-model",
+        goalCondition: "task is done",
+        messages: [
+          {
+            role: "user" as const,
+            content: "test",
+          },
+        ],
+      });
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.model).toBe("fast-model");
+      expect(callArgs.temperature).toBe(0); // function default, not agent model's 0.7
+    });
   });
 });

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -477,6 +477,135 @@ describe("ConfigurationService", () => {
     });
   });
 
+  describe("resolveModelConfig — fastModelConfig", () => {
+    it("should set fastModelConfig from models[fastModel] hyperparams", async () => {
+      const config = {
+        models: {
+          "gpt-4o": { temperature: 0.7 },
+          "gpt-4o-mini": { temperature: 0.2, top_p: 0.9 },
+        },
+      };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      const origModel = process.env.WAVE_MODEL;
+      const origFastModel = process.env.WAVE_FAST_MODEL;
+      delete process.env.WAVE_MODEL;
+      delete process.env.WAVE_FAST_MODEL;
+      try {
+        await configService.loadMergedConfiguration(tempDir);
+        const resolved = configService.resolveModelConfig(
+          "gpt-4o",
+          "gpt-4o-mini",
+        );
+
+        expect(resolved.fastModelConfig).toEqual({
+          temperature: 0.2,
+          top_p: 0.9,
+        });
+      } finally {
+        if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
+        else delete process.env.WAVE_MODEL;
+        if (origFastModel !== undefined)
+          process.env.WAVE_FAST_MODEL = origFastModel;
+        else delete process.env.WAVE_FAST_MODEL;
+      }
+    });
+
+    it("should strip structural fields from fastModelConfig", async () => {
+      const config = {
+        models: {
+          "gpt-4o-mini": {
+            model: "should-be-stripped",
+            fastModel: "should-be-stripped",
+            maxTokens: 999,
+            permissionMode: "default",
+            temperature: 0.3,
+          },
+        },
+      };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      const origModel = process.env.WAVE_MODEL;
+      const origFastModel = process.env.WAVE_FAST_MODEL;
+      delete process.env.WAVE_MODEL;
+      delete process.env.WAVE_FAST_MODEL;
+      try {
+        await configService.loadMergedConfiguration(tempDir);
+        const resolved = configService.resolveModelConfig(
+          undefined,
+          "gpt-4o-mini",
+        );
+
+        expect(resolved.fastModelConfig).toEqual({ temperature: 0.3 });
+      } finally {
+        if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
+        else delete process.env.WAVE_MODEL;
+        if (origFastModel !== undefined)
+          process.env.WAVE_FAST_MODEL = origFastModel;
+        else delete process.env.WAVE_FAST_MODEL;
+      }
+    });
+
+    it("should leave fastModelConfig undefined when fast model not in models", async () => {
+      const config = {
+        models: {
+          "gpt-4o": { temperature: 0.7 },
+        },
+      };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      const origModel = process.env.WAVE_MODEL;
+      const origFastModel = process.env.WAVE_FAST_MODEL;
+      delete process.env.WAVE_MODEL;
+      delete process.env.WAVE_FAST_MODEL;
+      try {
+        await configService.loadMergedConfiguration(tempDir);
+        const resolved = configService.resolveModelConfig(
+          "gpt-4o",
+          "unknown-fast-model",
+        );
+
+        expect(resolved.fastModelConfig).toBeUndefined();
+      } finally {
+        if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
+        else delete process.env.WAVE_MODEL;
+        if (origFastModel !== undefined)
+          process.env.WAVE_FAST_MODEL = origFastModel;
+        else delete process.env.WAVE_FAST_MODEL;
+      }
+    });
+
+    it("should leave fastModelConfig undefined when no fast model configured", async () => {
+      const config = {
+        models: {
+          "gpt-4o": { temperature: 0.7 },
+        },
+      };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      const origModel = process.env.WAVE_MODEL;
+      const origFastModel = process.env.WAVE_FAST_MODEL;
+      delete process.env.WAVE_MODEL;
+      delete process.env.WAVE_FAST_MODEL;
+      try {
+        await configService.loadMergedConfiguration(tempDir);
+        const resolved = configService.resolveModelConfig("gpt-4o");
+
+        expect(resolved.fastModelConfig).toBeUndefined();
+      } finally {
+        if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
+        else delete process.env.WAVE_MODEL;
+        if (origFastModel !== undefined)
+          process.env.WAVE_FAST_MODEL = origFastModel;
+        else delete process.env.WAVE_FAST_MODEL;
+      }
+    });
+  });
+
   describe("resolveMaxInputTokens", () => {
     const originalEnv = process.env.WAVE_MAX_INPUT_TOKENS;
 


### PR DESCRIPTION
## Problem

When `model` and `fastModel` are different model names, fast model calls (compact, goal eval, web fetch) incorrectly used the **agent model's** hyperparameters instead of `models[fastModel]`'s. This happened because `resolveModelConfig()` only merged `models[agentModel]`, and fast model callers passed `model: fastModel` as a name override while still using the agent model's `extraParams`.

## Solution

- **`config.ts`**: Added `fastModelConfig` field to `ModelConfig` interface.
- **`configurationService.ts`**: In `resolveModelConfig()`, look up `models[fastModel]`, strip structural fields (`model`, `fastModel`, `maxTokens`, `permissionMode`), and store the remaining hyperparams as `baseConfig.fastModelConfig` before the `modelSpecificConfig` spread.
- **`aiService.ts`**: Three fast model functions updated:
  - `compactMessages()` / `processWebContent()`: use `fastModelConfig` when `options.model` is provided (fast model call), fall back to agent model's `extraParams` otherwise.
  - `evaluateGoal()`: always uses `fastModelConfig` (since `model` is always the fast model).

## Tests

- `configurationService.test.ts`: 4 tests covering fastModelConfig resolution, structural field stripping, and undefined cases.
- `aiService.compact.test.ts`: 7 tests covering fastModelConfig usage and fallback for all three functions.

All 3082 tests pass (1 pre-existing skip).