### PR TITLE
fix(code): replay loading state when re-attaching to a live session

### DIFF
--- a/packages/code/src/stdio/agentBridge.ts
+++ b/packages/code/src/stdio/agentBridge.ts
@@ -464,6 +464,18 @@ export class AgentBridge {
         { messages: entry.agent.messages },
         entry.agent.sessionId,
       );
+      // The re-attached client also missed the loading state that settled
+      // before its router registered — replay it or the client's
+      // isStreaming/running indicator stays false while the live session
+      // keeps generating.
+      this.emit(
+        "loadingChange",
+        {
+          loading: entry.agent.isLoading,
+          latestTotalTokens: entry.agent.latestTotalTokens,
+        },
+        entry.agent.sessionId,
+      );
       return null;
     }
     await entry.agent.restoreSession(restoreId);

--- a/packages/code/tests/stdio/agentBridge.test.ts
+++ b/packages/code/tests/stdio/agentBridge.test.ts
@@ -1511,6 +1511,26 @@ test("initialize with an unknown restoreSessionId creates a new agent", async ()
   });
 });
 
+test("restoreSession to a live streaming session emits the current loading state so re-attached clients restore the running indicator", async () => {
+  const { bridge, notifications } = createBridge();
+  // The live agent is mid-generation on the daemon; a freshly attached client
+  // missed the loadingChange(true) that fired before its router registered.
+  const mockAgent = createMockAgent({ isLoading: true });
+  vi.mocked(Agent.create).mockResolvedValue(mockAgent);
+
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+
+  await bridge.handleRequest("restoreSession", { sessionId }, sessionId);
+
+  expect(mockAgent.restoreSession).not.toHaveBeenCalled();
+  expect(notifications).toContainEqual({
+    method: "loadingChange",
+    params: { loading: true, latestTotalTokens: 100 },
+    sessionId,
+  });
+});
+
 test("restoreSession to the live session emits a messagesChange snapshot without replaying", async () => {
   const { bridge, notifications } = createBridge();
   const mockAgent = createMockAgent({


### PR DESCRIPTION
## 问题

桌面端远程后台对话，重启桌面端后再次点击会话，内容正常恢复，但侧边栏没有显示运行图标。

## 根因

重启后点击远程会话走 daemon 复用分支（真后台会话仍在远端运行）。新附着的客户端拿不到会话仍在运行的状态：

1. initialize 命中 live session 复用分支，但响应不含 loading 状态
2. 桌面端新建 StdioAgent.isStreaming 默认为 false
3. restoreSession 的 re-attach 分支只 emit messagesChange，不 emit loadingChange
4. live agent 早已处于加载中（无状态跳变），之后也不会再触发 loadingChange 通知，isStreaming 永远为 false
5. 侧边栏运行点来自 refreshSessionTree 的 agent.isStreaming，因此不显示

## 修复

agentBridge.restoreSession 的 re-attach 分支在 messagesChange 旁补发当前 loading 状态（与既有"新客户端错过早期通知、重放快照"模式一致）。桌面端 StdioAgent 已有 loadingChange 分支，经 onLoadingChange 刷新会话树后运行点恢复。RPC 时序安全：restoreSession 在 router 注册之后调用。

## 验证

- 新增测试（先红后绿）：live streaming 会话 re-attach 时 emit loadingChange(true)
- agentBridge 119 / stdio 142 测试全过，code type-check 通过，desktop 413 测试全过