### PR TITLE
fix(code): strip bracketed paste markers in login, confirm, and marketplace inputs

### DIFF
--- a/packages/code/src/components/ConfirmationSelector.tsx
+++ b/packages/code/src/components/ConfirmationSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer } from "react";
+import React, { useEffect, useReducer, useRef } from "react";
 import { Box, Text, useInput } from "ink";
 import type {
   PermissionDecision,
@@ -13,6 +13,7 @@ import {
 } from "wave-agent-sdk";
 import { confirmationReducer } from "../reducers/confirmationReducer.js";
 import { questionReducer } from "../reducers/questionReducer.js";
+import { createBracketedPasteDetector } from "../utils/bracketedPaste.js";
 
 const getHeaderColor = (header: string) => {
   const colors = ["red", "green", "blue", "magenta", "cyan"] as const;
@@ -103,23 +104,37 @@ export const ConfirmationSelector: React.FC<ConfirmationSelectorProps> = ({
     return "Yes, and auto-accept edits";
   };
 
+  const pasteDetectorRef = useRef(createBracketedPasteDetector());
+
   useInput((input, key) => {
     if (key.escape) {
       onCancel();
       return;
     }
 
+    const result = pasteDetectorRef.current.process(input);
+    if (result.kind === "consume") {
+      // Content of an in-flight bracketed paste: hold it, never submit.
+      return;
+    }
+    let cleanInput: string;
+    if (result.kind === "paste") {
+      cleanInput = (result.leadingInput ?? "") + result.text;
+    } else {
+      cleanInput = result.input;
+    }
+
     if (toolName === ASK_USER_QUESTION_TOOL_NAME) {
       questionDispatch({
         type: "HANDLE_KEY",
-        input,
+        input: cleanInput,
         key,
         questions,
       });
     } else {
       dispatch({
         type: "HANDLE_KEY",
-        input,
+        input: cleanInput,
         key,
         toolName,
         toolInput,

--- a/packages/code/src/components/LoginCommand.tsx
+++ b/packages/code/src/components/LoginCommand.tsx
@@ -3,6 +3,7 @@ import { Box, Text, useInput } from "ink";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { authService } from "wave-agent-sdk";
+import { createBracketedPasteDetector } from "../utils/bracketedPaste.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -31,6 +32,12 @@ export const LoginCommand: React.FC<LoginCommandProps> = ({ onCancel }) => {
 
   const isLoadingRef = useRef(isLoading);
   isLoadingRef.current = isLoading;
+
+  // Detects and strips bracketed paste markers (\x1b[200~ ... \x1b[201~)
+  // that terminals wrap pasted text in. Unlike the main InputBox pipeline,
+  // this overlay's token input goes through raw ink useInput, which only
+  // strips ONE leading ESC, leaving the markers (e.g. "[200~") in the input.
+  const pasteDetectorRef = useRef(createBracketedPasteDetector());
 
   // Resolve/reject refs for the token promise
   const tokenResolveRef = useRef<((token: string) => void) | null>(null);
@@ -71,9 +78,34 @@ export const LoginCommand: React.FC<LoginCommandProps> = ({ onCancel }) => {
       setTokenInput((prev) => prev.slice(0, -1));
       return;
     }
-    // Regular character input (single or pasted multi-char)
+    // Regular character input (single or pasted multi-char). Run through the
+    // bracketed paste detector: a pasted token arrives wrapped in
+    // \x1b[200~ ... \x1b[201~ markers (possibly split across chunks), which
+    // must be stripped instead of being appended to the token.
     if (input && !key.ctrl && !key.meta && !key.return && input.length > 0) {
-      setTokenInput((prev) => prev + input);
+      const result = pasteDetectorRef.current.process(input);
+
+      if (result.kind === "consume") {
+        // In-flight bracketed paste content: hold it; the final chunk
+        // delivers the complete text.
+        return;
+      }
+
+      if (result.kind === "paste") {
+        // Tokens never contain carriage returns — drop \r (CRLF terminals
+        // send \r, not \n, in pasted text).
+        const leading = result.leadingInput?.replace(/\r/g, "");
+        if (leading) {
+          setTokenInput((prev) => prev + leading);
+        }
+        const text = result.text.replace(/\r/g, "");
+        if (text) {
+          setTokenInput((prev) => prev + text);
+        }
+        return;
+      }
+
+      setTokenInput((prev) => prev + result.input);
     }
   });
 
@@ -93,6 +125,7 @@ export const LoginCommand: React.FC<LoginCommandProps> = ({ onCancel }) => {
     setError("");
     setAuthUrl("");
     setTokenInput("");
+    pasteDetectorRef.current.reset();
     setMessage("Starting authentication...");
 
     // Promise that resolves when user presses Enter with token input

--- a/packages/code/src/components/MarketplaceAddForm.tsx
+++ b/packages/code/src/components/MarketplaceAddForm.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer, useEffect } from "react";
+import React, { useReducer, useEffect, useRef } from "react";
 import { Box, Text, useInput } from "ink";
 import { usePluginManagerContext } from "../contexts/PluginManagerContext.js";
 import {
@@ -6,6 +6,7 @@ import {
   SCOPES,
   type MarketplaceAddFormState,
 } from "../reducers/marketplaceAddFormReducer.js";
+import { createBracketedPasteDetector } from "../utils/bracketedPaste.js";
 
 export const MarketplaceAddForm: React.FC = () => {
   const { state: ctxState, actions } = usePluginManagerContext();
@@ -32,11 +33,25 @@ export const MarketplaceAddForm: React.FC = () => {
     dispatch({ type: "CLEAR_PENDING_ACTION" });
   }, [state.pendingAction, actions]);
 
+  const pasteDetectorRef = useRef(createBracketedPasteDetector());
+
   useInput((input, key) => {
+    const result = pasteDetectorRef.current.process(input);
+    if (result.kind === "consume") {
+      // Content of an in-flight bracketed paste: hold it, never submit.
+      return;
+    }
+    let cleanInput: string;
+    if (result.kind === "paste") {
+      cleanInput = (result.leadingInput ?? "") + result.text;
+    } else {
+      cleanInput = result.input;
+    }
+
     dispatch({
       type: "HANDLE_KEY",
       key,
-      input,
+      input: cleanInput,
       isLoading: ctxState.isLoading,
     });
   });

--- a/packages/code/tests/components/ConfirmationSelector.test.tsx
+++ b/packages/code/tests/components/ConfirmationSelector.test.tsx
@@ -556,6 +556,81 @@ describe("ConfirmationSelector Additional Coverage", () => {
     });
   });
 
+  describe("Bracketed paste handling", () => {
+    it("should strip bracketed paste markers when pasting into alternative text", async () => {
+      const { stdin, lastFrame } = render(
+        <ConfirmationSelector
+          toolName="Edit"
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("> Yes, proceed");
+      });
+      // Navigate to alternative
+      stdin.write("\u001b[B");
+      stdin.write("\u001b[B");
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain(
+          "Type here to tell Wave what to change",
+        );
+      });
+
+      // Paste with bracketed paste markers
+      stdin.write("\u001b[200~fix the typo in src/main.ts\u001b[201~");
+
+      await vi.waitFor(() => {
+        const frame = stripAnsiColors(lastFrame() || "");
+        expect(frame).toContain("fix the typo in src/main.ts");
+        expect(frame).not.toContain("[200~");
+        expect(frame).not.toContain("[201~");
+      });
+    });
+
+    it("should strip bracketed paste markers when pasting into AskUserQuestion Other text", async () => {
+      const mockQuestions = {
+        questions: [
+          {
+            question: "What color?",
+            header: "Color",
+            options: [{ label: "Red" }, { label: "Blue" }],
+          },
+        ],
+      };
+
+      const { stdin, lastFrame } = render(
+        <ConfirmationSelector
+          toolName="AskUserQuestion"
+          toolInput={mockQuestions as unknown as Record<string, unknown>}
+          onDecision={mockOnDecision}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("What color?");
+      });
+      // Navigate to Other
+      stdin.write("\u001b[B");
+      stdin.write("\u001b[B");
+      await vi.waitFor(() => {
+        expect(stripAnsiColors(lastFrame() || "")).toContain("Other");
+      });
+
+      // Paste with bracketed paste markers
+      stdin.write("\u001b[200~green-ish\u001b[201~");
+
+      await vi.waitFor(() => {
+        const frame = stripAnsiColors(lastFrame() || "");
+        expect(frame).toContain("green-ish");
+        expect(frame).not.toContain("[200~");
+        expect(frame).not.toContain("[201~");
+      });
+    });
+  });
+
   describe("AskUserQuestion edge cases", () => {
     it("should submit immediately when there is only one question", async () => {
       const mockQuestions = {

--- a/packages/code/tests/components/LoginCommand.test.tsx
+++ b/packages/code/tests/components/LoginCommand.test.tsx
@@ -208,6 +208,53 @@ describe("LoginCommand", () => {
     await vi.waitFor(() => expect(mockAuthService.login).toHaveBeenCalled());
   });
 
+  it("should strip bracketed paste markers from pasted code", async () => {
+    mockAuthService.login.mockImplementation(
+      ({ readToken }: { readToken: () => Promise<string> }) =>
+        new Promise<string>((resolve) => {
+          readToken().then(resolve);
+        }),
+    );
+
+    const { stdin, lastFrame } = render(<LoginCommand onCancel={vi.fn()} />);
+
+    stdin.write("\r");
+    await vi.waitFor(() => expect(lastFrame()).toContain("Code:"));
+
+    // Terminals with bracketed paste (DECSET 2004) wrap pasted text in
+    // \x1b[200~ ... \x1b[201~ markers; ink strips one leading ESC, so the
+    // handler sees "[200~<token>\x1b[201~" and must strip both markers.
+    stdin.write("\u001b[200~dcb412164583961543e63dc3c73beb0e\u001b[201~");
+    await vi.waitFor(() =>
+      expect(lastFrame()).toContain("dcb412164583961543e63dc3c73beb0e"),
+    );
+    expect(lastFrame()).not.toContain("[200~");
+    expect(lastFrame()).not.toContain("[201~");
+  });
+
+  it("should buffer bracketed paste split across input chunks", async () => {
+    mockAuthService.login.mockImplementation(
+      ({ readToken }: { readToken: () => Promise<string> }) =>
+        new Promise<string>((resolve) => {
+          readToken().then(resolve);
+        }),
+    );
+
+    const { stdin, lastFrame } = render(<LoginCommand onCancel={vi.fn()} />);
+
+    stdin.write("\r");
+    await vi.waitFor(() => expect(lastFrame()).toContain("Code:"));
+
+    // Start marker may arrive in its own chunk (pty splits the paste burst).
+    stdin.write("\u001b[200~");
+    stdin.write("dcb412164583961543e63dc3c73beb0e\u001b[201~");
+    await vi.waitFor(() =>
+      expect(lastFrame()).toContain("dcb412164583961543e63dc3c73beb0e"),
+    );
+    expect(lastFrame()).not.toContain("[200~");
+    expect(lastFrame()).not.toContain("[201~");
+  });
+
   it("should cancel on escape during login", async () => {
     mockAuthService.login.mockImplementation(
       ({ readToken }: { readToken: () => Promise<string> }) =>

--- a/packages/code/tests/components/MarketplaceAddForm.test.tsx
+++ b/packages/code/tests/components/MarketplaceAddForm.test.tsx
@@ -4,6 +4,7 @@ import { vi, describe, it, expect, beforeEach } from "vitest";
 import { MarketplaceAddForm } from "../../src/components/MarketplaceAddForm.js";
 import { PluginManagerContext } from "../../src/contexts/PluginManagerContext.js";
 import { PluginManagerContextType } from "../../src/components/PluginManagerTypes.js";
+import { stripAnsiColors } from "wave-agent-sdk";
 
 describe("MarketplaceAddForm", () => {
   const mockActions = {
@@ -130,6 +131,23 @@ describe("MarketplaceAddForm", () => {
       },
       { timeout: 3000 },
     );
+  });
+
+  it("should strip bracketed paste markers when entering source", async () => {
+    const { stdin, lastFrame } = render(
+      <PluginManagerContext.Provider value={mockContext}>
+        <MarketplaceAddForm />
+      </PluginManagerContext.Provider>,
+    );
+
+    stdin.write("\u001b[200~github:owner/repo\u001b[201~");
+
+    await vi.waitFor(() => {
+      const frame = stripAnsiColors(lastFrame() || "");
+      expect(frame).toContain("github:owner/repo");
+      expect(frame).not.toContain("[200~");
+      expect(frame).not.toContain("[201~");
+    });
   });
 
   it("should call setView('MARKETPLACES') when Escape is pressed on step 1", async () => {


### PR DESCRIPTION
Fixes bracketed paste marker leakage (x1b[200~ / x1b[201~) into CLI text inputs. Terminals wrap pasted text in these markers (DECSET 2004), and ink strips only the leading ESC, leaving raw markers in the input string.

Affected inputs (all now run chunks through createBracketedPasteDetector before dispatching):
- LoginCommand token input
- ConfirmationSelector alternative text and AskUserQuestion Other input
- MarketplaceAddForm marketplace source

All other useInput call sites audited and confirmed safe (key-only handlers, single-char comparisons, or the main pipeline which already had the detector).

TDD: 5 new tests (2 login, 2 confirm, 1 marketplace) written failing first, then fixed. Related suites: ConfirmationSelector 39/39, LoginCommand + bracketedPaste 33/33, type-check and lint green.