### PR TITLE
fix(workflow): live-update WorkflowRun + UI on progress during execution

### DIFF
--- a/packages/agent-sdk/src/managers/backgroundTaskManager.ts
+++ b/packages/agent-sdk/src/managers/backgroundTaskManager.ts
@@ -35,7 +35,12 @@ export class BackgroundTaskManager {
     return this.container.get<NotificationQueue>("NotificationQueue")!;
   }
 
-  private notifyTasksChange(): void {
+  /**
+   * Fire the onBackgroundTasksChange callback so UI consumers refresh.
+   * Public so other managers (e.g. WorkflowManager) can trigger a refresh
+   * when their state changes without mutating a background task.
+   */
+  public notifyTasksChange(): void {
     this.callbacks.onBackgroundTasksChange?.(Array.from(this.tasks.values()));
   }
 

--- a/packages/agent-sdk/src/managers/workflowManager.ts
+++ b/packages/agent-sdk/src/managers/workflowManager.ts
@@ -164,13 +164,20 @@ export class WorkflowManager {
     );
     const progressReporter = new ProgressReporter(run.meta, runId);
 
-    // Forward progress events via onProgress callback
+    // Forward progress events: mirror live counts onto the WorkflowRun and
+    // trigger a UI refresh so /workflows updates mid-execution (not just at
+    // completion). The UI reads getWorkflowRuns() -> listRuns(), which returns
+    // these same in-memory run objects.
     const onProgress = (
       event: import("../workflow/types.js").WorkflowProgressEvent,
     ) => {
       logger.debug(
         `[Workflow:${runId}] progress: ${event.type} phase=${event.phaseIndex} agent=${event.agentIndex}`,
       );
+      run.phases = progressReporter.getPhaseStates();
+      run.totalAgents = progressReporter.totalAgents;
+      run.totalTokens = progressReporter.totalTokens;
+      this.backgroundTaskManager.notifyTasksChange();
     };
     progressReporter.onEvent(onProgress);
 
@@ -251,11 +258,6 @@ export class WorkflowManager {
       sessionDir: this.sessionDir,
       runDir: path.join(this.sessionDir, "workflows", runId),
       agentControllers: runAgentControllers,
-      onProgress: (event) => {
-        logger.debug(
-          `[Workflow:${runId}] progress: ${event.type} phase=${event.phaseIndex} agent=${event.agentIndex}`,
-        );
-      },
       onLog: (message: string) => {
         logger.info(`[Workflow:${runId}] ${message}`);
       },

--- a/packages/agent-sdk/src/workflow/workflowApis.ts
+++ b/packages/agent-sdk/src/workflow/workflowApis.ts
@@ -5,7 +5,7 @@ import { ConcurrencyLimiter } from "./concurrencyLimiter.js";
 import { BudgetTracker } from "./budgetTracker.js";
 import { ProgressReporter } from "./progressReporter.js";
 import { Journal } from "./journal.js";
-import type { BudgetInfo, AgentMeta, WorkflowProgressEvent } from "./types.js";
+import type { BudgetInfo, AgentMeta } from "./types.js";
 import {
   createStructuredOutputPrompt,
   createStructuredOutputTool,
@@ -54,8 +54,6 @@ interface WorkflowApiContext {
   runDir: string;
   /** Per-agent abort controllers for kill/skip support */
   agentControllers: Map<number, AbortController>;
-  /** Optional callback for progress events */
-  onProgress?: (event: WorkflowProgressEvent) => void;
 }
 
 interface AgentOpts {

--- a/packages/agent-sdk/tests/workflow/workflowManager.test.ts
+++ b/packages/agent-sdk/tests/workflow/workflowManager.test.ts
@@ -17,6 +17,7 @@ function createMockContainer(sessionDir?: string) {
     generateId: vi.fn().mockReturnValue("task-1"),
     addTask: vi.fn(),
     getTask: vi.fn().mockReturnValue(null),
+    notifyTasksChange: vi.fn(),
   };
 
   const mockNotificationQueue = {
@@ -376,6 +377,123 @@ describe("WorkflowManager", () => {
       await expect(manager.retryAgent("wf_nonexistent", 0)).rejects.toThrow(
         "not found",
       );
+    });
+  });
+
+  describe("live progress updates", () => {
+    // Verifies that WorkflowRun fields (phases, totalAgents, totalTokens)
+    // update live during execution, not only at completion — so the
+    // /workflows UI reflects progress mid-run.
+    it("updates run phases/agents/tokens and notifies mid-run, not only at completion", async () => {
+      const tmpDir = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), "wf-progress-"),
+      );
+
+      const notifyTasksChange = vi.fn();
+      // Agent() blocks on these gates so the test can observe mid-run state.
+      let resolveScan: () => void = () => {};
+      let resolveSynth: () => void = () => {};
+      const scanGate = new Promise<void>((r) => {
+        resolveScan = r;
+      });
+      const synthGate = new Promise<void>((r) => {
+        resolveSynth = r;
+      });
+
+      const container = new Container();
+      container.register("BackgroundTaskManager", {
+        generateId: vi.fn().mockReturnValue("task-progress"),
+        addTask: vi.fn(),
+        getTask: vi
+          .fn()
+          .mockReturnValue({ id: "task-progress", status: "running" }),
+        notifyTasksChange,
+      });
+      container.register("NotificationQueue", { enqueue: vi.fn() });
+      container.register("SubagentManager", {
+        findSubagent: vi.fn().mockResolvedValue({ id: "general-purpose" }),
+        createInstance: vi.fn().mockResolvedValue({
+          subagentId: "sub-1",
+          toolManager: { register: vi.fn() },
+          permissionManager: { addTemporaryRules: vi.fn() },
+          messageManager: {
+            getMessages: vi
+              .fn()
+              .mockReturnValue([
+                { role: "assistant", usage: { total_tokens: 1234 } },
+              ]),
+            getTranscriptPath: vi.fn().mockReturnValue(undefined),
+          },
+        }),
+        // Block scan agents on the scan gate, synth agent on the synth gate.
+        executeAgent: vi
+          .fn()
+          .mockImplementation(async (_inst: unknown, _prompt: string) => {
+            if (_prompt.startsWith("scan")) {
+              await scanGate;
+            } else {
+              await synthGate;
+            }
+            return "result";
+          }),
+        cleanupInstance: vi.fn(),
+      });
+      container.register("MessageManager", {
+        getSessionDir: vi.fn().mockReturnValue(tmpDir),
+      });
+      container.register("workdir", tmpDir);
+
+      const progressManager = new WorkflowManager(container);
+
+      const script = [
+        "export const meta = { name: 'live-progress', description: 'd', phases: [{ title: 'Scan' }, { title: 'Synthesize' }] }",
+        "phase('Scan')",
+        "await parallel([() => agent('scan-a'), () => agent('scan-b')])",
+        "phase('Synthesize')",
+        "await agent('synthesize')",
+        "return 'done'",
+      ].join("\n");
+      const run = await progressManager.createRun(script);
+      await progressManager.startRun(run.runId);
+
+      // Let the event loop turn so scan agents start and emit agent_started.
+      await new Promise((r) => setTimeout(r, 20));
+
+      // --- MID-RUN snapshot: scan agents started, not yet completed ---
+      const midRun = progressManager.getRun(run.runId)!;
+      expect(midRun.status).toBe("running");
+      expect(midRun.totalAgents).toBe(2);
+      expect(midRun.totalTokens).toBe(0);
+      expect(midRun.phases).toHaveLength(2);
+      expect(midRun.phases[0].agentCount).toBe(2); // Scan phase
+      expect(midRun.phases[1].agentCount).toBe(0); // Synthesize not started
+      // notifyTasksChange fired for the phase/agent_started events.
+      expect(notifyTasksChange).toHaveBeenCalled();
+
+      // Release scan agents -> they complete and Synthesize starts.
+      resolveScan();
+      await new Promise((r) => setTimeout(r, 20));
+
+      // --- After scan completes, before synth completes ---
+      const afterScan = progressManager.getRun(run.runId)!;
+      expect(afterScan.status).toBe("running");
+      expect(afterScan.totalAgents).toBe(3);
+      expect(afterScan.totalTokens).toBe(2468); // 2 scan agents * 1234 tokens
+      expect(afterScan.phases[0].tokens).toBe(2468);
+      expect(afterScan.phases[1].agentCount).toBe(1); // synth agent started
+
+      // Release synth -> run completes.
+      resolveSynth();
+      await run.completionPromise;
+
+      // --- Final snapshot ---
+      expect(run.status).toBe("completed");
+      expect(run.totalAgents).toBe(3);
+      expect(run.totalTokens).toBe(3702); // 3 agents * 1234 tokens
+      expect(run.phases[0].tokens).toBe(2468);
+      expect(run.phases[1].tokens).toBe(1234);
+
+      await fs.promises.rm(tmpDir, { recursive: true, force: true });
     });
   });
 });


### PR DESCRIPTION
## Problem

The `/workflows` UI was frozen for the entire duration of a workflow run: phases, `totalAgents` and `totalTokens` stayed at `0`/`[]` and only appeared when the run completed.

## Root cause

- `WorkflowManager`'s `onProgress` handler only logged progress events (`logger.debug`) and never wrote them back onto the `WorkflowRun` object that `getWorkflowRuns()`/`listRuns()` exposes to the UI. Those fields were assigned **only** in the completion (`workflowManager.ts:277-279`) and failure (`:321-323`) branches.
- `BackgroundTaskManager.notifyTasksChange()` was private, so even if the run were updated there was no way for per-agent/per-phase progress events to trigger a UI refresh — notify only fired on task add/stop/complete.
- `ProgressReporter` already tracked live counts internally; they just weren't surfaced.

The UI refresh path in `packages/code` (`useChat.tsx:384-389`) calls `getWorkflowRuns()` on every `onBackgroundTasksChange`, so wiring progress events into `notifyTasksChange()` is sufficient to refresh it.

## Changes

- **`backgroundTaskManager.ts`**: make `notifyTasksChange()` public so other managers can trigger a UI refresh without mutating a task.
- **`workflowManager.ts`**: in the `onProgress` handler, mirror `ProgressReporter`'s live counts (`phases`/`totalAgents`/`totalTokens`) onto the `WorkflowRun` and call `backgroundTaskManager.notifyTasksChange()`. Remove the dead `onProgress` passed to `createWorkflowApis` (declared in the context but never invoked from inside `workflowApis`).
- **`workflowApis.ts`**: drop the now-unused `onProgress` context field and its import.

## Verification

- Added a unit test in `tests/workflow/workflowManager.test.ts` that gates `agent()` execution on controllable promises and asserts the run snapshot updates **mid-run** (agents started → scan completed → synth started) and that `notifyTasksChange` fires, not only at completion.
- Full agent-sdk suite: `3222 passed | 1 skipped`.
- `pnpm -F wave-agent-sdk run type-check` clean.

Before (mid-run snapshot via a temporary reproducer):
```
+    3ms  status=running totalAgents=0 totalTokens=0 phases=[]
```
After:
```
+    4ms  status=running totalAgents=3 totalTokens=0 phases=[Scan={agents:3,tok:0} Synthesize={agents:0,tok:0}]
+  329ms  status=running totalAgents=4 totalTokens=3702 phases=[Scan={agents:3,tok:3702} Synthesize={agents:1,tok:0}]
+  572ms  status=completed totalAgents=4 totalTokens=4936 phases=[Scan={agents:3,tok:3702} Synthesize={agents:1,tok:1234}]
```