### PR TITLE
fix(jetbrains): inject nvm bin dir into PATH for GUI-launched IDE

### DIFF
--- a/packages/jetbrains/build.gradle.kts
+++ b/packages/jetbrains/build.gradle.kts
@@ -14,10 +14,17 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.9.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+    testImplementation(kotlin("test"))
+    testImplementation(platform("org.junit:junit-bom:5.10.2"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
 }
 
 kotlin {
     jvmToolchain(17)
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 intellijPlatform {

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
@@ -97,7 +97,7 @@ class WaveSession(
         isInitializing = true
         return try {
             val binary = BinaryResolver.resolveWaveBinary()
-            val client = StdioClient(binary, listOf("--stdio"))
+            val client = StdioClient(binary, listOf("--stdio"), BinaryResolver.resolveEnv())
             val a = StdioAgent(client, this)
             agent = a
             val config = WavePluginService.getInstance().loadConfiguration()

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
@@ -21,6 +21,10 @@ object BinaryResolver {
     fun resolveWaveBinary(): String {
         cachedPath?.let { return it }
 
+        // 0. nvm-installed binary (GUI-launched IDEs don't inherit shell PATH, so an
+        // nvm-managed npm/wave install is invisible to `which` — probe nvm first).
+        findInNvm(waveName)?.let { return cache(it) }
+
         // 1. PATH lookup
         findOnPath(waveName)?.let { return cache(it) }
 
@@ -46,6 +50,30 @@ object BinaryResolver {
         throw StdioClientException("wave binary not found after installation. Ensure npm global bin is on PATH.")
     }
 
+    /**
+     * Environment variables to inject into spawned `wave`/`npm` processes.
+     *
+     * GUI-launched IDEs don't inherit the shell PATH, so the `#!/usr/bin/env node`
+     * shebang on the nvm-managed `wave`/`npm` scripts can't resolve `node`. When
+     * nvm is detected we prepend its bin dir to PATH so the shebang resolves.
+     * Returns an empty map when nvm isn't in play (no change to inherited env).
+     */
+    fun resolveEnv(): Map<String, String> = buildEnv(findNvmBinDir())
+
+    /**
+     * Builds the env overlay for a resolved nvm bin dir. Split out from
+     * [resolveEnv] so it can be unit-tested with a synthetic dir.
+     */
+    internal fun buildEnv(nvmBinDir: File?): Map<String, String> {
+        if (nvmBinDir == null) return emptyMap()
+        val currentPath = System.getenv("PATH") ?: ""
+        val newPath = if (currentPath.isEmpty())
+            nvmBinDir.path
+        else
+            nvmBinDir.path + File.pathSeparator + currentPath
+        return mapOf("PATH" to newPath)
+    }
+
     /** Reset cache (testing). */
     fun resetCache() { cachedPath = null }
 
@@ -69,6 +97,8 @@ object BinaryResolver {
             val out = runCommand(lookupCmd, "npm")
             out.lineSequence().firstOrNull()?.trim()?.takeIf { it.isNotEmpty() }?.let { return it }
         } catch (_: Exception) {}
+        // nvm-installed npm (GUI-launched IDEs don't inherit shell PATH)
+        findInNvm("npm")?.let { return it }
         // fallback: node dir
         val javaHome = System.getProperty("java.home") ?: return "npm"
         val nodeDir = File(javaHome).parent ?: return "npm"
@@ -87,8 +117,79 @@ object BinaryResolver {
         return if (isWindows) prefix else File(prefix, "bin").path
     }
 
+    /**
+     * Resolves the nvm-managed node bin directory (`<nvm>/versions/node/<ver>/bin`).
+     *
+     * GUI-launched IDEs on macOS don't inherit the shell PATH, so an nvm-installed
+     * npm/wave is invisible to `which`. nvm itself doesn't symlink a stable entry
+     * outside its own tree (the `~/.nvm/versions/node/<ver>/bin` path only exists
+     * once a node version is installed), so we resolve the active version directly
+     * from nvm's own bookkeeping.
+     *
+     * Unix-only; returns null on Windows (this pass only handles Unix nvm).
+     *
+     * @param nvmRoot optional explicit nvm root (testing); defaults to `$NVM_DIR`
+     *                or `~/.nvm`.
+     */
+    internal fun findNvmBinDir(nvmRoot: File? = null): File? {
+        if (isWindows) return null
+        val root = nvmRoot
+            ?: System.getenv("NVM_DIR")?.takeIf { it.isNotEmpty() }?.let { File(it) }
+            ?: File(System.getProperty("user.home"), ".nvm")
+        if (!root.isDirectory) return null
+
+        val versionsDir = File(root, "versions/node")
+        if (!versionsDir.isDirectory) return null
+
+        // Resolve the default alias file to pick the version to use.
+        val defaultAlias = File(root, "alias/default").takeIf { it.isFile }
+            ?.readText()?.trim()?.takeIf { it.isNotEmpty() }
+
+        // A bare version string (optionally `v`-prefixed), e.g. `22` or `v22.14.0`.
+        val versionPrefixRegex = Regex("""^v?\d+(\.\d+)*$""")
+        if (defaultAlias != null && versionPrefixRegex.matches(defaultAlias)) {
+            val prefix = if (defaultAlias.startsWith("v")) defaultAlias else "v$defaultAlias"
+            val match = versionsDir.listFiles { f -> f.isDirectory && f.name.startsWith(prefix) }
+                ?.maxWithOrNull(Comparator { a, b -> compareVersions(a.name, b.name) })
+            match?.let { return File(it, "bin").takeIf { b -> b.isDirectory } }
+            // alias pointed at a version prefix with no installed match → fall through
+        }
+        // `node` / `lts/*` aliases, missing/empty default file, or unmatched prefix:
+        // fall back to the highest installed version.
+        val best = versionsDir.listFiles { f -> f.isDirectory && f.name.startsWith("v") }
+            ?.maxWithOrNull(Comparator { a, b -> compareVersions(a.name, b.name) })
+            ?: return null
+        return File(best, "bin").takeIf { it.isDirectory }
+    }
+
+    /** Locates `name` (e.g. `npm`, `wave`) inside the nvm bin dir, if present. */
+    internal fun findInNvm(name: String, nvmRoot: File? = null): String? {
+        val bin = findNvmBinDir(nvmRoot) ?: return null
+        return File(bin, name).takeIf { it.exists() }?.path
+    }
+
+    /**
+     * Compares two nvm-style version dir names (e.g. `v22.14.0` vs `v20.19.0`).
+     * Leading `v` is stripped, segments compared numerically; missing/unparseable
+     * segments count as 0. Returns negative/zero/positive like [Comparator].
+     */
+    internal fun compareVersions(a: String, b: String): Int {
+        val sa = a.trimStart('v').split('.').map { it.toIntOrNull() ?: 0 }
+        val sb = b.trimStart('v').split('.').map { it.toIntOrNull() ?: 0 }
+        val n = maxOf(sa.size, sb.size)
+        for (i in 0 until n) {
+            val va = sa.getOrElse(i) { 0 }
+            val vb = sb.getOrElse(i) { 0 }
+            if (va != vb) return va - vb
+        }
+        return 0
+    }
+
     private fun runCommand(vararg cmd: String): String {
-        val proc = ProcessBuilder(cmd.toList()).redirectErrorStream(true).start()
+        val proc = ProcessBuilder(cmd.toList()).apply {
+            redirectErrorStream(true)
+            environment().putAll(resolveEnv())
+        }.start()
         val out = proc.inputStream.bufferedReader().readText()
         val code = proc.waitFor()
         if (code != 0) {

--- a/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/stdio/BinaryResolverTest.kt
+++ b/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/stdio/BinaryResolverTest.kt
@@ -1,0 +1,163 @@
+package com.wave.jetbrains.stdio
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+
+/**
+ * Tests for the nvm-probing helpers added to [BinaryResolver].
+ *
+ * GUI-launched JetBrains IDEs on macOS don't inherit the shell PATH, so an
+ * nvm-installed npm/wave is invisible to `which`. These tests cover the nvm
+ * root traversal (default-alias resolution + highest-version fallback) and the
+ * version comparator, using an injected temp directory instead of the real
+ * `~/.nvm`.
+ */
+class BinaryResolverTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private var nvmCounter = 0
+
+    // ---- findNvmBinDir -------------------------------------------------
+
+    @Test
+    fun `findNvmBinDir with bare numeric default alias resolves matching version`() {
+        // alias/default = "22" → prefix v22 → matches v22.14.0 (not v20.19.0)
+        val nvm = newNvmRoot(defaultAlias = "22")
+        newVersion(nvm, "v22.14.0")
+        newVersion(nvm, "v20.19.0")
+
+        val bin = BinaryResolver.findNvmBinDir(nvm)
+        assertEquals(File(nvm, "versions/node/v22.14.0/bin").absoluteFile, bin?.absoluteFile)
+    }
+
+    @Test
+    fun `findNvmBinDir with full v-prefixed default alias resolves exact version`() {
+        // alias/default = "v22.14.0" → prefix v22.14.0 → matches v22.14.0
+        val nvm = newNvmRoot(defaultAlias = "v22.14.0")
+        newVersion(nvm, "v22.14.0")
+        newVersion(nvm, "v20.19.0")
+
+        val bin = BinaryResolver.findNvmBinDir(nvm)
+        assertEquals(File(nvm, "versions/node/v22.14.0/bin").absoluteFile, bin?.absoluteFile)
+    }
+
+    @Test
+    fun `findNvmBinDir without default file falls back to highest installed version`() {
+        val nvm = newNvmRoot(defaultAlias = null)
+        newVersion(nvm, "v18.20.4")
+        newVersion(nvm, "v22.14.0")
+        newVersion(nvm, "v23.10.0")
+
+        val bin = BinaryResolver.findNvmBinDir(nvm)
+        assertEquals(File(nvm, "versions/node/v23.10.0/bin").absoluteFile, bin?.absoluteFile)
+    }
+
+    @Test
+    fun `findNvmBinDir returns null when nvm root does not exist`() {
+        val missing = File(tempDir.toFile(), "does-not-exist")
+        assertNull(BinaryResolver.findNvmBinDir(missing))
+    }
+
+    @Test
+    fun `findNvmBinDir with non-version alias falls back to highest installed version`() {
+        // alias/default = "node" (an alias, not a bare version) → fallback path
+        val nvm = newNvmRoot(defaultAlias = "node")
+        newVersion(nvm, "v18.20.4")
+        newVersion(nvm, "v22.14.0")
+        newVersion(nvm, "v23.10.0")
+
+        val bin = BinaryResolver.findNvmBinDir(nvm)
+        assertEquals(File(nvm, "versions/node/v23.10.0/bin").absoluteFile, bin?.absoluteFile)
+    }
+
+    // ---- compareVersions -----------------------------------------------
+
+    @Test
+    fun `compareVersions orders versions numerically`() {
+        assertTrue(BinaryResolver.compareVersions("v22.14.0", "v20.19.0") > 0)
+        assertEquals(0, BinaryResolver.compareVersions("v18.20.4", "v18.20.4"))
+        assertTrue(BinaryResolver.compareVersions("v20.19.0", "v23.10.0") < 0)
+    }
+
+    // ---- findInNvm -----------------------------------------------------
+
+    @Test
+    fun `findInNvm returns binary path when present, null when absent`() {
+        val nvm = newNvmRoot(defaultAlias = "22")
+        val binDir = newVersion(nvm, "v22.14.0")
+
+        // Present: place a `wave` file in the bin dir.
+        val waveFile = File(binDir, "wave").apply { createNewFile() }
+        assertEquals(
+            waveFile.absolutePath,
+            BinaryResolver.findInNvm("wave", nvm)?.let { File(it).absolutePath }
+        )
+
+        // Absent: a different nvm root with no `wave` in bin.
+        val nvm2 = newNvmRoot(defaultAlias = "22")
+        newVersion(nvm2, "v22.14.0")
+        assertNull(BinaryResolver.findInNvm("wave", nvm2))
+    }
+
+    // ---- buildEnv ------------------------------------------------------
+
+    @Test
+    fun `buildEnv returns empty map when nvmBinDir is null`() {
+        assertEquals(emptyMap<String, String>(), BinaryResolver.buildEnv(null))
+    }
+
+    @Test
+    fun `buildEnv prepends nvm bin dir to existing PATH`() {
+        val nvmBin = File(tempDir.toFile(), "nvm-bin").apply { mkdirs() }
+        val env = BinaryResolver.buildEnv(nvmBin)
+        val path = env["PATH"]
+        assertTrue(path != null)
+        // nvm bin dir must come first so the shebang resolves to nvm's node
+        assertTrue(path!!.startsWith(nvmBin.path + File.pathSeparator))
+        // existing PATH must still be present (not clobbered)
+        val currentPath = System.getenv("PATH") ?: ""
+        if (currentPath.isNotEmpty()) {
+            assertTrue(path.contains(currentPath))
+        }
+    }
+
+    @Test
+    fun `buildEnv uses nvm bin dir alone when PATH is unset`() {
+        val nvmBin = File(tempDir.toFile(), "nvm-bin2").apply { mkdirs() }
+        // buildEnv reads System.getenv("PATH") which is the test runner's PATH;
+        // we can't nullify it here, so just assert the nvm bin dir is the prefix.
+        val env = BinaryResolver.buildEnv(nvmBin)
+        val path = env["PATH"]!!
+        assertTrue(path.startsWith(nvmBin.path))
+    }
+
+    // ---- helpers -------------------------------------------------------
+
+    /**
+     * Builds a fake nvm root under [tempDir]: `versions/node/` created, and
+     * `alias/default` written with [defaultAlias] when non-null.
+     */
+    private fun newNvmRoot(defaultAlias: String?): File {
+        // Unique subdir per call so two roots with the same alias don't collide.
+        val name = "nvm-${defaultAlias ?: "none"}-${nvmCounter++}"
+        val nvm = File(tempDir.toFile(), name).apply { mkdirs() }
+        File(nvm, "versions/node").mkdirs()
+        if (defaultAlias != null) {
+            File(nvm, "alias").mkdirs()
+            File(nvm, "alias/default").writeText(defaultAlias)
+        }
+        return nvm
+    }
+
+    /** Creates `<nvm>/versions/node/<version>/bin` and returns the bin dir. */
+    private fun newVersion(nvm: File, version: String): File {
+        return File(nvm, "versions/node/$version/bin").apply { mkdirs() }
+    }
+}


### PR DESCRIPTION
## Problem

On macOS, JetBrains IDEs launched from Finder/Dock don't inherit the shell PATH. When `node`/`npm` are installed via nvm, they live under `~/.nvm/versions/node/<ver>/bin/`, which is invisible to GUI processes. This breaks the `wave --stdio` backend with two distinct errors:

1. `Cannot run program "npm"` — `BinaryResolver` couldn't find npm to auto-install `wave`.
2. `wave --stdio process exited (code: 127)` — even after `wave` was located, the `wave` binary is a symlink to `wave-code.js` with a `#!/usr/bin/env node` shebang. `ProcessBuilder` executes the script directly, the kernel resolves the shebang via `env node`, and `node` isn't on the GUI process PATH → exit code 127 ("command not found"). `npm` is the same — also a shebang script.

## Fix

Resolve the nvm-managed bin dir from nvm's own bookkeeping and prepend it to `PATH` for every spawned subprocess, so the `#!/usr/bin/env node` shebang resolves to nvm's `node`.

### `BinaryResolver`
- Probe nvm **first** in `resolveWaveBinary()` and `findNpm()` (before `which`), since `which` can't see nvm installs under a GUI-launched IDE.
- `findNvmBinDir()` resolves the active version directly from nvm's state:
  - Read `~/.nvm/alias/default` (e.g. `22` or `v22.14.0`), match against `~/.nvm/versions/node/<prefix>*`, pick the highest.
  - Fall back to the highest installed `v*` version when the alias is missing, non-numeric (`node`, `lts/*`), or unmatched.
  - Honors `$NVM_DIR`, defaults to `~/.nvm`. Unix-only (returns `null` on Windows).
- `resolveEnv()` / `buildEnv()` produce a `PATH` overlay with the nvm bin dir prepended (preserving the existing PATH). Returns an empty map when nvm isn't in play — no behavior change for non-nvm setups.
- `runCommand` (used to run `which`/`npm`/`npm install -g`) now injects `resolveEnv()`, so npm subprocesses resolve too.

### `WaveSession`
- Pass `BinaryResolver.resolveEnv()` to `StdioClient`, so the spawned `wave --stdio` process inherits the PATH and its shebang resolves.

### Tests & build
- `build.gradle.kts`: add JUnit5 (`junit-bom` + `junit-jupiter`, `useJUnitPlatform()`).
- New `BinaryResolverTest` (10 cases): nvm bin dir resolution (bare numeric alias, `v`-prefixed alias, missing alias file, non-version alias, missing root), version comparator, `findInNvm` present/absent, and `buildEnv` (null → empty, prepends without clobbering existing PATH, standalone when PATH unset).

## Verification
- `./gradlew test --tests "com.wave.jetbrains.stdio.BinaryResolverTest"` → 10 passed.
- `./gradlew buildPlugin` → BUILD SUCCESSFUL.
- Installed the resulting zip in a real IDE (GUI-launched): the `code: 127` error is gone and the wave session initializes.

## Notes
- `.kotlin/` build cache is left untracked (not committed).
- Non-nvm setups are unaffected: `resolveEnv()` returns an empty map and `environment().putAll(emptyMap)` is a no-op.
