### PR TITLE
feat(hooks): align Stop hook input with Claude Code background_tasks and session_crons

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -26,8 +26,10 @@ import { ChatCompletionMessageFunctionToolCall } from "openai/resources.js";
 
 import type { HookManager } from "./hookManager.js";
 import type { ExtendedHookExecutionContext } from "../types/hooks.js";
+import type { BackgroundTaskInfo, SessionCronInfo } from "../types/hooks.js";
 import type { PermissionManager } from "./permissionManager.js";
 import type { SubagentManager } from "./subagentManager.js";
+import type { CronManager } from "./cronManager.js";
 import type { SkillManager } from "./skillManager.js";
 import { buildSystemPrompt } from "../prompts/index.js";
 import {
@@ -49,6 +51,47 @@ import {
   resetTracingState,
 } from "../telemetry/sessionTracing.js";
 import { logOTelEvent } from "../telemetry/events.js";
+import type { BackgroundTask } from "../types/processes.js";
+
+// Truncate text to `max` chars and append a "… [+N chars]" marker when exceeded.
+// Used for background_tasks description/command fields (≤1000 chars per spec FR-063).
+function truncateWithMarker(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max) + `… [+${text.length - max} chars]`;
+}
+
+// Map a BackgroundTask (from BackgroundTaskManager) to the Stop hook's
+// background_tasks array element shape (aligned with Claude Code v2.1.145+).
+// Conditional fields are populated based on task type:
+//   - shell:    `command`
+//   - subagent: `agent_type` (looked up via SubagentManager by subagentId)
+//   - workflow: `name` (extracted from "Workflow: <name>" description)
+function mapBackgroundTask(
+  task: BackgroundTask,
+  subagentManager: SubagentManager | undefined,
+): BackgroundTaskInfo {
+  const base: BackgroundTaskInfo = {
+    id: task.id,
+    type: task.type,
+    status: task.status,
+    description: truncateWithMarker(task.description ?? "", 1000),
+  };
+  if (task.type === "shell") {
+    return { ...base, command: truncateWithMarker(task.command ?? "", 1000) };
+  }
+  if (task.type === "subagent") {
+    const instance = subagentManager
+      ?.getActiveInstances()
+      .find((i) => i.subagentId === task.subagentId);
+    return { ...base, agent_type: instance?.subagentType ?? "" };
+  }
+  // workflow
+  const prefix = "Workflow: ";
+  const name = task.description?.startsWith(prefix)
+    ? task.description.slice(prefix.length)
+    : (task.description ?? "");
+  return { ...base, name };
+}
 
 export interface AIManagerCallbacks {
   onCompactionStateChange?: (isCompacting: boolean) => void;
@@ -732,6 +775,10 @@ export class AIManager {
 
   private get subagentManager(): SubagentManager | undefined {
     return this.container.get<SubagentManager>("SubagentManager");
+  }
+
+  private get cronManager(): CronManager | undefined {
+    return this.container.get<CronManager>("CronManager");
   }
 
   private get skillManager(): SkillManager | undefined {
@@ -1435,14 +1482,24 @@ export class AIManager {
       // Use "SubagentStop" hook name when triggered by a subagent, otherwise use "Stop"
       const hookName = this.subagentType ? "SubagentStop" : "Stop";
 
-      // For main-agent Stop events, snapshot the count of active/initializing
-      // background subagents so the hook can decide whether to block stopping.
-      // SubagentStop does not include this field (per spec FR-064).
-      const activeBackgroundSubagents =
+      // For main-agent Stop events, snapshot running background tasks and
+      // session cron jobs so the hook can decide whether to block stopping.
+      // SubagentStop does not include these fields (per spec FR-065).
+      const backgroundTasks: BackgroundTaskInfo[] | undefined =
         hookName === "Stop"
-          ? (this.subagentManager
-              ?.getActiveInstances()
-              .filter((instance) => instance.backgroundTaskId).length ?? 0)
+          ? (this.backgroundTaskManager?.getAllTasks() ?? [])
+              .filter((t) => t.status === "running")
+              .map((t) => mapBackgroundTask(t, this.subagentManager))
+          : undefined;
+
+      const sessionCrons: SessionCronInfo[] | undefined =
+        hookName === "Stop"
+          ? (this.cronManager?.listJobs() ?? []).map((j) => ({
+              id: j.id,
+              schedule: j.cron,
+              recurring: j.recurring,
+              prompt: j.prompt,
+            }))
           : undefined;
 
       const context: ExtendedHookExecutionContext = {
@@ -1453,7 +1510,8 @@ export class AIManager {
         transcriptPath: this.messageManager.getTranscriptPath(),
         cwd: this.getWorkdir(),
         subagentType: this.subagentType, // Include subagent type in hook context
-        activeBackgroundSubagents, // Stop-only: background subagent count snapshot
+        backgroundTasks, // Stop-only: running background tasks snapshot
+        sessionCrons, // Stop-only: session cron jobs snapshot
         // Stop hooks don't need toolName, toolInput, toolResponse, or userPrompt
         env: Object.fromEntries(
           Object.entries(process.env).filter((e) => e[1] !== undefined),

--- a/packages/agent-sdk/src/services/hook.ts
+++ b/packages/agent-sdk/src/services/hook.ts
@@ -113,12 +113,11 @@ async function buildHookJsonInput(
     }
   }
 
-  // Add active_background_subagents for Stop events only (not SubagentStop)
-  if (
-    context.event === "Stop" &&
-    context.activeBackgroundSubagents !== undefined
-  ) {
-    jsonInput.active_background_subagents = context.activeBackgroundSubagents;
+  // Add background_tasks and session_crons for Stop events only (not SubagentStop).
+  // Fields are always present for Stop (empty arrays when nothing in flight).
+  if (context.event === "Stop") {
+    jsonInput.background_tasks = context.backgroundTasks ?? [];
+    jsonInput.session_crons = context.sessionCrons ?? [];
   }
 
   return jsonInput;

--- a/packages/agent-sdk/src/types/hooks.ts
+++ b/packages/agent-sdk/src/types/hooks.ts
@@ -196,7 +196,33 @@ export interface HookJsonInput {
   end_source?: SessionEndSource; // Present for SessionEnd events
   compact_instructions?: string; // Present for PreCompact events
   compact_summary?: string; // Present for PostCompact events
-  active_background_subagents?: number; // Present for Stop events: count of active/initializing background subagents at trigger instant
+  background_tasks?: BackgroundTaskInfo[]; // Present for Stop events: running background tasks snapshot
+  session_crons?: SessionCronInfo[]; // Present for Stop events: session-scoped cron jobs snapshot
+}
+
+// Describes one in-flight background task in the Stop hook input.
+// Aligned with Claude Code (v2.1.145+) background_tasks array element schema.
+// Conditional fields are populated based on `type`:
+//   - "shell":    `command` is set
+//   - "subagent": `agent_type` is set
+//   - "workflow": `name` is set
+export interface BackgroundTaskInfo {
+  id: string;
+  type: "shell" | "subagent" | "workflow";
+  status: string;
+  description: string; // Capped at 1000 chars with "… [+N chars]" marker
+  command?: string; // Present only for shell tasks (≤1000 chars)
+  agent_type?: string; // Present only for subagent tasks
+  name?: string; // Present only for workflow tasks
+}
+
+// Describes one session-scoped cron job in the Stop hook input.
+// Aligned with Claude Code (v2.1.145+) session_crons array element schema.
+export interface SessionCronInfo {
+  id: string;
+  schedule: string; // Cron expression
+  recurring: boolean;
+  prompt: string;
 }
 
 // Extended context interface for passing additional data to hook executor
@@ -217,7 +243,8 @@ export interface ExtendedHookExecutionContext extends HookExecutionContext {
   endSource?: SessionEndSource; // Session end source (SessionEnd only)
   compactInstructions?: string; // Custom instructions for PreCompact
   compactSummary?: string; // Summary text for PostCompact
-  activeBackgroundSubagents?: number; // Count of active/initializing background subagents (Stop only)
+  backgroundTasks?: BackgroundTaskInfo[]; // Running background tasks snapshot (Stop only)
+  sessionCrons?: SessionCronInfo[]; // Session-scoped cron jobs snapshot (Stop only)
 }
 
 // Environment variables injected into hook processes

--- a/packages/agent-sdk/tests/managers/aiManager.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.test.ts
@@ -1213,8 +1213,8 @@ describe("AIManager", () => {
     });
   });
 
-  describe("Stop hook active_background_subagents (User Story 17)", () => {
-    it("should inject active_background_subagents count from SubagentManager into Stop hook context", async () => {
+  describe("Stop hook background_tasks and session_crons (User Story 17)", () => {
+    it("should inject background_tasks from BackgroundTaskManager and session_crons from CronManager into Stop hook context", async () => {
       const taskManager = {
         on: vi.fn(),
         listTasks: vi.fn().mockResolvedValue([]),
@@ -1259,13 +1259,56 @@ describe("AIManager", () => {
         setNeedsPlanModeExitAttachment: vi.fn(),
         getNeedsPlanModeExitAttachment: vi.fn(() => false),
       } as unknown as Record<string, unknown>);
-      // SubagentManager with 2 background + 1 foreground instance
+      // BackgroundTaskManager: 3 running tasks (shell+subagent+workflow) + 1 completed (filtered out)
+      container.register("BackgroundTaskManager", {
+        getAllTasks: vi.fn().mockReturnValue([
+          {
+            id: "task-shell-1",
+            type: "shell",
+            status: "running",
+            command: "tail -f /var/log/syslog",
+            description: undefined,
+          },
+          {
+            id: "task-sub-1",
+            type: "subagent",
+            status: "running",
+            subagentId: "sub-1",
+            description: "refactor module",
+          },
+          {
+            id: "task-wf-1",
+            type: "workflow",
+            status: "running",
+            description: "Workflow: audit",
+            runId: "run-1",
+          },
+          {
+            id: "task-done-1",
+            type: "shell",
+            status: "completed",
+            command: "echo done",
+          },
+        ]),
+      });
+      // SubagentManager: one active instance matching task-sub-1's subagentId
       container.register("SubagentManager", {
         getConfigurations: vi.fn().mockReturnValue([]),
-        getActiveInstances: vi.fn().mockReturnValue([
-          { backgroundTaskId: "task-1" }, // background subagent
-          { backgroundTaskId: undefined }, // foreground subagent (not counted)
-          { backgroundTaskId: "task-2" }, // background subagent
+        getActiveInstances: vi
+          .fn()
+          .mockReturnValue([
+            { subagentId: "sub-1", subagentType: "general-purpose" },
+          ]),
+      });
+      // CronManager: one job
+      container.register("CronManager", {
+        listJobs: vi.fn().mockReturnValue([
+          {
+            id: "cron-001",
+            cron: "0 9 * * 1-5",
+            recurring: true,
+            prompt: "check the build",
+          },
         ]),
       });
       container.register("SkillManager", {
@@ -1282,18 +1325,49 @@ describe("AIManager", () => {
 
       await testAIManager.sendAIMessage();
 
-      // Stop hook should have been called with active_background_subagents = 2
-      // (only instances with backgroundTaskId count)
+      // Stop hook should receive background_tasks with 3 running tasks
+      // (completed task filtered out), with per-type conditional fields,
+      // and session_crons with 1 cron job.
       expect(mockHookManager.executeHooks).toHaveBeenCalledWith(
         "Stop",
         expect.objectContaining({
           event: "Stop",
-          activeBackgroundSubagents: 2,
+          backgroundTasks: [
+            {
+              id: "task-shell-1",
+              type: "shell",
+              status: "running",
+              description: "",
+              command: "tail -f /var/log/syslog",
+            },
+            {
+              id: "task-sub-1",
+              type: "subagent",
+              status: "running",
+              description: "refactor module",
+              agent_type: "general-purpose",
+            },
+            {
+              id: "task-wf-1",
+              type: "workflow",
+              status: "running",
+              description: "Workflow: audit",
+              name: "audit",
+            },
+          ],
+          sessionCrons: [
+            {
+              id: "cron-001",
+              schedule: "0 9 * * 1-5",
+              recurring: true,
+              prompt: "check the build",
+            },
+          ],
         }),
       );
     });
 
-    it("should inject active_background_subagents: 0 when no background subagents running", async () => {
+    it("should inject empty background_tasks and session_crons when nothing in flight", async () => {
       const taskManager = {
         on: vi.fn(),
         listTasks: vi.fn().mockResolvedValue([]),
@@ -1338,7 +1412,97 @@ describe("AIManager", () => {
         setNeedsPlanModeExitAttachment: vi.fn(),
         getNeedsPlanModeExitAttachment: vi.fn(() => false),
       } as unknown as Record<string, unknown>);
-      // No active subagents at all
+      // No background tasks
+      container.register("BackgroundTaskManager", {
+        getAllTasks: vi.fn().mockReturnValue([]),
+      });
+      container.register("SubagentManager", {
+        getConfigurations: vi.fn().mockReturnValue([]),
+        getActiveInstances: vi.fn().mockReturnValue([]),
+      });
+      // No CronManager registered → cronManager getter returns undefined
+      container.register("SkillManager", {
+        getAvailableSkills: vi.fn().mockReturnValue([]),
+      });
+      container.register("NotificationQueue", mockNotificationQueue);
+      container.register("HookManager", mockHookManager);
+      container.register("AgentOptions", { callbacks: {} });
+
+      const testAIManager = new AIManager(container, {
+        workdir: "/test/workdir",
+        stream: false,
+      });
+
+      await testAIManager.sendAIMessage();
+
+      expect(mockHookManager.executeHooks).toHaveBeenCalledWith(
+        "Stop",
+        expect.objectContaining({
+          event: "Stop",
+          backgroundTasks: [],
+          sessionCrons: [],
+        }),
+      );
+    });
+
+    it("should truncate shell command exceeding 1000 chars with marker", async () => {
+      const taskManager = {
+        on: vi.fn(),
+        listTasks: vi.fn().mockResolvedValue([]),
+      } as unknown as TaskManager;
+
+      const mockNotificationQueue = {
+        hasPending: vi.fn().mockReturnValue(false),
+      };
+
+      const mockHookManager = {
+        executeHooks: vi.fn().mockResolvedValue([]),
+        processHookResults: vi.fn().mockReturnValue({
+          shouldBlock: false,
+          errorMessage: "",
+        }),
+        hasHooks: vi.fn().mockReturnValue(true),
+      };
+
+      const longCommand = "a".repeat(1500);
+
+      const container = new Container();
+      container.register("ConfigurationService", {
+        resolveGatewayConfig: vi.fn().mockReturnValue(mockGatewayConfig),
+        resolveModelConfig: vi.fn().mockReturnValue(mockModelConfig),
+        resolveMaxInputTokens: vi.fn().mockReturnValue(96000),
+        resolveAutoMemoryEnabled: vi.fn().mockReturnValue(false),
+        resolveLanguage: vi.fn().mockReturnValue(undefined),
+      });
+      container.register("MessageManager", mockMessageManager);
+      container.register("ToolManager", mockToolManager);
+      container.register("TaskManager", taskManager);
+      container.register("MemoryService", {
+        getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+        getAutoMemoryDirectory: vi.fn().mockReturnValue("/mock/auto-memory"),
+        ensureAutoMemoryDirectory: vi.fn().mockResolvedValue(undefined),
+        getAutoMemoryContent: vi.fn().mockResolvedValue(""),
+      });
+      container.register("PermissionManager", {
+        getCurrentEffectiveMode: vi.fn().mockReturnValue("normal"),
+        clearTemporaryRules: vi.fn(),
+        getPlanFilePath: vi.fn().mockReturnValue(undefined),
+        setHasExitedPlanMode: vi.fn(),
+        hasExitedPlanModeInSession: vi.fn(() => false),
+        setNeedsPlanModeExitAttachment: vi.fn(),
+        getNeedsPlanModeExitAttachment: vi.fn(() => false),
+      } as unknown as Record<string, unknown>);
+      container.register("BackgroundTaskManager", {
+        getAllTasks: vi.fn().mockReturnValue([
+          {
+            id: "task-long",
+            type: "shell",
+            status: "running",
+            command: longCommand,
+            description: undefined,
+          },
+        ]),
+      });
       container.register("SubagentManager", {
         getConfigurations: vi.fn().mockReturnValue([]),
         getActiveInstances: vi.fn().mockReturnValue([]),
@@ -1357,13 +1521,10 @@ describe("AIManager", () => {
 
       await testAIManager.sendAIMessage();
 
-      expect(mockHookManager.executeHooks).toHaveBeenCalledWith(
-        "Stop",
-        expect.objectContaining({
-          event: "Stop",
-          activeBackgroundSubagents: 0,
-        }),
-      );
+      const callArgs = vi.mocked(mockHookManager.executeHooks).mock.calls[0][1];
+      const task = callArgs.backgroundTasks?.[0];
+      expect(task?.command).toBe("a".repeat(1000) + "… [+500 chars]");
+      expect(task?.command?.length).toBe(1000 + "… [+500 chars]".length);
     });
   });
 

--- a/packages/agent-sdk/tests/services/hook.test.ts
+++ b/packages/agent-sdk/tests/services/hook.test.ts
@@ -839,8 +839,8 @@ describe("Hook Services", () => {
     });
   });
 
-  describe("Stop hook active_background_subagents", () => {
-    it("should include active_background_subagents for Stop event when provided", async () => {
+  describe("Stop hook background_tasks and session_crons", () => {
+    it("should include background_tasks and session_crons for Stop event when provided", async () => {
       const mockProcess = new MockChildProcess();
       const mockStdin = new MockStdin();
       let stdinData = "";
@@ -864,7 +864,37 @@ describe("Hook Services", () => {
         sessionId: "test-session-123",
         transcriptPath: "/path/to/transcript.json",
         cwd: "/test/project",
-        activeBackgroundSubagents: 2,
+        backgroundTasks: [
+          {
+            id: "task-001",
+            type: "shell",
+            status: "running",
+            description: "tail logs",
+            command: "tail -f /var/log/syslog",
+          },
+          {
+            id: "task-002",
+            type: "subagent",
+            status: "running",
+            description: "refactor module",
+            agent_type: "general-purpose",
+          },
+          {
+            id: "task-003",
+            type: "workflow",
+            status: "running",
+            description: "Workflow: audit",
+            name: "audit",
+          },
+        ],
+        sessionCrons: [
+          {
+            id: "cron-001",
+            schedule: "0 9 * * 1-5",
+            recurring: true,
+            prompt: "check the build",
+          },
+        ],
       };
 
       const resultPromise = executeCommand("echo test", stopContext);
@@ -878,10 +908,40 @@ describe("Hook Services", () => {
       expect(stdinData).toBeTruthy();
       const parsedInput = JSON.parse(stdinData);
       expect(parsedInput.hook_event_name).toBe("Stop");
-      expect(parsedInput.active_background_subagents).toBe(2);
+      expect(parsedInput.background_tasks).toEqual([
+        {
+          id: "task-001",
+          type: "shell",
+          status: "running",
+          description: "tail logs",
+          command: "tail -f /var/log/syslog",
+        },
+        {
+          id: "task-002",
+          type: "subagent",
+          status: "running",
+          description: "refactor module",
+          agent_type: "general-purpose",
+        },
+        {
+          id: "task-003",
+          type: "workflow",
+          status: "running",
+          description: "Workflow: audit",
+          name: "audit",
+        },
+      ]);
+      expect(parsedInput.session_crons).toEqual([
+        {
+          id: "cron-001",
+          schedule: "0 9 * * 1-5",
+          recurring: true,
+          prompt: "check the build",
+        },
+      ]);
     });
 
-    it("should include active_background_subagents: 0 for Stop event when no background subagents", async () => {
+    it("should include empty background_tasks and session_crons arrays for Stop event when nothing in flight", async () => {
       const mockProcess = new MockChildProcess();
       const mockStdin = new MockStdin();
       let stdinData = "";
@@ -905,7 +965,8 @@ describe("Hook Services", () => {
         sessionId: "test-session-123",
         transcriptPath: "/path/to/transcript.json",
         cwd: "/test/project",
-        activeBackgroundSubagents: 0,
+        backgroundTasks: [],
+        sessionCrons: [],
       };
 
       const resultPromise = executeCommand("echo test", stopContext);
@@ -917,10 +978,11 @@ describe("Hook Services", () => {
       await resultPromise;
 
       const parsedInput = JSON.parse(stdinData);
-      expect(parsedInput.active_background_subagents).toBe(0);
+      expect(parsedInput.background_tasks).toEqual([]);
+      expect(parsedInput.session_crons).toEqual([]);
     });
 
-    it("should NOT include active_background_subagents for SubagentStop event", async () => {
+    it("should NOT include background_tasks and session_crons for SubagentStop event", async () => {
       const mockProcess = new MockChildProcess();
       const mockStdin = new MockStdin();
       let stdinData = "";
@@ -945,8 +1007,19 @@ describe("Hook Services", () => {
         transcriptPath: "/path/to/transcript.json",
         cwd: "/test/project",
         subagentType: "general-purpose",
-        // Even if provided, SubagentStop must not include this field
-        activeBackgroundSubagents: 1,
+        // Even if provided, SubagentStop must not include these fields
+        backgroundTasks: [
+          {
+            id: "task-001",
+            type: "subagent",
+            status: "running",
+            description: "x",
+            agent_type: "general-purpose",
+          },
+        ],
+        sessionCrons: [
+          { id: "c1", schedule: "0 9 * * *", recurring: true, prompt: "p" },
+        ],
       };
 
       const resultPromise = executeCommand("echo test", subagentStopContext);
@@ -959,10 +1032,11 @@ describe("Hook Services", () => {
 
       const parsedInput = JSON.parse(stdinData);
       expect(parsedInput.hook_event_name).toBe("SubagentStop");
-      expect(parsedInput.active_background_subagents).toBeUndefined();
+      expect(parsedInput.background_tasks).toBeUndefined();
+      expect(parsedInput.session_crons).toBeUndefined();
     });
 
-    it("should NOT include active_background_subagents for other hook events", async () => {
+    it("should NOT include background_tasks and session_crons for other hook events", async () => {
       const mockProcess = new MockChildProcess();
       const mockStdin = new MockStdin();
       let stdinData = "";
@@ -987,8 +1061,19 @@ describe("Hook Services", () => {
         transcriptPath: "/path/to/transcript.json",
         cwd: "/test/project",
         toolName: "Read",
-        // Even if provided, non-Stop events must not include this field
-        activeBackgroundSubagents: 3,
+        // Even if provided, non-Stop events must not include these fields
+        backgroundTasks: [
+          {
+            id: "task-001",
+            type: "shell",
+            status: "running",
+            description: "x",
+            command: "echo hi",
+          },
+        ],
+        sessionCrons: [
+          { id: "c1", schedule: "0 9 * * *", recurring: true, prompt: "p" },
+        ],
       };
 
       const resultPromise = executeCommand("echo test", postToolContext);
@@ -1001,7 +1086,8 @@ describe("Hook Services", () => {
 
       const parsedInput = JSON.parse(stdinData);
       expect(parsedInput.hook_event_name).toBe("PostToolUse");
-      expect(parsedInput.active_background_subagents).toBeUndefined();
+      expect(parsedInput.background_tasks).toBeUndefined();
+      expect(parsedInput.session_crons).toBeUndefined();
     });
   });
 });

--- a/specs/005-hooks.md
+++ b/specs/005-hooks.md
@@ -285,19 +285,23 @@ Hook 需要访问完整的对话历史以做出上下文感知的决策。Hook �
 
 ### 用户故事 17 - Stop Hook 后台工作感知（优先级：P3）
 
-作为开发者，我希望 Stop hook 触发时能通过 JSON 输入得知有多少后台 subagent 仍在运行，以便决定是否通过退出码 2 阻止停止以等待后台 subagent 完成，或执行相应的清理、通知、日志逻辑。字段值同时隐含"是否有"（0 即无）信息。
+作为开发者，我希望 Stop hook 触发时能通过 JSON 输入得知当前还有哪些后台任务（shell 命令、后台 subagent、后台 workflow）和会话级定时任务（cron）在运行，以便决定是否通过退出码 2 阻止停止以等待后台工作完成，或执行相应的清理、通知、日志逻辑。字段对齐 Claude Code（v2.1.145+）的 Stop hook 输入格式。
 
-**为什么是这个优先级**：Stop hook 默认在主代理回合结束的瞬间触发，不等待异步后台 subagent。没有该字段时，hook 无法区分"所有工作已结束"与"仍有后台 subagent 在跑"两种情况，无法实现"等后台完成再收尾"的工作流。注：Claude Code 的 Stop hook 输入不包含任何后台状态字段，本字段为 Wave 的增量能力。
+**为什么是这个优先级**：Stop hook 默认在主代理回合结束的瞬间触发，不等待异步后台任务（bash 工具的 `run_in_background`、后台 subagent、后台 workflow），也不反映尚未触发的 cron 任务。没有这两个字段时，hook 无法区分"所有工作已结束"与"仍有后台工作在跑/等待唤醒"两种情况，无法实现"等后台完成再收尾"或"有定时任务在等就不收尾"的工作流。Claude Code 在 Stop hook 输入中提供 `background_tasks` 和 `session_crons` 两个数组字段，本特性对齐该设计。
 
-**独立测试**：可以通过配置 Stop hook 输出 `jq -r '.active_background_subagents'`、启动一个后台 subagent、再让主代理结束回合，验证字段值随后台 subagent 状态变化来完整测试。
+**独立测试**：可以通过配置 Stop hook 输出 `jq -c '.background_tasks, .session_crons'`、启动一个后台 bash 命令、一个后台 subagent、一个后台 workflow 和一个 cron 任务、再让主代理结束回合，验证两个数组内容随后台/cron 状态变化来完整测试。
 
 **验收场景**：
 
-1. **假设**主代理回合结束时没有后台 subagent 运行，**当** Stop hook 触发时，**则** JSON 输入包含 `active_background_subagents: 0`
-2. **假设**主代理回合结束时有 2 个后台 subagent 处于 active/initializing 状态，**当** Stop hook 触发时，**则** JSON 输入包含 `active_background_subagents: 2`
-3. **假设** Stop hook 检测到 `active_background_subagents > 0` 并返回退出码 2，**当** hook 完成时，**则**停止被阻止（stderr 作为用户消息注入，AI 继续对话）；后台 subagent 完成后产生的通知将重启响应周期，Stop hook 在下一轮再次触发并看到更新后的字段值
-4. **假设**后台 subagent 在 Stop hook 构造输入与 hook 进程读取输入之间完成，**当** hook 读取字段时，**则**字段值反映触发瞬间的快照状态（不要求与 hook 执行期间实时一致）
-5. **假设** SubagentStop hook（子代理自身回合结束）触发，**当**其 JSON 输入被构造时，**则**不包含 `active_background_subagents` 字段（该字段仅主 Stop 事件提供）
+1. **假设**主代理回合结束时没有后台任务运行、也没有 cron 任务，**当** Stop hook 触发时，**则** JSON 输入包含 `background_tasks: []` 和 `session_crons: []`（空数组，字段始终存在）
+2. **假设**主代理回合结束时有一个后台 subagent 在运行，**当** Stop hook 触发时，**则** JSON 输入的 `background_tasks` 数组包含 1 个元素，其 `type` 为 `"subagent"`、`status` 为 `"running"`、`agent_type` 为该 subagent 的类型、`description` 为其描述
+3. **假设**主代理回合结束时有一个后台 bash 命令在运行（`run_in_background` 或超时自动转入后台），**当** Stop hook 触发时，**则** JSON 输入的 `background_tasks` 数组包含 1 个元素，其 `type` 为 `"shell"`、`status` 为 `"running"`、`command` 为该命令行、不含 `agent_type`/`name` 字段
+4. **假设**主代理回合结束时有一个后台 workflow 在运行，**当** Stop hook 触发时，**则** JSON 输入的 `background_tasks` 数组包含 1 个元素，其 `type` 为 `"workflow"`、`status` 为 `"running"`、`name` 为该 workflow 名称、不含 `command`/`agent_type` 字段
+5. **假设**主代理回合结束时有 1 个 cron 任务（recurring 或 one-shot），**当** Stop hook 触发时，**则** JSON 输入的 `session_crons` 数组包含 1 个元素，其 `id`、`schedule`（cron 表达式）、`recurring`、`prompt` 字段对应该任务
+6. **假设** Stop hook 检测到 `background_tasks` 非空并返回退出码 2，**当** hook 完成时，**则**停止被阻止（stderr 作为用户消息注入，AI 继续对话）；后台任务完成后产生的通知将重启响应周期，Stop hook 在下一轮再次触发并看到更新后的 `background_tasks` 数组
+7. **假设**后台任务在 Stop hook 构造输入与 hook 进程读取输入之间完成，**当** hook 读取字段时，**则**数组反映触发瞬间的快照状态（不要求与 hook 执行期间实时一致）；已完成（`completed`/`failed`/`killed`）的任务不出现在数组中
+8. **假设** SubagentStop hook（子代理自身回合结束）触发，**当**其 JSON 输入被构造时，**则**不包含 `background_tasks` 和 `session_crons` 字段（这两个字段仅主 Stop 事件提供；子代理作用域内无独立后台/cron 概念）
+9. **假设**某个后台任务的 `description` 或 `command` 超过 1000 字符，**当**构造 `background_tasks` 数组时，**则**该字段被截断至 1000 字符并以 `… [+N chars]` 标记被裁剪的字符数
 
 ## 边界情况
 
@@ -374,8 +378,9 @@ Hook 需要访问完整的对话历史以做出上下文感知的决策。Hook �
 - **FR-060**：系统必须在 PostCompact 事件的 JSON 数据中包含包含 AI 生成摘要的 `compact_summary` 字段
 - **FR-061**：系统在压缩失败时不得执行 PostCompact hook
 - **FR-062**：系统不得要求 PreCompact 或 PostCompact hook 配置使用 matcher
-- **FR-063**：系统必须在 Stop 事件的 JSON 数据中包含 `active_background_subagents` 整数字段，指示触发瞬间处于 active/initializing 状态的后台 subagent 数量；无后台 subagent 时为 0
-- **FR-064**：系统必须在除 Stop 以外的其他 hook 事件（PreToolUse、PostToolUse、UserPromptSubmit、PermissionRequest、SubagentStop、WorktreeCreate、PreCompact、PostCompact）的 JSON 数据中**不**包含 `active_background_subagents` 字段
+- **FR-063**：系统必须在 Stop 事件的 JSON 数据中包含 `background_tasks` 数组字段，对齐 Claude Code（v2.1.145+）的 Stop hook 输入格式。数组数据源为 `BackgroundTaskManager` 中所有 `status === "running"` 的任务（涵盖三种后台任务：bash 工具 `run_in_background`/超时自动后台产生的 `shell`、后台 subagent 产生的 `subagent`、后台 workflow 产生的 `workflow`）。每个元素包含公共字段 `id`、`type`（`"shell"` | `"subagent"` | `"workflow"`）、`status`（`"running"`）、`description`（≤1000 字符，超出以 `… [+N chars]` 标记）；并按 `type` 附带条件字段：`shell` 附带 `command`（≤1000 字符，同截断规则）、`subagent` 附带 `agent_type`（通过 `subagentId` 在 `SubagentManager` 中查到的 subagent 类型）、`workflow` 附带 `name`（从 description 中提取的 workflow 名称）。无运行中后台任务时为空数组 `[]`。字段始终存在（非 undefined）
+- **FR-064**：系统必须在 Stop 事件的 JSON 数据中包含 `session_crons` 数组字段，对齐 Claude Code（v2.1.145+）的 Stop hook 输入格式。数组数据源为 `CronManager.listJobs()`，每个元素描述一个会话级 cron 任务，包含以下字段：`id`、`schedule`（cron 表达式）、`recurring`（布尔）、`prompt`（触发时注入的提示文本）。无 cron 任务时为空数组 `[]`。字段始终存在（非 undefined）
+- **FR-065**：系统必须在除 Stop 以外的其他 hook 事件（PreToolUse、PostToolUse、UserPromptSubmit、PermissionRequest、SubagentStop、WorktreeCreate、PreCompact、PostCompact）的 JSON 数据中**不**包含 `background_tasks` 和 `session_crons` 字段
 
 ### 测试验证需求
 
@@ -406,7 +411,8 @@ Hook 需要访问完整的对话历史以做出上下文感知的决策。Hook �
 - **PreCompact Hook**：在对话压缩之前触发的生命周期 hook，通过 stdin JSON 接收自定义指令并通过 stdout 返回额外指令
 - **PostCompact Hook**：在成功压缩之后触发的生命周期 hook，通过 stdin JSON 接收压缩摘要
 - **压缩指令**：引导 AI 在压缩期间进行摘要的自定义文本，从用户输入和 PreCompact hook stdout 合并
-- **后台工作状态**：Stop 事件 JSON 输入中的 `active_background_subagents` 整数字段，反映触发瞬间当前 Agent 的后台 subagent（active/initializing 状态）数量快照，供 hook 决定是否通过退出码 2 阻止停止以等待后台 subagent 完成
+- **后台工作状态**：Stop 事件 JSON 输入中的 `background_tasks` 数组字段，对齐 Claude Code（v2.1.145+）。数据源为 `BackgroundTaskManager` 中所有 `status === "running"` 的任务，涵盖三种后台任务类型：`shell`（bash 工具后台运行，含 `command`）、`subagent`（后台子代理，含 `agent_type`）、`workflow`（后台工作流，含 `name`）。每个元素含公共字段 `id`/`type`/`status`/`description`，供 hook 决定是否通过退出码 2 阻止停止以等待后台任务完成
+- **会话定时任务状态**：Stop 事件 JSON 输入中的 `session_crons` 数组字段，对齐 Claude Code（v2.1.145+）。每个元素描述一个会话级 cron 任务（含 `id`/`schedule`/`recurring`/`prompt`），让 hook 区分"session 真结束了"与"session 暂停等待定时唤醒"
 
 ## 成功标准 *（必填）*
 


### PR DESCRIPTION
Replace the single integer `active_background_subagents` field (added in b2717442) with two array fields matching Claude Code (v2.1.145+) Stop hook input schema: `background_tasks` and `session_crons`.

## Context

The previous commit (b2717442) added `active_background_subagents` (an integer) to the Stop hook input and claimed "Claude Code's Stop hook input has no background-state field, so this is a Wave-specific capability." This claim was **wrong**: Claude Code (v2.1.145+) provides `background_tasks` and `session_crons` **arrays** in its Stop hook input — strictly more capable than a single count (per-task type/status/description, plus pending cron list).

This PR aligns Wave with Claude Code. A key correction: `background_tasks` is sourced from `BackgroundTaskManager` (covering all 3 background task types: `shell`, `subagent`, `workflow`), not just `SubagentManager` — so bash `run_in_background` commands and background workflows now appear, which were previously invisible.

## Changes

- **Spec** (`specs/005-hooks.md`): rewrite User Story 17, FR-063/064/065, and key entities. `background_tasks` sourced from `BackgroundTaskManager` filtered to `status === "running"`, supporting 3 types with conditional fields (`command` for shell, `agent_type` for subagent, `name` for workflow).
- **Types** (`types/hooks.ts`): remove `active_background_subagents`/`activeBackgroundSubagents`; add `BackgroundTaskInfo` and `SessionCronInfo` interfaces plus the snake_case fields on `HookJsonInput` and camelCase counterparts on `ExtendedHookExecutionContext`.
- **hook.ts**: `buildHookJsonInput` emits both arrays for Stop events only, always present (empty `[]` when nothing in flight).
- **aiManager.ts**: add `cronManager` getter; `executeStopHooks` builds `background_tasks` from `backgroundTaskManager.getAllTasks()` filtered to running, mapped per type via `mapBackgroundTask()` helper (subagent `agent_type` looked up via `SubagentManager` by `subagentId`; workflow `name` extracted from "Workflow: <name>" description). `session_crons` from `cronManager.listJobs()`. Add `truncateWithMarker()` helper for 1000-char cap with `… [+N chars]` marker.
- **Tests**: rewrite 4 cases in `hook.test.ts` (populated arrays with shell+subagent+workflow / empty arrays / SubagentStop excluded / PostToolUse excluded) and 2+1 cases in `aiManager.test.ts` (3 running task types + completed filtered + per-type fields / empty arrays when nothing in flight / command truncation at 1000 chars).

## Verification

- `pnpm -F wave-agent-sdk build` ✓
- `pnpm run type-check` ✓ (all packages)
- `pnpm -F wave-agent-sdk test tests/services/hook.test.ts` ✓ (30/30)
- `pnpm -F wave-agent-sdk test tests/managers/aiManager.test.ts` ✓ (27/27)
- `pnpm -F wave-agent-sdk test` ✓ (3230 passed, 1 skipped)
- Grep confirms no remaining `active_background_subagents` / `activeBackgroundSubagents` references in `packages/`.