### PR TITLE
fix(desktop): await stdio client before first git-branch query on fresh launch

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -1501,6 +1501,12 @@ export class DesktopHost {
   private async handleListGitBranches(workdir: string, paneId?: string): Promise<void> {
     const h = this.hostForPane(paneId);
     try {
+      // A fresh launch's first query (webview mount) can land before
+      // webviewReady has spawned the stdio client. Await the client instead of
+      // replying null — the webview never re-queries on a null reply, which
+      // would leave the branch/worktree controls hidden until the user
+      // re-picks a workdir.
+      await this.ensureClientFor(h);
       const result = await this.utilityClientFor(h).request('listGitBranches', { workdir });
       this.postMessage({ command: 'desktopGitBranches', workdir, paneId, result });
     } catch {

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -1259,6 +1259,22 @@ describe('worktree flow', () => {
     expect(msg).toMatchObject({ workdir: '/work/a', result: null });
   });
 
+  it('desktopListGitBranches arriving before the stdio client is ready waits for init instead of replying null', async () => {
+    // Fresh-launch sequence: the webview's branch query (mount effect) lands
+    // before webviewReady has spawned the stdio client. It must await the
+    // client init, otherwise the reply is null and the webview never re-queries
+    // — the branch/worktree controls stay hidden until the user re-picks a
+    // workdir.
+    const { host, sent } = createHost();
+    h.branchesResult = { branches: ['main', 'dev'], current: 'main' };
+
+    await host.handleWebviewMessage({ command: 'desktopReady' });
+    await host.handleWebviewMessage({ command: 'desktopListGitBranches', workdir: '/work/a' });
+
+    const msg = sent('desktopGitBranches').at(-1);
+    expect(msg).toMatchObject({ workdir: '/work/a', result: { branches: ['main', 'dev'], current: 'main' } });
+  });
+
   it('desktopCreateWorktree switches workdir into the worktree', async () => {
     const { host, store, sent } = await readyHost();
     h.worktreeResult = worktree;


### PR DESCRIPTION
## 问题

桌面端刚启动进入新对话（无任何会话）时，只显示上次的 workdir，branch 选择器和 worktree 开关不显示；再次选择一个 workdir 后才出现。

## 根因

webview 挂载时先发 desktopListGitBranches（其 effect 声明在 webviewReady 之前），而主进程此时尚未初始化 stdio client（this.client 为 null，需等 handleWebviewReady -> ensureClientFor 完成）。首次查询在 clientFor() 抛 StdioClient not initialized，被 handleListGitBranches 的 catch 吞掉并回 result: null。webview 将 paneGitBranches 置空后控件隐藏，且 effectiveWorkdir 不变不再重查，直到用户重新选择 workdir 触发新查询。

## 修复

handleListGitBranches 在请求前 await ensureClientFor(host)，首次查询等待 client 就绪而非失败返回 null（远程 host 同样生效）。

## 验证

- 新增回归测试：模拟 fresh-launch 顺序（desktopReady 后直接 desktopListGitBranches，client 未初始化），断言返回分支列表；修复前失败（result null），修复后通过
- desktop 全量套件 316/316 通过
- type-check + lint 通过