### PR TITLE
feat(worktree): add worktree.baseRef setting to support local HEAD base

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1323,6 +1323,7 @@ Wave 提供了一个强大的内置 `/settings` skill，作为用户与 Wave 配
 - `language`：AI 通信首选语言（如 `"zh"`、`"en"`）。
 - `autoMemoryEnabled`：启用或禁用自动记忆（默认：`true`）。
 - `autoMemoryFrequency`：自动记忆提取频率（默认：`1`）。
+- `worktree.baseRef`：新建 worktree 的基准引用。`"fresh"`（默认）基于 `origin/<默认分支>` 创建新分支；`"head"` 基于当前本地 HEAD 创建，跳过 origin 解析与网络 fetch。适用于基于尚未推送的本地分支工作的场景。
 
 ## 15. 官方插件市场 {#plugin-marketplaces}
 

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -14,9 +14,9 @@
 | 指标 | 数量 |
 |------|------|
 | 规格文件 | 60 |
-| 用户故事 | 281 |
-| 功能需求 | 1,163 |
-| 测试用例 | 4,348 |
+| 用户故事 | 282 |
+| 功能需求 | 1,165 |
+| 测试用例 | 4,352 |
 
 ## 规格列表
 
@@ -79,7 +79,7 @@
 | 任务后台执行 | `run_in_background`、`TaskOutput`/`TaskStop` 工具，`/tasks` 命令替代 `/bashes` | 7 | 42 | [规格](multi-agent/task-background-execution.md) |
 | 任务管理工具 | TaskCreate/TaskGet/TaskUpdate/TaskList，`~/.wave/tasks/` 存储和任务列表 UI | 6 | 32 | [规格](multi-agent/task-management-tools.md) |
 | Workflow 编排 | 确定性多子代理编排，支持 pipeline、parallel 和 phase 控制流 | 5 | 29 | [规格](multi-agent/workflow.md) |
-| CLI Worktree | `-w/--worktree` 隔离的 git worktree，位于 `.wave/worktrees/`，支持安全退出 | 8 | 44 | [规格](multi-agent/worktree.md) |
+| CLI Worktree | `-w/--worktree` 隔离的 git worktree，位于 `.wave/worktrees/`，支持安全退出 | 9 | 46 | [规格](multi-agent/worktree.md) |
 
 ### 扩展与生态
 

--- a/docs/specs/multi-agent/worktree.md
+++ b/docs/specs/multi-agent/worktree.md
@@ -134,6 +134,21 @@
 
 ---
 
+### 用户故事 9 - 基于本地 HEAD 创建 Worktree（优先级：P2）
+
+作为在本地分支上工作的开发者，我希望新 worktree 可基于当前本地 HEAD（而非 origin 默认分支）创建，以便基于尚未推送的本地分支工作、并避免联网 fetch。
+
+**为什么是这个优先级**：对齐 Claude Code 2.1.203 的 `worktree.baseRef` 设置。默认 `fresh` 保持现有行为，`head` 覆盖"基于本地分支"诉求。
+
+**独立测试**：临时仓库 `git checkout` 到某本地分支，settings.json 设置 `worktree.baseRef: "head"`，运行 `wave code -w` 或要求 AI 调用 `EnterWorktree`，验证新 worktree 的 HEAD 等于该本地分支的提交，且全程未发起网络请求；再改回 `"fresh"` 验证走 origin 默认分支。
+
+**验收场景**：
+
+1. **假设** settings.json 设置 `worktree.baseRef: "head"`，**当**通过 CLI `-w` 或 `EnterWorktree` 创建新 worktree 时，**则**新分支基于当前本地 HEAD 创建，不解析 `origin/<默认分支>` 也不发起 fetch。
+2. **假设** `worktree.baseRef` 未设置或为 `"fresh"`，**当**创建新 worktree 时，**则**沿用现有 `fresh` 行为（基于 `origin/<默认分支>`，fetch→HEAD 兜底），与 FR-003/FR-040 一致。
+
+---
+
 ### 边界情况
 
 - **当 worktree 目录已存在时会发生什么？** 系统应该报错或询问是否重用。
@@ -198,6 +213,11 @@
 - **FR-042**：worktree 会话状态（当前是否处于 worktree、其路径/原始 CWD/分支名）必须按会话隔离存储，不得使用进程级模块单例。一个会话进入 worktree 后，其它会话调用 `EnterWorktree` 不得被误拒，调用 `ExitWorktree` 不得读取到其它会话的 worktree 会话状态。
 - **FR-043**：`ExitWorktree` 工具必须只作用于**发起调用的会话自身**的 worktree 会话。当 `action` 为 `"remove"` 时，只能删除本会话的 worktree 目录与分支，绝不能删除或修改其它会话的 worktree 目录、分支或工作目录。
 - **FR-044**：`ExitWorktree` 的无操作判定（FR-036）必须基于**当前会话**是否处于活动 worktree 会话；当前会话未进入 worktree 时必须返回无操作，即使同一进程中的其它会话正处于 worktree 会话中。
+
+#### Worktree Base Ref 配置
+
+- **FR-045**：系统必须支持顶层 settings.json 字段 `worktree.baseRef`，枚举 `"fresh"`（默认）| `"head"`。`fresh` 基于 `origin/<默认分支>` 创建新分支（沿用 FR-003/FR-040）；`head` 基于当前本地 HEAD 创建新分支，跳过 origin 解析与网络 fetch。
+- **FR-046**：`EnterWorktree` 工具与 CLI `-w` 启动路径必须读取并应用 `worktree.baseRef`；未设置或值非法时回退默认 `"fresh"`（行为与现状一致，不影响存量用户）。设置值必须通过 `ConfigurationService` 解析并经 `AIManager` 暴露，按会话读取。
 
 ### 关键实体
 

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -29,6 +29,7 @@ export * from "./utils/tokenCalculation.js";
 export * from "./utils/gitUtils.js";
 export * from "./utils/nameGenerator.js";
 export * from "./utils/worktreeSession.js";
+export { loadMergedWaveConfig } from "./services/configurationService.js";
 export * from "./types/index.js";
 
 // Export tool building utilities

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -252,6 +252,10 @@ export class AIManager {
     return this.configurationService.resolveAutoMemoryEnabled();
   }
 
+  public getWorktreeBaseRef(): "fresh" | "head" {
+    return this.configurationService.resolveWorktreeBaseRef();
+  }
+
   public getWorkdir(): string {
     return this.container.get<string>("Workdir") ?? process.cwd();
   }

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -320,6 +320,23 @@ export class ConfigurationService {
       }
     }
 
+    // Validate worktree if present
+    if (config.worktree !== undefined) {
+      if (typeof config.worktree !== "object" || config.worktree === null) {
+        result.isValid = false;
+        result.errors.push("worktree configuration must be an object");
+      } else if (
+        config.worktree.baseRef !== undefined &&
+        config.worktree.baseRef !== "fresh" &&
+        config.worktree.baseRef !== "head"
+      ) {
+        result.isValid = false;
+        result.errors.push(
+          `Invalid worktree.baseRef: "${config.worktree.baseRef}". Must be "fresh" or "head".`,
+        );
+      }
+    }
+
     return result;
   }
 
@@ -638,6 +655,19 @@ export class ConfigurationService {
 
     // 3. Default (true)
     return true;
+  }
+
+  /**
+   * Resolves worktree base ref with fallbacks
+   * Resolution priority: settings.json > default ("fresh")
+   * @returns Resolved worktree base ref
+   */
+  resolveWorktreeBaseRef(): "fresh" | "head" {
+    const baseRef = this.currentConfiguration?.worktree?.baseRef;
+    if (baseRef === "head") {
+      return "head";
+    }
+    return "fresh";
   }
 
   /**
@@ -1172,6 +1202,7 @@ export function loadWaveConfigFromFile(
           : undefined,
       models: config.models || undefined,
       marketplaces: config.marketplaces || undefined,
+      worktree: config.worktree || undefined,
     };
   } catch (error) {
     if (error instanceof SyntaxError) {
@@ -1320,6 +1351,11 @@ export function loadMergedWaveConfig(
       Object.assign(mergedConfig.marketplaces, config.marketplaces);
     }
 
+    // Merge worktree (last one wins)
+    if (config.worktree !== undefined) {
+      mergedConfig.worktree = config.worktree;
+    }
+
     // Merge models
     if (config.models) {
       if (!mergedConfig.models) mergedConfig.models = {};
@@ -1363,5 +1399,6 @@ export function loadMergedWaveConfig(
       mergedConfig.models && Object.keys(mergedConfig.models).length > 0
         ? mergedConfig.models
         : undefined,
+    worktree: mergedConfig.worktree,
   };
 }

--- a/packages/agent-sdk/src/services/remoteSettingsService.ts
+++ b/packages/agent-sdk/src/services/remoteSettingsService.ts
@@ -326,6 +326,7 @@ export function mergeRemoteSettings(
     result.autoMemoryEnabled = remote.autoMemoryEnabled;
   if (remote.autoMemoryFrequency !== undefined)
     result.autoMemoryFrequency = remote.autoMemoryFrequency;
+  if (remote.worktree !== undefined) result.worktree = remote.worktree;
   if (remote.models !== undefined) result.models = remote.models;
   if (remote.marketplaces !== undefined)
     result.marketplaces = remote.marketplaces;

--- a/packages/agent-sdk/src/tools/enterWorktreeTool.ts
+++ b/packages/agent-sdk/src/tools/enterWorktreeTool.ts
@@ -102,7 +102,8 @@ export const enterWorktreeTool: ToolPlugin = {
     }
 
     // Create the worktree (captures originalHeadCommit internally)
-    const worktreeInfo = createWorktree(name, mainRepoRoot);
+    const baseRef = context.aiManager?.getWorktreeBaseRef?.();
+    const worktreeInfo = createWorktree(name, mainRepoRoot, { baseRef });
 
     // Build session state
     const session: WorktreeSession = {

--- a/packages/agent-sdk/src/types/configuration.ts
+++ b/packages/agent-sdk/src/types/configuration.ts
@@ -54,6 +54,11 @@ export interface WaveConfiguration {
   monitoring?: {
     telemetry?: Partial<TelemetryConfig>;
   };
+  /** Worktree configuration */
+  worktree?: {
+    /** Base ref for new worktrees: "fresh" (origin/<default-branch>, default) | "head" (local HEAD) */
+    baseRef?: "fresh" | "head";
+  };
 }
 
 /**

--- a/packages/agent-sdk/src/utils/worktreeUtils.ts
+++ b/packages/agent-sdk/src/utils/worktreeUtils.ts
@@ -93,8 +93,16 @@ export function getHeadCommit(cwd: string): string {
 
 /**
  * Create a git worktree for use during a session.
+ * @param name Worktree name
+ * @param cwd Current working directory (will be resolved to main repo root)
+ * @param options Optional creation options
+ * @param options.baseRef "fresh" (default, origin/<default-branch>) | "head" (local HEAD)
  */
-export function createWorktree(name: string, cwd: string): WorktreeInfo {
+export function createWorktree(
+  name: string,
+  cwd: string,
+  options?: { baseRef?: "fresh" | "head" },
+): WorktreeInfo {
   const repoRoot = getGitMainRepoRoot(cwd);
   if (!repoRoot) {
     throw new Error(
@@ -107,7 +115,8 @@ export function createWorktree(name: string, cwd: string): WorktreeInfo {
 
   const worktreePath = path.join(repoRoot, ".wave", "worktrees", name);
   const branchName = `worktree-${name}`;
-  const baseBranch = getDefaultRemoteBranch(cwd);
+  const useHead = options?.baseRef === "head";
+  const baseBranch = useHead ? "HEAD" : getDefaultRemoteBranch(cwd);
 
   // Ensure Wave runtime files are git-excluded in this repo
   ensureWaveRuntimeFilesExcluded(cwd);
@@ -183,8 +192,9 @@ export function createWorktree(name: string, cwd: string): WorktreeInfo {
       }
     }
     if (
-      stderr.includes("not a valid object name") ||
-      stderr.includes("unknown revision")
+      !useHead &&
+      (stderr.includes("not a valid object name") ||
+        stderr.includes("unknown revision"))
     ) {
       // Base branch not fetched yet — try fetching then retrying
       const branchNameOnly = baseBranch.split("/").pop()!;

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -753,6 +753,50 @@ describe("ConfigurationService", () => {
     });
   });
 
+  describe("resolveWorktreeBaseRef", () => {
+    it("should return 'fresh' by default", () => {
+      expect(configService.resolveWorktreeBaseRef()).toBe("fresh");
+    });
+
+    it("should return 'head' when configured", async () => {
+      const config = { worktree: { baseRef: "head" as const } };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      await configService.loadMergedConfiguration(tempDir);
+      expect(configService.resolveWorktreeBaseRef()).toBe("head");
+    });
+
+    it("should return 'fresh' when baseRef is 'fresh'", async () => {
+      const config = { worktree: { baseRef: "fresh" as const } };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      await configService.loadMergedConfiguration(tempDir);
+      expect(configService.resolveWorktreeBaseRef()).toBe("fresh");
+    });
+
+    it("should return 'fresh' for invalid baseRef value", async () => {
+      const config = { worktree: { baseRef: "invalid" } };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      // loadMergedConfiguration validates; invalid value fails validation
+      const result = await configService.loadMergedConfiguration(tempDir);
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject invalid baseRef in validation", () => {
+      const config = {
+        worktree: { baseRef: "invalid" },
+      } as unknown as WaveConfiguration;
+      const result = configService.validateConfiguration(config);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors[0]).toContain("Invalid worktree.baseRef");
+    });
+  });
+
   describe("validateEnvironmentConfig", () => {
     it("should validate correct env", () => {
       const result = validateEnvironmentConfig({ KEY: "VAL" });

--- a/packages/agent-sdk/tests/tools/enterWorktreeTool.test.ts
+++ b/packages/agent-sdk/tests/tools/enterWorktreeTool.test.ts
@@ -26,6 +26,7 @@ describe("enterWorktreeTool", () => {
   let mockSetWorkdir: ReturnType<typeof vi.fn>;
   let mockGetWorktreeSession: ReturnType<typeof vi.fn>;
   let mockSetWorktreeSession: ReturnType<typeof vi.fn>;
+  let mockGetWorktreeBaseRef: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -33,6 +34,7 @@ describe("enterWorktreeTool", () => {
     mockSetWorkdir = vi.fn();
     mockGetWorktreeSession = vi.fn().mockReturnValue(null);
     mockSetWorktreeSession = vi.fn();
+    mockGetWorktreeBaseRef = vi.fn().mockReturnValue("fresh");
 
     mockContext = {
       workdir: "/test/workdir",
@@ -42,6 +44,7 @@ describe("enterWorktreeTool", () => {
         getWorkdir: () => "/test/workdir",
         getWorktreeSession: mockGetWorktreeSession,
         setWorktreeSession: mockSetWorktreeSession,
+        getWorktreeBaseRef: mockGetWorktreeBaseRef,
       } as never,
     };
 
@@ -302,5 +305,87 @@ describe("enterWorktreeTool", () => {
     expect(result.success).toBe(true);
     expect(result.content).toContain("Created worktree");
     expect(result.content).not.toContain("WorktreeCreate hooks were executed");
+  });
+
+  it("should pass baseRef 'head' to createWorktree when aiManager returns 'head'", async () => {
+    mockGetWorktreeBaseRef.mockReturnValue("head");
+    vi.mocked(worktreeUtils.createWorktree).mockReturnValue({
+      name: "head-test",
+      path: "/test/repo/.wave/worktrees/head-test",
+      branch: "worktree-head-test",
+      repoRoot: "/test/repo",
+      isNew: true,
+      originalHeadCommit: "abc123",
+    });
+
+    const result = await enterWorktreeTool.execute(
+      { name: "head-test" },
+      mockContext,
+    );
+
+    expect(result.success).toBe(true);
+    expect(worktreeUtils.createWorktree).toHaveBeenCalledWith(
+      "head-test",
+      "/test/repo",
+      { baseRef: "head" },
+    );
+  });
+
+  it("should pass baseRef 'fresh' to createWorktree when aiManager returns 'fresh'", async () => {
+    mockGetWorktreeBaseRef.mockReturnValue("fresh");
+    vi.mocked(worktreeUtils.createWorktree).mockReturnValue({
+      name: "fresh-test",
+      path: "/test/repo/.wave/worktrees/fresh-test",
+      branch: "worktree-fresh-test",
+      repoRoot: "/test/repo",
+      isNew: true,
+      originalHeadCommit: "abc123",
+    });
+
+    const result = await enterWorktreeTool.execute(
+      { name: "fresh-test" },
+      mockContext,
+    );
+
+    expect(result.success).toBe(true);
+    expect(worktreeUtils.createWorktree).toHaveBeenCalledWith(
+      "fresh-test",
+      "/test/repo",
+      { baseRef: "fresh" },
+    );
+  });
+
+  it("should pass undefined baseRef when aiManager has no getWorktreeBaseRef", async () => {
+    // Simulate an aiManager without getWorktreeBaseRef (e.g. older SDK consumer)
+    vi.mocked(worktreeUtils.createWorktree).mockReturnValue({
+      name: "no-ref",
+      path: "/test/repo/.wave/worktrees/no-ref",
+      branch: "worktree-no-ref",
+      repoRoot: "/test/repo",
+      isNew: true,
+      originalHeadCommit: "abc123",
+    });
+
+    const contextNoBaseRef: ToolContext = {
+      ...mockContext,
+      aiManager: {
+        setWorkdir: mockSetWorkdir,
+        getWorkdir: () => "/test/workdir",
+        getWorktreeSession: mockGetWorktreeSession,
+        setWorktreeSession: mockSetWorktreeSession,
+      } as never,
+    };
+
+    const result = await enterWorktreeTool.execute(
+      { name: "no-ref" },
+      contextNoBaseRef,
+    );
+
+    expect(result.success).toBe(true);
+    expect(worktreeUtils.createWorktree).toHaveBeenCalledWith(
+      "no-ref",
+      "/test/repo",
+      { baseRef: undefined },
+    );
   });
 });

--- a/packages/agent-sdk/tests/utils/worktreeUtils.test.ts
+++ b/packages/agent-sdk/tests/utils/worktreeUtils.test.ts
@@ -100,6 +100,39 @@ describe("worktreeUtils", () => {
       expect(result.originalHeadCommit).toBe("abc123");
     });
 
+    it("uses HEAD as base when baseRef is 'head'", () => {
+      const result = worktreeUtils.createWorktree("my-feat", "/test", {
+        baseRef: "head",
+      });
+
+      expect(result.isNew).toBe(true);
+      // git worktree add -b <branch> <path> HEAD
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["HEAD"]),
+        expect.anything(),
+      );
+      // Should NOT call getDefaultRemoteBranch
+      expect(gitUtils.getDefaultRemoteBranch).not.toHaveBeenCalled();
+    });
+
+    it("uses origin default branch when baseRef is 'fresh'", () => {
+      worktreeUtils.createWorktree("my-feat", "/test", { baseRef: "fresh" });
+
+      expect(gitUtils.getDefaultRemoteBranch).toHaveBeenCalledWith("/test");
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["origin/main"]),
+        expect.anything(),
+      );
+    });
+
+    it("defaults to 'fresh' behavior when baseRef is undefined", () => {
+      worktreeUtils.createWorktree("my-feat", "/test");
+
+      expect(gitUtils.getDefaultRemoteBranch).toHaveBeenCalledWith("/test");
+    });
+
     it("reuses existing worktree", () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
 
@@ -247,6 +280,36 @@ describe("worktreeUtils", () => {
 
       expect(() => worktreeUtils.createWorktree("feat", "/test")).toThrow(
         "Failed to create worktree",
+      );
+    });
+
+    it("should NOT attempt fetch when baseRef is 'head' and creation fails", () => {
+      let callCount = 0;
+      vi.mocked(execFileSync).mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // getHeadCommit
+          return "abc123\n";
+        }
+        if (callCount === 2) {
+          // git worktree add -b ... HEAD fails
+          const err = new Error("git error") as Error & {
+            stderr?: Buffer;
+          };
+          err.stderr = Buffer.from("not a valid object name");
+          throw err;
+        }
+        return "";
+      });
+
+      expect(() =>
+        worktreeUtils.createWorktree("feat", "/test", { baseRef: "head" }),
+      ).toThrow("Failed to create worktree");
+      // Should not call git fetch
+      expect(execFileSync).not.toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["fetch"]),
+        expect.anything(),
       );
     });
   });

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -1,7 +1,12 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { startCli } from "./cli.js";
-import { Scope, generateRandomName, type PermissionMode } from "wave-agent-sdk";
+import {
+  Scope,
+  generateRandomName,
+  loadMergedWaveConfig,
+  type PermissionMode,
+} from "wave-agent-sdk";
 import { createWorktree, type WorktreeSession } from "./utils/worktree.js";
 import path from "path";
 import { readFileSync } from "fs";
@@ -320,7 +325,8 @@ export async function main() {
       if (!name || name === "") {
         name = generateRandomName();
       }
-      worktreeSession = createWorktree(name, originalCwd);
+      const baseRef = loadMergedWaveConfig(originalCwd)?.worktree?.baseRef;
+      worktreeSession = createWorktree(name, originalCwd, { baseRef });
 
       // Note: the full worktree session (originalCwd etc.) is injected into the
       // agent's DI container after the agent is created in useChat.tsx. This keeps

--- a/packages/code/src/utils/worktree.ts
+++ b/packages/code/src/utils/worktree.ts
@@ -17,13 +17,20 @@ export interface WorktreeSession {
  * Create a new git worktree
  * @param name Worktree name
  * @param cwd Current working directory
+ * @param options Optional creation options
+ * @param options.baseRef "fresh" (default, origin/<default-branch>) | "head" (local HEAD)
  * @returns Worktree session details
  */
-export function createWorktree(name: string, cwd: string): WorktreeSession {
+export function createWorktree(
+  name: string,
+  cwd: string,
+  options?: { baseRef?: "fresh" | "head" },
+): WorktreeSession {
   const repoRoot = getGitMainRepoRoot(cwd);
   const worktreePath = path.join(repoRoot, ".wave", "worktrees", name);
   const branchName = `worktree-${name}`;
-  const baseBranch = getDefaultRemoteBranch(cwd);
+  const useHead = options?.baseRef === "head";
+  const baseBranch = useHead ? "HEAD" : getDefaultRemoteBranch(cwd);
 
   // Ensure parent directory exists
   const parentDir = path.dirname(worktreePath);
@@ -90,8 +97,9 @@ export function createWorktree(name: string, cwd: string): WorktreeSession {
       }
     }
     if (
-      stderr.includes("not a valid object name") ||
-      stderr.includes("unknown revision")
+      !useHead &&
+      (stderr.includes("not a valid object name") ||
+        stderr.includes("unknown revision"))
     ) {
       // Base branch not fetched yet — try fetching then retrying
       const branchNameOnly = baseBranch.split("/").pop()!;

--- a/packages/code/tests/utils/worktree.test.ts
+++ b/packages/code/tests/utils/worktree.test.ts
@@ -46,6 +46,39 @@ describe("worktree utils", () => {
       );
     });
 
+    it("should use HEAD as base when baseRef is 'head'", () => {
+      vi.mocked(getGitMainRepoRoot).mockReturnValue("/repo/root");
+      vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const session = createWorktree("my-feat", "/repo/root", {
+        baseRef: "head",
+      });
+
+      expect(session.isNew).toBe(true);
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["HEAD"]),
+        expect.any(Object),
+      );
+      expect(getDefaultRemoteBranch).not.toHaveBeenCalled();
+    });
+
+    it("should use origin default branch when baseRef is 'fresh'", () => {
+      vi.mocked(getGitMainRepoRoot).mockReturnValue("/repo/root");
+      vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      createWorktree("my-feat", "/repo/root", { baseRef: "fresh" });
+
+      expect(getDefaultRemoteBranch).toHaveBeenCalledWith("/repo/root");
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["origin/main"]),
+        expect.any(Object),
+      );
+    });
+
     it("should reuse an existing worktree", () => {
       vi.mocked(getGitMainRepoRoot).mockReturnValue("/repo/root");
       vi.mocked(fs.existsSync).mockReturnValue(true);


### PR DESCRIPTION
Aligns with Claude Code 2.1.203's worktree.baseRef setting. New settings.json
field worktree.baseRef ("fresh" | "head") controls the base ref for new
worktrees:

- "fresh" (default): origin/<default-branch> with fetch fallback (existing behavior)
- "head": local HEAD, skipping origin resolution and network fetch entirely

Changes:
- Add worktree.baseRef to WaveConfiguration type
- Add resolveWorktreeBaseRef() to ConfigurationService with validation
- Add getWorktreeBaseRef() to AIManager (follows resolveAutoMemoryEnabled pattern)
- Wire EnterWorktree tool to read baseRef via context.aiManager?.getWorktreeBaseRef?.()
- Wire CLI -w startup to read baseRef via loadMergedWaveConfig
- Update createWorktree (SDK + CLI) to accept baseRef option, use HEAD when "head"
- Guard fetch fallback with !useHead so head mode never triggers network fetch
- Export loadMergedWaveConfig from SDK for CLI consumption
- Update docs/sdk.md with worktree.baseRef documentation
- Add spec US-9, FR-045, FR-046 to docs/specs/multi-agent/worktree.md
- Add tests for all modified files (worktreeUtils, enterWorktreeTool, configurationService, CLI worktree)
