### PR TITLE
feat(worktree): align hook model with Claude Code — hooks as creation/removal mechanism

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -877,44 +877,6 @@ export class Agent {
     this.options.callbacks?.onBackgroundCurrentTask?.();
   }
 
-  /**
-   * Trigger WorktreeRemove hook before agent destruction.
-   * Called from CLI exit dialog when user chooses to remove the worktree.
-   * Non-blocking: errors logged but don't prevent removal.
-   */
-  public async triggerWorktreeRemoveHook(worktreePath: string): Promise<void> {
-    if (!this.hookManager.hasHooks("WorktreeRemove")) {
-      return;
-    }
-    try {
-      const sessionId = this.messageManager.getSessionId();
-      const transcriptPath = this.messageManager.getTranscriptPath();
-      const hookResults = await this.hookManager.executeHooks(
-        "WorktreeRemove",
-        {
-          event: "WorktreeRemove",
-          projectDir: this.workdir,
-          timestamp: new Date(),
-          sessionId,
-          transcriptPath,
-          cwd: this.workdir,
-          worktreePath,
-          env: Object.fromEntries(
-            Object.entries(process.env).filter((e) => e[1] !== undefined),
-          ) as Record<string, string>,
-        },
-      );
-      // Process results via messageManager (may not be visible during shutdown)
-      this.hookManager.processHookResults(
-        "WorktreeRemove",
-        hookResults,
-        this.messageManager,
-      );
-    } catch (error) {
-      this.logger?.warn("WorktreeRemove hooks execution failed:", error);
-    }
-  }
-
   /** Destroy managers, clean up resources */
   public async destroy(): Promise<void> {
     // Log session_end event and shutdown telemetry

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -28,6 +28,7 @@ export * from "./utils/tokenCalculation.js";
 export * from "./utils/gitUtils.js";
 export * from "./utils/nameGenerator.js";
 export * from "./utils/worktreeSession.js";
+export * from "./utils/worktreeHooks.js";
 export * from "./types/index.js";
 
 // Export tool building utilities

--- a/packages/agent-sdk/src/services/hook.ts
+++ b/packages/agent-sdk/src/services/hook.ts
@@ -82,10 +82,15 @@ async function buildHookJsonInput(
     jsonInput.subagent_type = context.subagentType;
   }
 
-  // Add name field for WorktreeCreate events
   if (context.event === "WorktreeCreate") {
     if (context.worktreeName !== undefined) {
       jsonInput.name = context.worktreeName;
+    }
+  }
+
+  if (context.event === "WorktreeRemove") {
+    if (context.worktreePath !== undefined) {
+      jsonInput.worktree_path = context.worktreePath;
     }
   }
 
@@ -168,6 +173,9 @@ export async function executeCommand(
         HOOK_EVENT: context.event,
         HOOK_TOOL_NAME: context.toolName || "",
         WAVE_PROJECT_DIR: context.projectDir,
+        ...("mainRepoDir" in context && context.mainRepoDir
+          ? { WAVE_MAIN_REPO_DIR: context.mainRepoDir }
+          : {}),
       },
     });
 

--- a/packages/agent-sdk/src/services/initializationService.ts
+++ b/packages/agent-sdk/src/services/initializationService.ts
@@ -222,36 +222,6 @@ export class InitializationService {
       logger?.warn("SessionStart hooks execution failed:", error);
     }
 
-    // Trigger WorktreeCreate hook if this is a new worktree
-    if (agentOptions.isNewWorktree && hookManager) {
-      try {
-        logger?.info(
-          `Triggering WorktreeCreate hook for ${agentOptions.worktreeName}...`,
-        );
-        const hookResults = await hookManager.executeHooks("WorktreeCreate", {
-          event: "WorktreeCreate",
-          projectDir: workdir,
-          timestamp: new Date(),
-          sessionId: messageManager.getSessionId(),
-          transcriptPath: messageManager.getTranscriptPath(),
-          cwd: workdir,
-          worktreeName: agentOptions.worktreeName,
-          env: Object.fromEntries(
-            Object.entries(process.env).filter((e) => e[1] !== undefined),
-          ) as Record<string, string>,
-        });
-
-        // Process hook results
-        hookManager.processHookResults(
-          "WorktreeCreate",
-          hookResults,
-          messageManager,
-        );
-      } catch (error) {
-        logger?.warn("WorktreeCreate hooks execution failed:", error);
-      }
-    }
-
     // Resolve and validate configuration after loading settings.json
     resolveAndValidateConfig();
 

--- a/packages/agent-sdk/src/tools/enterWorktreeTool.ts
+++ b/packages/agent-sdk/src/tools/enterWorktreeTool.ts
@@ -13,10 +13,11 @@ import {
   createWorktree,
   validateWorktreeName,
   generateWorktreeName,
+  getHeadCommit,
 } from "../utils/worktreeUtils.js";
 import { getGitMainRepoRoot } from "../utils/gitUtils.js";
 import { ENTER_WORKTREE_TOOL_NAME } from "../constants/tools.js";
-import { logger } from "../utils/globalLogger.js";
+import { extractWorktreePath } from "../utils/worktreeHooks.js";
 
 export const ENTER_WORKTREE_TOOL_PROMPT = `Use this tool ONLY when the user explicitly asks to work in a worktree. This tool creates an isolated git worktree and switches the current session into it.
 
@@ -105,18 +106,87 @@ export const enterWorktreeTool: ToolPlugin = {
       };
     }
 
-    // Create the worktree (captures originalHeadCommit internally)
-    const worktreeInfo = createWorktree(name, mainRepoRoot);
+    const hasHook = context.hookManager?.hasHooks("WorktreeCreate") ?? false;
+
+    let worktreePath: string;
+    let branch: string;
+    let repoRoot: string;
+    let isNew: boolean;
+    let originalHeadCommit: string | undefined;
+    let hookBased: boolean;
+
+    if (hasHook && context.hookManager) {
+      const hookResults = await context.hookManager.executeHooks(
+        "WorktreeCreate",
+        {
+          event: "WorktreeCreate",
+          projectDir: mainRepoRoot,
+          timestamp: new Date(),
+          sessionId: context.sessionId ?? "",
+          transcriptPath: context.messageManager?.getTranscriptPath() ?? "",
+          cwd: mainRepoRoot,
+          worktreeName: name,
+          mainRepoDir: mainRepoRoot,
+          env: Object.fromEntries(
+            Object.entries(process.env).filter((e) => e[1] !== undefined),
+          ) as Record<string, string>,
+        },
+      );
+
+      if (context.messageManager) {
+        context.hookManager.processHookResults(
+          "WorktreeCreate",
+          hookResults,
+          context.messageManager,
+        );
+      }
+
+      if (hookResults.some((r) => !r.success)) {
+        return {
+          success: false,
+          content: "WorktreeCreate hook failed. Check hook output for details.",
+          error: "WorktreeCreate hook failed",
+        };
+      }
+
+      // Extract worktree path from hook stdout
+      const allStdout = hookResults.map((r) => r.stdout ?? "").join("\n");
+      worktreePath = extractWorktreePath(allStdout) ?? "";
+      if (!worktreePath) {
+        return {
+          success: false,
+          content:
+            "WorktreeCreate hook did not output a valid worktree path on stdout.",
+          error: "WorktreeCreate hook produced no path",
+        };
+      }
+
+      branch = `worktree-${name}`;
+      repoRoot = mainRepoRoot;
+      isNew = true;
+      originalHeadCommit = getHeadCommit(mainRepoRoot);
+      hookBased = true;
+    } else {
+      // No hook → git worktree add
+      const worktreeInfo = createWorktree(name, mainRepoRoot);
+      worktreePath = worktreeInfo.path;
+      branch = worktreeInfo.branch;
+      repoRoot = worktreeInfo.repoRoot;
+      isNew = worktreeInfo.isNew;
+      originalHeadCommit = worktreeInfo.originalHeadCommit;
+      hookBased = false;
+    }
 
     // Build session state
     const session: WorktreeSession = {
       originalCwd: context.workdir,
-      worktreePath: worktreeInfo.path,
-      worktreeBranch: worktreeInfo.branch,
-      worktreeName: worktreeInfo.name,
-      isNew: worktreeInfo.isNew,
-      repoRoot: worktreeInfo.repoRoot,
-      originalHeadCommit: worktreeInfo.originalHeadCommit,
+      worktreePath,
+      worktreeBranch: branch,
+      worktreeName: name,
+      isNew,
+      repoRoot,
+      originalHeadCommit,
+      hookBased,
     };
 
     // Set module-level session state
@@ -125,58 +195,15 @@ export const enterWorktreeTool: ToolPlugin = {
     // Update CWD via AIManager
     const aiManager = context.aiManager;
     if (aiManager) {
-      aiManager.setWorkdir(worktreeInfo.path);
+      aiManager.setWorkdir(worktreePath);
     }
 
-    // Also update the container's Workdir entry
-    // (Container is not directly accessible from ToolContext, but AIManager.setWorkdir
-    // handles both its internal field and process.chdir)
-
-    // Trigger WorktreeCreate hook if worktree is new
-    let hookTriggered = false;
-    if (session.isNew && context.hookManager) {
-      try {
-        const hookResults = await context.hookManager.executeHooks(
-          "WorktreeCreate",
-          {
-            event: "WorktreeCreate",
-            projectDir: worktreeInfo.path,
-            timestamp: new Date(),
-            sessionId: context.sessionId ?? "",
-            transcriptPath: context.messageManager?.getTranscriptPath() ?? "",
-            cwd: worktreeInfo.path,
-            worktreeName: worktreeInfo.name,
-            env: Object.fromEntries(
-              Object.entries(process.env).filter((e) => e[1] !== undefined),
-            ) as Record<string, string>,
-          },
-        );
-
-        if (context.messageManager) {
-          context.hookManager.processHookResults(
-            "WorktreeCreate",
-            hookResults,
-            context.messageManager,
-          );
-        }
-
-        hookTriggered = true;
-      } catch (error) {
-        // Non-blocking: log but don't fail the tool
-        logger?.warn("WorktreeCreate hooks execution failed:", error);
-      }
-    }
-
-    const branchInfo = worktreeInfo.branch
-      ? ` on branch ${worktreeInfo.branch}`
-      : "";
-    const hookInfo = hookTriggered
-      ? " WorktreeCreate hooks were executed."
-      : "";
+    const branchInfo = branch ? ` on branch ${branch}` : "";
+    const hookInfo = hookBased ? " WorktreeCreate hooks were executed." : "";
 
     return {
       success: true,
-      content: `Created worktree at ${worktreeInfo.path}${branchInfo}. The session is now working in the worktree. Use ExitWorktree to leave mid-session, or exit the session to be prompted.${hookInfo}`,
+      content: `Created worktree at ${worktreePath}${branchInfo}. The session is now working in the worktree. Use ExitWorktree to leave mid-session, or exit the session to be prompted.${hookInfo}`,
     };
   },
 };

--- a/packages/agent-sdk/src/tools/exitWorktreeTool.ts
+++ b/packages/agent-sdk/src/tools/exitWorktreeTool.ts
@@ -13,7 +13,6 @@ import {
   countWorktreeChanges,
 } from "../utils/worktreeUtils.js";
 import { EXIT_WORKTREE_TOOL_NAME } from "../constants/tools.js";
-import { logger } from "../utils/globalLogger.js";
 
 export const EXIT_WORKTREE_TOOL_PROMPT = `Exit a worktree session created by EnterWorktree and return the session to the original working directory.
 
@@ -154,13 +153,6 @@ export const exitWorktreeTool: ToolPlugin = {
     }
 
     // action === "remove"
-    const worktreeInfo = {
-      name: session.worktreeName,
-      path: worktreePath,
-      branch: worktreeBranch,
-      repoRoot: session.repoRoot,
-      isNew: session.isNew,
-    };
 
     // Count changes BEFORE removing the worktree (directory will be gone after)
     const summary = countWorktreeChanges(
@@ -168,30 +160,18 @@ export const exitWorktreeTool: ToolPlugin = {
       session.originalHeadCommit,
     ) ?? { changedFiles: 0, commits: 0 };
 
-    removeWorktree(worktreeInfo);
-
-    // Clear session state
-    setCurrentWorktreeSession(null);
-
-    // Restore CWD
-    const aiManager = context.aiManager;
-    if (aiManager) {
-      aiManager.setWorkdir(originalCwd);
-    }
-
-    // Trigger WorktreeRemove hook (non-blocking)
     let hookTriggered = false;
-    if (context.hookManager) {
+    if (session.hookBased && context.hookManager?.hasHooks("WorktreeRemove")) {
       try {
         const hookResults = await context.hookManager.executeHooks(
           "WorktreeRemove",
           {
             event: "WorktreeRemove",
-            projectDir: originalCwd,
+            projectDir: session.repoRoot,
             timestamp: new Date(),
             sessionId: context.sessionId ?? "",
             transcriptPath: context.messageManager?.getTranscriptPath() ?? "",
-            cwd: originalCwd,
+            cwd: session.repoRoot,
             worktreePath,
             env: Object.fromEntries(
               Object.entries(process.env).filter((e) => e[1] !== undefined),
@@ -209,9 +189,35 @@ export const exitWorktreeTool: ToolPlugin = {
 
         hookTriggered = true;
       } catch (error) {
-        // Non-blocking: log but don't fail the tool
-        logger?.warn("WorktreeRemove hooks execution failed:", error);
+        // Hook failed — fall back to git worktree remove
+        context.messageManager?.addErrorBlock(
+          `WorktreeRemove hook failed: ${(error as Error).message}. Falling back to git worktree remove.`,
+        );
+        removeWorktree({
+          name: session.worktreeName,
+          path: worktreePath,
+          branch: worktreeBranch,
+          repoRoot: session.repoRoot,
+          isNew: session.isNew,
+        });
       }
+    } else {
+      removeWorktree({
+        name: session.worktreeName,
+        path: worktreePath,
+        branch: worktreeBranch,
+        repoRoot: session.repoRoot,
+        isNew: session.isNew,
+      });
+    }
+
+    // Clear session state
+    setCurrentWorktreeSession(null);
+
+    // Restore CWD
+    const aiManager = context.aiManager;
+    if (aiManager) {
+      aiManager.setWorkdir(originalCwd);
     }
 
     const discardParts: string[] = [];

--- a/packages/agent-sdk/src/types/agent.ts
+++ b/packages/agent-sdk/src/types/agent.ts
@@ -71,8 +71,6 @@ export interface AgentOptions {
   tools?: string[];
   /**Optional worktree name */
   worktreeName?: string;
-  /**Whether this is a newly created worktree */
-  isNewWorktree?: boolean;
   /**Whether to watch for skill changes - defaults to true */
   watchSkills?: boolean;
   /**

--- a/packages/agent-sdk/src/types/hooks.ts
+++ b/packages/agent-sdk/src/types/hooks.ts
@@ -188,6 +188,7 @@ export interface HookJsonInput {
   user_prompt?: string; // Present for UserPromptSubmit only
   subagent_type?: string; // Present when hook is executed by a subagent
   name?: string; // Present for WorktreeCreate events
+  worktree_path?: string; // Present for WorktreeRemove events
   old_cwd?: string; // Present for CwdChanged events
   new_cwd?: string; // Present for CwdChanged events
   source?: SessionStartSource; // Present for SessionStart events
@@ -208,6 +209,7 @@ export interface ExtendedHookExecutionContext extends HookExecutionContext {
   userPrompt?: string; // User prompt text (UserPromptSubmit only)
   subagentType?: string; // Subagent type when hook is executed by a subagent
   worktreeName?: string; // Worktree name (WorktreeCreate only)
+  mainRepoDir?: string; // Main repo path (WorktreeCreate only)
   oldCwd?: string; // Previous working directory (CwdChanged only)
   newCwd?: string; // New working directory (CwdChanged only)
   source?: SessionStartSource; // Session start source (SessionStart only)
@@ -220,5 +222,6 @@ export interface ExtendedHookExecutionContext extends HookExecutionContext {
 // Environment variables injected into hook processes
 export interface HookEnvironment {
   WAVE_PROJECT_DIR: string; // Absolute path to project root
-  [key: string]: string; // Inherit all parent process environment variables
+  WAVE_MAIN_REPO_DIR?: string; // Main repo path (WorktreeCreate only)
+  [key: string]: string | undefined; // Inherit all parent process environment variables
 }

--- a/packages/agent-sdk/src/utils/worktreeHooks.ts
+++ b/packages/agent-sdk/src/utils/worktreeHooks.ts
@@ -1,0 +1,133 @@
+import { executeCommand } from "../services/hook.js";
+import { loadMergedWaveConfig } from "../services/configurationService.js";
+import type {
+  ExtendedHookExecutionContext,
+  HookExecutionResult,
+} from "../types/hooks.js";
+import { logger } from "./globalLogger.js";
+
+type WorktreeHookEvent = "WorktreeCreate" | "WorktreeRemove";
+
+export function extractWorktreePath(stdout: string): string | null {
+  const trimmed = stdout.trim();
+  if (!trimmed) return null;
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed?.hookSpecificOutput?.worktreePath) {
+      return String(parsed.hookSpecificOutput.worktreePath);
+    }
+    if (parsed?.worktreePath) {
+      return String(parsed.worktreePath);
+    }
+  } catch {
+    // Not JSON — fall through to path detection
+  }
+
+  if (trimmed.startsWith("/")) {
+    return trimmed.split("\n")[0].trim();
+  }
+
+  return null;
+}
+
+export function hasWorktreeHook(
+  workdir: string,
+  event: WorktreeHookEvent,
+): boolean {
+  const config = loadMergedWaveConfig(workdir);
+  return (config?.hooks?.[event]?.length ?? 0) > 0;
+}
+
+async function executeWorktreeHooksDirect(
+  event: WorktreeHookEvent,
+  mainRepoDir: string,
+  fields: Partial<
+    Pick<
+      ExtendedHookExecutionContext,
+      "worktreeName" | "worktreePath" | "mainRepoDir"
+    >
+  >,
+): Promise<{ results: HookExecutionResult[]; allStdout: string } | null> {
+  const config = loadMergedWaveConfig(mainRepoDir);
+  const hookConfigs = config?.hooks?.[event];
+  if (!hookConfigs || hookConfigs.length === 0) return null;
+
+  const context: ExtendedHookExecutionContext = {
+    event,
+    projectDir: mainRepoDir,
+    timestamp: new Date(),
+    sessionId: "",
+    cwd: mainRepoDir,
+    ...fields,
+    env: Object.fromEntries(
+      Object.entries(process.env).filter((e) => e[1] !== undefined),
+    ) as Record<string, string>,
+  };
+
+  const results: HookExecutionResult[] = [];
+  let allStdout = "";
+
+  for (const hookConfig of hookConfigs) {
+    for (const hook of hookConfig.hooks) {
+      const result = await executeCommand(hook.command, context);
+      results.push(result);
+      if (result.stdout) {
+        allStdout += result.stdout + "\n";
+      }
+    }
+  }
+
+  return { results, allStdout };
+}
+
+export async function executeWorktreeCreateHookDirect(
+  name: string,
+  mainRepoDir: string,
+): Promise<string | null> {
+  const output = await executeWorktreeHooksDirect(
+    "WorktreeCreate",
+    mainRepoDir,
+    { worktreeName: name, mainRepoDir },
+  );
+  if (!output) return null;
+
+  for (const r of output.results) {
+    if (!r.success) {
+      throw new Error(
+        `WorktreeCreate hook failed (exit code ${r.exitCode}): ${r.stderr || r.stdout}`,
+      );
+    }
+  }
+
+  const worktreePath = extractWorktreePath(output.allStdout);
+  if (!worktreePath) {
+    throw new Error(
+      `WorktreeCreate hook did not output a valid worktree path. stdout: ${output.allStdout}`,
+    );
+  }
+
+  return worktreePath;
+}
+
+export async function executeWorktreeRemoveHookDirect(
+  worktreePath: string,
+  mainRepoDir: string,
+): Promise<boolean> {
+  const output = await executeWorktreeHooksDirect(
+    "WorktreeRemove",
+    mainRepoDir,
+    { worktreePath },
+  );
+  if (!output) return false;
+
+  for (const r of output.results) {
+    if (!r.success) {
+      logger?.warn(
+        `WorktreeRemove hook failed (exit code ${r.exitCode}): ${r.stderr || r.stdout}`,
+      );
+    }
+  }
+
+  return true;
+}

--- a/packages/agent-sdk/src/utils/worktreeSession.ts
+++ b/packages/agent-sdk/src/utils/worktreeSession.ts
@@ -21,6 +21,7 @@ export interface WorktreeSession {
   repoRoot: string;
   /** The HEAD commit of the original branch at worktree creation time */
   originalHeadCommit?: string;
+  hookBased: boolean;
 }
 
 let currentWorktreeSession: WorktreeSession | null = null;

--- a/packages/agent-sdk/tests/agent/agent.worktree.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.worktree.test.ts
@@ -1,21 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { Agent } from "@/agent.js";
 import { HookManager } from "@/managers/hookManager.js";
 import { MessageManager } from "@/managers/messageManager.js";
 import * as fs from "fs/promises";
 import { homedir } from "os";
 
-// Mock AI service
 vi.mock("@/services/aiService");
-// Mock fs/promises to avoid actual file operations
 vi.mock("fs/promises");
 
 describe("Agent WorktreeCreate Hook", () => {
-  const mockCallbacks = {
-    onMessagesChange: vi.fn(),
-    onLoadingChange: vi.fn(),
-  };
-
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(fs.readFile).mockResolvedValue("");
@@ -26,85 +18,12 @@ describe("Agent WorktreeCreate Hook", () => {
     vi.clearAllMocks();
   });
 
-  it("should trigger WorktreeCreate hook when isNewWorktree is true during initialization", async () => {
-    // We need to spy on HookManager.prototype.executeHooks because it's created during Agent.create
-    const executeHooksSpy = vi.spyOn(HookManager.prototype, "executeHooks");
-    const processHookResultsSpy = vi.spyOn(
-      HookManager.prototype,
-      "processHookResults",
-    );
-
-    executeHooksSpy.mockResolvedValue([]);
-
-    const agent = await Agent.create({
-      callbacks: mockCallbacks,
-      workdir: "/tmp/test-workdir",
-      isNewWorktree: true,
-      worktreeName: "test-worktree",
-    });
-
-    expect(executeHooksSpy).toHaveBeenCalledWith(
-      "WorktreeCreate",
-      expect.objectContaining({
-        event: "WorktreeCreate",
-        worktreeName: "test-worktree",
-      }),
-    );
-    expect(processHookResultsSpy).toHaveBeenCalledWith(
-      "WorktreeCreate",
-      [],
-      expect.any(MessageManager),
-    );
-
-    await agent.destroy();
-  });
-
-  it("should handle errors during WorktreeCreate hook execution gracefully", async () => {
-    const executeHooksSpy = vi.spyOn(HookManager.prototype, "executeHooks");
-    executeHooksSpy.mockRejectedValue(new Error("Hook execution failed"));
-
-    // Should not throw
-    const agent = await Agent.create({
-      callbacks: mockCallbacks,
-      workdir: "/tmp/test-workdir",
-      isNewWorktree: true,
-    });
-
-    expect(executeHooksSpy).toHaveBeenCalledWith(
-      "WorktreeCreate",
-      expect.anything(),
-    );
-
-    await agent.destroy();
-  });
-
-  it("should NOT trigger WorktreeCreate hook when isNewWorktree is false", async () => {
-    const executeHooksSpy = vi.spyOn(HookManager.prototype, "executeHooks");
-
-    const agent = await Agent.create({
-      callbacks: mockCallbacks,
-      workdir: "/tmp/test-workdir",
-      isNewWorktree: false,
-    });
-
-    // Check if WorktreeCreate was called
-    const worktreeCreateCalls = executeHooksSpy.mock.calls.filter(
-      (call) => call[0] === "WorktreeCreate",
-    );
-    expect(worktreeCreateCalls.length).toBe(0);
-
-    await agent.destroy();
-  });
-
   describe("HookManager.processHookResults for WorktreeCreate", () => {
     it("should add an error block when a WorktreeCreate hook returns exit code 2", async () => {
-      // We can test this by calling processHookResults on a real HookManager instance
-      // but we need a MessageManager mock
       const mockMessageManager = {
         addErrorBlock: vi.fn(),
       } as unknown as MessageManager;
 
-      // Create a HookManager instance (we need a container but we can mock it)
       const mockContainer = {
         get: vi.fn(),
       } as unknown as import("@/utils/container.js").Container;
@@ -129,7 +48,7 @@ describe("Agent WorktreeCreate Hook", () => {
       expect(mockMessageManager.addErrorBlock).toHaveBeenCalledWith(
         "Worktree creation failed critically",
       );
-      expect(processResult.shouldBlock).toBe(false); // WorktreeCreate is non-blocking for now
+      expect(processResult.shouldBlock).toBe(false);
     });
 
     it("should add an error block for non-zero exit codes other than 2", async () => {
@@ -192,7 +111,6 @@ describe("Agent WorktreeCreate Hook", () => {
       );
 
       expect(mockMessageManager.addErrorBlock).not.toHaveBeenCalled();
-      // WorktreeCreate doesn't inject stdout even on success
       expect(mockMessageManager.addUserMessage).not.toHaveBeenCalled();
     });
   });

--- a/packages/agent-sdk/tests/managers/permissionManager.worktree.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.worktree.test.ts
@@ -157,6 +157,7 @@ describe("PermissionManager Worktree Safety — EnterWorktree mid-session", () =
       worktreeBranch: "worktree-feat-mid",
       worktreeName,
       isNew: true,
+      hookBased: false,
       repoRoot: mainRepoRoot,
       originalHeadCommit: "abc123",
     });

--- a/packages/agent-sdk/tests/prompts/prompts.test.ts
+++ b/packages/agent-sdk/tests/prompts/prompts.test.ts
@@ -214,6 +214,7 @@ describe("prompts", () => {
         worktreeBranch: "wave-test-feature",
         worktreeName: "test-feature",
         isNew: true,
+        hookBased: false,
         repoRoot: "/original/repo",
       });
 
@@ -323,6 +324,7 @@ describe("prompts", () => {
         worktreeBranch: "wave-fix-bug",
         worktreeName: "fix-bug",
         isNew: true,
+        hookBased: false,
         repoRoot: "/original/repo",
       });
 

--- a/packages/agent-sdk/tests/services/hook.test.ts
+++ b/packages/agent-sdk/tests/services/hook.test.ts
@@ -647,6 +647,7 @@ describe("Hook Services", () => {
         timestamp: new Date(),
         sessionId: "test-session-123",
         worktreeName: "test-worktree",
+        mainRepoDir: "/test/main-repo",
       };
 
       const resultPromise = executeCommand("echo test", worktreeContext);
@@ -662,6 +663,7 @@ describe("Hook Services", () => {
       expect(spawnEnv!.HOOK_WORKTREE_NAME).toBeUndefined();
       expect(spawnEnv!.HOOK_WORKTREE_PATH).toBeUndefined();
       expect(spawnEnv!.WAVE_PROJECT_DIR).toBe("/test/worktree-path");
+      expect(spawnEnv!.WAVE_MAIN_REPO_DIR).toBe("/test/main-repo");
     });
 
     it("should include 'name' field in JSON input and NOT include 'worktree_name' or 'worktree_path'", async () => {
@@ -687,6 +689,7 @@ describe("Hook Services", () => {
         timestamp: new Date(),
         sessionId: "test-session-123",
         worktreeName: "test-worktree",
+        mainRepoDir: "/test/main-repo",
       };
 
       const resultPromise = executeCommand("echo test", worktreeContext);
@@ -703,6 +706,48 @@ describe("Hook Services", () => {
       expect(parsedInput.worktree_name).toBeUndefined();
       expect(parsedInput.worktree_path).toBeUndefined();
       expect(parsedInput.hook_event_name).toBe("WorktreeCreate");
+    });
+  });
+
+  describe("WorktreeRemove hook", () => {
+    it("should include worktree_path in JSON input for WorktreeRemove event", async () => {
+      const mockProcess = new MockChildProcess();
+      const mockStdin = new MockStdin();
+      let stdinData = "";
+
+      vi.spyOn(mockStdin, "write").mockImplementation(
+        (_data?: string | Buffer | Uint8Array) => {
+          if (_data) {
+            stdinData += _data.toString();
+          }
+          return true;
+        },
+      );
+
+      mockProcess.stdin = mockStdin;
+      mockSpawn.mockReturnValue(mockProcess);
+
+      const worktreeRemoveContext: ExtendedHookExecutionContext = {
+        event: "WorktreeRemove",
+        projectDir: "/test/main-repo",
+        timestamp: new Date(),
+        sessionId: "test-session-123",
+        cwd: "/test/main-repo",
+        worktreePath: "/test/worktree-to-remove",
+      };
+
+      const resultPromise = executeCommand("echo test", worktreeRemoveContext);
+
+      setImmediate(() => {
+        mockProcess.emit("close", 0);
+      });
+
+      await resultPromise;
+
+      expect(stdinData).toBeTruthy();
+      const parsedInput = JSON.parse(stdinData);
+      expect(parsedInput.hook_event_name).toBe("WorktreeRemove");
+      expect(parsedInput.worktree_path).toBe("/test/worktree-to-remove");
     });
   });
 

--- a/packages/agent-sdk/tests/tools/enterWorktreeTool.test.ts
+++ b/packages/agent-sdk/tests/tools/enterWorktreeTool.test.ts
@@ -61,6 +61,7 @@ describe("enterWorktreeTool", () => {
       worktreeName: "other",
       isNew: true,
       repoRoot: "/repo",
+      hookBased: false,
     });
 
     const result = await enterWorktreeTool.execute({}, mockContext);
@@ -158,28 +159,29 @@ describe("enterWorktreeTool", () => {
     expect(result.content).toContain("Created worktree");
   });
 
-  it("should trigger WorktreeCreate hooks when worktree is new and hookManager is available", async () => {
-    const mockExecuteHooks = vi.fn().mockResolvedValue([]);
+  it("should use hook to create worktree when WorktreeCreate hooks are configured", async () => {
+    const mockExecuteHooks = vi.fn().mockResolvedValue([
+      {
+        success: true,
+        stdout: "/test/repo/.wave/worktrees/hook-test",
+        exitCode: 0,
+        duration: 0,
+        timedOut: false,
+      },
+    ]);
     const mockProcessHookResults = vi.fn();
     const mockGetTranscriptPath = vi
       .fn()
       .mockReturnValue("/test/transcript.jsonl");
 
     vi.mocked(worktreeUtils.generateWorktreeName).mockReturnValue("hook-test");
-    vi.mocked(worktreeUtils.createWorktree).mockReturnValue({
-      name: "hook-test",
-      path: "/test/repo/.wave/worktrees/hook-test",
-      branch: "worktree-hook-test",
-      repoRoot: "/test/repo",
-      isNew: true,
-      originalHeadCommit: "abc123",
-    });
 
     const contextWithHooks: ToolContext = {
       ...mockContext,
       hookManager: {
         executeHooks: mockExecuteHooks,
         processHookResults: mockProcessHookResults,
+        hasHooks: vi.fn().mockReturnValue(true),
       } as never,
       messageManager: {
         getTranscriptPath: mockGetTranscriptPath,
@@ -191,56 +193,91 @@ describe("enterWorktreeTool", () => {
 
     expect(result.success).toBe(true);
     expect(result.content).toContain("WorktreeCreate hooks were executed");
+    expect(result.content).toContain("/test/repo/.wave/worktrees/hook-test");
     expect(mockExecuteHooks).toHaveBeenCalledWith("WorktreeCreate", {
       event: "WorktreeCreate",
-      projectDir: "/test/repo/.wave/worktrees/hook-test",
+      projectDir: "/test/repo",
       timestamp: expect.any(Date),
       sessionId: "test-session-id",
       transcriptPath: "/test/transcript.jsonl",
-      cwd: "/test/repo/.wave/worktrees/hook-test",
+      cwd: "/test/repo",
       worktreeName: "hook-test",
+      mainRepoDir: "/test/repo",
       env: expect.any(Object),
     });
     expect(mockProcessHookResults).toHaveBeenCalledWith(
       "WorktreeCreate",
-      [],
+      expect.any(Array),
       contextWithHooks.messageManager,
+    );
+    expect(worktreeUtils.createWorktree).not.toHaveBeenCalled();
+    expect(mockSetWorkdir).toHaveBeenCalledWith(
+      "/test/repo/.wave/worktrees/hook-test",
     );
   });
 
-  it("should NOT trigger hooks when worktree is not new (reused)", async () => {
-    const mockExecuteHooks = vi.fn().mockResolvedValue([]);
-    const mockProcessHookResults = vi.fn();
+  it("should return error when hook fails", async () => {
+    const mockExecuteHooks = vi.fn().mockResolvedValue([
+      {
+        success: false,
+        stdout: "",
+        exitCode: 1,
+        stderr: "Hook error",
+        duration: 0,
+        timedOut: false,
+      },
+    ]);
 
-    vi.mocked(worktreeUtils.createWorktree).mockReturnValue({
-      name: "existing",
-      path: "/test/repo/.wave/worktrees/existing",
-      branch: "worktree-existing",
-      repoRoot: "/test/repo",
-      isNew: false,
-      originalHeadCommit: "abc123",
-    });
+    vi.mocked(worktreeUtils.generateWorktreeName).mockReturnValue("fail-hook");
 
     const contextWithHooks: ToolContext = {
       ...mockContext,
       hookManager: {
         executeHooks: mockExecuteHooks,
-        processHookResults: mockProcessHookResults,
+        processHookResults: vi.fn(),
+        hasHooks: vi.fn().mockReturnValue(true),
       } as never,
-      messageManager: {} as never,
+      messageManager: { getTranscriptPath: vi.fn() } as never,
     };
 
-    const result = await enterWorktreeTool.execute(
-      { name: "existing" },
-      contextWithHooks,
-    );
+    const result = await enterWorktreeTool.execute({}, contextWithHooks);
 
-    expect(result.success).toBe(true);
-    expect(result.content).not.toContain("WorktreeCreate hooks were executed");
-    expect(mockExecuteHooks).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("WorktreeCreate hook failed");
+    expect(worktreeUtils.createWorktree).not.toHaveBeenCalled();
   });
 
-  it("should NOT trigger hooks when hookManager is not available", async () => {
+  it("should return error when hook produces no path on stdout", async () => {
+    const mockExecuteHooks = vi.fn().mockResolvedValue([
+      {
+        success: true,
+        stdout: "",
+        exitCode: 0,
+        duration: 0,
+        timedOut: false,
+      },
+    ]);
+
+    vi.mocked(worktreeUtils.generateWorktreeName).mockReturnValue("no-path");
+
+    const contextWithHooks: ToolContext = {
+      ...mockContext,
+      hookManager: {
+        executeHooks: mockExecuteHooks,
+        processHookResults: vi.fn(),
+        hasHooks: vi.fn().mockReturnValue(true),
+      } as never,
+      messageManager: { getTranscriptPath: vi.fn() } as never,
+    };
+
+    const result = await enterWorktreeTool.execute({}, contextWithHooks);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("WorktreeCreate hook produced no path");
+    expect(worktreeUtils.createWorktree).not.toHaveBeenCalled();
+  });
+
+  it("should call createWorktree when no hook is configured", async () => {
     vi.mocked(worktreeUtils.generateWorktreeName).mockReturnValue("no-hook");
     vi.mocked(worktreeUtils.createWorktree).mockReturnValue({
       name: "no-hook",
@@ -251,38 +288,12 @@ describe("enterWorktreeTool", () => {
       originalHeadCommit: "abc123",
     });
 
-    const contextWithoutHooks: ToolContext = {
-      ...mockContext,
-      hookManager: undefined,
-      messageManager: {} as never,
-    };
-
-    const result = await enterWorktreeTool.execute({}, contextWithoutHooks);
-
-    expect(result.success).toBe(true);
-    expect(result.content).not.toContain("WorktreeCreate hooks were executed");
-  });
-
-  it("should not fail tool when hooks throw an error", async () => {
-    const mockExecuteHooks = vi
-      .fn()
-      .mockRejectedValue(new Error("Hook execution failed"));
-
-    vi.mocked(worktreeUtils.generateWorktreeName).mockReturnValue("error-hook");
-    vi.mocked(worktreeUtils.createWorktree).mockReturnValue({
-      name: "error-hook",
-      path: "/test/repo/.wave/worktrees/error-hook",
-      branch: "worktree-error-hook",
-      repoRoot: "/test/repo",
-      isNew: true,
-      originalHeadCommit: "abc123",
-    });
-
     const contextWithHooks: ToolContext = {
       ...mockContext,
       hookManager: {
-        executeHooks: mockExecuteHooks,
+        executeHooks: vi.fn(),
         processHookResults: vi.fn(),
+        hasHooks: vi.fn().mockReturnValue(false),
       } as never,
       messageManager: {} as never,
     };
@@ -292,5 +303,9 @@ describe("enterWorktreeTool", () => {
     expect(result.success).toBe(true);
     expect(result.content).toContain("Created worktree");
     expect(result.content).not.toContain("WorktreeCreate hooks were executed");
+    expect(worktreeUtils.createWorktree).toHaveBeenCalledWith(
+      "no-hook",
+      "/test/repo",
+    );
   });
 });

--- a/packages/agent-sdk/tests/tools/exitWorktreeTool.test.ts
+++ b/packages/agent-sdk/tests/tools/exitWorktreeTool.test.ts
@@ -20,6 +20,7 @@ describe("exitWorktreeTool", () => {
     isNew: true,
     repoRoot: "/repo",
     originalHeadCommit: "abc123",
+    hookBased: false,
   };
 
   beforeEach(() => {
@@ -36,7 +37,6 @@ describe("exitWorktreeTool", () => {
       } as never,
     };
 
-    // Default: no active session (override in specific tests)
     vi.mocked(worktreeSession.getCurrentWorktreeSession).mockReturnValue(null);
   });
 
@@ -174,7 +174,7 @@ describe("exitWorktreeTool", () => {
       expect(worktreeUtils.removeWorktree).toHaveBeenCalled();
     });
 
-    it("should trigger WorktreeRemove hooks when hookManager is available", async () => {
+    it("should use hook to remove worktree when hookBased and WorktreeRemove hooks are configured", async () => {
       const mockExecuteHooks = vi.fn().mockResolvedValue([]);
       const mockProcessHookResults = vi.fn();
       const mockGetTranscriptPath = vi
@@ -185,12 +185,17 @@ describe("exitWorktreeTool", () => {
         changedFiles: 0,
         commits: 0,
       });
+      vi.mocked(worktreeSession.getCurrentWorktreeSession).mockReturnValue({
+        ...mockSession,
+        hookBased: true,
+      });
 
       const contextWithHooks: ToolContext = {
         ...mockContext,
         hookManager: {
           executeHooks: mockExecuteHooks,
           processHookResults: mockProcessHookResults,
+          hasHooks: vi.fn().mockReturnValue(true),
         } as never,
         messageManager: {
           getTranscriptPath: mockGetTranscriptPath,
@@ -207,11 +212,11 @@ describe("exitWorktreeTool", () => {
       expect(result.content).toContain("WorktreeRemove hooks were executed");
       expect(mockExecuteHooks).toHaveBeenCalledWith("WorktreeRemove", {
         event: "WorktreeRemove",
-        projectDir: "/original/dir",
+        projectDir: "/repo",
         timestamp: expect.any(Date),
         sessionId: "test-session-id",
         transcriptPath: "/test/transcript.jsonl",
-        cwd: "/original/dir",
+        cwd: "/repo",
         worktreePath: "/repo/.wave/worktrees/test",
         env: expect.any(Object),
       });
@@ -220,38 +225,11 @@ describe("exitWorktreeTool", () => {
         [],
         contextWithHooks.messageManager,
       );
+      expect(worktreeUtils.removeWorktree).not.toHaveBeenCalled();
     });
 
-    it("should NOT trigger hooks when hookManager is not available", async () => {
+    it("should call removeWorktree when hookBased is false even if hooks are configured", async () => {
       const mockExecuteHooks = vi.fn().mockResolvedValue([]);
-
-      vi.mocked(worktreeUtils.countWorktreeChanges).mockReturnValue({
-        changedFiles: 0,
-        commits: 0,
-      });
-
-      const contextWithoutHooks: ToolContext = {
-        ...mockContext,
-        hookManager: undefined,
-        messageManager: {} as never,
-      };
-
-      const result = await exitWorktreeTool.execute(
-        { action: "remove" },
-        contextWithoutHooks,
-      );
-
-      expect(result.success).toBe(true);
-      expect(result.content).not.toContain(
-        "WorktreeRemove hooks were executed",
-      );
-      expect(mockExecuteHooks).not.toHaveBeenCalled();
-    });
-
-    it("should not fail tool when hooks throw an error", async () => {
-      const mockExecuteHooks = vi
-        .fn()
-        .mockRejectedValue(new Error("Hook execution failed"));
 
       vi.mocked(worktreeUtils.countWorktreeChanges).mockReturnValue({
         changedFiles: 0,
@@ -263,8 +241,46 @@ describe("exitWorktreeTool", () => {
         hookManager: {
           executeHooks: mockExecuteHooks,
           processHookResults: vi.fn(),
+          hasHooks: vi.fn().mockReturnValue(true),
         } as never,
-        messageManager: {} as never,
+        messageManager: { addErrorBlock: vi.fn() } as never,
+      };
+
+      const result = await exitWorktreeTool.execute(
+        { action: "remove" },
+        contextWithHooks,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.content).not.toContain(
+        "WorktreeRemove hooks were executed",
+      );
+      expect(mockExecuteHooks).not.toHaveBeenCalled();
+      expect(worktreeUtils.removeWorktree).toHaveBeenCalled();
+    });
+
+    it("should not fail tool when hooks throw an error", async () => {
+      const mockExecuteHooks = vi
+        .fn()
+        .mockRejectedValue(new Error("Hook execution failed"));
+
+      vi.mocked(worktreeUtils.countWorktreeChanges).mockReturnValue({
+        changedFiles: 0,
+        commits: 0,
+      });
+      vi.mocked(worktreeSession.getCurrentWorktreeSession).mockReturnValue({
+        ...mockSession,
+        hookBased: true,
+      });
+
+      const contextWithHooks: ToolContext = {
+        ...mockContext,
+        hookManager: {
+          executeHooks: mockExecuteHooks,
+          processHookResults: vi.fn(),
+          hasHooks: vi.fn().mockReturnValue(true),
+        } as never,
+        messageManager: { addErrorBlock: vi.fn() } as never,
       };
 
       const result = await exitWorktreeTool.execute(
@@ -282,18 +298,20 @@ describe("exitWorktreeTool", () => {
     it("should NOT trigger WorktreeRemove hooks when action is keep", async () => {
       const mockExecuteHooks = vi.fn().mockResolvedValue([]);
 
+      vi.mocked(worktreeSession.getCurrentWorktreeSession).mockReturnValue({
+        ...mockSession,
+        hookBased: true,
+      });
+
       const contextWithHooks: ToolContext = {
         ...mockContext,
         hookManager: {
           executeHooks: mockExecuteHooks,
           processHookResults: vi.fn(),
+          hasHooks: vi.fn().mockReturnValue(true),
         } as never,
-        messageManager: {} as never,
+        messageManager: { addErrorBlock: vi.fn() } as never,
       };
-
-      vi.mocked(worktreeSession.getCurrentWorktreeSession).mockReturnValue(
-        mockSession,
-      );
 
       const result = await exitWorktreeTool.execute(
         { action: "keep" },

--- a/packages/agent-sdk/tests/utils/worktreeSession.test.ts
+++ b/packages/agent-sdk/tests/utils/worktreeSession.test.ts
@@ -23,6 +23,7 @@ describe("worktreeSession", () => {
       worktreeBranch: "worktree-test",
       worktreeName: "test",
       isNew: true,
+      hookBased: false,
       repoRoot: "/repo",
       originalHeadCommit: "abc123",
     };
@@ -38,6 +39,7 @@ describe("worktreeSession", () => {
       worktreeBranch: "worktree-test",
       worktreeName: "test",
       isNew: true,
+      hookBased: false,
       repoRoot: "/repo",
     };
 

--- a/packages/code/src/cli.tsx
+++ b/packages/code/src/cli.tsx
@@ -68,7 +68,7 @@ export async function startCli(options: CliOptions): Promise<void> {
     // Cleanup worktree if requested
     if (shouldRemoveWorktree && worktreeSession) {
       process.chdir(worktreeSession.repoRoot);
-      removeWorktree(worktreeSession);
+      await removeWorktree(worktreeSession);
     }
 
     process.exit(0);

--- a/packages/code/src/components/App.tsx
+++ b/packages/code/src/components/App.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { useInput } from "ink";
 import { ChatInterface } from "./ChatInterface.js";
-import { ChatProvider, useChat } from "../contexts/useChat.js";
+import { ChatProvider } from "../contexts/useChat.js";
 import { AppProvider } from "../contexts/useAppConfig.js";
 import { WorktreeExitPrompt } from "./WorktreeExitPrompt.js";
 import {
@@ -21,12 +21,11 @@ interface AppWithProvidersProps extends BaseAppProps {
   onExit: (shouldRemove: boolean) => void;
 }
 
-/** Wraps ChatInterface with worktree exit handling, using useChat() for hook access. */
+/** Wraps ChatInterface with worktree exit handling. */
 const ChatWithExitPrompt: React.FC<{
   worktreeSession: NonNullable<BaseAppProps["worktreeSession"]>;
   onExit: (shouldRemove: boolean) => void;
 }> = ({ worktreeSession, onExit }) => {
-  const { triggerWorktreeRemoveHook } = useChat();
   const [isExiting, setIsExiting] = useState(false);
   const [worktreeStatus, setWorktreeStatus] = useState<{
     hasUncommittedChanges: boolean;
@@ -77,10 +76,7 @@ const ChatWithExitPrompt: React.FC<{
         hasUncommittedChanges={worktreeStatus.hasUncommittedChanges}
         hasNewCommits={worktreeStatus.hasNewCommits}
         onKeep={() => onExit(false)}
-        onRemove={async () => {
-          await triggerWorktreeRemoveHook(worktreeSession.path);
-          onExit(true);
-        }}
+        onRemove={() => onExit(true)}
         onCancel={() => setIsExiting(false)}
       />
     );

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -129,8 +129,6 @@ export interface ChatContextType {
   workdir?: string;
   // Agent recreation (e.g. after plugin install)
   recreateAgent: () => void;
-  // Trigger WorktreeRemove hook BEFORE agent destruction
-  triggerWorktreeRemoveHook: (worktreePath: string) => Promise<void>;
   // Goal state
   isGoalActive: boolean;
   goalElapsed?: string;
@@ -471,7 +469,6 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
           disallowedTools,
           workdir,
           worktreeName: worktreeSession?.name,
-          isNewWorktree: worktreeSession?.isNew,
           model,
           mcpServers,
         });
@@ -567,14 +564,6 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
       }
     };
   }, []);
-
-  // Trigger WorktreeRemove hook BEFORE agent destruction
-  const triggerWorktreeRemoveHook = useCallback(
-    async (worktreePath: string) => {
-      await agentRef.current?.triggerWorktreeRemoveHook(worktreePath);
-    },
-    [],
-  );
 
   // Send message function (including judgment logic)
   const sendMessage = useCallback(
@@ -893,7 +882,6 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
     version,
     workdir,
     recreateAgent,
-    triggerWorktreeRemoveHook,
     isGoalActive,
     goalElapsed,
     isGoalEvaluating,

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -324,7 +324,7 @@ export async function main() {
       if (!name || name === "") {
         name = generateRandomName();
       }
-      worktreeSession = createWorktree(name, originalCwd);
+      worktreeSession = await createWorktree(name, originalCwd);
 
       // Register worktree session so system prompt includes worktree warnings
       setCurrentWorktreeSession({
@@ -334,6 +334,7 @@ export async function main() {
         worktreeName: worktreeSession.name,
         isNew: worktreeSession.isNew,
         repoRoot: worktreeSession.repoRoot,
+        hookBased: worktreeSession.hookBased,
       });
     }
 

--- a/packages/code/src/print-cli.ts
+++ b/packages/code/src/print-cli.ts
@@ -167,7 +167,7 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
       const hasCommits = hasNewCommits(cwd, baseBranch);
 
       if (!hasChanges && !hasCommits) {
-        removeWorktree(worktreeSession);
+        await removeWorktree(worktreeSession);
       } else {
         process.stdout.write(
           `\n⚠️ Worktree '${worktreeSession.name}' has changes or commits. Keeping it at: ${worktreeSession.path}\n`,
@@ -203,7 +203,7 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
         const hasCommits = hasNewCommits(cwd, baseBranch);
 
         if (!hasChanges && !hasCommits) {
-          removeWorktree(worktreeSession);
+          await removeWorktree(worktreeSession);
         } else {
           process.stdout.write(
             `\n⚠️ Worktree '${worktreeSession.name}' has changes or commits. Keeping it at: ${worktreeSession.path}\n`,

--- a/packages/code/src/utils/worktree.ts
+++ b/packages/code/src/utils/worktree.ts
@@ -1,7 +1,12 @@
 import { execFileSync } from "node:child_process";
 import * as path from "node:path";
 import * as fs from "node:fs";
-import { getDefaultRemoteBranch, getGitMainRepoRoot } from "wave-agent-sdk";
+import {
+  getDefaultRemoteBranch,
+  getGitMainRepoRoot,
+  executeWorktreeCreateHookDirect,
+  executeWorktreeRemoveHookDirect,
+} from "wave-agent-sdk";
 
 export interface WorktreeSession {
   name: string;
@@ -11,6 +16,7 @@ export interface WorktreeSession {
   hasUncommittedChanges: boolean;
   hasNewCommits: boolean;
   isNew: boolean;
+  hookBased: boolean;
 }
 
 /**
@@ -19,8 +25,26 @@ export interface WorktreeSession {
  * @param cwd Current working directory
  * @returns Worktree session details
  */
-export function createWorktree(name: string, cwd: string): WorktreeSession {
+export async function createWorktree(
+  name: string,
+  cwd: string,
+): Promise<WorktreeSession> {
   const repoRoot = getGitMainRepoRoot(cwd);
+
+  const hookPath = await executeWorktreeCreateHookDirect(name, repoRoot);
+  if (hookPath) {
+    return {
+      name,
+      path: hookPath,
+      branch: `worktree-${name}`,
+      repoRoot,
+      hasUncommittedChanges: false,
+      hasNewCommits: false,
+      isNew: true,
+      hookBased: true,
+    };
+  }
+
   const worktreePath = path.join(repoRoot, ".wave", "worktrees", name);
   const branchName = `worktree-${name}`;
   const baseBranch = getDefaultRemoteBranch(cwd);
@@ -42,6 +66,7 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
       hasUncommittedChanges: false,
       hasNewCommits: false,
       isNew: false,
+      hookBased: false,
     };
   }
 
@@ -64,6 +89,7 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
       hasUncommittedChanges: false,
       hasNewCommits: false,
       isNew: true,
+      hookBased: false,
     };
   } catch (error: unknown) {
     const stderr = (error as { stderr?: Buffer }).stderr?.toString() || "";
@@ -82,6 +108,7 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
           hasUncommittedChanges: false,
           hasNewCommits: false,
           isNew: true,
+          hookBased: false,
         };
       } catch (innerError: unknown) {
         throw new Error(
@@ -116,6 +143,7 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
           hasUncommittedChanges: false,
           hasNewCommits: false,
           isNew: true,
+          hookBased: false,
         };
       } catch {
         // Fetch or retry failed — fall back to HEAD
@@ -136,6 +164,7 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
             hasUncommittedChanges: false,
             hasNewCommits: false,
             isNew: true,
+            hookBased: false,
           };
         } catch {
           throw new Error(
@@ -154,7 +183,15 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
  * Remove a git worktree and its associated branch
  * @param session Worktree session details
  */
-export function removeWorktree(session: WorktreeSession): void {
+export async function removeWorktree(session: WorktreeSession): Promise<void> {
+  if (session.hookBased) {
+    const removed = await executeWorktreeRemoveHookDirect(
+      session.path,
+      session.repoRoot,
+    );
+    if (removed) return;
+  }
+
   const repoRoot = session.repoRoot;
 
   try {

--- a/packages/code/tests/cli.test.tsx
+++ b/packages/code/tests/cli.test.tsx
@@ -40,6 +40,7 @@ describe("startCli", () => {
       hasUncommittedChanges: false,
       hasNewCommits: false,
       isNew: true,
+      hookBased: false,
     };
 
     // Mock render to call onExit with true

--- a/packages/code/tests/components/App.test.tsx
+++ b/packages/code/tests/components/App.test.tsx
@@ -83,6 +83,7 @@ describe("App Component", () => {
       hasUncommittedChanges: false,
       hasNewCommits: false,
       isNew: false,
+      hookBased: false,
     };
 
     vi.mocked(hasUncommittedChanges).mockReturnValue(false);
@@ -110,6 +111,7 @@ describe("App Component", () => {
       hasUncommittedChanges: false,
       hasNewCommits: false,
       isNew: false,
+      hookBased: false,
     };
 
     vi.mocked(hasUncommittedChanges).mockReturnValue(true);

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -91,7 +91,6 @@ describe("ChatProvider", () => {
     askBtw: vi.fn(),
     usages: [],
     sessionFilePath: "test-path",
-    triggerWorktreeRemoveHook: vi.fn(),
     getModelConfig: vi.fn(() => ({
       model: "test-model",
       fastModel: "test-fast-model",

--- a/packages/code/tests/index.test.ts
+++ b/packages/code/tests/index.test.ts
@@ -54,15 +54,19 @@ vi.mock("../src/cli.js");
 vi.mock("../src/print-cli.js");
 vi.mock("../src/session-selector-cli.js");
 vi.mock("../src/utils/worktree.js", () => ({
-  createWorktree: vi.fn().mockImplementation((name, cwd) => ({
-    name,
-    path: path.join(cwd, "..", `${path.basename(cwd)}.worktrees`, name),
-    branch: `worktree-${name}`,
-    repoRoot: cwd,
-    hasUncommittedChanges: false,
-    hasNewCommits: false,
-  })),
-  removeWorktree: vi.fn(),
+  createWorktree: vi.fn().mockImplementation((name, cwd) =>
+    Promise.resolve({
+      name,
+      path: path.join(cwd, "..", `${path.basename(cwd)}.worktrees`, name),
+      branch: `worktree-${name}`,
+      repoRoot: cwd,
+      isNew: true,
+      hasUncommittedChanges: false,
+      hasNewCommits: false,
+      hookBased: false,
+    }),
+  ),
+  removeWorktree: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe("main", () => {

--- a/packages/code/tests/utils/worktree.test.ts
+++ b/packages/code/tests/utils/worktree.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import { createWorktree, removeWorktree } from "../../src/utils/worktree.js";
-import { getDefaultRemoteBranch, getGitMainRepoRoot } from "wave-agent-sdk";
+import {
+  getDefaultRemoteBranch,
+  getGitMainRepoRoot,
+  executeWorktreeCreateHookDirect,
+  executeWorktreeRemoveHookDirect,
+} from "wave-agent-sdk";
 
 vi.mock("node:child_process", () => ({
   execFileSync: vi.fn(),
@@ -16,26 +21,31 @@ vi.mock("node:fs", () => ({
 vi.mock("wave-agent-sdk", () => ({
   getGitMainRepoRoot: vi.fn(),
   getDefaultRemoteBranch: vi.fn(),
+  executeWorktreeCreateHookDirect: vi.fn().mockResolvedValue(null),
+  executeWorktreeRemoveHookDirect: vi.fn().mockResolvedValue(false),
 }));
 
 describe("worktree utils", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(executeWorktreeCreateHookDirect).mockResolvedValue(null);
+    vi.mocked(executeWorktreeRemoveHookDirect).mockResolvedValue(false);
   });
 
   describe("createWorktree", () => {
-    it("should create a new worktree", () => {
+    it("should create a new worktree", async () => {
       vi.mocked(getGitMainRepoRoot).mockReturnValue("/repo/root");
       vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
-      const session = createWorktree("my-feat", "/repo/root");
+      const session = await createWorktree("my-feat", "/repo/root");
 
       expect(session.name).toBe("my-feat");
       expect(session.path).toBe("/repo/root/.wave/worktrees/my-feat");
       expect(session.branch).toBe("worktree-my-feat");
       expect(session.repoRoot).toBe("/repo/root");
       expect(session.isNew).toBe(true);
+      expect(session.hookBased).toBe(false);
       expect(execFileSync).toHaveBeenCalledWith(
         "git",
         expect.arrayContaining(["worktree", "add", "-b", "worktree-my-feat"]),
@@ -43,23 +53,23 @@ describe("worktree utils", () => {
       );
     });
 
-    it("should reuse an existing worktree", () => {
+    it("should reuse an existing worktree", async () => {
       vi.mocked(getGitMainRepoRoot).mockReturnValue("/repo/root");
       vi.mocked(fs.existsSync).mockReturnValue(true);
 
-      const session = createWorktree("my-feat", "/repo/root");
+      const session = await createWorktree("my-feat", "/repo/root");
 
       expect(session.name).toBe("my-feat");
       expect(session.isNew).toBe(false);
+      expect(session.hookBased).toBe(false);
       expect(execFileSync).not.toHaveBeenCalled();
     });
 
-    it("should handle branch already exists error by adding worktree without -b", () => {
+    it("should handle branch already exists error by adding worktree without -b", async () => {
       vi.mocked(getGitMainRepoRoot).mockReturnValue("/repo/root");
       vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
-      // First call fails with "already exists"
       const error = new Error("Command failed");
       (error as { stderr?: Buffer }).stderr = Buffer.from(
         "fatal: a branch named 'worktree-my-feat' already exists",
@@ -68,14 +78,14 @@ describe("worktree utils", () => {
         throw error;
       });
 
-      // Second call succeeds
       vi.mocked(execFileSync).mockImplementationOnce(() => Buffer.from(""));
 
-      const session = createWorktree("my-feat", "/repo/root");
+      const session = await createWorktree("my-feat", "/repo/root");
 
       expect(session.name).toBe("my-feat");
       expect(session.repoRoot).toBe("/repo/root");
       expect(session.isNew).toBe(true);
+      expect(session.hookBased).toBe(false);
       expect(execFileSync).toHaveBeenCalledTimes(2);
       expect(execFileSync).toHaveBeenCalledWith(
         "git",
@@ -84,7 +94,7 @@ describe("worktree utils", () => {
       );
     });
 
-    it("should throw error if worktree creation fails with other error", () => {
+    it("should throw error if worktree creation fails with other error", async () => {
       vi.mocked(getGitMainRepoRoot).mockReturnValue("/repo/root");
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
@@ -93,12 +103,12 @@ describe("worktree utils", () => {
         throw error;
       });
 
-      expect(() => createWorktree("my-feat", "/repo/root")).toThrow(
+      await expect(createWorktree("my-feat", "/repo/root")).rejects.toThrow(
         "Failed to create worktree",
       );
     });
 
-    it("should throw error if adding existing branch fails", () => {
+    it("should throw error if adding existing branch fails", async () => {
       vi.mocked(getGitMainRepoRoot).mockReturnValue("/repo/root");
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
@@ -114,17 +124,16 @@ describe("worktree utils", () => {
         throw new Error("Inner error");
       });
 
-      expect(() => createWorktree("my-feat", "/repo/root")).toThrow(
+      await expect(createWorktree("my-feat", "/repo/root")).rejects.toThrow(
         "Failed to add existing worktree branch",
       );
     });
 
-    it("should fetch default branch when not found locally, then create worktree", () => {
+    it("should fetch default branch when not found locally, then create worktree", async () => {
       vi.mocked(getGitMainRepoRoot).mockReturnValue("/repo/root");
       vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
-      // First git worktree add -b fails — branch not fetched
       const error = new Error("Command failed");
       (error as { stderr?: Buffer }).stderr = Buffer.from(
         "not a valid object name",
@@ -133,15 +142,13 @@ describe("worktree utils", () => {
         throw error;
       });
 
-      // git fetch origin main succeeds
+      vi.mocked(execFileSync).mockImplementationOnce(() => Buffer.from(""));
       vi.mocked(execFileSync).mockImplementationOnce(() => Buffer.from(""));
 
-      // Retry git worktree add -b succeeds
-      vi.mocked(execFileSync).mockImplementationOnce(() => Buffer.from(""));
-
-      const session = createWorktree("my-feat", "/repo/root");
+      const session = await createWorktree("my-feat", "/repo/root");
 
       expect(session.isNew).toBe(true);
+      expect(session.hookBased).toBe(false);
       expect(execFileSync).toHaveBeenCalledWith(
         "git",
         expect.arrayContaining(["fetch", "origin", "main"]),
@@ -149,12 +156,11 @@ describe("worktree utils", () => {
       );
     });
 
-    it("should fall back to HEAD when fetch also fails", () => {
+    it("should fall back to HEAD when fetch also fails", async () => {
       vi.mocked(getGitMainRepoRoot).mockReturnValue("/repo/root");
       vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
-      // First git worktree add -b fails
       const error = new Error("Command failed");
       (error as { stderr?: Buffer }).stderr = Buffer.from(
         "not a valid object name",
@@ -163,17 +169,16 @@ describe("worktree utils", () => {
         throw error;
       });
 
-      // git fetch origin main fails
       vi.mocked(execFileSync).mockImplementationOnce(() => {
         throw new Error("fetch failed");
       });
 
-      // git worktree add -b ... HEAD succeeds
       vi.mocked(execFileSync).mockImplementationOnce(() => Buffer.from(""));
 
-      const session = createWorktree("my-feat", "/repo/root");
+      const session = await createWorktree("my-feat", "/repo/root");
 
       expect(session.isNew).toBe(true);
+      expect(session.hookBased).toBe(false);
       expect(execFileSync).toHaveBeenCalledWith(
         "git",
         expect.arrayContaining([
@@ -187,12 +192,11 @@ describe("worktree utils", () => {
       );
     });
 
-    it("should throw when both fetch and HEAD fallback fail", () => {
+    it("should throw when both fetch and HEAD fallback fail", async () => {
       vi.mocked(getGitMainRepoRoot).mockReturnValue("/repo/root");
       vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
-      // First git worktree add -b fails
       const error = new Error("Command failed");
       (error as { stderr?: Buffer }).stderr = Buffer.from(
         "not a valid object name",
@@ -201,24 +205,22 @@ describe("worktree utils", () => {
         throw error;
       });
 
-      // git fetch origin main fails
       vi.mocked(execFileSync).mockImplementationOnce(() => {
         throw new Error("fetch failed");
       });
 
-      // git worktree add -b ... HEAD also fails
       vi.mocked(execFileSync).mockImplementationOnce(() => {
         throw new Error("HEAD fallback failed");
       });
 
-      expect(() => createWorktree("my-feat", "/repo/root")).toThrow(
+      await expect(createWorktree("my-feat", "/repo/root")).rejects.toThrow(
         "Failed to create worktree",
       );
     });
   });
 
   describe("removeWorktree", () => {
-    it("should remove worktree and branch", () => {
+    it("should remove worktree and branch", async () => {
       const session = {
         name: "my-feat",
         path: "/repo/root/.wave/worktrees/my-feat",
@@ -227,13 +229,14 @@ describe("worktree utils", () => {
         hasUncommittedChanges: false,
         hasNewCommits: false,
         isNew: false,
+        hookBased: false,
       };
 
       vi.mocked(execFileSync).mockReturnValue(
         Buffer.from("worktree-my-feat\n"),
       );
 
-      removeWorktree(session);
+      await removeWorktree(session);
 
       expect(execFileSync).toHaveBeenCalledWith(
         "git",
@@ -247,7 +250,7 @@ describe("worktree utils", () => {
       );
     });
 
-    it("should remove worktree, original branch, and current branch if different", () => {
+    it("should remove worktree, original branch, and current branch if different", async () => {
       const session = {
         name: "my-feat",
         path: "/repo/root/.wave/worktrees/my-feat",
@@ -256,6 +259,7 @@ describe("worktree utils", () => {
         hasUncommittedChanges: false,
         hasNewCommits: false,
         isNew: false,
+        hookBased: false,
       };
 
       vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
@@ -271,7 +275,7 @@ describe("worktree utils", () => {
         return "";
       });
 
-      removeWorktree(session);
+      await removeWorktree(session);
 
       expect(execFileSync).toHaveBeenCalledWith(
         "git",
@@ -290,7 +294,7 @@ describe("worktree utils", () => {
       );
     });
 
-    it("should NOT remove current branch if it is a protected branch", () => {
+    it("should NOT remove current branch if it is a protected branch", async () => {
       const session = {
         name: "my-feat",
         path: "/repo/root/.wave/worktrees/my-feat",
@@ -299,6 +303,7 @@ describe("worktree utils", () => {
         hasUncommittedChanges: false,
         hasNewCommits: false,
         isNew: false,
+        hookBased: false,
       };
 
       vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
@@ -314,7 +319,7 @@ describe("worktree utils", () => {
         return "";
       });
 
-      removeWorktree(session);
+      await removeWorktree(session);
 
       expect(execFileSync).toHaveBeenCalledWith(
         "git",
@@ -333,7 +338,7 @@ describe("worktree utils", () => {
       );
     });
 
-    it("should log error if removal fails", () => {
+    it("should log error if removal fails", async () => {
       const consoleSpy = vi
         .spyOn(console, "error")
         .mockImplementation(() => {});
@@ -349,9 +354,10 @@ describe("worktree utils", () => {
         hasUncommittedChanges: false,
         hasNewCommits: false,
         isNew: false,
+        hookBased: false,
       };
 
-      removeWorktree(session);
+      await removeWorktree(session);
 
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining("Failed to remove worktree or branch"),

--- a/specs/047-worktree.md
+++ b/specs/047-worktree.md
@@ -151,8 +151,8 @@
 - **FR-015**：如果用户取消退出提示（例如通过 Esc），CLI 必须返回活动会话。
 - **FR-016**：如果同名 worktree 已存在，系统必须重用它并跳过创建步骤。
 - **FR-017**：退出检测必须在 500ms 内完成，以避免用户可感知的延迟。
-- **FR-018**：系统必须在新 worktree 创建时触发 `WorktreeCreate` 钩子事件。
-- **FR-019**：`WorktreeCreate` 钩子必须通过 stdin 提供包含 `name` 字段的 JSON 输入。钩子必须在新创建的 worktree 目录中执行。
+- **FR-018**：当配置了 `WorktreeCreate` 钩子时，钩子即是创建机制——钩子负责运行 `git worktree add` 并在 stdout 输出 worktree 绝对路径。未配置时回退到内置 `git worktree add`。
+- **FR-019**：`WorktreeCreate` 钩子必须在主仓库目录中执行（worktree 尚未创建）。`WAVE_PROJECT_DIR` 指向主仓库。stdin JSON 含 `name` 字段。
 - **FR-020**：重用现有 worktree 时不得触发 `WorktreeCreate` 钩子。
 - **FR-021**：在 worktree 会话期间，系统必须自动拒绝尝试修改主仓库（当前 worktree 之外）文件的 `Write` 和 `Edit` 工具操作。
 - **FR-022**：自动拒绝机制必须提供描述性错误消息，说明在 worktree 会话期间对主仓库的修改受到限制。
@@ -172,8 +172,11 @@
 - **FR-036**：如果没有活跃的 EnterWorktree 会话，`ExitWorktree` 工具必须是无操作（无文件系统更改）。
 - **FR-037**：`ExitWorktree` 工具必须通过 `AIManager.setWorkdir()` 将会话的工作目录恢复到原始 CWD。
 - **FR-038**：当 `action` 为 `"remove"` 时，系统必须使用 `git worktree remove --force` 删除 worktree 目录，并使用 `git branch -D` 删除关联分支。
-- **FR-039**：`EnterWorktree` 工具不得触发 `WorktreeCreate` 钩子事件（钩子支持不在会话中工具的范围内）。
+- **FR-039**：`EnterWorktree` 工具在配置了 `WorktreeCreate` 钩子时通过钩子创建 worktree（从 stdout 提取路径）。未配置时使用内置 `git worktree add`。
 - **FR-040**：系统必须验证从 `origin/HEAD` 解析的分支存在于 `refs/remotes/origin/` 中。如果分支不存在（陈旧的 `origin/HEAD`），系统必须尝试 `git fetch origin HEAD` 来解析正确的默认分支。
+- **FR-041**：当配置了 `WorktreeRemove` 钩子且 worktree 会话为钩子创建（`hookBased: true`）时，钩子负责删除 worktree 目录。未配置时回退到 `git worktree remove`。
+- **FR-042**：`WorktreeSession` 必须跟踪 `hookBased` 标志，标识 worktree 是否由钩子创建，以决定删除路径。
+- **FR-043**：`WorktreeRemove` 钩子必须在主仓库目录中执行。stdin JSON 含 `worktree_path` 字段，指向要删除的 worktree 路径。
 
 ### 关键实体
 


### PR DESCRIPTION
## Summary

WorktreeCreate/WorktreeRemove hooks now ARE the worktree creation/removal mechanism (like Claude Code), not post-action notifications. The hook runs `git worktree add` itself and outputs the worktree path on stdout.

## Changes

### New file
- `worktreeHooks.ts`: `extractWorktreePath`, `hasWorktreeHook`, `executeWorktreeCreateHookDirect`, `executeWorktreeRemoveHookDirect`

### Source changes
- **enterWorktreeTool**: uses hook when configured (extracts path from stdout), falls back to `git worktree add`
- **exitWorktreeTool**: uses hook when `hookBased` + configured, falls back to `git worktree remove` on hook failure (with error reporting via `addErrorBlock`)
- **worktree.ts** (code package): `createWorktree`/`removeWorktree` now async with hook integration for CLI `--worktree` path
- **hook.ts**: `buildHookJsonInput` serializes `worktree_path` for WorktreeRemove events
- **hooks.ts**: `HookEnvironment` index signature widened to `string | undefined`
- **worktreeSession.ts**: added `hookBased` flag to `WorktreeSession`

### Deleted
- `agent.triggerWorktreeRemoveHook()` method
- `isNewWorktree` field from `AgentOptions`
- `initializationService` post-creation WorktreeCreate hook trigger
- `useChat`/`App.tsx` hook trigger wiring

### Spec
- Spec 047 updated: FR-018/019/039 rewritten, FR-041/042/043 added

## Test plan
- [x] All existing tests updated and passing (173 tests: 86 SDK + 87 code)
- [x] Type-check passes across all packages
- [x] Lint passes
- [x] Build passes for both `wave-agent-sdk` and `wave-code`