### PR TITLE
fix(webview): tooltip 超出视口时自动内移，位置统一为居中 top/bottom

### DIFF
--- a/packages/webview/src/components/ChatHeader.tsx
+++ b/packages/webview/src/components/ChatHeader.tsx
@@ -37,7 +37,7 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
       <div className="header-buttons">
         {!hideSessionButtons && (
           <>
-            <Tooltip text="新建会话" position="bottom-left">
+            <Tooltip text="新建会话" position="bottom">
               <button
                 className="header-button"
                 onClick={onClearChat}
@@ -48,7 +48,7 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
                 <NewSessionIcon />
               </button>
             </Tooltip>
-            <Tooltip text="历史对话" position="bottom-left">
+            <Tooltip text="历史对话" position="bottom">
               <button
                 className="header-button"
                 onClick={() => setShowSessionList((prev) => !prev)}
@@ -61,7 +61,7 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
           </>
         )}
         {!hideMoreButton && (
-          <Tooltip text="更多" position="bottom-left">
+          <Tooltip text="更多" position="bottom">
             <button
               className="header-button"
               onClick={() => setShowMoreMenu((prev) => !prev)}
@@ -73,7 +73,7 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
           </Tooltip>
         )}
         {panelToggle && (
-          <Tooltip text="面板" position="bottom-left">
+          <Tooltip text="面板" position="bottom">
             <button
               className="header-button header-panel-toggle"
               onClick={() => setShowPanelMenu((prev) => !prev)}

--- a/packages/webview/src/components/DesktopSidebar.tsx
+++ b/packages/webview/src/components/DesktopSidebar.tsx
@@ -145,7 +145,7 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
     <div className="desktop-sidebar" data-testid="desktop-sidebar">
       <div className="desktop-sidebar-header">
         <span className="desktop-sidebar-title">Wave 代码智聊</span>
-        <Tooltip text="更多" position="bottom-left">
+        <Tooltip text="更多" position="bottom">
           <button
             className="desktop-sidebar-more-btn"
             onClick={() => setShowMoreMenu((prev) => !prev)}

--- a/packages/webview/src/components/Message.tsx
+++ b/packages/webview/src/components/Message.tsx
@@ -718,7 +718,7 @@ export const Message: React.FC<MessageProps> = React.memo((props) => {
       {message.blocks?.map((block, index) => renderBlock(block, index))}
       {message.role === 'user' && !isQueued && message.id && !message.blocks?.some(b => b.type === 'bang') && (
         <div className="message-actions">
-          <Tooltip text="回滚到此消息" position="bottom-left">
+          <Tooltip text="回滚到此消息" position="bottom">
             <button 
               className="message-action-btn" 
               onClick={() => onRewindToMessage?.(message.id!)}

--- a/packages/webview/src/components/MessageInput.tsx
+++ b/packages/webview/src/components/MessageInput.tsx
@@ -1346,7 +1346,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>((p
           </div>
 
           {isStreaming ? (
-            <Tooltip text="停止" position="left">
+            <Tooltip text="停止" position="top">
               <button
                 className="abort-button ai-abort-btn"
                 id="abortButton"
@@ -1358,7 +1358,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>((p
               </button>
             </Tooltip>
           ) : (
-            <Tooltip text="发送" position="top-left">
+            <Tooltip text="发送" position="top">
               <button
                 id="sendButton"
                 className="send-button ai-send-btn"

--- a/packages/webview/src/components/Tooltip.tsx
+++ b/packages/webview/src/components/Tooltip.tsx
@@ -68,6 +68,14 @@ export const Tooltip: React.FC<TooltipProps> = ({
         break;
     }
     
+    // Keep the tooltip inside the viewport (webview bounds); if it would
+    // overflow an edge, shift it inward so it never gets clipped.
+    const margin = 4;
+    const maxLeft = Math.max(window.innerWidth - tooltipRect.width - margin, margin);
+    const maxTop = Math.max(window.innerHeight - tooltipRect.height - margin, margin);
+    left = Math.min(Math.max(left, margin), maxLeft);
+    top = Math.min(Math.max(top, margin), maxTop);
+    
     setTooltipStyle({ left, top });
   }, [position, offset]);
 

--- a/packages/webview/tests/webview/tooltip.test.tsx
+++ b/packages/webview/tests/webview/tooltip.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderChatApp, screen, waitFor, fireEvent, act, sendCommand } from './test-utils';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderChatApp, render, screen, waitFor, fireEvent, act, sendCommand } from './test-utils';
+import { Tooltip } from '../../src/components/Tooltip';
 
 describe('Tooltip Component', () => {
     beforeEach(() => {
@@ -121,6 +122,114 @@ describe('Tooltip Component', () => {
         await waitFor(() => {
             const tooltip = document.querySelector('[role="tooltip"]');
             expect(tooltip).not.toBeNull();
+        });
+    });
+
+    describe('viewport overflow clamping', () => {
+        const originalInnerWidth = window.innerWidth;
+        const originalInnerHeight = window.innerHeight;
+
+        const setViewport = (width: number, height: number) => {
+            Object.defineProperty(window, 'innerWidth', { value: width, configurable: true });
+            Object.defineProperty(window, 'innerHeight', { value: height, configurable: true });
+        };
+
+        const mockRects = (containerRect: Partial<DOMRect>, tooltipRect: Partial<DOMRect>) => {
+            vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+                const rect = this.classList.contains('tooltip-box') ? tooltipRect : containerRect;
+                return {
+                    left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0, x: 0, y: 0,
+                    ...rect,
+                    toJSON: () => ({}),
+                } as DOMRect;
+            });
+        };
+
+        const showTooltip = async (position: 'top' | 'bottom' | 'left' | 'right' | 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right') => {
+            render(
+                <Tooltip text="tip" position={position}>
+                    <button type="button">anchor</button>
+                </Tooltip>
+            );
+            const container = document.querySelector('.tooltip-container') as HTMLElement;
+            await act(async () => {
+                fireEvent.mouseEnter(container);
+            });
+            let tooltip: HTMLElement | null = null;
+            await waitFor(() => {
+                tooltip = document.querySelector('.tooltip-box.visible');
+                expect(tooltip).not.toBeNull();
+                expect((tooltip as unknown as HTMLElement).style.left).not.toBe('');
+            });
+            return tooltip as unknown as HTMLElement;
+        };
+
+        afterEach(() => {
+            vi.restoreAllMocks();
+            setViewport(originalInnerWidth, originalInnerHeight);
+        });
+
+        it('should shift left inward when overflowing the right edge', async () => {
+            setViewport(200, 300);
+            // position 'right': left = containerRect.right + offset = 180 + 8 = 188,
+            // tooltip width 100 → 188 + 100 = 288 > 200 → clamped to 200 - 100 - 4 = 96
+            mockRects(
+                { left: 160, top: 50, right: 180, bottom: 70, width: 20, height: 20 },
+                { width: 100, height: 20 }
+            );
+
+            const tooltip = await showTooltip('right');
+            expect(tooltip.style.left).toBe('96px');
+        });
+
+        it('should shift right inward when overflowing the left edge', async () => {
+            setViewport(1024, 768);
+            // position 'left': left = 20 - 100 - 8 = -88 → clamped to margin 4
+            mockRects(
+                { left: 20, top: 50, right: 40, bottom: 70, width: 20, height: 20 },
+                { width: 100, height: 20 }
+            );
+
+            const tooltip = await showTooltip('left');
+            expect(tooltip.style.left).toBe('4px');
+        });
+
+        it('should shift down inward when overflowing the top edge', async () => {
+            setViewport(1024, 768);
+            // position 'top': top = 10 - 20 - 8 = -18 → clamped to margin 4
+            mockRects(
+                { left: 100, top: 10, right: 120, bottom: 30, width: 20, height: 20 },
+                { width: 60, height: 20 }
+            );
+
+            const tooltip = await showTooltip('top');
+            expect(tooltip.style.top).toBe('4px');
+        });
+
+        it('should shift up inward when overflowing the bottom edge', async () => {
+            setViewport(1024, 200);
+            // position 'bottom-left': top = 190 + 8 = 198, tooltip height 20 → 218 > 200
+            // → clamped to 200 - 20 - 4 = 176
+            mockRects(
+                { left: 100, top: 170, right: 120, bottom: 190, width: 20, height: 20 },
+                { width: 60, height: 20 }
+            );
+
+            const tooltip = await showTooltip('bottom-left');
+            expect(tooltip.style.top).toBe('176px');
+        });
+
+        it('should keep the computed position when nothing overflows', async () => {
+            setViewport(1024, 768);
+            // position 'bottom-left': left = 120 - 60 = 60, top = 40 + 8 = 48 — all inside
+            mockRects(
+                { left: 100, top: 20, right: 120, bottom: 40, width: 20, height: 20 },
+                { width: 60, height: 20 }
+            );
+
+            const tooltip = await showTooltip('bottom-left');
+            expect(tooltip.style.left).toBe('60px');
+            expect(tooltip.style.top).toBe('48px');
         });
     });
 });


### PR DESCRIPTION
## 问题

JB 插件中 hover 用户消息的「回滚到此消息」tooltip 在超出 WebView 可视区时被裁剪（溢出隐藏），窄面板下尤为明显。

## 修复

- **Tooltip 视口钳制**（`packages/webview/src/components/Tooltip.tsx`）：计算位置后将 left/top 钳制在视口内（4px 边距），超出任意边缘自动往内移；tooltip 比视口更大时不反向推离屏。共享 webview 组件，VSCE / JB / Desktop 三端自动复用（含全部 12 处 Tooltip 使用点）。
- **位置统一简化**：有了钳制兜底后不再需要对齐变体 —— `bottom-left`→`bottom`（ChatHeader 4 个、DesktopSidebar 更多、回滚按钮）、`top-left`→`top`（发送）、停止按钮 `left`→`top`（与发送按钮一致）。

## 测试

- 新增 5 个视口溢出钳制测试（右/左/上/下溢出自动内移 + 无溢出保持原位）
- webview 全量 417 测试通过，type-check / lint 干净
- JB 插件真机验证通过（窄宽度下 tooltip 不再截断）

已知小取舍：钳制后箭头（CSS 固定偏移）可能不再精确指向按钮，与 VS Code 原生行为一致。