### PR TITLE
fix: use underscore for previous_tag input in vsce-release workflow

### DIFF
--- a/.github/workflows/vsce-release.yml
+++ b/.github/workflows/vsce-release.yml
@@ -48,6 +48,6 @@ jobs:
           draft: false
           prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
           generate_release_notes: true
-          previous-tag: ${{ steps.prev-tag.outputs.tag }}
+          previous_tag: ${{ steps.prev-tag.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix GitHub Actions warning: `previous-tag` is not a valid input for `softprops/action-gh-release@v3`. The correct input name is `previous_tag` (underscore, not hyphen).