### PR TITLE
fix(webview): 欢迎页登录按钮闪动 — 等初始登录状态到达后再显示

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -376,6 +376,10 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode }) => {
   // a direct-connect config (baseURL/apiKey) works without authentication, so an
   // unauthenticated user who sends a message must still see the chat, not the welcome page.
   const showWelcome = state.messages.length === 0;
+  // Withhold the welcome page until the initial state (incl. auth status) has
+  // arrived, otherwise logged-in users see the login CTA flash before
+  // setInitialState updates isAuthenticated to true.
+  const showWelcomeReady = showWelcome && state.initialized;
 
   // Initialize webview and load sessions on component mount
   useEffect(() => {
@@ -476,12 +480,16 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode }) => {
         isAuthenticated={state.isAuthenticated}
       />
       
-      {showWelcome ? (
+      {showWelcomeReady ? (
         <WelcomeView
           isAuthenticated={state.isAuthenticated}
           hasDirectConnectConfig={!!(state.configurationData?.apiKey && state.configurationData?.baseURL)}
           onLogin={handleLogin}
         />
+      ) : showWelcome ? (
+        // Initial placeholder: keep the flex slot occupied (flex:1) so the input
+        // area doesn't jump up before the welcome page is ready to show.
+        <div style={{ flex: 1, minHeight: 0 }} />
       ) : (
         <MessageList
           ref={messageListRef}

--- a/packages/webview/src/reducers/chatReducer.ts
+++ b/packages/webview/src/reducers/chatReducer.ts
@@ -25,6 +25,7 @@ export const initialState: ChatState = {
   attachedImages: [],
   // Auth state
   isAuthenticated: false,
+  initialized: false,
   workdir: undefined
 };
 
@@ -129,7 +130,8 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
     case 'SET_AUTHENTICATED':
       return {
         ...state,
-        isAuthenticated: action.payload
+        isAuthenticated: action.payload,
+        initialized: true
       };
     case 'SET_CONFIGURATION_LOADING':
       return {
@@ -167,6 +169,7 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
         attachedImages: action.payload.attachedImages || [],
         sessionsLoading: false,
         configurationLoading: false,
+        initialized: true,
         isAuthenticated: action.payload.isAuthenticated !== undefined ? action.payload.isAuthenticated : state.isAuthenticated,
         workdir: action.payload.workdir !== undefined ? action.payload.workdir : state.workdir
       };

--- a/packages/webview/src/types/index.ts
+++ b/packages/webview/src/types/index.ts
@@ -254,6 +254,10 @@ export interface ChatState {
   queuedMessages: QueuedMessage[];
   // Auth state
   isAuthenticated: boolean;
+  // Whether the initial state (incl. auth status) has been received from the
+  // backend. The welcome page is withheld until this is true so the login CTA
+  // doesn't flash for logged-in users before setInitialState arrives.
+  initialized: boolean;
   // Agent working directory, used to render tool file paths as relative.
   workdir?: string;
   // Dialog state

--- a/packages/webview/tests/webview/welcomeViewFlash.test.tsx
+++ b/packages/webview/tests/webview/welcomeViewFlash.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, act, sendCommand, createMockVscode } from './test-utils';
+import { ChatApp } from '../../src/components/ChatApp';
+
+/**
+ * Reproduces the welcome-page login-button flash:
+ * Before the backend pushes `setInitialState` (which carries the real auth
+ * status), the webview's initial `isAuthenticated` is `false`. A logged-in user
+ * would briefly see the "登 录" CTA, which then disappears once the real status
+ * arrives — a visible flash. The welcome page (incl. login button) must not
+ * render until the initial state is available.
+ */
+describe('WelcomeView login button flash', () => {
+    it('does not show the login button before initial state arrives', () => {
+        // Render directly (bypassing renderChatApp's auto authStatusResponse) to
+        // simulate the very first frame before setInitialState reaches the webview.
+        render(<ChatApp vscode={createMockVscode()} />);
+
+        expect(screen.queryByText('登 录')).not.toBeInTheDocument();
+        expect(screen.queryByText('登录后即可开始使用~')).not.toBeInTheDocument();
+    });
+
+    it('shows the login button once initial state arrives with isAuthenticated:false', () => {
+        render(<ChatApp vscode={createMockVscode()} />);
+
+        act(() => {
+            sendCommand('setInitialState', {
+                messages: [],
+                isStreaming: false,
+                sessions: [],
+                isAuthenticated: false,
+                configurationData: {},
+                pendingConfirmations: []
+            });
+        });
+
+        expect(screen.getByText('登 录')).toBeVisible();
+    });
+
+    it('does not show the login button when initial state arrives with isAuthenticated:true', () => {
+        render(<ChatApp vscode={createMockVscode()} />);
+
+        act(() => {
+            sendCommand('setInitialState', {
+                messages: [],
+                isStreaming: false,
+                sessions: [],
+                isAuthenticated: true,
+                configurationData: {},
+                pendingConfirmations: []
+            });
+        });
+
+        expect(screen.queryByText('登 录')).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## 问题

已登录用户打开 webview 时，欢迎页的「登 录」按钮会闪现一下后消失。

**根因**：webview 初始 `isAuthenticated: false`，而真实登录状态要等后端 `setInitialState`（内含 `isAuthenticated`）异步推送才到达（期间需初始化 agent + `getAuthStatus` RPC）。首帧时已登录用户的 `isAuthenticated` 仍是 `false`，于是渲染出登录按钮；`setInitialState` 到达后置为 `true`，按钮消失 → 视觉闪动。

## 修复

引入 `initialized` 标志（默认 `false`），欢迎页在初始状态到达前不渲染，到达后与真实登录状态一起显示。

- `ChatState` 新增 `initialized: boolean`
- `chatReducer`：初始 `initialized: false`；`SET_INITIAL_STATE` 与 `SET_AUTHENTICATED` 置 `true`（后者覆盖 webview 主动查询认证的 `authStatusResponse` 路径）
- `ChatApp`：`showWelcomeReady = showWelcome && state.initialized`；未就绪时渲染 `flex:1` 占位 div 保持布局稳定，避免输入框上移抖动
- 新增测试（test-before-fix）：先复现闪动，再验证初始状态到达前按钮不存在、到达后按真实 `isAuthenticated` 决定是否显示

后端（VSCE `messageHandler.ts` + JB `MessageHandler.kt`）已在 `setInitialState` 中推送 `isAuthenticated`，无需改动。

## 验证

- 失败测试先复现闪动，修复后 3/3 通过
- webview 全套 261 测试通过，类型检查通过
- webview dist 已构建并同步到 vsce/jetbrains
