### PR TITLE
fix(vsce): rewind button unresponsive after streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ coverage/
 Thumbs.db
 *.tmp
 *.swp
-.vscode/
 .idea/
 nohup.out
 .wave/settings.local.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}/packages/vsce"],
+      "env": {
+        "LOG_LEVEL": "DEBUG"
+      }
+    }
+  ]
+}

--- a/packages/vsce/webview/src/components/Message.tsx
+++ b/packages/vsce/webview/src/components/Message.tsx
@@ -594,5 +594,6 @@ export const Message: React.FC<MessageProps> = React.memo((props) => {
   // Custom comparison for React.memo
   return prev.message === next.message &&
     prev.isStreaming === next.isStreaming &&
-    prev.isQueued === next.isQueued;
+    prev.isQueued === next.isQueued &&
+    prev.onRewindToMessage === next.onRewindToMessage;
 });


### PR DESCRIPTION
## Root Cause

`Message.tsx` 的 `React.memo` 比较函数遗漏了 `onRewindToMessage` prop。流式输出期间 `isStreaming=true`，`handleRewindToMessage` 闭包捕获了这个值；流式结束后回调重建，但 Message 组件因 memo 未检测到 prop 变化而跳过渲染，仍持有旧闭包 → 点击 rewind 时 `if (state.isStreaming) return` 静默退出，按钮无反应。

## Fix

在 memo 比较函数中加入 `onRewindToMessage` 比较，确保回调重建时组件正确重渲染。

```diff
  return prev.message === next.message &&
    prev.isStreaming === next.isStreaming &&
-   prev.isQueued === next.isQueued;
+   prev.isQueued === next.isQueued &&
+   prev.onRewindToMessage === next.onRewindToMessage;
```

## Other Changes
- 移除 `.vscode/` from `.gitignore`，新增 `launch.json` 调试配置