### PR TITLE
feat(webview): align bash tool block styling with write preview

### DIFF
--- a/packages/webview/src/styles/Message.css
+++ b/packages/webview/src/styles/Message.css
@@ -519,9 +519,9 @@
     background-color: var(--vscode-textCodeBlock-background);
     font-size: 12px;
     line-height: 1.2;
-    border-radius: 4px;
-    border: 1px solid var(--vscode-textBlockQuote-border);
-    max-height: 160px;
+    border-radius: 6px;
+    border: 1px solid var(--vscode-panel-border);
+    max-height: 120px;
     overflow-y: auto;
     font-family: var(--vscode-editor-font-family);
 }
@@ -537,16 +537,29 @@
 
 /* Unified bash block for input + output */
 .bash-command-unified {
-    border: 1px solid var(--vscode-textBlockQuote-border);
-    border-radius: 4px;
+    position: relative;
+    border: 1px solid var(--vscode-panel-border);
+    border-radius: 6px;
     overflow: hidden;
+}
+
+/* Bottom fade for output (matches .write-preview-scrim) */
+.bash-command-unified::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 40px;
+    background: linear-gradient(to bottom, transparent, var(--vscode-terminal-background, var(--vscode-editor-background)));
+    pointer-events: none;
 }
 
 .bash-command-unified .bash-command-input {
     margin-top: 0;
     border: none;
     border-radius: 0;
-    border-bottom: 1px solid var(--vscode-textBlockQuote-border);
+    border-bottom: 1px solid var(--vscode-panel-border);
 }
 
 .bash-command-unified .bash-command-output {
@@ -559,13 +572,13 @@
     padding: 4px 8px;
     background-color: var(--vscode-terminal-background, var(--vscode-editor-background));
     color: var(--vscode-terminal-foreground, var(--vscode-editor-foreground));
-    border: 1px solid var(--vscode-textBlockQuote-border);
-    border-radius: 4px;
+    border: 1px solid var(--vscode-panel-border);
+    border-radius: 6px;
     font-size: 12px;
     line-height: 1.2;
     white-space: pre-wrap;
     word-break: break-word;
-    max-height: 160px;
+    max-height: 120px;
     overflow-y: auto;
     font-weight: normal;
     font-family: var(--vscode-editor-font-family);


### PR DESCRIPTION
## 背景
webview 中 bash 工具块（`.bash-command-unified`）与 write 预览框（`.write-preview-box`）摆在一起时视觉割裂：边框颜色、圆角、底部渐变、滚动区高度都不一致。

## 改动
统一 bash 块与 write 预览框的视觉样式：

- **边框/圆角**：`.bash-command-input` / `.bash-command-unified` / `.bash-command-output` 由 `--vscode-textBlockQuote-border` + 4px 改为 `--vscode-panel-border` + 6px，与 write 一致
- **底部渐变**：给 `.bash-command-unified::after` 加 40px scrim，渐变到 `terminal-background`，仅盖 output 底部（input 命令行通常不滚动，不加）
- **max-height**：input/output 由 160px 调为 120px，对齐 write 滚动区

## 验证
- webview 重建通过
- `product-spec-tools` demo（生成 spec-bash.png）+ `tool-error-scrollable` demo 全部通过，截图已重新生成