### PR TITLE
feat: 共享 webview host 契约 fixture 包 wave-webview-fixtures

### DIFF
--- a/packages/agent-sdk/tests/integration/session-metadata.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/session-metadata.integration.test.ts
@@ -959,10 +959,7 @@ invalid json line here
 
         const filenameFilterTime = Date.now() - filenameFilterStart;
 
-        // Simulate content-based filtering (much slower)
-        const contentFilterStart = Date.now();
-
-        // Simulate reading each file to determine type (slow approach)
+        // Simulate content-based filtering (slow approach: reading file content)
         const contentBasedSessions = sessionFilenames.map((filename) => ({
           filename,
           type: filename.startsWith("subagent-") ? "subagent" : "main", // Simulated content reading
@@ -975,8 +972,6 @@ invalid json line here
           (s) => s.type === "subagent",
         );
 
-        const contentFilterTime = Date.now() - contentFilterStart;
-
         // Verify both methods produce same results
         expect(filenameBasedMainSessions).toHaveLength(
           contentBasedMainSessions.length,
@@ -985,10 +980,10 @@ invalid json line here
           contentBasedSubagentSessions.length,
         );
 
-        // Verify performance benefit (filename-based should be equal or faster)
-        // Note: In some environments (like CI or fast local runs), both might be 0ms or very close.
-        // We use a larger tolerance to avoid flakiness while still ensuring it's not excessively slow.
-        expect(filenameFilterTime).toBeLessThanOrEqual(contentFilterTime + 10);
+        // Filename-based filtering must complete promptly. (No relative
+        // comparison against the simulated content pass: both are pure
+        // in-memory O(n) filters whose millisecond timings are noise under
+        // CI parallelism.)
         expect(filenameFilterTime).toBeLessThan(500); // Should complete in < 500ms
 
         // Verify correct counts

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -30,7 +30,8 @@
     "typescript": "^5.9.3",
     "vitest": "^4.1.7",
     "wave-agent-sdk": "workspace:*",
-    "wave-webview": "workspace:*"
+    "wave-webview": "workspace:*",
+    "wave-webview-fixtures": "workspace:*"
   },
   "build": {
     "appId": "com.netease.wave-desktop",

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -3,6 +3,7 @@ import type { BrowserWindow } from 'electron';
 import * as os from 'os';
 import * as path from 'path';
 import { BASH_TOOL_NAME } from 'wave-agent-sdk';
+import { fixtures, type HostToWebviewMessage } from 'wave-webview-fixtures';
 
 // ---------------------------------------------------------------------------
 // fs mock — ConfigStore persistence + desktopHost's tmpdir/artifact helpers
@@ -353,10 +354,13 @@ function createHost(winWidth = 1280, winHeight = 800) {
     getContentSize: () => [winWidth, winHeight],
   } as unknown as BrowserWindow;
   host.setMainWindow(win);
-  const sent = (command: string) =>
+  // Typed against the shared host→webview contract: an unknown command string
+  // or a field access outside the command's payload is a compile error, so a
+  // contract rename breaks this suite the same way it breaks the webview one.
+  const sent = <C extends HostToWebviewMessage['command']>(command: C) =>
     send.mock.calls
       .filter(([channel, msg]) => channel === HOST_CHANNEL && (msg as { command?: string }).command === command)
-      .map(([, msg]) => msg as Record<string, unknown>);
+      .map(([, msg]) => msg as Extract<HostToWebviewMessage, { command: C }>);
   return { host, store, send, sent };
 }
 
@@ -602,7 +606,8 @@ describe('webviewReady / setInitialState', () => {
 
     const states = sent('setInitialState');
     expect(states.length).toBeGreaterThanOrEqual(1);
-    expect(states[states.length - 1]).toMatchObject({
+    const last = states[states.length - 1];
+    expect(last).toMatchObject({
       command: 'setInitialState',
       messages: [],
       isStreaming: false,
@@ -610,7 +615,22 @@ describe('webviewReady / setInitialState', () => {
       isAuthenticated: false,
       workdir: '/work/a',
     });
-    expect(states[states.length - 1].configurationData).toBeDefined();
+    expect(last.configurationData).toBeDefined();
+
+    // Contract gates: setInitialState must always carry inputContent ('' when
+    // no draft) and the pane id. These mirror the shared fixture defaults — if
+    // the host stops sending them or the fixture default changes, both layers
+    // go red together instead of one passing on mock-defined expectations.
+    const anchors = fixtures.setInitialState();
+    expect(last.inputContent).toBe(anchors.inputContent);
+    expect(last.isAuthenticated).toBe(false);
+    expect(last.messages).toEqual(anchors.messages);
+    expect(last.tasks).toEqual(anchors.tasks);
+    expect(last.backgroundTasks).toEqual(anchors.backgroundTasks);
+    expect(last.workflowRuns).toEqual(anchors.workflowRuns);
+    expect(last.queuedMessages).toEqual(anchors.queuedMessages);
+    expect(last.pendingConfirmations).toEqual(anchors.pendingConfirmations);
+    expect(last.paneId).toBeTypeOf('string');
   });
 
   it('starts a fresh session on every launch: agent.initialize never carries restoreSessionId', async () => {

--- a/packages/desktop/vitest.config.ts
+++ b/packages/desktop/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     exclude: ['node_modules'],
     server: {
       deps: {
-        inline: ['wave-agent-sdk'],
+        inline: ['wave-agent-sdk', 'wave-webview-fixtures'],
       },
     },
     coverage: {

--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -109,6 +109,7 @@
     "typescript": "^5.9.3",
     "vitest": "^4.1.5",
     "wave-agent-sdk": "workspace:*",
-    "wave-webview": "workspace:*"
+    "wave-webview": "workspace:*",
+    "wave-webview-fixtures": "workspace:*"
   }
 }

--- a/packages/vsce/tests/session/messageHandler.test.ts
+++ b/packages/vsce/tests/session/messageHandler.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { fixtures, type HostToWebviewMessage } from 'wave-webview-fixtures';
 
 // ── Mocks ──────────────────────────────────────────────────────
 
@@ -63,6 +64,8 @@ function createReadySession(): ChatSession {
         pendingConfirmations: new Map(),
         messages: [],
         tasks: [],
+        backgroundTasks: [],
+        workflowRuns: [],
         messageQueue: [],
         sessionId: undefined,
         inputContent: '',
@@ -70,6 +73,17 @@ function createReadySession(): ChatSession {
         isCommandRunning: false,
         getMessages: vi.fn().mockResolvedValue([]),
     } as unknown as ChatSession;
+}
+
+// Typed against the shared host→webview contract: an unknown command string
+// or a field access outside the command's payload is a compile error, so a
+// contract rename breaks this suite the same way it breaks the webview one.
+function sentPosts(context: { postMessage: unknown }) {
+    const calls = (context.postMessage as ReturnType<typeof vi.fn>).mock.calls;
+    return <C extends HostToWebviewMessage['command']>(command: C) =>
+        calls
+            .map((call) => call[0] as { command?: string })
+            .filter((msg) => msg.command === command) as unknown as Extract<HostToWebviewMessage, { command: C }>[];
 }
 
 function createReadyHandler(session: ChatSession) {
@@ -203,13 +217,28 @@ describe('MessageHandler MCP handlers', () => {
         expect(utilityClient.request).toHaveBeenCalledWith('getAuthStatus');
         expect(configService.saveConfiguration).toHaveBeenCalledWith({ serverUrl: 'https://console.example.com' });
 
-        const posted = (context.postMessage as ReturnType<typeof vi.fn>).mock.calls
-            .map((call) => call[0])
-            .find((msg) => msg.command === 'setInitialState') as { configurationData: { serverUrl: string }; isAuthenticated: boolean };
+        const states = sentPosts(context)('setInitialState');
+        expect(states.length).toBeGreaterThanOrEqual(1);
+        const posted = states[states.length - 1];
 
         expect(posted).toBeDefined();
         expect(posted.configurationData.serverUrl).toBe('https://console.example.com');
         expect(posted.isAuthenticated).toBe(true);
+
+        // Contract gates mirroring the shared fixture defaults: if the host
+        // stops sending a field or the fixture default changes, both layers go
+        // red together instead of one passing on mock-defined expectations.
+        const anchors = fixtures.setInitialState();
+        expect(posted.inputContent).toBe(anchors.inputContent);
+        expect(posted.messages).toEqual(anchors.messages);
+        expect(posted.tasks).toEqual(anchors.tasks);
+        expect(posted.backgroundTasks).toEqual(anchors.backgroundTasks);
+        expect(posted.workflowRuns).toEqual(anchors.workflowRuns);
+        expect(posted.queuedMessages).toEqual(anchors.queuedMessages);
+        expect(posted.pendingConfirmations).toEqual(anchors.pendingConfirmations);
+        expect(posted.sessions).toEqual(anchors.sessions);
+        // IDE hosts never send pane-scoped messages — only desktop does.
+        expect(posted.paneId).toBeUndefined();
     });
 
     // Regression: /status showed empty version in VSCE because handleGetStatus

--- a/packages/vsce/vitest.config.ts
+++ b/packages/vsce/vitest.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
         setupFiles: ['tests/setup.ts'],
         server: {
             deps: {
-                inline: ['wave-agent-sdk'],
+                inline: ['wave-agent-sdk', 'wave-webview-fixtures'],
             },
         },
         coverage: {

--- a/packages/webview-fixtures/package.json
+++ b/packages/webview-fixtures/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "wave-webview-fixtures",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Shared host→webview message contract fixtures for the webview, VS Code, JetBrains and desktop test suites",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "rimraf dist && tsc -p tsconfig.build.json",
+    "type-check": "tsc --noEmit",
+    "test": "vitest run --reporter=dot"
+  },
+  "devDependencies": {
+    "rimraf": "^6.0.1",
+    "typescript": "^5.5.4",
+    "vitest": "^4.1.5",
+    "wave-agent-sdk": "workspace:*"
+  }
+}

--- a/packages/webview-fixtures/src/index.test.ts
+++ b/packages/webview-fixtures/src/index.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { fixtures, fixtureSession, fixtureConfirmation, fixtureQueuedMessage, fixtureConfig } from './index.js';
+
+describe('fixtures factory', () => {
+  it('setInitialState carries the contract anchors hosts must always send', () => {
+    const msg = fixtures.setInitialState();
+    expect(msg.command).toBe('setInitialState');
+    // Desktop host always sends inputContent ('' when no draft); a gate that
+    // stops asserting it would let the input-flush regression pass silently.
+    expect(msg.inputContent).toBe('');
+    expect(msg.isAuthenticated).toBe(true);
+    expect(msg.sessions).toEqual([]);
+    expect(msg.messages).toEqual([]);
+    expect(msg.tasks).toEqual([]);
+    expect(msg.backgroundTasks).toEqual([]);
+    expect(msg.workflowRuns).toEqual([]);
+    expect(msg.pendingConfirmations).toEqual([]);
+    expect(msg.queuedMessages).toEqual([]);
+    expect(msg.isStreaming).toBe(false);
+  });
+
+  it('overrides win over defaults', () => {
+    const msg = fixtures.setInitialState({ inputContent: 'draft', isAuthenticated: false });
+    expect(msg.inputContent).toBe('draft');
+    expect(msg.isAuthenticated).toBe(false);
+  });
+
+  it('authStatusResponse defaults to authenticated', () => {
+    expect(fixtures.authStatusResponse()).toMatchObject({ command: 'authStatusResponse', isAuthenticated: true });
+  });
+
+  it('pane-scoped commands accept an optional paneId', () => {
+    const msg = fixtures.updateMessages([], { paneId: 'pane-1' });
+    expect(msg.paneId).toBe('pane-1');
+    // Untagged variant is what IDE hosts send.
+    expect(fixtures.updateMessages([]).paneId).toBeUndefined();
+  });
+
+  it('desktop commands default to empty state', () => {
+    expect(fixtures.desktopPanes()).toMatchObject({ command: 'desktopPanes', panes: [] });
+    expect(fixtures.desktopSessionTree()).toMatchObject({ command: 'desktopSessionTree', groups: [] });
+    expect(fixtures.desktopWorkdirState()).toMatchObject({
+      command: 'desktopWorkdirState',
+      host: 'local',
+      hosts: ['local'],
+      recentWorkdirs: [],
+    });
+  });
+
+  it('nested value helpers carry realistic defaults', () => {
+    expect(fixtureSession().id).toBe('test-session');
+    expect(fixtureConfirmation()).toMatchObject({ confirmationId: 'confirm-1', toolName: 'Bash' });
+    expect(fixtureQueuedMessage('hi')).toMatchObject({ content: 'hi', type: 'message' });
+    expect(fixtureConfig().model).toBe('glm-5.2');
+  });
+});

--- a/packages/webview-fixtures/src/index.ts
+++ b/packages/webview-fixtures/src/index.ts
@@ -1,0 +1,246 @@
+/**
+ * Shared host → webview fixture factory.
+ *
+ * Every fixture is a superset of the real host payloads: it carries the union
+ * of fields both hosts (VSCE messageHandler, desktop desktopHost) actually
+ * send, with defaults pinned to realistic values (setInitialState always
+ * carries `inputContent: ''`, `isAuthenticated: true`, `sessions: []`, …).
+ *
+ * Contract gates must use `toMatchObject(fixture)` / `objectContaining`, NOT
+ * `toEqual` — a fixture may contain a field the asserting host does not send.
+ *
+ * This is test infrastructure, not runtime code: changing a fixture default
+ * intentionally breaks the tests that rely on it (that is the point), and the
+ * package must be rebuilt (`pnpm -F wave-webview-fixtures build`) for changes
+ * to reach consumers, same as agent-sdk.
+ */
+
+import type {
+  Message,
+  Task,
+  PermissionMode,
+  BackgroundTaskSummary,
+  SerializableWorkflowRun,
+  SessionMetadata,
+  SetInitialStateMessage,
+  AuthStatusResponseMessage,
+  UpdateMessagesMessage,
+  AppendMessageMessage,
+  UpdatePermissionModeMessage,
+  UpdateCurrentSessionMessage,
+  UpdateTasksMessage,
+  UpdateToolBlockMessage,
+  UpdateErrorBlockMessage,
+  UpdateWorkdirMessage,
+  StartStreamingMessage,
+  EndStreamingMessage,
+  CompactionStateChangeMessage,
+  BtwResponseMessage,
+  McpServersResponseMessage,
+  DesktopPanesMessage,
+  DesktopSessionTreeMessage,
+  DesktopWorkdirStateMessage,
+  DesktopTogglePanelMessage,
+  DesktopPanelKind,
+  ToolBlockUpdateCallbackParams,
+  ConfigurationData,
+  ConfirmationRequest,
+  QueuedMessage,
+} from './types.js';
+
+// Re-export the whole contract (message unions, payload shapes, SDK types) so
+// consumers can type test helpers against the shared union without importing
+// the deep path. `export *` (not a hand-maintained list) keeps this in sync
+// when types.ts grows.
+export * from './types.js';
+
+type Overrides<T> = Partial<T>;
+
+export interface Fixtures {
+  setInitialState: (overrides?: Overrides<SetInitialStateMessage>) => SetInitialStateMessage;
+  authStatusResponse: (overrides?: Overrides<AuthStatusResponseMessage>) => AuthStatusResponseMessage;
+  updateMessages: (messages: Message[], overrides?: Overrides<UpdateMessagesMessage>) => UpdateMessagesMessage;
+  appendMessage: (message: Message, overrides?: Overrides<AppendMessageMessage>) => AppendMessageMessage;
+  updatePermissionMode: (mode: PermissionMode, overrides?: Overrides<UpdatePermissionModeMessage>) => UpdatePermissionModeMessage;
+  updateCurrentSession: (session: SessionMetadata, overrides?: Overrides<UpdateCurrentSessionMessage>) => UpdateCurrentSessionMessage;
+  updateTasks: (tasks: Task[], overrides?: Overrides<UpdateTasksMessage>) => UpdateTasksMessage;
+  updateToolBlock: (params: ToolBlockUpdateCallbackParams, overrides?: Overrides<UpdateToolBlockMessage>) => UpdateToolBlockMessage;
+  updateErrorBlock: (error: unknown, overrides?: Overrides<UpdateErrorBlockMessage>) => UpdateErrorBlockMessage;
+  updateWorkdir: (workdir: string | undefined, overrides?: Overrides<UpdateWorkdirMessage>) => UpdateWorkdirMessage;
+  startStreaming: (overrides?: Overrides<StartStreamingMessage>) => StartStreamingMessage;
+  endStreaming: (overrides?: Overrides<EndStreamingMessage>) => EndStreamingMessage;
+  compactionStateChange: (isCompacting: boolean, overrides?: Overrides<CompactionStateChangeMessage>) => CompactionStateChangeMessage;
+  btwResponse: (question: string, answer: string, overrides?: Overrides<BtwResponseMessage>) => BtwResponseMessage;
+  mcpServersResponse: (servers: unknown[], overrides?: Overrides<McpServersResponseMessage>) => McpServersResponseMessage;
+  desktopPanes: (overrides?: Overrides<DesktopPanesMessage>) => DesktopPanesMessage;
+  desktopSessionTree: (overrides?: Overrides<DesktopSessionTreeMessage>) => DesktopSessionTreeMessage;
+  desktopWorkdirState: (overrides?: Overrides<DesktopWorkdirStateMessage>) => DesktopWorkdirStateMessage;
+  desktopTogglePanel: (kind: DesktopPanelKind, overrides?: Overrides<DesktopTogglePanelMessage>) => DesktopTogglePanelMessage;
+}
+
+const noopSession = (): SessionMetadata => ({
+  id: 'test-session',
+  sessionType: 'main',
+  workdir: '/tmp/test',
+  lastActiveAt: new Date(),
+  createdAt: new Date(),
+  latestTotalTokens: 0,
+});
+
+export const fixtures: Fixtures = {
+  setInitialState: (overrides = {}) => ({
+    command: 'setInitialState',
+    messages: [],
+    tasks: [],
+    backgroundTasks: [],
+    workflowRuns: [],
+    isStreaming: false,
+    isCommandRunning: false,
+    isCompacting: false,
+    isTaskListCollapsed: false,
+    isRestoring: false,
+    sessions: [],
+    session: undefined,
+    pendingConfirmations: [],
+    queuedMessages: [],
+    isAuthenticated: true,
+    workdir: '/tmp/test',
+    theme: { effective: 'dark' },
+    inputContent: '',
+    ...overrides,
+  }),
+
+  authStatusResponse: (overrides = {}) => ({
+    command: 'authStatusResponse',
+    isAuthenticated: true,
+    ...overrides,
+  }),
+
+  updateMessages: (messages, overrides = {}) => ({
+    command: 'updateMessages',
+    messages,
+    ...overrides,
+  }),
+
+  appendMessage: (message, overrides = {}) => ({
+    command: 'appendMessage',
+    message,
+    ...overrides,
+  }),
+
+  updatePermissionMode: (mode, overrides = {}) => ({
+    command: 'updatePermissionMode',
+    mode,
+    ...overrides,
+  }),
+
+  updateCurrentSession: (session, overrides = {}) => ({
+    command: 'updateCurrentSession',
+    session,
+    ...overrides,
+  }),
+
+  updateTasks: (tasks, overrides = {}) => ({
+    command: 'updateTasks',
+    tasks,
+    ...overrides,
+  }),
+
+  updateToolBlock: (params, overrides = {}) => ({
+    command: 'updateToolBlock',
+    params,
+    ...overrides,
+  }),
+
+  updateErrorBlock: (error, overrides = {}) => ({
+    command: 'updateErrorBlock',
+    error,
+    ...overrides,
+  }),
+
+  updateWorkdir: (workdir, overrides = {}) => ({
+    command: 'updateWorkdir',
+    workdir,
+    ...overrides,
+  }),
+
+  startStreaming: (overrides = {}) => ({
+    command: 'startStreaming',
+    ...overrides,
+  }),
+
+  endStreaming: (overrides = {}) => ({
+    command: 'endStreaming',
+    ...overrides,
+  }),
+
+  compactionStateChange: (isCompacting, overrides = {}) => ({
+    command: 'compactionStateChange',
+    isCompacting,
+    ...overrides,
+  }),
+
+  btwResponse: (question, answer, overrides = {}) => ({
+    command: 'btwResponse',
+    question,
+    answer,
+    ...overrides,
+  }),
+
+  mcpServersResponse: (servers, overrides = {}) => ({
+    command: 'mcpServersResponse',
+    servers,
+    ...overrides,
+  }),
+
+  desktopPanes: (overrides = {}) => ({
+    command: 'desktopPanes',
+    panes: [],
+    rowHeights: undefined,
+    focusedPaneId: undefined,
+    ...overrides,
+  }),
+
+  desktopSessionTree: (overrides = {}) => ({
+    command: 'desktopSessionTree',
+    groups: [],
+    ...overrides,
+  }),
+
+  desktopWorkdirState: (overrides = {}) => ({
+    command: 'desktopWorkdirState',
+    workdir: undefined,
+    host: 'local',
+    hosts: ['local'],
+    recentWorkdirs: [],
+    ...overrides,
+  }),
+
+  desktopTogglePanel: (kind, overrides = {}) => ({
+    command: 'desktopTogglePanel',
+    kind,
+    ...overrides,
+  }),
+};
+
+/** Convenience helpers for the most-constructed nested values. */
+export const fixtureSession = noopSession;
+export const fixtureConfirmation = (overrides: Partial<ConfirmationRequest> = {}): ConfirmationRequest => ({
+  confirmationId: 'confirm-1',
+  toolName: 'Bash',
+  confirmationType: 'bash',
+  toolInput: { command: 'ls' },
+  ...overrides,
+});
+export const fixtureQueuedMessage = (content: string, overrides: Partial<QueuedMessage> = {}): QueuedMessage => ({
+  id: 'queued-1',
+  type: 'message',
+  content,
+  ...overrides,
+});
+export const fixtureConfig = (overrides: Partial<ConfigurationData> = {}): ConfigurationData => ({
+  model: 'glm-5.2',
+  fastModel: 'deepseek-v4-flash',
+  language: 'zh',
+  ...overrides,
+});

--- a/packages/webview-fixtures/src/types.ts
+++ b/packages/webview-fixtures/src/types.ts
@@ -1,0 +1,575 @@
+/**
+ * Host → webview message contract.
+ *
+ * Single authoritative definition of the postMessage channel used by every host
+ * (VS Code extension, JetBrains plugin, Electron desktop) against the shared
+ * webview. Both host-side tests and webview-side tests consume this type, so a
+ * contract change (renamed field, dropped field, changed shape) makes both
+ * layers red at the same time instead of one layer passing on mock-defined
+ * expectations.
+ *
+ * `paneId` is optional: the desktop host tags every pane-scoped push with the
+ * target pane's id; IDE hosts never send it (untagged messages are consumed by
+ * the single webview instance / self-consumed per ChatApp).
+ */
+
+// SDK types come from the same deep imports the webview package itself uses.
+import type {
+  Message,
+  Task,
+  PermissionMode,
+  BackgroundTaskSummary,
+  SerializableWorkflowRun,
+} from 'wave-agent-sdk/dist/types/index.js';
+import type { SessionMetadata, SessionData } from 'wave-agent-sdk/dist/services/session.js';
+import type { ToolBlockUpdateCallbackParams } from 'wave-agent-sdk/dist/utils/messageOperations.js';
+
+export type {
+  Message,
+  Task,
+  PermissionMode,
+  BackgroundTaskSummary,
+  SerializableWorkflowRun,
+  ToolBlockUpdateCallbackParams,
+  SessionMetadata,
+  SessionData,
+};
+
+// ---- Webview-owned shapes (copied structurally — the fixtures package must
+// not depend on the webview package or a dependency cycle forms). ----
+
+export type EffectiveTheme = 'light' | 'dark';
+
+/** Desktop host theme snapshot (effective only; desktop follows the OS). */
+export interface ThemeState {
+  effective: EffectiveTheme;
+}
+
+/** Desktop conversation-level side panels. VSCE/JetBrains never render these. */
+export type DesktopPanelKind = 'preview' | 'diff' | 'terminal' | 'file';
+
+/** State of the desktop file panel, pushed via `desktopFileContent`. */
+export interface FileViewState {
+  path: string;
+  host: string;
+  loading?: boolean;
+  error?: string;
+  content?: string;
+  startLine?: number;
+  endLine?: number;
+  truncated?: boolean;
+  totalLines?: number;
+  imageBase64?: string;
+}
+
+export interface QueuedMessage {
+  id?: string;
+  type?: 'message' | 'bang';
+  content: string;
+  images?: Array<{ path: string; mimeType: string }>;
+  longTextMap?: Record<string, string>;
+  text?: string;
+}
+
+export interface SelectionInfo {
+  filePath: string;
+  fileName: string;
+  startLine: number;
+  endLine: number;
+  lineCount: number;
+  selectedText: string;
+  isEmpty: boolean;
+}
+
+export interface ConfirmationRequest {
+  confirmationId: string;
+  toolName: string;
+  confirmationType: string;
+  toolInput?: Record<string, unknown>;
+  planContent?: string;
+  suggestedPrefix?: string;
+  hidePersistentOption?: boolean;
+}
+
+export interface AttachedImage {
+  id: string;
+  data: string;
+  mimeType: string;
+  filename?: string;
+  size?: number;
+}
+
+/** Maps to VS Code global state (apiKey/headers/baseURL/model/fastModel/…). */
+export interface ConfigurationData {
+  apiKey?: string;
+  headers?: string;
+  baseURL?: string;
+  model?: string;
+  fastModel?: string;
+  language?: string;
+  serverUrl?: string;
+  [key: string]: unknown;
+}
+
+export interface DesktopPaneInfo {
+  paneId: string;
+  sessionId?: string;
+  host: string;
+  width: number;
+  row: number;
+}
+
+/** A session in the desktop sidebar tree, derived from the session index (FR-024). */
+export interface DesktopSessionEntry {
+  sessionId: string;
+  title: string;
+  lastActiveAt: number;
+  /** True when this session lives in a worktree (delete also cleans up branch+dir). */
+  hasWorktree: boolean;
+  /** True while this session is generating — drives the per-session running dot (FR-031). */
+  running?: boolean;
+  /** True while a confirmation request (tool/plan/question) awaits the user — drives the waiting dot. */
+  waitingConfirmation?: boolean;
+}
+
+export interface DesktopSessionGroup {
+  host: string;
+  workdir: string;
+  sessions: DesktopSessionEntry[];
+}
+
+/** One desktop pane's git branch state, pushed via `desktopGitBranches`. */
+export interface GitBranchesResult {
+  current?: string;
+  branches?: string[];
+  error?: unknown;
+}
+
+/** Streaming delta types shared by content/reasoning updates. */
+export type StreamingStage = 'start' | 'streaming' | 'end';
+
+// ---- The contract union. Every case mirrors a `case` in ChatApp.tsx's
+// handleMessage switch (plus host-only commands consumed outside the switch:
+// desktopPanes/desktopSessionTree/desktopWorkdirState in DesktopApp.tsx,
+// mcpServersResponse in McpDialog.tsx, historyResponse in HistorySearchPopup,
+// desktopThemeChange in ChatApp). ----
+
+export interface HostToWebviewMessageBase {
+  paneId?: string;
+}
+
+export interface UpdateMessagesMessage extends HostToWebviewMessageBase {
+  command: 'updateMessages';
+  messages: Message[];
+}
+
+export interface UpdateTasksMessage extends HostToWebviewMessageBase {
+  command: 'updateTasks';
+  tasks: Task[];
+  isTaskListCollapsed?: boolean;
+}
+
+export interface UpdateBackgroundTasksMessage extends HostToWebviewMessageBase {
+  command: 'updateBackgroundTasks';
+  tasks: BackgroundTaskSummary[];
+}
+
+export interface UpdateWorkflowRunsMessage extends HostToWebviewMessageBase {
+  command: 'updateWorkflowRuns';
+  runs: SerializableWorkflowRun[];
+}
+
+export interface UpdateSelectionMessage extends HostToWebviewMessageBase {
+  command: 'updateSelection';
+  selection: SelectionInfo;
+}
+
+export interface UpdatePermissionModeMessage extends HostToWebviewMessageBase {
+  command: 'updatePermissionMode';
+  mode: PermissionMode;
+}
+
+export interface UpdateWorkdirMessage extends HostToWebviewMessageBase {
+  command: 'updateWorkdir';
+  workdir?: string;
+}
+
+export interface DesktopGitBranchesMessage extends HostToWebviewMessageBase {
+  command: 'desktopGitBranches';
+  result?: GitBranchesResult;
+}
+
+export interface DesktopForwardPortResultMessage extends HostToWebviewMessageBase {
+  command: 'desktopForwardPortResult';
+  requestId: string;
+  error?: unknown;
+  url?: string;
+}
+
+export interface DesktopFileContentMessage extends HostToWebviewMessageBase {
+  command: 'desktopFileContent';
+  fileView: FileViewState;
+}
+
+export interface UpdateQueueMessage extends HostToWebviewMessageBase {
+  command: 'updateQueue';
+  queue: QueuedMessage[];
+}
+
+export interface UpdateQueuedMessageMissingMessage extends HostToWebviewMessageBase {
+  command: 'updateQueuedMessageMissing';
+}
+
+export interface UpdateCommandRunningMessage extends HostToWebviewMessageBase {
+  command: 'updateCommandRunning';
+  running: boolean;
+}
+
+export interface RewindCheckpointsMessage extends HostToWebviewMessageBase {
+  command: 'rewindCheckpoints';
+  checkpoints?: Array<{
+    messageId: string;
+    time: string;
+    isMeta: boolean;
+    content: string;
+    [key: string]: unknown;
+  }>;
+}
+
+export interface BtwStreamMessage extends HostToWebviewMessageBase {
+  command: 'btwStream';
+  question: string;
+  type?: string;
+  content?: string;
+}
+
+export interface BtwResponseMessage extends HostToWebviewMessageBase {
+  command: 'btwResponse';
+  question: string;
+  answer?: string;
+}
+
+export interface BtwErrorMessage extends HostToWebviewMessageBase {
+  command: 'btwError';
+  question: string;
+  error?: unknown;
+}
+
+export interface StartStreamingMessage extends HostToWebviewMessageBase {
+  command: 'startStreaming';
+}
+
+export interface EndStreamingMessage extends HostToWebviewMessageBase {
+  command: 'endStreaming';
+}
+
+export interface EnsureUIResetMessage extends HostToWebviewMessageBase {
+  command: 'ensureUIReset';
+}
+
+export interface UpdateSessionsMessage extends HostToWebviewMessageBase {
+  command: 'updateSessions';
+  sessions: SessionMetadata[];
+}
+
+export interface UpdateCurrentSessionMessage extends HostToWebviewMessageBase {
+  command: 'updateCurrentSession';
+  session?: SessionMetadata;
+}
+
+export interface ShowConfirmationMessage extends HostToWebviewMessageBase {
+  command: 'showConfirmation';
+  confirmationId: string;
+  toolName: string;
+  confirmationType: string;
+  toolInput?: Record<string, unknown>;
+  planContent?: string;
+  suggestedPrefix?: string;
+  hidePersistentOption?: boolean;
+}
+
+export interface ConfigurationResponseMessage extends HostToWebviewMessageBase {
+  command: 'configurationResponse';
+  configurationData: ConfigurationData;
+}
+
+export interface ProjectSettingsMessage extends HostToWebviewMessageBase {
+  command: 'projectSettings';
+  enabledPlugins: Record<string, boolean>;
+}
+
+export interface SetInitialStateMessage extends HostToWebviewMessageBase {
+  command: 'setInitialState';
+  messages: Message[];
+  tasks: Task[];
+  backgroundTasks: BackgroundTaskSummary[];
+  workflowRuns: SerializableWorkflowRun[];
+  isStreaming: boolean;
+  isCommandRunning: boolean;
+  isCompacting?: boolean;
+  isTaskListCollapsed?: boolean;
+  isRestoring?: boolean;
+  sessions: SessionMetadata[];
+  session?: SessionMetadata;
+  currentSession?: SessionMetadata;
+  configurationData?: ConfigurationData;
+  pendingConfirmations: ConfirmationRequest[];
+  pendingConfirmation?: ConfirmationRequest;
+  selection?: SelectionInfo;
+  inputContent?: string;
+  permissionMode?: PermissionMode;
+  attachedImages?: AttachedImage[];
+  queuedMessages: QueuedMessage[];
+  isAuthenticated: boolean;
+  workdir?: string;
+  theme?: ThemeState;
+}
+
+export interface DesktopThemeChangeMessage extends HostToWebviewMessageBase {
+  command: 'desktopThemeChange';
+  effective: EffectiveTheme;
+}
+
+export interface DesktopTogglePanelMessage extends HostToWebviewMessageBase {
+  command: 'desktopTogglePanel';
+  kind: DesktopPanelKind;
+}
+
+export interface ShowConfigurationMessage extends HostToWebviewMessageBase {
+  command: 'showConfiguration';
+  configurationData?: ConfigurationData;
+  error?: unknown;
+}
+
+export interface ShowDialogMessage extends HostToWebviewMessageBase {
+  command: 'showDialog';
+  dialogType: string;
+}
+
+export interface ConfigurationUpdatedMessage extends HostToWebviewMessageBase {
+  command: 'configurationUpdated';
+}
+
+export interface StatusResponseMessage extends HostToWebviewMessageBase {
+  command: 'statusResponse';
+  configurationData?: ConfigurationData;
+}
+
+export interface ConfigurationErrorMessage extends HostToWebviewMessageBase {
+  command: 'configurationError';
+  error: unknown;
+}
+
+export interface FocusInputMessage extends HostToWebviewMessageBase {
+  command: 'focusInput';
+}
+
+export interface TriggerShortcutMessage extends HostToWebviewMessageBase {
+  command: 'triggerShortcut';
+  name: string;
+}
+
+export interface ScrollToBottomMessage extends HostToWebviewMessageBase {
+  command: 'scrollToBottom';
+}
+
+export interface AppendMessageMessage extends HostToWebviewMessageBase {
+  command: 'appendMessage';
+  message: Message;
+}
+
+export interface BangMessageAddedMessage extends HostToWebviewMessageBase {
+  command: 'bangMessageAdded';
+  params: Record<string, unknown>;
+}
+
+export interface BangMessageUpdatedMessage extends HostToWebviewMessageBase {
+  command: 'bangMessageUpdated';
+  params: Record<string, unknown>;
+}
+
+export interface BangMessageCompletedMessage extends HostToWebviewMessageBase {
+  command: 'bangMessageCompleted';
+  params: Record<string, unknown>;
+}
+
+export interface CompactionStateChangeMessage extends HostToWebviewMessageBase {
+  command: 'compactionStateChange';
+  isCompacting: boolean;
+}
+
+export interface UpdateStreamingContentMessage extends HostToWebviewMessageBase {
+  command: 'updateStreamingContent';
+  messageId: string;
+  chunk: string;
+  stage?: StreamingStage;
+}
+
+export interface UpdateStreamingReasoningMessage extends HostToWebviewMessageBase {
+  command: 'updateStreamingReasoning';
+  messageId: string;
+  chunk: string;
+  stage?: 'end' | 'streaming';
+}
+
+export interface UpdateToolBlockMessage extends HostToWebviewMessageBase {
+  command: 'updateToolBlock';
+  params: ToolBlockUpdateCallbackParams;
+}
+
+export interface UpdateErrorBlockMessage extends HostToWebviewMessageBase {
+  command: 'updateErrorBlock';
+  error: unknown;
+}
+
+export interface AuthStatusResponseMessage extends HostToWebviewMessageBase {
+  command: 'authStatusResponse';
+  isAuthenticated: boolean;
+}
+
+export interface LoginResponseMessage extends HostToWebviewMessageBase {
+  command: 'loginResponse';
+  success: boolean;
+}
+
+export interface LogoutResponseMessage extends HostToWebviewMessageBase {
+  command: 'logoutResponse';
+  success: boolean;
+}
+
+// ---- Host-only commands (consumed outside the ChatApp switch). ----
+
+export interface DesktopPanesMessage extends HostToWebviewMessageBase {
+  command: 'desktopPanes';
+  panes: DesktopPaneInfo[];
+  rowHeights?: [number, number];
+  focusedPaneId?: string;
+}
+
+export interface DesktopSessionTreeMessage extends HostToWebviewMessageBase {
+  command: 'desktopSessionTree';
+  groups: DesktopSessionGroup[];
+}
+
+export interface DesktopWorkdirStateMessage extends HostToWebviewMessageBase {
+  command: 'desktopWorkdirState';
+  workdir?: string;
+  host: string;
+  hosts: string[];
+  recentWorkdirs: string[];
+}
+
+export interface McpServersResponseMessage extends HostToWebviewMessageBase {
+  command: 'mcpServersResponse';
+  servers: unknown[];
+}
+
+export interface HistoryResponseMessage extends HostToWebviewMessageBase {
+  command: 'historyResponse';
+  history: SessionMetadata[];
+}
+
+// ---- MessageInput-owned replies (consumed outside the ChatApp switch). ----
+
+export interface FileSuggestionsMessage extends HostToWebviewMessageBase {
+  command: 'fileSuggestions';
+  requestId: string;
+  suggestions: unknown[];
+}
+
+export interface FileSuggestionsErrorMessage extends HostToWebviewMessageBase {
+  command: 'fileSuggestionsError';
+  requestId: string;
+  error: unknown;
+}
+
+export interface SlashCommandsResponseMessage extends HostToWebviewMessageBase {
+  command: 'slashCommandsResponse';
+  commands: Array<{ id: string; name: string; description?: string }>;
+}
+
+export interface SlashCommandsErrorMessage extends HostToWebviewMessageBase {
+  command: 'slashCommandsError';
+  error: unknown;
+}
+
+export interface UploadSuccessMessage extends HostToWebviewMessageBase {
+  command: 'uploadSuccess';
+  uploadedFiles: string[];
+}
+
+export interface UploadErrorMessage extends HostToWebviewMessageBase {
+  command: 'uploadError';
+  error: unknown;
+}
+
+/** Remote directory listing reply for the desktop workdir browser. */
+export interface DesktopRemoteDirListMessage extends HostToWebviewMessageBase {
+  command: 'desktopRemoteDirList';
+  requestId: string;
+  resolvedPath?: string;
+  dirs?: string[];
+  error?: unknown;
+}
+
+export type HostToWebviewMessage =
+  | UpdateMessagesMessage
+  | UpdateTasksMessage
+  | UpdateBackgroundTasksMessage
+  | UpdateWorkflowRunsMessage
+  | UpdateSelectionMessage
+  | UpdatePermissionModeMessage
+  | UpdateWorkdirMessage
+  | DesktopGitBranchesMessage
+  | DesktopForwardPortResultMessage
+  | DesktopFileContentMessage
+  | UpdateQueueMessage
+  | UpdateQueuedMessageMissingMessage
+  | UpdateCommandRunningMessage
+  | RewindCheckpointsMessage
+  | BtwStreamMessage
+  | BtwResponseMessage
+  | BtwErrorMessage
+  | StartStreamingMessage
+  | EndStreamingMessage
+  | EnsureUIResetMessage
+  | UpdateSessionsMessage
+  | UpdateCurrentSessionMessage
+  | ShowConfirmationMessage
+  | ConfigurationResponseMessage
+  | ProjectSettingsMessage
+  | SetInitialStateMessage
+  | DesktopThemeChangeMessage
+  | DesktopTogglePanelMessage
+  | ShowConfigurationMessage
+  | ShowDialogMessage
+  | ConfigurationUpdatedMessage
+  | StatusResponseMessage
+  | ConfigurationErrorMessage
+  | FocusInputMessage
+  | TriggerShortcutMessage
+  | ScrollToBottomMessage
+  | AppendMessageMessage
+  | BangMessageAddedMessage
+  | BangMessageUpdatedMessage
+  | BangMessageCompletedMessage
+  | CompactionStateChangeMessage
+  | UpdateStreamingContentMessage
+  | UpdateStreamingReasoningMessage
+  | UpdateToolBlockMessage
+  | UpdateErrorBlockMessage
+  | AuthStatusResponseMessage
+  | LoginResponseMessage
+  | LogoutResponseMessage
+  | DesktopPanesMessage
+  | DesktopSessionTreeMessage
+  | DesktopWorkdirStateMessage
+  | McpServersResponseMessage
+  | HistoryResponseMessage
+  | FileSuggestionsMessage
+  | FileSuggestionsErrorMessage
+  | SlashCommandsResponseMessage
+  | SlashCommandsErrorMessage
+  | UploadSuccessMessage
+  | UploadErrorMessage
+  | DesktopRemoteDirListMessage;

--- a/packages/webview-fixtures/tsconfig.build.json
+++ b/packages/webview-fixtures/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declarationMap": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/packages/webview-fixtures/tsconfig.json
+++ b/packages/webview-fixtures/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "moduleResolution": "nodenext",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2020",
+    "module": "NodeNext",
+    "lib": ["ES2020", "DOM"]
+  },
+  "include": ["src/**/*", "vitest.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/webview-fixtures/vitest.config.ts
+++ b/packages/webview-fixtures/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -38,7 +38,8 @@
     "react-dom": "^18.0.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.5",
-    "wave-agent-sdk": "workspace:*"
+    "wave-agent-sdk": "workspace:*",
+    "wave-webview-fixtures": "workspace:*"
   },
   "dependencies": {
     "@vscode/codicons": "^0.0.43",

--- a/packages/webview/tests/webview/chatAppPanels.test.tsx
+++ b/packages/webview/tests/webview/chatAppPanels.test.tsx
@@ -5,7 +5,8 @@ import { DesktopApp } from '../../src/components/DesktopApp';
 import { ChatApp, prunePanelGroupCache } from '../../src/components/ChatApp';
 import type { WebviewTagElement } from '../../src/components/PreviewPane';
 import { EXIT_PLAN_MODE_TOOL_NAME } from 'wave-agent-sdk';
-import { createMockVscode, sendCommand, renderChatApp, fireInput } from './test-utils';
+import { createMockVscode, sendCommand, sendHostMessage, renderChatApp, fireInput } from './test-utils';
+import { fixtures } from 'wave-webview-fixtures';
 import { MockDataGenerator } from '../fixtures/mockData';
 
 vi.mock('../../src/styles/DesktopApp.css', () => ({}));
@@ -20,11 +21,11 @@ vi.mock('../../src/styles/DesktopApp.css', () => ({}));
 function renderDesktop(options?: { workdir?: string }) {
     const vscode = createMockVscode();
     const view = render(<DesktopApp vscode={vscode} />);
-    sendCommand('desktopWorkdirState', {
+    sendHostMessage(fixtures.desktopWorkdirState({
         workdir: options?.workdir,
         recentWorkdirs: options?.workdir ? [options.workdir] : [],
-    });
-    sendCommand('authStatusResponse', { isAuthenticated: true });
+    }));
+    sendHostMessage(fixtures.authStatusResponse());
     return { vscode, unmount: view.unmount };
 }
 
@@ -165,11 +166,11 @@ describe('ChatApp desktop panel framework', () => {
     it('desktopTogglePanel from the host takes the same path as the menu', () => {
         window.waveHostType = 'desktop';
         const { vscode } = renderDesktop({ workdir: '/work/a' });
-        sendCommand('desktopTogglePanel', { kind: 'diff' });
+        sendHostMessage(fixtures.desktopTogglePanel('diff'));
         expect(screen.getByTestId('diff-pane')).toBeInTheDocument();
         expect(lastPanelState(vscode)).toEqual(['diff']);
 
-        sendCommand('desktopTogglePanel', { kind: 'diff' });
+        sendHostMessage(fixtures.desktopTogglePanel('diff'));
         expect(screen.getByTestId('diff-pane').parentElement).toHaveStyle({ display: 'none' });
         expect(lastPanelState(vscode)).toEqual([]);
     });
@@ -188,7 +189,7 @@ describe('ChatApp desktop panel framework', () => {
         expect(vscode.postMessage).not.toHaveBeenCalledWith({ command: 'desktopGetWorkspaceDiff' });
 
         // Host-originated toggles hit the same guard.
-        sendCommand('desktopTogglePanel', { kind: 'terminal' });
+        sendHostMessage(fixtures.desktopTogglePanel('terminal'));
         expect(screen.queryByTestId('terminal-pane')).not.toBeInTheDocument();
     });
 
@@ -240,7 +241,7 @@ describe('ChatApp desktop panel framework', () => {
     it('does not show the panel toggle when waveHostType is not desktop', () => {
         const vscode = createMockVscode();
         render(<ChatApp vscode={vscode} />);
-        sendCommand('authStatusResponse', { isAuthenticated: true });
+        sendHostMessage(fixtures.authStatusResponse());
         expect(screen.queryByTestId('panel-toggle-btn')).not.toBeInTheDocument();
         expect(document.querySelector('.desktop-panel-slot')).toBeNull();
     });
@@ -454,9 +455,10 @@ describe('ChatApp desktop panel framework', () => {
             renderDesktop({ workdir: '/work/a' });
             // Sessions must exist in the sidebar tree — the prune keeps panel
             // groups only for live panes and tree sessions.
-            sendCommand('desktopSessionTree', {
+            sendHostMessage(fixtures.desktopSessionTree({
                 groups: [
                     {
+                        host: 'local',
                         workdir: '/work/a',
                         sessions: ['s1', 's2'].map((sessionId) => ({
                             sessionId,
@@ -466,30 +468,30 @@ describe('ChatApp desktop panel framework', () => {
                         })),
                     },
                 ],
-            });
-            sendCommand('desktopPanes', {
-                panes: [{ paneId: 'pane-1', sessionId: 's1', row: 0 }],
+            }));
+            sendHostMessage(fixtures.desktopPanes({
+                panes: [{ paneId: 'pane-1', sessionId: 's1', row: 0, host: 'local', width: 0.5 }],
                 focusedPaneId: 'pane-1',
-            });
+            }));
             openDiffPanel();
             dragDiffToRow2();
             expect(slotOf('diff-pane').className).toContain('desktop-panel-slot--row-2');
 
             // Switch to another session: its (empty) group swaps in — no
             // panels, no second row.
-            sendCommand('desktopPanes', {
-                panes: [{ paneId: 'pane-1', sessionId: 's2', row: 0 }],
+            sendHostMessage(fixtures.desktopPanes({
+                panes: [{ paneId: 'pane-1', sessionId: 's2', row: 0, host: 'local', width: 0.5 }],
                 focusedPaneId: 'pane-1',
-            });
+            }));
             expect(screen.queryByTestId('diff-pane')).not.toBeInTheDocument();
             expect(screen.queryByTestId('desktop-panel-row-separator')).not.toBeInTheDocument();
 
             // Switching back restores the diff panel in its second row with
             // the same height.
-            sendCommand('desktopPanes', {
-                panes: [{ paneId: 'pane-1', sessionId: 's1', row: 0 }],
+            sendHostMessage(fixtures.desktopPanes({
+                panes: [{ paneId: 'pane-1', sessionId: 's1', row: 0, host: 'local', width: 0.5 }],
                 focusedPaneId: 'pane-1',
-            });
+            }));
             expect(slotOf('diff-pane').className).toContain('desktop-panel-slot--row-2');
             expect(screen.getByTestId('desktop-panel-row-separator')).toBeInTheDocument();
             expect(bodyOf().style.getPropertyValue('--panel-row-height')).toBe('280px');
@@ -504,17 +506,17 @@ describe('ChatApp desktop panel framework', () => {
                 lastActiveAt: Date.now(),
                 hasWorktree: false,
             });
-            sendCommand('desktopSessionTree', {
-                groups: [{ workdir: '/work/a', sessions: [session('s1'), session('s2')] }],
-            });
-            sendCommand('desktopPanes', {
+            sendHostMessage(fixtures.desktopSessionTree({
+                groups: [{ host: 'local', workdir: '/work/a', sessions: [session('s1'), session('s2')] }],
+            }));
+            sendHostMessage(fixtures.desktopPanes({
                 panes: [
-                    { paneId: 'pane-cache-a', sessionId: 's1', row: 0 },
-                    { paneId: 'pane-cache-b', sessionId: 's2', row: 1 },
+                    { paneId: 'pane-cache-a', sessionId: 's1', row: 0, host: 'local', width: 0.5 },
+                    { paneId: 'pane-cache-b', sessionId: 's2', row: 1, host: 'local', width: 0.5 },
                 ],
                 rowHeights: [0.5, 0.5],
                 focusedPaneId: 'pane-cache-a',
-            });
+            }));
 
             // Open the diff panel in pane-cache-a and drag it into the second row.
             const paneA = screen.getByTestId('desktop-pane-pane-cache-a');
@@ -532,14 +534,14 @@ describe('ChatApp desktop panel framework', () => {
 
             // The host moves pane-cache-a into window row 1 — the pane subtree
             // unmounts and remounts (React cannot reparent DOM nodes).
-            sendCommand('desktopPanes', {
+            sendHostMessage(fixtures.desktopPanes({
                 panes: [
-                    { paneId: 'pane-cache-b', sessionId: 's2', row: 0 },
-                    { paneId: 'pane-cache-a', sessionId: 's1', row: 1 },
+                    { paneId: 'pane-cache-b', sessionId: 's2', row: 0, host: 'local', width: 0.5 },
+                    { paneId: 'pane-cache-a', sessionId: 's1', row: 1, host: 'local', width: 0.5 },
                 ],
                 rowHeights: [0.5, 0.5],
                 focusedPaneId: 'pane-cache-a',
-            });
+            }));
 
             // The panel group migrated with the pane: diff still checked and
             // still in its second row.
@@ -595,14 +597,14 @@ describe('session-level panel groups', () => {
         hasWorktree: false,
     });
     const pushPanes = (sessionId?: string) =>
-        sendCommand('desktopPanes', {
-            panes: [{ paneId: 'pane-1', sessionId, row: 0 }],
+        sendHostMessage(fixtures.desktopPanes({
+            panes: [{ paneId: 'pane-1', sessionId, row: 0, host: 'local', width: 0.5 }],
             focusedPaneId: 'pane-1',
-        });
+        }));
     const pushTree = (ids: string[]) =>
-        sendCommand('desktopSessionTree', {
-            groups: [{ workdir: '/work/a', sessions: ids.map(session) }],
-        });
+        sendHostMessage(fixtures.desktopSessionTree({
+            groups: [{ host: 'local', workdir: '/work/a', sessions: ids.map(session) }],
+        }));
     const openPanel = (kind: string) => {
         fireEvent.click(screen.getByTestId('panel-toggle-btn'));
         fireEvent.click(screen.getByTestId(`panel-toggle-item-${kind}`));
@@ -721,15 +723,15 @@ describe('remote preview port forwarding', () => {
         hasWorktree: false,
     });
     const pushRemotePane = () =>
-        sendCommand('desktopPanes', {
-            panes: [{ paneId: 'pane-1', sessionId: 's1', row: 0, host: 'prod' }],
+        sendHostMessage(fixtures.desktopPanes({
+            panes: [{ paneId: 'pane-1', sessionId: 's1', row: 0, host: 'prod', width: 0.5 }],
             focusedPaneId: 'pane-1',
-        });
+        }));
     const openLink = (url = 'http://localhost:5173/app') => {
-        sendCommand('updateMessages', {
-            paneId: 'pane-1',
-            messages: [MockDataGenerator.createAssistantMessage(`服务在 [这里](${url})`)],
-        });
+        sendHostMessage(fixtures.updateMessages(
+            [MockDataGenerator.createAssistantMessage(`服务在 [这里](${url})`)],
+            { paneId: 'pane-1' },
+        ));
         fireEvent.click(screen.getByText('这里'));
     };
     const forwardPosts = (vscode: ReturnType<typeof createMockVscode>) =>
@@ -744,7 +746,7 @@ describe('remote preview port forwarding', () => {
     it('clicking a localhost link in a remote session requests a forward on the pane host', () => {
         window.waveHostType = 'desktop';
         const { vscode } = renderDesktop({ workdir: '/work/a' });
-        sendCommand('desktopSessionTree', { groups: [{ workdir: '/work/a', sessions: [session('s1')] }] });
+        sendHostMessage(fixtures.desktopSessionTree({ groups: [{ host: 'local', workdir: '/work/a', sessions: [session('s1')] }] }));
         pushRemotePane();
         openLink();
 
@@ -762,7 +764,7 @@ describe('remote preview port forwarding', () => {
     it('the forward reply loads the rewritten address in the preview pane', () => {
         window.waveHostType = 'desktop';
         const { vscode } = renderDesktop({ workdir: '/work/a' });
-        sendCommand('desktopSessionTree', { groups: [{ workdir: '/work/a', sessions: [session('s1')] }] });
+        sendHostMessage(fixtures.desktopSessionTree({ groups: [{ host: 'local', workdir: '/work/a', sessions: [session('s1')] }] }));
         pushRemotePane();
         openLink();
 
@@ -787,7 +789,7 @@ describe('remote preview port forwarding', () => {
     it('clicking the same link again does not re-establish the forward', () => {
         window.waveHostType = 'desktop';
         const { vscode } = renderDesktop({ workdir: '/work/a' });
-        sendCommand('desktopSessionTree', { groups: [{ workdir: '/work/a', sessions: [session('s1')] }] });
+        sendHostMessage(fixtures.desktopSessionTree({ groups: [{ host: 'local', workdir: '/work/a', sessions: [session('s1')] }] }));
         pushRemotePane();
         openLink();
         sendCommand('desktopForwardPortResult', {
@@ -805,7 +807,7 @@ describe('remote preview port forwarding', () => {
     it('an equivalent loopback spelling of the same link reuses the forward', () => {
         window.waveHostType = 'desktop';
         const { vscode } = renderDesktop({ workdir: '/work/a' });
-        sendCommand('desktopSessionTree', { groups: [{ workdir: '/work/a', sessions: [session('s1')] }] });
+        sendHostMessage(fixtures.desktopSessionTree({ groups: [{ host: 'local', workdir: '/work/a', sessions: [session('s1')] }] }));
         pushRemotePane();
         openLink();
         sendCommand('desktopForwardPortResult', {
@@ -829,7 +831,7 @@ describe('remote preview port forwarding', () => {
     it('clicking a link on a different port does not release the tunnel', () => {
         window.waveHostType = 'desktop';
         const { vscode } = renderDesktop({ workdir: '/work/a' });
-        sendCommand('desktopSessionTree', { groups: [{ workdir: '/work/a', sessions: [session('s1')] }] });
+        sendHostMessage(fixtures.desktopSessionTree({ groups: [{ host: 'local', workdir: '/work/a', sessions: [session('s1')] }] }));
         pushRemotePane();
         openLink('http://localhost:5173/app');
         sendCommand('desktopForwardPortResult', {
@@ -861,7 +863,7 @@ describe('remote preview port forwarding', () => {
     it('a same-origin link with a different path reuses the tunnel (no release)', () => {
         window.waveHostType = 'desktop';
         const { vscode } = renderDesktop({ workdir: '/work/a' });
-        sendCommand('desktopSessionTree', { groups: [{ workdir: '/work/a', sessions: [session('s1')] }] });
+        sendHostMessage(fixtures.desktopSessionTree({ groups: [{ host: 'local', workdir: '/work/a', sessions: [session('s1')] }] }));
         pushRemotePane();
         openLink('http://localhost:5173/app');
         sendCommand('desktopForwardPortResult', {
@@ -892,7 +894,7 @@ describe('remote preview port forwarding', () => {
     it('a failed forward shows an actionable error; retry re-acquires and loads', () => {
         window.waveHostType = 'desktop';
         const { vscode } = renderDesktop({ workdir: '/work/a' });
-        sendCommand('desktopSessionTree', { groups: [{ workdir: '/work/a', sessions: [session('s1')] }] });
+        sendHostMessage(fixtures.desktopSessionTree({ groups: [{ host: 'local', workdir: '/work/a', sessions: [session('s1')] }] }));
         pushRemotePane();
         openLink();
 
@@ -924,7 +926,7 @@ describe('remote preview port forwarding', () => {
     it('closing the preview panel keeps the tunnel alive (session-scoped)', () => {
         window.waveHostType = 'desktop';
         const { vscode } = renderDesktop({ workdir: '/work/a' });
-        sendCommand('desktopSessionTree', { groups: [{ workdir: '/work/a', sessions: [session('s1')] }] });
+        sendHostMessage(fixtures.desktopSessionTree({ groups: [{ host: 'local', workdir: '/work/a', sessions: [session('s1')] }] }));
         pushRemotePane();
         openLink();
 
@@ -940,7 +942,7 @@ describe('remote preview port forwarding', () => {
     it('unmounting the pane (session still in the tree) keeps the tunnel alive', () => {
         window.waveHostType = 'desktop';
         const { vscode, unmount } = renderDesktop({ workdir: '/work/a' });
-        sendCommand('desktopSessionTree', { groups: [{ workdir: '/work/a', sessions: [session('s1')] }] });
+        sendHostMessage(fixtures.desktopSessionTree({ groups: [{ host: 'local', workdir: '/work/a', sessions: [session('s1')] }] }));
         pushRemotePane();
         openLink();
         sendCommand('desktopForwardPortResult', {
@@ -963,7 +965,7 @@ describe('remote preview port forwarding', () => {
     it('re-checking the preview panel restores the forwarded URL', () => {
         window.waveHostType = 'desktop';
         const { vscode } = renderDesktop({ workdir: '/work/a' });
-        sendCommand('desktopSessionTree', { groups: [{ workdir: '/work/a', sessions: [session('s1')] }] });
+        sendHostMessage(fixtures.desktopSessionTree({ groups: [{ host: 'local', workdir: '/work/a', sessions: [session('s1')] }] }));
         pushRemotePane();
         openLink();
         sendCommand('desktopForwardPortResult', {
@@ -991,7 +993,7 @@ describe('remote preview port forwarding', () => {
     it('switching host keeps the tunnel alive and the preview URL cached', () => {
         window.waveHostType = 'desktop';
         const { vscode } = renderDesktop({ workdir: '/work/a' });
-        sendCommand('desktopSessionTree', { groups: [{ workdir: '/work/a', sessions: [session('s1')] }] });
+        sendHostMessage(fixtures.desktopSessionTree({ groups: [{ host: 'local', workdir: '/work/a', sessions: [session('s1')] }] }));
         pushRemotePane();
         openLink();
         sendCommand('desktopForwardPortResult', {
@@ -1005,10 +1007,10 @@ describe('remote preview port forwarding', () => {
         // Host switch (remote → local): the tunnel is session-scoped — no
         // release. The pane's preview keeps its URL (still cached, still loads
         // through the live tunnel), so switching back shows it unchanged.
-        sendCommand('desktopPanes', {
-            panes: [{ paneId: 'pane-1', sessionId: 's1', row: 0, host: 'local' }],
+        sendHostMessage(fixtures.desktopPanes({
+            panes: [{ paneId: 'pane-1', sessionId: 's1', row: 0, host: 'local', width: 0.5 }],
             focusedPaneId: 'pane-1',
-        });
+        }));
 
         expect(releasePosts(vscode)).toHaveLength(0);
         expect(screen.getByTestId('preview-pane')).toBeInTheDocument();
@@ -1020,9 +1022,9 @@ describe('remote preview port forwarding', () => {
     it('switching to another session and back restores the remote preview URL (spec 场景 9)', () => {
         window.waveHostType = 'desktop';
         const { vscode } = renderDesktop({ workdir: '/work/a' });
-        sendCommand('desktopSessionTree', {
-            groups: [{ workdir: '/work/a', sessions: [session('s1'), session('s2')] }],
-        });
+        sendHostMessage(fixtures.desktopSessionTree({
+            groups: [{ host: 'local', workdir: '/work/a', sessions: [session('s1'), session('s2')] }],
+        }));
         pushRemotePane();
         openLink();
         sendCommand('desktopForwardPortResult', {
@@ -1035,20 +1037,20 @@ describe('remote preview port forwarding', () => {
 
         // Switch to s2 (local host): no release, and the pane shows s2's own
         // (empty) preview state.
-        sendCommand('desktopPanes', {
-            panes: [{ paneId: 'pane-1', sessionId: 's2', row: 0, host: 'local' }],
+        sendHostMessage(fixtures.desktopPanes({
+            panes: [{ paneId: 'pane-1', sessionId: 's2', row: 0, host: 'local', width: 0.5 }],
             focusedPaneId: 'pane-1',
-        });
+        }));
         expect(releasePosts(vscode)).toHaveLength(0);
         // s2 has no cached panel state — the preview slot is not mounted.
         expect(screen.queryByTestId('preview-pane')).not.toBeInTheDocument();
 
         // Switch back to s1: the forwarded URL is restored from the session
         // cache, and the tunnel was never released — no re-acquire needed.
-        sendCommand('desktopPanes', {
-            panes: [{ paneId: 'pane-1', sessionId: 's1', row: 0, host: 'prod' }],
+        sendHostMessage(fixtures.desktopPanes({
+            panes: [{ paneId: 'pane-1', sessionId: 's1', row: 0, host: 'prod', width: 0.5 }],
             focusedPaneId: 'pane-1',
-        });
+        }));
         expect(screen.getByTestId('preview-pane').querySelector('webview')?.getAttribute('src')).toBe(
             'http://127.0.0.1:5173/app',
         );
@@ -1059,7 +1061,7 @@ describe('remote preview port forwarding', () => {
     it('a stale forward reply for a released request is dropped', () => {
         window.waveHostType = 'desktop';
         const { vscode } = renderDesktop({ workdir: '/work/a' });
-        sendCommand('desktopSessionTree', { groups: [{ workdir: '/work/a', sessions: [session('s1')] }] });
+        sendHostMessage(fixtures.desktopSessionTree({ groups: [{ host: 'local', workdir: '/work/a', sessions: [session('s1')] }] }));
         pushRemotePane();
         openLink();
         // Fail, then retry: the current request is now fwd-2.
@@ -1083,9 +1085,9 @@ describe('remote preview port forwarding', () => {
     it('rebinding the pane to another session keeps both sessions\' tunnels', () => {
         window.waveHostType = 'desktop';
         const { vscode } = renderDesktop({ workdir: '/work/a' });
-        sendCommand('desktopSessionTree', {
-            groups: [{ workdir: '/work/a', sessions: [session('s1'), session('s2')] }],
-        });
+        sendHostMessage(fixtures.desktopSessionTree({
+            groups: [{ host: 'local', workdir: '/work/a', sessions: [session('s1'), session('s2')] }],
+        }));
         pushRemotePane();
         openLink();
         expect(forwardPosts(vscode)).toHaveLength(1);
@@ -1093,10 +1095,10 @@ describe('remote preview port forwarding', () => {
         // Rebind the pane to s2 (another remote host) and open a different
         // URL there: a SECOND tunnel is requested — s1's stays held, because
         // tunnels are owned by sessions, not by the pane (scenario 18).
-        sendCommand('desktopPanes', {
-            panes: [{ paneId: 'pane-1', sessionId: 's2', row: 0, host: 'prod2' }],
+        sendHostMessage(fixtures.desktopPanes({
+            panes: [{ paneId: 'pane-1', sessionId: 's2', row: 0, host: 'prod2', width: 0.5 }],
             focusedPaneId: 'pane-1',
-        });
+        }));
         openLink('http://localhost:8080/app');
         expect(forwardPosts(vscode)).toHaveLength(2);
         expect(forwardPosts(vscode)[1]).toMatchObject({
@@ -1132,10 +1134,10 @@ describe('remote preview port forwarding', () => {
 
         // Switch back to s1: its own forwarded URL shows again from the session
         // cache; neither tunnel was ever released.
-        sendCommand('desktopPanes', {
-            panes: [{ paneId: 'pane-1', sessionId: 's1', row: 0, host: 'prod' }],
+        sendHostMessage(fixtures.desktopPanes({
+            panes: [{ paneId: 'pane-1', sessionId: 's1', row: 0, host: 'prod', width: 0.5 }],
             focusedPaneId: 'pane-1',
-        });
+        }));
         expect(screen.getByTestId('preview-pane').querySelector('webview')?.getAttribute('src')).toBe(
             'http://127.0.0.1:5173/app',
         );
@@ -1146,7 +1148,7 @@ describe('remote preview port forwarding', () => {
     it('picker comments in a remote preview land in the chat input (URL rewritten to the original remote address)', () => {
         window.waveHostType = 'desktop';
         const { vscode } = renderDesktop({ workdir: '/work/a' });
-        sendCommand('desktopSessionTree', { groups: [{ workdir: '/work/a', sessions: [session('s1')] }] });
+        sendHostMessage(fixtures.desktopSessionTree({ groups: [{ host: 'local', workdir: '/work/a', sessions: [session('s1')] }] }));
         pushRemotePane();
         // The host always pushes a pane snapshot on session switch, including
         // the (possibly empty) input draft — see desktopHost.ts pushPaneSessionState.

--- a/packages/webview/tests/webview/sessionManagement.test.tsx
+++ b/packages/webview/tests/webview/sessionManagement.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { renderChatApp, screen, fireEvent, act, sendCommand, fireInput, setInputText } from './test-utils';
+import { renderChatApp, screen, fireEvent, act, sendCommand, sendHostMessage, fireInput, setInputText } from './test-utils';
+import { fixtures } from 'wave-webview-fixtures';
 import { MockDataGenerator } from '../fixtures/mockData';
 
 /**
@@ -206,7 +207,7 @@ describe('Session Management', () => {
             MockDataGenerator.createAssistantMessage('Hi! This is in the original session.')
         ];
         act(() => {
-            sendCommand('updateMessages', { messages: conversation });
+            sendHostMessage(fixtures.updateMessages(conversation));
         });
 
         // Verify current session title and messages are present
@@ -236,7 +237,7 @@ describe('Session Management', () => {
         // Simulate EXPECTED BEHAVIOR through proper callback mechanism:
         // 1. Messages are cleared
         act(() => {
-            sendCommand('updateMessages', { messages: [] });
+            sendHostMessage(fixtures.updateMessages([]));
         });
 
         // 2. Session ID changes
@@ -380,9 +381,7 @@ describe('Session Management', () => {
 
         // User sends "hi" — the title should now reflect it.
         act(() => {
-            sendCommand('updateMessages', {
-                messages: [MockDataGenerator.createUserMessage('hi')]
-            });
+            sendHostMessage(fixtures.updateMessages([MockDataGenerator.createUserMessage('hi')]));
         });
 
         const header = screen.getByTestId('chat-header');
@@ -394,17 +393,19 @@ describe('Session Management', () => {
 describe('input drafts per session (desktop-app.md 会话管理 scenario 11/12)', () => {
     const sessionA = {
         id: 'session-A',
-        sessionType: 'main',
+        sessionType: 'main' as const,
         workdir: '/test/project',
         firstMessage: 'Session A',
+        createdAt: new Date('2023-12-01T10:00:00Z'),
         lastActiveAt: new Date('2023-12-01T10:00:00Z'),
         latestTotalTokens: 150
     };
     const sessionB = {
         id: 'session-B',
-        sessionType: 'main',
+        sessionType: 'main' as const,
         workdir: '/test/project',
         firstMessage: 'Session B',
+        createdAt: new Date('2023-12-01T11:00:00Z'),
         lastActiveAt: new Date('2023-12-01T11:00:00Z'),
         latestTotalTokens: 250
     };
@@ -412,7 +413,7 @@ describe('input drafts per session (desktop-app.md 会话管理 scenario 11/12)'
     it('switching sessions resets the input even when both drafts are equal (empty)', async () => {
         const { vscode } = renderChatApp();
         act(() => {
-            sendCommand('setInitialState', { session: sessionA, messages: [], inputContent: '' });
+            sendHostMessage(fixtures.setInitialState({ session: sessionA, messages: [] }));
         });
         const input = screen.getByTestId('message-input');
 
@@ -424,7 +425,7 @@ describe('input drafts per session (desktop-app.md 会话管理 scenario 11/12)'
         // (value equality alone cannot distinguish two empty drafts).
         vscode.postMessage.mockClear();
         act(() => {
-            sendCommand('setInitialState', { session: sessionB, messages: [], inputContent: '' });
+            sendHostMessage(fixtures.setInitialState({ session: sessionB, messages: [] }));
         });
 
         expect(input.innerText).toBe('');
@@ -444,20 +445,20 @@ describe('input drafts per session (desktop-app.md 会话管理 scenario 11/12)'
 
         // A has an unsent draft persisted by the host.
         act(() => {
-            sendCommand('setInitialState', { session: sessionA, messages: [], inputContent: '1' });
+            sendHostMessage(fixtures.setInitialState({ session: sessionA, messages: [], inputContent: '1' }));
         });
         const input = screen.getByTestId('message-input');
         expect(input.innerText).toBe('1');
 
         // Switch to B (no draft) — the input clears.
         act(() => {
-            sendCommand('setInitialState', { session: sessionB, messages: [], inputContent: '' });
+            sendHostMessage(fixtures.setInitialState({ session: sessionB, messages: [] }));
         });
         expect(input.innerText).toBe('');
 
         // Back to A — the draft comes back with the conversation.
         act(() => {
-            sendCommand('setInitialState', { session: sessionA, messages: [], inputContent: '1' });
+            sendHostMessage(fixtures.setInitialState({ session: sessionA, messages: [], inputContent: '1' }));
         });
         expect(input.innerText).toBe('1');
     });
@@ -467,7 +468,7 @@ describe('input drafts per session (desktop-app.md 会话管理 scenario 11/12)'
         try {
             const { vscode } = renderChatApp();
             act(() => {
-                sendCommand('setInitialState', { session: sessionA, messages: [], inputContent: '' });
+                sendHostMessage(fixtures.setInitialState({ session: sessionA, messages: [] }));
             });
             const input = screen.getByTestId('message-input');
 
@@ -477,7 +478,7 @@ describe('input drafts per session (desktop-app.md 会话管理 scenario 11/12)'
             // Switch to B: the effect cancels the pending timer and flushes the
             // outgoing draft with A's tag immediately.
             act(() => {
-                sendCommand('setInitialState', { session: sessionB, messages: [], inputContent: '' });
+                sendHostMessage(fixtures.setInitialState({ session: sessionB, messages: [] }));
             });
             expect(vscode.postMessage).toHaveBeenCalledWith(
                 expect.objectContaining({ command: 'updateInputContent', sessionId: 'session-A', content: '1' })

--- a/packages/webview/tests/webview/test-utils.tsx
+++ b/packages/webview/tests/webview/test-utils.tsx
@@ -4,6 +4,7 @@ import { render, act, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { VsCodeApi } from '../../src/types';
 import { ChatApp } from '../../src/components/ChatApp';
+import { fixtures, type HostToWebviewMessage } from 'wave-webview-fixtures';
 
 // Mock heavy dependencies
 vi.mock('mermaid', () => ({
@@ -51,7 +52,7 @@ export function renderChatApp(vscode?: VsCodeApi) {
     const result = render(<ChatApp vscode={mockVscode} />);
     // Default to authenticated so the message input is enabled and MessageList
     // (not the unauthenticated WelcomeView) renders for empty-state assertions.
-    sendExtensionMessage({ command: 'authStatusResponse', isAuthenticated: true });
+    sendHostMessage(fixtures.authStatusResponse());
     const user = userEvent.setup();
     return { ...result, vscode: mockVscode, user };
 }
@@ -70,6 +71,15 @@ export function sendExtensionMessage(data: Record<string, unknown>) {
  */
 export function sendCommand(command: string, data?: Record<string, unknown>) {
     sendExtensionMessage({ command, ...data });
+}
+
+/**
+ * Send a typed host → webview message anchored to the shared contract
+ * (wave-webview-fixtures). Prefer this over sendCommand for messages that
+ * have a fixture, so test payloads stay in lockstep with the real hosts.
+ */
+export function sendHostMessage(message: HostToWebviewMessage) {
+    sendExtensionMessage(message as unknown as Record<string, unknown>);
 }
 
 /**

--- a/packages/webview/vitest.config.ts
+++ b/packages/webview/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
         setupFiles: ['tests/setup.ts'],
         server: {
             deps: {
-                inline: ['wave-agent-sdk'],
+                inline: ['wave-agent-sdk', 'wave-webview-fixtures'],
             },
         },
         coverage: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,6 +239,9 @@ importers:
       wave-webview:
         specifier: workspace:*
         version: link:../webview
+      wave-webview-fixtures:
+        specifier: workspace:*
+        version: link:../webview-fixtures
 
   packages/vsce:
     devDependencies:
@@ -266,6 +269,9 @@ importers:
       wave-webview:
         specifier: workspace:*
         version: link:../webview
+      wave-webview-fixtures:
+        specifier: workspace:*
+        version: link:../webview-fixtures
 
   packages/webview:
     dependencies:
@@ -335,6 +341,24 @@ importers:
         version: 18.3.1(react@18.3.1)
       typescript:
         specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.8.1))
+      wave-agent-sdk:
+        specifier: workspace:*
+        version: link:../agent-sdk
+      wave-webview-fixtures:
+        specifier: workspace:*
+        version: link:../webview-fixtures
+
+  packages/webview-fixtures:
+    devDependencies:
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.2
+      typescript:
+        specifier: ^5.5.4
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
@@ -7848,7 +7872,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.3)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.8.1))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.3)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@22.19.3)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.8.1))
 
   '@vitest/expect@4.1.7':
     dependencies:


### PR DESCRIPTION
新增私有包 wave-webview-fixtures：host→webview postMessage 契约类型 + fixture 工厂，webview/desktop/vsce 测试共用，契约变更时两层同时变红。

背景：WebView 场景 bug 频发的根因之一是 host→webview 通道无契约——命令字符串和 payload 字段在三端各自手写，两个测试层都可能全绿而真实 host 已损坏。

- 契约类型从真实 host payload 派生（setInitialState/desktopPanes/desktopSessionTree/updateMessages 等）
- desktop/vsce 增加契约守门断言，对比 fixture 默认值验证 payload 形状
- webview 测试迁移到 fixture：renderChatApp 默认 auth push 走 fixture，手写 payload 改为 fixtures.*，补齐 host/width 等真实字段
- 迁移过程发现并修正 fixture 类型 DesktopSessionGroup 的 sorted→sessions（对齐 desktopHost.ts wire 形状）

验证：webview 611 + desktop 448 + vsce 163 全绿，全仓 type-check 通过