### PR TITLE
fix(jetbrains): inject login-shell PATH so bash tool finds homebrew/pnpm/etc.

### DIFF
--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
@@ -14,6 +14,10 @@ object BinaryResolver {
 
     @Volatile
     private var cachedPath: String? = null
+    @Volatile
+    private var cachedLoginPath: String? = null
+    @Volatile
+    private var loginPathResolved = false
 
     private val isWindows = System.getProperty("os.name").lowercase().startsWith("win")
     private val waveName = if (isWindows) "wave.cmd" else "wave"
@@ -66,25 +70,71 @@ object BinaryResolver {
     /**
      * Environment variables to inject into spawned `wave`/`npm` processes.
      *
-     * GUI-launched IDEs don't inherit the shell PATH, so the `#!/usr/bin/env node`
-     * shebang on the nvm-managed `wave`/`npm` scripts can't resolve `node`. When
-     * nvm is detected we prepend its bin dir to PATH so the shebang resolves.
-     * Returns an empty map when nvm isn't in play (no change to inherited env).
+     * GUI-launched IDEs inherit a minimal launchd PATH and never source the
+     * shell profile, so homebrew, nvm, pnpm, and user-customized bin dirs are
+     * invisible to `System.getenv("PATH")` and the `#!/usr/bin/env node`
+     * shebang can't resolve `node`. We inject the login-shell PATH, which
+     * rebuilds the full PATH (including the nvm bin dir the shebang needs).
+     * Returns an empty map when there's nothing to inject.
      */
-    fun resolveEnv(): Map<String, String> = buildEnv(findNvmBinDir())
+    fun resolveEnv(): Map<String, String> = buildEnv(resolveLoginShellPath())
 
     /**
-     * Builds the env overlay for a resolved nvm bin dir. Split out from
-     * [resolveEnv] so it can be unit-tested with a synthetic dir.
+     * Assembles a deduped, ordered PATH: login-shell PATH first (the
+     * comprehensive set — homebrew, nvm, pnpm, user customizations), then the
+     * inherited PATH as a base. Split out from [resolveEnv] so it can be
+     * unit-tested with synthetic inputs. [currentPath] defaults to the live
+     * env so production callers don't need to pass it, while tests can inject
+     * a fixed value (or null to simulate unset).
      */
-    internal fun buildEnv(nvmBinDir: File?): Map<String, String> {
-        if (nvmBinDir == null) return emptyMap()
-        val currentPath = System.getenv("PATH") ?: ""
-        val newPath = if (currentPath.isEmpty())
-            nvmBinDir.path
-        else
-            nvmBinDir.path + File.pathSeparator + currentPath
-        return mapOf("PATH" to newPath)
+    internal fun buildEnv(
+        loginPath: String? = null,
+        currentPath: String? = System.getenv("PATH"),
+    ): Map<String, String> {
+        val segments = linkedSetOf<String>()
+        loginPath
+            ?.takeIf { it.isNotEmpty() }
+            ?.split(File.pathSeparator)
+            ?.forEach { if (it.isNotEmpty()) segments.add(it) }
+        currentPath
+            ?.takeIf { it.isNotEmpty() }
+            ?.split(File.pathSeparator)
+            ?.forEach { if (it.isNotEmpty()) segments.add(it) }
+        if (segments.isEmpty()) return emptyMap()
+        return mapOf("PATH" to segments.joinToString(File.pathSeparator))
+    }
+
+    /**
+     * Spawns the user's login shell once and captures the PATH it produces
+     * after sourcing the profile (login + interactive). GUI-launched IDEs
+     * inherit a minimal launchd PATH and never source `~/.zprofile`/`~/.zshrc`,
+     * so homebrew, nvm, pnpm, and user-customized bin dirs are invisible to
+     * `System.getenv("PATH")`. The login shell rebuilds the full PATH.
+     *
+     * Result is cached for the IDE session. Returns null on Windows or if the
+     * probe fails.
+     *
+     * Uses [runCommandRaw] (not [runCommand]) to avoid infinite recursion:
+     * `runCommand` injects [resolveEnv], which calls this method.
+     */
+    internal fun resolveLoginShellPath(): String? {
+        if (loginPathResolved) return cachedLoginPath
+        loginPathResolved = true
+        if (isWindows) return null
+        val shell = System.getenv("SHELL")
+            ?.takeIf { it.isNotEmpty() && File(it).exists() }
+            ?: listOf("/bin/zsh", "/bin/bash").firstOrNull { File(it).exists() }
+            ?: return null
+        cachedLoginPath = try {
+            // -l: login (sources profile), -i: interactive (sources rc, where
+            // nvm/brew/pnpm init usually live), -c: run command and exit.
+            // Take the last non-empty line in case rc files print banners.
+            val out = runCommandRaw(shell, "-lic", "echo \$PATH")
+            out.lineSequence().map { it.trim() }.lastOrNull { it.isNotEmpty() }
+        } catch (_: Exception) {
+            null
+        }
+        return cachedLoginPath
     }
 
     /** Reset cache (testing). */
@@ -196,6 +246,20 @@ object BinaryResolver {
             if (va != vb) return va - vb
         }
         return 0
+    }
+
+    /** Runs a command without injecting [resolveEnv] — used by the login-shell
+     *  PATH probe to avoid infinite recursion. Inherits the parent env as-is. */
+    private fun runCommandRaw(vararg cmd: String): String {
+        val proc = ProcessBuilder(cmd.toList()).apply {
+            redirectErrorStream(true)
+        }.start()
+        val out = proc.inputStream.bufferedReader().readText()
+        val code = proc.waitFor()
+        if (code != 0) {
+            throw StdioClientException("Command failed (${cmd.joinToString(" ")}): $out")
+        }
+        return out
     }
 
     private fun runCommand(vararg cmd: String): String {

--- a/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/stdio/BinaryResolverTest.kt
+++ b/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/stdio/BinaryResolverTest.kt
@@ -109,33 +109,45 @@ class BinaryResolverTest {
     // ---- buildEnv ------------------------------------------------------
 
     @Test
-    fun `buildEnv returns empty map when nvmBinDir is null`() {
-        assertEquals(emptyMap<String, String>(), BinaryResolver.buildEnv(null))
+    fun `buildEnv returns empty map when all inputs are null`() {
+        assertEquals(emptyMap<String, String>(), BinaryResolver.buildEnv(null, null))
     }
 
     @Test
-    fun `buildEnv prepends nvm bin dir to existing PATH`() {
-        val nvmBin = File(tempDir.toFile(), "nvm-bin").apply { mkdirs() }
-        val env = BinaryResolver.buildEnv(nvmBin)
-        val path = env["PATH"]
-        assertTrue(path != null)
-        // nvm bin dir must come first so the shebang resolves to nvm's node
-        assertTrue(path!!.startsWith(nvmBin.path + File.pathSeparator))
-        // existing PATH must still be present (not clobbered)
-        val currentPath = System.getenv("PATH") ?: ""
-        if (currentPath.isNotEmpty()) {
-            assertTrue(path.contains(currentPath))
-        }
-    }
-
-    @Test
-    fun `buildEnv uses nvm bin dir alone when PATH is unset`() {
-        val nvmBin = File(tempDir.toFile(), "nvm-bin2").apply { mkdirs() }
-        // buildEnv reads System.getenv("PATH") which is the test runner's PATH;
-        // we can't nullify it here, so just assert the nvm bin dir is the prefix.
-        val env = BinaryResolver.buildEnv(nvmBin)
+    fun `buildEnv includes login shell PATH segments`() {
+        val loginPath = "/opt/homebrew/bin:/usr/local/bin"
+        val env = BinaryResolver.buildEnv(loginPath, currentPath = null)
         val path = env["PATH"]!!
-        assertTrue(path.startsWith(nvmBin.path))
+        assertTrue(path.contains("/opt/homebrew/bin"))
+        assertTrue(path.contains("/usr/local/bin"))
+    }
+
+    @Test
+    fun `buildEnv puts login path before current path`() {
+        val loginPath = "/opt/homebrew/bin"
+        val currentPath = "/usr/bin"
+        val env = BinaryResolver.buildEnv(loginPath, currentPath)
+        val segments = env["PATH"]!!.split(File.pathSeparator)
+        assertEquals("/opt/homebrew/bin", segments[0])
+        assertEquals("/usr/bin", segments[1])
+    }
+
+    @Test
+    fun `buildEnv uses login path alone when current path is unset`() {
+        val loginPath = "/opt/homebrew/bin"
+        val env = BinaryResolver.buildEnv(loginPath, currentPath = null)
+        assertEquals(loginPath, env["PATH"])
+    }
+
+    @Test
+    fun `buildEnv dedupes repeated segments`() {
+        val env = BinaryResolver.buildEnv(
+            loginPath = "/opt/homebrew/bin:/usr/local/bin",
+            currentPath = "/opt/homebrew/bin:/usr/local/bin",
+        )
+        val segments = env["PATH"]!!.split(File.pathSeparator)
+        assertEquals(1, segments.count { it == "/opt/homebrew/bin" })
+        assertEquals(1, segments.count { it == "/usr/local/bin" })
     }
 
     // ---- helpers -------------------------------------------------------


### PR DESCRIPTION
## Problem

GUI-launched JetBrains IDEs (WebStorm, IntelliJ, etc.) inherit a minimal `launchd` PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) and never source the shell profile (`~/.zprofile`/`~/.zshrc`). As a result the agent's bash tool — which inherits `process.env` from the `wave --stdio` process spawned by the plugin — can't find homebrew (`gh`, `rg`, `brew`), pnpm, `/usr/local/bin`, or any user-customized bin dir. The agent has to manually `export PATH=/opt/homebrew/bin:$PATH` on every command.

The existing `BinaryResolver.resolveEnv()` only prepended the nvm bin dir (enough to make the `wave` shebang resolve `node`, but nothing more). It didn't recover the rest of the shell PATH.

## Root cause

`System.getenv("PATH")` returns the *already-truncated* GUI PATH, not the comprehensive one. The full PATH only exists inside a login shell after sourcing the profile (brew shellenv, nvm init, user customizations). Reading the env var is reading the problem, not the fix.

## Fix

Spawn the user's login shell once (`/bin/zsh -lic 'echo $PATH'`) to capture the full PATH it produces, and inject that into spawned `wave`/`npm` processes. The login-shell PATH is comprehensive (it already contains the nvm bin dir the shebang needs), so the separate nvm-bin prepend is no longer needed for env injection — one mechanism replaces two.

- `resolveLoginShellPath()`: probes the login shell, caches the result for the IDE session, returns `null` on Windows or on probe failure (no fallback — keeps it simple).
- `runCommandRaw()`: runs a command **without** injecting `resolveEnv`, used by the probe to avoid infinite recursion (`runCommand` → `resolveEnv` → `resolveLoginShellPath` → `runCommand`).
- `buildEnv(loginPath, currentPath)`: dedupes via `linkedSetOf`, login PATH first then inherited PATH as base.
- `findNvmBinDir()` is retained — still used by `resolveWaveBinary()` to locate the `wave` binary, just no longer participates in env injection.

## Verification

- `./gradlew compileKotlin` — BUILD SUCCESSFUL
- `./gradlew test --tests BinaryResolverTest` — 12 tests passed (5 buildEnv + 7 nvm-probe)
- Measured login-shell probe overhead: ~1.6s one-time, cached thereafter.

## Note

This fix changes how the plugin spawns `wave --stdio`. A running agent session won't pick it up until the IDE is restarted (so the plugin re-spawns wave with the new env).
