### PR TITLE
fix(desktop): mirror streaming deltas into agent cache so session switches keep assistant replies

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -24,6 +24,8 @@ import type {
   ToolPermissionContext,
   SessionMetadata,
   Scope,
+  ToolBlock,
+  ErrorBlock,
 } from 'wave-agent-sdk';
 import {
   EDIT_TOOL_NAME,
@@ -588,18 +590,123 @@ export class DesktopHost {
         if (paneId) this.postMessage({ command: 'appendMessage', paneId, message });
       },
       onAssistantContentUpdated: (params) => {
+        // The webview merges streaming deltas via UPDATE_STREAMING_CONTENT,
+        // but the cache only ever saw the initial empty assistant message.
+        // Mirror the deltas into it so a session switch (setInitialState from
+        // the cache) renders the full assistant reply.
+        agentRef.messages = agentRef.messages.map((m) => {
+          if (m.id !== params.messageId) return m;
+          const textIndex = m.blocks.findIndex((b) => b.type === 'text');
+          const blocks: Message['blocks'] =
+            textIndex === -1
+              ? [...m.blocks, { type: 'text' as const, content: params.chunk, stage: params.stage }]
+              : m.blocks.map((b, idx) =>
+                  idx === textIndex && b.type === 'text'
+                    ? { ...b, content: b.content + params.chunk, stage: params.stage }
+                    : b,
+                );
+          return { ...m, blocks };
+        });
         const paneId = paneIdOf();
         if (paneId) this.throttledStreamingContentUpdate(paneId, params.messageId, params.chunk, params.stage);
       },
       onAssistantReasoningUpdated: (params) => {
+        // Mirror reasoning deltas into the cache too (UPDATE_STREAMING_REASONING
+        // semantics: chunk append, startTime on first chunk, endTime on end).
+        agentRef.messages = agentRef.messages.map((m) => {
+          if (m.id !== params.messageId) return m;
+          const reasoningIndex = m.blocks.findIndex((b) => b.type === 'reasoning');
+          const blocks: Message['blocks'] =
+            reasoningIndex === -1
+              ? [
+                  ...m.blocks,
+                  {
+                    type: 'reasoning' as const,
+                    content: params.chunk,
+                    stage: params.stage,
+                    startTime: Date.now(),
+                    ...(params.stage === 'end' ? { endTime: Date.now() } : {}),
+                  },
+                ]
+              : m.blocks.map((b, idx) =>
+                  idx === reasoningIndex && b.type === 'reasoning'
+                    ? {
+                        ...b,
+                        content: b.content + params.chunk,
+                        stage: params.stage,
+                        startTime: b.startTime ?? Date.now(),
+                        ...(params.stage === 'end' ? { endTime: b.endTime ?? Date.now() } : {}),
+                      }
+                    : b,
+                );
+          return { ...m, blocks };
+        });
         const paneId = paneIdOf();
         if (paneId) this.throttledStreamingReasoningUpdate(paneId, params.messageId, params.chunk, params.stage);
       },
       onToolBlockUpdated: (params) => {
+        // Mirror tool block merges into the cache too (UPDATE_TOOL_BLOCK
+        // semantics: create on first update, merge fields, append
+        // parametersChunk to the accumulated parameters).
+        const { messageId, id: toolBlockId, parametersChunk, ...rest } = params;
+        agentRef.messages = agentRef.messages.map((m) => {
+          if (m.id !== messageId) return m;
+          const toolIndex = m.blocks.findIndex((b) => b.type === 'tool' && b.id === toolBlockId);
+          const blocks: Message['blocks'] =
+            toolIndex === -1
+              ? [
+                  ...m.blocks,
+                  {
+                    type: 'tool' as const,
+                    id: toolBlockId,
+                    name: rest.name || '',
+                    stage: rest.stage || 'start',
+                    result: rest.result || '',
+                    success: rest.success ?? false,
+                    ...rest,
+                    parameters: (rest.parameters || '') + (parametersChunk || ''),
+                  },
+                ]
+              : m.blocks.map((b, idx) => {
+                  if (idx !== toolIndex || b.type !== 'tool') return b;
+                  const merged: ToolBlock = { ...b, ...rest };
+                  if (parametersChunk) {
+                    merged.parameters = (b.parameters || '') + parametersChunk;
+                  }
+                  return merged;
+                });
+          return { ...m, blocks };
+        });
         const paneId = paneIdOf();
         if (paneId) this.postMessage({ command: 'updateToolBlock', paneId, params });
       },
       onErrorBlockAdded: (error: string) => {
+        // Mirror the error block into the cache too (APPEND_ERROR_BLOCK
+        // semantics: append to the last assistant message, creating one if no
+        // assistant message exists yet).
+        const newErrorBlock: ErrorBlock = { type: 'error', content: error };
+        let targetIndex = -1;
+        for (let i = agentRef.messages.length - 1; i >= 0; i--) {
+          if (agentRef.messages[i].role === 'assistant') {
+            targetIndex = i;
+            break;
+          }
+        }
+        if (targetIndex === -1) {
+          agentRef.messages = [
+            ...agentRef.messages,
+            {
+              id: `msg-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
+              role: 'assistant',
+              timestamp: new Date().toISOString(),
+              blocks: [newErrorBlock],
+            },
+          ];
+        } else {
+          agentRef.messages = agentRef.messages.map((m, idx) =>
+            idx === targetIndex ? { ...m, blocks: [...m.blocks, newErrorBlock] } : m,
+          );
+        }
         const paneId = paneIdOf();
         if (paneId) this.postMessage({ command: 'updateErrorBlock', paneId, error });
       },

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -646,6 +646,88 @@ describe('agent notifications', () => {
     expect(sent('appendMessage')).toEqual([expect.objectContaining({ message: userMsg })]);
   });
 
+  it('streaming content deltas are mirrored into the agent cache so a session switch shows the full assistant reply', async () => {
+    const { host, sent } = await readyHost();
+    const agent = lastAgent();
+    const userMsg = { id: 'u1', role: 'user', blocks: [{ type: 'text', content: '你好' }] };
+    agent.messages = [userMsg];
+    agent.callbacks.onUserMessageAdded(userMsg);
+    // The assistant message arrives empty — its content only exists as
+    // streaming deltas afterwards. The cache must accumulate them, otherwise a
+    // session switch (setInitialState) renders a blank reply.
+    const assistantMsg = { id: 'a1', role: 'assistant', blocks: [] };
+    agent.messages = [...agent.messages, assistantMsg];
+    agent.callbacks.onAssistantMessageAdded(assistantMsg);
+    agent.callbacks.onAssistantContentUpdated({ messageId: 'a1', chunk: 'Hello', stage: 'streaming' });
+    agent.callbacks.onAssistantContentUpdated({ messageId: 'a1', chunk: ' world', stage: 'end' });
+
+    // Re-push pane state (what a session switch does) — the cached list must
+    // carry the full accumulated text, not the initial empty block.
+    await host.handleWebviewMessage({ command: 'webviewReady' });
+    const messages = sent('setInitialState').at(-1)?.messages as Array<{ id: string; blocks: Array<{ type: string; content: string; stage?: string }> }>;
+    expect(messages.find((m) => m.id === 'a1')?.blocks).toEqual([
+      expect.objectContaining({ type: 'text', content: 'Hello world', stage: 'end' }),
+    ]);
+  });
+
+  it('reasoning deltas are mirrored into the agent cache too', async () => {
+    const { host, sent } = await readyHost();
+    const agent = lastAgent();
+    const userMsg = { id: 'u1', role: 'user', blocks: [{ type: 'text', content: '你好' }] };
+    agent.messages = [userMsg];
+    agent.callbacks.onUserMessageAdded(userMsg);
+    const assistantMsg = { id: 'a1', role: 'assistant', blocks: [] };
+    agent.messages = [...agent.messages, assistantMsg];
+    agent.callbacks.onAssistantMessageAdded(assistantMsg);
+    agent.callbacks.onAssistantReasoningUpdated({ messageId: 'a1', chunk: '思考中', stage: 'streaming' });
+    agent.callbacks.onAssistantReasoningUpdated({ messageId: 'a1', chunk: '…', stage: 'end' });
+    agent.callbacks.onAssistantContentUpdated({ messageId: 'a1', chunk: '结论', stage: 'end' });
+
+    await host.handleWebviewMessage({ command: 'webviewReady' });
+    const messages = sent('setInitialState').at(-1)?.messages as Array<{ id: string; blocks: Array<{ type: string; content: string; stage?: string }> }>;
+    const blocks = messages.find((m) => m.id === 'a1')?.blocks ?? [];
+    expect(blocks.find((b) => b.type === 'reasoning')).toEqual(expect.objectContaining({ content: '思考中…', stage: 'end' }));
+    expect(blocks.find((b) => b.type === 'text')).toEqual(expect.objectContaining({ content: '结论', stage: 'end' }));
+  });
+
+  it('tool block updates are mirrored into the agent cache', async () => {
+    const { host, sent } = await readyHost();
+    const agent = lastAgent();
+    const userMsg = { id: 'u1', role: 'user', blocks: [{ type: 'text', content: '你好' }] };
+    agent.messages = [userMsg];
+    agent.callbacks.onUserMessageAdded(userMsg);
+    const assistantMsg = { id: 'a1', role: 'assistant', blocks: [] };
+    agent.messages = [...agent.messages, assistantMsg];
+    agent.callbacks.onAssistantMessageAdded(assistantMsg);
+    agent.callbacks.onToolBlockUpdated({
+      messageId: 'a1',
+      id: 'tool-1',
+      name: 'read_file',
+      stage: 'start',
+      parameters: '{"path":',
+      parametersChunk: '"/a.txt"}',
+    });
+    agent.callbacks.onToolBlockUpdated({
+      messageId: 'a1',
+      id: 'tool-1',
+      stage: 'end',
+      result: 'file content',
+      success: true,
+    });
+
+    await host.handleWebviewMessage({ command: 'webviewReady' });
+    const messages = sent('setInitialState').at(-1)?.messages as Array<{ id: string; blocks: Array<{ type: string; id?: string; name?: string; stage?: string; parameters?: string; result?: string; success?: boolean }> }>;
+    const toolBlock = messages.find((m) => m.id === 'a1')?.blocks.find((b) => b.type === 'tool');
+    expect(toolBlock).toMatchObject({
+      id: 'tool-1',
+      name: 'read_file',
+      stage: 'end',
+      parameters: '{"path":"/a.txt"}',
+      result: 'file content',
+      success: true,
+    });
+  });
+
   it('first user message registers the new session in the sidebar tree with a truncated title (FR-024)', async () => {
     const { sent } = await readyHost();
     const agent = lastAgent();


### PR DESCRIPTION
Fixes: 桌面端切换对话后，之前对话里的助手消息丢失，只剩用户消息和新的 stream 助手消息。

Root cause: the streaming callbacks (onAssistantContentUpdated / onAssistantReasoningUpdated / onToolBlockUpdated / onErrorBlockAdded) only forwarded deltas to the webview and never updated agentRef.messages. Switching conversations re-pushes pane state via setInitialState built from that stale cache, so finished assistant replies rendered empty.

Fix: mirror the webview reducer's incremental semantics (UPDATE_STREAMING_CONTENT / UPDATE_STREAMING_REASONING / UPDATE_TOOL_BLOCK / APPEND_ERROR_BLOCK) into the cache in each callback. Verified with 3 new failing tests (content / reasoning / tool deltas), desktop suite 407 passed, type-check green.

Also includes a drive-by agent-sdk test fix: agent.btw.test.ts still referenced the removed onMessagesChange callback, which broke the recursive pre-commit type-check (pre-existing on main since 9cea65ea).