### PR TITLE
fix: ensure tool results with images produce proper role:tool messages

### DIFF
--- a/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
+++ b/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
@@ -86,24 +86,25 @@ export function convertMessagesForAPI(
       const completedToolIds = new Set<string>(); // Record completed tool IDs
 
       if (toolBlocks.length > 0) {
+        // Collect image user messages to place after all tool messages
+        const imageUserMessages: ChatCompletionMessageParam[] = [];
+
         toolBlocks.forEach((toolBlock) => {
           // Only add completed tool blocks (i.e., stage is 'end')
           if (toolBlock.id && toolBlock.stage === "end") {
             completedToolIds.add(toolBlock.id);
 
-            // Check for image data
+            // Always add a proper tool message to satisfy tool_call_id pairing
+            recentMessages.unshift({
+              tool_call_id: toolBlock.id,
+              role: "tool",
+              content: stripAnsiColors(toolBlock.result || ""),
+            });
+
+            // If there are images, also prepare a user message with image content
             if (toolBlock.images && toolBlock.images.length > 0) {
-              // If there is an image, create a user message instead of a tool message
               const contentParts: ChatCompletionContentPart[] = [];
 
-              // Add tool result as text
-              const toolResultText = `Tool result for ${toolBlock.name || "unknown tool"}:\n${stripAnsiColors(toolBlock.result || "")}`;
-              contentParts.push({
-                type: "text",
-                text: toolResultText,
-              });
-
-              // Add image
               toolBlock.images.forEach((image) => {
                 const imageUrl = image.data.startsWith("data:")
                   ? image.data
@@ -118,21 +119,22 @@ export function convertMessagesForAPI(
                 });
               });
 
-              // Add user message
-              recentMessages.unshift({
+              imageUserMessages.push({
                 role: "user",
                 content: contentParts,
-              });
-            } else {
-              // Normal tool message
-              recentMessages.unshift({
-                tool_call_id: toolBlock.id,
-                role: "tool",
-                content: stripAnsiColors(toolBlock.result || ""),
               });
             }
           }
         });
+
+        // Insert image user messages after all tool messages but before the
+        // assistant message (which will be unshifted next). Since tool messages
+        // were unshifted to the front, we splice images right after them.
+        if (imageUserMessages.length > 0) {
+          // Tool messages are at indices 0..N-1, existing messages start at N
+          const toolMsgCount = completedToolIds.size;
+          recentMessages.splice(toolMsgCount, 0, ...imageUserMessages);
+        }
       }
 
       // Construct the content of the assistant message

--- a/packages/agent-sdk/tests/utils/convertMessagesForAPI.test.ts
+++ b/packages/agent-sdk/tests/utils/convertMessagesForAPI.test.ts
@@ -432,6 +432,203 @@ describe("convertMessagesForAPI", () => {
     expect(assistantMessage.reasoning_content).toBeUndefined();
   });
 
+  it("should produce valid tool_call_id pairing for tool results with images", () => {
+    // When a tool result contains images, it must still produce a role:"tool"
+    // message, otherwise Claude API reports:
+    // "tool_use ids were found without tool_result blocks"
+    const messages: Message[] = [
+      {
+        id: generateMessageId(),
+        role: "user",
+        blocks: [{ type: "text", content: "Analyze this figma design" }],
+        timestamp: new Date().toISOString(),
+      },
+      {
+        id: generateMessageId(),
+        role: "assistant",
+        blocks: [
+          {
+            type: "tool",
+            id: "tool_call_1",
+            name: "get_design_context",
+            parameters: '{"nodeId": "9804:91114"}',
+            stage: "end",
+            result: "const img = 'http://localhost/assets/abc.svg';",
+            success: true,
+          },
+        ],
+        timestamp: new Date().toISOString(),
+      },
+      {
+        id: generateMessageId(),
+        role: "assistant",
+        blocks: [
+          {
+            type: "tool",
+            id: "tool_call_2",
+            name: "get_screenshot",
+            parameters: '{"nodeId": "9804:91114"}',
+            stage: "end",
+            result: "Tool returned 1 image(s).",
+            success: true,
+            images: [{ data: "iVBORw0KGgoAAAANS...", mediaType: "image/png" }],
+          },
+        ],
+        timestamp: new Date().toISOString(),
+      },
+    ];
+
+    const apiMessages = convertMessagesForAPI(messages);
+
+    // Find all assistant messages with tool_calls
+    type AssistantWithTools = ChatCompletionMessageParam & {
+      tool_calls: ChatCompletionMessageToolCall[];
+    };
+    const assistantWithToolCalls = apiMessages.filter(
+      (m): m is AssistantWithTools =>
+        m.role === "assistant" &&
+        "tool_calls" in m &&
+        Array.isArray((m as AssistantWithTools).tool_calls),
+    );
+
+    // For each assistant tool_call, there must be a role:"tool" message with matching tool_call_id
+    for (const assistantMsg of assistantWithToolCalls) {
+      const assistantIdx = apiMessages.indexOf(assistantMsg);
+
+      for (const tc of assistantMsg.tool_calls) {
+        const toolResult = apiMessages.find(
+          (m, idx) =>
+            idx > assistantIdx &&
+            m.role === "tool" &&
+            "tool_call_id" in m &&
+            (m as unknown as { tool_call_id: string }).tool_call_id === tc.id,
+        );
+        expect(
+          toolResult,
+          `tool_call_id "${tc.id}" must have a corresponding role:"tool" message`,
+        ).toBeDefined();
+      }
+    }
+  });
+
+  it("should handle single assistant message with image tool result correctly", () => {
+    const messages: Message[] = [
+      {
+        id: generateMessageId(),
+        role: "user",
+        blocks: [{ type: "text", content: "Take a screenshot" }],
+        timestamp: new Date().toISOString(),
+      },
+      {
+        id: generateMessageId(),
+        role: "assistant",
+        blocks: [
+          {
+            type: "tool",
+            id: "tool_img_1",
+            name: "get_screenshot",
+            parameters: '{"nodeId": "123"}',
+            stage: "end",
+            result: "Screenshot taken.",
+            success: true,
+            images: [{ data: "base64data", mediaType: "image/png" }],
+          },
+        ],
+        timestamp: new Date().toISOString(),
+      },
+    ];
+
+    const apiMessages = convertMessagesForAPI(messages);
+
+    // The tool message must use role:"tool" with proper tool_call_id
+    const toolMsg = apiMessages.find(
+      (m) =>
+        m.role === "tool" &&
+        "tool_call_id" in m &&
+        (m as unknown as { tool_call_id: string }).tool_call_id ===
+          "tool_img_1",
+    );
+    expect(
+      toolMsg,
+      "Image tool result must still produce a role:'tool' message with tool_call_id",
+    ).toBeDefined();
+
+    // Image should also be present somewhere (as user message)
+    type ContentPart = { type: string; image_url?: { url: string } };
+    const userMsgWithImage = apiMessages.find(
+      (m) =>
+        m.role === "user" &&
+        Array.isArray(m.content) &&
+        (m.content as ContentPart[]).some((p) => p.type === "image_url"),
+    );
+    expect(
+      userMsgWithImage,
+      "Image data should be passed to the model via a user message",
+    ).toBeDefined();
+  });
+
+  it("should not interleave user messages between tool messages for multi-tool calls", () => {
+    const messages: Message[] = [
+      {
+        id: generateMessageId(),
+        role: "user",
+        blocks: [{ type: "text", content: "Do multiple things" }],
+        timestamp: new Date().toISOString(),
+      },
+      {
+        id: generateMessageId(),
+        role: "assistant",
+        blocks: [
+          {
+            type: "tool",
+            id: "tc_a",
+            name: "bash",
+            parameters: '{"command": "ls"}',
+            stage: "end",
+            result: "file1.txt",
+            success: true,
+          },
+          {
+            type: "tool",
+            id: "tc_b",
+            name: "get_screenshot",
+            parameters: '{"nodeId": "1"}',
+            stage: "end",
+            result: "Image captured.",
+            success: true,
+            images: [{ data: "imgdata", mediaType: "image/png" }],
+          },
+        ],
+        timestamp: new Date().toISOString(),
+      },
+    ];
+
+    const apiMessages = convertMessagesForAPI(messages);
+
+    // Find the assistant message index
+    const assistantIdx = apiMessages.findIndex(
+      (m) => m.role === "assistant" && "tool_calls" in m,
+    );
+    expect(assistantIdx).toBeGreaterThanOrEqual(0);
+
+    // All tool messages must come immediately after assistant (contiguously)
+    const afterAssistant = apiMessages.slice(assistantIdx + 1);
+    let foundNonTool = false;
+    let toolCount = 0;
+    for (const msg of afterAssistant) {
+      if (msg.role === "tool") {
+        expect(
+          foundNonTool,
+          "tool messages must be contiguous after assistant",
+        ).toBe(false);
+        toolCount++;
+      } else {
+        foundNonTool = true;
+      }
+    }
+    expect(toolCount).toBe(2);
+  });
+
   it("should convert compact block to user role for API (matching Claude Code auto-compact)", () => {
     const messages: Message[] = [
       {

--- a/packages/agent-sdk/tests/utils/imageSupport.test.ts
+++ b/packages/agent-sdk/tests/utils/imageSupport.test.ts
@@ -58,7 +58,7 @@ describe("Image Support in Tool Results", () => {
     }
   });
 
-  it("should convert tool block with images to user message in convertMessagesForAPI", () => {
+  it("should convert tool block with images to tool message plus user message in convertMessagesForAPI", () => {
     const messages: Message[] = [
       {
         id: generateMessageId(),
@@ -85,8 +85,8 @@ describe("Image Support in Tool Results", () => {
 
     const apiMessages = convertMessagesForAPI(messages);
 
-    // Should generate two messages: assistant message (tool calls) + user message (tool result with images)
-    expect(apiMessages).toHaveLength(2);
+    // Should generate three messages: assistant (tool_calls) + tool (result) + user (images)
+    expect(apiMessages).toHaveLength(3);
 
     // First should be assistant message containing tool calls
     expect(apiMessages[0].role).toBe("assistant");
@@ -99,30 +99,21 @@ describe("Image Support in Tool Results", () => {
       }
     }
 
-    // Second should be user message containing tool results and images
-    expect(apiMessages[1].role).toBe("user");
+    // Second should be tool message with proper tool_call_id pairing
+    expect(apiMessages[1].role).toBe("tool");
+    expect(apiMessages[1]).toHaveProperty("tool_call_id", "tool-123");
+    expect(apiMessages[1].content).toBe("Screenshot captured successfully");
 
-    // Check content structure
-    const content = apiMessages[1].content;
+    // Third should be user message containing images
+    expect(apiMessages[2].role).toBe("user");
+    const content = apiMessages[2].content;
     expect(Array.isArray(content)).toBe(true);
 
     if (Array.isArray(content)) {
-      // Should contain text and images
-      expect(content).toHaveLength(2);
-
-      // First part should be text
-      expect(content[0].type).toBe("text");
-      expect(content[0]).toHaveProperty("text");
-      if (content[0].type === "text") {
-        expect(content[0].text).toContain("screenshot_tool");
-        expect(content[0].text).toContain("Screenshot captured successfully");
-      }
-
-      // Second part should be image
-      expect(content[1].type).toBe("image_url");
-      expect(content[1]).toHaveProperty("image_url");
-      if (content[1].type === "image_url") {
-        expect(content[1].image_url.url).toContain("data:image/png;base64,");
+      expect(content).toHaveLength(1);
+      expect(content[0].type).toBe("image_url");
+      if (content[0].type === "image_url") {
+        expect(content[0].image_url.url).toContain("data:image/png;base64,");
       }
     }
   });
@@ -192,33 +183,37 @@ describe("Image Support in Tool Results", () => {
 
     const apiMessages = convertMessagesForAPI(messages);
 
-    // Should generate two messages: assistant message + user message with images
-    expect(apiMessages).toHaveLength(2);
+    // Should generate three messages: assistant + tool + user (images)
+    expect(apiMessages).toHaveLength(3);
 
     // First should be assistant message
     expect(apiMessages[0].role).toBe("assistant");
     expect(apiMessages[0]).toHaveProperty("tool_calls");
 
-    // Second should be user message containing images
-    expect(apiMessages[1].role).toBe("user");
+    // Second should be tool message with proper pairing
+    expect(apiMessages[1].role).toBe("tool");
+    expect(apiMessages[1]).toHaveProperty("tool_call_id", "tool-789");
+    expect(apiMessages[1].content).toBe("Multiple screenshots captured");
 
-    const content = apiMessages[1].content;
+    // Third should be user message containing images
+    expect(apiMessages[2].role).toBe("user");
+
+    const content = apiMessages[2].content;
     if (Array.isArray(content)) {
-      // Should contain 1 text + 2 images = 3 content parts
-      expect(content).toHaveLength(3);
+      // Should contain 2 images
+      expect(content).toHaveLength(2);
 
-      expect(content[0].type).toBe("text");
+      expect(content[0].type).toBe("image_url");
       expect(content[1].type).toBe("image_url");
-      expect(content[2].type).toBe("image_url");
 
       // Check image URL format
-      if (content[1].type === "image_url") {
-        expect(content[1].image_url.url).toContain(
+      if (content[0].type === "image_url") {
+        expect(content[0].image_url.url).toContain(
           "data:image/png;base64,image1_base64_data",
         );
       }
-      if (content[2].type === "image_url") {
-        expect(content[2].image_url.url).toContain(
+      if (content[1].type === "image_url") {
+        expect(content[1].image_url.url).toContain(
           "data:image/jpeg;base64,image2_base64_data",
         );
       }


### PR DESCRIPTION
When a tool result contained images, convertMessagesForAPI was only
generating a role:'user' message (to carry the image data) but skipping
the required role:'tool' message with tool_call_id. This caused Claude
API to reject requests with:
  'tool_use ids were found without tool_result blocks'

Fix: Always emit a role:'tool' message for every completed tool call
(satisfying the API's tool_call_id pairing requirement), and additionally
emit a role:'user' message with the image content. Image user messages
are placed after all contiguous tool messages to avoid interleaving.
