### PR TITLE
fix: include full HTTP error response in error message

### DIFF
--- a/packages/agent-sdk/src/utils/openaiClient.ts
+++ b/packages/agent-sdk/src/utils/openaiClient.ts
@@ -166,37 +166,18 @@ export class OpenAIClient {
         }
       }
 
-      let errorBody: unknown;
+      let responseText = "";
       try {
-        const text = await response.text();
-        try {
-          errorBody = JSON.parse(text);
-        } catch (e) {
-          logger.error("Failed to parse error response body as JSON", {
-            error: e,
-            text,
-          });
-          errorBody = text;
-        }
+        responseText = await response.text();
       } catch (e) {
         logger.error("Failed to read error response text", { error: e });
-        errorBody = {};
       }
 
       const error = new Error(
-        typeof errorBody === "object" &&
-        errorBody !== null &&
-        "error" in errorBody &&
-        typeof (errorBody as { error: unknown }).error === "object" &&
-        (errorBody as { error: object }).error !== null &&
-        "message" in (errorBody as { error: { message: unknown } }).error
-          ? String((errorBody as { error: { message: string } }).error.message)
-          : typeof errorBody === "string"
-            ? errorBody
-            : response.statusText,
+        `HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ""}: ${responseText}`,
       ) as Error & { status?: number; body?: unknown };
       error.status = response.status;
-      error.body = errorBody;
+      error.body = responseText;
 
       const retryableStatus =
         response.status === 429 ||
@@ -215,7 +196,7 @@ export class OpenAIClient {
       logger.error("OpenAI API Error:", {
         status: response.status,
         statusText: response.statusText,
-        errorBody,
+        body: responseText,
       });
       throw error;
     }


### PR DESCRIPTION
## Problem

When an AI gateway returns a non-OpenAI-standard error response (e.g. `{error: "You must be in a team to access this resource"}`), the error message displayed to the user was just the HTTP statusText (e.g. `Forbidden`), completely losing the response body content.

## Fix

Simplify the error formatting in `openaiClient.ts` to use the raw HTTP response text directly, instead of trying to parse it as JSON and extract a nested `error.message` field:

**Before:** `Forbidden`

**After:** `HTTP 403 Forbidden: {"error":"You must be in a team to access this resource"}`

This works for all gateway response formats since it doesn't assume any specific JSON structure. The unnecessary `JSON.parse` step was also removed.