### PR TITLE
fix: pasted images lost on send due to clearImages dispatch ordering

### DIFF
--- a/packages/code/src/components/InputBox.tsx
+++ b/packages/code/src/components/InputBox.tsx
@@ -104,9 +104,6 @@ export const InputBox: React.FC<InputBoxProps> = ({
   const {
     inputText,
     cursorPosition,
-    // Image management
-    attachedImages,
-    clearImages,
     // File selector
     showFileSelector,
     filteredFiles,
@@ -200,7 +197,7 @@ export const InputBox: React.FC<InputBoxProps> = ({
     ) {
       return;
     }
-    await handleInput(input, key, attachedImages, clearImages);
+    await handleInput(input, key);
   });
 
   const handleRewindCancel = () => {

--- a/packages/code/src/hooks/useInputManager.ts
+++ b/packages/code/src/hooks/useInputManager.ts
@@ -531,17 +531,7 @@ export const useInputManager = (
   }, []);
 
   const handleInput = useCallback(
-    async (
-      input: string,
-      key: Key,
-      _attachedImages: Array<{ id: number; path: string; mimeType: string }>,
-      clearImages?: () => void,
-    ) => {
-      // Clear images side effect if return is pressed
-      if (key.return) {
-        clearImages?.();
-      }
-
+    async (input: string, key: Key) => {
       dispatch({
         type: "HANDLE_KEY",
         payload: {

--- a/packages/code/src/managers/inputReducer.ts
+++ b/packages/code/src/managers/inputReducer.ts
@@ -1008,6 +1008,7 @@ export function inputReducer(
               cursorPosition: 0,
               historyIndex: -1,
               longTextMap: {},
+              attachedImages: [],
               btwState: {
                 question,
                 isLoading: true,
@@ -1047,6 +1048,7 @@ export function inputReducer(
                 cursorPosition: 0,
                 historyIndex: -1,
                 longTextMap: {},
+                attachedImages: [],
                 pendingEffect: {
                   type: "EXECUTE_COMMAND",
                   command: commandName,
@@ -1062,6 +1064,7 @@ export function inputReducer(
             cursorPosition: 0,
             historyIndex: -1,
             longTextMap: {},
+            attachedImages: [],
             pendingEffect: {
               type: "SEND_MESSAGE",
               content: contentWithPlaceholders,

--- a/packages/code/tests/managers/inputReducer.test.ts
+++ b/packages/code/tests/managers/inputReducer.test.ts
@@ -862,6 +862,56 @@ describe("inputReducer", () => {
       });
     });
 
+    it("should extract referenced images and clear attachedImages on send", () => {
+      const state: InputState = {
+        ...initialState,
+        inputText: "Check this out [Image #1]",
+        attachedImages: [
+          { id: 1, path: "/tmp/img1.png", mimeType: "image/png" },
+          { id: 2, path: "/tmp/img2.png", mimeType: "image/png" },
+        ],
+      };
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { return: true } as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+      expect(result.inputText).toBe("");
+      expect(result.attachedImages).toEqual([]);
+      expect(result.pendingEffect).toEqual({
+        type: "SEND_MESSAGE",
+        content: "Check this out",
+        images: [{ path: "/tmp/img1.png", mimeType: "image/png" }],
+        longTextMap: {},
+      });
+    });
+
+    it("should clear attachedImages when sending /btw command", () => {
+      const state: InputState = {
+        ...initialState,
+        inputText: "/btw what is this [Image #1]",
+        attachedImages: [
+          { id: 1, path: "/tmp/img1.png", mimeType: "image/png" },
+        ],
+      };
+      const result = inputReducer(state, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "",
+          key: { return: true } as unknown as Key,
+          hasSlashCommand,
+        },
+      });
+      expect(result.attachedImages).toEqual([]);
+      expect(result.pendingEffect).toEqual({
+        type: "ASK_BTW",
+        question: "what is this",
+      });
+    });
+
     it("should handle /btw command", () => {
       const state = { ...initialState, inputText: "/btw what is life?" };
       const result = inputReducer(state, {


### PR DESCRIPTION
## Problem

After pasting an image (Ctrl+V) in the CLI and pressing Enter to send, the image was silently lost — it didn't appear in the message list or message queue.

## Root Cause

In `useInputManager.ts`, `handleInput` called `clearImages?.()` (dispatching `CLEAR_IMAGES`) **before** dispatching `HANDLE_KEY`. Since React processes sequential dispatches in order, the reducer saw `attachedImages: []` and couldn't match `[Image #N]` placeholders — silently dropping pasted images on send.

## Fix

1. **`useInputManager.ts`** — Removed the `clearImages?.()` call and unused params from `handleInput`. Images are now cleared by the reducer itself during the submit state transition.

2. **`inputReducer.ts`** — Added `attachedImages: []` to all three Enter-key submit return paths (`/btw`, internal command, `SEND_MESSAGE`), so images are cleared atomically with input text.

3. **`InputBox.tsx`** — Updated call site to `handleInput(input, key)` and removed unused destructured vars.

4. **Tests** — Added 2 regression tests verifying images are extracted into `pendingEffect.images` and `attachedImages` is cleared on both regular send and `/btw` command.