### PR TITLE
fix(desktop): notarize with p8 file path instead of raw PEM content

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -182,13 +182,23 @@ jobs:
       # notarization env vars are injected only on macOS (the p12 and App Store
       # Connect API key are Apple-specific; passing them to the Windows runner
       # would make electron-builder attempt an invalid signature there).
+      #
+      # APPLE_API_KEY must be a PATH to the .p8 file: @electron/notarize
+      # forwards it verbatim as `notarytool --key <value>` (no base64 decode
+      # or temp-file write on our installed 2.5.0), so the raw PEM content
+      # would be parsed as an option (starts with '-') → "Invalid option".
+      # Materialize the secret into a runner-local file first.
       - name: Build desktop installers (macOS)
         if: runner.os == 'macOS'
-        run: pnpm -F wave-desktop run dist -- --publish never
+        run: |
+          mkdir -p "$HOME/private_keys"
+          printf '%s' "$APPLE_API_KEY_CONTENT" > "$HOME/private_keys/AuthKey_$APPLE_API_KEY_ID.p8"
+          chmod 600 "$HOME/private_keys/AuthKey_$APPLE_API_KEY_ID.p8"
+          APPLE_API_KEY="$HOME/private_keys/AuthKey_$APPLE_API_KEY_ID.p8" pnpm -F wave-desktop run dist -- --publish never
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
 

--- a/.github/workflows/refresh-release-assets.yml
+++ b/.github/workflows/refresh-release-assets.yml
@@ -129,13 +129,23 @@ jobs:
       # env vars are injected only on macOS (see publish.yml build-desktop);
       # without them the macOS artifacts would be unsigned and --clobber
       # would overwrite the signed assets on the release.
+      #
+      # APPLE_API_KEY must be a PATH to the .p8 file: @electron/notarize
+      # forwards it verbatim as `notarytool --key <value>` (no base64 decode
+      # or temp-file write on our installed 2.5.0), so the raw PEM content
+      # would be parsed as an option (starts with '-') → "Invalid option".
+      # Materialize the secret into a runner-local file first.
       - name: Build desktop installers (macOS)
         if: runner.os == 'macOS'
-        run: pnpm -F wave-desktop run dist -- --publish never
+        run: |
+          mkdir -p "$HOME/private_keys"
+          printf '%s' "$APPLE_API_KEY_CONTENT" > "$HOME/private_keys/AuthKey_$APPLE_API_KEY_ID.p8"
+          chmod 600 "$HOME/private_keys/AuthKey_$APPLE_API_KEY_ID.p8"
+          APPLE_API_KEY="$HOME/private_keys/AuthKey_$APPLE_API_KEY_ID.p8" pnpm -F wave-desktop run dist -- --publish never
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
 


### PR DESCRIPTION
CI 公证失败 Invalid option: *** 的根因修复。

根因：@electron/notarize 2.5.0（electron-builder 26.15.3 透传）把 APPLE_API_KEY 原样作为 notarytool --key 参数，期望 p8 文件路径而非内容。GitHub secret 存的 PEM 内容以 ----BEGIN 开头，被 notarytool 当 option 解析报 Invalid option。electron-builder 文档页所述 base64 内容与实现不符（源码核实 2.5.0 与 master 均无解码）。

修复：workflow macOS 步骤先把 secret 写入 runner 本地 ~/private_keys/AuthKey_<id>.p8，APPLE_API_KEY 指向该路径。publish.yml 与 refresh-release-assets.yml 同步修改。