### PR TITLE
feat(skills): add /simplify and /code-review builtin skills

### DIFF
--- a/packages/agent-sdk/builtin/skills/code-review/SKILL.md
+++ b/packages/agent-sdk/builtin/skills/code-review/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: code-review
+description: Review the current diff for correctness bugs and reuse/simplification/efficiency cleanups at the given effort level (low/medium: fewer, high-confidence findings; high/max: broader coverage, may include lower-confidence findings)
+allowed-tools: Bash(git diff:*), Bash(git status:*), Bash(git log:*), Bash(git show:*), Bash(git blame:*), Read, Glob, Grep, Agent
+disable-model-invocation: true
+---
+
+# Code Review
+
+Review the current branch's changes for correctness bugs and quality issues.
+
+## Phase 1: Gather Context
+
+First, collect the diff and metadata:
+
+```
+GIT STATUS:
+!`git status`
+
+FILES MODIFIED:
+!`git diff --name-only $(git merge-base HEAD main)...HEAD 2>/dev/null || git diff --name-only HEAD~1...HEAD`
+
+COMMITS:
+!`git log --no-decorate $(git merge-base HEAD main 2>/dev/null || echo HEAD~1)...HEAD`
+
+DIFF CONTENT:
+!`git diff $(git merge-base HEAD main 2>/dev/null || echo HEAD~1)...HEAD`
+```
+
+If there are no changes, stop and tell the user.
+
+## Phase 2: Determine Effort Level
+
+Parse `$ARGUMENTS` for an effort level:
+- **low**: Launch 2 agents, confidence threshold 90 (only near-certain findings)
+- **medium** (default): Launch 3 agents, confidence threshold 80
+- **high**: Launch 4 agents, confidence threshold 70
+- **max**: Launch 5 agents, confidence threshold 60 (broader coverage, more noise)
+
+## Phase 3: Launch Review Agents in Parallel
+
+Use the Agent tool to launch all agents concurrently in a single message. Pass each agent the full diff so it has the complete context.
+
+### Agent 1: Bug Scanner (all effort levels)
+
+Read the file changes in the diff, then do a shallow scan for obvious bugs. Avoid reading extra context beyond the changes, focusing just on the changes themselves. Focus on large bugs, and avoid small issues and nitpicks. Ignore likely false positives.
+
+### Agent 2: AGENTS.md Compliance (all effort levels)
+
+Audit the changes to make sure they comply with any AGENTS.md files in the repository. Check the root AGENTS.md (if it exists) and any AGENTS.md files in the directories whose files were modified. Note that AGENTS.md is guidance for AI agents as they write code, so not all instructions will be applicable during code review.
+
+### Agent 3: Git History Context (medium and above)
+
+Read the git blame and history of the code modified, to identify any bugs in light of that historical context.
+
+### Agent 4: Code Reuse & Quality (high and above)
+
+Search for existing utilities and helpers that could replace newly written code. Also review for hacky patterns: redundant state, parameter sprawl, copy-paste with slight variation, leaky abstractions, stringly-typed code, and unnecessary comments.
+
+### Agent 5: Efficiency Review (max only)
+
+Review the changes for efficiency: unnecessary work, missed concurrency, hot-path bloat, recurring no-op updates, unnecessary existence checks, memory leaks, and overly broad operations.
+
+## Phase 4: Confidence Scoring
+
+For each issue found in Phase 3, launch a parallel Agent to independently score the issue. The scoring agent receives the PR diff, the issue description, and the list of AGENTS.md files (if any). It returns a confidence score from 0-100.
+
+Give the scoring agent this rubric verbatim:
+
+- **0**: Not confident at all. This is a false positive that doesn't stand up to light scrutiny, or is a pre-existing issue.
+- **25**: Somewhat confident. This might be a real issue, but may also be a false positive. The agent wasn't able to verify that it's a real issue. If the issue is stylistic, it is one that was not explicitly called out in the relevant AGENTS.md.
+- **50**: Moderately confident. The agent was able to verify this is a real issue, but it might be a nitpick or not happen very often in practice. Relative to the rest of the PR, it's not very important.
+- **75**: Highly confident. The agent double checked the issue, and verified that it is very likely it is a real issue that will be hit in practice. The existing approach in the PR is insufficient. The issue is very important and will directly impact the code's functionality, or it is an issue that is directly mentioned in the relevant AGENTS.md.
+- **100**: Absolutely certain. The agent double checked the issue, and confirmed that it is definitely a real issue, that will happen frequently in practice. The evidence directly confirms this.
+
+## Phase 5: Filter and Report
+
+1. Filter out any issues with a score below the effort level's threshold.
+2. If no issues remain, say so and stop.
+3. Otherwise, output the findings in this format:
+
+---
+
+## Code Review
+
+Found N issues:
+
+1. <brief description of bug> (AGENTS.md says "<...>")
+
+   `<file>:<line range>`
+
+2. <brief description of bug> (bug due to <file and code snippet>)
+
+   `<file>:<line range>`
+
+---
+
+## False Positive Filtering
+
+Examples of false positives to exclude:
+
+- Pre-existing issues not introduced in this diff
+- Something that looks like a bug but is not actually a bug
+- Pedantic nitpicks that a senior engineer wouldn't call out
+- Issues that a linter, typechecker, or compiler would catch (eg. missing or incorrect imports, type errors, broken tests, formatting issues)
+- General code quality issues (eg. lack of test coverage, general security issues, poor documentation), unless explicitly required in AGENTS.md
+- Issues that are called out in AGENTS.md, but explicitly silenced in the code (eg. due to a lint ignore comment)
+- Changes in functionality that are likely intentional or are directly related to the broader change
+- Real issues, but on lines that the user did not modify in their changes
+
+## Notes
+
+- Do not check build signal or attempt to build or typecheck the app. These will run separately.
+- You must cite the file and line range for each finding.
+- Make a todo list first.
+
+## Input
+
+$ARGUMENTS

--- a/packages/agent-sdk/builtin/skills/simplify/SKILL.md
+++ b/packages/agent-sdk/builtin/skills/simplify/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: simplify
+description: Review the changed code for reuse, simplification, efficiency, and altitude cleanups, then apply the fixes. Quality only — it does not hunt for bugs; use /code-review for that.
+disable-model-invocation: true
+---
+
+# Simplify: Code Review and Cleanup
+
+Review all changed files for reuse, quality, and efficiency. Fix any issues found.
+
+## Phase 1: Identify Changes
+
+Run `git diff` (or `git diff HEAD` if there are staged changes) to see what changed. If there are no git changes, review the most recently modified files that the user mentioned or that you edited earlier in this conversation.
+
+## Phase 2: Launch Three Review Agents in Parallel
+
+Use the Agent tool to launch all three agents concurrently in a single message. Pass each agent the full diff so it has the complete context.
+
+### Agent 1: Code Reuse Review
+
+For each change:
+
+1. **Search for existing utilities and helpers** that could replace newly written code. Look for similar patterns elsewhere in the codebase — common locations are utility directories, shared modules, and files adjacent to the changed ones.
+2. **Flag any new function that duplicates existing functionality.** Suggest the existing function to use instead.
+3. **Flag any inline logic that could use an existing utility** — hand-rolled string manipulation, manual path handling, custom environment checks, ad-hoc type guards, and similar patterns are common candidates.
+
+### Agent 2: Code Quality Review
+
+Review the same changes for hacky patterns:
+
+1. **Redundant state**: state that duplicates existing state, cached values that could be derived, observers/effects that could be direct calls
+2. **Parameter sprawl**: adding new parameters to a function instead of generalizing or restructuring existing ones
+3. **Copy-paste with slight variation**: near-duplicate code blocks that should be unified with a shared abstraction
+4. **Leaky abstractions**: exposing internal details that should be encapsulated, or breaking existing abstraction boundaries
+5. **Stringly-typed code**: using raw strings where constants, enums (string unions), or branded types already exist in the codebase
+6. **Unnecessary JSX nesting**: wrapper Boxes/elements that add no layout value — check if inner component props (flexShrink, alignItems, etc.) already provide the needed behavior
+7. **Unnecessary comments**: comments explaining WHAT the code does (well-named identifiers already do that), narrating the change, or referencing the task/caller — delete; keep only non-obvious WHY (hidden constraints, subtle invariants, workarounds)
+
+### Agent 3: Efficiency Review
+
+Review the same changes for efficiency:
+
+1. **Unnecessary work**: redundant computations, repeated file reads, duplicate network/API calls, N+1 patterns
+2. **Missed concurrency**: independent operations run sequentially when they could run in parallel
+3. **Hot-path bloat**: new blocking work added to startup or per-request/per-render hot paths
+4. **Recurring no-op updates**: state/store updates inside polling loops, intervals, or event handlers that fire unconditionally — add a change-detection guard so downstream consumers aren't notified when nothing changed. Also: if a wrapper function takes an updater/reducer callback, verify it honors same-reference returns (or whatever the "no change" signal is) — otherwise callers' early-return no-ops are silently defeated
+5. **Unnecessary existence checks**: pre-checking file/resource existence before operating (TOCTOU anti-pattern) — operate directly and handle the error
+6. **Memory**: unbounded data structures, missing cleanup, event listener leaks
+7. **Overly broad operations**: reading entire files when only a portion is needed, loading all items when filtering for one
+
+## Phase 3: Fix Issues
+
+Wait for all three agents to complete. Aggregate their findings and fix each issue directly. If a finding is a false positive or not worth addressing, note it and move on — do not argue with the finding, just skip it.
+
+When done, briefly summarize what was fixed (or confirm the code was already clean).


### PR DESCRIPTION
## Summary

Add two builtin skills adapted from Claude Code:

### /simplify
- 3 parallel Agent calls: Code Reuse Review, Code Quality Review, Efficiency Review
- Phase 3 fixes issues directly
- Quality-only — does not hunt for bugs; use /code-review for that

### /code-review
- Configurable effort level: low (2 agents, threshold 90), medium (3 agents, 80), high (4 agents, 70), max (5 agents, 60)
- Parallel confidence scoring (0-100) with rubric, filter below threshold
- Reports findings only — does NOT post PR comments
- 4 inline bash commands: `git status`, `git diff --name-only`, `git log`, `git diff`

## Design decisions

- **No `gh` dependency**: Uses `git diff` + `git merge-base` — works with any git hosting (GitLab, Gitee, self-hosted)
- **Pure markdown SKILL.md**: Zero JS code, leverages Wave's builtin skill mechanism
- **`disable-model-invocation: true`**: Prevents AI from auto-triggering expensive review operations
- **Inline bash (`!`cmd``)**: Executes server-side before AI sees content, no permission check needed (separate from `allowed-tools`)