### PR TITLE
fix(ci): download all ripgrep platforms in install_ripgrep, revert CI single-platform optimization

### DIFF
--- a/.github/workflows/vsce-release.yml
+++ b/.github/workflows/vsce-release.yml
@@ -40,9 +40,6 @@ jobs:
       - name: Build SDK
         run: pnpm -F wave-agent-sdk build
 
-      - name: Download all ripgrep platforms for packaging
-        run: CI=false node packages/agent-sdk/scripts/install_ripgrep.js
-
       - name: Package .vsix
         run: pnpm -F wave-vsce run package
 

--- a/packages/agent-sdk/scripts/install_ripgrep.js
+++ b/packages/agent-sdk/scripts/install_ripgrep.js
@@ -9,18 +9,6 @@ const __dirname = path.dirname(__filename);
 const MANIFEST_PATH = path.resolve(__dirname, "../bin/rg");
 const VENDOR_DIR = path.resolve(__dirname, "../vendor/ripgrep");
 
-function getCurrentPlatform() {
-  const platform = process.platform;
-  const arch = process.arch;
-  if (platform === "darwin")
-    return `macos-${arch === "arm64" ? "aarch64" : "x86_64"}`;
-  if (platform === "linux")
-    return `linux-${arch === "arm64" ? "aarch64" : "x86_64"}`;
-  if (platform === "win32")
-    return `windows-${arch === "arm64" ? "aarch64" : "x86_64"}`;
-  return null;
-}
-
 async function main() {
   if (!fs.existsSync(MANIFEST_PATH)) {
     console.error(`Manifest not found: ${MANIFEST_PATH}`);
@@ -30,15 +18,7 @@ async function main() {
   const manifestContent = fs.readFileSync(MANIFEST_PATH, "utf-8");
   const jsonContent = manifestContent.replace(/^#!.*\n/, "");
   const manifest = JSON.parse(jsonContent);
-  const allPlatforms = manifest.platforms;
-
-  // In CI, only download for the current platform
-  const isCI = process.env.CI === "true";
-  const currentPlatform = isCI ? getCurrentPlatform() : null;
-  const platforms =
-    currentPlatform && currentPlatform in allPlatforms
-      ? { [currentPlatform]: allPlatforms[currentPlatform] }
-      : allPlatforms;
+  const platforms = manifest.platforms;
 
   if (!fs.existsSync(VENDOR_DIR)) {
     fs.mkdirSync(VENDOR_DIR, { recursive: true });


### PR DESCRIPTION
## Problem

The v0.18.5 release VSIX was only 4.21 MB instead of the usual ~15 MB. macOS/Windows users would have a broken Grep tool because only the linux-x86_64 ripgrep binary was packaged.

## Root Cause

Commit `3ae94b86` added a CI optimization to `install_ripgrep.js` that only downloads the current platform's ripgrep binary when `CI=true`. This is fine for regular CI tests, but `vsce-release.yml` also runs in CI, so the VSIX was packaged with only 1 platform instead of all 6.

The old standalone `wave-vsce` repo didn't have this issue because it installed `wave-agent-sdk` from npm, which shipped with all platforms pre-packaged.

## Fix

Remove the CI single-platform optimization from `install_ripgrep.js` entirely — always download all 6 platforms. The `actions/cache` step in CI workflows already handles performance for repeated runs, so the optimization provided negligible benefit while creating a footgun for release packaging.

Also removes the `CI=false` workaround that was added to `vsce-release.yml` in the previous commit (2bf6161e), as it is no longer needed.

### Commits

- 2bf6161e fix(ci): download all ripgrep platforms for vsce release packaging (workaround, now reverted)
- b2adf439 fix(ci): remove CI single-platform optimization from install_ripgrep (root-cause fix)