### PR TITLE
fix(vsce): hide task list and message queue when dialog is open

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -495,22 +495,24 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode }) => {
       )}
 
       <div className="input-area-container">
-        <TaskList
-          tasks={state.tasks}
-          isCollapsed={state.isTaskListCollapsed}
-          onToggleCollapse={() => dispatch({ type: 'TOGGLE_TASK_LIST_COLLAPSE' })}
-        />
-        <QueuedMessageList
-          queuedMessages={state.queuedMessages}
-          isCollapsed={state.isQueueCollapsed}
-          onToggleCollapse={() => dispatch({ type: 'TOGGLE_QUEUE_COLLAPSE' })}
-          onEdit={handleEditQueuedMessage}
-          onSend={handleSendQueuedMessage}
-          onDelete={handleDeleteQueuedMessage}
-          editingQueuedId={state.editingQueuedId}
-          vscode={vscode}
-        />
-        
+        <div style={{ display: state.activeDialog ? 'none' : 'block' }}>
+          <TaskList
+            tasks={state.tasks}
+            isCollapsed={state.isTaskListCollapsed}
+            onToggleCollapse={() => dispatch({ type: 'TOGGLE_TASK_LIST_COLLAPSE' })}
+          />
+          <QueuedMessageList
+            queuedMessages={state.queuedMessages}
+            isCollapsed={state.isQueueCollapsed}
+            onToggleCollapse={() => dispatch({ type: 'TOGGLE_QUEUE_COLLAPSE' })}
+            onEdit={handleEditQueuedMessage}
+            onSend={handleSendQueuedMessage}
+            onDelete={handleDeleteQueuedMessage}
+            editingQueuedId={state.editingQueuedId}
+            vscode={vscode}
+          />
+        </div>
+
         <div style={{ display: state.pendingConfirmations.length === 0 ? 'block' : 'none' }}>
           <MessageInput
             ref={messageInputRef}


### PR DESCRIPTION
## Summary

Hide the TaskList and QueuedMessageList when a dialog (config/plugin/mcp/status) is open, matching the existing MessageInput pattern.

## Changes

- Wrap TaskList and QueuedMessageList in a container div that uses `display: none` when `state.activeDialog` is set
- Uses `display: none` (not conditional rendering) to keep components mounted, preserving internal state — consistent with how MessageInput is hidden during pending confirmations