### PR TITLE
fix: return string from import.meta.url shim to match spec

### DIFF
--- a/packages/desktop/scripts/import-meta-url-shim.js
+++ b/packages/desktop/scripts/import-meta-url-shim.js
@@ -1,1 +1,1 @@
-export var import_meta_url = require('url').pathToFileURL(__filename);
+export var import_meta_url = require('url').pathToFileURL(__filename).href;

--- a/packages/vsce/scripts/import-meta-url-shim.js
+++ b/packages/vsce/scripts/import-meta-url-shim.js
@@ -1,2 +1,2 @@
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-export var import_meta_url = require('url').pathToFileURL(__filename);
+export var import_meta_url = require('url').pathToFileURL(__filename).href;


### PR DESCRIPTION
The `import.meta.url` polyfill shims (used by esbuild/tsup CJS bundles in VSCE and desktop) returned a `URL` object via `pathToFileURL(__filename)`, but the spec defines `import.meta.url` as a string. Add `.href` so the shimmed value matches the spec type.

This is the officially-recommended esbuild pattern (evanw/esbuild#1633); no native CJS support exists yet. Behavior was already correct because downstream `fileURLToPath()` accepts both, but the type is now spec-accurate.