### PR TITLE
ci(jetbrains): run Gradle/JUnit tests on PRs

### DIFF
--- a/.github/workflows/ci-jetbrains.yml
+++ b/.github/workflows/ci-jetbrains.yml
@@ -1,0 +1,46 @@
+name: CI (JetBrains)
+
+# Runs the JetBrains plugin's Gradle (JUnit) test suite.
+# The Node-based `pnpm -r test` in ci.yml skips this package (it has no
+# package.json), so without this workflow BinaryResolver and other Kotlin
+# logic has no merge gate.
+
+on:
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-jetbrains-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-jetbrains:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Detect jetbrains changes
+        uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            jetbrains:
+              - 'packages/jetbrains/**'
+
+      - name: Setup JDK 17
+        if: steps.filter.outputs.jetbrains == 'true'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Gradle
+        if: steps.filter.outputs.jetbrains == 'true'
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run tests
+        if: steps.filter.outputs.jetbrains == 'true'
+        run: ./packages/jetbrains/gradlew -p packages/jetbrains test --no-daemon

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "jb:run": "./packages/jetbrains/gradlew -p packages/jetbrains runIde --no-daemon",
     "jb:build": "pnpm -F wave-webview build && ./packages/jetbrains/gradlew -p packages/jetbrains buildPlugin --no-daemon",
     "jb:package": "./packages/jetbrains/gradlew -p packages/jetbrains buildPlugin --no-daemon",
+    "jb:test": "./packages/jetbrains/gradlew -p packages/jetbrains test --no-daemon",
     "prepare": "husky"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem

The JetBrains package has no `package.json`, so the root `pnpm -r test` fan-out (and `ci.yml`) skips it entirely. `BinaryResolver` and other Kotlin logic thus had no merge gate — the single `BinaryResolverTest.kt` (10 JUnit tests) was only runnable locally via `./gradlew test`.

## Fix

- **`.github/workflows/ci-jetbrains.yml`** — new workflow mirroring `ci.yml` conventions: `ubuntu-latest`, JDK 17 (Temurin), `gradle/actions/setup-gradle@v4` for caching, `dorny/paths-filter` so it only runs when `packages/jetbrains/**` changes. Runs `./packages/jetbrains/gradlew -p packages/jetbrains test --no-daemon`.
- **`package.json`** — add `jb:test` root script matching the existing `jb:run` / `jb:build` convention.

## Verification

- `./packages/jetbrains/gradlew -p packages/jetbrains test --no-daemon` → BUILD SUCCESSFUL, 10 JUnit tests pass locally.