### PR TITLE
ci: bump gradle/actions/setup-gradle to v6

### DIFF
--- a/.github/workflows/ci-jetbrains.yml
+++ b/.github/workflows/ci-jetbrains.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Setup Gradle
         if: steps.filter.outputs.jetbrains == 'true'
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Run tests
         if: steps.filter.outputs.jetbrains == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,7 +107,7 @@ jobs:
           java-version: '17'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - uses: pnpm/action-setup@v5
 

--- a/.github/workflows/refresh-release-assets.yml
+++ b/.github/workflows/refresh-release-assets.yml
@@ -75,7 +75,7 @@ jobs:
           java-version: '17'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - uses: pnpm/action-setup@v5
 


### PR DESCRIPTION
v4 runs on the deprecated Node.js 20 runtime — GitHub Actions now forces it to Node 24 and emits a warning annotation on every JetBrains build. v6 targets `node24` natively, clearing the deprecation notice.

Bumps all three workflows that use `setup-gradle`:
- `.github/workflows/refresh-release-assets.yml`
- `.github/workflows/ci-jetbrains.yml`
- `.github/workflows/publish.yml`

No behavioral change; just silences the Node.js 20 deprecation warning. Surfaced during a manual run of *Refresh Release Assets* (#30607818532), which succeeded — this just removes the warning for future runs.