### PR TITLE
fix(vsce): spawn wave/npm .cmd shims with shell on Windows

### DIFF
--- a/packages/vsce/src/stdio/binaryResolver.ts
+++ b/packages/vsce/src/stdio/binaryResolver.ts
@@ -135,12 +135,25 @@ export function resetCache(): void {
  * Resets the cached path on success and returns the freshly-resolved binary path.
  */
 export async function upgradeWaveBinary(targetVersion: string): Promise<string> {
+    // Validate the version before it touches a shell. targetVersion originates
+    // from the extension's package.json (trusted), but on Windows execFile runs
+    // through cmd.exe (see shell option below); a strict semver check preserves
+    // the "no shell injection of the version arg" guarantee this function held
+    // when it used execFile without a shell.
+    const SEMVER_RE = /^v?\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$/;
+    if (!SEMVER_RE.test(targetVersion)) {
+        throw new Error(`Invalid version: ${targetVersion}`);
+    }
+
     const npm = findNpm();
     await new Promise<void>((resolve, reject) => {
         execFile(
             npm,
             ['install', '-g', `wave-code@${targetVersion}`, `--registry=${NPM_REGISTRY}`],
-            { encoding: 'utf-8' },
+            // `npm` is `npm.cmd` on Windows; Node refuses to execFile a `.cmd`
+            // without a shell (ERR_CHILD_PROCESS_INVALID_COMMAND_FILE). The
+            // validated version above contains no shell metacharacters.
+            { encoding: 'utf-8', shell: process.platform === 'win32' },
             (err) => {
                 if (err) reject(err);
                 else resolve();

--- a/packages/vsce/src/stdio/stdioClient.ts
+++ b/packages/vsce/src/stdio/stdioClient.ts
@@ -27,9 +27,15 @@ export class StdioClient {
         args: string[] = [],
         env?: Record<string, string>,
     ) {
+        // On Windows, binaryPath may be a `wave.cmd` shim. Node (since the
+        // CVE-2024-27980 patch) refuses to spawn `.cmd`/`.bat` files without a
+        // shell, throwing ERR_CHILD_PROCESS_INVALID_COMMAND_FILE. `args` is a
+        // fixed flag list (`['--stdio']`) with no metacharacters, so enabling
+        // the shell on Windows is safe; Unix behaviour is unchanged.
         this.proc = spawn(binaryPath, args, {
             stdio: ['pipe', 'pipe', 'pipe'],
             env: { ...process.env, ...env },
+            shell: process.platform === 'win32',
         });
 
         const rl = createInterface({ input: this.proc.stdout! });

--- a/packages/vsce/tests/stdio/binaryResolver.test.ts
+++ b/packages/vsce/tests/stdio/binaryResolver.test.ts
@@ -255,4 +255,74 @@ describe('binaryResolver', () => {
 
         await expect(upgradeWaveBinary('1.2.3')).rejects.toThrow('install failed');
     });
+
+    // ── Version validation (shell-injection guard) ────────────
+    // On Windows, execFile runs through cmd.exe; the version is validated
+    // first so shell metacharacters can never reach the shell.
+
+    it('upgradeWaveBinary rejects non-semver versions and never reaches execFile', async () => {
+        await expect(upgradeWaveBinary('1.2.3; rm -rf /')).rejects.toThrow('Invalid version');
+        await expect(upgradeWaveBinary('$(rm -rf /)')).rejects.toThrow('Invalid version');
+        await expect(upgradeWaveBinary('')).rejects.toThrow('Invalid version');
+        expect(mockExecFile).not.toHaveBeenCalled();
+    });
+
+    it('upgradeWaveBinary accepts prerelease/build semver', async () => {
+        mockExecSync.mockImplementation((cmd: string) => {
+            if (cmd.includes(npmLookup)) return `${npmBin}\n`;
+            if (cmd.includes(waveLookup)) return `${globalWave}\n`;
+            throw new Error(`unexpected: ${cmd}`);
+        });
+        mockExecFile.mockImplementation((...args: unknown[]) => {
+            const cb = args[args.length - 1] as (err: Error | null) => void;
+            cb(null);
+        });
+
+        await expect(upgradeWaveBinary('1.2.3-alpha.1')).resolves.toBe(globalWave);
+        await expect(upgradeWaveBinary('1.2.3+build.7')).resolves.toBe(globalWave);
+    });
+
+    // ── Windows .cmd execFile guard ───────────────────────────
+    // `npm` resolves to `npm.cmd` on Windows; execFile refuses a `.cmd`
+    // without `shell: true` (ERR_CHILD_PROCESS_INVALID_COMMAND_FILE).
+    // Simulate the guard on Linux so the reproducer runs in blocking CI.
+
+    function withPlatform<T>(platform: string, fn: () => Promise<T>): Promise<T> {
+        const original = Object.getOwnPropertyDescriptor(process, 'platform');
+        Object.defineProperty(process, 'platform', { value: platform });
+        return fn().finally(() => {
+            if (original) Object.defineProperty(process, 'platform', original);
+        });
+    }
+
+    it('upgradeWaveBinary uses shell:true for npm.cmd on Windows', async () => {
+        const npmCmd = 'C:\\nodejs\\npm.cmd';
+        const waveCmd = 'C:\\nodejs\\wave.cmd';
+
+        await withPlatform('win32', async () => {
+            mockExecSync.mockImplementation((cmd: string) => {
+                if (cmd.includes('where npm')) return `${npmCmd}\n`;
+                if (cmd.includes('where wave')) return `${waveCmd}\n`;
+                if (cmd.includes('prefix -g')) return 'C:\\nodejs\n';
+                throw new Error(`unexpected: ${cmd}`);
+            });
+            mockExecFile.mockImplementation((...args: unknown[]) => {
+                const cmd = args[0] as string;
+                const opts = args[2] as { shell?: boolean } | undefined;
+                // Enforce Node's Windows guard: refuse npm.cmd without shell.
+                if (/\.cmd$/i.test(cmd) && opts?.shell !== true) {
+                    throw new Error('ERR_CHILD_PROCESS_INVALID_COMMAND_FILE');
+                }
+                const cb = args[args.length - 1] as (err: Error | null) => void;
+                cb(null);
+            });
+
+            const result = await upgradeWaveBinary('1.2.3');
+
+            expect(result).toBe(waveCmd);
+            const callArgs = mockExecFile.mock.calls[0];
+            expect(callArgs[0]).toBe(npmCmd);
+            expect((callArgs[2] as { shell?: boolean }).shell).toBe(true);
+        });
+    });
 });

--- a/packages/vsce/tests/stdio/stdioClient.test.ts
+++ b/packages/vsce/tests/stdio/stdioClient.test.ts
@@ -100,6 +100,66 @@ describe('StdioClient', () => {
         expect(callEnv).toHaveProperty('PATH'); // inherited from process.env
     });
 
+    // ── Windows .cmd handling ─────────────────────────────────
+    // Node (since CVE-2024-27980, in VS Code's bundled Node 20.x) refuses to
+    // spawn a `.cmd`/`.bat` without `shell: true`, throwing
+    // ERR_CHILD_PROCESS_INVALID_COMMAND_FILE. `resolveWaveBinary` returns
+    // `wave.cmd` on Windows, so StdioClient must set `shell: true` there.
+    // These tests simulate that guard on Linux so the reproducer runs in the
+    // blocking CI pipeline.
+
+    function withPlatform<T>(platform: string, fn: () => T): T {
+        const original = Object.getOwnPropertyDescriptor(process, 'platform');
+        Object.defineProperty(process, 'platform', { value: platform });
+        try {
+            return fn();
+        } finally {
+            if (original) Object.defineProperty(process, 'platform', original);
+        }
+    }
+
+    /** Mock spawn that enforces Node's Windows `.cmd` guard. */
+    function spawnWithCmdGuard(proc: MockProc) {
+        mockSpawn.mockImplementation((cmd: string, _args: string[], options: { shell?: boolean } | undefined) => {
+            const isCmdShim = /\.cmd$/i.test(cmd);
+            if (isCmdShim && options?.shell !== true) {
+                const err = new Error('spawn wave.cmd ERR_CHILD_PROCESS_INVALID_COMMAND_FILE');
+                (err as Error & { code?: string }).code = 'ERR_CHILD_PROCESS_INVALID_COMMAND_FILE';
+                throw err;
+            }
+            return proc;
+        });
+    }
+
+    it('spawns wave.cmd with shell:true on Windows', () => {
+        withPlatform('win32', () => {
+            const proc = createMockProc();
+            const rl = new EventEmitter();
+            spawnWithCmdGuard(proc);
+            mockCreateInterface.mockReturnValue(rl);
+
+            // With the fix, shell:true is set → guard does not throw.
+            expect(() => new StdioClient('C:\\nodejs\\wave.cmd', ['--stdio'])).not.toThrow();
+
+            const call = mockSpawn.mock.calls[0];
+            expect(call[0]).toBe('C:\\nodejs\\wave.cmd');
+            expect(call[2].shell).toBe(true);
+        });
+    });
+
+    it('does not set shell on non-Windows platforms', () => {
+        // Force-evaluate on a non-win32 platform to confirm Unix parity.
+        withPlatform('linux', () => {
+            const proc = createMockProc();
+            mockSpawn.mockReturnValue(proc);
+            mockCreateInterface.mockReturnValue(new EventEmitter());
+
+            new StdioClient('/usr/local/bin/wave', ['--stdio']);
+
+            expect(mockSpawn.mock.calls[0][2].shell).toBe(false);
+        });
+    });
+
     // ── Request / Response ─────────────────────────────────────
 
     it('sends request with auto-incrementing id and returns result', async () => {


### PR DESCRIPTION
## Problem

On Windows the `wave` CLI installs as `wave.cmd` (and `npm` is `npm.cmd`). Since the CVE-2024-27980 patch — which VS Code's bundled Node 20.x includes — Node refuses to `spawn`/`execFile` a `.cmd`/`.bat` file without `shell: true`, throwing `ERR_CHILD_PROCESS_INVALID_COMMAND_FILE`.

The VSCode extension correctly *resolved* `wave.cmd` and `npm.cmd`, but the two sites that actually *execute* them passed the `.cmd` path without `shell: true`, so on Windows:
- the CLI failed to start (`stdioClient` spawn of `wave.cmd`), and
- the auto-upgrade failed (`binaryResolver.upgradeWaveBinary` execFile of `npm.cmd`).

Existing tests mocked `child_process` entirely, so real Node Windows behavior was never exercised and the issue shipped green.

## Fix

- **`stdioClient.ts`** — `spawn` now sets `shell: process.platform === 'win32'`. `args` is a fixed `['--stdio']` flag list with no metacharacters, so enabling the shell on Windows is safe; Unix behaviour is unchanged.
- **`binaryResolver.ts`** — `upgradeWaveBinary` adds a strict semver guard before `execFile` (preserving the existing no-shell-injection guarantee for the version arg), then sets `shell: process.platform === 'win32'` on `execFile`.

## Tests

New tests simulate Node's Windows `.cmd` guard on Linux so the reproducer runs in the blocking CI pipeline (not only the non-blocking Windows CI):
- `stdioClient.test.ts` — `wave.cmd` spawns with `shell:true` on win32; `shell:false` on Linux.
- `binaryResolver.test.ts` — non-semver versions (`1.2.3; rm -rf /`, `$(rm -rf /)`, empty) throw `Invalid version` and never reach `execFile`; prerelease/build semver accepted; `npm.cmd` execFile uses `shell:true` on win32.

Verified the new tests **fail on the unpatched source** (they throw `ERR_CHILD_PROCESS_INVALID_COMMAND_FILE`) before restoring the fix — i.e. they genuinely reproduce the issue rather than asserting the patch.

## Verification

- `pnpm --filter wave-vsce exec vitest run` — 7 files, 90 tests pass.
- `pnpm --filter wave-vsce run lint` — clean.
- Reproducer revert confirmed the tests catch the regression.