### PR TITLE
fix(vsce): show API errors immediately when no assistant message exists

### DIFF
--- a/packages/webview/src/reducers/chatReducer.ts
+++ b/packages/webview/src/reducers/chatReducer.ts
@@ -1,4 +1,4 @@
-import type { ChatState, ChatAction, MessageBlock, TextBlock, ToolBlock, ErrorBlock } from '../types';
+import type { ChatState, ChatAction, Message, MessageBlock, TextBlock, ToolBlock, ErrorBlock } from '../types';
 
 export const initialState: ChatState = {
   messages: [],
@@ -341,6 +341,8 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
     }
     case 'APPEND_ERROR_BLOCK': {
       const { error } = action.payload;
+      const newErrorBlock: ErrorBlock = { type: 'error', content: error };
+
       // Find the last assistant message
       let targetIndex = -1;
       for (let i = state.messages.length - 1; i >= 0; i--) {
@@ -349,10 +351,23 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
           break;
         }
       }
-      if (targetIndex === -1) return state;
+
+      // No assistant message yet (e.g. API error before any streaming chunk).
+      // Create one to carry the error block instead of silently dropping it.
+      if (targetIndex === -1) {
+        const errorMessage: Message = {
+          id: `msg-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
+          role: 'assistant',
+          timestamp: new Date().toISOString(),
+          blocks: [newErrorBlock],
+        };
+        return {
+          ...state,
+          messages: [...state.messages, errorMessage],
+        };
+      }
 
       const message = state.messages[targetIndex];
-      const newErrorBlock: ErrorBlock = { type: 'error', content: error };
       const newBlocks = [...message.blocks, newErrorBlock];
 
       const newMessages = state.messages.map((m, idx) => {

--- a/packages/webview/tests/reducers/chatReducer.test.ts
+++ b/packages/webview/tests/reducers/chatReducer.test.ts
@@ -417,7 +417,7 @@ describe('chatReducer', () => {
       expect(newState.messages[0].blocks).toHaveLength(1);
     });
 
-    it('should return original state if no assistant message exists', () => {
+    it('should create a new assistant message with error block if no assistant message exists', () => {
       const userMessage: Message = {
         id: 'msg-1',
         role: 'user',
@@ -428,10 +428,17 @@ describe('chatReducer', () => {
 
       const newState = chatReducer(state, {
         type: 'APPEND_ERROR_BLOCK',
-        payload: { error: 'Error' }
+        payload: { error: '402 Payment Required' }
       });
 
-      expect(newState).toBe(state);
+      expect(newState.messages).toHaveLength(2);
+      expect(newState.messages[0]).toBe(userMessage);
+      const errorMessage = newState.messages[1];
+      expect(errorMessage.role).toBe('assistant');
+      expect(errorMessage.blocks).toHaveLength(1);
+      const errorBlock = errorMessage.blocks[0] as ErrorBlock;
+      expect(errorBlock.type).toBe('error');
+      expect(errorBlock.content).toBe('402 Payment Required');
     });
 
     it('should not mutate original state', () => {


### PR DESCRIPTION
## Problem

When an API error (e.g. 402 Payment Required) fires before any streaming chunk arrives, no assistant message exists in the webview state yet. The `APPEND_ERROR_BLOCK` reducer silently dropped the error in this case (`targetIndex === -1 → return state`), causing it to only appear after switching away from and back to the sidebar (which triggers a full state re-sync via `setInitialState`).

## Root Cause

`packages/webview/src/reducers/chatReducer.ts` — the `APPEND_ERROR_BLOCK` case returned the original state unchanged when no assistant message existed. This is exactly the scenario for immediate error responses (402/401/400) where `onAssistantMessageAdded` never fires because no streaming chunk was received.

## Fix

When no assistant message exists, create a new assistant message to carry the error block — matching the SDK-side `addErrorBlockToMessage` behavior (`messageOperations.ts:412-421`).

## Test

Updated the test that previously asserted the buggy "drop error" behavior to verify a new assistant message with the error block is created instead.