### PR TITLE
fix(webview): 修复分割线/网络图片/mermaid 暗色/输入框边框 4 个渲染问题

### DIFF
--- a/packages/vsce/src/session/webviewManager.ts
+++ b/packages/vsce/src/session/webviewManager.ts
@@ -144,7 +144,7 @@ export class WebviewManager {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src ${webview.cspSource} data: blob:; img-src ${webview.cspSource} data: blob:; style-src ${webview.cspSource} 'unsafe-inline'; script-src ${webview.cspSource}; font-src ${webview.cspSource} data:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src ${webview.cspSource} data: blob:; img-src ${webview.cspSource} data: blob: https: http:; style-src ${webview.cspSource} 'unsafe-inline'; script-src ${webview.cspSource}; font-src ${webview.cspSource} data:;">
     <title>Wave AI Chat</title>
     <link rel="stylesheet" href="${cssUri}">
 </head>

--- a/packages/webview/src/components/MermaidRenderer.tsx
+++ b/packages/webview/src/components/MermaidRenderer.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import mermaid from 'mermaid';
+import { isDarkTheme } from '../utils/theme';
 import '../styles/MermaidRenderer.css';
 
 interface MermaidRendererProps {
@@ -16,7 +17,59 @@ interface FullscreenModalProps {
   vscode: { postMessage: (msg: unknown) => void };
 }
 
-let mermaidInitialized = false;
+let currentMermaidTheme: 'default' | 'dark' | null = null;
+
+// (Re-)initialize mermaid for the current host theme. Mermaid colors are baked into the
+// SVG at render time, so the theme must be set before mermaid.render() runs.
+const initMermaidForTheme = () => {
+  const theme = isDarkTheme() ? 'dark' : 'default';
+  if (currentMermaidTheme === theme) return;
+  try {
+    mermaid.initialize({
+      startOnLoad: false,
+      theme,
+      securityLevel: 'strict',
+      htmlLabels: false,
+      fontFamily: 'var(--vscode-font-family, monospace)',
+      deterministicIds: true,
+      deterministicIDSeed: 'wave-vscode',
+      flowchart: {
+        useMaxWidth: true,
+        htmlLabels: false,
+        curve: 'basis'
+      },
+      sequence: {
+        useMaxWidth: true,
+        wrap: true,
+        showSequenceNumbers: true
+      },
+      gantt: {
+        useMaxWidth: true,
+        leftPadding: 75,
+        gridLineStartPadding: 35
+      },
+      class: {
+        useMaxWidth: true
+      },
+      state: {
+        useMaxWidth: true
+      },
+      pie: {
+        useMaxWidth: true
+      },
+      logLevel: 'error',
+      suppressErrorRendering: true,
+      maxTextSize: 50000,
+      maxEdges: 500,
+      dompurifyConfig: {
+        USE_PROFILES: { html: true }
+      }
+    });
+    currentMermaidTheme = theme;
+  } catch (err) {
+    console.error('Failed to initialize mermaid:', err);
+  }
+};
 
 // Clean and validate mermaid syntax
 const cleanMermaidSyntax = (content: string): string => {
@@ -245,56 +298,17 @@ export const MermaidRenderer: React.FC<MermaidRendererProps> = ({ content, class
   const renderTimeoutRef = useRef<NodeJS.Timeout>();
   const cleanedContent = useRef<string>('');
   const lastRenderedContent = useRef<string>(''); // Track what was last rendered
+  // Bumped when the host theme flips (VS Code body class, desktop/JB <html data-theme>),
+  // so the diagram re-renders with matching mermaid colors.
+  const [themeVersion, setThemeVersion] = useState(0);
 
-  // Initialize mermaid configuration once
   useEffect(() => {
-    if (!mermaidInitialized) {
-      try {
-        mermaid.initialize({
-          startOnLoad: false,
-          theme: 'default',
-          securityLevel: 'strict',
-          htmlLabels: false,
-          fontFamily: 'var(--vscode-font-family, monospace)',
-          deterministicIds: true,
-          deterministicIDSeed: 'wave-vscode',
-          flowchart: {
-            useMaxWidth: true,
-            htmlLabels: false,
-            curve: 'basis'
-          },
-          sequence: {
-            useMaxWidth: true,
-            wrap: true,
-            showSequenceNumbers: true
-          },
-          gantt: {
-            useMaxWidth: true,
-            leftPadding: 75,
-            gridLineStartPadding: 35
-          },
-          class: {
-            useMaxWidth: true
-          },
-          state: {
-            useMaxWidth: true
-          },
-          pie: {
-            useMaxWidth: true
-          },
-          logLevel: 'error',
-          suppressErrorRendering: true,
-          maxTextSize: 50000,
-          maxEdges: 500,
-          dompurifyConfig: {
-            USE_PROFILES: { html: true }
-          }
-        });
-        mermaidInitialized = true;
-      } catch (err) {
-        console.error('Failed to initialize mermaid:', err);
-      }
+    const observer = new MutationObserver(() => setThemeVersion(v => v + 1));
+    if (document.body) {
+      observer.observe(document.body, { attributes: true, attributeFilter: ['class'] });
     }
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+    return () => observer.disconnect();
   }, []);
 
   // Clean content when it changes
@@ -309,6 +323,7 @@ export const MermaidRenderer: React.FC<MermaidRendererProps> = ({ content, class
 
     setIsRendering(true);
     setError(null);
+    initMermaidForTheme();
     
     try {
       // Generate a new unique ID for each render to avoid conflicts
@@ -369,6 +384,12 @@ export const MermaidRenderer: React.FC<MermaidRendererProps> = ({ content, class
     }
   }, []);
 
+  // Force re-render when host theme flips
+  useEffect(() => {
+    lastRenderedContent.current = '';
+    setSvgContent('');
+  }, [themeVersion]);
+
   // Render mermaid diagram when switching to preview or content changes
   useEffect(() => {
     if (activeTab === 'preview' && cleanedContent.current.trim()) {
@@ -405,7 +426,7 @@ export const MermaidRenderer: React.FC<MermaidRendererProps> = ({ content, class
         clearTimeout(renderTimeoutRef.current);
       }
     };
-  }, [activeTab, content, svgContent, renderMermaid]);
+  }, [activeTab, content, svgContent, themeVersion, renderMermaid]);
 
   // Update DOM when SVG content changes
   useEffect(() => {

--- a/packages/webview/src/components/Message.tsx
+++ b/packages/webview/src/components/Message.tsx
@@ -78,11 +78,11 @@ const parseMarkdownWithMermaid = (content: string): ParsedMarkdownContent => {
       const html = marked.parse(part);
       const sanitizedHtml = DOMPurify.sanitize(html, {
         ALLOWED_TAGS: [
-          'p', 'br', 'strong', 'b', 'em', 'i', 'code', 'pre', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 
-          'ul', 'ol', 'li', 'a', 'blockquote',
+          'p', 'br', 'strong', 'b', 'em', 'i', 'code', 'pre', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+          'ul', 'ol', 'li', 'a', 'blockquote', 'hr', 'img',
           'table', 'thead', 'tbody', 'tr', 'th', 'td', 'del', 'input'
         ],
-        ALLOWED_ATTR: ['href', 'title', 'align', 'type', 'checked', 'disabled', 'class'],
+        ALLOWED_ATTR: ['href', 'title', 'align', 'type', 'checked', 'disabled', 'class', 'src', 'alt'],
         ALLOW_DATA_ATTR: false,
         FORBID_ATTR: [],
         FORBID_TAGS: []

--- a/packages/webview/src/styles/MermaidRenderer.css
+++ b/packages/webview/src/styles/MermaidRenderer.css
@@ -116,18 +116,6 @@
   background: transparent;
 }
 
-/* Dark theme adjustments for mermaid diagrams */
-.vscode-dark .mermaid-container svg {
-  filter: invert(1) hue-rotate(180deg);
-}
-
-.vscode-dark .mermaid-container svg .node rect,
-.vscode-dark .mermaid-container svg .node circle,
-.vscode-dark .mermaid-container svg .node ellipse,
-.vscode-dark .mermaid-container svg .node polygon {
-  filter: invert(1) hue-rotate(180deg);
-}
-
 /* Source Tab Styles */
 .mermaid-source {
   padding: 0;

--- a/packages/webview/src/styles/Message.css
+++ b/packages/webview/src/styles/Message.css
@@ -826,6 +826,19 @@
     line-height: 1.5;
 }
 
+/* Markdown horizontal rule (---) */
+.markdown-content hr {
+    border: none;
+    border-top: 1px solid var(--vscode-panel-border, var(--vscode-widget-border, rgba(128, 128, 128, 0.35)));
+    margin: 12px 0;
+}
+
+/* Markdown images: keep inside the message bubble */
+.markdown-content img {
+    max-width: 100%;
+    height: auto;
+}
+
 /* Markdown Tables */
 .markdown-content table {
     border-collapse: collapse;

--- a/packages/webview/src/styles/MessageInput.css
+++ b/packages/webview/src/styles/MessageInput.css
@@ -25,7 +25,9 @@
     display: flex;
     flex-direction: column;
     background-color: var(--vscode-input-background);
-    border: 1px solid var(--vscode-input-border);
+    /* Some themes (e.g. Visual Studio Light) don't define input.border, which would
+       invalidate the whole shorthand — fall back through other border vars. */
+    border: 1px solid var(--vscode-input-border, var(--vscode-panel-border, var(--vscode-widget-border, rgba(128, 128, 128, 0.4))));
     border-radius: 6px;
     max-height: 176px;
 }

--- a/packages/webview/src/utils/theme.ts
+++ b/packages/webview/src/utils/theme.ts
@@ -1,0 +1,17 @@
+/**
+ * Cross-host dark theme detection.
+ * - VS Code webview: the host sets vscode-dark / vscode-light / vscode-high-contrast(-light)
+ *   classes on <body>.
+ * - Desktop / JetBrains: <html data-theme="dark|light"> (desktop preload; JB injects it in
+ *   WebviewContentBuilder).
+ */
+export const isDarkTheme = (): boolean => {
+    const bodyClass = document.body?.classList;
+    if (bodyClass?.contains('vscode-dark') || bodyClass?.contains('vscode-high-contrast')) {
+        return true;
+    }
+    if (bodyClass?.contains('vscode-light') || bodyClass?.contains('vscode-high-contrast-light')) {
+        return false;
+    }
+    return document.documentElement.getAttribute('data-theme') === 'dark';
+};

--- a/packages/webview/tests/webview/markdownSanitize.test.tsx
+++ b/packages/webview/tests/webview/markdownSanitize.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { Message } from '../../src/components/Message';
+import { MockDataGenerator } from '../fixtures/mockData';
+
+// Mermaid is heavy and irrelevant here; stub it out. DOMPurify must stay REAL so
+// these tests exercise the actual sanitize whitelist in Message.tsx.
+vi.mock('mermaid', () => ({
+    default: {
+        initialize: vi.fn(),
+        render: vi.fn().mockResolvedValue({ svg: '<svg></svg>', bindFunctions: vi.fn() }),
+    },
+}));
+
+function renderAssistantMessage(content: string) {
+    const vscode = { postMessage: vi.fn(), getState: vi.fn(), setState: vi.fn() };
+    const message = MockDataGenerator.createAssistantMessage(content);
+    return render(<Message message={message} vscode={vscode} />);
+}
+
+describe('markdown sanitize whitelist', () => {
+    it('renders --- as an <hr> divider', () => {
+        const { container } = renderAssistantMessage('before\n\n---\n\nafter');
+        expect(container.querySelector('.markdown-content hr')).not.toBeNull();
+    });
+
+    it('renders a remote image with src and alt preserved', () => {
+        const { container } = renderAssistantMessage('look ![架构图](https://example.com/arch.png) here');
+        const img = container.querySelector('.markdown-content img');
+        expect(img).not.toBeNull();
+        expect(img?.getAttribute('src')).toBe('https://example.com/arch.png');
+        expect(img?.getAttribute('alt')).toBe('架构图');
+    });
+});

--- a/packages/webview/tests/webview/mermaidTheme.test.tsx
+++ b/packages/webview/tests/webview/mermaidTheme.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import mermaid from 'mermaid';
+import { MermaidRenderer } from '../../src/components/MermaidRenderer';
+
+vi.mock('mermaid', () => ({
+    default: {
+        initialize: vi.fn(),
+        render: vi.fn().mockResolvedValue({ svg: '<svg></svg>', bindFunctions: vi.fn() }),
+    },
+}));
+
+const initializeMock = vi.mocked(mermaid.initialize);
+
+function renderDiagram() {
+    const vscode = { postMessage: vi.fn() };
+    return render(<MermaidRenderer content={'graph TD\nA-->B'} vscode={vscode} />);
+}
+
+afterEach(() => {
+    document.body.classList.remove('vscode-dark', 'vscode-light');
+    document.documentElement.removeAttribute('data-theme');
+    initializeMock.mockClear();
+});
+
+describe('MermaidRenderer theme', () => {
+    it('initializes with the dark theme when the host is dark, and re-initializes on theme flip', async () => {
+        document.body.classList.add('vscode-dark');
+        renderDiagram();
+        await vi.waitFor(() => {
+            expect(initializeMock).toHaveBeenCalledWith(expect.objectContaining({ theme: 'dark' }));
+        });
+
+        document.body.classList.remove('vscode-dark');
+        document.body.classList.add('vscode-light');
+        await vi.waitFor(() => {
+            expect(initializeMock).toHaveBeenCalledWith(expect.objectContaining({ theme: 'default' }));
+        });
+    });
+
+    it('detects dark mode from <html data-theme> for desktop/JetBrains hosts', async () => {
+        document.documentElement.setAttribute('data-theme', 'dark');
+        renderDiagram();
+        await vi.waitFor(() => {
+            expect(initializeMock).toHaveBeenCalledWith(expect.objectContaining({ theme: 'dark' }));
+        });
+    });
+});


### PR DESCRIPTION
## 修复内容

4 个 webview 渲染 bug：

1. **markdown 分割线不渲染**：DOMPurify 白名单缺 `hr` 标签 → 加入 `hr` 并在 `Message.css` 补充分割线样式
2. **消息内网络图片不渲染**：DOMPurify 白名单缺 `img` + `src`/`alt` 属性，VSCE CSP `img-src` 只允许 `data:`/`blob:` → 白名单补齐，CSP 放开 `https:`/`http:`
3. **暗色模式 mermaid 连线看不清**：原 `.vscode-dark` CSS `filter: invert()` hack 只在 VSCE 生效，JB/desktop 失效且破坏节点文字对比度 → 改用 mermaid 原生 `theme: 'dark'/'default'`；新增 `utils/theme.ts` 跨宿主 `isDarkTheme()` 检测（VSCE body class + desktop/JB `<html data-theme>`），MutationObserver 监听主题切换触发重渲染
4. **Visual Studio Light 输入框边框不可见**：该主题未定义 `--vscode-input-border`，整条 shorthand 失效 → 加 `--vscode-panel-border` → `--vscode-widget-border` → `rgba(128,128,128,0.4)` fallback 链

## 测试

- 新增 `markdownSanitize.test.tsx`（hr + img 白名单）2 个用例
- 新增 `mermaidTheme.test.tsx`（跨宿主暗色检测）2 个用例
- webview 全套 416 tests / 68 files 通过
- 已在 VSCE Extension Development Host 人工验证 4 个场景（含网络图片真实加载）