### PR TITLE
fix(docs): escape <your question> in btw spec to fix vitepress build

### DIFF
--- a/docs/specs/ui/btw-command.md
+++ b/docs/specs/ui/btw-command.md
@@ -82,7 +82,7 @@ order: 170
 
 ### 边界情况
 
-- **用户输入不带问题的 `/btw` 怎么办？** 命令不进入 BTW 状态，显示 "Usage: /btw <your question>"；输入行随 usage 消息隐藏，仅按 ESC 关闭（与 Claude Code 一致），其他按键被忽略。
+- **用户输入不带问题的 `/btw` 怎么办？** 命令不进入 BTW 状态，显示 `"Usage: /btw <your question>"`；输入行随 usage 消息隐藏，仅按 ESC 关闭（与 Claude Code 一致），其他按键被忽略。
 - **用户提出通常会触发工具的 `/btw` 问题怎么办？** btw 请求携带与主对话相同的工具列表（缓存键一致），但仅执行一轮且不反馈工具结果；模型若尝试调用工具，显示 "(The model tried to call X...)" 提示。
 - **请求失败（如 API 错误）怎么办？** `BtwDisplay` 显示 "(API error: ...)" 错误信息，不中断主对话。
 - **模型只输出 thinking 而无最终答案怎么办？** `BtwDisplay` 显示 thinking 内容（而非 "No response received"），避免思考阶段输出被丢弃。


### PR DESCRIPTION
修复 Deploy VitePress 失败（main 自 84bc4950 起 2 次红）：

- VitePress 以 html:true 渲染 markdown，第 85 行未加反引号的 Usage: /btw <your question> 中 <your question> 被当作原始 HTML 标签且未闭合，vue 编译报 Element is missing end tag（btw-command.md:68:89）
- 改为反引号包裹（与第 72 行同款写法），vitepress build 通过
- 已用 VitePress 真实渲染器扫描全部 65 个 spec 文件，无其他未闭合标签
- spec-count：65 规格 / 336 故事 / 1212 场景 通过