### PR TITLE
feat(skill-manager): support .agents/skills directory scanning

### DIFF
--- a/packages/agent-sdk/builtin/skills/settings/SKILLS.md
+++ b/packages/agent-sdk/builtin/skills/settings/SKILLS.md
@@ -48,12 +48,14 @@ When this skill is invoked, follow these steps:
 
 ## Skill Locations
 
-Wave looks for skills in two locations:
+Wave looks for skills in multiple locations, with later sources overriding earlier ones for same-named skills:
 
-1.  **User Skills**: `~/.wave/skills/` (Available in all projects)
-2.  **Project Skills**: `.wave/skills/` (Specific to the current project)
+1.  **User Skills**: `~/.agents/skills/` → `~/.claude/skills/` → `~/.wave/skills/` (Available in all projects)
+2.  **Project Skills**: `.agents/skills/` → `.claude/skills/` → `.wave/skills/` (Specific to the current project)
 
-Project skills take precedence over user skills with the same name.
+The `.agents/skills` directory is the cross-tool standard adopted by Codex, Cursor, Cline, Gemini CLI, GitHub Copilot, and OpenCode, so a single skill directory can be shared across all your AI tools.
+
+Project skills take precedence over user skills with the same name. Within each level, `.wave` overrides `.claude`, which overrides `.agents`.
 
 ## Invoking Skills
 

--- a/packages/agent-sdk/src/managers/skillManager.ts
+++ b/packages/agent-sdk/src/managers/skillManager.ts
@@ -30,6 +30,7 @@ import { logger } from "../utils/globalLogger.js";
 export class SkillManager extends EventEmitter {
   private personalSkillsPath: string;
   private personalClaudeSkillsPath: string;
+  private personalAgentsSkillsPath: string;
   private scanTimeout: number;
   private workdir: string;
 
@@ -50,6 +51,8 @@ export class SkillManager extends EventEmitter {
       options.personalSkillsPath || join(homedir(), ".wave", "skills");
     this.personalClaudeSkillsPath =
       options.personalClaudeSkillsPath || join(homedir(), ".claude", "skills");
+    this.personalAgentsSkillsPath =
+      options.personalAgentsSkillsPath || join(homedir(), ".agents", "skills");
     this.scanTimeout = options.scanTimeout || 5000;
     this.workdir = options.workdir || process.cwd();
     this.watchEnabled = options.watch ?? false;
@@ -131,8 +134,10 @@ export class SkillManager extends EventEmitter {
     const pathsToWatch = [
       this.personalSkillsPath,
       this.personalClaudeSkillsPath,
+      this.personalAgentsSkillsPath,
       join(this.workdir, ".wave", "skills"),
       join(this.workdir, ".claude", "skills"),
+      join(this.workdir, ".agents", "skills"),
     ];
 
     logger?.debug(`Setting up skill watcher for: ${pathsToWatch.join(", ")}`);
@@ -225,6 +230,11 @@ export class SkillManager extends EventEmitter {
       "builtin",
     );
 
+    const personalAgentsCollection = await this.discoverSkillCollection(
+      this.personalAgentsSkillsPath,
+      "personal",
+    );
+
     const personalClaudeCollection = await this.discoverSkillCollection(
       this.personalClaudeSkillsPath,
       "personal",
@@ -243,12 +253,14 @@ export class SkillManager extends EventEmitter {
     return {
       builtinSkills: builtinCollection.skills,
       personalSkills: new Map([
-        ...personalClaudeCollection.skills,
+        ...personalAgentsCollection.skills, // lowest priority
+        ...personalClaudeCollection.skills, // overrides .agents
         ...personalCollection.skills, // .wave overrides .claude
       ]),
       projectSkills: projectCollection.skills,
       errors: [
         ...builtinCollection.errors,
+        ...personalAgentsCollection.errors,
         ...personalClaudeCollection.errors,
         ...personalCollection.errors,
         ...projectCollection.errors,
@@ -271,9 +283,11 @@ export class SkillManager extends EventEmitter {
     };
 
     if (type === "project") {
-      // Scan .claude/skills first, then .wave/skills (wave overrides)
+      // Scan .agents/skills first, then .claude/skills, then .wave/skills (wave overrides)
+      const agentsPath = join(basePath, ".agents", "skills");
       const claudePath = join(basePath, ".claude", "skills");
       const wavePath = join(basePath, ".wave", "skills");
+      await this.scanSkillPath(agentsPath, collection);
       await this.scanSkillPath(claudePath, collection);
       await this.scanSkillPath(wavePath, collection);
     } else {

--- a/packages/agent-sdk/src/types/skills.ts
+++ b/packages/agent-sdk/src/types/skills.ts
@@ -74,6 +74,7 @@ export interface SkillToolArgs {
 export interface SkillManagerOptions {
   personalSkillsPath?: string;
   personalClaudeSkillsPath?: string;
+  personalAgentsSkillsPath?: string;
   scanTimeout?: number;
   workdir?: string;
   watch?: boolean;

--- a/packages/agent-sdk/src/utils/skillParser.ts
+++ b/packages/agent-sdk/src/utils/skillParser.ts
@@ -57,7 +57,9 @@ export function parseSkillFile(
       skillPath.includes("/.wave/skills") ||
       skillPath.includes("\\.wave\\skills") ||
       skillPath.includes("/.claude/skills") ||
-      skillPath.includes("\\.claude\\skills")
+      skillPath.includes("\\.claude\\skills") ||
+      skillPath.includes("/.agents/skills") ||
+      skillPath.includes("\\.agents\\skills")
         ? "project"
         : "personal";
 

--- a/packages/agent-sdk/tests/managers/skillManager.test.ts
+++ b/packages/agent-sdk/tests/managers/skillManager.test.ts
@@ -1011,7 +1011,7 @@ describe("SkillManager", () => {
     });
   });
 
-  describe("Claude ecosystem compatibility", () => {
+  describe("Cross-tool skill directory compatibility", () => {
     it("should discover skills from .claude/skills at project level", async () => {
       const manager = new SkillManager(container, {
         workdir: "/test/workdir",
@@ -1173,6 +1173,297 @@ describe("SkillManager", () => {
 
       expect(watchedPaths).toContain("/test/workdir/.claude/skills");
       expect(watchedPaths).toContain("/home/user/.claude/skills");
+
+      await manager.destroy();
+    });
+
+    it("should discover skills from .agents/skills at project level", async () => {
+      const manager = new SkillManager(container, {
+        workdir: "/test/workdir",
+      });
+
+      vi.mocked(readdir).mockImplementation(async (path) => {
+        const p = path.toString();
+        if (p === "/test/workdir/.agents/skills") {
+          return [
+            { name: "agents-skill", isDirectory: () => true },
+          ] as unknown as Awaited<ReturnType<typeof readdir>>;
+        }
+        return [] as unknown as Awaited<ReturnType<typeof readdir>>;
+      });
+
+      vi.mocked(stat).mockResolvedValue(
+        {} as unknown as Awaited<ReturnType<typeof stat>>,
+      );
+
+      vi.mocked(parseSkillFile).mockReturnValue({
+        isValid: true,
+        skillMetadata: {
+          name: "agents-skill",
+          description: "from agents",
+          type: "project",
+          skillPath: "/test/workdir/.agents/skills/agents-skill",
+        },
+        content: "---\nname: agents-skill\n---\ncontent",
+        frontmatter: { name: "agents-skill" },
+        validationErrors: [],
+      } as unknown as ReturnType<typeof parseSkillFile>);
+
+      await manager.initialize();
+
+      const skills = manager.getAvailableSkills();
+      expect(skills.find((s) => s.name === "agents-skill")).toBeDefined();
+
+      await manager.destroy();
+    });
+
+    it("should discover skills from ~/.agents/skills at personal level", async () => {
+      const manager = new SkillManager(container, {
+        workdir: "/test/workdir",
+        personalAgentsSkillsPath: "/home/user/.agents/skills",
+      });
+
+      vi.mocked(readdir).mockImplementation(async (path) => {
+        const p = path.toString();
+        if (p === "/home/user/.agents/skills") {
+          return [
+            { name: "personal-agents-skill", isDirectory: () => true },
+          ] as unknown as Awaited<ReturnType<typeof readdir>>;
+        }
+        return [] as unknown as Awaited<ReturnType<typeof readdir>>;
+      });
+
+      vi.mocked(stat).mockResolvedValue(
+        {} as unknown as Awaited<ReturnType<typeof stat>>,
+      );
+
+      vi.mocked(parseSkillFile).mockReturnValue({
+        isValid: true,
+        skillMetadata: {
+          name: "personal-agents-skill",
+          description: "from personal agents",
+          type: "personal",
+          skillPath: "/home/user/.agents/skills/personal-agents-skill",
+        },
+        content: "---\nname: personal-agents-skill\n---\ncontent",
+        frontmatter: { name: "personal-agents-skill" },
+        validationErrors: [],
+      } as unknown as ReturnType<typeof parseSkillFile>);
+
+      await manager.initialize();
+
+      const skills = manager.getAvailableSkills();
+      expect(
+        skills.find((s) => s.name === "personal-agents-skill"),
+      ).toBeDefined();
+
+      await manager.destroy();
+    });
+
+    it("should let .wave/skills override .agents/skills for same-named skill at project level", async () => {
+      const manager = new SkillManager(container, {
+        workdir: "/test/workdir",
+      });
+
+      vi.mocked(readdir).mockImplementation(async (path) => {
+        const p = path.toString();
+        if (
+          p === "/test/workdir/.agents/skills" ||
+          p === "/test/workdir/.wave/skills"
+        ) {
+          return [
+            { name: "override-skill", isDirectory: () => true },
+          ] as unknown as Awaited<ReturnType<typeof readdir>>;
+        }
+        return [] as unknown as Awaited<ReturnType<typeof readdir>>;
+      });
+
+      vi.mocked(stat).mockResolvedValue(
+        {} as unknown as Awaited<ReturnType<typeof stat>>,
+      );
+
+      vi.mocked(parseSkillFile).mockImplementation((filePath) => {
+        const p = filePath as string;
+        if (p.includes(".agents/skills")) {
+          return {
+            isValid: true,
+            skillMetadata: {
+              name: "override-skill",
+              description: "agents version",
+              type: "project",
+              skillPath: p,
+            },
+            content: "agents content",
+            frontmatter: { name: "override-skill" },
+            validationErrors: [],
+          } as unknown as ReturnType<typeof parseSkillFile>;
+        }
+        return {
+          isValid: true,
+          skillMetadata: {
+            name: "override-skill",
+            description: "wave version",
+            type: "project",
+            skillPath: p,
+          },
+          content: "wave content",
+          frontmatter: { name: "override-skill" },
+          validationErrors: [],
+        } as unknown as ReturnType<typeof parseSkillFile>;
+      });
+
+      await manager.initialize();
+
+      const skills = manager.getAvailableSkills();
+      const skill = skills.find((s) => s.name === "override-skill");
+      expect(skill).toBeDefined();
+      expect(skill?.description).toBe("wave version");
+
+      await manager.destroy();
+    });
+
+    it("should let .claude/skills override .agents/skills for same-named skill at project level", async () => {
+      const manager = new SkillManager(container, {
+        workdir: "/test/workdir",
+      });
+
+      vi.mocked(readdir).mockImplementation(async (path) => {
+        const p = path.toString();
+        if (
+          p === "/test/workdir/.agents/skills" ||
+          p === "/test/workdir/.claude/skills"
+        ) {
+          return [
+            { name: "override-skill", isDirectory: () => true },
+          ] as unknown as Awaited<ReturnType<typeof readdir>>;
+        }
+        return [] as unknown as Awaited<ReturnType<typeof readdir>>;
+      });
+
+      vi.mocked(stat).mockResolvedValue(
+        {} as unknown as Awaited<ReturnType<typeof stat>>,
+      );
+
+      vi.mocked(parseSkillFile).mockImplementation((filePath) => {
+        const p = filePath as string;
+        if (p.includes(".agents/skills")) {
+          return {
+            isValid: true,
+            skillMetadata: {
+              name: "override-skill",
+              description: "agents version",
+              type: "project",
+              skillPath: p,
+            },
+            content: "agents content",
+            frontmatter: { name: "override-skill" },
+            validationErrors: [],
+          } as unknown as ReturnType<typeof parseSkillFile>;
+        }
+        return {
+          isValid: true,
+          skillMetadata: {
+            name: "override-skill",
+            description: "claude version",
+            type: "project",
+            skillPath: p,
+          },
+          content: "claude content",
+          frontmatter: { name: "override-skill" },
+          validationErrors: [],
+        } as unknown as ReturnType<typeof parseSkillFile>;
+      });
+
+      await manager.initialize();
+
+      const skills = manager.getAvailableSkills();
+      const skill = skills.find((s) => s.name === "override-skill");
+      expect(skill).toBeDefined();
+      expect(skill?.description).toBe("claude version");
+
+      await manager.destroy();
+    });
+
+    it("should let ~/.wave/skills override ~/.agents/skills for same-named skill at personal level", async () => {
+      const manager = new SkillManager(container, {
+        workdir: "/test/workdir",
+        personalSkillsPath: "/home/user/.wave/skills",
+        personalAgentsSkillsPath: "/home/user/.agents/skills",
+      });
+
+      vi.mocked(readdir).mockImplementation(async (path) => {
+        const p = path.toString();
+        if (
+          p === "/home/user/.agents/skills" ||
+          p === "/home/user/.wave/skills"
+        ) {
+          return [
+            { name: "override-skill", isDirectory: () => true },
+          ] as unknown as Awaited<ReturnType<typeof readdir>>;
+        }
+        return [] as unknown as Awaited<ReturnType<typeof readdir>>;
+      });
+
+      vi.mocked(stat).mockResolvedValue(
+        {} as unknown as Awaited<ReturnType<typeof stat>>,
+      );
+
+      vi.mocked(parseSkillFile).mockImplementation((filePath) => {
+        const p = filePath as string;
+        if (p.includes(".agents/skills")) {
+          return {
+            isValid: true,
+            skillMetadata: {
+              name: "override-skill",
+              description: "agents version",
+              type: "personal",
+              skillPath: p,
+            },
+            content: "agents content",
+            frontmatter: { name: "override-skill" },
+            validationErrors: [],
+          } as unknown as ReturnType<typeof parseSkillFile>;
+        }
+        return {
+          isValid: true,
+          skillMetadata: {
+            name: "override-skill",
+            description: "wave version",
+            type: "personal",
+            skillPath: p,
+          },
+          content: "wave content",
+          frontmatter: { name: "override-skill" },
+          validationErrors: [],
+        } as unknown as ReturnType<typeof parseSkillFile>;
+      });
+
+      await manager.initialize();
+
+      const skills = manager.getAvailableSkills();
+      const skill = skills.find((s) => s.name === "override-skill");
+      expect(skill).toBeDefined();
+      expect(skill?.description).toBe("wave version");
+
+      await manager.destroy();
+    });
+
+    it("should include .agents/skills paths in watched paths", async () => {
+      const manager = new SkillManager(container, {
+        workdir: "/test/workdir",
+        watch: true,
+        personalAgentsSkillsPath: "/home/user/.agents/skills",
+      });
+      vi.mocked(readdir).mockResolvedValue([]);
+
+      await manager.initialize();
+
+      const watchedPaths = mockFileWatcher.watchFile.mock.calls.map(
+        (call: unknown[]) => call[0] as string,
+      );
+
+      expect(watchedPaths).toContain("/test/workdir/.agents/skills");
+      expect(watchedPaths).toContain("/home/user/.agents/skills");
 
       await manager.destroy();
     });

--- a/specs/006-agent-skills.md
+++ b/specs/006-agent-skills.md
@@ -174,6 +174,7 @@ Wave 需要根据用户请求和技能描述自主发现何时使用可用技能
 - **FR-023**：Wave 必须将技能 bash 输出上限设为每个命令 30,000 字符；截断的输出包含 2,048 字符预览和完整输出的临时文件路径
 - **FR-024**：Wave 必须在 `String.replace` 中使用函数替换器以避免 bash 输出替换时 `$$`、`$&`、`$'` 的损坏
 - **FR-025**：Wave 必须将内联 bash 模式扫描置于 `content.includes('!`')` 检查之后以提高性能
+- **FR-026**：Wave 必须支持从 `.agents/skills/` 目录发现技能（个人级 `~/.agents/skills/` 和项目级 `{workdir}/.agents/skills/`），作为跨工具共享技能目录的最低优先级来源。在个人级和项目级中，`.wave/skills` 优先于 `.claude/skills`，`.claude/skills` 优先于 `.agents/skills`
 
 ### 关键实体
 


### PR DESCRIPTION
## Summary

Add `.agents/skills` as the lowest-priority skill discovery source, both at personal (`~/.agents/skills/`) and project (`{workdir}/.agents/skills/`) levels. This aligns Wave with the cross-tool standard adopted by Codex, Cursor, Cline, Gemini CLI, GitHub Copilot, and OpenCode, letting users maintain a single shared skill directory across all their AI tools.

## Priority Chain (lowest → highest, later overrides earlier)

- **Personal:** `~/.agents/skills` → `~/.claude/skills` → `~/.wave/skills`
- **Project:** `.agents/skills` → `.claude/skills` → `.wave/skills`

Existing `.wave`/`.claude` behavior is unchanged — `.agents` only adds a new lowest-priority layer.

## Changes

| File | Change |
|------|--------|
| `src/types/skills.ts` | Add `personalAgentsSkillsPath` option to `SkillManagerOptions` |
| `src/managers/skillManager.ts` | Constructor default `~/.agents/skills`; scan `.agents` first in `discoverSkills()` and `discoverSkillCollection()`; watch `.agents/skills` paths in `setupWatcher()` |
| `src/utils/skillParser.ts` | Classify `.agents/skills` paths as `"project"` type |
| `tests/managers/skillManager.test.ts` | 6 new tests: discovery (project + personal), override (`.wave`→`.agents`, `.claude`→`.agents`, personal), watcher coverage |
| `builtin/skills/settings/SKILLS.md` | Document `.agents/skills` location with priority explanation |
| `specs/006-agent-skills.md` | Add FR-026 for `.agents/skills` scanning support |

## Verification

- `pnpm -F wave-agent-sdk build` — clean
- `pnpm -F wave-agent-sdk test tests/managers/skillManager.test.ts` — 45/45 pass
- `pnpm -F wave-agent-sdk test tests/utils/skillParser.test.ts` — 18/18 pass
- `pnpm run type-check` — clean across all 3 packages