### PR TITLE
fix(jetbrains): build webview with --production to slim the .zip

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,8 +127,12 @@ jobs:
 
       # copyWebviewAssets (build.gradle.kts) copies chat.js/chat.css from
       # packages/webview/dist into the plugin resources, so build the webview next.
+      # Use `compile -- --production` (not `build`) so the bundle is minified and
+      # source maps are omitted — `build` would also trigger postbuild syncTargets,
+      # which is unnecessary here and ships the unminified dev bundle (~9.4MB vs
+      # ~3.6MB), bloating the .zip.
       - name: Build webview dist
-        run: pnpm -F wave-webview run build
+        run: pnpm -F wave-webview run compile -- --production
 
       - name: Run Gradle tests
         run: ./packages/jetbrains/gradlew -p packages/jetbrains test --no-daemon

--- a/packages/jetbrains/build.gradle.kts
+++ b/packages/jetbrains/build.gradle.kts
@@ -39,9 +39,10 @@ intellijPlatform {
 }
 
 // Copy webview assets (chat.js/chat.css) from packages/webview/dist into resources.
-// Also copy the full VS Code theme variable set (vscode-styles.css) from the webview e2e
-// utils — JetBrains JCEF is a bare browser and does NOT inject --vscode-* CSS variables
-// the way VS Code's webview does, so we ship a complete theme as the styling base.
+// Also copy the full VS Code theme variable set (vscode-styles.css + theme-base-light.css)
+// from the webview e2e utils — JetBrains JCEF is a bare browser and does NOT inject
+// --vscode-* CSS variables the way VS Code's webview does, so we ship a complete theme
+// (dark + light bases) as the styling base.
 val copyWebviewAssets by tasks.registering(Copy::class) {
     val webviewDir = rootProject.projectDir.parentFile.resolve("webview")
     from(webviewDir.resolve("dist")) {
@@ -50,6 +51,9 @@ val copyWebviewAssets by tasks.registering(Copy::class) {
     from(webviewDir.resolve("e2e/utils")) {
         include("vscode-styles.css")
         rename { "theme-base.css" }
+    }
+    from(webviewDir.resolve("e2e/utils")) {
+        include("theme-base-light.css")
     }
     into(layout.projectDirectory.dir("src/main/resources/webview"))
 }


### PR DESCRIPTION
## Summary

The earlier slim commit `2562fed2` (strip source maps and minify webview) only added `--production` to the **VSCE** syncWebview path. The **JetBrains** CI job was missed — it ran `pnpm -F wave-webview run build` (= `compile` without `--production`), so the gradle `copyWebviewAssets` task copied the **unminified dev bundle** (`chat.js` ~9.4MB) into the jar.

## Evidence

The 0.19.5 jar shipped `webview/chat.js` at **9,435,991 bytes (dev)**. With `--production` it drops to **3,782,431 bytes (minified)** — verified locally.

## Changes

- **`publish.yml`**: `pnpm -F wave-webview run build` → `pnpm -F wave-webview run compile -- --production` for the `build-jetbrains` job. Uses `compile` (not `build`) to skip the unnecessary `postbuild` `syncTargets` run.
- **`build.gradle.kts`**: `copyWebviewAssets` now also copies `theme-base-light.css`. It was previously only synced by `syncTargets.mjs` (`postbuild`), which no longer runs in this job. Without it the light-theme base would regress.

## Result

Local `buildPlugin` output: `wave-jetbrains-0.19.7.zip` **5.63MB → 4.80MB** (jar `wave-jetbrains.jar` 2.06MB → 1.47MB). Verified jar contains 0 `.map` files and the minified `chat.js`.

Note: JB never shipped source maps (gradle only included `chat.js`/`chat.css`), so this release's slimming comes purely from minification. The remaining ~3.7MB is the Kotlin runtime (stdlib + coroutines + serialization), which is unchanged.
