### PR TITLE
fix(grepTool): search hidden dirs and exclude VCS by default

### DIFF
--- a/packages/agent-sdk/src/tools/grepTool.ts
+++ b/packages/agent-sdk/src/tools/grepTool.ts
@@ -8,6 +8,18 @@ import {
   AGENT_TOOL_NAME,
 } from "../constants/tools.js";
 
+// Version control system directories to exclude from searches.
+// These are excluded automatically because they create noise in search results.
+// Mirrors Claude Code's VCS_DIRECTORIES_TO_EXCLUDE.
+const VCS_DIRECTORIES_TO_EXCLUDE = [
+  ".git",
+  ".svn",
+  ".hg",
+  ".bzr",
+  ".jj",
+  ".sl",
+] as const;
+
 /**
  * Grep tool plugin - powerful search tool based on ripgrep
  */
@@ -144,7 +156,19 @@ export const grepTool: ToolPlugin = {
 
     try {
       const workdir = context.workdir;
-      const rgArgs: string[] = ["--color=never", "--max-columns=500"];
+      const rgArgs: string[] = [
+        "--color=never",
+        "--max-columns=500",
+        // Search hidden files/directories by default (aligns with Claude Code).
+        // --hidden does NOT disable .gitignore; only --no-ignore would.
+        "--hidden",
+      ];
+
+      // Exclude VCS directories to avoid noise from version control metadata.
+      // --hidden above would otherwise traverse .git/.svn/etc.
+      for (const dir of VCS_DIRECTORIES_TO_EXCLUDE) {
+        rgArgs.push("--glob", `!${dir}`);
+      }
 
       // Set output mode
       if (outputMode === "files_with_matches") {

--- a/packages/agent-sdk/tests/tools/grepTool.test.ts
+++ b/packages/agent-sdk/tests/tools/grepTool.test.ts
@@ -109,6 +109,49 @@ describe("grepTool", () => {
     }
   });
 
+  it("should search hidden directories and exclude VCS dirs by default", async () => {
+    const stdout = ".wave/rules/testing.md\n";
+    mockSpawn.mockReturnValueOnce(createMockProcess(stdout) as ChildProcess);
+
+    const result = await grepTool.execute(
+      {
+        pattern: "vitest-expert",
+        output_mode: "files_with_matches",
+      },
+      testContext,
+    );
+
+    expect(result.success).toBe(true);
+
+    // --hidden must always be present so hidden dirs like .wave/ are searched.
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "/mock/rg",
+      expect.arrayContaining(["--hidden"]),
+      expect.any(Object),
+    );
+
+    // VCS directories must be excluded via negated --glob patterns.
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "/mock/rg",
+      expect.arrayContaining(["--glob", "!.git"]),
+      expect.any(Object),
+    );
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "/mock/rg",
+      expect.arrayContaining(["--glob", "!.svn"]),
+      expect.any(Object),
+    );
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "/mock/rg",
+      expect.arrayContaining(["--glob", "!.hg"]),
+      expect.any(Object),
+    );
+
+    // Sanity: --no-ignore must NOT be present (gitignore still respected).
+    const callArgs = mockSpawn.mock.calls[0]?.[1] as string[];
+    expect(callArgs).not.toContain("--no-ignore");
+  });
+
   it("should find files containing pattern (files_with_matches mode)", async () => {
     const stdout = "src/index.ts\nsrc/utils.ts\n";
     mockSpawn.mockReturnValueOnce(createMockProcess(stdout) as ChildProcess);


### PR DESCRIPTION
## Problem

Wave's Grep tool did not search hidden directories by default, diverging from Claude Code. For example, `Grep vitest-expert in .` returned no matches because `.wave/rules/testing.md` lives in a hidden dir that ripgrep skips by default.

Wave's Glob tool was already aligned (`dot: true` + `ignore: ["**/.git/**"]`); only Grep was missing.

## Fix

Align `packages/agent-sdk/src/tools/grepTool.ts` with Claude Code's `GrepTool.ts`:

- Add `--hidden` to default ripgrep args so hidden dirs (e.g. `.wave/`) are searched.
- Exclude VCS metadata dirs (`.git`, `.svn`, `.hg`, `.bzr`, `.jj`, `.sl`) via negated `--glob` patterns to avoid noise.
- `.gitignore` is still respected (`--no-ignore` is NOT added).

## Verification

- `Grep vitest-expert in .` now finds `.wave/rules/testing.md`.
- `.git/` internal paths are correctly excluded.
- 25/25 existing tests pass, plus a new test asserting `--hidden` + VCS exclusions are always present and `--no-ignore` is absent.

Mirrors Claude Code's `src/tools/GrepTool/GrepTool.ts:330-335` (`VCS_DIRECTORIES_TO_EXCLUDE`).