### PR TITLE
fix(webview): remove hardcoded minWidth 560px to stop dialog overflow on narrow panels

### DIFF
--- a/packages/webview/src/components/BackgroundTaskManager.tsx
+++ b/packages/webview/src/components/BackgroundTaskManager.tsx
@@ -128,7 +128,7 @@ const BackgroundTaskManager: React.FC<BackgroundTaskManagerProps & {
 
   return (
     <div className="configuration-dialog-overlay">
-      <div ref={dialogRef} className="configuration-dialog" data-testid="background-task-manager" style={{ minWidth: '560px', maxWidth: '760px' }}>
+      <div ref={dialogRef} className="configuration-dialog" data-testid="background-task-manager" style={{ maxWidth: '760px' }}>
         <div className="configuration-dialog-header">
           <h3>后台任务</h3>
         </div>

--- a/packages/webview/src/components/WorkflowManager.tsx
+++ b/packages/webview/src/components/WorkflowManager.tsx
@@ -217,7 +217,7 @@ const WorkflowManager: React.FC<WorkflowManagerProps & {
 
   return (
     <div className="configuration-dialog-overlay">
-      <div ref={dialogRef} className="configuration-dialog" data-testid="workflow-manager" style={{ minWidth: '560px', maxWidth: '760px' }}>
+      <div ref={dialogRef} className="configuration-dialog" data-testid="workflow-manager" style={{ maxWidth: '760px' }}>
         <div className="configuration-dialog-header">
           <h3>工作流</h3>
         </div>


### PR DESCRIPTION
## Problem

The BackgroundTaskManager and WorkflowManager dialogs set an inline `minWidth: 560px`, overriding the base `.configuration-dialog` rule (`width: 90%; max-width: 400px`). On narrow VS Code webview panels (commonly <560px), the dialog was forced to at least 560px and overflowed the panel — independent of content.

## Fix

Removed the inline `minWidth: '560px'` from both dialogs so the CSS `width: 90%` drives the width, capped at `maxWidth: 760px`.

| Panel width | Before | After |
|---|---|---|
| 800px | 720px | 720px |
| 500px | 560px (overflow!) | 450px |
| 400px | 560px (overflow!) | 360px |

Inner content already wraps safely (`word-break: break-all` on command/log paths, `pre-wrap` + `overflow: auto` on output blocks), so no content-driven stretch risk.

## Changes
- `packages/webview/src/components/BackgroundTaskManager.tsx` — drop inline `minWidth`
- `packages/webview/src/components/WorkflowManager.tsx` — drop inline `minWidth`