### PR TITLE
fix: unify context-tag font size & open binary files in VSCE

### DIFF
--- a/packages/vsce/src/session/messageHandler.ts
+++ b/packages/vsce/src/session/messageHandler.ts
@@ -240,21 +240,27 @@ export class MessageHandler {
 
     private async handleOpenFile(filePath: string, startLine?: number, endLine?: number) {
         if (!filePath) return;
-        
+
+        const uri = vscode.Uri.file(filePath);
         try {
-            const uri = vscode.Uri.file(filePath);
             const document = await vscode.workspace.openTextDocument(uri);
             const editor = await vscode.window.showTextDocument(document);
-            
+
             if (startLine !== undefined) {
                 const start = new vscode.Position(Math.max(0, startLine - 1), 0);
                 const end = new vscode.Position(Math.max(0, (endLine || startLine) - 1), 0);
                 editor.selection = new vscode.Selection(start, end);
                 editor.revealRange(new vscode.Range(start, end), vscode.TextEditorRevealType.InCenter);
             }
-        } catch (error) {
-            console.error('打开文件失败:', error);
-            vscode.window.showErrorMessage('打开文件失败: ' + error);
+        } catch {
+            // Binary files (images, PDFs, etc.) cannot be opened as text —
+            // fall back to VS Code's built-in viewer.
+            try {
+                await vscode.commands.executeCommand('vscode.open', uri);
+            } catch (fallbackError) {
+                console.error('打开文件失败:', fallbackError);
+                vscode.window.showErrorMessage('打开文件失败: ' + fallbackError);
+            }
         }
     }
 

--- a/packages/webview/src/components/ContextTag.css
+++ b/packages/webview/src/components/ContextTag.css
@@ -3,7 +3,7 @@
     align-items: center;
     padding: 2px 8px;
     border-radius: 4px;
-    font-size: 13px;
+    font-size: 12px;
     background-color: var(--vscode-editor-inactiveSelectionBackground);
     color: var(--vscode-foreground);
     margin: 2px;
@@ -16,7 +16,7 @@
 
 .context-tag .tag-at {
     font-weight: bold;
-    font-size: 14px;
+    font-size: 12px;
     opacity: 0.9;
     margin-right: 4px;
 }


### PR DESCRIPTION
## Summary

Two fixes for the VS Code extension:

### 1. Unify context-tag font size to 12px (`cdec5617`)
Inline `@` context tags in the input box used a larger font size (13px for the tag, 14px for the `@` symbol) than the surrounding input text (12px), making them visually oversized. Both are now aligned to 12px.

| Element | Before | After |
|---------|--------|-------|
| Input text | 12px | 12px |
| context-tag | 13px | 12px |
| tag-at (`@`) | 14px | 12px |

### 2. Fall back to `vscode.open` for binary files (`037a0742`)
`handleOpenFile` used `openTextDocument`, which throws *"File seems to be binary and cannot be opened as text"* for images and other non-text files. It now catches the error and retries with the built-in `vscode.open` command, which uses VS Code's image viewer / binary previewer.

JetBrains plugin is unaffected — its `FileEditorManager.openFile` already auto-selects the appropriate editor per file type.