### PR TITLE
fix(webview): scroll long commands in confirmation dialog

### DIFF
--- a/packages/webview/src/styles/ConfirmationDialog.css
+++ b/packages/webview/src/styles/ConfirmationDialog.css
@@ -75,6 +75,8 @@
   border: 1px solid var(--vscode-panel-border);
   white-space: pre-wrap;
   word-break: break-all;
+  max-height: 120px;
+  overflow-y: auto;
 }
 
 .confirmation-mcp-params {


### PR DESCRIPTION
命令执行确认框的命令块原本没有高度上限，超长命令会把对话框撑得非常高。

改动：
- .confirmation-command 增加 max-height: 120px + overflow-y: auto
- 与消息列表 .bash-command-input 的最大高度对齐（同 120px）
- 按钮区始终可见，超出部分滚动查看