### PR TITLE
ci(release): version docs archive to match other release assets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Package .vsix
         run: pnpm -F wave-vscode run package
 
-      # --- Docs (docs.tar.gz) ---
+      # --- Docs (docs-<version>.tar.gz) ---
       - name: Cache Playwright browsers
         uses: actions/cache@v6
         with:
@@ -55,8 +55,13 @@ jobs:
       - name: Build docs with base /docs/
         run: npx vitepress build docs --base /docs/
 
-      - name: Package docs.tar.gz
-        run: tar -czf docs.tar.gz -C docs/.vitepress/dist .
+      # Version the archive like the other release assets (.vsix/.zip/.dmg/.exe);
+      # read from package.json (bumped by scripts/version.js) so it also works
+      # on workflow_dispatch, where GITHUB_REF_NAME is a branch, not a tag.
+      - name: Package docs archive
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          tar -czf "docs-${VERSION}.tar.gz" -C docs/.vitepress/dist .
 
       # --- GitHub Release ---
       - name: Get previous tag
@@ -70,7 +75,7 @@ jobs:
         with:
           files: |
             packages/vscode/releases/*.vsix
-            docs.tar.gz
+            docs-*.tar.gz
           draft: false
           prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
           generate_release_notes: true


### PR DESCRIPTION
Release 资产中只有 docs.tar.gz 不带版本号，其余资产均有（vsix/jetbrains zip/desktop dmg/exe）。

改动（publish.yml）：
- 打包步骤改为 docs-<version>.tar.gz，版本号从根 package.json 读取（scripts/version.js 统一 bump，与其他资产文件名同源）；不用 GITHUB_REF_NAME 是因为 workflow_dispatch 触发时它是分支名而非 tag
- release 上传 files 同步改为 docs-*.tar.gz 通配

已验证：YAML 解析通过，本地版本提取得 docs-1.0.6.tar.gz；全仓 grep 确认无其他代码按固定名消费 docs.tar.gz；refresh-release-assets.yml 不重建 docs，无需改动。