### PR TITLE
fix(desktop): destroy blank agents orphaned on pane switch or close

### DIFF
--- a/packages/agent-sdk/tests/services/session.errors.test.ts
+++ b/packages/agent-sdk/tests/services/session.errors.test.ts
@@ -247,23 +247,24 @@ describe("Session Error Handling and Edge Cases", () => {
       const olderMainSessionId = randomUUID();
       const newerMainSessionId = randomUUID();
 
-      // Create different timestamps - older session has more recent activity
-      // Note: timestamps are used to simulate file creation order in this test
-      new Date(Date.now() - 1000).toISOString(); // 1 second ago
-      new Date().toISOString(); // now
+      // Create different timestamps - older session has more recent activity.
+      // The two must differ deterministically: when both land in the same
+      // millisecond the sort order becomes a race and the test flakes.
+      const olderLastActiveAt = new Date().toISOString(); // now
+      const newerLastActiveAt = new Date(Date.now() - 1000).toISOString(); // 1 second ago
 
       const olderSessionMessage = {
         id: generateMessageId(),
         role: "user" as const,
         blocks: [{ type: "text" as const, content: "Hello" }],
-        timestamp: new Date().toISOString(),
+        timestamp: olderLastActiveAt,
       };
 
       const newerSessionMessage = {
         id: generateMessageId(),
         role: "user" as const,
         blocks: [{ type: "text" as const, content: "Hello" }],
-        timestamp: new Date().toISOString(),
+        timestamp: newerLastActiveAt,
       };
 
       // Create files - subagent sessions would be in separate directory

--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -668,6 +668,15 @@ export class DesktopHost {
     return agent;
   }
 
+  /**
+   * A message-less, non-streaming agent is new-session scaffolding: no session
+   * index entry, so the sidebar can never bring it back. Such agents must be
+   * destroyed when their pane releases them, or the pool accumulates orphans.
+   */
+  private isBlankAgent(agent: StdioAgent): boolean {
+    return agent.messages.length === 0 && !agent.isStreaming;
+  }
+
   /** Bind an agent to a pane (replacing whatever it showed) and focus the pane. */
   private bindAgentToPane(paneId: string, agent: StdioAgent | null): void {
     const pane = this.panes.find((p) => p.paneId === paneId);
@@ -681,10 +690,16 @@ export class DesktopHost {
       // the incoming session never flashes a stale list.
       this.workflowRuns.delete(paneId);
     }
+    const outgoing = pane.agent;
     this.clearThrottleState(paneId);
     pane.agent = agent;
     this.focusedPaneId = paneId;
     if (agent) this.touchAgentAsRecent(agent);
+    // Replacing or releasing a blank agent (worktree/workdir/host switch)
+    // would otherwise leak it in the pool until the app quits.
+    if (outgoing && outgoing !== agent && this.isBlankAgent(outgoing)) {
+      void this.discardAgent(outgoing);
+    }
   }
 
   /**
@@ -1017,6 +1032,7 @@ export class DesktopHost {
     if (idx === -1) return;
     this.terminalManager.killForPane(paneId);
     this.clearThrottleState(paneId);
+    const closedAgent = this.panes[idx].agent;
     const closedRow = this.panes[idx].row ?? 0;
     this.panes.splice(idx, 1);
     this.inputDrafts.delete(paneId);
@@ -1025,6 +1041,11 @@ export class DesktopHost {
     // An in-flight restore for the closed pane is dead — its token check
     // discards the half-spawned agent.
     this.pendingRestores.delete(paneId);
+    // A blank agent has no session to keep running in the background — destroy
+    // it instead of leaving it orphaned in the pool.
+    if (closedAgent && this.isBlankAgent(closedAgent)) {
+      void this.discardAgent(closedAgent);
+    }
     // The closed pane's width returns to its row-mates proportionally; an
     // untouched equal-split row (no explicit widths) stays equal-split.
     this.renormalizeRowWidths(closedRow);
@@ -2604,8 +2625,12 @@ export class DesktopHost {
     try {
       const agent = await this.spawnAgent({ host, workdir: dir });
       // Spawning is slow (agent init) — the user may have selected another
-      // session meanwhile; don't clobber their view.
-      if (this.agentForPane(pid) !== active) return;
+      // session meanwhile; don't clobber their view, and destroy the
+      // just-spawned agent so it doesn't linger orphaned in the pool.
+      if (this.agentForPane(pid) !== active) {
+        await this.discardAgent(agent);
+        return;
+      }
       if (backOffOnRestore && this.pendingRestores.has(pid)) {
         // The user selected a historical session while the delete was in
         // flight — its restore owns this pane. Destroy the just-spawned
@@ -2645,7 +2670,11 @@ export class DesktopHost {
     try {
       const agent = await this.spawnAgent({ host, workdir: dir });
       // Spawning is slow (agent init) — the pane may have been closed meanwhile.
-      if (!this.panes.some((p) => p.paneId === paneId)) return;
+      // Destroy the just-spawned agent so it doesn't linger orphaned in the pool.
+      if (!this.panes.some((p) => p.paneId === paneId)) {
+        await this.discardAgent(agent);
+        return;
+      }
       await this.activateAgentInPane(paneId, agent);
     } catch (error) {
       console.error('[DesktopHost] 新建分屏会话失败:', error);

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -394,6 +394,18 @@ describe('workdir lifecycle', () => {
     expect(states[states.length - 1]).toMatchObject({ recentWorkdirs: ['/work/b'] });
   });
 
+  it('switching workdir destroys the empty agent it replaces instead of leaking it in the pool', async () => {
+    const { host } = await readyHost();
+    const replaced = lastAgent(); // the fresh empty agent bound to the pane
+    h.existingPaths.add('/work/b');
+
+    await host.handleWebviewMessage({ command: 'desktopSelectRecentWorkdir', path: '/work/b' });
+
+    expect(lastAgent()).not.toBe(replaced);
+    expect(lastAgent().initialize).toHaveBeenCalledWith(expect.objectContaining({ workdir: '/work/b' }));
+    expect(replaced.destroy).toHaveBeenCalledTimes(1);
+  });
+
   it('desktopSelectRecentWorkdir drops a stale path and keeps the current agent', async () => {
     const { host, sent, store } = await readyHost();
     const agentBefore = lastAgent();
@@ -816,6 +828,32 @@ describe('misc commands', () => {
     expect(oldAgent.clearMessages).not.toHaveBeenCalled();
     expect(oldAgent.destroy).not.toHaveBeenCalled();
     expect(oldAgent.abortMessage).not.toHaveBeenCalled();
+  });
+
+  it('newSession destroys the spawned agent when another session claims the pane mid-spawn', async () => {
+    const { host, sent } = await readyHost();
+    const active = lastAgent();
+    active.messages = [{ id: 'm1' }]; // the active session is non-empty, so newSession spawns
+    let resolveInit!: () => void;
+    h.initializeGate = new Promise<void>((r) => { resolveInit = r; });
+
+    const spawnPromise = host.handleWebviewMessage({ command: 'newSession' });
+    await vi.waitFor(() => { expect(h.agentInstances).toHaveLength(2); });
+    const spawned = lastAgent();
+
+    // Mid-spawn the user picks a historical session whose restore lands first
+    // and rebinds the pane. The original spawn then has no pane to bind to —
+    // it must be destroyed instead of orphaned in the agent pool.
+    h.initializeGate = null;
+    await host.handleWebviewMessage({ command: 'desktopSelectSession', workdir: '/work/a', sessionId: 'sess-other' });
+    await vi.waitFor(() => {
+      expect(sent('setInitialState').at(-1)).toMatchObject({ isRestoring: false, session: { id: 'sess-other' } });
+    });
+
+    resolveInit();
+    await spawnPromise;
+
+    expect(spawned.destroy).toHaveBeenCalledTimes(1);
   });
 
   it('newSession on an empty active session is a no-op', async () => {
@@ -1501,6 +1539,19 @@ describe('worktree flow', () => {
 
     const msg = sent('desktopGitBranches').at(-1);
     expect(msg).toMatchObject({ workdir: '/work/a', result: null });
+  });
+
+  it('desktopCreateWorktree destroys the empty agent it replaces instead of leaking it in the pool', async () => {
+    const { host } = await readyHost();
+    const replaced = lastAgent(); // the fresh empty agent bound to the pane
+    expect(replaced.messages).toHaveLength(0);
+    h.worktreeResult = worktree;
+    h.existingPaths.add(worktree.path);
+
+    await host.handleWebviewMessage({ command: 'desktopCreateWorktree', workdir: '/work/a' });
+
+    expect(lastAgent()).not.toBe(replaced);
+    expect(replaced.destroy).toHaveBeenCalledTimes(1);
   });
 
   it('desktopListGitBranches arriving before the stdio client is ready waits for init instead of replying null', async () => {
@@ -2295,6 +2346,48 @@ describe('split-view panes (FR-032~036)', () => {
     expect(layout.focusedPaneId).toBe(layout.panes[0].paneId);
     expect(agent1.destroy).not.toHaveBeenCalled();
     expect(agent2.destroy).not.toHaveBeenCalled();
+  });
+
+  it('desktopClosePane destroys a message-less agent on the closed pane', async () => {
+    const { host, sent } = await readyHost();
+    const agent1 = seedActiveSession('sess-1'); // pane-1 keeps a real conversation
+    await host.handleWebviewMessage({ command: 'desktopNewSessionInPane' });
+    const layout = panePushes(sent).at(-1)!;
+    expect(layout.panes).toHaveLength(2);
+    const spawned = lastAgent(); // the fresh empty agent bound to pane-2
+
+    await host.handleWebviewMessage({ command: 'desktopClosePane', paneId: layout.panes[1].paneId });
+
+    const after = panePushes(sent).at(-1)!;
+    expect(after.panes).toHaveLength(1);
+    expect(spawned.destroy).toHaveBeenCalledTimes(1);
+    expect(agent1.destroy).not.toHaveBeenCalled();
+  });
+
+  it('desktopNewSessionInPane destroys the spawned agent when its pane is closed mid-spawn', async () => {
+    const { host, sent } = await readyHost();
+    seedActiveSession('sess-1');
+    let resolveInit!: () => void;
+    h.initializeGate = new Promise<void>((r) => { resolveInit = r; });
+
+    const spawnPromise = host.handleWebviewMessage({ command: 'desktopNewSessionInPane' });
+    const newPaneId = await vi.waitFor(() => {
+      const layout = panePushes(sent).at(-1)!;
+      expect(layout.panes).toHaveLength(2);
+      return layout.panes[1].paneId;
+    });
+    await vi.waitFor(() => { expect(h.agentInstances).toHaveLength(2); });
+    const spawned = lastAgent();
+
+    // Mid-spawn the user closes the new pane. When initialize finishes, the
+    // agent has no pane to bind to — it must be destroyed, not orphaned.
+    h.initializeGate = null;
+    await host.handleWebviewMessage({ command: 'desktopClosePane', paneId: newPaneId });
+
+    resolveInit();
+    await spawnPromise;
+
+    expect(spawned.destroy).toHaveBeenCalledTimes(1);
   });
 
   it('desktopClosePane on the last remaining pane is a no-op', async () => {
@@ -3313,6 +3406,16 @@ describe('SSH remote hosts', () => {
     expect(panes.panes[0]).toMatchObject({ host: 'prod' });
   });
 
+  it('desktopSelectHost destroys the message-less agent it releases from the pane', async () => {
+    seedSshConfig('Host prod\n  HostName 10.0.0.1\n');
+    const { host } = await readyHost();
+    const released = lastAgent(); // the fresh empty agent bound to the pane
+
+    await host.handleWebviewMessage({ command: 'desktopSelectHost', host: 'prod' });
+
+    expect(released.destroy).toHaveBeenCalledTimes(1);
+  });
+
   it('desktopAddHost appends the block, auto-selects the new host and eagerly connects', async () => {
     const { host, sent } = createHost();
 
@@ -3407,6 +3510,7 @@ describe('SSH remote hosts', () => {
 
     await host.handleWebviewMessage({ command: 'desktopSelectRemotePath', host: 'prod', path: '/repo' });
     const remoteAgent = lastAgent();
+    remoteAgent.messages = [{ id: 'm1' }]; // the user chatted in the remote session, so it must survive
 
     await host.handleWebviewMessage({ command: 'desktopSelectRecentWorkdir', path: '/repo', host: 'local' });
     const localAgent = lastAgent();


### PR DESCRIPTION
Switching workdir, creating a worktree, or switching host replaced the pane agent without destroying the outgoing one, and closing a pane left its message-less agent in the pool - agents accumulated as orphans until the app quit.

- bindAgentToPane now destroys a replaced/unbound agent that has no messages and is not streaming (isBlankAgent); covers workdir switch, worktree creation and host switch
- handleClosePane destroys a message-less agent on the closed pane
- handleNewSession / handleNewSessionInNewPane stale guards discard the just-spawned agent instead of returning and leaking it
- 6 new regression tests cover all five paths; one existing test seeds the remote agent with a message so it stays a real session

Verification: desktop suite 375 passed, tsc --noEmit passed.