### PR TITLE
ci(windows): skip redundant type-check and lint

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -52,10 +52,18 @@ jobs:
       # management on Windows the dot reporter's stdout buffering causes the
       # agent-sdk vitest process to crash silently right after emitting "RUN".
       # Calling `vitest run` directly (default reporter) is the invocation
-      # pattern proven to run all 3221 agent-sdk tests green on Windows.
+      # pattern proven to run all agent-sdk tests green on Windows.
+      #
+      # Only packages with platform-specific code paths (subprocess spawning,
+      # fs, .cmd/.exe resolution) are run here — these are the paths that can
+      # actually regress on Windows. wave-webview is omitted: its 43 tests are
+      # pure React/jsdom component + reducer logic with no OS contact (no
+      # process.platform / fs / child_process anywhere in tests/ or src/),
+      # so they produce identical results on Linux and are already covered by
+      # the blocking Linux `check` job. Skipping them saves ~48s (~30% of the
+      # remaining test time).
       - name: Tests
         run: |
           pnpm --filter wave-agent-sdk exec vitest run &&
           pnpm --filter wave-code exec vitest run &&
-          pnpm --filter wave-vsce exec vitest run &&
-          pnpm --filter wave-webview exec vitest run
+          pnpm --filter wave-vsce exec vitest run

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -37,12 +37,14 @@ jobs:
       - name: Build
         run: pnpm build
 
-      # Run type-check + lint + tests WITHOUT coverage on Windows.
-      # The v8 coverage provider crashes silently on Windows (process exits
-      # right after "Coverage enabled with v8" with no output), which is an
-      # upstream tooling issue unrelated to this repo's code. Coverage is
-      # already enforced by the Linux CI (required check). Windows only needs
-      # to verify the tests themselves pass cross-platform.
+      # Run tests WITHOUT coverage, type-check, or lint on Windows.
+      # - Coverage: the v8 provider crashes silently on Windows (process exits
+      #   right after "Coverage enabled with v8" with no output); already
+      #   enforced by the blocking Linux CI.
+      # - Type-check & lint: platform-agnostic (identical result on Linux), and
+      #   already enforced by the blocking Linux CI. Skipping them here saves
+      #   ~40s of redundant work — the only purpose of this Windows workflow is
+      #   to verify the tests themselves pass cross-platform.
       #
       # Tests are invoked per-package via `pnpm --filter <pkg> exec vitest run`
       # rather than `pnpm -r test`. The latter runs each package's `test`
@@ -51,8 +53,6 @@ jobs:
       # agent-sdk vitest process to crash silently right after emitting "RUN".
       # Calling `vitest run` directly (default reporter) is the invocation
       # pattern proven to run all 3221 agent-sdk tests green on Windows.
-      - name: Type-check & lint
-        run: pnpm -r --parallel type-check && pnpm -r --parallel lint
       - name: Tests
         run: |
           pnpm --filter wave-agent-sdk exec vitest run &&


### PR DESCRIPTION
## Problem

The Windows CI (`ci-windows.yml`) ran two kinds of redundant work that the blocking Linux `check` job already covers:

1. **Type-check & lint** — platform-agnostic (identical on Windows/Linux), ~40s.
2. **wave-webview tests** — 43 pure React/jsdom tests with zero OS contact (no `process.platform`/`fs`/`child_process`/`.cmd` in `tests/` or `src/`; the Playwright `e2e/` harness that does touch fs runs separately in `pages.yml`/`publish.yml`). Identical results on Linux, ~48s.

The Windows workflow's only purpose is to verify tests with **platform-specific** code paths (subprocess spawning, fs, `.cmd`/`.exe` resolution) pass cross-platform.

## Fix

- Drop the `Type-check & lint` step.
- Drop `wave-webview` from the test matrix; keep `wave-agent-sdk`, `wave-code`, `wave-vsce` (all have real platform code — `wave-vsce` is where the recent `.cmd` spawn bug lived).
- Expand the inline comment to record the rationale for both.

## Measured impact (per-step timings from CI runs)

| step | before | after |
|---|---|---|
| Type-check & lint | 40s | removed |
| wave-webview tests | ~48s | removed |
| wave-agent-sdk + code + vsce tests | ~110s | ~110s |
| Build / Install / setup | ~50s | ~50s |
| **total** | ~4m31s | **~2m35s** |

Verified incrementally: the first commit (drop type-check/lint) measured **3m23s** in CI; this commit drops webview for a further ~48s.

The remaining gap vs the Linux job (3m20s, which also runs coverage) is inherent Windows runner overhead (slower fs/Node/pnpm) and not addressable here.