### PR TITLE
chore(vsce): remove redundant pretest type-check hook

### DIFF
--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -103,7 +103,6 @@
     "esbuild:prod": "node esbuild.config.mjs --production",
     "package": "node scripts/package.mjs",
     "type-check": "tsc --noEmit && tsc -p webview --noEmit && tsc -p tests --noEmit",
-    "pretest": "pnpm run type-check",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "pretest:demo": "pnpm run type-check && pnpm run compile",


### PR DESCRIPTION
Remove the `pretest` script from `packages/vsce/package.json` that ran `pnpm run type-check` before every test invocation. This caused duplicate type checking in CI since `pnpm run ci` already runs `pnpm -r type-check` separately.