### PR TITLE
fix: SkillManager bash execution uses stale workdir after EnterWorktree

### DIFF
--- a/packages/agent-sdk/src/managers/skillManager.ts
+++ b/packages/agent-sdk/src/managers/skillManager.ts
@@ -503,7 +503,9 @@ export class SkillManager extends EventEmitter {
   private async executeBashInSkillContent(content: string): Promise<string> {
     const { commands } = parseBashCommands(content);
     if (commands.length > 0) {
-      const results = await executeBashCommands(commands, this.workdir);
+      const currentWorkdir =
+        this.container.get<string>("Workdir") ?? this.workdir;
+      const results = await executeBashCommands(commands, currentWorkdir);
       return replaceBashCommandsWithOutput(content, results);
     }
     return content;

--- a/packages/agent-sdk/tests/managers/skillManager.test.ts
+++ b/packages/agent-sdk/tests/managers/skillManager.test.ts
@@ -32,6 +32,7 @@ import {
   parseSkillFile,
   formatSkillError,
 } from "../../src/utils/skillParser.js";
+import { executeBashCommands } from "../../src/utils/markdownParser.js";
 
 vi.mock("fs/promises");
 vi.mock("../../src/services/fileWatcher.js");
@@ -41,6 +42,14 @@ vi.mock("../../src/utils/skillParser.js", async () => {
     ...actual,
     parseSkillFile: vi.fn(),
     formatSkillError: vi.fn(),
+  };
+});
+
+vi.mock("../../src/utils/markdownParser.js", async () => {
+  const actual = await vi.importActual("../../src/utils/markdownParser.js");
+  return {
+    ...actual,
+    executeBashCommands: vi.fn().mockResolvedValue(["mock-output"]),
   };
 });
 
@@ -748,6 +757,36 @@ describe("SkillManager", () => {
       await skillManager.executeSkill({ skill_name: "test-skill" });
 
       expect(logger.debug).toHaveBeenCalledWith("Invoking skill: test-skill");
+    });
+
+    it("should use container Workdir (not stale constructor workdir) for bash execution", async () => {
+      const mockSkill: Skill = {
+        name: "bash-skill",
+        description: "A skill with bash commands",
+        type: "personal",
+        skillPath: "/path/to/skill",
+        content:
+          "---\nname: bash-skill\ndescription: A skill with bash commands\n---\n\nResult: !`echo hello`",
+        frontmatter: {
+          name: "bash-skill",
+          description: "A skill with bash commands",
+        },
+        isValid: true,
+        errors: [],
+      };
+
+      vi.mocked(skillManager.loadSkill).mockResolvedValue(mockSkill);
+
+      // Simulate EnterWorktree: update the container's Workdir after construction
+      container.register("Workdir", "/new/worktree/path");
+
+      await skillManager.executeSkill({ skill_name: "bash-skill" });
+
+      // executeBashCommands should receive the updated workdir, not the original "/test/workdir"
+      expect(executeBashCommands).toHaveBeenCalledWith(
+        ["echo hello"],
+        "/new/worktree/path",
+      );
     });
   });
 


### PR DESCRIPTION
## Problem

After `EnterWorktree` changes the session CWD, skill bash commands (e.g. ``!`pwd```) still execute in the original repo root instead of the worktree directory.

## Root Cause

`SkillManager.executeBashInSkillContent()` used `this.workdir` — a snapshot captured at construction time. When `EnterWorktree` calls `aiManager.setWorkdir()`, it updates the container's `"Workdir"` binding and `process.chdir()`, but `SkillManager` never saw the change.

## Fix

Read the current workdir dynamically from the container in `executeBashInSkillContent()`, falling back to the constructor value if not registered:

```ts
const currentWorkdir = this.container.get<string>("Workdir") ?? this.workdir;
const results = await executeBashCommands(commands, currentWorkdir);
```

## Test

Added regression test verifying that after `container.register("Workdir", "/new/worktree/path")`, skill bash execution uses the updated path instead of the original constructor workdir.