### PR TITLE
refactor(agent-sdk): remove non-standard Claude usage field compatibility

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -1891,9 +1891,6 @@ ${question}`;
                 cache_creation_input_tokens:
                   result.usage.cache_creation_input_tokens,
               }),
-              ...(result.usage.cache_creation && {
-                cache_creation: result.usage.cache_creation,
-              }),
             };
           }
 

--- a/packages/agent-sdk/src/services/aiService.ts
+++ b/packages/agent-sdk/src/services/aiService.ts
@@ -9,12 +9,11 @@ import {
 import { OpenAIClient } from "../utils/openaiClient.js";
 import { logger } from "../utils/globalLogger.js";
 import { addOnceAbortListener } from "../utils/abortUtils.js";
-import type { GatewayConfig, ModelConfig } from "../types/index.js";
+import type { GatewayConfig, ModelConfig, Usage } from "../types/index.js";
 import { ConfigurationError, CONFIG_ERRORS } from "../types/index.js";
 import {
   transformMessagesForExplicitCache,
   extendUsageWithCacheMetrics,
-  type ClaudeUsage,
   type ClaudeChatCompletionContentPartText,
 } from "../utils/cacheControlUtils.js";
 import { supportsPromptCaching } from "../utils/modelCapabilities.js";
@@ -204,7 +203,7 @@ export interface CallAgentResult {
   content?: string;
   tool_calls?: ChatCompletionMessageToolCall[];
   reasoning_content?: string;
-  usage?: ClaudeUsage;
+  usage?: Usage;
   finish_reason?:
     | "stop"
     | "length"
@@ -403,21 +402,9 @@ export async function callAgent(
       const finalMessage = response.choices[0]?.message;
       const finishReason = response.choices[0]?.finish_reason || null;
 
-      let totalUsage = response.usage
-        ? {
-            prompt_tokens: response.usage.prompt_tokens,
-            completion_tokens: response.usage.completion_tokens,
-            total_tokens: response.usage.total_tokens,
-          }
+      const totalUsage = response.usage
+        ? extendUsageWithCacheMetrics(response.usage)
         : undefined;
-
-      // Extend usage with cache metrics (Claude top-level + OpenAI prompt_tokens_details)
-      if (totalUsage && response.usage) {
-        totalUsage = extendUsageWithCacheMetrics(
-          totalUsage,
-          response.usage as Partial<ClaudeUsage>,
-        );
-      }
 
       const result: CallAgentResult = {};
 
@@ -622,19 +609,8 @@ async function processStreamingResponse(
 
       // Check for usage information in any chunk
       if (chunk.usage) {
-        let chunkUsage = {
-          prompt_tokens: chunk.usage.prompt_tokens,
-          completion_tokens: chunk.usage.completion_tokens,
-          total_tokens: chunk.usage.total_tokens,
-        };
-
-        // Extend usage with cache metrics (Claude top-level + OpenAI prompt_tokens_details)
-        chunkUsage = extendUsageWithCacheMetrics(
-          chunkUsage,
-          chunk.usage as Partial<ClaudeUsage>,
-        );
-
-        usage = chunkUsage;
+        // Extend usage with cache metrics from OpenAI prompt_tokens_details
+        usage = extendUsageWithCacheMetrics(chunk.usage);
       }
 
       // Check for finish_reason in the choice
@@ -916,4 +892,3 @@ export async function processWebContent(
     throw error;
   }
 }
-

--- a/packages/agent-sdk/src/types/core.ts
+++ b/packages/agent-sdk/src/types/core.ts
@@ -3,8 +3,6 @@
  * Dependencies: None (foundation layer)
  */
 
-import type { CompletionUsage } from "openai/resources";
-
 /**
  * Logger interface definition
  * Compatible with OpenAI package Logger interface
@@ -18,7 +16,7 @@ export interface Logger {
 
 /**
  * Usage statistics for AI operations
- * Extends OpenAI's Usage format with additional tracking fields
+ * Extends OpenAI's Usage format with normalized cache fields
  */
 export interface Usage {
   prompt_tokens: number; // Tokens used in prompts
@@ -27,47 +25,10 @@ export interface Usage {
   model?: string; // Model used for the operation (e.g., "gpt-4", "gpt-3.5-turbo")
   operation_type?: "agent" | "compact"; // Type of operation that generated usage
 
-  // Cache-related tokens (Claude top-level + OpenAI prompt_tokens_details)
-  cache_read_input_tokens?: number; // Tokens read from cache (Claude) or cached_tokens (OpenAI prompt_tokens_details)
-  cache_creation_input_tokens?: number; // Tokens used to create cache entries
-  cache_creation?: {
-    ephemeral_5m_input_tokens: number; // Tokens cached for 5 minutes
-    ephemeral_1h_input_tokens: number; // Tokens cached for 1 hour
-  };
-}
-
-/**
- * Enhanced usage metrics including Claude cache information
- * Backward compatible with standard OpenAI CompletionUsage
- */
-export interface ClaudeUsage extends CompletionUsage {
-  // Standard OpenAI usage fields (inherited)
-  prompt_tokens: number;
-  completion_tokens: number;
-  total_tokens: number;
-
-  // Claude-specific cache extensions
-  /**
-   * Number of tokens read from existing cache
-   * Indicates cost savings from cache hits
-   */
+  // Normalized cache fields (from OpenAI prompt_tokens_details.cached_tokens
+  // and the gateway-provided prompt_tokens_details.cache_creation_input_tokens)
   cache_read_input_tokens?: number;
-
-  /**
-   * Number of tokens used to create new cache entries
-   * Investment in future cache hits
-   */
   cache_creation_input_tokens?: number;
-
-  /**
-   * Detailed breakdown of cache creation by duration
-   */
-  cache_creation?: {
-    /** Tokens cached for 5 minute duration */
-    ephemeral_5m_input_tokens: number;
-    /** Tokens cached for 1 hour duration */
-    ephemeral_1h_input_tokens: number;
-  };
 }
 
 /**

--- a/packages/agent-sdk/src/utils/cacheControlUtils.ts
+++ b/packages/agent-sdk/src/utils/cacheControlUtils.ts
@@ -15,6 +15,7 @@ import type {
 import { logger } from "./globalLogger.js";
 import { supportsPromptCaching } from "./modelCapabilities.js";
 import type { ModelCapabilities } from "../types/config.js";
+import type { Usage } from "../types/core.js";
 
 // ============================================================================
 // Core Types
@@ -44,27 +45,6 @@ export interface ClaudeChatCompletionContentPartText
 export interface ExtendedPromptTokensDetails
   extends CompletionUsage.PromptTokensDetails {
   cache_creation_input_tokens?: number;
-}
-
-/**
- * Enhanced usage metrics including cache information
- * Supports both Claude-specific top-level fields and OpenAI-standard prompt_tokens_details
- */
-export interface ClaudeUsage extends CompletionUsage {
-  prompt_tokens: number;
-  completion_tokens: number;
-  total_tokens: number;
-
-  // Cache extensions (from Claude top-level or OpenAI prompt_tokens_details)
-  cache_read_input_tokens?: number; // Claude: cache_read_input_tokens / OpenAI: prompt_tokens_details.cached_tokens
-  cache_creation_input_tokens?: number; // Claude: cache_creation_input_tokens / OpenAI: prompt_tokens_details.cache_creation_input_tokens
-  cache_creation?: {
-    ephemeral_5m_input_tokens: number;
-    ephemeral_1h_input_tokens: number;
-  };
-
-  // Override prompt_tokens_details to include cache_creation_input_tokens
-  prompt_tokens_details?: ExtendedPromptTokensDetails;
 }
 
 // ============================================================================
@@ -317,110 +297,28 @@ export function transformMessagesForExplicitCache(
 
 /**
  * Extends standard usage with cache metrics
- * Extracts cache tokens from both Claude-specific top-level fields and
- * OpenAI-standard prompt_tokens_details (used by Gemini, DeepSeek, etc.)
- * @param standardUsage - OpenAI usage response
- * @param cacheMetrics - Additional cache metrics from the API response
+ * Extracts cache tokens from OpenAI-standard prompt_tokens_details
+ * (cached_tokens and the gateway-provided cache_creation_input_tokens)
+ * @param usage - OpenAI usage response
  * @returns Extended usage with cache information
  */
-export function extendUsageWithCacheMetrics(
-  standardUsage: CompletionUsage,
-  cacheMetrics?: Partial<ClaudeUsage>,
-): ClaudeUsage {
-  const baseUsage: ClaudeUsage = {
-    prompt_tokens: standardUsage.prompt_tokens,
-    completion_tokens: standardUsage.completion_tokens,
-    total_tokens: standardUsage.total_tokens,
+export function extendUsageWithCacheMetrics(usage: CompletionUsage): Usage {
+  const baseUsage: Usage = {
+    prompt_tokens: usage.prompt_tokens,
+    completion_tokens: usage.completion_tokens,
+    total_tokens: usage.total_tokens,
   };
 
-  if (!cacheMetrics) {
-    return baseUsage;
-  }
+  const details = usage.prompt_tokens_details as
+    | ExtendedPromptTokensDetails
+    | undefined;
 
-  // Extract cache_read_input_tokens from Claude top-level field
-  if (typeof cacheMetrics.cache_read_input_tokens === "number") {
-    baseUsage.cache_read_input_tokens = cacheMetrics.cache_read_input_tokens;
+  if (details?.cached_tokens != null) {
+    baseUsage.cache_read_input_tokens = details.cached_tokens;
   }
-  // Fallback to prompt_tokens_details.cached_tokens (OpenAI standard)
-  else if (cacheMetrics.prompt_tokens_details?.cached_tokens != null) {
-    baseUsage.cache_read_input_tokens =
-      cacheMetrics.prompt_tokens_details.cached_tokens;
-  }
-
-  // Extract cache_creation_input_tokens from Claude top-level field
-  if (typeof cacheMetrics.cache_creation_input_tokens === "number") {
-    baseUsage.cache_creation_input_tokens =
-      cacheMetrics.cache_creation_input_tokens;
-  }
-  // Fallback to prompt_tokens_details.cache_creation_input_tokens
-  else if (
-    cacheMetrics.prompt_tokens_details?.cache_creation_input_tokens != null
-  ) {
-    baseUsage.cache_creation_input_tokens =
-      cacheMetrics.prompt_tokens_details.cache_creation_input_tokens;
-  }
-
-  // Extract cache_creation breakdown (Claude-specific)
-  if (
-    cacheMetrics.cache_creation &&
-    typeof cacheMetrics.cache_creation.ephemeral_5m_input_tokens === "number" &&
-    typeof cacheMetrics.cache_creation.ephemeral_1h_input_tokens === "number"
-  ) {
-    baseUsage.cache_creation = {
-      ephemeral_5m_input_tokens:
-        cacheMetrics.cache_creation.ephemeral_5m_input_tokens,
-      ephemeral_1h_input_tokens:
-        cacheMetrics.cache_creation.ephemeral_1h_input_tokens,
-    };
+  if (details?.cache_creation_input_tokens != null) {
+    baseUsage.cache_creation_input_tokens = details.cache_creation_input_tokens;
   }
 
   return baseUsage;
-}
-
-/**
- * Validates Claude usage structure
- * @param usage - Usage object to validate
- * @returns True if usage structure is valid
- */
-export function isValidClaudeUsage(usage: unknown): usage is ClaudeUsage {
-  if (!usage || typeof usage !== "object") {
-    return false;
-  }
-
-  const usageObj = usage as Record<string, unknown>;
-
-  // Check required standard fields
-  const hasStandardFields =
-    typeof usageObj.prompt_tokens === "number" &&
-    typeof usageObj.completion_tokens === "number" &&
-    typeof usageObj.total_tokens === "number";
-
-  if (!hasStandardFields) {
-    return false;
-  }
-
-  // Check optional cache fields
-  const hasCacheFields =
-    (usageObj.cache_read_input_tokens === undefined ||
-      typeof usageObj.cache_read_input_tokens === "number") &&
-    (usageObj.cache_creation_input_tokens === undefined ||
-      typeof usageObj.cache_creation_input_tokens === "number");
-
-  if (!hasCacheFields) {
-    return false;
-  }
-
-  // Check cache_creation object if present
-  if (usageObj.cache_creation !== undefined) {
-    const cacheCreation = usageObj.cache_creation as Record<string, unknown>;
-    if (
-      typeof cacheCreation !== "object" ||
-      typeof cacheCreation.ephemeral_5m_input_tokens !== "number" ||
-      typeof cacheCreation.ephemeral_1h_input_tokens !== "number"
-    ) {
-      return false;
-    }
-  }
-
-  return true;
 }

--- a/packages/agent-sdk/tests/managers/aiManager.coverage.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.coverage.test.ts
@@ -222,10 +222,6 @@ describe("AIManager - Coverage", () => {
         completion_tokens: 20,
         total_tokens: 30,
         cache_creation_input_tokens: 5,
-        cache_creation: {
-          ephemeral_5m_input_tokens: 100,
-          ephemeral_1h_input_tokens: 50,
-        },
       },
       tool_calls: [],
       finish_reason: "stop",

--- a/packages/agent-sdk/tests/services/aiService.cacheControl.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.cacheControl.test.ts
@@ -138,43 +138,6 @@ describe("AI Service - Claude Cache Control", () => {
       });
     });
 
-    describe("isValidClaudeUsage", () => {
-      it("should validate correct Claude usage objects", async () => {
-        const validUsage = {
-          prompt_tokens: 100,
-          completion_tokens: 50,
-          total_tokens: 150,
-          cache_read_input_tokens: 30,
-          cache_creation_input_tokens: 70,
-          cache_creation: {
-            ephemeral_5m_input_tokens: 70,
-            ephemeral_1h_input_tokens: 0,
-          },
-        };
-        expect(cacheUtils.isValidClaudeUsage(validUsage)).toBe(true);
-      });
-
-      it("should validate usage objects without cache fields", async () => {
-        const basicUsage = {
-          prompt_tokens: 100,
-          completion_tokens: 50,
-          total_tokens: 150,
-        };
-        expect(cacheUtils.isValidClaudeUsage(basicUsage)).toBe(true);
-      });
-
-      it("should reject invalid usage objects", async () => {
-        expect(cacheUtils.isValidClaudeUsage({})).toBe(false);
-        expect(cacheUtils.isValidClaudeUsage(null)).toBe(false);
-        expect(cacheUtils.isValidClaudeUsage({ prompt_tokens: "100" })).toBe(
-          false,
-        );
-        expect(cacheUtils.isValidClaudeUsage({ prompt_tokens: 100 })).toBe(
-          false,
-        ); // missing required fields
-      });
-    });
-
     describe("addCacheControlToContent", () => {
       it("should transform string content to structured arrays with cache control", async () => {
         const result = cacheUtils.addCacheControlToContent(
@@ -1048,8 +1011,8 @@ describe("AI Service - Claude Cache Control", () => {
       callAgent = aiService.callAgent;
     });
 
-    it("should extend usage tracking with cache metrics for Claude models", async () => {
-      // Mock Claude response with cache metrics
+    it("should extend usage tracking with cache metrics from prompt_tokens_details", async () => {
+      // Mock response with cache metrics in prompt_tokens_details
       const mockWithResponse = vi.fn().mockResolvedValue({
         data: {
           choices: [
@@ -1064,11 +1027,9 @@ describe("AI Service - Claude Cache Control", () => {
             prompt_tokens: 100,
             completion_tokens: 50,
             total_tokens: 150,
-            cache_read_input_tokens: 30,
-            cache_creation_input_tokens: 70,
-            cache_creation: {
-              ephemeral_5m_input_tokens: 70,
-              ephemeral_1h_input_tokens: 0,
+            prompt_tokens_details: {
+              cached_tokens: 30,
+              cache_creation_input_tokens: 70,
             },
           },
         },
@@ -1090,8 +1051,11 @@ describe("AI Service - Claude Cache Control", () => {
 
       expect(result).toBeDefined();
       expect(result.usage).toBeDefined();
-
-      // Test will verify cache metrics are properly handled once implementation is complete
+      expect(result.usage?.prompt_tokens).toBe(100);
+      expect(result.usage?.completion_tokens).toBe(50);
+      expect(result.usage?.total_tokens).toBe(150);
+      expect(result.usage?.cache_read_input_tokens).toBe(30);
+      expect(result.usage?.cache_creation_input_tokens).toBe(70);
     });
 
     it("should maintain backward compatibility for non-Claude usage tracking", async () => {
@@ -1134,10 +1098,9 @@ describe("AI Service - Claude Cache Control", () => {
       expect(result.usage?.completion_tokens).toBe(50);
       expect(result.usage?.total_tokens).toBe(150);
 
-      // Ensure no cache-specific fields are present for non-Claude models
+      // Ensure no cache-specific fields are present without cache data
       expect(result.usage).not.toHaveProperty("cache_read_input_tokens");
       expect(result.usage).not.toHaveProperty("cache_creation_input_tokens");
-      expect(result.usage).not.toHaveProperty("cache_creation");
     });
   });
 
@@ -1319,10 +1282,9 @@ describe("AI Service - Claude Cache Control", () => {
         expect(result.usage?.completion_tokens).toBe(20);
         expect(result.usage?.total_tokens).toBe(30);
 
-        // Should not have Claude-specific cache fields
+        // Should not have cache fields
         expect(result.usage).not.toHaveProperty("cache_read_input_tokens");
         expect(result.usage).not.toHaveProperty("cache_creation_input_tokens");
-        expect(result.usage).not.toHaveProperty("cache_creation");
       });
 
       it("should handle missing usage gracefully", async () => {
@@ -1435,7 +1397,7 @@ describe("AI Service - Claude Cache Control", () => {
         expect(result.usage?.cache_creation_input_tokens).toBe(40);
       });
 
-      it("should prefer Claude top-level fields over prompt_tokens_details when both present", async () => {
+      it("should ignore non-standard Claude top-level fields and only read prompt_tokens_details", async () => {
         const mockWithResponse = vi.fn().mockResolvedValue({
           data: {
             choices: [
@@ -1470,9 +1432,9 @@ describe("AI Service - Claude Cache Control", () => {
         });
 
         expect(result).toBeDefined();
-        // Claude top-level fields take priority
-        expect(result.usage?.cache_read_input_tokens).toBe(30);
-        expect(result.usage?.cache_creation_input_tokens).toBe(70);
+        // Only prompt_tokens_details is read; Claude top-level fields are ignored
+        expect(result.usage?.cache_read_input_tokens).toBe(999);
+        expect(result.usage?.cache_creation_input_tokens).toBe(888);
       });
     });
 

--- a/packages/agent-sdk/tests/utils/tokenCalculation.test.ts
+++ b/packages/agent-sdk/tests/utils/tokenCalculation.test.ts
@@ -111,10 +111,6 @@ describe("calculateComprehensiveTotalTokens", () => {
       cache_creation_input_tokens: 30,
       model: "claude-3-sonnet",
       operation_type: "agent",
-      cache_creation: {
-        ephemeral_5m_input_tokens: 15,
-        ephemeral_1h_input_tokens: 15,
-      },
     };
 
     const result = calculateComprehensiveTotalTokens(usage);

--- a/packages/code/src/utils/usageSummary.ts
+++ b/packages/code/src/utils/usageSummary.ts
@@ -12,13 +12,9 @@ export interface TokenSummary {
     agent_calls: number;
     compactions: number;
   };
-  // Cache-related tokens (for Claude models)
+  // Normalized cache tokens
   cache_read_input_tokens?: number;
   cache_creation_input_tokens?: number;
-  cache_creation?: {
-    ephemeral_5m_input_tokens: number;
-    ephemeral_1h_input_tokens: number;
-  };
 }
 
 /**
@@ -64,22 +60,6 @@ export function calculateTokenSummary(
       summary.cache_creation_input_tokens =
         (summary.cache_creation_input_tokens || 0) +
         usage.cache_creation_input_tokens;
-    }
-    if (
-      usage.cache_creation &&
-      (usage.cache_creation.ephemeral_5m_input_tokens > 0 ||
-        usage.cache_creation.ephemeral_1h_input_tokens > 0)
-    ) {
-      if (!summary.cache_creation) {
-        summary.cache_creation = {
-          ephemeral_5m_input_tokens: 0,
-          ephemeral_1h_input_tokens: 0,
-        };
-      }
-      summary.cache_creation.ephemeral_5m_input_tokens +=
-        usage.cache_creation.ephemeral_5m_input_tokens || 0;
-      summary.cache_creation.ephemeral_1h_input_tokens +=
-        usage.cache_creation.ephemeral_1h_input_tokens || 0;
     }
 
     // Track operation types
@@ -132,8 +112,6 @@ export function displayUsageSummary(
   let totalCompactions = 0;
   let totalCacheRead = 0;
   let totalCacheCreation = 0;
-  let totalCache5m = 0;
-  let totalCache1h = 0;
   let hasCacheData = false;
 
   for (const [, summary] of Object.entries(summaries)) {
@@ -147,8 +125,7 @@ export function displayUsageSummary(
     // Display cache information if available
     if (
       summary.cache_read_input_tokens ||
-      summary.cache_creation_input_tokens ||
-      summary.cache_creation
+      summary.cache_creation_input_tokens
     ) {
       hasCacheData = true;
       console.log("  Cache Usage:");
@@ -171,21 +148,6 @@ export function displayUsageSummary(
           `    Created cache: ${summary.cache_creation_input_tokens.toLocaleString()} tokens`,
         );
         totalCacheCreation += summary.cache_creation_input_tokens;
-      }
-
-      if (summary.cache_creation) {
-        if (summary.cache_creation.ephemeral_5m_input_tokens > 0) {
-          console.log(
-            `    5m cache: ${summary.cache_creation.ephemeral_5m_input_tokens.toLocaleString()} tokens`,
-          );
-          totalCache5m += summary.cache_creation.ephemeral_5m_input_tokens;
-        }
-        if (summary.cache_creation.ephemeral_1h_input_tokens > 0) {
-          console.log(
-            `    1h cache: ${summary.cache_creation.ephemeral_1h_input_tokens.toLocaleString()} tokens`,
-          );
-          totalCache1h += summary.cache_creation.ephemeral_1h_input_tokens;
-        }
       }
     }
 
@@ -218,12 +180,6 @@ export function displayUsageSummary(
         console.log(
           `    Created cache: ${totalCacheCreation.toLocaleString()} tokens`,
         );
-      }
-      if (totalCache5m > 0) {
-        console.log(`    5m cache: ${totalCache5m.toLocaleString()} tokens`);
-      }
-      if (totalCache1h > 0) {
-        console.log(`    1h cache: ${totalCache1h.toLocaleString()} tokens`);
       }
     }
 

--- a/packages/code/tests/utils/usageSummary.test.ts
+++ b/packages/code/tests/utils/usageSummary.test.ts
@@ -208,39 +208,6 @@ describe("Usage Summary Utilities", () => {
       });
     });
 
-    it("should handle partial cache creation data", () => {
-      const usages: Usage[] = [
-        {
-          prompt_tokens: 100,
-          completion_tokens: 50,
-          total_tokens: 150,
-          model: "claude-3",
-          operation_type: "agent",
-          cache_creation: {
-            ephemeral_5m_input_tokens: 10,
-            ephemeral_1h_input_tokens: 0,
-          },
-        },
-        {
-          prompt_tokens: 100,
-          completion_tokens: 50,
-          total_tokens: 150,
-          model: "claude-3",
-          operation_type: "agent",
-          cache_creation: {
-            ephemeral_5m_input_tokens: 0,
-            ephemeral_1h_input_tokens: 20,
-          },
-        },
-      ];
-
-      const result = calculateTokenSummary(usages);
-      expect(result["claude-3"].cache_creation).toEqual({
-        ephemeral_5m_input_tokens: 10,
-        ephemeral_1h_input_tokens: 20,
-      });
-    });
-
     it("should sort results by total tokens descending", () => {
       const usages: Usage[] = [
         {
@@ -512,10 +479,6 @@ describe("Usage Summary Utilities", () => {
             operation_type: "agent",
             cache_read_input_tokens: 30,
             cache_creation_input_tokens: 70,
-            cache_creation: {
-              ephemeral_5m_input_tokens: 40,
-              ephemeral_1h_input_tokens: 30,
-            },
           },
         ];
 
@@ -533,10 +496,6 @@ describe("Usage Summary Utilities", () => {
             },
             cache_read_input_tokens: 30,
             cache_creation_input_tokens: 70,
-            cache_creation: {
-              ephemeral_5m_input_tokens: 40,
-              ephemeral_1h_input_tokens: 30,
-            },
           },
         });
       });
@@ -555,10 +514,6 @@ describe("Usage Summary Utilities", () => {
             operation_type: "agent",
             cache_read_input_tokens: 30,
             cache_creation_input_tokens: 70,
-            cache_creation: {
-              ephemeral_5m_input_tokens: 40,
-              ephemeral_1h_input_tokens: 30,
-            },
           },
         ];
 
@@ -569,8 +524,6 @@ describe("Usage Summary Utilities", () => {
         expect(logCalls).toContain("  Cache Usage:");
         expect(logCalls).toContain("    Read from cache: 30 tokens");
         expect(logCalls).toContain("    Created cache: 70 tokens");
-        expect(logCalls).toContain("    5m cache: 40 tokens");
-        expect(logCalls).toContain("    1h cache: 30 tokens");
 
         consoleSpy.mockRestore();
       });
@@ -596,10 +549,6 @@ describe("Usage Summary Utilities", () => {
             model: "claude-3-opus",
             operation_type: "agent",
             cache_creation_input_tokens: 70,
-            cache_creation: {
-              ephemeral_5m_input_tokens: 40,
-              ephemeral_1h_input_tokens: 30,
-            },
           },
         ];
 
@@ -614,8 +563,6 @@ describe("Usage Summary Utilities", () => {
         expect(overallLogs).toContain("  Cache Usage:");
         expect(overallLogs).toContain("    Read from cache: 30 tokens");
         expect(overallLogs).toContain("    Created cache: 70 tokens");
-        expect(overallLogs).toContain("    5m cache: 40 tokens");
-        expect(overallLogs).toContain("    1h cache: 30 tokens");
 
         consoleSpy.mockRestore();
       });
@@ -642,28 +589,6 @@ describe("Usage Summary Utilities", () => {
             operation_type: "agent",
             cache_creation_input_tokens: 20,
           },
-          {
-            prompt_tokens: 100,
-            completion_tokens: 50,
-            total_tokens: 150,
-            model: "model-3",
-            operation_type: "agent",
-            cache_creation: {
-              ephemeral_5m_input_tokens: 5,
-              ephemeral_1h_input_tokens: 0,
-            },
-          },
-          {
-            prompt_tokens: 100,
-            completion_tokens: 50,
-            total_tokens: 150,
-            model: "model-4",
-            operation_type: "agent",
-            cache_creation: {
-              ephemeral_5m_input_tokens: 0,
-              ephemeral_1h_input_tokens: 15,
-            },
-          },
         ];
 
         displayUsageSummary(usages);
@@ -672,8 +597,6 @@ describe("Usage Summary Utilities", () => {
         const overallLogs = logCalls.slice(logCalls.indexOf("Overall Total:"));
         expect(overallLogs).toContain("    Read from cache: 10 tokens");
         expect(overallLogs).toContain("    Created cache: 20 tokens");
-        expect(overallLogs).toContain("    5m cache: 5 tokens");
-        expect(overallLogs).toContain("    1h cache: 15 tokens");
 
         consoleSpy.mockRestore();
       });


### PR DESCRIPTION
Drop support for Claude top-level cache fields (cache_read_input_tokens, cache_creation_input_tokens, cache_creation object) and the ClaudeUsage / isValidClaudeUsage helpers. Cache metrics are now read only from the OpenAI-compliant prompt_tokens_details (cached_tokens and the gateway extension cache_creation_input_tokens).

The normalized cache_read_input_tokens / cache_creation_input_tokens fields on the Usage interface are preserved since downstream consumers (token calculation, compaction, workflows, CLI usage summary) rely on them.

Changes:
- Simplify extendUsageWithCacheMetrics to a single-parameter version reading only prompt_tokens_details
- Remove cache_creation object from Usage / TokenSummary interfaces
- Update aiManager usage passthrough and CLI usageSummary display
- Update tests: Claude top-level field tests rewritten to prompt_tokens_details semantics