### PR TITLE
feat(hooks): expose active_background_subagents in Stop hook input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,11 @@ Always use `pnpm` as the package manager.
     - Explicitly instruct the subagent to ONLY perform the tasks delegated to them.
     - Instruct them to update their assigned tasks frequently using the task management tools.
 
+## 📋 Spec-First Workflow
+
+- **需求增加或变更时，优先更新 spec**：任何功能需求的新增或变更，必须先更新对应的 `specs/` 下的规格说明（新增用户故事、验收场景、功能需求 FR 等），**待用户确认 spec 后再进行代码实现**。spec 是功能设计的权威来源，不是实现的 changelog。
+- **不确定是否算需求变更时也先动 spec**：边界模糊时宁可先写 spec 草稿请用户确认，不要直接改代码。
+
 ## 🐛 Debugging
 
 - **Prefer temporary console.log/console.trace**: When diagnosing bugs, especially race conditions or complex flows, add temporary `console.log` or `console.trace` statements to trace execution rather than overthinking through static analysis. Run the code/tests, observe the actual output, then remove the logs once the issue is identified.

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -1435,6 +1435,16 @@ export class AIManager {
       // Use "SubagentStop" hook name when triggered by a subagent, otherwise use "Stop"
       const hookName = this.subagentType ? "SubagentStop" : "Stop";
 
+      // For main-agent Stop events, snapshot the count of active/initializing
+      // background subagents so the hook can decide whether to block stopping.
+      // SubagentStop does not include this field (per spec FR-064).
+      const activeBackgroundSubagents =
+        hookName === "Stop"
+          ? (this.subagentManager
+              ?.getActiveInstances()
+              .filter((instance) => instance.backgroundTaskId).length ?? 0)
+          : undefined;
+
       const context: ExtendedHookExecutionContext = {
         event: hookName,
         projectDir: this.getWorkdir(),
@@ -1443,6 +1453,7 @@ export class AIManager {
         transcriptPath: this.messageManager.getTranscriptPath(),
         cwd: this.getWorkdir(),
         subagentType: this.subagentType, // Include subagent type in hook context
+        activeBackgroundSubagents, // Stop-only: background subagent count snapshot
         // Stop hooks don't need toolName, toolInput, toolResponse, or userPrompt
         env: Object.fromEntries(
           Object.entries(process.env).filter((e) => e[1] !== undefined),

--- a/packages/agent-sdk/src/services/hook.ts
+++ b/packages/agent-sdk/src/services/hook.ts
@@ -113,6 +113,14 @@ async function buildHookJsonInput(
     }
   }
 
+  // Add active_background_subagents for Stop events only (not SubagentStop)
+  if (
+    context.event === "Stop" &&
+    context.activeBackgroundSubagents !== undefined
+  ) {
+    jsonInput.active_background_subagents = context.activeBackgroundSubagents;
+  }
+
   return jsonInput;
 }
 

--- a/packages/agent-sdk/src/types/hooks.ts
+++ b/packages/agent-sdk/src/types/hooks.ts
@@ -196,6 +196,7 @@ export interface HookJsonInput {
   end_source?: SessionEndSource; // Present for SessionEnd events
   compact_instructions?: string; // Present for PreCompact events
   compact_summary?: string; // Present for PostCompact events
+  active_background_subagents?: number; // Present for Stop events: count of active/initializing background subagents at trigger instant
 }
 
 // Extended context interface for passing additional data to hook executor
@@ -216,6 +217,7 @@ export interface ExtendedHookExecutionContext extends HookExecutionContext {
   endSource?: SessionEndSource; // Session end source (SessionEnd only)
   compactInstructions?: string; // Custom instructions for PreCompact
   compactSummary?: string; // Summary text for PostCompact
+  activeBackgroundSubagents?: number; // Count of active/initializing background subagents (Stop only)
 }
 
 // Environment variables injected into hook processes

--- a/packages/agent-sdk/tests/managers/aiManager.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.test.ts
@@ -1213,6 +1213,160 @@ describe("AIManager", () => {
     });
   });
 
+  describe("Stop hook active_background_subagents (User Story 17)", () => {
+    it("should inject active_background_subagents count from SubagentManager into Stop hook context", async () => {
+      const taskManager = {
+        on: vi.fn(),
+        listTasks: vi.fn().mockResolvedValue([]),
+      } as unknown as TaskManager;
+
+      const mockNotificationQueue = {
+        hasPending: vi.fn().mockReturnValue(false),
+      };
+
+      const mockHookManager = {
+        executeHooks: vi.fn().mockResolvedValue([]),
+        processHookResults: vi.fn().mockReturnValue({
+          shouldBlock: false,
+          errorMessage: "",
+        }),
+        hasHooks: vi.fn().mockReturnValue(true),
+      };
+
+      const container = new Container();
+      container.register("ConfigurationService", {
+        resolveGatewayConfig: vi.fn().mockReturnValue(mockGatewayConfig),
+        resolveModelConfig: vi.fn().mockReturnValue(mockModelConfig),
+        resolveMaxInputTokens: vi.fn().mockReturnValue(96000),
+        resolveAutoMemoryEnabled: vi.fn().mockReturnValue(false),
+        resolveLanguage: vi.fn().mockReturnValue(undefined),
+      });
+      container.register("MessageManager", mockMessageManager);
+      container.register("ToolManager", mockToolManager);
+      container.register("TaskManager", taskManager);
+      container.register("MemoryService", {
+        getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+        getAutoMemoryDirectory: vi.fn().mockReturnValue("/mock/auto-memory"),
+        ensureAutoMemoryDirectory: vi.fn().mockResolvedValue(undefined),
+        getAutoMemoryContent: vi.fn().mockResolvedValue(""),
+      });
+      container.register("PermissionManager", {
+        getCurrentEffectiveMode: vi.fn().mockReturnValue("normal"),
+        clearTemporaryRules: vi.fn(),
+        getPlanFilePath: vi.fn().mockReturnValue(undefined),
+        setHasExitedPlanMode: vi.fn(),
+        hasExitedPlanModeInSession: vi.fn(() => false),
+        setNeedsPlanModeExitAttachment: vi.fn(),
+        getNeedsPlanModeExitAttachment: vi.fn(() => false),
+      } as unknown as Record<string, unknown>);
+      // SubagentManager with 2 background + 1 foreground instance
+      container.register("SubagentManager", {
+        getConfigurations: vi.fn().mockReturnValue([]),
+        getActiveInstances: vi.fn().mockReturnValue([
+          { backgroundTaskId: "task-1" }, // background subagent
+          { backgroundTaskId: undefined }, // foreground subagent (not counted)
+          { backgroundTaskId: "task-2" }, // background subagent
+        ]),
+      });
+      container.register("SkillManager", {
+        getAvailableSkills: vi.fn().mockReturnValue([]),
+      });
+      container.register("NotificationQueue", mockNotificationQueue);
+      container.register("HookManager", mockHookManager);
+      container.register("AgentOptions", { callbacks: {} });
+
+      const testAIManager = new AIManager(container, {
+        workdir: "/test/workdir",
+        stream: false,
+      });
+
+      await testAIManager.sendAIMessage();
+
+      // Stop hook should have been called with active_background_subagents = 2
+      // (only instances with backgroundTaskId count)
+      expect(mockHookManager.executeHooks).toHaveBeenCalledWith(
+        "Stop",
+        expect.objectContaining({
+          event: "Stop",
+          activeBackgroundSubagents: 2,
+        }),
+      );
+    });
+
+    it("should inject active_background_subagents: 0 when no background subagents running", async () => {
+      const taskManager = {
+        on: vi.fn(),
+        listTasks: vi.fn().mockResolvedValue([]),
+      } as unknown as TaskManager;
+
+      const mockNotificationQueue = {
+        hasPending: vi.fn().mockReturnValue(false),
+      };
+
+      const mockHookManager = {
+        executeHooks: vi.fn().mockResolvedValue([]),
+        processHookResults: vi.fn().mockReturnValue({
+          shouldBlock: false,
+          errorMessage: "",
+        }),
+        hasHooks: vi.fn().mockReturnValue(true),
+      };
+
+      const container = new Container();
+      container.register("ConfigurationService", {
+        resolveGatewayConfig: vi.fn().mockReturnValue(mockGatewayConfig),
+        resolveModelConfig: vi.fn().mockReturnValue(mockModelConfig),
+        resolveMaxInputTokens: vi.fn().mockReturnValue(96000),
+        resolveAutoMemoryEnabled: vi.fn().mockReturnValue(false),
+        resolveLanguage: vi.fn().mockReturnValue(undefined),
+      });
+      container.register("MessageManager", mockMessageManager);
+      container.register("ToolManager", mockToolManager);
+      container.register("TaskManager", taskManager);
+      container.register("MemoryService", {
+        getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+        getAutoMemoryDirectory: vi.fn().mockReturnValue("/mock/auto-memory"),
+        ensureAutoMemoryDirectory: vi.fn().mockResolvedValue(undefined),
+        getAutoMemoryContent: vi.fn().mockResolvedValue(""),
+      });
+      container.register("PermissionManager", {
+        getCurrentEffectiveMode: vi.fn().mockReturnValue("normal"),
+        clearTemporaryRules: vi.fn(),
+        getPlanFilePath: vi.fn().mockReturnValue(undefined),
+        setHasExitedPlanMode: vi.fn(),
+        hasExitedPlanModeInSession: vi.fn(() => false),
+        setNeedsPlanModeExitAttachment: vi.fn(),
+        getNeedsPlanModeExitAttachment: vi.fn(() => false),
+      } as unknown as Record<string, unknown>);
+      // No active subagents at all
+      container.register("SubagentManager", {
+        getConfigurations: vi.fn().mockReturnValue([]),
+        getActiveInstances: vi.fn().mockReturnValue([]),
+      });
+      container.register("SkillManager", {
+        getAvailableSkills: vi.fn().mockReturnValue([]),
+      });
+      container.register("NotificationQueue", mockNotificationQueue);
+      container.register("HookManager", mockHookManager);
+      container.register("AgentOptions", { callbacks: {} });
+
+      const testAIManager = new AIManager(container, {
+        workdir: "/test/workdir",
+        stream: false,
+      });
+
+      await testAIManager.sendAIMessage();
+
+      expect(mockHookManager.executeHooks).toHaveBeenCalledWith(
+        "Stop",
+        expect.objectContaining({
+          event: "Stop",
+          activeBackgroundSubagents: 0,
+        }),
+      );
+    });
+  });
+
   describe("Tool Call Partitioning and Serialization", () => {
     it("should run concurrency-safe tools in parallel and non-safe tools serially", async () => {
       const aiServiceMod = await import("../../src/services/aiService.js");

--- a/packages/agent-sdk/tests/services/hook.test.ts
+++ b/packages/agent-sdk/tests/services/hook.test.ts
@@ -838,4 +838,170 @@ describe("Hook Services", () => {
       expect(parsedInput.end_source).toBe("stop");
     });
   });
+
+  describe("Stop hook active_background_subagents", () => {
+    it("should include active_background_subagents for Stop event when provided", async () => {
+      const mockProcess = new MockChildProcess();
+      const mockStdin = new MockStdin();
+      let stdinData = "";
+
+      vi.spyOn(mockStdin, "write").mockImplementation(
+        (_data?: string | Buffer | Uint8Array) => {
+          if (_data) {
+            stdinData += _data.toString();
+          }
+          return true;
+        },
+      );
+
+      mockProcess.stdin = mockStdin;
+      mockSpawn.mockReturnValue(mockProcess);
+
+      const stopContext: ExtendedHookExecutionContext = {
+        event: "Stop",
+        projectDir: "/test/project",
+        timestamp: new Date(),
+        sessionId: "test-session-123",
+        transcriptPath: "/path/to/transcript.json",
+        cwd: "/test/project",
+        activeBackgroundSubagents: 2,
+      };
+
+      const resultPromise = executeCommand("echo test", stopContext);
+
+      setImmediate(() => {
+        mockProcess.emit("close", 0);
+      });
+
+      await resultPromise;
+
+      expect(stdinData).toBeTruthy();
+      const parsedInput = JSON.parse(stdinData);
+      expect(parsedInput.hook_event_name).toBe("Stop");
+      expect(parsedInput.active_background_subagents).toBe(2);
+    });
+
+    it("should include active_background_subagents: 0 for Stop event when no background subagents", async () => {
+      const mockProcess = new MockChildProcess();
+      const mockStdin = new MockStdin();
+      let stdinData = "";
+
+      vi.spyOn(mockStdin, "write").mockImplementation(
+        (_data?: string | Buffer | Uint8Array) => {
+          if (_data) {
+            stdinData += _data.toString();
+          }
+          return true;
+        },
+      );
+
+      mockProcess.stdin = mockStdin;
+      mockSpawn.mockReturnValue(mockProcess);
+
+      const stopContext: ExtendedHookExecutionContext = {
+        event: "Stop",
+        projectDir: "/test/project",
+        timestamp: new Date(),
+        sessionId: "test-session-123",
+        transcriptPath: "/path/to/transcript.json",
+        cwd: "/test/project",
+        activeBackgroundSubagents: 0,
+      };
+
+      const resultPromise = executeCommand("echo test", stopContext);
+
+      setImmediate(() => {
+        mockProcess.emit("close", 0);
+      });
+
+      await resultPromise;
+
+      const parsedInput = JSON.parse(stdinData);
+      expect(parsedInput.active_background_subagents).toBe(0);
+    });
+
+    it("should NOT include active_background_subagents for SubagentStop event", async () => {
+      const mockProcess = new MockChildProcess();
+      const mockStdin = new MockStdin();
+      let stdinData = "";
+
+      vi.spyOn(mockStdin, "write").mockImplementation(
+        (_data?: string | Buffer | Uint8Array) => {
+          if (_data) {
+            stdinData += _data.toString();
+          }
+          return true;
+        },
+      );
+
+      mockProcess.stdin = mockStdin;
+      mockSpawn.mockReturnValue(mockProcess);
+
+      const subagentStopContext: ExtendedHookExecutionContext = {
+        event: "SubagentStop",
+        projectDir: "/test/project",
+        timestamp: new Date(),
+        sessionId: "subagent-session-456",
+        transcriptPath: "/path/to/transcript.json",
+        cwd: "/test/project",
+        subagentType: "general-purpose",
+        // Even if provided, SubagentStop must not include this field
+        activeBackgroundSubagents: 1,
+      };
+
+      const resultPromise = executeCommand("echo test", subagentStopContext);
+
+      setImmediate(() => {
+        mockProcess.emit("close", 0);
+      });
+
+      await resultPromise;
+
+      const parsedInput = JSON.parse(stdinData);
+      expect(parsedInput.hook_event_name).toBe("SubagentStop");
+      expect(parsedInput.active_background_subagents).toBeUndefined();
+    });
+
+    it("should NOT include active_background_subagents for other hook events", async () => {
+      const mockProcess = new MockChildProcess();
+      const mockStdin = new MockStdin();
+      let stdinData = "";
+
+      vi.spyOn(mockStdin, "write").mockImplementation(
+        (_data?: string | Buffer | Uint8Array) => {
+          if (_data) {
+            stdinData += _data.toString();
+          }
+          return true;
+        },
+      );
+
+      mockProcess.stdin = mockStdin;
+      mockSpawn.mockReturnValue(mockProcess);
+
+      const postToolContext: ExtendedHookExecutionContext = {
+        event: "PostToolUse",
+        projectDir: "/test/project",
+        timestamp: new Date(),
+        sessionId: "test-session-123",
+        transcriptPath: "/path/to/transcript.json",
+        cwd: "/test/project",
+        toolName: "Read",
+        // Even if provided, non-Stop events must not include this field
+        activeBackgroundSubagents: 3,
+      };
+
+      const resultPromise = executeCommand("echo test", postToolContext);
+
+      setImmediate(() => {
+        mockProcess.emit("close", 0);
+      });
+
+      await resultPromise;
+
+      const parsedInput = JSON.parse(stdinData);
+      expect(parsedInput.hook_event_name).toBe("PostToolUse");
+      expect(parsedInput.active_background_subagents).toBeUndefined();
+    });
+  });
 });

--- a/specs/005-hooks.md
+++ b/specs/005-hooks.md
@@ -281,6 +281,24 @@ Hook 需要访问完整的对话历史以做出上下文感知的决策。Hook �
 2. **假设**PostCompact hook 失败，**当**压缩运行时，**则**失败被记录但不影响压缩结果
 3. **假设**压缩失败，**当**错误被处理时，**则**PostCompact hook 不会执行
 
+---
+
+### 用户故事 17 - Stop Hook 后台工作感知（优先级：P3）
+
+作为开发者，我希望 Stop hook 触发时能通过 JSON 输入得知有多少后台 subagent 仍在运行，以便决定是否通过退出码 2 阻止停止以等待后台 subagent 完成，或执行相应的清理、通知、日志逻辑。字段值同时隐含"是否有"（0 即无）信息。
+
+**为什么是这个优先级**：Stop hook 默认在主代理回合结束的瞬间触发，不等待异步后台 subagent。没有该字段时，hook 无法区分"所有工作已结束"与"仍有后台 subagent 在跑"两种情况，无法实现"等后台完成再收尾"的工作流。注：Claude Code 的 Stop hook 输入不包含任何后台状态字段，本字段为 Wave 的增量能力。
+
+**独立测试**：可以通过配置 Stop hook 输出 `jq -r '.active_background_subagents'`、启动一个后台 subagent、再让主代理结束回合，验证字段值随后台 subagent 状态变化来完整测试。
+
+**验收场景**：
+
+1. **假设**主代理回合结束时没有后台 subagent 运行，**当** Stop hook 触发时，**则** JSON 输入包含 `active_background_subagents: 0`
+2. **假设**主代理回合结束时有 2 个后台 subagent 处于 active/initializing 状态，**当** Stop hook 触发时，**则** JSON 输入包含 `active_background_subagents: 2`
+3. **假设** Stop hook 检测到 `active_background_subagents > 0` 并返回退出码 2，**当** hook 完成时，**则**停止被阻止（stderr 作为用户消息注入，AI 继续对话）；后台 subagent 完成后产生的通知将重启响应周期，Stop hook 在下一轮再次触发并看到更新后的字段值
+4. **假设**后台 subagent 在 Stop hook 构造输入与 hook 进程读取输入之间完成，**当** hook 读取字段时，**则**字段值反映触发瞬间的快照状态（不要求与 hook 执行期间实时一致）
+5. **假设** SubagentStop hook（子代理自身回合结束）触发，**当**其 JSON 输入被构造时，**则**不包含 `active_background_subagents` 字段（该字段仅主 Stop 事件提供）
+
 ## 边界情况
 
 - 当 hook 命令失败或超时会发生什么？
@@ -356,6 +374,8 @@ Hook 需要访问完整的对话历史以做出上下文感知的决策。Hook �
 - **FR-060**：系统必须在 PostCompact 事件的 JSON 数据中包含包含 AI 生成摘要的 `compact_summary` 字段
 - **FR-061**：系统在压缩失败时不得执行 PostCompact hook
 - **FR-062**：系统不得要求 PreCompact 或 PostCompact hook 配置使用 matcher
+- **FR-063**：系统必须在 Stop 事件的 JSON 数据中包含 `active_background_subagents` 整数字段，指示触发瞬间处于 active/initializing 状态的后台 subagent 数量；无后台 subagent 时为 0
+- **FR-064**：系统必须在除 Stop 以外的其他 hook 事件（PreToolUse、PostToolUse、UserPromptSubmit、PermissionRequest、SubagentStop、WorktreeCreate、PreCompact、PostCompact）的 JSON 数据中**不**包含 `active_background_subagents` 字段
 
 ### 测试验证需求
 
@@ -386,6 +406,7 @@ Hook 需要访问完整的对话历史以做出上下文感知的决策。Hook �
 - **PreCompact Hook**：在对话压缩之前触发的生命周期 hook，通过 stdin JSON 接收自定义指令并通过 stdout 返回额外指令
 - **PostCompact Hook**：在成功压缩之后触发的生命周期 hook，通过 stdin JSON 接收压缩摘要
 - **压缩指令**：引导 AI 在压缩期间进行摘要的自定义文本，从用户输入和 PreCompact hook stdout 合并
+- **后台工作状态**：Stop 事件 JSON 输入中的 `active_background_subagents` 整数字段，反映触发瞬间当前 Agent 的后台 subagent（active/initializing 状态）数量快照，供 hook 决定是否通过退出码 2 阻止停止以等待后台 subagent 完成
 
 ## 成功标准 *（必填）*
 


### PR DESCRIPTION
Add active_background_subagents integer field to the Stop hook JSON
input, reflecting the count of active/initializing background subagents
at the trigger instant. This lets Stop hooks decide whether to block
stopping (exit code 2) to wait for background subagents to finish.

- Spec: add User Story 17 and FR-063/064 to specs/005-hooks.md; field
  is Stop-only (SubagentStop and other events exclude it per FR-064).
  Claude Code's Stop hook input has no background-state field, so this
  is a Wave-specific capability.
- Implementation: executeStopHooks() snapshots
  SubagentManager.getActiveInstances() filtered by backgroundTaskId;
  buildHookJsonInput() emits the field only for Stop events.
- Tests: 4 new cases in hook.test.ts (Stop with value/0, SubagentStop
  excluded, other events excluded) + 2 new cases in aiManager.test.ts
  (count from SubagentManager, 0 when none).
- AGENTS.md: add Spec-First Workflow section (update specs before code,
  confirm with user first).
