### PR TITLE
fix: 隐藏 Plan 模式下工具确认的 bypass 选项

### DIFF
--- a/packages/code/src/components/ChatInterface.tsx
+++ b/packages/code/src/components/ChatInterface.tsx
@@ -159,6 +159,7 @@ export const ChatInterface: React.FC = () => {
             toolInput={confirmingTool!.input}
             suggestedPrefix={confirmingTool!.suggestedPrefix}
             hidePersistentOption={confirmingTool!.hidePersistentOption}
+            permissionMode={confirmingTool!.permissionMode}
             isExpanded={isExpanded}
             onDecision={handleConfirmationDecision}
             onCancel={handleConfirmationCancel}

--- a/packages/code/src/components/ConfirmationSelector.tsx
+++ b/packages/code/src/components/ConfirmationSelector.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useReducer } from "react";
 import { Box, Text, useInput } from "ink";
-import type { PermissionDecision, AskUserQuestionInput } from "wave-agent-sdk";
+import type {
+  PermissionDecision,
+  PermissionMode,
+  AskUserQuestionInput,
+} from "wave-agent-sdk";
 import {
   BASH_TOOL_NAME,
   EXIT_PLAN_MODE_TOOL_NAME,
@@ -24,6 +28,7 @@ export interface ConfirmationSelectorProps {
   toolInput?: Record<string, unknown>;
   suggestedPrefix?: string;
   hidePersistentOption?: boolean;
+  permissionMode?: PermissionMode;
   isExpanded?: boolean;
   onDecision: (decision: PermissionDecision) => void;
   onCancel: () => void;
@@ -34,6 +39,7 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
   toolInput,
   suggestedPrefix,
   hidePersistentOption,
+  permissionMode,
   isExpanded = false,
   onDecision,
   onCancel,
@@ -119,6 +125,7 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
         toolInput,
         suggestedPrefix,
         hidePersistentOption,
+        permissionMode,
       });
     }
   });
@@ -240,8 +247,8 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
                 </Text>
               </Box>
             )}
-            {(toolName === BASH_TOOL_NAME ||
-              toolName === EXIT_PLAN_MODE_TOOL_NAME) && (
+            {(toolName === EXIT_PLAN_MODE_TOOL_NAME ||
+              (toolName === BASH_TOOL_NAME && permissionMode !== "plan")) && (
               <Box key="bypass-option">
                 <Text
                   color={state.selectedOption === "bypass" ? "black" : "white"}

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -108,6 +108,7 @@ export interface ChatContextType {
     suggestedPrefix?: string;
     hidePersistentOption?: boolean;
     planContent?: string;
+    permissionMode?: PermissionMode;
   };
   showConfirmation: (
     toolName: string,
@@ -115,6 +116,7 @@ export interface ChatContextType {
     suggestedPrefix?: string,
     hidePersistentOption?: boolean,
     planContent?: string,
+    permissionMode?: PermissionMode,
   ) => Promise<PermissionDecision>;
   hideConfirmation: () => void;
   handleConfirmationDecision: (decision: PermissionDecision) => void;
@@ -363,6 +365,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         suggestedPrefix?: string;
         hidePersistentOption?: boolean;
         planContent?: string;
+        permissionMode?: PermissionMode;
       }
     | undefined
   >();
@@ -373,6 +376,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
       suggestedPrefix?: string;
       hidePersistentOption?: boolean;
       planContent?: string;
+      permissionMode?: PermissionMode;
       resolver: (decision: PermissionDecision) => void;
       reject: () => void;
     }>
@@ -383,6 +387,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
     suggestedPrefix?: string;
     hidePersistentOption?: boolean;
     planContent?: string;
+    permissionMode?: PermissionMode;
     resolver: (decision: PermissionDecision) => void;
     reject: () => void;
   } | null>(null);
@@ -423,6 +428,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
       suggestedPrefix?: string,
       hidePersistentOption?: boolean,
       planContent?: string,
+      permissionMode?: PermissionMode,
     ): Promise<PermissionDecision> => {
       return new Promise<PermissionDecision>((resolve, reject) => {
         const queueItem = {
@@ -431,6 +437,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
           suggestedPrefix,
           hidePersistentOption,
           planContent,
+          permissionMode,
           resolver: resolve,
           reject,
         };
@@ -634,6 +641,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
               context.suggestedPrefix,
               context.hidePersistentOption,
               context.planContent,
+              context.permissionMode,
             );
           } catch {
             // If confirmation was cancelled or failed, deny the operation
@@ -975,6 +983,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         suggestedPrefix: next.suggestedPrefix,
         hidePersistentOption: next.hidePersistentOption,
         planContent: next.planContent,
+        permissionMode: next.permissionMode,
       });
       setIsConfirmationVisible(true);
       setConfirmationQueue((prev) => prev.slice(1));

--- a/packages/code/src/reducers/confirmationReducer.ts
+++ b/packages/code/src/reducers/confirmationReducer.ts
@@ -1,5 +1,5 @@
 import { Key } from "ink";
-import type { PermissionDecision } from "wave-agent-sdk";
+import type { PermissionDecision, PermissionMode } from "wave-agent-sdk";
 import {
   BASH_TOOL_NAME,
   EXIT_PLAN_MODE_TOOL_NAME,
@@ -30,6 +30,7 @@ export type ConfirmationAction =
       toolInput?: Record<string, unknown>;
       suggestedPrefix?: string;
       hidePersistentOption?: boolean;
+      permissionMode?: PermissionMode;
     };
 
 export function confirmationReducer(
@@ -95,6 +96,7 @@ export function confirmationReducer(
         toolInput,
         suggestedPrefix,
         hidePersistentOption,
+        permissionMode,
       } = action;
 
       if (key.return) {
@@ -175,7 +177,10 @@ export function confirmationReducer(
       const availableOptions: ConfirmationState["selectedOption"][] = [];
       availableOptions.push("allow");
       if (!hidePersistentOption) availableOptions.push("auto");
-      if (toolName === BASH_TOOL_NAME || toolName === EXIT_PLAN_MODE_TOOL_NAME)
+      if (
+        toolName === EXIT_PLAN_MODE_TOOL_NAME ||
+        (toolName === BASH_TOOL_NAME && permissionMode !== "plan")
+      )
         availableOptions.push("bypass");
       availableOptions.push("alternative");
 

--- a/packages/code/tests/components/ConfirmationSelector.test.tsx
+++ b/packages/code/tests/components/ConfirmationSelector.test.tsx
@@ -343,6 +343,48 @@ describe("ConfirmationSelector Additional Coverage", () => {
         });
       });
     });
+
+    it("should not show bypass option for Bash in plan mode", async () => {
+      const { lastFrame } = render(
+        <ConfirmationSelector
+          toolName="Bash"
+          toolInput={{ command: "ls -la" }}
+          permissionMode="plan"
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("Yes, proceed");
+      });
+      expect(stripAnsiColors(lastFrame() || "")).not.toContain(
+        "bypass permissions",
+      );
+    });
+
+    it("should navigate from allow straight to alternative for Bash in plan mode", async () => {
+      const { stdin, lastFrame } = render(
+        <ConfirmationSelector
+          toolName="Bash"
+          toolInput={{ command: "ls -la" }}
+          permissionMode="plan"
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
+      });
+      stdin.write("\u001b[B"); // Down to auto
+      stdin.write("\u001b[B"); // Down — bypass skipped, lands on alternative
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain(
+          "> Type here to tell Wave what to change",
+        );
+      });
+    });
   });
 
   describe("ExitPlanMode bypass permissions option", () => {

--- a/packages/code/tests/components/confirmationReducer.test.ts
+++ b/packages/code/tests/components/confirmationReducer.test.ts
@@ -298,6 +298,61 @@ describe("confirmationReducer", () => {
       });
       expect(result.selectedOption).toBe("auto");
     });
+
+    it("should not include bypass in navigation for Bash in plan mode", () => {
+      const afterAuto = confirmationReducer(initialState, {
+        type: "HANDLE_KEY",
+        input: "",
+        key: { downArrow: true } as unknown as Key,
+        toolName: "Bash",
+        toolInput: { command: "ls -la" },
+        permissionMode: "plan",
+      });
+      expect(afterAuto.selectedOption).toBe("auto");
+
+      const afterAlternative = confirmationReducer(afterAuto, {
+        type: "HANDLE_KEY",
+        input: "",
+        key: { downArrow: true } as unknown as Key,
+        toolName: "Bash",
+        toolInput: { command: "ls -la" },
+        permissionMode: "plan",
+      });
+      expect(afterAlternative.selectedOption).toBe("alternative");
+    });
+
+    it("should not include bypass for Bash in plan mode when persistent option is hidden", () => {
+      const result = confirmationReducer(initialState, {
+        type: "HANDLE_KEY",
+        input: "",
+        key: { downArrow: true } as unknown as Key,
+        toolName: "Bash",
+        toolInput: { command: "rm -rf temp/" },
+        hidePersistentOption: true,
+        permissionMode: "plan",
+      });
+      expect(result.selectedOption).toBe("alternative");
+    });
+
+    it("should still include bypass in navigation for ExitPlanMode in plan mode", () => {
+      const afterAuto = confirmationReducer(initialState, {
+        type: "HANDLE_KEY",
+        input: "",
+        key: { downArrow: true } as unknown as Key,
+        toolName: "ExitPlanMode",
+        permissionMode: "plan",
+      });
+      expect(afterAuto.selectedOption).toBe("auto");
+
+      const afterBypass = confirmationReducer(afterAuto, {
+        type: "HANDLE_KEY",
+        input: "",
+        key: { downArrow: true } as unknown as Key,
+        toolName: "ExitPlanMode",
+        permissionMode: "plan",
+      });
+      expect(afterBypass.selectedOption).toBe("bypass");
+    });
   });
 
   describe("default action", () => {

--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -75,6 +75,7 @@ interface PendingConfirmation {
   planContent?: string;
   suggestedPrefix?: string;
   hidePersistentOption?: boolean;
+  permissionMode?: PermissionMode;
 }
 
 interface WorktreeInfo {
@@ -1687,6 +1688,7 @@ export class DesktopHost {
       planContent: context.planContent,
       suggestedPrefix: context.suggestedPrefix,
       hidePersistentOption: context.hidePersistentOption,
+      permissionMode: context.permissionMode,
     });
     this.refreshSessionTree();
 
@@ -1704,6 +1706,7 @@ export class DesktopHost {
         planContent: context.planContent,
         suggestedPrefix: context.suggestedPrefix,
         hidePersistentOption: context.hidePersistentOption,
+        permissionMode: context.permissionMode,
       });
     }
   }
@@ -1801,6 +1804,7 @@ export class DesktopHost {
         confirmationType: p.confirmationType,
         toolInput: p.toolInput,
         suggestedPrefix: p.suggestedPrefix,
+        permissionMode: p.permissionMode,
       }));
 
     this.postMessage({

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
@@ -757,6 +757,7 @@ class MessageHandler(
                     put("confirmationType", pc.confirmationType)
                     if (pc.toolInput != null) put("toolInput", pc.toolInput)
                     if (pc.planContent != null) put("planContent", pc.planContent)
+                    if (pc.permissionMode != null) put("permissionMode", pc.permissionMode)
                 }
             }
             put("pendingConfirmations", JsonArray(confirmations))

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/PermissionFlow.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/PermissionFlow.kt
@@ -29,6 +29,7 @@ object PermissionFlow {
         val planContent = ctx?.get("planContent")?.jsonPrimitive?.content
         val suggestedPrefix = ctx?.get("suggestedPrefix")?.jsonPrimitive?.content
         val hidePersistentOption = ctx?.get("hidePersistentOption")?.jsonPrimitive?.content?.toBoolean() ?: false
+        val permissionMode = ctx?.get("permissionMode")?.jsonPrimitive?.content
 
         val confirmationId = "confirmation_${System.currentTimeMillis()}_${counter++}"
         val deferred = CompletableDeferred<JsonObject>()
@@ -40,6 +41,7 @@ object PermissionFlow {
             confirmationType = confirmationType,
             toolInput = toolInput,
             planContent = planContent,
+            permissionMode = permissionMode,
         )
 
         Edt.invokeLater {
@@ -51,6 +53,7 @@ object PermissionFlow {
                 if (planContent != null) put("planContent", planContent)
                 if (suggestedPrefix != null) put("suggestedPrefix", suggestedPrefix)
                 put("hidePersistentOption", hidePersistentOption)
+                if (permissionMode != null) put("permissionMode", permissionMode)
             })
         }
 

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
@@ -43,6 +43,7 @@ data class PendingConfirmation(
     val confirmationType: String,
     val toolInput: JsonElement? = null,
     val planContent: String? = null,
+    val permissionMode: String? = null,
 )
 
 /**

--- a/packages/vsce/src/chatProvider.ts
+++ b/packages/vsce/src/chatProvider.ts
@@ -510,7 +510,8 @@ export class ChatProvider implements vscode.WebviewViewProvider {
                 toolInput: context.toolInput,
                 planContent: context.planContent,
                 suggestedPrefix: context.suggestedPrefix,
-                hidePersistentOption: context.hidePersistentOption
+                hidePersistentOption: context.hidePersistentOption,
+                permissionMode: context.permissionMode
             });
 
             this.webviewManager.postMessage({
@@ -521,7 +522,8 @@ export class ChatProvider implements vscode.WebviewViewProvider {
                 toolInput: context.toolInput,
                 planContent: context.planContent,
                 suggestedPrefix: context.suggestedPrefix,
-                hidePersistentOption: context.hidePersistentOption
+                hidePersistentOption: context.hidePersistentOption,
+                permissionMode: context.permissionMode
             }, viewType, windowId);
         });
     }

--- a/packages/vsce/src/session/chatSession.ts
+++ b/packages/vsce/src/session/chatSession.ts
@@ -53,6 +53,7 @@ export class ChatSession {
         planContent?: string;
         suggestedPrefix?: string;
         hidePersistentOption?: boolean;
+        permissionMode?: PermissionMode;
     }> = new Map();
 
     // Throttled incremental update fields

--- a/packages/vsce/src/session/messageHandler.ts
+++ b/packages/vsce/src/session/messageHandler.ts
@@ -755,7 +755,8 @@ export class MessageHandler {
             toolName: pending.toolName,
             confirmationType: pending.confirmationType,
             toolInput: pending.toolInput,
-            suggestedPrefix: pending.suggestedPrefix
+            suggestedPrefix: pending.suggestedPrefix,
+            permissionMode: pending.permissionMode
         }));
 
         this.context.postMessage({

--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -642,7 +642,8 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
               toolInput: message.toolInput,
               planContent: message.planContent,
               suggestedPrefix: message.suggestedPrefix,
-              hidePersistentOption: message.hidePersistentOption
+              hidePersistentOption: message.hidePersistentOption,
+              permissionMode: message.permissionMode
             }
           });
           // Scroll to bottom when confirmation is shown

--- a/packages/webview/src/components/ConfirmationDialog.tsx
+++ b/packages/webview/src/components/ConfirmationDialog.tsx
@@ -593,7 +593,9 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
                   </button>
                 )}
 
-                {(confirmation.toolName === BASH_TOOL_NAME || confirmation.toolName === EXIT_PLAN_MODE_TOOL_NAME) && (
+                {(confirmation.toolName === EXIT_PLAN_MODE_TOOL_NAME ||
+                  (confirmation.toolName === BASH_TOOL_NAME &&
+                    confirmation.permissionMode !== 'plan')) && (
                   <button
                     className="confirmation-btn confirmation-btn-auto"
                     onClick={handleBypassConfirm}

--- a/packages/webview/src/types/index.ts
+++ b/packages/webview/src/types/index.ts
@@ -526,6 +526,7 @@ export interface ConfirmationRequest {
   planContent?: string;
   suggestedPrefix?: string;
   hidePersistentOption?: boolean;
+  permissionMode?: PermissionMode;
 }
 
 export interface ConfirmationDecision {

--- a/packages/webview/tests/webview/confirmationDialog.test.tsx
+++ b/packages/webview/tests/webview/confirmationDialog.test.tsx
@@ -612,4 +612,38 @@ describe('Confirmation Dialog', () => {
         expect(document.querySelector('.confirmation-dialog')).toBeInTheDocument();
         expect(screen.queryByText('是，并跳过权限确认')).not.toBeInTheDocument();
     });
+
+    it('should not show bypass button for Bash tool in plan mode', async () => {
+        renderChatApp();
+
+        await act(async () => {
+            sendCommand('showConfirmation', {
+                confirmationId: 'test_bash_plan_no_bypass',
+                toolName: BASH_TOOL_NAME,
+                confirmationType: '命令执行待确认',
+                toolInput: { command: 'ls -la' },
+                permissionMode: 'plan'
+            });
+        });
+
+        expect(document.querySelector('.confirmation-dialog')).toBeInTheDocument();
+        expect(screen.queryByText('是，并跳过权限确认')).not.toBeInTheDocument();
+    });
+
+    it('should still show bypass button for ExitPlanMode in plan mode', async () => {
+        renderChatApp();
+
+        await act(async () => {
+            sendCommand('showConfirmation', {
+                confirmationId: 'test_exit_plan_mode_bypass',
+                toolName: EXIT_PLAN_MODE_TOOL_NAME,
+                confirmationType: '计划待确认',
+                planContent: '## Test Plan\n- Step 1',
+                permissionMode: 'plan'
+            });
+        });
+
+        expect(document.querySelector('.confirmation-dialog')).toBeInTheDocument();
+        expect(screen.getByText('是，并跳过权限确认')).toBeInTheDocument();
+    });
 });


### PR DESCRIPTION
修复 Plan 模式下 Bash 工具权限确认仍提供 bypass 选项、选中后静默退出 Plan 模式的问题。

## 根因

permission 回调链逐层丢弃 context.permissionMode：CLI useChat 调用 showConfirmation 时未传、vsce/desktop/jetbrains 三个 host 构建 showConfirmation payload 时均不带，导致 CLI ConfirmationSelector 与共享 webview ConfirmationDialog 永远不知道当前权限模式，Bash 无条件提供 bypass permissions 选项。

## 修复

将 permissionMode 贯穿全链路（CLI reducer/selector/useChat/ChatInterface、webview ConfirmationRequest/ConfirmationDialog、vsce chatProvider/chatSession/messageHandler、desktop desktopHost、jetbrains PermissionFlow/WaveSession/MessageHandler），bypass 门控改为：

toolName === ExitPlanMode || (toolName === Bash && permissionMode !== plan)

- 仅隐藏 Bash-in-plan 的 bypass；ExitPlanMode 的 bypass 保留（显式退出为设计意图）
- permissionMode 为向后兼容的可选参数，现有 5 参调用不受影响

## 测试（TDD：先写失败测试，实现后全绿）

- 新增：CLI reducer 3 个（Bash+plan 导航跳过 bypass、hidePersistentOption 直落 alternative、ExitPlanMode+plan 仍达 bypass）、CLI selector 2 个、webview dialog 2 个
- code 1294、webview 613、vsce 165、desktop 448 全通过
- type-check 5 个 TS 包通过，jetbrains compileKotlin 通过

注：wave-code 全量跑时 InputBox.test.tsx 报 Maximum update depth exceeded unhandled error，stash 基线复现确认为 pre-existing（与本次改动无关）。