### PR TITLE
feat(jetbrains): add plugin release workflow and self-update check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,3 +85,56 @@ jobs:
           previous_tag: ${{ steps.prev-tag.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # --- JetBrains plugin (.zip) ---
+  # Builds the JB plugin distribution and attaches it to the same GitHub Release.
+  # Runs in parallel with `publish`; action-gh-release is idempotent (create-or-update)
+  # and merges assets, so both jobs targeting the same tag's release is safe. Only
+  # `publish` generates release notes / sets the body — this job adds the .zip asset
+  # and mirrors the prerelease flag in case it creates the release first.
+  build-jetbrains:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - uses: pnpm/action-setup@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      # copyWebviewAssets (build.gradle.kts) copies chat.js/chat.css from
+      # packages/webview/dist into the plugin resources, so build the webview first.
+      - name: Build webview dist
+        run: pnpm -F wave-webview run build
+
+      - name: Run Gradle tests
+        run: ./packages/jetbrains/gradlew -p packages/jetbrains test --no-daemon
+
+      - name: Build plugin distribution (.zip)
+        run: ./packages/jetbrains/gradlew -p packages/jetbrains buildPlugin --no-daemon
+
+      - name: Attach .zip to GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: packages/jetbrains/build/distributions/*.zip
+          prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.ui.Messages
 import com.wave.jetbrains.config.WavePluginService
 import com.wave.jetbrains.ide.IdeService
 import com.wave.jetbrains.stdio.StdioClientException
+import com.wave.jetbrains.update.UpdateChecker
 import com.wave.jetbrains.util.Edt
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -382,6 +383,13 @@ class MessageHandler(
                         put("language", config.language)
                     })
                 })
+            }
+
+            // ── Plugin update check (manual) ────────────────────────────
+            // VSCE updateService.checkAndNotify; shared webview "检查更新" button.
+            // Manual check bypasses the 24h cooldown (skipCooldown = true).
+            "checkForUpdates" -> {
+                UpdateChecker.checkAndNotify(project, skipCooldown = true)
             }
 
             // ── MCP servers ────────────────────────────────────────────

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
@@ -12,6 +12,7 @@ import com.wave.jetbrains.stdio.BinaryResolver
 import com.wave.jetbrains.stdio.StdioAgent
 import com.wave.jetbrains.stdio.StdioClient
 import com.wave.jetbrains.stdio.StdioClientException
+import com.wave.jetbrains.update.UpdateChecker
 import com.wave.jetbrains.util.Edt
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -152,6 +153,11 @@ class WaveSession(
                         IdeService.showError(project, "Wave CLI 升级失败，请手动执行: npm install -g wave-code --registry=https://registry.npmmirror.com")
                     }
                 }
+            }
+            // Plugin self-update check: once per activation, 24h cooldown (mirrors VSCE updateService).
+            if (!UpdateChecker.autoCheckTriggered) {
+                UpdateChecker.autoCheckTriggered = true
+                scope.launch { UpdateChecker.checkAndNotify(project) }
             }
             true
         } catch (e: Exception) {

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/update/UpdateChecker.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/update/UpdateChecker.kt
@@ -1,0 +1,326 @@
+package com.wave.jetbrains.update
+
+import com.intellij.ide.BrowserUtil
+import com.intellij.ide.plugins.IdeaPluginDescriptorImpl
+import com.intellij.ide.plugins.PluginInstaller
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.wave.jetbrains.util.Edt
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URI
+
+/**
+ * Plugin self-update checker — mirrors packages/vsce/src/services/updateService.ts.
+ *
+ * Queries the GitHub Releases API for the latest Wave release, compares against the
+ * installed plugin version, and notifies the user with 自动更新 / 查看更新 / 忽略 buttons.
+ * Auto-update downloads the .zip and schedules an install-on-restart via
+ * [PluginInstaller.installAfterRestart]; a browser-download fallback guarantees the
+ * user can still update manually if the internal install API is unavailable.
+ *
+ * Three deliberate divergences from the VSCode implementation:
+ *  - endpoint is `netease-lcap/wave-agent` (the live release repo; VSCode's
+ *    `wave-vsce` URL points at a stale repo and is a bug);
+ *  - the release artifact is a `.zip` (Gradle `buildPlugin` output), not a `.vsix`;
+ *  - install uses [PluginInstaller.installAfterRestart], not a marketplace install API.
+ */
+@Suppress("UnstableApiUsage") // PluginInstaller / IdeaPluginDescriptorImpl are @ApiStatus.Internal
+object UpdateChecker {
+    private val LOG = logger<UpdateChecker>()
+    private val JSON = Json { ignoreUnknownKeys = true }
+    private const val PLUGIN_ID = "com.wave.jetbrains"
+    private const val LATEST_RELEASE_URL =
+        "https://api.github.com/repos/netease-lcap/wave-agent/releases/latest"
+    private const val USER_AGENT = "Wave-JetBrains-Plugin"
+    private const val HTTP_TIMEOUT_MS = 10_000
+    private const val DOWNLOAD_TIMEOUT_MS = 120_000
+    private const val COOLDOWN_MS = 24L * 60 * 60 * 1000
+    private const val KEY_LAST_CHECK = "wave.lastUpdateCheck"
+    private const val KEY_IGNORED_VERSION = "wave.ignoredVersion"
+    private const val NOTIFICATION_GROUP = "Wave"
+
+    /** Once-per-activation guard for the automatic check (mirrors VSCode's in-memory flag). */
+    @Volatile var autoCheckTriggered = false
+
+    data class ParsedVersion(val major: Int, val minor: Int, val patch: Int)
+
+    data class UpdateInfo(
+        val latestVersion: String,
+        val currentVersion: String,
+        val downloadUrl: String,
+        val zipUrl: String?,
+        val releaseNotes: String?,
+    )
+
+    @Serializable
+    private data class GithubRelease(
+        val tag_name: String,
+        val html_url: String,
+        val body: String? = null,
+        val assets: List<GithubAsset> = emptyList(),
+    )
+
+    @Serializable
+    private data class GithubAsset(
+        val name: String,
+        val browser_download_url: String,
+    )
+
+    // ── Version parsing (VSCode parity: strip 'v', drop pre-release, require 3 numeric parts) ──
+
+    fun parseVersion(version: String): ParsedVersion? {
+        val core = version.trimStart('v').substringBefore('-')
+        val parts = core.split('.')
+        if (parts.size != 3) return null
+        val nums = parts.map { it.toIntOrNull() ?: return null }
+        return ParsedVersion(nums[0], nums[1], nums[2])
+    }
+
+    fun compareVersions(a: ParsedVersion, b: ParsedVersion): Int {
+        if (a.major != b.major) return if (a.major < b.major) -1 else 1
+        if (a.minor != b.minor) return if (a.minor < b.minor) -1 else 1
+        if (a.patch != b.patch) return if (a.patch < b.patch) -1 else 1
+        return 0
+    }
+
+    // ── HTTP ────────────────────────────────────────────────────────────────────
+
+    private fun httpGet(url: String): String {
+        val conn = (URI(url).toURL().openConnection() as HttpURLConnection).apply {
+            requestMethod = "GET"
+            setRequestProperty("User-Agent", USER_AGENT)
+            setRequestProperty("Accept", "application/vnd.github+json")
+            connectTimeout = HTTP_TIMEOUT_MS
+            readTimeout = HTTP_TIMEOUT_MS
+            instanceFollowRedirects = true
+        }
+        try {
+            val code = conn.responseCode
+            if (code != 200) throw UpdateCheckException("HTTP $code from $url")
+            return conn.inputStream.bufferedReader().use { it.readText() }
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    private fun httpDownload(url: String, dest: File) {
+        val conn = (URI(url).toURL().openConnection() as HttpURLConnection).apply {
+            setRequestProperty("User-Agent", USER_AGENT)
+            connectTimeout = HTTP_TIMEOUT_MS
+            readTimeout = DOWNLOAD_TIMEOUT_MS
+            instanceFollowRedirects = true
+        }
+        try {
+            val code = conn.responseCode
+            if (code != 200) throw UpdateCheckException("Download HTTP $code from $url")
+            conn.inputStream.use { input ->
+                dest.outputStream().use { input.copyTo(it) }
+            }
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    // ── Update check ────────────────────────────────────────────────────────────
+
+    suspend fun checkForUpdate(currentVersion: String): UpdateInfo? = withContext(Dispatchers.IO) {
+        val current = parseVersion(currentVersion) ?: run {
+            LOG.warn("Invalid current version: $currentVersion")
+            return@withContext null
+        }
+        try {
+            val body = httpGet(LATEST_RELEASE_URL)
+            val release = JSON.decodeFromString<GithubRelease>(body)
+            val latestTag = release.tag_name.trimStart('v')
+            val latest = parseVersion(latestTag) ?: run {
+                LOG.warn("Invalid latest tag from GitHub: ${release.tag_name}")
+                return@withContext null
+            }
+            if (compareVersions(latest, current) > 0) {
+                val zipAsset = release.assets.firstOrNull { it.name.endsWith(".zip") }
+                UpdateInfo(
+                    latestVersion = latestTag,
+                    currentVersion = currentVersion,
+                    downloadUrl = release.html_url,
+                    zipUrl = zipAsset?.browser_download_url,
+                    releaseNotes = release.body,
+                )
+            } else null
+        } catch (e: Exception) {
+            LOG.warn("Failed to check for updates: ${e.message}")
+            null
+        }
+    }
+
+    /**
+     * Check for an update and notify the user if one is available.
+     * @param skipCooldown when true (manual check), bypass the 24h cooldown.
+     */
+    suspend fun checkAndNotify(project: Project, skipCooldown: Boolean = false) {
+        val pc = PropertiesComponent.getInstance()
+        val now = System.currentTimeMillis()
+        if (!skipCooldown) {
+            val last = pc.getValue(KEY_LAST_CHECK)?.toLongOrNull() ?: 0L
+            if (now - last < COOLDOWN_MS) return
+        }
+        // Record check time before the network call (mirrors VSCode) to prevent racing checks.
+        pc.setValue(KEY_LAST_CHECK, now.toString())
+
+        val current = currentVersion()
+        if (current.isEmpty()) return
+        val info = checkForUpdate(current) ?: run {
+            if (skipCooldown) Edt.invokeLater { showInfo(project, "当前已是最新版本") }
+            return
+        }
+
+        val ignored = pc.getValue(KEY_IGNORED_VERSION, "")
+        if (info.latestVersion == ignored) {
+            if (skipCooldown) Edt.invokeLater {
+                showInfo(project, "当前已忽略 v${info.latestVersion}，最新版本为 v${info.latestVersion}")
+            }
+            return
+        }
+
+        Edt.invokeLater { showUpdateNotification(project, info) }
+    }
+
+    // ── Notifications ───────────────────────────────────────────────────────────
+
+    private fun showUpdateNotification(project: Project, info: UpdateInfo) {
+        val message = "Wave 代码智聊 新版本 v${info.latestVersion} 已可用 (当前 v${info.currentVersion})"
+        val notif = NotificationGroupManager.getInstance()
+            .getNotificationGroup(NOTIFICATION_GROUP)
+            .createNotification("Wave", message, NotificationType.INFORMATION)
+
+        if (info.zipUrl != null) {
+            notif.addAction(object : NotificationAction("自动更新") {
+                override fun actionPerformed(e: AnActionEvent, notification: Notification) {
+                    notification.expire()
+                    downloadAndInstallWithProgress(project, info)
+                }
+            })
+        }
+        notif.addAction(object : NotificationAction("查看更新") {
+            override fun actionPerformed(e: AnActionEvent, notification: Notification) {
+                notification.expire()
+                BrowserUtil.browse(info.downloadUrl)
+            }
+        })
+        notif.addAction(object : NotificationAction("忽略") {
+            override fun actionPerformed(e: AnActionEvent, notification: Notification) {
+                notification.expire()
+                PropertiesComponent.getInstance().setValue(KEY_IGNORED_VERSION, info.latestVersion)
+            }
+        })
+        notif.notify(project)
+    }
+
+    private fun showInfo(project: Project, message: String) {
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup(NOTIFICATION_GROUP)
+            .createNotification("Wave", message, NotificationType.INFORMATION)
+            .notify(project)
+    }
+
+    private fun showRestartNotification(project: Project, info: UpdateInfo) {
+        val notif = NotificationGroupManager.getInstance()
+            .getNotificationGroup(NOTIFICATION_GROUP)
+            .createNotification(
+                "Wave",
+                "Wave 代码智聊 已更新至 v${info.latestVersion}，重启后生效",
+                NotificationType.INFORMATION,
+            )
+        notif.addAction(object : NotificationAction("立即重启") {
+            override fun actionPerformed(e: AnActionEvent, notification: Notification) {
+                notification.expire()
+                ApplicationManager.getApplication().restart()
+            }
+        })
+        notif.notify(project)
+    }
+
+    // ── Auto-update (download + schedule install-on-restart) ────────────────────
+
+    private fun downloadAndInstallWithProgress(project: Project, info: UpdateInfo) {
+        val zipUrl = info.zipUrl ?: return
+        ProgressManager.getInstance().run(object : Task.Backgroundable(project, "正在下载更新...", true) {
+            override fun run(indicator: ProgressIndicator) {
+                indicator.isIndeterminate = true
+                val tmpDir = System.getProperty("java.io.tmpdir")
+                val fileName = zipUrl.substringAfterLast('/').substringBefore('?').ifEmpty { "wave-update.zip" }
+                val zipFile = File(tmpDir, "wave-update-$fileName")
+                try {
+                    httpDownload(zipUrl, zipFile)
+                    installPluginFromDisk(zipFile)
+                    Edt.invokeLater { showRestartNotification(project, info) }
+                } catch (t: Throwable) {
+                    // installAfterRestart / PluginInstaller are @Internal and may throw Error
+                    // (NoSuchMethodError/NoClassDefFoundError) on future platform versions.
+                    // Guarantee a manual fallback: open the release page in the browser.
+                    LOG.warn("Auto-update failed: ${t.message}", t)
+                    Edt.invokeLater {
+                        NotificationGroupManager.getInstance()
+                            .getNotificationGroup(NOTIFICATION_GROUP)
+                            .createNotification(
+                                "Wave",
+                                "自动更新失败，请手动下载更新",
+                                NotificationType.ERROR,
+                            ).notify(project)
+                        BrowserUtil.browse(info.downloadUrl)
+                    }
+                } finally {
+                    try { if (zipFile.exists()) zipFile.delete() } catch (_: Exception) {}
+                }
+            }
+        })
+    }
+
+    /**
+     * Schedule installation of [zipFile] to take effect on next IDE restart.
+     *
+     * Uses [PluginInstaller.installAfterRestart], which appends delete-old + unzip-new
+     * commands to the startup action script: on next launch the currently-installed plugin
+     * is removed and the new archive is unpacked into the plugins directory. The descriptor
+     * and old install path come from the running plugin via [PluginManagerCore.getPlugin],
+     * so no descriptor parsing is needed.
+     */
+    private fun installPluginFromDisk(zipFile: File) {
+        ApplicationManager.getApplication().invokeAndWait {
+            WriteAction.run<Exception> {
+                val descriptor = PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))
+                    ?: throw UpdateCheckException("Wave plugin descriptor not found")
+                val oldPath = (descriptor as? IdeaPluginDescriptorImpl)?.path
+                    ?: throw UpdateCheckException("Cannot resolve plugin install path")
+                PluginInstaller.installAfterRestart(
+                    descriptor,
+                    zipFile.toPath(),
+                    oldPath,
+                    /* deleteSrc = */ true,
+                )
+            }
+        }
+    }
+
+    private fun currentVersion(): String =
+        PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))?.version ?: ""
+
+    private class UpdateCheckException(message: String) : RuntimeException(message)
+}

--- a/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/update/UpdateCheckerTest.kt
+++ b/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/update/UpdateCheckerTest.kt
@@ -1,0 +1,118 @@
+package com.wave.jetbrains.update
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the pure version-parsing helpers in [UpdateChecker].
+ *
+ * These mirror the VSCode `updateService` test cases: strip leading `v`, drop
+ * pre-release suffixes, require exactly three numeric components, and compare
+ * major → minor → patch numerically (not lexicographically).
+ *
+ * The network/IDE-dependent paths (checkForUpdate, checkAndNotify, install)
+ * are intentionally not covered here — they need a live GitHub API and an
+ * Application/Project context, and are exercised manually via the webview
+ * "检查更新" button and the auto-check on session init.
+ */
+class UpdateCheckerTest {
+
+    // ---- parseVersion --------------------------------------------------
+
+    @Test
+    fun `parseVersion parses plain semver`() {
+        assertEquals(UpdateChecker.ParsedVersion(0, 19, 3), UpdateChecker.parseVersion("0.19.3"))
+    }
+
+    @Test
+    fun `parseVersion strips leading v`() {
+        assertEquals(UpdateChecker.ParsedVersion(1, 2, 3), UpdateChecker.parseVersion("v1.2.3"))
+    }
+
+    @Test
+    fun `parseVersion drops pre-release suffix`() {
+        assertEquals(UpdateChecker.ParsedVersion(0, 1, 0), UpdateChecker.parseVersion("v0.1.0-alpha.1"))
+        assertEquals(UpdateChecker.ParsedVersion(2, 0, 0), UpdateChecker.parseVersion("2.0.0-beta"))
+        assertEquals(UpdateChecker.ParsedVersion(3, 1, 4), UpdateChecker.parseVersion("v3.1.4-rc.2+build"))
+    }
+
+    @Test
+    fun `parseVersion returns null for malformed versions`() {
+        assertNull(UpdateChecker.parseVersion(""))
+        assertNull(UpdateChecker.parseVersion("v"))
+        assertNull(UpdateChecker.parseVersion("1.2"))            // too few parts
+        assertNull(UpdateChecker.parseVersion("1.2.3.4"))        // too many parts
+        assertNull(UpdateChecker.parseVersion("v1.2.x"))         // non-numeric patch
+        assertNull(UpdateChecker.parseVersion("v1.2.3."))        // trailing dot → empty part
+    }
+
+    @Test
+    fun `parseVersion handles large patch numbers`() {
+        assertEquals(UpdateChecker.ParsedVersion(0, 0, 9999), UpdateChecker.parseVersion("0.0.9999"))
+    }
+
+    // ---- compareVersions -----------------------------------------------
+
+    @Test
+    fun `compareVersions returns 0 for equal versions`() {
+        assertEquals(
+            0,
+            UpdateChecker.compareVersions(
+                UpdateChecker.parseVersion("1.2.3")!!,
+                UpdateChecker.parseVersion("v1.2.3")!!,
+            ),
+        )
+    }
+
+    @Test
+    fun `compareVersions orders by major then minor then patch`() {
+        val v0_19_3 = UpdateChecker.parseVersion("0.19.3")!!
+        val v0_20_0 = UpdateChecker.parseVersion("v0.20.0")!!
+        val v1_0_0 = UpdateChecker.parseVersion("1.0.0")!!
+        val v1_0_1 = UpdateChecker.parseVersion("v1.0.1")!!
+
+        assertTrue(UpdateChecker.compareVersions(v0_20_0, v0_19_3) > 0, "0.20.0 > 0.19.3")
+        assertTrue(UpdateChecker.compareVersions(v0_19_3, v0_20_0) < 0, "0.19.3 < 0.20.0")
+        assertTrue(UpdateChecker.compareVersions(v1_0_0, v0_20_0) > 0, "1.0.0 > 0.20.0 (major beats minor)")
+        assertTrue(UpdateChecker.compareVersions(v1_0_1, v1_0_0) > 0, "1.0.1 > 1.0.0 (patch)")
+        assertTrue(UpdateChecker.compareVersions(v1_0_0, v1_0_1) < 0, "1.0.0 < 1.0.1")
+    }
+
+    @Test
+    fun `compareVersions compares numerically not lexicographically`() {
+        // 0.10.0 > 0.9.0 numerically; lexicographic string compare would say "0.10.0" < "0.9.0".
+        val v0_10 = UpdateChecker.parseVersion("0.10.0")!!
+        val v0_9 = UpdateChecker.parseVersion("0.9.0")!!
+        assertTrue(UpdateChecker.compareVersions(v0_10, v0_9) > 0)
+        assertTrue(UpdateChecker.compareVersions(v0_9, v0_10) < 0)
+    }
+
+    @Test
+    fun `compareVersions is antisymmetric`() {
+        val a = UpdateChecker.parseVersion("2.3.4")!!
+        val b = UpdateChecker.parseVersion("2.3.5")!!
+        assertEquals(
+            UpdateChecker.compareVersions(a, b),
+            -UpdateChecker.compareVersions(b, a),
+        )
+    }
+
+    // ---- autoCheckTriggered guard --------------------------------------
+
+    @Test
+    fun `autoCheckTriggered flag is mutable and starts false`() {
+        val original = UpdateChecker.autoCheckTriggered
+        try {
+            UpdateChecker.autoCheckTriggered = false
+            assertFalse(UpdateChecker.autoCheckTriggered)
+            UpdateChecker.autoCheckTriggered = true
+            assertTrue(UpdateChecker.autoCheckTriggered)
+        } finally {
+            // Restore so the static state doesn't leak into other tests.
+            UpdateChecker.autoCheckTriggered = original
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Mirrors the VSCE release + updateService flow for the JetBrains plugin.

### 1. JB plugin release — `.github/workflows/publish.yml`
- New `build-jetbrains` job runs **in parallel** with `publish` on `v*` tags.
- JDK 17 + Gradle setup → build webview dist → `gradlew test` (fail-gate) → `gradlew buildPlugin` → attach `.zip` to the same `wave-agent` GitHub Release via `softprops/action-gh-release@v3` (idempotent asset merge, so both jobs targeting the same tag is safe).
- Version stays in sync via `scripts/version.js` (already bumps `packages/jetbrains/gradle.properties` `pluginVersion`).

### 2. JB plugin update check — mirrors `packages/vsce/src/services/updateService.ts`
- **`UpdateChecker.kt`**: queries `netease-lcap/wave-agent/releases/latest`, compares against installed plugin version. 24h cooldown via `PropertiesComponent`, once-per-activation guard. 3-button notification: 自动更新 / 查看更新 / 忽略. Auto-update downloads `.zip` under `Task.Backgroundable` progress and schedules install-on-restart via `PluginInstaller.installAfterRestart` (`@Internal`, with `try/catch(Throwable)` + browser-download fallback).
- **`MessageHandler.kt`**: manual check wired to the shared webview "检查更新" button (`checkForUpdates` command, `skipCooldown = true`).
- **`WaveSession.kt`**: auto-check fired from `initialize()`.

### Three deliberate divergences from VSCE (documented in kdoc)
- endpoint is `netease-lcap/wave-agent` (the live release repo; VSCE's `wave-vsce` URL points at a stale repo and is a bug)
- artifact is a `.zip` (Gradle `buildPlugin`), not a `.vsix`
- install uses `PluginInstaller.installAfterRestart`, not a marketplace install API

## Verification
- `./gradlew clean test buildPlugin` → BUILD SUCCESSFUL, `.zip` (5.3M) produced
- `UpdateCheckerTest`: 11 unit tests for `parseVersion` / `compareVersions` (VSCode parity)
- Pre-commit hook: type-check + lint pass

## Test plan
- [ ] CI `check` + `ci-jetbrains` green on this PR
- [ ] On next `v*` tag: `build-jetbrains` job produces `.zip` and attaches to the Release
- [ ] Manual: open Wave tool window → status dialog → 检查更新 → notification appears
- [ ] Manual: auto-check fires once per activation (check `wave.lastUpdateCheck` in PropertiesComponent)