### PR TITLE
fix(ci): restore publish.yml for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish Package
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+
+      - uses: pnpm/action-setup@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      - name: Cache ripgrep binaries
+        uses: actions/cache@v6
+        with:
+          path: packages/agent-sdk/vendor/ripgrep
+          key: ripgrep-${{ runner.os }}-${{ runner.arch }}
+          restore-keys: |
+            ripgrep-${{ runner.os }}-
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm test
+      - run: pnpm -r publish --no-git-checks --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write  # Required for npm OIDC provenance
 
 jobs:
   release:
@@ -18,36 +17,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-tags: true
-
-      - uses: pnpm/action-setup@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
-
-      - name: Cache ripgrep binaries
-        uses: actions/cache@v6
-        with:
-          path: packages/agent-sdk/vendor/ripgrep
-          key: ripgrep-${{ runner.os }}-${{ runner.arch }}
-          restore-keys: |
-            ripgrep-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build all packages
-        run: pnpm build
-
-      - name: Run tests
-        run: pnpm test
-
-      # --- npm publish ---
-      - name: Publish to npm
-        run: pnpm -r publish --no-git-checks --provenance --access public
 
       # --- GitHub Release ---
       - name: Get previous tag


### PR DESCRIPTION
## Problem

v0.19.3 release failed twice with npm 404 on OIDC token exchange:
```
[WARN] Skipped OIDC: ERR_PNPM_AUTH_TOKEN_EXCHANGE ... (status code 404)
[E404] 404 Not Found - PUT https://registry.npmjs.org/wave-agent-sdk
```

## Root cause

The npm trusted publisher is configured on the npm website to allow workflow file **`publish.yml`**. Commit 95af7844 merged `publish.yml` into `release.yml` (renaming the workflow file), so npm rejects the OIDC token exchange — the workflow filename no longer matches the trusted publisher config.

## Fix

- **Restore `publish.yml`** as the npm publish workflow (tag-triggered, pure OIDC `--provenance`, no `NODE_AUTH_TOKEN` env) — matches npm trusted publisher config.
- **Slim `release.yml`** to GitHub Release creation only (removed publish steps, pnpm, node setup).

Both workflows trigger on `v*` tags and run in parallel.

## Verification

After merge, delete + recreate `v0.19.3` tag to retrigger both workflows.