### PR TITLE
fix(mcp): retain tool snapshot during transient reconnect

### DIFF
--- a/packages/agent-sdk/src/managers/mcpManager.ts
+++ b/packages/agent-sdk/src/managers/mcpManager.ts
@@ -725,11 +725,17 @@ export class McpManager {
     }
   }
 
-  // Get all tools from connected servers
+  // Get all tools from connected servers.
+  // "reconnecting" servers retain their last-known tool snapshot so that
+  // transient SSE disconnects don't churn the tool list (which would bust
+  // the prompt cache). Tools are only dropped once the server truly fails
+  // (status "error"/"disconnected").
   getAllConnectedTools(): McpTool[] {
     const allTools: McpTool[] = [];
     for (const server of this.servers.values()) {
-      if (server.status === "connected" && server.tools) {
+      const usable =
+        server.status === "connected" || server.status === "reconnecting";
+      if (usable && server.tools) {
         allTools.push(...server.tools);
       }
     }

--- a/packages/agent-sdk/src/utils/mcpUtils.ts
+++ b/packages/agent-sdk/src/utils/mcpUtils.ts
@@ -132,6 +132,7 @@ export function findToolServer(
 ): McpServerStatus | undefined {
   return servers.find(
     (s) =>
-      s.status === "connected" && s.tools?.some((t) => t.name === toolName),
+      (s.status === "connected" || s.status === "reconnecting") &&
+      s.tools?.some((t) => t.name === toolName),
   );
 }

--- a/packages/agent-sdk/tests/managers/mcpManager.coverage.test.ts
+++ b/packages/agent-sdk/tests/managers/mcpManager.coverage.test.ts
@@ -268,6 +268,39 @@ describe("McpManager Coverage", () => {
       expect(plugins).toHaveLength(1);
       expect(plugins[0].name).toBe("mcp__s1__t1");
     });
+
+    it("should retain tools while a server is reconnecting", () => {
+      mcpManager.addServer("s1", { command: "c1" });
+      mcpManager.updateServerStatus("s1", {
+        status: "connected",
+        tools: [{ name: "t1", description: "desc", inputSchema: {} }],
+      });
+
+      // Transient SSE disconnect: status flips to "reconnecting" but the
+      // tool snapshot is preserved (updateServerStatus merges).
+      mcpManager.updateServerStatus("s1", {
+        status: "reconnecting",
+        error: "SSE stream disconnected",
+      });
+
+      const plugins = mcpManager.getMcpToolPlugins();
+      expect(plugins).toHaveLength(1);
+      expect(plugins[0].name).toBe("mcp__s1__t1");
+    });
+
+    it("should drop tools once a server errors out", () => {
+      mcpManager.addServer("s1", { command: "c1" });
+      mcpManager.updateServerStatus("s1", {
+        status: "connected",
+        tools: [{ name: "t1", description: "desc", inputSchema: {} }],
+      });
+      mcpManager.updateServerStatus("s1", {
+        status: "error",
+        error: "boom",
+      });
+
+      expect(mcpManager.getMcpToolPlugins()).toHaveLength(0);
+    });
   });
 
   describe("executeMcpToolByRegistry", () => {


### PR DESCRIPTION
## Problem

Transient SSE disconnects (e.g. Figma Desktop MCP server, which drops its stream roughly every 5 minutes on idle timeout) flipped a server's status to `reconnecting`. Because the tool list is filtered by connection status and recomputed on **every LLM request**, the server's tools would briefly disappear and reappear.

Since `tools` is part of the prompt prefix, this churn busts the **prompt cache** whenever a request happens to land in the ~3s reconnect window.

## Fix

Decouple connection state from tool visibility (mirroring claude-code's approach):

- `getAllConnectedTools` and `findToolServer` now treat `reconnecting` servers as usable, preserving their last-known tool snapshot.
- `updateServerStatus` already merges (`{ ...server, ...updates }`) and the transient path only sets `status`/`error`, so `tools` is retained untouched.
- Tools are only dropped once a server truly fails (`error`) or closes (`disconnected`, which explicitly sets `tools: []`).

Net effect: `connected -> reconnecting -> connected` leaves the tools array unchanged, keeping the prompt cache prefix stable across transient blips.

## Tests

- Added: tools retained while a server is `reconnecting`.
- Added: tools dropped once a server `error`s out.
- `pnpm -F wave-agent-sdk build` passes (no type errors); mcpManager/mcpTools/mcpUtils suites green.