### PR TITLE
fix(ci): remove redundant '**' glob from paths-filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
         with:
           filters: |
             code:
-              - '**'
               - '!**/*.md'
               - '!**/*.txt'
               - '!specs/**'


### PR DESCRIPTION
Negation-only filters work correctly in dorny/paths-filter without
an explicit positive match pattern.
