### PR TITLE
feat(desktop): predev auto-kill + git-diff repo-root path fix

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -12,6 +12,7 @@
     "build": "pnpm run compile",
     "compile": "pnpm run sync:webview && tsup",
     "sync:webview": "node scripts/syncWebview.mjs",
+    "predev": "node scripts/predev.mjs",
     "dev": "pnpm run compile && env -u ELECTRON_RUN_AS_NODE electron . --no-sandbox",
     "dist": "pnpm run compile && electron-builder",
     "clean": "node -e \"import('fs').then(fs => ['dist', 'release', 'webview'].forEach(d => {try{fs.rmSync(d, {recursive:true, force:true})}catch(e){}}))\"",

--- a/packages/desktop/scripts/predev.mjs
+++ b/packages/desktop/scripts/predev.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * predev — kill leftover dev Electron instances before launching a new one.
+ *
+ * The dev app shares the `wave-desktop-dev` userData across worktrees, so a
+ * stale instance makes a new `pnpm run dev` silently exit 0 (focus jumps to
+ * the old instance and edits look like they "didn't take"). We match only the
+ * workspace-installed electron (path contains `node_modules/electron`); the
+ * user's installed app never matches that fragment, so it is never touched.
+ */
+import { spawnSync } from 'node:child_process';
+
+const NEEDLE = 'node_modules/electron';
+const me = process.pid;
+
+function listProcesses() {
+  try {
+    if (process.platform === 'win32') {
+      const r = spawnSync(
+        'powershell',
+        [
+          '-NoProfile',
+          '-Command',
+          'Get-CimInstance Win32_Process | Where-Object CommandLine | ForEach-Object { "$($_.ProcessId)`t$($_.CommandLine)" }',
+        ],
+        { encoding: 'utf-8', timeout: 10000 },
+      );
+      return r.stdout.split(/\r?\n/).filter(Boolean);
+    }
+    const r = spawnSync('ps', ['-axo', 'pid=,command='], { encoding: 'utf-8', timeout: 10000 });
+    return r.stdout.split('\n').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+const victims = [];
+for (const raw of listProcesses()) {
+  const norm = raw.replace(/\\/g, '/');
+  if (!norm.includes(NEEDLE)) continue;
+  const m = raw.match(/^\s*(\d+)/);
+  if (!m) continue;
+  const pid = Number(m[1]);
+  if (pid === me) continue;
+  if (norm.includes('/Applications/Wave.app')) continue; // installed app, never kill
+  victims.push({ pid, snippet: norm.slice(norm.indexOf(NEEDLE)).slice(0, 80) });
+}
+
+if (victims.length === 0) {
+  console.log('[predev] no stale dev instance found');
+  process.exit(0);
+}
+
+for (const v of victims) {
+  try {
+    process.kill(v.pid, 'SIGKILL');
+    console.log(`[predev] killed ${v.pid}  ${v.snippet}`);
+  } catch {
+    // already gone or no permission — ignore
+  }
+}

--- a/packages/desktop/src/main/gitDiff.ts
+++ b/packages/desktop/src/main/gitDiff.ts
@@ -87,9 +87,9 @@ function truncateHunks(hunks: string): { hunks: string; truncated: boolean } {
   return { hunks: lines.slice(0, MAX_DIFF_LINES).join('\n'), truncated: true };
 }
 
-async function diffForTracked(cwd: string, base: string[], entry: StatusEntry): Promise<WorkspaceDiffFile> {
+async function diffForTracked(repoRoot: string, base: string[], entry: StatusEntry): Promise<WorkspaceDiffFile> {
   // numstat row: additions<TAB>deletions<TAB>path ('-' on both for binary)
-  const num = await git(cwd, ['diff', ...base, '--numstat', '--', entry.path]).catch(() => '');
+  const num = await git(repoRoot, ['diff', ...base, '--numstat', '--', entry.path]).catch(() => '');
   const m = num.split('\n')[0]?.match(/^(\d+|-)\t(\d+|-)\t/);
   const binary = m ? m[1] === '-' : false;
   const additions = m && m[1] !== '-' ? parseInt(m[1], 10) : 0;
@@ -98,7 +98,7 @@ async function diffForTracked(cwd: string, base: string[], entry: StatusEntry): 
   let hunks = '';
   let truncated = false;
   if (!binary) {
-    const patch = await git(cwd, ['diff', ...base, '--', entry.path]).catch(() => '');
+    const patch = await git(repoRoot, ['diff', ...base, '--', entry.path]).catch(() => '');
     const at = patch.indexOf('@@');
     const body = at === -1 ? '' : patch.slice(at).trimEnd();
     ({ hunks, truncated } = truncateHunks(body));
@@ -123,8 +123,8 @@ const UNREADABLE: Omit<WorkspaceDiffFile, 'path' | 'status'> = {
   binary: true,
 };
 
-async function diffForUntracked(cwd: string, entry: StatusEntry): Promise<WorkspaceDiffFile> {
-  const full = path.join(cwd, entry.path);
+async function diffForUntracked(repoRoot: string, entry: StatusEntry): Promise<WorkspaceDiffFile> {
+  const full = path.join(repoRoot, entry.path);
   try {
     const st = await fs.promises.stat(full);
     if (!st.isFile() || st.size > MAX_UNTRACKED_BYTES) {
@@ -160,6 +160,12 @@ export async function getWorkspaceDiff(cwd: string): Promise<WorkspaceDiffResult
     return { kind: 'not-a-repo' };
   }
 
+  // `git status --porcelain` always emits paths relative to the repo root,
+  // but `cwd` may be a subdirectory. Resolving untracked files (path.join)
+  // and matching pathspecs both need root-relative paths, so normalize to
+  // the toplevel; fall back to cwd if rev-parse is unavailable.
+  const root = (await git(cwd, ['rev-parse', '--show-toplevel']).catch(() => '')).trim() || cwd;
+
   // Without commits there is no HEAD to diff against — the staged tree is
   // the whole change set.
   const hasHead = await git(cwd, ['rev-parse', '--verify', 'HEAD']).then(
@@ -175,8 +181,8 @@ export async function getWorkspaceDiff(cwd: string): Promise<WorkspaceDiffResult
   for (const entry of entries) {
     files.push(
       entry.status === 'untracked'
-        ? await diffForUntracked(cwd, entry)
-        : await diffForTracked(cwd, base, entry),
+        ? await diffForUntracked(root, entry)
+        : await diffForTracked(root, base, entry),
     );
   }
   return { kind: 'ok', files };

--- a/packages/desktop/tests/gitDiff.test.ts
+++ b/packages/desktop/tests/gitDiff.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
 import { getWorkspaceDiff, MAX_DIFF_LINES } from '../src/main/gitDiff';
 
 /**
@@ -223,6 +224,39 @@ describe('getWorkspaceDiff', () => {
     expect(result.kind).toBe('ok');
     if (result.kind !== 'ok') return;
     expect(result.files[0]).toMatchObject({ path: 'gone.txt', status: 'untracked', binary: true });
+  });
+
+  it('resolves untracked paths against the repo root, not a subdirectory cwd', async () => {
+    // `git status --porcelain` always emits paths relative to the repo root,
+    // even when cwd is a subdirectory. A naive path.join(cwd, path) would
+    // double up the prefix, miss the file, and fall back to "binary".
+    const SUBCWD = '/repo/packages/desktop';
+    const ROOT = '/repo';
+    const relPath = 'packages/desktop/scripts/predev.mjs';
+    stubGit({ status: `?? ${relPath}\0` });
+    const inner = h.gitHandler;
+    h.gitHandler = (args) => {
+      if (args.join(' ') === 'rev-parse --show-toplevel') return `${ROOT}\n`;
+      return inner(args);
+    };
+    const correctAbs = `${ROOT}/${relPath}`;
+    vi.mocked(fs.promises.stat).mockImplementationOnce(async (p) => {
+      if (p === correctAbs) return { isFile: () => true, size: 5 } as unknown as Awaited<ReturnType<typeof fs.promises.stat>>;
+      throw new Error('ENOENT');
+    });
+    vi.mocked(fs.promises.readFile).mockImplementationOnce(async (p) => {
+      if (p === correctAbs) return Buffer.from('hello');
+      throw new Error('ENOENT');
+    });
+    const result = await getWorkspaceDiff(SUBCWD);
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    expect(result.files[0]).toMatchObject({
+      path: relPath,
+      status: 'untracked',
+      binary: false,
+      hunks: '+hello',
+    });
   });
 
   it('truncates per-file hunks beyond MAX_DIFF_LINES', async () => {


### PR DESCRIPTION
Two desktop fixes:

## 1. predev — auto-kill stale dev instance (692adcbb)

Add a `predev` pnpm hook (`scripts/predev.mjs`) that runs before `pnpm run dev` and kills leftover dev Electron instances. Dev apps share the `wave-desktop-dev` userData across worktrees (single-instance lock), so a stale instance from another worktree makes a new `pnpm run dev` silently exit 0 and steal focus to the old instance — looking like "changes didn't take effect". The hook enumerates processes (ps on macOS/Linux, Get-CimInstance on Windows), matches `node_modules/electron`, skips the current PID and the installed `/Applications/Wave.app`, and SIGKILLs the rest.

## 2. git-diff panel — resolve paths against repo root, not cwd (7ec294cf)

The diff panel's `getWorkspaceDiff` assumed `cwd == git root`: it did `path.join(cwd, entry.path)` for untracked files and `git -C cwd diff -- entry.path` for tracked files. But `git status --porcelain` always emits root-relative paths, and `paneAgent.workingDirectory` (the cwd passed in) can be a subdirectory when the agent's workdir was changed by a bash `cd` mid-session. With a subdirectory cwd the path got double-prefixed:

- **untracked**: `path.join('packages/desktop', 'packages/desktop/scripts/x')` → ENOENT → misdetected as **binary**, no diff shown
- **tracked**: pathspec `packages/desktop/package.json` under `-C packages/desktop` didn't match → empty diff, "modified" with no content

Fix: resolve the repo root once via `git rev-parse --show-toplevel` and pass root (not cwd) to `diffForTracked`/`diffForUntracked` so paths are always interpreted relative to the actual repository root. Correct for any cwd value (root, subdirectory, or even `/`). Adds a regression test reproducing the subdirectory-cwd binary misdetection.