### PR TITLE
feat(webview): Ctrl+B backgrounds the current foreground task

### DIFF
--- a/packages/code/src/stdio/agentBridge.ts
+++ b/packages/code/src/stdio/agentBridge.ts
@@ -335,6 +335,8 @@ export class AgentBridge {
         return this.getBackgroundTaskOutput(p.taskId as string, sessionId);
       case "stopBackgroundTask":
         return this.stopBackgroundTask(p.taskId as string, sessionId);
+      case "backgroundCurrentTask":
+        return this.backgroundCurrentTask(sessionId);
 
       case "getWorkflowRuns":
         return this.getWorkflowRuns(sessionId);
@@ -903,6 +905,12 @@ export class AgentBridge {
     const entry = this.requireSession(sessionId);
     const success = entry.agent.stopBackgroundTask(taskId);
     return { success };
+  }
+
+  private async backgroundCurrentTask(sessionId?: string): Promise<null> {
+    const entry = this.requireSession(sessionId);
+    await entry.agent.backgroundCurrentTask();
+    return null;
   }
 
   private async getWorkflowRuns(

--- a/packages/code/tests/stdio/agentBridge.test.ts
+++ b/packages/code/tests/stdio/agentBridge.test.ts
@@ -350,6 +350,23 @@ test("compact request without customInstructions calls agent.compact with undefi
   expect(r).toBeNull();
 });
 
+// ── backgroundCurrentTask request ─────────────────────────────────
+
+test("backgroundCurrentTask request calls agent.backgroundCurrentTask and returns null", async () => {
+  const { bridge } = createBridge();
+  const mockAgent = createMockAgent({
+    backgroundCurrentTask: vi.fn().mockResolvedValue(undefined),
+  });
+  vi.mocked(Agent.create).mockResolvedValue(mockAgent);
+
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  const r = await bridge.handleRequest("backgroundCurrentTask", {}, sessionId);
+
+  expect(mockAgent.backgroundCurrentTask).toHaveBeenCalledTimes(1);
+  expect(r).toBeNull();
+});
+
 test("onUserMessageAdded finds last user message and emits notification", async () => {
   const { bridge, notifications } = createBridge();
   const userMessage = {

--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -2591,6 +2591,12 @@ export class DesktopHost {
         break;
       }
 
+      case 'backgroundCurrentTask': {
+        const paneAgent = this.agentForPane(pid);
+        await paneAgent?.backgroundCurrentTask();
+        break;
+      }
+
       case 'getWorkflowRuns': {
         const paneAgent = this.agentForPane(pid);
         const runs = paneAgent ? await paneAgent.getWorkflowRuns() : [];

--- a/packages/desktop/src/main/stdio/stdioAgent.ts
+++ b/packages/desktop/src/main/stdio/stdioAgent.ts
@@ -378,6 +378,14 @@ export class StdioAgent {
         return result.success;
     }
 
+    async backgroundCurrentTask(): Promise<void> {
+        await this.client.request(
+            'backgroundCurrentTask',
+            undefined,
+            this.sessionId,
+        );
+    }
+
     async getWorkflowRuns(): Promise<SerializableWorkflowRun[]> {
         const result = (await this.client.request(
             'getWorkflowRuns',

--- a/packages/vsce/src/session/chatSession.ts
+++ b/packages/vsce/src/session/chatSession.ts
@@ -536,6 +536,13 @@ export class ChatSession {
         return await this.agent.stopBackgroundTask(taskId);
     }
 
+    public async backgroundCurrentTask(): Promise<void> {
+        if (!this.agent) {
+            return;
+        }
+        await this.agent.backgroundCurrentTask();
+    }
+
     private async refreshWorkflowRuns(): Promise<void> {
         const runs = await this.getWorkflowRuns();
         this.workflowRuns = runs;

--- a/packages/vsce/src/session/messageHandler.ts
+++ b/packages/vsce/src/session/messageHandler.ts
@@ -207,6 +207,11 @@ export class MessageHandler {
                 this.context.postMessage({ command: 'backgroundTaskStopped', taskId, success }, viewType, windowId);
                 break;
             }
+            case 'backgroundCurrentTask': {
+                const session = this.context.getChatSession(viewType || 'tab', windowId);
+                await session.backgroundCurrentTask();
+                break;
+            }
             case 'getWorkflowRuns': {
                 const session = this.context.getChatSession(viewType || 'tab', windowId);
                 const runs = await session.getWorkflowRuns();

--- a/packages/vsce/src/stdio/stdioAgent.ts
+++ b/packages/vsce/src/stdio/stdioAgent.ts
@@ -373,6 +373,14 @@ export class StdioAgent {
         return result.success;
     }
 
+    async backgroundCurrentTask(): Promise<void> {
+        await this.client.request(
+            'backgroundCurrentTask',
+            undefined,
+            this.sessionId,
+        );
+    }
+
     async getWorkflowRuns(): Promise<SerializableWorkflowRun[]> {
         const result = (await this.client.request(
             'getWorkflowRuns',

--- a/packages/webview/src/components/MessageInput.tsx
+++ b/packages/webview/src/components/MessageInput.tsx
@@ -987,6 +987,19 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>((p
       return;
     }
 
+    // Handle Ctrl+B to background the current foreground task (same as CLI).
+    // Only intercepted while a turn is running — when idle the key falls
+    // through so the host keeps its own Ctrl+B binding (e.g. VS Code's
+    // Toggle Sidebar).
+    if (event.key === 'b' && (event.ctrlKey || event.metaKey) && !isComposing) {
+      if (isStreaming) {
+        event.preventDefault();
+        event.stopPropagation();
+        vscode.postMessage({ command: 'backgroundCurrentTask' });
+        return;
+      }
+    }
+
     // Handle 指令 navigation. Navigate over the display-ordered list so the
     // highlighted item, up/down movement, and Enter selection all match the
     // grouped order shown in the popup.

--- a/packages/webview/tests/webview/backgroundCurrentTask.test.tsx
+++ b/packages/webview/tests/webview/backgroundCurrentTask.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderChatApp, screen, fireEvent, sendCommand, act } from './test-utils';
+
+/**
+ * Ctrl+B backgrounds the current foreground task (same behavior as the CLI).
+ * The webview forwards it to the host via `backgroundCurrentTask`; the host
+ * (vsce/desktop) then tells the underlying agent to move the running task to
+ * the background task manager. Like Esc-abort, the key is only intercepted
+ * while a turn is running so the host keeps its own Ctrl+B binding when idle
+ * (e.g. VS Code's Toggle Sidebar).
+ */
+describe('Background Current Task (Ctrl+B)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should post backgroundCurrentTask on Ctrl+B while streaming', async () => {
+        const { vscode } = renderChatApp();
+
+        sendCommand('startStreaming');
+
+        const messageInput = screen.getByTestId('message-input');
+        messageInput.focus();
+
+        await act(async () => {
+            fireEvent.keyDown(messageInput, { key: 'b', ctrlKey: true });
+        });
+
+        expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'backgroundCurrentTask' });
+    });
+
+    it('should post backgroundCurrentTask on Cmd+B while streaming (macOS convention)', async () => {
+        const { vscode } = renderChatApp();
+
+        sendCommand('startStreaming');
+
+        const messageInput = screen.getByTestId('message-input');
+        messageInput.focus();
+
+        await act(async () => {
+            fireEvent.keyDown(messageInput, { key: 'b', metaKey: true });
+        });
+
+        expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'backgroundCurrentTask' });
+    });
+
+    it('should not intercept Ctrl+B when idle (falls through to host binding)', async () => {
+        const { vscode } = renderChatApp();
+
+        const messageInput = screen.getByTestId('message-input');
+        messageInput.focus();
+
+        await act(async () => {
+            fireEvent.keyDown(messageInput, { key: 'b', ctrlKey: true });
+        });
+
+        expect(vscode.postMessage).not.toHaveBeenCalledWith({ command: 'backgroundCurrentTask' });
+    });
+});


### PR DESCRIPTION
## 背景
CLI 已支持 Ctrl+B 把当前前台任务后台化（background current task），但共享 webview UI（vsce / JetBrains / desktop）没有此快捷键。本次为 webview 补齐该能力，完整链路：

webview 捕获 Ctrl+B → `postMessage({command:'backgroundCurrentTask'})` → host（vsce/desktop）转发 → stdio Agent → `AgentBridge.backgroundCurrentTask` → `Agent.backgroundCurrentTask()`（复用现有 SDK 能力）。

## 设计决策
与 CLI 的始终捕获不同，webview 仅在 `isStreaming`（有前台任务在跑）时拦截 Ctrl+B；空闲时按键放行，保留宿主默认绑定（如 VS Code 的 Toggle Sidebar）。Ctrl/Cmd+B 双键支持遵循 Ctrl+R 先例。

## 涉及文件
- `packages/webview/src/components/MessageInput.tsx` — keydown handler 新增 Ctrl+B 拦截
- `packages/vsce/src/stdio/stdioAgent.ts`、`packages/vsce/src/session/chatSession.ts`、`packages/vsce/src/session/messageHandler.ts` — vsce host 转发
- `packages/desktop/src/main/stdio/stdioAgent.ts`、`packages/desktop/src/main/desktopHost.ts` — desktop host 转发（经 `agentForPane` 路由）
- `packages/code/src/stdio/agentBridge.ts` — stdio 协议新增 `backgroundCurrentTask` 请求
- 测试：`packages/webview/tests/webview/backgroundCurrentTask.test.tsx`（3 个）、`packages/code/tests/stdio/agentBridge.test.ts`（1 个）

## 验证
- webview 新测试 3/3、agentBridge 126/126、webview 回归 15/15
- webview type-check、vsce compile、desktop compile 全部通过