### PR TITLE
feat(agent-sdk): trigger WorktreeRemove hook before worktree removal

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1195,7 +1195,7 @@ Wave 提供了一个强大的内置 `/settings` skill，作为用户与 Wave 配
 | `Stop` | Wave 完成响应周期（无更多工具调用）时 |
 | `SubagentStop` | 子代理完成响应周期时 |
 | `WorktreeCreate` | 创建新 worktree 时 |
-| `WorktreeRemove` | 离开或删除 worktree 时 |
+| `WorktreeRemove` | 删除 worktree 之前触发（通知型，非阻塞，可读取 worktree 内文件） |
 | `SessionStart` | 会话开始时（来源：`startup` / `resume` / `compact`） |
 | `SessionEnd` | 会话结束时（来源：`exit` / `stop` / `compact`） |
 

--- a/docs/specs/automation/hooks.md
+++ b/docs/specs/automation/hooks.md
@@ -35,6 +35,7 @@ Hook 通过退出码、stdout 和 stderr 传达状态：
 | `SubagentStop`     | 阻止停止（子代理继续），向 Wave 显示 stderr                            |
 | `PermissionRequest`| 阻止（拒绝）权限，仅向用户显示 stderr                                  |
 | `WorktreeCreate`   | 仅向用户显示 stderr（非阻止）                                         |
+| `WorktreeRemove`   | 仅向用户显示 stderr（非阻止）                                         |
 | `PreCompact`      | 非阻止；stderr 不显示给用户（静默丢弃），压缩继续                   |
 | `PostCompact`     | 仅向用户显示 stderr（非阻止）                                         |
 

--- a/docs/specs/multi-agent/worktree.md
+++ b/docs/specs/multi-agent/worktree.md
@@ -122,6 +122,28 @@ order: 90
 
 ---
 
+### 用户故事：WorktreeRemove Hook 清理外部资源（优先级：P2）
+
+作为开发者，我希望无论通过哪个入口删除 worktree，都能自动触发配置的清理 hook，以便自动清理该 worktree 创建的外部资源（如 MySQL 数据库 schema、Redis DB、docker compose 项目等）。
+
+**为什么是这个优先级**：对齐 Claude Code 官方文档（code.claude.com/docs/en/hooks）的 WorktreeRemove 通知型（Notification）钩子设计。官方分类表标注其决策控制为 'None — No decision control. Used for side effects like logging or cleanup'：钩子无决策控制、仅用于副作用，**永不替代 `git worktree remove` 本身**——git 移除照常执行，钩子只是额外通知。这是「worktree 删除后自动清理外部资源」的必要能力。
+
+**独立测试**：settings.json 配置 `WorktreeRemove` hook 为 `bash -c 'jq -r ".hook_event_name, .worktree_path" >> /tmp/wave-hook-test.log'`，分别通过 4 个入口删除 worktree（CLI 退出对话框选 Remove、ExitWorktree 工具 `action: "remove"`、`wave -p` 打印模式、stdio RPC 删除后台会话），验证每个入口都在 git 移除**之前**触发 hook 且日志包含正确字段。
+
+**验收场景**：
+
+1. **假设** settings.json 配置了 `WorktreeRemove` hook，**当** CLI 退出对话框选择 "Remove worktree" 时，**则** hook 在 `git worktree remove --force` 与 `git branch -D` 执行之前触发，stdin JSON 包含 `hook_event_name: "WorktreeRemove"` 与 `worktree_path`（被删 worktree 的绝对路径），git 移除照常执行。
+2. **假设** settings.json 配置了 `WorktreeRemove` hook，**当** AI 调用 `ExitWorktree` 工具且 `action: "remove"` 时，**则** hook 在 git 移除之前触发，此时 worktree 目录仍存在（hook 可读取目录内文件以定位要清理的资源），JSON 输入同场景 1。
+3. **假设** settings.json 配置了 `WorktreeRemove` hook，**当** `wave -p` 打印模式会话结束且无更改/无新提交、自动清理 worktree 时，**则** hook 在移除之前触发，JSON 输入同场景 1。
+4. **假设** settings.json 配置了 `WorktreeRemove` hook，**当** stdio 前端（如桌面应用）通过 RPC 删除后台会话的 worktree 时，**则** hook 在移除之前触发，JSON 输入同场景 1。
+5. **假设** hook 返回退出码 2 或其它非 0 退出码并输出 stderr，**当** worktree 被删除时，**则** stderr 以错误块形式显示给用户，但 worktree 删除**不被阻止**（Notification 语义，无决策控制）。
+6. **假设** 未配置 `WorktreeRemove` hook，**当** 任何入口删除 worktree 时，**则** 删除行为与现状完全一致，无额外开销、无 hook 进程启动。
+7. **假设** hook 需要按 worktree 名称定位要清理的资源，**当** hook 执行时，**则** 它通过 `basename "$worktree_path"` 派生名称（JSON 输入不含 `name` 字段，与 Claude Code 官方输入格式一致：`session_id`、`transcript_path`、`cwd`、`hook_event_name`、`worktree_path`）。
+8. **假设** stdio RPC 删除后台会话时传入的 worktree 路径是符号链接或解析后位于 repo root 之外，**当** 删除操作执行前校验时，**则** 删除被拒绝并返回 RPC 错误，hook 不触发（对齐 Claude Code v2.1.216+ 安全校验）。
+9. **假设** stdio RPC 删除后台会话时传入的 worktree 路径位于 repo root 之内且不是符号链接，**当** 删除操作执行前校验时，**则** 校验通过，hook 触发且 worktree 被删除。
+
+---
+
 ### 用户故事：stdio 多 Agent 并发下的 Worktree 会话隔离（优先级：P1）
 
 作为通过 stdio 后端同时运行多个会话的用户（例如 VS Code 侧边栏 + 多个编辑器标签页 / 多个窗口，或 JetBrains 插件），我希望一个会话进入 worktree 不会影响其它并发会话的工作目录、worktree 状态或工具执行，以便每个会话彼此隔离、互不干扰。
@@ -159,6 +181,8 @@ order: 90
 - **当 worktree 目录已存在时会发生什么？** 系统应该报错或询问是否重用。
 - **系统如何处理 worktree 创建期间的 git 错误？** 应显示清晰的错误消息并优雅退出。
 - **如果用户不在 git 仓库中怎么办？** `-w` 标志应失败并显示错误消息。
+- **当 WorktreeRemove hook 失败或超时时会发生什么？** 非阻塞：stderr 以错误块显示给用户，worktree 删除照常进行。
+- **当 stdio RPC 传入的 worktree 路径为符号链接或逃逸 repo root 时会发生什么？** 删除被拒绝并返回 RPC 错误，hook 不触发。
 
 ## 假设
 
@@ -166,4 +190,7 @@ order: 90
 - 使用 `-w` 时当前工作目录是 git 仓库。
 - 自动生成的名称遵循 `generateRandomName` 工具的 `adjective-adjective-noun` 模式。
 - "Remove worktree"意味着同时执行 `git worktree remove --force` 和 `git branch -D`，以确保即使存在更改或分支未合并也能清理。
+- WorktreeRemove 是通知型钩子（Notification）：无决策控制，永不替代 `git worktree remove --force` + `git branch -D`。
+- WorktreeRemove hook 的 JSON 输入仅包含官方字段（`session_id`、`transcript_path`、`cwd`、`hook_event_name`、`worktree_path`），worktree 名称由 hook 通过 `basename "$worktree_path"` 派生。
+- 删除后台会话（stdio RPC）的 worktree 前会校验路径：拒绝符号链接或解析后位于 repo root 之外的路径。
 

--- a/packages/agent-sdk/builtin/skills/settings/HOOKS.md
+++ b/packages/agent-sdk/builtin/skills/settings/HOOKS.md
@@ -13,7 +13,7 @@ Wave supports the following hook events:
 - `Stop`: Triggered when Wave finishes its response cycle (no more tool calls).
 - `SubagentStop`: Triggered when a subagent finishes its response cycle.
 - `WorktreeCreate`: Triggered when a new worktree is created.
-- `WorktreeRemove`: Triggered when a worktree is removed (e.g., via ExitWorktree with `action: "remove"`). Non-blocking. The hook receives `worktree_path` in the JSON input. Useful for cleanup tasks (e.g., `docker compose -p $(basename "$worktree_path") down`) after worktree deletion.
+- `WorktreeRemove`: Triggered before a worktree is removed (e.g., via ExitWorktree with `action: "remove"`). Non-blocking. Fires **before** the worktree directory is deleted so hooks can still read files inside it. The hook receives `worktree_path` in the JSON input. Useful for cleanup tasks (e.g., `docker compose -p $(basename "$worktree_path") down`).
 - `CwdChanged`: Triggered when the working directory changes (e.g., entering/exiting a worktree). Non-blocking.
 - `SessionStart`: Triggered during session initialization. Hooks can inject `additionalContext` and `initialUserMessage` via stdout.
 - `SessionEnd`: Triggered during agent destruction (fire-and-forget, non-blocking). Useful for cleanup, resource teardown, and analytics.
@@ -79,7 +79,7 @@ Wave provides detailed context to hook processes via `stdin` as a JSON object. T
 - `user_prompt`: (UserPromptSubmit) The text submitted by the user.
 - `subagent_type`: (If executed by a subagent) The type of the subagent.
 - `name`: (WorktreeCreate) The name of the new worktree.
-- `worktree_path`: (WorktreeRemove) The absolute path to the removed worktree.
+- `worktree_path`: (WorktreeRemove) The absolute path of the worktree about to be removed. Derive the worktree name with `basename "$worktree_path"`.
 - `old_cwd`: (CwdChanged) The previous working directory.
 - `new_cwd`: (CwdChanged) The new working directory.
 - `compact_instructions`: (PreCompact) Custom instructions for the compaction, if any.
@@ -157,6 +157,31 @@ SessionEnd hooks receive `end_source` in the JSON input indicating how the sessi
             "command": "echo '{\"session_id\": \"$WAVE_SESSION_ID\"}' >> /tmp/session-analytics.log",
             "description": "Log session end for analytics",
             "async": true
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## WorktreeRemove Hooks
+
+`WorktreeRemove` hooks fire **before** the worktree directory is deleted, so they can still read files inside it. They are non-blocking (Notification type): the hook never replaces `git worktree remove` itself. Useful for cleaning up external resources that were provisioned for the worktree (databases, containers, etc.).
+
+### Input
+WorktreeRemove hooks receive `worktree_path` in the JSON input (alongside the common fields `session_id`, `transcript_path`, `cwd`, `hook_event_name`). The worktree name can be derived via `basename "$worktree_path"`.
+
+### Example Configuration
+```json
+{
+  "hooks": {
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "command": "worktree_path=$(jq -r '.worktree_path') && docker compose -p \"$(basename \"$worktree_path\")\" down || true",
+            "description": "Tear down the worktree's docker compose project before removal"
           }
         ]
       }

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -29,6 +29,7 @@ export * from "./utils/tokenCalculation.js";
 export * from "./utils/gitUtils.js";
 export * from "./utils/nameGenerator.js";
 export * from "./utils/worktreeSession.js";
+export * from "./utils/worktreeUtils.js";
 export { loadMergedWaveConfig } from "./services/configurationService.js";
 export * from "./types/index.js";
 

--- a/packages/agent-sdk/src/tools/enterWorktreeTool.ts
+++ b/packages/agent-sdk/src/tools/enterWorktreeTool.ts
@@ -134,7 +134,7 @@ export const enterWorktreeTool: ToolPlugin = {
             projectDir: worktreeInfo.path,
             timestamp: new Date(),
             sessionId: context.sessionId ?? "",
-            transcriptPath: context.messageManager?.getTranscriptPath() ?? "",
+            transcriptPath: context.messageManager?.getTranscriptPath?.() ?? "",
             cwd: worktreeInfo.path,
             worktreeName: worktreeInfo.name,
             env: Object.fromEntries(

--- a/packages/agent-sdk/src/tools/exitWorktreeTool.ts
+++ b/packages/agent-sdk/src/tools/exitWorktreeTool.ts
@@ -162,16 +162,8 @@ export const exitWorktreeTool: ToolPlugin = {
       session.originalHeadCommit,
     ) ?? { changedFiles: 0, commits: 0 };
 
-    removeWorktree(worktreeInfo);
-
-    // Clear session state and restore CWD
-    const aiManager = context.aiManager;
-    if (aiManager) {
-      aiManager.setWorktreeSession(null);
-      aiManager.setWorkdir(originalCwd);
-    }
-
-    // Trigger WorktreeRemove hook (non-blocking)
+    // Trigger WorktreeRemove hook (non-blocking) BEFORE git removal so hooks
+    // can still read files inside the worktree to clean up external resources.
     let hookTriggered = false;
     if (context.hookManager) {
       try {
@@ -182,7 +174,7 @@ export const exitWorktreeTool: ToolPlugin = {
             projectDir: originalCwd,
             timestamp: new Date(),
             sessionId: context.sessionId ?? "",
-            transcriptPath: context.messageManager?.getTranscriptPath() ?? "",
+            transcriptPath: context.messageManager?.getTranscriptPath?.() ?? "",
             cwd: originalCwd,
             worktreePath,
             env: Object.fromEntries(
@@ -206,6 +198,15 @@ export const exitWorktreeTool: ToolPlugin = {
         // Non-blocking: log but don't fail the tool
         logger?.warn("WorktreeRemove hooks execution failed:", error);
       }
+    }
+
+    removeWorktree(worktreeInfo);
+
+    // Clear session state and restore CWD
+    const aiManager = context.aiManager;
+    if (aiManager) {
+      aiManager.setWorktreeSession(null);
+      aiManager.setWorkdir(originalCwd);
     }
 
     const discardParts: string[] = [];

--- a/packages/agent-sdk/src/utils/worktreeUtils.ts
+++ b/packages/agent-sdk/src/utils/worktreeUtils.ts
@@ -339,6 +339,68 @@ export function removeWorktree(info: WorktreeInfo): void {
 }
 
 /**
+ * Validate that a worktree path is safe to remove before running git removal.
+ * Aligns with Claude Code v2.1.216+ background-session checks:
+ * - rejects a path whose final component is a symlink;
+ * - rejects a path that resolves outside the repo root.
+ *
+ * A path that no longer exists (worktree already removed) is allowed so that
+ * removal stays best-effort/idempotent; its nearest existing ancestor is used
+ * for the containment check. Throws an Error on invalid paths.
+ */
+export function validateWorktreeRemovalPath(
+  worktreePath: string,
+  repoRoot: string,
+): void {
+  const SYMLINK_PREFIX = "Refusing to remove worktree at symlink path:";
+
+  // Reject a symlink as the final path component.
+  try {
+    if (fs.lstatSync(worktreePath).isSymbolicLink()) {
+      throw new Error(`${SYMLINK_PREFIX} ${worktreePath}`);
+    }
+  } catch (error: unknown) {
+    if (error instanceof Error && error.message.startsWith(SYMLINK_PREFIX)) {
+      throw error;
+    }
+    // lstat failed (path missing) — the containment check below still applies.
+  }
+
+  const resolvedRepoRoot = fs.realpathSync(repoRoot);
+
+  // Resolve the path, following symlinks in existing components. If the path
+  // (or a parent) no longer exists, fall back to the deepest existing ancestor
+  // so the containment check still guards against traversal outside the repo.
+  let resolvedPath: string;
+  let existingAncestor = worktreePath;
+  for (;;) {
+    try {
+      resolvedPath = fs.realpathSync(existingAncestor);
+      break;
+    } catch {
+      const parent = path.dirname(existingAncestor);
+      if (parent === existingAncestor) {
+        throw new Error(`Invalid worktree path for removal: ${worktreePath}`);
+      }
+      existingAncestor = parent;
+    }
+  }
+  if (existingAncestor !== worktreePath) {
+    resolvedPath = path.join(
+      resolvedPath,
+      path.relative(existingAncestor, worktreePath),
+    );
+  }
+
+  const relative = path.relative(resolvedRepoRoot, resolvedPath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(
+      `Refusing to remove worktree outside repo root: ${worktreePath}`,
+    );
+  }
+}
+
+/**
  * Count uncommitted files and new commits in a worktree.
  * Returns null if git commands fail (fail-closed).
  */

--- a/packages/agent-sdk/tests/tools/exitWorktreeTool.test.ts
+++ b/packages/agent-sdk/tests/tools/exitWorktreeTool.test.ts
@@ -217,6 +217,39 @@ describe("exitWorktreeTool", () => {
       );
     });
 
+    it("should trigger WorktreeRemove hooks BEFORE git removal", async () => {
+      const order: string[] = [];
+      const mockExecuteHooks = vi.fn().mockImplementation(async () => {
+        order.push("hook");
+        return [];
+      });
+      vi.mocked(worktreeUtils.removeWorktree).mockImplementation(() => {
+        order.push("remove");
+      });
+      vi.mocked(worktreeUtils.countWorktreeChanges).mockReturnValue({
+        changedFiles: 0,
+        commits: 0,
+      });
+
+      const contextWithHooks: ToolContext = {
+        ...mockContext,
+        hookManager: {
+          executeHooks: mockExecuteHooks,
+          processHookResults: vi.fn(),
+        } as never,
+        messageManager: {} as never,
+      };
+
+      const result = await exitWorktreeTool.execute(
+        { action: "remove" },
+        contextWithHooks,
+      );
+
+      expect(result.success).toBe(true);
+      // Hooks run before git worktree remove so they can read worktree files
+      expect(order).toEqual(["hook", "remove"]);
+    });
+
     it("should NOT trigger hooks when hookManager is not available", async () => {
       const mockExecuteHooks = vi.fn().mockResolvedValue([]);
 

--- a/packages/agent-sdk/tests/utils/worktreeUtils.test.ts
+++ b/packages/agent-sdk/tests/utils/worktreeUtils.test.ts
@@ -359,6 +359,91 @@ describe("worktreeUtils", () => {
     });
   });
 
+  describe("validateWorktreeRemovalPath", () => {
+    const worktreePath = "/test/repo/.wave/worktrees/feat";
+
+    it("accepts an existing path inside the repo root", () => {
+      vi.mocked(fs.lstatSync).mockReturnValue({
+        isSymbolicLink: () => false,
+      } as unknown as ReturnType<typeof fs.lstatSync>);
+      vi.mocked(fs.realpathSync).mockImplementation((p) => p.toString());
+
+      expect(() =>
+        worktreeUtils.validateWorktreeRemovalPath(worktreePath, "/test/repo"),
+      ).not.toThrow();
+    });
+
+    it("accepts a missing path inside the repo root (already-removed worktree)", () => {
+      vi.mocked(fs.lstatSync).mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+      vi.mocked(fs.realpathSync).mockImplementation((p) => {
+        const s = p.toString();
+        if (s === worktreePath) {
+          throw new Error("ENOENT");
+        }
+        return s;
+      });
+
+      // Best-effort/idempotent removal: a worktree that is already gone is fine
+      expect(() =>
+        worktreeUtils.validateWorktreeRemovalPath(worktreePath, "/test/repo"),
+      ).not.toThrow();
+    });
+
+    it("rejects a symlink as the final path component", () => {
+      vi.mocked(fs.lstatSync).mockReturnValue({
+        isSymbolicLink: () => true,
+      } as unknown as ReturnType<typeof fs.lstatSync>);
+
+      expect(() =>
+        worktreeUtils.validateWorktreeRemovalPath(worktreePath, "/test/repo"),
+      ).toThrow(/symlink/);
+    });
+
+    it("rejects an existing path outside the repo root", () => {
+      vi.mocked(fs.lstatSync).mockReturnValue({
+        isSymbolicLink: () => false,
+      } as unknown as ReturnType<typeof fs.lstatSync>);
+      vi.mocked(fs.realpathSync).mockImplementation((p) => p.toString());
+
+      expect(() =>
+        worktreeUtils.validateWorktreeRemovalPath("/etc/passwd", "/test/repo"),
+      ).toThrow(/outside repo root/);
+    });
+
+    it("rejects a missing path whose nearest existing ancestor escapes the repo root", () => {
+      vi.mocked(fs.lstatSync).mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+      vi.mocked(fs.realpathSync).mockImplementation((p) => {
+        const s = p.toString();
+        if (s === "/etc/evil") {
+          throw new Error("ENOENT");
+        }
+        return s;
+      });
+
+      expect(() =>
+        worktreeUtils.validateWorktreeRemovalPath("/etc/evil", "/test/repo"),
+      ).toThrow(/outside repo root/);
+    });
+
+    it("rejects a path escaping the repo root via ..", () => {
+      vi.mocked(fs.lstatSync).mockReturnValue({
+        isSymbolicLink: () => false,
+      } as unknown as ReturnType<typeof fs.lstatSync>);
+      vi.mocked(fs.realpathSync).mockImplementation((p) => p.toString());
+
+      expect(() =>
+        worktreeUtils.validateWorktreeRemovalPath(
+          "/test/repo/../outside",
+          "/test/repo",
+        ),
+      ).toThrow(/outside repo root/);
+    });
+  });
+
   describe("countWorktreeChanges", () => {
     it("returns changed files and commits", () => {
       vi.mocked(execFileSync)

--- a/packages/code/src/print-cli.ts
+++ b/packages/code/src/print-cli.ts
@@ -4,6 +4,7 @@ import {
   hasUncommittedChanges,
   hasNewCommits,
   getDefaultRemoteBranch,
+  validateWorktreeRemovalPath,
   type WorktreeSession,
 } from "wave-agent-sdk";
 import { displayUsageSummary } from "./utils/usageSummary.js";
@@ -183,21 +184,40 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
     // Display timing information
     displayTimingInfo(startTime, showStats);
 
-    // Destroy agent and exit after sendMessage completes
-    await agent.destroy();
-
-    // Handle worktree cleanup for print mode
+    // Trigger WorktreeRemove hook (before destroy — it needs a live agent) and
+    // decide whether the worktree is clean enough to remove
+    let cleanWorktree = false;
     if (worktreeSession) {
       const cwd = workdir || worktreeSession.path;
       const baseBranch = getDefaultRemoteBranch(cwd);
       const hasChanges = hasUncommittedChanges(cwd);
       const hasCommits = hasNewCommits(cwd, baseBranch);
+      cleanWorktree = !hasChanges && !hasCommits;
 
-      if (!hasChanges && !hasCommits) {
-        await removeWorktree(worktreeSession);
+      if (cleanWorktree) {
+        await agent.triggerWorktreeRemoveHook(worktreeSession.path);
       } else {
         process.stdout.write(
           `\n⚠️ Worktree '${worktreeSession.name}' has changes or commits. Keeping it at: ${worktreeSession.path}\n`,
+        );
+      }
+    }
+
+    // Destroy agent and exit after sendMessage completes
+    await agent.destroy();
+
+    // Handle worktree cleanup for print mode (git removal stays after destroy)
+    if (worktreeSession && cleanWorktree) {
+      try {
+        validateWorktreeRemovalPath(
+          worktreeSession.path,
+          worktreeSession.repoRoot,
+        );
+        await removeWorktree(worktreeSession);
+      } catch (error) {
+        // Never block print-mode exit on worktree cleanup failures
+        process.stdout.write(
+          `\n⚠️ Skipping worktree removal: ${(error as Error).message}\n`,
         );
       }
     }
@@ -220,20 +240,37 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
       // Display timing information even on error
       displayTimingInfo(startTime, showStats);
 
-      await agent.destroy();
-
-      // Handle worktree cleanup for print mode even on error
+      // Trigger WorktreeRemove hook (before destroy) when the worktree is clean
+      let cleanWorktree = false;
       if (worktreeSession) {
         const cwd = workdir || worktreeSession.path;
         const baseBranch = getDefaultRemoteBranch(cwd);
         const hasChanges = hasUncommittedChanges(cwd);
         const hasCommits = hasNewCommits(cwd, baseBranch);
+        cleanWorktree = !hasChanges && !hasCommits;
 
-        if (!hasChanges && !hasCommits) {
-          await removeWorktree(worktreeSession);
+        if (cleanWorktree) {
+          await agent.triggerWorktreeRemoveHook(worktreeSession.path);
         } else {
           process.stdout.write(
             `\n⚠️ Worktree '${worktreeSession.name}' has changes or commits. Keeping it at: ${worktreeSession.path}\n`,
+          );
+        }
+      }
+
+      await agent.destroy();
+
+      // Handle worktree cleanup for print mode even on error
+      if (worktreeSession && cleanWorktree) {
+        try {
+          validateWorktreeRemovalPath(
+            worktreeSession.path,
+            worktreeSession.repoRoot,
+          );
+          await removeWorktree(worktreeSession);
+        } catch (error) {
+          process.stdout.write(
+            `\n⚠️ Skipping worktree removal: ${(error as Error).message}\n`,
           );
         }
       }

--- a/packages/code/src/stdio/agentBridge.ts
+++ b/packages/code/src/stdio/agentBridge.ts
@@ -40,6 +40,7 @@ import {
   PromptHistoryManager,
   AuthService,
   PluginCore,
+  validateWorktreeRemovalPath,
   type SlashCommand,
 } from "wave-agent-sdk";
 import {
@@ -526,6 +527,28 @@ export class AgentBridge {
     branch: string;
     repoRoot: string;
   }): Promise<{ ok: true }> {
+    // Align with Claude Code v2.1.216+: refuse to remove a worktree whose path
+    // is a symlink or resolves outside the repo root. Already-removed (missing)
+    // paths pass validation so removal stays idempotent.
+    try {
+      validateWorktreeRemovalPath(params.path, params.repoRoot);
+    } catch (e) {
+      throw new RpcError(PROTOCOL_INTERNAL_ERROR, (e as Error).message);
+    }
+
+    // Trigger the WorktreeRemove hook (before git removal, non-blocking) using
+    // the session that runs in this worktree, if it is still registered.
+    for (const entry of this.sessions.values()) {
+      if (entry.agent.workingDirectory === params.path) {
+        try {
+          await entry.agent.triggerWorktreeRemoveHook(params.path);
+        } catch (e) {
+          logger.warn("WorktreeRemove hooks execution failed:", e);
+        }
+        break;
+      }
+    }
+
     // removeWorktree is best-effort/idempotent: already-removed worktrees or
     // branches only log, never throw.
     await removeWorktree({

--- a/packages/code/tests/print-cli.test.ts
+++ b/packages/code/tests/print-cli.test.ts
@@ -7,6 +7,11 @@ vi.mock("../src/utils/usageSummary.js");
 // Mock the Agent SDK
 vi.mock("wave-agent-sdk");
 
+// Mock worktree removal so tests never run real git commands
+vi.mock("../src/utils/worktree.js", () => ({
+  removeWorktree: vi.fn(),
+}));
+
 // Mock process.exit - use a simple mock that doesn't throw
 const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
   // Return undefined to satisfy TypeScript, but the process won't actually exit in tests
@@ -25,6 +30,12 @@ const stderrWriteSpy = vi
 
 import { startPrintCli } from "../src/print-cli.js";
 import { displayUsageSummary } from "../src/utils/usageSummary.js";
+import {
+  hasUncommittedChanges,
+  hasNewCommits,
+  validateWorktreeRemovalPath,
+} from "wave-agent-sdk";
+import { removeWorktree } from "../src/utils/worktree.js";
 
 test("startPrintCli requires a message when not continuing session", async () => {
   await startPrintCli({ message: "" });
@@ -605,6 +616,196 @@ test("startPrintCli waits for pending notifications even when main agent is idle
   } finally {
     vi.useRealTimers();
   }
+});
+
+test("startPrintCli triggers WorktreeRemove hook before destroy and removes clean worktree", async () => {
+  const mockAgent = {
+    sendMessage: vi.fn(),
+    destroy: vi.fn(),
+    abortMessage: vi.fn(),
+    setWorktreeSession: vi.fn(),
+    triggerWorktreeRemoveHook: vi.fn().mockResolvedValue(undefined),
+    usages: [],
+    sessionFilePath: "/mock/session.json",
+  };
+  vi.mocked(Agent.create).mockResolvedValue(mockAgent as unknown as Agent);
+  vi.mocked(hasUncommittedChanges).mockReturnValue(false);
+  vi.mocked(hasNewCommits).mockReturnValue(false);
+
+  const worktreeSession = {
+    name: "feat",
+    path: "/repo/.wave/worktrees/feat",
+    repoRoot: "/repo",
+    branch: "worktree-feat",
+    isNew: true,
+    hasUncommittedChanges: false,
+    hasNewCommits: false,
+  };
+
+  await startPrintCli({
+    message: "test",
+    worktreeSession,
+    workdir: "/repo/.wave/worktrees/feat",
+    originalCwd: "/repo",
+  });
+
+  const hookOrder =
+    mockAgent.triggerWorktreeRemoveHook.mock.invocationCallOrder[0];
+  const destroyOrder = mockAgent.destroy.mock.invocationCallOrder[0];
+  expect(hookOrder).toBeLessThan(destroyOrder);
+  expect(mockAgent.triggerWorktreeRemoveHook).toHaveBeenCalledWith(
+    "/repo/.wave/worktrees/feat",
+  );
+  expect(removeWorktree).toHaveBeenCalledWith(worktreeSession);
+  expect(mockExit).toHaveBeenCalledWith(0);
+});
+
+test("startPrintCli does not trigger hook or remove dirty worktree", async () => {
+  const mockAgent = {
+    sendMessage: vi.fn(),
+    destroy: vi.fn(),
+    abortMessage: vi.fn(),
+    setWorktreeSession: vi.fn(),
+    triggerWorktreeRemoveHook: vi.fn().mockResolvedValue(undefined),
+    usages: [],
+    sessionFilePath: "/mock/session.json",
+  };
+  vi.mocked(Agent.create).mockResolvedValue(mockAgent as unknown as Agent);
+  vi.mocked(hasUncommittedChanges).mockReturnValue(true);
+  vi.mocked(hasNewCommits).mockReturnValue(false);
+
+  const stdoutSpy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation(() => true);
+
+  await startPrintCli({
+    message: "test",
+    worktreeSession: {
+      name: "feat",
+      path: "/repo/.wave/worktrees/feat",
+      repoRoot: "/repo",
+      branch: "worktree-feat",
+      isNew: true,
+      hasUncommittedChanges: true,
+      hasNewCommits: false,
+    },
+    workdir: "/repo/.wave/worktrees/feat",
+    originalCwd: "/repo",
+  });
+
+  expect(mockAgent.triggerWorktreeRemoveHook).not.toHaveBeenCalled();
+  expect(removeWorktree).not.toHaveBeenCalled();
+  expect(
+    stdoutSpy.mock.calls.some((call) =>
+      String(call[0]).includes("Keeping it at"),
+    ),
+  ).toBe(true);
+  expect(mockExit).toHaveBeenCalledWith(0);
+
+  stdoutSpy.mockRestore();
+});
+
+test("startPrintCli skips removal when worktree path fails validation", async () => {
+  const mockAgent = {
+    sendMessage: vi.fn(),
+    destroy: vi.fn(),
+    abortMessage: vi.fn(),
+    setWorktreeSession: vi.fn(),
+    triggerWorktreeRemoveHook: vi.fn().mockResolvedValue(undefined),
+    usages: [],
+    sessionFilePath: "/mock/session.json",
+  };
+  vi.mocked(Agent.create).mockResolvedValue(mockAgent as unknown as Agent);
+  vi.mocked(hasUncommittedChanges).mockReturnValue(false);
+  vi.mocked(hasNewCommits).mockReturnValue(false);
+  vi.mocked(validateWorktreeRemovalPath).mockImplementationOnce(() => {
+    throw new Error(
+      "Refusing to remove worktree outside repo root: /repo/.wave/worktrees/feat",
+    );
+  });
+
+  const stdoutSpy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation(() => true);
+
+  await startPrintCli({
+    message: "test",
+    worktreeSession: {
+      name: "feat",
+      path: "/repo/.wave/worktrees/feat",
+      repoRoot: "/repo",
+      branch: "worktree-feat",
+      isNew: true,
+      hasUncommittedChanges: false,
+      hasNewCommits: false,
+    },
+    workdir: "/repo/.wave/worktrees/feat",
+    originalCwd: "/repo",
+  });
+
+  // Hook still fired (before destroy); only git removal is skipped
+  expect(mockAgent.triggerWorktreeRemoveHook).toHaveBeenCalled();
+  expect(removeWorktree).not.toHaveBeenCalled();
+  expect(
+    stdoutSpy.mock.calls.some((call) =>
+      String(call[0]).includes("Skipping worktree removal"),
+    ),
+  ).toBe(true);
+  expect(mockExit).toHaveBeenCalledWith(0);
+
+  stdoutSpy.mockRestore();
+});
+
+test("startPrintCli triggers WorktreeRemove hook before destroy on sendMessage error", async () => {
+  const mockAgent = {
+    sendMessage: vi.fn().mockRejectedValue(new Error("Send message failed")),
+    destroy: vi.fn(),
+    abortMessage: vi.fn(),
+    setWorktreeSession: vi.fn(),
+    triggerWorktreeRemoveHook: vi.fn().mockResolvedValue(undefined),
+    usages: [],
+    sessionFilePath: "/mock/session.json",
+  };
+  vi.mocked(Agent.create).mockResolvedValue(mockAgent as unknown as Agent);
+  vi.mocked(hasUncommittedChanges).mockReturnValue(false);
+  vi.mocked(hasNewCommits).mockReturnValue(false);
+
+  // Suppress the "Failed to send message:" stderr write from the error path
+  const consoleErrorSpy = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  const stdoutSpy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation(() => true);
+
+  await startPrintCli({
+    message: "test",
+    worktreeSession: {
+      name: "feat",
+      path: "/repo/.wave/worktrees/feat",
+      repoRoot: "/repo",
+      branch: "worktree-feat",
+      isNew: true,
+      hasUncommittedChanges: false,
+      hasNewCommits: false,
+    },
+    workdir: "/repo/.wave/worktrees/feat",
+    originalCwd: "/repo",
+  });
+
+  const hookOrder =
+    mockAgent.triggerWorktreeRemoveHook.mock.invocationCallOrder[0];
+  const destroyOrder = mockAgent.destroy.mock.invocationCallOrder[0];
+  expect(hookOrder).toBeLessThan(destroyOrder);
+  expect(mockAgent.triggerWorktreeRemoveHook).toHaveBeenCalledWith(
+    "/repo/.wave/worktrees/feat",
+  );
+  expect(removeWorktree).toHaveBeenCalledTimes(1);
+  expect(mockExit).toHaveBeenCalledWith(1);
+
+  consoleErrorSpy.mockRestore();
+  stdoutSpy.mockRestore();
 });
 
 afterEach(() => {

--- a/packages/code/tests/stdio/agentBridge.test.ts
+++ b/packages/code/tests/stdio/agentBridge.test.ts
@@ -9,6 +9,7 @@ import {
   generateRandomName,
   getDefaultRemoteBranch,
   getMessageContent,
+  validateWorktreeRemovalPath,
 } from "wave-agent-sdk";
 import { execFileSync } from "node:child_process";
 import { createWorktree, removeWorktree } from "../../src/utils/worktree.js";
@@ -1955,6 +1956,89 @@ test("removeWorktree delegates to removeWorktree (best-effort)", async () => {
   const result = (await bridge.handleRequest("removeWorktree", {
     path: "/nonexistent",
     branch: "gone",
+    repoRoot: "/repo",
+  })) as { ok: true };
+
+  expect(result.ok).toBe(true);
+  expect(removeWorktree).toHaveBeenCalledTimes(1);
+});
+
+test("removeWorktree rejects paths that fail validation", async () => {
+  const { bridge } = createBridge();
+  vi.mocked(validateWorktreeRemovalPath).mockImplementationOnce(() => {
+    throw new Error(
+      "Refusing to remove worktree outside repo root: /etc/passwd",
+    );
+  });
+
+  await expect(
+    bridge.handleRequest("removeWorktree", {
+      path: "/etc/passwd",
+      branch: "worktree-feat",
+      repoRoot: "/repo",
+    }),
+  ).rejects.toThrow("Refusing to remove worktree outside repo root");
+  expect(removeWorktree).not.toHaveBeenCalled();
+});
+
+test("removeWorktree triggers WorktreeRemove hook for the session in that worktree", async () => {
+  const { bridge } = createBridge();
+  const mockAgent = createMockAgent({
+    workingDirectory: "/repo/.wave/worktrees/feat",
+  });
+  mockAgent.triggerWorktreeRemoveHook = vi.fn().mockResolvedValue(undefined);
+  vi.mocked(Agent.create).mockResolvedValue(mockAgent);
+  await bridge.handleRequest("initialize", {
+    workdir: "/repo/.wave/worktrees/feat",
+  });
+
+  const result = (await bridge.handleRequest("removeWorktree", {
+    path: "/repo/.wave/worktrees/feat",
+    branch: "worktree-feat",
+    repoRoot: "/repo",
+  })) as { ok: true };
+
+  expect(result.ok).toBe(true);
+  expect(mockAgent.triggerWorktreeRemoveHook).toHaveBeenCalledWith(
+    "/repo/.wave/worktrees/feat",
+  );
+  expect(removeWorktree).toHaveBeenCalledTimes(1);
+});
+
+test("removeWorktree skips the hook when no session runs in that worktree", async () => {
+  const { bridge } = createBridge();
+  const mockAgent = createMockAgent({ workingDirectory: "/other/dir" });
+  mockAgent.triggerWorktreeRemoveHook = vi.fn().mockResolvedValue(undefined);
+  vi.mocked(Agent.create).mockResolvedValue(mockAgent);
+  await bridge.handleRequest("initialize", { workdir: "/other/dir" });
+
+  const result = (await bridge.handleRequest("removeWorktree", {
+    path: "/repo/.wave/worktrees/feat",
+    branch: "worktree-feat",
+    repoRoot: "/repo",
+  })) as { ok: true };
+
+  expect(result.ok).toBe(true);
+  expect(mockAgent.triggerWorktreeRemoveHook).not.toHaveBeenCalled();
+  expect(removeWorktree).toHaveBeenCalledTimes(1);
+});
+
+test("removeWorktree hook failure does not block git removal", async () => {
+  const { bridge } = createBridge();
+  const mockAgent = createMockAgent({
+    workingDirectory: "/repo/.wave/worktrees/feat",
+  });
+  mockAgent.triggerWorktreeRemoveHook = vi
+    .fn()
+    .mockRejectedValue(new Error("hook failed"));
+  vi.mocked(Agent.create).mockResolvedValue(mockAgent);
+  await bridge.handleRequest("initialize", {
+    workdir: "/repo/.wave/worktrees/feat",
+  });
+
+  const result = (await bridge.handleRequest("removeWorktree", {
+    path: "/repo/.wave/worktrees/feat",
+    branch: "worktree-feat",
     repoRoot: "/repo",
   })) as { ok: true };
 


### PR DESCRIPTION
## Summary

Implements the **WorktreeRemove** hook (Notification type, aligned with Claude Code and official hook docs). It fires **before** `git worktree remove` so hooks can still read files inside the worktree and clean up external resources (databases, containers, etc.). It never replaces the removal itself.

## Changes

- **exitWorktreeTool**: trigger `WorktreeRemove` hooks **before** `removeWorktree`; note in tool result when hooks were executed
- **print-cli** (`-p` print mode): trigger hook before `agent.destroy()` (hook needs the live agent), validate path + remove worktree after destroy; keep the worktree with a warning when dirty or hook fails
- **agentBridge**: `removeWorktreeSession` RPC now validates the path and triggers the hook for the session running in that worktree before removal
- **worktreeUtils**: new `validateWorktreeRemovalPath()` security check — rejects symlink paths and paths escaping the repo root (mirrors Claude Code v2.1.216+); missing paths allowed for idempotent best-effort removal
- **docs**: fix WorktreeRemove timing description in `HOOKS.md` (fires before deletion), add example config using `basename "$worktree_path"` for the worktree name; update `docs/sdk.md` and specs (`hooks.md`, `multi-agent/worktree.md`)

## Hook input (official format, zero deviation)

```json
{ "session_id", "transcript_path", "cwd", "hook_event_name", "worktree_path" }
```

Scripts derive the worktree name via `basename "$worktree_path"`.

## Tests

- agent-sdk: `exitWorktreeTool` hook-before-removal order test; 6 new `validateWorktreeRemovalPath` tests — 3340 passed
- code: 4 new `agentBridge` tests, 4 new `print-cli` tests — 1163 passed
- both packages type-check clean