### PR TITLE
fix(jetbrains): theming for tool window icon and tool name text

### DIFF
--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/bridge/WebviewContentBuilder.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/bridge/WebviewContentBuilder.kt
@@ -94,6 +94,7 @@ $lafOverrides
         val inputBorder = laf("TextField.borderColor", JBColor.border(), Color(0x3c3c3c))
         val buttonBg = laf("Button.background", JBColor(0x0e639c, 0x0e639c), Color(0x0e639c))
         val buttonFg = laf("Button.foreground", Color.WHITE, Color.WHITE)
+        val linkFg = laf("Link.foreground", JBColor(0x589df6, 0x589df6), Color(0x589df6))
         val border = laf("Border.color", JBColor.border(), Color(0x3c3c3c))
         val font = lafFont("Label.font")
 
@@ -113,6 +114,8 @@ $lafOverrides
             "--vscode-button-background" to buttonBg,
             "--vscode-button-foreground" to buttonFg,
             "--vscode-icon-foreground" to fg,
+            "--vscode-textLink-foreground" to linkFg,
+            "--vscode-textLink-activeForeground" to linkFg,
         )
         return buildString {
             for ((key, color) in vars) {

--- a/packages/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/packages/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -20,6 +20,7 @@
             factoryClass="com.wave.jetbrains.WaveToolWindowFactory"
             icon="com.wave.jetbrains.icons.WaveIcons.Wave"/>
         <notificationGroup id="Wave" displayType="BALLOON"/>
+        <iconMapper mappingFile="WavePluginIconMappings.json"/>
     </extensions>
 
     <actions>

--- a/packages/jetbrains/src/main/resources/WavePluginIconMappings.json
+++ b/packages/jetbrains/src/main/resources/WavePluginIconMappings.json
@@ -1,0 +1,9 @@
+{
+  "icons": {
+    "expui": {
+      "toolwindow": {
+        "waveToolWindow.svg": "icons/waveToolWindow.svg"
+      }
+    }
+  }
+}

--- a/packages/jetbrains/src/main/resources/icons/expui/toolwindow/waveToolWindow.svg
+++ b/packages/jetbrains/src/main/resources/icons/expui/toolwindow/waveToolWindow.svg
@@ -1,3 +1,3 @@
-<svg width="13" height="13" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
   <path d="M4 9C4 9 5.5 18 10 18C14.5 18 14 9 14 9C14 9 13.5 18 18 18C22.5 18 24 9 24 9" stroke="#6C707E" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/packages/jetbrains/src/main/resources/icons/expui/toolwindow/waveToolWindow@20x20.svg
+++ b/packages/jetbrains/src/main/resources/icons/expui/toolwindow/waveToolWindow@20x20.svg
@@ -1,3 +1,3 @@
-<svg width="13" height="13" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
   <path d="M4 9C4 9 5.5 18 10 18C14.5 18 14 9 14 9C14 9 13.5 18 18 18C22.5 18 24 9 24 9" stroke="#6C707E" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/packages/jetbrains/src/main/resources/icons/expui/toolwindow/waveToolWindow@20x20_dark.svg
+++ b/packages/jetbrains/src/main/resources/icons/expui/toolwindow/waveToolWindow@20x20_dark.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 9C4 9 5.5 18 10 18C14.5 18 14 9 14 9C14 9 13.5 18 18 18C22.5 18 24 9 24 9" stroke="#CED0D6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/jetbrains/src/main/resources/icons/expui/toolwindow/waveToolWindow_dark.svg
+++ b/packages/jetbrains/src/main/resources/icons/expui/toolwindow/waveToolWindow_dark.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 9C4 9 5.5 18 10 18C14.5 18 14 9 14 9C14 9 13.5 18 18 18C22.5 18 24 9 24 9" stroke="#CED0D6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/jetbrains/src/main/resources/icons/waveToolWindow_dark.svg
+++ b/packages/jetbrains/src/main/resources/icons/waveToolWindow_dark.svg
@@ -1,0 +1,3 @@
+<svg width="13" height="13" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 9C4 9 5.5 18 10 18C14.5 18 14 9 14 9C14 9 13.5 18 18 18C22.5 18 24 9 24 9" stroke="#CED0D6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/webview/src/styles/Message.css
+++ b/packages/webview/src/styles/Message.css
@@ -169,7 +169,7 @@
 
 /* Tools */
 .tool-block {
-    color: var(--vscode-button-background);
+    color: var(--vscode-textLink-foreground);
     font-weight: bold;
     font-size: 12px;
     white-space: nowrap;


### PR DESCRIPTION
## 修复 JetBrains 插件两处暗色可读性问题

### 1. 工具窗口图标 "w" 暗色
**根因**：`waveToolWindow.svg` 用了 `stroke="currentColor"` 且只有 24×24 单一尺寸。`currentColor` 并非工具窗口图标支持的主题化机制。

按 [IntelliJ 图标文档](https://plugins.jetbrains.com/docs/intellij/icons.html)，New UI 工具窗口图标必须使用固定 hex 色（light `#6C707E` / dark `#CED0D6`），并按文件名约定提供多尺寸变体 + `IconMappings.json` 映射。

**改动**（参考 Maven 插件实现）：
- 覆写 classic `icons/waveToolWindow.svg`（13×13）+ 新增 `_dark.svg`
- 新增 New UI 变体 `icons/expui/toolwindow/` 下 `@20x20`/`_dark`（20×20）+ `waveToolWindow.svg`/`_dark`（16×16 compact）
- 新增 `WavePluginIconMappings.json`，`plugin.xml` 注册 `iconMapper`

### 2. 消息列表工具名称暗色看不清
**根因**：`Message.css` 的 `.tool-block { color: var(--vscode-button-background); }` 把"按钮填充背景"变量当文本前景色用。该变量在 `WebviewContentBuilder.kt` 写死 `JBColor(0x0e639c, 0x0e639c)`（亮暗都是深蓝），在 `#1e1e1e` 暗背景上对比度不足。

**改动**：
- `Message.css`：`.tool-block` 改用 `--vscode-textLink-foreground`（语义正确的前景色）
- `WebviewContentBuilder.kt`：`buildLafOverrides()` 新增读取 IntelliJ `Link.foreground` LaF 值，注入到 `--vscode-textLink-foreground` / `-activeForeground`，让链接/工具名在亮色主题下也跟随 IDE

### 主题色注入方式
当前用的即官方推荐的手动注入路径（读 `UIManager` LaF → 设 `--vscode-*` CSS 变量）。本次未加 `LafManagerListener`（主题切换实时刷新），属既有架构范围。

### 验证
- Kotlin `compileKotlin` 通过
- `gradlew build -x test` 通过，资源已正确打包进 `build/resources/main/`
- webview dist 重新生成，`chat.css` 含改动
- pre-commit hook（type-check + lint + lint-staged）全部通过
