### PR TITLE
feat(code): validate worktree slug and copy local settings into new worktrees

### DIFF
--- a/packages/code/src/utils/worktree.ts
+++ b/packages/code/src/utils/worktree.ts
@@ -19,6 +19,370 @@ export interface WorktreeSession {
   isNew: boolean;
 }
 
+// --- Worktree name validation ------------------------------------------------
+
+const VALID_WORKTREE_SLUG_SEGMENT = /^[a-zA-Z0-9._-]+$/;
+const MAX_WORKTREE_SLUG_LENGTH = 64;
+
+/**
+ * Validate a worktree name before any side effects. Names are slash-separated
+ * slugs: every segment must be non-empty and contain only letters, digits,
+ * dots, underscores, and dashes. The total length is capped at 64 characters
+ * and "." / ".." segments are rejected (path traversal protection).
+ * @throws {Error} When the name is not a valid slug
+ */
+export function validateWorktreeSlug(name: string): void {
+  if (name.length > MAX_WORKTREE_SLUG_LENGTH) {
+    throw new Error(
+      `Invalid worktree name: "${name}" must be ${MAX_WORKTREE_SLUG_LENGTH} characters or fewer (got ${name.length})`,
+    );
+  }
+  for (const segment of name.split("/")) {
+    if (segment === "." || segment === "..") {
+      throw new Error(
+        `Invalid worktree name: "${name}" must not contain "." or ".." path segments`,
+      );
+    }
+    if (segment.length === 0 || !VALID_WORKTREE_SLUG_SEGMENT.test(segment)) {
+      throw new Error(
+        `Invalid worktree name: "${name}" each "/"-separated segment must be non-empty and contain only letters, digits, dots, underscores, and dashes`,
+      );
+    }
+  }
+}
+
+// --- .worktreeinclude matching ----------------------------------------------
+
+interface WorktreeIncludePattern {
+  /** Normalized pattern text (no leading "/", no trailing "/", no "!") */
+  raw: string;
+  negated: boolean;
+  /** Pattern ends with "/" — matches directories only */
+  dirOnly: boolean;
+  /** Pattern had a leading "/" — anchored to the repo root */
+  anchored: boolean;
+  /** No "/" and not anchored — matches the basename at any level */
+  anyLevel: boolean;
+  regex: RegExp;
+}
+
+/** Translate a single gitignore glob into a RegExp (gitignore semantics). */
+function globToRegExp(glob: string): RegExp {
+  let source = "^";
+  for (let i = 0; i < glob.length; i++) {
+    const ch = glob[i];
+    if (ch === "*") {
+      if (glob[i + 1] === "*") {
+        if (glob[i + 2] === "/") {
+          // "**/" matches zero or more leading directories
+          source += "(?:.*/)?";
+          i += 2;
+        } else {
+          source += ".*";
+          i += 1;
+        }
+      } else {
+        source += "[^/]*";
+      }
+    } else if (ch === "?") {
+      source += "[^/]";
+    } else if (ch === "[") {
+      const end = glob.indexOf("]", i + 1);
+      if (end === -1) {
+        source += "\\[";
+      } else {
+        let charClass = glob.slice(i, end + 1);
+        if (charClass.startsWith("[!")) {
+          // gitignore uses "[!...]" for a negated character class
+          charClass = "[^" + charClass.slice(2);
+        }
+        source += charClass;
+        i = end;
+      }
+    } else {
+      source += ch.replace(/[.+^${}()|\\]/g, "\\$&");
+    }
+  }
+  source += "$";
+  return new RegExp(source);
+}
+
+/**
+ * Parse .worktreeinclude content into patterns. Blank lines and "#" comments
+ * are skipped, matching gitignore conventions.
+ */
+function parseWorktreeIncludePatterns(
+  content: string,
+): WorktreeIncludePattern[] {
+  const patterns: WorktreeIncludePattern[] = [];
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    let raw = line;
+    const negated = raw.startsWith("!");
+    if (negated) raw = raw.slice(1);
+    const dirOnly = raw.endsWith("/");
+    if (dirOnly) raw = raw.slice(0, -1);
+    const anchored = raw.startsWith("/");
+    if (anchored) raw = raw.slice(1);
+    if (!raw) continue;
+    patterns.push({
+      raw,
+      negated,
+      dirOnly,
+      anchored,
+      anyLevel: !anchored && !raw.includes("/"),
+      regex: globToRegExp(raw),
+    });
+  }
+  return patterns;
+}
+
+/** Test a single pattern against one candidate path. */
+function testPatternAgainst(
+  pattern: WorktreeIncludePattern,
+  candidate: string,
+): boolean {
+  if (pattern.anyLevel) {
+    // Match the full path or any "/"-suffix (basename at any level)
+    if (pattern.regex.test(candidate)) return true;
+    for (let i = 0; i < candidate.length; i++) {
+      if (candidate[i] === "/" && pattern.regex.test(candidate.slice(i + 1))) {
+        return true;
+      }
+    }
+    return false;
+  }
+  return pattern.regex.test(candidate);
+}
+
+/**
+ * Test a pattern against a path and every ancestor prefix. Excluding a
+ * directory excludes everything beneath it (gitignore semantics), so ancestor
+ * prefixes are always treated as directories.
+ */
+function patternMatchesPath(
+  pattern: WorktreeIncludePattern,
+  relPath: string,
+  isDir: boolean,
+): boolean {
+  let candidate = relPath;
+  for (;;) {
+    const candidateIsDir = candidate === relPath ? isDir : true;
+    if (
+      !(pattern.dirOnly && !candidateIsDir) &&
+      testPatternAgainst(pattern, candidate)
+    ) {
+      return true;
+    }
+    const idx = candidate.lastIndexOf("/");
+    if (idx === -1) break;
+    candidate = candidate.slice(0, idx);
+  }
+  return false;
+}
+
+/** Last-match-wins resolution with "!" negation. */
+function worktreeIncludeMatches(
+  patterns: WorktreeIncludePattern[],
+  relPath: string,
+  isDir: boolean,
+): boolean {
+  let matched = false;
+  for (const pattern of patterns) {
+    if (patternMatchesPath(pattern, relPath, isDir)) {
+      matched = !pattern.negated;
+    }
+  }
+  return matched;
+}
+
+/**
+ * A positive pattern targets something inside a collapsed directory: either it
+ * literally starts with the directory path, or the directory path starts with
+ * the pattern's literal (pre-glob) prefix.
+ */
+function needsExpansion(
+  patterns: WorktreeIncludePattern[],
+  dir: string,
+): boolean {
+  return patterns.some((p) => {
+    if (p.negated) return false;
+    if (p.raw.startsWith(dir + "/")) return true;
+    const globIdx = p.raw.search(/[*?[]/);
+    if (globIdx > 0 && dir.startsWith(p.raw.slice(0, globIdx))) return true;
+    return false;
+  });
+}
+
+// --- Post-creation setup -----------------------------------------------------
+
+/**
+ * Copy <repoRoot>/.wave/settings.local.json into the worktree so local
+ * configuration (permissions, env, ...) carries over. Missing files are
+ * skipped silently; other failures only log a warning.
+ */
+async function copyLocalSettingsToWorktree(
+  repoRoot: string,
+  worktreePath: string,
+): Promise<void> {
+  const relativePath = path.join(".wave", "settings.local.json");
+  const sourcePath = path.join(repoRoot, relativePath);
+  const destPath = path.join(worktreePath, relativePath);
+  let content: string;
+  try {
+    content = await fs.promises.readFile(sourcePath, "utf8");
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.warn(`Failed to read ${sourcePath}: ${(error as Error).message}`);
+    }
+    return;
+  }
+  try {
+    await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
+    await fs.promises.writeFile(destPath, content);
+  } catch (error: unknown) {
+    console.warn(
+      `Failed to copy ${relativePath} into worktree: ${(error as Error).message}`,
+    );
+  }
+}
+
+/**
+ * Copy files listed in <repoRoot>/.worktreeinclude into the worktree. Each
+ * non-comment line is a gitignore pattern; matching gitignored files are
+ * copied at their relative paths.
+ */
+async function copyWorktreeIncludeFiles(
+  repoRoot: string,
+  worktreePath: string,
+): Promise<string[]> {
+  const includePath = path.join(repoRoot, ".worktreeinclude");
+  let content: string;
+  try {
+    content = await fs.promises.readFile(includePath, "utf8");
+  } catch {
+    return [];
+  }
+  const patterns = parseWorktreeIncludePatterns(content);
+  if (patterns.length === 0) return [];
+
+  const worktreeRelPath = path
+    .relative(repoRoot, worktreePath)
+    .split(path.sep)
+    .join("/");
+  // The worktree lives under .wave/worktrees/, which is gitignored — never
+  // copy the worktree (or anything inside it) into itself.
+  const isSelf = (entry: string) =>
+    entry === worktreeRelPath || entry.startsWith(worktreeRelPath + "/");
+
+  // "--directory" collapses fully-ignored directories into single entries,
+  // which keeps the listing fast on large repos.
+  let entries: string[];
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      [
+        "ls-files",
+        "--others",
+        "--ignored",
+        "--exclude-standard",
+        "--directory",
+      ],
+      { cwd: repoRoot, encoding: "utf8" },
+    );
+    entries = stdout.trim().split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
+
+  const copied: string[] = [];
+  const dirsToExpand: string[] = [];
+
+  const copyToWorktree = async (relativePath: string): Promise<void> => {
+    const srcPath = path.join(repoRoot, relativePath);
+    const destPath = path.join(worktreePath, relativePath);
+    try {
+      await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
+      await fs.promises.copyFile(srcPath, destPath);
+      copied.push(relativePath);
+    } catch (error: unknown) {
+      console.warn(
+        `Failed to copy ${relativePath} into worktree: ${(error as Error).message}`,
+      );
+    }
+  };
+
+  for (const entry of entries) {
+    if (isSelf(entry)) continue;
+    if (entry.endsWith("/")) {
+      const dir = entry.slice(0, -1);
+      if (worktreeIncludeMatches(patterns, dir, true)) {
+        // The directory itself matches — copy it wholesale
+        try {
+          await fs.promises.cp(
+            path.join(repoRoot, dir),
+            path.join(worktreePath, dir),
+            {
+              recursive: true,
+            },
+          );
+          copied.push(entry);
+        } catch (error: unknown) {
+          console.warn(
+            `Failed to copy ${entry} into worktree: ${(error as Error).message}`,
+          );
+        }
+      } else if (needsExpansion(patterns, dir)) {
+        dirsToExpand.push(dir);
+      }
+    } else if (worktreeIncludeMatches(patterns, entry, false)) {
+      await copyToWorktree(entry);
+    }
+  }
+
+  if (dirsToExpand.length > 0) {
+    // List the files inside collapsed dirs whose contents are targeted
+    try {
+      const { stdout } = await execFileAsync(
+        "git",
+        [
+          "ls-files",
+          "--others",
+          "--ignored",
+          "--exclude-standard",
+          "--",
+          ...dirsToExpand,
+        ],
+        { cwd: repoRoot, encoding: "utf8" },
+      );
+      for (const file of stdout.trim().split("\n").filter(Boolean)) {
+        if (isSelf(file)) continue;
+        if (worktreeIncludeMatches(patterns, file, false)) {
+          await copyToWorktree(file);
+        }
+      }
+    } catch {
+      // Expansion is best-effort; the worktree is already usable without it
+    }
+  }
+
+  return copied;
+}
+
+/**
+ * Set up a freshly created worktree: copy local settings and gitignored
+ * project files (via .worktreeinclude) from the main repo. Best-effort — any
+ * failure only logs a warning and never fails worktree creation.
+ */
+export async function performPostCreationSetup(
+  worktreePath: string,
+  repoRoot: string,
+): Promise<void> {
+  await copyLocalSettingsToWorktree(repoRoot, worktreePath);
+  await copyWorktreeIncludeFiles(repoRoot, worktreePath);
+}
+
 /**
  * Create a new git worktree
  * @param name Worktree name
@@ -29,6 +393,19 @@ export interface WorktreeSession {
  * @returns Worktree session details
  */
 export async function createWorktree(
+  name: string,
+  cwd: string,
+  options?: { baseRef?: "fresh" | "head"; baseBranch?: string },
+): Promise<WorktreeSession> {
+  validateWorktreeSlug(name);
+  const session = await createWorktreeInternal(name, cwd, options);
+  if (session.isNew) {
+    await performPostCreationSetup(session.path, session.repoRoot);
+  }
+  return session;
+}
+
+async function createWorktreeInternal(
   name: string,
   cwd: string,
   options?: { baseRef?: "fresh" | "head"; baseBranch?: string },

--- a/packages/code/tests/utils/worktree.test.ts
+++ b/packages/code/tests/utils/worktree.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { createWorktree, removeWorktree } from "../../src/utils/worktree.js";
+import {
+  createWorktree,
+  performPostCreationSetup,
+  removeWorktree,
+  validateWorktreeSlug,
+} from "../../src/utils/worktree.js";
 import { getDefaultRemoteBranch, getGitMainRepoRoot } from "wave-agent-sdk";
 
 interface GitResult {
@@ -45,6 +50,13 @@ vi.mock("node:child_process", async () => {
 vi.mock("node:fs", () => ({
   existsSync: vi.fn(),
   mkdirSync: vi.fn(),
+  promises: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    mkdir: vi.fn(),
+    copyFile: vi.fn(),
+    cp: vi.fn(),
+  },
 }));
 
 vi.mock("wave-agent-sdk", () => ({
@@ -60,11 +72,33 @@ function gitError(message: string, stderr: string) {
   return Object.assign(new Error(message), { stderr });
 }
 
+function enoent() {
+  return Object.assign(new Error("ENOENT: no such file or directory"), {
+    code: "ENOENT",
+  });
+}
+
+/** readFile mock that returns content for exact paths and ENOENT otherwise */
+function mockReadFile(map: Record<string, string>) {
+  vi.mocked(fs.promises.readFile).mockImplementation(async (p) => {
+    for (const [filePath, content] of Object.entries(map)) {
+      if (p === filePath) return content;
+    }
+    throw enoent();
+  });
+}
+
 describe("worktree utils", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     git.calls.length = 0;
     git.handler = () => ({ stdout: "", stderr: "" });
+    // Default: neither settings.local.json nor .worktreeinclude exist
+    vi.mocked(fs.promises.readFile).mockRejectedValue(enoent());
+    vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined);
+    vi.mocked(fs.promises.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fs.promises.copyFile).mockResolvedValue(undefined);
+    vi.mocked(fs.promises.cp).mockResolvedValue(undefined);
   });
 
   describe("createWorktree", () => {
@@ -248,6 +282,54 @@ describe("worktree utils", () => {
         "Failed to create worktree",
       );
     });
+
+    it("should reject invalid worktree names before any side effects", async () => {
+      vi.mocked(getGitMainRepoRoot).mockReturnValue("/repo/root");
+
+      await expect(createWorktree("../escape", "/repo/root")).rejects.toThrow(
+        "must not contain",
+      );
+
+      expect(git.calls).toHaveLength(0);
+      expect(getGitMainRepoRoot).not.toHaveBeenCalled();
+    });
+
+    it("should copy settings.local.json into newly created worktrees", async () => {
+      vi.mocked(getGitMainRepoRoot).mockReturnValue("/repo/root");
+      vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      mockReadFile({
+        [path.join("/repo/root", ".wave", "settings.local.json")]:
+          '{"model":"claude"}',
+      });
+
+      const session = await createWorktree("my-feat", "/repo/root");
+
+      expect(session.isNew).toBe(true);
+      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledWith(
+        path.join(
+          "/repo/root",
+          ".wave",
+          "worktrees",
+          "my-feat",
+          ".wave",
+          "settings.local.json",
+        ),
+        '{"model":"claude"}',
+      );
+    });
+
+    it("should skip post-creation setup for existing worktrees", async () => {
+      vi.mocked(getGitMainRepoRoot).mockReturnValue("/repo/root");
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.promises.readFile).mockResolvedValue("{}");
+
+      const session = await createWorktree("my-feat", "/repo/root");
+
+      expect(session.isNew).toBe(false);
+      expect(vi.mocked(fs.promises.readFile)).not.toHaveBeenCalled();
+      expect(vi.mocked(fs.promises.writeFile)).not.toHaveBeenCalled();
+    });
   });
 
   describe("removeWorktree", () => {
@@ -327,6 +409,203 @@ describe("worktree utils", () => {
         expect.stringContaining("Failed to remove worktree or branch"),
       );
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe("validateWorktreeSlug", () => {
+    it("should accept valid names", () => {
+      expect(() => validateWorktreeSlug("my-feat")).not.toThrow();
+      expect(() => validateWorktreeSlug("a")).not.toThrow();
+      expect(() => validateWorktreeSlug("feature/123_abc.def")).not.toThrow();
+    });
+
+    it("should reject empty names", () => {
+      expect(() => validateWorktreeSlug("")).toThrow(
+        "segment must be non-empty",
+      );
+      expect(() => validateWorktreeSlug("/")).toThrow(
+        "segment must be non-empty",
+      );
+    });
+
+    it("should reject names longer than 64 characters", () => {
+      expect(() => validateWorktreeSlug("a".repeat(65))).toThrow(
+        "characters or fewer",
+      );
+      expect(() => validateWorktreeSlug("a".repeat(64))).not.toThrow();
+    });
+
+    it("should reject . and .. path segments", () => {
+      expect(() => validateWorktreeSlug("..")).toThrow("must not contain");
+      expect(() => validateWorktreeSlug("../x")).toThrow("must not contain");
+      expect(() => validateWorktreeSlug("a/../b")).toThrow("must not contain");
+      expect(() => validateWorktreeSlug(".")).toThrow("must not contain");
+    });
+
+    it("should reject invalid characters and leading/trailing slashes", () => {
+      expect(() => validateWorktreeSlug("my feat")).toThrow(
+        "only letters, digits",
+      );
+      expect(() => validateWorktreeSlug("feat@name")).toThrow(
+        "only letters, digits",
+      );
+      expect(() => validateWorktreeSlug("/leading")).toThrow(
+        "segment must be non-empty",
+      );
+      expect(() => validateWorktreeSlug("trailing/")).toThrow(
+        "segment must be non-empty",
+      );
+    });
+  });
+
+  describe("performPostCreationSetup", () => {
+    it("should copy settings.local.json into the worktree when present", async () => {
+      mockReadFile({
+        [path.join("/repo/root", ".wave", "settings.local.json")]:
+          '{"model":"claude"}',
+      });
+
+      await performPostCreationSetup(
+        "/repo/root/.wave/worktrees/my-feat",
+        "/repo/root",
+      );
+
+      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledWith(
+        path.join(
+          "/repo/root/.wave/worktrees/my-feat",
+          ".wave",
+          "settings.local.json",
+        ),
+        '{"model":"claude"}',
+      );
+    });
+
+    it("should not copy settings.local.json when the main repo lacks it", async () => {
+      await performPostCreationSetup(
+        "/repo/root/.wave/worktrees/my-feat",
+        "/repo/root",
+      );
+
+      expect(vi.mocked(fs.promises.writeFile)).not.toHaveBeenCalled();
+      expect(git.calls.filter((c) => c.args.includes("ls-files"))).toHaveLength(
+        0,
+      );
+    });
+
+    it("should copy matched files and skip unmatched ones", async () => {
+      mockReadFile({
+        [path.join("/repo/root", ".worktreeinclude")]:
+          "dist/\n*.env\n!prod.env\nconfig/secret.key\n",
+      });
+      git.handler = (_cmd, args) => {
+        if (args[0] === "ls-files") {
+          return {
+            stdout:
+              "dist/\n.env\nprod.env\nconfig/secret.key\nconfig/other.key\n",
+            stderr: "",
+          };
+        }
+        throw new Error("unexpected git call: " + args.join(" "));
+      };
+
+      await performPostCreationSetup(
+        "/repo/root/.wave/worktrees/my-feat",
+        "/repo/root",
+      );
+
+      // dist/ matches the dir-only pattern -> copied wholesale
+      expect(vi.mocked(fs.promises.cp)).toHaveBeenCalledWith(
+        path.join("/repo/root", "dist"),
+        path.join("/repo/root/.wave/worktrees/my-feat", "dist"),
+        { recursive: true },
+      );
+      // .env matches *.env at any level
+      expect(vi.mocked(fs.promises.copyFile)).toHaveBeenCalledWith(
+        path.join("/repo/root", ".env"),
+        path.join("/repo/root/.wave/worktrees/my-feat", ".env"),
+      );
+      // prod.env excluded by the later !prod.env negation
+      expect(vi.mocked(fs.promises.copyFile)).not.toHaveBeenCalledWith(
+        path.join("/repo/root", "prod.env"),
+        expect.anything(),
+      );
+      // config/secret.key matches its literal pattern
+      expect(vi.mocked(fs.promises.copyFile)).toHaveBeenCalledWith(
+        path.join("/repo/root", "config", "secret.key"),
+        path.join("/repo/root/.wave/worktrees/my-feat", "config", "secret.key"),
+      );
+      // config/other.key does not match any pattern
+      expect(vi.mocked(fs.promises.copyFile)).not.toHaveBeenCalledWith(
+        path.join("/repo/root", "config", "other.key"),
+        expect.anything(),
+      );
+      // no dirs needed expansion -> exactly one ls-files call
+      expect(git.calls.filter((c) => c.args.includes("ls-files"))).toHaveLength(
+        1,
+      );
+    });
+
+    it("should expand collapsed dirs whose contents match patterns", async () => {
+      mockReadFile({
+        [path.join("/repo/root", ".worktreeinclude")]:
+          "config/secrets/api.key\n",
+      });
+      let lsCalls = 0;
+      git.handler = (_cmd, args) => {
+        if (args[0] === "ls-files") {
+          lsCalls++;
+          if (lsCalls === 1) {
+            return { stdout: "config/secrets/\n", stderr: "" };
+          }
+          return {
+            stdout: "config/secrets/api.key\nconfig/secrets/other.key\n",
+            stderr: "",
+          };
+        }
+        throw new Error("unexpected git call: " + args.join(" "));
+      };
+
+      await performPostCreationSetup(
+        "/repo/root/.wave/worktrees/my-feat",
+        "/repo/root",
+      );
+
+      expect(lsCalls).toBe(2);
+      expect(git.calls[1].args).toContain("--");
+      expect(git.calls[1].args).toContain("config/secrets");
+      expect(vi.mocked(fs.promises.copyFile)).toHaveBeenCalledWith(
+        path.join("/repo/root", "config", "secrets", "api.key"),
+        path.join(
+          "/repo/root/.wave/worktrees/my-feat",
+          "config",
+          "secrets",
+          "api.key",
+        ),
+      );
+      expect(vi.mocked(fs.promises.copyFile)).not.toHaveBeenCalledWith(
+        path.join("/repo/root", "config", "secrets", "other.key"),
+        expect.anything(),
+      );
+    });
+
+    it("should copy nothing when no entries match", async () => {
+      mockReadFile({
+        [path.join("/repo/root", ".worktreeinclude")]: "dist/\n",
+      });
+      git.handler = (_cmd, args) => {
+        if (args[0] === "ls-files") {
+          return { stdout: "coverage/\nfoo.ts\n", stderr: "" };
+        }
+        throw new Error("unexpected git call: " + args.join(" "));
+      };
+
+      await performPostCreationSetup(
+        "/repo/root/.wave/worktrees/my-feat",
+        "/repo/root",
+      );
+
+      expect(vi.mocked(fs.promises.cp)).not.toHaveBeenCalled();
+      expect(vi.mocked(fs.promises.copyFile)).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds worktree config-include capability to `createWorktree`, modeled on Claude Code's `worktree.ts`:

- **`validateWorktreeSlug(name)`** — validates names before any side effects: each `/`-separated segment must match `^[a-zA-Z0-9._-]+$`, total length \u226464, rejects `.`/`..` segments (path traversal protection), empty names, and leading/trailing slashes.
- **`performPostCreationSetup(worktreePath, repoRoot)`** — runs after a new worktree is created:
  1. Copies `<repoRoot>/.wave/settings.local.json` → `<worktree>/.wave/settings.local.json` so local config carries over.
  2. Reads `<repoRoot>/.worktreeinclude` (gitignore-pattern lines) and copies matching gitignored files/directories into the worktree at their relative paths. Includes a compact self-implemented gitignore matcher (`**`, `*`, `?`, char classes, `!` negation, dir-only patterns, anchored patterns, any-level basename matching) and collapsed-dir expansion via `git ls-files --directory`.

Best-effort: any copy failure only logs a warning and never fails worktree creation. Existing keep/remove exit flow and `createWorktree`/`removeWorktree` signatures are unchanged.

## Out of scope (per task)

sparsePaths, WorktreeCreate/Remove hooks, session persistence, resume list scanning, tmux, symlink support (wave config has no `symlinkDirectories` field).

## Tests

27/27 passing in `packages/code/tests/utils/worktree.test.ts` (14 new): slug validation (traversal, empty, too-long, spaces), settings.local.json copy (present/absent), .worktreeinclude copy (matched copied, unmatched/negated not, collapsed-dir expansion). `pnpm lint` and type-check clean.