### PR TITLE
fix(host): anchor @file search and /status workdir to session root

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -2292,7 +2292,10 @@ export class DesktopHost {
           command: 'statusResponse',
           version: app.getVersion(),
           sessionId: paneAgent?.sessionId ?? '',
-          workdir: paneAgent?.workingDirectory ?? this.workdir ?? '',
+          // Report the session root (initialize-time cwd), not the subdir the
+          // agent bash-cd'd into — the workdir shown must match what @file
+          // searches, not the agent's transient cwd.
+          workdir: paneAgent?.sessionCwd ?? paneAgent?.workingDirectory ?? this.workdir ?? '',
           configurationData: this.configStore.getConfiguration(),
         });
         break;
@@ -3261,10 +3264,13 @@ export class DesktopHost {
 
   private async findWorkspaceFiles(filterText: string): Promise<Record<string, string | boolean>[]> {
     const host = this.currentHost;
-    // Before any agent activation (fresh launch) this.workdir is unset while
-    // the webview already treats recents[0] as the effective workdir — mirror
-    // that fallback so @file suggestions work before a directory is picked.
-    const workdir = this.workdir ?? this.configStore.getRecentWorkdirsForHost(host)[0];
+    // Anchor @file search to the session's stable root (initialize-time cwd):
+    // bash cd drifts this.workdir via pane focus, but file suggestions belong
+    // to the project the session started in. Before any agent activation
+    // (fresh launch) this.workdir is unset while the webview already treats
+    // recents[0] as the effective workdir — mirror that fallback so @file
+    // suggestions work before a directory is picked.
+    const workdir = this.activeAgent?.sessionCwd ?? this.workdir ?? this.configStore.getRecentWorkdirsForHost(host)[0];
     if (!workdir) return [];
     try {
       // Remote workdirs are POSIX paths; path.join/basename on Windows would mangle them.

--- a/packages/desktop/src/main/stdio/stdioAgent.ts
+++ b/packages/desktop/src/main/stdio/stdioAgent.ts
@@ -119,6 +119,13 @@ export class StdioAgent {
     // ── Cached state (synchronous access) ──
     public sessionId: string | undefined;
     public workingDirectory: string | undefined;
+    /**
+     * Initialize-time cwd — the session's stable root. Unlike
+     * `workingDirectory` it is never overwritten by the workdirChange
+     * notification (bash cd), so @file search and the /status workdir stay
+     * anchored to the project root.
+     */
+    public sessionCwd: string | undefined;
     public latestTotalTokens = 0;
     public permissionMode: PermissionMode | undefined;
     public messages: Message[] = [];
@@ -154,6 +161,7 @@ export class StdioAgent {
         )) as InitializeResult;
         this.sessionId = result.sessionId;
         this.workingDirectory = result.workingDirectory;
+        this.sessionCwd = result.workingDirectory;
         this.permissionMode = result.permissionMode;
         this.latestTotalTokens = result.latestTotalTokens;
         // Register with the router so subsequent notifications are routed here

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -167,6 +167,7 @@ vi.mock('../src/main/stdio/stdioAgent', () => ({
   StdioAgent: class {
     sessionId: string | undefined;
     workingDirectory: string | undefined;
+    sessionCwd: string | undefined;
     latestTotalTokens = 0;
     messages: unknown[] = [];
     tasks: unknown[] = [];
@@ -177,8 +178,9 @@ vi.mock('../src/main/stdio/stdioAgent', () => ({
     isCompacting = false;
     callbacks: Record<string, (...args: never[]) => void>;
 
-    initialize = vi.fn(async function (this: { workingDirectory?: string; sessionId?: string }, params: { workdir?: string }) {
+    initialize = vi.fn(async function (this: { workingDirectory?: string; sessionCwd?: string; sessionId?: string }, params: { workdir?: string }) {
       this.workingDirectory = params.workdir;
+      this.sessionCwd = params.workdir;
       this.sessionId = `sess-${++h.agentCounter}`;
       if (h.initializeGate) await h.initializeGate;
     });
@@ -485,6 +487,31 @@ describe('file suggestions', () => {
     await host.handleWebviewMessage({ command: 'desktopReady' });
     await host.handleWebviewMessage({ command: 'webviewReady' });
 
+    await host.handleWebviewMessage({ command: 'requestFileSuggestions', filterText: 'app', requestId: 'r1' });
+
+    const search = h.clientRequests.find((r) => r.method === 'searchFiles');
+    expect(search?.params).toMatchObject({ workdir: '/work/a', query: 'app', maxResults: 20 });
+  });
+
+  it('stays anchored to the session root after bash cd drifts the working directory', async () => {
+    const { host, sent } = await readyHost();
+    const first = lastAgent();
+    first.messages = [{ id: 'm-1' }];
+    fireSessionId(first, 'sess-1');
+    await host.handleWebviewMessage({ command: 'desktopOpenPane', workdir: '/work/a', sessionId: 'sess-2' });
+    await vi.waitFor(() => {
+      expect((sent('desktopPanes').at(-1)?.panes as Array<{ sessionId?: string }>)[1]?.sessionId).toBe('sess-2');
+    });
+    const panes = sent('desktopPanes').at(-1)!.panes as Array<{ paneId: string }>;
+
+    // The agent ran `cd src` — the CLI broadcast workdirChange, drifting the
+    // agent's workingDirectory.
+    first.workingDirectory = '/work/a/src';
+    first.callbacks.onWorkdirChange('/work/a/src');
+
+    // Switching back to the drifted pane re-anchors host workdir to the
+    // subdir. @file suggestions must still search the session root.
+    await host.handleWebviewMessage({ command: 'desktopFocusPane', paneId: panes[0].paneId });
     await host.handleWebviewMessage({ command: 'requestFileSuggestions', filterText: 'app', requestId: 'r1' });
 
     const search = h.clientRequests.find((r) => r.method === 'searchFiles');
@@ -924,6 +951,20 @@ describe('configuration and status', () => {
       sessionId: 'sess-1',
       workdir: '/work/a',
     });
+  });
+
+  it('getStatus keeps the session root workdir after bash cd drifts the working directory', async () => {
+    const { host, sent } = await readyHost();
+    // The agent ran `cd src` — the CLI broadcast workdirChange, which drifts
+    // the agent's workingDirectory. The /status popup must still report the
+    // session root, not the subdir the agent cd'd into.
+    const agent = lastAgent();
+    agent.workingDirectory = '/work/a/src';
+    agent.callbacks.onWorkdirChange('/work/a/src');
+
+    await host.handleWebviewMessage({ command: 'getStatus' });
+
+    expect(sent('statusResponse')[0]).toMatchObject({ workdir: '/work/a' });
   });
 
   it('openExternal allows https URLs (FR-008)', async () => {

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
@@ -641,7 +641,7 @@ class MessageHandler(
     }
 
     private fun currentWorkdir(): String =
-        session.agent?.workingDirectory ?: project.basePath ?: System.getProperty("user.dir")
+        session.agent?.sessionCwd ?: session.agent?.workingDirectory ?: project.basePath ?: System.getProperty("user.dir")
 
     private fun pluginVersion(): String =
         PluginManagerCore.getPlugin(PluginId.getId("com.wave.jetbrains"))?.version ?: ""

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioAgent.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioAgent.kt
@@ -53,6 +53,14 @@ class StdioAgent(
         private set
     @Volatile var workingDirectory: String? = null
         private set
+    /**
+     * Initialize-time cwd — the session's stable root. Unlike
+     * [workingDirectory] it is never overwritten by the workdirChange
+     * notification (bash cd), so @file search and the /status workdir stay
+     * anchored to the project root.
+     */
+    @Volatile var sessionCwd: String? = null
+        private set
     @Volatile var latestTotalTokens: Int = 0
         private set
     @Volatile var permissionMode: String? = null
@@ -153,6 +161,7 @@ class StdioAgent(
             ?: throw StdioClientException("initialize returned null")
         sessionId = res["sessionId"]?.jsonPrimitive?.content
         workingDirectory = res["workingDirectory"]?.jsonPrimitive?.content
+        sessionCwd = res["workingDirectory"]?.jsonPrimitive?.content
         permissionMode = res["permissionMode"]?.jsonPrimitive?.content
         res["latestTotalTokens"]?.jsonPrimitive?.intOrNull?.let { latestTotalTokens = it }
         sessionId?.let { router.register(it, this) }

--- a/packages/vsce/src/session/messageHandler.ts
+++ b/packages/vsce/src/session/messageHandler.ts
@@ -911,7 +911,9 @@ export class MessageHandler {
             command: 'statusResponse',
             version,
             sessionId: session.sessionId || '',
-            workdir: session.agent?.workingDirectory || '',
+            // Session root (initialize-time cwd), not the subdir the agent
+            // bash-cd'd into — matches where @file search is anchored.
+            workdir: session.agent?.sessionCwd || session.agent?.workingDirectory || '',
             configurationData: config
         }, viewType, windowId);
     }

--- a/packages/vsce/src/stdio/stdioAgent.ts
+++ b/packages/vsce/src/stdio/stdioAgent.ts
@@ -117,6 +117,13 @@ export class StdioAgent {
     // ── Cached state (synchronous access) ──
     public sessionId: string | undefined;
     public workingDirectory: string | undefined;
+    /**
+     * Initialize-time cwd — the session's stable root. Unlike
+     * `workingDirectory` it is never overwritten by the workdirChange
+     * notification (bash cd), so @file search and the /status workdir stay
+     * anchored to the project root.
+     */
+    public sessionCwd: string | undefined;
     public latestTotalTokens = 0;
     public permissionMode: PermissionMode | undefined;
     public messages: Message[] = [];
@@ -149,6 +156,7 @@ export class StdioAgent {
         )) as InitializeResult;
         this.sessionId = result.sessionId;
         this.workingDirectory = result.workingDirectory;
+        this.sessionCwd = result.workingDirectory;
         this.permissionMode = result.permissionMode;
         this.latestTotalTokens = result.latestTotalTokens;
         // Register with the router so subsequent notifications are routed here

--- a/packages/vsce/tests/session/messageHandler.test.ts
+++ b/packages/vsce/tests/session/messageHandler.test.ts
@@ -229,6 +229,23 @@ describe('MessageHandler MCP handlers', () => {
         expect(posted.version).toBe('1.2.3');
     });
 
+    // Regression: agent `cd` broadcasts workdirChange which drifts
+    // workingDirectory; the /status popup must keep showing the session root
+    // (initialize-time cwd), matching where @file search is anchored.
+    test('getStatus reports the session root workdir, not the agent cd drift', async () => {
+        const session = createReadySession();
+        const agent = session.agent as { sessionCwd?: string; workingDirectory?: string };
+        agent.sessionCwd = '/tmp';
+        agent.workingDirectory = '/tmp/src';
+        const { handler, context } = createReadyHandler(session);
+
+        await handler.handleMessage({ command: 'getStatus' }, 'tab');
+
+        const posted = (context.postMessage as ReturnType<typeof vi.fn>).mock.calls[0][0] as { command: string; workdir: string };
+        expect(posted.command).toBe('statusResponse');
+        expect(posted.workdir).toBe('/tmp');
+    });
+
     // /compact command: mirrors /clear — the webview posts { command: 'compact', customInstructions }
     // and the handler delegates to session.compact(customInstructions).
     test('compact command calls session.compact with customInstructions', async () => {


### PR DESCRIPTION
agent cd 到子目录时 CLI 会广播 workdirChange，使 desktop 各宿主中 agent 的 workingDirectory 漂移（desktop 的 pane focus 还会把 host workdir 重锚到子目录）。@ 文件搜索和 /status 弹窗必须锚定会话初始化时的稳定根目录。

修复：三个宿主（desktop / vsce / jetbrains）的 StdioAgent 新增 sessionCwd 字段，仅在 initialize 时写入、绝不随 workdirChange 更新；@ 与 /status 处理器优先使用它：
- desktop: findWorkspaceFiles（@）与 getStatus（/status）
- vsce: getStatus（@ 本就基于 workspace root，无需改）
- jetbrains: currentWorkdir() 共享辅助函数，覆盖 @、/status 与插件操作

顺带修复 main 上预存在的 type-check 失败：agent.btw.test.ts 引用了已不存在的 onMessagesChange 回调。

TDD：desktop 2 个失败测试 + vsce 1 个失败测试先红后绿。验证：desktop 406/406、vsce 154/154、jetbrains compileKotlin + test、monorepo type-check 与 lint 全绿。