### PR TITLE
feat(sdk): enforce worktree safety check in bypassPermissions mode

### DIFF
--- a/docs/specs/multi-agent/worktree.md
+++ b/docs/specs/multi-agent/worktree.md
@@ -179,6 +179,23 @@ order: 90
 
 ---
 
+### 用户故事：bypassPermissions 模式下 Worktree 安全拦截仍生效（优先级：P1）
+
+作为开发者，我希望即使开启了"跳过权限确认"（bypassPermissions）模式，worktree 会话中修改主仓库文件仍被拦截，以便安全隔离不因权限模式而失效。
+
+**为什么是这个优先级**：worktree 隔离是防数据破坏的安全机制（防止误写主仓库），与权限模式无关。read-before-edit 校验也是不区分权限模式的无条件安全检查——worktree 安全拦截应遵循同样的语义。bypassPermissions 的语义是"跳过权限确认"，不是"跳过安全校验"。
+
+**独立测试**：在 worktree 会话中通过 webview 或 CLI 将权限模式切换为 bypassPermissions，要求 AI 用 Write/Edit 修改主仓库（worktree 外）文件，验证操作被拒绝且出现 worktree 安全错误消息；再要求修改 worktree 内文件，验证正常写入。
+
+**验收场景**：
+
+1. **假设**我处于 bypassPermissions 模式且在 worktree 会话中（CLI `-w` 或 EnterWorktree 创建），**当** AI 调用 Write/Edit 修改主仓库（worktree 外）的文件时，**则**操作被拒绝，返回"Access denied: You are currently in a worktree session..."消息，且日志记录 Worktree safety violation。
+2. **假设**我处于 bypassPermissions 模式且在 worktree 会话中，**当** AI 调用 Write/Edit 修改 worktree 内的文件时，**则**操作正常执行，无需任何权限确认（bypass 语义不变）。
+3. **假设**我处于 bypassPermissions 模式但不在任何 worktree 会话中，**当** AI 调用 Write/Edit 修改任意文件时，**则**操作正常执行，无需权限确认（非 worktree 场景行为完全不变）。
+4. **假设**我处于 acceptEdits 或 default 模式且在 worktree 会话中，**当** AI 调用 Write/Edit 修改主仓库文件时，**则**行为与现状一致，仍被 worktree 安全拦截。
+
+---
+
 ### 边界情况
 
 - **当 worktree 目录已存在时会发生什么？** 系统应该报错或询问是否重用。

--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -427,18 +427,8 @@ export class PermissionManager {
       }
     }
 
-    // 1. If bypassPermissions mode, always allow
-    // Exception: tools that require user interaction (e.g. AskUserQuestion)
-    // must still prompt the user, matching Claude Code's requiresUserInteraction behavior.
-    if (context.permissionMode === "bypassPermissions") {
-      const requiresUserInteraction =
-        context.toolName === ASK_USER_QUESTION_TOOL_NAME;
-      if (!requiresUserInteraction) {
-        return { behavior: "allow" };
-      }
-    }
-
-    // 1.0 Check worktree safety for Write and Edit tools
+    // Check worktree safety for Write and Edit tools — unconditional safety
+    // check, applied regardless of permission mode (same as read-before-edit).
     // Support both CLI -w sessions (container-registered) and EnterWorktree mid-session
     // (per-agent WorktreeSession stored in this session's container)
     const worktreeSession = this.container.get<WorktreeSession | null>(
@@ -503,7 +493,19 @@ export class PermissionManager {
       }
     }
 
-    // 1.1 If acceptEdits mode, allow Edit, Write, and mkdir in safe zone
+    // If bypassPermissions mode, always allow
+    // Exception: tools that require user interaction (e.g. AskUserQuestion)
+    // must still prompt the user, matching Claude Code's requiresUserInteraction behavior.
+    // Worktree safety check above runs unconditionally, so bypass never skips it.
+    if (context.permissionMode === "bypassPermissions") {
+      const requiresUserInteraction =
+        context.toolName === ASK_USER_QUESTION_TOOL_NAME;
+      if (!requiresUserInteraction) {
+        return { behavior: "allow" };
+      }
+    }
+
+    // If acceptEdits mode, allow Edit, Write, and mkdir in safe zone
     if (context.permissionMode === "acceptEdits") {
       const autoAcceptedTools = [EDIT_TOOL_NAME, WRITE_TOOL_NAME];
       if (autoAcceptedTools.includes(context.toolName)) {

--- a/packages/agent-sdk/tests/managers/permissionManager.worktree.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.worktree.test.ts
@@ -138,6 +138,80 @@ describe("PermissionManager Worktree Safety", () => {
     const result = await manager.checkPermission(context);
     expect(result.behavior).toBe("allow");
   });
+
+  it("should auto-deny Write to main repo in bypassPermissions mode", async () => {
+    const container = createWorktreeContainer();
+    const manager = new PermissionManager(container);
+    const context: ToolPermissionContext = {
+      toolName: "Write",
+      permissionMode: "bypassPermissions",
+      toolInput: { file_path: path.join(mainRepoRoot, "main-file.txt") },
+    };
+
+    const result = await manager.checkPermission(context);
+    expect(result.behavior).toBe("deny");
+    expect(result.message).toContain(
+      "Access denied: You are currently in a worktree session",
+    );
+    expect(result.message).toContain(worktreeName);
+  });
+
+  it("should auto-deny Edit to main repo in bypassPermissions mode", async () => {
+    const container = createWorktreeContainer();
+    const manager = new PermissionManager(container);
+    const context: ToolPermissionContext = {
+      toolName: "Edit",
+      permissionMode: "bypassPermissions",
+      toolInput: { file_path: path.join(mainRepoRoot, "main-file.txt") },
+    };
+
+    const result = await manager.checkPermission(context);
+    expect(result.behavior).toBe("deny");
+    expect(result.message).toContain(
+      "Access denied: You are currently in a worktree session",
+    );
+  });
+
+  it("should allow Write inside worktree in bypassPermissions mode", async () => {
+    const container = createWorktreeContainer();
+    const manager = new PermissionManager(container);
+    const context: ToolPermissionContext = {
+      toolName: "Write",
+      permissionMode: "bypassPermissions",
+      toolInput: { file_path: path.join(workdir, "test.txt") },
+    };
+
+    const result = await manager.checkPermission(context);
+    expect(result.behavior).toBe("allow");
+  });
+
+  it("should allow Write outside worktree in bypassPermissions mode when not in a worktree session", async () => {
+    const container = new Container();
+    container.register("Workdir", mainRepoRoot);
+    const manager = new PermissionManager(container);
+    const context: ToolPermissionContext = {
+      toolName: "Write",
+      permissionMode: "bypassPermissions",
+      toolInput: { file_path: path.join(mainRepoRoot, "main-file.txt") },
+    };
+
+    const result = await manager.checkPermission(context);
+    expect(result.behavior).toBe("allow");
+  });
+
+  it("should allow Write to the plan file in bypassPermissions mode", async () => {
+    const planFilePath = "/home/user/.wave/plans/plan.md";
+    const container = createWorktreeContainer();
+    const manager = new PermissionManager(container, { planFilePath });
+    const context: ToolPermissionContext = {
+      toolName: "Write",
+      permissionMode: "bypassPermissions",
+      toolInput: { file_path: planFilePath },
+    };
+
+    const result = await manager.checkPermission(context);
+    expect(result.behavior).toBe("allow");
+  });
 });
 
 describe("PermissionManager Worktree Safety — EnterWorktree mid-session", () => {


### PR DESCRIPTION
## 背景

桌面端 worktree 会话在 bypassPermissions（跳过权限确认）模式下，agent 写主仓库文件未被拦截。根因：permissionManager.ts 中 bypass 检查在 worktree 安全拦截之前，bypass 直接 allow 跳过了拦截。

## 变更

- `permissionManager.ts`：worktree 安全拦截（Write/Edit 越界写主仓库 → deny）移为**无条件安全检查**，在 bypassPermissions allow 分支之前执行。语义与 read-before-edit 一致——bypass 跳过的是权限确认，不是安全校验。
- `docs/specs/multi-agent/worktree.md`：新增 P1 用户故事「bypassPermissions 模式下 Worktree 安全拦截仍生效」，4 条验收场景。
- `permissionManager.worktree.test.ts`：新增 5 个 bypass 模式测试（主仓库 Write/Edit deny、worktree 内 allow、非 worktree 会话 allow、plan 文件 allow）。

## 验证

- worktree 测试 15/15 通过（原 10 + 新 5）
- permission 全套 203/203 通过，无回归
- type-check / lint 通过