### PR TITLE
fix: resolve flaky MarketplaceAddForm tests via reducer-owns-data pattern

### DIFF
--- a/packages/code/src/components/MarketplaceAddForm.tsx
+++ b/packages/code/src/components/MarketplaceAddForm.tsx
@@ -1,61 +1,47 @@
-import React, { useReducer } from "react";
+import React, { useReducer, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import { usePluginManagerContext } from "../contexts/PluginManagerContext.js";
-import { marketplaceAddFormReducer } from "../reducers/marketplaceAddFormReducer.js";
-
-const SCOPES = [
-  { value: "user" as const, label: "user" },
-  { value: "project" as const, label: "project" },
-  { value: "local" as const, label: "local" },
-];
+import {
+  marketplaceAddFormReducer,
+  SCOPES,
+  type MarketplaceAddFormState,
+} from "../reducers/marketplaceAddFormReducer.js";
 
 export const MarketplaceAddForm: React.FC = () => {
-  const { state, actions } = usePluginManagerContext();
-  const [{ source, scopeIndex, step }, dispatch] = useReducer(
-    marketplaceAddFormReducer,
-    { source: "", scopeIndex: 0, step: "source" },
-  );
+  const { state: ctxState, actions } = usePluginManagerContext();
+  const [state, dispatch] = useReducer(marketplaceAddFormReducer, {
+    source: "",
+    scopeIndex: 0,
+    step: "source",
+    pendingAction: null,
+  } as MarketplaceAddFormState);
+
+  // Handle side effects from reducer decisions
+  useEffect(() => {
+    if (!state.pendingAction) return;
+
+    if (state.pendingAction.type === "submit") {
+      actions.addMarketplace(
+        state.pendingAction.source,
+        state.pendingAction.scope,
+      );
+    } else if (state.pendingAction.type === "cancel") {
+      actions.setView("MARKETPLACES");
+    }
+
+    dispatch({ type: "CLEAR_PENDING_ACTION" });
+  }, [state.pendingAction, actions]);
 
   useInput((input, key) => {
-    if (key.escape) {
-      if (step === "scope") {
-        dispatch({ type: "BACK_TO_SOURCE" });
-      } else {
-        actions.setView("MARKETPLACES");
-      }
-    } else if (state.isLoading) {
-      return;
-    } else if (step === "source" && key.return) {
-      if (source.trim()) {
-        dispatch({ type: "SET_STEP", step: "scope" });
-      }
-    } else if (step === "source" && (key.backspace || key.delete)) {
-      dispatch({ type: "DELETE_CHAR" });
-    } else if (
-      step === "source" &&
-      input &&
-      !key.ctrl &&
-      !key.meta &&
-      !("alt" in key && key.alt)
-    ) {
-      dispatch({ type: "INSERT_CHAR", text: input });
-    } else if (step === "scope") {
-      if (key.upArrow) {
-        dispatch({
-          type: "SET_SCOPE_INDEX",
-          index: Math.max(0, scopeIndex - 1),
-        });
-      } else if (key.downArrow) {
-        dispatch({
-          type: "SET_SCOPE_INDEX",
-          index: Math.min(SCOPES.length - 1, scopeIndex + 1),
-        });
-      } else if (key.return) {
-        const scope = SCOPES[scopeIndex].value;
-        actions.addMarketplace(source.trim(), scope);
-      }
-    }
+    dispatch({
+      type: "HANDLE_KEY",
+      key,
+      input,
+      isLoading: ctxState.isLoading,
+    });
   });
+
+  const { source, scopeIndex, step } = state;
 
   if (step === "source") {
     return (
@@ -66,7 +52,7 @@ export const MarketplaceAddForm: React.FC = () => {
         <Box marginTop={1}>
           <Text>Source: </Text>
           <Text color="yellow">{source}</Text>
-          {!state.isLoading && <Text color="yellow">_</Text>}
+          {!ctxState.isLoading && <Text color="yellow">_</Text>}
         </Box>
         <Box marginTop={1}>
           <Text dimColor>Enter to continue, Esc to cancel</Text>
@@ -86,20 +72,20 @@ export const MarketplaceAddForm: React.FC = () => {
       </Box>
       <Box marginTop={1} flexDirection="column">
         {SCOPES.map((s, i) => (
-          <Text key={s.value} color={i === scopeIndex ? "yellow" : "dim"}>
+          <Text key={s} color={i === scopeIndex ? "yellow" : "dim"}>
             {i === scopeIndex ? "> " : "  "}
-            {s.label}
+            {s}
           </Text>
         ))}
       </Box>
-      {state.isLoading && (
+      {ctxState.isLoading && (
         <Box marginTop={1}>
           <Text color="yellow">Adding marketplace...</Text>
         </Box>
       )}
       <Box marginTop={1}>
         <Text dimColor>
-          {state.isLoading
+          {ctxState.isLoading
             ? "Please wait..."
             : "Enter to confirm, \u2191/\u2193 to navigate, Esc to go back"}
         </Text>

--- a/packages/code/src/reducers/marketplaceAddFormReducer.ts
+++ b/packages/code/src/reducers/marketplaceAddFormReducer.ts
@@ -1,34 +1,81 @@
+import { Key } from "ink";
+
+export const SCOPES = ["user", "project", "local"] as const;
+export type Scope = (typeof SCOPES)[number];
+
 export interface MarketplaceAddFormState {
   source: string;
   scopeIndex: number;
   step: "source" | "scope";
+  pendingAction:
+    | { type: "submit"; source: string; scope: Scope }
+    | { type: "cancel" }
+    | null;
 }
 
 export type MarketplaceAddFormAction =
-  | { type: "SET_SOURCE"; source: string }
-  | { type: "SET_SCOPE_INDEX"; index: number }
-  | { type: "SET_STEP"; step: "source" | "scope" }
-  | { type: "INSERT_CHAR"; text: string }
-  | { type: "DELETE_CHAR" }
-  | { type: "BACK_TO_SOURCE" };
+  | { type: "HANDLE_KEY"; key: Key; input: string; isLoading: boolean }
+  | { type: "CLEAR_PENDING_ACTION" };
 
 export function marketplaceAddFormReducer(
   state: MarketplaceAddFormState,
   action: MarketplaceAddFormAction,
 ): MarketplaceAddFormState {
   switch (action.type) {
-    case "SET_SOURCE":
-      return { ...state, source: action.source };
-    case "SET_SCOPE_INDEX":
-      return { ...state, scopeIndex: action.index };
-    case "SET_STEP":
-      return { ...state, step: action.step };
-    case "INSERT_CHAR":
-      return { ...state, source: state.source + action.text };
-    case "DELETE_CHAR":
-      return { ...state, source: state.source.slice(0, -1) };
-    case "BACK_TO_SOURCE":
-      return { ...state, step: "source" };
+    case "HANDLE_KEY": {
+      const { key, input, isLoading } = action;
+
+      // Escape always works, even during loading
+      if (key.escape) {
+        if (state.step === "scope") {
+          return { ...state, step: "source" };
+        }
+        return { ...state, pendingAction: { type: "cancel" } };
+      }
+
+      // Ignore all other input during loading
+      if (isLoading) return state;
+
+      if (state.step === "source") {
+        if (key.return) {
+          if (state.source.trim()) {
+            return { ...state, step: "scope" };
+          }
+          return state;
+        }
+        if (key.backspace || key.delete) {
+          return { ...state, source: state.source.slice(0, -1) };
+        }
+        if (input && !key.ctrl && !key.meta && !("alt" in key && key.alt)) {
+          return { ...state, source: state.source + input };
+        }
+        return state;
+      }
+
+      // step === "scope"
+      if (key.upArrow) {
+        return { ...state, scopeIndex: Math.max(0, state.scopeIndex - 1) };
+      }
+      if (key.downArrow) {
+        return {
+          ...state,
+          scopeIndex: Math.min(SCOPES.length - 1, state.scopeIndex + 1),
+        };
+      }
+      if (key.return) {
+        return {
+          ...state,
+          pendingAction: {
+            type: "submit",
+            source: state.source.trim(),
+            scope: SCOPES[state.scopeIndex],
+          },
+        };
+      }
+      return state;
+    }
+    case "CLEAR_PENDING_ACTION":
+      return { ...state, pendingAction: null };
     default:
       return state;
   }


### PR DESCRIPTION
## Problem

Two tests in `MarketplaceAddForm.test.tsx` were flaky under `--coverage`:
- `should call addMarketplace after confirming scope selection`
- `should go back to source step when Escape is pressed on step 2`

## Root Cause

`useInput` stale-closure race condition (same pattern documented in prior fixes for `HistorySearch`, `CommandSelector`, etc.).

`useInput` registers its handler via an internal `useEffect`. When `step` changes from `"source"` to `"scope"`, the render output updates immediately (`lastFrame()` shows "Step 2/2") but the effect hasn't re-registered the handler yet. `vi.waitFor` passes early, and the subsequent keypress hits the **stale handler** where `step` is still `"source"`:

| Test | Key | Stale handler action | Expected action |
|------|-----|---------------------|-----------------|
| submit | 2nd `\r` | `step==="source" && key.return` → dispatch `SET_STEP` (no-op) | `step==="scope" && key.return` → `addMarketplace` |
| Esc back | `\u001B` | `step==="source"` → `setView("MARKETPLACES")` | `step==="scope"` → `BACK_TO_SOURCE` |

Coverage mode amplifies the timing window via v8 instrumentation overhead.

## Fix

Apply the **reducer-owns-data** pattern (matching `selectorReducer` + `CommandSelector`):

- All keyboard logic moved into the reducer's `HANDLE_KEY` action — the reducer always reads its own latest state, so no stale closure is possible
- Side effects (`addMarketplace`, `setView`) flow through a `pendingAction` field, handled in `useEffect`
- Component's `useInput` becomes a single-line `dispatch` call
- `SCOPES` constant moved to the reducer for consistent index calculation

## Verification

- `pnpm test tests/components/MarketplaceAddForm.test.tsx` — 7/7 pass
- `pnpm run test:coverage` (full suite) — 83 files, 1052 tests all pass
- `pnpm -F wave-code run type-check` — clean