### PR TITLE
chore(desktop): add desktop:install one-click update script

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "desktop:dev": "pnpm -F wave-webview build && pnpm -F wave-desktop run dev",
     "desktop:build": "pnpm -F wave-webview build && pnpm -F wave-desktop run compile",
     "desktop:package": "pnpm -F wave-webview build && pnpm -F wave-desktop run dist",
+    "desktop:install": "pnpm -F wave-webview build && pnpm -F wave-desktop run compile && pnpm -F wave-desktop exec electron-builder --dir && rsync -a --delete packages/desktop/release/mac-arm64/Wave.app/ /Applications/Wave.app/",
     "prepare": "husky"
   },
   "devDependencies": {


### PR DESCRIPTION
## 概述

新增根目录 `desktop:install` 一键更新脚本，用于将本机已安装的 `/Applications/Wave.app` 快速更新到当前代码。

## 改动

- `package.json` 新增 `desktop:install` 脚本：
  1. `pnpm -F wave-webview build` — 构建共享 webview
  2. `pnpm -F wave-desktop run compile` — 编译 desktop 主进程
  3. `pnpm -F wave-desktop exec electron-builder --dir` — 只产出未压缩的 `.app`（跳过 dmg/zip 压缩，约 1 分钟）
  4. `rsync -a --delete` 覆盖 `/Applications/Wave.app/`

## 说明

- **只更新、不重启**：脚本不会 quit 或 relaunch 正在运行的 Wave 实例，重启由用户手动进行。
- 未走 `pnpm run dist -- --dir`：pnpm 会把 `-- --dir` 原样追加，yargs 将 `--` 视为位置参数分隔符导致 `--dir` 被吞掉，故改用 `pnpm -F wave-desktop exec electron-builder --dir`。
