### PR TITLE
fix(vsce): restart agents when toggling project-level builtin plugins

### DIFF
--- a/packages/vsce/src/session/messageHandler.ts
+++ b/packages/vsce/src/session/messageHandler.ts
@@ -398,6 +398,10 @@ export class MessageHandler {
         try {
             const result = await this.pluginService.setBuiltinPluginEnabled(pluginId, enabled, scope as Scope);
             this.context.postMessage({ command: 'projectSettings', enabledPlugins: result.enabledPlugins }, viewType, windowId);
+
+            // Reload config and recreate agents to apply plugin changes
+            const config = await this.configService.loadConfiguration();
+            this.context.updateAllSessionsConfig(config);
         } catch (error) {
             vscode.window.showErrorMessage('修改项目设置失败: ' + error);
         }

--- a/packages/vsce/tests/session/messageHandler.test.ts
+++ b/packages/vsce/tests/session/messageHandler.test.ts
@@ -263,4 +263,44 @@ describe('MessageHandler MCP handlers', () => {
         expect(compact).toBeDefined();
         expect(compact?.name).toBe('compact');
     });
+
+    // Toggling a project-level builtin plugin (e.g. sdd@builtin) must recreate
+    // agents — same as handleEnablePlugin — so the change takes effect, not just
+    // refresh the projectSettings panel.
+    test('setBuiltinPluginEnabled reloads config and recreates agents on success', async () => {
+        const configService = {
+            loadConfiguration: vi.fn().mockResolvedValue({ serverUrl: '', language: 'Chinese' }),
+            saveConfiguration: vi.fn(),
+        };
+        const pluginService = {
+            setBuiltinPluginEnabled: vi.fn().mockResolvedValue({ enabledPlugins: { 'sdd@builtin': true } }),
+        };
+        const context: MessageHandlerContext = {
+            getChatSession: vi.fn().mockReturnValue(createMockSession()),
+            postMessage: vi.fn(),
+            initializeAgent: vi.fn(),
+            listSessions: vi.fn(),
+            updateAllSessionsConfig: vi.fn(),
+            checkForUpdates: vi.fn(),
+            getVersion: vi.fn().mockReturnValue('1.2.3'),
+        };
+        const handler = new MessageHandler(
+            configService as unknown as ConfigurationService,
+            {} as unknown as FileService,
+            {} as unknown as SessionService,
+            pluginService as unknown as PluginService,
+            {} as unknown as StdioClient,
+            context
+        );
+
+        await handler.handleMessage({ command: 'setBuiltinPluginEnabled', pluginId: 'sdd@builtin', enabled: true, scope: 'project' }, 'tab');
+
+        expect(pluginService.setBuiltinPluginEnabled).toHaveBeenCalledWith('sdd@builtin', true, 'project');
+        expect(configService.loadConfiguration).toHaveBeenCalled();
+        expect(context.updateAllSessionsConfig).toHaveBeenCalledWith({ serverUrl: '', language: 'Chinese' });
+
+        const posted = (context.postMessage as ReturnType<typeof vi.fn>).mock.calls[0][0] as { command: string; enabledPlugins: Record<string, boolean> };
+        expect(posted.command).toBe('projectSettings');
+        expect(posted.enabledPlugins).toEqual({ 'sdd@builtin': true });
+    });
 });


### PR DESCRIPTION
## Summary

`handleSetBuiltinPluginEnabled` previously only refreshed the projectSettings panel via postMessage — toggling a project-level builtin plugin (e.g. `sdd@builtin`) did not take effect until a manual reload.

Align with the existing `handleEnablePlugin`/`handleDisablePlugin` pattern: after a successful toggle, reload configuration and call `updateAllSessionsConfig` so all sessions recreate their agents with the new plugin state.

## Changes

- `packages/vsce/src/session/messageHandler.ts`: `handleSetBuiltinPluginEnabled` now calls `configService.loadConfiguration()` + `context.updateAllSessionsConfig(config)` after success
- `packages/vsce/tests/session/messageHandler.test.ts`: regression test asserting config reload + `updateAllSessionsConfig` receive the reloaded config, and projectSettings is still posted

## Verification

- `pnpm test tests/session/messageHandler.test.ts` — 12/12 pass
- `pnpm run compile` — clean
- `pnpm run type-check` — clean