### PR TITLE
fix(desktop): desktop:install uses ad-hoc signing, Developer ID reserved for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "desktop:dev": "pnpm -F wave-webview build && pnpm -F wave-desktop run dev",
     "desktop:build": "pnpm -F wave-webview build && pnpm -F wave-desktop run compile",
     "desktop:package": "pnpm -F wave-webview build && pnpm -F wave-desktop run dist",
-    "desktop:install": "pnpm build && pnpm -F wave-desktop exec electron-builder --dir && rsync -a --delete packages/desktop/release/mac-arm64/Wave.app/ /Applications/Wave.app/",
+    "desktop:install": "pnpm build && pnpm -F wave-desktop exec electron-builder --dir --config.mac.identity=null && rsync -a --delete packages/desktop/release/mac-arm64/Wave.app/ /Applications/Wave.app/",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/desktop/scripts/afterPack.js
+++ b/packages/desktop/scripts/afterPack.js
@@ -1,14 +1,16 @@
 #!/usr/bin/env node
 /**
- * electron-builder afterPack hook — ad-hoc re-sign the macOS bundle.
+ * electron-builder afterPack hook — re-seal the macOS bundle for ad-hoc
+ * (development) installs.
  *
- * electron-builder mutates the stock Electron bundle (renames it, drops in
- * app.asar, edits Info.plist) which breaks the linker-ad-hoc resource seal
- * ("code has no resources but signature indicates they must be present").
- * LaunchServices then silently refuses to open the app (direct exec of the
- * binary still works, which masks the bug). First release ships unsigned
- * (FR-021), so re-seal with an ad-hoc signature; without this hook
- * electron-builder skips signing entirely when `identity: null`.
+ * Two signing modes coexist:
+ * - Developer ID (release): electron-builder signs every file individually
+ *   with the configured identity; this hook does nothing.
+ * - ad-hoc (desktop:install, `--config.mac.identity=null`): electron-builder
+ *   skips signing entirely (`identity: null`), but its bundle mutation breaks
+ *   the stock Electron ad-hoc seal ("code has no resources but signature
+ *   indicates they must be present") and LaunchServices then silently refuses
+ *   to open the app. Re-seal the whole bundle in a single `--deep` pass.
  *
  * `--deep` also seals the node-pty native binaries (pty.node + the
  * spawn-helper executable, asar-unpacked so posix_spawn/dlopen can reach
@@ -18,6 +20,10 @@ import { execFileSync } from 'node:child_process';
 
 export default async function afterPack(context) {
   if (context.electronPlatformName !== 'darwin') return;
+  const identity = context.packager.config?.mac?.identity;
+  // Developer ID mode signs everything itself — an ad-hoc pass would be
+  // redundant (and would be overwritten anyway).
+  if (identity != null) return;
   const appPath = `${context.appOutDir}/${context.packager.appInfo.productFilename}.app`;
   execFileSync('codesign', ['--force', '--deep', '--sign', '-', appPath], { stdio: 'inherit' });
 }


### PR DESCRIPTION
desktop:install ran Developer ID signing (every file + --timestamp network round-trip, ~3-4 min) plus a redundant ad-hoc pass. Now passes --config.mac.identity=null so electron-builder skips signing entirely (seconds), and afterPack re-seals the bundle with a single --deep ad-hoc pass. Release dist keeps the Developer ID identity and notarization.

Verified: electron-builder --dir --config.mac.identity=null completes in 6.5s (skipped macOS code signing, reason=identity explicitly is set to null); codesign --verify --deep --strict passes on the ad-hoc bundle (Signature=adhoc).