### PR TITLE
fix(vsce): prevent tool block layout jitter during streaming

### DIFF
--- a/packages/vsce/webview/src/styles/Message.css
+++ b/packages/vsce/webview/src/styles/Message.css
@@ -172,6 +172,9 @@
     color: var(--vscode-button-background);
     font-weight: bold;
     font-size: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .tool-status-dot {


### PR DESCRIPTION
Add white-space: nowrap, overflow: hidden, and text-overflow: ellipsis
to .tool-block so the compact params preview stays single-line during
streaming, eliminating height changes that caused message list reflow.
