### PR TITLE
fix(desktop): default reply language to Chinese to match IDE plugins

### DIFF
--- a/packages/desktop/src/main/configStore.ts
+++ b/packages/desktop/src/main/configStore.ts
@@ -90,7 +90,14 @@ export class ConfigStore {
   }
 
   getConfiguration(): DesktopConfigData {
-    return { ...this.data.configuration };
+    // language defaults to 'Chinese' to match the VSCE extension
+    // (configurationService `|| 'Chinese'`) and the JetBrains plugin
+    // (WavePluginService default). Without this, a fresh desktop install
+    // sends an undefined language, so the system prompt never injects the
+    // `# Language` directive and the model replies in its own default.
+    const config = { ...this.data.configuration };
+    if (!config.language) config.language = 'Chinese';
+    return config;
   }
 
   /**

--- a/packages/desktop/tests/configStore.test.ts
+++ b/packages/desktop/tests/configStore.test.ts
@@ -33,17 +33,22 @@ beforeEach(() => {
 });
 
 describe('ConfigStore', () => {
-  it('starts with empty defaults when the file does not exist', () => {
+  it('starts with defaults when the file does not exist', () => {
     const store = new ConfigStore(STORE_PATH);
-    expect(store.getConfiguration()).toEqual({});
+    expect(store.getConfiguration()).toEqual({ language: 'Chinese' });
     expect(store.getRecentWorkdirs()).toEqual([]);
   });
 
   it('starts fresh when the file is corrupt', () => {
     h.files.set(STORE_PATH, 'not-json{{{');
     const store = new ConfigStore(STORE_PATH);
-    expect(store.getConfiguration()).toEqual({});
+    expect(store.getConfiguration()).toEqual({ language: 'Chinese' });
     expect(store.getRecentWorkdirs()).toEqual([]);
+  });
+
+  it('defaults language to Chinese when unset, matching VSCE/JetBrains', () => {
+    const store = new ConfigStore(STORE_PATH);
+    expect(store.getConfiguration().language).toBe('Chinese');
   });
 
   it('persists configuration across instances', () => {
@@ -51,7 +56,7 @@ describe('ConfigStore', () => {
     store.setConfiguration({ apiKey: 'k1', model: 'm1' });
 
     const reloaded = new ConfigStore(STORE_PATH);
-    expect(reloaded.getConfiguration()).toEqual({ apiKey: 'k1', model: 'm1' });
+    expect(reloaded.getConfiguration()).toEqual({ apiKey: 'k1', model: 'm1', language: 'Chinese' });
   });
 
   it('merge-updates configuration: absent fields keep their stored value', () => {
@@ -59,7 +64,7 @@ describe('ConfigStore', () => {
     store.setConfiguration({ apiKey: 'k1', model: 'm1', baseURL: 'https://a' });
     store.setConfiguration({ model: 'm2' });
 
-    expect(store.getConfiguration()).toEqual({ apiKey: 'k1', model: 'm2', baseURL: 'https://a' });
+    expect(store.getConfiguration()).toEqual({ apiKey: 'k1', model: 'm2', baseURL: 'https://a', language: 'Chinese' });
   });
 
   it('does not mutate the stored configuration through the returned copy', () => {


### PR DESCRIPTION
## Problem

Desktop's `configStore.getConfiguration()` returned an undefined `language` on a fresh install (no persisted config). This propagated through stdio (`wave --stdio`) to the agent, so `buildSystemPrompt` never injected the `# Language` directive (`packages/agent-sdk/src/prompts/index.ts:387` guards on `if (options.language)`). The model therefore replied in its own default — usually **English**.

VSCE (`configurationService.ts:23` → `|| 'Chinese'`) and JetBrains (`WavePluginService.kt:15` → default `"Chinese"`) both default to Chinese, so desktop was inconsistent with both IDE plugins.

## Fix

Add a read-time fallback in `packages/desktop/src/main/configStore.ts` — `getConfiguration()` now returns `language: 'Chinese'` when unset, mirroring the VSCE pattern (non-persisting; the stored file stays empty until the user explicitly sets it).

`getConfiguration()` is the single read point, so all consumers pick up the default:
- `spawnAgent` initialize params (`desktopHost.ts:527`) → stdio `agentBridge.ts:370` → agent-sdk `resolveLanguage()` returns `'Chinese'` → system prompt injects `Always respond in Chinese`
- `updateAgentConfig` (`desktopHost.ts:2126`)
- `getConfiguration` / `pushInitialState` responses sent to the webview ConfigDialog (the select now shows 中文 by default instead of nothing selected)

## Tests

- New regression test: `defaults language to Chinese when unset, matching VSCE/JetBrains`
- Updated 4 stale `toEqual` config assertions to include `language: 'Chinese'`
- Full desktop suite: **241 passed (11 files)**