### PR TITLE
fix: prevent queued notification dispatch during abort

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -78,6 +78,7 @@ export class Agent {
   private reversionManager: ReversionManager;
   private messageQueue: MessageQueue; // Unified queue for messages, bang commands, and notifications
   private dispatchPromise: Promise<void> | null = null; // Track current dispatch for teardown
+  private isAborting = false; // Guard: prevents tryDispatch from firing during abortMessage
   private memoryRuleManager: MemoryRuleManager; // Add memory rule manager instance
   private liveConfigManager: LiveConfigManager; // Add live configuration manager
   private taskManager: TaskManager;
@@ -412,6 +413,7 @@ export class Agent {
    * onLoadingChange(false), and onCommandRunningChange(false).
    */
   private tryDispatch(): void {
+    if (this.isAborting) return; // Suppress dispatch during abort to prevent queued notifications from being dispatched as a side-effect
     if (this.messageQueue.state !== "idle") return;
     if (!this.messageQueue.hasPending()) return;
     if (this.aiManager.isLoading || this.isCommandRunning) return;
@@ -847,17 +849,24 @@ export class Agent {
 
   /** Unified interrupt method, interrupts both AI messages and command execution */
   public abortMessage(): void {
-    if (this.aiManager.isLoading || this.isCommandRunning) {
-      // Clear user-facing queue items first to prevent processQueuedMessage
-      // from dequeuing when abortAIMessage triggers onLoadingChange(false).
-      // Notifications are preserved so background task results aren't lost.
-      this.messageQueue.clear();
-      this.options.callbacks?.onQueuedMessagesChange?.(this.queuedMessages);
+    // Guard: prevent tryDispatch (triggered by abortAIMessage → setIsLoading(false))
+    // from dispatching preserved notifications as a new AI turn during the abort.
+    this.isAborting = true;
+    try {
+      if (this.aiManager.isLoading || this.isCommandRunning) {
+        // Clear user-facing queue items first to prevent processQueuedMessage
+        // from dequeuing when abortAIMessage triggers onLoadingChange(false).
+        // Notifications are preserved so background task results aren't lost.
+        this.messageQueue.clear();
+        this.options.callbacks?.onQueuedMessagesChange?.(this.queuedMessages);
+      }
+      this.messageQueue.transitionTo("idle"); // Reset state on abort
+      this.abortAIMessage(); // This will abort tools including Agent tool (subagents)
+      this.abortBashCommand();
+      this.abortSlashCommand();
+    } finally {
+      this.isAborting = false;
     }
-    this.messageQueue.transitionTo("idle"); // Reset state on abort
-    this.abortAIMessage(); // This will abort tools including Agent tool (subagents)
-    this.abortBashCommand();
-    this.abortSlashCommand();
   }
 
   /** Interrupt bash command execution */

--- a/packages/agent-sdk/tests/agent/agent.abort.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.abort.test.ts
@@ -623,6 +623,88 @@ describe("Agent - Abort Handling", () => {
       expect(messageQueue.getQueue()).toHaveLength(0);
     });
 
+    it("should not dispatch queued notification during abort", async () => {
+      const mockCallbacks = {
+        onMessagesChange: vi.fn(),
+        onLoadingChange: vi.fn(),
+        onQueuedMessagesChange: vi.fn(),
+      };
+
+      const testAgent = await Agent.create({
+        apiKey: "test-key",
+        workdir: "/tmp/test-abort-notification",
+        callbacks: mockCallbacks,
+      });
+
+      activeTestAgent = testAgent;
+      const container = (testAgent as unknown as { container: Container })
+        .container;
+      container.register("ToolManager", mockToolManagerInstance);
+      container.register("McpManager", {
+        isMcpTool: vi.fn().mockReturnValue(false),
+        getMcpToolPlugins: vi.fn().mockReturnValue([]),
+        getMcpToolsConfig: vi.fn().mockReturnValue([]),
+      });
+      container.register("SubagentManager", {
+        getConfigurations: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("SkillManager", {
+        getAvailableSkills: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("ConfigurationService", {
+        resolveGatewayConfig: () => testAgent.getGatewayConfig(),
+        resolveModelConfig: () => testAgent.getModelConfig(),
+        resolveMaxInputTokens: () => testAgent.getMaxInputTokens(),
+        resolveAutoMemoryEnabled: () => true,
+        resolveLanguage: () => testAgent.getLanguage(),
+        getEnvironmentVars: () =>
+          (
+            testAgent as unknown as {
+              configurationService: {
+                getEnvironmentVars: () => Record<string, string>;
+              };
+            }
+          ).configurationService.getEnvironmentVars(),
+      });
+
+      const messageQueue = (
+        testAgent as unknown as {
+          messageQueue: import("@/managers/messageQueue.js").MessageQueue;
+        }
+      ).messageQueue;
+
+      const aiManager = (testAgent as unknown as { aiManager: AIManager })
+        .aiManager;
+
+      // Simulate active streaming — notifications will queue but not dispatch
+      aiManager.setIsLoading(true);
+
+      // Enqueue a background notification
+      const xml =
+        "<task-notification><task-id>bg-1</task-id><task-type>shell</task-type><status>completed</status><summary>Done</summary></task-notification>";
+      messageQueue.enqueueNotification(xml);
+      expect(messageQueue.hasNotifications()).toBe(true);
+
+      // Spy on sendAIMessage to detect if the notification gets dispatched
+      const sendSpy = vi
+        .spyOn(aiManager, "sendAIMessage")
+        .mockResolvedValue(undefined);
+
+      // Abort — should interrupt the current turn WITHOUT dispatching the
+      // queued notification as a new AI turn
+      testAgent.abortMessage();
+
+      // sendAIMessage must NOT have been called for the notification
+      expect(sendSpy).not.toHaveBeenCalled();
+
+      // Notification should still be preserved in the queue (not lost)
+      expect(messageQueue.hasNotifications()).toBe(true);
+
+      sendSpy.mockRestore();
+    });
+
     it("should reset queue state to idle on abort", async () => {
       const testAgent = await Agent.create({
         apiKey: "test-key",


### PR DESCRIPTION
## Problem

When pressing ESC to interrupt while a background notification is in the queue, the notification gets dispatched as a new AI turn — producing a second interrupt message.

## Root Cause

In `abortMessage()` (agent.ts):

1. `messageQueue.clear()` preserves notifications (by design, so background results aren't lost)
2. `abortAIMessage()` calls `setIsLoading(false)`
3. `setIsLoading(false)` fires `onLoadingChange(false)` → `tryDispatch()`
4. `tryDispatch()` sees: state=idle, notification pending, not loading → **dispatches the notification as a new AI turn**

The comment at the original code acknowledged this race for user messages, but `clear()` only removes user messages — notifications survive and get picked up by `tryDispatch()`.

## Fix

Added an `isAborting` guard flag that suppresses `tryDispatch()` for the duration of `abortMessage()`. The notification stays preserved in the queue and is dispatched later on the next natural trigger (e.g., when the user sends a new message) — not as an immediate side-effect of the interrupt.

## Test

Added a test that reproduces the bug: sets up loading=true, enqueues a notification, calls `abortMessage()`, and verifies `sendAIMessage` is NOT called (notification not dispatched during abort) while the notification is still preserved in the queue.