### PR TITLE
fix(auth): treat existing SSO token as authenticated, refresh on getAuthStatus

### DIFF
--- a/packages/code/src/components/ChatInterface.tsx
+++ b/packages/code/src/components/ChatInterface.tsx
@@ -50,8 +50,10 @@ export const ChatInterface: React.FC = () => {
 
   // Compute whether the user has any usable auth/direct-API config,
   // so the welcome page can prompt /login when neither is present.
+  // An SSO token counts as authenticated even if the access token is stale —
+  // it refreshes lazily on the next API call (matching the claude-code CLI).
   const computeAuthState = useCallback((): boolean => {
-    if (authService.isSSOAuthenticated()) return true;
+    if (authService.getSSOToken()) return true;
     const gateway = getGatewayConfig();
     return Boolean(gateway.apiKey || gateway.baseURL);
   }, [getGatewayConfig]);

--- a/packages/code/src/components/LoginCommand.tsx
+++ b/packages/code/src/components/LoginCommand.tsx
@@ -80,7 +80,9 @@ export const LoginCommand: React.FC<LoginCommandProps> = ({ onCancel }) => {
   const handleEnter = async () => {
     if (isLoadingRef.current) return;
 
-    const isAuthenticated = authService.isSSOAuthenticated();
+    // A stale-but-present SSO token still counts as logged in; it refreshes
+    // lazily on the next API call. Enter toggles logout only when a token exists.
+    const isAuthenticated = Boolean(authService.getSSOToken());
     if (isAuthenticated) {
       await authService.clearAuth();
       setMessage("Logged out successfully");
@@ -123,7 +125,7 @@ export const LoginCommand: React.FC<LoginCommandProps> = ({ onCancel }) => {
     }
   };
 
-  const isAuthenticated = authService.isSSOAuthenticated();
+  const isAuthenticated = Boolean(authService.getSSOToken());
   const token = authService.getSSOToken();
   const serverUrl = authService.getServerUrl();
 

--- a/packages/code/src/stdio/agentBridge.ts
+++ b/packages/code/src/stdio/agentBridge.ts
@@ -1057,6 +1057,14 @@ export class AgentBridge {
     serverUrl: string;
   }> {
     const authService = AuthService.getInstance();
+    // A stale-but-refreshable token still means "logged in" — the daemon may
+    // have started with an expired access token (hourly expiry) and only
+    // refreshes lazily on the first API call. Without this proactive refresh a
+    // fresh client querying right after daemon start gets a false
+    // isAuthenticated and e.g. the desktop welcome page keeps showing the
+    // login button for an authenticated host. Mirrors the refresh that
+    // createAuthAwareFetch does before every real request.
+    await authService.checkAndRefreshTokenIfNeeded();
     return {
       isAuthenticated: authService.isSSOAuthenticated(),
       user: authService.getAuthUser(),

--- a/packages/code/tests/components/ChatInterface.auth.test.tsx
+++ b/packages/code/tests/components/ChatInterface.auth.test.tsx
@@ -13,6 +13,7 @@ import { useTasks } from "../../src/hooks/useTasks.js";
 const { mockAuthService } = vi.hoisted(() => ({
   mockAuthService: {
     isSSOAuthenticated: vi.fn<() => boolean>(() => false),
+    getSSOToken: vi.fn<() => string | undefined>(() => undefined),
     onAuthChange:
       vi.fn<(cb: (event: "login" | "logout") => void) => () => void>(),
   },
@@ -94,6 +95,7 @@ describe("ChatInterface login hint", () => {
     vi.clearAllMocks();
     authChangeCallback = null;
     mockAuthService.isSSOAuthenticated.mockReturnValue(false);
+    mockAuthService.getSSOToken.mockReturnValue(undefined);
     mockAuthService.onAuthChange.mockImplementation((cb) => {
       authChangeCallback = cb;
       return () => {
@@ -119,6 +121,16 @@ describe("ChatInterface login hint", () => {
 
   it("should not show the /login hint when SSO authenticated", () => {
     mockAuthService.isSSOAuthenticated.mockReturnValue(true);
+    mockAuthService.getSSOToken.mockReturnValue("valid-token");
+
+    const { lastFrame } = render(<ChatInterface />);
+
+    expect(lastFrame()).not.toContain("Type /login to authenticate");
+  });
+
+  it("should not show the /login hint when SSO token exists but is expired", () => {
+    mockAuthService.isSSOAuthenticated.mockReturnValue(false);
+    mockAuthService.getSSOToken.mockReturnValue("expired-token");
 
     const { lastFrame } = render(<ChatInterface />);
 
@@ -160,6 +172,7 @@ describe("ChatInterface login hint", () => {
     // Wait until the auth-change subscription is active before simulating login
     await vi.waitFor(() => expect(authChangeCallback).not.toBeNull());
     mockAuthService.isSSOAuthenticated.mockReturnValue(true);
+    mockAuthService.getSSOToken.mockReturnValue("new-token");
     authChangeCallback?.("login");
 
     await vi.waitFor(() => {
@@ -169,12 +182,14 @@ describe("ChatInterface login hint", () => {
 
   it("should show the hint again when the user logs out", async () => {
     mockAuthService.isSSOAuthenticated.mockReturnValue(true);
+    mockAuthService.getSSOToken.mockReturnValue("valid-token");
 
     const { lastFrame } = render(<ChatInterface />);
     expect(lastFrame()).not.toContain("Type /login to authenticate");
 
     await vi.waitFor(() => expect(authChangeCallback).not.toBeNull());
     mockAuthService.isSSOAuthenticated.mockReturnValue(false);
+    mockAuthService.getSSOToken.mockReturnValue(undefined);
     authChangeCallback?.("logout");
 
     await vi.waitFor(() => {

--- a/packages/code/tests/components/LoginCommand.test.tsx
+++ b/packages/code/tests/components/LoginCommand.test.tsx
@@ -65,6 +65,16 @@ describe("LoginCommand", () => {
     expect(lastFrame()).toContain("Press Enter to logout");
   });
 
+  it("should show authenticated state when token exists but is expired", () => {
+    mockAuthService.isSSOAuthenticated.mockReturnValue(false);
+    mockAuthService.getSSOToken.mockReturnValue("expired-token");
+
+    const { lastFrame } = render(<LoginCommand onCancel={vi.fn()} />);
+
+    expect(lastFrame()).toContain("Authenticated");
+    expect(lastFrame()).toContain("Press Enter to logout");
+  });
+
   it("should show server URL when getServerUrl returns a value", () => {
     mockAuthService.isSSOAuthenticated.mockReturnValue(true);
     mockAuthService.getSSOToken.mockReturnValue("short-token");

--- a/packages/code/tests/stdio/agentBridge.test.ts
+++ b/packages/code/tests/stdio/agentBridge.test.ts
@@ -1182,10 +1182,43 @@ test("getAuthStatus returns auth state", async () => {
       .fn()
       .mockReturnValue({ id: "user-1", email: "test@test.com" }),
     getServerUrl: vi.fn().mockReturnValue("https://codechat.codewave.163.com"),
+    checkAndRefreshTokenIfNeeded: vi.fn().mockResolvedValue(true),
   } as unknown as AuthService);
 
   const result = await bridge.handleRequest("getAuthStatus", {});
 
+  expect(result).toEqual({
+    isAuthenticated: true,
+    user: { id: "user-1", email: "test@test.com" },
+    serverUrl: "https://codechat.codewave.163.com",
+  });
+});
+
+test("getAuthStatus refreshes a stale-but-refreshable token before reporting", async () => {
+  // A remote daemon started with an expired access token (hourly expiry) must
+  // still report the user as logged in once the refresh succeeds. Without the
+  // proactive refresh, getAuthStatus returns false right after daemon start —
+  // the desktop welcome page then keeps showing the login button although the
+  // user is authenticated (refresh token valid).
+  const { bridge } = createBridge();
+  let authenticated = false; // stale token on disk when the daemon starts
+  const isSSOAuthenticated = vi.fn(() => authenticated);
+  const checkAndRefreshTokenIfNeeded = vi.fn().mockImplementation(async () => {
+    authenticated = true; // the refresh writes a fresh token
+    return true;
+  });
+  vi.mocked(AuthService.getInstance).mockReturnValue({
+    isSSOAuthenticated,
+    getAuthUser: vi
+      .fn()
+      .mockReturnValue({ id: "user-1", email: "test@test.com" }),
+    getServerUrl: vi.fn().mockReturnValue("https://codechat.codewave.163.com"),
+    checkAndRefreshTokenIfNeeded,
+  } as unknown as AuthService);
+
+  const result = await bridge.handleRequest("getAuthStatus", {});
+
+  expect(checkAndRefreshTokenIfNeeded).toHaveBeenCalled();
   expect(result).toEqual({
     isAuthenticated: true,
     user: { id: "user-1", email: "test@test.com" },


### PR DESCRIPTION
## 问题

桌面端选择 lyq.u（SSO 远程 host）时，明明已登录，欢迎页仍显示"登录"按钮。

根因：host 选择动作触发远端 daemon 启动，而 daemon 可能以过期的 SSO access token（1 小时过期）启动；desktop 的 refreshAuthStatus 查询 `getAuthStatus` RPC，它直接读 `isSSOAuthenticated()`（含过期检查）→ 返回未认证。此后 daemon 惰性刷新了 token，但 desktop 从不重新查询 → 欢迎页按钮永久停留。

## 修复

1. **agentBridge.getAuthStatus 主动刷新**（desktop / VSCE / JetBrains 三端统一入口）：查询前先 `checkAndRefreshTokenIfNeeded()`，过期但可刷新的 token 仍正确回报已认证。
2. **CLI 对齐 claude-code 行为**：SSO token 存在即算已认证、不看过期（刷新完全惰性、发生在下一次 API 请求前）——`ChatInterface` 的 /login hint 与 `LoginCommand` 的状态判断由 `isSSOAuthenticated()` 改为 `getSSOToken()` 存在性检查。

## 测试

- TDD：新增 "expired token 仍视为已认证" 用例（先红后绿）
- `pnpm -F wave-code test`：1277 passed（另 1 个 pre-existing InputBox flaky，干净 baseline 同样出现）
- type-check + eslint 通过