### PR TITLE
feat: add default server URL and remove VSCE server URL settings

### DIFF
--- a/packages/agent-sdk/builtin/skills/settings/ENV.md
+++ b/packages/agent-sdk/builtin/skills/settings/ENV.md
@@ -23,7 +23,7 @@ Wave uses several environment variables to control its core functionality.
 | :--- | :--- | :--- |
 | `WAVE_API_KEY` | API key for the AI gateway. | - |
 | `WAVE_BASE_URL` | Base URL for the AI gateway. | - |
-| `WAVE_SERVER_URL` | Server URL for SSO authentication. | - |
+| `WAVE_SERVER_URL` | Server URL for SSO authentication. | `https://codechat.codewave.163.com` |
 | `WAVE_CUSTOM_HEADERS` | Custom HTTP headers for the AI gateway. Newline-separated `Key: Value` pairs (e.g., `"X-Foo: bar\nAuthorization: Bearer xxx"`). | - |
 | `WAVE_MODEL` | The primary AI model to use for the agent. | `gemini-3-flash` |
 | `WAVE_FAST_MODEL` | The fast AI model to use for quick tasks. | `gemini-2.5-flash` |

--- a/packages/agent-sdk/src/services/authService.ts
+++ b/packages/agent-sdk/src/services/authService.ts
@@ -21,6 +21,7 @@ import { createServer, Server } from "http";
 import { URL } from "url";
 import type { AuthConfig, AuthUser, TokenResponse } from "../types/auth.js";
 import { logger } from "../utils/globalLogger.js";
+import { DEFAULT_SERVER_URL } from "../utils/constants.js";
 
 /** Persistent anonymous ID for telemetry fallback when SSO is not authenticated. */
 let _anonymousId: string | undefined;
@@ -137,13 +138,7 @@ export class AuthService {
   }
 
   getServerUrl(): string {
-    const url = this._serverUrl || process.env.WAVE_SERVER_URL;
-    if (!url) {
-      throw new Error(
-        "WAVE_SERVER_URL environment variable is not set. SSO authentication requires this to be configured.",
-      );
-    }
-    return url;
+    return this._serverUrl || process.env.WAVE_SERVER_URL || DEFAULT_SERVER_URL;
   }
 
   async login(options?: {

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -39,6 +39,7 @@ import {
 import {
   DEFAULT_WAVE_MAX_INPUT_TOKENS,
   DEFAULT_WAVE_MAX_OUTPUT_TOKENS,
+  DEFAULT_SERVER_URL,
 } from "../utils/constants.js";
 import { ClientOptions } from "openai";
 import { parseCustomHeaders } from "../utils/stringUtils.js";
@@ -420,9 +421,12 @@ export class ConfigurationService {
     fetch?: ClientOptions["fetch"],
   ): GatewayConfig {
     // Check for SSO token first - if present and server URL is available, use SSO mode
-    // Server URL resolution: options > process.env
+    // Server URL resolution: options > process.env > default
     const ssoToken = this.readSSOToken();
-    const serverUrl = this.options.serverUrl || process.env.WAVE_SERVER_URL;
+    const serverUrl =
+      this.options.serverUrl ||
+      process.env.WAVE_SERVER_URL ||
+      DEFAULT_SERVER_URL;
     if (ssoToken && serverUrl) {
       const baseFetch = fetch ?? this.options.fetch ?? globalThis.fetch;
       const authAwareFetch = createAuthAwareFetch(

--- a/packages/agent-sdk/src/utils/constants.ts
+++ b/packages/agent-sdk/src/utils/constants.ts
@@ -31,3 +31,9 @@ export const USER_MEMORY_FILE = path.join(DATA_DIRECTORY, "AGENTS.md");
  */
 export const DEFAULT_WAVE_MAX_INPUT_TOKENS = 200000; // Default token limit
 export const DEFAULT_WAVE_MAX_OUTPUT_TOKENS = 32000; // Default output token limit (aligned with Claude Code)
+
+/**
+ * Default server URL for SSO authentication.
+ * Overridden by WAVE_SERVER_URL env var or programmatic AgentOptions.serverUrl.
+ */
+export const DEFAULT_SERVER_URL = "https://codechat.codewave.163.com";

--- a/packages/agent-sdk/tests/services/authService.test.ts
+++ b/packages/agent-sdk/tests/services/authService.test.ts
@@ -321,11 +321,9 @@ describe("AuthService", () => {
       expect(service.getServerUrl()).toBe("https://server.example.com");
     });
 
-    it("throws when WAVE_SERVER_URL is not set", () => {
+    it("returns default when WAVE_SERVER_URL is not set", () => {
       const service = AuthService.getInstance();
-      expect(() => service.getServerUrl()).toThrow(
-        "WAVE_SERVER_URL environment variable is not set",
-      );
+      expect(service.getServerUrl()).toBe("https://codechat.codewave.163.com");
     });
 
     it("returns _serverUrl when set via setServerUrl", () => {
@@ -348,11 +346,9 @@ describe("AuthService", () => {
       expect(service.getServerUrl()).toBe("https://fallback.example.com");
     });
 
-    it("throws when neither _serverUrl nor env var is set", () => {
+    it("falls back to default when neither _serverUrl nor env var is set", () => {
       const service = AuthService.getInstance();
-      expect(() => service.getServerUrl()).toThrow(
-        "WAVE_SERVER_URL environment variable is not set",
-      );
+      expect(service.getServerUrl()).toBe("https://codechat.codewave.163.com");
     });
   });
 

--- a/packages/code/src/components/LoginCommand.tsx
+++ b/packages/code/src/components/LoginCommand.tsx
@@ -125,12 +125,7 @@ export const LoginCommand: React.FC<LoginCommandProps> = ({ onCancel }) => {
 
   const isAuthenticated = authService.isSSOAuthenticated();
   const token = authService.getSSOToken();
-  let serverUrl: string | undefined;
-  try {
-    serverUrl = authService.getServerUrl();
-  } catch {
-    // serverUrl not configured, skip display
-  }
+  const serverUrl = authService.getServerUrl();
 
   const truncatedToken =
     token && token.length > 14

--- a/packages/vsce/e2e/demo/login-dialog.demo.ts
+++ b/packages/vsce/e2e/demo/login-dialog.demo.ts
@@ -10,17 +10,7 @@ test.describe('Login Dialog Demo', () => {
             });
         });
 
-        // 2. Simulate extension sending configuration data with serverUrl
-        await webviewPage.evaluate(() => {
-            window.simulateExtensionMessage({
-                command: 'configurationResponse',
-                configurationData: {
-                    serverUrl: 'https://wave.nebula-tech.com'
-                }
-            });
-        });
-
-        // 3. Simulate auth status (not authenticated)
+        // 2. Simulate auth status (not authenticated)
         await webviewPage.evaluate(() => {
             window.simulateExtensionMessage({
                 command: 'authStatusResponse',
@@ -31,10 +21,6 @@ test.describe('Login Dialog Demo', () => {
 
         // Verify dialog title
         await expect(webviewPage.getByText('SSO 认证', { exact: true })).toBeVisible();
-
-        // Verify server URL input is pre-filled
-        const serverUrlInput = webviewPage.locator('#login-serverUrl');
-        await expect(serverUrlInput).toHaveValue('https://wave.nebula-tech.com');
 
         // Verify login button is visible
         await expect(webviewPage.getByText('SSO 登录', { exact: true })).toBeVisible();
@@ -49,15 +35,6 @@ test.describe('Login Dialog Demo', () => {
             window.simulateExtensionMessage({
                 command: 'showDialog',
                 dialogType: 'login'
-            });
-        });
-
-        await webviewPage.evaluate(() => {
-            window.simulateExtensionMessage({
-                command: 'configurationResponse',
-                configurationData: {
-                    serverUrl: 'https://wave.nebula-tech.com'
-                }
             });
         });
 
@@ -76,44 +53,5 @@ test.describe('Login Dialog Demo', () => {
 
         const dialog = webviewPage.locator('.configuration-dialog');
         await dialog.screenshot({ path: '../../docs/public/screenshots/spec-login-dialog-authenticated.png' });
-    });
-
-    test('should show editable serverUrl input when no server URL configured', async ({ webviewPage }) => {
-        await webviewPage.evaluate(() => {
-            window.simulateExtensionMessage({
-                command: 'showDialog',
-                dialogType: 'login'
-            });
-        });
-
-        // No serverUrl configured
-        await webviewPage.evaluate(() => {
-            window.simulateExtensionMessage({
-                command: 'configurationResponse',
-                configurationData: {}
-            });
-        });
-
-        await webviewPage.evaluate(() => {
-            window.simulateExtensionMessage({
-                command: 'authStatusResponse',
-                isAuthenticated: false,
-                user: null
-            });
-        });
-
-        await expect(webviewPage.getByText('SSO 认证', { exact: true })).toBeVisible();
-
-        // ServerUrl input should be visible and empty
-        const serverUrlInput = webviewPage.locator('#login-serverUrl');
-        await expect(serverUrlInput).toBeVisible();
-        await expect(serverUrlInput).toHaveValue('');
-
-        // Login button should be disabled when serverUrl is empty
-        const loginBtn = webviewPage.getByText('SSO 登录', { exact: true });
-        await expect(loginBtn).toBeDisabled();
-
-        const dialog = webviewPage.locator('.configuration-dialog');
-        await dialog.screenshot({ path: '../../docs/public/screenshots/spec-login-dialog-no-url.png' });
     });
 });

--- a/packages/vsce/e2e/demo/status-dialog.demo.ts
+++ b/packages/vsce/e2e/demo/status-dialog.demo.ts
@@ -17,8 +17,7 @@ test.describe('Status Dialog Demo', () => {
                 configurationData: {
                     model: 'claude-sonnet-4-20250514',
                     fastModel: 'claude-haiku-4-20250514',
-                    baseURL: 'https://api.nebula-tech.com/v1',
-                    serverUrl: 'https://wave.nebula-tech.com'
+                    baseURL: 'https://api.nebula-tech.com/v1'
                 }
             });
         });
@@ -33,8 +32,7 @@ test.describe('Status Dialog Demo', () => {
                 configurationData: {
                     model: 'claude-sonnet-4-20250514',
                     fastModel: 'claude-haiku-4-20250514',
-                    baseURL: 'https://api.nebula-tech.com/v1',
-                    serverUrl: 'https://wave.nebula-tech.com'
+                    baseURL: 'https://api.nebula-tech.com/v1'
                 }
             });
         });

--- a/packages/vsce/src/services/configurationService.ts
+++ b/packages/vsce/src/services/configurationService.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 
 export interface ConfigurationData {
-    serverUrl?: string;
     apiKey?: string;
     headers?: string;
     baseURL?: string;
@@ -15,7 +14,6 @@ export class ConfigurationService {
 
     public async loadConfiguration(): Promise<ConfigurationData> {
         return {
-            serverUrl: this.context.globalState.get<string>('serverUrl') || '',
             apiKey: this.context.globalState.get<string>('apiKey') || '',
             headers: this.context.globalState.get<string>('headers') || '',
             baseURL: this.context.globalState.get<string>('baseURL') || '',
@@ -27,7 +25,6 @@ export class ConfigurationService {
 
     public async saveConfiguration(configData: Partial<ConfigurationData>): Promise<void> {
         try {
-            if (configData.serverUrl !== undefined) await this.context.globalState.update('serverUrl', configData.serverUrl);
             if (configData.apiKey !== undefined) await this.context.globalState.update('apiKey', configData.apiKey);
             if (configData.headers !== undefined) await this.context.globalState.update('headers', configData.headers);
             if (configData.baseURL !== undefined) await this.context.globalState.update('baseURL', configData.baseURL);

--- a/packages/vsce/src/session/chatSession.ts
+++ b/packages/vsce/src/session/chatSession.ts
@@ -174,7 +174,6 @@ export class ChatSession {
                     apiKey: config.apiKey || undefined,
                     defaultHeaders: this.parseHeaders(config.headers),
                     baseURL: config.baseURL || undefined,
-                    serverUrl: config.serverUrl || undefined,
                     model: config.model,
                     fastModel: config.fastModel,
                     language: config.language,

--- a/packages/vsce/src/session/messageHandler.ts
+++ b/packages/vsce/src/session/messageHandler.ts
@@ -661,16 +661,15 @@ export class MessageHandler {
     private async handleLogin(viewType?: 'sidebar' | 'tab' | 'window', windowId?: string) {
         try {
             const authService = AuthService.getInstance();
-            const config = await this.configService.loadConfiguration();
 
             // Open browser via VS Code
             const onAuthUrl = async (url: string) => {
                 await vscode.env.openExternal(vscode.Uri.parse(url));
             };
 
-            // Use configured serverUrl first, fallback to env var
-            const serverUrl = config.serverUrl || process.env.WAVE_SERVER_URL;
-            await authService.login({ onAuthUrl, serverUrl });
+            // authService.login() resolves server URL via getServerUrl()
+            // (env var WAVE_SERVER_URL > default)
+            await authService.login({ onAuthUrl });
             const user = authService.getAuthUser();
 
             this.context.postMessage({
@@ -680,7 +679,8 @@ export class MessageHandler {
             }, viewType, windowId);
 
             // After successful login, reinitialize all sessions to pick up SSO config
-            this.context.updateAllSessionsConfig(config);
+            const updatedConfig = await this.configService.loadConfiguration();
+            this.context.updateAllSessionsConfig(updatedConfig);
         } catch (error) {
             console.error('登录失败:', error);
             const errorMessage = error instanceof Error ? error.message : String(error);

--- a/packages/vsce/tests/webview/config-logic.test.tsx
+++ b/packages/vsce/tests/webview/config-logic.test.tsx
@@ -22,15 +22,13 @@ describe('Configuration Logic', () => {
         const config = {
             apiKey: '',
             headers: '',
-            baseURL: '',
-            serverUrl: ''
+            baseURL: ''
         };
 
         const isAuthValid = (!!config.apiKey || !!process.env.WAVE_API_KEY)
-            || (!!config.headers || !!process.env.WAVE_CUSTOM_HEADERS)
-            || (!!config.serverUrl || !!process.env.WAVE_SERVER_URL);
+            || (!!config.headers || !!process.env.WAVE_CUSTOM_HEADERS);
 
-        const isBaseURLValid = !!config.baseURL || !!process.env.WAVE_BASE_URL || !!config.serverUrl || !!process.env.WAVE_SERVER_URL;
+        const isBaseURLValid = !!config.baseURL || !!process.env.WAVE_BASE_URL;
 
         expect(isAuthValid).toBe(true);
         expect(isBaseURLValid).toBe(true);
@@ -40,15 +38,13 @@ describe('Configuration Logic', () => {
         const config = {
             apiKey: '',
             headers: '',
-            baseURL: '',
-            serverUrl: ''
+            baseURL: ''
         };
 
         const isAuthValid = (!!config.apiKey || !!process.env.WAVE_API_KEY)
-            || (!!config.headers || !!process.env.WAVE_CUSTOM_HEADERS)
-            || (!!config.serverUrl || !!process.env.WAVE_SERVER_URL);
+            || (!!config.headers || !!process.env.WAVE_CUSTOM_HEADERS);
 
-        const isBaseURLValid = !!config.baseURL || !!process.env.WAVE_BASE_URL || !!config.serverUrl || !!process.env.WAVE_SERVER_URL;
+        const isBaseURLValid = !!config.baseURL || !!process.env.WAVE_BASE_URL;
 
         expect(isAuthValid).toBe(false);
         expect(isBaseURLValid).toBe(false);

--- a/packages/vsce/tests/webview/model-status-login-commands.test.tsx
+++ b/packages/vsce/tests/webview/model-status-login-commands.test.tsx
@@ -75,41 +75,7 @@ describe('Model, Status, and Login Commands', () => {
             await waitFor(() => {
                 expect(document.querySelector('.configuration-dialog-overlay')).toBeInTheDocument();
             });
-            expect(document.querySelector('#login-serverUrl')).toBeInTheDocument();
-        });
-
-        it('should send updateConfiguration with serverUrl when save is clicked', async () => {
-            const { vscode } = renderChatApp();
-
-            await act(async () => {
-                await typeAndSend('/login');
-            });
-
-            await waitFor(() => {
-                expect(document.querySelector('#login-serverUrl')).toBeInTheDocument();
-            });
-
-            const serverUrlInput = document.querySelector('#login-serverUrl') as HTMLInputElement;
-            await act(async () => {
-                fireEvent.change(serverUrlInput, { target: { value: 'https://wave.example.com' } });
-            });
-
-            const saveButton = document.querySelector('#login-save-serverUrl') as HTMLButtonElement;
-            vscode.postMessage.mockClear();
-            await act(async () => {
-                fireEvent.click(saveButton);
-            });
-
-            await waitFor(() => {
-                expect(vscode.postMessage).toHaveBeenCalledWith(
-                    expect.objectContaining({
-                        command: 'updateConfiguration',
-                        configurationData: expect.objectContaining({
-                            serverUrl: 'https://wave.example.com'
-                        })
-                    })
-                );
-            });
+            expect(document.querySelector('.sso-auth-section')).toBeInTheDocument();
         });
     });
 

--- a/packages/vsce/webview/src/components/ChatApp.tsx
+++ b/packages/vsce/webview/src/components/ChatApp.tsx
@@ -470,7 +470,6 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode }) => {
       )}
       {state.activeDialog === 'login' && (
         <LoginDialog
-          configurationData={state.configurationData || {}}
           onClose={handleDialogClose}
           vscode={vscode}
         />

--- a/packages/vsce/webview/src/components/LoginDialog.tsx
+++ b/packages/vsce/webview/src/components/LoginDialog.tsx
@@ -10,7 +10,6 @@ import { LoginDialogProps, VsCodeApi } from '../types';
 import '../styles/ConfigurationDialog.css';
 
 const LoginDialog: React.FC<LoginDialogProps & { vscode: VsCodeApi }> = ({
-  configurationData,
   onClose,
   vscode
 }) => {
@@ -18,15 +17,7 @@ const LoginDialog: React.FC<LoginDialogProps & { vscode: VsCodeApi }> = ({
   const [authUser, setAuthUser] = useState<{ id: string; email?: string } | null>(null);
   const [authLoading, setAuthLoading] = useState(false);
   const [authMessage, setAuthMessage] = useState('');
-  const [serverUrlInput, setServerUrlInput] = useState('');
-  const [serverUrlSaved, setServerUrlSaved] = useState(false);
   const dialogRef = useRef<HTMLDivElement>(null);
-
-  // Initialize serverUrl input from configuration
-  useEffect(() => {
-    setServerUrlInput(configurationData?.serverUrl || '');
-    setServerUrlSaved(!!configurationData?.serverUrl);
-  }, [configurationData?.serverUrl]);
 
   // Fetch auth status on mount
   useEffect(() => {
@@ -74,17 +65,6 @@ const LoginDialog: React.FC<LoginDialogProps & { vscode: VsCodeApi }> = ({
     vscode?.postMessage({ command: 'logout' });
   };
 
-  const handleSaveServerUrl = () => {
-    vscode?.postMessage({
-      command: 'updateConfiguration',
-      configurationData: {
-        ...configurationData,
-        serverUrl: serverUrlInput
-      }
-    });
-    setServerUrlSaved(true);
-  };
-
   // Click outside / Escape to close
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -105,8 +85,6 @@ const LoginDialog: React.FC<LoginDialogProps & { vscode: VsCodeApi }> = ({
     };
   }, [onClose]);
 
-  const serverUrl = serverUrlSaved ? serverUrlInput : (configurationData?.serverUrl || '');
-
   return (
     <div className="configuration-dialog-overlay">
       <div ref={dialogRef} className="configuration-dialog">
@@ -116,28 +94,6 @@ const LoginDialog: React.FC<LoginDialogProps & { vscode: VsCodeApi }> = ({
 
         <div className="configuration-form">
           <div className="configuration-fields-scroll-area">
-            <div className="configuration-field">
-              <label htmlFor="login-serverUrl">服务端链接:</label>
-              <div className="login-serverUrl-row">
-                <input
-                  id="login-serverUrl"
-                  type="url"
-                  value={serverUrlInput}
-                  onChange={(e) => { setServerUrlInput(e.target.value); setServerUrlSaved(false); }}
-                  placeholder="https://wave.example.com"
-                />
-                <button
-                  type="button"
-                  id="login-save-serverUrl"
-                  className="login-save-serverUrl-btn"
-                  onClick={handleSaveServerUrl}
-                  disabled={!serverUrlInput || serverUrlSaved}
-                >
-                  {serverUrlSaved ? '已保存' : '保存'}
-                </button>
-              </div>
-            </div>
-
             <div className="configuration-field sso-auth-section">
               <label>认证状态:</label>
               {isAuthenticated ? (
@@ -162,7 +118,7 @@ const LoginDialog: React.FC<LoginDialogProps & { vscode: VsCodeApi }> = ({
                     type="button"
                     className="sso-login-btn"
                     onClick={handleLogin}
-                    disabled={authLoading || !serverUrl}
+                    disabled={authLoading}
                   >
                     {authLoading ? '登录中...' : 'SSO 登录'}
                   </button>

--- a/packages/vsce/webview/src/components/StatusDialog.tsx
+++ b/packages/vsce/webview/src/components/StatusDialog.tsx
@@ -64,7 +64,6 @@ const StatusDialog: React.FC<StatusDialogProps & { vscode: { postMessage: (msg: 
     };
   }, [onClose]);
 
-  const serverUrl = configurationData?.serverUrl;
   const baseURL = configurationData?.baseURL;
   const model = configurationData?.model;
   const fastModel = configurationData?.fastModel;
@@ -96,7 +95,6 @@ const StatusDialog: React.FC<StatusDialogProps & { vscode: { postMessage: (msg: 
             <StatusRow label="版本" value={version} />
             <StatusRow label="Session ID" value={sessionId} />
             <StatusRow label="工作目录" value={workdir} />
-            <StatusRow label="服务端链接" value={serverUrl} />
             <StatusRow label="Base URL" value={baseURL} />
             <StatusRow label="Model" value={model} />
             <StatusRow label="Fast Model" value={fastModel} />

--- a/packages/vsce/webview/src/styles/ConfigurationDialog.css
+++ b/packages/vsce/webview/src/styles/ConfigurationDialog.css
@@ -652,39 +652,6 @@ input:checked + .slider:before {
     color: var(--vscode-errorForeground);
 }
 
-/* Login Dialog - Server URL row */
-.login-serverUrl-row {
-    display: flex;
-    gap: 6px;
-    align-items: center;
-}
-
-.login-serverUrl-row input {
-    flex: 1;
-    min-width: 0;
-}
-
-.login-save-serverUrl-btn {
-    background-color: var(--vscode-button-background);
-    color: var(--vscode-button-foreground);
-    border: none;
-    padding: 6px 10px;
-    border-radius: 3px;
-    cursor: pointer;
-    font-size: 12px;
-    white-space: nowrap;
-    flex-shrink: 0;
-}
-
-.login-save-serverUrl-btn:hover {
-    background-color: var(--vscode-button-hoverBackground);
-}
-
-.login-save-serverUrl-btn:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-}
-
 /* MCP Server Management */
 .mcp-container {
     display: flex;

--- a/packages/vsce/webview/src/types/index.ts
+++ b/packages/vsce/webview/src/types/index.ts
@@ -295,8 +295,6 @@ export interface ConfirmationDialogProps {
  * Maps to VS Code global state
  */
 export interface ConfigurationData {
-  /** Wave server URL for SSO authentication (user-configured value) */
-  serverUrl?: string;
   /** API key for authentication */
   apiKey?: string;
   /** Headers for authentication */
@@ -377,7 +375,6 @@ export interface StatusDialogProps {
  * Props for the SSO login dialog component
  */
 export interface LoginDialogProps {
-  configurationData: ConfigurationData;
   onClose: () => void;
 }
 


### PR DESCRIPTION
## Summary

- Add `DEFAULT_SERVER_URL` constant (`https://codechat.codewave.163.com`) in agent-sdk; `getServerUrl()` now falls back to it instead of throwing when `WAVE_SERVER_URL` is unset
- Apply the same fallback chain (options > env var > default) in SDK `configurationService` gateway resolution
- Remove the `WAVE_SERVER_URL` required-check; CLI `LoginCommand` drops the now-unnecessary try/catch
- Remove the VSCE server URL settings entry entirely: LoginDialog input/save UI, StatusDialog display row, `ConfigurationData` field (backend + webview types), `chatSession` `AgentOptions.serverUrl`, and `messageHandler` `config.serverUrl` usage
- Update `authService` tests, VSCE webview tests, demo files, and `ENV.md` default value

## Changes

### agent-sdk
- `src/utils/constants.ts`: new `DEFAULT_SERVER_URL`
- `src/services/authService.ts`: `getServerUrl()` returns default fallback, no longer throws
- `src/services/configurationService.ts`: gateway resolution includes default fallback
- `builtin/skills/settings/ENV.md`: document default value
- `tests/services/authService.test.ts`: updated getServerUrl tests

### code (CLI)
- `src/components/LoginCommand.tsx`: removed try/catch around getServerUrl()

### vsce
- Removed `serverUrl` from `ConfigurationData` (backend + webview types)
- `LoginDialog.tsx`: removed server URL input, save button, related state/logic
- `StatusDialog.tsx`: removed server URL display row
- `chatSession.ts`: removed `serverUrl` from AgentOptions
- `messageHandler.ts`: login flow relies on `authService.login()` → `getServerUrl()`
- `ChatApp.tsx`: removed `configurationData` prop from LoginDialog
- Removed related CSS styles
- Updated tests and demo files