### PR TITLE
fix(sdk): split remoteSettingsService initialize to defer network fetch after env application

### DIFF
--- a/docs/specs/enterprise/server-managed-config.md
+++ b/docs/specs/enterprise/server-managed-config.md
@@ -64,4 +64,5 @@ order: 20
 - **如果用户退出 SSO 会怎样？** 后续启动不再下载托管设置，但之前缓存的托管设置保持有效，直到被本地更改覆盖。
 - **如果托管设置与环境变量冲突会怎样？** 用户的 `settings.json` `model` 字段覆盖管理员的 `env.WAVE_MODEL` 默认值。如果管理员想要强制执行，他们使用 `model` 标量字段，在合并期间覆盖本地值。Shell 环境变量（在 Wave 启动前设置）是最低优先级的回退。
 - **设置重新加载期间（文件监视器）会怎样？** 托管设置在文件更改时不会重新下载——它们仅在初始化期间下载。
+- **如果 `WAVE_SERVER_URL` 配置在 `settings.json` 的 `env` 中而非 shell 环境变量会怎样？** 启动时本地 `settings.json` 的 `env` 在 `loadMergedConfiguration` 内才写入 `process.env`，而远程设置的网络请求通过 `getServerUrl()` 读取 `process.env.WAVE_SERVER_URL` 来决定目标端点。因此网络请求必须在 `loadMergedConfiguration` **之后**启动；否则 `WAVE_SERVER_URL` 尚未写入 `process.env`，`getServerUrl()` 回落到 `DEFAULT_SERVER_URL`（生产），用测试环境签发的 token 命中生产端点，必然 401 且无法恢复。磁盘缓存加载（`loadCacheFromDisk`）仍须在 `loadMergedConfiguration` **之前**完成，以便合并时 `getRemoteSettingsSync()` 返回缓存的托管设置。两者职责分离：缓存加载在前，网络刷新在后。
 

--- a/packages/agent-sdk/src/services/initializationService.ts
+++ b/packages/agent-sdk/src/services/initializationService.ts
@@ -126,13 +126,16 @@ export class InitializationService {
       // Don't throw error to prevent app startup failure
     }
 
-    // Initialize remote settings (load disk cache synchronously, then fetch in background)
-    // Must happen BEFORE loadMergedConfiguration so remote env vars are available
+    // Load remote settings disk cache synchronously.
+    // Must happen BEFORE loadMergedConfiguration so cached managed settings
+    // (env, model, disallowedTools) are merged and applied to process.env.
+    // The network fetch is deferred until after loadMergedConfiguration (below)
+    // so settings.json env vars (e.g. WAVE_SERVER_URL) are in process.env first.
     try {
       const phaseStart = performance.now();
       await remoteSettingsService.initialize();
       logger?.debug(
-        `Initialization Phase [Remote Settings] took ${(performance.now() - phaseStart).toFixed(2)}ms`,
+        `Initialization Phase [Remote Settings Cache] took ${(performance.now() - phaseStart).toFixed(2)}ms`,
       );
     } catch (error) {
       logger?.error("Failed to initialize remote settings:", error);
@@ -189,6 +192,11 @@ export class InitializationService {
       logger?.error("Failed to initialize hooks system:", error);
       // Don't throw error to prevent app startup failure
     }
+
+    // Start remote settings network fetch + polling now that local env vars
+    // (e.g. WAVE_SERVER_URL) are applied to process.env by loadMergedConfiguration.
+    // Fire-and-forget: failures fall back to the cached/merged settings.
+    remoteSettingsService.startBackgroundFetch();
 
     // Execute SessionStart hooks
     try {

--- a/packages/agent-sdk/src/services/remoteSettingsService.ts
+++ b/packages/agent-sdk/src/services/remoteSettingsService.ts
@@ -198,8 +198,20 @@ function startPolling(): void {
 }
 
 export function initialize(): void {
+  // Load disk cache synchronously so getRemoteSettingsSync() returns cached
+  // managed settings during loadMergedConfiguration() (must run BEFORE it).
   loadCacheFromDisk();
-  // Fire-and-forget the initial fetch, then start background polling
+}
+
+/**
+ * Start the fire-and-forget initial network fetch + background polling.
+ *
+ * Must be called AFTER loadMergedConfiguration() so local settings.json env
+ * vars (e.g. WAVE_SERVER_URL) are applied to process.env first — otherwise
+ * getServerUrl() falls back to DEFAULT_SERVER_URL (prod) and a test-issued
+ * token hits the prod endpoint (401).
+ */
+export function startBackgroundFetch(): void {
   fetchRemoteSettings()
     .then(() => startPolling())
     .catch((err) => {
@@ -342,6 +354,7 @@ export function mergeRemoteSettings(
  */
 export const remoteSettingsService = {
   initialize,
+  startBackgroundFetch,
   getRemoteSettingsSync,
   refresh,
   clear,

--- a/packages/agent-sdk/tests/services/remoteSettingsService.test.ts
+++ b/packages/agent-sdk/tests/services/remoteSettingsService.test.ts
@@ -44,6 +44,7 @@ import {
   shutdown,
   refresh,
   initialize,
+  startBackgroundFetch,
   onSettingsUpdate,
   remoteSettingsService,
 } from "../../src/services/remoteSettingsService.js";
@@ -156,13 +157,13 @@ describe("remoteSettingsService", () => {
       );
       await refresh();
 
-      // Now cache is populated. Trigger another fetch via initialize (doesn't clear cache).
+      // Now cache is populated. Trigger another fetch via startBackgroundFetch (doesn't clear cache).
       const fetchSpy = vi.mocked(fetch);
       fetchSpy.mockResolvedValue({
         status: 304,
       } as Response);
 
-      initialize();
+      startBackgroundFetch();
       await new Promise((r) => setTimeout(r, 50));
 
       // Verify If-None-Match was sent
@@ -207,11 +208,12 @@ describe("remoteSettingsService", () => {
         }),
       );
 
-      // initialize loads cache from disk, then fetches
+      // initialize loads cache from disk, then startBackgroundFetch fetches
       initialize();
+      startBackgroundFetch();
       await new Promise((r) => setTimeout(r, 50));
 
-      // After initialize + 304, settings should still be available
+      // After fetch + 304, settings should still be available
       expect(getRemoteSettingsSync()).toEqual(settings);
 
       clear();
@@ -282,8 +284,9 @@ describe("remoteSettingsService", () => {
         }),
       );
 
-      // initialize loads cache from disk, then fetches
+      // initialize loads cache from disk, then startBackgroundFetch fetches
       initialize();
+      startBackgroundFetch();
       await new Promise((r) => setTimeout(r, 50));
 
       // Should fall back to cached settings
@@ -315,6 +318,7 @@ describe("remoteSettingsService", () => {
       );
 
       initialize();
+      startBackgroundFetch();
       await new Promise((r) => setTimeout(r, 50));
 
       expect(getRemoteSettingsSync()).toEqual(settings);
@@ -388,15 +392,46 @@ describe("remoteSettingsService", () => {
       );
 
       initialize();
-
-      // Synchronous: cache loaded from disk
+      // initialize() only loads the disk cache (no network fetch)
       expect(getRemoteSettingsSync()).toEqual(cachedSettings);
+
+      // startBackgroundFetch triggers the network fetch + polling
+      startBackgroundFetch();
 
       // Wait for async fetch to complete
       await new Promise((r) => setTimeout(r, 50));
 
       // After fetch, settings should be updated
       expect(getRemoteSettingsSync()).toEqual({ language: "en" });
+
+      clear();
+    });
+
+    it("loads cache from disk without triggering a network fetch", async () => {
+      (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
+      (authService.getSSOToken as Mock).mockReturnValue("token123");
+      (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
+
+      const cachedSettings = { language: "zh" };
+      (fs.existsSync as Mock).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockReturnValue(
+        JSON.stringify({
+          uuid: "u1",
+          checksum: "old",
+          settings: cachedSettings,
+          fetchedAt: "2024-01-01T00:00:00.000Z",
+        }),
+      );
+
+      const fetchSpy = vi.fn();
+      vi.stubGlobal("fetch", fetchSpy);
+
+      initialize();
+
+      // Cache loaded synchronously from disk
+      expect(getRemoteSettingsSync()).toEqual(cachedSettings);
+      // No network fetch was triggered (deferred to startBackgroundFetch)
+      expect(fetchSpy).not.toHaveBeenCalled();
 
       clear();
     });
@@ -412,6 +447,7 @@ describe("remoteSettingsService", () => {
       );
 
       initialize();
+      startBackgroundFetch();
       await new Promise((r) => setTimeout(r, 50));
 
       // Polling should still be started (no crash)
@@ -490,6 +526,7 @@ describe("remoteSettingsService", () => {
       );
 
       initialize();
+      startBackgroundFetch();
       await new Promise((r) => setTimeout(r, 50));
 
       // Should not throw
@@ -590,7 +627,8 @@ describe("remoteSettingsService", () => {
       const unsubscribe = onSettingsUpdate(callback);
 
       // Second fetch with same checksum — note refresh() clears cache first,
-      // so oldChecksum is undefined. We test via initialize() path instead.
+      // so oldChecksum is undefined. We test via startBackgroundFetch() instead
+      // (it fetches without clearing, so oldChecksum = "same").
       vi.mocked(fetch).mockResolvedValue({
         status: 200,
         ok: true,
@@ -601,10 +639,10 @@ describe("remoteSettingsService", () => {
             settings: { language: "en" },
           }),
       } as Response);
-      initialize();
+      startBackgroundFetch();
       await new Promise((r) => setTimeout(r, 50));
 
-      // initialize() doesn't clear cache, so oldChecksum = "same", new = "same" → no callback
+      // oldChecksum = "same", new = "same" → no callback
       expect(callback).not.toHaveBeenCalled();
       unsubscribe();
     });
@@ -639,7 +677,7 @@ describe("remoteSettingsService", () => {
         status: 404,
         ok: false,
       } as Response);
-      initialize();
+      startBackgroundFetch();
       await new Promise((r) => setTimeout(r, 50));
 
       expect(callback).toHaveBeenCalledTimes(1);
@@ -943,6 +981,7 @@ describe("remoteSettingsService", () => {
   describe("remoteSettingsService namespace", () => {
     it("exposes all expected methods", () => {
       expect(remoteSettingsService.initialize).toBeTypeOf("function");
+      expect(remoteSettingsService.startBackgroundFetch).toBeTypeOf("function");
       expect(remoteSettingsService.getRemoteSettingsSync).toBeTypeOf(
         "function",
       );
@@ -1078,7 +1117,7 @@ describe("remoteSettingsService", () => {
   // startPolling — second call is no-op
   // ---------------------------------------------------------------------------
   describe("startPolling idempotency", () => {
-    it("does not start duplicate timers on multiple initialize calls", async () => {
+    it("does not start duplicate timers on multiple startBackgroundFetch calls", async () => {
       (authService.isSSOAuthenticated as Mock).mockReturnValue(true);
       (authService.getSSOToken as Mock).mockReturnValue("token123");
       (authService.getServerUrl as Mock).mockReturnValue("https://server.test");
@@ -1098,10 +1137,11 @@ describe("remoteSettingsService", () => {
       );
 
       initialize();
+      startBackgroundFetch();
       await new Promise((r) => setTimeout(r, 50));
 
-      // Call initialize again — should not create a second timer
-      initialize();
+      // Call startBackgroundFetch again — should not create a second timer
+      startBackgroundFetch();
       await new Promise((r) => setTimeout(r, 50));
 
       clear();


### PR DESCRIPTION
## Problem

Every CLI startup produced a 401 auth error (with token recovery). Root cause: the fire-and-forget remote-settings network fetch read `getServerUrl()` (`process.env.WAVE_SERVER_URL`) BEFORE `loadMergedConfiguration()` applied local `settings.json` env to `process.env`. The fetch fell back to `DEFAULT_SERVER_URL` (prod `codechat.codewave.163.com`) and a test-issued token hit the prod endpoint → exactly one 401 per startup.

## Fix

Split `initialize()` into two responsibilities:

- **`initialize()`** — `loadCacheFromDisk()` only. Kept BEFORE `loadMergedConfiguration` so `getRemoteSettingsSync()` returns cached managed settings during merge. This preserves PR #1168's ordering: the disk cache is the only startup path that applies managed env/models/disallowedTools (the background fetch only re-applies on checksum change; 304 short-circuits without `notifySettingsUpdate`, so without cache-before-merge managed settings would be silently dropped for the whole session).
- **`startBackgroundFetch()`** (new) — fire-and-forget `fetchRemoteSettings` + polling, called from `initializationService` AFTER `loadMergedConfiguration` so `settings.json` env (`WAVE_SERVER_URL`) is in `process.env` first. Failures fall back to cached/merged settings.

## Why not just revert PR #1168?

Reverting (moving all of `initialize()` after `loadMergedConfiguration`) would fix the 401 but re-introduce MISSING_MODEL — `loadMergedConfiguration` calls `getRemoteSettingsSync()` which needs `_cachedSettings` populated by `loadCacheFromDisk()`; with `initialize` moved after, the cache is null → remote env vars never merged/applied. The ordering tension is fundamental: cache-load must precede merge, network-fetch must follow env application. `initialize()` bundling both means neither full placement works — hence split, not rollback.

## Spec

Updated `docs/specs/enterprise/server-managed-config.md` FIRST (spec-first workflow) with a boundary case documenting the initialization ordering constraint: network fetch after `loadMergedConfiguration`, disk cache load before. Spec-count validation: 62 specs / 310 user stories / 1013 acceptance scenarios pass.

## Tests

- Updated all fetch-triggering call sites in `remoteSettingsService.test.ts` to call `startBackgroundFetch()` (or `initialize(); startBackgroundFetch();` where disk-cache load is also needed).
- Left pure cache-load edge cases using `initialize()` alone.
- Added a new contract test asserting `initialize()` does NOT trigger a network fetch.

## Verification

- `remoteSettingsService.test.ts`: 57/57 pass
- Full agent-sdk suite: 239 files / 3332 passed + 1 skipped
- `tsc --noEmit`: clean
- Pre-commit hooks (type-check + lint): pass