### PR TITLE
fix: pass MCP tool result images to tool block in aiManager

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -1654,6 +1654,7 @@ export class AIManager {
         shortResult: toolResult.shortResult,
         isManuallyBackgrounded: toolResult.isManuallyBackgrounded,
         startLineNumber: toolResult.startLineNumber,
+        images: toolResult.images,
         timestamp: Date.now(),
       });
 

--- a/packages/agent-sdk/src/managers/mcpManager.ts
+++ b/packages/agent-sdk/src/managers/mcpManager.ts
@@ -848,9 +848,16 @@ export class McpManager {
         textContent.push(String(result.content));
       }
 
+      const textContentStr =
+        textContent.length > 0
+          ? textContent.join("\n")
+          : images.length > 0
+            ? `Tool returned ${images.length} image(s).`
+            : "No content";
+
       return {
         success: true,
-        content: textContent.length > 0 ? textContent.join("\n") : "No content",
+        content: textContentStr,
         images: images.length > 0 ? images : undefined,
         serverName,
       };

--- a/packages/agent-sdk/tests/managers/mcpManager.test.ts
+++ b/packages/agent-sdk/tests/managers/mcpManager.test.ts
@@ -1220,7 +1220,7 @@ describe("McpManager", () => {
 
       expect(result).toEqual({
         success: true,
-        content: "No content",
+        content: "Tool returned 1 image(s).",
         images: [
           {
             data: "only_image_data",


### PR DESCRIPTION
## Problem

MCP tools that return images (e.g. Figma `get_screenshot`) had their image data silently dropped — the AI never received the screenshot.

## Root Cause

1. **`aiManager.ts` (core bug)**: After tool execution, `updateToolBlock()` was called without forwarding `toolResult.images`, so image data from MCP tools was discarded before reaching the message store.
2. **`mcpManager.ts` (minor)**: When an MCP tool returned only images (no text), `content` was set to `"No content"`, which was unhelpful for the model.

## Fix

- Pass `images: toolResult.images` in the `updateToolBlock` call in `aiManager.ts`
- Return `"Tool returned N image(s)."` as `content` when an MCP tool returns only images
- Updated the corresponding unit test

## Testing

- All 3160 agent-sdk tests pass
- Verified via raw MCP client that Figma `get_screenshot` correctly returns base64 PNG image data