### PR TITLE
fix: move openBrowser from SDK to code package to prevent double browser open

### DIFF
--- a/packages/agent-sdk/src/services/authService.ts
+++ b/packages/agent-sdk/src/services/authService.ts
@@ -19,15 +19,11 @@ import * as os from "os";
 import { randomBytes } from "crypto";
 import { createServer, Server } from "http";
 import { URL } from "url";
-import { execFile } from "child_process";
-import { promisify } from "util";
 import type { AuthConfig, AuthUser, TokenResponse } from "../types/auth.js";
 import { logger } from "../utils/globalLogger.js";
 
 /** Persistent anonymous ID for telemetry fallback when SSO is not authenticated. */
 let _anonymousId: string | undefined;
-
-const execFileAsync = promisify(execFile);
 
 export class AuthService {
   private static instance: AuthService;
@@ -274,15 +270,8 @@ export class AuthService {
         const callbackUrl = `http://127.0.0.1:${port}`;
         const authUrl = `${serverUrl}/login?callback_url=${encodeURIComponent(callbackUrl)}`;
 
-        // Notify caller of the auth URL
+        // Notify caller of the auth URL; caller is responsible for opening browser
         options?.onAuthUrl?.(authUrl);
-
-        // Try to open browser; if it fails, keep server alive for manual visit
-        try {
-          await this.openBrowser(authUrl);
-        } catch {
-          // Browser not available — server stays alive
-        }
       });
 
       // If manual code reading is provided, race between server callback and user input
@@ -313,25 +302,6 @@ export class AuthService {
         5 * 60 * 1000,
       );
     });
-  }
-
-  private async openBrowser(url: string): Promise<void> {
-    const platform = process.platform;
-    let command: string;
-    let args: string[];
-
-    if (platform === "darwin") {
-      command = "open";
-      args = [url];
-    } else if (platform === "win32") {
-      command = "cmd";
-      args = ["/c", "start", "", url];
-    } else {
-      command = "xdg-open";
-      args = [url];
-    }
-
-    await execFileAsync(command, args);
   }
 
   isSSOAuthenticated(): boolean {

--- a/packages/agent-sdk/tests/services/authService.test.ts
+++ b/packages/agent-sdk/tests/services/authService.test.ts
@@ -64,14 +64,6 @@ vi.mock("http", () => ({
 }));
 
 vi.mock("fs");
-vi.mock("child_process", () => ({
-  execFile: vi.fn(
-    (_cmd: string, _args: string[], cb: (err: Error | null) => void) => {
-      cb(null);
-    },
-  ),
-}));
-
 const mockedExists = vi.mocked(existsSync);
 const mockedReadFile = vi.mocked(readFileSync);
 const mockedWriteFile = vi.mocked(writeFileSync);
@@ -492,7 +484,7 @@ describe("AuthService", () => {
       vi.unstubAllGlobals();
     });
 
-    it("opens browser, receives callback code, exchanges for JWT, and saves it", async () => {
+    it("receives callback code via onAuthUrl, exchanges for JWT, and saves it", async () => {
       process.env.WAVE_SERVER_URL = "https://ai.example.com";
       mockedExists.mockReturnValue(false);
       // exchange code for JWT

--- a/packages/code/src/components/LoginCommand.tsx
+++ b/packages/code/src/components/LoginCommand.tsx
@@ -1,6 +1,25 @@
 import React, { useRef, useState } from "react";
 import { Box, Text, useInput } from "ink";
+import { execFile } from "child_process";
+import { promisify } from "util";
 import { authService } from "wave-agent-sdk";
+
+const execFileAsync = promisify(execFile);
+
+function openBrowser(url: string): void {
+  const platform = process.platform;
+  try {
+    if (platform === "darwin") {
+      execFileAsync("open", [url]);
+    } else if (platform === "win32") {
+      execFileAsync("cmd", ["/c", "start", "", url]);
+    } else {
+      execFileAsync("xdg-open", [url]);
+    }
+  } catch {
+    // Browser not available — URL is still displayed in the UI
+  }
+}
 
 export interface LoginCommandProps {
   onCancel: () => void;
@@ -91,6 +110,7 @@ export const LoginCommand: React.FC<LoginCommandProps> = ({ onCancel }) => {
       await authService.login({
         onAuthUrl: (url: string) => {
           setAuthUrl(url);
+          openBrowser(url);
           setMessage("Paste the authorization code from your browser URL bar:");
         },
         readToken,

--- a/packages/code/tests/components/LoginCommand.test.tsx
+++ b/packages/code/tests/components/LoginCommand.test.tsx
@@ -18,6 +18,14 @@ vi.mock("wave-agent-sdk", () => ({
   authService: mockAuthService,
 }));
 
+vi.mock("child_process", () => ({
+  execFile: vi.fn(
+    (_cmd: string, _args: string[], cb: (err: Error | null) => void) => {
+      cb(null);
+    },
+  ),
+}));
+
 describe("LoginCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
## Problem

`startLocalAuthServer()` called both `onAuthUrl` callback and `openBrowser` unconditionally, causing the browser to open twice.

In VS Code Remote SSH, `onAuthUrl` uses `vscode.env.openExternal()` (correct) while the SDK's `openBrowser` uses `xdg-open` (fails on headless server but still runs).

## Fix

Moved `openBrowser` from `authService.ts` (SDK) to `LoginCommand.tsx` (code package). The SDK now only notifies via `onAuthUrl` callback — the caller controls browser opening.

## Changes

- **agent-sdk/authService.ts**: Removed `openBrowser` method, `execFile`/`promisify` imports
- **code/LoginCommand.tsx**: Added local `openBrowser`, called in `onAuthUrl` callback
- **Tests**: Moved `child_process` mock from SDK tests to code tests

Fixes #1267