### PR TITLE
feat(desktop): unify desktop notifications to the global toast

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -443,11 +443,16 @@ export class DesktopHost {
     this.onPanelStateChanged?.(this.panePanelState.get(this.focusedPaneId) ?? []);
   }
 
-  /** Surface an update event as a non-modal in-app toast (VS Code-style). */
-  private showUpdateToast(toast: Omit<UpdateToast, 'id'>): void {
+  /**
+   * Surface an event as a non-modal in-app toast (VS Code-style, bottom-right).
+   * Window-global: the webview shows it on the root instance only, so it never
+   * becomes a chat message and never flips the pane out of the new-session
+   * picker state.
+   */
+  private showToast(toast: Omit<UpdateToast, 'id'>): void {
     this.postMessage({
       command: 'showToast',
-      toast: { id: `update-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`, ...toast },
+      toast: { id: `toast-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`, ...toast },
     });
   }
 
@@ -1080,9 +1085,9 @@ export class DesktopHost {
     this.ensureClientFor(host)
       .then(() => this.refreshAuthStatus(host))
       .catch((error) => {
-        this.pushSystemMessage(
-          `连接主机 ${host} 失败：${error instanceof Error ? error.message : String(error)}`,
-        );
+        this.showToast({
+          message: `连接主机 ${host} 失败：${error instanceof Error ? error.message : String(error)}`,
+        });
       });
   }
 
@@ -1133,7 +1138,7 @@ export class DesktopHost {
     if (newRow && !hasSecondRow) {
       // Split the single row into two; the new pane is alone in its fresh row.
       if (!this.canSplitRows()) {
-        this.pushSystemMessage('窗口高度不足，无法拆分为两行', this.focusedPaneId);
+        this.showToast({ message: '窗口高度不足，无法拆分为两行' });
         return null;
       }
       if (newRow === 'above') this.panes.forEach((p) => { p.row = 1; });
@@ -1150,10 +1155,9 @@ export class DesktopHost {
         } else if (!hasSecondRow && this.canSplitRows()) {
           targetRow = 1;
         } else {
-          this.pushSystemMessage(
-            hasSecondRow ? '窗口宽度不足，无法添加更多分屏' : '空间不足，无法添加更多分屏',
-            this.focusedPaneId,
-          );
+          this.showToast({
+            message: hasSecondRow ? '窗口宽度不足，无法添加更多分屏' : '空间不足，无法添加更多分屏',
+          });
           return null;
         }
       }
@@ -1251,7 +1255,7 @@ export class DesktopHost {
     if (wantsSplit) {
       if (this.panes.length <= 1) return;
       if (!this.canSplitRows()) {
-        this.pushSystemMessage('窗口高度不足，无法拆分为两行', this.focusedPaneId);
+        this.showToast({ message: '窗口高度不足，无法拆分为两行' });
         return;
       }
       const targetRow = newRow != null ? (newRow === 'above' ? 0 : 1) : toRow!;
@@ -2202,6 +2206,13 @@ export class DesktopHost {
         await this.handleSelectHost(msg.host as string);
         break;
 
+      case 'desktopShowHint':
+        // Webview-side local validations (pane/panel min-size refusals, preview
+        // URL checks) route through the same global toast so desktop hints share
+        // one presentation with host failures instead of a second hint style.
+        this.showToast({ message: msg.text as string });
+        break;
+
       case 'desktopAddHost':
         await this.handleAddHost(msg.connectionString as string);
         break;
@@ -2522,7 +2533,7 @@ export class DesktopHost {
         try {
           await this.agentForPane(pid)?.connectMcpServer(msg.serverName as string);
         } catch (error) {
-          this.pushSystemMessage(`连接 MCP 服务器失败: ${error}`, pid);
+          this.showToast({ message: `连接 MCP 服务器失败: ${error}` });
         }
         break;
 
@@ -2530,7 +2541,7 @@ export class DesktopHost {
         try {
           await this.agentForPane(pid)?.disconnectMcpServer(msg.serverName as string);
         } catch (error) {
-          this.pushSystemMessage(`断开 MCP 服务器失败: ${error}`, pid);
+          this.showToast({ message: `断开 MCP 服务器失败: ${error}` });
         }
         break;
 
@@ -2787,7 +2798,7 @@ export class DesktopHost {
    */
   private async handleSelectHost(host: string): Promise<void> {
     if (host !== LOCAL_HOST && !parseSshConfigHosts().includes(host)) {
-      this.pushSystemMessage(`未知主机：${host}`);
+      this.showToast({ message: `未知主机：${host}` });
       return;
     }
     const pid = this.focusedPaneId;
@@ -2820,9 +2831,9 @@ export class DesktopHost {
     this.ensureClientFor(host)
       .then(() => this.refreshAuthStatus(host))
       .catch((error) => {
-        this.pushSystemMessage(
-          `连接主机 ${host} 失败：${error instanceof Error ? error.message : String(error)}`,
-        );
+        this.showToast({
+          message: `连接主机 ${host} 失败：${error instanceof Error ? error.message : String(error)}`,
+        });
       });
     this.sendWorkdirState();
     // The webview's host label reads the pane-bound host from desktopPanes —
@@ -2842,7 +2853,7 @@ export class DesktopHost {
     try {
       name = addSshHost(connectionString);
     } catch (error) {
-      this.pushSystemMessage(error instanceof Error ? error.message : String(error));
+      this.showToast({ message: error instanceof Error ? error.message : String(error) });
       return;
     }
     const pid = this.focusedPaneId;
@@ -2864,11 +2875,14 @@ export class DesktopHost {
     this.ensureClientFor(name)
       .then(() => this.refreshAuthStatus(name))
       .catch((error) => {
-        this.pushSystemMessage(
-          `连接主机 ${name} 失败：${error instanceof Error ? error.message : String(error)}`,
-        );
+        this.showToast({
+          message: `连接主机 ${name} 失败：${error instanceof Error ? error.message : String(error)}`,
+        });
       });
-    this.pushSystemMessage(`已添加主机：${name}`);
+    // Notices surface as a window-global toast — pushing them as chat messages
+    // would flip the pane out of the new-session picker state and hide the
+    // host/workdir selectors.
+    this.showToast({ message: `已添加主机：${name}` });
     this.sendWorkdirState();
     // Same as handleSelectHost: the pane layout must carry the new host or the
     // selector never leaves the old one.
@@ -2883,11 +2897,11 @@ export class DesktopHost {
   private async handleSelectRemotePath(host: string, path: string): Promise<void> {
     if (host === LOCAL_HOST || !path) return;
     if (!parseSshConfigHosts().includes(host)) {
-      this.pushSystemMessage(`未知主机：${host}`);
+      this.showToast({ message: `未知主机：${host}` });
       return;
     }
     if (!(await remotePathExists(host, path))) {
-      this.pushSystemMessage(`远端目录不存在：${path}`);
+      this.showToast({ message: `远端目录不存在：${path}` });
       return;
     }
     this.hostState.set(this.focusedPaneId, host);
@@ -2936,7 +2950,7 @@ export class DesktopHost {
       // index-derived session tree (FR-006), so no refreshSessionTree here.
       this.configStore.removeRecentWorkdir({ host: h, path: dir });
       this.sendWorkdirState();
-      this.pushSystemMessage(`目录不存在：${dir}，已从最近列表移除`);
+      this.showToast({ message: `目录不存在：${dir}，已从最近列表移除` });
       return;
     }
     await this.activateWorkdir({ host: h, dir });
@@ -3012,12 +3026,11 @@ export class DesktopHost {
           this.sendWorkdirState();
         }
         this.refreshSessionTree();
-        this.pushSystemMessage(
-          entry?.worktree
+        this.showToast({
+          message: entry?.worktree
             ? `worktree 目录不存在：${targetDir}，已从会话列表移除`
             : `目录不存在：${workdir}，已从最近列表与会话列表移除`,
-          pid,
-        );
+        });
         return;
       }
 
@@ -3310,7 +3323,7 @@ export class DesktopHost {
       if (!this.autoUpdaterService) {
         this.autoUpdaterService = new AutoUpdaterService({
           onUpdateAvailable: (info) =>
-            this.showUpdateToast({
+            this.showToast({
               message: `发现新版本 v${info.version}（当前 v${app.getVersion()}），正在后台下载…`,
             }),
           onUpdateDownloaded: (info) => void this.handleUpdateDownloaded(info.version),
@@ -3320,7 +3333,7 @@ export class DesktopHost {
       const outcome = await this.autoUpdaterService.checkForUpdates(serverUrl);
       if (outcome === 'update') return;
       if (outcome === 'no-update') {
-        if (manual) this.showUpdateToast({ message: '当前已是最新版本' });
+        if (manual) this.showToast({ message: '当前已是最新版本' });
         return;
       }
       // outcome === 'error': degrade to the manual checker below.
@@ -3329,13 +3342,13 @@ export class DesktopHost {
 
     const info = await checkForUpdate(app.getVersion(), serverUrl);
     if (info) {
-      this.showUpdateToast({
+      this.showToast({
         message: `发现新版本 v${info.latestVersion}（当前 v${info.currentVersion}）`,
         actionLabel: '打开下载页',
         action: { type: 'openDownloadPage', url: info.downloadUrl },
       });
     } else if (manual) {
-      this.showUpdateToast({ message: '当前已是最新版本' });
+      this.showToast({ message: '当前已是最新版本' });
     }
   }
 
@@ -3345,7 +3358,7 @@ export class DesktopHost {
     console.warn('[DesktopHost] Auto updater errored, falling back to manual check');
     const info = await checkForUpdate(app.getVersion(), serverUrl);
     if (info) {
-      this.showUpdateToast({
+      this.showToast({
         message: `发现新版本 v${info.latestVersion}（当前 v${info.currentVersion}）`,
         actionLabel: '打开下载页',
         action: { type: 'openDownloadPage', url: info.downloadUrl },
@@ -3356,7 +3369,7 @@ export class DesktopHost {
   /** The new version finished downloading — announce it via a toast whose
    *  「重启安装」 button quits and installs directly (no second confirm dialog). */
   private handleUpdateDownloaded(version: string): void {
-    this.showUpdateToast({
+    this.showToast({
       message: `新版本 v${version} 已下载完成，重启应用以完成安装。`,
       actionLabel: '重启安装',
       action: { type: 'quitAndInstall' },
@@ -3465,7 +3478,7 @@ export class DesktopHost {
       const result = (await this.utilityClientFor(this.currentHost).request('listPlugins', { workdir: this.workdir })) as { plugins: unknown[] };
       this.postMessage({ command: 'listPluginsResponse', plugins: result.plugins });
     } catch (error) {
-      this.pushSystemMessage(`获取插件列表失败: ${error}`);
+      this.showToast({ message: `获取插件列表失败: ${error}` });
     }
   }
 
@@ -3476,7 +3489,7 @@ export class DesktopHost {
       // Recreate agent to apply plugin changes
       await this.updateAgentConfig(this.configStore.getConfiguration());
     } catch (error) {
-      this.pushSystemMessage(`插件操作失败: ${error}`);
+      this.showToast({ message: `插件操作失败: ${error}` });
     }
   }
 
@@ -3488,7 +3501,7 @@ export class DesktopHost {
       };
       this.postMessage({ command: 'projectSettings', paneId, enabledPlugins: result.enabledPlugins });
     } catch (error) {
-      this.pushSystemMessage(`获取项目设置失败: ${error}`, paneId);
+      this.showToast({ message: `获取项目设置失败: ${error}` });
     }
   }
 
@@ -3510,7 +3523,7 @@ export class DesktopHost {
       // Recreate agents so the plugin change applies immediately (mirrors handlePluginMutation)
       await this.updateAgentConfig(this.configStore.getConfiguration());
     } catch (error) {
-      this.pushSystemMessage(`修改项目设置失败: ${error}`, paneId);
+      this.showToast({ message: `修改项目设置失败: ${error}` });
     }
   }
 
@@ -3519,7 +3532,7 @@ export class DesktopHost {
       const marketplaces = await this.utilityClientFor(this.currentHost).request('listMarketplaces', { workdir: this.workdir });
       this.postMessage({ command: 'listMarketplacesResponse', marketplaces });
     } catch (error) {
-      this.pushSystemMessage(`获取市场列表失败: ${error}`);
+      this.showToast({ message: `获取市场列表失败: ${error}` });
     }
   }
 
@@ -3528,7 +3541,7 @@ export class DesktopHost {
       await this.utilityClientFor(this.currentHost).request(method, { ...params, workdir: this.workdir });
       await this.handleListMarketplaces();
     } catch (error) {
-      this.pushSystemMessage(`市场操作失败: ${error}`);
+      this.showToast({ message: `市场操作失败: ${error}` });
     }
   }
 

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -375,6 +375,18 @@ function shownToasts(): Array<{ message: string; actionLabel?: string; action?: 
     );
 }
 
+/** Make one utility RPC method throw; returns a restore function for after the test. */
+function failRpc(method: string, message: string): () => void {
+  const orig = h.handleClientRequest;
+  h.handleClientRequest = (m: string, params?: unknown) => {
+    if (m === method) throw new Error(message);
+    return orig(m, params);
+  };
+  return () => {
+    h.handleClientRequest = orig;
+  };
+}
+
 function createHost(winWidth = 1280, winHeight = 800) {
   const store = new ConfigStore(STORE_PATH);
   const host = new DesktopHost(store);
@@ -510,10 +522,8 @@ describe('workdir lifecycle', () => {
 
     expect(store.getRecentWorkdirs()).not.toEqual(expect.arrayContaining([{ host: 'local', path: '/gone' }]));
     expect(lastAgent()).toBe(agentBefore);
-    const sysMsgs = sent('appendMessage').filter((m) =>
-      JSON.stringify(m).includes('已从最近列表移除'),
-    );
-    expect(sysMsgs).toHaveLength(1);
+    expect(shownToasts().some((t) => t.message.includes('已从最近列表移除'))).toBe(true);
+    expect(sent('appendMessage').filter((m) => JSON.stringify(m).includes('已从最近列表移除'))).toHaveLength(0);
   });
 
 });
@@ -1468,6 +1478,98 @@ describe('misc commands', () => {
     expect(sent('mcpServersResponse')[0]).toMatchObject({ servers: [] });
   });
 
+  it('connectMcpServer failure surfaces as a toast, not a chat message', async () => {
+    const { host, sent } = await readyHost();
+    lastAgent().connectMcpServer.mockRejectedValueOnce(new Error('server not found'));
+
+    await host.handleWebviewMessage({ command: 'connectMcpServer', serverName: 'srv' });
+
+    expect(shownToasts().some((t) => t.message.includes('连接 MCP 服务器失败'))).toBe(true);
+    expect(sent('appendMessage')).toHaveLength(0);
+  });
+
+  it('disconnectMcpServer failure surfaces as a toast, not a chat message', async () => {
+    const { host, sent } = await readyHost();
+    lastAgent().disconnectMcpServer.mockRejectedValueOnce(new Error('not connected'));
+
+    await host.handleWebviewMessage({ command: 'disconnectMcpServer', serverName: 'srv' });
+
+    expect(shownToasts().some((t) => t.message.includes('断开 MCP 服务器失败'))).toBe(true);
+    expect(sent('appendMessage')).toHaveLength(0);
+  });
+
+  it('listPlugins failure surfaces as a toast, not a chat message', async () => {
+    const { host, sent } = await readyHost();
+    const restore = failRpc('listPlugins', 'plugin service down');
+    try {
+      await host.handleWebviewMessage({ command: 'listPlugins' });
+    } finally {
+      restore();
+    }
+    expect(shownToasts().some((t) => t.message.includes('获取插件列表失败'))).toBe(true);
+    expect(sent('appendMessage')).toHaveLength(0);
+  });
+
+  it('plugin mutation failure surfaces as a toast, not a chat message', async () => {
+    const { host, sent } = await readyHost();
+    const restore = failRpc('enablePlugin', 'plugin service down');
+    try {
+      await host.handleWebviewMessage({ command: 'enablePlugin', pluginId: 'demo', scope: 'user' });
+    } finally {
+      restore();
+    }
+    expect(shownToasts().some((t) => t.message.includes('插件操作失败'))).toBe(true);
+    expect(sent('appendMessage')).toHaveLength(0);
+  });
+
+  it('getProjectSettings failure surfaces as a toast, not a chat message', async () => {
+    const { host, sent } = await readyHost();
+    const restore = failRpc('getProjectSettings', 'settings down');
+    try {
+      await host.handleWebviewMessage({ command: 'getProjectSettings' });
+    } finally {
+      restore();
+    }
+    expect(shownToasts().some((t) => t.message.includes('获取项目设置失败'))).toBe(true);
+    expect(sent('appendMessage')).toHaveLength(0);
+  });
+
+  it('setBuiltinPluginEnabled failure surfaces as a toast, not a chat message', async () => {
+    const { host, sent } = await readyHost();
+    const restore = failRpc('setBuiltinPluginEnabled', 'settings down');
+    try {
+      await host.handleWebviewMessage({ command: 'setBuiltinPluginEnabled', pluginId: 'builtin-review', enabled: true, scope: 'user' });
+    } finally {
+      restore();
+    }
+    expect(shownToasts().some((t) => t.message.includes('修改项目设置失败'))).toBe(true);
+    expect(sent('appendMessage')).toHaveLength(0);
+  });
+
+  it('listMarketplaces failure surfaces as a toast, not a chat message', async () => {
+    const { host, sent } = await readyHost();
+    const restore = failRpc('listMarketplaces', 'marketplace down');
+    try {
+      await host.handleWebviewMessage({ command: 'listMarketplaces' });
+    } finally {
+      restore();
+    }
+    expect(shownToasts().some((t) => t.message.includes('获取市场列表失败'))).toBe(true);
+    expect(sent('appendMessage')).toHaveLength(0);
+  });
+
+  it('marketplace mutation failure surfaces as a toast, not a chat message', async () => {
+    const { host, sent } = await readyHost();
+    const restore = failRpc('addMarketplace', 'marketplace down');
+    try {
+      await host.handleWebviewMessage({ command: 'addMarketplace', input: { name: 'm', url: 'https://m' } });
+    } finally {
+      restore();
+    }
+    expect(shownToasts().some((t) => t.message.includes('市场操作失败'))).toBe(true);
+    expect(sent('appendMessage')).toHaveLength(0);
+  });
+
   it('listRewindCheckpoints replies with the agent checkpoints', async () => {
     const { host, sent } = await readyHost();
     await host.handleWebviewMessage({ command: 'listRewindCheckpoints' });
@@ -1643,8 +1745,8 @@ describe('session tree', () => {
       expect(store.getSessionIndex().some((e) => e.sessionId === 'sess-z')).toBe(false);
       expect(store.getRecentWorkdirs()).not.toEqual(expect.arrayContaining([{ host: 'local', path: '/gone' }]));
       expect(lastAgent().restoreSession).not.toHaveBeenCalled();
-      const sysMsgs = sent('appendMessage').filter((m) => JSON.stringify(m).includes('已从最近列表与会话列表移除'));
-      expect(sysMsgs).toHaveLength(1);
+      expect(shownToasts().some((t) => t.message.includes('已从最近列表与会话列表移除'))).toBe(true);
+      expect(sent('appendMessage').filter((m) => JSON.stringify(m).includes('已从最近列表与会话列表移除'))).toHaveLength(0);
     });
   });
 
@@ -1869,8 +1971,9 @@ describe('session tree', () => {
       const states = sent('setInitialState');
       expect(states.some((s) => s?.isRestoring === true)).toBe(true);
       expect(store.getSessionIndex().some((e) => e.sessionId === 'gone-1')).toBe(false);
-      const sysMsgs = sent('appendMessage').filter((m) => JSON.stringify(m).includes('目录不存在'));
-      expect(sysMsgs).toHaveLength(1);
+      const toasts = shownToasts().filter((t) => t.message.includes('目录不存在'));
+      expect(toasts).toHaveLength(1);
+      expect(sent('appendMessage').filter((m) => JSON.stringify(m).includes('目录不存在'))).toHaveLength(0);
       expect(states.at(-1)?.isRestoring).toBe(false);
     });
   });
@@ -2032,10 +2135,8 @@ describe('session switch shortcut (FR-038)', () => {
 
     expect(ctx.store.getSessionIndex().some((e) => e.sessionId === 's2')).toBe(false);
     expect(h.agentInstances).toHaveLength(0);
-    const sysMsgs = ctx.sent('appendMessage').filter((m) =>
-      JSON.stringify(m).includes('已从最近列表与会话列表移除'),
-    );
-    expect(sysMsgs).toHaveLength(1);
+    expect(shownToasts().some((t) => t.message.includes('已从最近列表与会话列表移除'))).toBe(true);
+    expect(ctx.sent('appendMessage').filter((m) => JSON.stringify(m).includes('已从最近列表与会话列表移除'))).toHaveLength(0);
   });
 });
 
@@ -2348,8 +2449,8 @@ describe('worktree flow', () => {
       // Repo root stays in recents — only the stale index entry is dropped.
       expect(store.getRecentWorkdirs()).toEqual(expect.arrayContaining([{ host: 'local', path: '/work/a' }]));
       expect(lastAgent().restoreSession).not.toHaveBeenCalled();
-      const sysMsgs = sent('appendMessage').filter((m) => JSON.stringify(m).includes('worktree 目录不存在'));
-      expect(sysMsgs).toHaveLength(1);
+      expect(shownToasts().some((t) => t.message.includes('worktree 目录不存在'))).toBe(true);
+      expect(sent('appendMessage').filter((m) => JSON.stringify(m).includes('worktree 目录不存在'))).toHaveLength(0);
     });
   });
 
@@ -2859,6 +2960,34 @@ describe('split-view panes (FR-032~036)', () => {
     expect(panePushes(sent)).toHaveLength(layouts);
   });
 
+  it('desktopFocusPane surfaces the newly focused host connect failure as a toast', async () => {
+    seedSshConfig('Host prod\n');
+    const { host, sent } = await readyHost();
+    // pane-1's picker is pinned to prod (no agent bound yet), so focusing back
+    // onto it must establish the prod client again — and fail here.
+    await host.handleWebviewMessage({ command: 'desktopSelectHost', host: 'prod' });
+    await vi.waitFor(() => {
+      expect(shownToasts().length).toBe(0); // eager connect succeeded, no toast
+    });
+    // Open a local pane-2 so focus can move away from pane-1.
+    await host.handleWebviewMessage({ command: 'desktopOpenPane', workdir: '/work/a', sessionId: 'sess-9' });
+    await vi.waitFor(() => {
+      expect(panePushes(sent).at(-1)?.panes).toHaveLength(2);
+    });
+    const pane1 = panePushes(sent).at(-1)!.panes.find((p) => p.sessionId !== 'sess-2')!;
+    // Drop the prod tunnel: the cached client is released, and since no prod
+    // agent is bound to a pane, no auto-reconnect competes for the retry.
+    h.closedHandlers.at(-1)?.();
+    vi.mocked(connectRemoteDaemon).mockRejectedValueOnce(new Error('tunnel down'));
+
+    await host.handleWebviewMessage({ command: 'desktopFocusPane', paneId: pane1.paneId });
+
+    await vi.waitFor(() => {
+      expect(shownToasts().some((t) => t.message.includes('连接主机 prod 失败'))).toBe(true);
+    });
+    expect(sent('appendMessage')).toHaveLength(0);
+  });
+
   it('desktopClosePane removes the pane without destroying its agent, and moves focus to a neighbor', async () => {
     const { host, sent } = await readyHost();
     const agent1 = seedActiveSession('sess-1');
@@ -3108,12 +3237,23 @@ describe('pane rows (two-row layout)', () => {
 
     await host.handleWebviewMessage({ command: 'desktopOpenPane', workdir: '/work/a', sessionId: 'sess-2', newRow: 'below' });
 
-    // No new pane, no agent spawn, and a system message explains the refusal.
+    // No new pane, no agent spawn, and a toast explains the refusal.
     expect(h.agentInstances).toHaveLength(spawned);
     const layout = panePushes(sent).at(-1)!;
     expect(layout.panes).toHaveLength(1);
     expect(layout.rowHeights).toBeUndefined();
-    expect(lastSystemMessage(sent)?.blocks[0].content).toBe('窗口高度不足，无法拆分为两行');
+    expect(shownToasts().some((t) => t.message === '窗口高度不足，无法拆分为两行')).toBe(true);
+    expect(sent('appendMessage')).toHaveLength(0);
+  });
+
+  it('desktopShowHint relays a webview hint to the global toast stack', async () => {
+    const { host, sent } = await readyHost();
+
+    await host.handleWebviewMessage({ command: 'desktopShowHint', text: '空间不足，无法添加更多分屏' });
+
+    expect(shownToasts().some((t) => t.message === '空间不足，无法添加更多分屏')).toBe(true);
+    // The hint must never become a chat message.
+    expect(sent('appendMessage')).toHaveLength(0);
   });
 
   it('desktopOpenPane without a target row spills into a fresh second row when the single row is full', async () => {
@@ -3172,7 +3312,8 @@ describe('pane rows (two-row layout)', () => {
 
     expect(h.agentInstances).toHaveLength(spawned);
     expect(panePushes(sent).at(-1)!.panes).toHaveLength(1);
-    expect(lastSystemMessage(sent)?.blocks[0].content).toBe('空间不足，无法添加更多分屏');
+    expect(shownToasts().some((t) => t.message === '空间不足，无法添加更多分屏')).toBe(true);
+    expect(sent('appendMessage')).toHaveLength(0);
   });
 
   it('desktopOpenPane without a target row refuses with a hint when both rows are full', async () => {
@@ -3188,7 +3329,8 @@ describe('pane rows (two-row layout)', () => {
 
     expect(h.agentInstances).toHaveLength(spawned);
     expect(panePushes(sent).at(-1)!.panes).toHaveLength(2);
-    expect(lastSystemMessage(sent)?.blocks[0].content).toBe('窗口宽度不足，无法添加更多分屏');
+    expect(shownToasts().some((t) => t.message === '窗口宽度不足，无法添加更多分屏')).toBe(true);
+    expect(sent('appendMessage')).toHaveLength(0);
   });
 
   it('desktopOpenPane with a named target row squeezes into a narrow row like a pane move', async () => {
@@ -3445,12 +3587,6 @@ describe('desktopNewSessionInPane (new session side-by-side)', () => {
         },
     );
 
-  const lastSystemMessage = (sent: ReturnType<typeof createHost>['sent']) =>
-    sent('appendMessage')
-      .map((m) => m.message as { role: string; blocks: Array<{ type: string; content: string }> })
-      .filter((msg) => msg.blocks?.[0]?.type === 'text')
-      .at(-1);
-
   it('opens a fresh session in a new pane next to the current one', async () => {
     const { host, sent } = await readyHost();
     const original = seedActiveSession('sess-1');
@@ -3528,7 +3664,8 @@ describe('desktopNewSessionInPane (new session side-by-side)', () => {
 
     expect(h.agentInstances).toHaveLength(spawned);
     expect(panePushes(sent).at(-1)!.panes).toHaveLength(1);
-    expect(lastSystemMessage(sent)?.blocks[0].content).toBe('空间不足，无法添加更多分屏');
+    expect(shownToasts().some((t) => t.message === '空间不足，无法添加更多分屏')).toBe(true);
+    expect(sent('appendMessage')).toHaveLength(0);
   });
 
   it('still opens a new pane while the current one is streaming', async () => {
@@ -3975,16 +4112,31 @@ function treeSessions(tree: Record<string, unknown> | undefined) {
 }
 
 describe('SSH remote hosts', () => {
-  it('desktopSelectHost with an unknown host is rejected with a system message', async () => {
+  it('desktopSelectHost with an unknown host is rejected with a toast', async () => {
     const { host, sent } = await readyHost();
     const statesBefore = sent('desktopWorkdirState').length;
 
     await host.handleWebviewMessage({ command: 'desktopSelectHost', host: 'unknown' });
 
-    expect(sent('appendMessage').some((m) => JSON.stringify(m).includes('未知主机：unknown'))).toBe(true);
+    expect(shownToasts().some((t) => t.message.includes('未知主机：unknown'))).toBe(true);
+    // A picker refusal must not insert a message that hides the selectors.
+    expect(sent('appendMessage')).toHaveLength(0);
     // No workdir state re-send — the picker stays put.
     expect(sent('desktopWorkdirState').length).toBe(statesBefore);
     expect(vi.mocked(connectRemoteDaemon)).not.toHaveBeenCalled();
+  });
+
+  it('desktopSelectHost surfaces an eager-connect failure as a toast, not a chat message', async () => {
+    seedSshConfig('Host prod\n');
+    vi.mocked(connectRemoteDaemon).mockRejectedValueOnce(new Error('tunnel down'));
+    const { host, sent } = await readyHost();
+
+    await host.handleWebviewMessage({ command: 'desktopSelectHost', host: 'prod' });
+
+    await vi.waitFor(() => {
+      expect(shownToasts().some((t) => t.message.includes('连接主机 prod 失败'))).toBe(true);
+    });
+    expect(sent('appendMessage')).toHaveLength(0);
   });
 
   it('desktopSelectHost switches the picker to a host from ~/.ssh/config and shows its recents', async () => {
@@ -4141,7 +4293,11 @@ describe('SSH remote hosts', () => {
 
     const config = h.files.get(sshConfigPath()) as string;
     expect(config).toContain('\nHost newhost\n    User user\n    Port 2222\n');
-    expect(sent('appendMessage').some((m) => JSON.stringify(m).includes('已添加主机：newhost'))).toBe(true);
+    // The success notice is a window-global toast — never a chat message, or the
+    // new-session picker (host/workdir selectors) would be hidden by the
+    // visible-message state the append would create.
+    expect(shownToasts().some((t) => t.message.includes('已添加主机：newhost'))).toBe(true);
+    expect(sent('appendMessage')).toHaveLength(0);
     await vi.waitFor(() => {
       expect(vi.mocked(connectRemoteDaemon)).toHaveBeenCalledWith('newhost', expect.any(String));
     });
@@ -4150,6 +4306,21 @@ describe('SSH remote hosts', () => {
       host: 'newhost',
       hosts: ['newhost'],
     });
+  });
+
+  it('desktopAddHost surfaces an eager-connect failure as a toast, not a chat message', async () => {
+    vi.mocked(connectRemoteDaemon).mockRejectedValueOnce(new Error('tunnel down'));
+    const { host, sent } = createHost();
+
+    await host.handleWebviewMessage({
+      command: 'desktopAddHost',
+      connectionString: 'ssh user@newhost -p 2222',
+    });
+
+    await vi.waitFor(() => {
+      expect(shownToasts().some((t) => t.message.includes('连接主机 newhost 失败'))).toBe(true);
+    });
+    expect(sent('appendMessage')).toHaveLength(0);
   });
 
   it('desktopAddHost also re-queries the auth status on the auto-selected host', async () => {
@@ -4176,7 +4347,8 @@ describe('SSH remote hosts', () => {
       connectionString: 'ssh -i key.pem user@host',
     });
 
-    expect(sent('appendMessage').some((m) => JSON.stringify(m).includes('无法解析连接串'))).toBe(true);
+    expect(shownToasts().some((t) => t.message.includes('无法解析连接串'))).toBe(true);
+    expect(sent('appendMessage')).toHaveLength(0);
     expect(sent('desktopWorkdirState').at(-1)).toMatchObject({ host: 'local' });
   });
 
@@ -4213,9 +4385,23 @@ describe('SSH remote hosts', () => {
 
     await host.handleWebviewMessage({ command: 'desktopSelectRemotePath', host: 'prod', path: '/gone' });
 
-    expect(sent('appendMessage').some((m) => JSON.stringify(m).includes('远端目录不存在：/gone'))).toBe(true);
+    expect(shownToasts().some((t) => t.message.includes('远端目录不存在：/gone'))).toBe(true);
+    expect(sent('appendMessage')).toHaveLength(0);
     expect(h.agentInstances.length).toBe(1); // the local ready agent only
     expect(sent('desktopWorkdirState').at(-1)).toMatchObject({ host: 'local' });
+  });
+
+  it('desktopSelectRecentWorkdir drops a vanished directory with a toast', async () => {
+    const { host, store, sent } = await readyHost();
+    store.addRecentWorkdir({ host: 'local', path: '/gone' });
+
+    await host.handleWebviewMessage({ command: 'desktopSelectRecentWorkdir', path: '/gone' });
+
+    // The stale entry is removed from recents; the notice is a toast so the
+    // new-session picker stays visible.
+    expect(store.getRecentWorkdirs()).not.toEqual(expect.arrayContaining([{ host: 'local', path: '/gone' }]));
+    expect(shownToasts().some((t) => t.message.includes('目录不存在：/gone，已从最近列表移除'))).toBe(true);
+    expect(sent('appendMessage')).toHaveLength(0);
   });
 
   it('local and remote sessions in the same path stay separate agents', async () => {

--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -46,7 +46,6 @@ const PANEL_DEFAULT_WIDTH = 420;
 const PANEL_MIN_WIDTH = 320;
 /** The conversation (message) area never shrinks below this when opening/dragging panels. */
 const CHAT_MAIN_MIN_WIDTH = 360;
-const PANEL_HINT_DURATION_MS = 2400;
 
 /**
  * Hostname spellings that name the same remote service through an ssh tunnel:
@@ -284,9 +283,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
         file: PANEL_DEFAULT_WIDTH,
       },
   );
-  const [panelHint, setPanelHint] = useState<string | null>(null);
   const chatContainerRef = useRef<HTMLDivElement>(null);
-  const panelHintTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const checkedPanelsRef = useRef(checkedPanels);
   const panelWidthsRef = useRef(panelWidths);
   // Mirrors so the stable message listener can reach the panel toggle logic
@@ -1170,10 +1167,11 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
   }, [pendingRewindId, postToHost]);
 
   const showPanelHint = useCallback((text: string) => {
-    if (panelHintTimer.current) clearTimeout(panelHintTimer.current);
-    setPanelHint(text);
-    panelHintTimer.current = setTimeout(() => setPanelHint(null), PANEL_HINT_DURATION_MS);
-  }, []);
+    // Route local validations (panel min-width refusals, preview URL checks)
+    // through the host's global toast so desktop hints share one presentation
+    // with host failures instead of a second hint style.
+    postToHost({ command: 'desktopShowHint', text });
+  }, [postToHost]);
 
   // Desktop remote sessions: request an ssh port forward for the clicked
   // localhost URL (scenario 15). The main process picks a local port, starts
@@ -1727,11 +1725,6 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
               {renderPanelSlot(kind)}
             </div>
           ))}
-          {panelHint && (
-            <div className="desktop-pane-hint" role="status" data-testid="desktop-panel-hint">
-              {panelHint}
-            </div>
-          )}
         </div>
       ) : (
         chatBodyContent

--- a/packages/webview/src/components/DesktopShell.tsx
+++ b/packages/webview/src/components/DesktopShell.tsx
@@ -8,7 +8,6 @@ const MIN_PANE_WIDTH = 360;
 /** Minimum height of a pane row; splitting into two rows needs 2× this and
     the row separator clamps to it (the desktop host enforces the same limit). */
 const MIN_ROW_HEIGHT = 280;
-const HINT_DURATION_MS = 2400;
 const PANE_DRAG_MIME = 'application/x-wave-pane';
 
 type DropZone = 'above' | 'below';
@@ -61,7 +60,6 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
   if (paneRows[1].length === 0) paneRows.pop();
   const hasTwoRows = paneRows.length === 2;
 
-  const [hint, setHint] = useState<string | null>(null);
   const [dropIndicator, setDropIndicator] = useState<{ row: number; x: number } | null>(null);
   // VS Code-style translucent overlay while hovering an edge band (only in a
   // single-row layout): drop splits the layout into two rows.
@@ -72,17 +70,16 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
   const [rowSeparatorActive, setRowSeparatorActive] = useState(false);
   const rowsContainerRef = useRef<HTMLDivElement>(null);
   const rowRefs = useRef<(HTMLDivElement | null)[]>([]);
-  const hintTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const paneNodes = useRef(new Map<string, HTMLDivElement>());
   // Insertion boundary (row + gap index) tracked while a pane/session drags.
   const dropBoundary = useRef<{ row: number; index: number } | null>(null);
   const resizePreviewRef = useRef<{ row: number; widths: number[] } | null>(null);
 
   const showHint = useCallback((text: string) => {
-    if (hintTimer.current) clearTimeout(hintTimer.current);
-    setHint(text);
-    hintTimer.current = setTimeout(() => setHint(null), HINT_DURATION_MS);
-  }, []);
+    // Route local validations (min-size refusals) through the host's global
+    // toast so desktop hints share one presentation with host failures.
+    vscode.postMessage({ command: 'desktopShowHint', text });
+  }, [vscode]);
 
   const clearDragFeedback = useCallback(() => {
     dropBoundary.current = null;
@@ -570,11 +567,6 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
             className={`desktop-pane-dropzone desktop-pane-dropzone--${dropZone}`}
             data-testid="desktop-pane-dropzone"
           />
-        )}
-        {hint && (
-          <div className="desktop-pane-hint" role="status" data-testid="desktop-pane-hint">
-            {hint}
-          </div>
         )}
       </div>
     </div>

--- a/packages/webview/src/styles/DesktopApp.css
+++ b/packages/webview/src/styles/DesktopApp.css
@@ -885,26 +885,6 @@ body.is-panel-resizing * {
     background: var(--vscode-list-hoverBackground);
 }
 
-/* Transient hint (e.g. min-width refusal), centered at the top of the row.
-   Sits above dropdown menus (z-index 1000) like the panel toggle so a refusal
-   hint fired from a menu click is not covered by the still-open menu. */
-.desktop-pane-hint {
-    position: absolute;
-    top: 12px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 2000;
-    padding: 6px 14px;
-    border-radius: 4px;
-    background: var(--vscode-editorWidget-background, var(--vscode-editor-background));
-    color: var(--vscode-editorWidget-foreground, var(--vscode-foreground));
-    border: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.3));
-    box-shadow: 0 2px 8px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.3));
-    font-size: 12px;
-    pointer-events: none;
-    white-space: nowrap;
-}
-
 /* ---- Conversation-level panel group: message column + side panels ----
    The header spans the full pane width; below it the message column sits
    left of the checked panels (preview → diff → terminal). */

--- a/packages/webview/tests/webview/chatAppPanels.test.tsx
+++ b/packages/webview/tests/webview/chatAppPanels.test.tsx
@@ -202,11 +202,11 @@ describe('ChatApp desktop panel framework', () => {
             .spyOn(Element.prototype, 'getBoundingClientRect')
             .mockReturnValue({ width: 500, right: 500 } as DOMRect);
         try {
-            renderDesktop({ workdir: '/work/a' });
+            const { vscode } = renderDesktop({ workdir: '/work/a' });
             fireEvent.click(screen.getByTestId('panel-toggle-btn'));
             fireEvent.click(screen.getByTestId('panel-toggle-item-diff'));
             expect(screen.queryByTestId('diff-pane')).not.toBeInTheDocument();
-            expect(screen.getByTestId('desktop-panel-hint')).toHaveTextContent('空间不足');
+            expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'desktopShowHint', text: '空间不足，无法开启面板' });
         } finally {
             rectSpy.mockRestore();
         }
@@ -220,11 +220,11 @@ describe('ChatApp desktop panel framework', () => {
             .spyOn(Element.prototype, 'getBoundingClientRect')
             .mockReturnValue({ width: 300, right: 300 } as DOMRect);
         try {
-            renderDesktop({ workdir: '/work/a' });
+            const { vscode } = renderDesktop({ workdir: '/work/a' });
             fireEvent.click(screen.getByTestId('panel-toggle-btn'));
             fireEvent.click(screen.getByTestId('panel-toggle-item-diff'));
             expect(screen.queryByTestId('diff-pane')).not.toBeInTheDocument();
-            expect(screen.getByTestId('desktop-panel-hint')).toHaveTextContent('空间不足');
+            expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'desktopShowHint', text: '空间不足，无法开启面板' });
         } finally {
             rectSpy.mockRestore();
         }

--- a/packages/webview/tests/webview/desktopApp.test.tsx
+++ b/packages/webview/tests/webview/desktopApp.test.tsx
@@ -1326,7 +1326,6 @@ describe('DesktopApp', () => {
                 sessionId: 's2',
                 newRow: 'below',
             });
-            expect(screen.queryByTestId('desktop-pane-hint')).not.toBeInTheDocument();
         });
 
         it('refuses Cmd/Ctrl+Click with a hint when the row is too narrow and the window too short to split', () => {
@@ -1340,7 +1339,7 @@ describe('DesktopApp', () => {
             expect(vscode.postMessage).not.toHaveBeenCalledWith(
                 expect.objectContaining({ command: 'desktopOpenPane' }),
             );
-            expect(screen.getByTestId('desktop-pane-hint')).toHaveTextContent('空间不足');
+            expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'desktopShowHint', text: '空间不足，无法添加更多分屏' });
         });
 
         // jsdom lacks DragEvent, so fireEvent's dragOver drops clientX — build
@@ -1437,7 +1436,6 @@ describe('DesktopApp', () => {
             expect(vscode.postMessage).toHaveBeenCalledWith(
                 expect.objectContaining({ command: 'desktopOpenPane', workdir: '/work/a', sessionId: 's2', row: 0 }),
             );
-            expect(screen.queryByTestId('desktop-pane-hint')).not.toBeInTheDocument();
         });
 
         it('skips the width gate when the dropped session is already visible (host focuses its pane)', () => {
@@ -1451,7 +1449,6 @@ describe('DesktopApp', () => {
             expect(vscode.postMessage).toHaveBeenCalledWith(
                 expect.objectContaining({ command: 'desktopOpenPane', workdir: '/work/a', sessionId: 's1' }),
             );
-            expect(screen.queryByTestId('desktop-pane-hint')).not.toBeInTheDocument();
         });
 
         it('posts desktopMovePane when a pane header is dragged onto another pane edge', () => {
@@ -1851,7 +1848,7 @@ describe('DesktopApp', () => {
             dragOverAt(screen.getByTestId('desktop-pane-row'), dataTransfer, { clientX: 200, clientY: 370 });
 
             expect(screen.queryByTestId('desktop-pane-dropzone')).not.toBeInTheDocument();
-            expect(screen.getByTestId('desktop-pane-hint')).toHaveTextContent('窗口高度不足');
+            expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'desktopShowHint', text: '窗口高度不足，无法拆分为两行' });
 
             vscode.postMessage.mockClear();
             fireEvent.drop(screen.getByTestId('desktop-pane-row'), { dataTransfer });
@@ -1972,7 +1969,6 @@ describe('DesktopApp', () => {
             expect(vscode.postMessage).toHaveBeenCalledWith(
                 expect.objectContaining({ command: 'desktopOpenPane', workdir: '/work/a', sessionId: 's4', row: 1 }),
             );
-            expect(screen.queryByTestId('desktop-pane-hint')).not.toBeInTheDocument();
         });
 
         it('spills Cmd/Ctrl+Click into the other row when the focused row is full', () => {
@@ -1997,7 +1993,6 @@ describe('DesktopApp', () => {
                 sessionId: 's3',
                 row: 1,
             });
-            expect(screen.queryByTestId('desktop-pane-hint')).not.toBeInTheDocument();
         });
 
         it('refuses Cmd/Ctrl+Click with a hint when both rows are full', () => {
@@ -2016,7 +2011,7 @@ describe('DesktopApp', () => {
             expect(vscode.postMessage).not.toHaveBeenCalledWith(
                 expect.objectContaining({ command: 'desktopOpenPane' }),
             );
-            expect(screen.getByTestId('desktop-pane-hint')).toHaveTextContent('窗口宽度不足');
+            expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'desktopShowHint', text: '窗口宽度不足，无法添加更多分屏' });
         });
     });
 


### PR DESCRIPTION
All desktop feedback now flows through the single bottom-right toast stack instead of mixing a second hint style or chat messages:

- UI/state events (focus-pane connect failure, window min-size refusals, unknown host, missing remote/recent/session dirs) surface as toasts
- Picker ops (select host/remote path/recent workdir/session) surface as toasts
- Dialog failures (MCP connect/disconnect, plugins, project settings, marketplaces) surface as toasts; session-internal errors stay in chat
- Add-host success no longer inserts a chat message, which hid the host/workdir selectors
- Webview local hints route through a new desktopShowHint command the host renders as a global toast; desktop-pane-hint DOM/CSS removed
- Rename showUpdateToast to showToast (window-global semantics)

Tests: webview 627 passed, desktop 483 passed, type-check + lint clean.