### PR TITLE
docs: 规格侧边栏按 order 排序，与 index 表格顺序一致

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { SPEC_GROUPS, SPECS_DIR, specTitle } from './spec-stats.mjs';
+import { SPECS_DIR, specTitle, collectSpecs } from './spec-stats.mjs';
 
 const nav = [
   { text: '首页', link: '/' },
@@ -12,21 +12,18 @@ const nav = [
   { text: '规格说明', link: '/specs/' },
 ];
 
-// specs sidebar: generated from docs/specs/<group>/*.md
-const specsSidebar = SPEC_GROUPS.map(({ dir, text }) => ({
+// specs sidebar: generated from docs/specs/<group>/*.md, ordered the same as
+// the index table (frontmatter `order`, then path) — see spec-stats.mjs
+const specsSidebar = collectSpecs().groups.map(({ dir, text, specs }) => ({
   text,
   collapsed: true,
-  items: fs
-    .readdirSync(path.join(SPECS_DIR, dir))
-    .filter((f) => f.endsWith('.md'))
-    .sort()
-    .map((f) => ({
-      text: specTitle(
-        fs.readFileSync(path.join(SPECS_DIR, dir, f), 'utf-8'),
-        f.replace(/\.md$/, ''),
-      ),
-      link: `/specs/${dir}/${f.replace(/\.md$/, '')}`,
-    })),
+  items: specs.map(({ path: rel }) => ({
+    text: specTitle(
+      fs.readFileSync(path.join(SPECS_DIR, rel), 'utf-8'),
+      rel.replace(/.*\//, '').replace(/\.md$/, ''),
+    ),
+    link: `/specs/${rel.replace(/\.md$/, '')}`,
+  })),
 }));
 
 export default {


### PR DESCRIPTION
修复规格文档侧边栏顺序与 index 表格不一致的问题。

根因：docs/specs/index.md 的规格表格按 frontmatter order 排序（spec-stats.mjs 的 collectSpecs()），而侧边栏此前按文件名字母序排序（.sort()），两处顺序不一致。

改动：docs/.vitepress/config.js 的侧边栏改用 collectSpecs() 生成的同一份有序列表，与表格共享单一排序数据源（order → 路径）。验证：导入 config.js 生成侧边栏并与表格逐组比对，6 组全部一致。