### PR TITLE
ci: use pnpm --parallel for faster CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "pnpm -r lint",
     "format": "prettier --write .",
     "print-bin": "echo $(pwd)/packages/code/bin/wave-code.js",
-    "ci": "pnpm type-check && pnpm lint && pnpm test:coverage",
+    "ci": "pnpm -r --parallel type-check && pnpm -r --parallel lint && pnpm -r --parallel test:coverage",
     "release:patch": "node scripts/release.js patch",
     "release:minor": "node scripts/release.js minor",
     "release:major": "node scripts/release.js major",


### PR DESCRIPTION
## Summary

- Use `pnpm -r --parallel` for type-check, lint and test:coverage in CI
- Packages run concurrently instead of sequentially within each task
- Playwright browser install already removed in #1294

## Changes

```diff
- "ci": "pnpm type-check && pnpm lint && pnpm test:coverage"
+ "ci": "pnpm -r --parallel type-check && pnpm -r --parallel lint && pnpm -r --parallel test:coverage"
```

Three packages (agent-sdk, code, vsce) now run their type-check / lint / tests in parallel.