### PR TITLE
fix: explicitly resolve bash/zsh shell & align Windows Git Bash detection with Claude Code

### DIFF
--- a/packages/agent-sdk/src/managers/backgroundTaskManager.ts
+++ b/packages/agent-sdk/src/managers/backgroundTaskManager.ts
@@ -7,6 +7,7 @@ import { stripAnsiColors } from "../utils/stringUtils.js";
 import { logger } from "../utils/globalLogger.js";
 import { Container } from "../utils/container.js";
 import { NotificationQueue } from "./notificationQueue.js";
+import { resolveShellPath } from "../utils/shellResolver.js";
 
 export interface BackgroundTaskManagerCallbacks {
   onBackgroundTasksChange?: (tasks: BackgroundTask[]) => void;
@@ -69,7 +70,7 @@ export class BackgroundTaskManager {
     const startTime = Date.now();
 
     const child = spawn(command, {
-      shell: true,
+      shell: resolveShellPath() ?? true,
       stdio: "pipe",
       detached: true,
       cwd: this.workdir,

--- a/packages/agent-sdk/src/managers/bangManager.ts
+++ b/packages/agent-sdk/src/managers/bangManager.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess } from "child_process";
 import type { MessageManager } from "./messageManager.js";
 import { Container } from "../utils/container.js";
+import { resolveShellPath } from "../utils/shellResolver.js";
 
 export interface BangManagerOptions {
   workdir: string;
@@ -45,7 +46,7 @@ export class BangManager {
 
     return new Promise<number>((resolve) => {
       const child = spawn(command, {
-        shell: true,
+        shell: resolveShellPath() ?? true,
         stdio: "pipe",
         cwd: this.workdir,
         env: {

--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -173,14 +173,16 @@ The working directory persists between commands. Try to maintain your current wo
       };
     }
 
-    // Resolve shell path: on Windows, use Git Bash; on other platforms, use default
+    // Resolve shell path: on Windows, use Git Bash; on macOS/Linux, use bash or zsh
     const shellPath = resolveShellPath();
-    if (process.platform === "win32" && !shellPath) {
+    if (!shellPath) {
       return {
         success: false,
         content: "",
         error:
-          "Git Bash not found. Please install Git for Windows or set GIT_BASH_PATH environment variable.",
+          process.platform === "win32"
+            ? "Git Bash not found. Please install Git for Windows or set GIT_BASH_PATH environment variable."
+            : "No suitable shell found. Please ensure bash or zsh is installed, or set WAVE_SHELL environment variable.",
       };
     }
 
@@ -273,7 +275,7 @@ The working directory persists between commands. Try to maintain your current wo
       );
 
       const child: ChildProcess = spawn(wrappedCommand, {
-        shell: shellPath || true,
+        shell: shellPath,
         stdio: "pipe",
         detached: true,
         cwd: context.workdir,

--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -181,7 +181,7 @@ The working directory persists between commands. Try to maintain your current wo
         content: "",
         error:
           process.platform === "win32"
-            ? "Git Bash not found. Please install Git for Windows or set GIT_BASH_PATH environment variable."
+            ? "Git Bash not found. Please install Git for Windows or set WAVE_GIT_BASH_PATH environment variable."
             : "No suitable shell found. Please ensure bash or zsh is installed, or set WAVE_SHELL environment variable.",
       };
     }

--- a/packages/agent-sdk/src/utils/shellResolver.ts
+++ b/packages/agent-sdk/src/utils/shellResolver.ts
@@ -1,9 +1,16 @@
 import fs from "fs";
 import path from "path";
+import { execFileSync } from "child_process";
 
 export const WINDOWS_GIT_BASH_PATHS = [
   "C:\\Program Files\\Git\\bin\\bash.exe",
   "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
+];
+
+// Common git.exe locations (checked before falling back to `where.exe`).
+const WINDOWS_GIT_EXE_PATHS = [
+  "C:\\Program Files\\Git\\cmd\\git.exe",
+  "C:\\Program Files (x86)\\Git\\cmd\\git.exe",
 ];
 
 // Common directories where bash/zsh may live, used as fallback after PATH lookup.
@@ -39,6 +46,49 @@ function which(command: string): string | undefined {
 
 function isSupportedShell(shellPath: string): boolean {
   return shellPath.includes("bash") || shellPath.includes("zsh");
+}
+
+/**
+ * Locate the `git` executable on Windows, then infer bash.exe from it.
+ * Checks common Git for Windows install locations first, then falls back
+ * to `where.exe git` (aligned with Claude Code's findExecutable('git')).
+ * Returns the inferred bash.exe path, or undefined if not found.
+ */
+function inferGitBashFromGit(): string | undefined {
+  // 1. Common git.exe locations
+  let gitExe: string | undefined;
+  for (const candidate of WINDOWS_GIT_EXE_PATHS) {
+    if (fs.existsSync(candidate)) {
+      gitExe = candidate;
+      break;
+    }
+  }
+
+  // 2. Fallback: where.exe git
+  if (!gitExe) {
+    try {
+      const result = execFileSync("where", ["git"], {
+        stdio: "pipe",
+        encoding: "utf8",
+        timeout: 3000,
+      }).trim();
+      // where.exe may return multiple lines; take the first non-empty one.
+      gitExe = result.split(/\r?\n/).find((line) => line.trim()) || undefined;
+    } catch {
+      gitExe = undefined;
+    }
+  }
+
+  if (!gitExe) return undefined;
+
+  // git.exe is at <install>/cmd/git.exe → bash.exe is at <install>/bin/bash.exe
+  // join treats git.exe as a segment, so ".." cancels it (→ cmd dir),
+  // the second ".." cancels cmd (→ <install>), then bin/bash.exe.
+  const bashPath = path.win32.join(gitExe, "..", "..", "bin", "bash.exe");
+  if (fs.existsSync(bashPath)) {
+    return bashPath;
+  }
+  return undefined;
 }
 
 /**
@@ -94,26 +144,46 @@ function resolveUnixShell(): string | undefined {
   return candidates.find((candidate) => isExecutable(candidate));
 }
 
+/**
+ * Resolve the Git Bash path on Windows.
+ *
+ * Priority (aligned with Claude Code's findGitBashPath):
+ *   1. WAVE_GIT_BASH_PATH env var
+ *   2. Infer from `git` executable location (<git dir>/../../bin/bash.exe)
+ *   3. Common install paths (C:\Program Files\Git\bin\bash.exe, etc.)
+ */
+function resolveWindowsShell(): string | undefined {
+  // 1. Env var override
+  if (process.env.WAVE_GIT_BASH_PATH) {
+    return process.env.WAVE_GIT_BASH_PATH;
+  }
+
+  // 2. Infer from git executable location
+  const inferred = inferGitBashFromGit();
+  if (inferred) {
+    return inferred;
+  }
+
+  // 4. Common install paths
+  const paths = [
+    ...WINDOWS_GIT_BASH_PATHS,
+    process.env.LOCALAPPDATA
+      ? `${process.env.LOCALAPPDATA}\\Programs\\Git\\bin\\bash.exe`
+      : null,
+  ].filter(Boolean) as string[];
+
+  for (const p of paths) {
+    if (fs.existsSync(p)) {
+      return p;
+    }
+  }
+
+  return undefined;
+}
+
 export function resolveShellPath(): string | undefined {
   if (process.platform === "win32") {
-    if (process.env.GIT_BASH_PATH) {
-      return process.env.GIT_BASH_PATH;
-    }
-
-    const paths = [
-      ...WINDOWS_GIT_BASH_PATHS,
-      process.env.LOCALAPPDATA
-        ? `${process.env.LOCALAPPDATA}\\Programs\\Git\\bin\\bash.exe`
-        : null,
-    ].filter(Boolean) as string[];
-
-    for (const p of paths) {
-      if (fs.existsSync(p)) {
-        return p;
-      }
-    }
-
-    return undefined;
+    return resolveWindowsShell();
   }
 
   return resolveUnixShell();

--- a/packages/agent-sdk/src/utils/shellResolver.ts
+++ b/packages/agent-sdk/src/utils/shellResolver.ts
@@ -1,31 +1,120 @@
 import fs from "fs";
+import path from "path";
 
 export const WINDOWS_GIT_BASH_PATHS = [
   "C:\\Program Files\\Git\\bin\\bash.exe",
   "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
 ];
 
+// Common directories where bash/zsh may live, used as fallback after PATH lookup.
+const FIXED_SHELL_DIRS = [
+  "/bin",
+  "/usr/bin",
+  "/usr/local/bin",
+  "/opt/homebrew/bin",
+];
+
+function isExecutable(shellPath: string): boolean {
+  try {
+    fs.accessSync(shellPath, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve a command name (e.g. "bash") to an absolute path by searching $PATH. */
+function which(command: string): string | undefined {
+  const pathEnv = process.env.PATH;
+  if (!pathEnv) return undefined;
+  for (const dir of pathEnv.split(":")) {
+    if (!dir) continue;
+    const candidate = path.join(dir, command);
+    if (isExecutable(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function isSupportedShell(shellPath: string): boolean {
+  return shellPath.includes("bash") || shellPath.includes("zsh");
+}
+
+/**
+ * Resolve a bash or zsh binary on macOS/Linux.
+ *
+ * Priority (aligned with Claude Code's findSuitableShell):
+ *   1. WAVE_SHELL env var (only if it points to an executable bash/zsh)
+ *   2. $SHELL (only if it is bash/zsh)
+ *   3. `which bash` / `which zsh` discovered on $PATH
+ *   4. Common fixed locations (/bin, /usr/bin, /usr/local/bin, /opt/homebrew/bin)
+ *
+ * When $SHELL is bash, bash is preferred; otherwise zsh is preferred. This
+ * matters because /bin/sh may be dash (Debian/Ubuntu) or POSIX-mode bash
+ * (macOS), neither of which supports bashisms like process substitution
+ * `<()`, causing `eval '<()...'` to fail at parse time.
+ */
+function resolveUnixShell(): string | undefined {
+  // 1. WAVE_SHELL env override
+  const waveShell = process.env.WAVE_SHELL;
+  if (waveShell && isSupportedShell(waveShell) && isExecutable(waveShell)) {
+    return waveShell;
+  }
+
+  // 2. $SHELL (only bash/zsh)
+  const envShell = process.env.SHELL;
+  const isEnvShellSupported = !!envShell && isSupportedShell(envShell);
+  const preferBash = envShell?.includes("bash") ?? false;
+
+  // 3. Locate via PATH
+  const bashPath = which("bash");
+  const zshPath = which("zsh");
+
+  // 4. Fixed common locations, ordered by user preference
+  const shellOrder = preferBash ? ["bash", "zsh"] : ["zsh", "bash"];
+  const candidates = shellOrder.flatMap((shell) =>
+    FIXED_SHELL_DIRS.map((dir) => `${dir}/${shell}`),
+  );
+
+  // Discovered PATH paths: preferred type first, the other as fallback
+  if (preferBash) {
+    if (bashPath) candidates.unshift(bashPath);
+    if (zshPath) candidates.push(zshPath);
+  } else {
+    if (zshPath) candidates.unshift(zshPath);
+    if (bashPath) candidates.push(bashPath);
+  }
+
+  // Always prioritize $SHELL if it is a supported, executable shell
+  if (isEnvShellSupported && envShell && isExecutable(envShell)) {
+    candidates.unshift(envShell);
+  }
+
+  return candidates.find((candidate) => isExecutable(candidate));
+}
+
 export function resolveShellPath(): string | undefined {
-  if (process.platform !== "win32") {
+  if (process.platform === "win32") {
+    if (process.env.GIT_BASH_PATH) {
+      return process.env.GIT_BASH_PATH;
+    }
+
+    const paths = [
+      ...WINDOWS_GIT_BASH_PATHS,
+      process.env.LOCALAPPDATA
+        ? `${process.env.LOCALAPPDATA}\\Programs\\Git\\bin\\bash.exe`
+        : null,
+    ].filter(Boolean) as string[];
+
+    for (const p of paths) {
+      if (fs.existsSync(p)) {
+        return p;
+      }
+    }
+
     return undefined;
   }
 
-  if (process.env.GIT_BASH_PATH) {
-    return process.env.GIT_BASH_PATH;
-  }
-
-  const paths = [
-    ...WINDOWS_GIT_BASH_PATHS,
-    process.env.LOCALAPPDATA
-      ? `${process.env.LOCALAPPDATA}\\Programs\\Git\\bin\\bash.exe`
-      : null,
-  ].filter(Boolean) as string[];
-
-  for (const path of paths) {
-    if (fs.existsSync(path)) {
-      return path;
-    }
-  }
-
-  return undefined;
+  return resolveUnixShell();
 }

--- a/packages/agent-sdk/tests/managers/bangManager.test.ts
+++ b/packages/agent-sdk/tests/managers/bangManager.test.ts
@@ -8,6 +8,11 @@ vi.mock("child_process");
 // Mock bashHistory utility
 vi.mock("@/utils/bashHistory");
 
+// Mock shellResolver so spawn shell option is deterministic
+vi.mock("@/utils/shellResolver", () => ({
+  resolveShellPath: vi.fn(() => "/bin/bash"),
+}));
+
 import { BangManager } from "@/managers/bangManager.js";
 import type { MessageManager } from "@/managers/messageManager.js";
 import { Container } from "@/utils/container.js";
@@ -105,7 +110,7 @@ describe("BangManager", () => {
 
       // Verify spawn was called with correct arguments
       expect(mockSpawn).toHaveBeenCalledWith(command, {
-        shell: true,
+        shell: "/bin/bash",
         stdio: "pipe",
         cwd: testWorkdir,
         env: expect.any(Object),

--- a/packages/agent-sdk/tests/utils/shellResolver.test.ts
+++ b/packages/agent-sdk/tests/utils/shellResolver.test.ts
@@ -4,8 +4,12 @@ import {
   WINDOWS_GIT_BASH_PATHS,
 } from "../../src/utils/shellResolver.js";
 import fs from "node:fs";
+import { execFileSync } from "node:child_process";
 
 vi.mock("node:fs");
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
 
 describe("shellResolver", () => {
   const originalPlatform = process.platform;
@@ -13,7 +17,7 @@ describe("shellResolver", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    delete process.env.GIT_BASH_PATH;
+    delete process.env.WAVE_GIT_BASH_PATH;
     delete process.env.LOCALAPPDATA;
     delete process.env.WAVE_SHELL;
     delete process.env.SHELL;
@@ -140,18 +144,55 @@ describe("shellResolver", () => {
     });
   });
 
-  describe("Windows with GIT_BASH_PATH env var", () => {
-    it("returns the env var path when it exists", () => {
+  describe("Windows with WAVE_GIT_BASH_PATH env var", () => {
+    it("returns the env var path when set", () => {
       Object.defineProperty(process, "platform", { value: "win32" });
-      process.env.GIT_BASH_PATH = "D:\\custom\\git\\bash.exe";
+      process.env.WAVE_GIT_BASH_PATH = "D:\\custom\\git\\bash.exe";
       expect(resolveShellPath()).toBe("D:\\custom\\git\\bash.exe");
     });
 
     it("returns the env var path without checking existsSync", () => {
       Object.defineProperty(process, "platform", { value: "win32" });
-      process.env.GIT_BASH_PATH = "D:\\custom\\git\\bash.exe";
+      process.env.WAVE_GIT_BASH_PATH = "D:\\custom\\git\\bash.exe";
       resolveShellPath();
       expect(fs.existsSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Windows git-inference", () => {
+    it("infers bash.exe from git.exe in common location", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      const gitExe = "C:\\Program Files\\Git\\cmd\\git.exe";
+      const expectedBash = "C:\\Program Files\\Git\\bin\\bash.exe";
+      vi.mocked(fs.existsSync).mockImplementation(
+        (p) => p === gitExe || p === expectedBash,
+      );
+      expect(resolveShellPath()).toBe(expectedBash);
+    });
+
+    it("infers bash.exe from where.exe when git not in common locations", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      const expectedBash = "E:\\custom\\Git\\bin\\bash.exe";
+      vi.mocked(fs.existsSync).mockImplementation((p) => p === expectedBash);
+      vi.mocked(execFileSync).mockReturnValue(
+        "E:\\custom\\Git\\cmd\\git.exe\r\n",
+      );
+      expect(resolveShellPath()).toBe(expectedBash);
+      expect(execFileSync).toHaveBeenCalledWith(
+        "where",
+        ["git"],
+        expect.objectContaining({ encoding: "utf8" }),
+      );
+    });
+
+    it("falls through to common paths when git inference finds no bash.exe", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      // git.exe exists at common location, but inferred bash.exe does not
+      vi.mocked(fs.existsSync).mockImplementation(
+        (p) => p === WINDOWS_GIT_BASH_PATHS[0],
+      );
+      vi.mocked(execFileSync).mockReturnValue("");
+      expect(resolveShellPath()).toBe(WINDOWS_GIT_BASH_PATHS[0]);
     });
   });
 
@@ -161,6 +202,7 @@ describe("shellResolver", () => {
       vi.mocked(fs.existsSync).mockImplementation(
         (p) => p === WINDOWS_GIT_BASH_PATHS[0],
       );
+      vi.mocked(execFileSync).mockReturnValue("");
       expect(resolveShellPath()).toBe(WINDOWS_GIT_BASH_PATHS[0]);
     });
 
@@ -169,6 +211,7 @@ describe("shellResolver", () => {
       vi.mocked(fs.existsSync).mockImplementation(
         (p) => p === WINDOWS_GIT_BASH_PATHS[1],
       );
+      vi.mocked(execFileSync).mockReturnValue("");
       expect(resolveShellPath()).toBe(WINDOWS_GIT_BASH_PATHS[1]);
     });
 
@@ -179,24 +222,29 @@ describe("shellResolver", () => {
         "C:\\Users\\test\\AppData\\Local\\Programs\\Git\\bin\\bash.exe";
 
       vi.mocked(fs.existsSync).mockImplementation((p) => p === localPath);
+      vi.mocked(execFileSync).mockReturnValue("");
       expect(resolveShellPath()).toBe(localPath);
     });
   });
 
   describe("Windows without Git Bash", () => {
-    it("returns undefined when no path exists", () => {
+    it("returns undefined when no path exists and git not found", () => {
       Object.defineProperty(process, "platform", { value: "win32" });
       vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(execFileSync).mockImplementation(() => {
+        throw new Error("not found");
+      });
       expect(resolveShellPath()).toBeUndefined();
     });
   });
 
-  describe("priority order", () => {
-    it("GIT_BASH_PATH takes priority over common paths", () => {
+  describe("Windows priority order", () => {
+    it("WAVE_GIT_BASH_PATH takes priority over git-inference and common paths", () => {
       Object.defineProperty(process, "platform", { value: "win32" });
-      process.env.GIT_BASH_PATH = "D:\\custom\\git\\bash.exe";
+      process.env.WAVE_GIT_BASH_PATH = "D:\\custom\\git\\bash.exe";
       vi.mocked(fs.existsSync).mockReturnValue(true);
       expect(resolveShellPath()).toBe("D:\\custom\\git\\bash.exe");
+      expect(execFileSync).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/agent-sdk/tests/utils/shellResolver.test.ts
+++ b/packages/agent-sdk/tests/utils/shellResolver.test.ts
@@ -15,6 +15,9 @@ describe("shellResolver", () => {
     vi.clearAllMocks();
     delete process.env.GIT_BASH_PATH;
     delete process.env.LOCALAPPDATA;
+    delete process.env.WAVE_SHELL;
+    delete process.env.SHELL;
+    delete process.env.PATH;
   });
 
   afterEach(() => {
@@ -23,13 +26,116 @@ describe("shellResolver", () => {
   });
 
   describe("non-Windows platform", () => {
-    it("returns undefined on linux", () => {
+    it("returns WAVE_SHELL override when it points to an executable bash", () => {
       Object.defineProperty(process, "platform", { value: "linux" });
+      process.env.WAVE_SHELL = "/custom/bash";
+      vi.mocked(fs.accessSync).mockImplementation(() => undefined);
+      expect(resolveShellPath()).toBe("/custom/bash");
+    });
+
+    it("returns WAVE_SHELL override when it points to an executable zsh", () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      process.env.WAVE_SHELL = "/opt/homebrew/bin/zsh";
+      vi.mocked(fs.accessSync).mockImplementation(() => undefined);
+      expect(resolveShellPath()).toBe("/opt/homebrew/bin/zsh");
+    });
+
+    it("ignores WAVE_SHELL when it is not bash/zsh", () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      process.env.WAVE_SHELL = "/bin/sh";
+      vi.mocked(fs.accessSync).mockImplementation(() => undefined);
+      const result = resolveShellPath();
+      expect(result).not.toBe("/bin/sh");
+      // falls through to fixed-path resolution
+      expect(result).toBeDefined();
+    });
+
+    it("ignores WAVE_SHELL when not executable", () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      process.env.WAVE_SHELL = "/nonexistent/bash";
+      vi.mocked(fs.accessSync).mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
       expect(resolveShellPath()).toBeUndefined();
     });
 
-    it("returns undefined on darwin", () => {
+    it("returns $SHELL when it is bash", () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      process.env.SHELL = "/bin/bash";
+      vi.mocked(fs.accessSync).mockImplementation(() => undefined);
+      expect(resolveShellPath()).toBe("/bin/bash");
+    });
+
+    it("returns $SHELL when it is zsh", () => {
       Object.defineProperty(process, "platform", { value: "darwin" });
+      process.env.SHELL = "/bin/zsh";
+      vi.mocked(fs.accessSync).mockImplementation(() => undefined);
+      expect(resolveShellPath()).toBe("/bin/zsh");
+    });
+
+    it("prefers WAVE_SHELL over $SHELL", () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      process.env.WAVE_SHELL = "/custom/bash";
+      process.env.SHELL = "/bin/bash";
+      vi.mocked(fs.accessSync).mockImplementation(() => undefined);
+      expect(resolveShellPath()).toBe("/custom/bash");
+    });
+
+    it("prefers zsh when $SHELL is zsh, even if bash is available via fixed path", () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      process.env.SHELL = "/bin/zsh";
+      vi.mocked(fs.accessSync).mockImplementation((p) => {
+        // only /bin/zsh exists
+        return p === "/bin/zsh"
+          ? undefined
+          : (() => {
+              throw new Error("ENOENT");
+            })();
+      });
+      expect(resolveShellPath()).toBe("/bin/zsh");
+    });
+
+    it("prefers bash when $SHELL is bash, even if zsh is also available", () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      process.env.SHELL = "/bin/bash";
+      vi.mocked(fs.accessSync).mockImplementation(() => undefined);
+      // bash candidates come first when $SHELL is bash
+      expect(resolveShellPath()).toBe("/bin/bash");
+    });
+
+    it("finds bash via fixed path when $SHELL unset", () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      vi.mocked(fs.accessSync).mockImplementation((p) => {
+        if (p === "/bin/bash") return undefined;
+        throw new Error("ENOENT");
+      });
+      expect(resolveShellPath()).toBe("/bin/bash");
+    });
+
+    it("finds zsh via fixed path when $SHELL unset and bash unavailable", () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      vi.mocked(fs.accessSync).mockImplementation((p) => {
+        if (p === "/bin/zsh") return undefined;
+        throw new Error("ENOENT");
+      });
+      expect(resolveShellPath()).toBe("/bin/zsh");
+    });
+
+    it("resolves bash via $PATH when no fixed path exists", () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      process.env.PATH = "/usr/local/bin";
+      vi.mocked(fs.accessSync).mockImplementation((p) => {
+        if (p === "/usr/local/bin/bash") return undefined;
+        throw new Error("ENOENT");
+      });
+      expect(resolveShellPath()).toBe("/usr/local/bin/bash");
+    });
+
+    it("returns undefined when no bash/zsh found", () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      vi.mocked(fs.accessSync).mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
       expect(resolveShellPath()).toBeUndefined();
     });
   });

--- a/specs/002-bash-tools.md
+++ b/specs/002-bash-tools.md
@@ -71,6 +71,23 @@
 
 ---
 
+### 用户故事 5 - 跨平台显式 shell 解析（优先级：P1）
+
+作为 AI 代理，我希望 Bash 工具在所有平台上都显式使用 bash 或 zsh 执行命令（而非系统默认 `/bin/sh`），以便 bash 特有语法（进程替换 `<()`、`[[ ]]`、数组等）在 macOS、Linux 上正常工作。
+
+**优先级原因**：`/bin/sh` 在 Debian/Ubuntu 是 dash，不兼容 bashism；即使 macOS 上 `/bin/sh` 是 bash，也会以 POSIX 模式运行，导致 `eval '<()...'` 多行命令解析失败（报 `syntax error near unexpected token '('`）。这是命令执行的基本正确性需求。
+
+**独立测试**：在 macOS/Linux 上运行 `comm -23 <(echo a) <(echo b)`，验证进程替换正常工作，无 syntax error。
+
+**验收场景**：
+
+1. **假设** 运行在 macOS/Linux，**当** 执行含进程替换的命令（如 `comm -23 <(echo a) <(echo b)`）时，**则** 命令必须正常执行，不得报 syntax error。
+2. **假设** 设置了 `WAVE_SHELL` 环境变量指向可执行的 bash/zsh，**当** 调用 Bash 工具时，**则** 必须使用该 shell 执行命令。
+3. **假设** 系统未安装 bash 和 zsh，**当** 调用 Bash 工具时，**则** 必须返回清晰错误消息而非静默回退到 `/bin/sh`。
+4. **假设** `$SHELL` 指向 zsh，**当** 调用 Bash 工具时，**则** 必须优先使用 zsh。
+
+---
+
 ### 边界情况
 
 - **输出截断**：如果命令产生大量输出（例如 > 30,000 个字符），系统必须截断以防止 LLM 过载。多余输出被持久化到临时文件。
@@ -111,6 +128,11 @@
 - **FR-023**：在 Windows 系统上，CWD 追踪命令（`pwd -P >| tempfile`）必须使用 Git Bash 执行，确保输出为 POSIX 路径格式。
 - **FR-024**：在 Windows 系统上，传递给 Git Bash 的临时文件路径必须将反斜杠转换为正斜杠（`C:\Users\...` → `C:/Users/...`），因为 Bash 将反斜杠视为转义字符，会导致路径损坏并在项目目录中创建临时文件。
 - **FR-025**：CWD 追踪临时文件必须在所有退出路径上被清理，包括正常退出（exit）、中止（abort）、执行错误（error）和转为后台（background）。
+- **FR-026**：在所有平台上，Bash 工具必须显式解析一个 bash 或 zsh 二进制作为执行 shell，不得依赖 `spawn({shell: true})` 回退到 `/bin/sh`。
+- **FR-027**：在 macOS/Linux 上，shell 解析优先级为：`WAVE_SHELL` 环境变量（仅当指向可执行的 bash/zsh）→ `$SHELL`（仅当为 bash/zsh）→ `which('bash')` / `which('zsh')` → 常见固定路径（`/bin/bash`、`/usr/bin/bash`、`/usr/local/bin/bash`、`/bin/zsh`、`/opt/homebrew/bin/zsh` 等）。当 `$SHELL` 为 bash 时优先 bash，否则优先 zsh。
+- **FR-028**：当 `$SHELL` 指向 zsh 时，系统必须优先使用 zsh，以尊重用户交互式 shell 选择。
+- **FR-029**：在 macOS/Linux 上，若未找到任何可执行的 bash 或 zsh，系统必须返回清晰错误消息（提示安装 bash/zsh 或设置 `WAVE_SHELL` 环境变量），不得静默回退到 `/bin/sh`。
+- **FR-030**：`resolveShellPath()` 的返回值必须传入 `spawn()` 的 `shell` 选项（而非 `true`），确保 Node.js 使用解析到的 bash/zsh 而非默认 `/bin/sh`。
 
 ### 关键实体
 
@@ -121,7 +143,7 @@
 ## 假设
 
 - 代理具有在目标环境中执行 bash 命令所需的权限。
-- 在 Linux/macOS 上，系统默认 shell（`/bin/sh` 或 `$SHELL`）与 Bash 语法兼容。
+- 在 Linux/macOS 上，系统必须显式解析 bash 或 zsh 作为执行 shell；`/bin/sh` 可能是 dash 或 POSIX 模式 bash，不保证兼容 bashism。
 - 在 Windows 上，用户已安装 Git for Windows（提供 Git Bash）。
 - `PermissionManager` 将在任何命令实际执行之前处理安全检查。
 - 代理被指示在适当时优先使用专用工具（Read、Write 等）而非通用 bash 命令。

--- a/specs/002-bash-tools.md
+++ b/specs/002-bash-tools.md
@@ -68,6 +68,8 @@
 2. **假设** 运行在 Windows 系统上，**当** Git Bash 未安装时，**则** 系统必须返回清晰的错误消息，提示用户安装 Git for Windows。
 3. **假设** 运行在 Windows 系统上，**当** 执行包含 POSIX 语法的命令（如 `pwd -P >| file`）时，**则** 命令必须正常执行并返回正确结果。
 4. **假设** 运行在 Windows 系统上，**当** 命令执行后检测 CWD 时，**则** CWD 追踪机制必须正常工作——临时文件路径需转换为正斜杠格式以兼容 Git Bash，且临时文件在命令结束后必须被清理，不得残留在项目目录中。
+5. **假设** Git 安装在非标准路径但 `git` 在 PATH 中，**当** 调用 Bash 工具时，**则** 系统必须通过从 `git` 可执行文件位置反推（`<git 目录>/../../bin/bash.exe`）定位 Git Bash，而非仅依赖常见安装路径。
+6. **假设** 设置了 `WAVE_GIT_BASH_PATH` 环境变量指向 bash.exe，**当** 调用 Bash 工具时，**则** 必须优先使用该路径。
 
 ---
 
@@ -122,8 +124,8 @@
 - **FR-016**：`Read` 工具必须能够读取后台进程的 `outputPath`。
 - **FR-017**：系统必须在 Bash 执行后通过检查 shell 的最终工作目录来检测 CWD 更改。如果 CWD 发生更改（例如通过 `cd`），系统必须更新代理的 `workdir` 上下文以供后续工具调用使用。
 - **FR-018**：Bash 工具提示必须告知代理"工作目录在命令之间持久化"（当使用 `cd` 时），与实际行为一致。
-- **FR-020**：在 Windows 系统上，系统必须检测并使用 Git Bash 作为 shell，而非 cmd.exe。检测顺序：`$GIT_BASH_PATH` 环境变量 → 常见安装路径（`C:\Program Files\Git\bin\bash.exe` 等）。
-- **FR-021**：在 Windows 系统上，如果未检测到 Git Bash，系统必须返回错误消息，提示用户安装 Git for Windows 或设置 `GIT_BASH_PATH` 环境变量。
+- **FR-020**：在 Windows 系统上，系统必须检测并使用 Git Bash 作为 shell，而非 cmd.exe。检测顺序：`$WAVE_GIT_BASH_PATH` 环境变量 → 从 `git` 可执行文件位置反推（`<git 目录>/../../bin/bash.exe`，即使 Git Bash 不在 PATH 或常见目录，只要 `git` 可被定位即可）→ 常见安装路径（`C:\Program Files\Git\bin\bash.exe` 等）。
+- **FR-021**：在 Windows 系统上，如果未检测到 Git Bash，系统必须返回错误消息，提示用户安装 Git for Windows 或设置 `WAVE_GIT_BASH_PATH` 环境变量。
 - **FR-022**：在 Windows 系统上使用 Git Bash 时，`spawn` 调用必须将 shell 参数设置为检测到的 Git Bash 可执行文件路径，而非 `true`。
 - **FR-023**：在 Windows 系统上，CWD 追踪命令（`pwd -P >| tempfile`）必须使用 Git Bash 执行，确保输出为 POSIX 路径格式。
 - **FR-024**：在 Windows 系统上，传递给 Git Bash 的临时文件路径必须将反斜杠转换为正斜杠（`C:\Users\...` → `C:/Users/...`），因为 Bash 将反斜杠视为转义字符，会导致路径损坏并在项目目录中创建临时文件。


### PR DESCRIPTION
## Summary

Wave's Bash tool used `spawn(cmd, { shell: shellPath || true })`, which fell back to `/bin/sh` on macOS/Linux. `/bin/sh` is dash on Debian/Ubuntu and POSIX-mode bash on macOS — neither supports bashisms like process substitution `<()`, causing `syntax error near unexpected token '('` on otherwise valid commands.

This PR aligns Wave's shell resolution with Claude Code across all platforms.

## Changes

### 1. macOS/Linux: explicit bash/zsh resolution (`178df732`)
- New `resolveUnixShell()` with priority chain: `WAVE_SHELL` env → `/bin/bash` (bash/zsh only) → `which(bash|zsh)` → fixed paths
- `bashTool.ts`: guard now covers both platforms (was win32-only); `shell: shellPath` (was `shell: shellPath || true`)
- `backgroundTaskManager.ts` / `bangManager.ts`: `shell: true` → `shell: resolveShellPath() ?? true`
- Self-implemented `which()` via PATH traversal (no new dependency)

### 2. Windows: Git Bash detection aligned with Claude Code (`4e53841f`)
- Priority: `WAVE_GIT_BASH_PATH` env → infer from `git` executable location (`<git>/../../bin/bash.exe`) → common install paths
- New `inferGitBashFromGit()`: checks common git.exe paths, falls back to `where.exe git`
- Renamed env var `GIT_BASH_PATH` → `WAVE_GIT_BASH_PATH` (aligned with Claude Code's `CLAUDE_CODE_GIT_BASH_PATH`); no backward compat per design decision
- Updated error message to reference `WAVE_GIT_BASH_PATH`

### Spec
- Updated `specs/002-bash-tools.md`: added user story 5 (P1 cross-platform shell resolution), FR-026~FR-030; corrected wrong assumption that `/bin/sh` is Bash-compatible; updated FR-020/021

## Test plan
- [x] `shellResolver.test.ts`: 23 tests (unix resolution + Windows env/git-inference/common paths/priority)
- [x] `bangManager.test.ts`: 11 tests (updated assertions with mocked shellResolver)
- [x] `pnpm -r type-check` passes
- [x] `pnpm lint` + prettier pass
- [x] Smoke test: `comm -23 <(echo a) <(echo b)` now executes correctly via the Bash tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)