### PR TITLE
fix(jetbrains): declare optional jcef dependency for 2026.2+

### DIFF
--- a/packages/jetbrains/src/main/resources/META-INF/jcef.xml
+++ b/packages/jetbrains/src/main/resources/META-INF/jcef.xml
@@ -1,0 +1,8 @@
+<idea-plugin>
+    <!--
+      Optional depends (com.intellij.modules.jcef) 的 config-file：
+      - 2026.2+：JCEF 插件存在，本文件随依赖一并加载（本插件不在 XML 声明
+        JCEF 组件，JBCefBrowser 仅在 Kotlin 代码中实例化，故内容为空）；
+      - 2024.2–2026.1：JCEF 插件不存在，本文件与依赖一并被忽略。
+    -->
+</idea-plugin>

--- a/packages/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/packages/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -8,6 +8,13 @@
     ]]></description>
 
     <depends>com.intellij.modules.platform</depends>
+    <!--
+      JCEF 自 2026.2 起从平台核心拆分为独立 bundled 插件（IJPL-246446）。
+      - 2026.2+：声明该依赖后 JBCefBrowser 才对插件类加载器可见；
+      - 2024.2–2026.1：插件不存在，optional 依赖被忽略，JCEF 类仍由
+        平台核心的 app-client.jar 提供，插件照常工作。
+    -->
+    <depends optional="true" config-file="jcef.xml">com.intellij.modules.jcef</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <applicationService


### PR DESCRIPTION
修复客户在 IntelliJ IDEA 2026.2 安装插件后工具窗口崩溃：NoClassDefFoundError: com/intellij/ui/jcef/JBCefBrowser

根因（IJPL-246446）：2026.2 起 JCEF API 从平台核心拆分为独立 bundled 插件 com.intellij.modules.jcef，插件类加载器只可见 depends 声明插件导出的类，未声明依赖导致 JBCefBrowser 不可见。

修复：plugin.xml 声明 optional depends + config-file（2026.2+ 生效，2024.2-2026.1 自动忽略），新增 META-INF/jcef.xml 空配置满足验证器要求。

已验证：IDEA 2026.2 手动安装通过。