### PR TITLE
Revert per-worktree dev userData isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Always use `pnpm` as the package manager.
 - **Test**: `pnpm run jb:test`
 
 ### Desktop App (`packages/desktop`)
-- **Run dev**: `cd packages/desktop && pnpm run dev` (compiles, then launches Electron; dev uses a per-worktree `wave-desktop-dev-<hash>` userData keyed by app-path hash, so worktrees and the installed app all run side by side)
+- **Run dev**: `cd packages/desktop && pnpm run dev` (compiles, then launches Electron; dev uses a separate `wave-desktop-dev` userData so it coexists with the installed app)
 - **Build installer**: `pnpm run dist` (electron-builder → `release/`). **Do not bypass `scripts/afterPack.js`**: electron-builder's bundle mutation breaks the ad-hoc linker seal, and without the re-sign step LaunchServices silently refuses to launch the app.
 - **Test**: `pnpm -F wave-desktop test`
 - **Architecture**: the main process wraps the shared webview and talks JSON-RPC to a `wave --stdio` child process — `src/main/desktopHost.ts` (agent pool: one `StdioAgent` per session for parallel conversations, see FR-031) → `stdio/stdioClient.ts` + `stdio/notificationRouter.ts` (routes notifications by sessionId). Session index/worktree metadata persists in `userData/wave-desktop.json` via `configStore.ts`.

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -8,7 +8,6 @@
 
 import { app, BrowserWindow, ipcMain, nativeImage, shell } from 'electron';
 import { execFileSync } from 'child_process';
-import * as crypto from 'crypto';
 import * as path from 'path';
 import { WEBVIEW_CHANNEL } from './channels';
 import { ConfigStore } from './configStore';
@@ -41,13 +40,11 @@ function adoptLoginShellPath(): void {
 
 adoptLoginShellPath();
 
-// Dev instances get a per-worktree userData (keyed by a hash of the app
-// path): the single-instance lock is scoped to the userData directory, so
-// worktrees run side by side without focus-stealing and never touch the
-// installed app's config/session index.
+// Dev instances get their own userData so they can run alongside an installed
+// app (the single-instance lock is scoped to the userData directory) and never
+// touch the real config/session index.
 if (!app.isPackaged) {
-  const worktreeHash = crypto.createHash('sha256').update(app.getAppPath()).digest('hex').slice(0, 8);
-  app.setPath('userData', path.join(app.getPath('appData'), `wave-desktop-dev-${worktreeHash}`));
+  app.setPath('userData', path.join(app.getPath('appData'), 'wave-desktop-dev'));
 }
 
 let mainWindow: BrowserWindow | null = null;


### PR DESCRIPTION
Reverts commit 27a56dca (per-worktree `wave-desktop-dev-<hash>` userData keyed by app-path hash).

Dev 实例回到共享 `wave-desktop-dev` userData：每个 worktree 不再各自独立 userData/单实例锁/会话索引。原因：隔离方案导致每次换 worktree 都记不住上次目录、影响效率；用户决定多个 worktree 共享同一个 dev 实例。

副作用（已知、可接受）：跨 worktree 单实例锁重新生效——旧 dev 实例未关时新 `pnpm run dev` 会静默聚焦旧窗口，串行测试前需先关旧实例。

只影响 dev（`!app.isPackaged` 分支），已安装的 /Applications/Wave.app 不受影响。