### PR TITLE
chore(vsce): bump version to 0.18.4 to align with other packages

### DIFF
--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "displayName": "Wave 代码智聊",
   "description": "Wave code for VS Code",
-  "version": "0.4.20",
+  "version": "0.18.4",
   "publisher": "wave-code",
   "icon": "LOGO.png",
   "repository": {


### PR DESCRIPTION
Align `packages/vsce` version (`0.4.20` → `0.18.4`) with `wave-agent-sdk` and `wave-code`.