### PR TITLE
fix(vsce): use @vscode/vsce instead of deprecated vsce for packaging

### DIFF
--- a/packages/vsce/scripts/package.mjs
+++ b/packages/vsce/scripts/package.mjs
@@ -71,7 +71,7 @@ async function main() {
     const version = pkg.version;
     const vsixName = `${pkg.name}-${version}.vsix`;
     const vsixPath = path.join(releasesDir, vsixName);
-    execSync(`npx vsce package --out ${vsixPath} ${vsceArgs}`, { stdio: 'inherit' });
+    execSync(`npx @vscode/vsce package --out ${vsixPath} ${vsceArgs}`, { stdio: 'inherit' });
     
     console.log(`\nCreated releases/${vsixName}`);
     console.log('\nAll targets processed successfully!');


### PR DESCRIPTION
The packaging script used `npx vsce` which installs the deprecated
vsce@2.15.0 that requires explicit `activationEvents` in package.json.
Switch to `npx @vscode/vsce` (already in devDependencies) which
auto-derives activationEvents from contributes, fixing CI release builds.
