### PR TITLE
fix(sdk): self-heal session workdir after manual worktree removal

### DIFF
--- a/docs/specs/multi-agent/worktree.md
+++ b/docs/specs/multi-agent/worktree.md
@@ -147,6 +147,27 @@ order: 90
 
 ---
 
+### 用户故事：手动删除 worktree 后会话自动恢复（优先级：P1）
+
+作为开发者，我希望在会话中手动执行 `git worktree remove` 删掉当前 worktree 目录后，会话的工作目录自动回退到主仓库，以便会话内需要 spawn 子进程的工具（Bash、Grep、后台任务）不会因 cwd 失效而全部 ENOENT 崩溃。
+
+**为什么是这个优先级**：手动 `git worktree remove` 绕过 wave 的退出流程（ExitWorktree 工具 / CLI 退出对话框 / stdio RPC），会话的 "Workdir" 仍指向已删除目录。Node `spawn()` 会先 chdir 到 `cwd`，cwd 不存在直接抛 ENOENT——Bash（`spawn /bin/bash ENOENT`）、Grep（`spawn rg ENOENT`）、后台任务全部失效，而 Read/Write/Glob 正常，会话直接残废。Claude Code 的处理是 Shell.ts 在 spawn 前对 cwd 做 `realpath()` 检查并回退到 originalCwd，但其 originalCwd 在 worktree 会话中期就是 worktree 路径本身，回退同样失败，只能给出"目录不存在，请重启"的干净报错；wave 的 `getOriginalWorkdir()` 稳定指向主仓库（进入 worktree 时不改写），可以真正自动回退，比 Claude Code 更彻底。
+
+**独立测试**：进入 EnterWorktree 会话，在会话内用 Bash 执行 `git worktree remove --force <name>` 删除当前 worktree 目录，再执行任意 Bash/Grep 命令，验证命令正常执行、工作目录已回退到主仓库、工具结果包含回退提示；再调用 ExitWorktree，验证返回无操作消息（不报错）。
+
+**验收场景**：
+
+1. **假设** 会话在 EnterWorktree 创建的 worktree 中，**当** 用户在会话内手动执行 `git worktree remove --force` 删除当前 worktree 目录，**则** 下一次工具调用构建上下文时检测到会话 cwd 失效，自动回退到主仓库（原始 cwd），不再指向已删除目录。
+2. **假设** 回退已发生，**当** 会话内继续执行 Bash / Grep / 后台任务等需要 spawn 子进程的工具时，**则** 工具正常执行，不再出现 `spawn /bin/bash ENOENT` 或 `spawn rg ENOENT`。
+3. **假设** 回退已发生，**当** 下一个 spawn 工具执行时，**则** 工具结果开头包含提示："Note: working directory `<已删除路径>` no longer exists; session working directory recovered to `<主仓库路径>`"（该提示仅出现一次）。
+4. **假设** 回退已发生，**当** AI 调用 ExitWorktree 工具时，**则** 返回无操作消息（会话的 worktree 状态已随回退清除），不进行任何文件系统更改、不报错。
+5. **假设** 回退已发生，**当** AI 调用 EnterWorktree 工具时，**则** 能正常创建新的 worktree 会话（旧会话状态已清除，不会被误拒为"已在 worktree 会话中"）。
+6. **假设** 会话原始工作目录（主仓库）本身也不存在（极端场景），**当** 检测到当前 cwd 失效时，**则** 不进行回退，保持原值（没有有效的回退目标）。
+7. **假设** 原始工作目录是有效的主仓库，**当** 检测到当前 cwd 失效并回退时，**则** 日志记录 warn 级 "Working directory ... no longer exists; recovered session workdir to ..."，且宿主（CLI/webview）通过 workdirChange 通知更新会话工作目录显示。
+8. **假设** 用户在会话内手动删除 worktree 目录，**当** 删除发生时，**则** WorktreeRemove hook 不补触发——hook 契约要求目录仍存在（git 移除**之前**）以便 hook 读取目录内文件定位外部资源，且触发时机落在任意下一次工具调用对用户是意外副作用；与 Claude Code 行为一致（CC 也不检测手动删除、不补触发 hook）。用户通过工具提示获知目录已失效并完成回退。
+
+---
+
 ### 用户故事：stdio 多 Agent 并发下的 Worktree 会话隔离（优先级：P1）
 
 作为通过 stdio 后端同时运行多个会话的用户（例如 VS Code 侧边栏 + 多个编辑器标签页 / 多个窗口，或 JetBrains 插件），我希望一个会话进入 worktree 不会影响其它并发会话的工作目录、worktree 状态或工具执行，以便每个会话彼此隔离、互不干扰。
@@ -203,6 +224,7 @@ order: 90
 - **如果用户不在 git 仓库中怎么办？** `-w` 标志应失败并显示错误消息。
 - **当 WorktreeRemove hook 失败或超时时会发生什么？** 非阻塞：stderr 以错误块显示给用户，worktree 删除照常进行。
 - **当 stdio RPC 传入的 worktree 路径为符号链接或逃逸 repo root 时会发生什么？** 删除被拒绝并返回 RPC 错误，hook 不触发。
+- **当用户在会话内手动 `git worktree remove` 删除当前 worktree 目录时会发生什么？** 会话工作目录在下一次工具调用时自动回退到主仓库（原始 cwd），spawn 工具恢复可用，工具结果包含一次性回退提示；WorktreeRemove hook 不补触发（与 Claude Code 一致，hook 契约要求目录在 git 移除前仍可读）。
 
 ## 假设
 
@@ -213,4 +235,5 @@ order: 90
 - WorktreeRemove 是通知型钩子（Notification）：无决策控制，永不替代 `git worktree remove --force` + `git branch -D`。
 - WorktreeRemove hook 的 JSON 输入仅包含官方字段（`session_id`、`transcript_path`、`cwd`、`hook_event_name`、`worktree_path`），worktree 名称由 hook 通过 `basename "$worktree_path"` 派生。
 - 删除后台会话（stdio RPC）的 worktree 前会校验路径：拒绝符号链接或解析后位于 repo root 之外的路径。
+- 手动删除当前 worktree 目录不触发 WorktreeRemove hook（与 Claude Code 一致）；会话通过 cwd 失效检测 + 自动回退到主仓库 + 一次性工具提示恢复，回退时清除已失效的 worktree 会话状态。
 

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -11,6 +11,7 @@ import {
   TASK_REMINDER_CONFIG,
 } from "../utils/taskReminder.js";
 import { existsSync } from "node:fs";
+import * as path from "node:path";
 import type {
   GatewayConfig,
   ModelConfig,
@@ -149,6 +150,8 @@ export class AIManager {
   private modelOverride?: string;
   private _onCwdChange?: (newCwd: string) => void; // Store callback for CWD changes
   private originalWorkdir: string;
+  /** Pending cwd-recovery notice (set when getWorkdir() auto-recovers), consumed by tools */
+  private pendingCwdRecovery: { from: string; to: string } | null = null;
   private consecutiveCompactionFailures: number = 0;
   private readonly maxTurns?: number;
   /** Tracks file mtime/hash at read time for staleness detection on Edit/Write */
@@ -299,7 +302,55 @@ export class AIManager {
   }
 
   public getWorkdir(): string {
-    return this.container.get<string>("Workdir") ?? process.cwd();
+    const workdir = this.container.get<string>("Workdir") ?? process.cwd();
+    if (existsSync(workdir)) {
+      return workdir;
+    }
+
+    // The stored workdir no longer exists — e.g. the current worktree
+    // directory was removed manually with `git worktree remove` outside
+    // wave's exit flow. Node spawn() chdirs to `cwd` before spawning, so
+    // every tool that spawns a subprocess (Bash, Grep, background tasks)
+    // would fail with ENOENT and cripple the session. Recover to the
+    // original workdir (main repo) so the session keeps working.
+    if (!existsSync(this.originalWorkdir)) {
+      // No valid fallback — keep the stale value (sessions started in a
+      // directory that was deleted since cannot recover to anything real).
+      return workdir;
+    }
+
+    this.pendingCwdRecovery = { from: workdir, to: this.originalWorkdir };
+
+    // If the removed directory was this session's worktree, drop the stale
+    // worktree session state so ExitWorktree no-ops and EnterWorktree can
+    // start a fresh session.
+    const worktreeSession = this.getWorktreeSession();
+    if (
+      worktreeSession &&
+      path.resolve(worktreeSession.worktreePath) === path.resolve(workdir)
+    ) {
+      this.setWorktreeSession(null);
+    }
+
+    logger.warn(
+      `Working directory ${workdir} no longer exists; recovered session workdir to ${this.originalWorkdir}`,
+    );
+
+    this.container.register("Workdir", this.originalWorkdir);
+    this._onCwdChange?.(this.originalWorkdir);
+    return this.originalWorkdir;
+  }
+
+  /**
+   * Consume a pending cwd-recovery notice (if any). After the session
+   * workdir was auto-recovered because the previous directory disappeared,
+   * the first tool that calls this surfaces the notice to the model.
+   * Returns null when no recovery is pending.
+   */
+  public consumeCwdRecovery(): { from: string; to: string } | null {
+    const recovery = this.pendingCwdRecovery;
+    this.pendingCwdRecovery = null;
+    return recovery;
   }
 
   public getOriginalWorkdir(): string {

--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -173,6 +173,14 @@ The working directory persists between commands. Try to maintain your current wo
       };
     }
 
+    // If the session cwd was auto-recovered (e.g. the previous worktree
+    // directory was removed manually via `git worktree remove`), surface
+    // the notice in this tool's result so the model is aware of the switch.
+    const cwdRecovery = context.aiManager?.consumeCwdRecovery?.();
+    const recoveryNotice = cwdRecovery
+      ? `Note: working directory ${cwdRecovery.from} no longer exists; session working directory recovered to ${cwdRecovery.to}.\n`
+      : "";
+
     // Resolve shell path: on Windows, use Git Bash; on macOS/Linux, use bash or zsh
     const shellPath = resolveShellPath();
     if (!shellPath) {
@@ -260,7 +268,7 @@ The working directory persists between commands. Try to maintain your current wo
       ].join("\n");
       return {
         success: true,
-        content: backgroundMsg,
+        content: recoveryNotice + backgroundMsg,
         shortResult: `Background process ${taskId} started${outputPath ? ` → ${outputPath}` : ""}`,
       };
     }
@@ -471,9 +479,11 @@ The working directory persists between commands. Try to maintain your current wo
           );
           resolve({
             success: false,
-            content: processedOutput
-              ? `${processedOutput}\n\n${reason}`
-              : reason,
+            content: recoveryNotice
+              ? recoveryNotice + (processedOutput || reason)
+              : processedOutput
+                ? `${processedOutput}\n\n${reason}`
+                : reason,
             error: reason,
           });
         }
@@ -559,6 +569,7 @@ The working directory persists between commands. Try to maintain your current wo
 
           // Prepend CWD change message to output if present
           const finalOutput =
+            recoveryNotice +
             (cwdMessage ? cwdMessage + "\n" : "") +
             (combinedOutput || `Command executed with exit code: ${exitCode}`);
           const content = processToolResult(
@@ -601,7 +612,8 @@ The working directory persists between commands. Try to maintain your current wo
           resolve({
             success: false,
             content: "",
-            error: `Failed to execute command: ${error.message}`,
+            error:
+              `${recoveryNotice}Failed to execute command: ${error.message}`.trim(),
           });
         }
       });

--- a/packages/agent-sdk/src/tools/grepTool.ts
+++ b/packages/agent-sdk/src/tools/grepTool.ts
@@ -157,6 +157,14 @@ export const grepTool: ToolPlugin = {
 
     try {
       const workdir = context.workdir;
+
+      // If the session cwd was auto-recovered (e.g. the previous worktree
+      // directory was removed manually via `git worktree remove`), surface
+      // the notice in this tool's result so the model is aware of the switch.
+      const cwdRecovery = context.aiManager?.consumeCwdRecovery?.();
+      const recoveryNotice = cwdRecovery
+        ? `Note: working directory ${cwdRecovery.from} no longer exists; session working directory recovered to ${cwdRecovery.to}.\n`
+        : "";
       const rgArgs: string[] = [
         "--color=never",
         "--max-columns=500",
@@ -243,7 +251,7 @@ export const grepTool: ToolPlugin = {
         return {
           success: false,
           content: "",
-          error: `ripgrep failed: ${result.stderr}`,
+          error: `${recoveryNotice}ripgrep failed: ${result.stderr}`.trim(),
         };
       }
 
@@ -258,6 +266,7 @@ export const grepTool: ToolPlugin = {
         return {
           success: true,
           content:
+            recoveryNotice +
             "No matches found. Suggestion: specify the 'path' field to search in ignored or other directories (e.g., 'node_modules'), as the default search path is the current working directory and respects .gitignore.",
           shortResult: "No matches found",
           metadata: {
@@ -303,7 +312,7 @@ export const grepTool: ToolPlugin = {
 
       return {
         success: true,
-        content: finalOutput,
+        content: recoveryNotice + finalOutput,
         shortResult,
         metadata: {
           numMatches: totalMatches,

--- a/packages/agent-sdk/tests/managers/aiManager.workdirRecovery.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.workdirRecovery.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AIManager } from "../../src/managers/aiManager.js";
+import { Container } from "../../src/utils/container.js";
+import type { WorktreeSession } from "../../src/utils/worktreeSession.js";
+
+// Mock node:fs so tests control directory existence without touching the filesystem
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(() => false),
+}));
+
+import * as fs from "node:fs";
+
+const existsSyncMock = vi.mocked(fs.existsSync);
+
+/**
+ * User Story — 手动删除 worktree 后会话自动恢复.
+ *
+ * When the session's workdir is deleted behind wave's back (manual
+ * `git worktree remove`), getWorkdir() must auto-recover to the original
+ * workdir so spawn-based tools (Bash/Grep/background tasks) stop failing
+ * with ENOENT.
+ */
+const worktreeSession: WorktreeSession = {
+  originalCwd: "/repo",
+  worktreePath: "/repo/.wave/worktrees/feat-a",
+  worktreeBranch: "wave-feat-a",
+  worktreeName: "feat-a",
+  isNew: true,
+  repoRoot: "/repo",
+};
+
+function createManager(
+  workdir: string,
+  originalWorkdir: string = "/repo",
+): AIManager {
+  const container = new Container();
+  container.register("Workdir", workdir);
+  container.register<WorktreeSession | null>("WorktreeSession", null);
+  // Real scenario: the Agent is created in the main repo; EnterWorktree only
+  // changes the container "Workdir" to the worktree path, originalWorkdir
+  // stays at the main repo root.
+  return new AIManager(container, { workdir: originalWorkdir });
+}
+
+describe("AIManager workdir auto-recovery (manual worktree removal)", () => {
+  beforeEach(() => {
+    existsSyncMock.mockReset();
+    existsSyncMock.mockReturnValue(false); // default: nothing exists
+  });
+
+  it("recovers to the original workdir when the stored workdir is gone and the original exists", () => {
+    const manager = createManager("/repo/.wave/worktrees/feat-a");
+    existsSyncMock.mockImplementation((p) => p === "/repo");
+
+    expect(manager.getWorkdir()).toBe("/repo");
+  });
+
+  it("consumeCwdRecovery returns the notice exactly once", () => {
+    const manager = createManager("/repo/.wave/worktrees/feat-a");
+    existsSyncMock.mockImplementation((p) => p === "/repo");
+
+    manager.getWorkdir();
+    expect(manager.consumeCwdRecovery()).toEqual({
+      from: "/repo/.wave/worktrees/feat-a",
+      to: "/repo",
+    });
+    expect(manager.consumeCwdRecovery()).toBeNull();
+  });
+
+  it("clears the stale worktree session when the removed dir is the session's worktree", () => {
+    const container = new Container();
+    container.register("Workdir", "/repo/.wave/worktrees/feat-a");
+    container.register("WorktreeSession", worktreeSession);
+    const manager = new AIManager(container, { workdir: "/repo" });
+    existsSyncMock.mockImplementation((p) => p === "/repo");
+
+    manager.getWorkdir();
+    expect(manager.getWorkdir()).toBe("/repo");
+    expect(manager.getWorktreeSession()).toBeNull();
+  });
+
+  it("keeps the worktree session when the missing dir is not the session's worktree", () => {
+    const container = new Container();
+    container.register("Workdir", "/repo/.wave/worktrees/other");
+    container.register("WorktreeSession", worktreeSession);
+    const manager = new AIManager(container, { workdir: "/repo" });
+    existsSyncMock.mockImplementation((p) => p === "/repo");
+
+    manager.getWorkdir();
+    expect(manager.getWorktreeSession()).toEqual(worktreeSession);
+  });
+
+  it("keeps the stale value when the original workdir is also missing", () => {
+    const manager = createManager("/repo/.wave/worktrees/feat-a");
+
+    expect(manager.getWorkdir()).toBe("/repo/.wave/worktrees/feat-a");
+    expect(manager.consumeCwdRecovery()).toBeNull();
+  });
+
+  it("does not recover when the stored workdir still exists", () => {
+    const manager = createManager("/repo/.wave/worktrees/feat-a");
+    existsSyncMock.mockReturnValue(true);
+
+    expect(manager.getWorkdir()).toBe("/repo/.wave/worktrees/feat-a");
+    expect(manager.consumeCwdRecovery()).toBeNull();
+  });
+
+  it("notifies the host via onCwdChange exactly once and stays stable on subsequent calls", () => {
+    const manager = createManager("/repo/.wave/worktrees/feat-a");
+    existsSyncMock.mockImplementation((p) => p === "/repo");
+    const calls: string[] = [];
+    manager.setOnCwdChange((cwd) => calls.push(cwd));
+
+    expect(manager.getWorkdir()).toBe("/repo");
+    expect(manager.getWorkdir()).toBe("/repo");
+
+    // Host notified once (first call recovered; later calls short-circuit).
+    expect(calls).toEqual(["/repo"]);
+  });
+
+  it("is safe without a registered onCwdChange callback", () => {
+    const manager = createManager("/repo/.wave/worktrees/feat-a");
+    existsSyncMock.mockImplementation((p) => p === "/repo");
+
+    expect(() => manager.getWorkdir()).not.toThrow();
+    expect(manager.getWorkdir()).toBe("/repo");
+  });
+});

--- a/packages/agent-sdk/tests/tools/bashTool.test.ts
+++ b/packages/agent-sdk/tests/tools/bashTool.test.ts
@@ -130,6 +130,78 @@ describe("bashTool", () => {
       });
     });
 
+    it("prepends the cwd recovery notice when the session cwd was auto-recovered", async () => {
+      const mockProcess = {
+        pid: 1234,
+        stdout: {
+          on: vi.fn((event, callback) => {
+            if (event === "data") {
+              setTimeout(() => callback(Buffer.from("test output")), 10);
+            }
+          }),
+        },
+        stderr: {
+          on: vi.fn(),
+        },
+        on: vi.fn((event, callback) => {
+          if (event === "exit") {
+            setTimeout(() => callback(0), 20);
+          }
+        }),
+        kill: vi.fn(),
+        killed: false,
+      };
+      mockSpawn.mockReturnValue(mockProcess as unknown as ChildProcess);
+
+      // Session workdir was deleted behind wave's back (manual git worktree remove)
+      context.aiManager = {
+        consumeCwdRecovery: vi.fn().mockReturnValue({
+          from: "/repo/.wave/worktrees/feat-a",
+          to: "/repo",
+        }),
+      } as unknown as ToolContext["aiManager"];
+
+      const result = await bashTool.execute({ command: "echo hello" }, context);
+
+      expect(result.success).toBe(true);
+      expect(result.content).toBe(
+        "Note: working directory /repo/.wave/worktrees/feat-a no longer exists; session working directory recovered to /repo.\ntest output",
+      );
+    });
+
+    it("omits the notice when there is no pending cwd recovery", async () => {
+      const mockProcess = {
+        pid: 1234,
+        stdout: {
+          on: vi.fn((event, callback) => {
+            if (event === "data") {
+              setTimeout(() => callback(Buffer.from("test output")), 10);
+            }
+          }),
+        },
+        stderr: {
+          on: vi.fn(),
+        },
+        on: vi.fn((event, callback) => {
+          if (event === "exit") {
+            setTimeout(() => callback(0), 20);
+          }
+        }),
+        kill: vi.fn(),
+        killed: false,
+      };
+      mockSpawn.mockReturnValue(mockProcess as unknown as ChildProcess);
+
+      context.aiManager = {
+        consumeCwdRecovery: vi.fn().mockReturnValue(null),
+      } as unknown as ToolContext["aiManager"];
+
+      const result = await bashTool.execute({ command: "echo hello" }, context);
+
+      expect(result.success).toBe(true);
+      expect(result.content).toBe("test output");
+    });
+
     it("should handle background execution", async () => {
       const mockProcess = {
         pid: 1234,

--- a/packages/agent-sdk/tests/tools/grepTool.test.ts
+++ b/packages/agent-sdk/tests/tools/grepTool.test.ts
@@ -191,6 +191,45 @@ src/utils.ts:1:export const logger = {};
     expect(result.content).toContain("export const logger");
   });
 
+  it("prepends the cwd recovery notice when the session cwd was auto-recovered", async () => {
+    const stdout = "src/index.ts:1:export const app = 'main';\n";
+    mockSpawn.mockReturnValueOnce(createMockProcess(stdout) as ChildProcess);
+
+    const context: ToolContext = {
+      ...testContext,
+      aiManager: {
+        consumeCwdRecovery: vi.fn().mockReturnValue({
+          from: "/repo/.wave/worktrees/feat-a",
+          to: "/repo",
+        }),
+      } as unknown as ToolContext["aiManager"],
+    };
+
+    const result = await grepTool.execute({ pattern: "export const" }, context);
+
+    expect(result.success).toBe(true);
+    expect(result.content).toBe(
+      "Note: working directory /repo/.wave/worktrees/feat-a no longer exists; session working directory recovered to /repo.\nsrc/index.ts:1:export const app = 'main';",
+    );
+  });
+
+  it("omits the notice when there is no pending cwd recovery", async () => {
+    const stdout = "src/index.ts:1:export const app = 'main';\n";
+    mockSpawn.mockReturnValueOnce(createMockProcess(stdout) as ChildProcess);
+
+    const context: ToolContext = {
+      ...testContext,
+      aiManager: {
+        consumeCwdRecovery: vi.fn().mockReturnValue(null),
+      } as unknown as ToolContext["aiManager"],
+    };
+
+    const result = await grepTool.execute({ pattern: "export const" }, context);
+
+    expect(result.success).toBe(true);
+    expect(result.content).toBe("src/index.ts:1:export const app = 'main';");
+  });
+
   it("should show match counts (count mode)", async () => {
     const stdout = `src/index.ts:2
 src/utils.ts:3


### PR DESCRIPTION
## Summary

Fix a wave CLI bug: in a session entered via EnterWorktree, if the user manually runs `git worktree remove` inside the session (bypassing wave's exit flow), the session's cwd becomes an invalid path. Every tool that spawns a subprocess (Bash `spawn /bin/bash ENOENT`, Grep `spawn rg ENOENT`, background tasks) then fails — Node spawn chdirs to the `cwd` option first, and a nonexistent cwd throws ENOENT. Read/Write/Glob keep working, so the session is silently crippled.

## Fix

- **aiManager `getWorkdir()` self-healing**: detects the stored workdir no longer exists and auto-recovers to the original workdir (main repo). Also clears the stale worktree session state (so ExitWorktree no-ops, EnterWorktree can start fresh), logs a warning, and fires `onCwdChange` to update the host UI. One central change covers Bash/Grep/background tasks/subagents/permission/skill/cron — all read "Workdir" from the per-session container via `context.workdir` (built at aiManager.ts:2204).
- **One-time recovery notice** (`consumeCwdRecovery()` consumed by bashTool/grepTool): tool results surface `Note: working directory <path> no longer exists; session working directory recovered to <path>` once, so the model is aware of the switch.
- **WorktreeRemove hook NOT re-triggered** on manual removal — matches Claude Code (CC does not detect manual removal either); the hook contract requires the directory to still be readable before git removal. Documented in spec scenario 8.

## Tests

- New `tests/managers/aiManager.workdirRecovery.test.ts` (8 tests, mocked `node:fs`)
- 2 tests each in `bashTool.test.ts` / `grepTool.test.ts` (recovery-notice prepend + no-notice)

Verification: 3410 agent-sdk tests pass (1 skipped), `tsc --noEmit` clean, spec-count validation OK (worktree.md: 12 user stories / 51 scenarios).

## Spec

`docs/specs/multi-agent/worktree.md` — new user story "手动删除 worktree 后会话自动恢复（P1）" with 8 acceptance scenarios + boundary cases.