### PR TITLE
fix(ci): build agent-sdk before vsce test:demo in pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Install Playwright Chromium
         run: pnpm -F wave-vsce exec playwright install chromium
 
+      - name: Build agent-sdk
+        run: pnpm -F wave-agent-sdk build
+
       - name: Generate screenshots
         run: pnpm -F wave-vsce run test:demo
 


### PR DESCRIPTION
The pages workflow's `test:demo` step triggers a `pretest:demo` hook that runs `type-check`, which requires `wave-agent-sdk` built type declarations. The workflow was missing the SDK build step, causing `Cannot find module 'wave-agent-sdk'` errors.

Adds `pnpm -F wave-agent-sdk build` before the screenshot generation step.