### PR TITLE
fix(webview): 空间不足提示 z-index 提升至面板弹层之上

### DIFF
--- a/packages/webview/src/styles/DesktopApp.css
+++ b/packages/webview/src/styles/DesktopApp.css
@@ -634,13 +634,15 @@
     background: var(--vscode-list-hoverBackground);
 }
 
-/* Transient hint (e.g. min-width refusal), centered at the top of the row. */
+/* Transient hint (e.g. min-width refusal), centered at the top of the row.
+   Sits above dropdown menus (z-index 1000) like the panel toggle so a refusal
+   hint fired from a menu click is not covered by the still-open menu. */
 .desktop-pane-hint {
     position: absolute;
     top: 12px;
     left: 50%;
     transform: translateX(-50%);
-    z-index: 20;
+    z-index: 2000;
     padding: 6px 14px;
     border-radius: 4px;
     background: var(--vscode-editorWidget-background, var(--vscode-editor-background));


### PR DESCRIPTION
## 问题

窄对话下，从右上角面板弹层点击某个面板触发"空间不足"提示时，提示被未关闭的弹层遮挡。

## 根因

`.desktop-pane-hint`（分屏提示与面板提示共用）z-index 为 20，而 `.panel-toggle-menu` 为 1000；`.chat-header`/`.desktop-pane` 均为 `position: relative` 且无 z-index，不形成堆叠上下文，两者在同一堆叠上下文中直接比较，1000 盖住 20。

## 修复

`.desktop-pane-hint` z-index 20 → 2000（高于菜单层 1000，与对话框同级；提示为 transient + `pointer-events: none`，短暂覆盖对话框无害）。

## 验证

- `pnpm -F wave-webview build` 重建并同步 vsce/jetbrains
- `pnpm -F wave-webview test tests/webview/chatAppPanels.test.tsx` 18 通过
- z-index 为纯视觉堆叠，jsdom 无法有效断言，建议 desktop dev 实测