### PR TITLE
fix(vsce): push restored messages to webview after session restore

### DIFF
--- a/packages/vsce/src/session/chatSession.ts
+++ b/packages/vsce/src/session/chatSession.ts
@@ -270,6 +270,8 @@ export class ChatSession {
             this.forceNextUpdateImmediate = true;
             this.inputContent = '';
             await this.agent.restoreSession(sessionId);
+            // Push restored messages to webview (SDK callback only stores this.messages)
+            this.throttledUpdateChatMessages(this.messages);
         }
         this.clearQueue();
     }


### PR DESCRIPTION
## Problem

When selecting a session in the VS Code extension session selector, the conversation history (messages) was not loaded. The session dropdown would switch to the selected session, but the message list remained empty or showed the previous session's messages.

## Root Cause

 called  which internally triggered the SDK's  callback. However, in the VSCE  layer, the  callback only stored the messages into  — it did **not** call  to push the updated message list to the webview.

This is in contrast to , which explicitly calls  after .

## Fix

Add  after  in . The  flag (already set before the call) ensures the update fires immediately rather than being throttled.

## Testing

- Verified via debug logging that session list data flows correctly (6 sessions fetched and sent to webview)
- The missing link was specifically the message list not being pushed after restore
- Type-check and lint pass