### PR TITLE
fix(vsce): add test type-checking to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
 pnpm run type-check
+pnpm -r lint
 pnpm exec lint-staged

--- a/packages/vsce/eslint.config.mjs
+++ b/packages/vsce/eslint.config.mjs
@@ -70,6 +70,13 @@ export default [
     },
   },
   {
+    files: ["**/*.d.ts"],
+    rules: {
+      // .d.ts files legitimately need triple-slash references for type augmentation
+      "@typescript-eslint/triple-slash-reference": "off",
+    },
+  },
+  {
     files: ["tests/**/*.{ts,tsx}"],
     languageOptions: {
       globals: {

--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -102,7 +102,7 @@
     "watch:frontend": "node esbuild.config.mjs frontend --watch",
     "esbuild:prod": "node esbuild.config.mjs --production",
     "package": "node scripts/package.mjs",
-    "type-check": "tsc --noEmit && tsc -p webview --noEmit",
+    "type-check": "tsc --noEmit && tsc -p webview --noEmit && tsc -p tests --noEmit",
     "pretest": "pnpm run type-check",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/packages/vsce/tests/jest-dom.d.ts
+++ b/packages/vsce/tests/jest-dom.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../node_modules/@testing-library/jest-dom/types/vitest.d.ts" />

--- a/packages/vsce/tests/tsconfig.json
+++ b/packages/vsce/tests/tsconfig.json
@@ -2,9 +2,11 @@
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
+    "jsx": "react-jsx",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "types": ["vitest/globals"]
   }
 }

--- a/packages/vsce/tests/webview/richInputFeatures.test.tsx
+++ b/packages/vsce/tests/webview/richInputFeatures.test.tsx
@@ -136,7 +136,7 @@ describe('Rich Input Features', () => {
         const sentMessages = (vscode.postMessage as ReturnType<typeof vi.fn>).mock.calls.map(c => c[0]);
         const sendMsg = sentMessages.find((m: { command: string }) => m.command === 'sendMessage') as Record<string, unknown>;
         expect(sendMsg).toBeDefined();
-        const sentMarkdown = (sendMsg.text || '').replace(/\u00A0/g, ' ').trim();
+        const sentMarkdown = ((sendMsg.text as string) || '').replace(/\u00A0/g, ' ').trim();
         expect(sentMarkdown).toBe('Check these files: [@file:file1.ts] and also [@file:file2.ts]');
     });
 

--- a/packages/vsce/tests/webview/selectionFeature.test.tsx
+++ b/packages/vsce/tests/webview/selectionFeature.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { renderChatApp, screen, waitFor, fireEvent, act } from './test-utils';
-import type { Message } from 'wave-agent-sdk';
+import type { Message, TextBlock } from 'wave-agent-sdk';
 
 /**
  * Helper: append text to contenteditable input without destroying existing child nodes.
@@ -86,7 +86,7 @@ describe('Selection Feature (Inline Tags)', () => {
                     {
                         type: 'text',
                         content: 'Check this code: [Selection: /path/to/src/file.ts|file.ts#10-20]'
-                    } as unknown
+                    } as TextBlock
                 ]
             }
         ];
@@ -147,7 +147,7 @@ describe('Selection Feature (Inline Tags)', () => {
                     {
                         type: 'text',
                         content: 'Old format: [Selection: file.ts#10-20]'
-                    } as unknown
+                    } as TextBlock
                 ]
             }
         ];

--- a/packages/vsce/tests/webview/test-utils.tsx
+++ b/packages/vsce/tests/webview/test-utils.tsx
@@ -35,7 +35,7 @@ global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
 /**
  * Create a mock VS Code API object
  */
-export function createMockVscode(): VsCodeApi {
+export function createMockVscode() {
     return {
         postMessage: vi.fn(),
         getState: vi.fn().mockReturnValue(null),
@@ -47,7 +47,7 @@ export function createMockVscode(): VsCodeApi {
  * Render the ChatApp with a mock VS Code API
  */
 export function renderChatApp(vscode?: VsCodeApi) {
-    const mockVscode = vscode || createMockVscode();
+    const mockVscode = (vscode || createMockVscode()) as ReturnType<typeof createMockVscode>;
     const result = render(<ChatApp vscode={mockVscode} />);
     const user = userEvent.setup();
     return { ...result, vscode: mockVscode, user };

--- a/packages/vsce/tests/webview/toolDisplayTest.test.tsx
+++ b/packages/vsce/tests/webview/toolDisplayTest.test.tsx
@@ -36,7 +36,7 @@ describe('Tool Display Visual Test', () => {
         );
         // Remove compactParams to test fallback
         if (bashToolMessage.blocks && bashToolMessage.blocks.length > 1) {
-            const toolBlock = bashToolMessage.blocks[1] as Record<string, unknown>;
+            const toolBlock = bashToolMessage.blocks[1] as unknown as Record<string, unknown>;
             delete toolBlock.compactParams;
         }
         messages.push(bashToolMessage);
@@ -124,7 +124,7 @@ describe('Tool Display Visual Test', () => {
         // Override the tool block to set stage="streaming" and remove compactParams
         const toolMsg = messages[1];
         if (toolMsg.blocks && toolMsg.blocks.length > 1) {
-            const toolBlock = toolMsg.blocks[1] as Record<string, unknown>;
+            const toolBlock = toolMsg.blocks[1] as unknown as Record<string, unknown>;
             toolBlock.stage = 'streaming';
             delete toolBlock.compactParams;
         }


### PR DESCRIPTION
## Problem
The vsce package's `type-check` script only checked backend and webview source code, but never the test files. Type errors in tests (like missing `toHaveTextContent` matcher) were only visible in VS Code's Language Server, not caught by pre-commit hooks or CI.

## Changes
- **`tests/tsconfig.json`**: Added `jsx: "react-jsx"` and `types: ["vitest/globals"]` to match vitest.config.ts settings
- **`tests/jest-dom.d.ts`**: New file using `/// <reference>` to bring `@testing-library/jest-dom` types into the compilation graph (since `setup.ts` is not imported by test files)
- **`tests/webview/test-utils.tsx`**: Removed explicit `: VsCodeApi` return type from `createMockVscode()` to preserve `Mock` types; added cast in `renderChatApp()` to avoid union types
- **3 test files**: Fixed 5 pre-existing type errors (`unknown` type casts)
- **`package.json`**: Added `tsc -p tests --noEmit` to `type-check` script