### PR TITLE
fix(webview): render streaming cursor on messages container not per-message

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -367,11 +367,6 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode }) => {
     dispatch({ type: 'HIDE_DIALOG' });
   }, []);
 
-  // Simple streaming message detection
-  const streamingMessageIndex = state.isStreaming && state.messages.length > 0 
-    ? state.messages.length - 1 
-    : undefined;
-
   // Welcome page shows only when there are no messages yet. Login is optional:
   // a direct-connect config (baseURL/apiKey) works without authentication, so an
   // unauthenticated user who sends a message must still see the chat, not the welcome page.
@@ -496,7 +491,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode }) => {
           ref={messageListRef}
           messages={state.messages}
           queuedMessages={state.queuedMessages}
-          streamingMessageIndex={streamingMessageIndex}
+          isStreaming={state.isStreaming}
           vscode={vscode}
           onRewindToMessage={handleRewindToMessage}
           workdir={state.workdir}

--- a/packages/webview/src/components/Message.tsx
+++ b/packages/webview/src/components/Message.tsx
@@ -101,7 +101,7 @@ const parseMarkdownWithMermaid = (content: string): ParsedMarkdownContent => {
 
 
 export const Message: React.FC<MessageProps> = React.memo((props) => {
-  const { message, isStreaming = false, isQueued = false, onRewindToMessage, workdir } = props;
+  const { message, isQueued = false, onRewindToMessage, workdir } = props;
   const getMessageClassName = () => {
     const classes = ['message'];
     
@@ -116,9 +116,6 @@ export const Message: React.FC<MessageProps> = React.memo((props) => {
       }
     } else if (message.role === 'assistant') {
       classes.push('assistant');
-      if (isStreaming) {
-        classes.push('streaming');
-      }
     }
     
     return classes.join(' ');
@@ -719,7 +716,6 @@ export const Message: React.FC<MessageProps> = React.memo((props) => {
 }, (prev, next) => {
   // Custom comparison for React.memo
   return prev.message === next.message &&
-    prev.isStreaming === next.isStreaming &&
     prev.isQueued === next.isQueued &&
     prev.onRewindToMessage === next.onRewindToMessage;
 });

--- a/packages/webview/src/components/MessageList.tsx
+++ b/packages/webview/src/components/MessageList.tsx
@@ -26,7 +26,7 @@ function countTimelineBlocks(message: MessageType): number {
   return count;
 }
 
-export const MessageList = forwardRef<{ scrollToBottom: (behavior?: ScrollBehavior) => void }, MessageListProps>(function MessageList({ messages, queuedMessages, streamingMessageIndex, vscode, onRewindToMessage, workdir }, ref) {
+export const MessageList = forwardRef<{ scrollToBottom: (behavior?: ScrollBehavior) => void }, MessageListProps>(function MessageList({ messages, queuedMessages, isStreaming, vscode, onRewindToMessage, workdir }, ref) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -116,7 +116,7 @@ export const MessageList = forwardRef<{ scrollToBottom: (behavior?: ScrollBehavi
     // 1. It's a brand new message that should be forced
     // 2. We are currently streaming content AND user hasn't scrolled up
     // 3. The user is already near the bottom AND hasn't scrolled up
-    if (shouldForce || ((streamingMessageIndex !== undefined || isNearBottom) && !userScrolledUpRef.current)) {
+    if (shouldForce || ((isStreaming || isNearBottom) && !userScrolledUpRef.current)) {
       // A new user message means the user wants to follow the upcoming reply:
       // clear any prior opt-out so streaming auto-scrolls into view.
       if (shouldForce && isUserMessage) {
@@ -124,7 +124,7 @@ export const MessageList = forwardRef<{ scrollToBottom: (behavior?: ScrollBehavi
       }
       doScrollToBottom(behavior);
     }
-  }, [messages, streamingMessageIndex, doScrollToBottom]);
+  }, [messages, isStreaming, doScrollToBottom]);
 
   // Expose scrollToBottom method to parent component
   useImperativeHandle(ref, () => ({
@@ -181,20 +181,20 @@ export const MessageList = forwardRef<{ scrollToBottom: (behavior?: ScrollBehavi
     // Follow new content: scroll on every messages change (incl. streaming text
     // chunks so streamed text stays visible), gated by userScrolledUp inside
     // scrollToBottom. A brand-new message forces the scroll.
-    scrollToBottom(streamingMessageIndex !== undefined ? 'auto' : 'smooth', isNewMessage);
+    scrollToBottom(isStreaming ? 'auto' : 'smooth', isNewMessage);
     computeSticky();
 
     return () => {
       resizeObserver.disconnect();
       container.removeEventListener('scroll', handleScroll);
     };
-  }, [messages, queuedMessages, streamingMessageIndex, scrollToBottom, computeSticky]);
+  }, [messages, queuedMessages, isStreaming, scrollToBottom, computeSticky]);
 
   return (
     <div 
       ref={containerRef}
       id="messagesContainer" 
-      className="messages-container" 
+      className={`messages-container${isStreaming ? ' streaming' : ''}`}
       data-testid="messages-container"
     >
       {stickyMessage && (
@@ -212,23 +212,18 @@ export const MessageList = forwardRef<{ scrollToBottom: (behavior?: ScrollBehavi
       )}
       {/* Chat messages - filter out user meta messages */}
       {useMemo(() => {
-        // Filter out user messages with isMeta, and build index mapping for streaming detection
+        // Filter out user messages with isMeta (hidden from the list)
         const visibleMessages: MessageType[] = [];
-        const originalIndexMap: number[] = [];
-        for (let i = 0; i < messages.length; i++) {
-          const msg = messages[i];
+        for (const msg of messages) {
           if (msg.role === 'user' && msg.isMeta) continue;
           visibleMessages.push(msg);
-          originalIndexMap.push(i);
         }
 
-        const renderMessage = (message: MessageType, idx: number) => {
-          const isStreaming = streamingMessageIndex !== undefined && originalIndexMap[idx] === streamingMessageIndex;
+        const renderMessage = (message: MessageType) => {
           return (
             <Message
               key={message.id}
               message={message}
-              isStreaming={isStreaming}
               vscode={vscode}
               onRewindToMessage={onRewindToMessage}
               workdir={workdir}
@@ -240,7 +235,7 @@ export const MessageList = forwardRef<{ scrollToBottom: (behavior?: ScrollBehavi
         // the timeline vertical line runs continuously through all their dots. User
         // messages break the timeline (rendered as bare bubbles outside any group).
         const rendered: React.ReactNode[] = [];
-        let group: { message: MessageType; idx: number }[] = [];
+        let group: { message: MessageType }[] = [];
 
         const flushGroup = () => {
           if (group.length === 0) return;
@@ -251,24 +246,24 @@ export const MessageList = forwardRef<{ scrollToBottom: (behavior?: ScrollBehavi
               key={group[0].message.id}
               className={`assistant-group${single ? ' assistant-group--single' : ''}`}
             >
-              {group.map(g => renderMessage(g.message, g.idx))}
+              {group.map(g => renderMessage(g.message))}
             </div>
           );
           group = [];
         };
 
-        visibleMessages.forEach((message, idx) => {
+        visibleMessages.forEach((message) => {
           if (message.role === 'assistant') {
-            group.push({ message, idx });
+            group.push({ message });
           } else {
             flushGroup();
-            rendered.push(renderMessage(message, idx));
+            rendered.push(renderMessage(message));
           }
         });
         flushGroup();
 
         return rendered;
-      }, [messages, streamingMessageIndex, vscode, onRewindToMessage])}
+      }, [messages, vscode, onRewindToMessage])}
       
       {/* Invisible div to scroll to */}
       <div ref={messagesEndRef} />

--- a/packages/webview/src/styles/Message.css
+++ b/packages/webview/src/styles/Message.css
@@ -174,9 +174,12 @@
     word-break: break-word;
 }
 
-.message.streaming::after {
+.messages-container.streaming::after {
     content: "▋";
     animation: blink 1s ease-in-out infinite;
+    align-self: flex-start;
+    padding-left: 2px;
+    line-height: 1;
 }
 
 /* Content Container for Mixed HTML/Mermaid Content */

--- a/packages/webview/src/types/index.ts
+++ b/packages/webview/src/types/index.ts
@@ -132,7 +132,7 @@ export interface ChatAppProps {
 export interface MessageListProps {
   messages: Message[];
   queuedMessages?: QueuedMessage[];
-  streamingMessageIndex?: number;
+  isStreaming?: boolean;
   vscode: VsCodeApi;
   onRewindToMessage?: (messageId: string) => void;
   workdir?: string;
@@ -140,7 +140,6 @@ export interface MessageListProps {
 
 export interface MessageProps {
   message: Message;
-  isStreaming?: boolean;
   isQueued?: boolean;
   vscode: VsCodeApi;
   onRewindToMessage?: (messageId: string) => void;

--- a/packages/webview/tests/webview/streamingCursorMetaGap.test.tsx
+++ b/packages/webview/tests/webview/streamingCursorMetaGap.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderChatApp, screen, sendCommand } from './test-utils';
+
+/**
+ * Regression: the streaming cursor (blinking ▋) used to be a `::after` on the
+ * last `.message` element, picked via `streamingMessageIndex = messages.length - 1`.
+ * When the backend appended a trailing `isMeta` user message (task-reminder /
+ * goal reminder / length-resume prompt) before the first content chunk, that
+ * index pointed at a hidden meta message — the cursor vanished while the abort
+ * button (driven directly by isStreaming) stayed.
+ *
+ * The cursor is now a `::after` on `.messages-container` itself, toggled by the
+ * single `isStreaming` flag. It can never diverge from the abort button, shows
+ * even before the first assistant chunk lands, and is immune to trailing meta
+ * messages.
+ */
+describe('Streaming cursor on the messages container', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('shows the cursor (container.streaming) while streaming, even with a trailing meta message', () => {
+        renderChatApp();
+
+        // Seed a visible user message so the MessageList (not the welcome page) renders.
+        sendCommand('updateMessages', {
+            messages: [{
+                id: 'msg-user-1',
+                role: 'user',
+                timestamp: '2024-01-01T00:00:00.000Z',
+                blocks: [{ type: 'text', content: 'Hello' }]
+            }]
+        });
+
+        // Backend flips loading → webview isStreaming = true, BEFORE any assistant
+        // chunk has arrived. The cursor must already be visible at the list bottom.
+        sendCommand('startStreaming');
+
+        const container = screen.getByTestId('messages-container');
+        expect(container.classList.contains('streaming')).toBe(true);
+        // Abort button is driven by the same isStreaming flag.
+        expect(screen.getByTestId('abort-btn')).toBeInTheDocument();
+
+        // Agent injects a meta user message (task reminder) AFTER the assistant
+        // turn message but before content streams. The cursor must stay.
+        sendCommand('updateMessages', {
+            messages: [
+                {
+                    id: 'msg-user-1',
+                    role: 'user',
+                    timestamp: '2024-01-01T00:00:00.000Z',
+                    blocks: [{ type: 'text', content: 'Hello' }]
+                },
+                {
+                    id: 'msg-assistant-1',
+                    role: 'assistant',
+                    timestamp: '2024-01-01T00:00:00.000Z',
+                    blocks: [{ type: 'text', content: 'Let me think…' }]
+                },
+                {
+                    id: 'msg-meta-1',
+                    role: 'user',
+                    isMeta: true,
+                    timestamp: '2024-01-01T00:00:00.000Z',
+                    blocks: [{ type: 'text', content: '<!-- task-reminder -->' }]
+                }
+            ]
+        });
+
+        // Meta message stays hidden; cursor + abort button remain.
+        expect(screen.queryByText('<!-- task-reminder -->')).not.toBeInTheDocument();
+        expect(screen.getByTestId('messages-container').classList.contains('streaming')).toBe(true);
+        expect(screen.getByTestId('abort-btn')).toBeInTheDocument();
+
+        // No individual message carries a `streaming` class anymore.
+        const msgs = screen.getByTestId('messages-container').querySelectorAll('.message');
+        msgs.forEach(m => expect(m.classList.contains('streaming')).toBe(false));
+
+        // End streaming → cursor disappears in lockstep with the abort button.
+        sendCommand('endStreaming');
+        expect(screen.getByTestId('messages-container').classList.contains('streaming')).toBe(false);
+        expect(screen.queryByTestId('abort-btn')).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Problem
The streaming cursor (blinking block) sometimes disappeared while the pause/abort button stayed in its loading state.

Root cause: the cursor was a CSS ::after on the last .message element, picked via `streamingMessageIndex = messages.length - 1`. The backend appends trailing `isMeta` user messages (task-reminder, goal reminder, length-resume prompt) before the first content chunk lands; MessageList hides those, so the index pointed at a hidden message — the cursor vanished while `isStreaming` (which drives the abort button) stayed true.

## Fix
Render the cursor as a ::after on `.messages-container` itself, toggled by the single `isStreaming` flag. The cursor and abort button now share one source of truth and can no longer diverge.

Side benefits:
- The cursor shows even before the first assistant chunk arrives (previously absent in that window).
- Immune to trailing meta messages.

Removed the `streamingMessageIndex` computation, the per-message `isStreaming` prop, and the `originalIndexMap` index-mapping plumbing.

## Test
- New test `streamingCursorMetaGap.test.tsx`: cursor present before first chunk, stays with a trailing isMeta message, no per-message `streaming` class, disappears in lockstep with the abort button on `endStreaming`.
- Full webview suite (263 tests) passes; type-check passes.
