### PR TITLE
chore: bump pnpm from 11.5.2 to 11.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "vitepress": "^1.6.4",
     "vitest": "^4.0.18"
   },
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "engines": {
     "node": ">=22.0.0"
   },


### PR DESCRIPTION
Bumps the `packageManager` field in `package.json` from `pnpm@11.5.2` to `pnpm@11.9.0`.