### PR TITLE
fix(subagent): log LLM API errors to subagent log files

### DIFF
--- a/packages/agent-sdk/src/managers/forkedAgentManager.ts
+++ b/packages/agent-sdk/src/managers/forkedAgentManager.ts
@@ -138,7 +138,7 @@ export class ForkedAgentManager {
             `[${new Date().toISOString()}] Final response:\n${result}\n`,
           );
           entry.logStream.write(
-            `[${new Date().toISOString()}] Agent completed successfully\n`,
+            `[${new Date().toISOString()}] Agent completed\n`,
           );
           entry.logStream.end();
         }

--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -631,7 +631,7 @@ export class SubagentManager {
           );
         }
         instance.logStream?.write(
-          `[${new Date().toISOString()}] Agent completed successfully\n`,
+          `[${new Date().toISOString()}] Agent completed\n`,
         );
         instance.logStream?.end();
         const task = backgroundTaskManager.getTask(instance.backgroundTaskId);
@@ -874,6 +874,15 @@ export class SubagentManager {
         // Forward latest total tokens to parent via SubagentManager callbacks
         if (this.callbacks?.onSubagentLatestTotalTokensChange) {
           this.callbacks.onSubagentLatestTotalTokensChange(subagentId, tokens);
+        }
+      },
+
+      onErrorBlockAdded: (error: string) => {
+        const instance = this.instances.get(subagentId);
+        if (instance?.logStream) {
+          instance.logStream.write(
+            `[${new Date().toISOString()}] Error: ${error}\n`,
+          );
         }
       },
     };

--- a/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
@@ -320,7 +320,7 @@ describe("SubagentManager - Backgrounding Coverage", () => {
     const content = fs.readFileSync(outputPath, "utf8");
     expect(content).toContain("Final response:");
     expect(content).toContain("Build completed successfully");
-    expect(content).toContain("Agent completed successfully");
+    expect(content).toContain("Agent completed");
 
     // Cleanup
     if (fs.existsSync(outputPath)) {
@@ -371,6 +371,42 @@ describe("SubagentManager - Backgrounding Coverage", () => {
     const content = fs.readFileSync(outputPath, "utf8");
     expect(content).toContain("Agent failed:");
     expect(content).toContain("Build failed with exit code 1");
+
+    // Cleanup
+    if (fs.existsSync(outputPath)) {
+      fs.unlinkSync(outputPath);
+    }
+  });
+
+  it("should log error block to log file when onErrorBlockAdded fires", async () => {
+    const instance = await subagentManager.createInstance(testConfig, {
+      description: "d",
+      prompt: "p",
+      subagent_type: "t",
+    });
+
+    await subagentManager.backgroundInstance(instance.subagentId);
+
+    const addTaskMock = vi.mocked(mockBackgroundTaskManager.addTask);
+    const outputPath = addTaskMock.mock.calls[0][0].outputPath!;
+
+    // Capture callbacks passed to MessageManager
+    const MessageManagerMock = vi.mocked(MessageManager);
+    const lastCall =
+      MessageManagerMock.mock.calls[MessageManagerMock.mock.calls.length - 1];
+    const passedCallbacks = lastCall[1].callbacks;
+
+    // Trigger error block callback (simulating LLM API error like 429)
+    passedCallbacks.onErrorBlockAdded?.(
+      "Rate limit exceeded (429): Too many requests",
+    );
+
+    // Wait for file write
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const content = fs.readFileSync(outputPath, "utf8");
+    expect(content).toContain("Error:");
+    expect(content).toContain("Rate limit exceeded (429): Too many requests");
 
     // Cleanup
     if (fs.existsSync(outputPath)) {


### PR DESCRIPTION
## Problem

When a subagent fails due to LLM API errors (e.g. rate limiting / 429), the subagent log file only shows tool call entries and `Agent completed successfully` — with no indication of the actual error that caused the subagent to stop producing output.

This is because `aiManager.sendAIMessage()` catches LLM API errors internally and adds them as error blocks to the message manager **without re-throwing**. So `subagentManager.internalExecute()` never enters its catch block and proceeds to log `Agent completed successfully` with whatever partial response was generated.

## Fix

1. **Add `onErrorBlockAdded` callback** in `createSubagentCallbacks()` — writes errors to `instance.logStream` in real-time as `[timestamp] Error: <message>`. Now when a 429 or other API error occurs, the log captures it immediately.

2. **Change `Agent completed successfully` → `Agent completed`** in both `subagentManager.ts` and `forkedAgentManager.ts`. Since error blocks can come from non-blocking sources (compaction failures, hook errors), the `successfully` qualifier was misleading.

## Changes

- `packages/agent-sdk/src/managers/subagentManager.ts` — added `onErrorBlockAdded` callback + updated completion message
- `packages/agent-sdk/src/managers/forkedAgentManager.ts` — updated completion message
- `packages/agent-sdk/tests/managers/subagentManager.background.test.ts` — added test for error block logging + updated existing test

Fixes #1291