### PR TITLE
feat(desktop): rebuild webview in predev

### DIFF
--- a/packages/desktop/scripts/predev.mjs
+++ b/packages/desktop/scripts/predev.mjs
@@ -1,17 +1,40 @@
 #!/usr/bin/env node
 /**
- * predev — kill leftover dev Electron instances before launching a new one.
+ * predev — rebuild the shared webview, then kill leftover dev Electron
+ * instances before launching a new one.
  *
- * The dev app shares the `wave-desktop-dev` userData across worktrees, so a
- * stale instance makes a new `pnpm run dev` silently exit 0 (focus jumps to
- * the old instance and edits look like they "didn't take"). We match only the
- * workspace-installed electron (path contains `node_modules/electron`); the
- * user's installed app never matches that fragment, so it is never touched.
+ * syncWebview.mjs only copies the webview `dist`, it does not build it, so a
+ * stale bundle silently ships an old UI whenever webview src changed. Building
+ * it here keeps `pnpm run dev` honest without having to remember the build
+ * step. The kill-half matters because the dev app shares the
+ * `wave-desktop-dev` userData across worktrees: a stale instance makes a new
+ * `pnpm run dev` silently exit 0 (focus jumps to the old instance and edits
+ * look like they "didn't take"). We match only the workspace-installed
+ * electron (path contains `node_modules/electron`); the user's installed app
+ * never matches that fragment, so it is never touched.
  */
 import { spawnSync } from 'node:child_process';
 
 const NEEDLE = 'node_modules/electron';
 const me = process.pid;
+
+function buildWebview() {
+  const isWin = process.platform === 'win32';
+  const r = spawnSync(isWin ? 'pnpm.cmd' : 'pnpm', ['-F', 'wave-webview', 'build'], {
+    stdio: 'inherit',
+  });
+  if (r.error) {
+    console.error(`[predev] failed to spawn pnpm: ${r.error.message}`);
+    process.exit(1);
+  }
+  if (r.status !== 0) {
+    console.error(`[predev] webview build exited with status ${r.status}`);
+    process.exit(r.status ?? 1);
+  }
+  console.log('[predev] webview rebuilt');
+}
+
+buildWebview();
 
 function listProcesses() {
   try {


### PR DESCRIPTION
## Summary

desktop dev 现在会在 predev 钩子里先执行 `pnpm -F wave-webview build`，再清理残留的 dev Electron 实例。

## Motivation

syncWebview.mjs 只拷贝 webview 的 dist 产物、不会构建它。webview src 改动后忘记手动 build，dev 就会静默运行旧 bundle（2026-08-03 曾因未重建 webview 导致扫光动画缺失）。把构建步骤放进 predev 可避免该问题。

## Changes

- packages/desktop/scripts/predev.mjs: 新增 buildWebview() 步骤（spawnSync 执行 wave-webview build，失败即中止），随后执行原有的残留实例清理