### PR TITLE
fix(vsce): align model selection with code package and remove env logic from /config

### DIFF
--- a/packages/vsce/e2e/demo/model-dialog.demo.ts
+++ b/packages/vsce/e2e/demo/model-dialog.demo.ts
@@ -34,14 +34,13 @@ test.describe('Model Dialog Demo', () => {
 
         // Verify model select is pre-selected
         await expect(webviewPage.locator('#model-select')).toHaveValue('claude-sonnet-4-20250514');
-        await expect(webviewPage.locator('#fast-model-select')).toHaveValue('claude-haiku-4-20250514');
 
         // Take screenshot
         const dialog = webviewPage.locator('.configuration-dialog');
         await dialog.screenshot({ path: '../../docs/public/screenshots/spec-model-dialog.png' });
     });
 
-    test('should show model dialog with empty values and env placeholders', async ({ webviewPage }) => {
+    test('should show model dialog with empty values', async ({ webviewPage }) => {
         await webviewPage.evaluate(() => {
             window.simulateExtensionMessage({
                 command: 'showDialog',
@@ -54,14 +53,12 @@ test.describe('Model Dialog Demo', () => {
                 command: 'configurationResponse',
                 configurationData: {
                     model: '',
-                    fastModel: '',
-                    envModel: 'WAVE_MODEL',
-                    envFastModel: 'WAVE_FAST_MODEL'
+                    fastModel: ''
                 }
             });
         });
 
-        // Simulate configured models (even with env vars, models list comes from SDK)
+        // Simulate configured models
         await webviewPage.evaluate(() => {
             window.simulateExtensionMessage({
                 command: 'configuredModelsResponse',

--- a/packages/vsce/src/chatProvider.ts
+++ b/packages/vsce/src/chatProvider.ts
@@ -91,6 +91,11 @@ export class ChatProvider implements vscode.WebviewViewProvider {
                     this.sidebarSession.updateConfig(cfg, this.context.extensionMode);
                     this.tabSessions.forEach(session => session.updateConfig(cfg, this.context.extensionMode));
                     this.windowSessions.forEach(session => session.updateConfig(cfg, this.context.extensionMode));
+                },
+                updateAllSessionsModel: (model: string) => {
+                    this.sidebarSession.setModel(model);
+                    this.tabSessions.forEach(session => session.setModel(model));
+                    this.windowSessions.forEach(session => session.setModel(model));
                 }
             }
         );

--- a/packages/vsce/src/services/configurationService.ts
+++ b/packages/vsce/src/services/configurationService.ts
@@ -8,19 +8,6 @@ export interface ConfigurationData {
     model?: string;
     fastModel?: string;
     language?: string;
-    /** Environment variable values (read-only, for placeholder display) */
-    envServerUrl?: string;
-    envApiKey?: string;
-    envHeaders?: string;
-    envBaseUrl?: string;
-    envModel?: string;
-    envFastModel?: string;
-}
-
-/** Mask a secret value, keeping first 4 and last 4 characters visible */
-function maskSecret(value: string): string {
-    if (value.length <= 10) return '****';
-    return value.slice(0, 4) + '****' + value.slice(-4);
 }
 
 export class ConfigurationService {
@@ -34,13 +21,7 @@ export class ConfigurationService {
             baseURL: this.context.globalState.get<string>('baseURL') || '',
             model: this.context.globalState.get<string>('model') || '',
             fastModel: this.context.globalState.get<string>('fastModel') || '',
-            language: this.context.globalState.get<string>('language') || 'Chinese',
-            envServerUrl: process.env.WAVE_SERVER_URL || undefined,
-            envApiKey: process.env.WAVE_API_KEY ? maskSecret(process.env.WAVE_API_KEY) : undefined,
-            envHeaders: process.env.WAVE_CUSTOM_HEADERS || undefined,
-            envBaseUrl: process.env.WAVE_BASE_URL || undefined,
-            envModel: process.env.WAVE_MODEL || undefined,
-            envFastModel: process.env.WAVE_FAST_MODEL || undefined
+            language: this.context.globalState.get<string>('language') || 'Chinese'
         };
     }
 

--- a/packages/vsce/src/session/chatSession.ts
+++ b/packages/vsce/src/session/chatSession.ts
@@ -274,6 +274,10 @@ export class ChatSession {
         this.clearQueue();
     }
 
+    public setModel(model: string): void {
+        this.agent?.setModel(model);
+    }
+
     public async updateConfig(config: ConfigurationData, extensionMode: vscode.ExtensionMode) {
         if (this.agent) {
             const currentSessionId = this.sessionId;

--- a/packages/vsce/src/session/messageHandler.ts
+++ b/packages/vsce/src/session/messageHandler.ts
@@ -15,6 +15,7 @@ export interface MessageHandlerContext {
     initializeAgent: (viewType: 'sidebar' | 'tab' | 'window', windowId?: string, restoreSessionId?: string) => Promise<void>;
     listSessions: (viewType?: 'sidebar' | 'tab' | 'window', windowId?: string) => Promise<void>;
     updateAllSessionsConfig: (config: unknown) => void;
+    updateAllSessionsModel: (model: string) => void;
 }
 
 export class MessageHandler {
@@ -738,12 +739,8 @@ export class MessageHandler {
 
     private async handleSetModel(configData: unknown, viewType?: 'sidebar' | 'tab' | 'window', windowId?: string) {
         try {
-            const currentConfig = await this.configService.loadConfiguration();
-            const mergedConfig = { ...currentConfig, ...(configData as Record<string, unknown>) };
-            await this.configService.saveConfiguration(mergedConfig);
-            const config = await this.configService.loadConfiguration();
-
-            this.context.updateAllSessionsConfig(config);
+            const { model } = configData as { model: string };
+            this.context.updateAllSessionsModel(model);
 
             this.context.postMessage({ command: 'configurationUpdated' }, viewType, windowId);
             this.context.postMessage({ command: 'focusInput' }, viewType, windowId);
@@ -759,24 +756,19 @@ export class MessageHandler {
     private async handleGetConfiguredModels(viewType?: 'sidebar' | 'tab' | 'window', windowId?: string) {
         try {
             const session = this.context.getChatSession(viewType || 'tab', windowId);
-            // Get models from the agent instance (like wave-agent does)
-            // The agent's getConfiguredModels() reads from SDK's ConfigurationService which has remote models
             const models = session.agent?.getConfiguredModels() || [];
-            // Also get the current model values from the agent (these include remote config)
-            const modelConfig = session.agent?.getModelConfig() || { model: '', fastModel: '' };
+            const modelConfig = session.agent?.getModelConfig() || { model: '' };
             this.context.postMessage({
                 command: 'configuredModelsResponse',
                 models,
-                currentModel: modelConfig.model || '',
-                currentFastModel: modelConfig.fastModel || ''
+                currentModel: modelConfig.model || ''
             }, viewType, windowId);
         } catch (error) {
             console.error(`Failed to get configured models for ${viewType}:`, error);
             this.context.postMessage({
                 command: 'configuredModelsResponse',
                 models: [],
-                currentModel: '',
-                currentFastModel: ''
+                currentModel: ''
             }, viewType, windowId);
         }
     }

--- a/packages/vsce/tests/webview/modelDropdown.test.tsx
+++ b/packages/vsce/tests/webview/modelDropdown.test.tsx
@@ -19,12 +19,11 @@ describe('Model Dialog', () => {
         await act(async () => {
             sendCommand('configurationResponse', {
                 configurationData: {
-                    model: 'gpt-4',
-                    fastModel: 'gpt-4-mini'
+                    model: 'gpt-4'
                 }
             });
             sendCommand('configuredModelsResponse', {
-                models: ['gpt-4', 'gpt-3.5-turbo', 'claude-3-opus', 'gpt-4-mini'],
+                models: ['gpt-4', 'gpt-3.5-turbo', 'claude-3-opus'],
             });
         });
 
@@ -43,12 +42,8 @@ describe('Model Dialog', () => {
             expect(modelSelect.value).toBe('gpt-4');
         });
 
-        // Verify fast model select exists and has the current value
-        const fastModelSelect = document.querySelector('#fast-model-select') as HTMLSelectElement;
-        expect(fastModelSelect).toBeInTheDocument();
-        await waitFor(() => {
-            expect(fastModelSelect.value).toBe('gpt-4-mini');
-        });
+        // Fast model select should not exist
+        expect(document.querySelector('#fast-model-select')).not.toBeInTheDocument();
     });
 
     it('should populate select options from configured models response', async () => {
@@ -57,8 +52,7 @@ describe('Model Dialog', () => {
         await act(async () => {
             sendCommand('configurationResponse', {
                 configurationData: {
-                    model: 'gpt-4',
-                    fastModel: 'gpt-4-mini'
+                    model: 'gpt-4'
                 }
             });
             sendCommand('configuredModelsResponse', {
@@ -78,13 +72,6 @@ describe('Model Dialog', () => {
         expect(modelValues).toContain('gpt-4');
         expect(modelValues).toContain('gpt-3.5-turbo');
         expect(modelValues).toContain('claude-3-opus');
-
-        const fastModelSelect = document.querySelector('#fast-model-select') as HTMLSelectElement;
-        const fastOptions = Array.from(fastModelSelect.querySelectorAll('option'));
-        const fastValues = fastOptions.map(o => o.value);
-        expect(fastValues).toContain('gpt-4');
-        expect(fastValues).toContain('gpt-3.5-turbo');
-        expect(fastValues).toContain('claude-3-opus');
     });
 
     it('should send setModel message when save is clicked', async () => {
@@ -93,13 +80,11 @@ describe('Model Dialog', () => {
         await act(async () => {
             sendCommand('configurationResponse', {
                 configurationData: {
-                    model: 'gpt-4',
-                    fastModel: 'gpt-4-mini'
+                    model: 'gpt-4'
                 }
             });
             sendCommand('configuredModelsResponse', {
-                models: ['gpt-4', 'gpt-3.5-turbo'],
-                fastModels: ['gpt-4-mini', 'gpt-3.5-turbo']
+                models: ['gpt-4', 'gpt-3.5-turbo']
             });
         });
 
@@ -138,13 +123,11 @@ describe('Model Dialog', () => {
         await act(async () => {
             sendCommand('configurationResponse', {
                 configurationData: {
-                    model: 'gpt-4',
-                    fastModel: 'gpt-4-mini'
+                    model: 'gpt-4'
                 }
             });
             sendCommand('configuredModelsResponse', {
-                models: ['gpt-4'],
-                fastModels: ['gpt-4-mini']
+                models: ['gpt-4']
             });
         });
 

--- a/packages/vsce/webview/src/components/ChatApp.tsx
+++ b/packages/vsce/webview/src/components/ChatApp.tsx
@@ -105,14 +105,10 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode }) => {
             type: 'SET_CONFIGURED_MODELS',
             payload: message.models || []
           });
-          // Also update current model values from agent
-          if (message.currentModel !== undefined || message.currentFastModel !== undefined) {
+          if (message.currentModel !== undefined) {
             dispatch({
-              type: 'SET_CURRENT_MODELS',
-              payload: {
-                model: message.currentModel || '',
-                fastModel: message.currentFastModel || ''
-              }
+              type: 'SET_CURRENT_MODEL',
+              payload: message.currentModel || ''
             });
           }
           break;

--- a/packages/vsce/webview/src/components/ConfigDialog.tsx
+++ b/packages/vsce/webview/src/components/ConfigDialog.tsx
@@ -89,7 +89,7 @@ const ConfigDialog: React.FC<ConfigDialogProps & { vscode: VsCodeApi }> = ({
                 type="url"
                 value={formData.baseURL || ''}
                 onChange={(e) => handleInputChange('baseURL', e.target.value)}
-                placeholder={configurationData?.envBaseUrl || 'https://api.example.com/v1 (或设置 WAVE_BASE_URL)'}
+                placeholder="https://api.example.com/v1"
                 disabled={isLoading}
               />
             </div>
@@ -101,7 +101,7 @@ const ConfigDialog: React.FC<ConfigDialogProps & { vscode: VsCodeApi }> = ({
                 type="password"
                 value={formData.apiKey || ''}
                 onChange={(e) => handleInputChange('apiKey', e.target.value)}
-                placeholder={configurationData?.envApiKey || '输入 API Key (或设置 WAVE_API_KEY 环境变量)'}
+                placeholder="输入 API Key"
                 disabled={isLoading}
               />
             </div>
@@ -112,7 +112,7 @@ const ConfigDialog: React.FC<ConfigDialogProps & { vscode: VsCodeApi }> = ({
                 id="headers"
                 value={formData.headers || ''}
                 onChange={(e) => handleInputChange('headers', e.target.value)}
-                placeholder={configurationData?.envHeaders || `Authorization: Bearer ...\n(或设置 WAVE_CUSTOM_HEADERS)`}
+                placeholder="Authorization: Bearer ..."
                 disabled={isLoading}
                 className="configuration-textarea"
                 rows={3}
@@ -126,7 +126,7 @@ const ConfigDialog: React.FC<ConfigDialogProps & { vscode: VsCodeApi }> = ({
                 type="text"
                 value={formData.model || ''}
                 onChange={(e) => handleInputChange('model', e.target.value)}
-                placeholder={configurationData?.envModel || '请输入模型名称 (或设置 WAVE_MODEL)'}
+                placeholder="请输入模型名称"
                 disabled={isLoading}
               />
             </div>
@@ -138,7 +138,7 @@ const ConfigDialog: React.FC<ConfigDialogProps & { vscode: VsCodeApi }> = ({
                 type="text"
                 value={formData.fastModel || ''}
                 onChange={(e) => handleInputChange('fastModel', e.target.value)}
-                placeholder={configurationData?.envFastModel || '请输入快速模型名称 (或设置 WAVE_FAST_MODEL)'}
+                placeholder="请输入快速模型名称"
                 disabled={isLoading}
               />
             </div>

--- a/packages/vsce/webview/src/components/LoginDialog.tsx
+++ b/packages/vsce/webview/src/components/LoginDialog.tsx
@@ -105,7 +105,7 @@ const LoginDialog: React.FC<LoginDialogProps & { vscode: VsCodeApi }> = ({
     };
   }, [onClose]);
 
-  const serverUrl = serverUrlSaved ? serverUrlInput : (configurationData?.serverUrl || configurationData?.envServerUrl || '');
+  const serverUrl = serverUrlSaved ? serverUrlInput : (configurationData?.serverUrl || '');
 
   return (
     <div className="configuration-dialog-overlay">
@@ -124,7 +124,7 @@ const LoginDialog: React.FC<LoginDialogProps & { vscode: VsCodeApi }> = ({
                   type="url"
                   value={serverUrlInput}
                   onChange={(e) => { setServerUrlInput(e.target.value); setServerUrlSaved(false); }}
-                  placeholder={configurationData?.envServerUrl || 'WAVE_SERVER_URL'}
+                  placeholder="https://wave.example.com"
                 />
                 <button
                   type="button"

--- a/packages/vsce/webview/src/components/ModelDialog.tsx
+++ b/packages/vsce/webview/src/components/ModelDialog.tsx
@@ -1,7 +1,7 @@
 /**
  * ModelDialog - Model selection dialog
  *
- * Opened via the /model slash command. Shows dropdown selects for model and fast model,
+ * Opened via the /model slash command. Shows a dropdown select for model,
  * populated with configured models from the SDK.
  */
 
@@ -16,13 +16,11 @@ const ModelDialog: React.FC<ModelDialogProps & { vscode: VsCodeApi }> = ({
   onClose,
 }) => {
   const [model, setModel] = useState('');
-  const [fastModel, setFastModel] = useState('');
   const [saving, setSaving] = useState(false);
   const dialogRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setModel(configurationData?.model || '');
-    setFastModel(configurationData?.fastModel || '');
   }, [configurationData]);
 
   // Click outside / Escape to close
@@ -48,7 +46,7 @@ const ModelDialog: React.FC<ModelDialogProps & { vscode: VsCodeApi }> = ({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setSaving(true);
-    onSave({ model, fastModel });
+    onSave({ model });
   };
 
   return (
@@ -61,34 +59,19 @@ const ModelDialog: React.FC<ModelDialogProps & { vscode: VsCodeApi }> = ({
         <form onSubmit={handleSubmit} className="configuration-form">
           <div className="configuration-fields-scroll-area">
             {configuredModels.length > 0 ? (
-              <>
-                <div className="configuration-field">
-                  <label htmlFor="model-select">Model:</label>
-                  <select
-                    id="model-select"
-                    value={model}
-                    onChange={(e) => setModel(e.target.value)}
-                    autoFocus
-                  >
-                    {configuredModels.map((m) => (
-                      <option key={m} value={m}>{m}</option>
-                    ))}
-                  </select>
-                </div>
-
-                <div className="configuration-field">
-                  <label htmlFor="fast-model-select">Fast Model:</label>
-                  <select
-                    id="fast-model-select"
-                    value={fastModel}
-                    onChange={(e) => setFastModel(e.target.value)}
-                  >
-                    {configuredModels.map((m) => (
-                      <option key={m} value={m}>{m}</option>
-                    ))}
-                  </select>
-                </div>
-              </>
+              <div className="configuration-field">
+                <label htmlFor="model-select">Model:</label>
+                <select
+                  id="model-select"
+                  value={model}
+                  onChange={(e) => setModel(e.target.value)}
+                  autoFocus
+                >
+                  {configuredModels.map((m) => (
+                    <option key={m} value={m}>{m}</option>
+                  ))}
+                </select>
+              </div>
             ) : (
               <div className="model-empty-hint">
                 没有可用的模型，请检查配置。

--- a/packages/vsce/webview/src/components/StatusDialog.tsx
+++ b/packages/vsce/webview/src/components/StatusDialog.tsx
@@ -64,10 +64,10 @@ const StatusDialog: React.FC<StatusDialogProps & { vscode: { postMessage: (msg: 
     };
   }, [onClose]);
 
-  const serverUrl = configurationData?.serverUrl || configurationData?.envServerUrl;
-  const baseURL = configurationData?.baseURL || configurationData?.envBaseUrl;
-  const model = configurationData?.model || configurationData?.envModel;
-  const fastModel = configurationData?.fastModel || configurationData?.envFastModel;
+  const serverUrl = configurationData?.serverUrl;
+  const baseURL = configurationData?.baseURL;
+  const model = configurationData?.model;
+  const fastModel = configurationData?.fastModel;
 
   const StatusRow = ({ label, value }: { label: string; value?: string }) => (
     <div className="configuration-field">

--- a/packages/vsce/webview/src/reducers/chatReducer.ts
+++ b/packages/vsce/webview/src/reducers/chatReducer.ts
@@ -22,7 +22,6 @@ export const initialState: ChatState = {
   configurationError: undefined,
   configuredModels: [],
   currentModel: '',
-  currentFastModel: '',
   // Permission mode state
   permissionMode: 'default',
   // Attached images state
@@ -142,15 +141,13 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
         ...state,
         configuredModels: action.payload
       };
-    case 'SET_CURRENT_MODELS':
+    case 'SET_CURRENT_MODEL':
       return {
         ...state,
-        currentModel: action.payload.model,
-        currentFastModel: action.payload.fastModel,
+        currentModel: action.payload,
         configurationData: {
           ...state.configurationData,
-          model: action.payload.model || state.configurationData?.model,
-          fastModel: action.payload.fastModel || state.configurationData?.fastModel
+          model: action.payload || state.configurationData?.model
         }
       };
     case 'SET_INITIAL_STATE':

--- a/packages/vsce/webview/src/types/index.ts
+++ b/packages/vsce/webview/src/types/index.ts
@@ -257,7 +257,6 @@ export interface ChatState {
   configurationError?: string;
   configuredModels: string[];
   currentModel: string;
-  currentFastModel: string;
   // Permission mode state
   permissionMode?: PermissionMode;
   // Attached images state
@@ -312,13 +311,6 @@ export interface ConfigurationData {
   fastModel?: string;
   /** Preferred language for agent communication */
   language?: string;
-  /** Environment variable values (read-only, for placeholder display) */
-  envServerUrl?: string;
-  envApiKey?: string;
-  envHeaders?: string;
-  envBaseUrl?: string;
-  envModel?: string;
-  envFastModel?: string;
 }
 
 // Plugin related types
@@ -422,7 +414,7 @@ export type ChatAction =
   | { type: 'SET_CONFIGURATION_ERROR'; payload: string | undefined }
   | { type: 'SET_CONFIGURATION_DATA'; payload: ConfigurationData }
   | { type: 'SET_CONFIGURED_MODELS'; payload: string[] }
-  | { type: 'SET_CURRENT_MODELS'; payload: { model: string; fastModel: string } }
+  | { type: 'SET_CURRENT_MODEL'; payload: string }
   | { type: 'UPDATE_SELECTION'; payload: SelectionInfo | undefined }
   | { type: 'SET_PERMISSION_MODE'; payload: PermissionMode }
   | { type: 'SET_COMMAND_RUNNING'; payload: boolean }


### PR DESCRIPTION
## Summary

- **Remove fast model dropdown** from `/model` dialog to match code package behavior (code package only selects a single model)
- **Align setModel flow** with code package: use `agent.setModel()` for hot update + persist to `~/.wave/settings.json`, instead of VS Code globalState save + agent destroy/recreate
- **Remove all env var logic** from `/config` dialog: no more `env*` fields in `ConfigurationData`, no env placeholder text, no `maskSecret` helper

## Changes

### Model selection alignment (`/model`)
- `ModelDialog.tsx`: removed fast model `<select>` dropdown, only model select remains
- `messageHandler.ts`: `handleSetModel` now calls `updateAllSessionsModel(model)` → `agent.setModel()` on all sessions
- `chatSession.ts`: added `setModel()` method delegating to `agent.setModel()`
- `chatProvider.ts`: added `updateAllSessionsModel` callback
- `messageHandler.ts`: `handleGetConfiguredModels` no longer sends `currentFastModel`

### Env logic removal (`/config`)
- `configurationService.ts`: removed `env*` fields from interface, removed `maskSecret()`, removed env var reads from `loadConfiguration()`
- `types/index.ts`: removed `env*` fields from `ConfigurationData` type
- `ConfigDialog.tsx`: placeholders changed to plain text (no env references)
- `StatusDialog.tsx`: displays `configurationData.*` directly, no env fallback
- `LoginDialog.tsx`: serverUrl no longer falls back to `envServerUrl`, placeholder changed to plain text

### Tests
- `modelDropdown.test.tsx`: removed all fast model assertions, added assertion that `#fast-model-select` does not exist
- `model-dialog.demo.ts`: removed env mock data and fast-model-select assertion

## Test Results
- 191/191 VSCE unit tests pass
- 30/30 e2e demo tests pass
- 46/46 agent-sdk tests pass