### PR TITLE
feat(webview): 配置弹窗「模型设置」选项卡改名为「直连设置」

### DIFF
--- a/docs/vsce.md
+++ b/docs/vsce.md
@@ -670,13 +670,13 @@ _更多菜单：设置 / 企业控制台 / 登录（或退出登录）_
 
 ### 9.1 配置设置 {#configuration-settings}
 
-用户可以自定义 API Key、Base URL 等关键参数，以适配不同的 AI 服务提供商。通过 `/config`、`/status`、`/plugin`、`/mcp` 四个斜杠命令分别唤起独立的弹窗进行管理。配置弹窗分为「全局设置」与「模型设置」两个选项卡，表单字段仅显示用户手动输入的值，不会被环境变量填充。
+用户可以自定义 API Key、Base URL 等关键参数，以适配不同的 AI 服务提供商。通过 `/config`、`/status`、`/plugin`、`/mcp` 四个斜杠命令分别唤起独立的弹窗进行管理。配置弹窗分为「全局设置」与「直连设置」两个选项卡，表单字段仅显示用户手动输入的值，不会被环境变量填充。
 
 **主要特性：**
 
 - **常规设置（`/config`）**：
   - **全局设置**：选择 AI 回复语言（中文 / 英文）。
-  - **模型设置**：配置直连 LLM 的参数，保存后优先使用此配置，无需登录即可使用插件：
+  - **直连设置**：配置直连 LLM 的参数，保存后优先使用此配置，无需登录即可使用插件：
     - **API Key**：LLM 服务的访问密钥。
     - **Base URL**：LLM 服务的 API 基础地址。
     - **Agent Model**：主代理使用的模型。
@@ -697,8 +697,8 @@ _状态信息弹窗_
 ![配置设置](/screenshots/spec-configuration.webp)
 _配置设置（全局设置选项卡）_
 
-![模型设置](/screenshots/spec-config-model.webp)
-_模型设置选项卡_
+![直连设置](/screenshots/spec-config-direct.webp)
+_直连设置选项卡_
 
 ### 9.2 语言设置 {#language-settings}
 

--- a/packages/webview/e2e/demo/language-config.demo.ts
+++ b/packages/webview/e2e/demo/language-config.demo.ts
@@ -36,9 +36,9 @@ test.describe('Language Configuration Demo', () => {
         await elementScreenshotWebp(dialog, '../../docs/public/screenshots/language-config-ui.webp');
 
         // Switch to the model settings tab and capture it
-        await webviewPage.getByRole('tab', { name: '模型设置' }).click();
+        await webviewPage.getByRole('tab', { name: '直连设置' }).click();
         await expect(webviewPage.locator('#apiKey')).toBeVisible();
         await expect(webviewPage.locator('#fastModel')).toHaveValue('claude-haiku-4-20250514');
-        await elementScreenshotWebp(dialog, '../../docs/public/screenshots/spec-config-model.webp');
+        await elementScreenshotWebp(dialog, '../../docs/public/screenshots/spec-config-direct.webp');
     });
 });

--- a/packages/webview/src/components/ConfigDialog.tsx
+++ b/packages/webview/src/components/ConfigDialog.tsx
@@ -3,7 +3,7 @@
  *
  * Opened via the /config slash command. Contains two tabs:
  * - Global settings (language)
- * - Model settings (API Key, Base URL, Agent Model, Fast Model)
+ * - Direct connection settings (API Key, Base URL, Agent Model, Fast Model)
  */
 
 import React, { useState, useEffect, useRef } from 'react';
@@ -131,7 +131,7 @@ const ConfigDialog: React.FC<ConfigDialogProps & { vscode: VsCodeApi }> = ({
             className={`config-tab${activeTab === 'model' ? ' active' : ''}`}
             onClick={() => setActiveTab('model')}
           >
-            模型设置
+            直连设置
           </button>
           <button
             type="button"

--- a/packages/webview/tests/webview/configDialog.test.tsx
+++ b/packages/webview/tests/webview/configDialog.test.tsx
@@ -52,7 +52,7 @@ describe('ConfigDialog', () => {
     expect(screen.getByRole('heading', { name: '设置' })).toBeTruthy();
 
     const globalTab = screen.getByRole('tab', { name: '全局设置' });
-    const modelTab = screen.getByRole('tab', { name: '模型设置' });
+    const modelTab = screen.getByRole('tab', { name: '直连设置' });
     expect(globalTab.getAttribute('aria-selected')).toBe('true');
     expect(modelTab.getAttribute('aria-selected')).toBe('false');
 
@@ -65,9 +65,9 @@ describe('ConfigDialog', () => {
   it('switches to the model tab and renders model fields', () => {
     renderDialog();
 
-    fireEvent.click(screen.getByRole('tab', { name: '模型设置' }));
+    fireEvent.click(screen.getByRole('tab', { name: '直连设置' }));
 
-    expect(screen.getByRole('tab', { name: '模型设置' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('tab', { name: '直连设置' }).getAttribute('aria-selected')).toBe('true');
     expect(screen.getByText('保存后，优先使用此配置，无需登录即可正常使用插件。')).toBeTruthy();
     expect(screen.getByLabelText('API Key')).toBeTruthy();
     expect(screen.getByLabelText('Base URL')).toBeTruthy();
@@ -80,7 +80,7 @@ describe('ConfigDialog', () => {
 
   it('renders Fast Model as an <input>, not a <select>', () => {
     renderDialog();
-    fireEvent.click(screen.getByRole('tab', { name: '模型设置' }));
+    fireEvent.click(screen.getByRole('tab', { name: '直连设置' }));
 
     const fastModel = screen.getByLabelText('Fast Model');
     expect(fastModel.tagName).toBe('INPUT');
@@ -89,7 +89,7 @@ describe('ConfigDialog', () => {
 
   it('uses the correct placeholder text for Base URL', () => {
     renderDialog();
-    fireEvent.click(screen.getByRole('tab', { name: '模型设置' }));
+    fireEvent.click(screen.getByRole('tab', { name: '直连设置' }));
 
     expect(screen.getByLabelText('Base URL').getAttribute('placeholder')).toBe('请输入 Base URL');
     expect(screen.getByLabelText('API Key').getAttribute('placeholder')).toBe('请输入 API Key');
@@ -106,7 +106,7 @@ describe('ConfigDialog', () => {
       },
     });
 
-    fireEvent.click(screen.getByRole('tab', { name: '模型设置' }));
+    fireEvent.click(screen.getByRole('tab', { name: '直连设置' }));
 
     const apiKey = screen.getByLabelText('API Key');
     fireEvent.change(apiKey, { target: { value: 'new-key' } });


### PR DESCRIPTION
将 /config 配置弹窗中的「模型设置」选项卡改名为「直连设置」，语义更准确地表达该选项卡用于配置直连 LLM 的参数（API Key、Base URL、Agent Model、Fast Model），无需登录即可使用插件。

- ConfigDialog 选项卡文字及文件头注释同步更新
- configDialog 测试 6 处查询更新，16 个测试全部通过
- language-config 演示脚本及截图输出名改为 spec-config-direct.webp
- docs/vsce.md 9.1 节说明文字与截图标题同步更新