### PR TITLE
fix(subagent): isolate MessageQueue per subagent container to prevent notification theft

### DIFF
--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -15,7 +15,7 @@
 |------|------|
 | 规格文件 | 60 |
 | 用户故事 | 281 |
-| 功能需求 | 1,159 |
+| 功能需求 | 1,163 |
 | 测试用例 | 4,348 |
 
 ## 规格列表
@@ -76,7 +76,7 @@
 | 通用代理 | 内置子代理，用于复杂研究、代码搜索和多步骤任务 | 2 | 7 | [规格](multi-agent/general-purpose-agent.md) |
 | Plan 子代理 | 内置 Plan 子代理，在编码前设计实现方案 | 4 | 16 | [规格](multi-agent/plan-subagent.md) |
 | Bash 子代理 | 内置 Bash 子代理，执行 shell 命令 | 1 | 7 | [规格](multi-agent/bash-subagent.md) |
-| 任务后台执行 | `run_in_background`、`TaskOutput`/`TaskStop` 工具，`/tasks` 命令替代 `/bashes` | 7 | 38 | [规格](multi-agent/task-background-execution.md) |
+| 任务后台执行 | `run_in_background`、`TaskOutput`/`TaskStop` 工具，`/tasks` 命令替代 `/bashes` | 7 | 42 | [规格](multi-agent/task-background-execution.md) |
 | 任务管理工具 | TaskCreate/TaskGet/TaskUpdate/TaskList，`~/.wave/tasks/` 存储和任务列表 UI | 6 | 32 | [规格](multi-agent/task-management-tools.md) |
 | Workflow 编排 | 确定性多子代理编排，支持 pipeline、parallel 和 phase 控制流 | 5 | 29 | [规格](multi-agent/workflow.md) |
 | CLI Worktree | `-w/--worktree` 隔离的 git worktree，位于 `.wave/worktrees/`，支持安全退出 | 8 | 44 | [规格](multi-agent/worktree.md) |

--- a/docs/specs/multi-agent/task-background-execution.md
+++ b/docs/specs/multi-agent/task-background-execution.md
@@ -96,6 +96,9 @@
 4. **假设**多个后台任务在 agent 空闲时完成，**则**所有通知应出现在聊天中。
 5. **假设**后台任务在 agent 活跃响应时完成，**则**通知应被排队并在当前响应完成后显示。
 6. **假设**队列中已有待处理用户消息，**当**后台任务通知同时入队时，**则**系统必须串行处理二者，不会并发触发两个 AI turn，不会出现两个并行的响应 stream。
+7. **假设**主 Agent 并发启动 N（N≥3）个后台 subagent 并等待全部完成通知，**当**所有 subagent 完成时，**则**主 Agent 必须收到恰好 N 条完成通知（每个 taskId 恰好一次），且任何通知不得出现在兄弟 subagent 的会话 transcript 中、不得因此重新唤起兄弟 subagent 额外执行一轮。
+8. **假设**并发后台 subagent 完成通知入队期间，**当**某个兄弟 subagent 的 AIManager 回合结束时，**则**该 subagent 不得从主 Agent 的 MessageQueue 排空（`drainNotifications`）任何通知；subagent 的通知排空只能作用于其自身容器的独立队列。
+9. **假设**主 Agent 在 print 模式（`wave -p`）下等待后台 subagent 完成，**当**最后一个 subagent 完成且其通知已被主 Agent 消费、生成最终响应后，**则**print 模式才允许退出（exit 0）；不得因通知被错误消费者取走导致 `hasPendingMessages`/`hasRunningBackgroundWork`/`isLoading` 提前为假而提前退出。
 
 ---
 
@@ -128,6 +131,7 @@
 - **直接用户 bash 命令（`!command`）**：用户使用 `!` 前缀直接启动的命令不得受 Ctrl-B 影响。
 - **超时自动后台化**：当前台 Bash 命令超时时，进程被自动后台化而不是被终止（除非命令以 `sleep` 开头）。这保留了只需要更多时间的长时间运行工作。
 - **后台任务无超时**：显式后台化的任务（`run_in_background: true`）忽略默认和显式超时，运行直到完成或手动停止。
+- **并发后台 subagent 通知错误路由**：当多个后台 subagent 并发完成时，若 subagent 容器未持有独立 MessageQueue，其 AIManager 回合末会经由 `Container.get()` 的 parent 回退抽干主 Agent 队列，将兄弟任务完成通知注入自身会话并重新唤起自身回合（`shouldRestart`），同时主 Agent 因收不到该通知而提前退出。修复要求每个 subagent 容器注册独立 MessageQueue，且完成通知仅投递并消费于主 Agent 队列。
 
 ## 需求 *（必填）*
 
@@ -171,6 +175,10 @@
 - **FR-039**：webview 详情视图必须通过 `getBackgroundTaskOutput` 请求按需获取输出，不在列表通知中携带全文 stdout/stderr。
 - **FR-040**：webview 必须提供停止按钮，通过 `stopBackgroundTask` 请求终止选中的运行中任务。
 - **FR-041**：前台工具后台化（CLI 的 Ctrl-B）不在本迭代范围；IDE 插件仅支持查看与终止已有后台任务。
+- **FR-042**：每个 Agent 与 subagent 的 DI 容器必须注册独立、会话级的 `MessageQueue` 实例。`SubagentManager.createInstance()` 创建子容器时必须为该 subagent 注册独立的 `MessageQueue`，子容器不得通过 `Container.get()`/`has()` 的 parent 回退继承主 Agent 的 `MessageQueue`。
+- **FR-043**：subagent 的 AIManager 回合末通知排空（`drainNotifications`）必须仅作用于其自身容器的 `MessageQueue`；不得抽干主 Agent 的 `MessageQueue`，不得将兄弟 subagent 的完成通知注入自身会话、不得因此重新唤起自身回合（`shouldRestart`）。
+- **FR-044**：后台 subagent 完成通知必须投递到创建它的主 Agent 的 `MessageQueue`（由 `SubagentManager` 使用主容器入队），并仅由主 Agent 的 AIManager 回合末排空消费；兄弟 subagent 不得消费该通知。
+- **FR-045**：必须提供并发集成测试：并行启动至少 5 个后台 subagent，断言每个 `taskId` 恰好一次出现在主 Agent transcript、且不出现在任何兄弟 subagent transcript；并断言 print 模式（`wave -p`）在收齐全部通知并生成最终响应后才退出（exit 0）。
 
 ### 关键实体 *（如果功能涉及数据则包含）*
 

--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -290,6 +290,12 @@ export class SubagentManager {
     // Create a child container for the subagent to isolate its managers
     const subagentContainer = this.container.createChild();
 
+    // Register an independent MessageQueue so the subagent's AIManager drains its
+    // own (empty) queue instead of falling back to the parent container's queue.
+    // Without this, concurrent background subagents steal sibling completion
+    // notifications from the parent queue, causing the main agent to exit early.
+    subagentContainer.register("MessageQueue", new MessageQueue());
+
     // Register a modified AgentOptions without onLoadingChange to prevent subagent loading
     // from affecting the parent agent's loading state
     const parentOptions =

--- a/packages/agent-sdk/tests/managers/aiManager.notificationDrainIsolation.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.notificationDrainIsolation.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Container } from "../../src/utils/container.js";
+import { AIManager } from "../../src/managers/aiManager.js";
+import { MessageQueue } from "../../src/managers/messageQueue.js";
+import type { MessageManager } from "../../src/managers/messageManager.js";
+import type { ToolManager } from "../../src/managers/toolManager.js";
+import type { TaskManager } from "../../src/services/taskManager.js";
+import type { GatewayConfig, ModelConfig } from "../../src/types/index.js";
+
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("node:fs", () => ({ existsSync: vi.fn() }));
+vi.mock("../../src/utils/gitUtils.js", () => ({ isGitRepository: vi.fn() }));
+
+// callAgent returns a no-tool response so sendAIMessage completes exactly one
+// turn and reaches the end-of-turn notification-drain block.
+vi.mock("../../src/services/aiService.js", () => ({
+  callAgent: vi.fn().mockImplementation(async (options) => {
+    if (options.onContentUpdate) options.onContentUpdate("Test response");
+    return {
+      content: "Test response",
+      usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+      tool_calls: [],
+    };
+  }),
+  compactMessages: vi.fn().mockResolvedValue({
+    content: "Compacted content",
+    usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+  }),
+  transformMessagesForExplicitCache: vi.fn((m) => m),
+  extendUsageWithCacheMetrics: vi.fn((u) => u),
+}));
+
+vi.mock("../../src/services/memory.js", () => ({
+  MemoryService: vi.fn().mockImplementation(() => ({
+    getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+    getAutoMemoryDirectory: vi.fn().mockReturnValue("/mock/auto-memory"),
+    ensureAutoMemoryDirectory: vi.fn().mockResolvedValue(undefined),
+    getAutoMemoryContent: vi.fn().mockResolvedValue(""),
+  })),
+  getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+}));
+
+vi.mock("../../src/utils/messageOperations.js", () => ({}));
+vi.mock("../../src/utils/convertMessagesForAPI.js", () => ({
+  convertMessagesForAPI: vi.fn().mockReturnValue([]),
+}));
+
+const mockGatewayConfig: GatewayConfig = {
+  apiKey: "test-api-key",
+  baseURL: "https://test-gateway.com",
+};
+
+const mockModelConfig: ModelConfig = {
+  model: "test-agent-model",
+  fastModel: "test-fast-model",
+};
+
+function buildMockMessageManager(): MessageManager {
+  return {
+    getSessionId: vi.fn().mockReturnValue("test-session-id"),
+    getMessages: vi.fn().mockReturnValue([]),
+    addAssistantMessage: vi.fn(),
+    addUserMessage: vi.fn().mockImplementation(function (this: MessageManager) {
+      // no-op
+      return "msg-id";
+    }),
+    updateCurrentMessageContent: vi.fn(),
+    updateToolBlock: vi.fn(),
+    mergeAssistantAdditionalFields: vi.fn(),
+    setMessages: vi.fn(),
+    getLatestTotalTokens: vi.fn().mockReturnValue(0),
+    getCombinedMemory: vi.fn().mockResolvedValue(""),
+    getMemoryForInjection: vi.fn().mockResolvedValue({ prependContent: "" }),
+    processTriggeredRules: vi.fn().mockReturnValue([]),
+    addErrorBlock: vi.fn(),
+    setlatestTotalTokens: vi.fn(),
+    saveSession: vi.fn().mockResolvedValue(undefined),
+    compactMessagesAndUpdateSession: vi.fn(),
+    getTranscriptPath: vi.fn().mockReturnValue("/test/transcript.md"),
+    triggerFileRead: vi.fn(),
+    finalizeStreamingBlocks: vi.fn(),
+    finalizeAbortedToolBlocks: vi.fn(),
+  } as unknown as MessageManager;
+}
+
+function buildMockToolManager(): ToolManager {
+  return {
+    getToolsConfig: vi.fn().mockReturnValue([]),
+    getTools: vi.fn().mockReturnValue([]),
+    list: vi.fn().mockReturnValue([]),
+    execute: vi
+      .fn()
+      .mockResolvedValue({ success: true, content: "test result" }),
+    isConcurrencySafe: vi.fn().mockReturnValue(true),
+  } as unknown as ToolManager;
+}
+
+/**
+ * Build a real AIManager whose `this.container` is a CHILD of a parent container
+ * that owns `parentQueue` (pre-loaded with a sibling notification). When
+ * `withLocalQueue` is true a local (empty) MessageQueue is registered on the
+ * child — mirroring the post-fix createInstance() wiring, so the child resolves
+ * its own queue and never touches the parent's. When false, the child has no
+ * local queue, so `get("MessageQueue")` falls back to the parent — mirroring the
+ * pre-fix behaviour where sibling notifications were stolen.
+ */
+function buildChildAIManager({ withLocalQueue }: { withLocalQueue: boolean }) {
+  const parentQueue = new MessageQueue();
+  parentQueue.enqueueNotification(
+    "<task-notification><task-id>sibling-A</task-id></task-notification>",
+  );
+  const drainSpy = vi.spyOn(parentQueue, "drainNotifications");
+
+  const parentContainer = new Container();
+  parentContainer.register("MessageQueue", parentQueue);
+
+  const child = parentContainer.createChild();
+  child.register("ConfigurationService", {
+    resolveGatewayConfig: vi.fn().mockReturnValue(mockGatewayConfig),
+    resolveModelConfig: vi.fn().mockReturnValue(mockModelConfig),
+    resolveMaxInputTokens: vi.fn().mockReturnValue(96000),
+    resolveAutoMemoryEnabled: vi.fn().mockReturnValue(true),
+    resolveLanguage: vi.fn().mockReturnValue(undefined),
+  });
+  child.register("MessageManager", buildMockMessageManager());
+  child.register("ToolManager", buildMockToolManager());
+  child.register("TaskManager", {
+    on: vi.fn(),
+    listTasks: vi.fn().mockResolvedValue([]),
+  } as unknown as TaskManager);
+  child.register("MemoryService", {
+    getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+    getAutoMemoryDirectory: vi.fn().mockReturnValue("/mock/auto-memory"),
+    ensureAutoMemoryDirectory: vi.fn().mockResolvedValue(undefined),
+    getAutoMemoryContent: vi.fn().mockResolvedValue(""),
+  });
+  child.register("PermissionManager", {
+    getCurrentEffectiveMode: vi.fn().mockReturnValue("normal"),
+    clearTemporaryRules: vi.fn(),
+    getPlanFilePath: vi.fn().mockReturnValue(undefined),
+    setHasExitedPlanMode: vi.fn(),
+    hasExitedPlanModeInSession: vi.fn(() => false),
+    setNeedsPlanModeExitAttachment: vi.fn(),
+    getNeedsPlanModeExitAttachment: vi.fn(() => false),
+  });
+  child.register("SubagentManager", {
+    getConfigurations: vi.fn().mockReturnValue([]),
+  });
+  child.register("SkillManager", {
+    getAvailableSkills: vi.fn().mockReturnValue([]),
+  });
+  child.register("AgentOptions", { callbacks: {} });
+  if (withLocalQueue) {
+    child.register("MessageQueue", new MessageQueue());
+  }
+
+  const aiManager = new AIManager(child, {
+    workdir: "/test/workdir",
+    stream: false,
+    subagentType: "explore",
+  });
+  return { aiManager, parentQueue, drainSpy };
+}
+
+describe("AIManager notification drain isolation (FR-043/FR-044)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does NOT drain the parent queue when the subagent has its own MessageQueue (post-fix)", async () => {
+    const { aiManager, parentQueue, drainSpy } = buildChildAIManager({
+      withLocalQueue: true,
+    });
+
+    await aiManager.sendAIMessage();
+
+    // The sibling notification must remain in the parent queue, untouched.
+    expect(drainSpy).not.toHaveBeenCalled();
+    expect(parentQueue.hasNotifications()).toBe(true);
+  });
+
+  it("drains the parent queue via fallback when the subagent has no local MessageQueue (pre-fix harness)", async () => {
+    const { aiManager, parentQueue, drainSpy } = buildChildAIManager({
+      withLocalQueue: false,
+    });
+
+    await aiManager.sendAIMessage();
+
+    // Confirms the harness actually exercises the fallback/drain path: without
+    // a local queue the subagent steals the parent's notification.
+    expect(drainSpy).toHaveBeenCalled();
+    expect(parentQueue.hasNotifications()).toBe(false);
+  });
+});

--- a/packages/agent-sdk/tests/managers/subagentManager.messageQueueIsolation.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.messageQueueIsolation.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskManager } from "../../src/services/taskManager.js";
+import { SubagentManager } from "../../src/managers/subagentManager.js";
+import { ToolManager } from "../../src/managers/toolManager.js";
+import { BackgroundTaskManager } from "../../src/managers/backgroundTaskManager.js";
+import { MessageQueue } from "../../src/managers/messageQueue.js";
+import { Container } from "../../src/utils/container.js";
+import type { SubagentConfiguration } from "../../src/utils/subagentParser.js";
+
+// Capture the subagent container passed to each AIManager constructor so we can
+// assert it resolves its OWN MessageQueue (not the parent's via fallback).
+const { capturedContainers } = vi.hoisted(() => ({
+  capturedContainers: [] as Container[],
+}));
+
+// Mock dependencies. AIManager is mocked only to capture the subagent container;
+// createInstance() does the real container wiring we are testing.
+vi.mock("../../src/managers/messageManager.js");
+vi.mock("../../src/managers/toolManager.js");
+vi.mock("../../src/managers/backgroundTaskManager.js");
+vi.mock("../../src/managers/aiManager.js", () => ({
+  AIManager: vi.fn().mockImplementation(function (container: Container) {
+    capturedContainers.push(container);
+    return {
+      sendAIMessage: vi.fn().mockResolvedValue("done"),
+      abortAIMessage: vi.fn(),
+    };
+  }),
+}));
+
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/services/memory.js", () => ({
+  MemoryService: vi.fn().mockImplementation(() => ({
+    getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+    getAutoMemoryDirectory: vi.fn().mockReturnValue("/mock/auto-memory"),
+    ensureAutoMemoryDirectory: vi.fn().mockResolvedValue(undefined),
+    getAutoMemoryContent: vi.fn().mockResolvedValue(""),
+  })),
+  getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+}));
+
+const testConfig: SubagentConfiguration = {
+  name: "TestAgent",
+  description: "Test agent",
+  systemPrompt: "System prompt",
+  tools: ["Read"],
+  model: "inherit",
+  filePath: "/test/agent.md",
+  scope: "user",
+  priority: 1,
+};
+
+function buildParentContainer(messageQueue: MessageQueue): Container {
+  const mockToolManager = {
+    list: vi.fn(() => [{ name: "Read" }]),
+    getPermissionManager: vi.fn(),
+  } as unknown as ToolManager;
+
+  const mockBackgroundTaskManager = {
+    generateId: vi.fn().mockReturnValue("task_123"),
+    addTask: vi.fn(),
+    getTask: vi.fn(),
+  } as unknown as BackgroundTaskManager;
+
+  const taskManager = {
+    on: vi.fn(),
+    listTasks: vi.fn().mockResolvedValue([]),
+    getTaskListId: vi.fn().mockReturnValue("test-task-list"),
+  } as unknown as TaskManager;
+
+  const container = new Container();
+  container.register("ToolManager", mockToolManager);
+  container.register("TaskManager", taskManager);
+  container.register("BackgroundTaskManager", mockBackgroundTaskManager);
+  container.register("MessageQueue", messageQueue);
+  container.register("ConfigurationService", {
+    resolveGatewayConfig: () => ({ apiKey: "test", baseURL: "test" }),
+    resolveModelConfig: () => ({
+      model: "test-model",
+      fastModel: "test-fast-model",
+    }),
+    resolveMaxInputTokens: () => 1000,
+    resolveAutoMemoryEnabled: () => true,
+    resolveLanguage: () => "en",
+  });
+  return container;
+}
+
+describe("SubagentManager - MessageQueue isolation (FR-042)", () => {
+  let subagentManager: SubagentManager;
+  let parentQueue: MessageQueue;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedContainers.length = 0;
+
+    parentQueue = new MessageQueue();
+    // Pre-enqueue a sibling completion notification in the parent queue.
+    parentQueue.enqueueNotification(
+      "<task-notification><task-id>sibling-A</task-id></task-notification>",
+    );
+
+    const container = buildParentContainer(parentQueue);
+    subagentManager = new SubagentManager(container, {
+      workdir: "/test",
+      stream: false,
+    });
+  });
+
+  it("registers an independent MessageQueue in the subagent container", async () => {
+    await subagentManager.createInstance(testConfig, {
+      description: "isolated subagent",
+      prompt: "p",
+      subagent_type: "t",
+    });
+
+    expect(capturedContainers).toHaveLength(1);
+    const childQueue = capturedContainers[0].get<MessageQueue>("MessageQueue");
+
+    // The subagent must resolve its OWN queue, not the parent's via fallback.
+    expect(childQueue).toBeInstanceOf(MessageQueue);
+    expect(childQueue).not.toBe(parentQueue);
+    // The subagent's queue is empty — it must NOT see the parent's notification.
+    expect(childQueue?.hasNotifications()).toBe(false);
+    // The parent's notification is untouched.
+    expect(parentQueue.hasNotifications()).toBe(true);
+  });
+
+  it("gives each concurrent subagent a distinct MessageQueue", async () => {
+    const N = 5;
+    for (let i = 0; i < N; i++) {
+      await subagentManager.createInstance(testConfig, {
+        description: `subagent-${i}`,
+        prompt: "p",
+        subagent_type: "t",
+      });
+    }
+
+    expect(capturedContainers).toHaveLength(N);
+    const childQueues = capturedContainers.map(
+      (c) => c.get<MessageQueue>("MessageQueue")!,
+    );
+
+    // Every child queue is a real MessageQueue distinct from the parent...
+    for (const q of childQueues) {
+      expect(q).toBeInstanceOf(MessageQueue);
+      expect(q).not.toBe(parentQueue);
+      expect(q.hasNotifications()).toBe(false);
+    }
+    // ...and distinct from every other child queue.
+    const uniqueQueues = new Set(childQueues);
+    expect(uniqueQueues.size).toBe(N);
+
+    // The parent's single notification is never stolen by any subagent.
+    expect(parentQueue.hasNotifications()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Concurrent background subagents were stealing sibling completion notifications from the main Agent's MessageQueue via `Container.get()` parent fallback, causing the main Agent to exit early (exit code 0) in print mode (`wave -p`) without processing all notifications.

## Root Cause

`SubagentManager.createInstance()` created a child container without registering a local `MessageQueue`. The subagent's `AIManager.sendAIMessage()` end-of-turn drain (`aiManager.ts:1489`) resolved the **parent** container's queue via `Container.get()` fallback and:

1. Drained sibling subagent completion notifications from the main queue
2. Injected them into the subagent's own session transcript (`addNotificationMessage`)
3. Restarted its own turn (`shouldRestart = true`)

The main Agent saw no pending work (`hasPendingMessages` / `hasRunningBackgroundWork` / `isLoading` all false) and exited early.

## Fix

Register an independent `new MessageQueue()` in the subagent container (`subagentManager.ts:295`) so each subagent's AIManager drains its own (empty) queue instead of falling back to the parent's.

## Spec

Updated `docs/specs/multi-agent/task-background-execution.md`:
- User Story 6 acceptance scenarios 7-9 (concurrent notification routing, drain isolation, print-mode exit)
- Boundary case for concurrent notification misrouting
- FR-042: independent `MessageQueue` per Agent/subagent container; subagent must not inherit parent's via fallback
- FR-043: subagent drain (`drainNotifications`) must only act on its own container's queue
- FR-044: completion notifications must be delivered to and consumed only by the main Agent's queue
- FR-045: concurrent integration test requirement (≥5 subagents, each taskId once in main transcript, never in siblings)

## Tests

- `subagentManager.messageQueueIsolation.test.ts` (FR-042): mocks AIManager to capture each subagent's container; asserts every concurrent subagent resolves its own distinct empty `MessageQueue` ≠ parent's, and the parent's notification is never stolen. **Verified to fail without the fix.**
- `aiManager.notificationDrainIsolation.test.ts` (FR-043/044): real `AIManager` on a child container; asserts the parent's `drainNotifications` is **not** called when the child has a local queue (post-fix), and **is** called via fallback when it doesn't (harness validation that the test exercises the drain path).

## Verification

- Build: clean
- Type-check: clean
- `tests/managers/` (61 files): 820 passed, 1 skipped