### PR TITLE
webview/IDE UI cleanups: drop confirm tool-name row + single compact notification

### DIFF
--- a/docs/specs/core/message-compact.md
+++ b/docs/specs/core/message-compact.md
@@ -108,18 +108,18 @@
 
 ### 用户故事 7 - IDE 插件手动压缩与原生通知（优先级：P2）
 
-作为 IDE 插件（VS Code 扩展与 JetBrains 插件）用户，我希望能在 IDE 中手动触发对话压缩（`/compact`），并在压缩过程中收到原生通知，以便我主动管理上下文并实时知晓压缩状态。
+作为 IDE 插件（VS Code 扩展与 JetBrains 插件）用户，我希望能在 IDE 中手动触发对话压缩（`/compact`），并在压缩过程中收到单个原生通知，压缩完成后该通知自动关闭，以便我主动管理上下文并实时知晓压缩状态，且不被堆叠的通知打扰。
 
-**为什么是这个优先级**：IDE 插件以 stdio 子进程方式运行 Agent，无法直接调用 CLI 内部命令；若不做协议适配，`/compact` 会被当作普通消息发送给模型而失效。同时压缩可能耗时数秒，原生通知让用户明确知道压缩正在进行，避免误以为无响应。VS Code 扩展与 JetBrains 插件共享同一 webview 包与 stdio 协议，二者行为必须一致。
+**为什么是这个优先级**：IDE 插件以 stdio 子进程方式运行 Agent，无法直接调用 CLI 内部命令；若不做协议适配，`/compact` 会被当作普通消息发送给模型而失效。压缩可能耗时数秒，单个原生通知让用户明确知道压缩正在进行，完成后自动关闭，避免压缩开始与完成两个通知堆叠。VS Code 扩展与 JetBrains 插件共享同一 webview 包与 stdio 协议，二者行为必须一致。
 
-**独立测试**：在 VS Code 扩展与 JetBrains 插件中分别输入 `/compact`，验证通过 stdio `compact` 请求触发压缩而非发送普通消息；模拟 `compactionStateChange` 通知，验证两端均显示原生通知。
+**独立测试**：在 VS Code 扩展与 JetBrains 插件中分别输入 `/compact`，验证通过 stdio `compact` 请求触发压缩而非发送普通消息；模拟 `compactionStateChange` 通知，验证开始时显示单个进行中通知，完成时关闭该通知而不弹出完成通知。
 
 **验收场景**：
 
 1. **假设**对话中有消息，**当**用户在 IDE 插件中输入 `/compact` 时，**则**插件必须通过 stdio `compact` 请求触发压缩，而非将文本作为普通消息发送给模型
 2. **假设**用户输入 `/compact focus on the API design`，**当**请求发出时，**则**自定义指令必须作为 `customInstructions` 传递给 `compact` 请求并影响摘要
-3. **假设**压缩开始（手动或自动触发），**当**子进程发送 `compactionStateChange`（`isCompacting=true`）时，**则**IDE 插件必须显示原生通知提示压缩进行中
-4. **假设**压缩完成，**当**子进程发送 `compactionStateChange`（`isCompacting=false`）时，**则**IDE 插件必须显示原生通知提示压缩完成
+3. **假设**压缩开始（手动或自动触发），**当**子进程发送 `compactionStateChange`（`isCompacting=true`）时，**则**IDE 插件必须显示单个原生通知提示压缩进行中
+4. **假设**压缩完成，**当**子进程发送 `compactionStateChange`（`isCompacting=false`）时，**则**IDE 插件必须关闭该进行中通知，而非弹出新的完成通知
 5. **假设**压缩已在进行中，**当**用户再次输入 `/compact` 时，**则**第二次压缩必须被跳过（复用 FR-016 熔断器）
 
 ---
@@ -162,8 +162,8 @@
 - **FR-025**：当用户在 IDE 插件（VS Code 扩展或 JetBrains 插件）中输入 `/compact [instructions]` 时，插件必须将其识别为本地命令并通过 `compact` 请求触发压缩，而非通过 `sendMessage` 将文本作为普通消息发送
 - **FR-026**：stdio 协议必须支持 `compactionStateChange` 通知，携带 `isCompacting` 布尔参数，在压缩状态变化时由子进程发送给客户端
 - **FR-027**：AgentBridge 必须将 `AgentCallbacks.onCompactionStateChange` 回调转发为 `compactionStateChange` 通知
-- **FR-028**：IDE 插件必须在收到 `compactionStateChange` 通知（`isCompacting=true`）时显示原生通知提示压缩进行中（VS Code 扩展使用 `vscode.window` 通知 API，JetBrains 插件使用 `NotificationGroupManager`）
-- **FR-029**：IDE 插件必须在压缩完成（`isCompacting=false`）时显示原生通知提示压缩完成
+- **FR-028**：IDE 插件必须在收到 `compactionStateChange` 通知（`isCompacting=true`）时显示单个原生通知提示压缩进行中（VS Code 扩展使用 `vscode.window` 进度通知 API，JetBrains 插件使用 `NotificationGroupManager`），并在压缩期间保持显示
+- **FR-029**：IDE 插件必须在压缩完成（`isCompacting=false`）时关闭该进行中通知，而非弹出新的完成通知
 
 ### 关键实体 *（如果功能涉及数据则包含）*
 

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/CompactionNotifier.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/CompactionNotifier.kt
@@ -1,0 +1,45 @@
+package com.wave.jetbrains.session
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.project.Project
+
+/**
+ * Shows a single native notification while conversation compaction is in
+ * progress and expires (closes) it when compaction completes — instead of
+ * stacking separate "starting" and "complete" balloons.
+ *
+ * Mirrors packages/vsce/src/session/compactionNotifier.ts.
+ *
+ * [createAndShow] / [dismiss] are swappable seams so the lifecycle can be unit
+ * tested without the IntelliJ Platform (cf. UpdateChecker.httpGet).
+ */
+class CompactionNotifier<T : Any>(
+    private val createAndShow: (String) -> T,
+    private val dismiss: (T) -> Unit,
+) {
+    private var handle: T? = null
+
+    fun onCompactionStateChange(isCompacting: Boolean) {
+        if (isCompacting) {
+            handle = createAndShow("正在压缩对话…")
+        } else {
+            handle?.let(dismiss)
+            handle = null
+        }
+    }
+
+    companion object {
+        fun forProject(project: Project): CompactionNotifier<Notification> =
+            CompactionNotifier(
+                createAndShow = { message ->
+                    NotificationGroupManager.getInstance()
+                        .getNotificationGroup("Wave")
+                        .createNotification("Wave", message, NotificationType.INFORMATION)
+                        .also { it.notify(project) }
+                },
+                dismiss = { it.expire() },
+            )
+    }
+}

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
@@ -1,8 +1,6 @@
 package com.wave.jetbrains.session
 
 import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.notification.NotificationGroupManager
-import com.intellij.notification.NotificationType
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
@@ -171,16 +169,13 @@ class WaveSession(
         scope.launch { immediateMessagesUpdate() }
     }
 
-    // VSCE chatSession.ts:97-103: mirror vscode.window.showInformationMessage via the IDE's
-    // balloon notification group. Fires on the stdio reader thread → hop to the EDT.
+    // VSCE chatSession.ts: CompactionNotifier shows a single native notification
+    // while compaction runs and expires it on completion. Fires on the stdio
+    // reader thread → hop to the EDT.
+    private val compactionNotifier = CompactionNotifier.forProject(project)
+
     override fun onCompactionStateChange(isCompacting: Boolean) {
-        val message = if (isCompacting) "正在压缩对话…" else "对话压缩完成"
-        Edt.invokeLater {
-            NotificationGroupManager.getInstance()
-                .getNotificationGroup("Wave")
-                .createNotification("Wave", message, NotificationType.INFORMATION)
-                .notify(project)
-        }
+        Edt.invokeLater { compactionNotifier.onCompactionStateChange(isCompacting) }
     }
 
     override fun onUserMessageAdded(message: JsonElement?) {

--- a/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/session/CompactionNotifierTest.kt
+++ b/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/session/CompactionNotifierTest.kt
@@ -1,0 +1,58 @@
+package com.wave.jetbrains.session
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the pure lifecycle logic in [CompactionNotifier], using fakes
+ * for the create/dismiss seams so the IntelliJ Platform is not required.
+ * Mirrors packages/vsce/tests/session/compactionNotifier.test.ts.
+ */
+class CompactionNotifierTest {
+
+    private class Fake {
+        val shown = mutableListOf<String>()
+        val dismissed = mutableListOf<Int>()
+        private var counter = 0
+        val createAndShow: (String) -> Int = { message -> shown.add(message); counter++ }
+        val dismiss: (Int) -> Unit = { dismissed.add(it) }
+    }
+
+    @Test
+    fun `shows a single notification on start and dismisses it on complete without a second notification`() {
+        val fake = Fake()
+        val notifier = CompactionNotifier(fake.createAndShow, fake.dismiss)
+
+        notifier.onCompactionStateChange(true)
+        assertEquals(listOf("正在压缩对话…"), fake.shown)
+
+        notifier.onCompactionStateChange(false)
+        assertEquals(listOf(0), fake.dismissed)
+        // No second notification shown on complete
+        assertEquals(1, fake.shown.size)
+    }
+
+    @Test
+    fun `complete without a prior start is a no-op`() {
+        val fake = Fake()
+        val notifier = CompactionNotifier(fake.createAndShow, fake.dismiss)
+
+        notifier.onCompactionStateChange(false)
+        assertTrue(fake.shown.isEmpty())
+        assertTrue(fake.dismissed.isEmpty())
+    }
+
+    @Test
+    fun `a new start after complete shows a fresh notification`() {
+        val fake = Fake()
+        val notifier = CompactionNotifier(fake.createAndShow, fake.dismiss)
+
+        notifier.onCompactionStateChange(true)   // handle 0
+        notifier.onCompactionStateChange(false)  // dismiss 0
+        notifier.onCompactionStateChange(true)   // handle 1
+
+        assertEquals(listOf("正在压缩对话…", "正在压缩对话…"), fake.shown)
+        assertEquals(listOf(0), fake.dismissed) // handle 1 still shown
+    }
+}

--- a/packages/vsce/src/session/chatSession.ts
+++ b/packages/vsce/src/session/chatSession.ts
@@ -4,6 +4,7 @@ import { ConfigurationData } from '../services/configurationService';
 import { StdioClient } from '../stdio/stdioClient';
 import { StdioAgent, type StdioAgentCallbacks } from '../stdio/stdioAgent';
 import { NotificationRouter } from '../stdio/notificationRouter';
+import { CompactionNotifier } from './compactionNotifier';
 
 export interface ChatSessionCallbacks {
     onMessagesChange: (messages: Message[]) => void;
@@ -55,6 +56,7 @@ export class ChatSession {
     private updateTimer: NodeJS.Timeout | undefined;
     private pendingUpdate: boolean = false;
     private forceNextUpdateImmediate: boolean = false;
+    private compactionNotifier = new CompactionNotifier();
 
     // Throttled incremental update fields
     private streamingContentUpdateTimer: NodeJS.Timeout | undefined;
@@ -99,11 +101,7 @@ export class ChatSession {
                     this.throttledUpdateChatMessages(this.messages);
                 },
                 onCompactionStateChange: (isCompacting: boolean) => {
-                    if (isCompacting) {
-                        vscode.window.showInformationMessage('正在压缩对话…');
-                    } else {
-                        vscode.window.showInformationMessage('对话压缩完成');
-                    }
+                    this.compactionNotifier.notify(isCompacting);
                 },
                 onUserMessageAdded: (message: Message) => {
                     this.callbacks.onAssistantMessageAdded?.(message);

--- a/packages/vsce/src/session/compactionNotifier.ts
+++ b/packages/vsce/src/session/compactionNotifier.ts
@@ -1,0 +1,31 @@
+import * as vscode from 'vscode';
+
+/**
+ * Shows a single progress notification while conversation compaction is in
+ * progress and dismisses it when compaction completes — instead of stacking
+ * separate "starting" and "complete" notifications.
+ *
+ * Mirrors packages/jetbrains/.../session/CompactionNotifier.kt.
+ */
+export class CompactionNotifier {
+    private resolve?: () => void;
+
+    notify(isCompacting: boolean): void {
+        if (isCompacting) {
+            vscode.window.withProgress(
+                {
+                    location: vscode.ProgressLocation.Notification,
+                    title: '正在压缩对话…',
+                    cancellable: false,
+                },
+                () =>
+                    new Promise<void>((resolve) => {
+                        this.resolve = resolve;
+                    }),
+            );
+        } else {
+            this.resolve?.();
+            this.resolve = undefined;
+        }
+    }
+}

--- a/packages/vsce/tests/session/compactionNotifier.test.ts
+++ b/packages/vsce/tests/session/compactionNotifier.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect, vi } from 'vitest';
+
+const { withProgress } = vi.hoisted(() => ({ withProgress: vi.fn() }));
+
+vi.mock('vscode', () => ({
+    window: { withProgress },
+    ProgressLocation: { Notification: 15 },
+}));
+
+import { CompactionNotifier } from '../../src/session/compactionNotifier';
+
+describe('CompactionNotifier', () => {
+    test('shows a single notification on start and dismisses it on complete without a second notification', async () => {
+        withProgress.mockClear();
+        // Mock calls the task so its promise executor runs and captures resolve.
+        let taskPromise: Promise<void> | undefined;
+        withProgress.mockImplementation((_opts, task) => {
+            taskPromise = task(
+                { report: vi.fn() },
+                { onCancellationRequested: vi.fn() } as unknown as Parameters<
+                    Parameters<typeof withProgress>[1]
+                >[1],
+            );
+            return taskPromise;
+        });
+
+        const notifier = new CompactionNotifier();
+
+        // Start compaction → one notification shown
+        notifier.notify(true);
+        expect(withProgress).toHaveBeenCalledTimes(1);
+        expect(withProgress.mock.calls[0][0].title).toBe('正在压缩对话…');
+
+        const onResolve = vi.fn();
+        taskPromise!.then(onResolve);
+
+        // Complete compaction → no NEW notification, the in-flight one dismissed
+        notifier.notify(false);
+        expect(withProgress).toHaveBeenCalledTimes(1);
+        await vi.waitFor(() => expect(onResolve).toHaveBeenCalled());
+    });
+
+    test('complete without a prior start is a no-op', () => {
+        withProgress.mockClear();
+        const notifier = new CompactionNotifier();
+        notifier.notify(false);
+        expect(withProgress).not.toHaveBeenCalled();
+    });
+
+    test('a new start after complete shows a fresh notification', async () => {
+        withProgress.mockClear();
+        let taskPromise: Promise<void> | undefined;
+        withProgress.mockImplementation((_opts, task) => {
+            taskPromise = task(
+                { report: vi.fn() },
+                { onCancellationRequested: vi.fn() } as unknown as Parameters<
+                    Parameters<typeof withProgress>[1]
+                >[1],
+            );
+            return taskPromise;
+        });
+
+        const notifier = new CompactionNotifier();
+        notifier.notify(true);
+        expect(withProgress).toHaveBeenCalledTimes(1);
+
+        const firstResolved = vi.fn();
+        taskPromise!.then(firstResolved);
+        notifier.notify(false);
+        await vi.waitFor(() => expect(firstResolved).toHaveBeenCalled());
+
+        // A fresh start shows a new notification
+        notifier.notify(true);
+        expect(withProgress).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/webview/src/components/ConfirmationDialog.tsx
+++ b/packages/webview/src/components/ConfirmationDialog.tsx
@@ -530,9 +530,6 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
               <pre>{JSON.stringify(confirmation.toolInput, null, 2)}</pre>
             </div>
           )}
-          <div className="confirmation-details">
-            <strong>工具:</strong> {confirmation.toolName}
-          </div>
           {[WRITE_TOOL_NAME, EDIT_TOOL_NAME].includes(confirmation.toolName) && !!confirmation.toolInput?.file_path && (
             <div className="confirmation-file-path">
               <strong>文件:</strong> {String(confirmation.toolInput.file_path)}

--- a/packages/webview/src/styles/ConfirmationDialog.css
+++ b/packages/webview/src/styles/ConfirmationDialog.css
@@ -95,8 +95,7 @@
   margin: 0;
 }
 
-/* Meta rows: 工具 / 文件 */
-.confirmation-details,
+/* Meta rows: 文件 */
 .confirmation-file-path {
   display: flex;
   gap: 8px;
@@ -105,17 +104,11 @@
   line-height: 16px;
 }
 
-.confirmation-details strong,
 .confirmation-file-path strong {
   flex-shrink: 0;
   width: 40px;
   font-weight: 400;
   color: var(--vscode-descriptionForeground);
-}
-
-.confirmation-details {
-  color: var(--vscode-foreground);
-  font-weight: 500;
 }
 
 .confirmation-file-path {

--- a/packages/webview/tests/webview/confirmationDialog.test.tsx
+++ b/packages/webview/tests/webview/confirmationDialog.test.tsx
@@ -61,8 +61,6 @@ describe('Confirmation Dialog', () => {
         // Verify dialog content
         const title = document.querySelector('.confirmation-title');
         expect(title).toHaveTextContent('代码修改待确认');
-        const details = document.querySelector('.confirmation-details');
-        expect(details).toHaveTextContent(`工具: ${EDIT_TOOL_NAME}`);
 
         // Verify buttons are present
         const applyBtn = document.querySelector('.confirmation-btn-apply');
@@ -93,8 +91,6 @@ describe('Confirmation Dialog', () => {
         // Verify confirmation dialog content for bash command
         const title = document.querySelector('.confirmation-title');
         expect(title).toHaveTextContent('命令执行待确认');
-        const details = document.querySelector('.confirmation-details');
-        expect(details).toHaveTextContent(`工具: ${BASH_TOOL_NAME}`);
     });
 
     it('should send approval response when clicking apply button', async () => {
@@ -215,7 +211,7 @@ describe('Confirmation Dialog', () => {
 
         // Verify first confirmation is visible
         expect(document.querySelector('.confirmation-dialog')).toBeInTheDocument();
-        expect(document.querySelector('.confirmation-details')).toHaveTextContent(`工具: ${EDIT_TOOL_NAME}`);
+        expect(document.querySelector('.confirmation-title')).toHaveTextContent('代码修改待确认');
 
         // Approve first confirmation
         await act(async () => {
@@ -237,7 +233,7 @@ describe('Confirmation Dialog', () => {
 
         // Verify second confirmation is visible with correct content
         expect(document.querySelector('.confirmation-dialog')).toBeInTheDocument();
-        expect(document.querySelector('.confirmation-details')).toHaveTextContent('工具: SomeOtherTool');
+        expect(document.querySelector('.confirmation-title')).toHaveTextContent('操作待确认');
 
         // Reject second confirmation via Esc key
         await act(async () => {
@@ -279,7 +275,7 @@ describe('Confirmation Dialog', () => {
 
         // Verify first confirmation is visible
         expect(document.querySelector('.confirmation-dialog')).toBeInTheDocument();
-        expect(document.querySelector('.confirmation-details')).toHaveTextContent(`工具: ${EDIT_TOOL_NAME}`);
+        expect(document.querySelector('.confirmation-title')).toHaveTextContent('代码修改待确认');
 
         // Send second confirmation request while first is still showing
         await act(async () => {
@@ -292,7 +288,7 @@ describe('Confirmation Dialog', () => {
         });
 
         // Still should show first confirmation
-        expect(document.querySelector('.confirmation-details')).toHaveTextContent(`工具: ${EDIT_TOOL_NAME}`);
+        expect(document.querySelector('.confirmation-title')).toHaveTextContent('代码修改待确认');
 
         // Approve first confirmation
         await act(async () => {
@@ -301,7 +297,7 @@ describe('Confirmation Dialog', () => {
 
         // Verify second confirmation is now visible
         expect(document.querySelector('.confirmation-dialog')).toBeInTheDocument();
-        expect(document.querySelector('.confirmation-details')).toHaveTextContent(`工具: ${BASH_TOOL_NAME}`);
+        expect(document.querySelector('.confirmation-title')).toHaveTextContent('命令执行待确认');
 
         // Approve second confirmation
         await act(async () => {
@@ -358,7 +354,6 @@ describe('Confirmation Dialog', () => {
 
             // Verify correct confirmation type
             expect(document.querySelector('.confirmation-title')).toHaveTextContent(expectedType);
-            expect(document.querySelector('.confirmation-details')).toHaveTextContent('工具: ');
 
             // Dismiss the dialog
             await act(async () => {


### PR DESCRIPTION
Two independent UI changes:

- **webview**: Remove the redundant "工具: {toolName}" row from the confirm dialog — the title (e.g. 代码修改待确认 / 命令执行待确认) already describes the action. Cleaned up the `.confirmation-details` CSS and updated the confirmation dialog tests.
- **compact**: VSCE/JB previously stacked two native notifications (开始 + 完成). Now a single in-progress notification is shown on compaction start and closed on completion. Extracts `CompactionNotifier` in both packages so the lifecycle is unit-testable without the IDE platform. Spec `FR-028`/`FR-029` updated to the single-dismissable behavior.