### PR TITLE
fix(code): drop unused refreshMessages dep in useCallback

### DIFF
--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -797,7 +797,6 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
       originalCwd,
       model,
       initialPermissionMode,
-      refreshMessages,
       throttledContentUpdate,
       throttledReasoningUpdate,
       throttledToolBlockUpdate,


### PR DESCRIPTION
Remove refreshMessages from the initializeAgent useCallback dependency array - it is not referenced in the callback body, fixing the react-hooks/exhaustive-deps lint warning.