### PR TITLE
fix(desktop): 消除分屏并排时的多余水平滚动条

### DIFF
--- a/packages/webview/src/components/DesktopShell.tsx
+++ b/packages/webview/src/components/DesktopShell.tsx
@@ -503,7 +503,14 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
                   // Live preview while a separator drags (pixel widths).
                   paneStyle.flex = `0 0 ${resizePreview.widths[index]}px`;
                 } else if (pane.width != null) {
-                  paneStyle.flex = `0 0 ${pane.width * 100}%`;
+                  // flex-shrink:1 lets panes absorb the few px of overflow that
+                  // otherwise accumulates from each pane's border-right (content-
+                  // box, not counted in the % basis) plus the separators' net
+                  // width — and triggers an overflow-x scrollbar by ~5px even
+                  // when every pane is far above MIN_PANE_WIDTH. Grow stays 0
+                  // (sizes are authoritative ratios); shrink bottoms out at the
+                  // min-width above.
+                  paneStyle.flex = `0 1 ${pane.width * 100}%`;
                 }
                 return (
                   <React.Fragment key={pane.paneId}>


### PR DESCRIPTION
3-4 个对话并排时出现水平滚动条，根因是 DesktopShell 渲染 pane 时用 flex: 0 0 ${width*100}%（flex-shrink:0），禁止 pane 收缩，导致以下几像素溢出无法被吸收，触发 .desktop-pane-row 的 overflow-x:auto：

- 每个 pane 的 border-right:1px 在 content-box 下不计入 % basis（+1px/pane）
- 分隔条 flex:0 0 5px + margin:0 -2px 净占 ~1px/条

宽屏下每个 pane 远超 MIN_PANE_WIDTH(360)，min-width 并未触发，溢出仅 ~5px，表现为「每个窗格已经很宽、稍窄一点就消失」的假滚动条。

修复：改为 flex: 0 1，允许 pane 收缩这几像素（到 min-width 为止兜底）；grow 仍为 0（宽度比例由 host 权威下发）；拖动中的实时像素预览保留 0 0 维持精确。
