### PR TITLE
fix(plugins): rename marketplace display name to Wave Code Chat

### DIFF
--- a/packages/jetbrains/gradle.properties
+++ b/packages/jetbrains/gradle.properties
@@ -1,5 +1,5 @@
 pluginGroup=com.wave.jetbrains
-pluginName=Wave
+pluginName=Wave Code Chat
 pluginVersion=1.0.6
 
 platformType=IC

--- a/packages/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/packages/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -1,10 +1,10 @@
 <idea-plugin>
     <id>com.wave.jetbrains</id>
-    <name>Wave 代码智聊</name>
+    <name>Wave Code Chat</name>
     <vendor>wave-codechat</vendor>
 
     <description><![CDATA[
-        Wave code for JetBrains IDEs — AI-powered development assistant.
+        Wave 代码智聊
     ]]></description>
 
     <depends>com.intellij.modules.platform</depends>

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "wave-vscode",
   "private": true,
-  "displayName": "Wave 代码智聊",
-  "description": "Wave code for VS Code",
+  "displayName": "Wave Code Chat",
+  "description": "Wave 代码智聊",
   "version": "1.0.6",
   "publisher": "wave-codechat",
   "icon": "LOGO.png",


### PR DESCRIPTION
VS Marketplace 的扩展 display name 全局唯一，且删除扩展后名字不释放（此前上传过一个同名插件导致 "This extension display name is taken"）。将两端 displayName 统一改为 Wave Code Chat：\n\n- vsce package.json: displayName Wave 代码智聊 → Wave Code Chat，description 保留中文 Wave 代码智聊\n- jb gradle.properties pluginName + plugin.xml name: → Wave Code Chat，description 改为中文\n\n不影响扩展 id（wave-vscode / com.wave.jetbrains）。