### PR TITLE
fix(fileWatcher): add depth/ignored limits and EMFILE error handling

### DIFF
--- a/packages/agent-sdk/src/services/fileWatcher.ts
+++ b/packages/agent-sdk/src/services/fileWatcher.ts
@@ -22,6 +22,8 @@ export interface FileWatcherConfig {
   maxRetries: number; // Default: 3
   fallbackPolling: boolean; // Default: false
   ignoreTempFiles: boolean; // Default: true
+  depth: number; // default: 5
+  ignored: string[]; // default: ['**/node_modules/**', '**/.git/**', '**/*.swp', '**/*~']
 }
 
 export interface FileWatcherStatus {
@@ -59,6 +61,8 @@ export class FileWatcherService extends EventEmitter {
       maxRetries: 3,
       fallbackPolling: false,
       ignoreTempFiles: true,
+      depth: 5,
+      ignored: ["**/node_modules/**", "**/.git/**", "**/*.swp", "**/*~"],
       ...config,
     };
   }
@@ -185,6 +189,8 @@ export class FileWatcherService extends EventEmitter {
         this.globalWatcher = chokidar.watch([], {
           persistent: true,
           ignoreInitial: true,
+          depth: entry.config.depth,
+          ignored: entry.config.ignored,
           awaitWriteFinish: {
             stabilityThreshold: entry.config.stabilityThreshold,
             pollInterval: entry.config.pollInterval,
@@ -262,7 +268,15 @@ export class FileWatcherService extends EventEmitter {
 
     this.globalWatcher.on("error", (err: unknown) => {
       const error = err instanceof Error ? err : new Error(String(err));
-      this.logger?.error(`FileWatcher: File watcher error: ${error.message}`);
+      const isEMFILE = (error as NodeJS.ErrnoException).code === "EMFILE";
+      if (isEMFILE) {
+        this.logger?.warn(
+          "FileWatcher: Too many open files (EMFILE). " +
+            "Consider increasing the limit: `ulimit -n 10240` (macOS) or `ulimit -n 65536` (Linux).",
+        );
+      } else {
+        this.logger?.error(`FileWatcher: File watcher error: ${error.message}`);
+      }
       this.emit("watcherError", error);
     });
   }

--- a/packages/agent-sdk/tests/services/fileWatcher.test.ts
+++ b/packages/agent-sdk/tests/services/fileWatcher.test.ts
@@ -267,6 +267,89 @@ describe("FileWatcherService", () => {
     ).rejects.toThrow("Persistent failure");
   });
 
+  it("should pass depth and ignored to chokidar config", async () => {
+    const mockWatcher = {
+      add: vi.fn(),
+      on: vi.fn().mockReturnThis(),
+      close: vi.fn(),
+    };
+    vi.mocked(chokidar.watch).mockImplementation(
+      () => mockWatcher as unknown as chokidar.FSWatcher,
+    );
+
+    await service.watchFile("/test/file.txt", () => {});
+
+    expect(chokidar.watch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        depth: 5,
+        ignored: ["**/node_modules/**", "**/.git/**", "**/*.swp", "**/*~"],
+      }),
+    );
+  });
+
+  it("should pass custom depth and ignored to chokidar config", async () => {
+    const mockWatcher = {
+      add: vi.fn(),
+      on: vi.fn().mockReturnThis(),
+      close: vi.fn(),
+    };
+    vi.mocked(chokidar.watch).mockImplementation(
+      () => mockWatcher as unknown as chokidar.FSWatcher,
+    );
+
+    const customService = new FileWatcherService(mockLogger, {
+      depth: 10,
+      ignored: ["**/dist/**"],
+    });
+
+    await customService.watchFile("/test/file.txt", () => {});
+
+    expect(chokidar.watch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        depth: 10,
+        ignored: ["**/dist/**"],
+      }),
+    );
+
+    await customService.cleanup();
+  });
+
+  it("should warn with ulimit hint on EMFILE error", async () => {
+    const mockWatcher = {
+      add: vi.fn(),
+      on: vi.fn().mockReturnThis(),
+      close: vi.fn(),
+    };
+    vi.mocked(chokidar.watch).mockImplementation(
+      () => mockWatcher as unknown as chokidar.FSWatcher,
+    );
+
+    const errorListener = vi.fn();
+    service.on("watcherError", errorListener);
+
+    await service.watchFile("/test/file.txt", () => {});
+
+    const errorHandler = mockWatcher.on.mock.calls.find(
+      (c) => c[0] === "error",
+    )![1] as (err: Error) => void;
+
+    const emfileError = Object.assign(new Error("too many open files"), {
+      code: "EMFILE",
+    });
+    errorHandler(emfileError);
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("EMFILE"),
+    );
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("ulimit"),
+    );
+    expect(mockLogger.error).not.toHaveBeenCalled();
+    expect(errorListener).toHaveBeenCalledWith(emfileError);
+  });
+
   it("should handle unwatch errors", async () => {
     const filePath = "/test/file.txt";
 


### PR DESCRIPTION
## Problem

Users on macOS (default 256 file descriptors) hit `EMFILE: too many open files` when chokidar recursively watches skill directories. The root cause is two missing chokidar options: no `depth` limit and no `ignored` patterns. Additionally, the `ignoreTempFiles` config field existed but was dead code — never wired to chokidar.

Closes #1268

## Changes

- **FileWatcherConfig**: Added `depth` (default: 5) and `ignored` (default: `node_modules`, `.git`, `.swp`, `~`) fields
- **chokidar.watch()**: Wired `depth` and `ignored` to chokidar options in `initializeWatcher()`
- **EMFILE handling**: EMFILE errors now log `warn` with actionable `ulimit` hint instead of `error`
- **Tests**: Added 3 tests for config passthrough (defaults + custom) and EMFILE error handling