### PR TITLE
revert: restore UUID session IDs, remove timestamp-prefixed format

### DIFF
--- a/packages/agent-sdk/src/services/jsonlHandler.ts
+++ b/packages/agent-sdk/src/services/jsonlHandler.ts
@@ -229,19 +229,7 @@ export class JsonlHandler {
     // Extract filename from path
     const filename = filePath.split("/").pop() || "";
 
-    // New timestamp-prefixed format
-    const newSubagentMatch = filename.match(
-      /^subagent-(\d{14}-[0-9a-f]{8})\.jsonl$/,
-    );
-    if (newSubagentMatch) {
-      return { sessionId: newSubagentMatch[1], sessionType: "subagent" };
-    }
-    const newMainMatch = filename.match(/^(\d{14}-[0-9a-f]{8})\.jsonl$/);
-    if (newMainMatch) {
-      return { sessionId: newMainMatch[1], sessionType: "main" };
-    }
-
-    // Old UUID format (backward compat)
+    // Check if it's a subagent session
     const subagentMatch = filename.match(
       /^subagent-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/,
     );
@@ -252,6 +240,7 @@ export class JsonlHandler {
       };
     }
 
+    // Check if it's a main session
     const mainMatch = filename.match(
       /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/,
     );
@@ -271,26 +260,18 @@ export class JsonlHandler {
    * @returns True if valid, false otherwise
    */
   isValidSessionFilename(filename: string): boolean {
-    // New timestamp-prefixed format patterns
-    const newFormatPattern = /^(\d{14}-[0-9a-f]{8})\.jsonl$/;
-    const newSubagentPattern = /^subagent-(\d{14}-[0-9a-f]{8})\.jsonl$/;
-    // Old UUID format patterns (backward compat)
+    // UUID validation patterns
     const uuidPattern =
       /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/;
     const subagentPattern =
       /^subagent-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/;
 
-    return (
-      newFormatPattern.test(filename) ||
-      newSubagentPattern.test(filename) ||
-      uuidPattern.test(filename) ||
-      subagentPattern.test(filename)
-    );
+    return uuidPattern.test(filename) || subagentPattern.test(filename);
   }
 
   /**
    * Generate simple filename for sessions
-   * @param sessionId - Session identifier (timestamp-prefixed or legacy UUID format)
+   * @param sessionId - UUID session identifier
    * @param sessionType - Type of session ("main" or "subagent")
    * @returns Generated filename
    */
@@ -298,11 +279,10 @@ export class JsonlHandler {
     sessionId: string,
     sessionType: "main" | "subagent",
   ): string {
-    // Validate sessionId is either new timestamp-prefixed format or legacy UUID
-    const newFormatPattern = /^\d{14}-[0-9a-f]{8}$/;
+    // Validate sessionId is a valid UUID
     const uuidPattern =
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-    if (!newFormatPattern.test(sessionId) && !uuidPattern.test(sessionId)) {
+    if (!uuidPattern.test(sessionId)) {
       throw new Error(`Invalid session ID format: ${sessionId}`);
     }
 

--- a/packages/agent-sdk/src/services/session.ts
+++ b/packages/agent-sdk/src/services/session.ts
@@ -63,43 +63,11 @@ export interface SessionIndex {
 }
 
 /**
- * Generate a new session ID with a timestamp prefix for sortability
- * Format: {YYYYMMDDHHmmss}-{8hex} (e.g. 20260527143025-a1b2c3d4)
- * @returns Timestamp-prefixed session ID string
+ * Generate a new session ID using Node.js native crypto.randomUUID()
+ * @returns UUID string for session identification
  */
 export function generateSessionId(): string {
-  const now = new Date();
-  const ts = [
-    now.getFullYear(),
-    String(now.getMonth() + 1).padStart(2, "0"),
-    String(now.getDate()).padStart(2, "0"),
-    String(now.getHours()).padStart(2, "0"),
-    String(now.getMinutes()).padStart(2, "0"),
-    String(now.getSeconds()).padStart(2, "0"),
-  ].join("");
-  const shortId = randomUUID().slice(0, 8);
-  return `${ts}-${shortId}`;
-}
-
-/**
- * Parse the timestamp prefix from a session ID back into a Date
- * Format: {YYYYMMDDHHmmss}-{8hex} (e.g. 20260527143025-a1b2c3d4)
- * @returns Date from the session ID timestamp prefix
- */
-export function parseSessionIdTimestamp(sessionId: string): Date {
-  const match = sessionId.match(/^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/);
-  if (!match) {
-    return new Date(); // Fallback to now for legacy UUID-format session IDs
-  }
-  const [, year, month, day, hour, minute, second] = match;
-  return new Date(
-    Number(year),
-    Number(month) - 1,
-    Number(day),
-    Number(hour),
-    Number(minute),
-    Number(second),
-  );
+  return randomUUID();
 }
 
 /**
@@ -293,9 +261,9 @@ export async function appendMessages(
       (await getFirstMessageContent(sessionId, workdir)) || undefined;
   }
 
-  // Derive createdAt from session ID timestamp if not in index
+  // Derive createdAt from session ID if not in index
   if (!createdAt) {
-    createdAt = new Date(parseSessionIdTimestamp(sessionId));
+    createdAt = new Date();
   }
 
   await updateSessionIndex(projectDir.encodedPath, {
@@ -520,17 +488,15 @@ export async function listSessionsFromJsonl(
       try {
         const filePath = join(projectDir.encodedPath, file);
 
-        // Validate main session filename format (new timestamp format or legacy UUID)
-        const newFormatMatch = file.match(/^(\d{14}-[0-9a-f]{8})\.jsonl$/);
+        // Validate main session filename format (UUID.jsonl)
         const uuidMatch = file.match(
           /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/,
         );
-        const match = newFormatMatch || uuidMatch;
-        if (!match) {
+        if (!uuidMatch) {
           continue; // Skip invalid filenames
         }
 
-        const sessionId = match[1];
+        const sessionId = uuidMatch[1];
 
         // PERFORMANCE OPTIMIZATION: Only read the last message for timestamps and tokens
         const jsonlHandler = new JsonlHandler();
@@ -557,7 +523,7 @@ export async function listSessionsFromJsonl(
           sessionType: "main",
           subagentType: undefined, // No longer stored in metadata
           workdir: projectDir.originalPath,
-          createdAt: new Date(parseSessionIdTimestamp(sessionId)),
+          createdAt: new Date(),
           lastActiveAt,
           latestTotalTokens: lastMessage?.usage
             ? extractLatestTotalTokens([lastMessage])
@@ -720,24 +686,17 @@ export async function cleanupExpiredSessionsFromJsonl(
             );
             const indexContent = await fs.readFile(indexPath, "utf8");
             const index = JSON.parse(indexContent) as SessionIndex;
-            // New timestamp-prefixed format patterns
-            const newMainMatch = file.match(/^(\d{14}-[0-9a-f]{8})\.jsonl$/);
-            const newSubagentMatch = file.match(
-              /^subagent-(\d{14}-[0-9a-f]{8})\.jsonl$/,
-            );
-            // Old UUID format patterns (backward compat)
             const uuidMatch = file.match(
-              /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/,
+              /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/,
             );
             const subagentMatch = file.match(
-              /^subagent-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/,
+              /^subagent-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/,
             );
-            const sessionId =
-              newMainMatch?.[1] ??
-              newSubagentMatch?.[1] ??
-              uuidMatch?.[1] ??
-              subagentMatch?.[1] ??
-              null;
+            const sessionId = uuidMatch
+              ? uuidMatch[1]
+              : subagentMatch
+                ? subagentMatch[1]
+                : null;
 
             if (sessionId && index.sessions[sessionId]) {
               delete index.sessions[sessionId];

--- a/packages/agent-sdk/tests/services/jsonlHandler.test.ts
+++ b/packages/agent-sdk/tests/services/jsonlHandler.test.ts
@@ -555,7 +555,7 @@ describe("JsonlHandler.createSession() - TDD Tests for User Story 1", () => {
   describe("Session creation without metadata header", () => {
     it("should create session file without metadata header", async () => {
       // Create session using the NEW simplified API
-      const sessionId = "20260527143025-a1b2c3d4";
+      const sessionId = "12345678-1234-1234-1234-123456789abc";
       const sessionType = "main";
       const filePath = `/test/sessions/${handler.generateSessionFilename(sessionId, sessionType)}`;
 
@@ -572,7 +572,7 @@ describe("JsonlHandler.createSession() - TDD Tests for User Story 1", () => {
     });
 
     it("should create session file that is initially empty and ready for messages", async () => {
-      const sessionId = "20260527143025-a1b2c3d4";
+      const sessionId = "12345678-1234-1234-1234-123456789abc";
       const filePath = `/test/sessions/${handler.generateSessionFilename(sessionId, "main")}`;
 
       await handler.createSession(filePath);
@@ -589,7 +589,7 @@ describe("JsonlHandler.createSession() - TDD Tests for User Story 1", () => {
     });
 
     it("should create subagent session file without metadata header", async () => {
-      const sessionId = "20260527143025-a1b2c3d4";
+      const sessionId = "87654321-4321-4321-4321-abcdef123456";
       const filePath = `/test/sessions/${handler.generateSessionFilename(sessionId, "subagent")}`;
 
       await handler.createSession(filePath);
@@ -602,7 +602,7 @@ describe("JsonlHandler.createSession() - TDD Tests for User Story 1", () => {
 
   describe("Session file contains only messages after creation", () => {
     it("should contain only messages after creation and adding messages", async () => {
-      const sessionId = "20260527143025-a1b2c3d4";
+      const sessionId = "11111111-2222-3333-4444-555555555555";
       const filePath = `/test/sessions/${handler.generateSessionFilename(sessionId, "main")}`;
 
       // Create session
@@ -675,7 +675,7 @@ describe("JsonlHandler.createSession() - TDD Tests for User Story 1", () => {
 
   describe("Error handling in new session creation", () => {
     it("should handle directory creation errors gracefully", async () => {
-      const sessionId = "20260527143025-a1b2c3d4";
+      const sessionId = "12345678-1234-1234-1234-123456789abc";
       const filePath = `/test/sessions/${handler.generateSessionFilename(sessionId, "main")}`;
 
       // Mock mkdir to fail with permission error
@@ -687,7 +687,7 @@ describe("JsonlHandler.createSession() - TDD Tests for User Story 1", () => {
     });
 
     it("should handle file creation errors gracefully", async () => {
-      const sessionId = "20260527143025-a1b2c3d4";
+      const sessionId = "12345678-1234-1234-1234-123456789abc";
       const filePath = `/test/sessions/${handler.generateSessionFilename(sessionId, "main")}`;
 
       // Mock writeFile to fail
@@ -743,28 +743,6 @@ describe("JsonlHandler filename utilities", () => {
           sessionType: "main",
         });
       });
-
-      it("should parse new timestamp-prefixed main session filename", () => {
-        const result = handler.parseSessionFilename(
-          "/path/to/20260527143025-a1b2c3d4.jsonl",
-        );
-
-        expect(result).toEqual({
-          sessionId: "20260527143025-a1b2c3d4",
-          sessionType: "main",
-        });
-      });
-
-      it("should parse new timestamp-prefixed main session from just filename", () => {
-        const result = handler.parseSessionFilename(
-          "20260101000000-deadbeef.jsonl",
-        );
-
-        expect(result).toEqual({
-          sessionId: "20260101000000-deadbeef",
-          sessionType: "main",
-        });
-      });
     });
 
     describe("Subagent session filename parsing", () => {
@@ -797,28 +775,6 @@ describe("JsonlHandler filename utilities", () => {
 
         expect(result).toEqual({
           sessionId: "11111111-2222-3333-4444-555555555555",
-          sessionType: "subagent",
-        });
-      });
-
-      it("should parse new timestamp-prefixed subagent session filename", () => {
-        const result = handler.parseSessionFilename(
-          "/path/to/subagent-20260527143025-a1b2c3d4.jsonl",
-        );
-
-        expect(result).toEqual({
-          sessionId: "20260527143025-a1b2c3d4",
-          sessionType: "subagent",
-        });
-      });
-
-      it("should parse new timestamp-prefixed subagent session from just filename", () => {
-        const result = handler.parseSessionFilename(
-          "subagent-20260101000000-deadbeef.jsonl",
-        );
-
-        expect(result).toEqual({
-          sessionId: "20260101000000-deadbeef",
           sessionType: "subagent",
         });
       });
@@ -866,9 +822,6 @@ describe("JsonlHandler filename utilities", () => {
           "abcdef12-3456-789a-bcde-f123456789ab.jsonl",
           "11111111-2222-3333-4444-555555555555.jsonl",
           "ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb.jsonl",
-          // New timestamp-prefixed format
-          "20260527143025-a1b2c3d4.jsonl",
-          "20260101000000-deadbeef.jsonl",
         ];
 
         validMainFilenames.forEach((filename) => {
@@ -882,9 +835,6 @@ describe("JsonlHandler filename utilities", () => {
           "subagent-abcdef12-3456-789a-bcde-f123456789ab.jsonl",
           "subagent-11111111-2222-3333-4444-555555555555.jsonl",
           "subagent-ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb.jsonl",
-          // New timestamp-prefixed format
-          "subagent-20260527143025-a1b2c3d4.jsonl",
-          "subagent-20260101000000-deadbeef.jsonl",
         ];
 
         validSubagentFilenames.forEach((filename) => {
@@ -907,21 +857,18 @@ describe("JsonlHandler filename utilities", () => {
         });
       });
 
-      it("should reject filenames with invalid session ID formats", () => {
-        const invalidFilenames = [
+      it("should reject filenames with invalid UUID formats", () => {
+        const invalidUuidFilenames = [
           "invalid-uuid.jsonl",
-          "12345678-1234-1234-1234.jsonl", // Too short for UUID
-          "12345678-1234-1234-1234-123456789abcd.jsonl", // Too long for UUID
+          "12345678-1234-1234-1234.jsonl", // Too short
+          "12345678-1234-1234-1234-123456789abcd.jsonl", // Too long
           "12345678-1234-1234-1234-123456789abg.jsonl", // Invalid hex char
           "12345678123412341234123456789abc.jsonl", // Missing hyphens
           "subagent-invalid-uuid.jsonl",
           "subagent-12345678-1234-1234-1234.jsonl", // Too short
-          "20260527-a1b2c3d4.jsonl", // Not enough timestamp digits
-          "20260527143025-a1b2c3d4e5f6.jsonl", // Too many hex chars
-          "subagent-2026052-a1b2c3d4.jsonl", // Not enough timestamp digits
         ];
 
-        invalidFilenames.forEach((filename) => {
+        invalidUuidFilenames.forEach((filename) => {
           expect(handler.isValidSessionFilename(filename)).toBe(false);
         });
       });
@@ -960,9 +907,6 @@ describe("JsonlHandler filename utilities", () => {
           "12345678-1234-1234-1234-123456789abc",
           "abcdef12-3456-789a-bcde-f123456789ab",
           "11111111-2222-3333-4444-555555555555",
-          // New timestamp-prefixed format
-          "20260527143025-a1b2c3d4",
-          "20260101000000-deadbeef",
         ];
 
         sessionIds.forEach((sessionId) => {
@@ -993,7 +937,7 @@ describe("JsonlHandler filename utilities", () => {
 
   describe("generateSessionFilename() - TDD Tests for User Story 1", () => {
     describe("Main session filename generation", () => {
-      it("should generate correct main session filename format (UUID)", () => {
+      it("should generate correct main session filename format", () => {
         const sessionId = "12345678-1234-1234-1234-123456789abc";
         const result = handler.generateSessionFilename(sessionId, "main");
 
@@ -1002,14 +946,6 @@ describe("JsonlHandler filename utilities", () => {
         expect(result).toMatch(
           /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
         );
-      });
-
-      it("should generate correct main session filename format (new timestamp-prefixed)", () => {
-        const sessionId = "20260527143025-a1b2c3d4";
-        const result = handler.generateSessionFilename(sessionId, "main");
-
-        expect(result).toBe("20260527143025-a1b2c3d4.jsonl");
-        expect(result).toMatch(/^\d{14}-[0-9a-f]{8}\.jsonl$/);
       });
 
       it("should generate unique filenames for different session IDs", () => {
@@ -1025,12 +961,7 @@ describe("JsonlHandler filename utilities", () => {
       });
 
       it("should validate session ID format for main sessions", () => {
-        // Valid new timestamp-prefixed formats should work
-        expect(() => {
-          handler.generateSessionFilename("20260527143025-a1b2c3d4", "main");
-        }).not.toThrow();
-
-        // Valid legacy UUID formats should also work
+        // Valid UUID formats should work
         expect(() => {
           handler.generateSessionFilename(
             "12345678-1234-1234-1234-123456789abc",
@@ -1054,7 +985,7 @@ describe("JsonlHandler filename utilities", () => {
     });
 
     describe("Subagent session filename generation", () => {
-      it("should generate correct subagent session filename format (UUID)", () => {
+      it("should generate correct subagent session filename format", () => {
         const sessionId = "87654321-4321-4321-4321-abcdef123456";
         const result = handler.generateSessionFilename(sessionId, "subagent");
 
@@ -1065,14 +996,6 @@ describe("JsonlHandler filename utilities", () => {
         expect(result).toMatch(
           /^subagent-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
         );
-      });
-
-      it("should generate correct subagent session filename format (new timestamp-prefixed)", () => {
-        const sessionId = "20260527143025-a1b2c3d4";
-        const result = handler.generateSessionFilename(sessionId, "subagent");
-
-        expect(result).toBe("subagent-20260527143025-a1b2c3d4.jsonl");
-        expect(result).toMatch(/^subagent-\d{14}-[0-9a-f]{8}\.jsonl$/);
       });
 
       it("should generate unique filenames for different subagent session IDs", () => {
@@ -1092,15 +1015,7 @@ describe("JsonlHandler filename utilities", () => {
       });
 
       it("should validate session ID format for subagent sessions", () => {
-        // Valid new timestamp-prefixed formats should work
-        expect(() => {
-          handler.generateSessionFilename(
-            "20260527143025-a1b2c3d4",
-            "subagent",
-          );
-        }).not.toThrow();
-
-        // Valid legacy UUID formats should also work
+        // Valid UUID formats should work
         expect(() => {
           handler.generateSessionFilename(
             "12345678-1234-1234-1234-123456789abc",
@@ -1117,7 +1032,7 @@ describe("JsonlHandler filename utilities", () => {
 
     describe("Session type differentiation", () => {
       it("should generate different filenames for main vs subagent with same session ID", () => {
-        const sessionId = "20260527143025-a1b2c3d4";
+        const sessionId = "12345678-1234-1234-1234-123456789abc";
 
         const mainFilename = handler.generateSessionFilename(sessionId, "main");
         const subagentFilename = handler.generateSessionFilename(
@@ -1125,13 +1040,15 @@ describe("JsonlHandler filename utilities", () => {
           "subagent",
         );
 
-        expect(mainFilename).toBe("20260527143025-a1b2c3d4.jsonl");
-        expect(subagentFilename).toBe("subagent-20260527143025-a1b2c3d4.jsonl");
+        expect(mainFilename).toBe("12345678-1234-1234-1234-123456789abc.jsonl");
+        expect(subagentFilename).toBe(
+          "subagent-12345678-1234-1234-1234-123456789abc.jsonl",
+        );
         expect(mainFilename).not.toBe(subagentFilename);
       });
 
       it("should enable session type identification from filename alone", () => {
-        const sessionId = "20260527143025-99999999";
+        const sessionId = "99999999-9999-9999-9999-999999999999";
 
         const mainFilename = handler.generateSessionFilename(sessionId, "main");
         const subagentFilename = handler.generateSessionFilename(
@@ -1154,15 +1071,7 @@ describe("JsonlHandler filename utilities", () => {
     });
 
     describe("Edge cases and validation", () => {
-      it("should handle mixed case in new format (lowercase hex)", () => {
-        // New format uses lowercase hex in the 8-char suffix
-        const sessionId = "20260527143025-a1b2c3d4";
-
-        const result = handler.generateSessionFilename(sessionId, "main");
-        expect(result).toBe("20260527143025-a1b2c3d4.jsonl");
-      });
-
-      it("should handle mixed case UUID properly (legacy format)", () => {
+      it("should handle mixed case UUID properly", () => {
         const mixedCaseId = "AbCdEf12-3456-789A-BcDe-F123456789AB";
         const lowercaseId = mixedCaseId.toLowerCase();
 
@@ -1171,16 +1080,13 @@ describe("JsonlHandler filename utilities", () => {
         expect(result).toBe("abcdef12-3456-789a-bcde-f123456789ab.jsonl");
       });
 
-      it("should reject non-session-ID strings", () => {
+      it("should reject non-UUID strings", () => {
         const invalidIds = [
-          "not-a-session-id",
-          "12345678-1234-1234-1234-123456789abg", // Invalid hex character (UUID)
-          "12345678-1234-1234-1234-123456789ab", // Too short (UUID)
-          "12345678-1234-1234-1234-123456789abcd", // Too long (UUID)
-          "12345678123412341234123456789abc", // Missing hyphens (UUID)
-          "20260527-a1b2c3d4", // Not enough timestamp digits
-          "20260527143025-a1b2c3d4e5f6", // Too many hex chars
-          "20260527143025-ABCDEF12", // Uppercase hex not allowed in new format
+          "not-a-uuid",
+          "12345678-1234-1234-1234-123456789abg", // Invalid hex character
+          "12345678-1234-1234-1234-123456789ab", // Too short
+          "12345678-1234-1234-1234-123456789abcd", // Too long
+          "12345678123412341234123456789abc", // Missing hyphens
         ];
 
         invalidIds.forEach((invalidId) => {
@@ -1195,29 +1101,35 @@ describe("JsonlHandler filename utilities", () => {
   describe("TDD Tests for User Story 2: Subagent Filename Generation - T019", () => {
     describe("Subagent filename generation tests", () => {
       it("should generate subagent filename with correct prefix format", () => {
-        const sessionId = "20260527143025-a1b2c3d4";
+        const sessionId = "12345678-1234-1234-1234-123456789abc";
         const result = handler.generateSessionFilename(sessionId, "subagent");
 
         // Should follow pattern: subagent-{sessionId}.jsonl
-        expect(result).toBe("subagent-20260527143025-a1b2c3d4.jsonl");
+        expect(result).toBe(
+          "subagent-12345678-1234-1234-1234-123456789abc.jsonl",
+        );
         expect(result.startsWith("subagent-")).toBe(true);
         expect(result.endsWith(".jsonl")).toBe(true);
       });
 
       it("should generate different subagent filenames for different session IDs", () => {
-        const sessionId1 = "20260527143025-aaaaaaaa";
-        const sessionId2 = "20260527143026-bbbbbbbb";
+        const sessionId1 = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        const sessionId2 = "11111111-2222-3333-4444-555555555555";
 
         const result1 = handler.generateSessionFilename(sessionId1, "subagent");
         const result2 = handler.generateSessionFilename(sessionId2, "subagent");
 
-        expect(result1).toBe("subagent-20260527143025-aaaaaaaa.jsonl");
-        expect(result2).toBe("subagent-20260527143026-bbbbbbbb.jsonl");
+        expect(result1).toBe(
+          "subagent-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl",
+        );
+        expect(result2).toBe(
+          "subagent-11111111-2222-3333-4444-555555555555.jsonl",
+        );
         expect(result1).not.toBe(result2);
       });
 
       it("should maintain consistency between main and subagent filename generation", () => {
-        const sessionId = "20260527143025-a1b2c3d4";
+        const sessionId = "87654321-4321-4321-4321-abcdef123456";
 
         const mainFilename = handler.generateSessionFilename(sessionId, "main");
         const subagentFilename = handler.generateSessionFilename(
@@ -1234,16 +1146,8 @@ describe("JsonlHandler filename utilities", () => {
         expect(handler.isValidSessionFilename(subagentFilename)).toBe(true);
       });
 
-      it("should validate session ID format for subagent session generation", () => {
-        // Valid new timestamp-prefixed format should work
-        expect(() => {
-          handler.generateSessionFilename(
-            "20260527143025-a1b2c3d4",
-            "subagent",
-          );
-        }).not.toThrow();
-
-        // Valid legacy UUID should also work
+      it("should validate UUID format for subagent session generation", () => {
+        // Valid UUID should work
         expect(() => {
           handler.generateSessionFilename(
             "12345678-1234-1234-1234-123456789abc",
@@ -1251,11 +1155,11 @@ describe("JsonlHandler filename utilities", () => {
           );
         }).not.toThrow();
 
-        // Invalid IDs should throw
+        // Invalid UUIDs should throw
         const invalidIds = [
           "invalid-subagent-id",
-          "12345678-1234-1234-1234", // Too short for UUID
-          "12345678-1234-1234-1234-123456789abcd", // Too long for UUID
+          "12345678-1234-1234-1234", // Too short
+          "12345678-1234-1234-1234-123456789abcd", // Too long
           "12345678123412341234123456789abc", // Missing hyphens
           "",
         ];
@@ -1272,23 +1176,25 @@ describe("JsonlHandler filename utilities", () => {
       it("should parse subagent filename correctly", () => {
         const testCases = [
           {
-            filePath: "/path/to/subagent-20260527143025-a1b2c3d4.jsonl",
+            filePath:
+              "/path/to/subagent-12345678-1234-1234-1234-123456789abc.jsonl",
             expected: {
-              sessionId: "20260527143025-a1b2c3d4",
+              sessionId: "12345678-1234-1234-1234-123456789abc",
               sessionType: "subagent" as const,
             },
           },
           {
-            filePath: "sessions/subagent-20260101000000-deadbeef.jsonl",
+            filePath:
+              "sessions/subagent-87654321-4321-4321-4321-abcdef123456.jsonl",
             expected: {
-              sessionId: "20260101000000-deadbeef",
+              sessionId: "87654321-4321-4321-4321-abcdef123456",
               sessionType: "subagent" as const,
             },
           },
           {
-            filePath: "subagent-20260527143025-ffffffff.jsonl",
+            filePath: "subagent-ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb.jsonl",
             expected: {
-              sessionId: "20260527143025-ffffffff",
+              sessionId: "ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb",
               sessionType: "subagent" as const,
             },
           },
@@ -1301,7 +1207,7 @@ describe("JsonlHandler filename utilities", () => {
       });
 
       it("should parse main vs subagent filename formats correctly", () => {
-        const sessionId = "20260527143025-a1b2c3d4";
+        const sessionId = "12345678-1234-1234-1234-123456789abc";
 
         const mainResult = handler.parseSessionFilename(`${sessionId}.jsonl`);
         const subagentResult = handler.parseSessionFilename(
@@ -1322,9 +1228,9 @@ describe("JsonlHandler filename utilities", () => {
       it("should handle parsing edge cases and invalid formats", () => {
         const invalidFilenames = [
           "agent-12345678-1234-1234-1234-123456789abc.jsonl", // Wrong prefix
-          "subagent-invalid-uuid.jsonl", // Invalid session ID
-          "subagent-12345678-1234-1234-1234.jsonl", // Too short for both formats
-          "subagent-.jsonl", // Empty session ID
+          "subagent-invalid-uuid.jsonl", // Invalid UUID
+          "subagent-12345678-1234-1234-1234.jsonl", // Too short UUID
+          "subagent-.jsonl", // Empty UUID
           "subagent-12345678-1234-1234-1234-123456789abc.txt", // Wrong extension
         ];
 
@@ -1343,9 +1249,6 @@ describe("JsonlHandler filename utilities", () => {
           "subagent-87654321-4321-4321-4321-abcdef123456.jsonl",
           "subagent-ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb.jsonl",
           "subagent-00000000-0000-0000-0000-000000000000.jsonl",
-          // New timestamp-prefixed format
-          "subagent-20260527143025-a1b2c3d4.jsonl",
-          "subagent-20260101000000-deadbeef.jsonl",
         ];
 
         validSubagentFilenames.forEach((filename) => {
@@ -1357,15 +1260,13 @@ describe("JsonlHandler filename utilities", () => {
         const invalidSubagentFilenames = [
           "agent-12345678-1234-1234-1234-123456789abc.jsonl", // Wrong prefix
           "sub-12345678-1234-1234-1234-123456789abc.jsonl", // Wrong prefix
-          "subagent-invalid-uuid.jsonl", // Invalid session ID
-          "subagent-12345678-1234-1234-1234.jsonl", // Too short for both formats
+          "subagent-invalid-uuid.jsonl", // Invalid UUID
+          "subagent-12345678-1234-1234-1234.jsonl", // UUID too short
           "subagent-12345678-1234-1234-1234-123456789abcd.jsonl", // UUID too long
           "subagent-12345678-1234-1234-1234-123456789abg.jsonl", // Invalid hex char
           "subagent-12345678123412341234123456789abc.jsonl", // Missing hyphens
           "subagent-12345678-1234-1234-1234-123456789abc.txt", // Wrong extension
           "subagent-12345678-1234-1234-1234-123456789abc", // Missing extension
-          "subagent-20260527-a1b2c3d4.jsonl", // Not enough timestamp digits
-          "subagent-20260527143025-a1b2c3d4e5f6.jsonl", // Too many hex chars
         ];
 
         invalidSubagentFilenames.forEach((filename) => {
@@ -1379,9 +1280,6 @@ describe("JsonlHandler filename utilities", () => {
           "87654321-4321-4321-4321-abcdef123456",
           "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
           "ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb",
-          // New timestamp-prefixed format
-          "20260527143025-a1b2c3d4",
-          "20260101000000-deadbeef",
         ];
 
         sessionIds.forEach((sessionId) => {
@@ -1406,24 +1304,15 @@ describe("JsonlHandler filename utilities", () => {
       it("should identify session type from filename pattern alone", () => {
         const testFilenames = [
           {
-            filename: "20260527143025-a1b2c3d4.jsonl",
-            expectedType: "main",
-          },
-          {
-            filename: "subagent-20260527143025-a1b2c3d4.jsonl",
-            expectedType: "subagent",
-          },
-          {
-            filename: "20260101000000-deadbeef.jsonl",
-            expectedType: "main",
-          },
-          {
-            filename: "subagent-20260101000000-deadbeef.jsonl",
-            expectedType: "subagent",
-          },
-          // Legacy UUID format (backward compat)
-          {
             filename: "12345678-1234-1234-1234-123456789abc.jsonl",
+            expectedType: "main",
+          },
+          {
+            filename: "subagent-12345678-1234-1234-1234-123456789abc.jsonl",
+            expectedType: "subagent",
+          },
+          {
+            filename: "87654321-4321-4321-4321-abcdef123456.jsonl",
             expectedType: "main",
           },
           {
@@ -1446,14 +1335,11 @@ describe("JsonlHandler filename utilities", () => {
 
       it("should enable efficient session filtering by filename patterns", () => {
         const mixedSessionFiles = [
-          "20260527143025-a1b2c3d4.jsonl", // main (new format)
-          "subagent-20260527143025-a1b2c3d4.jsonl", // subagent (new format)
-          "20260101000000-deadbeef.jsonl", // main (new format)
-          "subagent-20260101000000-deadbeef.jsonl", // subagent (new format)
-          "20260527143026-11111111.jsonl", // main (new format)
-          // Legacy UUID format (backward compat)
           "12345678-1234-1234-1234-123456789abc.jsonl", // main
           "subagent-87654321-4321-4321-4321-abcdef123456.jsonl", // subagent
+          "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl", // main
+          "subagent-ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb.jsonl", // subagent
+          "11111111-2222-3333-4444-555555555555.jsonl", // main
         ];
 
         // Filter main sessions using filename pattern (no file reading needed)
@@ -1470,8 +1356,8 @@ describe("JsonlHandler filename utilities", () => {
             filename.startsWith("subagent-"),
         );
 
-        expect(mainSessions).toHaveLength(4);
-        expect(subagentSessions).toHaveLength(3);
+        expect(mainSessions).toHaveLength(3);
+        expect(subagentSessions).toHaveLength(2);
 
         // Verify correct categorization
         mainSessions.forEach((filename) => {
@@ -1489,15 +1375,12 @@ describe("JsonlHandler filename utilities", () => {
 
       it("should support session discovery without content inspection", () => {
         const sessionFiles = [
-          "20260527143025-a1b2c3d4.jsonl",
-          "subagent-20260527143025-a1b2c3d4.jsonl",
-          "invalid-filename.jsonl",
-          "not-a-session.txt",
-          "20260101000000-deadbeef.jsonl",
-          "subagent-20260101000000-deadbeef.jsonl",
-          // Legacy UUID format
           "12345678-1234-1234-1234-123456789abc.jsonl",
           "subagent-87654321-4321-4321-4321-abcdef123456.jsonl",
+          "invalid-filename.jsonl",
+          "not-a-session.txt",
+          "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl",
+          "subagent-ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb.jsonl",
         ];
 
         const discoveredSessions = sessionFiles
@@ -1511,10 +1394,10 @@ describe("JsonlHandler filename utilities", () => {
           })
           .filter((session) => session !== null);
 
-        // Should discover 6 valid sessions
-        expect(discoveredSessions).toHaveLength(6);
+        // Should discover 4 valid sessions
+        expect(discoveredSessions).toHaveLength(4);
 
-        // Should have 3 main and 3 subagent sessions
+        // Should have 2 main and 2 subagent sessions
         const mainCount = discoveredSessions.filter(
           (s) => s!.sessionType === "main",
         ).length;
@@ -1522,8 +1405,8 @@ describe("JsonlHandler filename utilities", () => {
           (s) => s!.sessionType === "subagent",
         ).length;
 
-        expect(mainCount).toBe(3);
-        expect(subagentCount).toBe(3);
+        expect(mainCount).toBe(2);
+        expect(subagentCount).toBe(2);
       });
     });
   });

--- a/packages/agent-sdk/tests/services/session.core.test.ts
+++ b/packages/agent-sdk/tests/services/session.core.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
+import { randomUUID } from "crypto";
 import { join } from "path";
 import { homedir } from "os";
 
@@ -253,18 +254,20 @@ describe("Session Core Functionality", () => {
     );
   });
 
-  describe("T016: generateSessionId() Generation and Validation", () => {
-    it("should generate valid timestamp-prefixed format", () => {
+  describe("T016: crypto.randomUUID() Generation and Validation", () => {
+    it("should generate valid UUID format", () => {
       const sessionId = generateSessionId();
 
-      // Timestamp-prefixed format: {YYYYMMDDHHmmss}-{8hex}
-      const timestampPrefixRegex = /^\d{14}-[0-9a-f]{8}$/;
+      // UUID v4 format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+      // where y is 8, 9, A, or B (variant bits)
+      const uuidRegex =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-      expect(sessionId).toMatch(timestampPrefixRegex);
+      expect(sessionId).toMatch(uuidRegex);
       expect(sessionId).toBe(sessionId.toLowerCase());
     });
 
-    it("should generate different session IDs on multiple calls", () => {
+    it("should generate different UUIDs on multiple calls", () => {
       const id1 = generateSessionId();
       const id2 = generateSessionId();
       const id3 = generateSessionId();
@@ -274,53 +277,59 @@ describe("Session Core Functionality", () => {
       expect(id1).not.toBe(id3);
     });
 
-    it("should generate unique session IDs", () => {
+    it("should generate unique UUIDs", () => {
       const ids: string[] = [];
 
-      // Generate multiple session IDs
+      // Generate multiple UUIDs
       for (let i = 0; i < 10; i++) {
         ids.push(generateSessionId());
       }
 
-      // All session IDs should be unique
+      // All UUIDs should be unique
       const uniqueIds = new Set(ids);
       expect(uniqueIds.size).toBe(10);
 
-      // All should be valid timestamp-prefixed format
-      const timestampPrefixRegex = /^\d{14}-[0-9a-f]{8}$/;
+      // All should be valid UUID format
+      const uuidRegex =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
       ids.forEach((id) => {
-        expect(id).toMatch(timestampPrefixRegex);
+        expect(id).toMatch(uuidRegex);
       });
     });
 
-    it("should validate session ID format correctly", () => {
+    it("should validate UUID format using Node.js crypto", () => {
       const validId = generateSessionId();
       const invalidIds = [
         "invalid-uuid",
-        "12345678-1234-6678-9abc-123456789012", // Old UUID format (not new format)
-        "12345678-1234-5678-9abc-123456789012", // Old UUID format
+        "12345678-1234-6678-9abc-123456789012", // v6 format (we now use v4)
+        "12345678-1234-5678-9abc-123456789012", // v5 format
         "",
-        "not-a-session-id-at-all",
-        "20260527143025-a1b2c3d4e5f6", // Too many hex chars
-        "20260527-a1b2c3d4", // Not enough digits
+        "not-a-uuid-at-all",
       ];
 
-      // Valid session ID should pass format validation
-      const timestampPrefixRegex = /^\d{14}-[0-9a-f]{8}$/;
+      // Valid UUID should pass format validation
+      const uuidRegex =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-      expect(validId).toMatch(timestampPrefixRegex);
+      expect(validId).toMatch(uuidRegex);
+      expect(validId.length).toBe(36);
+      expect(() => randomUUID()).not.toThrow();
+      expect(validId).toBeTruthy();
+      expect(() => randomUUID()).not.toThrow();
       expect(validId).toBeTruthy();
       expect(typeof validId).toBe("string");
 
-      // Invalid IDs should be rejected
+      // Invalid UUIDs should be rejected
       invalidIds.forEach((id) => {
-        expect(id).not.toMatch(/^\d{14}-[0-9a-f]{8}$/);
+        expect(id).not.toMatch(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+        );
       });
     });
   });
 
   describe("T017: Integration test for session file naming", () => {
-    it("should create session files with clean timestamp-prefixed names", async () => {
+    it("should create session files with clean UUID names", async () => {
       const sessionId = generateSessionId();
       const filePath = await getSessionFilePath(sessionId, testWorkdir);
 
@@ -328,7 +337,9 @@ describe("Session Core Functionality", () => {
       // The session ID itself should not have session- or wave- prefixes
       expect(sessionId).not.toContain("session-");
       expect(sessionId).not.toContain("wave-");
-      expect(filePath).toMatch(/\d{14}-[0-9a-f]{8}\.jsonl$/);
+      expect(filePath).toMatch(
+        /[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.jsonl$/i,
+      );
     });
 
     it("should use .jsonl file extension", async () => {

--- a/packages/agent-sdk/tests/services/session.errors.test.ts
+++ b/packages/agent-sdk/tests/services/session.errors.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
+import { randomUUID } from "crypto";
 
 // Mock fs/promises (used by session.ts)
 vi.mock("fs", () => ({
@@ -53,7 +54,6 @@ vi.mock("@/utils/pathEncoder.js", () => ({
 }));
 
 import {
-  generateSessionId,
   listSessionsFromJsonl,
   getLatestSessionFromJsonl,
   loadSessionFromJsonl,
@@ -244,8 +244,8 @@ describe("Session Error Handling and Edge Cases", () => {
     });
 
     it("should handle getLatestSessionFromJsonl with directory separation based on last active time", async () => {
-      const olderMainSessionId = generateSessionId();
-      const newerMainSessionId = generateSessionId();
+      const olderMainSessionId = randomUUID();
+      const newerMainSessionId = randomUUID();
 
       // Create different timestamps - older session has more recent activity
       // Note: timestamps are used to simulate file creation order in this test
@@ -308,7 +308,7 @@ describe("Session Error Handling and Edge Cases", () => {
     });
 
     it("should support loading subagent sessions", async () => {
-      const subagentSessionId = generateSessionId();
+      const subagentSessionId = randomUUID();
 
       const messages = [
         {

--- a/packages/agent-sdk/tests/services/session.subagent.test.ts
+++ b/packages/agent-sdk/tests/services/session.subagent.test.ts
@@ -224,7 +224,7 @@ describe("Subagent Session Tests", () => {
     describe("generateSubagentFilename function (to be implemented)", () => {
       it("should generate subagent filename with correct prefix", () => {
         // This test validates expected functionality that should be implemented
-        const sessionId = "20260527143025-a1b2c3d4";
+        const sessionId = "12345678-1234-1234-1234-123456789abc";
 
         // Mock the expected generateSubagentFilename function call
         const expectedResult = `subagent-${sessionId}.jsonl`;
@@ -238,8 +238,8 @@ describe("Subagent Session Tests", () => {
       });
 
       it("should generate unique subagent filenames for different session IDs", () => {
-        const sessionId1 = "20260527143025-aaaaaaaa";
-        const sessionId2 = "20260527143026-bbbbbbbb";
+        const sessionId1 = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        const sessionId2 = "11111111-2222-3333-4444-555555555555";
 
         const result1 = mockJsonlHandler.generateSessionFilename(
           sessionId1,
@@ -256,19 +256,20 @@ describe("Subagent Session Tests", () => {
       });
 
       it("should validate session ID format for subagent filename generation", () => {
-        // Test with valid new format session ID
+        // Test with valid UUID
         expect(() => {
           mockJsonlHandler.generateSessionFilename(
-            "20260527143025-a1b2c3d4",
+            "12345678-1234-1234-1234-123456789abc",
             "subagent",
           );
         }).not.toThrow();
 
-        // Mock implementation should validate timestamp-prefixed format
+        // Mock implementation should validate UUID format
         mockJsonlHandler.generateSessionFilename.mockImplementation(
           (sessionId: string, sessionType: "main" | "subagent" = "main") => {
-            const newFormatPattern = /^\d{14}-[0-9a-f]{8}$/;
-            if (!newFormatPattern.test(sessionId)) {
+            const uuidPattern =
+              /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+            if (!uuidPattern.test(sessionId)) {
               throw new Error(`Invalid session ID format: ${sessionId}`);
             }
             return sessionType === "main"
@@ -277,10 +278,10 @@ describe("Subagent Session Tests", () => {
           },
         );
 
-        // Test with invalid session IDs
+        // Test with invalid UUIDs
         const invalidIds = [
           "invalid-id",
-          "12345678-1234-1234-1234", // Too short for both formats
+          "12345678-1234-1234-1234", // Too short
           "12345678-1234-1234-1234-123456789abcd", // Too long
           "",
         ];
@@ -315,7 +316,7 @@ describe("Subagent Session Tests", () => {
       });
 
       it("should distinguish subagent sessions from main sessions by filename", async () => {
-        const sessionId = "20260527143025-a1b2c3d4";
+        const sessionId = "87654321-4321-4321-4321-abcdef123456";
 
         // Test filename generation distinguishes session types
         const mainFilename = mockJsonlHandler.generateSessionFilename(
@@ -429,21 +430,17 @@ describe("Subagent Session Tests", () => {
 
       it("should support session filtering by type using filename patterns", () => {
         const sessionFiles = [
-          "20260527143025-a1b2c3d4.jsonl", // main (new format)
-          "subagent-20260527143025-a1b2c3d4.jsonl", // subagent (new format)
-          "20260101000000-deadbeef.jsonl", // main (new format)
-          "subagent-20260101000000-deadbeef.jsonl", // subagent (new format)
-          "12345678-1234-1234-1234-123456789abc.jsonl", // main (legacy UUID format)
-          "subagent-87654321-4321-4321-4321-abcdef123456.jsonl", // subagent (legacy UUID format)
+          "12345678-1234-1234-1234-123456789abc.jsonl", // main
+          "subagent-87654321-4321-4321-4321-abcdef123456.jsonl", // subagent
+          "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl", // main
+          "subagent-ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb.jsonl", // subagent
           "invalid-file.txt", // invalid
         ];
 
         // Filter sessions by type using filename patterns (no file reading)
         const mainSessionFiles = sessionFiles.filter((filename) => {
-          // Mock isValidSessionFilename behavior - both new and legacy formats
+          // Mock isValidSessionFilename behavior
           const validPatterns = [
-            /^\d{14}-[0-9a-f]{8}\.jsonl$/,
-            /^subagent-\d{14}-[0-9a-f]{8}\.jsonl$/,
             /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
             /^subagent-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
           ];
@@ -455,15 +452,13 @@ describe("Subagent Session Tests", () => {
         });
 
         const subagentSessionFiles = sessionFiles.filter((filename) => {
-          const validSubagentPatterns = [
-            /^subagent-\d{14}-[0-9a-f]{8}\.jsonl$/,
-            /^subagent-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
-          ];
-          return validSubagentPatterns.some((p) => p.test(filename));
+          const validSubagentPattern =
+            /^subagent-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/;
+          return validSubagentPattern.test(filename);
         });
 
-        expect(mainSessionFiles).toHaveLength(3);
-        expect(subagentSessionFiles).toHaveLength(3);
+        expect(mainSessionFiles).toHaveLength(2);
+        expect(subagentSessionFiles).toHaveLength(2);
 
         // Verify correct categorization
         mainSessionFiles.forEach((filename) => {
@@ -505,8 +500,6 @@ describe("Subagent Session Tests", () => {
         mockJsonlHandler.isValidSessionFilename.mockImplementation(
           (filename: string) => {
             const validPatterns = [
-              /^\d{14}-[0-9a-f]{8}\.jsonl$/,
-              /^subagent-\d{14}-[0-9a-f]{8}\.jsonl$/,
               /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
               /^subagent-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
             ];
@@ -557,19 +550,15 @@ describe("Subagent Session Tests", () => {
 
         // Filter using filename patterns (simulating efficient filtering)
         const mainSessions = sessionFiles.filter((filename) => {
-          const mainPatterns = [
-            /^\d{14}-[0-9a-f]{8}\.jsonl$/,
-            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
-          ];
-          return mainPatterns.some((pattern) => pattern.test(filename));
+          const mainPattern =
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/;
+          return mainPattern.test(filename);
         });
 
         const subagentSessions = sessionFiles.filter((filename) => {
-          const subagentPatterns = [
-            /^subagent-\d{14}-[0-9a-f]{8}\.jsonl$/,
-            /^subagent-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
-          ];
-          return subagentPatterns.some((pattern) => pattern.test(filename));
+          const subagentPattern =
+            /^subagent-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/;
+          return subagentPattern.test(filename);
         });
 
         // Verify filtering worked correctly
@@ -596,9 +585,9 @@ describe("Subagent Session Tests", () => {
 
         // Create test session files
         const sessionFiles = [
-          "20260527143025-a1b2c3d4.jsonl", // main (new format)
-          "subagent-20260527143025-a1b2c3d4.jsonl", // subagent (new format)
-          "20260101000000-deadbeef.jsonl", // main (new format)
+          "12345678-1234-1234-1234-123456789abc.jsonl", // main
+          "subagent-87654321-4321-4321-4321-abcdef123456.jsonl", // subagent
+          "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl", // main
         ];
 
         vi.mocked(fs.readdir).mockResolvedValue(
@@ -615,8 +604,6 @@ describe("Subagent Session Tests", () => {
         const validSessions = sessionFiles
           .filter((filename) => {
             const validPatterns = [
-              /^\d{14}-[0-9a-f]{8}\.jsonl$/,
-              /^subagent-\d{14}-[0-9a-f]{8}\.jsonl$/,
               /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
               /^subagent-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/,
             ];


### PR DESCRIPTION
Reverts `b0e76dc9` (feat: generate session timestamp) and `d457d095` (feat(sessions): use timestamp-prefixed session IDs for sortable JSONL files) to restore `randomUUID()` as the session ID format.

Changes:
- `generateSessionId()` returns `randomUUID()` again
- Removed `generateSessionTimestamp()` and `parseSessionIdTimestamp()`
- `jsonlHandler.ts` filename validation restored to UUID-only
- Replaced `parseSessionIdTimestamp()` calls with `new Date()` fallback

No backward compatibility for timestamp-prefixed session IDs (by design).