### PR TITLE
fix(code): handle stdout backpressure and ENOBUFS in stdio server

### DIFF
--- a/packages/code/src/stdio/stdioServer.ts
+++ b/packages/code/src/stdio/stdioServer.ts
@@ -31,10 +31,20 @@ export class StdioServer {
   private input: Readable;
   private output: Writable;
   private started = false;
+  // Lines waiting to be written while the output pipe is full (backpressure).
+  private pendingLines: string[] = [];
+  private awaitingDrain = false;
+  // A stdout write failure (e.g. ENOBUFS when the reader is briefly slow,
+  // which macOS reports instead of EAGAIN) must not crash the shared stdio
+  // process — log it and keep going.
+  private handleOutputError = (err: Error): void => {
+    process.stderr.write(`[stdio] stdout write error: ${err.message}\n`);
+  };
 
   constructor(options: StdioServerOptions = {}) {
     this.input = options.input ?? process.stdin;
     this.output = options.output ?? process.stdout;
+    this.output.on("error", this.handleOutputError);
     this.bridge = new AgentBridge({
       ...options.bridgeOptions,
       emit: (method, params, sessionId) =>
@@ -74,6 +84,7 @@ export class StdioServer {
     this.rl?.close();
     this.rl = undefined;
     this.started = false;
+    this.output.off("error", this.handleOutputError);
   }
 
   async handleLine(line: string): Promise<void> {
@@ -164,6 +175,31 @@ export class StdioServer {
   }
 
   private write(obj: JsonRpcResponse | JsonRpcNotification): void {
-    this.output.write(JSON.stringify(obj) + "\n");
+    this.pendingLines.push(JSON.stringify(obj) + "\n");
+    this.flush();
+  }
+
+  /**
+   * Write queued lines until the output reports backpressure (write returns
+   * false), then pause and resume on 'drain'. Without this, a reader that is
+   * briefly slow (e.g. the desktop host restoring a session) lets the OS pipe
+   * fill up; on macOS the kernel reports that as ENOBUFS and the unhandled
+   * 'error' event would kill the whole shared stdio process.
+   */
+  private flush(): void {
+    if (this.awaitingDrain) return;
+    while (this.pendingLines.length > 0) {
+      const line = this.pendingLines[0];
+      this.pendingLines.shift();
+      if (!this.output.write(line)) {
+        // The line is buffered but the pipe is full — stop until drain.
+        this.awaitingDrain = true;
+        this.output.once("drain", () => {
+          this.awaitingDrain = false;
+          this.flush();
+        });
+        break;
+      }
+    }
   }
 }

--- a/packages/code/tests/stdio/stdioServer.test.ts
+++ b/packages/code/tests/stdio/stdioServer.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, vi, beforeEach, afterEach } from "vitest";
-import { PassThrough } from "stream";
+import { PassThrough, Writable } from "stream";
 import { Agent } from "wave-agent-sdk";
 
 // Mock the Agent SDK
@@ -447,6 +447,69 @@ test("handleNotification forwards permissionResponse notification without throwi
   // No new response written for notifications
   await linesBefore;
   expect(true).toBe(true);
+
+  server.stop();
+});
+
+// ── Output resilience: backpressure + write errors ───────────────
+
+test("output write error (ENOBUFS) is logged, not fatal", async () => {
+  const stderrSpy = vi
+    .spyOn(process.stderr, "write")
+    .mockImplementation(() => true);
+  const input = new PassThrough();
+  const output = new Writable({
+    write(_chunk, _enc, cb) {
+      cb(new Error("write ENOBUFS"));
+    },
+  });
+  const server = new StdioServer({ input, output });
+  server.start();
+
+  server.sendNotification("boom", { v: 1 });
+
+  await vi.waitFor(() => {
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("ENOBUFS"));
+  });
+  server.stop();
+  stderrSpy.mockRestore();
+});
+
+test("backpressure: pauses writes when pipe is full, resumes on drain in order", async () => {
+  const input = new PassThrough();
+  const written: string[] = [];
+  let pendingCb: (() => void) | null = null;
+  const output = new Writable({
+    highWaterMark: 1,
+    write(chunk, _enc, cb) {
+      written.push(chunk.toString());
+      pendingCb = () => cb();
+    },
+  });
+  const writeSpy = vi.spyOn(output, "write");
+  const server = new StdioServer({ input, output });
+  server.start();
+
+  server.sendNotification("n1", { v: 1 });
+  server.sendNotification("n2", { v: 2 });
+  server.sendNotification("n3", { v: 3 });
+
+  // First write fills the pipe (returns false) → the server must pause
+  // instead of piling more writes into the OS pipe.
+  expect(writeSpy).toHaveBeenCalledTimes(1);
+  expect(written[0]).toContain('"method":"n1"');
+
+  // Reader drains → queued lines flush one at a time, in order.
+  // NOTE: Writable calls the write callback synchronously when we release it,
+  // so drain fires synchronously inside pendingCb() and the next line is
+  // already written (and pendingCb re-assigned) by the time we await.
+  pendingCb!();
+  await vi.waitFor(() => expect(written).toHaveLength(2));
+  expect(written[1]).toContain('"method":"n2"');
+
+  pendingCb!();
+  await vi.waitFor(() => expect(written).toHaveLength(3));
+  expect(written[2]).toContain('"method":"n3"');
 
   server.stop();
 });


### PR DESCRIPTION
## Problem

The shared wave --stdio process occasionally crashed with 'write ENOBUFS' (errno 55) on the desktop app, reported as "恢复会话失败: wave --stdio process exited (code: 1, signal: null)" with an Unhandled 'error' event on a Socket.

Root cause: during session restore the child process emits full message-array messagesChange notifications faster than the Electron main process consumes them. The OS stdout pipe fills up; on macOS the kernel reports a full pipe as ENOBUFS (Linux would retry with EAGAIN), and the unhandled 'error' event on the stdout Socket kills the whole shared stdio process. High-speed model streaming contributes the same pressure (unthrottled assistantContentUpdated notifications carrying accumulated text).

## Fix

packages/code/src/stdio/stdioServer.ts:
- Attach an 'error' listener to stdout so a write failure is logged to stderr instead of crashing the process.
- Add drain-based backpressure: sendNotification/sendResponse queue lines and flush them; when Writable.write returns false the pipe is full, so writing pauses and resumes on 'drain' — messages stay complete and in order, and the pipe never overflows.

Tests (TDD, packages/code/tests/stdio/stdioServer.test.ts):
- stdout write error (ENOBUFS) is logged and not fatal
- backpressure pauses writes when the pipe is full and resumes on drain in order

## Verification

- packages/code: 1160 tests pass (84 files), type-check clean
- husky pre-commit type-check/lint/prettier pass