### PR TITLE
fix(desktop): 终端面板打开时自动聚焦并预取 xterm chunk

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -23,7 +23,7 @@ import { DesktopWorkdirSelector } from './DesktopWorkdirSelector';
 import { DesktopWorktreeControls } from './DesktopWorktreeControls';
 import { PreviewPane } from './PreviewPane';
 import { DiffPane } from './DiffPane';
-import { TerminalPane } from './TerminalPane';
+import { TerminalPane, prefetchTerminalLib } from './TerminalPane';
 import type {
   ChatAppProps,
   ConfigurationData,
@@ -772,6 +772,16 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
   }, []);
 
   const isDesktop = host?.type === 'desktop';
+
+  // Desktop: idle-preload the lazily injected xterm chunk so the first
+  // terminal open doesn't pay the fetch+parse cost.
+  useEffect(() => {
+    if (!isDesktop) return;
+    const id = window.requestIdleCallback?.(() => prefetchTerminalLib());
+    return () => {
+      if (id !== undefined) window.cancelIdleCallback?.(id);
+    };
+  }, [isDesktop]);
 
   // Check a panel on: when its assigned row lacks the width, a first-row panel
   // spills into the second row (creating it when the body is tall enough);

--- a/packages/webview/src/components/TerminalPane.tsx
+++ b/packages/webview/src/components/TerminalPane.tsx
@@ -39,6 +39,11 @@ function loadTerminalLib(): Promise<NonNullable<Window['WaveTerminal']>> {
   return terminalLibPromise;
 }
 
+/** Preload the xterm chunk so the first terminal open skips the fetch+parse. */
+export function prefetchTerminalLib(): void {
+  loadTerminalLib().catch(() => {});
+}
+
 /** Terminal colors follow the app theme via --vscode-* variables. */
 const readTerminalTheme = () => {
   const styles = getComputedStyle(document.documentElement);
@@ -199,7 +204,12 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({
         });
         resizeObserver.observe(containerRef.current);
         fit.fit();
-        if (visibleRef.current) createPty();
+        if (visibleRef.current) {
+          createPty();
+          // 首次打开走这条路径（chunk 异步加载完成后才建终端）——聚焦，
+          // 对齐 VS Code 打开终端面板的行为。
+          term.focus();
+        }
       })
       .catch((err) => {
         if (!disposed) {
@@ -229,8 +239,10 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({
     if (contextChanged) {
       killPty();
       if (visible) createPty();
-    } else if (becameVisible && !liveRef.current) {
-      createPty();
+    } else if (becameVisible) {
+      // 用户主动打开终端面板（勾选/快捷键）——聚焦终端，对齐 VS Code 行为。
+      if (!liveRef.current) createPty();
+      termRef.current?.focus();
     }
   }, [visible, sessionId, workdir, killPty, createPty]);
 

--- a/packages/webview/tests/webview/terminalPane.test.tsx
+++ b/packages/webview/tests/webview/terminalPane.test.tsx
@@ -18,6 +18,7 @@ class MockTerminal {
     }
     loadAddon() {}
     open() {}
+    focus = vi.fn();
     onData(cb: (data: string) => void) {
         this.dataCb = cb;
     }
@@ -115,6 +116,21 @@ describe('TerminalPane', () => {
         rerenderWith({ visible: true });
         await act(async () => {});
         expect(postsOf(vscode, 'desktopTerminalCreate')).toHaveLength(1);
+    });
+
+    it('focuses the terminal on first open (visible mount after chunk load)', async () => {
+        renderPane();
+        await act(async () => {});
+        expect(mockTerminals[0].focus).toHaveBeenCalledTimes(1);
+    });
+
+    it('focuses the terminal when the panel becomes visible, not on hidden mount', async () => {
+        const { rerenderWith } = renderPane({ visible: false });
+        await act(async () => {});
+        expect(mockTerminals[0].focus).not.toHaveBeenCalled();
+        rerenderWith({ visible: true });
+        await act(async () => {});
+        expect(mockTerminals[0].focus).toHaveBeenCalledTimes(1);
     });
 
     it('relays host output into xterm and keystrokes back to the host', async () => {


### PR DESCRIPTION
## 改动

- 首次打开终端（xterm chunk 异步加载完成后建终端）与再次打开（面板隐藏→可见）两条路径都调用 `term.focus()`，对齐 VS Code 打开终端面板自动聚焦的行为
- desktop 端空闲时（`requestIdleCallback`）预取 `terminal.js` chunk，消除首次打开的动态加载延迟

## 背景

- 终端面板此前从未调用 `term.focus()`，打开后需要手动点击才能输入
- 首次打开不聚焦的根因：chunk 懒加载未完成时 `becameVisible` 触发，`termRef.current` 仍为 null，focus 落空
- 实测验证：仅保留预取、去掉显式 focus 依然不聚焦（xterm `open()` 不自聚焦），两处 focus 均必要

## 测试

- `terminalPane.test.tsx` 新增 2 个聚焦用例（首次打开聚焦、隐藏→可见聚焦），共 16 用例通过
- `chatAppPanels.test.tsx` 18 用例通过，type-check / lint 全绿
- 用户已在 desktop dev 实测验证