### PR TITLE
fix(vsce): 后台通知消息不显示

### DIFF
--- a/packages/vsce/src/session/chatSession.ts
+++ b/packages/vsce/src/session/chatSession.ts
@@ -141,6 +141,18 @@ export class ChatSession {
                 },
                 onCompleteBangMessage: () => {
                     this.callbacks.onBangMessageUpdated?.();
+                },
+                onNotificationMessageAdded: (params) => {
+                    // Incremental update: find the notification message and append it,
+                    // consistent with how onUserMessageAdded works.
+                    const notificationMessage = this.agent?.messages.find(
+                        m => m.role === 'user' && m.blocks.some(
+                            b => b.type === 'task_notification' && (b as { taskId: string }).taskId === params.taskId
+                        )
+                    );
+                    if (notificationMessage) {
+                        this.callbacks.onAssistantMessageAdded?.(notificationMessage);
+                    }
                 }
             };
 

--- a/packages/vsce/tests/__mocks__/vscode.ts
+++ b/packages/vsce/tests/__mocks__/vscode.ts
@@ -1,0 +1,12 @@
+export const workspace = {
+    workspaceFolders: [{ uri: { fsPath: '/test-workspace' } }],
+};
+
+export enum ExtensionMode {
+    Development = 1,
+    Production = 2,
+}
+
+export const window = {
+    activeTextEditor: null,
+};

--- a/packages/vsce/tests/session/chatSession.notification.test.ts
+++ b/packages/vsce/tests/session/chatSession.notification.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock VscodeLspAdapter - must be a constructor (not arrow function)
+vi.mock('../../src/services/lspAdapter', () => ({
+    VscodeLspAdapter: vi.fn(function() { return {}; }),
+}));
+
+// Mock wave-agent-sdk: Agent.create captures callbacks, PromptHistoryManager is noop
+const { capturedCallbacks, setCapturedCallbacks } = vi.hoisted(() => {
+    let capturedCallbacks: Record<string, (...args: unknown[]) => void> | undefined;
+    return {
+        capturedCallbacks: () => capturedCallbacks,
+        setCapturedCallbacks: (cb: Record<string, (...args: unknown[]) => void>) => { capturedCallbacks = cb; },
+    };
+});
+
+vi.mock('wave-agent-sdk', () => {
+    return {
+        Agent: {
+            create: async (options: { callbacks: Record<string, (...args: unknown[]) => void> }) => {
+                setCapturedCallbacks(options.callbacks);
+                const messages: Message[] = [];
+                return {
+                    sessionId: 'test-session-1',
+                    get messages() { return messages; },
+                    _setMessages(arr: Message[]) { messages.splice(0, messages.length, ...arr); },
+                };
+            },
+        },
+        PromptHistoryManager: {
+            addEntry: () => {},
+        },
+    };
+});
+
+import { ChatSession } from '../../src/session/chatSession';
+import type { Message } from 'wave-agent-sdk';
+
+function createMockCallbacks() {
+    return {
+        onMessagesChange: vi.fn(),
+        onTasksChange: vi.fn(),
+        onSessionIdChange: vi.fn(),
+        onStreamingChange: vi.fn(),
+        onQueueChange: vi.fn(),
+        onCommandRunningChange: vi.fn(),
+        onPermissionModeChange: vi.fn(),
+        onToolPermissionRequest: vi.fn(),
+        onError: vi.fn(),
+        onAssistantMessageAdded: vi.fn(),
+    };
+}
+
+async function createInitializedSession() {
+    const callbacks = createMockCallbacks();
+    const session = new ChatSession('sidebar', undefined, callbacks);
+    await session.initialize({} as never, 2 satisfies number);
+
+    if (!session.agent) {
+        throw new Error('Agent init failed');
+    }
+    return { session, callbacks };
+}
+
+describe('ChatSession onNotificationMessageAdded callback', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should forward notification message via onAssistantMessageAdded (incremental)', async () => {
+        const { session, callbacks } = await createInitializedSession();
+
+        const notificationMessage: Message = {
+            id: 'msg_notif_1',
+            role: 'user',
+            timestamp: '2025-01-01T00:00:00.000Z',
+            blocks: [{
+                type: 'task_notification',
+                taskId: 'task-001',
+                taskType: 'shell',
+                status: 'completed',
+                summary: 'Build succeeded',
+            }],
+        };
+        (session.agent as unknown as { _setMessages: (arr: Message[]) => void })._setMessages([notificationMessage]);
+
+        capturedCallbacks()!.onNotificationMessageAdded({
+            taskId: 'task-001',
+            taskType: 'shell',
+            status: 'completed',
+            summary: 'Build succeeded',
+        });
+
+        expect(callbacks.onAssistantMessageAdded).toHaveBeenCalledWith(notificationMessage);
+        // Should NOT trigger full message list update
+        expect(callbacks.onMessagesChange).not.toHaveBeenCalled();
+    });
+
+    it('should find the correct notification among multiple messages', async () => {
+        const { session, callbacks } = await createInitializedSession();
+
+        const otherMessage: Message = {
+            id: 'msg_other',
+            role: 'user',
+            timestamp: '2025-01-01T00:00:00.000Z',
+            blocks: [{ type: 'text', content: 'hello' }],
+        };
+        const targetNotification: Message = {
+            id: 'msg_notif_target',
+            role: 'user',
+            timestamp: '2025-01-01T00:00:01.000Z',
+            blocks: [{
+                type: 'task_notification',
+                taskId: 'task-target',
+                taskType: 'agent',
+                status: 'failed',
+                summary: 'Agent timed out',
+            }],
+        };
+        (session.agent as unknown as { _setMessages: (arr: Message[]) => void })._setMessages([otherMessage, targetNotification]);
+
+        capturedCallbacks()!.onNotificationMessageAdded({
+            taskId: 'task-target',
+            taskType: 'agent',
+            status: 'failed',
+            summary: 'Agent timed out',
+        });
+
+        expect(callbacks.onAssistantMessageAdded).toHaveBeenCalledWith(targetNotification);
+        expect(callbacks.onAssistantMessageAdded).not.toHaveBeenCalledWith(otherMessage);
+    });
+
+    it('should not call onAssistantMessageAdded when no matching message found', async () => {
+        const { session, callbacks } = await createInitializedSession();
+
+        (session.agent as unknown as { _setMessages: (arr: Message[]) => void })._setMessages([]);
+
+        capturedCallbacks()!.onNotificationMessageAdded({
+            taskId: 'nonexistent',
+            taskType: 'shell',
+            status: 'completed',
+            summary: 'Nothing',
+        });
+
+        expect(callbacks.onAssistantMessageAdded).not.toHaveBeenCalled();
+    });
+
+    it('should not call onAssistantMessageAdded when agent is undefined', async () => {
+        const { session, callbacks } = await createInitializedSession();
+
+        session.agent = undefined;
+
+        expect(() => {
+            capturedCallbacks()!.onNotificationMessageAdded({
+                taskId: 'task-001',
+                taskType: 'shell',
+                status: 'completed',
+                summary: 'Build succeeded',
+            });
+        }).not.toThrow();
+
+        expect(callbacks.onAssistantMessageAdded).not.toHaveBeenCalled();
+    });
+});

--- a/packages/vsce/vitest.config.ts
+++ b/packages/vsce/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+    resolve: {
+        alias: {
+            vscode: path.resolve(__dirname, 'tests/__mocks__/vscode.ts'),
+        },
+    },
     test: {
         globals: true,
         reporter: 'dot',
@@ -8,6 +14,11 @@ export default defineConfig({
         include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
         exclude: ['tests/services/**', 'node_modules'],
         setupFiles: ['tests/setup.ts'],
+        server: {
+            deps: {
+                inline: ['wave-agent-sdk'],
+            },
+        },
         coverage: {
             provider: 'v8',
             include: ['webview/src/**'],


### PR DESCRIPTION
## 问题

后台任务完成后的通知消息无法在 VS Code 扩展前端显示。

## 根因

`ChatSession` 中 `onMessagesChange` 回调被设计为只存储消息不转发（避免流式输出期间发送全量消息），而 `onNotificationMessageAdded` 回调完全未实现。通知通过 `addNotificationMessage()` 触发这两个回调，但两者都不会将更新推送到前端 webview。

## 修复

在 `chatSession.ts` 添加 `onNotificationMessageAdded` 回调，通过 `taskId` 从 `agent.messages` 中匹配通知消息，然后复用已有的 `onAssistantMessageAdded` 增量更新路径发送到前端，与 `onUserMessageAdded` 的处理方式一致。

## 测试

新增 `ChatSession` 通知回调单元测试，覆盖：
- 正常增量转发（验证不触发全量更新）
- 多条消息中通过 taskId 精确匹配
- 无匹配消息时不调用回调
- agent 未初始化时不崩溃