### PR TITLE
feat: IDE plugin manual /compact + native compaction notifications

### DIFF
--- a/packages/code/src/stdio/agentBridge.ts
+++ b/packages/code/src/stdio/agentBridge.ts
@@ -278,6 +278,11 @@ export class AgentBridge {
           p.workdir as string | undefined,
           sessionId,
         );
+      case "compact":
+        return this.compact(
+          p.customInstructions as string | undefined,
+          sessionId,
+        );
 
       default:
         throw new RpcError(
@@ -553,6 +558,15 @@ export class AgentBridge {
   }> {
     const entry = this.requireSession(sessionId);
     return entry.agent.getFullMessageThread();
+  }
+
+  private async compact(
+    customInstructions: string | undefined,
+    sessionId?: string,
+  ): Promise<null> {
+    const entry = this.requireSession(sessionId);
+    await entry.agent.compact(customInstructions);
+    return null;
   }
 
   // ── Permissions ───────────────────────────────────────────────
@@ -921,6 +935,13 @@ export class AgentBridge {
       },
       onCompactBlockAdded: (content: string) => {
         this.emit("compactBlockAdded", { content }, ctx.registeredSessionId);
+      },
+      onCompactionStateChange: (isCompacting: boolean) => {
+        this.emit(
+          "compactionStateChange",
+          { isCompacting },
+          ctx.registeredSessionId,
+        );
       },
     };
   }

--- a/packages/code/src/stdio/protocol.ts
+++ b/packages/code/src/stdio/protocol.ts
@@ -86,7 +86,8 @@ export type RequestMethod =
   | "listMarketplaces"
   | "addMarketplace"
   | "removeMarketplace"
-  | "updateMarketplace";
+  | "updateMarketplace"
+  | "compact";
 
 // ── Client → Server notification methods ────────────────────────
 
@@ -116,7 +117,8 @@ export type ServerNotificationMethod =
   | "notificationMessageAdded"
   | "permissionRequest"
   | "authUrl"
-  | "compactBlockAdded";
+  | "compactBlockAdded"
+  | "compactionStateChange";
 
 // ── Helper: is this a request (has id)? ─────────────────────────
 

--- a/packages/code/tests/stdio/agentBridge.test.ts
+++ b/packages/code/tests/stdio/agentBridge.test.ts
@@ -46,6 +46,7 @@ function createMockAgent(overrides: Record<string, unknown> = {}) {
     getFullMessageThread: vi
       .fn()
       .mockResolvedValue({ messages, sessionIds: ["test-session-id"] }),
+    compact: vi.fn().mockResolvedValue(undefined),
     getPermissionMode: vi.fn().mockReturnValue("default"),
     setPermissionMode: vi.fn(),
     getMcpServers: vi.fn().mockReturnValue([]),
@@ -162,6 +163,55 @@ test("onCompactBlockAdded emits compactBlockAdded notification", async () => {
     params: { content: "summary content" },
     sessionId: "test-session-id",
   });
+});
+
+test("onCompactionStateChange emits compactionStateChange notification", async () => {
+  const { bridge, notifications } = createBridge();
+  vi.mocked(Agent.create).mockResolvedValue(createMockAgent());
+
+  await bridge.handleRequest("initialize", {});
+  const callbacks = vi.mocked(Agent.create).mock.calls[0][0]
+    .callbacks as AgentCallbacks;
+
+  callbacks.onCompactionStateChange!(true);
+
+  expect(notifications).toContainEqual({
+    method: "compactionStateChange",
+    params: { isCompacting: true },
+    sessionId: "test-session-id",
+  });
+});
+
+// ── compact request ───────────────────────────────────────────────
+
+test("compact request with customInstructions calls agent.compact and returns null", async () => {
+  const { bridge } = createBridge();
+  const mockAgent = createMockAgent();
+  vi.mocked(Agent.create).mockResolvedValue(mockAgent);
+
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  const r = await bridge.handleRequest(
+    "compact",
+    { customInstructions: "focus on tests" },
+    sessionId,
+  );
+
+  expect(mockAgent.compact).toHaveBeenCalledWith("focus on tests");
+  expect(r).toBeNull();
+});
+
+test("compact request without customInstructions calls agent.compact with undefined", async () => {
+  const { bridge } = createBridge();
+  const mockAgent = createMockAgent();
+  vi.mocked(Agent.create).mockResolvedValue(mockAgent);
+
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  const r = await bridge.handleRequest("compact", {}, sessionId);
+
+  expect(mockAgent.compact).toHaveBeenCalledWith(undefined);
+  expect(r).toBeNull();
 });
 
 test("onUserMessageAdded finds last user message and emits notification", async () => {

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
@@ -82,6 +82,10 @@ class MessageHandler(
                 postMessage("updateMessages", buildJsonObject { put("messages", JsonArray(emptyList())) })
                 postMessage("updateQueue", buildJsonObject { put("queue", JsonArray(emptyList())) })
             }
+            "compact" -> {
+                val customInstructions = msg["customInstructions"]?.jsonPrimitive?.content
+                session.agent?.compact(customInstructions)
+            }
             "abortMessage" -> session.agent?.abortMessage()
             "setPermissionMode" -> {
                 val mode = msg["mode"]?.jsonPrimitive?.content ?: "default"
@@ -687,6 +691,7 @@ class MessageHandler(
             triple("mcp", "mcp", "打开 MCP 服务器管理"),
             triple("status", "status", "查看当前状态"),
             triple("clear", "clear", "清除对话历史并重置会话"),
+            triple("compact", "compact", "手动压缩对话历史"),
         )
         val all = sdkCommands + local
         // VSCE messageHandler.ts:618-624: filter by id/name (case-insensitive includes)

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
@@ -1,6 +1,8 @@
 package com.wave.jetbrains.session
 
 import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
@@ -12,6 +14,7 @@ import com.wave.jetbrains.stdio.StdioAgent
 import com.wave.jetbrains.stdio.StdioClient
 import com.wave.jetbrains.stdio.StdioClientException
 import com.wave.jetbrains.update.UpdateChecker
+import com.wave.jetbrains.util.Edt
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -162,6 +165,18 @@ class WaveSession(
     override fun onCompactBlockAdded(content: String) {
         // onMessagesChange（截断列表）已先于此到达并更新 this.messages；即时推一次
         scope.launch { immediateMessagesUpdate() }
+    }
+
+    // VSCE chatSession.ts:97-103: mirror vscode.window.showInformationMessage via the IDE's
+    // balloon notification group. Fires on the stdio reader thread → hop to the EDT.
+    override fun onCompactionStateChange(isCompacting: Boolean) {
+        val message = if (isCompacting) "正在压缩对话…" else "对话压缩完成"
+        Edt.invokeLater {
+            NotificationGroupManager.getInstance()
+                .getNotificationGroup("Wave")
+                .createNotification("Wave", message, NotificationType.INFORMATION)
+                .notify(project)
+        }
     }
 
     override fun onUserMessageAdded(message: JsonElement?) {

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/NotificationRouter.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/NotificationRouter.kt
@@ -84,6 +84,7 @@ class NotificationRouter(private val client: StdioClient) {
             "permissionRequest",
             "authUrl",
             "compactBlockAdded",
+            "compactionStateChange",
         )
     }
 }

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioAgent.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioAgent.kt
@@ -23,6 +23,7 @@ interface AgentCallbacks {
     fun onToolBlockUpdated(params: JsonElement?) {}
     fun onErrorBlockAdded(error: String) {}
     fun onCompactBlockAdded(content: String) {}
+    fun onCompactionStateChange(isCompacting: Boolean) {}
     fun onLoadingChange(loading: Boolean) {}
     fun onCommandRunningChange(running: Boolean) {}
     fun onQueuedMessagesChange(messages: JsonElement?) {}
@@ -118,6 +119,9 @@ class StdioAgent(
             "bangMessageCompleted" -> callbacks.onBangMessageCompleted()
             "notificationMessageAdded" -> callbacks.onNotificationMessageAdded(params?.jsonObject ?: JsonObject(emptyMap()))
             "compactBlockAdded" -> callbacks.onCompactBlockAdded(params?.jsonObject?.get("content")?.jsonPrimitive?.content ?: "")
+            "compactionStateChange" -> callbacks.onCompactionStateChange(
+                params?.jsonObject?.get("isCompacting")?.jsonPrimitive?.content?.toBoolean() ?: false
+            )
             else -> {}
         }
     }
@@ -159,6 +163,12 @@ class StdioAgent(
 
     suspend fun abortMessage() { client.request("abortMessage", sessionId = sessionId) }
     suspend fun clearMessages() { client.request("clearMessages", sessionId = sessionId) }
+
+    suspend fun compact(customInstructions: String? = null) {
+        client.request("compact", buildJsonObject {
+            if (customInstructions != null) put("customInstructions", customInstructions)
+        }, sessionId)
+    }
 
     suspend fun restoreSession(sessionId: String) {
         client.request("restoreSession", buildJsonObject { put("sessionId", sessionId) }, this.sessionId)

--- a/packages/vsce/src/session/chatSession.ts
+++ b/packages/vsce/src/session/chatSession.ts
@@ -94,6 +94,13 @@ export class ChatSession {
                     this.forceNextUpdateImmediate = true;
                     this.throttledUpdateChatMessages(this.messages);
                 },
+                onCompactionStateChange: (isCompacting: boolean) => {
+                    if (isCompacting) {
+                        vscode.window.showInformationMessage('正在压缩对话…');
+                    } else {
+                        vscode.window.showInformationMessage('对话压缩完成');
+                    }
+                },
                 onUserMessageAdded: (message: Message) => {
                     this.callbacks.onAssistantMessageAdded?.(message);
                 },
@@ -259,6 +266,12 @@ export class ChatSession {
             this.throttledUpdateChatMessages([]);
         }
         await this.clearQueue();
+    }
+
+    public async compact(customInstructions?: string) {
+        if (this.agent) {
+            await this.agent.compact(customInstructions);
+        }
     }
 
     private async clearQueue() {

--- a/packages/vsce/src/session/messageHandler.ts
+++ b/packages/vsce/src/session/messageHandler.ts
@@ -51,6 +51,9 @@ export class MessageHandler {
             case 'clearChat':
                 await this.clearChat(viewType, windowId);
                 break;
+            case 'compact':
+                await this.compactChat(msg.customInstructions as string | undefined, viewType, windowId);
+                break;
             case 'abortMessage':
                 await this.abortMessage(viewType, windowId);
                 break;
@@ -504,6 +507,16 @@ export class MessageHandler {
         }
     }
 
+    private async compactChat(customInstructions: string | undefined, viewType?: 'sidebar' | 'tab' | 'window', windowId?: string) {
+        const session = this.context.getChatSession(viewType || 'tab', windowId);
+        try {
+            await session.compact(customInstructions);
+        } catch (error) {
+            console.error(`压缩 ${viewType} 聊天会话失败:`, error);
+            vscode.window.showErrorMessage('压缩对话失败: ' + error);
+        }
+    }
+
     private async restoreSession(sessionId: string, viewType?: 'sidebar' | 'tab' | 'window', windowId?: string) {
         if (!sessionId) return;
         const session = this.context.getChatSession(viewType || 'tab', windowId);
@@ -681,7 +694,8 @@ export class MessageHandler {
                 { id: 'plugin', name: 'plugin', description: '打开插件管理' },
                 { id: 'mcp', name: 'mcp', description: '打开 MCP 服务器管理' },
                 { id: 'status', name: 'status', description: '查看当前状态' },
-                { id: 'clear', name: 'clear', description: '清除对话历史并重置会话' }
+                { id: 'clear', name: 'clear', description: '清除对话历史并重置会话' },
+                { id: 'compact', name: 'compact', description: '手动压缩对话历史' }
             ];
 
             const allCommands = [...sdkCommands, ...localCommands];

--- a/packages/vsce/src/stdio/notificationRouter.ts
+++ b/packages/vsce/src/stdio/notificationRouter.ts
@@ -45,6 +45,7 @@ const ALL_NOTIFICATION_METHODS = [
     'permissionRequest',
     'authUrl',
     'compactBlockAdded',
+    'compactionStateChange',
 ] as const;
 
 export class NotificationRouter {

--- a/packages/vsce/src/stdio/stdioAgent.ts
+++ b/packages/vsce/src/stdio/stdioAgent.ts
@@ -84,6 +84,7 @@ export interface StdioAgentCallbacks {
     onToolBlockUpdated?: (params: ToolBlockUpdateCallbackParams) => void;
     onErrorBlockAdded?: (error: string) => void;
     onCompactBlockAdded?: (content: string) => void;
+    onCompactionStateChange?: (isCompacting: boolean) => void;
     onLoadingChange?: (loading: boolean) => void;
     onCommandRunningChange?: (running: boolean) => void;
     onQueuedMessagesChange?: (messages: QueuedMessage[]) => void;
@@ -214,6 +215,14 @@ export class StdioAgent {
 
     async clearMessages(): Promise<void> {
         await this.client.request('clearMessages', undefined, this.sessionId);
+    }
+
+    async compact(customInstructions?: string): Promise<void> {
+        await this.client.request(
+            'compact',
+            { customInstructions },
+            this.sessionId,
+        );
     }
 
     async rewindToMessage(
@@ -387,6 +396,11 @@ export class StdioAgent {
             case 'compactBlockAdded': {
                 const p = params as { content: string };
                 this.callbacks.onCompactBlockAdded?.(p.content);
+                break;
+            }
+            case 'compactionStateChange': {
+                const p = params as { isCompacting: boolean };
+                this.callbacks.onCompactionStateChange?.(p.isCompacting);
                 break;
             }
             case 'loadingChange': {

--- a/packages/vsce/tests/session/messageHandler.test.ts
+++ b/packages/vsce/tests/session/messageHandler.test.ts
@@ -26,6 +26,8 @@ function createMockSession(): ChatSession {
         getMcpServers: vi.fn(),
         connectMcpServer: vi.fn(),
         disconnectMcpServer: vi.fn(),
+        compact: vi.fn(),
+        getSlashCommands: vi.fn().mockResolvedValue([]),
     } as unknown as ChatSession;
 }
 
@@ -219,5 +221,43 @@ describe('MessageHandler MCP handlers', () => {
         const posted = (context.postMessage as ReturnType<typeof vi.fn>).mock.calls[0][0] as { command: string; version: string };
         expect(posted.command).toBe('statusResponse');
         expect(posted.version).toBe('1.2.3');
+    });
+
+    // /compact command: mirrors /clear — the webview posts { command: 'compact', customInstructions }
+    // and the handler delegates to session.compact(customInstructions).
+    test('compact command calls session.compact with customInstructions', async () => {
+        const session = createMockSession();
+        (session.compact as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+        const { handler } = createHandler(session);
+        await handler.handleMessage({ command: 'compact', customInstructions: 'focus on API' }, 'tab');
+
+        expect(session.compact).toHaveBeenCalledWith('focus on API');
+    });
+
+    test('compact command calls session.compact with undefined when no instructions', async () => {
+        const session = createMockSession();
+        (session.compact as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+        const { handler } = createHandler(session);
+        await handler.handleMessage({ command: 'compact' }, 'tab');
+
+        expect(session.compact).toHaveBeenCalledWith(undefined);
+    });
+
+    test('slashCommandsRequest includes compact in localCommands', async () => {
+        const session = createMockSession();
+
+        const { handler, context } = createHandler(session);
+        await handler.handleMessage({ command: 'requestSlashCommands', filterText: '' }, 'tab');
+
+        const posted = (context.postMessage as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+            command: string;
+            commands: Array<{ id: string; name: string; description: string }>;
+        };
+        expect(posted.command).toBe('slashCommandsResponse');
+        const compact = posted.commands.find(c => c.id === 'compact');
+        expect(compact).toBeDefined();
+        expect(compact?.name).toBe('compact');
     });
 });

--- a/packages/vsce/tests/stdio/notificationRouter.test.ts
+++ b/packages/vsce/tests/stdio/notificationRouter.test.ts
@@ -75,6 +75,7 @@ describe('NotificationRouter', () => {
         expect(methods).toContain('permissionRequest');
         expect(methods).toContain('authUrl');
         expect(methods).toContain('compactBlockAdded');
+        expect(methods).toContain('compactionStateChange');
     });
 
     it('attach is idempotent — does not register handlers twice', () => {
@@ -101,6 +102,18 @@ describe('NotificationRouter', () => {
         getHandler(client, 'messagesChange')({ messages: [] }, 's1');
 
         expect(agent.handleNotification).toHaveBeenCalledWith('messagesChange', { messages: [] });
+    });
+
+    it('dispatches compactionStateChange to registered agent by sessionId', () => {
+        const router = new NotificationRouter(client as unknown as StdioClient);
+        router.attach();
+
+        const agent = createFakeAgent();
+        router.register('s1', agent as unknown as Parameters<NotificationRouter['register']>[1]);
+
+        getHandler(client, 'compactionStateChange')({ isCompacting: true }, 's1');
+
+        expect(agent.handleNotification).toHaveBeenCalledWith('compactionStateChange', { isCompacting: true });
     });
 
     it('drops notification for unregistered sessionId without throwing', () => {

--- a/packages/vsce/tests/stdio/stdioAgent.test.ts
+++ b/packages/vsce/tests/stdio/stdioAgent.test.ts
@@ -81,6 +81,7 @@ describe('StdioAgent', () => {
         expect(registeredMethods).toContain('permissionRequest');
         expect(registeredMethods).toContain('authUrl');
         expect(registeredMethods).toContain('compactBlockAdded');
+        expect(registeredMethods).toContain('compactionStateChange');
     });
 
     // ── initialize ─────────────────────────────────────────────
@@ -246,6 +247,40 @@ describe('StdioAgent', () => {
         await agent.clearMessages();
 
         expect(client.request).toHaveBeenCalledWith('clearMessages', undefined, 'session-123');
+    });
+
+    // ── compact ────────────────────────────────────────────────
+
+    it('sends compact request with customInstructions and sessionId', async () => {
+        const { agent, client } = createAgent();
+        client.request.mockResolvedValue({
+            sessionId: 'session-123',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
+        client.request.mockClear();
+
+        await agent.compact('focus on tests');
+
+        expect(client.request).toHaveBeenCalledWith('compact', { customInstructions: 'focus on tests' }, 'session-123');
+    });
+
+    it('sends compact request with undefined customInstructions and sessionId', async () => {
+        const { agent, client } = createAgent();
+        client.request.mockResolvedValue({
+            sessionId: 'session-123',
+            workingDirectory: '/w',
+            permissionMode: 'default',
+            latestTotalTokens: 0,
+        });
+        await agent.initialize({ workdir: '/w' });
+        client.request.mockClear();
+
+        await agent.compact();
+
+        expect(client.request).toHaveBeenCalledWith('compact', { customInstructions: undefined }, 'session-123');
     });
 
     // ── rewindToMessage ────────────────────────────────────────
@@ -586,6 +621,15 @@ describe('StdioAgent', () => {
         agent.handleNotification('compactBlockAdded', { content: 'compacted summary' });
 
         expect(onCompactBlockAdded).toHaveBeenCalledWith('compacted summary');
+    });
+
+    it('compactionStateChange forwards isCompacting boolean to callback', () => {
+        const onCompactionStateChange = vi.fn();
+        const { agent } = createAgent({ onCompactionStateChange });
+
+        agent.handleNotification('compactionStateChange', { isCompacting: true });
+
+        expect(onCompactionStateChange).toHaveBeenCalledWith(true);
     });
 
     it('loadingChange updates latestTotalTokens and calls callback', () => {

--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -263,6 +263,14 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode }) => {
       handleClearChat();
       return;
     }
+    if (trimmedText === '/compact' || trimmedText.startsWith('/compact ')) {
+      const customInstructions = trimmedText.slice('/compact'.length).trim() || undefined;
+      vscode.postMessage({
+        command: 'compact',
+        customInstructions
+      });
+      return;
+    }
     if (trimmedText === '/config') {
       dispatch({ type: 'SHOW_DIALOG', payload: { type: 'config', data: stateRef.current.configurationData || {} } });
       vscode.postMessage({ command: 'getConfiguration' });

--- a/packages/webview/src/components/MessageInput.tsx
+++ b/packages/webview/src/components/MessageInput.tsx
@@ -785,7 +785,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>((p
     // mouse click on the popup works even when the browser selection is no
     // longer inside the input's text node (which made getSelection()-based
     // logic below silently no-op on click).
-    const localCommands = ['config', 'plugin', 'mcp', 'status', 'clear'];
+    const localCommands = ['config', 'plugin', 'mcp', 'status', 'clear', 'compact'];
     if (localCommands.includes(command.name)) {
       textareaRef.current.innerHTML = '';
       setMessage('');

--- a/packages/webview/src/components/SlashCommandsPopup.tsx
+++ b/packages/webview/src/components/SlashCommandsPopup.tsx
@@ -17,7 +17,7 @@ interface SlashCommandsPopupProps {
 }
 
 const PLUGIN_COMMAND = 'plugin';
-const SYSTEM_COMMANDS = ['config', 'mcp', 'status', 'clear'];
+const SYSTEM_COMMANDS = ['config', 'mcp', 'status', 'clear', 'compact'];
 
 interface CommandGroup {
   title: string;

--- a/packages/webview/tests/webview/slashCommandsGrouping.test.tsx
+++ b/packages/webview/tests/webview/slashCommandsGrouping.test.tsx
@@ -39,6 +39,7 @@ describe('SlashCommandsPopup grouping', () => {
             { id: 'mcp', name: 'mcp', description: 'MCP' },
             { id: 'status', name: 'status', description: '状态' },
             { id: 'clear', name: 'clear', description: '清空' },
+            { id: 'compact', name: 'compact', description: '压缩' },
             { id: 'settings', name: 'settings', description: '设置技能' },
             { id: 'loop', name: 'loop', description: '循环技能' },
             { id: 'deepwiki:ask', name: 'deepwiki:ask', description: 'DeepWiki' }
@@ -56,9 +57,9 @@ describe('SlashCommandsPopup grouping', () => {
         expect(within(pluginGroup).getByTestId('slash-command-plugin')).toBeInTheDocument();
         expect(within(pluginGroup).queryByTestId('slash-command-config')).not.toBeInTheDocument();
 
-        // config/mcp/status/clear -> 系统指令
+        // config/mcp/status/clear/compact -> 系统指令
         const systemGroup = getGroup('系统指令');
-        for (const id of ['config', 'mcp', 'status', 'clear']) {
+        for (const id of ['config', 'mcp', 'status', 'clear', 'compact']) {
             expect(within(systemGroup).getByTestId(`slash-command-${id}`)).toBeInTheDocument();
         }
         expect(within(systemGroup).queryByTestId('slash-command-plugin')).not.toBeInTheDocument();

--- a/specs/013-message-compact.md
+++ b/specs/013-message-compact.md
@@ -106,6 +106,24 @@
 
 ---
 
+### 用户故事 7 - IDE 插件手动压缩与原生通知（优先级：P2）
+
+作为 IDE 插件（VS Code 扩展与 JetBrains 插件）用户，我希望能在 IDE 中手动触发对话压缩（`/compact`），并在压缩过程中收到原生通知，以便我主动管理上下文并实时知晓压缩状态。
+
+**为什么是这个优先级**：IDE 插件以 stdio 子进程方式运行 Agent，无法直接调用 CLI 内部命令；若不做协议适配，`/compact` 会被当作普通消息发送给模型而失效。同时压缩可能耗时数秒，原生通知让用户明确知道压缩正在进行，避免误以为无响应。VS Code 扩展与 JetBrains 插件共享同一 webview 包与 stdio 协议，二者行为必须一致。
+
+**独立测试**：在 VS Code 扩展与 JetBrains 插件中分别输入 `/compact`，验证通过 stdio `compact` 请求触发压缩而非发送普通消息；模拟 `compactionStateChange` 通知，验证两端均显示原生通知。
+
+**验收场景**：
+
+1. **假设**对话中有消息，**当**用户在 IDE 插件中输入 `/compact` 时，**则**插件必须通过 stdio `compact` 请求触发压缩，而非将文本作为普通消息发送给模型
+2. **假设**用户输入 `/compact focus on the API design`，**当**请求发出时，**则**自定义指令必须作为 `customInstructions` 传递给 `compact` 请求并影响摘要
+3. **假设**压缩开始（手动或自动触发），**当**子进程发送 `compactionStateChange`（`isCompacting=true`）时，**则**IDE 插件必须显示原生通知提示压缩进行中
+4. **假设**压缩完成，**当**子进程发送 `compactionStateChange`（`isCompacting=false`）时，**则**IDE 插件必须显示原生通知提示压缩完成
+5. **假设**压缩已在进行中，**当**用户再次输入 `/compact` 时，**则**第二次压缩必须被跳过（复用 FR-016 熔断器）
+
+---
+
 ### 边界情况
 
 - **递归压缩**：当压缩已包含摘要的历史时，整个历史（包括旧摘要）被新的延续摘要替换
@@ -140,6 +158,12 @@
 - **FR-021**：系统必须将 PreCompact 钩子的 stdout 与用户提供的自定义指令合并作为额外的压缩指令
 - **FR-022**：系统必须将 PreCompact 和 PostCompact 钩子的退出码 2 视为非阻塞（压缩继续）
 - **FR-023**：系统不得要求 PreCompact 和 PostCompact 钩子配置使用匹配器
+- **FR-024**：stdio 协议必须支持 `compact` 请求方法，携带可选的 `customInstructions` 参数，调用 `Agent.compact(customInstructions)`
+- **FR-025**：当用户在 IDE 插件（VS Code 扩展或 JetBrains 插件）中输入 `/compact [instructions]` 时，插件必须将其识别为本地命令并通过 `compact` 请求触发压缩，而非通过 `sendMessage` 将文本作为普通消息发送
+- **FR-026**：stdio 协议必须支持 `compactionStateChange` 通知，携带 `isCompacting` 布尔参数，在压缩状态变化时由子进程发送给客户端
+- **FR-027**：AgentBridge 必须将 `AgentCallbacks.onCompactionStateChange` 回调转发为 `compactionStateChange` 通知
+- **FR-028**：IDE 插件必须在收到 `compactionStateChange` 通知（`isCompacting=true`）时显示原生通知提示压缩进行中（VS Code 扩展使用 `vscode.window` 通知 API，JetBrains 插件使用 `NotificationGroupManager`）
+- **FR-029**：IDE 插件必须在压缩完成（`isCompacting=false`）时显示原生通知提示压缩完成
 
 ### 关键实体 *（如果功能涉及数据则包含）*
 


### PR DESCRIPTION
## Summary

Add stdio protocol support for manual compaction from IDE plugins (VS Code extension + JetBrains plugin), with native notifications during compaction.

## Changes

### Protocol layer (`packages/code/src/stdio/`)
- **protocol.ts** — add `compact` request method + `compactionStateChange` server→client notification
- **agentBridge.ts** — `compact` request → `Agent.compact(customInstructions)`; forward `onCompactionStateChange` callback as `compactionStateChange` notification

### VS Code extension (`packages/vsce/`)
- **stdioAgent.ts** — `compact()` RPC + `onCompactionStateChange` callback + notification dispatch case
- **notificationRouter.ts** — subscribe to `compactionStateChange`
- **chatSession.ts** — `compact()` method; native `vscode.window.showInformationMessage` on start (`正在压缩对话…`) / complete (`对话压缩完成`)
- **messageHandler.ts** — `compact` command case + `compact` entry in localCommands

### Shared webview (`packages/webview/`)
- **ChatApp.tsx** — intercept `/compact [instructions]` before normal send
- **MessageInput.tsx** + **SlashCommandsPopup.tsx** — register `compact` as a system command

### JetBrains plugin (`packages/jetbrains/`)
- **StdioAgent.kt** — `compact()` RPC + `onCompactionStateChange` callback + notification case
- **NotificationRouter.kt** — register `compactionStateChange`
- **WaveSession.kt** — native balloon via `NotificationGroupManager` ("Wave" group)
- **MessageHandler.kt** — `compact` command case + local command entry

## Spec
`specs/013-message-compact.md` — User Story 7 + FR-024..FR-029 (P2)

## Verification
- `pnpm run type-check` — all packages pass
- Tests: wave-code stdio 98/98, wave-vsce 148/148, wave-webview 264/264
- JetBrains `./gradlew compileKotlin` — BUILD SUCCESSFUL