### PR TITLE
fix: 会话保存在 worktree 删除时失败 (ENOENT)

### DIFF
--- a/packages/agent-sdk/src/utils/pathEncoder.ts
+++ b/packages/agent-sdk/src/utils/pathEncoder.ts
@@ -212,8 +212,13 @@ export class PathEncoder {
       resolvedPath = absolutePath;
     }
 
-    // Encode the resolved path
-    const encodedName = await this.encode(resolvedPath);
+    // Encode the resolved path. Use encodeSync (pure string transform) rather
+    // than encode(): realpath was already attempted above with its own fallback,
+    // so re-resolving via encode()->resolvePath() would throw ENOENT again when
+    // the workdir no longer exists (e.g. a deleted worktree during agent
+    // shutdown). Session files live under <baseSessionDir>/<encoded>/ regardless
+    // of the workdir's existence, so encoding must not require it to exist.
+    const encodedName = this.encodeSync(resolvedPath);
     const encodedPath = join(baseSessionDir, encodedName);
 
     // Generate hash if encoding resulted in truncation

--- a/packages/agent-sdk/tests/utils/pathEncoder.test.ts
+++ b/packages/agent-sdk/tests/utils/pathEncoder.test.ts
@@ -299,16 +299,10 @@ describe("PathEncoder", () => {
     });
 
     it("should handle realpath failure gracefully", async () => {
-      // Mock realpath to fail only for the first call in createProjectDirectory
-      // but succeed for the second call in encode method
-      let callCount = 0;
-      vi.mocked(realpath).mockImplementation((path) => {
-        callCount++;
-        if (callCount === 1) {
-          return Promise.reject(new Error("Permission denied"));
-        }
-        return Promise.resolve(path as string);
-      });
+      // realpath fails for every call (e.g. the directory was deleted) —
+      // createProjectDirectory must still succeed, falling back to the
+      // absolute path.
+      vi.mocked(realpath).mockRejectedValue(new Error("Permission denied"));
 
       const result = await pathEncoder.createProjectDirectory(
         "/protected/path",
@@ -317,6 +311,34 @@ describe("PathEncoder", () => {
 
       // Should use absolute path when realpath fails
       expect(result.originalPath).toMatch(/.*[/\\]protected[/\\]path$/);
+      expect(result.isSymbolicLink).toBe(false);
+    });
+
+    it("should fall back to absolute path when the workdir no longer exists", async () => {
+      // Reproduces the deleted-worktree scenario: the working directory has been
+      // removed (ENOENT) so every realpath call fails. Session files live under
+      // ~/.wave/projects/<encoded>/ — independent of the workdir's existence —
+      // so getProjectDirectory must not throw and must keep a stable encoding.
+      vi.mocked(realpath).mockRejectedValue(
+        Object.assign(new Error("ENOENT: no such file or directory"), {
+          code: "ENOENT",
+        }),
+      );
+
+      const workdir =
+        "/Users/liuyiqi/github/wave-agent/.wave/worktrees/smart-brave-hawk";
+
+      const result = await pathEncoder.getProjectDirectory(
+        workdir,
+        baseSessionDir,
+      );
+
+      // Encoded name must match encodeSync of the absolute path so the session
+      // file remains locatable after the worktree directory is deleted.
+      expect(result.encodedName).toBe(pathEncoder.encodeSync(workdir));
+      expect(result.encodedPath).toBe(
+        path.join(baseSessionDir, result.encodedName),
+      );
       expect(result.isSymbolicLink).toBe(false);
     });
 

--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -1265,7 +1265,19 @@ export class DesktopHost {
         resetSolePane = true;
       }
     }
-    if (target) void target.destroy().catch(() => { /* best-effort */ });
+    // Destroy the agent BEFORE removing its worktree directory. The agent's
+    // cwd is the worktree path, and Agent.destroy() flushes the session file
+    // (which resolves the worktree path via realpath). Previously destroy and
+    // removeWorktree raced as independent fire-and-forget calls — the fast
+    // `git worktree remove` deleted the directory before the slow destroy
+    // reached saveSession, leaving it failing ENOENT and losing the trailing
+    // messages. Keep both backgrounded (no UI block) but sequence them:
+    // removeWorktree runs only after destroy resolves. destroy() does not
+    // dispose the shared stdio client, so the connection stays alive for
+    // removeWorktree to reuse.
+    const destroyPromise = target
+      ? target.destroy().catch(() => { /* best-effort */ })
+      : Promise.resolve();
 
     this.configStore.removeSession(sessionId);
     // Update the sidebar right away — the worktree cleanup below runs in the
@@ -1280,12 +1292,15 @@ export class DesktopHost {
       }
     }
 
-    if (entry?.worktree) {
-      void this.removeWorktree({
-        path: entry.worktree.path,
-        branch: entry.worktree.branch,
-        repoRoot: entry.worktree.repoRoot,
-      });
+    const worktree = entry?.worktree;
+    if (worktree) {
+      void destroyPromise.then(() =>
+        this.removeWorktree({
+          path: worktree.path,
+          branch: worktree.branch,
+          repoRoot: worktree.repoRoot,
+        }),
+      );
     }
   }
 

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -1496,6 +1496,39 @@ describe('worktree flow', () => {
     });
     expect(store.getSessionIndex().some((e) => e.sessionId === 'live-wt')).toBe(false);
   });
+
+  it('desktopDeleteSession removes the worktree only after the agent is destroyed', async () => {
+    const { host, store } = await readyHost();
+    h.worktreeResult = worktree;
+    h.existingPaths.add(worktree.path);
+    await host.handleWebviewMessage({ command: 'desktopCreateWorktree', workdir: '/work/a', baseBranch: 'main' });
+    const wtAgent = lastAgent();
+    wtAgent.messages = [{ id: 'm1' }];
+    wtAgent.callbacks.onSessionIdChange('live-wt');
+
+    // Gate the agent's destroy so the ordering is observable: removeWorktree
+    // must not be requested until destroy resolves. This reproduces the race
+    // where a fast `git worktree remove` deletes the agent's cwd before the
+    // slow Agent.destroy() reaches saveSession (which realpath's the workdir).
+    let releaseDestroy = () => {};
+    wtAgent.destroy = vi.fn(() => new Promise<void>((resolve) => { releaseDestroy = () => resolve(); }));
+
+    await host.handleWebviewMessage({ command: 'desktopDeleteSession', sessionId: 'live-wt' });
+
+    // destroy is still pending — removeWorktree must NOT have been requested yet.
+    expect(h.clientRequests.some((r) => r.method === 'removeWorktree')).toBe(false);
+
+    releaseDestroy();
+    // destroy resolves → the chained removeWorktree runs now.
+    await vi.waitFor(() => {
+      expect(h.clientRequests).toContainEqual({
+        method: 'removeWorktree',
+        params: { path: worktree.path, branch: worktree.branch, repoRoot: worktree.repoRoot },
+      });
+    });
+
+    expect(store.getSessionIndex().some((e) => e.sessionId === 'live-wt')).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 问题

删除 worktree 会话时，Agent.destroy() 的 saveSession 抛出 ENOENT，丢失尾部消息：

Failed to resolve path ".wave/worktrees/smart-brave-hawk": Error: ENOENT: no such file or directory, realpath '...'

调用链：Agent.destroy → MessageManager.saveSession → appendMessages → generateSessionFilePath → PathEncoder.getProjectDirectory → PathEncoder.encode → resolvePath → realpath（抛异常）。

## 根因

两层问题叠加：

1. pathEncoder 死代码回退：getProjectDirectory 有自己的 realpath try/catch 回退，但随后调 encode()，它又经 resolvePath() 调一次 realpath() 且无回退——worktree 目录被删时再次抛 ENOENT，回退形同虚设。

2. desktop 竞态：handleDeleteSession 两个独立 fire-and-forget void 调用——快的 git worktree remove 先删目录，慢的 destroy→saveSession 才跑到就 ENOENT。

## 修复

agent-sdk/pathEncoder.ts：getProjectDirectory 改用 encodeSync（纯字符串转换），不再走 encode()→resolvePath()→realpath()。realpath 已在上面尝试过并有回退，无需重复解析。会话文件位于 ~/.wave/projects/<encoded>/ 下，不依赖 workdir 是否存在，故编码不得要求其存在。

desktop/desktopHost.ts：handleDeleteSession 改为 destroyPromise.then(() => removeWorktree(...))，两者仍后台运行不阻塞 UI，但 removeWorktree 等 destroy resolve 后才跑。共享 stdio 连接不被 destroy 销毁，可复用。

## 测试

- 修掉掩盖 bug 的旧 mock（第一次 realpath 失败、第二次成功），改为始终拒绝，暴露真实场景
- 新增回归测试：should fall back to absolute path when the workdir no longer exists（复现报错堆栈，修复前失败）
- desktop 新增排序测试：gate 住 destroy，断言释放前 removeWorktree 未请求、释放后才请求；该测试在旧代码上失败

## 验证

- pathEncoder: 68/68 ✅
- desktop 全套: 245/245 ✅
- type-check: 5 包全 Done ✅
- agent-sdk dist 已重建