### PR TITLE
fix(ci): copy screenshots to docs/public for VitePress

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Install Playwright Chromium
         run: pnpm -F wave-vsce exec playwright install chromium
 
+      - name: Build agent-sdk
+        run: pnpm -F wave-agent-sdk build
+
       - name: Generate screenshots
         run: pnpm -F wave-vsce run test:demo
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,6 +54,11 @@ jobs:
       - name: Generate screenshots
         run: pnpm -F wave-vsce run test:demo
 
+      - name: Copy screenshots to docs
+        run: |
+          mkdir -p docs/public/screenshots
+          cp -r packages/vsce/docs/public/screenshots/* docs/public/screenshots/ 2>/dev/null || true
+
       - name: Build VitePress
         run: pnpm run docs:build
 


### PR DESCRIPTION
Demo tests save screenshots to relative paths that resolve to `packages/vsce/docs/public/screenshots/` when run via `pnpm -F wave-vsce`. This adds a step to copy them to the root `docs/public/screenshots/` for VitePress to find them.

Fixes the VitePress build error: `Rollup failed to resolve import "/screenshots/spec-welcome.png"`