### PR TITLE
feat(webview): add 历史提示词 entry to plus menu and align popup placeholder

### DIFF
--- a/packages/webview/src/components/HistorySearchPopup.tsx
+++ b/packages/webview/src/components/HistorySearchPopup.tsx
@@ -138,7 +138,7 @@ export const HistorySearchPopup: React.FC<HistorySearchPopupProps> = ({
           ref={inputRef}
           type="text"
           className="history-search-input"
-          placeholder="搜索历史记录..."
+          placeholder="搜索历史提示词..."
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}

--- a/packages/webview/src/components/MessageInput.tsx
+++ b/packages/webview/src/components/MessageInput.tsx
@@ -1275,6 +1275,16 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>((p
                   >
                     上传文件
                   </li>
+                  <li
+                    role="menuitem"
+                    className="plus-menu-item"
+                    onClick={() => {
+                      openHistorySearch();
+                      setPlusMenuOpen(false);
+                    }}
+                  >
+                    历史提示词
+                  </li>
                 </ul>
               )}
             </div>


### PR DESCRIPTION
## Summary

### 1. Add '历史提示词' item to the '+' menu
Adds a new menu item below '上传文件' in the input box '+' dropdown. Clicking it calls the existing `openHistorySearch()` — identical to pressing Ctrl+R — opening the history search popup.

### 2. Align popup placeholder terminology
The history search input placeholder is updated from '搜索历史记录...' to '搜索历史提示词...' to stay consistent with the new menu item name.