### PR TITLE
fix(desktop): isolate new-session pane workdir/branch from sibling focus

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -1342,13 +1342,15 @@ export class DesktopHost {
     }
   }
 
-  /** FR-052 proxy: branch list for the new-session worktree selector. */
-  private async handleListGitBranches(workdir: string): Promise<void> {
+  /** FR-052 proxy: branch list for the new-session worktree selector. The
+   * reply carries paneId so each pane consumes only its own branch list — a
+   * sibling pane focusing and re-querying must not overwrite this pane. */
+  private async handleListGitBranches(workdir: string, paneId?: string): Promise<void> {
     try {
       const result = await this.utilityClient.request('listGitBranches', { workdir });
-      this.postMessage({ command: 'desktopGitBranches', workdir, result });
+      this.postMessage({ command: 'desktopGitBranches', workdir, paneId, result });
     } catch {
-      this.postMessage({ command: 'desktopGitBranches', workdir, result: null });
+      this.postMessage({ command: 'desktopGitBranches', workdir, paneId, result: null });
     }
   }
 
@@ -1509,7 +1511,7 @@ export class DesktopHost {
         break;
 
       case 'desktopListGitBranches':
-        await this.handleListGitBranches(msg.workdir as string);
+        await this.handleListGitBranches(msg.workdir as string, msg.paneId as string | undefined);
         break;
 
       // Read-only workspace diff for the diff panel — runs git directly in

--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -106,6 +106,16 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
   // Desktop new-session worktree controls (FR-022/FR-023).
   const [worktreeBranch, setWorktreeBranch] = useState<string>('');
   const [worktreeChecked, setWorktreeChecked] = useState(true);
+  // Per-pane git branches for this pane's OWN workdir (FR-022). The host-level
+  // workdir follows the focused pane — sharing it would bleed one pane's
+  // directory/branch into a sibling new-session pane, so each new-session pane
+  // queries branches against its own session workdir.
+  const [paneGitBranches, setPaneGitBranches] = useState<{ branches: string[]; current: string } | null>(null);
+  // The pane's effective cwd: its own session workdir wins over the host-level
+  // current workdir (which follows the focused pane and must not leak here).
+  const effectiveWorkdir = state.workdir ?? (host?.type === 'desktop' ? host?.workdir : undefined);
+  const gitBranches = host?.type === 'desktop' ? paneGitBranches : null;
+  const effectiveWorkdirRef = useRef(effectiveWorkdir);
   // Desktop only: the panel group follows the session bound to this pane. The
   // cache key is the session id from the host-authoritative `desktopPanes`
   // push, or the pane's new-session bucket while no session is bound.
@@ -186,6 +196,10 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
   useEffect(() => {
     stateRef.current = state;
   }, [state]);
+
+  useEffect(() => {
+    effectiveWorkdirRef.current = effectiveWorkdir;
+  }, [effectiveWorkdir]);
 
   useEffect(() => {
     checkedPanelsRef.current = checkedPanels;
@@ -277,7 +291,6 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
 
   // Desktop: reset the worktree controls when the branch list changes (i.e. the
   // workdir was re-queried). Default to the repo's current branch, checked.
-  const gitBranches = host?.type === 'desktop' ? host.gitBranches : null;
   useEffect(() => {
     setWorktreeBranch(gitBranches?.current ?? '');
     setWorktreeChecked(true);
@@ -326,6 +339,12 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
         case 'updateWorkdir':
           if (!forThisPane(message)) break;
           dispatch({ type: 'SET_WORKDIR', payload: message.workdir });
+          break;
+        case 'desktopGitBranches':
+          // Per-pane branch list reply (FR-052). Routed by paneId so a sibling
+          // pane's reply never overwrites this pane's selector.
+          if (!forThisPane(message)) break;
+          setPaneGitBranches(message.result ?? null);
           break;
         case 'updateQueue':
           if (!forThisPane(message)) break;
@@ -558,6 +577,18 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
     vscode.postMessage(pid === undefined ? message : { ...message, paneId: pid });
   }, [vscode]);
 
+  // Desktop: query this pane's own workdir for its git branches (FR-052). Each
+  // pane asks independently so a new-session pane keeps its workdir/branch even
+  // when focus moves to a sibling pane (which would otherwise rewire the host's
+  // global workdir). Clear stale branches first so the selector hides until the
+  // fresh reply lands.
+  useEffect(() => {
+    if (host?.type !== 'desktop') return;
+    setPaneGitBranches(null);
+    if (!effectiveWorkdir) return;
+    postToHost({ command: 'desktopListGitBranches', workdir: effectiveWorkdir, paneId });
+  }, [effectiveWorkdir, host, postToHost, paneId]);
+
   const handleClearChat = useCallback(() => {
     // /clear 斜杠命令：三端统一为"原地清空当前会话"，streaming 期间忽略。
     if (stateRef.current.isStreaming) return;
@@ -655,13 +686,13 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
       host?.type === 'desktop' &&
       stateRef.current.messages.length === 0 &&
       worktreeChecked &&
-      host.workdir &&
-      host.gitBranches
+      effectiveWorkdirRef.current &&
+      gitBranches
     ) {
       postToHost({
         command: 'desktopCreateWorktree',
-        workdir: host.workdir,
-        baseBranch: worktreeBranch || host.gitBranches.current,
+        workdir: effectiveWorkdirRef.current,
+        baseBranch: worktreeBranch || gitBranches.current,
         text: trimmedText,
         images: images,
       });
@@ -675,7 +706,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
       images: images,
       force: force
     });
-  }, [handleClearChat, host, worktreeChecked, worktreeBranch, postToHost, paneId]);
+  }, [handleClearChat, host, worktreeChecked, worktreeBranch, postToHost, paneId, gitBranches]);
 
   const handleAbortMessage = useCallback(() => {
     if (!state.isStreaming) return;
@@ -1102,9 +1133,6 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
     setPreviewUrl(url);
   }, [tryOpenPanel]);
 
-  // The pane's effective cwd: the session's own workdir (per-pane on desktop)
-  // wins over the host-level current workdir.
-  const effectiveWorkdir = state.workdir ?? (isDesktop ? host?.workdir : undefined);
   // Diff/terminal need a workdir; preview only needs a URL.
   const panelDisabled: DesktopPanelKind[] = effectiveWorkdir ? [] : ['diff', 'terminal'];
 
@@ -1250,21 +1278,21 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
             inputContent={state.inputContent}
             permissionMode={state.permissionMode}
             initialAttachedImages={state.attachedImages}
-            disabled={host?.type === 'desktop' && !host.workdir}
+            disabled={host?.type === 'desktop' && !effectiveWorkdir}
             workdirSelector={
               host?.type === 'desktop' && state.messages.length === 0 ? (
                 <>
                   <DesktopWorkdirSelector
-                    workdir={host.workdir}
+                    workdir={effectiveWorkdir}
                     recentWorkdirs={host.recentWorkdirs}
                     onSelectWorkdir={host.onSelectWorkdir}
                     onSelectRecentWorkdir={host.onSelectRecentWorkdir}
                     onRemoveRecentWorkdir={host.onRemoveRecentWorkdir}
                   />
-                  {host.workdir && host.gitBranches && (
+                  {effectiveWorkdir && gitBranches && (
                     <DesktopWorktreeControls
-                      branches={host.gitBranches.branches}
-                      branch={worktreeBranch || host.gitBranches.current}
+                      branches={gitBranches.branches}
+                      branch={worktreeBranch || gitBranches.current}
                       worktreeChecked={worktreeChecked}
                       onBranchChange={setWorktreeBranch}
                       onWorktreeChange={setWorktreeChecked}

--- a/packages/webview/src/components/DesktopApp.tsx
+++ b/packages/webview/src/components/DesktopApp.tsx
@@ -20,13 +20,9 @@ interface DesktopAppProps {
 export const DesktopApp: React.FC<DesktopAppProps> = ({ vscode }) => {
   const [workdirState, setWorkdirState] = useState<DesktopWorkdirState | null>(null);
   const [sessionTree, setSessionTree] = useState<DesktopSessionGroup[]>([]);
-  const [gitBranches, setGitBranches] = useState<{ branches: string[]; current: string } | null>(null);
   const [panes, setPanes] = useState<DesktopPane[]>([]);
   const [rowHeights, setRowHeights] = useState<number[] | undefined>(undefined);
   const [focusedPaneId, setFocusedPaneId] = useState<string | null>(null);
-  // Current workdir in a ref so the message handler can drop stale
-  // desktopGitBranches responses from a previous workdir.
-  const workdirRef = useRef<string | undefined>(undefined);
   // Latest panes/session tree for the panel-group prune below (the message
   // handler closes over refs, not state, so both messages see fresh values).
   const panesRef = useRef<DesktopPane[]>([]);
@@ -50,25 +46,14 @@ export const DesktopApp: React.FC<DesktopAppProps> = ({ vscode }) => {
     const handleMessage = (event: MessageEvent) => {
       const message = event.data;
       if (message.command === 'desktopWorkdirState') {
-        workdirRef.current = message.workdir;
         setWorkdirState({
           workdir: message.workdir,
           recentWorkdirs: message.recentWorkdirs ?? [],
         });
-        // Workdir changed — re-query branches (FR-022); clear stale list first.
-        setGitBranches(null);
-        if (message.workdir) {
-          vscode.postMessage({ command: 'desktopListGitBranches', workdir: message.workdir });
-        }
       } else if (message.command === 'desktopSessionTree') {
         sessionTreeRef.current = message.groups ?? [];
         setSessionTree(sessionTreeRef.current);
         prunePanels();
-      } else if (message.command === 'desktopGitBranches') {
-        // Ignore responses that raced a workdir switch.
-        if (message.workdir === workdirRef.current) {
-          setGitBranches(message.result ?? null);
-        }
       } else if (message.command === 'desktopPanes') {
         const nextPanes: DesktopPane[] = message.panes ?? [];
         panesRef.current = nextPanes;
@@ -128,7 +113,6 @@ export const DesktopApp: React.FC<DesktopAppProps> = ({ vscode }) => {
         onSelectSession: handleSelectSession,
         onDeleteSession: handleDeleteSession,
         onOpenPane: handleOpenPane,
-        gitBranches,
         panes,
         rowHeights,
         focusedPaneId,

--- a/packages/webview/src/types/index.ts
+++ b/packages/webview/src/types/index.ts
@@ -207,12 +207,6 @@ export interface DesktopHostProps {
    */
   onOpenPane: (workdir: string, sessionId: string, opts?: OpenPaneOptions) => void;
   /**
-   * Git branches of the current workdir (FR-022), pushed via the
-   * `desktopGitBranches` message. `null` = not a git repo / git unavailable —
-   * branch selector and worktree checkbox stay hidden.
-   */
-  gitBranches: { branches: string[]; current: string } | null;
-  /**
    * Split-view panes (FR-032) grouped into up to two rows, pushed via
    * `desktopPanes`. Empty until the first layout push; the layout renders a
    * single pane in that case.

--- a/packages/webview/tests/webview/desktopApp.test.tsx
+++ b/packages/webview/tests/webview/desktopApp.test.tsx
@@ -721,6 +721,47 @@ describe('DesktopApp', () => {
             );
         });
 
+        it('keeps a new-session pane on its own workdir/branch when focus moves to a sibling pane', () => {
+            const { vscode } = renderWithPanes(
+                [{ paneId: 'pane-0', sessionId: 's1' }, { paneId: 'pane-1' }],
+                'pane-1',
+            );
+            // pane-1 is a fresh (empty) session on its own workdir; pane-0 is an
+            // existing session in a different workdir.
+            sendCommand('setInitialState', {
+                paneId: 'pane-1',
+                messages: [],
+                workdir: '/home/user/project-b',
+                isAuthenticated: true,
+            });
+            sendCommand('setInitialState', {
+                paneId: 'pane-0',
+                messages: [{ id: 'm1', role: 'user', blocks: [{ type: 'text', content: 'hi' }], timestamp: '2026-01-01T00:00:00.000Z' } as any],
+                workdir: '/home/user/project-a',
+                isAuthenticated: true,
+            });
+
+            // The host-level workdir follows the focused pane (handleFocusPane rewires
+            // it on click); focus now moves to pane-0. pane-1 must keep its OWN dir.
+            sendCommand('desktopWorkdirState', { workdir: '/home/user/project-a', recentWorkdirs: ['/home/user/project-a', '/home/user/project-b'] });
+            sendCommand('desktopPanes', { panes: [{ paneId: 'pane-0', sessionId: 's1' }, { paneId: 'pane-1' }], focusedPaneId: 'pane-0' });
+
+            const pane1 = () => within(screen.getByTestId('desktop-pane-pane-1'));
+            expect(pane1().getByTestId('desktop-workdir')).toHaveTextContent('project-b');
+
+            // pane-1 queries branches for its OWN workdir (per-pane isolation) and
+            // renders its own branch after the reply — not pane-0's.
+            expect(vscode.postMessage).toHaveBeenCalledWith(
+                expect.objectContaining({ command: 'desktopListGitBranches', workdir: '/home/user/project-b', paneId: 'pane-1' }),
+            );
+            sendCommand('desktopGitBranches', {
+                paneId: 'pane-1',
+                workdir: '/home/user/project-b',
+                result: { branches: ['b-branch', 'main'], current: 'b-branch' },
+            });
+            expect(pane1().getByTestId('desktop-branch-selector')).toHaveTextContent('b-branch');
+        });
+
         it('posts desktopOpenPane on Ctrl+Click of a sidebar session (non-mac platform)', () => {
             const { vscode } = renderWithPanes([{ paneId: 'pane-0', sessionId: 's1' }], 'pane-0');
             mockRowWidth(1200);


### PR DESCRIPTION
## Problem

When a new conversation pane and an existing pane are shown side by side, clicking the existing (sibling) pane caused the **new** pane's directory and branch to change to the clicked pane's directory/branch.

## Root cause

The new-conversation worktree selector rendered from the **global** `host.workdir` / `host.gitBranches`. `handleFocusPane` rewires that global workdir (and re-broadcasts `desktopWorkdirState`) on every pane click, so it leaked into every sibling new-session pane.

## Fix

Per-pane isolation of workdir/branches:
- **ChatApp.tsx** — new `paneGitBranches` state; a query effect re-asks `desktopListGitBranches` against this pane's own `effectiveWorkdir` (clearing stale branches first) and tags the request with `paneId`. The selector and the worktree-create flow now use per-pane `effectiveWorkdir` / `gitBranches` instead of the global host values.
- **desktopHost.ts** — `handleListGitBranches` + dispatch carry `paneId`; the `desktopGitBranches` reply is pane-tagged so a sibling pane's reply never overwrites this pane.
- **DesktopApp.tsx / types** — removed the global `gitBranches` state, the `desktopGitBranches` handler, and the `gitBranches` host prop (no longer needed).

## Tests

- New case: a new-session pane keeps its own workdir/branch when focus moves to a sibling pane.
- `pnpm -F wave-webview test`: 483 passed; `pnpm -F wave-desktop test`: 240 passed; full `pnpm run type-check` clean; webview dist rebuilt.