### PR TITLE
fix(webview): hide TaskList on pendingConfirmations instead of activeDialog

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -516,7 +516,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode }) => {
       )}
 
       <div className="input-area-container">
-        <div style={{ display: state.activeDialog ? 'none' : 'block' }}>
+        <div style={{ display: state.pendingConfirmations.length === 0 ? 'block' : 'none' }}>
           <TaskList
             tasks={state.tasks}
             isCollapsed={state.isTaskListCollapsed}


### PR DESCRIPTION
## Summary

The TaskList/QueuedMessageList visibility condition in `ChatApp.tsx` was inverted.

- **Before:** hidden when `state.activeDialog` is set
- **After:** hidden when `state.pendingConfirmations.length > 0` (aligned with MessageInput's existing condition)

## Rationale

- Confirmation dialogs (AskUserQuestion, tool confirmations) render **inline** within `input-area-container` and stack vertically above TaskList. They should hide TaskList to keep the user focused on the pending decision.
- `activeDialog` modals (`/config`, `/plugin`, `/mcp`, `/status`, `/tasks`, `/workflows`) render as **independent overlays** outside the container and self-cover, so they should not control TaskList visibility.

## Test

`pnpm -F wave-webview build` passes; output synced to vsce/jetbrains.