### PR TITLE
fix(compaction): 压缩 fork 改为流式请求，避免慢推理模型触发网关空闲超时

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -790,6 +790,10 @@ export class AIManager {
         tools: toolsConfig,
         systemPrompt,
         toolChoice: this.toolChoiceOverride,
+        // Stream so a slow reasoning model emits first bytes before the
+        // gateway's idle timeout fires (non-streaming waits for the full
+        // summary, which exceeds the timeout on large contexts).
+        stream: true,
       });
 
       if (result.usage) {

--- a/packages/agent-sdk/src/services/aiService.ts
+++ b/packages/agent-sdk/src/services/aiService.ts
@@ -168,6 +168,12 @@ export interface CallAgentOptions {
     | "required"
     | { type: "function"; function: { name: string } }; // Force tool selection
 
+  // Force SSE streaming independent of callback presence. Long-running
+  // non-interactive calls (e.g. the compaction fork) need streaming so a
+  // slow reasoning model isn't killed by a gateway idle timeout before the
+  // first byte arrives.
+  stream?: boolean;
+
   // NEW: Streaming callbacks
   onContentUpdate?: (content: string) => void;
   onToolUpdate?: (toolCall: {
@@ -318,11 +324,9 @@ export async function callAgent(
     });
 
     // Determine if streaming is needed
-    const isStreaming = !!(
-      onContentUpdate ||
-      onToolUpdate ||
-      onReasoningUpdate
-    );
+    const isStreaming =
+      options.stream === true ||
+      !!(onContentUpdate || onToolUpdate || onReasoningUpdate);
 
     // Prepare API call parameters
     createParams = {

--- a/packages/agent-sdk/tests/managers/aiManager.compactConversation.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.compactConversation.test.ts
@@ -188,6 +188,10 @@ describe("AIManager - compactConversation", () => {
       );
       // The fork must NOT use the fast model — that would bust the cache.
       expect(callAgentMock.mock.calls[0][0].model).toBeUndefined();
+      // The fork must stream so a slow reasoning model emits first bytes
+      // before the gateway idle timeout fires (non-streaming waits for the
+      // full summary on the largest context and gets killed).
+      expect(callAgentMock.mock.calls[0][0].stream).toBe(true);
       expect(
         mockMessageManager.compactMessagesAndUpdateSession,
       ).toHaveBeenCalled();

--- a/packages/agent-sdk/tests/services/aiService.streaming.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.streaming.test.ts
@@ -501,6 +501,49 @@ describe("AI Service - Streaming", () => {
       expect(callArgs.stream).toBeFalsy();
     });
 
+    it("should enable streaming mode when stream option is true without callbacks", async () => {
+      // Mock streaming response
+      const mockStream = (async function* () {
+        yield {
+          choices: [
+            {
+              delta: { content: "Hello" },
+            },
+          ],
+        };
+        yield {
+          choices: [
+            {
+              delta: { content: " world" },
+              finish_reason: "stop",
+            },
+          ],
+        };
+      })();
+
+      const mockWithResponse = vi.fn().mockResolvedValue({
+        data: mockStream,
+        response: {
+          headers: new Map(),
+        },
+      });
+      mockCreate.mockReturnValue({ withResponse: mockWithResponse });
+
+      const result = await callAgent({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: TEST_MODEL_CONFIG,
+        messages: [{ role: "user", content: "Test message" }],
+        workdir: "/test/workdir",
+        stream: true,
+      });
+
+      // Should call create with stream: true even though no callbacks
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.stream).toBe(true);
+      // Streamed content is still accumulated into the result
+      expect(result.content).toBe("Hello world");
+    });
+
     it("should include reasoning_content in streaming result even if it is an empty string", async () => {
       // Mock streaming response with an empty reasoning_content delta
       const mockStream = (async function* () {


### PR DESCRIPTION
## 根因

`runCompactFork` 调用 `callAgent` 时未传流式回调（`onContentUpdate`/`onToolUpdate`/`onReasoningUpdate`），而 `callAgent` 的 `isStreaming` 完全靠回调是否存在来判断，于是走 **非流式** 路径（`stream: false`）。

非流式请求 = 网关必须等模型**生成完整 summary 后才返回首字节**。而压缩请求是整个会话里最坏的情况：

- 输入最大——正是刚撞到 `maxInputTokens` 阈值才触发压缩的那条历史；
- 模型最慢——重构后从 `fastModel` 换成了主模型 `glm-5.2`（慢推理模型，TTFT ~30-44s）。

glm-5.2 × 最大上下文 × 非流式 → 首字节 > 60s → codechat 网关的 `SSE_IDLE_TIMEOUT_MS`（默认 60s）把上游 fetch abort → `clientClosed=false` 走 `next(err)` → 转成 500 → wave-agent 重试 → 又超 60s → 一串乱序 attempt 重试循环。

服务端分析已确认：这 11 个 500 不是真·网关 5xx（0 条上游 `AI gateway error` 转发日志），全是代理自己的 60s 空闲超时。

## 三条路径对比

| 路径 | stream | 模型 | 结果 |
|---|---|---|---|
| 主循环 | ✅ stream（首字节续命 timer）| glm-5.2 | 活 |
| 旧 `compactMessages` | ❌ 非流式 | fastModel（快，<60s）| 活 |
| 新 `runCompactFork` | ❌ 非流式 | glm-5.2（慢，>60s）| **被砍→500** |

## 修复

- `aiService.ts`：`CallAgentOptions` 新增 `stream?: boolean`；`isStreaming = options.stream === true || !!(onContentUpdate||onToolUpdate||onReasoningUpdate)`，将「流式模式」与「内容回调」解耦
- `aiManager.ts`：`runCompactFork` 传 `stream: true`

`processStreamingResponse` 本就返回 `content`/`tool_calls`/`usage`/`finish_reason`，所以 fork 的工具拒绝 + usage 逻辑不变；主循环已靠流式续命，fork 现在与之一致。

## 测试

- `aiService.streaming.test.ts`：新增 `stream: true` 无回调场景 → `callArgs.stream === true` 且内容正确累积
- `aiManager.compactConversation.test.ts`：断言 fork 调用带 `stream: true`

dist 已重建，type-check 通过，compaction/streaming 共 45 测试全过。

## 兜底提示

流式只能保证「首字节 < 60s 即续命」；对极端大上下文若 TTFT 本身超 60s，服务端 `SSE_IDLE_TIMEOUT_MS` 仍需调高（如 120000）兜底。