### PR TITLE
fix(stdio): decode GBK stderr from wave --stdio on Windows

### DIFF
--- a/packages/desktop/src/main/stdio/stdioClient.ts
+++ b/packages/desktop/src/main/stdio/stdioClient.ts
@@ -13,9 +13,30 @@ import { JsonRpcClient } from './jsonRpcClient';
 export type { NotificationHandler } from './jsonRpcClient';
 export type StderrHandler = (data: string) => void;
 
+/** Keep a bounded tail of stderr (bytes) for inclusion in the exit error. */
+const STDERR_TAIL_LIMIT = 4096;
+
+/**
+ * Decode stderr bytes: UTF-8 when valid, otherwise GBK (Windows console
+ * code page 936). cmd.exe and native Windows tools emit GBK on Chinese
+ * systems; decoding those bytes as UTF-8 yields U+FFFD garbage and the real
+ * error message is lost.
+ */
+function decodeStderr(buf: Buffer): string {
+    const utf8 = buf.toString('utf-8');
+    if (!utf8.includes('\uFFFD')) return utf8;
+    try {
+        return new TextDecoder('gbk').decode(buf);
+    } catch {
+        return utf8;
+    }
+}
+
 export class StdioClient extends JsonRpcClient {
     private proc: ChildProcess;
-    private stderrBuffer = '';
+    /** Raw stderr bytes, bounded to the last STDERR_TAIL_LIMIT bytes. */
+    private stderrChunks: Buffer[] = [];
+    private stderrBytes = 0;
     private onStderr?: StderrHandler;
 
     constructor(
@@ -52,15 +73,26 @@ export class StdioClient extends JsonRpcClient {
         });
 
         this.proc.stderr!.on('data', (data: Buffer) => {
-            const text = data.toString();
-            // Keep a rolling tail for inclusion in the exit error message.
-            this.stderrBuffer = (this.stderrBuffer + text).slice(-4096);
-            const trimmed = text.trimEnd();
+            // Keep raw bytes (not per-chunk strings) so the exit error can be
+            // decoded exactly, without splitting a multi-byte character across
+            // chunk boundaries.
+            this.stderrChunks.push(data);
+            this.stderrBytes += data.length;
+            while (
+                this.stderrChunks.length > 1 &&
+                this.stderrBytes - this.stderrChunks[0].length >= STDERR_TAIL_LIMIT
+            ) {
+                this.stderrBytes -= this.stderrChunks[0].length;
+                this.stderrChunks.shift();
+            }
+            const trimmed = decodeStderr(data).trimEnd();
             if (trimmed) this.onStderr?.(trimmed);
         });
 
         this.proc.on('exit', (code, signal) => {
-            const stderr = this.stderrBuffer.trim();
+            const stderr = decodeStderr(
+                Buffer.concat(this.stderrChunks),
+            ).trim();
             const parts = [
                 `wave --stdio process exited (code: ${code}, signal: ${signal})`,
             ];

--- a/packages/vsce/src/stdio/stdioClient.ts
+++ b/packages/vsce/src/stdio/stdioClient.ts
@@ -16,13 +16,34 @@ interface PendingRequest {
     reject: (error: Error) => void;
 }
 
+/** Keep a bounded tail of stderr (bytes) for inclusion in the exit error. */
+const STDERR_TAIL_LIMIT = 4096;
+
+/**
+ * Decode stderr bytes: UTF-8 when valid, otherwise GBK (Windows console
+ * code page 936). cmd.exe and native Windows tools emit GBK on Chinese
+ * systems; decoding those bytes as UTF-8 yields U+FFFD garbage and the real
+ * error message is lost.
+ */
+function decodeStderr(buf: Buffer): string {
+    const utf8 = buf.toString('utf-8');
+    if (!utf8.includes('\uFFFD')) return utf8;
+    try {
+        return new TextDecoder('gbk').decode(buf);
+    } catch {
+        return utf8;
+    }
+}
+
 export class StdioClient {
     private proc: ChildProcess;
     private nextId = 1;
     private pending = new Map<number, PendingRequest>();
     private handlers = new Map<string, Set<NotificationHandler>>();
     private disposed = false;
-    private stderrBuffer = '';
+    /** Raw stderr bytes, bounded to the last STDERR_TAIL_LIMIT bytes. */
+    private stderrChunks: Buffer[] = [];
+    private stderrBytes = 0;
     private onStderr?: StderrHandler;
 
     constructor(
@@ -54,15 +75,26 @@ export class StdioClient {
         rl.on('line', (line) => this.handleLine(line));
 
         this.proc.stderr!.on('data', (data: Buffer) => {
-            const text = data.toString();
-            // Keep a rolling tail for inclusion in the exit error message.
-            this.stderrBuffer = (this.stderrBuffer + text).slice(-4096);
-            const trimmed = text.trimEnd();
+            // Keep raw bytes (not per-chunk strings) so the exit error can be
+            // decoded exactly, without splitting a multi-byte character across
+            // chunk boundaries.
+            this.stderrChunks.push(data);
+            this.stderrBytes += data.length;
+            while (
+                this.stderrChunks.length > 1 &&
+                this.stderrBytes - this.stderrChunks[0].length >= STDERR_TAIL_LIMIT
+            ) {
+                this.stderrBytes -= this.stderrChunks[0].length;
+                this.stderrChunks.shift();
+            }
+            const trimmed = decodeStderr(data).trimEnd();
             if (trimmed) this.onStderr?.(trimmed);
         });
 
         this.proc.on('exit', (code, signal) => {
-            const stderr = this.stderrBuffer.trim();
+            const stderr = decodeStderr(
+                Buffer.concat(this.stderrChunks),
+            ).trim();
             const parts = [
                 `wave --stdio process exited (code: ${code}, signal: ${signal})`,
             ];

--- a/packages/vsce/tests/stdio/stdioClient.test.ts
+++ b/packages/vsce/tests/stdio/stdioClient.test.ts
@@ -511,4 +511,45 @@ describe('StdioClient', () => {
         expect(err.message).toContain('wave --stdio process exited');
         expect(err.message).toContain('FATAL: cannot find module');
     });
+
+    // ── stderr encoding fallback (Windows GBK/CP936) ────────────
+
+    it('decodes GBK stderr into readable Chinese in exit error', async () => {
+        const { client, proc } = createClient();
+
+        // "node 不是内部或外部命令" in GBK/CP936 (Windows Chinese console).
+        const gbk = Buffer.from([
+            0x6e, 0x6f, 0x64, 0x65, 0x20, // "node "
+            0xb2, 0xbb, 0xca, 0xc7, // 不是
+            0xc4, 0xda, 0xb2, 0xbf, // 内部
+            0xbb, 0xf2, 0xcd, 0xe2, 0xb2, 0xbf, // 外部
+            0xc3, 0xfc, 0xc1, 0xee, // 命令
+        ]);
+        proc.stderr.emit('data', gbk);
+
+        const p = expectReject(client.request('method1'));
+        proc.emit('exit', 1, null);
+
+        const err = await p;
+        expect(err.message).toContain('node 不是内部或外部命令');
+        expect(err.message).not.toContain('\uFFFD');
+    });
+
+    it('forwards GBK stderr to onStderr as readable Chinese', () => {
+        const onStderr = vi.fn();
+        const { proc } = createClient([], undefined, onStderr);
+
+        proc.stderr.emit('data', Buffer.from([0xb2, 0xbb, 0xca, 0xc7])); // "不是"
+
+        expect(onStderr).toHaveBeenCalledWith('不是');
+    });
+
+    it('keeps valid UTF-8 stderr untouched', () => {
+        const onStderr = vi.fn();
+        const { proc } = createClient([], undefined, onStderr);
+
+        proc.stderr.emit('data', Buffer.from('工作目录不存在\n', 'utf-8'));
+
+        expect(onStderr).toHaveBeenCalledWith('工作目录不存在');
+    });
 });


### PR DESCRIPTION
Windows 中文系统下 cmd.exe / 原生工具向 stderr 输出 GBK(CP936) 编码，插件固定按 UTF-8 解码变成乱码(U+FFFD)，wave --stdio 启动失败的真实原因被掩盖（客户反馈 "stderr: eT???..." 无法诊断）。

改动：
- 新增 decodeStderr：UTF-8 有效时原样返回，否则 TextDecoder(gbk) 兜底
- stderr 改为累积原始 Buffer（4096 字节窗口）再解码，避免多字节字符跨 chunk 切断
- vsce 与 desktop 的 StdioClient 同步修复
- 新增 3 个测试用例（GBK exit 错误还原、GBK onStderr 转发、UTF-8 不受影响）

验证：vsce 168 测试全绿、desktop 448 全绿、type-check 全过。