### PR TITLE
fix(webview): 初始加载即时钉底 + 异步内容加载后 re-pin 修正落点

### DIFF
--- a/packages/webview/src/components/MessageList.tsx
+++ b/packages/webview/src/components/MessageList.tsx
@@ -32,6 +32,10 @@ export const MessageList = forwardRef<{ scrollToBottom: (behavior?: ScrollBehavi
 
   const prevMessagesLengthRef = useRef(messages.length);
   const prevQueuedLengthRef = useRef(queuedMessages?.length || 0);
+  // True until the first effect run after mount. MessageList only renders once
+  // messages exist (empty state shows LoadingLogo/WelcomeView), so the first run
+  // IS the initial session load and must force-scroll to the bottom.
+  const isFirstEffectRef = useRef(true);
   // True when the user has scrolled up away from the bottom. While set,
   // auto-scroll-to-bottom is suspended so the user can read history undisturbed
   // during streaming. Set by ANY upward scroll (even a few px) — detected by
@@ -150,6 +154,11 @@ export const MessageList = forwardRef<{ scrollToBottom: (behavior?: ScrollBehavi
     const container = containerRef.current;
     if (!container) return;
 
+    // Initial load scrolls instantly ('auto') — a smooth animation would compute
+    // its target once and land short while async content (images, webfonts,
+    // mermaid) is still loading. isNewMessage marks appended messages.
+    const isInitialLoad = isFirstEffectRef.current && messages.length > 0;
+    isFirstEffectRef.current = false;
     const isNewMessage = messages.length > prevMessagesLengthRef.current || (queuedMessages?.length || 0) > prevQueuedLengthRef.current;
     prevMessagesLengthRef.current = messages.length;
     prevQueuedLengthRef.current = queuedMessages?.length || 0;
@@ -213,7 +222,7 @@ export const MessageList = forwardRef<{ scrollToBottom: (behavior?: ScrollBehavi
     // Follow new content: scroll on every messages change (incl. streaming text
     // chunks so streamed text stays visible), gated by userScrolledUp inside
     // scrollToBottom. A brand-new message forces the scroll.
-    scrollToBottom(isStreaming ? 'auto' : 'smooth', isNewMessage);
+    scrollToBottom(isStreaming || isInitialLoad ? 'auto' : 'smooth', isNewMessage || isInitialLoad);
     computeSticky();
 
     return () => {
@@ -221,6 +230,20 @@ export const MessageList = forwardRef<{ scrollToBottom: (behavior?: ScrollBehavi
       container.removeEventListener('scroll', handleScroll);
     };
   }, [messages, queuedMessages, isStreaming, scrollToBottom, computeSticky]);
+
+  // Re-pin to the true bottom after async content finishes loading (image
+  // decode, webfont reflow, mermaid render). 'load' doesn't bubble, so listen in
+  // capture phase; re-pin with 'auto' — a smooth re-pin would miss again.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const repin = () => {
+      if (!userScrolledUpRef.current) doScrollToBottom('auto');
+    };
+    container.addEventListener('load', repin, true);
+    document.fonts?.ready.then(repin);
+    return () => container.removeEventListener('load', repin, true);
+  }, [doScrollToBottom]);
 
   return (
     <div 

--- a/packages/webview/tests/webview/initialLoadScroll.test.tsx
+++ b/packages/webview/tests/webview/initialLoadScroll.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderChatApp, screen, waitFor, act, sendCommand, fireEvent } from './test-utils';
+
+const userMsg = (content: string, id: string) => ({
+  id,
+  role: 'user' as const,
+  timestamp: '2025-01-01T00:00:00.000Z',
+  blocks: [{ type: 'text', content }]
+});
+
+const assistantMsg = (content: string, id: string) => ({
+  id,
+  role: 'assistant' as const,
+  timestamp: '2025-01-01T00:00:00.000Z',
+  blocks: [{ type: 'text', content }]
+});
+
+function setGeometryAndScroll(scrollTop: number, scrollHeight: number, clientHeight = 400) {
+  const container = screen.getByTestId('messages-container');
+  Object.defineProperty(container, 'scrollTop', { value: scrollTop, configurable: true });
+  Object.defineProperty(container, 'clientHeight', { value: clientHeight, configurable: true });
+  Object.defineProperty(container, 'scrollHeight', { value: scrollHeight, configurable: true });
+  act(() => {
+    fireEvent.scroll(container);
+  });
+}
+
+/**
+ * Initial-load scrolling + async-content re-pin.
+ * jsdom does no layout (scrollTop/clientHeight/scrollHeight are 0), so the
+ * "near bottom" check is always true there; these tests assert the parts that
+ * are deterministic regardless: the initial forced 'auto' scroll, and the
+ * re-pin triggered by async content loads.
+ */
+describe('initial load scroll + async-content re-pin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Remove the document.fonts mock injected by the fonts test (if any).
+    delete (document as unknown as { fonts?: unknown }).fonts;
+  });
+
+  it('initial load force-scrolls instantly with behavior auto', async () => {
+    const scrollIntoView = vi.fn();
+    window.Element.prototype.scrollIntoView = scrollIntoView;
+
+    renderChatApp();
+    act(() => {
+      sendCommand('setInitialState', {
+        messages: [userMsg('问题', 'u1'), assistantMsg('回答', 'a1')],
+        isStreaming: false
+      });
+    });
+    await waitFor(() => expect(screen.getByTestId('messages-container')).toBeInTheDocument());
+
+    // The mount effect IS the initial load: MessageList only renders once
+    // messages exist, so the first scroll must be an instant 'auto' pin.
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'auto' });
+  });
+
+  it('re-pins to the bottom when an image finishes loading', async () => {
+    const scrollIntoView = vi.fn();
+    window.Element.prototype.scrollIntoView = scrollIntoView;
+
+    renderChatApp();
+    act(() => {
+      sendCommand('setInitialState', {
+        messages: [userMsg('问题', 'u1'), assistantMsg('回答', 'a1')],
+        isStreaming: false
+      });
+    });
+    await waitFor(() => expect(screen.getByTestId('messages-container')).toBeInTheDocument());
+    scrollIntoView.mockClear();
+
+    // 'load' does not bubble — the container listens in capture phase, so
+    // dispatching a non-bubbling load still reaches it.
+    fireEvent.load(screen.getByTestId('messages-container'));
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'auto' });
+  });
+
+  it('does NOT re-pin on image load after the user scrolled up', async () => {
+    const scrollIntoView = vi.fn();
+    window.Element.prototype.scrollIntoView = scrollIntoView;
+
+    renderChatApp();
+    act(() => {
+      sendCommand('setInitialState', {
+        messages: [userMsg('问题', 'u1'), assistantMsg('回答', 'a1')],
+        isStreaming: false
+      });
+    });
+    await waitFor(() => expect(screen.getByTestId('messages-container')).toBeInTheDocument());
+    // Let the programmatic-scroll flag (reset via requestAnimationFrame) clear.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    // Genuine user scroll-up: scrollTop decreases with geometry unchanged.
+    setGeometryAndScroll(1600, 2000);
+    setGeometryAndScroll(1500, 2000);
+    scrollIntoView.mockClear();
+
+    fireEvent.load(screen.getByTestId('messages-container'));
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('re-pins once web fonts are ready', async () => {
+    const scrollIntoView = vi.fn();
+    window.Element.prototype.scrollIntoView = scrollIntoView;
+    // Must be set BEFORE mount: the re-pin effect registers the fonts.ready
+    // callback when MessageList mounts. An unresolved promise keeps the re-pin
+    // pending so we can resolve it after clearing the initial-scroll call.
+    let resolveFonts: () => void = () => {};
+    const ready = new Promise<void>((resolve) => { resolveFonts = resolve; });
+    Object.defineProperty(document, 'fonts', {
+      value: { ready },
+      configurable: true
+    });
+
+    renderChatApp();
+    act(() => {
+      sendCommand('setInitialState', {
+        messages: [userMsg('问题', 'u1'), assistantMsg('回答', 'a1')],
+        isStreaming: false
+      });
+    });
+    await waitFor(() => expect(screen.getByTestId('messages-container')).toBeInTheDocument());
+    scrollIntoView.mockClear();
+
+    // Resolve the fonts.ready promise → the re-pin callback fires.
+    await act(async () => { resolveFonts(); });
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'auto' });
+  });
+});


### PR DESCRIPTION
## 背景

初始加载历史会话时，MessageList 的滚动落点偏短：图片解码、webfont reflow、mermaid 异步渲染会让 scrollHeight 在首次滚动后继续增长，smooth 动画只计算一次目标位置。

## 调查发现

- MessageList 只在有消息后才挂载（空消息渲染 LoadingLogo/WelcomeView），setInitialState 全量消息一次到位，首次 effect 即初始加载——原 "0 到 N 触发 isNewMessage" 的机制在真实流程下并不成立
- 静态长会话（非流式）初始滚动依赖 isNearBottom，长会话 scrollTop=0 时不会触发

## 改动（packages/webview/src/components/MessageList.tsx）

1. isFirstEffectRef 标记首次 effect：初始加载强制 auto 即时钉底（替代 smooth，避免落点偏短）
2. 新增只挂一次的 re-pin effect：容器 capture 相位监听 load（load 不冒泡，须捕获）+ document.fonts.ready，异步内容加载完成后重新钉到真底部；用户上滑时跳过
3. re-pin 刻意用 auto 而非 smooth，避免重蹈单次目标动画的坑

## 测试

新增 tests/webview/initialLoadScroll.test.tsx 4 个用例：初始 auto 滚动、图片 load 后 re-pin、用户上滑后不 re-pin、fonts.ready resolve 后 re-pin。webview 全量 74 文件 580 测试通过，tsc 无错误。