### PR TITLE
ci: rename Docs Checks job from checks to docs-checks

### DIFF
--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -17,7 +17,7 @@ on:
       - 'scripts/check-sidebar-anchors.mjs'
 
 jobs:
-  checks:
+  docs-checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Renames the `checks` job in `docs-checks.yml` to `docs-checks`, so it no longer collides visually with the main CI job `check (22)` in PR check lists.

- Before: `checks` (Docs Checks) vs `check (22)` (CI matrix) — confusingly similar names
- After: `docs-checks` vs `check (22)` — clearly distinguishable

Branch protection verified: required checks on `main` only include `check (22)`, so no protection settings need updating.