### PR TITLE
fix(webview): 分屏窗格关闭按钮与头部面板开关重叠

### DIFF
--- a/packages/webview/e2e/demo/desktop-split-view.demo.ts
+++ b/packages/webview/e2e/demo/desktop-split-view.demo.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "../utils/desktopTestHarness.js";
+import { MessageInjector } from "../utils/messageInjector.js";
+
+const DIR_A = "/Users/dev/projects/wave-agent";
+
+const initialState = {
+  messages: [],
+  isStreaming: false,
+  sessions: [],
+  isAuthenticated: true,
+  configurationData: {
+    baseURL: "https://api.anthropic.com/v1",
+    model: "claude-sonnet-4-20250514",
+    fastModel: "claude-haiku-4-20250514",
+  },
+  permissionMode: "default",
+};
+
+test.describe("Desktop split-view panes", () => {
+  test("pane close button does not overlap the header panel toggle", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+
+    await webviewPage.setViewportSize({ width: 1280, height: 720 });
+
+    await injector.simulateExtensionMessage("setInitialState", initialState);
+    await injector.simulateExtensionMessage("desktopWorkdirState", {
+      workdir: DIR_A,
+      recentWorkdirs: [DIR_A],
+    });
+    await injector.simulateExtensionMessage("desktopPanes", {
+      panes: [
+        { paneId: "pane-1", sessionId: "sess-a1" },
+        { paneId: "pane-2", sessionId: "sess-a2" },
+      ],
+      focusedPaneId: "pane-1",
+    });
+
+    const pane = webviewPage.getByTestId("desktop-pane-pane-1");
+    const closeButton = webviewPage.getByTestId("desktop-pane-close-pane-1");
+    const panelToggle = pane.getByTestId("panel-toggle-btn");
+    await expect(closeButton).toBeVisible();
+    await expect(panelToggle).toBeVisible();
+
+    // The absolutely-positioned close button must sit in its own reserved
+    // header space, not on top of the right-most header button.
+    const closeBox = await closeButton.boundingBox();
+    const toggleBox = await panelToggle.boundingBox();
+    expect(closeBox).not.toBeNull();
+    expect(toggleBox).not.toBeNull();
+    const intersects =
+      closeBox!.x < toggleBox!.x + toggleBox!.width &&
+      closeBox!.x + closeBox!.width > toggleBox!.x &&
+      closeBox!.y < toggleBox!.y + toggleBox!.height &&
+      closeBox!.y + closeBox!.height > toggleBox!.y;
+    expect(intersects).toBe(false);
+
+    await webviewPage.screenshot({
+      path: "../../docs/public/screenshots/desktop-split-view.png",
+    });
+  });
+});

--- a/packages/webview/src/components/DesktopShell.tsx
+++ b/packages/webview/src/components/DesktopShell.tsx
@@ -340,7 +340,7 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
                   if (el) paneNodes.current.set(pane.paneId, el);
                   else paneNodes.current.delete(pane.paneId);
                 }}
-                className={`desktop-pane${pane.paneId === focusedPaneId ? ' desktop-pane--focused' : ''}`}
+                className={`desktop-pane${pane.paneId === focusedPaneId ? ' desktop-pane--focused' : ''}${panes.length > 1 ? ' desktop-pane--closable' : ''}`}
                 style={paneStyle}
                 onMouseDown={() => handleFocusPane(pane.paneId)}
                 onDragOver={(e) => handlePaneDragOver(e, index)}

--- a/packages/webview/src/styles/DesktopApp.css
+++ b/packages/webview/src/styles/DesktopApp.css
@@ -543,6 +543,12 @@
     pointer-events: none;
 }
 
+/* Multi-pane: reserve top-right header space for the overlay close button so
+   it never covers the header's right-most button (panel toggle). */
+.desktop-pane--closable .chat-header {
+    padding-right: 34px;
+}
+
 .desktop-pane-close {
     position: absolute;
     top: 6px;


### PR DESCRIPTION
## 问题
并排多对话时，.desktop-pane-close 绝对定位在窗格右上角（top:6px right:6px），正好盖住 ChatHeader 最右侧的面板开关按钮，导致面板按钮难以点击且视觉重叠。

## 修复
多窗格（panes.length > 1）时给窗格加 desktop-pane--closable class，为该窗格的 chat-header 预留右侧 34px 空间，关闭按钮独占该区域，不再与头部按钮重叠。单窗格不受影响。

## 测试
- 新增 desktop-split-view demo 测试：并排两窗格，断言关闭按钮与面板开关包围盒不相交（修复前失败、修复后通过），并生成 desktop-split-view.png 截图
- 408 webview 单测 + 29 demo 测试全绿
- type-check / lint 通过