### PR TITLE
feat(webview): cap message column at 800px and align gutters with input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ Always use `pnpm` as the package manager.
 ### Desktop App (`packages/desktop`)
 - **Run dev**: `cd packages/desktop && pnpm run dev` (compiles, then launches Electron; dev uses a separate `wave-desktop-dev` userData so it coexists with the installed app)
 - **Build installer**: `pnpm run dist` (electron-builder → `release/`). **Do not bypass `scripts/afterPack.js`**: electron-builder's bundle mutation breaks the ad-hoc linker seal, and without the re-sign step LaunchServices silently refuses to launch the app.
+- **Install/update installed app**: `pnpm run desktop:install` (run from repo root). Does a full `pnpm build` → `electron-builder --dir` → `rsync -a --delete` over `/Applications/Wave.app/`. Full build (not selective) is required because the user consumes `wave-code` via npm link. **Do not quit/kill/relaunch the user's running Wave.app** — rsync over a running `.app` is safe on macOS; restart is manual.
 - **Test**: `pnpm -F wave-desktop test`
 - **Architecture**: the main process wraps the shared webview and talks JSON-RPC to a `wave --stdio` child process — `src/main/desktopHost.ts` (agent pool: one `StdioAgent` per session for parallel conversations, see FR-031) → `stdio/stdioClient.ts` + `stdio/notificationRouter.ts` (routes notifications by sessionId). Session index/worktree metadata persists in `userData/wave-desktop.json` via `configStore.ts`.
 - **CLI resolution**: `WAVE_CLI_PATH` env var points at a workspace `wave-code` build; otherwise the bundled binary is used.

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -92,6 +92,10 @@ Wave 桌面版是一个独立的 Electron 应用，无需安装 IDE 即可使用
 
 ![核心交互](/screenshots/desktop-chat.png)
 
+消息列表与输入框共用同一套最大宽度（800px）并居中显示，窗口越宽两侧留白越明显，对话内容始终与输入框左右对齐，避免消息拉满整行显得松散：
+
+![居中的对话列](/screenshots/desktop-chat-centered.png)
+
 详细说明请移步：
 
 - [基础对话与 AI 思考过程](/vsce#basic-chat)

--- a/packages/webview/e2e/demo/desktop-message-width.demo.ts
+++ b/packages/webview/e2e/demo/desktop-message-width.demo.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '../utils/desktopTestHarness.js';
+import { MessageInjector } from '../utils/messageInjector.js';
+import { MockDataGenerator } from '../fixtures/mockData.js';
+
+const WORKDIR = '/Users/dev/projects/wave-agent';
+
+const initialState = {
+    messages: [],
+    isStreaming: false,
+    sessions: [],
+    isAuthenticated: true,
+    configurationData: {
+        baseURL: 'https://api.anthropic.com/v1',
+        model: 'claude-sonnet-4-20250514',
+        fastModel: 'claude-haiku-4-20250514'
+    },
+    permissionMode: 'default'
+};
+
+// Demonstrates that the conversation column is capped at 800px and centered,
+// lining up with the input box — instead of messages spanning the full pane
+// width on a wide window. A wide viewport makes the side gutters obvious.
+test.describe('Desktop message column width', () => {
+    test('messages are centered and aligned with the input', async ({ webviewPage }) => {
+        const injector = new MessageInjector(webviewPage);
+
+        // Wide window so the 800px cap leaves visible gutters on both sides.
+        await webviewPage.setViewportSize({ width: 1280, height: 800 });
+
+        await injector.simulateExtensionMessage('setInitialState', initialState);
+        await injector.simulateExtensionMessage('desktopWorkdirState', {
+            workdir: WORKDIR,
+            recentWorkdirs: [WORKDIR]
+        });
+
+        // Wait for the desktop layout to mount ChatApp and attach its message
+        // listener before pushing messages — otherwise updateMessages lands in
+        // the gap before workdirState triggers the mount and is dropped.
+        await expect(webviewPage.getByTestId('desktop-workdir')).toBeVisible();
+
+        await injector.updateMessages([
+            MockDataGenerator.createUserMessage(
+                '帮我把消息列表加一个最大宽度并居中，跟输入框保持一致，否则消息太宽不好看。',
+                'msg-u1'
+            ),
+            MockDataGenerator.createAssistantMessage(
+                '好的，我给 .messages-container 加了 max-width: 800px 和 margin: 0 auto，与 .input-wrapper 的约束方式一致。这样消息内容会居中显示在 800px 的列里，两侧留出与输入框对齐的留白，窗口越宽效果越明显。',
+                'msg-a1'
+            )
+        ]);
+
+        await expect(webviewPage.locator('.message.user')).toBeVisible();
+        await expect(webviewPage.locator('.message.assistant')).toBeVisible();
+
+        // The conversation column is capped (narrower than the chat area) and
+        // centered, and its content edges line up with the input box. Content
+        // edge = container edge + 10px padding (content-box), matching the
+        // input-wrapper's own 800px column.
+        const geom = await webviewPage.evaluate(() => {
+            const r = (sel: string) => document.querySelector(sel)!.getBoundingClientRect();
+            const cs = (sel: string) => getComputedStyle(document.querySelector(sel)!).backgroundColor;
+            const msg = r('.messages-container');
+            const input = r('.input-wrapper');
+            const main = r('.desktop-chat-main');
+            return {
+                msgCapped: msg.width < main.width,
+                centered: Math.abs((msg.left - main.left) - (main.right - msg.right)) < 1,
+                contentAlignsInput: Math.abs((msg.left + 10) - input.left) < 1 && Math.abs((msg.right - 10) - input.right) < 1,
+                // The gutter (chat-area background showing through the transparent
+                // wrappers around the message column) must match the message list's
+                // own background, not the host's editor-background body.
+                gutterBg: cs('.chat-container'),
+                msgBg: cs('.messages-container'),
+            };
+        });
+        expect(geom.msgCapped).toBeTruthy();
+        expect(geom.centered).toBeTruthy();
+        expect(geom.contentAlignsInput).toBeTruthy();
+        expect(geom.gutterBg).toBe(geom.msgBg);
+
+        await webviewPage.screenshot({ path: '../../docs/public/screenshots/desktop-chat-centered.png' });
+    });
+});

--- a/packages/webview/src/styles/ChatApp.css
+++ b/packages/webview/src/styles/ChatApp.css
@@ -4,6 +4,12 @@
     display: flex;
     flex-direction: column;
     height: 100%;
+    /* Paint the whole chat column (header + message gutters + input) in
+       panel-background so the gutters on either side of the 800px message
+       column match the message list. Hosts set body to editor-background
+       (the editor-area chrome), which would otherwise bleed through the
+       transparent wrappers around .messages-container. */
+    background-color: var(--vscode-panel-background);
 }
 
 .input-area-container {

--- a/packages/webview/src/styles/MessageList.css
+++ b/packages/webview/src/styles/MessageList.css
@@ -4,6 +4,13 @@
     overflow-y: auto;
     overflow-x: hidden;
     padding: 10px;
+    /* Cap the conversation column at 800px and center it, mirroring .input-wrapper
+       so messages line up with the input box instead of spanning the full pane
+       width. The panel-background gutters come from .chat-container (see
+       ChatApp.css) so they match this list exactly. */
+    max-width: 800px;
+    width: 100%;
+    margin: 0 auto;
     display: flex;
     flex-direction: column;
     align-items: flex-start;


### PR DESCRIPTION
Capping `.messages-container` at 800px and centering it mirrors `.input-wrapper`, so conversation content lines up with the input box instead of spanning the full pane width on wide windows.

Once the column is no longer full-width, the side gutters reveal the host body background. Hosts paint body with editor-background (the editor-area chrome), which differs from the message list's panel-background — so the gutters read as a mismatched shade. Paint the shared chat-area container (`.chat-container`) with panel-background so the gutters match the message list exactly, regardless of what the host sets on body.

Adds a desktop demo test (`desktop-message-width`) with geometry + gutter-color regression assertions, and a docs screenshot.