### PR TITLE
chore: lower minimum Node version from 22 to 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "packageManager": "pnpm@11.9.0",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=20"
   },
   "license": "MIT"
 }

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -48,7 +48,7 @@
     "@opentelemetry/sdk-logs": "^0.217.0",
     "@opentelemetry/sdk-node": "^0.217.0",
     "@opentelemetry/sdk-trace-node": "^2.7.1",
-    "chokidar": "^5.0.0",
+    "chokidar": "^4.0.3",
     "cron-parser": "^5.5.0",
     "find-up": "^8.0.0",
     "fuzzysort": "^3.1.0",
@@ -67,7 +67,7 @@
     "vitest": "^4.1.7"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=20"
   },
   "license": "MIT"
 }

--- a/packages/code/package.json
+++ b/packages/code/package.json
@@ -71,7 +71,7 @@
     "react": ">=18.0.0"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=20"
   },
   "license": "MIT"
 }

--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "engines": {
     "vscode": "^1.107.0",
-    "node": ">=22.0.0"
+    "node": ">=20"
   },
   "files": [
     "dist/",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^2.7.1
         version: 2.7.1(@opentelemetry/api@1.9.1)
       chokidar:
-        specifier: ^5.0.0
-        version: 5.0.0
+        specifier: ^4.0.3
+        version: 4.0.3
       cron-parser:
         specifier: ^5.5.0
         version: 5.5.0
@@ -2415,9 +2415,9 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
-  chokidar@5.0.0:
-    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
-    engines: {node: '>= 20.19.0'}
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -4436,9 +4436,9 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
-  readdirp@5.0.0:
-    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
-    engines: {node: '>= 20.19.0'}
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -7508,9 +7508,9 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  chokidar@5.0.0:
+  chokidar@4.0.3:
     dependencies:
-      readdirp: 5.0.0
+      readdirp: 4.1.2
 
   chownr@1.1.4:
     optional: true
@@ -9816,7 +9816,7 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
-  readdirp@5.0.0: {}
+  readdirp@4.1.2: {}
 
   redent@3.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Lower the minimum supported Node.js version from 22 to 20 to improve compatibility.

## Changes

- **chokidar**: downgraded from `^5.0.0` to `^4.0.3` — v5 requires Node `>=20.19`, while v4 only requires `>=14.16`
- **engines.node**: updated from `>=22.0.0` to `>=20` across all four `package.json` files (root, agent-sdk, code, vsce)

## Rationale

Audited all source code and direct dependencies for Node version requirements:

- **Source code**: only uses Node 18+ APIs (global `fetch()`, `AbortSignal.timeout()`) — no Node 20+ or 22+ specific APIs
- **Dependencies**: the highest Node version requirement was `chokidar@5` (`>=20.19`). All other direct dependencies require `>=20` or lower:
  - `lru-cache@11`: `20 || >=22`
  - `minimatch@10`: `20 || >=22`
  - `find-up@8`: `>=20`
  - `ink@6`: `>=20`
  - `marked@17`: `>= 20`

Downgrading chokidar to v4 removes the `20.19` floor, allowing a clean `>=20`.

## Verification

- `pnpm install` resolves cleanly
- `fileWatcher` tests pass (15/15) with chokidar@4
- chokidar v4 API is fully compatible with current usage (`watch`, `add`, `unwatch`, `close`, events, `awaitWriteFinish`, `usePolling`, `depth`, `ignored`)