### PR TITLE
fix(desktop): 第二行面板未占满分屏宽度

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -1294,6 +1294,13 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
   // With no first-row panels the message area must claim the full first line,
   // otherwise the row separator would share its line (flex-wrap line packing).
   const panelRow1Empty = !checkedPanels.some((k) => panelRows[k] === 1);
+  // The last checked second-row panel (by the fixed Preview→Diff→Terminal
+  // order) grows to fill the remaining width so the second row spans the full
+  // pane width instead of leaving a gap to the right of a lone panel.
+  const row2CheckedKinds = PANEL_ORDER.filter(
+    (k) => checkedPanels.includes(k) && panelRows[k] === 2,
+  );
+  const row2FillKind = row2CheckedKinds[row2CheckedKinds.length - 1];
 
   const chatContainer = (
     <div className="chat-container" data-testid="chat-container" ref={isDesktop ? chatContainerRef : undefined}>
@@ -1353,7 +1360,9 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
                 if (el) panelSlotNodes.current.set(kind, el);
                 else panelSlotNodes.current.delete(kind);
               }}
-              className={`desktop-panel-slot desktop-panel-slot--row-${panelRows[kind]}`}
+              className={`desktop-panel-slot desktop-panel-slot--row-${panelRows[kind]}${
+                kind === row2FillKind ? ' desktop-panel-slot--row-2-fill' : ''
+              }`}
               style={{ display: checkedPanels.includes(kind) ? undefined : 'none' }}
             >
               {renderPanelSlot(kind)}

--- a/packages/webview/src/styles/DesktopApp.css
+++ b/packages/webview/src/styles/DesktopApp.css
@@ -695,6 +695,18 @@
     order: 3;
 }
 
+/* The last second-row panel grows to span the full pane width (the spec's
+   "第二行横贯分屏宽度"); earlier second-row panels keep their set widths.
+   basis:auto keeps the panel's pixel width as the line-break hypothetical so
+   the slot lands on its own line, then flex-grow stretches it to fill. */
+.desktop-panel-slot--row-2-fill {
+    flex: 1 1 auto;
+}
+
+.desktop-panel-slot--row-2-fill > * {
+    flex: 1 1 auto;
+}
+
 /* Two-row mode: the first line (message area + first-row panels) takes the
    height left by the second row and the separator; second-row slots take the
    configured row height. */

--- a/packages/webview/tests/webview/chatAppPanels.test.tsx
+++ b/packages/webview/tests/webview/chatAppPanels.test.tsx
@@ -177,6 +177,11 @@ describe('ChatApp desktop panel framework', () => {
             expect(screen.getByTestId('diff-pane').closest('.desktop-panel-slot')).toHaveClass(
                 'desktop-panel-slot--row-2',
             );
+            // A lone second-row panel must fill the pane width (spec: 第二行
+            // 横贯分屏宽度), so the slot stretches instead of leaving a gap.
+            expect(screen.getByTestId('diff-pane').closest('.desktop-panel-slot')).toHaveClass(
+                'desktop-panel-slot--row-2-fill',
+            );
             expect(screen.queryByTestId('desktop-panel-hint')).not.toBeInTheDocument();
         } finally {
             rectSpy.mockRestore();
@@ -258,16 +263,18 @@ describe('ChatApp desktop panel framework', () => {
         }
 
         // Starts a toolbar drag, targets the bottom band, and drops there.
-        function dragDiffToRow2(bodyHeight = 800) {
+        function dragToRow2(testid: string, bodyHeight = 800) {
             const body = bodyOf();
             mockChatBodyHeight(body, bodyHeight);
-            const toolbar = toolbarOf('diff-pane');
+            const toolbar = toolbarOf(testid);
             const dataTransfer = makeDataTransfer();
             fireEvent.dragStart(toolbar, { dataTransfer });
             dragOverBody(body, dataTransfer, bodyHeight - 10);
             fireEvent.drop(body, { dataTransfer });
             fireEvent.dragEnd(toolbar, { dataTransfer });
         }
+
+        const dragDiffToRow2 = (bodyHeight = 800) => dragToRow2('diff-pane', bodyHeight);
 
         it('dragging a panel toolbar into the bottom band creates the second row', () => {
             window.waveHostType = 'desktop';
@@ -391,6 +398,24 @@ describe('ChatApp desktop panel framework', () => {
 
             expect(slotOf('diff-pane').className).toContain('desktop-panel-slot--row-1');
             expect(screen.queryByTestId('desktop-panel-row-separator')).not.toBeInTheDocument();
+        });
+
+        it('only the last second-row panel grows to fill the row width', () => {
+            window.waveHostType = 'desktop';
+            renderDesktop({ workdir: '/work/a' });
+            fireEvent.click(screen.getByTestId('panel-toggle-btn'));
+            fireEvent.click(screen.getByTestId('panel-toggle-item-diff'));
+            fireEvent.click(screen.getByTestId('panel-toggle-item-terminal'));
+            // Drag both into the second row; the fixed order is Preview→Diff→Terminal,
+            // so terminal is the last and should absorb the remaining width.
+            dragToRow2('diff-pane');
+            dragToRow2('terminal-pane');
+            const diffSlot = slotOf('diff-pane');
+            const termSlot = slotOf('terminal-pane');
+            expect(diffSlot.className).toContain('desktop-panel-slot--row-2');
+            expect(termSlot.className).toContain('desktop-panel-slot--row-2');
+            expect(diffSlot.className).not.toContain('desktop-panel-slot--row-2-fill');
+            expect(termSlot.className).toContain('desktop-panel-slot--row-2-fill');
         });
 
         it('the second-row layout is remembered per session across switches', () => {


### PR DESCRIPTION
## 问题

并排分屏时，给某个对话打开 diff/预览面板，面板出现在对话下方（第二行）但宽度没有占满，右侧留白。

## 原因

第二行面板槽 `desktop-panel-slot--row-2` 只设了 `order` 和高度，**没有 `flex-grow`**，所以只占内部 `<aside>` 的固定像素宽度（默认 420px），剩余空间空着。这与 spec「第二行横贯分屏宽度」（docs/specs/ui/desktop-app.md）相矛盾——第一行（消息区右侧）不填满是设计，但第二行应当横贯整个分屏宽度。

## 修复

- `ChatApp.tsx`：算出第二行最后一个可见面板（按 Preview→Diff→Terminal 固定序）`row2FillKind`，给它的槽加 `desktop-panel-slot--row-2-fill`。
- `DesktopApp.css`：该槽及内部面板用 `flex: 1 1 auto`——以面板像素宽度为 `flex-basis` 保证换行落位（之前 `flex: 1 1 0` 会让换行假定尺寸塌成 0、面板消失），再用 `flex-grow` 撑满剩余宽度。

语义对齐 VS Code 编辑器分组「最后一组撑满」：单个面板撑满整行；多个面板时前面的保持各自像素宽度可拖拽，最后一个吸收剩余宽度。

## 测试

- `chatAppPanels.test.tsx` 新增 2 个用例：单面板填满 / 仅最后一个面板填满；24 项全过。
- type-check、lint 通过；webview 已重建并同步到 VSCE/JetBrains；桌面 dev 真机确认填满。