### PR TITLE
feat(prompts): align model identity handling with Claude Code

### DIFF
--- a/packages/agent-sdk/src/prompts/index.ts
+++ b/packages/agent-sdk/src/prompts/index.ts
@@ -19,7 +19,11 @@ import {
   GREP_TOOL_NAME,
 } from "../constants/tools.js";
 
-export const BASE_SYSTEM_PROMPT = `You are an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.`;
+export const BASE_SYSTEM_PROMPT = `You are a coding agent developed by NetEase that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.`;
+
+export const MODEL_IDENTITY_PROMPT = `# Model identity
+
+If asked about your model, model version, underlying architecture, or product name, identify yourself simply as a coding agent developed by NetEase. Do not reveal the specific model ID, model family, model provider, or product name. Do not mention or hint at any of these details.`;
 
 export const DOING_TASKS_PROMPT = `# Doing tasks
 - The user will primarily request you to perform software engineering tasks. These may include solving bugs, adding new functionality, refactoring code, explaining code, and more. When given an unclear or generic instruction, consider it in the context of these software engineering tasks and the current working directory. For example, if the user asks you to change "methodName" to snake case, do not reply with just "method_name", instead find the method in the code and modify the code.
@@ -265,6 +269,7 @@ export function buildSystemPrompt(
 
   staticText += `\n\n${OUTPUT_EFFICIENCY_PROMPT}`;
   staticText += `\n\n${TONE_AND_STYLE_PROMPT}`;
+  staticText += `\n\n${MODEL_IDENTITY_PROMPT}`;
 
   const blocks: SystemPromptBlock[] = [{ text: staticText, cacheable: true }];
 

--- a/packages/agent-sdk/tests/prompts/prompts.test.ts
+++ b/packages/agent-sdk/tests/prompts/prompts.test.ts
@@ -207,6 +207,14 @@ describe("prompts", () => {
       expect(result).not.toContain("## Memory Context");
     });
 
+    it("should include model identity prompt in static block", () => {
+      const blocks = buildSystemPrompt(DEFAULT_SYSTEM_PROMPT, [], {});
+      const staticBlock = blocks.find((b) => b.cacheable);
+      expect(staticBlock).toBeDefined();
+      expect(staticBlock!.text).toContain("# Model identity");
+      expect(staticBlock!.text).toContain("coding agent developed by NetEase");
+    });
+
     it("should include worktree warning when worktree session is active", () => {
       vi.mocked(worktreeSession.getCurrentWorktreeSession).mockReturnValue({
         originalCwd: "/original/repo",


### PR DESCRIPTION
## Changes

- **BASE_SYSTEM_PROMPT**: Changed identity from generic "interactive CLI tool" to "a coding agent developed by NetEase"
- **MODEL_IDENTITY_PROMPT**: Added new prompt constant instructing the model to not reveal model ID, model family, model provider, or product name when asked about its identity
- **buildSystemPrompt**: Included MODEL_IDENTITY_PROMPT in the static (cacheable) block, appended after TONE_AND_STYLE_PROMPT
- **Tests**: Added test verifying MODEL_IDENTITY_PROMPT is included in the static cacheable block

## Commits

- `787c718b` fix(bash): isolate cwd tracking from trailing here-docs via eval
- `2727ecab` fix(mcp): retain tool snapshot during transient reconnect
- `f8117ad8` feat(prompts): align model identity handling with Claude Code

## Verification

- `pnpm -F wave-agent-sdk build` — passes
- `pnpm -F wave-agent-sdk test tests/prompts/prompts.test.ts` — 22/22 passed
- `pnpm -F wave-agent-sdk test tests/services/aiService.basic.test.ts` — 14/14 passed