### PR TITLE
docs(specs): fix stale content across 9 spec files

### DIFF
--- a/docs/specs/automation/hooks.md
+++ b/docs/specs/automation/hooks.md
@@ -30,7 +30,7 @@ Hook 通过退出码、stdout 和 stderr 传达状态：
 | `SubagentStop`     | 阻止停止（子代理继续），向 Wave 显示 stderr                            |
 | `PermissionRequest`| 阻止（拒绝）权限，仅向用户显示 stderr                                  |
 | `WorktreeCreate`   | 仅向用户显示 stderr（非阻止）                                         |
-| `PreCompact`      | 仅向用户显示 stderr（非阻止）                                         |
+| `PreCompact`      | 非阻止；stderr 不显示给用户（静默丢弃），压缩继续                   |
 | `PostCompact`     | 仅向用户显示 stderr（非阻止）                                         |
 
 ## 用户场景与测试 *（必填）*
@@ -361,7 +361,7 @@ Hook 需要访问完整的对话历史以做出上下文感知的决策。Hook �
 - **FR-014**：系统必须在 UserPromptSubmit 事件的 JSON 数据中包含包含用户提交文本的 prompt 字段
 - **FR-028**：系统必须在 hook 由子代理执行时在 JSON 数据中包含 subagent_type 字段
 - **FR-029**：系统必须在 WorktreeCreate 事件的 JSON 数据中包含 name 字段
-- **FR-015**：系统必须将 transcript_path 设置为存储会话数据的实际文件路径（格式：~/.wave/sessions/session_[shortId].json）
+- **FR-015**：系统必须将 transcript_path 设置为存储会话数据的实际文件路径（格式：~/.wave/projects/[project-slug]/[sessionId].jsonl）
 - **FR-016**：系统必须在 hook 被调用时将 cwd 设置为当前工作目录
 - **FR-017**：系统必须确保 JSON 数据在发送到 hook 进程之前格式正确且有效
 - **FR-018**：系统必须处理 hook 进程不从 stdin 读取的情况，不阻止或导致错误

--- a/docs/specs/core/agent-config.md
+++ b/docs/specs/core/agent-config.md
@@ -168,9 +168,9 @@ SDK 用户需要按子代理类型配置不同的 HTTP 请求头，以便 `custo
 - **FR-008**：系统必须保留与测试相关的环境变量的现有行为（`NODE_ENV`、`VITEST`、`WAVE_TEST_HOOKS_EXECUTION`）
 - **FR-009**：服务必须使用已解析的配置而非直接 `process.env` 访问
 - **FR-010**：系统必须为可选配置值提供合理默认值，当构造函数和环境变量都不存在时
-- **FR-011**：`callAgent` 必须在其选项参数中接受 `maxTokens` 参数，默认为 4096
+- **FR-011**：`callAgent` 必须在其选项参数中接受 `maxTokens` 参数，默认为 32000
 - **FR-012**：系统必须读取 `WAVE_MAX_OUTPUT_TOKENS` 环境变量作为默认最大输出 token
-- **FR-013**：`maxTokens` 的优先级必须为：`callAgent` 参数 > `Agent.create` 选项 > `WAVE_MAX_OUTPUT_TOKENS` > 默认值（4096）
+- **FR-013**：`maxTokens` 的优先级必须为：`callAgent` 参数 > `Agent.create` 选项 > `WAVE_MAX_OUTPUT_TOKENS` > 默认值（32000）
 - **FR-014**：SDK 必须读取 `WAVE_CUSTOM_HEADERS` 环境变量，按换行符分割并解析为 `Key: Value` 对
 - **FR-015**：如果通过自定义请求头提供了替代认证，SDK 不得在初始化时强制要求 `apiKey`
 - **FR-016**：系统必须支持通过 `AgentOptions` 或 `settings.json` 设置 `language`

--- a/docs/specs/core/tool-permission-system.md
+++ b/docs/specs/core/tool-permission-system.md
@@ -174,7 +174,7 @@
 - **FR-003**：CLI 必须为 "default" 模式下的受限工具提供确认组件。
 - **FR-004**：确认组件必须支持"是"、"是，不再询问"、"是，并自动接受编辑"（用于文件系统工具），以及通过文本输入的替代指令。
 - **FR-005**：系统必须支持 Agent SDK 中的 `canUseTool` 回调用于自定义权限逻辑。
-- **FR-006**：系统必须支持通过 `Shift+Tab` 切换权限模式（default -> acceptEdits -> plan -> bypassPermissions）。
+- **FR-006**：系统必须支持通过 `Shift+Tab` 切换权限模式（default -> acceptEdits -> bypassPermissions -> plan）。
 - **FR-021**：系统必须对识别为危险或越界的命令隐藏"不再询问"选项。
 - **FR-056**：系统必须检测 bash 命令中的写入重定向（`>`、`>>` 等）并将其视为危险操作，隐藏"不再询问"选项。
 - **FR-057**：系统在检测写入重定向时必须忽略文件描述符重定向（如 `2>&1`）。
@@ -184,7 +184,7 @@
 - **FR-046**：在 `dontAsk` 模式下，系统必须自动拒绝任何不匹配 `permissions.allow` 或 `temporaryRules` 中规则的受限工具调用。
 - **FR-047**：在 `dontAsk` 模式下，系统不得对未批准的受限工具调用 `canUseToolCallback`（通常会触发用户提示）。
 - **FR-048**：`dontAsk` 模式不得包含在 "Shift+Tab" 快捷键触发的权限模式循环中。
-- **FR-049**：当 `dontAsk` 模式激活时，系统必须向 agent 的系统提示中注入一条消息，说明："工具在'用户选择的权限模式'下执行。权限可以通过 settings.json 和 settings.local.json 配置。"
+- ~~**FR-049**：当 `dontAsk` 模式激活时，系统必须向 agent 的系统提示中注入一条消息，说明："工具在'用户选择的权限模式'下执行。权限可以通过 settings.json 和 settings.local.json 配置。"~~ *已移除：代码中不存在此提示注入。*
 
 #### 安全区域与安全文件访问
 - **FR-050**：系统必须将"安全区域"识别为当前工作目录和 `permissions.additionalDirectories` 中列出的所有路径的并集。

--- a/docs/specs/ecosystem/init-slash-command.md
+++ b/docs/specs/ecosystem/init-slash-command.md
@@ -39,28 +39,28 @@
 
 - **代码库为空或没有可识别的结构怎么办？** agent 应该提供带有必需前缀的最小 `AGENTS.md`，并注明未检测到特定架构，而不是失败或臆造。
 - **系统如何处理只读文件系统？** agent 应该通知用户由于权限问题无法创建或修改 `AGENTS.md`。
-- **如果 `init-prompt.md` 在预期位置缺失怎么办？** 命令应该使用提示的硬编码版本，因为它是内置命令。
+- **如果内置 init skill 的 `SKILL.md` 在预期位置缺失怎么办？** 命令应该使用提示的硬编码版本，因为它是内置命令。
 
 ## 需求 *（必填）*
 
 ### 功能需求
 
 - **FR-001**：系统必须在 agent 界面中支持 `/init` 斜杠命令。
-- **FR-002**：系统必须使用 `init-prompt.md` 的内容（作为内置提示硬编码）作为 `/init` 调用时 agent 的基础指令。
+- **FR-002**：系统必须使用内置 init skill（`builtin/skills/init/SKILL.md`）的内容作为 `/init` 调用时 agent 的基础指令。
 - **FR-003**：系统必须分析当前仓库以识别构建/测试/lint 命令和高级架构。
 - **FR-004**：系统必须在仓库根目录中创建或更新名为 `AGENTS.md` 的文件。
-- **FR-005**：系统必须确保 `AGENTS.md` 以 `init-prompt.md` 中指定的必需前缀开头。
+- **FR-005**：系统必须确保 `AGENTS.md` 以内置 init skill 中指定的必需前缀开头。
 - **FR-006**：系统必须不包含通用开发实践、冗余指令或 `.wave/rules/` 中的规则，如提示指南中所指定。
 - **FR-007**：系统必须纳入 `.cursor/rules/`、`.cursorrules` 或 `.github/copilot-instructions.md` 中的现有规则（如果它们存在）。
 
 ### 关键实体
 
 - **AGENTS.md**：包含未来 agent 实例指导的输出文件。
-- **init-prompt.md**：定义 `/init` 命令应如何行为的模板/指令文件。
+- **init skill（`SKILL.md`）**：定义 `/init` 命令应如何行为的内置 skill 指令文件。
 - **Repository Context**：用于生成指导而分析的文件集（README、配置文件、规则文件）。
 
 ## 假设
 
-- `init-prompt.md` 文件位于相对于 agent 执行环境的稳定路径，或与 agent 捆绑。
+- 内置 init skill 的 `SKILL.md` 文件位于相对于 agent 执行环境的稳定路径，或与 agent 捆绑。
 - agent 有足够的权限读取整个仓库并写入根目录。
 - 用户意图让 `AGENTS.md` 成为任何在仓库上工作的 AI agent 的共享资源，而不仅仅是 Wave Agent。

--- a/docs/specs/enterprise/server-managed-config.md
+++ b/docs/specs/enterprise/server-managed-config.md
@@ -64,7 +64,7 @@
 
 ### 功能需求
 
-- **FR-001**：在 SSO 认证期间初始化时，系统必须从 `WAVE_SERVER_URL/api/v1/managed-settings` 下载托管设置。
+- **FR-001**：在 SSO 认证期间初始化时，系统必须从 `WAVE_SERVER_URL/api/wave/settings` 下载托管设置。
 - **FR-002**：系统必须在托管设置下载请求中包含 SSO token 作为 Bearer 认证。
 - **FR-003**：系统必须缓存最后下载设置的校验和（ETag 或响应头），以避免后续启动时的冗余下载。
 - **FR-004**：系统必须将缓存的托管设置及其校验和存储在本地（在 `~/.wave/` 目录中）。

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -15,7 +15,7 @@
 |------|------|
 | 规格文件 | 59 |
 | 用户故事 | 266 |
-| 功能需求 | 1,064 |
+| 功能需求 | 1,063 |
 | 测试用例 | 4,337 |
 
 ## 规格列表
@@ -36,7 +36,7 @@
 | 记忆管理 | 通过记忆文件在对话间持久化信息 | 8 | 26 | [规格](core/memory-management.md) |
 | 流式输出 | 助手消息和工具参数的实时内容流式传输 | 6 | 26 | [规格](core/stream-content-updates.md) |
 | AI 错误处理 | 处理输出 token 限制超限，提示 agent 将工作拆分为更小的块 | 6 | 10 | [规格](core/ai-error-handling.md) |
-| 工具权限系统 | 权限系统，支持模式、通配符、拒绝规则、信任、acceptEdits、dontAsk、安全区 | 18 | 55 | [规格](core/tool-permission-system.md) |
+| 工具权限系统 | 权限系统，支持模式、通配符、拒绝规则、信任、acceptEdits、dontAsk、安全区 | 18 | 54 | [规格](core/tool-permission-system.md) |
 | Plan 模式 | Shift+Tab plan 模式，只读分析并增量编辑 plan 文件 | 9 | 29 | [规格](core/plan-mode.md) |
 
 ### 交互与 UI

--- a/docs/specs/multi-agent/plan-subagent.md
+++ b/docs/specs/multi-agent/plan-subagent.md
@@ -80,12 +80,12 @@ Plan 子 agent 识别并列出实现其提议计划最关键的 3-5 个文件，
 ### 功能需求
 
 - **FR-001**：系统必须提供内置的"Plan"子 agent，无需用户配置即可使用
-- **FR-002**：Plan 子 agent 必须限制为只读工具（Glob、Grep、Read 和只读 Bash 命令）
+- **FR-002**：Plan 子 agent 必须限制为只读工具（Glob、Grep、Read、LSP 和只读 Bash 命令）
 - **FR-003**：Plan 子 agent 不得有文件修改工具的访问权限（Write、Edit、NotebookEdit）
 - **FR-004**：Plan 子 agent 必须包含系统提示，明确说明只读限制和规划职责
 - **FR-005**：系统必须允许并行生成多个具有不同视角的 Plan 子 agent
 - **FR-006**：Plan 子 agent 必须生成包含"Critical Files for Implementation"部分的输出
-- **FR-007**：Plan 子 agent 必须按照 plan.tmp.js 中描述的方式与计划模式工作流集成
+- **FR-007**：Plan 子 agent 必须与计划模式工作流集成（见 FR-016 的计划模式提醒行为）
 - **FR-008**：当 Plan 子 agent 尝试禁止的操作时，系统必须提供清晰的错误消息
 - **FR-009**：Plan 子 agent 必须支持使用 Glob、Grep 和 Read 工具不受限制地探索代码库
 - **FR-010**：Plan 子 agent 必须能够执行只读 Bash 命令（ls、git status、git log、git diff、find、cat、head、tail）

--- a/docs/specs/multi-agent/workflow.md
+++ b/docs/specs/multi-agent/workflow.md
@@ -94,7 +94,6 @@
 - **运行中中止**：如果用户停止工作流，所有飞行中的 agent 被取消，运行状态设置为"aborted"。
 - **子 agent 中的 Workflow 工具**：Workflow 工具在子 agent 中被禁止（防止无限递归）。
 - **脚本持久化**：每次 Workflow 调用都将脚本持久化到会话目录，即使执行失败。
-- **嵌套工作流存根**：`workflow()` API 函数当前抛出"not yet implemented"——它是未来嵌套工作流支持的占位符。
 
 ## 需求 *（必填）*
 
@@ -103,7 +102,7 @@
 - **FR-001**：系统必须提供 `Workflow` 工具，AI 模型使用 JavaScript `script`、可选 `args`、可选 `scriptPath` 和可选 `resumeFromRunId` 调用。
 - **FR-002**：Workflow 工具必须仅在用户显式选择加入多 agent 编排时调用——通过直接请求、斜杠命令或命名工作流调用。
 - **FR-003**：每个工作流脚本必须以 `export const meta = {name, description, phases?}` 开头，后跟纯 JavaScript 主体。meta 必须是纯字面量。
-- **FR-004**：脚本必须在沙箱化的 async 上下文中通过 `new Function()` 执行，API 作为闭包变量注入：`agent()`、`parallel()`、`pipeline()`、`phase()`、`log()`、`args`、`budget`、`workflow()`。
+- **FR-004**：脚本必须在沙箱化的 async 上下文中通过 `new Function()` 执行，API 作为闭包变量注入：`agent()`、`parallel()`、`pipeline()`、`phase()`、`log()`、`args`、`budget`。
 - **FR-005**：运行时必须拒绝包含禁止模式的脚本：`require()`、`process.`、`eval()`、`import`、`Date.now()`、`Math.random()`、无参 `new Date()`、`fs.*`/`require('fs')`、`child_process`、`__dirname`、`__filename`、`global.`、`globalThis`。
 - **FR-006**：工作流必须在后台运行。Workflow 工具立即返回运行 ID 和脚本路径。
 - **FR-007**：并发 `agent()` 调用必须限制在 `min(16, cpu_cores - 2)`。每次运行的总 agent 数必须限制在 1000。单个 `parallel()`/`pipeline()` 调用必须最多接受 4096 项。

--- a/docs/specs/multi-agent/worktree.md
+++ b/docs/specs/multi-agent/worktree.md
@@ -153,7 +153,7 @@
 
 - **FR-001**：系统必须支持 `-w` 和 `--worktree [feat-name]` 命令行参数。
 - **FR-002**：如果未提供 `<feat-name>`，系统必须生成唯一的功能名称（例如 `adjective-adjective-noun`）。
-- **FR-003**：系统必须在 `.wave/worktrees/<feat-name>`（绝对路径）创建 git worktree，相对于**主仓库根目录**（即使从 worktree 内运行），从默认远程分支分支。默认分支必须使用文件系统读取（`.git/refs/remotes/origin/HEAD`）而非子进程调用来解析。如果 `origin/HEAD` 指向不再存在的分支（陈旧引用），系统必须回退到从 origin 获取 `refs/heads/HEAD` 并解析结果 SHA。
+- **FR-003**：系统必须在 `.wave/worktrees/<feat-name>`（绝对路径）创建 git worktree，相对于**主仓库根目录**（即使从 worktree 内运行），从默认远程分支分支。默认分支必须使用文件系统读取（`.git/refs/remotes/origin/HEAD`）而非子进程调用来解析。如果 `origin/HEAD` 指向不再存在的分支（陈旧引用），系统必须依次回退到 `refs/remotes/origin/main`、`refs/remotes/origin/master`，最终回退到硬编码的 `main`。
 - **FR-004**：系统必须将 worktree 分支命名为 `worktree-<feat-name>`。
 - **FR-005**：CLI 启动时若通过 `-w` 进入 worktree，允许在启动阶段调用一次 `process.chdir()` 到 worktree 路径（便于 tmux 和其他窗口复制功能）。但会话中途通过 `EnterWorktree`/`ExitWorktree` 切换工作目录时，系统不得调用 `process.chdir()`；工作目录的切换必须只作用于当前会话的 DI 容器（见 FR-041）。`AIManager.setWorkdir()` 不得改变进程级 `process.cwd()`。
 - **FR-006**：系统必须在退出时检测 worktree 中的未提交更改（已暂存或未暂存，通过 `git status --porcelain` 识别）。
@@ -190,7 +190,7 @@
 - **FR-037**：`ExitWorktree` 工具必须通过 `AIManager.setWorkdir()` 将会话的工作目录恢复到原始 CWD。
 - **FR-038**：当 `action` 为 `"remove"` 时，系统必须使用 `git worktree remove --force` 删除 worktree 目录，并使用 `git branch -D` 删除关联分支。
 - **FR-039**：`EnterWorktree` 工具不得触发 `WorktreeCreate` 钩子事件（钩子支持不在会话中工具的范围内）。
-- **FR-040**：系统必须验证从 `origin/HEAD` 解析的分支存在于 `refs/remotes/origin/` 中。如果分支不存在（陈旧的 `origin/HEAD`），系统必须尝试 `git fetch origin HEAD` 来解析正确的默认分支。
+- **FR-040**：系统必须验证从 `origin/HEAD` 解析的分支存在于 `refs/remotes/origin/` 中。如果分支不存在（陈旧的 `origin/HEAD`），系统必须依次回退到 `origin/main`、`origin/master`，最终回退到硬编码的 `main`，全部通过文件系统读取解析，不发起网络请求。
 
 #### 多会话隔离需求
 

--- a/docs/specs/ui/status-line.md
+++ b/docs/specs/ui/status-line.md
@@ -19,7 +19,7 @@
 1. **假设** CLI 正在运行，**当**用户处于正常模式时，**则**状态栏显示 "Mode: [current mode] (Shift+Tab to cycle)"。
 2. **假设** CLI 正在运行，**当**用户输入 `!` 时，**则**状态栏显示 "Shell: Run shell command"。
 3. **假设** CLI 正在运行，**当**用户使用 Shift+Tab 切换模式时，**则**状态栏中的 `permissionMode` 更新并相应改变颜色。
-4. **假设** CLI 正在运行，**当**用户处于 BTW 模式时，**则**状态栏显示 "Mode: BTW (ESC to dismiss)"。
+4. **假设** CLI 正在运行，**当**用户处于 BTW 模式时，**则**输入区域显示独立的 `BtwDisplay` 组件，状态栏不显示。
 
 ### 用户故事 2 - 上下文使用百分比（优先级：P1）
 
@@ -44,8 +44,8 @@
 ### 功能需求
 
 - **FR-001**：系统必须在 `packages/code/src/components/StatusLine.tsx` 中拥有专用的 `StatusLine` 组件。
-- **FR-002**：`StatusLine` 组件必须接受 `permissionMode`（字符串）、`isShellCommand`（布尔值）和 `isBtwActive`（布尔值）作为 props。
-- **FR-003**：`StatusLine` 组件必须在 `isBtwActive` 为 true 时优先显示 BTW 模式。
+- **FR-002**：`StatusLine` 组件必须接受 `permissionMode`（字符串）、`isShellCommand`（布尔值）、`isGoalActive`（可选布尔值）和 `goalElapsed`（可选字符串）作为 props。
+- **FR-003**：BTW 模式必须由独立的 `BtwDisplay` 组件渲染；BTW 激活时 `StatusLine` 随输入区域一起隐藏，`StatusLine` 自身不负责 BTW 显示。
 - **FR-004**：`InputBox.tsx` 必须使用 `StatusLine` 组件替代内联渲染逻辑。
 - **FR-005**：`StatusLine` 组件必须接受 `latestTotalTokens`（数字）和 `maxInputTokens`（数字）作为可选 props。
 - **FR-006**：`StatusLine` 组件必须在 `latestTotalTokens > 0` 时显示右对齐的 "X% context" 文本。


### PR DESCRIPTION
## Summary

Audited all 59 spec files against the actual code and corrected 13 outdated claims across 9 files.

| Spec file | Fix |
|---|---|
| `multi-agent/workflow.md` | Removed `workflow()` from injected APIs (FR-004) and edge cases — API was deleted from code |
| `multi-agent/plan-subagent.md` | FR-002: added LSP to tool list; FR-007: replaced non-existent `plan.tmp.js` reference |
| `multi-agent/worktree.md` | FR-003/FR-040: corrected default-branch fallback to `origin/main` → `origin/master` → `main` (no `git fetch`) |
| `core/agent-config.md` | FR-011/FR-013: default maxTokens 4096 → 32000 |
| `core/tool-permission-system.md` | FR-006: corrected Shift+Tab cycle order (`default → acceptEdits → bypassPermissions → plan`); FR-049: struck through (prompt injection never implemented) |
| `ui/status-line.md` | FR-002: actual props (`isGoalActive`/`goalElapsed`, no `isBtwActive`); FR-003: BTW renders via separate `BtwDisplay`, StatusLine hidden |
| `automation/hooks.md` | FR-015: transcript_path format `.jsonl` in `~/.wave/projects/[slug]/`; exit-2 table: PreCompact stderr silently dropped |
| `ecosystem/init-slash-command.md` | All 5 `init-prompt.md` references → builtin `init/SKILL.md` |
| `enterprise/server-managed-config.md` | FR-001: endpoint `/api/v1/managed-settings` → `/api/wave/settings` |

Each fix was verified against the actual code before editing. The remaining 50 specs were audited and confirmed current. `docs/specs/index.md` stats regenerated via `node scripts/spec-count.js` (FR count 1,064 → 1,063 due to the struck-through FR-049).