### PR TITLE
fix(readTool): align file size limit with Claude Code and add CJK-aware token estimation

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -3,6 +3,7 @@ import * as aiService from "../services/aiService.js";
 import { convertMessagesForAPI } from "../utils/convertMessagesForAPI.js";
 import { parseTaskNotificationXml } from "../utils/notificationXml.js";
 import { calculateComprehensiveTotalTokens } from "../utils/tokenCalculation.js";
+import { estimateTokens } from "../utils/tokenEstimate.js";
 import {
   getTaskReminderTurnCounts,
   maybeInjectTaskReminder,
@@ -606,7 +607,7 @@ export class AIManager {
     );
     let usedTokens = 0;
     for (const file of recentFiles) {
-      const fileTokens = Math.ceil(file.content.length / 4);
+      const fileTokens = estimateTokens(file.content);
       if (usedTokens + fileTokens > POST_COMPACT_MAX_TOKENS_PER_FILE) continue;
       if (fileTokens > 0) usedTokens += fileTokens;
       contextParts.push(`\n\n## ${file.path}\n\`\`\`\n${file.content}\n\`\`\``);
@@ -639,7 +640,7 @@ export class AIManager {
               skillContent.slice(0, maxSkillChars) + "\n\n...[truncated]...";
           }
 
-          const skillTokens = Math.ceil(skillContent.length / 4);
+          const skillTokens = estimateTokens(skillContent);
           if (skillsUsedTokens + skillTokens > POST_COMPACT_SKILLS_TOKEN_BUDGET)
             break;
           skillsUsedTokens += skillTokens;

--- a/packages/agent-sdk/src/managers/messageManager.ts
+++ b/packages/agent-sdk/src/managers/messageManager.ts
@@ -31,6 +31,7 @@ import type { MemoryRuleManager } from "./MemoryRuleManager.js";
 import type { MemoryRule } from "../types/memoryRule.js";
 import type { MemoryService } from "../services/memory.js";
 import { pathEncoder } from "../utils/pathEncoder.js";
+import { estimateTokens } from "../utils/tokenEstimate.js";
 import { READ_TOOL_NAME } from "../constants/tools.js";
 
 import { Container } from "../utils/container.js";
@@ -1063,7 +1064,7 @@ export class MessageManager {
   /**
    * Get recent file read contents, sorted by timestamp (newest first).
    * @param maxFiles - Maximum number of files to return
-   * @param maxTokensPerFile - Maximum tokens per file (~4 chars/token)
+   * @param maxTokensPerFile - Maximum tokens per file (CJK-aware estimation)
    * @returns Array of { path, content } sorted by recency
    */
   public getRecentFileReads(
@@ -1076,10 +1077,14 @@ export class MessageManager {
 
     const result: Array<{ path: string; content: string }> = [];
     for (const [path, { content }] of sorted) {
-      const truncated =
-        content.length > maxTokensPerFile * 4
-          ? content.slice(0, maxTokensPerFile * 4)
-          : content;
+      const tokenCount = estimateTokens(content);
+      let truncated = content;
+      if (tokenCount > maxTokensPerFile) {
+        // Truncate proportionally to fit within the token budget
+        const ratio = maxTokensPerFile / tokenCount;
+        const cutIndex = Math.floor(content.length * ratio);
+        truncated = content.slice(0, cutIndex);
+      }
       result.push({ path, content: truncated });
     }
     return result;

--- a/packages/agent-sdk/src/tools/readTool.ts
+++ b/packages/agent-sdk/src/tools/readTool.ts
@@ -5,6 +5,7 @@ import { logger } from "../utils/globalLogger.js";
 import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
 import { resolvePath, getDisplayPath } from "../utils/path.js";
 import { formatLineNumberPrefix } from "../utils/stringUtils.js";
+import { estimateTokens } from "../utils/tokenEstimate.js";
 import {
   isBinaryDocument,
   getBinaryDocumentError,
@@ -267,14 +268,11 @@ Usage:
         }
       }
 
-      // Resource Limits
+      // Resource Limits — align with Claude Code: 256KB default, bypassed only
+      // when the caller provides an explicit line limit (not offset alone).
       const maxSizeBytes =
-        context.fileReadingLimits?.maxSizeBytes ?? 1024 * 1024; // Default 1MB
-      if (
-        stats.size > maxSizeBytes &&
-        typeof offset !== "number" &&
-        typeof limit !== "number"
-      ) {
+        context.fileReadingLimits?.maxSizeBytes ?? 0.25 * 1024 * 1024; // Default 256KB
+      if (stats.size > maxSizeBytes && typeof limit !== "number") {
         return {
           success: false,
           content: "",
@@ -357,11 +355,7 @@ Usage:
       // Token-level validation: estimate tokens and reject if over limit
       const maxTokens = context.fileReadingLimits?.maxTokens ?? 25000; // Default 25000 tokens
       const ext = extname(actualFilePath).toLowerCase().slice(1);
-      const bytesPerToken =
-        ext === "json" || ext === "jsonl" || ext === "jsonc" ? 2 : 4;
-      const estimatedTokens = Math.ceil(
-        formattedContent.length / bytesPerToken,
-      );
+      const estimatedTokens = estimateTokens(formattedContent, ext);
       if (estimatedTokens > maxTokens) {
         return {
           success: false,

--- a/packages/agent-sdk/src/utils/groupMessagesByApiRound.ts
+++ b/packages/agent-sdk/src/utils/groupMessagesByApiRound.ts
@@ -1,4 +1,5 @@
 import type { Message } from "../types/index.js";
+import { estimateTokens as estimateStrTokens } from "./tokenEstimate.js";
 
 export interface ApiRound {
   messages: Message[];
@@ -95,26 +96,26 @@ export function getLastApiRounds(
 }
 
 /**
- * Roughly estimate token count from character count (~4 chars per token).
+ * Estimate token count from message blocks using CJK-aware estimation.
  */
 function estimateTokens(messages: Message[]): number {
-  let chars = 0;
+  let combined = "";
   for (const msg of messages) {
     for (const block of msg.blocks) {
       if ("content" in block && typeof block.content === "string") {
-        chars += block.content.length;
+        combined += block.content;
       }
       if (
         block.type === "tool" &&
         block.parameters &&
         typeof block.parameters === "string"
       ) {
-        chars += block.parameters.length;
+        combined += block.parameters;
       }
       if (block.type === "tool" && block.result) {
-        chars += block.result.length;
+        combined += block.result;
       }
     }
   }
-  return Math.ceil(chars / 4);
+  return estimateStrTokens(combined);
 }

--- a/packages/agent-sdk/src/utils/tokenEstimate.ts
+++ b/packages/agent-sdk/src/utils/tokenEstimate.ts
@@ -1,0 +1,34 @@
+/**
+ * CJK-aware token estimation without external dependencies.
+ *
+ * The naive `length / 4` heuristic under-estimates CJK text by ~4x because
+ * each Chinese/Japanese/Korean character is typically 1-2 tokens, not 0.25.
+ * This function separates CJK characters from other text and applies
+ * different ratios:
+ *
+ * - CJK characters: 1 char ≈ 1 token
+ * - Other characters: 4 chars ≈ 1 token (2 for JSON/JSONL/JSONC)
+ *
+ * The estimate intentionally leans high for CJK (safe direction for limit
+ * checks — better to reject than to let oversized content through).
+ */
+
+// CJK Unified Ideographs + Extension A + Hiragana + Katakana + Hangul Syllables
+const CJK_REGEX =
+  /[\u4e00-\u9fff\u3400-\u4dbf\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]/g;
+
+/**
+ * Estimate token count for a string, with CJK-awareness.
+ *
+ * @param content - The text content to estimate
+ * @param ext - File extension (without dot), e.g. "ts", "json". JSON/JSONL/JSONC
+ *              files use a tighter ratio (2 chars/token) for non-CJK text.
+ * @returns Estimated token count
+ */
+export function estimateTokens(content: string, ext?: string): number {
+  const cjkCount = (content.match(CJK_REGEX) || []).length;
+  const otherCount = content.length - cjkCount;
+  const bytesPerToken =
+    ext === "json" || ext === "jsonl" || ext === "jsonc" ? 2 : 4;
+  return Math.ceil(cjkCount + otherCount / bytesPerToken);
+}

--- a/packages/agent-sdk/tests/tools/readTool.test.ts
+++ b/packages/agent-sdk/tests/tools/readTool.test.ts
@@ -381,9 +381,9 @@ describe("readTool", () => {
             ReturnType<typeof stat>
           >; // 25MB - exceeds limit
         }
-        return { size: 1024 * 1024 } as unknown as Awaited<
+        return { size: 100 * 1024 } as unknown as Awaited<
           ReturnType<typeof stat>
-        >; // 1MB - within limit
+        >; // 100KB - within limit
       });
     });
 

--- a/packages/agent-sdk/tests/utils/tokenEstimate.test.ts
+++ b/packages/agent-sdk/tests/utils/tokenEstimate.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { estimateTokens } from "@/utils/tokenEstimate.js";
+
+describe("estimateTokens", () => {
+  it("should estimate ASCII text at ~4 chars/token", () => {
+    const text = "The quick brown fox jumps over the lazy dog";
+    expect(estimateTokens(text)).toBe(Math.ceil(text.length / 4));
+  });
+
+  it("should estimate CJK text at ~1 char/token (not 4x under-estimate)", () => {
+    const text = "敏捷的棕色狐狸跳过了懒惰的狗";
+    // All 14 chars are CJK → 14 tokens (naive would be 14/4 = 4)
+    expect(estimateTokens(text)).toBe(text.length);
+  });
+
+  it("should handle mixed CJK + ASCII content", () => {
+    const text = "hello 世界 hello world";
+    // 8 ASCII chars (hello + space + space + hello + space) → but let's count precisely
+    // "hello 世界 hello world"
+    //  CJK: 世, 界 = 2
+    //  non-CJK: "hello " (6) + " " (1) + " hello world" (12) = 19
+    const cjkCount = 2;
+    const otherCount = text.length - cjkCount; // 19
+    expect(estimateTokens(text)).toBe(Math.ceil(cjkCount + otherCount / 4));
+  });
+
+  it("should use 2 chars/token for JSON files", () => {
+    const json = '{"key":"value","num":123}';
+    // No CJK, so ratio is 2
+    expect(estimateTokens(json, "json")).toBe(Math.ceil(json.length / 2));
+  });
+
+  it("should use 2 chars/token for JSONL files", () => {
+    const jsonl = '{"a":1}\n{"b":2}';
+    expect(estimateTokens(jsonl, "jsonl")).toBe(Math.ceil(jsonl.length / 2));
+  });
+
+  it("should use 2 chars/token for JSONC files", () => {
+    const jsonc = '// comment\n{"key":"value"}';
+    expect(estimateTokens(jsonc, "jsonc")).toBe(Math.ceil(jsonc.length / 2));
+  });
+
+  it("should handle CJK in JSON (mixed ratios)", () => {
+    const json = '{"name":"订单系统"}';
+    const cjkCount = 4; // 订,单,系,统
+    const otherCount = json.length - cjkCount;
+    expect(estimateTokens(json, "json")).toBe(
+      Math.ceil(cjkCount + otherCount / 2),
+    );
+  });
+
+  it("should return 0 for empty string", () => {
+    expect(estimateTokens("")).toBe(0);
+  });
+
+  it("should handle Japanese (Hiragana + Katakana + Kanji)", () => {
+    const text = "お誕生日おめでとう"; // 9 chars
+    expect(estimateTokens(text)).toBe(9);
+  });
+
+  it("should handle Korean (Hangul)", () => {
+    const text = "안녕하세요"; // 5 chars
+    expect(estimateTokens(text)).toBe(5);
+  });
+
+  it("should estimate higher than naive length/4 for CJK-heavy content", () => {
+    const text = "这是一个包含中文内容的测试行用于验证令牌估算的准确性";
+    const naive = Math.ceil(text.length / 4);
+    const cjkAware = estimateTokens(text);
+    expect(cjkAware).toBeGreaterThan(naive);
+    // Should be ~4x higher (1 token/char vs 0.25 token/char)
+    expect(cjkAware).toBe(text.length);
+  });
+
+  it("should handle code with Chinese comments", () => {
+    const code = `function add(a, b) {\n  // 计算两数之和\n  return a + b;\n}`;
+    const cjkCount = 6; // 计,算,两,数,之,和
+    const otherCount = code.length - cjkCount;
+    expect(estimateTokens(code, "ts")).toBe(
+      Math.ceil(cjkCount + otherCount / 4),
+    );
+  });
+});

--- a/specs/001-fs-tools.md
+++ b/specs/001-fs-tools.md
@@ -59,7 +59,7 @@
 
 ### 边界情况
 
-- **大文件**：读取超出内存限制或令牌窗口的文件。通过 `offset` 和 `limit` 处理。如果估计令牌超过 `maxTokens`，工具返回错误并建议使用 offset/limit 或 grep/jq。
+- **大文件**：读取超出内存限制或令牌窗口的文件。文件大小超过 256KB 且未显式提供 `limit` 参数时，工具直接返回错误。通过 `offset` 和 `limit` 分页读取。如果估计令牌超过 `maxTokens`，工具返回错误并建议使用 offset/limit 或 grep/jq。
 - **二进制文档**：尝试读取 PDF、DOCX 或其他不支持的二进制格式。工具必须阻止此操作并返回错误。
 - **不匹配分析**：当未找到 `old_string` 时，`Edit` 工具必须提供详细的不匹配报告，包括尝试的字符串（截断为 200 个字符）以帮助模型自我纠正。
 - **编辑前读取**：`Edit` 工具必须拒绝编辑在当前对话中尚未读取的文件，防止盲目编辑。
@@ -72,9 +72,9 @@
 ### 功能需求
 
 - **FR-001**：系统必须提供 `Read` 工具，支持文本、图片（PNG、JPEG、GIF、WebP）和 Jupyter 笔记本。
-- **FR-002**：`Read` 工具必须支持通过 `offset` 和 `limit` 进行分页，强制执行令牌级验证（估计令牌不得超过 `maxTokens`，默认 25000，来自 `context.fileReadingLimits.maxTokens`；JSON/JSONL/JSONC 的 bytesPerToken 为 2，其他文件为 4），并提供结构化元数据。
+- **FR-002**：`Read` 工具必须支持通过 `offset` 和 `limit` 进行分页，强制执行令牌级验证（使用 CJK 感知的 `estimateTokens` 估算令牌数，不得超过 `maxTokens`，默认 25000，来自 `context.fileReadingLimits.maxTokens`；CJK 字符按 1 字符≈1 令牌计算，其他字符 JSON/JSONL/JSONC 按 2 字符/令牌、其余按 4 字符/令牌计算），并提供结构化元数据。
 - **FR-018**：`Read` 工具必须支持去重，通过检查文件修改时间并在未变化时返回最小响应。
-- **FR-019**：`Read` 工具必须强制执行资源限制（例如默认 1MB）用于完整文件读取。
+- **FR-019**：`Read` 工具必须强制执行资源限制（默认 256KB）用于文件读取。仅当调用方显式提供 `limit` 参数时跳过大小检查，仅提供 `offset` 不跳过。
 - **FR-015**：`Read` 工具必须通过扩展名不区分大小写地检测图片文件并将内容转换为 base64 编码。
 - **FR-016**：`Read` 工具必须使用 base64 数据和正确的 MIME 类型填充 `ToolResult.images` 数组。
 - **FR-017**：`Read` 工具必须对图片文件强制执行 20MB 的文件大小限制。


### PR DESCRIPTION
## Summary

- **File size threshold**: reduced from 1MB to 256KB, matching Claude Code's default
- **Size check condition**: bypass only when caller provides explicit `limit` parameter (previously `offset` alone could bypass, reading entire large files into memory)
- **CJK-aware token estimation**: new shared `tokenEstimate.ts` utility — CJK chars ≈ 1 token, others ≈ 4 chars/token (2 for JSON). The previous `length/4` heuristic under-estimated CJK content by ~4x, allowing oversized reads to pass the 25K token limit
- **Replaced all 5 `length/4` call sites** with the shared utility:
  - `readTool.ts` — token limit validation
  - `groupMessagesByApiRound.ts` — compaction round grouping
  - `aiManager.ts` (x2) — post-compact file/skill context restoration
  - `messageManager.ts` — recent file read truncation
- Updated spec FR-002/FR-019 to reflect new limits and estimation

## Test plan

- [x] 12 new unit tests for `tokenEstimate` (CJK, mixed, JSON, Japanese, Korean, code with Chinese comments)
- [x] 41 existing readTool tests pass (1 mock value adjusted for 256KB threshold)
- [x] 12 groupMessagesByApiRound tests pass
- [x] 788 manager tests pass
- [x] Type-check and lint pass