### PR TITLE
fix: eliminate stale closure race in Ink useInput handlers via reducer-owns-data pattern

### DIFF
--- a/packages/code/src/components/CommandSelector.tsx
+++ b/packages/code/src/components/CommandSelector.tsx
@@ -23,20 +23,16 @@ export const CommandSelector: React.FC<CommandSelectorProps> = ({
   commands = [],
 }) => {
   const MAX_VISIBLE_ITEMS = 3;
-  const [state, dispatch] = useReducer(selectorReducer, {
+  const [state, dispatch] = useReducer(selectorReducer<SlashCommand>, {
     selectedIndex: 0,
     pendingDecision: null,
-  } as SelectorState);
+    items: [],
+  } as SelectorState<SlashCommand>);
 
-  const { selectedIndex, pendingDecision } = state;
-
-  // Reset selected index when search query changes
-  useEffect(() => {
-    dispatch({ type: "RESET_INDEX" });
-  }, [searchQuery]);
+  const { selectedIndex, pendingDecision, items: filteredCommands } = state;
 
   // Merge agent commands and local commands, memoized to stabilize useEffect dependencies
-  const filteredCommands = useMemo(() => {
+  const computedCommands = useMemo(() => {
     const allCommands = [...AVAILABLE_COMMANDS, ...commands];
     return allCommands.filter(
       (command) =>
@@ -44,6 +40,11 @@ export const CommandSelector: React.FC<CommandSelectorProps> = ({
         command.id.toLowerCase().includes(searchQuery.toLowerCase()),
     );
   }, [searchQuery, commands]);
+
+  // Sync computed commands into reducer state (SET_ITEMS also resets index)
+  useEffect(() => {
+    dispatch({ type: "SET_ITEMS", items: computedCommands });
+  }, [computedCommands]);
 
   // Handle decisions from reducer
   useEffect(() => {
@@ -91,12 +92,7 @@ export const CommandSelector: React.FC<CommandSelectorProps> = ({
   );
 
   useInput((input, key) => {
-    dispatch({
-      type: "HANDLE_KEY",
-      key,
-      maxIndex: filteredCommands.length - 1,
-      hasInsert: !!onInsert,
-    });
+    dispatch({ type: "HANDLE_KEY", key, hasInsert: !!onInsert });
   });
 
   if (filteredCommands.length === 0) {

--- a/packages/code/src/components/ConfirmationSelector.tsx
+++ b/packages/code/src/components/ConfirmationSelector.tsx
@@ -108,7 +108,6 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
         type: "HANDLE_KEY",
         input,
         key,
-        currentQuestion,
         questions,
       });
     } else {

--- a/packages/code/src/components/DiscoverView.tsx
+++ b/packages/code/src/components/DiscoverView.tsx
@@ -1,37 +1,52 @@
 import React, { useReducer, useEffect } from "react";
 import { Box, useInput } from "ink";
+import type { MarketplacePluginEntry } from "wave-agent-sdk";
 import { usePluginManagerContext } from "../contexts/PluginManagerContext.js";
 import { PluginList } from "./PluginList.js";
-import { selectorReducer } from "../reducers/selectorReducer.js";
+import {
+  selectorReducer,
+  type SelectorState,
+} from "../reducers/selectorReducer.js";
+
+type DiscoverablePlugin = MarketplacePluginEntry & {
+  marketplace: string;
+  installed: boolean;
+  version?: string;
+};
 
 export const DiscoverView: React.FC = () => {
   const { discoverablePlugins, actions } = usePluginManagerContext();
-  const [state, dispatch] = useReducer(selectorReducer, {
+  const [state, dispatch] = useReducer(selectorReducer<DiscoverablePlugin>, {
     selectedIndex: 0,
     pendingDecision: null,
-  });
+    items: [],
+  } as SelectorState<DiscoverablePlugin>);
 
-  const { selectedIndex, pendingDecision } = state;
+  const { selectedIndex, pendingDecision, items } = state;
+
+  // Sync plugins into reducer state
+  useEffect(() => {
+    dispatch({ type: "SET_ITEMS", items: discoverablePlugins });
+  }, [discoverablePlugins]);
 
   useInput((_input, key) => {
     dispatch({
       type: "HANDLE_KEY",
       key,
-      maxIndex: discoverablePlugins.length - 1,
       hasInsert: false,
     });
   });
 
   useEffect(() => {
     if (pendingDecision === "select") {
-      const plugin = discoverablePlugins[selectedIndex];
+      const plugin = items[selectedIndex];
       if (plugin) {
         actions.setSelectedId(`${plugin.name}@${plugin.marketplace}`);
         actions.setView("PLUGIN_DETAIL");
       }
       dispatch({ type: "CLEAR_DECISION" });
     }
-  }, [pendingDecision, selectedIndex, discoverablePlugins, actions]);
+  }, [pendingDecision, selectedIndex, items, actions]);
 
   return (
     <Box flexDirection="column">

--- a/packages/code/src/components/FileSelector.tsx
+++ b/packages/code/src/components/FileSelector.tsx
@@ -23,16 +23,17 @@ export const FileSelector: React.FC<FileSelectorProps> = ({
   onSelect,
   onCancel,
 }) => {
-  const [state, dispatch] = useReducer(selectorReducer, {
+  const [state, dispatch] = useReducer(selectorReducer<FileItem>, {
     selectedIndex: 0,
     pendingDecision: null,
-  } as SelectorState);
+    items: [],
+  } as SelectorState<FileItem>);
 
-  const { selectedIndex, pendingDecision } = state;
+  const { selectedIndex, pendingDecision, items: filesInState } = state;
 
-  // Reset selected index when files change
+  // Sync files from props into reducer state (SET_ITEMS also resets index)
   useEffect(() => {
-    dispatch({ type: "RESET_INDEX" });
+    dispatch({ type: "SET_ITEMS", items: files });
   }, [files]);
 
   // Handle decisions from reducer
@@ -40,21 +41,20 @@ export const FileSelector: React.FC<FileSelectorProps> = ({
     if (!pendingDecision) return;
 
     if (pendingDecision === "select" || pendingDecision === "insert") {
-      if (files.length > 0 && selectedIndex < files.length) {
-        onSelect(files[selectedIndex].path);
+      if (filesInState.length > 0 && selectedIndex < filesInState.length) {
+        onSelect(filesInState[selectedIndex].path);
       }
     } else if (pendingDecision === "cancel") {
       onCancel();
     }
 
     dispatch({ type: "CLEAR_DECISION" });
-  }, [pendingDecision, selectedIndex, files, onSelect, onCancel]);
+  }, [pendingDecision, selectedIndex, filesInState, onSelect, onCancel]);
 
   useInput((input, key) => {
     dispatch({
       type: "HANDLE_KEY",
       key,
-      maxIndex: files.length - 1,
       hasInsert: true, // For FileSelector, Tab is also select
     });
   });

--- a/packages/code/src/components/HistorySearch.tsx
+++ b/packages/code/src/components/HistorySearch.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer, useEffect, useState } from "react";
+import React, { useReducer, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import { PromptHistoryManager, type PromptEntry } from "wave-agent-sdk";
 import {
@@ -18,20 +18,18 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
   onCancel,
 }) => {
   const MAX_VISIBLE_ITEMS = 5;
-  const [state, dispatch] = useReducer(selectorReducer, {
+  const [state, dispatch] = useReducer(selectorReducer<PromptEntry>, {
     selectedIndex: 0,
     pendingDecision: null,
-  } as SelectorState);
-  const [entries, setEntries] = useState<PromptEntry[]>([]);
+    items: [],
+  } as SelectorState<PromptEntry>);
 
-  const { selectedIndex, pendingDecision } = state;
+  const { selectedIndex, pendingDecision, items: entries } = state;
 
   useEffect(() => {
     const fetchHistory = async () => {
       const results = await PromptHistoryManager.searchHistory(searchQuery);
-      const limitedResults = results.slice(0, 20);
-      setEntries(limitedResults);
-      dispatch({ type: "RESET_INDEX" });
+      dispatch({ type: "SET_ITEMS", items: results.slice(0, 20) });
     };
     fetchHistory();
   }, [searchQuery]);
@@ -52,12 +50,7 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
   }, [pendingDecision, selectedIndex, entries, onSelect, onCancel]);
 
   useInput((input, key) => {
-    dispatch({
-      type: "HANDLE_KEY",
-      key,
-      maxIndex: entries.length - 1,
-      hasInsert: false,
-    });
+    dispatch({ type: "HANDLE_KEY", key, hasInsert: false });
   });
 
   if (entries.length === 0) {

--- a/packages/code/src/components/InstalledView.tsx
+++ b/packages/code/src/components/InstalledView.tsx
@@ -1,36 +1,50 @@
 import React, { useReducer, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
+import type { InstalledPlugin } from "wave-agent-sdk";
 import { usePluginManagerContext } from "../contexts/PluginManagerContext.js";
-import { selectorReducer } from "../reducers/selectorReducer.js";
+import {
+  selectorReducer,
+  type SelectorState,
+} from "../reducers/selectorReducer.js";
+
+type InstalledPluginWithEnabled = InstalledPlugin & { enabled: boolean };
 
 export const InstalledView: React.FC = () => {
   const { installedPlugins, actions } = usePluginManagerContext();
-  const [state, dispatch] = useReducer(selectorReducer, {
-    selectedIndex: 0,
-    pendingDecision: null,
-  });
+  const [state, dispatch] = useReducer(
+    selectorReducer<InstalledPluginWithEnabled>,
+    {
+      selectedIndex: 0,
+      pendingDecision: null,
+      items: [],
+    } as SelectorState<InstalledPluginWithEnabled>,
+  );
 
-  const { selectedIndex, pendingDecision } = state;
+  const { selectedIndex, pendingDecision, items } = state;
+
+  // Sync plugins into reducer state
+  useEffect(() => {
+    dispatch({ type: "SET_ITEMS", items: installedPlugins });
+  }, [installedPlugins]);
 
   useInput((_input, key) => {
     dispatch({
       type: "HANDLE_KEY",
       key,
-      maxIndex: installedPlugins.length - 1,
       hasInsert: false,
     });
   });
 
   useEffect(() => {
     if (pendingDecision === "select") {
-      const plugin = installedPlugins[selectedIndex];
+      const plugin = items[selectedIndex];
       if (plugin) {
         actions.setSelectedId(`${plugin.name}@${plugin.marketplace}`);
         actions.setView("PLUGIN_DETAIL");
       }
       dispatch({ type: "CLEAR_DECISION" });
     }
-  }, [pendingDecision, selectedIndex, installedPlugins, actions]);
+  }, [pendingDecision, selectedIndex, items, actions]);
 
   if (installedPlugins.length === 0) {
     return (

--- a/packages/code/src/components/MarketplaceDetail.tsx
+++ b/packages/code/src/components/MarketplaceDetail.tsx
@@ -1,16 +1,27 @@
 import React, { useReducer, useEffect, useMemo } from "react";
 import { Box, Text, useInput } from "ink";
 import { usePluginManagerContext } from "../contexts/PluginManagerContext.js";
-import { selectorReducer } from "../reducers/selectorReducer.js";
+import {
+  selectorReducer,
+  type SelectorState,
+} from "../reducers/selectorReducer.js";
 
 export const MarketplaceDetail: React.FC = () => {
   const { state, marketplaces, actions } = usePluginManagerContext();
-  const [selectorState, dispatch] = useReducer(selectorReducer, {
-    selectedIndex: 0,
-    pendingDecision: null,
-  });
+  const [selectorState, dispatch] = useReducer(
+    selectorReducer<{ id: string; label: string }>,
+    {
+      selectedIndex: 0,
+      pendingDecision: null,
+      items: [],
+    } as SelectorState<{ id: string; label: string }>,
+  );
 
-  const { selectedIndex: selectedActionIndex, pendingDecision } = selectorState;
+  const {
+    selectedIndex: selectedActionIndex,
+    pendingDecision,
+    items: actionsList,
+  } = selectorState;
 
   const marketplace = marketplaces.find((m) => m.name === state.selectedId);
 
@@ -27,13 +38,17 @@ export const MarketplaceDetail: React.FC = () => {
     [marketplace?.autoUpdate],
   );
 
+  // Sync ACTIONS into reducer state
+  useEffect(() => {
+    dispatch({ type: "SET_ITEMS", items: [...ACTIONS] });
+  }, [ACTIONS]);
+
   useInput((_input, key) => {
     if (state.isLoading && !key.escape) return;
 
     dispatch({
       type: "HANDLE_KEY",
       key,
-      maxIndex: ACTIONS.length - 1,
       hasInsert: false,
     });
   });
@@ -42,12 +57,12 @@ export const MarketplaceDetail: React.FC = () => {
     if (!pendingDecision) return;
 
     if (pendingDecision === "select" && marketplace && !state.isLoading) {
-      const action = ACTIONS[selectedActionIndex].id;
+      const action = actionsList[selectedActionIndex]?.id;
       if (action === "toggle-auto-update") {
         actions.toggleAutoUpdate(marketplace.name, !marketplace.autoUpdate);
       } else if (action === "update") {
         actions.updateMarketplace(marketplace.name);
-      } else {
+      } else if (action === "remove") {
         actions.removeMarketplace(marketplace.name);
       }
     } else if (pendingDecision === "cancel") {
@@ -58,10 +73,10 @@ export const MarketplaceDetail: React.FC = () => {
   }, [
     pendingDecision,
     selectedActionIndex,
+    actionsList,
     marketplace,
     state.isLoading,
     actions,
-    ACTIONS,
   ]);
 
   if (!marketplace) {

--- a/packages/code/src/components/MarketplaceView.tsx
+++ b/packages/code/src/components/MarketplaceView.tsx
@@ -1,18 +1,28 @@
 import React, { useReducer, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
+import type { KnownMarketplace } from "wave-agent-sdk";
 import { usePluginManagerContext } from "../contexts/PluginManagerContext.js";
-import { selectorReducer } from "../reducers/selectorReducer.js";
+import {
+  selectorReducer,
+  type SelectorState,
+} from "../reducers/selectorReducer.js";
 
 import { MarketplaceList } from "./MarketplaceList.js";
 
 export const MarketplaceView: React.FC = () => {
   const { marketplaces, actions } = usePluginManagerContext();
-  const [state, dispatch] = useReducer(selectorReducer, {
+  const [state, dispatch] = useReducer(selectorReducer<KnownMarketplace>, {
     selectedIndex: 0,
     pendingDecision: null,
-  });
+    items: [],
+  } as SelectorState<KnownMarketplace>);
 
-  const { selectedIndex, pendingDecision } = state;
+  const { selectedIndex, pendingDecision, items } = state;
+
+  // Sync marketplaces into reducer state
+  useEffect(() => {
+    dispatch({ type: "SET_ITEMS", items: marketplaces });
+  }, [marketplaces]);
 
   useInput((input, key) => {
     if (input === "a") {
@@ -23,21 +33,20 @@ export const MarketplaceView: React.FC = () => {
     dispatch({
       type: "HANDLE_KEY",
       key,
-      maxIndex: marketplaces.length - 1,
       hasInsert: false,
     });
   });
 
   useEffect(() => {
     if (pendingDecision === "select") {
-      const mk = marketplaces[selectedIndex];
+      const mk = items[selectedIndex];
       if (mk) {
         actions.setSelectedId(mk.name);
         actions.setView("MARKETPLACE_DETAIL");
       }
       dispatch({ type: "CLEAR_DECISION" });
     }
-  }, [pendingDecision, selectedIndex, marketplaces, actions]);
+  }, [pendingDecision, selectedIndex, items, actions]);
 
   return (
     <Box flexDirection="column">

--- a/packages/code/src/components/ModelSelector.tsx
+++ b/packages/code/src/components/ModelSelector.tsx
@@ -1,6 +1,9 @@
 import React, { useReducer, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
-import { selectorReducer } from "../reducers/selectorReducer.js";
+import {
+  selectorReducer,
+  type SelectorState,
+} from "../reducers/selectorReducer.js";
 
 export interface ModelSelectorProps {
   onCancel: () => void;
@@ -17,29 +20,29 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   configuredModels,
   onSelectModel,
 }) => {
-  const [state, dispatch] = useReducer(selectorReducer, {
+  const [state, dispatch] = useReducer(selectorReducer<string>, {
     selectedIndex:
       configuredModels.indexOf(currentModel) !== -1
         ? configuredModels.indexOf(currentModel)
         : 0,
     pendingDecision: null,
-  });
+    items: configuredModels,
+  } as SelectorState<string>);
 
-  const { selectedIndex, pendingDecision } = state;
+  const { selectedIndex, pendingDecision, items: models } = state;
 
   useInput((_input, key) => {
     dispatch({
       type: "HANDLE_KEY",
       key,
-      maxIndex: configuredModels.length - 1,
       hasInsert: false,
     });
   });
 
   useEffect(() => {
     if (pendingDecision === "select") {
-      if (configuredModels.length > 0) {
-        onSelectModel(configuredModels[selectedIndex]);
+      if (models.length > 0) {
+        onSelectModel(models[selectedIndex]);
       }
       onCancel();
       dispatch({ type: "CLEAR_DECISION" });
@@ -47,23 +50,17 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       onCancel();
       dispatch({ type: "CLEAR_DECISION" });
     }
-  }, [
-    pendingDecision,
-    selectedIndex,
-    configuredModels,
-    onSelectModel,
-    onCancel,
-  ]);
+  }, [pendingDecision, selectedIndex, models, onSelectModel, onCancel]);
 
   // Calculate visible window
   const startIndex = Math.max(
     0,
     Math.min(
       selectedIndex - Math.floor(MAX_VISIBLE_ITEMS / 2),
-      Math.max(0, configuredModels.length - MAX_VISIBLE_ITEMS),
+      Math.max(0, models.length - MAX_VISIBLE_ITEMS),
     ),
   );
-  const visibleModels = configuredModels.slice(
+  const visibleModels = models.slice(
     startIndex,
     startIndex + MAX_VISIBLE_ITEMS,
   );

--- a/packages/code/src/components/SessionSelector.tsx
+++ b/packages/code/src/components/SessionSelector.tsx
@@ -1,10 +1,15 @@
 import React, { useReducer, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import type { SessionMetadata } from "wave-agent-sdk";
-import { selectorReducer } from "../reducers/selectorReducer.js";
+import {
+  selectorReducer,
+  type SelectorState,
+} from "../reducers/selectorReducer.js";
+
+type SessionItem = SessionMetadata & { firstMessage?: string };
 
 export interface SessionSelectorProps {
-  sessions: (SessionMetadata & { firstMessage?: string })[];
+  sessions: SessionItem[];
   onSelect: (sessionId: string) => void;
   onCancel: () => void;
 }
@@ -14,33 +19,38 @@ export const SessionSelector: React.FC<SessionSelectorProps> = ({
   onSelect,
   onCancel,
 }) => {
-  const [state, dispatch] = useReducer(selectorReducer, {
+  const [state, dispatch] = useReducer(selectorReducer<SessionItem>, {
     selectedIndex: 0,
     pendingDecision: null,
-  });
+    items: [],
+  } as SelectorState<SessionItem>);
 
-  const { selectedIndex, pendingDecision } = state;
+  const { selectedIndex, pendingDecision, items } = state;
+
+  // Sync sessions into reducer state
+  useEffect(() => {
+    dispatch({ type: "SET_ITEMS", items: sessions });
+  }, [sessions]);
 
   useInput((_input, key) => {
     dispatch({
       type: "HANDLE_KEY",
       key,
-      maxIndex: sessions.length - 1,
       hasInsert: false,
     });
   });
 
   useEffect(() => {
     if (pendingDecision === "select") {
-      if (sessions.length > 0 && selectedIndex < sessions.length) {
-        onSelect(sessions[selectedIndex].id);
+      if (items.length > 0 && selectedIndex < items.length) {
+        onSelect(items[selectedIndex].id);
       }
       dispatch({ type: "CLEAR_DECISION" });
     } else if (pendingDecision === "cancel") {
       onCancel();
       dispatch({ type: "CLEAR_DECISION" });
     }
-  }, [pendingDecision, selectedIndex, sessions, onSelect, onCancel]);
+  }, [pendingDecision, selectedIndex, items, onSelect, onCancel]);
 
   if (sessions.length === 0) {
     return (

--- a/packages/code/src/components/WorktreeExitPrompt.tsx
+++ b/packages/code/src/components/WorktreeExitPrompt.tsx
@@ -1,6 +1,9 @@
 import React, { useReducer, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
-import { selectorReducer } from "../reducers/selectorReducer.js";
+import {
+  selectorReducer,
+  type SelectorState,
+} from "../reducers/selectorReducer.js";
 
 interface WorktreeExitPromptProps {
   name: string;
@@ -21,10 +24,11 @@ export const WorktreeExitPrompt: React.FC<WorktreeExitPromptProps> = ({
   onRemove,
   onCancel,
 }) => {
-  const [state, dispatch] = useReducer(selectorReducer, {
+  const [state, dispatch] = useReducer(selectorReducer<string>, {
     selectedIndex: 0,
     pendingDecision: null,
-  });
+    items: ["keep", "remove"],
+  } as SelectorState<string>);
 
   const { selectedIndex, pendingDecision } = state;
 
@@ -32,7 +36,6 @@ export const WorktreeExitPrompt: React.FC<WorktreeExitPromptProps> = ({
     dispatch({
       type: "HANDLE_KEY",
       key,
-      maxIndex: 1,
       hasInsert: false,
     });
   });

--- a/packages/code/src/reducers/questionReducer.ts
+++ b/packages/code/src/reducers/questionReducer.ts
@@ -52,11 +52,6 @@ export type QuestionAction =
       type: "HANDLE_KEY";
       input: string;
       key: Key;
-      currentQuestion: {
-        question: string;
-        options: Array<{ label: string }>;
-        multiSelect?: boolean;
-      };
       questions: Array<{
         question: string;
         options: Array<{ label: string }>;
@@ -265,7 +260,8 @@ export function questionReducer(
     case "CLEAR_DECISION":
       return { ...state, decision: null };
     case "HANDLE_KEY": {
-      const { input, key, currentQuestion, questions } = action;
+      const { input, key, questions } = action;
+      const currentQuestion = questions[state.currentQuestionIndex];
       if (!currentQuestion) return state;
 
       const options = [...currentQuestion.options, { label: "Other" }];

--- a/packages/code/src/reducers/selectorReducer.ts
+++ b/packages/code/src/reducers/selectorReducer.ts
@@ -1,31 +1,38 @@
 import { Key } from "ink";
 
-export interface SelectorState {
+export interface SelectorState<T = unknown> {
   selectedIndex: number;
   pendingDecision: "select" | "insert" | "cancel" | null;
+  items: T[];
 }
 
-export type SelectorAction =
+export type SelectorAction<T = unknown> =
   | { type: "MOVE_UP" }
-  | { type: "MOVE_DOWN"; maxIndex: number }
+  | { type: "MOVE_DOWN" }
   | { type: "RESET_INDEX" }
-  | { type: "HANDLE_KEY"; key: Key; maxIndex: number; hasInsert: boolean }
+  | { type: "SET_ITEMS"; items: T[] }
+  | { type: "HANDLE_KEY"; key: Key; hasInsert: boolean }
   | { type: "CLEAR_DECISION" };
 
-export function selectorReducer(
-  state: SelectorState,
-  action: SelectorAction,
-): SelectorState {
+export function selectorReducer<T = unknown>(
+  state: SelectorState<T>,
+  action: SelectorAction<T>,
+): SelectorState<T> {
   switch (action.type) {
     case "MOVE_UP":
       return { ...state, selectedIndex: Math.max(0, state.selectedIndex - 1) };
     case "MOVE_DOWN":
       return {
         ...state,
-        selectedIndex: Math.min(action.maxIndex, state.selectedIndex + 1),
+        selectedIndex: Math.min(
+          state.items.length - 1,
+          state.selectedIndex + 1,
+        ),
       };
     case "RESET_INDEX":
       return { ...state, selectedIndex: 0 };
+    case "SET_ITEMS":
+      return { ...state, items: action.items, selectedIndex: 0 };
     case "HANDLE_KEY":
       if (action.key.upArrow) {
         return {
@@ -36,7 +43,10 @@ export function selectorReducer(
       if (action.key.downArrow) {
         return {
           ...state,
-          selectedIndex: Math.min(action.maxIndex, state.selectedIndex + 1),
+          selectedIndex: Math.min(
+            state.items.length - 1,
+            state.selectedIndex + 1,
+          ),
         };
       }
       if (action.key.return) {

--- a/packages/code/tests/reducers/selectorReducer.test.ts
+++ b/packages/code/tests/reducers/selectorReducer.test.ts
@@ -10,6 +10,7 @@ describe("selectorReducer", () => {
   const initialState: SelectorState = {
     selectedIndex: 0,
     pendingDecision: null,
+    items: ["a", "b", "c"],
   };
 
   it("should handle HANDLE_KEY up/down", () => {
@@ -19,7 +20,6 @@ describe("selectorReducer", () => {
     let result = selectorReducer(initialState, {
       type: "HANDLE_KEY",
       key: downKey,
-      maxIndex: 2,
       hasInsert: false,
     });
     expect(result.selectedIndex).toBe(1);
@@ -27,7 +27,6 @@ describe("selectorReducer", () => {
     result = selectorReducer(result, {
       type: "HANDLE_KEY",
       key: upKey,
-      maxIndex: 2,
       hasInsert: false,
     });
     expect(result.selectedIndex).toBe(0);
@@ -38,7 +37,6 @@ describe("selectorReducer", () => {
     const result = selectorReducer(initialState, {
       type: "HANDLE_KEY",
       key: returnKey,
-      maxIndex: 0,
       hasInsert: false,
     });
     expect(result.pendingDecision).toBe("select");
@@ -49,7 +47,6 @@ describe("selectorReducer", () => {
     const result = selectorReducer(initialState, {
       type: "HANDLE_KEY",
       key: tabKey,
-      maxIndex: 0,
       hasInsert: true,
     });
     expect(result.pendingDecision).toBe("insert");
@@ -60,7 +57,6 @@ describe("selectorReducer", () => {
     const result = selectorReducer(initialState, {
       type: "HANDLE_KEY",
       key: tabKey,
-      maxIndex: 0,
       hasInsert: false,
     });
     expect(result.pendingDecision).toBe(null);
@@ -71,7 +67,6 @@ describe("selectorReducer", () => {
     const result = selectorReducer(initialState, {
       type: "HANDLE_KEY",
       key: escKey,
-      maxIndex: 0,
       hasInsert: false,
     });
     expect(result.pendingDecision).toBe("cancel");
@@ -80,7 +75,6 @@ describe("selectorReducer", () => {
   it("should handle MOVE_UP/MOVE_DOWN actions", () => {
     let result = selectorReducer(initialState, {
       type: "MOVE_DOWN",
-      maxIndex: 5,
     });
     expect(result.selectedIndex).toBe(1);
     result = selectorReducer(result, { type: "MOVE_UP" });
@@ -88,8 +82,17 @@ describe("selectorReducer", () => {
   });
 
   it("should handle RESET_INDEX", () => {
-    const state = { ...initialState, selectedIndex: 5 };
+    const state = { ...initialState, selectedIndex: 2 };
     const result = selectorReducer(state, { type: "RESET_INDEX" });
+    expect(result.selectedIndex).toBe(0);
+  });
+
+  it("should handle SET_ITEMS", () => {
+    const result = selectorReducer(initialState, {
+      type: "SET_ITEMS",
+      items: ["x", "y"],
+    });
+    expect(result.items).toEqual(["x", "y"]);
     expect(result.selectedIndex).toBe(0);
   });
 


### PR DESCRIPTION
## Problem

Flaky test failures under `pnpm run ci` (coverage mode) in `packages/code` — different tests failed per run (Confirmation multi-select Space key, HistorySearch arrow navigation, etc.). Root cause: `useInput` handlers captured stale state-derived values (e.g. `entries`, `filteredCommands`, `currentQuestion`) in their closure. When async state updates completed, the render output updated before the effect re-registered the handler, so `stdin.write` after `vi.waitFor` hit the old handler with stale values.

## Solution

**selectorReducer (方案 B — items in reducer state):**
- Added `items: T[]` to `SelectorState<T>` and `SET_ITEMS` action
- Removed `maxIndex` from `HANDLE_KEY` and `MOVE_DOWN` — reducer reads `state.items.length - 1` internally
- `dispatch` is stable across re-renders, so `useInput` always dispatches the latest action — no stale closure possible
- Migrated all 10 consumers: HistorySearch, CommandSelector, FileSelector, MarketplaceView, SessionSelector, DiscoverView, MarketplaceDetail, ModelSelector, InstalledView, WorktreeExitPrompt

**questionReducer (方案 C — reducer derives internally):**
- Removed `currentQuestion` from `HANDLE_KEY` action payload
- Reducer derives `currentQuestion = questions[state.currentQuestionIndex]` internally (questions is a stable prop, index is in state)

## Verification

- Type-check clean, lint clean
- 76 reducer tests pass
- 5/5 `pnpm run ci` passes (previously 2-3 failures per 5 runs)