### PR TITLE
fix(desktop): pull transcript after restoreSession so re-attached sessions load messages

### DIFF
--- a/packages/agent-sdk/tests/agent/agent.btw.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.btw.test.ts
@@ -62,9 +62,7 @@ describe("Agent askBtw", () => {
       tool_calls: [],
     });
 
-    mockCallbacks = {
-      onMessagesChange: vi.fn(),
-    };
+    mockCallbacks = {};
 
     agent = await Agent.create({
       workdir: `${BTW_HOME}/workdir`,

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -6,7 +6,7 @@ import {
   useChat,
   ChatContextType,
 } from "../../src/contexts/useChat.js";
-import { Agent, BackgroundShell } from "wave-agent-sdk";
+import { Agent, BackgroundShell, Task } from "wave-agent-sdk";
 import { AppProvider } from "../../src/contexts/useAppConfig.js";
 import { useInput } from "ink";
 
@@ -1368,6 +1368,200 @@ describe("ChatProvider", () => {
         success: true,
         parameters: '{"cmd":"ls"}',
       });
+    });
+  });
+
+  it("throttles reasoning streaming updates and flushes on end", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
+    const callbacks = agentCreateArgs.callbacks!;
+
+    // Start with a text block so the reasoning append + in-place update paths
+    // both map over a multi-block message
+    const assistantMsg = {
+      id: "msg-reason",
+      role: "assistant" as const,
+      blocks: [{ type: "text" as const, content: "pre" }],
+      timestamp: new Date().toISOString(),
+    };
+    Object.assign(mockAgent, { messages: [assistantMsg] });
+    callbacks.onAssistantMessageAdded!("msg-reason");
+    await vi.waitFor(() => {
+      expect(lastValue?.messages).toHaveLength(1);
+    });
+
+    // Leading edge appends a new reasoning block immediately
+    callbacks.onAssistantReasoningUpdated!({
+      messageId: "msg-reason",
+      chunk: "Th",
+      accumulated: "Th",
+      stage: "streaming",
+    });
+    await vi.waitFor(() => {
+      const reasoning = lastValue?.messages[0].blocks.find(
+        (b) => b.type === "reasoning",
+      ) as { content: string } | undefined;
+      expect(reasoning?.content).toBe("Th");
+    });
+
+    // Subsequent chunks within the 500ms window are coalesced (trailing)
+    callbacks.onAssistantReasoningUpdated!({
+      messageId: "msg-reason",
+      chunk: "ink",
+      accumulated: "Think",
+      stage: "streaming",
+    });
+    callbacks.onAssistantReasoningUpdated!({
+      messageId: "msg-reason",
+      chunk: "ing",
+      accumulated: "Thinking",
+      stage: "streaming",
+    });
+    const beforeFlush = lastValue?.messages[0].blocks.find(
+      (b) => b.type === "reasoning",
+    ) as { content: string } | undefined;
+    expect(beforeFlush?.content).toBe("Th");
+
+    // stage === "end" flushes the accumulated reasoning as an in-place update
+    callbacks.onAssistantReasoningUpdated!({
+      messageId: "msg-reason",
+      chunk: "…",
+      accumulated: "Thinking complete",
+      stage: "end",
+    });
+    await vi.waitFor(() => {
+      const reasoning = lastValue?.messages[0].blocks.find(
+        (b) => b.type === "reasoning",
+      ) as { content: string } | undefined;
+      expect(reasoning?.content).toBe("Thinking complete");
+    });
+
+    // Unknown messageId leaves messages untouched
+    callbacks.onAssistantReasoningUpdated!({
+      messageId: "nonexistent",
+      chunk: "x",
+      accumulated: "x",
+      stage: "end",
+    });
+    expect(lastValue?.messages[0].blocks).toHaveLength(2);
+  });
+
+  it("handles bang message callbacks", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
+    const callbacks = agentCreateArgs.callbacks!;
+
+    // onAddBangMessage appends a new user message with a bang block
+    callbacks.onAddBangMessage!("ls", "bang-1");
+    await vi.waitFor(() => {
+      expect(lastValue?.messages.some((m) => m.id === "bang-1")).toBe(true);
+    });
+
+    // A duplicate messageId must not append a second message
+    callbacks.onAddBangMessage!("ls", "bang-1");
+    await vi.waitFor(() => {
+      expect(lastValue?.messages.filter((m) => m.id === "bang-1")).toHaveLength(
+        1,
+      );
+    });
+
+    // onUpdateBangMessage patches the trailing bang block in place
+    callbacks.onUpdateBangMessage!("ls -la", "file.txt\n", "bang-1");
+    await vi.waitFor(() => {
+      const msg = lastValue!.messages.find((m) => m.id === "bang-1")!;
+      const bangBlock = msg.blocks[msg.blocks.length - 1];
+      expect(bangBlock).toMatchObject({
+        type: "bang",
+        command: "ls -la",
+        output: "file.txt\n",
+      });
+    });
+
+    // onCompleteBangMessage records the exit code and final stage
+    callbacks.onCompleteBangMessage!("ls -la", 0, "bang-1");
+    await vi.waitFor(() => {
+      const msg = lastValue!.messages.find((m) => m.id === "bang-1")!;
+      const bangBlock = msg.blocks[msg.blocks.length - 1];
+      expect(bangBlock).toMatchObject({
+        type: "bang",
+        exitCode: 0,
+        stage: "end",
+      });
+    });
+
+    // Unknown messageId is a no-op for update/complete
+    callbacks.onUpdateBangMessage!("x", "y", "nonexistent");
+    callbacks.onCompleteBangMessage!("x", 1, "nonexistent");
+    expect(lastValue?.messages).toHaveLength(1);
+  });
+
+  it("updates tasks only when the task list actually changes", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
+    const callbacks = agentCreateArgs.callbacks!;
+
+    const tasks = [
+      { id: "t1", subject: "Task 1", status: "pending" },
+    ] as unknown as Task[];
+    callbacks.onTasksChange!(tasks);
+    await vi.waitFor(() => {
+      expect(lastValue?.tasks).toEqual(tasks);
+    });
+
+    // Identical task list → reducer keeps the previous reference
+    const before = lastValue?.tasks;
+    callbacks.onTasksChange!([
+      { id: "t1", subject: "Task 1", status: "pending" },
+    ] as unknown as Task[]);
+    await vi.waitFor(() => {
+      expect(lastValue?.tasks).toBe(before);
+    });
+
+    // A task status change replaces the list
+    callbacks.onTasksChange!([
+      { id: "t1", subject: "Task 1", status: "running" },
+    ] as unknown as Task[]);
+    await vi.waitFor(() => {
+      expect(lastValue?.tasks[0].status).toBe("running");
+    });
+
+    // A length change replaces the list
+    callbacks.onTasksChange!([
+      ...tasks,
+      { id: "t2", subject: "Task 2", status: "pending" },
+    ] as unknown as Task[]);
+    await vi.waitFor(() => {
+      expect(lastValue?.tasks).toHaveLength(2);
     });
   });
 

--- a/packages/code/tests/stdio/agentBridge.test.ts
+++ b/packages/code/tests/stdio/agentBridge.test.ts
@@ -492,6 +492,46 @@ test("onSessionIdChange emits sessionIdChange notification", async () => {
   });
 });
 
+test("onSessionIdChange with unchanged session id skips re-key", async () => {
+  const { bridge, notifications } = createBridge();
+  vi.mocked(Agent.create).mockResolvedValue(createMockAgent());
+
+  await bridge.handleRequest("initialize", {});
+  const callbacks = vi.mocked(Agent.create).mock.calls[0][0]
+    .callbacks as AgentCallbacks;
+
+  // oldSessionId === newSessionId → the re-key condition is skipped
+  callbacks.onSessionIdChange!("test-session-id");
+
+  expect(notifications).toContainEqual({
+    method: "sessionIdChange",
+    params: { sessionId: "test-session-id" },
+    sessionId: "test-session-id",
+  });
+});
+
+test("onSessionIdChange after destroy handles missing sessions entry", async () => {
+  const { bridge, notifications } = createBridge();
+  const mockAgent = createMockAgent();
+  vi.mocked(Agent.create).mockResolvedValue(mockAgent);
+
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  const callbacks = vi.mocked(Agent.create).mock.calls[0][0]
+    .callbacks as AgentCallbacks;
+
+  // destroy removes the sessions map entry while registeredSessionId stays set
+  await bridge.handleRequest("destroy", {}, sessionId);
+
+  callbacks.onSessionIdChange!("session-after-destroy");
+
+  expect(notifications).toContainEqual({
+    method: "sessionIdChange",
+    params: { sessionId: "session-after-destroy" },
+    sessionId,
+  });
+});
+
 test("onMcpServersChange emits mcpServersChange notification", async () => {
   const { bridge, notifications } = createBridge();
   vi.mocked(Agent.create).mockResolvedValue(createMockAgent());
@@ -959,6 +999,17 @@ test("destroy destroys the agent", async () => {
   expect(mockAgent.destroy).toHaveBeenCalled();
 });
 
+test("destroy with unknown sessionId is a no-op", async () => {
+  const { bridge } = createBridge();
+  vi.mocked(Agent.create).mockResolvedValue(createMockAgent());
+
+  await bridge.handleRequest("initialize", {});
+
+  const result = await bridge.handleRequest("destroy", {}, "unknown-session");
+
+  expect(result).toBeNull();
+});
+
 // ── Error handling ───────────────────────────────────────────────
 
 test("unknown method throws METHOD_NOT_FOUND", async () => {
@@ -978,6 +1029,17 @@ test("calling method before initialize throws INTERNAL_ERROR", async () => {
   await expect(
     bridge.handleRequest("sendMessage", { text: "hi" }),
   ).rejects.toThrow("sessionId is required for this request");
+});
+
+test("calling method with an unknown sessionId throws Session not found", async () => {
+  const { bridge } = createBridge();
+  vi.mocked(Agent.create).mockResolvedValue(createMockAgent());
+
+  await bridge.handleRequest("initialize", {});
+
+  await expect(
+    bridge.handleRequest("sendMessage", { text: "hi" }, "unknown-session"),
+  ).rejects.toThrow("Session not found: unknown-session");
 });
 
 test("RpcError has correct code and toJsonRpcError", () => {
@@ -1411,6 +1473,25 @@ test("initialize with restoreSessionId reuses a live session instead of creating
   });
 });
 
+test("initialize with an unknown restoreSessionId creates a new agent", async () => {
+  const { bridge } = createBridge();
+  vi.mocked(Agent.create).mockResolvedValue(createMockAgent());
+
+  const result = await bridge.handleRequest("initialize", {
+    workdir: "/test/workdir",
+    restoreSessionId: "ghost-session",
+  });
+
+  // No live session matches → falls through to a fresh Agent.create
+  expect(vi.mocked(Agent.create)).toHaveBeenCalledTimes(1);
+  expect(result).toEqual({
+    sessionId: "test-session-id",
+    workingDirectory: "/test/workdir",
+    permissionMode: "default",
+    latestTotalTokens: 100,
+  });
+});
+
 test("restoreSession to the live session emits a messagesChange snapshot without replaying", async () => {
   const { bridge, notifications } = createBridge();
   const mockAgent = createMockAgent({
@@ -1773,6 +1854,31 @@ test("onUserMessageAdded before initialize does not crash", async () => {
   ).toHaveLength(0);
 });
 
+test("onUserMessageAdded with no agent (pre-create) does not crash", async () => {
+  const { bridge, notifications } = createBridge();
+  const mockAgent = createMockAgent();
+  let resolveCreate!: (agent: Agent) => void;
+  vi.mocked(Agent.create).mockReturnValue(
+    new Promise<Agent>((resolve) => {
+      resolveCreate = resolve;
+    }),
+  );
+
+  // Kick off initialize without awaiting — ctx.agent is still undefined here
+  const initPromise = bridge.handleRequest("initialize", {});
+  const callbacks = vi.mocked(Agent.create).mock.calls[0][0]
+    .callbacks as AgentCallbacks;
+
+  callbacks.onUserMessageAdded!({} as never);
+
+  expect(
+    notifications.filter((n) => n.method === "userMessageAdded"),
+  ).toHaveLength(0);
+
+  resolveCreate(mockAgent);
+  await initPromise;
+});
+
 // ── Multi-session (multi-tenant) ─────────────────────────────────
 
 test("two sessions are independent and route notifications by sessionId", async () => {
@@ -1953,6 +2059,18 @@ test("listGitBranches returns null current when rev-parse fails", async () => {
 
   expect(result.branches).toEqual(["main"]);
   expect(result.current).toBeNull();
+});
+
+test("listGitBranches returns an empty list when the repo has no refs", async () => {
+  const { bridge } = createBridge();
+  vi.mocked(execFileSync).mockReturnValueOnce("").mockReturnValueOnce("main\n");
+
+  const result = (await bridge.handleRequest("listGitBranches", {
+    workdir: "/repo",
+  })) as { branches: string[]; current: string | null };
+
+  expect(result.branches).toEqual([]);
+  expect(result.current).toBe("main");
 });
 
 // ── createWorktree ─────────────────────────────────────────────

--- a/packages/code/tests/utils/throttle.test.ts
+++ b/packages/code/tests/utils/throttle.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { throttle } from "../../src/utils/throttle.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("throttle", () => {
+  it("invokes on the leading edge and coalesces calls within the window", () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const throttled = throttle(fn, 500);
+
+    // Leading edge applies immediately
+    throttled("first");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("first");
+
+    // Calls inside the window are coalesced; only the last one fires on the
+    // trailing edge
+    throttled("second");
+    throttled("third");
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(500);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith("third");
+  });
+
+  it("flush applies pending calls immediately and is a no-op when idle", () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const throttled = throttle(fn, 500);
+
+    // Pending trailing call is flushed before the window elapses
+    throttled("first");
+    throttled("second");
+    throttled.flush();
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith("second");
+
+    // Flush with nothing pending (lastArgs already consumed) is a no-op
+    throttled.flush();
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancel drops pending calls", () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const throttled = throttle(fn, 500);
+
+    throttled("first");
+    throttled("second");
+    throttled.cancel();
+
+    vi.advanceTimersByTime(500);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("first");
+  });
+
+  it("respects leading: false by delaying the first invocation", () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const throttled = throttle(fn, 500, { leading: false });
+
+    throttled("first");
+    expect(fn).not.toHaveBeenCalled();
+
+    // With leading: false the first call only records the invocation time;
+    // a subsequent call inside the window schedules the trailing timer
+    throttled("first");
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(500);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("first");
+  });
+
+  it("respects trailing: false by dropping in-window calls", () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const throttled = throttle(fn, 500, { trailing: false });
+
+    throttled("first");
+    throttled("second");
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(500);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("first");
+  });
+});

--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -1223,6 +1223,14 @@ export class DesktopHost {
         await this.discardAgent(agent);
         return;
       }
+      // Restore is a bare RPC — the daemon does not deliver the transcript, so
+      // pull it into the cache. Without this, a re-attached session (remote or
+      // local) opens with an empty list and its agent looks "blank".
+      try {
+        await agent.getMessages();
+      } catch (error) {
+        console.warn('[DesktopHost] getMessages failed:', error);
+      }
       this.rekeyAgent(agent, opts.sessionId);
       // activateAgentInPane clears the pending entry — the pane is now live.
       await this.activateAgentInPane(paneId, agent);

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -183,10 +183,12 @@ vi.mock('../src/main/stdio/stdioAgent', () => ({
       if (h.initializeGate) await h.initializeGate;
     });
     destroy = vi.fn(async () => undefined);
-    restoreSession = vi.fn(async function (this: { sessionId?: string; messages?: unknown[] }, sessionId: string) {
+    restoreSession = vi.fn(async function (this: { sessionId?: string; daemonMessages?: unknown[] }, sessionId: string) {
       this.sessionId = sessionId;
-      // Mirror the real agent: after restore, messages holds the full history.
-      this.messages = [{ id: 'restored-u1', role: 'user', blocks: [{ type: 'text', content: '历史会话的第一条消息' }] }];
+      // Mirror the real StdioAgent: restore is a bare RPC — the daemon switches
+      // to the session and holds its history daemon-side. The desktop cache is
+      // NOT filled here; the host must pull it via getMessages().
+      this.daemonMessages = [{ id: 'restored-u1', role: 'user', blocks: [{ type: 'text', content: '历史会话的第一条消息' }] }];
     });
     updateConfig = vi.fn(async () => undefined);
     sendMessage = vi.fn(async () => undefined);
@@ -196,10 +198,12 @@ vi.mock('../src/main/stdio/stdioAgent', () => ({
     // through the sessionIdChange notification.
     clearMessages = vi.fn(async function (this: {
       messages: unknown[];
+      daemonMessages?: unknown[];
       sessionId?: string;
       callbacks: Record<string, (id: string) => void>;
     }) {
       this.messages = [];
+      this.daemonMessages = [];
       const newId = `sess-${++h.agentCounter}`;
       this.sessionId = newId;
       this.callbacks.onSessionIdChange(newId);
@@ -209,8 +213,12 @@ vi.mock('../src/main/stdio/stdioAgent', () => ({
     getFullMessageThread = vi.fn(async function (this: { messages?: unknown[] }) {
       return { messages: this.messages ?? [], sessionIds: [] };
     });
-    getMessages = vi.fn(async function (this: { messages?: unknown[] }) {
-      return this.messages ?? [];
+    getMessages = vi.fn(async function (this: { daemonMessages?: unknown[]; messages?: unknown[] }) {
+      // Mirrors StdioAgent.getMessages: pull the daemon's authoritative list
+      // into the cache. A restored session's history lives daemon-side until
+      // this pull — without it, a re-attached session opens with no messages.
+      this.messages = this.daemonMessages ?? this.messages ?? [];
+      return this.messages;
     });
     listRewindCheckpoints = vi.fn(async () => ({ checkpoints: [{ id: 'u1', content: 'hello' }] }));
     removeQueuedMessage = vi.fn(async () => undefined);
@@ -609,6 +617,18 @@ describe('agent notifications', () => {
       ]);
     });
     expect(sent('updateMessages')).toHaveLength(0);
+  });
+
+  it('restoreSession pulls the transcript via getMessages (re-attach regression)', async () => {
+    const { host } = await readyHost();
+
+    await host.handleWebviewMessage({ command: 'restoreSession', sessionId: 'sess-x' });
+
+    // The daemon emits no transcript on restore — the host must pull it, or a
+    // re-attached session (remote or local) opens with an empty message list.
+    await vi.waitFor(() => {
+      expect(lastAgent().getMessages).toHaveBeenCalled();
+    });
   });
 
   it('onMessagesChange never pushes the full list — each message arrives once via appendMessage', async () => {
@@ -2790,11 +2810,16 @@ describe('pane rows (two-row layout)', () => {
 
     await host.handleWebviewMessage({ command: 'desktopMovePane', paneId: first.paneId, newRow: 'below' });
 
+    // The opened session binds asynchronously (fire-and-forget restore) — wait
+    // for the binding push so the layout assertion sees the final row state.
+    await vi.waitFor(() => {
+      const layout = panePushes(sent).at(-1)!;
+      expect(layout.panes.map((p) => [p.sessionId, p.row])).toEqual([
+        ['sess-2', 0],
+        ['sess-1', 1],
+      ]);
+    });
     const layout = panePushes(sent).at(-1)!;
-    expect(layout.panes.map((p) => [p.sessionId, p.row])).toEqual([
-      ['sess-2', 0],
-      ['sess-1', 1],
-    ]);
     // The remaining top-row pane re-expands to the full row width.
     expect(layout.panes[0].width).toBeCloseTo(1);
     expect(layout.panes[1].width).toBeUndefined();
@@ -2898,6 +2923,11 @@ describe('pane rows (two-row layout)', () => {
     const { host, sent } = await readyHost();
     seedActiveSession('sess-1');
     await host.handleWebviewMessage({ command: 'desktopOpenPane', workdir: '/work/a', sessionId: 'sess-2', newRow: 'below' });
+    // The pane binds asynchronously — settle it before counting pushes, so a
+    // late restore binding push can't be miscounted as an ignored payload.
+    await vi.waitFor(() => {
+      expect(panePushes(sent).at(-1)!.panes.some((p) => p.sessionId === 'sess-2')).toBe(true);
+    });
 
     await host.handleWebviewMessage({ command: 'desktopResizePaneRows', heights: [300, 500] });
     const pushes = panePushes(sent).length;
@@ -2935,6 +2965,9 @@ describe('pane rows (two-row layout)', () => {
     const { host, sent } = await readyHost();
     seedActiveSession('sess-1');
     await host.handleWebviewMessage({ command: 'desktopOpenPane', workdir: '/work/a', sessionId: 'sess-2', newRow: 'below' });
+    await vi.waitFor(() => {
+      expect(panePushes(sent).at(-1)!.panes.some((p) => p.sessionId === 'sess-2')).toBe(true);
+    });
     const topPane = panePushes(sent).at(-1)!.panes[0];
 
     await host.handleWebviewMessage({ command: 'desktopClosePane', paneId: topPane.paneId });


### PR DESCRIPTION
## 问题

连接 remote host → 发送消息 → 关闭桌面端 → 重新打开 → 点击该 remote 会话：消息列表不加载，会话看起来也没有在后台运行。

## 根因

9cea65ea streaming 重构移除了桌面端对 messagesChange 全量快照通知的处理，daemon 侧 restoreSession 的 snapshot emit 成为死代码被静默丢弃。桌面端 runPaneRestore 从不拉取消息（pullAndPushMessages 仅在 compact/clearChat/rewind 处调用），而真实 StdioAgent.restoreSession 是裸 RPC、不填充本端消息缓存。结果：

- pushPaneSessionState 推送空消息列表 → 会话打开无消息
- 空消息使 agent 被 isBlankAgent 判定为空白 → pane 释放即销毁 → 后台运行丢失

## 修复

runPaneRestore 在 restoreSession + token 检查之后、rekey/activate 之前调用 agent.getMessages() 把 transcript 拉入缓存。daemon 侧 getMessages 返回 entry.agent.messages（agentBridge.ts），冷恢复（restoreSession 已加载历史）与 live 重连（agent 已持有消息）两条路径均覆盖。单点覆盖 handleSelectSession 与 bindSessionToPane 两个入口。

## 测试

- mock 改为忠实真实行为：restoreSession 只种 daemon 侧历史、getMessages 拉进缓存，使 bug 在测试中复现（TDD 红 → 绿）
- 新增回归测试：restoreSession pulls the transcript via getMessages
- 加固 3 个 pane-rows 测试：fire-and-forget restore 异步绑定 pane，原测试在绑定前同步读布局（新增 getMessages await 翻转了潜伏竞态），补 vi.waitFor 等绑定完成
- 顺带修复 agent-sdk btw 测试的 stale onMessagesChange 引用（重构遗留，导致 pre-commit type-check 全分支变红）

## 验证

- desktop 全量 405 tests passed（16 files）
- agent-sdk btw 测试 3 passed
- pnpm -r type-check 全绿，lint 无错误