### PR TITLE
fix(desktop): @file suggestions fall back to recents[0] before agent activation

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -2948,21 +2948,25 @@ export class DesktopHost {
   }
 
   private async findWorkspaceFiles(filterText: string): Promise<Record<string, string | boolean>[]> {
-    if (!this.workdir) return [];
+    const host = this.currentHost;
+    // Before any agent activation (fresh launch) this.workdir is unset while
+    // the webview already treats recents[0] as the effective workdir — mirror
+    // that fallback so @file suggestions work before a directory is picked.
+    const workdir = this.workdir ?? this.configStore.getRecentWorkdirsForHost(host)[0];
+    if (!workdir) return [];
     try {
-      const host = this.currentHost;
       // Remote workdirs are POSIX paths; path.join/basename on Windows would mangle them.
       const join = host === LOCAL_HOST ? path.join.bind(path) : path.posix.join.bind(path.posix);
       const basename = host === LOCAL_HOST ? path.basename.bind(path) : path.posix.basename.bind(path.posix);
       const result = (await this.utilityClientFor(host).request('searchFiles', {
         query: filterText || '',
         maxResults: 20,
-        workdir: this.workdir,
+        workdir,
       })) as { files: Array<{ path: string; type: string }> };
 
       const allItems = result.files.map((item) => {
         const relativePath = item.path;
-        const fullPath = join(this.workdir!, relativePath);
+        const fullPath = join(workdir, relativePath);
         const normalizedPath = relativePath.endsWith('/') ? relativePath.slice(0, -1) : relativePath;
         const name = basename(normalizedPath);
         const extensionMatch = name.match(/\.([^.]+)$/);

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -423,6 +423,29 @@ describe('workdir lifecycle', () => {
 });
 
 // ---------------------------------------------------------------------------
+// file suggestions (@file) — workdir resolution
+// ---------------------------------------------------------------------------
+
+describe('file suggestions', () => {
+  it('falls back to the most recent workdir before any agent activates (fresh launch)', async () => {
+    // Fresh launch: recents list a directory (the webview picker shows it as
+    // the default workdir) but no agent has been spawned yet, so host-side
+    // this.workdir is unset. @file suggestions must still search that default
+    // directory instead of returning an empty list.
+    const { host, store } = createHost();
+    store.addRecentWorkdir({ host: 'local', path: '/work/a' });
+    h.existingPaths.add('/work/a');
+    await host.handleWebviewMessage({ command: 'desktopReady' });
+    await host.handleWebviewMessage({ command: 'webviewReady' });
+
+    await host.handleWebviewMessage({ command: 'requestFileSuggestions', filterText: 'app', requestId: 'r1' });
+
+    const search = h.clientRequests.find((r) => r.method === 'searchFiles');
+    expect(search?.params).toMatchObject({ workdir: '/work/a', query: 'app', maxResults: 20 });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // initial state
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fix @file suggestions returning an empty list on desktop fresh launch.

Fresh launch leaves host-side this.workdir unset (webviewReady skips spawning until a directory is picked), so @file suggestions returned an empty list even though the webview input was enabled via the recents[0] fallback. findWorkspaceFiles now mirrors the webview effectiveWorkdir resolution, searching the most recent workdir before any agent spawns.

Tests: new desktopHost test covering the fresh-launch fallback; desktop suite 375 passed; type-check green.