### PR TITLE
chore(rules): remove references to non-existent subagents

### DIFF
--- a/.wave/rules/testing.md
+++ b/.wave/rules/testing.md
@@ -3,7 +3,6 @@ paths:
   - "packages/*/tests/**/*"
 ---
 - `packages/*/tests` directories contain test files that are easy to mock, can run locally and on CI/CD
-  - Task vitest-expert to write tests
   - Testing framework is vitest
   - Run test use `cd packages/xxx && pnpm test test_file`
   - Use HookTester to test hooks

--- a/.wave/rules/typescript.md
+++ b/.wave/rules/typescript.md
@@ -1,5 +1,4 @@
 - For type and eslint errors:
-  - MUST task typescript-expert to fix type and eslint errors in order to reduce context usage of main agent
   - Don't write any types
   - Do not modify tsconfig unless user ask you to do that
   - Do not prefix unused variables with underscore, just remove them


### PR DESCRIPTION
Remove task delegation lines for `vitest-expert` and `typescript-expert` from `.wave/rules/testing.md` and `.wave/rules/typescript.md`, since neither subagent exists (only `bash`, `explore`, `general-purpose`, `plan` do).