### PR TITLE
feat(code-review): add comment-first delivery via gh/glab with terminal fallback

### DIFF
--- a/packages/agent-sdk/builtin/skills/code-review/SKILL.md
+++ b/packages/agent-sdk/builtin/skills/code-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-review
 description: Review the current diff for correctness bugs and reuse/simplification/efficiency cleanups at the given effort level (low/medium: fewer, high-confidence findings; high/max: broader coverage, may include lower-confidence findings)
-allowed-tools: Bash(git diff:*), Bash(git status:*), Bash(git log:*), Bash(git show:*), Bash(git blame:*), Read, Glob, Grep, Agent
+allowed-tools: Bash(git diff:*), Bash(git status:*), Bash(git log:*), Bash(git show:*), Bash(git blame:*), Bash(git remote:*), Bash(command -v:*), Bash(gh pr comment:*), Bash(gh pr view:*), Bash(glab mr note:*), Bash(glab mr view:*), Read, Glob, Grep, Agent
 disable-model-invocation: true
 ---
 
@@ -73,11 +73,27 @@ Give the scoring agent this rubric verbatim:
 - **75**: Highly confident. The agent double checked the issue, and verified that it is very likely it is a real issue that will be hit in practice. The existing approach in the PR is insufficient. The issue is very important and will directly impact the code's functionality, or it is an issue that is directly mentioned in the relevant AGENTS.md.
 - **100**: Absolutely certain. The agent double checked the issue, and confirmed that it is definitely a real issue, that will happen frequently in practice. The evidence directly confirms this.
 
-## Phase 5: Filter and Report
+## Phase 5: Filter and Deliver
 
 1. Filter out any issues with a score below the effort level's threshold.
-2. If no issues remain, say so and stop.
-3. Otherwise, output the findings in this format:
+2. If no issues remain, say so and stop — do not post anything.
+3. Otherwise, detect the platform and CLI availability:
+
+```
+REMOTE URL:
+!`git remote get-url origin 2>/dev/null || echo "no-remote"`
+
+GH CLI:
+!`command -v gh 2>/dev/null || echo "not-installed"`
+
+GLAB CLI:
+!`command -v glab 2>/dev/null || echo "not-installed"`
+```
+
+4. **Post as comment** (preferred): If the remote URL contains `github` and `gh` is installed, check if a PR exists for the current branch (`gh pr view --json number`), then post the review as a comment: `gh pr comment --body "<review content>"`. If the remote URL contains `gitlab` and `glab` is installed, check if an MR exists for the current branch (`glab mr view`), then post the review as a note: `glab mr note --message "<review content>"`.
+5. **Output directly** (fallback): If no CLI is installed, no PR/MR exists, or the platform is unrecognized, output the findings directly instead.
+
+Whether posting or outputting, use this format:
 
 ---
 
@@ -94,6 +110,8 @@ Found N issues:
    `<file>:<line range>`
 
 ---
+
+Keep the comment brief and avoid emojis.
 
 ## False Positive Filtering
 

--- a/specs/058-code-review-skill/checklists/requirements.md
+++ b/specs/058-code-review-skill/checklists/requirements.md
@@ -1,0 +1,32 @@
+# Specification Quality Checklist: Code Review Skill
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-29
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Feature is already implemented (commit 8d13e248). This spec documents the existing behavior.
+- Items marked complete reflect the finalized specification.

--- a/specs/058-code-review-skill/contracts/code-review.md
+++ b/specs/058-code-review-skill/contracts/code-review.md
@@ -1,0 +1,83 @@
+# Code Review Skill Contracts
+
+## Skill Frontmatter
+
+```yaml
+name: code-review
+description: >
+  Review the current diff for correctness bugs and reuse/simplification/efficiency
+  cleanups at the given effort level (low/medium: fewer, high-confidence findings;
+  high/max: broader coverage, may include lower-confidence findings)
+allowed-tools: Bash(git diff:*), Bash(git status:*), Bash(git log:*), Bash(git show:*), Bash(git blame:*), Read, Glob, Grep, Agent
+disable-model-invocation: true
+```
+
+## Phase Contracts
+
+### Phase 1: Gather Context
+
+Executes four bash commands via skill substitution:
+- `git status`
+- `git diff --name-only <merge-base>...HEAD` (fallback: `HEAD~1...HEAD`)
+- `git log --no-decorate <merge-base>...HEAD` (fallback: `HEAD~1...HEAD`)
+- `git diff <merge-base>...HEAD` (fallback: `HEAD~1...HEAD`)
+
+Stops early if no changes exist.
+
+### Phase 2: Determine Effort Level
+
+Parses `$ARGUMENTS`:
+- `low` → 2 agents, threshold 90
+- `medium` (default/empty) → 3 agents, threshold 80
+- `high` → 4 agents, threshold 70
+- `max` → 5 agents, threshold 60
+
+### Phase 3: Launch Review Agents
+
+All agents launched concurrently in a single message via the Agent tool. Each receives the full diff.
+
+| # | Agent | Effort Levels |
+|---|-------|---------------|
+| 1 | Bug Scanner | all |
+| 2 | AGENTS.md Compliance | all |
+| 3 | Git History Context | medium+ |
+| 4 | Code Reuse & Quality | high+ |
+| 5 | Efficiency Review | max only |
+
+### Phase 4: Confidence Scoring
+
+For each finding from Phase 3, launch a parallel Agent that independently scores 0–100 using the fixed rubric (see [data-model.md](../data-model.md)). The scoring agent receives: the PR diff, the issue description, and the list of AGENTS.md files.
+
+### Phase 5: Filter and Report
+
+1. Drop findings with score < threshold.
+2. If none remain, say so and stop.
+3. Output findings in the fixed report format with `<file>:<line range>` citations.
+
+## Report Format Contract
+
+```
+## Code Review
+
+Found N issues:
+
+1. <description> (AGENTS.md says "<quote>")
+
+   `<file>:<line range>`
+
+2. <description> (bug due to <file and code snippet>)
+
+   `<file>:<line range>`
+```
+
+## False-Positive Exclusion Contract
+
+The following categories MUST be excluded:
+- Pre-existing issues not introduced in this diff
+- Non-bug-looking patterns
+- Pedantic nitpicks
+- Linter/typechecker/compiler-level issues
+- General quality gaps (unless AGENTS.md requires)
+- Issues silenced in code (e.g., lint-ignore comments)
+- Intentional/directly-related changes
+- Real issues on unmodified lines

--- a/specs/058-code-review-skill/contracts/code-review.md
+++ b/specs/058-code-review-skill/contracts/code-review.md
@@ -8,7 +8,7 @@ description: >
   Review the current diff for correctness bugs and reuse/simplification/efficiency
   cleanups at the given effort level (low/medium: fewer, high-confidence findings;
   high/max: broader coverage, may include lower-confidence findings)
-allowed-tools: Bash(git diff:*), Bash(git status:*), Bash(git log:*), Bash(git show:*), Bash(git blame:*), Read, Glob, Grep, Agent
+allowed-tools: Bash(git diff:*), Bash(git status:*), Bash(git log:*), Bash(git show:*), Bash(git blame:*), Bash(git remote:*), Bash(command -v:*), Bash(gh pr comment:*), Bash(gh pr view:*), Bash(glab mr note:*), Bash(glab mr view:*), Read, Glob, Grep, Agent
 disable-model-invocation: true
 ```
 
@@ -48,11 +48,18 @@ All agents launched concurrently in a single message via the Agent tool. Each re
 
 For each finding from Phase 3, launch a parallel Agent that independently scores 0–100 using the fixed rubric (see [data-model.md](../data-model.md)). The scoring agent receives: the PR diff, the issue description, and the list of AGENTS.md files.
 
-### Phase 5: Filter and Report
+### Phase 5: Filter and Deliver
 
 1. Drop findings with score < threshold.
-2. If none remain, say so and stop.
-3. Output findings in the fixed report format with `<file>:<line range>` citations.
+2. If none remain, say "no issues" and stop — do not post or output anything.
+3. Detect platform and CLI availability via skill bash substitution:
+   - `git remote get-url origin` — remote URL
+   - `command -v gh` — GitHub CLI availability
+   - `command -v glab` — GitLab CLI availability
+4. **Post as comment** (preferred): If GitHub + `gh` + PR exists → `gh pr comment --body "<review>"`. If GitLab + `glab` + MR exists → `glab mr note --message "<review>"`. Do NOT output to terminal.
+5. **Output directly** (fallback): If no CLI, no PR/MR, unrecognized platform, or posting failed → output findings to terminal.
+
+**Constraints**: Same format for both comment and direct output. Brief, no emojis.
 
 ## Report Format Contract
 

--- a/specs/058-code-review-skill/data-model.md
+++ b/specs/058-code-review-skill/data-model.md
@@ -46,4 +46,23 @@
 - An **EffortLevel** maps to a set of **ReviewAgent**s and a confidence threshold.
 - Each **ReviewAgent** produces zero or more candidate **Finding**s (pre-scoring).
 - Each candidate **Finding** is scored by exactly one independent **ScoringAgent**.
-- Only **Finding**s with `confidence >= threshold` appear in the final report.
+- Only **Finding**s with `confidence >= threshold` are delivered.
+- Delivery is **comment-first**: if a **Platform** CLI is available and a **CommentTarget** (PR/MR) exists, findings are posted as a comment and NOT output to terminal. Otherwise, findings fall back to direct terminal output.
+- If no findings pass the threshold, nothing is posted or output.
+
+## Platform Detection
+
+| Remote URL Pattern | Platform | CLI | Comment Command |
+|--------------------|----------|-----|-----------------|
+| contains `github` | `github` | `gh` | `gh pr comment --body "<review>"` |
+| contains `gitlab` | `gitlab` | `glab` | `glab mr note --message "<review>"` |
+| other | `unknown` | N/A | skip (direct output only) |
+
+## CommentTarget
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `platform` | `'github' \| 'gitlab' \| 'unknown'` | Detected from remote URL |
+| `cliInstalled` | `boolean` | Whether the corresponding CLI is available |
+| `prOrMrExists` | `boolean` | Whether a PR/MR exists for the current branch |
+| `commentPosted` | `boolean` | Whether the review was successfully posted as a comment |

--- a/specs/058-code-review-skill/data-model.md
+++ b/specs/058-code-review-skill/data-model.md
@@ -1,0 +1,49 @@
+# Data Model: Code Review Skill
+
+## Configuration
+
+### EffortLevel Mapping
+
+| Effort | Agent Count | Confidence Threshold | Review Agents |
+|--------|-------------|----------------------|---------------|
+| `low` | 2 | 90 | Bug Scanner, AGENTS.md Compliance |
+| `medium` (default) | 3 | 80 | Bug Scanner, AGENTS.md Compliance, Git History Context |
+| `high` | 4 | 70 | Bug Scanner, AGENTS.md Compliance, Git History Context, Code Reuse & Quality |
+| `max` | 5 | 60 | Bug Scanner, AGENTS.md Compliance, Git History Context, Code Reuse & Quality, Efficiency Review |
+
+## Review Agents
+
+| Agent | Effort Levels | Focus |
+|-------|---------------|-------|
+| Bug Scanner | all | Shallow scan for obvious, large bugs in the diff; avoid nitpicks and false positives |
+| AGENTS.md Compliance | all | Audit changes against root + modified-directory AGENTS.md files |
+| Git History Context | medium+ | Read `git blame` and history of modified code to find context-dependent bugs |
+| Code Reuse & Quality | high+ | Search for existing utilities; flag redundant state, parameter sprawl, copy-paste, leaky abstractions, stringly-typed code, unnecessary comments |
+| Efficiency Review | max only | Unnecessary work, missed concurrency, hot-path bloat, no-op updates, existence checks, memory leaks, overly broad operations |
+
+## Confidence Rubric
+
+| Score | Meaning |
+|-------|---------|
+| `0` | False positive that doesn't stand up to light scrutiny, or a pre-existing issue |
+| `25` | Might be real, may be a false positive; unverifiable. Stylistic issues not in AGENTS.md |
+| `50` | Verified real issue, but a nitpick or rare in practice; not very important relative to the PR |
+| `75` | Highly confident; double-checked; very likely hit in practice; existing approach insufficient; important or directly mentioned in AGENTS.md |
+| `100` | Absolutely certain; confirmed real; happens frequently; evidence directly confirms |
+
+## Finding
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `description` | `string` | Brief description of the bug/issue |
+| `agentsMdQuote` | `string?` | Verbatim quote from AGENTS.md if the finding violates a rule |
+| `contextSnippet` | `string?` | File and code snippet explaining the bug (e.g. "bug due to <file and code snippet>") |
+| `file` | `string` | File path where the issue occurs |
+| `lineRange` | `string` | Line range citation (e.g. `42-58`) |
+| `confidence` | `number` | Independent 0–100 score from the scoring agent |
+
+## Relationships
+- An **EffortLevel** maps to a set of **ReviewAgent**s and a confidence threshold.
+- Each **ReviewAgent** produces zero or more candidate **Finding**s (pre-scoring).
+- Each candidate **Finding** is scored by exactly one independent **ScoringAgent**.
+- Only **Finding**s with `confidence >= threshold` appear in the final report.

--- a/specs/058-code-review-skill/plan.md
+++ b/specs/058-code-review-skill/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Add a builtin `/code-review` skill that reviews the current branch's diff for correctness bugs and quality issues. Uses `git diff` (no `gh` dependency) so it works with any git host. Configurable effort level (low/medium/high/max) controls agent count and confidence threshold. Launches parallel review agents across independent dimensions (bugs, AGENTS.md compliance, git history, code reuse, efficiency), then scores each finding with an independent agent before filtering and reporting. Report-only — does not auto-fix. Sets `disable-model-invocation: true` to prevent AI auto-triggering.
+Add a builtin `/code-review` skill that reviews the current branch's diff for correctness bugs and quality issues. Uses `git diff` (no `gh` dependency for diff gathering) so it works with any git host. Configurable effort level (low/medium/high/max) controls agent count and confidence threshold. Launches parallel review agents across independent dimensions (bugs, AGENTS.md compliance, git history, code reuse, efficiency), then scores each finding with an independent agent before filtering. Delivery is comment-first: posts the review as a PR/MR comment via `gh`/`glab` when available, falling back to direct terminal output when no CLI or PR/MR exists. Does not auto-fix. Sets `disable-model-invocation: true` to prevent AI auto-triggering.
 
 ## Technical Context
 

--- a/specs/058-code-review-skill/plan.md
+++ b/specs/058-code-review-skill/plan.md
@@ -1,0 +1,64 @@
+# Implementation Plan: Code Review Skill
+
+**Branch**: `058-code-review-skill` | **Status**: Complete | **Date**: 2026-06-29 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/058-code-review-skill/spec.md`
+
+## Summary
+
+Add a builtin `/code-review` skill that reviews the current branch's diff for correctness bugs and quality issues. Uses `git diff` (no `gh` dependency) so it works with any git host. Configurable effort level (low/medium/high/max) controls agent count and confidence threshold. Launches parallel review agents across independent dimensions (bugs, AGENTS.md compliance, git history, code reuse, efficiency), then scores each finding with an independent agent before filtering and reporting. Report-only — does not auto-fix. Sets `disable-model-invocation: true` to prevent AI auto-triggering.
+
+## Technical Context
+
+**Language/Version**: Markdown skill definition (SKILL.md) + YAML frontmatter
+**Primary Dependencies**: Existing skill system (spec 006), Agent tool (spec 009/041), Bash skill substitution (spec 006)
+**Testing**: Manual invocation + verification of report format and finding filtering
+**Target Platform**: Linux/macOS/Windows (any environment with git)
+**Project Type**: Monorepo (agent-sdk builtin skills)
+**Constraints**: Must work without `gh` CLI or GitHub auth; must not auto-trigger; must not attempt build/typecheck
+**Scale/Scope**: Single SKILL.md file; no source code changes outside builtin skills directory
+
+## Constitution Check
+
+1. **Package-First Architecture**: Skill lives in `agent-sdk/builtin/skills/`. Pass.
+2. **TypeScript Excellence**: N/A — pure markdown skill, no TypeScript. Pass.
+3. **Test Alignment**: Manual verification scenarios defined in quickstart.md. Pass.
+4. **Build Dependencies**: No build step required for skill markdown. Pass.
+5. **Documentation Minimalism**: No extra .md files beyond spec/plan/research/data-model/quickstart/contracts/checklists. Pass.
+6. **Quality Gates**: N/A — no TypeScript to lint. Pass.
+7. **Source Code Structure**: `builtin/skills/code-review/SKILL.md`. Pass.
+8. **Data Model Minimalism**: Effort mapping, agent definitions, rubric — simple data structures. Pass.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/058-code-review-skill/
+├── plan.md              # This file
+├── research.md          # Decision rationale
+├── data-model.md        # Effort mapping, agent/rubric/finding models
+├── quickstart.md        # Usage examples
+├── contracts/           # API contracts
+│   └── code-review.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # Implementation tasks
+```
+
+### Source Code (repository root)
+
+```
+packages/
+└── agent-sdk/
+    └── builtin/
+        └── skills/
+            └── code-review/
+                └── SKILL.md     # Skill definition with frontmatter + 5 phases
+```
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| 5 effort levels with fixed agent counts | Predictable cost/coverage tradeoff | Continuous threshold arg rejected — users think in discrete tiers |
+| Independent scoring agent per finding | Filters false positives from biased reviewers | Self-reported score rejected — same-context bias |

--- a/specs/058-code-review-skill/quickstart.md
+++ b/specs/058-code-review-skill/quickstart.md
@@ -1,0 +1,63 @@
+# Quickstart: Code Review Skill
+
+## Overview
+
+`/code-review` reviews the current branch's diff for correctness bugs and quality issues. It works with any git host (GitHub, GitLab, self-hosted) — no `gh` CLI required.
+
+## Basic Usage
+
+```bash
+# Default review (medium effort: 3 agents, confidence threshold 80)
+/code-review
+
+# Quick review (2 agents, only near-certain findings)
+/code-review low
+
+# Thorough review (4 agents, broader coverage)
+/code-review high
+
+# Maximum review (5 agents, includes efficiency check)
+/code-review max
+```
+
+## How It Works
+
+1. **Gather context** — runs `git diff` against `main` (falls back to `HEAD~1`).
+2. **Launch review agents** — parallel subagents scan different dimensions (bugs, AGENTS.md compliance, git history, code reuse, efficiency) depending on effort level.
+3. **Score findings** — each finding gets an independent 0–100 confidence score from a separate agent.
+4. **Filter & report** — findings below the effort's threshold are dropped; the rest are reported with file + line range.
+
+## Effort Levels
+
+| Effort | Agents | Threshold | Best For |
+|--------|--------|-----------|----------|
+| `low` | 2 | 90 | Small changes, quick sanity check |
+| `medium` (default) | 3 | 80 | Everyday review |
+| `high` | 4 | 70 | Larger changes, moderate risk |
+| `max` | 5 | 60 | Big refactors, high-risk changes |
+
+## Report Format
+
+Findings are reported as a numbered list:
+
+```
+## Code Review
+
+Found 2 issues:
+
+1. <brief description> (AGENTS.md says "<rule>")
+
+   `src/foo.ts:42-58`
+
+2. <brief description> (bug due to <file and snippet>)
+
+   `src/bar.ts:10-15`
+```
+
+If no issues pass the threshold, the skill says so and stops.
+
+## Notes
+
+- The skill does **not** auto-fix issues — it reports only. Use `/simplify` to apply quality fixes.
+- The skill does **not** build or typecheck — run those separately.
+- The skill is **not** auto-triggered by the AI; it must be invoked explicitly via `/code-review`.

--- a/specs/058-code-review-skill/quickstart.md
+++ b/specs/058-code-review-skill/quickstart.md
@@ -25,7 +25,9 @@
 1. **Gather context** — runs `git diff` against `main` (falls back to `HEAD~1`).
 2. **Launch review agents** — parallel subagents scan different dimensions (bugs, AGENTS.md compliance, git history, code reuse, efficiency) depending on effort level.
 3. **Score findings** — each finding gets an independent 0–100 confidence score from a separate agent.
-4. **Filter & report** — findings below the effort's threshold are dropped; the rest are reported with file + line range.
+4. **Filter & deliver** — findings below the effort's threshold are dropped. If no issues remain, says "no issues" and stops. Otherwise:
+   - **Post as comment** (preferred): if `gh`/`glab` is installed and a PR/MR exists, the review is posted as a PR/MR comment.
+   - **Output directly** (fallback): if no CLI, no PR/MR, or posting fails, findings are output to the terminal.
 
 ## Effort Levels
 
@@ -54,7 +56,16 @@ Found 2 issues:
    `src/bar.ts:10-15`
 ```
 
-If no issues pass the threshold, the skill says so and stops.
+If no issues pass the threshold, the skill says so and stops — nothing is posted or output.
+
+## Delivery: Comment vs Terminal
+
+Findings are delivered via one of two paths:
+
+- **Post as comment** (preferred): if `gh` is installed and a GitHub PR exists → `gh pr comment`; if `glab` is installed and a GitLab MR exists → `glab mr note`. Findings are NOT output to the terminal.
+- **Output directly** (fallback): if no CLI is installed, no PR/MR exists, the platform is unrecognized, or posting fails → findings are output to the terminal.
+
+Platform detection is based on the remote URL (`git remote get-url origin`).
 
 ## Notes
 

--- a/specs/058-code-review-skill/research.md
+++ b/specs/058-code-review-skill/research.md
@@ -39,8 +39,34 @@
 - **Alternatives considered**:
   - Free-form score: Rejected — no calibration, scores inconsistent across agents.
 
+## Decision: Detect Platform and Post Comment via `gh`/`glab` (Optional)
+- **Rationale**: Posting the review as a PR/MR comment makes findings visible to the whole team and persists alongside the code. Detecting the platform from the remote URL and checking for the corresponding CLI (`gh` for GitHub, `glab` for GitLab) keeps the skill host-agnostic — it works with either platform and falls back to direct terminal output when no CLI is available.
+- **Alternatives considered**:
+  - GitHub-only via `gh` (like Claude Code's plugin): Rejected — Wave supports GitLab and self-hosted git; locking comment posting to GitHub excludes non-GitHub users.
+  - Always post via API calls (no CLI): Rejected — requires storing tokens and reimplementing API clients; `gh`/`glab` CLIs already handle auth.
+  - Never post, always output directly: Rejected — loses the team visibility benefit when a CLI is available.
+
+## Decision: Comment-First, Terminal Fallback (Not Both)
+- **Rationale**: When a platform CLI (`gh`/`glab`) is available and a PR/MR exists, posting the review as a comment is the primary delivery — the team sees it on the PR/MR. Outputting to the terminal as well is redundant noise. Only when no CLI or PR/MR exists do we fall back to terminal output. This matches Claude Code's `/code-review` plugin, which posts to the PR and produces no terminal output.
+- **Alternatives considered**:
+  - Always output to terminal, optionally also comment: Rejected — redundant when a comment is posted; the user would see the same content twice.
+  - Always comment, never output: Rejected — fails when no CLI is installed or no PR/MR exists; the user would lose the findings.
+
+## Decision: No Output When No Issues
+- **Rationale**: If no findings pass the confidence threshold, there is nothing to report. Posting an empty comment or printing "no issues" adds noise. The skill says "no issues" briefly and stops — no comment posted, no findings output. This matches Claude Code's behavior (step 6: "do not proceed").
+- **Alternatives considered**:
+  - Post a "no issues found" comment: Rejected — noise on the PR for no actionable content.
+
+## Decision: Platform Detection via Remote URL Substring
+- **Rationale**: Checking if the remote URL contains `github` or `gitlab` is simple and covers the common cases (github.com, gitlab.com, and most self-hosted instances with those names in the domain).
+- **Alternatives considered**:
+  - API probing (try `gh api` / `glab api`): Rejected — slower, requires auth just to detect the platform.
+  - Config file: Rejected — adds configuration burden for something detectable from git.
+
 ## Integration Points
 - Skill frontmatter (`allowed-tools`, `disable-model-invocation`) — parsed by the existing skill system (spec 006).
 - `$ARGUMENTS` substitution — effort level passed by the existing parameter system (spec 006).
 - Bash command placeholders (`!`git diff``) — executed by the existing skill bash substitution (spec 006).
 - Agent tool — used to launch parallel review and scoring subagents (spec 009/041).
+- `gh` CLI — used for GitHub PR comment posting (optional, detected at runtime).
+- `glab` CLI — used for GitLab MR comment posting (optional, detected at runtime).

--- a/specs/058-code-review-skill/research.md
+++ b/specs/058-code-review-skill/research.md
@@ -1,0 +1,46 @@
+# Research: Code Review Skill
+
+## Decision: Use `git diff` Instead of `gh` for Change Discovery
+- **Rationale**: `gh` ties the skill to GitHub-hosted repos and requires authentication. `git diff` works with any git host — GitLab, self-hosted, or local-only — and needs no credentials. The merge-base against `main` captures the full branch diff; `HEAD~1` is a safe fallback when `main` is absent.
+- **Alternatives considered**:
+  - `gh pr diff`: Rejected — GitHub-only, requires `gh` CLI + auth, fails on self-hosted/git-local repos.
+  - `git diff` with hardcoded `main`: Rejected without fallback — breaks on repos without a local `main` branch.
+
+## Decision: Configurable Effort Level (low/medium/high/max)
+- **Rationale**: Review depth should scale with change risk. A one-line fix needs a quick high-confidence pass; a large refactor benefits from broader coverage. Mapping each level to a fixed agent count + confidence threshold makes the tradeoff explicit and predictable.
+- **Alternatives considered**:
+  - Single fixed depth: Rejected — either too noisy for small changes or too shallow for large ones.
+  - Continuous confidence threshold argument: Rejected — users think in discrete effort tiers, not raw numbers.
+
+## Decision: Parallel Review Agents per Dimension
+- **Rationale**: Review dimensions (bugs, compliance, history, reuse, efficiency) are independent. Running them as parallel subagents reduces wall-clock latency and gives each dimension a focused context window.
+- **Alternatives considered**:
+  - Single agent reviewing all dimensions: Rejected — context dilution, slower, misses cross-dimension breadth.
+  - Sequential dimension agents: Rejected — latency multiplies with dimension count.
+
+## Decision: Independent Confidence Scoring per Finding
+- **Rationale**: A reviewing agent that found an issue is biased toward believing it's real. A separate scoring agent, given the diff + issue description + AGENTS.md context, provides an independent 0–100 assessment. Filtering by threshold then suppresses false positives predictably.
+- **Alternatives considered**:
+  - Self-reported confidence from the reviewing agent: Rejected — same-context bias, tends to over-score its own findings.
+  - No scoring, report everything: Rejected — too noisy, especially at higher effort levels.
+
+## Decision: Report-Only (No Auto-Fix)
+- **Rationale**: Code review reports findings; the developer decides what to fix. Auto-fixing would conflate review with modification and reduce trust in the report. This contrasts with the sibling `/simplify` skill, which does apply fixes.
+- **Alternatives considered**:
+  - Review + auto-fix: Rejected — scope creep; user may want to evaluate findings before acting. `/simplify` already covers the fix-applied workflow.
+
+## Decision: `disable-model-invocation: true`
+- **Rationale**: Code review is a deliberate, user-initiated action — it gathers the current diff and spends multiple subagent calls. Auto-triggering on casual "review my code" mentions would waste tokens and produce noisy reports against stale diffs. Restricting to explicit `/code-review` invocation keeps it intentional.
+- **Alternatives considered**:
+  - Model-invocable: Rejected — risk of unintended multi-agent fan-out on ambiguous requests.
+
+## Decision: Fixed Rubric Anchors (0/25/50/75/100)
+- **Rationale**: A fixed rubric with five anchors gives scoring agents a shared calibration scale, making scores comparable across findings and runs. The rubric text is passed verbatim to every scoring agent.
+- **Alternatives considered**:
+  - Free-form score: Rejected — no calibration, scores inconsistent across agents.
+
+## Integration Points
+- Skill frontmatter (`allowed-tools`, `disable-model-invocation`) — parsed by the existing skill system (spec 006).
+- `$ARGUMENTS` substitution — effort level passed by the existing parameter system (spec 006).
+- Bash command placeholders (`!`git diff``) — executed by the existing skill bash substitution (spec 006).
+- Agent tool — used to launch parallel review and scoring subagents (spec 009/041).

--- a/specs/058-code-review-skill/spec.md
+++ b/specs/058-code-review-skill/spec.md
@@ -1,0 +1,121 @@
+# Feature Specification: Code Review Skill
+
+**Feature Branch**: `058-code-review-skill`
+**Created**: 2026-06-29
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Review Current Diff for Correctness Bugs (Priority: P1)
+
+As a developer, I want to review my current branch's changes for correctness bugs so I can catch issues before merging, without relying on external CI or a hosted git platform.
+
+**Why this priority**: Bug detection is the primary value of code review. Using `git diff` (rather than `gh`) makes the skill work with any git host — GitLab, self-hosted, or local-only repos.
+
+**Independent Test**: Make a change with an obvious bug on a feature branch, run `/code-review`, and verify the bug is reported with file and line range.
+
+**Acceptance Scenarios**:
+
+1. **Given** there are uncommitted or committed-but-unmerged changes on the current branch, **When** the user runs `/code-review`, **Then** the skill gathers the diff against `main` (or `HEAD~1` as fallback) and reports correctness bugs found in the changes.
+2. **Given** there are no changes on the current branch, **When** the user runs `/code-review`, **Then** the skill stops and tells the user there is nothing to review.
+3. **Given** a correctness bug is found, **When** the report is rendered, **Then** each finding includes a brief description and the `<file>:<line range>` citation.
+
+---
+
+### User Story 2 - Configurable Effort Level (Priority: P2)
+
+As a developer, I want to control how thorough the review is — from a quick low-confidence pass to an exhaustive max-effort sweep — so I can trade review cost against coverage depending on the change size and risk.
+
+**Why this priority**: Different changes warrant different review depth. A one-line typo fix needs a quick scan; a large refactor benefits from broader coverage even at the cost of more noise.
+
+**Independent Test**: Run `/code-review low` and `/code-review max` on the same diff and verify that `max` launches more agents and surfaces lower-confidence findings that `low` filtered out.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user runs `/code-review low`, **When** the skill executes, **Then** it launches 2 review agents and filters out findings with confidence below 90.
+2. **Given** the user runs `/code-review` with no argument, **When** the skill executes, **Then** it defaults to `medium` effort: 3 agents, confidence threshold 80.
+3. **Given** the user runs `/code-review high`, **When** the skill executes, **Then** it launches 4 agents with confidence threshold 70.
+4. **Given** the user runs `/code-review max`, **When** the skill executes, **Then** it launches 5 agents with confidence threshold 60, including the efficiency reviewer.
+
+---
+
+### User Story 3 - Parallel Multi-Dimensional Review with Confidence Scoring (Priority: P2)
+
+As a developer, I want the review to cover multiple independent dimensions (bugs, AGENTS.md compliance, git history, code reuse, efficiency) in parallel, with each finding independently scored for confidence so I can focus on high-signal issues.
+
+**Why this priority**: Parallel review reduces latency and broadens coverage. Independent confidence scoring filters false positives that a single-pass review would surface.
+
+**Independent Test**: Run `/code-review max` on a diff with a reuse issue and an efficiency issue, and verify both dimensions produce findings, each with an independent confidence score that passes the threshold.
+
+**Acceptance Scenarios**:
+
+1. **Given** the effort level launches N agents, **When** Phase 3 executes, **Then** all review agents are launched concurrently in a single message, each receiving the full diff.
+2. **Given** a finding is produced by any review agent, **When** Phase 4 executes, **Then** a separate parallel scoring agent independently assigns a 0–100 confidence score using the fixed rubric.
+3. **Given** findings have been scored, **When** Phase 5 executes, **Then** only findings at or above the effort level's threshold are reported; the rest are filtered out.
+4. **Given** no findings pass the threshold, **When** the report renders, **Then** the skill says so and stops.
+
+---
+
+### User Story 4 - AGENTS.md Compliance Audit (Priority: P2)
+
+As a project maintainer, I want the review to check whether changes comply with the repository's `AGENTS.md` files (root and directory-level) so that AI-authored code follows project conventions.
+
+**Why this priority**: AGENTS.md encodes project-specific guidance; auditing compliance keeps AI-generated changes aligned with team standards.
+
+**Independent Test**: Add an `AGENTS.md` rule forbidding a pattern, introduce that pattern in a change, run `/code-review`, and verify the finding cites the AGENTS.md rule.
+
+**Acceptance Scenarios**:
+
+1. **Given** a root `AGENTS.md` exists, **When** the AGENTS.md compliance agent runs, **Then** it checks the diff against the root AGENTS.md guidance.
+2. **Given** AGENTS.md files exist in directories whose files were modified, **When** the compliance agent runs, **Then** it also checks those directory-level AGENTS.md files.
+3. **Given** a finding violates an AGENTS.md rule, **When** the finding is reported, **Then** it includes the quote `(AGENTS.md says "<...>")`.
+
+---
+
+### Edge Cases
+
+- **What happens if the diff is very large?** The skill passes the full diff to each agent; no truncation is performed by the skill itself. Large diffs may hit model context limits — this is acceptable and surfaces as an agent error.
+- **What happens if `main` branch doesn't exist locally?** The merge-base command falls back to `HEAD~1`, reviewing only the last commit.
+- **What if a finding is a false positive?** The confidence-scoring phase is designed to filter false positives; the skill also lists explicit false-positive categories to exclude (pre-existing issues, linter-level nitpicks, intentional changes, etc.).
+- **What if the AI tries to auto-trigger the skill?** `disable-model-invocation: true` in the frontmatter prevents the AI from invoking the skill autonomously; it is user-invoked only via `/code-review`.
+- **What if a scoring agent disagrees with the reviewing agent?** The scoring agent's independent score is authoritative for filtering; the reviewing agent's own assessment is not used for thresholding.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a builtin `code-review` skill invoked via `/code-review [effort]`.
+- **FR-002**: Skill MUST gather the diff using `git diff` against the merge-base of `HEAD` and `main`, falling back to `HEAD~1` when `main` is unavailable. No `gh` dependency.
+- **FR-003**: Skill MUST stop and inform the user when there are no changes to review.
+- **FR-004**: Skill MUST parse `$ARGUMENTS` for an effort level: `low`, `medium` (default), `high`, `max`.
+- **FR-005**: Each effort level MUST map to a fixed agent count and confidence threshold: low→2 agents/90, medium→3 agents/80, high→4 agents/70, max→5 agents/60.
+- **FR-006**: Skill MUST launch all review agents concurrently in a single message, passing each the full diff.
+- **FR-007**: Skill MUST include a Bug Scanner agent at all effort levels, performing a shallow scan focused on large bugs.
+- **FR-008**: Skill MUST include an AGENTS.md Compliance agent at all effort levels, auditing against root and modified-directory AGENTS.md files.
+- **FR-009**: Skill MUST include a Git History Context agent at `medium` and above, using `git blame` and history.
+- **FR-010**: Skill MUST include a Code Reuse & Quality agent at `high` and above.
+- **FR-011**: Skill MUST include an Efficiency Review agent at `max` only.
+- **FR-012**: Skill MUST launch a separate parallel scoring agent for each finding, returning a 0–100 confidence score per the fixed rubric.
+- **FR-013**: Skill MUST filter out findings whose confidence score is below the effort level's threshold.
+- **FR-014**: Skill MUST report findings in the fixed format: numbered list with description, optional AGENTS.md quote, and `<file>:<line range>` citation.
+- **FR-015**: Skill MUST report "no issues" and stop when no findings pass the threshold.
+- **FR-016**: Skill MUST cite the file and line range for every finding.
+- **FR-017**: Skill MUST set `disable-model-invocation: true` so the AI cannot auto-trigger it.
+- **FR-018**: Skill MUST restrict its own tools via `allowed-tools` to: git diff/status/log/show/blame, Read, Glob, Grep, and Agent.
+- **FR-019**: Skill MUST NOT check build signal or attempt to build or typecheck the app — these run separately.
+- **FR-020**: Skill MUST make a todo list first before executing the review phases.
+- **FR-021**: Skill MUST exclude false-positive categories: pre-existing issues, non-bug-looking issues, pedantic nitpicks, linter/typechecker-level issues, general quality gaps (unless AGENTS.md requires), silenced issues, intentional changes, and issues on unmodified lines.
+
+### Key Entities
+
+- **EffortLevel**: One of `low`, `medium`, `high`, `max` — controls agent count and confidence threshold.
+- **ReviewAgent**: A parallel subagent assigned a review dimension (bug scan, compliance, history, reuse, efficiency). Receives the full diff.
+- **ScoringAgent**: An independent subagent that assigns a 0–100 confidence score to a single finding using a fixed rubric.
+- **Finding**: A reported issue with description, optional AGENTS.md citation, file, and line range.
+- **ConfidenceScore**: Integer 0–100 with fixed rubric anchors at 0, 25, 50, 75, 100.
+
+### Assumptions
+
+- The skill is implemented as a builtin skill under `packages/agent-sdk/builtin/skills/code-review/SKILL.md`.
+- The Agent tool is available to the skill (listed in `allowed-tools`) for launching parallel review/scoring subagents.
+- `$ARGUMENTS` substitution is handled by the existing skill parameter system (spec 006).
+- Bash command execution (`!`git diff``) is handled by the existing skill bash substitution system (spec 006).

--- a/specs/058-code-review-skill/spec.md
+++ b/specs/058-code-review-skill/spec.md
@@ -71,6 +71,24 @@ As a project maintainer, I want the review to check whether changes comply with 
 
 ---
 
+### User Story 5 - Post Review Comment to PR/MR (Priority: P2)
+
+As a developer, I want the review findings posted as a comment on my pull/merge request when the platform CLI (`gh` or `glab`) is available, so my team can see the review alongside the code without copy-pasting from the terminal.
+
+**Why this priority**: Posting to the PR/MR makes findings visible to the whole team and persists alongside the code change. When no CLI or PR/MR exists, findings fall back to direct terminal output.
+
+**Independent Test**: On a GitHub repo with `gh` installed and a PR open, run `/code-review` and verify a comment appears on the PR with no terminal output. On a repo without `gh`, verify findings are output directly to the terminal.
+
+**Acceptance Scenarios**:
+
+1. **Given** the remote URL contains `github` and `gh` is installed and a PR exists for the current branch, **When** Phase 5 executes, **Then** the review is posted as a PR comment via `gh pr comment` and NOT output to the terminal.
+2. **Given** the remote URL contains `gitlab` and `glab` is installed and an MR exists for the current branch, **When** Phase 5 executes, **Then** the review is posted as an MR note via `glab mr note` and NOT output to the terminal.
+3. **Given** no platform CLI is installed, **When** Phase 5 executes, **Then** the findings are output directly to the terminal.
+4. **Given** a CLI is installed but no PR/MR exists for the current branch, **When** Phase 5 executes, **Then** the findings are output directly to the terminal.
+5. **Given** no findings pass the threshold, **When** Phase 5 executes, **Then** the skill says "no issues" and stops — no comment is posted and no findings are output.
+
+---
+
 ### Edge Cases
 
 - **What happens if the diff is very large?** The skill passes the full diff to each agent; no truncation is performed by the skill itself. Large diffs may hit model context limits — this is acceptable and surfaces as an agent error.
@@ -78,6 +96,9 @@ As a project maintainer, I want the review to check whether changes comply with 
 - **What if a finding is a false positive?** The confidence-scoring phase is designed to filter false positives; the skill also lists explicit false-positive categories to exclude (pre-existing issues, linter-level nitpicks, intentional changes, etc.).
 - **What if the AI tries to auto-trigger the skill?** `disable-model-invocation: true` in the frontmatter prevents the AI from invoking the skill autonomously; it is user-invoked only via `/code-review`.
 - **What if a scoring agent disagrees with the reviewing agent?** The scoring agent's independent score is authoritative for filtering; the reviewing agent's own assessment is not used for thresholding.
+- **What if the remote is self-hosted GitLab (not gitlab.com)?** Platform detection checks if the remote URL contains `gitlab`; self-hosted instances with custom domains are not recognized and the skill falls back to direct output.
+- **What if `gh` or `glab` is installed but not authenticated?** The CLI command to post a comment will fail; the skill treats this the same as "no PR/MR exists" and skips silently.
+- **What if posting the comment fails?** The skill falls back to direct terminal output so no information is lost.
 
 ## Requirements *(mandatory)*
 
@@ -97,13 +118,19 @@ As a project maintainer, I want the review to check whether changes comply with 
 - **FR-012**: Skill MUST launch a separate parallel scoring agent for each finding, returning a 0–100 confidence score per the fixed rubric.
 - **FR-013**: Skill MUST filter out findings whose confidence score is below the effort level's threshold.
 - **FR-014**: Skill MUST report findings in the fixed format: numbered list with description, optional AGENTS.md quote, and `<file>:<line range>` citation.
-- **FR-015**: Skill MUST report "no issues" and stop when no findings pass the threshold.
+- **FR-015**: Skill MUST report "no issues" and stop when no findings pass the threshold — no comment posted, no findings output.
 - **FR-016**: Skill MUST cite the file and line range for every finding.
 - **FR-017**: Skill MUST set `disable-model-invocation: true` so the AI cannot auto-trigger it.
-- **FR-018**: Skill MUST restrict its own tools via `allowed-tools` to: git diff/status/log/show/blame, Read, Glob, Grep, and Agent.
+- **FR-018**: Skill MUST restrict its own tools via `allowed-tools` to: git diff/status/log/show/blame/remote, command -v, gh pr comment/view, glab mr note/view, Read, Glob, Grep, and Agent.
 - **FR-019**: Skill MUST NOT check build signal or attempt to build or typecheck the app — these run separately.
 - **FR-020**: Skill MUST make a todo list first before executing the review phases.
 - **FR-021**: Skill MUST exclude false-positive categories: pre-existing issues, non-bug-looking issues, pedantic nitpicks, linter/typechecker-level issues, general quality gaps (unless AGENTS.md requires), silenced issues, intentional changes, and issues on unmodified lines.
+- **FR-022**: Skill MUST detect the repository platform by checking the remote URL (`git remote get-url origin`) — `github` in URL → GitHub, `gitlab` in URL → GitLab.
+- **FR-023**: Skill MUST detect whether the corresponding CLI is installed (`command -v gh` / `command -v glab`) before attempting to post a comment.
+- **FR-024**: Skill MUST check that a PR/MR exists for the current branch before posting (`gh pr view` / `glab mr view`).
+- **FR-025**: Skill MUST post the review as a PR comment via `gh pr comment --body` (preferred) when the platform is GitHub and `gh` is installed and a PR exists — and MUST NOT output findings to the terminal in this case.
+- **FR-026**: Skill MUST post the review as an MR note via `glab mr note --message` (preferred) when the platform is GitLab and `glab` is installed and an MR exists — and MUST NOT output findings to the terminal in this case.
+- **FR-027**: Skill MUST output findings directly to the terminal (fallback) when no CLI is installed, no PR/MR exists, the platform is unrecognized, or comment posting fails.
 
 ### Key Entities
 
@@ -112,6 +139,8 @@ As a project maintainer, I want the review to check whether changes comply with 
 - **ScoringAgent**: An independent subagent that assigns a 0–100 confidence score to a single finding using a fixed rubric.
 - **Finding**: A reported issue with description, optional AGENTS.md citation, file, and line range.
 - **ConfidenceScore**: Integer 0–100 with fixed rubric anchors at 0, 25, 50, 75, 100.
+- **Platform**: Detected repository platform — `github` or `gitlab` or `unknown` (inferred from remote URL).
+- **CommentTarget**: The PR or MR that receives the review comment, if a CLI is available and a PR/MR exists.
 
 ### Assumptions
 

--- a/specs/058-code-review-skill/tasks.md
+++ b/specs/058-code-review-skill/tasks.md
@@ -37,17 +37,22 @@
 - [x] T012 [US3] Implement Phase 4: launch parallel scoring agent per finding
 - [x] T013 [US3] Embed the fixed 0/25/50/75/100 rubric verbatim in the scoring agent prompt
 
-## Phase 5: Filter and Report
+## Phase 5: Filter and Deliver
 
 - [x] T014 [US3] Implement filtering by confidence threshold
-- [x] T015 [US1] Implement "no issues" early-stop report
+- [x] T015 [US1] Implement "no issues" early-stop (no comment, no terminal output)
 - [x] T016 [US1] Implement the numbered report format with `<file>:<line range>` citations
+- [x] T017 [US5] Add `Bash(git remote:*)`, `Bash(command -v:*)`, `Bash(gh pr comment:*)`, `Bash(gh pr view:*)`, `Bash(glab mr note:*)`, `Bash(glab mr view:*)` to `allowed-tools` in frontmatter
+- [x] T018 [US5] Implement platform detection via `git remote get-url origin`
+- [x] T019 [US5] Implement CLI detection via `command -v gh` / `command -v glab`
+- [x] T020 [US5] Implement comment-first delivery: post via `gh pr comment --body` / `glab mr note --message` when CLI + PR/MR exists, do NOT output to terminal
+- [x] T021 [US5] Implement terminal fallback: output directly when no CLI, no PR/MR, unrecognized platform, or posting fails
 
 ## Phase 6: Polish
 
-- [x] T017 [US1] Add False Positive Filtering guidance section
-- [x] T018 [US1] Add Notes section (no build/typecheck, cite file+lines, make todo list first)
-- [x] T019 [P] Add `$ARGUMENTS` input section at end of SKILL.md
+- [x] T022 [US1] Add False Positive Filtering guidance section
+- [x] T023 [US1] Add Notes section (no build/typecheck, cite file+lines, make todo list first)
+- [x] T024 [P] Add `$ARGUMENTS` input section at end of SKILL.md
 
 ## Dependencies & Execution Order
 
@@ -55,5 +60,8 @@
 - T004, T005 (effort level: sequential parse then map)
 - T006–T011 (review agents: parallel, independent prompts)
 - T012, T013 (scoring: sequential)
-- T014, T015, T016 (report: sequential)
-- T017, T018, T019 (polish: parallel)
+- T014 → T015 (filter then early-stop)
+- T017 → T018, T019 (frontmatter update before detection logic)
+- T020, T021 (delivery: comment-first then fallback — mutually exclusive paths)
+- T016 (report format: shared by both delivery paths)
+- T022, T023, T024 (polish: parallel)

--- a/specs/058-code-review-skill/tasks.md
+++ b/specs/058-code-review-skill/tasks.md
@@ -1,0 +1,59 @@
+# Tasks: Code Review Skill
+
+**Input**: Design documents from `/specs/058-code-review-skill/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Manual invocation verification — no unit/integration tests required for a pure-markdown skill.
+
+**Organization**: Tasks grouped by phase. Feature is already implemented (commit 8d13e248); tasks document the completed work.
+
+## Format: `[ID] [P?] [Story] Description`
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+## Phase 1: Skill Definition
+
+- [x] T001 [US1] Create `packages/agent-sdk/builtin/skills/code-review/SKILL.md` with frontmatter (`name`, `description`, `allowed-tools`, `disable-model-invocation: true`)
+- [x] T002 [US1] Implement Phase 1 (Gather Context): bash commands for `git status`, `git diff --name-only`, `git log`, `git diff` with merge-base fallback to `HEAD~1`
+- [x] T003 [US1] Implement early-stop when no changes exist
+
+## Phase 2: Effort Level
+
+- [x] T004 [US2] Implement Phase 2 (Determine Effort Level): parse `$ARGUMENTS` for low/medium/high/max with default `medium`
+- [x] T005 [US2] Map each effort level to agent count + confidence threshold (low→2/90, medium→3/80, high→4/70, max→5/60)
+
+## Phase 3: Parallel Review Agents
+
+- [x] T006 [US3] [P] Implement Bug Scanner agent prompt (all effort levels)
+- [x] T007 [US4] [P] Implement AGENTS.md Compliance agent prompt (all effort levels)
+- [x] T008 [US3] [P] Implement Git History Context agent prompt (medium+)
+- [x] T009 [US3] [P] Implement Code Reuse & Quality agent prompt (high+)
+- [x] T010 [US3] [P] Implement Efficiency Review agent prompt (max only)
+- [x] T011 [US3] Instruct launching all agents concurrently in a single message with full diff
+
+## Phase 4: Confidence Scoring
+
+- [x] T012 [US3] Implement Phase 4: launch parallel scoring agent per finding
+- [x] T013 [US3] Embed the fixed 0/25/50/75/100 rubric verbatim in the scoring agent prompt
+
+## Phase 5: Filter and Report
+
+- [x] T014 [US3] Implement filtering by confidence threshold
+- [x] T015 [US1] Implement "no issues" early-stop report
+- [x] T016 [US1] Implement the numbered report format with `<file>:<line range>` citations
+
+## Phase 6: Polish
+
+- [x] T017 [US1] Add False Positive Filtering guidance section
+- [x] T018 [US1] Add Notes section (no build/typecheck, cite file+lines, make todo list first)
+- [x] T019 [P] Add `$ARGUMENTS` input section at end of SKILL.md
+
+## Dependencies & Execution Order
+
+- T001 → T002 → T003 (sequential: frontmatter then phases)
+- T004, T005 (effort level: sequential parse then map)
+- T006–T011 (review agents: parallel, independent prompts)
+- T012, T013 (scoring: sequential)
+- T014, T015, T016 (report: sequential)
+- T017, T018, T019 (polish: parallel)

--- a/specs/059-simplify-skill/checklists/requirements.md
+++ b/specs/059-simplify-skill/checklists/requirements.md
@@ -1,0 +1,32 @@
+# Specification Quality Checklist: Simplify Skill
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-29
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Feature is already implemented (commit 8d13e248). This spec documents the existing behavior.
+- Items marked complete reflect the finalized specification.

--- a/specs/059-simplify-skill/contracts/simplify.md
+++ b/specs/059-simplify-skill/contracts/simplify.md
@@ -1,0 +1,67 @@
+# Simplify Skill Contracts
+
+## Skill Frontmatter
+
+```yaml
+name: simplify
+description: >
+  Review the changed code for reuse, simplification, efficiency, and altitude cleanups,
+  then apply the fixes. Quality only — it does not hunt for bugs; use /code-review for that.
+disable-model-invocation: true
+```
+
+## Phase Contracts
+
+### Phase 1: Identify Changes
+
+- Run `git diff` (or `git diff HEAD` if there are staged changes).
+- If no git changes exist, review the most recently modified files that the user mentioned or that the agent edited earlier in the conversation.
+
+### Phase 2: Launch Three Review Agents in Parallel
+
+All three agents launched concurrently in a single message via the Agent tool. Each receives the full diff.
+
+| # | Agent | Dimension |
+|---|-------|-----------|
+| 1 | Code Reuse Review | reuse |
+| 2 | Code Quality Review | quality |
+| 3 | Efficiency Review | efficiency |
+
+#### Agent 1: Code Reuse Review
+
+1. Search for existing utilities/helpers that could replace newly written code.
+2. Flag any new function that duplicates existing functionality.
+3. Flag inline logic that could use an existing utility (string manipulation, path handling, env checks, type guards).
+
+#### Agent 2: Code Quality Review
+
+1. Redundant state
+2. Parameter sprawl
+3. Copy-paste with slight variation
+4. Leaky abstractions
+5. Stringly-typed code
+6. Unnecessary JSX nesting
+7. Unnecessary comments (keep only non-obvious WHY)
+
+#### Agent 3: Efficiency Review
+
+1. Unnecessary work (redundant computations, repeated reads, N+1)
+2. Missed concurrency
+3. Hot-path bloat
+4. Recurring no-op updates (including same-reference-return violations)
+5. Unnecessary existence checks (TOCTOU)
+6. Memory (unbounded structures, missing cleanup, listener leaks)
+7. Overly broad operations
+
+### Phase 3: Fix Issues
+
+1. Wait for all three agents to complete.
+2. Aggregate findings.
+3. Fix each issue directly.
+4. If a finding is a false positive or not worth addressing, note it and skip — do not argue.
+5. Summarize what was fixed (or confirm the code was already clean).
+
+## False-Positive Handling
+
+- False positives are noted and skipped, not argued with.
+- No confidence scoring (unlike `/code-review`); the main agent uses judgment to skip.

--- a/specs/059-simplify-skill/data-model.md
+++ b/specs/059-simplify-skill/data-model.md
@@ -1,0 +1,46 @@
+# Data Model: Simplify Skill
+
+## Review Agents
+
+| Agent | Dimension | Focus |
+|-------|-----------|-------|
+| Code Reuse Review | Reuse | Search for existing utilities/helpers; flag duplicates; flag inline logic replaceable by existing utilities (string manipulation, path handling, env checks, type guards) |
+| Code Quality Review | Quality | Redundant state, parameter sprawl, copy-paste with variation, leaky abstractions, stringly-typed code, unnecessary JSX nesting, unnecessary comments (keep only non-obvious WHY) |
+| Efficiency Review | Efficiency | Unnecessary work, missed concurrency, hot-path bloat, recurring no-op updates (incl. same-reference-return violations), unnecessary existence checks (TOCTOU), memory issues, overly broad operations |
+
+## Code Quality Checklist
+
+| Pattern | Description |
+|---------|-------------|
+| Redundant state | State duplicating existing state; cached values that could be derived; observers/effects that could be direct calls |
+| Parameter sprawl | Adding parameters instead of generalizing or restructuring |
+| Copy-paste with variation | Near-duplicate blocks that should be unified |
+| Leaky abstractions | Exposing internal details that should be encapsulated |
+| Stringly-typed code | Raw strings where constants/enums/branded types exist |
+| Unnecessary JSX nesting | Wrapper Boxes/elements adding no layout value |
+| Unnecessary comments | Comments explaining WHAT (delete); keep only non-obvious WHY |
+
+## Efficiency Checklist
+
+| Pattern | Description |
+|---------|-------------|
+| Unnecessary work | Redundant computations, repeated file reads, duplicate API calls, N+1 patterns |
+| Missed concurrency | Sequential operations that could be parallel |
+| Hot-path bloat | Blocking work in startup or per-request/per-render paths |
+| Recurring no-op updates | State/store updates in loops/intervals/handlers firing unconditionally; updater callbacks not honoring same-reference returns |
+| Unnecessary existence checks | Pre-checking file/resource existence before operating (TOCTOU) — operate directly and handle errors |
+| Memory | Unbounded data structures, missing cleanup, event listener leaks |
+| Overly broad operations | Reading entire files when a portion suffices; loading all items when filtering for one |
+
+## Finding
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `dimension` | `'reuse' \| 'quality' \| 'efficiency'` | Which agent found it |
+| `description` | `string` | Description of the quality issue |
+| `suggestion` | `string?` | Suggested fix or existing utility to use |
+
+## Relationships
+- A **ReviewAgent** produces zero or more **Finding**s.
+- Each **Finding** is resolved by a **Fix** applied in Phase 3.
+- False-positive **Finding**s are skipped (noted, not fixed).

--- a/specs/059-simplify-skill/plan.md
+++ b/specs/059-simplify-skill/plan.md
@@ -1,0 +1,64 @@
+# Implementation Plan: Simplify Skill
+
+**Branch**: `059-simplify-skill` | **Status**: Complete | **Date**: 2026-06-29 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/059-simplify-skill/spec.md`
+
+## Summary
+
+Add a builtin `/simplify` skill that reviews changed code for reuse, quality, and efficiency issues, then applies fixes directly. Three parallel review agents (reuse/quality/efficiency) each receive the full diff. Uses `git diff` (or `git diff HEAD` for staged changes) with fallback to recently-modified files when no git changes exist. Quality-only — does not hunt for bugs (use `/code-review` for that). Sets `disable-model-invocation: true` to prevent AI auto-triggering.
+
+## Technical Context
+
+**Language/Version**: Markdown skill definition (SKILL.md) + YAML frontmatter
+**Primary Dependencies**: Existing skill system (spec 006), Agent tool (spec 009/041), Write/Edit tools
+**Testing**: Manual invocation + verification of applied fixes
+**Target Platform**: Linux/macOS/Windows (any environment with git)
+**Project Type**: Monorepo (agent-sdk builtin skills)
+**Constraints**: Must work without `gh` CLI; must not auto-trigger; must not hunt for bugs; quality fixes only
+**Scale/Scope**: Single SKILL.md file; no source code changes outside builtin skills directory
+
+## Constitution Check
+
+1. **Package-First Architecture**: Skill lives in `agent-sdk/builtin/skills/`. Pass.
+2. **TypeScript Excellence**: N/A — pure markdown skill, no TypeScript. Pass.
+3. **Test Alignment**: Manual verification scenarios defined in quickstart.md. Pass.
+4. **Build Dependencies**: No build step required for skill markdown. Pass.
+5. **Documentation Minimalism**: No extra .md files beyond spec/plan/research/data-model/quickstart/contracts/checklists. Pass.
+6. **Quality Gates**: N/A — no TypeScript to lint. Pass.
+7. **Source Code Structure**: `builtin/skills/simplify/SKILL.md`. Pass.
+8. **Data Model Minimalism**: Three agent dimensions + checklists — simple data structures. Pass.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/059-simplify-skill/
+├── plan.md              # This file
+├── research.md          # Decision rationale
+├── data-model.md        # Agent dimensions, quality/efficiency checklists
+├── quickstart.md        # Usage examples
+├── contracts/           # API contracts
+│   └── simplify.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # Implementation tasks
+```
+
+### Source Code (repository root)
+
+```
+packages/
+└── agent-sdk/
+    └── builtin/
+        └── skills/
+            └── simplify/
+                └── SKILL.md     # Skill definition with frontmatter + 3 phases
+```
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| Three parallel agents (not one) | Independent dimensions need focused context | Single agent rejected — context dilution, shallower coverage |
+| Auto-fix (not report-only) | Quality fixes are low-risk; one-step workflow | Report-only rejected — duplicates `/code-review` workflow |

--- a/specs/059-simplify-skill/quickstart.md
+++ b/specs/059-simplify-skill/quickstart.md
@@ -1,0 +1,41 @@
+# Quickstart: Simplify Skill
+
+## Overview
+
+`/simplify` reviews your changed code for reuse, quality, and efficiency issues, then applies fixes directly. Quality only — it does not hunt for bugs; use `/code-review` for that.
+
+## Basic Usage
+
+```bash
+# Review and fix quality issues in current changes
+/simplify
+```
+
+## How It Works
+
+1. **Identify changes** — runs `git diff` (or `git diff HEAD` if staged). Falls back to recently-modified files if no git changes.
+2. **Launch three review agents** — parallel subagents review reuse, quality, and efficiency.
+3. **Fix issues** — aggregates findings and fixes each issue directly. False positives are skipped.
+
+## Review Dimensions
+
+| Agent | What It Checks |
+|-------|---------------|
+| Code Reuse | Duplicated logic, existing utilities that could replace new code, inline logic (string/path/env/type-guard) |
+| Code Quality | Redundant state, parameter sprawl, copy-paste, leaky abstractions, stringly-typed code, unnecessary JSX/comments |
+| Efficiency | Unnecessary work, missed concurrency, hot-path bloat, no-op updates, TOCTOU checks, memory leaks, broad operations |
+
+## When to Use Which
+
+| Skill | Reports | Auto-Fixes | Focus |
+|-------|---------|------------|-------|
+| `/code-review` | Yes | No | Correctness bugs + quality |
+| `/simplify` | No | Yes | Quality only (reuse/efficiency) |
+
+Typical workflow: run `/code-review` to find bugs, fix them, then run `/simplify` to clean up quality.
+
+## Notes
+
+- The skill is **not** auto-triggered by the AI; it must be invoked explicitly via `/simplify`.
+- False positives are skipped — the skill notes them and moves on without arguing.
+- After fixing, the skill summarizes what was fixed (or confirms the code was already clean).

--- a/specs/059-simplify-skill/research.md
+++ b/specs/059-simplify-skill/research.md
@@ -1,0 +1,41 @@
+# Research: Simplify Skill
+
+## Decision: Review + Auto-Fix (Not Report-Only)
+- **Rationale**: `/simplify` is the "apply fixes" counterpart to `/code-review` (report-only). Developers want a one-step cleanup: review for quality issues, then fix them immediately. This avoids the round-trip of reading a report and manually applying fixes.
+- **Alternatives considered**:
+  - Report-only (like `/code-review`): Rejected — duplicates `/code-review`'s workflow; quality fixes are low-risk and safe to auto-apply.
+  - Review + suggest fixes without applying: Rejected — extra step for the developer.
+
+## Decision: Three Parallel Agents (Reuse / Quality / Efficiency)
+- **Rationale**: The three quality dimensions are independent and cover the most common degradation patterns. Parallel execution reduces latency. Each agent gets a focused context for its dimension.
+- **Alternatives considered**:
+  - Single agent reviewing all dimensions: Rejected — context dilution, slower, shallower per-dimension coverage.
+  - Sequential dimension agents: Rejected — latency multiplies.
+  - Five agents (like `/code-review max`): Rejected — `/simplify` is quality-focused, not bug-focused; three dimensions suffice.
+
+## Decision: Quality-Only (No Bug Hunting)
+- **Rationale**: Separating quality from correctness lets developers choose the right tool. Bug hunting requires careful, confidence-scored review (provided by `/code-review`). Quality cleanup is lower-risk and faster, suitable for auto-fix.
+- **Alternatives considered**:
+  - Combined quality + bug review: Rejected — conflates two concerns; bug findings would need confidence scoring (adds latency), and auto-fixing bugs is riskier than auto-fixing quality issues.
+
+## Decision: `git diff` with Staged-Change Fallback
+- **Rationale**: `git diff` captures unstaged changes (the common case). When changes are staged, `git diff HEAD` captures both staged and unstaged. This covers the typical "I just edited some files" workflow without requiring commits.
+- **Alternatives considered**:
+  - `git diff --cached` only: Rejected — misses unstaged changes.
+  - Review last commit: Rejected — too narrow; developers often clean up before committing.
+
+## Decision: Fallback to Recently-Modified Files
+- **Rationale**: When there are no git changes (e.g., the agent just edited files in-session), reviewing the files the user mentioned or the agent edited earlier keeps the skill useful in conversational workflows.
+- **Alternatives considered**:
+  - Stop with "nothing to review": Rejected — too rigid for in-session editing flows.
+
+## Decision: `disable-model-invocation: true`
+- **Rationale**: `/simplify` applies code changes and launches multiple subagents. Auto-triggering on casual mentions would make unintended modifications. Restricting to explicit `/simplify` invocation keeps it intentional.
+- **Alternatives considered**:
+  - Model-invocable: Rejected — risk of unintended code modifications and token spend.
+
+## Integration Points
+- Skill frontmatter (`disable-model-invocation`) — parsed by the existing skill system (spec 006).
+- Agent tool — used to launch parallel review subagents (spec 009/041).
+- Write/Edit tools — used to apply fixes in Phase 3.
+- Bash command placeholders (`!`git diff``) — executed by the existing skill bash substitution (spec 006).

--- a/specs/059-simplify-skill/spec.md
+++ b/specs/059-simplify-skill/spec.md
@@ -1,0 +1,95 @@
+# Feature Specification: Simplify Skill
+
+**Feature Branch**: `059-simplify-skill`
+**Created**: 2026-06-29
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Review and Apply Quality Cleanups (Priority: P1)
+
+As a developer, I want to review my changed code for reuse opportunities, quality issues, and efficiency problems, and have the fixes applied automatically, so I can keep my code clean without manually hunting for improvements.
+
+**Why this priority**: This is the core value — review + auto-fix in one step. It complements `/code-review` (which reports bugs only) by focusing on quality and applying fixes.
+
+**Independent Test**: Make a change with an obvious duplication or inefficiency, run `/simplify`, and verify the issue is fixed in the working tree.
+
+**Acceptance Scenarios**:
+
+1. **Given** there are git changes (staged or unstaged), **When** the user runs `/simplify`, **Then** the skill gathers the diff via `git diff` (or `git diff HEAD` for staged changes) and reviews all changed files.
+2. **Given** there are no git changes, **When** the user runs `/simplify`, **Then** the skill reviews the most recently modified files that the user mentioned or that the agent edited earlier in the conversation.
+3. **Given** quality issues are found, **When** Phase 3 executes, **Then** the skill fixes each issue directly in the code.
+4. **Given** a finding is a false positive or not worth addressing, **When** the skill evaluates it, **Then** it notes it and moves on without arguing.
+
+---
+
+### User Story 2 - Parallel Three-Dimension Quality Review (Priority: P2)
+
+As a developer, I want the review to cover three independent quality dimensions — code reuse, code quality, and efficiency — in parallel, so I get comprehensive coverage with low latency.
+
+**Why this priority**: Parallel review reduces latency and gives each dimension a focused context. The three dimensions cover the most common quality degradation patterns.
+
+**Independent Test**: Make a change with a reuse issue (duplicating an existing utility), a quality issue (copy-paste code), and an efficiency issue (sequential calls that could be parallel), run `/simplify`, and verify all three are fixed.
+
+**Acceptance Scenarios**:
+
+1. **Given** the skill enters Phase 2, **When** it executes, **Then** it launches three agents concurrently in a single message, each receiving the full diff.
+2. **Given** the Code Reuse agent runs, **When** it reviews the changes, **Then** it searches for existing utilities/helpers that could replace newly written code and flags duplicates and inline logic that could use existing utilities.
+3. **Given** the Code Quality agent runs, **When** it reviews the changes, **Then** it flags redundant state, parameter sprawl, copy-paste with variation, leaky abstractions, stringly-typed code, unnecessary JSX nesting, and unnecessary comments.
+4. **Given** the Efficiency agent runs, **When** it reviews the changes, **Then** it flags unnecessary work, missed concurrency, hot-path bloat, recurring no-op updates, unnecessary existence checks, memory issues, and overly broad operations.
+
+---
+
+### User Story 3 - Bug-Free Quality Focus (Priority: P2)
+
+As a developer, I want `/simplify` to focus on quality only and not hunt for bugs, so I can use it as a fast cleanup pass separate from a full bug review.
+
+**Why this priority**: Separating concerns (quality vs. correctness) lets developers run the right tool for the job. Bug hunting requires a different, more careful review (provided by `/code-review`).
+
+**Independent Test**: Run `/simplify` on a change containing a subtle bug; verify the skill does not report the bug (it focuses on quality). Then run `/code-review` and verify the bug is caught.
+
+**Acceptance Scenarios**:
+
+1. **Given** the skill description states "Quality only — it does not hunt for bugs; use /code-review for that", **When** the skill executes, **Then** the review agents focus on reuse/quality/efficiency, not correctness bugs.
+2. **Given** a developer wants a bug review, **When** they run `/code-review` instead, **Then** bugs are reported.
+
+---
+
+### Edge Cases
+
+- **What happens if no git changes exist and no files were recently edited?** The skill reviews the most recently modified files the user mentioned or that the agent edited earlier. If none can be identified, the skill has nothing to review.
+- **What happens if the three agents produce conflicting fixes?** Phase 3 aggregates findings and fixes each issue directly; conflicts are resolved by the main agent applying fixes sequentially.
+- **What if a fix introduces a new issue?** The skill does not re-review after fixing; it applies fixes and summarizes. A subsequent `/simplify` or `/code-review` can catch regressions.
+- **What if the AI tries to auto-trigger the skill?** `disable-model-invocation: true` in the frontmatter prevents autonomous invocation; it is user-invoked only via `/simplify`.
+- **What if a finding is a false positive?** The skill notes it and moves on — it does not argue with the finding, just skips it.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a builtin `simplify` skill invoked via `/simplify`.
+- **FR-002**: Skill MUST gather changes via `git diff`, or `git diff HEAD` if there are staged changes.
+- **FR-003**: Skill MUST fall back to reviewing the most recently modified files (mentioned by user or edited by the agent earlier) when there are no git changes.
+- **FR-004**: Skill MUST launch three review agents concurrently in a single message, each receiving the full diff.
+- **FR-005**: Skill MUST include a Code Reuse Review agent that searches for existing utilities/helpers and flags duplicates and inline logic replaceable by existing utilities.
+- **FR-006**: Skill MUST include a Code Quality Review agent that flags: redundant state, parameter sprawl, copy-paste with variation, leaky abstractions, stringly-typed code, unnecessary JSX nesting, and unnecessary comments (keeping only non-obvious WHY comments).
+- **FR-007**: Skill MUST include an Efficiency Review agent that flags: unnecessary work, missed concurrency, hot-path bloat, recurring no-op updates (including same-reference-return violations), unnecessary existence checks (TOCTOU), memory issues (unbounded structures, missing cleanup, listener leaks), and overly broad operations.
+- **FR-008**: Skill MUST wait for all three agents to complete before fixing.
+- **FR-009**: Skill MUST aggregate findings and fix each issue directly in Phase 3.
+- **FR-010**: Skill MUST skip false positives or not-worth-addressing findings without arguing.
+- **FR-011**: Skill MUST summarize what was fixed (or confirm the code was already clean) when done.
+- **FR-012**: Skill MUST set `disable-model-invocation: true` so the AI cannot auto-trigger it.
+- **FR-013**: Skill MUST be quality-focused only — it MUST NOT hunt for correctness bugs (use `/code-review` for that).
+- **FR-014**: Skill description MUST state "Quality only — it does not hunt for bugs; use /code-review for that."
+
+### Key Entities
+
+- **ReviewAgent**: A parallel subagent assigned a quality dimension (reuse, quality, efficiency). Receives the full diff.
+- **Finding**: A quality issue identified by a review agent, to be fixed in Phase 3.
+- **Fix**: A direct code change applied by the main agent to resolve a finding.
+
+### Assumptions
+
+- The skill is implemented as a builtin skill under `packages/agent-sdk/builtin/skills/simplify/SKILL.md`.
+- The Agent tool is available to the skill for launching parallel review subagents.
+- The skill can edit files directly (Write/Edit tools) to apply fixes.
+- `disable-model-invocation: true` is handled by the existing skill system (spec 006).

--- a/specs/059-simplify-skill/tasks.md
+++ b/specs/059-simplify-skill/tasks.md
@@ -1,0 +1,44 @@
+# Tasks: Simplify Skill
+
+**Input**: Design documents from `/specs/059-simplify-skill/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Manual invocation verification — no unit/integration tests required for a pure-markdown skill.
+
+**Organization**: Tasks grouped by phase. Feature is already implemented (commit 8d13e248); tasks document the completed work.
+
+## Format: `[ID] [P?] [Story] Description`
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Skill Definition
+
+- [x] T001 [US1] Create `packages/agent-sdk/builtin/skills/simplify/SKILL.md` with frontmatter (`name`, `description`, `disable-model-invocation: true`)
+- [x] T002 [US1] Implement Phase 1 (Identify Changes): `git diff` / `git diff HEAD` with fallback to recently-modified files
+
+## Phase 2: Parallel Review Agents
+
+- [x] T003 [US2] [P] Implement Code Reuse Review agent prompt (search existing utilities, flag duplicates, flag inline logic)
+- [x] T004 [US2] [P] Implement Code Quality Review agent prompt (redundant state, parameter sprawl, copy-paste, leaky abstractions, stringly-typed, JSX nesting, comments)
+- [x] T005 [US2] [P] Implement Efficiency Review agent prompt (unnecessary work, missed concurrency, hot-path bloat, no-op updates, TOCTOU, memory, broad operations)
+- [x] T006 [US2] Instruct launching all three agents concurrently in a single message with full diff
+
+## Phase 3: Fix Issues
+
+- [x] T007 [US1] Implement Phase 3: wait for all agents, aggregate findings, fix each issue directly
+- [x] T008 [US1] Implement false-positive skipping (note and move on, do not argue)
+- [x] T009 [US1] Implement summary output (what was fixed or code was already clean)
+
+## Phase 4: Polish
+
+- [x] T010 [US3] Ensure description states "Quality only — it does not hunt for bugs; use /code-review for that"
+- [x] T011 [US3] Verify no bug-hunting instructions in any agent prompt
+
+## Dependencies & Execution Order
+
+- T001 → T002 (sequential: frontmatter then Phase 1)
+- T003, T004, T005 (review agents: parallel, independent prompts)
+- T006 depends on T003–T005 (launch instruction after agents defined)
+- T007, T008, T009 (fix phase: sequential)
+- T010, T011 (polish: parallel)


### PR DESCRIPTION
## Summary

- Add comment-first delivery to `/code-review` skill: when `gh`/`glab` is installed and a PR/MR exists, post the review as a comment (not output to terminal)
- Fall back to direct terminal output when no CLI, no PR/MR, unrecognized platform, or posting fails
- Detect platform via `git remote get-url origin` substring (`github`/`gitlab`)
- Add `Bash(git remote:*)`, `Bash(command -v:*)`, `Bash(gh pr comment:*)`, `Bash(gh pr view:*)`, `Bash(glab mr note:*)`, `Bash(glab mr view:*)` to `allowed-tools`

## Commits

- `933f6aa3` docs: add specs for /code-review and /simplify builtin skills
- `5009e7c5` feat(code-review): post review as PR/MR comment via gh/glab with terminal fallback

## Spec changes (058-code-review-skill)

All 7 spec files updated to reflect comment-first delivery logic:
- `spec.md` — added User Story 5 (Post Review Comment), FR-022 to FR-027, Platform/CommentTarget entities, edge cases
- `contracts/code-review.md` — updated Phase 5 contract (Filter and Deliver), updated allowed-tools
- `data-model.md` — added Platform Detection table, CommentTarget entity, delivery model
- `quickstart.md` — added Delivery section (Comment vs Terminal)
- `research.md` — added 4 decisions (platform detection, comment-first, no-output-when-no-issues, substring detection)
- `tasks.md` — added T017–T021 (delivery tasks), renumbered polish tasks
- `plan.md` — updated summary with comment-first delivery description

## Test plan

- [x] Type-check passes (`pnpm run type-check`)
- [ ] Manual: on a GitHub repo with `gh` installed and a PR open, verify `/code-review` posts a comment and produces no terminal output
- [ ] Manual: on a repo without `gh`, verify findings are output to the terminal
- [ ] Manual: on a GitLab repo with `glab` installed and an MR open, verify `glab mr note` is used
- [ ] Manual: verify "no issues" case posts nothing and outputs nothing