### PR TITLE
fix: workflowManager flaky 测试改用 vi.waitFor，消除固定延时竞态

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { SPEC_GROUPS, SPECS_DIR, specTitle } from './spec-stats.mjs';
+import { SPECS_DIR, specTitle, collectSpecs } from './spec-stats.mjs';
 
 const nav = [
   { text: '首页', link: '/' },
@@ -12,21 +12,18 @@ const nav = [
   { text: '规格说明', link: '/specs/' },
 ];
 
-// specs sidebar: generated from docs/specs/<group>/*.md
-const specsSidebar = SPEC_GROUPS.map(({ dir, text }) => ({
+// specs sidebar: generated from docs/specs/<group>/*.md, ordered the same as
+// the index table (frontmatter `order`, then path) — see spec-stats.mjs
+const specsSidebar = collectSpecs().groups.map(({ dir, text, specs }) => ({
   text,
   collapsed: true,
-  items: fs
-    .readdirSync(path.join(SPECS_DIR, dir))
-    .filter((f) => f.endsWith('.md'))
-    .sort()
-    .map((f) => ({
-      text: specTitle(
-        fs.readFileSync(path.join(SPECS_DIR, dir, f), 'utf-8'),
-        f.replace(/\.md$/, ''),
-      ),
-      link: `/specs/${dir}/${f.replace(/\.md$/, '')}`,
-    })),
+  items: specs.map(({ path: rel }) => ({
+    text: specTitle(
+      fs.readFileSync(path.join(SPECS_DIR, rel), 'utf-8'),
+      rel.replace(/.*\//, '').replace(/\.md$/, ''),
+    ),
+    link: `/specs/${rel.replace(/\.md$/, '')}`,
+  })),
 }));
 
 export default {

--- a/packages/agent-sdk/tests/workflow/workflowManager.test.ts
+++ b/packages/agent-sdk/tests/workflow/workflowManager.test.ts
@@ -456,8 +456,11 @@ describe("WorkflowManager", () => {
       const run = await progressManager.createRun(script);
       await progressManager.startRun(run.runId);
 
-      // Let the event loop turn so scan agents start and emit agent_started.
-      await new Promise((r) => setTimeout(r, 20));
+      // Wait until the scan agents have started (agent_started events
+      // propagate asynchronously; polling beats a fixed sleep on slow CI).
+      await vi.waitFor(() => {
+        expect(progressManager.getRun(run.runId)!.totalAgents).toBe(2);
+      });
 
       // --- MID-RUN snapshot: scan agents started, not yet completed ---
       const midRun = progressManager.getRun(run.runId)!;
@@ -470,9 +473,15 @@ describe("WorkflowManager", () => {
       // notifyTasksChange fired for the phase/agent_started events.
       expect(notifyTasksChange).toHaveBeenCalled();
 
-      // Release scan agents -> they complete and Synthesize starts.
+      // Release scan agents -> they complete and Synthesize starts. Wait
+      // until the synth agent has started and scan tokens are counted.
       resolveScan();
-      await new Promise((r) => setTimeout(r, 20));
+      await vi.waitFor(() => {
+        const r = progressManager.getRun(run.runId)!;
+        expect(r.totalAgents).toBe(3);
+        expect(r.totalTokens).toBe(2468); // 2 scan agents * 1234 tokens
+        expect(r.phases[1].agentCount).toBe(1); // synth agent started
+      });
 
       // --- After scan completes, before synth completes ---
       const afterScan = progressManager.getRun(run.runId)!;


### PR DESCRIPTION
修复 check (22) CI 偶发失败（此前被误判为静默 flaky）的真实根因。

根因：tests/workflow/workflowManager.test.ts 的 live progress updates 测试用固定 await new Promise(setTimeout(r, 20)) 等待进度事件跨异步链传播（script 执行 → phase() → parallel() → agent() → executeAgent → agentStarted() → emit → listener 更新 run.totalAgents）。CI 慢负载下 20ms 不够，synth agent 的 agent_started 尚未到达，断言 afterScan.totalAgents === 3 收到 2（AssertionError: expected 2 to be 3，workflowManager.test.ts:480）。

修复：两处固定 20ms 延时替换为 vi.waitFor 轮询（符合 .wave/rules/testing.md 规范）：
- midRun 前：等 totalAgents === 2（scan agents 启动）
- afterScan 前（resolveScan 后）：等 totalAgents === 3 且 totalTokens === 2468 且 phases[1].agentCount === 1

验证：单文件 27 测试通过；该测试循环 10/10 通过；agent-sdk type-check 通过。

附带流程教训（已更新项目记忆）：gh run view --log-failed 只输出失败步骤日志尾部，会漏掉真实 FAIL；须用 gh api repos/<owner>/<repo>/actions/jobs/<jobId>/logs 拉完整日志再 grep FAIL。