### PR TITLE
fix(webview): stop panel drag handle + cursor flicker on fast drag

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -1178,11 +1178,35 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
       onClose: () => handleTogglePanel(kind),
       widthFromLeft: panelRows[kind] === 2,
     };
+
+    // Empty preview (no URL yet) reuses the same left-edge resize handle so it
+    // can be widened like the loaded preview/diff/terminal panels.
+    const onEmptyPreviewDragStart = (e: React.MouseEvent) => {
+      e.preventDefault();
+      const handle = e.currentTarget as HTMLElement;
+      handle.style.background = 'var(--vscode-focusBorder, #007fd4)';
+      document.body.classList.add('is-panel-resizing');
+      const rect = handle.parentElement?.getBoundingClientRect();
+      const onMove = (ev: MouseEvent) => {
+        const next = common.widthFromLeft ? ev.clientX - (rect?.left ?? 0) : (rect?.right ?? 0) - ev.clientX;
+        common.onWidthChange(Math.min(Math.max(next, PANEL_MIN_WIDTH), common.maxWidth));
+      };
+      const onUp = () => {
+        handle.style.background = '';
+        document.body.classList.remove('is-panel-resizing');
+        window.removeEventListener('mousemove', onMove);
+        window.removeEventListener('mouseup', onUp);
+      };
+      window.addEventListener('mousemove', onMove);
+      window.addEventListener('mouseup', onUp);
+    };
+
     if (kind === 'preview') {
       return previewUrl ? (
         <PreviewPane url={previewUrl} vscode={vscode} onAddComment={handleAddComment} {...common} />
       ) : (
         <aside className="preview-pane" style={{ width: common.width }} data-testid="preview-pane-empty">
+          <div className="preview-pane-drag-handle" onMouseDown={onEmptyPreviewDragStart} />
           <div className="preview-pane-inner">
             <div className="preview-pane-toolbar">
               <span className="preview-pane-url">预览</span>

--- a/packages/webview/src/components/DiffPane.tsx
+++ b/packages/webview/src/components/DiffPane.tsx
@@ -183,12 +183,19 @@ export const DiffPane: React.FC<DiffPaneProps> = ({
 
   const onDragStart = (e: React.MouseEvent) => {
     e.preventDefault();
+    const handle = e.currentTarget as HTMLElement;
+    // Keep the handle lit + cursor locked for the whole drag — :hover and the
+    // 6px-only col-resize cursor both flicker as the pointer outruns the handle.
+    handle.style.background = 'var(--vscode-focusBorder, #007fd4)';
+    document.body.classList.add('is-panel-resizing');
     const rect = asideRef.current?.getBoundingClientRect();
     const onMove = (ev: MouseEvent) => {
       const next = widthFromLeft ? ev.clientX - (rect?.left ?? 0) : (rect?.right ?? 0) - ev.clientX;
       onWidthChange(Math.min(Math.max(next, MIN_WIDTH), maxWidth));
     };
     const onUp = () => {
+      handle.style.background = '';
+      document.body.classList.remove('is-panel-resizing');
       window.removeEventListener('mousemove', onMove);
       window.removeEventListener('mouseup', onUp);
     };

--- a/packages/webview/src/components/PreviewPane.tsx
+++ b/packages/webview/src/components/PreviewPane.tsx
@@ -226,12 +226,19 @@ export const PreviewPane: React.FC<PreviewPaneProps> = ({ url, vscode, onClose, 
   // drag; in the second row the left edge is fixed instead.
   const onDragStart = (e: React.MouseEvent) => {
     e.preventDefault();
+    const handle = e.currentTarget as HTMLElement;
+    // Keep the handle lit + cursor locked for the whole drag — :hover and the
+    // 6px-only col-resize cursor both flicker as the pointer outruns the handle.
+    handle.style.background = 'var(--vscode-focusBorder, #007fd4)';
+    document.body.classList.add('is-panel-resizing');
     const rect = asideRef.current?.getBoundingClientRect();
     const onMove = (ev: MouseEvent) => {
       const next = widthFromLeft ? ev.clientX - (rect?.left ?? 0) : (rect?.right ?? 0) - ev.clientX;
       onWidthChange(Math.min(Math.max(next, MIN_WIDTH), maxWidth));
     };
     const onUp = () => {
+      handle.style.background = '';
+      document.body.classList.remove('is-panel-resizing');
       window.removeEventListener('mousemove', onMove);
       window.removeEventListener('mouseup', onUp);
     };

--- a/packages/webview/src/components/TerminalPane.tsx
+++ b/packages/webview/src/components/TerminalPane.tsx
@@ -271,12 +271,19 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({
 
   const onDragStart = (e: React.MouseEvent) => {
     e.preventDefault();
+    const handle = e.currentTarget as HTMLElement;
+    // Keep the handle lit + cursor locked for the whole drag — :hover and the
+    // 6px-only col-resize cursor both flicker as the pointer outruns the handle.
+    handle.style.background = 'var(--vscode-focusBorder, #007fd4)';
+    document.body.classList.add('is-panel-resizing');
     const rect = asideRef.current?.getBoundingClientRect();
     const onMove = (ev: MouseEvent) => {
       const next = widthFromLeft ? ev.clientX - (rect?.left ?? 0) : (rect?.right ?? 0) - ev.clientX;
       onWidthChange(Math.min(Math.max(next, MIN_WIDTH), maxWidth));
     };
     const onUp = () => {
+      handle.style.background = '';
+      document.body.classList.remove('is-panel-resizing');
       window.removeEventListener('mousemove', onMove);
       window.removeEventListener('mouseup', onUp);
     };

--- a/packages/webview/src/styles/DesktopApp.css
+++ b/packages/webview/src/styles/DesktopApp.css
@@ -383,6 +383,18 @@
     z-index: 10;
 }
 
+/* Visible affordance on hover, matching the pane separator style. */
+.preview-pane-drag-handle:hover {
+    background: var(--vscode-focusBorder, #007fd4);
+}
+
+/* While dragging a panel handle, lock the cursor globally so it doesn't
+   flicker as the pointer crosses the 6px handle onto adjacent elements. */
+body.is-panel-resizing,
+body.is-panel-resizing * {
+    cursor: col-resize !important;
+}
+
 .preview-pane-inner {
     display: flex;
     flex-direction: column;

--- a/packages/webview/tests/webview/chatAppPanels.test.tsx
+++ b/packages/webview/tests/webview/chatAppPanels.test.tsx
@@ -87,6 +87,34 @@ describe('ChatApp desktop panel framework', () => {
         expect(slots[2].querySelector('[data-testid="terminal-pane"]')).not.toBeNull();
     });
 
+    it('the empty preview pane (no URL) resizes via its left-edge handle', () => {
+        window.waveHostType = 'desktop';
+        // jsdom reports 0 rects; pin a container width so panelMaxWidth stays
+        // positive and the drag can actually widen the panel.
+        const rectSpy = vi
+            .spyOn(Element.prototype, 'getBoundingClientRect')
+            .mockReturnValue({ width: 1024, right: 1024, left: 0 } as DOMRect);
+        try {
+            renderDesktop({ workdir: '/work/a' });
+            fireEvent.click(screen.getByTestId('panel-toggle-btn'));
+            fireEvent.click(screen.getByTestId('panel-toggle-item-preview'));
+
+            const empty = screen.getByTestId('preview-pane-empty');
+            expect(empty.style.width).toBe('420px'); // default width, no URL loaded yet
+            // The empty state must carry the same drag affordance as loaded panels.
+            expect(empty.querySelector('.preview-pane-drag-handle')).not.toBeNull();
+
+            // Row 1 (widthFromLeft=false): width = rect.right - clientX.
+            const handle = empty.querySelector('.preview-pane-drag-handle') as HTMLElement;
+            fireEvent.mouseDown(handle);
+            fireEvent.mouseMove(window, { clientX: 624 }); // 1024 - 624 = 400
+            expect(empty.style.width).toBe('400px');
+            fireEvent.mouseUp(window);
+        } finally {
+            rectSpy.mockRestore();
+        }
+    });
+
     it('unchecking hides the panel (display:none) but keeps it mounted', () => {
         window.waveHostType = 'desktop';
         renderDesktop({ workdir: '/work/a' });

--- a/packages/webview/tests/webview/diffPane.test.tsx
+++ b/packages/webview/tests/webview/diffPane.test.tsx
@@ -245,13 +245,20 @@ describe('DiffPane', () => {
         vi.spyOn(pane, 'getBoundingClientRect').mockReturnValue({ right: 1024 } as DOMRect);
 
         fireEvent.mouseDown(handle);
+        // The handle stays lit for the whole drag instead of relying on :hover,
+        // which flickers when the pointer outruns the 6px handle.
+        expect(handle.style.background).not.toBe('');
+        expect(document.body.classList.contains('is-panel-resizing')).toBe(true);
         fireEvent.mouseMove(window, { clientX: 624 }); // 1024 - 624 = 400
         expect(onWidthChange).toHaveBeenLastCalledWith(400);
+        expect(handle.style.background).not.toBe(''); // still lit mid-drag
         fireEvent.mouseMove(window, { clientX: 950 }); // 74 → clamped to 320
         expect(onWidthChange).toHaveBeenLastCalledWith(320);
         fireEvent.mouseMove(window, { clientX: 10 }); // 1014 → clamped to 716
         expect(onWidthChange).toHaveBeenLastCalledWith(716);
         fireEvent.mouseUp(window);
+        expect(handle.style.background).toBe(''); // cleared on release
+        expect(document.body.classList.contains('is-panel-resizing')).toBe(false);
     });
 
     describe('line comments', () => {


### PR DESCRIPTION
Panel width drag handles (preview/diff/terminal + empty preview) relied on
:hover for the highlight and a 6px-only col-resize cursor. During fast
dragging the pointer outruns the 6px handle as it slides with the panel
edge, so both the highlight bar and the cursor flicker on/off.

- Keep the handle lit via inline style for the whole drag (set on mousedown,
  cleared on mouseup). React does not touch element.style for elements with
  no style prop, so the highlight survives re-renders — unlike classList,
  which the className prop overwrites.
- Add a left-edge drag handle to the empty (no-URL) preview pane so it
  widens like loaded panels.
- Lock the cursor globally during drag via a body.is-panel-resizing class
  (body is outside React's tree, so classList is safe from re-renders).