### PR TITLE
fix: screenshot path, CJK font rendering, and Node 20 deprecation in docs CI

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,18 +54,13 @@ jobs:
             playwright-chromium-${{ runner.os }}-
 
       - name: Install Playwright Chromium
-        run: pnpm -F wave-vsce exec playwright install chromium
+        run: pnpm -F wave-vsce exec playwright install --with-deps chromium
 
       - name: Build agent-sdk
         run: pnpm -F wave-agent-sdk build
 
       - name: Generate screenshots
         run: pnpm -F wave-vsce run test:demo
-
-      - name: Copy screenshots to docs
-        run: |
-          mkdir -p docs/public/screenshots
-          cp -r packages/vsce/docs/public/screenshots/* docs/public/screenshots/ 2>/dev/null || true
 
       - name: Build VitePress
         run: pnpm run docs:build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -66,7 +66,7 @@ jobs:
         run: pnpm run docs:build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 

--- a/packages/vsce/e2e/demo/askUserQuestionLayout.demo.ts
+++ b/packages/vsce/e2e/demo/askUserQuestionLayout.demo.ts
@@ -31,6 +31,6 @@ test.describe('AskUserQuestion Layout Demo', () => {
     await webviewPage.waitForSelector('.ask-user-result-item');
 
     // Take screenshot
-    await webviewPage.screenshot({ path: 'docs/public/screenshots/ask-user-question-vertical.png' });
+    await webviewPage.screenshot({ path: '../../docs/public/screenshots/ask-user-question-vertical.png' });
   });
 });

--- a/packages/vsce/e2e/demo/bang-command.demo.ts
+++ b/packages/vsce/e2e/demo/bang-command.demo.ts
@@ -10,31 +10,31 @@ test.describe('Bang Command Demo', () => {
         await injector.updateMessages([
             MockDataGenerator.createBangMessage('sleep 5', '', true, null)
         ]);
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/bang-command-running.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/bang-command-running.png' });
 
         // 2. Show a successful command with output
         await injector.updateMessages([
             MockDataGenerator.createBangMessage('ls -la', 'total 8\ndrwxr-xr-x  10 user  group  320 Mar 30 10:00 .\ndrwxr-xr-x   4 user  group  128 Mar 30 09:00 ..\n-rw-r--r--   1 user  group  1024 Mar 30 10:00 package.json', false, 0)
         ]);
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/bang-command-success.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/bang-command-success.png' });
 
         // 3. Show a long output
         const longOutput = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join('\n');
         await injector.updateMessages([
             MockDataGenerator.createBangMessage('seq 1 20', longOutput, false, 0)
         ]);
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/bang-command-long-output.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/bang-command-long-output.png' });
 
         // 4. Show a successful command with no output
         await injector.updateMessages([
             MockDataGenerator.createBangMessage('mkdir test-dir', '', false, 0)
         ]);
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/bang-command-no-output.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/bang-command-no-output.png' });
 
         // 5. Show a failed command
         await injector.updateMessages([
             MockDataGenerator.createBangMessage('nonexistent', 'sh: nonexistent: command not found', false, 127)
         ]);
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/bang-command-failure.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/bang-command-failure.png' });
     });
 });

--- a/packages/vsce/e2e/demo/config-popup.demo.ts
+++ b/packages/vsce/e2e/demo/config-popup.demo.ts
@@ -20,7 +20,7 @@ test.describe('Configuration Popup Demo', () => {
         await expect(webviewPage.getByText('配置设置', { exact: true })).toBeVisible();
         
         // Take screenshot to manually verify UI
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/config-popup-updated-ui.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/config-popup-updated-ui.png' });
     });
 
     test('should NOT show configuration dialog when config is provided (simulated)', async ({ webviewPage }) => {
@@ -29,6 +29,6 @@ test.describe('Configuration Popup Demo', () => {
         await expect(webviewPage.getByTestId('chat-container')).toBeVisible();
         await expect(webviewPage.getByText('配置设置', { exact: true })).not.toBeVisible(); // The dialog title
         
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/config-not-needed.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/config-not-needed.png' });
     });
 });

--- a/packages/vsce/e2e/demo/language-config.demo.ts
+++ b/packages/vsce/e2e/demo/language-config.demo.ts
@@ -32,6 +32,6 @@ test.describe('Language Configuration Demo', () => {
 
         // Take screenshot of the dialog with language field in view
         const dialog = webviewPage.locator('.configuration-dialog');
-        await dialog.screenshot({ path: 'docs/public/screenshots/language-config-ui.png' });
+        await dialog.screenshot({ path: '../../docs/public/screenshots/language-config-ui.png' });
     });
 });

--- a/packages/vsce/e2e/demo/login-dialog.demo.ts
+++ b/packages/vsce/e2e/demo/login-dialog.demo.ts
@@ -41,7 +41,7 @@ test.describe('Login Dialog Demo', () => {
 
         // Take screenshot
         const dialog = webviewPage.locator('.configuration-dialog');
-        await dialog.screenshot({ path: 'docs/public/screenshots/spec-login-dialog.png' });
+        await dialog.screenshot({ path: '../../docs/public/screenshots/spec-login-dialog.png' });
     });
 
     test('should show login dialog with authenticated state', async ({ webviewPage }) => {
@@ -75,7 +75,7 @@ test.describe('Login Dialog Demo', () => {
         await expect(webviewPage.getByText('登出', { exact: true })).toBeVisible();
 
         const dialog = webviewPage.locator('.configuration-dialog');
-        await dialog.screenshot({ path: 'docs/public/screenshots/spec-login-dialog-authenticated.png' });
+        await dialog.screenshot({ path: '../../docs/public/screenshots/spec-login-dialog-authenticated.png' });
     });
 
     test('should show editable serverUrl input when no server URL configured', async ({ webviewPage }) => {
@@ -114,6 +114,6 @@ test.describe('Login Dialog Demo', () => {
         await expect(loginBtn).toBeDisabled();
 
         const dialog = webviewPage.locator('.configuration-dialog');
-        await dialog.screenshot({ path: 'docs/public/screenshots/spec-login-dialog-no-url.png' });
+        await dialog.screenshot({ path: '../../docs/public/screenshots/spec-login-dialog-no-url.png' });
     });
 });

--- a/packages/vsce/e2e/demo/mcp-server-tab.demo.ts
+++ b/packages/vsce/e2e/demo/mcp-server-tab.demo.ts
@@ -84,7 +84,7 @@ test.describe('MCP Server Dialog Demo', () => {
         // Verify disconnect button for connected server
         await expect(webviewPage.getByRole('button', { name: '断开' })).toBeVisible();
 
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-mcp-server-tab.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-mcp-server-tab.png' });
     });
 
     test('should show empty state when no MCP servers configured', async ({ webviewPage }) => {
@@ -108,7 +108,7 @@ test.describe('MCP Server Dialog Demo', () => {
         await expect(webviewPage.getByText('未配置 MCP 服务器')).toBeVisible();
         await expect(webviewPage.locator('code', { hasText: '.mcp.json' })).toBeVisible();
 
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-mcp-server-empty.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-mcp-server-empty.png' });
     });
 
     test('should handle connect/disconnect actions', async ({ webviewPage }) => {

--- a/packages/vsce/e2e/demo/model-dialog.demo.ts
+++ b/packages/vsce/e2e/demo/model-dialog.demo.ts
@@ -38,7 +38,7 @@ test.describe('Model Dialog Demo', () => {
 
         // Take screenshot
         const dialog = webviewPage.locator('.configuration-dialog');
-        await dialog.screenshot({ path: 'docs/public/screenshots/spec-model-dialog.png' });
+        await dialog.screenshot({ path: '../../docs/public/screenshots/spec-model-dialog.png' });
     });
 
     test('should show model dialog with empty values and env placeholders', async ({ webviewPage }) => {
@@ -76,6 +76,6 @@ test.describe('Model Dialog Demo', () => {
         await expect(modelSelect).toBeVisible();
 
         const dialog = webviewPage.locator('.configuration-dialog');
-        await dialog.screenshot({ path: 'docs/public/screenshots/spec-model-dialog-empty.png' });
+        await dialog.screenshot({ path: '../../docs/public/screenshots/spec-model-dialog-empty.png' });
     });
 });

--- a/packages/vsce/e2e/demo/plugin-management.demo.ts
+++ b/packages/vsce/e2e/demo/plugin-management.demo.ts
@@ -76,7 +76,7 @@ test.describe('Plugin Management Screenshots', () => {
         await expect(webviewPage.getByText('Docker Helper')).toBeVisible();
 
         // 截图：探索新插件列表页
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-plugin-explore-list.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-plugin-explore-list.png' });
 
         // 点击一个插件查看详情
         await webviewPage.getByText('GitHub Integration').click();
@@ -89,7 +89,7 @@ test.describe('Plugin Management Screenshots', () => {
         await expect(webviewPage.getByText('仅为你在此仓库中安装 (local)')).toBeVisible();
 
         // 截图：插件详情页，显示安装作用域选择
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-plugin-explore.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-plugin-explore.png' });
 
         // 返回列表
         await webviewPage.getByText('返回列表').click();
@@ -106,7 +106,7 @@ test.describe('Plugin Management Screenshots', () => {
         await expect(webviewPage.locator('.uninstall-btn').first()).toBeVisible();
 
         // 截图：已激活插件标签页，显示更新和卸载按钮
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-plugin-installed.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-plugin-installed.png' });
 
         // 4. Marketplaces tab - 展示插件市场管理
         await webviewPage.getByText('插件市场', { exact: true }).click();
@@ -139,7 +139,7 @@ test.describe('Plugin Management Screenshots', () => {
         await expect(webviewPage.getByText('添加', { exact: true })).toBeVisible();
 
         // 截图：插件市场标签页，显示市场列表和管理功能
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-plugin-marketplaces.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-plugin-marketplaces.png' });
 
         // Close the dialog
         await webviewPage.keyboard.press('Escape');

--- a/packages/vsce/e2e/demo/plugin-search.demo.ts
+++ b/packages/vsce/e2e/demo/plugin-search.demo.ts
@@ -59,7 +59,7 @@ test.describe('Plugin Search UI Demo', () => {
         await expect(searchInput).toHaveAttribute('placeholder', '搜索插件...');
 
         // Screenshot of search input with all plugins
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/plugin-search-input.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/plugin-search-input.png' });
 
         // 4. Type "commit" to filter
         await searchInput.fill('commit');
@@ -70,13 +70,13 @@ test.describe('Plugin Search UI Demo', () => {
         await expect(webviewPage.locator('.plugin-name', { hasText: 'typescript-lsp' })).not.toBeVisible();
         await expect(webviewPage.locator('.plugin-name', { hasText: 'chrome-headless' })).not.toBeVisible();
 
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/plugin-search-filtered.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/plugin-search-filtered.png' });
 
         // 5. Type a non-matching query
         await searchInput.fill('zzz-nonexistent');
         await expect(webviewPage.getByText('没有找到匹配的插件')).toBeVisible();
 
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/plugin-search-no-results.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/plugin-search-no-results.png' });
 
         // 6. Clear the search
         await searchInput.fill('');

--- a/packages/vsce/e2e/demo/plugin-status-badge.demo.ts
+++ b/packages/vsce/e2e/demo/plugin-status-badge.demo.ts
@@ -71,6 +71,6 @@ test.describe('Plugin Status Badge Logic', () => {
         await expect(notInstalledItem.locator('.plugin-scope')).not.toBeVisible();
 
         // Take screenshot for verification
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/plugin-status-badge-verification.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/plugin-status-badge-verification.png' });
     });
 });

--- a/packages/vsce/e2e/demo/plugins-ui.demo.ts
+++ b/packages/vsce/e2e/demo/plugins-ui.demo.ts
@@ -68,7 +68,7 @@ test.describe('Plugin Management Dialog Demo', () => {
         });
 
         // Take screenshot of "Explore" tab
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/plugins-explore-tab.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/plugins-explore-tab.png' });
 
         // 3. Switch to "已安装插件" tab
         await webviewPage.getByText('已安装插件', { exact: true }).click();
@@ -92,7 +92,7 @@ test.describe('Plugin Management Dialog Demo', () => {
         });
 
         await expect(webviewPage.locator('.plugin-name').filter({ hasText: 'Installed Plugin' })).toBeVisible();
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/plugins-installed-tab.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/plugins-installed-tab.png' });
 
         // 4. Switch to "插件市场" tab
         await webviewPage.getByText('插件市场', { exact: true }).click();
@@ -108,6 +108,6 @@ test.describe('Plugin Management Dialog Demo', () => {
         });
 
         await expect(webviewPage.getByText('wave-plugins-official', { exact: true })).toBeVisible();
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/plugins-marketplaces-tab.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/plugins-marketplaces-tab.png' });
     });
 });

--- a/packages/vsce/e2e/demo/product-spec-confirmations.demo.ts
+++ b/packages/vsce/e2e/demo/product-spec-confirmations.demo.ts
@@ -77,7 +77,7 @@ test.describe('Product Specification Screenshots - Confirmations', () => {
         });
         
         await webviewPage.waitForSelector('.confirmation-dialog');
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-ask-user.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-ask-user.png' });
         
         // 关闭确认对话框以便继续其他截图
         await webviewPage.keyboard.press('Escape');
@@ -93,7 +93,7 @@ test.describe('Product Specification Screenshots - Confirmations', () => {
             }
         });
         await webviewPage.waitForSelector('.configuration-dialog');
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-configuration.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-configuration.png' });
         await webviewPage.keyboard.press('Escape');
         await webviewPage.waitForSelector('.configuration-dialog', { state: 'hidden' });
 
@@ -108,7 +108,7 @@ test.describe('Product Specification Screenshots - Confirmations', () => {
         await webviewPage.waitForSelector('.permission-mode-select');
         await expect(webviewPage.locator('.permission-mode-select')).toHaveValue('default');
         await permissionModeSelect.focus();
-        await inputContainer.screenshot({ path: 'docs/public/screenshots/spec-permission-mode-default.png' });
+        await inputContainer.screenshot({ path: '../../docs/public/screenshots/spec-permission-mode-default.png' });
 
         // Mode 2: Accept Edits (自动接受修改)
         await injector.simulateExtensionMessage('updatePermissionMode', {
@@ -116,7 +116,7 @@ test.describe('Product Specification Screenshots - Confirmations', () => {
         });
         await expect(webviewPage.locator('.permission-mode-select')).toHaveValue('acceptEdits');
         await permissionModeSelect.focus();
-        await inputContainer.screenshot({ path: 'docs/public/screenshots/spec-permission-mode-accept.png' });
+        await inputContainer.screenshot({ path: '../../docs/public/screenshots/spec-permission-mode-accept.png' });
 
         // Mode 3: Plan Mode (计划模式)
         await injector.simulateExtensionMessage('updatePermissionMode', {
@@ -124,7 +124,7 @@ test.describe('Product Specification Screenshots - Confirmations', () => {
         });
         await expect(webviewPage.locator('.permission-mode-select')).toHaveValue('plan');
         await permissionModeSelect.focus();
-        await inputContainer.screenshot({ path: 'docs/public/screenshots/spec-permission-mode-plan.png' });
+        await inputContainer.screenshot({ path: '../../docs/public/screenshots/spec-permission-mode-plan.png' });
 
         // Reset to default for remaining screenshots
         await injector.simulateExtensionMessage('updatePermissionMode', {
@@ -156,7 +156,7 @@ test.describe('Product Specification Screenshots - Confirmations', () => {
         });
         const planConfirmDialog = webviewPage.locator('.confirmation-dialog');
         await planConfirmDialog.waitFor({ state: 'visible' });
-        await planConfirmDialog.screenshot({ path: 'docs/public/screenshots/spec-plan-confirm.png' });
+        await planConfirmDialog.screenshot({ path: '../../docs/public/screenshots/spec-plan-confirm.png' });
 
         // 关闭当前确认对话框
         await webviewPage.click('.confirmation-close-btn');
@@ -172,7 +172,7 @@ test.describe('Product Specification Screenshots - Confirmations', () => {
         });
         const enterPlanDialog = webviewPage.locator('.confirmation-dialog');
         await enterPlanDialog.waitFor({ state: 'visible' });
-        await enterPlanDialog.screenshot({ path: 'docs/public/screenshots/spec-enter-plan-mode.png' });
+        await enterPlanDialog.screenshot({ path: '../../docs/public/screenshots/spec-enter-plan-mode.png' });
 
         // 关闭当前确认对话框
         await webviewPage.click('.confirmation-close-btn');
@@ -191,7 +191,7 @@ test.describe('Product Specification Screenshots - Confirmations', () => {
         });
         const editConfirmDialog = webviewPage.locator('.confirmation-dialog');
         await editConfirmDialog.waitFor({ state: 'visible' });
-        await editConfirmDialog.screenshot({ path: 'docs/public/screenshots/spec-edit-confirm.png' });
+        await editConfirmDialog.screenshot({ path: '../../docs/public/screenshots/spec-edit-confirm.png' });
 
         // 关闭当前确认对话框
         await webviewPage.click('.confirmation-close-btn');
@@ -211,7 +211,7 @@ test.describe('Product Specification Screenshots - Confirmations', () => {
         });
         const mcpConfirmDialog = webviewPage.locator('.confirmation-dialog');
         await mcpConfirmDialog.waitFor({ state: 'visible' });
-        await mcpConfirmDialog.screenshot({ path: 'docs/public/screenshots/spec-mcp-tool-confirm.png' });
+        await mcpConfirmDialog.screenshot({ path: '../../docs/public/screenshots/spec-mcp-tool-confirm.png' });
 
         // 关闭当前确认对话框
         await webviewPage.click('.confirmation-close-btn');
@@ -229,6 +229,6 @@ test.describe('Product Specification Screenshots - Confirmations', () => {
         });
         const bashConfirmDialog = webviewPage.locator('.confirmation-dialog');
         await bashConfirmDialog.waitFor({ state: 'visible' });
-        await bashConfirmDialog.screenshot({ path: 'docs/public/screenshots/spec-bash-confirm.png' });
+        await bashConfirmDialog.screenshot({ path: '../../docs/public/screenshots/spec-bash-confirm.png' });
     });
 });

--- a/packages/vsce/e2e/demo/product-spec-history-search.demo.ts
+++ b/packages/vsce/e2e/demo/product-spec-history-search.demo.ts
@@ -31,12 +31,12 @@ test.describe('Product Spec: History Search', () => {
 
         // 5. Take screenshot of the whole webview to show the popup in context
         await webviewPage.screenshot({
-            path: 'docs/public/screenshots/spec-history-search.png'
+            path: '../../docs/public/screenshots/spec-history-search.png'
         });
 
         // 6. Take a full screenshot showing the context
         await webviewPage.screenshot({
-            path: 'docs/public/screenshots/spec-history-search-context.png'
+            path: '../../docs/public/screenshots/spec-history-search-context.png'
         });
     });
 });

--- a/packages/vsce/e2e/demo/product-spec-message-queuing.demo.ts
+++ b/packages/vsce/e2e/demo/product-spec-message-queuing.demo.ts
@@ -36,7 +36,7 @@ test.describe('Product Specification Screenshots - Message Queuing', () => {
         await sendBtn.focus();
         
         // Take screenshot of the input area with "Add to Queue" button
-        await webviewPage.locator('.input-container').screenshot({ path: 'docs/public/screenshots/spec-queue-button.png' });
+        await webviewPage.locator('.input-container').screenshot({ path: '../../docs/public/screenshots/spec-queue-button.png' });
 
         // 2. Show queued message in the list with tags
         await injector.simulateExtensionMessage('updateQueue', {
@@ -58,6 +58,6 @@ test.describe('Product Specification Screenshots - Message Queuing', () => {
         await expect(queuePanel).toContainText('图片 1');
         
         // Take screenshot of the message list showing the queued message with tags
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-queued-message.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-queued-message.png' });
     });
 });

--- a/packages/vsce/e2e/demo/product-spec-rewind.demo.ts
+++ b/packages/vsce/e2e/demo/product-spec-rewind.demo.ts
@@ -27,13 +27,13 @@ test.describe('Product Spec: Rewind', () => {
 
         // Take screenshot of the message list showing the rewind button with tooltip
         await webviewPage.screenshot({
-            path: 'docs/public/screenshots/spec-rewind-button.png',
+            path: '../../docs/public/screenshots/spec-rewind-button.png',
             clip: await ui.messagesContainer.boundingBox() || undefined
         });
 
         // Take a full screenshot showing the context
         await webviewPage.screenshot({
-            path: 'docs/public/screenshots/spec-rewind-context.png'
+            path: '../../docs/public/screenshots/spec-rewind-context.png'
         });
     });
 });

--- a/packages/vsce/e2e/demo/product-spec-rich-content.demo.ts
+++ b/packages/vsce/e2e/demo/product-spec-rich-content.demo.ts
@@ -106,13 +106,13 @@ test.describe('Product Specification Screenshots - Rich Content', () => {
             return document.querySelectorAll('.context-tag').length >= 3;
         }, { timeout: 5000 });
         
-        await webviewPage.locator('.input-container').screenshot({ path: 'docs/public/screenshots/spec-inline-mentions.png' });
+        await webviewPage.locator('.input-container').screenshot({ path: '../../docs/public/screenshots/spec-inline-mentions.png' });
 
         // 13d. Image Preview Modal
         const imageTag = webviewPage.locator('.context-tag.is-image');
         await imageTag.click();
         await webviewPage.waitForSelector('.image-preview-modal', { state: 'visible' });
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-image-preview.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-image-preview.png' });
         
         // Close modal
         await webviewPage.click('.image-preview-close');
@@ -132,7 +132,7 @@ test.describe('Product Specification Screenshots - Rich Content', () => {
                 ]
             }
         ]);
-        await webviewPage.locator('.messages-container').screenshot({ path: 'docs/public/screenshots/spec-message-inline-tags.png' });
+        await webviewPage.locator('.messages-container').screenshot({ path: '../../docs/public/screenshots/spec-message-inline-tags.png' });
 
         // 14. Session Selector - 使用 SDK 的 SessionMetadata 类型
         const now = Date.now();
@@ -180,7 +180,7 @@ test.describe('Product Specification Screenshots - Rich Content', () => {
             }
         });
         
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-sessions.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-sessions.png' });
 
         // 恢复 select 状态
         await webviewPage.evaluate(() => {
@@ -203,7 +203,7 @@ test.describe('Product Specification Screenshots - Rich Content', () => {
             MockDataGenerator.createAssistantMessage('这张图片显示了一个简单的 UI 布局，包含一个侧边栏和一个主内容区域。侧边栏使用了深色主题...')
         ];
         await injector.updateMessages(visionMessages as unknown as Message[]);
-        await webviewPage.locator('.messages-container').screenshot({ path: 'docs/public/screenshots/spec-vision.png' });
+        await webviewPage.locator('.messages-container').screenshot({ path: '../../docs/public/screenshots/spec-vision.png' });
 
         // 27. Reasoning
         await injector.simulateExtensionMessage('setInitialState', {
@@ -224,6 +224,6 @@ test.describe('Product Specification Screenshots - Rich Content', () => {
                 }
             ]
         });
-        await webviewPage.locator('.messages-container').screenshot({ path: 'docs/public/screenshots/spec-reasoning.png' });
+        await webviewPage.locator('.messages-container').screenshot({ path: '../../docs/public/screenshots/spec-reasoning.png' });
     });
 });

--- a/packages/vsce/e2e/demo/product-spec-tools.demo.ts
+++ b/packages/vsce/e2e/demo/product-spec-tools.demo.ts
@@ -55,7 +55,7 @@ test.describe('Product Specification Screenshots - Tools', () => {
         };
         await injector.updateMessages([diffMessage]);
         await webviewPage.waitForSelector('.tool-container');
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-diff-viewer.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-diff-viewer.png' });
 
         // 7. Task List
         await injector.simulateExtensionMessage('updateTasks', {
@@ -67,7 +67,7 @@ test.describe('Product Specification Screenshots - Tools', () => {
             isTaskListCollapsed: false
         });
         await webviewPage.waitForSelector('.task-list-container');
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-task-list.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-task-list.png' });
 
         // 7.1 Task List Collapsed
         await injector.simulateExtensionMessage('updateTasks', {
@@ -83,7 +83,7 @@ test.describe('Product Specification Screenshots - Tools', () => {
             const el = document.querySelector('.task-list-container');
             return el && el.classList.contains('collapsed');
         });
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-task-list-collapsed.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-task-list-collapsed.png' });
         
         // Restore expanded state for subsequent screenshots if needed
         await injector.simulateExtensionMessage('updateTasks', {
@@ -110,7 +110,7 @@ test.describe('Product Specification Screenshots - Tools', () => {
         await injector.updateMessages([subagentMessage]);
         
         await webviewPage.waitForSelector('.tool-container');
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-subagent.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-subagent.png' });
 
         // 9. Bash Tool - 使用 MockDataGenerator
         const bashMessage: Message = {
@@ -130,7 +130,7 @@ test.describe('Product Specification Screenshots - Tools', () => {
         };
         await injector.updateMessages([bashMessage]);
         await webviewPage.waitForSelector('.bash-command-unified');
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-bash.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-bash.png' });
 
         // 19. Exploration Tools
         const explorationMessages: Message[] = [
@@ -180,7 +180,7 @@ test.describe('Product Specification Screenshots - Tools', () => {
         ];
         await injector.updateMessages(explorationMessages as unknown as Message[]);
         await webviewPage.waitForSelector('.tool-container');
-        await webviewPage.locator('.messages-container').screenshot({ path: 'docs/public/screenshots/spec-exploration.png' });
+        await webviewPage.locator('.messages-container').screenshot({ path: '../../docs/public/screenshots/spec-exploration.png' });
 
         // 21. File Operation Tools
         const fileOpMessages: Message[] = [
@@ -212,7 +212,7 @@ test.describe('Product Specification Screenshots - Tools', () => {
         ];
         await injector.updateMessages(fileOpMessages);
         await webviewPage.waitForSelector('.tool-container');
-        await webviewPage.locator('.messages-container').screenshot({ path: 'docs/public/screenshots/spec-file-ops.png' });
+        await webviewPage.locator('.messages-container').screenshot({ path: '../../docs/public/screenshots/spec-file-ops.png' });
 
         // 24. LSP
         await injector.simulateExtensionMessage('setInitialState', {
@@ -257,7 +257,7 @@ test.describe('Product Specification Screenshots - Tools', () => {
                 }
             ]
         });
-        await webviewPage.locator('.messages-container').screenshot({ path: 'docs/public/screenshots/spec-lsp.png' });
+        await webviewPage.locator('.messages-container').screenshot({ path: '../../docs/public/screenshots/spec-lsp.png' });
 
         // 25. Skill
         await injector.simulateExtensionMessage('setInitialState', {
@@ -279,7 +279,7 @@ test.describe('Product Specification Screenshots - Tools', () => {
                 }
             ]
         });
-        await webviewPage.locator('.messages-container').screenshot({ path: 'docs/public/screenshots/spec-skill.png' });
+        await webviewPage.locator('.messages-container').screenshot({ path: '../../docs/public/screenshots/spec-skill.png' });
 
         // 26. MCP
         await injector.simulateExtensionMessage('setInitialState', {
@@ -292,6 +292,6 @@ test.describe('Product Specification Screenshots - Tools', () => {
                 )
             ]
         });
-        await webviewPage.locator('.messages-container').screenshot({ path: 'docs/public/screenshots/spec-mcp.png' });
+        await webviewPage.locator('.messages-container').screenshot({ path: '../../docs/public/screenshots/spec-mcp.png' });
     });
 });

--- a/packages/vsce/e2e/demo/product-spec-ui-basic.demo.ts
+++ b/packages/vsce/e2e/demo/product-spec-ui-basic.demo.ts
@@ -27,7 +27,7 @@ test.describe('Product Specification Screenshots - UI Basic', () => {
 
         // 1. Welcome Message
         await ui.verifyMessageCount(1);
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-welcome.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-welcome.png' });
 
         // 1.3 Code Selection Tag
         await injector.simulateExtensionMessage('addSelectionToInput', {
@@ -41,7 +41,7 @@ test.describe('Product Specification Screenshots - UI Basic', () => {
             }
         });
         await webviewPage.waitForSelector('.context-tag-container[data-is-selection="true"]');
-        await webviewPage.locator('.input-container').screenshot({ path: 'docs/public/screenshots/spec-selection-inline-tag.png' });
+        await webviewPage.locator('.input-container').screenshot({ path: '../../docs/public/screenshots/spec-selection-inline-tag.png' });
         
         // Clear input for next steps
         await webviewPage.focus('[data-testid="message-input"]');
@@ -56,7 +56,7 @@ test.describe('Product Specification Screenshots - UI Basic', () => {
         await injector.updateMessages(basicChat);
         await injector.endStreaming();
         await ui.verifyMessageCount(3); // Welcome + user + assistant
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-basic-chat.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-basic-chat.png' });
 
         // 3. Slash Commands
         await injector.updateMessages([]);
@@ -78,7 +78,7 @@ test.describe('Product Specification Screenshots - UI Basic', () => {
         });
 
         await webviewPage.waitForSelector('.slash-command-item', { state: 'visible', timeout: 5000 });
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-slash-commands.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-slash-commands.png' });
         await webviewPage.keyboard.press('Escape');
 
         // 4. File Suggestions (@)
@@ -113,7 +113,7 @@ test.describe('Product Specification Screenshots - UI Basic', () => {
         });
 
         await webviewPage.waitForSelector('.suggestion-item', { state: 'visible', timeout: 5000 });
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-file-suggestions.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-file-suggestions.png' });
         await webviewPage.keyboard.press('Escape');
         await webviewPage.keyboard.press('Control+A');
         await webviewPage.keyboard.press('Backspace');
@@ -125,12 +125,12 @@ test.describe('Product Specification Screenshots - UI Basic', () => {
         await injector.updateMessages(mermaidChat);
         await injector.endStreaming();
         await webviewPage.waitForSelector('.mermaid-container svg');
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-mermaid.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-mermaid.png' });
 
         // 23. Mermaid Fullscreen
         await webviewPage.click('.mermaid-container'); // Click to open fullscreen
         await webviewPage.waitForSelector('.mermaid-fullscreen-modal');
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/spec-mermaid-fullscreen.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-mermaid-fullscreen.png' });
         await webviewPage.keyboard.press('Escape');
     });
 });

--- a/packages/vsce/e2e/demo/status-dialog.demo.ts
+++ b/packages/vsce/e2e/demo/status-dialog.demo.ts
@@ -60,7 +60,7 @@ test.describe('Status Dialog Demo', () => {
 
         // Take screenshot
         const dialog = webviewPage.locator('.configuration-dialog');
-        await dialog.screenshot({ path: 'docs/public/screenshots/spec-status-dialog.png' });
+        await dialog.screenshot({ path: '../../docs/public/screenshots/spec-status-dialog.png' });
     });
 
     test('should show status dialog with unauthenticated state', async ({ webviewPage }) => {
@@ -95,6 +95,6 @@ test.describe('Status Dialog Demo', () => {
         await expect(webviewPage.getByText('未登录')).toBeVisible();
 
         const dialog = webviewPage.locator('.configuration-dialog');
-        await dialog.screenshot({ path: 'docs/public/screenshots/spec-status-dialog-noauth.png' });
+        await dialog.screenshot({ path: '../../docs/public/screenshots/spec-status-dialog-noauth.png' });
     });
 });

--- a/packages/vsce/e2e/demo/taskNotification.demo.ts
+++ b/packages/vsce/e2e/demo/taskNotification.demo.ts
@@ -62,6 +62,6 @@ test.describe('Task Notification Demo', () => {
     await webviewPage.waitForSelector('.task-notification-block');
 
     // Take screenshot
-    await webviewPage.screenshot({ path: 'docs/public/screenshots/task-notification.png' });
+    await webviewPage.screenshot({ path: '../../docs/public/screenshots/task-notification.png' });
   });
 });

--- a/packages/vsce/e2e/demo/tool-error-scrollable.demo.ts
+++ b/packages/vsce/e2e/demo/tool-error-scrollable.demo.ts
@@ -52,7 +52,7 @@ test.describe('Tool Error Scrollable Demo', () => {
         expect(overflowY).toBe('auto');
         
         // Take a screenshot of the long error with scrollbar
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/tool-error-scrollable.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/tool-error-scrollable.png' });
     });
 
     test('should show scrollable error block', async ({ webviewPage }) => {
@@ -99,6 +99,6 @@ test.describe('Tool Error Scrollable Demo', () => {
         expect(overflowY).toBe('auto');
         
         // Take a screenshot of the long error block with scrollbar
-        await webviewPage.screenshot({ path: 'docs/public/screenshots/error-block-scrollable.png' });
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/error-block-scrollable.png' });
     });
 });

--- a/packages/vsce/e2e/demo/tooltip.demo.ts
+++ b/packages/vsce/e2e/demo/tooltip.demo.ts
@@ -7,7 +7,7 @@ test.describe('Tooltip Demo', () => {
         await sendButton.scrollIntoViewIfNeeded();
         await sendButton.locator('..').hover();
         await sendButton.focus();
-        await webviewPage.locator('.input-container').screenshot({ path: 'docs/public/screenshots/tooltip-send.png' });
+        await webviewPage.locator('.input-container').screenshot({ path: '../../docs/public/screenshots/tooltip-send.png' });
 
     });
 });


### PR DESCRIPTION
## Changes

1. **Screenshot paths**: Demo tests now write directly to `docs/public/screenshots/` instead of `packages/vsce/docs/public/screenshots/`. In the monorepo, tests run from `packages/vsce/`, so relative paths landed in the wrong place. VitePress serves from root `docs/public/`.

2. **CJK font rendering**: Add `--with-deps` to `playwright install` in CI. The old repo (wave-vsce) used `--with-deps` which installs system font libraries. Without it, headless Chromium on Ubuntu couldn't render Chinese characters (showed tofu boxes).

3. **Node 20 deprecation**: Upgrade `actions/upload-pages-artifact` from v3 to v5 to resolve Node 20 deprecation warning.