### PR TITLE
fix(webview): 将 /rewind 弹窗对齐到历史记录弹窗的宽度与定位

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -1234,13 +1234,6 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
       )}
 
       <div className={`input-area-container${isDesktop && state.pendingConfirmations.length > 0 ? ' input-area-container--confirm' : ''}`}>
-        <RewindPopup
-          isVisible={rewindPopupOpen}
-          isLoading={rewindCheckpointsLoading}
-          checkpoints={rewindCheckpoints}
-          onSelect={handleRewindCheckpointSelect}
-          onClose={handleRewindPopupClose}
-        />
         <div style={{ display: state.pendingConfirmations.length === 0 ? 'block' : 'none' }}>
           <TaskList
             // 按会话 id 重挂载：切换会话时重置“观察过未完成任务”的跟踪，
@@ -1300,6 +1293,15 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
                   )}
                 </>
               ) : undefined
+            }
+            rewindPopup={
+              <RewindPopup
+                isVisible={rewindPopupOpen}
+                isLoading={rewindCheckpointsLoading}
+                checkpoints={rewindCheckpoints}
+                onSelect={handleRewindCheckpointSelect}
+                onClose={handleRewindPopupClose}
+              />
             }
           />
         </div>

--- a/packages/webview/src/components/MessageInput.tsx
+++ b/packages/webview/src/components/MessageInput.tsx
@@ -81,6 +81,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>((p
     permissionMode,
     initialAttachedImages,
     workdirSelector,
+    rewindPopup,
     disabled
   } = props;
   const [message, setMessage] = useState('');
@@ -1438,6 +1439,9 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>((p
           position={historyPopupPosition}
           vscode={vscode}
         />
+
+        {/* /rewind 检查点弹窗，与历史记录弹窗共用 .input-wrapper 定位上下文 */}
+        {rewindPopup}
       </div>
     </div>
   );

--- a/packages/webview/src/styles/RewindPopup.css
+++ b/packages/webview/src/styles/RewindPopup.css
@@ -1,19 +1,22 @@
 .rewind-popup {
   position: absolute;
-  bottom: 100%;
-  left: 10px;
-  right: 10px;
+  bottom: 100%; /* Anchor to the top of .input-wrapper (= top of the input box) */
+  margin-bottom: 8px; /* Gap above the input */
   z-index: 1000;
   background-color: var(--vscode-dropdown-background);
   border: 1px solid var(--vscode-dropdown-border);
   border-radius: 4px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  width: 100%;
+  max-width: 600px;
+  min-width: 200px;
+  box-sizing: border-box;
   max-height: 300px;
   display: flex;
   flex-direction: column;
   overflow: hidden;
   outline: none;
-  margin-bottom: 8px;
+  left: 0; /* Align with the input container */
 }
 
 .rewind-popup-header {

--- a/packages/webview/src/types/index.ts
+++ b/packages/webview/src/types/index.ts
@@ -312,6 +312,8 @@ export interface MessageInputProps {
   initialAttachedImages?: AttachedImage[];
   /** Optional slot rendered at the top-left of the input box (desktop workdir selector). */
   workdirSelector?: React.ReactNode;
+  /** Optional /rewind popup rendered above the input box, anchored to .input-wrapper. */
+  rewindPopup?: React.ReactNode;
   /** Disable the whole input area (e.g. desktop host without a workdir). */
   disabled?: boolean;
 }


### PR DESCRIPTION
## 问题

`/rewind` 检查点弹窗宽度撑满了整个消息列表，且定位算错会盖住输入框。

根因：`RewindPopup` 原先挂在 `.input-area-container`（全宽容器）下，用 `left:10/right:10` 定位，所以铺满整个容器宽度；而 `HistorySearchPopup` 挂在 `.input-wrapper`（800px 居中）里，宽度限到 600px。两者挂载点 + CSS 写法不一致。

## 改动

- 通过 `rewindPopup?: React.ReactNode` slot，将 `RewindPopup` 从 `.input-area-container` 移入 `MessageInput` 的 `.input-wrapper`，与 `HistorySearchPopup` 共用定位上下文
- `RewindPopup.css`：改用 `bottom:100%` 锚到输入框顶部上方（不再盖住 input），`left:0` + `width:100%/max-width:600px` 左对齐限宽，与历史记录弹窗一致

## 验证

- type-check + lint 通过
- `rewindPopup`/`rewind` 单测 10 个全过
- demo 截图（宽视口 1000px）确认弹窗落在输入框上方、限宽 600px 居中对齐输入框