### PR TITLE
feat(stdio): migrate to multi-session single-process architecture

### DIFF
--- a/packages/code/src/stdio/agentBridge.ts
+++ b/packages/code/src/stdio/agentBridge.ts
@@ -2,9 +2,15 @@
  * AgentBridge — wraps the SDK Agent and translates between the JSON-RPC-like
  * stdio protocol and Agent method calls / callbacks.
  *
+ * Multi-tenant: maintains a Map<sessionId, {agent, storedConfig}> so a single
+ * `wave --stdio` process can host multiple sessions. Session-scoped requests
+ * carry `sessionId` on the JSON-RPC envelope for routing; global requests
+ * (listSessions/searchFiles/auth/plugins) don't require it but may use it
+ * for workdir fallback.
+ *
  * Responsibilities:
- * - Route incoming requests to the appropriate Agent method
- * - Translate AgentCallbacks into outgoing notifications
+ * - Route incoming requests to the appropriate Agent method (by sessionId)
+ * - Translate AgentCallbacks into outgoing notifications (with sessionId)
  * - Implement the canUseTool permission flow over the stdio protocol
  * - Handle config updates by destroying and recreating the Agent
  */
@@ -51,7 +57,11 @@ const CLI_VERSION: string = (() => {
   }
 })();
 
-export type NotificationEmitter = (method: string, params: unknown) => void;
+export type NotificationEmitter = (
+  method: string,
+  params: unknown,
+  sessionId?: string,
+) => void;
 
 export interface AgentBridgeOptions {
   emit: NotificationEmitter;
@@ -92,14 +102,30 @@ interface SearchFilesParams {
   workdir?: string;
 }
 
+interface SessionEntry {
+  agent: Agent;
+  storedConfig: Partial<InitializeParams>;
+}
+
+/**
+ * Mutable holder so callbacks/canUseTool (created before Agent.create resolves)
+ * can reference the agent and its registered sessionId after creation.
+ * `registeredSessionId` is the sessionId the client knows about; it's used as
+ * the envelope sessionId for outgoing notifications so the client's router can
+ * demultiplex correctly. It's updated atomically when onSessionIdChange fires.
+ */
+interface SessionContext {
+  agent?: Agent;
+  registeredSessionId?: string;
+}
+
 export class AgentBridge {
-  private agent: Agent | undefined;
+  private sessions = new Map<string, SessionEntry>();
   private pendingPermissions = new Map<
     string,
     (decision: PermissionDecision) => void
   >();
   private permissionCounter = 0;
-  private storedConfig: Partial<InitializeParams> = {};
   private emit: NotificationEmitter;
   private pluginCore: PluginCore | undefined;
   private pluginCoreWorkdir: string | undefined;
@@ -110,22 +136,26 @@ export class AgentBridge {
 
   // ── Public API ────────────────────────────────────────────────
 
-  async handleRequest(method: string, params: unknown): Promise<unknown> {
+  async handleRequest(
+    method: string,
+    params: unknown,
+    sessionId?: string,
+  ): Promise<unknown> {
     const p = (params ?? {}) as Record<string, unknown>;
     switch (method) {
       // ── Lifecycle ──
       case "initialize":
         return this.initialize(p as unknown as InitializeParams);
       case "destroy":
-        return this.destroy();
+        return this.destroy(sessionId);
       case "restoreSession":
-        return this.restoreSession(p.sessionId as string);
+        return this.restoreSession(p.sessionId as string, sessionId);
       case "listSessions":
-        return this.listSessions(p.workdir as string | undefined);
+        return this.listSessions(p.workdir as string | undefined, sessionId);
       case "getSessionInfo":
-        return this.getSessionInfo();
+        return this.getSessionInfo(sessionId);
       case "updateConfig":
-        return this.updateConfig(p as unknown as UpdateConfigParams);
+        return this.updateConfig(p as unknown as UpdateConfigParams, sessionId);
 
       // ── Messages ──
       case "sendMessage":
@@ -135,52 +165,57 @@ export class AgentBridge {
             images?: Array<{ path: string; mimeType: string }>;
             force?: boolean;
           },
+          sessionId,
         );
       case "bang":
-        return this.bang(p.command as string);
+        return this.bang(p.command as string, sessionId);
       case "abortMessage":
-        return this.abortMessage();
+        return this.abortMessage(sessionId);
       case "clearMessages":
-        return this.clearMessages();
+        return this.clearMessages(sessionId);
       case "rewindToMessage":
-        return this.rewindToMessage(p.messageId as string);
+        return this.rewindToMessage(p.messageId as string, sessionId);
       case "deleteQueuedMessage":
-        return this.deleteQueuedMessage(p.index as number);
+        return this.deleteQueuedMessage(p.index as number, sessionId);
       case "getMessages":
-        return this.getMessages();
+        return this.getMessages(sessionId);
       case "getFullMessageThread":
-        return this.getFullMessageThread();
+        return this.getFullMessageThread(sessionId);
 
       // ── Permissions ──
       case "setPermissionMode":
-        return this.setPermissionMode(p.mode as PermissionMode);
+        return this.setPermissionMode(p.mode as PermissionMode, sessionId);
       case "getPermissionMode":
-        return this.getPermissionMode();
+        return this.getPermissionMode(sessionId);
 
       // ── MCP ──
       case "getMcpServers":
-        return this.getMcpServers();
+        return this.getMcpServers(sessionId);
       case "connectMcpServer":
-        return this.connectMcpServer(p.serverName as string);
+        return this.connectMcpServer(p.serverName as string, sessionId);
       case "disconnectMcpServer":
-        return this.disconnectMcpServer(p.serverName as string);
+        return this.disconnectMcpServer(p.serverName as string, sessionId);
 
       // ── Commands ──
       case "getSlashCommands":
-        return this.getSlashCommands();
+        return this.getSlashCommands(sessionId);
 
-      // ── File / History ──
+      // ── File / History (global — no session required) ──
       case "searchFiles":
-        return this.searchFiles(p as unknown as SearchFilesParams);
+        return this.searchFiles(p as unknown as SearchFilesParams, sessionId);
       case "getPromptHistory":
-        return this.getPromptHistory(p.workdir as string | undefined);
+        return this.getPromptHistory(
+          p.workdir as string | undefined,
+          sessionId,
+        );
       case "searchPromptHistory":
         return this.searchPromptHistory(
           p.query as string,
           p.workdir as string | undefined,
+          sessionId,
         );
 
-      // ── Auth ──
+      // ── Auth (global — no session required) ──
       case "getAuthStatus":
         return this.getAuthStatus();
       case "login":
@@ -188,55 +223,66 @@ export class AgentBridge {
       case "logout":
         return this.logout();
 
-      // ── Plugins ──
+      // ── Plugins (global — no session required) ──
       case "listPlugins":
-        return this.listPlugins(p.workdir as string | undefined);
+        return this.listPlugins(p.workdir as string | undefined, sessionId);
       case "installPlugin":
         return this.installPlugin(
           p.pluginId as string,
           p.scope as Scope | undefined,
           p.workdir as string | undefined,
+          sessionId,
         );
       case "uninstallPlugin":
         return this.uninstallPlugin(
           p.pluginId as string,
           p.workdir as string | undefined,
+          sessionId,
         );
       case "enablePlugin":
         return this.enablePlugin(
           p.pluginId as string,
           p.scope as Scope | undefined,
           p.workdir as string | undefined,
+          sessionId,
         );
       case "disablePlugin":
         return this.disablePlugin(
           p.pluginId as string,
           p.scope as Scope | undefined,
           p.workdir as string | undefined,
+          sessionId,
         );
       case "updatePlugin":
         return this.updatePlugin(
           p.pluginId as string,
           p.workdir as string | undefined,
+          sessionId,
         );
       case "listMarketplaces":
-        return this.listMarketplaces(p.workdir as string | undefined);
+        return this.listMarketplaces(
+          p.workdir as string | undefined,
+          sessionId,
+        );
       case "addMarketplace":
         return this.addMarketplace(
           p.input as string,
           p.scope as Scope | undefined,
           p.workdir as string | undefined,
+          sessionId,
         );
       case "removeMarketplace":
         return this.removeMarketplace(
           p.name as string,
           p.scope as Scope | undefined,
           p.workdir as string | undefined,
+          sessionId,
         );
       case "updateMarketplace":
         return this.updateMarketplace(
           p.name as string | undefined,
           p.workdir as string | undefined,
+          sessionId,
         );
 
       default:
@@ -253,6 +299,7 @@ export class AgentBridge {
         requestId: string;
         decision: PermissionDecision;
       };
+      // requestId is process-level unique; lookup doesn't need sessionId
       const resolve = this.pendingPermissions.get(p.requestId);
       if (resolve) {
         this.pendingPermissions.delete(p.requestId);
@@ -270,10 +317,9 @@ export class AgentBridge {
     latestTotalTokens: number;
     serverVersion: string;
   }> {
-    // Merge with stored config (CLI defaults can be overridden by client)
-    this.storedConfig = { ...this.storedConfig, ...params };
+    const ctx: SessionContext = {};
+    const callbacks = this.createCallbacks(ctx);
 
-    const callbacks = this.createCallbacks();
     const options: AgentOptions = {
       callbacks,
       workdir: params.workdir,
@@ -290,10 +336,18 @@ export class AgentBridge {
       disallowedTools: params.disallowedTools,
       plugins: params.pluginDirs?.map((path) => ({ type: "local", path })),
       mcpServers: params.mcpServers,
-      canUseTool: (context: ToolPermissionContext) => this.canUseTool(context),
+      canUseTool: (context: ToolPermissionContext) =>
+        this.canUseTool(context, ctx),
     };
 
-    this.agent = await Agent.create(options);
+    const agent = await Agent.create(options);
+    ctx.agent = agent;
+    ctx.registeredSessionId = agent.sessionId;
+
+    this.sessions.set(agent.sessionId, {
+      agent,
+      storedConfig: { ...params },
+    });
 
     if (params.clientVersion) {
       console.debug(
@@ -302,120 +356,164 @@ export class AgentBridge {
     }
 
     return {
-      sessionId: this.agent.sessionId,
-      workingDirectory: this.agent.workingDirectory,
-      permissionMode: this.agent.getPermissionMode(),
-      latestTotalTokens: this.agent.latestTotalTokens,
+      sessionId: agent.sessionId,
+      workingDirectory: agent.workingDirectory,
+      permissionMode: agent.getPermissionMode(),
+      latestTotalTokens: agent.latestTotalTokens,
       serverVersion: CLI_VERSION,
     };
   }
 
-  private async destroy(): Promise<null> {
-    if (this.agent) {
-      await this.agent.destroy();
-      this.agent = undefined;
+  private async destroy(sessionId?: string): Promise<null> {
+    if (sessionId) {
+      const entry = this.sessions.get(sessionId);
+      if (entry) {
+        await entry.agent.destroy();
+        this.sessions.delete(sessionId);
+      }
     }
     return null;
   }
 
-  private async restoreSession(sessionId: string): Promise<null> {
-    this.requireAgent();
-    await this.agent!.restoreSession(sessionId);
+  private async restoreSession(
+    restoreId: string,
+    sessionId?: string,
+  ): Promise<null> {
+    const entry = this.requireSession(sessionId);
+    await entry.agent.restoreSession(restoreId);
     return null;
   }
 
   private async listSessions(
     workdir?: string,
+    sessionId?: string,
   ): Promise<{ sessions: SessionMetadata[] }> {
     const sessions = await listSessions(
-      workdir || this.agent?.workingDirectory || process.cwd(),
+      workdir || this.getSessionWorkdir(sessionId) || process.cwd(),
     );
     return { sessions };
   }
 
-  private getSessionInfo(): {
+  private getSessionInfo(sessionId?: string): {
     sessionId: string;
     workingDirectory: string;
     latestTotalTokens: number;
     permissionMode: PermissionMode;
     availableTools: string[];
   } {
-    this.requireAgent();
+    const entry = this.requireSession(sessionId);
     return {
-      sessionId: this.agent!.sessionId,
-      workingDirectory: this.agent!.workingDirectory,
-      latestTotalTokens: this.agent!.latestTotalTokens,
-      permissionMode: this.agent!.getPermissionMode(),
-      availableTools: this.agent!.getAvailableToolNames(),
+      sessionId: entry.agent.sessionId,
+      workingDirectory: entry.agent.workingDirectory,
+      latestTotalTokens: entry.agent.latestTotalTokens,
+      permissionMode: entry.agent.getPermissionMode(),
+      availableTools: entry.agent.getAvailableToolNames(),
     };
   }
 
   private async updateConfig(
     params: UpdateConfigParams,
+    sessionId?: string,
   ): Promise<{ sessionId: string }> {
-    this.requireAgent();
-    const currentSessionId = this.agent!.sessionId;
+    const entry = this.requireSession(sessionId);
+    const currentSessionId = entry.agent.sessionId;
     // Merge new config into stored config
-    this.storedConfig = { ...this.storedConfig, ...params };
-    // Destroy and recreate
-    await this.agent!.destroy();
-    this.agent = undefined;
-    await this.initialize({
-      ...this.storedConfig,
+    entry.storedConfig = { ...entry.storedConfig, ...params };
+    // Destroy and recreate within the same session slot
+    await entry.agent.destroy();
+    this.sessions.delete(currentSessionId);
+
+    const ctx: SessionContext = {};
+    const callbacks = this.createCallbacks(ctx);
+    const options: AgentOptions = {
+      callbacks,
+      workdir: entry.storedConfig.workdir,
       restoreSessionId: currentSessionId,
+      apiKey: entry.storedConfig.apiKey,
+      baseURL: entry.storedConfig.baseURL,
+      defaultHeaders: entry.storedConfig.defaultHeaders,
+      model: entry.storedConfig.model,
+      fastModel: entry.storedConfig.fastModel,
+      language: entry.storedConfig.language,
+      permissionMode: entry.storedConfig.permissionMode,
+      tools: entry.storedConfig.tools,
+      allowedTools: entry.storedConfig.allowedTools,
+      disallowedTools: entry.storedConfig.disallowedTools,
+      plugins: entry.storedConfig.pluginDirs?.map((p) => ({
+        type: "local",
+        path: p,
+      })),
+      mcpServers: entry.storedConfig.mcpServers,
+      canUseTool: (context: ToolPermissionContext) =>
+        this.canUseTool(context, ctx),
+    };
+
+    const agent = await Agent.create(options);
+    ctx.agent = agent;
+    ctx.registeredSessionId = agent.sessionId;
+    this.sessions.set(agent.sessionId, {
+      agent,
+      storedConfig: { ...entry.storedConfig },
     });
-    return { sessionId: this.agent!.sessionId };
+
+    return { sessionId: agent.sessionId };
   }
 
   // ── Messages ──────────────────────────────────────────────────
 
-  private async sendMessage(params: {
-    text: string;
-    images?: Array<{ path: string; mimeType: string }>;
-    force?: boolean;
-  }): Promise<null> {
-    this.requireAgent();
+  private async sendMessage(
+    params: {
+      text: string;
+      images?: Array<{ path: string; mimeType: string }>;
+      force?: boolean;
+    },
+    sessionId?: string,
+  ): Promise<null> {
+    const entry = this.requireSession(sessionId);
     if (params.force) {
-      this.agent!.abortMessage();
+      entry.agent.abortMessage();
     }
     // Save prompt to history (mirrors VSCE chatSession.ts:236-242)
     try {
       await PromptHistoryManager.addEntry(
         params.text,
-        this.agent!.sessionId,
+        entry.agent.sessionId,
         {},
-        this.agent!.workingDirectory,
+        entry.agent.workingDirectory,
       );
     } catch {
       // Best-effort; don't block message sending on history save failure
     }
-    await this.agent!.sendMessage(params.text, params.images);
+    await entry.agent.sendMessage(params.text, params.images);
     return null;
   }
 
-  private async bang(command: string): Promise<null> {
-    this.requireAgent();
-    await this.agent!.bang(command);
+  private async bang(command: string, sessionId?: string): Promise<null> {
+    const entry = this.requireSession(sessionId);
+    await entry.agent.bang(command);
     return null;
   }
 
-  private async abortMessage(): Promise<null> {
-    this.requireAgent();
-    this.agent!.abortMessage();
+  private async abortMessage(sessionId?: string): Promise<null> {
+    const entry = this.requireSession(sessionId);
+    entry.agent.abortMessage();
     return null;
   }
 
-  private async clearMessages(): Promise<null> {
-    this.requireAgent();
-    this.agent!.clearMessages();
+  private async clearMessages(sessionId?: string): Promise<null> {
+    const entry = this.requireSession(sessionId);
+    entry.agent.clearMessages();
     return null;
   }
 
-  private async rewindToMessage(messageId: string): Promise<{
+  private async rewindToMessage(
+    messageId: string,
+    sessionId?: string,
+  ): Promise<{
     inputContent: string;
   }> {
-    this.requireAgent();
-    const { messages } = await this.agent!.getFullMessageThread();
+    const entry = this.requireSession(sessionId);
+    const { messages } = await entry.agent.getFullMessageThread();
     const index = messages.findIndex((m) => m.id === messageId);
     if (index === -1) {
       throw new RpcError(
@@ -427,90 +525,99 @@ export class AgentBridge {
     const textBlock = message.blocks.find((b) => b.type === "text") as
       | { content?: string }
       | undefined;
-    await this.agent!.truncateHistory(index);
+    await entry.agent.truncateHistory(index);
     return { inputContent: textBlock?.content || "" };
   }
 
-  private deleteQueuedMessage(index: number): null {
-    this.requireAgent();
-    this.agent!.removeQueuedMessage(index);
+  private deleteQueuedMessage(index: number, sessionId?: string): null {
+    const entry = this.requireSession(sessionId);
+    entry.agent.removeQueuedMessage(index);
     return null;
   }
 
-  private getMessages(): { messages: Message[] } {
-    this.requireAgent();
-    return { messages: this.agent!.messages };
+  private getMessages(sessionId?: string): { messages: Message[] } {
+    const entry = this.requireSession(sessionId);
+    return { messages: entry.agent.messages };
   }
 
-  private async getFullMessageThread(): Promise<{
+  private async getFullMessageThread(sessionId?: string): Promise<{
     messages: Message[];
     sessionIds: string[];
   }> {
-    this.requireAgent();
-    return this.agent!.getFullMessageThread();
+    const entry = this.requireSession(sessionId);
+    return entry.agent.getFullMessageThread();
   }
 
   // ── Permissions ───────────────────────────────────────────────
 
-  private async setPermissionMode(mode: PermissionMode): Promise<null> {
-    this.requireAgent();
-    await this.agent!.setPermissionMode(mode);
+  private async setPermissionMode(
+    mode: PermissionMode,
+    sessionId?: string,
+  ): Promise<null> {
+    const entry = this.requireSession(sessionId);
+    await entry.agent.setPermissionMode(mode);
     return null;
   }
 
-  private getPermissionMode(): { mode: PermissionMode } {
-    this.requireAgent();
-    return { mode: this.agent!.getPermissionMode() };
+  private getPermissionMode(sessionId?: string): { mode: PermissionMode } {
+    const entry = this.requireSession(sessionId);
+    return { mode: entry.agent.getPermissionMode() };
   }
 
   // ── MCP ───────────────────────────────────────────────────────
 
-  private getMcpServers(): { servers: McpServerStatus[] } {
-    this.requireAgent();
-    return { servers: this.agent!.getMcpServers() };
+  private getMcpServers(sessionId?: string): { servers: McpServerStatus[] } {
+    const entry = this.requireSession(sessionId);
+    return { servers: entry.agent.getMcpServers() };
   }
 
   private async connectMcpServer(
     serverName: string,
+    sessionId?: string,
   ): Promise<{ success: boolean }> {
-    this.requireAgent();
-    const success = await this.agent!.connectMcpServer(serverName);
+    const entry = this.requireSession(sessionId);
+    const success = await entry.agent.connectMcpServer(serverName);
     return { success };
   }
 
   private async disconnectMcpServer(
     serverName: string,
+    sessionId?: string,
   ): Promise<{ success: boolean }> {
-    this.requireAgent();
-    const success = await this.agent!.disconnectMcpServer(serverName);
+    const entry = this.requireSession(sessionId);
+    const success = await entry.agent.disconnectMcpServer(serverName);
     return { success };
   }
 
   // ── Commands ──────────────────────────────────────────────────
 
-  private getSlashCommands(): { commands: SlashCommand[] } {
-    this.requireAgent();
-    return { commands: this.agent!.getSlashCommands() };
+  private getSlashCommands(sessionId?: string): { commands: SlashCommand[] } {
+    const entry = this.requireSession(sessionId);
+    return { commands: entry.agent.getSlashCommands() };
   }
 
-  // ── File / History ────────────────────────────────────────────
+  // ── File / History (global) ───────────────────────────────────
 
   private async searchFiles(
     params: SearchFilesParams,
+    sessionId?: string,
   ): Promise<{ files: Awaited<ReturnType<typeof searchFiles>> }> {
     const files = await searchFiles(params.query, {
       maxResults: params.maxResults,
       workingDirectory:
-        params.workdir || this.agent?.workingDirectory || process.cwd(),
+        params.workdir || this.getSessionWorkdir(sessionId) || process.cwd(),
     });
     return { files };
   }
 
-  private async getPromptHistory(workdir?: string): Promise<{
+  private async getPromptHistory(
+    workdir?: string,
+    sessionId?: string,
+  ): Promise<{
     history: Awaited<ReturnType<typeof PromptHistoryManager.getHistory>>;
   }> {
     const history = await PromptHistoryManager.getHistory({
-      workdir: workdir || this.agent?.workingDirectory,
+      workdir: workdir || this.getSessionWorkdir(sessionId),
     });
     return { history };
   }
@@ -518,11 +625,12 @@ export class AgentBridge {
   private async searchPromptHistory(
     query: string,
     workdir?: string,
+    sessionId?: string,
   ): Promise<{
     history: Awaited<ReturnType<typeof PromptHistoryManager.searchHistory>>;
   }> {
     const history = await PromptHistoryManager.searchHistory(query, {
-      workdir: workdir || this.agent?.workingDirectory,
+      workdir: workdir || this.getSessionWorkdir(sessionId),
     });
     return { history };
   }
@@ -531,11 +639,16 @@ export class AgentBridge {
 
   private canUseTool(
     context: ToolPermissionContext,
+    ctx: SessionContext,
   ): Promise<PermissionDecision> {
     const requestId = `perm_${++this.permissionCounter}`;
     return new Promise<PermissionDecision>((resolve) => {
       this.pendingPermissions.set(requestId, resolve);
-      this.emit("permissionRequest", { requestId, context });
+      this.emit(
+        "permissionRequest",
+        { requestId, context },
+        ctx.registeredSessionId,
+      );
 
       // 5-minute timeout → auto-deny
       setTimeout(
@@ -553,7 +666,7 @@ export class AgentBridge {
     });
   }
 
-  // ── Auth ─────────────────────────────────────────────────────
+  // ── Auth (global) ────────────────────────────────────────────
 
   private async getAuthStatus(): Promise<{
     isAuthenticated: boolean;
@@ -585,11 +698,11 @@ export class AgentBridge {
     return null;
   }
 
-  // ── Plugins ──────────────────────────────────────────────────
+  // ── Plugins (global) ─────────────────────────────────────────
 
-  private getPluginCore(workdir?: string): PluginCore {
+  private getPluginCore(workdir?: string, sessionId?: string): PluginCore {
     const resolvedWorkdir =
-      workdir || this.agent?.workingDirectory || process.cwd();
+      workdir || this.getSessionWorkdir(sessionId) || process.cwd();
     if (!this.pluginCore || this.pluginCoreWorkdir !== resolvedWorkdir) {
       this.pluginCore = new PluginCore(resolvedWorkdir);
       this.pluginCoreWorkdir = resolvedWorkdir;
@@ -597,8 +710,8 @@ export class AgentBridge {
     return this.pluginCore;
   }
 
-  private async listPlugins(workdir?: string) {
-    const core = this.getPluginCore(workdir);
+  private async listPlugins(workdir?: string, sessionId?: string) {
+    const core = this.getPluginCore(workdir, sessionId);
     const { plugins, mergedEnabled } = await core.listPlugins();
     return {
       plugins: plugins.map((p) => {
@@ -621,12 +734,20 @@ export class AgentBridge {
     pluginId: string,
     scope?: Scope,
     workdir?: string,
+    sessionId?: string,
   ) {
-    return this.getPluginCore(workdir).installPlugin(pluginId, scope);
+    return this.getPluginCore(workdir, sessionId).installPlugin(
+      pluginId,
+      scope,
+    );
   }
 
-  private async uninstallPlugin(pluginId: string, workdir?: string) {
-    await this.getPluginCore(workdir).uninstallPlugin(pluginId);
+  private async uninstallPlugin(
+    pluginId: string,
+    workdir?: string,
+    sessionId?: string,
+  ) {
+    await this.getPluginCore(workdir, sessionId).uninstallPlugin(pluginId);
     return null;
   }
 
@@ -634,106 +755,154 @@ export class AgentBridge {
     pluginId: string,
     scope?: Scope,
     workdir?: string,
+    sessionId?: string,
   ) {
-    return this.getPluginCore(workdir).enablePlugin(pluginId, scope);
+    return this.getPluginCore(workdir, sessionId).enablePlugin(pluginId, scope);
   }
 
   private async disablePlugin(
     pluginId: string,
     scope?: Scope,
     workdir?: string,
+    sessionId?: string,
   ) {
-    return this.getPluginCore(workdir).disablePlugin(pluginId, scope);
+    return this.getPluginCore(workdir, sessionId).disablePlugin(
+      pluginId,
+      scope,
+    );
   }
 
-  private async updatePlugin(pluginId: string, workdir?: string) {
-    return this.getPluginCore(workdir).updatePlugin(pluginId);
+  private async updatePlugin(
+    pluginId: string,
+    workdir?: string,
+    sessionId?: string,
+  ) {
+    return this.getPluginCore(workdir, sessionId).updatePlugin(pluginId);
   }
 
-  private async listMarketplaces(workdir?: string) {
-    return this.getPluginCore(workdir).listMarketplaces();
+  private async listMarketplaces(workdir?: string, sessionId?: string) {
+    return this.getPluginCore(workdir, sessionId).listMarketplaces();
   }
 
-  private async addMarketplace(input: string, scope?: Scope, workdir?: string) {
-    return this.getPluginCore(workdir).addMarketplace(input, scope);
+  private async addMarketplace(
+    input: string,
+    scope?: Scope,
+    workdir?: string,
+    sessionId?: string,
+  ) {
+    return this.getPluginCore(workdir, sessionId).addMarketplace(input, scope);
   }
 
   private async removeMarketplace(
     name: string,
     scope?: Scope,
     workdir?: string,
+    sessionId?: string,
   ) {
-    await this.getPluginCore(workdir).removeMarketplace(name, scope);
+    await this.getPluginCore(workdir, sessionId).removeMarketplace(name, scope);
     return null;
   }
 
-  private async updateMarketplace(name?: string, workdir?: string) {
-    await this.getPluginCore(workdir).updateMarketplace(name);
+  private async updateMarketplace(
+    name?: string,
+    workdir?: string,
+    sessionId?: string,
+  ) {
+    await this.getPluginCore(workdir, sessionId).updateMarketplace(name);
     return null;
   }
 
   // ── Callbacks → Notifications ─────────────────────────────────
 
-  private createCallbacks(): AgentCallbacks {
+  private createCallbacks(ctx: SessionContext): AgentCallbacks {
     return {
       onMessagesChange: (messages: Message[]) => {
-        this.emit("messagesChange", { messages });
+        this.emit("messagesChange", { messages }, ctx.registeredSessionId);
       },
       onUserMessageAdded: () => {
-        const msg = this.findLastUserMessage();
-        if (msg) this.emit("userMessageAdded", { message: msg });
+        const msg = this.findLastUserMessage(ctx.agent);
+        if (msg)
+          this.emit(
+            "userMessageAdded",
+            { message: msg },
+            ctx.registeredSessionId,
+          );
       },
       onAssistantMessageAdded: (messageId: string) => {
-        const msg = this.agent?.messages.find((m) => m.id === messageId);
-        if (msg) this.emit("assistantMessageAdded", { message: msg });
+        const msg = ctx.agent?.messages.find((m) => m.id === messageId);
+        if (msg)
+          this.emit(
+            "assistantMessageAdded",
+            { message: msg },
+            ctx.registeredSessionId,
+          );
       },
       onAssistantContentUpdated: (params) => {
-        this.emit("assistantContentUpdated", params);
+        this.emit("assistantContentUpdated", params, ctx.registeredSessionId);
       },
       onAssistantReasoningUpdated: (params) => {
-        this.emit("assistantReasoningUpdated", params);
+        this.emit("assistantReasoningUpdated", params, ctx.registeredSessionId);
       },
       onToolBlockUpdated: (params) => {
-        this.emit("toolBlockUpdated", params);
+        this.emit("toolBlockUpdated", params, ctx.registeredSessionId);
       },
       onErrorBlockAdded: (error: string) => {
-        this.emit("errorBlockAdded", { error });
+        this.emit("errorBlockAdded", { error }, ctx.registeredSessionId);
       },
       onLoadingChange: (loading: boolean) => {
-        this.emit("loadingChange", {
-          loading,
-          latestTotalTokens: this.agent?.latestTotalTokens,
-        });
+        this.emit(
+          "loadingChange",
+          {
+            loading,
+            latestTotalTokens: ctx.agent?.latestTotalTokens,
+          },
+          ctx.registeredSessionId,
+        );
       },
       onCommandRunningChange: (running: boolean) => {
-        this.emit("commandRunningChange", { running });
+        this.emit("commandRunningChange", { running }, ctx.registeredSessionId);
       },
       onQueuedMessagesChange: (messages: QueuedMessage[]) => {
-        this.emit("queuedMessagesChange", { messages });
+        this.emit(
+          "queuedMessagesChange",
+          { messages },
+          ctx.registeredSessionId,
+        );
       },
       onTasksChange: (tasks: Task[]) => {
-        this.emit("tasksChange", { tasks });
+        this.emit("tasksChange", { tasks }, ctx.registeredSessionId);
       },
-      onSessionIdChange: (sessionId: string) => {
-        this.emit("sessionIdChange", { sessionId });
+      onSessionIdChange: (newSessionId: string) => {
+        const oldSessionId = ctx.registeredSessionId;
+        // Emit with the OLD sessionId so the client's router can deliver it
+        this.emit("sessionIdChange", { sessionId: newSessionId }, oldSessionId);
+        // Update the sessions Map key atomically (single-threaded, no await)
+        if (oldSessionId && oldSessionId !== newSessionId) {
+          const entry = this.sessions.get(oldSessionId);
+          if (entry) {
+            this.sessions.delete(oldSessionId);
+            this.sessions.set(newSessionId, entry);
+          }
+        }
+        ctx.registeredSessionId = newSessionId;
       },
       onPermissionModeChange: (mode: PermissionMode) => {
-        this.emit("permissionModeChange", { mode });
+        this.emit("permissionModeChange", { mode }, ctx.registeredSessionId);
       },
       onMcpServersChange: (servers: McpServerStatus[]) => {
-        this.emit("mcpServersChange", { servers });
+        this.emit("mcpServersChange", { servers }, ctx.registeredSessionId);
       },
       onAddBangMessage: () => {
-        this.emit("bangMessageAdded", {});
+        this.emit("bangMessageAdded", {}, ctx.registeredSessionId);
       },
       onUpdateBangMessage: () => {
-        this.emit("bangMessageUpdated", {});
+        this.emit("bangMessageUpdated", {}, ctx.registeredSessionId);
       },
       onCompleteBangMessage: () => {
-        this.emit("bangMessageCompleted", {});
+        this.emit("bangMessageCompleted", {}, ctx.registeredSessionId);
       },
       onNotificationMessageAdded: (params) => {
-        const msg = this.agent?.messages.find(
+        const msg = ctx.agent?.messages.find(
           (m) =>
             m.role === "user" &&
             m.blocks.some(
@@ -742,26 +911,42 @@ export class AgentBridge {
                 (b as { taskId: string }).taskId === params.taskId,
             ),
         );
-        this.emit("notificationMessageAdded", {
-          ...params,
-          message: msg,
-        });
+        this.emit(
+          "notificationMessageAdded",
+          { ...params, message: msg },
+          ctx.registeredSessionId,
+        );
       },
     };
   }
 
-  private findLastUserMessage(): Message | undefined {
-    const userMessages =
-      this.agent?.messages.filter((m) => m.role === "user") ?? [];
+  private findLastUserMessage(agent?: Agent): Message | undefined {
+    const userMessages = agent?.messages.filter((m) => m.role === "user") ?? [];
     return userMessages[userMessages.length - 1];
   }
 
   // ── Utils ─────────────────────────────────────────────────────
 
-  private requireAgent(): void {
-    if (!this.agent) {
-      throw new RpcError(PROTOCOL_INTERNAL_ERROR, "Agent not initialized");
+  private requireSession(sessionId?: string): SessionEntry {
+    if (!sessionId) {
+      throw new RpcError(
+        PROTOCOL_INTERNAL_ERROR,
+        "sessionId is required for this request",
+      );
     }
+    const entry = this.sessions.get(sessionId);
+    if (!entry) {
+      throw new RpcError(
+        PROTOCOL_INTERNAL_ERROR,
+        `Session not found: ${sessionId}`,
+      );
+    }
+    return entry;
+  }
+
+  private getSessionWorkdir(sessionId?: string): string | undefined {
+    if (!sessionId) return undefined;
+    return this.sessions.get(sessionId)?.agent.workingDirectory;
   }
 }
 

--- a/packages/code/src/stdio/protocol.ts
+++ b/packages/code/src/stdio/protocol.ts
@@ -13,6 +13,8 @@ export interface JsonRpcRequest {
   id: number | string;
   method: string;
   params?: unknown;
+  /** Session-scoped requests carry sessionId for routing to the right Agent. */
+  sessionId?: string;
 }
 
 export interface JsonRpcResponse {
@@ -30,6 +32,8 @@ export interface JsonRpcError {
 export interface JsonRpcNotification {
   method: string;
   params?: unknown;
+  /** Session-scoped notifications carry sessionId for demultiplexing on the client. */
+  sessionId?: string;
 }
 
 // ── Error codes (JSON-RPC 2.0 standard) ────────────────────────

--- a/packages/code/src/stdio/stdioServer.ts
+++ b/packages/code/src/stdio/stdioServer.ts
@@ -37,7 +37,8 @@ export class StdioServer {
     this.output = options.output ?? process.stdout;
     this.bridge = new AgentBridge({
       ...options.bridgeOptions,
-      emit: (method, params) => this.sendNotification(method, params),
+      emit: (method, params, sessionId) =>
+        this.sendNotification(method, params, sessionId),
     });
   }
 
@@ -113,7 +114,11 @@ export class StdioServer {
 
   private async handleRequest(msg: JsonRpcRequest): Promise<void> {
     try {
-      const result = await this.bridge.handleRequest(msg.method, msg.params);
+      const result = await this.bridge.handleRequest(
+        msg.method,
+        msg.params,
+        msg.sessionId,
+      );
       this.sendResponse(msg.id, result);
     } catch (err) {
       const code =
@@ -152,8 +157,9 @@ export class StdioServer {
     this.write(response);
   }
 
-  sendNotification(method: string, params?: unknown): void {
+  sendNotification(method: string, params?: unknown, sessionId?: string): void {
     const notification: JsonRpcNotification = { method, params };
+    if (sessionId) notification.sessionId = sessionId;
     this.write(notification);
   }
 

--- a/packages/code/tests/stdio/agentBridge.test.ts
+++ b/packages/code/tests/stdio/agentBridge.test.ts
@@ -66,9 +66,14 @@ function createMockAgent(overrides: Record<string, unknown> = {}) {
 }
 
 function createBridge() {
-  const notifications: Array<{ method: string; params: unknown }> = [];
+  const notifications: Array<{
+    method: string;
+    params: unknown;
+    sessionId?: string;
+  }> = [];
   const bridge = new AgentBridge({
-    emit: (method, params) => notifications.push({ method, params }),
+    emit: (method, params, sessionId) =>
+      notifications.push({ method, params, sessionId }),
   });
   return { bridge, notifications };
 }
@@ -168,6 +173,7 @@ test("onMessagesChange emits messagesChange notification", async () => {
   expect(notifications).toContainEqual({
     method: "messagesChange",
     params: { messages },
+    sessionId: "test-session-id",
   });
 });
 
@@ -190,6 +196,7 @@ test("onUserMessageAdded finds last user message and emits notification", async 
   expect(notifications).toContainEqual({
     method: "userMessageAdded",
     params: { message: userMessage },
+    sessionId: "test-session-id",
   });
 });
 
@@ -212,6 +219,7 @@ test("onAssistantMessageAdded finds message by id and emits notification", async
   expect(notifications).toContainEqual({
     method: "assistantMessageAdded",
     params: { message: assistantMessage },
+    sessionId: "test-session-id",
   });
 });
 
@@ -228,6 +236,7 @@ test("onLoadingChange emits loadingChange notification", async () => {
   expect(notifications).toContainEqual({
     method: "loadingChange",
     params: { loading: true, latestTotalTokens: 100 },
+    sessionId: "test-session-id",
   });
 });
 
@@ -244,6 +253,7 @@ test("onErrorBlockAdded emits errorBlockAdded notification", async () => {
   expect(notifications).toContainEqual({
     method: "errorBlockAdded",
     params: { error: "something went wrong" },
+    sessionId: "test-session-id",
   });
 });
 
@@ -260,6 +270,7 @@ test("onPermissionModeChange emits permissionModeChange notification", async () 
   expect(notifications).toContainEqual({
     method: "permissionModeChange",
     params: { mode: "plan" },
+    sessionId: "test-session-id",
   });
 });
 
@@ -276,6 +287,7 @@ test("onCommandRunningChange emits commandRunningChange notification", async () 
   expect(notifications).toContainEqual({
     method: "commandRunningChange",
     params: { running: true },
+    sessionId: "test-session-id",
   });
 });
 
@@ -293,6 +305,7 @@ test("onQueuedMessagesChange emits queuedMessagesChange notification", async () 
   expect(notifications).toContainEqual({
     method: "queuedMessagesChange",
     params: { messages: queued },
+    sessionId: "test-session-id",
   });
 });
 
@@ -310,6 +323,7 @@ test("onTasksChange emits tasksChange notification", async () => {
   expect(notifications).toContainEqual({
     method: "tasksChange",
     params: { tasks },
+    sessionId: "test-session-id",
   });
 });
 
@@ -326,6 +340,7 @@ test("onSessionIdChange emits sessionIdChange notification", async () => {
   expect(notifications).toContainEqual({
     method: "sessionIdChange",
     params: { sessionId: "session-new" },
+    sessionId: "test-session-id",
   });
 });
 
@@ -345,6 +360,7 @@ test("onMcpServersChange emits mcpServersChange notification", async () => {
   expect(notifications).toContainEqual({
     method: "mcpServersChange",
     params: { servers },
+    sessionId: "test-session-id",
   });
 });
 
@@ -361,6 +377,7 @@ test("onAddBangMessage emits bangMessageAdded notification", async () => {
   expect(notifications).toContainEqual({
     method: "bangMessageAdded",
     params: {},
+    sessionId: "test-session-id",
   });
 });
 
@@ -377,6 +394,7 @@ test("onUpdateBangMessage emits bangMessageUpdated notification", async () => {
   expect(notifications).toContainEqual({
     method: "bangMessageUpdated",
     params: {},
+    sessionId: "test-session-id",
   });
 });
 
@@ -393,6 +411,7 @@ test("onCompleteBangMessage emits bangMessageCompleted notification", async () =
   expect(notifications).toContainEqual({
     method: "bangMessageCompleted",
     params: {},
+    sessionId: "test-session-id",
   });
 });
 
@@ -424,10 +443,11 @@ test("canUseTool emits permissionRequest and resolves when permissionResponse re
   const permNotification = notifications.find(
     (n) => n.method === "permissionRequest",
   )!;
+  expect(permNotification.sessionId).toBe("test-session-id");
   const requestId = (permNotification.params as { requestId: string })
     .requestId;
 
-  // Client responds with allow
+  // Client responds with allow (permissionResponse uses requestId, no sessionId needed)
   bridge.handleNotification("permissionResponse", {
     requestId,
     decision: { behavior: "allow" },
@@ -470,11 +490,16 @@ test("sendMessage calls agent.sendMessage with text and images", async () => {
   const mockAgent = createMockAgent();
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", {});
-  await bridge.handleRequest("sendMessage", {
-    text: "hello world",
-    images: [{ path: "/img.png", mimeType: "image/png" }],
-  });
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  await bridge.handleRequest(
+    "sendMessage",
+    {
+      text: "hello world",
+      images: [{ path: "/img.png", mimeType: "image/png" }],
+    },
+    sessionId,
+  );
 
   expect(mockAgent.sendMessage).toHaveBeenCalledWith("hello world", [
     { path: "/img.png", mimeType: "image/png" },
@@ -486,8 +511,9 @@ test("bang calls agent.bang with command", async () => {
   const mockAgent = createMockAgent();
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", {});
-  await bridge.handleRequest("bang", { command: "git status" });
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  await bridge.handleRequest("bang", { command: "git status" }, sessionId);
 
   expect(mockAgent.bang).toHaveBeenCalledWith("git status");
 });
@@ -497,8 +523,9 @@ test("abortMessage calls agent.abortMessage", async () => {
   const mockAgent = createMockAgent();
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", {});
-  await bridge.handleRequest("abortMessage", {});
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  await bridge.handleRequest("abortMessage", {}, sessionId);
 
   expect(mockAgent.abortMessage).toHaveBeenCalled();
 });
@@ -508,8 +535,9 @@ test("clearMessages calls agent.clearMessages", async () => {
   const mockAgent = createMockAgent();
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", {});
-  await bridge.handleRequest("clearMessages", {});
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  await bridge.handleRequest("clearMessages", {}, sessionId);
 
   expect(mockAgent.clearMessages).toHaveBeenCalled();
 });
@@ -522,10 +550,11 @@ test("getMessages returns agent messages", async () => {
   const mockAgent = createMockAgent({ messages: testMessages });
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", {});
-  const result = await bridge.handleRequest("getMessages", {});
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  const r = await bridge.handleRequest("getMessages", {}, sessionId);
 
-  expect(result).toEqual({ messages: testMessages });
+  expect(r).toEqual({ messages: testMessages });
 });
 
 test("getFullMessageThread returns messages and sessionIds", async () => {
@@ -533,10 +562,11 @@ test("getFullMessageThread returns messages and sessionIds", async () => {
   const mockAgent = createMockAgent();
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", {});
-  const result = await bridge.handleRequest("getFullMessageThread", {});
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  const r = await bridge.handleRequest("getFullMessageThread", {}, sessionId);
 
-  expect(result).toEqual({
+  expect(r).toEqual({
     messages: [],
     sessionIds: ["test-session-id"],
   });
@@ -547,10 +577,11 @@ test("getSessionInfo returns session info", async () => {
   const { bridge } = createBridge();
   vi.mocked(Agent.create).mockResolvedValue(createMockAgent());
 
-  await bridge.handleRequest("initialize", {});
-  const result = await bridge.handleRequest("getSessionInfo", {});
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  const r = await bridge.handleRequest("getSessionInfo", {}, sessionId);
 
-  expect(result).toEqual({
+  expect(r).toEqual({
     sessionId: "test-session-id",
     workingDirectory: "/test/workdir",
     latestTotalTokens: 100,
@@ -564,8 +595,9 @@ test("setPermissionMode calls agent.setPermissionMode", async () => {
   const mockAgent = createMockAgent();
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", {});
-  await bridge.handleRequest("setPermissionMode", { mode: "plan" });
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  await bridge.handleRequest("setPermissionMode", { mode: "plan" }, sessionId);
 
   expect(mockAgent.setPermissionMode).toHaveBeenCalledWith("plan");
 });
@@ -574,10 +606,11 @@ test("getPermissionMode returns current mode", async () => {
   const { bridge } = createBridge();
   vi.mocked(Agent.create).mockResolvedValue(createMockAgent());
 
-  await bridge.handleRequest("initialize", {});
-  const result = await bridge.handleRequest("getPermissionMode", {});
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  const r = await bridge.handleRequest("getPermissionMode", {}, sessionId);
 
-  expect(result).toEqual({ mode: "default" });
+  expect(r).toEqual({ mode: "default" });
 });
 
 test("getMcpServers returns server list", async () => {
@@ -587,10 +620,11 @@ test("getMcpServers returns server list", async () => {
     createMockAgent({ getMcpServers: vi.fn().mockReturnValue(servers) }),
   );
 
-  await bridge.handleRequest("initialize", {});
-  const result = await bridge.handleRequest("getMcpServers", {});
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  const r = await bridge.handleRequest("getMcpServers", {}, sessionId);
 
-  expect(result).toEqual({ servers });
+  expect(r).toEqual({ servers });
 });
 
 test("connectMcpServer calls agent.connectMcpServer", async () => {
@@ -598,13 +632,16 @@ test("connectMcpServer calls agent.connectMcpServer", async () => {
   const mockAgent = createMockAgent();
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", {});
-  const result = await bridge.handleRequest("connectMcpServer", {
-    serverName: "my-server",
-  });
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  const r = await bridge.handleRequest(
+    "connectMcpServer",
+    { serverName: "my-server" },
+    sessionId,
+  );
 
   expect(mockAgent.connectMcpServer).toHaveBeenCalledWith("my-server");
-  expect(result).toEqual({ success: true });
+  expect(r).toEqual({ success: true });
 });
 
 test("disconnectMcpServer calls agent.disconnectMcpServer", async () => {
@@ -612,13 +649,16 @@ test("disconnectMcpServer calls agent.disconnectMcpServer", async () => {
   const mockAgent = createMockAgent();
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", {});
-  const result = await bridge.handleRequest("disconnectMcpServer", {
-    serverName: "my-server",
-  });
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  const r = await bridge.handleRequest(
+    "disconnectMcpServer",
+    { serverName: "my-server" },
+    sessionId,
+  );
 
   expect(mockAgent.disconnectMcpServer).toHaveBeenCalledWith("my-server");
-  expect(result).toEqual({ success: true });
+  expect(r).toEqual({ success: true });
 });
 
 test("getSlashCommands returns command list", async () => {
@@ -628,10 +668,11 @@ test("getSlashCommands returns command list", async () => {
     createMockAgent({ getSlashCommands: vi.fn().mockReturnValue(commands) }),
   );
 
-  await bridge.handleRequest("initialize", {});
-  const result = await bridge.handleRequest("getSlashCommands", {});
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  const r = await bridge.handleRequest("getSlashCommands", {}, sessionId);
 
-  expect(result).toEqual({ commands });
+  expect(r).toEqual({ commands });
 });
 
 test("rewindToMessage truncates history and returns input content", async () => {
@@ -653,13 +694,16 @@ test("rewindToMessage truncates history and returns input content", async () => 
   });
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", {});
-  const result = await bridge.handleRequest("rewindToMessage", {
-    messageId: "msg-1",
-  });
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  const r = await bridge.handleRequest(
+    "rewindToMessage",
+    { messageId: "msg-1" },
+    sessionId,
+  );
 
   expect(mockAgent.truncateHistory).toHaveBeenCalledWith(0);
-  expect(result).toEqual({ inputContent: "hello" });
+  expect(r).toEqual({ inputContent: "hello" });
 });
 
 test("deleteQueuedMessage calls removeQueuedMessage", async () => {
@@ -667,8 +711,9 @@ test("deleteQueuedMessage calls removeQueuedMessage", async () => {
   const mockAgent = createMockAgent();
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", {});
-  await bridge.handleRequest("deleteQueuedMessage", { index: 2 });
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  await bridge.handleRequest("deleteQueuedMessage", { index: 2 }, sessionId);
 
   expect(mockAgent.removeQueuedMessage).toHaveBeenCalledWith(2);
 });
@@ -678,8 +723,9 @@ test("destroy destroys the agent", async () => {
   const mockAgent = createMockAgent();
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", {});
-  await bridge.handleRequest("destroy", {});
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  await bridge.handleRequest("destroy", {}, sessionId);
 
   expect(mockAgent.destroy).toHaveBeenCalled();
 });
@@ -702,7 +748,7 @@ test("calling method before initialize throws INTERNAL_ERROR", async () => {
 
   await expect(
     bridge.handleRequest("sendMessage", { text: "hi" }),
-  ).rejects.toThrow("Agent not initialized");
+  ).rejects.toThrow("sessionId is required for this request");
 });
 
 test("RpcError has correct code and toJsonRpcError", () => {
@@ -719,10 +765,9 @@ test("sendMessage saves prompt to history before sending", async () => {
   const mockAgent = createMockAgent();
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", {});
-  await bridge.handleRequest("sendMessage", {
-    text: "hello world",
-  });
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  await bridge.handleRequest("sendMessage", { text: "hello world" }, sessionId);
 
   expect(PromptHistoryManager.addEntry).toHaveBeenCalledWith(
     "hello world",
@@ -738,13 +783,18 @@ test("sendMessage saves prompt to history before sending", async () => {
 test("searchFiles uses workdir param when provided", async () => {
   const { bridge } = createBridge();
   vi.mocked(Agent.create).mockResolvedValue(createMockAgent());
-  await bridge.handleRequest("initialize", {});
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
 
-  await bridge.handleRequest("searchFiles", {
-    query: "test",
-    maxResults: 10,
-    workdir: "/custom/workdir",
-  });
+  await bridge.handleRequest(
+    "searchFiles",
+    {
+      query: "test",
+      maxResults: 10,
+      workdir: "/custom/workdir",
+    },
+    sessionId,
+  );
 
   expect(searchFiles).toHaveBeenCalledWith("test", {
     maxResults: 10,
@@ -755,9 +805,10 @@ test("searchFiles uses workdir param when provided", async () => {
 test("searchFiles falls back to agent workingDirectory", async () => {
   const { bridge } = createBridge();
   vi.mocked(Agent.create).mockResolvedValue(createMockAgent());
-  await bridge.handleRequest("initialize", {});
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
 
-  await bridge.handleRequest("searchFiles", { query: "test" });
+  await bridge.handleRequest("searchFiles", { query: "test" }, sessionId);
 
   expect(searchFiles).toHaveBeenCalledWith("test", {
     maxResults: undefined,
@@ -996,6 +1047,7 @@ test("onNotificationMessageAdded emits with full message", async () => {
       summary: "Done",
       message: notificationMessage,
     },
+    sessionId: "test-session-id",
   });
 });
 
@@ -1006,9 +1058,10 @@ test("handleRequest with null params defaults to empty object", async () => {
   const mockAgent = createMockAgent();
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", {});
+  const initResult = await bridge.handleRequest("initialize", {});
+  const sessionId = (initResult as { sessionId: string }).sessionId;
   // getSessionInfo uses p but doesn't read any field, so null params should work
-  const result = await bridge.handleRequest("getSessionInfo", null);
+  const result = await bridge.handleRequest("getSessionInfo", null, sessionId);
   expect(result).toEqual({
     sessionId: "test-session-id",
     workingDirectory: "/test/workdir",
@@ -1023,8 +1076,13 @@ test("restoreSession delegates to agent.restoreSession", async () => {
   const mockAgent = createMockAgent();
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", {});
-  await bridge.handleRequest("restoreSession", { sessionId: "old-session" });
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  await bridge.handleRequest(
+    "restoreSession",
+    { sessionId: "old-session" },
+    sessionId,
+  );
 
   expect(mockAgent.restoreSession).toHaveBeenCalledWith("old-session");
 });
@@ -1032,9 +1090,14 @@ test("restoreSession delegates to agent.restoreSession", async () => {
 test("listSessions with workdir delegates to listSessions SDK", async () => {
   const { bridge } = createBridge();
   vi.mocked(Agent.create).mockResolvedValue(createMockAgent());
-  await bridge.handleRequest("initialize", {});
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
 
-  await bridge.handleRequest("listSessions", { workdir: "/custom/workdir" });
+  await bridge.handleRequest(
+    "listSessions",
+    { workdir: "/custom/workdir" },
+    sessionId,
+  );
 
   expect(listSessions).toHaveBeenCalledWith("/custom/workdir");
 });
@@ -1053,13 +1116,16 @@ test("updateConfig destroys and recreates agent with merged config", async () =>
   const mockAgent = createMockAgent();
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", { model: "gpt-4" });
-  const result = await bridge.handleRequest("updateConfig", {
-    permissionMode: "plan",
-  });
+  const result = await bridge.handleRequest("initialize", { model: "gpt-4" });
+  const sessionId = (result as { sessionId: string }).sessionId;
+  const r = await bridge.handleRequest(
+    "updateConfig",
+    { permissionMode: "plan" },
+    sessionId,
+  );
 
   expect(mockAgent.destroy).toHaveBeenCalled();
-  expect(result).toEqual({ sessionId: "test-session-id" });
+  expect(r).toEqual({ sessionId: "test-session-id" });
   // Second Agent.create call should have merged config
   const secondCall = vi.mocked(Agent.create).mock.calls[1][0];
   expect(secondCall.model).toBe("gpt-4");
@@ -1132,11 +1198,13 @@ test("sendMessage with force aborts before sending", async () => {
   const mockAgent = createMockAgent();
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", {});
-  await bridge.handleRequest("sendMessage", {
-    text: "hello",
-    force: true,
-  });
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  await bridge.handleRequest(
+    "sendMessage",
+    { text: "hello", force: true },
+    sessionId,
+  );
 
   expect(mockAgent.abortMessage).toHaveBeenCalled();
   expect(mockAgent.sendMessage).toHaveBeenCalledWith("hello", undefined);
@@ -1158,10 +1226,15 @@ test("rewindToMessage throws when messageId not found", async () => {
   });
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", {});
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
 
   await expect(
-    bridge.handleRequest("rewindToMessage", { messageId: "nonexistent" }),
+    bridge.handleRequest(
+      "rewindToMessage",
+      { messageId: "nonexistent" },
+      sessionId,
+    ),
   ).rejects.toThrow("Message not found: nonexistent");
 });
 
@@ -1179,12 +1252,15 @@ test("rewindToMessage returns empty string when message has no text block", asyn
   });
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", {});
-  const result = await bridge.handleRequest("rewindToMessage", {
-    messageId: "msg-1",
-  });
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  const r = await bridge.handleRequest(
+    "rewindToMessage",
+    { messageId: "msg-1" },
+    sessionId,
+  );
 
-  expect(result).toEqual({ inputContent: "" });
+  expect(r).toEqual({ inputContent: "" });
 });
 
 // ── Branch coverage: searchFiles / history without agent ─────────
@@ -1248,8 +1324,11 @@ test("PluginCore uses agent workingDirectory when no workdir provided", async ()
   mockPluginCore({ listPlugins });
 
   // Initialize agent first, then call listPlugins without workdir
-  await bridge.handleRequest("initialize", { workdir: "/test/workdir" });
-  await bridge.handleRequest("listPlugins", {});
+  const result = await bridge.handleRequest("initialize", {
+    workdir: "/test/workdir",
+  });
+  const sessionId = (result as { sessionId: string }).sessionId;
+  await bridge.handleRequest("listPlugins", {}, sessionId);
 
   // PluginCore should be constructed with agent's workingDirectory
   expect(PluginCore).toHaveBeenCalledWith("/test/workdir");
@@ -1303,12 +1382,13 @@ test("onUserMessageAdded before initialize does not crash", async () => {
   const mockAgent = createMockAgent({ messages: [] });
   vi.mocked(Agent.create).mockResolvedValue(mockAgent);
 
-  await bridge.handleRequest("initialize", {});
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
   const callbacks = vi.mocked(Agent.create).mock.calls[0][0]
     .callbacks as AgentCallbacks;
 
   // Destroy agent so this.agent becomes undefined
-  await bridge.handleRequest("destroy", {});
+  await bridge.handleRequest("destroy", {}, sessionId);
 
   // Now onUserMessageAdded should handle undefined agent gracefully
   callbacks.onUserMessageAdded!({} as never);
@@ -1398,4 +1478,103 @@ test("canUseTool timeout is no-op when permission already resolved", async () =>
   vi.advanceTimersByTime(5 * 60 * 1000 + 1000);
 
   vi.useRealTimers();
+});
+
+// ── Multi-session (multi-tenant) ─────────────────────────────────
+
+test("two sessions are independent and route notifications by sessionId", async () => {
+  const { bridge } = createBridge();
+  const agentA = createMockAgent({ sessionId: "sess-A" });
+  const agentB = createMockAgent({ sessionId: "sess-B" });
+  vi.mocked(Agent.create)
+    .mockResolvedValueOnce(agentA)
+    .mockResolvedValueOnce(agentB);
+
+  const initA = await bridge.handleRequest("initialize", {});
+  const initB = await bridge.handleRequest("initialize", {});
+  const sessionA = (initA as { sessionId: string }).sessionId;
+  const sessionB = (initB as { sessionId: string }).sessionId;
+  expect(sessionA).toBe("sess-A");
+  expect(sessionB).toBe("sess-B");
+
+  // Send message on each; verify each agent's sendMessage is called exactly once
+  await bridge.handleRequest("sendMessage", { text: "hi-A" }, sessionA);
+  await bridge.handleRequest("sendMessage", { text: "hi-B" }, sessionB);
+
+  expect(agentA.sendMessage).toHaveBeenCalledTimes(1);
+  expect(agentA.sendMessage).toHaveBeenCalledWith("hi-A", undefined);
+  expect(agentB.sendMessage).toHaveBeenCalledTimes(1);
+  expect(agentB.sendMessage).toHaveBeenCalledWith("hi-B", undefined);
+
+  // Verify getMessages routes to the correct session's agent
+  const msgsA = await bridge.handleRequest("getMessages", {}, sessionA);
+  const msgsB = await bridge.handleRequest("getMessages", {}, sessionB);
+  expect(agentA.messages).toBe((msgsA as { messages: Message[] }).messages);
+  expect(agentB.messages).toBe((msgsB as { messages: Message[] }).messages);
+});
+
+test("destroying one session leaves the other intact", async () => {
+  const { bridge } = createBridge();
+  const agentA = createMockAgent({ sessionId: "sess-A" });
+  const agentB = createMockAgent({ sessionId: "sess-B" });
+  vi.mocked(Agent.create)
+    .mockResolvedValueOnce(agentA)
+    .mockResolvedValueOnce(agentB);
+
+  const initA = await bridge.handleRequest("initialize", {});
+  const initB = await bridge.handleRequest("initialize", {});
+  const sessionA = (initA as { sessionId: string }).sessionId;
+  const sessionB = (initB as { sessionId: string }).sessionId;
+
+  // Destroy session A
+  await bridge.handleRequest("destroy", {}, sessionA);
+  expect(agentA.destroy).toHaveBeenCalledTimes(1);
+
+  // Session B should still work
+  const result = await bridge.handleRequest("getMessages", {}, sessionB);
+  expect(result).toEqual({ messages: [] });
+  expect(agentB.destroy).not.toHaveBeenCalled();
+});
+
+test("notifications route by sessionId when callbacks fire", async () => {
+  const { bridge, notifications } = createBridge();
+  const agentA = createMockAgent({ sessionId: "sess-A" });
+  const agentB = createMockAgent({ sessionId: "sess-B" });
+  vi.mocked(Agent.create)
+    .mockResolvedValueOnce(agentA)
+    .mockResolvedValueOnce(agentB);
+
+  await bridge.handleRequest("initialize", {});
+  await bridge.handleRequest("initialize", {});
+
+  // Grab callbacks for each Agent.create call
+  const callbacksA = vi.mocked(Agent.create).mock.calls[0][0]
+    .callbacks as AgentCallbacks;
+  const callbacksB = vi.mocked(Agent.create).mock.calls[1][0]
+    .callbacks as AgentCallbacks;
+
+  const messagesA = [
+    { id: "a-1", role: "user", blocks: [] },
+  ] as unknown as Message[];
+  const messagesB = [
+    { id: "b-1", role: "user", blocks: [] },
+  ] as unknown as Message[];
+
+  // Fire onMessagesChange for session A's callbacks
+  callbacksA.onMessagesChange!(messagesA);
+
+  // The notification emitted via session A's callbacks should carry sessionId "sess-A"
+  expect(notifications).toContainEqual({
+    method: "messagesChange",
+    params: { messages: messagesA },
+    sessionId: "sess-A",
+  });
+
+  // Fire for session B → should carry "sess-B"
+  callbacksB.onMessagesChange!(messagesB);
+  expect(notifications).toContainEqual({
+    method: "messagesChange",
+    params: { messages: messagesB },
+    sessionId: "sess-B",
+  });
 });

--- a/packages/code/tests/stdio/stdioServer.test.ts
+++ b/packages/code/tests/stdio/stdioServer.test.ts
@@ -119,9 +119,19 @@ test("multiple sequential requests get correct responses", async () => {
   server.start();
 
   send({ id: 1, method: "initialize", params: {} });
-  await waitForMessages(1);
+  const initMsgs = await waitForMessages(1);
+  const initResp = initMsgs[0] as {
+    id: number;
+    result: { sessionId: string };
+  };
+  const sessionId = initResp.result.sessionId;
 
-  send({ id: 2, method: "getPermissionMode", params: {} });
+  send({
+    id: 2,
+    method: "getPermissionMode",
+    params: {},
+    sessionId,
+  });
   const msgs = await waitForMessages(2);
 
   const resp2 = msgs[1] as { id: number; result: unknown };
@@ -252,7 +262,7 @@ test("calling method before initialize returns internal error", async () => {
 
   expect(response.id).toBe(1);
   expect(response.error.code).toBe(-32603); // INTERNAL_ERROR
-  expect(response.error.message).toContain("not initialized");
+  expect(response.error.message).toContain("sessionId is required");
 
   server.stop();
 });
@@ -264,7 +274,12 @@ test("callback triggers notification output on stdout", async () => {
   server.start();
 
   send({ id: 1, method: "initialize", params: {} });
-  await waitForMessages(1);
+  const initMsgs = await waitForMessages(1);
+  const initResp = initMsgs[0] as {
+    id: number;
+    result: { sessionId: string };
+  };
+  const sessionId = initResp.result.sessionId;
 
   // Grab callbacks from Agent.create
   const options = vi.mocked(Agent.create).mock.calls[0][0];
@@ -277,10 +292,12 @@ test("callback triggers notification output on stdout", async () => {
   const notification = msgs[1] as {
     method: string;
     params: { loading: boolean; latestTotalTokens?: number };
+    sessionId?: string;
   };
 
   expect(notification.method).toBe("loadingChange");
   expect(notification.params).toEqual({ loading: true, latestTotalTokens: 0 });
+  expect(notification.sessionId).toBe(sessionId);
 
   server.stop();
 });
@@ -292,7 +309,12 @@ test("canUseTool triggers permissionRequest notification and resolves on permiss
   server.start();
 
   send({ id: 1, method: "initialize", params: {} });
-  await waitForMessages(1);
+  const initMsgs = await waitForMessages(1);
+  const initResp = initMsgs[0] as {
+    id: number;
+    result: { sessionId: string };
+  };
+  const sessionId = initResp.result.sessionId;
 
   // Get canUseTool from options
   const options = vi.mocked(Agent.create).mock.calls[0][0];
@@ -318,10 +340,15 @@ test("canUseTool triggers permissionRequest notification and resolves on permiss
   const allMsgs = getMessages();
   const permNotif = allMsgs.find(
     (m) => (m as { method: string }).method === "permissionRequest",
-  ) as { method: string; params: { requestId: string } };
+  ) as {
+    method: string;
+    params: { requestId: string };
+    sessionId?: string;
+  };
   const requestId = permNotif.params.requestId;
+  expect(permNotif.sessionId).toBe(sessionId);
 
-  // Client sends permissionResponse notification
+  // Client sends permissionResponse notification (uses requestId, no sessionId needed)
   send({
     method: "permissionResponse",
     params: { requestId, decision: { behavior: "allow" } },
@@ -345,4 +372,90 @@ test("stop() closes the readline interface", async () => {
 
   // No crash = pass
   expect(true).toBe(true);
+});
+
+// ── sendNotification sessionId envelope ──────────────────────────
+
+test("sendNotification includes sessionId in envelope when provided", () => {
+  const { server, getMessages } = createServer();
+
+  server.sendNotification("messagesChange", { messages: [] }, "sess-1");
+
+  const msgs = getMessages();
+  expect(msgs).toHaveLength(1);
+  expect(msgs[0]).toEqual({
+    method: "messagesChange",
+    params: { messages: [] },
+    sessionId: "sess-1",
+  });
+});
+
+test("sendNotification omits sessionId when not provided", () => {
+  const { server, getMessages } = createServer();
+
+  server.sendNotification("authUrl", { url: "https://example.com" });
+
+  const msgs = getMessages();
+  expect(msgs).toHaveLength(1);
+  expect(msgs[0]).toEqual({
+    method: "authUrl",
+    params: { url: "https://example.com" },
+  });
+  expect(msgs[0]).not.toHaveProperty("sessionId");
+});
+
+// ── sessionId extraction/forwarding ──────────────────────────────
+
+test("handleRequest extracts msg.sessionId and passes to bridge.handleRequest", async () => {
+  const { server, send, waitForMessages } = createServer();
+  server.start();
+
+  send({ id: 1, method: "initialize", params: {} });
+  const initMsgs = await waitForMessages(1);
+  const sessionId = (initMsgs[0] as { result: { sessionId: string } }).result
+    .sessionId;
+
+  // Calling getMessages WITHOUT sessionId → should error
+  send({ id: 2, method: "getMessages", params: {} });
+  const msgsNoSession = await waitForMessages(2);
+  const errResp = msgsNoSession[1] as {
+    id: number;
+    error: { code: number; message: string };
+  };
+  expect(errResp.error.message).toContain("sessionId is required");
+
+  // Calling getMessages WITH sessionId → should succeed
+  send({ id: 3, method: "getMessages", params: {}, sessionId });
+  const msgs = await waitForMessages(3);
+  const okResp = msgs[2] as { id: number; result: unknown };
+  expect(okResp.id).toBe(3);
+  expect(okResp.result).toEqual({ messages: [] });
+
+  server.stop();
+});
+
+test("handleNotification forwards permissionResponse notification without throwing", async () => {
+  const { server, send, waitForMessages } = createServer();
+  server.start();
+
+  send({ id: 1, method: "initialize", params: {} });
+  const initMsgs = await waitForMessages(1);
+  const sessionId = (initMsgs[0] as { result: { sessionId: string } }).result
+    .sessionId;
+
+  const linesBefore = waitForMessages(1);
+
+  // Send permissionResponse notification — handleNotification should not throw
+  // even though the notification carries a sessionId (lookup uses requestId only)
+  send({
+    method: "permissionResponse",
+    params: { requestId: "unknown-id", decision: { behavior: "allow" } },
+    sessionId,
+  });
+
+  // No new response written for notifications
+  await linesBefore;
+  expect(true).toBe(true);
+
+  server.stop();
 });

--- a/packages/jetbrains/.gitignore
+++ b/packages/jetbrains/.gitignore
@@ -1,4 +1,5 @@
 .gradle/
+.kotlin/
 build/
 !gradle/wrapper/gradle-wrapper.jar
 .intellijPlatform/

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioAgent.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioAgent.kt
@@ -158,49 +158,49 @@ class StdioAgent(
             put("text", text)
             if (images != null) put("images", images)
             if (force) put("force", true)
-        })
+        }, sessionId)
     }
 
     suspend fun bang(command: String) {
-        client.request("bang", buildJsonObject { put("command", command) })
+        client.request("bang", buildJsonObject { put("command", command) }, sessionId)
     }
 
-    suspend fun abortMessage() { client.request("abortMessage") }
-    suspend fun clearMessages() { client.request("clearMessages") }
+    suspend fun abortMessage() { client.request("abortMessage", sessionId = sessionId) }
+    suspend fun clearMessages() { client.request("clearMessages", sessionId = sessionId) }
 
     suspend fun restoreSession(sessionId: String) {
-        client.request("restoreSession", buildJsonObject { put("sessionId", sessionId) })
+        client.request("restoreSession", buildJsonObject { put("sessionId", sessionId) }, this.sessionId)
     }
 
     suspend fun setPermissionMode(mode: String) {
-        client.request("setPermissionMode", buildJsonObject { put("mode", mode) })
+        client.request("setPermissionMode", buildJsonObject { put("mode", mode) }, sessionId)
     }
 
     suspend fun deleteQueuedMessage(index: Int) {
-        client.request("deleteQueuedMessage", buildJsonObject { put("index", index) })
+        client.request("deleteQueuedMessage", buildJsonObject { put("index", index) }, sessionId)
     }
 
-    suspend fun getSlashCommands(): JsonElement? = client.request("getSlashCommands")
+    suspend fun getSlashCommands(): JsonElement? = client.request("getSlashCommands", sessionId = sessionId)
 
     suspend fun updateConfig(params: JsonObject) {
-        client.request("updateConfig", params)
+        client.request("updateConfig", params, sessionId)
     }
 
     suspend fun rewindToMessage(messageId: String): String {
-        val result = client.request("rewindToMessage", buildJsonObject { put("messageId", messageId) })
+        val result = client.request("rewindToMessage", buildJsonObject { put("messageId", messageId) }, sessionId)
         return result?.jsonObject?.get("inputContent")?.jsonPrimitive?.content ?: ""
     }
 
     suspend fun getMcpServers(): JsonElement =
-        client.request("getMcpServers") ?: JsonObject(emptyMap())
+        client.request("getMcpServers", sessionId = sessionId) ?: JsonObject(emptyMap())
 
     suspend fun connectMcpServer(serverName: String): Boolean {
-        val result = client.request("connectMcpServer", buildJsonObject { put("serverName", serverName) })
+        val result = client.request("connectMcpServer", buildJsonObject { put("serverName", serverName) }, sessionId)
         return result?.jsonObject?.get("success")?.jsonPrimitive?.booleanOrNull ?: false
     }
 
     suspend fun disconnectMcpServer(serverName: String): Boolean {
-        val result = client.request("disconnectMcpServer", buildJsonObject { put("serverName", serverName) })
+        val result = client.request("disconnectMcpServer", buildJsonObject { put("serverName", serverName) }, sessionId)
         return result?.jsonObject?.get("success")?.jsonPrimitive?.booleanOrNull ?: false
     }
 
@@ -210,7 +210,7 @@ class StdioAgent(
         client.notify("permissionResponse", buildJsonObject {
             put("requestId", requestId)
             put("decision", decision)
-        })
+        }, sessionId)
     }
 
     // ── Utility RPCs (standalone, mirror VSCE services) ───────────

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioClient.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioClient.kt
@@ -106,7 +106,7 @@ class StdioClient(
     }
 
     /** Send a request (expects a response with matching id). */
-    suspend fun request(method: String, params: JsonObject? = null): JsonElement? {
+    suspend fun request(method: String, params: JsonObject? = null, sessionId: String? = null): JsonElement? {
         if (disposed) throw StdioClientException("StdioClient is disposed")
         val id = nextId.getAndIncrement()
         val deferred = CompletableDeferred<JsonElement?>()
@@ -116,6 +116,7 @@ class StdioClient(
                 put("id", id)
                 put("method", method)
                 if (params != null) put("params", params)
+                if (sessionId != null) put("sessionId", sessionId)
             }
             val line = json.encodeToString(JsonObject.serializer(), payload)
             writeLine(line)
@@ -127,11 +128,12 @@ class StdioClient(
     }
 
     /** Send a notification (no response expected). Fire-and-forget. */
-    suspend fun notify(method: String, params: JsonObject? = null) {
+    suspend fun notify(method: String, params: JsonObject? = null, sessionId: String? = null) {
         if (disposed) return
         val payload = buildJsonObject {
             put("method", method)
             if (params != null) put("params", params)
+            if (sessionId != null) put("sessionId", sessionId)
         }
         writeLine(json.encodeToString(JsonObject.serializer(), payload))
     }

--- a/packages/vsce/src/chatProvider.ts
+++ b/packages/vsce/src/chatProvider.ts
@@ -17,6 +17,7 @@ import { PluginService } from './services/pluginService';
 import { WebviewManager } from './session/webviewManager';
 import { MessageHandler } from './session/messageHandler';
 import { StdioClient } from './stdio/stdioClient';
+import { NotificationRouter } from './stdio/notificationRouter';
 import { resolveWaveBinary, upgradeWaveBinary } from './stdio/binaryResolver';
 import { parseVersion, compareVersions } from './services/updateService';
 
@@ -46,21 +47,23 @@ export class ChatProvider implements vscode.WebviewViewProvider {
     private pluginService: PluginService;
     private webviewManager: WebviewManager;
     private messageHandler: MessageHandler;
-    private utilityClient: StdioClient | undefined;
+    private sharedClient: StdioClient | undefined;
+    private notificationRouter: NotificationRouter | undefined;
     private cliUpgradeAttempted = false;
 
     constructor(context: vscode.ExtensionContext) {
         this.context = context;
         this.configService = new ConfigurationService(context);
 
-        // Create utility stdio client for standalone calls (searchFiles, listSessions,
-        // promptHistory, plugins, auth). Never calls initialize.
-        this.initUtilityClient();
+        // Create the single shared stdio client + notification router for all sessions.
+        // Session-scoped notifications are demuxed by sessionId via the router.
+        // Global notifications (authUrl) are handled here.
+        this.initSharedClient();
 
-        this.fileService = new FileService(this.utilityClient!);
-        this.sessionService = new SessionService(this.utilityClient!);
+        this.fileService = new FileService(this.sharedClient!);
+        this.sessionService = new SessionService(this.sharedClient!);
         this.selectionService = new SelectionService(context);
-        this.pluginService = new PluginService(this.utilityClient!);
+        this.pluginService = new PluginService(this.sharedClient!);
 
         this.webviewManager = new WebviewManager(context, {
             onMessage: async (message, viewType, windowId) => {
@@ -91,7 +94,7 @@ export class ChatProvider implements vscode.WebviewViewProvider {
             this.fileService,
             this.sessionService,
             this.pluginService,
-            this.utilityClient!,
+            this.sharedClient!,
             {
                 getChatSession: (viewType, windowId) => this.getChatSession(viewType, windowId),
                 postMessage: (message, viewType, windowId) => this.webviewManager.postMessage(message, viewType, windowId),
@@ -136,12 +139,14 @@ export class ChatProvider implements vscode.WebviewViewProvider {
         */
     }
 
-    private initUtilityClient(): void {
+    private initSharedClient(): void {
         try {
             const binaryPath = resolveWaveBinary();
-            this.utilityClient = new StdioClient(binaryPath, ['--stdio']);
-            // Open browser when auth URL is received from the server
-            this.utilityClient.onNotification('authUrl', (params) => {
+            this.sharedClient = new StdioClient(binaryPath, ['--stdio']);
+            this.notificationRouter = new NotificationRouter(this.sharedClient);
+            this.notificationRouter.attach();
+            // Open browser when auth URL is received (global — no sessionId).
+            this.notificationRouter.registerGlobal('authUrl', (params) => {
                 const p = params as { url: string };
                 if (p.url) {
                     vscode.env.openExternal(vscode.Uri.parse(p.url));
@@ -261,10 +266,17 @@ export class ChatProvider implements vscode.WebviewViewProvider {
 
         try {
             const config = await this.configService.loadConfiguration();
-            await session.initialize(config, restoreSessionId, clientVersion);
+            await session.initialize(
+                config,
+                restoreSessionId,
+                clientVersion,
+                this.sharedClient!,
+                this.notificationRouter!,
+            );
 
             // Version negotiation: if the CLI is older than the extension, silently
-            // upgrade once per activation and re-initialize.
+            // upgrade once per activation and re-initialize. Because the shared process
+            // must be killed to pick up the new binary, ALL active sessions are re-init'd.
             if (!upgradedThisCall && clientVersion && session.agent?.serverVersion) {
                 const client = parseVersion(clientVersion);
                 const server = parseVersion(session.agent.serverVersion);
@@ -272,9 +284,7 @@ export class ChatProvider implements vscode.WebviewViewProvider {
                     this.cliUpgradeAttempted = true;
                     try {
                         console.log(`[Wave] CLI ${session.agent.serverVersion} < extension ${clientVersion}, upgrading...`);
-                        await upgradeWaveBinary(clientVersion);
-                        await session.destroy();
-                        await session.initialize(config, undefined, clientVersion);
+                        await this.reinitAllAfterUpgrade(config, clientVersion);
                     } catch (upgradeError) {
                         console.error('[Wave] CLI auto-upgrade failed:', upgradeError);
                         vscode.window.showErrorMessage(
@@ -292,6 +302,65 @@ export class ChatProvider implements vscode.WebviewViewProvider {
                 vscode.window.showErrorMessage(`初始化 ${viewType} AI 智能体失败: ` + error);
             }
         }
+    }
+
+    /**
+     * Kill the shared process, upgrade the CLI binary, rebuild the shared client +
+     * router, and re-initialize every active session with its restoreSessionId.
+     *
+     * This is called when the running CLI is older than the extension. Because the
+     * binary is replaced on disk, the shared process must be restarted to pick it up.
+     * All sessions that were live before the upgrade are re-initialized on the new
+     * process, preserving their session IDs so conversation history is restored.
+     */
+    private async reinitAllAfterUpgrade(config: ConfigurationData, clientVersion: string): Promise<void> {
+        // Collect every active session along with the sessionId to restore.
+        const active: Array<{ session: ChatSession; restoreSessionId: string | undefined }> = [];
+        if (this.sidebarSession.agent) {
+            active.push({ session: this.sidebarSession, restoreSessionId: this.sidebarSession.sessionId });
+        }
+        for (const session of this.tabSessions.values()) {
+            if (session.agent) {
+                active.push({ session, restoreSessionId: session.sessionId });
+            }
+        }
+        for (const session of this.windowSessions.values()) {
+            if (session.agent) {
+                active.push({ session, restoreSessionId: session.sessionId });
+            }
+        }
+
+        // Best-effort destroy: unregisters each agent from the router and sends a
+        // destroy request to the server. Failures are swallowed because the process
+        // will be killed next regardless.
+        await Promise.all(active.map(({ session }) => session.destroy().catch(() => {})));
+
+        // Kill the old shared process so the binary file can be replaced and the new
+        // binary picked up on restart.
+        this.sharedClient?.dispose();
+        this.sharedClient = undefined;
+        this.notificationRouter = undefined;
+
+        await upgradeWaveBinary(clientVersion);
+
+        // Rebuild the shared client + router against the freshly installed binary.
+        this.initSharedClient();
+
+        // Re-initialize every previously-active session on the new process, restoring
+        // each one's conversation history by sessionId.
+        await Promise.all(
+            active.map(({ session, restoreSessionId }) =>
+                session.initialize(
+                    config,
+                    restoreSessionId,
+                    clientVersion,
+                    this.sharedClient!,
+                    this.notificationRouter!,
+                ).catch((err) => {
+                    console.error('[Wave] Failed to re-initialize session after upgrade:', err);
+                }),
+            ),
+        );
     }
 
     private getChatSession(viewType: 'sidebar' | 'tab' | 'window', windowId?: string): ChatSession {
@@ -495,7 +564,7 @@ export class ChatProvider implements vscode.WebviewViewProvider {
             console.error('销毁智能体时出错:', error);
         }
 
-        this.utilityClient?.dispose();
+        this.sharedClient?.dispose();
 
         this.webviewManager.dispose();
         

--- a/packages/vsce/src/session/chatSession.ts
+++ b/packages/vsce/src/session/chatSession.ts
@@ -3,7 +3,7 @@ import type { Message, PermissionDecision, ToolPermissionContext, PermissionMode
 import { ConfigurationData } from '../services/configurationService';
 import { StdioClient } from '../stdio/stdioClient';
 import { StdioAgent, type StdioAgentCallbacks } from '../stdio/stdioAgent';
-import { resolveWaveBinary } from '../stdio/binaryResolver';
+import { NotificationRouter } from '../stdio/notificationRouter';
 
 export interface ChatSessionCallbacks {
     onMessagesChange: (messages: Message[]) => void;
@@ -63,7 +63,13 @@ export class ChatSession {
         private callbacks: ChatSessionCallbacks
     ) {}
 
-    public async initialize(config: ConfigurationData, restoreSessionId?: string, clientVersion?: string) {
+    public async initialize(
+        config: ConfigurationData,
+        restoreSessionId: string | undefined,
+        clientVersion: string | undefined,
+        sharedClient: StdioClient,
+        router: NotificationRouter,
+    ) {
         if (this.isInitializing) {
             return;
         }
@@ -78,9 +84,6 @@ export class ChatSession {
             if (workdir) {
                 console.log(`设置智能体工作目录为: ${workdir}`);
             }
-
-            const binaryPath = await resolveWaveBinary();
-            const client = new StdioClient(binaryPath, ['--stdio']);
 
             const agentCallbacks: StdioAgentCallbacks = {
                 onMessagesChange: (messages: Message[]) => {
@@ -151,7 +154,7 @@ export class ChatSession {
                 },
             };
 
-            this.agent = new StdioAgent(client, agentCallbacks);
+            this.agent = new StdioAgent(sharedClient, router, agentCallbacks);
 
             const initParams = {
                 workdir,

--- a/packages/vsce/src/stdio/notificationRouter.ts
+++ b/packages/vsce/src/stdio/notificationRouter.ts
@@ -1,0 +1,107 @@
+/**
+ * NotificationRouter — demultiplexes server→client notifications by sessionId.
+ *
+ * In the single-shared-process architecture, all sessions share one StdioClient.
+ * The server tags each session-scoped notification with `sessionId` on the
+ * JSON-RPC envelope. The router inspects that field and dispatches to the
+ * matching StdioAgent; notifications without sessionId (e.g. `authUrl`) go to
+ * a global handler.
+ *
+ * Lifecycle:
+ * 1. `attach()` once — subscribes to every notification method on the shared client
+ * 2. Per session: `register(sessionId, agent)` after `initialize` response
+ * 3. On `sessionIdChange`: router auto-rekeys the agent (old → new)
+ * 4. On `destroy`: `unregister(sessionId)` removes the agent
+ */
+
+import type { StdioClient } from './stdioClient';
+
+type GlobalHandler = (params: unknown) => void;
+
+// StdioAgent is imported lazily via a type-only import to avoid a circular
+// dependency at runtime (StdioAgent imports NotificationRouter for its type).
+import type { StdioAgent } from './stdioAgent';
+
+const ALL_NOTIFICATION_METHODS = [
+    'messagesChange',
+    'userMessageAdded',
+    'assistantMessageAdded',
+    'assistantContentUpdated',
+    'assistantReasoningUpdated',
+    'toolBlockUpdated',
+    'errorBlockAdded',
+    'loadingChange',
+    'commandRunningChange',
+    'queuedMessagesChange',
+    'tasksChange',
+    'sessionIdChange',
+    'permissionModeChange',
+    'mcpServersChange',
+    'bangMessageAdded',
+    'bangMessageUpdated',
+    'bangMessageCompleted',
+    'notificationMessageAdded',
+    'permissionRequest',
+    'authUrl',
+] as const;
+
+export class NotificationRouter {
+    private sessions = new Map<string, StdioAgent>();
+    private globalHandlers = new Map<string, GlobalHandler>();
+    private attached = false;
+
+    constructor(private client: StdioClient) {}
+
+    /**
+     * Subscribe to all notification methods on the shared StdioClient.
+     * Must be called once after construction. Idempotent.
+     */
+    attach(): void {
+        if (this.attached) return;
+        this.attached = true;
+        for (const method of ALL_NOTIFICATION_METHODS) {
+            this.client.onNotification(method, (params, sessionId) => {
+                this.dispatch(method, params, sessionId);
+            });
+        }
+    }
+
+    /** Register a session-scoped agent. Call after `initialize` response. */
+    register(sessionId: string, agent: StdioAgent): void {
+        this.sessions.set(sessionId, agent);
+    }
+
+    /** Unregister a session. Call on destroy. */
+    unregister(sessionId: string): void {
+        this.sessions.delete(sessionId);
+    }
+
+    /** Register a global (non-session-scoped) notification handler. */
+    registerGlobal(method: string, handler: GlobalHandler): void {
+        this.globalHandlers.set(method, handler);
+    }
+
+    private dispatch(
+        method: string,
+        params: unknown,
+        sessionId?: string,
+    ): void {
+        if (sessionId) {
+            const agent = this.sessions.get(sessionId);
+            if (!agent) return; // early notification before register — drop (v1)
+            // sessionIdChange requires rekeying the agent in the map
+            if (method === 'sessionIdChange') {
+                const newId = (params as { sessionId: string }).sessionId;
+                if (newId && newId !== sessionId) {
+                    this.sessions.delete(sessionId);
+                    this.sessions.set(newId, agent);
+                }
+            }
+            agent.handleNotification(method, params);
+        } else {
+            // Global notification (e.g. authUrl)
+            const handler = this.globalHandlers.get(method);
+            if (handler) handler(params);
+        }
+    }
+}

--- a/packages/vsce/src/stdio/stdioAgent.ts
+++ b/packages/vsce/src/stdio/stdioAgent.ts
@@ -1,13 +1,16 @@
 /**
  * StdioAgent — typed wrapper around StdioClient that mirrors the Agent API.
  *
- * Replaces direct `Agent` usage in ChatSession. All previously-synchronous
- * methods (abortMessage, clearMessages, getSlashCommands, etc.) are now async
- * because they cross a subprocess boundary.
+ * In the single-shared-process architecture, all sessions share one
+ * StdioClient. The NotificationRouter dispatches incoming notifications to
+ * the appropriate StdioAgent via `handleNotification()`. The agent no longer
+ * subscribes directly to the client.
  *
- * Cached state (sessionId, workingDirectory, latestTotalTokens, permissionMode,
- * messages, queuedMessages, tasks) is kept in sync via notifications, allowing
- * synchronous property access where the old code used `agent.xxx`.
+ * All session-scoped requests carry `this.sessionId` on the JSON-RPC envelope
+ * so the server can route them to the right Agent.
+ *
+ * `destroy()` only unregisters from the router and sends the destroy request;
+ * it does NOT dispose the shared StdioClient.
  */
 
 import type {
@@ -23,6 +26,7 @@ import type {
     McpServerConfig,
 } from 'wave-agent-sdk';
 import { StdioClient } from './stdioClient';
+import { NotificationRouter } from './notificationRouter';
 
 // ── Params / Results ─────────────────────────────────────────────
 
@@ -118,12 +122,17 @@ export class StdioAgent {
     public tasks: Task[] = [];
 
     private client: StdioClient;
+    private router: NotificationRouter;
     private callbacks: StdioAgentCallbacks;
 
-    constructor(client: StdioClient, callbacks: StdioAgentCallbacks) {
+    constructor(
+        client: StdioClient,
+        router: NotificationRouter,
+        callbacks: StdioAgentCallbacks,
+    ) {
         this.client = client;
+        this.router = router;
         this.callbacks = callbacks;
-        this.registerNotifications();
     }
 
     // ── Lifecycle ─────────────────────────────────────────────────
@@ -140,28 +149,47 @@ export class StdioAgent {
         this.permissionMode = result.permissionMode;
         this.latestTotalTokens = result.latestTotalTokens;
         this.serverVersion = result.serverVersion;
+        // Register with the router so subsequent notifications are routed here
+        this.router.register(this.sessionId, this);
         return result;
     }
 
     async destroy(): Promise<void> {
-        try {
-            await this.client.request('destroy');
-        } finally {
-            this.client.dispose();
+        if (this.sessionId) {
+            this.router.unregister(this.sessionId);
         }
+        try {
+            await this.client.request('destroy', undefined, this.sessionId);
+        } catch {
+            // Process may have already exited; best-effort
+        }
+        // NOTE: do NOT dispose the shared client — other sessions may still use it
     }
 
     async restoreSession(sessionId: string): Promise<void> {
-        await this.client.request('restoreSession', { sessionId });
+        await this.client.request(
+            'restoreSession',
+            { sessionId },
+            this.sessionId,
+        );
     }
 
     async updateConfig(
         params: UpdateConfigParams,
     ): Promise<{ sessionId: string }> {
-        return (await this.client.request(
+        const oldSessionId = this.sessionId;
+        const result = (await this.client.request(
             'updateConfig',
             params,
+            this.sessionId,
         )) as { sessionId: string };
+        // If sessionId changed, re-register with the router
+        if (oldSessionId && result.sessionId !== oldSessionId) {
+            this.router.unregister(oldSessionId);
+            this.sessionId = result.sessionId;
+            this.router.register(this.sessionId, this);
+        }
+        return result;
     }
 
     // ── Messages ──────────────────────────────────────────────────
@@ -171,31 +199,41 @@ export class StdioAgent {
         images?: Array<{ path: string; mimeType: string }>,
         force?: boolean,
     ): Promise<void> {
-        await this.client.request('sendMessage', { text, images, force });
+        await this.client.request(
+            'sendMessage',
+            { text, images, force },
+            this.sessionId,
+        );
     }
 
     async bang(command: string): Promise<void> {
-        await this.client.request('bang', { command });
+        await this.client.request('bang', { command }, this.sessionId);
     }
 
     async abortMessage(): Promise<void> {
-        await this.client.request('abortMessage');
+        await this.client.request('abortMessage', undefined, this.sessionId);
     }
 
     async clearMessages(): Promise<void> {
-        await this.client.request('clearMessages');
+        await this.client.request('clearMessages', undefined, this.sessionId);
     }
 
     async rewindToMessage(
         messageId: string,
     ): Promise<{ inputContent: string }> {
-        return (await this.client.request('rewindToMessage', {
-            messageId,
-        })) as { inputContent: string };
+        return (await this.client.request(
+            'rewindToMessage',
+            { messageId },
+            this.sessionId,
+        )) as { inputContent: string };
     }
 
     async removeQueuedMessage(index: number): Promise<void> {
-        await this.client.request('deleteQueuedMessage', { index });
+        await this.client.request(
+            'deleteQueuedMessage',
+            { index },
+            this.sessionId,
+        );
     }
 
     async getFullMessageThread(): Promise<{
@@ -204,13 +242,19 @@ export class StdioAgent {
     }> {
         return (await this.client.request(
             'getFullMessageThread',
+            undefined,
+            this.sessionId,
         )) as { messages: Message[]; sessionIds: string[] };
     }
 
     // ── Permissions ───────────────────────────────────────────────
 
     async setPermissionMode(mode: PermissionMode): Promise<void> {
-        await this.client.request('setPermissionMode', { mode });
+        await this.client.request(
+            'setPermissionMode',
+            { mode },
+            this.sessionId,
+        );
     }
 
     /** Returns cached permission mode (updated via notification). */
@@ -222,172 +266,175 @@ export class StdioAgent {
         requestId: string,
         decision: PermissionDecision,
     ): void {
-        this.client.notify('permissionResponse', { requestId, decision });
+        this.client.notify(
+            'permissionResponse',
+            { requestId, decision },
+            this.sessionId,
+        );
     }
 
     // ── MCP ───────────────────────────────────────────────────────
 
     async getMcpServers(): Promise<McpServerStatus[]> {
-        const result = (await this.client.request('getMcpServers')) as {
-            servers: McpServerStatus[];
-        };
+        const result = (await this.client.request(
+            'getMcpServers',
+            undefined,
+            this.sessionId,
+        )) as { servers: McpServerStatus[] };
         return result.servers;
     }
 
     async connectMcpServer(serverName: string): Promise<boolean> {
-        const result = (await this.client.request('connectMcpServer', {
-            serverName,
-        })) as { success: boolean };
+        const result = (await this.client.request(
+            'connectMcpServer',
+            { serverName },
+            this.sessionId,
+        )) as { success: boolean };
         return result.success;
     }
 
     async disconnectMcpServer(serverName: string): Promise<boolean> {
-        const result = (await this.client.request('disconnectMcpServer', {
-            serverName,
-        })) as { success: boolean };
+        const result = (await this.client.request(
+            'disconnectMcpServer',
+            { serverName },
+            this.sessionId,
+        )) as { success: boolean };
         return result.success;
     }
 
     // ── Commands ──────────────────────────────────────────────────
 
     async getSlashCommands(): Promise<SlashCommand[]> {
-        const result = (await this.client.request('getSlashCommands')) as {
-            commands: SlashCommand[];
-        };
+        const result = (await this.client.request(
+            'getSlashCommands',
+            undefined,
+            this.sessionId,
+        )) as { commands: SlashCommand[] };
         return result.commands;
     }
 
-    // ── Notification registration ─────────────────────────────────
+    // ── Notification dispatch (called by NotificationRouter) ──────
 
-    private registerNotifications(): void {
-        const on = (method: string, handler: NotificationHandler) => {
-            this.client.onNotification(method, handler);
-        };
-
-        on('messagesChange', (params) => {
-            const p = params as { messages: Message[] };
-            this.messages = p.messages;
-            this.callbacks.onMessagesChange?.(this.messages);
-        });
-
-        on('userMessageAdded', (params) => {
-            const p = params as { message: Message };
-            if (p.message) this.callbacks.onUserMessageAdded?.(p.message);
-        });
-
-        on('assistantMessageAdded', (params) => {
-            const p = params as { message: Message };
-            if (p.message) this.callbacks.onAssistantMessageAdded?.(p.message);
-        });
-
-        on('assistantContentUpdated', (params) => {
-            this.callbacks.onAssistantContentUpdated?.(
-                params as {
-                    messageId: string;
-                    accumulated: string;
-                    stage: 'streaming' | 'end';
-                },
-            );
-        });
-
-        on('assistantReasoningUpdated', (params) => {
-            this.callbacks.onAssistantReasoningUpdated?.(
-                params as {
-                    messageId: string;
-                    accumulated: string;
-                    stage: 'streaming' | 'end';
-                },
-            );
-        });
-
-        on('toolBlockUpdated', (params) => {
-            this.callbacks.onToolBlockUpdated?.(
-                params as ToolBlockUpdateCallbackParams,
-            );
-        });
-
-        on('errorBlockAdded', (params) => {
-            const p = params as { error: string };
-            this.callbacks.onErrorBlockAdded?.(p.error);
-        });
-
-        on('loadingChange', (params) => {
-            const p = params as {
-                loading: boolean;
-                latestTotalTokens: number;
-            };
-            if (p.latestTotalTokens !== undefined) {
-                this.latestTotalTokens = p.latestTotalTokens;
+    handleNotification(method: string, params: unknown): void {
+        switch (method) {
+            case 'messagesChange': {
+                const p = params as { messages: Message[] };
+                this.messages = p.messages;
+                this.callbacks.onMessagesChange?.(this.messages);
+                break;
             }
-            this.callbacks.onLoadingChange?.(p.loading);
-        });
-
-        on('commandRunningChange', (params) => {
-            const p = params as { running: boolean };
-            this.callbacks.onCommandRunningChange?.(p.running);
-        });
-
-        on('queuedMessagesChange', (params) => {
-            const p = params as { messages: QueuedMessage[] };
-            this.queuedMessages = p.messages;
-            this.callbacks.onQueuedMessagesChange?.(p.messages);
-        });
-
-        on('tasksChange', (params) => {
-            const p = params as { tasks: Task[] };
-            this.tasks = p.tasks;
-            this.callbacks.onTasksChange?.(p.tasks);
-        });
-
-        on('sessionIdChange', (params) => {
-            const p = params as { sessionId: string };
-            this.sessionId = p.sessionId;
-            this.callbacks.onSessionIdChange?.(p.sessionId);
-        });
-
-        on('permissionModeChange', (params) => {
-            const p = params as { mode: PermissionMode };
-            this.permissionMode = p.mode;
-            this.callbacks.onPermissionModeChange?.(p.mode);
-        });
-
-        on('mcpServersChange', (params) => {
-            const p = params as { servers: McpServerStatus[] };
-            this.callbacks.onMcpServersChange?.(p.servers);
-        });
-
-        on('bangMessageAdded', () => {
-            this.callbacks.onBangMessageAdded?.();
-        });
-
-        on('bangMessageUpdated', () => {
-            this.callbacks.onBangMessageUpdated?.();
-        });
-
-        on('bangMessageCompleted', () => {
-            this.callbacks.onBangMessageCompleted?.();
-        });
-
-        on('notificationMessageAdded', (params) => {
-            this.callbacks.onNotificationMessageAdded?.(
-                params as {
-                    taskId: string;
-                    taskType: string;
-                    status: string;
-                    summary: string;
-                    message?: Message;
-                },
-            );
-        });
-
-        on('permissionRequest', (params) => {
-            const p = params as {
-                requestId: string;
-                context: ToolPermissionContext;
-            };
-            this.callbacks.onPermissionRequest?.(p.requestId, p.context);
-        });
+            case 'userMessageAdded': {
+                const p = params as { message: Message };
+                if (p.message) this.callbacks.onUserMessageAdded?.(p.message);
+                break;
+            }
+            case 'assistantMessageAdded': {
+                const p = params as { message: Message };
+                if (p.message)
+                    this.callbacks.onAssistantMessageAdded?.(p.message);
+                break;
+            }
+            case 'assistantContentUpdated':
+                this.callbacks.onAssistantContentUpdated?.(
+                    params as {
+                        messageId: string;
+                        accumulated: string;
+                        stage: 'streaming' | 'end';
+                    },
+                );
+                break;
+            case 'assistantReasoningUpdated':
+                this.callbacks.onAssistantReasoningUpdated?.(
+                    params as {
+                        messageId: string;
+                        accumulated: string;
+                        stage: 'streaming' | 'end';
+                    },
+                );
+                break;
+            case 'toolBlockUpdated':
+                this.callbacks.onToolBlockUpdated?.(
+                    params as ToolBlockUpdateCallbackParams,
+                );
+                break;
+            case 'errorBlockAdded': {
+                const p = params as { error: string };
+                this.callbacks.onErrorBlockAdded?.(p.error);
+                break;
+            }
+            case 'loadingChange': {
+                const p = params as {
+                    loading: boolean;
+                    latestTotalTokens: number;
+                };
+                if (p.latestTotalTokens !== undefined) {
+                    this.latestTotalTokens = p.latestTotalTokens;
+                }
+                this.callbacks.onLoadingChange?.(p.loading);
+                break;
+            }
+            case 'commandRunningChange': {
+                const p = params as { running: boolean };
+                this.callbacks.onCommandRunningChange?.(p.running);
+                break;
+            }
+            case 'queuedMessagesChange': {
+                const p = params as { messages: QueuedMessage[] };
+                this.queuedMessages = p.messages;
+                this.callbacks.onQueuedMessagesChange?.(p.messages);
+                break;
+            }
+            case 'tasksChange': {
+                const p = params as { tasks: Task[] };
+                this.tasks = p.tasks;
+                this.callbacks.onTasksChange?.(p.tasks);
+                break;
+            }
+            case 'sessionIdChange': {
+                const p = params as { sessionId: string };
+                this.sessionId = p.sessionId;
+                this.callbacks.onSessionIdChange?.(p.sessionId);
+                break;
+            }
+            case 'permissionModeChange': {
+                const p = params as { mode: PermissionMode };
+                this.permissionMode = p.mode;
+                this.callbacks.onPermissionModeChange?.(p.mode);
+                break;
+            }
+            case 'mcpServersChange': {
+                const p = params as { servers: McpServerStatus[] };
+                this.callbacks.onMcpServersChange?.(p.servers);
+                break;
+            }
+            case 'bangMessageAdded':
+                this.callbacks.onBangMessageAdded?.();
+                break;
+            case 'bangMessageUpdated':
+                this.callbacks.onBangMessageUpdated?.();
+                break;
+            case 'bangMessageCompleted':
+                this.callbacks.onBangMessageCompleted?.();
+                break;
+            case 'notificationMessageAdded':
+                this.callbacks.onNotificationMessageAdded?.(
+                    params as {
+                        taskId: string;
+                        taskType: string;
+                        status: string;
+                        summary: string;
+                        message?: Message;
+                    },
+                );
+                break;
+            case 'permissionRequest': {
+                const p = params as {
+                    requestId: string;
+                    context: ToolPermissionContext;
+                };
+                this.callbacks.onPermissionRequest?.(p.requestId, p.context);
+                break;
+            }
+        }
     }
 }
-
-type NotificationHandler = (params: unknown) => void;

--- a/packages/vsce/src/stdio/stdioClient.ts
+++ b/packages/vsce/src/stdio/stdioClient.ts
@@ -8,7 +8,7 @@
 import { type ChildProcess, spawn } from 'child_process';
 import { createInterface } from 'readline';
 
-export type NotificationHandler = (params: unknown) => void;
+export type NotificationHandler = (params: unknown, sessionId?: string) => void;
 
 interface PendingRequest {
     resolve: (value: unknown) => void;
@@ -63,12 +63,18 @@ export class StdioClient {
 
     // ── Public API ────────────────────────────────────────────────
 
-    async request(method: string, params?: unknown): Promise<unknown> {
+    async request(
+        method: string,
+        params?: unknown,
+        sessionId?: string,
+    ): Promise<unknown> {
         if (this.disposed) {
             throw new Error('StdioClient is disposed');
         }
         const id = this.nextId++;
-        const message = JSON.stringify({ id, method, params }) + '\n';
+        const envelope: Record<string, unknown> = { id, method, params };
+        if (sessionId) envelope.sessionId = sessionId;
+        const message = JSON.stringify(envelope) + '\n';
 
         return new Promise((resolve, reject) => {
             this.pending.set(id, { resolve, reject });
@@ -76,9 +82,11 @@ export class StdioClient {
         });
     }
 
-    notify(method: string, params?: unknown): void {
+    notify(method: string, params?: unknown, sessionId?: string): void {
         if (this.disposed) return;
-        const message = JSON.stringify({ method, params }) + '\n';
+        const envelope: Record<string, unknown> = { method, params };
+        if (sessionId) envelope.sessionId = sessionId;
+        const message = JSON.stringify(envelope) + '\n';
         this.proc.stdin!.write(message);
     }
 
@@ -135,10 +143,12 @@ export class StdioClient {
         if ('method' in obj && !('id' in obj)) {
             const method = obj.method as string;
             const params = obj.params;
+            const sessionId =
+                typeof obj.sessionId === 'string' ? obj.sessionId : undefined;
             const set = this.handlers.get(method);
             if (set) {
                 for (const handler of set) {
-                    handler(params);
+                    handler(params, sessionId);
                 }
             }
             return;

--- a/packages/vsce/tests/stdio/notificationRouter.test.ts
+++ b/packages/vsce/tests/stdio/notificationRouter.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { StdioClient } from '../../src/stdio/stdioClient';
+import { NotificationRouter } from '../../src/stdio/notificationRouter';
+
+// ── Mock StdioClient ───────────────────────────────────────────
+
+interface MockClient {
+    request: ReturnType<typeof vi.fn>;
+    notify: ReturnType<typeof vi.fn>;
+    dispose: ReturnType<typeof vi.fn>;
+    onNotification: ReturnType<typeof vi.fn>;
+    offNotification: ReturnType<typeof vi.fn>;
+}
+
+function createMockClient(): MockClient {
+    return {
+        request: vi.fn(),
+        notify: vi.fn(),
+        dispose: vi.fn(),
+        onNotification: vi.fn(),
+        offNotification: vi.fn(),
+    };
+}
+
+interface FakeAgent {
+    handleNotification: ReturnType<typeof vi.fn>;
+}
+
+function createFakeAgent(): FakeAgent {
+    return { handleNotification: vi.fn() };
+}
+
+// Look up the handler the router registered on the client for a method.
+function getHandler(client: MockClient, method: string): (params: unknown, sessionId?: string) => void {
+    for (const call of client.onNotification.mock.calls) {
+        const [m, h] = call as [string, (params: unknown, sessionId?: string) => void];
+        if (m === method) return h;
+    }
+    throw new Error(`No handler registered for method: ${method}`);
+}
+
+describe('NotificationRouter', () => {
+    let client: MockClient;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        client = createMockClient();
+    });
+
+    // ── attach ─────────────────────────────────────────────────
+
+    it('attach subscribes to all notification methods on the client', () => {
+        const router = new NotificationRouter(client as unknown as StdioClient);
+        router.attach();
+
+        const methods = client.onNotification.mock.calls.map((c) => c[0] as string);
+        expect(methods).toContain('messagesChange');
+        expect(methods).toContain('userMessageAdded');
+        expect(methods).toContain('assistantMessageAdded');
+        expect(methods).toContain('assistantContentUpdated');
+        expect(methods).toContain('assistantReasoningUpdated');
+        expect(methods).toContain('toolBlockUpdated');
+        expect(methods).toContain('errorBlockAdded');
+        expect(methods).toContain('loadingChange');
+        expect(methods).toContain('commandRunningChange');
+        expect(methods).toContain('queuedMessagesChange');
+        expect(methods).toContain('tasksChange');
+        expect(methods).toContain('sessionIdChange');
+        expect(methods).toContain('permissionModeChange');
+        expect(methods).toContain('mcpServersChange');
+        expect(methods).toContain('bangMessageAdded');
+        expect(methods).toContain('bangMessageUpdated');
+        expect(methods).toContain('bangMessageCompleted');
+        expect(methods).toContain('notificationMessageAdded');
+        expect(methods).toContain('permissionRequest');
+        expect(methods).toContain('authUrl');
+    });
+
+    it('attach is idempotent — does not register handlers twice', () => {
+        const router = new NotificationRouter(client as unknown as StdioClient);
+        router.attach();
+        router.attach();
+
+        expect(client.onNotification.mock.calls.length).toBeGreaterThanOrEqual(20);
+        // Each method should appear exactly once
+        const methods = client.onNotification.mock.calls.map((c) => c[0] as string);
+        const unique = new Set(methods);
+        expect(unique.size).toBe(methods.length);
+    });
+
+    // ── Session-scoped dispatch ────────────────────────────────
+
+    it('dispatches notification to registered agent by sessionId', () => {
+        const router = new NotificationRouter(client as unknown as StdioClient);
+        router.attach();
+
+        const agent = createFakeAgent();
+        router.register('s1', agent as unknown as Parameters<NotificationRouter['register']>[1]);
+
+        getHandler(client, 'messagesChange')({ messages: [] }, 's1');
+
+        expect(agent.handleNotification).toHaveBeenCalledWith('messagesChange', { messages: [] });
+    });
+
+    it('drops notification for unregistered sessionId without throwing', () => {
+        const router = new NotificationRouter(client as unknown as StdioClient);
+        router.attach();
+
+        const agent = createFakeAgent();
+        router.register('s1', agent as unknown as Parameters<NotificationRouter['register']>[1]);
+
+        expect(() => {
+            getHandler(client, 'messagesChange')({ messages: [] }, 's2');
+        }).not.toThrow();
+        expect(agent.handleNotification).not.toHaveBeenCalled();
+    });
+
+    it('dispatches to the correct agent when multiple are registered', () => {
+        const router = new NotificationRouter(client as unknown as StdioClient);
+        router.attach();
+
+        const agent1 = createFakeAgent();
+        const agent2 = createFakeAgent();
+        router.register('s1', agent1 as unknown as Parameters<NotificationRouter['register']>[1]);
+        router.register('s2', agent2 as unknown as Parameters<NotificationRouter['register']>[1]);
+
+        getHandler(client, 'tasksChange')({ tasks: [] }, 's2');
+
+        expect(agent1.handleNotification).not.toHaveBeenCalled();
+        expect(agent2.handleNotification).toHaveBeenCalledWith('tasksChange', { tasks: [] });
+    });
+
+    // ── Global dispatch ────────────────────────────────────────
+
+    it('dispatches notification without sessionId to global handler', () => {
+        const router = new NotificationRouter(client as unknown as StdioClient);
+        router.attach();
+
+        const globalHandler = vi.fn();
+        router.registerGlobal('authUrl', globalHandler);
+
+        getHandler(client, 'authUrl')({ url: 'https://example.com/auth' }, undefined);
+
+        expect(globalHandler).toHaveBeenCalledWith({ url: 'https://example.com/auth' });
+    });
+
+    it('notification with sessionId for a global method goes to the agent (sessionId wins)', () => {
+        const router = new NotificationRouter(client as unknown as StdioClient);
+        router.attach();
+
+        const globalHandler = vi.fn();
+        router.registerGlobal('authUrl', globalHandler);
+
+        const agent = createFakeAgent();
+        router.register('s1', agent as unknown as Parameters<NotificationRouter['register']>[1]);
+
+        getHandler(client, 'authUrl')({ url: 'https://example.com/auth' }, 's1');
+
+        expect(agent.handleNotification).toHaveBeenCalledWith('authUrl', { url: 'https://example.com/auth' });
+        expect(globalHandler).not.toHaveBeenCalled();
+    });
+
+    it('global notification for unregistered global method is dropped silently', () => {
+        const router = new NotificationRouter(client as unknown as StdioClient);
+        router.attach();
+
+        expect(() => {
+            getHandler(client, 'authUrl')({ url: 'x' }, undefined);
+        }).not.toThrow();
+    });
+
+    // ── unregister ─────────────────────────────────────────────
+
+    it('unregister stops dispatching notifications to that agent', () => {
+        const router = new NotificationRouter(client as unknown as StdioClient);
+        router.attach();
+
+        const agent = createFakeAgent();
+        router.register('s1', agent as unknown as Parameters<NotificationRouter['register']>[1]);
+
+        router.unregister('s1');
+
+        getHandler(client, 'messagesChange')({ messages: [] }, 's1');
+
+        expect(agent.handleNotification).not.toHaveBeenCalled();
+    });
+
+    it('unregister of unknown sessionId does not throw', () => {
+        const router = new NotificationRouter(client as unknown as StdioClient);
+        router.attach();
+
+        expect(() => router.unregister('never-registered')).not.toThrow();
+    });
+
+    // ── sessionIdChange rekeying ───────────────────────────────
+
+    it('sessionIdChange rekeys the agent from old to new sessionId', () => {
+        const router = new NotificationRouter(client as unknown as StdioClient);
+        router.attach();
+
+        const agent = createFakeAgent();
+        router.register('old-id', agent as unknown as Parameters<NotificationRouter['register']>[1]);
+
+        // Server emits sessionIdChange notification tagged with the OLD sessionId
+        // and params carrying the NEW sessionId.
+        getHandler(client, 'sessionIdChange')({ sessionId: 'new-id' }, 'old-id');
+
+        // Agent's handleNotification is invoked for the change notification
+        expect(agent.handleNotification).toHaveBeenCalledWith('sessionIdChange', { sessionId: 'new-id' });
+
+        // Subsequent notification tagged with new-id dispatches to the same agent
+        getHandler(client, 'messagesChange')({ messages: [] }, 'new-id');
+        expect(agent.handleNotification).toHaveBeenCalledWith('messagesChange', { messages: [] });
+
+        // Old sessionId no longer routes to the agent
+        getHandler(client, 'loadingChange')({ loading: true }, 'old-id');
+        expect(agent.handleNotification).toHaveBeenCalledTimes(2);
+    });
+
+    it('sessionIdChange with same sessionId does not rekey', () => {
+        const router = new NotificationRouter(client as unknown as StdioClient);
+        router.attach();
+
+        const agent = createFakeAgent();
+        router.register('same-id', agent as unknown as Parameters<NotificationRouter['register']>[1]);
+
+        getHandler(client, 'sessionIdChange')({ sessionId: 'same-id' }, 'same-id');
+
+        // Still dispatches under same-id
+        getHandler(client, 'messagesChange')({ messages: [] }, 'same-id');
+        expect(agent.handleNotification).toHaveBeenCalledWith('messagesChange', { messages: [] });
+    });
+});

--- a/packages/vsce/tests/stdio/stdioAgent.test.ts
+++ b/packages/vsce/tests/stdio/stdioAgent.test.ts
@@ -1,17 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { StdioClient } from '../../src/stdio/stdioClient';
 import { StdioAgent } from '../../src/stdio/stdioAgent';
+import { NotificationRouter } from '../../src/stdio/notificationRouter';
 import type { Message, Task, QueuedMessage, PermissionMode, ToolPermissionContext } from 'wave-agent-sdk';
-
-/** Await a promise that is expected to reject, returning the error. */
-async function expectReject(p: Promise<unknown>): Promise<Error> {
-    try {
-        await p;
-        throw new Error('Expected promise to reject');
-    } catch (e) {
-        return e as Error;
-    }
-}
 
 // ── Mock StdioClient ───────────────────────────────────────────
 
@@ -33,11 +24,11 @@ function createMockClient(): MockClient {
     };
 }
 
-// Collect notification handlers registered by StdioAgent
-function getNotificationHandlers(client: MockClient): Map<string, (params: unknown) => void> {
-    const handlers = new Map<string, (params: unknown) => void>();
+// Collect notification handlers registered on the client (by the router)
+function getNotificationHandlers(client: MockClient): Map<string, (params: unknown, sessionId?: string) => void> {
+    const handlers = new Map<string, (params: unknown, sessionId?: string) => void>();
     for (const call of client.onNotification.mock.calls) {
-        const [method, handler] = call as [string, (params: unknown) => void];
+        const [method, handler] = call as [string, (params: unknown, sessionId?: string) => void];
         handlers.set(method, handler);
     }
     return handlers;
@@ -45,11 +36,14 @@ function getNotificationHandlers(client: MockClient): Map<string, (params: unkno
 
 function createAgent(callbacks: Record<string, (...args: unknown[]) => void> = {}) {
     const client = createMockClient();
+    const router = new NotificationRouter(client as unknown as StdioClient);
+    router.attach();
     const agent = new StdioAgent(
         client as unknown as StdioClient,
+        router,
         callbacks,
     );
-    return { agent, client, handlers: getNotificationHandlers(client) };
+    return { agent, client, router, handlers: getNotificationHandlers(client) };
 }
 
 describe('StdioAgent', () => {
@@ -59,7 +53,7 @@ describe('StdioAgent', () => {
 
     // ── Construction ───────────────────────────────────────────
 
-    it('registers notification handlers for all notification types', () => {
+    it('router attaches notification handlers for all notification types', () => {
         const { client } = createAgent();
 
         const registeredMethods = client.onNotification.mock.calls.map(
@@ -84,12 +78,13 @@ describe('StdioAgent', () => {
         expect(registeredMethods).toContain('bangMessageCompleted');
         expect(registeredMethods).toContain('notificationMessageAdded');
         expect(registeredMethods).toContain('permissionRequest');
+        expect(registeredMethods).toContain('authUrl');
     });
 
     // ── initialize ─────────────────────────────────────────────
 
-    it('sends initialize request and caches returned state', async () => {
-        const { agent, client } = createAgent();
+    it('sends initialize request, caches returned state, and registers with router', async () => {
+        const { agent, client, router } = createAgent();
 
         client.request.mockResolvedValue({
             sessionId: 'session-123',
@@ -97,6 +92,8 @@ describe('StdioAgent', () => {
             permissionMode: 'default',
             latestTotalTokens: 500,
         });
+
+        const registerSpy = vi.spyOn(router, 'register');
 
         const result = await agent.initialize({ workdir: '/workspace' });
 
@@ -111,35 +108,59 @@ describe('StdioAgent', () => {
         expect(agent.workingDirectory).toBe('/workspace');
         expect(agent.permissionMode).toBe('default');
         expect(agent.latestTotalTokens).toBe(500);
+        expect(registerSpy).toHaveBeenCalledWith('session-123', agent);
     });
 
     // ── destroy ────────────────────────────────────────────────
 
-    it('sends destroy request and disposes client', async () => {
-        const { agent, client } = createAgent();
-        client.request.mockResolvedValue(undefined);
+    it('sends destroy request with sessionId, unregisters router, does NOT dispose client', async () => {
+        const { agent, client, router } = createAgent();
+        client.request.mockResolvedValue({
+            sessionId: 'session-123',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
+
+        const unregisterSpy = vi.spyOn(router, 'unregister');
+        client.request.mockClear();
 
         await agent.destroy();
 
-        expect(client.request).toHaveBeenCalledWith('destroy');
-        expect(client.dispose).toHaveBeenCalled();
+        expect(unregisterSpy).toHaveBeenCalledWith('session-123');
+        expect(client.request).toHaveBeenCalledWith('destroy', undefined, 'session-123');
+        expect(client.dispose).not.toHaveBeenCalled();
     });
 
-    it('disposes client even if destroy request fails', async () => {
+    it('destroy swallows request failure and still does not dispose client', async () => {
         const { agent, client } = createAgent();
+        client.request.mockResolvedValue({
+            sessionId: 'session-123',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
+
         client.request.mockRejectedValue(new Error('destroy failed'));
 
-        const error = await expectReject(agent.destroy());
-        expect(error).toBeInstanceOf(Error);
-        expect(error.message).toBe('destroy failed');
-        expect(client.dispose).toHaveBeenCalled();
+        await expect(agent.destroy()).resolves.toBeUndefined();
+        expect(client.dispose).not.toHaveBeenCalled();
     });
 
     // ── sendMessage ────────────────────────────────────────────
 
-    it('sends sendMessage with text, images, and force', async () => {
+    it('sends sendMessage with text, images, force, and sessionId', async () => {
         const { agent, client } = createAgent();
-        client.request.mockResolvedValue(undefined);
+        client.request.mockResolvedValue({
+            sessionId: 'session-123',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
+        client.request.mockClear();
 
         const images = [{ path: '/img.png', mimeType: 'image/png' }];
         await agent.sendMessage('hello', images, true);
@@ -148,12 +169,19 @@ describe('StdioAgent', () => {
             text: 'hello',
             images,
             force: true,
-        });
+        }, 'session-123');
     });
 
-    it('sends sendMessage with minimal args', async () => {
+    it('sends sendMessage with minimal args and sessionId', async () => {
         const { agent, client } = createAgent();
-        client.request.mockResolvedValue(undefined);
+        client.request.mockResolvedValue({
+            sessionId: 'session-123',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
+        client.request.mockClear();
 
         await agent.sendMessage('hello');
 
@@ -161,69 +189,111 @@ describe('StdioAgent', () => {
             text: 'hello',
             images: undefined,
             force: undefined,
-        });
+        }, 'session-123');
     });
 
     // ── bang ───────────────────────────────────────────────────
 
-    it('sends bang request', async () => {
+    it('sends bang request with sessionId', async () => {
         const { agent, client } = createAgent();
-        client.request.mockResolvedValue(undefined);
+        client.request.mockResolvedValue({
+            sessionId: 'session-123',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
+        client.request.mockClear();
 
         await agent.bang('git status');
 
-        expect(client.request).toHaveBeenCalledWith('bang', { command: 'git status' });
+        expect(client.request).toHaveBeenCalledWith('bang', { command: 'git status' }, 'session-123');
     });
 
     // ── abortMessage ───────────────────────────────────────────
 
-    it('sends abortMessage request', async () => {
+    it('sends abortMessage request with sessionId', async () => {
         const { agent, client } = createAgent();
-        client.request.mockResolvedValue(undefined);
+        client.request.mockResolvedValue({
+            sessionId: 'session-123',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
+        client.request.mockClear();
 
         await agent.abortMessage();
 
-        expect(client.request).toHaveBeenCalledWith('abortMessage');
+        expect(client.request).toHaveBeenCalledWith('abortMessage', undefined, 'session-123');
     });
 
     // ── clearMessages ──────────────────────────────────────────
 
-    it('sends clearMessages request', async () => {
+    it('sends clearMessages request with sessionId', async () => {
         const { agent, client } = createAgent();
-        client.request.mockResolvedValue(undefined);
+        client.request.mockResolvedValue({
+            sessionId: 'session-123',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
+        client.request.mockClear();
 
         await agent.clearMessages();
 
-        expect(client.request).toHaveBeenCalledWith('clearMessages');
+        expect(client.request).toHaveBeenCalledWith('clearMessages', undefined, 'session-123');
     });
 
     // ── rewindToMessage ────────────────────────────────────────
 
-    it('sends rewindToMessage and returns inputContent', async () => {
+    it('sends rewindToMessage with sessionId and returns inputContent', async () => {
         const { agent, client } = createAgent();
+        client.request.mockResolvedValue({
+            sessionId: 'session-123',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
         client.request.mockResolvedValue({ inputContent: 'previous text' });
 
         const result = await agent.rewindToMessage('msg-1');
 
-        expect(client.request).toHaveBeenCalledWith('rewindToMessage', { messageId: 'msg-1' });
+        expect(client.request).toHaveBeenCalledWith('rewindToMessage', { messageId: 'msg-1' }, 'session-123');
         expect(result).toEqual({ inputContent: 'previous text' });
     });
 
     // ── removeQueuedMessage ────────────────────────────────────
 
-    it('sends deleteQueuedMessage with index', async () => {
+    it('sends deleteQueuedMessage with index and sessionId', async () => {
         const { agent, client } = createAgent();
-        client.request.mockResolvedValue(undefined);
+        client.request.mockResolvedValue({
+            sessionId: 'session-123',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
+        client.request.mockClear();
 
         await agent.removeQueuedMessage(2);
 
-        expect(client.request).toHaveBeenCalledWith('deleteQueuedMessage', { index: 2 });
+        expect(client.request).toHaveBeenCalledWith('deleteQueuedMessage', { index: 2 }, 'session-123');
     });
 
     // ── getFullMessageThread ───────────────────────────────────
 
-    it('returns messages and sessionIds', async () => {
+    it('returns messages and sessionIds with sessionId in request', async () => {
         const { agent, client } = createAgent();
+        client.request.mockResolvedValue({
+            sessionId: 'session-123',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
         client.request.mockResolvedValue({
             messages: [{ id: 'm1' }],
             sessionIds: ['s1', 's2'],
@@ -231,6 +301,7 @@ describe('StdioAgent', () => {
 
         const result = await agent.getFullMessageThread();
 
+        expect(client.request).toHaveBeenCalledWith('getFullMessageThread', undefined, 'session-123');
         expect(result).toEqual({
             messages: [{ id: 'm1' }],
             sessionIds: ['s1', 's2'],
@@ -239,39 +310,86 @@ describe('StdioAgent', () => {
 
     // ── updateConfig ───────────────────────────────────────────
 
-    it('sends updateConfig and returns new sessionId', async () => {
-        const { agent, client } = createAgent();
+    it('sends updateConfig with sessionId and re-registers router when sessionId changes', async () => {
+        const { agent, client, router } = createAgent();
+        client.request.mockResolvedValue({
+            sessionId: 'old-session',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
+
+        const registerSpy = vi.spyOn(router, 'register');
+        const unregisterSpy = vi.spyOn(router, 'unregister');
         client.request.mockResolvedValue({ sessionId: 'new-session' });
 
         const result = await agent.updateConfig({ model: 'gpt-4' });
 
-        expect(client.request).toHaveBeenCalledWith('updateConfig', { model: 'gpt-4' });
+        expect(client.request).toHaveBeenCalledWith('updateConfig', { model: 'gpt-4' }, 'old-session');
         expect(result).toEqual({ sessionId: 'new-session' });
+        expect(unregisterSpy).toHaveBeenCalledWith('old-session');
+        expect(registerSpy).toHaveBeenCalledWith('new-session', agent);
+        expect(agent.sessionId).toBe('new-session');
+    });
+
+    it('does not re-register router when sessionId unchanged by updateConfig', async () => {
+        const { agent, client, router } = createAgent();
+        client.request.mockResolvedValue({
+            sessionId: 'same-session',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
+
+        const registerSpy = vi.spyOn(router, 'register');
+        const unregisterSpy = vi.spyOn(router, 'unregister');
+        client.request.mockResolvedValue({ sessionId: 'same-session' });
+
+        await agent.updateConfig({ model: 'gpt-4' });
+
+        expect(unregisterSpy).not.toHaveBeenCalled();
+        expect(registerSpy).not.toHaveBeenCalled();
     });
 
     // ── restoreSession ─────────────────────────────────────────
 
-    it('sends restoreSession request', async () => {
+    it('sends restoreSession request with sessionId', async () => {
         const { agent, client } = createAgent();
-        client.request.mockResolvedValue(undefined);
+        client.request.mockResolvedValue({
+            sessionId: 'session-123',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
+        client.request.mockClear();
 
         await agent.restoreSession('old-session-id');
 
-        expect(client.request).toHaveBeenCalledWith('restoreSession', { sessionId: 'old-session-id' });
+        expect(client.request).toHaveBeenCalledWith('restoreSession', { sessionId: 'old-session-id' }, 'session-123');
     });
 
     // ── setPermissionMode ──────────────────────────────────────
 
-    it('sends setPermissionMode request', async () => {
+    it('sends setPermissionMode request with sessionId', async () => {
         const { agent, client } = createAgent();
-        client.request.mockResolvedValue(undefined);
+        client.request.mockResolvedValue({
+            sessionId: 'session-123',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
+        client.request.mockClear();
 
         await agent.setPermissionMode('plan' as PermissionMode);
 
-        expect(client.request).toHaveBeenCalledWith('setPermissionMode', { mode: 'plan' });
+        expect(client.request).toHaveBeenCalledWith('setPermissionMode', { mode: 'plan' }, 'session-123');
     });
 
-    it('getPermissionMode returns cached value', async () => {
+    it('getPermissionMode returns cached value', () => {
         const { agent } = createAgent();
 
         expect(agent.getPermissionMode()).toBeUndefined();
@@ -283,72 +401,109 @@ describe('StdioAgent', () => {
 
     // ── sendPermissionResponse ─────────────────────────────────
 
-    it('sends permissionResponse as notification (not request)', () => {
+    it('sends permissionResponse as notification with sessionId', async () => {
         const { agent, client } = createAgent();
+        client.request.mockResolvedValue({
+            sessionId: 'session-123',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
 
         agent.sendPermissionResponse('req-1', 'allow' as never);
 
         expect(client.notify).toHaveBeenCalledWith('permissionResponse', {
             requestId: 'req-1',
             decision: 'allow',
-        });
-        expect(client.request).not.toHaveBeenCalled();
+        }, 'session-123');
+        expect(client.request).not.toHaveBeenCalledWith('permissionResponse', expect.anything(), expect.anything());
     });
 
     // ── MCP ────────────────────────────────────────────────────
 
-    it('getMcpServers unwraps servers from result', async () => {
+    it('getMcpServers unwraps servers from result with sessionId', async () => {
         const { agent, client } = createAgent();
+        client.request.mockResolvedValue({
+            sessionId: 'session-123',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
         const servers = [{ name: 'server1', status: 'connected' }];
         client.request.mockResolvedValue({ servers });
 
         const result = await agent.getMcpServers();
 
+        expect(client.request).toHaveBeenCalledWith('getMcpServers', undefined, 'session-123');
         expect(result).toEqual(servers);
     });
 
-    it('connectMcpServer returns success boolean', async () => {
+    it('connectMcpServer returns success boolean with sessionId', async () => {
         const { agent, client } = createAgent();
+        client.request.mockResolvedValue({
+            sessionId: 'session-123',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
         client.request.mockResolvedValue({ success: true });
 
         const result = await agent.connectMcpServer('my-server');
 
-        expect(client.request).toHaveBeenCalledWith('connectMcpServer', { serverName: 'my-server' });
+        expect(client.request).toHaveBeenCalledWith('connectMcpServer', { serverName: 'my-server' }, 'session-123');
         expect(result).toBe(true);
     });
 
-    it('disconnectMcpServer returns success boolean', async () => {
+    it('disconnectMcpServer returns success boolean with sessionId', async () => {
         const { agent, client } = createAgent();
+        client.request.mockResolvedValue({
+            sessionId: 'session-123',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
         client.request.mockResolvedValue({ success: false });
 
         const result = await agent.disconnectMcpServer('my-server');
 
-        expect(client.request).toHaveBeenCalledWith('disconnectMcpServer', { serverName: 'my-server' });
+        expect(client.request).toHaveBeenCalledWith('disconnectMcpServer', { serverName: 'my-server' }, 'session-123');
         expect(result).toBe(false);
     });
 
     // ── getSlashCommands ───────────────────────────────────────
 
-    it('unwraps commands from result', async () => {
+    it('unwraps commands from result with sessionId', async () => {
         const { agent, client } = createAgent();
+        client.request.mockResolvedValue({
+            sessionId: 'session-123',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
         const commands = [{ name: 'compact', description: 'Compact' }];
         client.request.mockResolvedValue({ commands });
 
         const result = await agent.getSlashCommands();
 
+        expect(client.request).toHaveBeenCalledWith('getSlashCommands', undefined, 'session-123');
         expect(result).toEqual(commands);
     });
 
-    // ── Notification forwarding ────────────────────────────────
+    // ── handleNotification (called by NotificationRouter) ──────
 
     it('messagesChange updates cached messages and calls callback', () => {
         const onMessagesChange = vi.fn();
-        const { agent, handlers } = createAgent({ onMessagesChange });
+        const { agent } = createAgent({ onMessagesChange });
 
         const messages: Message[] = [
             { id: 'm1', role: 'user', timestamp: '', blocks: [] },
         ];
-        handlers.get('messagesChange')!({ messages });
+        agent.handleNotification('messagesChange', { messages });
 
         expect(agent.messages).toEqual(messages);
         expect(onMessagesChange).toHaveBeenCalledWith(messages);
@@ -356,77 +511,77 @@ describe('StdioAgent', () => {
 
     it('userMessageAdded forwards message to callback', () => {
         const onUserMessageAdded = vi.fn();
-        const { handlers } = createAgent({ onUserMessageAdded });
+        const { agent } = createAgent({ onUserMessageAdded });
 
         const message: Message = { id: 'm1', role: 'user', timestamp: '', blocks: [] };
-        handlers.get('userMessageAdded')!({ message });
+        agent.handleNotification('userMessageAdded', { message });
 
         expect(onUserMessageAdded).toHaveBeenCalledWith(message);
     });
 
     it('userMessageAdded does not call callback when message is undefined', () => {
         const onUserMessageAdded = vi.fn();
-        const { handlers } = createAgent({ onUserMessageAdded });
+        const { agent } = createAgent({ onUserMessageAdded });
 
-        handlers.get('userMessageAdded')!({ message: undefined });
+        agent.handleNotification('userMessageAdded', { message: undefined });
 
         expect(onUserMessageAdded).not.toHaveBeenCalled();
     });
 
     it('assistantMessageAdded forwards message to callback', () => {
         const onAssistantMessageAdded = vi.fn();
-        const { handlers } = createAgent({ onAssistantMessageAdded });
+        const { agent } = createAgent({ onAssistantMessageAdded });
 
         const message: Message = { id: 'a1', role: 'assistant', timestamp: '', blocks: [] };
-        handlers.get('assistantMessageAdded')!({ message });
+        agent.handleNotification('assistantMessageAdded', { message });
 
         expect(onAssistantMessageAdded).toHaveBeenCalledWith(message);
     });
 
     it('assistantContentUpdated forwards params to callback', () => {
         const onAssistantContentUpdated = vi.fn();
-        const { handlers } = createAgent({ onAssistantContentUpdated });
+        const { agent } = createAgent({ onAssistantContentUpdated });
 
         const params = { messageId: 'a1', accumulated: 'hello', stage: 'streaming' as const };
-        handlers.get('assistantContentUpdated')!(params);
+        agent.handleNotification('assistantContentUpdated', params);
 
         expect(onAssistantContentUpdated).toHaveBeenCalledWith(params);
     });
 
     it('assistantReasoningUpdated forwards params to callback', () => {
         const onAssistantReasoningUpdated = vi.fn();
-        const { handlers } = createAgent({ onAssistantReasoningUpdated });
+        const { agent } = createAgent({ onAssistantReasoningUpdated });
 
         const params = { messageId: 'a1', accumulated: 'thinking', stage: 'end' as const };
-        handlers.get('assistantReasoningUpdated')!(params);
+        agent.handleNotification('assistantReasoningUpdated', params);
 
         expect(onAssistantReasoningUpdated).toHaveBeenCalledWith(params);
     });
 
     it('toolBlockUpdated forwards params to callback', () => {
         const onToolBlockUpdated = vi.fn();
-        const { handlers } = createAgent({ onToolBlockUpdated });
+        const { agent } = createAgent({ onToolBlockUpdated });
 
         const params = { toolName: 'bash', toolCallId: 'tc1', status: 'running' };
-        handlers.get('toolBlockUpdated')!(params);
+        agent.handleNotification('toolBlockUpdated', params);
 
         expect(onToolBlockUpdated).toHaveBeenCalledWith(params);
     });
 
     it('errorBlockAdded forwards error string to callback', () => {
         const onErrorBlockAdded = vi.fn();
-        const { handlers } = createAgent({ onErrorBlockAdded });
+        const { agent } = createAgent({ onErrorBlockAdded });
 
-        handlers.get('errorBlockAdded')!({ error: 'Something went wrong' });
+        agent.handleNotification('errorBlockAdded', { error: 'Something went wrong' });
 
         expect(onErrorBlockAdded).toHaveBeenCalledWith('Something went wrong');
     });
 
     it('loadingChange updates latestTotalTokens and calls callback', () => {
         const onLoadingChange = vi.fn();
-        const { agent, handlers } = createAgent({ onLoadingChange });
+        const { agent } = createAgent({ onLoadingChange });
 
-        handlers.get('loadingChange')!({ loading: true, latestTotalTokens: 1000 });
+        agent.handleNotification('loadingChange', { loading: true, latestTotalTokens: 1000 });
 
         expect(agent.latestTotalTokens).toBe(1000);
         expect(onLoadingChange).toHaveBeenCalledWith(true);
@@ -434,10 +589,10 @@ describe('StdioAgent', () => {
 
     it('loadingChange does not update latestTotalTokens when undefined', () => {
         const onLoadingChange = vi.fn();
-        const { agent, handlers } = createAgent({ onLoadingChange });
+        const { agent } = createAgent({ onLoadingChange });
 
         agent.latestTotalTokens = 500;
-        handlers.get('loadingChange')!({ loading: false });
+        agent.handleNotification('loadingChange', { loading: false });
 
         expect(agent.latestTotalTokens).toBe(500);
         expect(onLoadingChange).toHaveBeenCalledWith(false);
@@ -445,19 +600,19 @@ describe('StdioAgent', () => {
 
     it('commandRunningChange forwards running boolean', () => {
         const onCommandRunningChange = vi.fn();
-        const { handlers } = createAgent({ onCommandRunningChange });
+        const { agent } = createAgent({ onCommandRunningChange });
 
-        handlers.get('commandRunningChange')!({ running: true });
+        agent.handleNotification('commandRunningChange', { running: true });
 
         expect(onCommandRunningChange).toHaveBeenCalledWith(true);
     });
 
     it('queuedMessagesChange updates cached queue and calls callback', () => {
         const onQueuedMessagesChange = vi.fn();
-        const { agent, handlers } = createAgent({ onQueuedMessagesChange });
+        const { agent } = createAgent({ onQueuedMessagesChange });
 
         const queue: QueuedMessage[] = [{ content: 'queued msg' }];
-        handlers.get('queuedMessagesChange')!({ messages: queue });
+        agent.handleNotification('queuedMessagesChange', { messages: queue });
 
         expect(agent.queuedMessages).toEqual(queue);
         expect(onQueuedMessagesChange).toHaveBeenCalledWith(queue);
@@ -465,10 +620,10 @@ describe('StdioAgent', () => {
 
     it('tasksChange updates cached tasks and calls callback', () => {
         const onTasksChange = vi.fn();
-        const { agent, handlers } = createAgent({ onTasksChange });
+        const { agent } = createAgent({ onTasksChange });
 
         const tasks: Task[] = [{ id: 't1', subject: 'Task 1', description: 'desc', status: 'pending', blocks: [], blockedBy: [], metadata: {} }];
-        handlers.get('tasksChange')!({ tasks });
+        agent.handleNotification('tasksChange', { tasks });
 
         expect(agent.tasks).toEqual(tasks);
         expect(onTasksChange).toHaveBeenCalledWith(tasks);
@@ -476,9 +631,9 @@ describe('StdioAgent', () => {
 
     it('sessionIdChange updates cached sessionId and calls callback', () => {
         const onSessionIdChange = vi.fn();
-        const { agent, handlers } = createAgent({ onSessionIdChange });
+        const { agent } = createAgent({ onSessionIdChange });
 
-        handlers.get('sessionIdChange')!({ sessionId: 'new-session' });
+        agent.handleNotification('sessionIdChange', { sessionId: 'new-session' });
 
         expect(agent.sessionId).toBe('new-session');
         expect(onSessionIdChange).toHaveBeenCalledWith('new-session');
@@ -486,9 +641,9 @@ describe('StdioAgent', () => {
 
     it('permissionModeChange updates cached mode and calls callback', () => {
         const onPermissionModeChange = vi.fn();
-        const { agent, handlers } = createAgent({ onPermissionModeChange });
+        const { agent } = createAgent({ onPermissionModeChange });
 
-        handlers.get('permissionModeChange')!({ mode: 'plan' });
+        agent.handleNotification('permissionModeChange', { mode: 'plan' });
 
         expect(agent.permissionMode).toBe('plan');
         expect(onPermissionModeChange).toHaveBeenCalledWith('plan');
@@ -496,10 +651,10 @@ describe('StdioAgent', () => {
 
     it('mcpServersChange forwards servers to callback', () => {
         const onMcpServersChange = vi.fn();
-        const { handlers } = createAgent({ onMcpServersChange });
+        const { agent } = createAgent({ onMcpServersChange });
 
         const servers = [{ name: 's1', status: 'connected' }];
-        handlers.get('mcpServersChange')!({ servers });
+        agent.handleNotification('mcpServersChange', { servers });
 
         expect(onMcpServersChange).toHaveBeenCalledWith(servers);
     });
@@ -508,15 +663,15 @@ describe('StdioAgent', () => {
         const onBangMessageAdded = vi.fn();
         const onBangMessageUpdated = vi.fn();
         const onBangMessageCompleted = vi.fn();
-        const { handlers } = createAgent({
+        const { agent } = createAgent({
             onBangMessageAdded,
             onBangMessageUpdated,
             onBangMessageCompleted,
         });
 
-        handlers.get('bangMessageAdded')!(undefined);
-        handlers.get('bangMessageUpdated')!(undefined);
-        handlers.get('bangMessageCompleted')!(undefined);
+        agent.handleNotification('bangMessageAdded', undefined);
+        agent.handleNotification('bangMessageUpdated', undefined);
+        agent.handleNotification('bangMessageCompleted', undefined);
 
         expect(onBangMessageAdded).toHaveBeenCalled();
         expect(onBangMessageUpdated).toHaveBeenCalled();
@@ -525,7 +680,7 @@ describe('StdioAgent', () => {
 
     it('notificationMessageAdded forwards params to callback', () => {
         const onNotificationMessageAdded = vi.fn();
-        const { handlers } = createAgent({ onNotificationMessageAdded });
+        const { agent } = createAgent({ onNotificationMessageAdded });
 
         const params = {
             taskId: 'task-1',
@@ -533,20 +688,20 @@ describe('StdioAgent', () => {
             status: 'completed',
             summary: 'Build succeeded',
         };
-        handlers.get('notificationMessageAdded')!(params);
+        agent.handleNotification('notificationMessageAdded', params);
 
         expect(onNotificationMessageAdded).toHaveBeenCalledWith(params);
     });
 
     it('permissionRequest forwards requestId and context to callback', () => {
         const onPermissionRequest = vi.fn();
-        const { handlers } = createAgent({ onPermissionRequest });
+        const { agent } = createAgent({ onPermissionRequest });
 
         const context: Partial<ToolPermissionContext> = {
             toolName: 'bash',
             toolInput: { command: 'rm -rf /' },
         };
-        handlers.get('permissionRequest')!({ requestId: 'req-1', context });
+        agent.handleNotification('permissionRequest', { requestId: 'req-1', context });
 
         expect(onPermissionRequest).toHaveBeenCalledWith('req-1', context);
     });
@@ -554,12 +709,12 @@ describe('StdioAgent', () => {
     // ── Callbacks are optional ─────────────────────────────────
 
     it('does not throw when callback is not provided', () => {
-        const { handlers } = createAgent(); // no callbacks
+        const { agent } = createAgent(); // no callbacks
 
         expect(() => {
-            handlers.get('messagesChange')!({ messages: [] });
-            handlers.get('loadingChange')!({ loading: true, latestTotalTokens: 0 });
-            handlers.get('permissionRequest')!({ requestId: 'r1', context: {} });
+            agent.handleNotification('messagesChange', { messages: [] });
+            agent.handleNotification('loadingChange', { loading: true, latestTotalTokens: 0 });
+            agent.handleNotification('permissionRequest', { requestId: 'r1', context: {} });
         }).not.toThrow();
     });
 });

--- a/packages/vsce/tests/stdio/stdioClient.test.ts
+++ b/packages/vsce/tests/stdio/stdioClient.test.ts
@@ -219,6 +219,33 @@ describe('StdioClient', () => {
         expect(await promise).toBe('ok');
     });
 
+    it('injects sessionId into request envelope when provided', async () => {
+        const { client, proc, rl } = createClient();
+
+        const promise = client.request('sendMessage', { text: 'hi' }, 'session-1');
+        const sent = JSON.parse(proc.stdin.write.mock.calls[0][0]);
+        expect(sent).toEqual({
+            id: 1,
+            method: 'sendMessage',
+            params: { text: 'hi' },
+            sessionId: 'session-1',
+        });
+
+        rl.emit('line', JSON.stringify({ id: 1, result: null }));
+        await promise;
+    });
+
+    it('does not include sessionId in request envelope when omitted', async () => {
+        const { client, proc, rl } = createClient();
+
+        const promise = client.request('initialize', { workdir: '/x' });
+        const sent = JSON.parse(proc.stdin.write.mock.calls[0][0]);
+        expect(sent).not.toHaveProperty('sessionId');
+
+        rl.emit('line', JSON.stringify({ id: 1, result: null }));
+        await promise;
+    });
+
     // ── Notify ─────────────────────────────────────────────────
 
     it('sends notification without id', () => {
@@ -244,6 +271,28 @@ describe('StdioClient', () => {
         expect(sent.params).toBeUndefined();
     });
 
+    it('injects sessionId into notify envelope when provided', () => {
+        const { client, proc } = createClient();
+
+        client.notify('permissionResponse', { requestId: 'r1' }, 'session-1');
+
+        const sent = JSON.parse(proc.stdin.write.mock.calls[0][0]);
+        expect(sent).toEqual({
+            method: 'permissionResponse',
+            params: { requestId: 'r1' },
+            sessionId: 'session-1',
+        });
+    });
+
+    it('does not include sessionId in notify envelope when omitted', () => {
+        const { client, proc } = createClient();
+
+        client.notify('someNotification');
+
+        const sent = JSON.parse(proc.stdin.write.mock.calls[0][0]);
+        expect(sent).not.toHaveProperty('sessionId');
+    });
+
     // ── Notifications ──────────────────────────────────────────
 
     it('calls registered handler when notification arrives', () => {
@@ -254,7 +303,7 @@ describe('StdioClient', () => {
 
         rl.emit('line', JSON.stringify({ method: 'messagesChange', params: { messages: [] } }));
 
-        expect(handler).toHaveBeenCalledWith({ messages: [] });
+        expect(handler).toHaveBeenCalledWith({ messages: [] }, undefined);
     });
 
     it('supports multiple handlers for same notification', () => {
@@ -267,8 +316,8 @@ describe('StdioClient', () => {
 
         rl.emit('line', JSON.stringify({ method: 'tasksChange', params: { tasks: [] } }));
 
-        expect(h1).toHaveBeenCalledWith({ tasks: [] });
-        expect(h2).toHaveBeenCalledWith({ tasks: [] });
+        expect(h1).toHaveBeenCalledWith({ tasks: [] }, undefined);
+        expect(h2).toHaveBeenCalledWith({ tasks: [] }, undefined);
     });
 
     it('offNotification removes specific handler', () => {
@@ -283,7 +332,22 @@ describe('StdioClient', () => {
         rl.emit('line', JSON.stringify({ method: 'loadingChange', params: { loading: true } }));
 
         expect(h1).not.toHaveBeenCalled();
-        expect(h2).toHaveBeenCalledWith({ loading: true });
+        expect(h2).toHaveBeenCalledWith({ loading: true }, undefined);
+    });
+
+    it('passes sessionId to handler when present in notification', () => {
+        const { client, rl } = createClient();
+
+        const handler = vi.fn();
+        client.onNotification('messagesChange', handler);
+
+        rl.emit('line', JSON.stringify({
+            method: 'messagesChange',
+            params: { messages: [] },
+            sessionId: 's1',
+        }));
+
+        expect(handler).toHaveBeenCalledWith({ messages: [] }, 's1');
     });
 
     it('does not call handlers for different notification methods', () => {


### PR DESCRIPTION
Replace N+1 process model (1 utility + N per-session wave --stdio processes)
with a single shared process hosting Map<sessionId, Agent>. The JSON-RPC
envelope gains an optional sessionId routing dimension; session-scoped
requests carry it, global requests (auth/plugins/searchFiles/listSessions)
don't require it.

Server (wave-code):
- protocol.ts: add sessionId? to JsonRpcRequest/JsonRpcNotification
- stdioServer.ts: extract/forward msg.sessionId on requests, notifications
- agentBridge.ts: Map<sessionId, {agent, storedConfig}> multi-tenant
  routing; SessionContext holder binds callbacks/canUseTool to the correct
  session before Agent.create resolves; onSessionIdChange rekeys the map
  atomically and emits with the old sessionId for client delivery

VSCE client:
- New NotificationRouter demuxes notifications by sessionId on the shared
  StdioClient (session-scoped -> agent.handleNotification; no sessionId ->
  global handler e.g. authUrl); handles sessionIdChange rekeying
- StdioClient.request/notify take optional sessionId, inject into envelope
- StdioAgent constructor takes (client, router, callbacks); destroys only
  unregister from router, never dispose the shared client; all session-
  scoped requests pass this.sessionId as 3rd arg
- ChatProvider: single sharedClient + router replace utility + per-session
  clients; CLI auto-upgrade now kills shared process, upgrades, rebuilds
  client+router, and re-initializes ALL active sessions with their
  restoreSessionId preserved

JetBrains:
- StdioClient.request/notify take optional sessionId
- StdioAgent injects sessionId on all session-scoped calls (no router
  needed; single session per project)

Tests:
- agentBridge.test.ts: 26 session-scoped tests pass sessionId; 3 new
  multi-session routing tests
- stdioServer.test.ts: sessionId envelope extraction/forwarding
- stdioClient.test.ts: sessionId envelope assertions
- stdioAgent.test.ts: 3-arg constructor, router register/unregister,
  handleNotification replaces registerNotifications
- New notificationRouter.test.ts: session/global dispatch, rekeying
