### PR TITLE
fix(sdk): add messageId to incremental MessageManager callbacks

### DIFF
--- a/packages/agent-sdk/src/managers/messageManager.ts
+++ b/packages/agent-sdk/src/managers/messageManager.ts
@@ -12,6 +12,7 @@ import {
   addNotificationMessageToMessages,
   UserMessageParams,
   type AgentToolBlockUpdateParams,
+  type ToolBlockUpdateCallbackParams,
   type AddNotificationMessageParams,
   generateMessageId,
 } from "../utils/messageOperations.js";
@@ -40,12 +41,20 @@ export interface MessageManagerCallbacks {
   // Incremental callback
   onUserMessageAdded?: (params: UserMessageParams) => void;
   // MODIFIED: Remove arguments for separation of concerns
-  onAssistantMessageAdded?: () => void;
+  onAssistantMessageAdded?: (messageId: string) => void;
   // NEW: Streaming content callback - FR-001: receives chunk and accumulated content
-  onAssistantContentUpdated?: (chunk: string, accumulated: string) => void;
+  onAssistantContentUpdated?: (
+    messageId: string,
+    chunk: string,
+    accumulated: string,
+  ) => void;
   // NEW: Streaming reasoning callback
-  onAssistantReasoningUpdated?: (chunk: string, accumulated: string) => void;
-  onToolBlockUpdated?: (params: AgentToolBlockUpdateParams) => void;
+  onAssistantReasoningUpdated?: (
+    messageId: string,
+    chunk: string,
+    accumulated: string,
+  ) => void;
+  onToolBlockUpdated?: (params: ToolBlockUpdateCallbackParams) => void;
   onErrorBlockAdded?: (error: string) => void;
   onCompactBlockAdded?: (content: string) => void;
   onCompactionStateChange?: (isCompacting: boolean) => void;
@@ -419,7 +428,8 @@ export class MessageManager {
       additionalFieldsRecord,
     );
     this.setMessages(newMessages);
-    this.callbacks.onAssistantMessageAdded?.();
+    const messageId = this.messages[this.messages.length - 1]?.id;
+    this.callbacks.onAssistantMessageAdded?.(messageId);
 
     // Note: Subagent-specific callbacks are now handled by SubagentManager
   }
@@ -460,12 +470,21 @@ export class MessageManager {
   public updateToolBlock(params: AgentToolBlockUpdateParams): void {
     // Finalize any streaming text/reasoning blocks before adding/updating a tool block
     this.finalizeCurrentStreamingBlocks();
-    const newMessages = updateToolBlockInMessage({
-      messages: this.messages,
-      ...params,
-    });
+    const { messages: newMessages, messageId: resolvedMessageId } =
+      updateToolBlockInMessage({
+        messages: this.messages,
+        ...params,
+      });
     this.setMessages(newMessages);
-    this.callbacks.onToolBlockUpdated?.(params);
+    const callbackParams: ToolBlockUpdateCallbackParams = {
+      ...params,
+      messageId:
+        params.messageId ||
+        resolvedMessageId ||
+        this.messages[this.messages.length - 1]?.id ||
+        "",
+    };
+    this.callbacks.onToolBlockUpdated?.(callbackParams);
 
     // Note: Subagent-specific callbacks are now handled by SubagentManager
   }
@@ -482,7 +501,11 @@ export class MessageManager {
     const { messages: newMessages, toolBlockId } =
       addToolBlockToMessageInMessages(this.messages, messageId, params);
     this.setMessages(newMessages);
-    this.callbacks.onToolBlockUpdated?.({ ...params, id: toolBlockId });
+    this.callbacks.onToolBlockUpdated?.({
+      ...params,
+      id: toolBlockId,
+      messageId,
+    });
     return toolBlockId;
   }
 
@@ -722,7 +745,11 @@ export class MessageManager {
     }
 
     // FR-001: Trigger callbacks with chunk and accumulated content
-    this.callbacks.onAssistantContentUpdated?.(chunk, newAccumulatedContent);
+    this.callbacks.onAssistantContentUpdated?.(
+      lastMessage.id,
+      chunk,
+      newAccumulatedContent,
+    );
 
     // Note: Subagent-specific callbacks are now handled by SubagentManager
 
@@ -793,6 +820,7 @@ export class MessageManager {
 
     // Trigger callbacks with chunk and accumulated reasoning content
     this.callbacks.onAssistantReasoningUpdated?.(
+      lastMessage.id,
       chunk,
       newAccumulatedReasoning,
     );

--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -17,7 +17,7 @@ import { NotificationQueue } from "./notificationQueue.js";
 import { logger } from "../utils/globalLogger.js";
 import {
   UserMessageParams,
-  type AgentToolBlockUpdateParams,
+  type ToolBlockUpdateCallbackParams,
 } from "../utils/messageOperations.js";
 
 import { Container } from "../utils/container.js";
@@ -33,23 +33,28 @@ export interface SubagentManagerCallbacks {
     params: UserMessageParams,
   ) => void;
   /** Triggered when subagent creates assistant message */
-  onSubagentAssistantMessageAdded?: (subagentId: string) => void;
+  onSubagentAssistantMessageAdded?: (
+    subagentId: string,
+    messageId: string,
+  ) => void;
   /** Triggered during subagent content streaming updates */
   onSubagentAssistantContentUpdated?: (
     subagentId: string,
+    messageId: string,
     chunk: string,
     accumulated: string,
   ) => void;
   /** Triggered during subagent reasoning streaming updates */
   onSubagentAssistantReasoningUpdated?: (
     subagentId: string,
+    messageId: string,
     chunk: string,
     accumulated: string,
   ) => void;
   /** Triggered when subagent tool block is updated */
   onSubagentToolBlockUpdated?: (
     subagentId: string,
-    params: AgentToolBlockUpdateParams,
+    params: ToolBlockUpdateCallbackParams,
   ) => void;
   /** Triggered when subagent messages change */
   onSubagentMessagesChange?: (subagentId: string, messages: Message[]) => void;
@@ -777,35 +782,45 @@ export class SubagentManager {
         }
       },
 
-      onAssistantMessageAdded: () => {
+      onAssistantMessageAdded: (messageId: string) => {
         // Forward assistant message events to parent via SubagentManager callbacks
         if (this.callbacks?.onSubagentAssistantMessageAdded) {
-          this.callbacks.onSubagentAssistantMessageAdded(subagentId);
+          this.callbacks.onSubagentAssistantMessageAdded(subagentId, messageId);
         }
       },
 
-      onAssistantContentUpdated: (chunk: string, accumulated: string) => {
+      onAssistantContentUpdated: (
+        messageId: string,
+        chunk: string,
+        accumulated: string,
+      ) => {
         // Forward assistant content updates to parent via SubagentManager callbacks
         if (this.callbacks?.onSubagentAssistantContentUpdated) {
           this.callbacks.onSubagentAssistantContentUpdated(
             subagentId,
+            messageId,
             chunk,
             accumulated,
           );
         }
       },
-      onAssistantReasoningUpdated: (chunk: string, accumulated: string) => {
+      onAssistantReasoningUpdated: (
+        messageId: string,
+        chunk: string,
+        accumulated: string,
+      ) => {
         // Forward assistant reasoning updates to parent via SubagentManager callbacks
         if (this.callbacks?.onSubagentAssistantReasoningUpdated) {
           this.callbacks.onSubagentAssistantReasoningUpdated(
             subagentId,
+            messageId,
             chunk,
             accumulated,
           );
         }
       },
 
-      onToolBlockUpdated: (params: AgentToolBlockUpdateParams) => {
+      onToolBlockUpdated: (params: ToolBlockUpdateCallbackParams) => {
         const instance = this.instances.get(subagentId);
         if (instance) {
           // Log tool execution to file only when finalized

--- a/packages/agent-sdk/src/utils/messageOperations.ts
+++ b/packages/agent-sdk/src/utils/messageOperations.ts
@@ -58,6 +58,14 @@ export type AgentToolBlockUpdateParams = Omit<
   "messages"
 >;
 
+// Callback payload type — SDK always fills messageId (required)
+export type ToolBlockUpdateCallbackParams = Omit<
+  AgentToolBlockUpdateParams,
+  "messageId"
+> & {
+  messageId: string;
+};
+
 export interface AddErrorBlockParams {
   messages: Message[];
   error: string;
@@ -289,7 +297,7 @@ export const updateToolBlockInMessage = ({
   compactParams,
   parametersChunk,
   isManuallyBackgrounded,
-}: UpdateToolBlockParams): Message[] => {
+}: UpdateToolBlockParams): { messages: Message[]; messageId?: string } => {
   const newMessages = [...messages];
 
   // If messageId is provided, target that specific message
@@ -321,7 +329,7 @@ export const updateToolBlockInMessage = ({
         }
       }
     }
-    return newMessages;
+    return { messages: newMessages, messageId };
   }
 
   // Find the last assistant or user message
@@ -350,7 +358,8 @@ export const updateToolBlockInMessage = ({
           if (isManuallyBackgrounded !== undefined)
             toolBlock.isManuallyBackgrounded = isManuallyBackgrounded;
         }
-        break; // Found and updated, stop searching
+        const foundMessageId = newMessages[i].id;
+        return { messages: newMessages, messageId: foundMessageId };
       } else if (newMessages[i].role === "assistant") {
         // If existing block not found in assistant message, create new one
         // This handles cases where we're streaming tool parameters before execution
@@ -370,11 +379,12 @@ export const updateToolBlockInMessage = ({
           parametersChunk: parametersChunk,
           isManuallyBackgrounded: isManuallyBackgrounded,
         });
-        break; // Created and added, stop searching
+        const foundMessageId = newMessages[i].id;
+        return { messages: newMessages, messageId: foundMessageId };
       }
     }
   }
-  return newMessages;
+  return { messages: newMessages };
 };
 
 // Add Error Block to the last assistant message

--- a/packages/agent-sdk/tests/managers/messageManager.streaming.test.ts
+++ b/packages/agent-sdk/tests/managers/messageManager.streaming.test.ts
@@ -23,11 +23,13 @@ describe("MessageManager - Streaming Functionality", () => {
 
       // Add an assistant message first
       messageManager.addAssistantMessage();
+      const messageId = messageManager.getMessages().slice(-1)[0].id;
 
       // First update
       messageManager.updateCurrentMessageContent("Hello");
 
       expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith(
+        messageId,
         "Hello",
         "Hello",
       );
@@ -36,6 +38,7 @@ describe("MessageManager - Streaming Functionality", () => {
       messageManager.updateCurrentMessageContent("Hello, world!");
 
       expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith(
+        messageId,
         ", world!",
         "Hello, world!",
       );
@@ -44,6 +47,7 @@ describe("MessageManager - Streaming Functionality", () => {
       messageManager.updateCurrentMessageContent("Hello, world! How are you?");
 
       expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith(
+        messageId,
         " How are you?",
         "Hello, world! How are you?",
       );
@@ -67,11 +71,16 @@ describe("MessageManager - Streaming Functionality", () => {
 
       // Add an assistant message first
       messageManager.addAssistantMessage();
+      const messageId = messageManager.getMessages().slice(-1)[0].id;
 
       // Update with empty content
       messageManager.updateCurrentMessageContent("");
 
-      expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith("", "");
+      expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith(
+        messageId,
+        "",
+        "",
+      );
     });
 
     it("should create new text block when none exists", () => {
@@ -88,11 +97,13 @@ describe("MessageManager - Streaming Functionality", () => {
 
       // Add an assistant message first
       messageManager.addAssistantMessage();
+      const messageId = messageManager.getMessages().slice(-1)[0].id;
 
       // Update content (should create new text block)
       messageManager.updateCurrentMessageContent("New content");
 
       expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith(
+        messageId,
         "New content",
         "New content",
       );

--- a/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
@@ -218,10 +218,15 @@ describe("SubagentManager - Backgrounding Coverage", () => {
     const lastCall =
       MessageManagerMock.mock.calls[MessageManagerMock.mock.calls.length - 1];
     const passedCallbacks = lastCall[1].callbacks;
-    passedCallbacks.onAssistantReasoningUpdated?.("chunk", "accumulated");
+    passedCallbacks.onAssistantReasoningUpdated?.(
+      "msg-test-id",
+      "chunk",
+      "accumulated",
+    );
 
     expect(onSubagentAssistantReasoningUpdated).toHaveBeenCalledWith(
       instance.subagentId,
+      "msg-test-id",
       "chunk",
       "accumulated",
     );
@@ -253,6 +258,7 @@ describe("SubagentManager - Backgrounding Coverage", () => {
     // Trigger tool block update (stage "end" to trigger logging)
     passedCallbacks.onToolBlockUpdated?.({
       id: "tool_123",
+      messageId: "msg-test-id",
       stage: "end",
       name: "Read",
       parameters: JSON.stringify({ file_path: "test.txt" }),

--- a/packages/agent-sdk/tests/managers/subagentManager.callbacks.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.callbacks.test.ts
@@ -234,6 +234,7 @@ describe("SubagentManager - Callback Integration", () => {
       // Verify that the subagent callback was called with the subagent ID
       expect(callbacks.onSubagentAssistantMessageAdded).toHaveBeenCalledWith(
         instance.subagentId,
+        expect.any(String),
       );
 
       // Note: onAssistantMessageAdded is not expected to be called in this context
@@ -274,6 +275,7 @@ describe("SubagentManager - Callback Integration", () => {
 
       expect(callbacks.onSubagentAssistantMessageAdded).toHaveBeenCalledWith(
         instance.subagentId,
+        expect.any(String),
       );
     });
   });
@@ -307,9 +309,10 @@ describe("SubagentManager - Callback Integration", () => {
       const newContent = "Starting to stream content...";
       instance.messageManager.updateCurrentMessageContent(newContent);
 
-      // Verify that the subagent callback was called with the subagent ID, chunk, and accumulated content
+      // Verify that the subagent callback was called with the subagent ID, messageId, chunk, and accumulated content
       expect(callbacks.onSubagentAssistantContentUpdated).toHaveBeenCalledWith(
         instance.subagentId,
+        expect.any(String), // messageId
         expect.any(String), // chunk
         newContent, // accumulated content
       );
@@ -358,9 +361,9 @@ describe("SubagentManager - Callback Integration", () => {
       expect(mockedCallback.mock.calls).toBeDefined();
       const calls = mockedCallback.mock.calls!;
       expect(calls[0]![0]).toBe(instance.subagentId); // subagentId
-      expect(calls[0]![2]).toBe("Hello world"); // accumulated content
+      expect(calls[0]![3]).toBe("Hello world"); // accumulated content
       expect(calls[1]![0]).toBe(instance.subagentId); // subagentId
-      expect(calls[1]![2]).toBe("Hello world!"); // accumulated content
+      expect(calls[1]![3]).toBe("Hello world!"); // accumulated content
     });
   });
 
@@ -412,7 +415,10 @@ describe("SubagentManager - Callback Integration", () => {
       // Verify that the subagent callback was called with the subagent ID and params
       expect(callbacks.onSubagentToolBlockUpdated).toHaveBeenCalledWith(
         instance.subagentId,
-        toolUpdateParams,
+        expect.objectContaining({
+          ...toolUpdateParams,
+          messageId: expect.any(String),
+        }),
       );
 
       // Verify that the regular callback was also called
@@ -477,8 +483,20 @@ describe("SubagentManager - Callback Integration", () => {
       const mockedCallback = vi.mocked(callbacks.onSubagentToolBlockUpdated)!;
       expect(mockedCallback.mock.calls).toBeDefined();
       const calls = mockedCallback.mock.calls!;
-      expect(calls[0]).toEqual([instance.subagentId, runningParams]);
-      expect(calls[1]).toEqual([instance.subagentId, completedParams]);
+      expect(calls[0]).toEqual([
+        instance.subagentId,
+        expect.objectContaining({
+          ...runningParams,
+          messageId: expect.any(String),
+        }),
+      ]);
+      expect(calls[1]).toEqual([
+        instance.subagentId,
+        expect.objectContaining({
+          ...completedParams,
+          messageId: expect.any(String),
+        }),
+      ]);
     });
   });
 

--- a/packages/agent-sdk/tests/utils/imageSupport.test.ts
+++ b/packages/agent-sdk/tests/utils/imageSupport.test.ts
@@ -33,7 +33,7 @@ describe("Image Support in Tool Results", () => {
       },
     ];
 
-    const updatedMessages = updateToolBlockInMessage({
+    const { messages: updatedMessages } = updateToolBlockInMessage({
       messages,
       id: "tool-123",
       parameters: '{"action": "screenshot"}',

--- a/packages/agent-sdk/tests/utils/messageOperations.test.ts
+++ b/packages/agent-sdk/tests/utils/messageOperations.test.ts
@@ -903,14 +903,16 @@ describe("updateToolBlockInMessage with messageId", () => {
       },
     ];
 
-    const result = updateToolBlockInMessage({
-      messages: initialMessages,
-      id: toolBlockId,
-      messageId: messageId,
-      stage: "end",
-      result: "success",
-    });
+    const { messages: result, messageId: foundMessageId } =
+      updateToolBlockInMessage({
+        messages: initialMessages,
+        id: toolBlockId,
+        messageId: messageId,
+        stage: "end",
+        result: "success",
+      });
 
+    expect(foundMessageId).toBe(messageId);
     expect(result[0].blocks[1]).toMatchObject({
       id: toolBlockId,
       stage: "end",
@@ -939,7 +941,7 @@ describe("updateToolBlockInMessage with messageId", () => {
       },
     ];
 
-    const result = updateToolBlockInMessage({
+    const { messages: result } = updateToolBlockInMessage({
       messages: initialMessages,
       id: toolBlockId,
       stage: "end",
@@ -973,7 +975,7 @@ describe("updateToolBlockInMessage with messageId", () => {
       },
     ];
 
-    const result = updateToolBlockInMessage({
+    const { messages: result } = updateToolBlockInMessage({
       messages: initialMessages,
       id: toolBlockId,
       parameters: '{"key": "val"}',

--- a/packages/code/src/acp/agent.ts
+++ b/packages/code/src/acp/agent.ts
@@ -224,10 +224,10 @@ export class WaveAcpAgent implements AcpAgent {
         );
       },
       callbacks: {
-        onAssistantContentUpdated: (chunk: string) =>
-          callbacks.onAssistantContentUpdated?.(chunk, ""),
-        onAssistantReasoningUpdated: (chunk: string) =>
-          callbacks.onAssistantReasoningUpdated?.(chunk, ""),
+        onAssistantContentUpdated: (messageId: string, chunk: string) =>
+          callbacks.onAssistantContentUpdated?.(messageId, chunk, ""),
+        onAssistantReasoningUpdated: (messageId: string, chunk: string) =>
+          callbacks.onAssistantReasoningUpdated?.(messageId, chunk, ""),
         onToolBlockUpdated: (params: unknown) => {
           const cb = callbacks.onToolBlockUpdated as
             | ((params: unknown) => void)
@@ -1127,7 +1127,7 @@ export class WaveAcpAgent implements AcpAgent {
     >();
     return {
       callbacks: {
-        onAssistantContentUpdated: (chunk: string) => {
+        onAssistantContentUpdated: (_messageId: string, chunk: string) => {
           this.connection.sessionUpdate({
             sessionId: sessionRef.id as AcpSessionId,
             update: {
@@ -1139,7 +1139,7 @@ export class WaveAcpAgent implements AcpAgent {
             },
           });
         },
-        onAssistantReasoningUpdated: (chunk: string) => {
+        onAssistantReasoningUpdated: (_messageId: string, chunk: string) => {
           this.connection.sessionUpdate({
             sessionId: sessionRef.id as AcpSessionId,
             update: {

--- a/packages/code/src/print-cli.ts
+++ b/packages/code/src/print-cli.ts
@@ -75,14 +75,14 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
       isReasoning = false;
       isContent = false;
     },
-    onAssistantReasoningUpdated: (chunk: string) => {
+    onAssistantReasoningUpdated: (_messageId: string, chunk: string) => {
       if (!isReasoning) {
         process.stdout.write("\n💭 Reasoning:\n");
         isReasoning = true;
       }
       process.stdout.write(chunk);
     },
-    onAssistantContentUpdated: (chunk: string) => {
+    onAssistantContentUpdated: (_messageId: string, chunk: string) => {
       if (!isContent) {
         if (isReasoning) {
           process.stdout.write("\n\n📝 Response:\n");

--- a/packages/code/tests/acp/agent.test.ts
+++ b/packages/code/tests/acp/agent.test.ts
@@ -585,6 +585,7 @@ describe("WaveAcpAgent", () => {
 
     // Write tool
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "1",
       name: "Write",
       stage: "start",
@@ -620,6 +621,7 @@ describe("WaveAcpAgent", () => {
 
     // Edit tool
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "2",
       name: "Edit",
       stage: "end",
@@ -1353,7 +1355,11 @@ describe("WaveAcpAgent", () => {
 
     await agent.newSession({ cwd: "/test", mcpServers: [] });
 
-    capturedCallbacks!.onAssistantContentUpdated!("chunk", "chunk");
+    capturedCallbacks!.onAssistantContentUpdated!(
+      "msg-test-id",
+      "chunk",
+      "chunk",
+    );
     expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
         update: expect.objectContaining({
@@ -1363,7 +1369,11 @@ describe("WaveAcpAgent", () => {
       }),
     );
 
-    capturedCallbacks!.onAssistantReasoningUpdated!("thought", "thought");
+    capturedCallbacks!.onAssistantReasoningUpdated!(
+      "msg-test-id",
+      "thought",
+      "thought",
+    );
     expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
         update: expect.objectContaining({
@@ -1374,6 +1384,7 @@ describe("WaveAcpAgent", () => {
     );
 
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "1",
       name: "tool",
       stage: "start",
@@ -1388,6 +1399,7 @@ describe("WaveAcpAgent", () => {
     );
 
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "1",
       name: "tool",
       stage: "end",
@@ -1698,6 +1710,7 @@ describe("WaveAcpAgent", () => {
 
     // Streaming stage
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "1",
       name: "tool",
       stage: "streaming",
@@ -1706,6 +1719,7 @@ describe("WaveAcpAgent", () => {
 
     // Running stage
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "1",
       name: "tool",
       stage: "running",
@@ -1721,6 +1735,7 @@ describe("WaveAcpAgent", () => {
 
     // Failed stage
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "1",
       name: "tool",
       stage: "end",
@@ -1777,6 +1792,7 @@ describe("WaveAcpAgent", () => {
 
     // Test with compactParams
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "1",
       name: "Read",
       stage: "start",
@@ -1795,6 +1811,7 @@ describe("WaveAcpAgent", () => {
 
     // Test update with compactParams
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "1",
       name: "Read",
       stage: "end",
@@ -1814,6 +1831,7 @@ describe("WaveAcpAgent", () => {
 
     // Test fallback when compactParams is missing
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "2",
       name: "Read",
       stage: "start",
@@ -1848,6 +1866,7 @@ describe("WaveAcpAgent", () => {
 
     // 1. Start with name only
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "1",
       name: "Read",
       stage: "start",
@@ -1864,6 +1883,7 @@ describe("WaveAcpAgent", () => {
 
     // 2. Update with compactParams in running stage
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "1",
       stage: "running",
       compactParams: "file.txt",
@@ -1880,6 +1900,7 @@ describe("WaveAcpAgent", () => {
 
     // 3. Update in end stage with missing name and compactParams
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "1",
       stage: "end",
       success: true,
@@ -1957,6 +1978,7 @@ describe("WaveAcpAgent", () => {
     await agent.newSession({ cwd: "/test", mcpServers: [] });
 
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "1",
       name: "Grep",
       stage: "end",
@@ -2000,6 +2022,7 @@ describe("WaveAcpAgent", () => {
     await agent.newSession({ cwd: "/test", mcpServers: [] });
 
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "1",
       name: "Bash",
       stage: "start",
@@ -2036,6 +2059,7 @@ describe("WaveAcpAgent", () => {
     await agent.newSession({ cwd: "/test", mcpServers: [] });
 
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "1",
       name: "Bash",
       stage: "end",
@@ -2080,6 +2104,7 @@ describe("WaveAcpAgent", () => {
 
     // LSP tool
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "1",
       name: "LSP",
       stage: "start",
@@ -2107,6 +2132,7 @@ describe("WaveAcpAgent", () => {
 
     // Edit tool with startLineNumber
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "2",
       name: "Edit",
       stage: "end",
@@ -2221,6 +2247,7 @@ describe("WaveAcpAgent", () => {
     await agent.newSession({ cwd: "/test", mcpServers: [] });
 
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "1",
       name: "UnknownTool",
       stage: "start",
@@ -2467,6 +2494,7 @@ describe("WaveAcpAgent", () => {
     await agent.newSession({ cwd: "/test", mcpServers: [] });
 
     capturedCallbacks!.onToolBlockUpdated!({
+      messageId: "msg-test-id",
       id: "1",
       name: "mcp__UnknownTool",
       stage: "start",

--- a/packages/code/tests/print-cli.test.ts
+++ b/packages/code/tests/print-cli.test.ts
@@ -92,11 +92,6 @@ test("onAssistantMessageAdded outputs newline", async () => {
     sessionFilePath: "/mock/session.json",
   };
 
-  interface AgentCallbacks {
-    onAssistantMessageAdded?: () => void;
-    onAssistantContentUpdated?: (chunk: string, accumulated: string) => void;
-  }
-
   let capturedCallbacks: AgentCallbacks | undefined;
   vi.mocked(Agent.create).mockImplementation(async (options) => {
     capturedCallbacks = options.callbacks;
@@ -110,7 +105,7 @@ test("onAssistantMessageAdded outputs newline", async () => {
   await startPrintCli({ message: "test message" });
 
   // Test the onAssistantMessageAdded callback
-  capturedCallbacks?.onAssistantMessageAdded?.();
+  capturedCallbacks?.onAssistantMessageAdded?.("msg-test-id");
 
   // Verify that process.stdout.write was called with newline
   expect(stdoutSpy).toHaveBeenCalledWith("\n");
@@ -409,6 +404,7 @@ test("reasoning callbacks output correctly", async () => {
 
   // 1. Trigger onAssistantReasoningUpdated and verify the output
   capturedCallbacks?.onAssistantReasoningUpdated?.(
+    "msg-test-id",
     "Thinking...",
     "Thinking...",
   );
@@ -418,6 +414,7 @@ test("reasoning callbacks output correctly", async () => {
   // Verify header is not printed again
   stdoutSpy.mockClear();
   capturedCallbacks?.onAssistantReasoningUpdated?.(
+    "msg-test-id",
     " more thinking",
     "Thinking... more thinking",
   );
@@ -426,13 +423,21 @@ test("reasoning callbacks output correctly", async () => {
 
   // 2. Trigger onAssistantContentUpdated after reasoning and verify the "📝 Response:" header
   stdoutSpy.mockClear();
-  capturedCallbacks?.onAssistantContentUpdated?.("Hello!", "Hello!");
+  capturedCallbacks?.onAssistantContentUpdated?.(
+    "msg-test-id",
+    "Hello!",
+    "Hello!",
+  );
   expect(stdoutSpy).toHaveBeenCalledWith("\n\n📝 Response:\n");
   expect(stdoutSpy).toHaveBeenCalledWith("Hello!");
 
   // Verify header is not printed again
   stdoutSpy.mockClear();
-  capturedCallbacks?.onAssistantContentUpdated?.(" world", "Hello! world");
+  capturedCallbacks?.onAssistantContentUpdated?.(
+    "msg-test-id",
+    " world",
+    "Hello! world",
+  );
   expect(stdoutSpy).not.toHaveBeenCalledWith("\n\n📝 Response:\n");
   expect(stdoutSpy).toHaveBeenCalledWith(" world");
 


### PR DESCRIPTION
## Summary

Add `messageId` to all incremental `MessageManagerCallbacks` so consumers (e.g. wave-vsce) can reliably locate target messages without relying on "last assistant message" assumptions or fallback tool-block searches.

Closes #1281

## Changes

**Callback signature updates:**
- `onAssistantMessageAdded`: `()` → `(messageId: string)`
- `onAssistantContentUpdated`: `(chunk, accumulated)` → `(messageId, chunk, accumulated)`
- `onAssistantReasoningUpdated`: `(chunk, accumulated)` → `(messageId, chunk, accumulated)`
- `onToolBlockUpdated`: `params.messageId` now required (new `ToolBlockUpdateCallbackParams` type)

**SDK core:**
- `messageOperations.ts` — New `ToolBlockUpdateCallbackParams` type; `updateToolBlockInMessage` returns `{ messages, messageId? }`
- `messageManager.ts` — All 4 callbacks carry `messageId`; `updateToolBlock()` fills it internally from the resolved message
- `subagentManager.ts` — 4 subagent callbacks + forwarding updated

**Consumers:**
- `acp/agent.ts` — Outer forwarders + inner session handlers updated
- `print-cli.ts` — Streaming handlers accept `messageId` first param

**Bug fix:** Fixed a positional-binding runtime bug in `print-cli.ts` and `acp/agent.ts` where handlers used fewer params than the callback type, causing `messageId` to bind to `chunk`.

No changes needed in `aiManager.ts`, `slashCommandManager.ts`, `hookManager.ts`, or examples — callers don't pass `messageId`; the SDK fills it internally in `updateToolBlock()`.

## Verification
- Type-check: clean (both packages)
- SDK tests: 234 files, 3108 passed, 1 skipped
- CLI tests: 83 files, 1051 passed
- Lint: clean