### PR TITLE
feat: auto-write .git/info/exclude for Wave runtime files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ Thumbs.db
 nohup.out
 .wave/settings.local.json
 .wave/worktrees/
+.wave/scheduled_tasks.json
+.wave/scheduled_tasks.lock
 vendor/
 
 # VS Code Extension

--- a/packages/agent-sdk/src/managers/cronManager.ts
+++ b/packages/agent-sdk/src/managers/cronManager.ts
@@ -15,6 +15,7 @@ import {
   releaseSchedulerLock,
   registerSchedulerLockCleanup,
 } from "../utils/cronTasksLock.js";
+import { ensureWaveRuntimeFilesExcluded } from "../utils/gitUtils.js";
 
 export class CronManager {
   private jobs = new Map<string, CronJob>();
@@ -100,6 +101,7 @@ export class CronManager {
   }
 
   private tryLock(workdir: string): void {
+    ensureWaveRuntimeFilesExcluded(workdir);
     tryAcquireSchedulerLock({ dir: workdir, sessionId: this.sessionId })
       .then((acquired) => {
         if (acquired) {

--- a/packages/agent-sdk/src/managers/liveConfigManager.ts
+++ b/packages/agent-sdk/src/managers/liveConfigManager.ts
@@ -17,7 +17,6 @@ import type { HookManager } from "./hookManager.js";
 import type { PermissionManager } from "./permissionManager.js";
 import { isValidHookEvent } from "../types/hooks.js";
 import { ConfigurationService } from "../services/configurationService.js";
-import { ensureGlobalGitIgnore } from "../utils/fileUtils.js";
 import { Container } from "../utils/container.js";
 
 import type {
@@ -97,9 +96,6 @@ export class LiveConfigManager {
       if (projectPaths) {
         for (const projectPath of projectPaths) {
           if (existsSync(projectPath)) {
-            if (projectPath.endsWith("settings.local.json")) {
-              await ensureGlobalGitIgnore("**/.wave/settings.local.json");
-            }
             await this.fileWatcher.watchFile(projectPath, (event) =>
               this.handleFileChange(event, "project"),
             );
@@ -364,14 +360,6 @@ export class LiveConfigManager {
 
       // Handle file creation or modification
       if (event.type === "change" || event.type === "create") {
-        if (
-          source === "project" &&
-          event.path.endsWith("settings.local.json") &&
-          event.type === "create"
-        ) {
-          await ensureGlobalGitIgnore("**/.wave/settings.local.json");
-        }
-
         // Add small delay to ensure file write is complete
         await new Promise((resolve) => setTimeout(resolve, 50));
 

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -47,6 +47,7 @@ import {
   mergeRemoteSettings,
 } from "./remoteSettingsService.js";
 import { createAuthAwareFetch } from "./authService.js";
+import { ensureWaveRuntimeFilesExcluded } from "../utils/gitUtils.js";
 
 /**
  * Default ConfigurationService implementation
@@ -791,6 +792,7 @@ export class ConfigurationService {
 
     // Ensure .wave directory exists
     const waveDir = path.join(workdir, ".wave");
+    ensureWaveRuntimeFilesExcluded(workdir);
     if (!existsSync(waveDir)) {
       await fs.mkdir(waveDir, { recursive: true });
     }

--- a/packages/agent-sdk/src/utils/fileUtils.ts
+++ b/packages/agent-sdk/src/utils/fileUtils.ts
@@ -1,8 +1,6 @@
 import fs from "node:fs/promises";
 import { createReadStream } from "node:fs";
 import path from "node:path";
-import { execSync } from "node:child_process";
-import { homedir } from "node:os";
 import { glob } from "glob";
 
 /**
@@ -153,50 +151,6 @@ export async function getLastLine(
     if (fileHandle) {
       await fileHandle.close();
     }
-  }
-}
-
-/**
- * Ensures that a pattern is present in the global git ignore file.
- *
- * @param {string} pattern - The pattern to add to global git ignore.
- */
-export async function ensureGlobalGitIgnore(pattern: string): Promise<void> {
-  try {
-    let globalIgnorePath: string;
-    try {
-      globalIgnorePath = execSync("git config --get core.excludesfile", {
-        encoding: "utf8",
-      }).trim();
-    } catch {
-      // If not set, use default paths
-      const xdgConfigHome =
-        process.env.XDG_CONFIG_HOME || path.join(homedir(), ".config");
-      globalIgnorePath = path.join(xdgConfigHome, "git", "ignore");
-    }
-
-    if (!globalIgnorePath) return;
-
-    // Ensure directory exists
-    await fs.mkdir(path.dirname(globalIgnorePath), { recursive: true });
-
-    let content = "";
-    try {
-      content = await fs.readFile(globalIgnorePath, "utf8");
-    } catch {
-      // File doesn't exist
-    }
-
-    const lines = content.split("\n").map((line) => line.trim());
-    if (!lines.includes(pattern)) {
-      const newContent =
-        content.endsWith("\n") || content === ""
-          ? `${content}${pattern}\n`
-          : `${content}\n${pattern}\n`;
-      await fs.writeFile(globalIgnorePath, newContent, "utf8");
-    }
-  } catch {
-    // Ignore errors
   }
 }
 

--- a/packages/agent-sdk/src/utils/gitUtils.ts
+++ b/packages/agent-sdk/src/utils/gitUtils.ts
@@ -223,6 +223,60 @@ export function getDefaultRemoteBranch(cwd: string): string {
 }
 
 /**
+ * Module-level set tracking git dirs already processed in this process,
+ * to avoid redundant I/O.
+ */
+const excludedGitDirs = new Set<string>();
+
+/**
+ * Ensure that Wave runtime files are excluded from git status by writing
+ * patterns to `.git/info/exclude` (per-repo, not global).
+ *
+ * Idempotent: if the marker `# wave-runtime` is already present in the
+ * exclude file, it skips writing. A module-level Set provides additional
+ * per-process dedup to avoid redundant file reads.
+ *
+ * @param cwd Working directory to start searching from
+ */
+export function ensureWaveRuntimeFilesExcluded(cwd: string): void {
+  try {
+    const gitDir = resolveGitDir(cwd);
+    if (!gitDir) return;
+
+    if (excludedGitDirs.has(gitDir)) return;
+
+    const excludePath = path.join(gitDir, "info", "exclude");
+    let content = "";
+    try {
+      content = fsSync.readFileSync(excludePath, "utf8");
+    } catch {
+      // File doesn't exist yet
+    }
+
+    const marker = "# wave-runtime";
+    if (content.includes(marker)) {
+      excludedGitDirs.add(gitDir);
+      return;
+    }
+
+    const block = [
+      marker,
+      "**/.wave/scheduled_tasks.lock",
+      "**/.wave/scheduled_tasks.json",
+      "**/.wave/worktrees/",
+      "**/.wave/settings.local.json",
+      "",
+    ].join("\n");
+
+    fsSync.mkdirSync(path.join(gitDir, "info"), { recursive: true });
+    fsSync.appendFileSync(excludePath, block);
+    excludedGitDirs.add(gitDir);
+  } catch {
+    // Best-effort: ignore all errors
+  }
+}
+
+/**
  * Check if there are uncommitted changes in the working directory
  * @param cwd Working directory
  * @returns True if there are uncommitted changes

--- a/packages/agent-sdk/src/utils/worktreeUtils.ts
+++ b/packages/agent-sdk/src/utils/worktreeUtils.ts
@@ -6,7 +6,11 @@
 import { execFileSync } from "node:child_process";
 import * as path from "node:path";
 import * as fs from "node:fs";
-import { getGitMainRepoRoot, getDefaultRemoteBranch } from "./gitUtils.js";
+import {
+  getGitMainRepoRoot,
+  getDefaultRemoteBranch,
+  ensureWaveRuntimeFilesExcluded,
+} from "./gitUtils.js";
 import { logger } from "./globalLogger.js";
 
 export interface WorktreeInfo {
@@ -104,6 +108,9 @@ export function createWorktree(name: string, cwd: string): WorktreeInfo {
   const worktreePath = path.join(repoRoot, ".wave", "worktrees", name);
   const branchName = `worktree-${name}`;
   const baseBranch = getDefaultRemoteBranch(cwd);
+
+  // Ensure Wave runtime files are git-excluded in this repo
+  ensureWaveRuntimeFilesExcluded(cwd);
 
   // Ensure parent directory exists
   const parentDir = path.dirname(worktreePath);

--- a/packages/agent-sdk/tests/managers/liveConfigManager.test.ts
+++ b/packages/agent-sdk/tests/managers/liveConfigManager.test.ts
@@ -13,10 +13,8 @@ import { ConfigurationService } from "../../src/services/configurationService.js
 import { FileWatcherService } from "../../src/services/fileWatcher.js";
 import { PermissionManager } from "../../src/managers/permissionManager.js";
 import * as configPaths from "../../src/utils/configPaths.js";
-import { ensureGlobalGitIgnore } from "../../src/utils/fileUtils.js";
 import type { WaveConfiguration } from "../../src/types/configuration.js";
 import type { ConfigurationLoadResult } from "../../src/types/configuration.js";
-import { existsSync } from "fs";
 import { logger } from "../../src/utils/globalLogger.js";
 
 vi.mock("../../src/utils/globalLogger.js", () => ({
@@ -32,7 +30,6 @@ vi.mock("../../src/utils/globalLogger.js", () => ({
 vi.mock("../../src/services/configurationService.js");
 vi.mock("../../src/services/fileWatcher.js");
 vi.mock("../../src/utils/configPaths.js");
-vi.mock("../../src/utils/fileUtils.js");
 vi.mock("fs", () => ({
   existsSync: vi.fn().mockReturnValue(false),
 }));
@@ -367,129 +364,6 @@ describe("LiveConfigManager - Configuration Management", () => {
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining("Configuration reload failed with exception"),
       );
-    });
-  });
-
-  describe("GitIgnore Integration", () => {
-    it("should add settings.local.json to global gitignore on initialization if it exists", async () => {
-      const localConfigPath = "/mock/project/.wave/settings.local.json";
-      vi.mocked(mockConfigurationService.getConfigurationPaths).mockReturnValue(
-        {
-          userPaths: [],
-          projectPaths: [localConfigPath, "/mock/project/.wave/settings.json"],
-          builtinPaths: [],
-          allPaths: [localConfigPath, "/mock/project/.wave/settings.json"],
-          existingPaths: [localConfigPath],
-        },
-      );
-      vi.mocked(existsSync).mockImplementation(
-        (path) => path === localConfigPath,
-      );
-
-      const mockResult: ConfigurationLoadResult = {
-        success: true,
-        configuration: {},
-        sourcePath: "/mock/project/.wave/settings.json",
-        warnings: [],
-      };
-      vi.mocked(
-        mockConfigurationService.loadMergedConfiguration,
-      ).mockResolvedValue(mockResult);
-
-      await liveConfigManager.initialize();
-
-      expect(ensureGlobalGitIgnore).toHaveBeenCalledWith(
-        "**/.wave/settings.local.json",
-      );
-    });
-
-    it("should add settings.local.json to global gitignore when it is created", async () => {
-      const localConfigPath = "/mock/project/.wave/settings.local.json";
-      vi.mocked(mockConfigurationService.getConfigurationPaths).mockReturnValue(
-        {
-          userPaths: [],
-          projectPaths: [localConfigPath, "/mock/project/.wave/settings.json"],
-          builtinPaths: [],
-          allPaths: [localConfigPath, "/mock/project/.wave/settings.json"],
-          existingPaths: [localConfigPath],
-        },
-      );
-
-      const mockResult: ConfigurationLoadResult = {
-        success: true,
-        configuration: {},
-        sourcePath: "/mock/project/.wave/settings.json",
-        warnings: [],
-      };
-      vi.mocked(
-        mockConfigurationService.loadMergedConfiguration,
-      ).mockResolvedValue(mockResult);
-
-      // Let's mock existsSync to return true so it starts watching
-      vi.mocked(existsSync).mockReturnValue(true);
-      await liveConfigManager.initialize();
-
-      const localConfigCall = vi
-        .mocked(mockFileWatcherService.watchFile)
-        .mock.calls.find((call) => call[0].endsWith("settings.local.json"));
-
-      expect(localConfigCall).toBeDefined();
-      const callback = localConfigCall![1];
-
-      // Simulate file creation
-      await callback({
-        type: "create",
-        path: "/mock/project/.wave/settings.local.json",
-        timestamp: Date.now(),
-      });
-
-      expect(ensureGlobalGitIgnore).toHaveBeenCalledWith(
-        "**/.wave/settings.local.json",
-      );
-    });
-
-    it("should not add settings.local.json to global gitignore when it is modified", async () => {
-      const localConfigPath = "/mock/project/.wave/settings.local.json";
-      vi.mocked(mockConfigurationService.getConfigurationPaths).mockReturnValue(
-        {
-          userPaths: [],
-          projectPaths: [localConfigPath, "/mock/project/.wave/settings.json"],
-          builtinPaths: [],
-          allPaths: [localConfigPath, "/mock/project/.wave/settings.json"],
-          existingPaths: [localConfigPath],
-        },
-      );
-
-      const mockResult: ConfigurationLoadResult = {
-        success: true,
-        configuration: {},
-        sourcePath: "/mock/project/.wave/settings.json",
-        warnings: [],
-      };
-      vi.mocked(
-        mockConfigurationService.loadMergedConfiguration,
-      ).mockResolvedValue(mockResult);
-
-      vi.mocked(existsSync).mockReturnValue(true);
-      await liveConfigManager.initialize();
-
-      const localConfigCall = vi
-        .mocked(mockFileWatcherService.watchFile)
-        .mock.calls.find((call) => call[0].endsWith("settings.local.json"));
-
-      const callback = localConfigCall![1];
-
-      // Reset mock to clear calls from initialization
-      vi.mocked(ensureGlobalGitIgnore).mockClear();
-
-      // Simulate file modification
-      await callback({
-        type: "change",
-        path: "/mock/project/.wave/settings.local.json",
-        timestamp: Date.now(),
-      });
-
-      expect(ensureGlobalGitIgnore).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/agent-sdk/tests/utils/fileUtils.test.ts
+++ b/packages/agent-sdk/tests/utils/fileUtils.test.ts
@@ -1,17 +1,9 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import * as fs from "node:fs/promises";
-import * as path from "node:path";
-import {
-  ensureGlobalGitIgnore,
-  readFirstLine,
-} from "../../src/utils/fileUtils.js";
-import { execSync } from "node:child_process";
-import { homedir } from "node:os";
+import { readFirstLine } from "../../src/utils/fileUtils.js";
 import { Readable } from "node:stream";
 
 vi.mock("node:fs/promises");
-vi.mock("node:child_process");
-vi.mock("node:os");
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   return {
@@ -70,79 +62,5 @@ describe("fileUtils - getLastLine", () => {
     const { getLastLine } = await import("../../src/utils/fileUtils.js");
     const result = await getLastLine("non-existent.txt");
     expect(result).toBe("");
-  });
-});
-
-describe("fileUtils - ensureGlobalGitIgnore", () => {
-  const mockHomedir = "/home/user";
-  const defaultGlobalIgnorePath = path.join(
-    mockHomedir,
-    ".config",
-    "git",
-    "ignore",
-  );
-
-  beforeEach(() => {
-    vi.stubEnv("XDG_CONFIG_HOME", "");
-    vi.mocked(homedir).mockReturnValue(mockHomedir);
-    vi.mocked(fs.mkdir).mockResolvedValue(undefined);
-  });
-
-  afterEach(() => {
-    vi.unstubAllEnvs();
-    vi.resetAllMocks();
-  });
-
-  it("should add pattern to global ignore file if not present", async () => {
-    vi.mocked(execSync).mockReturnValue(Buffer.from(defaultGlobalIgnorePath));
-    vi.mocked(fs.readFile).mockResolvedValue("existing-pattern\n");
-    vi.mocked(fs.writeFile).mockResolvedValue(undefined);
-
-    await ensureGlobalGitIgnore("new-pattern");
-
-    expect(fs.writeFile).toHaveBeenCalledWith(
-      defaultGlobalIgnorePath,
-      "existing-pattern\nnew-pattern\n",
-      "utf8",
-    );
-  });
-
-  it("should not add pattern if already present", async () => {
-    vi.mocked(execSync).mockReturnValue(Buffer.from(defaultGlobalIgnorePath));
-    vi.mocked(fs.readFile).mockResolvedValue("existing-pattern\nnew-pattern\n");
-
-    await ensureGlobalGitIgnore("new-pattern");
-
-    expect(fs.writeFile).not.toHaveBeenCalled();
-  });
-
-  it("should create file if it doesn't exist", async () => {
-    vi.mocked(execSync).mockReturnValue(Buffer.from(defaultGlobalIgnorePath));
-    vi.mocked(fs.readFile).mockRejectedValue(new Error("File not found"));
-    vi.mocked(fs.writeFile).mockResolvedValue(undefined);
-
-    await ensureGlobalGitIgnore("new-pattern");
-
-    expect(fs.writeFile).toHaveBeenCalledWith(
-      defaultGlobalIgnorePath,
-      "new-pattern\n",
-      "utf8",
-    );
-  });
-
-  it("should use default path if git config fails", async () => {
-    vi.mocked(execSync).mockImplementation(() => {
-      throw new Error("git config failed");
-    });
-    vi.mocked(fs.readFile).mockResolvedValue("");
-    vi.mocked(fs.writeFile).mockResolvedValue(undefined);
-
-    await ensureGlobalGitIgnore("new-pattern");
-
-    expect(fs.writeFile).toHaveBeenCalledWith(
-      defaultGlobalIgnorePath,
-      "new-pattern\n",
-      "utf8",
-    );
   });
 });

--- a/packages/agent-sdk/tests/utils/gitUtils.test.ts
+++ b/packages/agent-sdk/tests/utils/gitUtils.test.ts
@@ -9,6 +9,7 @@ import {
   resolveGitDir,
   hasUncommittedChanges,
   hasNewCommits,
+  ensureWaveRuntimeFilesExcluded,
 } from "../../src/utils/gitUtils.js";
 
 vi.mock("node:child_process", () => ({
@@ -21,6 +22,7 @@ vi.mock("node:fs", () => ({
   statSync: vi.fn(),
   readdirSync: vi.fn(),
   mkdirSync: vi.fn(),
+  appendFileSync: vi.fn(),
 }));
 
 describe("gitUtils", () => {
@@ -280,6 +282,70 @@ describe("gitUtils", () => {
         "" as unknown as ReturnType<typeof execFileSync>,
       );
       expect(hasNewCommits("/repo/root", "origin/main")).toBe(false);
+    });
+  });
+
+  describe("ensureWaveRuntimeFilesExcluded", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("should write marker + patterns to info/exclude when marker absent", () => {
+      const gitDir = "/repo/write-test/.git";
+      const excludePath = path.join(gitDir, "info", "exclude");
+      vi.mocked(fsSync.existsSync).mockImplementation(
+        (p) => p === path.join("/repo/write-test", ".git"),
+      );
+      vi.mocked(fsSync.statSync).mockReturnValue({
+        isDirectory: () => true,
+      } as unknown as fsSync.Stats);
+      // exclude file doesn't exist yet (readFileSync throws)
+      vi.mocked(fsSync.readFileSync).mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+
+      ensureWaveRuntimeFilesExcluded("/repo/write-test");
+
+      expect(fsSync.mkdirSync).toHaveBeenCalledWith(path.join(gitDir, "info"), {
+        recursive: true,
+      });
+      expect(fsSync.appendFileSync).toHaveBeenCalledWith(
+        excludePath,
+        expect.stringContaining("# wave-runtime"),
+      );
+      expect(fsSync.appendFileSync).toHaveBeenCalledWith(
+        excludePath,
+        expect.stringContaining("**/.wave/scheduled_tasks.lock"),
+      );
+      expect(fsSync.appendFileSync).toHaveBeenCalledWith(
+        excludePath,
+        expect.stringContaining("**/.wave/settings.local.json"),
+      );
+    });
+
+    it("should skip when marker already present (idempotent)", () => {
+      vi.mocked(fsSync.existsSync).mockImplementation(
+        (p) => p === path.join("/repo/idempotent-test", ".git"),
+      );
+      vi.mocked(fsSync.statSync).mockReturnValue({
+        isDirectory: () => true,
+      } as unknown as fsSync.Stats);
+      vi.mocked(fsSync.readFileSync).mockReturnValue(
+        "# wave-runtime\n**/.wave/settings.local.json\n",
+      );
+
+      ensureWaveRuntimeFilesExcluded("/repo/idempotent-test");
+
+      expect(fsSync.appendFileSync).not.toHaveBeenCalled();
+    });
+
+    it("should be a no-op when not a git repo (resolveGitDir returns null)", () => {
+      vi.mocked(fsSync.existsSync).mockReturnValue(false);
+
+      ensureWaveRuntimeFilesExcluded("/some/non-repo/path");
+
+      expect(fsSync.readFileSync).not.toHaveBeenCalled();
+      expect(fsSync.appendFileSync).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

Replace the overly broad `ensureGlobalGitIgnore()` (which wrote to the global `~/.config/git/ignore` affecting all repos on the machine) with a per-repo approach via `.git/info/exclude`, matching Claude Code's pattern.

## Changes

- **New function** `ensureWaveRuntimeFilesExcluded()` in `gitUtils.ts` — writes 4 Wave runtime file patterns (`scheduled_tasks.lock`, `scheduled_tasks.json`, `worktrees/`, `settings.local.json`) to `.git/info/exclude` with a `# wave-runtime` marker for idempotency. Uses a module-level `Set` for per-process dedup and catches all errors silently.
- **3 trigger points**: cron lock acquisition (`cronManager.ts`), worktree creation (`worktreeUtils.ts`), settings save (`configurationService.ts`)
- **Deleted** `ensureGlobalGitIgnore()` from `fileUtils.ts` and all references in `liveConfigManager.ts` (import + 2 call sites)
- **Updated** `.gitignore` with `.wave/scheduled_tasks.json` and `.wave/scheduled_tasks.lock` as baseline
- **3 tests** added in `gitUtils.test.ts`: writes patterns when marker absent, idempotent when present, no-op when not a git repo

## Test plan

- [x] `pnpm -F wave-agent-sdk build` passes
- [x] `pnpm -F wave-agent-sdk test tests/utils/gitUtils.test.ts` — 23 tests pass
- [x] `pnpm -F wave-agent-sdk test tests/utils/fileUtils.test.ts` — 4 tests pass
- [x] `pnpm -F wave-agent-sdk test tests/managers/liveConfigManager.test.ts` — 11 tests pass
- [x] `pnpm run type-check` — clean across all 3 packages
- [x] `pnpm lint` — clean