### PR TITLE
feat(stdio): improve error diagnostics, Node.js version check, stderr forwarding, and install progress

### DIFF
--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/WaveBackendService.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/WaveBackendService.kt
@@ -1,6 +1,8 @@
 package com.wave.jetbrains
 
 import com.intellij.ide.BrowserUtil
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
@@ -52,12 +54,21 @@ class WaveBackendService(private val project: Project) : Disposable {
     suspend fun ensureClient(): Pair<StdioClient, NotificationRouter> {
         initMutex.withLock {
             if (sharedClient == null) {
+                BinaryResolver.onInstall = { message ->
+                    Edt.invokeLater {
+                        NotificationGroupManager.getInstance()
+                            .getNotificationGroup("Wave")
+                            .createNotification("Wave", message, NotificationType.INFORMATION)
+                            .notify(project)
+                    }
+                }
                 val pluginVer = WaveSession.pluginVersion()
                 val binary = if (pluginVer.isNotEmpty()) {
                     BinaryResolver.ensureCliUpToDate(pluginVer)
                 } else {
                     BinaryResolver.resolveWaveBinary()
                 }
+                BinaryResolver.onInstall = null
                 val c = StdioClient(binary, listOf("--stdio"), BinaryResolver.resolveEnv())
                 val r = NotificationRouter(c)
                 r.attach()

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
@@ -3,6 +3,9 @@ package com.wave.jetbrains.stdio
 import com.intellij.openapi.diagnostic.logger
 import java.io.File
 
+/** Minimum Node.js major version required by `wave --stdio`. */
+private const val MIN_NODE_MAJOR = 20
+
 /**
  * Resolves the `wave` binary at runtime: PATH → npm global bin → auto-install.
  * Mirrors packages/vsce/src/stdio/binaryResolver.ts.
@@ -23,10 +26,16 @@ object BinaryResolver {
     private val waveName = if (isWindows) "wave.cmd" else "wave"
     private val lookupCmd = if (isWindows) "where" else "which"
 
+    /** Optional callback invoked when an npm install/upgrade starts. */
+    var onInstall: ((String) -> Unit)? = null
+
     fun resolveWaveBinary(): String {
         cachedPath?.let { return it }
 
-        // 0. nvm-installed binary (GUI-launched IDEs don't inherit shell PATH, so an
+        // 0. Verify Node.js >= 20 — wave --stdio requires it.
+        checkNodeVersion()
+
+        // 0a. nvm-installed binary (GUI-launched IDEs don't inherit shell PATH, so an
         // nvm-managed npm/wave install is invisible to `which` — probe nvm first).
         findInNvm(waveName)?.let { return cache(it) }
 
@@ -43,6 +52,7 @@ object BinaryResolver {
         // 4. auto-install
         val npm = findNpm()
         LOG.info("wave not found; running: \"$npm\" install -g $PACKAGE --registry=$NPM_REGISTRY")
+        onInstall?.invoke("正在安装 wave-code，请稍候…")
         runCommand(npm, "install", "-g", PACKAGE, "--registry=$NPM_REGISTRY")
 
         // 5. recheck global bin
@@ -62,6 +72,7 @@ object BinaryResolver {
     fun upgradeWaveBinary(targetVersion: String): String {
         val npm = findNpm()
         LOG.info("Upgrading $PACKAGE to $targetVersion via: \"$npm\" install -g $PACKAGE@$targetVersion --registry=$NPM_REGISTRY")
+        onInstall?.invoke("正在升级 wave-code 到 v$targetVersion，请稍候…")
         runCommand(npm, "install", "-g", "$PACKAGE@$targetVersion", "--registry=$NPM_REGISTRY")
         resetCache()
         return resolveWaveBinary()
@@ -196,6 +207,61 @@ object BinaryResolver {
         }
     }
 
+    /**
+     * Find `node` executable: PATH first, then nvm, then java.home parent
+     * (the JBR Node that ships with some IDEs).
+     */
+    private fun findNode(): String {
+        try {
+            val out = runCommand(lookupCmd, "node")
+            out.lineSequence().firstOrNull()?.trim()?.takeIf { it.isNotEmpty() }?.let { return it }
+        } catch (_: Exception) {}
+        findInNvm("node")?.let { return it }
+        // JBR-shipped node lives in jbr/bin/node relative to the IDE install.
+        val javaHome = System.getProperty("java.home") ?: throw StdioClientException(
+            "未检测到 Node.js/npm。请先安装 Node.js (https://nodejs.org)，然后重启编辑器。"
+        )
+        val nodeDir = File(javaHome).parent ?: throw StdioClientException(
+            "未检测到 Node.js/npm。请先安装 Node.js (https://nodejs.org)，然后重启编辑器。"
+        )
+        val candidates: List<File> = if (isWindows) {
+            listOf(File(nodeDir, "node.exe"), File(nodeDir, "node"))
+        } else {
+            listOf(File(nodeDir, "node"), File(File(nodeDir, ".."), "bin").let { File(it, "node") })
+        }
+        candidates.firstOrNull { it.exists() }?.path?.let { return it }
+        throw StdioClientException(
+            "未检测到 Node.js/npm。请先安装 Node.js (https://nodejs.org)，然后重启编辑器。"
+        )
+    }
+
+    /**
+     * Check that the system Node.js is >= [MIN_NODE_MAJOR].
+     * @throws StdioClientException if the version is below the minimum or cannot be determined.
+     */
+    private fun checkNodeVersion() {
+        val node = findNode()
+        val output = try {
+            runCommandRaw(node, "-v").trim()
+        } catch (e: Exception) {
+            throw StdioClientException(
+                "未检测到 Node.js/npm。请先安装 Node.js (https://nodejs.org)，然后重启编辑器。"
+            )
+        }
+        val match = Regex("^v?(\\d+)").find(output)
+        val major = match?.groupValues?.get(1)?.toIntOrNull()
+        if (major == null) {
+            throw StdioClientException(
+                "无法确定 Node.js 版本（输出: $output）。请安装 Node.js >= $MIN_NODE_MAJOR (https://nodejs.org)，然后重启编辑器。"
+            )
+        }
+        if (major < MIN_NODE_MAJOR) {
+            throw StdioClientException(
+                "Node.js 版本过低（当前 v$major，需要 >= $MIN_NODE_MAJOR）。请升级 Node.js (https://nodejs.org)，然后重启编辑器。"
+            )
+        }
+    }
+
     private fun findNpm(): String {
         // which/where npm
         try {
@@ -205,15 +271,21 @@ object BinaryResolver {
         // nvm-installed npm (GUI-launched IDEs don't inherit shell PATH)
         findInNvm("npm")?.let { return it }
         // fallback: node dir
-        val javaHome = System.getProperty("java.home") ?: return "npm"
-        val nodeDir = File(javaHome).parent ?: return "npm"
+        val javaHome = System.getProperty("java.home") ?: throw StdioClientException(
+            "未检测到 Node.js/npm。请先安装 Node.js (https://nodejs.org)，然后重启编辑器。"
+        )
+        val nodeDir = File(javaHome).parent ?: throw StdioClientException(
+            "未检测到 Node.js/npm。请先安装 Node.js (https://nodejs.org)，然后重启编辑器。"
+        )
         val candidates: List<File> = if (isWindows) {
             listOf(File(nodeDir, "npm.cmd"), File(nodeDir, "npm"))
         } else {
             listOf(File(nodeDir, "npm"), File(File(nodeDir, ".."), "bin").let { File(it, "npm") })
         }
         candidates.firstOrNull { it.exists() }?.path?.let { return it }
-        return "npm"
+        throw StdioClientException(
+            "未检测到 Node.js/npm。请先安装 Node.js (https://nodejs.org)，然后重启编辑器。"
+        )
     }
 
     private fun getNpmGlobalBin(): String {

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioClient.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioClient.kt
@@ -54,6 +54,8 @@ class StdioClient(
     var disposed = false
         private set
 
+    private val stderrBuffer = StringBuilder()
+
     private val process: Process = ProcessBuilder(listOf(binaryPath) + args).apply {
         redirectErrorStream(false)
         environment().putAll(env)
@@ -82,13 +84,19 @@ class StdioClient(
                 if (!disposed) LOG.warn("wave stdio stdout stream closed", e)
             }
         }
-        // stderr logger
+        // stderr logger + buffer (for inclusion in exit error)
         scope.launch {
             try {
                 BufferedReader(InputStreamReader(process.errorStream, StandardCharsets.UTF_8)).use { reader ->
                     var line = reader.readLine()
                     while (line != null) {
                         LOG.warn("[wave-stdio] $line")
+                        synchronized(stderrBuffer) {
+                            stderrBuffer.append(line).append('\n')
+                            if (stderrBuffer.length > 4096) {
+                                stderrBuffer.delete(0, stderrBuffer.length - 4096)
+                            }
+                        }
                         line = reader.readLine()
                     }
                 }
@@ -98,7 +106,10 @@ class StdioClient(
         // Exit handler: reject all pending
         process.onExit().thenRun {
             val code = process.exitValue()
-            val error = StdioClientException("wave --stdio process exited (code: $code)")
+            val stderr = synchronized(stderrBuffer) { stderrBuffer.toString().trim() }
+            val parts = mutableListOf("wave --stdio process exited (code: $code)")
+            if (stderr.isNotEmpty()) parts.add("stderr:\n$stderr")
+            val error = StdioClientException(parts.joinToString("\n"))
             pending.values.forEach { it.completeExceptionally(error) }
             pending.clear()
             disposed = true
@@ -107,7 +118,7 @@ class StdioClient(
 
     /** Send a request (expects a response with matching id). */
     suspend fun request(method: String, params: JsonObject? = null, sessionId: String? = null): JsonElement? {
-        if (disposed) throw StdioClientException("StdioClient is disposed")
+        if (disposed) throw StdioClientException("连接已断开。wave 进程已退出，请重启编辑器或检查 CLI 安装。")
         val id = nextId.getAndIncrement()
         val deferred = CompletableDeferred<JsonElement?>()
         pending[id] = deferred

--- a/packages/vsce/src/chatProvider.ts
+++ b/packages/vsce/src/chatProvider.ts
@@ -18,7 +18,7 @@ import { WebviewManager } from './session/webviewManager';
 import { MessageHandler } from './session/messageHandler';
 import { StdioClient } from './stdio/stdioClient';
 import { NotificationRouter } from './stdio/notificationRouter';
-import { resolveWaveBinary, ensureCliUpToDate } from './stdio/binaryResolver';
+import { resolveWaveBinary, ensureCliUpToDate, NodeJsNotFoundError, NodeJsVersionError } from './stdio/binaryResolver';
 import { checkAndNotify } from './services/updateService';
 
 export class ChatProvider implements vscode.WebviewViewProvider {
@@ -49,6 +49,7 @@ export class ChatProvider implements vscode.WebviewViewProvider {
     private messageHandler!: MessageHandler;
     private sharedClient: StdioClient | undefined;
     private notificationRouter: NotificationRouter | undefined;
+    private outputChannel: vscode.OutputChannel;
     private initPromise: Promise<void>;
     private updateCheckTriggered = false;
 
@@ -56,6 +57,7 @@ export class ChatProvider implements vscode.WebviewViewProvider {
         this.context = context;
         this.configService = new ConfigurationService(context);
         this.selectionService = new SelectionService(context);
+        this.outputChannel = vscode.window.createOutputChannel('Wave');
 
         this.webviewManager = new WebviewManager(context, {
             onMessage: async (message, viewType, windowId) => {
@@ -132,11 +134,26 @@ export class ChatProvider implements vscode.WebviewViewProvider {
     private async init(): Promise<void> {
         try {
             const clientVersion: string | undefined = this.context.extension.packageJSON?.version;
-            const binaryPath = clientVersion
-                ? await ensureCliUpToDate(clientVersion)
-                : resolveWaveBinary();
+            const binaryPath = await vscode.window.withProgress(
+                {
+                    location: vscode.ProgressLocation.Notification,
+                    title: 'Wave',
+                    cancellable: false,
+                },
+                (progress) => {
+                    const onInstall = (message: string) => progress.report({ message });
+                    return clientVersion
+                        ? ensureCliUpToDate(clientVersion, onInstall)
+                        : Promise.resolve(resolveWaveBinary(onInstall));
+                },
+            );
 
-            this.sharedClient = new StdioClient(binaryPath, ['--stdio']);
+            this.sharedClient = new StdioClient(
+                binaryPath,
+                ['--stdio'],
+                undefined,
+                (data) => this.outputChannel.appendLine(`[wave-stdio] ${data}`),
+            );
             this.notificationRouter = new NotificationRouter(this.sharedClient);
             this.notificationRouter.attach();
             // Open browser when auth URL is received (global — no sessionId).
@@ -178,9 +195,18 @@ export class ChatProvider implements vscode.WebviewViewProvider {
             );
         } catch (err) {
             console.error('[Wave] Failed to initialize shared client:', err);
-            vscode.window.showErrorMessage(
-                '无法启动 wave 二进制文件。请手动安装: npm install -g wave-code',
+            this.outputChannel.appendLine(
+                `[Wave] Failed to initialize shared client: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
             );
+            if (err instanceof NodeJsNotFoundError) {
+                vscode.window.showErrorMessage(err.message);
+            } else if (err instanceof NodeJsVersionError) {
+                vscode.window.showErrorMessage(err.message);
+            } else {
+                vscode.window.showErrorMessage(
+                    '无法启动 wave 二进制文件。请手动安装: npm install -g wave-code',
+                );
+            }
         }
     }
 

--- a/packages/vsce/src/stdio/binaryResolver.ts
+++ b/packages/vsce/src/stdio/binaryResolver.ts
@@ -18,9 +18,72 @@ export const NPM_REGISTRY = 'https://registry.npmmirror.com';
 
 let cachedPath: string | undefined;
 
+/** Minimum Node.js major version required by `wave --stdio`. */
+const MIN_NODE_MAJOR = 20;
+
+/**
+ * Error thrown when Node.js/npm cannot be found on the system.
+ * Callers catch this to show a user-friendly "install Node.js" message
+ * instead of a cryptic npm failure.
+ */
+export class NodeJsNotFoundError extends Error {
+    constructor() {
+        super(
+            '未检测到 Node.js/npm。请先安装 Node.js (https://nodejs.org)，然后重启编辑器。',
+        );
+        this.name = 'NodeJsNotFoundError';
+    }
+}
+
+/**
+ * Error thrown when the system Node.js version is below the minimum required.
+ * Callers catch this to show a user-friendly "upgrade Node.js" message.
+ */
+export class NodeJsVersionError extends Error {
+    constructor(currentVersion: string) {
+        super(
+            `Node.js 版本过低（当前 ${currentVersion}，需要 >= ${MIN_NODE_MAJOR}）。请升级 Node.js (https://nodejs.org)，然后重启编辑器。`,
+        );
+        this.name = 'NodeJsVersionError';
+    }
+}
+
+/**
+ * Find `node` executable: PATH first, then `process.execPath` (the Node
+ * running the extension host, which is always a valid node binary).
+ */
+function findNode(): string {
+    const cmd = process.platform === 'win32' ? 'where node' : 'which node';
+    try {
+        const result = execSync(cmd, { encoding: 'utf-8', stdio: 'pipe' }).trim();
+        if (result) return result.split('\n')[0].trim();
+    } catch {
+        // not on PATH
+    }
+    // process.execPath is always a Node binary (the extension host runtime).
+    return process.execPath;
+}
+
+/**
+ * Check that the system Node.js is >= MIN_NODE_MAJOR.
+ * @throws {NodeJsVersionError} if the version is below the minimum.
+ */
+function checkNodeVersion(): void {
+    const node = findNode();
+    const output = execFileSync(node, ['-v'], {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+    const match = output.match(/^v?(\d+)/);
+    if (!match) throw new NodeJsVersionError(output);
+    const major = parseInt(match[1], 10);
+    if (major < MIN_NODE_MAJOR) throw new NodeJsVersionError(`v${major}`);
+}
+
 /**
  * Find `npm` CLI executable.
  * Checks PATH first, then falls back to the directory of the running Node binary.
+ * @throws {NodeJsNotFoundError} if npm cannot be located anywhere.
  */
 function findNpm(): string {
     const cmd = process.platform === 'win32' ? 'where npm' : 'which npm';
@@ -41,7 +104,7 @@ function findNpm(): string {
         if (fs.existsSync(c)) return c;
     }
 
-    return 'npm';
+    throw new NodeJsNotFoundError();
 }
 
 /** Resolve the npm global bin directory. */
@@ -63,8 +126,14 @@ function fileExists(p: string): boolean {
     }
 }
 
-export function resolveWaveBinary(): string {
+/** Optional callback invoked when an npm install/upgrade starts. */
+export type InstallProgressCallback = (message: string) => void;
+
+export function resolveWaveBinary(onInstall?: InstallProgressCallback): string {
     if (cachedPath) return cachedPath;
+
+    // 0. Verify Node.js >= 20 — wave --stdio requires it.
+    checkNodeVersion();
 
     // 1. Try PATH
     const whichCmd = process.platform === 'win32' ? 'where wave' : 'which wave';
@@ -82,7 +151,9 @@ export function resolveWaveBinary(): string {
     let globalBin: string;
     try {
         globalBin = getNpmGlobalBin();
-    } catch {
+    } catch (e) {
+        // NodeJsNotFoundError / NodeJsVersionError have user-friendly messages — propagate.
+        if (e instanceof NodeJsNotFoundError || e instanceof NodeJsVersionError) throw e;
         throw new Error(
             'Failed to determine npm global directory. Please install wave-code manually: npm install -g wave-code --registry=https://registry.npmmirror.com',
         );
@@ -97,6 +168,7 @@ export function resolveWaveBinary(): string {
 
     // 3. Install globally
     console.log('[Wave] wave binary not found, installing wave-code globally...');
+    onInstall?.('正在安装 wave-code，请稍候…');
     const npm = findNpm();
     execSync(`"${npm}" install -g wave-code --registry=${NPM_REGISTRY}`, {
         encoding: 'utf-8',
@@ -158,8 +230,8 @@ export function getCliVersion(binaryPath: string): string | null {
  * 3. If null (binary corrupt/unreadable) or older than target → upgrade to
  *    targetVersion (which resets the cache and re-resolves).
  */
-export async function ensureCliUpToDate(targetVersion: string): Promise<string> {
-    const binaryPath = resolveWaveBinary();
+export async function ensureCliUpToDate(targetVersion: string, onInstall?: InstallProgressCallback): Promise<string> {
+    const binaryPath = resolveWaveBinary(onInstall);
     const current = getCliVersion(binaryPath);
     if (current !== null) {
         const cur = parseVersion(current);
@@ -169,7 +241,7 @@ export async function ensureCliUpToDate(targetVersion: string): Promise<string> 
         }
     }
     // current is null (corrupt) or older than target → upgrade.
-    return upgradeWaveBinary(targetVersion);
+    return upgradeWaveBinary(targetVersion, onInstall);
 }
 
 /** Reset cached binary path. Public so callers can force re-resolve after an upgrade. */
@@ -182,7 +254,7 @@ export function resetCache(): void {
  * Uses `execFile` (not a shell string) to avoid shell injection of the version arg.
  * Resets the cached path on success and returns the freshly-resolved binary path.
  */
-export async function upgradeWaveBinary(targetVersion: string): Promise<string> {
+export async function upgradeWaveBinary(targetVersion: string, onInstall?: InstallProgressCallback): Promise<string> {
     // Validate the version before it touches a shell. targetVersion originates
     // from the extension's package.json (trusted), but on Windows execFile runs
     // through cmd.exe (see shell option below); a strict semver check preserves
@@ -193,6 +265,7 @@ export async function upgradeWaveBinary(targetVersion: string): Promise<string> 
         throw new Error(`Invalid version: ${targetVersion}`);
     }
 
+    onInstall?.(`正在升级 wave-code 到 v${targetVersion}，请稍候…`);
     const npm = findNpm();
     await new Promise<void>((resolve, reject) => {
         execFile(

--- a/packages/vsce/src/stdio/stdioClient.ts
+++ b/packages/vsce/src/stdio/stdioClient.ts
@@ -9,6 +9,7 @@ import { type ChildProcess, spawn } from 'child_process';
 import { createInterface } from 'readline';
 
 export type NotificationHandler = (params: unknown, sessionId?: string) => void;
+export type StderrHandler = (data: string) => void;
 
 interface PendingRequest {
     resolve: (value: unknown) => void;
@@ -21,12 +22,16 @@ export class StdioClient {
     private pending = new Map<number, PendingRequest>();
     private handlers = new Map<string, Set<NotificationHandler>>();
     private disposed = false;
+    private stderrBuffer = '';
+    private onStderr?: StderrHandler;
 
     constructor(
         binaryPath: string,
         args: string[] = [],
         env?: Record<string, string>,
+        onStderr?: StderrHandler,
     ) {
+        this.onStderr = onStderr;
         // On Windows, binaryPath may be a `wave.cmd` shim. Node (since the
         // CVE-2024-27980 patch) refuses to spawn `.cmd`/`.bat` files without a
         // shell, throwing ERR_CHILD_PROCESS_INVALID_COMMAND_FILE. `args` is a
@@ -42,13 +47,20 @@ export class StdioClient {
         rl.on('line', (line) => this.handleLine(line));
 
         this.proc.stderr!.on('data', (data: Buffer) => {
-            console.error('[wave-stdio]', data.toString().trimEnd());
+            const text = data.toString();
+            // Keep a rolling tail for inclusion in the exit error message.
+            this.stderrBuffer = (this.stderrBuffer + text).slice(-4096);
+            const trimmed = text.trimEnd();
+            if (trimmed) this.onStderr?.(trimmed);
         });
 
         this.proc.on('exit', (code, signal) => {
-            const error = new Error(
+            const stderr = this.stderrBuffer.trim();
+            const parts = [
                 `wave --stdio process exited (code: ${code}, signal: ${signal})`,
-            );
+            ];
+            if (stderr) parts.push(`stderr:\n${stderr}`);
+            const error = new Error(parts.join('\n'));
             for (const p of this.pending.values()) {
                 p.reject(error);
             }
@@ -69,7 +81,7 @@ export class StdioClient {
         sessionId?: string,
     ): Promise<unknown> {
         if (this.disposed) {
-            throw new Error('StdioClient is disposed');
+            throw new Error('连接已断开。wave 进程已退出，请重启编辑器或检查 CLI 安装。');
         }
         const id = this.nextId++;
         const envelope: Record<string, unknown> = { id, method, params };

--- a/packages/vsce/tests/stdio/binaryResolver.test.ts
+++ b/packages/vsce/tests/stdio/binaryResolver.test.ts
@@ -28,6 +28,8 @@ vi.mock('fs', () => ({
 const isWin = process.platform === 'win32';
 const waveLookup = isWin ? 'where wave' : 'which wave';
 const npmLookup = isWin ? 'where npm' : 'which npm';
+const nodeLookup = isWin ? 'where node' : 'which node';
+const nodeBin = isWin ? 'C:\\nodejs\\node.exe' : '/usr/bin/node';
 const npmBin = isWin ? 'C:\\nodejs\\npm.cmd' : '/usr/bin/npm';
 const npmPrefix = isWin ? 'C:\\nodejs' : '/usr/local';
 // Source: globalBin = prefix on Windows, path.join(prefix, 'bin') elsewhere.
@@ -37,12 +39,21 @@ const globalWave = path.join(globalBin, waveName);
 
 // ── Import after mocks ─────────────────────────────────────────
 
-import { resolveWaveBinary, _resetCacheForTesting, upgradeWaveBinary, resetCache, getCliVersion, ensureCliUpToDate, NPM_REGISTRY } from '../../src/stdio/binaryResolver';
+import { resolveWaveBinary, _resetCacheForTesting, upgradeWaveBinary, resetCache, getCliVersion, ensureCliUpToDate, NPM_REGISTRY, NodeJsNotFoundError, NodeJsVersionError } from '../../src/stdio/binaryResolver';
 
 describe('binaryResolver', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockExistsSync.mockReturnValue(false);
+        // Default: node version check passes (>= 20). findNode() tries
+        // `which node`/`where node` first; if that throws it falls back to
+        // process.execPath. Either way checkNodeVersion() calls
+        // execFileSync(<nodePath>, ['-v']).
+        mockExecSync.mockImplementation((cmd: string) => {
+            if (cmd.includes(nodeLookup)) return `${nodeBin}\n`;
+            throw new Error(`unexpected: ${cmd}`);
+        });
+        mockExecFileSync.mockReturnValue('v20.0.0\n');
         _resetCacheForTesting();
     });
 
@@ -141,18 +152,18 @@ describe('binaryResolver', () => {
 
     // ── Error cases ────────────────────────────────────────────
 
-    it('throws when npm global prefix cannot be determined', () => {
+    it('throws NodeJsNotFoundError when npm cannot be found anywhere', () => {
         mockExecSync.mockImplementation((cmd: string) => {
             if (cmd.includes(waveLookup)) throw new Error('not found');
             if (cmd.includes(npmLookup)) throw new Error('not found');
+            if (cmd.includes(nodeLookup)) return `${nodeBin}\n`;
             throw new Error(`unexpected: ${cmd}`);
         });
         // findNpm falls back to process.execPath dir checks; all return false
         mockExistsSync.mockReturnValue(false);
 
-        expect(() => resolveWaveBinary()).toThrow(
-            'Failed to determine npm global directory',
-        );
+        expect(() => resolveWaveBinary()).toThrow(NodeJsNotFoundError);
+        expect(() => resolveWaveBinary()).toThrow('未检测到 Node.js/npm');
     });
 
     it('throws when wave not found after installation', () => {
@@ -359,9 +370,13 @@ describe('binaryResolver', () => {
     it('ensureCliUpToDate returns existing path when version is >= target', async () => {
         mockExecSync.mockImplementation((cmd: string) => {
             if (cmd.includes(waveLookup)) return `${globalWave}\n`;
+            if (cmd.includes(nodeLookup)) return `${nodeBin}\n`;
             throw new Error(`unexpected: ${cmd}`);
         });
-        mockExecFileSync.mockReturnValue('1.0.0\n');
+        // Node -v returns v20+; wave -v returns 1.0.0 (>= target)
+        mockExecFileSync.mockImplementation((cmd: string | Buffer) =>
+            String(cmd) === globalWave ? '1.0.0\n' : 'v20.0.0\n',
+        );
 
         const result = await ensureCliUpToDate('1.0.0');
         expect(result).toBe(globalWave);
@@ -372,9 +387,13 @@ describe('binaryResolver', () => {
         mockExecSync.mockImplementation((cmd: string) => {
             if (cmd.includes(waveLookup)) return `${globalWave}\n`;
             if (cmd.includes(npmLookup)) return `${npmBin}\n`;
+            if (cmd.includes(nodeLookup)) return `${nodeBin}\n`;
             throw new Error(`unexpected: ${cmd}`);
         });
-        mockExecFileSync.mockReturnValue('0.18.0\n');
+        // Node -v returns v20+; wave -v returns 0.18.0 (< target)
+        mockExecFileSync.mockImplementation((cmd: string | Buffer) =>
+            String(cmd) === globalWave ? '0.18.0\n' : 'v20.0.0\n',
+        );
         mockExecFile.mockImplementation((...args: unknown[]) => {
             const cb = args[args.length - 1] as (err: Error | null) => void;
             cb(null);
@@ -392,10 +411,14 @@ describe('binaryResolver', () => {
         mockExecSync.mockImplementation((cmd: string) => {
             if (cmd.includes(waveLookup)) return `${globalWave}\n`;
             if (cmd.includes(npmLookup)) return `${npmBin}\n`;
+            if (cmd.includes(nodeLookup)) return `${nodeBin}\n`;
             throw new Error(`unexpected: ${cmd}`);
         });
-        // corrupt binary: -v fails
-        mockExecFileSync.mockImplementation(() => { throw new Error('corrupt'); });
+        // Node -v returns v20+; wave -v fails (corrupt binary)
+        mockExecFileSync.mockImplementation((cmd: string | Buffer) => {
+            if (String(cmd) === globalWave) throw new Error('corrupt');
+            return 'v20.0.0\n';
+        });
         mockExecFile.mockImplementation((...args: unknown[]) => {
             const cb = args[args.length - 1] as (err: Error | null) => void;
             cb(null);
@@ -409,12 +432,52 @@ describe('binaryResolver', () => {
     it('ensureCliUpToDate does not upgrade when version is newer than target', async () => {
         mockExecSync.mockImplementation((cmd: string) => {
             if (cmd.includes(waveLookup)) return `${globalWave}\n`;
+            if (cmd.includes(nodeLookup)) return `${nodeBin}\n`;
             throw new Error(`unexpected: ${cmd}`);
         });
-        mockExecFileSync.mockReturnValue('2.0.0\n');
+        // Node -v returns v20+; wave -v returns 2.0.0 (> target)
+        mockExecFileSync.mockImplementation((cmd: string | Buffer) =>
+            String(cmd) === globalWave ? '2.0.0\n' : 'v20.0.0\n',
+        );
 
         const result = await ensureCliUpToDate('1.0.0');
         expect(result).toBe(globalWave);
         expect(mockExecFile).not.toHaveBeenCalled();
+    });
+
+    // ── Node.js version check (FR-005b) ──────────────────────────
+
+    it('throws NodeJsVersionError when Node.js version is below 20', () => {
+        mockExecSync.mockImplementation((cmd: string) => {
+            if (cmd.includes(nodeLookup)) return `${nodeBin}\n`;
+            throw new Error(`unexpected: ${cmd}`);
+        });
+        mockExecFileSync.mockReturnValue('v18.17.0\n');
+
+        expect(() => resolveWaveBinary()).toThrow(NodeJsVersionError);
+        expect(() => resolveWaveBinary()).toThrow('Node.js 版本过低');
+        expect(() => resolveWaveBinary()).toThrow('v18');
+    });
+
+    it('does not throw version error when Node.js is exactly v20', () => {
+        mockExecSync.mockImplementation((cmd: string) => {
+            if (cmd.includes(waveLookup)) return `${globalWave}\n`;
+            if (cmd.includes(nodeLookup)) return `${nodeBin}\n`;
+            throw new Error(`unexpected: ${cmd}`);
+        });
+        mockExecFileSync.mockReturnValue('v20.0.0\n');
+
+        expect(() => resolveWaveBinary()).not.toThrow();
+    });
+
+    it('does not throw version error when Node.js is above v20', () => {
+        mockExecSync.mockImplementation((cmd: string) => {
+            if (cmd.includes(waveLookup)) return `${globalWave}\n`;
+            if (cmd.includes(nodeLookup)) return `${nodeBin}\n`;
+            throw new Error(`unexpected: ${cmd}`);
+        });
+        mockExecFileSync.mockReturnValue('v22.14.0\n');
+
+        expect(() => resolveWaveBinary()).not.toThrow();
     });
 });

--- a/packages/vsce/tests/stdio/stdioClient.test.ts
+++ b/packages/vsce/tests/stdio/stdioClient.test.ts
@@ -34,13 +34,13 @@ function createMockProc(): MockProc {
     return proc;
 }
 
-function createClient(args?: string[], env?: Record<string, string>) {
+function createClient(args?: string[], env?: Record<string, string>, onStderr?: (data: string) => void) {
     const proc = createMockProc();
     const rl = new EventEmitter();
     mockSpawn.mockReturnValue(proc);
     mockCreateInterface.mockReturnValue(rl);
 
-    const client = new StdioClient('/fake/wave', args, env);
+    const client = new StdioClient('/fake/wave', args, env, onStderr);
     return { client, proc, rl };
 }
 
@@ -421,7 +421,7 @@ describe('StdioClient', () => {
 
         const error = await expectReject(client.request('test'));
         expect(error).toBeInstanceOf(Error);
-        expect(error.message).toBe('StdioClient is disposed');
+        expect(error.message).toBe('连接已断开。wave 进程已退出，请重启编辑器或检查 CLI 安装。');
     });
 
     it('notify is silent after dispose', () => {
@@ -458,6 +458,49 @@ describe('StdioClient', () => {
 
         const error = await expectReject(client.request('test'));
         expect(error).toBeInstanceOf(Error);
-        expect(error.message).toBe('StdioClient is disposed');
+        expect(error.message).toBe('连接已断开。wave 进程已退出，请重启编辑器或检查 CLI 安装。');
+    });
+
+    // ── stderr forwarding (FR-029) ─────────────────────────────
+
+    it('forwards stderr to onStderr callback', () => {
+        const onStderr = vi.fn();
+        const { proc } = createClient([], undefined, onStderr);
+
+        proc.stderr.emit('data', Buffer.from('some warning\n'));
+
+        expect(onStderr).toHaveBeenCalledWith('some warning');
+    });
+
+    it('does not call onStderr for empty stderr lines', () => {
+        const onStderr = vi.fn();
+        const { proc } = createClient([], undefined, onStderr);
+
+        proc.stderr.emit('data', Buffer.from('  \n'));
+
+        expect(onStderr).not.toHaveBeenCalled();
+    });
+
+    it('works without onStderr callback (backward compat)', () => {
+        const { proc } = createClient();
+
+        expect(() => {
+            proc.stderr.emit('data', Buffer.from('some output\n'));
+        }).not.toThrow();
+    });
+
+    // ── stderr buffer in exit error (FR-017) ───────────────────
+
+    it('includes stderr in exit error message when process exits', async () => {
+        const { client, proc } = createClient();
+
+        proc.stderr.emit('data', Buffer.from('FATAL: cannot find module\n'));
+
+        const p = expectReject(client.request('method1'));
+        proc.emit('exit', 1, null);
+
+        const err = await p;
+        expect(err.message).toContain('wave --stdio process exited');
+        expect(err.message).toContain('FATAL: cannot find module');
     });
 });

--- a/specs/049-stdio-transport.md
+++ b/specs/049-stdio-transport.md
@@ -1,0 +1,264 @@
+# 功能规格说明：Stdio 传输层
+
+**特性分支**：`049-stdio-transport`
+**创建日期**：2026-07-24
+
+## 概述
+
+编辑器插件（VS Code 扩展、JetBrains 插件等）不在插件宿主进程中运行 Agent 逻辑，而是通过 JSON-RPC 2.0 over stdio 与 `wave --stdio` 子进程通信。本规格覆盖该传输层的完整生命周期：CLI 二进制文件的解析/安装/升级、JSON-RPC 通信协议、共享进程的多会话路由、以及错误诊断。本规格以 VSCE 实现为参考基准，JB 插件复用同一协议和架构。
+
+### 架构
+
+```
+                     Editor Plugin (扩展入口)
+                    /     |      \
+          sidebarSession  tabSessions[]  windowSessions[]
+                    \     |      /
+                   ChatSession (每个会话一个)
+                      │ 持有
+                   StdioAgent (类型化包装层 + 状态缓存)
+                      │
+          ┌───────────┼───────────┐
+          │           │           │
+   NotificationRouter  │    FileService / SessionService / PluginService
+          │           │           │ (utility 请求，无 session 上下文)
+    register/unregister│          
+          │     StdioClient (单共享实例)
+          │           │
+    按 sessionId 分发   spawn
+          │           │
+    StdioAgent      wave --stdio (子进程)
+```
+
+**关键设计决策**：所有会话（sidebar/tab/window）共享同一个 `StdioClient` 子进程实例，通过 JSON-RPC 信封中的 `sessionId` 字段区分不同会话的请求和通知。
+
+## 用户场景与测试 *（必填）*
+
+### 用户故事 1 - CLI 二进制自动解析与安装（优先级：P1）
+
+作为编辑器插件用户，我希望插件能自动找到或安装 `wave` CLI 二进制文件，以便无需手动配置即可开始使用。
+
+**为什么是这个优先级**：这是整个 stdio 传输层的前提——没有 CLI 二进制文件，插件无法做任何事情。
+
+**独立测试**：在一台未安装 `wave-code` 的机器上安装插件，打开聊天面板，验证插件自动通过 npm 安装 CLI 并启动子进程。
+
+**验收场景**：
+
+1. **假设** `wave` 已在系统 PATH 中，**当**插件初始化时，**则**通过 `which wave`（Unix）或 `where wave`（Windows）直接解析到二进制路径并使用它，不触发 npm 安装。
+2. **假设** `wave` 不在 PATH 中但已通过 npm 全局安装，**当**插件初始化时，**则**通过 `npm prefix -g` 获取全局 bin 目录，在其中找到 `wave`（Unix）或 `wave.cmd`（Windows）并使用它。
+3. **假设** `wave` 完全未安装，**当**插件初始化时，**则**自动执行 `npm install -g wave-code --registry=https://registry.npmmirror.com`，安装完成后重新解析二进制路径。
+4. **假设** 二进制路径已解析成功，**当**同一插件生命周期内再次调用解析时，**则**直接返回缓存的路径，不重复查找。
+5. **假设** 自动安装完成后二进制文件仍未出现在预期位置，**当**插件再次检查时，**则**再次尝试 PATH 查找作为兜底，仍失败则抛出明确错误。
+
+---
+
+### 用户故事 2 - CLI 版本管理与升级（优先级：P1）
+
+作为编辑器插件用户，我希望插件自动确保 CLI 版本与插件版本匹配，以便获得一致的功能体验。
+
+**为什么是这个优先级**：CLI 和插件版本不匹配会导致协议不兼容、功能缺失或运行时崩溃。
+
+**独立测试**：手动安装一个旧版本的 `wave-code` CLI，然后安装较新版本的插件，打开聊天面板，验证插件自动升级 CLI 到匹配版本。
+
+**验收场景**：
+
+1. **假设** 已安装 CLI 版本 >= 插件版本，**当**插件初始化时，**则**不执行升级，直接使用现有二进制。
+2. **假设** 已安装 CLI 版本 < 插件版本，**当**插件初始化时，**则**自动执行 `npm install -g wave-code@<插件版本>` 升级到精确匹配版本。
+3. **假设** CLI 二进制存在但损坏（`wave -v` 执行失败或返回空），**当**插件初始化时，**则**视为需要升级，执行升级流程。
+4. **假设** 升级完成后，**当**插件重新解析二进制时，**则**缓存被清除并重新查找，确保使用新安装的二进制。
+5. **假设** 目标版本字符串不匹配 semver 格式，**当**尝试升级时，**则**拒绝执行升级并抛出 "Invalid version" 错误，防止 shell 注入。
+
+---
+
+### 用户故事 3 - 初始化失败诊断（优先级：P1）
+
+作为编辑器插件用户，我希望在 CLI 无法启动时获得明确的错误信息和可操作的修复指引，以便快速解决问题而不是面对晦涩的技术错误。
+
+**为什么是这个优先级**：当前缺少 Node.js/npm 的用户会看到 "Failed to determine npm global directory" 这样令人困惑的错误，无法理解根本原因或如何修复。错误诊断是用户体验的关键环节。
+
+**独立测试**：在一台未安装 Node.js 的 Windows 机器上安装插件，打开聊天面板，验证错误消息明确告知用户需要安装 Node.js。
+
+**验收场景**：
+
+1. **假设** 系统未安装 Node.js（`where npm` / `which npm` 失败，且 `process.execPath` 同目录无 npm），**当**插件尝试解析二进制时，**则**抛出明确错误："未检测到 Node.js/npm。请先安装 Node.js (https://nodejs.org)，然后重启编辑器。"，并在编辑器通知中显示该消息。
+2. **假设** 系统已安装 Node.js 但版本低于 20，**当**插件尝试解析二进制时，**则**抛出明确错误："Node.js 版本过低（当前 vX，需要 >= 20）。请升级 Node.js (https://nodejs.org)，然后重启编辑器。"，并在编辑器通知中显示该消息。
+3. **假设** npm 存在但 `npm prefix -g` 执行失败，**当**插件尝试获取全局 bin 目录时，**则**抛出包含 npm 错误输出的问题描述，并建议用户检查 npm 配置。
+4. **假设** npm install 执行失败（网络问题、权限不足等），**当**插件尝试自动安装 CLI 时，**则**抛出包含 npm 错误输出的描述，并建议用户手动执行安装命令。
+5. **假设** CLI 子进程启动后立即退出（exit code 非 0），**当**插件检测到进程退出时，**则**在编辑器通知中显示错误，包含 stderr 输出（如果有），并建议用户检查 CLI 安装。
+6. **假设** 任何初始化错误发生后，**当**用户查看编辑器输出面板的 Wave 通道时，**则**能看到完整的错误堆栈和上下文信息用于诊断。
+
+---
+
+### 用户故事 4 - JSON-RPC 通信（优先级：P1）
+
+作为扩展开发者，我希望通过标准 JSON-RPC 2.0 协议与 CLI 子进程进行双向通信，以便发送请求、接收响应和订阅通知。
+
+**为什么是这个优先级**：JSON-RPC 是整个传输层的通信基础，所有上层功能（发消息、执行命令、状态同步）都依赖它。
+
+**独立测试**：启动插件后发送一条消息，验证请求通过 stdin 发出、响应从 stdout 返回、通知被正确分发。
+
+**验收场景**：
+
+1. **假设** 插件向 CLI 发送一个请求，**当**请求发出时，**则**stdin 写入一行 JSON，格式为 `{"id": <自增整数>, "method": "<方法名>", "params": {...}, "sessionId": "<会话ID>"}`。
+2. **假设** CLI 返回一个响应，**当**stdout 收到一行 JSON 时，**则**通过 `id` 字段匹配到 pending 请求，`result` 字段 resolve 请求 Promise，`error` 字段 reject 请求 Promise。
+3. **假设** CLI 推送一个通知，**当**stdout 收到包含 `method` 但无 `id` 的 JSON 时，**则**将其作为通知分发到已注册的处理器，不创建 pending 请求。
+4. **假设** stdout 收到一行无法解析为 JSON 的内容，**当**处理该行时，**则**静默忽略该行，不影响后续消息处理。
+5. **假设** stdout 收到一行 JSON 但值为 `null` 或非对象类型，**当**处理该行时，**则**静默忽略该行，不影响后续消息处理。
+6. **假设** 插件发送一个通知（非请求），**当**通知发出时，**则**stdin 写入一行 JSON，格式为 `{"method": "<方法名>", "params": {...}, "sessionId": "<会话ID>"}`，不含 `id` 字段，不期待响应。
+
+---
+
+### 用户故事 5 - 共享进程与多会话路由（优先级：P1）
+
+作为同时打开多个聊天面板（sidebar + tab + window）的用户，我希望所有会话共享同一个 CLI 子进程，通过 sessionId 区分各自的消息流，以便减少资源占用同时保持会话隔离。
+
+**为什么是这个优先级**：共享进程是多面板架构的基础，路由错误会导致消息串台、状态混乱。
+
+**独立测试**：打开 sidebar 聊天和一个 tab 聊天，在两个面板分别发送消息，验证各自收到正确的响应和通知，不串台。
+
+**验收场景**：
+
+1. **假设** 插件初始化完成，**当**创建多个 ChatSession（sidebar/tab/window）时，**则**所有 session 共享同一个 StdioClient 实例，不创建多个子进程。
+2. **假设** 某个 session 发送请求，**当**请求携带该 session 的 sessionId 时，**则**CLI 返回的响应通过 id 匹配直接返回给发起者，不经过路由。
+3. **假设** CLI 推送一个带 sessionId 的通知，**当**NotificationRouter 收到时，**则**将通知分发到 sessionId 对应的 StdioAgent，不分发给其他 session。
+4. **假设** CLI 推送一个不带 sessionId 的全局通知（如 `authUrl`），**当**NotificationRouter 收到时，**则**将其分发到已注册的全局处理器。
+5. **假设** session 的 sessionId 发生变更（如 restoreSession），**当**收到 `sessionIdChange` 通知时，**则**NotificationRouter 将旧 sessionId 的映射迁移到新 sessionId，确保后续通知仍能正确路由。
+6. **假设** 某个 session 被销毁（关闭 tab/window），**当**执行 destroy 时，**则**从 NotificationRouter 取消注册该 session，但**不**销毁共享的 StdioClient（其他 session 仍在使用）。
+7. **假设** 所有 session 都已销毁，**当**插件本身被关闭时，**则**ChatProvider.dispose() 先销毁所有 session，再 dispose 共享的 StdioClient。
+
+---
+
+### 用户故事 6 - 进程生命周期与崩溃处理（优先级：P2）
+
+作为用户，我希望 CLI 子进程的异常退出能被妥善处理，pending 请求不会永远挂起，以便插件在进程崩溃时能给出明确反馈而不是无限等待。
+
+**为什么是这个优先级**：当前进程崩溃后 pending 请求会被 reject（已实现），但没有自动恢复机制，且 stderr 输出对用户不可见。
+
+**独立测试**：在插件运行期间手动 kill CLI 子进程，验证 pending 请求被 reject、后续操作给出明确错误。
+
+**验收场景**：
+
+1. **假设** CLI 子进程意外退出（非正常 dispose），**当**进程 `exit` 事件触发时，**则**所有 pending 请求被 reject（错误信息包含退出码），StdioClient 标记为 disposed。
+2. **假设** StdioClient 已 disposed，**当**尝试发送新请求时，**则**立即 reject，不尝试写入 stdin。
+3. **假设** CLI 子进程向 stderr 输出内容，**当**stderr 收到数据时，**则**输出到编辑器输出面板的 Wave 通道（而非仅 console.error），便于用户和开发者诊断。
+4. **假设** dispose() 被调用，**当**执行销毁时，**则**杀掉子进程、标记 disposed，且多次调用 dispose() 是幂等的。
+5. **假设** CLI 子进程退出后 StdioClient 已 disposed，**当**用户尝试在聊天面板发送消息时，**则**显示明确的错误消息告知用户连接已断开，需要重启插件。
+
+---
+
+### 用户故事 7 - 状态缓存与同步读取（优先级：P2）
+
+作为扩展 UI 层，我希望 StdioAgent 在本地缓存最新状态（消息列表、任务、权限模式等），以便在渲染时同步读取，无需 await 异步请求。
+
+**为什么是这个优先级**：React 组件渲染是同步的，异步获取状态会导致渲染闪烁和竞态条件。本地缓存确保 UI 始终有最新状态可读。
+
+**独立测试**：发送一条消息后立即读取 StdioAgent.messages，验证缓存已更新为最新消息列表。
+
+**验收场景**：
+
+1. **假设** CLI 推送 `messagesChange` 通知，**当**StdioAgent 处理该通知时，**则**更新 `this.messages` 缓存并触发 `onMessagesChange` 回调。
+2. **假设** CLI 推送 `tasksChange` 通知，**当**StdioAgent 处理该通知时，**则**更新 `this.tasks` 缓存并触发 `onTasksChange` 回调。
+3. **假设** CLI 推送 `permissionModeChange` 通知，**当**StdioAgent 处理该通知时，**则**更新 `this.permissionMode` 缓存并触发 `onPermissionModeChange` 回调。
+4. **假设** CLI 推送 `loadingChange` 通知，**当**StdioAgent 处理该通知时，**则**更新 `this.latestTotalTokens` 缓存并触发 `onLoadingChange` 回调。
+5. **假设** StdioAgent 的某个回调未设置（为 undefined），**当**对应通知到达时，**则**正常更新缓存但不触发回调，不抛出错误。
+6. **假设** StdioAgent 收到 `sessionIdChange` 通知，**当**处理该通知时，**则**更新 `this.sessionId` 缓存、触发 `onSessionIdChange` 回调，同时 NotificationRouter 执行 rekey。
+7. **假设** StdioAgent 收到 `workdirChange` 通知，**当**处理该通知时，**则**更新 `this.workingDirectory` 缓存并触发 `onWorkdirChange` 回调。
+
+---
+
+### 边界情况
+
+- **Windows `.cmd` 兼容性**：Node.js（CVE-2024-27980 补丁后）拒绝在没有 shell 的情况下 spawn `.cmd` 文件。所有执行 `npm.cmd` 和 `wave.cmd` 的地方必须设置 `shell: true`（或 `shell: process.platform === 'win32'`）。
+- **`getCliVersion` 超时**：`wave -v` 执行有 5 秒超时，超时返回 `null`（视为二进制损坏，触发升级）。
+- **semver 校验防注入**：`upgradeWaveBinary` 中的目标版本来自插件 `package.json`（可信源），但仍通过正则 `SEMVER_RE` 校验，因为 Windows 上 execFile 通过 cmd.exe 执行，严格的 semver 检查保留 "不对版本参数进行 shell 注入" 的保证。
+- **npm 全局目录差异**：`npm prefix -g` 在 Windows 上直接返回全局 bin 目录（如 `C:\Users\xxx\AppData\Roaming\npm`），Unix 上返回 prefix 需要拼接 `/bin`。
+- **utility 请求无 session 上下文**：FileService（搜索文件）、SessionService（列出会话）、PluginService（管理插件）的请求不需要 sessionId，直接通过共享 StdioClient 发送。
+- **`authUrl` 全局通知**：SSO 登录流程中 CLI 推送的 `authUrl` 通知不带 sessionId，通过 `router.registerGlobal` 注册的处理器接收，直接打开系统浏览器。
+- **CLI 子进程的 env 传递**：StdioClient 构造函数接受可选的 `env` 参数，未传时子进程继承插件宿主的 `process.env`。
+
+## 需求 *（必填）*
+
+### 功能需求
+
+#### 二进制解析与安装
+
+- **FR-001**：系统必须按以下优先级解析 `wave` CLI 二进制路径：① PATH 查找（`which`/`where`）→ ② npm 全局 bin 目录 → ③ 自动安装。
+- **FR-002**：系统必须缓存已解析的二进制路径，在同一插件生命周期内不重复查找。
+- **FR-003**：当 `wave` 未安装时，系统必须自动执行 `npm install -g wave-code --registry=https://registry.npmmirror.com`。
+- **FR-004**：系统必须通过 `findNpm()` 定位 npm 可执行文件：先尝试 PATH（`which npm`/`where npm`），失败后回退到 `process.execPath` 同目录（`npm`/`npm.cmd`）和 `../bin/npm`。
+- **FR-005**：当 `findNpm()` 所有查找路径均失败（即系统未安装 Node.js/npm）时，系统必须抛出明确错误，告知用户需要安装 Node.js，而非抛出 "Failed to determine npm global directory" 等技术性错误。
+- **FR-005b**：系统必须检查 Node.js 版本是否 >= 20。当版本低于 20 时，系统必须抛出明确错误，告知用户当前版本过低并需要升级到 >= 20，包含实际版本号和 Node.js 下载链接。
+- **FR-006**：系统必须通过 `npm prefix -g` 获取 npm 全局 bin 目录，Windows 上直接使用返回值，Unix 上拼接 `/bin`。
+- **FR-007**：所有执行 `.cmd` 文件的操作（Windows 平台）必须设置 `shell: true`，以兼容 Node.js CVE-2024-27980 补丁后的安全限制。
+- **FR-007b**：当系统执行 CLI 自动安装或升级（`npm install -g wave-code`）时，必须通过编辑器通知告知用户"正在安装/升级 wave-code，请稍候…"，安装完成后通知消失或提示完成。避免用户在长时间等待中无任何反馈。
+
+#### 版本管理
+
+- **FR-008**：系统必须通过执行 `<binaryPath> -v`（5 秒超时）读取已安装 CLI 的版本号。
+- **FR-009**：当 `wave -v` 执行失败、返回空或超时时，系统必须返回 `null`（视为二进制损坏）。
+- **FR-010**：系统必须比较已安装 CLI 版本与插件版本（来自 `package.json`），当 CLI 版本 >= 插件版本时不执行升级。
+- **FR-011**：当 CLI 版本 < 插件版本或 CLI 版本为 `null`（损坏）时，系统必须执行升级到插件版本。
+- **FR-012**：升级时系统必须通过 semver 正则 `^v?\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$` 校验目标版本，拒绝不合法的版本字符串。
+- **FR-013**：升级完成后系统必须清除缓存的二进制路径，重新执行解析流程以确保使用新安装的二进制。
+
+#### 错误诊断
+
+- **FR-014**：当 CLI 二进制解析失败时，系统必须通过编辑器通知显示用户可理解的错误消息和修复指引。
+- **FR-015**：错误消息必须根据失败原因区分：① 未安装 Node.js → 提示安装 Node.js 的 URL；② Node.js 版本过低 → 提示升级到 >= 20 并给出当前版本；③ npm 命令失败 → 包含 npm 错误输出；④ 网络安装失败 → 建议手动执行安装命令。
+- **FR-016**：系统必须将完整的错误堆栈和诊断信息输出到编辑器输出面板的 Wave 通道，便于高级用户和开发者排查。
+- **FR-017**：当 CLI 子进程启动后立即退出时，系统必须捕获 stderr 输出（如果有）并包含在错误消息中。
+
+#### JSON-RPC 通信
+
+- **FR-018**：系统必须通过 stdin/stdout 以行分隔的 JSON 进行通信，每行一个 JSON-RPC 2.0 消息。
+- **FR-019**：请求消息必须包含 `id`（自增整数）、`method`、可选 `params` 和可选 `sessionId`。
+- **FR-020**：响应消息必须通过 `id` 匹配到 pending 请求，`result` 字段 resolve，`error` 字段 reject（包含 `code` 和 `message`）。
+- **FR-021**：通知消息必须包含 `method` 但不包含 `id`，fire-and-forget，不创建 pending 请求。
+- **FR-022**：系统必须支持为同一通知方法注册多个处理器。
+- **FR-023**：系统必须静默忽略 stdout 中无法解析为 JSON、值为 `null` 或非对象类型的行，不影响后续消息处理。
+- **FR-024**：系统必须使用 `readline.createInterface` 逐行读取 stdout，确保跨平台换行符兼容。
+
+#### 进程生命周期
+
+- **FR-025**：系统必须通过 `spawn(binaryPath, args)` 启动 CLI 子进程，Windows 上设置 `shell: true`。
+- **FR-026**：当 CLI 子进程退出时，系统必须 reject 所有 pending 请求（错误信息包含退出码）并标记 StdioClient 为 disposed。
+- **FR-027**：当 StdioClient 已 disposed 时，系统必须立即 reject 新请求，不尝试写入 stdin。
+- **FR-028**：`dispose()` 必须杀掉子进程、标记 disposed，且幂等（多次调用不报错）。
+- **FR-029**：系统必须将 CLI 子进程的 stderr 输出转发到编辑器输出面板的 Wave 通道。
+- **FR-030**：当 StdioClient disposed 后用户尝试操作时，系统必须显示明确的"连接已断开"错误消息。
+
+#### 多会话路由
+
+- **FR-031**：所有 ChatSession 必须共享同一个 StdioClient 实例，通过 JSON-RPC 信封中的 `sessionId` 区分会话。
+- **FR-032**：NotificationRouter 必须维护 `sessionId → StdioAgent` 的映射表，将带 sessionId 的通知分发到对应 agent。
+- **FR-033**：NotificationRouter 必须支持全局通知处理器（无 sessionId 的通知），如 `authUrl`。
+- **FR-034**：当收到 `sessionIdChange` 通知时，NotificationRouter 必须将旧 sessionId 的映射迁移到新 sessionId（rekey）。
+- **FR-035**：StdioAgent.destroy() 必须从 NotificationRouter 取消注册，但不 dispose 共享的 StdioClient。
+- **FR-036**：ChatProvider.dispose() 必须先销毁所有 ChatSession，再 dispose 共享的 StdioClient。
+- **FR-037**：NotificationRouter.attach() 必须一次性订阅所有已知通知类型，且幂等（多次调用不重复订阅）。
+
+#### 状态缓存
+
+- **FR-038**：StdioAgent 必须在本地缓存以下状态字段：`sessionId`、`workingDirectory`、`latestTotalTokens`、`permissionMode`、`messages`、`queuedMessages`、`tasks`。
+- **FR-039**：StdioAgent 必须处理以下通知类型并更新对应缓存：`messagesChange`→messages、`queuedMessagesChange`→queuedMessages、`tasksChange`→tasks、`sessionIdChange`→sessionId、`permissionModeChange`→permissionMode、`workdirChange`→workingDirectory、`loadingChange`→latestTotalTokens。
+- **FR-040**：当回调函数未设置（undefined）时，StdioAgent 必须正常更新缓存但不触发回调，不抛出错误。
+- **FR-041**：StdioAgent 必须处理以下无缓存更新的通知类型（仅触发回调）：`userMessageAdded`、`assistantMessageAdded`、`assistantContentUpdated`、`assistantReasoningUpdated`、`toolBlockUpdated`、`errorBlockAdded`、`compactBlockAdded`、`commandRunningChange`、`mcpServersChange`、`bangMessageAdded`、`bangMessageUpdated`、`bangMessageCompleted`、`notificationMessageAdded`、`permissionRequest`。
+
+### 关键实体
+
+- **StdioClient**：低层 JSON-RPC 2.0 传输层。管理 `wave --stdio` 子进程的 stdin/stdout，提供 `request()`/`notify()`/`onNotification()`/`dispose()` 接口。单实例共享。
+- **StdioAgent**：围绕 StdioClient 的类型化包装层。维护本地状态缓存，处理 20+ 种通知类型，提供与 Agent API 语义一致的高层接口（sendMessage/bang/abort/clear/rewind/权限/MCP 等）。每会话一个实例。
+- **NotificationRouter**：通知分发路由器。维护 `sessionId → StdioAgent` 映射表，将带 sessionId 的通知分发到对应 agent，无 sessionId 的通知分发到全局处理器。处理 sessionIdChange rekey。
+- **BinaryResolver**：CLI 二进制文件解析器。按 PATH → npm 全局 → 自动安装的优先级解析，支持版本检查和升级。模块级缓存。
+- **JSON-RPC 信封**：行分隔的 JSON 消息格式。Request: `{id, method, params?, sessionId?}`；Response: `{id, result?|error?}`；Notification: `{method, params?, sessionId?}`。
+
+### 假设
+
+- 编辑器插件（VSCE / JB 等）运行在插件宿主进程中，该进程自带 Node.js 运行时（`process.execPath`），但该运行时不包含 npm。
+- 用户系统可能安装了独立的 Node.js（含 npm），也可能完全未安装 Node.js，或安装了低于 20 的旧版本。
+- `wave --stdio` 子进程要求 Node.js >= 20。
+- `wave --stdio` 子进程实现了 JSON-RPC 2.0 服务端协议，通过 stdin 接收请求/通知，通过 stdout 返回响应/推送通知。
+- 插件版本号来自 `package.json` 的 `version` 字段，遵循 semver 格式。
+- npm 全局镜像 `https://registry.npmmirror.com` 适用于中国用户加速下载。
+- 多个 ChatSession（sidebar/tab/window）共享同一个 CLI 子进程是刻意的设计决策，通过 sessionId 区分会话。
+- 本规格以 VSCE 实现为参考基准，JB 插件复用同一协议和架构。

--- a/specs/README.md
+++ b/specs/README.md
@@ -13,9 +13,9 @@
 
 | 指标 | 数量 |
 |------|------|
-| 规格文件 | 58 |
-| 用户故事 | 250 |
-| 功能需求 | 971 |
+| 规格文件 | 59 |
+| 用户故事 | 257 |
+| 功能需求 | 1,013 |
 | 测试用例 | 4,193 |
 
 ## 规格列表
@@ -108,6 +108,7 @@
 | Status 命令 | `/status` 显示版本、会话 ID、cwd、模型和运行时信息 | 1 | 9 | [规格](048-status-command.md) |
 | Update 命令 | `wave update` / `wave-code update` 更新到最新版本 | 2 | 7 | [规格](029-update-command.md) |
 | 历史搜索 | Ctrl+R 历史搜索，复用 `~/.wave/history.jsonl` 中的历史提示 | 2 | 10 | [规格](040-history-search-prompt.md) |
+| Stdio 传输层 | 编辑器插件与 `wave --stdio` 子进程的 JSON-RPC 通信，CLI 解析/安装/升级、多会话路由、错误诊断 | 7 | 42 | [规格](049-stdio-transport.md) |
 
 ### 多 Agent 与并发
 


### PR DESCRIPTION
## Summary

Implements spec 049 (Stdio 传输层) — comprehensive error diagnostics and UX improvements for the stdio transport layer in both VSCE and JB plugins.

## Changes

### Error Diagnostics (FR-005, FR-005b, FR-014, FR-015)
- **NodeJsNotFoundError**: `findNpm()` now throws a clear error when Node.js/npm is not found, instead of falling back to `'npm'` string which caused the cryptic "Failed to determine npm global directory" error
- **NodeJsVersionError**: Added Node.js >= 20 version check — throws with current version and download link when below minimum
- **chatProvider**: Error messages now differentiate: ① Node.js not installed → install URL; ② Version too low → upgrade hint; ③ Other → generic install command

### stderr Forwarding (FR-016, FR-029)
- VSCE: stderr forwarded to VS Code OutputChannel via `onStderr` callback
- JB: stderr already logged via `LOG.warn` (no change needed)

### Process Exit Handling (FR-017, FR-030)
- stderr is buffered (4KB rolling window) and included in the process exit error message
- Disposed client error message changed from "StdioClient is disposed" to user-friendly "连接已断开。wave 进程已退出，请重启编辑器或检查 CLI 安装。"

### Install Progress (FR-007b)
- VSCE: `withProgress` notification shows "正在安装/升级 wave-code，请稍候…" during npm install/upgrade
- JB: `NotificationGroupManager` shows INFORMATION notification during install/upgrade

### JB Plugin Sync
- All changes mirrored to `BinaryResolver.kt`, `StdioClient.kt`, `WaveBackendService.kt`

### Spec
- Added `specs/049-stdio-transport.md` — 7 user stories, 43 FRs covering the full stdio transport lifecycle

## Test plan
- [x] VSCE: 58 tests pass (binaryResolver + stdioClient, including 8 new tests)
- [x] JB: 15 gradle tasks pass
- [x] VSCE compiles (esbuild)
- [x] JB compiles (gradle)
- [x] Verified on Windows without Node.js: shows "未检测到 Node.js/npm" instead of cryptic error