### PR TITLE
ci: only trigger on pull_request, remove push trigger to avoid duplicate runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  push:
+  pull_request:
     branches: [ main, develop ]
     paths-ignore:
       - '**/*.md'
@@ -10,8 +10,6 @@ on:
       - 'docs/**'
       - 'scripts/**'
       - 'LICENSE'
-  pull_request:
-    branches: [ main, develop ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
     branches: [ main, develop ]
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Remove the `push` trigger from CI workflow, keeping only `pull_request` and `workflow_dispatch`.

## Rationale

Since this repo does not support direct push to main (all changes go through PRs), the `push` trigger was redundant — it caused CI to run again after every PR merge. Now CI only runs on PRs, eliminating the duplicate run.

The `workflow_dispatch` trigger is retained for manual runs when needed.

## Changes

- Removed `push` trigger from `on:` block
- Moved `paths-ignore` to `pull_request` trigger
- Kept `concurrency` block (still useful for cancelling stale runs on the same PR branch)