### PR TITLE
fix(desktop): 新对话 Cmd+N 在流式期间可用 — 与侧边栏按钮等效

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -201,9 +201,8 @@ export class DesktopHost {
    */
   onMenuStateChange?: (state: { canNewSession: boolean; canClosePane: boolean }) => void;
 
-  /** 会话 → 新对话 (CmdOrCtrl+N): new session in the focused pane. No-op while it streams. */
+  /** 会话 → 新对话 (CmdOrCtrl+N): new session in the focused pane, same as the sidebar button. */
   async newSessionInFocusedPane(): Promise<void> {
-    if (this.activeAgent?.isStreaming) return;
     await this.handleNewSession(this.focusedPaneId);
   }
 
@@ -454,8 +453,6 @@ export class DesktopHost {
           this.touchSessionInIndex(agentRef);
         }
         this.refreshSessionTree();
-        // 新对话 is disabled while the focused pane streams.
-        this.emitMenuState();
       },
       onCommandRunningChange: (running: boolean) => {
         const paneId = paneIdOf();
@@ -574,7 +571,9 @@ export class DesktopHost {
   /** Menu enablement — index.ts reflects this in the application menu. */
   private emitMenuState(): void {
     this.onMenuStateChange?.({
-      canNewSession: !(this.activeAgent?.isStreaming ?? false),
+      // 新对话 is always available (like the sidebar button) — a streaming
+      // session keeps generating in the background while the pane switches.
+      canNewSession: true,
       // Multiple panes: close removes one. Sole pane: close resets it, which
       // is only meaningful while it still shows a session.
       canClosePane: this.panes.length > 1 || this.panes[0]?.agent != null,

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -1928,14 +1928,20 @@ describe('native menu actions', () => {
     expect(layout.panes[0].sessionId).not.toBe('sess-1');
   });
 
-  it('newSessionInFocusedPane is a no-op while the active agent streams', async () => {
-    const { host } = await readyHost();
-    lastAgent().isStreaming = true;
+  it('newSessionInFocusedPane spawns a new session even while the active agent streams', async () => {
+    const { host, sent } = await readyHost();
+    seedActiveSession('sess-1');
+    const streaming = lastAgent();
+    streaming.isStreaming = true;
     const agentsBefore = h.agentInstances.length;
 
     await host.newSessionInFocusedPane();
 
-    expect(h.agentInstances.length).toBe(agentsBefore);
+    expect(h.agentInstances.length).toBe(agentsBefore + 1);
+    expect(streaming.destroy).not.toHaveBeenCalled();
+    const layout = panePushes(sent).at(-1)!;
+    expect(layout.panes).toHaveLength(1);
+    expect(layout.panes[0].sessionId).not.toBe('sess-1');
   });
 
   it('closeFocusedPane closes the focused pane and keeps its agent alive', async () => {
@@ -1981,18 +1987,21 @@ describe('native menu actions', () => {
     expect(panePushes(sent).length).toBe(pushesBefore);
   });
 
-  it('onMenuStateChange fires on pushPanes and stream toggles with enabled states', async () => {
+  it('onMenuStateChange fires on pushPanes with enabled states, not on stream toggles', async () => {
     const { host } = await readyHost();
     const fn = vi.fn();
     host.onMenuStateChange = fn;
 
+    // Stream toggles don't change menu enablement — 新对话 stays available
+    // while streaming, same as the sidebar button.
     const agent = lastAgent();
     agent.isStreaming = true;
     agent.callbacks.onLoadingChange(true);
-    expect(fn).toHaveBeenLastCalledWith({ canNewSession: false, canClosePane: true });
-
     agent.isStreaming = false;
     agent.callbacks.onLoadingChange(false);
+    expect(fn).not.toHaveBeenCalled();
+
+    seedActiveSession('sess-1');
     expect(fn).toHaveBeenLastCalledWith({ canNewSession: true, canClosePane: true });
 
     await host.handleWebviewMessage({ command: 'desktopOpenPane', workdir: '/work/a', sessionId: 'sess-2' });


### PR DESCRIPTION
## 问题

正在运行的对话（流式中）按 `Cmd+N` 无反应，macOS 菜单栏「会话 → 新对话」置灰；但点击侧边栏「新对话」按钮可以正常新建。

## 原因

菜单/快捷键路径与侧边栏路径不一致：

- `newSessionInFocusedPane()` 在焦点分屏流式时直接 no-op
- `emitMenuState()` 将 `canNewSession` 置为 `!isStreaming`，流式期间菜单项置灰、快捷键随之失效
- 侧边栏按钮发 `clearChat` → `handleNewSession()` 无流式检查：直接 spawn 新 agent 绑定到分屏，旧会话在后台继续生成（agent 池设计本就支持）

spec（`docs/specs/ui/desktop-app.md`）要求 `Cmd+N` 与侧边栏「新对话」按钮等效，这道守卫是 split-view 提交引入的不一致。

## 修改

- `newSessionInFocusedPane()` 删除流式 early-return，与侧边栏同路径
- `emitMenuState()` 的 `canNewSession` 恒为 `true`，菜单项不再置灰
- 移除 `onLoadingChange` 中因此失去意义的 `emitMenuState()` 调用
- 测试：原「流式时 no-op」用例改为断言流式中也能新建会话且旧 agent 不被销毁；菜单状态用例改为断言流式切换不再触发菜单状态变更

## 验证

- `wave-desktop` 全量 203 个测试通过，type-check + lint 通过
- 真机 dev 验证：流式期间 `Cmd+N` 正常开新对话，菜单项可用
