### PR TITLE
fix(webview): 切换到含确认弹窗的并排对话时聚焦弹窗主按钮

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -400,9 +400,32 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
           break;
         case 'focusInput':
           if (!forThisPane(message)) break;
-          // Focus the message input
-          if (messageInputRef.current && typeof messageInputRef.current.focus === 'function') {
-            messageInputRef.current.focus();
+          // When a confirm/rewind dialog is open in this pane, focus its
+          // primary action instead of the message input. The input is hidden
+          // (display:none) during a tool-permission confirmation, so focusing it
+          // silently no-ops; a rewind modal also covers it. Landing focus on
+          // the dialog lets the user act on it immediately (Enter to confirm,
+          // Esc to cancel) right after the pane switch. Falls back to the
+          // message input when no dialog is open.
+          {
+            const root = chatContainerRef.current ?? document;
+            const rewindBtn = root.querySelector<HTMLElement>(
+              '.confirm-dialog-btn-confirm:not([disabled])',
+            );
+            if (rewindBtn) {
+              rewindBtn.focus();
+              break;
+            }
+            const applyBtn = root.querySelector<HTMLElement>(
+              '.confirmation-btn-apply:not([disabled])',
+            );
+            if (applyBtn) {
+              applyBtn.focus();
+              break;
+            }
+            if (messageInputRef.current && typeof messageInputRef.current.focus === 'function') {
+              messageInputRef.current.focus();
+            }
           }
           break;
         case 'triggerShortcut':

--- a/packages/webview/tests/webview/focusInputDialog.test.tsx
+++ b/packages/webview/tests/webview/focusInputDialog.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderChatApp, screen, fireEvent, act, sendCommand } from './test-utils';
+import { MockDataGenerator } from '../fixtures/mockData';
+import { EDIT_TOOL_NAME } from 'wave-agent-sdk';
+
+// Switching to a side-by-side pane fires `focusInput`. When a confirm/rewind
+// dialog is open in that pane the message input is hidden (display:none during
+// a tool confirmation) or covered (rewind modal), so focusing it silently
+// no-ops. Instead the dialog's primary action should receive focus so the
+// keyboard works on it immediately after the switch.
+describe('focusInput with an open dialog', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    function blurActive() {
+        (document.activeElement as HTMLElement | null)?.blur();
+    }
+
+    it('focuses the message input when no dialog is open', () => {
+        renderChatApp();
+
+        blurActive();
+        act(() => {
+            sendCommand('focusInput');
+        });
+
+        expect(document.activeElement).toBe(screen.getByTestId('message-input'));
+    });
+
+    it('focuses the confirmation dialog primary button when a tool confirmation is open', async () => {
+        renderChatApp();
+
+        await act(async () => {
+            sendCommand('showConfirmation', {
+                confirmationId: 'test_confirmation',
+                toolName: EDIT_TOOL_NAME,
+                confirmationType: '代码修改待确认',
+                toolInput: { file_path: 'test.ts', old_string: 'old', new_string: 'new' },
+            });
+        });
+
+        const applyBtn = document.querySelector('.confirmation-btn-apply') as HTMLElement;
+        expect(applyBtn).not.toBeNull();
+        // The message input is hidden while the confirmation is showing.
+        expect(screen.getByTestId('message-input')).not.toBeVisible();
+
+        blurActive();
+        act(() => {
+            sendCommand('focusInput');
+        });
+
+        expect(document.activeElement).toBe(applyBtn);
+    });
+
+    it('focuses the rewind confirm button when the rewind modal is open', async () => {
+        renderChatApp();
+
+        const messages = [
+            MockDataGenerator.createUserMessage('Message 1', 'msg-1'),
+            MockDataGenerator.createAssistantMessage('Response 1', 'msg-2'),
+        ];
+        act(() => {
+            sendCommand('updateMessages', { messages });
+        });
+
+        // Open the rewind confirmation modal.
+        await act(async () => {
+            fireEvent.click(document.querySelector('.message-action-btn') as HTMLElement);
+        });
+        expect(screen.getByTestId('confirm-dialog-overlay')).toBeInTheDocument();
+
+        const confirmBtn = screen.getByTestId('confirm-dialog-confirm');
+        blurActive();
+        act(() => {
+            sendCommand('focusInput');
+        });
+
+        expect(document.activeElement).toBe(confirmBtn);
+    });
+});


### PR DESCRIPTION
## 背景

并排显示对话时，用快捷键（Ctrl+Tab 等）切换到一个对话会发送 `focusInput`，消息输入框自动聚焦。但当目标窗格开着确认弹窗时焦点无处可落：

- **工具权限确认**期间，`MessageInput` 被外层 `display: none` 隐藏（`ChatApp.tsx:1149`），`textarea.focus()` 作用在隐藏元素上被浏览器静默忽略。
- **回滚确认弹窗**（modal overlay）覆盖输入框，聚焦输入框意义不大。

## 改动

`focusInput` 处理逻辑改为优先聚焦当前窗格内已打开弹窗的主操作按钮，无弹窗时再回退到消息输入框（`ChatApp.tsx`）：

1. 回滚弹窗 → `.confirm-dialog-btn-confirm`（确定）
2. 工具权限确认 → `.confirmation-btn-apply`（批准并继续 / 是 / 提交回答）
3. 否则 → 消息输入框（保持原行为）

查询作用域为 `chatContainerRef.current`（各窗格独立容器，避免误选兄弟窗格的弹窗），非桌面单视图回退到 `document`。使用 `:not([disabled])` 跳过禁用按钮（如 AskUserQuestion 未作答时的提交按钮）。切换过去后即可 Enter 确认、Esc 取消。

## 测试

新增 `focusInputDialog.test.tsx`，覆盖三种场景：

- 无弹窗 → 聚焦消息输入框
- 工具权限确认打开 → 聚焦 `.confirmation-btn-apply`
- 回滚弹窗打开 → 聚焦 `.confirm-dialog-btn-confirm`

已验证三个用例在修复前会失败（焦点落在隐藏的输入框上）、修复后通过。webview 全量测试 474/474 通过。