### PR TITLE
fix: atomic settings write + read tolerance for concurrent config access

### DIFF
--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -48,6 +48,7 @@ import {
 } from "./remoteSettingsService.js";
 import { createAuthAwareFetch } from "./authService.js";
 import { ensureWaveRuntimeFilesExcluded } from "../utils/gitUtils.js";
+import { atomicWriteFile } from "../utils/atomicWrite.js";
 
 /**
  * Default ConfigurationService implementation
@@ -729,7 +730,7 @@ export class ConfigurationService {
     }
 
     config.model = model;
-    await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+    await atomicWriteFile(configPath, JSON.stringify(config, null, 2));
   }
 
   /**
@@ -816,11 +817,7 @@ export class ConfigurationService {
 
     if (!config.permissions.allow.includes(rule)) {
       config.permissions.allow.push(rule);
-      await fs.writeFile(
-        localConfigPath,
-        JSON.stringify(config, null, 2),
-        "utf-8",
-      );
+      await atomicWriteFile(localConfigPath, JSON.stringify(config, null, 2));
     }
   }
 
@@ -868,7 +865,7 @@ export class ConfigurationService {
 
     config.enabledPlugins[pluginId] = enabled;
 
-    await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+    await atomicWriteFile(configPath, JSON.stringify(config, null, 2));
   }
 
   /**
@@ -940,11 +937,7 @@ export class ConfigurationService {
     }
     fileConfig.marketplaces[name] = config;
 
-    await fs.writeFile(
-      configPath,
-      JSON.stringify(fileConfig, null, 2),
-      "utf-8",
-    );
+    await atomicWriteFile(configPath, JSON.stringify(fileConfig, null, 2));
   }
 
   /**
@@ -978,11 +971,7 @@ export class ConfigurationService {
 
       if (fileConfig.marketplaces && name in fileConfig.marketplaces) {
         delete fileConfig.marketplaces[name];
-        await fs.writeFile(
-          configPath,
-          JSON.stringify(fileConfig, null, 2),
-          "utf-8",
-        );
+        await atomicWriteFile(configPath, JSON.stringify(fileConfig, null, 2));
       }
     } catch {
       // Ignore errors for corrupted or non-existent files
@@ -1020,11 +1009,7 @@ export class ConfigurationService {
 
       if (config.enabledPlugins && pluginId in config.enabledPlugins) {
         delete config.enabledPlugins[pluginId];
-        await fs.writeFile(
-          configPath,
-          JSON.stringify(config, null, 2),
-          "utf-8",
-        );
+        await atomicWriteFile(configPath, JSON.stringify(config, null, 2));
       }
     } catch {
       // Ignore errors for corrupted or non-existent files
@@ -1171,6 +1156,15 @@ export function loadWaveConfigFromFile(
 
   try {
     const content = readFileSync(filePath, "utf-8");
+
+    // Tolerate empty/whitespace-only files: a concurrent writer may have the
+    // file truncated mid-write. Returning null lets callers skip this source
+    // instead of crashing (consistent with the "file not found" path).
+    if (content.trim() === "") {
+      logger.warn(`Empty configuration file (likely mid-write): ${filePath}`);
+      return null;
+    }
+
     const config = JSON.parse(content) as WaveConfiguration;
 
     return {
@@ -1189,10 +1183,14 @@ export function loadWaveConfigFromFile(
     };
   } catch (error) {
     if (error instanceof SyntaxError) {
-      throw new Error(`Invalid JSON syntax in ${filePath}: ${error.message}`);
+      // Tolerate corrupt JSON: a concurrent writer may leave the file in a
+      // partially-written state. Warn and return null so callers skip this
+      // source instead of crashing.
+      logger.warn(`Invalid JSON syntax in ${filePath}: ${error.message}`);
+      return null;
     }
 
-    // Re-throw validation errors and other errors as-is
+    // Re-throw other errors as-is
     throw error;
   }
 }

--- a/packages/agent-sdk/src/utils/atomicWrite.ts
+++ b/packages/agent-sdk/src/utils/atomicWrite.ts
@@ -1,0 +1,61 @@
+/**
+ * Atomic file write utilities.
+ *
+ * Writes data to a temporary file first, then renames it to the target path.
+ * This prevents readers from observing a partially-written (truncated) file,
+ * which is critical for config files that may be read concurrently.
+ *
+ * Temp file naming: `${targetPath}.tmp.${process.pid}.${randomUUID()}`
+ * — avoids collisions when multiple processes write the same file.
+ */
+import { writeFileSync, renameSync, unlinkSync, promises as fsp } from "fs";
+import { randomUUID } from "crypto";
+
+function tmpPathFor(targetPath: string): string {
+  return `${targetPath}.tmp.${process.pid}.${randomUUID()}`;
+}
+
+/**
+ * Atomically write `data` to `filePath` (async).
+ *
+ * Writes to a temp file then renames it into place. On any failure the temp
+ * file is removed and the error is re-thrown so callers can handle it.
+ */
+export async function atomicWriteFile(
+  filePath: string,
+  data: string,
+): Promise<void> {
+  const tmpPath = tmpPathFor(filePath);
+  try {
+    await fsp.writeFile(tmpPath, data, "utf-8");
+    await fsp.rename(tmpPath, filePath);
+  } catch (error) {
+    try {
+      await fsp.unlink(tmpPath);
+    } catch {
+      // Ignore cleanup errors — the original error is more important
+    }
+    throw error;
+  }
+}
+
+/**
+ * Atomically write `data` to `filePath` (sync).
+ *
+ * Sync variant for callers that cannot await. Same temp-file-then-rename
+ * strategy as {@link atomicWriteFile}.
+ */
+export function atomicWriteFileSync(filePath: string, data: string): void {
+  const tmpPath = tmpPathFor(filePath);
+  try {
+    writeFileSync(tmpPath, data, "utf-8");
+    renameSync(tmpPath, filePath);
+  } catch (error) {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // Ignore cleanup errors — the original error is more important
+    }
+    throw error;
+  }
+}

--- a/packages/agent-sdk/tests/services/configurationService.plugins.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.plugins.test.ts
@@ -13,6 +13,8 @@ vi.mock("fs", async () => {
       mkdir: vi.fn(),
       readFile: vi.fn(),
       writeFile: vi.fn(),
+      rename: vi.fn().mockResolvedValue(undefined),
+      unlink: vi.fn().mockResolvedValue(undefined),
     },
   };
 });
@@ -71,9 +73,13 @@ describe("ConfigurationService - Plugins", () => {
         recursive: true,
       });
       expect(fs.writeFile).toHaveBeenCalledWith(
-        userConfigPath,
+        expect.any(String),
         expect.stringContaining('"test-plugin": false'),
         "utf-8",
+      );
+      expect(fs.rename).toHaveBeenCalledWith(
+        expect.any(String),
+        userConfigPath,
       );
       const writtenConfig = JSON.parse(
         vi.mocked(fs.writeFile).mock.calls[0][1] as string,
@@ -102,9 +108,13 @@ describe("ConfigurationService - Plugins", () => {
         recursive: true,
       });
       expect(fs.writeFile).toHaveBeenCalledWith(
-        projectConfigPath,
+        expect.any(String),
         expect.stringContaining('"test-plugin": true'),
         "utf-8",
+      );
+      expect(fs.rename).toHaveBeenCalledWith(
+        expect.any(String),
+        projectConfigPath,
       );
     });
 
@@ -130,9 +140,13 @@ describe("ConfigurationService - Plugins", () => {
         recursive: true,
       });
       expect(fs.writeFile).toHaveBeenCalledWith(
-        localConfigPath,
+        expect.any(String),
         expect.stringContaining('"test-plugin": true'),
         "utf-8",
+      );
+      expect(fs.rename).toHaveBeenCalledWith(
+        expect.any(String),
+        localConfigPath,
       );
     });
 
@@ -152,9 +166,13 @@ describe("ConfigurationService - Plugins", () => {
       );
 
       expect(fs.writeFile).toHaveBeenCalledWith(
-        localConfigPath,
+        expect.any(String),
         expect.stringContaining('"test-plugin": true'),
         "utf-8",
+      );
+      expect(fs.rename).toHaveBeenCalledWith(
+        expect.any(String),
+        localConfigPath,
       );
     });
   });
@@ -174,9 +192,13 @@ describe("ConfigurationService - Plugins", () => {
       await configService.removeEnabledPlugin(workdir, "user", "test-plugin");
 
       expect(fs.writeFile).toHaveBeenCalledWith(
-        userConfigPath,
+        expect.any(String),
         expect.stringContaining('"other-plugin"'),
         "utf-8",
+      );
+      expect(fs.rename).toHaveBeenCalledWith(
+        expect.any(String),
+        userConfigPath,
       );
       const writtenConfig = JSON.parse(
         vi.mocked(fs.writeFile).mock.calls[0][1] as string,
@@ -205,9 +227,13 @@ describe("ConfigurationService - Plugins", () => {
       );
 
       expect(fs.writeFile).toHaveBeenCalledWith(
-        projectConfigPath,
+        expect.any(String),
         expect.stringContaining("enabledPlugins"),
         "utf-8",
+      );
+      expect(fs.rename).toHaveBeenCalledWith(
+        expect.any(String),
+        projectConfigPath,
       );
       const writtenConfig = JSON.parse(
         vi.mocked(fs.writeFile).mock.calls[0][1] as string,

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -19,7 +19,9 @@ import {
   validateEnvironmentConfig,
   mergeEnvironmentConfig,
   loadMergedWaveConfig,
+  loadWaveConfigFromFile,
 } from "../../src/services/configurationService.js";
+import { atomicWriteFile } from "../../src/utils/atomicWrite.js";
 import {
   DEFAULT_WAVE_MAX_OUTPUT_TOKENS,
   DEFAULT_WAVE_MAX_INPUT_TOKENS,
@@ -898,6 +900,144 @@ describe("ConfigurationService", () => {
 
       const result = loadMergedWaveConfig(tempDir);
       expect(result?.model).toBe("user-model");
+    });
+  });
+
+  describe("loadWaveConfigFromFile — read tolerance", () => {
+    it("should return null for empty file (not throw)", () => {
+      const configPath = path.join(tempDir, "settings.json");
+      mockExistsSync.mockImplementation((p) => p.toString() === configPath);
+      mockReadFileSync.mockReturnValue("");
+
+      expect(() => loadWaveConfigFromFile(configPath)).not.toThrow();
+      expect(loadWaveConfigFromFile(configPath)).toBeNull();
+    });
+
+    it("should return null for whitespace-only file (not throw)", () => {
+      const configPath = path.join(tempDir, "settings.json");
+      mockExistsSync.mockImplementation((p) => p.toString() === configPath);
+      mockReadFileSync.mockReturnValue("   \n\t  ");
+
+      expect(() => loadWaveConfigFromFile(configPath)).not.toThrow();
+      expect(loadWaveConfigFromFile(configPath)).toBeNull();
+    });
+
+    it("should return null for corrupted JSON (not throw)", () => {
+      const configPath = path.join(tempDir, "settings.json");
+      mockExistsSync.mockImplementation((p) => p.toString() === configPath);
+      mockReadFileSync.mockReturnValue('{"model": "test"');
+
+      expect(() => loadWaveConfigFromFile(configPath)).not.toThrow();
+      expect(loadWaveConfigFromFile(configPath)).toBeNull();
+    });
+
+    it("should still return config for valid JSON", () => {
+      const configPath = path.join(tempDir, "settings.json");
+      mockExistsSync.mockImplementation((p) => p.toString() === configPath);
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({ model: "valid-model" }),
+      );
+
+      const result = loadWaveConfigFromFile(configPath);
+      expect(result).not.toBeNull();
+      expect(result?.model).toBe("valid-model");
+    });
+  });
+
+  describe("atomicWriteFile", () => {
+    it("should write file content correctly", async () => {
+      const filePath = path.join(tempDir, "test-atomic.json");
+      const data = JSON.stringify({ key: "value" }, null, 2);
+
+      await atomicWriteFile(filePath, data);
+
+      const content = await fs.readFile(filePath, "utf-8");
+      expect(content).toBe(data);
+      expect(JSON.parse(content)).toEqual({ key: "value" });
+    });
+
+    it("should leave no temp file on success", async () => {
+      const filePath = path.join(tempDir, "test-no-tmp.json");
+      await atomicWriteFile(filePath, "{}");
+
+      const dirEntries = await fs.readdir(tempDir);
+      const tmpFiles = dirEntries.filter((f) => f.includes(".tmp."));
+      expect(tmpFiles).toHaveLength(0);
+    });
+
+    it("should overwrite existing file atomically", async () => {
+      const filePath = path.join(tempDir, "overwrite.json");
+      await fs.writeFile(filePath, JSON.stringify({ old: true }));
+
+      await atomicWriteFile(filePath, JSON.stringify({ new: true }));
+
+      const content = await fs.readFile(filePath, "utf-8");
+      expect(JSON.parse(content)).toEqual({ new: true });
+    });
+
+    it("should not leave temp file on write failure", async () => {
+      const filePath = path.join(tempDir, "nonexistent-dir", "fail.json");
+
+      await expect(atomicWriteFile(filePath, "{}")).rejects.toThrow();
+
+      // The temp file should have been cleaned up (directory doesn't exist
+      // so the temp file was never created, but the cleanup path ran)
+      // Verify no temp files in tempDir itself
+      const dirEntries = await fs.readdir(tempDir);
+      const tmpFiles = dirEntries.filter((f) => f.includes(".tmp."));
+      expect(tmpFiles).toHaveLength(0);
+    });
+  });
+
+  describe("atomic settings write integration", () => {
+    it("addMarketplaceToScope should produce valid JSON immediately after write", async () => {
+      const projectConfigPath = path.join(tempDir, ".wave", "settings.json");
+      mockExistsSync.mockImplementation(
+        (p) => p.toString() === projectConfigPath || p.toString() === tempDir,
+      );
+
+      const marketConfig = {
+        source: { source: "git", url: "https://example.com/repo.git" },
+      } as unknown as import("../../src/types/configuration.js").MarketplaceConfig;
+
+      await configService.addMarketplaceToScope(
+        tempDir,
+        "project",
+        "test-market",
+        marketConfig,
+      );
+
+      // Read back the real file (not mocked) — it should be valid JSON
+      const content = await fs.readFile(projectConfigPath, "utf-8");
+      expect(() => JSON.parse(content)).not.toThrow();
+      const parsed = JSON.parse(content);
+      expect(parsed.marketplaces["test-market"]).toBeDefined();
+      expect(parsed.marketplaces["test-market"].source.source).toBe("git");
+
+      // Ensure no leftover temp files
+      const waveDir = path.join(tempDir, ".wave");
+      const dirEntries = await fs.readdir(waveDir);
+      const tmpFiles = dirEntries.filter((f) => f.includes(".tmp."));
+      expect(tmpFiles).toHaveLength(0);
+    });
+
+    it("updateEnabledPlugin should produce valid JSON immediately after write", async () => {
+      const projectConfigPath = path.join(tempDir, ".wave", "settings.json");
+      mockExistsSync.mockImplementation(
+        (p) => p.toString() === projectConfigPath || p.toString() === tempDir,
+      );
+
+      await configService.updateEnabledPlugin(
+        tempDir,
+        "project",
+        "plugin@market",
+        true,
+      );
+
+      const content = await fs.readFile(projectConfigPath, "utf-8");
+      expect(() => JSON.parse(content)).not.toThrow();
+      const parsed = JSON.parse(content);
+      expect(parsed.enabledPlugins["plugin@market"]).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Problem

In sandbox environments (`/data/workspace/<id>/`), `homedir()` resolves to the workspace root, making user config (`~/.wave/settings.json`) and project config (`{workdir}/.wave/settings.json`) the **same file**. On every first startup (cache wiped), `MarketplaceService.seedBuiltinMarketplace()` writes to settings.json via non-atomic `fs.writeFile` (truncate-then-write). Meanwhile `loadInstalledPlugins()` synchronously reads the same file via `readFileSync` → `JSON.parse`. The reader can catch the file mid-truncate (0 bytes), causing `JSON.parse("")` → `Unexpected end of JSON input`.

## Solution

Two layers, matching Claude Code's approach:

### 1. Atomic writes
- New utility `packages/agent-sdk/src/utils/atomicWrite.ts` with `atomicWriteFile` (async) and `atomicWriteFileSync` (sync)
- Strategy: write to `.tmp..` then `rename` to target
- On failure: unlink temp file, rethrow
- Replaced 6 `fs.writeFile` calls in `ConfigurationService`:
  - `persistModelToSettings`
  - `addAllowedRule`
  - `updateEnabledPlugin`
  - `addMarketplaceToScope`
  - `removeMarketplaceFromScope`
  - `removeEnabledPlugin`

### 2. Read tolerance
`loadWaveConfigFromFile` now returns `null` + `logger.warn` (instead of throwing) for:
- Empty/whitespace-only content
- `SyntaxError` (corrupt JSON)

This prevents crashes when a reader catches a file mid-write. Callers already handle `null` by skipping that config source.

## Tests
- 4 new tests for `loadWaveConfigFromFile` read tolerance (empty, whitespace, corrupt, valid)
- 4 new tests for `atomicWriteFile` (content correctness, no temp left, overwrite, failure cleanup)
- 2 integration tests verifying `addMarketplaceToScope`/`updateEnabledPlugin` produce valid parseable JSON immediately after write
- Updated `configurationService.plugins.test.ts` mock to include `rename`/`unlink` and assert atomic write path

## Verification
- `configurationService.test.ts`: 56 passed
- `configurationService.plugins.test.ts`: 13 passed
- `MarketplaceService.test.ts`: 65 passed
- `pluginScopeManager.test.ts`: 5 passed
- Type-check + lint: clean