### PR TITLE
fix: forward bang command output to CLI and webview UIs

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -249,7 +249,7 @@ callbacks: {
 |------|------|------|
 | `onAddBangMessage` | `command: string, messageId: string` | Bang 命令开始执行 |
 | `onUpdateBangMessage` | `command: string, output: string, messageId: string` | Bang 命令输出更新 |
-| `onCompleteBangMessage` | `command: string, exitCode: number \| null, messageId: string` | Bang 命令执行完成 |
+| `onCompleteBangMessage` | `command: string, exitCode: number \| null, messageId: string, output?: string` | Bang 命令执行完成（`output` 为最终输出，可能不存在） |
 
 ### 后台任务回调 {#callbacks-background}
 

--- a/docs/specs/core/stream-content-updates.md
+++ b/docs/specs/core/stream-content-updates.md
@@ -123,7 +123,7 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 1. **假设**会话已积累大量消息，**当**助手开始流式响应时，**则**CLI 与插件界面通过增量回调就地更新，不整屏刷新、不卡顿
 2. **假设**助手响应正在流式传输，**当**每个内容 chunk 到达时，**则**SDK 只触发 `onAssistantContentUpdated` 等增量回调，不再触发任何携带完整消息列表的回调
 3. **假设**CLI 正在渲染流式响应，**当**新 chunk 到达时，**则**消息内容就地更新，不再执行全量 `setMessages`
-4. **假设**CLI 收到 bang 信号（`onAddBangMessage(command, messageId)`/`onUpdateBangMessage(command, output, messageId)`/`onCompleteBangMessage(command, exitCode, messageId)`，携带 messageId），**当**需要渲染命令消息时，**则**按 messageId 就地创建/更新 bang 消息块，无需读取 `agent.messages`
+4. **假设**CLI 收到 bang 信号（`onAddBangMessage(command, messageId)`/`onUpdateBangMessage(command, output, messageId)`/`onCompleteBangMessage(command, exitCode, messageId, output?)`，携带 messageId），**当**需要渲染命令消息时，**则**按 messageId 就地创建/更新 bang 消息块，无需读取 `agent.messages`
 5. **假设**插件 webview 需要完整会话（webviewReady / compact / rewind / clearChat / restoreSession），**当**触发上述任一场景时，**则**宿主主动调用 `getMessages` 请求拉取并下发全量渲染，而非订阅持续的全量推送
 6. **假设**子代理（subagent）运行中，**当**其消息变更时，**则** `SubagentManager` 通过 `instance.messageManager.getMessages()` 拉取最新列表维护 `instance.messages` 与 `usedTools`，并继续转发 `onSubagentMessagesChange`，不再依赖子代理的 `onMessagesChange`
 7. **假设**助手响应正在流式传输，**当**每个内容/推理 chunk 到达时，**则**增量回调与 stdio 增量通知都只携带 `chunk`（增量片段）+ `messageId` + `stage`，不再携带 `accumulated` 累积值；进程内消费者（CLI、print-cli）与跨进程宿主（agentBridge）统一消费纯 chunk，自行累积追加

--- a/packages/agent-sdk/src/managers/messageManager.ts
+++ b/packages/agent-sdk/src/managers/messageManager.ts
@@ -72,6 +72,7 @@ export interface MessageManagerCallbacks {
     command: string,
     exitCode: number,
     messageId: string,
+    output?: string,
   ) => void;
   onInfoBlockAdded?: (content: string) => void;
   // Rewind callbacks
@@ -680,7 +681,12 @@ export class MessageManager {
     });
     this.setMessages(updatedMessages);
     const messageId = this.findBangMessageId(command) ?? "";
-    this.callbacks.onCompleteBangMessage?.(command, exitCode, messageId);
+    this.callbacks.onCompleteBangMessage?.(
+      command,
+      exitCode,
+      messageId,
+      output?.trim(),
+    );
   }
 
   /**

--- a/packages/agent-sdk/tests/managers/messageManager.streaming.test.ts
+++ b/packages/agent-sdk/tests/managers/messageManager.streaming.test.ts
@@ -486,4 +486,49 @@ describe("MessageManager - Streaming Functionality", () => {
       expect(mockToolBlockUpdated).not.toHaveBeenCalled();
     });
   });
+
+  describe("bang message callbacks", () => {
+    it("completeBangMessage forwards the captured output to onCompleteBangMessage", () => {
+      const onCompleteBangMessage = vi.fn();
+
+      const messageManager = new MessageManager(container, {
+        callbacks: { onCompleteBangMessage },
+        workdir: "/test",
+      });
+
+      messageManager.addBangMessage("ls");
+      const messageId = messageManager.getMessages().slice(-1)[0].id;
+
+      messageManager.completeBangMessage("ls", 0, "file.txt\n");
+
+      expect(onCompleteBangMessage).toHaveBeenCalledWith(
+        "ls",
+        0,
+        messageId,
+        "file.txt",
+      );
+    });
+
+    it("completeBangMessage keeps the captured output in the stored message", () => {
+      const messageManager = new MessageManager(container, {
+        callbacks: {},
+        workdir: "/test",
+      });
+
+      messageManager.addBangMessage("ls");
+      messageManager.completeBangMessage("ls", 0, "file.txt\n");
+
+      const bangBlock = messageManager
+        .getMessages()
+        .slice(-1)[0]
+        .blocks.find((b) => b.type === "bang") as
+        | { output?: string; stage?: string; exitCode?: number | null }
+        | undefined;
+      expect(bangBlock).toMatchObject({
+        output: "file.txt",
+        stage: "end",
+        exitCode: 0,
+      });
+    });
+  });
 });

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -627,7 +627,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
             ),
           );
         },
-        onCompleteBangMessage: (command, exitCode, messageId) => {
+        onCompleteBangMessage: (command, exitCode, messageId, output) => {
           if (isExpandedRef.current) return;
           setMessages((prev) =>
             prev.map((m) =>
@@ -636,7 +636,13 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
                     ...m,
                     blocks: m.blocks.map((b, idx) =>
                       idx === m.blocks.length - 1 && b.type === "bang"
-                        ? { ...b, command, exitCode, stage: "end" }
+                        ? {
+                            ...b,
+                            command,
+                            exitCode,
+                            stage: "end",
+                            ...(output !== undefined ? { output } : {}),
+                          }
                         : b,
                     ),
                   }

--- a/packages/code/src/stdio/agentBridge.ts
+++ b/packages/code/src/stdio/agentBridge.ts
@@ -1424,10 +1424,10 @@ export class AgentBridge {
           ctx.registeredSessionId,
         );
       },
-      onCompleteBangMessage: (command, exitCode, messageId) => {
+      onCompleteBangMessage: (command, exitCode, messageId, output) => {
         this.emit(
           "bangMessageCompleted",
-          { command, exitCode, messageId },
+          { command, exitCode, messageId, output },
           ctx.registeredSessionId,
         );
       },

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -1488,13 +1488,17 @@ describe("ChatProvider", () => {
       });
     });
 
-    // onCompleteBangMessage records the exit code and final stage
-    callbacks.onCompleteBangMessage!("ls -la", 0, "bang-1");
+    // onCompleteBangMessage records the exit code, final stage AND the
+    // captured output (regression: output was dropped after 9cea65ea).
+    // bangManager streams nothing — output arrives only at completion, so it
+    // must be delivered here with a value distinct from the earlier update.
+    callbacks.onCompleteBangMessage!("ls -la", 0, "bang-1", "final-output\n");
     await vi.waitFor(() => {
       const msg = lastValue!.messages.find((m) => m.id === "bang-1")!;
       const bangBlock = msg.blocks[msg.blocks.length - 1];
       expect(bangBlock).toMatchObject({
         type: "bang",
+        output: "final-output\n",
         exitCode: 0,
         stage: "end",
       });

--- a/packages/code/tests/stdio/agentBridge.test.ts
+++ b/packages/code/tests/stdio/agentBridge.test.ts
@@ -636,11 +636,16 @@ test("onCompleteBangMessage emits bangMessageCompleted notification", async () =
   const callbacks = vi.mocked(Agent.create).mock.calls[0][0]
     .callbacks as AgentCallbacks;
 
-  callbacks.onCompleteBangMessage!("ls", 0, "msg-1");
+  callbacks.onCompleteBangMessage!("ls", 0, "msg-1", "file.txt\n");
 
   expect(notifications).toContainEqual({
     method: "bangMessageCompleted",
-    params: { command: "ls", exitCode: 0, messageId: "msg-1" },
+    params: {
+      command: "ls",
+      exitCode: 0,
+      messageId: "msg-1",
+      output: "file.txt\n",
+    },
     sessionId: "test-session-id",
   });
 });

--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -903,7 +903,13 @@ export class DesktopHost {
                 ...m,
                 blocks: m.blocks.map((b, idx) =>
                   idx === m.blocks.length - 1 && b.type === 'bang'
-                    ? { ...b, command: params.command, exitCode: params.exitCode, stage: 'end' }
+                    ? {
+                        ...b,
+                        command: params.command,
+                        exitCode: params.exitCode,
+                        stage: 'end',
+                        ...(params.output !== undefined ? { output: params.output } : {}),
+                      }
                     : b,
                 ),
               }

--- a/packages/desktop/src/main/stdio/stdioAgent.ts
+++ b/packages/desktop/src/main/stdio/stdioAgent.ts
@@ -99,7 +99,7 @@ export interface StdioAgentCallbacks {
     onWorkdirChange?: (workdir: string) => void;
     onBangMessageAdded?: (params: { command: string; messageId: string }) => void;
     onBangMessageUpdated?: (params: { command: string; output: string; messageId: string }) => void;
-    onBangMessageCompleted?: (params: { command: string; exitCode: number; messageId: string }) => void;
+    onBangMessageCompleted?: (params: { command: string; exitCode: number; messageId: string; output?: string }) => void;
     onNotificationMessageAdded?: (params: {
         taskId: string;
         taskType: string;
@@ -568,7 +568,7 @@ export class StdioAgent {
                 break;
             }
             case 'bangMessageCompleted': {
-                const p = params as { command: string; exitCode: number; messageId: string };
+                const p = params as { command: string; exitCode: number; messageId: string; output?: string };
                 this.callbacks.onBangMessageCompleted?.(p);
                 break;
             }

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
@@ -449,12 +449,13 @@ class WaveSession(
         })
     }
 
-    override fun onBangMessageCompleted(command: String, exitCode: Int, messageId: String) {
+    override fun onBangMessageCompleted(command: String, exitCode: Int, messageId: String, output: String?) {
         postMessage("bangMessageCompleted", buildJsonObject {
             put("params", buildJsonObject {
                 put("command", command)
                 put("exitCode", exitCode)
                 put("messageId", messageId)
+                if (output != null) put("output", output)
             })
         })
     }

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioAgent.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioAgent.kt
@@ -35,7 +35,7 @@ interface AgentCallbacks {
     fun onPermissionRequest(requestId: String, context: JsonElement?) {}
     fun onBangMessageAdded(command: String, messageId: String) {}
     fun onBangMessageUpdated(command: String, output: String, messageId: String) {}
-    fun onBangMessageCompleted(command: String, exitCode: Int, messageId: String) {}
+    fun onBangMessageCompleted(command: String, exitCode: Int, messageId: String, output: String?) {}
     fun onNotificationMessageAdded(message: JsonObject) {}
     fun onBtwContent(question: String, content: String, type: String) {}
     fun onError(message: String) {}
@@ -144,6 +144,7 @@ class StdioAgent(
                     o?.get("command")?.jsonPrimitive?.content ?: "",
                     o?.get("exitCode")?.jsonPrimitive?.intOrNull ?: 0,
                     o?.get("messageId")?.jsonPrimitive?.content ?: "",
+                    o?.get("output")?.jsonPrimitive?.content,
                 )
             }
             "notificationMessageAdded" -> callbacks.onNotificationMessageAdded(params?.jsonObject ?: JsonObject(emptyMap()))

--- a/packages/vscode/src/session/chatSession.ts
+++ b/packages/vscode/src/session/chatSession.ts
@@ -29,7 +29,7 @@ export interface ChatSessionCallbacks {
     // Bang message callbacks (incremental; messageId identifies the message)
     onBangMessageAdded?: (params: { command: string; messageId: string }) => void;
     onBangMessageUpdated?: (params: { command: string; output: string; messageId: string }) => void;
-    onBangMessageCompleted?: (params: { command: string; exitCode: number; messageId: string }) => void;
+    onBangMessageCompleted?: (params: { command: string; exitCode: number; messageId: string; output?: string }) => void;
     onBtwContent?: (params: { question: string; content: string; type: 'thinking' | 'content' }) => void;
 }
 

--- a/packages/vscode/src/stdio/stdioAgent.ts
+++ b/packages/vscode/src/stdio/stdioAgent.ts
@@ -97,7 +97,7 @@ export interface StdioAgentCallbacks {
     onWorkdirChange?: (workdir: string) => void;
     onBangMessageAdded?: (params: { command: string; messageId: string }) => void;
     onBangMessageUpdated?: (params: { command: string; output: string; messageId: string }) => void;
-    onBangMessageCompleted?: (params: { command: string; exitCode: number; messageId: string }) => void;
+    onBangMessageCompleted?: (params: { command: string; exitCode: number; messageId: string; output?: string }) => void;
     onNotificationMessageAdded?: (params: {
         taskId: string;
         taskType: string;
@@ -569,6 +569,7 @@ export class StdioAgent {
                         command: string;
                         exitCode: number;
                         messageId: string;
+                        output?: string;
                     },
                 );
                 break;

--- a/packages/webview/src/reducers/chatReducer.ts
+++ b/packages/webview/src/reducers/chatReducer.ts
@@ -468,7 +468,7 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
       return { ...state, messages: newMessages };
     }
     case 'COMPLETE_BANG_MESSAGE': {
-      const { command, exitCode, messageId } = action.payload;
+      const { command, exitCode, messageId, output } = action.payload;
       const messageIndex = state.messages.findIndex(m => m.id === messageId);
       if (messageIndex === -1) return state;
       const newMessages = state.messages.map((m, idx) => {
@@ -476,7 +476,15 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
         return {
           ...m,
           blocks: m.blocks.map((b, bidx) =>
-            bidx === m.blocks.length - 1 && b.type === 'bang' ? { ...b, command, exitCode, stage: 'end' as const } : b
+            bidx === m.blocks.length - 1 && b.type === 'bang'
+              ? {
+                  ...b,
+                  command,
+                  exitCode,
+                  stage: 'end' as const,
+                  ...(output !== undefined ? { output } : {})
+                }
+              : b
           )
         };
       });

--- a/packages/webview/src/types/index.ts
+++ b/packages/webview/src/types/index.ts
@@ -713,4 +713,4 @@ export type ChatAction =
   // constructed in the reducer because it needs a Message wrapper (id/timestamp).
   | { type: 'APPEND_BANG_MESSAGE'; payload: { command: string; messageId: string } }
   | { type: 'UPDATE_BANG_MESSAGE'; payload: { command: string; output: string; messageId: string } }
-  | { type: 'COMPLETE_BANG_MESSAGE'; payload: { command: string; exitCode: number; messageId: string } };
+  | { type: 'COMPLETE_BANG_MESSAGE'; payload: { command: string; exitCode: number; messageId: string; output?: string } };

--- a/packages/webview/tests/reducers/chatReducer.test.ts
+++ b/packages/webview/tests/reducers/chatReducer.test.ts
@@ -723,16 +723,44 @@ describe('chatReducer', () => {
 
       const newState = chatReducer(state, {
         type: 'COMPLETE_BANG_MESSAGE',
-        payload: { command: 'false', exitCode: 1, messageId: 'bang-1' }
+        payload: { command: 'false', exitCode: 1, messageId: 'bang-1', output: 'boom\n' }
       });
 
       const block = newState.messages[0].blocks[0];
       expect(block).toEqual({
         type: 'bang',
         command: 'false',
-        output: '',
+        output: 'boom\n',
         stage: 'end',
         exitCode: 1
+      });
+    });
+
+    it('COMPLETE_BANG_MESSAGE without output preserves the running-stage output', () => {
+      const state = {
+        ...initialState,
+        messages: [
+          {
+            id: 'bang-1',
+            role: 'user' as const,
+            timestamp: '0',
+            blocks: [{ type: 'bang' as const, command: 'ls', output: 'partial', stage: 'running' as const, exitCode: null }]
+          }
+        ]
+      };
+
+      const newState = chatReducer(state, {
+        type: 'COMPLETE_BANG_MESSAGE',
+        payload: { command: 'ls', exitCode: 0, messageId: 'bang-1' }
+      });
+
+      const block = newState.messages[0].blocks[0];
+      expect(block).toEqual({
+        type: 'bang',
+        command: 'ls',
+        output: 'partial',
+        stage: 'end',
+        exitCode: 0
       });
     });
 

--- a/packages/webview/tests/webview/bangCommand.test.tsx
+++ b/packages/webview/tests/webview/bangCommand.test.tsx
@@ -182,6 +182,25 @@ describe('Bang Command', () => {
         });
     });
 
+    it('should show output delivered only via bangMessageCompleted', async () => {
+        renderChatApp();
+
+        // bangManager buffers output and only delivers it at completion
+        // (no bangMessageUpdated fires) — the completed notification must
+        // carry the output.
+        await act(async () => {
+            dispatchBang('bangMessageAdded', { command: 'ls', messageId: 'bang-1' });
+        });
+        await act(async () => {
+            dispatchBang('bangMessageCompleted', { command: 'ls', exitCode: 0, messageId: 'bang-1', output: 'file.txt' });
+        });
+
+        await waitFor(() => {
+            const output = document.querySelector('.bash-command-unified .bash-command-output');
+            expect(output).toHaveTextContent('file.txt');
+        });
+    });
+
     it('should show failure exit code after bangMessageCompleted', async () => {
         renderChatApp();
 


### PR DESCRIPTION
## Problem

Since the 9cea65ea incremental refactor (removal of the full-snapshot onMessagesChange callback), the onCompleteBangMessage callback signature (command, exitCode, messageId) dropped the captured command output. Bang blocks rendered with empty output in both the CLI and the webview UIs.

## Root cause

bangManager delivers output only once at completion (completeBangMessage), never streaming it. With the incremental contract, the completion callback was the only delivery point, but its signature did not carry the output.

## Fix

Add a 4th positional output argument end-to-end:

- agent-sdk: messageManager passes the captured output (trimmed, matching the stored block value)
- CLI: useChat consumer applies output to the bang block when defined
- agentBridge: forwards output via the bangMessageCompleted stdio notification
- hosts: desktop / vscode stdioAgent + mirror, jetbrains StdioAgent.kt + WaveSession.kt pass it through
- webview: COMPLETE_BANG_MESSAGE reducer applies output only when output is defined, preserving running-stage partial output

Backwards compatible: hosts/reducers only apply output when the new argument is present.

## Testing (TDD)

Failing tests first, all green after the fix:

- agent-sdk messageManager.streaming.test.ts: completion callback carries output; stored block matches
- code useChat.test.tsx: CLI bang block ends with output (distinct final value guards against fake-green)
- code agentBridge.test.ts: notification params include output
- webview chatReducer.test.ts: with/without output branches
- webview bangCommand.test.tsx: real bug shape — output delivered only via bangMessageCompleted

Docs: sdk.md and stream-content-updates spec signature lines updated.

Full suites: agent-sdk 3423 passed, code 1295 passed (1 pre-existing InputBox flaky, verified via stash baseline), webview 634 passed, desktop 483 passed, type-check all green, jb:build gradle compile passed.