### PR TITLE
fix(desktop): stop compaction hint leaking across sessions on switch

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -1109,6 +1109,7 @@ export class DesktopHost {
       inputContent: this.inputDrafts.get(paneId) ?? '',
       isStreaming: agent?.isStreaming ?? false,
       isCommandRunning: agent?.isCommandRunning ?? false,
+      isCompacting: agent?.isCompacting ?? false,
       session: agent?.sessionId ? {
         id: agent.sessionId,
         sessionType: 'main',

--- a/packages/desktop/src/main/stdio/stdioAgent.ts
+++ b/packages/desktop/src/main/stdio/stdioAgent.ts
@@ -128,6 +128,7 @@ export class StdioAgent {
     public backgroundTasks: BackgroundTaskSummary[] = [];
     public isStreaming = false;
     public isCommandRunning = false;
+    public isCompacting = false;
 
     private client: StdioClient;
     private router: NotificationRouter;
@@ -461,6 +462,7 @@ export class StdioAgent {
             }
             case 'compactionStateChange': {
                 const p = params as { isCompacting: boolean };
+                this.isCompacting = p.isCompacting;
                 this.callbacks.onCompactionStateChange?.(p.isCompacting);
                 break;
             }

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -120,6 +120,7 @@ vi.mock('../src/main/stdio/stdioAgent', () => ({
     queuedMessages: unknown[] = [];
     isStreaming = false;
     isCommandRunning = false;
+    isCompacting = false;
     callbacks: Record<string, (...args: never[]) => void>;
 
     initialize = vi.fn(async function (this: { workingDirectory?: string; sessionId?: string }, params: { workdir?: string }) {
@@ -1680,6 +1681,28 @@ describe('multi-session parallel (FR-031)', () => {
 
     await host.handleWebviewMessage({ command: 'desktopSelectSession', workdir: '/work/a', sessionId: 'sess-1' });
     expect(sent('setInitialState').at(-1)?.messages).toEqual([{ id: 'm-sess-1' }, { id: 'bg-1' }]);
+  });
+
+  it('pushes isCompacting from the activated session so the compaction hint does not leak across sessions', async () => {
+    const { host, sent } = await readyHost();
+    const agent1 = seedActiveSession('sess-1');
+    await host.handleWebviewMessage({ command: 'newSession' });
+    seedActiveSession('sess-2');
+    // Switch back to sess-1, then start a compaction on it (active session).
+    await host.handleWebviewMessage({ command: 'desktopSelectSession', workdir: '/work/a', sessionId: 'sess-1' });
+    agent1.isCompacting = true;
+    agent1.callbacks.onCompactionStateChange(true);
+    expect(sent('compactionStateChange').at(-1)).toMatchObject({ isCompacting: true });
+
+    // Switch to sess-2 (not compacting): the pushed initial state must not
+    // inherit sess-1's compaction hint.
+    await host.handleWebviewMessage({ command: 'desktopSelectSession', workdir: '/work/a', sessionId: 'sess-2' });
+    expect(sent('setInitialState').at(-1)).toMatchObject({ isCompacting: false });
+
+    // Switch back to sess-1 (still compacting): the hint must reappear from
+    // the agent's cached flag.
+    await host.handleWebviewMessage({ command: 'desktopSelectSession', workdir: '/work/a', sessionId: 'sess-1' });
+    expect(sent('setInitialState').at(-1)).toMatchObject({ isCompacting: true });
   });
 
   it('never evicts idle agents — the pool is unbounded until session deletion', async () => {

--- a/packages/webview/src/reducers/chatReducer.ts
+++ b/packages/webview/src/reducers/chatReducer.ts
@@ -173,6 +173,10 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
         isTaskListCollapsed: action.payload.isTaskListCollapsed !== undefined ? action.payload.isTaskListCollapsed : state.isTaskListCollapsed,
         isStreaming: action.payload.isStreaming !== undefined ? action.payload.isStreaming : state.isStreaming,
         isCommandRunning: action.payload.isCommandRunning !== undefined ? action.payload.isCommandRunning : state.isCommandRunning,
+        // A session switch must not inherit the previous session's compaction
+        // hint; the host pushes the activated session's own state (or omits
+        // it, meaning "not compacting").
+        isCompacting: action.payload.isCompacting ?? false,
         sessions: action.payload.sessions || state.sessions || [],
         // Re-pin from the same-snapshot messages: hosts re-push the session
         // object without firstMessage on pane/webview re-init.

--- a/packages/webview/src/types/index.ts
+++ b/packages/webview/src/types/index.ts
@@ -590,6 +590,7 @@ export type ChatAction =
       tasks?: Task[];
       isStreaming: boolean;
       isCommandRunning?: boolean;
+      isCompacting?: boolean;
       isTaskListCollapsed?: boolean;
       sessions: SessionMetadata[];
       currentSession?: SessionMetadata;

--- a/packages/webview/tests/reducers/chatReducer.test.ts
+++ b/packages/webview/tests/reducers/chatReducer.test.ts
@@ -811,6 +811,48 @@ describe('chatReducer', () => {
 
       expect(newState.currentSession?.firstMessage).toBe('原始标题');
     });
+
+    it('SET_INITIAL_STATE clears a stale isCompacting so a session switch does not leak the compaction hint', () => {
+      // Session A is mid-compaction: the view shows "正在压缩对话…".
+      let state = chatReducer(initialState, { type: 'SET_COMPACTING', payload: true });
+      expect(state.isCompacting).toBe(true);
+
+      // User switches to session B, which is not compacting. The host pushes
+      // setInitialState for B (isCompacting absent). The hint must not leak
+      // from A into B.
+      state = chatReducer(state, {
+        type: 'SET_INITIAL_STATE',
+        payload: {
+          messages: [],
+          sessions: [],
+          configurationData: {} as any,
+          pendingConfirmations: [],
+          isStreaming: false,
+        },
+      });
+
+      expect(state.isCompacting).toBe(false);
+    });
+
+    it('SET_INITIAL_STATE preserves isCompacting when the host pushes a still-compacting session', () => {
+      // Switching back to a session that is still compacting must keep the hint.
+      const state = chatReducer(
+        { ...initialState, isCompacting: false },
+        {
+          type: 'SET_INITIAL_STATE',
+          payload: {
+            messages: [],
+            sessions: [],
+            configurationData: {} as any,
+            pendingConfirmations: [],
+            isStreaming: false,
+            isCompacting: true,
+          },
+        },
+      );
+
+      expect(state.isCompacting).toBe(true);
+    });
   });
 
   describe('theme state', () => {


### PR DESCRIPTION
## Problem

Desktop: when one conversation auto-compacted, switching to another conversation showed the previous session's **"正在压缩对话…"** hint, even though that conversation was not actually compacting.

## Root cause

Switching conversations sends `setInitialState` via `pushPaneSessionState`, but the webview `SET_INITIAL_STATE` reducer spread `...state` **without touching `isCompacting`**, so the prior session's compaction flag leaked into the newly activated session.

Compounding this, `StdioAgent` cached `isStreaming` / `isCommandRunning` but **not `isCompacting`` (the `compactionStateChange` handler only forwarded, never stored). So switching back to a still-compacting session could not restore the correct hint — and once a session unbinds from a pane, its `compactionStateChange(false)` completion notification is dropped (`paneIdOf()` returns undefined), leaving the stale flag stuck on.

## Fix

Mirrors the existing `isStreaming` / `isCommandRunning` handling so `isCompacting` is treated as the same kind of transient per-session flag:

- `stdioAgent.ts`: cache `isCompacting` in the `compactionStateChange` handler
- `desktopHost.ts`: `pushPaneSessionState` pushes `isCompacting` from the activated agent
- `types/index.ts`: `SetInitialStatePayload` gains `isCompacting?`
- `chatReducer.ts`: `SET_INITIAL_STATE` reads `payload.isCompacting ?? false` (default false = no leak)

## Tests (written failing first)

- webview reducer: switching to a non-compacting session clears a stale hint; switching back to a still-compacting session preserves it
- desktop host: `desktopSelectSession` to a non-compacting session pushes `isCompacting: false`; switching back to a compacting session pushes `true`

488 webview + 242 desktop tests pass; type-check clean; webview dist rebuilt.