### PR TITLE
fix(webview): desktop 更多菜单设置无反应 + 设置项 host 标注

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -1597,6 +1597,64 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
     </>
   );
 
+  // Dialogs render at the component root — not inside chatContainer — so they
+  // stay visible in every layout: the desktop split-view shell (where the root
+  // ChatApp never mounts its own chatContainer) still shows the config dialog
+  // opened from the sidebar 更多 menu.
+  const dialogs = (
+    <>
+      {state.activeDialog === 'config' && (
+        <ConfigDialog
+          configurationData={state.configurationData || {}}
+          isLoading={state.configurationLoading}
+          error={state.configurationError}
+          onSave={handleConfigurationSave}
+          onCancel={handleDialogClose}
+          projectSettings={state.projectSettings}
+          onLoadProjectSettings={() => postToHost({ command: 'getProjectSettings' })}
+          onToggleBuiltinPlugin={(pluginId, enabled) =>
+            postToHost({ command: 'setBuiltinPluginEnabled', pluginId, enabled, scope: 'project' })
+          }
+          vscode={vscode}
+        />
+      )}
+      {state.activeDialog === 'plugin' && (
+        <PluginDialog vscode={vscode} onClose={handleDialogClose} />
+      )}
+      {state.activeDialog === 'mcp' && (
+        <McpDialog vscode={vscode} onClose={handleDialogClose} />
+      )}
+      {state.activeDialog === 'status' && (
+        <StatusDialog
+          onClose={handleDialogClose}
+          vscode={vscode}
+        />
+      )}
+      {state.activeDialog === 'tasks' && (
+        <BackgroundTaskManager
+          tasks={state.backgroundTasks}
+          vscode={vscode}
+          onClose={handleDialogClose}
+        />
+      )}
+      {state.activeDialog === 'workflows' && (
+        <WorkflowManager
+          runs={state.workflowRuns}
+          vscode={vscode}
+          onCancel={handleDialogClose}
+        />
+      )}
+      {pendingRewindId && (
+        <ConfirmDialog
+          title="确定要回滚到此消息吗？"
+          description="这将删除之后的所有消息并撤销相关的文件更改。"
+          onConfirm={handleRewindConfirm}
+          onCancel={() => setPendingRewindId(null)}
+        />
+      )}
+    </>
+  );
+
   const chatContainer = (
     <div className="chat-container" data-testid="chat-container" ref={isDesktop ? chatContainerRef : undefined}>
       {queueEditWarning && (
@@ -1654,56 +1712,6 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
       ) : (
         chatBodyContent
       )}
-
-      {state.activeDialog === 'config' && (
-        <ConfigDialog
-          configurationData={state.configurationData || {}}
-          isLoading={state.configurationLoading}
-          error={state.configurationError}
-          onSave={handleConfigurationSave}
-          onCancel={handleDialogClose}
-          projectSettings={state.projectSettings}
-          onLoadProjectSettings={() => postToHost({ command: 'getProjectSettings' })}
-          onToggleBuiltinPlugin={(pluginId, enabled) =>
-            postToHost({ command: 'setBuiltinPluginEnabled', pluginId, enabled, scope: 'project' })
-          }
-          vscode={vscode}
-        />
-      )}
-      {state.activeDialog === 'plugin' && (
-        <PluginDialog vscode={vscode} onClose={handleDialogClose} />
-      )}
-      {state.activeDialog === 'mcp' && (
-        <McpDialog vscode={vscode} onClose={handleDialogClose} />
-      )}
-      {state.activeDialog === 'status' && (
-        <StatusDialog
-          onClose={handleDialogClose}
-          vscode={vscode}
-        />
-      )}
-      {state.activeDialog === 'tasks' && (
-        <BackgroundTaskManager
-          tasks={state.backgroundTasks}
-          vscode={vscode}
-          onClose={handleDialogClose}
-        />
-      )}
-      {state.activeDialog === 'workflows' && (
-        <WorkflowManager
-          runs={state.workflowRuns}
-          vscode={vscode}
-          onCancel={handleDialogClose}
-        />
-      )}
-      {pendingRewindId && (
-        <ConfirmDialog
-          title="确定要回滚到此消息吗？"
-          description="这将删除之后的所有消息并撤销相关的文件更改。"
-          onConfirm={handleRewindConfirm}
-          onCancel={() => setPendingRewindId(null)}
-        />
-      )}
     </div>
   );
 
@@ -1714,21 +1722,29 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
     // paneId it would double-render, so bail out to the shell instead.
     if ((host.panes?.length ?? 0) > 0 && paneId === undefined) {
       return (
-        <DesktopShell
-          vscode={vscode}
-          host={host}
-          onOpenSettings={handleOpenSettings}
-          onOpenEnterpriseConsole={handleOpenEnterpriseConsole}
-          onLogin={handleLogin}
-          onLogout={handleLogout}
-          isAuthenticated={state.isAuthenticated}
-        />
+        <>
+          <DesktopShell
+            vscode={vscode}
+            host={host}
+            onOpenSettings={handleOpenSettings}
+            onOpenEnterpriseConsole={handleOpenEnterpriseConsole}
+            onLogin={handleLogin}
+            onLogout={handleLogout}
+            isAuthenticated={state.isAuthenticated}
+          />
+          {dialogs}
+        </>
       );
     }
     // Inside DesktopShell each pane renders only its own chatContainer; the
     // sidebar / preview pane live in the shell / single-pane layout.
     if (paneId !== undefined) {
-      return chatContainer;
+      return (
+        <>
+          {chatContainer}
+          {dialogs}
+        </>
+      );
     }
     return (
       <div className="desktop-layout">
@@ -1750,9 +1766,15 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
           onDeleteSession={host.onDeleteSession}
         />
         {chatContainer}
+        {dialogs}
       </div>
     );
   }
 
-  return chatContainer;
+  return (
+    <>
+      {chatContainer}
+      {dialogs}
+    </>
+  );
 };

--- a/packages/webview/src/components/MoreMenu.tsx
+++ b/packages/webview/src/components/MoreMenu.tsx
@@ -72,7 +72,7 @@ export const MoreMenu: React.FC<MoreMenuProps> = ({
   return (
     <div ref={menuRef} className="more-menu" data-testid="more-menu">
       <div className="more-menu-item" onClick={handleSettings} data-testid="more-menu-settings">
-        设置
+        设置{hostLabel ? `（${hostLabel}）` : ''}
       </div>
       <div
         className="more-menu-item more-menu-item--between"

--- a/packages/webview/tests/webview/desktopApp.test.tsx
+++ b/packages/webview/tests/webview/desktopApp.test.tsx
@@ -552,6 +552,24 @@ describe('DesktopApp', () => {
             expect(screen.queryByTestId('more-menu')).not.toBeInTheDocument();
         });
 
+        it('opens the config dialog from the sidebar when panes are present (DesktopShell layout)', () => {
+            renderDesktopApp();
+            sendCommand('desktopWorkdirState', { workdir: '/work/a', recentWorkdirs: [] });
+            // Once desktopPanes arrives the root ChatApp renders DesktopShell and
+            // never mounts its own chatContainer — the config dialog must still
+            // appear (regression: 更多-设置 did nothing while /config worked).
+            sendCommand('desktopPanes', {
+                panes: [{ paneId: 'pane-0', sessionId: 's1', host: 'local' }],
+                focusedPaneId: 'pane-0',
+            });
+
+            openSidebarMoreMenu();
+            fireEvent.click(screen.getByTestId('more-menu-settings'));
+
+            expect(screen.getByRole('heading', { name: '设置' })).toBeInTheDocument();
+            expect(screen.getByRole('tab', { name: '全局设置' })).toBeInTheDocument();
+        });
+
         it('posts login when 登录 is clicked while unauthenticated', () => {
             const { vscode } = renderDesktopApp();
             sendCommand('desktopWorkdirState', { workdir: '/work/a', recentWorkdirs: [] });
@@ -581,6 +599,8 @@ describe('DesktopApp', () => {
             openSidebarMoreMenu();
 
             expect(screen.getByTestId('more-menu-logout')).toHaveTextContent('退出登录（prod）');
+            // The 设置 entry names the host its config applies to, same as login
+            expect(screen.getByTestId('more-menu-settings')).toHaveTextContent('设置（prod）');
         });
 
         it('re-labels the login/logout entry when the focused pane switches host', () => {
@@ -598,6 +618,7 @@ describe('DesktopApp', () => {
             openSidebarMoreMenu();
             // The local host is the default subject — no annotation.
             expect(screen.getByTestId('more-menu-login').textContent).toBe('登录');
+            expect(screen.getByTestId('more-menu-settings').textContent).toBe('设置');
             fireEvent.keyDown(document, { key: 'Escape' });
 
             sendCommand('desktopPanes', {
@@ -609,6 +630,7 @@ describe('DesktopApp', () => {
             });
             openSidebarMoreMenu();
             expect(screen.getByTestId('more-menu-login')).toHaveTextContent('登录（prod）');
+            expect(screen.getByTestId('more-menu-settings')).toHaveTextContent('设置（prod）');
         });
     });
 


### PR DESCRIPTION
修复桌面端侧边栏「更多-设置」无反应，并为设置项加 host 标注（与登录条目一致，本地不加）。

根因：desktopHost 初始即持有 pane，任意操作后推送 desktopPanes，webview 侧根 ChatApp 只渲染 DesktopShell 而不挂载自己的 chatContainer；ConfigDialog 等所有对话框都渲染在 chatContainer 内，侧边栏更多-设置的 SHOW_DIALOG dispatch 到根实例 state 后无处渲染，因此点击无反应。/config 由 pane 子实例处理、渲染自己的 chatContainer，所以正常。

改动：
- ChatApp：全部对话框（config/plugin/mcp/status/tasks/workflows/rewind 确认框）从 chatContainer 提取为组件顶层 dialogs，四个 return 分支（DesktopShell / pane 实例 / 单 pane 布局 / 非桌面）均渲染
- MoreMenu：设置项按 hostLabel 标注远程主机（如「设置（lyq.u）」），本地 host 不标注
- 测试：新增 DesktopShell 布局下点击设置断言对话框渲染的回归测试；host 标注断言覆盖本地/远程

验证：desktopApp 98 测试全绿，webview 全量 614 测试通过，type-check 通过，webview dist 已重建同步。