### PR TITLE
fix(ci): add test:coverage script to vsce package

### DIFF
--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -105,6 +105,7 @@
     "type-check": "tsc --noEmit && tsc -p webview --noEmit && tsc -p e2e --noEmit",
     "pretest": "pnpm run type-check && pnpm run compile",
     "test": "vitest run && playwright test --project=chromium",
+    "test:coverage": "vitest run --coverage --reporter=dot && playwright test --project=chromium",
     "pretest:demo": "pnpm run type-check && pnpm run compile",
     "test:demo": "playwright test --project=demo",
     "preinstall:vsix": "pnpm run package",


### PR DESCRIPTION
vsce tests (vitest + playwright) were silently skipped in CI because
the pipeline runs 'pnpm -r test:coverage' but vsce only had a 'test'
script. Add test:coverage to match agent-sdk and code packages.
