### PR TITLE
fix: replace newlines with spaces in confirm/question text inputs

### DIFF
--- a/packages/code/src/reducers/confirmationReducer.ts
+++ b/packages/code/src/reducers/confirmationReducer.ts
@@ -40,16 +40,17 @@ export function confirmationReducer(
     case "SELECT_OPTION":
       return { ...state, selectedOption: action.option };
     case "INSERT_TEXT": {
+      const sanitized = action.text.replace(/\r\n?|\n/g, " ");
       const nextText =
         state.alternativeText.slice(0, state.alternativeCursorPosition) +
-        action.text +
+        sanitized +
         state.alternativeText.slice(state.alternativeCursorPosition);
       return {
         ...state,
         selectedOption: "alternative",
         alternativeText: nextText,
         alternativeCursorPosition:
-          state.alternativeCursorPosition + action.text.length,
+          state.alternativeCursorPosition + sanitized.length,
         hasUserInput: true,
       };
     }
@@ -210,16 +211,17 @@ export function confirmationReducer(
       }
 
       if (input && !key.ctrl && !key.meta && !("alt" in key && key.alt)) {
+        const sanitized = input.replace(/\r\n?|\n/g, " ");
         const nextText =
           state.alternativeText.slice(0, state.alternativeCursorPosition) +
-          input +
+          sanitized +
           state.alternativeText.slice(state.alternativeCursorPosition);
         return {
           ...state,
           selectedOption: "alternative",
           alternativeText: nextText,
           alternativeCursorPosition:
-            state.alternativeCursorPosition + input.length,
+            state.alternativeCursorPosition + sanitized.length,
           hasUserInput: true,
         };
       }

--- a/packages/code/src/reducers/questionReducer.ts
+++ b/packages/code/src/reducers/questionReducer.ts
@@ -145,14 +145,15 @@ export function questionReducer(
     }
     case "INSERT_OTHER": {
       if (state.selectedOptionIndex !== action.optionsLength - 1) return state;
+      const sanitized = action.text.replace(/\r\n?|\n/g, " ");
       const newText =
         state.otherText.slice(0, state.otherCursorPosition) +
-        action.text +
+        sanitized +
         state.otherText.slice(state.otherCursorPosition);
       return {
         ...state,
         otherText: newText,
-        otherCursorPosition: state.otherCursorPosition + action.text.length,
+        otherCursorPosition: state.otherCursorPosition + sanitized.length,
       };
     }
     case "DELETE_OTHER":
@@ -431,14 +432,15 @@ export function questionReducer(
           return state;
         }
         if (input && !key.ctrl && !key.meta) {
+          const sanitized = input.replace(/\r\n?|\n/g, " ");
           const newText =
             state.otherText.slice(0, state.otherCursorPosition) +
-            input +
+            sanitized +
             state.otherText.slice(state.otherCursorPosition);
           return {
             ...state,
             otherText: newText,
-            otherCursorPosition: state.otherCursorPosition + input.length,
+            otherCursorPosition: state.otherCursorPosition + sanitized.length,
           };
         }
       }

--- a/packages/code/tests/components/confirmationReducer.test.ts
+++ b/packages/code/tests/components/confirmationReducer.test.ts
@@ -78,6 +78,15 @@ describe("confirmationReducer", () => {
       expect(result.alternativeText).toBe("hello");
       expect(result.alternativeCursorPosition).toBe(5);
     });
+
+    it("should replace newlines with spaces in pasted text", () => {
+      const result = confirmationReducer(initialState, {
+        type: "INSERT_TEXT",
+        text: "line1\nline2\r\nline3",
+      });
+      expect(result.alternativeText).toBe("line1 line2 line3");
+      expect(result.alternativeCursorPosition).toBe(17);
+    });
   });
 
   describe("BACKSPACE", () => {

--- a/packages/code/tests/components/questionReducer.test.ts
+++ b/packages/code/tests/components/questionReducer.test.ts
@@ -214,6 +214,20 @@ describe("questionReducer", () => {
       expect(result.otherText).toBe("abc");
       expect(result.otherCursorPosition).toBe(2);
     });
+
+    it("should replace newlines with spaces in pasted text", () => {
+      const state: QuestionState = {
+        ...initialState,
+        selectedOptionIndex: 2,
+      };
+      const result = questionReducer(state, {
+        type: "INSERT_OTHER",
+        text: "line1\nline2\r\nline3",
+        optionsLength: 3,
+      });
+      expect(result.otherText).toBe("line1 line2 line3");
+      expect(result.otherCursorPosition).toBe(17);
+    });
   });
 
   describe("DELETE_OTHER", () => {


### PR DESCRIPTION
## Problem

When pasting text containing newlines (`\n`, `\r\n`) into the confirmation selector's alternative input or the question reducer's Other input, the single-line display would render incorrectly because the newlines were stored and rendered inline in a single-line `<Text>` element.

## Fix

Sanitize inserted text by replacing `\r\n`, `\r`, and `\n` with spaces in both `confirmationReducer` (INSERT_TEXT + HANDLE_KEY) and `questionReducer` (INSERT_OTHER + HANDLE_KEY). This keeps the input on a single line as the UI expects.

## Tests

Added test cases for both reducers verifying that pasted text with newlines is converted to spaces with correct cursor position.