### PR TITLE
fix(code): handle tmux/SSH coalesced Enter, drop paste-buffer debounce

### DIFF
--- a/packages/code/src/hooks/useInputManager.ts
+++ b/packages/code/src/hooks/useInputManager.ts
@@ -72,26 +72,6 @@ export const useInputManager = (
     }
   }, [state.showFileSelector, state.fileSearchQuery]);
 
-  // Handle paste debouncing
-  useEffect(() => {
-    if (state.isPasting) {
-      const pasteDebounceDelay = parseInt(
-        process.env.PASTE_DEBOUNCE_MS || "30",
-        10,
-      );
-      const timer = setTimeout(() => {
-        const processedInput = state.pasteBuffer.replace(/\r/g, "\n");
-        dispatch({
-          type: "INSERT_TEXT_WITH_PLACEHOLDER",
-          payload: processedInput,
-        });
-        dispatch({ type: "END_PASTE" });
-        dispatch({ type: "RESET_HISTORY_NAVIGATION" });
-      }, pasteDebounceDelay);
-      return () => clearTimeout(timer);
-    }
-  }, [state.isPasting, state.pasteBuffer]);
-
   // Auto-expire the double-Esc clear pending flag after the timeout window
   // (aligned with Claude Code's useDoublePress timeout-based expiry).
   useEffect(() => {

--- a/packages/code/src/managers/inputHandlers.ts
+++ b/packages/code/src/managers/inputHandlers.ts
@@ -292,17 +292,13 @@ export const handlePasteInput = (
   input: string,
 ): void => {
   const inputString = input;
-  const isPasteOperation =
-    inputString.length > 1 ||
-    inputString.includes("\n") ||
-    inputString.includes("\r");
 
-  if (isPasteOperation) {
-    // Dispatch a single action type; the reducer determines start vs append
-    // by checking pasteBuffer, avoiding stale state issues
+  if (inputString.length > 1) {
+    // Multi-char chunk: insert immediately (\r → \n normalizes CRLF
+    // terminals), matching the reducer's HANDLE_KEY path.
     dispatch({
-      type: "APPEND_PASTE_CHUNK",
-      payload: { chunk: inputString, cursorPosition: state.cursorPosition },
+      type: "INSERT_TEXT_WITH_PLACEHOLDER",
+      payload: inputString.replace(/\r/g, "\n"),
     });
   } else {
     let char = inputString;

--- a/packages/code/src/managers/inputReducer.ts
+++ b/packages/code/src/managers/inputReducer.ts
@@ -126,9 +126,6 @@ export interface InputState {
   showWorkflowManager: boolean;
   permissionMode: PermissionMode;
   selectorJustUsed: boolean;
-  isPasting: boolean;
-  pasteBuffer: string;
-  initialPasteCursorPosition: number;
   history: PromptEntry[];
   historyIndex: number;
   originalInputText: string;
@@ -166,9 +163,6 @@ export const initialState: InputState = {
   showWorkflowManager: false,
   permissionMode: "default",
   selectorJustUsed: false,
-  isPasting: false,
-  pasteBuffer: "",
-  initialPasteCursorPosition: 0,
   history: [],
   historyIndex: -1,
   originalInputText: "",
@@ -181,6 +175,172 @@ export const initialState: InputState = {
   pendingEffect: null,
   escClearPending: false,
 };
+
+/**
+ * Insert text at the cursor position, folding text longer than 200 chars
+ * into a [LongText#N] placeholder. Shared by the INSERT_TEXT_WITH_PLACEHOLDER
+ * action and multi-char chunk inserts (typed bursts, terminal paste, tmux
+ * send-keys).
+ */
+function insertTextWithPlaceholder(
+  textToInsert: string,
+  state: InputState,
+): InputState {
+  let text = textToInsert;
+  let newLongTextCounter = state.longTextCounter;
+  const newLongTextMap = { ...state.longTextMap };
+
+  if (text.length > 200) {
+    newLongTextCounter += 1;
+    const placeholderLabel = `[LongText#${newLongTextCounter}]`;
+    newLongTextMap[placeholderLabel] = text;
+    text = placeholderLabel;
+  }
+
+  const beforeCursor = state.inputText.substring(0, state.cursorPosition);
+  const afterCursor = state.inputText.substring(state.cursorPosition);
+  const newText = beforeCursor + text + afterCursor;
+  const newCursorPosition = state.cursorPosition + text.length;
+
+  const newState: InputState = {
+    ...state,
+    inputText: newText,
+    cursorPosition: newCursorPosition,
+    longTextCounter: newLongTextCounter,
+    longTextMap: newLongTextMap,
+    historyIndex: -1,
+  };
+
+  // Sync selectors
+  const atPos = getAtSelectorPosition(newText, newCursorPosition);
+  if (atPos !== -1 && !newState.showFileSelector) {
+    newState.showFileSelector = true;
+    newState.atPosition = atPos;
+    newState.isFileSearching = true;
+  }
+
+  const slashPos = getSlashSelectorPosition(newText, newCursorPosition);
+  if (slashPos !== -1 && !newState.showCommandSelector) {
+    newState.showCommandSelector = true;
+    newState.slashPosition = slashPos;
+  }
+
+  if (newState.showFileSelector && newState.atPosition >= 0) {
+    newState.fileSearchQuery = newText.substring(
+      newState.atPosition + 1,
+      newCursorPosition,
+    );
+  } else if (newState.showCommandSelector && newState.slashPosition >= 0) {
+    newState.commandSearchQuery = newText.substring(
+      newState.slashPosition + 1,
+      newCursorPosition,
+    );
+  }
+
+  return newState;
+}
+
+/**
+ * Submit the current input text: extract [Image #N] references, route /btw
+ * and CLI-internal slash commands, otherwise send as a message. Returns null
+ * when there is nothing to submit (empty text, bare /btw).
+ */
+function submitInput(state: InputState): InputState | null {
+  if (!state.inputText.trim()) {
+    return null;
+  }
+  const imageRegex = /\[Image #(\d+)\]/g;
+  const matches = [...state.inputText.matchAll(imageRegex)];
+  const referencedImages = matches
+    .map((match) => {
+      const imageId = parseInt(match[1], 10);
+      return state.attachedImages.find((img) => img.id === imageId);
+    })
+    .filter((img): img is AttachedImage => img !== undefined)
+    .map((img) => ({ path: img.path, mimeType: img.mimeType }));
+
+  const contentWithPlaceholders = state.inputText
+    .replace(imageRegex, "")
+    .trim();
+
+  if (contentWithPlaceholders.startsWith("/btw ")) {
+    const question = contentWithPlaceholders.substring(5).trim();
+    if (!question) {
+      // Bare /btw with no question text — ignore
+      return null;
+    }
+
+    return {
+      ...state,
+      inputText: "",
+      cursorPosition: 0,
+      historyIndex: -1,
+      longTextMap: {},
+      attachedImages: [],
+      btwState: {
+        question,
+        isLoading: true,
+        answer: undefined,
+      },
+      pendingEffect: { type: "ASK_BTW", question },
+    };
+  }
+
+  if (contentWithPlaceholders === "/btw") {
+    // Bare /btw — ignore
+    return null;
+  }
+
+  // Check if the content is a CLI-internal slash command (help, tasks,
+  // etc.) that should be executed locally rather than sent as a message.
+  // Agent slash commands and unknown /commands always go to SEND_MESSAGE.
+  if (contentWithPlaceholders.startsWith("/")) {
+    const spaceIndex = contentWithPlaceholders.indexOf(" ");
+    const commandName =
+      spaceIndex === -1
+        ? contentWithPlaceholders.substring(1)
+        : contentWithPlaceholders.substring(1, spaceIndex);
+
+    const isInternalCommand = AVAILABLE_COMMANDS.some(
+      (cmd) => cmd.id === commandName,
+    );
+    if (isInternalCommand) {
+      const argsText =
+        spaceIndex === -1
+          ? undefined
+          : contentWithPlaceholders.substring(spaceIndex + 1).trim() ||
+            undefined;
+      return {
+        ...state,
+        inputText: "",
+        cursorPosition: 0,
+        historyIndex: -1,
+        longTextMap: {},
+        attachedImages: [],
+        pendingEffect: {
+          type: "EXECUTE_COMMAND",
+          command: commandName,
+          args: argsText,
+        },
+      };
+    }
+  }
+
+  return {
+    ...state,
+    inputText: "",
+    cursorPosition: 0,
+    historyIndex: -1,
+    longTextMap: {},
+    attachedImages: [],
+    pendingEffect: {
+      type: "SEND_MESSAGE",
+      content: contentWithPlaceholders,
+      images: referencedImages.length > 0 ? referencedImages : undefined,
+      longTextMap: state.longTextMap,
+    },
+  };
+}
 
 export type InputAction =
   | { type: "SET_INPUT_TEXT"; payload: string }
@@ -215,13 +375,6 @@ export type InputAction =
   | { type: "INSERT_TEXT_WITH_PLACEHOLDER"; payload: string }
   | { type: "CLEAR_LONG_TEXT_MAP" }
   | { type: "CLEAR_INPUT" }
-  | { type: "START_PASTE"; payload: { buffer: string; cursorPosition: number } }
-  | { type: "APPEND_PASTE_BUFFER"; payload: string }
-  | {
-      type: "APPEND_PASTE_CHUNK";
-      payload: { chunk: string; cursorPosition: number };
-    }
-  | { type: "END_PASTE" }
   | {
       type: "ADD_IMAGE_AND_INSERT_PLACEHOLDER";
       payload: { path: string; mimeType: string };
@@ -445,60 +598,8 @@ export function inputReducer(
       return { ...state, permissionMode: action.payload };
     case "SET_SELECTOR_JUST_USED":
       return { ...state, selectorJustUsed: action.payload };
-    case "INSERT_TEXT_WITH_PLACEHOLDER": {
-      let textToInsert = action.payload;
-      let newLongTextCounter = state.longTextCounter;
-      const newLongTextMap = { ...state.longTextMap };
-
-      if (textToInsert.length > 200) {
-        newLongTextCounter += 1;
-        const placeholderLabel = `[LongText#${newLongTextCounter}]`;
-        newLongTextMap[placeholderLabel] = textToInsert;
-        textToInsert = placeholderLabel;
-      }
-
-      const beforeCursor = state.inputText.substring(0, state.cursorPosition);
-      const afterCursor = state.inputText.substring(state.cursorPosition);
-      const newText = beforeCursor + textToInsert + afterCursor;
-      const newCursorPosition = state.cursorPosition + textToInsert.length;
-
-      const newState: InputState = {
-        ...state,
-        inputText: newText,
-        cursorPosition: newCursorPosition,
-        longTextCounter: newLongTextCounter,
-        longTextMap: newLongTextMap,
-        historyIndex: -1,
-      };
-
-      // Sync selectors
-      const atPos = getAtSelectorPosition(newText, newCursorPosition);
-      if (atPos !== -1 && !newState.showFileSelector) {
-        newState.showFileSelector = true;
-        newState.atPosition = atPos;
-        newState.isFileSearching = true;
-      }
-
-      const slashPos = getSlashSelectorPosition(newText, newCursorPosition);
-      if (slashPos !== -1 && !newState.showCommandSelector) {
-        newState.showCommandSelector = true;
-        newState.slashPosition = slashPos;
-      }
-
-      if (newState.showFileSelector && newState.atPosition >= 0) {
-        newState.fileSearchQuery = newText.substring(
-          newState.atPosition + 1,
-          newCursorPosition,
-        );
-      } else if (newState.showCommandSelector && newState.slashPosition >= 0) {
-        newState.commandSearchQuery = newText.substring(
-          newState.slashPosition + 1,
-          newCursorPosition,
-        );
-      }
-
-      return newState;
-    }
+    case "INSERT_TEXT_WITH_PLACEHOLDER":
+      return insertTextWithPlaceholder(action.payload, state);
     case "CLEAR_LONG_TEXT_MAP":
       return { ...state, longTextMap: {} };
     case "CLEAR_INPUT":
@@ -507,39 +608,6 @@ export function inputReducer(
         inputText: "",
         cursorPosition: 0,
         historyIndex: -1,
-      };
-    case "APPEND_PASTE_CHUNK": {
-      // The reducer determines if this is a new paste or a continuation
-      // by checking if pasteBuffer is already set. This avoids the
-      // handler needing to track isPasting state, which can be stale
-      // when multiple dispatches fire before React state updates.
-      const isNewPaste = !state.pasteBuffer;
-      return {
-        ...state,
-        isPasting: true,
-        pasteBuffer: state.pasteBuffer + action.payload.chunk,
-        initialPasteCursorPosition: isNewPaste
-          ? action.payload.cursorPosition
-          : state.initialPasteCursorPosition,
-      };
-    }
-    case "START_PASTE":
-      return {
-        ...state,
-        isPasting: true,
-        pasteBuffer: action.payload.buffer,
-        initialPasteCursorPosition: action.payload.cursorPosition,
-      };
-    case "APPEND_PASTE_BUFFER":
-      return {
-        ...state,
-        pasteBuffer: state.pasteBuffer + action.payload,
-      };
-    case "END_PASTE":
-      return {
-        ...state,
-        isPasting: false,
-        pasteBuffer: "",
       };
     case "ADD_IMAGE_AND_INSERT_PLACEHOLDER": {
       const newImage: AttachedImage = {
@@ -1166,101 +1234,7 @@ export function inputReducer(
 
       // 6. Return / Submit
       if (key.return) {
-        if (state.inputText.trim()) {
-          const imageRegex = /\[Image #(\d+)\]/g;
-          const matches = [...state.inputText.matchAll(imageRegex)];
-          const referencedImages = matches
-            .map((match) => {
-              const imageId = parseInt(match[1], 10);
-              return state.attachedImages.find((img) => img.id === imageId);
-            })
-            .filter((img): img is AttachedImage => img !== undefined)
-            .map((img) => ({ path: img.path, mimeType: img.mimeType }));
-
-          const contentWithPlaceholders = state.inputText
-            .replace(imageRegex, "")
-            .trim();
-
-          if (contentWithPlaceholders.startsWith("/btw ")) {
-            const question = contentWithPlaceholders.substring(5).trim();
-            if (!question) {
-              // Bare /btw with no question text — ignore
-              return state;
-            }
-
-            return {
-              ...state,
-              inputText: "",
-              cursorPosition: 0,
-              historyIndex: -1,
-              longTextMap: {},
-              attachedImages: [],
-              btwState: {
-                question,
-                isLoading: true,
-                answer: undefined,
-              },
-              pendingEffect: { type: "ASK_BTW", question },
-            };
-          }
-
-          if (contentWithPlaceholders === "/btw") {
-            // Bare /btw — ignore
-            return state;
-          }
-
-          // Check if the content is a CLI-internal slash command (help, tasks,
-          // etc.) that should be executed locally rather than sent as a message.
-          // Agent slash commands and unknown /commands always go to SEND_MESSAGE.
-          if (contentWithPlaceholders.startsWith("/")) {
-            const spaceIndex = contentWithPlaceholders.indexOf(" ");
-            const commandName =
-              spaceIndex === -1
-                ? contentWithPlaceholders.substring(1)
-                : contentWithPlaceholders.substring(1, spaceIndex);
-
-            const isInternalCommand = AVAILABLE_COMMANDS.some(
-              (cmd) => cmd.id === commandName,
-            );
-            if (isInternalCommand) {
-              const argsText =
-                spaceIndex === -1
-                  ? undefined
-                  : contentWithPlaceholders.substring(spaceIndex + 1).trim() ||
-                    undefined;
-              return {
-                ...state,
-                inputText: "",
-                cursorPosition: 0,
-                historyIndex: -1,
-                longTextMap: {},
-                attachedImages: [],
-                pendingEffect: {
-                  type: "EXECUTE_COMMAND",
-                  command: commandName,
-                  args: argsText,
-                },
-              };
-            }
-          }
-
-          return {
-            ...state,
-            inputText: "",
-            cursorPosition: 0,
-            historyIndex: -1,
-            longTextMap: {},
-            attachedImages: [],
-            pendingEffect: {
-              type: "SEND_MESSAGE",
-              content: contentWithPlaceholders,
-              images:
-                referencedImages.length > 0 ? referencedImages : undefined,
-              longTextMap: state.longTextMap,
-            },
-          };
-        }
-        return state;
+        return submitInput(state) ?? state;
       }
 
       // 7. Regular Input
@@ -1276,19 +1250,32 @@ export function inputReducer(
         !("home" in key && key.home) &&
         !("end" in key && key.end)
       ) {
-        const isPasteOperation =
-          input.length > 1 || input.includes("\n") || input.includes("\r");
+        // SSH-coalesced Enter: on slow links, "text" + Enter arrive as one
+        // chunk ("o\r"). ink's parseKeypress only matches a lone \r, so
+        // key.return is false here. Text with exactly one trailing \r is a
+        // coalesced Enter — strip the \r, insert, and submit immediately
+        // (aligned with Claude Code's useTextInput).
+        const isCoalescedEnter =
+          input.length > 1 &&
+          input.endsWith("\r") &&
+          !input.slice(0, -1).includes("\r") &&
+          // Backslash+CR is a stale VS Code Shift+Enter binding, not a
+          // coalesced Enter — keep it as regular input.
+          input[input.length - 2] !== "\\";
 
-        if (isPasteOperation) {
-          const isNewPaste = !state.pasteBuffer;
-          return {
-            ...state,
-            isPasting: true,
-            pasteBuffer: state.pasteBuffer + input,
-            initialPasteCursorPosition: isNewPaste
-              ? state.cursorPosition
-              : state.initialPasteCursorPosition,
-          };
+        if (isCoalescedEnter) {
+          const insertedState = insertTextWithPlaceholder(
+            input.slice(0, -1),
+            state,
+          );
+          return submitInput(insertedState) ?? insertedState;
+        }
+
+        if (input.length > 1) {
+          // Multi-char chunk (typed burst, terminal paste, tmux send-keys):
+          // insert immediately — no debounce or paste buffer. \r → \n
+          // normalizes carriage returns from CRLF terminals.
+          return insertTextWithPlaceholder(input.replace(/\r/g, "\n"), state);
         } else {
           let char = input;
           if (char === "！" && state.cursorPosition === 0) {

--- a/packages/code/tests/managers/inputHandlers.test.ts
+++ b/packages/code/tests/managers/inputHandlers.test.ts
@@ -439,39 +439,40 @@ describe("inputHandlers", () => {
   });
 
   describe("handlePasteInput", () => {
-    it("should dispatch APPEND_PASTE_CHUNK for multi-char input", () => {
+    it("should insert multi-char input immediately", () => {
       const state = { ...initialState, cursorPosition: 0 };
       handlePasteInput(state, dispatch, callbacks, "pasted text");
       expect(dispatch).toHaveBeenCalledWith({
-        type: "APPEND_PASTE_CHUNK",
-        payload: { chunk: "pasted text", cursorPosition: 0 },
+        type: "INSERT_TEXT_WITH_PLACEHOLDER",
+        payload: "pasted text",
       });
     });
 
-    it("should dispatch APPEND_PASTE_CHUNK regardless of isPasting state", () => {
-      const state = { ...initialState, isPasting: true, cursorPosition: 5 };
-      handlePasteInput(state, dispatch, callbacks, "more text");
+    it("should insert long input immediately (reducer folds into LongText)", () => {
+      const state = { ...initialState, cursorPosition: 5 };
+      const longText = "a".repeat(801);
+      handlePasteInput(state, dispatch, callbacks, longText);
       expect(dispatch).toHaveBeenCalledWith({
-        type: "APPEND_PASTE_CHUNK",
-        payload: { chunk: "more text", cursorPosition: 5 },
+        type: "INSERT_TEXT_WITH_PLACEHOLDER",
+        payload: longText,
       });
     });
 
-    it("should handle paste with newline in single-char-like input", () => {
-      const state = { ...initialState, isPasting: false, cursorPosition: 0 };
+    it("should insert multi-line input with newline", () => {
+      const state = { ...initialState, cursorPosition: 0 };
       handlePasteInput(state, dispatch, callbacks, "a\nb");
       expect(dispatch).toHaveBeenCalledWith({
-        type: "APPEND_PASTE_CHUNK",
-        payload: { chunk: "a\nb", cursorPosition: 0 },
+        type: "INSERT_TEXT_WITH_PLACEHOLDER",
+        payload: "a\nb",
       });
     });
 
-    it("should handle paste with carriage return", () => {
-      const state = { ...initialState, isPasting: false, cursorPosition: 0 };
+    it("should convert carriage returns to newlines", () => {
+      const state = { ...initialState, cursorPosition: 0 };
       handlePasteInput(state, dispatch, callbacks, "a\rb");
       expect(dispatch).toHaveBeenCalledWith({
-        type: "APPEND_PASTE_CHUNK",
-        payload: { chunk: "a\rb", cursorPosition: 0 },
+        type: "INSERT_TEXT_WITH_PLACEHOLDER",
+        payload: "a\nb",
       });
     });
 

--- a/packages/code/tests/managers/inputReducer.test.ts
+++ b/packages/code/tests/managers/inputReducer.test.ts
@@ -36,9 +36,6 @@ describe("inputReducer", () => {
       showModelSelector: false,
       permissionMode: "default",
       selectorJustUsed: false,
-      isPasting: false,
-      pasteBuffer: "",
-      initialPasteCursorPosition: 0,
       history: [],
       historyIndex: -1,
       originalInputText: "",
@@ -482,82 +479,6 @@ describe("inputReducer", () => {
     const state = inputReducer(stateWithInput, { type: "CLEAR_INPUT" });
     expect(state.inputText).toBe("");
     expect(state.cursorPosition).toBe(0);
-  });
-
-  it("should handle START_PASTE, APPEND_PASTE_BUFFER, END_PASTE", () => {
-    let state = inputReducer(initialState, {
-      type: "START_PASTE",
-      payload: { buffer: "start", cursorPosition: 0 },
-    });
-    expect(state.isPasting).toBe(true);
-    expect(state.pasteBuffer).toBe("start");
-    expect(state.initialPasteCursorPosition).toBe(0);
-
-    state = inputReducer(state, {
-      type: "APPEND_PASTE_BUFFER",
-      payload: " more",
-    });
-    expect(state.pasteBuffer).toBe("start more");
-
-    state = inputReducer(state, { type: "END_PASTE" });
-    expect(state.isPasting).toBe(false);
-    expect(state.pasteBuffer).toBe("");
-  });
-
-  it("should handle APPEND_PASTE_CHUNK as new paste when buffer is empty", () => {
-    const state = inputReducer(initialState, {
-      type: "APPEND_PASTE_CHUNK",
-      payload: { chunk: "first chunk", cursorPosition: 3 },
-    });
-    expect(state.isPasting).toBe(true);
-    expect(state.pasteBuffer).toBe("first chunk");
-    expect(state.initialPasteCursorPosition).toBe(3);
-  });
-
-  it("should handle APPEND_PASTE_CHUNK as append when buffer is already set", () => {
-    let state = inputReducer(initialState, {
-      type: "APPEND_PASTE_CHUNK",
-      payload: { chunk: "first", cursorPosition: 0 },
-    });
-    state = inputReducer(state, {
-      type: "APPEND_PASTE_CHUNK",
-      payload: { chunk: "second", cursorPosition: 0 },
-    });
-    state = inputReducer(state, {
-      type: "APPEND_PASTE_CHUNK",
-      payload: { chunk: "third", cursorPosition: 5 },
-    });
-
-    expect(state.pasteBuffer).toBe("firstsecondthird");
-    expect(state.initialPasteCursorPosition).toBe(0); // preserved from first chunk
-  });
-
-  it("should accumulate paste chunks through rapid sequential dispatches", () => {
-    let state = inputReducer(initialState, {
-      type: "APPEND_PASTE_CHUNK",
-      payload: { chunk: "chunk1", cursorPosition: 0 },
-    });
-    state = inputReducer(state, {
-      type: "APPEND_PASTE_CHUNK",
-      payload: { chunk: "chunk2", cursorPosition: 0 },
-    });
-    state = inputReducer(state, {
-      type: "APPEND_PASTE_CHUNK",
-      payload: { chunk: "chunk3", cursorPosition: 0 },
-    });
-
-    expect(state.pasteBuffer).toBe("chunk1chunk2chunk3");
-    expect(state.isPasting).toBe(true);
-  });
-
-  it("should handle END_PASTE after APPEND_PASTE_CHUNK", () => {
-    let state = inputReducer(initialState, {
-      type: "APPEND_PASTE_CHUNK",
-      payload: { chunk: "pasted text", cursorPosition: 0 },
-    });
-    state = inputReducer(state, { type: "END_PASTE" });
-    expect(state.isPasting).toBe(false);
-    expect(state.pasteBuffer).toBe("");
   });
 
   it("should handle ADD_IMAGE_AND_INSERT_PLACEHOLDER", () => {
@@ -1026,7 +947,6 @@ describe("inputReducer", () => {
         });
         expect(result.inputText).toBe("a");
         expect(result.cursorPosition).toBe(1);
-        expect(result.isPasting).toBe(false);
       });
 
       it("should ignore DEL bytes when cursor is at start", () => {
@@ -1464,7 +1384,7 @@ describe("inputReducer", () => {
       });
     });
 
-    it("should handle paste operation in HANDLE_KEY", () => {
+    it("should insert short multi-char chunk immediately", () => {
       const result = inputReducer(initialState, {
         type: "HANDLE_KEY",
         payload: {
@@ -1473,8 +1393,69 @@ describe("inputReducer", () => {
           hasSlashCommand: () => false,
         },
       });
-      expect(result.isPasting).toBe(true);
-      expect(result.pasteBuffer).toBe("pasted text");
+      expect(result.inputText).toBe("pasted text");
+      expect(result.cursorPosition).toBe("pasted text".length);
+    });
+
+    it("should insert long chunk immediately, folded into LongText placeholder", () => {
+      const longText = "a".repeat(801);
+      const result = inputReducer(initialState, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: longText,
+          key: {} as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+      expect(result.inputText).toBe("[LongText#1]");
+      expect(result.longTextMap["[LongText#1]"]).toBe(longText);
+      expect(result.cursorPosition).toBe("[LongText#1]".length);
+    });
+
+    it("should insert chunk with newline immediately", () => {
+      const result = inputReducer(initialState, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "line1\nline2",
+          key: {} as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+      expect(result.inputText).toBe("line1\nline2");
+      expect(result.pendingEffect).toBeNull();
+    });
+
+    it("should submit on SSH-coalesced Enter chunk (text + \\r)", () => {
+      const result = inputReducer(initialState, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "hello\r",
+          key: {} as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+      expect(result.inputText).toBe("");
+      expect(result.pendingEffect).toEqual({
+        type: "SEND_MESSAGE",
+        content: "hello",
+        images: undefined,
+        longTextMap: {},
+      });
+    });
+
+    it("should not treat backslash + \\r as coalesced Enter", () => {
+      const result = inputReducer(initialState, {
+        type: "HANDLE_KEY",
+        payload: {
+          input: "\\\r",
+          key: {} as unknown as Key,
+          hasSlashCommand: () => false,
+        },
+      });
+      // Not a coalesced Enter — falls through to the multi-char insert,
+      // where the trailing \r becomes \n.
+      expect(result.inputText).toBe("\\\n");
+      expect(result.pendingEffect).toBeNull();
     });
 
     it("should handle ！ character at start of input", () => {

--- a/packages/code/vitest.config.ts
+++ b/packages/code/vitest.config.ts
@@ -35,7 +35,6 @@ export default defineConfig(() => {
         DISABLE_LOGGER_IO: "true",
         // Set shorter debounce time to accelerate tests
         FILE_SELECTOR_DEBOUNCE_MS: "0",
-        PASTE_DEBOUNCE_MS: "0",
         WAVE_API_KEY: "test-token",
         WAVE_BASE_URL: "http://localhost:8080",
         WAVE_MODEL: "test-model",


### PR DESCRIPTION
## Problem

Sending a message to the Wave CLI via `tmux send-keys "text" Enter` often required a **second** Enter to submit. Root cause (research confirmed against Claude Code's `useTextInput.ts`):

- ink delivers a stdin data-event chunk to `useInput`; `parseKeypress` only maps a **lone** `\r` to `key.return`, so multi-char chunks never look like Enter.
- Wave's `isPasteOperation = input.length > 1 || \n || \r` routed every multi-char chunk to a `pasteBuffer`, deferred 30ms by `PASTE_DEBOUNCE_MS`.
- tmux/SSH send-keys: `"text"` chunk → buffered (insert deferred 30ms); `Enter` chunk arrives before the debounce commits → empty input → Enter dropped. On slow links `"text\r"` arrives as one chunk that ink can't parse as return either.

## Fix (aligned with Claude Code)

- **Multi-char chunks insert immediately** via `INSERT_TEXT_WITH_PLACEHOLDER` (`\r → \n`), no debounce, no paste buffer. >200-char chunks fold into `[LongText#N]` as before.
- **Coalesced Enter**: a chunk ending in exactly one `\r` (no other `\r`, no backslash prefix — that's a stale VS Code Shift+Enter binding) is treated as text + Enter: strip `\r`, insert, submit immediately (mirrors CC `useTextInput.ts` coalesced-Enter condition).
- **Enter** with pending text submits directly.

## Simplification (breaking change, per request)

Deleted the entire paste-buffer machinery:
- `isPasting` / `pasteBuffer` / `initialPasteCursorPosition` state fields
- `START_PASTE` / `APPEND_PASTE_BUFFER` / `APPEND_PASTE_CHUNK` / `END_PASTE` actions + reducer cases
- the 30ms debounce effect in `useInputManager.ts`
- `PASTE_DEBOUNCE_MS` env var
- `PASTE_THRESHOLD` (no longer needed — all multi-char chunks insert directly)

Behavior trade-off: a large paste split across chunks now folds into one `[LongText#N]` per chunk (cosmetic; content identical on submit).

## Verification

- `pnpm test` (packages/code): 84 files / 1157 tests pass
- `pnpm run type-check` (all packages): clean
- prettier + eslint on changed files: clean
- New tests cover: short multi-char direct insert, long-chunk LongText folding, newline chunk insert, `\r→\n` conversion, coalesced `"hello\r"` submit, backslash+`\r` excluded from coalesced path