### PR TITLE
fix(webview): 文件面板标题常驻 + 文件路径移入内容区域

### DIFF
--- a/packages/webview/src/components/FilePane.tsx
+++ b/packages/webview/src/components/FilePane.tsx
@@ -258,17 +258,7 @@ export const FilePane: React.FC<FilePaneProps> = ({
       <div className="preview-pane-drag-handle" onMouseDown={onDragStart} />
       <div className="preview-pane-inner">
         <div className="preview-pane-toolbar">
-          {fileView && (
-            <>
-              <span className={`file-pane-host${isLocal ? ' file-pane-host--local' : ''}`}>
-                {isLocal ? '本地' : fileView.host}
-              </span>
-              <span className="preview-pane-url file-pane-path" title={fileView.path}>
-                {relativePath || fileView.path}
-              </span>
-            </>
-          )}
-          <span className="preview-pane-spacer" />
+          <span className="preview-pane-url">文件</span>
           {fileView && isLocal && onOpenExternal && (
             <button
               className="preview-pane-button"
@@ -299,6 +289,16 @@ export const FilePane: React.FC<FilePaneProps> = ({
           </button>
         </div>
         <div className="preview-pane-body file-pane-body" ref={scrollRef}>
+          {fileView && (
+            <div className="file-pane-location">
+              <span className={`file-pane-host${isLocal ? ' file-pane-host--local' : ''}`}>
+                {isLocal ? '本地' : fileView.host}
+              </span>
+              <span className="file-pane-path" title={fileView.path}>
+                {relativePath || fileView.path}
+              </span>
+            </div>
+          )}
           {!fileView && (
             <div className="desktop-panel-placeholder">
               <i className="codicon codicon-file file-pane-placeholder-icon" />

--- a/packages/webview/src/styles/FilePane.css
+++ b/packages/webview/src/styles/FilePane.css
@@ -1,10 +1,25 @@
-/* Desktop file panel: title bar (host + relative path + actions), line-numbered
+/* Desktop file panel: title bar, host + path location row, line-numbered
    code view with horizontal scrolling, markdown rendering and inline images. */
 
 .file-pane-body {
     display: flex;
     flex-direction: column;
     overflow: auto;
+}
+
+/* Host badge + relative path, sticky so the location stays visible while the
+   code scrolls under it (same background as the line-number gutter). */
+.file-pane-location {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    border-bottom: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.2));
+    flex-shrink: 0;
+    position: sticky;
+    top: 0;
+    background: var(--vscode-sideBar-background, var(--vscode-panel-background));
+    z-index: 1;
 }
 
 .file-pane-body .desktop-panel-placeholder {

--- a/packages/webview/tests/webview/filePane.test.tsx
+++ b/packages/webview/tests/webview/filePane.test.tsx
@@ -62,6 +62,25 @@ describe('FilePane', () => {
         expect(screen.queryByTestId('file-open-external')).not.toBeInTheDocument();
     });
 
+    it('keeps the 文件 title and right-aligned close button in the empty state', () => {
+        renderPane({ fileView: null });
+        const toolbar = screen.getByTestId('file-pane').querySelector('.preview-pane-toolbar');
+        expect(toolbar?.querySelector('.preview-pane-url')?.textContent).toBe('文件');
+        const close = screen.getByTestId('file-close');
+        expect(close.compareDocumentPosition(toolbar!.querySelector('.preview-pane-url') as Node)).toBe(
+            Node.DOCUMENT_POSITION_PRECEDING,
+        );
+        expect(screen.queryByText(/本地|^prod$/, { selector: '.file-pane-host' })).not.toBeInTheDocument();
+    });
+
+    it('shows the host badge and path inside the body location row', () => {
+        const { container } = renderPane({ workdir: '/work/a' });
+        const location = container.querySelector('.file-pane-location');
+        expect(location?.querySelector('.file-pane-host')?.textContent).toBe('本地');
+        expect(location?.querySelector('.file-pane-path')?.textContent).toBe('src/app.ts');
+        expect(screen.getByText('文件')).toBeInTheDocument();
+    });
+
     it('shows the error state instead of content', () => {
         renderPane({ fileView: { path: '/work/a/nope.ts', host: 'local', error: '文件不存在：/work/a/nope.ts' } });
         expect(screen.getByText('文件不存在：/work/a/nope.ts')).toBeInTheDocument();


### PR DESCRIPTION
修复文件面板空状态时关闭按钮跑到左侧的问题。

- toolbar 常驻标题「文件」，与其他面板（差异/终端/预览）一致，关闭按钮始终右侧对齐
- host 徽标 + 相对路径从 toolbar 移入内容区域顶部（sticky，滚动代码时路径仍可见）
- 新增空态标题与位置行单测（FilePane 26 个用例全过，webview 全量 578 通过）
- Playwright demo 48 通过，文件面板 3 张截图已重新生成