### PR TITLE
fix(webview,desktop): block IME Enter from submitting preview/diff comments

### DIFF
--- a/packages/desktop/src/main/pickerPreload.ts
+++ b/packages/desktop/src/main/pickerPreload.ts
@@ -234,7 +234,9 @@ function showCard(el: Element): void {
     send.disabled = textarea.value.trim() === '';
   });
   textarea.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    // IME composing (e.g. Chinese pinyin): Enter confirms the candidate, not a
+    // submit. keyCode 229 covers older engines where isComposing is unset.
+    if (e.key === 'Enter' && !e.shiftKey && !e.isComposing && e.keyCode !== 229) {
       e.preventDefault();
       submit();
     }

--- a/packages/desktop/tests/pickerPreload.test.ts
+++ b/packages/desktop/tests/pickerPreload.test.ts
@@ -161,6 +161,31 @@ describe('pickerPreload', () => {
     expect(shadowRoot().querySelector('.tag')?.textContent).toBe('div');
   });
 
+  it('Enter does not submit while IME is composing (e.g. pinyin)', () => {
+    // sendToHost is intentionally NOT cleared between tests (the ready
+    // handshake test relies on the import-time call), so scope the assertion
+    // to calls made within this test only.
+    ipcRenderer.sendToHost.mockClear();
+    const { button } = renderPage();
+    activate({ accent: '#ff0000' });
+    click(button);
+
+    const root = shadowRoot();
+    const textarea = root.querySelector('textarea') as HTMLTextAreaElement;
+    textarea.value = '这个按钮颜色太淡了';
+    // Chinese IME uses Enter to confirm the candidate; that keydown fires with
+    // isComposing=true (keyCode 229) and must NOT submit the draft comment.
+    textarea.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true, isComposing: true, keyCode: 229 }),
+    );
+    expect(ipcRenderer.sendToHost).not.toHaveBeenCalledWith(
+      'wave-picker',
+      expect.objectContaining({ type: 'submit' }),
+    );
+    // Card stays open so the user can keep composing.
+    expect(document.body.lastElementChild?.shadowRoot ?? null).not.toBeNull();
+  });
+
   it('send button is an equivalent submit entry once text is present', () => {
     const { button } = renderPage();
     activate();

--- a/packages/webview/src/components/DiffPane.tsx
+++ b/packages/webview/src/components/DiffPane.tsx
@@ -260,6 +260,10 @@ export const DiffPane: React.FC<DiffPaneProps> = ({
                 value={commentDraft}
                 onChange={(e) => setCommentDraft(e.target.value)}
                 onKeyDown={(e) => {
+                  // IME composing (e.g. Chinese pinyin): Enter confirms the
+                  // candidate, not a submit. keyCode 229 covers older engines
+                  // where isComposing is unset.
+                  if (e.nativeEvent.isComposing || e.keyCode === 229) return;
                   if (e.key === 'Enter' && !e.shiftKey) {
                     e.preventDefault();
                     submitComment();

--- a/packages/webview/tests/webview/diffPane.test.tsx
+++ b/packages/webview/tests/webview/diffPane.test.tsx
@@ -311,6 +311,19 @@ describe('DiffPane', () => {
             expect(onAddComment).toHaveBeenCalled();
         });
 
+        it('does not submit on Enter while IME is composing (e.g. pinyin)', () => {
+            const onAddComment = vi.fn();
+            renderPane({ onAddComment });
+            sendDiffResult([makeFile()]);
+            fireEvent.click(screen.getByTestId('diff-comment-add-2'));
+            const input = screen.getByTestId('diff-comment-input');
+            fireEvent.change(input, { target: { value: '改这里' } });
+            // Chinese IME uses Enter to confirm the candidate; that keydown fires
+            // with isComposing=true (keyCode 229) and must NOT submit the draft.
+            fireEvent.keyDown(input, { key: 'Enter', isComposing: true, keyCode: 229 });
+            expect(onAddComment).not.toHaveBeenCalled();
+        });
+
         it('does not submit when the comment is empty', () => {
             const onAddComment = vi.fn();
             renderPane({ onAddComment });


### PR DESCRIPTION
## 问题

预览面板（元素拾取）和差异面板的行评论框，按 Enter 提交时只判断了 \`!shiftKey\`，没有判断 IME 组合态。用中文拼音输入法时，按回车确认候选词会触发 keydown Enter，被当成提交，草稿还没输完就发出去了。

主聊天输入框 \`MessageInput.tsx\` 早有 \`!isComposing\` 守卫，这两个评论框漏抄了。

## 修复

参考主输入框的守卫模式，加 IME 组合态判断（\`isComposing\` / \`keyCode 229\`）：

- \`packages/webview/src/components/DiffPane.tsx\` — React 合成事件，提前 \`return\` 当 \`e.nativeEvent.isComposing || e.keyCode === 229\`
- \`packages/desktop/src/main/pickerPreload.ts\` — 原生 DOM 事件，提交条件加 \`!e.isComposing && e.keyCode !== 229\`

## 测试

先写失败测试复现 bug（拼音回车仍提交 → 红），修复后转绿：

- \`packages/webview/tests/webview/diffPane.test.tsx\`：新增 \"does not submit on Enter while IME is composing\"，全 31 passed
- \`packages/desktop/tests/pickerPreload.test.ts\`：新增 \"Enter does not submit while IME is composing\"，全 11 passed

原有 Enter 提交 / Shift+Enter 换行 / Escape 取消 / 按钮提交等用例均保留。