### PR TITLE
fix(agent-sdk,code): daemon 启动即镜像 settings env 的 WAVE_SERVER_URL

### DIFF
--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -30,7 +30,10 @@ export * from "./utils/gitUtils.js";
 export * from "./utils/nameGenerator.js";
 export * from "./utils/worktreeSession.js";
 export * from "./utils/worktreeUtils.js";
-export { loadMergedWaveConfig } from "./services/configurationService.js";
+export {
+  loadMergedWaveConfig,
+  loadUserConfigEnv,
+} from "./services/configurationService.js";
 export * from "./types/index.js";
 
 // Export subagent types (used by CLI /agents overlay)

--- a/packages/agent-sdk/src/services/authService.ts
+++ b/packages/agent-sdk/src/services/authService.ts
@@ -377,7 +377,6 @@ export class AuthService {
           refresh_token: config.SSO_REFRESH_TOKEN,
         }),
       });
-
       if (response.status === 400 || response.status === 401) {
         // Refresh token revoked — clear auth
         logger.info(

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -1335,6 +1335,17 @@ export function loadWaveConfigFromFile(
 }
 
 /**
+ * Load the user-level (~/.wave/settings.json) `env` block only — no workdir
+ * dependency. Used at daemon startup to apply WAVE_SERVER_URL before any agent
+ * initializes: auth queries (getAuthStatus) can run before the first agent,
+ * and AuthService falls back to the default URL otherwise.
+ */
+export function loadUserConfigEnv(): Record<string, string> {
+  const config = loadWaveConfigFromFile(getUserConfigPaths()[0]);
+  return config?.env ?? {};
+}
+
+/**
  * Load and merge Wave configuration from both user and project sources
  * Project configuration takes precedence over user configuration
  * Checks .local.json files first, then falls back to .json files

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -20,6 +20,7 @@ import {
   mergeEnvironmentConfig,
   loadMergedWaveConfig,
   loadWaveConfigFromFile,
+  loadUserConfigEnv,
 } from "../../src/services/configurationService.js";
 import { atomicWriteFile } from "../../src/utils/atomicWrite.js";
 import {
@@ -1309,6 +1310,36 @@ describe("ConfigurationService", () => {
       expect(() => JSON.parse(content)).not.toThrow();
       const parsed = JSON.parse(content);
       expect(parsed.enabledPlugins["plugin@market"]).toBe(true);
+    });
+  });
+
+  describe("loadUserConfigEnv", () => {
+    it("returns the user-level settings.json env block", () => {
+      const userSettingsPath = path.join(userHome, ".wave", "settings.json");
+      mockExistsSync.mockImplementation(
+        (p) => p.toString() === userSettingsPath,
+      );
+      mockReadFileSync.mockImplementation((p) => {
+        const pathStr = p.toString();
+        if (pathStr === userSettingsPath) {
+          return JSON.stringify({
+            env: {
+              WAVE_SERVER_URL: "https://codechat.codewave-test.163yun.com",
+            },
+          });
+        }
+        return "";
+      });
+
+      expect(loadUserConfigEnv()).toEqual({
+        WAVE_SERVER_URL: "https://codechat.codewave-test.163yun.com",
+      });
+    });
+
+    it("returns an empty object when the user settings file is missing", () => {
+      mockExistsSync.mockReturnValue(false);
+
+      expect(loadUserConfigEnv()).toEqual({});
     });
   });
 });

--- a/packages/code/src/stdio/agentBridge.ts
+++ b/packages/code/src/stdio/agentBridge.ts
@@ -42,6 +42,7 @@ import {
   PluginCore,
   validateWorktreeRemovalPath,
   type SlashCommand,
+  loadUserConfigEnv,
 } from "wave-agent-sdk";
 import {
   type JsonRpcError,
@@ -140,6 +141,15 @@ export class AgentBridge {
 
   constructor(options: AgentBridgeOptions) {
     this.emit = options.emit;
+    // Mirror the user-level settings env WAVE_SERVER_URL into process.env
+    // before any agent initializes. getAuthStatus (webviewReady →
+    // pushInitialState) can run before the first agent, and AuthService falls
+    // back to the default URL otherwise — refreshing a custom-domain token
+    // against the wrong host 401s into a logged-out state.
+    const userEnv = loadUserConfigEnv();
+    if (userEnv.WAVE_SERVER_URL) {
+      process.env.WAVE_SERVER_URL = userEnv.WAVE_SERVER_URL;
+    }
   }
 
   // ── Public API ────────────────────────────────────────────────
@@ -1132,13 +1142,6 @@ export class AgentBridge {
     serverUrl: string;
   }> {
     const authService = AuthService.getInstance();
-    // A stale-but-refreshable token still means "logged in" — the daemon may
-    // have started with an expired access token (hourly expiry) and only
-    // refreshes lazily on the first API call. Without this proactive refresh a
-    // fresh client querying right after daemon start gets a false
-    // isAuthenticated and e.g. the desktop welcome page keeps showing the
-    // login button for an authenticated host. Mirrors the refresh that
-    // createAuthAwareFetch does before every real request.
     await authService.checkAndRefreshTokenIfNeeded();
     return {
       isAuthenticated: authService.isSSOAuthenticated(),

--- a/packages/code/tests/stdio/agentBridge.test.ts
+++ b/packages/code/tests/stdio/agentBridge.test.ts
@@ -10,6 +10,7 @@ import {
   getDefaultRemoteBranch,
   getMessageContent,
   validateWorktreeRemovalPath,
+  loadUserConfigEnv,
 } from "wave-agent-sdk";
 import { execFileSync } from "node:child_process";
 import path from "node:path";
@@ -120,10 +121,14 @@ function createBridge() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // The constructor applies the user-level settings env to process.env —
+  // default the mock to an empty env so unrelated tests are unaffected.
+  vi.mocked(loadUserConfigEnv).mockReturnValue({});
 });
 
 afterEach(() => {
   stderrWriteSpy.mockRestore();
+  delete process.env.WAVE_SERVER_URL;
 });
 
 // ── initialize ───────────────────────────────────────────────────
@@ -1342,6 +1347,31 @@ test("writeArtifactFile rejects empty or dot names", async () => {
 });
 
 // ── Auth handlers ────────────────────────────────────────────────
+
+test("constructor mirrors user settings WAVE_SERVER_URL into process.env", () => {
+  // getAuthStatus can run before any agent initializes (webviewReady →
+  // pushInitialState). AuthService reads process.env.WAVE_SERVER_URL, which
+  // settings.json `env` only mirrors at agent initialization — without an
+  // early mirror the daemon falls back to the default URL and refreshes a
+  // custom-domain token against the wrong host (401 → logged out).
+  vi.mocked(loadUserConfigEnv).mockReturnValue({
+    WAVE_SERVER_URL: "https://codechat.codewave-test.163yun.com",
+  });
+
+  createBridge();
+
+  expect(process.env.WAVE_SERVER_URL).toBe(
+    "https://codechat.codewave-test.163yun.com",
+  );
+});
+
+test("constructor does not set WAVE_SERVER_URL when user settings omit it", () => {
+  vi.mocked(loadUserConfigEnv).mockReturnValue({});
+
+  createBridge();
+
+  expect(process.env.WAVE_SERVER_URL).toBeUndefined();
+});
 
 test("getAuthStatus returns auth state", async () => {
   const { bridge } = createBridge();

--- a/packages/code/tests/stdio/daemonServer.test.ts
+++ b/packages/code/tests/stdio/daemonServer.test.ts
@@ -5,7 +5,7 @@ import * as net from "net";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { Agent } from "wave-agent-sdk";
+import { Agent, loadUserConfigEnv } from "wave-agent-sdk";
 
 // Unix-domain sockets are unreliable on Windows: libuv rejects binding a
 // non-"\\.\pipe\..." path with EACCES, so every socket-based test fails there.
@@ -100,6 +100,7 @@ let socketPath: string;
 
 beforeEach(async () => {
   vi.clearAllMocks();
+  vi.mocked(loadUserConfigEnv).mockReturnValue({});
   vi.mocked(Agent.create).mockResolvedValue(createMockAgent());
   socketPath = path.join(
     os.tmpdir(),

--- a/packages/code/tests/stdio/stdioServer.test.ts
+++ b/packages/code/tests/stdio/stdioServer.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, vi, beforeEach, afterEach } from "vitest";
 import { PassThrough } from "stream";
-import { Agent } from "wave-agent-sdk";
+import { Agent, loadUserConfigEnv } from "wave-agent-sdk";
 
 // Mock the Agent SDK
 vi.mock("wave-agent-sdk");
@@ -77,6 +77,7 @@ function createServer() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(loadUserConfigEnv).mockReturnValue({});
   vi.mocked(Agent.create).mockResolvedValue(createMockAgent());
 });
 


### PR DESCRIPTION
## 问题

桌面端在 user scope 设置了 server url（~/.wave/settings.json 的 env.WAVE_SERVER_URL）后，每次打开新对话都显示登录按钮，实际已登录。

## 根因

settings.json env 的 WAVE_SERVER_URL 只在 agent 初始化时（setEnvironmentVars）才镜像到 daemon 进程的 process.env。而 getAuthStatus 在 webviewReady → pushInitialState 时执行，早于任何 agent 初始化——此时 AuthService 读不到 WAVE_SERVER_URL，回退默认 163.com，对 163yun.com 签发的 token 刷新返回 401 → clearAuth → 登录按钮。

## 修复

1. agent-sdk 新增 loadUserConfigEnv()：只读 user 级 settings.json 的 env 块，无 workdir 依赖（index.ts 导出）
2. AgentBridge 构造器预热：进程启动即把 settings env 的 WAVE_SERVER_URL 镜像到 process.env，与 setEnvironmentVars 的语义一致但提前到任何 agent 初始化之前。覆盖桌面本地 daemon + 远程 daemon 两条 stdio 路径；CLI 交互模式不调用 AuthService，不受影响
3. 顺带清理本次排查遗留的 AUTH-DEBUG 临时日志

## 验证

- agent-sdk 3427 passed / code 1334 passed / desktop 485 passed，type-check 全绿
- TDD：新增 loadUserConfigEnv 2 测试 + AgentBridge 构造器预热 2 测试（红→绿）