### PR TITLE
ci: add concurrency control to cancel duplicate runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
     branches: [ main, develop ]
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add `concurrency` block to CI workflow to cancel in-progress runs on the same branch when a new run is triggered.

## Changes

- Added `concurrency` with `group: ci-${{ github.ref }}` and `cancel-in-progress: true` to `.github/workflows/ci.yml`

## Rationale

When multiple pushes happen to the same branch (e.g., consecutive commits to a PR), previous CI runs that are still in progress get automatically cancelled, saving CI resources and reducing redundant builds.