### PR TITLE
ci: make JetBrains workflow manual-only

### DIFF
--- a/.github/workflows/ci-jetbrains.yml
+++ b/.github/workflows/ci-jetbrains.yml
@@ -6,8 +6,6 @@ name: CI (JetBrains)
 # logic has no merge gate.
 
 on:
-  pull_request:
-    branches: [main, develop]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
将 `ci-jetbrains.yml` 的触发条件改为仅 `workflow_dispatch`（手动运行），移除 `pull_request` 触发，避免每次 PR 都跑 JetBrains Gradle 测试套件。