### PR TITLE
fix(vsce): dynamic VSIX name & skip CI for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ name: CI
 on:
   pull_request:
     branches: [ main, develop ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'specs/**'
+      - 'LICENSE'
   workflow_dispatch:
 
 jobs:

--- a/packages/code/src/components/CommandSelector.tsx
+++ b/packages/code/src/components/CommandSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer, useEffect } from "react";
+import React, { useReducer, useEffect, useMemo } from "react";
 import { Box, Text, useInput } from "ink";
 import type { SlashCommand } from "wave-agent-sdk";
 import { AVAILABLE_COMMANDS } from "../constants/commands.js";
@@ -35,15 +35,15 @@ export const CommandSelector: React.FC<CommandSelectorProps> = ({
     dispatch({ type: "RESET_INDEX" });
   }, [searchQuery]);
 
-  // Merge agent commands and local commands
-  const allCommands = [...AVAILABLE_COMMANDS, ...commands];
-
-  // Filter command list
-  const filteredCommands = allCommands.filter(
-    (command) =>
-      !searchQuery ||
-      command.id.toLowerCase().includes(searchQuery.toLowerCase()),
-  );
+  // Merge agent commands and local commands, memoized to stabilize useEffect dependencies
+  const filteredCommands = useMemo(() => {
+    const allCommands = [...AVAILABLE_COMMANDS, ...commands];
+    return allCommands.filter(
+      (command) =>
+        !searchQuery ||
+        command.id.toLowerCase().includes(searchQuery.toLowerCase()),
+    );
+  }, [searchQuery, commands]);
 
   // Handle decisions from reducer
   useEffect(() => {

--- a/packages/vsce/scripts/package.mjs
+++ b/packages/vsce/scripts/package.mjs
@@ -69,7 +69,7 @@ async function main() {
     console.log(`\n=== Packaging extension ===`);
     const pkg = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf-8'));
     const version = pkg.version;
-    const vsixName = `wave-vscode-chat-${version}.vsix`;
+    const vsixName = `${pkg.name}-${version}.vsix`;
     const vsixPath = path.join(releasesDir, vsixName);
     execSync(`npx vsce package --out ${vsixPath} ${vsceArgs}`, { stdio: 'inherit' });
     


### PR DESCRIPTION
## Changes

- **fix(vsce)**: VSIX filename now reads dynamically from `package.json` `name` field instead of hardcoded `wave-vscode-chat`
- **chore(ci)**: CI workflow skips runs when only documentation files change (`*.md`, `docs/`, `specs/`, `LICENSE`)