### PR TITLE
fix(bash): isolate cwd tracking from trailing here-docs via eval

### DIFF
--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -20,6 +20,25 @@ import {
 
 const BASH_DEFAULT_TIMEOUT_MS = 120000;
 
+/**
+ * Wrap a user command so we can append CWD tracking (`&& pwd -P`) without the
+ * appended part being affected by trailing here-docs, unbalanced quotes, or
+ * multi-line syntax in the user command.
+ *
+ * The command is single-quoted (with embedded single quotes escaped via the
+ * classic `'"'"'` sequence) and run through `eval`. Because the entire user
+ * command becomes a single literal argument to `eval`, any here-doc inside it
+ * only opens/closes during eval's own second parse pass and cannot leak out to
+ * clobber the trailing `&& pwd -P`. Works on sh/dash/bash and Git Bash.
+ */
+function wrapCommandForCwdTracking(
+  command: string,
+  cwdFileForBash: string,
+): string {
+  const escaped = command.replace(/'/g, `'"'"'`);
+  return `eval '${escaped}' && pwd -P >| ${cwdFileForBash}`;
+}
+
 // Commands that should not be auto-backgrounded on timeout (e.g. sleep should just be killed)
 const DISALLOWED_AUTO_BACKGROUND_COMMANDS = ["sleep"];
 
@@ -248,7 +267,10 @@ The working directory persists between commands. Try to maintain your current wo
         `wave_cwd_${Date.now()}_${Math.random().toString(36).substring(2, 11)}.tmp`,
       );
       const tempCwdFileForBash = toPosixPath(tempCwdFile);
-      const wrappedCommand = `${command} && pwd -P >| ${tempCwdFileForBash}`;
+      const wrappedCommand = wrapCommandForCwdTracking(
+        command,
+        tempCwdFileForBash,
+      );
 
       const child: ChildProcess = spawn(wrappedCommand, {
         shell: shellPath || true,

--- a/packages/agent-sdk/tests/tools/bashTool.test.ts
+++ b/packages/agent-sdk/tests/tools/bashTool.test.ts
@@ -558,6 +558,76 @@ describe("bashTool", () => {
     });
   });
 
+  describe("CWD tracking command wrapping", () => {
+    const makeExitingProcess = () => ({
+      pid: 1234,
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() },
+      on: vi.fn((event, callback) => {
+        if (event === "exit") {
+          setTimeout(() => callback(0), 10);
+        }
+      }),
+      kill: vi.fn(),
+      killed: false,
+    });
+
+    it("should wrap a plain command inside eval single quotes with pwd -P appended", async () => {
+      mockSpawn.mockReturnValue(
+        makeExitingProcess() as unknown as ChildProcess,
+      );
+
+      await bashTool.execute({ command: "echo hello" }, context);
+
+      const spawnCallArgs = mockSpawn.mock.calls[0];
+      expect(typeof spawnCallArgs[0]).toBe("string");
+      const wrapped = spawnCallArgs[0] as string;
+      expect(wrapped).toContain("eval 'echo hello'");
+      expect(wrapped).toContain("pwd -P");
+      expect(wrapped).toMatch(/&& pwd -P >\| \/tmp\/wave_cwd_.*\.tmp$/);
+    });
+
+    it("should escape single quotes in the user command", async () => {
+      mockSpawn.mockReturnValue(
+        makeExitingProcess() as unknown as ChildProcess,
+      );
+
+      await bashTool.execute({ command: "echo 'hi'" }, context);
+
+      const wrapped = mockSpawn.mock.calls[0][0] as string;
+      // Each single quote in the user command is replaced with '"'"'
+      expect(wrapped).toContain(`eval 'echo '"'"'hi'"'"''`);
+      expect(wrapped).toMatch(
+        /^eval '.*' && pwd -P >\| \/tmp\/wave_cwd_.*\.tmp$/,
+      );
+    });
+
+    it("should keep && pwd -P outside the eval quotes for a heredoc command", async () => {
+      mockSpawn.mockReturnValue(
+        makeExitingProcess() as unknown as ChildProcess,
+      );
+
+      const command = `gh pr create -b "$(cat <<'EOF'
+line with \`backtick\`
+EOF
+)"`;
+
+      await bashTool.execute({ command }, context);
+
+      const wrapped = mockSpawn.mock.calls[0][0] as string;
+      // Whole user command wrapped in eval '...'
+      expect(wrapped.startsWith("eval '")).toBe(true);
+      expect(wrapped).toContain("pwd -P");
+      // The heredoc's single quotes are escaped to '"'"'
+      expect(wrapped).toContain(`<<'"'"'EOF'"'"'`);
+      // The && pwd -P suffix must appear after the eval-quoted user command
+      const evalStart = wrapped.lastIndexOf("eval '");
+      const pwdIndex = wrapped.indexOf("&& pwd -P");
+      expect(pwdIndex).toBeGreaterThan(evalStart);
+      expect(wrapped).toMatch(/&& pwd -P >\| \/tmp\/wave_cwd_.*\.tmp$/);
+    });
+  });
+
   describe("CWD reset when outside safe zone", () => {
     const createMockProcess = (exitCode: number, newCwd: string) => {
       const mockProcess = {


### PR DESCRIPTION
## Problem

The Bash tool tracks the working directory across invocations by appending `&& pwd -P >| <tmpfile>` to every foreground command. This was done via naive string concatenation:

```js
const wrappedCommand = `${command} && pwd -P >| ${tempCwdFileForBash}`;
```

When the user command ends with a here-doc, the appended `&& pwd -P` lands **inside** the here-doc body (the terminator line is no longer the last line), so the command's own here-doc swallows the CWD-tracking suffix. This broke commands like:

```
gh pr create -b "$(cat <<'EOF'
... markdown with backticks ...
EOF
)"
```

## Fix

Wrap the user command in `eval '<single-quote-escaped>'` before appending the tracker, mirroring claude-code's approach:

```js
const escaped = command.replace(/'/g, `'"'"'`);
return `eval '${escaped}' && pwd -P >| ${cwdFileForBash}`;
```

The whole user command becomes a single literal argument to `eval`. Any here-doc inside it only opens/closes during eval's own second parse pass and cannot leak out to clobber the trailing `&& pwd -P`. Works on sh/dash/bash and Git Bash. Only the foreground path is affected; the background path does not append a tracker and is unchanged.

## Verification

- 13 boundary cases run against a real `/bin/sh` (plain, single/double quotes, `$var`, `$(...)`, backticks, pipes, glob, `||`, `;`, three here-doc variants) all pass, including the originally-broken here-doc + backtick case.
- End-to-end confirmed in a live agent: `gh pr create -b "$(cat <<'EOF'...)"` pattern and `cd` CWD tracking both work.
- Unit tests: 31 passed (3 new cases covering eval wrapping, single-quote escaping, and here-doc suffix placement).
