### PR TITLE
fix(webview): 侧边栏会话状态圆点改为图标并换色

### DIFF
--- a/packages/webview/e2e/demo/desktop-app.demo.ts
+++ b/packages/webview/e2e/demo/desktop-app.demo.ts
@@ -94,7 +94,7 @@ test.describe('Desktop App Screenshots', () => {
         await injector.simulateExtensionMessage('startStreaming');
 
         await expect(webviewPage.getByTestId('desktop-session-item-sess-a1')).toBeVisible();
-        await expect(webviewPage.locator('.desktop-session-dot--running')).toBeVisible();
+        await expect(webviewPage.getByTestId('desktop-session-item-sess-a1').locator('.codicon-loading')).toBeVisible();
         // Other groups are expanded by default too
         await expect(webviewPage.getByTestId('desktop-session-item-sess-b1')).toBeVisible();
         await webviewPage.screenshot({ path: '../../docs/public/screenshots/desktop-session-tree.png' });

--- a/packages/webview/src/components/DesktopSidebar.tsx
+++ b/packages/webview/src/components/DesktopSidebar.tsx
@@ -119,10 +119,15 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
         }}
         data-testid={`desktop-session-item-${session.sessionId}`}
       >
-        <span
-          className={`desktop-session-dot${waiting ? ' desktop-session-dot--waiting' : running ? ' desktop-session-dot--running' : ''}`}
-          title={waiting ? '等待确认' : running ? '正在运行' : undefined}
-        />
+        {running || waiting ? (
+          <i
+            className={`codicon codicon-${waiting ? 'bell' : 'loading codicon-modifier-spin'} desktop-session-status-icon`}
+            style={{ color: waiting ? 'var(--vscode-charts-purple, #b180d7)' : 'var(--vscode-charts-blue, #59a4f9)' }}
+            title={waiting ? '等待确认' : '正在运行'}
+          />
+        ) : (
+          <span className="desktop-session-dot" aria-hidden="true" />
+        )}
         <span className="desktop-session-title">{session.title || '新对话'}</span>
         <button
           className="desktop-session-delete"

--- a/packages/webview/src/styles/DesktopApp.css
+++ b/packages/webview/src/styles/DesktopApp.css
@@ -157,18 +157,20 @@
 }
 
 .desktop-session-dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
+    width: 16px;
+    height: 16px;
     flex-shrink: 0;
 }
 
-.desktop-session-dot--running {
-    background: var(--vscode-testing-iconPassed, #73c991);
-}
-
-.desktop-session-dot--waiting {
-    background: var(--vscode-testing-iconQueued, #cca700);
+.desktop-session-status-icon {
+    font-size: 14px;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
 }
 
 .desktop-session-title {

--- a/packages/webview/tests/webview/desktopApp.test.tsx
+++ b/packages/webview/tests/webview/desktopApp.test.tsx
@@ -325,9 +325,11 @@ describe('DesktopApp', () => {
             sendCommand('startStreaming', {});
 
             const current = screen.getByTestId('desktop-session-item-s1');
-            expect(current.querySelector('.desktop-session-dot--running')).not.toBeNull();
+            const runningIcon = current.querySelector('.desktop-session-status-icon.codicon-loading');
+            expect(runningIcon).not.toBeNull();
+            expect(runningIcon).toHaveAttribute('title', '正在运行');
             expect(current.className).toContain('desktop-session-item--current');
-            expect(screen.getByTestId('desktop-session-item-s2').querySelector('.desktop-session-dot--running')).toBeNull();
+            expect(screen.getByTestId('desktop-session-item-s2').querySelector('.desktop-session-status-icon')).toBeNull();
         });
 
         it('shows a waiting dot on sessions with a pending confirmation, taking precedence over running', () => {
@@ -346,14 +348,15 @@ describe('DesktopApp', () => {
             sendCommand('startStreaming', {});
 
             const waiting = screen.getByTestId('desktop-session-item-s1');
-            // Both flags set: waiting wins, no running modifier.
-            expect(waiting.querySelector('.desktop-session-dot--waiting')).not.toBeNull();
-            expect(waiting.querySelector('.desktop-session-dot--running')).toBeNull();
-            expect(waiting.querySelector('.desktop-session-dot')).toHaveAttribute('title', '等待确认');
+            // Both flags set: waiting wins — shows a bell, no running loader.
+            const waitingIcon = waiting.querySelector('.desktop-session-status-icon.codicon-bell');
+            expect(waitingIcon).not.toBeNull();
+            expect(waitingIcon).toHaveAttribute('title', '等待确认');
+            expect(waiting.querySelector('.codicon-loading')).toBeNull();
 
             const running = screen.getByTestId('desktop-session-item-s2');
-            expect(running.querySelector('.desktop-session-dot--waiting')).toBeNull();
-            expect(running.querySelector('.desktop-session-dot--running')).not.toBeNull();
+            expect(running.querySelector('.codicon-bell')).toBeNull();
+            expect(running.querySelector('.desktop-session-status-icon.codicon-loading')).not.toBeNull();
         });
 
         it('shows 无会话 for an expanded empty group', () => {


### PR DESCRIPTION
将侧边栏会话状态实心圆点改为 codicon 图标，避免与 message list 工具圆点(●)混淆：

- **running**：旋转 loading 图标（蓝 `--vscode-charts-blue`）
- **waiting**：bell 图标（紫 `--vscode-charts-purple`）
- **空闲**：无图标占位

原绿/黄（`--vscode-testing-iconPassed/iconQueued`）与工具 success/running 圆点完全撞色，改用 charts-blue/purple（三端 theme map 均有定义）错开，形状+颜色双重区分。同步更新单测断言与 demo selector。

验证：77 单元测试 + desktop-app demo + 临时三态截图均通过。