### PR TITLE
fix: add afterEach destroy() cleanup to 19 test files leaking Agent resources

### DIFF
--- a/packages/agent-sdk/tests/agent.plugin.test.ts
+++ b/packages/agent-sdk/tests/agent.plugin.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Agent } from "../src/agent.js";
 import { PluginLoader } from "../src/services/pluginLoader.js";
 import { AIManager } from "../src/managers/aiManager.js";
@@ -18,6 +18,7 @@ import { SkillManager } from "../src/managers/skillManager.js";
 
 describe("Agent Plugin Integration", () => {
   const workdir = "/test/workdir";
+  let activeAgent: Agent | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -55,6 +56,13 @@ describe("Agent Plugin Integration", () => {
     vi.spyOn(PluginLoader, "loadCommands").mockImplementation(() => []);
   });
 
+  afterEach(async () => {
+    if (activeAgent) {
+      await activeAgent.destroy();
+      activeAgent = undefined;
+    }
+  });
+
   it("should load plugins from AgentOptions and register commands", async () => {
     const mockManifest = {
       name: "test-plugin",
@@ -85,6 +93,7 @@ describe("Agent Plugin Integration", () => {
         },
       ],
     });
+    activeAgent = agent;
 
     const commands = agent.getSlashCommands();
     // Plugin commands are namespaced as pluginName:commandId
@@ -124,6 +133,7 @@ describe("Agent Plugin Integration", () => {
         },
       ],
     });
+    activeAgent = agent;
 
     // Mock AIManager.sendAIMessage
     const aiManager = vi.mocked(AIManager).mock.instances[0];
@@ -175,6 +185,7 @@ describe("Agent Plugin Integration", () => {
         },
       ],
     });
+    activeAgent = agent;
 
     const aiManager = vi.mocked(AIManager).mock.instances[0];
     vi.spyOn(aiManager, "sendAIMessage").mockResolvedValue(undefined);

--- a/packages/agent-sdk/tests/agent.prefix.test.ts
+++ b/packages/agent-sdk/tests/agent.prefix.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Agent } from "../src/agent.js";
 import * as fs from "fs/promises";
 
@@ -7,6 +7,7 @@ vi.mock("./services/session.js");
 
 describe("Agent Prefix Matching Integration", () => {
   const workdir = "/test/workdir";
+  let activeAgent: Agent | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -15,11 +16,19 @@ describe("Agent Prefix Matching Integration", () => {
     vi.mocked(fs.writeFile).mockResolvedValue(undefined);
   });
 
+  afterEach(async () => {
+    if (activeAgent) {
+      await activeAgent.destroy();
+      activeAgent = undefined;
+    }
+  });
+
   it("should automatically save and use prefix rules for smart commands", async () => {
     const agent = await Agent.create({
       workdir,
       permissionMode: "default",
     });
+    activeAgent = agent;
 
     // 1. Simulate trusting a command that has a smart prefix
     // In a real scenario, this comes from the Confirmation component decision
@@ -44,6 +53,7 @@ describe("Agent Prefix Matching Integration", () => {
       workdir,
       permissionMode: "default",
     });
+    activeAgent = agent;
 
     // 1. Simulate trusting a blacklisted command
     await agent.addPermissionRule("Bash(rm file.txt)");

--- a/packages/agent-sdk/tests/agent/agent.abort.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.abort.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Agent } from "@/agent.js";
 import * as aiService from "@/services/aiService.js";
 import { createMockToolManager } from "../helpers/mockFactories.js";
@@ -38,6 +38,7 @@ vi.mock("@/managers/toolManager", () => ({
 
 describe("Agent - Abort Handling", () => {
   let agent: Agent;
+  let activeTestAgent: Agent | undefined;
 
   beforeEach(async () => {
     // Create mock callbacks
@@ -126,6 +127,16 @@ describe("Agent - Abort Handling", () => {
     });
 
     vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    if (activeTestAgent) {
+      await activeTestAgent.destroy();
+      activeTestAgent = undefined;
+    }
+    if (agent) {
+      await agent.destroy();
+    }
   });
 
   it(
@@ -398,6 +409,7 @@ describe("Agent - Abort Handling", () => {
     });
 
     // Register mock ToolManager
+    activeTestAgent = testAgent;
     const container = (testAgent as unknown as { container: Container })
       .container;
     container.register("ToolManager", mockToolManagerInstance);
@@ -473,6 +485,7 @@ describe("Agent - Abort Handling", () => {
         callbacks: mockCallbacks,
       });
 
+      activeTestAgent = testAgent;
       const container = (testAgent as unknown as { container: Container })
         .container;
       container.register("ToolManager", mockToolManagerInstance);
@@ -551,6 +564,7 @@ describe("Agent - Abort Handling", () => {
         callbacks: mockCallbacks,
       });
 
+      activeTestAgent = testAgent;
       const container = (testAgent as unknown as { container: Container })
         .container;
       container.register("ToolManager", mockToolManagerInstance);
@@ -619,6 +633,7 @@ describe("Agent - Abort Handling", () => {
         },
       });
 
+      activeTestAgent = testAgent;
       const container = (testAgent as unknown as { container: Container })
         .container;
       container.register("ToolManager", mockToolManagerInstance);
@@ -682,6 +697,7 @@ describe("Agent - Abort Handling", () => {
         callbacks: mockCallbacks,
       });
 
+      activeTestAgent = testAgent;
       const container = (testAgent as unknown as { container: Container })
         .container;
       container.register("ToolManager", mockToolManagerInstance);
@@ -750,6 +766,7 @@ describe("Agent - Abort Handling", () => {
         },
       });
 
+      activeTestAgent = testAgent;
       const container = (testAgent as unknown as { container: Container })
         .container;
       container.register("ToolManager", mockToolManagerInstance);
@@ -799,6 +816,7 @@ describe("Agent - Abort Handling", () => {
         callbacks: mockCallbacks,
       });
 
+      activeTestAgent = testAgent;
       const container = (testAgent as unknown as { container: Container })
         .container;
       container.register("ToolManager", mockToolManagerInstance);
@@ -868,6 +886,7 @@ describe("Agent - Abort Handling", () => {
         callbacks: mockCallbacks,
       });
 
+      activeTestAgent = testAgent;
       const container = (testAgent as unknown as { container: Container })
         .container;
       container.register("ToolManager", mockToolManagerInstance);
@@ -930,6 +949,7 @@ describe("Agent - Abort Handling", () => {
         },
       });
 
+      activeTestAgent = testAgent;
       const container = (testAgent as unknown as { container: Container })
         .container;
       container.register("ToolManager", mockToolManagerInstance);

--- a/packages/agent-sdk/tests/agent/agent.autoAccept.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.autoAccept.test.ts
@@ -11,6 +11,7 @@ import * as path from "path";
 describe("Agent Auto-Accept Permissions Integration", () => {
   let tempDir: string;
   const originalEnv = process.env;
+  let activeAgent: Agent | undefined;
 
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "wave-agent-test-"));
@@ -23,6 +24,10 @@ describe("Agent Auto-Accept Permissions Integration", () => {
   });
 
   afterEach(async () => {
+    if (activeAgent) {
+      await activeAgent.destroy();
+      activeAgent = undefined;
+    }
     process.env = originalEnv;
     await fs.rm(tempDir, { recursive: true, force: true });
     vi.restoreAllMocks();
@@ -36,6 +41,7 @@ describe("Agent Auto-Accept Permissions Integration", () => {
       permissionMode: "default",
       canUseTool: mockCallback as unknown as PermissionCallback,
     });
+    activeAgent = agent;
 
     // 1. Test transition to acceptEdits
     mockCallback.mockResolvedValueOnce({
@@ -111,6 +117,7 @@ describe("Agent Auto-Accept Permissions Integration", () => {
       permissionMode: "default",
       canUseTool: mockCallback as unknown as PermissionCallback,
     });
+    activeAgent = agent;
 
     // 3. Verify rule is loaded and applied
     const toolManager = (agent as unknown as { toolManager: ToolManager })
@@ -133,6 +140,7 @@ describe("Agent Auto-Accept Permissions Integration", () => {
         onPermissionModeChange: mockModeCallback,
       },
     });
+    activeAgent = agent;
 
     agent.setPermissionMode("acceptEdits");
     expect(mockModeCallback).toHaveBeenCalledWith("acceptEdits");
@@ -167,6 +175,7 @@ describe("Agent Auto-Accept Permissions Integration", () => {
       permissionMode: "default",
       canUseTool: mockCallback as unknown as PermissionCallback,
     });
+    activeAgent = agent;
 
     // 4. Verify both rules are applied
     const toolManager = (agent as unknown as { toolManager: ToolManager })
@@ -198,6 +207,7 @@ describe("Agent Auto-Accept Permissions Integration", () => {
       permissionMode: "default",
       canUseTool: mockCallback as unknown as PermissionCallback,
     });
+    activeAgent = agent;
 
     const toolManager = (agent as unknown as { toolManager: ToolManager })
       .toolManager;

--- a/packages/agent-sdk/tests/agent/agent.foreground.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.foreground.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Agent } from "../../src/agent.js";
 import { SkillManager } from "../../src/managers/skillManager.js";
 import * as fs from "fs/promises";
@@ -11,6 +11,7 @@ vi.mock("../../src/services/session.js");
 
 describe("Agent Foreground Task Management", () => {
   const workdir = "/test/workdir";
+  let activeAgent: Agent | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -18,8 +19,16 @@ describe("Agent Foreground Task Management", () => {
     vi.mocked(SkillManager.prototype.getAvailableSkills).mockReturnValue([]);
   });
 
+  afterEach(async () => {
+    if (activeAgent) {
+      await activeAgent.destroy();
+      activeAgent = undefined;
+    }
+  });
+
   it("should register and unregister foreground tasks via Agent", async () => {
     const agent = await Agent.create({ workdir });
+    activeAgent = agent;
     const backgroundHandler = vi.fn().mockResolvedValue(undefined);
 
     agent.registerForegroundTask({
@@ -39,6 +48,7 @@ describe("Agent Foreground Task Management", () => {
       workdir,
       callbacks: { onBackgroundCurrentTask },
     });
+    activeAgent = agent;
 
     agent.registerForegroundTask({
       id: "test-task",

--- a/packages/agent-sdk/tests/agent/agent.headers.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.headers.test.ts
@@ -4,6 +4,7 @@ import { ConfigurationService } from "@/services/configurationService.js";
 
 describe("Agent Custom Headers", () => {
   const originalEnv = process.env;
+  let activeAgent: Agent | undefined;
 
   beforeEach(() => {
     // Reset environment variables
@@ -15,7 +16,11 @@ describe("Agent Custom Headers", () => {
     process.env.WAVE_BASE_URL = "https://test-gateway.com/api";
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    if (activeAgent) {
+      await activeAgent.destroy();
+      activeAgent = undefined;
+    }
     process.env = originalEnv;
     vi.restoreAllMocks();
   });
@@ -24,6 +29,7 @@ describe("Agent Custom Headers", () => {
     process.env.WAVE_CUSTOM_HEADERS = "X-Test-Header: value123";
 
     const agent = await Agent.create({});
+    activeAgent = agent;
     const gatewayConfig = agent.getGatewayConfig();
 
     expect(gatewayConfig.defaultHeaders).toBeDefined();
@@ -34,6 +40,7 @@ describe("Agent Custom Headers", () => {
     process.env.WAVE_CUSTOM_HEADERS = "X-Header-1: val1\nX-Header-2: val2";
 
     const agent = await Agent.create({});
+    activeAgent = agent;
     const gatewayConfig = agent.getGatewayConfig();
 
     expect(gatewayConfig.defaultHeaders).toEqual({
@@ -51,6 +58,7 @@ describe("Agent Custom Headers", () => {
         "X-Another": "another",
       },
     });
+    activeAgent = agent;
     const gatewayConfig = agent.getGatewayConfig();
 
     expect(gatewayConfig.defaultHeaders).toEqual({
@@ -69,6 +77,7 @@ describe("Agent Custom Headers", () => {
         "X-Conflict": "const-conflict",
       },
     });
+    activeAgent = agent;
     const gatewayConfig = agent.getGatewayConfig();
 
     expect(gatewayConfig.defaultHeaders).toEqual({
@@ -98,6 +107,7 @@ describe("Agent Custom Headers", () => {
     });
 
     const agent = await Agent.create({});
+    activeAgent = agent;
     const gatewayConfig = agent.getGatewayConfig();
 
     expect(gatewayConfig.defaultHeaders?.["X-Settings"]).toBe("settings-val");
@@ -124,6 +134,7 @@ describe("Agent Custom Headers", () => {
     });
 
     const agent = await Agent.create({});
+    activeAgent = agent;
     const gatewayConfig = agent.getGatewayConfig();
 
     expect(gatewayConfig.defaultHeaders?.["X-Header"]).toBe("settings-val");

--- a/packages/agent-sdk/tests/agent/agent.planModeDefault.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.planModeDefault.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Agent } from "../../src/agent.js";
 import { ConfigurationService } from "../../src/services/configurationService.js";
 import fs from "node:fs/promises";
@@ -69,6 +69,7 @@ vi.mock("node:fs/promises", () => {
 
 describe("Agent Plan Mode Default", () => {
   const workdir = "/test/workdir";
+  let activeAgent: Agent | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -76,8 +77,16 @@ describe("Agent Plan Mode Default", () => {
     mockMemoryServiceInstance.readMemoryFile.mockResolvedValue("");
   });
 
+  afterEach(async () => {
+    if (activeAgent) {
+      await activeAgent.destroy();
+      activeAgent = undefined;
+    }
+  });
+
   it("should generate plan file path when default mode is plan in configuration", async () => {
     const agent = await Agent.create({ workdir });
+    activeAgent = agent;
 
     // Wait for async plan file path generation
     // We need to wait because the callback is async and not awaited in initialize
@@ -129,6 +138,7 @@ describe("Agent Plan Mode Default", () => {
     });
 
     const agent = await Agent.create({ workdir });
+    activeAgent = agent;
 
     expect(agent.getPermissionMode()).toBe("default");
     expect(agent.getPlanFilePath()).toBeUndefined();

--- a/packages/agent-sdk/tests/agent/agent.subagentMessagesCallback.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.subagentMessagesCallback.test.ts
@@ -3,7 +3,15 @@
  * Tests that the callback is properly invoked when subagent messages are updated
  */
 
-import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from "vitest";
 import { Agent } from "@/agent.js";
 import type { AgentCallbacks } from "@/types/index.js";
 import type { SubagentConfiguration } from "@/utils/subagentParser.js";
@@ -38,6 +46,7 @@ vi.mock("@/utils/subagentParser", () => ({
 }));
 
 describe("Agent - onSubagentMessagesChange Callback Tests", () => {
+  let activeAgent: Agent | undefined;
   let agent: Agent;
   let mockOnSubagentMessagesChange: Mock<
     NonNullable<AgentCallbacks["onSubagentMessagesChange"]>
@@ -55,6 +64,16 @@ describe("Agent - onSubagentMessagesChange Callback Tests", () => {
         onSubagentMessagesChange: mockOnSubagentMessagesChange,
       },
     });
+  });
+
+  afterEach(async () => {
+    if (agent) {
+      await agent.destroy();
+    }
+    if (activeAgent) {
+      await activeAgent.destroy();
+      activeAgent = undefined;
+    }
   });
 
   describe("Direct SubagentManager Integration Tests", () => {
@@ -253,6 +272,7 @@ describe("Agent - onSubagentMessagesChange Callback Tests", () => {
           // No onSubagentMessagesChange callback
         },
       });
+      activeAgent = agentWithoutCallback;
 
       const subagentManager = (
         agentWithoutCallback as unknown as {
@@ -288,6 +308,7 @@ describe("Agent - onSubagentMessagesChange Callback Tests", () => {
           onSubagentMessagesChange: errorCallback,
         },
       });
+      activeAgent = agentWithErrorCallback;
 
       const subagentManager = (
         agentWithErrorCallback as unknown as {

--- a/packages/agent-sdk/tests/agent/agent.toolRecursion.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.toolRecursion.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Agent } from "@/agent.js";
 import * as aiService from "@/services/aiService.js";
 import { createMockToolManager } from "../helpers/mockFactories.js";
@@ -46,6 +46,12 @@ describe("Agent Tool Recursion Tests", () => {
     aiServiceCallCount = 0;
 
     vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    if (agent) {
+      await agent.destroy();
+    }
   });
 
   it("should trigger recursive AI call after tool execution and verify message structure", async () => {

--- a/packages/agent-sdk/tests/agent/exitPlanMode.clearContext.test.ts
+++ b/packages/agent-sdk/tests/agent/exitPlanMode.clearContext.test.ts
@@ -37,6 +37,7 @@ vi.mock("@/services/aiService", () => ({
 
 describe("ExitPlanMode Clear Context", () => {
   const originalEnv = process.env;
+  let activeAgent: Agent | undefined;
   let mockStdout: typeof process.stdout.write;
   let mockStderr: typeof process.stderr.write;
   let originalStdoutWrite: typeof process.stdout.write;
@@ -56,7 +57,11 @@ describe("ExitPlanMode Clear Context", () => {
     process.stderr.write = mockStderr;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    if (activeAgent) {
+      await activeAgent.destroy();
+      activeAgent = undefined;
+    }
     process.env = originalEnv;
     process.stdout.write = originalStdoutWrite;
     process.stderr.write = originalStderrWrite;
@@ -78,6 +83,7 @@ describe("ExitPlanMode Clear Context", () => {
       permissionMode: "plan",
       canUseTool: mockCallback as PermissionCallback,
     });
+    activeAgent = agent;
 
     // Add some initial messages
     agent.sendMessage("Initial message");
@@ -126,6 +132,7 @@ describe("ExitPlanMode Clear Context", () => {
       permissionMode: "plan",
       canUseTool: mockCallback as PermissionCallback,
     });
+    activeAgent = agent;
 
     // Add some initial messages
     await agent.sendMessage("Initial message");
@@ -164,6 +171,7 @@ describe("ExitPlanMode Clear Context", () => {
       permissionMode: "plan",
       canUseTool: mockCallback as PermissionCallback,
     });
+    activeAgent = agent;
 
     // Add some initial messages
     await agent.sendMessage("Initial message");
@@ -202,6 +210,7 @@ describe("ExitPlanMode Clear Context", () => {
       permissionMode: "plan",
       canUseTool: mockCallback as PermissionCallback,
     });
+    activeAgent = agent;
 
     // Wait for plan file path generation
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -234,6 +243,7 @@ describe("ExitPlanMode Clear Context", () => {
       permissionMode: "default",
       canUseTool: mockCallback as PermissionCallback,
     });
+    activeAgent = agent;
 
     // Add some initial messages
     await agent.sendMessage("Initial message");

--- a/packages/agent-sdk/tests/agent/exitPlanMode.integration.test.ts
+++ b/packages/agent-sdk/tests/agent/exitPlanMode.integration.test.ts
@@ -16,6 +16,7 @@ vi.mock("fs/promises");
 
 describe("ExitPlanMode Integration", () => {
   const originalEnv = process.env;
+  let activeAgent: Agent | undefined;
   let mockStdout: typeof process.stdout.write;
   let mockStderr: typeof process.stderr.write;
   let originalStdoutWrite: typeof process.stdout.write;
@@ -35,7 +36,11 @@ describe("ExitPlanMode Integration", () => {
     process.stderr.write = mockStderr;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    if (activeAgent) {
+      await activeAgent.destroy();
+      activeAgent = undefined;
+    }
     process.env = originalEnv;
     process.stdout.write = originalStdoutWrite;
     process.stderr.write = originalStderrWrite;
@@ -47,6 +52,7 @@ describe("ExitPlanMode Integration", () => {
       workdir: "/test/workdir",
       permissionMode: "default",
     });
+    activeAgent = agent;
 
     // Both tools always in tool list (runtime guard handles mode validation)
     const tools = (
@@ -100,6 +106,7 @@ describe("ExitPlanMode Integration", () => {
     const agent = await Agent.create({
       workdir: "/test/workdir",
     });
+    activeAgent = agent;
 
     vi.mocked(readFile).mockResolvedValue("test");
 
@@ -129,6 +136,7 @@ describe("ExitPlanMode Integration", () => {
       permissionMode: "plan",
       canUseTool: mockCallback as PermissionCallback,
     });
+    activeAgent = agent;
 
     // Wait for plan file path generation
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -167,6 +175,7 @@ describe("ExitPlanMode Integration", () => {
       permissionMode: "plan",
       canUseTool: mockCallback as PermissionCallback,
     });
+    activeAgent = agent;
 
     // Wait for plan file path generation
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -199,6 +208,7 @@ describe("ExitPlanMode Integration", () => {
       permissionMode: "plan",
       canUseTool: mockCallback as PermissionCallback,
     });
+    activeAgent = agent;
 
     // Wait for plan file path generation
     await new Promise((resolve) => setTimeout(resolve, 100));

--- a/packages/agent-sdk/tests/agentAllowedRules.test.ts
+++ b/packages/agent-sdk/tests/agentAllowedRules.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Agent } from "../src/agent.js";
 import * as fs from "fs/promises";
 
@@ -7,6 +7,7 @@ vi.mock("./services/session.js");
 
 describe("Agent Allowed Rules", () => {
   const workdir = "/test/workdir";
+  let activeAgent: Agent | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -15,11 +16,19 @@ describe("Agent Allowed Rules", () => {
     vi.mocked(fs.writeFile).mockResolvedValue(undefined);
   });
 
+  afterEach(async () => {
+    if (activeAgent) {
+      await activeAgent.destroy();
+      activeAgent = undefined;
+    }
+  });
+
   it("should return both user and default rules in getAllowedRules", async () => {
     const agent = await Agent.create({
       workdir,
       permissionMode: "default",
     });
+    activeAgent = agent;
 
     await agent.addPermissionRule("Bash(npm install lodash)");
 
@@ -33,6 +42,7 @@ describe("Agent Allowed Rules", () => {
       workdir,
       permissionMode: "default",
     });
+    activeAgent = agent;
 
     await agent.addPermissionRule("Bash(npm install lodash)");
 
@@ -46,6 +56,7 @@ describe("Agent Allowed Rules", () => {
       workdir,
       permissionMode: "default",
     });
+    activeAgent = agent;
 
     await agent.addPermissionRule("Bash(git status)");
 

--- a/packages/agent-sdk/tests/agentHooksOption.test.ts
+++ b/packages/agent-sdk/tests/agentHooksOption.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Agent } from "../src/agent.js";
 import * as fs from "fs/promises";
 
@@ -7,12 +7,20 @@ vi.mock("./services/session.js");
 
 describe("Agent hooks option", () => {
   const workdir = "/test/workdir";
+  let activeAgent: Agent | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(fs.readFile).mockResolvedValue("");
     vi.mocked(fs.mkdir).mockResolvedValue(undefined);
     vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    if (activeAgent) {
+      await activeAgent.destroy();
+      activeAgent = undefined;
+    }
   });
 
   it("should load hooks from AgentOptions into HookManager", async () => {
@@ -29,6 +37,7 @@ describe("Agent hooks option", () => {
       permissionMode: "default",
       hooks,
     });
+    activeAgent = agent;
 
     const hookManager = agent["hookManager"];
     expect(hookManager.hasHooks("Stop")).toBe(true);
@@ -40,6 +49,7 @@ describe("Agent hooks option", () => {
       workdir,
       permissionMode: "default",
     });
+    activeAgent = agent;
 
     const hookManager = agent["hookManager"];
     expect(hookManager.hasHooks("Stop")).toBe(false);

--- a/packages/agent-sdk/tests/defaultGitRules.test.ts
+++ b/packages/agent-sdk/tests/defaultGitRules.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Agent } from "../src/agent.js";
 import * as fs from "fs/promises";
 
@@ -7,6 +7,7 @@ vi.mock("./services/session.js");
 
 describe("Default Allowed Git Rules", () => {
   const workdir = "/test/workdir";
+  let activeAgent: Agent | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -15,11 +16,19 @@ describe("Default Allowed Git Rules", () => {
     vi.mocked(fs.writeFile).mockResolvedValue(undefined);
   });
 
+  afterEach(async () => {
+    if (activeAgent) {
+      await activeAgent.destroy();
+      activeAgent = undefined;
+    }
+  });
+
   it("should allow read-only git commands by default", async () => {
     const agent = await Agent.create({
       workdir,
       permissionMode: "default",
     });
+    activeAgent = agent;
 
     const gitCommands = [
       "git status",
@@ -52,6 +61,7 @@ describe("Default Allowed Git Rules", () => {
       workdir,
       permissionMode: "default",
     });
+    activeAgent = agent;
 
     const destructiveGitCommands = [
       "git reset --hard",
@@ -77,6 +87,7 @@ describe("Default Allowed Git Rules", () => {
       workdir,
       permissionMode: "default",
     });
+    activeAgent = agent;
 
     const safeCommands = [
       "echo hello",

--- a/packages/agent-sdk/tests/integration/agent-tools.test.ts
+++ b/packages/agent-sdk/tests/integration/agent-tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Agent } from "../../src/agent.js";
 import { ToolManager } from "../../src/managers/toolManager.js";
 
@@ -22,14 +22,24 @@ vi.mock("fs", async (importOriginal) => {
 });
 
 describe("Agent Tool Selection Integration", () => {
+  let activeAgent: Agent | undefined;
+
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    if (activeAgent) {
+      await activeAgent.destroy();
+      activeAgent = undefined;
+    }
   });
 
   it("should initialize agent with all tools by default", async () => {
     const agent = await Agent.create({
       apiKey: "test-key",
     });
+    activeAgent = agent;
 
     // Access private toolManager for verification
     const toolManager = (agent as unknown as { toolManager: ToolManager })
@@ -48,6 +58,7 @@ describe("Agent Tool Selection Integration", () => {
       apiKey: "test-key",
       tools: ["Read", "Edit"],
     });
+    activeAgent = agent;
 
     const toolManager = (agent as unknown as { toolManager: ToolManager })
       .toolManager;
@@ -65,6 +76,7 @@ describe("Agent Tool Selection Integration", () => {
       apiKey: "test-key",
       tools: [],
     });
+    activeAgent = agent;
 
     const toolManager = (agent as unknown as { toolManager: ToolManager })
       .toolManager;

--- a/packages/agent-sdk/tests/integration/planMode.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/planMode.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock os.homedir BEFORE importing anything else
 vi.mock("node:os", async (importOriginal) => {
@@ -25,6 +25,7 @@ describe("Plan Mode Integration", () => {
   const workdir = "/test/workdir";
   const homedir = "/home/user";
   const planDir = path.join(homedir, ".wave", "plans");
+  let activeAgent: Agent | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -36,8 +37,16 @@ describe("Plan Mode Integration", () => {
     process.env.WAVE_BASE_URL = "https://test.api";
   });
 
+  afterEach(async () => {
+    if (activeAgent) {
+      await activeAgent.destroy();
+      activeAgent = undefined;
+    }
+  });
+
   it("should transition to plan mode and generate a plan file path", async () => {
     const agent = await Agent.create({ workdir });
+    activeAgent = agent;
 
     expect(agent.getPermissionMode()).toBe("default");
 
@@ -54,6 +63,7 @@ describe("Plan Mode Integration", () => {
 
   it("should include plan reminder in messages when in plan mode", async () => {
     const agent = await Agent.create({ workdir });
+    activeAgent = agent;
 
     // Transition to plan mode and wait for path generation
     agent.setPermissionMode("plan");
@@ -120,6 +130,7 @@ describe("Plan Mode Integration", () => {
 
   it("should allow writing to the plan file but block other writes", async () => {
     const agent = await Agent.create({ workdir });
+    activeAgent = agent;
 
     // Transition to plan mode and wait for path generation
     agent.setPermissionMode("plan");
@@ -195,6 +206,7 @@ describe("Plan Mode Integration", () => {
         },
       },
     });
+    activeAgent = agent;
 
     expect(agent.getPermissionMode()).toBe("bypassPermissions");
     expect(agent.getPlanFilePath()).toBeUndefined();
@@ -223,5 +235,6 @@ describe("Plan Mode Integration", () => {
     expect(tools).toContain("EnterPlanMode");
 
     await agent.destroy();
+    activeAgent = undefined;
   });
 });

--- a/packages/agent-sdk/tests/integration/recoveryMessage.test.ts
+++ b/packages/agent-sdk/tests/integration/recoveryMessage.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Agent } from "../../src/agent.js";
 import * as aiService from "../../src/services/aiService.js";
 import { MessageManager } from "../../src/managers/messageManager.js";
@@ -33,14 +33,24 @@ vi.mock("fs", async (importOriginal) => {
 });
 
 describe("Recovery Message Integration", () => {
+  let activeAgent: Agent | undefined;
+
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    if (activeAgent) {
+      await activeAgent.destroy();
+      activeAgent = undefined;
+    }
   });
 
   it("should automatically trigger recovery when finish_reason is 'length'", async () => {
     const agent = await Agent.create({
       apiKey: "test-key",
     });
+    activeAgent = agent;
 
     const messageManager = (
       agent as unknown as { messageManager: MessageManager }

--- a/packages/agent-sdk/tests/plugin-loading-integration.test.ts
+++ b/packages/agent-sdk/tests/plugin-loading-integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Agent } from "../src/agent.js";
 import { MarketplaceService } from "../src/services/MarketplaceService.js";
 import { PluginLoader } from "../src/services/pluginLoader.js";
@@ -12,6 +12,7 @@ vi.mock("fs");
 
 describe("Agent Plugin Loading Integration", () => {
   const workdir = "/test/workdir";
+  let activeAgent: Agent | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -81,8 +82,16 @@ describe("Agent Plugin Loading Integration", () => {
     } as unknown as typeof fs.readFileSync);
   });
 
+  afterEach(async () => {
+    if (activeAgent) {
+      await activeAgent.destroy();
+      activeAgent = undefined;
+    }
+  });
+
   it("should load plugins from both user and project configurations and skip unmentioned ones", async () => {
     const agent = await Agent.create({ workdir });
+    activeAgent = agent;
 
     const loadedPlugins = agent["pluginManager"].getPlugins();
     const pluginNames = loadedPlugins.map((p) => p.name);

--- a/packages/agent-sdk/tests/rewindTaskListSync.test.ts
+++ b/packages/agent-sdk/tests/rewindTaskListSync.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { TaskManager } from "../src/services/taskManager.js";
 import { Agent } from "../src/agent.js";
 import { MessageManager } from "../src/managers/messageManager.js";
@@ -45,6 +45,15 @@ vi.mock("../../src/utils/globalLogger.js", () => ({
 }));
 
 describe("Rewind Task List Sync", () => {
+  let activeAgent: Agent | undefined;
+
+  afterEach(async () => {
+    if (activeAgent) {
+      await activeAgent.destroy();
+      activeAgent = undefined;
+    }
+  });
+
   describe("TaskManager.refreshTasks", () => {
     it("should emit tasksChange event", async () => {
       const container = new Container();
@@ -75,6 +84,7 @@ describe("Rewind Task List Sync", () => {
           onTasksChange: onTasksChangeSpy,
         },
       });
+      activeAgent = agent;
 
       // Mock listTasks to return some tasks
       const mockTasks = [{ id: "1", subject: "test", status: "pending" }];

--- a/packages/agent-sdk/tests/setup.ts
+++ b/packages/agent-sdk/tests/setup.ts
@@ -1,5 +1,16 @@
-import { vi } from "vitest";
+import { vi, afterEach } from "vitest";
 import * as os from "os";
+
+// Safety net: hint V8 to reclaim memory between tests. Leaked Agent resources
+// (timers, watchers) from tests that forgot to call destroy() accumulate under
+// coverage instrumentation. Forcing GC when available (--expose-gc) helps keep
+// peak memory bounded within a single fork worker.
+afterEach(() => {
+  const gc = (globalThis as { gc?: () => void }).gc;
+  if (gc) {
+    gc();
+  }
+});
 
 // Mock os.homedir globally to prevent tests from reading user settings
 // Mock both "os" and "node:os" specifiers since Vitest treats them as different modules


### PR DESCRIPTION
## Problem

CI intermittently failed with **JavaScript heap OOM** in the agent-sdk test suite. The heap grew to ~8GB on a ~7GB GitHub Actions runner.

**Root cause**: 19 test files created `Agent` instances via `Agent.create()` but never called `destroy()`. Each Agent holds live resources: `setInterval` timers (cronManager 60s/5s, remoteSettingsService 60min), chokidar file watchers (liveConfigManager, skillManager), MCP/LSP connections, background task processes, and OTel telemetry. Under V8 coverage instrumentation, leaked resources across 235 test files compounded until the process OOM'd.

## Fix

Added `afterEach` cleanup calling `agent.destroy()` to all 19 test files using the `activeAgent` tracker pattern for inline-created agents:

- **Group A (4 files)** — augmented existing `afterEach` with destroy before env/mock restoration
- **Group B (14 files)** — added new `afterEach` with `activeAgent` tracker for inline `Agent.create()` calls
- **Group C (1 file, `agent.abort.test.ts`)** — added `afterEach` for beforeEach-assigned agent + `activeTestAgent` tracker for 9 inline test agents

Also added a GC hint in `tests/setup.ts` `afterEach` as a best-effort safety net.

## Verification

- All 19 modified test files pass individually (60 tests)
- Full agent-sdk suite: **235 files, 3124 passed** (1 skipped)
- Full CI (`pnpm run ci`): **all 3 packages pass, 4366 tests total, 0 failures** — without any memory caps or worker limits