### PR TITLE
fix(cli): pasted text no longer submits — bracketed paste support

### DIFF
--- a/docs/specs/ui/text-paste.md
+++ b/docs/specs/ui/text-paste.md
@@ -1,0 +1,44 @@
+---
+name: "文本粘贴"
+description: "修复粘贴文本被立即提交：对齐 Claude Code 启用 bracketed paste（DECSET 2004）并在 stdin 原始字节层识别粘贴标记，粘贴内容仅插入不提交"
+order: 260
+---
+
+# 功能规格说明：文本粘贴
+
+**创建日期**：2026-08-04
+
+## 用户场景与测试 _（必填）_
+
+### 用户故事：粘贴文本仅插入不提交（优先级：P1）
+
+作为 Wave CLI 用户，我希望从 tmux/终端复制并粘贴文本时，粘贴内容只进入输入框而不是立即发送，以便粘贴后我可以先编辑再手动回车提交。
+
+**为什么是这个优先级**：这是用户反馈的 bug（从 tmux 复制 "Watch PR checks until completion" 粘贴到 CLI 立即提交）。根因：tmux 复制内容以换行符结尾，粘贴时终端发送 `\r`；ink 将整段粘贴作为一个回调传入且 `key.return=false`（ink 的 `parseKeypress` 只把孤立的 `\r` 识别为回车），于是落入输入框的 "SSH-coalesced Enter" 启发式（`inputReducer.ts:1258`：多字符 chunk 以单个 `\r` 结尾视为"打字+回车合包"）→ 插入文本后立即提交。Claude Code 不会发生此问题：CC 启用 bracketed paste（DECSET 2004），终端将粘贴内容包裹在 `\x1b[200~` / `\x1b[201~` 中，CC 解析时标记 `isPasted=true`，粘贴内容路由到 `onTextPaste` 仅做归一化插入（`\r`→`\n`），绝不提交，因此 CC 的 coalesced-Enter 启发式只对真实的"打字+回车"生效。Wave 未启用 bracketed paste 也无粘贴状态跟踪，故粘贴尾部 `\r` 落入合包回车误判。
+
+**独立测试**：通过 stdin 注入 `\x1b[200~Watch PR checks until completion\r\x1b[201~`，验证输入框文本变为粘贴内容（`\r` 归一化为 `\n`）且不触发提交。
+
+**验收场景**：
+
+1. **假设**终端支持 bracketed paste 且 Wave 已启用，**当**粘贴单行文本（尾部带换行，如 `Watch PR checks until completion\r`）时，**则**文本插入输入框，不触发提交。
+2. **假设**同上，**当**粘贴多行文本（如 `line1\rline2\r`）时，**则**换行统一归一化为 `\n` 插入输入框（对齐 CC `onTextPaste` 的 `\r`→`\n` 替换），不触发提交。
+3. **假设**粘贴内容不含换行（纯单行无尾部 `\r`），**当**粘贴时，**则**直接插入文本，不触发提交。
+4. **假设**用户手动输入文本后按回车（真实打字+回车在慢链路下合包为 `text\r`），**当**该 chunk 到达时，**则**保留现有 "SSH-coalesced Enter" 行为：插入文本并提交（对齐 CC `useTextInput.ts:485-499`）。
+5. **假设**终端不支持 bracketed paste（无 `\x1b[200~` 包裹），**当**粘贴时，**则**退化为现状行为，不报错、不崩溃。
+6. **假设**正在输入框中输入，**当**收到非粘贴的普通按键输入（退格、编辑键、快捷键等）时，**则**行为完全不变。
+
+---
+
+### 边界情况
+
+- **长粘贴分块**：终端可能将长粘贴拆成多个 chunk（起始 chunk 含 `\x1b[200~`、中间为纯文本 chunk、结束 chunk 含 `\x1b[201~`）。从检测到粘贴起始标记起进入"粘贴中"状态，缓冲所有中间 chunk，直到 `\x1b[201~` 结束并一次性插入；粘贴中到达的独立 `\r` chunk 必须作为换行内容缓冲，不得触发提交。
+- **启用与退出 bracketed paste**：Wave 启动渲染时向 stdout 写入 `\x1b[?2004h`，退出/卸载时写入 `\x1b[?2004l`，避免残留终端模式状态。
+- **与既有启发式共存**："SSH-coalesced Enter" 启发式保留（CC 同样保留），仅对不含粘贴标记的输入生效；进入粘贴路径的内容绝不进入该启发式。
+- **实施层级**：ink 的 `useInput` 回调层不可靠——chunk 已过 `parseKeypress`（剥离前导 ESC、破坏粘贴起始转义序列）。需在 stdin 原始字节层拦截（参考 ink `confirmKittySupport` 的 `stdin.unshift()` 重注入模式：`prependListener('readable')` 先读 chunk，剥离粘贴标记后把非粘贴字节 `unshift` 回 stdin 交给 ink 正常管线，粘贴内容直接派发"插入文本"事件）。[待确认实现方案]
+- **纯文本终端兼容**：不支持 bracketed paste 的终端（如部分旧版 tmux）不发送标记，走现状路径。
+
+## 假设
+
+- 目标终端（tmux、常见 xterm 兼容终端）支持 DECSET 2004 bracketed paste；不支持时行为退化为现状。
+- 粘贴内容归一化与 Claude Code `onTextPaste` 一致：`stripAnsi` + `\r`→`\n`；Tab 展开为 4 空格是否纳入本次范围待确认（CC 包含该处理）。[待确认]
+- 长粘贴的输入框呈现（多行输入、占位符）沿用现有机制，不在本规格范围内扩展。

--- a/packages/code/src/cli.tsx
+++ b/packages/code/src/cli.tsx
@@ -31,6 +31,17 @@ export async function startCli(options: CliOptions): Promise<void> {
   // Continue with ink-based UI for normal mode
   let shouldRemoveWorktree = false;
 
+  // Enable bracketed paste (DECSET 2004) so terminals wrap pasted text in
+  // \x1b[200~ ... \x1b[201~ markers. The input pipeline uses these to insert
+  // pasted text without submitting (a pasted trailing \r is not an Enter).
+  // Terminals without bracketed-paste support ignore the sequence and paste
+  // without markers, falling back to legacy behavior. No-op when stdout is
+  // not a TTY (piped input, stdio mode).
+  const stdoutIsTTY = process.stdout.isTTY === true;
+  if (stdoutIsTTY) {
+    process.stdout.write("\x1b[?2004h");
+  }
+
   const handleExit = (shouldRemove: boolean) => {
     shouldRemoveWorktree = shouldRemove;
     unmount();
@@ -59,7 +70,15 @@ export async function startCli(options: CliOptions): Promise<void> {
   );
 
   // Wait for the app to finish unmounting
-  await waitUntilExit();
+  try {
+    await waitUntilExit();
+  } finally {
+    // Disable bracketed paste (DECSET 2004) so the terminal returns to its
+    // previous paste handling.
+    if (stdoutIsTTY) {
+      process.stdout.write("\x1b[?2004l");
+    }
+  }
 
   try {
     // Clean up old log files

--- a/packages/code/src/hooks/useInputManager.ts
+++ b/packages/code/src/hooks/useInputManager.ts
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, useCallback } from "react";
+import { useEffect, useReducer, useCallback, useRef } from "react";
 import { Key } from "ink";
 import {
   inputReducer,
@@ -6,6 +6,7 @@ import {
   InputManagerCallbacks,
   ESC_DOUBLE_PRESS_TIMEOUT_MS,
 } from "../managers/inputReducer.js";
+import { createBracketedPasteDetector } from "../utils/bracketedPaste.js";
 import {
   searchFiles as searchFilesUtil,
   PermissionMode,
@@ -18,6 +19,11 @@ export const useInputManager = (
   callbacks: Partial<InputManagerCallbacks> = {},
 ) => {
   const [state, dispatch] = useReducer(inputReducer, initialState);
+
+  // Detects bracketed paste (DECSET 2004) markers so pasted text is inserted
+  // without triggering submit — a pasted trailing \r must not be treated as
+  // Enter (see utils/bracketedPaste.ts).
+  const pasteDetectorRef = useRef(createBracketedPasteDetector());
 
   const {
     onInputTextChange,
@@ -536,10 +542,42 @@ export const useInputManager = (
 
   const handleInput = useCallback(
     async (input: string, key: Key) => {
+      const result = pasteDetectorRef.current.process(input);
+
+      if (result.kind === "consume") {
+        // Content of an in-flight bracketed paste (or an empty paste):
+        // hold it, never submit or insert prematurely.
+        return true;
+      }
+
+      if (result.kind === "paste") {
+        if (result.leadingInput) {
+          dispatch({
+            type: "HANDLE_KEY",
+            payload: {
+              input: result.leadingInput,
+              key,
+              hasSlashCommand: (cmd) => !!onHasSlashCommand?.(cmd),
+              hasQueuedMessages: hasQueuedMessagesProp ?? false,
+              isIdle: isIdleProp ?? false,
+            },
+          });
+        }
+        if (result.text !== "") {
+          // Insert-only: \r → \n normalizes CRLF terminals, matching the
+          // canonical paste path (inputHandlers.handlePasteInput).
+          dispatch({
+            type: "INSERT_TEXT_WITH_PLACEHOLDER",
+            payload: result.text.replace(/\r/g, "\n"),
+          });
+        }
+        return true;
+      }
+
       dispatch({
         type: "HANDLE_KEY",
         payload: {
-          input,
+          input: result.input,
           key,
           hasSlashCommand: (cmd) => !!onHasSlashCommand?.(cmd),
           hasQueuedMessages: hasQueuedMessagesProp ?? false,

--- a/packages/code/src/utils/bracketedPaste.ts
+++ b/packages/code/src/utils/bracketedPaste.ts
@@ -1,0 +1,170 @@
+/**
+ * Bracketed paste (DECSET 2004) detector.
+ *
+ * When bracketed paste is enabled, terminals wrap pasted text in
+ * `\x1b[200~` (start) and `\x1b[201~` (end) markers, which lets the input
+ * pipeline distinguish "text was pasted" from "user typed keys" — most
+ * importantly, a pasted trailing `\r` must NOT be treated as an Enter key.
+ *
+ * ink delivers each stdin chunk through useInput after stripping ONE leading
+ * ESC from the parsed sequence (see use-input.js), so markers may arrive in
+ * either the raw form (`\x1b[200~`) or the stripped form (`[200~`), and may
+ * be split across chunks. The detector normalizes both forms and buffers
+ * partial markers until they complete (deferral is safe: a deferred partial
+ * is flushed unchanged if the next chunk does not complete a marker).
+ */
+export type PasteProcessResult =
+  | { kind: "input"; input: string }
+  | { kind: "paste"; text: string; leadingInput?: string }
+  | { kind: "consume" };
+
+export interface BracketedPasteDetector {
+  /**
+   * Feed one input chunk (as delivered by ink's useInput callback).
+   * - `input`: regular keystrokes, pass through to normal handling.
+   * - `paste`: completed bracketed paste; insert `text` without submitting.
+   *   `leadingInput` (rare) is content that preceded the start marker in the
+   *   same chunk and should be handled as regular input first.
+   * - `consume`: content of an in-flight paste (or an empty paste); do
+   *   nothing with this chunk.
+   */
+  process(chunk: string): PasteProcessResult;
+  reset(): void;
+}
+
+const ESC = "\u001b";
+const START_STRIPPED = "[200~";
+const START_RAW = `${ESC}[200~`;
+const END_STRIPPED = "[201~";
+const END_RAW = `${ESC}[201~`;
+
+const START_FORMS = [START_RAW, START_STRIPPED];
+const END_FORMS = [END_RAW, END_STRIPPED];
+
+/**
+ * Suffixes that may be the beginning of a marker split across chunks.
+ * Longest-first so the longest matching suffix is deferred (e.g. `[200`
+ * rather than `[20` for `...x[200`). Deferral is flush-equivalent: if the
+ * next chunk does not complete a marker, the deferred suffix is delivered
+ * as regular input unchanged.
+ */
+const PARTIAL_SUFFIXES = [
+  `${ESC}[201`,
+  `${ESC}[200`,
+  `${ESC}[20`,
+  `${ESC}[2`,
+  "[201",
+  "[200",
+  "[20",
+  "[2",
+].sort((a, b) => b.length - a.length);
+
+export function createBracketedPasteDetector(): BracketedPasteDetector {
+  let inPaste = false;
+  let buffer = ""; // paste content collected since the start marker
+  let pending = ""; // deferred partial marker suffix from a previous chunk
+
+  const findFirst = (
+    text: string,
+    forms: string[],
+  ): { index: number; length: number } | null => {
+    let best: { index: number; length: number } | null = null;
+    for (const form of forms) {
+      const index = text.indexOf(form);
+      if (index !== -1 && (best === null || index < best.index)) {
+        best = { index, length: form.length };
+      }
+    }
+    return best;
+  };
+
+  const endsWithPartial = (text: string): string | null => {
+    for (const prefix of PARTIAL_SUFFIXES) {
+      if (text.endsWith(prefix)) {
+        return prefix;
+      }
+    }
+    return null;
+  };
+
+  const process = (chunk: string): PasteProcessResult => {
+    let remaining = pending + chunk;
+    pending = "";
+    let leadingInput = "";
+    let pasteText: string | null = null;
+
+    while (remaining.length > 0) {
+      if (!inPaste) {
+        const start = findFirst(remaining, START_FORMS);
+        if (start) {
+          leadingInput += remaining.slice(0, start.index);
+          remaining = remaining.slice(start.index + start.length);
+          inPaste = true;
+          continue;
+        }
+        // Orphan end marker (start was missed, e.g. consumed by another
+        // input handler): treat the preceding text as paste so a trailing
+        // `\r` cannot trigger the coalesced-Enter submit heuristic.
+        const end = findFirst(remaining, END_FORMS);
+        if (end) {
+          pasteText =
+            (pasteText ?? "") + leadingInput + remaining.slice(0, end.index);
+          leadingInput = "";
+          remaining = remaining.slice(end.index + end.length);
+          continue;
+        }
+        const partial = endsWithPartial(remaining);
+        if (partial) {
+          pending = remaining.slice(remaining.length - partial.length);
+          remaining = remaining.slice(0, remaining.length - partial.length);
+        }
+        if (remaining.length > 0) {
+          leadingInput += remaining;
+          remaining = "";
+        }
+        break;
+      }
+
+      const end = findFirst(remaining, END_FORMS);
+      if (end) {
+        pasteText = (pasteText ?? "") + buffer + remaining.slice(0, end.index);
+        buffer = "";
+        inPaste = false;
+        remaining = remaining.slice(end.index + end.length);
+        continue;
+      }
+      const partial = endsWithPartial(remaining);
+      if (partial) {
+        pending = remaining.slice(remaining.length - partial.length);
+        remaining = remaining.slice(0, remaining.length - partial.length);
+      }
+      buffer += remaining;
+      remaining = "";
+      break;
+    }
+
+    if (inPaste) {
+      // Paste still in flight: hold the content, deliver nothing yet.
+      return { kind: "consume" };
+    }
+    if (pasteText !== null) {
+      const result: { kind: "paste"; text: string; leadingInput?: string } = {
+        kind: "paste",
+        text: pasteText,
+      };
+      if (leadingInput !== "") {
+        result.leadingInput = leadingInput;
+      }
+      return result;
+    }
+    return { kind: "input", input: leadingInput };
+  };
+
+  const reset = (): void => {
+    inPaste = false;
+    buffer = "";
+    pending = "";
+  };
+
+  return { process, reset };
+}

--- a/packages/code/tests/utils/bracketedPaste.test.ts
+++ b/packages/code/tests/utils/bracketedPaste.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import { createBracketedPasteDetector } from "../../src/utils/bracketedPaste.js";
+
+const ESC = "\u001b";
+
+describe("createBracketedPasteDetector", () => {
+  describe("single-chunk paste (whole paste in one stdin chunk)", () => {
+    it("detects a paste with a trailing \\r (the tmux copy bug)", () => {
+      const detector = createBracketedPasteDetector();
+      // ink strips ONE leading ESC, so the callback sees `[200~...\x1b[201~`.
+      const result = detector.process(
+        `[200~Watch PR checks until completion\r${ESC}[201~`,
+      );
+      expect(result).toEqual({
+        kind: "paste",
+        text: "Watch PR checks until completion\r",
+      });
+    });
+
+    it("detects the raw (un-stripped) marker form", () => {
+      const detector = createBracketedPasteDetector();
+      const result = detector.process(
+        `${ESC}[200~Watch PR checks until completion\r${ESC}[201~`,
+      );
+      expect(result).toEqual({
+        kind: "paste",
+        text: "Watch PR checks until completion\r",
+      });
+    });
+
+    it("detects a multi-line paste", () => {
+      const detector = createBracketedPasteDetector();
+      const result = detector.process(`[200~line1\rline2${ESC}[201~`);
+      expect(result).toEqual({ kind: "paste", text: "line1\rline2" });
+    });
+
+    it("detects an empty paste", () => {
+      const detector = createBracketedPasteDetector();
+      const result = detector.process(`[200~${ESC}[201~`);
+      expect(result).toEqual({ kind: "paste", text: "" });
+    });
+
+    it("keeps content after a nested-looking start marker inside the paste", () => {
+      const detector = createBracketedPasteDetector();
+      const result = detector.process(`[200~a[200~b${ESC}[201~`);
+      expect(result).toEqual({ kind: "paste", text: "a[200~b" });
+    });
+
+    it("reports content before the start marker as leadingInput", () => {
+      const detector = createBracketedPasteDetector();
+      const result = detector.process(`abc[200~pasted${ESC}[201~`);
+      expect(result).toEqual({
+        kind: "paste",
+        text: "pasted",
+        leadingInput: "abc",
+      });
+    });
+  });
+
+  describe("split-chunk paste (markers and content across stdin chunks)", () => {
+    it("holds chunks while in paste and never yields input for the \\r chunk", () => {
+      const detector = createBracketedPasteDetector();
+      expect(detector.process(`[200~`)).toEqual({ kind: "consume" });
+      expect(detector.process("Watch PR checks until completion")).toEqual({
+        kind: "consume",
+      });
+      // The lone \r mid-paste must NOT be surfaced as input (no submit).
+      expect(detector.process("\r")).toEqual({ kind: "consume" });
+      expect(detector.process(`${ESC}[201~`)).toEqual({
+        kind: "paste",
+        text: "Watch PR checks until completion\r",
+      });
+    });
+
+    it("handles an end marker split across two chunks", () => {
+      const detector = createBracketedPasteDetector();
+      expect(detector.process(`[200~text\r`)).toEqual({ kind: "consume" });
+      expect(detector.process(`${ESC}[201`)).toEqual({ kind: "consume" });
+      expect(detector.process(`~`)).toEqual({
+        kind: "paste",
+        text: "text\r",
+      });
+    });
+
+    it("handles a start marker split across two chunks", () => {
+      const detector = createBracketedPasteDetector();
+      // `[200` is a deferred partial, so the chunk yields no input.
+      expect(detector.process(`[200`)).toEqual({ kind: "input", input: "" });
+      expect(detector.process(`~pasted${ESC}[201~`)).toEqual({
+        kind: "paste",
+        text: "pasted",
+      });
+    });
+
+    it("flushes a deferred partial unchanged when no marker completes", () => {
+      const detector = createBracketedPasteDetector();
+      expect(detector.process(`[200`)).toEqual({ kind: "input", input: "" });
+      expect(detector.process("xyz")).toEqual({
+        kind: "input",
+        input: "[200xyz",
+      });
+    });
+
+    it("handles a partial start marker at the end of a longer chunk", () => {
+      const detector = createBracketedPasteDetector();
+      // "abc[200" -> "abc" is input, "[200" is deferred.
+      expect(detector.process("abc[200")).toEqual({
+        kind: "input",
+        input: "abc",
+      });
+      expect(detector.process(`~pasted${ESC}[201~`)).toEqual({
+        kind: "paste",
+        text: "pasted",
+      });
+    });
+  });
+
+  describe("orphan end marker (start marker missed)", () => {
+    it("treats text before the orphan end marker as paste, not input", () => {
+      const detector = createBracketedPasteDetector();
+      const result = detector.process(
+        `Watch PR checks until completion\r${ESC}[201~`,
+      );
+      expect(result).toEqual({
+        kind: "paste",
+        text: "Watch PR checks until completion\r",
+      });
+    });
+  });
+
+  describe("normal input passthrough", () => {
+    it("passes through typed text", () => {
+      const detector = createBracketedPasteDetector();
+      expect(detector.process("hello")).toEqual({
+        kind: "input",
+        input: "hello",
+      });
+    });
+
+    it("passes through a lone \\r (genuine Enter is a separate key event)", () => {
+      const detector = createBracketedPasteDetector();
+      expect(detector.process("\r")).toEqual({ kind: "input", input: "\r" });
+    });
+
+    it("passes through an empty chunk (arrow keys etc.)", () => {
+      const detector = createBracketedPasteDetector();
+      expect(detector.process("")).toEqual({ kind: "input", input: "" });
+    });
+
+    it("passes through text ending in a bracket that is not a marker partial", () => {
+      const detector = createBracketedPasteDetector();
+      expect(detector.process("[200a")).toEqual({
+        kind: "input",
+        input: "[200a",
+      });
+    });
+
+    it("passes through mixed content without markers", () => {
+      const detector = createBracketedPasteDetector();
+      expect(detector.process("a\rb\nc")).toEqual({
+        kind: "input",
+        input: "a\rb\nc",
+      });
+    });
+  });
+
+  describe("reset", () => {
+    it("abandons an in-flight paste", () => {
+      const detector = createBracketedPasteDetector();
+      expect(detector.process(`[200~half`)).toEqual({ kind: "consume" });
+      detector.reset();
+      expect(detector.process(`[200~done${ESC}[201~`)).toEqual({
+        kind: "paste",
+        text: "done",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 背景

从 tmux 复制单行文本（如 `Watch PR checks until completion`）粘贴到 Wave CLI 输入框时会**直接提交**，而不是插入文本。根因：tmux 复制内容尾部带 `\r`，Ink 将整段粘贴作为单个 chunk 交给输入层，`inputReducer` 的 "SSH 合并回车" 启发式（`inputReducer.ts` 的 `isCoalescedEnter`）误判为"输入文本 + 回车"，从而插入后立即提交。Claude Code 不触发该问题。

## 修复

启用 bracketed paste（DECSET 2004），在输入层识别粘贴标记，粘贴内容**只插入不提交**：

- **`packages/code/src/utils/bracketedPaste.ts`**（新增）：纯状态机 `createBracketedPasteDetector()`，识别 `\x1b[200~` / `\x1b[201~` 标记（兼容 ink 剥除前导 ESC 后的 `[200~` 形式）、跨 chunk 缓冲、部分标记延迟（后续 chunk 不补全则原样吐出）、孤儿结束标记兜底（防 `\r` 命中提交启发式）。
- **`packages/code/src/hooks/useInputManager.ts`**：`handleInput` 先过 detector —— `consume`（粘贴流中）丢弃；`paste` 只 dispatch `INSERT_TEXT_WITH_PLACEHOLDER`（`\r`→`\n`，与既有 `handlePasteInput` 一致）；`input` 走原路径。真实键入的 Enter 行为不变。
- **`packages/code/src/cli.tsx`**：TTY 下启用/退出时禁用 bracketed paste（`\x1b[?2004h` / `\x1b[?2004l`）；非 TTY（管道/stdio）自动跳过；不支持该模式的终端忽略序列、回退旧行为。
- **`docs/specs/ui/text-paste.md`**（新增）：规格说明（1 用户故事 / 6 验收场景）。

## 验证

- `packages/code` 全量测试 **1186/1186 通过**（含既有 coalesced-Enter 与 `handlePasteInput` 测试，未改动）
- 新增 18 个 detector 单元测试
- tsc 类型检查、eslint、pre-commit hooks 全部通过
- spec-count 校验：66 个规格 ✓

## 说明

粘贴归一化只做 `\r`→`\n`（与 Wave 既有粘贴路径一致）；未引入 strip-ansi 依赖、未做 Tab 展开，如需与 Claude Code 完全对齐可后续补充。