### PR TITLE
fix(webview): preserve background tasks across setInitialState

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -444,6 +444,13 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
               isAuthenticated: message.isAuthenticated,
               workdir: message.workdir,
               theme: message.theme,
+              // Hosts (VSCE messageHandler / Desktop desktopHost) include the
+              // running background tasks + workflow runs in the snapshot so a
+              // webview re-init / pane switch does not wipe them. Without this
+              // the reducer falls back to [] and /tasks shows "暂无后台任务"
+              // until the next incremental updateBackgroundTasks (e.g. stop).
+              backgroundTasks: message.backgroundTasks,
+              workflowRuns: message.workflowRuns,
             }
           });
           break;

--- a/packages/webview/tests/webview/backgroundTasksInitState.test.tsx
+++ b/packages/webview/tests/webview/backgroundTasksInitState.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderChatApp, screen, act, sendCommand } from './test-utils';
+import type { BackgroundTaskSummary } from '../../src/types';
+
+const runningTask: BackgroundTaskSummary = {
+  id: 'bg-1',
+  type: 'shell',
+  status: 'running',
+  startTime: 1000,
+  command: 'sleep 300',
+  description: 'long-running build'
+};
+
+describe('Background tasks visibility across setInitialState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preserves running background tasks when the host re-pushes setInitialState (webview re-init / pane switch)', () => {
+    // Repro: agent starts a background bash task; a mid-session setInitialState
+    // (VSCE sidebar cold-start, desktop pane/session switch, rewind) re-pushes
+    // state. The host includes backgroundTasks in the payload, so the running
+    // task must stay visible in /tasks — not wiped to "暂无后台任务".
+    renderChatApp();
+
+    act(() => {
+      sendCommand('setInitialState', {
+        messages: [],
+        backgroundTasks: [runningTask],
+        isAuthenticated: true,
+      });
+    });
+
+    act(() => {
+      sendCommand('showDialog', { dialogType: 'tasks' });
+    });
+
+    const manager = screen.getByTestId('background-task-manager');
+    expect(manager).toHaveTextContent('sleep 300');
+    expect(manager).toHaveTextContent('running');
+    expect(manager).not.toHaveTextContent('暂无后台任务');
+  });
+
+  it('shows background tasks pushed incrementally via updateBackgroundTasks (baseline)', () => {
+    // Baseline: the incremental notification path (also used by stopTask)
+    // populates the list and is unaffected by the setInitialState wiring.
+    renderChatApp();
+
+    act(() => {
+      sendCommand('updateBackgroundTasks', { tasks: [runningTask] });
+    });
+    act(() => {
+      sendCommand('showDialog', { dialogType: 'tasks' });
+    });
+
+    const manager = screen.getByTestId('background-task-manager');
+    expect(manager).toHaveTextContent('sleep 300');
+    expect(manager).not.toHaveTextContent('暂无后台任务');
+  });
+});


### PR DESCRIPTION
## Problem
Opening /tasks showed no background tasks while a task was running, but the task appeared after asking the agent to stop it.

## Root cause
ChatApp's setInitialState dispatch payload omitted backgroundTasks and workflowRuns, even though both hosts send them in the snapshot (VSCE messageHandler.ts, Desktop desktopHost.ts). The reducer's ?? [] fallback then wiped the running-task list to [] on every mid-session setInitialState (webview re-init, pane/session switch, rewind). The next incremental updateBackgroundTasks (e.g. stopTask -> notifyTasksChange) repopulated the list, so the killed task suddenly appeared — matching the "visible only after stop" symptom. CLI unaffected (useChat.ts is the only setBackgroundTasks call site, no init reset).

## Fix
Forward backgroundTasks and workflowRuns in the setInitialState dispatch payload.

## Test
New backgroundTasksInitState.test.tsx: fails before the fix (empty state) and passes after; baseline updateBackgroundTasks path covered too. Type-check + 124 related tests pass.