### PR TITLE
webview 自动跟随修复 + worktree 偏好规则

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ Always use `pnpm` as the package manager.
 ## 🔍 Code Navigation & Exploration
 
 - **Worktree Isolation**: If the current working directory is within a worktree (e.g., `.wave/worktrees/`), do NOT read or edit files in the base repository. Always stay within the current worktree.
+- **Prefer worktree for edits**: If the working directory is the base repository (not a worktree), prefer creating a worktree before making code/doc changes. Pure research, reading, or running commands may stay in the base repo.
 - **Code Exploration**: This is a large codebase. NEVER read too many code files at once. You MUST ALWAYS use the `LSP` tool (goToDefinition, findReferences, etc.) as your primary method to understand code relationships and navigate the codebase. Only fallback to `Grep` or `Read` when `LSP` is insufficient.
 - **Grep in node_modules**: When using the `Grep` tool to search within `node_modules`, you MUST explicitly set the `path` parameter to include `node_modules` (e.g., `path: "node_modules"` or `path: "packages/code/node_modules"`), as it may be excluded by default. Note that `path: "."` will NOT work because `node_modules` is typically ignored by `.gitignore`.
 

--- a/packages/webview/src/components/MessageList.tsx
+++ b/packages/webview/src/components/MessageList.tsx
@@ -46,6 +46,12 @@ export const MessageList = forwardRef<{ scrollToBottom: (behavior?: ScrollBehavi
   const isProgrammaticScrollRef = useRef(false);
   // Last seen scrollTop, used to detect scroll direction (up vs down).
   const prevScrollTopRef = useRef(0);
+  // Last seen scrollHeight, used to tell a content-shrink clamp apart from a
+  // genuine user scroll-up. When content above the viewport shrinks (reasoning
+  // auto-collapse, streaming-end reflow, image load, etc.) the browser clamps
+  // scrollTop downward to keep it within bounds, which otherwise looks identical
+  // to an upward user gesture and would wrongly suspend auto-follow.
+  const prevScrollHeightRef = useRef(0);
 
   // The most-recent user message that has scrolled above the viewport top; pinned
   // at the top of the list as a context hint (设计稿 2236-3792).
@@ -154,16 +160,21 @@ export const MessageList = forwardRef<{ scrollToBottom: (behavior?: ScrollBehavi
       if (!isProgrammaticScrollRef.current) {
         const isNearBottom = container.scrollTop + container.clientHeight >= container.scrollHeight - 300;
         const scrolledUp = container.scrollTop < prevScrollTopRef.current;
+        // A clamp from a content-shrink reflow (scrollHeight decreased) moves
+        // scrollTop downward but is NOT user intent — ignore it so auto-follow
+        // survives reasoning collapse / streaming-end reflow / image load.
+        const contentShrank = container.scrollHeight < prevScrollHeightRef.current;
         // An upward gesture always opts out of following (covers the "slight
         // nudge up then stop" case that the distance threshold alone missed).
         // A downward gesture to the bottom region opts back in.
-        if (scrolledUp) {
+        if (scrolledUp && !contentShrank) {
           userScrolledUpRef.current = true;
         } else if (isNearBottom) {
           userScrolledUpRef.current = false;
         }
       }
       prevScrollTopRef.current = container.scrollTop;
+      prevScrollHeightRef.current = container.scrollHeight;
       computeSticky();
     };
 

--- a/packages/webview/tests/webview/autoScrollFollow.test.tsx
+++ b/packages/webview/tests/webview/autoScrollFollow.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderChatApp, screen, waitFor, act, sendCommand, fireEvent } from './test-utils';
+
+const userMsg = (content: string, id: string) => ({
+  id,
+  role: 'user' as const,
+  timestamp: '2025-01-01T00:00:00.000Z',
+  blocks: [{ type: 'text', content }]
+});
+
+const assistantMsg = (content: string, id: string) => ({
+  id,
+  role: 'assistant' as const,
+  timestamp: '2025-01-01T00:00:00.000Z',
+  blocks: [{ type: 'text', content }]
+});
+
+/**
+ * jsdom does not do layout, so offsetTop/scrollTop/clientHeight/scrollHeight are all 0.
+ * Fake the geometry by redefining those properties on the container, then dispatch a
+ * scroll event so MessageList's scroll handler records the position.
+ */
+function setGeometryAndScroll(scrollTop: number, scrollHeight: number, clientHeight = 400) {
+  const container = screen.getByTestId('messages-container');
+  Object.defineProperty(container, 'scrollTop', { value: scrollTop, configurable: true });
+  Object.defineProperty(container, 'clientHeight', { value: clientHeight, configurable: true });
+  Object.defineProperty(container, 'scrollHeight', { value: scrollHeight, configurable: true });
+  act(() => {
+    fireEvent.scroll(container);
+  });
+}
+
+describe('auto-scroll follow during streaming', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps following when content above the viewport shrinks (e.g. reasoning collapse) without a user scroll-up', async () => {
+    const scrollIntoView = vi.fn();
+    // jsdom doesn't implement Element.scrollIntoView
+    window.Element.prototype.scrollIntoView = scrollIntoView;
+
+    renderChatApp();
+    act(() => {
+      sendCommand('updateMessages', {
+        messages: [userMsg('问题', 'u1'), assistantMsg('正在回答', 'a1')]
+      });
+    });
+    await waitFor(() => expect(screen.getByTestId('messages-container')).toBeInTheDocument());
+
+    // Begin streaming so streamingMessageIndex is set and the effect follows content.
+    act(() => {
+      sendCommand('startStreaming');
+    });
+    // Let the programmatic-scroll flag (reset via requestAnimationFrame in
+    // doScrollToBottom) clear so the subsequent manual scroll events are evaluated
+    // as user/layout intent rather than ignored as our own scroll.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    // Park the viewport at the bottom: scrollTop 1600 + clientHeight 400 = scrollHeight 2000.
+    setGeometryAndScroll(1600, 2000);
+    scrollIntoView.mockClear();
+
+    // Simulate content above the viewport shrinking (reasoning block auto-collapse,
+    // streaming-end reflow, image load reflow, etc.): scrollHeight drops and the
+    // browser clamps scrollTop downward to keep it within bounds. This is NOT a user
+    // scroll-up gesture, yet the raw scrollTop decreases.
+    setGeometryAndScroll(800, 1200);
+    scrollIntoView.mockClear();
+
+    // A subsequent streaming chunk arrives (messages change → effect runs). The user
+    // never scrolled up, so auto-scroll-to-bottom must still fire.
+    act(() => {
+      sendCommand('updateMessages', {
+        messages: [userMsg('问题', 'u1'), assistantMsg('正在回答……更多内容追加', 'a1')]
+      });
+    });
+
+    expect(scrollIntoView).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 本次变更

本分支包含两个独立提交：

### 1. fix(webview): 内容收缩时不要误判为用户上滑而中止自动跟随

**问题**：有时消息列表会丢失自动滚动到底部（用户未主动上滑的情况下）。

**根因**：`MessageList.tsx` 的 `handleScroll` 用方向判定用户意图——只要 `scrollTop` 减小就置 `userScrolledUp = true`。但内容收缩（reasoning 自动折叠、streaming 结束 reflow、图片加载等）会让 `scrollHeight` 减小，浏览器自动 clamp `scrollTop` 下移，产生一个非用户操作的向上 scroll 事件，被误判为"用户上滑"，于是后续 streaming 文本不再自动跟随到底部。

**修复**：新增 `prevScrollHeightRef` 追踪 `scrollHeight`，当检测到 `scrollHeight` 减小（内容收缩 clamp）时，不把 `scrollTop` 的下移当作用户上滑，`userScrolledUp` 保持原状，auto-follow 得以存活。既有的方向判定行为（"轻微上滑即停止跟随"）原样保留。

**测试**：新增 `autoScrollFollow.test.tsx`，先写失败用例复现内容收缩后 auto-follow 丢失，修复后通过。全部 263 测试无回归。

### 2. docs: 新增 prefer worktree for edits 偏好规则

在 `AGENTS.md` 的 Code Navigation & Exploration 区块新增一条，与既有 Worktree Isolation 配对：若 workdir 在主仓库（非 worktree），做代码/文档修改前优先创建 worktree；纯调研、读取、运行命令可留在主仓库。