### PR TITLE
feat(agent-sdk): structured background status return for bash tool

### DIFF
--- a/docs/specs/core/bash-tools.md
+++ b/docs/specs/core/bash-tools.md
@@ -22,8 +22,8 @@ order: 20
 **验收场景**：
 
 1. **假设** 有要执行的命令，**当** 调用 `Bash` 工具时，**则** 它必须返回命令的输出（stdout 和 stderr）。
-2. **假设** 前台命令耗时较长，**当** 超过超时时，**则** 它必须被自动转为后台（如果命令允许）或终止（如果不允许，例如 `sleep`）。
-3. **假设** 前台命令超时并被自动转为后台，**则** 代理必须收到一条消息，指示进程已被移至后台，并包含其任务 ID 和输出路径。
+2. **假设** 前台命令耗时较长，**当** 超过超时时，**则** 它必须被自动转为后台（如果命令允许）或终止（如果不允许，例如 `sleep`），且返回结果必须标记为成功（`success: true`），不得视为错误。
+3. **假设** 前台命令超时并被自动转为后台，**则** 代理必须收到一条消息，指示进程仍在后台运行、完成时会收到通知，并包含其任务 ID 和输出路径；消息不得使用 "timed out" 等暗示失败的措辞。
 
 ---
 
@@ -41,6 +41,26 @@ order: 20
 2. **假设** `run_in_background` 为 true，**则** 命令必须在没有任何超时的情况下运行——它持续运行直到完成或手动停止。
 3. **假设** 有运行中的后台进程，**当** 使用其 ID 调用 `TaskStop`（原 `KillBash`）时，**则** 进程必须被终止。
 4. **假设** 后台进程已启动，**当** 我使用 `Read` 工具读取提供的 `outputPath` 文件时，**则** 我应该看到进程的实时输出。
+
+---
+
+### 用户故事：后台状态结构化返回（优先级：P2）
+
+作为 AI 代理，我希望 Bash 工具的结果包含结构化的后台状态字段，以便精确区分"用户手动转后台"、"超时自动转后台"和"显式后台启动"三种场景，而无需解析文本。
+
+**优先级原因**：当前超时转后台的返回文本含 "timed out"，容易被模型误解为命令失败；结构化字段（与 Claude Code 输出 schema 对齐：`backgroundTaskId`、`backgroundedByUser`、`assistantAutoBackgrounded`）让模型与 UI 可机器可读地判断后台状态。
+
+**独立测试**：运行 `sleep 60`（timeout 设为 2000ms），验证返回结果包含 `assistantAutoBackgrounded: true` 与 `backgroundTaskId`，且文本与 Claude Code 对齐（不含 "timed out"）。
+
+**验收场景**：
+
+1. **假设** 命令超时被自动转为后台，**当** Bash 工具返回结果时，**则** 结果必须包含 `backgroundTaskId` 与 `assistantAutoBackgrounded: true`，且 `success: true`。
+2. **假设** 用户通过 Ctrl+B 手动将命令转为后台，**当** Bash 工具返回结果时，**则** 结果必须包含 `backgroundTaskId` 与 `backgroundedByUser: true`。
+3. **假设** 命令通过 `run_in_background: true` 显式启动，**当** Bash 工具返回结果时，**则** 结果必须包含 `backgroundTaskId`，且 `backgroundedByUser` 与 `assistantAutoBackgrounded` 为 false 或省略。
+4. **假设** 命令超时被自动转为后台，**当** 返回结果时，**则** 文本内容必须为（与 Claude Code 对齐，其中 X 为任务 ID、Y 为输出路径）：`Command exceeded the timeout (Xs) and was moved to the background with ID: X. It is still running — you will be notified when it completes. Output is being written to: Y`。
+5. **假设** 命令通过 Ctrl+B 手动转为后台，**当** 返回结果时，**则** 文本内容必须为：`Command was manually backgrounded by user with ID: X. Output is being written to: Y`。
+6. **假设** 命令通过 `run_in_background: true` 启动，**当** 返回结果时，**则** 文本内容必须为：`Command running in background with ID: X. Output is being written to: Y`。
+7. **假设** 命令超时被自动转为后台，**则** 该结果不得中断代理当前运行循环——只有用户手动转后台（`backgroundedByUser`）才停止循环。
 
 ---
 
@@ -104,6 +124,7 @@ order: 20
 - **无效任务 ID**：使用不存在或已过期的 ID 调用 `TaskStop` 应返回清晰的错误消息。
 - **每次命令使用新 Shell**：每次前台命令都会生成新的 shell；`cd` 和环境变量更改不会在调用之间持久化。
 - **超时自动转后台**：当前台命令超时时，系统必须自动将其转为后台（移至 `BackgroundTaskManager`）而不是终止，除非命令以 `sleep` 开头（仍按原方式终止）。
+- **超时转后台措辞**：自动转后台的通知文本必须避免 "timed out" 等暗示失败的措辞，改用"超出超时预算并移至后台、命令仍在运行、完成时会收到通知"的语义，并携带任务 ID 与输出路径。
 - **后台无超时**：当 `run_in_background` 明确为 `true` 时，任何超时（默认或显式）必须被取消——进程无限期运行直到完成或手动停止。
 - **Windows 路径转换**：在 Windows 上使用 Git Bash 时，临时 CWD 文件路径必须从 Windows 路径（`C:\Users\...`）转换为 POSIX 路径（`C:/Users/...`），否则 Bash 会将反斜杠视为转义字符导致路径损坏、临时文件泄漏到项目目录中。
 - **Git Bash 未安装**：Windows 上未检测到 Git Bash 时，必须返回错误而非静默降级到 cmd.exe。

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -2009,7 +2009,7 @@ ${question}`;
                 ) || [];
               const hasBackgrounded =
                 toolBlocks.length > 0 &&
-                toolBlocks.some((block) => block.isManuallyBackgrounded);
+                toolBlocks.some((block) => block.backgroundedByUser);
 
               if (hasBackgrounded) {
                 logger?.info(
@@ -2542,7 +2542,9 @@ ${question}`;
         name: toolName,
         compactParams,
         shortResult: toolResult.shortResult,
-        isManuallyBackgrounded: toolResult.isManuallyBackgrounded,
+        backgroundTaskId: toolResult.backgroundTaskId,
+        backgroundedByUser: toolResult.backgroundedByUser,
+        assistantAutoBackgrounded: toolResult.assistantAutoBackgrounded,
         startLineNumber: toolResult.startLineNumber,
         images: toolResult.images,
         timestamp: Date.now(),
@@ -2568,7 +2570,6 @@ ${question}`;
         stage: "end",
         name: toolName,
         compactParams,
-        isManuallyBackgrounded: false,
         timestamp: Date.now(),
       });
     }

--- a/packages/agent-sdk/src/managers/messageManager.ts
+++ b/packages/agent-sdk/src/managers/messageManager.ts
@@ -975,7 +975,9 @@ export class MessageManager {
         stage: "end",
         success: false,
         error: errorMessage,
-        isManuallyBackgrounded: block.isManuallyBackgrounded,
+        backgroundTaskId: block.backgroundTaskId,
+        backgroundedByUser: block.backgroundedByUser,
+        assistantAutoBackgrounded: block.assistantAutoBackgrounded,
         timestamp,
       });
     }

--- a/packages/agent-sdk/src/tools/agentTool.ts
+++ b/packages/agent-sdk/src/tools/agentTool.ts
@@ -214,7 +214,8 @@ When using the Agent tool, you must specify a subagent_type parameter to select 
                   success: true,
                   content: `Agent backgrounded with ID: ${taskId}.${outputPath ? ` Real-time output: ${outputPath}` : ""}`,
                   shortResult: "Agent backgrounded",
-                  isManuallyBackgrounded: true,
+                  backgroundedByUser: true,
+                  backgroundTaskId: taskId,
                 });
               },
             });

--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -259,17 +259,14 @@ The working directory persists between commands. Try to maintain your current wo
       );
       const task = backgroundTaskManager.getTask(taskId);
       const outputPath = task?.outputPath;
-      const backgroundMsg = [
-        `Command started in background with ID: ${taskId}.`,
-        `You will be notified automatically when it completes.`,
-        outputPath
-          ? `output_file: ${outputPath}`
-          : `Use ${READ_TOOL_NAME} tool with task_id="${taskId}" to read the output.`,
-      ].join("\n");
+      const backgroundMsg = outputPath
+        ? `Command running in background with ID: ${taskId}. Output is being written to: ${outputPath}`
+        : `Command running in background with ID: ${taskId}. Use ${READ_TOOL_NAME} tool with task_id="${taskId}" to read the output.`;
       return {
         success: true,
         content: recoveryNotice + backgroundMsg,
         shortResult: `Background process ${taskId} started${outputPath ? ` → ${outputPath}` : ""}`,
+        backgroundTaskId: taskId,
       };
     }
 
@@ -366,9 +363,10 @@ The working directory persists between commands. Try to maintain your current wo
               const outputPath = task?.outputPath;
               resolve({
                 success: true,
-                content: `Command moved to background with ID: ${taskId}.${outputPath ? ` Real-time output: ${outputPath}` : ""}`,
+                content: `Command was manually backgrounded by user with ID: ${taskId}.${outputPath ? ` Output is being written to: ${outputPath}` : ""}`,
                 shortResult: `Process ${taskId} backgrounded`,
-                isManuallyBackgrounded: true,
+                backgroundedByUser: true,
+                backgroundTaskId: taskId,
               });
             } else {
               handleAbort(
@@ -414,8 +412,10 @@ The working directory persists between commands. Try to maintain your current wo
               );
               resolve({
                 success: true,
-                content: `Command timed out after ${timeout / 1000} seconds and was moved to background with ID: ${taskId}.${outputPath ? ` Real-time output: ${outputPath}` : ""}`,
-                shortResult: `Process ${taskId} auto-backgrounded (timeout)`,
+                content: `Command exceeded the timeout (${timeout / 1000}s) and was moved to the background with ID: ${taskId}. It is still running — you will be notified when it completes.${outputPath ? ` Output is being written to: ${outputPath}` : ""}`,
+                shortResult: `Process ${taskId} auto-backgrounded`,
+                assistantAutoBackgrounded: true,
+                backgroundTaskId: taskId,
               });
             } else {
               handleAbort("Command timed out");

--- a/packages/agent-sdk/src/tools/types.ts
+++ b/packages/agent-sdk/src/tools/types.ts
@@ -54,8 +54,12 @@ export interface ToolResult {
     data: string; // base64 encoded image data
     mediaType?: string; // Image media type, such as "image/png"
   }>;
-  // Whether the tool was manually backgrounded by the user (e.g. via Ctrl-B)
-  isManuallyBackgrounded?: boolean;
+  // ID of the background task if the command is running in the background
+  backgroundTaskId?: string;
+  // True if the user manually backgrounded the command (e.g. via Ctrl-B)
+  backgroundedByUser?: boolean;
+  // True if the command was auto-backgrounded after exceeding the timeout
+  assistantAutoBackgrounded?: boolean;
   // Optional metadata for the tool result
   metadata?: Record<string, unknown>;
 }

--- a/packages/agent-sdk/src/types/messaging.ts
+++ b/packages/agent-sdk/src/types/messaging.ts
@@ -69,7 +69,12 @@ export interface ToolBlock {
   error?: string | Error;
   compactParams?: string; // Compact parameter display
   parametersChunk?: string; // Incremental parameter updates for streaming
-  isManuallyBackgrounded?: boolean; // Whether the tool was manually backgrounded by the user
+  // ID of the background task if the command is running in the background
+  backgroundTaskId?: string;
+  // True if the user manually backgrounded the command (e.g. via Ctrl-B)
+  backgroundedByUser?: boolean;
+  // True if the command was auto-backgrounded after exceeding the timeout
+  assistantAutoBackgrounded?: boolean;
   timestamp?: number; // Unix ms, set when tool result is finalized (stage="end")
 }
 

--- a/packages/agent-sdk/src/utils/messageOperations.ts
+++ b/packages/agent-sdk/src/utils/messageOperations.ts
@@ -48,7 +48,9 @@ export interface UpdateToolBlockParams {
   images?: Array<{ data: string; mediaType?: string }>;
   compactParams?: string;
   parametersChunk?: string; // Incremental parameter updates for streaming
-  isManuallyBackgrounded?: boolean;
+  backgroundTaskId?: string;
+  backgroundedByUser?: boolean;
+  assistantAutoBackgrounded?: boolean;
   timestamp?: number;
 }
 
@@ -296,7 +298,9 @@ export const updateToolBlockInMessage = ({
   images,
   compactParams,
   parametersChunk,
-  isManuallyBackgrounded,
+  backgroundTaskId,
+  backgroundedByUser,
+  assistantAutoBackgrounded,
 }: UpdateToolBlockParams): { messages: Message[]; messageId?: string } => {
   const newMessages = [...messages];
 
@@ -324,8 +328,12 @@ export const updateToolBlockInMessage = ({
             toolBlock.compactParams = compactParams;
           if (parametersChunk !== undefined)
             toolBlock.parametersChunk = parametersChunk;
-          if (isManuallyBackgrounded !== undefined)
-            toolBlock.isManuallyBackgrounded = isManuallyBackgrounded;
+          if (backgroundTaskId !== undefined)
+            toolBlock.backgroundTaskId = backgroundTaskId;
+          if (backgroundedByUser !== undefined)
+            toolBlock.backgroundedByUser = backgroundedByUser;
+          if (assistantAutoBackgrounded !== undefined)
+            toolBlock.assistantAutoBackgrounded = assistantAutoBackgrounded;
         }
       }
     }
@@ -355,8 +363,12 @@ export const updateToolBlockInMessage = ({
             toolBlock.compactParams = compactParams;
           if (parametersChunk !== undefined)
             toolBlock.parametersChunk = parametersChunk;
-          if (isManuallyBackgrounded !== undefined)
-            toolBlock.isManuallyBackgrounded = isManuallyBackgrounded;
+          if (backgroundTaskId !== undefined)
+            toolBlock.backgroundTaskId = backgroundTaskId;
+          if (backgroundedByUser !== undefined)
+            toolBlock.backgroundedByUser = backgroundedByUser;
+          if (assistantAutoBackgrounded !== undefined)
+            toolBlock.assistantAutoBackgrounded = assistantAutoBackgrounded;
         }
         const foundMessageId = newMessages[i].id;
         return { messages: newMessages, messageId: foundMessageId };
@@ -377,7 +389,9 @@ export const updateToolBlockInMessage = ({
           stage: stage ?? "start",
           compactParams: compactParams,
           parametersChunk: parametersChunk,
-          isManuallyBackgrounded: isManuallyBackgrounded,
+          backgroundTaskId: backgroundTaskId,
+          backgroundedByUser: backgroundedByUser,
+          assistantAutoBackgrounded: assistantAutoBackgrounded,
         });
         const foundMessageId = newMessages[i].id;
         return { messages: newMessages, messageId: foundMessageId };

--- a/packages/agent-sdk/tests/tools/bashTool.test.ts
+++ b/packages/agent-sdk/tests/tools/bashTool.test.ts
@@ -228,8 +228,9 @@ describe("bashTool", () => {
 
       expect(result.success).toBe(true);
       expect(result.content).toMatch(
-        /Command started in background with ID: task_\d+_\d+/,
+        /Command running in background with ID: task_\d+_\d+/,
       );
+      expect(result.backgroundTaskId).toMatch(/task_\d+_\d+/);
     });
 
     it("should run background command in context.workdir, not the BTM stale workdir (worktree cwd)", async () => {
@@ -425,9 +426,16 @@ describe("bashTool", () => {
       const result = await promise;
 
       expect(result.success).toBe(true);
-      expect(result.content).toContain("timed out after 1 seconds");
-      expect(result.content).toContain("moved to background");
-      expect(result.shortResult).toContain("auto-backgrounded (timeout)");
+      expect(result.content).toContain("exceeded the timeout (1s)");
+      expect(result.content).toContain("moved to the background");
+      expect(result.content).toContain(
+        "It is still running — you will be notified when it completes.",
+      );
+      expect(result.content).not.toContain("timed out");
+      expect(result.assistantAutoBackgrounded).toBe(true);
+      expect(result.backgroundTaskId).toBeTruthy();
+      expect(result.shortResult).toContain("auto-backgrounded");
+      expect(result.shortResult).not.toContain("(timeout)");
       vi.useRealTimers();
     });
 
@@ -493,7 +501,8 @@ describe("bashTool", () => {
       const result = await promise;
 
       expect(result.success).toBe(true);
-      expect(result.content).toContain("moved to background");
+      expect(result.content).toContain("moved to the background");
+      expect(result.assistantAutoBackgrounded).toBe(true);
       vi.useRealTimers();
     });
 
@@ -612,8 +621,13 @@ describe("bashTool", () => {
       const result = await executePromise;
       expect(result.success).toBe(true);
       expect(result.content).toContain(
-        "Command moved to background with ID: task_adopted",
+        "Command was manually backgrounded by user with ID: task_adopted",
       );
+      expect(result.content).toContain(
+        "Output is being written to: /tmp/test.log",
+      );
+      expect(result.backgroundedByUser).toBe(true);
+      expect(result.backgroundTaskId).toBe("task_adopted");
       expect(mockBackgroundTaskManager.adoptProcess).toHaveBeenCalled();
     });
 

--- a/packages/agent-sdk/tests/utils/messageOperations.test.ts
+++ b/packages/agent-sdk/tests/utils/messageOperations.test.ts
@@ -988,7 +988,9 @@ describe("updateToolBlockInMessage with messageId", () => {
       stage: "end",
       compactParams: "compact",
       parametersChunk: "chunk",
-      isManuallyBackgrounded: true,
+      backgroundTaskId: "task-1",
+      backgroundedByUser: true,
+      assistantAutoBackgrounded: true,
     });
 
     const block = result[0].blocks[0];
@@ -1003,7 +1005,9 @@ describe("updateToolBlockInMessage with messageId", () => {
       stage: "end",
       compactParams: "compact",
       parametersChunk: "chunk",
-      isManuallyBackgrounded: true,
+      backgroundTaskId: "task-1",
+      backgroundedByUser: true,
+      assistantAutoBackgrounded: true,
     });
   });
 });


### PR DESCRIPTION
## 背景

当前 Bash 工具超时转后台的返回文本含 "timed out"，容易被模型理解成命令失败。本次对齐 Claude Code 的处理方式：结构化返回后台状态字段 + 逐字对齐文案。

## 变更

**结构化字段（照搬 CC 三字段，替换原 `isManuallyBackgrounded`）**
- `ToolResult` / `ToolBlock` / `UpdateToolBlockParams` 新增 `backgroundTaskId` / `backgroundedByUser` / `assistantAutoBackgrounded`
- 消费点迁移：aiManager 停止循环判断改为 `backgroundedByUser`（只有用户手动转后台才停止循环，超时自动转后台不中断）；agentTool / messageManager 同步

**文案逐字对齐 CC（bashTool.ts）**
- 超时自动转后台：`Command exceeded the timeout (Xs) and was moved to the background with ID: X. It is still running — you will be notified when it completes. Output is being written to: Y` + `assistantAutoBackgrounded: true`，shortResult 去掉 "(timeout)"
- 手动转后台（Ctrl+B）：`Command was manually backgrounded by user with ID: X. Output is being written to: Y` + `backgroundedByUser: true`
- run_in_background：`Command running in background with ID: X. Output is being written to: Y`

**Spec**
- docs/specs/core/bash-tools.md 新增 P2「后台状态结构化返回」用户故事，7 个验收场景（含 CC 逐字文案断言）；P1 场景 2/3 更新为 `success: true` + 不使用 "timed out" 措辞

## 验证

- `pnpm -F wave-agent-sdk build` ✓
- agent-sdk 全量测试 249 files / 3424 passed（1 个无关 flake：configurationService 临时文件 rename，单独跑 69/69 通过）✓
- 根 type-check（全部包）✓
- prettier / lint（pre-commit hooks）✓
- spec-count：69 规格 / 353 用户故事 / 1329 验收场景 ✓