### PR TITLE
fix: skip empty SSE data lines to avoid spurious parse errors

### DIFF
--- a/packages/agent-sdk/src/utils/openaiClient.ts
+++ b/packages/agent-sdk/src/utils/openaiClient.ts
@@ -222,12 +222,16 @@ export class OpenAIClient {
 
           const data = trimmedLine.slice(5).trim();
           if (data === "[DONE]") return;
+          if (!data) continue; // Skip empty data lines (keepalive heartbeats)
 
           try {
             const json = JSON.parse(data);
             yield json as ChatCompletionChunk;
           } catch (e) {
-            logger.error("Failed to parse stream chunk", { error: e, data });
+            logger.error("Failed to parse stream chunk", {
+              error: e instanceof Error ? e.message : String(e),
+              data,
+            });
           }
         }
       }


### PR DESCRIPTION
## Problem

`app.log` was flooded with errors every ~12s:
```
[ERROR] Failed to parse stream chunk {"error":{},"data":""}
```

## Root Cause

Servers/proxies send empty `data:` lines as SSE keepalive heartbeats. The streaming parser in `openaiClient.ts` attempted `JSON.parse("")` on these empty payloads, throwing a `SyntaxError` each time. The `SyntaxError` object's `message` property is non-enumerable, so it serialized as `{}` in the log.

## Fix

- **Skip empty data lines** (`if (!data) continue`) before attempting `JSON.parse`, silently ignoring keepalive heartbeats.
- **Log actual error message** (`e instanceof Error ? e.message : String(e)`) instead of the raw error object, so any future parse failures are diagnosable.

## Testing

- All 14 existing `openaiClient` tests pass.
- Type-check and lint pass (pre-commit hooks verified).