### PR TITLE
fix(webview): scope queued-message edit to the active pane via ref

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ Always use `pnpm` as the package manager.
 ### Desktop App (`packages/desktop`)
 - **Run dev**: `cd packages/desktop && pnpm run dev` (compiles, then launches Electron; dev uses a separate `wave-desktop-dev` userData so it coexists with the installed app)
 - **Build installer**: `pnpm run dist` (electron-builder → `release/`). **Do not bypass `scripts/afterPack.js`**: electron-builder's bundle mutation breaks the ad-hoc linker seal, and without the re-sign step LaunchServices silently refuses to launch the app.
+- **Install/update installed app**: `pnpm run desktop:install` (run from repo root). Does a full `pnpm build` → `electron-builder --dir` → `rsync -a --delete` over `/Applications/Wave.app/`. Full build (not selective) is required because the user consumes `wave-code` via npm link. **Do not quit/kill/relaunch the user's running Wave.app** — rsync over a running `.app` is safe on macOS; restart is manual.
 - **Test**: `pnpm -F wave-desktop test`
 - **Architecture**: the main process wraps the shared webview and talks JSON-RPC to a `wave --stdio` child process — `src/main/desktopHost.ts` (agent pool: one `StdioAgent` per session for parallel conversations, see FR-031) → `stdio/stdioClient.ts` + `stdio/notificationRouter.ts` (routes notifications by sessionId). Session index/worktree metadata persists in `userData/wave-desktop.json` via `configStore.ts`.
 - **CLI resolution**: `WAVE_CLI_PATH` env var points at a workspace `wave-code` build; otherwise the bundled binary is used.

--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -707,10 +707,10 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
     if (!qm) return;
 
     const text = qm.content || qm.text || '';
-    const images = qm.images?.map(img => ({ data: img.path || '', mediaType: img.mimeType || '' }));
 
-    // Load content into the input (reuse the window-message insertion mechanism)
-    window.postMessage({ command: 'loadQueuedEditContent', text, images }, '*');
+    // Load content into this pane's input via the imperative ref (scoped to this
+    // pane only; window.postMessage would be received by all split-view panes).
+    messageInputRef.current?.loadQueuedEditContent(text);
     dispatch({ type: 'SET_EDITING_QUEUED_ID', payload: id });
   }, [state.queuedMessages]);
 

--- a/packages/webview/src/components/MessageInput.tsx
+++ b/packages/webview/src/components/MessageInput.tsx
@@ -63,6 +63,7 @@ export interface MessageInputHandle {
   focus: () => void;
   triggerShortcut: (name: string) => void;
   appendText: (text: string) => void;
+  loadQueuedEditContent: (text: string) => void;
 }
 
 export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>((props, ref) => {
@@ -200,7 +201,11 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>((p
         sel.removeAllRanges();
         sel.addRange(range);
       }
-    }
+    },
+    // Loads a queued message's content into the input for editing (chip + body).
+    // Called via ref from ChatApp so it only affects this pane's input, not every
+    // pane in a split-view layout (window.postMessage would be received by all panes).
+    loadQueuedEditContent
   }));
 
   // Auto-focus input on component mount
@@ -615,14 +620,12 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>((p
         // Could show an error notification here if needed
       } else if (data.command === 'addSelectionToInput') {
         insertSelectionTag(data.selection);
-      } else if (data.command === 'loadQueuedEditContent') {
-        loadQueuedEditContent(typeof data.text === 'string' ? data.text : '');
       }
     };
 
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, [insertUploadedFilePaths, insertSelectionTag, closeDropdown, loadQueuedEditContent]);
+  }, [insertUploadedFilePaths, insertSelectionTag, closeDropdown]);
 
   // Handle image preview
   const handleImagePreview = useCallback((url: string, name: string) => {

--- a/packages/webview/tests/webview/messageQueueEnhancements.test.tsx
+++ b/packages/webview/tests/webview/messageQueueEnhancements.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { renderChatApp, screen, fireEvent, sendCommand, fireInput, waitFor } from './test-utils';
+import { renderChatApp, render, screen, within, fireEvent, sendCommand, fireInput, waitFor, createMockVscode } from './test-utils';
+import { ChatApp } from '../../src/components/ChatApp';
 
 /**
  * Helper: set contenteditable text and fire input event
@@ -263,5 +264,39 @@ describe('Message Queue Features', () => {
         const sentMessages = vscode.postMessage.mock.calls.map(c => c[0]);
         const sendMsg = sentMessages.find((m: Record<string, unknown>) => m.command === 'sendMessage' && m.text === 'New Message');
         expect(sendMsg).toBeDefined();
+    });
+
+    it('editing a queued message should not leak the edit chip into sibling panes', async () => {
+        // Simulate a split-view layout: two ChatApp instances sharing the same window.
+        // Both panes receive the same queued message. Clicking edit in pane A must only
+        // insert the "编辑队列消息" chip into pane A's input — pane B's input must stay
+        // untouched. (Previously loadQueuedEditContent used window.postMessage, which is
+        // received by every pane's MessageInput listener.)
+        const containerA = document.createElement('div');
+        const containerB = document.createElement('div');
+        document.body.append(containerA, containerB);
+        render(<ChatApp vscode={createMockVscode()} />, { container: containerA });
+        render(<ChatApp vscode={createMockVscode()} />, { container: containerB });
+
+        sendCommand('authStatusResponse', { isAuthenticated: true });
+        sendCommand('startStreaming');
+        sendCommand('updateQueue', { queue: [{ id: 'q1', content: 'Editable text' }] });
+
+        const inputA = within(containerA).getByTestId('message-input');
+        const inputB = within(containerB).getByTestId('message-input');
+        expect(inputA.querySelector('.queued-edit-chip')).toBeNull();
+        expect(inputB.querySelector('.queued-edit-chip')).toBeNull();
+
+        // Click edit in pane A only.
+        fireEvent.click(within(containerA).getByTestId('queued-edit-q1'));
+
+        // Pane A enters edit mode (chip + body loaded)...
+        await waitFor(() => {
+            expect(inputA.querySelector('.queued-edit-chip')).not.toBeNull();
+        });
+        expect(inputA.textContent).toContain('Editable text');
+
+        // ...but pane B's input must remain untouched.
+        expect(inputB.querySelector('.queued-edit-chip')).toBeNull();
     });
 });


### PR DESCRIPTION
## Problem

When editing a queued message with side-by-side (split-view) conversations open, **all panes' input boxes entered edit-queue mode**, not just the one where edit was clicked.

## Root cause

`ChatApp.handleEditQueuedMessage` loaded the edit content into the input via `window.postMessage({ command: 'loadQueuedEditContent' })`. In Electron all split-view panes share a single `window` object, and every `MessageInput` registers a `window.addEventListener('message')` listener — so the "编辑队列消息" chip got inserted into **every** pane's input. The reducer state (`editingQueuedId`) was already per-pane, but the visual content load was global.

## Fix

Expose `loadQueuedEditContent` through the existing `MessageInputHandle` imperative ref (alongside `focus` / `appendText`) and call it via `messageInputRef.current?.loadQueuedEditContent(text)`. Each pane's `ChatApp` owns its own ref, so the edit naturally scopes to the clicked pane only.

- `MessageInput.tsx`: add `loadQueuedEditContent` to the handle interface + `useImperativeHandle`; remove the now-dead `loadQueuedEditContent` window-listener branch and its dep.
- `ChatApp.tsx`: replace `window.postMessage` with the ref call; drop the unused `images` variable (the listener never consumed it).
- Added a regression test rendering two `ChatApp` instances sharing one window, asserting the chip does **not** leak into the sibling pane. Verified the test fails on the old implementation and passes on the new one.