### PR TITLE
test: remove CI test retry to expose flaky tests early

### DIFF
--- a/packages/agent-sdk/tests/agent/agent.autoAccept.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.autoAccept.test.ts
@@ -94,7 +94,7 @@ describe("Agent Auto-Accept Permissions Integration", () => {
       { workdir: tempDir, taskManager },
     );
     expect(mockCallback).not.toHaveBeenCalled();
-  }, 15000);
+  });
 
   it("should load persistent rules on startup", async () => {
     // 1. Create a settings.local.json file

--- a/packages/agent-sdk/tests/agent/agent.autoAccept.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.autoAccept.test.ts
@@ -94,7 +94,7 @@ describe("Agent Auto-Accept Permissions Integration", () => {
       { workdir: tempDir, taskManager },
     );
     expect(mockCallback).not.toHaveBeenCalled();
-  });
+  }, 15000);
 
   it("should load persistent rules on startup", async () => {
     // 1. Create a settings.local.json file

--- a/packages/agent-sdk/tests/agent/agent.autoAccept.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.autoAccept.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as os from "os";
+import type { ChildProcess } from "child_process";
 
 import { TaskManager } from "../../src/services/taskManager.js";
 import { Agent } from "@/agent.js";
@@ -7,6 +8,11 @@ import { ToolManager } from "../../src/managers/toolManager.js";
 import type { PermissionCallback } from "../../src/types/permissions.js";
 import * as fs from "fs/promises";
 import * as path from "path";
+
+// Mock child_process to prevent real command execution (e.g. npm install triggers network I/O)
+vi.mock("child_process");
+import { spawn } from "child_process";
+const mockSpawn = vi.mocked(spawn);
 
 describe("Agent Auto-Accept Permissions Integration", () => {
   let tempDir: string;
@@ -21,6 +27,18 @@ describe("Agent Auto-Accept Permissions Integration", () => {
       WAVE_BASE_URL: "https://test.api",
     };
     vi.mocked(os.homedir).mockReturnValue(os.tmpdir());
+
+    // Return a mock process that exits successfully without executing anything
+    mockSpawn.mockReturnValue({
+      pid: 1234,
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() },
+      on: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
+        if (event === "exit") setTimeout(() => callback(0), 0);
+      }),
+      kill: vi.fn(),
+      killed: false,
+    } as unknown as ChildProcess);
   });
 
   afterEach(async () => {

--- a/packages/agent-sdk/vitest.config.ts
+++ b/packages/agent-sdk/vitest.config.ts
@@ -2,14 +2,6 @@ import { defineConfig } from "vitest/config";
 import { resolve } from "path";
 
 export default defineConfig(() => {
-  // Check if running in CI environment - supports multiple CI environment variables
-  const isCI = !!(process.env.CI === "true");
-
-  // Output retry configuration info in CI environment
-  if (isCI) {
-    console.log(`🔄 CI environment detected: test retry enabled (2 retries)`);
-  }
-
   return {
     test: {
       globals: true,
@@ -17,8 +9,6 @@ export default defineConfig(() => {
       environment: "node",
       include: ["tests/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
       exclude: ["node_modules", "dist"],
-      // Enable retry in CI environment: failed tests will retry up to 2 times
-      retry: isCI ? 2 : 0,
       // reporters: ["dot"],
       coverage: {
         provider: "v8" as const,

--- a/packages/code/vitest.config.ts
+++ b/packages/code/vitest.config.ts
@@ -2,22 +2,12 @@ import { defineConfig } from "vitest/config";
 import { resolve } from "path";
 
 export default defineConfig(() => {
-  // Check if running in CI environment - supports multiple CI environment variables
-  const isCI = !!(process.env.CI === "true");
-
-  // Output retry configuration info in CI environment
-  if (isCI) {
-    console.log(`🔄 CI environment detected: test retry enabled (2 retries)`);
-  }
-
   return {
     test: {
       globals: true,
       environment: "node",
       include: ["tests/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
       exclude: ["node_modules", "dist"],
-      // Enable retry in CI environment: failed tests will retry up to 2 times
-      retry: isCI ? 2 : 0,
       // reporters: ["dot"],
       coverage: {
         provider: "v8" as const,


### PR DESCRIPTION
## Summary

Remove the `isCI`-based retry (2 retries) and the associated log message from both `packages/agent-sdk/vitest.config.ts` and `packages/code/vitest.config.ts`.

## Why

Retrying failed tests in CI masks flaky tests. Removing the retry ensures tests fail fast, exposing flaky tests early so they can be investigated and fixed.