### PR TITLE
fix(webview): 确认按钮长文本省略号截断防止溢出

### DIFF
--- a/packages/webview/src/styles/ConfirmationDialog.css
+++ b/packages/webview/src/styles/ConfirmationDialog.css
@@ -432,6 +432,13 @@
   box-sizing: border-box;
 }
 
+.confirmation-btn .btn-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .confirmation-btn-apply {
   background-color: var(--vscode-button-background);
   color: var(--vscode-button-foreground);


### PR DESCRIPTION
## 变更

确认对话框（ConfirmationDialog）中 "不再询问" 等按钮的文字过长时会溢出按钮边界。

新增 `.confirmation-btn .btn-text` 样式：

- `min-width: 0`：允许 flex 子项收缩
- `overflow: hidden` + `text-overflow: ellipsis` + `white-space: nowrap`：超长文本以省略号单行截断

按钮固定高度（32px）保持不变，避免长命令前缀或长名 MCP 工具（如 `mcp__wave_requirements__create_requirement`）撑爆按钮布局。

## 验证

- webview 构建通过
- `bashPermissionFix` / `confirmationDialog` 测试通过（14 passed）
- Playwright demo 截图确认 bash 长命令与长名 MCP 工具的省略号效果正常
