### PR TITLE
feat(sdk): remove accumulated from streaming callbacks, pure chunk deltas

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -194,7 +194,7 @@ Agent 支持多种消息块类型，通过回调通知 UI 层：
 
 | 类型 | 回调 | 说明 |
 |------|------|------|
-| 文本内容 | `onAssistantContentUpdated` | AI 文本流式输出，含 `chunk`、`accumulated`、`stage` |
+| 文本内容 | `onAssistantContentUpdated` | AI 文本流式输出，含 `chunk`、`stage`（chunk 为增量片段，消费端自行累积） |
 | 推理内容 | `onAssistantReasoningUpdated` | 推理/思考过程流式输出 |
 | 工具调用 | `onToolBlockUpdated` | 工具执行状态更新 |
 | 压缩摘要 | `onCompactBlockAdded` | 上下文压缩后生成的摘要 |
@@ -209,13 +209,14 @@ Agent 支持多种消息块类型，通过回调通知 UI 层：
 ```typescript
 callbacks: {
   // 文本流式输出
-  onAssistantContentUpdated: ({ messageId, chunk, accumulated, stage }) => {
-    // stage: "streaming" | "end"
+  onAssistantContentUpdated: ({ messageId, chunk, stage }) => {
+    // chunk: 增量片段（自上次回调以来的新内容）；stage: "streaming" | "end"
+    // 注意：回调不再提供 accumulated，需自行追加累积
     process.stdout.write(chunk);
   },
   // 推理过程流式输出
-  onAssistantReasoningUpdated: ({ messageId, chunk, accumulated, stage }) => {
-    // 推理内容（thinking/reasoning）
+  onAssistantReasoningUpdated: ({ messageId, chunk, stage }) => {
+    // 推理内容（thinking/reasoning），chunk 同样为增量片段
   },
 }
 ```
@@ -235,8 +236,8 @@ callbacks: {
 | `onUsagesChange` | `Usage[]` | Token 使用记录更新 |
 | `onUserMessageAdded` | `UserMessageParams` | 用户消息添加 |
 | `onAssistantMessageAdded` | `messageId: string` | AI 消息创建 |
-| `onAssistantContentUpdated` | `{ messageId, chunk, accumulated, stage }` | 文本流式输出 |
-| `onAssistantReasoningUpdated` | `{ messageId, chunk, accumulated, stage }` | 推理流式输出 |
+| `onAssistantContentUpdated` | `{ messageId, chunk, stage }` | 文本流式输出（chunk 为增量片段） |
+| `onAssistantReasoningUpdated` | `{ messageId, chunk, stage }` | 推理流式输出（chunk 为增量片段） |
 | `onToolBlockUpdated` | `ToolBlockUpdateCallbackParams` | 工具块更新 |
 | `onErrorBlockAdded` | `error: string` | 错误块添加 |
 | `onCompactBlockAdded` | `content: string` | 压缩摘要添加 |
@@ -263,7 +264,7 @@ callbacks: {
 |------|------|------|
 | `onSubagentUserMessageAdded` | `subagentId, params` | 子代理收到用户消息 |
 | `onSubagentAssistantMessageAdded` | `subagentId, messageId` | 子代理创建 AI 消息 |
-| `onSubagentAssistantContentUpdated` | `{ subagentId, messageId, chunk, accumulated, stage }` | 子代理流式输出 |
+| `onSubagentAssistantContentUpdated` | `{ subagentId, messageId, chunk, stage }` | 子代理流式输出（chunk 为增量片段） |
 | `onSubagentLatestTotalTokensChange` | `subagentId, tokens` | 子代理 Token 更新 |
 
 ### MCP 回调 {#callbacks-mcp}

--- a/docs/specs/core/stream-content-updates.md
+++ b/docs/specs/core/stream-content-updates.md
@@ -114,7 +114,7 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 
 作为 CLI 或 IDE 插件的使用者，我希望在积累了大量消息的会话中，助手流式输出时界面依然即时、平滑地更新，以便消息越多时交互越不卡顿。
 
-**为什么是这个优先级**：当前每次流式 chunk 都会触发 `onMessagesChange` 全量回调，CLI 侧随之全量 `setMessages`、插件宿主经 stdio 全量下发消息列表，序列化与传输成本随会话长度线性增长，是长会话流式卡顿的主要来源；且它与增量回调在时间上重复（同一 chunk 同时触发 `onAssistantContentUpdated` 与 `onMessagesChange`），造成数据冗余与竞态。为此移除 `onMessagesChange`，使流式更新全链路走增量通道；bang 信号携带 `messageId` 支持增量定位，完整消息列表仅在"拉取"场景（初始化、compact、rewind、clear、restore）传输。进一步地，跨进程（stdio）增量通知的负载从"chunk + accumulated 并存"收敛为"纯 chunk delta"（tool block streaming 只携带 `parametersChunk`），使单个通知的序列化成本与已流式内容总长度解耦，从根源消除传输层随流式累积的内存/带宽压力；进程内消费者（CLI、print-cli）不经 wire，继续直接使用 SDK 回调中的 accumulated（详见下方"状态管理架构"与 2026-08-04 会议记录）。
+**为什么是这个优先级**：当前每次流式 chunk 都会触发 `onMessagesChange` 全量回调，CLI 侧随之全量 `setMessages`、插件宿主经 stdio 全量下发消息列表，序列化与传输成本随会话长度线性增长，是长会话流式卡顿的主要来源；且它与增量回调在时间上重复（同一 chunk 同时触发 `onAssistantContentUpdated` 与 `onMessagesChange`），造成数据冗余与竞态。为此移除 `onMessagesChange`，使流式更新全链路走增量通道；bang 信号携带 `messageId` 支持增量定位，完整消息列表仅在"拉取"场景（初始化、compact、rewind、clear、restore）传输。进一步地，增量负载从"chunk + accumulated 并存"收敛为"纯 chunk delta"（tool block streaming 只携带 `parametersChunk`），SDK 回调与跨进程（stdio）通知统一不再携带 `accumulated`，使单个通知的序列化成本与已流式内容总长度解耦，从根源消除传输层随流式累积的内存/带宽压力；进程内消费者（CLI、print-cli）改为消费纯 chunk 并自行累积追加（详见下方"状态管理架构"与 2026-08-08 会议记录）。
 
 **独立测试**：构造一个包含数百条消息的长会话并发送一条消息触发流式响应：CLI 消息内容增量就地更新、无整屏刷新闪烁；插件侧记录 CLI stdout，流式期间只出现增量通知、无全量消息推送。执行 `!` bang 命令后消息列表正确显示命令输出。
 
@@ -126,7 +126,7 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 4. **假设**CLI 收到 bang 信号（`onAddBangMessage(command, messageId)`/`onUpdateBangMessage(command, output, messageId)`/`onCompleteBangMessage(command, exitCode, messageId)`，携带 messageId），**当**需要渲染命令消息时，**则**按 messageId 就地创建/更新 bang 消息块，无需读取 `agent.messages`
 5. **假设**插件 webview 需要完整会话（webviewReady / compact / rewind / clearChat / restoreSession），**当**触发上述任一场景时，**则**宿主主动调用 `getMessages` 请求拉取并下发全量渲染，而非订阅持续的全量推送
 6. **假设**子代理（subagent）运行中，**当**其消息变更时，**则** `SubagentManager` 通过 `instance.messageManager.getMessages()` 拉取最新列表维护 `instance.messages` 与 `usedTools`，并继续转发 `onSubagentMessagesChange`，不再依赖子代理的 `onMessagesChange`
-7. **假设**助手响应正在经 stdio 跨进程流式传输，**当**每个内容/推理 chunk 到达时，**则**增量通知只携带 `chunk`（增量片段），不再携带 `accumulated` 累积值；SDK 侧回调仍同时提供 chunk 与 accumulated 供进程内消费者使用，剥离仅发生在跨进程 wire 层（agentBridge）
+7. **假设**助手响应正在流式传输，**当**每个内容/推理 chunk 到达时，**则**增量回调与 stdio 增量通知都只携带 `chunk`（增量片段）+ `messageId` + `stage`，不再携带 `accumulated` 累积值；进程内消费者（CLI、print-cli）与跨进程宿主（agentBridge）统一消费纯 chunk，自行累积追加
 8. **假设**工具参数正在经 stdio 流式传输，**当** `stage="streaming"` 通知到达时，**则**只携带 `parametersChunk`（增量），不再携带累积 `parameters`；**当** `stage="end"` 通知到达时，**则**携带全量 `parameters` + `result` 作为一次性权威值
 9. **假设**宿主（VSCE/桌面/CLI）对增量通知做了节流（如 16ms/500ms 窗口），**当**窗口内累积了多个 chunk 时，**则**按到达顺序将窗口内所有 chunks 拼接为一个合并 delta 发送，而非 last-value-wins 丢弃中间值——丢弃中间 chunk 会造成内容永久缺失，只能由后续 `getMessages` 拉取自愈
 10. **假设**webview 正在追加流式 delta，**当**触发 `getMessages` 拉取全量列表时，**则**全量响应整体替换消息块为权威快照，随后到达的 delta 继续追加；管道 FIFO 保证拉取响应包含其之前发出的所有 chunk，不发生重复或错乱
@@ -148,10 +148,10 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 
 - **Agent SDK 职责**：在内部管理所有消息状态并更新消息；变更通过增量回调（`onUserMessageAdded`、`onAssistantMessageAdded`、`onAssistantContentUpdated`、`onAssistantReasoningUpdated`、`onToolBlockUpdated`、`onErrorBlockAdded` 等）对外发布；完整列表通过 `agent.messages` getter（同进程）或 `getMessages` 请求（stdio 跨进程）按需获取。`onMessagesChange` 全量回调已移除
 - **增量回调用途**：为第三方集成、扩展、CLI 与示例（如 `packages/code/src/print-cli.ts` 和 `packages/agent-sdk/examples`）提供实时流式数据；增量回调是消息状态同步的唯一推送通道
-- **SDK 回调负载**：`onAssistantContentUpdated`/`onAssistantReasoningUpdated` 始终同时提供 `chunk`（增量）与 `accumulated`（累积）两个字段，进程内消费者免费使用 `accumulated` 就地替换；`onToolBlockUpdated` 提供 `parametersChunk`（增量）与 `parameters`（累积）并存
-- **跨进程 wire 负载（纯 delta）**：agentBridge 在转发 stdio 通知时剥离累积字段——`assistantContentUpdated`/`assistantReasoningUpdated` 只携带 `{messageId, chunk, stage}`；`toolBlockUpdated` 在 `stage="streaming"` 时只携带 `parametersChunk`，`stage="end"` 时携带全量 `parameters` + `result` 作为权威值。消费端负责累积（追加），丢失的 delta 由 `getMessages` 拉取的全量快照自愈
-- **UI 状态流**：CLI 直接订阅增量回调就地更新消息（accumulated 替换 + 500ms 节流）；插件/桌面经 stdio 增量通知（`userMessageAdded`、`assistantContentUpdated`、`toolBlockUpdated` 等，纯 delta 负载）驱动 webview 增量 reducer——文本/推理块追加 chunk、工具块追加 `parametersChunk`，end 时以权威值终结；需要完整列表的场景（初始化、compact、rewind、clear、bang）主动拉取，拉取响应整体替换为权威快照
-- **节流语义**：节流器对 delta 负载必须按到达顺序拼接窗口内所有 chunks 为一个合并 delta（window-concat），绝不能 last-value-wins 丢弃中间值；对 accumulated 负载（CLI 进程内）last-value-wins 仍然正确。为配合该语义，SDK 必须在每次 running 事件中重复携带 `compactParams` 等稳定展示字段（见"工具块阶段更新"验收场景 4），保证丢弃中间事件不丢失这些字段
+- **SDK 回调负载**：`onAssistantContentUpdated`/`onAssistantReasoningUpdated` 只提供 `chunk`（增量）+ `messageId` + `stage`，不再携带 `accumulated` 累积值，进程内消费者（CLI、print-cli）自行累积追加；`onToolBlockUpdated` 提供 `parametersChunk`（增量）与 `parameters`（累积）并存
+- **跨进程 wire 负载（纯 delta）**：agentBridge 原样透传增量回调负载——`assistantContentUpdated`/`assistantReasoningUpdated` 只携带 `{messageId, chunk, stage}`（SDK 回调本身已无累积字段，无需剥离）；`toolBlockUpdated` 在 `stage="streaming"` 时只携带 `parametersChunk`，`stage="end"` 时携带全量 `parameters` + `result` 作为权威值。消费端负责累积（追加），丢失的 delta 由 `getMessages` 拉取的全量快照自愈
+- **UI 状态流**：CLI 直接订阅增量回调就地更新消息（chunk 追加 + 500ms 窗口拼接节流）；插件/桌面经 stdio 增量通知（`userMessageAdded`、`assistantContentUpdated`、`toolBlockUpdated` 等，纯 delta 负载）驱动 webview 增量 reducer——文本/推理块追加 chunk、工具块追加 `parametersChunk`，end 时以权威值终结；需要完整列表的场景（初始化、compact、rewind、clear、bang）主动拉取，拉取响应整体替换为权威快照
+- **节流语义**：SDK 回调与 wire 通知均只携带纯 delta，节流器一律按到达顺序拼接窗口内所有 chunks 为一个合并 delta（window-concat），绝不能 last-value-wins 丢弃中间值。为配合该语义，SDK 必须在每次 running 事件中重复携带 `compactParams` 等稳定展示字段（见"工具块阶段更新"验收场景 4），保证丢弃中间事件不丢失这些字段
 - **清晰分离**：增量回调是消息状态管理的正式对外通道；全量数据按需获取，避免随每次流式 chunk 序列化整个列表
 
 ## 澄清
@@ -195,13 +195,20 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 ### 2026-08-04 会议（流式通知纯增量负载）
 
 - 问：为什么从"chunk + accumulated 并存"收敛为纯 delta → 答：节流只能减少通知条数，每个通知仍携带与已流式内容等长的累积 payload，总序列化/传输成本 O(n²)，长流时 stdio 内存与带宽压力持续存在；改为 wire 纯 delta 后通知负载与内容总长度解耦，总成本 O(n)
-- 问：SDK 回调签名是否改变 → 答：不改。SDK 回调继续同时提供 chunk 与 accumulated（进程内消费者免费使用 accumulated）；剥离只发生在跨进程 wire 层（agentBridge），CLI/print-cli 进程内路径完全不动
+- 问：SDK 回调签名是否改变 → 答：不改。SDK 回调继续同时提供 chunk 与 accumulated（进程内消费者免费使用 accumulated）；剥离只发生在跨进程 wire 层（agentBridge），CLI/print-cli 进程内路径完全不动（注：2026-08-08 起此决定已被推翻——SDK 回调一并移除 accumulated，见下方会议记录）
 - 问：tool block 流式通知负载 → 答：`stage="streaming"` 只携带 `parametersChunk`（增量），不再携带累积 `parameters`；`stage="end"` 仍携带全量 `parameters` + `result`（一次性权威值，UI 以此为最终值）
 - 问：流结束信号如何表示 → 答：与现状一致——`chunk: ""`（空字符串）作为流结束标记，配合 `stage="end"`
 - 问：webview 如何应用 delta → 答：reducer 追加——文本/推理块 `content += chunk`；工具块 `parameters += parametersChunk`；`getMessages` 拉取全量时整体替换为权威快照（自愈通道）
 - 问：节流语义如何调整 → 答：从 last-value-wins（对累积值安全）改为窗口拼接（window-concat）：窗口内按到达顺序拼接所有 chunks 发送一个合并 delta；丢弃中间值会造成内容永久缺失
 - 问：乱序/丢失如何保证正确性 → 答：管道 FIFO 保证通知与请求响应按序到达，"assistantMessageAdded 先于其首个 delta"、拉取响应包含其之前全部 chunk；偶发丢失由后续 `getMessages` 全量快照自愈
 - 问：受影响范围 → 答：agentBridge（剥离累积字段）、各宿主 stdioAgent（透传 delta）、各宿主 webview 转发层（VSCE chatSession、桌面 desktopHost、JetBrains WaveSession 等的节流改为窗口拼接）；CLI/print-cli 进程内不变
+
+### 2026-08-08 会议（SDK 回调移除 accumulated）
+
+- 问：SDK 回调的 `accumulated` 是否保留 → 答：移除（breaking change，不留向后兼容）。`onAssistantContentUpdated`/`onAssistantReasoningUpdated` 与 wire 通知统一只携带 `{messageId, chunk, stage}`，进程内/跨进程只有一种负载模式，消除"两套语义"分裂，也避免消费者误用累积值造成 O(n²) 拷贝
+- 问：SDK 内部累积逻辑是否一并移除 → 答：不移除。aiService 仍内部累积全文，messageManager 仍以"新值 slice 当前长度"计算 chunk delta——只是累积值不再暴露到外部回调
+- 问：进程内消费者如何适配 → 答：CLI useChat 改为消费纯 chunk：新增窗口拼接节流器（window-concat，500ms），窗口内按到达顺序拼接 chunks 为一个合并 delta 发送，`stage="end"` 时先冲刷窗口内 pending 增量再转发 end 信号，最后一条 chunk 以空串 end 终结；print-cli 直接按 chunk 打印，无累积依赖
+- 问：为什么 `stage="end"` 事件以 `chunk: ""` 结尾 → 答：end 是流结束信号，权威最终值由消费端自行累积得到，end 事件不再重复携带全量值
 
 ## 假设 *（必填）*
 
@@ -211,6 +218,6 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 - 用户通常使用支持实时文本渲染的标准终端模拟器
 - 在正常网络条件下内容流按时间顺序到达
 - 消息变更通过增量回调对外发布，完整列表按需拉取（`agent.messages` / `getMessages` 请求）；每次流式 chunk 不触发全量列表推送
-- 跨进程增量通知只携带增量负载（chunk / parametersChunk），SDK 回调在进程内仍同时提供累积值；消费端负责累积，`getMessages` 全量快照负责对账自愈
+- 增量回调与跨进程通知一律只携带增量负载（chunk / parametersChunk），SDK 不再对外提供累积值；消费端负责累积追加，`getMessages` 全量快照负责对账自愈
 - 工具参数流包含有效的 JSON 或结构化数据，可以使用新的 `extractStreamingParams` 工具函数（待实现）增量解析，该函数将验证 JSON 完整性并从部分流中提取有效的参数对象
 - Agent SDK 在内部管理消息状态，并通过增量回调与按需读取（`agent.messages`）对外提供消息数据

--- a/docs/specs/ui/stdio-transport.md
+++ b/docs/specs/ui/stdio-transport.md
@@ -194,7 +194,7 @@ order: 220
 
 作为 stdio 传输层，我希望跨进程增量通知只携带增量片段（delta）而非累积值，以便流式期间单条通知的序列化与传输成本与已流式内容总长度无关，长会话流式不再对子进程内存和管道带宽造成 O(n²) 压力。
 
-**为什么是这个优先级**：移除 `messagesChange` 后通知条数已经与消息条数无关，但每个 `assistantContentUpdated` 通知仍携带与已流式内容等长的累积 `accumulated` payload（tool block 携带累积 `parameters`），节流只能减少条数、无法减少单条负载。改为纯 delta 后，`assistantContentUpdated`/`assistantReasoningUpdated` 只携带 `{messageId, chunk, stage}`（SDK 侧已计算 chunk = 新内容 − 旧内容），`toolBlockUpdated` 在 `stage="streaming"` 只携带 `parametersChunk`；消费端负责累积（追加），`getMessages` 全量响应作为权威对账通道自愈丢失的 delta。剥离发生在 agentBridge（wire 入口），SDK 回调与 CLI 进程内路径不受影响。
+**为什么是这个优先级**：移除 `messagesChange` 后通知条数已经与消息条数无关，但每个 `assistantContentUpdated` 通知仍携带与已流式内容等长的累积 `accumulated` payload（tool block 携带累积 `parameters`），节流只能减少条数、无法减少单条负载。改为纯 delta 后，`assistantContentUpdated`/`assistantReasoningUpdated` 只携带 `{messageId, chunk, stage}`（SDK 侧已计算 chunk = 新内容 − 旧内容），`toolBlockUpdated` 在 `stage="streaming"` 只携带 `parametersChunk`；消费端负责累积（追加），`getMessages` 全量响应作为权威对账通道自愈丢失的 delta。SDK 回调与 wire 通知统一为纯 delta（`accumulated` 已从 SDK 回调移除，2026-08-08），agentBridge 原样透传、无需剥离。
 
 **独立测试**：构造长会话触发流式，在 CLI 侧记录 stdout 并测量通知负载大小：通知字节数随流式累积不增长（仅随 chunk 本身大小波动）；流式过程中 kill/重启任一宿主的 webview 转发层后，通过一次 `getMessages` 拉取即可恢复完整内容。
 
@@ -203,7 +203,7 @@ order: 220
 1. **假设** 助手响应正在流式传输，**当** CLI 推送 `assistantContentUpdated`/`assistantReasoningUpdated` 通知时，**则** 通知负载为 `{messageId, chunk, stage}`，不含 `accumulated` 字段；内容由消费端按序追加累积
 2. **假设** 工具参数正在流式传输，**当** CLI 推送 `toolBlockUpdated` 且 `stage="streaming"` 时，**则** 负载只含 `parametersChunk` 增量，不含累积 `parameters`；**当** `stage="end"` 时，**则** 负载携带全量 `parameters` + `result` 作为一次性权威值
 3. **假设** 某条流结束，**当** CLI 推送最后一个增量通知时，**则** `chunk` 为空字符串（`chunk: ""`）且 `stage="end"`，消费端据此终结流式块
-4. **假设** 宿主对增量通知做节流（如桌面 16ms / CLI 500ms 窗口），**当** 窗口内有多条 chunk 时，**则** 按到达顺序拼接为一个合并 delta 发送（window-concat），不丢弃中间值；进程内 CLI 对 accumulated 的 last-value-wins 节流不变
+4. **假设** 宿主对增量通知做节流（如桌面 16ms / CLI 500ms 窗口），**当** 窗口内有多条 chunk 时，**则** 按到达顺序拼接为一个合并 delta 发送（window-concat），不丢弃中间值；进程内 CLI 同样使用 window-concat（SDK 回调已无 accumulated，不存在 last-value-wins 路径）
 5. **假设** 增量通知中途丢失（传输异常），**当** 消费端发现内容不完整时，**则** 通过一次 `getMessages` 请求拉取全量权威快照整体替换自愈，管道 FIFO 保证拉取响应包含其之前发出的所有 chunk，不重复
 6. **假设** 某个宿主需要将 delta 转发给 webview，**当** 转发时，**则** 透传 delta（消费端 webview reducer 追加），不在宿主侧重新累积为全量后再下发
 

--- a/packages/agent-sdk/src/managers/messageManager.ts
+++ b/packages/agent-sdk/src/managers/messageManager.ts
@@ -45,18 +45,16 @@ export interface MessageManagerCallbacks {
   onUserMessageAdded?: (params: UserMessageParams) => void;
   // MODIFIED: Remove arguments for separation of concerns
   onAssistantMessageAdded?: (messageId: string) => void;
-  // NEW: Streaming content callback - FR-001: receives chunk and accumulated content
+  // NEW: Streaming content callback - FR-001: receives chunk delta and stage
   onAssistantContentUpdated?: (params: {
     messageId: string;
     chunk: string;
-    accumulated: string;
     stage: "streaming" | "end";
   }) => void;
   // NEW: Streaming reasoning callback
   onAssistantReasoningUpdated?: (params: {
     messageId: string;
     chunk: string;
-    accumulated: string;
     stage: "streaming" | "end";
   }) => void;
   onToolBlockUpdated?: (params: ToolBlockUpdateCallbackParams) => void;
@@ -780,7 +778,6 @@ export class MessageManager {
     const callbackParams = {
       messageId: lastMessage.id,
       chunk: "",
-      accumulated: block.content,
       stage: "end" as const,
     };
     if (type === "text") {
@@ -794,7 +791,7 @@ export class MessageManager {
   /**
    * Update the current assistant message content during streaming
    * This method updates the last assistant message's content without creating a new message
-   * FR-001: Tracks and provides both chunk (new content) and accumulated (total content)
+   * FR-001: Tracks and provides chunk (new content since last update)
    */
   public updateCurrentMessageContent(newAccumulatedContent: string): void {
     if (this.messages.length === 0) return;
@@ -838,11 +835,10 @@ export class MessageManager {
       });
     }
 
-    // FR-001: Trigger callbacks with chunk and accumulated content
+    // FR-001: Trigger callbacks with chunk delta and stage
     this.callbacks.onAssistantContentUpdated?.({
       messageId: lastMessage.id,
       chunk,
-      accumulated: newAccumulatedContent,
       stage: "streaming",
     });
 
@@ -902,11 +898,10 @@ export class MessageManager {
       });
     }
 
-    // Trigger callbacks with chunk and accumulated reasoning content
+    // Trigger callbacks with chunk delta and stage
     this.callbacks.onAssistantReasoningUpdated?.({
       messageId: lastMessage.id,
       chunk,
-      accumulated: newAccumulatedReasoning,
       stage: "streaming",
     });
   }

--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -48,7 +48,6 @@ export interface SubagentManagerCallbacks {
     subagentId: string;
     messageId: string;
     chunk: string;
-    accumulated: string;
     stage: "streaming" | "end";
   }) => void;
   /** Triggered during subagent reasoning streaming updates */
@@ -56,7 +55,6 @@ export interface SubagentManagerCallbacks {
     subagentId: string;
     messageId: string;
     chunk: string;
-    accumulated: string;
     stage: "streaming" | "end";
   }) => void;
   /** Triggered when subagent tool block is updated */
@@ -810,7 +808,6 @@ export class SubagentManager {
       onAssistantContentUpdated: (params: {
         messageId: string;
         chunk: string;
-        accumulated: string;
         stage: "streaming" | "end";
       }) => {
         this.refreshSubagentState(subagentId);
@@ -825,7 +822,6 @@ export class SubagentManager {
       onAssistantReasoningUpdated: (params: {
         messageId: string;
         chunk: string;
-        accumulated: string;
         stage: "streaming" | "end";
       }) => {
         this.refreshSubagentState(subagentId);

--- a/packages/agent-sdk/tests/managers/messageManager.streaming.test.ts
+++ b/packages/agent-sdk/tests/managers/messageManager.streaming.test.ts
@@ -7,7 +7,7 @@ describe("MessageManager - Streaming Functionality", () => {
   const container = new Container();
 
   describe("updateCurrentMessageContent with FR-001 compliance", () => {
-    it("should call onAssistantContentUpdated with chunk and accumulated content", () => {
+    it("should call onAssistantContentUpdated with chunk and stage", () => {
       const mockOnAssistantContentUpdated = vi.fn();
 
       const callbacks: MessageManagerCallbacks = {
@@ -29,7 +29,6 @@ describe("MessageManager - Streaming Functionality", () => {
       expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith({
         messageId,
         chunk: "Hello",
-        accumulated: "Hello",
         stage: "streaming",
       });
 
@@ -39,7 +38,6 @@ describe("MessageManager - Streaming Functionality", () => {
       expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith({
         messageId,
         chunk: ", world!",
-        accumulated: "Hello, world!",
         stage: "streaming",
       });
 
@@ -49,7 +47,6 @@ describe("MessageManager - Streaming Functionality", () => {
       expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith({
         messageId,
         chunk: " How are you?",
-        accumulated: "Hello, world! How are you?",
         stage: "streaming",
       });
 
@@ -79,7 +76,6 @@ describe("MessageManager - Streaming Functionality", () => {
       expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith({
         messageId,
         chunk: "",
-        accumulated: "",
         stage: "streaming",
       });
     });
@@ -106,7 +102,6 @@ describe("MessageManager - Streaming Functionality", () => {
       expect(mockOnAssistantContentUpdated).toHaveBeenCalledWith({
         messageId,
         chunk: "New content",
-        accumulated: "New content",
         stage: "streaming",
       });
 
@@ -192,7 +187,6 @@ describe("MessageManager - Streaming Functionality", () => {
         {
           messageId,
           chunk: "",
-          accumulated: "Let me think...",
           stage: "end",
         },
       ]);
@@ -201,7 +195,6 @@ describe("MessageManager - Streaming Functionality", () => {
       expect(mockContentUpdated).toHaveBeenCalledWith({
         messageId,
         chunk: "Hello",
-        accumulated: "Hello",
         stage: "streaming",
       });
     });
@@ -236,7 +229,6 @@ describe("MessageManager - Streaming Functionality", () => {
         {
           messageId,
           chunk: "",
-          accumulated: "Hello world",
           stage: "end",
         },
       ]);
@@ -245,7 +237,6 @@ describe("MessageManager - Streaming Functionality", () => {
       expect(mockReasoningUpdated).toHaveBeenCalledWith({
         messageId,
         chunk: "Thinking...",
-        accumulated: "Thinking...",
         stage: "streaming",
       });
     });
@@ -283,7 +274,6 @@ describe("MessageManager - Streaming Functionality", () => {
       expect(mockReasoningUpdated).toHaveBeenCalledWith({
         messageId,
         chunk: "",
-        accumulated: "Some reasoning",
         stage: "end",
       });
     });
@@ -308,7 +298,6 @@ describe("MessageManager - Streaming Functionality", () => {
       expect(mockContentUpdated).toHaveBeenCalledWith({
         messageId,
         chunk: "Hello",
-        accumulated: "Hello",
         stage: "streaming",
       });
     });

--- a/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
@@ -225,7 +225,6 @@ describe("SubagentManager - Backgrounding Coverage", () => {
     passedCallbacks.onAssistantReasoningUpdated?.({
       messageId: "msg-test-id",
       chunk: "chunk",
-      accumulated: "accumulated",
       stage: "streaming",
     });
 
@@ -233,7 +232,6 @@ describe("SubagentManager - Backgrounding Coverage", () => {
       subagentId: instance.subagentId,
       messageId: "msg-test-id",
       chunk: "chunk",
-      accumulated: "accumulated",
       stage: "streaming",
     });
   });

--- a/packages/agent-sdk/tests/managers/subagentManager.callbacks.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.callbacks.test.ts
@@ -314,7 +314,6 @@ describe("SubagentManager - Callback Integration", () => {
         subagentId: instance.subagentId,
         messageId: expect.any(String),
         chunk: expect.any(String),
-        accumulated: newContent,
         stage: "streaming",
       });
 
@@ -355,16 +354,16 @@ describe("SubagentManager - Callback Integration", () => {
         2,
       );
 
-      // Check the accumulated content in calls
+      // Check the chunk deltas in calls
       const mockedCallback = vi.mocked(
         callbacks.onSubagentAssistantContentUpdated,
       )!;
       expect(mockedCallback.mock.calls).toBeDefined();
       const calls = mockedCallback.mock.calls!;
       expect(calls[0]![0].subagentId).toBe(instance.subagentId);
-      expect(calls[0]![0].accumulated).toBe("Hello world");
+      expect(calls[0]![0].chunk).toBe(" world");
       expect(calls[1]![0].subagentId).toBe(instance.subagentId);
-      expect(calls[1]![0].accumulated).toBe("Hello world!");
+      expect(calls[1]![0].chunk).toBe("!");
     });
   });
 

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -158,6 +158,84 @@ export interface ChatProviderProps extends BaseAppProps {
   children: React.ReactNode;
 }
 
+interface StreamingUpdateParams {
+  messageId: string;
+  chunk: string;
+  stage: "streaming" | "end";
+}
+
+/**
+ * Window-concat throttle for pure-delta streaming updates: chunks arriving
+ * within the cooldown window are merged so no delta is lost (a dropped delta
+ * would permanently lose content, unlike the accumulated-payload throttle it
+ * replaces). Leading edge fires immediately; the trailing edge carries only
+ * chunks that arrived within the window. `end` flushes any pending deltas
+ * first, then forwards the end signal right away.
+ */
+function createStreamingWindowThrottle(
+  fn: (params: StreamingUpdateParams) => void,
+  wait: number,
+): {
+  (params: StreamingUpdateParams): void;
+  cancel: () => void;
+  flush: () => void;
+} {
+  let timer: NodeJS.Timeout | null = null;
+  let pending: { messageId: string; chunk: string } | null = null;
+
+  const fire = (stage: "streaming" | "end") => {
+    if (pending) {
+      fn({ ...pending, stage });
+      pending = null;
+    }
+  };
+
+  const throttled = (params: StreamingUpdateParams) => {
+    if (params.stage === "end") {
+      // Flush any deltas still pending inside the cooldown window first
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      fire("streaming");
+      fn(params);
+      return;
+    }
+    if (pending) {
+      pending.chunk += params.chunk;
+    } else {
+      pending = { messageId: params.messageId, chunk: params.chunk };
+    }
+    if (!timer) {
+      // Leading edge: fire the current delta immediately, then reset pending so
+      // the trailing edge only carries chunks arriving within this window
+      fire("streaming");
+      timer = setTimeout(() => {
+        timer = null;
+        fire("streaming");
+      }, wait);
+    }
+  };
+
+  throttled.cancel = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    pending = null;
+  };
+
+  throttled.flush = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    fire("streaming");
+  };
+
+  return throttled;
+}
+
 export const ChatProvider: React.FC<ChatProviderProps> = ({
   children,
   bypassPermissions,
@@ -188,86 +266,77 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   const [latestTotalTokens, setLatestTotalTokens] = useState(0);
   const [maxInputTokens, setMaxInputTokens] = useState(200000);
 
-  // Throttled incremental streaming updaters — 500ms leading+trailing, the same interval
-  // as the pre-incremental throttledSetMessages. `stage === "end"` flushes the final
-  // update immediately so completion results are never delayed.
+  // Throttled incremental streaming updaters — 500ms window-concat, the same
+  // interval as the pre-incremental throttledSetMessages. Chunks are pure
+  // deltas: within-window chunks are merged so none is dropped, and
+  // `stage === "end"` flushes pending deltas + applies the end signal
+  // immediately so completion results are never delayed.
   const throttledContentUpdate = useMemo(
     () =>
-      throttle(
-        (params: {
-          messageId: string;
-          accumulated: string;
-          stage: "streaming" | "end";
-        }) => {
-          const { messageId, accumulated, stage } = params;
-          setMessages((prev) =>
-            prev.map((m) => {
-              if (m.id !== messageId) return m;
-              const textBlockIndex = m.blocks.findIndex(
-                (b) => b.type === "text",
-              );
-              if (textBlockIndex === -1) {
-                return {
-                  ...m,
-                  blocks: [
-                    ...m.blocks,
-                    { type: "text", content: accumulated, stage },
-                  ],
-                };
-              }
+      createStreamingWindowThrottle((params) => {
+        const { messageId, chunk, stage } = params;
+        setMessages((prev) =>
+          prev.map((m) => {
+            if (m.id !== messageId) return m;
+            const textBlockIndex = m.blocks.findIndex((b) => b.type === "text");
+            if (textBlockIndex === -1) {
               return {
                 ...m,
-                blocks: m.blocks.map((b, idx) =>
-                  idx === textBlockIndex && b.type === "text"
-                    ? { ...b, content: accumulated, stage }
-                    : b,
-                ),
+                blocks: [...m.blocks, { type: "text", content: chunk, stage }],
               };
-            }),
-          );
-        },
-        500,
-      ),
+            }
+            return {
+              ...m,
+              blocks: m.blocks.map((b, idx) =>
+                idx === textBlockIndex && b.type === "text"
+                  ? {
+                      ...b,
+                      content: (b.content || "") + chunk,
+                      stage,
+                    }
+                  : b,
+              ),
+            };
+          }),
+        );
+      }, 500),
     [],
   );
 
   const throttledReasoningUpdate = useMemo(
     () =>
-      throttle(
-        (params: {
-          messageId: string;
-          accumulated: string;
-          stage: "streaming" | "end";
-        }) => {
-          const { messageId, accumulated, stage } = params;
-          setMessages((prev) =>
-            prev.map((m) => {
-              if (m.id !== messageId) return m;
-              const reasoningBlockIndex = m.blocks.findIndex(
-                (b) => b.type === "reasoning",
-              );
-              if (reasoningBlockIndex === -1) {
-                return {
-                  ...m,
-                  blocks: [
-                    ...m.blocks,
-                    { type: "reasoning", content: accumulated, stage },
-                  ],
-                };
-              }
+      createStreamingWindowThrottle((params) => {
+        const { messageId, chunk, stage } = params;
+        setMessages((prev) =>
+          prev.map((m) => {
+            if (m.id !== messageId) return m;
+            const reasoningBlockIndex = m.blocks.findIndex(
+              (b) => b.type === "reasoning",
+            );
+            if (reasoningBlockIndex === -1) {
               return {
                 ...m,
-                blocks: m.blocks.map((b, idx) =>
-                  idx === reasoningBlockIndex && b.type === "reasoning"
-                    ? { ...b, content: accumulated, stage }
-                    : b,
-                ),
+                blocks: [
+                  ...m.blocks,
+                  { type: "reasoning", content: chunk, stage },
+                ],
               };
-            }),
-          );
-        },
-        500,
-      ),
+            }
+            return {
+              ...m,
+              blocks: m.blocks.map((b, idx) =>
+                idx === reasoningBlockIndex && b.type === "reasoning"
+                  ? {
+                      ...b,
+                      content: (b.content || "") + chunk,
+                      stage,
+                    }
+                  : b,
+              ),
+            };
+          }),
+        );
+      }, 500),
     [],
   );
 
@@ -477,12 +546,10 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         onAssistantContentUpdated: (params) => {
           if (isExpandedRef.current) return;
           throttledContentUpdate(params);
-          if (params.stage === "end") throttledContentUpdate.flush();
         },
         onAssistantReasoningUpdated: (params) => {
           if (isExpandedRef.current) return;
           throttledReasoningUpdate(params);
-          if (params.stage === "end") throttledReasoningUpdate.flush();
         },
         onToolBlockUpdated: (params) => {
           if (isExpandedRef.current) return;

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -916,7 +916,6 @@ describe("ChatProvider", () => {
     callbacks.onAssistantContentUpdated!({
       messageId: "msg-1",
       chunk: "hi",
-      accumulated: "hi",
       stage: "streaming",
     });
     await vi.advanceTimersByTimeAsync(10);
@@ -1201,7 +1200,6 @@ describe("ChatProvider", () => {
     callbacks.onAssistantContentUpdated!({
       messageId: "msg-1",
       chunk: "Hel",
-      accumulated: "Hel",
       stage: "streaming",
     });
     await vi.waitFor(() => {
@@ -1212,10 +1210,10 @@ describe("ChatProvider", () => {
       });
     });
 
+    // The next chunk is a pure delta — the window-concat throttle appends it
     callbacks.onAssistantContentUpdated!({
       messageId: "msg-1",
       chunk: "lo",
-      accumulated: "Hello",
       stage: "streaming",
     });
     await vi.waitFor(() => {
@@ -1283,7 +1281,6 @@ describe("ChatProvider", () => {
     callbacks.onAssistantContentUpdated!({
       messageId: "msg-throttle",
       chunk: "Hel",
-      accumulated: "Hel",
       stage: "streaming",
     });
     await vi.waitFor(() => {
@@ -1296,13 +1293,11 @@ describe("ChatProvider", () => {
     callbacks.onAssistantContentUpdated!({
       messageId: "msg-throttle",
       chunk: "lo",
-      accumulated: "Hello",
       stage: "streaming",
     });
     callbacks.onAssistantContentUpdated!({
       messageId: "msg-throttle",
       chunk: " Wor",
-      accumulated: "Hello Wor",
       stage: "streaming",
     });
     // No timer advanced yet — still shows the leading update
@@ -1310,11 +1305,10 @@ describe("ChatProvider", () => {
       (lastValue?.messages[0].blocks[0] as { content: string }).content,
     ).toBe("Hel");
 
-    // stage === "end" flushes the accumulated content immediately
+    // stage === "end" flushes pending deltas and applies the end signal
     callbacks.onAssistantContentUpdated!({
       messageId: "msg-throttle",
       chunk: "ld",
-      accumulated: "Hello World",
       stage: "end",
     });
     await vi.waitFor(() => {
@@ -1406,7 +1400,6 @@ describe("ChatProvider", () => {
     callbacks.onAssistantReasoningUpdated!({
       messageId: "msg-reason",
       chunk: "Th",
-      accumulated: "Th",
       stage: "streaming",
     });
     await vi.waitFor(() => {
@@ -1420,13 +1413,11 @@ describe("ChatProvider", () => {
     callbacks.onAssistantReasoningUpdated!({
       messageId: "msg-reason",
       chunk: "ink",
-      accumulated: "Think",
       stage: "streaming",
     });
     callbacks.onAssistantReasoningUpdated!({
       messageId: "msg-reason",
       chunk: "ing",
-      accumulated: "Thinking",
       stage: "streaming",
     });
     const beforeFlush = lastValue?.messages[0].blocks.find(
@@ -1434,25 +1425,23 @@ describe("ChatProvider", () => {
     ) as { content: string } | undefined;
     expect(beforeFlush?.content).toBe("Th");
 
-    // stage === "end" flushes the accumulated reasoning as an in-place update
+    // stage === "end" flushes pending deltas and applies the end signal
     callbacks.onAssistantReasoningUpdated!({
       messageId: "msg-reason",
       chunk: "…",
-      accumulated: "Thinking complete",
       stage: "end",
     });
     await vi.waitFor(() => {
       const reasoning = lastValue?.messages[0].blocks.find(
         (b) => b.type === "reasoning",
       ) as { content: string } | undefined;
-      expect(reasoning?.content).toBe("Thinking complete");
+      expect(reasoning?.content).toBe("Thinking…");
     });
 
     // Unknown messageId leaves messages untouched
     callbacks.onAssistantReasoningUpdated!({
       messageId: "nonexistent",
       chunk: "x",
-      accumulated: "x",
       stage: "end",
     });
     expect(lastValue?.messages[0].blocks).toHaveLength(2);

--- a/packages/code/tests/print-cli.test.ts
+++ b/packages/code/tests/print-cli.test.ts
@@ -280,7 +280,6 @@ test("subagent content callbacks are not registered in print mode", async () => 
     subagentId: "test-subagent-123",
     messageId: "msg-123",
     chunk: "Hello from subagent",
-    accumulated: "Hello from subagent",
     stage: "streaming",
   });
   expect(stdoutSpy).not.toHaveBeenCalled();
@@ -419,7 +418,6 @@ test("reasoning callbacks output correctly", async () => {
   capturedCallbacks?.onAssistantReasoningUpdated?.({
     messageId: "msg-test-id",
     chunk: "Thinking...",
-    accumulated: "Thinking...",
     stage: "streaming",
   });
   expect(stdoutSpy).toHaveBeenCalledWith("\n💭 Reasoning:\n");
@@ -430,7 +428,6 @@ test("reasoning callbacks output correctly", async () => {
   capturedCallbacks?.onAssistantReasoningUpdated?.({
     messageId: "msg-test-id",
     chunk: " more thinking",
-    accumulated: "Thinking... more thinking",
     stage: "streaming",
   });
   expect(stdoutSpy).not.toHaveBeenCalledWith("\n💭 Reasoning:\n");
@@ -441,7 +438,6 @@ test("reasoning callbacks output correctly", async () => {
   capturedCallbacks?.onAssistantContentUpdated?.({
     messageId: "msg-test-id",
     chunk: "Hello!",
-    accumulated: "Hello!",
     stage: "streaming",
   });
   expect(stdoutSpy).toHaveBeenCalledWith("\n\n📝 Response:\n");
@@ -452,7 +448,6 @@ test("reasoning callbacks output correctly", async () => {
   capturedCallbacks?.onAssistantContentUpdated?.({
     messageId: "msg-test-id",
     chunk: " world",
-    accumulated: "Hello! world",
     stage: "streaming",
   });
   expect(stdoutSpy).not.toHaveBeenCalledWith("\n\n📝 Response:\n");

--- a/packages/code/tests/stdio/agentBridge.test.ts
+++ b/packages/code/tests/stdio/agentBridge.test.ts
@@ -199,7 +199,6 @@ test("onAssistantContentUpdated emits assistantContentUpdated notification", asy
   const params = {
     messageId: "msg-1",
     chunk: "Hello",
-    accumulated: "Hello",
     stage: "streaming" as const,
   };
   callbacks.onAssistantContentUpdated!(params);
@@ -2176,13 +2175,11 @@ test("notifications route by sessionId when callbacks fire", async () => {
   const paramsA = {
     messageId: "a-1",
     chunk: "A",
-    accumulated: "A",
     stage: "streaming" as const,
   };
   const paramsB = {
     messageId: "b-1",
     chunk: "B",
-    accumulated: "B",
     stage: "streaming" as const,
   };
 


### PR DESCRIPTION
## 背景

SDK 回调层（`onAssistantContentUpdated` / `onAssistantReasoningUpdated` / `onSubagentAssistantContentUpdated` / `onSubagentAssistantReasoningUpdated`）的 `accumulated` 字段导致每条流式通知携带与已流式内容等长的累积值，长会话下节流只能减少条数、无法减少单条负载（O(n²) 内存/序列化压力）。经调研确认：wire 层（agentBridge stdio 通知）已是纯增量，SDK 回调层的 `accumulated` 仅被 CLI useChat 消费用于计算 delta，冗余。用户确认全量移除，接受 breaking change。

## 改动

- **SDK（breaking）**：4 个流式回调参数去掉 `accumulated`，保留 `{ messageId, chunk, stage }`。SDK 内部累积逻辑保留（aiService 累积全文 → messageManager 计算 `chunk = 新内容 − 旧内容`）。
- **CLI 消费端**：`useChat.tsx` 新增 `createStreamingWindowThrottle`（window-concat 语义，窗口内按到达顺序拼接 chunk 不丢 delta；`stage="end"` 冲刷 pending 并转发 end 信号）。tool block 更新仍用旧 `throttle`（end 事件携带累积 `parameters`，last-value-wins 安全）。
- **测试**：6 个测试文件适配纯 chunk 语义（断言改为 delta 值 / 拼接结果）。
- **Spec/文档**：`stream-content-updates.md`（验收场景 7、状态管理架构、2026-08-08 会议记录）、`stdio-transport.md`（验收场景 4）、`sdk.md`（回调表 + 示例）。

## 验证

- 相关测试 38 + 191 通过；全量 agent-sdk 3410 通过（1 skip）、code 1294 通过
- `pnpm run type-check` 全仓库通过（含 agent-sdk dist 重建）
- spec 校验：66 specs / 341 用户故事 / 1266 验收场景