### PR TITLE
fix: add model name to OpenAI API retry warning logs

### DIFF
--- a/packages/agent-sdk/src/utils/openaiClient.ts
+++ b/packages/agent-sdk/src/utils/openaiClient.ts
@@ -133,6 +133,7 @@ export class OpenAIClient {
         }
         if (attempt < MAX_RETRIES) {
           logger.warn("OpenAI API network error, retrying...", {
+            model: params.model,
             attempt: attempt + 1,
             error: e,
           });
@@ -185,6 +186,7 @@ export class OpenAIClient {
       if (retryableStatus && attempt < MAX_RETRIES) {
         lastRetryAfter = response.headers.get("retry-after");
         logger.warn("OpenAI API error, retrying...", {
+          model: params.model,
           attempt: attempt + 1,
           status: response.status,
           retryAfter: lastRetryAfter,


### PR DESCRIPTION
Include `params.model` in both the HTTP error retry and network error retry warning logs so it's easier to identify which model hit rate limiting or network issues.