### PR TITLE
ci: add non-blocking Windows compatibility check

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -43,5 +43,19 @@ jobs:
       # upstream tooling issue unrelated to this repo's code. Coverage is
       # already enforced by the Linux CI (required check). Windows only needs
       # to verify the tests themselves pass cross-platform.
-      - name: CI (no coverage)
-        run: pnpm -r --parallel type-check && pnpm -r --parallel lint && pnpm -r test
+      #
+      # Tests are invoked per-package via `pnpm --filter <pkg> exec vitest run`
+      # rather than `pnpm -r test`. The latter runs each package's `test`
+      # script (which uses `--reporter=dot`); under pnpm's child-process
+      # management on Windows the dot reporter's stdout buffering causes the
+      # agent-sdk vitest process to crash silently right after emitting "RUN".
+      # Calling `vitest run` directly (default reporter) is the invocation
+      # pattern proven to run all 3221 agent-sdk tests green on Windows.
+      - name: Type-check & lint
+        run: pnpm -r --parallel type-check && pnpm -r --parallel lint
+      - name: Tests
+        run: |
+          pnpm --filter wave-agent-sdk exec vitest run &&
+          pnpm --filter wave-code exec vitest run &&
+          pnpm --filter wave-vsce exec vitest run &&
+          pnpm --filter wave-webview exec vitest run

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -40,13 +40,9 @@ jobs:
       - name: CI
         run: pnpm run ci
 
-      # TEMP: diagnose agent-sdk test:coverage silent failure on Windows.
-      # Step 1: run tests WITHOUT coverage to isolate whether v8 coverage
-      # provider is the culprit. Step 2: run WITH coverage but default reporter.
-      # Remove once root cause is fixed.
-      - name: Diagnose agent-sdk tests (no coverage)
+      # TEMP diagnosis: agent-sdk tests have Unix-path hardcoding that fails on
+      # Windows. This verbose step (no coverage) surfaces every failing assertion
+      # so we can iterate. Remove once all agent-sdk tests pass on Windows.
+      - name: Diagnose agent-sdk tests (verbose)
         if: always()
         run: pnpm --filter wave-agent-sdk exec vitest run --reporter=verbose
-      - name: Diagnose agent-sdk tests (with coverage, verbose)
-        if: always()
-        run: pnpm --filter wave-agent-sdk exec vitest run --coverage --reporter=verbose

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -37,12 +37,11 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: CI
-        run: pnpm run ci
-
-      # TEMP diagnosis: agent-sdk tests have Unix-path hardcoding that fails on
-      # Windows. This verbose step (no coverage) surfaces every failing assertion
-      # so we can iterate. Remove once all agent-sdk tests pass on Windows.
-      - name: Diagnose agent-sdk tests (verbose)
-        if: always()
-        run: pnpm --filter wave-agent-sdk exec vitest run --reporter=verbose
+      # Run type-check + lint + tests WITHOUT coverage on Windows.
+      # The v8 coverage provider crashes silently on Windows (process exits
+      # right after "Coverage enabled with v8" with no output), which is an
+      # upstream tooling issue unrelated to this repo's code. Coverage is
+      # already enforced by the Linux CI (required check). Windows only needs
+      # to verify the tests themselves pass cross-platform.
+      - name: CI (no coverage)
+        run: pnpm -r --parallel type-check && pnpm -r --parallel lint && pnpm -r test

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -41,8 +41,12 @@ jobs:
         run: pnpm run ci
 
       # TEMP: diagnose agent-sdk test:coverage silent failure on Windows.
-      # Runs agent-sdk tests in isolation with verbose reporter so output
-      # is not swallowed by pnpm --parallel. Remove once root cause is fixed.
-      - name: Diagnose agent-sdk tests (verbose)
+      # Step 1: run tests WITHOUT coverage to isolate whether v8 coverage
+      # provider is the culprit. Step 2: run WITH coverage but default reporter.
+      # Remove once root cause is fixed.
+      - name: Diagnose agent-sdk tests (no coverage)
         if: always()
-        run: pnpm --filter wave-agent-sdk test:coverage -- --reporter=verbose
+        run: pnpm --filter wave-agent-sdk exec vitest run --reporter=verbose
+      - name: Diagnose agent-sdk tests (with coverage, verbose)
+        if: always()
+        run: pnpm --filter wave-agent-sdk exec vitest run --coverage --reporter=verbose

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -39,3 +39,10 @@ jobs:
 
       - name: CI
         run: pnpm run ci
+
+      # TEMP: diagnose agent-sdk test:coverage silent failure on Windows.
+      # Runs agent-sdk tests in isolation with verbose reporter so output
+      # is not swallowed by pnpm --parallel. Remove once root cause is fixed.
+      - name: Diagnose agent-sdk tests (verbose)
+        if: always()
+        run: pnpm --filter wave-agent-sdk test:coverage -- --reporter=verbose

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,0 +1,41 @@
+name: CI (Windows)
+
+# Non-blocking Windows compatibility check.
+# Runs in parallel with the main Linux CI but is NOT a required check —
+# failures surface in the PR checks list (visible) but do not block merge.
+# Configure in repo Settings → Branches → main protection rule:
+# keep only the Linux `check` job as required; do NOT add `check-windows`.
+
+on:
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-windows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: CI
+        run: pnpm run ci

--- a/packages/agent-sdk/scripts/install_ripgrep.js
+++ b/packages/agent-sdk/scripts/install_ripgrep.js
@@ -16,7 +16,7 @@ async function main() {
   }
 
   const manifestContent = fs.readFileSync(MANIFEST_PATH, "utf-8");
-  const jsonContent = manifestContent.replace(/^#!.*\n/, "");
+  const jsonContent = manifestContent.replace(/^#!.*\r?\n/, "");
   const manifest = JSON.parse(jsonContent);
   const platforms = manifest.platforms;
 

--- a/packages/agent-sdk/src/tools/lspTool.ts
+++ b/packages/agent-sdk/src/tools/lspTool.ts
@@ -2,7 +2,7 @@ import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
 import { relative, join, isAbsolute } from "path";
 import * as fs from "fs";
 import { logger } from "../utils/globalLogger.js";
-import { getDisplayPath } from "../utils/path.js";
+import { getDisplayPath, toPosixPath } from "../utils/path.js";
 import { LSP_TOOL_NAME } from "../constants/tools.js";
 import type {
   LspLocation as Location,
@@ -45,10 +45,10 @@ function formatUri(uri: string, workdir?: string): string {
       relativePath.length < path.length &&
       !relativePath.startsWith("../../")
     ) {
-      return relativePath;
+      return toPosixPath(relativePath);
     }
   }
-  return path;
+  return toPosixPath(path);
 }
 
 /**

--- a/packages/agent-sdk/src/utils/path.ts
+++ b/packages/agent-sdk/src/utils/path.ts
@@ -24,10 +24,16 @@ export function resolvePath(filePath: string, workdir: string): string {
 }
 
 /**
- * Get relative path for display, use relative path if shorter and not in parent directory
+ * Get relative path for display, use relative path if shorter and not in parent directory.
+ *
+ * The returned path is always normalized to forward slashes (posix) regardless of
+ * platform. This keeps display output consistent across Windows/Unix so that logs,
+ * LLM context, and tests don't need platform-specific branches — `path.relative`
+ * and `path.join` produce backslashes on Windows, which we collapse here.
+ *
  * @param filePath Absolute path
  * @param workdir Working directory
- * @returns Path for display (relative or absolute)
+ * @returns Path for display (relative or absolute), always forward-slash
  */
 export function getDisplayPath(filePath: string, workdir: string): string {
   if (!filePath) {
@@ -47,12 +53,12 @@ export function getDisplayPath(filePath: string, workdir: string): string {
       relativePath.length < filePath.length &&
       !relativePath.startsWith("..")
     ) {
-      return relativePath;
+      return toPosixPath(relativePath);
     }
   } catch {
     // If calculating the relative path fails, keep the original path
   }
-  return filePath;
+  return toPosixPath(filePath);
 }
 
 /**

--- a/packages/agent-sdk/src/utils/pathEncoder.ts
+++ b/packages/agent-sdk/src/utils/pathEncoder.ts
@@ -86,8 +86,14 @@ export class PathEncoder {
     // Convert to safe directory name
     let encoded = pathToEncode;
 
-    // Remove leading slash to avoid empty directory names
-    if (encoded.startsWith("/")) {
+    // Remove Windows drive letter prefix (e.g. "D:") so encoded names are
+    // stable across platforms — path.resolve("/home/user/project") yields
+    // "D:\home\user\project" on Windows and we want the same encoded name
+    // as on Linux ("home-user-project").
+    encoded = encoded.replace(/^[a-zA-Z]:/, "");
+
+    // Remove leading slash/backslash to avoid empty directory names
+    if (encoded.startsWith("/") || encoded.startsWith("\\")) {
       encoded = encoded.substring(1);
     }
 

--- a/packages/agent-sdk/tests/integration/subagentPermission.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/subagentPermission.integration.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import path from "node:path";
 import { SubagentManager } from "../../src/managers/subagentManager.js";
 import { ToolManager } from "../../src/managers/toolManager.js";
 import { PermissionManager } from "../../src/managers/permissionManager.js";
@@ -183,8 +184,11 @@ describe("Subagent Permission Integration", () => {
     );
     expect(subagentPermissionManager.getAllowedRules()).toContain("git:*");
     expect(subagentPermissionManager.getDeniedRules()).toContain("Bash(rm *)");
+    // Source resolves additionalDirectories via path.resolve; "/tmp/other" is absolute
+    // so source does path.resolve("/tmp/other") which yields /tmp/other on Linux and
+    // D:\tmp\other on Windows. Mirror the transformation in the assertion.
     expect(subagentPermissionManager.getAdditionalDirectories()).toContain(
-      "/tmp/other",
+      path.resolve("/tmp/other"),
     );
     expect(subagentPermissionManager.getPlanFilePath()).toBe(
       "/tmp/test/plan.md",

--- a/packages/agent-sdk/tests/integration/subagentPermissionSync.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/subagentPermissionSync.integration.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import path from "node:path";
 import { SubagentManager } from "../../src/managers/subagentManager.js";
 import { ToolManager } from "../../src/managers/toolManager.js";
 import { PermissionManager } from "../../src/managers/permissionManager.js";
@@ -127,7 +128,11 @@ describe("Subagent Permission Sync", () => {
     parentPermissionManager.updateAdditionalDirectories(["/tmp/other"]);
 
     // Subagent should have synced
-    expect(subagentPm.getAdditionalDirectories()).toEqual(["/tmp/other"]);
+    // Source resolves additionalDirectories via path.resolve, which yields
+    // /tmp/other on Linux and D:\tmp\other on Windows. Mirror the transformation.
+    expect(subagentPm.getAdditionalDirectories()).toEqual([
+      path.resolve("/tmp/other"),
+    ]);
   });
 
   it("should sync to multiple running subagents", async () => {
@@ -193,6 +198,9 @@ describe("Subagent Permission Sync", () => {
 
     expect(subagentPm.getAllowedRules()).toEqual(["git:*"]);
     expect(subagentPm.getDeniedRules()).toEqual(["Bash(rm *)"]);
-    expect(subagentPm.getAdditionalDirectories()).toEqual(["/tmp/shared"]);
+    // Source resolves additionalDirectories via path.resolve; mirror transformation.
+    expect(subagentPm.getAdditionalDirectories()).toEqual([
+      path.resolve("/tmp/shared"),
+    ]);
   });
 });

--- a/packages/agent-sdk/tests/integration/subagentTaskSharing.test.ts
+++ b/packages/agent-sdk/tests/integration/subagentTaskSharing.test.ts
@@ -4,6 +4,7 @@ import {
   taskGetTool,
 } from "../../src/tools/taskManagementTools.js";
 import { promises as fs } from "fs";
+import * as path from "path";
 import { TaskManager } from "../../src/services/taskManager.js";
 import type { ToolContext } from "../../src/tools/types.js";
 import { Container } from "../../src/utils/container.js";
@@ -52,17 +53,24 @@ describe("Subagent Task Sharing Integration Tests", () => {
       return content;
     });
 
-    vi.mocked(fs.readdir).mockImplementation(async (path) => {
-      const dirPath = path.toString();
+    vi.mocked(fs.readdir).mockImplementation(async (p) => {
+      const dirPath = p.toString();
+      // Source builds paths with path.join (backslash on Windows), so strip
+      // either separator when deriving the entry name from the stored path.
       const files = Array.from(virtualFs.keys())
-        .filter((p) => p.startsWith(dirPath))
-        .map((p) => p.replace(dirPath + "/", ""));
+        .filter(
+          (key) =>
+            key.startsWith(dirPath + path.sep) ||
+            key.startsWith(dirPath + "/") ||
+            key.startsWith(dirPath + "\\"),
+        )
+        .map((key) => key.slice(dirPath.length).replace(/^[\\/]/, ""));
 
       return files as unknown as Awaited<ReturnType<typeof fs.readdir>>;
     });
 
-    vi.mocked(fs.unlink).mockImplementation(async (path) => {
-      virtualFs.delete(path.toString());
+    vi.mocked(fs.unlink).mockImplementation(async (p) => {
+      virtualFs.delete(p.toString());
     });
   });
 

--- a/packages/agent-sdk/tests/integration/taskManagement.test.ts
+++ b/packages/agent-sdk/tests/integration/taskManagement.test.ts
@@ -6,6 +6,7 @@ import {
   taskListTool,
 } from "../../src/tools/taskManagementTools.js";
 import { promises as fs } from "fs";
+import * as path from "path";
 import { TaskManager } from "../../src/services/taskManager.js";
 import type { ToolContext } from "../../src/tools/types.js";
 import { Container } from "../../src/utils/container.js";
@@ -59,11 +60,18 @@ describe("Task Management Integration Tests", () => {
       return content;
     });
 
-    vi.mocked(fs.readdir).mockImplementation(async (path) => {
-      const dirPath = path.toString();
+    vi.mocked(fs.readdir).mockImplementation(async (p) => {
+      const dirPath = p.toString();
+      // Source builds paths with path.join (backslash on Windows), so strip
+      // either separator when deriving the entry name from the stored path.
       const files = Array.from(virtualFs.keys())
-        .filter((p) => p.startsWith(dirPath))
-        .map((p) => p.replace(dirPath + "/", ""));
+        .filter(
+          (key) =>
+            key.startsWith(dirPath + path.sep) ||
+            key.startsWith(dirPath + "/") ||
+            key.startsWith(dirPath + "\\"),
+        )
+        .map((key) => key.slice(dirPath.length).replace(/^[\\/]/, ""));
 
       return files as unknown as Awaited<ReturnType<typeof fs.readdir>>;
     });

--- a/packages/agent-sdk/tests/managers/lspManager.test.ts
+++ b/packages/agent-sdk/tests/managers/lspManager.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as path from "path";
 import { LspManager } from "../../src/managers/lspManager.js";
 import { Container } from "../../src/utils/container.js";
 import { spawn, ChildProcess } from "child_process";
@@ -281,7 +282,7 @@ describe("LspManager (Mocked)", () => {
 
   it("should load config from .lsp.json", async () => {
     const workdir = "/mock/workdir";
-    const lspJsonPath = "/mock/workdir/.lsp.json";
+    const lspJsonPath = path.join(workdir, ".lsp.json");
     const mockConfig = {
       python: {
         command: "pyright-langserver",

--- a/packages/agent-sdk/tests/managers/messageManager.coverage.test.ts
+++ b/packages/agent-sdk/tests/managers/messageManager.coverage.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as path from "path";
 import { MessageManager } from "../../src/managers/messageManager.js";
 import * as sessionService from "../../src/services/session.js";
 import { Container } from "../../src/utils/container.js";
@@ -452,7 +453,9 @@ describe("MessageManager Coverage Improvements", () => {
             type: "tool" as const,
             name: "Read",
             stage: "end" as const,
-            parameters: JSON.stringify({ file_path: "src/index.ts" }),
+            parameters: JSON.stringify({
+              file_path: path.join("src", "index.ts"),
+            }),
             result: "file contents",
           },
         ],

--- a/packages/agent-sdk/tests/managers/permissionManager.safeZone.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.safeZone.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import path from "node:path";
 import { PermissionManager } from "../../src/managers/permissionManager.js";
 import { Container } from "../../src/utils/container.js";
 import type { ToolPermissionContext } from "../../src/types/permissions.js";
@@ -90,15 +91,23 @@ describe("PermissionManager - Safe Zone anchored to original workdir", () => {
 
       manager.updateAdditionalDirectories(["./config", "./data"]);
 
-      expect(manager.getAdditionalDirectories()).toContain("/a/config");
-      expect(manager.getAdditionalDirectories()).toContain("/a/data");
+      // Source resolves relative dirs via path.resolve(workdir, dir); mirror that
+      // so the assertion matches on both Linux (/a/config) and Windows (D:\a\config).
+      expect(manager.getAdditionalDirectories()).toContain(
+        path.resolve("/a", "config"),
+      );
+      expect(manager.getAdditionalDirectories()).toContain(
+        path.resolve("/a", "data"),
+      );
 
       // Change workdir
       container.register("Workdir", "/a/frontend");
 
       // Update additional directories - should still resolve against /a
       manager.updateAdditionalDirectories(["./shared"]);
-      expect(manager.getAdditionalDirectories()).toContain("/a/shared");
+      expect(manager.getAdditionalDirectories()).toContain(
+        path.resolve("/a", "shared"),
+      );
     });
 
     it("should consider files in additional directories as safe after workdir changes", async () => {
@@ -135,8 +144,9 @@ describe("PermissionManager - Safe Zone anchored to original workdir", () => {
       manager.addSystemAdditionalDirectory("./system-data");
 
       const dirs = manager.getSystemAdditionalDirectories();
-      expect(dirs).toContain("/a/system-config");
-      expect(dirs).toContain("/a/system-data");
+      // Source resolves via path.resolve(workdir, dir); mirror in assertion.
+      expect(dirs).toContain(path.resolve("/a", "system-config"));
+      expect(dirs).toContain(path.resolve("/a", "system-data"));
     });
   });
 });

--- a/packages/agent-sdk/tests/managers/permissionManager.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.test.ts
@@ -1622,9 +1622,15 @@ describe("PermissionManager", () => {
       });
 
       it("should set hidePersistentOption for out-of-bounds cd", () => {
+        // Source resolves "cd .." via path.resolve(workdir, ".."), which yields
+        // /home/user on Linux and D:\home\user on Windows. Compare the realpathSync
+        // arg against path.resolve(workdir, "..") so the mock distinguishes the
+        // parent (out-of-bounds) from the workdir on both platforms.
         vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
-          if (p.toString() === "/home/user") return "/home/user";
-          return "/home/user/project";
+          const resolved = path.resolve(p.toString());
+          const parent = path.resolve(workdir, "..");
+          if (resolved === parent) return parent;
+          return path.resolve(workdir);
         });
 
         const context = permissionManager.createContext(
@@ -1980,10 +1986,14 @@ describe("PermissionManager", () => {
     });
 
     it("should deny 'cd ..' if it goes outside workdir", async () => {
+      // Source resolves "cd .." via path.resolve(workdir, ".."). Mirror that
+      // so the mock distinguishes the parent (out-of-bounds) from the workdir
+      // on both Linux (/home/user) and Windows (D:\home\user).
       vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
-        const pathStr = p.toString();
-        if (pathStr === "/home/user") return "/home/user";
-        return "/home/user/project";
+        const resolved = path.resolve(p.toString());
+        const parent = path.resolve(workdir, "..");
+        if (resolved === parent) return parent;
+        return path.resolve(workdir);
       });
 
       const context: ToolPermissionContext = {

--- a/packages/agent-sdk/tests/managers/pluginManager.test.ts
+++ b/packages/agent-sdk/tests/managers/pluginManager.test.ts
@@ -151,14 +151,14 @@ describe("PluginManager", () => {
       );
       expect(mockLspManager.registerServer).toHaveBeenCalledWith("go", {
         ...lspConfig.go,
-        pluginRoot: "/test/workdir/plugins/test-plugin",
+        pluginRoot: path.resolve(workdir, configs[0].path),
       });
       expect(mockMcpManager.addServer).toHaveBeenCalledWith("test", {
         ...mcpConfig.mcpServers.test,
-        pluginRoot: "/test/workdir/plugins/test-plugin",
+        pluginRoot: path.resolve(workdir, configs[0].path),
       });
       expect(mockHookManager.registerPluginHooks).toHaveBeenCalledWith(
-        "/test/workdir/plugins/test-plugin",
+        path.resolve(workdir, configs[0].path),
         hooksConfig,
       );
 
@@ -339,9 +339,10 @@ describe("PluginManager", () => {
         enabledPlugins,
       );
 
+      const localPluginPath = path.resolve(workdir, configs[0].path);
       vi.mocked(PluginLoader.loadManifest).mockImplementation(
         async function (p) {
-          if (p.includes("plugins/test-plugin")) {
+          if (p === localPluginPath) {
             return localManifest as PluginManifest;
           }
           return marketplaceManifest as PluginManifest;

--- a/packages/agent-sdk/tests/managers/skillManager.test.ts
+++ b/packages/agent-sdk/tests/managers/skillManager.test.ts
@@ -8,6 +8,7 @@ import type {
   Skill,
 } from "../../src/types/index.js";
 import { readdir, stat } from "fs/promises";
+import * as path from "path";
 import { logger } from "../../src/utils/globalLogger.js";
 import { FileWatcherService } from "../../src/services/fileWatcher.js";
 
@@ -105,7 +106,7 @@ describe("SkillManager", () => {
   describe("initialize", () => {
     it("should discover builtin, personal and project skills successfully", async () => {
       vi.mocked(readdir).mockImplementation(async (path) => {
-        const p = path.toString();
+        const p = path.toString().replace(/\\/g, "/");
         if (p.includes("builtin-skills")) {
           return [
             { name: "builtin1", isDirectory: () => true },
@@ -154,7 +155,7 @@ describe("SkillManager", () => {
 
     it("should return skill metadata by name", async () => {
       vi.mocked(readdir).mockImplementation(async (path) => {
-        if (path.toString().includes(".wave/skills")) {
+        if (path.toString().replace(/\\/g, "/").includes(".wave/skills")) {
           return [
             { name: "skill1", isDirectory: () => true },
           ] as unknown as Awaited<ReturnType<typeof readdir>>;
@@ -191,7 +192,7 @@ describe("SkillManager", () => {
 
     it("should handle discovery errors and log warnings", async () => {
       vi.mocked(readdir).mockImplementation(async (path) => {
-        const p = path.toString();
+        const p = path.toString().replace(/\\/g, "/");
         if (p.includes(".wave/skills") || p.includes("builtin-skills")) {
           return [
             { name: "invalid-skill", isDirectory: () => true },
@@ -284,7 +285,7 @@ describe("SkillManager", () => {
 
     it("should handle invalid skill files", async () => {
       vi.mocked(readdir).mockImplementation(async (path) => {
-        const p = path.toString();
+        const p = path.toString().replace(/\\/g, "/");
         if (p.includes(".wave/skills") || p.includes("builtin-skills")) {
           return [
             { name: "bad-skill", isDirectory: () => true },
@@ -434,7 +435,7 @@ describe("SkillManager", () => {
   describe("loadSkill", () => {
     it("should load skill from skillContent map", async () => {
       vi.mocked(readdir).mockImplementation(async (path) => {
-        if (path.toString().includes(".wave/skills")) {
+        if (path.toString().replace(/\\/g, "/").includes(".wave/skills")) {
           return [
             { name: "skill1", isDirectory: () => true },
           ] as unknown as Awaited<ReturnType<typeof readdir>>;
@@ -847,11 +848,11 @@ describe("SkillManager", () => {
 
       expect(FileWatcherService).toHaveBeenCalled();
       expect(mockFileWatcher.watchFile).toHaveBeenCalledWith(
-        expect.stringContaining(".wave/skills"),
+        expect.stringMatching(/[/\\]\.wave[/\\]skills$/),
         expect.any(Function),
       );
       expect(mockFileWatcher.watchFile).toHaveBeenCalledWith(
-        expect.stringContaining("/test/workdir/.wave/skills"),
+        expect.stringContaining(path.join("/test/workdir", ".wave", "skills")),
         expect.any(Function),
       );
     });
@@ -888,7 +889,7 @@ describe("SkillManager", () => {
 
       // Mock readdir to return a new skill after refresh
       vi.mocked(readdir).mockImplementation(async (path) => {
-        if (path.toString().includes(".wave/skills")) {
+        if (path.toString().replace(/\\/g, "/").includes(".wave/skills")) {
           return [
             { name: "new-skill", isDirectory: () => true },
           ] as unknown as Awaited<ReturnType<typeof readdir>>;
@@ -1018,7 +1019,7 @@ describe("SkillManager", () => {
       });
 
       vi.mocked(readdir).mockImplementation(async (path) => {
-        const p = path.toString();
+        const p = path.toString().replace(/\\/g, "/");
         if (p === "/test/workdir/.claude/skills") {
           return [
             { name: "claude-skill", isDirectory: () => true },
@@ -1101,7 +1102,7 @@ describe("SkillManager", () => {
       });
 
       vi.mocked(readdir).mockImplementation(async (path) => {
-        const p = path.toString();
+        const p = path.toString().replace(/\\/g, "/");
         if (
           p === "/test/workdir/.claude/skills" ||
           p === "/test/workdir/.wave/skills"
@@ -1171,7 +1172,9 @@ describe("SkillManager", () => {
         (call: unknown[]) => call[0] as string,
       );
 
-      expect(watchedPaths).toContain("/test/workdir/.claude/skills");
+      expect(watchedPaths).toContain(
+        path.join("/test/workdir", ".claude", "skills"),
+      );
       expect(watchedPaths).toContain("/home/user/.claude/skills");
 
       await manager.destroy();
@@ -1183,7 +1186,7 @@ describe("SkillManager", () => {
       });
 
       vi.mocked(readdir).mockImplementation(async (path) => {
-        const p = path.toString();
+        const p = path.toString().replace(/\\/g, "/");
         if (p === "/test/workdir/.agents/skills") {
           return [
             { name: "agents-skill", isDirectory: () => true },
@@ -1266,7 +1269,7 @@ describe("SkillManager", () => {
       });
 
       vi.mocked(readdir).mockImplementation(async (path) => {
-        const p = path.toString();
+        const p = path.toString().replace(/\\/g, "/");
         if (
           p === "/test/workdir/.agents/skills" ||
           p === "/test/workdir/.wave/skills"
@@ -1328,7 +1331,7 @@ describe("SkillManager", () => {
       });
 
       vi.mocked(readdir).mockImplementation(async (path) => {
-        const p = path.toString();
+        const p = path.toString().replace(/\\/g, "/");
         if (
           p === "/test/workdir/.agents/skills" ||
           p === "/test/workdir/.claude/skills"
@@ -1462,7 +1465,9 @@ describe("SkillManager", () => {
         (call: unknown[]) => call[0] as string,
       );
 
-      expect(watchedPaths).toContain("/test/workdir/.agents/skills");
+      expect(watchedPaths).toContain(
+        path.join("/test/workdir", ".agents", "skills"),
+      );
       expect(watchedPaths).toContain("/home/user/.agents/skills");
 
       await manager.destroy();

--- a/packages/agent-sdk/tests/managers/subagentManager.sessions.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.sessions.test.ts
@@ -175,7 +175,7 @@ describe("SubagentManager - Session Functionality", () => {
       expect(transcriptPath).toMatch(
         /[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.jsonl$/,
       );
-      expect(transcriptPath).toContain("/mock/session/dir/");
+      expect(transcriptPath).toMatch(/[/\\]mock[/\\]session[/\\]dir[/\\]/);
     });
 
     it("should save subagent sessions using appendMessages function", async () => {

--- a/packages/agent-sdk/tests/services/MarketplaceService.git.test.ts
+++ b/packages/agent-sdk/tests/services/MarketplaceService.git.test.ts
@@ -111,11 +111,12 @@ describe("MarketplaceService - General Git Support", () => {
       });
 
       mockExistsSync.mockImplementation((p) => {
-        if (p.toString().includes(".wave-plugin/marketplace.json")) {
+        const s = p.toString().replace(/\\/g, "/");
+        if (s.includes(".wave-plugin/marketplace.json")) {
           return true;
         }
         // Mock that the target path doesn't exist yet
-        if (p.toString().includes("marketplaces/")) {
+        if (s.includes("marketplaces/")) {
           return false;
         }
         return true;
@@ -152,10 +153,11 @@ describe("MarketplaceService - General Git Support", () => {
       });
 
       mockExistsSync.mockImplementation((p) => {
-        if (p.toString().includes(".wave-plugin/marketplace.json")) {
+        const s = p.toString().replace(/\\/g, "/");
+        if (s.includes(".wave-plugin/marketplace.json")) {
           return true;
         }
-        if (p.toString().includes("marketplaces/")) {
+        if (s.includes("marketplaces/")) {
           return false;
         }
         return true;
@@ -192,10 +194,11 @@ describe("MarketplaceService - General Git Support", () => {
       });
 
       mockExistsSync.mockImplementation((p) => {
-        if (p.toString().includes(".wave-plugin/marketplace.json")) {
+        const s = p.toString().replace(/\\/g, "/");
+        if (s.includes(".wave-plugin/marketplace.json")) {
           return true;
         }
-        if (p.toString().includes("marketplaces/")) {
+        if (s.includes("marketplaces/")) {
           return false;
         }
         return true;

--- a/packages/agent-sdk/tests/services/MarketplaceService.test.ts
+++ b/packages/agent-sdk/tests/services/MarketplaceService.test.ts
@@ -191,7 +191,7 @@ describe("MarketplaceService - Builtin Marketplace", () => {
     };
     const result = service.getMarketplacePath(marketplace.source);
     expect(result).toContain("marketplaces");
-    expect(result).toContain("user/repo");
+    expect(result).toContain(path.join("user", "repo"));
   });
 
   it("should return correct marketplace path for directory source", () => {

--- a/packages/agent-sdk/tests/services/authService.test.ts
+++ b/packages/agent-sdk/tests/services/authService.test.ts
@@ -15,6 +15,7 @@ import {
   statSync,
 } from "fs";
 import * as os from "os";
+import * as path from "path";
 
 // ---- http mock with controllable behavior ----
 interface MockResponse {
@@ -101,7 +102,9 @@ describe("AuthService", () => {
     it("returns ~/.wave/auth.json", () => {
       vi.mocked(os.homedir).mockReturnValue("/home/user");
       const service = AuthService.getInstance();
-      expect(service.getAuthPath()).toBe("/home/user/.wave/auth.json");
+      expect(service.getAuthPath()).toBe(
+        path.join("/home/user", ".wave", "auth.json"),
+      );
     });
   });
 
@@ -135,15 +138,18 @@ describe("AuthService", () => {
       const service = AuthService.getInstance();
       service.saveAuth({ SSO_TOKEN: "new-token" });
 
-      expect(mockedMkdir).toHaveBeenCalledWith("/tmp/.wave", {
+      expect(mockedMkdir).toHaveBeenCalledWith(path.join("/tmp", ".wave"), {
         recursive: true,
       });
       expect(mockedWriteFile).toHaveBeenCalledWith(
-        "/tmp/.wave/auth.json",
+        path.join("/tmp", ".wave", "auth.json"),
         JSON.stringify({ SSO_TOKEN: "new-token" }, null, 2),
         "utf-8",
       );
-      expect(mockedChmod).toHaveBeenCalledWith("/tmp/.wave/auth.json", 0o600);
+      expect(mockedChmod).toHaveBeenCalledWith(
+        path.join("/tmp", ".wave", "auth.json"),
+        0o600,
+      );
     });
 
     it("does not create directory if it already exists", () => {
@@ -168,7 +174,9 @@ describe("AuthService", () => {
       const service = AuthService.getInstance();
       await service.clearAuth();
 
-      expect(mockedRm).toHaveBeenCalledWith("/tmp/.wave/auth.json");
+      expect(mockedRm).toHaveBeenCalledWith(
+        path.join("/tmp", ".wave", "auth.json"),
+      );
     });
 
     it("removes SSO_REFRESH_TOKEN and SSO_TOKEN_EXPIRES_AT along with SSO_TOKEN", async () => {
@@ -185,7 +193,7 @@ describe("AuthService", () => {
       await service.clearAuth();
 
       expect(mockedWriteFile).toHaveBeenCalledWith(
-        "/tmp/.wave/auth.json",
+        path.join("/tmp", ".wave", "auth.json"),
         JSON.stringify({ OTHER_KEY: "value" }, null, 2),
         "utf-8",
       );
@@ -201,7 +209,7 @@ describe("AuthService", () => {
       await service.clearAuth();
 
       expect(mockedWriteFile).toHaveBeenCalledWith(
-        "/tmp/.wave/auth.json",
+        path.join("/tmp", ".wave", "auth.json"),
         JSON.stringify({ OTHER_KEY: "value" }, null, 2),
         "utf-8",
       );

--- a/packages/agent-sdk/tests/services/autoMemory.test.ts
+++ b/packages/agent-sdk/tests/services/autoMemory.test.ts
@@ -56,7 +56,15 @@ describe("MemoryService Auto-Memory", () => {
 
       expect(getGitCommonDir).toHaveBeenCalledWith("/repo/root/worktree");
       expect(pathEncoder.encodeSync).toHaveBeenCalledWith("/repo/root");
-      expect(result).toBe("/home/user/.wave/projects/repo-root-hash/memory");
+      expect(result).toBe(
+        path.join(
+          "/home/user",
+          ".wave",
+          "projects",
+          "repo-root-hash",
+          "memory",
+        ),
+      );
     });
   });
 
@@ -70,7 +78,13 @@ describe("MemoryService Auto-Memory", () => {
 
       await memoryService.ensureAutoMemoryDirectory("/repo/root/worktree");
 
-      const expectedDir = "/home/user/.wave/projects/repo-root-hash/memory";
+      const expectedDir = path.join(
+        "/home/user",
+        ".wave",
+        "projects",
+        "repo-root-hash",
+        "memory",
+      );
       const expectedFile = path.join(expectedDir, "MEMORY.md");
 
       expect(fsPromises.mkdir).toHaveBeenCalledWith(expectedDir, {

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -48,8 +48,29 @@ describe("ConfigurationService", () => {
   });
 
   afterEach(async () => {
-    await fs.rm(tempDir, { recursive: true, force: true });
-    await fs.rm(userHome, { recursive: true, force: true });
+    // setModel() fires off an async persistModelToSettings() write to
+    // ~/.wave/settings.json without awaiting. On Windows the write can still
+    // be in-flight (or file handles linger) when rm runs, causing ENOTEMPTY.
+    // Retry a few times to let the write settle and locks release.
+    const rmRetry = async (target: string, attempts = 5) => {
+      for (let i = 0; i < attempts; i++) {
+        try {
+          await fs.rm(target, { recursive: true, force: true });
+          return;
+        } catch (e) {
+          if (
+            (e as NodeJS.ErrnoException).code === "ENOTEMPTY" &&
+            i < attempts - 1
+          ) {
+            await new Promise((r) => setTimeout(r, 50 * (i + 1)));
+            continue;
+          }
+          throw e;
+        }
+      }
+    };
+    await rmRetry(tempDir);
+    await rmRetry(userHome);
     vi.restoreAllMocks();
   });
 

--- a/packages/agent-sdk/tests/services/session.core.test.ts
+++ b/packages/agent-sdk/tests/services/session.core.test.ts
@@ -352,13 +352,14 @@ describe("Session Core Functionality", () => {
     it("should create files in correct project directory structure", async () => {
       const sessionId = generateSessionId();
       const filePath = await getSessionFilePath(sessionId, testWorkdir);
+      const normalizedFilePath = filePath.replace(/\\/g, "/");
 
       // Should be in tempDir/encoded-workdir/sessionId.jsonl format
-      expect(filePath).toContain(tempDir);
+      expect(normalizedFilePath).toContain(tempDir);
       expect(filePath).not.toBe(`${tempDir}/${sessionId}.jsonl`); // Not directly in tempDir
 
       // Should be in a subdirectory
-      const relativePath = filePath.replace(tempDir, "");
+      const relativePath = normalizedFilePath.replace(tempDir, "");
       const pathParts = relativePath.split("/").filter((p) => p);
       expect(pathParts).toHaveLength(2); // [encoded-workdir, sessionId.jsonl]
     });
@@ -376,7 +377,7 @@ describe("Session Core Functionality", () => {
         const sessionId = generateSessionId();
         const filePath = await getSessionFilePath(sessionId, workdir);
 
-        expect(filePath).toContain(tempDir);
+        expect(filePath.replace(/\\/g, "/")).toContain(tempDir);
         expect(filePath.endsWith(`${sessionId}.jsonl`)).toBe(true);
 
         // In the real implementation, paths would be encoded, but in our mock test,

--- a/packages/agent-sdk/tests/services/taskManager.test.ts
+++ b/packages/agent-sdk/tests/services/taskManager.test.ts
@@ -70,7 +70,7 @@ describe("TaskManager", () => {
         { recursive: true },
       );
       expect(fs.open).toHaveBeenCalledWith(
-        expect.stringMatching(/\/\.lock$/),
+        expect.stringMatching(/[/\\]\.lock$/),
         "wx",
       );
       expect(fs.writeFile).toHaveBeenCalledWith(
@@ -80,7 +80,7 @@ describe("TaskManager", () => {
       );
       expect(mockFileHandle.close).toHaveBeenCalled();
       expect(fs.unlink).toHaveBeenCalledWith(
-        expect.stringMatching(/\/\.lock$/),
+        expect.stringMatching(/[/\\]\.lock$/),
       );
     });
 
@@ -254,7 +254,7 @@ describe("TaskManager", () => {
 
       expect(mockFileHandle.close).toHaveBeenCalled();
       expect(fs.unlink).toHaveBeenCalledWith(
-        expect.stringMatching(/\/\.lock$/),
+        expect.stringMatching(/[/\\]\.lock$/),
       );
     });
 
@@ -326,7 +326,7 @@ describe("TaskManager", () => {
 
       expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining("1.json"));
       expect(fs.unlink).toHaveBeenCalledWith(
-        expect.stringMatching(/\/\.lock$/),
+        expect.stringMatching(/[/\\]\.lock$/),
       );
     });
 

--- a/packages/agent-sdk/tests/tools/bashTool.test.ts
+++ b/packages/agent-sdk/tests/tools/bashTool.test.ts
@@ -58,6 +58,7 @@ vi.mock("../../src/utils/globalLogger.js", () => ({
 
 import { spawn } from "child_process";
 import { logger } from "../../src/utils/globalLogger.js";
+import { resolveShellPath } from "../../src/utils/shellResolver.js";
 const mockSpawn = vi.mocked(spawn);
 
 describe("bashTool", () => {
@@ -123,7 +124,7 @@ describe("bashTool", () => {
       expect(spawnCallArgs[0]).toContain("echo hello");
       expect(spawnCallArgs[0]).toContain("pwd -P");
       expect(spawnCallArgs[1]).toMatchObject({
-        shell: true,
+        shell: resolveShellPath() || true,
         stdio: "pipe",
         cwd: "/test/workdir",
       });

--- a/packages/agent-sdk/tests/tools/editTool.test.ts
+++ b/packages/agent-sdk/tests/tools/editTool.test.ts
@@ -2,8 +2,17 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { editTool } from "@/tools/editTool.js";
 import { TaskManager } from "@/services/taskManager.js";
 import { readFile, writeFile, stat } from "fs/promises";
+import * as path from "path";
 import type { ToolContext } from "@/tools/types.js";
 import { Container } from "@/utils/container.js";
+
+// Source resolves file_path against context.workdir via path.resolve().
+// On Windows that prepends a drive letter (D:\...), so any path the source
+// stores/returns (readFileState keys, result.filePath, readFile/writeFile
+// call args) must be expressed as path.resolve(...) to match cross-platform.
+// Input file_path args stay literal; only the *resolved* form is wrapped.
+const WORKDIR = "/test/workdir";
+const r = (p: string) => path.resolve(WORKDIR, p);
 
 // Mock fs/promises
 vi.mock("fs/promises");
@@ -20,15 +29,16 @@ describe("editTool", () => {
   beforeEach(() => {
     mockContext = {
       abortSignal: new AbortController().signal,
-      workdir: "/test/workdir",
+      workdir: WORKDIR,
       taskManager: new TaskManager(new Container(), "test-session"),
       // Pre-populate readFileState so read-before-edit check passes.
+      // Keys must be the *resolved* path (matches source's resolvePath()).
       // Individual tests can override with an empty Map or undefined.
       readFileState: new Map([
-        ["/test/file.js", { mtime: 1000, hash: "abc" }],
-        ["/test/workdir/file.js", { mtime: 1000, hash: "abc" }],
-        ["/test/nonexistent.js", { mtime: 1000, hash: "abc" }],
-        ["/absolute/path/file.js", { mtime: 1000, hash: "abc" }],
+        [r("/test/file.js"), { mtime: 1000, hash: "abc" }],
+        [r("/test/workdir/file.js"), { mtime: 1000, hash: "abc" }],
+        [r("/test/nonexistent.js"), { mtime: 1000, hash: "abc" }],
+        [r("/absolute/path/file.js"), { mtime: 1000, hash: "abc" }],
       ]),
     };
   });
@@ -85,11 +95,11 @@ describe("editTool", () => {
 
     expect(result.success).toBe(true);
     expect(result.content).toContain("Text replaced successfully");
-    expect(result.filePath).toBe("/test/file.js");
+    expect(result.filePath).toBe(r("/test/file.js"));
 
-    expect(readFile).toHaveBeenCalledWith("/test/file.js", "utf-8");
+    expect(readFile).toHaveBeenCalledWith(r("/test/file.js"), "utf-8");
     expect(writeFile).toHaveBeenCalledWith(
-      "/test/file.js",
+      r("/test/file.js"),
       expectedContent,
       "utf-8",
     );
@@ -116,7 +126,7 @@ describe("editTool", () => {
     expect(result.content).toContain("Replaced 3 instances");
 
     expect(writeFile).toHaveBeenCalledWith(
-      "/test/file.js",
+      r("/test/file.js"),
       expectedContent,
       "utf-8",
     );
@@ -320,9 +330,9 @@ describe("editTool", () => {
 
     expect(result.success).toBe(true);
     // Should preserve absolute path
-    expect(readFile).toHaveBeenCalledWith("/absolute/path/file.js", "utf-8");
+    expect(readFile).toHaveBeenCalledWith(r("/absolute/path/file.js"), "utf-8");
     expect(writeFile).toHaveBeenCalledWith(
-      "/absolute/path/file.js",
+      r("/absolute/path/file.js"),
       expectedContent,
       "utf-8",
     );
@@ -412,7 +422,7 @@ describe("editTool", () => {
     expect(result.success).toBe(true);
     expect(mockReversionManager.recordSnapshot).toHaveBeenCalledWith(
       "msg-123",
-      "/test/file.js",
+      r("/test/file.js"),
       "modify",
     );
     expect(mockReversionManager.commitSnapshot).toHaveBeenCalledWith(
@@ -486,7 +496,7 @@ describe("editTool", () => {
       {
         ...mockContext,
         readFileState: new Map([
-          ["/test/workdir/file.js", { mtime: 1000, hash: "abc" }],
+          [r("/test/workdir/file.js"), { mtime: 1000, hash: "abc" }],
         ]),
       },
     );
@@ -514,7 +524,7 @@ describe("editTool", () => {
 
     expect(result.success).toBe(true);
     expect(writeFile).toHaveBeenCalledWith(
-      "/test/file.js",
+      r("/test/file.js"),
       expectedContent,
       "utf-8",
     );
@@ -546,7 +556,7 @@ describe("editTool", () => {
       string,
       { mtime: number; hash: string; offset?: number; limit?: number }
     >();
-    readFileState.set("/test/file.js", { mtime: 1000, hash: "abc" });
+    readFileState.set(r("/test/file.js"), { mtime: 1000, hash: "abc" });
 
     vi.mocked(stat).mockResolvedValue({
       mtime: { getTime: () => 2000 } as Date,
@@ -575,7 +585,7 @@ describe("editTool", () => {
       string,
       { mtime: number; hash: string; offset?: number; limit?: number }
     >();
-    readFileState.set("/test/file.js", { mtime: 1000, hash: "abc" });
+    readFileState.set(r("/test/file.js"), { mtime: 1000, hash: "abc" });
 
     // First stat: staleness check (mtime matches)
     // Second stat: post-write state update
@@ -608,7 +618,7 @@ describe("editTool", () => {
       string,
       { mtime: number; hash: string; offset?: number; limit?: number }
     >();
-    readFileState.set("/test/file.js", { mtime: 1000, hash: "abc" });
+    readFileState.set(r("/test/file.js"), { mtime: 1000, hash: "abc" });
 
     // First stat: staleness check (mtime matches readFileState)
     // Second stat: post-write state update (new mtime)
@@ -630,7 +640,7 @@ describe("editTool", () => {
     );
 
     expect(result.success).toBe(true);
-    const updated = readFileState.get("/test/file.js");
+    const updated = readFileState.get(r("/test/file.js"));
     expect(updated).toBeDefined();
     expect(updated?.mtime).toBe(2000);
   });

--- a/packages/agent-sdk/tests/tools/lspTool.test.ts
+++ b/packages/agent-sdk/tests/tools/lspTool.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as fs from "fs";
-import * as path from "path";
 import { lspTool, MAX_RESULTS, MAX_FILES } from "../../src/tools/lspTool.js";
 
 vi.mock("fs", async (importOriginal) => {
@@ -62,9 +61,7 @@ describe("lspTool", () => {
     );
 
     expect(result.success).toBe(true);
-    expect(result.content).toContain(
-      `Defined in ${path.join("src", "index.ts")}:11:6`,
-    );
+    expect(result.content).toContain("Defined in src/index.ts:11:6");
     expect(mockLspManager.execute).toHaveBeenCalledWith({
       operation: "goToDefinition",
       filePath: "src/main.ts",
@@ -108,8 +105,8 @@ describe("lspTool", () => {
 
     expect(result.success).toBe(true);
     expect(result.content).toContain("Found 2 definitions:");
-    expect(result.content).toContain(`${path.join("src", "index.ts")}:11:6`);
-    expect(result.content).toContain(`${path.join("src", "other.ts")}:21:1`);
+    expect(result.content).toContain("src/index.ts:11:6");
+    expect(result.content).toContain("src/other.ts:21:1");
   });
 
   it("should format hover result", async () => {
@@ -204,7 +201,7 @@ describe("lspTool", () => {
 
     expect(result.success).toBe(true);
     expect(result.content).toContain("Found 1 reference:");
-    expect(result.content).toContain(`${path.join("src", "index.ts")}:11:6`);
+    expect(result.content).toContain("src/index.ts:11:6");
   });
 
   it("should format documentSymbol result", async () => {
@@ -289,7 +286,7 @@ describe("lspTool", () => {
 
     expect(result.success).toBe(true);
     expect(result.content).toContain("Found 1 symbol in workspace:");
-    expect(result.content).toContain(`${path.join("src", "globals.ts")}:`);
+    expect(result.content).toContain("src/globals.ts:");
     expect(result.content).toContain("GlobalVar (Variable) - Line 6");
   });
 
@@ -327,7 +324,7 @@ describe("lspTool", () => {
     );
     expect(prepareResult.success).toBe(true);
     expect(prepareResult.content).toContain(
-      `Call hierarchy item: myFunc (Function) - ${path.join("src", "main.ts")}:11`,
+      "Call hierarchy item: myFunc (Function) - src/main.ts:11",
     );
 
     // incomingCalls
@@ -494,9 +491,7 @@ describe("lspTool", () => {
     );
 
     expect(result.success).toBe(true);
-    expect(result.content).toContain(
-      `Defined in ${path.join("src", "link.ts")}:6:1`,
-    );
+    expect(result.content).toContain("Defined in src/link.ts:6:1");
   });
 
   it("should handle hover with array contents", async () => {

--- a/packages/agent-sdk/tests/tools/lspTool.test.ts
+++ b/packages/agent-sdk/tests/tools/lspTool.test.ts
@@ -466,7 +466,7 @@ describe("lspTool", () => {
       character: 5,
     };
     const result = lspTool.formatCompactParams?.(params, context);
-    expect(result).toBe(`hover ${path.join("src", "main.ts")}:10:5`);
+    expect(result).toBe("hover src/main.ts:10:5");
   });
 
   it("should handle LocationLink in goToDefinition", async () => {
@@ -906,9 +906,7 @@ describe("lspTool", () => {
 
     expect(result.success).toBe(true);
     expect(result.content).toContain("No definition found");
-    expect(result.content).toContain(
-      `Context at ${path.join("src", "main.ts")}:1:3:`,
-    );
+    expect(result.content).toContain("Context at src/main.ts:1:3:");
     expect(result.content).toContain(mockLineContent);
     expect(result.content).toContain("  ^");
     expect(result.content).toContain(

--- a/packages/agent-sdk/tests/tools/lspTool.test.ts
+++ b/packages/agent-sdk/tests/tools/lspTool.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as fs from "fs";
+import * as path from "path";
 import { lspTool, MAX_RESULTS, MAX_FILES } from "../../src/tools/lspTool.js";
 
 vi.mock("fs", async (importOriginal) => {
@@ -61,7 +62,9 @@ describe("lspTool", () => {
     );
 
     expect(result.success).toBe(true);
-    expect(result.content).toContain("Defined in src/index.ts:11:6");
+    expect(result.content).toContain(
+      `Defined in ${path.join("src", "index.ts")}:11:6`,
+    );
     expect(mockLspManager.execute).toHaveBeenCalledWith({
       operation: "goToDefinition",
       filePath: "src/main.ts",
@@ -105,8 +108,8 @@ describe("lspTool", () => {
 
     expect(result.success).toBe(true);
     expect(result.content).toContain("Found 2 definitions:");
-    expect(result.content).toContain("src/index.ts:11:6");
-    expect(result.content).toContain("src/other.ts:21:1");
+    expect(result.content).toContain(`${path.join("src", "index.ts")}:11:6`);
+    expect(result.content).toContain(`${path.join("src", "other.ts")}:21:1`);
   });
 
   it("should format hover result", async () => {
@@ -201,7 +204,7 @@ describe("lspTool", () => {
 
     expect(result.success).toBe(true);
     expect(result.content).toContain("Found 1 reference:");
-    expect(result.content).toContain("src/index.ts:11:6");
+    expect(result.content).toContain(`${path.join("src", "index.ts")}:11:6`);
   });
 
   it("should format documentSymbol result", async () => {
@@ -286,7 +289,7 @@ describe("lspTool", () => {
 
     expect(result.success).toBe(true);
     expect(result.content).toContain("Found 1 symbol in workspace:");
-    expect(result.content).toContain("src/globals.ts:");
+    expect(result.content).toContain(`${path.join("src", "globals.ts")}:`);
     expect(result.content).toContain("GlobalVar (Variable) - Line 6");
   });
 
@@ -324,7 +327,7 @@ describe("lspTool", () => {
     );
     expect(prepareResult.success).toBe(true);
     expect(prepareResult.content).toContain(
-      "Call hierarchy item: myFunc (Function) - src/main.ts:11",
+      `Call hierarchy item: myFunc (Function) - ${path.join("src", "main.ts")}:11`,
     );
 
     // incomingCalls
@@ -463,7 +466,7 @@ describe("lspTool", () => {
       character: 5,
     };
     const result = lspTool.formatCompactParams?.(params, context);
-    expect(result).toBe("hover src/main.ts:10:5");
+    expect(result).toBe(`hover ${path.join("src", "main.ts")}:10:5`);
   });
 
   it("should handle LocationLink in goToDefinition", async () => {
@@ -491,7 +494,9 @@ describe("lspTool", () => {
     );
 
     expect(result.success).toBe(true);
-    expect(result.content).toContain("Defined in src/link.ts:6:1");
+    expect(result.content).toContain(
+      `Defined in ${path.join("src", "link.ts")}:6:1`,
+    );
   });
 
   it("should handle hover with array contents", async () => {
@@ -901,7 +906,9 @@ describe("lspTool", () => {
 
     expect(result.success).toBe(true);
     expect(result.content).toContain("No definition found");
-    expect(result.content).toContain("Context at src/main.ts:1:3:");
+    expect(result.content).toContain(
+      `Context at ${path.join("src", "main.ts")}:1:3:`,
+    );
     expect(result.content).toContain(mockLineContent);
     expect(result.content).toContain("  ^");
     expect(result.content).toContain(

--- a/packages/agent-sdk/tests/tools/writeTool.test.ts
+++ b/packages/agent-sdk/tests/tools/writeTool.test.ts
@@ -285,7 +285,7 @@ describe("writeTool", () => {
 
     expect(result.success).toBe(true);
     expect(writeFile).toHaveBeenCalledWith(
-      "/test/special.txt",
+      path.resolve("/test/special.txt"),
       content,
       "utf-8",
     );
@@ -403,7 +403,7 @@ describe("writeTool", () => {
       expect(result.success).toBe(true);
       expect(mockReversionManager.recordSnapshot).toHaveBeenCalledWith(
         "msg-1",
-        "/test/new.txt",
+        path.resolve("/test/new.txt"),
         "create",
       );
       expect(mockReversionManager.commitSnapshot).toHaveBeenCalledWith(
@@ -433,7 +433,7 @@ describe("writeTool", () => {
       expect(result.success).toBe(true);
       expect(mockReversionManager.recordSnapshot).toHaveBeenCalledWith(
         "msg-2",
-        "/test/existing.txt",
+        path.resolve("/test/existing.txt"),
         "modify",
       );
       expect(mockReversionManager.commitSnapshot).toHaveBeenCalledWith(

--- a/packages/agent-sdk/tests/tools/writeTool.test.ts
+++ b/packages/agent-sdk/tests/tools/writeTool.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as path from "path";
 import { writeTool } from "@/tools/writeTool.js";
 import { TaskManager } from "@/services/taskManager.js";
 import { readFile, writeFile, mkdir } from "fs/promises";
@@ -70,11 +71,14 @@ describe("writeTool", () => {
     expect(result.success).toBe(true);
     expect(result.content).toContain("File created");
     expect(result.shortResult).toBe("File created");
-    expect(result.filePath).toBe("/test/newfile.js");
+    expect(result.filePath).toBe(path.resolve("/test/newfile.js"));
 
-    expect(mkdir).toHaveBeenCalledWith("/test", { recursive: true });
+    expect(mkdir).toHaveBeenCalledWith(
+      path.dirname(path.resolve("/test/newfile.js")),
+      { recursive: true },
+    );
     expect(writeFile).toHaveBeenCalledWith(
-      "/test/newfile.js",
+      path.resolve("/test/newfile.js"),
       content,
       "utf-8",
     );
@@ -99,11 +103,14 @@ describe("writeTool", () => {
     expect(result.success).toBe(true);
     expect(result.content).toContain("File overwritten");
     expect(result.shortResult).toBe("File overwritten");
-    expect(result.filePath).toBe("/test/file.js");
+    expect(result.filePath).toBe(path.resolve("/test/file.js"));
 
-    expect(readFile).toHaveBeenCalledWith("/test/file.js", "utf-8");
+    expect(readFile).toHaveBeenCalledWith(
+      path.resolve("/test/file.js"),
+      "utf-8",
+    );
     expect(writeFile).toHaveBeenCalledWith(
-      "/test/file.js",
+      path.resolve("/test/file.js"),
       newContent,
       "utf-8",
     );
@@ -187,13 +194,19 @@ describe("writeTool", () => {
     );
 
     expect(result.success).toBe(true);
-    expect(readFile).toHaveBeenCalledWith("/absolute/path/file.js", "utf-8");
+    expect(readFile).toHaveBeenCalledWith(
+      path.resolve("/absolute/path/file.js"),
+      "utf-8",
+    );
     expect(writeFile).toHaveBeenCalledWith(
-      "/absolute/path/file.js",
+      path.resolve("/absolute/path/file.js"),
       content,
       "utf-8",
     );
-    expect(mkdir).toHaveBeenCalledWith("/absolute/path", { recursive: true });
+    expect(mkdir).toHaveBeenCalledWith(
+      path.dirname(path.resolve("/absolute/path/file.js")),
+      { recursive: true },
+    );
   });
 
   it("should handle directory creation gracefully when directory exists", async () => {

--- a/packages/agent-sdk/tests/utils/commandPathResolver.test.ts
+++ b/packages/agent-sdk/tests/utils/commandPathResolver.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as path from "path";
 
 import {
   generateCommandId,
@@ -23,10 +24,11 @@ describe("Command Path Resolver Utilities", () => {
 
     it("should reject nested commands", () => {
       // Test nested command: .wave/commands/openspec/apply.md -> should be rejected
-      expect(() =>
-        generateCommandId("/root/commands/openspec/apply.md", "/root/commands"),
-      ).toThrow(
-        "Command nesting not supported: openspec/apply.md. Commands must be in the root directory.",
+      const filePath = "/root/commands/openspec/apply.md";
+      const rootDir = "/root/commands";
+      const relativePath = path.relative(rootDir, filePath);
+      expect(() => generateCommandId(filePath, rootDir)).toThrow(
+        `Command nesting not supported: ${relativePath}. Commands must be in the root directory.`,
       );
     });
 

--- a/packages/agent-sdk/tests/utils/cronTasksLock.test.ts
+++ b/packages/agent-sdk/tests/utils/cronTasksLock.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as path from "path";
 import {
   tryAcquireSchedulerLock,
   releaseSchedulerLock,
@@ -19,7 +20,6 @@ vi.mock("crypto", () => ({
 }));
 
 const MOCK_DIR = "/mock/project";
-const WAVE_DIR = `${MOCK_DIR}/.wave`;
 
 import {
   readFileSync,
@@ -58,7 +58,9 @@ describe("cronTasksLock", () => {
       });
 
       expect(result).toBe(true);
-      expect(mkdirSync).toHaveBeenCalledWith(WAVE_DIR, { recursive: true });
+      expect(mkdirSync).toHaveBeenCalledWith(path.join(MOCK_DIR, ".wave"), {
+        recursive: true,
+      });
       expect(writeFileSync).toHaveBeenCalled();
     });
 

--- a/packages/agent-sdk/tests/utils/customCommands.description.test.ts
+++ b/packages/agent-sdk/tests/utils/customCommands.description.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { loadCustomSlashCommands } from "../../src/utils/customCommands.js";
 import * as fs from "fs";
+import * as path from "path";
 
 // Mock fs operations
 vi.mock("fs", () => ({
@@ -109,8 +110,8 @@ This is a test command without description.`;
 
   describe("Claude ecosystem compatibility", () => {
     it("should load commands from .claude/commands directories", () => {
-      const claudeUserDir = "/mock/home/.claude/commands";
-      const claudeProjectDir = "/mock/tmp/wave-test-123/.claude/commands";
+      const claudeUserDir = path.join("/mock/home", ".claude", "commands");
+      const claudeProjectDir = path.join(mockTestDir, ".claude", "commands");
 
       vi.mocked(fs.existsSync).mockImplementation((p) => {
         const path = p.toString();
@@ -158,8 +159,8 @@ Project claude command content`;
     });
 
     it("should let .wave/commands override .claude/commands for same-named command", () => {
-      const claudeProjectDir = "/mock/tmp/wave-test-123/.claude/commands";
-      const waveProjectDir = "/mock/tmp/wave-test-123/.wave/commands";
+      const claudeProjectDir = path.join(mockTestDir, ".claude", "commands");
+      const waveProjectDir = path.join(mockTestDir, ".wave", "commands");
 
       vi.mocked(fs.existsSync).mockImplementation((p) => {
         const path = p.toString();
@@ -178,13 +179,19 @@ Project claude command content`;
 
       vi.mocked(fs.readFileSync).mockImplementation((filePath) => {
         const p = filePath.toString();
-        if (p.includes(".claude/commands") && p.includes("shared-cmd.md")) {
+        if (
+          p.match(/[/\\]\.claude[/\\]commands/) &&
+          p.includes("shared-cmd.md")
+        ) {
           return `---
 description: Claude version
 ---
 Claude content`;
         }
-        if (p.includes(".wave/commands") && p.includes("shared-cmd.md")) {
+        if (
+          p.match(/[/\\]\.wave[/\\]commands/) &&
+          p.includes("shared-cmd.md")
+        ) {
           return `---
 description: Wave version
 ---

--- a/packages/agent-sdk/tests/utils/gitUtils.test.ts
+++ b/packages/agent-sdk/tests/utils/gitUtils.test.ts
@@ -99,31 +99,41 @@ describe("gitUtils", () => {
 
   describe("resolveGitDir", () => {
     it("should find .git directory for a normal repo", () => {
+      const root = path.resolve("/repo/root");
+      const expectedGitDir = path.join(root, ".git");
       vi.mocked(fsSync.existsSync).mockImplementation(
-        (p) => p === "/repo/root/.git",
+        (p) => p === expectedGitDir,
       );
       vi.mocked(fsSync.statSync).mockReturnValue({
         isDirectory: () => true,
       } as unknown as fsSync.Stats);
-      expect(resolveGitDir("/repo/root")).toBe("/repo/root/.git");
+      expect(resolveGitDir("/repo/root")).toBe(expectedGitDir);
     });
 
     it("should resolve worktree git dir via commondir", () => {
-      const worktreeGitDir = "/repo/main/.git/worktrees/wt1";
+      const worktreeRoot = path.resolve("/repo/worktree");
+      const worktreeGitFile = path.join(worktreeRoot, ".git");
+      const worktreeGitDir = path.join(
+        path.resolve("/repo/main"),
+        ".git",
+        "worktrees",
+        "wt1",
+      );
       vi.mocked(fsSync.existsSync).mockImplementation(
         (p) =>
-          p === "/repo/worktree/.git" ||
-          p === path.join(worktreeGitDir, "commondir"),
+          p === worktreeGitFile || p === path.join(worktreeGitDir, "commondir"),
       );
       vi.mocked(fsSync.statSync).mockReturnValue({
         isDirectory: () => false,
       } as unknown as fsSync.Stats);
       vi.mocked(fsSync.readFileSync).mockImplementation((p) => {
-        if (p === "/repo/worktree/.git") return `gitdir: ${worktreeGitDir}`;
+        if (p === worktreeGitFile) return `gitdir: ${worktreeGitDir}`;
         if (p === path.join(worktreeGitDir, "commondir")) return "../..\n";
         throw new Error("Not found");
       });
-      expect(resolveGitDir("/repo/worktree")).toBe("/repo/main/.git");
+      expect(resolveGitDir("/repo/worktree")).toBe(
+        path.join(path.resolve("/repo/main"), ".git"),
+      );
     });
 
     it("should return null if no .git found", () => {
@@ -133,12 +143,12 @@ describe("gitUtils", () => {
   });
 
   describe("getDefaultRemoteBranch", () => {
-    const gitDir = "/repo/root/.git";
+    const gitDir = path.join(path.resolve("/repo/root"), ".git");
 
     function mockGitDirFound() {
       vi.mocked(fsSync.existsSync).mockImplementation(
         (p) =>
-          p === "/repo/root/.git" ||
+          p === gitDir ||
           p === path.join(gitDir, "refs/remotes/origin/main") ||
           p === path.join(gitDir, "refs/remotes/origin/master") ||
           p === path.join(gitDir, "refs/remotes/origin/HEAD"),
@@ -162,7 +172,7 @@ describe("gitUtils", () => {
     it("should skip stale origin/HEAD and fallback (Step 1 stale)", () => {
       vi.mocked(fsSync.existsSync).mockImplementation(
         (p) =>
-          p === "/repo/root/.git" ||
+          p === gitDir ||
           p === path.join(gitDir, "refs/remotes/origin/HEAD") ||
           p === path.join(gitDir, "refs/remotes/origin/main"),
       );
@@ -181,8 +191,7 @@ describe("gitUtils", () => {
     it("should fallback to origin/main if ref exists (Step 2)", () => {
       vi.mocked(fsSync.existsSync).mockImplementation(
         (p) =>
-          p === "/repo/root/.git" ||
-          p === path.join(gitDir, "refs/remotes/origin/main"),
+          p === gitDir || p === path.join(gitDir, "refs/remotes/origin/main"),
       );
       vi.mocked(fsSync.statSync).mockReturnValue({
         isDirectory: () => true,
@@ -194,8 +203,7 @@ describe("gitUtils", () => {
     it("should fallback to origin/master if ref exists (Step 3)", () => {
       vi.mocked(fsSync.existsSync).mockImplementation(
         (p) =>
-          p === "/repo/root/.git" ||
-          p === path.join(gitDir, "refs/remotes/origin/master"),
+          p === gitDir || p === path.join(gitDir, "refs/remotes/origin/master"),
       );
       vi.mocked(fsSync.statSync).mockReturnValue({
         isDirectory: () => true,
@@ -204,9 +212,7 @@ describe("gitUtils", () => {
     });
 
     it("should return 'main' as hardcoded fallback (Step 4)", () => {
-      vi.mocked(fsSync.existsSync).mockImplementation(
-        (p) => p === "/repo/root/.git",
-      );
+      vi.mocked(fsSync.existsSync).mockImplementation((p) => p === gitDir);
       vi.mocked(fsSync.statSync).mockReturnValue({
         isDirectory: () => true,
       } as unknown as fsSync.Stats);
@@ -220,8 +226,7 @@ describe("gitUtils", () => {
 
     it("should find ref in packed-refs", () => {
       vi.mocked(fsSync.existsSync).mockImplementation(
-        (p) =>
-          p === "/repo/root/.git" || p === path.join(gitDir, "packed-refs"),
+        (p) => p === gitDir || p === path.join(gitDir, "packed-refs"),
       );
       vi.mocked(fsSync.statSync).mockReturnValue({
         isDirectory: () => true,
@@ -236,8 +241,7 @@ describe("gitUtils", () => {
 
     it("should skip comments and peeled lines in packed-refs", () => {
       vi.mocked(fsSync.existsSync).mockImplementation(
-        (p) =>
-          p === "/repo/root/.git" || p === path.join(gitDir, "packed-refs"),
+        (p) => p === gitDir || p === path.join(gitDir, "packed-refs"),
       );
       vi.mocked(fsSync.statSync).mockReturnValue({
         isDirectory: () => true,
@@ -291,11 +295,9 @@ describe("gitUtils", () => {
     });
 
     it("should write marker + patterns to info/exclude when marker absent", () => {
-      const gitDir = "/repo/write-test/.git";
+      const gitDir = path.join(path.resolve("/repo/write-test"), ".git");
       const excludePath = path.join(gitDir, "info", "exclude");
-      vi.mocked(fsSync.existsSync).mockImplementation(
-        (p) => p === path.join("/repo/write-test", ".git"),
-      );
+      vi.mocked(fsSync.existsSync).mockImplementation((p) => p === gitDir);
       vi.mocked(fsSync.statSync).mockReturnValue({
         isDirectory: () => true,
       } as unknown as fsSync.Stats);
@@ -325,7 +327,7 @@ describe("gitUtils", () => {
 
     it("should skip when marker already present (idempotent)", () => {
       vi.mocked(fsSync.existsSync).mockImplementation(
-        (p) => p === path.join("/repo/idempotent-test", ".git"),
+        (p) => p === path.join(path.resolve("/repo/idempotent-test"), ".git"),
       );
       vi.mocked(fsSync.statSync).mockReturnValue({
         isDirectory: () => true,

--- a/packages/agent-sdk/tests/utils/path.test.ts
+++ b/packages/agent-sdk/tests/utils/path.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { resolvePath, getDisplayPath } from "../../src/utils/path.js";
 import { homedir } from "os";
-import { resolve, join } from "path";
+import { resolve } from "path";
 
 describe("path utils", () => {
   describe("resolvePath", () => {
@@ -55,7 +55,7 @@ describe("path utils", () => {
         "/Users/test/project/src/utils/path.ts",
         mockWorkdir,
       );
-      expect(result).toBe(join("src", "utils", "path.ts"));
+      expect(result).toBe("src/utils/path.ts");
     });
 
     it("should return absolute path when relative path starts with ..", () => {
@@ -118,7 +118,8 @@ describe("path utils", () => {
         "C:\\Users\\test\\project\\src\\file.ts",
         mockWorkdir,
       );
-      expect(result).toBe("src\\file.ts");
+      // getDisplayPath normalizes to forward slashes on all platforms
+      expect(result).toBe("src/file.ts");
     });
 
     it("should handle different workdir consistently", () => {
@@ -127,7 +128,7 @@ describe("path utils", () => {
         "/custom/workdir/src/utils/file.ts",
         customWorkdir,
       );
-      expect(result).toBe(join("src", "utils", "file.ts"));
+      expect(result).toBe("src/utils/file.ts");
 
       // Test with different path that would be longer as relative
       const absolutePath = "/other/path/file.ts";

--- a/packages/agent-sdk/tests/utils/path.test.ts
+++ b/packages/agent-sdk/tests/utils/path.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { resolvePath, getDisplayPath } from "../../src/utils/path.js";
 import { homedir } from "os";
-import { resolve } from "path";
+import { resolve, join } from "path";
 
 describe("path utils", () => {
   describe("resolvePath", () => {
@@ -55,7 +55,7 @@ describe("path utils", () => {
         "/Users/test/project/src/utils/path.ts",
         mockWorkdir,
       );
-      expect(result).toBe("src/utils/path.ts");
+      expect(result).toBe(join("src", "utils", "path.ts"));
     });
 
     it("should return absolute path when relative path starts with ..", () => {
@@ -127,7 +127,7 @@ describe("path utils", () => {
         "/custom/workdir/src/utils/file.ts",
         customWorkdir,
       );
-      expect(result).toBe("src/utils/file.ts");
+      expect(result).toBe(join("src", "utils", "file.ts"));
 
       // Test with different path that would be longer as relative
       const absolutePath = "/other/path/file.ts";

--- a/packages/agent-sdk/tests/utils/pathEncoder.test.ts
+++ b/packages/agent-sdk/tests/utils/pathEncoder.test.ts
@@ -5,6 +5,7 @@ import {
 } from "../../src/utils/pathEncoder.js";
 import { realpath, mkdir } from "fs/promises";
 import { homedir, platform } from "os";
+import * as path from "path";
 
 // Mock fs/promises
 vi.mock("fs/promises");
@@ -110,7 +111,9 @@ describe("PathEncoder", () => {
       // Mock realpath to return the input path directly (no resolution)
       vi.mocked(realpath).mockResolvedValue("C:\\Users\\John\\Project");
       const result = await pathEncoder.encode("C:\\Users\\John\\Project");
-      expect(result).toBe("C:-Users-John-Project");
+      // Drive letter is stripped so the encoded name is stable cross-platform
+      // (matches what "C:\\Users\\John\\Project" would encode to on Linux).
+      expect(result).toBe("Users-John-Project");
     });
 
     it("should truncate long paths and add hash", async () => {
@@ -174,7 +177,7 @@ describe("PathEncoder", () => {
 
       // Verify realpath was called with expanded path
       expect(realpath).toHaveBeenCalledWith(
-        expect.stringContaining("/home/testuser/project"),
+        expect.stringMatching(/home[/\\]testuser[/\\]project$/),
       );
     });
 
@@ -198,7 +201,7 @@ describe("PathEncoder", () => {
       );
 
       const result = await pathEncoder.resolvePath("relative/path");
-      expect(result).toMatch(/.*relative\/path$/);
+      expect(result).toMatch(/.*[/\\]relative[/\\]path$/);
     });
 
     it("should throw error when realpath fails", async () => {
@@ -215,7 +218,7 @@ describe("PathEncoder", () => {
       const result = await pathEncoder.resolvePath("/path/to/symlink");
       expect(result).toBe("/real/path/target");
       expect(realpath).toHaveBeenCalledWith(
-        expect.stringMatching(/.*path\/to\/symlink$/),
+        expect.stringMatching(/.*[/\\]path[/\\]to[/\\]symlink$/),
       );
     });
   });
@@ -239,16 +242,19 @@ describe("PathEncoder", () => {
       );
 
       expect(result).toEqual({
-        originalPath: "/home/user/project",
+        originalPath: path.resolve("/home/user/project"),
         encodedName: "home-user-project",
-        encodedPath: "/session/base/home-user-project",
+        encodedPath: path.join("/session/base", "home-user-project"),
         pathHash: undefined,
         isSymbolicLink: false,
       });
 
-      expect(mkdir).toHaveBeenCalledWith("/session/base/home-user-project", {
-        recursive: true,
-      });
+      expect(mkdir).toHaveBeenCalledWith(
+        path.join("/session/base", "home-user-project"),
+        {
+          recursive: true,
+        },
+      );
     });
 
     it("should detect symbolic links", async () => {
@@ -274,7 +280,7 @@ describe("PathEncoder", () => {
         baseSessionDir,
       );
 
-      expect(result.originalPath).toBe("/home/testuser/project");
+      expect(result.originalPath).toBe(path.resolve("/home/testuser/project"));
       expect(result.encodedName).toBe("home-testuser-project");
     });
 
@@ -310,7 +316,7 @@ describe("PathEncoder", () => {
       );
 
       // Should use absolute path when realpath fails
-      expect(result.originalPath).toMatch(/.*protected\/path$/);
+      expect(result.originalPath).toMatch(/.*[/\\]protected[/\\]path$/);
       expect(result.isSymbolicLink).toBe(false);
     });
 
@@ -324,7 +330,7 @@ describe("PathEncoder", () => {
 
       // Should not throw error
       expect(result).toBeDefined();
-      expect(result.originalPath).toBe("/home/user/project");
+      expect(result.originalPath).toBe(path.resolve("/home/user/project"));
     });
 
     it("should create nested encoded path correctly", async () => {
@@ -337,7 +343,7 @@ describe("PathEncoder", () => {
 
       expect(result.encodedName).toBe("very-deep-nested-project-structure");
       expect(result.encodedPath).toBe(
-        "/session/base/very-deep-nested-project-structure",
+        path.join("/session/base", "very-deep-nested-project-structure"),
       );
     });
   });
@@ -670,10 +676,10 @@ describe("PathEncoder", () => {
 
       expect(projectDir.encodedName).toBe(encoded);
       expect(projectDir.originalPath).toBe(
-        "/home/testuser/my project/subfolder",
+        path.resolve("/home/testuser/my project/subfolder"),
       );
       expect(mkdir).toHaveBeenCalledWith(
-        "/tmp/sessions/home-testuser-my_project-subfolder",
+        path.join("/tmp/sessions", "home-testuser-my_project-subfolder"),
         { recursive: true },
       );
     });

--- a/packages/agent-sdk/tests/utils/subagentParser.test.ts
+++ b/packages/agent-sdk/tests/utils/subagentParser.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as path from "path";
 import { loadSubagentConfigurations } from "../../src/utils/subagentParser.js";
 import * as configPaths from "../../src/utils/configPaths.js";
 
@@ -51,7 +52,7 @@ describe("SubagentParser with Built-ins", () => {
       } as import("fs").Stats);
 
       vi.mocked(mockFs.readFileSync).mockImplementation((filePath) => {
-        if (filePath === "/builtin/subagents/explore.md") {
+        if (filePath === path.join("/builtin/subagents", "explore.md")) {
           return `---
 description: Built-in codebase exploration agent
 tools: [Glob, Grep, Read, Bash]
@@ -90,7 +91,7 @@ You are a file search specialist...`;
       } as import("fs").Stats);
 
       vi.mocked(mockFs.readFileSync).mockImplementation((filePath) => {
-        if (filePath === "/builtin/subagents/explore.md") {
+        if (filePath === path.join("/builtin/subagents", "explore.md")) {
           return `---
 description: Built-in codebase exploration agent
 ---
@@ -148,7 +149,7 @@ test`;
             typeof import("fs").readdirSync
           >;
         }
-        if (dirPath === "/home/testuser/.wave/agents") {
+        if (dirPath === path.join("/home/testuser", ".wave", "agents")) {
           return ["explore.md"] as unknown as ReturnType<
             typeof import("fs").readdirSync
           >;
@@ -161,13 +162,16 @@ test`;
       } as import("fs").Stats);
 
       vi.mocked(mockFs.readFileSync).mockImplementation((filePath) => {
-        if (filePath === "/builtin/subagents/explore.md") {
+        if (filePath === path.join("/builtin/subagents", "explore.md")) {
           return `---
 description: Built-in agent
 ---
 builtin prompt`;
         }
-        if (filePath === "/home/testuser/.wave/agents/explore.md") {
+        if (
+          filePath ===
+          path.join("/home/testuser", ".wave", "agents", "explore.md")
+        ) {
           return `---
 name: explore
 description: Custom Explore agent
@@ -197,12 +201,12 @@ Custom system prompt for user override`;
       process.env.HOME = "/home/testuser";
 
       vi.mocked(mockFs.readdirSync).mockImplementation((dirPath) => {
-        if (dirPath === "/home/testuser/.claude/agents") {
+        if (dirPath === path.join("/home/testuser", ".claude", "agents")) {
           return ["claude-agent.md"] as unknown as ReturnType<
             typeof import("fs").readdirSync
           >;
         }
-        if (dirPath === "/test/workdir/.claude/agents") {
+        if (dirPath === path.join("/test/workdir", ".claude", "agents")) {
           return ["project-claude-agent.md"] as unknown as ReturnType<
             typeof import("fs").readdirSync
           >;
@@ -215,14 +219,23 @@ Custom system prompt for user override`;
       } as import("fs").Stats);
 
       vi.mocked(mockFs.readFileSync).mockImplementation((filePath) => {
-        if (filePath === "/home/testuser/.claude/agents/claude-agent.md") {
+        if (
+          filePath ===
+          path.join("/home/testuser", ".claude", "agents", "claude-agent.md")
+        ) {
           return `---
 description: User-level Claude agent
 ---
 Claude agent system prompt`;
         }
         if (
-          filePath === "/test/workdir/.claude/agents/project-claude-agent.md"
+          filePath ===
+          path.join(
+            "/test/workdir",
+            ".claude",
+            "agents",
+            "project-claude-agent.md",
+          )
         ) {
           return `---
 description: Project-level Claude agent
@@ -258,8 +271,8 @@ Project Claude agent system prompt`;
 
       vi.mocked(mockFs.readdirSync).mockImplementation((dirPath) => {
         if (
-          dirPath === "/home/testuser/.claude/agents" ||
-          dirPath === "/home/testuser/.wave/agents"
+          dirPath === path.join("/home/testuser", ".claude", "agents") ||
+          dirPath === path.join("/home/testuser", ".wave", "agents")
         ) {
           return ["shared-agent.md"] as unknown as ReturnType<
             typeof import("fs").readdirSync
@@ -273,14 +286,20 @@ Project Claude agent system prompt`;
       } as import("fs").Stats);
 
       vi.mocked(mockFs.readFileSync).mockImplementation((filePath) => {
-        if (filePath === "/home/testuser/.claude/agents/shared-agent.md") {
+        if (
+          filePath ===
+          path.join("/home/testuser", ".claude", "agents", "shared-agent.md")
+        ) {
           return `---
 name: shared-agent
 description: Claude version
 ---
 Claude version prompt`;
         }
-        if (filePath === "/home/testuser/.wave/agents/shared-agent.md") {
+        if (
+          filePath ===
+          path.join("/home/testuser", ".wave", "agents", "shared-agent.md")
+        ) {
           return `---
 name: shared-agent
 description: Wave version

--- a/packages/agent-sdk/tests/utils/toolResultStorage.test.ts
+++ b/packages/agent-sdk/tests/utils/toolResultStorage.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as fs from "fs";
+import * as path from "path";
 
 // Mock fs
 vi.mock("fs", async () => {
@@ -108,15 +109,16 @@ describe("toolResultStorage", () => {
   describe("getToolResultsDir", () => {
     it("should create directory with mkdirSync recursive", () => {
       const dir = getToolResultsDir();
-      expect(dir).toBe("/tmp/wave-tool-results");
-      expect(fs.mkdirSync).toHaveBeenCalledWith("/tmp/wave-tool-results", {
+      const expected = path.join("/tmp", "wave-tool-results");
+      expect(dir).toBe(expected);
+      expect(fs.mkdirSync).toHaveBeenCalledWith(expected, {
         recursive: true,
       });
     });
 
     it("should use os.tmpdir() as base path", () => {
       const dir = getToolResultsDir();
-      expect(dir.startsWith("/tmp/")).toBe(true);
+      expect(dir.startsWith(path.join("/tmp"))).toBe(true);
       expect(dir).toContain("wave-tool-results");
     });
   });
@@ -127,10 +129,12 @@ describe("toolResultStorage", () => {
       const result = persistToolResult(content, "bash");
 
       expect(result).toMatch(
-        /\/tmp\/wave-tool-results\/bash_\d+_[a-z0-9]+\.txt$/,
+        /[/\\]wave-tool-results[/\\]bash_\d+_[a-z0-9]+\.txt$/,
       );
       expect(fs.writeFileSync).toHaveBeenCalledWith(
-        expect.stringContaining("/tmp/wave-tool-results/bash_"),
+        expect.stringContaining(
+          path.join("/tmp", "wave-tool-results", "bash_"),
+        ),
         content,
         "utf8",
       );
@@ -139,7 +143,7 @@ describe("toolResultStorage", () => {
     it("should use default prefix 'tool' when none provided", () => {
       const result = persistToolResult("content");
       expect(result).toMatch(
-        /\/tmp\/wave-tool-results\/tool_\d+_[a-z0-9]+\.txt$/,
+        /[/\\]wave-tool-results[/\\]tool_\d+_[a-z0-9]+\.txt$/,
       );
     });
 
@@ -179,7 +183,7 @@ describe("toolResultStorage", () => {
 
       expect(result).toContain("<persisted-output>");
       expect(result).toContain("100 characters");
-      expect(result).toContain("/tmp/wave-tool-results/bash_");
+      expect(result).toContain(path.join("/tmp", "wave-tool-results", "bash_"));
       expect(result).toContain("</persisted-output>");
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         expect.stringContaining("bash_"),
@@ -228,7 +232,9 @@ describe("toolResultStorage", () => {
       processToolResult(content, 50);
 
       expect(fs.writeFileSync).toHaveBeenCalledWith(
-        expect.stringContaining("/tmp/wave-tool-results/tool_"),
+        expect.stringContaining(
+          path.join("/tmp", "wave-tool-results", "tool_"),
+        ),
         content,
         "utf8",
       );

--- a/packages/agent-sdk/tests/utils/worktreeUtils.test.ts
+++ b/packages/agent-sdk/tests/utils/worktreeUtils.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as path from "node:path";
 import * as worktreeUtils from "@/utils/worktreeUtils.js";
 import * as gitUtils from "@/utils/gitUtils.js";
 import * as fs from "node:fs";
@@ -91,7 +92,9 @@ describe("worktreeUtils", () => {
 
       expect(result.name).toBe("my-feat");
       expect(result.branch).toBe("worktree-my-feat");
-      expect(result.path).toBe("/test/repo/.wave/worktrees/my-feat");
+      expect(result.path).toBe(
+        path.join("/test/repo", ".wave", "worktrees", "my-feat"),
+      );
       expect(result.repoRoot).toBe("/test/repo");
       expect(result.isNew).toBe(true);
       expect(result.originalHeadCommit).toBe("abc123");

--- a/packages/code/tests/index.test.ts
+++ b/packages/code/tests/index.test.ts
@@ -274,8 +274,8 @@ describe("main", () => {
       continueLastSession: undefined,
       bypassPermissions: false,
       pluginDirs: [
-        expect.stringContaining("/tmp/plugins1"),
-        expect.stringContaining("/tmp/plugins2"),
+        expect.stringContaining(path.join("/tmp", "plugins1")),
+        expect.stringContaining(path.join("/tmp", "plugins2")),
       ],
       tools: undefined,
       worktreeSession: undefined,

--- a/packages/code/tests/index.test.ts
+++ b/packages/code/tests/index.test.ts
@@ -236,7 +236,7 @@ describe("main", () => {
       restoreSessionId: undefined,
       continueLastSession: undefined,
       bypassPermissions: false,
-      pluginDirs: [expect.stringContaining("/tmp/plugins")],
+      pluginDirs: [expect.stringContaining(path.join("/tmp", "plugins"))],
       tools: undefined,
       worktreeSession: undefined,
       workdir: process.cwd(),

--- a/packages/code/tests/utils/worktree.test.ts
+++ b/packages/code/tests/utils/worktree.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
+import * as path from "node:path";
 import { createWorktree, removeWorktree } from "../../src/utils/worktree.js";
 import { getDefaultRemoteBranch, getGitMainRepoRoot } from "wave-agent-sdk";
 
@@ -32,7 +33,9 @@ describe("worktree utils", () => {
       const session = createWorktree("my-feat", "/repo/root");
 
       expect(session.name).toBe("my-feat");
-      expect(session.path).toBe("/repo/root/.wave/worktrees/my-feat");
+      expect(session.path).toBe(
+        path.join("/repo/root", ".wave", "worktrees", "my-feat"),
+      );
       expect(session.branch).toBe("worktree-my-feat");
       expect(session.repoRoot).toBe("/repo/root");
       expect(session.isNew).toBe(true);

--- a/packages/vsce/tests/stdio/binaryResolver.test.ts
+++ b/packages/vsce/tests/stdio/binaryResolver.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'path';
 
 // ── Mocks ──────────────────────────────────────────────────────
 
@@ -16,6 +17,21 @@ vi.mock('fs', () => ({
     default: { existsSync: mockExistsSync },
     existsSync: mockExistsSync,
 }));
+
+// ── Platform-aware constants ───────────────────────────────────
+// The source uses `which`/`where`, `wave`/`wave.cmd`, and a different
+// global-bin layout per platform. Mirror those here so mocks match on
+// both Linux and Windows runners.
+
+const isWin = process.platform === 'win32';
+const waveLookup = isWin ? 'where wave' : 'which wave';
+const npmLookup = isWin ? 'where npm' : 'which npm';
+const npmBin = isWin ? 'C:\\nodejs\\npm.cmd' : '/usr/bin/npm';
+const npmPrefix = isWin ? 'C:\\nodejs' : '/usr/local';
+// Source: globalBin = prefix on Windows, path.join(prefix, 'bin') elsewhere.
+const globalBin = isWin ? npmPrefix : path.join(npmPrefix, 'bin');
+const waveName = isWin ? 'wave.cmd' : 'wave';
+const globalWave = path.join(globalBin, waveName);
 
 // ── Import after mocks ─────────────────────────────────────────
 
@@ -36,20 +52,20 @@ describe('binaryResolver', () => {
 
     it('returns wave path from which/where command', async () => {
         mockExecSync.mockImplementation((cmd: string) => {
-            if (cmd.includes('which wave') || cmd.includes('where wave')) {
-                return '/usr/local/bin/wave\n';
+            if (cmd.includes(waveLookup)) {
+                return `${globalWave}\n`;
             }
             throw new Error('unexpected');
         });
 
         const result = await resolveWaveBinary();
-        expect(result).toBe('/usr/local/bin/wave');
+        expect(result).toBe(globalWave);
     });
 
     it('trims whitespace and takes first line from which output', async () => {
         mockExecSync.mockImplementation((cmd: string) => {
-            if (cmd.includes('which wave')) {
-                return '  /usr/bin/wave\n/opt/wave\n';
+            if (cmd.includes(waveLookup)) {
+                return `  /usr/bin/wave\n/opt/wave\n`;
             }
             throw new Error('unexpected');
         });
@@ -62,17 +78,17 @@ describe('binaryResolver', () => {
 
     it('finds wave in npm global bin directory when not on PATH', async () => {
         mockExecSync.mockImplementation((cmd: string) => {
-            if (cmd.includes('which wave')) throw new Error('not found');
-            if (cmd.includes('which npm')) return '/usr/bin/npm\n';
-            if (cmd.includes('prefix -g')) return '/usr/local\n';
+            if (cmd.includes(waveLookup)) throw new Error('not found');
+            if (cmd.includes(npmLookup)) return `${npmBin}\n`;
+            if (cmd.includes('prefix -g')) return `${npmPrefix}\n`;
             throw new Error(`unexpected: ${cmd}`);
         });
         mockExistsSync.mockImplementation((p: string) => {
-            return p === '/usr/local/bin/wave';
+            return p === globalWave;
         });
 
         const result = await resolveWaveBinary();
-        expect(result).toBe('/usr/local/bin/wave');
+        expect(result).toBe(globalWave);
     });
 
     // ── Installs wave-code when not found ──────────────────────
@@ -80,12 +96,12 @@ describe('binaryResolver', () => {
     it('installs wave-code globally when not found anywhere', async () => {
         let installCalled = false;
         mockExecSync.mockImplementation((cmd: string) => {
-            if (cmd.includes('which wave')) {
-                if (installCalled) return '/usr/local/bin/wave\n';
+            if (cmd.includes(waveLookup)) {
+                if (installCalled) return `${globalWave}\n`;
                 throw new Error('not found');
             }
-            if (cmd.includes('which npm')) return '/usr/bin/npm\n';
-            if (cmd.includes('prefix -g')) return '/usr/local\n';
+            if (cmd.includes(npmLookup)) return `${npmBin}\n`;
+            if (cmd.includes('prefix -g')) return `${npmPrefix}\n`;
             if (cmd.includes('install -g wave-code')) {
                 installCalled = true;
                 return '';
@@ -93,11 +109,11 @@ describe('binaryResolver', () => {
             throw new Error(`unexpected: ${cmd}`);
         });
         mockExistsSync.mockImplementation((p: string) => {
-            return installCalled && p === '/usr/local/bin/wave';
+            return installCalled && p === globalWave;
         });
 
         const result = await resolveWaveBinary();
-        expect(result).toBe('/usr/local/bin/wave');
+        expect(result).toBe(globalWave);
         expect(installCalled).toBe(true);
     });
 
@@ -105,18 +121,18 @@ describe('binaryResolver', () => {
 
     it('caches result and does not re-resolve on second call', async () => {
         mockExecSync.mockImplementation((cmd: string) => {
-            if (cmd.includes('which wave')) return '/usr/local/bin/wave\n';
+            if (cmd.includes(waveLookup)) return `${globalWave}\n`;
             throw new Error('unexpected');
         });
 
         const result1 = await resolveWaveBinary();
         const result2 = await resolveWaveBinary();
 
-        expect(result1).toBe('/usr/local/bin/wave');
-        expect(result2).toBe('/usr/local/bin/wave');
-        // which wave should only be called once due to caching
+        expect(result1).toBe(globalWave);
+        expect(result2).toBe(globalWave);
+        // wave lookup should only be called once due to caching
         const whichCalls = mockExecSync.mock.calls.filter(
-            (c: unknown[]) => (c[0] as string).includes('which wave'),
+            (c: unknown[]) => (c[0] as string).includes(waveLookup),
         );
         expect(whichCalls).toHaveLength(1);
     });
@@ -125,8 +141,8 @@ describe('binaryResolver', () => {
 
     it('throws when npm global prefix cannot be determined', () => {
         mockExecSync.mockImplementation((cmd: string) => {
-            if (cmd.includes('which wave')) throw new Error('not found');
-            if (cmd.includes('which npm')) throw new Error('not found');
+            if (cmd.includes(waveLookup)) throw new Error('not found');
+            if (cmd.includes(npmLookup)) throw new Error('not found');
             throw new Error(`unexpected: ${cmd}`);
         });
         // findNpm falls back to process.execPath dir checks; all return false
@@ -139,9 +155,9 @@ describe('binaryResolver', () => {
 
     it('throws when wave not found after installation', () => {
         mockExecSync.mockImplementation((cmd: string) => {
-            if (cmd.includes('which wave')) throw new Error('not found');
-            if (cmd.includes('which npm')) return '/usr/bin/npm\n';
-            if (cmd.includes('prefix -g')) return '/usr/local\n';
+            if (cmd.includes(waveLookup)) throw new Error('not found');
+            if (cmd.includes(npmLookup)) return `${npmBin}\n`;
+            if (cmd.includes('prefix -g')) return `${npmPrefix}\n`;
             if (cmd.includes('install -g wave-code')) return '';
             throw new Error(`unexpected: ${cmd}`);
         });
@@ -158,22 +174,22 @@ describe('binaryResolver', () => {
     it('install-if-missing uses npmmirror registry', async () => {
         let installCmd = '';
         mockExecSync.mockImplementation((cmd: string) => {
-            if (cmd.includes('which wave')) {
-                if (installCmd) return '/usr/local/bin/wave\n';
+            if (cmd.includes(waveLookup)) {
+                if (installCmd) return `${globalWave}\n`;
                 throw new Error('not found');
             }
-            if (cmd.includes('which npm')) return '/usr/bin/npm\n';
-            if (cmd.includes('prefix -g')) return '/usr/local\n';
+            if (cmd.includes(npmLookup)) return `${npmBin}\n`;
+            if (cmd.includes('prefix -g')) return `${npmPrefix}\n`;
             if (cmd.includes('install -g wave-code')) {
                 installCmd = cmd;
                 return '';
             }
             throw new Error(`unexpected: ${cmd}`);
         });
-        mockExistsSync.mockImplementation((p: string) => !!installCmd && p === '/usr/local/bin/wave');
+        mockExistsSync.mockImplementation((p: string) => !!installCmd && p === globalWave);
 
         const result = await resolveWaveBinary();
-        expect(result).toBe('/usr/local/bin/wave');
+        expect(result).toBe(globalWave);
         expect(installCmd).toContain(`--registry=${NPM_REGISTRY}`);
     });
 
@@ -181,7 +197,7 @@ describe('binaryResolver', () => {
 
     it('resetCache clears the cached path', async () => {
         mockExecSync.mockImplementation((cmd: string) => {
-            if (cmd.includes('which wave')) return '/usr/local/bin/wave\n';
+            if (cmd.includes(waveLookup)) return `${globalWave}\n`;
             throw new Error('unexpected');
         });
 
@@ -190,7 +206,7 @@ describe('binaryResolver', () => {
         await resolveWaveBinary();
 
         const whichCalls = mockExecSync.mock.calls.filter(
-            (c: unknown[]) => (c[0] as string).includes('which wave'),
+            (c: unknown[]) => (c[0] as string).includes(waveLookup),
         );
         expect(whichCalls).toHaveLength(2);
     });
@@ -199,8 +215,8 @@ describe('binaryResolver', () => {
 
     it('upgradeWaveBinary installs the target version via execFile with npmmirror registry', async () => {
         mockExecSync.mockImplementation((cmd: string) => {
-            if (cmd.includes('which npm')) return '/usr/bin/npm\n';
-            if (cmd.includes('which wave')) return '/usr/local/bin/wave\n';
+            if (cmd.includes(npmLookup)) return `${npmBin}\n`;
+            if (cmd.includes(waveLookup)) return `${globalWave}\n`;
             throw new Error(`unexpected: ${cmd}`);
         });
         mockExecFile.mockImplementation((...args: unknown[]) => {
@@ -210,26 +226,26 @@ describe('binaryResolver', () => {
 
         const result = await upgradeWaveBinary('1.2.3');
 
-        expect(result).toBe('/usr/local/bin/wave');
+        expect(result).toBe(globalWave);
         expect(mockExecFile).toHaveBeenCalledTimes(1);
         const callArgs = mockExecFile.mock.calls[0];
-        expect(callArgs[0]).toBe('/usr/bin/npm');
+        expect(callArgs[0]).toBe(npmBin);
         expect(callArgs[1]).toEqual([
             'install',
             '-g',
             'wave-code@1.2.3',
             `--registry=${NPM_REGISTRY}`,
         ]);
-        // cache was invalidated: resolveWaveBinary re-ran `which wave`
+        // cache was invalidated: resolveWaveBinary re-ran wave lookup
         const whichCalls = mockExecSync.mock.calls.filter(
-            (c: unknown[]) => (c[0] as string).includes('which wave'),
+            (c: unknown[]) => (c[0] as string).includes(waveLookup),
         );
         expect(whichCalls).toHaveLength(1);
     });
 
     it('upgradeWaveBinary rejects when execFile errors', async () => {
         mockExecSync.mockImplementation((cmd: string) => {
-            if (cmd.includes('which npm')) return '/usr/bin/npm\n';
+            if (cmd.includes(npmLookup)) return `${npmBin}\n`;
             throw new Error(`unexpected: ${cmd}`);
         });
         mockExecFile.mockImplementation((...args: unknown[]) => {


### PR DESCRIPTION
## 背景

现有 CI（\`.github/workflows/ci.yml\`）只跑 \`ubuntu-latest\`，Windows 分支代码（\`binaryResolver.ts\` / \`BinaryResolver.kt\` 里的 \`win32\` / \`where\` / \`wave.cmd\` 路径处理）从未被自动化测试覆盖。

## 方案

新增 \`ci-windows.yml\`，在 \`windows-latest\` 上跑 \`pnpm build && pnpm run ci\`，和 Linux CI 并行。

**不阻塞 PR merge**：
- Windows runner 较慢，不应拖累 merge 速度
- 本 workflow 不设为 required status check
- 失败结果在 PR checks 列表可见（红叉），但不阻断合并

## 需要的 repo 配置

合并后在 **Settings → Branches → \`main\` protection rule → Require status checks** 里：
- ✅ 只勾 Linux 的 \`check\`
- ❌ 不要勾 \`check-windows\`

## 测试计划

- [ ] 本 PR 触发 \`CI (Windows)\` workflow，确认能跑通 \`pnpm install --frozen-lockfile\` + \`pnpm build\` + \`pnpm run ci\`
- [ ] 如有 Windows 特定失败（路径分隔符 / \`where\` 行为差异等），单独修