### PR TITLE
fix(webview): avoid jsdom navigation warning in link routing test

### DIFF
--- a/packages/webview/tests/webview/messageLinkRouting.test.tsx
+++ b/packages/webview/tests/webview/messageLinkRouting.test.tsx
@@ -12,12 +12,12 @@ import { MockDataGenerator } from '../fixtures/mockData';
 const CONTENT =
     'preview [local app](http://localhost:5173/app) then [docs](https://example.com/docs)';
 
-function renderMessage(options?: { onOpenPreview?: (url: string) => void; hostType?: string }) {
+function renderMessage(options?: { onOpenPreview?: (url: string) => void; hostType?: string; content?: string }) {
     const vscode = createMockVscode();
     if (options?.hostType) {
         window.waveHostType = options.hostType;
     }
-    const message = MockDataGenerator.createAssistantMessage(CONTENT);
+    const message = MockDataGenerator.createAssistantMessage(options?.content ?? CONTENT);
     const result = render(
         <Message message={message} vscode={vscode} onOpenPreview={options?.onOpenPreview} />
     );
@@ -67,7 +67,12 @@ describe('Message link routing', () => {
 
     it('IDE host: links are not intercepted at all', () => {
         const onOpenPreview = vi.fn();
-        const { vscode, localLink, externalLink } = renderMessage({ onOpenPreview });
+        // jsdom only implements same-document (fragment) navigation; clicking
+        // real URLs would trigger its unimplemented cross-document navigation.
+        const { vscode, localLink, externalLink } = renderMessage({
+            onOpenPreview,
+            content: 'preview [local app](#app) then [docs](#docs)',
+        });
 
         const localNotPrevented = fireEvent.click(localLink);
         const externalNotPrevented = fireEvent.click(externalLink);


### PR DESCRIPTION
jsdom does not implement cross-document navigation; clicking a real URL link in the IDE host link-routing test triggered the "Not implemented: navigation to another Document" warning on every test run.

Fix the test at the source instead of silencing the warning: the IDE host case now uses fragment links (#app / #docs), which jsdom handles natively (navigateToFragment), keeping the same not-prevented assertions intact. The desktop host cases are unaffected since they preventDefault anyway. No setup.ts console silencing needed.