### PR TITLE
fix(webview): slash popup selected skill description readable on light theme

### DIFF
--- a/packages/webview/src/styles/SlashCommandsPopup.css
+++ b/packages/webview/src/styles/SlashCommandsPopup.css
@@ -61,7 +61,8 @@
 }
 
 .slash-command-item.selected .slash-command-description {
-    color: var(--vscode-foreground);
+    color: var(--vscode-list-activeSelectionForeground);
+    opacity: 0.85;
 }
 
 .slash-command-name {


### PR DESCRIPTION
fix(webview): slash popup selected skill description readable on light theme

Use --vscode-list-activeSelectionForeground (matching the name text)
instead of --vscode-foreground, which stays gray on the deep-blue
selection background of light themes (e.g. VS Code Light+) and was
unreadable. Opacity 0.85 keeps the name/description hierarchy.