### PR TITLE
chore: run docs link/anchor checks in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
 pnpm run type-check
 pnpm -r lint
 pnpm exec lint-staged
+node scripts/check-docs-links.mjs && node scripts/check-sidebar-anchors.mjs


### PR DESCRIPTION
## 背景

CI 中 docs-checks 失败（如 PR #1648 的 sidebar anchor 检查）只能在 push 后才发现。把两个零依赖静态检查脚本加入 pre-commit 钩子，提交时即拦截。

## 改动

```diff
 pnpm run type-check
 pnpm -r lint
 pnpm exec lint-staged
+node scripts/check-docs-links.mjs && node scripts/check-sidebar-anchors.mjs
```

- 零依赖静态检查，实测 ~0.26s
- 必须全量跑（不能进 lint-staged）：检查对象是完整 docs 树而非本次暂存文件
- check-docs-links 的 missing-image 为 warnings（screenshot 构建产物，docs:build 时才生成），不阻塞提交

## 验证

commit 时 pre-commit 钩子完整自运行：type-check / lint / lint-staged / docs 检查全部通过。