### PR TITLE
fix(tools): Bash tool improvements - sequential execution and Windows Git Bash support

### DIFF
--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -3,6 +3,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import { logger } from "../utils/globalLogger.js";
+import { resolveShellPath } from "../utils/shellResolver.js";
 import { stripAnsiColors } from "../utils/stringUtils.js";
 import { processToolResult } from "../utils/toolResultStorage.js";
 import { BASH_MAX_OUTPUT_CHARS } from "../constants/toolLimits.js";
@@ -152,6 +153,17 @@ The working directory persists between commands. Try to maintain your current wo
       };
     }
 
+    // Resolve shell path: on Windows, use Git Bash; on other platforms, use default
+    const shellPath = resolveShellPath();
+    if (process.platform === "win32" && !shellPath) {
+      return {
+        success: false,
+        content: "",
+        error:
+          "Git Bash not found. Please install Git for Windows or set GIT_BASH_PATH environment variable.",
+      };
+    }
+
     // Validate timeout
     if (
       timeout !== undefined &&
@@ -237,7 +249,7 @@ The working directory persists between commands. Try to maintain your current wo
       const wrappedCommand = `${command} && pwd -P >| ${tempCwdFile}`;
 
       const child: ChildProcess = spawn(wrappedCommand, {
-        shell: true,
+        shell: shellPath || true,
         stdio: "pipe",
         detached: true,
         cwd: context.workdir,

--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -34,6 +34,7 @@ function isAutobackgroundingAllowed(command: string): boolean {
  */
 export const bashTool: ToolPlugin = {
   name: BASH_TOOL_NAME,
+  isConcurrencySafe: false,
   config: {
     type: "function",
     function: {

--- a/packages/agent-sdk/src/utils/shellResolver.ts
+++ b/packages/agent-sdk/src/utils/shellResolver.ts
@@ -1,0 +1,31 @@
+import fs from "fs";
+
+export const WINDOWS_GIT_BASH_PATHS = [
+  "C:\\Program Files\\Git\\bin\\bash.exe",
+  "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
+];
+
+export function resolveShellPath(): string | undefined {
+  if (process.platform !== "win32") {
+    return undefined;
+  }
+
+  if (process.env.GIT_BASH_PATH) {
+    return process.env.GIT_BASH_PATH;
+  }
+
+  const paths = [
+    ...WINDOWS_GIT_BASH_PATHS,
+    process.env.LOCALAPPDATA
+      ? `${process.env.LOCALAPPDATA}\\Programs\\Git\\bin\\bash.exe`
+      : null,
+  ].filter(Boolean) as string[];
+
+  for (const path of paths) {
+    if (fs.existsSync(path)) {
+      return path;
+    }
+  }
+
+  return undefined;
+}

--- a/packages/agent-sdk/tests/utils/shellResolver.test.ts
+++ b/packages/agent-sdk/tests/utils/shellResolver.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  resolveShellPath,
+  WINDOWS_GIT_BASH_PATHS,
+} from "../../src/utils/shellResolver.js";
+import fs from "node:fs";
+
+vi.mock("node:fs");
+
+describe("shellResolver", () => {
+  const originalPlatform = process.platform;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.GIT_BASH_PATH;
+    delete process.env.LOCALAPPDATA;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    process.env = { ...originalEnv };
+  });
+
+  describe("non-Windows platform", () => {
+    it("returns undefined on linux", () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      expect(resolveShellPath()).toBeUndefined();
+    });
+
+    it("returns undefined on darwin", () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      expect(resolveShellPath()).toBeUndefined();
+    });
+  });
+
+  describe("Windows with GIT_BASH_PATH env var", () => {
+    it("returns the env var path when it exists", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      process.env.GIT_BASH_PATH = "D:\\custom\\git\\bash.exe";
+      expect(resolveShellPath()).toBe("D:\\custom\\git\\bash.exe");
+    });
+
+    it("returns the env var path without checking existsSync", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      process.env.GIT_BASH_PATH = "D:\\custom\\git\\bash.exe";
+      resolveShellPath();
+      expect(fs.existsSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Windows with common path", () => {
+    it("returns the first existing common path", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      vi.mocked(fs.existsSync).mockImplementation(
+        (p) => p === WINDOWS_GIT_BASH_PATHS[0],
+      );
+      expect(resolveShellPath()).toBe(WINDOWS_GIT_BASH_PATHS[0]);
+    });
+
+    it("returns the second common path if the first does not exist", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      vi.mocked(fs.existsSync).mockImplementation(
+        (p) => p === WINDOWS_GIT_BASH_PATHS[1],
+      );
+      expect(resolveShellPath()).toBe(WINDOWS_GIT_BASH_PATHS[1]);
+    });
+
+    it("includes LOCALAPPDATA path when set", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      process.env.LOCALAPPDATA = "C:\\Users\\test\\AppData\\Local";
+      const localPath =
+        "C:\\Users\\test\\AppData\\Local\\Programs\\Git\\bin\\bash.exe";
+
+      vi.mocked(fs.existsSync).mockImplementation((p) => p === localPath);
+      expect(resolveShellPath()).toBe(localPath);
+    });
+  });
+
+  describe("Windows without Git Bash", () => {
+    it("returns undefined when no path exists", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      expect(resolveShellPath()).toBeUndefined();
+    });
+  });
+
+  describe("priority order", () => {
+    it("GIT_BASH_PATH takes priority over common paths", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      process.env.GIT_BASH_PATH = "D:\\custom\\git\\bash.exe";
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      expect(resolveShellPath()).toBe("D:\\custom\\git\\bash.exe");
+    });
+  });
+});

--- a/specs/002-bash-tools.md
+++ b/specs/002-bash-tools.md
@@ -54,6 +54,23 @@
 
 ---
 
+### 用户故事 4 - Windows 平台 Git Bash 支持（优先级：P2）
+
+作为 Windows 用户，我希望 Bash 工具能自动使用 Git Bash 执行命令，以便所有 POSIX 语法（如 `pwd`、`&&`、管道等）在 Windows 上正常工作。
+
+**优先级原因**：当前 `spawn(cmd, { shell: true })` 在 Windows 上使用 `cmd.exe`，导致 POSIX 语法失败。这是 Windows 用户的基本可用性需求。
+
+**独立测试**：在 Windows 系统上安装 Git Bash，运行 `echo "hello"` 验证输出正常；运行 `pwd` 验证 POSIX 命令可用。
+
+**验收场景**：
+
+1. **假设** 运行在 Windows 系统上，**当** Git Bash 已安装时，**则** Bash 工具必须使用 Git Bash 而非 cmd.exe 执行命令。
+2. **假设** 运行在 Windows 系统上，**当** Git Bash 未安装时，**则** 系统必须返回清晰的错误消息，提示用户安装 Git for Windows。
+3. **假设** 运行在 Windows 系统上，**当** 执行包含 POSIX 语法的命令（如 `pwd -P >| file`）时，**则** 命令必须正常执行并返回正确结果。
+4. **假设** 运行在 Windows 系统上，**当** 命令执行后检测 CWD 时，**则** CWD 追踪机制必须正常工作（使用 POSIX 路径格式）。
+
+---
+
 ### 边界情况
 
 - **输出截断**：如果命令产生大量输出（例如 > 30,000 个字符），系统必须截断以防止 LLM 过载。多余输出被持久化到临时文件。
@@ -63,6 +80,8 @@
 - **每次命令使用新 Shell**：每次前台命令都会生成新的 shell；`cd` 和环境变量更改不会在调用之间持久化。
 - **超时自动转后台**：当前台命令超时时，系统必须自动将其转为后台（移至 `BackgroundTaskManager`）而不是终止，除非命令以 `sleep` 开头（仍按原方式终止）。
 - **后台无超时**：当 `run_in_background` 明确为 `true` 时，任何超时（默认或显式）必须被取消——进程无限期运行直到完成或手动停止。
+- **Windows 路径转换**：在 Windows 上使用 Git Bash 时，`cwd` 参数可能需要从 Windows 路径（`C:\Users\...`）转换为 POSIX 路径（`/c/Users/...`）。
+- **Git Bash 未安装**：Windows 上未检测到 Git Bash 时，必须返回错误而非静默降级到 cmd.exe。
 
 ## 需求 *(必填)*
 
@@ -86,6 +105,10 @@
 - **FR-016**：`Read` 工具必须能够读取后台进程的 `outputPath`。
 - **FR-017**：系统必须在 Bash 执行后通过检查 shell 的最终工作目录来检测 CWD 更改。如果 CWD 发生更改（例如通过 `cd`），系统必须更新代理的 `workdir` 上下文以供后续工具调用使用。
 - **FR-018**：Bash 工具提示必须告知代理"工作目录在命令之间持久化"（当使用 `cd` 时），与实际行为一致。
+- **FR-020**：在 Windows 系统上，系统必须检测并使用 Git Bash 作为 shell，而非 cmd.exe。检测顺序：`$GIT_BASH_PATH` 环境变量 → 常见安装路径（`C:\Program Files\Git\bin\bash.exe` 等）。
+- **FR-021**：在 Windows 系统上，如果未检测到 Git Bash，系统必须返回错误消息，提示用户安装 Git for Windows 或设置 `GIT_BASH_PATH` 环境变量。
+- **FR-022**：在 Windows 系统上使用 Git Bash 时，`spawn` 调用必须将 shell 参数设置为检测到的 Git Bash 可执行文件路径，而非 `true`。
+- **FR-023**：在 Windows 系统上，CWD 追踪命令（`pwd -P >| tempfile`）必须使用 Git Bash 执行，确保输出为 POSIX 路径格式。
 
 ### 关键实体
 
@@ -96,6 +119,7 @@
 ## 假设
 
 - 代理具有在目标环境中执行 bash 命令所需的权限。
-- 底层 shell 与标准 Bash 语法兼容。
+- 在 Linux/macOS 上，系统默认 shell（`/bin/sh` 或 `$SHELL`）与 Bash 语法兼容。
+- 在 Windows 上，用户已安装 Git for Windows（提供 Git Bash）。
 - `PermissionManager` 将在任何命令实际执行之前处理安全检查。
 - 代理被指示在适当时优先使用专用工具（Read、Write 等）而非通用 bash 命令。


### PR DESCRIPTION
## Changes

- Set Bash `isConcurrencySafe` to `false` so all bash commands run sequentially (safer default)
- Add Windows Git Bash support for bashTool:
  - New `shellResolver` utility detects Git Bash on Windows
  - Detection order: $GIT_BASH_PATH env var → common install paths
  - Returns clear error if Git Bash not found on Windows
  - Updates spawn to use detected shell path
- Update spec 002 with Windows support requirements (FR-020 to FR-023)
- Add 9 unit tests for shell detection

## Commits

- `fix(tools): set Bash isConcurrencySafe to false for sequential execution`
- `feat(tools): add Windows Git Bash support for bashTool`