### PR TITLE
ci: rename docs-checks to check-docs for naming consistency

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - 'docs/**'
-      - '.github/workflows/docs-checks.yml'
+      - '.github/workflows/check-docs.yml'
       - 'scripts/check-docs-links.mjs'
       - 'scripts/check-sidebar-anchors.mjs'
   push:
@@ -12,12 +12,12 @@ on:
       - main
     paths:
       - 'docs/**'
-      - '.github/workflows/docs-checks.yml'
+      - '.github/workflows/check-docs.yml'
       - 'scripts/check-docs-links.mjs'
       - 'scripts/check-sidebar-anchors.mjs'
 
 jobs:
-  docs-checks:
+  check-docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Renames the `docs-checks` workflow to `check-docs` (file + job name + path filters) to align with the existing `check-jetbrains` / `check-windows` naming convention (singular `check-` prefix).