### PR TITLE
chore(desktop): sign and notarize macOS desktop builds on CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -143,8 +143,9 @@ jobs:
   # --- Desktop app (Electron) ---
   # Builds the desktop installers and attaches them to the same GitHub Release
   # (FR-021). macOS .dmg requires a macOS runner and Windows NSIS a Windows
-  # runner, hence the matrix. Unsigned builds — no signing certs configured yet;
-  # the docs describe the Gatekeeper bypass for macOS users.
+  # runner, hence the matrix. macOS builds are Developer ID-signed and notarized
+  # via CSC_LINK/CSC_KEY_PASSWORD (p12) + App Store Connect API key secrets;
+  # Windows builds remain unsigned (no code-signing cert configured).
   build-desktop:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -177,8 +178,22 @@ jobs:
         run: pnpm -F wave-webview run compile -- --production
 
       # `--publish never`: electron-builder only produces the installers; the
-      # release upload is handled by action-gh-release below.
-      - name: Build desktop installers
+      # release upload is handled by action-gh-release below. Apple signing +
+      # notarization env vars are injected only on macOS (the p12 and App Store
+      # Connect API key are Apple-specific; passing them to the Windows runner
+      # would make electron-builder attempt an invalid signature there).
+      - name: Build desktop installers (macOS)
+        if: runner.os == 'macOS'
+        run: pnpm -F wave-desktop run dist -- --publish never
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+      - name: Build desktop installers (Windows)
+        if: runner.os == 'Windows'
         run: pnpm -F wave-desktop run dist -- --publish never
 
       - name: Attach installers to GitHub Release

--- a/.github/workflows/refresh-release-assets.yml
+++ b/.github/workflows/refresh-release-assets.yml
@@ -125,8 +125,23 @@ jobs:
       - run: pnpm -F wave-webview run compile -- --production
 
       # `--publish never`: electron-builder only produces the installers;
-      # the release upload is handled below.
-      - run: pnpm -F wave-desktop run dist -- --publish never
+      # the release upload is handled below. Apple signing + notarization
+      # env vars are injected only on macOS (see publish.yml build-desktop);
+      # without them the macOS artifacts would be unsigned and --clobber
+      # would overwrite the signed assets on the release.
+      - name: Build desktop installers (macOS)
+        if: runner.os == 'macOS'
+        run: pnpm -F wave-desktop run dist -- --publish never
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+      - name: Build desktop installers (Windows)
+        if: runner.os == 'Windows'
+        run: pnpm -F wave-desktop run dist -- --publish never
 
       - name: Overwrite desktop installers on latest release
         shell: bash

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -52,8 +52,10 @@
     "afterPack": "scripts/afterPack.js",
     "mac": {
       "category": "public.app-category.developer-tools",
-      "identity": null,
+      "identity": "Hangzhou Langhe Technology Company Limited (86Y5QKVXN9)",
       "icon": "assets/icon.png",
+      "hardenedRuntime": true,
+      "notarize": true,
       "target": [
         {
           "target": "dmg",


### PR DESCRIPTION
macOS desktop installers are now Developer ID-signed and notarized in CI.

- packages/desktop/package.json: mac.identity set to the Developer ID (Hangzhou Langhe Technology Company Limited), hardenedRuntime + notarize enabled
- .github/workflows/publish.yml: desktop build split into macOS/Windows steps; macOS runner injects CSC_LINK (p12) + CSC_KEY_PASSWORD + App Store Connect API key secrets
- .github/workflows/refresh-release-assets.yml: same split so the --clobber release overwrite never replaces signed macOS artifacts with unsigned ones

Windows builds remain unsigned (no code-signing cert configured). Secrets already set in the repo. Local verify loop done: notarization accepted, Gatekeeper spctl accepted (Notarized Developer ID), stapler validate passed.