### PR TITLE
fix(agent-sdk): ripgrep exit 2 保留部分结果；desktop:install 脚本与分屏拖拽 veto

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "desktop:dev": "pnpm -F wave-webview build && pnpm -F wave-desktop run dev",
     "desktop:build": "pnpm -F wave-webview build && pnpm -F wave-desktop run compile",
     "desktop:package": "pnpm -F wave-webview build && pnpm -F wave-desktop run dist",
+    "desktop:install": "pnpm -F wave-webview build && pnpm -F wave-desktop run compile && pnpm -F wave-desktop exec electron-builder --dir && rsync -a --delete packages/desktop/release/mac-arm64/Wave.app/ /Applications/Wave.app/",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/agent-sdk/src/tools/grepTool.ts
+++ b/packages/agent-sdk/src/tools/grepTool.ts
@@ -2,6 +2,7 @@ import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
 import { spawn } from "child_process";
 import { rgPath } from "../utils/ripgrep.js";
 import { getDisplayPath } from "../utils/path.js";
+import { logger } from "../utils/globalLogger.js";
 import {
   GREP_TOOL_NAME,
   BASH_TOOL_NAME,
@@ -235,13 +236,21 @@ export const grepTool: ToolPlugin = {
 
       const result = await executeCommand(rgPath, rgArgs, workdir);
 
-      if (result.error && result.exitCode !== 1) {
-        // rg returns 1 for no matches, not an error
+      // Only a process-level spawn failure (exitCode null) is a hard error.
+      // rg exit 2 means some files were unreadable (e.g. device-name files
+      // like "nul" on Windows); stdout still holds usable partial results.
+      if (result.exitCode === null) {
         return {
           success: false,
           content: "",
           error: `ripgrep failed: ${result.stderr}`,
         };
+      }
+
+      if (result.exitCode !== 0 && result.exitCode !== 1) {
+        logger.debug(
+          `ripgrep exited with code ${result.exitCode}, keeping partial results: ${result.stderr.trim()}`,
+        );
       }
 
       const output = result.stdout.trim();

--- a/packages/agent-sdk/src/utils/fileSearch.ts
+++ b/packages/agent-sdk/src/utils/fileSearch.ts
@@ -34,9 +34,13 @@ async function getAllFiles(workingDirectory: string): Promise<string[]> {
     });
 
     child.on("close", (code) => {
+      // Exit 2 = some files were unreadable (e.g. device-name files like
+      // "nul" on Windows); stdout still holds usable partial results.
+      // Spawn failures surface via the 'error' listener instead.
       if (code !== 0 && code !== 1) {
-        reject(new Error(`ripgrep failed: ${stderr}`));
-        return;
+        logger.warn(
+          `ripgrep exited with code ${code}, keeping partial results: ${stderr.trim()}`,
+        );
       }
       const files = stdout
         .trim()

--- a/packages/agent-sdk/tests/tools/grepTool.test.ts
+++ b/packages/agent-sdk/tests/tools/grepTool.test.ts
@@ -463,6 +463,48 @@ src/index.ts-3-  return new Application();
     expect(result.shortResult).toBe("No matches found");
   });
 
+  it("should return partial results when ripgrep exits with code 2", async () => {
+    // rg exit 2 = some files were unreadable (e.g. a file named "nul" on
+    // Windows), but stdout still holds matches from the remaining files.
+    const stdout = "src/index.ts\nsrc/utils.ts\n";
+    const stderr = "rg: .\\nul: Incorrect function. (os error 1)";
+    mockSpawn.mockReturnValueOnce(
+      createMockProcess(stdout, stderr, 2) as ChildProcess,
+    );
+
+    const result = await grepTool.execute(
+      {
+        pattern: "export",
+        output_mode: "files_with_matches",
+      },
+      testContext,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.content).toContain("src/index.ts");
+    expect(result.content).toContain("src/utils.ts");
+  });
+
+  it("should report no matches when ripgrep exits with code 2 and empty output", async () => {
+    mockSpawn.mockReturnValueOnce(
+      createMockProcess(
+        "",
+        "rg: .\\nul: Incorrect function. (os error 1)",
+        2,
+      ) as ChildProcess,
+    );
+
+    const result = await grepTool.execute(
+      {
+        pattern: "export",
+      },
+      testContext,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.shortResult).toBe("No matches found");
+  });
+
   it("should return error for missing pattern", async () => {
     const result = await grepTool.execute({}, testContext);
 

--- a/packages/agent-sdk/tests/utils/fileSearch.test.ts
+++ b/packages/agent-sdk/tests/utils/fileSearch.test.ts
@@ -185,4 +185,29 @@ describe("searchFiles", () => {
     const results = await searchFiles("query");
     expect(results).toEqual([]);
   });
+
+  it("should keep partial results when ripgrep exits with code 2", async () => {
+    // rg exit 2 = some files were unreadable (e.g. a file named "nul" on
+    // Windows), but stdout still holds the files it could walk.
+    const mockProcess = new EventEmitter() as unknown as ReturnType<
+      typeof spawn
+    >;
+    const mockStdout = new EventEmitter();
+    const mockStderr = new EventEmitter();
+    Object.defineProperty(mockProcess, "stdout", { value: mockStdout });
+    Object.defineProperty(mockProcess, "stderr", { value: mockStderr });
+    vi.mocked(spawn).mockReturnValue(mockProcess);
+
+    setTimeout(() => {
+      mockStdout.emit("data", Buffer.from("src/index.ts\nsrc/utils.ts"));
+      mockStderr.emit(
+        "data",
+        Buffer.from("rg: .\\nul: Incorrect function. (os error 1)"),
+      );
+      mockProcess.emit("close", 2);
+    }, 10);
+
+    const results = await searchFiles("index");
+    expect(results.some((r) => r.path === "src/index.ts")).toBe(true);
+  });
 });

--- a/packages/webview/src/components/DesktopShell.tsx
+++ b/packages/webview/src/components/DesktopShell.tsx
@@ -97,8 +97,24 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
       const header = paneNodes.current.get(pane.paneId)?.querySelector<HTMLElement>('.chat-header');
       if (!header) return;
       header.draggable = true;
+      // A press that begins on an interactive header child (panel toggle,
+      // popup menu items) must stay a click: any pointer movement during the
+      // press would otherwise start a pane drag and swallow the click.
+      // dragstart is dispatched to the draggable header itself, so the press
+      // target is recorded on mousedown and the drag is vetoed here.
+      let pressTarget: EventTarget | null = null;
+      const onMouseDown = (e: MouseEvent) => {
+        pressTarget = e.target;
+      };
       const onDragStart = (e: DragEvent) => {
         if (!e.dataTransfer) return;
+        if (
+          pressTarget instanceof Element &&
+          pressTarget.closest('button, a, input, select, textarea, [role="button"]')
+        ) {
+          e.preventDefault();
+          return;
+        }
         e.dataTransfer.setData(PANE_DRAG_MIME, JSON.stringify({ paneId: pane.paneId, fromIndex: index }));
         try {
           e.dataTransfer.effectAllowed = 'move';
@@ -107,12 +123,15 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
         }
       };
       const onDragEnd = () => {
+        pressTarget = null;
         dropBoundary.current = null;
         setDropIndicatorX(null);
       };
+      header.addEventListener('mousedown', onMouseDown);
       header.addEventListener('dragstart', onDragStart);
       header.addEventListener('dragend', onDragEnd);
       disposers.push(() => {
+        header.removeEventListener('mousedown', onMouseDown);
         header.removeEventListener('dragstart', onDragStart);
         header.removeEventListener('dragend', onDragEnd);
         header.draggable = false;

--- a/packages/webview/tests/webview/desktopApp.test.tsx
+++ b/packages/webview/tests/webview/desktopApp.test.tsx
@@ -912,6 +912,35 @@ describe('DesktopApp', () => {
             );
         });
 
+        it('vetoes the pane drag when the press starts on a header button, so buttons stay clickable', () => {
+            renderWithPanes(
+                [{ paneId: 'pane-0', sessionId: 's1' }, { paneId: 'pane-1', sessionId: 's2' }],
+                'pane-0',
+            );
+
+            const pane = screen.getByTestId('desktop-pane-pane-1');
+            const header = within(pane).getByTestId('chat-header');
+            const toggle = within(pane).getByTestId('panel-toggle-btn');
+
+            // Browsers dispatch dragstart at the draggable header even when
+            // the press began on a button inside it; simulate that sequence.
+            fireEvent.mouseDown(toggle);
+            const dataTransfer = makeDataTransfer();
+            const dragStart = createEvent.dragStart(header, { dataTransfer });
+            fireEvent(header, dragStart);
+
+            expect(dataTransfer.getData('application/x-wave-pane')).toBe('');
+            expect(dragStart.defaultPrevented).toBe(true);
+
+            // A press on the header body still drags normally.
+            fireEvent.mouseDown(header);
+            const second = makeDataTransfer();
+            fireEvent.dragStart(header, { dataTransfer: second });
+            expect(second.getData('application/x-wave-pane')).toBe(
+                JSON.stringify({ paneId: 'pane-1', fromIndex: 1 }),
+            );
+        });
+
         it('renders host-pushed pane widths as flex ratios', () => {
             renderWithPanes(
                 [{ paneId: 'pane-0', sessionId: 's1', width: 0.75 }, { paneId: 'pane-1', sessionId: 's2', width: 0.25 }],


### PR DESCRIPTION
## 改动

本分支相对 main 含 3 个提交：

- **fix(agent-sdk): ripgrep exit 2 时保留部分搜索结果，对齐 Claude Code** — Windows 下目录中存在 `nul` 等保留设备名文件时，rg 报 "Incorrect function (os error 1)" 并以退出码 2 结束；此前 grepTool/fileSearch 将其判为整体失败并丢弃 stdout 中已搜到的结果。改为仅进程级 spawn 失败（exitCode null）才报错，exit 2 保留部分结果并写日志，与 Claude Code `ripGrep()` 的处理分级一致。新增 3 个测试（先写失败测试复现再修）。
- **chore(desktop): add desktop:install one-click update script** — 一键更新已安装桌面应用的脚本（只更新文件，不退出用户正在运行的 Wave）。
- **fix(webview): keep desktop header buttons clickable by vetoing pane drags from interactive presses** — 拖拽源祖先上的按钮按下时 veto dragstart，保持头部按钮可点击。

## 验证

- agent-sdk 全量 240 文件 3332 测试通过；build / lint / type-check / prettier 干净，dist 已重建