### PR TITLE
fix(vsce): display bang commands in queue and message lists

### DIFF
--- a/packages/vsce/src/chatProvider.ts
+++ b/packages/vsce/src/chatProvider.ts
@@ -193,6 +193,15 @@ export class ChatProvider implements vscode.WebviewViewProvider {
             },
             onToolBlockUpdate: (params) => {
                 this.webviewManager.postMessage({ command: 'updateToolBlock', params }, viewType, windowId);
+            },
+            // Bang message callbacks - send full message list update
+            onBangMessageAdded: () => {
+                const session = this.getChatSession(viewType, windowId);
+                this.webviewManager.postMessage({ command: 'updateMessages', messages: session.messages }, viewType, windowId);
+            },
+            onBangMessageUpdated: () => {
+                const session = this.getChatSession(viewType, windowId);
+                this.webviewManager.postMessage({ command: 'updateMessages', messages: session.messages }, viewType, windowId);
             }
         });
     }

--- a/packages/vsce/src/session/chatSession.ts
+++ b/packages/vsce/src/session/chatSession.ts
@@ -19,6 +19,9 @@ export interface ChatSessionCallbacks {
     onStreamingContentUpdate?: (params: { messageId: string; accumulated: string; stage: 'streaming' | 'end' }) => void;
     onStreamingReasoningUpdate?: (params: { messageId: string; accumulated: string; stage: 'streaming' | 'end' }) => void;
     onToolBlockUpdate?: (params: ToolBlockUpdateCallbackParams) => void;
+    // Bang message callbacks
+    onBangMessageAdded?: () => void;
+    onBangMessageUpdated?: () => void;
 }
 
 export class ChatSession {
@@ -129,6 +132,15 @@ export class ChatSession {
                 },
                 onMcpServersChange: (servers: McpServerStatus[]) => {
                     this.callbacks.onMcpServersChange?.(servers);
+                },
+                onAddBangMessage: () => {
+                    this.callbacks.onBangMessageAdded?.();
+                },
+                onUpdateBangMessage: () => {
+                    this.callbacks.onBangMessageUpdated?.();
+                },
+                onCompleteBangMessage: () => {
+                    this.callbacks.onBangMessageUpdated?.();
                 }
             };
 

--- a/packages/vsce/tests/webview/queue-messages.test.tsx
+++ b/packages/vsce/tests/webview/queue-messages.test.tsx
@@ -199,4 +199,29 @@ describe('Message Queuing', () => {
         const selectionTag = Array.from(contextTags).find(el => el.textContent?.includes('utils.ts#10-20'));
         expect(selectionTag).toBeDefined();
     });
+
+    it('should display bang commands with ! prefix in the queue', () => {
+        renderChatApp();
+
+        // 1. Start streaming to enable queuing
+        sendCommand('startStreaming');
+
+        // 2. Simulate queue update with a bang command and a normal message
+        sendCommand('updateQueue', {
+            queue: [
+                { type: 'bang', content: 'ls -la' },
+                { type: 'message', content: 'normal message' }
+            ]
+        });
+
+        // 3. Verify the queue panel is visible
+        const queuePanel = screen.getByTestId('queued-message-list');
+        expect(queuePanel).toBeInTheDocument();
+
+        // 4. Bang command should display with ! prefix
+        expect(queuePanel).toHaveTextContent('!ls -la');
+        // 5. Normal message should not have ! prefix
+        expect(queuePanel).toHaveTextContent('normal message');
+        expect(queuePanel).not.toHaveTextContent('!normal message');
+    });
 });

--- a/packages/vsce/webview/src/components/QueuedMessageList.tsx
+++ b/packages/vsce/webview/src/components/QueuedMessageList.tsx
@@ -50,7 +50,7 @@ export const QueuedMessageList: React.FC<QueuedMessageListProps> = ({
                       role: 'user',
                       timestamp: new Date().toISOString(),
                       blocks: [
-                        { type: 'text', content: qm.content || qm.text || '' },
+                        { type: 'text', content: (qm.type === 'bang' ? '!' : '') + (qm.content || qm.text || '') },
                         ...(qm.images || []).map(img => ({
                           type: 'image' as const,
                           imageUrls: [img.path || (img as Record<string, string>).data || '']


### PR DESCRIPTION
- Add ! prefix to bang commands in QueuedMessageList
- Wire up onAddBangMessage/onUpdateBangMessage/onCompleteBangMessage callbacks
- Send full message list updates to frontend when bang messages change
- Add test for bang command display in queue
