### PR TITLE
fix(sdk): log compact failure without stack, drop stale onMessagesChange in btw test

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -710,8 +710,7 @@ export class AIManager {
     } catch (compactError) {
       this.consecutiveCompactionFailures++;
       logger?.error(
-        `Failed to compact messages (${this.consecutiveCompactionFailures} consecutive):`,
-        compactError,
+        `Failed to compact messages (${this.consecutiveCompactionFailures} consecutive): ${compactError instanceof Error ? compactError.message : String(compactError)}`,
       );
       this.messageManager.addErrorBlock(
         `Failed to compact conversation history: ${compactError instanceof Error ? compactError.message : String(compactError)}. You may encounter context limit issues.`,

--- a/packages/agent-sdk/tests/agent/agent.btw.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.btw.test.ts
@@ -62,9 +62,7 @@ describe("Agent askBtw", () => {
       tool_calls: [],
     });
 
-    mockCallbacks = {
-      onMessagesChange: vi.fn(),
-    };
+    mockCallbacks = {};
 
     agent = await Agent.create({
       workdir: `${BTW_HOME}/workdir`,


### PR DESCRIPTION
## 改动内容

1. **compact 失败日志不再输出 stack**（`packages/agent-sdk/src/managers/aiManager.ts`）
   - 之前 `logger?.error()` 传入整个 Error 对象，CLI logger 的 `formatArg` 会输出完整调用栈（`at Module.callAgent ...`），挤占日志可读性
   - 现在只记录 `error.message`，日志更简洁：
     - 之前：`Failed to compact messages (1 consecutive): Error: Request was aborted at Module.callAgent ...`
     - 之后：`Failed to compact messages (1 consecutive): Request was aborted`

2. **修复 agent.btw.test.ts 类型错误**（`packages/agent-sdk/tests/agent/agent.btw.test.ts`）
   - 该测试残留已删除的 `onMessagesChange` 回调（commit 9cea65ea 移除了它，改为增量回调），导致 `tsc --noEmit` 和 pre-commit type-check 失败
   - 按其他测试惯例改为 `callbacks: {}`

## 验证

- `pnpm -F wave-agent-sdk exec tsc --noEmit` 通过
- `pnpm -F wave-agent-sdk test tests/managers/aiManager.test.ts` 32/32 通过
- `pnpm -F wave-agent-sdk test tests/agent/agent.btw.test.ts` 3/3 通过
- 全仓 type-check / lint / prettier 通过
