### PR TITLE
fix: serialize worktree_path in WorktreeRemove hook JSON input

### DIFF
--- a/packages/agent-sdk/builtin/skills/settings/HOOKS.md
+++ b/packages/agent-sdk/builtin/skills/settings/HOOKS.md
@@ -13,7 +13,7 @@ Wave supports the following hook events:
 - `Stop`: Triggered when Wave finishes its response cycle (no more tool calls).
 - `SubagentStop`: Triggered when a subagent finishes its response cycle.
 - `WorktreeCreate`: Triggered when a new worktree is created.
-- `WorktreeRemove`: Triggered when a worktree is removed (e.g., via ExitWorktree with `action: "remove"`). Non-blocking. Useful for cleanup tasks after worktree deletion.
+- `WorktreeRemove`: Triggered when a worktree is removed (e.g., via ExitWorktree with `action: "remove"`). Non-blocking. The hook receives `worktree_path` in the JSON input. Useful for cleanup tasks (e.g., `docker compose -p $(basename "$worktree_path") down`) after worktree deletion.
 - `CwdChanged`: Triggered when the working directory changes (e.g., entering/exiting a worktree). Non-blocking.
 - `SessionStart`: Triggered during session initialization. Hooks can inject `additionalContext` and `initialUserMessage` via stdout.
 - `SessionEnd`: Triggered during agent destruction (fire-and-forget, non-blocking). Useful for cleanup, resource teardown, and analytics.
@@ -79,6 +79,7 @@ Wave provides detailed context to hook processes via `stdin` as a JSON object. T
 - `user_prompt`: (UserPromptSubmit) The text submitted by the user.
 - `subagent_type`: (If executed by a subagent) The type of the subagent.
 - `name`: (WorktreeCreate) The name of the new worktree.
+- `worktree_path`: (WorktreeRemove) The absolute path to the removed worktree.
 - `old_cwd`: (CwdChanged) The previous working directory.
 - `new_cwd`: (CwdChanged) The new working directory.
 - `compact_instructions`: (PreCompact) Custom instructions for the compaction, if any.

--- a/packages/agent-sdk/src/services/hook.ts
+++ b/packages/agent-sdk/src/services/hook.ts
@@ -89,6 +89,13 @@ async function buildHookJsonInput(
     }
   }
 
+  // Add worktree_path field for WorktreeRemove events
+  if (context.event === "WorktreeRemove") {
+    if (context.worktreePath !== undefined) {
+      jsonInput.worktree_path = context.worktreePath;
+    }
+  }
+
   // Add SessionStart-specific fields
   if (context.event === "SessionStart") {
     if (context.source !== undefined) {

--- a/packages/agent-sdk/src/types/hooks.ts
+++ b/packages/agent-sdk/src/types/hooks.ts
@@ -188,6 +188,7 @@ export interface HookJsonInput {
   user_prompt?: string; // Present for UserPromptSubmit only
   subagent_type?: string; // Present when hook is executed by a subagent
   name?: string; // Present for WorktreeCreate events
+  worktree_path?: string; // Present for WorktreeRemove events
   old_cwd?: string; // Present for CwdChanged events
   new_cwd?: string; // Present for CwdChanged events
   source?: SessionStartSource; // Present for SessionStart events

--- a/packages/agent-sdk/tests/services/hook.test.ts
+++ b/packages/agent-sdk/tests/services/hook.test.ts
@@ -706,6 +706,51 @@ describe("Hook Services", () => {
     });
   });
 
+  describe("WorktreeRemove hook", () => {
+    it("should include worktree_path in JSON input for WorktreeRemove event", async () => {
+      const mockProcess = new MockChildProcess();
+      const mockStdin = new MockStdin();
+      let stdinData = "";
+
+      vi.spyOn(mockStdin, "write").mockImplementation(
+        (_data?: string | Buffer | Uint8Array) => {
+          if (_data) {
+            stdinData += _data.toString();
+          }
+          return true;
+        },
+      );
+
+      mockProcess.stdin = mockStdin;
+      mockSpawn.mockReturnValue(mockProcess);
+
+      const worktreeRemoveContext: ExtendedHookExecutionContext = {
+        event: "WorktreeRemove",
+        projectDir: "/test/main-repo",
+        timestamp: new Date(),
+        sessionId: "test-session-123",
+        transcriptPath: "/path/to/transcript.json",
+        cwd: "/test/main-repo",
+        worktreePath: "/test/main-repo/.wave/worktrees/my-feature",
+      };
+
+      const resultPromise = executeCommand("echo test", worktreeRemoveContext);
+
+      setImmediate(() => {
+        mockProcess.emit("close", 0);
+      });
+
+      await resultPromise;
+
+      expect(stdinData).toBeTruthy();
+      const parsedInput = JSON.parse(stdinData);
+      expect(parsedInput.hook_event_name).toBe("WorktreeRemove");
+      expect(parsedInput.worktree_path).toBe(
+        "/test/main-repo/.wave/worktrees/my-feature",
+      );
+    });
+  });
+
   describe("SessionStart hook", () => {
     it("should include source and agent_type in JSON input for SessionStart event", async () => {
       const mockProcess = new MockChildProcess();


### PR DESCRIPTION
## Problem

`buildHookJsonInput` in `hook.ts` never serialized `worktreePath` to the JSON stdin for `WorktreeRemove` events. The execution context had the field (set by `exitWorktreeTool.ts`), but it was silently dropped during serialization — hook scripts received JSON without `worktree_path`, making it impossible to clean up worktree-specific resources (e.g., docker compose containers).

## Changes

1. **`src/types/hooks.ts`** — Added `worktree_path?: string` to `HookJsonInput` interface
2. **`src/services/hook.ts`** — Added `WorktreeRemove` branch in `buildHookJsonInput` that serializes `context.worktreePath` → `jsonInput.worktree_path`
3. **`tests/services/hook.test.ts`** — Added test verifying `worktree_path` appears in JSON stdin for `WorktreeRemove` events
4. **`builtin/skills/settings/HOOKS.md`** — Documented `worktree_path` field and added usage example (`docker compose -p $(basename "$worktree_path") down`)

## Verification

- 26/26 hook service tests pass
- 12/12 exitWorktreeTool tests pass