### PR TITLE
feat: negotiate CLI version in stdio handshake and auto-upgrade from plugin

### DIFF
--- a/packages/code/src/stdio/agentBridge.ts
+++ b/packages/code/src/stdio/agentBridge.ts
@@ -35,6 +35,21 @@ import {
   INTERNAL_ERROR as PROTOCOL_INTERNAL_ERROR,
   METHOD_NOT_FOUND as PROTOCOL_METHOD_NOT_FOUND,
 } from "./protocol.js";
+import { readFileSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI_VERSION: string = (() => {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(path.resolve(__dirname, "../../package.json"), "utf-8"),
+    );
+    return pkg.version ?? "";
+  } catch {
+    return "";
+  }
+})();
 
 export type NotificationEmitter = (method: string, params: unknown) => void;
 
@@ -58,6 +73,7 @@ interface InitializeParams {
   disallowedTools?: string[];
   pluginDirs?: string[];
   mcpServers?: Record<string, McpServerConfig>;
+  clientVersion?: string;
 }
 
 interface UpdateConfigParams {
@@ -252,6 +268,7 @@ export class AgentBridge {
     workingDirectory: string;
     permissionMode: PermissionMode;
     latestTotalTokens: number;
+    serverVersion: string;
   }> {
     // Merge with stored config (CLI defaults can be overridden by client)
     this.storedConfig = { ...this.storedConfig, ...params };
@@ -278,11 +295,18 @@ export class AgentBridge {
 
     this.agent = await Agent.create(options);
 
+    if (params.clientVersion) {
+      console.debug(
+        `[agentBridge] clientVersion=${params.clientVersion} serverVersion=${CLI_VERSION}`,
+      );
+    }
+
     return {
       sessionId: this.agent.sessionId,
       workingDirectory: this.agent.workingDirectory,
       permissionMode: this.agent.getPermissionMode(),
       latestTotalTokens: this.agent.latestTotalTokens,
+      serverVersion: CLI_VERSION,
     };
   }
 

--- a/packages/code/tests/stdio/agentBridge.test.ts
+++ b/packages/code/tests/stdio/agentBridge.test.ts
@@ -7,6 +7,14 @@ import {
   listSessions,
   searchFiles,
 } from "wave-agent-sdk";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI_PACKAGE_VERSION = JSON.parse(
+  readFileSync(path.resolve(__dirname, "../../package.json"), "utf-8"),
+).version as string;
 
 // Mock the Agent SDK
 vi.mock("wave-agent-sdk");
@@ -93,6 +101,7 @@ test("initialize creates Agent with correct options and returns session info", a
     workingDirectory: "/test/workdir",
     permissionMode: "default",
     latestTotalTokens: 100,
+    serverVersion: CLI_PACKAGE_VERSION,
   });
   expect(Agent.create).toHaveBeenCalledTimes(1);
 
@@ -118,6 +127,27 @@ test("initialize passes pluginDirs as PluginConfig[]", async () => {
     { type: "local", path: "/path/to/plugin1" },
     { type: "local", path: "/path/to/plugin2" },
   ]);
+});
+
+test("initialize returns serverVersion from package.json", async () => {
+  const { bridge } = createBridge();
+  vi.mocked(Agent.create).mockResolvedValue(createMockAgent());
+
+  const result = (await bridge.handleRequest("initialize", {
+    workdir: "/test",
+  })) as { serverVersion: string };
+
+  expect(typeof result.serverVersion).toBe("string");
+  expect(result.serverVersion).toBe(CLI_PACKAGE_VERSION);
+});
+
+test("initialize accepts missing clientVersion without error", async () => {
+  const { bridge } = createBridge();
+  vi.mocked(Agent.create).mockResolvedValue(createMockAgent());
+
+  await expect(
+    bridge.handleRequest("initialize", { workdir: "/test" }),
+  ).resolves.toBeDefined();
 });
 
 // ── Callbacks → Notifications ────────────────────────────────────

--- a/packages/code/tests/stdio/stdioServer.test.ts
+++ b/packages/code/tests/stdio/stdioServer.test.ts
@@ -1,6 +1,14 @@
 import { test, expect, vi, beforeEach, afterEach } from "vitest";
 import { PassThrough } from "stream";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import path from "path";
 import { Agent } from "wave-agent-sdk";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI_PACKAGE_VERSION = JSON.parse(
+  readFileSync(path.resolve(__dirname, "../../package.json"), "utf-8"),
+).version as string;
 
 // Mock the Agent SDK
 vi.mock("wave-agent-sdk");
@@ -100,6 +108,7 @@ test("initialize request returns response with sessionId", async () => {
     workingDirectory: "/test/workdir",
     permissionMode: "default",
     latestTotalTokens: 0,
+    serverVersion: CLI_PACKAGE_VERSION,
   });
 
   server.stop();

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
@@ -1,9 +1,12 @@
 package com.wave.jetbrains.session
 
 import com.intellij.ide.BrowserUtil
+import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.wave.jetbrains.config.WavePluginService
+import com.wave.jetbrains.ide.IdeService
 import com.wave.jetbrains.stdio.AgentCallbacks
 import com.wave.jetbrains.stdio.BinaryResolver
 import com.wave.jetbrains.stdio.StdioAgent
@@ -111,6 +114,7 @@ class WaveSession(
                 if (config.model.isNotEmpty()) put("model", config.model)
                 if (config.fastModel.isNotEmpty()) put("fastModel", config.fastModel)
                 put("language", config.language)
+                put("clientVersion", pluginVersion())
             }
             try {
                 a.initialize(params)
@@ -127,6 +131,28 @@ class WaveSession(
                 sessionId = a.sessionId
             }
             permissionMode = a.permissionMode
+            // Version negotiation: if the CLI is older than the plugin, silently upgrade once per activation.
+            val pluginVer = pluginVersion()
+            if (!cliUpgradeAttempted && pluginVer.isNotEmpty() && !a.serverVersion.isNullOrEmpty()) {
+                val cmp = try {
+                    BinaryResolver.compareVersions(a.serverVersion!!, pluginVer)
+                } catch (_: Exception) { 0 }
+                if (cmp < 0) {
+                    cliUpgradeAttempted = true
+                    try {
+                        LOG.info("CLI ${a.serverVersion} < plugin $pluginVer; upgrading wave-code to $pluginVer")
+                        BinaryResolver.upgradeWaveBinary(pluginVer)
+                        // Restart on the new binary: destroy current agent and re-initialize once.
+                        try { a.close() } catch (_: Exception) {}
+                        agent = null
+                        isInitializing = false
+                        return initialize(null)
+                    } catch (e: Exception) {
+                        LOG.error("CLI auto-upgrade failed", e)
+                        IdeService.showError(project, "Wave CLI 升级失败，请手动执行: npm install -g wave-code --registry=https://registry.npmmirror.com")
+                    }
+                }
+            }
             true
         } catch (e: Exception) {
             LOG.error("Failed to initialize wave session", e)
@@ -353,6 +379,12 @@ class WaveSession(
     }
 
     companion object {
+        @Volatile
+        private var cliUpgradeAttempted = false
+
+        fun pluginVersion(): String =
+            PluginManagerCore.getPlugin(PluginId.getId("com.wave.jetbrains"))?.version ?: ""
+
         fun parseHeaders(text: String): JsonObject? {
             if (text.isBlank()) return null
             return try {

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
@@ -10,6 +10,7 @@ import java.io.File
 object BinaryResolver {
     private val LOG = logger<BinaryResolver>()
     private const val PACKAGE = "wave-code"
+    const val NPM_REGISTRY = "https://registry.npmmirror.com"
 
     @Volatile
     private var cachedPath: String? = null
@@ -37,8 +38,8 @@ object BinaryResolver {
 
         // 4. auto-install
         val npm = findNpm()
-        LOG.info("wave not found; running: \"$npm\" install -g $PACKAGE")
-        runCommand(npm, "install", "-g", PACKAGE)
+        LOG.info("wave not found; running: \"$npm\" install -g $PACKAGE --registry=$NPM_REGISTRY")
+        runCommand(npm, "install", "-g", PACKAGE, "--registry=$NPM_REGISTRY")
 
         // 5. recheck global bin
         if (File(globalPath).exists()) return cache(globalPath)
@@ -47,7 +48,19 @@ object BinaryResolver {
         findOnPath(waveName)?.let { return cache(it) }
 
         // 7. fail
-        throw StdioClientException("wave binary not found after installation. Ensure npm global bin is on PATH.")
+        throw StdioClientException("wave binary not found after installation. Install manually: npm install -g $PACKAGE --registry=$NPM_REGISTRY")
+    }
+
+    /**
+     * Upgrade the globally-installed `wave-code` CLI to [targetVersion].
+     * Resets the cached path on success and returns the freshly-resolved binary path.
+     */
+    fun upgradeWaveBinary(targetVersion: String): String {
+        val npm = findNpm()
+        LOG.info("Upgrading $PACKAGE to $targetVersion via: \"$npm\" install -g $PACKAGE@$targetVersion --registry=$NPM_REGISTRY")
+        runCommand(npm, "install", "-g", "$PACKAGE@$targetVersion", "--registry=$NPM_REGISTRY")
+        resetCache()
+        return resolveWaveBinary()
     }
 
     /**
@@ -173,7 +186,7 @@ object BinaryResolver {
      * Leading `v` is stripped, segments compared numerically; missing/unparseable
      * segments count as 0. Returns negative/zero/positive like [Comparator].
      */
-    internal fun compareVersions(a: String, b: String): Int {
+    fun compareVersions(a: String, b: String): Int {
         val sa = a.trimStart('v').split('.').map { it.toIntOrNull() ?: 0 }
         val sb = b.trimStart('v').split('.').map { it.toIntOrNull() ?: 0 }
         val n = maxOf(sa.size, sb.size)

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioAgent.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioAgent.kt
@@ -54,6 +54,8 @@ class StdioAgent(
         private set
     @Volatile var permissionMode: String? = null
         private set
+    @Volatile var serverVersion: String? = null
+        private set
 
     val isDisposed get() = client.disposed
 
@@ -141,11 +143,13 @@ class StdioAgent(
         workingDirectory = res["workingDirectory"]?.jsonPrimitive?.content
         permissionMode = res["permissionMode"]?.jsonPrimitive?.content
         res["latestTotalTokens"]?.jsonPrimitive?.intOrNull?.let { latestTotalTokens = it }
+        res["serverVersion"]?.jsonPrimitive?.content?.let { serverVersion = it }
         return InitializeResult(
             sessionId = sessionId,
             workingDirectory = workingDirectory,
             permissionMode = permissionMode,
             latestTotalTokens = latestTotalTokens,
+            serverVersion = serverVersion,
         )
     }
 
@@ -301,6 +305,7 @@ data class InitializeResult(
     val workingDirectory: String?,
     val permissionMode: String?,
     val latestTotalTokens: Int,
+    val serverVersion: String? = null,
 )
 
 private val JsonPrimitive.intOrNull: Int? get() = content.toIntOrNull()

--- a/packages/vsce/src/chatProvider.ts
+++ b/packages/vsce/src/chatProvider.ts
@@ -17,7 +17,8 @@ import { PluginService } from './services/pluginService';
 import { WebviewManager } from './session/webviewManager';
 import { MessageHandler } from './session/messageHandler';
 import { StdioClient } from './stdio/stdioClient';
-import { resolveWaveBinary } from './stdio/binaryResolver';
+import { resolveWaveBinary, upgradeWaveBinary } from './stdio/binaryResolver';
+import { parseVersion, compareVersions } from './services/updateService';
 
 export class ChatProvider implements vscode.WebviewViewProvider {
     private static formatConfigError(error: unknown): string {
@@ -46,6 +47,7 @@ export class ChatProvider implements vscode.WebviewViewProvider {
     private webviewManager: WebviewManager;
     private messageHandler: MessageHandler;
     private utilityClient: StdioClient | undefined;
+    private cliUpgradeAttempted = false;
 
     constructor(context: vscode.ExtensionContext) {
         this.context = context;
@@ -254,10 +256,33 @@ export class ChatProvider implements vscode.WebviewViewProvider {
             return;
         }
 
+        const clientVersion: string | undefined = this.context.extension.packageJSON?.version;
+        const upgradedThisCall = this.cliUpgradeAttempted;
+
         try {
             const config = await this.configService.loadConfiguration();
-            
-            await session.initialize(config, restoreSessionId);
+            await session.initialize(config, restoreSessionId, clientVersion);
+
+            // Version negotiation: if the CLI is older than the extension, silently
+            // upgrade once per activation and re-initialize.
+            if (!upgradedThisCall && clientVersion && session.agent?.serverVersion) {
+                const client = parseVersion(clientVersion);
+                const server = parseVersion(session.agent.serverVersion);
+                if (client && server && compareVersions(server, client) < 0) {
+                    this.cliUpgradeAttempted = true;
+                    try {
+                        console.log(`[Wave] CLI ${session.agent.serverVersion} < extension ${clientVersion}, upgrading...`);
+                        await upgradeWaveBinary(clientVersion);
+                        await session.destroy();
+                        await session.initialize(config, undefined, clientVersion);
+                    } catch (upgradeError) {
+                        console.error('[Wave] CLI auto-upgrade failed:', upgradeError);
+                        vscode.window.showErrorMessage(
+                            'Wave CLI 升级失败，请手动执行: npm install -g wave-code --registry=https://registry.npmmirror.com',
+                        );
+                    }
+                }
+            }
         } catch (error) {
             console.error(`初始化 ${viewType} 智能体失败:`, error);
             const isConfigError = error && typeof error === 'object' && 'name' in error && error.name === 'ConfigurationError';

--- a/packages/vsce/src/session/chatSession.ts
+++ b/packages/vsce/src/session/chatSession.ts
@@ -63,7 +63,7 @@ export class ChatSession {
         private callbacks: ChatSessionCallbacks
     ) {}
 
-    public async initialize(config: ConfigurationData, restoreSessionId?: string) {
+    public async initialize(config: ConfigurationData, restoreSessionId?: string, clientVersion?: string) {
         if (this.isInitializing) {
             return;
         }
@@ -162,6 +162,7 @@ export class ChatSession {
                 model: config.model,
                 fastModel: config.fastModel,
                 language: config.language,
+                clientVersion,
             };
 
             try {

--- a/packages/vsce/src/stdio/binaryResolver.ts
+++ b/packages/vsce/src/stdio/binaryResolver.ts
@@ -8,9 +8,12 @@
  * Result is cached for the extension lifetime.
  */
 
-import { execSync } from 'child_process';
+import { execSync, execFile } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+
+/** npm registry mirror for China users (faster than the default registry). */
+export const NPM_REGISTRY = 'https://registry.npmmirror.com';
 
 let cachedPath: string | undefined;
 
@@ -80,7 +83,7 @@ export function resolveWaveBinary(): string {
         globalBin = getNpmGlobalBin();
     } catch {
         throw new Error(
-            'Failed to determine npm global directory. Please install wave-code manually: npm install -g wave-code',
+            'Failed to determine npm global directory. Please install wave-code manually: npm install -g wave-code --registry=https://registry.npmmirror.com',
         );
     }
 
@@ -94,7 +97,7 @@ export function resolveWaveBinary(): string {
     // 3. Install globally
     console.log('[Wave] wave binary not found, installing wave-code globally...');
     const npm = findNpm();
-    execSync(`"${npm}" install -g wave-code`, {
+    execSync(`"${npm}" install -g wave-code --registry=${NPM_REGISTRY}`, {
         encoding: 'utf-8',
         stdio: 'pipe',
     });
@@ -117,8 +120,35 @@ export function resolveWaveBinary(): string {
     }
 
     throw new Error(
-        'wave binary not found after installation. Please install manually: npm install -g wave-code',
+        'wave binary not found after installation. Please install manually: npm install -g wave-code --registry=https://registry.npmmirror.com',
     );
+}
+
+/** Reset cached binary path. Public so callers can force re-resolve after an upgrade. */
+export function resetCache(): void {
+    cachedPath = undefined;
+}
+
+/**
+ * Upgrade the globally-installed `wave-code` CLI to a specific version.
+ * Uses `execFile` (not a shell string) to avoid shell injection of the version arg.
+ * Resets the cached path on success and returns the freshly-resolved binary path.
+ */
+export async function upgradeWaveBinary(targetVersion: string): Promise<string> {
+    const npm = findNpm();
+    await new Promise<void>((resolve, reject) => {
+        execFile(
+            npm,
+            ['install', '-g', `wave-code@${targetVersion}`, `--registry=${NPM_REGISTRY}`],
+            { encoding: 'utf-8' },
+            (err) => {
+                if (err) reject(err);
+                else resolve();
+            },
+        );
+    });
+    cachedPath = undefined; // invalidate cache so resolveWaveBinary picks up the new binary
+    return resolveWaveBinary();
 }
 
 /** Reset cached path — for testing only. */

--- a/packages/vsce/src/stdio/stdioAgent.ts
+++ b/packages/vsce/src/stdio/stdioAgent.ts
@@ -42,6 +42,7 @@ export interface InitializeParams {
     disallowedTools?: string[];
     pluginDirs?: string[];
     mcpServers?: Record<string, McpServerConfig>;
+    clientVersion?: string;
 }
 
 export interface InitializeResult {
@@ -49,6 +50,7 @@ export interface InitializeResult {
     workingDirectory: string;
     permissionMode: PermissionMode;
     latestTotalTokens: number;
+    serverVersion?: string;
 }
 
 export interface UpdateConfigParams {
@@ -110,6 +112,7 @@ export class StdioAgent {
     public workingDirectory: string | undefined;
     public latestTotalTokens = 0;
     public permissionMode: PermissionMode | undefined;
+    public serverVersion: string | undefined;
     public messages: Message[] = [];
     public queuedMessages: QueuedMessage[] = [];
     public tasks: Task[] = [];
@@ -136,6 +139,7 @@ export class StdioAgent {
         this.workingDirectory = result.workingDirectory;
         this.permissionMode = result.permissionMode;
         this.latestTotalTokens = result.latestTotalTokens;
+        this.serverVersion = result.serverVersion;
         return result;
     }
 

--- a/packages/vsce/tests/stdio/binaryResolver.test.ts
+++ b/packages/vsce/tests/stdio/binaryResolver.test.ts
@@ -4,10 +4,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mockExecSync = vi.hoisted(() => vi.fn());
 const mockExistsSync = vi.hoisted(() => vi.fn());
+const mockExecFile = vi.hoisted(() => vi.fn());
 
 vi.mock('child_process', () => ({
-    default: { execSync: mockExecSync },
+    default: { execSync: mockExecSync, execFile: mockExecFile },
     execSync: mockExecSync,
+    execFile: mockExecFile,
 }));
 
 vi.mock('fs', () => ({
@@ -17,7 +19,7 @@ vi.mock('fs', () => ({
 
 // ── Import after mocks ─────────────────────────────────────────
 
-import { resolveWaveBinary, _resetCacheForTesting } from '../../src/stdio/binaryResolver';
+import { resolveWaveBinary, _resetCacheForTesting, upgradeWaveBinary, resetCache, NPM_REGISTRY } from '../../src/stdio/binaryResolver';
 
 describe('binaryResolver', () => {
     beforeEach(() => {
@@ -149,5 +151,92 @@ describe('binaryResolver', () => {
         expect(() => resolveWaveBinary()).toThrow(
             'wave binary not found after installation',
         );
+    });
+
+    // ── install-if-missing registry ──────────────────────────────
+
+    it('install-if-missing uses npmmirror registry', async () => {
+        let installCmd = '';
+        mockExecSync.mockImplementation((cmd: string) => {
+            if (cmd.includes('which wave')) {
+                if (installCmd) return '/usr/local/bin/wave\n';
+                throw new Error('not found');
+            }
+            if (cmd.includes('which npm')) return '/usr/bin/npm\n';
+            if (cmd.includes('prefix -g')) return '/usr/local\n';
+            if (cmd.includes('install -g wave-code')) {
+                installCmd = cmd;
+                return '';
+            }
+            throw new Error(`unexpected: ${cmd}`);
+        });
+        mockExistsSync.mockImplementation((p: string) => !!installCmd && p === '/usr/local/bin/wave');
+
+        const result = await resolveWaveBinary();
+        expect(result).toBe('/usr/local/bin/wave');
+        expect(installCmd).toContain(`--registry=${NPM_REGISTRY}`);
+    });
+
+    // ── resetCache ───────────────────────────────────────────────
+
+    it('resetCache clears the cached path', async () => {
+        mockExecSync.mockImplementation((cmd: string) => {
+            if (cmd.includes('which wave')) return '/usr/local/bin/wave\n';
+            throw new Error('unexpected');
+        });
+
+        await resolveWaveBinary();
+        resetCache();
+        await resolveWaveBinary();
+
+        const whichCalls = mockExecSync.mock.calls.filter(
+            (c: unknown[]) => (c[0] as string).includes('which wave'),
+        );
+        expect(whichCalls).toHaveLength(2);
+    });
+
+    // ── upgradeWaveBinary ────────────────────────────────────────
+
+    it('upgradeWaveBinary installs the target version via execFile with npmmirror registry', async () => {
+        mockExecSync.mockImplementation((cmd: string) => {
+            if (cmd.includes('which npm')) return '/usr/bin/npm\n';
+            if (cmd.includes('which wave')) return '/usr/local/bin/wave\n';
+            throw new Error(`unexpected: ${cmd}`);
+        });
+        mockExecFile.mockImplementation((...args: unknown[]) => {
+            const cb = args[args.length - 1] as (err: Error | null) => void;
+            cb(null);
+        });
+
+        const result = await upgradeWaveBinary('1.2.3');
+
+        expect(result).toBe('/usr/local/bin/wave');
+        expect(mockExecFile).toHaveBeenCalledTimes(1);
+        const callArgs = mockExecFile.mock.calls[0];
+        expect(callArgs[0]).toBe('/usr/bin/npm');
+        expect(callArgs[1]).toEqual([
+            'install',
+            '-g',
+            'wave-code@1.2.3',
+            `--registry=${NPM_REGISTRY}`,
+        ]);
+        // cache was invalidated: resolveWaveBinary re-ran `which wave`
+        const whichCalls = mockExecSync.mock.calls.filter(
+            (c: unknown[]) => (c[0] as string).includes('which wave'),
+        );
+        expect(whichCalls).toHaveLength(1);
+    });
+
+    it('upgradeWaveBinary rejects when execFile errors', async () => {
+        mockExecSync.mockImplementation((cmd: string) => {
+            if (cmd.includes('which npm')) return '/usr/bin/npm\n';
+            throw new Error(`unexpected: ${cmd}`);
+        });
+        mockExecFile.mockImplementation((...args: unknown[]) => {
+            const cb = args[args.length - 1] as (err: Error | null) => void;
+            cb(new Error('install failed'));
+        });
+
+        await expect(upgradeWaveBinary('1.2.3')).rejects.toThrow('install failed');
     });
 });

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,11 +1,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
 
 const type = process.argv[2] || 'patch';
 const isAll = process.argv[3] === 'all';
 
-function bumpVersion(pkgPath) {
+export function bumpVersion(pkgPath) {
   const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
   const oldVersion = pkg.version;
   const versionMatch = oldVersion.match(/^(\d+)\.(\d+)\.(\d+)(.*)$/);
@@ -44,47 +45,71 @@ function bumpVersion(pkgPath) {
   return { name: pkg.name, version: newVersion, path: pkgPath };
 }
 
-const results = [];
-if (isAll) {
-  // Bump root
-  const rootPkg = bumpVersion(path.resolve(process.cwd(), 'package.json'));
-  if (rootPkg) results.push(rootPkg);
-
-  // Bump packages
-  const packagesDir = path.resolve(process.cwd(), 'packages');
-  const dirs = fs.readdirSync(packagesDir);
-  for (const dir of dirs) {
-    const pkgPath = path.resolve(packagesDir, dir, 'package.json');
-    if (fs.existsSync(pkgPath)) {
-      const res = bumpVersion(pkgPath);
-      if (res) results.push(res);
-    }
+export function bumpGradleProperties(propsPath, newVersion) {
+  const content = fs.readFileSync(propsPath, 'utf8');
+  const oldMatch = content.match(/^pluginVersion=(.*)$/m);
+  const oldVersion = oldMatch ? oldMatch[1] : '';
+  const replaced = content.replace(/^pluginVersion=.*$/m, `pluginVersion=${newVersion}`);
+  if (replaced !== content) {
+    fs.writeFileSync(propsPath, replaced);
   }
-} else {
-  const res = bumpVersion(path.resolve(process.cwd(), 'package.json'));
-  if (res) results.push(res);
+  console.log(`wave-jetbrains: ${oldVersion} -> ${newVersion}`);
+  return { name: 'wave-jetbrains', version: newVersion, path: propsPath };
 }
 
-if (results.length > 0) {
-  try {
-    execSync('git rev-parse --is-inside-work-tree', { stdio: 'ignore' });
-    for (const res of results) {
-      execSync(`git add ${res.path}`, { stdio: 'inherit' });
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const results = [];
+  if (isAll) {
+    // Bump root
+    const rootPkg = bumpVersion(path.resolve(process.cwd(), 'package.json'));
+    if (rootPkg) results.push(rootPkg);
+
+    // Bump packages
+    const packagesDir = path.resolve(process.cwd(), 'packages');
+    const dirs = fs.readdirSync(packagesDir);
+    for (const dir of dirs) {
+      const pkgPath = path.resolve(packagesDir, dir, 'package.json');
+      if (fs.existsSync(pkgPath)) {
+        const res = bumpVersion(pkgPath);
+        if (res) results.push(res);
+      } else {
+        // Packages without package.json (e.g. jetbrains) may have a gradle.properties
+        // with a pluginVersion= field that must stay in sync with the monorepo version.
+        const propsPath = path.resolve(packagesDir, dir, 'gradle.properties');
+        if (fs.existsSync(propsPath)) {
+          // Use the root package's new version (already bumped above) as the target.
+          const targetVersion = rootPkg.version;
+          const res = bumpGradleProperties(propsPath, targetVersion);
+          if (res) results.push(res);
+        }
+      }
     }
+  } else {
+    const res = bumpVersion(path.resolve(process.cwd(), 'package.json'));
+    if (res) results.push(res);
+  }
 
-    const mainPkg = results[0];
-    const tagName = isAll ? `v${mainPkg.version}` : `v${mainPkg.version}-${mainPkg.name}`;
-    const commitMsg = isAll
-      ? `chore: bump all versions to v${mainPkg.version}`
-      : `chore: bump ${mainPkg.name} to v${mainPkg.version}`;
+  if (results.length > 0) {
+    try {
+      execSync('git rev-parse --is-inside-work-tree', { stdio: 'ignore' });
+      for (const res of results) {
+        execSync(`git add ${res.path}`, { stdio: 'inherit' });
+      }
 
-    execSync(`git commit -m "${commitMsg}" --no-verify`, { stdio: 'inherit' });
+      const mainPkg = results[0];
+      const tagName = isAll ? `v${mainPkg.version}` : `v${mainPkg.version}-${mainPkg.name}`;
+      const commitMsg = isAll
+        ? `chore: bump all versions to v${mainPkg.version}`
+        : `chore: bump ${mainPkg.name} to v${mainPkg.version}`;
 
-    execSync(`git tag -a ${tagName} -m "${commitMsg.replace(/"/g, '\\"')}"`, { stdio: 'inherit' });
-    console.log(`Created tag: ${tagName}`);
-    console.log(`\nTo publish this version, run:\n  git push origin ${tagName}\n`);
-  } catch (error) {
-    console.error('Git operation failed:', error.message);
-    process.exit(1);
+      execSync(`git commit -m "${commitMsg}" --no-verify`, { stdio: 'inherit' });
+
+      execSync(`git tag -a ${tagName} -m "${commitMsg.replace(/"/g, '\\"')}"`, { stdio: 'inherit' });
+      console.log(`Created tag: ${tagName}`);
+      console.log(`\nTo publish this version, run:\n  git push origin ${tagName}\n`);
+    } catch (error) {
+      console.error('Git operation failed:', error.message);
+      process.exit(1);
+    }
   }
 }

--- a/scripts/version.test.mjs
+++ b/scripts/version.test.mjs
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import { bumpVersion, bumpGradleProperties } from './version.js';
+
+describe('version.js', () => {
+  let readSpy;
+  let writeSpy;
+
+  beforeEach(() => {
+    readSpy = vi.spyOn(fs, 'readFileSync');
+    writeSpy = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('bumpVersion', () => {
+    it('bumps a patch version and writes the updated package.json', () => {
+      const pkg = { name: 'demo-pkg', version: '1.0.0' };
+      readSpy.mockReturnValue(JSON.stringify(pkg));
+
+      const result = bumpVersion('/fake/package.json');
+
+      expect(result).toEqual({
+        name: 'demo-pkg',
+        version: '1.0.1',
+        path: '/fake/package.json',
+      });
+      expect(writeSpy).toHaveBeenCalledTimes(1);
+      const [, written] = writeSpy.mock.calls[0];
+      expect(JSON.parse(written).version).toBe('1.0.1');
+    });
+
+    it('returns null for an invalid version format without writing', () => {
+      readSpy.mockReturnValue(JSON.stringify({ name: 'bad', version: 'not-a-version' }));
+
+      const result = bumpVersion('/fake/package.json');
+
+      expect(result).toBeNull();
+      expect(writeSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('bumpGradleProperties', () => {
+    it('replaces the pluginVersion line and returns the expected shape', () => {
+      const original =
+        'pluginGroup=com.wave.jetbrains\n' +
+        'pluginName=Wave\n' +
+        'pluginVersion=0.1.0\n' +
+        '\n' +
+        'platformType=IC\n';
+      readSpy.mockReturnValue(original);
+
+      const result = bumpGradleProperties('/fake/gradle.properties', '0.2.0');
+
+      expect(result).toEqual({
+        name: 'wave-jetbrains',
+        version: '0.2.0',
+        path: '/fake/gradle.properties',
+      });
+      expect(writeSpy).toHaveBeenCalledTimes(1);
+      const [destPath, written] = writeSpy.mock.calls[0];
+      expect(destPath).toBe('/fake/gradle.properties');
+      expect(written).toContain('pluginVersion=0.2.0');
+      // Other lines preserved.
+      expect(written).toContain('pluginGroup=com.wave.jetbrains');
+      expect(written).toContain('pluginName=Wave');
+      expect(written).toContain('platformType=IC');
+      // Only one pluginVersion line in the output.
+      expect(written.match(/^pluginVersion=/gm).length).toBe(1);
+    });
+
+    it('skips writing when the version is already the target', () => {
+      const original = 'pluginVersion=0.2.0\n';
+      readSpy.mockReturnValue(original);
+
+      const result = bumpGradleProperties('/fake/gradle.properties', '0.2.0');
+
+      expect(result).toEqual({
+        name: 'wave-jetbrains',
+        version: '0.2.0',
+        path: '/fake/gradle.properties',
+      });
+      expect(writeSpy).not.toHaveBeenCalled();
+    });
+
+    it('handles a missing pluginVersion line by still writing the new line', () => {
+      const original = 'pluginGroup=com.wave.jetbrains\n';
+      readSpy.mockReturnValue(original);
+
+      const result = bumpGradleProperties('/fake/gradle.properties', '0.3.0');
+
+      expect(result.version).toBe('0.3.0');
+      // No pluginVersion= line existed, so the regex replace produces no change;
+      // the function should not write in that case.
+      expect(writeSpy).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add version negotiation to the IDE plugin ↔ wave CLI stdio handshake, and make the **plugin drive silent auto-upgrades** of the CLI when it detects the CLI is older than itself. Wave's architecture (plugin is host, spawns `wave --stdio`) is the inverse of Claude Code (CLI-led, plugin as MCP server), so the plugin must own the upgrade — without this, a plugin upgrade over a stale CLI would pass the versionless handshake and crash/misbehave at runtime.

Also unifies the JetBrains plugin version with the monorepo so the comparison is meaningful.

## Changes

### Part 1 — Handshake version fields (optional, progressive upgrade)
- **CLI** (`agentBridge.ts`): `InitializeParams` + `clientVersion?`; `initialize()` returns `serverVersion` read from `packages/code/package.json`. Server only logs `clientVersion`, never rejects.
- **VSCE** (`stdioAgent.ts`): `InitializeParams` + `clientVersion?`, `InitializeResult` + `serverVersion?`, cached `this.serverVersion`.
- **JetBrains** (`StdioAgent.kt`): reads `serverVersion` from response, adds to `InitializeResult` + cached `@Volatile var`.

### Part 2 — Plugin-driven silent auto-upgrade
On first session init, compare `serverVersion` vs `clientVersion`; if the CLI is older, run `npm install -g wave-code@<pluginVersion> --registry=https://registry.npmmirror.com`, then destroy + re-initialize the session on the new binary. A per-activation flag (`cliUpgradeAttempted`) prevents loops. Failure degrades to an error notification with the manual command.
- **VSCE**: `binaryResolver.ts` adds `NPM_REGISTRY`, `upgradeWaveBinary()` via `execFile` (no shell injection), public `resetCache()`, `--registry` on install-if-missing; `chatProvider.ts` compares via `parseVersion`/`compareVersions` and upgrades.
- **JetBrains**: `BinaryResolver.kt` adds `NPM_REGISTRY`, `upgradeWaveBinary()`, public `compareVersions()`, `--registry` on install; `WaveSession.kt` compares, upgrades, re-inits, shows `IdeService.showError` on failure.
- All install paths (first-install + upgrade + manual-recovery hints) now use the China npm mirror.

### Part 3 — Unified version bump
- `scripts/version.js` `all` mode now bumps `packages/jetbrains/gradle.properties` `pluginVersion` to match the root version. Previously jetbrains was silently skipped (no `package.json`), leaving its `0.1.0` out of sync with the CLI and making `clientVersion`/`serverVersion` comparison meaningless. Made `bumpVersion`/`bumpGradleProperties` exported + ESM direct-run guard for testability.

## Test plan
- [x] `packages/code` agentBridge tests: 79 pass (2 new: `serverVersion` returned, missing `clientVersion` doesn't break)
- [x] `packages/vsce` binaryResolver tests: 11 pass (4 new: registry flag, `resetCache`, `upgradeWaveBinary` success/error)
- [x] `scripts/version.test.mjs`: 5 pass (`bumpVersion`, `bumpGradleProperties`)
- [x] JetBrains `./gradlew compileKotlin`: BUILD SUCCESSFUL
- [x] `pnpm run type-check`: clean (sdk, code, webview, vsce)
- [ ] Manual end-to-end: temporarily set VSCE `package.json` to `0.99.0`, `F5`, open chat → should attempt `npm install -g wave-code@0.99.0` (expected to fail, no such version) → degrade to error notification, session stays up.
- [ ] Manual positive: install old CLI, new plugin → upgrade succeeds → re-init → versions match.