### PR TITLE
feat: flatten file-history storage and add auto-cleanup

### DIFF
--- a/packages/agent-sdk/src/services/reversionService.ts
+++ b/packages/agent-sdk/src/services/reversionService.ts
@@ -1,5 +1,5 @@
-import { readFile, writeFile, mkdir, rm } from "fs/promises";
-import { join } from "path";
+import { readFile, writeFile, mkdir, rm, readdir, stat } from "fs/promises";
+import { join, dirname } from "path";
 import { homedir } from "os";
 import { createHash } from "crypto";
 import { FileSnapshot } from "../types/reversion.js";
@@ -9,37 +9,37 @@ export class ReversionService {
   private rootSessionId: string;
 
   constructor(rootSessionId: string) {
-    this.rootSessionId = rootSessionId;
+    this.rootSessionId = rootSessionId || "default";
     this.historyBaseDir = join(
       homedir(),
       ".wave",
       "file-history",
-      rootSessionId || "default",
+      this.rootSessionId,
     );
   }
 
   private getFilePathHash(filePath: string): string {
-    return createHash("md5").update(filePath).digest("hex");
+    return createHash("sha256").update(filePath).digest("hex").slice(0, 16);
   }
 
-  private async getNextVersion(fileHashDir: string): Promise<number> {
+  private async getNextVersion(filePath: string): Promise<number> {
+    const hash = this.getFilePathHash(filePath);
+    const prefix = `${hash}@v`;
     try {
-      const files = await readFile(join(fileHashDir, "versions"), "utf-8");
-      const versions = files
-        .split("\n")
-        .map((v) => parseInt(v, 10))
-        .filter((v) => !isNaN(v));
-      return versions.length > 0 ? Math.max(...versions) + 1 : 1;
+      const files = await readdir(this.historyBaseDir);
+      let maxVersion = 0;
+      for (const file of files) {
+        if (file.startsWith(prefix)) {
+          const v = parseInt(file.slice(prefix.length), 10);
+          if (!isNaN(v) && v > maxVersion) {
+            maxVersion = v;
+          }
+        }
+      }
+      return maxVersion + 1;
     } catch {
       return 1;
     }
-  }
-
-  private async updateVersionsFile(
-    fileHashDir: string,
-    version: number,
-  ): Promise<void> {
-    await appendFile(join(fileHashDir, "versions"), `${version}\n`, "utf-8");
   }
 
   /**
@@ -48,11 +48,10 @@ export class ReversionService {
    */
   async saveSnapshot(snapshot: FileSnapshot): Promise<string> {
     const fileHash = this.getFilePathHash(snapshot.filePath);
-    const fileHashDir = join(this.historyBaseDir, fileHash);
-    await this.ensureDirectory(fileHashDir);
+    await this.ensureDirectory(this.historyBaseDir);
 
-    const version = await this.getNextVersion(fileHashDir);
-    const snapshotPath = join(fileHashDir, `v${version}`);
+    const version = await this.getNextVersion(snapshot.filePath);
+    const snapshotPath = join(this.historyBaseDir, `${fileHash}@v${version}`);
 
     const snapshotWithContent = snapshot as FileSnapshot & {
       content: string | null;
@@ -65,7 +64,6 @@ export class ReversionService {
       return ""; // Return empty string to indicate no snapshot file
     }
 
-    await this.updateVersionsFile(fileHashDir, version);
     return snapshotPath;
   }
 
@@ -90,10 +88,35 @@ export class ReversionService {
     await rm(this.historyBaseDir, { recursive: true, force: true });
   }
 
+  /**
+   * Cleans up session directories older than the given number of days.
+   * Skips the current session.
+   */
+  async cleanupOldSessions(days: number = 30): Promise<void> {
+    const threshold = Date.now() - days * 24 * 60 * 60 * 1000;
+    const parentDir = dirname(this.historyBaseDir);
+    try {
+      const entries = await readdir(parentDir);
+      await Promise.all(
+        entries.map(async (entry) => {
+          if (entry === this.rootSessionId) return;
+          const dirPath = join(parentDir, entry);
+          try {
+            const stats = await stat(dirPath);
+            if (stats.isDirectory() && stats.mtimeMs < threshold) {
+              await rm(dirPath, { recursive: true, force: true });
+            }
+          } catch {
+            // ENOENT — concurrently deleted, skip
+          }
+        }),
+      );
+    } catch {
+      // parent dir doesn't exist — nothing to clean
+    }
+  }
+
   private async ensureDirectory(dirPath: string): Promise<void> {
     await mkdir(dirPath, { recursive: true });
   }
 }
-
-// Helper to avoid appendFile import error if not imported
-import { appendFile } from "fs/promises";

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -205,7 +205,11 @@ export function setupAgentContainer(
 
   const rootSessionId = messageManager.getRootSessionId();
 
-  container.register("ReversionService", new ReversionService(rootSessionId));
+  const reversionService = new ReversionService(rootSessionId);
+  container.register("ReversionService", reversionService);
+  reversionService.cleanupOldSessions(30).catch((error) => {
+    logger.error("Failed to cleanup old file history:", error);
+  });
   const reversionManager = new ReversionManager(container);
   container.register("ReversionManager", reversionManager);
 

--- a/packages/agent-sdk/tests/services/reversionService.test.ts
+++ b/packages/agent-sdk/tests/services/reversionService.test.ts
@@ -25,32 +25,84 @@ describe("ReversionService", () => {
       operation: "modify",
     };
 
-    vi.mocked(fs.readFile).mockRejectedValue(new Error("ENOENT")); // No versions file
+    vi.mocked(fs.readdir).mockResolvedValue([]);
 
     const snapshotPath = await service.saveSnapshot(
       snapshot as unknown as import("../../src/types/reversion.js").FileSnapshot,
     );
 
-    expect(snapshotPath).toContain("v1");
+    expect(snapshotPath).toContain("@v1");
     expect(fs.writeFile).toHaveBeenCalledWith(
-      expect.stringContaining("v1"),
+      expect.stringContaining("@v1"),
       "c1",
       "utf-8",
     );
-    expect(fs.appendFile).toHaveBeenCalledWith(
-      expect.stringContaining("versions"),
-      "1\n",
+  });
+
+  it("should compute next version by scanning existing files", async () => {
+    const snapshot = {
+      messageId: "m1",
+      filePath: "/path/to/f1",
+      content: "c1",
+      timestamp: 1,
+      operation: "modify",
+    };
+
+    // Simulate an existing v3 snapshot for the same file
+    const hash = service["getFilePathHash"]("/path/to/f1");
+    const existingFiles = [`${hash}@v1`, `${hash}@v3`, "other@v2"];
+    vi.mocked(fs.readdir).mockResolvedValue(
+      existingFiles as unknown as Awaited<ReturnType<typeof fs.readdir>>,
+    );
+
+    const snapshotPath = await service.saveSnapshot(
+      snapshot as unknown as import("../../src/types/reversion.js").FileSnapshot,
+    );
+
+    expect(snapshotPath).toContain("@v4");
+    expect(fs.writeFile).toHaveBeenCalledWith(
+      expect.stringContaining("@v4"),
+      "c1",
       "utf-8",
     );
+  });
+
+  it("should return empty string for create operation", async () => {
+    const snapshot = {
+      messageId: "m1",
+      filePath: "/path/to/newfile",
+      content: null,
+      timestamp: 1,
+      operation: "create",
+    };
+
+    vi.mocked(fs.readdir).mockResolvedValue([]);
+
+    const snapshotPath = await service.saveSnapshot(
+      snapshot as unknown as import("../../src/types/reversion.js").FileSnapshot,
+    );
+
+    expect(snapshotPath).toBe("");
+    expect(fs.writeFile).not.toHaveBeenCalled();
   });
 
   it("should read snapshot content", async () => {
     vi.mocked(fs.readFile).mockResolvedValue("snapshot content");
 
-    const result = await service.readSnapshotContent("/some/path/v1");
+    const result = await service.readSnapshotContent("/some/path/hash@v1");
 
     expect(result).toBe("snapshot content");
-    expect(fs.readFile).toHaveBeenCalledWith("/some/path/v1", "utf-8");
+    expect(fs.readFile).toHaveBeenCalledWith("/some/path/hash@v1", "utf-8");
+  });
+
+  it("should return null when snapshot file does not exist", async () => {
+    vi.mocked(fs.readFile).mockRejectedValue(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+    );
+
+    const result = await service.readSnapshotContent("/some/path/missing");
+
+    expect(result).toBeNull();
   });
 
   it("should delete session history", async () => {
@@ -60,5 +112,64 @@ describe("ReversionService", () => {
       recursive: true,
       force: true,
     });
+  });
+
+  it("should cleanup old sessions and skip current session", async () => {
+    const oldTime = Date.now() - 31 * 24 * 60 * 60 * 1000;
+    const recentTime = Date.now() - 1 * 24 * 60 * 60 * 1000;
+
+    vi.mocked(fs.readdir).mockResolvedValue([
+      "test-session",
+      "old-session",
+      "recent-session",
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+
+    vi.mocked(fs.stat).mockImplementation(async (path) => {
+      const p = path as unknown as string;
+      if (p.includes("old-session")) {
+        return {
+          isDirectory: () => true,
+          mtimeMs: oldTime,
+        } as unknown as Awaited<ReturnType<typeof fs.stat>>;
+      }
+      if (p.includes("recent-session")) {
+        return {
+          isDirectory: () => true,
+          mtimeMs: recentTime,
+        } as unknown as Awaited<ReturnType<typeof fs.stat>>;
+      }
+      return {
+        isDirectory: () => true,
+        mtimeMs: Date.now(),
+      } as unknown as Awaited<ReturnType<typeof fs.stat>>;
+    });
+
+    await service.cleanupOldSessions(30);
+
+    // old-session should be deleted
+    expect(fs.rm).toHaveBeenCalledWith(expect.stringContaining("old-session"), {
+      recursive: true,
+      force: true,
+    });
+    // recent-session should NOT be deleted
+    expect(fs.rm).not.toHaveBeenCalledWith(
+      expect.stringContaining("recent-session"),
+      { recursive: true, force: true },
+    );
+    // current session should NOT be deleted
+    expect(fs.rm).not.toHaveBeenCalledWith(
+      expect.stringContaining("test-session"),
+      { recursive: true, force: true },
+    );
+  });
+
+  it("should handle missing parent directory gracefully", async () => {
+    vi.mocked(fs.readdir).mockRejectedValue(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+    );
+
+    await service.cleanupOldSessions(30);
+
+    expect(fs.rm).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Aligns Wave's file-history storage format and cleanup mechanism with Claude Code.

## Changes

### Flatten storage format (`reversionService.ts`)
- **Hash**: `md5` → `sha256` first 16 chars (matches Claude Code's `getBackupFileName`)
- **Layout**: `~/.wave/file-history/{sessionId}/{md5hash}/v{N}` + `versions` file → flat `~/.wave/file-history/{sessionId}/{hash}@v{N}`
- **`getNextVersion`**: scans session dir for existing `{hash}@v{N}` files instead of reading a `versions` file
- Removed `updateVersionsFile` method and the bottom-of-file `appendFile` import

### Add auto-cleanup (`reversionService.ts` + `containerSetup.ts`)
- New `cleanupOldSessions(days=30)` method: scans parent `~/.wave/file-history/`, `rm -rf` session dirs with mtime older than threshold, skips current session
- Mirrors Claude Code's `cleanupOldFileHistoryBackups()` in `cleanup.ts`
- Triggered fire-and-forget at Agent init in `containerSetup.ts`, same pattern as the existing `taskManager.cleanupOldTaskLists(30)`

### Tests (`reversionService.test.ts`)
- 8 tests: saveSnapshot (flat path), next-version scan, create operation, readSnapshotContent, ENOENT handling, deleteSessionHistory, cleanupOldSessions (old deleted/recent+current preserved), missing parent dir

## Problem

`~/.wave/file-history/` had 1784 session directories totaling 646MB with no cleanup mechanism. The `deleteSessionHistory()` method existed but was never called in production code.

## Verification

- `pnpm -F wave-agent-sdk build` — compiles cleanly
- `pnpm -F wave-agent-sdk test` — 238 test files, 3215 passed, 1 skipped
- `pnpm -r type-check` — all packages pass
- `pnpm -r lint` — all packages pass
