### PR TITLE
docs: add desktop:install command to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ Always use `pnpm` as the package manager.
 ### Desktop App (`packages/desktop`)
 - **Run dev**: `cd packages/desktop && pnpm run dev` (compiles, then launches Electron; dev uses a separate `wave-desktop-dev` userData so it coexists with the installed app)
 - **Build installer**: `pnpm run dist` (electron-builder → `release/`). **Do not bypass `scripts/afterPack.js`**: electron-builder's bundle mutation breaks the ad-hoc linker seal, and without the re-sign step LaunchServices silently refuses to launch the app.
+- **Install/update installed app**: `pnpm run desktop:install` (run from repo root). Does a full `pnpm build` → `electron-builder --dir` → `rsync -a --delete` over `/Applications/Wave.app/`. Full build (not selective) is required because the user consumes `wave-code` via npm link. **Do not quit/kill/relaunch the user's running Wave.app** — rsync over a running `.app` is safe on macOS; restart is manual.
 - **Test**: `pnpm -F wave-desktop test`
 - **Architecture**: the main process wraps the shared webview and talks JSON-RPC to a `wave --stdio` child process — `src/main/desktopHost.ts` (agent pool: one `StdioAgent` per session for parallel conversations, see FR-031) → `stdio/stdioClient.ts` + `stdio/notificationRouter.ts` (routes notifications by sessionId). Session index/worktree metadata persists in `userData/wave-desktop.json` via `configStore.ts`.
 - **CLI resolution**: `WAVE_CLI_PATH` env var points at a workspace `wave-code` build; otherwise the bundled binary is used.


### PR DESCRIPTION
## 改动
在 AGENTS.md 的 Desktop App 小节补充 `pnpm run desktop:install` 命令文档。

## 流程
全量 `pnpm build` → `electron-builder --dir` → `rsync -a --delete` 覆盖 `/Applications/Wave.app/`。

## 要点
- 全量 build（用户通过 npm link 使用 workspace 的 wave-code 包作为 CLI 后端，需重建）
- 不退出/重启用户正在运行的 Wave.app（rsync 覆盖运行中的 .app 在 macOS 上安全，重启由用户手动）

省得下次安装客户端时到处找命令。