### PR TITLE
feat(config): store settings.json env in per-session snapshot, not process.env

### DIFF
--- a/docs/specs/core/agent-config.md
+++ b/docs/specs/core/agent-config.md
@@ -101,7 +101,7 @@ order: 60
 
 ### 用户故事：自定义环境变量（优先级：P1）
 
-开发者需要将自定义环境变量（API 密钥、数据库 URL、功能标志）传递给 Wave Agent SDK，而不需要在代码中硬编码。他们在 settings.json 文件中添加 "env" 字段，并期望这些变量在代理执行上下文中可用。Wave Code CLI 将继承此功能，因为它使用 SDK。
+开发者需要将自定义环境变量（API 密钥、数据库 URL、功能标志）传递给 Wave Agent SDK，而不需要在代码中硬编码。他们在 settings.json 文件中添加 "env" 字段，并期望这些变量在代理执行上下文中可用。这些变量被存入 Agent 的**会话级环境快照**（`ConfigurationService` 实例，每个会话独立），优先级高于 OS 环境变量，但**不写入 `process.env`**——这样在 stdio 多会话模式下，一个进程承载多个会话时不会相互污染。Wave Code CLI 将继承此功能，因为它使用 SDK。
 
 **为什么是这个优先级**：这提供了必要的配置灵活性，并遵循安全最佳实践，将敏感数据保留在配置文件中而非代码中。
 
@@ -109,9 +109,12 @@ order: 60
 
 **验收场景**：
 
-1. **假设**settings.json 文件包含带有键值对的 env 字段，**当**Wave Agent SDK 启动时，**则**这些环境变量对所有代理进程可用
+1. **假设**settings.json 文件包含带有键值对的 env 字段，**当**Wave Agent SDK 启动时，**则**这些环境变量存入该 Agent 的**会话级环境快照**（per-session env snapshot），优先级高于 OS 环境变量；它们**不写入 `process.env`**
 2. **假设**用户级和项目级 settings.json 文件都包含 env 字段，**当**代理运行时，**则**项目级环境变量覆盖同名的用户级变量
 3. **假设**env 字段格式无效，**当**设置被加载时，**则**系统显示关于无效环境变量配置的清晰错误消息
+4. **假设**一个 stdio 进程承载多个会话（不同项目/workdir），且各自的 settings.json `env` 设置了不同的 `WAVE_MODEL`/`WAVE_API_KEY`，**当**任一会话解析网关/模型配置时，**则**只读取本会话的快照，不发生"后启动会话覆盖前一会话"的污染（last-session-wins 污染消除）
+5. **假设**settings.json `env` 中的变量被子进程（bash、hooks、bang、后台任务、MCP 模板替换）读取，**当**这些子进程启动时，**则**其环境为 `OS env + 本会话快照` 的合并（基础设施子进程如 git/worktree/LSP 仍只读 OS env）
+6. **假设**settings.json `env` 中设置了 `WAVE_SERVER_URL`，**当**配置被加载时，**则**该值被忽略——`WAVE_SERVER_URL` 仅从 OS 环境或 `options.serverUrl`/stdio `initialize` 参数读取（详见边界说明）
 
 ---
 
@@ -182,6 +185,13 @@ SDK 用户需要按子代理类型配置不同的 HTTP 请求头，以便 `custo
 - IDE 插件配置对话框只填写部分字段（如仅 API Key、无 API 地址）时如何生效？（未填写的字段保持原值或回退到环境变量）
 - IDE 插件配置对话框加载已保存配置失败时如何展示？（对话框内显示错误，表单仍可填写重试）
 
+### 边界说明：环境变量作用域与优先级
+
+- **settings.json `env` 与 OS 环境变量的关系**：settings.json `env` 存入会话级快照，优先级高于 OS 环境变量，但**不写入 `process.env`**。优先级从高到低：显式构造参数 / stdio `initialize` 参数 > settings.json `env`（快照）> OS 环境变量 > 默认值。
+- **`WAVE_SERVER_URL` 仅从 OS 环境读取**：它**不从** settings.json `env` 读取。设置服务端地址需通过 OS 环境变量、`options.serverUrl` 或 stdio `initialize` 参数。这样做消除了启动时 401 竞态（OS 环境变量在进程启动时即已就绪，远端设置拉取不需要等待 settings env 应用）。
+- **SSO 认证 / 远端设置轮询为进程级单例**：`authService` 与 `remoteSettingsService` 是进程级单例（一个 `auth.json` / 远端设置缓存——按用户）。因此对于后台 token 刷新/远端设置轮询，**每个进程只有一个 `serverUrl`**；AI 网关/模型/密钥的解析本身仍是按会话进行的。
+- **基础设施子进程保持 OS-env-only**：git/worktree/LSP 等基础设施子进程只读取 OS 环境变量（`PATH`/`HOME`/`LC_ALL` 等），不合并会话快照。`WAVE_PLUGIN_GIT_TIMEOUT_MS`、`WAVE_SHELL`、`WAVE_GIT_BASH_PATH` 等"基础设施级"变量不从 settings.json `env` 读取，需通过 OS 环境设置。
+
 ## 成功标准 *（必填）*
 
 ### 可衡量结果
@@ -191,7 +201,7 @@ SDK 用户需要按子代理类型配置不同的 HTTP 请求头，以便 `custo
 - **SC-003**：当两个来源都缺少必需配置时（自定义请求头存在时的 `apiKey` 除外），Agent 创建失败并带有描述性错误消息
 - **SC-004**：当两者都存在时，构造函数参数覆盖环境变量
 - **SC-005**：与测试相关的环境变量继续像以前一样工作
-- **SC-006**：服务使用已解析的配置而非直接环境变量访问
+- **SC-006**：服务读取已解析的配置 / 会话级环境快照，而非直接访问 `process.env`（settings.json `env` 不写入 `process.env`）
 - **SC-007**：`maxTokens` 以正确的优先级正确应用于 AI 服务调用
 - **SC-008**：来自 `WAVE_CUSTOM_HEADERS` 的自定义请求头包含在发出的请求中
 - **SC-009**：代理以配置的语言响应，同时保留技术术语

--- a/packages/agent-sdk/builtin/skills/settings/ENV.md
+++ b/packages/agent-sdk/builtin/skills/settings/ENV.md
@@ -17,13 +17,13 @@ Environment variables are configured in the `env` field of `settings.json`. It i
 
 ## Supported `WAVE_*` Environment Variables
 
-Wave uses several environment variables to control its core functionality.
+Wave uses several environment variables to control its core functionality. Variables marked **OS env only** are read from the OS environment (or constructor / stdio `initialize` params) and are **NOT** read from settings.json `env` — set them in your shell, not in the `env` field.
 
 | Variable | Description | Default |
 | :--- | :--- | :--- |
 | `WAVE_API_KEY` | API key for the AI gateway. | - |
 | `WAVE_BASE_URL` | Base URL for the AI gateway. | - |
-| `WAVE_SERVER_URL` | Server URL for SSO authentication. | `https://codechat.codewave.163.com` |
+| `WAVE_SERVER_URL` | Server URL for SSO authentication. **OS env only** — set via OS env or `options.serverUrl`; not read from settings.json `env` (avoids a startup 401 race). | `https://codechat.codewave.163.com` |
 | `WAVE_CUSTOM_HEADERS` | Custom HTTP headers for the AI gateway. Newline-separated `Key: Value` pairs (e.g., `"X-Foo: bar\nAuthorization: Bearer xxx"`). | - |
 | `WAVE_MODEL` | The primary AI model to use for the agent. | `gemini-3-flash` |
 | `WAVE_FAST_MODEL` | The fast AI model to use for quick tasks. | `gemini-2.5-flash` |
@@ -32,23 +32,29 @@ Wave uses several environment variables to control its core functionality.
 | `WAVE_DISABLE_AUTO_MEMORY` | Set to `1` or `true` to disable the auto-memory feature. | `false` |
 | `WAVE_AUTO_MEMORY_FREQUENCY` | Auto memory update frequency. `1` = every turn, `2` = every 2 turns, etc. | `1` |
 | `WAVE_TASK_LIST_ID` | Explicitly set the task list ID for the session. | (Session ID) |
-| `WAVE_PLUGIN_GIT_TIMEOUT_MS` | Timeout in milliseconds for git operations when installing plugins. | `300000` |
+| `WAVE_PLUGIN_GIT_TIMEOUT_MS` | Timeout in milliseconds for git operations when installing plugins. **OS env only** (infrastructure). | `300000` |
 
 ## Configuration Scopes
 
-Environment variables can be set in different scopes, with the following precedence (highest to lowest):
+Environment variables can be set in different scopes. Wave merges scopes from lowest to highest priority and stores the result in the agent's **per-session environment snapshot**. The snapshot takes priority over OS environment variables but is **NOT written to `process.env`** — this keeps multiple sessions in one `wave --stdio` process from polluting each other.
+
+Precedence (highest to lowest):
 
 1.  **Local Scope**: `.wave/settings.local.json` (Local overrides, ignored by git)
 2.  **Project Scope**: `.wave/settings.json` (Project-specific settings, shared via git)
 3.  **User Scope**: `~/.wave/settings.json` (Global settings for all projects)
-4.  **System Environment**: Variables set in your shell (e.g., `export WAVE_API_KEY=...`)
+4.  **System Environment**: Variables set in your shell (e.g., `export WAVE_API_KEY=...`). Used as a fallback when a key is absent from the settings snapshot.
+
+> Settings `env` shadows (does not mutate) OS env: a key set in both settings.json `env` and the OS environment resolves to the settings value for that session, while the OS value remains untouched and visible to unrelated processes.
 
 ## Custom Environment Variables
 
-You can also define custom environment variables in the `env` field. These variables will be available to:
+You can also define custom environment variables in the `env` field. These variables are stored in the session's environment snapshot and will be available to:
 
-- **Hooks**: Any shell command executed as a hook will have these variables in its environment.
-- **Tools**: Tools like `Bash` will have access to these variables.
+- **Hooks**: Any shell command executed as a hook will have these variables in its environment (merged on top of OS env).
+- **Tools**: Tools like `Bash` will have access to these variables (merged on top of OS env).
+
+In `wave --stdio` mode one process hosts multiple sessions; each session keeps its own snapshot, so sessions with different `env` do not pollute each other (no "last session wins").
 
 Example:
 ```json
@@ -62,7 +68,7 @@ Example:
 
 ## Live Reload
 
-Environment variables configured in `settings.json` support **live reload**. When you modify the `env` field in any `settings.json` file (user, project, or local scope), the changes take effect immediately without requiring a Wave session restart.
+Environment variables configured in `settings.json` support **live reload**. When you modify the `env` field in any `settings.json` file (user, project, or local scope), the changes take effect immediately without requiring a Wave session restart — the session's environment snapshot is refreshed and subsequent resolve calls / subprocess spawns use the new values.
 
 ## Best Practices
 

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -927,7 +927,9 @@ export class Agent {
           cwd: this.workdir,
           worktreePath,
           env: Object.fromEntries(
-            Object.entries(process.env).filter((e) => e[1] !== undefined),
+            Object.entries(this.configurationService.getMergedEnv()).filter(
+              (e) => e[1] !== undefined,
+            ),
           ) as Record<string, string>,
         },
       );

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -214,6 +214,21 @@ export class AIManager {
     return this.container.get<ConfigurationService>("ConfigurationService")!;
   }
 
+  /**
+   * OS env merged with the per-session env snapshot. Falls back to process.env
+   * when ConfigurationService is absent or its getMergedEnv is missing (e.g. in
+   * unit tests with partial mocks), so hook-context env construction never
+   * throws. Use this (not the non-null `configurationService` getter) when
+   * building hook context env.
+   */
+  private get mergedEnv(): Record<string, string> {
+    return (
+      this.container
+        .get<ConfigurationService>("ConfigurationService")
+        ?.getMergedEnv?.() ?? (process.env as Record<string, string>)
+    );
+  }
+
   // Getter methods for accessing dynamic configuration
   public getGatewayConfig(): GatewayConfig {
     return {
@@ -1742,7 +1757,7 @@ export class AIManager {
         lastAssistantMessage: lastAssistantText, // Stop/SubagentStop: last assistant message text
         // Stop hooks don't need toolName, toolInput, toolResponse, or userPrompt
         env: Object.fromEntries(
-          Object.entries(process.env).filter((e) => e[1] !== undefined),
+          Object.entries(this.mergedEnv).filter((e) => e[1] !== undefined),
         ) as Record<string, string>, // Include environment variables
       };
 
@@ -1936,7 +1951,7 @@ export class AIManager {
             const sessionId = this.messageManager.getSessionId();
             const transcriptPath = this.messageManager.getTranscriptPath();
             const env = Object.fromEntries(
-              Object.entries(process.env).filter((e) => e[1] !== undefined),
+              Object.entries(this.mergedEnv).filter((e) => e[1] !== undefined),
             ) as Record<string, string>;
             await this.hookManager.executeCwdChangedHooks(
               oldCwd,
@@ -2031,7 +2046,7 @@ export class AIManager {
         toolInput,
         subagentType: this.subagentType, // Include subagent type in hook context
         env: Object.fromEntries(
-          Object.entries(process.env).filter((e) => e[1] !== undefined),
+          Object.entries(this.mergedEnv).filter((e) => e[1] !== undefined),
         ) as Record<string, string>, // Include environment variables
       };
 
@@ -2107,7 +2122,7 @@ export class AIManager {
         subagentType: this.subagentType, // Include subagent type in hook context
         planFilePath: this.permissionManager?.getPlanFilePath(),
         env: Object.fromEntries(
-          Object.entries(process.env).filter((e) => e[1] !== undefined),
+          Object.entries(this.mergedEnv).filter((e) => e[1] !== undefined),
         ) as Record<string, string>, // Include environment variables
       };
 

--- a/packages/agent-sdk/src/managers/backgroundTaskManager.ts
+++ b/packages/agent-sdk/src/managers/backgroundTaskManager.ts
@@ -8,6 +8,7 @@ import { logger } from "../utils/globalLogger.js";
 import { Container } from "../utils/container.js";
 import { MessageQueue } from "./messageQueue.js";
 import { resolveShellPath } from "../utils/shellResolver.js";
+import type { ConfigurationService } from "../services/configurationService.js";
 
 export interface BackgroundTaskManagerCallbacks {
   onBackgroundTasksChange?: (tasks: BackgroundTask[]) => void;
@@ -30,6 +31,19 @@ export class BackgroundTaskManager {
   ) {
     this.callbacks = options.callbacks || {};
     this.workdir = options.workdir;
+  }
+
+  /**
+   * Merged env (OS env overlaid with this session's settings snapshot) for
+   * background-task subprocesses, so settings `env` vars reach them without
+   * polluting other sessions in one `wave --stdio` process.
+   */
+  private get sessionEnv(): Record<string, string> {
+    return (
+      this.container
+        .get<ConfigurationService>("ConfigurationService")
+        ?.getMergedEnv?.() ?? (process.env as Record<string, string>)
+    );
   }
 
   /**
@@ -73,6 +87,7 @@ export class BackgroundTaskManager {
       cwd: cwd ?? this.workdir,
       env: {
         ...process.env,
+        ...this.sessionEnv,
       },
     });
 

--- a/packages/agent-sdk/src/managers/bangManager.ts
+++ b/packages/agent-sdk/src/managers/bangManager.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcess } from "child_process";
 import type { MessageManager } from "./messageManager.js";
 import { Container } from "../utils/container.js";
 import { resolveShellPath } from "../utils/shellResolver.js";
+import type { ConfigurationService } from "../services/configurationService.js";
 
 export interface BangManagerOptions {
   workdir: string;
@@ -29,6 +30,19 @@ export class BangManager {
     return this.container.get<MessageManager>("MessageManager")!;
   }
 
+  /**
+   * Merged env (OS env overlaid with this session's settings snapshot) for
+   * bang-command subprocesses, so settings `env` vars reach them without
+   * polluting other sessions in one `wave --stdio` process.
+   */
+  private get sessionEnv(): Record<string, string> {
+    return (
+      this.container
+        .get<ConfigurationService>("ConfigurationService")
+        ?.getMergedEnv?.() ?? (process.env as Record<string, string>)
+    );
+  }
+
   private setCommandRunning(isRunning: boolean): void {
     this.isCommandRunning = isRunning;
     this.onCommandRunningChange?.(isRunning);
@@ -51,6 +65,7 @@ export class BangManager {
         cwd: this.workdir,
         env: {
           ...process.env,
+          ...this.sessionEnv,
         },
       });
 

--- a/packages/agent-sdk/src/managers/hookManager.ts
+++ b/packages/agent-sdk/src/managers/hookManager.ts
@@ -26,6 +26,7 @@ import { executeCommand, isCommandSafe } from "../services/hook.js";
 import { MessageSource } from "../types/index.js";
 import type { MessageManager } from "./messageManager.js";
 import { Container } from "../utils/container.js";
+import type { ConfigurationService } from "../services/configurationService.js";
 
 import { logger } from "../utils/globalLogger.js";
 
@@ -44,6 +45,19 @@ export class HookManager {
   ) {
     this.workdir = workdir;
     this.matcher = matcher;
+  }
+
+  /**
+   * Merged env for this session (OS env overlaid with the per-session settings
+   * snapshot). Hook subprocesses spawn with this env so settings.json `env`
+   * vars reach hooks without polluting other sessions in one stdio process.
+   */
+  private get sessionEnv(): Record<string, string> {
+    return (
+      this.container
+        .get<ConfigurationService>("ConfigurationService")
+        ?.getMergedEnv?.() ?? (process.env as Record<string, string>)
+    );
   }
 
   /**
@@ -935,7 +949,7 @@ export class HookManager {
       source,
       agentType,
       env: Object.fromEntries(
-        Object.entries(process.env).filter((e) => e[1] !== undefined),
+        Object.entries(this.sessionEnv).filter((e) => e[1] !== undefined),
       ) as Record<string, string>,
     };
 
@@ -989,7 +1003,7 @@ export class HookManager {
       cwd: this.workdir,
       endSource: source,
       env: Object.fromEntries(
-        Object.entries(process.env).filter((e) => e[1] !== undefined),
+        Object.entries(this.sessionEnv).filter((e) => e[1] !== undefined),
       ) as Record<string, string>,
     };
 
@@ -1024,7 +1038,7 @@ export class HookManager {
       cwd: this.workdir,
       compactInstructions: customInstructions,
       env: Object.fromEntries(
-        Object.entries(process.env).filter((e) => e[1] !== undefined),
+        Object.entries(this.sessionEnv).filter((e) => e[1] !== undefined),
       ) as Record<string, string>,
     };
 
@@ -1061,7 +1075,7 @@ export class HookManager {
       cwd: this.workdir,
       compactSummary,
       env: Object.fromEntries(
-        Object.entries(process.env).filter((e) => e[1] !== undefined),
+        Object.entries(this.sessionEnv).filter((e) => e[1] !== undefined),
       ) as Record<string, string>,
     };
 

--- a/packages/agent-sdk/src/managers/mcpManager.ts
+++ b/packages/agent-sdk/src/managers/mcpManager.ts
@@ -9,6 +9,7 @@ import { ChatCompletionFunctionTool } from "openai/resources.js";
 import { createMcpToolPlugin, findToolServer } from "../utils/mcpUtils.js";
 import type { ToolPlugin, ToolResult, ToolContext } from "../tools/types.js";
 import { Container } from "../utils/container.js";
+import type { ConfigurationService } from "../services/configurationService.js";
 import type {
   Logger,
   McpServerConfig,
@@ -42,7 +43,21 @@ export interface McpManagerOptions {
  */
 const WAVE_TEMPLATE_VARS = ["WAVE_PLUGIN_ROOT", "CLAUDE_PLUGIN_ROOT"];
 
-export function expandEnvVars(value: string): string {
+/**
+ * Expand environment variables in a string value.
+ * Supports ${VAR} and ${VAR:-default} patterns.
+ *
+ * @param env - Merged env to resolve against (session snapshot over OS env).
+ *              Defaults to `process.env` for backward compatibility with tests
+ *              and standalone callers.
+ */
+export function expandEnvVars(
+  value: string,
+  env: Record<string, string | undefined> = process.env as Record<
+    string,
+    string | undefined
+  >,
+): string {
   return value.replace(/\$\{([^}]+)\}/g, (_match, expr: string) => {
     const [varName, ...rest] = expr.split(":-");
     const defaultValue = rest.join(":-");
@@ -50,45 +65,53 @@ export function expandEnvVars(value: string): string {
     if (WAVE_TEMPLATE_VARS.includes(varName)) {
       return _match; // return original ${...} string untouched
     }
-    return process.env[varName] ?? defaultValue;
+    return env[varName] ?? process.env[varName] ?? defaultValue;
   });
 }
 
 /**
  * Walk an MCP config and resolve environment variables in all string fields.
- * Only expands ${VAR} from process.env (skipping WAVE_PLUGIN_ROOT which is
- * handled at spawn time).
+ * Expands ${VAR} against the session env snapshot (over OS env); falls back to
+ * process.env. WAVE_PLUGIN_ROOT is skipped — handled at spawn time.
  */
-export function resolveMcpConfig(config: McpConfig): McpConfig {
+export function resolveMcpConfig(
+  config: McpConfig,
+  env: Record<string, string | undefined> = process.env as Record<
+    string,
+    string | undefined
+  >,
+): McpConfig {
   const resolved: McpConfig = { mcpServers: {} };
 
   for (const [name, serverConfig] of Object.entries(config.mcpServers)) {
     const resolvedServer: McpServerConfig = { ...serverConfig };
 
     if (resolvedServer.command) {
-      resolvedServer.command = expandEnvVars(resolvedServer.command);
+      resolvedServer.command = expandEnvVars(resolvedServer.command, env);
     }
 
     if (resolvedServer.args) {
-      resolvedServer.args = resolvedServer.args.map(expandEnvVars);
+      resolvedServer.args = resolvedServer.args.map((a) =>
+        expandEnvVars(a, env),
+      );
     }
 
     if (resolvedServer.env) {
       const resolvedEnv: Record<string, string> = {};
       for (const [key, val] of Object.entries(resolvedServer.env)) {
-        resolvedEnv[key] = expandEnvVars(val);
+        resolvedEnv[key] = expandEnvVars(val, env);
       }
       resolvedServer.env = resolvedEnv;
     }
 
     if (resolvedServer.url) {
-      resolvedServer.url = expandEnvVars(resolvedServer.url);
+      resolvedServer.url = expandEnvVars(resolvedServer.url, env);
     }
 
     if (resolvedServer.headers) {
       const resolvedHeaders: Record<string, string> = {};
       for (const [key, val] of Object.entries(resolvedServer.headers)) {
-        resolvedHeaders[key] = expandEnvVars(val);
+        resolvedHeaders[key] = expandEnvVars(val, env);
       }
       resolvedServer.headers = resolvedHeaders;
     }
@@ -117,6 +140,19 @@ export class McpManager {
   ) {
     this.callbacks = options.callbacks || {};
     this.mcpServers = options.mcpServers;
+  }
+
+  /**
+   * Merged env for this session: OS env overlaid with the per-session settings
+   * snapshot. MCP env-var expansion (${VAR}) resolves against this so multiple
+   * sessions in one `wave --stdio` process don't read each other's settings env.
+   */
+  private get envSnapshot(): Record<string, string> {
+    return (
+      this.container
+        .get<ConfigurationService>("ConfigurationService")
+        ?.getMergedEnv?.() ?? (process.env as Record<string, string>)
+    );
   }
 
   /**
@@ -189,7 +225,7 @@ export class McpManager {
     try {
       const configContent = await fs.readFile(this.configPath, "utf-8");
       const rawConfig: McpConfig = JSON.parse(configContent);
-      const workspaceConfig = resolveMcpConfig(rawConfig);
+      const workspaceConfig = resolveMcpConfig(rawConfig, this.envSnapshot);
 
       // Extract original (pre-resolution) URLs for safe display
       const originalUrls: Record<string, string | undefined> = {};
@@ -284,28 +320,31 @@ export class McpManager {
     // Capture original URL before any resolution for safe display
     const originalUrl = config.url;
 
-    // Expand env vars from process.env (e.g. ${TAVILY_API_KEY})
+    // Expand env vars against the session snapshot (over OS env, e.g. ${TAVILY_API_KEY})
+    const env = this.envSnapshot;
     const resolvedConfig: McpServerConfig = { ...config };
     if (resolvedConfig.command) {
-      resolvedConfig.command = expandEnvVars(resolvedConfig.command);
+      resolvedConfig.command = expandEnvVars(resolvedConfig.command, env);
     }
     if (resolvedConfig.args) {
-      resolvedConfig.args = resolvedConfig.args.map(expandEnvVars);
+      resolvedConfig.args = resolvedConfig.args.map((a) =>
+        expandEnvVars(a, env),
+      );
     }
     if (resolvedConfig.env) {
       const resolvedEnv: Record<string, string> = {};
       for (const [key, val] of Object.entries(resolvedConfig.env)) {
-        resolvedEnv[key] = expandEnvVars(val);
+        resolvedEnv[key] = expandEnvVars(val, env);
       }
       resolvedConfig.env = resolvedEnv;
     }
     if (resolvedConfig.url) {
-      resolvedConfig.url = expandEnvVars(resolvedConfig.url);
+      resolvedConfig.url = expandEnvVars(resolvedConfig.url, env);
     }
     if (resolvedConfig.headers) {
       const resolvedHeaders: Record<string, string> = {};
       for (const [key, val] of Object.entries(resolvedConfig.headers)) {
-        resolvedHeaders[key] = expandEnvVars(val);
+        resolvedHeaders[key] = expandEnvVars(val, env);
       }
       resolvedConfig.headers = resolvedHeaders;
     }
@@ -433,8 +472,11 @@ export class McpManager {
           );
         }
 
+        // Base env = OS env overlaid with this session's settings snapshot, so
+        // custom env vars from settings.json reach the MCP server subprocess
+        // without polluting other sessions sharing one `wave --stdio` process.
         const env: Record<string, string> = {
-          ...(process.env as Record<string, string>),
+          ...this.envSnapshot,
           ...(server.config.env || {}),
         };
 

--- a/packages/agent-sdk/src/managers/toolManager.ts
+++ b/packages/agent-sdk/src/managers/toolManager.ts
@@ -253,6 +253,13 @@ class ToolManager {
             "WorkflowManager",
           )
         : undefined,
+      sessionEnv: this.container.has("ConfigurationService")
+        ? this.container
+            .get<
+              import("../services/configurationService.js").ConfigurationService
+            >("ConfigurationService")
+            ?.getMergedEnv?.()
+        : undefined,
       sessionId: context.sessionId,
       toolCallId: context.toolCallId,
     };

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -61,12 +61,38 @@ export class ConfigurationService {
   private currentConfiguration: WaveConfiguration | null = null;
   private options: AgentOptions = {};
   private _configuredEnvKeys = new Set<string>();
+  // Per-session environment snapshot: settings.json `env` is stored here (NOT
+  // written to process.env) so multiple sessions in one `wave --stdio` process
+  // don't cross-pollute. Resolve methods read `this.envSnapshot ?? process.env`.
+  private envSnapshot: Record<string, string> = {};
 
   /**
    * Set agent options for configuration resolution
    */
   setOptions(options: AgentOptions): void {
     this.options = options;
+  }
+
+  /**
+   * Returns a copy of the per-session environment snapshot (settings.json `env`).
+   * Priority over OS env; does NOT include OS env. For subprocess spawning use
+   * {@link getMergedEnv} instead.
+   */
+  getEnvSnapshot(): Record<string, string> {
+    return { ...this.envSnapshot };
+  }
+
+  /**
+   * Returns OS env merged with the session snapshot (snapshot wins). Use this
+   * when spawning user-facing subprocesses (bash, hooks, bang, background, MCP)
+   * so they inherit both OS env and the session's settings env.
+   */
+  getMergedEnv(): Record<string, string> {
+    return Object.fromEntries(
+      Object.entries({ ...process.env, ...this.envSnapshot }).filter(
+        ([, v]) => v !== undefined,
+      ),
+    ) as Record<string, string>;
   }
 
   // Core loading operations
@@ -384,15 +410,20 @@ export class ConfigurationService {
   // Utility operations
 
   /**
-   * Set environment variables from configuration
-   * This replaces direct process.env modification
+   * Store environment variables from configuration into the per-session
+   * snapshot (NOT process.env). Settings `env` shadows OS env for this session
+   * only — multiple sessions in one stdio process stay isolated.
    */
   setEnvironmentVars(env: Record<string, string>): void {
     for (const [key, value] of Object.entries(env)) {
-      if (process.env[key] !== undefined && !this._configuredEnvKeys.has(key)) {
+      if (
+        process.env[key] !== undefined &&
+        !this._configuredEnvKeys.has(key) &&
+        process.env[key] !== value
+      ) {
         logger.warn(`Overriding environment variable: ${key}`);
       }
-      process.env[key] = value;
+      this.envSnapshot[key] = value;
       this._configuredEnvKeys.add(key);
     }
   }
@@ -438,7 +469,11 @@ export class ConfigurationService {
     fetch?: ClientOptions["fetch"],
   ): GatewayConfig {
     // Check for SSO token first - if present and server URL is available, use SSO mode
-    // Server URL resolution: options > process.env > default
+    // Server URL resolution: options.serverUrl > OS env (WAVE_SERVER_URL) > default.
+    // WAVE_SERVER_URL is intentionally OS-env-only (NOT read from the settings env
+    // snapshot): AuthService is a process singleton with one server per process,
+    // and the background remote-settings fetch reads OS env present at process start,
+    // avoiding a startup 401 race. See docs/specs/core/agent-config.md.
     const ssoToken = this.readSSOToken();
     const serverUrl =
       this.options.serverUrl ||
@@ -469,7 +504,8 @@ export class ConfigurationService {
     } else if (this.options.apiKey !== undefined) {
       resolvedApiKey = this.options.apiKey;
     } else {
-      resolvedApiKey = process.env.WAVE_API_KEY;
+      resolvedApiKey =
+        this.envSnapshot.WAVE_API_KEY ?? process.env.WAVE_API_KEY;
     }
 
     // Resolve base URL: override > options > env (settings.json) > process.env
@@ -480,15 +516,18 @@ export class ConfigurationService {
     } else if (this.options.baseURL !== undefined) {
       resolvedBaseURL = this.options.baseURL;
     } else {
-      resolvedBaseURL = process.env.WAVE_BASE_URL;
+      resolvedBaseURL =
+        this.envSnapshot.WAVE_BASE_URL ?? process.env.WAVE_BASE_URL;
     }
 
     // Fallback to process.env if still not resolved (for dynamic updates in tests)
     if (resolvedApiKey === undefined) {
-      resolvedApiKey = process.env.WAVE_API_KEY;
+      resolvedApiKey =
+        this.envSnapshot.WAVE_API_KEY ?? process.env.WAVE_API_KEY;
     }
     if (!resolvedBaseURL) {
-      resolvedBaseURL = process.env.WAVE_BASE_URL;
+      resolvedBaseURL =
+        this.envSnapshot.WAVE_BASE_URL ?? process.env.WAVE_BASE_URL;
     }
 
     // Treat empty string as not provided
@@ -497,7 +536,10 @@ export class ConfigurationService {
     }
 
     // Resolve custom headers from environment: env (settings.json) > process.env
-    const envCustomHeaders = process.env.WAVE_CUSTOM_HEADERS || "";
+    const envCustomHeaders =
+      this.envSnapshot.WAVE_CUSTOM_HEADERS ??
+      process.env.WAVE_CUSTOM_HEADERS ??
+      "";
     const parsedEnvHeaders = parseCustomHeaders(envCustomHeaders);
 
     // Merge headers: env headers < options < override
@@ -539,11 +581,13 @@ export class ConfigurationService {
       model ||
       this.options.model ||
       this.currentConfiguration?.model ||
-      process.env.WAVE_MODEL;
+      (this.envSnapshot.WAVE_MODEL ?? process.env.WAVE_MODEL);
 
     // Resolve fast model: override > options > process.env (includes settings.json env)
     const resolvedFastModel =
-      fastModel || this.options.fastModel || process.env.WAVE_FAST_MODEL;
+      fastModel ||
+      this.options.fastModel ||
+      (this.envSnapshot.WAVE_FAST_MODEL ?? process.env.WAVE_FAST_MODEL);
 
     // Resolve max output tokens
     const resolvedMaxTokens = this.resolveMaxOutputTokens(maxTokens);
@@ -596,8 +640,10 @@ export class ConfigurationService {
       return this.options.maxInputTokens;
     }
 
-    // Try env (settings.json) first, then process.env
-    const envMaxInputTokens = process.env.WAVE_MAX_INPUT_TOKENS;
+    // Try env (settings.json snapshot) first, then process.env
+    const envMaxInputTokens =
+      this.envSnapshot.WAVE_MAX_INPUT_TOKENS ??
+      process.env.WAVE_MAX_INPUT_TOKENS;
     if (envMaxInputTokens) {
       const parsed = parseInt(envMaxInputTokens, 10);
       if (!isNaN(parsed)) {
@@ -645,9 +691,9 @@ export class ConfigurationService {
       return this.currentConfiguration.autoMemoryEnabled;
     }
 
-    // 2. WAVE_DISABLE_AUTO_MEMORY environment variable
+    // 2. WAVE_DISABLE_AUTO_MEMORY environment variable (settings snapshot > OS env)
     const disableAutoMemory =
-      process.env.WAVE_DISABLE_AUTO_MEMORY ||
+      this.envSnapshot.WAVE_DISABLE_AUTO_MEMORY ??
       process.env.WAVE_DISABLE_AUTO_MEMORY;
     if (disableAutoMemory === "1" || disableAutoMemory === "true") {
       return false;
@@ -681,9 +727,9 @@ export class ConfigurationService {
       return this.currentConfiguration.autoMemoryFrequency;
     }
 
-    // 2. WAVE_AUTO_MEMORY_FREQUENCY environment variable
+    // 2. WAVE_AUTO_MEMORY_FREQUENCY environment variable (settings snapshot > OS env)
     const envFrequency =
-      process.env.WAVE_AUTO_MEMORY_FREQUENCY ||
+      this.envSnapshot.WAVE_AUTO_MEMORY_FREQUENCY ??
       process.env.WAVE_AUTO_MEMORY_FREQUENCY;
     if (envFrequency) {
       const parsed = parseInt(envFrequency, 10);
@@ -713,8 +759,10 @@ export class ConfigurationService {
       return this.options.maxTokens;
     }
 
-    // Try env (settings.json) first, then process.env
-    const envMaxOutputTokens = process.env.WAVE_MAX_OUTPUT_TOKENS;
+    // Try env (settings.json snapshot) first, then process.env
+    const envMaxOutputTokens =
+      this.envSnapshot.WAVE_MAX_OUTPUT_TOKENS ??
+      process.env.WAVE_MAX_OUTPUT_TOKENS;
     if (envMaxOutputTokens) {
       const parsed = parseInt(envMaxOutputTokens, 10);
       if (!isNaN(parsed) && parsed > 0) {
@@ -761,8 +809,10 @@ export class ConfigurationService {
   getConfiguredModels(): string[] {
     const models = new Set<string>();
 
-    // Add current model from options or environment
-    const currentModel = this.options.model || process.env.WAVE_MODEL;
+    // Add current model from options or environment (settings snapshot > OS env)
+    const currentModel =
+      this.options.model ||
+      (this.envSnapshot.WAVE_MODEL ?? process.env.WAVE_MODEL);
     if (currentModel) {
       models.add(currentModel);
     }

--- a/packages/agent-sdk/src/services/initializationService.ts
+++ b/packages/agent-sdk/src/services/initializationService.ts
@@ -128,9 +128,10 @@ export class InitializationService {
 
     // Load remote settings disk cache synchronously.
     // Must happen BEFORE loadMergedConfiguration so cached managed settings
-    // (env, model, disallowedTools) are merged and applied to process.env.
-    // The network fetch is deferred until after loadMergedConfiguration (below)
-    // so settings.json env vars (e.g. WAVE_SERVER_URL) are in process.env first.
+    // (env, model, disallowedTools) are merged into the config. Settings `env`
+    // is stored in the per-session env snapshot (NOT process.env); the network
+    // fetch is deferred until after merge (below) and reads OS-env
+    // WAVE_SERVER_URL via authService.getServerUrl(), so there is no race.
     try {
       const phaseStart = performance.now();
       await remoteSettingsService.initialize();
@@ -193,9 +194,10 @@ export class InitializationService {
       // Don't throw error to prevent app startup failure
     }
 
-    // Start remote settings network fetch + polling now that local env vars
-    // (e.g. WAVE_SERVER_URL) are applied to process.env by loadMergedConfiguration.
-    // Fire-and-forget: failures fall back to the cached/merged settings.
+    // Start remote settings network fetch + polling now that the config is
+    // merged. The fetch reads OS-env WAVE_SERVER_URL via authService.getServerUrl()
+    // (WAVE_SERVER_URL is OS-env-only); fire-and-forget, failures fall back to
+    // the cached/merged settings.
     remoteSettingsService.startBackgroundFetch();
 
     // Execute SessionStart hooks
@@ -245,7 +247,9 @@ export class InitializationService {
           cwd: workdir,
           worktreeName: agentOptions.worktreeName,
           env: Object.fromEntries(
-            Object.entries(process.env).filter((e) => e[1] !== undefined),
+            Object.entries(configurationService.getMergedEnv()).filter(
+              (e) => e[1] !== undefined,
+            ),
           ) as Record<string, string>,
         });
 

--- a/packages/agent-sdk/src/services/interactionService.ts
+++ b/packages/agent-sdk/src/services/interactionService.ts
@@ -93,7 +93,9 @@ export class InteractionService {
               cwd: workdir,
               userPrompt: content,
               env: Object.fromEntries(
-                Object.entries(process.env).filter((e) => e[1] !== undefined),
+                Object.entries(
+                  context.configurationService.getMergedEnv(),
+                ).filter((e) => e[1] !== undefined),
               ) as Record<string, string>, // Include environment variables
             },
           );

--- a/packages/agent-sdk/src/services/remoteSettingsService.ts
+++ b/packages/agent-sdk/src/services/remoteSettingsService.ts
@@ -206,10 +206,11 @@ export function initialize(): void {
 /**
  * Start the fire-and-forget initial network fetch + background polling.
  *
- * Must be called AFTER loadMergedConfiguration() so local settings.json env
- * vars (e.g. WAVE_SERVER_URL) are applied to process.env first — otherwise
- * getServerUrl() falls back to DEFAULT_SERVER_URL (prod) and a test-issued
- * token hits the prod endpoint (401).
+ * Must be called AFTER loadMergedConfiguration() so disk-cached managed
+ * settings are merged before the fetch. The fetch uses authService.getServerUrl(),
+ * which reads OS-env WAVE_SERVER_URL (present at process start) — it does NOT
+ * read the settings env snapshot, so there is no init-ordering race that would
+ * fall back to DEFAULT_SERVER_URL (prod) and hit a test endpoint (401).
  */
 export function startBackgroundFetch(): void {
   fetchRemoteSettings()

--- a/packages/agent-sdk/src/services/taskManager.ts
+++ b/packages/agent-sdk/src/services/taskManager.ts
@@ -6,6 +6,7 @@ import { Task } from "../types/tasks.js";
 import { logger } from "../utils/globalLogger.js";
 import { Container } from "../utils/container.js";
 import type { MessageManager } from "../managers/messageManager.js";
+import type { ConfigurationService } from "./configurationService.js";
 
 function byIdAsc(a: Task, b: Task) {
   const aNum = parseInt(a.id, 10);
@@ -44,7 +45,15 @@ export class TaskManager extends EventEmitter {
     if (!messageManager) return;
 
     const rootSessionId = messageManager.getRootSessionId();
-    if (this.taskListId !== rootSessionId && !process.env.WAVE_TASK_LIST_ID) {
+    // Read the per-session snapshot (not process.env) so multiple sessions in
+    // one `wave --stdio` process don't cross-pollute this flag.
+    const envSnap =
+      this.container
+        .get<ConfigurationService>("ConfigurationService")
+        ?.getEnvSnapshot() ?? {};
+    const pinnedTaskListId =
+      envSnap.WAVE_TASK_LIST_ID ?? process.env.WAVE_TASK_LIST_ID;
+    if (this.taskListId !== rootSessionId && !pinnedTaskListId) {
       this.setTaskListId(rootSessionId);
       await this.refreshTasks();
     }

--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -285,6 +285,7 @@ The working directory persists between commands. Try to maintain your current wo
         cwd: context.workdir,
         env: {
           ...process.env,
+          ...context.sessionEnv,
         },
       });
 

--- a/packages/agent-sdk/src/tools/enterWorktreeTool.ts
+++ b/packages/agent-sdk/src/tools/enterWorktreeTool.ts
@@ -138,7 +138,9 @@ export const enterWorktreeTool: ToolPlugin = {
             cwd: worktreeInfo.path,
             worktreeName: worktreeInfo.name,
             env: Object.fromEntries(
-              Object.entries(process.env).filter((e) => e[1] !== undefined),
+              Object.entries(context.sessionEnv ?? process.env).filter(
+                (e) => e[1] !== undefined,
+              ),
             ) as Record<string, string>,
           },
         );

--- a/packages/agent-sdk/src/tools/exitWorktreeTool.ts
+++ b/packages/agent-sdk/src/tools/exitWorktreeTool.ts
@@ -186,7 +186,9 @@ export const exitWorktreeTool: ToolPlugin = {
             cwd: originalCwd,
             worktreePath,
             env: Object.fromEntries(
-              Object.entries(process.env).filter((e) => e[1] !== undefined),
+              Object.entries(context.sessionEnv ?? process.env).filter(
+                (e) => e[1] !== undefined,
+              ),
             ) as Record<string, string>,
           },
         );

--- a/packages/agent-sdk/src/tools/types.ts
+++ b/packages/agent-sdk/src/tools/types.ts
@@ -127,4 +127,11 @@ export interface ToolContext {
   originalWorkdir?: string;
   /** Workflow manager instance for workflow orchestration */
   workflowManager?: import("../managers/workflowManager.js").WorkflowManager;
+  /**
+   * Per-session merged environment (OS env overlaid with the settings env
+   * snapshot) for this session. Tools that spawn subprocesses (Bash, hooks)
+   * should merge this on top of `process.env` so settings `env` vars reach
+   * the subprocess without polluting other sessions in one stdio process.
+   */
+  sessionEnv?: Record<string, string>;
 }

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -227,7 +227,9 @@ export function setupAgentContainer(
             toolInput: context.toolInput,
             planFilePath: permissionManager.getPlanFilePath(),
             env: Object.fromEntries(
-              Object.entries(process.env).filter((e) => e[1] !== undefined),
+              Object.entries(configurationService.getMergedEnv()).filter(
+                (e) => e[1] !== undefined,
+              ),
             ) as Record<string, string>,
           });
 

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -110,9 +110,15 @@ describe("ConfigurationService", () => {
       });
       expect(result.configuration?.permissions?.allow).toContain("rule1");
       expect(result.configuration?.permissions?.allow).toContain("rule2");
-      expect(process.env.USER_VAR).toBe("user");
-      expect(process.env.PROJECT_VAR).toBe("project");
-      expect(process.env.WAVE_PROJECT_DIR).toBe(tempDir);
+      // Env vars land in the per-session snapshot (NOT process.env) so multiple
+      // sessions in one stdio process stay isolated.
+      expect(configService.getEnvSnapshot()).toMatchObject({
+        USER_VAR: "user",
+        PROJECT_VAR: "project",
+        WAVE_PROJECT_DIR: tempDir,
+      });
+      expect(process.env.USER_VAR).toBeUndefined();
+      expect(process.env.PROJECT_VAR).toBeUndefined();
     });
 
     it("should merge deny rules from all sources", async () => {
@@ -380,10 +386,13 @@ describe("ConfigurationService", () => {
   });
 
   describe("Environment Variable Management", () => {
-    it("should set environment variables to process.env", () => {
+    it("should set environment variables to the session snapshot (not process.env)", () => {
+      delete process.env.KEY;
       const env = { KEY: "VALUE" };
       configService.setEnvironmentVars(env);
-      expect(process.env.KEY).toBe("VALUE");
+      // Stored in the per-session snapshot, NOT written to process.env.
+      expect(configService.getEnvSnapshot().KEY).toBe("VALUE");
+      expect(process.env.KEY).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
In stdio mode a single `wave --stdio` process hosts multiple sessions
(VSCE/Desktop agent pool). Writing settings.json `env` to shared
`process.env` caused last-session-wins cross-pollution of model/API-key/
server config across sessions.

Replace all process.env writes from ConfigurationService with a per-session
`envSnapshot`:
- `envSnapshot: Record<string,string>` on ConfigurationService (per-session,
  since ConfigurationService is constructed per session via its own DI container)
- `getEnvSnapshot()` returns the snapshot only; `getMergedEnv()` returns
  OS env merged with the snapshot (snapshot wins) for spawning user-facing
  subprocesses (bash, hooks, bang, background, MCP)
- `setEnvironmentVars()` writes only to the snapshot (never process.env)
- resolve methods read `envSnapshot.X ?? process.env.X` (snapshot > OS env > default)

WAVE_SERVER_URL stays OS-env-only (not read from settings.json env): AuthService
is a process singleton with one server per process, and the background
remote-settings fetch reads OS-env WAVE_SERVER_URL via authService.getServerUrl()
at process start, preserving the 401 init-ordering fix.

Subprocess env: user-facing subprocesses (bash/hooks/bang/background/MCP) merge
the session snapshot on top of OS env; infra subprocesses (git/worktree/LSP)
stay OS-env-only.

Defensive getters use `?.getMergedEnv?.()` (not `?.getMergedEnv()`) so a
partial test mock lacking the method falls back to process.env instead of
throwing — the try/catch in executeStopHooks silently swallowed that throw,
surfacing as `executeHooks` called 0 times.

Spec (docs/specs/core/agent-config.md) and ENV.md updated. Tests assert
`process.env.USER_VAR === undefined` after load/set (env lands in snapshot).

Verified: agent-sdk 3332/1-skip, code 1124, vsce 152, webview 514, tsc clean.
