### PR TITLE
ci: exclude webview e2e demo screenshots from CI test trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
               - '!**/*.txt'
               - '!docs/**'
               - '!scripts/**'
+              - '!packages/webview/e2e/**'
               - '!LICENSE'
 
       - name: Setup pnpm


### PR DESCRIPTION
## Summary

Adds `!packages/webview/e2e/**` to the paths-filter in `ci.yml` so screenshot-demo-only changes no longer trigger the full build + test suite.

- The entire `packages/webview/e2e/` directory serves only the Playwright `demo` project that generates docs screenshots — it is documentation infrastructure, not product code
- Safety net remains: `pages.yml` on main push already triggers on this path and runs `docs:build` → `test:demo` (type-checks e2e via `pretest:demo` and executes all demos), so broken demos are still caught before docs deploy
- PRs touching both demo files and real code still run full CI (paths-filter evaluates per file)