### PR TITLE
feat: query CodeChat server manifest for plugin update checks

### DIFF
--- a/packages/code/src/stdio/agentBridge.ts
+++ b/packages/code/src/stdio/agentBridge.ts
@@ -671,11 +671,13 @@ export class AgentBridge {
   private async getAuthStatus(): Promise<{
     isAuthenticated: boolean;
     user: { id: string; email?: string } | undefined;
+    serverUrl: string;
   }> {
     const authService = AuthService.getInstance();
     return {
       isAuthenticated: authService.isSSOAuthenticated(),
       user: authService.getAuthUser(),
+      serverUrl: authService.getServerUrl(),
     };
   }
 

--- a/packages/code/tests/stdio/agentBridge.test.ts
+++ b/packages/code/tests/stdio/agentBridge.test.ts
@@ -825,6 +825,7 @@ test("getAuthStatus returns auth state", async () => {
     getAuthUser: vi
       .fn()
       .mockReturnValue({ id: "user-1", email: "test@test.com" }),
+    getServerUrl: vi.fn().mockReturnValue("https://codechat.codewave.163.com"),
   } as unknown as AuthService);
 
   const result = await bridge.handleRequest("getAuthStatus", {});
@@ -832,6 +833,7 @@ test("getAuthStatus returns auth state", async () => {
   expect(result).toEqual({
     isAuthenticated: true,
     user: { id: "user-1", email: "test@test.com" },
+    serverUrl: "https://codechat.codewave.163.com",
   });
 });
 

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/config/WavePluginService.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/config/WavePluginService.kt
@@ -13,6 +13,7 @@ data class ConfigurationData(
     var model: String = "",
     var fastModel: String = "",
     var language: String = "Chinese",
+    var serverUrl: String = "",
 )
 
 @State(name = "WavePlugin", storages = [Storage("wave.xml")])

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
@@ -21,6 +21,7 @@ import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -109,6 +110,7 @@ class MessageHandler(
                     model = data["model"]?.jsonPrimitive?.content ?: ""
                     fastModel = data["fastModel"]?.jsonPrimitive?.content ?: ""
                     language = data["language"]?.jsonPrimitive?.content ?: "Chinese"
+                    serverUrl = data["serverUrl"]?.jsonPrimitive?.content ?: this.serverUrl
                 }
                 WavePluginService.getInstance().saveConfiguration(config)
                 session.agent?.updateConfig(buildConfigParams(config))
@@ -320,17 +322,30 @@ class MessageHandler(
             // ── Auth ───────────────────────────────────────────────────
             // VSCE :143/:643 → authStatusResponse { isAuthenticated, user }
             "getAuthStatus" -> {
-                val (authenticated, user) = try {
+                val (authenticated, user, serverUrl) = try {
                     val res = session.agent?.getAuthStatus()?.jsonObject
-                    (res?.get("isAuthenticated")?.jsonPrimitive?.content?.toBoolean() ?: false) to res?.get("user")
+                    val url = (res?.get("serverUrl") as? JsonPrimitive)?.contentOrNull ?: ""
+                    if (url.isNotEmpty()) {
+                        val merged = WavePluginService.getInstance().loadConfiguration().apply {
+                            serverUrl = url
+                        }
+                        WavePluginService.getInstance().saveConfiguration(merged)
+                        postConfigurationResponse()
+                    }
+                    Triple(
+                        res?.get("isAuthenticated")?.jsonPrimitive?.content?.toBoolean() ?: false,
+                        res?.get("user"),
+                        url,
+                    )
                 } catch (e: StdioClientException) {
                     LOG.warn("getAuthStatus failed: ${e.message}")
-                    false to null
+                    Triple(false, null, "")
                 }
                 postMessage("authStatusResponse", buildJsonObject {
                     put("isAuthenticated", authenticated)
                     // VSCE sends user: null on failure; send JsonNull to match.
                     put("user", user ?: JsonNull)
+                    put("serverUrl", serverUrl)
                 })
             }
             // VSCE :146/:664 → loginResponse { success, user } + updateAllSessionsConfig
@@ -544,6 +559,7 @@ class MessageHandler(
                 put("model", config.model)
                 put("fastModel", config.fastModel)
                 put("language", config.language)
+                put("serverUrl", config.serverUrl)
             })
         })
     }
@@ -581,6 +597,7 @@ class MessageHandler(
                 put("model", config.model)
                 put("fastModel", config.fastModel)
                 put("language", config.language)
+                put("serverUrl", config.serverUrl)
             })
             put("permissionMode", session.permissionMode ?: "default")
             put("queuedMessages", session.messageQueue ?: JsonArray(emptyList()))

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/update/UpdateChecker.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/update/UpdateChecker.kt
@@ -18,6 +18,7 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.wave.jetbrains.config.WavePluginService
 import com.wave.jetbrains.util.Edt
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -51,6 +52,7 @@ object UpdateChecker {
         "https://api.github.com/repos/netease-lcap/wave-agent/releases/latest"
     private const val USER_AGENT = "Wave-JetBrains-Plugin"
     private const val HTTP_TIMEOUT_MS = 10_000
+    private const val MANIFEST_TIMEOUT_MS = 5_000
     private const val DOWNLOAD_TIMEOUT_MS = 120_000
     private const val COOLDOWN_MS = 24L * 60 * 60 * 1000
     private const val KEY_LAST_CHECK = "wave.lastUpdateCheck"
@@ -84,6 +86,18 @@ object UpdateChecker {
         val browser_download_url: String,
     )
 
+    @Serializable
+    data class CodeChatManifest(
+        val version: String,
+        val downloads: CodeChatDownloads = CodeChatDownloads(),
+    )
+
+    @Serializable
+    data class CodeChatDownloads(
+        val vscode: String? = null,
+        val jetbrains: String? = null,
+    )
+
     // ── Version parsing (VSCode parity: strip 'v', drop pre-release, require 3 numeric parts) ──
 
     fun parseVersion(version: String): ParsedVersion? {
@@ -103,13 +117,15 @@ object UpdateChecker {
 
     // ── HTTP ────────────────────────────────────────────────────────────────────
 
-    private fun httpGet(url: String): String {
+    @Volatile internal var httpGet: (String, Int) -> String = ::realHttpGet
+
+    internal fun realHttpGet(url: String, timeoutMs: Int): String {
         val conn = (URI(url).toURL().openConnection() as HttpURLConnection).apply {
             requestMethod = "GET"
             setRequestProperty("User-Agent", USER_AGENT)
             setRequestProperty("Accept", "application/vnd.github+json")
-            connectTimeout = HTTP_TIMEOUT_MS
-            readTimeout = HTTP_TIMEOUT_MS
+            connectTimeout = timeoutMs
+            readTimeout = timeoutMs
             instanceFollowRedirects = true
         }
         try {
@@ -141,33 +157,61 @@ object UpdateChecker {
 
     // ── Update check ────────────────────────────────────────────────────────────
 
-    suspend fun checkForUpdate(currentVersion: String): UpdateInfo? = withContext(Dispatchers.IO) {
+    suspend fun checkForUpdate(currentVersion: String, serverUrl: String = ""): UpdateInfo? = withContext(Dispatchers.IO) {
         val current = parseVersion(currentVersion) ?: run {
             LOG.warn("Invalid current version: $currentVersion")
             return@withContext null
         }
         try {
-            val body = httpGet(LATEST_RELEASE_URL)
-            val release = JSON.decodeFromString<GithubRelease>(body)
-            val latestTag = release.tag_name.trimStart('v')
-            val latest = parseVersion(latestTag) ?: run {
-                LOG.warn("Invalid latest tag from GitHub: ${release.tag_name}")
-                return@withContext null
+            if (serverUrl.isNotEmpty()) {
+                try {
+                    return@withContext checkViaCodeChat(currentVersion, current, serverUrl)
+                } catch (e: Exception) {
+                    LOG.warn("CodeChat manifest check failed, falling back to GitHub: ${e.message}")
+                }
             }
-            if (compareVersions(latest, current) > 0) {
-                val zipAsset = release.assets.firstOrNull { it.name.endsWith(".zip") }
-                UpdateInfo(
-                    latestVersion = latestTag,
-                    currentVersion = currentVersion,
-                    downloadUrl = release.html_url,
-                    zipUrl = zipAsset?.browser_download_url,
-                    releaseNotes = release.body,
-                )
-            } else null
+            return@withContext checkViaGitHub(currentVersion, current)
         } catch (e: Exception) {
             LOG.warn("Failed to check for updates: ${e.message}")
             null
         }
+    }
+
+    private fun checkViaGitHub(currentVersion: String, current: ParsedVersion): UpdateInfo? {
+        val body = httpGet(LATEST_RELEASE_URL, HTTP_TIMEOUT_MS)
+        val release = JSON.decodeFromString<GithubRelease>(body)
+        val latestTag = release.tag_name.trimStart('v')
+        val latest = parseVersion(latestTag) ?: run {
+            LOG.warn("Invalid latest tag from GitHub: ${release.tag_name}")
+            return null
+        }
+        if (compareVersions(latest, current) > 0) {
+            val zipAsset = release.assets.firstOrNull { it.name.endsWith(".zip") }
+            return UpdateInfo(
+                latestVersion = latestTag,
+                currentVersion = currentVersion,
+                downloadUrl = release.html_url,
+                zipUrl = zipAsset?.browser_download_url,
+                releaseNotes = release.body,
+            )
+        }
+        return null
+    }
+
+    private fun checkViaCodeChat(currentVersion: String, current: ParsedVersion, serverUrl: String): UpdateInfo? {
+        val body = httpGet("${serverUrl}/api/downloads/manifest.json", MANIFEST_TIMEOUT_MS)
+        val manifest = JSON.decodeFromString<CodeChatManifest>(body)
+        val zipPath = manifest.downloads?.jetbrains ?: return null
+        val latest = parseVersion(manifest.version) ?: return null
+        if (compareVersions(latest, current) <= 0) return null
+        val zipUrl = URI(serverUrl).resolve(zipPath).toString()
+        return UpdateInfo(
+            latestVersion = manifest.version,
+            currentVersion = currentVersion,
+            downloadUrl = zipUrl,
+            zipUrl = zipUrl,
+            releaseNotes = null,
+        )
     }
 
     /**
@@ -186,7 +230,8 @@ object UpdateChecker {
 
         val current = currentVersion()
         if (current.isEmpty()) return
-        val info = checkForUpdate(current) ?: run {
+        val serverUrl = WavePluginService.getInstance().loadConfiguration().serverUrl
+        val info = checkForUpdate(current, serverUrl) ?: run {
             if (skipCooldown) Edt.invokeLater { showInfo(project, "当前已是最新版本") }
             return
         }

--- a/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/update/UpdateCheckerTest.kt
+++ b/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/update/UpdateCheckerTest.kt
@@ -1,24 +1,29 @@
 package com.wave.jetbrains.update
 
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 /**
- * Unit tests for the pure version-parsing helpers in [UpdateChecker].
+ * Unit tests for the pure version-parsing helpers in [UpdateChecker], plus
+ * manifest-driven update checks via the swappable [UpdateChecker.httpGet] seam.
  *
  * These mirror the VSCode `updateService` test cases: strip leading `v`, drop
  * pre-release suffixes, require exactly three numeric components, and compare
  * major → minor → patch numerically (not lexicographically).
- *
- * The network/IDE-dependent paths (checkForUpdate, checkAndNotify, install)
- * are intentionally not covered here — they need a live GitHub API and an
- * Application/Project context, and are exercised manually via the webview
- * "检查更新" button and the auto-check on session init.
  */
 class UpdateCheckerTest {
+
+    @AfterEach
+    fun tearDown() {
+        UpdateChecker.httpGet = UpdateChecker::realHttpGet
+    }
+
 
     // ---- parseVersion --------------------------------------------------
 
@@ -114,5 +119,50 @@ class UpdateCheckerTest {
             // Restore so the static state doesn't leak into other tests.
             UpdateChecker.autoCheckTriggered = original
         }
+    }
+
+    // ---- checkForUpdate via CodeChat manifest --------------------------
+
+    @Test
+    fun `checkForUpdate returns CodeChat UpdateInfo when manifest has newer jetbrains version`() = runBlocking {
+        val manifestJson = """{"version":"0.19.4","downloads":{"vscode":"/api/downloads/codechat-vscode.vsix","jetbrains":"/api/downloads/codechat-jetbrains.zip"}}"""
+        UpdateChecker.httpGet = { url, _ ->
+            if (url.endsWith("/api/downloads/manifest.json")) manifestJson
+            else error("unexpected url: $url")
+        }
+        val info = UpdateChecker.checkForUpdate("0.19.3", "https://codechat.example.com")
+        assertNotNull(info)
+        assertEquals("0.19.4", info!!.latestVersion)
+        assertEquals("0.19.3", info.currentVersion)
+        assertTrue(info.zipUrl!!.endsWith("codechat-jetbrains.zip"), "zipUrl=${info.zipUrl}")
+        assertEquals(info.zipUrl, info.downloadUrl)
+        assertNull(info.releaseNotes)
+    }
+
+    @Test
+    fun `checkForUpdate returns null when CodeChat manifest has no jetbrains artifact`() = runBlocking {
+        val manifestJson = """{"version":"0.19.4","downloads":{"vscode":"/api/downloads/codechat-vscode.vsix"}}"""
+        UpdateChecker.httpGet = { url, _ ->
+            if (url.endsWith("/api/downloads/manifest.json")) manifestJson
+            else error("unexpected url: $url")
+        }
+        // No GitHub fallback when the manifest is authoritative but has no jetbrains artifact.
+        assertNull(UpdateChecker.checkForUpdate("0.19.3", "https://codechat.example.com"))
+    }
+
+    @Test
+    fun `checkForUpdate falls back to GitHub when CodeChat manifest throws`() = runBlocking {
+        val githubJson = """{"tag_name":"v0.19.5","html_url":"https://github.com/netease-lcap/wave-agent/releases/latest","body":"release notes","assets":[{"name":"codechat-jetbrains.zip","browser_download_url":"https://github.com/netease-lcap/wave-agent/releases/download/v0.19.5/codechat-jetbrains.zip"}]}"""
+        UpdateChecker.httpGet = { url, _ ->
+            if (url.endsWith("/api/downloads/manifest.json")) error("manifest endpoint down")
+            else githubJson
+        }
+        val info = UpdateChecker.checkForUpdate("0.19.4", "https://codechat.example.com")
+        assertNotNull(info)
+        assertEquals("0.19.5", info!!.latestVersion)
+        assertEquals("0.19.4", info.currentVersion)
+        assertEquals("https://github.com/netease-lcap/wave-agent/releases/latest", info.downloadUrl)
+        assertTrue(info.zipUrl!!.endsWith("codechat-jetbrains.zip"))
+        assertEquals("release notes", info.releaseNotes)
     }
 }

--- a/packages/vsce/src/chatProvider.ts
+++ b/packages/vsce/src/chatProvider.ts
@@ -107,7 +107,10 @@ export class ChatProvider implements vscode.WebviewViewProvider {
                     this.tabSessions.forEach(session => session.updateConfig(cfg));
                     this.windowSessions.forEach(session => session.updateConfig(cfg));
                 },
-                checkForUpdates: () => checkAndNotify(this.context, true)
+                checkForUpdates: async () => {
+                    const cfg = await this.configService.loadConfiguration();
+                    return checkAndNotify(this.context, true, cfg.serverUrl);
+                }
             }
         );
 
@@ -280,7 +283,8 @@ export class ChatProvider implements vscode.WebviewViewProvider {
             // The 24h cooldown is enforced inside checkAndNotify via globalState.
             if (!this.updateCheckTriggered) {
                 this.updateCheckTriggered = true;
-                checkAndNotify(this.context).catch(err => {
+                const cfg = await this.configService.loadConfiguration();
+                checkAndNotify(this.context, false, cfg.serverUrl).catch(err => {
                     console.warn('[UpdateService] Update check failed:', err);
                 });
             }

--- a/packages/vsce/src/services/configurationService.ts
+++ b/packages/vsce/src/services/configurationService.ts
@@ -7,6 +7,7 @@ export interface ConfigurationData {
     model?: string;
     fastModel?: string;
     language?: string;
+    serverUrl?: string;
 }
 
 export class ConfigurationService {
@@ -19,7 +20,8 @@ export class ConfigurationService {
             baseURL: this.context.globalState.get<string>('baseURL') || '',
             model: this.context.globalState.get<string>('model') || '',
             fastModel: this.context.globalState.get<string>('fastModel') || '',
-            language: this.context.globalState.get<string>('language') || 'Chinese'
+            language: this.context.globalState.get<string>('language') || 'Chinese',
+            serverUrl: this.context.globalState.get<string>('serverUrl') || ''
         };
     }
 
@@ -31,6 +33,7 @@ export class ConfigurationService {
             if (configData.model !== undefined) await this.context.globalState.update('model', configData.model);
             if (configData.fastModel !== undefined) await this.context.globalState.update('fastModel', configData.fastModel);
             if (configData.language !== undefined) await this.context.globalState.update('language', configData.language);
+            if (configData.serverUrl !== undefined) await this.context.globalState.update('serverUrl', configData.serverUrl);
         } catch (error) {
             console.error('Failed to save configuration:', error);
             throw error;

--- a/packages/vsce/src/services/updateService.ts
+++ b/packages/vsce/src/services/updateService.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import * as http from 'http';
 import * as https from 'https';
 import * as os from 'os';
 import * as path from 'path';
@@ -55,7 +56,8 @@ function httpGet(url: string, timeout = 10000): Promise<{ statusCode: number; bo
             reject(new Error('Request timed out'));
         }, timeout);
 
-        https.get(url, {
+        const getter = url.startsWith('https:') ? https.get : http.get;
+        getter(url, {
             headers: { 'User-Agent': 'Wave-VSCode-Extension' },
             timeout
         }, (res) => {
@@ -72,7 +74,81 @@ function httpGet(url: string, timeout = 10000): Promise<{ statusCode: number; bo
     });
 }
 
-export async function checkForUpdate(currentVersion: string): Promise<UpdateInfo | null> {
+async function checkViaGitHub(currentVersion: string, current: ParsedVersion): Promise<UpdateInfo | null> {
+    const { statusCode, body } = await httpGet('https://api.github.com/repos/netease-lcap/wave-agent/releases/latest');
+
+    if (statusCode !== 200) {
+        console.warn('[UpdateService] GitHub API returned non-OK status:', statusCode);
+        return null;
+    }
+
+    const data = JSON.parse(body) as {
+        tag_name: string;
+        html_url: string;
+        body?: string;
+        assets?: Array<{ name: string; browser_download_url: string }>;
+    };
+
+    const latestTag = data.tag_name.replace(/^v/, '');
+    const latest = parseVersion(latestTag);
+
+    if (!latest) {
+        console.warn('[UpdateService] Invalid latest version from GitHub:', data.tag_name);
+        return null;
+    }
+
+    if (compareVersions(latest, current) > 0) {
+        const vsixAsset = data.assets?.find(a => a.name.endsWith('.vsix'));
+        return {
+            latestVersion: latestTag,
+            currentVersion: currentVersion,
+            downloadUrl: data.html_url,
+            vsixUrl: vsixAsset?.browser_download_url,
+            releaseNotes: data.body
+        };
+    }
+
+    return null;
+}
+
+async function checkViaCodeChat(currentVersion: string, current: ParsedVersion, serverUrl: string): Promise<UpdateInfo | null> {
+    const { statusCode, body } = await httpGet(`${serverUrl}/api/downloads/manifest.json`, 5000);
+
+    if (statusCode !== 200) {
+        throw new Error(`CodeChat manifest returned non-OK status: ${statusCode}`);
+    }
+
+    const data = JSON.parse(body) as {
+        version: string;
+        downloads?: { vscode?: string };
+    };
+
+    const vsixPath = data.downloads?.vscode;
+    if (!vsixPath) {
+        return null;
+    }
+
+    const latest = parseVersion(data.version);
+    if (!latest) {
+        console.warn('[UpdateService] Invalid latest version from CodeChat:', data.version);
+        return null;
+    }
+
+    if (compareVersions(latest, current) <= 0) {
+        return null;
+    }
+
+    const vsixUrl = new URL(vsixPath, serverUrl).toString();
+    return {
+        latestVersion: data.version,
+        currentVersion: currentVersion,
+        downloadUrl: vsixUrl,
+        vsixUrl,
+        releaseNotes: undefined
+    };
+}
+
+export async function checkForUpdate(currentVersion: string, serverUrl?: string): Promise<UpdateInfo | null> {
     const current = parseVersion(currentVersion);
     if (!current) {
         console.warn('[UpdateService] Invalid current version:', currentVersion);
@@ -80,40 +156,14 @@ export async function checkForUpdate(currentVersion: string): Promise<UpdateInfo
     }
 
     try {
-        const { statusCode, body } = await httpGet('https://api.github.com/repos/netease-lcap/wave-vsce/releases/latest');
-
-        if (statusCode !== 200) {
-            console.warn('[UpdateService] GitHub API returned non-OK status:', statusCode);
-            return null;
+        if (serverUrl) {
+            try {
+                return await checkViaCodeChat(currentVersion, current, serverUrl);
+            } catch (error) {
+                console.warn('[UpdateService] CodeChat manifest check failed, falling back to GitHub:', error);
+            }
         }
-
-        const data = JSON.parse(body) as {
-            tag_name: string;
-            html_url: string;
-            body?: string;
-            assets?: Array<{ name: string; browser_download_url: string }>;
-        };
-
-        const latestTag = data.tag_name.replace(/^v/, '');
-        const latest = parseVersion(latestTag);
-
-        if (!latest) {
-            console.warn('[UpdateService] Invalid latest version from GitHub:', data.tag_name);
-            return null;
-        }
-
-        if (compareVersions(latest, current) > 0) {
-            const vsixAsset = data.assets?.find(a => a.name.endsWith('.vsix'));
-            return {
-                latestVersion: latestTag,
-                currentVersion: currentVersion,
-                downloadUrl: data.html_url,
-                vsixUrl: vsixAsset?.browser_download_url,
-                releaseNotes: data.body
-            };
-        }
-
-        return null;
+        return await checkViaGitHub(currentVersion, current);
     } catch (error) {
         console.warn('[UpdateService] Failed to check for updates:', error);
         return null;
@@ -128,7 +178,8 @@ function httpDownload(url: string, destPath: string, timeout = 120000): Promise<
             reject(new Error('Download timed out'));
         }, timeout);
 
-        https.get(url, {
+        const getter = url.startsWith('https:') ? https.get : http.get;
+        getter(url, {
             headers: { 'User-Agent': 'Wave-VSCode-Extension' },
             timeout
         }, (res) => {
@@ -177,7 +228,7 @@ async function downloadAndInstall(vsixUrl: string): Promise<void> {
  * Uses globalState to cache: checks at most once per 24 hours, and dismisses ignored versions.
  * @param skipCooldown - When true (e.g. manual check), bypass the 24-hour cooldown.
  */
-export async function checkAndNotify(context: vscode.ExtensionContext, skipCooldown = false): Promise<void> {
+export async function checkAndNotify(context: vscode.ExtensionContext, skipCooldown = false, serverUrl?: string): Promise<void> {
     const now = Date.now();
     const twentyFourHours = 24 * 60 * 60 * 1000;
 
@@ -192,7 +243,7 @@ export async function checkAndNotify(context: vscode.ExtensionContext, skipCoold
     await context.globalState.update('wave.lastUpdateCheck', now);
 
     const ignoredVersion = context.globalState.get<string>('wave.ignoredVersion');
-    const updateInfo = await checkForUpdate(context.extension.packageJSON.version);
+    const updateInfo = await checkForUpdate(context.extension.packageJSON.version, serverUrl);
 
     if (!updateInfo) {
         if (skipCooldown) {

--- a/packages/vsce/src/session/messageHandler.ts
+++ b/packages/vsce/src/session/messageHandler.ts
@@ -649,11 +649,18 @@ export class MessageHandler {
             const result = await this.utilityClient.request('getAuthStatus') as {
                 isAuthenticated: boolean;
                 user: { id: string; email?: string } | undefined;
+                serverUrl: string;
             };
+            await this.configService.saveConfiguration({ serverUrl: result.serverUrl });
             this.context.postMessage({
                 command: 'authStatusResponse',
                 isAuthenticated: result.isAuthenticated,
-                user: result.user
+                user: result.user,
+                serverUrl: result.serverUrl
+            }, viewType, windowId);
+            this.context.postMessage({
+                command: 'configurationResponse',
+                configurationData: await this.configService.loadConfiguration()
             }, viewType, windowId);
         } catch (error) {
             console.error('获取认证状态失败:', error);

--- a/packages/vsce/tests/services/updateService.test.ts
+++ b/packages/vsce/tests/services/updateService.test.ts
@@ -1,13 +1,75 @@
-import { describe, test, expect, vi } from 'vitest';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
 
 vi.mock('vscode', () => ({}));
 vi.mock('fs', () => ({}));
-vi.mock('http', () => ({}));
-vi.mock('https', () => ({}));
 vi.mock('os', () => ({}));
 vi.mock('path', () => ({}));
 
-import { parseVersion, compareVersions } from '../../src/services/updateService';
+const httpGetCalls: Array<{ proto: 'http' | 'https'; url: string }> = [];
+function createMockGetter(proto: 'http' | 'https') {
+    return vi.fn((url: string, _options: unknown, callback: (res: { statusCode: number; on: typeof EventEmitter.prototype.on; emit: typeof EventEmitter.prototype.emit }) => void) => {
+        httpGetCalls.push({ proto, url });
+        const ee = new EventEmitter();
+        const res = { statusCode: 0, on: ee.on.bind(ee), emit: ee.emit.bind(ee) };
+        // Defer so the callback can attach listeners before events fire.
+        process.nextTick(() => {
+            if (url.includes('/api/downloads/manifest.json')) {
+                const fixture = manifestFixture;
+                if (fixture === null) {
+                    res.statusCode = 500;
+                    callback(res);
+                    res.emit('end');
+                    return;
+                }
+                res.statusCode = fixture.statusCode;
+                callback(res);
+                res.emit('data', fixture.body);
+                res.emit('end');
+                return;
+            } else if (url.includes('api.github.com')) {
+                const fixture = githubFixture;
+                if (fixture === null) {
+                    throw new Error('GitHub fixture not configured for this test');
+                }
+                res.statusCode = fixture.statusCode;
+                callback(res);
+                res.emit('data', fixture.body);
+                res.emit('end');
+                return;
+            }
+            res.statusCode = 404;
+            callback(res);
+            res.emit('end');
+        });
+        // Return an emitter so .on('error', ...) can be chained by the caller.
+        const req = new EventEmitter();
+        return req;
+    });
+}
+
+let manifestFixture: { statusCode: number; body: string } | null = null;
+let githubFixture: { statusCode: number; body: string } | null = null;
+
+vi.mock('http', () => ({ get: createMockGetter('http') }));
+vi.mock('https', () => ({ get: createMockGetter('https') }));
+
+import { parseVersion, compareVersions, checkForUpdate } from '../../src/services/updateService';
+
+const GITHUB_RELEASE_BODY = JSON.stringify({
+    tag_name: 'v1.2.0',
+    html_url: 'https://github.com/netease-lcap/wave-agent/releases/tag/v1.2.0',
+    body: 'release notes',
+    assets: [
+        { name: 'wave-vscode-1.2.0.vsix', browser_download_url: 'https://github.com/netease-lcap/wave-agent/releases/download/v1.2.0/wave-vscode-1.2.0.vsix' }
+    ]
+});
+
+beforeEach(() => {
+    httpGetCalls.length = 0;
+    manifestFixture = null;
+    githubFixture = null;
+});
 
 describe('parseVersion', () => {
     test('parses standard semver', () => {
@@ -63,5 +125,80 @@ describe('compareVersions', () => {
             { major: 1, minor: 2, patch: 4 },
             { major: 1, minor: 2, patch: 3 }
         )).toBe(1);
+    });
+});
+
+describe('checkForUpdate', () => {
+    test('CodeChat manifest 200 + vscode present + newer version returns UpdateInfo with absolute vsixUrl', async () => {
+        manifestFixture = {
+            statusCode: 200,
+            body: JSON.stringify({
+                version: '1.2.0',
+                downloads: { vscode: '/api/downloads/codechat-vscode.vsix' }
+            })
+        };
+
+        const result = await checkForUpdate('1.1.0', 'http://example.test');
+
+        expect(result).not.toBeNull();
+        expect(result!.latestVersion).toBe('1.2.0');
+        expect(result!.currentVersion).toBe('1.1.0');
+        expect(result!.vsixUrl).toBe('http://example.test/api/downloads/codechat-vscode.vsix');
+        // GitHub NOT hit
+        expect(httpGetCalls.some(c => c.url.includes('api.github.com'))).toBe(false);
+    });
+
+    test('CodeChat manifest 200 + vscode absent returns null and does not fall back to GitHub', async () => {
+        manifestFixture = {
+            statusCode: 200,
+            body: JSON.stringify({
+                version: '1.2.0',
+                downloads: {}
+            })
+        };
+
+        const result = await checkForUpdate('1.1.0', 'http://example.test');
+
+        expect(result).toBeNull();
+        expect(httpGetCalls.some(c => c.url.includes('api.github.com'))).toBe(false);
+    });
+
+    test('CodeChat manifest non-200 falls back to GitHub and returns GitHub UpdateInfo', async () => {
+        manifestFixture = null; // manifest endpoint returns 500
+        githubFixture = { statusCode: 200, body: GITHUB_RELEASE_BODY };
+
+        const result = await checkForUpdate('1.1.0', 'http://example.test');
+
+        expect(result).not.toBeNull();
+        expect(result!.latestVersion).toBe('1.2.0');
+        expect(httpGetCalls.some(c => c.url.includes('api.github.com'))).toBe(true);
+    });
+
+    test('serverUrl empty/undefined uses GitHub path with netease-lcap/wave-agent repo', async () => {
+        githubFixture = { statusCode: 200, body: GITHUB_RELEASE_BODY };
+
+        const result = await checkForUpdate('1.1.0');
+
+        expect(result).not.toBeNull();
+        expect(result!.latestVersion).toBe('1.2.0');
+        const githubCall = httpGetCalls.find(c => c.url.includes('api.github.com'));
+        expect(githubCall).toBeDefined();
+        expect(githubCall!.url).toContain('netease-lcap/wave-agent');
+        expect(githubCall!.url).not.toContain('netease-lcap/wave-vsce');
+    });
+
+    test('CodeChat manifest 200 + version not newer returns null', async () => {
+        manifestFixture = {
+            statusCode: 200,
+            body: JSON.stringify({
+                version: '1.1.0',
+                downloads: { vscode: '/api/downloads/codechat-vscode.vsix' }
+            })
+        };
+
+        const result = await checkForUpdate('1.1.0', 'http://example.test');
+
+        expect(result).toBeNull();
+        expect(httpGetCalls.some(c => c.url.includes('api.github.com'))).toBe(false);
     });
 });

--- a/packages/vsce/vitest.config.ts
+++ b/packages/vsce/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
         reporter: 'dot',
         environment: 'node',
         include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
-        exclude: ['tests/services/**', 'node_modules'],
+        exclude: ['node_modules'],
         setupFiles: ['tests/setup.ts'],
         server: {
             deps: {

--- a/packages/webview/src/components/StatusDialog.tsx
+++ b/packages/webview/src/components/StatusDialog.tsx
@@ -67,6 +67,7 @@ const StatusDialog: React.FC<StatusDialogProps & { vscode: { postMessage: (msg: 
   const baseURL = configurationData?.baseURL;
   const model = configurationData?.model;
   const fastModel = configurationData?.fastModel;
+  const serverUrl = configurationData?.serverUrl;
 
   const StatusRow = ({ label, value }: { label: string; value?: string }) => (
     <div className="configuration-field">
@@ -113,6 +114,7 @@ const StatusDialog: React.FC<StatusDialogProps & { vscode: { postMessage: (msg: 
             <StatusRow label="Session ID" value={sessionId} />
             <StatusRow label="工作目录" value={workdir} />
             <StatusRow label="Base URL" value={baseURL} />
+            <StatusRow label="Server URL" value={serverUrl} />
             <StatusRow label="Model" value={model} />
             <StatusRow label="Fast Model" value={fastModel} />
 

--- a/packages/webview/src/types/index.ts
+++ b/packages/webview/src/types/index.ts
@@ -307,6 +307,8 @@ export interface ConfigurationData {
   fastModel?: string;
   /** Preferred language for agent communication */
   language?: string;
+  /** CodeChat server URL (reported by SDK, used for update checks) */
+  serverUrl?: string;
 }
 
 // Plugin related types


### PR DESCRIPTION
## Summary

Plugin update checks now query the CodeChat server manifest (`/api/downloads/manifest.json`) instead of GitHub Releases when a `serverUrl` is configured, falling back to GitHub on network/HTTP errors only. The SDK reports `serverUrl` via the existing `getAuthStatus` RPC; both plugins persist it into `ConfigurationData` and display it read-only in `StatusDialog`.

Closes #1423.

## Why
GitHub Releases (`api.github.com`) is unreliable in mainland China — timeouts/被墙. The VSCode checker also pointed at a stale, abandoned repo (`netease-lcap/wave-vsce\), stuck at v0.4.17, instead of the live `netease-lcap/wave-agent`. CodeChat now serves a unified version manifest on the same host the SDK already uses for SSO.

## Changes
**SDK** (`agentBridge.ts`): `getAuthStatus` reports `serverUrl: authService.getServerUrl()`.

**Shared webview**: `serverUrl` added to `ConfigurationData`; `StatusDialog` shows it read-only as "Server URL".

**VSCode**:
- `configurationService.ts` persists `serverUrl` to globalState (with `!== undefined` merge guard).
- `messageHandler.ts` `handleGetAuthStatus` persists the reported `serverUrl` and posts a refreshed `configurationResponse`.
- `updateService.ts`: `http`/`https` protocol dispatcher; `checkViaGitHub` extracted with the **stale-repo fix** (`wave-vsce` → `wave-agent`); `checkViaCodeChat` added (5s probe, returns `null` if no `vscode` artifact — no fallback); `checkForUpdate` orchestrates CodeChat-first → GitHub fallback; `checkAndNotify` takes `serverUrl`.
- `chatProvider.ts` passes `cfg.serverUrl` to both manual and auto checks.
- Tests: 5 new cases (manifest newer / absent-`vscode` / non-200-fallback / empty-serverUrl / old-version). `vitest.config.ts` stale `tests/services/**` exclude removed (was hiding the test file).

**JetBrains**:
- `WavePluginService.kt`: `serverUrl` added to `ConfigurationData`.
- `MessageHandler.kt`: extracts+persists `serverUrl` (merge, preserves others), includes it in `authStatusResponse` + `configurationData`; `updateConfiguration` uses `: config.serverUrl` (preserve); not added to `buildConfigParams`/`WaveSession.initialize`.
- `UpdateChecker.kt`: `CodeChatManifest`/`CodeChatDownloads` serializables; swappable `httpGet` seam with `MANIFEST_TIMEOUT_MS=5_000`; `checkViaGitHub` extracted; `checkViaCodeChat` returns `null` when `jetbrains` absent; `checkForUpdate(currentVersion, serverUrl)` CodeChat-first → GitHub fallback.
- Tests: 3 new cases via `httpGet` seam.

## Update-check flow
CodeChat manifest is **authoritative when reachable** (HTTP 200). A 200 with the platform's download key absent → return `null` (no artifact) — does **not** fall back to GitHub. Only network/HTTP errors (or empty `serverUrl`) fall back to GitHub. 5s manifest probe timeout keeps the fallback snappy when CodeChat is down. Version comparison unchanged — `manifest.version` (no `v`) is already handled.

## Verification
- `pnpm -F wave-vsce test`: 122 passed (9 files, incl. 14 in `updateService.test.ts`).
- `cd packages/jetbrains && ./gradlew test --rerun-tasks`: BUILD SUCCESSFUL — `UpdateCheckerTest` 13/13, `BinaryResolverTest` 10/10.
- `pnpm -F wave-code build`: succeeded.
- `pnpm run type-check`: all 4 packages pass.

## Notes
- Prod (`https://codechat.codewave.163.com`) manifest not deployed yet (times out) — GitHub fallback is essential. Test env (`http://codechat.codewave-test.163yun.com`) verified live: `curl` → `200 {"version":"0.19.4",...}`.
- The `agentBridge.ts` `InitializeParams.serverUrl` forwarding gap (plugin→SDK direction) is **not** fixed — in this model the plugin is a consumer of the SDK-reported value, so the fix would be dead code. SSO login and downloads both read the SDK's resolved `serverUrl`.
- Manual spot-check remaining: StatusDialog "Server URL" display, manifest request with `WAVE_SERVER_URL=http://codechat.codewave-test.163yun.com`, GitHub fallback when host unreachable.