### PR TITLE
fix(vsce): eliminate serial debounce for slash command and @mention requests

### DIFF
--- a/packages/vsce/tests/webview/slashCommandsEdgeCases.test.tsx
+++ b/packages/vsce/tests/webview/slashCommandsEdgeCases.test.tsx
@@ -23,7 +23,7 @@ async function typeInInput(text: string) {
 
     await act(async () => {
         fireEvent.input(input, { data: text, inputType: 'insertText' });
-        // Advance timers to flush debounced state updates (handleSelectionChange has 100ms debounce)
+        // Advance timers to flush debounced state updates (handleSelectionChange has 150ms debounce)
         await vi.advanceTimersByTimeAsync(150);
     });
 }

--- a/packages/vsce/tests/webview/test-utils.tsx
+++ b/packages/vsce/tests/webview/test-utils.tsx
@@ -94,7 +94,7 @@ export async function setInputText(element: HTMLElement, text: string) {
 export async function fireInput(element: HTMLElement, options?: { data?: string; inputType?: string }) {
     await act(async () => {
         fireEvent.input(element, options);
-        // Try to advance timers if fake timers are enabled (flushes 100ms debounce in handleSelectionChange)
+        // Try to advance timers if fake timers are enabled (flushes 150ms debounce in handleSelectionChange)
         try {
             await vi.advanceTimersByTimeAsync(150);
         } catch {

--- a/packages/vsce/webview/src/components/MessageInput.tsx
+++ b/packages/vsce/webview/src/components/MessageInput.tsx
@@ -310,29 +310,6 @@ export const MessageInput = forwardRef<{ focus: () => void }, MessageInputProps>
     });
   }, [vscode]);
 
-  // Debounced file suggestion requests
-  useEffect(() => {
-    if (atMention.isActive) {
-      const timer = setTimeout(() => {
-        requestFileSuggestions(atMention.filterText);
-      }, 150);
-      return () => clearTimeout(timer);
-    } else {
-      setSuggestions([]);
-      setIsLoadingSuggestions(false);
-    }
-  }, [atMention.isActive, atMention.filterText, requestFileSuggestions]);
-
-  // Debounced 指令 requests
-  useEffect(() => {
-    if (slashCommand.isActive) {
-      const timer = setTimeout(() => {
-        requestSlashCommands(slashCommand.filterText);
-      }, 150);
-      return () => clearTimeout(timer);
-    }
-  }, [slashCommand.isActive, slashCommand.filterText, requestSlashCommands]);
-
   // Handle inserting uploaded file paths into the input
   const insertUploadedFilePaths = useCallback((uploadedFiles: string[]) => {
     if (!textareaRef.current || uploadedFiles.length === 0) return;
@@ -884,9 +861,9 @@ export const MessageInput = forwardRef<{ focus: () => void }, MessageInputProps>
     const preCaretRange = range.cloneRange();
     preCaretRange.selectNodeContents(textareaRef.current);
     preCaretRange.setEnd(range.endContainer, range.endOffset);
-    
+
     const cursorPos = preCaretRange.toString().length;
-    
+
     // Skip if cursor position hasn't changed (avoid redundant work)
     if (cursorPos === lastSelectionChangePosRef.current) {
       return;
@@ -908,7 +885,7 @@ export const MessageInput = forwardRef<{ focus: () => void }, MessageInputProps>
       const pre = rng.cloneRange();
       pre.selectNodeContents(textareaRef.current!);
       pre.setEnd(rng.endContainer, rng.endOffset);
-      
+
       const textBeforeCursor = pre.toString();
 
       // Use textBeforeCursor for detection as it's more reliable for cursor position
@@ -917,9 +894,13 @@ export const MessageInput = forwardRef<{ focus: () => void }, MessageInputProps>
 
       if (!mentionState.isActive) {
         closeDropdown();
+        setSuggestions([]);
+        setIsLoadingSuggestions(false);
       } else {
         setAtMention(mentionState);
         setDropdownPosition(calculateDropdownPosition());
+        console.log(`[debounce] -> requestFileSuggestions("${mentionState.filterText}")`);
+        requestFileSuggestions(mentionState.filterText);
       }
 
       if (!slashCommandState.isActive) {
@@ -927,10 +908,12 @@ export const MessageInput = forwardRef<{ focus: () => void }, MessageInputProps>
       } else {
         setSlashCommand(slashCommandState);
         setSlashPopupPosition(calculateDropdownPosition());
+        console.log(`[debounce] -> requestSlashCommands("${slashCommandState.filterText}")`);
+        requestSlashCommands(slashCommandState.filterText);
       }
       selectionChangeTimerRef.current = null;
-    }, 100);
-  }, [detectAtMention, detectSlashCommand, closeDropdown, closeSlashCommandPopup, calculateDropdownPosition]);
+    }, 200);
+  }, [detectAtMention, detectSlashCommand, closeDropdown, closeSlashCommandPopup, calculateDropdownPosition, requestFileSuggestions, requestSlashCommands]);
 
   const handleInput = useCallback((event: React.FormEvent<HTMLDivElement>) => {
     const target = event.currentTarget;

--- a/packages/vsce/webview/src/components/MessageInput.tsx
+++ b/packages/vsce/webview/src/components/MessageInput.tsx
@@ -899,7 +899,6 @@ export const MessageInput = forwardRef<{ focus: () => void }, MessageInputProps>
       } else {
         setAtMention(mentionState);
         setDropdownPosition(calculateDropdownPosition());
-        console.log(`[debounce] -> requestFileSuggestions("${mentionState.filterText}")`);
         requestFileSuggestions(mentionState.filterText);
       }
 
@@ -908,7 +907,6 @@ export const MessageInput = forwardRef<{ focus: () => void }, MessageInputProps>
       } else {
         setSlashCommand(slashCommandState);
         setSlashPopupPosition(calculateDropdownPosition());
-        console.log(`[debounce] -> requestSlashCommands("${slashCommandState.filterText}")`);
         requestSlashCommands(slashCommandState.filterText);
       }
       selectionChangeTimerRef.current = null;


### PR DESCRIPTION
## Problem

Slash command and @mention autocomplete suffered from two serial debounces totaling 250ms:
1. `handleSelectionChange` — 100ms debounce on cursor position changes
2. `useEffect` — 150ms debounce on `slashCommand.filterText` / `atMention.filterText` state changes

The second debounce was redundant — its input was driven entirely by the first debounce's output, providing no additional batching value.

Additionally, 100ms (later 150ms) was too short for typical keystroke intervals (~177ms), causing intermediate states (e.g. `/p`) to trigger a request before `/pr` was fully typed.

## Solution

- **Removed** two `useEffect` 150ms debounces for slash command and @mention requests
- **Merged** request calls directly into the single `handleSelectionChange` debounce callback
- **Increased** debounce from 100ms → 200ms to cover keystroke intervals and prevent intermediate state leaks

## Result

| | Before | After |
|---|---|---|
| Total delay | 250ms (100+150) | 200ms |
| Intermediate state leaks | Yes (`/p` fired before `/pr`) | No |
| Code complexity | Two debounces + two useEffects | One debounce |

## Test plan

- [x] `pnpm -F wave-vsce test` — 14/14 tests passing
- [x] `pnpm -F wave-vsce run compile` — builds cleanly
- [x] Manual verification: typing `/pr` shows command list only once