### PR TITLE
fix(desktop): 两行布局下内联 confirmation 超高改为内层滚动

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -1205,7 +1205,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
         />
       )}
 
-      <div className="input-area-container">
+      <div className={`input-area-container${isDesktop && state.pendingConfirmations.length > 0 ? ' input-area-container--confirm' : ''}`}>
         <RewindPopup
           isVisible={rewindPopupOpen}
           isLoading={rewindCheckpointsLoading}

--- a/packages/webview/src/styles/DesktopApp.css
+++ b/packages/webview/src/styles/DesktopApp.css
@@ -762,3 +762,31 @@
     font-size: 12px;
     color: var(--vscode-descriptionForeground, #999);
 }
+
+/* Two-row mode compresses the message row; an inline ConfirmationDialog
+   (plan preview / permission / AskUserQuestions) can grow taller than the
+   compressed first row. Let the input area shrink within the flex column and
+   the dialog body scroll, instead of overflowing onto the second-row panels.
+   Scoped under .desktop-chat-main so VSCE/JB (single-row, full-height) stay
+   on the inline auto-height path. */
+.desktop-chat-main .input-area-container--confirm {
+    flex: 0 1 auto;
+    min-height: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.desktop-chat-main .input-area-container--confirm .confirmation-dialog {
+    flex: 0 1 auto;
+    min-height: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.desktop-chat-main .input-area-container--confirm .confirmation-dialog-inner {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+}

--- a/packages/webview/tests/webview/chatAppPanels.test.tsx
+++ b/packages/webview/tests/webview/chatAppPanels.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent, screen, createEvent, within, act } from '@testing-li
 import React from 'react';
 import { DesktopApp } from '../../src/components/DesktopApp';
 import { ChatApp, prunePanelGroupCache } from '../../src/components/ChatApp';
+import { EXIT_PLAN_MODE_TOOL_NAME } from 'wave-agent-sdk';
 import { createMockVscode, sendCommand, renderChatApp, fireInput } from './test-utils';
 
 vi.mock('../../src/styles/DesktopApp.css', () => ({}));
@@ -494,6 +495,33 @@ describe('ChatApp desktop panel framework', () => {
             const bodyA2 = paneA2.querySelector('.desktop-chat-body') as HTMLElement;
             expect(bodyA2.className).toContain('desktop-chat-body--two-rows');
             expect(bodyA2.style.getPropertyValue('--panel-row-height')).toBe('280px');
+        });
+
+        // Two-row mode compresses the message row; an inline ConfirmationDialog
+        // (plan preview / permission / AskUserQuestions) can grow taller than the
+        // compressed first row. The input area must clamp and the dialog body must
+        // scroll instead of overflowing onto the second-row panels.
+        it('two-row mode clamps an over-tall inline ConfirmationDialog with an inner scroller', async () => {
+            window.waveHostType = 'desktop';
+            renderDesktop({ workdir: '/work/a' });
+            openDiffPanel();
+            dragDiffToRow2();
+            expect(bodyOf().className).toContain('desktop-chat-body--two-rows');
+
+            await act(async () => {
+                sendCommand('showConfirmation', {
+                    confirmationId: 'confirm_two_row',
+                    toolName: EXIT_PLAN_MODE_TOOL_NAME,
+                    confirmationType: '计划待确认',
+                    planContent: '## Plan\n' + '- step\n'.repeat(120),
+                });
+            });
+
+            const inputArea = document.querySelector('.input-area-container') as HTMLElement;
+            expect(inputArea).not.toBeNull();
+            expect(inputArea.className).toContain('input-area-container--confirm');
+            const inner = document.querySelector('.confirmation-dialog-inner') as HTMLElement;
+            expect(inner).toBeInTheDocument();
         });
     });
 });


### PR DESCRIPTION
## 问题

desktop 两行布局（消息区第一行 + 面板第二行）压缩第一行高度时，内联 `ConfirmationDialog`（plan mode 的 plan 预览 / 工具权限确认 / AskUserQuestions）会超出第一行可用高度，溢出到第二行面板区或被裁剪。

`.confirmation-dialog-inner` 整体没有 max-height，子块各自封顶（plan preview 300、diff 300、mcp-params 200），堆叠起来轻松 600–800px，两行压缩后必然溢出。

## 改动

- `ChatApp.tsx`：`input-area-container` 在 desktop 且有 pending confirmation 时加 `--confirm` modifier。
- `DesktopApp.css`：`.desktop-chat-main .input-area-container--confirm` 链路用 flex 收缩 + overflow，让 `.confirmation-dialog-inner` 自身 `flex:1; min-height:0; overflow-y:auto`——内容超高时在第一行内滚动，而不是溢出。
- 选择器限定在 `.desktop-chat-main` 下，VSCE/JB 单行全高路径不受影响。
- `ConfirmDialog`（回滚/删会话）本就是 `position:fixed` 视口 overlay，两行布局不影响它，无需改动。

## 测试

- 新增 `chatAppPanels` 测试：两行 + 长 plan confirmation 验证 `--confirm` class 与 inner 存在（19 全过）。
- 回归 confirmation/desktop 共 102 测试全过。
- webview dist 已 rebuild 并同步到 vsce/jetbrains。

> jsdom 测不了真实 CSS 滚动溢出，建议 desktop dev 拉矮窗口 + 两行 + 触发长 plan confirmation 真机确认 inner 滚动。