### PR TITLE
fix: Windows 路径含空格导致插件初始化失败（shell:true 引号 + where 选行）

### DIFF
--- a/packages/agent-sdk/tests/managers/backgroundTaskManager.notification.test.ts
+++ b/packages/agent-sdk/tests/managers/backgroundTaskManager.notification.test.ts
@@ -19,14 +19,22 @@ vi.mock("child_process", () => ({
   }),
 }));
 
-// Mock fs
-vi.mock("fs", () => ({
-  createWriteStream: vi.fn(() => ({
+// Mock fs. Both named exports (namespace-imported by backgroundTaskManager)
+// and a default export (default-imported by shellResolver) are required —
+// on a real win32 runner resolveShellPath() probes Git Bash via fs.existsSync.
+vi.mock("fs", () => {
+  const createWriteStream = vi.fn(() => ({
     writable: true,
     write: vi.fn(),
     end: vi.fn(),
-  })),
-}));
+  }));
+  const existsSync = vi.fn(() => false);
+  return {
+    createWriteStream,
+    existsSync,
+    default: { createWriteStream, existsSync },
+  };
+});
 
 import { BackgroundTaskManager } from "../../src/managers/backgroundTaskManager.js";
 import { MessageQueue } from "../../src/managers/messageQueue.js";

--- a/packages/desktop/src/main/stdio/binaryResolver.ts
+++ b/packages/desktop/src/main/stdio/binaryResolver.ts
@@ -18,6 +18,34 @@ export const NPM_REGISTRY = 'https://registry.npmmirror.com';
 
 let cachedPath: string | undefined;
 
+/**
+ * Pick the executable line from `which`/`where` output. On Windows `where`
+ * lists the extensionless bash launcher first (e.g. `C:\Program Files\nodejs\npm`)
+ * followed by `npm.cmd` — cmd.exe cannot execute the bash launcher, so prefer
+ * `.cmd`/`.exe`/`.bat` lines.
+ */
+function pickExecutableLine(lookupOutput: string): string {
+    const lines = lookupOutput
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+    if (process.platform === 'win32') {
+        const cmdLine = lines.find((l) => /\.(cmd|exe|bat)$/i.test(l));
+        if (cmdLine) return cmdLine;
+    }
+    return lines[0] ?? '';
+}
+
+/**
+ * With `shell: true` on Windows, Node concatenates file+args into the cmd.exe
+ * command line WITHOUT quoting the file — a path containing spaces (e.g.
+ * `C:\Program Files\nodejs\npm.cmd`) is split at the space and fails with
+ * "'C:\Program' is not recognized". Pre-quote it.
+ */
+function quoteForShell(executable: string): string {
+    return process.platform === 'win32' ? `"${executable}"` : executable;
+}
+
 /** Minimum Node.js major version required by `wave --stdio`. */
 const MIN_NODE_MAJOR = 20;
 
@@ -97,7 +125,7 @@ function findNpm(): string {
     const cmd = process.platform === 'win32' ? 'where npm' : 'which npm';
     try {
         const result = execSync(cmd, { encoding: 'utf-8', stdio: 'pipe' }).trim();
-        if (result) return result.split('\n')[0].trim();
+        if (result) return pickExecutableLine(result);
     } catch {
         // not on PATH
     }
@@ -155,7 +183,7 @@ export function resolveWaveBinary(onInstall?: InstallProgressCallback): string {
     try {
         const result = execSync(whichCmd, { encoding: 'utf-8', stdio: 'pipe' }).trim();
         if (result) {
-            cachedPath = result.split('\n')[0].trim();
+            cachedPath = pickExecutableLine(result);
             return cachedPath;
         }
     } catch {
@@ -200,7 +228,7 @@ export function resolveWaveBinary(onInstall?: InstallProgressCallback): string {
     try {
         const result = execSync(whichCmd, { encoding: 'utf-8', stdio: 'pipe' }).trim();
         if (result) {
-            cachedPath = result.split('\n')[0].trim();
+            cachedPath = pickExecutableLine(result);
             return cachedPath;
         }
     } catch {
@@ -219,7 +247,7 @@ export function resolveWaveBinary(onInstall?: InstallProgressCallback): string {
  */
 export function getCliVersion(binaryPath: string): string | null {
     try {
-        const output = execFileSync(binaryPath, ['-v'], {
+        const output = execFileSync(quoteForShell(binaryPath), ['-v'], {
             encoding: 'utf-8',
             stdio: ['ignore', 'pipe', 'ignore'],
             timeout: 5000,
@@ -284,7 +312,7 @@ export async function upgradeWaveBinary(targetVersion: string, onInstall?: Insta
     const npm = findNpm();
     await new Promise<void>((resolve, reject) => {
         execFile(
-            npm,
+            quoteForShell(npm),
             ['install', '-g', `wave-code@${targetVersion}`, `--registry=${NPM_REGISTRY}`],
             // `npm` is `npm.cmd` on Windows; Node refuses to execFile a `.cmd`
             // without a shell (ERR_CHILD_PROCESS_INVALID_COMMAND_FILE). The

--- a/packages/desktop/src/main/stdio/stdioClient.ts
+++ b/packages/desktop/src/main/stdio/stdioClient.ts
@@ -37,7 +37,14 @@ export class StdioClient {
         // shell, throwing ERR_CHILD_PROCESS_INVALID_COMMAND_FILE. `args` is a
         // fixed flag list (`['--stdio']`) with no metacharacters, so enabling
         // the shell on Windows is safe; Unix behaviour is unchanged.
-        this.proc = spawn(binaryPath, args, {
+        //
+        // With `shell: true`, Node concatenates file+args into the cmd.exe
+        // command line WITHOUT quoting the file — a path containing spaces
+        // (e.g. `C:\Users\a b\...\wave.cmd`) is split at the space and fails
+        // with "'C:\Users\a' is not recognized". Pre-quote it on Windows.
+        const command =
+            process.platform === 'win32' ? `"${binaryPath}"` : binaryPath;
+        this.proc = spawn(command, args, {
             stdio: ['pipe', 'pipe', 'pipe'],
             env: { ...process.env, ...env },
             shell: process.platform === 'win32',

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
@@ -201,10 +201,27 @@ object BinaryResolver {
     private fun findOnPath(name: String): String? {
         return try {
             val out = runCommand(lookupCmd, name)
-            out.lineSequence().firstOrNull()?.trim()?.takeIf { it.isNotEmpty() }
+            pickExecutableLine(out)
         } catch (e: Exception) {
             null
         }
+    }
+
+    /**
+     * Pick the executable line from `which`/`where` output. On Windows `where`
+     * lists the extensionless bash launcher first (e.g. `C:\Program Files\nodejs\npm`)
+     * followed by `npm.cmd` — CreateProcess cannot execute the bash launcher, so
+     * prefer `.cmd`/`.exe`/`.bat` lines. [windows] is injectable for tests.
+     */
+    internal fun pickExecutableLine(lookupOutput: String, windows: Boolean = isWindows): String? {
+        val lines = lookupOutput.lineSequence().map { it.trim() }.filter { it.isNotEmpty() }.toList()
+        if (windows) {
+            lines.firstOrNull {
+                val l = it.lowercase()
+                l.endsWith(".cmd") || l.endsWith(".exe") || l.endsWith(".bat")
+            }?.let { return it }
+        }
+        return lines.firstOrNull()
     }
 
     /**
@@ -266,7 +283,7 @@ object BinaryResolver {
         // which/where npm
         try {
             val out = runCommand(lookupCmd, "npm")
-            out.lineSequence().firstOrNull()?.trim()?.takeIf { it.isNotEmpty() }?.let { return it }
+            pickExecutableLine(out)?.let { return it }
         } catch (_: Exception) {}
         // nvm-installed npm (GUI-launched IDEs don't inherit shell PATH)
         findInNvm("npm")?.let { return it }

--- a/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/stdio/BinaryResolverTest.kt
+++ b/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/stdio/BinaryResolverTest.kt
@@ -142,6 +142,47 @@ class BinaryResolverTest {
         assertNull(BinaryResolver.getCliVersion(missing))
     }
 
+    // ---- pickExecutableLine --------------------------------------------
+    //
+    // Customer repro: a default Node.js install on Windows lives at
+    // `C:\Program Files\nodejs`, and `where npm` lists the extensionless
+    // bash launcher FIRST (`...\npm`, then `...\npm.cmd`). CreateProcess
+    // cannot execute the bash launcher, so the npm install/upgrade fails
+    // and the stdio client never initializes.
+
+    @Test
+    fun `pickExecutableLine prefers the cmd line from where output on Windows`() {
+        // `where` emits CRLF line endings.
+        val out = "C:\\Program Files\\nodejs\\npm\r\nC:\\Program Files\\nodejs\\npm.cmd\r\n"
+        assertEquals(
+            "C:\\Program Files\\nodejs\\npm.cmd",
+            BinaryResolver.pickExecutableLine(out, windows = true)
+        )
+    }
+
+    @Test
+    fun `pickExecutableLine prefers an exe line on Windows`() {
+        val out = "C:\\tools\\wave\nC:\\tools\\wave.exe\n"
+        assertEquals("C:\\tools\\wave.exe", BinaryResolver.pickExecutableLine(out, windows = true))
+    }
+
+    @Test
+    fun `pickExecutableLine falls back to first line when no cmd or exe on Windows`() {
+        val out = "C:\\tools\\wave\nC:\\other\\wave\n"
+        assertEquals("C:\\tools\\wave", BinaryResolver.pickExecutableLine(out, windows = true))
+    }
+
+    @Test
+    fun `pickExecutableLine takes the first line off-Windows`() {
+        val out = "/usr/bin/npm\n/usr/local/bin/npm\n"
+        assertEquals("/usr/bin/npm", BinaryResolver.pickExecutableLine(out, windows = false))
+    }
+
+    @Test
+    fun `pickExecutableLine returns null for empty output`() {
+        assertNull(BinaryResolver.pickExecutableLine("", windows = true))
+    }
+
     // ---- findInNvm -----------------------------------------------------
 
     @Test

--- a/packages/vsce/src/stdio/binaryResolver.ts
+++ b/packages/vsce/src/stdio/binaryResolver.ts
@@ -18,6 +18,34 @@ export const NPM_REGISTRY = 'https://registry.npmmirror.com';
 
 let cachedPath: string | undefined;
 
+/**
+ * Pick the executable line from `which`/`where` output. On Windows `where`
+ * lists the extensionless bash launcher first (e.g. `C:\Program Files\nodejs\npm`)
+ * followed by `npm.cmd` — cmd.exe cannot execute the bash launcher, so prefer
+ * `.cmd`/`.exe`/`.bat` lines.
+ */
+function pickExecutableLine(lookupOutput: string): string {
+    const lines = lookupOutput
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+    if (process.platform === 'win32') {
+        const cmdLine = lines.find((l) => /\.(cmd|exe|bat)$/i.test(l));
+        if (cmdLine) return cmdLine;
+    }
+    return lines[0] ?? '';
+}
+
+/**
+ * With `shell: true` on Windows, Node concatenates file+args into the cmd.exe
+ * command line WITHOUT quoting the file — a path containing spaces (e.g.
+ * `C:\Program Files\nodejs\npm.cmd`) is split at the space and fails with
+ * "'C:\Program' is not recognized". Pre-quote it.
+ */
+function quoteForShell(executable: string): string {
+    return process.platform === 'win32' ? `"${executable}"` : executable;
+}
+
 /** Minimum Node.js major version required by `wave --stdio`. */
 const MIN_NODE_MAJOR = 20;
 
@@ -89,7 +117,7 @@ function findNpm(): string {
     const cmd = process.platform === 'win32' ? 'where npm' : 'which npm';
     try {
         const result = execSync(cmd, { encoding: 'utf-8', stdio: 'pipe' }).trim();
-        if (result) return result.split('\n')[0].trim();
+        if (result) return pickExecutableLine(result);
     } catch {
         // not on PATH
     }
@@ -140,7 +168,7 @@ export function resolveWaveBinary(onInstall?: InstallProgressCallback): string {
     try {
         const result = execSync(whichCmd, { encoding: 'utf-8', stdio: 'pipe' }).trim();
         if (result) {
-            cachedPath = result.split('\n')[0].trim();
+            cachedPath = pickExecutableLine(result);
             return cachedPath;
         }
     } catch {
@@ -185,7 +213,7 @@ export function resolveWaveBinary(onInstall?: InstallProgressCallback): string {
     try {
         const result = execSync(whichCmd, { encoding: 'utf-8', stdio: 'pipe' }).trim();
         if (result) {
-            cachedPath = result.split('\n')[0].trim();
+            cachedPath = pickExecutableLine(result);
             return cachedPath;
         }
     } catch {
@@ -204,7 +232,7 @@ export function resolveWaveBinary(onInstall?: InstallProgressCallback): string {
  */
 export function getCliVersion(binaryPath: string): string | null {
     try {
-        const output = execFileSync(binaryPath, ['-v'], {
+        const output = execFileSync(quoteForShell(binaryPath), ['-v'], {
             encoding: 'utf-8',
             stdio: ['ignore', 'pipe', 'ignore'],
             timeout: 5000,
@@ -269,7 +297,7 @@ export async function upgradeWaveBinary(targetVersion: string, onInstall?: Insta
     const npm = findNpm();
     await new Promise<void>((resolve, reject) => {
         execFile(
-            npm,
+            quoteForShell(npm),
             ['install', '-g', `wave-code@${targetVersion}`, `--registry=${NPM_REGISTRY}`],
             // `npm` is `npm.cmd` on Windows; Node refuses to execFile a `.cmd`
             // without a shell (ERR_CHILD_PROCESS_INVALID_COMMAND_FILE). The

--- a/packages/vsce/src/stdio/stdioClient.ts
+++ b/packages/vsce/src/stdio/stdioClient.ts
@@ -37,7 +37,14 @@ export class StdioClient {
         // shell, throwing ERR_CHILD_PROCESS_INVALID_COMMAND_FILE. `args` is a
         // fixed flag list (`['--stdio']`) with no metacharacters, so enabling
         // the shell on Windows is safe; Unix behaviour is unchanged.
-        this.proc = spawn(binaryPath, args, {
+        //
+        // With `shell: true`, Node concatenates file+args into the cmd.exe
+        // command line WITHOUT quoting the file — a path containing spaces
+        // (e.g. `C:\Users\a b\...\wave.cmd`) is split at the space and fails
+        // with "'C:\Users\a' is not recognized". Pre-quote it on Windows.
+        const command =
+            process.platform === 'win32' ? `"${binaryPath}"` : binaryPath;
+        this.proc = spawn(command, args, {
             stdio: ['pipe', 'pipe', 'pipe'],
             env: { ...process.env, ...env },
             shell: process.platform === 'win32',

--- a/packages/vsce/tests/stdio/binaryResolver.test.ts
+++ b/packages/vsce/tests/stdio/binaryResolver.test.ts
@@ -242,7 +242,9 @@ describe('binaryResolver', () => {
         expect(result).toBe(globalWave);
         expect(mockExecFile).toHaveBeenCalledTimes(1);
         const callArgs = mockExecFile.mock.calls[0];
-        expect(callArgs[0]).toBe(npmBin);
+        // On Windows the executable is pre-quoted for the cmd.exe `shell:true`
+        // command line; off-Windows it is passed as-is.
+        expect(callArgs[0]).toBe(isWin ? `"${npmBin}"` : npmBin);
         expect(callArgs[1]).toEqual([
             'install',
             '-g',
@@ -303,9 +305,17 @@ describe('binaryResolver', () => {
     function withPlatform<T>(platform: string, fn: () => Promise<T>): Promise<T> {
         const original = Object.getOwnPropertyDescriptor(process, 'platform');
         Object.defineProperty(process, 'platform', { value: platform });
-        return fn().finally(() => {
+        const restore = () => {
             if (original) Object.defineProperty(process, 'platform', original);
-        });
+        };
+        try {
+            return fn().finally(restore);
+        } catch (e) {
+            // fn threw synchronously (before returning a promise) — restore here
+            // too or the fake platform leaks into every later test.
+            restore();
+            throw e;
+        }
     }
 
     it('upgradeWaveBinary uses shell:true for npm.cmd on Windows', async () => {
@@ -323,7 +333,8 @@ describe('binaryResolver', () => {
                 const cmd = args[0] as string;
                 const opts = args[2] as { shell?: boolean } | undefined;
                 // Enforce Node's Windows guard: refuse npm.cmd without shell.
-                if (/\.cmd$/i.test(cmd) && opts?.shell !== true) {
+                // (The executable may be pre-quoted for the shell command line.)
+                if (/\.cmd"?$/i.test(cmd) && opts?.shell !== true) {
                     throw new Error('ERR_CHILD_PROCESS_INVALID_COMMAND_FILE');
                 }
                 const cb = args[args.length - 1] as (err: Error | null) => void;
@@ -334,8 +345,84 @@ describe('binaryResolver', () => {
 
             expect(result).toBe(waveCmd);
             const callArgs = mockExecFile.mock.calls[0];
-            expect(callArgs[0]).toBe(npmCmd);
+            expect(callArgs[0]).toBe(`"${npmCmd}"`);
             expect((callArgs[2] as { shell?: boolean }).shell).toBe(true);
+        });
+    });
+
+    // ── Windows: `where` multi-line output + path-with-spaces quoting ──
+    // Customer repro: a default Node.js install lives at
+    // `C:\Program Files\nodejs`. `where npm` lists the extensionless bash
+    // launcher FIRST (`...\npm`, then `...\npm.cmd`); with `shell: true`
+    // Node concatenates file+args into the cmd.exe command line WITHOUT
+    // quoting, so cmd splits the path at the space and fails with
+    // "'C:\Program' 不是内部或外部命令" — the auto-upgrade then dies and the
+    // shared stdio client never initializes.
+
+    it('on Windows, resolveWaveBinary prefers the .cmd line from where output', async () => {
+        const nodeBinWin = 'C:\\Program Files\\nodejs\\node.exe';
+        const waveShim = 'C:\\Users\\runneradmin\\AppData\\Roaming\\npm\\wave';
+        const waveCmd = 'C:\\Users\\runneradmin\\AppData\\Roaming\\npm\\wave.cmd';
+
+        await withPlatform('win32', async () => {
+            mockExecSync.mockImplementation((cmd: string) => {
+                if (cmd.includes('where wave')) return `${waveShim}\n${waveCmd}\n`;
+                if (cmd.includes('where node')) return `${nodeBinWin}\n`;
+                throw new Error(`unexpected: ${cmd}`);
+            });
+
+            const result = await resolveWaveBinary();
+            // cmd.exe cannot execute the extensionless bash launcher.
+            expect(result).toBe(waveCmd);
+        });
+    });
+
+    it('on Windows, upgradeWaveBinary picks npm.cmd and quotes the space-containing path', async () => {
+        const nodeBinWin = 'C:\\Program Files\\nodejs\\node.exe';
+        const npmShim = 'C:\\Program Files\\nodejs\\npm';
+        const npmCmd = 'C:\\Program Files\\nodejs\\npm.cmd';
+        const waveCmd = 'C:\\Program Files\\nodejs\\wave.cmd';
+
+        await withPlatform('win32', async () => {
+            mockExecSync.mockImplementation((cmd: string) => {
+                if (cmd.includes('where npm')) return `${npmShim}\n${npmCmd}\n`;
+                if (cmd.includes('where wave')) return `${waveCmd}\n`;
+                if (cmd.includes('where node')) return `${nodeBinWin}\n`;
+                throw new Error(`unexpected: ${cmd}`);
+            });
+            mockExecFile.mockImplementation((...args: unknown[]) => {
+                const file = args[0] as string;
+                // cmd.exe parses the `shell: true` command line by whitespace:
+                // an unquoted path with spaces breaks at "C:\Program".
+                expect(file.startsWith('"')).toBe(true);
+                const cb = args[args.length - 1] as (err: Error | null) => void;
+                cb(null);
+            });
+
+            const result = await upgradeWaveBinary('0.19.8');
+
+            expect(result).toBe(waveCmd);
+            const callArgs = mockExecFile.mock.calls[0];
+            expect(callArgs[0]).toBe(`"${npmCmd}"`);
+            expect(callArgs[1]).toEqual([
+                'install',
+                '-g',
+                'wave-code@0.19.8',
+                `--registry=${NPM_REGISTRY}`,
+            ]);
+        });
+    });
+
+    it('on Windows, getCliVersion quotes a wave path containing spaces', async () => {
+        const waveCmd = 'C:\\Users\\a b\\AppData\\Roaming\\npm\\wave.cmd';
+
+        await withPlatform('win32', async () => {
+            mockExecFileSync.mockReturnValue('0.19.8\n');
+
+            expect(getCliVersion(waveCmd)).toBe('0.19.8');
+            const call = mockExecFileSync.mock.calls[0];
+            expect(call[0]).toBe(`"${waveCmd}"`);
+            expect((call[2] as { shell?: boolean }).shell).toBe(true);
         });
     });
 
@@ -346,7 +433,7 @@ describe('binaryResolver', () => {
         expect(getCliVersion(globalWave)).toBe('0.18.7');
         expect(mockExecFileSync).toHaveBeenCalledTimes(1);
         const args = mockExecFileSync.mock.calls[0];
-        expect(args[0]).toBe(globalWave);
+        expect(args[0]).toBe(isWin ? `"${globalWave}"` : globalWave);
         expect(args[1]).toEqual(['-v']);
     });
 
@@ -373,9 +460,10 @@ describe('binaryResolver', () => {
             if (cmd.includes(nodeLookup)) return `${nodeBin}\n`;
             throw new Error(`unexpected: ${cmd}`);
         });
-        // Node -v returns v20+; wave -v returns 1.0.0 (>= target)
+        // Node -v returns v20+; wave -v returns 1.0.0 (>= target).
+        // (On Windows the wave path reaches execFileSync pre-quoted.)
         mockExecFileSync.mockImplementation((cmd: string | Buffer) =>
-            String(cmd) === globalWave ? '1.0.0\n' : 'v20.0.0\n',
+            String(cmd).replace(/^"|"$/g, '') === globalWave ? '1.0.0\n' : 'v20.0.0\n',
         );
 
         const result = await ensureCliUpToDate('1.0.0');
@@ -392,7 +480,7 @@ describe('binaryResolver', () => {
         });
         // Node -v returns v20+; wave -v returns 0.18.0 (< target)
         mockExecFileSync.mockImplementation((cmd: string | Buffer) =>
-            String(cmd) === globalWave ? '0.18.0\n' : 'v20.0.0\n',
+            String(cmd).replace(/^"|"$/g, '') === globalWave ? '0.18.0\n' : 'v20.0.0\n',
         );
         mockExecFile.mockImplementation((...args: unknown[]) => {
             const cb = args[args.length - 1] as (err: Error | null) => void;
@@ -416,7 +504,7 @@ describe('binaryResolver', () => {
         });
         // Node -v returns v20+; wave -v fails (corrupt binary)
         mockExecFileSync.mockImplementation((cmd: string | Buffer) => {
-            if (String(cmd) === globalWave) throw new Error('corrupt');
+            if (String(cmd).replace(/^"|"$/g, '') === globalWave) throw new Error('corrupt');
             return 'v20.0.0\n';
         });
         mockExecFile.mockImplementation((...args: unknown[]) => {
@@ -437,7 +525,7 @@ describe('binaryResolver', () => {
         });
         // Node -v returns v20+; wave -v returns 2.0.0 (> target)
         mockExecFileSync.mockImplementation((cmd: string | Buffer) =>
-            String(cmd) === globalWave ? '2.0.0\n' : 'v20.0.0\n',
+            String(cmd).replace(/^"|"$/g, '') === globalWave ? '2.0.0\n' : 'v20.0.0\n',
         );
 
         const result = await ensureCliUpToDate('1.0.0');

--- a/packages/vsce/tests/stdio/stdioClient.test.ts
+++ b/packages/vsce/tests/stdio/stdioClient.test.ts
@@ -18,6 +18,11 @@ vi.mock('readline', () => ({
 
 // ── Helpers ────────────────────────────────────────────────────
 
+// On Windows the executable is pre-quoted for the cmd.exe `shell:true`
+// command line; off-Windows it is passed as-is.
+const isWin = process.platform === 'win32';
+const fakeWave = isWin ? '"/fake/wave"' : '/fake/wave';
+
 interface MockProc extends EventEmitter {
     stdin: { write: ReturnType<typeof vi.fn> };
     stdout: EventEmitter;
@@ -73,7 +78,7 @@ describe('StdioClient', () => {
         createClient(['--stdio'], { FOO: 'bar' });
 
         expect(mockSpawn).toHaveBeenCalledWith(
-            '/fake/wave',
+            fakeWave,
             ['--stdio'],
             expect.objectContaining({
                 env: expect.objectContaining({ FOO: 'bar' }),
@@ -86,7 +91,7 @@ describe('StdioClient', () => {
         createClient();
 
         expect(mockSpawn).toHaveBeenCalledWith(
-            '/fake/wave',
+            fakeWave,
             [],
             expect.any(Object),
         );

--- a/packages/vsce/tests/stdio/stdioClient.test.ts
+++ b/packages/vsce/tests/stdio/stdioClient.test.ts
@@ -121,7 +121,8 @@ describe('StdioClient', () => {
     /** Mock spawn that enforces Node's Windows `.cmd` guard. */
     function spawnWithCmdGuard(proc: MockProc) {
         mockSpawn.mockImplementation((cmd: string, _args: string[], options: { shell?: boolean } | undefined) => {
-            const isCmdShim = /\.cmd$/i.test(cmd);
+            // (The executable may be pre-quoted for the shell command line.)
+            const isCmdShim = /\.cmd"?$/i.test(cmd);
             if (isCmdShim && options?.shell !== true) {
                 const err = new Error('spawn wave.cmd ERR_CHILD_PROCESS_INVALID_COMMAND_FILE');
                 (err as Error & { code?: string }).code = 'ERR_CHILD_PROCESS_INVALID_COMMAND_FILE';
@@ -131,7 +132,7 @@ describe('StdioClient', () => {
         });
     }
 
-    it('spawns wave.cmd with shell:true on Windows', () => {
+    it('spawns wave.cmd quoted with shell:true on Windows', () => {
         withPlatform('win32', () => {
             const proc = createMockProc();
             const rl = new EventEmitter();
@@ -142,7 +143,9 @@ describe('StdioClient', () => {
             expect(() => new StdioClient('C:\\nodejs\\wave.cmd', ['--stdio'])).not.toThrow();
 
             const call = mockSpawn.mock.calls[0];
-            expect(call[0]).toBe('C:\\nodejs\\wave.cmd');
+            // Pre-quoted for the cmd.exe `shell:true` command line so paths
+            // containing spaces are not split at the space.
+            expect(call[0]).toBe('"C:\\nodejs\\wave.cmd"');
             expect(call[2].shell).toBe(true);
         });
     });


### PR DESCRIPTION
## 问题

客户反馈 Windows 上打开 VS Code 插件有一定概率初始化失败。日志显示：

```
[Wave] Failed to initialize shared client: Error: Command failed: C:\Program Files\nodejs\npm install -g wave-code@0.19.8 --registry=https://registry.npmmirror.com
'C:\Program' 不是内部或外部命令，也不是可运行的程序
```

## 根因（两个叠加 bug）

1. **Node `execFile`/`execFileSync`/`spawn` 在 `shell: true` 下不会给可执行路径加引号**。默认 Node 装在 `C:\Program Files\nodejs`，路径含空格被 cmd.exe 在空格处截断。
2. **`where npm`/`where wave` 首行是无扩展名的 bash 启动器**（`...\npm`），第二行才是 `npm.cmd`。cmd.exe/CreateProcess 无法执行 bash 启动器。

"一定概率"是因为只有触发自动安装/升级 wave-code 流程的用户才踩中。

## 修复

- 新增 `pickExecutableLine()`：Windows 下从 `where` 输出中优先选 `.cmd`/`.exe`/`.bat` 行
- 新增 `quoteForShell()`：win32 + `shell: true` 时预加双引号
- 三端同步修复（逻辑为三份拷贝）：
  - `packages/vsce/src/stdio/binaryResolver.ts` + `stdioClient.ts`
  - `packages/desktop/src/main/stdio/binaryResolver.ts` + `stdioClient.ts`
  - `packages/jetbrains/.../stdio/BinaryResolver.kt`（ProcessBuilder 由 JVM 处理空格引号，只需修选行）

## 测试

- TDD：先写 3 个客户场景复现测试（`C:\Program Files\nodejs` 路径 + `where` 多行输出），确认失败后修复
- VSCE 153 / Desktop 237 / JetBrains 21 测试全绿；type-check + lint 通过
- **真 Windows CI 验证通过**（ci-windows.yml，run 30522025163）：agent-sdk 240 文件、wave-code 84 文件、wave-vsce 9 文件全绿

## 顺带的 Windows CI 修复（main 上预存失败，阻塞了本次验证）

- `a8d63034` test(agent-sdk): backgroundTaskManager notification 测试的 fs mock 缺 `default` 导出 —— shellResolver default-import fs，只在 win32 Git-Bash 探测路径触发（main baseline 同样失败，已证实预存）
- `e938dfb3` test(vsce): stdioClient spawn 路径断言改为平台感知（真 Windows 下路径预加引号）