### PR TITLE
fix(auth): force-refresh SSO token on 401/403 recovery (#1555)

### DIFF
--- a/docs/specs/enterprise/sso-auth.md
+++ b/docs/specs/enterprise/sso-auth.md
@@ -109,5 +109,6 @@ order: 10
 - **如果浏览器无法打开（无头服务器）会怎样？** 认证服务器保持活动，用户可以手动打开 URL 并粘贴授权码。
 - **如果用户将来在 `auth.json` 中保存额外字段会怎样？** `saveAuth` 方法与现有配置合并，保留非 SSO_TOKEN 字段。
 - **如果 token 过期（JWT 默认 8 小时）会怎样？** 系统在过期前 5 分钟使用存储的 refresh token 主动刷新 token。如果 refresh token 被撤销（400/401），认证被清除，用户必须重新运行 `/login`。在刷新期间的瞬时网络错误中，保留现有 token，重试在下次请求时进行。
+- **如果服务端返回 401/403 但本地认为 token 仍在有效期会怎样？**（token 被服务端主动吊销、白名单变更、时钟偏移、`auth.json` 缺失 `SSO_TOKEN_EXPIRES_AT` 等）401/403 是服务端对 token 失效的权威反馈，比本地基于 `SSO_TOKEN_EXPIRES_AT` 的推断更可靠。recovery 分支**不**依赖 `isTokenExpired()` 判断，无条件尝试一次强制刷新（force refresh，绕过本地过期判断，复用 `_refreshPromise` 去重）；刷新成功则用新 token 重试一次原请求，刷新失败（refresh token 被撤销返回 400/401、无 refresh token、或网络错误）则返回原始 401 响应。每次请求的 recovery 只重试一次，不无限循环。
 - **如果 SSO 登录超时（5 分钟）会怎样？** 认证服务器关闭并显示错误。用户可以重试 `/login`。
 

--- a/packages/agent-sdk/src/services/authService.ts
+++ b/packages/agent-sdk/src/services/authService.ts
@@ -339,6 +339,19 @@ export class AuthService {
    */
   async checkAndRefreshTokenIfNeeded(): Promise<boolean> {
     if (!this.isTokenExpired()) return true;
+    return this.forceRefreshToken();
+  }
+
+  /**
+   * Force a token refresh regardless of local expiry state.
+   *
+   * Used by the 401/403 recovery path: a server-side rejection is the
+   * authoritative signal that the token is invalid, which is more reliable
+   * than the local `SSO_TOKEN_EXPIRES_AT` heuristic (token may be revoked,
+   * allow-list changed, or expiry info missing). Deduplicates concurrent
+   * refresh calls.
+   */
+  async forceRefreshToken(): Promise<boolean> {
     // Dedup: if a refresh is already in-flight, reuse the same promise
     if (this._refreshPromise) {
       logger.info(
@@ -494,8 +507,9 @@ export function createAuthAwareFetch(innerFetch: typeof fetch): typeof fetch {
         return innerFetch(input, { ...init, headers: retryHeaders });
       }
 
-      // Try force refresh
-      if (await authService.checkAndRefreshTokenIfNeeded()) {
+      // Try force refresh — bypass local expiry check: a server-side 401/403
+      // is the authoritative signal that the token is invalid.
+      if (await authService.forceRefreshToken()) {
         const retryToken = authService.getSSOToken();
         if (retryToken) {
           const retryHeaders = new Headers(init?.headers);

--- a/packages/agent-sdk/tests/services/authService.test.ts
+++ b/packages/agent-sdk/tests/services/authService.test.ts
@@ -1046,6 +1046,147 @@ describe("AuthService", () => {
     });
   });
 
+  describe("forceRefreshToken", () => {
+    const mockFetch = vi.fn();
+
+    beforeEach(() => {
+      vi.stubGlobal("fetch", mockFetch);
+      process.env.WAVE_SERVER_URL = "https://ai.example.com";
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      delete process.env.WAVE_SERVER_URL;
+    });
+
+    it("refreshes even when token is locally fresh (not expired)", async () => {
+      // checkAndRefreshTokenIfNeeded() would skip refresh here (future expiry),
+      // but forceRefreshToken() must bypass isTokenExpired() and refresh.
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "fresh-token",
+          SSO_REFRESH_TOKEN: "refresh-token",
+          SSO_TOKEN_EXPIRES_AT: Date.now() + 60 * 60 * 1000,
+        }),
+      );
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token: "new-token",
+          refreshToken: "new-refresh",
+          expiresIn: 3600,
+          user: { id: "u1" },
+        }),
+      });
+
+      const service = AuthService.getInstance();
+      const result = await service.forceRefreshToken();
+      expect(result).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://ai.example.com/api/auth/token",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            grant_type: "refresh_token",
+            refresh_token: "refresh-token",
+          }),
+        }),
+      );
+    });
+
+    it("refreshes when auth.json has no expiry info", async () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "no-expiry-token",
+          SSO_REFRESH_TOKEN: "refresh-token",
+        }),
+      );
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token: "new-token",
+          expiresIn: 3600,
+          user: { id: "u1" },
+        }),
+      });
+
+      const service = AuthService.getInstance();
+      const result = await service.forceRefreshToken();
+      expect(result).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns false without clearing auth on network error", async () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "fresh-token",
+          SSO_REFRESH_TOKEN: "refresh-token",
+          SSO_TOKEN_EXPIRES_AT: Date.now() + 60 * 60 * 1000,
+        }),
+      );
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+      const service = AuthService.getInstance();
+      const result = await service.forceRefreshToken();
+      expect(result).toBe(false);
+      expect(mockedRm).not.toHaveBeenCalled();
+    });
+
+    it("clears auth when refresh token is revoked (400)", async () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "fresh-token",
+          SSO_REFRESH_TOKEN: "revoked-refresh",
+          SSO_TOKEN_EXPIRES_AT: Date.now() + 60 * 60 * 1000,
+        }),
+      );
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 400 });
+
+      const service = AuthService.getInstance();
+      const result = await service.forceRefreshToken();
+      expect(result).toBe(false);
+      expect(mockedRm).toHaveBeenCalled();
+    });
+
+    it("deduplicates concurrent force refresh calls", async () => {
+      mockedExists.mockReturnValue(true);
+      mockedReadFile.mockReturnValue(
+        JSON.stringify({
+          SSO_TOKEN: "fresh-token",
+          SSO_REFRESH_TOKEN: "refresh-token",
+          SSO_TOKEN_EXPIRES_AT: Date.now() + 60 * 60 * 1000,
+        }),
+      );
+      let resolveRefresh: (value: unknown) => void;
+      const pending = new Promise((resolve) => {
+        resolveRefresh = resolve;
+      });
+      mockFetch.mockReturnValueOnce(pending);
+
+      const service = AuthService.getInstance();
+      const p1 = service.forceRefreshToken();
+      const p2 = service.forceRefreshToken();
+      // Both force-refresh attempts share a single in-flight refresh
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      resolveRefresh!({
+        ok: true,
+        json: async () => ({
+          token: "new-token",
+          expiresIn: 3600,
+          user: { id: "u1" },
+        }),
+      });
+      const [r1, r2] = await Promise.all([p1, p2]);
+      expect(r1).toBe(true);
+      expect(r2).toBe(true);
+    });
+  });
+
   describe("refreshToken", () => {
     const mockFetch = vi.fn();
 
@@ -1170,35 +1311,31 @@ describe("AuthService", () => {
     });
 
     it("retries on 401 after disk refresh", async () => {
+      // Another process refreshed the token on disk while this process held an
+      // older, now server-invalid token. On 401, tryReadRefreshedTokenFromDisk()
+      // detects a newer file mtime and retries with the disk-refreshed token.
       mockedExists.mockReturnValue(true);
-      // First loadAuth: token expired, triggers refresh
-      mockedReadFile.mockReturnValueOnce(
-        JSON.stringify({
-          SSO_TOKEN: "expired-token",
-          SSO_REFRESH_TOKEN: "refresh-token",
-          SSO_TOKEN_EXPIRES_AT: Date.now() - 1000,
-        }),
+      // Increasing mtime so the disk check sees a file modified after the last
+      // loadAuth() (which records the mtime it observed).
+      let mtime = 1000;
+      mockedStat.mockImplementation(
+        () =>
+          ({ mtimeMs: ++mtime }) as unknown as Awaited<
+            ReturnType<typeof statSync>
+          >,
       );
-      // For tryReadRefreshedTokenFromDisk — stat says file was updated
-      mockedStat.mockReturnValueOnce({
-        mtimeMs: Date.now(),
-      } as unknown as Awaited<ReturnType<typeof statSync>>);
-      // After disk read, token is fresh
-      mockedReadFile.mockReturnValue(
-        JSON.stringify({
-          SSO_TOKEN: "new-from-disk",
-          SSO_TOKEN_EXPIRES_AT: Date.now() + 60 * 60 * 1000,
-        }),
-      );
-      // Refresh call succeeds
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          token: "refreshed-token",
-          expiresIn: 3600,
-          user: { id: "u1" },
-        }),
-      });
+      const staleConfig = {
+        SSO_TOKEN: "stale-token",
+        SSO_TOKEN_EXPIRES_AT: Date.now() + 60 * 60 * 1000,
+      };
+      const diskConfig = {
+        SSO_TOKEN: "new-from-disk",
+        SSO_TOKEN_EXPIRES_AT: Date.now() + 60 * 60 * 1000,
+      };
+      mockedReadFile
+        .mockReturnValueOnce(JSON.stringify(staleConfig)) // proactive isTokenExpired
+        .mockReturnValueOnce(JSON.stringify(staleConfig)) // getSSOToken before request
+        .mockReturnValue(JSON.stringify(diskConfig)); // disk refresh + retries
 
       mockInnerFetch.mockResolvedValueOnce(
         new Response("unauthorized", { status: 401 }),
@@ -1210,6 +1347,10 @@ describe("AuthService", () => {
 
       expect(response.status).toBe(200);
       expect(mockInnerFetch).toHaveBeenCalledTimes(2);
+      const firstHeaders = mockInnerFetch.mock.calls[0][1].headers as Headers;
+      expect(firstHeaders.get("Authorization")).toBe("Bearer stale-token");
+      const retryHeaders = mockInnerFetch.mock.calls[1][1].headers as Headers;
+      expect(retryHeaders.get("Authorization")).toBe("Bearer new-from-disk");
     });
 
     it("returns original 401 when both disk and force refresh fail", async () => {
@@ -1230,6 +1371,161 @@ describe("AuthService", () => {
 
       expect(response.status).toBe(401);
       expect(mockInnerFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("force-refreshes on 401 even when token is locally fresh (regression: issue #1555)", async () => {
+      // Token is NOT locally expired, but server still returns 401 (revoked /
+      // allow-list change / clock skew). Recovery must force-refresh regardless
+      // of the local expiry heuristic, not silently reuse the stale token.
+      process.env.WAVE_SERVER_URL = "https://ai.example.com";
+      mockedExists.mockReturnValue(true);
+      // Fixed mtime => tryReadRefreshedTokenFromDisk() short-circuits to false,
+      // forcing the force-refresh branch.
+      mockedStat.mockReturnValue({
+        mtimeMs: 1000,
+      } as unknown as Awaited<ReturnType<typeof statSync>>);
+      const freshConfig = {
+        SSO_TOKEN: "stale-but-locally-valid",
+        SSO_REFRESH_TOKEN: "refresh-token",
+        SSO_TOKEN_EXPIRES_AT: Date.now() + 60 * 60 * 1000,
+      };
+      const refreshedConfig = {
+        SSO_TOKEN: "refreshed-token",
+        SSO_REFRESH_TOKEN: "new-refresh",
+        SSO_TOKEN_EXPIRES_AT: Date.now() + 60 * 60 * 1000,
+      };
+      // Reads: (1) proactive isTokenExpired, (2) getSSOToken before request,
+      // (3) refreshToken loadAuth — all return the stale config; then (4+)
+      // getSSOToken after refresh returns the refreshed config.
+      mockedReadFile
+        .mockReturnValueOnce(JSON.stringify(freshConfig))
+        .mockReturnValueOnce(JSON.stringify(freshConfig))
+        .mockReturnValueOnce(JSON.stringify(freshConfig))
+        .mockReturnValue(JSON.stringify(refreshedConfig));
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token: "refreshed-token",
+          refreshToken: "new-refresh",
+          expiresIn: 3600,
+          user: { id: "u1" },
+        }),
+      });
+      mockInnerFetch
+        .mockResolvedValueOnce(new Response("unauthorized", { status: 401 }))
+        .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+      const authFetch = createAuthAwareFetch(mockInnerFetch);
+      const response = await authFetch("https://api.example.com/test");
+
+      expect(response.status).toBe(200);
+      expect(mockInnerFetch).toHaveBeenCalledTimes(2);
+      // First attempt used the stale token
+      const firstHeaders = mockInnerFetch.mock.calls[0][1].headers as Headers;
+      expect(firstHeaders.get("Authorization")).toBe(
+        "Bearer stale-but-locally-valid",
+      );
+      // Retry after force refresh used the new token
+      const retryHeaders = mockInnerFetch.mock.calls[1][1].headers as Headers;
+      expect(retryHeaders.get("Authorization")).toBe("Bearer refreshed-token");
+      // A real refresh call was made to the token endpoint
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://ai.example.com/api/auth/token",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            grant_type: "refresh_token",
+            refresh_token: "refresh-token",
+          }),
+        }),
+      );
+      delete process.env.WAVE_SERVER_URL;
+    });
+
+    it("force-refreshes on 401 when auth.json has no expiry info (regression: issue #1555)", async () => {
+      // No SSO_TOKEN_EXPIRES_AT => isTokenExpired() returns false (backward
+      // compat), so the old code skipped refresh entirely and retried the same
+      // token. The recovery path must still force-refresh on 401.
+      process.env.WAVE_SERVER_URL = "https://ai.example.com";
+      mockedExists.mockReturnValue(true);
+      mockedStat.mockReturnValue({
+        mtimeMs: 1000,
+      } as unknown as Awaited<ReturnType<typeof statSync>>);
+      const noExpiryConfig = {
+        SSO_TOKEN: "no-expiry-token",
+        SSO_REFRESH_TOKEN: "refresh-token",
+      };
+      const refreshedConfig = {
+        SSO_TOKEN: "refreshed-token",
+        SSO_REFRESH_TOKEN: "new-refresh",
+        SSO_TOKEN_EXPIRES_AT: Date.now() + 60 * 60 * 1000,
+      };
+      mockedReadFile
+        .mockReturnValueOnce(JSON.stringify(noExpiryConfig))
+        .mockReturnValueOnce(JSON.stringify(noExpiryConfig))
+        .mockReturnValueOnce(JSON.stringify(noExpiryConfig))
+        .mockReturnValue(JSON.stringify(refreshedConfig));
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token: "refreshed-token",
+          refreshToken: "new-refresh",
+          expiresIn: 3600,
+          user: { id: "u1" },
+        }),
+      });
+      mockInnerFetch
+        .mockResolvedValueOnce(new Response("unauthorized", { status: 401 }))
+        .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+      const authFetch = createAuthAwareFetch(mockInnerFetch);
+      const response = await authFetch("https://api.example.com/test");
+
+      expect(response.status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://ai.example.com/api/auth/token",
+        expect.any(Object),
+      );
+      delete process.env.WAVE_SERVER_URL;
+    });
+
+    it("retries only once on 401 (no infinite loop) when force refresh yields a still-invalid token", async () => {
+      process.env.WAVE_SERVER_URL = "https://ai.example.com";
+      mockedExists.mockReturnValue(true);
+      mockedStat.mockReturnValue({
+        mtimeMs: 1000,
+      } as unknown as Awaited<ReturnType<typeof statSync>>);
+      const config = {
+        SSO_TOKEN: "stale-token",
+        SSO_REFRESH_TOKEN: "refresh-token",
+        SSO_TOKEN_EXPIRES_AT: Date.now() + 60 * 60 * 1000,
+      };
+      mockedReadFile
+        .mockReturnValueOnce(JSON.stringify(config))
+        .mockReturnValueOnce(JSON.stringify(config))
+        .mockReturnValueOnce(JSON.stringify(config))
+        .mockReturnValue(JSON.stringify(config));
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token: "refreshed-but-still-invalid",
+          refreshToken: "new-refresh",
+          expiresIn: 3600,
+          user: { id: "u1" },
+        }),
+      });
+      // Both the original and the retry return 401
+      mockInnerFetch
+        .mockResolvedValueOnce(new Response("unauthorized", { status: 401 }))
+        .mockResolvedValueOnce(new Response("unauthorized", { status: 401 }));
+
+      const authFetch = createAuthAwareFetch(mockInnerFetch);
+      const response = await authFetch("https://api.example.com/test");
+
+      expect(response.status).toBe(401);
+      // Original + single retry = 2 calls, no further retries
+      expect(mockInnerFetch).toHaveBeenCalledTimes(2);
+      delete process.env.WAVE_SERVER_URL;
     });
 
     it("updates Authorization header with fresh token after refresh", async () => {


### PR DESCRIPTION
## Problem

CLI SSO 收到 401 后无法强制刷新 token,进入 401 循环 (issue #1555)。

401/403 recovery 分支调用的是 `checkAndRefreshTokenIfNeeded()`,其第一行就被 `isTokenExpired()` 短路:

```ts
async checkAndRefreshTokenIfNeeded(): Promise<boolean> {
  if (!this.isTokenExpired()) return true;   // 本地没过期就直接返回,不刷新
  ...
}
```

当 token 被服务端主动吊销、白名单变更、时钟偏移,或 `auth.json` 缺失 `SSO_TOKEN_EXPIRES_AT`(`isTokenExpired` 返回 false)时,本地认为 token 仍在有效期,recovery 分支直接 `return true` 不刷新,然后用同一个已失效 token 重试 → 再次 401 → "Token recovery failed"。

## Fix

新增 `forceRefreshToken()`,绕过本地 `isTokenExpired()` 判断,无条件尝试一次 refresh(复用 `_refreshPromise` 去重)。401/403 recovery 分支改用它:

```ts
// Try force refresh — bypass local expiry check: a server-side 401/403
// is the authoritative signal that the token is invalid.
if (await authService.forceRefreshToken()) { ... }
```

401/403 是服务端对 token 失效的权威反馈,比本地基于 `SSO_TOKEN_EXPIRES_AT` 的推断更可靠。recovery 仍然每次请求只重试一次,不会无限循环。

## Changes

- `authService.ts`: 新增 `forceRefreshToken()`;`checkAndRefreshTokenIfNeeded()` 委托给它(无重复);recovery 分支改用 `forceRefreshToken()`
- `sso-auth.md` spec: 新增 401 force-refresh 边界条件
- `authService.test.ts`: 修复了通过 bug 路径蒙混过的 `retries on 401 after disk refresh` 测试;新增 #1555 回归测试(本地未过期 / 无 expiry 两种场景 + 只重试一次不循环)+ `forceRefreshToken` 专项测试块

## Verification

- `pnpm test`: 72/72 通过 (干净树 64,新增 8)
- `tsc --noEmit`: 通过
- `pnpm -F wave-agent-sdk build`: 通过

Closes #1555