### PR TITLE
docs: hide download link in Release artifact via DOCS_HIDE_DOWNLOAD env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,10 @@ jobs:
         run: pnpm -F wave-vsce run test:demo
 
       - name: Build docs with base /docs/
+        env:
+          # CodeChat embeds these docs and hides the GitHub Releases download link;
+          # only the Release artifact gets this flag, GitHub Pages keeps the link.
+          DOCS_HIDE_DOWNLOAD: '1'
         run: npx vitepress build docs --base /docs/
 
       - name: Package docs.tar.gz

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,14 +1,21 @@
+const SHOW_DOWNLOAD_LINK = process.env.DOCS_HIDE_DOWNLOAD !== '1';
+
+const nav = [
+  { text: '首页', link: '/' },
+  { text: 'VS Code 扩展', link: '/vsce' },
+  { text: 'CLI', link: '/cli' },
+  { text: 'SDK', link: '/sdk' },
+];
+if (SHOW_DOWNLOAD_LINK) {
+  nav.push({ text: '下载', link: 'https://github.com/netease-lcap/wave-agent/releases' });
+}
+
 export default {
   base: '/wave-agent/',
   title: 'CodeChat',
   description: 'AI 辅助编程工具链 — SDK、CLI 与 VS Code 扩展',
   themeConfig: {
-    nav: [
-      { text: '首页', link: '/' },
-      { text: 'VS Code 扩展', link: '/vsce' },
-      { text: 'CLI', link: '/cli' },
-      { text: 'SDK', link: '/sdk' },
-    ],
+    nav,
     sidebar: {
       '/vsce': [
         {

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,14 +9,6 @@ AI 辅助编程工具链，提供 SDK、CLI 终端界面与 VS Code 扩展三种
 
 [VS Code 扩展](/vsce) · [CLI](/cli) · [SDK](/sdk)
 
-## 项目结构
-
-| 包 | 说明 |
-| --- | --- |
-| **agent-sdk** | 核心 SDK，处理 AI 模型集成、工具系统与记忆管理 |
-| **code** | CLI 终端界面，基于 React Ink 构建的交互式命令行 |
-| **vsce** | VS Code 扩展，带 React Webview 聊天 UI |
-
 ## 快速开始
 
 ### CLI 终端
@@ -34,7 +26,7 @@ wave
 
 ### VS Code 扩展
 
-从 [Releases](https://github.com/netease-lcap/wave-agent/releases) 下载 `.vsix` 文件安装，在对话中输入 `/login` 完成 SSO 登录。
+下载 `.vsix` 文件安装，在对话中输入 `/login` 完成 SSO 登录。
 
 ### SDK 集成
 


### PR DESCRIPTION
## 背景

Issue #1395 补充评论要求：CodeChat 嵌入文档站后，不应再显示指向 GitHub Releases 的下载链接，下载入口改由 CodeChat 自身提供。

## 改动

1. `docs/.vitepress/config.js`：新增环境变量 `DOCS_HIDE_DOWNLOAD`，控制导航栏「下载」项是否显示
   - GitHub Pages（`pages.yml`）不设此变量 → 显示「下载」项
   - Release artifact（`release.yml`）设 `DOCS_HIDE_DOWNLOAD=1` → 隐藏「下载」项

2. `docs/index.md`：移除正文中 GitHub Releases 下载链接，改为通用「下载 `.vsix` 文件安装」表述

3. `.github/workflows/release.yml`：docs 构建步骤注入 `DOCS_HIDE_DOWNLOAD: '1'`

## 验证
- 默认模式：导航栏含「下载」项，指向 GitHub Releases
- 隐藏模式（`DOCS_HIDE_DOWNLOAD=1`）：导航栏无「下载」项，`index.html` 中 `releases` 出现 0 次

Closes #1395