### PR TITLE
fix: Windows path compatibility — eliminate shell string interpolation for paths

### DIFF
--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import * as os from "os";
 import { logger } from "../utils/globalLogger.js";
 import { resolveShellPath } from "../utils/shellResolver.js";
+import { toPosixPath } from "../utils/path.js";
 import { stripAnsiColors } from "../utils/stringUtils.js";
 import { processToolResult } from "../utils/toolResultStorage.js";
 import { BASH_MAX_OUTPUT_CHARS } from "../constants/toolLimits.js";
@@ -246,7 +247,8 @@ The working directory persists between commands. Try to maintain your current wo
         os.tmpdir(),
         `wave_cwd_${Date.now()}_${Math.random().toString(36).substring(2, 11)}.tmp`,
       );
-      const wrappedCommand = `${command} && pwd -P >| ${tempCwdFile}`;
+      const tempCwdFileForBash = toPosixPath(tempCwdFile);
+      const wrappedCommand = `${command} && pwd -P >| ${tempCwdFileForBash}`;
 
       const child: ChildProcess = spawn(wrappedCommand, {
         shell: shellPath || true,
@@ -263,6 +265,17 @@ The working directory persists between commands. Try to maintain your current wo
       let isAborted = false;
       let isBackgrounded = false;
       let isFinished = false;
+
+      // Best-effort cleanup of the temp CWD file — used by abort/error/exit paths
+      const cleanupTempFile = () => {
+        try {
+          if (fs.existsSync(tempCwdFile)) {
+            fs.unlinkSync(tempCwdFile);
+          }
+        } catch {
+          // ignore — best-effort cleanup
+        }
+      };
 
       const updateRealtimeResults = () => {
         if (isAborted || isBackgrounded || isFinished) return;
@@ -420,6 +433,8 @@ The working directory persists between commands. Try to maintain your current wo
             }
           }
 
+          cleanupTempFile();
+
           const processedOutput = processToolResult(
             outputBuffer + (errorBuffer ? "\n" + errorBuffer : ""),
             BASH_MAX_OUTPUT_CHARS,
@@ -491,14 +506,7 @@ The working directory persists between commands. Try to maintain your current wo
             );
             newCwd = undefined;
           } finally {
-            // Ensure temp file is cleaned up even if reading fails
-            try {
-              if (fs.existsSync(tempCwdFile)) {
-                fs.unlinkSync(tempCwdFile);
-              }
-            } catch (fileError) {
-              logger.error("Failed to clean up temp CWD file:", fileError);
-            }
+            cleanupTempFile();
           }
 
           // If CWD changed, call the onCwdChange callback and add notification
@@ -560,6 +568,7 @@ The working directory persists between commands. Try to maintain your current wo
           if (timeoutHandle) {
             clearTimeout(timeoutHandle);
           }
+          cleanupTempFile();
           resolve({
             success: false,
             content: "",

--- a/packages/agent-sdk/src/utils/gitUtils.ts
+++ b/packages/agent-sdk/src/utils/gitUtils.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 import * as fsSync from "node:fs";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 /**
  * Check if a directory is a git repository
@@ -31,7 +31,7 @@ export function isGitRepository(dirPath: string): string {
  */
 export function getGitRepoRoot(cwd: string): string {
   try {
-    return execSync("git rev-parse --show-toplevel", {
+    return execFileSync("git", ["rev-parse", "--show-toplevel"], {
       cwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
@@ -48,7 +48,7 @@ export function getGitRepoRoot(cwd: string): string {
  */
 export function getGitCommonDir(cwd: string): string {
   try {
-    const commonDir = execSync("git rev-parse --git-common-dir", {
+    const commonDir = execFileSync("git", ["rev-parse", "--git-common-dir"], {
       cwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
@@ -66,7 +66,7 @@ export function getGitCommonDir(cwd: string): string {
  */
 export function getGitMainRepoRoot(cwd: string): string {
   try {
-    const output = execSync("git worktree list --porcelain", {
+    const output = execFileSync("git", ["worktree", "list", "--porcelain"], {
       cwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
@@ -229,7 +229,7 @@ export function getDefaultRemoteBranch(cwd: string): string {
  */
 export function hasUncommittedChanges(cwd: string): boolean {
   try {
-    const status = execSync("git status --porcelain", {
+    const status = execFileSync("git", ["status", "--porcelain"], {
       cwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
@@ -249,7 +249,7 @@ export function hasUncommittedChanges(cwd: string): boolean {
 export function hasNewCommits(cwd: string, baseBranch?: string): boolean {
   try {
     const range = baseBranch ? `${baseBranch}..HEAD` : "@{u}..HEAD";
-    const log = execSync(`git log ${range} --oneline`, {
+    const log = execFileSync("git", ["log", range, "--oneline"], {
       cwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],

--- a/packages/agent-sdk/src/utils/path.ts
+++ b/packages/agent-sdk/src/utils/path.ts
@@ -54,3 +54,13 @@ export function getDisplayPath(filePath: string, workdir: string): string {
   }
   return filePath;
 }
+
+/**
+ * Convert backslashes to forward slashes for shell compatibility on Windows.
+ * On Windows, os.tmpdir() returns paths with backslashes (e.g., C:\Users\foo\Temp),
+ * which are treated as escape characters when interpolated into shell command strings.
+ * Returns the path as-is on non-Windows platforms.
+ */
+export function toPosixPath(p: string): string {
+  return process.platform === "win32" ? p.replace(/\\/g, "/") : p;
+}

--- a/packages/agent-sdk/src/utils/worktreeUtils.ts
+++ b/packages/agent-sdk/src/utils/worktreeUtils.ts
@@ -3,7 +3,7 @@
  * Used by EnterWorktree and ExitWorktree tools.
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import * as path from "node:path";
 import * as fs from "node:fs";
 import { getGitMainRepoRoot, getDefaultRemoteBranch } from "./gitUtils.js";
@@ -81,7 +81,7 @@ export function generateWorktreeName(): string {
  * Get the current HEAD commit SHA.
  */
 export function getHeadCommit(cwd: string): string {
-  return execSync(`git -C "${cwd}" rev-parse HEAD`, {
+  return execFileSync("git", ["-C", cwd, "rev-parse", "HEAD"], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "ignore"],
   }).trim();
@@ -125,8 +125,9 @@ export function createWorktree(name: string, cwd: string): WorktreeInfo {
 
   try {
     // Create worktree and branch
-    execSync(
-      `git worktree add -b ${branchName} "${worktreePath}" ${baseBranch}`,
+    execFileSync(
+      "git",
+      ["worktree", "add", "-b", branchName, worktreePath, baseBranch],
       {
         cwd: repoRoot,
         stdio: ["ignore", "pipe", "pipe"],
@@ -151,7 +152,7 @@ export function createWorktree(name: string, cwd: string): WorktreeInfo {
     if (stderr.includes("already exists")) {
       // Branch exists but worktree doesn't — attach to existing branch
       try {
-        execSync(`git worktree add "${worktreePath}" ${branchName}`, {
+        execFileSync("git", ["worktree", "add", worktreePath, branchName], {
           cwd: repoRoot,
           stdio: ["ignore", "pipe", "pipe"],
           env: {
@@ -181,7 +182,7 @@ export function createWorktree(name: string, cwd: string): WorktreeInfo {
       // Base branch not fetched yet — try fetching then retrying
       const branchNameOnly = baseBranch.split("/").pop()!;
       try {
-        execSync(`git fetch origin ${branchNameOnly}`, {
+        execFileSync("git", ["fetch", "origin", branchNameOnly], {
           cwd: repoRoot,
           stdio: ["ignore", "pipe", "pipe"],
           env: {
@@ -190,8 +191,9 @@ export function createWorktree(name: string, cwd: string): WorktreeInfo {
             GIT_ASKPASS: "",
           },
         });
-        execSync(
-          `git worktree add -b ${branchName} "${worktreePath}" ${baseBranch}`,
+        execFileSync(
+          "git",
+          ["worktree", "add", "-b", branchName, worktreePath, baseBranch],
           {
             cwd: repoRoot,
             stdio: ["ignore", "pipe", "pipe"],
@@ -213,15 +215,19 @@ export function createWorktree(name: string, cwd: string): WorktreeInfo {
       } catch {
         // Fetch or retry failed — fall back to HEAD
         try {
-          execSync(`git worktree add -b ${branchName} "${worktreePath}" HEAD`, {
-            cwd: repoRoot,
-            stdio: ["ignore", "pipe", "pipe"],
-            env: {
-              ...process.env,
-              GIT_TERMINAL_PROMPT: "0",
-              GIT_ASKPASS: "",
+          execFileSync(
+            "git",
+            ["worktree", "add", "-b", branchName, worktreePath, "HEAD"],
+            {
+              cwd: repoRoot,
+              stdio: ["ignore", "pipe", "pipe"],
+              env: {
+                ...process.env,
+                GIT_TERMINAL_PROMPT: "0",
+                GIT_ASKPASS: "",
+              },
             },
-          });
+          );
           return {
             name,
             path: worktreePath,
@@ -253,24 +259,28 @@ export function removeWorktree(info: WorktreeInfo): void {
     // Get current branch in worktree before removing
     let currentBranch: string | undefined;
     try {
-      currentBranch = execSync(`git rev-parse --abbrev-ref HEAD`, {
-        cwd: info.path,
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"],
-      }).trim();
+      currentBranch = execFileSync(
+        "git",
+        ["rev-parse", "--abbrev-ref", "HEAD"],
+        {
+          cwd: info.path,
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+        },
+      ).trim();
     } catch {
       // Ignore errors
     }
 
     // Remove worktree
-    execSync(`git worktree remove --force "${info.path}"`, {
+    execFileSync("git", ["worktree", "remove", "--force", info.path], {
       cwd: repoRoot,
       stdio: ["ignore", "pipe", "pipe"],
     });
 
     // Delete worktree branch
     try {
-      execSync(`git branch -D ${info.branch}`, {
+      execFileSync("git", ["branch", "-D", info.branch], {
         cwd: repoRoot,
         stdio: ["ignore", "pipe", "pipe"],
       });
@@ -293,7 +303,7 @@ export function removeWorktree(info: WorktreeInfo): void {
         currentBranch !== "master"
       ) {
         try {
-          execSync(`git branch -D ${currentBranch}`, {
+          execFileSync("git", ["branch", "-D", currentBranch], {
             cwd: repoRoot,
             stdio: ["ignore", "pipe", "pipe"],
           });
@@ -320,8 +330,9 @@ export function countWorktreeChanges(
   originalHeadCommit: string | undefined,
 ): { changedFiles: number; commits: number } | null {
   try {
-    const statusOutput = execSync(
-      `git -C "${worktreePath}" status --porcelain`,
+    const statusOutput = execFileSync(
+      "git",
+      ["-C", worktreePath, "status", "--porcelain"],
       {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],
@@ -335,8 +346,15 @@ export function countWorktreeChanges(
       return null;
     }
 
-    const revListOutput = execSync(
-      `git -C "${worktreePath}" rev-list --count ${originalHeadCommit}..HEAD`,
+    const revListOutput = execFileSync(
+      "git",
+      [
+        "-C",
+        worktreePath,
+        "rev-list",
+        "--count",
+        `${originalHeadCommit}..HEAD`,
+      ],
       {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],

--- a/packages/agent-sdk/tests/utils/gitUtils.test.ts
+++ b/packages/agent-sdk/tests/utils/gitUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import * as fsSync from "node:fs";
 import * as path from "node:path";
 import {
@@ -12,7 +12,7 @@ import {
 } from "../../src/utils/gitUtils.js";
 
 vi.mock("node:child_process", () => ({
-  execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
 vi.mock("node:fs", () => ({
@@ -30,18 +30,19 @@ describe("gitUtils", () => {
 
   describe("getGitRepoRoot", () => {
     it("should return the git repo root", () => {
-      vi.mocked(execSync).mockReturnValue(
-        "/repo/root\n" as unknown as ReturnType<typeof execSync>,
+      vi.mocked(execFileSync).mockReturnValue(
+        "/repo/root\n" as unknown as ReturnType<typeof execFileSync>,
       );
       expect(getGitRepoRoot("/some/path")).toBe("/repo/root");
-      expect(execSync).toHaveBeenCalledWith(
-        "git rev-parse --show-toplevel",
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        ["rev-parse", "--show-toplevel"],
         expect.any(Object),
       );
     });
 
     it("should return cwd if git command fails", () => {
-      vi.mocked(execSync).mockImplementation(() => {
+      vi.mocked(execFileSync).mockImplementation(() => {
         throw new Error("Not a git repo");
       });
       expect(getGitRepoRoot("/some/path")).toBe("/some/path");
@@ -50,25 +51,27 @@ describe("gitUtils", () => {
 
   describe("getGitMainRepoRoot", () => {
     it("should return the main repo root from git worktree list", () => {
-      vi.mocked(execSync).mockReturnValue(
+      vi.mocked(execFileSync).mockReturnValue(
         "worktree /repo/main\nHEAD 123\nbranch refs/heads/main\n\nworktree /repo/worktree1\nHEAD 456\nbranch refs/heads/wt1\n" as unknown as ReturnType<
-          typeof execSync
+          typeof execFileSync
         >,
       );
       expect(getGitMainRepoRoot("/repo/worktree1")).toBe("/repo/main");
-      expect(execSync).toHaveBeenCalledWith(
-        "git worktree list --porcelain",
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        ["worktree", "list", "--porcelain"],
         expect.any(Object),
       );
     });
 
     it("should fallback to getGitRepoRoot if git worktree list fails", () => {
-      vi.mocked(execSync).mockImplementation((cmd) => {
-        if (cmd === "git worktree list --porcelain") {
+      vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+        const a = args as string[];
+        if (a[0] === "worktree" && a[1] === "list") {
           throw new Error("Command failed");
         }
-        if (cmd === "git rev-parse --show-toplevel") {
-          return "/repo/root\n" as unknown as ReturnType<typeof execSync>;
+        if (a[0] === "rev-parse" && a[1] === "--show-toplevel") {
+          return "/repo/root\n" as unknown as ReturnType<typeof execFileSync>;
         }
         throw new Error("Command failed");
       });
@@ -76,12 +79,15 @@ describe("gitUtils", () => {
     });
 
     it("should fallback to getGitRepoRoot if output is unexpected", () => {
-      vi.mocked(execSync).mockImplementation((cmd) => {
-        if (cmd === "git worktree list --porcelain") {
-          return "unexpected output" as unknown as ReturnType<typeof execSync>;
+      vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+        const a = args as string[];
+        if (a[0] === "worktree" && a[1] === "list") {
+          return "unexpected output" as unknown as ReturnType<
+            typeof execFileSync
+          >;
         }
-        if (cmd === "git rev-parse --show-toplevel") {
-          return "/repo/root\n" as unknown as ReturnType<typeof execSync>;
+        if (a[0] === "rev-parse" && a[1] === "--show-toplevel") {
+          return "/repo/root\n" as unknown as ReturnType<typeof execFileSync>;
         }
         throw new Error("Command failed");
       });
@@ -245,15 +251,15 @@ describe("gitUtils", () => {
 
   describe("hasUncommittedChanges", () => {
     it("should return true if there are changes", () => {
-      vi.mocked(execSync).mockReturnValue(
-        " M file.ts\n" as unknown as ReturnType<typeof execSync>,
+      vi.mocked(execFileSync).mockReturnValue(
+        " M file.ts\n" as unknown as ReturnType<typeof execFileSync>,
       );
       expect(hasUncommittedChanges("/repo/root")).toBe(true);
     });
 
     it("should return false if there are no changes", () => {
-      vi.mocked(execSync).mockReturnValue(
-        "" as unknown as ReturnType<typeof execSync>,
+      vi.mocked(execFileSync).mockReturnValue(
+        "" as unknown as ReturnType<typeof execFileSync>,
       );
       expect(hasUncommittedChanges("/repo/root")).toBe(false);
     });
@@ -261,15 +267,17 @@ describe("gitUtils", () => {
 
   describe("hasNewCommits", () => {
     it("should return true if there are new commits", () => {
-      vi.mocked(execSync).mockReturnValue(
-        "abc1234 Commit message\n" as unknown as ReturnType<typeof execSync>,
+      vi.mocked(execFileSync).mockReturnValue(
+        "abc1234 Commit message\n" as unknown as ReturnType<
+          typeof execFileSync
+        >,
       );
       expect(hasNewCommits("/repo/root", "origin/main")).toBe(true);
     });
 
     it("should return false if there are no new commits", () => {
-      vi.mocked(execSync).mockReturnValue(
-        "" as unknown as ReturnType<typeof execSync>,
+      vi.mocked(execFileSync).mockReturnValue(
+        "" as unknown as ReturnType<typeof execFileSync>,
       );
       expect(hasNewCommits("/repo/root", "origin/main")).toBe(false);
     });

--- a/packages/agent-sdk/tests/utils/worktreeUtils.test.ts
+++ b/packages/agent-sdk/tests/utils/worktreeUtils.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as worktreeUtils from "@/utils/worktreeUtils.js";
 import * as gitUtils from "@/utils/gitUtils.js";
 import * as fs from "node:fs";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 vi.mock("node:child_process");
 vi.mock("node:fs");
@@ -65,13 +65,14 @@ describe("worktreeUtils", () => {
 
   describe("getHeadCommit", () => {
     it("returns HEAD commit SHA", () => {
-      vi.mocked(execSync).mockReturnValue("abc123def\n");
+      vi.mocked(execFileSync).mockReturnValue("abc123def\n");
 
       const result = worktreeUtils.getHeadCommit("/test");
 
       expect(result).toBe("abc123def");
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining("git -C"),
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["-C"]),
         expect.objectContaining({ encoding: "utf8" }),
       );
     });
@@ -81,7 +82,7 @@ describe("worktreeUtils", () => {
     beforeEach(() => {
       vi.mocked(gitUtils.getGitMainRepoRoot).mockReturnValue("/test/repo");
       vi.mocked(gitUtils.getDefaultRemoteBranch).mockReturnValue("origin/main");
-      vi.mocked(execSync).mockReturnValue("abc123\n");
+      vi.mocked(execFileSync).mockReturnValue("abc123\n");
       vi.mocked(fs.existsSync).mockReturnValue(false);
     });
 
@@ -102,8 +103,9 @@ describe("worktreeUtils", () => {
       const result = worktreeUtils.createWorktree("existing", "/test");
 
       expect(result.isNew).toBe(false);
-      expect(execSync).not.toHaveBeenCalledWith(
-        expect.stringContaining("git worktree add -b"),
+      expect(execFileSync).not.toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["worktree", "add", "-b"]),
         expect.anything(),
       );
     });
@@ -118,7 +120,7 @@ describe("worktreeUtils", () => {
 
     it("handles branch already exists fallback", () => {
       let callCount = 0;
-      vi.mocked(execSync).mockImplementation(() => {
+      vi.mocked(execFileSync).mockImplementation(() => {
         callCount++;
         if (callCount === 1) {
           // getHeadCommit
@@ -143,7 +145,7 @@ describe("worktreeUtils", () => {
 
     it("should fetch default branch when not found locally, then create worktree", () => {
       let callCount = 0;
-      vi.mocked(execSync).mockImplementation(() => {
+      vi.mocked(execFileSync).mockImplementation(() => {
         callCount++;
         if (callCount === 1) {
           // getHeadCommit
@@ -169,15 +171,16 @@ describe("worktreeUtils", () => {
 
       expect(result.isNew).toBe(true);
       expect(result.originalHeadCommit).toBe("abc123");
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining("git fetch origin main"),
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["fetch", "origin", "main"]),
         expect.anything(),
       );
     });
 
     it("should fall back to HEAD when fetch also fails", () => {
       let callCount = 0;
-      vi.mocked(execSync).mockImplementation(() => {
+      vi.mocked(execFileSync).mockImplementation(() => {
         callCount++;
         if (callCount === 1) {
           // getHeadCommit
@@ -202,15 +205,22 @@ describe("worktreeUtils", () => {
       const result = worktreeUtils.createWorktree("feat", "/test");
 
       expect(result.isNew).toBe(true);
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringMatching(/git worktree add -b worktree-feat ".*" HEAD/),
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining([
+          "worktree",
+          "add",
+          "-b",
+          "worktree-feat",
+          "HEAD",
+        ]),
         expect.anything(),
       );
     });
 
     it("should throw when both fetch and HEAD fallback fail", () => {
       let callCount = 0;
-      vi.mocked(execSync).mockImplementation(() => {
+      vi.mocked(execFileSync).mockImplementation(() => {
         callCount++;
         if (callCount === 1) {
           // getHeadCommit
@@ -240,7 +250,7 @@ describe("worktreeUtils", () => {
 
   describe("removeWorktree", () => {
     beforeEach(() => {
-      vi.mocked(execSync).mockReturnValue("");
+      vi.mocked(execFileSync).mockReturnValue("");
       vi.mocked(gitUtils.getDefaultRemoteBranch).mockReturnValue("origin/main");
     });
 
@@ -253,19 +263,21 @@ describe("worktreeUtils", () => {
         isNew: true,
       });
 
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining("git worktree remove --force"),
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["worktree", "remove", "--force"]),
         expect.anything(),
       );
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining("git branch -D worktree-feat"),
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["branch", "-D", "worktree-feat"]),
         expect.anything(),
       );
     });
 
     it("logs and rethrows on failure", () => {
       const error = new Error("git failed");
-      vi.mocked(execSync).mockImplementation(() => {
+      vi.mocked(execFileSync).mockImplementation(() => {
         throw error;
       });
 
@@ -283,7 +295,7 @@ describe("worktreeUtils", () => {
 
   describe("countWorktreeChanges", () => {
     it("returns changed files and commits", () => {
-      vi.mocked(execSync)
+      vi.mocked(execFileSync)
         .mockReturnValueOnce("M file1.txt\n?? file2.txt\n") // status
         .mockReturnValueOnce("3\n"); // rev-list
 
@@ -296,7 +308,7 @@ describe("worktreeUtils", () => {
     });
 
     it("returns null when originalHeadCommit is undefined", () => {
-      vi.mocked(execSync).mockReturnValueOnce("\n"); // empty status
+      vi.mocked(execFileSync).mockReturnValueOnce("\n"); // empty status
 
       const result = worktreeUtils.countWorktreeChanges(
         "/test/worktree",
@@ -307,7 +319,7 @@ describe("worktreeUtils", () => {
     });
 
     it("returns null when git commands fail", () => {
-      vi.mocked(execSync).mockImplementation(() => {
+      vi.mocked(execFileSync).mockImplementation(() => {
         throw new Error("git error");
       });
 
@@ -320,7 +332,7 @@ describe("worktreeUtils", () => {
     });
 
     it("returns 0 commits for clean worktree", () => {
-      vi.mocked(execSync)
+      vi.mocked(execFileSync)
         .mockReturnValueOnce("") // no changes
         .mockReturnValueOnce("0\n"); // no commits
 

--- a/packages/code/src/utils/worktree.ts
+++ b/packages/code/src/utils/worktree.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import * as path from "node:path";
 import * as fs from "node:fs";
 import { getDefaultRemoteBranch, getGitMainRepoRoot } from "wave-agent-sdk";
@@ -47,8 +47,9 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
 
   try {
     // Create worktree and branch
-    execSync(
-      `git worktree add -b ${branchName} "${worktreePath}" ${baseBranch}`,
+    execFileSync(
+      "git",
+      ["worktree", "add", "-b", branchName, worktreePath, baseBranch],
       {
         cwd: repoRoot,
         stdio: ["ignore", "pipe", "pipe"],
@@ -69,7 +70,7 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
     if (stderr.includes("already exists")) {
       // If branch already exists, try to add worktree without -b
       try {
-        execSync(`git worktree add "${worktreePath}" ${branchName}`, {
+        execFileSync("git", ["worktree", "add", worktreePath, branchName], {
           cwd: repoRoot,
           stdio: ["ignore", "pipe", "pipe"],
         });
@@ -95,12 +96,13 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
       // Base branch not fetched yet — try fetching then retrying
       const branchNameOnly = baseBranch.split("/").pop()!;
       try {
-        execSync(`git fetch origin ${branchNameOnly}`, {
+        execFileSync("git", ["fetch", "origin", branchNameOnly], {
           cwd: repoRoot,
           stdio: ["ignore", "pipe", "pipe"],
         });
-        execSync(
-          `git worktree add -b ${branchName} "${worktreePath}" ${baseBranch}`,
+        execFileSync(
+          "git",
+          ["worktree", "add", "-b", branchName, worktreePath, baseBranch],
           {
             cwd: repoRoot,
             stdio: ["ignore", "pipe", "pipe"],
@@ -118,10 +120,14 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
       } catch {
         // Fetch or retry failed — fall back to HEAD
         try {
-          execSync(`git worktree add -b ${branchName} "${worktreePath}" HEAD`, {
-            cwd: repoRoot,
-            stdio: ["ignore", "pipe", "pipe"],
-          });
+          execFileSync(
+            "git",
+            ["worktree", "add", "-b", branchName, worktreePath, "HEAD"],
+            {
+              cwd: repoRoot,
+              stdio: ["ignore", "pipe", "pipe"],
+            },
+          );
           return {
             name,
             path: worktreePath,
@@ -155,24 +161,28 @@ export function removeWorktree(session: WorktreeSession): void {
     // Get current branch in worktree before removing it
     let currentBranch: string | undefined;
     try {
-      currentBranch = execSync(`git rev-parse --abbrev-ref HEAD`, {
-        cwd: session.path,
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"],
-      }).trim();
+      currentBranch = execFileSync(
+        "git",
+        ["rev-parse", "--abbrev-ref", "HEAD"],
+        {
+          cwd: session.path,
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+        },
+      ).trim();
     } catch {
       // Ignore errors getting current branch
     }
 
     // Remove worktree
-    execSync(`git worktree remove --force "${session.path}"`, {
+    execFileSync("git", ["worktree", "remove", "--force", session.path], {
       cwd: repoRoot,
       stdio: ["ignore", "pipe", "pipe"],
     });
 
     // Delete original branch
     try {
-      execSync(`git branch -D ${session.branch}`, {
+      execFileSync("git", ["branch", "-D", session.branch], {
         cwd: repoRoot,
         stdio: ["ignore", "pipe", "pipe"],
       });
@@ -195,7 +205,7 @@ export function removeWorktree(session: WorktreeSession): void {
         currentBranch !== "master"
       ) {
         try {
-          execSync(`git branch -D ${currentBranch}`, {
+          execFileSync("git", ["branch", "-D", currentBranch], {
             cwd: repoRoot,
             stdio: ["ignore", "pipe", "pipe"],
           });

--- a/packages/code/tests/components/MarketplaceAddForm.test.tsx
+++ b/packages/code/tests/components/MarketplaceAddForm.test.tsx
@@ -58,10 +58,7 @@ describe("MarketplaceAddForm", () => {
       </PluginManagerContext.Provider>,
     );
 
-    stdin.write("h");
-    stdin.write("t");
-    stdin.write("t");
-    stdin.write("p");
+    stdin.write("http");
 
     await vi.waitFor(() => {
       expect(lastFrame()).toContain("http");
@@ -75,8 +72,7 @@ describe("MarketplaceAddForm", () => {
       </PluginManagerContext.Provider>,
     );
 
-    stdin.write("a");
-    stdin.write("b");
+    stdin.write("ab");
     await vi.waitFor(() => {
       expect(lastFrame()).toContain("ab");
     });
@@ -95,10 +91,7 @@ describe("MarketplaceAddForm", () => {
       </PluginManagerContext.Provider>,
     );
 
-    stdin.write("t");
-    stdin.write("e");
-    stdin.write("s");
-    stdin.write("t");
+    stdin.write("test");
     await vi.waitFor(() => {
       expect(lastFrame()).toContain("test");
     });
@@ -117,10 +110,7 @@ describe("MarketplaceAddForm", () => {
       </PluginManagerContext.Provider>,
     );
 
-    stdin.write("t");
-    stdin.write("e");
-    stdin.write("s");
-    stdin.write("t");
+    stdin.write("test");
     await vi.waitFor(() => {
       expect(lastFrame()).toContain("test");
     });
@@ -162,10 +152,7 @@ describe("MarketplaceAddForm", () => {
       </PluginManagerContext.Provider>,
     );
 
-    stdin.write("t");
-    stdin.write("e");
-    stdin.write("s");
-    stdin.write("t");
+    stdin.write("test");
     await vi.waitFor(() => {
       expect(lastFrame()).toContain("test");
     });

--- a/packages/code/tests/utils/worktree.test.ts
+++ b/packages/code/tests/utils/worktree.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import { createWorktree, removeWorktree } from "../../src/utils/worktree.js";
 import { getDefaultRemoteBranch, getGitMainRepoRoot } from "wave-agent-sdk";
 
 vi.mock("node:child_process", () => ({
-  execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
 vi.mock("node:fs", () => ({
@@ -36,8 +36,9 @@ describe("worktree utils", () => {
       expect(session.branch).toBe("worktree-my-feat");
       expect(session.repoRoot).toBe("/repo/root");
       expect(session.isNew).toBe(true);
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining("git worktree add -b worktree-my-feat"),
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["worktree", "add", "-b", "worktree-my-feat"]),
         expect.any(Object),
       );
     });
@@ -50,7 +51,7 @@ describe("worktree utils", () => {
 
       expect(session.name).toBe("my-feat");
       expect(session.isNew).toBe(false);
-      expect(execSync).not.toHaveBeenCalled();
+      expect(execFileSync).not.toHaveBeenCalled();
     });
 
     it("should handle branch already exists error by adding worktree without -b", () => {
@@ -63,21 +64,22 @@ describe("worktree utils", () => {
       (error as { stderr?: Buffer }).stderr = Buffer.from(
         "fatal: a branch named 'worktree-my-feat' already exists",
       );
-      vi.mocked(execSync).mockImplementationOnce(() => {
+      vi.mocked(execFileSync).mockImplementationOnce(() => {
         throw error;
       });
 
       // Second call succeeds
-      vi.mocked(execSync).mockImplementationOnce(() => Buffer.from(""));
+      vi.mocked(execFileSync).mockImplementationOnce(() => Buffer.from(""));
 
       const session = createWorktree("my-feat", "/repo/root");
 
       expect(session.name).toBe("my-feat");
       expect(session.repoRoot).toBe("/repo/root");
       expect(session.isNew).toBe(true);
-      expect(execSync).toHaveBeenCalledTimes(2);
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringMatching(/git worktree add "[^"]+" worktree-my-feat/),
+      expect(execFileSync).toHaveBeenCalledTimes(2);
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["worktree", "add", "worktree-my-feat"]),
         expect.any(Object),
       );
     });
@@ -87,7 +89,7 @@ describe("worktree utils", () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
       const error = new Error("Some other error");
-      vi.mocked(execSync).mockImplementationOnce(() => {
+      vi.mocked(execFileSync).mockImplementationOnce(() => {
         throw error;
       });
 
@@ -104,11 +106,11 @@ describe("worktree utils", () => {
       (error as { stderr?: Buffer }).stderr = Buffer.from(
         "fatal: a branch named 'worktree-my-feat' already exists",
       );
-      vi.mocked(execSync).mockImplementationOnce(() => {
+      vi.mocked(execFileSync).mockImplementationOnce(() => {
         throw error;
       });
 
-      vi.mocked(execSync).mockImplementationOnce(() => {
+      vi.mocked(execFileSync).mockImplementationOnce(() => {
         throw new Error("Inner error");
       });
 
@@ -127,21 +129,22 @@ describe("worktree utils", () => {
       (error as { stderr?: Buffer }).stderr = Buffer.from(
         "not a valid object name",
       );
-      vi.mocked(execSync).mockImplementationOnce(() => {
+      vi.mocked(execFileSync).mockImplementationOnce(() => {
         throw error;
       });
 
       // git fetch origin main succeeds
-      vi.mocked(execSync).mockImplementationOnce(() => Buffer.from(""));
+      vi.mocked(execFileSync).mockImplementationOnce(() => Buffer.from(""));
 
       // Retry git worktree add -b succeeds
-      vi.mocked(execSync).mockImplementationOnce(() => Buffer.from(""));
+      vi.mocked(execFileSync).mockImplementationOnce(() => Buffer.from(""));
 
       const session = createWorktree("my-feat", "/repo/root");
 
       expect(session.isNew).toBe(true);
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining("git fetch origin main"),
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["fetch", "origin", "main"]),
         expect.any(Object),
       );
     });
@@ -156,23 +159,30 @@ describe("worktree utils", () => {
       (error as { stderr?: Buffer }).stderr = Buffer.from(
         "not a valid object name",
       );
-      vi.mocked(execSync).mockImplementationOnce(() => {
+      vi.mocked(execFileSync).mockImplementationOnce(() => {
         throw error;
       });
 
       // git fetch origin main fails
-      vi.mocked(execSync).mockImplementationOnce(() => {
+      vi.mocked(execFileSync).mockImplementationOnce(() => {
         throw new Error("fetch failed");
       });
 
       // git worktree add -b ... HEAD succeeds
-      vi.mocked(execSync).mockImplementationOnce(() => Buffer.from(""));
+      vi.mocked(execFileSync).mockImplementationOnce(() => Buffer.from(""));
 
       const session = createWorktree("my-feat", "/repo/root");
 
       expect(session.isNew).toBe(true);
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringMatching(/git worktree add -b worktree-my-feat ".*" HEAD/),
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining([
+          "worktree",
+          "add",
+          "-b",
+          "worktree-my-feat",
+          "HEAD",
+        ]),
         expect.any(Object),
       );
     });
@@ -187,17 +197,17 @@ describe("worktree utils", () => {
       (error as { stderr?: Buffer }).stderr = Buffer.from(
         "not a valid object name",
       );
-      vi.mocked(execSync).mockImplementationOnce(() => {
+      vi.mocked(execFileSync).mockImplementationOnce(() => {
         throw error;
       });
 
       // git fetch origin main fails
-      vi.mocked(execSync).mockImplementationOnce(() => {
+      vi.mocked(execFileSync).mockImplementationOnce(() => {
         throw new Error("fetch failed");
       });
 
       // git worktree add -b ... HEAD also fails
-      vi.mocked(execSync).mockImplementationOnce(() => {
+      vi.mocked(execFileSync).mockImplementationOnce(() => {
         throw new Error("HEAD fallback failed");
       });
 
@@ -219,16 +229,20 @@ describe("worktree utils", () => {
         isNew: false,
       };
 
-      vi.mocked(execSync).mockReturnValue(Buffer.from("worktree-my-feat\n"));
+      vi.mocked(execFileSync).mockReturnValue(
+        Buffer.from("worktree-my-feat\n"),
+      );
 
       removeWorktree(session);
 
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining("git worktree remove --force"),
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["worktree", "remove", "--force"]),
         expect.any(Object),
       );
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining("git branch -D worktree-my-feat"),
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["branch", "-D", "worktree-my-feat"]),
         expect.any(Object),
       );
     });
@@ -245,8 +259,13 @@ describe("worktree utils", () => {
       };
 
       vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
-      vi.mocked(execSync).mockImplementation((cmd) => {
-        if (cmd === "git rev-parse --abbrev-ref HEAD") {
+      vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+        const a = args as string[];
+        if (
+          a[0] === "rev-parse" &&
+          a[1] === "--abbrev-ref" &&
+          a[2] === "HEAD"
+        ) {
           return "another-branch\n";
         }
         return "";
@@ -254,16 +273,19 @@ describe("worktree utils", () => {
 
       removeWorktree(session);
 
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining("git worktree remove --force"),
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["worktree", "remove", "--force"]),
         expect.any(Object),
       );
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining("git branch -D worktree-my-feat"),
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["branch", "-D", "worktree-my-feat"]),
         expect.any(Object),
       );
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining("git branch -D another-branch"),
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["branch", "-D", "another-branch"]),
         expect.any(Object),
       );
     });
@@ -280,8 +302,13 @@ describe("worktree utils", () => {
       };
 
       vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
-      vi.mocked(execSync).mockImplementation((cmd) => {
-        if (cmd === "git rev-parse --abbrev-ref HEAD") {
+      vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+        const a = args as string[];
+        if (
+          a[0] === "rev-parse" &&
+          a[1] === "--abbrev-ref" &&
+          a[2] === "HEAD"
+        ) {
           return "main\n";
         }
         return "";
@@ -289,16 +316,19 @@ describe("worktree utils", () => {
 
       removeWorktree(session);
 
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining("git worktree remove --force"),
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["worktree", "remove", "--force"]),
         expect.any(Object),
       );
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining("git branch -D worktree-my-feat"),
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["branch", "-D", "worktree-my-feat"]),
         expect.any(Object),
       );
-      expect(execSync).not.toHaveBeenCalledWith(
-        expect.stringContaining("git branch -D main"),
+      expect(execFileSync).not.toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["branch", "-D", "main"]),
         expect.any(Object),
       );
     });
@@ -307,7 +337,7 @@ describe("worktree utils", () => {
       const consoleSpy = vi
         .spyOn(console, "error")
         .mockImplementation(() => {});
-      vi.mocked(execSync).mockImplementation(() => {
+      vi.mocked(execFileSync).mockImplementation(() => {
         throw new Error("Removal failed");
       });
 

--- a/specs/002-bash-tools.md
+++ b/specs/002-bash-tools.md
@@ -67,7 +67,7 @@
 1. **假设** 运行在 Windows 系统上，**当** Git Bash 已安装时，**则** Bash 工具必须使用 Git Bash 而非 cmd.exe 执行命令。
 2. **假设** 运行在 Windows 系统上，**当** Git Bash 未安装时，**则** 系统必须返回清晰的错误消息，提示用户安装 Git for Windows。
 3. **假设** 运行在 Windows 系统上，**当** 执行包含 POSIX 语法的命令（如 `pwd -P >| file`）时，**则** 命令必须正常执行并返回正确结果。
-4. **假设** 运行在 Windows 系统上，**当** 命令执行后检测 CWD 时，**则** CWD 追踪机制必须正常工作（使用 POSIX 路径格式）。
+4. **假设** 运行在 Windows 系统上，**当** 命令执行后检测 CWD 时，**则** CWD 追踪机制必须正常工作——临时文件路径需转换为正斜杠格式以兼容 Git Bash，且临时文件在命令结束后必须被清理，不得残留在项目目录中。
 
 ---
 
@@ -80,7 +80,7 @@
 - **每次命令使用新 Shell**：每次前台命令都会生成新的 shell；`cd` 和环境变量更改不会在调用之间持久化。
 - **超时自动转后台**：当前台命令超时时，系统必须自动将其转为后台（移至 `BackgroundTaskManager`）而不是终止，除非命令以 `sleep` 开头（仍按原方式终止）。
 - **后台无超时**：当 `run_in_background` 明确为 `true` 时，任何超时（默认或显式）必须被取消——进程无限期运行直到完成或手动停止。
-- **Windows 路径转换**：在 Windows 上使用 Git Bash 时，`cwd` 参数可能需要从 Windows 路径（`C:\Users\...`）转换为 POSIX 路径（`/c/Users/...`）。
+- **Windows 路径转换**：在 Windows 上使用 Git Bash 时，临时 CWD 文件路径必须从 Windows 路径（`C:\Users\...`）转换为 POSIX 路径（`C:/Users/...`），否则 Bash 会将反斜杠视为转义字符导致路径损坏、临时文件泄漏到项目目录中。
 - **Git Bash 未安装**：Windows 上未检测到 Git Bash 时，必须返回错误而非静默降级到 cmd.exe。
 
 ## 需求 *(必填)*
@@ -109,6 +109,8 @@
 - **FR-021**：在 Windows 系统上，如果未检测到 Git Bash，系统必须返回错误消息，提示用户安装 Git for Windows 或设置 `GIT_BASH_PATH` 环境变量。
 - **FR-022**：在 Windows 系统上使用 Git Bash 时，`spawn` 调用必须将 shell 参数设置为检测到的 Git Bash 可执行文件路径，而非 `true`。
 - **FR-023**：在 Windows 系统上，CWD 追踪命令（`pwd -P >| tempfile`）必须使用 Git Bash 执行，确保输出为 POSIX 路径格式。
+- **FR-024**：在 Windows 系统上，传递给 Git Bash 的临时文件路径必须将反斜杠转换为正斜杠（`C:\Users\...` → `C:/Users/...`），因为 Bash 将反斜杠视为转义字符，会导致路径损坏并在项目目录中创建临时文件。
+- **FR-025**：CWD 追踪临时文件必须在所有退出路径上被清理，包括正常退出（exit）、中止（abort）、执行错误（error）和转为后台（background）。
 
 ### 关键实体
 


### PR DESCRIPTION
## Problem

On Windows, `os.tmpdir()` returns paths with backslashes (e.g., `C:\Users\foo\Temp`). When these paths are interpolated into Git Bash command strings, backslashes are treated as escape characters, mangling paths (e.g., `C:UsersfooTemp`) and causing temp files to leak into project directories instead of the system temp dir.

The same class of bug existed in all git command execution — `execSync('git -C "C:\Users\foo" rev-parse HEAD')` would fail on Windows because the shell interprets backslashes.

## Root Cause

`execSync` takes a single command string that goes through the shell. On Windows, the shell is Git Bash, which treats `\` as an escape character. Any Windows path with backslashes gets corrupted.

## Fix

Two industry best practices (aligned with Claude Code's approach):

### 1. `execSync` → `execFileSync` with argument arrays (root fix)

`execFileSync('git', ['-C', path, 'rev-parse', 'HEAD'])` passes arguments directly to the process, completely bypassing the shell. No string interpolation, no escape character issues.

- `worktreeUtils.ts`: 12 calls converted
- `worktree.ts` (code package): 9 calls converted  
- `gitUtils.ts`: 5 calls converted

### 2. Centralized `toPosixPath()` utility (defense-in-depth)

For cases where shell string interpolation is unavoidable (e.g., `bashTool.ts` wraps user commands with `&& pwd -P >| tempfile`):

- Added `toPosixPath()` to `utils/path.ts` — converts backslashes to forward slashes on Windows, no-op elsewhere
- `bashTool.ts`: inline `replace(/\\/g, '/')` replaced with `toPosixPath()` call
- `bashTool.ts`: added `cleanupTempFile()` helper to ensure temp file cleanup on all exit paths (abort/error/exit)

### 3. Spec updated

`specs/002-bash-tools.md`: added FR-024 (backslash→forward-slash conversion for Git Bash) and FR-025 (temp file cleanup on all exit paths)

### 4. Tests updated

Mocks changed from `execSync` to `execFileSync`, assertions changed from string matching to argument array matching.

## Verification

- All 4395 tests pass (agent-sdk: 3151, code: 1052, vsce: 191)
- Type-check passes for all packages
- Lint passes for all packages