### PR TITLE
perf(ci): simplify pnpm cache with setup-node cache:'pnpm' and add push trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,15 @@
 name: CI
 
 on:
+  push:
+    branches: [ main, develop ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+      - 'specs/**'
+      - 'docs/**'
+      - 'scripts/**'
+      - 'LICENSE'
   pull_request:
     branches: [ main, develop ]
   workflow_dispatch:
@@ -39,20 +48,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Get pnpm store directory
-        if: steps.filter.outputs.code == 'true'
-        id: pnpm-cache
-        run: echo "store_path=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-      - name: Cache pnpm dependencies
-        if: steps.filter.outputs.code == 'true'
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pnpm-cache.outputs.store_path }}
-          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            pnpm-${{ runner.os }}-
+          cache: 'pnpm'
 
       - name: Cache ripgrep binaries
         if: steps.filter.outputs.code == 'true'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,18 +32,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: echo "store_path=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-      - name: Cache pnpm dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pnpm-cache.outputs.store_path }}
-          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            pnpm-${{ runner.os }}-
+          cache: 'pnpm'
 
       - name: Cache ripgrep binaries
         uses: actions/cache@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,17 +22,7 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: echo "store_path=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        with:
-          path: ${{ steps.pnpm-cache.outputs.store_path }}
-          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            pnpm-${{ runner.os }}-
+          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build

--- a/.github/workflows/vsce-release.yml
+++ b/.github/workflows/vsce-release.yml
@@ -24,18 +24,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: echo "store_path=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-      - name: Cache pnpm dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pnpm-cache.outputs.store_path }}
-          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            pnpm-${{ runner.os }}-
+          cache: 'pnpm'
 
       - name: Cache ripgrep binaries
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary

- Replace explicit `actions/cache@v4` + manual `pnpm store path` detection with `setup-node` built-in `cache: 'pnpm'` across all 4 workflows (ci, pages, publish, vsce-release)
- Add `push` trigger to `main`/`develop` in `ci.yml` with `paths-ignore` to seed the default-branch cache, enabling cross-branch cache hits for all PRs
- Net -36 lines of config while maintaining equivalent cache behavior

## Why

GitHub Actions cache is scoped per-branch — PR branches can only restore their own cache or the default branch's cache. The previous workflow only triggered on `pull_request`, so `main` never had a cache to seed from. Every new PR branch started cold.

Adding `push: [main, develop]` seeds the default-branch cache. All subsequent PRs hit it via `setup-node`'s built-in `restore-keys` fallback.

## Alignment with industry

`setup-node` with `cache: 'pnpm'` is the dominant pattern used by vite, astro, vue, nuxt, and pnpm's own official docs. Simplifies config by removing the manual store-path step and explicit `actions/cache` block.

Ripgrep binary caching (`actions/cache@v4`) is preserved — `setup-node` only manages pnpm store.