### PR TITLE
docs(spec): correct fast-model scenario descriptions for background forks

### DIFF
--- a/docs/specs/core/agent-config.md
+++ b/docs/specs/core/agent-config.md
@@ -174,18 +174,18 @@ SDK 用户需要按子代理类型配置不同的 HTTP 请求头，以便 `custo
 
 ### 用户故事：快速模型思考禁用配置（优先级：P1）
 
-用户将推理模型（如 deepseek-v4-flash）配置为快速模型（fastModel）后，WebFetch 内容处理、目标评估等轻量任务会偶发 "Empty response from AI" 错误——推理模型的思考（reasoning）消耗了全部输出 token（max_tokens），导致 content 为空。用户希望为不同模型配置各自的"禁用思考"参数，使快速模型场景可按需禁用思考、稳定返回内容，同时不影响主代理对话（agent loop）中的思考能力。
+用户将推理模型（如 deepseek-v4-flash）配置为快速模型（fastModel）后，WebFetch 内容处理、快速子代理（`model: fastModel`）等轻量任务会偶发 "Empty response from AI" 错误——推理模型的思考（reasoning）消耗了全部输出 token（max_tokens），导致 content 为空。用户希望为不同模型配置各自的"禁用思考"参数，使快速模型场景可按需禁用思考、稳定返回内容，同时不影响主代理对话（agent loop）中的思考能力。
 
 **为什么是这个优先级**：这是快速模型场景空响应错误的直接修复，影响 WebFetch 等常用工具的可用性。
 
-**独立测试**：分别配置与不配置 `models[X].disableThinkingOptions`，触发 WebFetch 内容处理、目标评估与自动记忆提取，验证请求携带正确参数；同时验证主代理对话请求不受影响。
+**独立测试**：分别配置与不配置 `models[X].disableThinkingOptions`，触发 WebFetch 内容处理与快速子代理，验证请求携带正确参数；同时验证主代理对话与自动记忆提取、上下文压缩等后台 fork 请求不受影响。
 
 **验收场景**：
 
 1. **假设**用户未配置 `disableThinkingOptions`，**当**快速模型场景（如 WebFetch 内容处理）发起请求时，**则**请求不携带任何禁用思考参数，交由模型默认处理（避免对不支持该参数的网关报错）
 2. **假设**用户为模型 X 配置 `models[X].disableThinkingOptions: {"enable_thinking": false}`，**当**快速模型场景使用模型 X 时，**则**请求携带 `{"enable_thinking": false}`
-3. **假设**用户为快速模型配置了 `models[fastModel].disableThinkingOptions`，**当** WebFetch 内容处理与目标评估使用快速模型时，**则**两类请求都携带该模型的禁用思考参数
-4. **假设**用户为快速模型配置了 `models[fastModel].disableThinkingOptions`，**当**自动记忆提取等后台子代理使用快速模型时，**则**子代理请求同样携带该参数
+3. **假设**用户为快速模型配置了 `models[fastModel].disableThinkingOptions`，**当** WebFetch 内容处理与快速子代理使用快速模型时，**则**两类请求都携带该模型的禁用思考参数
+4. **假设**用户为快速模型配置了 `models[fastModel].disableThinkingOptions`，**当**自动记忆提取、上下文压缩等后台 fork 使用主模型（复用主对话 prompt cache，无 `modelOverride`）时，**则**请求不携带禁用思考参数，思考行为保持模型默认
 5. **假设**用户配置了 `models[X].disableThinkingOptions`，**当**主代理对话（agent loop）使用模型 X 时，**则**请求不携带禁用思考参数，思考行为保持模型默认
 6. **假设**用户为模型 X 配置 `disableThinkingOptions: {}`，**当**快速模型场景使用模型 X 时，**则**请求不携带任何禁用思考参数，交由模型默认处理
 

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -45,4 +45,8 @@ const specHref = (p) => withBase(`/specs/${p.replace(/\.md$/, '.html')}`)
 | 历史 | user / assistant / tool | 文本块 / 图片块 / 工具块 / 后台任务通知块 / 推理块 | 最后一条有 | 持久化到 session JSONL | 是 | |
 | | user (isMeta) | 计划模式提醒 / 条件规则 / 任务提醒 / SessionStart Hook 上下文 / 后台任务通知 / Token 限制续写 | 同上 | 同上 | 否 | 触发时插入当时的结尾，各类型有独立触发条件 |
 
-**专用调用**（独立系统提示词，不经过主系统提示词组装）：压缩、网页内容提取、BTW 旁路问题、Workflow 结构化输出。
+**专用调用**：
+
+- **Fork 复用主对话上下文**（复用主系统提示词、工具、模型与生成参数，指令作为末尾 user 消息追加，命中 prompt cache；无独立系统提示词）：上下文压缩（`runCompactFork` → `runForkLoop`）、自动记忆提取（`runAutoMemoryFork` → `runForkLoop`）、BTW 旁路问题（`runBtwFork`，同构的内联单轮调用）。
+- **独立调用**（自带独立系统提示词，不经过主系统提示词组装）：网页内容提取（`processWebContent`，内置 `WEB_CONTENT_SYSTEM_PROMPT`，独立请求，不走会话历史）。
+- **常规子代理机制**：Workflow 结构化输出——spawn 常规子代理（general-purpose），schema 指令追加到 prompt 末尾并强制 StructuredOutput `tool_choice`，非独立调用路径。

--- a/packages/agent-sdk/src/types/config.ts
+++ b/packages/agent-sdk/src/types/config.ts
@@ -36,8 +36,8 @@ export interface ModelConfig {
   /**
    * Fast-model-only disable-thinking params passed through verbatim
    * (e.g. `{ thinking: { type: "disabled" } }`). Applied only in fast-model
-   * scenarios (webFetch, fast subagents, autoMemory), never in the agent loop.
-   * `{}` clears the default.
+   * scenarios (webFetch content processing, `model: fastModel` subagents),
+   * never in the agent loop. `{}` clears the default.
    */
   disableThinkingOptions?: Record<string, unknown>;
 }


### PR DESCRIPTION
## 背景

快速模型调研发现规格文档过期：`docs/specs/core/agent-config.md` 声称"自动记忆提取等后台子代理使用快速模型"，实际代码中 autoMemory/compaction 均走主模型（`runAutoMemoryFork`/`runCompactFork` 无 modelOverride，复用主对话 prompt cache），只有 WebFetch 内容处理与 `model: fastModel` 子代理真正使用快速模型。代码是对的，spec 过期。

## 改动

### docs/specs/core/agent-config.md（快速模型思考禁用配置用户故事）
- 用户故事描述/独立测试/验收场景 3：将过期的"目标评估"替换为"快速子代理（model: fastModel）"（/goal 功能已移除）
- 验收场景 4（核心修正）：原"自动记忆提取等后台子代理使用快速模型时携带禁用思考参数" → 改为"自动记忆提取、上下文压缩等后台 fork 使用主模型（复用主对话 prompt cache，无 modelOverride）时不携带禁用思考参数"
- 独立测试补充验证：主代理对话与后台 fork 请求不受影响

### docs/specs/index.md（上下文消息结构总览底部"专用调用"）
- 重新分类：压缩/BTW/自动记忆提取为 **fork 复用主对话上下文**（复用主系统提示词、工具、模型，无独立系统提示词）；仅网页内容提取（processWebContent）为**独立调用**（内置 WEB_CONTENT_SYSTEM_PROMPT）；Workflow 结构化输出为**常规子代理机制**（spawn general-purpose 子代理 + schema 指令追加 + StructuredOutput tool_choice）
- 自动记忆提取原先完全缺失，已补入 fork 分类

### packages/agent-sdk/src/types/config.ts
- `disableThinkingOptions` 注释：移除过期的 autoMemory（fast-model 场景 = webFetch 内容处理 + `model: fastModel` 子代理）

## 验证

- spec-count：65 规格 / 337 用户故事 / 1220 验收场景，校验通过
- 受影响测试：aiService.disableThinking + configurationService（73 通过）、aiManager（32 通过）
- type-check + lint：全部通过（useChat.tsx 一条既有 warning，与本 PR 无关）
