### PR TITLE
fix(webview): keep header title as first user message after compaction

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -429,6 +429,7 @@ export class DesktopHost {
               workdir: agentRef.workingDirectory,
               lastActiveAt: new Date(),
               latestTotalTokens: agentRef.latestTotalTokens ?? 0,
+              firstMessage: this.configStore.getSessionIndex().find((e) => e.sessionId === sessionId)?.title || undefined,
             } as SessionMetadata,
           });
           this.pushPanes();
@@ -939,6 +940,10 @@ export class DesktopHost {
         workdir: agent.workingDirectory,
         lastActiveAt: new Date(),
         latestTotalTokens: agent.latestTotalTokens,
+        // Backfill the header title from the session index: after compaction
+        // the pushed messages start at the compact boundary, so the webview
+        // can no longer derive the first user message itself.
+        firstMessage: this.configStore.getSessionIndex().find((e) => e.sessionId === agent.sessionId)?.title || undefined,
       } : undefined,
       configurationData,
       pendingConfirmations,

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -464,6 +464,28 @@ describe('agent notifications', () => {
     expect(sessionsAfter.find((s) => s.sessionId === 'sess-1')?.title).toBe('x'.repeat(30) + '...');
   });
 
+  it('setInitialState backfills session.firstMessage from the index after compaction truncated the messages', async () => {
+    const { host, sent } = await readyHost();
+    const agent = lastAgent();
+
+    // First user message establishes the index title (same as the sidebar).
+    const userMsg = { id: 'u1', role: 'user', blocks: [{ type: 'text', content: '帮我重构登录模块' }] };
+    agent.messages = [userMsg];
+    agent.callbacks.onUserMessageAdded(userMsg);
+
+    // Compaction truncates the agent's message list to the compact boundary,
+    // so a re-pushed pane state can no longer derive the title from messages.
+    agent.messages = [{ id: 'c1', role: 'assistant', blocks: [{ type: 'compact', content: '对话摘要' }] }];
+    agent.callbacks.onCompactBlockAdded('对话摘要');
+
+    await host.handleWebviewMessage({ command: 'webviewReady' });
+
+    expect(sent('setInitialState').at(-1)?.session).toMatchObject({
+      id: 'sess-1',
+      firstMessage: '帮我重构登录模块',
+    });
+  });
+
   it('restoring a historical session backfills its sidebar title from history (FR-024)', async () => {
     const { host, store, sent } = await readyHost();
     store.upsertSession({ sessionId: 'hist-1', title: '', workdir: '/work/a', cwd: '/work/a', lastActiveAt: 1 });

--- a/packages/webview/src/reducers/chatReducer.ts
+++ b/packages/webview/src/reducers/chatReducer.ts
@@ -1,5 +1,5 @@
 import type { ChatState, ChatAction, Message, MessageBlock, TextBlock, ToolBlock, ErrorBlock } from '../types';
-import { firstUserMessageText } from '../utils/session';
+import { pinSessionTitle } from '../utils/session';
 
 export const initialState: ChatState = {
   messages: [],
@@ -36,21 +36,10 @@ export const initialState: ChatState = {
 export function chatReducer(state: ChatState, action: ChatAction): ChatState {
   switch (action.type) {
     case 'SET_MESSAGES': {
-      let currentSession = state.currentSession;
-      // Pin the header title while the first user message is still in the
-      // list — compaction later truncates it to [compact, ...tail rounds]
-      // (assistant-only), so derivation after the fact comes up empty and the
-      // header would fall back to the default title.
-      if (currentSession && !currentSession.firstMessage) {
-        const derived = firstUserMessageText(action.payload);
-        if (derived) {
-          currentSession = { ...currentSession, firstMessage: derived };
-        }
-      }
       return {
         ...state,
         messages: action.payload,
-        currentSession
+        currentSession: pinSessionTitle(state.currentSession, action.payload)
       };
     }
     case 'SET_TASKS':
@@ -185,7 +174,12 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
         isStreaming: action.payload.isStreaming !== undefined ? action.payload.isStreaming : state.isStreaming,
         isCommandRunning: action.payload.isCommandRunning !== undefined ? action.payload.isCommandRunning : state.isCommandRunning,
         sessions: action.payload.sessions || state.sessions || [],
-        currentSession: action.payload.currentSession || state.currentSession,
+        // Re-pin from the same-snapshot messages: hosts re-push the session
+        // object without firstMessage on pane/webview re-init.
+        currentSession: pinSessionTitle(
+          action.payload.currentSession || state.currentSession,
+          action.payload.messages
+        ),
         configurationData: action.payload.configurationData || state.configurationData,
         pendingConfirmations: action.payload.pendingConfirmations || [],
         queuedMessages: action.payload.queuedMessages || [],
@@ -233,11 +227,17 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
         workdir: action.payload
       };
     // Incremental update actions for streaming optimization
-    case 'APPEND_MESSAGE':
+    case 'APPEND_MESSAGE': {
+      const messages = [...state.messages, action.payload];
       return {
         ...state,
-        messages: [...state.messages, action.payload]
+        messages,
+        // Hosts that deliver user messages incrementally (desktop, VSCE) never
+        // route them through SET_MESSAGES, so the title pin must happen here
+        // too — otherwise compaction wipes the derivation material.
+        currentSession: pinSessionTitle(state.currentSession, messages)
       };
+    }
     case 'UPDATE_STREAMING_CONTENT': {
       const { messageId, accumulated, stage } = action.payload;
       const messageIndex = state.messages.findIndex(m => m.id === messageId);

--- a/packages/webview/src/utils/session.ts
+++ b/packages/webview/src/utils/session.ts
@@ -34,6 +34,22 @@ export const formatSessionLabel = (session: SessionMetadata): string => {
 };
 
 /**
+ * Pin the session title from the first user message while it is still in the
+ * message list. Compaction later truncates the list to [compact, ...tail
+ * rounds] (assistant-only), so deriving after the fact comes up empty and the
+ * header would fall back to the default title. An already-set firstMessage
+ * always wins.
+ */
+export const pinSessionTitle = (
+  currentSession: SessionMetadata | undefined,
+  messages?: Message[],
+): SessionMetadata | undefined => {
+  if (!currentSession || currentSession.firstMessage) return currentSession;
+  const derived = firstUserMessageText(messages);
+  return derived ? { ...currentSession, firstMessage: derived } : currentSession;
+};
+
+/**
  * Resolve the header title for the active session. The backend pushes a
  * currentSession without a firstMessage on creation, so once the user sends a
  * message we derive the title from the message list instead of leaving it stuck

--- a/packages/webview/tests/reducers/chatReducer.test.ts
+++ b/packages/webview/tests/reducers/chatReducer.test.ts
@@ -41,6 +41,82 @@ describe('chatReducer', () => {
       expect(newState.messages).toHaveLength(1);
       expect(newState.messages[0]).toBe(newMessage);
     });
+
+    it('should pin currentSession.firstMessage when the first user message arrives incrementally', () => {
+      const currentSession: SessionMetadata = {
+        id: 's1',
+        sessionType: 'main',
+        workdir: '/w',
+        createdAt: new Date(0),
+        lastActiveAt: new Date(0),
+        latestTotalTokens: 0
+      };
+      const state = { ...initialState, currentSession };
+
+      const newState = chatReducer(state, {
+        type: 'APPEND_MESSAGE',
+        payload: { id: 'u1', role: 'user', timestamp: '0', blocks: [{ type: 'text', content: '帮我重构登录模块' }] }
+      });
+
+      expect(newState.currentSession?.firstMessage).toBe('帮我重构登录模块');
+    });
+
+    it('should keep the title pinned via APPEND_MESSAGE after compaction truncates the list', () => {
+      // Desktop sequence: session pushed without firstMessage, user/assistant
+      // messages arrive incrementally, then compaction pushes the truncated
+      // list ([assistant(compact), ...assistant-only tail]).
+      const currentSession: SessionMetadata = {
+        id: 's1',
+        sessionType: 'main',
+        workdir: '/w',
+        createdAt: new Date(0),
+        lastActiveAt: new Date(0),
+        latestTotalTokens: 0
+      };
+      let state: typeof initialState = { ...initialState, currentSession };
+
+      state = chatReducer(state, {
+        type: 'APPEND_MESSAGE',
+        payload: { id: 'u1', role: 'user', timestamp: '0', blocks: [{ type: 'text', content: '帮我重构登录模块' }] }
+      });
+      state = chatReducer(state, {
+        type: 'APPEND_MESSAGE',
+        payload: { id: 'a1', role: 'assistant', timestamp: '0', blocks: [{ type: 'text', content: '好的' }] }
+      });
+
+      const compacted = chatReducer(state, {
+        type: 'SET_MESSAGES',
+        payload: [
+          { id: 'c1', role: 'assistant', timestamp: '0', blocks: [{ type: 'compact', content: '对话摘要' }] },
+          { id: 'a2', role: 'assistant', timestamp: '0', blocks: [{ type: 'text', content: '继续' }] }
+        ]
+      });
+
+      expect(compacted.currentSession?.firstMessage).toBe('帮我重构登录模块');
+    });
+
+    it('should not pin firstMessage from appended assistant or meta messages', () => {
+      const currentSession: SessionMetadata = {
+        id: 's1',
+        sessionType: 'main',
+        workdir: '/w',
+        createdAt: new Date(0),
+        lastActiveAt: new Date(0),
+        latestTotalTokens: 0
+      };
+      let state: typeof initialState = { ...initialState, currentSession };
+
+      state = chatReducer(state, {
+        type: 'APPEND_MESSAGE',
+        payload: { id: 'm1', role: 'user', timestamp: '0', isMeta: true, blocks: [{ type: 'text', content: '系统提醒' }] }
+      });
+      state = chatReducer(state, {
+        type: 'APPEND_MESSAGE',
+        payload: { id: 'a1', role: 'assistant', timestamp: '0', blocks: [{ type: 'text', content: '好的' }] }
+      });
+
+      expect(state.currentSession?.firstMessage).toBeUndefined();
+    });
   });
 
   describe('UPDATE_STREAMING_CONTENT', () => {
@@ -677,6 +753,63 @@ describe('chatReducer', () => {
       const newState = chatReducer(state, { type: 'SET_CURRENT_SESSION', payload: undefined });
 
       expect(newState.currentSession).toBeUndefined();
+    });
+  });
+
+  describe('SET_INITIAL_STATE', () => {
+    it('should pin firstMessage from the initial messages when the pushed session lacks it', () => {
+      // Desktop re-pushes pane state (setInitialState) with a session object
+      // that never carries firstMessage; the title must be re-derived from the
+      // same-snapshot messages so a pane switch does not drop the pinned title.
+      const newState = chatReducer(initialState, {
+        type: 'SET_INITIAL_STATE',
+        payload: {
+          messages: [
+            { id: 'u1', role: 'user', timestamp: '0', blocks: [{ type: 'text', content: '帮我重构登录模块' }] },
+            { id: 'a1', role: 'assistant', timestamp: '0', blocks: [{ type: 'text', content: '好的' }] }
+          ],
+          sessions: [],
+          currentSession: {
+            id: 's1',
+            sessionType: 'main',
+            workdir: '/w',
+            createdAt: new Date(0),
+            lastActiveAt: new Date(0),
+            latestTotalTokens: 0
+          },
+          configurationData: {} as any,
+          pendingConfirmations: [],
+          isStreaming: false,
+        },
+      });
+
+      expect(newState.currentSession?.firstMessage).toBe('帮我重构登录模块');
+    });
+
+    it('should not overwrite a firstMessage already present on the pushed session', () => {
+      const newState = chatReducer(initialState, {
+        type: 'SET_INITIAL_STATE',
+        payload: {
+          messages: [
+            { id: 'u1', role: 'user', timestamp: '0', blocks: [{ type: 'text', content: '新首条消息' }] }
+          ],
+          sessions: [],
+          currentSession: {
+            id: 's1',
+            sessionType: 'main',
+            firstMessage: '原始标题',
+            workdir: '/w',
+            createdAt: new Date(0),
+            lastActiveAt: new Date(0),
+            latestTotalTokens: 0
+          },
+          configurationData: {} as any,
+          pendingConfirmations: [],
+          isStreaming: false,
+        },
+      });
+
+      expect(newState.currentSession?.firstMessage).toBe('原始标题');
     });
   });
 


### PR DESCRIPTION
## 问题

对话自动压缩后，顶部标题回退为"新对话"。

**根因**：标题固定（`currentSession.firstMessage`）只在 `SET_MESSAGES` 路径执行，但 desktop/VSCE 通过 `APPEND_MESSAGE` 增量投递用户消息，固定逻辑从未触发。压缩把消息列表截断为纯 assistant 消息后，`getSessionTitle()` 无从推导，回退默认标题。

## 修复

- `packages/webview/src/utils/session.ts`：抽取 `pinSessionTitle()` 公共逻辑（已固定则不覆盖）
- `packages/webview/src/reducers/chatReducer.ts`：在 `APPEND_MESSAGE`（首条真实用户消息到达时固定，跳过 meta/assistant）和 `SET_INITIAL_STATE`（webview 重新初始化）中应用固定
- `packages/desktop/src/main/desktopHost.ts`：`pushPaneSessionState` 与 `onSessionIdChange` 推送会话对象时从会话索引回填 `firstMessage`，保证压缩后跨面板状态重推标题仍保留

## 测试

- `chatReducer.test.ts`：增量首条用户消息固定标题；压缩截断后标题保持；assistant/meta 消息不触发固定；SET_INITIAL_STATE 固定（含不覆盖已有 firstMessage）
- `desktopHost.test.ts`：压缩截断消息后 setInitialState 仍从索引回填 `session.firstMessage`

验证：webview 417/417、desktop 204/204、两包 type-check 通过。