### PR TITLE
fix(vsce): 修复打开 /mcp 报错 r.map is not a function

### DIFF
--- a/packages/vsce/src/session/messageHandler.ts
+++ b/packages/vsce/src/session/messageHandler.ts
@@ -726,7 +726,7 @@ export class MessageHandler {
 
     private async handleGetMcpServers(viewType?: 'sidebar' | 'tab' | 'window', windowId?: string) {
         const session = this.context.getChatSession(viewType || 'tab', windowId);
-        const servers = session.getMcpServers();
+        const servers = await session.getMcpServers();
         this.context.postMessage({
             command: 'mcpServersResponse',
             servers

--- a/packages/vsce/tests/session/messageHandler.test.ts
+++ b/packages/vsce/tests/session/messageHandler.test.ts
@@ -1,0 +1,137 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ──────────────────────────────────────────────────────
+
+vi.mock('vscode', () => ({
+    window: {
+        showInformationMessage: vi.fn(),
+        showErrorMessage: vi.fn(),
+    },
+}));
+
+import * as vscode from 'vscode';
+import { MessageHandler, type MessageHandlerContext } from '../../src/session/messageHandler';
+import type { ChatSession } from '../../src/session/chatSession';
+import type { McpServerStatus } from 'wave-agent-sdk';
+import type { ConfigurationService } from '../../src/services/configurationService';
+import type { FileService } from '../../src/services/fileService';
+import type { SessionService } from '../../src/services/sessionService';
+import type { PluginService } from '../../src/services/pluginService';
+import type { StdioClient } from '../../src/stdio/stdioClient';
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function createMockSession(): ChatSession {
+    return {
+        getMcpServers: vi.fn(),
+        connectMcpServer: vi.fn(),
+        disconnectMcpServer: vi.fn(),
+    } as unknown as ChatSession;
+}
+
+function createHandler(session: ChatSession) {
+    const context: MessageHandlerContext = {
+        getChatSession: vi.fn().mockReturnValue(session),
+        postMessage: vi.fn(),
+        initializeAgent: vi.fn(),
+        listSessions: vi.fn(),
+        updateAllSessionsConfig: vi.fn(),
+    };
+    const handler = new MessageHandler(
+        {} as unknown as ConfigurationService,
+        {} as unknown as FileService,
+        {} as unknown as SessionService,
+        {} as unknown as PluginService,
+        {} as unknown as StdioClient,
+        context
+    );
+    return { handler, context };
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe('MessageHandler MCP handlers', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    // Regression for missing `await` on session.getMcpServers().
+    // If await is removed, `servers` sent to postMessage is a Promise,
+    // which would fail Array.isArray and .map downstream.
+    test('getMcpServers posts resolved array (regression for missing await)', async () => {
+        const servers = [
+            { name: 's1', status: 'connected', toolCount: 3 },
+        ] as unknown as McpServerStatus[];
+        const session = createMockSession();
+        (session.getMcpServers as ReturnType<typeof vi.fn>).mockResolvedValue(servers);
+
+        const { handler, context } = createHandler(session);
+        await handler.handleMessage({ command: 'getMcpServers' }, 'tab');
+
+        expect(context.getChatSession).toHaveBeenCalledWith('tab', undefined);
+        expect(context.postMessage).toHaveBeenCalledTimes(1);
+        const posted = (context.postMessage as ReturnType<typeof vi.fn>).mock.calls[0][0] as { command: string; servers: unknown };
+        expect(posted.command).toBe('mcpServersResponse');
+        expect(Array.isArray(posted.servers)).toBe(true);
+        expect(posted.servers).toEqual(servers);
+    });
+
+    test('getMcpServers posts empty array when no servers', async () => {
+        const session = createMockSession();
+        (session.getMcpServers as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+        const { handler, context } = createHandler(session);
+        await handler.handleMessage({ command: 'getMcpServers' }, 'tab');
+
+        const posted = (context.postMessage as ReturnType<typeof vi.fn>).mock.calls[0][0] as { command: string; servers: unknown };
+        expect(posted.command).toBe('mcpServersResponse');
+        expect(Array.isArray(posted.servers)).toBe(true);
+        expect(posted.servers).toEqual([]);
+    });
+
+    test('connectMcpServer shows info message on success', async () => {
+        const session = createMockSession();
+        (session.connectMcpServer as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+        const { handler } = createHandler(session);
+        await handler.handleMessage({ command: 'connectMcpServer', serverName: 'my-server' }, 'tab');
+
+        expect(session.connectMcpServer).toHaveBeenCalledWith('my-server');
+        expect(vscode.window.showInformationMessage).toHaveBeenCalledTimes(1);
+        expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+    });
+
+    test('connectMcpServer shows error message on failure', async () => {
+        const session = createMockSession();
+        (session.connectMcpServer as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('boom'));
+
+        const { handler } = createHandler(session);
+        await handler.handleMessage({ command: 'connectMcpServer', serverName: 'bad-server' }, 'tab');
+
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(1);
+        expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+    });
+
+    test('disconnectMcpServer shows info message on success', async () => {
+        const session = createMockSession();
+        (session.disconnectMcpServer as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+        const { handler } = createHandler(session);
+        await handler.handleMessage({ command: 'disconnectMcpServer', serverName: 'my-server' }, 'tab');
+
+        expect(session.disconnectMcpServer).toHaveBeenCalledWith('my-server');
+        expect(vscode.window.showInformationMessage).toHaveBeenCalledTimes(1);
+        expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+    });
+
+    test('disconnectMcpServer shows error message on failure', async () => {
+        const session = createMockSession();
+        (session.disconnectMcpServer as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('boom'));
+
+        const { handler } = createHandler(session);
+        await handler.handleMessage({ command: 'disconnectMcpServer', serverName: 'bad-server' }, 'tab');
+
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(1);
+        expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## 问题

打开 VS Code 扩展的 `/mcp` 时前端报错：

```
TypeError: r.map is not a function
```

## 根因

`messageHandler.ts` 的 `handleGetMcpServers` 中 `session.getMcpServers()` 是异步方法但未 `await`，导致通过 `postMessage` 发送给前端的是 Promise 对象而非数组，前端对 Promise 调用 `.map()` 即报错。

```diff
  const session = this.context.getChatSession(viewType || 'tab', windowId);
- const servers = session.getMcpServers();
+ const servers = await session.getMcpServers();
```

## 测试

`messageHandler.ts` 之前 0 测试覆盖。补充 6 个回归测试覆盖 3 个 MCP 处理器（getMcpServers / connectMcpServer / disconnectMcpServer），其中关键回归用例用 `mockResolvedValue` 返回真正的 Promise（而非同步值），这样缺失 `await` 会让 `Array.isArray(posted.servers)` 断言失败，确保该 bug 不会再回归。

```
Test Files  1 passed (1)
     Tests  6 passed (6)
```

## Why existing tests didn't catch it

`messageHandler.ts` 在本次之前没有任何测试覆盖；`chatSession.ts` / `stdioAgent.ts` 各自有单测，但 `messageHandler` 作为消息分发层一直是盲区。