### PR TITLE
perf(ci): fix pnpm cache and optimize ripgrep downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,29 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
+
+      - name: Get pnpm store directory
+        if: steps.filter.outputs.code == 'true'
+        id: pnpm-cache
+        run: echo "store_path=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm dependencies
+        if: steps.filter.outputs.code == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store_path }}
+          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-${{ runner.os }}-
+
+      - name: Cache ripgrep binaries
+        if: steps.filter.outputs.code == 'true'
+        uses: actions/cache@v4
+        with:
+          path: packages/agent-sdk/vendor/ripgrep
+          key: ripgrep-${{ runner.os }}-${{ runner.arch }}
+          restore-keys: |
+            ripgrep-${{ runner.os }}-
 
       - name: Install dependencies
         if: steps.filter.outputs.code == 'true'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,26 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
-          cache: 'pnpm'
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store_path=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store_path }}
+          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-${{ runner.os }}-
+
+      - name: Cache ripgrep binaries
+        uses: actions/cache@v4
+        with:
+          path: packages/agent-sdk/vendor/ripgrep
+          key: ripgrep-${{ runner.os }}-${{ runner.arch }}
+          restore-keys: |
+            ripgrep-${{ runner.os }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,17 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store_path=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store_path }}
+          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-${{ runner.os }}-
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build

--- a/.github/workflows/vsce-release.yml
+++ b/.github/workflows/vsce-release.yml
@@ -24,7 +24,26 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
-          cache: 'pnpm'
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store_path=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store_path }}
+          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-${{ runner.os }}-
+
+      - name: Cache ripgrep binaries
+        uses: actions/cache@v4
+        with:
+          path: packages/agent-sdk/vendor/ripgrep
+          key: ripgrep-${{ runner.os }}-${{ runner.arch }}
+          restore-keys: |
+            ripgrep-${{ runner.os }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/packages/agent-sdk/scripts/install_ripgrep.js
+++ b/packages/agent-sdk/scripts/install_ripgrep.js
@@ -9,6 +9,18 @@ const __dirname = path.dirname(__filename);
 const MANIFEST_PATH = path.resolve(__dirname, "../bin/rg");
 const VENDOR_DIR = path.resolve(__dirname, "../vendor/ripgrep");
 
+function getCurrentPlatform() {
+  const platform = process.platform;
+  const arch = process.arch;
+  if (platform === "darwin")
+    return `macos-${arch === "arm64" ? "aarch64" : "x86_64"}`;
+  if (platform === "linux")
+    return `linux-${arch === "arm64" ? "aarch64" : "x86_64"}`;
+  if (platform === "win32")
+    return `windows-${arch === "arm64" ? "aarch64" : "x86_64"}`;
+  return null;
+}
+
 async function main() {
   if (!fs.existsSync(MANIFEST_PATH)) {
     console.error(`Manifest not found: ${MANIFEST_PATH}`);
@@ -18,7 +30,15 @@ async function main() {
   const manifestContent = fs.readFileSync(MANIFEST_PATH, "utf-8");
   const jsonContent = manifestContent.replace(/^#!.*\n/, "");
   const manifest = JSON.parse(jsonContent);
-  const platforms = manifest.platforms;
+  const allPlatforms = manifest.platforms;
+
+  // In CI, only download for the current platform
+  const isCI = process.env.CI === "true";
+  const currentPlatform = isCI ? getCurrentPlatform() : null;
+  const platforms =
+    currentPlatform && currentPlatform in allPlatforms
+      ? { [currentPlatform]: allPlatforms[currentPlatform] }
+      : allPlatforms;
 
   if (!fs.existsSync(VENDOR_DIR)) {
     fs.mkdirSync(VENDOR_DIR, { recursive: true });


### PR DESCRIPTION
## Changes

- Replace `setup-node cache:'pnpm'` with explicit `actions/cache@v4` using `pnpm store path` for reliable cache hits
- Add ripgrep vendor directory cache in ci/pages/vsce-release workflows
- `install_ripgrep.js`: only download current platform binary in CI (1 ~2.5MB instead of 6 platforms ~12MB)

## Expected improvement

- First run: install ~25s → ~15s
- Cache hit: install ~2-3s