### PR TITLE
fix(version): sync all monorepo packages to root version on bump

### DIFF
--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "displayName": "Wave 代码智聊",
   "description": "Wave code for VS Code",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "publisher": "wave-code",
   "icon": "LOGO.png",
   "repository": {

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -2,7 +2,7 @@
   "name": "wave-webview",
   "private": true,
   "description": "Shared webview layer (React IIFE bundle) for Wave VS Code and JetBrains plugins",
-  "version": "0.0.1",
+  "version": "0.19.4",
   "type": "module",
   "engines": {
     "node": ">=22.0.0"

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -38,8 +38,18 @@ export function bumpVersion(pkgPath) {
   }
 
   const newVersion = parts.join('.') + (type === 'patch' ? suffix : '');
-  pkg.version = newVersion;
+  return setVersion(pkgPath, newVersion);
+}
 
+// Overwrite a package's version to an explicit target (used to keep all
+// packages in the monorepo on the same version as the root).
+export function setVersion(pkgPath, newVersion) {
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  const oldVersion = pkg.version;
+  if (oldVersion === newVersion) {
+    return null;
+  }
+  pkg.version = newVersion;
   fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
   console.log(`${pkg.name}: ${oldVersion} -> ${newVersion}`);
   return { name: pkg.name, version: newVersion, path: pkgPath };
@@ -60,26 +70,26 @@ export function bumpGradleProperties(propsPath, newVersion) {
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const results = [];
   if (isAll) {
-    // Bump root
+    // Bump root first to determine the target version for the whole monorepo.
     const rootPkg = bumpVersion(path.resolve(process.cwd(), 'package.json'));
     if (rootPkg) results.push(rootPkg);
 
-    // Bump packages
+    // Sync every sub-package to the root's new version so the monorepo stays
+    // on a single consistent version (independent bumps drift when packages
+    // are added/removed mid-release).
     const packagesDir = path.resolve(process.cwd(), 'packages');
     const dirs = fs.readdirSync(packagesDir);
     for (const dir of dirs) {
       const pkgPath = path.resolve(packagesDir, dir, 'package.json');
       if (fs.existsSync(pkgPath)) {
-        const res = bumpVersion(pkgPath);
+        const res = setVersion(pkgPath, rootPkg.version);
         if (res) results.push(res);
       } else {
         // Packages without package.json (e.g. jetbrains) may have a gradle.properties
         // with a pluginVersion= field that must stay in sync with the monorepo version.
         const propsPath = path.resolve(packagesDir, dir, 'gradle.properties');
         if (fs.existsSync(propsPath)) {
-          // Use the root package's new version (already bumped above) as the target.
-          const targetVersion = rootPkg.version;
-          const res = bumpGradleProperties(propsPath, targetVersion);
+          const res = bumpGradleProperties(propsPath, rootPkg.version);
           if (res) results.push(res);
         }
       }


### PR DESCRIPTION
## Problem

`pnpm release:patch` bumped each package independently (`+1` on its own version). Packages that were deleted and restored mid-release (vsce, webview) drifted off the root version:

- root: `0.19.4`
- wave-vsce: `0.19.3` (was deleted in `4092a792`, restored in `c913b5d0` at its pre-deletion version 0.19.2, then only got one bump)
- wave-webview: `0.0.1` (never tracked the monorepo version)

## Fix

`scripts/version.js` now bumps the root first, then overwrites every sub-package to the root's new version via a new `setVersion()` helper. The whole monorepo stays on a single consistent version regardless of add/remove history.

Also aligns vsce and webview to `0.19.4` to match the current release state. The `v0.19.4` tag is left unchanged.

## Verification

Dry-run on a copy with vsce=`0.19.2` and webview=`0.0.1` (drifted): after `node version.js patch all`, all packages including jetbrains (`pluginVersion`) land on `0.19.5`.