### PR TITLE
chore(desktop): desktop:install 改为全量 pnpm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "desktop:dev": "pnpm -F wave-webview build && pnpm -F wave-desktop run dev",
     "desktop:build": "pnpm -F wave-webview build && pnpm -F wave-desktop run compile",
     "desktop:package": "pnpm -F wave-webview build && pnpm -F wave-desktop run dist",
-    "desktop:install": "pnpm -F wave-webview build && pnpm -F wave-desktop run compile && pnpm -F wave-desktop exec electron-builder --dir && rsync -a --delete packages/desktop/release/mac-arm64/Wave.app/ /Applications/Wave.app/",
+    "desktop:install": "pnpm build && pnpm -F wave-desktop exec electron-builder --dir && rsync -a --delete packages/desktop/release/mac-arm64/Wave.app/ /Applications/Wave.app/",
     "prepare": "husky"
   },
   "devDependencies": {


### PR DESCRIPTION
## 变更

`desktop:install` 脚本从选择性构建（webview + desktop compile）改为全量 `pnpm build`。

## 原因

本地通过 npm link 使用 workspace 的 wave-code 包作为 desktop 的 CLI 后端，选择性构建不会重建 code 包，导致安装的 app 跑到旧的 CLI。直接 `pnpm build` 覆盖全部包（agent-sdk / code / webview / vsce / desktop)，简单且不会漏建。