### PR TITLE
fix(rewind): 统一消息列表回滚按钮与 /rewind 检查点判定

### DIFF
--- a/packages/code/src/utils/rewindCheckpoints.ts
+++ b/packages/code/src/utils/rewindCheckpoints.ts
@@ -2,8 +2,8 @@ import type { Message } from "wave-agent-sdk";
 
 /**
  * 判断一条 user 消息能否作为 /rewind 检查点。
- * 后台任务通知（task_notification）与 hook 注入的消息（source: "hook"）
- * 都是系统生成、用户不可见的，不能作为回滚点。
+ * 后台任务通知（task_notification）、hook 注入的消息（source: "hook"）
+ * 与 bang 命令消息都是系统生成、用户不可见的，不能作为回滚点。
  * CLI 交互式选择器与 stdio listRewindCheckpoints 共用此判定，避免两处漂移。
  */
 export function isUserCheckpointMessage(m: Message): boolean {
@@ -11,5 +11,6 @@ export function isUserCheckpointMessage(m: Message): boolean {
   if (m.blocks.some((b) => b.type === "task_notification")) return false;
   if (m.blocks.some((b) => b.type === "text" && b.source === "hook"))
     return false;
+  if (m.blocks.some((b) => b.type === "bang")) return false;
   return true;
 }

--- a/packages/code/tests/components/RewindCommand.test.tsx
+++ b/packages/code/tests/components/RewindCommand.test.tsx
@@ -57,7 +57,7 @@ describe("RewindCommand Content", () => {
     });
   });
 
-  it("should display bang command content", async () => {
+  it("should exclude bang command messages", async () => {
     const mockMessages: Partial<Message>[] = [
       {
         id: "1",
@@ -84,7 +84,9 @@ describe("RewindCommand Content", () => {
 
     await vi.waitFor(() => {
       const output = stripAnsiColors(lastFrame() || "");
-      expect(output).toContain("!ls -la");
+      // bang 命令消息是系统执行结果，不作为回滚点
+      expect(output).not.toContain("!ls -la");
+      expect(output).toContain("No user messages found to rewind to.");
     });
   });
 

--- a/packages/code/tests/stdio/agentBridge.test.ts
+++ b/packages/code/tests/stdio/agentBridge.test.ts
@@ -851,6 +851,12 @@ test("listRewindCheckpoints filters to real user messages and flattens content",
       id: "u5",
       blocks: [{ type: "text", content: "hook 输出", source: "hook" }],
     },
+    // bang 命令消息是系统执行结果，不是用户输入
+    {
+      role: "user",
+      id: "u6",
+      blocks: [{ type: "bang", command: "deploy", stage: "end", exitCode: 0 }],
+    },
   ] as unknown as Message[];
   const mockAgent = createMockAgent({
     getFullMessageThread: vi.fn().mockResolvedValue({

--- a/packages/webview/src/components/Message.tsx
+++ b/packages/webview/src/components/Message.tsx
@@ -17,7 +17,7 @@ import {
   ASK_USER_QUESTION_TOOL_NAME,
   EXIT_PLAN_MODE_TOOL_NAME
 } from 'wave-agent-sdk/dist/constants/tools.js';
-import type { MessageProps, ToolBlock, ImageBlock, TaskNotificationBlock, ReasoningBlock, CompactBlock, MessageBlock } from '../types';
+import type { Message as MessageType, MessageProps, ToolBlock, ImageBlock, TaskNotificationBlock, ReasoningBlock, CompactBlock, MessageBlock } from '../types';
 import { DiffViewer } from './DiffViewer';
 import { MermaidRenderer } from './MermaidRenderer';
 import { ReasoningBlockView } from './ReasoningBlockView';
@@ -99,6 +99,16 @@ const parseMarkdownWithMermaid = (content: string): ParsedMarkdownContent => {
 
   return { elements };
 };
+
+// 与 CLI /rewind 检查点判定（isUserCheckpointMessage）保持一致：后台任务
+// 通知与 hook 注入的系统生成消息不作为回滚目标，bang 命令消息也不显示按钮。
+const isRewindTargetMessage = (message: MessageType): boolean =>
+  message.role === 'user' &&
+  !message.isMeta &&
+  !!message.id &&
+  !message.blocks.some((b) => b.type === 'bang') &&
+  !message.blocks.some((b) => b.type === 'task_notification') &&
+  !message.blocks.some((b) => b.type === 'text' && b.source === 'hook');
 
 
 export const Message: React.FC<MessageProps> = React.memo((props) => {
@@ -721,7 +731,7 @@ export const Message: React.FC<MessageProps> = React.memo((props) => {
   return (
     <div className={getMessageClassName()} data-message-id={message.id} data-role={message.role}>
       {message.blocks?.map((block, index) => renderBlock(block, index))}
-      {message.role === 'user' && !isQueued && message.id && !message.blocks?.some(b => b.type === 'bang') && (
+      {isRewindTargetMessage(message) && !isQueued && (
         <div className="message-actions">
           <Tooltip text="回滚到此消息" position="bottom">
             <button 

--- a/packages/webview/tests/webview/rewind.test.tsx
+++ b/packages/webview/tests/webview/rewind.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderChatApp, screen, waitFor, fireEvent, act, sendCommand } from './test-utils';
 import { MockDataGenerator } from '../fixtures/mockData';
+import type { Message } from 'wave-agent-sdk';
+import { MessageSource } from 'wave-agent-sdk';
 
 describe('Rewind Feature', () => {
     beforeEach(() => {
@@ -178,6 +180,70 @@ describe('Rewind Feature', () => {
         // Rewind buttons should only appear on user messages
         const rewindButtons = document.querySelectorAll('.message-action-btn');
         // Only 1 user message (non-bang) should have a rewind button
+        expect(rewindButtons).toHaveLength(1);
+    });
+
+    it('should not show rewind button on background task notification messages', async () => {
+        renderChatApp();
+
+        const notificationMessage: Message = {
+            id: 'msg-notif',
+            role: 'user',
+            timestamp: '2024-01-01T00:00:00.000Z',
+            blocks: [{
+                type: 'task_notification',
+                taskId: 'task-1',
+                taskType: 'shell',
+                status: 'completed',
+                summary: 'Task done'
+            }]
+        };
+
+        const messages = [
+            MockDataGenerator.createUserMessage('User message', 'msg-user'),
+            notificationMessage,
+            MockDataGenerator.createAssistantMessage('Assistant message', 'msg-assistant')
+        ];
+
+        act(() => {
+            sendCommand('updateMessages', { messages });
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('User message')).toBeInTheDocument();
+        });
+
+        // Only the real user message has a rewind button; the background
+        // notification (role: user) must not — it is not a rewind checkpoint.
+        const rewindButtons = document.querySelectorAll('.message-action-btn');
+        expect(rewindButtons).toHaveLength(1);
+    });
+
+    it('should not show rewind button on hook-injected user messages', async () => {
+        renderChatApp();
+
+        const hookMessage: Message = {
+            id: 'msg-hook',
+            role: 'user',
+            timestamp: '2024-01-01T00:00:00.000Z',
+            blocks: [{ type: 'text', content: 'hook context', source: MessageSource.HOOK }]
+        };
+
+        const messages = [
+            MockDataGenerator.createUserMessage('User message', 'msg-user'),
+            hookMessage
+        ];
+
+        act(() => {
+            sendCommand('updateMessages', { messages });
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('User message')).toBeInTheDocument();
+        });
+
+        // Hook-injected messages are system-generated and not rewind checkpoints
+        const rewindButtons = document.querySelectorAll('.message-action-btn');
         expect(rewindButtons).toHaveLength(1);
     });
 });


### PR DESCRIPTION
统一消息列表回滚按钮与 /rewind 检查点判定，三者（webview 按钮 / CLI 选择器 / stdio listRewindCheckpoints）行为一致：

- webview Message 组件新增 isRewindTargetMessage：后台任务通知（task_notification）、hook 注入消息、isMeta 与 bang 命令消息不显示回滚按钮
- code isUserCheckpointMessage 新增 bang 消息排除
- 测试：webview rewind.test.tsx 新增 notification/hook 两用例；agentBridge.test.ts 线程加 bang 消息断言；RewindCommand.test.tsx bang 用例改为排除断言

验证：webview 616 通过、code 1295 通过、type-check 全绿。