### PR TITLE
fix: align OTEL tracing with Claude Code — dual ALS, explicit span passing, token/output recording

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -814,6 +814,7 @@ export class AIManager {
       let turnDepth = turnOffset;
 
       inner: while (true) {
+        let llmSpan: import("@opentelemetry/api").Span | undefined;
         try {
           // Save session in each iteration to ensure message persistence
           await this.messageManager.saveSession();
@@ -950,15 +951,21 @@ export class AIManager {
             };
           }
 
-          startLLMRequestSpan(model || this.getModelConfig().model || "");
+          llmSpan = startLLMRequestSpan(
+            model || this.getModelConfig().model || "",
+          );
 
           const result = await aiService.callAgent(callAgentOptions);
 
           // End LLM span with usage data
-          endLLMRequestSpan({
+          endLLMRequestSpan(llmSpan, {
             model: model || this.getModelConfig().model || "",
             success: true,
             hasToolCall: !!(result.tool_calls && result.tool_calls.length > 0),
+            inputTokens: result.usage?.prompt_tokens,
+            outputTokens: result.usage?.completion_tokens,
+            cacheReadTokens: result.usage?.cache_read_input_tokens,
+            cacheCreationTokens: result.usage?.cache_creation_input_tokens,
           });
 
           const createdByStreaming = assistantMessageCreated;
@@ -1239,7 +1246,7 @@ export class AIManager {
           break inner;
         } catch (error) {
           // End LLM span with error
-          endLLMRequestSpan({
+          endLLMRequestSpan(llmSpan, {
             model: model || this.getModelConfig().model || "",
             success: false,
             error: error instanceof Error ? error.message : String(error),

--- a/packages/agent-sdk/src/managers/toolManager.ts
+++ b/packages/agent-sdk/src/managers/toolManager.ts
@@ -279,6 +279,7 @@ class ToolManager {
         endToolSpan({
           success: result.success,
           durationMs: Date.now() - toolStartTime,
+          output: result.content,
         });
         return result;
       } catch (error) {
@@ -303,6 +304,7 @@ class ToolManager {
         endToolSpan({
           success: result.success,
           durationMs: Date.now() - toolStartTime,
+          output: result.content,
         });
         return result;
       } catch (error) {

--- a/packages/agent-sdk/src/telemetry/sessionTracing.ts
+++ b/packages/agent-sdk/src/telemetry/sessionTracing.ts
@@ -2,7 +2,12 @@
  * Session Tracing -- OpenTelemetry Span Management
  *
  * Provides span creation/ending APIs for interactions, LLM requests, and tool
- * executions with AsyncLocalStorage context propagation and stale span cleanup.
+ * executions. Uses two independent AsyncLocalStorage contexts:
+ * - interactionContext: holds the interaction span for the entire turn
+ * - toolContext: holds the current tool span (cleared on end)
+ *
+ * LLM request spans do not enter any ALS; they are passed explicitly to
+ * endLLMRequestSpan, aligning with Claude Code's approach.
  */
 
 import { AsyncLocalStorage } from "node:async_hooks";
@@ -16,12 +21,8 @@ import type { LLMRequestMetadata, ToolMetadata } from "../types/telemetry.js";
 
 // -- AsyncLocalStorage for context propagation --
 
-const spanContext = new AsyncLocalStorage<Span>();
-
-// -- LIFO stacks for nested span tracking --
-
-const llmSpans: Span[] = [];
-const toolSpans: Span[] = [];
+const interactionContext = new AsyncLocalStorage<Span | undefined>();
+const toolContext = new AsyncLocalStorage<Span | undefined>();
 
 // -- Tracer accessor --
 
@@ -32,37 +33,19 @@ function getTracer() {
   return otelApi.trace.getTracer("wave");
 }
 
-// -- Helper: create child span with parent context --
-
-function startChildSpan(
-  name: string,
-  attributes: Record<string, string | number>,
-): Span | undefined {
-  const tracer = getTracer();
-  if (!tracer) return undefined;
-
-  const parent = spanContext.getStore();
-  let span: Span;
-  if (parent) {
-    const otelApi = getOTELApi()!;
-    const ctx = otelApi.trace.setSpan(otelApi.context.active(), parent);
-    span = tracer.startSpan(name, { attributes }, ctx);
-  } else {
-    span = tracer.startSpan(name, { attributes });
-  }
-  spanContext.enterWith(span);
-  return span;
-}
-
 // -- Public API --
 
 /**
  * Creates an interaction span for a user turn.
+ * The span is stored in interactionContext for the duration of the turn.
  */
 export function startInteractionSpan(
   userPrompt: string,
   sequence: number,
 ): Span | undefined {
+  const tracer = getTracer();
+  if (!tracer) return undefined;
+
   const config = getCurrentConfig();
   const attributes: Record<string, string | number> = {
     "span.type": "interaction",
@@ -72,25 +55,33 @@ export function startInteractionSpan(
   if (config?.logUserPrompts) {
     attributes.user_prompt = userPrompt;
   }
-  return startChildSpan("interaction", attributes);
+
+  const span = tracer.startSpan("interaction", { attributes });
+  interactionContext.enterWith(span);
+  return span;
 }
 
 /**
- * Ends the current active interaction span.
+ * Ends the current interaction span and clears the context.
  */
 export function endInteractionSpan(): void {
-  const span = spanContext.getStore();
+  const span = interactionContext.getStore();
   if (!span) return;
   span.end();
+  interactionContext.enterWith(undefined);
 }
 
 /**
- * Creates an LLM request span as a child of the current active span.
+ * Creates an LLM request span as a child of the interaction span.
+ * Does NOT enter any ALS — the span must be passed explicitly to endLLMRequestSpan.
  */
 export function startLLMRequestSpan(
   model: string,
   options?: { context?: string },
 ): Span | undefined {
+  const tracer = getTracer();
+  if (!tracer) return undefined;
+
   const attributes: Record<string, string> = {
     "span.type": "llm_request",
     model,
@@ -99,18 +90,26 @@ export function startLLMRequestSpan(
     attributes["llm_request.context"] = options.context;
   }
 
-  const span = startChildSpan("llm.request", attributes);
-  if (span) {
-    llmSpans.push(span);
+  const parent = interactionContext.getStore();
+  let span: Span;
+  if (parent) {
+    const otelApi = getOTELApi()!;
+    const ctx = otelApi.trace.setSpan(otelApi.context.active(), parent);
+    span = tracer.startSpan("llm.request", { attributes }, ctx);
+  } else {
+    span = tracer.startSpan("llm.request", { attributes });
   }
   return span;
 }
 
 /**
- * Ends the most recent LLM request span with response metadata.
+ * Ends an LLM request span with response metadata.
+ * The span is passed explicitly — no ALS is read or modified.
  */
-export function endLLMRequestSpan(metadata: LLMRequestMetadata): void {
-  const span = llmSpans.pop();
+export function endLLMRequestSpan(
+  span: Span | undefined,
+  metadata: LLMRequestMetadata,
+): void {
   if (!span) return;
 
   if (metadata.inputTokens != null)
@@ -129,19 +128,19 @@ export function endLLMRequestSpan(metadata: LLMRequestMetadata): void {
     span.setAttribute("has_tool_call", metadata.hasToolCall);
 
   span.end();
-
-  if (llmSpans.length > 0) {
-    spanContext.enterWith(llmSpans[llmSpans.length - 1]);
-  }
 }
 
 /**
- * Creates a tool execution span as a child of the current active span.
+ * Creates a tool execution span as a child of the interaction span.
+ * Enters toolContext with the new span.
  */
 export function startToolSpan(
   toolName: string,
   input?: unknown,
 ): Span | undefined {
+  const tracer = getTracer();
+  if (!tracer) return undefined;
+
   const config = getCurrentConfig();
   const attributes: Record<string, string | number> = {
     "span.type": "tool",
@@ -155,42 +154,40 @@ export function startToolSpan(
     attributes.tool_input = inputStr;
   }
 
-  const span = startChildSpan(`tool.${toolName}`, attributes);
-  if (span) {
-    toolSpans.push(span);
+  const parent = interactionContext.getStore();
+  let span: Span;
+  if (parent) {
+    const otelApi = getOTELApi()!;
+    const ctx = otelApi.trace.setSpan(otelApi.context.active(), parent);
+    span = tracer.startSpan(`tool.${toolName}`, { attributes }, ctx);
+  } else {
+    span = tracer.startSpan(`tool.${toolName}`, { attributes });
   }
+  toolContext.enterWith(span);
   return span;
 }
 
 /**
- * Ends a tool span with execution metadata.
+ * Ends the current tool span with execution metadata.
+ * Reads the span from toolContext, then clears it.
  */
 export function endToolSpan(metadata: ToolMetadata): void {
-  const span = toolSpans.pop();
+  const span = toolContext.getStore();
   if (!span) return;
 
   span.setAttribute("success", metadata.success);
   if (metadata.error) span.setAttribute("error", metadata.error);
   span.setAttribute("duration_ms", metadata.durationMs);
 
-  span.end();
-
-  if (toolSpans.length > 0) {
-    spanContext.enterWith(toolSpans[toolSpans.length - 1]);
+  const config = getCurrentConfig();
+  if (config?.logToolContent && metadata.output) {
+    let outputStr = metadata.output;
+    if (outputStr.length > 1000) {
+      outputStr = outputStr.substring(0, 1000);
+    }
+    span.setAttribute("tool_output", outputStr);
   }
-}
 
-/**
- * Returns the current active span from ALS context.
- */
-export function getActiveInteractionSpan(): Span | undefined {
-  return spanContext.getStore();
-}
-
-/**
- * Executes `fn` with `span` as the active context via ALS.
- * Useful for parallel tool calls that each need their own span context.
- */
-export function withSpanContext<T>(span: Span, fn: () => T): T {
-  return spanContext.run(span, fn);
+  span.end();
+  toolContext.enterWith(undefined);
 }

--- a/packages/agent-sdk/src/types/telemetry.ts
+++ b/packages/agent-sdk/src/types/telemetry.ts
@@ -68,6 +68,8 @@ export interface ToolMetadata {
   error?: string;
   /** Execution time (ms) */
   durationMs: number;
+  /** Tool output content (recorded when logToolContent is true) */
+  output?: string;
 }
 
 /** Event names for OTel structured logging */

--- a/packages/agent-sdk/tests/telemetry/sessionTracing.test.ts
+++ b/packages/agent-sdk/tests/telemetry/sessionTracing.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import type { Span } from "@opentelemetry/api";
 
 // Mock the instrumentation module
 const mockIsInitialized = vi.fn();
@@ -45,9 +44,9 @@ describe("sessionTracing", () => {
       expect(result).toBeUndefined();
     });
 
-    it("endLLMRequestSpan does nothing", () => {
+    it("endLLMRequestSpan does nothing without span", () => {
       expect(() =>
-        tracing.endLLMRequestSpan({ model: "gpt-4", success: true }),
+        tracing.endLLMRequestSpan(undefined, { model: "gpt-4", success: true }),
       ).not.toThrow();
     });
 
@@ -60,24 +59,6 @@ describe("sessionTracing", () => {
       expect(() =>
         tracing.endToolSpan({ success: true, durationMs: 100 }),
       ).not.toThrow();
-    });
-
-    it("getActiveInteractionSpan returns undefined", () => {
-      const result = tracing.getActiveInteractionSpan();
-      expect(result).toBeUndefined();
-    });
-
-    it("withSpanContext executes the function", () => {
-      let executed = false;
-      // withSpanContext needs a span object — we can't easily mock a Span,
-      // but we can verify it calls the function when given a mock span
-      const mockSpan = {
-        spanContext: () => ({ spanId: "abc" }),
-      } as unknown as Span;
-      tracing.withSpanContext(mockSpan, () => {
-        executed = true;
-      });
-      expect(executed).toBe(true);
     });
   });
 
@@ -100,7 +81,6 @@ describe("sessionTracing", () => {
 
     const mockContext = {
       active: vi.fn().mockReturnValue({}),
-      with: vi.fn((_ctx, fn: () => void) => fn()),
     };
 
     beforeEach(() => {
@@ -161,34 +141,58 @@ describe("sessionTracing", () => {
     });
 
     it("startLLMRequestSpan creates a span with model attribute", () => {
+      tracing.startInteractionSpan("Hello", 1);
       const span = tracing.startLLMRequestSpan("gpt-4o");
 
       expect(span).toBeDefined();
-      expect(mockTracer.startSpan).toHaveBeenCalledWith("llm.request", {
-        attributes: {
-          "span.type": "llm_request",
-          model: "gpt-4o",
-        },
-      });
+      expect(mockTracer.startSpan).toHaveBeenCalledWith(
+        "llm.request",
+        expect.objectContaining({
+          attributes: {
+            "span.type": "llm_request",
+            model: "gpt-4o",
+          },
+        }),
+        expect.any(Object), // context argument for parent
+      );
     });
 
     it("startLLMRequestSpan includes context option", () => {
+      tracing.startInteractionSpan("Hello", 1);
       tracing.startLLMRequestSpan("gpt-4", { context: "interaction" });
 
-      expect(mockTracer.startSpan).toHaveBeenCalledWith("llm.request", {
-        attributes: {
-          "span.type": "llm_request",
-          model: "gpt-4",
-          "llm_request.context": "interaction",
-        },
-      });
+      expect(mockTracer.startSpan).toHaveBeenCalledWith(
+        "llm.request",
+        expect.objectContaining({
+          attributes: {
+            "span.type": "llm_request",
+            model: "gpt-4",
+            "llm_request.context": "interaction",
+          },
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("LLM span does not enter ALS — interactionContext unchanged", () => {
+      tracing.startInteractionSpan("Hello", 1);
+      tracing.startLLMRequestSpan("gpt-4");
+
+      // startToolSpan after LLM span should still parent to interaction span
+      tracing.startToolSpan("Bash");
+
+      // 3 spans: interaction, llm.request, tool.Bash
+      expect(mockTracer.startSpan).toHaveBeenCalledTimes(3);
+      // The tool span call should include a context (parent = interaction)
+      const toolCall = mockTracer.startSpan.mock.calls[2];
+      expect(toolCall[2]).toBeDefined(); // context arg present
     });
 
     it("endLLMRequestSpan sets metadata attributes and ends span", () => {
       tracing.startInteractionSpan("Hello", 1);
-      tracing.startLLMRequestSpan("gpt-4");
+      const span = tracing.startLLMRequestSpan("gpt-4");
 
-      tracing.endLLMRequestSpan({
+      tracing.endLLMRequestSpan(span, {
         model: "gpt-4",
         inputTokens: 100,
         outputTokens: 50,
@@ -214,9 +218,9 @@ describe("sessionTracing", () => {
 
     it("endLLMRequestSpan handles error attribute", () => {
       tracing.startInteractionSpan("Hello", 1);
-      tracing.startLLMRequestSpan("gpt-4");
+      const span = tracing.startLLMRequestSpan("gpt-4");
 
-      tracing.endLLMRequestSpan({
+      tracing.endLLMRequestSpan(span, {
         model: "gpt-4",
         success: false,
         error: "Connection timeout",
@@ -228,186 +232,21 @@ describe("sessionTracing", () => {
       );
     });
 
-    it("startToolSpan creates a span with tool name", () => {
-      const span = tracing.startToolSpan("Bash");
-
-      expect(span).toBeDefined();
-      expect(mockTracer.startSpan).toHaveBeenCalledWith("tool.Bash", {
-        attributes: {
-          "span.type": "tool",
-          tool_name: "Bash",
-        },
-      });
-    });
-
-    it("startToolSpan includes input when logToolContent is true", () => {
-      mockGetCurrentConfig.mockReturnValue({ logToolContent: true });
-
-      tracing.startToolSpan("Write", { path: "/test", content: "hello" });
-
-      expect(mockTracer.startSpan).toHaveBeenCalledWith("tool.Write", {
-        attributes: {
-          "span.type": "tool",
-          tool_name: "Write",
-          tool_input: '{"path":"/test","content":"hello"}',
-        },
-      });
-    });
-
-    it("startToolSpan excludes input when logToolContent is false", () => {
-      mockGetCurrentConfig.mockReturnValue({ logToolContent: false });
-
-      tracing.startToolSpan("Read", { path: "/test" });
-
-      const callArgs = mockTracer.startSpan.mock.calls[0][1];
-      expect(callArgs.attributes).not.toHaveProperty("tool_input");
-    });
-
-    it("startToolSpan truncates long input to 1000 chars", () => {
-      mockGetCurrentConfig.mockReturnValue({ logToolContent: true });
-
-      const longInput = "a".repeat(2000);
-      tracing.startToolSpan("Write", longInput);
-
-      const callArgs = mockTracer.startSpan.mock.calls[0][1];
-      const inputAttr = callArgs.attributes["tool_input"] as string;
-      expect(inputAttr.length).toBe(1000);
-    });
-
-    it("endToolSpan sets success/error/duration attributes and ends", () => {
-      tracing.startInteractionSpan("Hello", 1);
-      tracing.startToolSpan("Bash");
-
-      // Need to set span.type on the mock for endToolSpan to process it
-      mockSpan.attributes = { "span.type": "tool" };
-
-      tracing.endToolSpan({
-        success: true,
-        durationMs: 150,
-      });
-
-      expect(mockSpan.setAttribute).toHaveBeenCalledWith("success", true);
-      expect(mockSpan.setAttribute).toHaveBeenCalledWith("duration_ms", 150);
-      expect(mockSpan.end).toHaveBeenCalled();
-    });
-
-    it("endToolSpan sets error attribute when present", () => {
-      tracing.startInteractionSpan("Hello", 1);
-      tracing.startToolSpan("Bash");
-      mockSpan.attributes = { "span.type": "tool" };
-
-      tracing.endToolSpan({
-        success: false,
-        error: "Command failed",
-        durationMs: 200,
-      });
-
-      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
-        "error",
-        "Command failed",
-      );
-    });
-
-    it("endToolSpan returns early if span type is not tool", () => {
-      tracing.startInteractionSpan("Hello", 1);
-      mockSpan.attributes = { "span.type": "interaction" };
-
-      const setAttrSpy = vi.spyOn(mockSpan, "setAttribute");
-      tracing.endToolSpan({
-        success: true,
-        durationMs: 100,
-      });
-
-      expect(setAttrSpy).not.toHaveBeenCalled();
-    });
-
-    it("endLLMRequestSpan restores context when multiple LLM spans exist", () => {
-      tracing.startInteractionSpan("Hello", 1);
-      tracing.startLLMRequestSpan("gpt-4");
-      tracing.startLLMRequestSpan("gpt-4o");
-
-      // End the most recent LLM span
-      tracing.endLLMRequestSpan({
-        model: "gpt-4o",
-        success: true,
-      });
-
-      // The first LLM span should still be on the stack
-      // and the active span should have been restored
-      expect(mockSpan.end).toHaveBeenCalledTimes(1);
-
-      // Now end the first LLM span
-      tracing.endLLMRequestSpan({
-        model: "gpt-4",
-        success: true,
-      });
-
-      expect(mockSpan.end).toHaveBeenCalledTimes(2);
-    });
-
-    it("endToolSpan restores context when multiple tool spans exist", () => {
-      tracing.startInteractionSpan("Hello", 1);
-      tracing.startToolSpan("Bash");
-      tracing.startToolSpan("Write");
-
-      // End the most recent tool span
-      mockSpan.attributes = { "span.type": "tool" };
-      tracing.endToolSpan({
-        success: true,
-        durationMs: 50,
-      });
-
-      expect(mockSpan.end).toHaveBeenCalledTimes(1);
-
-      // End the first tool span
-      tracing.endToolSpan({
-        success: true,
-        durationMs: 100,
-      });
-
-      expect(mockSpan.end).toHaveBeenCalledTimes(2);
-    });
-
-    it("startToolSpan with string input when logToolContent is true", () => {
-      mockGetCurrentConfig.mockReturnValue({ logToolContent: true });
-
-      tracing.startToolSpan("Write", "simple string input");
-
-      expect(mockTracer.startSpan).toHaveBeenCalledWith("tool.Write", {
-        attributes: {
-          "span.type": "tool",
-          tool_name: "Write",
-          tool_input: "simple string input",
-        },
-      });
-    });
-
-    it("startToolSpan truncates long string input to 1000 chars", () => {
-      mockGetCurrentConfig.mockReturnValue({ logToolContent: true });
-
-      const longInput = "x".repeat(2000);
-      tracing.startToolSpan("Write", longInput);
-
-      const callArgs = mockTracer.startSpan.mock.calls[0][1];
-      const inputAttr = callArgs.attributes["tool_input"] as string;
-      expect(inputAttr.length).toBe(1000);
-      expect(inputAttr).toBe("x".repeat(1000));
-    });
-
-    it("startToolSpan excludes input when logToolContent is false even with input provided", () => {
-      mockGetCurrentConfig.mockReturnValue({ logToolContent: false });
-
-      tracing.startToolSpan("Read", "some content");
-
-      const callArgs = mockTracer.startSpan.mock.calls[0][1];
-      expect(callArgs.attributes).not.toHaveProperty("tool_input");
+    it("endLLMRequestSpan with undefined span does nothing", () => {
+      expect(() =>
+        tracing.endLLMRequestSpan(undefined, {
+          model: "gpt-4",
+          success: true,
+        }),
+      ).not.toThrow();
+      expect(mockSpan.end).not.toHaveBeenCalled();
     });
 
     it("endLLMRequestSpan with minimal metadata", () => {
       tracing.startInteractionSpan("Hello", 1);
-      tracing.startLLMRequestSpan("gpt-4");
+      const span = tracing.startLLMRequestSpan("gpt-4");
 
-      tracing.endLLMRequestSpan({
+      tracing.endLLMRequestSpan(span, {
         model: "gpt-4",
         success: true,
       });
@@ -423,10 +262,257 @@ describe("sessionTracing", () => {
       );
     });
 
+    it("startToolSpan creates a span with tool name", () => {
+      tracing.startInteractionSpan("Hello", 1);
+      const span = tracing.startToolSpan("Bash");
+
+      expect(span).toBeDefined();
+      expect(mockTracer.startSpan).toHaveBeenCalledWith(
+        "tool.Bash",
+        expect.objectContaining({
+          attributes: {
+            "span.type": "tool",
+            tool_name: "Bash",
+          },
+        }),
+        expect.any(Object), // context argument for parent
+      );
+    });
+
+    it("startToolSpan includes input when logToolContent is true", () => {
+      mockGetCurrentConfig.mockReturnValue({ logToolContent: true });
+      tracing.startInteractionSpan("Hello", 1);
+
+      tracing.startToolSpan("Write", { path: "/test", content: "hello" });
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith(
+        "tool.Write",
+        expect.objectContaining({
+          attributes: {
+            "span.type": "tool",
+            tool_name: "Write",
+            tool_input: '{"path":"/test","content":"hello"}',
+          },
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("startToolSpan excludes input when logToolContent is false", () => {
+      mockGetCurrentConfig.mockReturnValue({ logToolContent: false });
+      tracing.startInteractionSpan("Hello", 1);
+
+      tracing.startToolSpan("Read", { path: "/test" });
+
+      const callArgs = mockTracer.startSpan.mock.calls[1][1];
+      expect(callArgs.attributes).not.toHaveProperty("tool_input");
+    });
+
+    it("startToolSpan truncates long input to 1000 chars", () => {
+      mockGetCurrentConfig.mockReturnValue({ logToolContent: true });
+      tracing.startInteractionSpan("Hello", 1);
+
+      const longInput = "a".repeat(2000);
+      tracing.startToolSpan("Write", longInput);
+
+      const callArgs = mockTracer.startSpan.mock.calls[1][1];
+      const inputAttr = callArgs.attributes["tool_input"] as string;
+      expect(inputAttr.length).toBe(1000);
+    });
+
+    it("startToolSpan with string input when logToolContent is true", () => {
+      mockGetCurrentConfig.mockReturnValue({ logToolContent: true });
+      tracing.startInteractionSpan("Hello", 1);
+
+      tracing.startToolSpan("Write", "simple string input");
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith(
+        "tool.Write",
+        expect.objectContaining({
+          attributes: {
+            "span.type": "tool",
+            tool_name: "Write",
+            tool_input: "simple string input",
+          },
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("startToolSpan truncates long string input to 1000 chars", () => {
+      mockGetCurrentConfig.mockReturnValue({ logToolContent: true });
+      tracing.startInteractionSpan("Hello", 1);
+
+      const longInput = "x".repeat(2000);
+      tracing.startToolSpan("Write", longInput);
+
+      const callArgs = mockTracer.startSpan.mock.calls[1][1];
+      const inputAttr = callArgs.attributes["tool_input"] as string;
+      expect(inputAttr.length).toBe(1000);
+      expect(inputAttr).toBe("x".repeat(1000));
+    });
+
+    it("startToolSpan excludes input when logToolContent is false even with input provided", () => {
+      mockGetCurrentConfig.mockReturnValue({ logToolContent: false });
+      tracing.startInteractionSpan("Hello", 1);
+
+      tracing.startToolSpan("Read", "some content");
+
+      const callArgs = mockTracer.startSpan.mock.calls[1][1];
+      expect(callArgs.attributes).not.toHaveProperty("tool_input");
+    });
+
+    it("endToolSpan sets success/error/duration attributes and ends", () => {
+      tracing.startInteractionSpan("Hello", 1);
+      tracing.startToolSpan("Bash");
+
+      tracing.endToolSpan({
+        success: true,
+        durationMs: 150,
+      });
+
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith("success", true);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith("duration_ms", 150);
+      expect(mockSpan.end).toHaveBeenCalled();
+    });
+
+    it("endToolSpan sets error attribute when present", () => {
+      tracing.startInteractionSpan("Hello", 1);
+      tracing.startToolSpan("Bash");
+
+      tracing.endToolSpan({
+        success: false,
+        error: "Command failed",
+        durationMs: 200,
+      });
+
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        "error",
+        "Command failed",
+      );
+    });
+
+    it("endToolSpan records tool_output when logToolContent is true", () => {
+      mockGetCurrentConfig.mockReturnValue({ logToolContent: true });
+      tracing.startInteractionSpan("Hello", 1);
+      tracing.startToolSpan("Bash");
+
+      tracing.endToolSpan({
+        success: true,
+        durationMs: 100,
+        output: "command output here",
+      });
+
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        "tool_output",
+        "command output here",
+      );
+    });
+
+    it("endToolSpan excludes tool_output when logToolContent is false", () => {
+      mockGetCurrentConfig.mockReturnValue({ logToolContent: false });
+      tracing.startInteractionSpan("Hello", 1);
+      tracing.startToolSpan("Bash");
+
+      tracing.endToolSpan({
+        success: true,
+        durationMs: 100,
+        output: "command output here",
+      });
+
+      expect(mockSpan.setAttribute).not.toHaveBeenCalledWith(
+        "tool_output",
+        expect.anything(),
+      );
+    });
+
+    it("endToolSpan truncates tool_output to 1000 chars", () => {
+      mockGetCurrentConfig.mockReturnValue({ logToolContent: true });
+      tracing.startInteractionSpan("Hello", 1);
+      tracing.startToolSpan("Bash");
+
+      const longOutput = "y".repeat(2000);
+      tracing.endToolSpan({
+        success: true,
+        durationMs: 100,
+        output: longOutput,
+      });
+
+      const outputCall = mockSpan.setAttribute.mock.calls.find(
+        (c) => c[0] === "tool_output",
+      );
+      expect(outputCall).toBeDefined();
+      expect((outputCall![1] as string).length).toBe(1000);
+    });
+
+    it("endToolSpan does not record tool_output when output is undefined", () => {
+      mockGetCurrentConfig.mockReturnValue({ logToolContent: true });
+      tracing.startInteractionSpan("Hello", 1);
+      tracing.startToolSpan("Bash");
+
+      tracing.endToolSpan({
+        success: true,
+        durationMs: 100,
+      });
+
+      expect(mockSpan.setAttribute).not.toHaveBeenCalledWith(
+        "tool_output",
+        expect.anything(),
+      );
+    });
+
+    it("tool span parent is always interaction span", () => {
+      tracing.startInteractionSpan("Hello", 1);
+      tracing.startToolSpan("Bash");
+
+      // Tool span should have a context arg (parent = interaction)
+      const toolCall = mockTracer.startSpan.mock.calls[1];
+      expect(toolCall[2]).toBeDefined();
+      expect(mockTrace.setSpan).toHaveBeenCalledWith(
+        mockContext.active(),
+        mockSpan, // The interaction span (mockSpan is returned by startSpan)
+      );
+    });
+
+    it("tool span clears toolContext after end", () => {
+      tracing.startInteractionSpan("Hello", 1);
+      tracing.startToolSpan("Bash");
+      tracing.endToolSpan({ success: true, durationMs: 50 });
+
+      // Calling endToolSpan again should be a no-op (no second end)
+      tracing.endToolSpan({ success: true, durationMs: 100 });
+      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+    });
+
+    it("serial LLM→Tool→LLM: all parents are interaction span", () => {
+      tracing.startInteractionSpan("Hello", 1);
+
+      // LLM request 1
+      const llm1 = tracing.startLLMRequestSpan("gpt-4");
+      tracing.endLLMRequestSpan(llm1!, { model: "gpt-4", success: true });
+
+      // Tool call
+      tracing.startToolSpan("Bash");
+      tracing.endToolSpan({ success: true, durationMs: 10 });
+
+      // LLM request 2 — parent should still be interaction span
+      const llm2 = tracing.startLLMRequestSpan("gpt-4");
+      tracing.endLLMRequestSpan(llm2!, { model: "gpt-4", success: true });
+
+      // All child spans (llm.request, tool.Bash, llm.request) should have
+      // been created with a parent context
+      expect(mockTracer.startSpan).toHaveBeenCalledTimes(4); // 1 interaction + 3 children
+      // Each child call should have a context argument (3rd arg)
+      for (let i = 1; i < 4; i++) {
+        expect(mockTracer.startSpan.mock.calls[i][2]).toBeDefined();
+      }
+
+      tracing.endInteractionSpan();
+    });
+
     it("endToolSpan with error attribute", () => {
       tracing.startInteractionSpan("Hello", 1);
       tracing.startToolSpan("Bash");
-      mockSpan.attributes = { "span.type": "tool" };
 
       tracing.endToolSpan({
         success: false,
@@ -440,31 +526,6 @@ describe("sessionTracing", () => {
         "Exit code 1",
       );
       expect(mockSpan.setAttribute).toHaveBeenCalledWith("duration_ms", 300);
-    });
-  });
-
-  describe("withSpanContext", () => {
-    beforeEach(() => {
-      mockIsInitialized.mockReturnValue(true);
-    });
-
-    it("executes fn within the span context and returns result", () => {
-      const mockSpan = {
-        spanContext: () => ({ spanId: "abc" }),
-      } as unknown as Span;
-      const result = tracing.withSpanContext(mockSpan, () => "test-value");
-      expect(result).toBe("test-value");
-    });
-
-    it("executes fn even when it throws", () => {
-      const mockSpan = {
-        spanContext: () => ({ spanId: "abc" }),
-      } as unknown as Span;
-      expect(() => {
-        tracing.withSpanContext(mockSpan, () => {
-          throw new Error("test error");
-        });
-      }).toThrow("test error");
     });
   });
 });


### PR DESCRIPTION
## Summary

Align Wave's OTEL tracing architecture with Claude Code to fix two issues:
1. **Span infinite nesting** — / didn't restore the interaction span, causing subsequent spans to attach under already-ended spans
2. **Insufficient trace data** — tool output, LLM token usage were not recorded

## Changes

###  — Refactored span context management
- Replaced single ALS () + two LIFO stacks (, ) with two independent ALS:
  -  — holds interaction span for the entire turn, never overwritten by child spans
  -  — holds current tool span, cleared on 
-  now reads parent from  but does NOT enter any ALS — the span is returned for explicit passing
-  now takes an explicit  first arg
-  reads parent from  (always the interaction span)
- Deleted dead code: , , , ,  helper

###  — Type update
- Added  to 

###  — Pass LLM span + token data
- Declares  before inner try block
- Passes span explicitly to  with token usage data (, , , ) on success
- Passes error info on failure path

###  — Pass tool output
- Passes  on success-path  calls

###  — Updated tests
- Removed tests for deleted APIs (, , LIFO stack restoration)
- Added tests for new architecture: ALS independence, explicit span passing, serial LLM→Tool→LLM parent chain,  recording/truncation,  clearing

## Verification
- ✅ SDK build passes
- ✅ 35/35 sessionTracing tests pass
- ✅ Type-check passes across all packages