### PR TITLE
feat: add per-turn task reminder injection aligned with Claude Code

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -4,6 +4,11 @@ import { convertMessagesForAPI } from "../utils/convertMessagesForAPI.js";
 import { microcompactMessages } from "../utils/microcompact.js";
 import { parseTaskNotificationXml } from "../utils/notificationXml.js";
 import { calculateComprehensiveTotalTokens } from "../utils/tokenCalculation.js";
+import {
+  getTaskReminderTurnCounts,
+  maybeInjectTaskReminder,
+  TASK_REMINDER_CONFIG,
+} from "../utils/taskReminder.js";
 import { existsSync } from "node:fs";
 import type {
   GatewayConfig,
@@ -17,6 +22,7 @@ import type { ToolContext, ToolResult } from "../tools/types.js";
 import type { MessageManager } from "./messageManager.js";
 import type { BackgroundTaskManager } from "./backgroundTaskManager.js";
 import { ChatCompletionMessageFunctionToolCall } from "openai/resources.js";
+import type { ChatCompletionMessageParam } from "openai/resources.js";
 import type { HookManager } from "./hookManager.js";
 import type { ExtendedHookExecutionContext } from "../types/hooks.js";
 import type { PermissionManager } from "./permissionManager.js";
@@ -290,6 +296,29 @@ export class AIManager {
       }
       planMgr.consumePlanEntryReminder();
     }
+  }
+
+  private async maybeInjectTaskReminderIntoMessages(
+    messages: ChatCompletionMessageParam[],
+    toolNames: Set<string>,
+  ): Promise<void> {
+    // Guard: no task tools available
+    if (!toolNames.has("TaskUpdate")) return;
+
+    const internalMessages = this.messageManager.getMessages();
+    const turnCounts = getTaskReminderTurnCounts(internalMessages);
+
+    if (
+      turnCounts.turnsSinceLastTaskManagement <
+        TASK_REMINDER_CONFIG.TURNS_SINCE_WRITE ||
+      turnCounts.turnsSinceLastReminder <
+        TASK_REMINDER_CONFIG.TURNS_BETWEEN_REMINDERS
+    ) {
+      return;
+    }
+
+    const tasks = await this.taskManager.listTasks();
+    maybeInjectTaskReminder(messages, turnCounts, tasks);
   }
 
   public setIsLoading(isLoading: boolean): void {
@@ -851,6 +880,12 @@ export class AIManager {
         maxTokens: maxTokens, // Pass max tokens override
         toolChoice: this.toolChoiceOverride, // Pass tool_choice override
       };
+
+      // Inject task reminder if needed (not persisted, regenerated each turn)
+      await this.maybeInjectTaskReminderIntoMessages(
+        callAgentOptions.messages,
+        toolNames,
+      );
 
       // Add streaming callbacks only if streaming is enabled
       if (this.stream) {

--- a/packages/agent-sdk/src/utils/taskReminder.ts
+++ b/packages/agent-sdk/src/utils/taskReminder.ts
@@ -1,0 +1,108 @@
+import type { Message } from "../types/messaging.js";
+import type { Task } from "../types/tasks.js";
+import type { ChatCompletionMessageParam } from "openai/resources.js";
+
+export const TASK_REMINDER_CONFIG = {
+  TURNS_SINCE_WRITE: 10,
+  TURNS_BETWEEN_REMINDERS: 10,
+};
+
+const TASK_MANAGEMENT_TOOLS = new Set([
+  "TaskCreate",
+  "TaskUpdate",
+  "TaskList",
+  "TaskGet",
+]);
+const TASK_REMINDER_MARKER = "<!-- task-reminder -->";
+
+function isQualifyingAssistantMessage(message: Message): boolean {
+  if (message.role !== "assistant") return false;
+  if (message.isMeta) return false;
+  return message.blocks.some((block) => block.type !== "reasoning");
+}
+
+export function getTaskReminderTurnCounts(messages: Message[]): {
+  turnsSinceLastTaskManagement: number;
+  turnsSinceLastReminder: number;
+} {
+  let assistantTurnCount = 0;
+  let turnsSinceLastTaskManagement: number | undefined;
+  let turnsSinceLastReminder: number | undefined;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+
+    // Check blocks for task management tools and reminder markers
+    for (const block of message.blocks) {
+      if (
+        turnsSinceLastTaskManagement === undefined &&
+        block.type === "tool" &&
+        block.name &&
+        TASK_MANAGEMENT_TOOLS.has(block.name)
+      ) {
+        turnsSinceLastTaskManagement = assistantTurnCount;
+      }
+      if (
+        turnsSinceLastReminder === undefined &&
+        block.type === "text" &&
+        block.content.includes(TASK_REMINDER_MARKER)
+      ) {
+        turnsSinceLastReminder = assistantTurnCount;
+      }
+    }
+
+    if (isQualifyingAssistantMessage(message)) {
+      assistantTurnCount++;
+    }
+  }
+
+  return {
+    turnsSinceLastTaskManagement:
+      turnsSinceLastTaskManagement ?? assistantTurnCount,
+    turnsSinceLastReminder: turnsSinceLastReminder ?? assistantTurnCount,
+  };
+}
+
+export function buildTaskReminderText(tasks: Task[]): string {
+  let text = `${TASK_REMINDER_MARKER}\n`;
+  text +=
+    "Here is a gentle reminder about the task list. The user may not have explicitly asked for the following to be done, but you should check the task list to see if any tasks need attention.\n";
+
+  if (tasks.length > 0) {
+    text += "\n";
+    for (const task of tasks) {
+      text += `#${task.id} [${task.status}] ${task.subject}\n`;
+    }
+  } else {
+    text += "The task list is currently empty.\n";
+  }
+
+  return text;
+}
+
+export function maybeInjectTaskReminder(
+  messages: ChatCompletionMessageParam[],
+  turnCounts: {
+    turnsSinceLastTaskManagement: number;
+    turnsSinceLastReminder: number;
+  },
+  tasks: Task[],
+): void {
+  if (
+    turnCounts.turnsSinceLastTaskManagement <
+    TASK_REMINDER_CONFIG.TURNS_SINCE_WRITE
+  ) {
+    return;
+  }
+  if (
+    turnCounts.turnsSinceLastReminder <
+    TASK_REMINDER_CONFIG.TURNS_BETWEEN_REMINDERS
+  ) {
+    return;
+  }
+
+  messages.push({
+    role: "user",
+    content: buildTaskReminderText(tasks),
+  } as ChatCompletionMessageParam);
+}

--- a/packages/agent-sdk/tests/utils/taskReminder.test.ts
+++ b/packages/agent-sdk/tests/utils/taskReminder.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from "vitest";
+import {
+  getTaskReminderTurnCounts,
+  buildTaskReminderText,
+  maybeInjectTaskReminder,
+  TASK_REMINDER_CONFIG,
+} from "../../src/utils/taskReminder.js";
+import type {
+  Message,
+  MessageBlock,
+  ToolBlock,
+} from "../../src/types/messaging.js";
+import type { Task } from "../../src/types/tasks.js";
+import type { ChatCompletionMessageParam } from "openai/resources";
+
+function makeAssistantMessage(
+  opts: { blocks?: MessageBlock[]; isMeta?: boolean } = {},
+): Message {
+  return {
+    id: `msg-${Math.random().toString(36).slice(2)}`,
+    role: "assistant",
+    blocks: opts.blocks ?? [{ type: "text", content: "response" }],
+    timestamp: new Date().toISOString(),
+    isMeta: opts.isMeta,
+  };
+}
+
+function makeUserMessage(content: string): Message {
+  return {
+    id: `msg-${Math.random().toString(36).slice(2)}`,
+    role: "user",
+    blocks: [{ type: "text", content }],
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function makeToolBlock(name: string): ToolBlock {
+  return {
+    type: "tool",
+    name,
+    stage: "end",
+    success: true,
+  };
+}
+
+function makeTask(overrides: Partial<Task> & { id: string }): Task {
+  return {
+    subject: "Test task",
+    description: "Test description",
+    status: "pending",
+    blocks: [],
+    blockedBy: [],
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe("getTaskReminderTurnCounts", () => {
+  it("returns 0 for task management when TaskCreate used in most recent message", () => {
+    const messages: Message[] = [
+      makeAssistantMessage(),
+      makeAssistantMessage(),
+      makeAssistantMessage(),
+      makeAssistantMessage(),
+      makeAssistantMessage({
+        blocks: [{ type: "text", content: "ok" }, makeToolBlock("TaskCreate")],
+      }),
+    ];
+
+    const result = getTaskReminderTurnCounts(messages);
+    expect(result.turnsSinceLastTaskManagement).toBe(0);
+  });
+
+  it("counts 15 turns since last task management when no task tools used", () => {
+    const messages: Message[] = Array.from({ length: 15 }, () =>
+      makeAssistantMessage(),
+    );
+
+    const result = getTaskReminderTurnCounts(messages);
+    expect(result.turnsSinceLastTaskManagement).toBe(15);
+  });
+
+  it("counts turns since last reminder marker correctly", () => {
+    // 15 assistant messages with user messages interspersed
+    // Put a reminder marker in a user message 5 assistant turns from the end
+    const messages: Message[] = [];
+    for (let i = 0; i < 15; i++) {
+      messages.push(makeAssistantMessage());
+      if (i === 9) {
+        // After 10th assistant msg (index 9), before 11th
+        // From the end: assistant turns at indices 14,13,12,11,10 = 5 turns
+        // then we hit this user message with the marker
+        messages.push(makeUserMessage("<!-- task-reminder -->\nReminder text"));
+      }
+    }
+
+    const result = getTaskReminderTurnCounts(messages);
+    expect(result.turnsSinceLastReminder).toBe(5);
+  });
+
+  it("handles empty messages array", () => {
+    const result = getTaskReminderTurnCounts([]);
+    expect(result.turnsSinceLastTaskManagement).toBe(0);
+    expect(result.turnsSinceLastReminder).toBe(0);
+  });
+
+  it("ignores meta assistant messages", () => {
+    const messages: Message[] = [
+      makeAssistantMessage({ isMeta: true }),
+      makeAssistantMessage({ isMeta: true }),
+      makeAssistantMessage(),
+    ];
+
+    const result = getTaskReminderTurnCounts(messages);
+    // Only 1 qualifying assistant turn
+    expect(result.turnsSinceLastTaskManagement).toBe(1);
+  });
+
+  it("ignores reasoning-only assistant messages", () => {
+    const messages: Message[] = [
+      makeAssistantMessage({
+        blocks: [{ type: "reasoning", content: "thinking" }],
+      }),
+      makeAssistantMessage(),
+    ];
+
+    const result = getTaskReminderTurnCounts(messages);
+    // Only 1 qualifying assistant turn (the reasoning-only one doesn't count)
+    expect(result.turnsSinceLastTaskManagement).toBe(1);
+  });
+
+  it("finds task tool in earlier message", () => {
+    const messages: Message[] = [
+      makeAssistantMessage({
+        blocks: [{ type: "text", content: "ok" }, makeToolBlock("TaskUpdate")],
+      }),
+      makeAssistantMessage(),
+      makeAssistantMessage(),
+      makeAssistantMessage(),
+    ];
+
+    const result = getTaskReminderTurnCounts(messages);
+    // TaskUpdate is in the earliest message; 3 assistant turns after it
+    expect(result.turnsSinceLastTaskManagement).toBe(3);
+  });
+});
+
+describe("buildTaskReminderText", () => {
+  it("includes current task list content", () => {
+    const tasks = [
+      makeTask({ id: "1", subject: "Fix auth bug", status: "pending" }),
+      makeTask({ id: "2", subject: "Add tests", status: "in_progress" }),
+      makeTask({ id: "3", subject: "Update docs", status: "completed" }),
+    ];
+
+    const text = buildTaskReminderText(tasks);
+    expect(text).toContain("<!-- task-reminder -->");
+    expect(text).toContain("#1 [pending] Fix auth bug");
+    expect(text).toContain("#2 [in_progress] Add tests");
+    expect(text).toContain("#3 [completed] Update docs");
+    expect(text).toContain("gentle reminder");
+  });
+
+  it("handles empty task list", () => {
+    const text = buildTaskReminderText([]);
+    expect(text).toContain("task list is currently empty");
+    expect(text).toContain("<!-- task-reminder -->");
+  });
+});
+
+describe("maybeInjectTaskReminder", () => {
+  it("pushes message when thresholds are met", () => {
+    const messages: ChatCompletionMessageParam[] = [];
+    const turnCounts = {
+      turnsSinceLastTaskManagement: TASK_REMINDER_CONFIG.TURNS_SINCE_WRITE,
+      turnsSinceLastReminder: TASK_REMINDER_CONFIG.TURNS_BETWEEN_REMINDERS,
+    };
+    const tasks = [
+      makeTask({ id: "1", subject: "Do something", status: "pending" }),
+    ];
+
+    maybeInjectTaskReminder(messages, turnCounts, tasks);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("user");
+    const content =
+      typeof messages[0].content === "string"
+        ? messages[0].content
+        : String(messages[0].content);
+    expect(content).toContain("#1 [pending] Do something");
+    expect(content).toContain("<!-- task-reminder -->");
+  });
+
+  it("does nothing when turnsSinceLastTaskManagement is below threshold", () => {
+    const messages: ChatCompletionMessageParam[] = [];
+    const turnCounts = {
+      turnsSinceLastTaskManagement: TASK_REMINDER_CONFIG.TURNS_SINCE_WRITE - 1,
+      turnsSinceLastReminder: TASK_REMINDER_CONFIG.TURNS_BETWEEN_REMINDERS,
+    };
+
+    maybeInjectTaskReminder(messages, turnCounts, []);
+    expect(messages).toHaveLength(0);
+  });
+
+  it("does nothing when turnsSinceLastReminder is below threshold", () => {
+    const messages: ChatCompletionMessageParam[] = [];
+    const turnCounts = {
+      turnsSinceLastTaskManagement: TASK_REMINDER_CONFIG.TURNS_SINCE_WRITE,
+      turnsSinceLastReminder: TASK_REMINDER_CONFIG.TURNS_BETWEEN_REMINDERS - 1,
+    };
+
+    maybeInjectTaskReminder(messages, turnCounts, []);
+    expect(messages).toHaveLength(0);
+  });
+
+  it("does nothing when both thresholds are below", () => {
+    const messages: ChatCompletionMessageParam[] = [];
+    const turnCounts = {
+      turnsSinceLastTaskManagement: 0,
+      turnsSinceLastReminder: 0,
+    };
+
+    maybeInjectTaskReminder(messages, turnCounts, []);
+    expect(messages).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
After auto-compact, the agent forgets to update the task list because
compaction replaces conversation history with a summary. Claude Code
solves this with a per-turn task reminder that checks if the model has
used TaskCreate/TaskUpdate recently and injects a reminder after 10+
turns without task tool use.

- Add taskReminder.ts utility with turn counting, reminder text
  building, and injection logic
- Integrate into aiManager.sendAIMessage() to inject reminders into
  API messages (not persisted, regenerated each turn)
- Add 13 unit tests covering all threshold and formatting scenarios
