### PR TITLE
fix(webview): 修复分屏关闭按钮与面板开关重叠 — 补上 --closable 修饰类

### DIFF
--- a/packages/webview/src/components/DesktopShell.tsx
+++ b/packages/webview/src/components/DesktopShell.tsx
@@ -521,7 +521,7 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
                         if (el) paneNodes.current.set(pane.paneId, el);
                         else paneNodes.current.delete(pane.paneId);
                       }}
-                      className={`desktop-pane${pane.paneId === focusedPaneId ? ' desktop-pane--focused' : ''}`}
+                      className={`desktop-pane${pane.paneId === focusedPaneId ? ' desktop-pane--focused' : ''}${panes.length > 1 ? ' desktop-pane--closable' : ''}`}
                       style={paneStyle}
                       onMouseDown={() => handleFocusPane(pane.paneId)}
                       onDragOver={(e) => handlePaneDragOver(e, rowIdx, index)}


### PR DESCRIPTION
## 问题

CI Deploy VitePress 工作流失败(run 30516360374):demo 测试 `pane close button does not overlap the header panel toggle` 重试 3 次全挂。

## 根因

c9c573ff 的修复依赖 `.desktop-pane--closable .chat-header { padding-right: 34px }` 选择器,但 `DesktopShell.tsx` 从未给窗格元素添加 `desktop-pane--closable` 类 —— padding 规则从未生效,成为死 CSS。绝对定位的关闭按钮(`right:6px`,宽约 22px)因此总是压在头部面板开关上(其右缘位于 header 默认 `padding-right:12px` 处)。

## 修复

多窗格时(`panes.length > 1`,与关闭按钮渲染条件一致)为窗格补上 `desktop-pane--closable` 修饰类。

## 验证

- 目标 demo 测试本地通过
- 完整 demo 套件 32/32 通过
- type-check + lint 通过