### PR TITLE
fix(webview): apply --vscode-font-size to body so JetBrains JCEF inherits correct size

### DIFF
--- a/packages/webview/src/styles/globals.css
+++ b/packages/webview/src/styles/globals.css
@@ -2,6 +2,7 @@
 
 body {
     font-family: var(--vscode-font-family);
+    font-size: var(--vscode-font-size);
     background-color: var(--vscode-editor-background);
     color: var(--vscode-editor-foreground);
     margin: 0;


### PR DESCRIPTION
## Problem

JetBrains plugin's user messages, assistant text messages, and error-block messages all rendered ~23% larger than VS Code extension (16px vs 13px).

## Root cause

The shared webview's `body` rule in `packages/webview/src/styles/globals.css` set `font-family` but **never applied `--vscode-font-size`**. All three message styles (user / assistant / error block) in `Message.css` use `inherit` or omit `font-size`, so they all fall back to body's font-size.

- **VS Code**: at runtime injects `body { font-size: 13px }` into webviews automatically → 13px.
- **JetBrains JCEF**: is a bare browser with no such auto-injection. `WebviewContentBuilder.kt` defined `--vscode-font-size: 13px` but never applied it to `body`, so body fell back to the browser default **16px**.

## Fix

Add `font-size: var(--vscode-font-size);` to `body` in `globals.css` so all three consumers (VSCE / JetBrains / e2e) read from the same variable at the source, eliminating the implicit dependency on host auto-injection.

## Verification

- `pnpm -F wave-webview build` rebuilt `chat.css`; confirmed `body { font-size: var(--vscode-font-size) }` appears at `chat.css:3080`.
- `pnpm -r type-check` and `pnpm lint` pass.
- JetBrains side still needs `copyWebviewAssets` + IDE restart to pick up the new `chat.css`.