### PR TITLE
vsce: 移动自动更新触发到 agent 创建后，手动检查移入 StatusDialog

### DIFF
--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -70,11 +70,6 @@
         "command": "wave-code.addToWave",
         "title": "添加到 Wave",
         "category": "Wave"
-      },
-      {
-        "command": "wave-code.checkForUpdates",
-        "title": "检查更新",
-        "category": "Wave"
       }
     ],
     "menus": {

--- a/packages/vsce/src/chatProvider.ts
+++ b/packages/vsce/src/chatProvider.ts
@@ -19,7 +19,7 @@ import { MessageHandler } from './session/messageHandler';
 import { StdioClient } from './stdio/stdioClient';
 import { NotificationRouter } from './stdio/notificationRouter';
 import { resolveWaveBinary, upgradeWaveBinary } from './stdio/binaryResolver';
-import { parseVersion, compareVersions } from './services/updateService';
+import { parseVersion, compareVersions, checkAndNotify } from './services/updateService';
 
 export class ChatProvider implements vscode.WebviewViewProvider {
     private static formatConfigError(error: unknown): string {
@@ -50,6 +50,7 @@ export class ChatProvider implements vscode.WebviewViewProvider {
     private sharedClient: StdioClient | undefined;
     private notificationRouter: NotificationRouter | undefined;
     private cliUpgradeAttempted = false;
+    private updateCheckTriggered = false;
 
     constructor(context: vscode.ExtensionContext) {
         this.context = context;
@@ -105,7 +106,8 @@ export class ChatProvider implements vscode.WebviewViewProvider {
                     this.sidebarSession.updateConfig(cfg);
                     this.tabSessions.forEach(session => session.updateConfig(cfg));
                     this.windowSessions.forEach(session => session.updateConfig(cfg));
-                }
+                },
+                checkForUpdates: () => checkAndNotify(this.context, true)
             }
         );
 
@@ -273,6 +275,15 @@ export class ChatProvider implements vscode.WebviewViewProvider {
                 this.sharedClient!,
                 this.notificationRouter!,
             );
+
+            // Auto-update check: trigger once per activation after the first agent is created.
+            // The 24h cooldown is enforced inside checkAndNotify via globalState.
+            if (!this.updateCheckTriggered) {
+                this.updateCheckTriggered = true;
+                checkAndNotify(this.context).catch(err => {
+                    console.warn('[UpdateService] Update check failed:', err);
+                });
+            }
 
             // Version negotiation: if the CLI is older than the extension, silently
             // upgrade once per activation and re-initialize. Because the shared process

--- a/packages/vsce/src/extension.ts
+++ b/packages/vsce/src/extension.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
 import { ChatProvider } from './chatProvider';
-import { checkAndNotify } from './services/updateService';
 
 let chatProvider: ChatProvider | undefined;
 
@@ -9,11 +8,6 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Create a single ChatProvider instance for the extension lifecycle
     chatProvider = new ChatProvider(context);
-
-    // Check for updates asynchronously (non-blocking)
-    checkAndNotify(context).catch(err => {
-        console.warn('[UpdateService] Update check failed:', err);
-    });
 
     // Register sidebar command
     const openChatSidebarCommand = vscode.commands.registerCommand('wave-code.openChatSidebar', async () => {
@@ -50,16 +44,6 @@ export function activate(context: vscode.ExtensionContext) {
         }
     });
 
-    // Register check for updates command
-    const checkUpdatesCommand = vscode.commands.registerCommand('wave-code.checkForUpdates', async () => {
-        try {
-            await checkAndNotify(context, true);
-        } catch (error) {
-            console.error('检查更新时出错:', error);
-            vscode.window.showErrorMessage('检查更新失败: ' + error);
-        }
-    });
-
     async function openChatWithProgress(mode: 'sidebar' | 'tab' | 'window') {
         try {
             // Show progress indicator while opening chat
@@ -81,8 +65,7 @@ export function activate(context: vscode.ExtensionContext) {
         openChatTabCommand,
         openChatWindowCommand,
         focusViewCommand,
-        addToWaveCommand,
-        checkUpdatesCommand
+        addToWaveCommand
     );
     
     console.log('Wave 聊天命令注册成功');

--- a/packages/vsce/src/session/messageHandler.ts
+++ b/packages/vsce/src/session/messageHandler.ts
@@ -14,6 +14,7 @@ export interface MessageHandlerContext {
     initializeAgent: (viewType: 'sidebar' | 'tab' | 'window', windowId?: string, restoreSessionId?: string) => Promise<void>;
     listSessions: (viewType?: 'sidebar' | 'tab' | 'window', windowId?: string) => Promise<void>;
     updateAllSessionsConfig: (config: unknown) => void;
+    checkForUpdates: () => Promise<void>;
 }
 
 export class MessageHandler {
@@ -160,6 +161,9 @@ export class MessageHandler {
                 break;
             case 'disconnectMcpServer':
                 await this.handleDisconnectMcpServer(msg.serverName as string, viewType, windowId);
+                break;
+            case 'checkForUpdates':
+                await this.context.checkForUpdates();
                 break;
         }
     }

--- a/packages/vsce/tests/session/messageHandler.test.ts
+++ b/packages/vsce/tests/session/messageHandler.test.ts
@@ -36,6 +36,7 @@ function createHandler(session: ChatSession) {
         initializeAgent: vi.fn(),
         listSessions: vi.fn(),
         updateAllSessionsConfig: vi.fn(),
+        checkForUpdates: vi.fn(),
     };
     const handler = new MessageHandler(
         {} as unknown as ConfigurationService,

--- a/packages/webview/src/components/StatusDialog.tsx
+++ b/packages/webview/src/components/StatusDialog.tsx
@@ -92,7 +92,24 @@ const StatusDialog: React.FC<StatusDialogProps & { vscode: { postMessage: (msg: 
 
         <div className="configuration-form">
           <div className="configuration-fields-scroll-area">
-            <StatusRow label="版本" value={version} />
+            <div className="configuration-field">
+              <label>版本:</label>
+              <div style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+                fontSize: '13px',
+                color: 'var(--vscode-descriptionForeground)',
+                fontFamily: 'var(--vscode-editor-font-family, monospace)',
+                wordBreak: 'break-all',
+                padding: '4px 0'
+              }}>
+                <span>{version || '—'}</span>
+                <button type="button" onClick={() => vscode?.postMessage({ command: 'checkForUpdates' })} className="configuration-cancel-btn" style={{ padding: '2px 8px' }}>
+                  检查更新
+                </button>
+              </div>
+            </div>
             <StatusRow label="Session ID" value={sessionId} />
             <StatusRow label="工作目录" value={workdir} />
             <StatusRow label="Base URL" value={baseURL} />

--- a/packages/webview/tests/webview/model-status-login-commands.test.tsx
+++ b/packages/webview/tests/webview/model-status-login-commands.test.tsx
@@ -53,7 +53,7 @@ describe('Model, Status, and Login Commands', () => {
                 expect(document.querySelector('.configuration-dialog-overlay')).toBeInTheDocument();
             });
 
-            const closeButton = document.querySelector('.configuration-cancel-btn') as HTMLButtonElement;
+            const closeButton = document.querySelector('.configuration-actions .configuration-cancel-btn') as HTMLButtonElement;
             await act(async () => {
                 fireEvent.click(closeButton);
             });


### PR DESCRIPTION
- 自动更新从 extension.activate() 移到 chatProvider.initializeAgent() 在
  session.initialize() 成功后触发，保留 24h 冷却，用 updateCheckTriggered
  标志保证每次激活只触发一次
- 移除 wave-code.checkForUpdates 命令注册
- StatusDialog 版本号右侧新增检查更新按钮，点击走原有 checkAndNotify 原生通知流程
- MessageHandlerContext 新增 checkForUpdates 回调
