### PR TITLE
fix(ci): download all ripgrep platforms for vsce release packaging

### DIFF
--- a/.github/workflows/vsce-release.yml
+++ b/.github/workflows/vsce-release.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Build SDK
         run: pnpm -F wave-agent-sdk build
 
+      - name: Download all ripgrep platforms for packaging
+        run: CI=false node packages/agent-sdk/scripts/install_ripgrep.js
+
       - name: Package .vsix
         run: pnpm -F wave-vsce run package
 


### PR DESCRIPTION
## Problem

The v0.18.5 release VSIX was only 4.21 MB instead of the usual ~15 MB. macOS/Windows users would have a broken Grep tool.

## Root Cause

Commit `3ae94b86` optimized `install_ripgrep.js` to only download the current platform's ripgrep binary when `CI=true`. This is fine for regular CI tests, but `vsce-release.yml` also runs in CI, so the VSIX was packaged with only `linux-x86_64` ripgrep (~6 MB) instead of all 6 platforms (~30 MB).

The old standalone `wave-vsce` repo didn't have this issue because it installed `wave-agent-sdk` from npm, which shipped with all platforms pre-packaged.

## Fix

Add a step before packaging to force-download all ripgrep platforms:

```yaml
- name: Download all ripgrep platforms for packaging
  run: CI=false node packages/agent-sdk/scripts/install_ripgrep.js
```

This runs the installer with `CI=false` so it downloads all 6 platforms, while preserving the single-platform optimization for other CI workflows.