### PR TITLE
feat: align task reminder with Claude Code behavior

### DIFF
--- a/packages/agent-sdk/src/utils/taskReminder.ts
+++ b/packages/agent-sdk/src/utils/taskReminder.ts
@@ -7,12 +7,7 @@ export const TASK_REMINDER_CONFIG = {
   TURNS_BETWEEN_REMINDERS: 10,
 };
 
-const TASK_MANAGEMENT_TOOLS = new Set([
-  "TaskCreate",
-  "TaskUpdate",
-  "TaskList",
-  "TaskGet",
-]);
+const TASK_MANAGEMENT_TOOLS = new Set(["TaskCreate", "TaskUpdate"]);
 const TASK_REMINDER_MARKER = "<!-- task-reminder -->";
 
 function isQualifyingAssistantMessage(message: Message): boolean {
@@ -66,15 +61,13 @@ export function getTaskReminderTurnCounts(messages: Message[]): {
 export function buildTaskReminderText(tasks: Task[]): string {
   let text = `${TASK_REMINDER_MARKER}\n`;
   text +=
-    "Here is a gentle reminder about the task list. The user may not have explicitly asked for the following to be done, but you should check the task list to see if any tasks need attention.\n";
+    "The task tools haven't been used recently. If you're working on tasks that would benefit from tracking progress, consider using TaskCreate to add new tasks and TaskUpdate to update task status (set to in_progress when starting, completed when done). Also consider cleaning up the task list if it has become stale. Only use these if relevant to the current work. This is just a gentle reminder - ignore if not applicable. Make sure that you never mention this reminder to the user";
 
   if (tasks.length > 0) {
-    text += "\n";
+    text += "\n\nHere are the existing tasks:\n";
     for (const task of tasks) {
       text += `#${task.id} [${task.status}] ${task.subject}\n`;
     }
-  } else {
-    text += "The task list is currently empty.\n";
   }
 
   return text;

--- a/packages/agent-sdk/tests/utils/taskReminder.test.ts
+++ b/packages/agent-sdk/tests/utils/taskReminder.test.ts
@@ -143,6 +143,22 @@ describe("getTaskReminderTurnCounts", () => {
     // TaskUpdate is in the earliest message; 3 assistant turns after it
     expect(result.turnsSinceLastTaskManagement).toBe(3);
   });
+
+  it("TaskList and TaskGet do NOT reset the management counter", () => {
+    const messages: Message[] = [
+      makeAssistantMessage({
+        blocks: [{ type: "text", content: "ok" }, makeToolBlock("TaskList")],
+      }),
+      makeAssistantMessage({
+        blocks: [{ type: "text", content: "ok" }, makeToolBlock("TaskGet")],
+      }),
+      makeAssistantMessage(),
+    ];
+
+    const result = getTaskReminderTurnCounts(messages);
+    // TaskList and TaskGet are read-only; counter should count all 3 turns
+    expect(result.turnsSinceLastTaskManagement).toBe(3);
+  });
 });
 
 describe("buildTaskReminderText", () => {
@@ -155,6 +171,9 @@ describe("buildTaskReminderText", () => {
 
     const text = buildTaskReminderText(tasks);
     expect(text).toContain("<!-- task-reminder -->");
+    expect(text).toContain("task tools haven't been used recently");
+    expect(text).toContain("never mention this reminder to the user");
+    expect(text).toContain("Here are the existing tasks:");
     expect(text).toContain("#1 [pending] Fix auth bug");
     expect(text).toContain("#2 [in_progress] Add tests");
     expect(text).toContain("#3 [completed] Update docs");
@@ -163,8 +182,18 @@ describe("buildTaskReminderText", () => {
 
   it("handles empty task list", () => {
     const text = buildTaskReminderText([]);
-    expect(text).toContain("task list is currently empty");
     expect(text).toContain("<!-- task-reminder -->");
+    expect(text).toContain("task tools haven't been used recently");
+    expect(text).not.toContain("Here are the existing tasks:");
+    expect(text).not.toContain("currently empty");
+  });
+
+  it("empty task list reminder does not include task listing", () => {
+    const text = buildTaskReminderText([]);
+    expect(text).not.toContain("Here are the existing tasks");
+    expect(text).not.toContain("currently empty");
+    expect(text).toContain("<!-- task-reminder -->");
+    expect(text).toContain("task tools haven't been used recently");
   });
 });
 

--- a/specs/043-task-management-tools.md
+++ b/specs/043-task-management-tools.md
@@ -78,12 +78,33 @@
 
 ---
 
+### 用户故事 6 - 任务提醒注入（优先级：P3）
+
+作为系统，我必须定期提醒 agent 使用任务跟踪工具，以确保 agent 不会遗忘对任务进度的管理。
+
+**为什么是这个优先级**：任务提醒是辅助性功能，提升 agent 自主管理任务的意识，但不影响核心任务 CRUD 操作。
+
+**独立测试**：可以通过模拟连续 10 个 assistant turn 不使用 TaskCreate/TaskUpdate，然后验证下一次 API 调用中注入了提醒消息来进行测试。
+
+**验收场景**：
+
+1. **假设**会话处于活动状态且 TaskCreate/TaskUpdate 工具可用，**当**连续 10 个 assistant turn 未调用 TaskCreate 或 TaskUpdate，且距上次提醒也已过去至少 10 个 assistant turn 时，**则**系统在下一次 API 调用中注入一条 user 消息形式的任务提醒。
+2. **假设**提醒已注入，**当** agent 收到提醒时，**则**提醒内容指示 agent 不得向用户提及该提醒的存在。
+3. **假设**当前存在活动任务，**当**提醒触发时，**则**提醒消息末尾附加当前任务列表，格式为 `#id [status] subject`。
+4. **假设**当前任务列表为空，**当**提醒触发时，**则**提醒消息仍然注入，作为通用提醒，不包含任务列表。
+5. **假设** agent 调用了 TaskCreate 或 TaskUpdate，**当**工具执行完成后，**则** `turnsSinceLastTaskManagement` 计数器重置为 0。
+6. **假设** agent 调用了 TaskList 或 TaskGet（只读工具），**当**工具执行完成后，**则** `turnsSinceLastTaskManagement` 计数器**不**被重置。
+
+---
+
 ### 边界情况
 
 - **任务 ID 不存在时会发生什么？** TaskGet 和 TaskUpdate 应返回清晰的错误消息，指示任务未找到。
 - **系统如何处理无效的状态转换？** 系统应验证提供的状态是允许值之一。
 - **如果存储目录不可写会怎样？** 工具应优雅地处理文件系统错误。
 - **任务很多时会发生什么？** TaskList 组件使用终端自适应显示限制、优先级排序、折叠摘要和自动隐藏已完成任务来处理长任务列表。
+- **如果 TaskCreate/TaskUpdate 工具不可用会怎样？** 系统必须完全跳过任务提醒注入，不发送任何提醒消息。
+- **如果任务列表为空会怎样？** 提醒仍然触发，作为通用提醒鼓励 agent 使用任务跟踪，但不附加任务列表。
 
 ## 需求 *（必填）*
 
@@ -111,6 +132,15 @@
 - **FR-020**：TaskList 组件必须在所有活动任务完成后 5 秒自动隐藏，并在新非完成任务添加时重新出现。
 - **FR-021**：任务主题文本必须使用 `wrap="truncate-end"` 来优雅地处理长主题。
 - **FR-022**：组件必须通过 taskId → 完成时间戳的 ref map 跟踪最近完成的任务（30秒内），过期条目被修剪以触发重新渲染。
+- **FR-023**：系统必须在每个 assistant turn 后追踪自上次 TaskCreate 或 TaskUpdate 调用以来的 turn 数（`turnsSinceLastTaskManagement`）。
+- **FR-024**：系统必须在每个 assistant turn 后追踪自上次提醒注入以来的 turn 数（`turnsSinceLastReminder`）。
+- **FR-025**：当 `turnsSinceLastTaskManagement >= 10` **且** `turnsSinceLastReminder >= 10` 同时满足时，系统必须在 API 调用中注入一条 user 消息形式的任务提醒。
+- **FR-026**：只有 `TaskCreate` 和 `TaskUpdate` 工具调用必须重置 `turnsSinceLastTaskManagement` 计数器；只读工具（`TaskList`、`TaskGet`）不得重置该计数器。
+- **FR-027**：当任务列表非空时，提醒消息末尾必须附加当前任务列表，格式为 `#id [status] subject`（每个任务一行）。
+- **FR-028**：当任务列表为空时，提醒消息必须仍然注入，作为通用提醒鼓励 agent 使用任务跟踪功能，但不附加任务列表。
+- **FR-029**：提醒消息的文本必须明确指示 agent 不得向用户提及该提醒的存在。
+- **FR-030**：任务提醒不得持久化到会话历史中——它仅在每次 API 调用时动态生成并注入，不会保留在后续的消息上下文中。
+- **FR-031**：如果 TaskCreate 和 TaskUpdate 工具不在当前 agent 的可用工具集中，系统必须完全跳过任务提醒逻辑，不注入任何提醒消息。
 
 ### 关键实体 *（如果功能涉及数据则包含）*
 


### PR DESCRIPTION
## Summary

Align task reminder injection fully with Claude Code's design.

## Changes

### Code (`taskReminder.ts`)
- **TASK_MANAGEMENT_TOOLS**: Remove `TaskList` and `TaskGet` — only `TaskCreate` and `TaskUpdate` (write ops) reset the management counter
- **Reminder text**: Align with Claude Code wording ("The task tools haven't been used recently...")
- **Empty list**: Remove "task list is currently empty" branch; empty list still fires generic nudge without task listing

### Spec (`043-task-management-tools.md`)
- Add user story 6 (任务提醒注入) with 6 acceptance scenarios
- Add edge cases for tool unavailability and empty task list
- Add FR-023 through FR-031 covering counter tracking, trigger conditions, read-only tool exclusion, reminder text, and persistence behavior

### Tests (`taskReminder.test.ts`)
- New test: TaskList/TaskGet do NOT reset the management counter
- New test: empty task list reminder excludes task listing
- Updated existing tests for new text format