### PR TITLE
fix(vsce): decode GBK output from cmd.exe builtins on Windows

### DIFF
--- a/packages/vsce/src/stdio/binaryResolver.ts
+++ b/packages/vsce/src/stdio/binaryResolver.ts
@@ -39,6 +39,25 @@ function waveCodeSpec(targetVersion?: string): string {
 let cachedPath: string | undefined;
 
 /**
+ * Decode output of cmd.exe builtins (`where`, `which`). On Chinese Windows
+ * those write the system OEM code page (CP936/GBK); decoding GBK bytes as
+ * UTF-8 corrupts non-ASCII path segments (`C:\Users\刘一奇\...` → U+FFFD),
+ * and spawning the corrupted path fails with ERROR_PATH_NOT_FOUND. Try UTF-8
+ * first (covers non-Windows and chcp 65001), fall back to GBK on U+FFFD —
+ * same policy as stdioClient.decodeStderr.
+ */
+function decodeCommandOutput(out: string | Buffer): string {
+    const buf = Buffer.isBuffer(out) ? out : Buffer.from(out);
+    const utf8 = buf.toString('utf-8');
+    if (!utf8.includes('\uFFFD')) return utf8;
+    try {
+        return new TextDecoder('gbk').decode(buf);
+    } catch {
+        return utf8;
+    }
+}
+
+/**
  * Pick the executable line from `which`/`where` output. On Windows `where`
  * lists the extensionless bash launcher first (e.g. `C:\Program Files\nodejs\npm`)
  * followed by `npm.cmd` — cmd.exe cannot execute the bash launcher, so prefer
@@ -103,7 +122,7 @@ export class NodeJsVersionError extends Error {
 function findNode(): string {
     const cmd = process.platform === 'win32' ? 'where node' : 'which node';
     try {
-        const result = execSync(cmd, { encoding: 'utf-8', stdio: 'pipe' }).trim();
+        const result = decodeCommandOutput(execSync(cmd, { encoding: 'buffer', stdio: 'pipe' })).trim();
         if (result) return result.split('\n')[0].trim();
     } catch {
         // not on PATH
@@ -136,7 +155,7 @@ function checkNodeVersion(): void {
 function findNpm(): string {
     const cmd = process.platform === 'win32' ? 'where npm' : 'which npm';
     try {
-        const result = execSync(cmd, { encoding: 'utf-8', stdio: 'pipe' }).trim();
+        const result = decodeCommandOutput(execSync(cmd, { encoding: 'buffer', stdio: 'pipe' })).trim();
         if (result) return pickExecutableLine(result);
     } catch {
         // not on PATH
@@ -158,10 +177,10 @@ function findNpm(): string {
 /** Resolve the npm global bin directory. */
 function getNpmGlobalBin(): string {
     const npm = findNpm();
-    const prefix = execSync(`"${npm}" prefix -g`, {
-        encoding: 'utf-8',
+    const prefix = decodeCommandOutput(execSync(`"${npm}" prefix -g`, {
+        encoding: 'buffer',
         stdio: 'pipe',
-    }).trim();
+    })).trim();
     return process.platform === 'win32' ? prefix : path.join(prefix, 'bin');
 }
 
@@ -192,7 +211,7 @@ export function resolveWaveBinary(onInstall?: InstallProgressCallback, targetVer
     // 1. Try PATH
     const whichCmd = process.platform === 'win32' ? 'where wave' : 'which wave';
     try {
-        const result = execSync(whichCmd, { encoding: 'utf-8', stdio: 'pipe' }).trim();
+        const result = decodeCommandOutput(execSync(whichCmd, { encoding: 'buffer', stdio: 'pipe' })).trim();
         if (result) {
             cachedPath = pickExecutableLine(result);
             return cachedPath;
@@ -238,7 +257,7 @@ export function resolveWaveBinary(onInstall?: InstallProgressCallback, targetVer
 
     // 5. Try PATH again (install may have added it)
     try {
-        const result = execSync(whichCmd, { encoding: 'utf-8', stdio: 'pipe' }).trim();
+        const result = decodeCommandOutput(execSync(whichCmd, { encoding: 'buffer', stdio: 'pipe' })).trim();
         if (result) {
             cachedPath = pickExecutableLine(result);
             return cachedPath;

--- a/packages/vsce/tests/stdio/binaryResolver.test.ts
+++ b/packages/vsce/tests/stdio/binaryResolver.test.ts
@@ -476,6 +476,43 @@ describe('binaryResolver', () => {
         });
     });
 
+    // ── Windows: cmd.exe builtins output GBK on Chinese systems ──
+    // `where` is a cmd.exe builtin — on a Chinese system its stdout is in the
+    // OEM code page (CP936/GBK), NOT UTF-8. Decoding those bytes as UTF-8
+    // corrupts non-ASCII path segments (`C:\Users\刘一奇\...` → U+FFFD
+    // garbage), and spawning the corrupted path fails with
+    // ERROR_PATH_NOT_FOUND ("系统找不到指定的路径。") — the upgrade-only
+    // regression where fresh installs worked but any upgrade failed.
+    // The resolver must decode cmd output UTF-8-first / GBK-fallback.
+
+    it('on Windows, decodes GBK-encoded Chinese username paths from where output', async () => {
+        const nodeBinWin = 'C:\\Program Files\\nodejs\\node.exe';
+        // GBK (CP936) bytes of `刘一奇` — what cmd.exe actually writes when
+        // the username contains Chinese characters.
+        const gbkUsername = Buffer.from([0xc1, 0xf5, 0xd2, 0xbb, 0xc6, 0xe6]);
+        const gbkLine = (suffix: string) =>
+            Buffer.concat([
+                Buffer.from('C:\\Users\\', 'ascii'),
+                gbkUsername,
+                Buffer.from(suffix, 'ascii'),
+            ]);
+        const whereOutput = Buffer.concat([
+            gbkLine('\\AppData\\Roaming\\npm\\wave\r\n'),
+            gbkLine('\\AppData\\Roaming\\npm\\wave.cmd\r\n'),
+        ]);
+
+        await withPlatform('win32', async () => {
+            mockExecSync.mockImplementation((cmd: string) => {
+                if (cmd.includes('where wave')) return whereOutput;
+                if (cmd.includes('where node')) return `${nodeBinWin}\n`;
+                throw new Error(`unexpected: ${cmd}`);
+            });
+
+            const result = await resolveWaveBinary();
+            expect(result).toBe('C:\\Users\\刘一奇\\AppData\\Roaming\\npm\\wave.cmd');
+        });
+    });
+
     it('on Windows, upgradeWaveBinary picks npm.cmd and quotes the space-containing path', async () => {
         const nodeBinWin = 'C:\\Program Files\\nodejs\\node.exe';
         const npmShim = 'C:\\Program Files\\nodejs\\npm';


### PR DESCRIPTION
## 背景

Windows 中文系统（用户名含中文，如 刘一奇）上，VSCE 插件在"升级 wave-code CLI"后报"初始化 sidebar 智能体失败"，错误为 `wave --stdio process exited (code: 1)`，stderr 为"系统找不到指定的路径。"（ERROR_PATH_NOT_FOUND）。全新安装正常，任何版本组合的升级都坏。

## 根因

`where` 是 cmd.exe 内建命令，中文 Windows 上输出使用系统 OEM 代码页（CP936/GBK）。binaryResolver 之前按 UTF-8 解码该输出，中文路径段（如 `C:\Users\刘一奇\...`）被损坏为 U+FFFD 乱码，spawn 乱码路径时 cmd 报 ERROR_PATH_NOT_FOUND。

升级路径必经 PATH 解析（`where wave` → GBK 乱码）；全新安装走 npm 全局 bin 拼接（Node 进程输出 UTF-8 → 路径正确），所以只有升级坏。

## 修复

新增 `decodeCommandOutput()`（UTF-8 先试，含 U+FFFD 回退 GBK 解码，与 stdioClient.decodeStderr 同策略），应用到全部 5 处 cmd 内建/npm 输出解析：
- findNode（where node）
- findNpm（where npm）
- getNpmGlobalBin（npm prefix -g）
- resolveWaveBinary PATH 分支 ×2（where wave，根因处）

## 测试

TDD：先写失败测试——mock `where wave` 返回真实 GBK 字节（刘一奇 = c1f5d2bbc6e6），断言 resolveWaveBinary 返回正确 Unicode 路径；修复后转绿。

- binaryResolver 33/33、vsce 全量 169/169、type-check 通过
- 已由用户在真实中文 Windows 环境验证通过（诊断 vsix → 复现升级场景不再报错）