### PR TITLE
fix(jetbrains): auto-update fails on platform 2026.1+ (NoSuchFieldError on IdeaPluginDescriptorImpl.path)

### DIFF
--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/update/UpdateChecker.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/update/UpdateChecker.kt
@@ -352,7 +352,10 @@ object UpdateChecker {
             WriteAction.run<Exception> {
                 val descriptor = PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))
                     ?: throw UpdateCheckException("Wave plugin descriptor not found")
-                val oldPath = (descriptor as? IdeaPluginDescriptorImpl)?.path
+                // Use getPluginPath() (method call) instead of the internal `path` field:
+                // the field was removed in newer platform versions (2026.1+), which breaks
+                // the compiled `getfield` with NoSuchFieldError; the accessor survives.
+                val oldPath = (descriptor as? IdeaPluginDescriptorImpl)?.pluginPath
                     ?: throw UpdateCheckException("Cannot resolve plugin install path")
                 PluginInstaller.installAfterRestart(
                     descriptor,


### PR DESCRIPTION
## 问题

WebStorm 2026.1 上点击「自动更新」报「自动更新失败，请手动下载更新」。

## 根因

`UpdateChecker.installPluginFromDisk` 直接访问内部字段 `IdeaPluginDescriptorImpl.path`（插件按 2024.2 平台编译，运行时加载 2026.1 平台的类）。该字段在 2026.1 平台被移除，编译期内联的 `getfield` 字节码运行时抛：

```
java.lang.NoSuchFieldError: Class com.intellij.ide.plugins.IdeaPluginDescriptorImpl does not have member field java.nio.file.Path path
```

触发 catch 兜底（浏览器打开 release 页 + 错误提示）。

## 修复

改用 `getPluginPath()` 方法调用（`.path` 字段 → `.pluginPath` 属性）：

- 该方法在 2024.2 与 2026.1 平台均存在（2026.1 标记 @Deprecated 但保留，返回 parent.pluginPath）
- IntelliJ 平台自身的 `PluginInstaller.uninstallAfterRestart` / `installFromDisk` 内部同样用它拿安装路径
- 字节码从 `getfield` 变为 `invokevirtual`，动态分派，不受字段移除影响

## 验证

- 编译目标 2024.2：compileKotlin + jb test 通过
- javap 确认产物字节码为 `invokevirtual IdeaPluginDescriptorImpl.getPluginPath()`
- 用户真机验证通过：临时构建 0.19.9 安装到 WebStorm 2026.1，点「自动更新」成功下载并调度重启安装 v1.0.0

单测无法覆盖该场景（单测跑在 2024.2 平台，`path` 字段仍存在，复现不了 NoSuchFieldError）。