### PR TITLE
fix: align default max output tokens with Claude Code (16384 → 32000)

### DIFF
--- a/packages/agent-sdk/builtin/skills/settings/ENV.md
+++ b/packages/agent-sdk/builtin/skills/settings/ENV.md
@@ -28,7 +28,7 @@ Wave uses several environment variables to control its core functionality.
 | `WAVE_MODEL` | The primary AI model to use for the agent. | `gemini-3-flash` |
 | `WAVE_FAST_MODEL` | The fast AI model to use for quick tasks. | `gemini-2.5-flash` |
 | `WAVE_MAX_INPUT_TOKENS` | Maximum number of input tokens allowed. | `200000` |
-| `WAVE_MAX_OUTPUT_TOKENS` | Maximum number of output tokens allowed. | `16384` |
+| `WAVE_MAX_OUTPUT_TOKENS` | Maximum number of output tokens allowed. | `32000` |
 | `WAVE_DISABLE_AUTO_MEMORY` | Set to `1` or `true` to disable the auto-memory feature. | `false` |
 | `WAVE_AUTO_MEMORY_FREQUENCY` | Auto memory update frequency. `1` = every turn, `2` = every 2 turns, etc. | `1` |
 | `WAVE_TASK_LIST_ID` | Explicitly set the task list ID for the session. | (Session ID) |

--- a/packages/agent-sdk/src/utils/constants.ts
+++ b/packages/agent-sdk/src/utils/constants.ts
@@ -30,4 +30,4 @@ export const USER_MEMORY_FILE = path.join(DATA_DIRECTORY, "AGENTS.md");
  * AI related constants
  */
 export const DEFAULT_WAVE_MAX_INPUT_TOKENS = 200000; // Default token limit
-export const DEFAULT_WAVE_MAX_OUTPUT_TOKENS = 16384; // Default output token limit
+export const DEFAULT_WAVE_MAX_OUTPUT_TOKENS = 32000; // Default output token limit (aligned with Claude Code)


### PR DESCRIPTION
## Summary

Align Wave's default `max output tokens` with Claude Code's default of 32,000.

- Claude Code uses 32,000 as the default `max_tokens` for mainstream models (sonnet-4, opus-4.5, etc.) and as the fallback default
- Wave was using 16,384, roughly half of Claude Code's value
- This change updates `DEFAULT_WAVE_MAX_OUTPUT_TOKENS` from 16384 to 32000

## Changes

- `packages/agent-sdk/src/utils/constants.ts`: `DEFAULT_WAVE_MAX_OUTPUT_TOKENS` 16384 → 32000
- `packages/agent-sdk/builtin/skills/settings/ENV.md`: Update documented default value

## Test

- `configurationService.test.ts`: 46/46 passed (tests reference the constant by name, not hardcoded value)