### PR TITLE
feat(vsce): upgrade demo mock data to professional enterprise-grade content

### DIFF
--- a/packages/vsce/e2e/demo/askUserQuestionLayout.demo.ts
+++ b/packages/vsce/e2e/demo/askUserQuestionLayout.demo.ts
@@ -9,7 +9,7 @@ test.describe('AskUserQuestion Layout Demo', () => {
     const mockMessage: Message = {
       id: 'msg_ask_demo',
       role: 'assistant' as const,
-      timestamp: '2024-01-01T00:00:00.000Z',
+      timestamp: '2025-07-09T10:30:00.000Z',
       blocks: [
         {
           type: 'tool' as const,
@@ -17,8 +17,8 @@ test.describe('AskUserQuestion Layout Demo', () => {
           stage: 'end' as const,
           result: JSON.stringify({
             answers: {
-              "Which library should we use for date formatting?": "date-fns",
-              "Which features do you want to enable?": "Authentication, Database, Logging"
+              "支付服务应该采用哪种缓存策略？": "Redis Cluster",
+              "哪些模块需要优先重构？": "PaymentService, TransactionLogger, RefundHandler"
             }
           })
         }

--- a/packages/vsce/e2e/demo/bang-command.demo.ts
+++ b/packages/vsce/e2e/demo/bang-command.demo.ts
@@ -8,32 +8,32 @@ test.describe('Bang Command Demo', () => {
 
         // 1. Show a running command
         await injector.updateMessages([
-            MockDataGenerator.createBangMessage('sleep 5', '', true, null)
+            MockDataGenerator.createBangMessage('docker build -t nebula-payment .', '', true, null)
         ]);
         await webviewPage.screenshot({ path: '../../docs/public/screenshots/bang-command-running.png' });
 
         // 2. Show a successful command with output
         await injector.updateMessages([
-            MockDataGenerator.createBangMessage('ls -la', 'total 8\ndrwxr-xr-x  10 user  group  320 Mar 30 10:00 .\ndrwxr-xr-x   4 user  group  128 Mar 30 09:00 ..\n-rw-r--r--   1 user  group  1024 Mar 30 10:00 package.json', false, 0)
+            MockDataGenerator.createBangMessage('kubectl get pods -n payment', 'NAME                            READY   STATUS    RESTARTS   AGE\npayment-service-7f4d           1/1     Running   0          2d\npayment-worker-9c2a            1/1     Running   0          2d\npayment-scheduler-5x8b         1/1     Running   0          5h', false, 0)
         ]);
         await webviewPage.screenshot({ path: '../../docs/public/screenshots/bang-command-success.png' });
 
         // 3. Show a long output
-        const longOutput = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join('\n');
+        const longOutput = Array.from({ length: 20 }, (_, i) => `Test suite ${i + 1} passed`).join('\n');
         await injector.updateMessages([
-            MockDataGenerator.createBangMessage('seq 1 20', longOutput, false, 0)
+            MockDataGenerator.createBangMessage('pnpm test', longOutput, false, 0)
         ]);
         await webviewPage.screenshot({ path: '../../docs/public/screenshots/bang-command-long-output.png' });
 
         // 4. Show a successful command with no output
         await injector.updateMessages([
-            MockDataGenerator.createBangMessage('mkdir test-dir', '', false, 0)
+            MockDataGenerator.createBangMessage('git tag v1.2.0', '', false, 0)
         ]);
         await webviewPage.screenshot({ path: '../../docs/public/screenshots/bang-command-no-output.png' });
 
         // 5. Show a failed command
         await injector.updateMessages([
-            MockDataGenerator.createBangMessage('nonexistent', 'sh: nonexistent: command not found', false, 127)
+            MockDataGenerator.createBangMessage('docker push registry.nebula-tech.com/payment', 'denied: access forbidden to repository payment', false, 1)
         ]);
         await webviewPage.screenshot({ path: '../../docs/public/screenshots/bang-command-failure.png' });
     });

--- a/packages/vsce/e2e/demo/config-popup.demo.ts
+++ b/packages/vsce/e2e/demo/config-popup.demo.ts
@@ -9,8 +9,8 @@ test.describe('Configuration Popup Demo', () => {
                 configurationData: {
                     apiKey: '',
                     baseURL: '',
-                    model: 'gemini-3-flash',
-                    fastModel: 'gemini-2.5-flash'
+                    model: 'claude-sonnet-4-20250514',
+                    fastModel: 'claude-haiku-4-20250514'
                 },
                 error: '请先在设置中配置鉴权信息 (API Key 或 Headers) 和 Base URL。也可以通过环境变量 WAVE_API_KEY/WAVE_CUSTOM_HEADERS 和 WAVE_BASE_URL 进行配置。'
             });

--- a/packages/vsce/e2e/demo/language-config.demo.ts
+++ b/packages/vsce/e2e/demo/language-config.demo.ts
@@ -7,13 +7,13 @@ test.describe('Language Configuration Demo', () => {
             window.simulateExtensionMessage({
                 command: 'showConfiguration',
                 configurationData: {
-                    apiKey: 'test-key',
+                    apiKey: 'sk-ant-api03-CXB9pH2k...mH8wQz',
                     headers: '',
-                    baseURL: 'https://api.example.com',
-                    model: 'gemini-3-flash',
-                    fastModel: 'gemini-2.5-flash',
-                    backendLink: 'https://backend.example.com',
-                    language: 'English'
+                    baseURL: 'https://api.nebula-tech.com/v1',
+                    model: 'claude-sonnet-4-20250514',
+                    fastModel: 'claude-haiku-4-20250514',
+                    backendLink: 'https://wave.nebula-tech.com',
+                    language: 'Chinese'
                 }
             });
         });
@@ -28,7 +28,7 @@ test.describe('Language Configuration Demo', () => {
 
         // Verify the language field is visible and has the correct value
         await expect(languageField).toBeVisible();
-        await expect(webviewPage.locator('#language')).toHaveValue('English');
+        await expect(webviewPage.locator('#language')).toHaveValue('Chinese');
 
         // Take screenshot of the dialog with language field in view
         const dialog = webviewPage.locator('.configuration-dialog');

--- a/packages/vsce/e2e/demo/login-dialog.demo.ts
+++ b/packages/vsce/e2e/demo/login-dialog.demo.ts
@@ -15,7 +15,7 @@ test.describe('Login Dialog Demo', () => {
             window.simulateExtensionMessage({
                 command: 'configurationResponse',
                 configurationData: {
-                    serverUrl: 'https://wave-ai.example.com'
+                    serverUrl: 'https://wave.nebula-tech.com'
                 }
             });
         });
@@ -34,7 +34,7 @@ test.describe('Login Dialog Demo', () => {
 
         // Verify server URL input is pre-filled
         const serverUrlInput = webviewPage.locator('#login-serverUrl');
-        await expect(serverUrlInput).toHaveValue('https://wave-ai.example.com');
+        await expect(serverUrlInput).toHaveValue('https://wave.nebula-tech.com');
 
         // Verify login button is visible
         await expect(webviewPage.getByText('SSO 登录', { exact: true })).toBeVisible();
@@ -56,7 +56,7 @@ test.describe('Login Dialog Demo', () => {
             window.simulateExtensionMessage({
                 command: 'configurationResponse',
                 configurationData: {
-                    serverUrl: 'https://wave-ai.example.com'
+                    serverUrl: 'https://wave.nebula-tech.com'
                 }
             });
         });
@@ -66,12 +66,12 @@ test.describe('Login Dialog Demo', () => {
             window.simulateExtensionMessage({
                 command: 'authStatusResponse',
                 isAuthenticated: true,
-                user: { id: 'user-xyz789', email: 'alice@example.com' }
+                user: { id: 'usr_7f3k2d8x', email: 'sarah.chen@nebula-tech.com' }
             });
         });
 
         await expect(webviewPage.getByText('SSO 认证', { exact: true })).toBeVisible();
-        await expect(webviewPage.getByText('alice@example.com')).toBeVisible();
+        await expect(webviewPage.getByText('sarah.chen@nebula-tech.com')).toBeVisible();
         await expect(webviewPage.getByText('登出', { exact: true })).toBeVisible();
 
         const dialog = webviewPage.locator('.configuration-dialog');

--- a/packages/vsce/e2e/demo/mcp-server-tab.demo.ts
+++ b/packages/vsce/e2e/demo/mcp-server-tab.demo.ts
@@ -19,70 +19,70 @@ test.describe('MCP Server Dialog Demo', () => {
                 command: 'mcpServersResponse',
                 servers: [
                     {
-                        name: 'sqlite',
+                        name: 'jira',
+                        config: {
+                            command: 'npx',
+                            args: ['-y', '@mcp/server-jira'],
+                            env: { JIRA_API_TOKEN: 'your-token-here', JIRA_BASE_URL: 'https://nebula-tech.atlassian.net' }
+                        },
+                        status: 'connected',
+                        toolCount: 8,
+                        capabilities: ['tools'],
+                        lastConnected: Date.now() - 60000
+                    },
+                    {
+                        name: 'postgres',
                         config: {
                             command: 'uvx',
-                            args: ['mcp-server-sqlite', '--db-path', '/path/to/db.db']
+                            args: ['mcp-server-postgres', '--connection-string', 'postgresql://localhost:5432/nebula']
                         },
                         status: 'connected',
                         toolCount: 5,
                         capabilities: ['tools'],
-                        lastConnected: Date.now() - 60000
+                        lastConnected: Date.now() - 120000
                     },
                     {
                         name: 'github',
                         config: {
                             command: 'npx',
                             args: ['-y', '@modelcontextprotocol/server-github'],
-                            env: {
-                                GITHUB_PERSONAL_ACCESS_TOKEN: 'your-token-here'
-                            }
+                            env: { GITHUB_PERSONAL_ACCESS_TOKEN: 'ghp_xxxxxxxxxxxx' }
                         },
                         status: 'disconnected',
                         toolCount: 0,
                         capabilities: []
                     },
                     {
-                        name: 'remote-server',
+                        name: 'sentry',
                         config: {
-                            url: 'https://mcp-server.example.com/sse'
+                            url: 'https://mcp.sentry.io/sse'
                         },
                         status: 'error',
                         toolCount: 0,
-                        error: 'Connection refused',
+                        error: 'Authentication failed: invalid token',
                         capabilities: []
-                    },
-                    {
-                        name: 'fetch',
-                        config: {
-                            command: 'npx',
-                            args: ['-y', '@mcp/server-fetch']
-                        },
-                        status: 'connecting',
-                        toolCount: 0,
-                        capabilities: ['tools']
                     }
                 ]
             }, '*');
         });
 
         // Verify all four servers are visible
-        await expect(webviewPage.getByText('sqlite', { exact: true })).toBeVisible();
+        await expect(webviewPage.getByText('jira', { exact: true })).toBeVisible();
         await expect(webviewPage.getByText('github', { exact: true })).toBeVisible();
-        await expect(webviewPage.getByText('remote-server', { exact: true })).toBeVisible();
-        await expect(webviewPage.getByText('fetch', { exact: true })).toBeVisible();
+        await expect(webviewPage.getByText('sentry', { exact: true })).toBeVisible();
+        await expect(webviewPage.getByText('postgres', { exact: true })).toBeVisible();
 
         // Verify connected server shows tool count
         await expect(webviewPage.getByText('5 tools')).toBeVisible();
 
         // Verify error server shows error message
-        await expect(webviewPage.getByText('Connection refused')).toBeVisible();
+        await expect(webviewPage.getByText('Authentication failed: invalid token')).toBeVisible();
 
         // Verify connect button for disconnected server (two servers are not connected)
         await expect(webviewPage.getByRole('button', { name: '连接' }).first()).toBeVisible();
 
         // Verify disconnect button for connected server
-        await expect(webviewPage.getByRole('button', { name: '断开' })).toBeVisible();
+        await expect(webviewPage.getByRole('button', { name: '断开' }).first()).toBeVisible();
 
         await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-mcp-server-tab.png' });
     });
@@ -126,8 +126,8 @@ test.describe('MCP Server Dialog Demo', () => {
                 command: 'mcpServersResponse',
                 servers: [
                     {
-                        name: 'sqlite',
-                        config: { command: 'uvx', args: ['mcp-server-sqlite'] },
+                        name: 'jira',
+                        config: { command: 'npx', args: ['-y', '@mcp/server-jira'] },
                         status: 'disconnected',
                         toolCount: 0,
                         capabilities: []
@@ -145,8 +145,8 @@ test.describe('MCP Server Dialog Demo', () => {
                 command: 'mcpServersResponse',
                 servers: [
                     {
-                        name: 'sqlite',
-                        config: { command: 'uvx', args: ['mcp-server-sqlite'] },
+                        name: 'jira',
+                        config: { command: 'npx', args: ['-y', '@mcp/server-jira'] },
                         status: 'connected',
                         toolCount: 5,
                         capabilities: ['tools'],

--- a/packages/vsce/e2e/demo/model-dialog.demo.ts
+++ b/packages/vsce/e2e/demo/model-dialog.demo.ts
@@ -25,7 +25,7 @@ test.describe('Model Dialog Demo', () => {
         await webviewPage.evaluate(() => {
             window.simulateExtensionMessage({
                 command: 'configuredModelsResponse',
-                models: ['claude-sonnet-4-20250514', 'claude-haiku-4-20250514', 'gpt-4', 'gpt-4-mini']
+                models: ['claude-sonnet-4-20250514', 'claude-haiku-4-20250514', 'claude-opus-4-20250514', 'gpt-4o', 'gpt-4o-mini']
             });
         });
 
@@ -62,7 +62,7 @@ test.describe('Model Dialog Demo', () => {
         await webviewPage.evaluate(() => {
             window.simulateExtensionMessage({
                 command: 'configuredModelsResponse',
-                models: ['gpt-4', 'gpt-4-mini']
+                models: ['claude-sonnet-4-20250514', 'claude-haiku-4-20250514']
             });
         });
 

--- a/packages/vsce/e2e/demo/plugin-management.demo.ts
+++ b/packages/vsce/e2e/demo/plugin-management.demo.ts
@@ -22,47 +22,47 @@ test.describe('Plugin Management Screenshots', () => {
                 command: 'listPluginsResponse',
                 plugins: [
                     {
-                        id: 'github-plugin@official',
-                        name: 'GitHub Integration',
-                        description: '集成 GitHub API，支持仓库管理、Issue 追踪和 PR 审查',
-                        marketplace: 'official',
+                        id: 'git-workflow@wave-plugins-official',
+                        name: 'Git Workflow',
+                        description: '集成 Git 工作流，支持智能提交信息生成、PR 审查和冲突解决',
+                        marketplace: 'wave-plugins-official',
                         installed: false,
-                        version: '1.2.3'
+                        version: '2.3.1'
                     },
                     {
-                        id: 'docker-helper@official',
-                        name: 'Docker Helper',
-                        description: '简化 Docker 容器和镜像的管理，提供常用命令快捷方式',
-                        marketplace: 'official',
+                        id: 'kubernetes-helper@wave-plugins-official',
+                        name: 'Kubernetes Helper',
+                        description: '简化 K8s 集群管理，提供 Pod 诊断、日志查询和资源监控',
+                        marketplace: 'wave-plugins-official',
                         installed: false,
-                        version: '2.0.1'
+                        version: '1.8.0'
                     },
                     {
-                        id: 'database-tools@community',
-                        name: 'Database Tools',
-                        description: '连接和查询多种数据库（MySQL、PostgreSQL、MongoDB 等）',
-                        marketplace: 'community',
+                        id: 'database-explorer@wave-community',
+                        name: 'Database Explorer',
+                        description: '连接多种数据库（PostgreSQL、MySQL、MongoDB），支持智能查询和 schema 可视化',
+                        marketplace: 'wave-community',
                         installed: false,
                         version: '0.9.5'
                     },
                     {
-                        id: 'code-reviewer@official',
+                        id: 'code-reviewer@wave-plugins-official',
                         name: 'Code Reviewer',
-                        description: '智能代码审查工具，提供最佳实践建议和代码质量分析',
-                        marketplace: 'official',
+                        description: 'AI 驱动的代码审查工具，自动检测安全漏洞、性能问题和最佳实践违规',
+                        marketplace: 'wave-plugins-official',
                         installed: true,
                         enabled: true,
-                        version: '1.5.0',
+                        version: '3.1.2',
                         scope: 'user'
                     },
                     {
-                        id: 'markdown-enhancer@community',
-                        name: 'Markdown Enhancer',
-                        description: '增强 Markdown 处理能力，支持高级格式化和预览',
-                        marketplace: 'community',
+                        id: 'api-docs-generator@wave-community',
+                        name: 'API Docs Generator',
+                        description: '从代码自动生成 OpenAPI 文档，支持实时预览和交互式测试',
+                        marketplace: 'wave-community',
                         installed: true,
                         enabled: false,
-                        version: '1.1.2',
+                        version: '1.4.0',
                         scope: 'project'
                     }
                 ]
@@ -72,14 +72,14 @@ test.describe('Plugin Management Screenshots', () => {
         await webviewPage.waitForSelector('.plugin-item');
 
         // 确保可以看到可安装的插件列表
-        await expect(webviewPage.getByText('GitHub Integration')).toBeVisible();
-        await expect(webviewPage.getByText('Docker Helper')).toBeVisible();
+        await expect(webviewPage.getByText('Git Workflow')).toBeVisible();
+        await expect(webviewPage.getByText('Kubernetes Helper')).toBeVisible();
 
         // 截图：探索新插件列表页
         await webviewPage.screenshot({ path: '../../docs/public/screenshots/spec-plugin-explore-list.png' });
 
         // 点击一个插件查看详情
-        await webviewPage.getByText('GitHub Integration').click();
+        await webviewPage.getByText('Git Workflow').click();
 
         // 等待详情页显示
         await expect(webviewPage.getByText('返回列表')).toBeVisible();
@@ -93,7 +93,7 @@ test.describe('Plugin Management Screenshots', () => {
 
         // 返回列表
         await webviewPage.getByText('返回列表').click();
-        await expect(webviewPage.getByText('GitHub Integration')).toBeVisible();
+        await expect(webviewPage.getByText('Git Workflow')).toBeVisible();
 
         // 3. Installed plugins tab - 展示已激活插件及更新和卸载按钮
         await webviewPage.getByText('已安装插件', { exact: true }).click();
@@ -116,18 +116,9 @@ test.describe('Plugin Management Screenshots', () => {
             window.postMessage({
                 command: 'listMarketplacesResponse',
                 marketplaces: [
-                    {
-                        name: 'official',
-                        url: 'https://github.com/wave-ai/official-plugins'
-                    },
-                    {
-                        name: 'community',
-                        url: 'https://github.com/wave-community/plugins'
-                    },
-                    {
-                        name: 'my-custom',
-                        url: '/home/user/my-local-plugins'
-                    }
+                    { name: 'wave-plugins-official', url: 'https://github.com/wave-ai/wave-plugins-official' },
+                    { name: 'wave-community', url: 'https://github.com/wave-community/plugins' },
+                    { name: 'nebula-internal', url: 'https://git.nebula-tech.com/plugins' }
                 ]
             }, '*');
         });

--- a/packages/vsce/e2e/demo/plugin-search.demo.ts
+++ b/packages/vsce/e2e/demo/plugin-search.demo.ts
@@ -18,36 +18,36 @@ test.describe('Plugin Search UI Demo', () => {
                 command: 'listPluginsResponse',
                 plugins: [
                     {
-                        id: 'commit-commands@wave-plugins-official',
-                        name: 'commit-commands',
-                        description: 'Commands for git commit workflows',
+                        id: 'git-workflow@wave-plugins-official',
+                        name: 'git-workflow',
+                        description: '集成 Git 工作流，支持智能提交信息和 PR 审查',
                         marketplace: 'wave-plugins-official',
                         installed: false,
-                        version: '1.0.0'
+                        version: '2.3.1'
                     },
                     {
-                        id: 'document-skills@wave-plugins-official',
-                        name: 'document-skills',
-                        description: 'Document processing suite including Excel and Word',
+                        id: 'kubernetes-helper@wave-plugins-official',
+                        name: 'kubernetes-helper',
+                        description: 'K8s 集群管理和 Pod 诊断工具',
                         marketplace: 'wave-plugins-official',
                         installed: false,
-                        version: '1.0.0'
+                        version: '1.8.0'
                     },
                     {
-                        id: 'typescript-lsp@wave-plugins-official',
-                        name: 'typescript-lsp',
-                        description: 'TypeScript language server for code intelligence',
-                        marketplace: 'wave-plugins-official',
+                        id: 'database-explorer@wave-community',
+                        name: 'database-explorer',
+                        description: '多数据库连接和智能查询工具',
+                        marketplace: 'wave-community',
                         installed: false,
-                        version: '1.0.0'
+                        version: '0.9.5'
                     },
                     {
-                        id: 'chrome-headless@wave-plugins-official',
-                        name: 'chrome-headless',
-                        description: 'Chrome DevTools Protocol for browser automation',
-                        marketplace: 'wave-plugins-official',
+                        id: 'api-docs-generator@wave-community',
+                        name: 'api-docs-generator',
+                        description: '自动生成 OpenAPI 文档',
+                        marketplace: 'wave-community',
                         installed: false,
-                        version: '1.0.0'
+                        version: '1.4.0'
                     }
                 ]
             }, '*');
@@ -61,14 +61,14 @@ test.describe('Plugin Search UI Demo', () => {
         // Screenshot of search input with all plugins
         await webviewPage.screenshot({ path: '../../docs/public/screenshots/plugin-search-input.png' });
 
-        // 4. Type "commit" to filter
-        await searchInput.fill('commit');
+        // 4. Type "git" to filter
+        await searchInput.fill('git');
 
-        // Verify only commit-commands is shown
-        await expect(webviewPage.locator('.plugin-name', { hasText: 'commit-commands' })).toBeVisible();
-        await expect(webviewPage.locator('.plugin-name', { hasText: 'document-skills' })).not.toBeVisible();
-        await expect(webviewPage.locator('.plugin-name', { hasText: 'typescript-lsp' })).not.toBeVisible();
-        await expect(webviewPage.locator('.plugin-name', { hasText: 'chrome-headless' })).not.toBeVisible();
+        // Verify only git-workflow is shown
+        await expect(webviewPage.locator('.plugin-name', { hasText: 'git-workflow' })).toBeVisible();
+        await expect(webviewPage.locator('.plugin-name', { hasText: 'kubernetes-helper' })).not.toBeVisible();
+        await expect(webviewPage.locator('.plugin-name', { hasText: 'database-explorer' })).not.toBeVisible();
+        await expect(webviewPage.locator('.plugin-name', { hasText: 'api-docs-generator' })).not.toBeVisible();
 
         await webviewPage.screenshot({ path: '../../docs/public/screenshots/plugin-search-filtered.png' });
 
@@ -80,7 +80,7 @@ test.describe('Plugin Search UI Demo', () => {
 
         // 6. Clear the search
         await searchInput.fill('');
-        await expect(webviewPage.locator('.plugin-name', { hasText: 'commit-commands' })).toBeVisible();
-        await expect(webviewPage.locator('.plugin-name', { hasText: 'document-skills' })).toBeVisible();
+        await expect(webviewPage.locator('.plugin-name', { hasText: 'git-workflow' })).toBeVisible();
+        await expect(webviewPage.locator('.plugin-name', { hasText: 'kubernetes-helper' })).toBeVisible();
     });
 });

--- a/packages/vsce/e2e/demo/plugin-status-badge.demo.ts
+++ b/packages/vsce/e2e/demo/plugin-status-badge.demo.ts
@@ -16,58 +16,58 @@ test.describe('Plugin Status Badge Logic', () => {
                 command: 'listPluginsResponse',
                 plugins: [
                     {
-                        id: 'installed-user@wave-plugins-official',
-                        name: 'Installed User Scope',
-                        description: 'This plugin should show [user] badge',
+                        id: 'git-workflow@wave-plugins-official',
+                        name: 'Git Workflow',
+                        description: '已安装到用户作用域，显示 [user] 标签',
                         marketplace: 'wave-plugins-official',
                         installed: true,
                         scope: 'user',
-                        version: '1.0.0'
+                        version: '2.3.1'
                     },
                     {
-                        id: 'installed-project@wave-plugins-official',
-                        name: 'Installed Project Scope',
-                        description: 'This plugin should show [project] badge',
+                        id: 'code-reviewer@wave-plugins-official',
+                        name: 'Code Reviewer',
+                        description: '已安装到项目作用域，显示 [project] 标签',
                         marketplace: 'wave-plugins-official',
                         installed: true,
                         scope: 'project',
-                        version: '1.0.0'
+                        version: '3.1.2'
                     },
                     {
-                        id: 'installed-no-scope@wave-plugins-official',
-                        name: 'Installed No Scope',
-                        description: 'This plugin should NOT show any badge',
-                        marketplace: 'wave-plugins-official',
+                        id: 'database-explorer@wave-community',
+                        name: 'Database Explorer',
+                        description: '已安装但无作用域信息，不显示标签',
+                        marketplace: 'wave-community',
                         installed: true,
                         scope: null,
-                        version: '1.0.0'
+                        version: '0.9.5'
                     },
                     {
-                        id: 'not-installed@wave-plugins-official',
-                        name: 'Not Installed',
-                        description: 'This plugin should NOT show any badge',
+                        id: 'kubernetes-helper@wave-plugins-official',
+                        name: 'Kubernetes Helper',
+                        description: '未安装的插件，不显示标签',
                         marketplace: 'wave-plugins-official',
                         installed: false,
-                        version: '1.0.0'
+                        version: '1.8.0'
                     }
                 ]
             }, '*');
         });
 
-        // 3. Verify "Installed User Scope" plugin has the [user] badge
-        const userItem = webviewPage.locator('.plugin-item').filter({ hasText: 'Installed User Scope' });
+        // 3. Verify "Git Workflow" plugin has the [user] badge
+        const userItem = webviewPage.locator('.plugin-item').filter({ hasText: 'Git Workflow' });
         await expect(userItem.locator('.plugin-scope')).toHaveText('[user]');
 
-        // 4. Verify "Installed Project Scope" plugin has the [project] badge
-        const projectItem = webviewPage.locator('.plugin-item').filter({ hasText: 'Installed Project Scope' });
+        // 4. Verify "Code Reviewer" plugin has the [project] badge
+        const projectItem = webviewPage.locator('.plugin-item').filter({ hasText: 'Code Reviewer' });
         await expect(projectItem.locator('.plugin-scope')).toHaveText('[project]');
 
-        // 5. Verify "Installed No Scope" plugin does NOT have the badge
-        const noScopeItem = webviewPage.locator('.plugin-item').filter({ hasText: 'Installed No Scope' });
+        // 5. Verify "Database Explorer" plugin does NOT have the badge
+        const noScopeItem = webviewPage.locator('.plugin-item').filter({ hasText: 'Database Explorer' });
         await expect(noScopeItem.locator('.plugin-scope')).not.toBeVisible();
 
-        // 6. Verify "Not Installed" plugin does NOT have the badge
-        const notInstalledItem = webviewPage.locator('.plugin-item').filter({ hasText: 'Not Installed' });
+        // 6. Verify "Kubernetes Helper" plugin does NOT have the badge
+        const notInstalledItem = webviewPage.locator('.plugin-item').filter({ hasText: 'Kubernetes Helper' });
         await expect(notInstalledItem.locator('.plugin-scope')).not.toBeVisible();
 
         // Take screenshot for verification

--- a/packages/vsce/e2e/demo/plugins-ui.demo.ts
+++ b/packages/vsce/e2e/demo/plugins-ui.demo.ts
@@ -24,44 +24,44 @@ test.describe('Plugin Management Dialog Demo', () => {
                 command: 'listPluginsResponse',
                 plugins: [
                     {
-                        id: 'commit-commands@wave-plugins-official',
-                        name: 'commit-commands',
-                        description: 'Commands for git commit workflows including commit, push, and PR creation',
+                        id: 'git-workflow@wave-plugins-official',
+                        name: 'git-workflow',
+                        description: '集成 Git 工作流，支持智能提交信息生成、PR 审查和冲突解决',
                         marketplace: 'wave-plugins-official',
                         installed: false,
-                        version: '1.0.0'
+                        version: '2.3.1'
                     },
                     {
-                        id: 'document-skills@wave-plugins-official',
-                        name: 'document-skills',
-                        description: 'Collection of document processing suite including Excel, Word, PowerPoint, and PDF capabilities',
+                        id: 'kubernetes-helper@wave-plugins-official',
+                        name: 'kubernetes-helper',
+                        description: '简化 K8s 集群管理，提供 Pod 诊断、日志查询和资源监控',
                         marketplace: 'wave-plugins-official',
                         installed: false,
-                        version: '1.0.0'
+                        version: '1.8.0'
                     },
                     {
-                        id: 'typescript-lsp@wave-plugins-official',
-                        name: 'typescript-lsp',
-                        description: 'TypeScript/JavaScript language server for enhanced code intelligence',
-                        marketplace: 'wave-plugins-official',
+                        id: 'database-explorer@wave-community',
+                        name: 'database-explorer',
+                        description: '连接多种数据库（PostgreSQL、MySQL、MongoDB），支持智能查询和 schema 可视化',
+                        marketplace: 'wave-community',
                         installed: false,
-                        version: '1.0.0'
+                        version: '0.9.5'
                     },
                     {
-                        id: 'chrome-headless@wave-plugins-official',
-                        name: 'chrome-headless',
-                        description: 'Chrome DevTools Protocol MCP server for headless browser automation',
+                        id: 'code-reviewer@wave-plugins-official',
+                        name: 'code-reviewer',
+                        description: 'AI 驱动的代码审查工具，自动检测安全漏洞、性能问题和最佳实践违规',
                         marketplace: 'wave-plugins-official',
                         installed: false,
-                        version: '1.0.0'
+                        version: '3.1.2'
                     },
                     {
-                        id: 'sdd@wave-plugins-official',
-                        name: 'sdd',
-                        description: '规格驱动开发工作流，用于创建和管理技术规格文档',
-                        marketplace: 'wave-plugins-official',
+                        id: 'api-docs-generator@wave-community',
+                        name: 'api-docs-generator',
+                        description: '从代码自动生成 OpenAPI 文档，支持实时预览和交互式测试',
+                        marketplace: 'wave-community',
                         installed: false,
-                        version: '1.0.0'
+                        version: '1.4.0'
                     }
                 ]
             }, '*');
@@ -79,19 +79,19 @@ test.describe('Plugin Management Dialog Demo', () => {
                 command: 'listPluginsResponse',
                 plugins: [
                     {
-                        id: 'installed-plugin@wave-plugins-official',
-                        name: 'Installed Plugin',
-                        description: 'An already installed plugin',
+                        id: 'code-reviewer@wave-plugins-official',
+                        name: 'code-reviewer',
+                        description: 'AI 驱动的代码审查工具，自动检测安全漏洞、性能问题和最佳实践违规',
                         marketplace: 'wave-plugins-official',
                         installed: true,
                         scope: 'user',
-                        version: '1.0.0'
+                        version: '3.1.2'
                     }
                 ]
             }, '*');
         });
 
-        await expect(webviewPage.locator('.plugin-name').filter({ hasText: 'Installed Plugin' })).toBeVisible();
+        await expect(webviewPage.locator('.plugin-name').filter({ hasText: 'code-reviewer' })).toBeVisible();
         await webviewPage.screenshot({ path: '../../docs/public/screenshots/plugins-installed-tab.png' });
 
         // 4. Switch to "插件市场" tab
@@ -102,7 +102,9 @@ test.describe('Plugin Management Dialog Demo', () => {
             window.postMessage({
                 command: 'listMarketplacesResponse',
                 marketplaces: [
-                    { name: 'wave-plugins-official', url: 'https://github.com/wave-team/wave-plugins-official' }
+                    { name: 'wave-plugins-official', url: 'https://github.com/wave-ai/wave-plugins-official' },
+                    { name: 'wave-community', url: 'https://github.com/wave-community/plugins' },
+                    { name: 'nebula-internal', url: 'https://git.nebula-tech.com/plugins' }
                 ]
             }, '*');
         });

--- a/packages/vsce/e2e/demo/product-spec-confirmations.demo.ts
+++ b/packages/vsce/e2e/demo/product-spec-confirmations.demo.ts
@@ -22,10 +22,10 @@ test.describe('Product Specification Screenshots - Confirmations', () => {
             isStreaming: false,
             sessions: [],
             configurationData: {
-                apiKey: 'sk-xxxxxxxxxxxxxxxx',
-                baseURL: 'https://api.openai.com/v1',
-                model: 'gpt-4',
-                fastModel: 'gpt-3.5-turbo'
+                apiKey: 'sk-ant-api03-CXB9pH2k...mH8wQz',
+                baseURL: 'https://api.anthropic.com/v1',
+                model: 'claude-sonnet-4-20250514',
+                fastModel: 'claude-haiku-4-20250514'
             },
             permissionMode: 'default'
         });
@@ -34,7 +34,7 @@ test.describe('Product Specification Screenshots - Confirmations', () => {
         const askUserMessage: Message = {
             id: 'msg_demo_ask',
             role: 'assistant',
-            timestamp: '2024-01-01T00:00:00.000Z',
+            timestamp: '2025-07-09T10:30:00.000Z',
             blocks: [
                 {
                     type: 'tool',
@@ -43,11 +43,11 @@ test.describe('Product Specification Screenshots - Confirmations', () => {
                     parameters: JSON.stringify({
                         questions: [
                             {
-                                header: '选择框架',
-                                question: '你想使用哪个前端框架？',
+                                header: '缓存方案',
+                                question: '支付服务应该采用哪种缓存策略？',
                                 options: [
-                                    { label: 'React', description: '流行的 UI 库' },
-                                    { label: 'Vue', description: '渐进式框架' }
+                                    { label: 'Redis Cluster', description: '分布式缓存，高可用，支持自动故障转移' },
+                                    { label: 'Redis Sentinel', description: '主从架构，自动故障转移，适合中等规模' }
                                 ]
                             }
                         ]
@@ -65,11 +65,11 @@ test.describe('Product Specification Screenshots - Confirmations', () => {
             toolInput: {
                 questions: [
                     {
-                        header: '选择框架',
-                        question: '你想使用哪个前端框架？',
+                        header: '缓存方案',
+                        question: '支付服务应该采用哪种缓存策略？',
                         options: [
-                            { label: 'React', description: '流行的 UI 库' },
-                            { label: 'Vue', description: '渐进式框架' }
+                            { label: 'Redis Cluster', description: '分布式缓存，高可用，支持自动故障转移' },
+                            { label: 'Redis Sentinel', description: '主从架构，自动故障转移，适合中等规模' }
                         ]
                     }
                 ]
@@ -86,10 +86,10 @@ test.describe('Product Specification Screenshots - Confirmations', () => {
         // 11. Configuration Dialog (opened via /config or showConfiguration message)
         await injector.simulateExtensionMessage('showConfiguration', {
             configurationData: {
-                apiKey: 'sk-xxxxxxxxxxxxxxxx',
-                baseURL: 'https://api.openai.com/v1',
-                model: 'gpt-4',
-                fastModel: 'gpt-3.5-turbo'
+                apiKey: 'sk-ant-api03-CXB9pH2k...mH8wQz',
+                baseURL: 'https://api.anthropic.com/v1',
+                model: 'claude-sonnet-4-20250514',
+                fastModel: 'claude-haiku-4-20250514'
             }
         });
         await webviewPage.waitForSelector('.configuration-dialog');
@@ -137,22 +137,22 @@ test.describe('Product Specification Screenshots - Confirmations', () => {
             confirmationId: 'plan-confirm-001',
             confirmationType: '计划执行确认',
             toolName: EXIT_PLAN_MODE_TOOL_NAME, // "ExitPlanMode"
-            planContent: `## 项目重构计划
+            planContent: `## PaymentService 高并发重构计划
 
-### 第一步：代码分析
-- 分析现有代码结构
-- 识别重构重点模块
-- 评估依赖关系
+### 第一阶段：乐观锁引入
+- 在 PaymentRepository 中添加 version 字段
+- 实现 withOptimisticLock 中间件
+- 处理乐观锁冲突重试逻辑
 
-### 第二步：重构实施
-- 重构核心组件
-- 优化数据流
-- 更新测试用例
+### 第二阶段：缓存层接入
+- 引入 Redis 作为热数据缓存
+- 实现缓存失效策略（TTL + 主动失效）
+- 添加缓存命中率监控
 
-### 第三步：验证测试
-- 运行完整测试套件
-- 性能基准测试
-- 用户验收测试`
+### 第三阶段：异步化改造
+- 将审计日志改为异步写入
+- 接入消息队列处理非核心流程
+- 性能基准测试与对比`
         });
         const planConfirmDialog = webviewPage.locator('.confirmation-dialog');
         await planConfirmDialog.waitFor({ state: 'visible' });
@@ -184,9 +184,9 @@ test.describe('Product Specification Screenshots - Confirmations', () => {
             confirmationType: '代码修改确认',
             toolName: EDIT_TOOL_NAME, // "Edit"
             toolInput: {
-                file_path: '/src/components/ChatInterface.tsx',
-                old_string: 'const [messages, setMessages] = useState([]);',
-                new_string: 'const [messages, setMessages] = useState<Message[]>([]);'
+                file_path: '/src/services/payment/PaymentService.ts',
+                old_string: 'const result = await this.db.query("SELECT * FROM payments WHERE id = ?", tx.id);',
+                new_string: 'const result = await this.db.query("SELECT * FROM payments WHERE id = $1", [tx.id]);'
             }
         });
         const editConfirmDialog = webviewPage.locator('.confirmation-dialog');
@@ -201,12 +201,12 @@ test.describe('Product Specification Screenshots - Confirmations', () => {
         await injector.simulateExtensionMessage('showConfirmation', {
             confirmationId: 'mcp-confirm-001',
             confirmationType: 'MCP 工具确认',
-            toolName: 'mcp__wave_requirements__create_requirement',
+            toolName: 'mcp__jira__create_issue',
             toolInput: {
-                title: '前端改动',
-                description: '在需求管理界面添加列表页',
+                title: 'PaymentService 乐观锁支持',
+                description: '为支付服务引入乐观锁机制，处理并发更新冲突',
                 priority: 'high',
-                tags: ['frontend', 'ui']
+                tags: ['payment', 'concurrency', 'refactor']
             }
         });
         const mcpConfirmDialog = webviewPage.locator('.confirmation-dialog');
@@ -223,8 +223,8 @@ test.describe('Product Specification Screenshots - Confirmations', () => {
             confirmationType: 'Bash 命令执行确认', 
             toolName: BASH_TOOL_NAME, // "Bash"
             toolInput: {
-                command: 'npm install --save-dev @types/react',
-                description: '安装 React TypeScript 类型定义'
+                command: 'pnpm -F @nebula/payment-service test -- --coverage',
+                description: '运行支付服务测试套件并生成覆盖率报告'
             }
         });
         const bashConfirmDialog = webviewPage.locator('.confirmation-dialog');

--- a/packages/vsce/e2e/demo/product-spec-history-search.demo.ts
+++ b/packages/vsce/e2e/demo/product-spec-history-search.demo.ts
@@ -14,9 +14,9 @@ test.describe('Product Spec: History Search', () => {
 
         // 3. Simulate history response from extension
         const mockHistory = [
-            { prompt: '帮我重构一下这个组件，用函数式写法', timestamp: 1774325357000 },
-            { prompt: '创建一个新文件 src/utils/format.ts，导出时间格式化函数', timestamp: 1774325174000 },
-            { prompt: '/speckit:constitution 所有模板必须用中文编写', timestamp: 1774851151833 }
+            { prompt: '为 PaymentService 添加分布式事务支持，使用 Saga 模式', timestamp: 1752052800000 },
+            { prompt: '分析 src/services/payment 目录下的竞态条件，生成修复方案', timestamp: 1752051000000 },
+            { prompt: '/review 审查 PaymentController.ts 中的安全性问题', timestamp: 1751966400000 }
         ];
 
         await injector.simulateExtensionMessage('historyResponse', {

--- a/packages/vsce/e2e/demo/product-spec-message-queuing.demo.ts
+++ b/packages/vsce/e2e/demo/product-spec-message-queuing.demo.ts
@@ -12,23 +12,23 @@ test.describe('Product Specification Screenshots - Message Queuing', () => {
         // Provide initial state
         await injector.simulateExtensionMessage('setInitialState', {
             messages: [
-                MockDataGenerator.createUserMessage('请帮我重构这个函数'),
-                MockDataGenerator.createAssistantMessage('好的，我正在分析代码并准备重构建议...')
+                MockDataGenerator.createUserMessage('帮我分析 PaymentService 的分布式事务实现，看看有没有竞态条件'),
+                MockDataGenerator.createAssistantMessage('好的，我正在扫描支付服务代码，分析事务边界和并发控制机制...')
             ],
             isStreaming: true,
             sessions: [],
             configurationData: {
-                apiKey: 'sk-xxxxxxxxxxxxxxxx',
-                baseURL: 'https://api.openai.com/v1',
-                model: 'gpt-4',
-                fastModel: 'gpt-3.5-turbo'
+                apiKey: 'sk-ant-api03-CXB9pH2k...mH8wQz',
+                baseURL: 'https://api.anthropic.com/v1',
+                model: 'claude-sonnet-4-20250514',
+                fastModel: 'claude-haiku-4-20250514'
             },
             permissionMode: 'default'
         });
 
         // 1. Show "Add to Queue" button in input
         await webviewPage.focus('[data-testid="message-input"]');
-        await webviewPage.keyboard.type('顺便帮我写个测试用例');
+        await webviewPage.keyboard.type('顺便帮我写一个乐观锁中间件的单元测试，参考 [file:src/services/payment/PaymentService.ts] 和 [image1]');
         
         // Wait for the button to update and focus it for screenshot
         const sendBtn = webviewPage.getByTestId('send-btn');
@@ -42,7 +42,7 @@ test.describe('Product Specification Screenshots - Message Queuing', () => {
         await injector.simulateExtensionMessage('updateQueue', {
             queue: [
                 { 
-                    content: '顺便帮我写个测试用例，参考 [@file:src/utils.ts] 和 [image1]',
+                    content: '顺便帮我写一个乐观锁中间件的单元测试，参考 [file:src/services/payment/PaymentService.ts] 和 [image1]',
                     images: [{ path: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==', mimeType: 'image/png' }]
                 }
             ]
@@ -54,7 +54,7 @@ test.describe('Product Specification Screenshots - Message Queuing', () => {
         // Wait for the queued message to appear in the queue panel
         const queuePanel = webviewPage.getByTestId('queued-message-list');
         await expect(queuePanel).toBeVisible();
-        await expect(queuePanel).toContainText('utils.ts');
+        await expect(queuePanel).toContainText('PaymentService.ts');
         await expect(queuePanel).toContainText('图片 1');
         
         // Take screenshot of the message list showing the queued message with tags

--- a/packages/vsce/e2e/demo/product-spec-rewind.demo.ts
+++ b/packages/vsce/e2e/demo/product-spec-rewind.demo.ts
@@ -10,9 +10,9 @@ test.describe('Product Spec: Rewind', () => {
 
         // Setup a conversation
         const messages = [
-            MockDataGenerator.createUserMessage('帮我重构一下这个函数'),
-            MockDataGenerator.createAssistantMessage('好的，我来看看这个函数...'),
-            MockDataGenerator.createUserMessage('再帮我写个测试用例')
+            MockDataGenerator.createUserMessage('帮我分析 PaymentService 的并发问题，看看有没有竞态条件'),
+            MockDataGenerator.createAssistantMessage('我已经分析了 PaymentService 的代码，发现 `processPayment` 方法中存在竞态条件。当前的悲观锁实现会导致高并发下性能下降，建议改用乐观锁...'),
+            MockDataGenerator.createUserMessage('好的，请为乐观锁实现编写单元测试，覆盖并发冲突场景')
         ];
         await injector.updateMessages(messages);
         await injector.endStreaming();

--- a/packages/vsce/e2e/demo/product-spec-rich-content.demo.ts
+++ b/packages/vsce/e2e/demo/product-spec-rich-content.demo.ts
@@ -21,10 +21,10 @@ test.describe('Product Specification Screenshots - Rich Content', () => {
             isStreaming: false,
             sessions: [],
             configurationData: {
-                apiKey: 'sk-xxxxxxxxxxxxxxxx',
-                baseURL: 'https://api.openai.com/v1',
-                model: 'gpt-4',
-                fastModel: 'gpt-3.5-turbo'
+                apiKey: 'sk-ant-api03-CXB9pH2k...mH8wQz',
+                baseURL: 'https://api.anthropic.com/v1',
+                model: 'claude-sonnet-4-20250514',
+                fastModel: 'claude-haiku-4-20250514'
             },
             permissionMode: 'default'
         });
@@ -123,11 +123,11 @@ test.describe('Product Specification Screenshots - Rich Content', () => {
             {
                 id: 'msg_demo_inline_tags',
                 role: 'user',
-                timestamp: '2024-01-01T00:00:00.000Z',
+                timestamp: '2025-07-09T10:30:00.000Z',
                 blocks: [
                     {
                         type: 'text',
-                        content: '这是一个文件夹 [@file:src] 这是文本 [@file:src/main.ts] 这是图片 [@file:pasted-image.png]'
+                        content: '[@file:src/services] 分析这个服务目录 [@file:src/services/payment/PaymentService.ts] 这是相关截图 [image1]'
                     }
                 ]
             }
@@ -140,26 +140,26 @@ test.describe('Product Specification Screenshots - Rich Content', () => {
             {
                 id: 'session-1',
                 sessionType: 'main',
-                workdir: '/project',
+                workdir: '/home/dev/projects/nebula-platform',
                 createdAt: new Date(now - 1000 * 60 * 60), // 1小时前创建
                 lastActiveAt: new Date(now - 1000 * 60 * 30), // 30分钟前
-                latestTotalTokens: 1500
+                latestTotalTokens: 15420
             },
             {
                 id: 'session-2',
                 sessionType: 'main',
-                workdir: '/project',
+                workdir: '/home/dev/projects/nebula-platform',
                 createdAt: new Date(now - 1000 * 60 * 60 * 3), // 3小时前创建
                 lastActiveAt: new Date(now - 1000 * 60 * 60 * 2), // 2小时前
-                latestTotalTokens: 2200
+                latestTotalTokens: 32800
             },
             {
                 id: 'session-3',
                 sessionType: 'main',
-                workdir: '/project',
+                workdir: '/home/dev/projects/nebula-platform',
                 createdAt: new Date(now - 1000 * 60 * 60 * 48), // 2天前创建
                 lastActiveAt: new Date(now - 1000 * 60 * 60 * 24), // 1天前
-                latestTotalTokens: 800
+                latestTotalTokens: 8600
             }
         ];
         
@@ -196,11 +196,11 @@ test.describe('Product Specification Screenshots - Rich Content', () => {
                 id: 'msg_demo_vision_user',
                 role: 'user',
                 blocks: [
-                    { type: 'text', content: '这张图片里有什么？ [image1]' },
+                    { type: 'text', content: '请分析这个 UI 设计稿，帮我生成对应的 React 组件 [image1]' },
                     { type: 'image', imageUrls: ['data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='] }
                 ]
             },
-            MockDataGenerator.createAssistantMessage('这张图片显示了一个简单的 UI 布局，包含一个侧边栏和一个主内容区域。侧边栏使用了深色主题...')
+            MockDataGenerator.createAssistantMessage('这是一个支付确认页面的设计稿。我可以识别出以下元素：\n\n1. **顶部导航栏** - 包含返回按钮和标题\n2. **金额展示区** - 大号字体显示支付金额\n3. **支付方式选择** - 支持银行卡和电子钱包\n4. **底部确认按钮** - 固定在底部\n\n我将基于这些元素生成对应的 React 组件...')
         ];
         await injector.updateMessages(visionMessages as unknown as Message[]);
         await webviewPage.locator('.messages-container').screenshot({ path: '../../docs/public/screenshots/spec-vision.png' });
@@ -214,11 +214,11 @@ test.describe('Product Specification Screenshots - Rich Content', () => {
                     blocks: [
                         {
                             type: 'reasoning',
-                            content: '我将按照以下步骤进行：\n\n1. **分析需求**：用户需要一个 React 教程\n2. **搜索资源**：查找相关文档和示例\n3. **生成内容**：整理并输出教程\n\n```typescript\n// 示例代码\nconst App = () => <div>Hello Wave</div>;\n```'
+                            content: '用户需要对 PaymentService 进行重构以提高并发性能。我的分析步骤：\n\n1. **代码审查**：当前实现使用悲观锁，在高并发场景下会导致大量线程阻塞\n2. **性能分析**：数据库连接池在峰值时耗尽，平均响应时间 2.3s\n3. **重构方案**：\n   - 引入乐观锁替代悲观锁\n   - 添加 Redis 缓存层减少数据库访问\n   - 实现异步日志写入\n\n```typescript\n// 乐观锁实现示例\nconst withOptimisticLock = async <T>(\n  fn: (version: number) => Promise<T>\n): Promise<T> => {\n  const version = await getCurrentVersion();\n  return fn(version);\n};\n```'
                         },
                         {
                             type: 'text',
-                            content: '好的，这是一个关于 React 的基础教程...'
+                            content: '基于以上分析，我建议分三个阶段进行重构。首先从乐观锁机制开始...'
                         }
                     ]
                 }

--- a/packages/vsce/e2e/demo/product-spec-tools.demo.ts
+++ b/packages/vsce/e2e/demo/product-spec-tools.demo.ts
@@ -25,10 +25,10 @@ test.describe('Product Specification Screenshots - Tools', () => {
             isStreaming: false,
             sessions: [],
             configurationData: {
-                apiKey: 'sk-xxxxxxxxxxxxxxxx',
-                baseURL: 'https://api.openai.com/v1',
-                model: 'gpt-4',
-                fastModel: 'gpt-3.5-turbo'
+                apiKey: 'sk-ant-api03-CXB9pH2k...mH8wQz',
+                baseURL: 'https://api.anthropic.com/v1',
+                model: 'claude-sonnet-4-20250514',
+                fastModel: 'claude-haiku-4-20250514'
             },
             permissionMode: 'default'
         });
@@ -37,17 +37,17 @@ test.describe('Product Specification Screenshots - Tools', () => {
         const diffMessage: Message = {
             id: 'msg_demo_diff',
             role: 'assistant',
-            timestamp: '2024-01-01T00:00:00.000Z',
+            timestamp: '2025-07-09T10:30:00.000Z',
             blocks: [
                 {
                     type: 'tool',
                     name: EDIT_TOOL_NAME,
                     stage: 'end',
-                    compactParams: 'src/main.ts',
+                    compactParams: 'src/services/payment/PaymentService.ts',
                     parameters: JSON.stringify({
-                        file_path: 'src/main.ts',
-                        old_string: 'console.log("Hello, World!");',
-                        new_string: 'console.log("Hello, Wave!");'
+                        file_path: 'src/services/payment/PaymentService.ts',
+                        old_string: 'const result = await this.db.query("SELECT * FROM payments WHERE id = ?", tx.id);',
+                        new_string: 'const result = await this.db.query("SELECT * FROM payments WHERE id = $1", [tx.id]);'
                     }),
                     result: 'Text replaced successfully'
                 }
@@ -60,9 +60,9 @@ test.describe('Product Specification Screenshots - Tools', () => {
         // 7. Task List
         await injector.simulateExtensionMessage('updateTasks', {
             tasks: [
-                { id: '1', subject: '搜索相关文件', description: '查找项目中与任务列表相关的组件和样式文件', status: 'completed', blocks: [], blockedBy: [], metadata: {} },
-                { id: '2', subject: '实现任务列表组件', description: '编写 React 组件和 CSS 样式', status: 'in_progress', activeForm: '编写 CSS', blocks: ['3'], blockedBy: [], metadata: {} },
-                { id: '3', subject: '运行测试', description: '确保新功能正常工作且不影响现有功能', status: 'pending', blocks: [], blockedBy: ['2'], metadata: {} }
+                { id: '1', subject: '分析现有支付服务架构', description: '审查 PaymentService 的分布式事务实现，识别竞态条件和性能瓶颈', status: 'completed', blocks: [], blockedBy: [], metadata: {} },
+                { id: '2', subject: '实现乐观锁机制', description: '为支付服务引入版本号控制，防止并发更新冲突', status: 'in_progress', activeForm: '编写乐观锁中间件', blocks: ['3'], blockedBy: [], metadata: {} },
+                { id: '3', subject: '编写集成测试', description: '覆盖并发支付场景，验证乐观锁和事务回滚的正确性', status: 'pending', blocks: [], blockedBy: ['2'], metadata: {} }
             ],
             isTaskListCollapsed: false
         });
@@ -72,9 +72,9 @@ test.describe('Product Specification Screenshots - Tools', () => {
         // 7.1 Task List Collapsed
         await injector.simulateExtensionMessage('updateTasks', {
             tasks: [
-                { id: '1', subject: '搜索相关文件', status: 'completed', blocks: [], blockedBy: [], metadata: {} },
-                { id: '2', subject: '实现任务列表组件', status: 'in_progress', blocks: ['3'], blockedBy: [], metadata: {} },
-                { id: '3', subject: '运行测试', status: 'pending', blocks: [], blockedBy: ['2'], metadata: {} }
+                { id: '1', subject: '分析现有支付服务架构', status: 'completed', blocks: [], blockedBy: [], metadata: {} },
+                { id: '2', subject: '实现乐观锁机制', status: 'in_progress', blocks: ['3'], blockedBy: [], metadata: {} },
+                { id: '3', subject: '编写集成测试', status: 'pending', blocks: [], blockedBy: ['2'], metadata: {} }
             ],
             isTaskListCollapsed: true
         });
@@ -95,15 +95,15 @@ test.describe('Product Specification Screenshots - Tools', () => {
         const subagentMessage: Message = {
             id: 'msg_demo_subagent',
             role: 'assistant',
-            timestamp: '2024-01-01T00:00:00.000Z',
+            timestamp: '2025-07-09T10:30:00.000Z',
             blocks: [
                 {
                     type: 'tool',
                     name: AGENT_TOOL_NAME,
                     stage: 'running',
-                    compactParams: 'Explore: 查找所有 API 定义',
-                    parameters: JSON.stringify({ subagent_type: 'Explore', description: '查找所有 API 定义', prompt: '...' }),
-                    shortResult: '...Read, Write (2 tools | 1,234 tokens)'
+                    compactParams: 'Explore: 查找所有支付相关 API 定义',
+                    parameters: JSON.stringify({ subagent_type: 'Explore', description: '查找所有支付相关 API 定义', prompt: '...' }),
+                    shortResult: '...Read, Grep (2 tools | 3,421 tokens)'
                 }
             ]
         };
@@ -116,15 +116,15 @@ test.describe('Product Specification Screenshots - Tools', () => {
         const bashMessage: Message = {
             id: 'msg_demo_bash',
             role: 'assistant',
-            timestamp: '2024-01-01T00:00:00.000Z',
+            timestamp: '2025-07-09T10:30:00.000Z',
             blocks: [
                 {
                     type: 'tool',
                     name: BASH_TOOL_NAME,
                     stage: 'end',
-                    compactParams: '运行测试',
-                    parameters: JSON.stringify({ command: 'npm test', description: '运行测试' }),
-                    result: 'PASS  tests/index.test.ts\n  ✓ should work (5ms)\n\nTest Suites: 1 passed, 1 total\nTests:       1 passed, 1 total\nSnapshots:   0 total\nTime:        1.2s'
+                    compactParams: 'pnpm test -- --coverage',
+                    parameters: JSON.stringify({ command: 'pnpm test -- --coverage', description: '运行测试套件并生成覆盖率报告' }),
+                    result: ' RUN  v3.1.0 /home/dev/projects/nebula-platform\n\n ✓ src/services/payment/PaymentService.test.ts (8 tests) 142ms\n ✓ src/utils/eventBus.test.ts (5 tests) 67ms\n ✓ src/middleware/optimisticLock.test.ts (3 tests) 89ms\n\n Test Files  3 passed (3)\n      Tests  16 passed (16)\n   Coverage  94.2% Statements\n              87.5% Branches\n              92.1% Functions\n Duration   2.4s'
                 }
             ]
         };
@@ -137,43 +137,43 @@ test.describe('Product Specification Screenshots - Tools', () => {
             {
                 id: 'msg_demo_exploration',
                 role: 'assistant',
-                timestamp: '2024-01-01T00:00:00.000Z',
+                timestamp: '2025-07-09T10:30:00.000Z',
                 blocks: [
                     {
                         type: 'tool',
                         name: AGENT_TOOL_NAME,
                         stage: 'end',
-                        compactParams: 'Explore: 查找所有 API 定义',
-                        parameters: JSON.stringify({ subagent_type: 'Explore', description: '查找所有 API 定义', prompt: '...' }),
-                        result: '子代理已完成探索',
-                        shortResult: '子代理已完成探索'
+                        compactParams: 'Explore: 查找所有支付相关 API 定义',
+                        parameters: JSON.stringify({ subagent_type: 'Explore', description: '查找所有支付相关 API 定义', prompt: '...' }),
+                        result: '子代理已扫描 42 个文件，识别出 12 个支付相关接口定义',
+                        shortResult: '子代理已扫描 42 个文件，识别出 12 个支付相关接口定义'
                     },
                     {
                         type: 'tool',
                         name: GLOB_TOOL_NAME,
                         stage: 'end',
-                        compactParams: 'src/**/*.ts in src',
-                        parameters: JSON.stringify({ pattern: 'src/**/*.ts', path: 'src' }),
-                        result: 'src/main.ts\nsrc/app.tsx\nsrc/utils.ts',
+                        compactParams: 'src/services/**/*.ts in src',
+                        parameters: JSON.stringify({ pattern: 'src/services/**/*.ts', path: 'src' }),
+                        result: 'src/services/payment/PaymentService.ts\nsrc/services/payment/TransactionLogger.ts\nsrc/services/payment/RefundHandler.ts',
                         shortResult: 'Found 3 files'
                     },
                     {
                         type: 'tool',
                         name: GREP_TOOL_NAME,
                         stage: 'end',
-                        compactParams: 'interface.*API ts in src',
-                        parameters: JSON.stringify({ pattern: 'interface.*API', type: 'ts', path: 'src' }),
-                        result: 'src/types.ts:10:export interface UserAPI {\nsrc/types.ts:20:export interface AuthAPI {',
-                        shortResult: 'Found 2 matching lines'
+                        compactParams: 'interface.*Payment ts in src',
+                        parameters: JSON.stringify({ pattern: 'interface.*Payment', type: 'ts', path: 'src' }),
+                        result: 'src/types/payment.ts:15:export interface PaymentRequest {\nsrc/types/payment.ts:32:export interface PaymentResult {\nsrc/services/payment/PaymentService.ts:28:export interface PaymentService {',
+                        shortResult: 'Found 3 matching lines'
                     },
                     {
                         type: 'tool',
                         name: READ_TOOL_NAME,
                         stage: 'end',
-                        compactParams: 'src/main.ts 1:2000',
-                        parameters: JSON.stringify({ file_path: 'src/main.ts' }),
-                        result: 'import express from "express";\n...',
-                        shortResult: 'Read 150 lines'
+                        compactParams: 'src/services/payment/PaymentService.ts 1:2000',
+                        parameters: JSON.stringify({ file_path: 'src/services/payment/PaymentService.ts' }),
+                        result: 'import { Injectable } from "@nestjs/common";\nimport { PaymentRepository } from "./PaymentRepository";\n\n@Injectable()\nexport class PaymentService {\n  constructor(private readonly repo: PaymentRepository) {}',
+                        shortResult: 'Read 156 lines'
                     }
                 ]
             }
@@ -187,23 +187,23 @@ test.describe('Product Specification Screenshots - Tools', () => {
             {
                 id: 'msg_demo_file_ops',
                 role: 'assistant',
-                timestamp: '2024-01-01T00:00:00.000Z',
+                timestamp: '2025-07-09T10:30:00.000Z',
                 blocks: [
                     {
                         type: 'tool',
                         name: WRITE_TOOL_NAME,
                         stage: 'end',
-                        compactParams: 'src/new-file.ts 1 lines, 29 chars',
-                        parameters: JSON.stringify({ file_path: 'src/new-file.ts', content: 'export const hello = "world";' }),
-                        result: 'File created (1 lines, 29 characters)',
+                        compactParams: 'src/middleware/optimisticLock.ts 1 lines, 89 chars',
+                        parameters: JSON.stringify({ file_path: 'src/middleware/optimisticLock.ts', content: 'export const withOptimisticLock = <T>(handler: (version: number) => Promise<T>) => { ... };' }),
+                        result: 'File created (1 lines, 89 characters)',
                         shortResult: 'File created'
                     },
                     {
                         type: 'tool',
                         name: EDIT_TOOL_NAME,
                         stage: 'end',
-                        compactParams: 'src/app.tsx',
-                        parameters: JSON.stringify({ file_path: 'src/app.tsx', old_string: 'A', new_string: 'B' }),
+                        compactParams: 'src/services/payment/PaymentService.ts',
+                        parameters: JSON.stringify({ file_path: 'src/services/payment/PaymentService.ts', old_string: 'async processPayment(tx) {', new_string: 'async processPayment(tx: PaymentTx): Promise<Result> {' }),
                         result: 'Text replaced successfully',
                         shortResult: 'Text replaced successfully'
                     }
@@ -225,33 +225,33 @@ test.describe('Product Specification Screenshots - Tools', () => {
                             type: 'tool',
                             name: 'LSP',
                             stage: 'end',
-                            compactParams: 'goToDefinition (src/main.ts:10:5)',
-                            parameters: JSON.stringify({ operation: 'goToDefinition', filePath: 'src/main.ts', line: 10, character: 5 }),
-                            result: 'Found definition at src/utils.ts:25:10'
+                            compactParams: 'goToDefinition (src/services/payment/PaymentService.ts:28:15)',
+                            parameters: JSON.stringify({ operation: 'goToDefinition', filePath: 'src/services/payment/PaymentService.ts', line: 28, character: 15 }),
+                            result: 'Found definition at src/repositories/PaymentRepository.ts:12:14'
                         },
                         {
                             type: 'tool',
                             name: 'LSP',
                             stage: 'end',
-                            compactParams: 'findReferences (src/utils.ts:25:10)',
-                            parameters: JSON.stringify({ operation: 'findReferences', filePath: 'src/utils.ts', line: 25, character: 10 }),
-                            result: 'Found 3 references:\n- src/main.ts:10:5\n- src/app.ts:42:12\n- tests/utils.test.ts:15:8'
+                            compactParams: 'findReferences (src/repositories/PaymentRepository.ts:12:14)',
+                            parameters: JSON.stringify({ operation: 'findReferences', filePath: 'src/repositories/PaymentRepository.ts', line: 12, character: 14 }),
+                            result: 'Found 8 references:\n- src/services/payment/PaymentService.ts:28:5\n- src/services/payment/RefundHandler.ts:45:12\n- src/services/payment/TransactionLogger.ts:67:8\n- src/controllers/PaymentController.ts:33:22\n- src/middleware/paymentGuard.ts:18:3\n- tests/payment/PaymentService.test.ts:92:14\n- tests/payment/integration.test.ts:28:9\n- e2e/payment.spec.ts:15:7'
                         },
                         {
                             type: 'tool',
                             name: 'LSP',
                             stage: 'end',
-                            compactParams: 'hover (src/main.ts:10:5)',
-                            parameters: JSON.stringify({ operation: 'hover', filePath: 'src/main.ts', line: 10, character: 5 }),
-                            result: 'interface User {\n  id: string;\n  name: string;\n}\n\nRepresents a user in the system.'
+                            compactParams: 'hover (src/services/payment/PaymentService.ts:28:15)',
+                            parameters: JSON.stringify({ operation: 'hover', filePath: 'src/services/payment/PaymentService.ts', line: 28, character: 15 }),
+                            result: 'class PaymentService\n\nHandles payment processing with distributed transaction support. Implements optimistic locking and automatic retry logic for concurrent operations.\n\n@Injectable()'
                         },
                         {
                             type: 'tool',
                             name: 'LSP',
                             stage: 'end',
-                            compactParams: 'incomingCalls (src/utils.ts:25:10)',
-                            parameters: JSON.stringify({ operation: 'incomingCalls', filePath: 'src/utils.ts', line: 25, character: 10 }),
-                            result: 'Callers of getUser:\n- AuthService.login (src/auth.ts:50)\n- AdminPanel.render (src/admin.tsx:120)'
+                            compactParams: 'incomingCalls (src/repositories/PaymentRepository.ts:12:14)',
+                            parameters: JSON.stringify({ operation: 'incomingCalls', filePath: 'src/repositories/PaymentRepository.ts', line: 12, character: 14 }),
+                            result: 'Callers of findById:\n- PaymentService.processPayment (src/services/payment/PaymentService.ts:45)\n- RefundHandler.processRefund (src/services/payment/RefundHandler.ts:78)\n- TransactionLogger.audit (src/services/payment/TransactionLogger.ts:112)\n- PaymentController.getStatus (src/controllers/PaymentController.ts:55)'
                         }
                     ]
                 }
@@ -270,10 +270,10 @@ test.describe('Product Specification Screenshots - Tools', () => {
                             type: 'tool',
                             name: 'Skill',
                             stage: 'end',
-                            compactParams: 'docx',
-                            parameters: JSON.stringify({ skill_name: 'docx' }),
-                            result: 'Document created successfully at ./report.docx',
-                            shortResult: 'Invoked skill: docx'
+                            compactParams: 'deep-research',
+                            parameters: JSON.stringify({ skill_name: 'deep-research' }),
+                            result: 'Research complete: analyzed 15 sources, generated comprehensive report at ./reports/payment-gateway-comparison.md',
+                            shortResult: 'Invoked skill: deep-research'
                         }
                     ]
                 }
@@ -285,10 +285,10 @@ test.describe('Product Specification Screenshots - Tools', () => {
         await injector.simulateExtensionMessage('setInitialState', {
             messages: [
                 MockDataGenerator.createAssistantMessageWithTool(
-                    '正在通过 MCP 查询外部数据...',
-                    'mcp_search_tool',
-                    JSON.stringify({ query: 'latest news' }),
-                    'Found 3 results from external source.'
+                    '正在通过 MCP 服务器查询 Jira 中的支付相关需求...',
+                    'mcp__jira__search_issues',
+                    JSON.stringify({ jql: 'project = PAY AND status = "In Progress"', maxResults: 5 }),
+                    'Found 5 issues: PAY-142 (Optimistic Lock), PAY-138 (Retry Logic), PAY-135 (Webhook), PAY-129 (Refund Flow), PAY-121 (Multi-currency)'
                 )
             ]
         });

--- a/packages/vsce/e2e/demo/product-spec-ui-basic.demo.ts
+++ b/packages/vsce/e2e/demo/product-spec-ui-basic.demo.ts
@@ -17,10 +17,10 @@ test.describe('Product Specification Screenshots - UI Basic', () => {
             isStreaming: false,
             sessions: [],
             configurationData: {
-                apiKey: 'sk-xxxxxxxxxxxxxxxx',
-                baseURL: 'https://api.openai.com/v1',
-                model: 'gpt-4',
-                fastModel: 'gpt-3.5-turbo'
+                apiKey: 'sk-ant-api03-CXB9pH2k...mH8wQz',
+                baseURL: 'https://api.anthropic.com/v1',
+                model: 'claude-sonnet-4-20250514',
+                fastModel: 'claude-haiku-4-20250514'
             },
             permissionMode: 'default'
         });
@@ -32,11 +32,11 @@ test.describe('Product Specification Screenshots - UI Basic', () => {
         // 1.3 Code Selection Tag
         await injector.simulateExtensionMessage('addSelectionToInput', {
             selection: {
-                filePath: '/src/main.ts',
-                fileName: 'main.ts',
-                startLine: 10,
-                endLine: 20,
-                selectedText: 'console.log("Hello");',
+                filePath: '/src/services/payment/PaymentService.ts',
+                fileName: 'PaymentService.ts',
+                startLine: 45,
+                endLine: 62,
+                selectedText: 'async processPayment(tx: PaymentTx): Promise<Result> {',
                 isEmpty: false
             }
         });
@@ -50,8 +50,8 @@ test.describe('Product Specification Screenshots - UI Basic', () => {
 
         // 2. Basic Chat (Markdown & Code)
         const basicChat = [
-            MockDataGenerator.createUserMessage('如何写一个 Hello World?'),
-            MockDataGenerator.createAssistantMessage('在 TypeScript 中，你可以这样写：\n\n```typescript\nconsole.log("Hello, World!");\n```\n\n你可以使用 `tsc` 编译它。')
+            MockDataGenerator.createUserMessage('如何在 TypeScript 中实现一个类型安全的 EventBus？'),
+            MockDataGenerator.createAssistantMessage('下面是一个类型安全的 EventBus 实现，利用泛型与类型映射来保证事件名与回调参数的对应关系：\n\n```typescript\ntype EventHandler<T = unknown> = (payload: T) => void;\n\nclass EventBus<EventMap extends Record<string, unknown>> {\n  private handlers: { [K in keyof EventMap]?: EventHandler<EventMap[K]>[] } = {};\n\n  on<K extends keyof EventMap>(event: K, handler: EventHandler<EventMap[K]>): void {\n    (this.handlers[event] ||= []).push(handler);\n  }\n\n  off<K extends keyof EventMap>(event: K, handler: EventHandler<EventMap[K]>): void {\n    this.handlers[event] = (this.handlers[event] || []).filter(h => h !== handler);\n  }\n\n  emit<K extends keyof EventMap>(event: K, payload: EventMap[K]): void {\n    (this.handlers[event] || []).forEach(h => h(payload));\n  }\n}\n```\n\n你可以通过 `EventBus.on(\'payment.completed\', handler)` 来订阅事件。')
         ];
         await injector.updateMessages(basicChat);
         await injector.endStreaming();
@@ -71,9 +71,21 @@ test.describe('Product Specification Screenshots - UI Basic', () => {
 
         await injector.simulateExtensionMessage('slashCommandsResponse', {
             commands: [
-                { id: 'explain', name: 'explain', description: '解释选中的代码' },
-                { id: 'fix', name: 'fix', description: '修复代码中的问题' },
-                { id: 'test', name: 'test', description: '为代码生成单元测试' }
+                // SDK 内置技能命令
+                { id: 'code-review', name: 'code-review', description: '审查当前代码变更，检测正确性缺陷并提供优化建议' },
+                { id: 'deep-research', name: 'deep-research', description: '深度研究：多源搜索、交叉验证、生成引用报告' },
+                { id: 'init', name: 'init', description: '分析代码库并生成 AGENTS.md 文件，指导后续 Agent 工作' },
+                { id: 'loop', name: 'loop', description: '按固定间隔循环执行指令（如 /loop 5m /code-review）' },
+                { id: 'settings', name: 'settings', description: '管理 Wave 设置：hooks、环境变量、权限、MCP、内存等' },
+                { id: 'simplify', name: 'simplify', description: '审查代码变更的复用性、简洁性和效率，并自动应用修复' },
+                // UI 内置指令
+                { id: 'config', name: 'config', description: '打开配置设置' },
+                { id: 'model', name: 'model', description: '切换 AI 模型' },
+                { id: 'plugin', name: 'plugin', description: '打开插件管理' },
+                { id: 'mcp', name: 'mcp', description: '打开 MCP 服务器管理' },
+                { id: 'status', name: 'status', description: '查看当前状态' },
+                { id: 'login', name: 'login', description: 'SSO 登录/登出' },
+                { id: 'clear', name: 'clear', description: '清除对话历史并重置会话' }
             ]
         });
 
@@ -106,9 +118,9 @@ test.describe('Product Specification Screenshots - UI Basic', () => {
             filterText: '',
             suggestions: [
                 { path: 'src', relativePath: 'src', name: 'src', icon: 'codicon-folder' },
-                { path: 'src/main.ts', relativePath: 'src/main.ts', name: 'main.ts', icon: 'codicon-file-code' },
-                { path: 'package.json', relativePath: 'package.json', name: 'package.json', icon: 'codicon-json' },
-                { path: 'tsconfig.json', relativePath: 'tsconfig.json', name: 'tsconfig.json', icon: 'codicon-json' }
+                { path: 'src/services/payment/PaymentService.ts', relativePath: 'src/services/payment/PaymentService.ts', name: 'PaymentService.ts', icon: 'codicon-file-code' },
+                { path: 'src/utils/eventBus.ts', relativePath: 'src/utils/eventBus.ts', name: 'eventBus.ts', icon: 'codicon-file-code' },
+                { path: 'package.json', relativePath: 'package.json', name: 'package.json', icon: 'codicon-json' }
             ]
         });
 
@@ -120,7 +132,7 @@ test.describe('Product Specification Screenshots - UI Basic', () => {
 
         // 5. Mermaid Diagrams
         const mermaidChat = [
-            MockDataGenerator.createAssistantMessage('这是一个系统架构图：\n\n```mermaid\ngraph TD\n    User --> WebApp\n    WebApp --> API\n    API --> DB[(Database)]\n```')
+            MockDataGenerator.createAssistantMessage('这是一个微服务架构图：\n\n```mermaid\ngraph TD\n    Client[Client App] --> Gateway[API Gateway]\n    Gateway --> AuthSvc[Auth Service]\n    Gateway --> PaySvc[Payment Service]\n    Gateway --> OrderSvc[Order Service]\n    PaySvc --> DB[(Payment DB)]\n    OrderSvc --> DB2[(Order DB)]\n    PaySvc --> MQ[[Message Queue]]\n    MQ --> NotifySvc[Notification Service]\n```')
         ];
         await injector.updateMessages(mermaidChat);
         await injector.endStreaming();

--- a/packages/vsce/e2e/demo/status-dialog.demo.ts
+++ b/packages/vsce/e2e/demo/status-dialog.demo.ts
@@ -17,8 +17,8 @@ test.describe('Status Dialog Demo', () => {
                 configurationData: {
                     model: 'claude-sonnet-4-20250514',
                     fastModel: 'claude-haiku-4-20250514',
-                    baseURL: 'https://api.example.com/v1',
-                    serverUrl: 'https://wave.example.com'
+                    baseURL: 'https://api.nebula-tech.com/v1',
+                    serverUrl: 'https://wave.nebula-tech.com'
                 }
             });
         });
@@ -27,14 +27,14 @@ test.describe('Status Dialog Demo', () => {
         await webviewPage.evaluate(() => {
             window.simulateExtensionMessage({
                 command: 'statusResponse',
-                version: '0.4.15',
-                sessionId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
-                workdir: '/home/user/projects/my-app',
+                version: '1.2.0',
+                sessionId: 'sess_a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+                workdir: '/home/dev/projects/nebula-platform',
                 configurationData: {
                     model: 'claude-sonnet-4-20250514',
                     fastModel: 'claude-haiku-4-20250514',
-                    baseURL: 'https://api.example.com/v1',
-                    serverUrl: 'https://wave.example.com'
+                    baseURL: 'https://api.nebula-tech.com/v1',
+                    serverUrl: 'https://wave.nebula-tech.com'
                 }
             });
         });
@@ -44,7 +44,7 @@ test.describe('Status Dialog Demo', () => {
             window.simulateExtensionMessage({
                 command: 'authStatusResponse',
                 isAuthenticated: true,
-                user: { id: 'user-abc123', email: 'developer@example.com' }
+                user: { id: 'usr_7f3k2d8x', email: 'sarah.chen@nebula-tech.com' }
             });
         });
 
@@ -52,11 +52,11 @@ test.describe('Status Dialog Demo', () => {
         await expect(webviewPage.getByText('状态信息', { exact: true })).toBeVisible();
 
         // Verify key info fields are displayed
-        await expect(webviewPage.getByText('0.4.15')).toBeVisible();
-        await expect(webviewPage.getByText('a1b2c3d4-e5f6-7890-abcd-ef1234567890')).toBeVisible();
-        await expect(webviewPage.getByText('/home/user/projects/my-app')).toBeVisible();
+        await expect(webviewPage.getByText('1.2.0')).toBeVisible();
+        await expect(webviewPage.getByText('sess_a1b2c3d4-e5f6-7890-abcd-ef1234567890')).toBeVisible();
+        await expect(webviewPage.getByText('/home/dev/projects/nebula-platform')).toBeVisible();
         await expect(webviewPage.getByText('claude-sonnet-4-20250514').first()).toBeVisible();
-        await expect(webviewPage.getByText('developer@example.com')).toBeVisible();
+        await expect(webviewPage.getByText('sarah.chen@nebula-tech.com')).toBeVisible();
 
         // Take screenshot
         const dialog = webviewPage.locator('.configuration-dialog');
@@ -75,7 +75,7 @@ test.describe('Status Dialog Demo', () => {
         await webviewPage.evaluate(() => {
             window.simulateExtensionMessage({
                 command: 'statusResponse',
-                version: '0.4.15',
+                version: '1.2.0',
                 sessionId: '',
                 workdir: '',
                 configurationData: {}

--- a/packages/vsce/e2e/demo/taskNotification.demo.ts
+++ b/packages/vsce/e2e/demo/taskNotification.demo.ts
@@ -10,47 +10,44 @@ test.describe('Task Notification Demo', () => {
       {
         id: 'msg_notify_completed',
         role: 'assistant' as const,
-        timestamp: '2024-01-01T00:00:00.000Z',
+        timestamp: '2025-07-09T10:30:00.000Z',
         blocks: [
-          {
-            type: 'text' as const,
-            content: 'Background task completed:'
-          },
+          { type: 'text' as const, content: '后台任务已完成：' },
           {
             type: 'task_notification' as const,
-            taskId: 'task-1',
+            taskId: 'task-build-001',
             taskType: 'shell',
             status: 'completed',
-            summary: 'npm test passed with 42 tests',
-            outputFile: '/tmp/test-output.log'
+            summary: 'Docker 镜像构建成功: nebula-payment:v1.2.0 (142MB)',
+            outputFile: '/tmp/docker-build-001.log'
           }
         ]
       },
       {
         id: 'msg_notify_failed',
         role: 'assistant' as const,
-        timestamp: '2024-01-01T00:00:00.000Z',
+        timestamp: '2025-07-09T10:30:00.000Z',
         blocks: [
           {
             type: 'task_notification' as const,
-            taskId: 'task-2',
+            taskId: 'task-agent-002',
             taskType: 'agent',
             status: 'failed',
-            summary: 'Explore agent encountered an error during file analysis'
+            summary: '代码审查子代理在分析 PaymentService.ts 时超时'
           }
         ]
       },
       {
         id: 'msg_notify_killed',
         role: 'assistant' as const,
-        timestamp: '2024-01-01T00:00:00.000Z',
+        timestamp: '2025-07-09T10:30:00.000Z',
         blocks: [
           {
             type: 'task_notification' as const,
-            taskId: 'task-3',
+            taskId: 'task-deploy-003',
             taskType: 'shell',
             status: 'killed',
-            summary: 'Long-running process was terminated by user'
+            summary: 'Kubernetes 部署过程被用户手动终止'
           }
         ]
       }

--- a/packages/vsce/e2e/demo/tool-error-scrollable.demo.ts
+++ b/packages/vsce/e2e/demo/tool-error-scrollable.demo.ts
@@ -13,10 +13,10 @@ test.describe('Tool Error Scrollable Demo', () => {
             isStreaming: false,
             sessions: [],
             configurationData: {
-                apiKey: 'sk-xxxxxxxxxxxxxxxx',
-                baseURL: 'https://api.openai.com/v1',
-                model: 'gpt-4',
-                fastModel: 'gpt-3.5-turbo'
+                apiKey: 'sk-ant-api03-CXB9pH2k...mH8wQz',
+                baseURL: 'https://api.anthropic.com/v1',
+                model: 'claude-sonnet-4-20250514',
+                fastModel: 'claude-haiku-4-20250514'
             },
             permissionMode: 'default'
         });
@@ -30,8 +30,8 @@ test.describe('Tool Error Scrollable Demo', () => {
                     type: 'tool',
                     name: BASH_TOOL_NAME,
                     stage: 'end',
-                    compactParams: 'ls -R /',
-                    parameters: JSON.stringify({ command: 'ls -R /' }),
+                    compactParams: 'pnpm -F @nebula/payment-service build',
+                    parameters: JSON.stringify({ command: 'pnpm -F @nebula/payment-service build' }),
                     error: longError,
                     success: false
                 }
@@ -65,10 +65,10 @@ test.describe('Tool Error Scrollable Demo', () => {
             isStreaming: false,
             sessions: [],
             configurationData: {
-                apiKey: 'sk-xxxxxxxxxxxxxxxx',
-                baseURL: 'https://api.openai.com/v1',
-                model: 'gpt-4',
-                fastModel: 'gpt-3.5-turbo'
+                apiKey: 'sk-ant-api03-CXB9pH2k...mH8wQz',
+                baseURL: 'https://api.anthropic.com/v1',
+                model: 'claude-sonnet-4-20250514',
+                fastModel: 'claude-haiku-4-20250514'
             },
             permissionMode: 'default'
         });

--- a/packages/vsce/e2e/fixtures/mockData.ts
+++ b/packages/vsce/e2e/fixtures/mockData.ts
@@ -24,7 +24,7 @@ export class MockDataGenerator {
         return {
             id: id || `msg_${Math.random().toString(36).substring(2, 9)}`,
             role: "user",
-            timestamp: '2024-01-01T00:00:00.000Z',
+            timestamp: '2025-07-09T10:30:00.000Z',
             blocks: [textBlock]
         };
     }
@@ -41,7 +41,7 @@ export class MockDataGenerator {
         return {
             id: id || `msg_${Math.random().toString(36).substring(2, 9)}`,
             role: "assistant",
-            timestamp: '2024-01-01T00:00:00.000Z',
+            timestamp: '2025-07-09T10:30:00.000Z',
             blocks: [textBlock]
         };
     }
@@ -78,7 +78,7 @@ export class MockDataGenerator {
         return {
             id: `msg_${Math.random().toString(36).substring(2, 9)}`,
             role: "assistant",
-            timestamp: '2024-01-01T00:00:00.000Z',
+            timestamp: '2025-07-09T10:30:00.000Z',
             blocks: blocks
         };
     }
@@ -95,7 +95,7 @@ export class MockDataGenerator {
         return {
             id: `msg_${Math.random().toString(36).substring(2, 9)}`,
             role: "assistant",
-            timestamp: '2024-01-01T00:00:00.000Z',
+            timestamp: '2025-07-09T10:30:00.000Z',
             blocks: [errorBlock]
         };
     }
@@ -112,7 +112,7 @@ export class MockDataGenerator {
         return {
             id: `msg_${Math.random().toString(36).substring(2, 9)}`,
             role: "assistant",
-            timestamp: '2024-01-01T00:00:00.000Z',
+            timestamp: '2025-07-09T10:30:00.000Z',
             blocks: [textBlock]
         };
     }
@@ -155,7 +155,7 @@ export class MockDataGenerator {
         return {
             id: `msg_${Math.random().toString(36).substring(2, 9)}`,
             role: "assistant",
-            timestamp: '2024-01-01T00:00:00.000Z',
+            timestamp: '2025-07-09T10:30:00.000Z',
             blocks: blocks
         };
     }
@@ -216,7 +216,7 @@ export class MockDataGenerator {
         return {
             id: `msg_${Math.random().toString(36).substring(2, 9)}`,
             role: "assistant",
-            timestamp: '2024-01-01T00:00:00.000Z',
+            timestamp: '2025-07-09T10:30:00.000Z',
             blocks: blocks
         };
     }
@@ -227,7 +227,7 @@ export class MockDataGenerator {
         return {
             id: `msg_${Math.random().toString(36).substring(2, 9)}`,
             role: "user",
-            timestamp: '2024-01-01T00:00:00.000Z',
+            timestamp: '2025-07-09T10:30:00.000Z',
             blocks: [{
                 type: "bang",
                 command,
@@ -274,21 +274,21 @@ export class MockDataGenerator {
         return {
             id: `msg_${Math.random().toString(36).substring(2, 9)}`,
             role: "assistant",
-            timestamp: '2024-01-01T00:00:00.000Z',
+            timestamp: '2025-07-09T10:30:00.000Z',
             blocks
         };
     }
 
     static createSampleConversation(): Message[] {
         return [
-            this.createUserMessage("Hello, can you help me with my project?"),
-            this.createAssistantMessage("Hello! I'd be happy to help you with your project. What would you like to know?"),
-            this.createUserMessage("Can you read the package.json file?"),
+            this.createUserMessage("帮我分析 PaymentService 的分布式事务实现，看看有没有竞态条件"),
+            this.createAssistantMessage("好的，我来分析 PaymentService 的分布式事务实现。让我先读取相关代码。"),
+            this.createUserMessage("请检查 src/services/payment/PaymentService.ts 中的事务逻辑"),
             this.createAssistantMessageWithTool(
-                "I'll read the package.json file for you.", 
+                "好的，我来读取 PaymentService.ts 的代码。",
                 READ_TOOL_NAME,
-                '{"file_path": "/project/package.json"}',
-                '{"name": "test-project", "version": "1.0.0"}'
+                '{"file_path": "src/services/payment/PaymentService.ts"}',
+                'class PaymentService {\n  private txManager: TransactionManager;\n\n  async processPayment(tx: PaymentTx): Promise<Result> {\n    const session = this.txManager.startSession();\n    try {\n      await session.withTransaction(async () => {\n        const account = await AccountModel.findById(tx.accountId).session(session);\n        account.balance -= tx.amount;\n        await account.save({ session });\n      });\n      return { success: true, txId: tx.id };\n    } finally {\n      await session.endSession();\n    }\n  }\n}'
             )
         ];
     }

--- a/packages/vsce/e2e/utils/messageInjector.ts
+++ b/packages/vsce/e2e/utils/messageInjector.ts
@@ -58,7 +58,7 @@ export class MessageInjector {
         const abortedMessage: Message = {
             id: `msg_abort_${Date.now()}`,
             role: 'assistant' as const,
-            timestamp: '2024-01-01T00:00:00.000Z',
+            timestamp: '2025-07-09T10:30:00.000Z',
             blocks: [
                 {
                     type: 'error' as const,


### PR DESCRIPTION
## Summary

Upgraded all VS Code extension demo mock data to professional, enterprise-grade content for customer-facing screenshots.

## Changes

### Unified Configuration
- API Key: `sk-xxxx` → `sk-ant-api03-...` (Anthropic style)
- baseURL: `api.openai.com` → `api.anthropic.com/v1`
- Models: `gpt-4`/`gpt-3.5-turbo` → `claude-sonnet-4-20250514`/`claude-haiku-4-20250514`
- Timestamps: `2024-01-01` → `2025-07-09`

### Content Professionalization
- **Chat examples**: Hello World → type-safe EventBus implementation, PaymentService distributed transaction analysis
- **Task lists**: Generic tasks → analyze payment architecture / implement optimistic lock / write integration tests
- **Bash outputs**: Simple test → 94.2% coverage report, K8s pod status
- **LSP**: Generic lookups → PaymentRepository with 8 references and 4 callers
- **Mermaid**: Simple 4-node graph → microservice architecture (Gateway + Auth/Payment/Order + MQ + DB)
- **MCP servers**: sqlite/fetch → Jira, PostgreSQL, GitHub, Sentry
- **Plugins**: Generic names → Git Workflow, Kubernetes Helper, Database Explorer, Code Reviewer
- **Project paths**: `/project` → `/home/dev/projects/nebula-platform`
- **User email**: `alice@example.com` → `sarah.chen@nebula-tech.com`

### Slash Commands (2.4)
Now displays real built-in commands:
- **SDK skills** (6): code-review, deep-research, init, loop, settings, simplify
- **UI commands** (7): config, model, plugin, mcp, status, login, clear

### Files Changed
- 22 demo files in `packages/vsce/e2e/demo/`
- 1 fixture file (`mockData.ts`)
- 1 utility file (`messageInjector.ts`)

### Screenshots
All 72 screenshots regenerated successfully via `pnpm run test:demo`.

| Metric | Value |
|--------|-------|
| Tests passed | 30/30 |
| Screenshots generated | 72 |
| Files modified | 23 |