### PR TITLE
feat(agent-sdk): add x-session-id header to LLM requests

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -95,7 +95,10 @@ export class Agent {
 
   // Dynamic configuration getter methods
   public getGatewayConfig(): GatewayConfig {
-    return this.configurationService.resolveGatewayConfig();
+    return {
+      ...this.configurationService.resolveGatewayConfig(),
+      sessionId: this.messageManager.getSessionId(),
+    };
   }
 
   public getModelConfig(): ModelConfig {

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -216,7 +216,10 @@ export class AIManager {
 
   // Getter methods for accessing dynamic configuration
   public getGatewayConfig(): GatewayConfig {
-    return this.configurationService.resolveGatewayConfig();
+    return {
+      ...this.configurationService.resolveGatewayConfig(),
+      sessionId: this.messageManager.getSessionId(),
+    };
   }
 
   public getModelConfig(): ModelConfig {

--- a/packages/agent-sdk/src/types/config.ts
+++ b/packages/agent-sdk/src/types/config.ts
@@ -12,6 +12,8 @@ export interface GatewayConfig {
   defaultHeaders?: Record<string, string>;
   fetchOptions?: OpenAI["fetchOptions"];
   fetch?: OpenAI["fetch"];
+  /** Session identifier, sent as the `x-session-id` request header for backend correlation. */
+  sessionId?: string;
 }
 
 export interface ModelCapabilities {

--- a/packages/agent-sdk/src/utils/openaiClient.ts
+++ b/packages/agent-sdk/src/utils/openaiClient.ts
@@ -97,6 +97,7 @@ export class OpenAIClient {
     const {
       baseURL,
       apiKey,
+      sessionId,
       defaultHeaders,
       fetchOptions,
       fetch: customFetch,
@@ -105,6 +106,7 @@ export class OpenAIClient {
     const headers = {
       "Content-Type": "application/json",
       ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      ...(sessionId ? { "x-session-id": sessionId } : {}),
       ...defaultHeaders,
     };
 

--- a/packages/agent-sdk/tests/agent/agent.headers.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.headers.test.ts
@@ -25,6 +25,15 @@ describe("Agent Custom Headers", () => {
     vi.restoreAllMocks();
   });
 
+  it("should expose sessionId in gateway config for backend correlation", async () => {
+    const agent = await Agent.create({});
+    activeAgent = agent;
+    const gatewayConfig = agent.getGatewayConfig();
+
+    expect(gatewayConfig.sessionId).toBe(agent.sessionId);
+    expect(gatewayConfig.sessionId).toBeTruthy();
+  });
+
   it("should include headers from WAVE_CUSTOM_HEADERS environment variable", async () => {
     process.env.WAVE_CUSTOM_HEADERS = "X-Test-Header: value123";
 

--- a/packages/agent-sdk/tests/managers/aiManager.compactConversation.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.compactConversation.test.ts
@@ -179,7 +179,10 @@ describe("AIManager - compactConversation", () => {
       expect(callAgentMock).toHaveBeenCalledTimes(1);
       expect(callAgentMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          gatewayConfig: mockGatewayConfig,
+          gatewayConfig: expect.objectContaining({
+            ...mockGatewayConfig,
+            sessionId: expect.any(String),
+          }),
           modelConfig: mockModelConfig,
           workdir: "/test/workdir",
           tools: [],

--- a/packages/agent-sdk/tests/utils/openaiClient.test.ts
+++ b/packages/agent-sdk/tests/utils/openaiClient.test.ts
@@ -143,6 +143,53 @@ describe("OpenAIClient", () => {
     expect(chunks[0].choices[0].delta.content).toBe("hello");
   });
 
+  describe("Session header", () => {
+    it("should send x-session-id header when sessionId is configured", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: "ok" } }] }),
+        headers: new Headers(),
+      });
+
+      const client = new OpenAIClient({
+        baseURL: "https://api.openai.com/v1",
+        apiKey: "test-key",
+        sessionId: "sess-123",
+        fetch: mockFetch,
+      });
+
+      await client.chat.completions.create({
+        model: "gpt-4",
+        messages: [{ role: "user", content: "hi" }],
+      });
+
+      const init = mockFetch.mock.calls[0][1] as RequestInit;
+      expect(init.headers).toHaveProperty("x-session-id", "sess-123");
+    });
+
+    it("should not send x-session-id when sessionId is absent", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: "ok" } }] }),
+        headers: new Headers(),
+      });
+
+      const client = new OpenAIClient({
+        baseURL: "https://api.openai.com/v1",
+        apiKey: "test-key",
+        fetch: mockFetch,
+      });
+
+      await client.chat.completions.create({
+        model: "gpt-4",
+        messages: [{ role: "user", content: "hi" }],
+      });
+
+      const init = mockFetch.mock.calls[0][1] as RequestInit;
+      expect(init.headers).not.toHaveProperty("x-session-id");
+    });
+  });
+
   describe("Retry logic", () => {
     it("should retry on 429 status code and eventually succeed", async () => {
       const mockFetch = vi


### PR DESCRIPTION
## Summary

Tag every model (LLM) request with the session id via an `x-session-id` request header, enabling backend session correlation/logging.

## Changes

- **`GatewayConfig`** (`src/types/config.ts`): new optional `sessionId` field.
- **`OpenAIClient`** (`src/utils/openaiClient.ts`): the HTTP boundary now injects `x-session-id: <sessionId>` on each request when a sessionId is present.
- **`getGatewayConfig()`** in both `Agent` (`src/agent.ts`) and `AIManager` (`src/managers/aiManager.ts`): populate `sessionId` from `messageManager.getSessionId()`.

## Coverage

All LLM call paths funnel through `getGatewayConfig()`, so this single change covers:
- Main agent loop
- Compaction fork
- `btw` (side questions)
- `processWebContent` (web fetch processing)
- `evaluateGoal` (goal evaluation)

Subagents are separate `Agent` instances, so they tag requests with their own session id.

## Notes

- SSO mode's auth-aware fetch wrapper only touches `Authorization`, so `x-session-id` passes through unchanged.
- Explicit `defaultHeaders` take precedence over the auto-injected header (config can override).

## Tests

- Added `openaiClient.test.ts` cases: header sent when `sessionId` configured; absent otherwise.
- Added `agent.headers.test.ts` wiring test: `getGatewayConfig().sessionId === agent.sessionId`.
- Updated one `aiManager.compactConversation.test.ts` assertion for the new field.
- agent-sdk full suite: 3330 passed, type-check clean.