### PR TITLE
fix(agent-sdk): carry compactParams/name in running-stage tool block updates

### DIFF
--- a/docs/specs/core/stream-content-updates.md
+++ b/docs/specs/core/stream-content-updates.md
@@ -71,8 +71,9 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 1. **假设**工具执行开始，**当**`onToolBlockUpdated`触发时，**则**收到的第一个事件包含 `stage="start"` 和工具的显示名称
 2. **假设**工具发出流式输出，**当**`onToolBlockUpdated`以 `stage="streaming"` 触发时，**则**每个事件包含最新的 `parametersChunk`
 3. **假设**长时间运行的工具，**当**进度更新发生但没有新块时，**则**`onToolBlockUpdated`发出 `stage="running"`
-4. **假设**工具完成，**当**`onToolBlockUpdated`发出最终更新时，**则**事件使用 `stage="end"` 并携带最终输出或错误摘要
-5. **假设**任何 `onToolBlockUpdated` 事件，**则**有效载荷不包含已弃用的 `isRunning` 标志
+4. **假设**工具处于 `running` 阶段，**当**其产生增量结果或短结果时，**则**每次 `stage="running"` 事件都必须携带该工具调用自始至终不变的稳定展示字段（`compactParams`、`name`），而不是只在首次 running 事件携带——消费端（如 CLI）以 last-value-wins 节流丢弃中间事件后，仍能在 running 阶段正确渲染 compactParams
+5. **假设**工具完成，**当**`onToolBlockUpdated`发出最终更新时，**则**事件使用 `stage="end"` 并携带最终输出或错误摘要
+6. **假设**任何 `onToolBlockUpdated` 事件，**则**有效载荷不包含已弃用的 `isRunning` 标志
 
 ---
 
@@ -150,7 +151,7 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 - **SDK 回调负载**：`onAssistantContentUpdated`/`onAssistantReasoningUpdated` 始终同时提供 `chunk`（增量）与 `accumulated`（累积）两个字段，进程内消费者免费使用 `accumulated` 就地替换；`onToolBlockUpdated` 提供 `parametersChunk`（增量）与 `parameters`（累积）并存
 - **跨进程 wire 负载（纯 delta）**：agentBridge 在转发 stdio 通知时剥离累积字段——`assistantContentUpdated`/`assistantReasoningUpdated` 只携带 `{messageId, chunk, stage}`；`toolBlockUpdated` 在 `stage="streaming"` 时只携带 `parametersChunk`，`stage="end"` 时携带全量 `parameters` + `result` 作为权威值。消费端负责累积（追加），丢失的 delta 由 `getMessages` 拉取的全量快照自愈
 - **UI 状态流**：CLI 直接订阅增量回调就地更新消息（accumulated 替换 + 500ms 节流）；插件/桌面经 stdio 增量通知（`userMessageAdded`、`assistantContentUpdated`、`toolBlockUpdated` 等，纯 delta 负载）驱动 webview 增量 reducer——文本/推理块追加 chunk、工具块追加 `parametersChunk`，end 时以权威值终结；需要完整列表的场景（初始化、compact、rewind、clear、bang）主动拉取，拉取响应整体替换为权威快照
-- **节流语义**：节流器对 delta 负载必须按到达顺序拼接窗口内所有 chunks 为一个合并 delta（window-concat），绝不能 last-value-wins 丢弃中间值；对 accumulated 负载（CLI 进程内）last-value-wins 仍然正确
+- **节流语义**：节流器对 delta 负载必须按到达顺序拼接窗口内所有 chunks 为一个合并 delta（window-concat），绝不能 last-value-wins 丢弃中间值；对 accumulated 负载（CLI 进程内）last-value-wins 仍然正确。为配合该语义，SDK 必须在每次 running 事件中重复携带 `compactParams` 等稳定展示字段（见"工具块阶段更新"验收场景 4），保证丢弃中间事件不丢失这些字段
 - **清晰分离**：增量回调是消息状态管理的正式对外通道；全量数据按需获取，避免随每次流式 chunk 序列化整个列表
 
 ## 澄清

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -2195,6 +2195,8 @@ ${question}`;
             id: toolId,
             shortResult,
             stage: "running",
+            compactParams,
+            name: toolName,
           });
         },
         onResultUpdate: (result: string) => {
@@ -2202,6 +2204,8 @@ ${question}`;
             id: toolId,
             result,
             stage: "running",
+            compactParams,
+            name: toolName,
           });
         },
         onCwdChange: async (newCwd: string) => {

--- a/packages/agent-sdk/tests/managers/aiManager.compactParamsRunning.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.compactParamsRunning.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi } from "vitest";
+import { Container } from "../../src/utils/container.js";
+import { AIManager } from "../../src/managers/aiManager.js";
+import { MessageManager } from "../../src/managers/messageManager.js";
+import { ToolManager } from "../../src/managers/toolManager.js";
+import type { GatewayConfig, ModelConfig } from "../../src/types/index.js";
+import type { ToolBlockUpdateCallbackParams } from "../../src/utils/messageOperations.js";
+import * as aiService from "../../src/services/aiService.js";
+
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock("../../src/utils/gitUtils.js", () => ({
+  isGitRepository: vi.fn(),
+}));
+
+vi.mock("../../src/services/aiService.js", () => ({
+  callAgent: vi.fn(),
+  compactMessages: vi.fn(),
+  transformMessagesForExplicitCache: vi.fn((m) => m),
+  extendUsageWithCacheMetrics: vi.fn((u) => u),
+}));
+
+vi.mock("../../src/services/memory.js", () => ({
+  MemoryService: vi.fn().mockImplementation(() => ({
+    getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+    getAutoMemoryDirectory: vi.fn().mockReturnValue("/mock/auto-memory"),
+    ensureAutoMemoryDirectory: vi.fn().mockResolvedValue(undefined),
+    getAutoMemoryContent: vi.fn().mockResolvedValue(""),
+  })),
+  getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+}));
+
+vi.mock("../../src/utils/convertMessagesForAPI.js", () => ({
+  convertMessagesForAPI: vi.fn().mockReturnValue([]),
+}));
+
+describe("aiManager: running-stage tool block updates carry compactParams", () => {
+  const mockGatewayConfig: GatewayConfig = {
+    apiKey: "test-api-key",
+    baseURL: "https://test-gateway.com",
+  };
+  const mockModelConfig: ModelConfig = {
+    model: "test-agent-model",
+    fastModel: "test-fast-model",
+  };
+
+  function createContainer() {
+    const container = new Container();
+    container.register("ConfigurationService", {
+      setOptions: vi.fn(),
+      resolveGatewayConfig: vi.fn().mockReturnValue(mockGatewayConfig),
+      resolveModelConfig: vi.fn().mockReturnValue(mockModelConfig),
+      resolveMaxInputTokens: vi.fn().mockReturnValue(96000),
+      resolveAutoMemoryEnabled: vi.fn().mockReturnValue(true),
+      resolveLanguage: vi.fn().mockReturnValue(undefined),
+      getEnvironmentVars: vi.fn().mockReturnValue({}),
+      getMergedEnv: vi.fn().mockReturnValue({}),
+    });
+    container.register("TaskManager", {
+      on: vi.fn(),
+      listTasks: vi.fn().mockResolvedValue([]),
+    });
+    container.register("MemoryService", {
+      getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+      getAutoMemoryDirectory: vi.fn().mockReturnValue("/mock/auto-memory"),
+      ensureAutoMemoryDirectory: vi.fn().mockResolvedValue(undefined),
+      getAutoMemoryContent: vi.fn().mockResolvedValue(""),
+    });
+    container.register("PermissionManager", {
+      getCurrentEffectiveMode: vi.fn().mockReturnValue("normal"),
+      clearTemporaryRules: vi.fn(),
+      getPlanFilePath: vi.fn().mockReturnValue(undefined),
+      setHasExitedPlanMode: vi.fn(),
+      hasExitedPlanModeInSession: vi.fn(() => false),
+      setNeedsPlanModeExitAttachment: vi.fn(),
+      getNeedsPlanModeExitAttachment: vi.fn(() => false),
+      isToolDenied: vi.fn().mockReturnValue(false),
+    });
+    container.register("SubagentManager", {
+      getConfigurations: vi.fn().mockReturnValue([]),
+    });
+    container.register("SkillManager", {
+      getAvailableSkills: vi.fn().mockReturnValue([]),
+    });
+    container.register("MessageQueue", {
+      hasNotifications: vi.fn().mockReturnValue(false),
+      drainNotifications: vi.fn().mockReturnValue([]),
+    });
+    container.register("ForegroundTaskManager", {});
+    container.register("LspManager", {});
+    container.register("McpManager", {
+      getMcpToolsConfig: vi.fn().mockReturnValue([]),
+      isMcpTool: vi.fn().mockReturnValue(false),
+      getMcpToolPlugins: vi.fn().mockReturnValue([]),
+    });
+    container.register("BackgroundTaskManager", {
+      listTasks: vi.fn().mockReturnValue([]),
+    });
+    container.register("HookManager", undefined);
+    container.register("ReversionManager", undefined);
+    container.register("PlanManager", undefined);
+    return container;
+  }
+
+  it("shortResult/result running events include compactParams + name after streaming", async () => {
+    const container = createContainer();
+
+    // Real MessageManager; capture every onToolBlockUpdated callback param,
+    // which is exactly what CLI/desktop/vsce consumers subscribe to.
+    const capturedUpdates: ToolBlockUpdateCallbackParams[] = [];
+    const messageManager = new MessageManager(container, {
+      workdir: "/test/workdir",
+      callbacks: {
+        onToolBlockUpdated: (params) => {
+          capturedUpdates.push(params);
+        },
+      },
+    });
+    container.register("MessageManager", messageManager);
+
+    // Real ToolManager with agentTool registered so generateCompactParams
+    // resolves "explore: find foo" instead of silently returning "".
+    const toolManager = new ToolManager({ container });
+    toolManager.initializeBuiltInTools();
+    vi.spyOn(toolManager, "execute").mockImplementation(
+      async (_name, _args, context) => {
+        // Emit running-stage progress updates like a real subagent does.
+        context.onShortResultUpdate?.("step 1: searching");
+        context.onResultUpdate?.("progress output");
+        return {
+          success: true,
+          content: "found foo",
+          shortResult: "found foo",
+        };
+      },
+    );
+    container.register("ToolManager", toolManager);
+
+    // Simulate streaming tool call deltas, then the resolved tool_calls.
+    vi.mocked(aiService.callAgent).mockImplementationOnce(async (options) => {
+      if (options.onToolUpdate) {
+        options.onToolUpdate({
+          id: "call_1",
+          name: "Agent",
+          parameters: "",
+          parametersChunk: "",
+          stage: "start",
+        });
+        options.onToolUpdate({
+          id: "call_1",
+          name: "Agent",
+          parameters: '{"subagent_type":"explore"',
+          parametersChunk: '{"subagent_type":"explore"',
+          stage: "streaming",
+        });
+        options.onToolUpdate({
+          id: "call_1",
+          name: "Agent",
+          parameters: '{"subagent_type":"explore","description":"find foo"',
+          parametersChunk: ',"description":"find foo"',
+          stage: "streaming",
+        });
+        options.onToolUpdate({
+          id: "call_1",
+          name: "Agent",
+          parameters:
+            '{"subagent_type":"explore","description":"find foo","prompt":"find foo in codebase"}',
+          parametersChunk: ',"prompt":"find foo in codebase"}',
+          stage: "streaming",
+        });
+      }
+      return {
+        content: "",
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+        tool_calls: [
+          {
+            id: "call_1",
+            type: "function",
+            function: {
+              name: "Agent",
+              arguments:
+                '{"subagent_type":"explore","description":"find foo","prompt":"find foo in codebase"}',
+            },
+          },
+        ],
+      };
+    });
+    // Subsequent calls (loop restart) return no tool calls.
+    vi.mocked(aiService.callAgent).mockImplementation(async () => ({
+      content: "done",
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      tool_calls: [],
+    }));
+
+    const aiManager = new AIManager(container, {
+      workdir: "/test/workdir",
+      stream: true,
+    });
+    await aiManager.sendAIMessage();
+
+    // Progress updates (shortResult/result) during running stage must carry
+    // compactParams + name: consumers throttle with last-value-wins and would
+    // otherwise lose the single compactParams-carrying running update.
+    const runningUpdates = capturedUpdates.filter((u) => u.stage === "running");
+    const progressUpdates = runningUpdates.filter(
+      (u) => u.shortResult !== undefined || u.result !== undefined,
+    );
+    expect(progressUpdates.length).toBeGreaterThan(0);
+    for (const u of progressUpdates) {
+      expect(u.compactParams).toBe("explore: find foo");
+      expect(u.name).toBe("Agent");
+    }
+  });
+});


### PR DESCRIPTION
onShortResultUpdate/onResultUpdate now include compactParams and name in the updateToolBlock call, so every stage="running" onToolBlockUpdated event is self-contained. Consumers (CLI) throttle with last-value-wins and were losing the single compactParams-carrying running update behind the subagent's rapid shortResult updates, so compactParams only appeared at the end stage. Spec: stream-content-updates.md (工具块阶段更新 scenario 4 + throttle semantics) Test: aiManager.compactParamsRunning.test.ts
