### PR TITLE
feat(desktop): per-worktree dev userData keyed by app-path hash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Always use `pnpm` as the package manager.
 - **Test**: `pnpm run jb:test`
 
 ### Desktop App (`packages/desktop`)
-- **Run dev**: `cd packages/desktop && pnpm run dev` (compiles, then launches Electron; dev uses a separate `wave-desktop-dev` userData so it coexists with the installed app)
+- **Run dev**: `cd packages/desktop && pnpm run dev` (compiles, then launches Electron; dev uses a per-worktree `wave-desktop-dev-<hash>` userData keyed by app-path hash, so worktrees and the installed app all run side by side)
 - **Build installer**: `pnpm run dist` (electron-builder → `release/`). **Do not bypass `scripts/afterPack.js`**: electron-builder's bundle mutation breaks the ad-hoc linker seal, and without the re-sign step LaunchServices silently refuses to launch the app.
 - **Test**: `pnpm -F wave-desktop test`
 - **Architecture**: the main process wraps the shared webview and talks JSON-RPC to a `wave --stdio` child process — `src/main/desktopHost.ts` (agent pool: one `StdioAgent` per session for parallel conversations, see FR-031) → `stdio/stdioClient.ts` + `stdio/notificationRouter.ts` (routes notifications by sessionId). Session index/worktree metadata persists in `userData/wave-desktop.json` via `configStore.ts`.

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -8,6 +8,7 @@
 
 import { app, BrowserWindow, ipcMain, nativeImage, shell } from 'electron';
 import { execFileSync } from 'child_process';
+import * as crypto from 'crypto';
 import * as path from 'path';
 import { WEBVIEW_CHANNEL } from './channels';
 import { ConfigStore } from './configStore';
@@ -40,11 +41,13 @@ function adoptLoginShellPath(): void {
 
 adoptLoginShellPath();
 
-// Dev instances get their own userData so they can run alongside an installed
-// app (the single-instance lock is scoped to the userData directory) and never
-// touch the real config/session index.
+// Dev instances get a per-worktree userData (keyed by a hash of the app
+// path): the single-instance lock is scoped to the userData directory, so
+// worktrees run side by side without focus-stealing and never touch the
+// installed app's config/session index.
 if (!app.isPackaged) {
-  app.setPath('userData', path.join(app.getPath('appData'), 'wave-desktop-dev'));
+  const worktreeHash = crypto.createHash('sha256').update(app.getAppPath()).digest('hex').slice(0, 8);
+  app.setPath('userData', path.join(app.getPath('appData'), `wave-desktop-dev-${worktreeHash}`));
 }
 
 let mainWindow: BrowserWindow | null = null;


### PR DESCRIPTION
## 问题

桌面端 dev 实例共用同一个 `wave-desktop-dev` userData 目录，而 Electron 单实例锁按 userData 隔离 —— 从第二个 worktree 启动 `pnpm run dev` 会静默退出并把焦点切到旧实例，造成「改动没生效」的假象，每次都要手动查进程杀旧实例。

## 方案

把 `app.getAppPath()`（即该 worktree 的 `packages/desktop` 路径）的 sha256 前 8 位拼进 userData 目录名：`wave-desktop-dev-<hash>`。每个 worktree 获得独立实例、独立单实例锁、独立会话索引；同一 worktree 内重复启动仍走原有单实例聚焦逻辑，行为不变。

## 影响面

- 仅 `app.isPackaged === false` 的 dev 路径，打包应用不受影响
- 同步更新 AGENTS.md 中 dev userData 的描述

## 验证

- `pnpm -F wave-desktop type-check` / `build` / `test`（237 passed）通过
- 真机验证：本 worktree 启动 dev 后生成 `~/Library/Application Support/wave-desktop-dev-c4453f91`，与旧共享目录互不干扰