### PR TITLE
feat(agent-sdk): pass disableThinkingOptions to fast-model scenarios

### DIFF
--- a/docs/specs/core/agent-config.md
+++ b/docs/specs/core/agent-config.md
@@ -172,6 +172,25 @@ SDK 用户需要按子代理类型配置不同的 HTTP 请求头，以便 `custo
 
 ---
 
+### 用户故事：快速模型思考禁用配置（优先级：P1）
+
+用户将推理模型（如 deepseek-v4-flash）配置为快速模型（fastModel）后，WebFetch 内容处理、目标评估等轻量任务会偶发 "Empty response from AI" 错误——推理模型的思考（reasoning）消耗了全部输出 token（max_tokens），导致 content 为空。用户希望为不同模型配置各自的"禁用思考"参数，使快速模型场景可按需禁用思考、稳定返回内容，同时不影响主代理对话（agent loop）中的思考能力。
+
+**为什么是这个优先级**：这是快速模型场景空响应错误的直接修复，影响 WebFetch 等常用工具的可用性。
+
+**独立测试**：分别配置与不配置 `models[X].disableThinkingOptions`，触发 WebFetch 内容处理、目标评估与自动记忆提取，验证请求携带正确参数；同时验证主代理对话请求不受影响。
+
+**验收场景**：
+
+1. **假设**用户未配置 `disableThinkingOptions`，**当**快速模型场景（如 WebFetch 内容处理）发起请求时，**则**请求不携带任何禁用思考参数，交由模型默认处理（避免对不支持该参数的网关报错）
+2. **假设**用户为模型 X 配置 `models[X].disableThinkingOptions: {"enable_thinking": false}`，**当**快速模型场景使用模型 X 时，**则**请求携带 `{"enable_thinking": false}`
+3. **假设**用户为快速模型配置了 `models[fastModel].disableThinkingOptions`，**当** WebFetch 内容处理与目标评估使用快速模型时，**则**两类请求都携带该模型的禁用思考参数
+4. **假设**用户为快速模型配置了 `models[fastModel].disableThinkingOptions`，**当**自动记忆提取等后台子代理使用快速模型时，**则**子代理请求同样携带该参数
+5. **假设**用户配置了 `models[X].disableThinkingOptions`，**当**主代理对话（agent loop）使用模型 X 时，**则**请求不携带禁用思考参数，思考行为保持模型默认
+6. **假设**用户为模型 X 配置 `disableThinkingOptions: {}`，**当**快速模型场景使用模型 X 时，**则**请求不携带任何禁用思考参数，交由模型默认处理
+
+---
+
 ### 边界情况
 
 - 当提供部分配置时会发生什么（如 apiKey 但无 baseURL）？
@@ -184,6 +203,8 @@ SDK 用户需要按子代理类型配置不同的 HTTP 请求头，以便 `custo
 - 当文件监视器在系统启动时初始化失败会发生什么？
 - IDE 插件配置对话框只填写部分字段（如仅 API Key、无 API 地址）时如何生效？（未填写的字段保持原值或回退到环境变量）
 - IDE 插件配置对话框加载已保存配置失败时如何展示？（对话框内显示错误，表单仍可填写重试）
+- 不同模型的禁用思考参数形态不同（`thinking: {type}` / `enable_thinking` / `reasoning_effort`），SDK 不做内置映射，由用户在 `models[X].disableThinkingOptions` 中按目标接口格式原样配置
+- 未配置 `disableThinkingOptions` 时，快速模型场景不发送任何禁用思考参数；SDK 不内置默认值，避免直连不支持 `thinking` 参数的网关时报错
 
 ### 边界说明：环境变量作用域与优先级
 

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -1150,6 +1150,12 @@ export class AIManager {
             systemPrompt: mainSystemPrompt, // Pass custom system prompt
             maxTokens: maxTokens, // Pass max tokens override
             toolChoice: this.toolChoiceOverride, // Pass tool_choice override
+            // Fast-model subagents send disable-thinking params only when
+            // explicitly configured (never in the agent loop).
+            disableThinkingOptions:
+              this.modelOverride === "fastModel"
+                ? this.getModelConfig().disableThinkingOptions
+                : undefined,
           };
 
           // Prepend: AGENTS.md + user memory + unconditional rules as system-reminder

--- a/packages/agent-sdk/src/services/aiService.ts
+++ b/packages/agent-sdk/src/services/aiService.ts
@@ -148,6 +148,18 @@ function getModelConfig(
   return config;
 }
 
+/**
+ * Effective disable-thinking params for a model config. No default: these
+ * params are only sent when the user explicitly configures
+ * `models[X].disableThinkingOptions` (an empty object clears them), so a
+ * gateway that doesn't understand the params is never hit with them.
+ */
+function effectiveDisableThinkingOptions(
+  modelConfig: ModelConfig,
+): Record<string, unknown> | undefined {
+  return modelConfig.disableThinkingOptions;
+}
+
 export interface CallAgentOptions {
   // Resolved configuration
   gatewayConfig: GatewayConfig;
@@ -184,6 +196,10 @@ export interface CallAgentOptions {
     stage?: "start" | "streaming" | "running" | "end";
   }) => void;
   onReasoningUpdate?: (content: string) => void;
+
+  // Disable-thinking params for fast-model subagent calls (merged into the
+  // request; never used in the agent loop).
+  disableThinkingOptions?: Record<string, unknown>;
 }
 
 export interface CallAgentResult {
@@ -238,6 +254,7 @@ export async function callAgent(
     onContentUpdate,
     onToolUpdate,
     onReasoningUpdate,
+    disableThinkingOptions,
   } = options;
 
   // Validate model config at call time
@@ -321,6 +338,7 @@ export async function callAgent(
     const openaiModelConfig = getModelConfig(model || modelConfig.model, {
       max_tokens: resolvedMaxTokens,
       ...(modelConfig.options || {}),
+      ...(disableThinkingOptions ?? {}),
     });
 
     // Determine if streaming is needed
@@ -842,10 +860,17 @@ export async function processWebContent(
     ? modelConfig.fastModelOptions || {}
     : modelConfig.options || {};
 
+  // Disable-thinking params only apply to the fast-model override path;
+  // the agent-model path is untouched.
+  const disableThinking = options.model
+    ? effectiveDisableThinkingOptions(modelConfig)
+    : undefined;
+
   const openaiModelConfig = getModelConfig(options.model || modelConfig.model, {
     temperature: 0.1,
     max_tokens: 4096,
     ...activeExtraParams,
+    ...(disableThinking || {}),
   });
 
   try {
@@ -1037,6 +1062,7 @@ export async function evaluateGoal(
     temperature: 0,
     max_tokens: 200,
     ...(modelConfig.fastModelOptions || {}),
+    ...(effectiveDisableThinkingOptions(modelConfig) || {}),
   });
 
   // Strip images from messages to reduce token usage (same as compact)

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -619,16 +619,31 @@ export class ConfigurationService {
       baseConfig.fastModelOptions = fastModelSource.options;
     }
 
+    // Resolve fast-model disable-thinking params from models[fastModel].disableThinkingOptions
+    const fastModelDisableThinking =
+      fastModelSource && fastModelSource.disableThinkingOptions
+        ? fastModelSource.disableThinkingOptions
+        : undefined;
+    if (fastModelDisableThinking) {
+      baseConfig.disableThinkingOptions = fastModelDisableThinking;
+    }
+
     // Merge model-specific settings from configuration
     const modelSpecificConfig =
       resolvedAgentModel &&
       this.currentConfiguration?.models?.[resolvedAgentModel];
 
     if (modelSpecificConfig) {
-      return {
+      const resolved: ModelConfig = {
         ...baseConfig,
         ...modelSpecificConfig,
       };
+      // Re-apply after the spread so the agent model's own
+      // disableThinkingOptions cannot clobber the fast-model value.
+      if (fastModelDisableThinking) {
+        resolved.disableThinkingOptions = fastModelDisableThinking;
+      }
+      return resolved;
     }
 
     return baseConfig;

--- a/packages/agent-sdk/src/types/config.ts
+++ b/packages/agent-sdk/src/types/config.ts
@@ -33,4 +33,11 @@ export interface ModelConfig {
   options?: Record<string, unknown>;
   /** Fast model generation params (resolved from models[fastModel].options) */
   fastModelOptions?: Record<string, unknown>;
+  /**
+   * Fast-model-only disable-thinking params passed through verbatim
+   * (e.g. `{ thinking: { type: "disabled" } }`). Applied only in fast-model
+   * scenarios (webFetch, goal evaluation, fast subagents, autoMemory),
+   * never in the agent loop. `{}` clears the default.
+   */
+  disableThinkingOptions?: Record<string, unknown>;
 }

--- a/packages/agent-sdk/tests/managers/aiManager.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.test.ts
@@ -73,6 +73,7 @@ function flattenSystemPrompt(sp: unknown): string {
 
 describe("AIManager", () => {
   let aiManager: AIManager;
+  let container: Container;
   let mockMessageManager: MessageManager;
   let mockToolManager: ToolManager;
 
@@ -140,7 +141,7 @@ describe("AIManager", () => {
       getEnvironmentVars: vi.fn().mockReturnValue({}),
     };
 
-    const container = new Container();
+    container = new Container();
     container.register("ConfigurationService", mockConfigurationService);
     container.register("MessageManager", mockMessageManager);
     container.register("ToolManager", mockToolManager);
@@ -196,6 +197,83 @@ describe("AIManager", () => {
   it("should call callAgent", async () => {
     await aiManager.sendAIMessage();
     expect(aiService.callAgent).toHaveBeenCalled();
+  });
+
+  it("does not send disableThinkingOptions in the agent loop", async () => {
+    await aiManager.sendAIMessage();
+    const options = vi.mocked(aiService.callAgent).mock.calls[0][0];
+    expect(options.disableThinkingOptions).toBeUndefined();
+  });
+
+  it("does not send disableThinkingOptions for fast-model subagents when none configured", async () => {
+    const subagent = new AIManager(container, {
+      workdir: "/test/workdir",
+      stream: false,
+      modelOverride: "fastModel",
+    });
+    await subagent.sendAIMessage();
+    const options = vi.mocked(aiService.callAgent).mock.calls[0][0];
+    expect(options.disableThinkingOptions).toBeUndefined();
+  });
+
+  it("passes through explicitly configured disableThinkingOptions for fast-model subagents", async () => {
+    const taskManager = {
+      on: vi.fn(),
+      listTasks: vi.fn().mockResolvedValue([]),
+    } as unknown as TaskManager;
+
+    const fastContainer = new Container();
+    fastContainer.register("ConfigurationService", {
+      setOptions: vi.fn(),
+      resolveGatewayConfig: vi.fn().mockReturnValue(mockGatewayConfig),
+      resolveModelConfig: vi.fn().mockReturnValue({
+        ...mockModelConfig,
+        disableThinkingOptions: { thinking: { type: "disabled" } },
+      }),
+      resolveMaxInputTokens: vi.fn().mockReturnValue(96000),
+      resolveAutoMemoryEnabled: vi.fn().mockReturnValue(true),
+      resolveLanguage: vi.fn().mockReturnValue(undefined),
+      getEnvironmentVars: vi.fn().mockReturnValue({}),
+    });
+    fastContainer.register("MessageManager", mockMessageManager);
+    fastContainer.register("ToolManager", mockToolManager);
+    fastContainer.register("TaskManager", taskManager);
+    fastContainer.register("MemoryService", {
+      getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+      getAutoMemoryDirectory: vi.fn().mockReturnValue("/mock/auto-memory"),
+      ensureAutoMemoryDirectory: vi.fn().mockResolvedValue(undefined),
+      getAutoMemoryContent: vi.fn().mockResolvedValue(""),
+    });
+    fastContainer.register("PermissionManager", {
+      getCurrentEffectiveMode: vi.fn().mockReturnValue("normal"),
+      clearTemporaryRules: vi.fn(),
+      getPlanFilePath: vi.fn().mockReturnValue(undefined),
+      setHasExitedPlanMode: vi.fn(),
+      hasExitedPlanModeInSession: vi.fn(() => false),
+      setNeedsPlanModeExitAttachment: vi.fn(),
+      getNeedsPlanModeExitAttachment: vi.fn(() => false),
+    } as unknown as Record<string, unknown>);
+    fastContainer.register("SubagentManager", {
+      getConfigurations: vi.fn().mockReturnValue([]),
+    });
+    fastContainer.register("SkillManager", {
+      getAvailableSkills: vi.fn().mockReturnValue([]),
+    });
+    fastContainer.register("MessageQueue", {
+      hasNotifications: vi.fn().mockReturnValue(false),
+      drainNotifications: vi.fn().mockReturnValue([]),
+    });
+
+    const fastSubagent = new AIManager(fastContainer, {
+      workdir: "/test/workdir",
+      stream: false,
+      modelOverride: "fastModel",
+    });
+    await fastSubagent.sendAIMessage();
+    const options = vi.mocked(aiService.callAgent).mock.calls[0][0];
+    expect(options.disableThinkingOptions).toEqual({
+      thinking: { type: "disabled" },
+    });
   });
 
   describe("Language Prompt Injection", () => {

--- a/packages/agent-sdk/tests/services/aiService.disableThinking.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.disableThinking.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { GatewayConfig, ModelConfig } from "@/types/index.js";
+
+// Test configuration constants
+const TEST_GATEWAY_CONFIG: GatewayConfig = {
+  apiKey: "test-api-key",
+  baseURL: "http://localhost:test",
+};
+
+const TEST_MODEL_CONFIG: ModelConfig = {
+  model: "agent-model",
+  fastModel: "fast-model",
+};
+
+const DEFAULT_THINKING = { thinking: { type: "disabled" } };
+
+// Mock the OpenAI client
+const mockCreate = vi.fn();
+const mockOpenAI = {
+  chat: {
+    completions: {
+      create: mockCreate,
+    },
+  },
+};
+
+vi.mock("@/utils/openaiClient.js", () => ({
+  OpenAIClient: vi.fn().mockImplementation(function () {
+    return mockOpenAI;
+  }),
+}));
+
+function mockCreateWithResponse(content = "processed") {
+  mockCreate.mockReturnValue({
+    withResponse: vi.fn().mockResolvedValue({
+      data: {
+        choices: [{ message: { content }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+      },
+      response: {
+        headers: new Map([["content-type", "application/json"]]),
+      },
+    }),
+  });
+}
+
+describe("AI Service - disable thinking options (fast-model scenarios)", () => {
+  beforeEach(() => {
+    mockCreate.mockReset();
+  });
+
+  describe("processWebContent", () => {
+    let processWebContent: typeof import("@/services/aiService.js").processWebContent;
+
+    beforeEach(async () => {
+      const aiService = await import("@/services/aiService.js");
+      processWebContent = aiService.processWebContent;
+      mockCreate.mockResolvedValue({
+        choices: [{ message: { content: "processed content" } }],
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+      });
+    });
+
+    it("does not send disable-thinking params when none configured", async () => {
+      await processWebContent({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: TEST_MODEL_CONFIG,
+        content: "<html>...</html>",
+        prompt: "Summarize",
+        model: "fast-model",
+      });
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.model).toBe("fast-model");
+      expect(callArgs.thinking).toBeUndefined();
+      expect(callArgs.enable_thinking).toBeUndefined();
+    });
+
+    it("uses explicitly configured disableThinkingOptions", async () => {
+      await processWebContent({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: {
+          ...TEST_MODEL_CONFIG,
+          disableThinkingOptions: { enable_thinking: false },
+        },
+        content: "<html>...</html>",
+        prompt: "Summarize",
+        model: "fast-model",
+      });
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.enable_thinking).toBe(false);
+      expect(callArgs.thinking).toBeUndefined();
+    });
+
+    it("omits disable-thinking params when explicitly configured as an empty object", async () => {
+      await processWebContent({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: {
+          ...TEST_MODEL_CONFIG,
+          disableThinkingOptions: {},
+        },
+        content: "<html>...</html>",
+        prompt: "Summarize",
+        model: "fast-model",
+      });
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.thinking).toBeUndefined();
+      expect(callArgs.enable_thinking).toBeUndefined();
+    });
+
+    it("does not send disable-thinking params when no fast model override is used", async () => {
+      await processWebContent({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: TEST_MODEL_CONFIG,
+        content: "<html>...</html>",
+        prompt: "Summarize",
+      });
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.model).toBe("agent-model");
+      expect(callArgs.thinking).toBeUndefined();
+    });
+  });
+
+  describe("evaluateGoal", () => {
+    let evaluateGoal: typeof import("@/services/aiService.js").evaluateGoal;
+
+    beforeEach(async () => {
+      const aiService = await import("@/services/aiService.js");
+      evaluateGoal = aiService.evaluateGoal;
+      mockCreate.mockResolvedValue({
+        choices: [{ message: { content: "yes" } }],
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+      });
+    });
+
+    it("does not send disable-thinking params when none configured", async () => {
+      await evaluateGoal({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: TEST_MODEL_CONFIG,
+        model: "fast-model",
+        goalCondition: "Task complete",
+        messages: [{ role: "user", content: "hi" }],
+      });
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.model).toBe("fast-model");
+      expect(callArgs.thinking).toBeUndefined();
+      expect(callArgs.enable_thinking).toBeUndefined();
+    });
+
+    it("uses explicitly configured disableThinkingOptions", async () => {
+      await evaluateGoal({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: {
+          ...TEST_MODEL_CONFIG,
+          disableThinkingOptions: { enable_thinking: false },
+        },
+        model: "fast-model",
+        goalCondition: "Task complete",
+        messages: [{ role: "user", content: "hi" }],
+      });
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.enable_thinking).toBe(false);
+      expect(callArgs.thinking).toBeUndefined();
+    });
+  });
+
+  describe("callAgent", () => {
+    let callAgent: typeof import("@/services/aiService.js").callAgent;
+
+    beforeEach(async () => {
+      const aiService = await import("@/services/aiService.js");
+      callAgent = aiService.callAgent;
+      mockCreateWithResponse();
+    });
+
+    it("merges disableThinkingOptions when provided (fast-model subagent loop)", async () => {
+      await callAgent({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: TEST_MODEL_CONFIG,
+        messages: [{ role: "user", content: "Test message" }],
+        workdir: "/test/workdir",
+        disableThinkingOptions: DEFAULT_THINKING,
+      });
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.thinking).toEqual({ type: "disabled" });
+    });
+
+    it("does not send disable-thinking params when none provided (agent loop untouched)", async () => {
+      await callAgent({
+        gatewayConfig: TEST_GATEWAY_CONFIG,
+        modelConfig: TEST_MODEL_CONFIG,
+        messages: [{ role: "user", content: "Test message" }],
+        workdir: "/test/workdir",
+      });
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.thinking).toBeUndefined();
+      expect(callArgs.enable_thinking).toBeUndefined();
+    });
+  });
+});

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -660,6 +660,111 @@ describe("ConfigurationService", () => {
     });
   });
 
+  describe("resolveModelConfig — disableThinkingOptions", () => {
+    it("should set disableThinkingOptions from models[fastModel]", async () => {
+      const config = {
+        models: {
+          "gpt-4o": { options: { temperature: 0.7 } },
+          "gpt-4o-mini": {
+            disableThinkingOptions: { enable_thinking: false },
+          },
+        },
+      };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      const origModel = process.env.WAVE_MODEL;
+      const origFastModel = process.env.WAVE_FAST_MODEL;
+      delete process.env.WAVE_MODEL;
+      delete process.env.WAVE_FAST_MODEL;
+      try {
+        await configService.loadMergedConfiguration(tempDir);
+        const resolved = configService.resolveModelConfig(
+          "gpt-4o",
+          "gpt-4o-mini",
+        );
+
+        expect(resolved.disableThinkingOptions).toEqual({
+          enable_thinking: false,
+        });
+      } finally {
+        if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
+        else delete process.env.WAVE_MODEL;
+        if (origFastModel !== undefined)
+          process.env.WAVE_FAST_MODEL = origFastModel;
+        else delete process.env.WAVE_FAST_MODEL;
+      }
+    });
+
+    it("should prefer the fast model's disableThinkingOptions over the agent model's", async () => {
+      const config = {
+        models: {
+          "gpt-4o": {
+            disableThinkingOptions: { thinking: { type: "disabled" } },
+          },
+          "gpt-4o-mini": {
+            disableThinkingOptions: { enable_thinking: false },
+          },
+        },
+      };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      const origModel = process.env.WAVE_MODEL;
+      const origFastModel = process.env.WAVE_FAST_MODEL;
+      delete process.env.WAVE_MODEL;
+      delete process.env.WAVE_FAST_MODEL;
+      try {
+        await configService.loadMergedConfiguration(tempDir);
+        const resolved = configService.resolveModelConfig(
+          "gpt-4o",
+          "gpt-4o-mini",
+        );
+
+        expect(resolved.disableThinkingOptions).toEqual({
+          enable_thinking: false,
+        });
+      } finally {
+        if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
+        else delete process.env.WAVE_MODEL;
+        if (origFastModel !== undefined)
+          process.env.WAVE_FAST_MODEL = origFastModel;
+        else delete process.env.WAVE_FAST_MODEL;
+      }
+    });
+
+    it("should leave disableThinkingOptions undefined when neither model configures it", async () => {
+      const config = {
+        models: {
+          "gpt-4o": { options: { temperature: 0.7 } },
+          "gpt-4o-mini": { options: { temperature: 0.2 } },
+        },
+      };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      const origModel = process.env.WAVE_MODEL;
+      const origFastModel = process.env.WAVE_FAST_MODEL;
+      delete process.env.WAVE_MODEL;
+      delete process.env.WAVE_FAST_MODEL;
+      try {
+        await configService.loadMergedConfiguration(tempDir);
+        const resolved = configService.resolveModelConfig(
+          "gpt-4o",
+          "gpt-4o-mini",
+        );
+
+        expect(resolved.disableThinkingOptions).toBeUndefined();
+      } finally {
+        if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
+        else delete process.env.WAVE_MODEL;
+        if (origFastModel !== undefined)
+          process.env.WAVE_FAST_MODEL = origFastModel;
+        else delete process.env.WAVE_FAST_MODEL;
+      }
+    });
+  });
+
   describe("resolveModelConfig — capabilities", () => {
     it("should merge capabilities from models[modelName] into resolved config", async () => {
       const config = {


### PR DESCRIPTION
Fix "Empty response from AI" for reasoning fast models: models[X].disableThinkingOptions now passes verbatim disable-thinking params (e.g. {"thinking":{"type":"disabled"}} / {"enable_thinking":false}) to fast-model scenarios (webFetch content processing, goal evaluation, fast subagents, autoMemory) — never to the agent loop.

No built-in default: params are sent only when explicitly configured, so gateways that do not accept thinking params are never hit with them; {} explicitly clears. resolveModelConfig re-applies the fast-model value after the spread so models[agentModel] cannot clobber it.

Spec (agent-config.md) updated with user story + 6 acceptance scenarios; TDD tests cover processWebContent, evaluateGoal, callAgent merge, agent-loop exclusion, and fastModel > agentModel precedence.