### PR TITLE
feat: align compaction model with Claude Code — append-only session files

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -492,7 +492,7 @@ export class AIManager {
       );
 
       // 7. Execute message reconstruction
-      this.messageManager.compactMessagesAndUpdateSession(
+      await this.messageManager.compactMessagesAndUpdateSession(
         enhancedSummary,
         compactUsage,
       );

--- a/packages/agent-sdk/src/managers/messageManager.ts
+++ b/packages/agent-sdk/src/managers/messageManager.ts
@@ -94,8 +94,6 @@ export interface MessageManagerOptions {
 export class MessageManager {
   // Private state properties
   private sessionId: string;
-  private rootSessionId: string;
-  private parentSessionId?: string;
   private messages: Message[];
   private latestTotalTokens: number;
   private workdir: string;
@@ -118,7 +116,6 @@ export class MessageManager {
     options: MessageManagerOptions,
   ) {
     this.sessionId = generateSessionId();
-    this.rootSessionId = this.sessionId;
     this.messages = [];
     this.latestTotalTokens = 0;
     this.workdir = options.workdir;
@@ -152,11 +149,7 @@ export class MessageManager {
   }
 
   public getRootSessionId(): string {
-    return this.rootSessionId;
-  }
-
-  public getParentSessionId(): string | undefined {
-    return this.parentSessionId;
+    return this.sessionId;
   }
 
   public getMessages(): Message[] {
@@ -358,8 +351,6 @@ export class MessageManager {
         unsavedMessages,
         this.workdir,
         this.sessionType,
-        this.rootSessionId,
-        this.parentSessionId,
       );
 
       // Update the saved message count
@@ -383,7 +374,6 @@ export class MessageManager {
   public clearMessages(): void {
     this.setMessages([]);
     const newSessionId = generateSessionId();
-    this.rootSessionId = newSessionId;
     this.setSessionId(newSessionId);
     this.setlatestTotalTokens(0);
     this.savedMessageCount = 0; // Reset saved message count
@@ -399,8 +389,6 @@ export class MessageManager {
   // Initialize state from session data
   public initializeFromSession(sessionData: SessionData): void {
     this.setSessionId(sessionData.id);
-    this.rootSessionId = sessionData.rootSessionId || sessionData.id;
-    this.parentSessionId = sessionData.parentSessionId;
     this.setMessages([...sessionData.messages]);
     this.setlatestTotalTokens(sessionData.metadata.latestTotalTokens);
 
@@ -563,12 +551,13 @@ export class MessageManager {
   }
 
   /**
-   * Compact messages and update session, delete compacted messages, only keep compacted messages and last 3 messages
+   * Compact messages and update session — append compact message to same file (append-only).
+   * After compaction, in-memory messages are [compactMessage, ...lastThreeMessages].
    */
-  public compactMessagesAndUpdateSession(
+  public async compactMessagesAndUpdateSession(
     compactedContent: string,
     usage?: Usage,
-  ): void {
+  ): Promise<void> {
     // Get last 2 API rounds to preserve (structurally safe boundary)
     const lastThreeMessages = getLastApiRounds(this.messages, 2);
 
@@ -580,23 +569,27 @@ export class MessageManager {
         {
           type: "compact",
           content: compactedContent,
-          sessionId: this.sessionId,
         },
       ],
       timestamp: new Date().toISOString(),
       ...(usage && { usage }),
     };
 
-    // Build new message array: keep the compacted message and last 3 messages
+    // Build new message array: keep the compacted message and last messages
     const newMessages: Message[] = [compactMessage, ...lastThreeMessages];
 
-    // Update sessionId and parentSessionId
-    const oldSessionId = this.sessionId;
-    this.setSessionId(generateSessionId());
-    this.parentSessionId = oldSessionId;
+    // APPEND to the same session file (append-only, like Claude Code)
+    const { appendMessages } = await import("../services/session.js");
+    await appendMessages(
+      this.sessionId,
+      newMessages,
+      this.workdir,
+      this.sessionType,
+    );
 
-    // Set new message list
+    // Update in-memory state
     this.setMessages(newMessages);
+    this.savedMessageCount = newMessages.length;
 
     // Clear and rebuild loaded rule IDs from remaining meta messages
     this.clearLoadedRuleIds();
@@ -911,101 +904,26 @@ export class MessageManager {
     index: number,
     reversionManager?: import("./reversionManager.js").ReversionManager,
   ): Promise<void> {
-    const { messages, sessionIds } = await this.getFullMessageThread();
+    const { messages } = await this.getFullMessageThread();
 
     if (index < 0 || index >= messages.length) {
       throw new Error(`Invalid message index: ${index}`);
     }
 
-    // Find which session the index belongs to
-    let targetSessionId = this.sessionId;
-    let targetIndexInSession = index;
-
-    // We need to be careful here because loadFullMessageThread might have removed "compact" blocks
-    // Let's re-calculate based on the actual messages returned.
-    // Actually, it's easier to just load sessions one by one again or keep track of counts.
-
-    // For simplicity, let's assume we want to truncate the WHOLE thread.
-    // If the index is in a previous session, we need to:
-    // 1. Load that session.
-    // 2. Truncate it.
-    // 3. Make it the current session.
-    // 4. Delete/Invalidate subsequent sessions.
-
-    // To correctly map 'index' to a session, we need to know the message count of each session
-    // as they appear in the concatenated 'messages' array.
-
-    let remainingIndex = index;
-    const { loadSessionFromJsonl } = await import("../services/session.js");
-
-    for (const sid of sessionIds) {
-      const sessionData = await loadSessionFromJsonl(sid, this.workdir);
-      if (!sessionData) continue;
-
-      const sessionMessages = sessionData.messages;
-      // If this is not the first session in the thread, it might have a compact block at the start
-      // that was removed in getFullMessageThread.
-      const hasCompactBlock = sessionMessages[0]?.blocks.some(
-        (b) => b.type === "compact",
-      );
-      const effectiveMessages =
-        hasCompactBlock && sid !== sessionIds[0]
-          ? sessionMessages.slice(1)
-          : sessionMessages;
-
-      if (remainingIndex < effectiveMessages.length) {
-        targetSessionId = sid;
-        targetIndexInSession = hasCompactBlock
-          ? remainingIndex + 1
-          : remainingIndex;
-        break;
-      }
-      remainingIndex -= effectiveMessages.length;
-    }
-
-    // Load the target session to perform truncation
-    const targetSessionData = await loadSessionFromJsonl(
-      targetSessionId,
-      this.workdir,
-    );
-    if (!targetSessionData)
-      throw new Error(`Target session ${targetSessionId} not found`);
-
-    // Identify messages to be removed (from the whole thread)
+    const newMessages = messages.slice(0, index);
     const messagesToRemove = messages.slice(index);
     const messageIdsToRemove = messagesToRemove
       .map((m) => m.id as string)
       .filter((id) => !!id);
 
-    // Revert file changes if manager is provided
     if (reversionManager && messageIdsToRemove.length > 0) {
       await reversionManager.revertTo(messageIdsToRemove, messages);
     }
 
-    // Truncate messages in the target session
-    const newMessagesInSession = targetSessionData.messages.slice(
-      0,
-      targetIndexInSession,
-    );
-
-    // Update target session file
-    this.sessionId = targetSessionId;
-    this.rootSessionId = targetSessionData.rootSessionId || targetSessionId;
-    this.parentSessionId = targetSessionData.parentSessionId;
-    this.transcriptPath = this.computeTranscriptPath();
-
-    await this.rewriteSessionFile(newMessagesInSession);
-
-    // Update in-memory messages to the truncated session messages
-    // We do NOT include ancestor messages here to avoid exceeding context limits.
-    // The 'compact' block at the start of the session (if any) already summarizes them.
-    this.setMessages(newMessagesInSession);
-
-    // Update saved message count
-    this.savedMessageCount = newMessagesInSession.length;
-
-    // Notify session ID change if it changed
-    this.callbacks.onSessionIdChange?.(this.sessionId);
+    // Rewrite file with truncated messages
+    await this.rewriteSessionFile(newMessages);
+    this.setMessages(newMessages);
+    this.savedMessageCount = newMessages.length;
   }
 
   /**

--- a/packages/agent-sdk/src/services/initializationService.ts
+++ b/packages/agent-sdk/src/services/initializationService.ts
@@ -326,9 +326,7 @@ export class InitializationService {
         messageManager.initializeFromSession(sessionToRestore);
 
         // Update task manager with the root session ID to ensure continuity across compactions
-        taskManager.setTaskListId(
-          sessionToRestore.rootSessionId || sessionToRestore.id,
-        );
+        taskManager.setTaskListId(sessionToRestore.id);
 
         // After session is initialized, load tasks for the session
         const tasks = await taskManager.listTasks();

--- a/packages/agent-sdk/src/services/interactionService.ts
+++ b/packages/agent-sdk/src/services/interactionService.ts
@@ -166,7 +166,7 @@ export class InteractionService {
     messageManager.initializeFromSession(sessionData);
 
     // Update task manager with the root session ID to ensure continuity across compactions
-    taskManager.setTaskListId(sessionData.rootSessionId || sessionData.id);
+    taskManager.setTaskListId(sessionData.id);
 
     // 7. Load tasks for the restored session
     const tasks = await taskManager.listTasks();

--- a/packages/agent-sdk/src/services/session.ts
+++ b/packages/agent-sdk/src/services/session.ts
@@ -28,8 +28,6 @@ import { getMessageContent } from "../utils/messageOperations.js";
 
 export interface SessionData {
   id: string;
-  rootSessionId?: string;
-  parentSessionId?: string;
   messages: Message[];
   metadata: {
     workdir: string;
@@ -40,8 +38,6 @@ export interface SessionData {
 
 export interface SessionMetadata {
   id: string;
-  rootSessionId?: string;
-  parentSessionId?: string;
   sessionType: "main" | "subagent";
   subagentType?: string;
   workdir: string;
@@ -49,17 +45,6 @@ export interface SessionMetadata {
   lastActiveAt: Date;
   latestTotalTokens: number;
   firstMessage?: string;
-}
-
-export interface SessionIndex {
-  sessions: Record<
-    string,
-    Omit<SessionMetadata, "id" | "lastActiveAt" | "createdAt"> & {
-      lastActiveAt: string;
-      createdAt: string;
-    }
-  >;
-  lastUpdated: string;
 }
 
 /**
@@ -82,40 +67,6 @@ export function generateSubagentFilename(sessionId: string): string {
 // Constants
 export const SESSION_DIR = join(homedir(), ".wave", "projects");
 const MAX_SESSION_AGE_DAYS = 14;
-const SESSION_INDEX_FILENAME = "sessions-index.json";
-
-/**
- * Update the session index for a project directory
- */
-async function updateSessionIndex(
-  projectDirPath: string,
-  metadata: SessionMetadata,
-): Promise<void> {
-  const indexPath = join(projectDirPath, SESSION_INDEX_FILENAME);
-  let index: SessionIndex = {
-    sessions: {},
-    lastUpdated: new Date().toISOString(),
-  };
-
-  try {
-    const content = await fs.readFile(indexPath, "utf8");
-    index = JSON.parse(content);
-  } catch {
-    // Index doesn't exist or is invalid, start fresh
-  }
-
-  const { id, ...rest } = metadata;
-  index.sessions[id] = {
-    ...rest,
-    createdAt: metadata.createdAt.toISOString(),
-    lastActiveAt: metadata.lastActiveAt.toISOString(),
-    firstMessage: metadata.firstMessage || index.sessions[id]?.firstMessage,
-    parentSessionId: metadata.parentSessionId,
-  };
-  index.lastUpdated = new Date().toISOString();
-
-  await fs.writeFile(indexPath, JSON.stringify(index, null, 2), "utf8");
-}
 
 /**
  * Ensure session directory exists
@@ -201,8 +152,6 @@ export async function appendMessages(
   newMessages: Message[],
   workdir: string,
   sessionType: "main" | "subagent" = "main",
-  rootSessionId?: string,
-  parentSessionId?: string,
 ): Promise<void> {
   // Do not save session files in test environment
   if (process.env.NODE_ENV === "test") {
@@ -234,50 +183,6 @@ export async function appendMessages(
 
   await jsonlHandler.append(filePath, newMessages, {
     atomic: false,
-  });
-
-  // Update index
-  const encoder = new PathEncoder();
-  const projectDir = await encoder.getProjectDirectory(workdir, SESSION_DIR);
-  const lastMessage = newMessages[newMessages.length - 1];
-
-  // Get first message content and createdAt from existing index
-  let firstMessage: string | undefined;
-  let createdAt: Date | undefined;
-  try {
-    const indexPath = join(projectDir.encodedPath, SESSION_INDEX_FILENAME);
-    const content = await fs.readFile(indexPath, "utf8");
-    const index = JSON.parse(content) as SessionIndex;
-    if (!index.sessions[sessionId]?.firstMessage) {
-      firstMessage =
-        (await getFirstMessageContent(sessionId, workdir)) || undefined;
-    }
-    if (index.sessions[sessionId]?.createdAt) {
-      createdAt = new Date(index.sessions[sessionId].createdAt);
-    }
-  } catch {
-    // If index doesn't exist, this might be the first message
-    firstMessage =
-      (await getFirstMessageContent(sessionId, workdir)) || undefined;
-  }
-
-  // Derive createdAt from session ID if not in index
-  if (!createdAt) {
-    createdAt = new Date();
-  }
-
-  await updateSessionIndex(projectDir.encodedPath, {
-    id: sessionId,
-    rootSessionId,
-    parentSessionId,
-    sessionType,
-    workdir,
-    createdAt,
-    lastActiveAt: new Date(lastMessage.timestamp),
-    latestTotalTokens: lastMessage.usage
-      ? extractLatestTotalTokens([lastMessage])
-      : 0,
-    firstMessage,
   });
 }
 
@@ -314,34 +219,25 @@ export async function loadSessionFromJsonl(
       throw error;
     }
 
-    const messages = await jsonlHandler.read(filePath);
+    const allMessages = await jsonlHandler.read(filePath);
+
+    // Find the last compact boundary — only return messages from there forward
+    let lastCompactIndex = -1;
+    for (let i = allMessages.length - 1; i >= 0; i--) {
+      if (allMessages[i].blocks?.some((b) => b.type === "compact")) {
+        lastCompactIndex = i;
+        break;
+      }
+    }
+    const messages =
+      lastCompactIndex >= 0 ? allMessages.slice(lastCompactIndex) : allMessages;
 
     // Extract metadata from messages
     const lastMessage =
       messages.length > 0 ? messages[messages.length - 1] : null;
 
-    // Try to get rootSessionId and parentSessionId from index
-    let rootSessionId: string | undefined;
-    let parentSessionId: string | undefined;
-    try {
-      const encoder = new PathEncoder();
-      const projectDir = await encoder.getProjectDirectory(
-        workdir,
-        SESSION_DIR,
-      );
-      const indexPath = join(projectDir.encodedPath, SESSION_INDEX_FILENAME);
-      const indexContent = await fs.readFile(indexPath, "utf8");
-      const index = JSON.parse(indexContent) as SessionIndex;
-      rootSessionId = index.sessions[sessionId]?.rootSessionId;
-      parentSessionId = index.sessions[sessionId]?.parentSessionId;
-    } catch {
-      // Ignore index errors
-    }
-
     const sessionData: SessionData = {
       id: sessionId,
-      rootSessionId: rootSessionId || sessionId,
-      parentSessionId,
       messages,
       metadata: {
         workdir,
@@ -435,32 +331,8 @@ export async function listSessionsFromJsonl(
 
     const projectDir = await encoder.getProjectDirectory(workdir, baseDir);
 
-    // Try to read from index first
-    const indexPath = join(projectDir.encodedPath, SESSION_INDEX_FILENAME);
     const sevenDaysAgo = new Date();
     sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
-
-    try {
-      const indexContent = await fs.readFile(indexPath, "utf8");
-      const index = JSON.parse(indexContent) as SessionIndex;
-      const sessions: SessionMetadata[] = Object.entries(index.sessions)
-        .filter(([, meta]) => {
-          const lastActiveAt = new Date(meta.lastActiveAt);
-          return meta.sessionType === "main" && lastActiveAt >= sevenDaysAgo;
-        })
-        .map(([id, meta]) => ({
-          id,
-          ...meta,
-          createdAt: new Date(meta.createdAt),
-          lastActiveAt: new Date(meta.lastActiveAt),
-        }));
-
-      return sessions.sort(
-        (a, b) => b.lastActiveAt.getTime() - a.lastActiveAt.getTime(),
-      );
-    } catch {
-      // Fallback to manual listing if index fails
-    }
 
     let files: string[];
     try {
@@ -521,7 +393,7 @@ export async function listSessionsFromJsonl(
         const sessionMeta: SessionMetadata = {
           id: sessionId,
           sessionType: "main",
-          subagentType: undefined, // No longer stored in metadata
+          subagentType: undefined,
           workdir: projectDir.originalPath,
           createdAt: new Date(),
           lastActiveAt,
@@ -530,7 +402,7 @@ export async function listSessionsFromJsonl(
             : 0,
         };
 
-        // Try to get first message content for the fallback/rebuild case
+        // Try to get first message content for display
         try {
           const firstContent = await getFirstMessageContent(sessionId, workdir);
           if (firstContent) {
@@ -548,30 +420,9 @@ export async function listSessionsFromJsonl(
     }
 
     // Sort by last active time (most recently active first)
-    const sortedSessions = sessions.sort(
+    return sessions.sort(
       (a, b) => b.lastActiveAt.getTime() - a.lastActiveAt.getTime(),
     );
-
-    // Rebuild index if we had to fall back
-    try {
-      const index: SessionIndex = {
-        sessions: {},
-        lastUpdated: new Date().toISOString(),
-      };
-      for (const session of sessions) {
-        const { id, ...rest } = session;
-        index.sessions[id] = {
-          ...rest,
-          createdAt: session.createdAt.toISOString(),
-          lastActiveAt: session.lastActiveAt.toISOString(),
-        };
-      }
-      await fs.writeFile(indexPath, JSON.stringify(index, null, 2), "utf8");
-    } catch (error) {
-      logger.warn(`Failed to rebuild session index for ${workdir}:`, error);
-    }
-
-    return sortedSessions;
   } catch (error) {
     throw new Error(`Failed to list sessions: ${error}`);
   }
@@ -607,28 +458,52 @@ export async function listAllSessions(): Promise<SessionMetadata[]> {
           continue;
         }
 
-        // Try to read from index first
-        const indexPath = join(projectPath, SESSION_INDEX_FILENAME);
-        try {
-          const indexContent = await fs.readFile(indexPath, "utf8");
-          const index = JSON.parse(indexContent) as SessionIndex;
-          for (const [id, meta] of Object.entries(index.sessions)) {
-            const lastActiveAt = new Date(meta.lastActiveAt);
-            if (meta.sessionType === "main" && lastActiveAt >= sevenDaysAgo) {
-              allSessions.push({
-                id,
-                ...meta,
-                createdAt: new Date(meta.createdAt),
-                lastActiveAt,
-              });
-            }
+        // Scan .jsonl files in the project directory
+        const files = await fs.readdir(projectPath);
+
+        for (const file of files) {
+          if (!file.endsWith(".jsonl") || file.startsWith("subagent-")) {
+            continue;
           }
-        } catch {
-          // If index fails, we skip this project directory
-          // In the future, we could scan for .jsonl files here
+
+          try {
+            const filePath = join(projectPath, file);
+            const uuidMatch = file.match(
+              /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/,
+            );
+            if (!uuidMatch) continue;
+
+            const sessionId = uuidMatch[1];
+            const jsonlHandler = new JsonlHandler();
+            const lastMessage = await jsonlHandler.getLastMessage(filePath);
+
+            let lastActiveAt: Date;
+            if (lastMessage) {
+              lastActiveAt = new Date(lastMessage.timestamp);
+            } else {
+              const stats = await fs.stat(filePath);
+              lastActiveAt = stats.mtime;
+            }
+
+            if (lastActiveAt < sevenDaysAgo) continue;
+
+            allSessions.push({
+              id: sessionId,
+              sessionType: "main" as const,
+              subagentType: undefined,
+              workdir: projectDirName,
+              createdAt: new Date(),
+              lastActiveAt,
+              latestTotalTokens: lastMessage?.usage
+                ? extractLatestTotalTokens([lastMessage])
+                : 0,
+            });
+          } catch {
+            continue;
+          }
         }
       } catch {
-        // Skip if stat fails
+        // Skip if stat/readdir fails
       }
     }
 
@@ -677,38 +552,6 @@ export async function cleanupExpiredSessionsFromJsonl(
         if (fileAge > maxAge) {
           await fs.unlink(filePath);
           deletedCount++;
-
-          // Remove from index if it exists
-          try {
-            const indexPath = join(
-              projectDir.encodedPath,
-              SESSION_INDEX_FILENAME,
-            );
-            const indexContent = await fs.readFile(indexPath, "utf8");
-            const index = JSON.parse(indexContent) as SessionIndex;
-            const uuidMatch = file.match(
-              /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/,
-            );
-            const subagentMatch = file.match(
-              /^subagent-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/,
-            );
-            const sessionId = uuidMatch
-              ? uuidMatch[1]
-              : subagentMatch
-                ? subagentMatch[1]
-                : null;
-
-            if (sessionId && index.sessions[sessionId]) {
-              delete index.sessions[sessionId];
-              await fs.writeFile(
-                indexPath,
-                JSON.stringify(index, null, 2),
-                "utf8",
-              );
-            }
-          } catch {
-            // Ignore index update errors during cleanup
-          }
         }
       } catch {
         // Skip failed operations and continue processing other files
@@ -897,21 +740,6 @@ export async function deleteSession(
       throw error;
     }
   }
-
-  // Also remove from index
-  try {
-    const encoder = new PathEncoder();
-    const projectDir = await encoder.getProjectDirectory(workdir, SESSION_DIR);
-    const indexPath = join(projectDir.encodedPath, SESSION_INDEX_FILENAME);
-    const indexContent = await fs.readFile(indexPath, "utf8");
-    const index = JSON.parse(indexContent) as SessionIndex;
-    if (index.sessions[sessionId]) {
-      delete index.sessions[sessionId];
-      await fs.writeFile(indexPath, JSON.stringify(index, null, 2), "utf8");
-    }
-  } catch {
-    // Ignore index errors
-  }
 }
 
 /**
@@ -995,7 +823,9 @@ export async function handleSessionRestoration(
 }
 
 /**
- * Load the full message thread by following parentSessionId links
+ * Load the full message thread for a session.
+ * With append-only compaction, all messages are in a single file.
+ * Returns the active messages (post-compact boundary).
  * @param currentSessionId - The ID of the current session
  * @param workdir - Working directory for the session
  * @returns Promise that resolves to an array of all messages in the thread
@@ -1004,36 +834,7 @@ export async function loadFullMessageThread(
   currentSessionId: string,
   workdir: string,
 ): Promise<{ messages: Message[]; sessionIds: string[] }> {
-  const sessionIds: string[] = [];
-  let currentId: string | undefined = currentSessionId;
-  const allMessages: Message[] = [];
-
-  while (currentId) {
-    const sessionData = await loadSessionFromJsonl(currentId, workdir);
-    if (!sessionData) break;
-
-    sessionIds.unshift(currentId);
-    // Add messages from this session to the beginning of the list
-    // But skip the "compact" block if it's not the first session in our traversal (which is the latest)
-    // Actually, we should probably keep all messages and let the UI/logic handle it.
-    // But wait, if we are concatenating, the "compact" block in session N summarizes session N-1.
-    // So if we have session N-1 and session N, we should probably skip the compact block in session N.
-
-    const messages = sessionData.messages;
-    if (allMessages.length > 0) {
-      // If we already have messages (from "later" sessions),
-      // we are now adding messages from an "earlier" session.
-      // The later session's first message might be a "compact" block.
-      if (allMessages[0].blocks.some((b) => b.type === "compact")) {
-        // Remove the compact block from the later session's messages
-        // because we are now providing the actual messages it summarized.
-        allMessages.shift();
-      }
-    }
-
-    allMessages.unshift(...messages);
-    currentId = sessionData.parentSessionId;
-  }
-
-  return { messages: allMessages, sessionIds };
+  const sessionData = await loadSessionFromJsonl(currentSessionId, workdir);
+  if (!sessionData) return { messages: [], sessionIds: [] };
+  return { messages: sessionData.messages, sessionIds: [currentSessionId] };
 }

--- a/packages/agent-sdk/src/types/messaging.ts
+++ b/packages/agent-sdk/src/types/messaging.ts
@@ -89,7 +89,6 @@ export interface BangBlock {
 export interface CompactBlock {
   type: "compact";
   content: string;
-  sessionId: string;
 }
 
 export interface ReasoningBlock {

--- a/packages/agent-sdk/tests/agent/agent.compaction.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.compaction.test.ts
@@ -319,7 +319,6 @@ describe("Agent Message Compaction Tests", () => {
           {
             type: "compact",
             content: "Compacted content: Contains summary of first 6 messages",
-            sessionId: "test-session-id",
           },
         ],
         timestamp: new Date().toISOString(),

--- a/packages/agent-sdk/tests/integration/compactionFlow.test.ts
+++ b/packages/agent-sdk/tests/integration/compactionFlow.test.ts
@@ -205,7 +205,6 @@ describe("Integration: Compaction Flow (API-round grouping + API conversion)", (
         {
           type: "compact",
           content: "Previous summary",
-          sessionId: "old-session",
         },
       ],
       timestamp: new Date().toISOString(),
@@ -247,7 +246,6 @@ describe("Integration: Compaction Flow (API-round grouping + API conversion)", (
         {
           type: "compact",
           content: "Initial work summarized",
-          sessionId: "s1",
         },
       ],
       timestamp: new Date().toISOString(),

--- a/packages/agent-sdk/tests/managers/messageManager.context_safe_rewind.test.ts
+++ b/packages/agent-sdk/tests/managers/messageManager.context_safe_rewind.test.ts
@@ -1,11 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MessageManager } from "../../src/managers/messageManager.js";
 import * as sessionService from "../../src/services/session.js";
-import type {
-  Message,
-  CompactBlock,
-  TextBlock,
-} from "../../src/types/index.js";
+import type { Message, TextBlock } from "../../src/types/index.js";
 import { Container } from "../../src/utils/container.js";
 
 vi.mock("fs/promises", () => ({
@@ -24,7 +20,7 @@ vi.mock("../../src/services/session.js", async (importOriginal) => {
   };
 });
 
-describe("MessageManager Context-Safe Rewind", () => {
+describe("MessageManager Context-Safe Rewind (Single Session)", () => {
   let messageManager: MessageManager;
   const workdir = "/test/workdir";
   const container = new Container();
@@ -37,202 +33,121 @@ describe("MessageManager Context-Safe Rewind", () => {
     });
   });
 
-  it("should only load messages from the target session after rewind (preventing context overflow)", async () => {
-    const session1Id = "session1";
-    const session2Id = "session2";
-
-    // Session 1: Original messages
-    const session1Messages = [
-      { role: "user", blocks: [{ type: "text", content: "user1" }] },
-      { role: "assistant", blocks: [{ type: "text", content: "assistant1" }] },
-    ];
-
-    // Session 2: Starts with a summary of Session 1, then new messages
-    const session2Messages = [
+  it("should only see active messages after compaction (pre-compaction messages not visible)", async () => {
+    // After compaction, loadFullMessageThread returns only active messages:
+    // [compact, user2, assistant2] — pre-compaction messages are NOT included
+    const activeMessages = [
       {
+        id: "msg0",
         role: "assistant",
-        blocks: [{ type: "compact", content: "summary of session 1" }],
+        blocks: [{ type: "compact", content: "summary of old conversation" }],
       },
-      { role: "user", blocks: [{ type: "text", content: "user2" }] },
-      { role: "assistant", blocks: [{ type: "text", content: "assistant2" }] },
+      {
+        id: "msg1",
+        role: "user",
+        blocks: [{ type: "text", content: "user2" }],
+      },
+      {
+        id: "msg2",
+        role: "assistant",
+        blocks: [{ type: "text", content: "assistant2" }],
+      },
     ];
 
-    // Mock loadFullMessageThread to return the concatenated thread (for the UI to show)
-    // Note: loadFullMessageThread removes the 'compact' block when joining
     vi.mocked(sessionService.loadFullMessageThread).mockResolvedValue({
-      messages: [
-        session1Messages[0],
-        session1Messages[1],
-        session2Messages[1], // user2
-        session2Messages[2], // assistant2
-      ] as Message[],
-      sessionIds: [session1Id, session2Id],
+      messages: activeMessages as Message[],
+      sessionIds: [messageManager.getSessionId()],
     });
 
-    // Mock loadSessionFromJsonl for both sessions
-    vi.mocked(sessionService.loadSessionFromJsonl).mockImplementation(
-      async (id) => {
-        if (id === session1Id)
-          return {
-            id: session1Id,
-            messages: session1Messages,
-          } as unknown as sessionService.SessionData;
-        if (id === session2Id)
-          return {
-            id: session2Id,
-            messages: session2Messages,
-            parentSessionId: session1Id,
-          } as unknown as sessionService.SessionData;
-        return null;
-      },
-    );
+    messageManager.setMessages(activeMessages as Message[]);
 
-    // Initialize current state as Session 2
-    messageManager.initializeFromSession({
-      id: session2Id,
-      messages: session2Messages,
-      parentSessionId: session1Id,
-      metadata: {
-        lastActiveAt: new Date().toISOString(),
-        latestTotalTokens: 0,
-        workdir,
-      },
-    } as unknown as sessionService.SessionData);
+    // Truncate to index 2 (keep compact + user2)
+    await messageManager.truncateHistory(2);
 
-    // SCENARIO: Rewind to "user2" in Session 2 (index 2 in the full thread)
-    // Full thread index 2 corresponds to session2Messages[1]
-    // We need to ensure the targetIndexInSession is calculated correctly.
-    // In Session 2, messages are [compact, user2, assistant2].
-    // index 2 in full thread [user1, assistant1, user2, assistant2] should map to session2Messages[1] (user2).
-    // The logic in truncateHistory:
-    // sid=session1: remainingIndex=2, effectiveMessages.length=2. remainingIndex < 2 is false. remainingIndex becomes 0.
-    // sid=session2: remainingIndex=0, effectiveMessages.length=2. remainingIndex < 2 is true.
-    // targetIndexInSession = hasCompactBlock (true) && sid !== sessionIds[0] (true) ? 0 + 1 : 0 = 1.
-    // newMessagesInSession = session2Messages.slice(0, 1) = [compact].
-    // Wait, if we want to KEEP user2, we should rewind to index 3 or change the logic.
-    // Usually "rewind to X" means X is the LAST message.
-    // But truncateHistory(index) does messages.slice(0, index), so index is EXCLUDED.
-    // To keep user2 (index 2 in full thread), we need to call truncateHistory(3).
-    await messageManager.truncateHistory(3);
-
-    // VERIFICATION:
-    // 1. Session ID remains session2
-    expect(messageManager.getSessionId()).toBe(session2Id);
-
-    // 2. Messages in memory should ONLY be from Session 2 (truncated)
-    // This includes the 'compact' block (summary) + 'user2'
     const currentMessages = messageManager.getMessages();
     expect(currentMessages.length).toBe(2);
     expect(currentMessages[0].blocks[0].type).toBe("compact");
-    expect((currentMessages[0].blocks[0] as CompactBlock).content).toBe(
-      "summary of session 1",
-    );
     expect((currentMessages[1].blocks[0] as TextBlock).content).toBe("user2");
 
-    // 3. Ancestor messages (user1, assistant1) are NOT in the active message list
-    const hasAncestor = currentMessages.some((m) =>
+    // Pre-compaction messages are NOT in the active set
+    const hasOldMessage = currentMessages.some((m) =>
       m.blocks.some(
-        (b) =>
-          b.type === "text" &&
-          (b.content === "user1" || b.content === "assistant1"),
+        (b) => b.type === "text" && (b as TextBlock).content.includes("user1"),
       ),
     );
-    expect(hasAncestor).toBe(false);
+    expect(hasOldMessage).toBe(false);
   });
 
-  it("should restore ancestor session and its summary when rewinding to an earlier session", async () => {
-    const session1Id = "session1";
-    const session2Id = "session2";
-
-    // Session 1: Already has a summary from a previous compaction
-    const session1Messages = [
+  it("should preserve compact boundary when truncating after it", async () => {
+    // Session with compact boundary at index 0
+    const messages = [
       {
+        id: "msg0",
         role: "assistant",
-        blocks: [{ type: "compact", content: "summary of root" }],
+        blocks: [{ type: "compact", content: "summary" }],
       },
-      { role: "user", blocks: [{ type: "text", content: "user1" }] },
-    ];
-
-    const session2Messages = [
       {
-        role: "assistant",
-        blocks: [{ type: "compact", content: "summary of session 1" }],
+        id: "msg1",
+        role: "user",
+        blocks: [{ type: "text", content: "user1" }],
       },
-      { role: "user", blocks: [{ type: "text", content: "user2" }] },
+      {
+        id: "msg2",
+        role: "assistant",
+        blocks: [{ type: "text", content: "assistant1" }],
+      },
+      {
+        id: "msg3",
+        role: "user",
+        blocks: [{ type: "text", content: "user2" }],
+      },
     ];
 
     vi.mocked(sessionService.loadFullMessageThread).mockResolvedValue({
-      messages: [
-        session1Messages[1], // user1
-        session2Messages[1], // user2
-      ] as Message[],
-      sessionIds: [session1Id, session2Id],
+      messages: messages as Message[],
+      sessionIds: [messageManager.getSessionId()],
     });
 
-    vi.mocked(sessionService.loadSessionFromJsonl).mockImplementation(
-      async (id) => {
-        if (id === session1Id)
-          return {
-            id: session1Id,
-            messages: session1Messages,
-          } as unknown as sessionService.SessionData;
-        if (id === session2Id)
-          return {
-            id: session2Id,
-            messages: session2Messages,
-            parentSessionId: session1Id,
-          } as unknown as sessionService.SessionData;
-        return null;
-      },
+    messageManager.setMessages(messages as Message[]);
+
+    // Truncate to index 3 (keep compact + user1 + assistant1)
+    await messageManager.truncateHistory(3);
+
+    const currentMessages = messageManager.getMessages();
+    expect(currentMessages.length).toBe(3);
+    expect(currentMessages[0].blocks[0].type).toBe("compact");
+    expect((currentMessages[1].blocks[0] as TextBlock).content).toBe("user1");
+    expect((currentMessages[2].blocks[0] as TextBlock).content).toBe(
+      "assistant1",
     );
+  });
 
-    // SCENARIO: Rewind to "user1" in Session 1 (index 0 in the full thread)
-    // To keep user1 (index 0), we call truncateHistory(1)
-    // In Session 1, messages are [compact, user1].
-    // index 0 in full thread [user1, user2] should map to session1Messages[1] (user1).
-    // The logic in truncateHistory:
-    // sid=session1: remainingIndex=0, effectiveMessages.length=1. remainingIndex < 1 is true.
-    // targetIndexInSession = hasCompactBlock (true) && sid !== sessionIds[0] (false) ? 0 + 1 : 0 = 0.
-    // Wait, sid === sessionIds[0] is true for the first session.
-    // So targetIndexInSession = 0.
-    // newMessagesInSession = session1Messages.slice(0, 0) = [].
-    // To keep user1, we need targetIndexInSession = 2.
-    // If we call truncateHistory(1):
-    // index=1. remainingIndex=1.
-    // sid=session1: remainingIndex=1, effectiveMessages.length=1. remainingIndex < 1 is false. remainingIndex becomes 0.
-    // sid=session2: remainingIndex=0, effectiveMessages.length=1. remainingIndex < 1 is true.
-    // targetSessionId = session2.
-    // So to keep user1, we must call truncateHistory(1) but the logic for targetIndexInSession needs to be correct.
-    // Actually, if index=1, it means we keep 1 message from the full thread.
-    // That 1 message is user1.
-    // user1 is at session1Messages[1].
-    // So we need targetIndexInSession = 2.
+  it("should allow truncating to just the compact boundary", async () => {
+    const messages = [
+      {
+        id: "msg0",
+        role: "assistant",
+        blocks: [{ type: "compact", content: "summary" }],
+      },
+      {
+        id: "msg1",
+        role: "user",
+        blocks: [{ type: "text", content: "user1" }],
+      },
+    ];
 
-    // Let's adjust the test to call truncateHistory(1) and expect 2 messages if we fix the logic,
-    // or just understand the current logic.
-    // Current logic: targetIndexInSession = hasCompactBlock && sid !== sessionIds[0] ? remainingIndex + 1 : remainingIndex;
-    // For sid=session1, sid === sessionIds[0], so targetIndexInSession = remainingIndex.
-    // If remainingIndex = 1, targetIndexInSession = 1. session1Messages.slice(0, 1) = [compact].
-    // Still missing user1.
+    vi.mocked(sessionService.loadFullMessageThread).mockResolvedValue({
+      messages: messages as Message[],
+      sessionIds: [messageManager.getSessionId()],
+    });
 
-    // The fix should be: if it's the first session, we don't skip anything, but we still need to account for the compact block if it exists.
-    // If session1Messages[0] is compact, then user1 is at index 1.
-    // So if we want to keep 1 message from the "effective" thread, we need to keep 2 messages from the session file.
+    messageManager.setMessages(messages as Message[]);
 
+    // Truncate to index 1 (keep only compact)
     await messageManager.truncateHistory(1);
 
-    // VERIFICATION:
-    // 1. Session ID is restored to session1
-    expect(messageManager.getSessionId()).toBe(session1Id);
-
-    // 2. Messages in memory should be from Session 1 (truncated)
-    // This includes the 'compact' block (summary of root) + 'user1'
     const currentMessages = messageManager.getMessages();
-    expect(currentMessages.length).toBe(2);
+    expect(currentMessages.length).toBe(1);
     expect(currentMessages[0].blocks[0].type).toBe("compact");
-    expect((currentMessages[0].blocks[0] as CompactBlock).content).toBe(
-      "summary of root",
-    );
-    expect((currentMessages[1].blocks[0] as TextBlock).content).toBe("user1");
   });
 });

--- a/packages/agent-sdk/tests/managers/messageManager.coverage.test.ts
+++ b/packages/agent-sdk/tests/managers/messageManager.coverage.test.ts
@@ -185,15 +185,15 @@ describe("MessageManager Coverage Improvements", () => {
     );
   });
 
-  it("should handle compactMessagesAndUpdateSession and preserve rootSessionId and last 3 messages", () => {
-    const initialRootSessionId = messageManager.getRootSessionId();
+  it("should handle compactMessagesAndUpdateSession and keep same session with last messages", async () => {
+    const initialSessionId = messageManager.getSessionId();
     messageManager.addUserMessage({ content: "msg1" });
     messageManager.addAssistantMessage("msg2");
     messageManager.addUserMessage({ content: "msg3" });
     messageManager.addAssistantMessage("msg4");
     messageManager.addUserMessage({ content: "msg5" });
 
-    messageManager.compactMessagesAndUpdateSession("compacted content");
+    await messageManager.compactMessagesAndUpdateSession("compacted content");
 
     const messages = messageManager.getMessages();
     expect(messages.length).toBe(4); // [compact] + msg3, msg4, msg5
@@ -204,8 +204,7 @@ describe("MessageManager Coverage Improvements", () => {
     expect((messages[1].blocks[0] as { content: string }).content).toBe("msg3");
     expect((messages[2].blocks[0] as { content: string }).content).toBe("msg4");
     expect((messages[3].blocks[0] as { content: string }).content).toBe("msg5");
-    expect(messageManager.getRootSessionId()).toBe(initialRootSessionId);
-    expect(messageManager.getSessionId()).not.toBe(initialRootSessionId);
+    expect(messageManager.getSessionId()).toBe(initialSessionId);
   });
 
   it("should handle addFileHistoryBlock", () => {

--- a/packages/agent-sdk/tests/managers/messageManager.rewind.test.ts
+++ b/packages/agent-sdk/tests/managers/messageManager.rewind.test.ts
@@ -20,7 +20,7 @@ vi.mock("../../src/services/session.js", async (importOriginal) => {
   };
 });
 
-describe("MessageManager Cross-Session Rewind", () => {
+describe("MessageManager Single-Session Rewind", () => {
   let messageManager: MessageManager;
   const workdir = "/test/workdir";
   const container = new Container();
@@ -33,13 +33,17 @@ describe("MessageManager Cross-Session Rewind", () => {
     });
   });
 
-  it("should establish parentSessionId link after compaction", () => {
-    const oldSessionId = messageManager.getSessionId();
+  it("should keep same session ID after compaction (no parent session)", async () => {
+    const originalSessionId = messageManager.getSessionId();
     messageManager.addUserMessage({ content: "msg1" });
-    messageManager.compactMessagesAndUpdateSession("compacted content");
+    messageManager.addAssistantMessage("msg2");
 
-    expect(messageManager.getParentSessionId()).toBe(oldSessionId);
-    expect(messageManager.getSessionId()).not.toBe(oldSessionId);
+    await messageManager.compactMessagesAndUpdateSession("compacted content");
+
+    // Session ID stays the same — compaction appends to the same file
+    expect(messageManager.getSessionId()).toBe(originalSessionId);
+    // getRootSessionId returns the same ID (no separate root concept)
+    expect(messageManager.getRootSessionId()).toBe(originalSessionId);
   });
 
   it("should call loadFullMessageThread when getFullMessageThread is called", async () => {
@@ -61,68 +65,81 @@ describe("MessageManager Cross-Session Rewind", () => {
     expect(result).toEqual(mockThread);
   });
 
-  it("should handle truncateHistory across session boundaries", async () => {
-    const session1Id = "session1";
-    const session2Id = "session2";
-
-    const session1Messages = [
-      { role: "user", blocks: [{ type: "text", content: "user1" }] },
-      { role: "assistant", blocks: [{ type: "text", content: "assistant1" }] },
+  it("should truncate history within a single session", async () => {
+    const messages = [
+      {
+        id: "msg1",
+        role: "user",
+        blocks: [{ type: "text", content: "user1" }],
+      },
+      {
+        id: "msg2",
+        role: "assistant",
+        blocks: [{ type: "text", content: "assistant1" }],
+      },
+      {
+        id: "msg3",
+        role: "user",
+        blocks: [{ type: "text", content: "user2" }],
+      },
     ];
-    const session2Messages = [
-      { role: "assistant", blocks: [{ type: "compact", content: "summary" }] },
-      { role: "user", blocks: [{ type: "text", content: "user2" }] },
-    ];
 
-    // Mock loadFullMessageThread to return concatenated messages (with compact block removed)
+    // Mock loadFullMessageThread to return current session's messages
     vi.mocked(sessionService.loadFullMessageThread).mockResolvedValue({
-      messages: [
-        session1Messages[0],
-        session1Messages[1],
-        session2Messages[1], // user2
-      ] as Message[],
-      sessionIds: [session1Id, session2Id],
+      messages: messages as Message[],
+      sessionIds: [messageManager.getSessionId()],
     });
 
-    // Mock loadSessionFromJsonl for both sessions
-    vi.mocked(sessionService.loadSessionFromJsonl).mockImplementation(
-      async (id) => {
-        if (id === session1Id)
-          return {
-            id: session1Id,
-            messages: session1Messages,
-          } as unknown as sessionService.SessionData;
-        if (id === session2Id)
-          return {
-            id: session2Id,
-            messages: session2Messages,
-            parentSessionId: session1Id,
-          } as unknown as sessionService.SessionData;
-        return null;
-      },
-    );
+    // Set messages in memory
+    messageManager.setMessages(messages as Message[]);
 
-    // Set current session to session2
-    messageManager.initializeFromSession({
-      id: session2Id,
-      messages: session2Messages,
-      parentSessionId: session1Id,
-      metadata: {
-        lastActiveAt: new Date().toISOString(),
-        latestTotalTokens: 0,
-        workdir,
-      },
-    } as unknown as sessionService.SessionData);
-
-    // Truncate to index 1 (assistant1 in session1)
+    // Truncate to index 1 (keep only msg1)
     await messageManager.truncateHistory(1);
-
-    // Verify session ID was restored to session1
-    expect(messageManager.getSessionId()).toBe(session1Id);
 
     // Verify messages in memory are truncated
     const currentMessages = messageManager.getMessages();
     expect(currentMessages.length).toBe(1);
     expect((currentMessages[0].blocks[0] as TextBlock).content).toBe("user1");
+  });
+
+  it("should truncate history after compaction boundary", async () => {
+    // Simulate a session that has been compacted: [compact, user1, assistant1, user2]
+    const messages = [
+      {
+        id: "msg0",
+        role: "assistant",
+        blocks: [{ type: "compact", content: "summary" }],
+      },
+      {
+        id: "msg1",
+        role: "user",
+        blocks: [{ type: "text", content: "user1" }],
+      },
+      {
+        id: "msg2",
+        role: "assistant",
+        blocks: [{ type: "text", content: "assistant1" }],
+      },
+      {
+        id: "msg3",
+        role: "user",
+        blocks: [{ type: "text", content: "user2" }],
+      },
+    ];
+
+    vi.mocked(sessionService.loadFullMessageThread).mockResolvedValue({
+      messages: messages as Message[],
+      sessionIds: [messageManager.getSessionId()],
+    });
+
+    messageManager.setMessages(messages as Message[]);
+
+    // Truncate to index 2 (keep compact + user1)
+    await messageManager.truncateHistory(2);
+
+    const currentMessages = messageManager.getMessages();
+    expect(currentMessages.length).toBe(2);
+    expect(currentMessages[0].blocks[0].type).toBe("compact");
+    expect((currentMessages[1].blocks[0] as TextBlock).content).toBe("user1");
   });
 });

--- a/packages/agent-sdk/tests/managers/subagentManager.sessions.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.sessions.test.ts
@@ -220,10 +220,6 @@ describe("SubagentManager - Session Functionality", () => {
         expect.any(Array), // messages
         "/tmp/test", // workdir
         "subagent", // sessionType
-        expect.stringMatching(
-          /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
-        ), // rootSessionId
-        undefined, // parentSessionId
       );
     });
 
@@ -382,10 +378,6 @@ describe("SubagentManager - Session Functionality", () => {
         expect.any(Array), // messages
         "/tmp/test", // workdir
         "subagent", // sessionType
-        expect.stringMatching(
-          /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
-        ), // rootSessionId
-        undefined, // parentSessionId
       );
     });
 

--- a/packages/agent-sdk/tests/services/session.compact.test.ts
+++ b/packages/agent-sdk/tests/services/session.compact.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { join } from "path";
+import { homedir } from "os";
+
+// Shared mock functions so every `new JsonlHandler()` returns the same mocks
+const mockRead = vi.fn();
+const mockAppend = vi.fn();
+
+vi.mock("fs", () => ({
+  promises: {
+    access: vi.fn(),
+    mkdir: vi.fn(),
+    readdir: vi.fn(),
+    stat: vi.fn(),
+    unlink: vi.fn(),
+    rmdir: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+  },
+}));
+
+vi.mock("fs/promises", () => ({
+  access: vi.fn(),
+  mkdir: vi.fn(),
+  readdir: vi.fn(),
+  stat: vi.fn(),
+  unlink: vi.fn(),
+  rmdir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+vi.mock("@/utils/fileUtils.js", () => ({
+  readFirstLine: vi.fn(),
+  getLastLine: vi.fn(),
+}));
+
+vi.mock("@/services/jsonlHandler.js", () => ({
+  JsonlHandler: vi.fn().mockImplementation(function () {
+    return {
+      read: mockRead,
+      append: mockAppend,
+      isValidSessionFilename: vi.fn().mockReturnValue(true),
+      parseSessionFilename: vi.fn().mockReturnValue({
+        sessionId: "test",
+        sessionType: "main",
+      }),
+      generateSessionFilename: vi
+        .fn()
+        .mockImplementation((sessionId: string) => `${sessionId}.jsonl`),
+      getLastMessage: vi.fn(),
+      createSession: vi.fn().mockResolvedValue(undefined),
+    };
+  }),
+}));
+
+vi.mock("@/utils/pathEncoder.js", () => ({
+  PathEncoder: vi.fn().mockImplementation(function () {
+    return {
+      createProjectDirectory: vi.fn(),
+      getProjectDirectory: vi.fn().mockResolvedValue({
+        originalPath: "/test/workdir",
+        encodedName: "encoded-test",
+        encodedPath: join(homedir(), ".wave", "projects", "encoded-test"),
+        pathHash: undefined,
+        isSymbolicLink: false,
+      }),
+      decode: vi.fn(),
+    };
+  }),
+}));
+
+import {
+  appendMessages,
+  loadSessionFromJsonl,
+  loadFullMessageThread,
+  listAllSessions,
+} from "@/services/session.js";
+import type { Message } from "@/types/index.js";
+import { generateMessageId } from "@/utils/messageOperations.js";
+
+describe("Session Append-Only Compaction", () => {
+  const testWorkdir = "/test/workdir";
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockRead.mockResolvedValue([]);
+    mockAppend.mockResolvedValue(undefined);
+
+    const fs = await import("fs/promises");
+    vi.mocked(fs.access).mockResolvedValue(undefined);
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fs.readdir).mockResolvedValue(
+      [] as unknown as Awaited<ReturnType<typeof fs.readdir>>,
+    );
+  });
+
+  function makeMessage(role: "user" | "assistant", content: string): Message {
+    return {
+      id: generateMessageId(),
+      role,
+      blocks: [{ type: "text", content }],
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  function makeCompactMessage(content: string): Message {
+    return {
+      id: generateMessageId(),
+      role: "assistant",
+      blocks: [{ type: "compact", content }],
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  it("compaction appends to the same session file (not creating a new session)", async () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+
+    const sessionId = "test-session-1";
+    const compactMsg = makeCompactMessage("summary of conversation");
+    const retainedMsg = makeMessage("user", "hello");
+    const messagesToAppend = [compactMsg, retainedMsg];
+
+    await appendMessages(sessionId, messagesToAppend, testWorkdir, "main");
+
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+    // append(filePath, messages, options)
+    expect(mockAppend.mock.calls[0][0]).toContain(sessionId);
+    expect(mockAppend.mock.calls[0][1]).toEqual(messagesToAppend);
+
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  it("multiple compactions append multiple compact boundaries to the same file", async () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+
+    const sessionId = "test-session-2";
+
+    // First compaction
+    const compact1 = makeCompactMessage("first summary");
+    const retained1 = makeMessage("user", "msg after first compact");
+    await appendMessages(sessionId, [compact1, retained1], testWorkdir, "main");
+
+    // Second compaction
+    const compact2 = makeCompactMessage("second summary");
+    const retained2 = makeMessage("user", "msg after second compact");
+    await appendMessages(sessionId, [compact2, retained2], testWorkdir, "main");
+
+    // Both appends go to the same file path
+    expect(mockAppend).toHaveBeenCalledTimes(2);
+    const filePath1 = mockAppend.mock.calls[0][0];
+    const filePath2 = mockAppend.mock.calls[1][0];
+    expect(filePath1).toBe(filePath2);
+    expect(filePath1).toContain(sessionId);
+
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  it("loadSessionFromJsonl returns only messages after the last compact boundary", async () => {
+    const sessionId = "test-session-3";
+
+    // File contains: [old_user, old_assistant, compact1, user1, assistant1, compact2, user2]
+    const allMessagesInFile: Message[] = [
+      makeMessage("user", "old_user"),
+      makeMessage("assistant", "old_assistant"),
+      makeCompactMessage("first summary"),
+      makeMessage("user", "user1"),
+      makeMessage("assistant", "assistant1"),
+      makeCompactMessage("second summary"),
+      makeMessage("user", "user2"),
+    ];
+
+    mockRead.mockResolvedValue(allMessagesInFile);
+
+    const result = await loadSessionFromJsonl(sessionId, testWorkdir, "main");
+
+    expect(result).not.toBeNull();
+    // Should return only [compact2, user2] — last compact boundary forward
+    expect(result!.messages.length).toBe(2);
+    expect(result!.messages[0].blocks[0].type).toBe("compact");
+    expect((result!.messages[0].blocks[0] as { content: string }).content).toBe(
+      "second summary",
+    );
+    expect((result!.messages[1].blocks[0] as { content: string }).content).toBe(
+      "user2",
+    );
+  });
+
+  it("loadSessionFromJsonl returns all messages when no compact boundary exists", async () => {
+    const sessionId = "test-session-4";
+    const messages = [
+      makeMessage("user", "hello"),
+      makeMessage("assistant", "hi"),
+      makeMessage("user", "bye"),
+    ];
+
+    mockRead.mockResolvedValue(messages);
+
+    const result = await loadSessionFromJsonl(sessionId, testWorkdir, "main");
+
+    expect(result).not.toBeNull();
+    expect(result!.messages.length).toBe(3);
+    expect((result!.messages[0].blocks[0] as { content: string }).content).toBe(
+      "hello",
+    );
+    expect((result!.messages[2].blocks[0] as { content: string }).content).toBe(
+      "bye",
+    );
+  });
+
+  it("loadFullMessageThread returns current session's active messages only (no session chain)", async () => {
+    const sessionId = "test-session-5";
+    const messages = [
+      makeCompactMessage("summary"),
+      makeMessage("user", "current msg"),
+    ];
+
+    mockRead.mockResolvedValue(messages);
+
+    const result = await loadFullMessageThread(sessionId, testWorkdir);
+
+    // Returns only this session's active messages, single session ID
+    expect(result.messages.length).toBe(2);
+    expect(result.sessionIds).toEqual([sessionId]);
+    expect(result.sessionIds.length).toBe(1);
+  });
+
+  it("no sessions-index.json is created or read during listAllSessions", async () => {
+    // session.ts imports { promises as fs } from "fs", not from "fs/promises"
+    const fs = await import("fs");
+    vi.mocked(fs.promises.readdir).mockResolvedValue(
+      [] as unknown as Awaited<ReturnType<typeof fs.promises.readdir>>,
+    );
+
+    const sessions = await listAllSessions();
+
+    expect(sessions).toEqual([]);
+
+    // Verify writeFile was NOT called to create an index file
+    expect(fs.promises.writeFile).not.toHaveBeenCalledWith(
+      expect.stringContaining("sessions-index"),
+      expect.anything(),
+    );
+    // Verify readFile was NOT called to read an index file
+    expect(fs.promises.readFile).not.toHaveBeenCalledWith(
+      expect.stringContaining("sessions-index"),
+    );
+  });
+});

--- a/packages/agent-sdk/tests/utils/convertMessagesForAPI.test.ts
+++ b/packages/agent-sdk/tests/utils/convertMessagesForAPI.test.ts
@@ -442,7 +442,6 @@ describe("convertMessagesForAPI", () => {
             type: "compact",
             content:
               "[Compacted Message Summary] User asked to refactor a function...",
-            sessionId: "test-session",
           },
         ],
         timestamp: new Date().toISOString(),

--- a/packages/agent-sdk/tests/utils/groupMessagesByApiRound.test.ts
+++ b/packages/agent-sdk/tests/utils/groupMessagesByApiRound.test.ts
@@ -28,7 +28,7 @@ function createCompactMsg(content = "compacted"): Message {
   return {
     id: generateMessageId(),
     role: "assistant",
-    blocks: [{ type: "compact", content, sessionId: "session-1" }],
+    blocks: [{ type: "compact", content }],
     timestamp: new Date().toISOString(),
   };
 }

--- a/packages/agent-sdk/tests/utils/messageOperations.test.ts
+++ b/packages/agent-sdk/tests/utils/messageOperations.test.ts
@@ -1136,7 +1136,6 @@ describe("getMessageContent", () => {
         {
           type: "compact",
           content: "summarized context",
-          sessionId: "test-session",
         },
       ],
       timestamp: expect.any(String),

--- a/packages/code/tests/components/MessageBlockItem.test.tsx
+++ b/packages/code/tests/components/MessageBlockItem.test.tsx
@@ -158,7 +158,6 @@ describe("MessageBlockItem Component", () => {
       const block: MessageBlock = {
         type: "compact",
         content: "compacted",
-        sessionId: "s1",
       };
       const { lastFrame } = render(
         <MessageBlockItem block={block} message={message} isExpanded={false} />,


### PR DESCRIPTION
## Summary

Aligns Wave's compaction model with Claude Code's approach (fixes #1363). Removes the session chain concept, sessions-index.json index file, and index update logic entirely. Compaction now appends a compact boundary message to the same session file instead of creating a new session.

## Root Cause Fixed

`updateSessionIndex()` did read-modify-write without locking — concurrent subagent `saveSession()` calls could corrupt the index, and the catch block wiped it to `{}` on parse error.

## Changes

### Source
- **messaging.ts**: Remove `sessionId` field from `CompactBlock`
- **session.ts**: Remove `SessionIndex` interface, `SESSION_INDEX_FILENAME`, `updateSessionIndex()`. Remove `rootSessionId`/`parentSessionId` from `SessionData`/`SessionMetadata`. `appendMessages()` takes 4 args (no chain IDs). `loadSessionFromJsonl()` finds last compact boundary and returns only messages from there forward. `loadFullMessageThread()` simplified to single-session. `listAllSessions()`/`listSessionsFromJsonl()`/`deleteSession()`/`cleanupExpiredSessionsFromJsonl()` all removed index-related code.
- **messageManager.ts**: Remove `rootSessionId`/`parentSessionId` fields and `getParentSessionId()`. `getRootSessionId()` now returns `sessionId`. `compactMessagesAndUpdateSession()` is async, appends to same file, keeps same session ID. `truncateHistory()` simplified for single-session model.
- **aiManager.ts**: Add `await` to `compactMessagesAndUpdateSession()` call
- **initializationService.ts** / **interactionService.ts**: Remove `rootSessionId` fallback

### Tests
- Updated 9 existing test files (removed `sessionId` from CompactBlock, fixed `appendMessages` assertions, rewrote rewind tests for single-session model)
- Created new `session.compact.test.ts` with 6 tests covering append-only compaction, boundary-based loading, no index file

## Test Results
- agent-sdk: 3168 tests pass (1 skipped)
- wave-code: 1052 tests pass
- Type-check: passes for all packages

Fixes #1363