### PR TITLE
refactor: replace regex-based model capability detection with declarative capabilities

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1238,7 +1238,6 @@ Wave 提供了一个强大的内置 `/settings` skill，作为用户与 Wave 配
 | `WAVE_MAX_OUTPUT_TOKENS` | 最大输出 Token 数 |
 | `WAVE_DISABLE_AUTO_MEMORY` | 禁用自动记忆 |
 | `WAVE_AUTO_MEMORY_FREQUENCY` | 自动记忆触发频率 |
-| `WAVE_PROMPT_CACHE_REGEX` | Prompt 缓存匹配正则（默认 `claude`） |
 | `WAVE_PLUGIN_GIT_TIMEOUT_MS` | 插件 Git 操作超时（毫秒） |
 
 #### OTEL_* 变量（OpenTelemetry）
@@ -1268,14 +1267,30 @@ Wave 提供了一个强大的内置 `/settings` skill，作为用户与 Wave 配
 
 此外还支持 `fastModel` 配置，用于子代理（Explore）和网页抓取摘要等轻量场景。
 
-### Prompt 缓存 {#settings-prompt-cache}
+### 模型能力配置 {#settings-capabilities}
 
-SDK 默认对名称包含 `claude` 的模型自动启用 Prompt Cache（提示词缓存），通过在消息内容中插入 `ephemeral` 缓存标记来复用上下文，降低 API 调用成本。
+在 `models` 字段中通过 `capabilities` 声明式配置每个模型的能力，支持以下字段：
 
-对于其他支持 Prompt Cache 的模型，可通过 `WAVE_PROMPT_CACHE_REGEX` 匹配模型名称：
+- `promptCaching`：是否支持 Prompt Cache（提示词缓存）。设为 `true` 时，SDK 会在消息内容中插入 `ephemeral` 缓存标记来复用上下文，降低 API 调用成本。默认 `false`。
+- `vision`：是否支持图像识别（视觉）。设为 `false` 时，SDK 会在发送前自动剥离图像并用文本占位符替换。默认 `true`。
 
-- `WAVE_PROMPT_CACHE_REGEX="qwen"` — 匹配 qwen 系列模型
-- `WAVE_PROMPT_CACHE_REGEX="(qwen|claude)"` — 同时匹配多个
+```json
+{
+  "models": {
+    "claude-sonnet-4": {
+      "capabilities": { "promptCaching": true, "vision": true }
+    },
+    "deepseek-r1": {
+      "capabilities": { "vision": false }
+    },
+    "qwen-plus": {
+      "capabilities": { "promptCaching": true }
+    }
+  }
+}
+```
+
+> **注意**：`promptCaching` 默认为 `false`。即使是 Claude 模型，也需要显式声明 `capabilities: { promptCaching: true }` 才会启用缓存。
 
 ### MCP 协议 {#settings-mcp}
 

--- a/packages/agent-sdk/builtin/skills/settings/ENV.md
+++ b/packages/agent-sdk/builtin/skills/settings/ENV.md
@@ -32,7 +32,6 @@ Wave uses several environment variables to control its core functionality.
 | `WAVE_DISABLE_AUTO_MEMORY` | Set to `1` or `true` to disable the auto-memory feature. | `false` |
 | `WAVE_AUTO_MEMORY_FREQUENCY` | Auto memory update frequency. `1` = every turn, `2` = every 2 turns, etc. | `1` |
 | `WAVE_TASK_LIST_ID` | Explicitly set the task list ID for the session. | (Session ID) |
-| `WAVE_PROMPT_CACHE_REGEX` | Regex pattern to match model names that support prompt caching. Models matching this pattern will have cache control markers applied. | `claude` |
 | `WAVE_PLUGIN_GIT_TIMEOUT_MS` | Timeout in milliseconds for git operations when installing plugins. | `300000` |
 
 ## Configuration Scopes

--- a/packages/agent-sdk/builtin/skills/settings/MODELS.md
+++ b/packages/agent-sdk/builtin/skills/settings/MODELS.md
@@ -37,6 +37,43 @@ Wave supports passing arbitrary parameters to the underlying AI provider. Common
   - `type`: `"enabled"` or `"disabled"`.
   - `budget_tokens`: Maximum tokens to use for thinking.
 
+## Model Capabilities
+
+Wave needs to know whether a model supports certain features. Instead of guessing from the model name, you declare these explicitly via the `capabilities` field:
+
+- `vision` (default: `true`): Whether the model can accept image inputs. When `false`, images are stripped and replaced with text placeholders.
+- `promptCaching` (default: `false`): Whether the model supports ephemeral prompt caching (e.g., Anthropic's `cache_control` markers). When `true`, Wave injects cache markers on the system prompt and last user message.
+
+```json
+{
+  "models": {
+    "claude-3-7-sonnet-20250219": {
+      "capabilities": {
+        "vision": true,
+        "promptCaching": true
+      }
+    },
+    "deepseek-r1": {
+      "capabilities": {
+        "vision": false,
+        "promptCaching": false
+      }
+    }
+  }
+}
+```
+
+You can also set `capabilities` at the top level of `settings.json` to apply to the default model:
+
+```json
+{
+  "capabilities": {
+    "vision": true,
+    "promptCaching": false
+  }
+}
+```
+
 ## Unsetting Default Parameters
 
 If a model does not support a default parameter (like `temperature` for some reasoning models), you can explicitly set it to `null` to ensure it is not sent to the provider.

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -41,6 +41,7 @@ import { SkillManager } from "./managers/skillManager.js";
 import { TaskManager } from "./services/taskManager.js";
 import { btw } from "./services/aiService.js";
 import { convertMessagesForAPI } from "./utils/convertMessagesForAPI.js";
+import { supportsVision } from "./utils/modelCapabilities.js";
 import { parseTaskNotificationXml } from "./utils/notificationXml.js";
 import { InitializationService } from "./services/initializationService.js";
 import { InteractionService } from "./services/interactionService.js";
@@ -995,7 +996,9 @@ export class Agent {
    * @returns Promise that resolves to the AI's answer
    */
   public async askBtw(question: string): Promise<string> {
-    const messages = convertMessagesForAPI(this.messageManager.getMessages());
+    const messages = convertMessagesForAPI(this.messageManager.getMessages(), {
+      supportsVision: supportsVision(this.getModelConfig().capabilities),
+    });
     const result = await btw({
       gatewayConfig: this.getGatewayConfig(),
       modelConfig: this.getModelConfig(),

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -14,6 +14,7 @@ export * from "./managers/messageQueue.js";
 // Export all utilities
 export * from "./utils/bashParser.js";
 export * from "./utils/convertMessagesForAPI.js";
+export * from "./utils/modelCapabilities.js";
 export * from "./utils/fileSearch.js";
 export * from "./utils/globalLogger.js";
 export * from "./utils/mcpUtils.js";

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -1,6 +1,7 @@
 import { type CallAgentOptions } from "../services/aiService.js";
 import * as aiService from "../services/aiService.js";
 import { convertMessagesForAPI } from "../utils/convertMessagesForAPI.js";
+import { supportsVision } from "../utils/modelCapabilities.js";
 import { parseTaskNotificationXml } from "../utils/notificationXml.js";
 import { calculateComprehensiveTotalTokens } from "../utils/tokenCalculation.js";
 import { estimateTokens } from "../utils/tokenEstimate.js";
@@ -842,7 +843,10 @@ export class AIManager {
 
           // Get recent message history
           const rawMessages = this.messageManager.getMessages();
-          const recentMessages = convertMessagesForAPI(rawMessages);
+          const currentModelConfig = this.getModelConfig();
+          const recentMessages = convertMessagesForAPI(rawMessages, {
+            supportsVision: supportsVision(currentModelConfig.capabilities),
+          });
 
           // Track if assistant message has been created
           let assistantMessageCreated = false;

--- a/packages/agent-sdk/src/services/aiService.ts
+++ b/packages/agent-sdk/src/services/aiService.ts
@@ -13,11 +13,11 @@ import type { GatewayConfig, ModelConfig } from "../types/index.js";
 import { ConfigurationError, CONFIG_ERRORS } from "../types/index.js";
 import {
   transformMessagesForExplicitCache,
-  supportsPromptCaching,
   extendUsageWithCacheMetrics,
   type ClaudeUsage,
   type ClaudeChatCompletionContentPartText,
 } from "../utils/cacheControlUtils.js";
+import { supportsPromptCaching } from "../utils/modelCapabilities.js";
 
 import * as os from "os";
 import * as fs from "fs";
@@ -265,13 +265,12 @@ export async function callAgent(
     });
 
     // Determine model early (needed for system prompt construction)
-    const currentModel = model || modelConfig.model;
     const resolvedMaxTokens = options.maxTokens ?? modelConfig.maxTokens;
 
     // Build system message content
     let systemMessage: ChatCompletionMessageParam;
     if (Array.isArray(systemPrompt)) {
-      if (supportsPromptCaching(currentModel)) {
+      if (supportsPromptCaching(modelConfig.capabilities)) {
         // For Claude models, map blocks to content parts with cache_control on cacheable blocks
         const contentParts: ClaudeChatCompletionContentPartText[] =
           systemPrompt.map((block) => {
@@ -307,10 +306,10 @@ export async function callAgent(
 
     processedTools = tools;
 
-    if (supportsPromptCaching(currentModel)) {
+    if (supportsPromptCaching(modelConfig.capabilities)) {
       openaiMessages = transformMessagesForExplicitCache(
         openaiMessages,
-        currentModel,
+        modelConfig.capabilities,
       );
     }
 
@@ -320,12 +319,14 @@ export async function callAgent(
       fastModel: _fastModel,
       maxTokens: _maxTokens,
       permissionMode: _permissionMode,
+      capabilities: _capabilities,
       ...extraParams
     } = modelConfig;
     void _model;
     void _fastModel;
     void _maxTokens;
     void _permissionMode;
+    void _capabilities;
 
     const openaiModelConfig = getModelConfig(model || modelConfig.model, {
       max_tokens: resolvedMaxTokens,
@@ -866,6 +867,7 @@ export async function compactMessages(
     fastModel: _fastModel,
     maxTokens: _maxTokens,
     permissionMode: _permissionMode,
+    capabilities: _capabilities,
     fastModelConfig: _fastModelConfig,
     ...extraParams
   } = modelConfig;
@@ -873,6 +875,7 @@ export async function compactMessages(
   void _fastModel;
   void _maxTokens;
   void _permissionMode;
+  void _capabilities;
 
   // When a fast model override is provided, use the fast model's hyperparams
   // (if configured); otherwise fall back to the agent model's extraParams.
@@ -989,6 +992,7 @@ export async function processWebContent(
     fastModel: _fastModel,
     maxTokens: _maxTokens,
     permissionMode: _permissionMode,
+    capabilities: _capabilities,
     fastModelConfig: _fastModelConfig,
     ...extraParams
   } = modelConfig;
@@ -996,6 +1000,7 @@ export async function processWebContent(
   void _fastModel;
   void _maxTokens;
   void _permissionMode;
+  void _capabilities;
 
   // When a fast model override is provided, use the fast model's hyperparams
   // (if configured); otherwise fall back to the agent model's extraParams.
@@ -1106,12 +1111,14 @@ export async function btw(options: BtwOptions): Promise<BtwResult> {
     fastModel: _fastModel,
     maxTokens: _maxTokens,
     permissionMode: _permissionMode,
+    capabilities: _capabilities,
     ...extraParams
   } = modelConfig;
   void _model;
   void _fastModel;
   void _maxTokens;
   void _permissionMode;
+  void _capabilities;
 
   const openaiModelConfig = getModelConfig(options.model || modelConfig.model, {
     temperature: 0.1,

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -545,12 +545,14 @@ export class ConfigurationService {
         fastModel: _ffm,
         maxTokens: _fmt,
         permissionMode: _fpm,
+        capabilities: _fcap,
         ...fastHyperparams
       } = fastModelConfigSource;
       void _fm;
       void _ffm;
       void _fmt;
       void _fpm;
+      void _fcap;
       baseConfig.fastModelConfig = fastHyperparams;
     }
 

--- a/packages/agent-sdk/src/types/config.ts
+++ b/packages/agent-sdk/src/types/config.ts
@@ -14,11 +14,19 @@ export interface GatewayConfig {
   fetch?: OpenAI["fetch"];
 }
 
+export interface ModelCapabilities {
+  /** Whether the model supports image/vision input. Default: true. */
+  vision?: boolean;
+  /** Whether the model supports prompt caching (ephemeral cache_control markers). Default: false. */
+  promptCaching?: boolean;
+}
+
 export interface ModelConfig {
   model?: string;
   fastModel?: string;
   maxTokens?: number;
   permissionMode?: PermissionMode;
   fastModelConfig?: Record<string, unknown>;
+  capabilities?: ModelCapabilities;
   [key: string]: unknown;
 }

--- a/packages/agent-sdk/src/utils/cacheControlUtils.ts
+++ b/packages/agent-sdk/src/utils/cacheControlUtils.ts
@@ -13,6 +13,8 @@ import type {
   CompletionUsage,
 } from "openai/resources";
 import { logger } from "./globalLogger.js";
+import { supportsPromptCaching } from "./modelCapabilities.js";
+import type { ModelCapabilities } from "../types/config.js";
 
 // ============================================================================
 // Core Types
@@ -72,41 +74,6 @@ export interface ClaudeUsage extends CompletionUsage {
 // ============================================================================
 // Utility Functions (Basic Structure - to be implemented)
 // ============================================================================
-
-/**
- * Determines if a model supports prompt caching
- * @param modelName - Model identifier
- * @returns True if model name matches the cache pattern (default: contains 'claude')
- */
-export function supportsPromptCaching(modelName: string): boolean {
-  // Handle null, undefined, and non-string inputs
-  if (!modelName || typeof modelName !== "string") {
-    return false;
-  }
-
-  // Handle empty strings and whitespace-only strings
-  const trimmed = modelName.trim();
-  if (trimmed.length === 0) {
-    return false;
-  }
-
-  const cachePattern = process.env.WAVE_PROMPT_CACHE_REGEX || "claude";
-  try {
-    const regex = new RegExp(cachePattern, "i");
-    return regex.test(trimmed);
-  } catch {
-    // If regex is invalid, fall back to simple includes check with default
-    return trimmed.toLowerCase().includes("claude");
-  }
-}
-
-/**
- * Determines if a model supports cache control
- * @param modelName - Model identifier
- * @returns True if model name contains 'claude' (case-insensitive)
- * @deprecated Use supportsPromptCaching instead
- */
-export const isClaudeModel = supportsPromptCaching;
 
 /**
  * Validates cache control structure
@@ -254,12 +221,12 @@ export function countContentBlocks(
  * Tools are marked separately via addCacheControlToLastTool (called by aiService).
  *
  * @param messages - Original OpenAI message array
- * @param modelName - Model name for cache detection
+ * @param capabilities - Declarative model capabilities for cache detection
  * @returns Messages with cache control markers applied
  */
 export function transformMessagesForExplicitCache(
   messages: ChatCompletionMessageParam[],
-  modelName: string,
+  capabilities?: ModelCapabilities,
 ): ChatCompletionMessageParam[] {
   // Validate inputs
   if (!messages || !Array.isArray(messages)) {
@@ -274,7 +241,7 @@ export function transformMessagesForExplicitCache(
   }
 
   // Only apply cache control for models that support prompt caching
-  if (!supportsPromptCaching(modelName)) {
+  if (!supportsPromptCaching(capabilities)) {
     return messages;
   }
 

--- a/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
+++ b/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
@@ -40,14 +40,25 @@ function safeToolArguments(args: string): string {
 }
 
 /**
+ * Options for converting messages to API format.
+ */
+export interface ConvertMessagesOptions {
+  /** When false, images are stripped and replaced with text placeholders. */
+  supportsVision?: boolean;
+}
+
+/**
  * Convert message format to API call format, stopping when a compacted message is encountered.
  * Messages with no meaningful content or tool calls are filtered out.
  * @param messages Message list
+ * @param options Optional conversion options (e.g. supportsVision)
  * @returns Converted API message format list
  */
 export function convertMessagesForAPI(
   messages: Message[],
+  options?: ConvertMessagesOptions,
 ): ChatCompletionMessageParam[] {
+  const supportsVision = options?.supportsVision !== false;
   const recentMessages: ChatCompletionMessageParam[] = [];
 
   const startIndex = messages.length - 1;
@@ -103,26 +114,35 @@ export function convertMessagesForAPI(
 
             // If there are images, also prepare a user message with image content
             if (toolBlock.images && toolBlock.images.length > 0) {
-              const contentParts: ChatCompletionContentPart[] = [];
+              if (supportsVision) {
+                const contentParts: ChatCompletionContentPart[] = [];
 
-              toolBlock.images.forEach((image) => {
-                const imageUrl = image.data.startsWith("data:")
-                  ? image.data
-                  : `data:${image.mediaType || "image/png"};base64,${image.data}`;
+                toolBlock.images.forEach((image) => {
+                  const imageUrl = image.data.startsWith("data:")
+                    ? image.data
+                    : `data:${image.mediaType || "image/png"};base64,${image.data}`;
 
-                contentParts.push({
-                  type: "image_url",
-                  image_url: {
-                    url: imageUrl,
-                    detail: "auto",
-                  },
+                  contentParts.push({
+                    type: "image_url",
+                    image_url: {
+                      url: imageUrl,
+                      detail: "auto",
+                    },
+                  });
                 });
-              });
 
-              imageUserMessages.push({
-                role: "user",
-                content: contentParts,
-              });
+                imageUserMessages.push({
+                  role: "user",
+                  content: contentParts,
+                });
+              } else {
+                // Non-vision model: replace images with a text placeholder
+                imageUserMessages.push({
+                  role: "user",
+                  content:
+                    "[Tool returned an image, but the current model does not support image recognition]",
+                });
+              }
             }
           }
         });
@@ -229,32 +249,40 @@ export function convertMessagesForAPI(
           block.imageUrls &&
           block.imageUrls.length > 0
         ) {
-          block.imageUrls.forEach((imageUrl: string) => {
-            // Check if it's already base64, convert if not
-            let finalImageUrl = imageUrl;
-            if (!imageUrl.startsWith("data:image/")) {
-              // If it's a file path, it needs to be converted to base64
-              try {
-                finalImageUrl = convertImageToBase64(imageUrl);
-              } catch (error) {
-                logger.error(
-                  "Failed to convert image path to base64:",
-                  imageUrl,
-                  error,
-                );
-                // Skip this image, do not add to content
-                return;
-              }
-            }
-
+          if (!supportsVision) {
+            // Non-vision model: replace images with a text placeholder
             contentParts.push({
-              type: "image_url",
-              image_url: {
-                url: finalImageUrl,
-                detail: "auto",
-              },
+              type: "text",
+              text: "[User shared an image, but the current model does not support image recognition]",
             });
-          });
+          } else {
+            block.imageUrls.forEach((imageUrl: string) => {
+              // Check if it's already base64, convert if not
+              let finalImageUrl = imageUrl;
+              if (!imageUrl.startsWith("data:image/")) {
+                // If it's a file path, it needs to be converted to base64
+                try {
+                  finalImageUrl = convertImageToBase64(imageUrl);
+                } catch (error) {
+                  logger.error(
+                    "Failed to convert image path to base64:",
+                    imageUrl,
+                    error,
+                  );
+                  // Skip this image, do not add to content
+                  return;
+                }
+              }
+
+              contentParts.push({
+                type: "image_url",
+                image_url: {
+                  url: finalImageUrl,
+                  detail: "auto",
+                },
+              });
+            });
+          }
         }
 
         // If there is a tool block in user message, add its result

--- a/packages/agent-sdk/src/utils/modelCapabilities.ts
+++ b/packages/agent-sdk/src/utils/modelCapabilities.ts
@@ -1,0 +1,30 @@
+/**
+ * Model Capability Detection
+ *
+ * Pure declarative capability accessors. Capabilities are configured per-model
+ * via the `capabilities` field in `ModelConfig` (settings.json), not via regex
+ * or environment variables.
+ */
+
+import type { ModelCapabilities } from "../types/config.js";
+
+/**
+ * Determines if a model supports prompt caching.
+ * @param capabilities - Declarative model capabilities
+ * @returns True if promptCaching is explicitly enabled (default: false)
+ */
+export function supportsPromptCaching(
+  capabilities?: ModelCapabilities,
+): boolean {
+  return capabilities?.promptCaching ?? false;
+}
+
+/**
+ * Determines if a model supports image/vision recognition.
+ * Opt-out semantics: by default all models are assumed to support vision.
+ * @param capabilities - Declarative model capabilities
+ * @returns True unless vision is explicitly disabled (default: true)
+ */
+export function supportsVision(capabilities?: ModelCapabilities): boolean {
+  return capabilities?.vision ?? true;
+}

--- a/packages/agent-sdk/tests/agent/agent.coverage.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.coverage.test.ts
@@ -15,7 +15,6 @@ vi.mock("@/services/aiService", () => ({
     content: "compacted",
     usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
   }),
-  isClaudeModel: vi.fn().mockReturnValue(false),
   transformMessagesForExplicitCache: vi.fn((m) => m),
   extendUsageWithCacheMetrics: vi.fn((u) => u),
 }));

--- a/packages/agent-sdk/tests/managers/aiManager.compactConversation.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.compactConversation.test.ts
@@ -45,7 +45,6 @@ vi.mock("../../src/services/aiService.js", () => ({
     };
   }),
   compactMessages: compactMessagesMock,
-  isClaudeModel: vi.fn().mockReturnValue(false),
   transformMessagesForExplicitCache: vi.fn((m) => m),
   extendUsageWithCacheMetrics: vi.fn((u) => u),
 }));

--- a/packages/agent-sdk/tests/managers/aiManager.coverage.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.coverage.test.ts
@@ -25,7 +25,6 @@ vi.mock("../../src/services/aiService.js", () => ({
     content: "Compacted",
     usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
   }),
-  isClaudeModel: vi.fn().mockReturnValue(false),
   transformMessagesForExplicitCache: vi.fn((m) => m),
   extendUsageWithCacheMetrics: vi.fn((u) => u),
 }));

--- a/packages/agent-sdk/tests/managers/aiManager.maxTurns.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.maxTurns.test.ts
@@ -38,7 +38,6 @@ vi.mock("../../src/services/aiService.js", () => ({
     content: "Compacted content",
     usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
   }),
-  isClaudeModel: vi.fn().mockReturnValue(false),
   transformMessagesForExplicitCache: vi.fn((m) => m),
   extendUsageWithCacheMetrics: vi.fn((u) => u),
 }));

--- a/packages/agent-sdk/tests/managers/aiManager.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.test.ts
@@ -42,7 +42,6 @@ vi.mock("../../src/services/aiService.js", () => ({
     content: "Compacted content",
     usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
   }),
-  isClaudeModel: vi.fn().mockReturnValue(false),
   transformMessagesForExplicitCache: vi.fn((m) => m),
   extendUsageWithCacheMetrics: vi.fn((u) => u),
 }));

--- a/packages/agent-sdk/tests/services/aiService.cacheControl.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.cacheControl.test.ts
@@ -14,6 +14,7 @@ const TEST_GATEWAY_CONFIG: GatewayConfig = {
 const CLAUDE_MODEL_CONFIG: ModelConfig = {
   model: "claude-3-sonnet-20240229",
   fastModel: "gemini-2.5-flash",
+  capabilities: { promptCaching: true },
 };
 
 // Non-Claude model config for compatibility testing
@@ -69,111 +70,50 @@ describe("AI Service - Claude Cache Control", () => {
 
   describe("Cache Control Utilities", () => {
     let cacheUtils: typeof import("@/utils/cacheControlUtils.js");
+    let modelCaps: typeof import("@/utils/modelCapabilities.js");
 
     beforeEach(async () => {
       cacheUtils = await import("@/utils/cacheControlUtils.js");
+      modelCaps = await import("@/utils/modelCapabilities.js");
     });
 
     describe("supportsPromptCaching", () => {
-      it("should return true for Claude model names (case-insensitive)", async () => {
-        expect(
-          cacheUtils.supportsPromptCaching("claude-3-sonnet-20240229"),
-        ).toBe(true);
-        expect(cacheUtils.supportsPromptCaching("CLAUDE-3-OPUS")).toBe(true);
-        expect(cacheUtils.supportsPromptCaching("anthropic/claude-2")).toBe(
+      it("should return true when promptCaching is true", async () => {
+        expect(modelCaps.supportsPromptCaching({ promptCaching: true })).toBe(
           true,
         );
-        expect(cacheUtils.supportsPromptCaching("Claude-Instant")).toBe(true);
       });
 
-      it("should return false for non-Claude model names", async () => {
-        expect(cacheUtils.supportsPromptCaching("gpt-4o")).toBe(false);
-        expect(cacheUtils.supportsPromptCaching("gpt-3.5-turbo")).toBe(false);
-        expect(cacheUtils.supportsPromptCaching("gemini-pro")).toBe(false);
-        expect(cacheUtils.supportsPromptCaching("llama2")).toBe(false);
-      });
-
-      it("should handle invalid inputs gracefully", async () => {
-        expect(cacheUtils.supportsPromptCaching("")).toBe(false);
-        expect(
-          cacheUtils.supportsPromptCaching(null as unknown as string),
-        ).toBe(false);
-        expect(
-          cacheUtils.supportsPromptCaching(undefined as unknown as string),
-        ).toBe(false);
-        expect(cacheUtils.supportsPromptCaching(123 as unknown as string)).toBe(
+      it("should return false when promptCaching is false", async () => {
+        expect(modelCaps.supportsPromptCaching({ promptCaching: false })).toBe(
           false,
         );
       });
 
-      it("should support regex patterns via WAVE_PROMPT_CACHE_REGEX", async () => {
-        // Save original env
-        const originalEnv = process.env.WAVE_PROMPT_CACHE_REGEX;
-
-        // Test with regex pattern "claude|qwen"
-        process.env.WAVE_PROMPT_CACHE_REGEX = "claude|qwen";
-
-        // Re-import to pick up new env variable
-        vi.resetModules();
-        const cacheUtilsNew = await import("@/utils/cacheControlUtils.js");
-
-        // Should match claude
-        expect(cacheUtilsNew.supportsPromptCaching("claude-3-sonnet")).toBe(
-          true,
-        );
-        // Should match qwen
-        expect(cacheUtilsNew.supportsPromptCaching("qwen3.6-plus")).toBe(true);
-        expect(cacheUtilsNew.supportsPromptCaching("QWEN-turbo")).toBe(true);
-        // Should not match others
-        expect(cacheUtilsNew.supportsPromptCaching("gpt-4o")).toBe(false);
-        expect(cacheUtilsNew.supportsPromptCaching("gemini-pro")).toBe(false);
-
-        // Restore original env
-        if (originalEnv === undefined) {
-          delete process.env.WAVE_PROMPT_CACHE_REGEX;
-        } else {
-          process.env.WAVE_PROMPT_CACHE_REGEX = originalEnv;
-        }
-        vi.resetModules();
+      it("should return false (default) when capabilities is undefined", async () => {
+        expect(modelCaps.supportsPromptCaching(undefined)).toBe(false);
       });
 
-      it("should fall back to default for invalid regex patterns", async () => {
-        // Save original env
-        const originalEnv = process.env.WAVE_PROMPT_CACHE_REGEX;
-
-        // Test with invalid regex pattern
-        process.env.WAVE_PROMPT_CACHE_REGEX = "[invalid(regex";
-
-        // Re-import to pick up new env variable
-        vi.resetModules();
-        const cacheUtilsNew = await import("@/utils/cacheControlUtils.js");
-
-        // Should fall back to default "claude" matching
-        expect(cacheUtilsNew.supportsPromptCaching("claude-3-sonnet")).toBe(
-          true,
-        );
-        expect(cacheUtilsNew.supportsPromptCaching("CLAUDE")).toBe(true);
-        expect(cacheUtilsNew.supportsPromptCaching("gpt-4o")).toBe(false);
-
-        // Restore original env
-        if (originalEnv === undefined) {
-          delete process.env.WAVE_PROMPT_CACHE_REGEX;
-        } else {
-          process.env.WAVE_PROMPT_CACHE_REGEX = originalEnv;
-        }
-        vi.resetModules();
+      it("should return false (default) when capabilities is empty object", async () => {
+        expect(modelCaps.supportsPromptCaching({})).toBe(false);
       });
     });
 
-    describe("isClaudeModel (deprecated alias)", () => {
-      it("should be an alias for supportsPromptCaching", async () => {
-        // Both should return the same result
-        expect(cacheUtils.isClaudeModel("claude-3-sonnet")).toBe(
-          cacheUtils.supportsPromptCaching("claude-3-sonnet"),
-        );
-        expect(cacheUtils.isClaudeModel("gpt-4o")).toBe(
-          cacheUtils.supportsPromptCaching("gpt-4o"),
-        );
+    describe("supportsVision", () => {
+      it("should return true when vision is true", async () => {
+        expect(modelCaps.supportsVision({ vision: true })).toBe(true);
+      });
+
+      it("should return false when vision is false", async () => {
+        expect(modelCaps.supportsVision({ vision: false })).toBe(false);
+      });
+
+      it("should return true (default) when capabilities is undefined", async () => {
+        expect(modelCaps.supportsVision(undefined)).toBe(true);
+      });
+
+      it("should return true (default) when capabilities is empty object", async () => {
+        expect(modelCaps.supportsVision({})).toBe(true);
       });
     });
 
@@ -322,10 +262,9 @@ describe("AI Service - Claude Cache Control", () => {
           { role: "system" as const, content: "Last system message" },
         ];
 
-        const result = cacheUtils.transformMessagesForExplicitCache(
-          messages,
-          "claude-3-sonnet",
-        );
+        const result = cacheUtils.transformMessagesForExplicitCache(messages, {
+          promptCaching: true,
+        });
 
         // First system message (index 1) should have cache control
         expect(Array.isArray(result[1].content)).toBe(true);
@@ -376,10 +315,9 @@ describe("AI Service - Claude Cache Control", () => {
           { role: "user" as const, content: "What can you do?" },
         ];
 
-        const result = cacheUtils.transformMessagesForExplicitCache(
-          messages,
-          "claude-3-sonnet",
-        );
+        const result = cacheUtils.transformMessagesForExplicitCache(messages, {
+          promptCaching: true,
+        });
 
         // System message (index 0) should have cache control
         expect(Array.isArray(result[0].content)).toBe(true);
@@ -405,10 +343,9 @@ describe("AI Service - Claude Cache Control", () => {
           { role: "assistant" as const, content: "Hello!" },
         ];
 
-        const result = cacheUtils.transformMessagesForExplicitCache(
-          messages,
-          "claude-3-sonnet",
-        );
+        const result = cacheUtils.transformMessagesForExplicitCache(messages, {
+          promptCaching: true,
+        });
 
         // System message should have cache control
         expect(Array.isArray(result[0].content)).toBe(true);
@@ -443,10 +380,9 @@ describe("AI Service - Claude Cache Control", () => {
           },
         ];
 
-        const result = cacheUtils.transformMessagesForExplicitCache(
-          messages,
-          "claude-3-sonnet",
-        );
+        const result = cacheUtils.transformMessagesForExplicitCache(messages, {
+          promptCaching: true,
+        });
 
         // System message should have cache control
         expect(Array.isArray(result[0].content)).toBe(true);
@@ -471,18 +407,17 @@ describe("AI Service - Claude Cache Control", () => {
         expect(typeof result[1].content).toBe("string");
       });
 
-      it("should not apply cache control for non-Claude models", async () => {
+      it("should not apply cache control for models without promptCaching capability", async () => {
         const messages = Array.from({ length: 25 }, (_, i) => ({
           role: i === 0 ? "system" : i % 2 === 1 ? "user" : "assistant",
           content: `Message ${i + 1}`,
         })) as ChatCompletionMessageParam[];
 
-        const result = cacheUtils.transformMessagesForExplicitCache(
-          messages,
-          "gpt-4o",
-        );
+        const result = cacheUtils.transformMessagesForExplicitCache(messages, {
+          promptCaching: false,
+        });
 
-        // Should return messages unchanged for non-Claude models
+        // Should return messages unchanged for non-caching models
         expect(result).toEqual(messages);
         result.forEach((message) => {
           expect(typeof message.content).toBe("string");
@@ -492,20 +427,22 @@ describe("AI Service - Claude Cache Control", () => {
       it("should handle edge cases gracefully", async () => {
         // Empty conversation
         expect(
-          cacheUtils.transformMessagesForExplicitCache([], "claude-3-sonnet"),
+          cacheUtils.transformMessagesForExplicitCache([], {
+            promptCaching: true,
+          }),
         ).toEqual([]);
 
         // Invalid messages array
         expect(
           cacheUtils.transformMessagesForExplicitCache(
             null as unknown as ChatCompletionMessageParam[],
-            "claude-3-sonnet",
+            { promptCaching: true },
           ),
         ).toEqual([]);
         expect(
           cacheUtils.transformMessagesForExplicitCache(
             undefined as unknown as ChatCompletionMessageParam[],
-            "claude-3-sonnet",
+            { promptCaching: true },
           ),
         ).toEqual([]);
       });
@@ -526,10 +463,9 @@ describe("AI Service - Claude Cache Control", () => {
           { role: "assistant" as const, content: "I can see the image" },
         ];
 
-        const result = cacheUtils.transformMessagesForExplicitCache(
-          messages,
-          "claude-3-sonnet",
-        );
+        const result = cacheUtils.transformMessagesForExplicitCache(messages, {
+          promptCaching: true,
+        });
 
         // System message should have cache control
         expect(Array.isArray(result[0].content)).toBe(true);
@@ -566,10 +502,9 @@ describe("AI Service - Claude Cache Control", () => {
           { role: "user" as const, content: "How are you?" },
         ];
 
-        const result = cacheUtils.transformMessagesForExplicitCache(
-          messages,
-          "claude-3-sonnet",
-        );
+        const result = cacheUtils.transformMessagesForExplicitCache(messages, {
+          promptCaching: true,
+        });
 
         // System message (index 0) should have cache control
         expect(Array.isArray(result[0].content)).toBe(true);
@@ -613,10 +548,9 @@ describe("AI Service - Claude Cache Control", () => {
           { role: "assistant" as const, content: "Hi there!" },
         ];
 
-        const result = cacheUtils.transformMessagesForExplicitCache(
-          messages,
-          "claude-3-sonnet",
-        );
+        const result = cacheUtils.transformMessagesForExplicitCache(messages, {
+          promptCaching: true,
+        });
 
         // System message (index 0) should have cache control
         expect(Array.isArray(result[0].content)).toBe(true);
@@ -652,10 +586,9 @@ describe("AI Service - Claude Cache Control", () => {
           { role: "user" as const, content: "Thanks" },
         ];
 
-        const result = cacheUtils.transformMessagesForExplicitCache(
-          messages,
-          "claude-3-sonnet",
-        );
+        const result = cacheUtils.transformMessagesForExplicitCache(messages, {
+          promptCaching: true,
+        });
 
         // System message (index 0) should have cache control
         expect(Array.isArray(result[0].content)).toBe(true);
@@ -686,7 +619,7 @@ describe("AI Service - Claude Cache Control", () => {
 
         const shortResult = cacheUtils.transformMessagesForExplicitCache(
           shortMessages,
-          "claude-3-sonnet",
+          { promptCaching: true },
         );
 
         // System + last message = 2 markers
@@ -714,7 +647,7 @@ describe("AI Service - Claude Cache Control", () => {
 
         const longResult = cacheUtils.transformMessagesForExplicitCache(
           longMessages,
-          "claude-3-sonnet",
+          { promptCaching: true },
         );
 
         // System + last message = 2 markers (no bridge)
@@ -738,10 +671,9 @@ describe("AI Service - Claude Cache Control", () => {
           { role: "system" as const, content: "You are helpful" },
         ];
 
-        const result = cacheUtils.transformMessagesForExplicitCache(
-          messages,
-          "claude-3-sonnet",
-        );
+        const result = cacheUtils.transformMessagesForExplicitCache(messages, {
+          promptCaching: true,
+        });
 
         // System message should have cache control
         expect(Array.isArray(result[0].content)).toBe(true);
@@ -1321,14 +1253,28 @@ describe("AI Service - Claude Cache Control", () => {
         });
       });
 
-      it("should handle mixed Claude and non-Claude model names correctly", async () => {
+      it("should handle caching and non-caching model configs correctly", async () => {
         const testCases = [
-          { modelName: "claude-3-sonnet", shouldCache: true },
-          { modelName: "gpt-4o-claude-variant", shouldCache: true }, // Contains 'claude'
-          { modelName: "anthropic-claude-2", shouldCache: true },
-          { modelName: "CLAUDE-INSTANT", shouldCache: true },
-          { modelName: "gpt-4o", shouldCache: false }, // Pure GPT model
-          { modelName: "gemini-pro", shouldCache: false }, // Pure Gemini model
+          {
+            modelName: "claude-3-sonnet",
+            shouldCache: true,
+            capabilities: { promptCaching: true },
+          },
+          {
+            modelName: "qwen-plus",
+            shouldCache: true,
+            capabilities: { promptCaching: true },
+          },
+          {
+            modelName: "gpt-4o",
+            shouldCache: false,
+            capabilities: undefined,
+          },
+          {
+            modelName: "gemini-pro",
+            shouldCache: false,
+            capabilities: { promptCaching: false },
+          },
         ];
 
         for (const testCase of testCases) {
@@ -1337,6 +1283,7 @@ describe("AI Service - Claude Cache Control", () => {
             modelConfig: {
               model: testCase.modelName,
               fastModel: "gpt-4o-mini",
+              capabilities: testCase.capabilities,
             },
             messages: [{ role: "user", content: "Test message" }],
             workdir: "/test/workdir",

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -606,6 +606,76 @@ describe("ConfigurationService", () => {
     });
   });
 
+  describe("resolveModelConfig — capabilities", () => {
+    it("should merge capabilities from models[modelName] into resolved config", async () => {
+      const config = {
+        models: {
+          "claude-sonnet-4": {
+            capabilities: { promptCaching: true, vision: true },
+          },
+        },
+      };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      const origModel = process.env.WAVE_MODEL;
+      const origFastModel = process.env.WAVE_FAST_MODEL;
+      delete process.env.WAVE_MODEL;
+      delete process.env.WAVE_FAST_MODEL;
+      try {
+        await configService.loadMergedConfiguration(tempDir);
+        const resolved = configService.resolveModelConfig("claude-sonnet-4");
+
+        expect(resolved.capabilities).toEqual({
+          promptCaching: true,
+          vision: true,
+        });
+      } finally {
+        if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
+        else delete process.env.WAVE_MODEL;
+        if (origFastModel !== undefined)
+          process.env.WAVE_FAST_MODEL = origFastModel;
+        else delete process.env.WAVE_FAST_MODEL;
+      }
+    });
+
+    it("should strip capabilities from fastModelConfig extraction", async () => {
+      const config = {
+        models: {
+          "gpt-4o": { capabilities: { promptCaching: true } },
+          "gpt-4o-mini": {
+            capabilities: { vision: false },
+            temperature: 0.2,
+          },
+        },
+      };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      const origModel = process.env.WAVE_MODEL;
+      const origFastModel = process.env.WAVE_FAST_MODEL;
+      delete process.env.WAVE_MODEL;
+      delete process.env.WAVE_FAST_MODEL;
+      try {
+        await configService.loadMergedConfiguration(tempDir);
+        const resolved = configService.resolveModelConfig(
+          "gpt-4o",
+          "gpt-4o-mini",
+        );
+
+        // capabilities should NOT leak into fastModelConfig
+        expect(resolved.fastModelConfig).toEqual({ temperature: 0.2 });
+        expect(resolved.fastModelConfig).not.toHaveProperty("capabilities");
+      } finally {
+        if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
+        else delete process.env.WAVE_MODEL;
+        if (origFastModel !== undefined)
+          process.env.WAVE_FAST_MODEL = origFastModel;
+        else delete process.env.WAVE_FAST_MODEL;
+      }
+    });
+  });
+
   describe("resolveMaxInputTokens", () => {
     const originalEnv = process.env.WAVE_MAX_INPUT_TOKENS;
 

--- a/packages/agent-sdk/tests/utils/convertMessagesForAPI.test.ts
+++ b/packages/agent-sdk/tests/utils/convertMessagesForAPI.test.ts
@@ -669,4 +669,132 @@ describe("convertMessagesForAPI", () => {
     expect(apiMessages[1].role).toBe("user");
     expect(apiMessages[2].role).toBe("assistant");
   });
+
+  describe("supportsVision option", () => {
+    it("should replace user ImageBlock with text placeholder when supportsVision is false", () => {
+      const messages: Message[] = [
+        {
+          id: generateMessageId(),
+          role: "user",
+          blocks: [
+            { type: "text", content: "What is in this image?" },
+            {
+              type: "image",
+              imageUrls: ["data:image/png;base64,iVBORw0KGgoAAAANS..."],
+            },
+          ],
+          timestamp: new Date().toISOString(),
+        },
+      ];
+
+      const apiMessages = convertMessagesForAPI(messages, {
+        supportsVision: false,
+      });
+
+      expect(apiMessages).toHaveLength(1);
+      expect(apiMessages[0].role).toBe("user");
+      const content = apiMessages[0].content as Array<{
+        type: string;
+        text?: string;
+      }>;
+      expect(content).toHaveLength(2);
+      expect(content[0]).toEqual({
+        type: "text",
+        text: "What is in this image?",
+      });
+      expect(content[1].type).toBe("text");
+      expect(content[1].text).toContain("does not support image recognition");
+
+      // Ensure no image_url parts remain
+      const allContent = JSON.stringify(apiMessages);
+      expect(allContent).not.toContain("image_url");
+    });
+
+    it("should replace tool result images with text placeholder when supportsVision is false", () => {
+      const messages: Message[] = [
+        {
+          id: generateMessageId(),
+          role: "user",
+          blocks: [{ type: "text", content: "Take a screenshot" }],
+          timestamp: new Date().toISOString(),
+        },
+        {
+          id: generateMessageId(),
+          role: "assistant",
+          blocks: [
+            {
+              type: "tool",
+              id: "tool_img_1",
+              name: "get_screenshot",
+              parameters: '{"nodeId": "123"}',
+              stage: "end",
+              result: "Screenshot taken.",
+              success: true,
+              images: [{ data: "base64data", mediaType: "image/png" }],
+            },
+          ],
+          timestamp: new Date().toISOString(),
+        },
+      ];
+
+      const apiMessages = convertMessagesForAPI(messages, {
+        supportsVision: false,
+      });
+
+      // Find the user message that contains the placeholder (not the original text)
+      type ContentPart = { type: string; text?: string; image_url?: unknown };
+      const userMessages = apiMessages.filter((m) => m.role === "user");
+
+      // The placeholder should be in one of the user messages (string or array content)
+      const placeholderFound = userMessages.some((m) => {
+        if (typeof m.content === "string") {
+          return m.content.includes("does not support image recognition");
+        }
+        if (Array.isArray(m.content)) {
+          const parts = m.content as ContentPart[];
+          return parts.some(
+            (p) =>
+              p.type === "text" &&
+              typeof p.text === "string" &&
+              p.text.includes("does not support image recognition"),
+          );
+        }
+        return false;
+      });
+      expect(placeholderFound).toBe(true);
+
+      // Ensure no image_url parts remain
+      const allContent = JSON.stringify(apiMessages);
+      expect(allContent).not.toContain("image_url");
+    });
+
+    it("should send images as image_url when supportsVision is true (default)", () => {
+      const messages: Message[] = [
+        {
+          id: generateMessageId(),
+          role: "user",
+          blocks: [
+            { type: "text", content: "What is in this image?" },
+            {
+              type: "image",
+              imageUrls: ["data:image/png;base64,iVBORw0KGgoAAAANS..."],
+            },
+          ],
+          timestamp: new Date().toISOString(),
+        },
+      ];
+
+      // Default (no options) = supportsVision undefined = true
+      const apiMessagesDefault = convertMessagesForAPI(messages);
+      const allContentDefault = JSON.stringify(apiMessagesDefault);
+      expect(allContentDefault).toContain("image_url");
+
+      // Explicitly true
+      const apiMessagesTrue = convertMessagesForAPI(messages, {
+        supportsVision: true,
+      });
+      const allContentTrue = JSON.stringify(apiMessagesTrue);
+      expect(allContentTrue).toContain("image_url");
+    });
+  });
 });

--- a/specs/019-prompt-cache-control.md
+++ b/specs/019-prompt-cache-control.md
@@ -15,9 +15,9 @@
 
 **验收场景**：
 
-1. **假设**配置了 Claude 模型（模型名称包含"claude"），**当**进行代理调用时，**则**系统消息内容被包装在 type 为"ephemeral"的 cache_control 结构中
+1. **假设**配置了支持缓存的模型（`capabilities.promptCaching: true`），**当**进行代理调用时，**则**系统消息内容被包装在 type 为"ephemeral"的 cache_control 结构中
 2. **假设**使用相同系统消息的多次代理调用，**当**后续调用发生时，**则**用量追踪报告系统消息的 cache_read_input_tokens
-3. **假设**配置了非 Claude 模型，**当**进行代理调用时，**则**不向任何消息添加 cache_control 标记
+3. **假设**配置了不支持缓存的模型（`capabilities.promptCaching` 未设为 `true`），**当**进行代理调用时，**则**不向任何消息添加 cache_control 标记
 
 ---
 
@@ -98,7 +98,7 @@
 
 ### 边界情况
 
-- **边界情况 1**：模型名称检测必须不区分大小写（"Claude-3-Sonnet"和"claude-3-sonnet"都触发 cache_control 标记注入）。从 usage 中提取缓存 token 适用于所有模型名称
+- **边界情况 1**：模型能力检测通过声明式 `capabilities.promptCaching` 字段（默认 `false`）和 `capabilities.vision` 字段（默认 `true`）完成，不依赖模型名称匹配。从 usage 中提取缓存 token 适用于所有模型
 - **边界情况 2**：混合内容消息必须仅对文本内容部分应用 cache_control，保持图片不变
 - **边界情况 3**：流式和非流式请求必须应用相同的 cache_control 转换逻辑
 - **边界情况 4**：Token 追踪必须优雅处理缺失的缓存 token 字段（将 undefined 视为 0）
@@ -111,10 +111,10 @@
 
 ### 功能需求
 
-- **FR-001**：系统必须使用 `WAVE_PROMPT_CACHE_REGEX` 环境变量（默认："claude"）检测支持缓存的模型以进行 cache_control 标记注入，允许配置正则模式进行模型匹配。此门控仅控制 `cache_control: {type: "ephemeral"}` 标记到消息中的注入——它不门控从 usage 响应中提取缓存 token，后者适用于所有模型
+- **FR-001**：系统必须使用声明式 `capabilities.promptCaching` 字段（位于 `ModelConfig` 中）检测支持缓存的模型以进行 cache_control 标记注入。门控检查 `modelConfig.capabilities?.promptCaching`（默认 `false`）。此门控仅控制 `cache_control: {type: "ephemeral"}` 标记到消息中的注入——它不门控从 usage 响应中提取缓存 token，后者适用于所有模型
 - **FR-002**：系统必须将系统提示拆分为静态块和动态块。静态块（`cacheable: true`）包含 base prompt + DOING_TASKS + EXECUTING_ACTIONS + TOOL_POLICY + OUTPUT_EFFICIENCY + TONE_AND_STYLE，这些内容在会话期间不变。动态块（`cacheable: false`）包含权限模式、语言、环境信息（workdir、isGitRepo、platform、shell、OS version、date、worktree session）、auto memory 指令和 MEMORY.md 内容，这些内容可能随时间或交互变化。`buildSystemPrompt` 返回 `SystemPromptBlock[]` 而非字符串。系统提示必须在计划模式切换间保持不变——计划模式指令作为 `<system-reminder>` 用户消息注入而非系统提示更改以保持缓存的系统提示前缀。`<env>` 部分的 `Primary working directory` 字段必须使用不可变的 `originalWorkdir`（在会话开始时设置一次）而非动态的 `workdir`（追踪 `cd` 更改），以便 CWD 更改不会失效缓存的系统提示
 - **FR-003**：系统必须维护两个缓存标记：(1) 系统消息的静态块（通过 `callAgent` 中的块映射获得 cache_control），和 (2) 最后一条有内容的消息（user 或 assistant，不区分角色，由 `transformMessagesForExplicitCache` 标记）。策略完全无状态——无模块级状态、无桥接追踪、无 tools 参数。`transformMessagesForExplicitCache` 函数仅接收消息和模型名称。`transformMessagesForExplicitCache` 的幂等性检查检测到系统消息已有 cache_control（来自块映射）时跳过重新标记，避免重复。最后消息标记每轮前进约 2 个块，因为新消息被添加，但由于 API 从每个标记向后扫描 20 个块窗口且正常对话每轮添加少于 20 个块，之前的缓存位置始终在扫描窗口内，导致缓存命中。工具作为最后消息标记覆盖的前缀的一部分被隐式缓存。内容块被精确计数：字符串内容 = 1 块，数组内容 = 元素计数，null/undefined 内容 = 0 块
-- **FR-004**：系统在使用非 Claude 模型时（由 `WAVE_PROMPT_CACHE_REGEX` 确定）不得添加 cache_control 标记。当传入 `SystemPromptBlock[]` 时，非 Claude 模型将所有块文本以 `\n\n` 拼接为单个字符串。但是，从 usage 中提取缓存 token（FR-005）适用于所有模型，不受此门控限制
+- **FR-004**：系统在不支持缓存的模型（即 `capabilities.promptCaching` 未设为 `true` 的模型，由 `supportsPromptCaching(capabilities)` 返回 `false` 确定）时不得添加 cache_control 标记。当传入 `SystemPromptBlock[]` 时，不支持缓存的模型将所有块文本以 `\n\n` 拼接为单个字符串。但是，从 usage 中提取缓存 token（FR-005）适用于所有模型，不受此门控限制
 - **FR-005**：系统必须扩展用量追踪以包含所有模型（不受 `supportsPromptCaching` 门控）的缓存相关指标。缓存 token 从两个来源按优先级提取：(1) Claude 顶层字段（cache_read_input_tokens、cache_creation_input_tokens、cache_creation 对象）优先，(2) OpenAI 标准 prompt_tokens_details 字段（cached_tokens → cache_read_input_tokens，cache_creation_input_tokens → cache_creation_input_tokens）作为通过 prompt_tokens_details 返回缓存数据的非 Claude 模型的后备
 - **FR-006**：系统必须在消息准备阶段对流式和非流式请求相同地应用 cache_control 标记
 - **FR-007**：系统必须保持与现有消息处理逻辑的向后兼容性：`CallAgentOptions.systemPrompt` 类型为 `string | SystemPromptBlock[]`，纯字符串输入按原有逻辑处理（向后兼容）
@@ -125,6 +125,6 @@
 - **对话线程**：表示用户和 AI 代理之间的消息序列，属性包括消息计数和会话上下文
 - **消息上下文**：表示为 AI 代理响应提供上下文的系统提示和工具的组合
 - **增强用量指标**：扩展的用量对象，包括缓存相关 token 计数和创建明细
-- **Claude 模型检测**：基于不区分大小写的模型名称匹配的布尔判定。仅门控 cache_control 标记注入——缓存 token 提取适用于所有模型
+- **Prompt caching 能力检测**：基于声明式 `capabilities.promptCaching` 字段的布尔判定，而非模型名称匹配。仅门控 cache_control 标记注入——缓存 token 提取适用于所有模型
 - **结构化消息内容**：基于数组的消息内容格式，支持在单个内容部分上的 cache_control
 - **SystemPromptBlock**：系统提示分块结构 `{ text: string; cacheable: boolean }`。`cacheable: true` 的块在 Claude 模型下获得 `cache_control: {type: "ephemeral"}` 标记，`cacheable: false` 的块不获得标记。`buildSystemPrompt` 返回 `SystemPromptBlock[]`，`callAgent` 根据模型类型决定映射方式


### PR DESCRIPTION
## Summary

Replace `WAVE_PROMPT_CACHE_REGEX` and `WAVE_NON_VISION_REGEX` env vars with a declarative `capabilities` field on `ModelConfig`. Each model in `settings.json` can now declare its capabilities explicitly instead of relying on regex-based model name matching.

## Changes

- **`ModelConfig`**: Added `ModelCapabilities` interface with `vision` (default `true`) and `promptCaching` (default `false`) fields
- **`modelCapabilities.ts`**: Rewritten to pure declarative — no regex, no env vars
- **`cacheControlUtils.ts`**: `transformMessagesForExplicitCache` now accepts `capabilities` instead of model name string
- **`aiService.ts`**: Threaded `capabilities` through `callAgent`, `compactMessages`, `processWebContent`, `btw`; stripped `capabilities` from `extraParams` to prevent leaking to API providers
- **`aiManager.ts`** / **`agent.ts`**: Updated `supportsVision` calls to use `capabilities`
- **`configurationService.ts`**: Strip `capabilities` from `fastModelConfig` extraction
- **Tests**: Rewrote `aiService.cacheControl.test.ts` and `configurationService.test.ts` to use declarative capabilities
- **Docs**: Updated spec 019, `docs/sdk.md`, settings skill (`ENV.md` + `MODELS.md`)

## Migration

Users previously using `WAVE_PROMPT_CACHE_REGEX` should instead declare capabilities per-model:

```json
{
  "models": {
    "claude-sonnet-4": {
      "capabilities": { "promptCaching": true }
    }
  }
}
```

Similarly, `WAVE_NON_VISION_REGEX` users should declare `"capabilities": { "vision": false }` for non-vision models.