### PR TITLE
fix(ci): remove empty NPM_TOKEN env that breaks OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,6 @@ jobs:
       # --- npm publish ---
       - name: Publish to npm
         run: pnpm -r publish --no-git-checks --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # --- GitHub Release ---
       - name: Get previous tag


### PR DESCRIPTION
## Problem

v0.19.3 release failed (run 29588125924) with npm 404:
```
[WARN] Skipped OIDC: ERR_PNPM_AUTH_TOKEN_EXCHANGE ... (status code 404)
[E404] 404 Not Found - PUT https://registry.npmjs.org/wave-agent-sdk - Not found
```

## Root cause

Commit 95af7844 ("ci: merge publish+vsce-release") merged the old `publish.yml` into `release.yml` but **added** `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env. The old `publish.yml` never had this — it used pure `--provenance` + `id-token: write` (OIDC).

`NPM_TOKEN` secret was never set, so `actions/setup-node` writes an empty token into `.npmrc`. pnpm prefers `.npmrc` auth over OIDC, so publish sends an empty/invalid token → npm returns 404.

## Fix

Remove the `env: NODE_AUTH_TOKEN` block, restoring the original pure-OIDC publish flow that worked for all prior releases.

## Verification

After merge, delete and recreate the `v0.19.3` tag to retrigger release.yml with the fixed workflow.