### PR TITLE
fix(code): stabilize InputBox test mock to fix flaky Maximum update depth error

### DIFF
--- a/packages/code/tests/components/InputBox.test.tsx
+++ b/packages/code/tests/components/InputBox.test.tsx
@@ -23,7 +23,7 @@ afterEach(() => {
 });
 import { InputBox } from "../../src/components/InputBox.js";
 import { stripAnsiColors } from "wave-agent-sdk";
-import type { SlashCommand } from "wave-agent-sdk";
+import type { BackgroundTask, Message, SlashCommand } from "wave-agent-sdk";
 
 vi.mock("wave-agent-sdk", async (importOriginal) => {
   const actual = (await importOriginal()) as object;
@@ -39,14 +39,19 @@ vi.mock("wave-agent-sdk", async (importOriginal) => {
 const mockSetPermissionMode = vi.fn();
 const mockHandleRewindSelect = vi.fn();
 const mockBackgroundCurrentTask = vi.fn();
+// Stable references mirror the real useChat context (useState-backed values),
+// so effects keyed on these (e.g. BackgroundTaskManager's SET_TASKS sync)
+// don't re-fire on every render and loop into "Maximum update depth exceeded".
+const mockBackgroundTasks: BackgroundTask[] = [];
+const mockMessages: Message[] = [];
 
 vi.mock("../../src/contexts/useChat.js", () => ({
   useChat: () => ({
     permissionMode: "default",
     setPermissionMode: mockSetPermissionMode,
     setIsBtwActive: vi.fn(),
-    backgroundTasks: [],
-    messages: [],
+    backgroundTasks: mockBackgroundTasks,
+    messages: mockMessages,
     handleRewindSelect: mockHandleRewindSelect,
     backgroundCurrentTask: mockBackgroundCurrentTask,
   }),


### PR DESCRIPTION
The useChat mock in InputBox.test.tsx created a fresh backgroundTasks/messages array on every render, while the real context returns stable useState-backed references. BackgroundTaskManager's SET_TASKS effect keyed on backgroundTasks then re-fired every render, looping into React's "Maximum update depth exceeded" and failing vitest's onConsoleLog stderr guard (flaky 3/6 runs locally).

Fix: hoist both arrays to module-level constants so references are stable across renders, mirroring the real context semantics.

Verified: 8/8 single-file runs clean (was 3/6 failing), full packages/code suite 93 files / 1295 tests green, type-check passes.