### PR TITLE
ci(jetbrains): build agent-sdk dist before webview in build-jetbrains job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,8 +120,13 @@ jobs:
       - name: Install deps
         run: pnpm install --frozen-lockfile
 
+      # The webview bundles from wave-agent-sdk/dist (see imports like
+      # 'wave-agent-sdk/dist/types/...'), so build the SDK dist first.
+      - name: Build agent-sdk dist
+        run: pnpm -F wave-agent-sdk build
+
       # copyWebviewAssets (build.gradle.kts) copies chat.js/chat.css from
-      # packages/webview/dist into the plugin resources, so build the webview first.
+      # packages/webview/dist into the plugin resources, so build the webview next.
       - name: Build webview dist
         run: pnpm -F wave-webview run build
 


### PR DESCRIPTION
## Problem

The `build-jetbrains` job in `publish.yml` builds the webview (`pnpm -F wave-webview run build`) directly after installing deps. The webview bundles from `wave-agent-sdk/dist` (e.g. imports like `wave-agent-sdk/dist/types/...` and `wave-agent-sdk/dist/constants/tools.js`), so without a prior SDK build, the required dist artifacts don't exist and the webview build fails.

## Fix

Add an explicit `Build agent-sdk dist` step (`pnpm -F wave-agent-sdk build`) before the `Build webview dist` step in the `build-jetbrains` job, mirroring how the main `publish` job runs `pnpm build` before packaging.

## Testing

- Local type-check and lint passed (pre-commit hook ran `pnpm -r type-check` and `pnpm lint` successfully).