### PR TITLE
fix(webview): 预览面板评论在 SSH 远程会话中未进入输入框

### DIFF
--- a/packages/webview/src/components/MessageInput.tsx
+++ b/packages/webview/src/components/MessageInput.tsx
@@ -242,6 +242,12 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>((p
   // Use a ref to avoid re-running effect on every local message change
   const inputContentRef = useRef(inputContent);
   const prevSessionRef = useRef(sessionId);
+  // Mirror the latest local message so the session-switch flush can read it
+  // without depending on `message` in the effect deps: a message dep would
+  // re-run this effect after every keystroke/appendText and wipe the input
+  // with the (stale) inputContent prop the host last pushed.
+  const messageRef = useRef(message);
+  messageRef.current = message;
   useEffect(() => {
     const prevSession = prevSessionRef.current;
     const sessionChanged = prevSession !== sessionId;
@@ -255,7 +261,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>((p
         clearTimeout(inputContentTimerRef.current);
         inputContentTimerRef.current = null;
       }
-      const text = textareaRef.current?.innerText ?? message;
+      const text = textareaRef.current?.innerText ?? messageRef.current;
       if (text) {
         vscode.postMessage({ command: 'updateInputContent', sessionId: prevSession, content: text });
       }
@@ -269,7 +275,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>((p
         textareaRef.current.innerText = inputContent ?? '';
       }
     }
-  }, [inputContent, sessionId, vscode, message]);
+  }, [inputContent, sessionId, vscode]);
   
   // Initialize attached images from initialAttachedImages prop
   useEffect(() => {

--- a/packages/webview/tests/webview/chatAppPanels.test.tsx
+++ b/packages/webview/tests/webview/chatAppPanels.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent, screen, createEvent, within, act } from '@testing-li
 import React from 'react';
 import { DesktopApp } from '../../src/components/DesktopApp';
 import { ChatApp, prunePanelGroupCache } from '../../src/components/ChatApp';
+import type { WebviewTagElement } from '../../src/components/PreviewPane';
 import { EXIT_PLAN_MODE_TOOL_NAME } from 'wave-agent-sdk';
 import { createMockVscode, sendCommand, renderChatApp, fireInput } from './test-utils';
 import { MockDataGenerator } from '../fixtures/mockData';
@@ -1140,5 +1141,71 @@ describe('remote preview port forwarding', () => {
         );
         expect(forwardPosts(vscode)).toHaveLength(2);
         expect(releasePosts(vscode)).toHaveLength(0);
+    });
+
+    it('picker comments in a remote preview land in the chat input (URL rewritten to the original remote address)', () => {
+        window.waveHostType = 'desktop';
+        const { vscode } = renderDesktop({ workdir: '/work/a' });
+        sendCommand('desktopSessionTree', { groups: [{ workdir: '/work/a', sessions: [session('s1')] }] });
+        pushRemotePane();
+        // The host always pushes a pane snapshot on session switch, including
+        // the (possibly empty) input draft — see desktopHost.ts pushPaneSessionState.
+        sendCommand('setInitialState', {
+            paneId: 'pane-1',
+            messages: [],
+            inputContent: '',
+            isAuthenticated: true,
+        });
+        openLink();
+        sendCommand('desktopForwardPortResult', {
+            paneId: 'pane-1',
+            requestId: 'fwd-1',
+            url: 'http://127.0.0.1:5173/app',
+            originalUrl: 'http://localhost:5173/app',
+        });
+
+        const wv = screen.getByTestId('preview-pane').querySelector('webview') as unknown as Omit<
+            WebviewTagElement,
+            'send' | 'loadURL' | 'reload' | 'reloadIgnoringCache' | 'getURL'
+        > & {
+            send: ReturnType<typeof vi.fn>;
+            loadURL: ReturnType<typeof vi.fn>;
+            reload: ReturnType<typeof vi.fn>;
+            reloadIgnoringCache: ReturnType<typeof vi.fn>;
+            getURL: ReturnType<typeof vi.fn>;
+        };
+        wv.send = vi.fn();
+        wv.loadURL = vi.fn().mockResolvedValue(undefined);
+        wv.reload = vi.fn();
+        wv.reloadIgnoringCache = vi.fn();
+        wv.getURL = vi.fn(() => 'http://127.0.0.1:5173/app');
+        fireEvent(wv, new Event('dom-ready'));
+        fireEvent(wv, Object.assign(new Event('ipc-message'), { channel: 'wave-picker', args: [{ type: 'ready' }] }));
+        fireEvent.click(screen.getByTestId('preview-picker-toggle'));
+
+        // The picker submits the tunnel URL (the guest's location.href); the
+        // pane rewrites it back to the original remote address before appending.
+        fireEvent(
+            wv,
+            Object.assign(new Event('ipc-message'), {
+                channel: 'wave-picker',
+                args: [
+                    {
+                        type: 'submit',
+                        url: 'http://127.0.0.1:5173/app',
+                        selector: '#app > button',
+                        summary: 'button',
+                        text: '登录',
+                        comment: '远程评论要进输入框',
+                    },
+                ],
+            }),
+        );
+
+        const input = screen.getByTestId('message-input') as HTMLElement;
+        expect(input.textContent).toContain('远程评论要进输入框');
+        expect(input.textContent).toContain('http://localhost:5173/app');
+        // Nothing is sent directly — the user reviews the batch and sends manually.
+        expect(vscode.postMessage).not.toHaveBeenCalledWith(expect.objectContaining({ command: 'sendMessage' }));
     });
 });


### PR DESCRIPTION
## 问题

桌面端选择 SSH 远程会话后，预览面板的元素评论不会进入输入框。

## 根因

127501ba 为 MessageInput 的 inputContent 同步 effect 增加 message 依赖（仅用于 session 切换时 flush 读取），导致每次本地输入/appendText 后 effect 重跑，用 host 上一次推送的 inputContent（桌面端 setInitialState 总是携带，空串）覆盖刚追加的文本。本地场景单测未触发是因为测试未模拟 host 推送 setInitialState。

## 修复

MessageInput.tsx 新增 messageRef 镜像最新本地消息，session 切换 flush 改读 messageRef.current，message 移出 effect 依赖。effect 只响应外部变化（setInitialState / session 切换），不再响应本地输入。session 切换的 flush 与无条件重置行为保持不变。

## 验证

- 新增复现测试：远程预览评论提交后断言进入输入框（模拟 host 推送 inputContent 空串），修复前红、修复后绿
- webview 全量 611 测试通过（含 input draft 持久化测试，flush 语义未破坏）
- type-check 通过，webview dist 已重建