### PR TITLE
refactor: introduce `options` field to separate model generation params from structural fields

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1259,11 +1259,29 @@ Wave 提供了一个强大的内置 `/settings` skill，作为用户与 Wave 配
 
 ### 模型配置 {#settings-models}
 
-在 `models` 字段中定义 AI 模型及其专属参数，支持任意模型参数：
+在 `models` 字段中定义 AI 模型及其专属参数。生成参数需嵌套在每个模型的 `options` 子对象下：
 
 - `temperature`：控制输出的随机性
 - `reasoning_effort`：推理强度（`low`/`medium`/`high`），适用于支持推理的模型
 - `thinking`：是否开启思考模式及预算 tokens，如 `{"type": "enabled", "budget_tokens": 2048}`
+
+```json
+{
+  "models": {
+    "claude-3-7-sonnet-20250219": {
+      "options": {
+        "thinking": { "type": "enabled", "budget_tokens": 2048 },
+        "temperature": 1.0
+      }
+    },
+    "o3-mini": {
+      "options": {
+        "reasoning_effort": "high"
+      }
+    }
+  }
+}
+```
 
 此外还支持 `fastModel` 配置，用于子代理（Explore）和网页抓取摘要等轻量场景。
 

--- a/packages/agent-sdk/builtin/skills/settings/MODELS.md
+++ b/packages/agent-sdk/builtin/skills/settings/MODELS.md
@@ -10,17 +10,23 @@ You can define overrides for specific models in the `models` field. The key shou
 {
   "models": {
     "claude-3-7-sonnet-20250219": {
-      "thinking": {
-        "type": "enabled",
-        "budget_tokens": 1024
-      },
-      "temperature": 1.0
+      "options": {
+        "thinking": {
+          "type": "enabled",
+          "budget_tokens": 1024
+        },
+        "temperature": 1.0
+      }
     },
     "o3-mini": {
-      "reasoning_effort": "high"
+      "options": {
+        "reasoning_effort": "high"
+      }
     },
     "gpt-4o": {
-      "temperature": 0.5
+      "options": {
+        "temperature": 0.5
+      }
     }
   }
 }
@@ -28,7 +34,7 @@ You can define overrides for specific models in the `models` field. The key shou
 
 ## Supported Parameters
 
-Wave supports passing arbitrary parameters to the underlying AI provider. Common parameters include:
+Generation parameters are nested under the `options` field within each model's configuration. Wave supports passing arbitrary parameters to the underlying AI provider. Common parameters include:
 
 - `temperature`: Controls randomness (0.0 to 2.0).
 - `maxTokens`: Maximum number of tokens to generate in the response.
@@ -39,7 +45,7 @@ Wave supports passing arbitrary parameters to the underlying AI provider. Common
 
 ## Model Capabilities
 
-Wave needs to know whether a model supports certain features. Instead of guessing from the model name, you declare these explicitly via the `capabilities` field:
+Wave needs to know whether a model supports certain features. Instead of guessing from the model name, you declare these explicitly via the `capabilities` field. Note that `capabilities` is set at the top level of the model configuration, **not** inside the `options` field — `options` is reserved for generation parameters only.
 
 - `vision` (default: `true`): Whether the model can accept image inputs. When `false`, images are stripped and replaced with text placeholders.
 - `promptCaching` (default: `false`): Whether the model supports ephemeral prompt caching (e.g., Anthropic's `cache_control` markers). When `true`, Wave injects cache markers on the system prompt and last user message.
@@ -76,13 +82,15 @@ You can also set `capabilities` at the top level of `settings.json` to apply to 
 
 ## Unsetting Default Parameters
 
-If a model does not support a default parameter (like `temperature` for some reasoning models), you can explicitly set it to `null` to ensure it is not sent to the provider.
+If a model does not support a default parameter (like `temperature` for some reasoning models), you can explicitly set it to `null` inside the `options` field to ensure it is not sent to the provider.
 
 ```json
 {
   "models": {
     "o1-preview": {
-      "temperature": null
+      "options": {
+        "temperature": null
+      }
     }
   }
 }

--- a/packages/agent-sdk/builtin/skills/settings/SKILL.md
+++ b/packages/agent-sdk/builtin/skills/settings/SKILL.md
@@ -63,13 +63,17 @@ For detailed model configuration, see [MODELS.md](${WAVE_SKILL_DIR}/MODELS.md).
 {
   "models": {
     "claude-3-7-sonnet-20250219": {
-      "thinking": {
-        "type": "enabled",
-        "budget_tokens": 1024
+      "options": {
+        "thinking": {
+          "type": "enabled",
+          "budget_tokens": 1024
+        }
       }
     },
     "o3-mini": {
-      "reasoning_effort": "high"
+      "options": {
+        "reasoning_effort": "high"
+      }
     }
   }
 }

--- a/packages/agent-sdk/src/services/aiService.ts
+++ b/packages/agent-sdk/src/services/aiService.ts
@@ -313,24 +313,9 @@ export async function callAgent(
       );
     }
 
-    // Get model configuration - use injected modelConfig with optional override
-    const {
-      model: _model,
-      fastModel: _fastModel,
-      maxTokens: _maxTokens,
-      permissionMode: _permissionMode,
-      capabilities: _capabilities,
-      ...extraParams
-    } = modelConfig;
-    void _model;
-    void _fastModel;
-    void _maxTokens;
-    void _permissionMode;
-    void _capabilities;
-
     const openaiModelConfig = getModelConfig(model || modelConfig.model, {
       max_tokens: resolvedMaxTokens,
-      ...extraParams,
+      ...(modelConfig.options || {}),
     });
 
     // Determine if streaming is needed
@@ -861,27 +846,11 @@ export async function compactMessages(
     fetch: gatewayConfig.fetch,
   });
 
-  // Get model configuration - use injected agent model
-  const {
-    model: _model,
-    fastModel: _fastModel,
-    maxTokens: _maxTokens,
-    permissionMode: _permissionMode,
-    capabilities: _capabilities,
-    fastModelConfig: _fastModelConfig,
-    ...extraParams
-  } = modelConfig;
-  void _model;
-  void _fastModel;
-  void _maxTokens;
-  void _permissionMode;
-  void _capabilities;
-
-  // When a fast model override is provided, use the fast model's hyperparams
-  // (if configured); otherwise fall back to the agent model's extraParams.
+  // When a fast model override is provided, use the fast model's options
+  // (if configured); otherwise fall back to the agent model's options.
   const activeExtraParams = options.model
-    ? _fastModelConfig || {}
-    : extraParams;
+    ? modelConfig.fastModelOptions || {}
+    : modelConfig.options || {};
 
   const openaiModelConfig = getModelConfig(options.model || modelConfig.model, {
     temperature: 0.1,
@@ -986,27 +955,11 @@ export async function processWebContent(
     fetch: gatewayConfig.fetch,
   });
 
-  // Get model configuration - use injected agent model
-  const {
-    model: _model,
-    fastModel: _fastModel,
-    maxTokens: _maxTokens,
-    permissionMode: _permissionMode,
-    capabilities: _capabilities,
-    fastModelConfig: _fastModelConfig,
-    ...extraParams
-  } = modelConfig;
-  void _model;
-  void _fastModel;
-  void _maxTokens;
-  void _permissionMode;
-  void _capabilities;
-
-  // When a fast model override is provided, use the fast model's hyperparams
-  // (if configured); otherwise fall back to the agent model's extraParams.
+  // When a fast model override is provided, use the fast model's options
+  // (if configured); otherwise fall back to the agent model's options.
   const activeExtraParams = options.model
-    ? _fastModelConfig || {}
-    : extraParams;
+    ? modelConfig.fastModelOptions || {}
+    : modelConfig.options || {};
 
   const openaiModelConfig = getModelConfig(options.model || modelConfig.model, {
     temperature: 0.1,
@@ -1105,25 +1058,10 @@ export async function btw(options: BtwOptions): Promise<BtwResult> {
     fetch: gatewayConfig.fetch,
   });
 
-  // Get model configuration - use injected agent model
-  const {
-    model: _model,
-    fastModel: _fastModel,
-    maxTokens: _maxTokens,
-    permissionMode: _permissionMode,
-    capabilities: _capabilities,
-    ...extraParams
-  } = modelConfig;
-  void _model;
-  void _fastModel;
-  void _maxTokens;
-  void _permissionMode;
-  void _capabilities;
-
   const openaiModelConfig = getModelConfig(options.model || modelConfig.model, {
     temperature: 0.1,
     max_tokens: 4096,
-    ...extraParams,
+    ...(modelConfig.options || {}),
   });
 
   try {
@@ -1214,25 +1152,10 @@ export async function evaluateGoal(
     fetch: gatewayConfig.fetch,
   });
 
-  const {
-    model: _model,
-    fastModel: _fastModel,
-    maxTokens: _maxTokens,
-    permissionMode: _permissionMode,
-    fastModelConfig: _fastModelConfig,
-  } = modelConfig;
-  void _model;
-  void _fastModel;
-  void _maxTokens;
-  void _permissionMode;
-
-  // evaluateGoal always uses the fast model; use its hyperparams if configured.
-  const activeExtraParams = _fastModelConfig || {};
-
   const openaiModelConfig = getModelConfig(model, {
     temperature: 0,
     max_tokens: 200,
-    ...activeExtraParams,
+    ...(modelConfig.fastModelOptions || {}),
   });
 
   // Strip images from messages to reduce token usage (same as compact)

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -534,27 +534,13 @@ export class ConfigurationService {
       permissionMode: permissionMode ?? this.options.permissionMode,
     };
 
-    // Resolve fast model hyperparams from models[fastModel], stripping
-    // structural fields so only hyperparameters remain. Set on baseConfig
-    // before the modelSpecificConfig spread so it isn't overwritten.
-    const fastModelConfigSource =
+    // Resolve fast model generation params from models[fastModel].options.
+    // Set on baseConfig before the modelSpecificConfig spread so it isn't overwritten.
+    const fastModelSource =
       resolvedFastModel &&
       this.currentConfiguration?.models?.[resolvedFastModel];
-    if (fastModelConfigSource) {
-      const {
-        model: _fm,
-        fastModel: _ffm,
-        maxTokens: _fmt,
-        permissionMode: _fpm,
-        capabilities: _fcap,
-        ...fastHyperparams
-      } = fastModelConfigSource;
-      void _fm;
-      void _ffm;
-      void _fmt;
-      void _fpm;
-      void _fcap;
-      baseConfig.fastModelConfig = fastHyperparams;
+    if (fastModelSource && fastModelSource.options) {
+      baseConfig.fastModelOptions = fastModelSource.options;
     }
 
     // Merge model-specific settings from configuration

--- a/packages/agent-sdk/src/types/config.ts
+++ b/packages/agent-sdk/src/types/config.ts
@@ -26,7 +26,9 @@ export interface ModelConfig {
   fastModel?: string;
   maxTokens?: number;
   permissionMode?: PermissionMode;
-  fastModelConfig?: Record<string, unknown>;
   capabilities?: ModelCapabilities;
-  [key: string]: unknown;
+  /** Generation params passed through to the API provider (temperature, thinking, etc.) */
+  options?: Record<string, unknown>;
+  /** Fast model generation params (resolved from models[fastModel].options) */
+  fastModelOptions?: Record<string, unknown>;
 }

--- a/packages/agent-sdk/tests/services/aiService.basic.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.basic.test.ts
@@ -346,9 +346,11 @@ describe("AI Service - Basic CallAgent", () => {
         gatewayConfig: TEST_GATEWAY_CONFIG,
         modelConfig: {
           ...TEST_MODEL_CONFIG,
-          temperature: 0.7,
-          reasoning_effort: "high",
-          thinking: { type: "enabled", budget_tokens: 1024 },
+          options: {
+            temperature: 0.7,
+            reasoning_effort: "high",
+            thinking: { type: "enabled", budget_tokens: 1024 },
+          },
         },
         messages: [{ role: "user", content: "Test message" }],
         workdir: "/test/workdir",
@@ -368,7 +370,7 @@ describe("AI Service - Basic CallAgent", () => {
         gatewayConfig: TEST_GATEWAY_CONFIG,
         modelConfig: {
           ...TEST_MODEL_CONFIG,
-          temperature: null as unknown as number,
+          options: { temperature: null as unknown as number },
         },
         messages: [{ role: "user", content: "Test message" }],
         workdir: "/test/workdir",

--- a/packages/agent-sdk/tests/services/aiService.btw.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.btw.test.ts
@@ -152,8 +152,10 @@ describe("AI Service - BTW", () => {
         gatewayConfig: TEST_GATEWAY_CONFIG,
         modelConfig: {
           ...TEST_MODEL_CONFIG,
-          temperature: 0.7,
-          reasoning_effort: "high",
+          options: {
+            temperature: 0.7,
+            reasoning_effort: "high",
+          },
         },
         messages,
         question,

--- a/packages/agent-sdk/tests/services/aiService.compact.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.compact.test.ts
@@ -289,8 +289,10 @@ describe("AI Service - CompactMessages", () => {
         gatewayConfig: TEST_GATEWAY_CONFIG,
         modelConfig: {
           ...TEST_MODEL_CONFIG,
-          temperature: 0.7,
-          reasoning_effort: "high",
+          options: {
+            temperature: 0.7,
+            reasoning_effort: "high",
+          },
         },
         messages,
       });
@@ -300,7 +302,7 @@ describe("AI Service - CompactMessages", () => {
       expect(callArgs.reasoning_effort).toBe("high");
     });
 
-    it("should use fastModelConfig hyperparams when model option is provided", async () => {
+    it("should use fastModelOptions hyperparams when model option is provided", async () => {
       const messages = [
         {
           role: "user" as const,
@@ -312,8 +314,8 @@ describe("AI Service - CompactMessages", () => {
         gatewayConfig: TEST_GATEWAY_CONFIG,
         modelConfig: {
           ...TEST_MODEL_CONFIG,
-          temperature: 0.7, // agent model hyperparam
-          fastModelConfig: { temperature: 0.2, top_p: 0.9 }, // fast model hyperparams
+          options: { temperature: 0.7 }, // agent model hyperparam
+          fastModelOptions: { temperature: 0.2, top_p: 0.9 }, // fast model hyperparams
         },
         messages,
         model: "fast-model",
@@ -337,8 +339,8 @@ describe("AI Service - CompactMessages", () => {
         gatewayConfig: TEST_GATEWAY_CONFIG,
         modelConfig: {
           ...TEST_MODEL_CONFIG,
-          temperature: 0.7,
-          fastModelConfig: { temperature: 0.2 },
+          options: { temperature: 0.7 },
+          fastModelOptions: { temperature: 0.2 },
         },
         messages,
         // no model option — uses agent model
@@ -349,7 +351,7 @@ describe("AI Service - CompactMessages", () => {
       expect(callArgs.temperature).toBe(0.7);
     });
 
-    it("should use no extra hyperparams when model option is provided but fastModelConfig is undefined", async () => {
+    it("should use no extra hyperparams when model option is provided but fastModelOptions is undefined", async () => {
       const messages = [
         {
           role: "user" as const,
@@ -361,7 +363,7 @@ describe("AI Service - CompactMessages", () => {
         gatewayConfig: TEST_GATEWAY_CONFIG,
         modelConfig: {
           ...TEST_MODEL_CONFIG,
-          temperature: 0.7, // agent model hyperparam — should NOT be used
+          options: { temperature: 0.7 }, // agent model hyperparam — should NOT be used
         },
         messages,
         model: "fast-model",
@@ -373,7 +375,7 @@ describe("AI Service - CompactMessages", () => {
     });
   });
 
-  describe("processWebContent — fastModelConfig", () => {
+  describe("processWebContent — fastModelOptions", () => {
     let processWebContent: (
       options: import("@/services/aiService.js").ProcessWebContentOptions,
     ) => Promise<import("@/services/aiService.js").ProcessWebContentResult>;
@@ -383,13 +385,13 @@ describe("AI Service - CompactMessages", () => {
       processWebContent = aiService.processWebContent;
     });
 
-    it("should use fastModelConfig hyperparams when model option is provided", async () => {
+    it("should use fastModelOptions hyperparams when model option is provided", async () => {
       await processWebContent({
         gatewayConfig: TEST_GATEWAY_CONFIG,
         modelConfig: {
           ...TEST_MODEL_CONFIG,
-          temperature: 0.7,
-          fastModelConfig: { temperature: 0.2, top_p: 0.9 },
+          options: { temperature: 0.7 },
+          fastModelOptions: { temperature: 0.2, top_p: 0.9 },
         },
         content: "web content",
         prompt: "summarize",
@@ -407,8 +409,8 @@ describe("AI Service - CompactMessages", () => {
         gatewayConfig: TEST_GATEWAY_CONFIG,
         modelConfig: {
           ...TEST_MODEL_CONFIG,
-          temperature: 0.7,
-          fastModelConfig: { temperature: 0.2 },
+          options: { temperature: 0.7 },
+          fastModelOptions: { temperature: 0.2 },
         },
         content: "web content",
         prompt: "summarize",
@@ -420,7 +422,7 @@ describe("AI Service - CompactMessages", () => {
     });
   });
 
-  describe("evaluateGoal — fastModelConfig", () => {
+  describe("evaluateGoal — fastModelOptions", () => {
     let evaluateGoal: (
       options: import("@/services/aiService.js").EvaluateGoalOptions,
     ) => Promise<import("@/services/aiService.js").EvaluateGoalResult>;
@@ -430,13 +432,13 @@ describe("AI Service - CompactMessages", () => {
       evaluateGoal = aiService.evaluateGoal;
     });
 
-    it("should use fastModelConfig hyperparams", async () => {
+    it("should use fastModelOptions hyperparams", async () => {
       await evaluateGoal({
         gatewayConfig: TEST_GATEWAY_CONFIG,
         modelConfig: {
           ...TEST_MODEL_CONFIG,
-          temperature: 0.7,
-          fastModelConfig: { temperature: 0, top_p: 0.95 },
+          options: { temperature: 0.7 },
+          fastModelOptions: { temperature: 0, top_p: 0.95 },
         },
         model: "fast-model",
         goalCondition: "task is done",
@@ -454,12 +456,12 @@ describe("AI Service - CompactMessages", () => {
       expect(callArgs.top_p).toBe(0.95);
     });
 
-    it("should use no extra hyperparams when fastModelConfig is undefined", async () => {
+    it("should use no extra hyperparams when fastModelOptions is undefined", async () => {
       await evaluateGoal({
         gatewayConfig: TEST_GATEWAY_CONFIG,
         modelConfig: {
           ...TEST_MODEL_CONFIG,
-          temperature: 0.7, // agent model hyperparam — should NOT be used
+          options: { temperature: 0.7 }, // agent model hyperparam — should NOT be used
         },
         model: "fast-model",
         goalCondition: "task is done",

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -171,8 +171,8 @@ describe("ConfigurationService", () => {
         env: { VAR1: "user", VAR2: "user" },
         permissions: { allow: ["rule-user"], permissionMode: "default" },
         models: {
-          model1: { temperature: 0.1, maxTokens: 500 },
-          model2: { temperature: 0.2 },
+          model1: { options: { temperature: 0.1 }, maxTokens: 500 },
+          model2: { options: { temperature: 0.2 } },
         },
       };
 
@@ -182,8 +182,8 @@ describe("ConfigurationService", () => {
         env: { VAR2: "project", VAR3: "project" },
         permissions: { allow: ["rule-project"], permissionMode: "acceptEdits" },
         models: {
-          model1: { temperature: 0.5, maxTokens: 1000 },
-          model2: { temperature: 0.8 },
+          model1: { options: { temperature: 0.5 }, maxTokens: 1000 },
+          model2: { options: { temperature: 0.8 } },
         },
       };
 
@@ -196,7 +196,7 @@ describe("ConfigurationService", () => {
           permissionMode: "bypassPermissions",
         },
         models: {
-          model2: { reasoning_effort: "high" },
+          model2: { options: { reasoning_effort: "high" } },
         },
       };
 
@@ -255,12 +255,11 @@ describe("ConfigurationService", () => {
 
       // Verify models (merged with precedence)
       expect(result?.models?.["model1"]).toEqual({
-        temperature: 0.5,
+        options: { temperature: 0.5 },
         maxTokens: 1000,
       });
       expect(result?.models?.["model2"]).toEqual({
-        temperature: 0.8,
-        reasoning_effort: "high",
+        options: { reasoning_effort: "high" },
       });
     });
   });
@@ -462,8 +461,10 @@ describe("ConfigurationService", () => {
       const config = {
         models: {
           "gpt-4o": {
-            temperature: 0.5,
-            reasoning_effort: "high",
+            options: {
+              temperature: 0.5,
+              reasoning_effort: "high",
+            },
           },
         },
       };
@@ -474,17 +475,17 @@ describe("ConfigurationService", () => {
       const resolved = configService.resolveModelConfig("gpt-4o");
 
       expect(resolved.model).toBe("gpt-4o");
-      expect(resolved.temperature).toBe(0.5);
-      expect(resolved.reasoning_effort).toBe("high");
+      expect(resolved.options?.temperature).toBe(0.5);
+      expect(resolved.options?.reasoning_effort).toBe("high");
     });
   });
 
-  describe("resolveModelConfig — fastModelConfig", () => {
-    it("should set fastModelConfig from models[fastModel] hyperparams", async () => {
+  describe("resolveModelConfig — fastModelOptions", () => {
+    it("should set fastModelOptions from models[fastModel] options", async () => {
       const config = {
         models: {
-          "gpt-4o": { temperature: 0.7 },
-          "gpt-4o-mini": { temperature: 0.2, top_p: 0.9 },
+          "gpt-4o": { options: { temperature: 0.7 } },
+          "gpt-4o-mini": { options: { temperature: 0.2, top_p: 0.9 } },
         },
       };
       mockExistsSync.mockReturnValue(true);
@@ -501,7 +502,7 @@ describe("ConfigurationService", () => {
           "gpt-4o-mini",
         );
 
-        expect(resolved.fastModelConfig).toEqual({
+        expect(resolved.fastModelOptions).toEqual({
           temperature: 0.2,
           top_p: 0.9,
         });
@@ -514,7 +515,7 @@ describe("ConfigurationService", () => {
       }
     });
 
-    it("should strip structural fields from fastModelConfig", async () => {
+    it("should strip structural fields from fastModelOptions", async () => {
       const config = {
         models: {
           "gpt-4o-mini": {
@@ -522,7 +523,7 @@ describe("ConfigurationService", () => {
             fastModel: "should-be-stripped",
             maxTokens: 999,
             permissionMode: "default",
-            temperature: 0.3,
+            options: { temperature: 0.3 },
           },
         },
       };
@@ -540,7 +541,7 @@ describe("ConfigurationService", () => {
           "gpt-4o-mini",
         );
 
-        expect(resolved.fastModelConfig).toEqual({ temperature: 0.3 });
+        expect(resolved.fastModelOptions).toEqual({ temperature: 0.3 });
       } finally {
         if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
         else delete process.env.WAVE_MODEL;
@@ -550,10 +551,10 @@ describe("ConfigurationService", () => {
       }
     });
 
-    it("should leave fastModelConfig undefined when fast model not in models", async () => {
+    it("should leave fastModelOptions undefined when fast model not in models", async () => {
       const config = {
         models: {
-          "gpt-4o": { temperature: 0.7 },
+          "gpt-4o": { options: { temperature: 0.7 } },
         },
       };
       mockExistsSync.mockReturnValue(true);
@@ -570,7 +571,7 @@ describe("ConfigurationService", () => {
           "unknown-fast-model",
         );
 
-        expect(resolved.fastModelConfig).toBeUndefined();
+        expect(resolved.fastModelOptions).toBeUndefined();
       } finally {
         if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
         else delete process.env.WAVE_MODEL;
@@ -580,10 +581,10 @@ describe("ConfigurationService", () => {
       }
     });
 
-    it("should leave fastModelConfig undefined when no fast model configured", async () => {
+    it("should leave fastModelOptions undefined when no fast model configured", async () => {
       const config = {
         models: {
-          "gpt-4o": { temperature: 0.7 },
+          "gpt-4o": { options: { temperature: 0.7 } },
         },
       };
       mockExistsSync.mockReturnValue(true);
@@ -597,7 +598,7 @@ describe("ConfigurationService", () => {
         await configService.loadMergedConfiguration(tempDir);
         const resolved = configService.resolveModelConfig("gpt-4o");
 
-        expect(resolved.fastModelConfig).toBeUndefined();
+        expect(resolved.fastModelOptions).toBeUndefined();
       } finally {
         if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
         else delete process.env.WAVE_MODEL;
@@ -641,13 +642,13 @@ describe("ConfigurationService", () => {
       }
     });
 
-    it("should strip capabilities from fastModelConfig extraction", async () => {
+    it("should strip capabilities from fastModelOptions extraction", async () => {
       const config = {
         models: {
           "gpt-4o": { capabilities: { promptCaching: true } },
           "gpt-4o-mini": {
             capabilities: { vision: false },
-            temperature: 0.2,
+            options: { temperature: 0.2 },
           },
         },
       };
@@ -665,9 +666,9 @@ describe("ConfigurationService", () => {
           "gpt-4o-mini",
         );
 
-        // capabilities should NOT leak into fastModelConfig
-        expect(resolved.fastModelConfig).toEqual({ temperature: 0.2 });
-        expect(resolved.fastModelConfig).not.toHaveProperty("capabilities");
+        // capabilities should NOT leak into fastModelOptions
+        expect(resolved.fastModelOptions).toEqual({ temperature: 0.2 });
+        expect(resolved.fastModelOptions).not.toHaveProperty("capabilities");
       } finally {
         if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
         else delete process.env.WAVE_MODEL;

--- a/specs/007-agent-config.md
+++ b/specs/007-agent-config.md
@@ -175,9 +175,9 @@ SDK 用户需要按子代理类型配置不同的 HTTP 请求头，以便 `custo
 - **FR-015**：如果通过自定义请求头提供了替代认证，SDK 不得在初始化时强制要求 `apiKey`
 - **FR-016**：系统必须支持通过 `AgentOptions` 或 `settings.json` 设置 `language`
 - **FR-017**：系统必须在配置了语言时向系统提示注入语言指令，遵循指定格式
-- **FR-018**：`AgentOptions` 和 `ModelConfig` 必须支持任意额外属性以允许模型特定参数（如 `temperature`、`reasoning_effort`、`thinking`）
-- **FR-019**：系统必须支持通过 `settings.json` 的 `models` 字段进行模型特定覆盖
-- **FR-020**：系统必须允许通过在配置中设置为 `null` 来取消设置默认参数
+- **FR-018**：`AgentOptions` 和 `ModelConfig` 必须支持 `options` 字段用于传递模型特定的生成参数（如 `temperature`、`reasoning_effort`、`thinking`）
+- **FR-019**：系统必须支持通过 `settings.json` 的 `models` 字段进行模型特定覆盖，生成参数嵌套在 `options` 子对象中
+- **FR-020**：系统必须允许通过在 `options` 字段中设置为 `null` 来取消设置默认生成参数
 - **FR-021**：settings.json 必须支持可选的 "env" 字段，包含环境变量的键值对
 - **FR-022**：系统必须合并用户级和项目级 env 配置，项目级优先
 - **FR-023**：系统必须验证 env 字段格式并对无效配置显示清晰错误
@@ -195,7 +195,7 @@ SDK 用户需要按子代理类型配置不同的 HTTP 请求头，以便 `custo
 
 - **AgentConfig**：直接放在 `AgentOptions` 中的扁平化配置参数（apiKey、baseURL、model、fastModel、maxInputTokens、maxTokens、language）
 - **GatewayConfig**：网关服务的已解析配置，包括认证、端点详情和自定义请求头
-- **ModelConfig**：已解析的模型选择配置，指定不同操作使用的模型
+- **ModelConfig**：已解析的模型选择配置，指定不同操作使用的模型；包含 `options` 字段用于携带模型特定的生成参数（如 `temperature`、`reasoning_effort`、`thinking`）
 - **设置配置**：包含 hooks、环境变量和其他配置选项，监视更改
 - **文件监视器**：监视配置文件并触发重载事件
 - **环境上下文**：从用户和项目设置合并的环境变量，传递给代理进程


### PR DESCRIPTION
## Context

Previously, generation parameters (temperature, thinking, reasoning_effort, etc.) were mixed with structural fields (model, fastModel, maxTokens, permissionMode, capabilities) at the top level of `models[modelName]` in `settings.json`. The `ModelConfig` type used `[key: string]: unknown` to allow arbitrary params, and consumers extracted them by **destructuring to strip known structural fields** — a pattern duplicated in 6 places that is fragile and error-prone.

## Changes

This refactor introduces an explicit `options` field (naming aligned with Ollama's convention) to group generation params, eliminating all destructuring-to-strip patterns.

### New `settings.json` format

```json
{
  "models": {
    "glm-5.2": {
      "capabilities": { "vision": false, "promptCaching": false },
      "options": { "temperature": 0.5 }
    }
  }
}
```

### Source code
- **`types/config.ts`**: Added `options` and `fastModelOptions` fields to `ModelConfig`; removed `[key: string]: unknown` index signature and `fastModelConfig`
- **`configurationService.ts`**: Simplified `resolveModelConfig` — fast model param extraction reduced from a 15-line destructure-to-strip block to a 3-line direct read of `.options`
- **`aiService.ts`**: Eliminated all 5 destructure-to-strip patterns (`callAgent`, `compactMessages`, `processWebContent`, `btw`, `evaluateGoal`) — each replaced with a single-line read of `modelConfig.options` / `modelConfig.fastModelOptions`

### Bug fix
- `btw()` previously did not strip `fastModelConfig` from its destructure, causing it to leak into API params. This is now fixed as a side effect of the refactor.

### Tests
- Updated all test fixtures to nest generation params under `options`
- Renamed `fastModelConfig` → `fastModelOptions` in all assertions

### Documentation & specs
- Updated `MODELS.md`, `SKILL.md`, `docs/sdk.md`, `specs/007-agent-config.md`

## Verification
- `pnpm run type-check`: all packages pass
- `pnpm -F wave-agent-sdk test`: 3221 passed, 1 skipped
- `pnpm lint`: all packages pass

## Breaking change
Generation params must now be nested under `options` in `settings.json`. No backward compatibility migration is included per design decision.