### PR TITLE
feat(acp): emit turn-end notification for out-of-turn messages

### DIFF
--- a/packages/code/src/acp/agent.ts
+++ b/packages/code/src/acp/agent.ts
@@ -245,6 +245,8 @@ export class WaveAcpAgent implements AcpAgent {
           callbacks.onSessionIdChange?.(newSessionId),
         onLatestTotalTokensChange: (tokens: number) =>
           callbacks.onLatestTotalTokensChange?.(tokens),
+        onLoadingChange: (loading: boolean) =>
+          callbacks.onLoadingChange?.(loading),
       },
     });
 
@@ -1397,6 +1399,18 @@ export class WaveAcpAgent implements AcpAgent {
               used: tokens,
             },
           });
+        },
+        onLoadingChange: (loading: boolean) => {
+          if (!loading) {
+            this.connection.sessionUpdate({
+              sessionId: sessionRef.id as AcpSessionId,
+              update: {
+                sessionUpdate: "agent_message_chunk",
+                content: { type: "text", text: "" },
+                _meta: { endOfTurn: true },
+              },
+            });
+          }
         },
       },
       sessionRef,


### PR DESCRIPTION
## Summary

ACP clients (like popo-acp) cannot reliably detect when internally-triggered turns (cron jobs, background tasks, goal evaluator restarts) end. These turns go through `aiManager.sendAIMessage()` directly, bypassing the ACP `prompt()` method — so the client never receives a `PromptResponse` with `stopReason`.

## Changes

Register the existing `onLoadingChange` callback in the ACP layer (`packages/code/src/acp/agent.ts`):

1. **`createAgent()`** — Add `onLoadingChange` to the callback forwarding list so SDK calls propagate through to `createCallbacks()`.

2. **`createCallbacks()`** — When `loading` becomes `false`, emit an `agent_message_chunk` session update with empty text and `_meta: { endOfTurn: true }`.

## Why `onLoadingChange(false)`

`setIsLoading(false)` fires after the inner loop breaks (no more tool calls, LLM done). After this, the code may restart with `shouldRestart = true` (notification queue or goal evaluator). This is correct: the current round ended and the client should flush its buffer. The subsequent restart is a new turn that emits its own message sequence.

## Client-side handling

ACP clients check `update._meta?.endOfTurn` to flush immediately instead of relying on debounce timers.

Closes #1348