### PR TITLE
fix: 桌面端切换到全完成任务会话时任务列表不再闪现 5 秒

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -1130,6 +1130,9 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
         />
         <div style={{ display: state.pendingConfirmations.length === 0 ? 'block' : 'none' }}>
           <TaskList
+            // 按会话 id 重挂载：切换会话时重置“观察过未完成任务”的跟踪，
+            // 使全部已完成的新会话立即隐藏，而不是沿用上一会话的 5 秒宽限
+            key={state.currentSession?.id}
             tasks={state.tasks}
             isCollapsed={state.isTaskListCollapsed}
             onToggleCollapse={() => dispatch({ type: 'TOGGLE_TASK_LIST_COLLAPSE' })}

--- a/packages/webview/tests/webview/taskListToggle.test.tsx
+++ b/packages/webview/tests/webview/taskListToggle.test.tsx
@@ -221,3 +221,85 @@ describe('auto-hide when all tasks completed', () => {
     expect(screen.queryByTestId('task-list')).not.toBeInTheDocument();
   });
 });
+
+describe('desktop session switch via setInitialState', () => {
+  const mixed = [
+    { id: '1', subject: '任务一', description: '', status: 'in_progress', blocks: [], blockedBy: [], metadata: {} },
+    { id: '2', subject: '任务二', description: '', status: 'pending', blocks: [], blockedBy: [], metadata: {} },
+  ];
+  const allCompleted = [
+    { id: '1', subject: '任务一', description: '', status: 'completed', blocks: [], blockedBy: [], metadata: {} },
+    { id: '2', subject: '任务二', description: '', status: 'completed', blocks: [], blockedBy: [], metadata: {} },
+  ];
+  const makeSession = (id: string) => ({
+    id,
+    sessionType: 'main',
+    workdir: '/test/project',
+    firstMessage: `Session ${id}`,
+    lastActiveAt: new Date('2023-12-01T10:00:00Z'),
+    latestTotalTokens: 100
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('stays hidden when switching from a session with incomplete tasks to an all-completed one', async () => {
+    renderChatApp();
+    // 桌面端会话 A：存在未完成任务，任务列表可见
+    act(() => {
+      sendCommand('setInitialState', {
+        messages: [],
+        tasks: mixed,
+        session: makeSession('session-a'),
+        isAuthenticated: true
+      });
+    });
+    expect(screen.getByTestId('task-list')).toBeInTheDocument();
+
+    // 桌面端侧边栏切换到会话 B：宿主一次性推送 setInitialState（不经过清空任务）
+    act(() => {
+      sendCommand('setInitialState', {
+        messages: [],
+        tasks: allCompleted,
+        session: makeSession('session-b'),
+        isAuthenticated: true
+      });
+    });
+    // 会话 B 任务全部完成：立即隐藏，不经历 5 秒展示
+    expect(screen.queryByTestId('task-list')).not.toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000);
+    });
+    expect(screen.queryByTestId('task-list')).not.toBeInTheDocument();
+  });
+
+  it('keeps the 5s grace when tasks complete within the same session', async () => {
+    renderChatApp();
+    act(() => {
+      sendCommand('setInitialState', {
+        messages: [],
+        tasks: mixed,
+        session: makeSession('session-a'),
+        isAuthenticated: true
+      });
+    });
+    expect(screen.getByTestId('task-list')).toBeInTheDocument();
+
+    // 同一会话内任务完成（会话 id 不变）：保留 5 秒宽限
+    act(() => {
+      sendCommand('updateTasks', { tasks: allCompleted });
+    });
+    expect(screen.getByTestId('task-list')).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(screen.queryByTestId('task-list')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 问题

桌面端从侧边栏切换到一个任务全部已完成的会话时，任务列表 UI 会先显示几秒再消失，期望这种本就该隐藏的情况一开始就不要显示。

## 根因

2026-07-29 的「加载已全部完成的会话时立即隐藏」修复只覆盖了 IDE 路径（`ChatApp.handleSessionSelect` 切换会话时先 `SET_TASKS []` 清空任务）。桌面端侧边栏切换走的是另一条链路：

`DesktopApp.handleSelectSession` → `desktopSelectSession` → 宿主 `handleSelectSession` → `pushPaneSessionState` 发 `setInitialState`，把新会话的 session + tasks 一次性推给 webview，**不经过清空任务这一步**。

由于同一 pane 的 `ChatApp` 实例不卸载，`TaskList` 内部的 `hadIncompleteRef`（是否在当前组件生命周期内观察到过未完成任务）沿用了上一会话的 `true`，于是切到全完成会话时走进 5 秒宽限分支 → 闪现 5 秒再消失。

## 修复

给 `<TaskList>` 加 `key={state.currentSession?.id}`，按会话 id 重挂载，重置跟踪 ref：全完成的新会话立即隐藏，不再闪现。同一会话内任务完成仍保留 5 秒宽限（行为不变）。

- `packages/webview/src/components/ChatApp.tsx` — TaskList 按会话 id 重挂载
- `packages/webview/tests/webview/taskListToggle.test.tsx` — 新增桌面端 `setInitialState` 切换的两个回归用例：①从有未完成任务的会话切到全完成会话立即隐藏；②同一会话内完成仍保留 5 秒宽限

## 验证

webview 473 tests 全过，类型检查通过，已重建 webview dist 并同步至 vsce/jetbrains/desktop。