### PR TITLE
fix: use readFileState for Edit read-before-edit check, align with Claude Code

### DIFF
--- a/packages/agent-sdk/src/tools/editTool.ts
+++ b/packages/agent-sdk/src/tools/editTool.ts
@@ -112,11 +112,11 @@ Usage:
     // Trigger conditional rule loading for this file
     context.messageManager?.triggerFileRead(filePath);
 
-    // Enforce read-before-edit: the file must have been read first
-    if (
-      context.messageManager &&
-      !context.messageManager.hasFileBeenRead(filePath)
-    ) {
+    // Enforce read-before-edit: the file must have been read or written first.
+    // readFileState is populated by Read, Write, and Edit tools — single source
+    // of truth, aligned with Claude Code's readFileState approach.
+    const resolvedPath = resolvePath(filePath, context.workdir);
+    if (!context.readFileState?.has(resolvedPath)) {
       return {
         success: false,
         content: "",
@@ -125,8 +125,6 @@ Usage:
     }
 
     try {
-      const resolvedPath = resolvePath(filePath, context.workdir);
-
       // Read file content
       let originalContent: string;
       try {

--- a/packages/agent-sdk/tests/tools/editTool.test.ts
+++ b/packages/agent-sdk/tests/tools/editTool.test.ts
@@ -22,11 +22,23 @@ describe("editTool", () => {
       abortSignal: new AbortController().signal,
       workdir: "/test/workdir",
       taskManager: new TaskManager(new Container(), "test-session"),
+      // Pre-populate readFileState so read-before-edit check passes.
+      // Individual tests can override with an empty Map or undefined.
+      readFileState: new Map([
+        ["/test/file.js", { mtime: 1000, hash: "abc" }],
+        ["/test/workdir/file.js", { mtime: 1000, hash: "abc" }],
+        ["/test/nonexistent.js", { mtime: 1000, hash: "abc" }],
+        ["/absolute/path/file.js", { mtime: 1000, hash: "abc" }],
+      ]),
     };
   });
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default stat mock returns mtime matching pre-populated readFileState
+    vi.mocked(stat).mockResolvedValue({
+      mtime: { getTime: () => 1000 } as Date,
+    } as unknown as Awaited<ReturnType<typeof stat>>);
   });
 
   afterEach(() => {
@@ -443,11 +455,6 @@ describe("editTool", () => {
   });
 
   it("should reject edit when file has not been read first", async () => {
-    const mockMessageManager = {
-      triggerFileRead: vi.fn(),
-      hasFileBeenRead: vi.fn().mockReturnValue(false),
-    };
-
     const result = await editTool.execute(
       {
         file_path: "/test/workdir/file.js",
@@ -456,8 +463,7 @@ describe("editTool", () => {
       },
       {
         ...mockContext,
-        messageManager:
-          mockMessageManager as unknown as ToolContext["messageManager"],
+        readFileState: new Map(),
       },
     );
 
@@ -471,11 +477,6 @@ describe("editTool", () => {
     vi.mocked(readFile).mockResolvedValue(mockContent);
     vi.mocked(writeFile).mockResolvedValue(undefined);
 
-    const mockMessageManager = {
-      triggerFileRead: vi.fn(),
-      hasFileBeenRead: vi.fn().mockReturnValue(true),
-    };
-
     const result = await editTool.execute(
       {
         file_path: "/test/workdir/file.js",
@@ -484,8 +485,9 @@ describe("editTool", () => {
       },
       {
         ...mockContext,
-        messageManager:
-          mockMessageManager as unknown as ToolContext["messageManager"],
+        readFileState: new Map([
+          ["/test/workdir/file.js", { mtime: 1000, hash: "abc" }],
+        ]),
       },
     );
 
@@ -633,22 +635,24 @@ describe("editTool", () => {
     expect(updated?.mtime).toBe(2000);
   });
 
-  it("should skip staleness check when readFileState is not provided", async () => {
+  it("should reject edit when readFileState is not provided", async () => {
     const mockContent = "some content";
     vi.mocked(readFile).mockResolvedValue(mockContent);
     vi.mocked(writeFile).mockResolvedValue(undefined);
 
-    // No readFileState in context — staleness check is skipped entirely
+    // No readFileState in context — read-before-edit check rejects,
+    // staleness check never reached (stat not called)
     const result = await editTool.execute(
       {
         file_path: "/test/file.js",
         old_string: "some",
         new_string: "other",
       },
-      mockContext,
+      { ...mockContext, readFileState: undefined },
     );
 
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("must read the file");
     expect(stat).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem

Edit's read-before-edit check used `messageManager.hasFileBeenRead()` which only tracked Read tool results. The Write tool only updates `context.readFileState`, so **Write → Edit failed** without an intermediate Read — the agent had to Read a file it just wrote.

## Fix

Changed Edit's read-before-edit check from `messageManager.hasFileBeenRead(filePath)` to `context.readFileState?.has(resolvedPath)`.

`readFileState` is populated by Read, Write, and Edit tools — a single source of truth, matching Claude Code's `readFileState` approach where all three tools write to the same Map.

## Changes

- **`packages/agent-sdk/src/tools/editTool.ts`**: Moved `resolvedPath` computation before the check; replaced `messageManager.hasFileBeenRead()` with `context.readFileState?.has(resolvedPath)`
- **`packages/agent-sdk/tests/tools/editTool.test.ts`**:
  - Pre-populated `readFileState` in `beforeEach` for happy-path tests
  - Added default `stat` mock returning matching `mtime` to prevent staleness check crashes
  - Updated rejection test to use empty `readFileState` instead of mocking `messageManager`
  - Updated allow test to use path-specific `readFileState`
  - Renamed "skip staleness check" test to "reject edit when readFileState is not provided" (now expects failure)

## Test Results

- 24/24 editTool tests pass
- 65/65 related tool tests pass (writeTool, readTool, editToolSerialization)
- Build and type-check pass

## Notes

`messageManager.hasFileBeenRead()` and `recentFileReads` are left intact — still used by `getRecentFileReads()` for compaction context attachment.