### PR TITLE
worktree strong weak moon

### DIFF
--- a/docs/specs/core/agent-config.md
+++ b/docs/specs/core/agent-config.md
@@ -101,7 +101,7 @@ order: 60
 
 ### 用户故事：自定义环境变量（优先级：P1）
 
-开发者需要将自定义环境变量（API 密钥、数据库 URL、功能标志）传递给 Wave Agent SDK，而不需要在代码中硬编码。他们在 settings.json 文件中添加 "env" 字段，并期望这些变量在代理执行上下文中可用。这些变量被存入 Agent 的**会话级环境快照**（`ConfigurationService` 实例，每个会话独立），优先级高于 OS 环境变量，但**不写入 `process.env`**——这样在 stdio 多会话模式下，一个进程承载多个会话时不会相互污染。Wave Code CLI 将继承此功能，因为它使用 SDK。
+开发者需要将自定义环境变量（API 密钥、数据库 URL、功能标志）传递给 Wave Agent SDK，而不需要在代码中硬编码。他们在 settings.json 文件中添加 "env" 字段，并期望这些变量在代理执行上下文中可用。这些变量被存入 Agent 的**会话级环境快照**（`ConfigurationService` 实例，每个会话独立），优先级高于 OS 环境变量，但**不写入 `process.env`**——这样在 stdio 多会话模式下，一个进程承载多个会话时不会相互污染。**例外**：`WAVE_SERVER_URL` 因需被进程级单例（`AuthService`、远端设置后台拉取）读取，会额外镜像写入 `process.env`（详见边界说明）。Wave Code CLI 将继承此功能，因为它使用 SDK。
 
 **为什么是这个优先级**：这提供了必要的配置灵活性，并遵循安全最佳实践，将敏感数据保留在配置文件中而非代码中。
 
@@ -109,12 +109,12 @@ order: 60
 
 **验收场景**：
 
-1. **假设**settings.json 文件包含带有键值对的 env 字段，**当**Wave Agent SDK 启动时，**则**这些环境变量存入该 Agent 的**会话级环境快照**（per-session env snapshot），优先级高于 OS 环境变量；它们**不写入 `process.env`**
+1. **假设**settings.json 文件包含带有键值对的 env 字段，**当**Wave Agent SDK 启动时，**则**这些环境变量存入该 Agent 的**会话级环境快照**（per-session env snapshot），优先级高于 OS 环境变量；它们**不写入 `process.env`**（`WAVE_SERVER_URL` 例外，见验收场景 6 与边界说明）
 2. **假设**用户级和项目级 settings.json 文件都包含 env 字段，**当**代理运行时，**则**项目级环境变量覆盖同名的用户级变量
 3. **假设**env 字段格式无效，**当**设置被加载时，**则**系统显示关于无效环境变量配置的清晰错误消息
 4. **假设**一个 stdio 进程承载多个会话（不同项目/workdir），且各自的 settings.json `env` 设置了不同的 `WAVE_MODEL`/`WAVE_API_KEY`，**当**任一会话解析网关/模型配置时，**则**只读取本会话的快照，不发生"后启动会话覆盖前一会话"的污染（last-session-wins 污染消除）
 5. **假设**settings.json `env` 中的变量被子进程（bash、hooks、bang、后台任务、MCP 模板替换）读取，**当**这些子进程启动时，**则**其环境为 `OS env + 本会话快照` 的合并（基础设施子进程如 git/worktree/LSP 仍只读 OS env）
-6. **假设**settings.json `env` 中设置了 `WAVE_SERVER_URL`，**当**配置被加载时，**则**该值被忽略——`WAVE_SERVER_URL` 仅从 OS 环境或 `options.serverUrl`/stdio `initialize` 参数读取（详见边界说明）
+6. **假设**settings.json `env` 中设置了 `WAVE_SERVER_URL`，**当**配置被加载时，**则**该值既存入会话快照、也镜像写入 `process.env`，使进程级单例 `AuthService`/`remoteSettingsService` 能读到它（详见边界说明）
 
 ---
 
@@ -187,8 +187,8 @@ SDK 用户需要按子代理类型配置不同的 HTTP 请求头，以便 `custo
 
 ### 边界说明：环境变量作用域与优先级
 
-- **settings.json `env` 与 OS 环境变量的关系**：settings.json `env` 存入会话级快照，优先级高于 OS 环境变量，但**不写入 `process.env`**。优先级从高到低：显式构造参数 / stdio `initialize` 参数 > settings.json `env`（快照）> OS 环境变量 > 默认值。
-- **`WAVE_SERVER_URL` 仅从 OS 环境读取**：它**不从** settings.json `env` 读取。设置服务端地址需通过 OS 环境变量、`options.serverUrl` 或 stdio `initialize` 参数。这样做消除了启动时 401 竞态（OS 环境变量在进程启动时即已就绪，远端设置拉取不需要等待 settings env 应用）。
+- **settings.json `env` 与 OS 环境变量的关系**：settings.json `env` 存入会话级快照，优先级高于 OS 环境变量，但**不写入 `process.env`**（`WAVE_SERVER_URL` 例外，见下条）。优先级从高到低：显式构造参数 / stdio `initialize` 参数 > settings.json `env`（快照）> OS 环境变量 > 默认值。
+- **`WAVE_SERVER_URL` 支持从 settings.json `env` 读取（镜像到 `process.env`）**：`AuthService` 与 `remoteSettingsService` 是进程级单例，不持有 per-session 快照，因此 settings `env` 里的 `WAVE_SERVER_URL` 经 `setEnvironmentVars` 特例**镜像写入 `process.env`**，使这些单例能读到。优先级：`options.serverUrl` / stdio `initialize` 参数 > settings.json `env`（镜像到 `process.env`）> OS 环境变量 > 默认值。由于 `AuthService` 是进程单例（一个进程一个 server），同进程多会话的 `WAVE_SERVER_URL` 应为同值，镜像不造成跨会话污染。启动 401 竞态已通过 init 顺序消除（`loadCacheFromDisk` → `loadMergedConfiguration` 写入 `process.env` → `startBackgroundFetch` 读取）。
 - **SSO 认证 / 远端设置轮询为进程级单例**：`authService` 与 `remoteSettingsService` 是进程级单例（一个 `auth.json` / 远端设置缓存——按用户）。因此对于后台 token 刷新/远端设置轮询，**每个进程只有一个 `serverUrl`**；AI 网关/模型/密钥的解析本身仍是按会话进行的。
 - **基础设施子进程保持 OS-env-only**：git/worktree/LSP 等基础设施子进程只读取 OS 环境变量（`PATH`/`HOME`/`LC_ALL` 等），不合并会话快照。`WAVE_PLUGIN_GIT_TIMEOUT_MS`、`WAVE_SHELL`、`WAVE_GIT_BASH_PATH` 等"基础设施级"变量不从 settings.json `env` 读取，需通过 OS 环境设置。
 

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -413,6 +413,11 @@ export class ConfigurationService {
    * Store environment variables from configuration into the per-session
    * snapshot (NOT process.env). Settings `env` shadows OS env for this session
    * only — multiple sessions in one stdio process stay isolated.
+   *
+   * Exception: `WAVE_SERVER_URL` is also mirrored to `process.env` because the
+   * process-level singletons (AuthService, remoteSettingsService background
+   * fetch) need to read it and don't hold a per-session snapshot. Same value
+   * across sessions ⇒ no cross-pollution. See docs/specs/core/agent-config.md.
    */
   setEnvironmentVars(env: Record<string, string>): void {
     for (const [key, value] of Object.entries(env)) {
@@ -425,6 +430,13 @@ export class ConfigurationService {
       }
       this.envSnapshot[key] = value;
       this._configuredEnvKeys.add(key);
+      // WAVE_SERVER_URL is consumed by process-level singletons (AuthService,
+      // remoteSettingsService) that can't see the per-session snapshot — mirror
+      // it to process.env so they read the settings value. Same value across
+      // sessions ⇒ no last-session-wins cross-pollution.
+      if (key === "WAVE_SERVER_URL") {
+        process.env[key] = value;
+      }
     }
   }
 
@@ -468,12 +480,11 @@ export class ConfigurationService {
     fetchOptions?: ClientOptions["fetchOptions"],
     fetch?: ClientOptions["fetch"],
   ): GatewayConfig {
-    // Check for SSO token first - if present and server URL is available, use SSO mode
-    // Server URL resolution: options.serverUrl > OS env (WAVE_SERVER_URL) > default.
-    // WAVE_SERVER_URL is intentionally OS-env-only (NOT read from the settings env
-    // snapshot): AuthService is a process singleton with one server per process,
-    // and the background remote-settings fetch reads OS env present at process start,
-    // avoiding a startup 401 race. See docs/specs/core/agent-config.md.
+    // Check for SSO token first - if present and server URL is available, use SSO mode.
+    // Server URL resolution: options.serverUrl > process.env.WAVE_SERVER_URL > default.
+    // settings.json `env` WAVE_SERVER_URL is mirrored to process.env by
+    // setEnvironmentVars (so process-level singletons AuthService / remoteSettings
+    // can read it), then read here. See docs/specs/core/agent-config.md.
     const ssoToken = this.readSSOToken();
     const serverUrl =
       this.options.serverUrl ||

--- a/packages/agent-sdk/src/services/initializationService.ts
+++ b/packages/agent-sdk/src/services/initializationService.ts
@@ -129,9 +129,9 @@ export class InitializationService {
     // Load remote settings disk cache synchronously.
     // Must happen BEFORE loadMergedConfiguration so cached managed settings
     // (env, model, disallowedTools) are merged into the config. Settings `env`
-    // is stored in the per-session env snapshot (NOT process.env); the network
-    // fetch is deferred until after merge (below) and reads OS-env
-    // WAVE_SERVER_URL via authService.getServerUrl(), so there is no race.
+    // is stored in the per-session env snapshot (NOT process.env), except
+    // WAVE_SERVER_URL which is mirrored to process.env so the network fetch
+    // (below) can read it via authService.getServerUrl(); no race.
     try {
       const phaseStart = performance.now();
       await remoteSettingsService.initialize();
@@ -195,9 +195,10 @@ export class InitializationService {
     }
 
     // Start remote settings network fetch + polling now that the config is
-    // merged. The fetch reads OS-env WAVE_SERVER_URL via authService.getServerUrl()
-    // (WAVE_SERVER_URL is OS-env-only); fire-and-forget, failures fall back to
-    // the cached/merged settings.
+    // merged. Settings `env` WAVE_SERVER_URL was mirrored to process.env by
+    // loadMergedConfiguration → setEnvironmentVars, so the fetch reads it via
+    // authService.getServerUrl(); fire-and-forget, failures fall back to the
+    // cached/merged settings.
     remoteSettingsService.startBackgroundFetch();
 
     // Execute SessionStart hooks

--- a/packages/agent-sdk/src/services/remoteSettingsService.ts
+++ b/packages/agent-sdk/src/services/remoteSettingsService.ts
@@ -207,10 +207,11 @@ export function initialize(): void {
  * Start the fire-and-forget initial network fetch + background polling.
  *
  * Must be called AFTER loadMergedConfiguration() so disk-cached managed
- * settings are merged before the fetch. The fetch uses authService.getServerUrl(),
- * which reads OS-env WAVE_SERVER_URL (present at process start) — it does NOT
- * read the settings env snapshot, so there is no init-ordering race that would
- * fall back to DEFAULT_SERVER_URL (prod) and hit a test endpoint (401).
+ * settings are merged before the fetch, and so settings `env` WAVE_SERVER_URL
+ * is mirrored to process.env (by setEnvironmentVars) before the fetch. The
+ * fetch uses authService.getServerUrl(), which reads process.env.WAVE_SERVER_URL
+ * — the settings value is visible there, so there is no init-ordering race
+ * that would fall back to DEFAULT_SERVER_URL (prod) and hit a test endpoint (401).
  */
 export function startBackgroundFetch(): void {
   fetchRemoteSettings()

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -394,6 +394,27 @@ describe("ConfigurationService", () => {
       expect(configService.getEnvSnapshot().KEY).toBe("VALUE");
       expect(process.env.KEY).toBeUndefined();
     });
+
+    it("should mirror WAVE_SERVER_URL to process.env (process-singleton consumers)", () => {
+      const origServerUrl = process.env.WAVE_SERVER_URL;
+      delete process.env.WAVE_SERVER_URL;
+      try {
+        configService.setEnvironmentVars({
+          WAVE_SERVER_URL: "https://test.example.com",
+        });
+        // Mirrored to process.env so AuthService / remoteSettings (process
+        // singletons without a per-session snapshot) can read it; also stored
+        // in the session snapshot.
+        expect(configService.getEnvSnapshot().WAVE_SERVER_URL).toBe(
+          "https://test.example.com",
+        );
+        expect(process.env.WAVE_SERVER_URL).toBe("https://test.example.com");
+      } finally {
+        if (origServerUrl !== undefined)
+          process.env.WAVE_SERVER_URL = origServerUrl;
+        else delete process.env.WAVE_SERVER_URL;
+      }
+    });
   });
 
   describe("resolveGatewayConfig", () => {


### PR DESCRIPTION
- **feat(config): store settings.json env in per-session snapshot, not process.env**
- **feat(config): support WAVE_SERVER_URL in settings.json env**
