### PR TITLE
refactor: upgrade CLI pre-spawn instead of post-init reinit

### DIFF
--- a/packages/code/src/stdio/agentBridge.ts
+++ b/packages/code/src/stdio/agentBridge.ts
@@ -41,22 +41,7 @@ import {
   INTERNAL_ERROR as PROTOCOL_INTERNAL_ERROR,
   METHOD_NOT_FOUND as PROTOCOL_METHOD_NOT_FOUND,
 } from "./protocol.js";
-import { readFileSync } from "fs";
-import path from "path";
-import { fileURLToPath } from "url";
 import { logger } from "../utils/logger.js";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const CLI_VERSION: string = (() => {
-  try {
-    const pkg = JSON.parse(
-      readFileSync(path.resolve(__dirname, "../../package.json"), "utf-8"),
-    );
-    return pkg.version ?? "";
-  } catch {
-    return "";
-  }
-})();
 
 export type NotificationEmitter = (
   method: string,
@@ -84,7 +69,6 @@ interface InitializeParams {
   disallowedTools?: string[];
   pluginDirs?: string[];
   mcpServers?: Record<string, McpServerConfig>;
-  clientVersion?: string;
 }
 
 interface UpdateConfigParams {
@@ -325,7 +309,6 @@ export class AgentBridge {
     workingDirectory: string;
     permissionMode: PermissionMode;
     latestTotalTokens: number;
-    serverVersion: string;
   }> {
     const ctx: SessionContext = {};
     const callbacks = this.createCallbacks(ctx);
@@ -360,19 +343,11 @@ export class AgentBridge {
       storedConfig: { ...params },
     });
 
-    if (params.clientVersion) {
-      // stdout 是 JSON-RPC 协议通道，诊断日志必须走 stderr 以免污染协议
-      process.stderr.write(
-        `[agentBridge] clientVersion=${params.clientVersion} serverVersion=${CLI_VERSION}\n`,
-      );
-    }
-
     return {
       sessionId: agent.sessionId,
       workingDirectory: agent.workingDirectory,
       permissionMode: agent.getPermissionMode(),
       latestTotalTokens: agent.latestTotalTokens,
-      serverVersion: CLI_VERSION,
     };
   }
 

--- a/packages/code/tests/stdio/agentBridge.test.ts
+++ b/packages/code/tests/stdio/agentBridge.test.ts
@@ -7,14 +7,6 @@ import {
   listSessions,
   searchFiles,
 } from "wave-agent-sdk";
-import { readFileSync } from "fs";
-import { fileURLToPath } from "url";
-import path from "path";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const CLI_PACKAGE_VERSION = JSON.parse(
-  readFileSync(path.resolve(__dirname, "../../package.json"), "utf-8"),
-).version as string;
 
 // Mock the Agent SDK
 vi.mock("wave-agent-sdk");
@@ -106,7 +98,6 @@ test("initialize creates Agent with correct options and returns session info", a
     workingDirectory: "/test/workdir",
     permissionMode: "default",
     latestTotalTokens: 100,
-    serverVersion: CLI_PACKAGE_VERSION,
   });
   expect(Agent.create).toHaveBeenCalledTimes(1);
 
@@ -132,27 +123,6 @@ test("initialize passes pluginDirs as PluginConfig[]", async () => {
     { type: "local", path: "/path/to/plugin1" },
     { type: "local", path: "/path/to/plugin2" },
   ]);
-});
-
-test("initialize returns serverVersion from package.json", async () => {
-  const { bridge } = createBridge();
-  vi.mocked(Agent.create).mockResolvedValue(createMockAgent());
-
-  const result = (await bridge.handleRequest("initialize", {
-    workdir: "/test",
-  })) as { serverVersion: string };
-
-  expect(typeof result.serverVersion).toBe("string");
-  expect(result.serverVersion).toBe(CLI_PACKAGE_VERSION);
-});
-
-test("initialize accepts missing clientVersion without error", async () => {
-  const { bridge } = createBridge();
-  vi.mocked(Agent.create).mockResolvedValue(createMockAgent());
-
-  await expect(
-    bridge.handleRequest("initialize", { workdir: "/test" }),
-  ).resolves.toBeDefined();
 });
 
 // ── Callbacks → Notifications ────────────────────────────────────

--- a/packages/code/tests/stdio/stdioServer.test.ts
+++ b/packages/code/tests/stdio/stdioServer.test.ts
@@ -1,14 +1,6 @@
 import { test, expect, vi, beforeEach, afterEach } from "vitest";
 import { PassThrough } from "stream";
-import { readFileSync } from "fs";
-import { fileURLToPath } from "url";
-import path from "path";
 import { Agent } from "wave-agent-sdk";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const CLI_PACKAGE_VERSION = JSON.parse(
-  readFileSync(path.resolve(__dirname, "../../package.json"), "utf-8"),
-).version as string;
 
 // Mock the Agent SDK
 vi.mock("wave-agent-sdk");
@@ -108,7 +100,6 @@ test("initialize request returns response with sessionId", async () => {
     workingDirectory: "/test/workdir",
     permissionMode: "default",
     latestTotalTokens: 0,
-    serverVersion: CLI_PACKAGE_VERSION,
   });
 
   server.stop();

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/WaveBackendService.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/WaveBackendService.kt
@@ -3,9 +3,7 @@ package com.wave.jetbrains
 import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
-import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
-import com.wave.jetbrains.ide.IdeService
 import com.wave.jetbrains.session.WaveSession
 import com.wave.jetbrains.stdio.BinaryResolver
 import com.wave.jetbrains.stdio.NotificationRouter
@@ -23,12 +21,11 @@ import kotlinx.serialization.json.jsonPrimitive
  * in this project, mirroring the VSCE ChatProvider's shared-client architecture.
  *
  * Session-scoped notifications are demuxed by sessionId via the router; the shared client
- * is never per-session. CLI auto-upgrade (version negotiation) is centralized here so it
- * can reinitialize every active session after killing the shared process.
+ * is never per-session. CLI version upgrade happens pre-spawn in [ensureClient] via
+ * BinaryResolver.ensureCliUpToDate, so no post-init reinit is needed.
  */
 @Service(Service.Level.PROJECT)
 class WaveBackendService(private val project: Project) : Disposable {
-    private val LOG = logger<WaveBackendService>()
 
     @Volatile
     private var sharedClient: StdioClient? = null
@@ -36,9 +33,6 @@ class WaveBackendService(private val project: Project) : Disposable {
     private var router: NotificationRouter? = null
 
     private val initMutex = Mutex()
-    private val upgradeMutex = Mutex()
-    @Volatile
-    private var cliUpgradeAttempted = false
 
     private val sessions = java.util.Collections.synchronizedSet(mutableSetOf<WaveSession>())
 
@@ -58,7 +52,12 @@ class WaveBackendService(private val project: Project) : Disposable {
     suspend fun ensureClient(): Pair<StdioClient, NotificationRouter> {
         initMutex.withLock {
             if (sharedClient == null) {
-                val binary = BinaryResolver.resolveWaveBinary()
+                val pluginVer = WaveSession.pluginVersion()
+                val binary = if (pluginVer.isNotEmpty()) {
+                    BinaryResolver.ensureCliUpToDate(pluginVer)
+                } else {
+                    BinaryResolver.resolveWaveBinary()
+                }
                 val c = StdioClient(binary, listOf("--stdio"), BinaryResolver.resolveEnv())
                 val r = NotificationRouter(c)
                 r.attach()
@@ -76,53 +75,12 @@ class WaveBackendService(private val project: Project) : Disposable {
     }
 
     /**
-     * Initialize a session on the shared client, then run the CLI version-negotiation
-     * upgrade check (once per activation). Mirrors VSCE chatProvider.ts:264-321.
+     * Initialize a session on the shared client. The CLI is upgraded pre-spawn
+     * in [ensureClient], so no post-init version negotiation is needed here.
+     * Mirrors VSCE chatProvider.ts initializeAgent (post-refactor).
      */
     suspend fun initializeSession(session: WaveSession, restoreSessionId: String?): Boolean {
-        val upgradedThisCall = cliUpgradeAttempted
-        val ok = session.initialize(restoreSessionId)
-        if (!ok) return false
-        val pluginVer = WaveSession.pluginVersion()
-        if (!upgradedThisCall && pluginVer.isNotEmpty()) {
-            val srv = session.agent?.serverVersion
-            if (!srv.isNullOrEmpty()) {
-                val cmp = try { BinaryResolver.compareVersions(srv, pluginVer) } catch (_: Exception) { 0 }
-                if (cmp < 0) {
-                    upgradeMutex.withLock {
-                        if (!cliUpgradeAttempted) {
-                            cliUpgradeAttempted = true
-                            try {
-                                LOG.info("CLI $srv < plugin $pluginVer; upgrading wave-code")
-                                reinitAllAfterUpgrade()
-                            } catch (e: Exception) {
-                                LOG.error("CLI auto-upgrade failed", e)
-                                IdeService.showError(project, "Wave CLI 升级失败，请手动执行: npm install -g wave-code --registry=https://registry.npmmirror.com")
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        return true
-    }
-
-    /**
-     * Kill the shared process, upgrade the CLI binary, rebuild the shared client + router,
-     * and re-initialize every previously-active session with its restoreSessionId.
-     * Mirrors VSCE chatProvider.ts:332-380.
-     */
-    private suspend fun reinitAllAfterUpgrade() {
-        val active = synchronized(sessions) { sessions.toList() }
-            .filter { it.agent != null }
-            .map { it to it.sessionId }
-        active.forEach { (s, _) -> runCatching { s.destroyAgent() } }
-        sharedClient?.close()
-        sharedClient = null
-        router = null
-        BinaryResolver.upgradeWaveBinary(WaveSession.pluginVersion())
-        ensureClient()
-        active.forEach { (s, rid) -> runCatching { s.initialize(rid) } }
+        return session.initialize(restoreSessionId)
     }
 
     override fun dispose() {

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
@@ -121,7 +121,6 @@ class WaveSession(
                 if (config.model.isNotEmpty()) put("model", config.model)
                 if (config.fastModel.isNotEmpty()) put("fastModel", config.fastModel)
                 put("language", config.language)
-                put("clientVersion", pluginVersion())
             }
             try {
                 a.initialize(params)
@@ -138,7 +137,7 @@ class WaveSession(
                 sessionId = a.sessionId
             }
             permissionMode = a.permissionMode
-            // CLI 升级由 WaveBackendService.initializeSession 在 initialize 返回后统一处理
+            // CLI 升级由 WaveBackendService.ensureClient 在进程启动前统一处理（pre-spawn upgrade）
             // Plugin self-update check: once per activation, 24h cooldown (mirrors VSCE updateService).
             if (!UpdateChecker.autoCheckTriggered) {
                 UpdateChecker.autoCheckTriggered = true

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
@@ -68,6 +68,48 @@ object BinaryResolver {
     }
 
     /**
+     * Runs `<binaryPath> -v` and returns the bare version string (e.g. "0.18.7"),
+     * stripping a leading "v" if present. Returns null if the binary is
+     * missing/corrupt or `-v` fails (callers treat null as "needs upgrade").
+     * Uses a separate timed process rather than [runCommand] (which has no
+     * timeout): if the process hangs it is destroyed and null is returned.
+     */
+    fun getCliVersion(binaryPath: String): String? {
+        return try {
+            val proc = ProcessBuilder(listOf(binaryPath, "-v")).apply {
+                redirectErrorStream(true)
+                environment().putAll(resolveEnv())
+            }.start()
+            val out = proc.inputStream.bufferedReader().readText()
+            if (!proc.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)) {
+                proc.destroyForcibly()
+                return null
+            }
+            val line = out.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }
+                ?: return null
+            line.trimStart('v')
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Ensure the wave CLI exists and its version is >= [targetVersion]. Returns the
+     * (possibly upgraded) binary path. Mirrors packages/vsce/src/stdio/binaryResolver.ts
+     * ensureCliUpToDate.
+     */
+    fun ensureCliUpToDate(targetVersion: String): String {
+        val binaryPath = resolveWaveBinary()
+        val current = getCliVersion(binaryPath)
+        if (current != null) {
+            val cmp = try { compareVersions(current, targetVersion) } catch (_: Exception) { 0 }
+            if (cmp >= 0) return binaryPath
+        }
+        // current is null (corrupt) or older than target → upgrade.
+        return upgradeWaveBinary(targetVersion)
+    }
+
+    /**
      * Environment variables to inject into spawned `wave`/`npm` processes.
      *
      * GUI-launched IDEs inherit a minimal launchd PATH and never source the

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioAgent.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioAgent.kt
@@ -56,8 +56,6 @@ class StdioAgent(
         private set
     @Volatile var permissionMode: String? = null
         private set
-    @Volatile var serverVersion: String? = null
-        private set
 
     fun handleNotification(method: String, params: JsonElement?) {
         when (method) {
@@ -133,14 +131,12 @@ class StdioAgent(
         workingDirectory = res["workingDirectory"]?.jsonPrimitive?.content
         permissionMode = res["permissionMode"]?.jsonPrimitive?.content
         res["latestTotalTokens"]?.jsonPrimitive?.intOrNull?.let { latestTotalTokens = it }
-        res["serverVersion"]?.jsonPrimitive?.content?.let { serverVersion = it }
         sessionId?.let { router.register(it, this) }
         return InitializeResult(
             sessionId = sessionId,
             workingDirectory = workingDirectory,
             permissionMode = permissionMode,
             latestTotalTokens = latestTotalTokens,
-            serverVersion = serverVersion,
         )
     }
 
@@ -319,7 +315,6 @@ data class InitializeResult(
     val workingDirectory: String?,
     val permissionMode: String?,
     val latestTotalTokens: Int,
-    val serverVersion: String? = null,
 )
 
 private val JsonPrimitive.intOrNull: Int? get() = content.toIntOrNull()

--- a/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/stdio/BinaryResolverTest.kt
+++ b/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/stdio/BinaryResolverTest.kt
@@ -23,6 +23,7 @@ class BinaryResolverTest {
     lateinit var tempDir: Path
 
     private var nvmCounter = 0
+    private var shimCounter = 0
 
     // ---- findNvmBinDir -------------------------------------------------
 
@@ -84,6 +85,61 @@ class BinaryResolverTest {
         assertTrue(BinaryResolver.compareVersions("v22.14.0", "v20.19.0") > 0)
         assertEquals(0, BinaryResolver.compareVersions("v18.20.4", "v18.20.4"))
         assertTrue(BinaryResolver.compareVersions("v20.19.0", "v23.10.0") < 0)
+    }
+
+    // ---- getCliVersion -------------------------------------------------
+    //
+    // getCliVersion spawns `<path> -v` in a timed process. We exercise the
+    // real subprocess path (no mocking) by writing a tiny shim script into
+    // the temp dir that prints a canned version line, then asserting on the
+    // parsed/stripped result. The `__VERSION__` placeholder keeps each case a
+    // one-liner; `assumeFalse(isWindows)` skips the .sh variant on Windows
+    // (where the test harness lacks a POSIX shell), matching the prod guard.
+
+    private fun writeVersionShim(versionLine: String): File {
+        val script = File(tempDir.toFile(), "version-shim-${shimCounter++}.sh").apply {
+            writeText("#!/bin/sh\necho '$versionLine'\n")
+            setExecutable(true)
+        }
+        return script
+    }
+
+    @Test
+    fun `getCliVersion returns the bare version from -v output`() {
+        org.junit.jupiter.api.Assumptions.assumeFalse(
+            System.getProperty("os.name").lowercase().startsWith("win"),
+            "POSIX shell shim not available on Windows CI"
+        )
+        val shim = writeVersionShim("0.18.7")
+        assertEquals("0.18.7", BinaryResolver.getCliVersion(shim.absolutePath))
+    }
+
+    @Test
+    fun `getCliVersion strips a leading v`() {
+        org.junit.jupiter.api.Assumptions.assumeFalse(
+            System.getProperty("os.name").lowercase().startsWith("win"),
+            "POSIX shell shim not available on Windows CI"
+        )
+        val shim = writeVersionShim("v1.2.3")
+        assertEquals("1.2.3", BinaryResolver.getCliVersion(shim.absolutePath))
+    }
+
+    @Test
+    fun `getCliVersion uses the first non-empty line`() {
+        org.junit.jupiter.api.Assumptions.assumeFalse(
+            System.getProperty("os.name").lowercase().startsWith("win"),
+            "POSIX shell shim not available on Windows CI"
+        )
+        // A leading blank line (common from banner-printing shells) must be
+        // skipped, and trailing lines ignored.
+        val shim = writeVersionShim("\n4.5.6\nextra-noise")
+        assertEquals("4.5.6", BinaryResolver.getCliVersion(shim.absolutePath))
+    }
+
+    @Test
+    fun `getCliVersion returns null when the binary path does not exist`() {
+        val missing = File(tempDir.toFile(), "no-such-binary").absolutePath
+        assertNull(BinaryResolver.getCliVersion(missing))
     }
 
     // ---- findInNvm -----------------------------------------------------

--- a/packages/vsce/src/chatProvider.ts
+++ b/packages/vsce/src/chatProvider.ts
@@ -18,8 +18,8 @@ import { WebviewManager } from './session/webviewManager';
 import { MessageHandler } from './session/messageHandler';
 import { StdioClient } from './stdio/stdioClient';
 import { NotificationRouter } from './stdio/notificationRouter';
-import { resolveWaveBinary, upgradeWaveBinary } from './stdio/binaryResolver';
-import { parseVersion, compareVersions, checkAndNotify } from './services/updateService';
+import { resolveWaveBinary, ensureCliUpToDate } from './stdio/binaryResolver';
+import { checkAndNotify } from './services/updateService';
 
 export class ChatProvider implements vscode.WebviewViewProvider {
     private static formatConfigError(error: unknown): string {
@@ -41,33 +41,30 @@ export class ChatProvider implements vscode.WebviewViewProvider {
     private windowSessions: Map<string, ChatSession> = new Map();
 
     private configService: ConfigurationService;
-    private fileService: FileService;
-    private sessionService: SessionService;
+    private fileService!: FileService;
+    private sessionService!: SessionService;
     private selectionService: SelectionService;
-    private pluginService: PluginService;
+    private pluginService!: PluginService;
     private webviewManager: WebviewManager;
-    private messageHandler: MessageHandler;
+    private messageHandler!: MessageHandler;
     private sharedClient: StdioClient | undefined;
     private notificationRouter: NotificationRouter | undefined;
-    private cliUpgradeAttempted = false;
+    private initPromise: Promise<void>;
     private updateCheckTriggered = false;
 
     constructor(context: vscode.ExtensionContext) {
         this.context = context;
         this.configService = new ConfigurationService(context);
-
-        // Create the single shared stdio client + notification router for all sessions.
-        // Session-scoped notifications are demuxed by sessionId via the router.
-        // Global notifications (authUrl) are handled here.
-        this.initSharedClient();
-
-        this.fileService = new FileService(this.sharedClient!);
-        this.sessionService = new SessionService(this.sharedClient!);
         this.selectionService = new SelectionService(context);
-        this.pluginService = new PluginService(this.sharedClient!);
 
         this.webviewManager = new WebviewManager(context, {
             onMessage: async (message, viewType, windowId) => {
+                // Gate on init so services/messageHandler exist before dispatch.
+                await this.initPromise.catch(() => {});
+                if (!this.messageHandler) {
+                    console.error('[Wave] Shared client not initialized; dropping message:', message);
+                    return;
+                }
                 await this.messageHandler.handleMessage(message, viewType, windowId);
             },
             onTabDispose: (tabId) => {
@@ -90,32 +87,12 @@ export class ChatProvider implements vscode.WebviewViewProvider {
             }
         });
 
-        this.messageHandler = new MessageHandler(
-            this.configService,
-            this.fileService,
-            this.sessionService,
-            this.pluginService,
-            this.sharedClient!,
-            {
-                getChatSession: (viewType, windowId) => this.getChatSession(viewType, windowId),
-                postMessage: (message, viewType, windowId) => this.webviewManager.postMessage(message, viewType, windowId),
-                initializeAgent: (viewType, windowId, restoreSessionId) => this.initializeAgent(viewType, windowId, restoreSessionId),
-                listSessions: (viewType, windowId) => this.listSessions(viewType, windowId),
-                updateAllSessionsConfig: (config) => {
-                    const cfg = config as ConfigurationData;
-                    this.sidebarSession.updateConfig(cfg);
-                    this.tabSessions.forEach(session => session.updateConfig(cfg));
-                    this.windowSessions.forEach(session => session.updateConfig(cfg));
-                },
-                checkForUpdates: async () => {
-                    const cfg = await this.configService.loadConfiguration();
-                    return checkAndNotify(this.context, true, cfg.serverUrl);
-                },
-                getVersion: () => this.context.extension.packageJSON?.version || ''
-            }
-        );
-
         this.sidebarSession = this.createChatSession('sidebar');
+
+        // Spawn the shared stdio client asynchronously (runs the `wave -v`
+        // upgrade check before spawning) and build the services/messageHandler
+        // that depend on it. All client-touching entry points await initPromise.
+        this.initPromise = this.init();
 
         console.log('创建了 ChatProvider');
         
@@ -145,9 +122,20 @@ export class ChatProvider implements vscode.WebviewViewProvider {
         */
     }
 
-    private initSharedClient(): void {
+    /**
+     * Spawn the shared stdio client, upgrading the `wave` CLI first (via
+     * `wave -v`) if it is older than the extension. Services/MessageHandler are
+     * constructed AFTER the upgrade so they capture the post-upgrade client —
+     * this is what avoids the "StdioClient is disposed" dangling-reference
+     * failure that the old post-init reinit path had.
+     */
+    private async init(): Promise<void> {
         try {
-            const binaryPath = resolveWaveBinary();
+            const clientVersion: string | undefined = this.context.extension.packageJSON?.version;
+            const binaryPath = clientVersion
+                ? await ensureCliUpToDate(clientVersion)
+                : resolveWaveBinary();
+
             this.sharedClient = new StdioClient(binaryPath, ['--stdio']);
             this.notificationRouter = new NotificationRouter(this.sharedClient);
             this.notificationRouter.attach();
@@ -158,8 +146,38 @@ export class ChatProvider implements vscode.WebviewViewProvider {
                     vscode.env.openExternal(vscode.Uri.parse(p.url));
                 }
             });
+
+            // Build the services + messageHandler against the (possibly
+            // upgraded) client so they never hold a stale reference.
+            this.fileService = new FileService(this.sharedClient);
+            this.sessionService = new SessionService(this.sharedClient);
+            this.pluginService = new PluginService(this.sharedClient);
+            this.messageHandler = new MessageHandler(
+                this.configService,
+                this.fileService,
+                this.sessionService,
+                this.pluginService,
+                this.sharedClient,
+                {
+                    getChatSession: (viewType, windowId) => this.getChatSession(viewType, windowId),
+                    postMessage: (message, viewType, windowId) => this.webviewManager.postMessage(message, viewType, windowId),
+                    initializeAgent: (viewType, windowId, restoreSessionId) => this.initializeAgent(viewType, windowId, restoreSessionId),
+                    listSessions: (viewType, windowId) => this.listSessions(viewType, windowId),
+                    updateAllSessionsConfig: (config) => {
+                        const cfg = config as ConfigurationData;
+                        this.sidebarSession.updateConfig(cfg);
+                        this.tabSessions.forEach(session => session.updateConfig(cfg));
+                        this.windowSessions.forEach(session => session.updateConfig(cfg));
+                    },
+                    checkForUpdates: async () => {
+                        const cfg = await this.configService.loadConfiguration();
+                        return checkAndNotify(this.context, true, cfg.serverUrl);
+                    },
+                    getVersion: () => this.context.extension.packageJSON?.version || ''
+                }
+            );
         } catch (err) {
-            console.error('[Wave] Failed to resolve wave binary:', err);
+            console.error('[Wave] Failed to initialize shared client:', err);
             vscode.window.showErrorMessage(
                 '无法启动 wave 二进制文件。请手动安装: npm install -g wave-code',
             );
@@ -270,15 +288,15 @@ export class ChatProvider implements vscode.WebviewViewProvider {
             return;
         }
 
-        const clientVersion: string | undefined = this.context.extension.packageJSON?.version;
-        const upgradedThisCall = this.cliUpgradeAttempted;
+        // Wait for the shared client (and the `wave -v` upgrade check) to finish
+        // before touching the client or its dependent services.
+        await this.initPromise;
 
         try {
             const config = await this.configService.loadConfiguration();
             await session.initialize(
                 config,
                 restoreSessionId,
-                clientVersion,
                 this.sharedClient!,
                 this.notificationRouter!,
             );
@@ -292,26 +310,6 @@ export class ChatProvider implements vscode.WebviewViewProvider {
                     console.warn('[UpdateService] Update check failed:', err);
                 });
             }
-
-            // Version negotiation: if the CLI is older than the extension, silently
-            // upgrade once per activation and re-initialize. Because the shared process
-            // must be killed to pick up the new binary, ALL active sessions are re-init'd.
-            if (!upgradedThisCall && clientVersion && session.agent?.serverVersion) {
-                const client = parseVersion(clientVersion);
-                const server = parseVersion(session.agent.serverVersion);
-                if (client && server && compareVersions(server, client) < 0) {
-                    this.cliUpgradeAttempted = true;
-                    try {
-                        console.log(`[Wave] CLI ${session.agent.serverVersion} < extension ${clientVersion}, upgrading...`);
-                        await this.reinitAllAfterUpgrade(config, clientVersion);
-                    } catch (upgradeError) {
-                        console.error('[Wave] CLI auto-upgrade failed:', upgradeError);
-                        vscode.window.showErrorMessage(
-                            'Wave CLI 升级失败，请手动执行: npm install -g wave-code --registry=https://registry.npmmirror.com',
-                        );
-                    }
-                }
-            }
         } catch (error) {
             console.error(`初始化 ${viewType} 智能体失败:`, error);
             const isConfigError = error && typeof error === 'object' && 'name' in error && error.name === 'ConfigurationError';
@@ -321,65 +319,6 @@ export class ChatProvider implements vscode.WebviewViewProvider {
                 vscode.window.showErrorMessage(`初始化 ${viewType} AI 智能体失败: ` + error);
             }
         }
-    }
-
-    /**
-     * Kill the shared process, upgrade the CLI binary, rebuild the shared client +
-     * router, and re-initialize every active session with its restoreSessionId.
-     *
-     * This is called when the running CLI is older than the extension. Because the
-     * binary is replaced on disk, the shared process must be restarted to pick it up.
-     * All sessions that were live before the upgrade are re-initialized on the new
-     * process, preserving their session IDs so conversation history is restored.
-     */
-    private async reinitAllAfterUpgrade(config: ConfigurationData, clientVersion: string): Promise<void> {
-        // Collect every active session along with the sessionId to restore.
-        const active: Array<{ session: ChatSession; restoreSessionId: string | undefined }> = [];
-        if (this.sidebarSession.agent) {
-            active.push({ session: this.sidebarSession, restoreSessionId: this.sidebarSession.sessionId });
-        }
-        for (const session of this.tabSessions.values()) {
-            if (session.agent) {
-                active.push({ session, restoreSessionId: session.sessionId });
-            }
-        }
-        for (const session of this.windowSessions.values()) {
-            if (session.agent) {
-                active.push({ session, restoreSessionId: session.sessionId });
-            }
-        }
-
-        // Best-effort destroy: unregisters each agent from the router and sends a
-        // destroy request to the server. Failures are swallowed because the process
-        // will be killed next regardless.
-        await Promise.all(active.map(({ session }) => session.destroy().catch(() => {})));
-
-        // Kill the old shared process so the binary file can be replaced and the new
-        // binary picked up on restart.
-        this.sharedClient?.dispose();
-        this.sharedClient = undefined;
-        this.notificationRouter = undefined;
-
-        await upgradeWaveBinary(clientVersion);
-
-        // Rebuild the shared client + router against the freshly installed binary.
-        this.initSharedClient();
-
-        // Re-initialize every previously-active session on the new process, restoring
-        // each one's conversation history by sessionId.
-        await Promise.all(
-            active.map(({ session, restoreSessionId }) =>
-                session.initialize(
-                    config,
-                    restoreSessionId,
-                    clientVersion,
-                    this.sharedClient!,
-                    this.notificationRouter!,
-                ).catch((err) => {
-                    console.error('[Wave] Failed to re-initialize session after upgrade:', err);
-                }),
-            ),
-        );
     }
 
     private getChatSession(viewType: 'sidebar' | 'tab' | 'window', windowId?: string): ChatSession {
@@ -582,6 +521,10 @@ export class ChatProvider implements vscode.WebviewViewProvider {
         } catch (error) {
             console.error('销毁智能体时出错:', error);
         }
+
+        // Wait for init to complete (best-effort) before disposing the shared
+        // client so we don't race with init() still assigning sharedClient/router.
+        await this.initPromise.catch(() => {});
 
         this.sharedClient?.dispose();
 

--- a/packages/vsce/src/session/chatSession.ts
+++ b/packages/vsce/src/session/chatSession.ts
@@ -67,7 +67,6 @@ export class ChatSession {
     public async initialize(
         config: ConfigurationData,
         restoreSessionId: string | undefined,
-        clientVersion: string | undefined,
         sharedClient: StdioClient,
         router: NotificationRouter,
     ) {
@@ -174,7 +173,6 @@ export class ChatSession {
                 model: config.model,
                 fastModel: config.fastModel,
                 language: config.language,
-                clientVersion,
             };
 
             try {

--- a/packages/vsce/src/stdio/binaryResolver.ts
+++ b/packages/vsce/src/stdio/binaryResolver.ts
@@ -8,9 +8,10 @@
  * Result is cached for the extension lifetime.
  */
 
-import { execSync, execFile } from 'child_process';
+import { execSync, execFile, execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+import { parseVersion, compareVersions } from '../services/updateService';
 
 /** npm registry mirror for China users (faster than the default registry). */
 export const NPM_REGISTRY = 'https://registry.npmmirror.com';
@@ -122,6 +123,53 @@ export function resolveWaveBinary(): string {
     throw new Error(
         'wave binary not found after installation. Please install manually: npm install -g wave-code --registry=https://registry.npmmirror.com',
     );
+}
+
+/**
+ * Run `<binaryPath> -v` and return the CLI's version (e.g. "0.18.7").
+ * Returns null if the binary is missing, corrupt, or `-v` fails/times out —
+ * callers treat null as "needs upgrade" rather than crashing.
+ */
+export function getCliVersion(binaryPath: string): string | null {
+    try {
+        const output = execFileSync(binaryPath, ['-v'], {
+            encoding: 'utf-8',
+            stdio: ['ignore', 'pipe', 'ignore'],
+            timeout: 5000,
+            // `wave` is `wave.cmd` on Windows; Node refuses to execFileSync a
+            // `.cmd` without a shell.
+            shell: process.platform === 'win32',
+        });
+        const line = output.trim().split('\n')[0]?.trim();
+        if (!line) return null;
+        // `wave -v` prints the bare version; tolerate a leading "v" just in case.
+        return line.replace(/^v/, '');
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Ensure the `wave` CLI exists and its version is >= targetVersion.
+ * Returns the (possibly upgraded) binary path.
+ *
+ * 1. resolveWaveBinary() — auto-installs via npm if missing.
+ * 2. getCliVersion(path) — read the installed CLI version via `wave -v`.
+ * 3. If null (binary corrupt/unreadable) or older than target → upgrade to
+ *    targetVersion (which resets the cache and re-resolves).
+ */
+export async function ensureCliUpToDate(targetVersion: string): Promise<string> {
+    const binaryPath = resolveWaveBinary();
+    const current = getCliVersion(binaryPath);
+    if (current !== null) {
+        const cur = parseVersion(current);
+        const target = parseVersion(targetVersion);
+        if (cur && target && compareVersions(cur, target) >= 0) {
+            return binaryPath;
+        }
+    }
+    // current is null (corrupt) or older than target → upgrade.
+    return upgradeWaveBinary(targetVersion);
 }
 
 /** Reset cached binary path. Public so callers can force re-resolve after an upgrade. */

--- a/packages/vsce/src/stdio/stdioAgent.ts
+++ b/packages/vsce/src/stdio/stdioAgent.ts
@@ -46,7 +46,6 @@ export interface InitializeParams {
     disallowedTools?: string[];
     pluginDirs?: string[];
     mcpServers?: Record<string, McpServerConfig>;
-    clientVersion?: string;
 }
 
 export interface InitializeResult {
@@ -54,7 +53,6 @@ export interface InitializeResult {
     workingDirectory: string;
     permissionMode: PermissionMode;
     latestTotalTokens: number;
-    serverVersion?: string;
 }
 
 export interface UpdateConfigParams {
@@ -118,7 +116,6 @@ export class StdioAgent {
     public workingDirectory: string | undefined;
     public latestTotalTokens = 0;
     public permissionMode: PermissionMode | undefined;
-    public serverVersion: string | undefined;
     public messages: Message[] = [];
     public queuedMessages: QueuedMessage[] = [];
     public tasks: Task[] = [];
@@ -150,7 +147,6 @@ export class StdioAgent {
         this.workingDirectory = result.workingDirectory;
         this.permissionMode = result.permissionMode;
         this.latestTotalTokens = result.latestTotalTokens;
-        this.serverVersion = result.serverVersion;
         // Register with the router so subsequent notifications are routed here
         this.router.register(this.sessionId, this);
         return result;

--- a/packages/vsce/tests/stdio/binaryResolver.test.ts
+++ b/packages/vsce/tests/stdio/binaryResolver.test.ts
@@ -6,11 +6,13 @@ import path from 'path';
 const mockExecSync = vi.hoisted(() => vi.fn());
 const mockExistsSync = vi.hoisted(() => vi.fn());
 const mockExecFile = vi.hoisted(() => vi.fn());
+const mockExecFileSync = vi.hoisted(() => vi.fn());
 
 vi.mock('child_process', () => ({
-    default: { execSync: mockExecSync, execFile: mockExecFile },
+    default: { execSync: mockExecSync, execFile: mockExecFile, execFileSync: mockExecFileSync },
     execSync: mockExecSync,
     execFile: mockExecFile,
+    execFileSync: mockExecFileSync,
 }));
 
 vi.mock('fs', () => ({
@@ -35,7 +37,7 @@ const globalWave = path.join(globalBin, waveName);
 
 // ── Import after mocks ─────────────────────────────────────────
 
-import { resolveWaveBinary, _resetCacheForTesting, upgradeWaveBinary, resetCache, NPM_REGISTRY } from '../../src/stdio/binaryResolver';
+import { resolveWaveBinary, _resetCacheForTesting, upgradeWaveBinary, resetCache, getCliVersion, ensureCliUpToDate, NPM_REGISTRY } from '../../src/stdio/binaryResolver';
 
 describe('binaryResolver', () => {
     beforeEach(() => {
@@ -324,5 +326,95 @@ describe('binaryResolver', () => {
             expect(callArgs[0]).toBe(npmCmd);
             expect((callArgs[2] as { shell?: boolean }).shell).toBe(true);
         });
+    });
+
+    // ── getCliVersion ────────────────────────────────────────────
+
+    it('getCliVersion returns the bare version from wave -v', () => {
+        mockExecFileSync.mockReturnValue('0.18.7\n');
+        expect(getCliVersion(globalWave)).toBe('0.18.7');
+        expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+        const args = mockExecFileSync.mock.calls[0];
+        expect(args[0]).toBe(globalWave);
+        expect(args[1]).toEqual(['-v']);
+    });
+
+    it('getCliVersion strips a leading v prefix', () => {
+        mockExecFileSync.mockReturnValue('v0.19.0\n');
+        expect(getCliVersion(globalWave)).toBe('0.19.0');
+    });
+
+    it('getCliVersion returns null when wave -v throws', () => {
+        mockExecFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
+        expect(getCliVersion(globalWave)).toBeNull();
+    });
+
+    it('getCliVersion returns null for empty output', () => {
+        mockExecFileSync.mockReturnValue('   \n  \n');
+        expect(getCliVersion(globalWave)).toBeNull();
+    });
+
+    // ── ensureCliUpToDate ────────────────────────────────────────
+
+    it('ensureCliUpToDate returns existing path when version is >= target', async () => {
+        mockExecSync.mockImplementation((cmd: string) => {
+            if (cmd.includes(waveLookup)) return `${globalWave}\n`;
+            throw new Error(`unexpected: ${cmd}`);
+        });
+        mockExecFileSync.mockReturnValue('1.0.0\n');
+
+        const result = await ensureCliUpToDate('1.0.0');
+        expect(result).toBe(globalWave);
+        expect(mockExecFile).not.toHaveBeenCalled();
+    });
+
+    it('ensureCliUpToDate upgrades when version is older than target', async () => {
+        mockExecSync.mockImplementation((cmd: string) => {
+            if (cmd.includes(waveLookup)) return `${globalWave}\n`;
+            if (cmd.includes(npmLookup)) return `${npmBin}\n`;
+            throw new Error(`unexpected: ${cmd}`);
+        });
+        mockExecFileSync.mockReturnValue('0.18.0\n');
+        mockExecFile.mockImplementation((...args: unknown[]) => {
+            const cb = args[args.length - 1] as (err: Error | null) => void;
+            cb(null);
+        });
+
+        const result = await ensureCliUpToDate('1.0.0');
+        expect(result).toBe(globalWave);
+        expect(mockExecFile).toHaveBeenCalledTimes(1);
+        expect(mockExecFile.mock.calls[0][1]).toEqual([
+            'install', '-g', 'wave-code@1.0.0', `--registry=${NPM_REGISTRY}`,
+        ]);
+    });
+
+    it('ensureCliUpToDate upgrades when getCliVersion returns null (corrupt binary)', async () => {
+        mockExecSync.mockImplementation((cmd: string) => {
+            if (cmd.includes(waveLookup)) return `${globalWave}\n`;
+            if (cmd.includes(npmLookup)) return `${npmBin}\n`;
+            throw new Error(`unexpected: ${cmd}`);
+        });
+        // corrupt binary: -v fails
+        mockExecFileSync.mockImplementation(() => { throw new Error('corrupt'); });
+        mockExecFile.mockImplementation((...args: unknown[]) => {
+            const cb = args[args.length - 1] as (err: Error | null) => void;
+            cb(null);
+        });
+
+        const result = await ensureCliUpToDate('1.0.0');
+        expect(result).toBe(globalWave);
+        expect(mockExecFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('ensureCliUpToDate does not upgrade when version is newer than target', async () => {
+        mockExecSync.mockImplementation((cmd: string) => {
+            if (cmd.includes(waveLookup)) return `${globalWave}\n`;
+            throw new Error(`unexpected: ${cmd}`);
+        });
+        mockExecFileSync.mockReturnValue('2.0.0\n');
+
+        const result = await ensureCliUpToDate('1.0.0');
+        expect(result).toBe(globalWave);
+        expect(mockExecFile).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Summary

Replaces the fragile **post-initialize version-negotiation + `reinitAllAfterUpgrade`** flow with a **pre-spawn upgrade**. `BinaryResolver.ensureCliUpToDate(version)` runs `wave -v`, compares versions, and upgrades via `npm install -g` **before** the stdio process is spawned — so the shared client is never killed/recreated mid-session, eliminating the dangling-reference class of issues.

## Changes

### VSCode (`packages/vsce` + `packages/code`)
- **`chatProvider.ts`** — constructor starts async `init()` storing `initPromise`; every entry point (`onMessage`, `initializeAgent`, `destroy`) awaits it. `initializeAgent` reduced to a simple `session.initialize`. `reinitAllAfterUpgrade` + `cliUpgradeAttempted` deleted.
- **`binaryResolver.ts`** — new `getCliVersion()` (runs `<binary> -v`, parses + strips leading `v`) and `ensureCliUpToDate(targetVersion)` (resolve → compare → upgrade-if-older/corrupt).
- Removed `serverVersion`/`clientVersion` from `stdioAgent.ts`, `chatSession.ts`, and the server `agentBridge`.

### JetBrains (`packages/jetbrains`)
- **`BinaryResolver.kt`** — `getCliVersion()` (ProcessBuilder with 5s timeout) + `ensureCliUpToDate()`.
- **`WaveBackendService.kt`** — `ensureClient()` uses `ensureCliUpToDate`; `initializeSession` simplified. Deleted `reinitAllAfterUpgrade`, `upgradeMutex`, `cliUpgradeAttempted`.
- **`StdioAgent.kt`** — removed `serverVersion` from `InitializeResult` and its reading in `initialize()`.
- **`WaveSession.kt`** — removed `clientVersion` from initialize params.

### Tests
- Removed obsolete `serverVersion`/`clientVersion` assertions (incl. the `CLI_PACKAGE_VERSION` machinery in `agentBridge.test.ts` / `stdioServer.test.ts`).
- Added `getCliVersion` + `ensureCliUpToDate` coverage in VSCE `binaryResolver.test.ts` (8 tests).
- Added `getCliVersion` subprocess tests in JB `BinaryResolverTest.kt` (4 tests via a temp-dir shim script).

## Verification
| Check | Result |
|---|---|
| `pnpm -w run build` (workspace) | ✅ |
| `code` / `vsce` type-check | ✅ |
| `code` tests | ✅ 1085 passed (84 files) |
| `vsce` tests | ✅ 134 passed (9 files) |
| JB `compileKotlin` + `compileTestKotlin` | ✅ |
| JB `test` (BinaryResolverTest: 16 tests) | ✅ 0 skipped, 0 failed |

## Risk
The CLI is now upgraded **once** at shared-client creation (gated by `initMutex` on JB / `initPromise` on VSCE) rather than reactively after a version mismatch is detected. If the upgrade itself fails, init fails fast rather than leaving a stale client around — which is the desired behavior.