### PR TITLE
feat(desktop): 侧边栏高亮所有分屏展示的会话（焦点强标识，其余弱标识）

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "desktop:dev": "pnpm -F wave-webview build && pnpm -F wave-desktop run dev",
     "desktop:build": "pnpm -F wave-webview build && pnpm -F wave-desktop run compile",
     "desktop:package": "pnpm -F wave-webview build && pnpm -F wave-desktop run dist",
+    "desktop:install": "pnpm -F wave-webview build && pnpm -F wave-desktop run compile && pnpm -F wave-desktop exec electron-builder --dir && rsync -a --delete packages/desktop/release/mac-arm64/Wave.app/ /Applications/Wave.app/",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/webview/src/components/DesktopShell.tsx
+++ b/packages/webview/src/components/DesktopShell.tsx
@@ -97,8 +97,24 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
       const header = paneNodes.current.get(pane.paneId)?.querySelector<HTMLElement>('.chat-header');
       if (!header) return;
       header.draggable = true;
+      // A press that begins on an interactive header child (panel toggle,
+      // popup menu items) must stay a click: any pointer movement during the
+      // press would otherwise start a pane drag and swallow the click.
+      // dragstart is dispatched to the draggable header itself, so the press
+      // target is recorded on mousedown and the drag is vetoed here.
+      let pressTarget: EventTarget | null = null;
+      const onMouseDown = (e: MouseEvent) => {
+        pressTarget = e.target;
+      };
       const onDragStart = (e: DragEvent) => {
         if (!e.dataTransfer) return;
+        if (
+          pressTarget instanceof Element &&
+          pressTarget.closest('button, a, input, select, textarea, [role="button"]')
+        ) {
+          e.preventDefault();
+          return;
+        }
         e.dataTransfer.setData(PANE_DRAG_MIME, JSON.stringify({ paneId: pane.paneId, fromIndex: index }));
         try {
           e.dataTransfer.effectAllowed = 'move';
@@ -107,12 +123,15 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
         }
       };
       const onDragEnd = () => {
+        pressTarget = null;
         dropBoundary.current = null;
         setDropIndicatorX(null);
       };
+      header.addEventListener('mousedown', onMouseDown);
       header.addEventListener('dragstart', onDragStart);
       header.addEventListener('dragend', onDragEnd);
       disposers.push(() => {
+        header.removeEventListener('mousedown', onMouseDown);
         header.removeEventListener('dragstart', onDragStart);
         header.removeEventListener('dragend', onDragEnd);
         header.draggable = false;

--- a/packages/webview/src/components/DesktopShell.tsx
+++ b/packages/webview/src/components/DesktopShell.tsx
@@ -309,6 +309,9 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
   }, [panes, vscode]);
 
   const focusedSessionId = panes.find((p) => p.paneId === focusedPaneId)?.sessionId;
+  // Every session shown in a pane is highlighted in the sidebar — the focused
+  // one strongly (current), the rest weakly. New-session panes carry no id.
+  const visibleSessionIds = panes.map((p) => p.sessionId).filter((id): id is string => id != null);
 
   return (
     <div className="desktop-layout" data-testid="desktop-shell">
@@ -324,6 +327,7 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
         sessionTree={host.sessionTree}
         currentWorkdir={host.workdir}
         currentSessionId={focusedSessionId}
+        visibleSessionIds={visibleSessionIds}
         onSelectSession={host.onSelectSession}
         onOpenPane={handleOpenPane}
         onDeleteSession={host.onDeleteSession}

--- a/packages/webview/src/components/DesktopSidebar.tsx
+++ b/packages/webview/src/components/DesktopSidebar.tsx
@@ -25,6 +25,8 @@ export interface DesktopSidebarProps {
   currentWorkdir?: string;
   /** Active session id — its group defaults to expanded; gets the running dot while streaming. */
   currentSessionId?: string;
+  /** Sessions shown in panes — those other than currentSessionId get a weak highlight. */
+  visibleSessionIds?: string[];
   onSelectSession: (workdir: string, sessionId: string) => void;
   /** Cmd/Ctrl+Click: open the session in an additional pane to the right. */
   onOpenPane: (workdir: string, sessionId: string) => void;
@@ -56,6 +58,7 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
   sessionTree,
   currentWorkdir,
   currentSessionId,
+  visibleSessionIds,
   onSelectSession,
   onOpenPane,
   onDeleteSession,
@@ -90,10 +93,12 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
     // meaningfully "running", and it needs attention more than the running dot.
     const waiting = session.waitingConfirmation ?? false;
     const isCurrent = session.sessionId === currentSessionId;
+    // A session displayed in a non-focused pane gets the weak highlight.
+    const isVisible = !isCurrent && (visibleSessionIds?.includes(session.sessionId) ?? false);
     return (
       <li
         key={session.sessionId}
-        className={`desktop-session-item${isCurrent ? ' desktop-session-item--current' : ''}`}
+        className={`desktop-session-item${isCurrent ? ' desktop-session-item--current' : ''}${isVisible ? ' desktop-session-item--visible' : ''}`}
         draggable
         onDragStart={(e) => {
           // Drag into the chat area opens the session in a new pane (drop on a

--- a/packages/webview/src/styles/DesktopApp.css
+++ b/packages/webview/src/styles/DesktopApp.css
@@ -151,6 +151,11 @@
     color: var(--vscode-list-activeSelectionForeground);
 }
 
+/* Weak counterpart of --current: the session is shown in a non-focused pane. */
+.desktop-session-item--visible {
+    background: var(--vscode-list-inactiveSelectionBackground);
+}
+
 .desktop-session-dot {
     width: 6px;
     height: 6px;

--- a/packages/webview/tests/webview/desktopApp.test.tsx
+++ b/packages/webview/tests/webview/desktopApp.test.tsx
@@ -912,6 +912,35 @@ describe('DesktopApp', () => {
             );
         });
 
+        it('vetoes the pane drag when the press starts on a header button, so buttons stay clickable', () => {
+            renderWithPanes(
+                [{ paneId: 'pane-0', sessionId: 's1' }, { paneId: 'pane-1', sessionId: 's2' }],
+                'pane-0',
+            );
+
+            const pane = screen.getByTestId('desktop-pane-pane-1');
+            const header = within(pane).getByTestId('chat-header');
+            const toggle = within(pane).getByTestId('panel-toggle-btn');
+
+            // Browsers dispatch dragstart at the draggable header even when
+            // the press began on a button inside it; simulate that sequence.
+            fireEvent.mouseDown(toggle);
+            const dataTransfer = makeDataTransfer();
+            const dragStart = createEvent.dragStart(header, { dataTransfer });
+            fireEvent(header, dragStart);
+
+            expect(dataTransfer.getData('application/x-wave-pane')).toBe('');
+            expect(dragStart.defaultPrevented).toBe(true);
+
+            // A press on the header body still drags normally.
+            fireEvent.mouseDown(header);
+            const second = makeDataTransfer();
+            fireEvent.dragStart(header, { dataTransfer: second });
+            expect(second.getData('application/x-wave-pane')).toBe(
+                JSON.stringify({ paneId: 'pane-1', fromIndex: 1 }),
+            );
+        });
+
         it('renders host-pushed pane widths as flex ratios', () => {
             renderWithPanes(
                 [{ paneId: 'pane-0', sessionId: 's1', width: 0.75 }, { paneId: 'pane-1', sessionId: 's2', width: 0.25 }],

--- a/packages/webview/tests/webview/desktopApp.test.tsx
+++ b/packages/webview/tests/webview/desktopApp.test.tsx
@@ -614,6 +614,46 @@ describe('DesktopApp', () => {
             );
         });
 
+        it('highlights every pane-displayed session in the sidebar — focused strong, others weak', () => {
+            renderWithPanes(
+                [{ paneId: 'pane-0', sessionId: 's1' }, { paneId: 'pane-1', sessionId: 's2' }],
+                'pane-0',
+            );
+
+            const s1 = screen.getByTestId('desktop-session-item-s1');
+            const s2 = screen.getByTestId('desktop-session-item-s2');
+            expect(s1.className).toContain('desktop-session-item--current');
+            expect(s1.className).not.toContain('desktop-session-item--visible');
+            expect(s2.className).toContain('desktop-session-item--visible');
+            expect(s2.className).not.toContain('desktop-session-item--current');
+        });
+
+        it('moves the strong sidebar highlight when the focused pane changes', () => {
+            renderWithPanes(
+                [{ paneId: 'pane-0', sessionId: 's1' }, { paneId: 'pane-1', sessionId: 's2' }],
+                'pane-0',
+            );
+            sendCommand('desktopPanes', {
+                panes: [{ paneId: 'pane-0', sessionId: 's1' }, { paneId: 'pane-1', sessionId: 's2' }],
+                focusedPaneId: 'pane-1',
+            });
+
+            expect(screen.getByTestId('desktop-session-item-s1').className).toContain('desktop-session-item--visible');
+            expect(screen.getByTestId('desktop-session-item-s2').className).toContain('desktop-session-item--current');
+        });
+
+        it('does not weak-highlight sessions that no pane displays, nor new-session panes', () => {
+            renderWithPanes([{ paneId: 'pane-0', sessionId: 's1' }, { paneId: 'pane-1' }], 'pane-1');
+
+            const s1 = screen.getByTestId('desktop-session-item-s1');
+            const s2 = screen.getByTestId('desktop-session-item-s2');
+            // Focused pane has no session — nothing gets the strong highlight.
+            expect(s1.className).toContain('desktop-session-item--visible');
+            expect(s1.className).not.toContain('desktop-session-item--current');
+            expect(s2.className).not.toContain('desktop-session-item--visible');
+            expect(s2.className).not.toContain('desktop-session-item--current');
+        });
+
         it('shows a close button per pane only when more than one pane is open', () => {
             renderWithPanes(
                 [{ paneId: 'pane-0', sessionId: 's1' }, { paneId: 'pane-1', sessionId: 's2' }],


### PR DESCRIPTION
## 概述

侧边栏高亮所有正在分屏中展示的会话：焦点分屏强标识（`activeSelection`），其余分屏弱标识（`inactiveSelection`），对齐 spec `docs/specs/ui/desktop-app.md` 的「分屏展示标识」条目。

## 改动

- `DesktopShell`：从所有分屏收集 `visibleSessionIds`（过滤无 sessionId 的新会话分屏）传给侧边栏
- `DesktopSidebar`：新增 `visibleSessionIds` prop，非焦点的在屏会话加 `desktop-session-item--visible` 弱高亮
- `DesktopApp.css`：`.desktop-session-item--visible` 使用 `--vscode-list-inactiveSelectionBackground`（dark/light 主题均已定义）

## 测试

- 新增 3 条 webview 测试：双分屏强弱标识、焦点切换后强标识移动、未展示会话/新会话分屏无高亮
- `desktopApp.test.tsx` 62 条全过；type-check + lint 通过
