### PR TITLE
fix: surface subagent error info to main agent instead of empty content

### DIFF
--- a/packages/agent-sdk/src/tools/agentTool.ts
+++ b/packages/agent-sdk/src/tools/agentTool.ts
@@ -266,10 +266,32 @@ When using the Agent tool, you must specify a subagent_type parameter to select 
             });
           } catch (error) {
             if (!isBackgrounded) {
+              // Extract content from the subagent's last assistant message.
+              // aiManager.sendAIMessage() catch block already added an error
+              // block via addErrorBlock(), so the error info is in the message
+              // history — just return it directly.
+              let content = "";
+              try {
+                const messages = instance.messageManager.getMessages();
+                const lastAssistant = messages
+                  .filter((m) => m.role === "assistant")
+                  .pop();
+                if (lastAssistant) {
+                  content = lastAssistant.blocks
+                    .filter((b) => b.type === "text" || b.type === "error")
+                    .map((b) => (b as { content: string }).content)
+                    .join("\n")
+                    .trim();
+                }
+              } catch {
+                // Ignore errors when extracting messages
+              }
+
+              const errorMsg = `Agent delegation failed: ${error instanceof Error ? error.message : String(error)}`;
               resolve({
                 success: false,
-                content: "",
-                error: `Agent delegation failed: ${error instanceof Error ? error.message : String(error)}`,
+                content: content || errorMsg,
+                error: errorMsg,
                 shortResult: "Delegation error",
               });
             }

--- a/packages/agent-sdk/tests/tools/agentTool.test.ts
+++ b/packages/agent-sdk/tests/tools/agentTool.test.ts
@@ -268,6 +268,122 @@ describe("Agent Tool Background Execution", () => {
     expect(result.error).toContain('No agent found matching "Invalid"');
   });
 
+  it("should surface error message in content when subagent fails", async () => {
+    const mockInstance = {
+      subagentId: "gp-test-id",
+      usedTools: [],
+      messageManager: {
+        getMessages: vi.fn(() => []),
+        getLatestTotalTokens: vi.fn(() => 0),
+      },
+    };
+
+    vi.mocked(mockSubagentManager.findSubagent).mockResolvedValue(gpConfig);
+    vi.mocked(mockSubagentManager.createInstance).mockResolvedValue(
+      mockInstance as unknown as SubagentInstance,
+    );
+    vi.mocked(mockSubagentManager.executeAgent).mockRejectedValue(
+      new Error("429 Too Many Requests"),
+    );
+
+    const result = await agentTool.execute(
+      {
+        description: "Test",
+        prompt: "Test",
+        subagent_type: "general-purpose",
+      },
+      mockToolContext,
+    );
+
+    expect(result.success).toBe(false);
+    // content must contain the error message, not be empty
+    expect(result.content).toContain("Agent delegation failed");
+    expect(result.content).toContain("429 Too Many Requests");
+    expect(result.error).toContain("429 Too Many Requests");
+  });
+
+  it("should return error block when last assistant message has no text", async () => {
+    // Simulates what aiManager.sendAIMessage() does on error: it calls
+    // addErrorBlock() which appends an error block to the last assistant message
+    const mockInstance = {
+      subagentId: "gp-test-id",
+      usedTools: [],
+      messageManager: {
+        getMessages: vi.fn(() => [
+          { role: "user", blocks: [{ type: "text", content: "do work" }] },
+          {
+            role: "assistant",
+            blocks: [{ type: "error", content: "429 Too Many Requests" }],
+          },
+        ]),
+        getLatestTotalTokens: vi.fn(() => 0),
+      },
+    };
+
+    vi.mocked(mockSubagentManager.findSubagent).mockResolvedValue(gpConfig);
+    vi.mocked(mockSubagentManager.createInstance).mockResolvedValue(
+      mockInstance as unknown as SubagentInstance,
+    );
+    vi.mocked(mockSubagentManager.executeAgent).mockRejectedValue(
+      new Error("429 Too Many Requests"),
+    );
+
+    const result = await agentTool.execute(
+      {
+        description: "Test",
+        prompt: "Test",
+        subagent_type: "general-purpose",
+      },
+      mockToolContext,
+    );
+
+    expect(result.success).toBe(false);
+    // no text block → fallback to error block
+    expect(result.content).toContain("429 Too Many Requests");
+  });
+
+  it("should include both text and error block from last assistant message", async () => {
+    const mockInstance = {
+      subagentId: "gp-test-id",
+      usedTools: [],
+      messageManager: {
+        getMessages: vi.fn(() => [
+          { role: "user", blocks: [{ type: "text", content: "do work" }] },
+          {
+            role: "assistant",
+            blocks: [
+              { type: "text", content: "I found 3 files." },
+              { type: "error", content: "429 Too Many Requests" },
+            ],
+          },
+        ]),
+        getLatestTotalTokens: vi.fn(() => 0),
+      },
+    };
+
+    vi.mocked(mockSubagentManager.findSubagent).mockResolvedValue(gpConfig);
+    vi.mocked(mockSubagentManager.createInstance).mockResolvedValue(
+      mockInstance as unknown as SubagentInstance,
+    );
+    vi.mocked(mockSubagentManager.executeAgent).mockRejectedValue(
+      new Error("429 Too Many Requests"),
+    );
+
+    const result = await agentTool.execute(
+      {
+        description: "Test",
+        prompt: "Test",
+        subagent_type: "general-purpose",
+      },
+      mockToolContext,
+    );
+
+    expect(result.success).toBe(false);
+    // both text and error blocks are included
+    expect(result.content).toContain("I found 3 files.");
+    expect(result.content).toContain("429 Too Many Requests");
+  });
+
   it("should format compact params", () => {
     const params = {
       subagent_type: "Explore",


### PR DESCRIPTION
## Problem

When a subagent fails (e.g., 429 network error, rate limiting), the catch block in `agentTool.ts` returned `content: ""` — an empty string. This meant the main agent received no error information, making it impossible to understand why the delegation failed.

## Fix

The catch block now extracts text and error blocks from the subagent's last assistant message before returning. This works because `aiManager.sendAIMessage()` already calls `addErrorBlock()` on error, which appends the error info to the message history.

**Logic:**
1. Get the last assistant message from `instance.messageManager.getMessages()`
2. Filter for `text` and `error` blocks, join their content
3. Fall back to raw `"Agent delegation failed: ..."` string if message history is empty

## Changes

- `packages/agent-sdk/src/tools/agentTool.ts`: Replace `content: ""` with extraction from message history
- `packages/agent-sdk/tests/tools/agentTool.test.ts`: 3 new test cases covering empty messages, error-block-only, and text+error-block scenarios