### PR TITLE
refactor: use object params for streaming callbacks and fire stage=end events

### DIFF
--- a/packages/agent-sdk/examples/auto-memory-demo.ts
+++ b/packages/agent-sdk/examples/auto-memory-demo.ts
@@ -40,13 +40,13 @@ async function main() {
         },
       },
       callbacks: {
-        onAssistantContentUpdated: (chunk) => {
-          process.stdout.write(chunk);
+        onAssistantContentUpdated: (params) => {
+          process.stdout.write(params.chunk);
         },
-        onSubagentAssistantContentUpdated: (subagentId, chunk) => {
+        onSubagentAssistantContentUpdated: (params) => {
           // We can see the background agent working!
           process.stdout.write(
-            `\x1b[2m[Background Memory Agent] ${chunk}\x1b[0m`,
+            `\x1b[2m[Background Memory Agent] ${params.chunk}\x1b[0m`,
           );
         },
       },

--- a/packages/agent-sdk/examples/backgrounding-demo.ts
+++ b/packages/agent-sdk/examples/backgrounding-demo.ts
@@ -20,7 +20,7 @@ async function demonstrateBackgrounding(): Promise<void> {
       permissionMode: "bypassPermissions", // Ensure tools can run without permission prompts
       callbacks: {
         onAssistantContentUpdated: () => {
-          // process.stdout.write(chunk);
+          // process.stdout.write(params.chunk);
         },
         onToolBlockUpdated: (params) => {
           const { name: toolName, stage, id: toolId } = params;

--- a/packages/agent-sdk/examples/btw-command-demo.ts
+++ b/packages/agent-sdk/examples/btw-command-demo.ts
@@ -11,8 +11,8 @@ async function main() {
     model: process.env.WAVE_FAST_MODEL,
     permissionMode: "bypassPermissions", // Allow memory access to keep history clean
     callbacks: {
-      onAssistantContentUpdated: (chunk) => {
-        process.stdout.write(chunk);
+      onAssistantContentUpdated: (params) => {
+        process.stdout.write(params.chunk);
       },
     },
   });

--- a/packages/agent-sdk/examples/build-tool-demo.ts
+++ b/packages/agent-sdk/examples/build-tool-demo.ts
@@ -76,8 +76,8 @@ const calculatorTool = buildTool({
 const agent = await Agent.create({
   customTools: [weatherTool, calculatorTool],
   callbacks: {
-    onAssistantContentUpdated: (chunk: string) => {
-      process.stdout.write(chunk);
+    onAssistantContentUpdated: (params: { chunk: string }) => {
+      process.stdout.write(params.chunk);
     },
     onToolBlockUpdated: (params) => {
       if (params.stage === "start") {

--- a/packages/agent-sdk/examples/chrome-mcp.ts
+++ b/packages/agent-sdk/examples/chrome-mcp.ts
@@ -43,8 +43,8 @@ async function setupTest() {
       onAssistantMessageAdded: () => {
         console.log("🤖 Assistant message started");
       },
-      onAssistantContentUpdated: (chunk: string) => {
-        process.stdout.write(chunk);
+      onAssistantContentUpdated: (params: { chunk: string }) => {
+        process.stdout.write(params.chunk);
       },
       onToolBlockUpdated: (params) => {
         if (params.stage === "start") {

--- a/packages/agent-sdk/examples/custom-slash-command.ts
+++ b/packages/agent-sdk/examples/custom-slash-command.ts
@@ -49,8 +49,8 @@ const agent = await Agent.create({
     onAssistantMessageAdded: () => {
       console.log("Assistant message started");
     },
-    onAssistantContentUpdated: (chunk: string) => {
-      process.stdout.write(chunk);
+    onAssistantContentUpdated: (params: { chunk: string }) => {
+      process.stdout.write(params.chunk);
     },
     onToolBlockUpdated: (params) => {
       if (params.result) console.log(`🔧 ${params.name}:`, params.result);

--- a/packages/agent-sdk/examples/custom-tools.ts
+++ b/packages/agent-sdk/examples/custom-tools.ts
@@ -143,8 +143,8 @@ console.error("Favorite Number MCP Server ready");`;
       onAssistantMessageAdded: () => {
         console.log("Assistant message started");
       },
-      onAssistantContentUpdated: (chunk: string) => {
-        process.stdout.write(chunk);
+      onAssistantContentUpdated: (params: { chunk: string }) => {
+        process.stdout.write(params.chunk);
       },
       onToolBlockUpdated: (params) => {
         if (params.stage === "end" && params.success) {

--- a/packages/agent-sdk/examples/cwd-tracking.ts
+++ b/packages/agent-sdk/examples/cwd-tracking.ts
@@ -64,8 +64,8 @@ async function setupTest() {
           }
         }
       },
-      onAssistantContentUpdated: (chunk: string) => {
-        process.stdout.write(chunk);
+      onAssistantContentUpdated: (params: { chunk: string }) => {
+        process.stdout.write(params.chunk);
       },
     },
     logger: {

--- a/packages/agent-sdk/examples/demo-tools.ts
+++ b/packages/agent-sdk/examples/demo-tools.ts
@@ -16,8 +16,8 @@ const agent = await Agent.create({
     onAssistantMessageAdded: () => {
       console.log("\nAssistant message started");
     },
-    onAssistantContentUpdated: (chunk: string) => {
-      process.stdout.write(chunk);
+    onAssistantContentUpdated: (params: { chunk: string }) => {
+      process.stdout.write(params.chunk);
     },
     onToolBlockUpdated: (params) => {
       if (params.stage === "start") {

--- a/packages/agent-sdk/examples/dynamic-headers-example.ts
+++ b/packages/agent-sdk/examples/dynamic-headers-example.ts
@@ -48,8 +48,8 @@ async function main() {
       systemPrompt: "You are a helpful assistant.",
       fetch: customFetch,
       callbacks: {
-        onAssistantContentUpdated: (chunk: string) => {
-          process.stdout.write(chunk);
+        onAssistantContentUpdated: (params: { chunk: string }) => {
+          process.stdout.write(params.chunk);
         },
       },
     });
@@ -62,8 +62,8 @@ async function main() {
       systemPrompt: "You are a special-agent.",
       fetch: customFetch,
       callbacks: {
-        onAssistantContentUpdated: (chunk: string) => {
-          process.stdout.write(chunk);
+        onAssistantContentUpdated: (params: { chunk: string }) => {
+          process.stdout.write(params.chunk);
         },
       },
     });

--- a/packages/agent-sdk/examples/general-purpose-agent.ts
+++ b/packages/agent-sdk/examples/general-purpose-agent.ts
@@ -10,10 +10,10 @@ async function main() {
         const name = instance?.configuration.name || subagentId;
         console.log(`[Subagent ${name}] Assistant started responding...`);
       },
-      onSubagentAssistantContentUpdated: (subagentId, chunk) => {
-        const instance = agent.getSubagentInstance(subagentId);
-        const name = instance?.configuration.name || subagentId;
-        process.stdout.write(`[Subagent ${name}] ${chunk}`);
+      onSubagentAssistantContentUpdated: (params) => {
+        const instance = agent.getSubagentInstance(params.subagentId);
+        const name = instance?.configuration.name || params.subagentId;
+        process.stdout.write(`[Subagent ${name}] ${params.chunk}`);
       },
       onSubagentToolBlockUpdated: (subagentId, params) => {
         const instance = agent.getSubagentInstance(subagentId);
@@ -26,8 +26,8 @@ async function main() {
           );
         }
       },
-      onAssistantContentUpdated: (chunk) => {
-        process.stdout.write(chunk);
+      onAssistantContentUpdated: (params) => {
+        process.stdout.write(params.chunk);
       },
     },
   });

--- a/packages/agent-sdk/examples/goal-demo.ts
+++ b/packages/agent-sdk/examples/goal-demo.ts
@@ -22,8 +22,8 @@ async function main() {
     model: process.env.WAVE_FAST_MODEL,
     permissionMode: "bypassPermissions",
     callbacks: {
-      onAssistantContentUpdated: (chunk) => {
-        process.stdout.write(chunk);
+      onAssistantContentUpdated: (params) => {
+        process.stdout.write(params.chunk);
       },
       onGoalStateChange: (active, condition, elapsed) => {
         if (active) {

--- a/packages/agent-sdk/examples/hi.ts
+++ b/packages/agent-sdk/examples/hi.ts
@@ -5,8 +5,8 @@ import { Agent } from "../src/agent.js";
 // Create Agent instance
 const agent = await Agent.create({
   callbacks: {
-    onAssistantContentUpdated: (chunk: string) => {
-      process.stdout.write(chunk);
+    onAssistantContentUpdated: (params: { chunk: string }) => {
+      process.stdout.write(params.chunk);
     },
   },
 });

--- a/packages/agent-sdk/examples/hook-exitcode-blocking.ts
+++ b/packages/agent-sdk/examples/hook-exitcode-blocking.ts
@@ -212,8 +212,8 @@ async function demonstrateBlockingErrors(): Promise<void> {
       model: process.env.WAVE_FAST_MODEL,
       logger: console,
       callbacks: {
-        onAssistantContentUpdated: (chunk: string) => {
-          process.stdout.write(chunk);
+        onAssistantContentUpdated: (params: { chunk: string }) => {
+          process.stdout.write(params.chunk);
         },
       },
     });

--- a/packages/agent-sdk/examples/hook-exitcode-nonblocking.ts
+++ b/packages/agent-sdk/examples/hook-exitcode-nonblocking.ts
@@ -226,8 +226,8 @@ async function demonstrateNonBlockingErrors(): Promise<void> {
       model: process.env.WAVE_FAST_MODEL,
       logger: console,
       callbacks: {
-        onAssistantContentUpdated: (chunk: string) => {
-          process.stdout.write(chunk);
+        onAssistantContentUpdated: (params: { chunk: string }) => {
+          process.stdout.write(params.chunk);
         },
       },
     });

--- a/packages/agent-sdk/examples/hook-exitcode-success.ts
+++ b/packages/agent-sdk/examples/hook-exitcode-success.ts
@@ -160,8 +160,8 @@ async function demonstrateSuccessExitCodes(): Promise<void> {
       model: process.env.WAVE_FAST_MODEL,
       logger: console,
       callbacks: {
-        onAssistantContentUpdated: (chunk: string) => {
-          process.stdout.write(chunk);
+        onAssistantContentUpdated: (params: { chunk: string }) => {
+          process.stdout.write(params.chunk);
         },
       },
     });

--- a/packages/agent-sdk/examples/hook-json-input.ts
+++ b/packages/agent-sdk/examples/hook-json-input.ts
@@ -111,8 +111,8 @@ async function demonstrateHookJsonInput(): Promise<void> {
     const agent = await Agent.create({
       workdir: hookDir,
       callbacks: {
-        onAssistantContentUpdated: (chunk: string) => {
-          process.stdout.write(chunk);
+        onAssistantContentUpdated: (params: { chunk: string }) => {
+          process.stdout.write(params.chunk);
         },
       },
     });

--- a/packages/agent-sdk/examples/loop-command-demo.ts
+++ b/packages/agent-sdk/examples/loop-command-demo.ts
@@ -20,8 +20,8 @@ async function main() {
     workdir: tempDir,
     model: process.env.WAVE_FAST_MODEL, // Use a supported model
     callbacks: {
-      onAssistantContentUpdated: (chunk) => {
-        process.stdout.write(chunk);
+      onAssistantContentUpdated: (params) => {
+        process.stdout.write(params.chunk);
       },
       onToolBlockUpdated: (params) => {
         if (params.stage === "start") {

--- a/packages/agent-sdk/examples/modular-rules-basic.ts
+++ b/packages/agent-sdk/examples/modular-rules-basic.ts
@@ -79,8 +79,8 @@ paths:
         error: (...args: unknown[]) => console.error("[ERROR]", ...args),
       },
       callbacks: {
-        onAssistantContentUpdated: (chunk: string) => {
-          process.stdout.write(chunk);
+        onAssistantContentUpdated: (params: { chunk: string }) => {
+          process.stdout.write(params.chunk);
         },
       },
     });

--- a/packages/agent-sdk/examples/parallel-execution-demo.ts
+++ b/packages/agent-sdk/examples/parallel-execution-demo.ts
@@ -28,8 +28,8 @@ async function demonstrateParallelExecution(): Promise<void> {
       workdir,
       model: process.env.WAVE_FAST_MODEL,
       callbacks: {
-        onAssistantContentUpdated: (chunk: string) => {
-          process.stdout.write(chunk);
+        onAssistantContentUpdated: (params: { chunk: string }) => {
+          process.stdout.write(params.chunk);
         },
         onToolBlockUpdated: (params) => {
           const { id: toolId, name: toolName, stage } = params;

--- a/packages/agent-sdk/examples/permission-deny-config.ts
+++ b/packages/agent-sdk/examples/permission-deny-config.ts
@@ -48,8 +48,8 @@ async function main() {
           console.log(`❌ Tool Blocked: ${params.error}`);
         }
       },
-      onAssistantContentUpdated: (chunk) => {
-        process.stdout.write(chunk);
+      onAssistantContentUpdated: (params) => {
+        process.stdout.write(params.chunk);
       },
     },
   });

--- a/packages/agent-sdk/examples/rate-limit-example.ts
+++ b/packages/agent-sdk/examples/rate-limit-example.ts
@@ -44,8 +44,8 @@ const customFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
 const agent = await Agent.create({
   fetch: customFetch,
   callbacks: {
-    onAssistantContentUpdated: (chunk: string) => {
-      process.stdout.write(chunk);
+    onAssistantContentUpdated: (params: { chunk: string }) => {
+      process.stdout.write(params.chunk);
     },
   },
 });

--- a/packages/agent-sdk/examples/read-tool-image-test.ts
+++ b/packages/agent-sdk/examples/read-tool-image-test.ts
@@ -165,9 +165,9 @@ async function testWithAgent() {
         }
       },
 
-      onAssistantContentUpdated: (chunk) => {
+      onAssistantContentUpdated: (params) => {
         // Show a small sample of the response
-        if (chunk.length > 0) {
+        if (params.chunk.length > 0) {
           process.stdout.write(".");
         }
       },

--- a/packages/agent-sdk/examples/rewind-demo.ts
+++ b/packages/agent-sdk/examples/rewind-demo.ts
@@ -25,8 +25,8 @@ async function main() {
       onUserMessageAdded: (params) => {
         console.log(`👤 User: ${params.content}`);
       },
-      onAssistantContentUpdated: (chunk) => {
-        process.stdout.write(chunk);
+      onAssistantContentUpdated: (params) => {
+        process.stdout.write(params.chunk);
       },
       onAssistantMessageAdded: () => {
         console.log("\n🤖 Assistant:");

--- a/packages/agent-sdk/examples/skill-args-bash.ts
+++ b/packages/agent-sdk/examples/skill-args-bash.ts
@@ -50,8 +50,8 @@ This skill was invoked with arguments and executed bash commands.
       model: process.env.WAVE_FAST_MODEL, // Using a fast model as suggested
       workdir: tempDir,
       callbacks: {
-        onAssistantContentUpdated: (chunk: string) => {
-          process.stdout.write(chunk);
+        onAssistantContentUpdated: (params: { chunk: string }) => {
+          process.stdout.write(params.chunk);
         },
         onToolBlockUpdated: (params) => {
           if (params.result) {

--- a/packages/agent-sdk/examples/skillDemo.ts
+++ b/packages/agent-sdk/examples/skillDemo.ts
@@ -61,8 +61,8 @@ Template Variables:
         onAssistantMessageAdded: () => {
           console.log("Assistant message started");
         },
-        onAssistantContentUpdated: (chunk: string) => {
-          process.stdout.write(chunk);
+        onAssistantContentUpdated: (params: { chunk: string }) => {
+          process.stdout.write(params.chunk);
         },
         onToolBlockUpdated: (params) => {
           if (params.result) {

--- a/packages/agent-sdk/examples/subagent-execution.ts
+++ b/packages/agent-sdk/examples/subagent-execution.ts
@@ -84,8 +84,8 @@ This file will be analyzed by the file-analyzer subagent to test the real execut
       onAssistantMessageAdded: () => {
         console.log("Assistant message started");
       },
-      onAssistantContentUpdated: (chunk: string) => {
-        process.stdout.write(chunk);
+      onAssistantContentUpdated: (params: { chunk: string }) => {
+        process.stdout.write(params.chunk);
       },
       onToolBlockUpdated: (params) => {
         if (params.stage === "running") {

--- a/packages/agent-sdk/examples/task-management-demo.ts
+++ b/packages/agent-sdk/examples/task-management-demo.ts
@@ -9,8 +9,8 @@ async function main() {
   const agent = await Agent.create({
     model: process.env.WAVE_FAST_MODEL, // Use a fast model for testing
     callbacks: {
-      onAssistantContentUpdated: (chunk) => {
-        process.stdout.write(chunk);
+      onAssistantContentUpdated: (params) => {
+        process.stdout.write(params.chunk);
       },
       onToolBlockUpdated: (params) => {
         if (params.stage === "start") {

--- a/packages/agent-sdk/examples/verify-plan-mode-bypass.ts
+++ b/packages/agent-sdk/examples/verify-plan-mode-bypass.ts
@@ -31,8 +31,8 @@ async function main() {
       return { behavior: "allow" };
     },
     callbacks: {
-      onAssistantContentUpdated: (chunk: string) => {
-        process.stdout.write(chunk);
+      onAssistantContentUpdated: (params: { chunk: string }) => {
+        process.stdout.write(params.chunk);
       },
       onPermissionModeChange: (mode: string) => {
         modeChangeCount++;

--- a/packages/agent-sdk/examples/web-fetch-demo.ts
+++ b/packages/agent-sdk/examples/web-fetch-demo.ts
@@ -28,8 +28,8 @@ async function setupTest() {
       onAssistantMessageAdded: () => {
         console.log("\n🤖 Assistant:");
       },
-      onAssistantContentUpdated: (chunk: string) => {
-        process.stdout.write(chunk);
+      onAssistantContentUpdated: (params: { chunk: string }) => {
+        process.stdout.write(params.chunk);
       },
       onToolBlockUpdated: (params) => {
         if (params.stage === "start") {

--- a/packages/agent-sdk/examples/workflow-demo.ts
+++ b/packages/agent-sdk/examples/workflow-demo.ts
@@ -66,8 +66,8 @@ async function main() {
     model: process.env.WAVE_FAST_MODEL,
     workdir: tempDir,
     callbacks: {
-      onAssistantContentUpdated: (chunk) => {
-        process.stdout.write(chunk);
+      onAssistantContentUpdated: (params) => {
+        process.stdout.write(params.chunk);
       },
       onToolBlockUpdated: (params) => {
         if (params.stage === "start") {

--- a/packages/agent-sdk/src/managers/messageManager.ts
+++ b/packages/agent-sdk/src/managers/messageManager.ts
@@ -43,17 +43,19 @@ export interface MessageManagerCallbacks {
   // MODIFIED: Remove arguments for separation of concerns
   onAssistantMessageAdded?: (messageId: string) => void;
   // NEW: Streaming content callback - FR-001: receives chunk and accumulated content
-  onAssistantContentUpdated?: (
-    messageId: string,
-    chunk: string,
-    accumulated: string,
-  ) => void;
+  onAssistantContentUpdated?: (params: {
+    messageId: string;
+    chunk: string;
+    accumulated: string;
+    stage: "streaming" | "end";
+  }) => void;
   // NEW: Streaming reasoning callback
-  onAssistantReasoningUpdated?: (
-    messageId: string,
-    chunk: string,
-    accumulated: string,
-  ) => void;
+  onAssistantReasoningUpdated?: (params: {
+    messageId: string;
+    chunk: string;
+    accumulated: string;
+    stage: "streaming" | "end";
+  }) => void;
   onToolBlockUpdated?: (params: ToolBlockUpdateCallbackParams) => void;
   onErrorBlockAdded?: (error: string) => void;
   onCompactBlockAdded?: (content: string) => void;
@@ -469,7 +471,7 @@ export class MessageManager {
 
   public updateToolBlock(params: AgentToolBlockUpdateParams): void {
     // Finalize any streaming text/reasoning blocks before adding/updating a tool block
-    this.finalizeCurrentStreamingBlocks();
+    this.finalizeStreamingBlocks();
     const { messages: newMessages, messageId: resolvedMessageId } =
       updateToolBlockInMessage({
         messages: this.messages,
@@ -497,7 +499,7 @@ export class MessageManager {
     params: Omit<AgentToolBlockUpdateParams, "id">,
   ): string {
     // Finalize any streaming text/reasoning blocks before adding a tool block
-    this.finalizeCurrentStreamingBlocks();
+    this.finalizeStreamingBlocks();
     const { messages: newMessages, toolBlockId } =
       addToolBlockToMessageInMessages(this.messages, messageId, params);
     this.setMessages(newMessages);
@@ -682,6 +684,49 @@ export class MessageManager {
   }
 
   /**
+   * Finalize a streaming block of the given type by setting its stage to "end".
+   * Fires the corresponding incremental callback with chunk="" to signal finalization.
+   * Does NOT call onMessagesChange — the caller is responsible for that.
+   * Returns true if a block was finalized.
+   */
+  private finalizeStreamingBlock(
+    lastMessage: Message,
+    type: "text" | "reasoning",
+  ): boolean {
+    const index = lastMessage.blocks.findIndex(
+      (block) =>
+        block.type === type &&
+        (block as { stage?: string }).stage === "streaming",
+    );
+    if (index < 0) return false;
+
+    const block = lastMessage.blocks[index] as {
+      type: "text" | "reasoning";
+      content: string;
+      stage?: string;
+    };
+    lastMessage.blocks[index] = {
+      type: block.type,
+      content: block.content,
+      stage: "end" as const,
+    };
+
+    // Fire incremental callback to signal finalization
+    const callbackParams = {
+      messageId: lastMessage.id,
+      chunk: "",
+      accumulated: block.content,
+      stage: "end" as const,
+    };
+    if (type === "text") {
+      this.callbacks.onAssistantContentUpdated?.(callbackParams);
+    } else {
+      this.callbacks.onAssistantReasoningUpdated?.(callbackParams);
+    }
+    return true;
+  }
+
+  /**
    * Update the current assistant message content during streaming
    * This method updates the last assistant message's content without creating a new message
    * FR-001: Tracks and provides both chunk (new content) and accumulated (total content)
@@ -693,23 +738,7 @@ export class MessageManager {
     if (lastMessage.role !== "assistant") return;
 
     // Finalize any streaming reasoning blocks before text content arrives
-    const reasoningIndex = lastMessage.blocks.findIndex(
-      (block) =>
-        block.type === "reasoning" &&
-        (block as { stage?: string }).stage === "streaming",
-    );
-    if (reasoningIndex >= 0) {
-      const reasoningBlock = lastMessage.blocks[reasoningIndex] as {
-        type: "reasoning";
-        content: string;
-        stage?: string;
-      };
-      lastMessage.blocks[reasoningIndex] = {
-        type: "reasoning" as const,
-        content: reasoningBlock.content,
-        stage: "end" as const,
-      };
-    }
+    this.finalizeStreamingBlock(lastMessage, "reasoning");
 
     // Get the current content to calculate the chunk
     const textBlockIndex = lastMessage.blocks.findIndex(
@@ -745,11 +774,12 @@ export class MessageManager {
     }
 
     // FR-001: Trigger callbacks with chunk and accumulated content
-    this.callbacks.onAssistantContentUpdated?.(
-      lastMessage.id,
+    this.callbacks.onAssistantContentUpdated?.({
+      messageId: lastMessage.id,
       chunk,
-      newAccumulatedContent,
-    );
+      accumulated: newAccumulatedContent,
+      stage: "streaming",
+    });
 
     // Note: Subagent-specific callbacks are now handled by SubagentManager
 
@@ -767,23 +797,7 @@ export class MessageManager {
     if (lastMessage.role !== "assistant") return;
 
     // Finalize any streaming text blocks before reasoning content arrives
-    const textIndex = lastMessage.blocks.findIndex(
-      (block) =>
-        block.type === "text" &&
-        (block as { stage?: string }).stage === "streaming",
-    );
-    if (textIndex >= 0) {
-      const textBlock = lastMessage.blocks[textIndex] as {
-        type: "text";
-        content: string;
-        stage?: string;
-      };
-      lastMessage.blocks[textIndex] = {
-        type: "text" as const,
-        content: textBlock.content,
-        stage: "end" as const,
-      };
-    }
+    this.finalizeStreamingBlock(lastMessage, "text");
 
     // Get the current reasoning content to calculate the chunk
     const reasoningBlockIndex = lastMessage.blocks.findIndex(
@@ -819,46 +833,33 @@ export class MessageManager {
     }
 
     // Trigger callbacks with chunk and accumulated reasoning content
-    this.callbacks.onAssistantReasoningUpdated?.(
-      lastMessage.id,
+    this.callbacks.onAssistantReasoningUpdated?.({
+      messageId: lastMessage.id,
       chunk,
-      newAccumulatedReasoning,
-    );
+      accumulated: newAccumulatedReasoning,
+      stage: "streaming",
+    });
 
     this.callbacks.onMessagesChange?.([...this.messages]); // Still need to notify of changes
   }
 
   /**
-   * Public wrapper for finalizeCurrentStreamingBlocks.
-   * Finalizes text/reasoning blocks after streaming completes (e.g. final response with no tools).
+   * Finalize streaming text/reasoning blocks by setting their stage to "end".
+   * Called when a new block (e.g. tool) is appended during streaming, or when streaming completes.
+   * Fires incremental callbacks for each finalized block.
    */
   public finalizeStreamingBlocks(): void {
-    this.finalizeCurrentStreamingBlocks();
-  }
-
-  /**
-   * Finalize streaming text/reasoning blocks by setting their stage to "end".
-   * Called when a new block (e.g. tool) is appended during streaming.
-   */
-  private finalizeCurrentStreamingBlocks(): void {
     if (this.messages.length === 0) return;
     const lastMessage = this.messages[this.messages.length - 1];
     if (lastMessage.role !== "assistant") return;
 
-    const newBlocks = lastMessage.blocks.map((block) => {
-      if (
-        (block.type === "text" || block.type === "reasoning") &&
-        block.stage === "streaming"
-      ) {
-        return { ...block, stage: "end" as const };
-      }
-      return block;
-    });
+    const textFinalized = this.finalizeStreamingBlock(lastMessage, "text");
+    const reasoningFinalized = this.finalizeStreamingBlock(
+      lastMessage,
+      "reasoning",
+    );
 
-    // Only update if something changed
-    const changed = newBlocks.some((b, i) => b !== lastMessage.blocks[i]);
-    if (changed) {
-      lastMessage.blocks = newBlocks;
+    if (textFinalized || reasoningFinalized) {
       this.callbacks.onMessagesChange?.([...this.messages]);
     }
   }

--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -38,19 +38,21 @@ export interface SubagentManagerCallbacks {
     messageId: string,
   ) => void;
   /** Triggered during subagent content streaming updates */
-  onSubagentAssistantContentUpdated?: (
-    subagentId: string,
-    messageId: string,
-    chunk: string,
-    accumulated: string,
-  ) => void;
+  onSubagentAssistantContentUpdated?: (params: {
+    subagentId: string;
+    messageId: string;
+    chunk: string;
+    accumulated: string;
+    stage: "streaming" | "end";
+  }) => void;
   /** Triggered during subagent reasoning streaming updates */
-  onSubagentAssistantReasoningUpdated?: (
-    subagentId: string,
-    messageId: string,
-    chunk: string,
-    accumulated: string,
-  ) => void;
+  onSubagentAssistantReasoningUpdated?: (params: {
+    subagentId: string;
+    messageId: string;
+    chunk: string;
+    accumulated: string;
+    stage: "streaming" | "end";
+  }) => void;
   /** Triggered when subagent tool block is updated */
   onSubagentToolBlockUpdated?: (
     subagentId: string,
@@ -789,34 +791,32 @@ export class SubagentManager {
         }
       },
 
-      onAssistantContentUpdated: (
-        messageId: string,
-        chunk: string,
-        accumulated: string,
-      ) => {
+      onAssistantContentUpdated: (params: {
+        messageId: string;
+        chunk: string;
+        accumulated: string;
+        stage: "streaming" | "end";
+      }) => {
         // Forward assistant content updates to parent via SubagentManager callbacks
         if (this.callbacks?.onSubagentAssistantContentUpdated) {
-          this.callbacks.onSubagentAssistantContentUpdated(
+          this.callbacks.onSubagentAssistantContentUpdated({
+            ...params,
             subagentId,
-            messageId,
-            chunk,
-            accumulated,
-          );
+          });
         }
       },
-      onAssistantReasoningUpdated: (
-        messageId: string,
-        chunk: string,
-        accumulated: string,
-      ) => {
+      onAssistantReasoningUpdated: (params: {
+        messageId: string;
+        chunk: string;
+        accumulated: string;
+        stage: "streaming" | "end";
+      }) => {
         // Forward assistant reasoning updates to parent via SubagentManager callbacks
         if (this.callbacks?.onSubagentAssistantReasoningUpdated) {
-          this.callbacks.onSubagentAssistantReasoningUpdated(
+          this.callbacks.onSubagentAssistantReasoningUpdated({
+            ...params,
             subagentId,
-            messageId,
-            chunk,
-            accumulated,
-          );
+          });
         }
       },
 

--- a/packages/agent-sdk/tests/managers/messageManager.streaming.test.ts
+++ b/packages/agent-sdk/tests/managers/messageManager.streaming.test.ts
@@ -28,29 +28,32 @@ describe("MessageManager - Streaming Functionality", () => {
       // First update
       messageManager.updateCurrentMessageContent("Hello");
 
-      expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith(
+      expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith({
         messageId,
-        "Hello",
-        "Hello",
-      );
+        chunk: "Hello",
+        accumulated: "Hello",
+        stage: "streaming",
+      });
 
       // Second update (should calculate chunk correctly)
       messageManager.updateCurrentMessageContent("Hello, world!");
 
-      expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith(
+      expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith({
         messageId,
-        ", world!",
-        "Hello, world!",
-      );
+        chunk: ", world!",
+        accumulated: "Hello, world!",
+        stage: "streaming",
+      });
 
       // Third update (adding more content)
       messageManager.updateCurrentMessageContent("Hello, world! How are you?");
 
-      expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith(
+      expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith({
         messageId,
-        " How are you?",
-        "Hello, world! How are you?",
-      );
+        chunk: " How are you?",
+        accumulated: "Hello, world! How are you?",
+        stage: "streaming",
+      });
 
       // Verify total calls
       expect(mockOnAssistantContentUpdated).toHaveBeenCalledTimes(3);
@@ -76,11 +79,12 @@ describe("MessageManager - Streaming Functionality", () => {
       // Update with empty content
       messageManager.updateCurrentMessageContent("");
 
-      expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith(
+      expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith({
         messageId,
-        "",
-        "",
-      );
+        chunk: "",
+        accumulated: "",
+        stage: "streaming",
+      });
     });
 
     it("should create new text block when none exists", () => {
@@ -102,11 +106,12 @@ describe("MessageManager - Streaming Functionality", () => {
       // Update content (should create new text block)
       messageManager.updateCurrentMessageContent("New content");
 
-      expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith(
+      expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith({
         messageId,
-        "New content",
-        "New content",
-      );
+        chunk: "New content",
+        accumulated: "New content",
+        stage: "streaming",
+      });
 
       // Verify the message has the content
       const messages = messageManager.getMessages();
@@ -156,6 +161,159 @@ describe("MessageManager - Streaming Functionality", () => {
       messageManager.updateCurrentMessageContent("Should not work");
 
       expect(mockOnAssistantContentUpdated).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("stage='end' callback on block finalization", () => {
+    it("updateCurrentMessageContent fires onAssistantReasoningUpdated with stage='end' when finalizing streaming reasoning", () => {
+      const mockContentUpdated = vi.fn();
+      const mockReasoningUpdated = vi.fn();
+
+      const callbacks: MessageManagerCallbacks = {
+        onAssistantContentUpdated: mockContentUpdated,
+        onAssistantReasoningUpdated: mockReasoningUpdated,
+      };
+
+      const messageManager = new MessageManager(container, {
+        callbacks,
+        workdir: "/test",
+      });
+
+      messageManager.addAssistantMessage();
+      const messageId = messageManager.getMessages().slice(-1)[0].id;
+
+      // First, create a streaming reasoning block
+      messageManager.updateCurrentMessageReasoning("Let me think...");
+
+      // Now update content — should finalize the reasoning block
+      messageManager.updateCurrentMessageContent("Hello");
+
+      // Reasoning should have been finalized with stage="end"
+      const reasoningCalls = mockReasoningUpdated.mock.calls;
+      const finalizeCall = reasoningCalls[reasoningCalls.length - 1];
+      expect(finalizeCall).toEqual([
+        {
+          messageId,
+          chunk: "",
+          accumulated: "Let me think...",
+          stage: "end",
+        },
+      ]);
+
+      // Content should fire with stage="streaming"
+      expect(mockContentUpdated).toHaveBeenCalledWith({
+        messageId,
+        chunk: "Hello",
+        accumulated: "Hello",
+        stage: "streaming",
+      });
+    });
+
+    it("updateCurrentMessageReasoning fires onAssistantContentUpdated with stage='end' when finalizing streaming text", () => {
+      const mockContentUpdated = vi.fn();
+      const mockReasoningUpdated = vi.fn();
+
+      const callbacks: MessageManagerCallbacks = {
+        onAssistantContentUpdated: mockContentUpdated,
+        onAssistantReasoningUpdated: mockReasoningUpdated,
+      };
+
+      const messageManager = new MessageManager(container, {
+        callbacks,
+        workdir: "/test",
+      });
+
+      messageManager.addAssistantMessage();
+      const messageId = messageManager.getMessages().slice(-1)[0].id;
+
+      // First, create a streaming text block
+      messageManager.updateCurrentMessageContent("Hello world");
+
+      // Now update reasoning — should finalize the text block
+      messageManager.updateCurrentMessageReasoning("Thinking...");
+
+      // Content should have been finalized with stage="end"
+      const contentCalls = mockContentUpdated.mock.calls;
+      const finalizeCall = contentCalls[contentCalls.length - 1];
+      expect(finalizeCall).toEqual([
+        {
+          messageId,
+          chunk: "",
+          accumulated: "Hello world",
+          stage: "end",
+        },
+      ]);
+
+      // Reasoning should fire with stage="streaming"
+      expect(mockReasoningUpdated).toHaveBeenCalledWith({
+        messageId,
+        chunk: "Thinking...",
+        accumulated: "Thinking...",
+        stage: "streaming",
+      });
+    });
+
+    it("finalizeStreamingBlocks fires callback with stage='end' for remaining streaming block", () => {
+      const mockContentUpdated = vi.fn();
+      const mockReasoningUpdated = vi.fn();
+
+      const callbacks: MessageManagerCallbacks = {
+        onAssistantContentUpdated: mockContentUpdated,
+        onAssistantReasoningUpdated: mockReasoningUpdated,
+      };
+
+      const messageManager = new MessageManager(container, {
+        callbacks,
+        workdir: "/test",
+      });
+
+      messageManager.addAssistantMessage();
+      const messageId = messageManager.getMessages().slice(-1)[0].id;
+
+      // Create streaming text block, then reasoning (which finalizes text)
+      messageManager.updateCurrentMessageContent("Some text");
+      messageManager.updateCurrentMessageReasoning("Some reasoning");
+
+      mockContentUpdated.mockClear();
+      mockReasoningUpdated.mockClear();
+
+      // Finalize remaining streaming blocks (only reasoning is still streaming)
+      messageManager.finalizeStreamingBlocks();
+
+      // Text was already finalized by updateCurrentMessageReasoning, so no callback
+      expect(mockContentUpdated).not.toHaveBeenCalled();
+      // Reasoning is finalized by finalizeStreamingBlocks
+      expect(mockReasoningUpdated).toHaveBeenCalledWith({
+        messageId,
+        chunk: "",
+        accumulated: "Some reasoning",
+        stage: "end",
+      });
+    });
+
+    it("normal streaming fires callbacks with stage='streaming'", () => {
+      const mockContentUpdated = vi.fn();
+
+      const callbacks: MessageManagerCallbacks = {
+        onAssistantContentUpdated: mockContentUpdated,
+      };
+
+      const messageManager = new MessageManager(container, {
+        callbacks,
+        workdir: "/test",
+      });
+
+      messageManager.addAssistantMessage();
+      const messageId = messageManager.getMessages().slice(-1)[0].id;
+
+      messageManager.updateCurrentMessageContent("Hello");
+
+      expect(mockContentUpdated).toHaveBeenCalledWith({
+        messageId,
+        chunk: "Hello",
+        accumulated: "Hello",
+        stage: "streaming",
+      });
     });
   });
 });

--- a/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
@@ -218,18 +218,20 @@ describe("SubagentManager - Backgrounding Coverage", () => {
     const lastCall =
       MessageManagerMock.mock.calls[MessageManagerMock.mock.calls.length - 1];
     const passedCallbacks = lastCall[1].callbacks;
-    passedCallbacks.onAssistantReasoningUpdated?.(
-      "msg-test-id",
-      "chunk",
-      "accumulated",
-    );
+    passedCallbacks.onAssistantReasoningUpdated?.({
+      messageId: "msg-test-id",
+      chunk: "chunk",
+      accumulated: "accumulated",
+      stage: "streaming",
+    });
 
-    expect(onSubagentAssistantReasoningUpdated).toHaveBeenCalledWith(
-      instance.subagentId,
-      "msg-test-id",
-      "chunk",
-      "accumulated",
-    );
+    expect(onSubagentAssistantReasoningUpdated).toHaveBeenCalledWith({
+      subagentId: instance.subagentId,
+      messageId: "msg-test-id",
+      chunk: "chunk",
+      accumulated: "accumulated",
+      stage: "streaming",
+    });
   });
 
   it("should create a log file and log tool execution for background subagent", async () => {

--- a/packages/agent-sdk/tests/managers/subagentManager.callbacks.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.callbacks.test.ts
@@ -309,13 +309,14 @@ describe("SubagentManager - Callback Integration", () => {
       const newContent = "Starting to stream content...";
       instance.messageManager.updateCurrentMessageContent(newContent);
 
-      // Verify that the subagent callback was called with the subagent ID, messageId, chunk, and accumulated content
-      expect(callbacks.onSubagentAssistantContentUpdated).toHaveBeenCalledWith(
-        instance.subagentId,
-        expect.any(String), // messageId
-        expect.any(String), // chunk
-        newContent, // accumulated content
-      );
+      // Verify that the subagent callback was called with the object parameter
+      expect(callbacks.onSubagentAssistantContentUpdated).toHaveBeenCalledWith({
+        subagentId: instance.subagentId,
+        messageId: expect.any(String),
+        chunk: expect.any(String),
+        accumulated: newContent,
+        stage: "streaming",
+      });
 
       // Verify that the regular callback was also called
       // Note: onAssistantContentUpdated is not expected to be called in this context
@@ -360,10 +361,10 @@ describe("SubagentManager - Callback Integration", () => {
       )!;
       expect(mockedCallback.mock.calls).toBeDefined();
       const calls = mockedCallback.mock.calls!;
-      expect(calls[0]![0]).toBe(instance.subagentId); // subagentId
-      expect(calls[0]![3]).toBe("Hello world"); // accumulated content
-      expect(calls[1]![0]).toBe(instance.subagentId); // subagentId
-      expect(calls[1]![3]).toBe("Hello world!"); // accumulated content
+      expect(calls[0]![0].subagentId).toBe(instance.subagentId);
+      expect(calls[0]![0].accumulated).toBe("Hello world");
+      expect(calls[1]![0].subagentId).toBe(instance.subagentId);
+      expect(calls[1]![0].accumulated).toBe("Hello world!");
     });
   });
 

--- a/packages/code/src/acp/agent.ts
+++ b/packages/code/src/acp/agent.ts
@@ -224,10 +224,10 @@ export class WaveAcpAgent implements AcpAgent {
         );
       },
       callbacks: {
-        onAssistantContentUpdated: (messageId: string, chunk: string) =>
-          callbacks.onAssistantContentUpdated?.(messageId, chunk, ""),
-        onAssistantReasoningUpdated: (messageId: string, chunk: string) =>
-          callbacks.onAssistantReasoningUpdated?.(messageId, chunk, ""),
+        onAssistantContentUpdated: (params) =>
+          callbacks.onAssistantContentUpdated?.(params),
+        onAssistantReasoningUpdated: (params) =>
+          callbacks.onAssistantReasoningUpdated?.(params),
         onToolBlockUpdated: (params: unknown) => {
           const cb = callbacks.onToolBlockUpdated as
             | ((params: unknown) => void)
@@ -1127,26 +1127,32 @@ export class WaveAcpAgent implements AcpAgent {
     >();
     return {
       callbacks: {
-        onAssistantContentUpdated: (_messageId: string, chunk: string) => {
+        onAssistantContentUpdated: (params: {
+          chunk: string;
+          stage: "streaming" | "end";
+        }) => {
           this.connection.sessionUpdate({
             sessionId: sessionRef.id as AcpSessionId,
             update: {
               sessionUpdate: "agent_message_chunk",
               content: {
                 type: "text",
-                text: chunk,
+                text: params.chunk,
               },
             },
           });
         },
-        onAssistantReasoningUpdated: (_messageId: string, chunk: string) => {
+        onAssistantReasoningUpdated: (params: {
+          chunk: string;
+          stage: "streaming" | "end";
+        }) => {
           this.connection.sessionUpdate({
             sessionId: sessionRef.id as AcpSessionId,
             update: {
               sessionUpdate: "agent_thought_chunk",
               content: {
                 type: "text",
-                text: chunk,
+                text: params.chunk,
               },
             },
           });

--- a/packages/code/src/print-cli.ts
+++ b/packages/code/src/print-cli.ts
@@ -75,14 +75,14 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
       isReasoning = false;
       isContent = false;
     },
-    onAssistantReasoningUpdated: (_messageId: string, chunk: string) => {
+    onAssistantReasoningUpdated: (params: { chunk: string }) => {
       if (!isReasoning) {
         process.stdout.write("\n💭 Reasoning:\n");
         isReasoning = true;
       }
-      process.stdout.write(chunk);
+      process.stdout.write(params.chunk);
     },
-    onAssistantContentUpdated: (_messageId: string, chunk: string) => {
+    onAssistantContentUpdated: (params: { chunk: string }) => {
       if (!isContent) {
         if (isReasoning) {
           process.stdout.write("\n\n📝 Response:\n");
@@ -91,7 +91,7 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
         }
         isContent = true;
       }
-      process.stdout.write(chunk);
+      process.stdout.write(params.chunk);
     },
 
     // Tool block callback - display tool name when tool starts

--- a/packages/code/tests/acp/agent.test.ts
+++ b/packages/code/tests/acp/agent.test.ts
@@ -1355,11 +1355,12 @@ describe("WaveAcpAgent", () => {
 
     await agent.newSession({ cwd: "/test", mcpServers: [] });
 
-    capturedCallbacks!.onAssistantContentUpdated!(
-      "msg-test-id",
-      "chunk",
-      "chunk",
-    );
+    capturedCallbacks!.onAssistantContentUpdated!({
+      messageId: "msg-test-id",
+      chunk: "chunk",
+      accumulated: "chunk",
+      stage: "streaming",
+    });
     expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
         update: expect.objectContaining({
@@ -1369,11 +1370,12 @@ describe("WaveAcpAgent", () => {
       }),
     );
 
-    capturedCallbacks!.onAssistantReasoningUpdated!(
-      "msg-test-id",
-      "thought",
-      "thought",
-    );
+    capturedCallbacks!.onAssistantReasoningUpdated!({
+      messageId: "msg-test-id",
+      chunk: "thought",
+      accumulated: "thought",
+      stage: "streaming",
+    });
     expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
         update: expect.objectContaining({

--- a/packages/code/tests/print-cli.test.ts
+++ b/packages/code/tests/print-cli.test.ts
@@ -265,11 +265,13 @@ test("subagent content callbacks are not registered in print mode", async () => 
   expect(capturedCallbacks?.onSubagentUserMessageAdded).toBeUndefined();
 
   // Calling them as undefined should not produce output
-  capturedCallbacks?.onSubagentAssistantContentUpdated?.(
-    "test-subagent-123",
-    "Hello from subagent",
-    "Hello from subagent",
-  );
+  capturedCallbacks?.onSubagentAssistantContentUpdated?.({
+    subagentId: "test-subagent-123",
+    messageId: "msg-123",
+    chunk: "Hello from subagent",
+    accumulated: "Hello from subagent",
+    stage: "streaming",
+  });
   expect(stdoutSpy).not.toHaveBeenCalled();
 
   // Error callback still works
@@ -403,41 +405,45 @@ test("reasoning callbacks output correctly", async () => {
   await startPrintCli({ message: "test message" });
 
   // 1. Trigger onAssistantReasoningUpdated and verify the output
-  capturedCallbacks?.onAssistantReasoningUpdated?.(
-    "msg-test-id",
-    "Thinking...",
-    "Thinking...",
-  );
+  capturedCallbacks?.onAssistantReasoningUpdated?.({
+    messageId: "msg-test-id",
+    chunk: "Thinking...",
+    accumulated: "Thinking...",
+    stage: "streaming",
+  });
   expect(stdoutSpy).toHaveBeenCalledWith("\n💭 Reasoning:\n");
   expect(stdoutSpy).toHaveBeenCalledWith("Thinking...");
 
   // Verify header is not printed again
   stdoutSpy.mockClear();
-  capturedCallbacks?.onAssistantReasoningUpdated?.(
-    "msg-test-id",
-    " more thinking",
-    "Thinking... more thinking",
-  );
+  capturedCallbacks?.onAssistantReasoningUpdated?.({
+    messageId: "msg-test-id",
+    chunk: " more thinking",
+    accumulated: "Thinking... more thinking",
+    stage: "streaming",
+  });
   expect(stdoutSpy).not.toHaveBeenCalledWith("\n💭 Reasoning:\n");
   expect(stdoutSpy).toHaveBeenCalledWith(" more thinking");
 
   // 2. Trigger onAssistantContentUpdated after reasoning and verify the "📝 Response:" header
   stdoutSpy.mockClear();
-  capturedCallbacks?.onAssistantContentUpdated?.(
-    "msg-test-id",
-    "Hello!",
-    "Hello!",
-  );
+  capturedCallbacks?.onAssistantContentUpdated?.({
+    messageId: "msg-test-id",
+    chunk: "Hello!",
+    accumulated: "Hello!",
+    stage: "streaming",
+  });
   expect(stdoutSpy).toHaveBeenCalledWith("\n\n📝 Response:\n");
   expect(stdoutSpy).toHaveBeenCalledWith("Hello!");
 
   // Verify header is not printed again
   stdoutSpy.mockClear();
-  capturedCallbacks?.onAssistantContentUpdated?.(
-    "msg-test-id",
-    " world",
-    "Hello! world",
-  );
+  capturedCallbacks?.onAssistantContentUpdated?.({
+    messageId: "msg-test-id",
+    chunk: " world",
+    accumulated: "Hello! world",
+    stage: "streaming",
+  });
   expect(stdoutSpy).not.toHaveBeenCalledWith("\n\n📝 Response:\n");
   expect(stdoutSpy).toHaveBeenCalledWith(" world");
 


### PR DESCRIPTION
- Change onAssistantContentUpdated/onAssistantReasoningUpdated from positional
  args (messageId, chunk, accumulated) to object params with stage field
- Extract finalizeStreamingBlock() helper to unify three finalize locations
- Fire callbacks with stage='end' when streaming blocks transition to end
- Remove finalizeCurrentStreamingBlocks private method, make public
- Update all consumers (ACP, subagent, print-cli) to forward stage param
- Update ~30 example files and all test files for new signature
