### PR TITLE
fix(vsce): wire onErrorBlockAdded callback for real-time error block updates

### DIFF
--- a/packages/vsce/src/chatProvider.ts
+++ b/packages/vsce/src/chatProvider.ts
@@ -199,6 +199,9 @@ export class ChatProvider implements vscode.WebviewViewProvider {
             onToolBlockUpdate: (params) => {
                 this.webviewManager.postMessage({ command: 'updateToolBlock', params }, viewType, windowId);
             },
+            onErrorBlockAdded: (error) => {
+                this.webviewManager.postMessage({ command: 'updateErrorBlock', error }, viewType, windowId);
+            },
             // Bang message callbacks - send full message list update
             onBangMessageAdded: () => {
                 const session = this.getChatSession(viewType, windowId);

--- a/packages/vsce/src/session/chatSession.ts
+++ b/packages/vsce/src/session/chatSession.ts
@@ -19,6 +19,7 @@ export interface ChatSessionCallbacks {
     onStreamingContentUpdate?: (params: { messageId: string; accumulated: string; stage: 'streaming' | 'end' }) => void;
     onStreamingReasoningUpdate?: (params: { messageId: string; accumulated: string; stage: 'streaming' | 'end' }) => void;
     onToolBlockUpdate?: (params: ToolBlockUpdateCallbackParams) => void;
+    onErrorBlockAdded?: (error: string) => void;
     // Bang message callbacks
     onBangMessageAdded?: () => void;
     onBangMessageUpdated?: () => void;
@@ -106,6 +107,9 @@ export class ChatSession {
                 },
                 onToolBlockUpdated: (params) => {
                     this.callbacks.onToolBlockUpdate?.(params);
+                },
+                onErrorBlockAdded: (error: string) => {
+                    this.callbacks.onErrorBlockAdded?.(error);
                 },
                 onTasksChange: (tasks: Task[]) => {
                     this.tasks = tasks;

--- a/packages/vsce/tests/reducers/chatReducer.test.ts
+++ b/packages/vsce/tests/reducers/chatReducer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { chatReducer, initialState } from '../../webview/src/reducers/chatReducer';
-import type { Message, TextBlock, ToolBlock, ReasoningBlock } from '../../webview/src/types';
+import type { Message, TextBlock, ToolBlock, ReasoningBlock, ErrorBlock } from '../../webview/src/types';
 
 describe('chatReducer', () => {
   describe('APPEND_MESSAGE', () => {
@@ -319,6 +319,92 @@ describe('chatReducer', () => {
       expect(newState.messages).toHaveLength(2);
       expect(newState.messages[0].id).toBe('new-1');
       expect(newState.messages[1].id).toBe('new-2');
+    });
+  });
+
+  describe('APPEND_ERROR_BLOCK', () => {
+    it('should append error block to last assistant message', () => {
+      const textBlock: TextBlock = { type: 'text', content: 'Hello', stage: 'end' };
+      const assistantMessage: Message = {
+        id: 'msg-1',
+        role: 'assistant',
+        timestamp: '0',
+        blocks: [textBlock]
+      };
+      const state = { ...initialState, messages: [assistantMessage] };
+
+      const newState = chatReducer(state, {
+        type: 'APPEND_ERROR_BLOCK',
+        payload: { error: 'API rate limit exceeded' }
+      });
+
+      expect(newState.messages[0].blocks).toHaveLength(2);
+      const errorBlock = newState.messages[0].blocks[1] as ErrorBlock;
+      expect(errorBlock.type).toBe('error');
+      expect(errorBlock.content).toBe('API rate limit exceeded');
+    });
+
+    it('should append error block to last assistant message when multiple messages exist', () => {
+      const userMessage: Message = {
+        id: 'msg-1',
+        role: 'user',
+        timestamp: '0',
+        blocks: [{ type: 'text', content: 'Hi', stage: 'end' }]
+      };
+      const assistantMessage: Message = {
+        id: 'msg-2',
+        role: 'assistant',
+        timestamp: '0',
+        blocks: [{ type: 'text', content: 'Hello', stage: 'end' }]
+      };
+      const state = { ...initialState, messages: [userMessage, assistantMessage] };
+
+      const newState = chatReducer(state, {
+        type: 'APPEND_ERROR_BLOCK',
+        payload: { error: 'Something went wrong' }
+      });
+
+      expect(newState.messages[1].blocks).toHaveLength(2);
+      const errorBlock = newState.messages[1].blocks[1] as ErrorBlock;
+      expect(errorBlock.type).toBe('error');
+      expect(errorBlock.content).toBe('Something went wrong');
+      // User message unchanged
+      expect(newState.messages[0].blocks).toHaveLength(1);
+    });
+
+    it('should return original state if no assistant message exists', () => {
+      const userMessage: Message = {
+        id: 'msg-1',
+        role: 'user',
+        timestamp: '0',
+        blocks: []
+      };
+      const state = { ...initialState, messages: [userMessage] };
+
+      const newState = chatReducer(state, {
+        type: 'APPEND_ERROR_BLOCK',
+        payload: { error: 'Error' }
+      });
+
+      expect(newState).toBe(state);
+    });
+
+    it('should not mutate original state', () => {
+      const assistantMessage: Message = {
+        id: 'msg-1',
+        role: 'assistant',
+        timestamp: '0',
+        blocks: []
+      };
+      const state = { ...initialState, messages: [assistantMessage] };
+
+      const newState = chatReducer(state, {
+        type: 'APPEND_ERROR_BLOCK',
+        payload: { error: 'Error' }
+      });
+
+      expect(state.messages[0].blocks).toHaveLength(0);
+      expect(newState.messages[0].blocks).toHaveLength(1);
     });
   });
 

--- a/packages/vsce/webview/src/components/ChatApp.tsx
+++ b/packages/vsce/webview/src/components/ChatApp.tsx
@@ -191,6 +191,9 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode }) => {
         case 'updateToolBlock':
           dispatch({ type: 'UPDATE_TOOL_BLOCK', payload: message.params as ToolBlockUpdateCallbackParams });
           break;
+        case 'updateErrorBlock':
+          dispatch({ type: 'APPEND_ERROR_BLOCK', payload: { error: message.error } });
+          break;
       }
     };
 

--- a/packages/vsce/webview/src/reducers/chatReducer.ts
+++ b/packages/vsce/webview/src/reducers/chatReducer.ts
@@ -1,4 +1,4 @@
-import type { ChatState, ChatAction, MessageBlock, TextBlock, ToolBlock } from '../types';
+import type { ChatState, ChatAction, MessageBlock, TextBlock, ToolBlock, ErrorBlock } from '../types';
 
 export const initialState: ChatState = {
   messages: [],
@@ -309,6 +309,34 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
 
       const newMessages = state.messages.map((m, idx) => {
         if (idx === messageIndex) {
+          return { ...m, blocks: newBlocks };
+        }
+        return m;
+      });
+
+      return {
+        ...state,
+        messages: newMessages
+      };
+    }
+    case 'APPEND_ERROR_BLOCK': {
+      const { error } = action.payload;
+      // Find the last assistant message
+      let targetIndex = -1;
+      for (let i = state.messages.length - 1; i >= 0; i--) {
+        if (state.messages[i].role === 'assistant') {
+          targetIndex = i;
+          break;
+        }
+      }
+      if (targetIndex === -1) return state;
+
+      const message = state.messages[targetIndex];
+      const newErrorBlock: ErrorBlock = { type: 'error', content: error };
+      const newBlocks = [...message.blocks, newErrorBlock];
+
+      const newMessages = state.messages.map((m, idx) => {
+        if (idx === targetIndex) {
           return { ...m, blocks: newBlocks };
         }
         return m;

--- a/packages/vsce/webview/src/types/index.ts
+++ b/packages/vsce/webview/src/types/index.ts
@@ -439,4 +439,5 @@ export type ChatAction =
   | { type: 'APPEND_MESSAGE'; payload: Message }
   | { type: 'UPDATE_STREAMING_CONTENT'; payload: { messageId: string; accumulated: string; stage: 'streaming' | 'end' } }
   | { type: 'UPDATE_STREAMING_REASONING'; payload: { messageId: string; accumulated: string; stage: 'streaming' | 'end' } }
-  | { type: 'UPDATE_TOOL_BLOCK'; payload: ToolBlockUpdateCallbackParams };
+  | { type: 'UPDATE_TOOL_BLOCK'; payload: ToolBlockUpdateCallbackParams }
+  | { type: 'APPEND_ERROR_BLOCK'; payload: { error: string } };


### PR DESCRIPTION
## Problem

Error blocks were not updating in real-time during streaming in the VS Code extension. Users had to switch away and back to the message list to see error blocks appear.

## Root Cause

The SDK provides an `onErrorBlockAdded` callback for incremental error block updates during streaming, but the VSCE layer never registered it — leaving a gap in the streaming update pipeline:

| Block type | SDK callback | VSCE registered? | Reducer action |
|---|---|---|---|
| Text | `onAssistantContentUpdated` | ✅ | `UPDATE_STREAMING_CONTENT` |
| Reasoning | `onAssistantReasoningUpdated` | ✅ | `UPDATE_STREAMING_REASONING` |
| Tool | `onToolBlockUpdated` | ✅ | `UPDATE_TOOL_BLOCK` |
| **Error** | `onErrorBlockAdded` | **❌** | **❌** |

The `onMessagesChange` callback (which does carry error blocks) is intentionally swallowed during streaming to rely on incremental callbacks — but since `onErrorBlockAdded` was never wired, error blocks were lost until a full state sync (triggered by switching away and back).

## Fix

Wire the full incremental update chain for error blocks:

1. **chatSession.ts** — Add `onErrorBlockAdded` to `ChatSessionCallbacks` + register SDK callback
2. **chatProvider.ts** — Wire callback to postMessage `updateErrorBlock` to webview
3. **ChatApp.tsx** — Add `updateErrorBlock` message handler → dispatch `APPEND_ERROR_BLOCK`
4. **chatReducer.ts** — Add `APPEND_ERROR_BLOCK` case: finds last assistant message, appends `ErrorBlock`
5. **types/index.ts** — Add `APPEND_ERROR_BLOCK` action type

## Tests

4 new reducer tests covering: append to assistant message, append with multiple messages, no-op without assistant message, immutability. All 199 VSCE tests pass.