### PR TITLE
fix(desktop): 正在运行的远程会话切换不被 workflow-runs RPC 阻塞

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -675,7 +675,12 @@ export class DesktopHost {
     // Panel groups follow the session, so the outgoing session's PTY dies with
     // the switch — the webview respawns one when the incoming session's group
     // has the terminal checked. A same-agent rebind keeps it alive.
-    if (pane.agent !== agent) this.terminalManager.killForPane(paneId);
+    if (pane.agent !== agent) {
+      this.terminalManager.killForPane(paneId);
+      // The cached workflow runs belong to the outgoing session — drop them so
+      // the incoming session never flashes a stale list.
+      this.workflowRuns.delete(paneId);
+    }
     this.clearThrottleState(paneId);
     pane.agent = agent;
     this.focusedPaneId = paneId;
@@ -1332,14 +1337,17 @@ export class DesktopHost {
   private async pushPaneSessionState(paneId: string): Promise<void> {
     const configurationData = this.configStore.getConfiguration();
     const agent = this.agentForPane(paneId);
+    // Workflow runs refresh in the background — a live remote session's RPC
+    // round trip (SSH hop) must not delay the session switch. The cache shows
+    // immediately; refreshWorkflowRuns supersedes it when the response lands.
     if (agent) {
-      const runs = await agent.getWorkflowRuns().catch(() => this.workflowRuns.get(paneId) ?? []);
-      this.workflowRuns.set(paneId, runs);
+      void this.refreshWorkflowRuns(paneId).catch(() => {});
     }
-    // The pane binding may have changed while getWorkflowRuns was in flight (a
-    // restore completed / a new session selected). Re-read everything at send
-    // time so the pushed message is self-consistent; the pending entry is also
-    // resolved here so a stale overlay can never clobber a completed restore.
+    // The pane binding may have changed while a workflow-runs refresh was in
+    // flight (a restore completed / a new session selected). Re-read everything
+    // at send time so the pushed message is self-consistent; the pending entry
+    // is also resolved here so a stale overlay can never clobber a completed
+    // restore.
     const current = this.agentForPane(paneId);
     const pending = this.pendingRestores.get(paneId);
     const pendingConfirmations = Array.from(this.pendingConfirmations.entries())
@@ -1662,6 +1670,9 @@ export class DesktopHost {
     const agent = this.agentForPane(paneId);
     if (!agent) return;
     const runs = await agent.getWorkflowRuns();
+    // The pane may have switched to another session while the RPC was in
+    // flight — never write a stale session's runs into the new one.
+    if (this.agentForPane(paneId) !== agent) return;
     this.workflowRuns.set(paneId, runs);
     this.postMessage({ command: 'updateWorkflowRuns', paneId, runs });
   }

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -637,11 +637,14 @@ describe('agent notifications', () => {
 
   it('onBackgroundTasksChange posts tasks and refreshes workflow runs', async () => {
     const { sent } = await readyHost();
+    const runsBefore = sent('updateWorkflowRuns').length;
     lastAgent().callbacks.onBackgroundTasksChange([{ task_id: 't1' }]);
 
     expect(sent('updateBackgroundTasks')[0]).toMatchObject({ tasks: [{ task_id: 't1' }] });
+    // A fresh refresh lands after the background-task change (session pushes
+    // also refresh in the background, so assert a new one, not a total count).
     await vi.waitFor(() => {
-      expect(sent('updateWorkflowRuns')).toHaveLength(1);
+      expect(sent('updateWorkflowRuns').length).toBeGreaterThan(runsBefore);
     });
   });
 
@@ -3486,6 +3489,70 @@ describe('SSH remote hosts', () => {
 
     expect(vi.mocked(listRemoteDirs)).not.toHaveBeenCalled();
     expect(sent('desktopRemoteDirList')).toEqual([]);
+  });
+
+  it('a live remote session switch does not wait for the workflow-runs RPC', async () => {
+    seedSshConfig('Host prod\n  HostName 10.0.0.1\n');
+    h.existingPaths.add('/remote/repo');
+    const { host, store, send, sent } = await readyHost();
+
+    // Start a remote session — a live agent in the pool, bound to the pane.
+    await host.handleWebviewMessage({ command: 'desktopSelectRemotePath', host: 'prod', path: '/remote/repo' });
+    const remoteAgent = lastAgent();
+    registerAgentInIndex(remoteAgent); // pool + index, keyed by host prod
+    const remoteSessionId = remoteAgent.sessionId as string;
+
+    // Park the remote session in the background (a closed pane also keeps its
+    // agent running): activate a local historical session so the pane binds to
+    // a different agent while the remote one stays live in the pool.
+    store.upsertSession({
+      sessionId: 'sess-local',
+      title: 'Local history',
+      workdir: '/work/a',
+      cwd: '/work/a',
+      createdAt: Date.now(),
+      lastActiveAt: Date.now(),
+    });
+    await host.handleWebviewMessage({ command: 'desktopSelectSession', workdir: '/work/a', sessionId: 'sess-local' });
+    // Wait for the restore to fully settle — startPaneRestore pushes an
+    // optimistic overlay (isRestoring: true) before the local agent binds, and
+    // selecting the remote session while the pane is still bound to it would
+    // early-return as "already shown".
+    await vi.waitFor(() => {
+      expect(sent('setInitialState').at(-1)).toMatchObject({ session: { id: 'sess-local' }, isRestoring: false });
+    });
+    expect(lastAgent()).not.toBe(remoteAgent);
+
+    send.mockClear();
+
+    // A congested SSH hop (the streaming session floods the connection with
+    // notification lines) makes the workflow-runs round trip slow — it must
+    // not delay the title + message switch to the live session.
+    let resolveRuns!: (runs: unknown[]) => void;
+    remoteAgent.getWorkflowRuns.mockImplementationOnce(
+      () => new Promise((resolve) => { resolveRuns = resolve; }),
+    );
+
+    const selectPromise = host.handleWebviewMessage({
+      command: 'desktopSelectSession',
+      workdir: '/remote/repo',
+      sessionId: remoteSessionId,
+    });
+
+    // The switch lands immediately from cached state; the fresh workflow runs
+    // refresh in the background and arrive afterwards.
+    await vi.waitFor(() => {
+      const first = sent('setInitialState')[0];
+      expect(first?.session).toMatchObject({ id: remoteSessionId });
+      expect(first?.messages).toHaveLength(1);
+    });
+    expect(remoteAgent.getWorkflowRuns).toHaveBeenCalled();
+
+    resolveRuns([{ runId: 'run-1' }]);
+    await selectPromise;
+    await vi.waitFor(() => {
+      expect(sent('updateWorkflowRuns').at(-1)?.runs).toEqual([{ runId: 'run-1' }]);
+    });
   });
 });
 


### PR DESCRIPTION
## 问题

从本地对话切换到正在运行的远程对话时，顶部标题和消息列表不立即切换，停留在上个本地对话；但侧边栏里远程对话已高亮。停止的远程会话无此问题，且偶发复现。

## 根因

切换会话时 handleSelectSession 的 live 分支走 activateAgentInPane，await pushPaneSessionState，其中唯一 await 是 agent.getWorkflowRuns()——远程主机上是 SSH RPC 往返。侧边栏高亮由前面的 pushPanes() 同步发送所以先亮，标题+消息要等 RPC 返回才推送。流式会话持续向 ssh 连接灌 notification 行，拥塞时该往返偶发变慢；停止的远程会话走 fire-and-forget 的 startPaneRestore，所以不延迟。

## 修复

- pushPaneSessionState 不再 await getWorkflowRuns()，改为后台 refreshWorkflowRuns 刷新，消息立即用缓存推送
- refreshWorkflowRuns RPC 返回后复查 pane 绑定，防止快速切换后陈旧 runs 串到新会话
- bindAgentToPane 换会话时清 workflowRuns 缓存，避免上个会话的 runs 在新会话下闪现

## 验证

- 失败测试先行：挂起 live 远程 agent 的 getWorkflowRuns，断言 setInitialState（远程标题+消息）在 RPC resolve 前已推送（修复前红，修复后绿）
- 全套件 pnpm -F wave-desktop test 361/361 通过，type-check + lint 通过