### PR TITLE
fix(vsce): deliver updateMessages after restore/clear

### DIFF
--- a/packages/vsce/src/session/messageHandler.ts
+++ b/packages/vsce/src/session/messageHandler.ts
@@ -591,6 +591,9 @@ export class MessageHandler {
         const session = this.context.getChatSession(viewType || 'tab', windowId);
         try {
             await session.clearChat();
+            // No full-snapshot push from the server — deliver the (now empty)
+            // list so the webview actually clears.
+            this.context.postMessage({ command: 'updateMessages', messages: session.messages }, viewType, windowId);
         } catch (error) {
             console.error(`清除 ${viewType} 聊天会话失败:`, error);
             vscode.window.showErrorMessage('清除聊天失败: ' + error);
@@ -612,6 +615,9 @@ export class MessageHandler {
         const session = this.context.getChatSession(viewType || 'tab', windowId);
         try {
             await session.restoreSession(sessionId);
+            // No full-snapshot push from the server — deliver the restored list
+            // so the webview re-renders instead of keeping the welcome page.
+            this.context.postMessage({ command: 'updateMessages', messages: session.messages }, viewType, windowId);
         } catch (error) {
             console.error(`恢复 ${viewType} 会话失败:`, error);
             vscode.window.showErrorMessage('恢复会话失败: ' + error);

--- a/packages/vsce/tests/session/messageHandler.test.ts
+++ b/packages/vsce/tests/session/messageHandler.test.ts
@@ -30,6 +30,8 @@ function createMockSession(): ChatSession {
         connectMcpServer: vi.fn(),
         disconnectMcpServer: vi.fn(),
         compact: vi.fn(),
+        clearChat: vi.fn(),
+        restoreSession: vi.fn(),
         getSlashCommands: vi.fn().mockResolvedValue([]),
         getMessages: vi.fn().mockResolvedValue([]),
         askBtw: vi.fn(),
@@ -248,6 +250,41 @@ describe('MessageHandler MCP handlers', () => {
 
     // /compact command: mirrors /clear — the webview posts { command: 'compact', customInstructions }
     // and the handler delegates to session.compact(customInstructions).
+    // Regression (9cea65ea): the onMessagesChange full-snapshot push was removed;
+    // restoring a history session must deliver the pulled list to the webview via
+    // updateMessages, otherwise state.messages stays empty and the webview keeps
+    // showing the welcome page after selecting a session in the sidebar.
+    test('restoreSession posts updateMessages with the restored messages', async () => {
+        const restoredMessages = [{ id: 'm1', role: 'user', content: 'hello' }];
+        const session = createMockSession();
+        (session.restoreSession as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+        session.messages = restoredMessages as unknown as ChatSession['messages'];
+
+        const { handler, context } = createHandler(session);
+        await handler.handleMessage({ command: 'restoreSession', sessionId: 'sess-1' }, 'tab');
+
+        expect(session.restoreSession).toHaveBeenCalledWith('sess-1');
+        const posted = (context.postMessage as ReturnType<typeof vi.fn>).mock.calls[0][0] as { command: string; messages: unknown };
+        expect(posted.command).toBe('updateMessages');
+        expect(posted.messages).toEqual(restoredMessages);
+    });
+
+    // Same regression class: /clear pulls the (now empty) list into the cache
+    // but never pushes it, so the webview would keep showing the old messages.
+    test('clearChat posts updateMessages with the cleared message list', async () => {
+        const session = createMockSession();
+        (session.clearChat as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+        session.messages = [];
+
+        const { handler, context } = createHandler(session);
+        await handler.handleMessage({ command: 'clearChat' }, 'tab');
+
+        expect(session.clearChat).toHaveBeenCalled();
+        const posted = (context.postMessage as ReturnType<typeof vi.fn>).mock.calls[0][0] as { command: string; messages: unknown };
+        expect(posted.command).toBe('updateMessages');
+        expect(posted.messages).toEqual([]);
+    });
+
     test('compact command calls session.compact with customInstructions', async () => {
         const session = createMockSession();
         (session.compact as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);


### PR DESCRIPTION
commit 9cea65ea removed the onMessagesChange full-snapshot push; VSCE only pulled the list into the session cache and never delivered it to the webview. Restoring a history session from the sidebar kept state.messages empty so the welcome page never left; /clear kept showing the old messages.

Fix: post updateMessages after session.restoreSession and session.clearChat, mirroring the JetBrains pullAndPushMessages pattern. TDD: 2 failing tests written first (restoreSession / clearChat), vsce 165 tests green + type-check passed.