### PR TITLE
feat(desktop): auto-update via codechat feed with electron-updater

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -182,6 +182,7 @@ export default {
             { text: '终端面板', link: '/desktop#终端面板' },
             { text: 'localhost 原型预览与元素评论', link: '/desktop#localhost-原型预览与元素评论' },
             { text: '核心交互', link: '/desktop#核心交互' },
+            { text: '自动更新', link: '/desktop#自动更新' },
             { text: '登录', link: '/desktop#登录' },
           ],
         },

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -221,6 +221,19 @@ Wave 桌面版是一个独立的 Electron 应用，无需安装 IDE 即可使用
 - [权限模式管理](/vsce#permission-modes)
 - [配置设置](/vsce#configuration-settings)
 
+## 自动更新
+
+应用在后台自动检查新版本（已登录企业版时经 codechat 下载端点，未登录回退 GitHub Releases），发现新版本时在右下角弹出应用内 toast 提示（非模态，不打断当前输入），无需理会、会自动消失：
+
+![发现新版本 toast](/screenshots/desktop-update-toast.webp)
+
+新版本下载完成后，toast 带「重启安装」按钮，点击即退出并安装新版本：
+
+![更新就绪 toast](/screenshots/desktop-update-toast-action.webp)
+
+- 下载完成后不弹二次确认对话框——toast 按钮即唯一操作入口；不需要时可点右上角 × 关闭，稍后侧边栏「更多」→ 设置中的「检查更新」可再次触发
+- 更新服务故障（端点不可达 / 下载失败）或 macOS 上应用位于不可写位置时，toast 会带「打开下载页」按钮，引导手动下载安装，不静默失败
+
 ## 登录
 
 桌面版支持 SSO 登录，复用与 IDE 插件相同的登录按钮与登录对话框；授权页面会在系统默认浏览器中打开，登录流程由内置 CLI 子进程完成。登录为可选项 —— 未登录时也可通过自定义配置（API Key / Base URL）直连模型服务。登录/登出入口位于侧边栏「更多」菜单（见上文）。

--- a/docs/specs/ui/desktop-app.md
+++ b/docs/specs/ui/desktop-app.md
@@ -287,11 +287,11 @@ desktop 还支持**并排多对话**：`Cmd/Ctrl+Click` 或拖拽侧边栏中的
 **验收场景**：
 
 1. **假设**用户已登录企业版（存在 serverUrl），**当**应用触发更新检查，**则**必须通过 electron-updater 的 generic provider 查询 `serverUrl/api/downloads/desktop/{mac|win}/` 下的更新元数据（按当前平台区分 mac/win），不得再查询 GitHub Releases。
-2. **假设**用户未登录（无 serverUrl），**当**应用触发更新检查，**则**不得启动 electron-updater，必须回退现有 checkForUpdate 流程（GitHub Releases 查询 + 系统消息提示 + 下载 URL）。
-3. **假设**electron-updater 检测到新版本，**当**收到 update-available 事件，**则**必须向消息流推送系统消息（非模态）告知发现新版本，不打断当前输入。
-4. **假设**新版本下载完成，**当**收到 update-downloaded 事件，**则**必须提供「重启安装」入口（如消息流中的操作按钮），用户确认后调用 quitAndInstall 退出并安装新版本。
-5. **假设**更新服务故障（端点不可达 / 元数据解析失败 / 下载失败），**当**自动更新链路失败，**则**必须降级为现有 checkForUpdate 提示流程（系统消息给出新版本号与下载 URL），不得静默失败或让用户错过更新。
-6. **假设**用户打开状态对话框点击「检查更新」，**当**手动检查触发，**则**必须复用自动更新链路：已登录走 electron-updater（无更新时提示「当前已是最新版本」，有更新按场景 3-4 下载安装），未登录回退 GitHub 提示。
+2. **假设**用户未登录（无 serverUrl），**当**应用触发更新检查，**则**不得启动 electron-updater，必须回退现有 checkForUpdate 流程（GitHub Releases 查询 + 系统通知提示 + 下载 URL）。
+3. **假设**electron-updater 检测到新版本，**当**收到 update-available 事件，**则**必须弹出系统通知（非模态）告知发现新版本，不打断当前输入。
+4. **假设**新版本下载完成，**当**收到 update-downloaded 事件，**则**必须弹出确认对话框提供「重启安装」入口，用户确认后调用 quitAndInstall 退出并安装新版本。
+5. **假设**更新服务故障（端点不可达 / 元数据解析失败 / 下载失败），**当**自动更新链路失败，**则**必须降级为现有 checkForUpdate 提示流程（系统通知给出新版本号与下载 URL），不得静默失败或让用户错过更新。
+6. **假设**用户打开状态对话框点击「检查更新」，**当**手动检查触发，**则**必须复用自动更新链路：已登录走 electron-updater（无更新时系统通知「当前已是最新版本」，有更新按场景 3-4 下载安装），未登录回退 GitHub 提示。
 7. **假设**已登录企业版且 codechat 端点返回更新信息，**当**updateChecker 构造下载地址，**则** downloadUrl 必须指向真实下载入口（安装包 / 下载页），不得指向 manifest.json 自身（修复 updateChecker.ts:99）。
 8. **假设**macOS 上应用运行于不可写位置（如非 /Applications），**当**更新下载完成但无法原地安装，**则**必须提示用户手动下载安装并给出下载 URL，不得静默失败。
 

--- a/docs/specs/ui/desktop-app.md
+++ b/docs/specs/ui/desktop-app.md
@@ -287,13 +287,13 @@ desktop 还支持**并排多对话**：`Cmd/Ctrl+Click` 或拖拽侧边栏中的
 **验收场景**：
 
 1. **假设**用户已登录企业版（存在 serverUrl），**当**应用触发更新检查，**则**必须通过 electron-updater 的 generic provider 查询 `serverUrl/api/downloads/desktop/{mac|win}/` 下的更新元数据（按当前平台区分 mac/win），不得再查询 GitHub Releases。
-2. **假设**用户未登录（无 serverUrl），**当**应用触发更新检查，**则**不得启动 electron-updater，必须回退现有 checkForUpdate 流程（GitHub Releases 查询 + 系统通知提示 + 下载 URL）。
-3. **假设**electron-updater 检测到新版本，**当**收到 update-available 事件，**则**必须弹出系统通知（非模态）告知发现新版本，不打断当前输入。
-4. **假设**新版本下载完成，**当**收到 update-downloaded 事件，**则**必须弹出确认对话框提供「重启安装」入口，用户确认后调用 quitAndInstall 退出并安装新版本。
-5. **假设**更新服务故障（端点不可达 / 元数据解析失败 / 下载失败），**当**自动更新链路失败，**则**必须降级为现有 checkForUpdate 提示流程（系统通知给出新版本号与下载 URL），不得静默失败或让用户错过更新。
-6. **假设**用户打开状态对话框点击「检查更新」，**当**手动检查触发，**则**必须复用自动更新链路：已登录走 electron-updater（无更新时系统通知「当前已是最新版本」，有更新按场景 3-4 下载安装），未登录回退 GitHub 提示。
+2. **假设**用户未登录（无 serverUrl），**当**应用触发更新检查，**则**不得启动 electron-updater，必须回退现有 checkForUpdate 流程（GitHub Releases 查询 + 应用内 toast 提示 + 下载 URL）。
+3. **假设**electron-updater 检测到新版本，**当**收到 update-available 事件，**则**必须在右下角弹出应用内 toast（非模态，模仿 VS Code）告知发现新版本，不打断当前输入。
+4. **假设**新版本下载完成，**当**收到 update-downloaded 事件，**则**必须通过应用内 toast 提供「重启安装」按钮，用户点击后调用 quitAndInstall 退出并安装新版本（不再弹二次确认对话框）。
+5. **假设**更新服务故障（端点不可达 / 元数据解析失败 / 下载失败），**当**自动更新链路失败，**则**必须降级为现有 checkForUpdate 提示流程（应用内 toast 给出新版本号与「打开下载页」按钮），不得静默失败或让用户错过更新。
+6. **假设**用户打开状态对话框点击「检查更新」，**当**手动检查触发，**则**必须复用自动更新链路：已登录走 electron-updater（无更新时 toast 提示「当前已是最新版本」，有更新按场景 3-4 下载安装），未登录回退 GitHub 提示。
 7. **假设**已登录企业版且 codechat 端点返回更新信息，**当**updateChecker 构造下载地址，**则** downloadUrl 必须指向真实下载入口（安装包 / 下载页），不得指向 manifest.json 自身（修复 updateChecker.ts:99）。
-8. **假设**macOS 上应用运行于不可写位置（如非 /Applications），**当**更新下载完成但无法原地安装，**则**必须提示用户手动下载安装并给出下载 URL，不得静默失败。
+8. **假设**macOS 上应用运行于不可写位置（如非 /Applications），**当**更新下载完成但无法原地安装，**则**必须通过应用内 toast 提示用户手动下载安装（带「打开下载页」按钮）并给出下载 URL，不得静默失败。
 
 ---
 

--- a/docs/specs/ui/desktop-app.md
+++ b/docs/specs/ui/desktop-app.md
@@ -276,6 +276,27 @@ desktop 还支持**并排多对话**：`Cmd/Ctrl+Click` 或拖拽侧边栏中的
 
 ---
 
+### 用户故事：桌面端自动更新（优先级：P1）
+
+作为用户，我希望桌面应用检测到新版本时自动下载、就绪后一键重启安装，以便我无需手动访问下载页面即可获得修复与新功能。
+
+**为什么是这个优先级**：应用更新是修复与功能到达用户的唯一通道；现状仅「提示 + 给下载 URL」，用户不主动访问下载页就拿不到修复。macOS 签名 + 公证已就绪（ed2d9bf7 + 6f00c44a），自动更新链路可以端到端闭环。企业版用户登录后 serverUrl 已知，更新源（codechat 的 file-center 更新元数据）运行时注入，构建期不写死。
+
+**独立测试**：本地 mock 一个 generic 更新源（`latest-mac.yml`/`latest.yml`，元数据指向更高版本），登录后触发检查，验证「发现更新 → 下载 → 重启安装」全流程；无 serverUrl 时验证回退 GitHub 提示流程；更新端点故障时验证降级提示。
+
+**验收场景**：
+
+1. **假设**用户已登录企业版（存在 serverUrl），**当**应用触发更新检查，**则**必须通过 electron-updater 的 generic provider 查询 `serverUrl/api/downloads/desktop/{mac|win}/` 下的更新元数据（按当前平台区分 mac/win），不得再查询 GitHub Releases。
+2. **假设**用户未登录（无 serverUrl），**当**应用触发更新检查，**则**不得启动 electron-updater，必须回退现有 checkForUpdate 流程（GitHub Releases 查询 + 系统消息提示 + 下载 URL）。
+3. **假设**electron-updater 检测到新版本，**当**收到 update-available 事件，**则**必须向消息流推送系统消息（非模态）告知发现新版本，不打断当前输入。
+4. **假设**新版本下载完成，**当**收到 update-downloaded 事件，**则**必须提供「重启安装」入口（如消息流中的操作按钮），用户确认后调用 quitAndInstall 退出并安装新版本。
+5. **假设**更新服务故障（端点不可达 / 元数据解析失败 / 下载失败），**当**自动更新链路失败，**则**必须降级为现有 checkForUpdate 提示流程（系统消息给出新版本号与下载 URL），不得静默失败或让用户错过更新。
+6. **假设**用户打开状态对话框点击「检查更新」，**当**手动检查触发，**则**必须复用自动更新链路：已登录走 electron-updater（无更新时提示「当前已是最新版本」，有更新按场景 3-4 下载安装），未登录回退 GitHub 提示。
+7. **假设**已登录企业版且 codechat 端点返回更新信息，**当**updateChecker 构造下载地址，**则** downloadUrl 必须指向真实下载入口（安装包 / 下载页），不得指向 manifest.json 自身（修复 updateChecker.ts:99）。
+8. **假设**macOS 上应用运行于不可写位置（如非 /Applications），**当**更新下载完成但无法原地安装，**则**必须提示用户手动下载安装并给出下载 URL，不得静默失败。
+
+---
+
 ### 用户故事：跟随系统主题（优先级：P2）
 
 作为用户，我希望 desktop 自动跟随操作系统的亮色/暗色外观，与 IDE 插件保持一致的"不暴露独立主题切换选项"行为（VSCE 跟随 VS Code 主题、JetBrains 跟随 IDE LaF），避免在桌面端重复维护一套主题切换 UI。
@@ -661,3 +682,7 @@ desktop 还支持**并排多对话**：`Cmd/Ctrl+Click` 或拖拽侧边栏中的
 - **IDE 插件的 file 面板**：VSCE/JetBrains 不提供该面板，其 `openFile` 由 IDE 自身处理（含 IDE 的 Remote-SSH 能力）。
 - **语法高亮的语言覆盖**：仅覆盖常用语言子集（highlight.js common 集），未覆盖语言纯文本展示。
 - **文件内搜索与符号跳转**：不做文件内文本搜索、符号跳转等编辑器能力。
+- **Windows 更新包签名校验**：Windows 安装包未签名，electron-updater 对未签名当前应用不校验更新签名（与现分发一致，SmartScreen 警告不在自动更新范围解决）。
+- **Linux 自动更新**：首版仅 macOS（arm64）与 Windows。
+- **CI 发布自动上传**：CI 保持 `--publish never` 零改动，安装包由 ops 手动上传 codechat file-center，与 vscode/jetbrains 分发方式一致。
+- **更新安装的推迟调度**：重启安装立即执行（quitAndInstall），不做「推迟到下次退出应用」的调度。

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -83,6 +83,8 @@
     }
   },
   "dependencies": {
+    "electron-updater": "^6.8.9",
+    "js-yaml": "^5.2.3",
     "node-pty": "^1.2.0-beta.14"
   }
 }

--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -60,6 +60,7 @@ import { getWorkspaceDiff } from './gitDiff';
 import { TerminalManager } from './terminal';
 import { PortForwardManager, type AuthCallbackForward } from './portForward';
 import { checkForUpdate } from './updateChecker';
+import { AutoUpdaterService } from './updateAutoUpdater';
 import { HOST_CHANNEL } from './channels';
 import type { PanelKind } from './menu';
 
@@ -219,6 +220,8 @@ export class DesktopHost {
 
   private updateCheckTriggered = false;
   private lastIsAuthenticated = false;
+  /** electron-updater path, created lazily once a serverUrl is configured. */
+  private autoUpdaterService: AutoUpdaterService | null = null;
 
   /** Latest panel toggle state reported by each pane's webview (drives the 面板 menu). */
   private panePanelState = new Map<string, PanelKind[]>();
@@ -3289,11 +3292,61 @@ export class DesktopHost {
   }
 
   private async handleCheckForUpdates(manual: boolean): Promise<void> {
-    const info = await checkForUpdate(app.getVersion(), this.configStore.getConfiguration().serverUrl);
+    const serverUrl = this.configStore.getConfiguration().serverUrl;
+
+    // Logged in → the codechat feed drives updates via electron-updater
+    // (background download + one-shot install). Unauthenticated installs fall
+    // back to the GitHub Releases flow (system message + download URL).
+    if (serverUrl) {
+      if (!this.autoUpdaterService) {
+        this.autoUpdaterService = new AutoUpdaterService({
+          onUpdateAvailable: (info) =>
+            this.pushSystemMessage(`发现新版本 v${info.version}（当前 v${app.getVersion()}），正在后台下载…`),
+          onUpdateDownloaded: (info) => void this.handleUpdateDownloaded(info.version),
+          onError: () => void this.handleAutoUpdaterError(serverUrl),
+        });
+      }
+      const outcome = await this.autoUpdaterService.checkForUpdates(serverUrl);
+      if (outcome === 'update') return;
+      if (outcome === 'no-update') {
+        if (manual) this.pushSystemMessage('当前已是最新版本');
+        return;
+      }
+      // outcome === 'error': degrade to the manual checker below.
+      console.warn('[DesktopHost] Auto update check failed, falling back to manual check');
+    }
+
+    const info = await checkForUpdate(app.getVersion(), serverUrl);
     if (info) {
       this.pushSystemMessage(`发现新版本 v${info.latestVersion}（当前 v${info.currentVersion}）：${info.downloadUrl}`);
     } else if (manual) {
       this.pushSystemMessage('当前已是最新版本');
+    }
+  }
+
+  /** The background download (or a later check) errored — degrade to the
+   *  manual checker so the user still learns about the update with a URL. */
+  private async handleAutoUpdaterError(serverUrl: string): Promise<void> {
+    console.warn('[DesktopHost] Auto updater errored, falling back to manual check');
+    const info = await checkForUpdate(app.getVersion(), serverUrl);
+    if (info) {
+      this.pushSystemMessage(`发现新版本 v${info.latestVersion}（当前 v${info.currentVersion}）：${info.downloadUrl}`);
+    }
+  }
+
+  /** The new version finished downloading — confirm before installing. */
+  private async handleUpdateDownloaded(version: string): Promise<void> {
+    this.pushSystemMessage(`新版本 v${version} 已下载完成，重启应用即可安装`);
+    const { response } = await dialog.showMessageBox({
+      type: 'info',
+      buttons: ['重启安装', '稍后'],
+      defaultId: 0,
+      cancelId: 1,
+      message: 'Wave 更新已就绪',
+      detail: `新版本 v${version} 已下载完成，重启应用以完成安装。`,
+    });
+    if (response === 0) {
+      this.autoUpdaterService?.quitAndInstall();
     }
   }
 

--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -8,7 +8,7 @@
  * packages/vsce/src/session/{chatSession,messageHandler}.ts).
  */
 
-import { app, dialog, shell, nativeTheme, powerMonitor, type BrowserWindow } from 'electron';
+import { app, dialog, shell, nativeTheme, powerMonitor, Notification, type BrowserWindow } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -440,6 +440,13 @@ export class DesktopHost {
 
   private emitPanelState(): void {
     this.onPanelStateChanged?.(this.panePanelState.get(this.focusedPaneId) ?? []);
+  }
+
+  /** Surface an update event as a non-modal OS notification. */
+  private showUpdateNotification(title: string, body: string): void {
+    if (Notification.isSupported()) {
+      new Notification({ title, body }).show();
+    }
   }
 
   /** Insert a host-generated system message into a pane's chat stream (focused pane by default). */
@@ -3301,7 +3308,10 @@ export class DesktopHost {
       if (!this.autoUpdaterService) {
         this.autoUpdaterService = new AutoUpdaterService({
           onUpdateAvailable: (info) =>
-            this.pushSystemMessage(`发现新版本 v${info.version}（当前 v${app.getVersion()}），正在后台下载…`),
+            this.showUpdateNotification(
+              '发现新版本',
+              `v${info.version}（当前 v${app.getVersion()}），正在后台下载…`,
+            ),
           onUpdateDownloaded: (info) => void this.handleUpdateDownloaded(info.version),
           onError: () => void this.handleAutoUpdaterError(serverUrl),
         });
@@ -3309,7 +3319,7 @@ export class DesktopHost {
       const outcome = await this.autoUpdaterService.checkForUpdates(serverUrl);
       if (outcome === 'update') return;
       if (outcome === 'no-update') {
-        if (manual) this.pushSystemMessage('当前已是最新版本');
+        if (manual) this.showUpdateNotification('Wave 更新', '当前已是最新版本');
         return;
       }
       // outcome === 'error': degrade to the manual checker below.
@@ -3318,9 +3328,9 @@ export class DesktopHost {
 
     const info = await checkForUpdate(app.getVersion(), serverUrl);
     if (info) {
-      this.pushSystemMessage(`发现新版本 v${info.latestVersion}（当前 v${info.currentVersion}）：${info.downloadUrl}`);
+      this.showUpdateNotification('发现新版本', `v${info.latestVersion}（当前 v${info.currentVersion}）：${info.downloadUrl}`);
     } else if (manual) {
-      this.pushSystemMessage('当前已是最新版本');
+      this.showUpdateNotification('Wave 更新', '当前已是最新版本');
     }
   }
 
@@ -3330,13 +3340,13 @@ export class DesktopHost {
     console.warn('[DesktopHost] Auto updater errored, falling back to manual check');
     const info = await checkForUpdate(app.getVersion(), serverUrl);
     if (info) {
-      this.pushSystemMessage(`发现新版本 v${info.latestVersion}（当前 v${info.currentVersion}）：${info.downloadUrl}`);
+      this.showUpdateNotification('发现新版本', `v${info.latestVersion}（当前 v${info.currentVersion}）：${info.downloadUrl}`);
     }
   }
 
   /** The new version finished downloading — confirm before installing. */
   private async handleUpdateDownloaded(version: string): Promise<void> {
-    this.pushSystemMessage(`新版本 v${version} 已下载完成，重启应用即可安装`);
+    this.showUpdateNotification('Wave 更新', `新版本 v${version} 已下载完成`);
     const { response } = await dialog.showMessageBox({
       type: 'info',
       buttons: ['重启安装', '稍后'],

--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -8,7 +8,7 @@
  * packages/vsce/src/session/{chatSession,messageHandler}.ts).
  */
 
-import { app, dialog, shell, nativeTheme, powerMonitor, Notification, type BrowserWindow } from 'electron';
+import { app, dialog, shell, nativeTheme, powerMonitor, type BrowserWindow } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -55,6 +55,7 @@ import {
   REMOTE_FILE_MAX_LINES,
   REMOTE_FILE_MAX_BYTES,
 } from './remoteCli';
+import type { ToastAction, UpdateToast } from 'wave-webview-fixtures';
 import type { ChildProcess } from 'child_process';
 import { getWorkspaceDiff } from './gitDiff';
 import { TerminalManager } from './terminal';
@@ -442,11 +443,12 @@ export class DesktopHost {
     this.onPanelStateChanged?.(this.panePanelState.get(this.focusedPaneId) ?? []);
   }
 
-  /** Surface an update event as a non-modal OS notification. */
-  private showUpdateNotification(title: string, body: string): void {
-    if (Notification.isSupported()) {
-      new Notification({ title, body }).show();
-    }
+  /** Surface an update event as a non-modal in-app toast (VS Code-style). */
+  private showUpdateToast(toast: Omit<UpdateToast, 'id'>): void {
+    this.postMessage({
+      command: 'showToast',
+      toast: { id: `update-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`, ...toast },
+    });
   }
 
   /** Insert a host-generated system message into a pane's chat stream (focused pane by default). */
@@ -2673,6 +2675,10 @@ export class DesktopHost {
         break;
       }
 
+      case 'toastAction':
+        this.handleToastAction(msg.action as ToastAction);
+        break;
+
       case 'downloadMermaid':
         await this.handleDownloadMermaid(msg.content as string, msg.format as 'svg' | 'png');
         break;
@@ -3308,10 +3314,9 @@ export class DesktopHost {
       if (!this.autoUpdaterService) {
         this.autoUpdaterService = new AutoUpdaterService({
           onUpdateAvailable: (info) =>
-            this.showUpdateNotification(
-              '发现新版本',
-              `v${info.version}（当前 v${app.getVersion()}），正在后台下载…`,
-            ),
+            this.showUpdateToast({
+              message: `发现新版本 v${info.version}（当前 v${app.getVersion()}），正在后台下载…`,
+            }),
           onUpdateDownloaded: (info) => void this.handleUpdateDownloaded(info.version),
           onError: () => void this.handleAutoUpdaterError(serverUrl),
         });
@@ -3319,7 +3324,7 @@ export class DesktopHost {
       const outcome = await this.autoUpdaterService.checkForUpdates(serverUrl);
       if (outcome === 'update') return;
       if (outcome === 'no-update') {
-        if (manual) this.showUpdateNotification('Wave 更新', '当前已是最新版本');
+        if (manual) this.showUpdateToast({ message: '当前已是最新版本' });
         return;
       }
       // outcome === 'error': degrade to the manual checker below.
@@ -3328,9 +3333,13 @@ export class DesktopHost {
 
     const info = await checkForUpdate(app.getVersion(), serverUrl);
     if (info) {
-      this.showUpdateNotification('发现新版本', `v${info.latestVersion}（当前 v${info.currentVersion}）：${info.downloadUrl}`);
+      this.showUpdateToast({
+        message: `发现新版本 v${info.latestVersion}（当前 v${info.currentVersion}）`,
+        actionLabel: '打开下载页',
+        action: { type: 'openDownloadPage', url: info.downloadUrl },
+      });
     } else if (manual) {
-      this.showUpdateNotification('Wave 更新', '当前已是最新版本');
+      this.showUpdateToast({ message: '当前已是最新版本' });
     }
   }
 
@@ -3340,23 +3349,32 @@ export class DesktopHost {
     console.warn('[DesktopHost] Auto updater errored, falling back to manual check');
     const info = await checkForUpdate(app.getVersion(), serverUrl);
     if (info) {
-      this.showUpdateNotification('发现新版本', `v${info.latestVersion}（当前 v${info.currentVersion}）：${info.downloadUrl}`);
+      this.showUpdateToast({
+        message: `发现新版本 v${info.latestVersion}（当前 v${info.currentVersion}）`,
+        actionLabel: '打开下载页',
+        action: { type: 'openDownloadPage', url: info.downloadUrl },
+      });
     }
   }
 
-  /** The new version finished downloading — confirm before installing. */
-  private async handleUpdateDownloaded(version: string): Promise<void> {
-    this.showUpdateNotification('Wave 更新', `新版本 v${version} 已下载完成`);
-    const { response } = await dialog.showMessageBox({
-      type: 'info',
-      buttons: ['重启安装', '稍后'],
-      defaultId: 0,
-      cancelId: 1,
-      message: 'Wave 更新已就绪',
-      detail: `新版本 v${version} 已下载完成，重启应用以完成安装。`,
+  /** The new version finished downloading — announce it via a toast whose
+   *  「重启安装」 button quits and installs directly (no second confirm dialog). */
+  private handleUpdateDownloaded(version: string): void {
+    this.showUpdateToast({
+      message: `新版本 v${version} 已下载完成，重启应用以完成安装。`,
+      actionLabel: '重启安装',
+      action: { type: 'quitAndInstall' },
     });
-    if (response === 0) {
+  }
+
+  /** A toast's button was clicked: quit-and-install the downloaded update, or
+   *  open the manual download page. The webview sends the opaque action payload
+   *  back verbatim, so the host stays the single source of the action semantics. */
+  private handleToastAction(action: ToastAction): void {
+    if (action.type === 'quitAndInstall') {
       this.autoUpdaterService?.quitAndInstall();
+    } else if (action.type === 'openDownloadPage' && /^(https?):/.test(action.url)) {
+      void shell.openExternal(action.url);
     }
   }
 

--- a/packages/desktop/src/main/updateAutoUpdater.ts
+++ b/packages/desktop/src/main/updateAutoUpdater.ts
@@ -1,0 +1,58 @@
+/**
+ * AutoUpdaterService — electron-updater wrapper for logged-in (serverUrl)
+ * installs. The update feed is the codechat downloads endpoint served in
+ * electron-builder metadata format (latest-mac.yml / latest.yml), NOT GitHub
+ * Releases. Hosts the update-available / update-downloaded callbacks so the
+ * desktop host can surface them as chat system messages.
+ */
+
+import { app } from 'electron';
+import { autoUpdater, type UpdateInfo } from 'electron-updater';
+
+export interface AutoUpdaterCallbacks {
+  /** A newer version was found and the background download has started. */
+  onUpdateAvailable: (info: UpdateInfo) => void;
+  /** The new version finished downloading — the host decides whether to install. */
+  onUpdateDownloaded: (info: UpdateInfo) => void;
+  /** The check or background download failed — the host degrades to the manual flow. */
+  onError: (error: Error) => void;
+}
+
+export type UpdateCheckOutcome = 'update' | 'no-update' | 'error';
+
+export function feedUrlFor(serverUrl: string): string {
+  const platform = process.platform === 'win32' ? 'win' : 'mac';
+  return `${serverUrl.replace(/\/+$/, '')}/api/downloads/desktop/${platform}/`;
+}
+
+export class AutoUpdaterService {
+  private listenersAttached = false;
+
+  constructor(private readonly callbacks: AutoUpdaterCallbacks) {}
+
+  private attachListeners(): void {
+    if (this.listenersAttached) return;
+    this.listenersAttached = true;
+    autoUpdater.on('update-available', (info) => this.callbacks.onUpdateAvailable(info));
+    autoUpdater.on('update-downloaded', (info) => this.callbacks.onUpdateDownloaded(info));
+    autoUpdater.on('error', (error) => this.callbacks.onError(error));
+  }
+
+  /** Point the generic provider at the codechat feed and check for updates. */
+  async checkForUpdates(serverUrl: string): Promise<UpdateCheckOutcome> {
+    this.attachListeners();
+    autoUpdater.setFeedURL({ provider: 'generic', url: feedUrlFor(serverUrl) });
+    try {
+      const result = await autoUpdater.checkForUpdates();
+      const version = result?.updateInfo.version;
+      return version && version !== app.getVersion() ? 'update' : 'no-update';
+    } catch (error) {
+      console.warn('[AutoUpdater] update check failed:', error);
+      return 'error';
+    }
+  }
+
+  quitAndInstall(): void {
+    autoUpdater.quitAndInstall();
+  }
+}

--- a/packages/desktop/src/main/updateChecker.ts
+++ b/packages/desktop/src/main/updateChecker.ts
@@ -1,12 +1,13 @@
 /**
  * Update checker for the desktop app — queries GitHub Releases (or the
- * CodeChat downloads manifest when a serverUrl is configured).
+ * CodeChat electron-builder download feed when a serverUrl is configured).
  * Ported from packages/vsce/src/services/updateService.ts without the
  * VS Code-specific notification/install code.
  */
 
 import * as http from 'http';
 import * as https from 'https';
+import { load as parseYaml } from 'js-yaml';
 import { parseVersion, compareVersions, type ParsedVersion } from './version';
 
 export interface UpdateInfo {
@@ -75,15 +76,34 @@ async function checkViaGitHub(currentVersion: string, current: ParsedVersion): P
 }
 
 async function checkViaCodeChat(currentVersion: string, current: ParsedVersion, serverUrl: string): Promise<UpdateInfo | null> {
-  const { statusCode, body } = await httpGet(`${serverUrl}/api/downloads/manifest.json`, 5000);
+  // The codechat downloads endpoint serves electron-builder metadata:
+  // mac → latest-mac.yml, win → latest.yml. The `path` field is the absolute
+  // download entry (e.g. a file-center URL) — pointing users at the metadata
+  // itself would be useless.
+  const platform = process.platform === 'win32' ? 'win' : 'mac';
+  const fileName = process.platform === 'win32' ? 'latest.yml' : 'latest-mac.yml';
+  const feedUrl = `${serverUrl}/api/downloads/desktop/${platform}/${fileName}`;
+
+  const { statusCode, body } = await httpGet(feedUrl, 5000);
 
   if (statusCode !== 200) {
-    throw new Error(`CodeChat manifest returned non-OK status: ${statusCode}`);
+    throw new Error(`CodeChat download feed returned non-OK status: ${statusCode}`);
   }
 
-  const data = JSON.parse(body) as { version: string };
-  const latest = parseVersion(data.version);
+  let data: { version?: unknown; path?: unknown };
+  try {
+    data = parseYaml(body) as { version?: unknown; path?: unknown };
+  } catch (error) {
+    console.warn('[UpdateChecker] Failed to parse CodeChat download feed:', error);
+    return null;
+  }
 
+  if (typeof data.version !== 'string') {
+    console.warn('[UpdateChecker] Invalid latest version from CodeChat:', data.version);
+    return null;
+  }
+
+  const latest = parseVersion(data.version);
   if (!latest) {
     console.warn('[UpdateChecker] Invalid latest version from CodeChat:', data.version);
     return null;
@@ -96,7 +116,7 @@ async function checkViaCodeChat(currentVersion: string, current: ParsedVersion, 
   return {
     latestVersion: data.version,
     currentVersion,
-    downloadUrl: `${serverUrl}/api/downloads/manifest.json`,
+    downloadUrl: typeof data.path === 'string' ? data.path : feedUrl,
     releaseNotes: undefined,
   };
 }
@@ -114,7 +134,7 @@ export async function checkForUpdate(currentVersion: string, serverUrl?: string)
       try {
         return await checkViaCodeChat(currentVersion, current, serverUrl);
       } catch (error) {
-        console.warn('[UpdateChecker] CodeChat manifest check failed, falling back to GitHub:', error);
+        console.warn('[UpdateChecker] CodeChat download feed check failed, falling back to GitHub:', error);
       }
     }
     return await checkViaGitHub(currentVersion, current);

--- a/packages/desktop/tests/__mocks__/electron.ts
+++ b/packages/desktop/tests/__mocks__/electron.ts
@@ -20,6 +20,17 @@ export const shell = {
   openPath: vi.fn(async () => ''),
 };
 
+// vi.fn-wrapped class so tests can inspect Notification.mock.instances /
+// mockClear() across tests (a plain class has no .mock).
+export const Notification = vi.fn(function (this: { options: unknown; show: ReturnType<typeof vi.fn> }, options: unknown) {
+  this.options = options;
+  this.show = vi.fn();
+}) as unknown as typeof import('electron').Notification & {
+  isSupported: ReturnType<typeof vi.fn>;
+  mockClear: ReturnType<typeof vi.fn>;
+};
+Notification.isSupported = vi.fn(() => true);
+
 export const ipcMain = {
   on: vi.fn(),
   handle: vi.fn(),

--- a/packages/desktop/tests/__mocks__/electron.ts
+++ b/packages/desktop/tests/__mocks__/electron.ts
@@ -20,17 +20,6 @@ export const shell = {
   openPath: vi.fn(async () => ''),
 };
 
-// vi.fn-wrapped class so tests can inspect Notification.mock.instances /
-// mockClear() across tests (a plain class has no .mock).
-export const Notification = vi.fn(function (this: { options: unknown; show: ReturnType<typeof vi.fn> }, options: unknown) {
-  this.options = options;
-  this.show = vi.fn();
-}) as unknown as typeof import('electron').Notification & {
-  isSupported: ReturnType<typeof vi.fn>;
-  mockClear: ReturnType<typeof vi.fn>;
-};
-Notification.isSupported = vi.fn(() => true);
-
 export const ipcMain = {
   on: vi.fn(),
   handle: vi.fn(),

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -342,7 +342,7 @@ vi.mock('../src/main/sshHosts', async () => {
 import { DesktopHost } from '../src/main/desktopHost';
 import { ConfigStore } from '../src/main/configStore';
 import { HOST_CHANNEL } from '../src/main/channels';
-import { shell, dialog, nativeTheme, powerMonitor, Notification } from 'electron';
+import { shell, dialog, nativeTheme, powerMonitor } from 'electron';
 import { checkForUpdate } from '../src/main/updateChecker';
 import { autoUpdater } from 'electron-updater';
 import {
@@ -360,17 +360,26 @@ import {
 
 const STORE_PATH = '/mock-userData/wave-desktop.json';
 
-/** The title/body pairs of every Notification the host showed. */
-function shownNotifications(): Array<{ title: string; body: string }> {
-  return vi
-    .mocked(Notification)
-    .mock.instances.map((n) => (n as unknown as { options: { title: string; body: string } }).options);
+/** The send mock of the most recently created host (shownToasts reads it). */
+let lastSend: ReturnType<typeof vi.fn> | undefined;
+
+/** The message/action of every update toast the host pushed to the webview. */
+function shownToasts(): Array<{ message: string; actionLabel?: string; action?: { type: string; url?: string } }> {
+  const send = lastSend;
+  if (!send) return [];
+  return send.mock.calls
+    .filter(([channel, msg]) => channel === HOST_CHANNEL && (msg as { command?: string }).command === 'showToast')
+    .map(
+      ([, msg]) =>
+        (msg as { toast: { message: string; actionLabel?: string; action?: { type: string; url?: string } } }).toast,
+    );
 }
 
 function createHost(winWidth = 1280, winHeight = 800) {
   const store = new ConfigStore(STORE_PATH);
   const host = new DesktopHost(store);
   const send = vi.fn();
+  lastSend = send;
   const win = {
     webContents: { send },
     isDestroyed: () => false,
@@ -431,7 +440,6 @@ beforeEach(() => {
   h.pendingPermissionRequests = [];
   vi.clearAllMocks();
   for (const key of Object.keys(auListeners)) delete auListeners[key];
-  vi.mocked(Notification).mockClear();
   nativeTheme.__reset();
   powerMonitor.__reset();
   // Reset the auto-reconnect seams (tests shrink them to keep retries fast).
@@ -1122,7 +1130,7 @@ describe('configuration and status', () => {
 // ---------------------------------------------------------------------------
 
 describe('checkForUpdates', () => {
-  it('manual check announces a newer version as a system notification', async () => {
+  it('manual check announces a newer version as a toast with a download-page action', async () => {
     vi.mocked(checkForUpdate).mockResolvedValueOnce({
       latestVersion: '0.20.0',
       currentVersion: '0.19.7',
@@ -1132,17 +1140,19 @@ describe('checkForUpdates', () => {
 
     await host.handleWebviewMessage({ command: 'checkForUpdates' });
 
-    const notices = shownNotifications().filter((n) => JSON.stringify(n).includes('0.20.0'));
-    expect(notices).toHaveLength(1);
-    expect(notices[0].body).toContain('https://github.com/release');
+    const toasts = shownToasts().filter((n) => n.message.includes('0.20.0'));
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].message).toContain('0.19.7');
+    expect(toasts[0].actionLabel).toBe('打开下载页');
+    expect(toasts[0].action).toEqual({ type: 'openDownloadPage', url: 'https://github.com/release' });
   });
 
-  it('manual check says "already latest" via a system notification when no update exists', async () => {
+  it('manual check says "already latest" via a toast when no update exists', async () => {
     const { host } = await readyHost();
     await host.handleWebviewMessage({ command: 'checkForUpdates' });
 
-    const notices = shownNotifications().filter((n) => JSON.stringify(n).includes('已是最新'));
-    expect(notices).toHaveLength(1);
+    const toasts = shownToasts().filter((n) => n.message.includes('已是最新'));
+    expect(toasts).toHaveLength(1);
   });
 
   it('runs an automatic check once after the first webviewReady', async () => {
@@ -1187,7 +1197,7 @@ describe('checkForUpdates with a configured serverUrl', () => {
     expect(checkForUpdate).not.toHaveBeenCalled();
   });
 
-  it('announces the update via a system notification on update-available', async () => {
+  it('announces the update via a toast on update-available', async () => {
     vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
       updateInfo: { version: '0.20.0', files: [], path: 'wave-0.20.0.dmg' },
       isUpdateAvailable: true,
@@ -1199,12 +1209,14 @@ describe('checkForUpdates with a configured serverUrl', () => {
       cb({ version: '0.20.0' });
     }
 
-    const notices = shownNotifications().filter((n) => JSON.stringify(n).includes('0.20.0'));
-    expect(notices).toHaveLength(1);
-    expect(notices[0].body).toContain('正在后台下载');
+    const toasts = shownToasts().filter((n) => n.message.includes('0.20.0'));
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].message).toContain('正在后台下载');
+    // Informational only — no action button; the user acts once downloaded.
+    expect(toasts[0].action).toBeUndefined();
   });
 
-  it('asks before installing once the update is downloaded, then quits and installs', async () => {
+  it('shows a restart-install toast once the update is downloaded, and quitAndInstall fires on its action', async () => {
     vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
       updateInfo: { version: '0.20.0', files: [], path: 'wave-0.20.0.dmg' },
       isUpdateAvailable: true,
@@ -1215,13 +1227,28 @@ describe('checkForUpdates with a configured serverUrl', () => {
     for (const cb of auListeners['update-downloaded'] ?? []) {
       cb({ version: '0.20.0' });
     }
-    await vi.waitFor(() => expect(dialog.showMessageBox).toHaveBeenCalledTimes(1));
 
-    expect(JSON.stringify(dialog.showMessageBox.mock.calls[0][0])).toContain('重启安装');
-    // electron mock's showMessageBox resolves { response: 0 } → 重启安装.
-    await vi.waitFor(() => expect(autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1));
-    const notices = shownNotifications().filter((n) => JSON.stringify(n).includes('已下载完成'));
-    expect(notices).toHaveLength(1);
+    const toasts = shownToasts().filter((n) => n.message.includes('已下载完成'));
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].actionLabel).toBe('重启安装');
+    expect(toasts[0].action).toEqual({ type: 'quitAndInstall' });
+    // No native confirm dialog anymore (spec: the toast button installs directly).
+    expect(dialog.showMessageBox).not.toHaveBeenCalled();
+    expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+
+    // The webview echoes the action back; the host performs it.
+    await host.handleWebviewMessage({ command: 'toastAction', toastId: 'x', action: { type: 'quitAndInstall' } });
+    expect(autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the download page when the toast action is openDownloadPage', async () => {
+    const { host } = await readyHost();
+    await host.handleWebviewMessage({
+      command: 'toastAction',
+      toastId: 'x',
+      action: { type: 'openDownloadPage', url: 'https://github.com/release' },
+    });
+    expect(shell.openExternal).toHaveBeenCalledWith('https://github.com/release');
   });
 
   it('falls back to the manual checker when electron-updater fails', async () => {
@@ -1236,8 +1263,9 @@ describe('checkForUpdates with a configured serverUrl', () => {
     await host.handleWebviewMessage({ command: 'checkForUpdates' });
 
     expect(checkForUpdate).toHaveBeenCalledWith('0.19.7', SERVER);
-    const notices = shownNotifications().filter((n) => JSON.stringify(n).includes('0.20.0'));
-    expect(notices.length).toBeGreaterThanOrEqual(1);
+    const toasts = shownToasts().filter((n) => n.message.includes('0.20.0'));
+    expect(toasts.length).toBeGreaterThanOrEqual(1);
+    expect(toasts[0].action).toEqual({ type: 'openDownloadPage', url: 'https://github.com/release' });
     // Restore the default implementation — this persistent mock leaks into the
     // next test's one-shot automatic check otherwise (it would announce a fake
     // update and mutate that test's agent message list).
@@ -1262,14 +1290,15 @@ describe('checkForUpdates with a configured serverUrl', () => {
     }
 
     await vi.waitFor(() => expect(checkForUpdate).toHaveBeenCalledWith('0.19.7', SERVER));
-    const notices = shownNotifications().filter((n) =>
-      JSON.stringify(n).includes('https://codechat.example.com/api/downloads'),
+    const toasts = shownToasts().filter((n) =>
+      n.message.includes('0.20.0'),
     );
-    expect(notices.length).toBeGreaterThanOrEqual(1);
+    expect(toasts.length).toBeGreaterThanOrEqual(1);
+    expect(toasts[0].action).toEqual({ type: 'openDownloadPage', url: 'https://codechat.example.com/api/downloads/manifest.json' });
     vi.mocked(checkForUpdate).mockResolvedValue(null);
   });
 
-  it('says "already latest" via a system notification without a GitHub round trip when the feed has no update', async () => {
+  it('says "already latest" via a toast without a GitHub round trip when the feed has no update', async () => {
     vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
       updateInfo: { version: '0.19.7', files: [], path: 'wave-0.19.7.dmg' },
       isUpdateAvailable: false,
@@ -1281,8 +1310,8 @@ describe('checkForUpdates with a configured serverUrl', () => {
     expect(checkForUpdate).not.toHaveBeenCalled();
     // The one-shot automatic check stays silent on no-update; only the manual
     // check announces it.
-    const notices = shownNotifications().filter((n) => JSON.stringify(n).includes('已是最新'));
-    expect(notices).toHaveLength(1);
+    const toasts = shownToasts().filter((n) => n.message.includes('已是最新'));
+    expect(toasts).toHaveLength(1);
   });
 });
 

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -342,7 +342,7 @@ vi.mock('../src/main/sshHosts', async () => {
 import { DesktopHost } from '../src/main/desktopHost';
 import { ConfigStore } from '../src/main/configStore';
 import { HOST_CHANNEL } from '../src/main/channels';
-import { shell, dialog, nativeTheme, powerMonitor } from 'electron';
+import { shell, dialog, nativeTheme, powerMonitor, Notification } from 'electron';
 import { checkForUpdate } from '../src/main/updateChecker';
 import { autoUpdater } from 'electron-updater';
 import {
@@ -359,6 +359,13 @@ import {
 // ---------------------------------------------------------------------------
 
 const STORE_PATH = '/mock-userData/wave-desktop.json';
+
+/** The title/body pairs of every Notification the host showed. */
+function shownNotifications(): Array<{ title: string; body: string }> {
+  return vi
+    .mocked(Notification)
+    .mock.instances.map((n) => (n as unknown as { options: { title: string; body: string } }).options);
+}
 
 function createHost(winWidth = 1280, winHeight = 800) {
   const store = new ConfigStore(STORE_PATH);
@@ -424,6 +431,7 @@ beforeEach(() => {
   h.pendingPermissionRequests = [];
   vi.clearAllMocks();
   for (const key of Object.keys(auListeners)) delete auListeners[key];
+  vi.mocked(Notification).mockClear();
   nativeTheme.__reset();
   powerMonitor.__reset();
   // Reset the auto-reconnect seams (tests shrink them to keep retries fast).
@@ -1114,26 +1122,27 @@ describe('configuration and status', () => {
 // ---------------------------------------------------------------------------
 
 describe('checkForUpdates', () => {
-  it('manual check announces a newer version in the chat', async () => {
+  it('manual check announces a newer version as a system notification', async () => {
     vi.mocked(checkForUpdate).mockResolvedValueOnce({
       latestVersion: '0.20.0',
       currentVersion: '0.19.7',
       downloadUrl: 'https://github.com/release',
     });
-    const { host, sent } = await readyHost();
+    const { host } = await readyHost();
 
     await host.handleWebviewMessage({ command: 'checkForUpdates' });
 
-    const msgs = sent('appendMessage').filter((m) => JSON.stringify(m).includes('0.20.0'));
-    expect(msgs).toHaveLength(1);
+    const notices = shownNotifications().filter((n) => JSON.stringify(n).includes('0.20.0'));
+    expect(notices).toHaveLength(1);
+    expect(notices[0].body).toContain('https://github.com/release');
   });
 
-  it('manual check says "already latest" when no update exists', async () => {
-    const { host, sent } = await readyHost();
+  it('manual check says "already latest" via a system notification when no update exists', async () => {
+    const { host } = await readyHost();
     await host.handleWebviewMessage({ command: 'checkForUpdates' });
 
-    const msgs = sent('appendMessage').filter((m) => JSON.stringify(m).includes('已是最新'));
-    expect(msgs).toHaveLength(1);
+    const notices = shownNotifications().filter((n) => JSON.stringify(n).includes('已是最新'));
+    expect(notices).toHaveLength(1);
   });
 
   it('runs an automatic check once after the first webviewReady', async () => {
@@ -1178,21 +1187,21 @@ describe('checkForUpdates with a configured serverUrl', () => {
     expect(checkForUpdate).not.toHaveBeenCalled();
   });
 
-  it('announces the update via the update-available event', async () => {
+  it('announces the update via a system notification on update-available', async () => {
     vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
       updateInfo: { version: '0.20.0', files: [], path: 'wave-0.20.0.dmg' },
       isUpdateAvailable: true,
     } as never);
-    const { host, sent } = await readyHostWithServerUrl();
+    const { host } = await readyHostWithServerUrl();
 
     await host.handleWebviewMessage({ command: 'checkForUpdates' });
     for (const cb of auListeners['update-available'] ?? []) {
       cb({ version: '0.20.0' });
     }
 
-    const msgs = sent('appendMessage').filter((m) => JSON.stringify(m).includes('0.20.0'));
-    expect(msgs).toHaveLength(1);
-    expect(JSON.stringify(msgs[0])).toContain('正在后台下载');
+    const notices = shownNotifications().filter((n) => JSON.stringify(n).includes('0.20.0'));
+    expect(notices).toHaveLength(1);
+    expect(notices[0].body).toContain('正在后台下载');
   });
 
   it('asks before installing once the update is downloaded, then quits and installs', async () => {
@@ -1200,7 +1209,7 @@ describe('checkForUpdates with a configured serverUrl', () => {
       updateInfo: { version: '0.20.0', files: [], path: 'wave-0.20.0.dmg' },
       isUpdateAvailable: true,
     } as never);
-    const { host, sent } = await readyHostWithServerUrl();
+    const { host } = await readyHostWithServerUrl();
 
     await host.handleWebviewMessage({ command: 'checkForUpdates' });
     for (const cb of auListeners['update-downloaded'] ?? []) {
@@ -1211,8 +1220,8 @@ describe('checkForUpdates with a configured serverUrl', () => {
     expect(JSON.stringify(dialog.showMessageBox.mock.calls[0][0])).toContain('重启安装');
     // electron mock's showMessageBox resolves { response: 0 } → 重启安装.
     await vi.waitFor(() => expect(autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1));
-    const msgs = sent('appendMessage').filter((m) => JSON.stringify(m).includes('已下载完成'));
-    expect(msgs).toHaveLength(1);
+    const notices = shownNotifications().filter((n) => JSON.stringify(n).includes('已下载完成'));
+    expect(notices).toHaveLength(1);
   });
 
   it('falls back to the manual checker when electron-updater fails', async () => {
@@ -1222,13 +1231,13 @@ describe('checkForUpdates with a configured serverUrl', () => {
       currentVersion: '0.19.7',
       downloadUrl: 'https://github.com/release',
     });
-    const { host, sent } = await readyHostWithServerUrl();
+    const { host } = await readyHostWithServerUrl();
 
     await host.handleWebviewMessage({ command: 'checkForUpdates' });
 
     expect(checkForUpdate).toHaveBeenCalledWith('0.19.7', SERVER);
-    const msgs = sent('appendMessage').filter((m) => JSON.stringify(m).includes('0.20.0'));
-    expect(msgs.length).toBeGreaterThanOrEqual(1);
+    const notices = shownNotifications().filter((n) => JSON.stringify(n).includes('0.20.0'));
+    expect(notices.length).toBeGreaterThanOrEqual(1);
     // Restore the default implementation — this persistent mock leaks into the
     // next test's one-shot automatic check otherwise (it would announce a fake
     // update and mutate that test's agent message list).
@@ -1245,7 +1254,7 @@ describe('checkForUpdates with a configured serverUrl', () => {
       currentVersion: '0.19.7',
       downloadUrl: 'https://codechat.example.com/api/downloads/manifest.json',
     });
-    const { host, sent } = await readyHostWithServerUrl();
+    const { host } = await readyHostWithServerUrl();
 
     await host.handleWebviewMessage({ command: 'checkForUpdates' });
     for (const cb of auListeners['error'] ?? []) {
@@ -1253,25 +1262,27 @@ describe('checkForUpdates with a configured serverUrl', () => {
     }
 
     await vi.waitFor(() => expect(checkForUpdate).toHaveBeenCalledWith('0.19.7', SERVER));
-    const msgs = sent('appendMessage').filter((m) => JSON.stringify(m).includes('https://codechat.example.com/api/downloads'));
-    expect(msgs.length).toBeGreaterThanOrEqual(1);
+    const notices = shownNotifications().filter((n) =>
+      JSON.stringify(n).includes('https://codechat.example.com/api/downloads'),
+    );
+    expect(notices.length).toBeGreaterThanOrEqual(1);
     vi.mocked(checkForUpdate).mockResolvedValue(null);
   });
 
-  it('says "already latest" without a GitHub round trip when the feed has no update', async () => {
+  it('says "already latest" via a system notification without a GitHub round trip when the feed has no update', async () => {
     vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
       updateInfo: { version: '0.19.7', files: [], path: 'wave-0.19.7.dmg' },
       isUpdateAvailable: false,
     } as never);
-    const { host, sent } = await readyHostWithServerUrl();
+    const { host } = await readyHostWithServerUrl();
 
     await host.handleWebviewMessage({ command: 'checkForUpdates' });
 
     expect(checkForUpdate).not.toHaveBeenCalled();
     // The one-shot automatic check stays silent on no-update; only the manual
     // check announces it.
-    const msgs = sent('appendMessage').filter((m) => JSON.stringify(m).includes('已是最新'));
-    expect(msgs).toHaveLength(1);
+    const notices = shownNotifications().filter((n) => JSON.stringify(n).includes('已是最新'));
+    expect(notices).toHaveLength(1);
   });
 });
 

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -262,6 +262,21 @@ vi.mock('../src/main/updateChecker', () => ({
   checkForUpdate: vi.fn(async () => null),
 }));
 
+// electron-updater — the auto-update service for logged-in (serverUrl) installs.
+// The on() mock records listeners so tests can fire update-available /
+// update-downloaded to assert the host's system-message wiring.
+const auListeners: Record<string, Array<(info: unknown) => void>> = {};
+vi.mock('electron-updater', () => ({
+  autoUpdater: {
+    checkForUpdates: vi.fn(async () => null),
+    setFeedURL: vi.fn(),
+    quitAndInstall: vi.fn(),
+    on: vi.fn((event: string, cb: (info: unknown) => void) => {
+      (auListeners[event] ??= []).push(cb);
+    }),
+  },
+}));
+
 // PortForwardManager spawns real `ssh -N -L` processes — stub it entirely and
 // assert the wiring (messages in, forwarded results out, session-scoped teardown).
 vi.mock('../src/main/portForward', () => {
@@ -327,8 +342,9 @@ vi.mock('../src/main/sshHosts', async () => {
 import { DesktopHost } from '../src/main/desktopHost';
 import { ConfigStore } from '../src/main/configStore';
 import { HOST_CHANNEL } from '../src/main/channels';
-import { shell, nativeTheme, powerMonitor } from 'electron';
+import { shell, dialog, nativeTheme, powerMonitor } from 'electron';
 import { checkForUpdate } from '../src/main/updateChecker';
+import { autoUpdater } from 'electron-updater';
 import {
   connectRemoteDaemon,
   remotePathExists,
@@ -407,6 +423,7 @@ beforeEach(() => {
   h.closedHandlers.length = 0;
   h.pendingPermissionRequests = [];
   vi.clearAllMocks();
+  for (const key of Object.keys(auListeners)) delete auListeners[key];
   nativeTheme.__reset();
   powerMonitor.__reset();
   // Reset the auto-reconnect seams (tests shrink them to keep retries fast).
@@ -1124,6 +1141,137 @@ describe('checkForUpdates', () => {
     await vi.waitFor(() => {
       expect(checkForUpdate).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+describe('checkForUpdates with a configured serverUrl', () => {
+  const SERVER = 'https://codechat.example.com';
+
+  // Like readyHost() but the serverUrl is in place BEFORE webviewReady, so the
+  // one-shot automatic check takes the electron-updater path too.
+  async function readyHostWithServerUrl() {
+    const ctx = createHost();
+    ctx.store.addRecentWorkdir({ host: 'local', path: '/work/a' });
+    h.existingPaths.add('/work/a');
+    ctx.store.setConfiguration({ serverUrl: SERVER });
+    await ctx.host.handleWebviewMessage({ command: 'desktopReady' });
+    await ctx.host.handleWebviewMessage({ command: 'desktopSelectRecentWorkdir', path: '/work/a' });
+    await ctx.host.handleWebviewMessage({ command: 'webviewReady' });
+    return ctx;
+  }
+
+  it('routes the check through electron-updater against the codechat feed', async () => {
+    vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
+      updateInfo: { version: '0.20.0', files: [], path: 'wave-0.20.0.dmg' },
+      isUpdateAvailable: true,
+    } as never);
+    const { host } = await readyHostWithServerUrl();
+
+    await host.handleWebviewMessage({ command: 'checkForUpdates' });
+
+    expect(autoUpdater.setFeedURL).toHaveBeenCalledWith({
+      provider: 'generic',
+      url: `${SERVER}/api/downloads/desktop/mac/`,
+    });
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalled();
+    // The electron-updater path is authoritative when logged in — no GitHub fallback.
+    expect(checkForUpdate).not.toHaveBeenCalled();
+  });
+
+  it('announces the update via the update-available event', async () => {
+    vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
+      updateInfo: { version: '0.20.0', files: [], path: 'wave-0.20.0.dmg' },
+      isUpdateAvailable: true,
+    } as never);
+    const { host, sent } = await readyHostWithServerUrl();
+
+    await host.handleWebviewMessage({ command: 'checkForUpdates' });
+    for (const cb of auListeners['update-available'] ?? []) {
+      cb({ version: '0.20.0' });
+    }
+
+    const msgs = sent('appendMessage').filter((m) => JSON.stringify(m).includes('0.20.0'));
+    expect(msgs).toHaveLength(1);
+    expect(JSON.stringify(msgs[0])).toContain('正在后台下载');
+  });
+
+  it('asks before installing once the update is downloaded, then quits and installs', async () => {
+    vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
+      updateInfo: { version: '0.20.0', files: [], path: 'wave-0.20.0.dmg' },
+      isUpdateAvailable: true,
+    } as never);
+    const { host, sent } = await readyHostWithServerUrl();
+
+    await host.handleWebviewMessage({ command: 'checkForUpdates' });
+    for (const cb of auListeners['update-downloaded'] ?? []) {
+      cb({ version: '0.20.0' });
+    }
+    await vi.waitFor(() => expect(dialog.showMessageBox).toHaveBeenCalledTimes(1));
+
+    expect(JSON.stringify(dialog.showMessageBox.mock.calls[0][0])).toContain('重启安装');
+    // electron mock's showMessageBox resolves { response: 0 } → 重启安装.
+    await vi.waitFor(() => expect(autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1));
+    const msgs = sent('appendMessage').filter((m) => JSON.stringify(m).includes('已下载完成'));
+    expect(msgs).toHaveLength(1);
+  });
+
+  it('falls back to the manual checker when electron-updater fails', async () => {
+    vi.mocked(autoUpdater.checkForUpdates).mockRejectedValue(new Error('ECONNREFUSED'));
+    vi.mocked(checkForUpdate).mockResolvedValue({
+      latestVersion: '0.20.0',
+      currentVersion: '0.19.7',
+      downloadUrl: 'https://github.com/release',
+    });
+    const { host, sent } = await readyHostWithServerUrl();
+
+    await host.handleWebviewMessage({ command: 'checkForUpdates' });
+
+    expect(checkForUpdate).toHaveBeenCalledWith('0.19.7', SERVER);
+    const msgs = sent('appendMessage').filter((m) => JSON.stringify(m).includes('0.20.0'));
+    expect(msgs.length).toBeGreaterThanOrEqual(1);
+    // Restore the default implementation — this persistent mock leaks into the
+    // next test's one-shot automatic check otherwise (it would announce a fake
+    // update and mutate that test's agent message list).
+    vi.mocked(checkForUpdate).mockResolvedValue(null);
+  });
+
+  it('degrades to the manual checker when the background download errors', async () => {
+    vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
+      updateInfo: { version: '0.19.7', files: [], path: 'wave-0.19.7.dmg' },
+      isUpdateAvailable: false,
+    } as never);
+    vi.mocked(checkForUpdate).mockResolvedValue({
+      latestVersion: '0.20.0',
+      currentVersion: '0.19.7',
+      downloadUrl: 'https://codechat.example.com/api/downloads/manifest.json',
+    });
+    const { host, sent } = await readyHostWithServerUrl();
+
+    await host.handleWebviewMessage({ command: 'checkForUpdates' });
+    for (const cb of auListeners['error'] ?? []) {
+      cb(new Error('download failed'));
+    }
+
+    await vi.waitFor(() => expect(checkForUpdate).toHaveBeenCalledWith('0.19.7', SERVER));
+    const msgs = sent('appendMessage').filter((m) => JSON.stringify(m).includes('https://codechat.example.com/api/downloads'));
+    expect(msgs.length).toBeGreaterThanOrEqual(1);
+    vi.mocked(checkForUpdate).mockResolvedValue(null);
+  });
+
+  it('says "already latest" without a GitHub round trip when the feed has no update', async () => {
+    vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
+      updateInfo: { version: '0.19.7', files: [], path: 'wave-0.19.7.dmg' },
+      isUpdateAvailable: false,
+    } as never);
+    const { host, sent } = await readyHostWithServerUrl();
+
+    await host.handleWebviewMessage({ command: 'checkForUpdates' });
+
+    expect(checkForUpdate).not.toHaveBeenCalled();
+    // The one-shot automatic check stays silent on no-update; only the manual
+    // check announces it.
+    const msgs = sent('appendMessage').filter((m) => JSON.stringify(m).includes('已是最新'));
+    expect(msgs).toHaveLength(1);
   });
 });
 

--- a/packages/desktop/tests/updateAutoUpdater.test.ts
+++ b/packages/desktop/tests/updateAutoUpdater.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const h = vi.hoisted(() => {
+  const listeners: Record<string, Array<(info: unknown) => void>> = {};
+  return {
+    listeners,
+    checkForUpdates: vi.fn(),
+    setFeedURL: vi.fn(),
+    quitAndInstall: vi.fn(),
+    on: vi.fn((event: string, cb: (info: unknown) => void) => {
+      (listeners[event] ??= []).push(cb);
+    }),
+  };
+});
+
+vi.mock('electron-updater', () => ({
+  autoUpdater: {
+    checkForUpdates: (...args: unknown[]) => h.checkForUpdates(...args),
+    setFeedURL: (...args: unknown[]) => h.setFeedURL(...args),
+    quitAndInstall: (...args: unknown[]) => h.quitAndInstall(...args),
+    on: h.on,
+  },
+}));
+
+import { AutoUpdaterService, feedUrlFor } from '../src/main/updateAutoUpdater';
+
+function fire(event: string, info: unknown): void {
+  for (const cb of h.listeners[event] ?? []) cb(info);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const key of Object.keys(h.listeners)) delete h.listeners[key];
+});
+
+describe('feedUrlFor', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  });
+
+  it('uses the mac channel on darwin', () => {
+    expect(feedUrlFor('https://codechat.example.com')).toBe(
+      'https://codechat.example.com/api/downloads/desktop/mac/',
+    );
+  });
+
+  it('uses the win channel on win32', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    expect(feedUrlFor('https://codechat.example.com')).toBe(
+      'https://codechat.example.com/api/downloads/desktop/win/',
+    );
+  });
+
+  it('strips trailing slashes from the serverUrl', () => {
+    expect(feedUrlFor('https://codechat.example.com///')).toBe(
+      'https://codechat.example.com/api/downloads/desktop/mac/',
+    );
+  });
+});
+
+describe('AutoUpdaterService.checkForUpdates', () => {
+  it('points the generic provider at the codechat feed and returns "update" for a newer version', async () => {
+    vi.mocked(h.checkForUpdates).mockResolvedValue({
+      updateInfo: { version: '0.20.0', files: [], path: 'wave-0.20.0.dmg' },
+      isUpdateAvailable: true,
+    } as never);
+    const service = new AutoUpdaterService({ onUpdateAvailable: vi.fn(), onUpdateDownloaded: vi.fn(), onError: vi.fn() });
+
+    const outcome = await service.checkForUpdates('https://codechat.example.com');
+
+    expect(outcome).toBe('update');
+    expect(h.setFeedURL).toHaveBeenCalledWith({
+      provider: 'generic',
+      url: 'https://codechat.example.com/api/downloads/desktop/mac/',
+    });
+    expect(h.checkForUpdates).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns "no-update" when the feed version equals the running version', async () => {
+    // electron mock app.getVersion() is 0.19.7
+    vi.mocked(h.checkForUpdates).mockResolvedValue({
+      updateInfo: { version: '0.19.7', files: [], path: 'wave-0.19.7.dmg' },
+      isUpdateAvailable: false,
+    } as never);
+    const service = new AutoUpdaterService({ onUpdateAvailable: vi.fn(), onUpdateDownloaded: vi.fn(), onError: vi.fn() });
+
+    expect(await service.checkForUpdates('https://codechat.example.com')).toBe('no-update');
+  });
+
+  it('returns "error" when the check rejects', async () => {
+    vi.mocked(h.checkForUpdates).mockRejectedValue(new Error('ECONNREFUSED'));
+    const service = new AutoUpdaterService({ onUpdateAvailable: vi.fn(), onUpdateDownloaded: vi.fn(), onError: vi.fn() });
+
+    expect(await service.checkForUpdates('https://codechat.example.com')).toBe('error');
+  });
+});
+
+describe('AutoUpdaterService events and quitAndInstall', () => {
+  it('fires onUpdateAvailable when the update-available event arrives', () => {
+    const onUpdateAvailable = vi.fn();
+    const service = new AutoUpdaterService({ onUpdateAvailable, onUpdateDownloaded: vi.fn(), onError: vi.fn() });
+    // Attach listeners through a check so the wiring is exercised for real.
+    service.checkForUpdates('https://codechat.example.com');
+    service.checkForUpdates('https://codechat.example.com');
+
+    fire('update-available', { version: '0.20.0' });
+    expect(onUpdateAvailable).toHaveBeenCalledWith({ version: '0.20.0' });
+  });
+
+  it('fires onUpdateDownloaded when the update-downloaded event arrives', () => {
+    const onUpdateDownloaded = vi.fn();
+    const service = new AutoUpdaterService({ onUpdateAvailable: vi.fn(), onUpdateDownloaded, onError: vi.fn() });
+    service.checkForUpdates('https://codechat.example.com');
+
+    fire('update-downloaded', { version: '0.20.0' });
+    expect(onUpdateDownloaded).toHaveBeenCalledWith({ version: '0.20.0' });
+  });
+
+  it('fires onError when the error event arrives', () => {
+    const onError = vi.fn();
+    const service = new AutoUpdaterService({ onUpdateAvailable: vi.fn(), onUpdateDownloaded: vi.fn(), onError });
+    service.checkForUpdates('https://codechat.example.com');
+
+    fire('error', new Error('download failed'));
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('registers each event listener only once across repeated checks', async () => {
+    vi.mocked(h.checkForUpdates).mockResolvedValue(null);
+    const service = new AutoUpdaterService({ onUpdateAvailable: vi.fn(), onUpdateDownloaded: vi.fn(), onError: vi.fn() });
+    await service.checkForUpdates('https://codechat.example.com');
+    await service.checkForUpdates('https://codechat.example.com');
+
+    const registered = Object.values(h.listeners);
+    expect(registered.length).toBe(3); // update-available + update-downloaded + error
+    expect(h.on).toHaveBeenCalledTimes(3);
+  });
+
+  it('forwards quitAndInstall to electron-updater', () => {
+    const service = new AutoUpdaterService({ onUpdateAvailable: vi.fn(), onUpdateDownloaded: vi.fn(), onError: vi.fn() });
+    service.quitAndInstall();
+    expect(h.quitAndInstall).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/desktop/tests/updateChecker.test.ts
+++ b/packages/desktop/tests/updateChecker.test.ts
@@ -88,24 +88,43 @@ describe('checkForUpdate via GitHub', () => {
   });
 });
 
-describe('checkForUpdate via CodeChat manifest', () => {
+describe('checkForUpdate via CodeChat download feed', () => {
   const SERVER = 'https://codechat.example.com';
+  // The test host is macOS, so the feed is the electron-builder mac metadata.
+  const FEED_URL = `${SERVER}/api/downloads/desktop/mac/latest-mac.yml`;
 
-  it('returns UpdateInfo from the manifest when newer', async () => {
+  it('returns UpdateInfo parsed from the YAML feed when newer', async () => {
     h.handler = (url) => {
       if (url.startsWith(SERVER)) {
-        return { statusCode: 200, body: JSON.stringify({ version: '1.0.0' }) };
+        return {
+          statusCode: 200,
+          body: `version: 1.0.0\nfiles:\n  - url: wave-1.0.0.dmg\npath: https://file-center.example.com/wave-1.0.0.dmg\n`,
+        };
       }
       return new Error(`unexpected url: ${url}`);
     };
 
     const info = await checkForUpdate('0.19.7', SERVER);
     expect(info?.latestVersion).toBe('1.0.0');
-    expect(info?.downloadUrl).toBe(`${SERVER}/api/downloads/manifest.json`);
-    expect(h.requestedUrls).toEqual([`https:${SERVER}/api/downloads/manifest.json`]);
+    // The downloadUrl must point at the real download entry, not the feed itself.
+    expect(info?.downloadUrl).toBe('https://file-center.example.com/wave-1.0.0.dmg');
+    expect(h.requestedUrls).toEqual([`https:${FEED_URL}`]);
   });
 
-  it('falls back to GitHub when the manifest check fails', async () => {
+  it('falls back to the feed URL when the feed has no path field', async () => {
+    h.handler = () => ({ statusCode: 200, body: 'version: 1.0.0\n' });
+
+    const info = await checkForUpdate('0.19.7', SERVER);
+    expect(info?.latestVersion).toBe('1.0.0');
+    expect(info?.downloadUrl).toBe(FEED_URL);
+  });
+
+  it('returns null when the feed version is not newer', async () => {
+    h.handler = () => ({ statusCode: 200, body: 'version: 0.19.7\n' });
+    expect(await checkForUpdate('0.19.7', SERVER)).toBeNull();
+  });
+
+  it('falls back to GitHub when the feed check fails', async () => {
     h.handler = (url) => {
       if (url.startsWith(SERVER)) {
         return { statusCode: 500, body: '' };
@@ -118,9 +137,6 @@ describe('checkForUpdate via CodeChat manifest', () => {
 
     const info = await checkForUpdate('0.19.7', SERVER);
     expect(info?.latestVersion).toBe('0.20.0');
-    expect(h.requestedUrls).toEqual([
-      `https:${SERVER}/api/downloads/manifest.json`,
-      `https:${GITHUB_LATEST}`,
-    ]);
+    expect(h.requestedUrls).toEqual([`https:${FEED_URL}`, `https:${GITHUB_LATEST}`]);
   });
 });

--- a/packages/webview-fixtures/src/types.ts
+++ b/packages/webview-fixtures/src/types.ts
@@ -330,6 +330,24 @@ export interface DesktopThemeChangeMessage extends HostToWebviewMessageBase {
   effective: EffectiveTheme;
 }
 
+/** Action a toast's button triggers when clicked (host-side semantics). */
+export type ToastAction =
+  | { type: 'quitAndInstall' }
+  | { type: 'openDownloadPage'; url: string };
+
+/** A non-modal in-app toast (VS Code-style, bottom-right). Desktop host only. */
+export interface UpdateToast {
+  id: string;
+  message: string;
+  actionLabel?: string;
+  action?: ToastAction;
+}
+
+export interface ShowToastMessage extends HostToWebviewMessageBase {
+  command: 'showToast';
+  toast: UpdateToast;
+}
+
 export interface DesktopTogglePanelMessage extends HostToWebviewMessageBase {
   command: 'desktopTogglePanel';
   kind: DesktopPanelKind;
@@ -540,6 +558,7 @@ export type HostToWebviewMessage =
   | ProjectSettingsMessage
   | SetInitialStateMessage
   | DesktopThemeChangeMessage
+  | ShowToastMessage
   | DesktopTogglePanelMessage
   | ShowConfigurationMessage
   | ShowDialogMessage

--- a/packages/webview/e2e/demo/desktop-update-toast.demo.ts
+++ b/packages/webview/e2e/demo/desktop-update-toast.demo.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '../utils/desktopTestHarness.js';
+import { MessageInjector } from '../utils/messageInjector.js';
+import { MockDataGenerator } from '../fixtures/mockData.js';
+import { screenshotWebp } from '../utils/screenshot.js';
+
+const DIR_A = '/Users/dev/projects/wave-agent';
+
+const initialState = {
+    messages: [],
+    isStreaming: false,
+    sessions: [],
+    isAuthenticated: true,
+    configurationData: {
+        baseURL: 'https://api.anthropic.com/v1',
+        model: 'claude-sonnet-4-20250514',
+        fastModel: 'claude-haiku-4-20250514'
+    },
+    permissionMode: 'default'
+};
+
+// Update announcements are pushed by the desktop host as showToast messages and
+// rendered by the root ChatApp instance as a VS Code-style bottom-right toast.
+// Button-less toasts (update found, downloading) auto-dismiss after 8s; toasts
+// with an action (restart-install, open download page) persist until acted on.
+test.describe('Desktop Update Toast Screenshots', () => {
+    test('capture the update toasts', async ({ webviewPage }) => {
+        const injector = new MessageInjector(webviewPage);
+
+        await webviewPage.setViewportSize({ width: 960, height: 640 });
+
+        // Mount ChatApp (single pane) and wait for its message listener before
+        // sending setInitialState, otherwise the payload is lost to the race.
+        await injector.simulateExtensionMessage('desktopWorkdirState', {
+            workdir: DIR_A,
+            recentWorkdirs: [DIR_A]
+        });
+        await injector.waitForChatAppReady();
+        await injector.simulateExtensionMessage('setInitialState', initialState);
+        await injector.updateMessages([
+            MockDataGenerator.createUserMessage('帮我修复登录页的样式问题', 'msg-u1'),
+            MockDataGenerator.createAssistantMessage(
+                '我先看一下登录页组件的样式文件，找出对齐问题的原因。',
+                'msg-a1'
+            )
+        ]);
+        await expect(webviewPage.locator('.message.user')).toBeVisible();
+
+        // ── 1. Update found, downloading in background (no button) ──────
+        await injector.simulateExtensionMessage('showToast', {
+            toast: {
+                id: 'update-1',
+                message: '发现新版本 v0.20.0（当前 v0.19.7），正在后台下载…'
+            }
+        });
+        await expect(webviewPage.getByTestId('toast')).toBeVisible();
+        await expect(webviewPage.getByTestId('toast')).toContainText('发现新版本 v0.20.0');
+        // Wait for the 0.15s fade-in to finish — toBeVisible passes at opacity 0
+        // and a screenshot taken mid-animation would look translucent.
+        await expect(webviewPage.getByTestId('toast')).toHaveCSS('opacity', '1');
+        await screenshotWebp(webviewPage, '../../docs/public/screenshots/desktop-update-toast.webp');
+
+        // The button-less toast auto-dismisses after 8s; wait for it to leave
+        // so the second screenshot shows the action toast alone (not stacked).
+        await expect(webviewPage.getByTestId('toast')).toHaveCount(0, { timeout: 10000 });
+
+        // ── 2. Download finished: action toast with 重启安装 button ─────
+        await injector.simulateExtensionMessage('showToast', {
+            toast: {
+                id: 'update-2',
+                message: '新版本 v0.20.0 已下载完成，重启应用以完成安装。',
+                actionLabel: '重启安装',
+                action: { type: 'quitAndInstall' }
+            }
+        });
+        await expect(webviewPage.getByTestId('toast')).toContainText('已下载完成');
+        await expect(webviewPage.getByRole('button', { name: '重启安装' })).toBeVisible();
+        await expect(webviewPage.getByTestId('toast')).toHaveCSS('opacity', '1');
+        await screenshotWebp(webviewPage, '../../docs/public/screenshots/desktop-update-toast-action.webp');
+    });
+});

--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -9,6 +9,7 @@ import { ConfirmationDialog } from './ConfirmationDialog';
 import { ConfirmDialog } from './ConfirmDialog';
 import { RewindPopup } from './RewindPopup';
 import type { RewindCheckpoint } from './RewindPopup';
+import { ToastStack } from './ToastStack';
 import { BtwPanel } from './BtwPanel';
 import ConfigDialog from './ConfigDialog';
 import PluginDialog from './PluginDialog';
@@ -34,6 +35,7 @@ import type {
   DesktopPanelKind,
   FileViewState,
   ToolBlockUpdateCallbackParams,
+  UpdateToast,
 } from '../types';
 import { chatReducer, initialState } from '../reducers/chatReducer';
 import '../styles/ChatApp.css';
@@ -162,6 +164,9 @@ export function prunePanelGroupCache(keepKeys: Set<string>): void {
 export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
   const [state, dispatch] = useReducer(chatReducer, initialState);
   const [queueEditWarning, setQueueEditWarning] = useState<string | null>(null);
+  // In-app toasts (VS Code-style, bottom-right). Desktop host only: pushed via
+  // `showToast` (update announcements), acknowledged via `toastAction`.
+  const [toasts, setToasts] = useState<UpdateToast[]>([]);
   // Message id awaiting rewind confirmation; non-null shows the ConfirmDialog.
   const [pendingRewindId, setPendingRewindId] = useState<string | null>(null);
   // /rewind popup: checkpoint list requested from the host on open.
@@ -644,6 +649,13 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
         case 'desktopThemeChange':
           document.documentElement.setAttribute('data-theme', message.effective);
           break;
+        case 'showToast':
+          // Toasts are window-global (no paneId) — only the root instance (the
+          // one that renders the shell/sidebar, never a split-view pane) tracks
+          // them, so a multi-pane desktop never stacks duplicates.
+          if (myPane !== undefined) break;
+          setToasts((prev) => [...prev.filter((t) => t.id !== message.toast.id), message.toast]);
+          break;
         case 'desktopTogglePanel':
           if (!forThisPane(message)) break;
           togglePanelRef.current(message.kind as DesktopPanelKind);
@@ -827,6 +839,16 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
     postToHost({
       command: 'clearChat'
     });
+  }, [postToHost]);
+
+  const handleToastDismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const handleToastAction = useCallback((toast: UpdateToast) => {
+    if (!toast.action) return;
+    postToHost({ command: 'toastAction', toastId: toast.id, action: toast.action });
+    setToasts((prev) => prev.filter((t) => t.id !== toast.id));
   }, [postToHost]);
 
   // Desktop 的"新对话"入口（侧边栏按钮）：由宿主 spawn 新 agent 承载全新会话，
@@ -1652,6 +1674,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
           onCancel={() => setPendingRewindId(null)}
         />
       )}
+      <ToastStack toasts={toasts} onDismiss={handleToastDismiss} onAction={handleToastAction} />
     </>
   );
 

--- a/packages/webview/src/components/ToastStack.tsx
+++ b/packages/webview/src/components/ToastStack.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect } from 'react';
+import type { UpdateToast } from '../types';
+import '../styles/ToastStack.css';
+
+interface ToastStackProps {
+  toasts: UpdateToast[];
+  onDismiss: (id: string) => void;
+  onAction: (toast: UpdateToast) => void;
+}
+
+/** How long a button-less toast stays up before auto-dismissing (ms). */
+const AUTO_DISMISS_MS = 8000;
+
+/** One VS Code-style toast: message text + optional action button + close. */
+const Toast: React.FC<{
+  toast: UpdateToast;
+  onDismiss: (id: string) => void;
+  onAction: (toast: UpdateToast) => void;
+}> = ({ toast, onDismiss, onAction }) => {
+  // Informational toasts (no action) disappear on their own; actionable ones
+  // stay until the user acts or closes them.
+  useEffect(() => {
+    if (toast.action) return;
+    const timer = setTimeout(() => onDismiss(toast.id), AUTO_DISMISS_MS);
+    return () => clearTimeout(timer);
+  }, [toast.id, toast.action, onDismiss]);
+
+  return (
+    <div className="toast" role="status" data-testid="toast">
+      <span className="toast-message">{toast.message}</span>
+      {toast.actionLabel && toast.action && (
+        <button
+          className="toast-action"
+          onClick={() => onAction(toast)}
+        >
+          {toast.actionLabel}
+        </button>
+      )}
+      <button className="toast-close" onClick={() => onDismiss(toast.id)} aria-label="关闭">
+        <i className="codicon codicon-close"></i>
+      </button>
+    </div>
+  );
+};
+
+/** Bottom-right stacked toast container (VS Code notification style). */
+export const ToastStack: React.FC<ToastStackProps> = ({ toasts, onDismiss, onAction }) => {
+  if (toasts.length === 0) return null;
+  return (
+    <div className="toast-stack" data-testid="toast-stack">
+      {toasts.map((toast) => (
+        <Toast key={toast.id} toast={toast} onDismiss={onDismiss} onAction={onAction} />
+      ))}
+    </div>
+  );
+};

--- a/packages/webview/src/styles/ToastStack.css
+++ b/packages/webview/src/styles/ToastStack.css
@@ -1,0 +1,79 @@
+/* VS Code-style non-modal toast stack, bottom-right. Desktop host only (update
+ * announcements); VSCE/JetBrains never push showToast so this stays inert. */
+
+.toast-stack {
+  position: fixed;
+  right: 12px;
+  bottom: 12px;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: min(420px, calc(100vw - 24px));
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--vscode-notifications-border, rgba(128, 128, 128, 0.35));
+  background: var(--vscode-notifications-background, #252526);
+  color: var(--vscode-notifications-foreground, #cccccc);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  animation: toast-slide-in 0.15s ease-out;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+@keyframes toast-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.toast-message {
+  flex: 1;
+  min-width: 0;
+  word-break: break-word;
+}
+
+.toast-action {
+  flex-shrink: 0;
+  padding: 3px 10px;
+  border: none;
+  border-radius: 4px;
+  background: var(--vscode-button-background, #0e639c);
+  color: var(--vscode-button-foreground, #ffffff);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.toast-action:hover {
+  background: var(--vscode-button-hoverBackground, #1177bb);
+}
+
+.toast-close {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  opacity: 0.8;
+  cursor: pointer;
+}
+
+.toast-close:hover {
+  opacity: 1;
+  background: var(--vscode-toolbar-hoverBackground, rgba(128, 128, 128, 0.2));
+}

--- a/packages/webview/src/types/index.ts
+++ b/packages/webview/src/types/index.ts
@@ -277,6 +277,19 @@ export interface ThemeState {
   effective: EffectiveTheme;
 }
 
+/** Action a toast's button triggers when clicked (host-side semantics). */
+export type ToastAction =
+  | { type: 'quitAndInstall' }
+  | { type: 'openDownloadPage'; url: string };
+
+/** A non-modal in-app toast (VS Code-style, bottom-right). Desktop host only. */
+export interface UpdateToast {
+  id: string;
+  message: string;
+  actionLabel?: string;
+  action?: ToastAction;
+}
+
 // Pushed by the desktop main process in response to `desktopReady` and after
 // every workdir/host change (message command: 'desktopWorkdirState').
 export interface DesktopWorkdirState {

--- a/packages/webview/tests/webview/chatAppToast.test.tsx
+++ b/packages/webview/tests/webview/chatAppToast.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderChatApp, sendHostMessage, screen, fireEvent } from './test-utils';
+
+// Desktop-host update toasts (showToast → in-app ToastStack → toastAction echo).
+describe('ChatApp showToast integration', () => {
+    it('renders a host-pushed toast and echoes its action button back as toastAction', () => {
+        const { vscode } = renderChatApp();
+
+        sendHostMessage({
+            command: 'showToast',
+            toast: {
+                id: 't1',
+                message: '新版本 v0.20.0 已下载完成，重启应用以完成安装。',
+                actionLabel: '重启安装',
+                action: { type: 'quitAndInstall' },
+            },
+        });
+
+        expect(screen.getByText('新版本 v0.20.0 已下载完成，重启应用以完成安装。')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: '重启安装' }));
+
+        // The webview echoes the opaque action back; the host performs it.
+        expect(vscode.postMessage).toHaveBeenCalledWith({
+            command: 'toastAction',
+            toastId: 't1',
+            action: { type: 'quitAndInstall' },
+        });
+        // The toast is removed once acted upon.
+        expect(screen.queryByText('新版本 v0.20.0 已下载完成，重启应用以完成安装。')).not.toBeInTheDocument();
+    });
+
+    it('dismisses a toast via its close button without echoing an action', () => {
+        const { vscode } = renderChatApp();
+
+        sendHostMessage({ command: 'showToast', toast: { id: 't1', message: '当前已是最新版本' } });
+        expect(screen.getByText('当前已是最新版本')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: '关闭' }));
+        expect(screen.queryByText('当前已是最新版本')).not.toBeInTheDocument();
+        expect(vscode.postMessage).not.toHaveBeenCalledWith(expect.objectContaining({ command: 'toastAction' }));
+    });
+
+    it('replaces a toast with the same id instead of stacking duplicates', () => {
+        renderChatApp();
+
+        sendHostMessage({ command: 'showToast', toast: { id: 't1', message: '发现新版本 v0.20.0，正在后台下载…' } });
+        sendHostMessage({ command: 'showToast', toast: { id: 't1', message: '新版本 v0.20.0 已下载完成' } });
+
+        expect(screen.getAllByTestId('toast')).toHaveLength(1);
+        expect(screen.getByText('新版本 v0.20.0 已下载完成')).toBeInTheDocument();
+    });
+});

--- a/packages/webview/tests/webview/toastStack.test.tsx
+++ b/packages/webview/tests/webview/toastStack.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ToastStack } from '../../src/components/ToastStack';
+import type { UpdateToast } from '../../src/types';
+
+const toast = (overrides: Partial<UpdateToast> = {}): UpdateToast => ({
+  id: 't1',
+  message: '新版本 v0.20.0 已下载完成',
+  ...overrides,
+});
+
+describe('ToastStack', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders nothing when empty', () => {
+    const { container } = render(
+      <ToastStack toasts={[]} onDismiss={vi.fn()} onAction={vi.fn()} />
+    );
+    expect(container.querySelector('.toast-stack')).toBeNull();
+  });
+
+  it('renders the message with an action button and a close button', () => {
+    render(
+      <ToastStack
+        toasts={[toast({ actionLabel: '重启安装', action: { type: 'quitAndInstall' } })]}
+        onDismiss={vi.fn()}
+        onAction={vi.fn()}
+      />
+    );
+    expect(screen.getByText('新版本 v0.20.0 已下载完成')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '重启安装' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '关闭' })).toBeInTheDocument();
+  });
+
+  it('omits the action button when the toast has no action', () => {
+    render(<ToastStack toasts={[toast()]} onDismiss={vi.fn()} onAction={vi.fn()} />);
+    expect(screen.getByText('新版本 v0.20.0 已下载完成')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '重启安装' })).toBeNull();
+  });
+
+  it('stacks multiple toasts vertically', () => {
+    render(
+      <ToastStack
+        toasts={[toast({ id: 't1' }), toast({ id: 't2', message: '当前已是最新版本' })]}
+        onDismiss={vi.fn()}
+        onAction={vi.fn()}
+      />
+    );
+    expect(screen.getAllByTestId('toast')).toHaveLength(2);
+    expect(screen.getByText('当前已是最新版本')).toBeInTheDocument();
+  });
+
+  it('auto-dismisses a button-less toast after the timeout', () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+    render(<ToastStack toasts={[toast()]} onDismiss={onDismiss} onAction={vi.fn()} />);
+    vi.advanceTimersByTime(7999);
+    expect(onDismiss).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(onDismiss).toHaveBeenCalledWith('t1');
+  });
+
+  it('does not auto-dismiss a toast with an action (waits for the user)', () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+    render(
+      <ToastStack
+        toasts={[toast({ actionLabel: '重启安装', action: { type: 'quitAndInstall' } })]}
+        onDismiss={onDismiss}
+        onAction={vi.fn()}
+      />
+    );
+    vi.advanceTimersByTime(60000);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('fires onAction with the whole toast when the action button is clicked', () => {
+    const onAction = vi.fn();
+    const item = toast({ actionLabel: '重启安装', action: { type: 'quitAndInstall' } });
+    render(<ToastStack toasts={[item]} onDismiss={vi.fn()} onAction={onAction} />);
+    fireEvent.click(screen.getByRole('button', { name: '重启安装' }));
+    expect(onAction).toHaveBeenCalledWith(item);
+  });
+
+  it('dismisses by id when the close button is clicked', () => {
+    const onDismiss = vi.fn();
+    render(<ToastStack toasts={[toast()]} onDismiss={onDismiss} onAction={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: '关闭' }));
+    expect(onDismiss).toHaveBeenCalledWith('t1');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,12 @@ importers:
 
   packages/desktop:
     dependencies:
+      electron-updater:
+        specifier: ^6.8.9
+        version: 6.8.9
+      js-yaml:
+        specifier: ^5.2.3
+        version: 5.2.3
       node-pty:
         specifier: ^1.2.0-beta.14
         version: 1.2.0-beta.14
@@ -3178,6 +3184,9 @@ packages:
   electron-publish@26.15.3:
     resolution: {integrity: sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==}
 
+  electron-updater@6.8.9:
+    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
+
   electron-winstaller@5.4.0:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
@@ -4050,6 +4059,10 @@ packages:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
+  js-yaml@5.2.3:
+    resolution: {integrity: sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==}
+    hasBin: true
+
   jsdom@29.1.1:
     resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
@@ -4169,11 +4182,18 @@ packages:
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
@@ -5438,6 +5458,9 @@ packages:
 
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -7616,7 +7639,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.3)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@22.19.3)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.8.1))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.8.1))
 
   '@vitest/expect@4.1.7':
     dependencies:
@@ -8881,6 +8904,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  electron-updater@6.8.9:
+    dependencies:
+      builder-util-runtime: 9.7.0
+      fs-extra: 10.1.0
+      js-yaml: 4.3.0
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   electron-winstaller@5.4.0:
     dependencies:
       '@electron/asar': 3.4.1
@@ -9025,7 +9061,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es-shim-unscopables@1.1.0:
     dependencies:
@@ -9492,7 +9528,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
@@ -10005,6 +10041,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  js-yaml@5.2.3:
+    dependencies:
+      argparse: 2.0.1
+
   jsdom@29.1.1(@noble/hashes@2.2.0):
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
@@ -10162,9 +10202,13 @@ snapshots:
 
   lodash-es@4.18.1: {}
 
+  lodash.escaperegexp@4.1.2: {}
+
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.isinteger@4.0.4: {}
 
@@ -11556,6 +11600,8 @@ snapshots:
   tiny-async-pool@1.3.0:
     dependencies:
       semver: 5.7.2
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
Fixes #1685

登录态（serverUrl）时用 electron-updater generic provider 查询 codechat 下载端点（mac 请求 latest-mac.yml、win 请求 latest.yml），未登录回退 GitHub checkForUpdate 流程。

- 新增 AutoUpdaterService：update-available → 应用内 toast（右下角，VS Code 风格，无按钮 8s 自动消失）；update-downloaded → toast 带「重启安装」按钮，点击直接 quitAndInstall（无二次确认弹窗）；error 事件（检查/后台下载失败）→ 降级到 checkForUpdate 手动流程，toast 带「打开下载页」按钮，不静默失败
- updateChecker.ts 修复 downloadUrl 指向 manifest.json 自身的 bug，改为从 electron-builder 元数据（latest.yml / latest-mac.yml）解析 path
- StatusDialog 检查更新按钮复用同链路
- webview 新增 ToastStack 组件：消息 + 可选动作按钮 + 关闭；多 pane 时仅主实例管理，不重复渲染
- 非目标（见 spec）：Windows 签名验证、Linux 自动更新、CI publish 上传（保持 --publish never）
- spec：docs/specs/ui/desktop-app.md 自动更新用户故事 8 验收场景（系统通知改为应用内 toast）

验证：desktop 470 + webview 635 测试全绿、type-check / lint / compile 通过