### PR TITLE
feat(agent-sdk): Artifact tool with enableArtifact gating, WebFetch interception, and confirmation UI

### DIFF
--- a/docs/specs/core/artifact-tool.md
+++ b/docs/specs/core/artifact-tool.md
@@ -1,0 +1,119 @@
+---
+name: "Artifact 工具"
+description: "发布本地 HTML/Markdown 为默认私有的可分享网页，WebFetch 读取 artifact URL"
+order: 35
+---
+
+# 功能规格说明：Artifact 工具
+
+**创建日期**：2026-08-12
+
+> 对齐 Claude Code 的内建 Artifact 工具：把本地 `.html`/`.md` 文件发布为默认私有的可分享网页（claude.ai 风格），并通过 WebFetch 拦截读取已发布的 artifact 页面。
+> 服务端契约已落地（codechat 自托管同源实现）：`POST /api/frame/deploy/direct`（发布）、`GET /api/frame/{slug}?via=model_read`（元数据）、`GET /api/frame/{slug}/content?v={version}`（正文，同源 + Bearer 鉴权，无独立域名/assetToken 流程）。
+> 已拍板的简化决定：零新增配置（API 端点复用 Server URL origin：`options.serverUrl > WAVE_SERVER_URL > 默认值`，不新增 baseUrl 配置项）；客户端只实现 inline 直传一条路径（无 signed URL / DIRECT_UPLOAD）；无 AUTO_OPEN / FRAME_TIMING / OWNERSHIP_FRAME 遥测；**启用开关 `enableArtifact`（未设置时跟随代码默认值常量，当前默认禁用**——后端未上线先不发功能，内测/灰度通过 `enableArtifact: true` 显式打开；后端上线后翻转默认值常量为启用）。`disableArtifact` opt-out 开关等 GA 后再对齐 CC，本期不实现。
+> 范围：wave-agent 客户端侧工具 + WebFetch 拦截。分享管理（`POST /api/frame/{slug}/share`、pinned_version）由服务端/网页外壳承担，客户端仅发布私有页面并探测分享状态。
+
+## 用户场景与测试 *（必填）*
+
+### 用户故事：发布 HTML/Markdown 为 artifact 网页（优先级：P1）
+
+作为用户，我希望把本地已写好的 `.html`/`.md` 文件发布为一个默认私有的可分享网页并拿到 URL，以便把工作成果分享给团队成员。
+
+**为什么是这个优先级**：这是 Artifact 功能的核心价值。
+
+**独立测试**：可以调用 `Artifact` 工具（参数 `file_path` + `favicon`）并 mock 服务端 201 响应，验证工具返回 `{ url, path, title, version }`。
+
+**验收场景**：
+
+1. **假设** model 调用 `Artifact` 工具且参数为 `file_path: "a.html"`、`favicon: "📄"`，文件已存在于磁盘，**当** 发布请求返回 201 时，**则** 工具返回 `{ url, path, title, version }`，其中 `url` 形如 `{host}/code/artifact/{slug}`。
+2. **假设** `file_path` 指向磁盘上不存在的文件，**当** 工具执行时，**则** 返回 `success: false` 与明确的错误消息（提示先 Write/Edit 落盘，不接受内联 content）。
+3. **假设** `file_path` 扩展名不是 `.html` 或 `.md`，**当** 工具执行时，**则** 返回 `success: false` 与扩展名受限的错误。
+4. **假设** `file_path` 是 `.md` 文件，**当** 工具执行时，**则** 客户端先将其渲染为完整 HTML 再上传（服务端只接收完整 HTML）。
+5. **假设** `favicon` 包含非 emoji 字符（如文字、URL、HTML markup），**当** 工具执行时，**则** 返回 `success: false` 与错误提示。
+6. **假设** 发布内容超过 16MB（服务端返回 413），**当** 工具执行时，**则** 返回 `success: false` 与大小超限的错误。
+7. **假设** 客户端未登录（无有效 token），**当** 工具执行时，**则** 返回鉴权错误并提示先登录。
+
+### 用户故事：WebFetch 读取 artifact 页面（优先级：P1）
+
+作为用户，我希望 WebFetch 能识别 artifact URL 并走专用通道读取发布内容，以便 AI 可以基于 artifact 内容回答、排查或继续迭代。
+
+**为什么是这个优先级**：发布与读取构成完整闭环，也是冲突防护（stale_version_guard）的基础。
+
+**验收场景**：
+
+1. **假设** WebFetch 的 `url` 形如 `{host}/code/artifact/{slug}`（匹配 artifact URL 格式），**当** 工具执行时，**则** 走专用读取通道：先 `GET /api/frame/{slug}?via=model_read` 取元数据，再拉取正文，返回页面内容。
+2. **假设** artifact 读取成功，**当** WebFetch 返回结果时，**则** 输出 schema 附带可选 `artifactRead: { slug, ver }` 元数据（`ver` 为当前版本号）。
+3. **假设** artifact HTML 内容较大（超过 ~2KB），**当** WebFetch 执行时，**则** 完整内容落盘到临时文件，返回文件路径 + head 截断预览，避免工具结果过大。
+4. **假设** artifact 不存在或已删除（服务端 404），**当** WebFetch 执行时，**则** 返回 `success: false` 与对应的错误消息。
+5. **假设** 读取接口返回的 `contentUrl` 需要鉴权，**当** WebFetch 拉取正文时，**则** 携带当前登录 token（Bearer）请求。
+
+### 用户故事：重新部署与并发冲突防护（优先级：P2）
+
+作为系统，我希望同一 artifact 的并发发布受版本保护，以便多会话协作时不发生静默覆盖。
+
+**为什么是这个优先级**：多会话同时发布同一 slug 是真实协作场景，409 + stale_version_guard 是 CC 对齐的关键行为。
+
+**验收场景**：
+
+1. **假设** model 调用 `Artifact` 工具且带 `url` 参数（已有 artifact 的 URL），**当** 发布时，**则** 使用该 slug 重新部署，返回包含新 `version` 的结果。
+2. **假设** 重部署时服务端返回 409（`{ conflict: true, live: "<最新版本号>" }`，他人已发布新版），**当** 工具执行时，**则** 返回 `success: false`，错误信息包含 `live` 版本号并提示先 WebFetch 最新内容、和解后重新发布。
+3. **假设** 冲突时 model 带 `force: true` 重发，**当** 工具执行时，**则** 跳过冲突检查直接覆盖发布。
+4. **假设** 同会话内 model 未先 WebFetch 最新版本就重发同一 artifact（stale_version_guard：本地记录的版本落后于服务端），**当** 工具执行时，**则** 返回 `success: false` 阻止发布，除非带 `force: true`。
+5. **假设** 服务端 409 响应携带 `live` 版本号，**当** 冲突错误返回后，**则** 客户端用 `live` 作为下一次发布的 `baseVersion` 重试（供服务端做并发检测）。
+
+### 用户故事：默认私有与分享状态探测（优先级：P2）
+
+作为用户，我希望发布出的页面默认只有我能看到，并且读取时能感知页面的分享状态，以便安全地决定是否传播 URL。
+
+**为什么是这个优先级**：默认私有是 CC 的默认行为，分享状态探测决定发布确认文案与重发布行为。
+
+**验收场景**：
+
+1. **假设** model 首次发布新 artifact 且未指定分享方式，**当** 发布完成时，**则** 页面默认为私有（服务端 `share_mode=owner`）。
+2. **假设** WebFetch 读取 artifact 元数据，**当** 返回结果时，**则** 元数据包含 `perm: { mode, role }`（mode: owner/users/org；role: owner/reader），用于探测当前分享状态。
+3. **假设** 已分享为 shared-live（`shared` 字段为空，读者实时看到更新）的 artifact 被重发布，**当** 工具执行时，**则** 发布确认中提示影响读者可见版本，需用户确认（对齐 CC 行为）。
+
+### 用户故事：发布确认与同会话自动允许（优先级：P2）
+
+作为用户，我希望发布动作默认经过确认、但同会话内的重复发布不再打扰，以便既不误发又保持流畅。
+
+**为什么是这个优先级**：发布是外发动作需确认；同会话重发是常见迭代循环，频繁确认会打断工作流。
+
+**验收场景**：
+
+1. **假设** model 首次发布某文件，**当** 调用 `Artifact` 工具时，**则** 触发权限确认（文案形如 "publish \"<file>\" to a private page"），用户拒绝则取消发布。
+2. **假设** 同会话内 model 再次发布本会话已发布过的文件（`url` 省略，靠会话内 file_path → artifact URL 映射），**当** 调用 `Artifact` 工具时，**则** 自动允许，不再弹确认。
+3. **假设** 会话内映射不存在（本会话未发布过该文件）且用户未配置自动允许，**当** 调用 `Artifact` 工具时，**则** 仍弹确认。
+
+### 用户故事：启用开关与默认禁用（优先级：P2）
+
+作为管理员或内测用户，我希望 Artifact 功能默认不可用、但可显式开启，以便在后端上线前不暴露无效工具，同时支持内测/灰度先行体验。
+
+**为什么是这个优先级**：当前 frame 后端尚未上线，功能需默认禁用（不注册工具、不拦截读取）；内测/灰度通过 `enableArtifact: true` 显式打开（无需改代码）；后端上线后把代码默认值常量翻转为启用（未设置 = 启用，对齐 CC `enableArtifact` 的"未设置跟随功能可用性"语义）。
+
+**验收场景**：
+
+1. **假设** 未配置 `enableArtifact`（默认状态，后端上线前），**当** 会话初始化时，**则** `Artifact` 工具不注册、不可调用。
+2. **假设** settings.json 配置 `enableArtifact: true`，**当** 会话初始化时，**则** `Artifact` 工具注册、可调用（内测/灰度入口）。
+3. **假设** 后端已上线、代码默认值常量已翻转为启用，**当** 会话初始化时，**则** 未配置 `enableArtifact` 也默认启用。
+4. **假设** Artifact 被禁用（默认或显式），**当** WebFetch 收到 artifact URL 时，**则** 不进入专用读取通道（按普通 URL 处理或报错），不执行 `via=model_read` 调用。
+
+### 非功能需求
+
+- **零新增配置**：API 端点相对 Server URL origin 硬编码（`options.serverUrl > WAVE_SERVER_URL > 默认值`，经 authService.getServerUrl() 获取），不新增 baseUrl/artifactUrl 配置项。
+- **鉴权**：发布（deploy/direct）与读取（model_read、contentUrl）请求均携带当前登录 token（Bearer）；未登录返回明确错误。
+- **大小上限**：发布内容上限 16MB（413 透传为友好错误）。
+- **文件大小策略**：读取时 >~2KB 的 HTML 落盘到临时文件（返回路径 + head 预览），避免工具结果膨胀。
+- **只读性**：WebFetch 侧读取行为保持只读，不修改 artifact 内容。
+- **会话映射**：会话内维护 file_path → artifact URL 映射，用于同会话重发免 `url` 参数与 stale_version_guard。
+- **测试**：SDK 层 mock 服务端（201/409/404/413）覆盖发布、重部署、冲突、读取、禁用开关场景。
+
+### 边界情况
+
+- **md → HTML 渲染失败怎么办？** 渲染失败时返回 `success: false` 与渲染错误信息，不发起上传。
+- **未登录时发布/读取怎么办？** 返回鉴权错误并提示先登录（`/login`）。
+- **artifact URL 的主机与 Server URL 不一致？** 自托管场景下发布返回的 URL 即当前 Server URL origin 下的 `/code/artifact/{slug}`；WebFetch 按 URL 路径格式 `{host}/code/artifact/{slug}` 识别，读取请求发往同一 origin。
+- **并发发布同一 slug（跨会话）怎么办？** 服务端 409 + `live` 版本号；客户端透传错误并提示先 WebFetch 最新内容，或带 `force: true` 覆盖。
+- **大文件读取的临时文件何时清理？** 沿用现有工具临时文件生命周期管理，不引入独立清理机制。
+- **与 disallowedTools 的关系？** `enableArtifact` 是独立功能开关（未设置跟随默认值常量）；disallowedTools 对 Artifact 工具的显式禁用仍生效（两者取并集）。
+- **Artifact 工具是受限工具吗？** 是——发布是外发网络动作，需加入 RESTRICTED_TOOLS 以触发默认模式的确认流程。

--- a/packages/agent-sdk/examples/tools/artifact-demo.ts
+++ b/packages/agent-sdk/examples/tools/artifact-demo.ts
@@ -1,0 +1,300 @@
+#!/usr/bin/env tsx
+
+/**
+ * Artifact 工具端到端示例（真实服务端）
+ *
+ * 覆盖链路：
+ * 1. 发布本地 .md 文件为 artifact（Artifact 工具，POST /api/frame/deploy/direct）
+ * 2. 从会话消息历史中提取发布 URL
+ * 3. 直接校验 artifact 内容可读（GET /api/frame/{slug}/content?v={version}）
+ * 4. WebFetch 拦截读取 artifact URL（via=model_read 专用通道）
+ * 5. 同一会话重新发布（版本升级，自动允许不弹确认）
+ *
+ * 前置条件：
+ * - 已登录（~/.wave/auth.json 存在有效 SSO token）
+ * - 已配置服务端地址：WAVE_SERVER_URL 环境变量（或 settings.json env），
+ *   例如 https://codechat.codewave-test.163yun.com
+ * - 服务端 frame 后端已上线（POST /api/frame/deploy/direct 可用）
+ *
+ * 运行：
+ *   cd packages/agent-sdk && pnpm exec tsx examples/tools/artifact-demo.ts
+ */
+
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+import { Agent } from "../../src/agent.js";
+import {
+  authService,
+  createAuthAwareFetch,
+} from "../../src/services/authService.js";
+import type { Message, ToolBlock } from "../../src/types/messaging.js";
+import { ARTIFACT_TOOL_NAME } from "../../src/constants/tools.js";
+
+// Use WAVE_FAST_MODEL for cheaper and faster testing
+process.env.WAVE_MODEL = process.env.WAVE_FAST_MODEL;
+
+let tempDir: string;
+let agent: Agent;
+
+/** 从消息历史中提取最近一次成功的 Artifact 工具调用结果。 */
+function findArtifactResult(messages: Message[]): ToolBlock | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const block = messages[i].blocks.find(
+      (b): b is ToolBlock =>
+        b.type === "tool" &&
+        b.name === "Artifact" &&
+        b.stage === "end" &&
+        b.success === true,
+    );
+    if (block) return block;
+  }
+  return undefined;
+}
+
+/** 从 Artifact 工具结果中提取 artifact URL。 */
+function extractArtifactUrl(result: ToolBlock): string | null {
+  const text = `${result.shortResult || ""}\n${result.result || ""}`;
+  const match = text.match(/https?:\/\/[^\s]+\/code\/artifact\/[^\s]+/);
+  return match ? match[0] : null;
+}
+
+/** 从 artifact URL 提取 slug（{host}/code/artifact/{slug}）。 */
+function extractSlug(url: string): string | null {
+  try {
+    const match = new URL(url).pathname.match(/^\/code\/artifact\/([^/]+)\/?$/);
+    return match ? decodeURIComponent(match[1]) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function setupTest() {
+  // 创建临时目录作为工作目录
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "artifact-demo-"));
+  console.log(`📁 Created temporary directory: ${tempDir}`);
+
+  // 项目级 settings.json 开启 Artifact（未设置时跟随代码默认值，当前默认禁用）
+  await fs.mkdir(path.join(tempDir, ".wave"), { recursive: true });
+  await fs.writeFile(
+    path.join(tempDir, ".wave", "settings.json"),
+    JSON.stringify({ enableArtifact: true }, null, 2),
+  );
+
+  // 创建要发布的 Markdown 文件
+  const md = `# Wave Artifact Demo
+
+This page was published by the **Artifact tool** end-to-end example.
+
+- Supports Markdown rendering
+- Private by default
+- Redeployable in the same session
+
+\`\`\`ts
+const published = await artifactTool.execute(...);
+\`\`\`
+`;
+  await fs.writeFile(path.join(tempDir, "guide.md"), md, "utf-8");
+  console.log(`📝 Created guide.md (${md.length} chars)`);
+
+  if (!authService.getSSOToken()) {
+    throw new Error(
+      "Not authenticated — run /login first, or ensure ~/.wave/auth.json has a valid token.",
+    );
+  }
+  console.log(`🔑 Authenticated. Server: ${authService.getServerUrl()}`);
+
+  // 创建 Agent
+  agent = await Agent.create({
+    workdir: tempDir,
+    model: process.env.WAVE_FAST_MODEL,
+    permissionMode: "bypassPermissions", // 示例自动运行，跳过确认弹窗
+    callbacks: {
+      onAssistantContentUpdated: (params: { chunk: string }) => {
+        process.stdout.write(params.chunk);
+      },
+      onToolBlockUpdated: (params) => {
+        if (params.stage === "start") {
+          console.log(`\n🔧 Calling tool ${params.name}...`);
+        } else if (params.stage === "end") {
+          if (params.success) {
+            console.log(`\n✅ Tool ${params.name} succeeded`);
+          } else {
+            console.log(`\n❌ Tool ${params.name} failed: ${params.error}`);
+          }
+        }
+      },
+    },
+  });
+
+  // 确认 Artifact 工具已注册（enableArtifact 生效）
+  const available = agent.getAvailableToolNames();
+  if (!available.includes(ARTIFACT_TOOL_NAME)) {
+    throw new Error(
+      `Artifact tool is NOT registered. Available tools: ${available.join(", ")}.\n` +
+        "Check that the project .wave/settings.json contains enableArtifact: true.",
+    );
+  }
+  console.log(`🧩 Artifact tool registered (${available.length} tools total)`);
+}
+
+async function runTest() {
+  // ---- 1. 发布 ----
+  console.log("\n💬 Step 1: Publishing guide.md as an artifact...");
+  await agent.sendMessage(
+    'You MUST call the Artifact tool directly with file_path="guide.md" and favicon="📘". ' +
+      "The Artifact tool is already registered and is the ONLY acceptable way to publish. " +
+      "Do NOT use Bash, curl, Read, Write, or any other tool to publish the file. " +
+      "After the Artifact tool returns, report the URL it returned.",
+  );
+
+  const publishResult = findArtifactResult(agent.messages);
+  const publishUrl = publishResult ? extractArtifactUrl(publishResult) : null;
+  if (!publishUrl) {
+    throw new Error(
+      "Failed to extract artifact URL from tool result.\n" +
+        `Tool result: ${JSON.stringify(publishResult?.result || publishResult?.shortResult || publishResult?.error)}`,
+    );
+  }
+  console.log(`🔗 Published artifact URL: ${publishUrl}`);
+
+  const slug = extractSlug(publishUrl);
+  if (!slug) throw new Error(`Cannot parse slug from URL: ${publishUrl}`);
+
+  // ---- 2. 直接校验内容可读 ----
+  console.log("\n💬 Step 2: Verifying artifact content is readable...");
+  const authFetch = createAuthAwareFetch(globalThis.fetch);
+  const serverUrl = authService.getServerUrl();
+  const metaRes = await authFetch(
+    `${serverUrl}/api/frame/${encodeURIComponent(slug)}?via=model_read`,
+    { method: "GET" },
+  );
+  if (!metaRes.ok) {
+    throw new Error(`Metadata probe failed: HTTP ${metaRes.status}`);
+  }
+  const meta = (await metaRes.json()) as {
+    version: number;
+    contentUrl?: string;
+    perm?: { mode: string };
+  };
+  console.log(`   Metadata: version=${meta.version}, perm=${meta.perm?.mode}`);
+  if (!meta.contentUrl) throw new Error("Metadata missing contentUrl");
+
+  const contentRes = await authFetch(meta.contentUrl, { method: "GET" });
+  if (!contentRes.ok) {
+    throw new Error(`Content fetch failed: HTTP ${contentRes.status}`);
+  }
+  const html = await contentRes.text();
+  if (!html.includes("Wave Artifact Demo") || !html.includes("<h1>")) {
+    throw new Error("Published content does not match the source markdown");
+  }
+  console.log(`   Content OK (${html.length} bytes, contains title + <h1>)`);
+
+  // ---- 3. WebFetch 拦截读取 artifact URL ----
+  console.log("\n💬 Step 3: WebFetch reading the artifact URL...");
+  await agent.sendMessage(
+    `You MUST use the WebFetch tool to fetch ${publishUrl} and tell me what the artifact page contains. ` +
+      "Do NOT use Bash or curl — WebFetch is the only acceptable way to read the page.",
+  );
+
+  // ---- 4. 同一会话重新发布 ----
+  console.log("\n💬 Step 4: Republishing with updated content...");
+  const updated = `# Wave Artifact Demo v2
+
+Updated in the same session — the version should bump and the old URL stays valid.
+`;
+  await fs.writeFile(path.join(tempDir, "guide.md"), updated, "utf-8");
+  await agent.sendMessage(
+    `You MUST call the Artifact tool directly to republish "guide.md" to the same artifact URL: ${publishUrl}. ` +
+      "The Artifact tool is the ONLY acceptable way to republish — do NOT use Bash, curl, Read, Write, or any other tool. " +
+      "After the Artifact tool returns, report the URL it returned.",
+  );
+
+  const redeployResult = findArtifactResult(agent.messages);
+  const redeployUrl = redeployResult
+    ? extractArtifactUrl(redeployResult)
+    : null;
+  if (!redeployUrl) {
+    throw new Error(
+      "Failed to extract redeploy URL from tool result.\n" +
+        `Tool result: ${JSON.stringify(redeployResult?.result || redeployResult?.shortResult || redeployResult?.error)}`,
+    );
+  }
+  console.log(`🔗 Redeployed artifact URL: ${redeployUrl}`);
+  if (redeployUrl !== publishUrl) {
+    throw new Error(
+      `Redeploy URL mismatch: expected ${publishUrl}, got ${redeployUrl}`,
+    );
+  }
+
+  // 校验版本升级 + 新内容
+  const metaRes2 = await authFetch(
+    `${serverUrl}/api/frame/${encodeURIComponent(slug)}?via=model_read`,
+    { method: "GET" },
+  );
+  const meta2 = (await metaRes2.json()) as {
+    version: number;
+    contentUrl?: string;
+  };
+  if (meta2.version <= meta.version) {
+    throw new Error(
+      `Version did not bump: expected > ${meta.version}, got ${meta2.version}`,
+    );
+  }
+  console.log(`   Version bumped: ${meta.version} → ${meta2.version}`);
+
+  const contentRes2 = await authFetch(meta2.contentUrl!, { method: "GET" });
+  const html2 = await contentRes2.text();
+  if (!html2.includes("v2")) {
+    throw new Error("Redeployed content does not contain the updated text");
+  }
+  console.log(`   Redeployed content OK (${html2.length} bytes)`);
+
+  console.log("\n🎉 All artifact checks passed!");
+}
+
+async function cleanup() {
+  console.log("\n🧹 Cleaning up...");
+  try {
+    if (agent) {
+      await agent.destroy();
+      console.log("✅ Agent cleaned up");
+    }
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      console.log(`🗑️ Cleaned up temporary directory: ${tempDir}`);
+    }
+  } catch (cleanupError) {
+    console.error("❌ Cleanup failed:", cleanupError);
+  }
+}
+
+async function main() {
+  try {
+    await setupTest();
+    await runTest();
+  } catch (error) {
+    console.error("❌ Test failed:", error);
+  } finally {
+    await cleanup();
+    console.log("👋 Done!");
+    process.exit(0);
+  }
+}
+
+// Handle process exit
+process.on("SIGINT", async () => {
+  console.log("\n\n🛑 Received SIGINT, cleaning up...");
+  await cleanup();
+  process.exit(0);
+});
+
+// Run main function
+main()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error("💥 Unhandled error:", error);
+    process.exit(1);
+  });

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -65,6 +65,7 @@
     "fuzzysort": "^3.1.0",
     "glob": "^13.0.0",
     "lru-cache": "^11.3.5",
+    "marked": "^17.0.2",
     "minimatch": "^10.0.3",
     "openai": "^5.12.2",
     "turndown": "^7.2.2"

--- a/packages/agent-sdk/src/constants/tools.ts
+++ b/packages/agent-sdk/src/constants/tools.ts
@@ -22,3 +22,4 @@ export const WEB_FETCH_TOOL_NAME = "WebFetch";
 export const ENTER_WORKTREE_TOOL_NAME = "EnterWorktree";
 export const EXIT_WORKTREE_TOOL_NAME = "ExitWorktree";
 export const WORKFLOW_TOOL_NAME = "Workflow";
+export const ARTIFACT_TOOL_NAME = "Artifact";

--- a/packages/agent-sdk/src/managers/toolManager.ts
+++ b/packages/agent-sdk/src/managers/toolManager.ts
@@ -10,6 +10,8 @@ import { cronCreateTool } from "../tools/cronCreateTool.js";
 import { cronDeleteTool } from "../tools/cronDeleteTool.js";
 import { cronListTool } from "../tools/cronListTool.js";
 import { webFetchTool } from "../tools/webFetchTool.js";
+import { artifactTool } from "../tools/artifactTool.js";
+import { isArtifactEnabled } from "../services/artifactAvailability.js";
 // New tools
 import { globTool } from "../tools/globTool.js";
 import { grepTool } from "../tools/grepTool.js";
@@ -135,6 +137,12 @@ class ToolManager {
       exitWorktreeTool,
       workflowTool,
     ];
+
+    // Artifact is a feature-gated tool: not registered at all while the frame
+    // backend is not live, unless settings.json opts in via enableArtifact: true.
+    if (isArtifactEnabled(this.container.get<string>("Workdir"))) {
+      builtInTools.push(artifactTool);
+    }
 
     for (const tool of builtInTools) {
       if (this.shouldEnableTool(tool.name)) {

--- a/packages/agent-sdk/src/services/artifactAvailability.ts
+++ b/packages/agent-sdk/src/services/artifactAvailability.ts
@@ -1,0 +1,28 @@
+/**
+ * Artifact feature availability.
+ *
+ * The frame backend (`POST /api/frame/deploy/direct`) is not live yet, so the
+ * code default is DISABLED. Internal beta / gradual rollout enables the feature
+ * via settings.json `enableArtifact: true` without code changes. Once the
+ * backend goes live, flip `ARTIFACT_DEFAULT_ENABLED` to `true` so an unset
+ * `enableArtifact` defaults to enabled (matching Claude Code's `enableArtifact`
+ * "unset follows feature availability" semantics).
+ */
+import { loadMergedWaveConfig } from "./configurationService.js";
+
+/** Code default for Artifact availability. Flip to true after the frame backend goes live. */
+export const ARTIFACT_DEFAULT_ENABLED = false;
+
+/**
+ * Whether the Artifact tool should be registered / usable for the given workdir.
+ * Explicit `enableArtifact` in merged settings wins over the code default.
+ */
+export function isArtifactEnabled(workdir?: string): boolean {
+  if (workdir) {
+    const config = loadMergedWaveConfig(workdir);
+    if (config?.enableArtifact !== undefined) {
+      return config.enableArtifact;
+    }
+  }
+  return ARTIFACT_DEFAULT_ENABLED;
+}

--- a/packages/agent-sdk/src/services/artifactSession.ts
+++ b/packages/agent-sdk/src/services/artifactSession.ts
@@ -1,0 +1,80 @@
+/**
+ * Session-scoped state shared between the Artifact tool and the WebFetch tool.
+ *
+ * - file_path → artifact record: lets a model republish a file it already
+ *   published this session without passing `url` again, and enables the
+ *   same-session auto-allow (the publish was already confirmed once).
+ * - slug → latest known version: powers the stale-version guard
+ *   (local knowledge older than the live version blocks a redeploy
+ *   unless `force` is set) and lets WebFetch record versions it observed.
+ *
+ * State is keyed by sessionId so parallel sessions never observe each other.
+ */
+
+export interface ArtifactRecord {
+  url: string;
+  slug: string;
+  version: string;
+}
+
+const sessionArtifacts = new Map<string, Map<string, ArtifactRecord>>();
+const sessionSlugVersions = new Map<string, Map<string, string>>();
+
+function fileMapFor(sessionId: string): Map<string, ArtifactRecord> {
+  let map = sessionArtifacts.get(sessionId);
+  if (!map) {
+    map = new Map();
+    sessionArtifacts.set(sessionId, map);
+  }
+  return map;
+}
+
+function slugMapFor(sessionId: string): Map<string, string> {
+  let map = sessionSlugVersions.get(sessionId);
+  if (!map) {
+    map = new Map();
+    sessionSlugVersions.set(sessionId, map);
+  }
+  return map;
+}
+
+/** Record a successful publish so same-session republishes auto-allow. */
+export function recordArtifact(
+  sessionId: string,
+  filePath: string,
+  record: ArtifactRecord,
+): void {
+  fileMapFor(sessionId).set(filePath, record);
+  slugMapFor(sessionId).set(record.slug, record.version);
+}
+
+/** Look up an artifact previously published in this session by file path. */
+export function getArtifactByFilePath(
+  sessionId: string,
+  filePath: string,
+): ArtifactRecord | undefined {
+  return sessionArtifacts.get(sessionId)?.get(filePath);
+}
+
+/** Latest version of a slug this session has observed (publish, conflict, or read). */
+export function getRecordedVersion(
+  sessionId: string,
+  slug: string,
+): string | undefined {
+  return sessionSlugVersions.get(sessionId)?.get(slug);
+}
+
+/** Record an observed version (from a publish, a 409 conflict, or a WebFetch read). */
+export function recordVersion(
+  sessionId: string,
+  slug: string,
+  version: string,
+): void {
+  slugMapFor(sessionId).set(slug, version);
+}
+
+/** Clear all session-scoped artifact state (used when a session ends). */
+export function clearArtifactSession(sessionId: string): void {
+  sessionArtifacts.delete(sessionId);
+  sessionSlugVersions.delete(sessionId);
+}

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -1316,9 +1316,15 @@ export function loadWaveConfigFromFile(
         config.autoMemoryEnabled !== undefined
           ? config.autoMemoryEnabled
           : undefined,
+      autoMemoryFrequency:
+        config.autoMemoryFrequency !== undefined
+          ? config.autoMemoryFrequency
+          : undefined,
       models: config.models || undefined,
       marketplaces: config.marketplaces || undefined,
       worktree: config.worktree || undefined,
+      enableArtifact:
+        config.enableArtifact !== undefined ? config.enableArtifact : undefined,
     };
   } catch (error) {
     if (error instanceof SyntaxError) {
@@ -1483,6 +1489,11 @@ export function loadMergedWaveConfig(
       mergedConfig.worktree = config.worktree;
     }
 
+    // Merge enableArtifact (last one wins)
+    if (config.enableArtifact !== undefined) {
+      mergedConfig.enableArtifact = config.enableArtifact;
+    }
+
     // Merge models
     if (config.models) {
       if (!mergedConfig.models) mergedConfig.models = {};
@@ -1527,5 +1538,6 @@ export function loadMergedWaveConfig(
         ? mergedConfig.models
         : undefined,
     worktree: mergedConfig.worktree,
+    enableArtifact: mergedConfig.enableArtifact,
   };
 }

--- a/packages/agent-sdk/src/tools/artifactTool.ts
+++ b/packages/agent-sdk/src/tools/artifactTool.ts
@@ -1,0 +1,441 @@
+import { readFileSync } from "fs";
+import path from "path";
+import { marked } from "marked";
+import { ARTIFACT_TOOL_NAME } from "../constants/tools.js";
+import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
+import { authService, createAuthAwareFetch } from "../services/authService.js";
+import { logger } from "../utils/globalLogger.js";
+import {
+  recordArtifact,
+  getArtifactByFilePath,
+  getRecordedVersion,
+  recordVersion,
+} from "../services/artifactSession.js";
+
+// --- Limits ---
+const DEPLOY_TIMEOUT_MS = 30_000;
+const PROBE_TIMEOUT_MS = 15_000;
+/** Server-side content limit — POSTs above this get a 413. */
+const ARTIFACT_MAX_CONTENT_BYTES = 16 * 1024 * 1024; // 16MB
+const LABEL_MAX_LENGTH = 60;
+const DEFAULT_FAVICON = "📄";
+
+/** Server response shape for a successful deploy (HTTP 201). */
+interface DeployResponse {
+  url: string;
+  slug: string;
+  path?: string;
+  title?: string;
+  version: string;
+}
+
+/** Frame metadata returned by `GET /api/frame/{slug}?via=model_read`. */
+interface FrameMeta {
+  slug: string;
+  version: string;
+  title?: string;
+  favicon?: string;
+  perm?: { mode: "owner" | "users" | "org"; role?: string };
+  url?: string;
+  contentUrl?: string;
+  /** Empty/missing = shared-live (readers see live updates); non-empty = pinned. */
+  shared?: string;
+}
+
+function isValidFavicon(favicon: string): boolean {
+  if (!favicon || favicon.trim().length === 0) return false;
+  // Count code points excluding variation selectors (👨‍👩‍👧 counts as 3 and is
+  // rejected — only simple 1-2 emoji are accepted per the server contract).
+  const codePoints = [...favicon].filter((cp) => cp !== "\uFE0F");
+  if (codePoints.length < 1 || codePoints.length > 2) return false;
+  return codePoints.every((cp) => {
+    // \p{Emoji} also matches ASCII digits/letters — plain text is not an emoji.
+    if (/[A-Za-z0-9]/.test(cp)) return false;
+    return /\p{Emoji}/u.test(cp);
+  });
+}
+
+/** Extract the artifact slug from a `{host}/code/artifact/{slug}` URL. */
+function extractSlugFromUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const match = parsed.pathname.match(/^\/code\/artifact\/([^/]+)\/?$/);
+    return match ? decodeURIComponent(match[1]) : null;
+  } catch {
+    return null;
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[
+        c
+      ]!,
+  );
+}
+
+/** Render Markdown to a complete HTML document (client-side md→HTML). */
+function renderMarkdown(md: string, title?: string): string {
+  const body = marked.parse(md, { async: false }) as string;
+  const titleTag = title ? `<title>${escapeHtml(title)}</title>` : "";
+  return `<!DOCTYPE html><html lang="zh-CN"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">${titleTag}</head><body>${body}</body></html>`;
+}
+
+/** Probe an artifact's current metadata (`via=model_read` marks model access). */
+async function probeFrame(
+  slug: string,
+  signal: AbortSignal,
+): Promise<FrameMeta | null> {
+  const serverUrl = authService.getServerUrl();
+  const authFetch = createAuthAwareFetch(globalThis.fetch);
+  try {
+    const res = await authFetch(
+      `${serverUrl}/api/frame/${encodeURIComponent(slug)}?via=model_read`,
+      { method: "GET", signal },
+    );
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      logger?.warn("Artifact probe failed", {
+        slug,
+        status: res.status,
+        statusText: res.statusText,
+      });
+      return null;
+    }
+    return (await res.json()) as FrameMeta;
+  } catch (err) {
+    logger?.warn("Artifact probe error", { slug, error: String(err) });
+    return null;
+  }
+}
+
+export const artifactTool: ToolPlugin = {
+  name: ARTIFACT_TOOL_NAME,
+  isConcurrencySafe: false,
+  config: {
+    type: "function",
+    function: {
+      name: ARTIFACT_TOOL_NAME,
+      description:
+        "Publish local HTML or Markdown files as shareable web pages (artifacts). " +
+        "Each publish returns a private URL you can share; the page is only accessible to you " +
+        "unless you change its sharing. Only .html and .md files are supported — inline content " +
+        "is not accepted. Markdown files are rendered to HTML automatically. " +
+        "Pass `url` (an existing artifact URL) to redeploy that artifact, " +
+        "or omit it to republish a file already published in this session. " +
+        "Use `force` to overwrite an artifact that has been updated by someone else.",
+      parameters: {
+        type: "object",
+        properties: {
+          file_path: {
+            type: "string",
+            description:
+              "Path to the .html or .md file to publish (relative to the working directory). The file must exist.",
+          },
+          favicon: {
+            type: "string",
+            description:
+              "1-2 emoji characters shown as the page favicon (no text, URLs, or HTML). Defaults to 📄.",
+          },
+          label: {
+            type: "string",
+            description: `Optional short label for the artifact (max ${LABEL_MAX_LENGTH} characters).`,
+          },
+          url: {
+            type: "string",
+            description:
+              "Existing artifact URL to redeploy, e.g. https://host/code/artifact/abc123. Omit when republishing a file already published earlier in this session.",
+          },
+          force: {
+            type: "boolean",
+            description:
+              "Set true to overwrite an artifact that was updated since this session last saw it (stale version or conflict).",
+          },
+        },
+        required: ["file_path"],
+      },
+    },
+  },
+  formatCompactParams: (params: Record<string, unknown>) => {
+    const filePath =
+      typeof params.file_path === "string" ? params.file_path : "";
+    const url = typeof params.url === "string" ? params.url : "";
+    return `${ARTIFACT_TOOL_NAME}(${filePath}${url ? ` → ${url}` : ""})`;
+  },
+  execute: async (
+    args: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<ToolResult> => {
+    const filePath =
+      typeof args.file_path === "string" ? args.file_path.trim() : "";
+    if (!filePath) {
+      return {
+        success: false,
+        content: "",
+        error: `${ARTIFACT_TOOL_NAME}: missing required parameter "file_path"`,
+      };
+    }
+
+    const faviconRaw =
+      typeof args.favicon === "string" ? args.favicon.trim() : "";
+    const favicon = faviconRaw || DEFAULT_FAVICON;
+    if (!isValidFavicon(favicon)) {
+      return {
+        success: false,
+        content: "",
+        error: `${ARTIFACT_TOOL_NAME}: favicon must be 1-2 emoji characters (e.g. "📄" or "🔖"), no text, URLs, or HTML markup`,
+      };
+    }
+
+    const labelRaw = typeof args.label === "string" ? args.label.trim() : "";
+    const label = labelRaw || undefined;
+    if (label !== undefined && label.length > LABEL_MAX_LENGTH) {
+      return {
+        success: false,
+        content: "",
+        error: `${ARTIFACT_TOOL_NAME}: label must be at most ${LABEL_MAX_LENGTH} characters (got ${label.length})`,
+      };
+    }
+
+    const force = args.force === true;
+    const urlRaw = typeof args.url === "string" ? args.url.trim() : "";
+    const url = urlRaw || undefined;
+    let slug: string | null | undefined;
+    if (url) {
+      slug = extractSlugFromUrl(url);
+      if (!slug) {
+        return {
+          success: false,
+          content: "",
+          error: `${ARTIFACT_TOOL_NAME}: url must point to an artifact page ({host}/code/artifact/{slug})`,
+        };
+      }
+    }
+
+    // Resolve and read the file (relative to the workdir).
+    const absolutePath = path.resolve(context.workdir, filePath);
+    const ext = path.extname(absolutePath).toLowerCase();
+    if (ext !== ".html" && ext !== ".md") {
+      return {
+        success: false,
+        content: "",
+        error: `${ARTIFACT_TOOL_NAME}: only .html and .md files can be published as artifacts (got "${ext || "no extension"}")`,
+      };
+    }
+    let fileContent: string;
+    try {
+      fileContent = readFileSync(absolutePath, "utf-8");
+    } catch {
+      return {
+        success: false,
+        content: "",
+        error: `${ARTIFACT_TOOL_NAME}: file not found or unreadable: ${filePath}`,
+      };
+    }
+
+    const content =
+      ext === ".md" ? renderMarkdown(fileContent, label) : fileContent;
+    const contentBytes = Buffer.byteLength(content, "utf-8");
+    if (contentBytes > ARTIFACT_MAX_CONTENT_BYTES) {
+      return {
+        success: false,
+        content: "",
+        error: `${ARTIFACT_TOOL_NAME}: content exceeds the ${Math.floor(ARTIFACT_MAX_CONTENT_BYTES / 1024 / 1024)}MB server limit (${(contentBytes / 1024 / 1024).toFixed(1)}MB). Reduce the file or split it up.`,
+      };
+    }
+
+    if (!authService.getSSOToken()) {
+      return {
+        success: false,
+        content: "",
+        error: `${ARTIFACT_TOOL_NAME}: not authenticated. Run /login to connect your account before publishing artifacts.`,
+      };
+    }
+
+    const sessionId = context.sessionId || "";
+    const signal = context.abortSignal
+      ? AbortSignal.any([
+          context.abortSignal,
+          AbortSignal.timeout(DEPLOY_TIMEOUT_MS),
+        ])
+      : AbortSignal.timeout(DEPLOY_TIMEOUT_MS);
+
+    // Redeploy: probe current metadata for baseVersion, shared-live detection,
+    // and the stale-version guard.
+    let serverVersion: string | undefined;
+    let sharedLive = false;
+    if (url && slug) {
+      const meta = await probeFrame(
+        slug,
+        AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      );
+      if (!meta) {
+        return {
+          success: false,
+          content: "",
+          error: `${ARTIFACT_TOOL_NAME}: artifact not found at ${url}. It may have been deleted or the URL is invalid.`,
+        };
+      }
+      serverVersion = meta.version;
+      sharedLive = !!(meta.perm && meta.perm.mode !== "owner" && !meta.shared);
+      const recorded = getRecordedVersion(sessionId, slug);
+      if (recorded !== undefined && recorded !== meta.version && !force) {
+        return {
+          success: false,
+          content: "",
+          error: `${ARTIFACT_TOOL_NAME}: stale version — this artifact has been updated to version ${meta.version} since this session last saw version ${recorded}. Pass "force": true to overwrite it anyway.`,
+        };
+      }
+    }
+
+    // Permission check: first publish and shared-live redeploys require
+    // confirmation; republishing a file/artifact this session already
+    // confirmed once auto-allows (matching Claude Code's behavior).
+    const publishedThisSession =
+      !!getArtifactByFilePath(sessionId, filePath) ||
+      (slug ? getRecordedVersion(sessionId, slug) !== undefined : false);
+    const needsConfirm = !publishedThisSession || sharedLive;
+
+    if (context.permissionManager && needsConfirm) {
+      const permissionContext = context.permissionManager.createContext(
+        ARTIFACT_TOOL_NAME,
+        context.permissionMode || "default",
+        context.canUseToolCallback,
+        {
+          file_path: filePath,
+          ...(favicon !== DEFAULT_FAVICON ? { favicon } : {}),
+          ...(label !== undefined ? { label } : {}),
+          ...(url !== undefined ? { url } : {}),
+          ...(force ? { force: true } : {}),
+        },
+        context.toolCallId,
+      );
+      if (sharedLive) {
+        permissionContext.warning =
+          "此 artifact 处于 shared-live 状态（共享且实时更新），重新部署后所有访问者都会立即看到新内容。";
+        permissionContext.hidePersistentOption = true;
+      }
+      const permissionResult =
+        await context.permissionManager.checkPermission(permissionContext);
+      if (permissionResult.behavior === "deny") {
+        return {
+          success: false,
+          content: "",
+          error: `${ARTIFACT_TOOL_NAME} operation denied by user, reason: ${permissionResult.message || "No reason provided"}`,
+        };
+      }
+    }
+
+    // Deploy.
+    const serverUrl = authService.getServerUrl();
+    const authFetch = createAuthAwareFetch(globalThis.fetch);
+    const body: Record<string, unknown> = {
+      content,
+      favicon,
+      ...(label !== undefined ? { label } : {}),
+      ...(url !== undefined ? { url } : {}),
+      ...(serverVersion !== undefined ? { baseVersion: serverVersion } : {}),
+      ...(force ? { force: true } : {}),
+    };
+
+    let res: Response;
+    try {
+      res = await authFetch(`${serverUrl}/api/frame/deploy/direct`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal,
+      });
+    } catch (err) {
+      logger?.warn("Artifact deploy request failed", { error: String(err) });
+      return {
+        success: false,
+        content: "",
+        error: `${ARTIFACT_TOOL_NAME}: failed to reach the server: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    const data = (await res.json().catch(() => ({}))) as Record<
+      string,
+      unknown
+    >;
+
+    if (res.status === 201) {
+      const deploy = data as unknown as DeployResponse;
+      recordArtifact(sessionId, filePath, {
+        url: deploy.url,
+        slug: deploy.slug,
+        version: deploy.version,
+      });
+      const lines = [`Artifact published: ${deploy.url}`];
+      if (deploy.path) lines.push(`Path: ${deploy.path}`);
+      if (deploy.title) lines.push(`Title: ${deploy.title}`);
+      lines.push(`Version: ${deploy.version}`);
+      return {
+        success: true,
+        content: lines.join("\n"),
+        shortResult: `Published ${filePath} → ${deploy.url}`,
+      };
+    }
+
+    if (res.status === 409) {
+      const live = typeof data.live === "string" ? data.live : undefined;
+      if (live && slug) {
+        recordVersion(sessionId, slug, live);
+      }
+      const serverMessage =
+        typeof data.message === "string"
+          ? data.message
+          : typeof data.error === "string"
+            ? data.error
+            : "the artifact has been updated by someone else";
+      return {
+        success: false,
+        content: "",
+        error: `${ARTIFACT_TOOL_NAME}: conflict detected — ${serverMessage}${live ? ` (live version: ${live})` : ""}. Pass "force": true to overwrite the live version.`,
+      };
+    }
+
+    if (res.status === 413) {
+      return {
+        success: false,
+        content: "",
+        error: `${ARTIFACT_TOOL_NAME}: the published content is too large (server limit is 16MB). Reduce the file or split it up.`,
+      };
+    }
+
+    if (res.status === 400) {
+      const serverMessage =
+        typeof data.message === "string"
+          ? data.message
+          : typeof data.error === "string"
+            ? data.error
+            : "the server rejected the content";
+      return {
+        success: false,
+        content: "",
+        error: `${ARTIFACT_TOOL_NAME}: the server rejected the publish — ${serverMessage}`,
+      };
+    }
+
+    if (res.status === 401 || res.status === 403) {
+      return {
+        success: false,
+        content: "",
+        error: `${ARTIFACT_TOOL_NAME}: authentication failed (HTTP ${res.status}). Run /login again and retry.`,
+      };
+    }
+
+    logger?.warn("Artifact deploy unexpected status", {
+      status: res.status,
+      statusText: res.statusText,
+    });
+    return {
+      success: false,
+      content: "",
+      error: `${ARTIFACT_TOOL_NAME}: server returned HTTP ${res.status} ${res.statusText}`,
+    };
+  },
+};

--- a/packages/agent-sdk/src/tools/webFetchTool.ts
+++ b/packages/agent-sdk/src/tools/webFetchTool.ts
@@ -3,6 +3,14 @@ import { LRUCache } from "lru-cache";
 import { WEB_FETCH_TOOL_NAME } from "../constants/tools.js";
 import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
 import { logger } from "../utils/globalLogger.js";
+import { isArtifactEnabled } from "../services/artifactAvailability.js";
+import { authService, createAuthAwareFetch } from "../services/authService.js";
+import { recordVersion } from "../services/artifactSession.js";
+import {
+  buildPersistedOutputMessage,
+  generatePreview,
+  persistToolResult,
+} from "../utils/toolResultStorage.js";
 
 // --- Security Limits ---
 const MAX_HTTP_CONTENT_LENGTH = 10 * 1024 * 1024; // 10MB
@@ -10,6 +18,8 @@ const FETCH_TIMEOUT_MS = 60_000; // 60s
 const MAX_REDIRECTS = 10;
 const MAX_MARKDOWN_LENGTH = 100_000;
 const USER_AGENT = "Wave-User (+https://github.com/netease-lcap/wave-agent)";
+/** Artifact HTML beyond this size is persisted to a temp file (path + head preview). */
+const ARTIFACT_PREVIEW_BYTES = 2 * 1024; // ~2KB
 
 // --- Cache (LRU with 15min TTL, 50MB max) ---
 const CACHE_TTL = 15 * 60 * 1000; // 15 minutes
@@ -96,6 +106,168 @@ function isPermittedRedirect(
   }
 }
 
+// --- Artifact read channel ---
+
+/** Extract the artifact slug from a `{host}/code/artifact/{slug}` URL. */
+function extractArtifactSlug(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const match = parsed.pathname.match(/^\/code\/artifact\/([^/]+)\/?$/);
+    return match ? decodeURIComponent(match[1]) : null;
+  } catch {
+    return null;
+  }
+}
+
+type ArtifactReadResult =
+  | {
+      kind: "ok";
+      slug: string;
+      version: string;
+      markdown: string;
+      bytes: number;
+    }
+  | { kind: "error"; error: string };
+
+/**
+ * Fetch artifact metadata (`via=model_read`) then the HTML content (Bearer).
+ * Returns markdown (HTML converted via turndown) on success.
+ */
+async function readArtifact(
+  url: string,
+  slug: string,
+  abortSignal?: AbortSignal,
+): Promise<ArtifactReadResult> {
+  const serverUrl = authService.getServerUrl();
+  const authFetch = createAuthAwareFetch(globalThis.fetch);
+  const signal = abortSignal
+    ? AbortSignal.any([abortSignal, AbortSignal.timeout(FETCH_TIMEOUT_MS)])
+    : AbortSignal.timeout(FETCH_TIMEOUT_MS);
+
+  let meta: Record<string, unknown>;
+  try {
+    const metaRes = await authFetch(
+      `${serverUrl}/api/frame/${encodeURIComponent(slug)}?via=model_read`,
+      { method: "GET", signal },
+    );
+    if (metaRes.status === 404) {
+      return {
+        kind: "error",
+        error: `Artifact not found: ${url} (it may have been deleted)`,
+      };
+    }
+    if (!metaRes.ok) {
+      return {
+        kind: "error",
+        error: `Failed to fetch artifact metadata: ${metaRes.status} ${metaRes.statusText}`,
+      };
+    }
+    meta = (await metaRes.json()) as Record<string, unknown>;
+  } catch (error) {
+    logger?.warn("Artifact read metadata failed", {
+      slug,
+      error: String(error),
+    });
+    return {
+      kind: "error",
+      error: `Failed to fetch artifact metadata: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  const contentUrl = typeof meta.contentUrl === "string" ? meta.contentUrl : "";
+  const version = typeof meta.version === "string" ? meta.version : "";
+  if (!contentUrl) {
+    return {
+      kind: "error",
+      error: "Artifact metadata did not include a contentUrl",
+    };
+  }
+
+  let html: string;
+  try {
+    const contentRes = await authFetch(
+      new URL(contentUrl, serverUrl).toString(),
+      { method: "GET", signal },
+    );
+    if (!contentRes.ok) {
+      return {
+        kind: "error",
+        error: `Failed to fetch artifact content: ${contentRes.status} ${contentRes.statusText}`,
+      };
+    }
+    html = await contentRes.text();
+  } catch (error) {
+    logger?.warn("Artifact read content failed", {
+      slug,
+      error: String(error),
+    });
+    return {
+      kind: "error",
+      error: `Failed to fetch artifact content: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  const turndownService = new TurndownService();
+  const markdown = turndownService.turndown(html);
+  return {
+    kind: "ok",
+    slug,
+    version,
+    markdown,
+    bytes: new TextEncoder().encode(markdown).length,
+  };
+}
+
+/**
+ * Process an artifact read result: persist content >~2KB to a temp file
+ * (return file path + head preview), run the prompt, attach artifactRead metadata.
+ */
+async function processArtifactRead(
+  url: string,
+  prompt: string,
+  markdown: string,
+  slug: string,
+  version: string,
+  context: ToolContext,
+): Promise<ToolResult> {
+  const bytes = new TextEncoder().encode(markdown).length;
+  let aiInput = markdown;
+  let persistedMessage = "";
+  if (bytes > ARTIFACT_PREVIEW_BYTES) {
+    const filePath = persistToolResult(markdown, "artifact");
+    if (filePath) {
+      persistedMessage = buildPersistedOutputMessage(
+        markdown.length,
+        filePath,
+        generatePreview(markdown),
+      );
+      aiInput = persistedMessage;
+    } else {
+      aiInput =
+        markdown.substring(0, MAX_MARKDOWN_LENGTH) +
+        "\n\n... (content truncated, failed to persist full output)";
+    }
+  }
+
+  const result = await processWithAI(
+    url,
+    prompt,
+    aiInput,
+    200,
+    "OK",
+    context,
+    bytes,
+  );
+  result.metadata = { artifactRead: { slug, ver: version } };
+  if (persistedMessage) {
+    // Append the persisted-output message so the model can Read the full content.
+    result.content = result.content
+      ? result.content + "\n\n" + persistedMessage
+      : persistedMessage;
+  }
+  return result;
+}
+
 // --- Tool ---
 
 export const webFetchTool: ToolPlugin = {
@@ -170,6 +342,35 @@ Usage notes:
         content: "",
         error: validation.error,
       };
+    }
+
+    // Artifact URL interception: {host}/code/artifact/{slug} goes through the
+    // dedicated read channel (via=model_read + Bearer) instead of a public fetch.
+    // Only when the Artifact tool is enabled (spec 6.4: disabled = no interception).
+    if (isArtifactEnabled(context.workdir)) {
+      const artifactSlug = extractArtifactSlug(url);
+      if (artifactSlug) {
+        const readResult = await readArtifact(
+          url,
+          artifactSlug,
+          context.abortSignal,
+        );
+        if (readResult.kind === "error") {
+          return { success: false, content: "", error: readResult.error };
+        }
+        if (context.sessionId && readResult.version) {
+          // Keep the stale-version guard in sync with what the model has seen.
+          recordVersion(context.sessionId, artifactSlug, readResult.version);
+        }
+        return processArtifactRead(
+          url,
+          prompt,
+          readResult.markdown,
+          artifactSlug,
+          readResult.version,
+          context,
+        );
+      }
     }
 
     try {

--- a/packages/agent-sdk/src/types/configuration.ts
+++ b/packages/agent-sdk/src/types/configuration.ts
@@ -59,6 +59,8 @@ export interface WaveConfiguration {
     /** Base ref for new worktrees: "fresh" (origin/<default-branch>, default) | "head" (local HEAD) */
     baseRef?: "fresh" | "head";
   };
+  /** Whether the Artifact tool is enabled. Unset follows the code default constant (ARTIFACT_DEFAULT_ENABLED). */
+  enableArtifact?: boolean;
 }
 
 /**

--- a/packages/agent-sdk/src/types/permissions.ts
+++ b/packages/agent-sdk/src/types/permissions.ts
@@ -15,6 +15,7 @@ import {
   ENTER_PLAN_MODE_TOOL_NAME,
   EXIT_PLAN_MODE_TOOL_NAME,
   ASK_USER_QUESTION_TOOL_NAME,
+  ARTIFACT_TOOL_NAME,
 } from "../constants/tools.js";
 
 /** Permission mode configuration */
@@ -60,6 +61,8 @@ export interface ToolPermissionContext {
   toolCallId?: string;
   /** The content of the plan being exited from */
   planContent?: string;
+  /** Optional warning line to surface in the confirmation UI (e.g. shared-live redeploy impact) */
+  warning?: string;
 }
 
 /** List of tools that require permission checks in default mode */
@@ -70,6 +73,7 @@ export const RESTRICTED_TOOLS = [
   ENTER_PLAN_MODE_TOOL_NAME,
   EXIT_PLAN_MODE_TOOL_NAME,
   ASK_USER_QUESTION_TOOL_NAME,
+  ARTIFACT_TOOL_NAME,
 ] as const;
 
 /** Type for restricted tool names */

--- a/packages/agent-sdk/tests/managers/permissionManager.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.test.ts
@@ -1788,6 +1788,7 @@ describe("PermissionManager", () => {
         "EnterPlanMode",
         "ExitPlanMode",
         "AskUserQuestion",
+        "Artifact",
       ]);
     });
   });

--- a/packages/agent-sdk/tests/services/artifactAvailability.test.ts
+++ b/packages/agent-sdk/tests/services/artifactAvailability.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Mock } from "vitest";
+
+vi.mock("../../src/services/configurationService.js", () => ({
+  loadMergedWaveConfig: vi.fn(),
+}));
+
+import { loadMergedWaveConfig } from "../../src/services/configurationService.js";
+import {
+  isArtifactEnabled,
+  ARTIFACT_DEFAULT_ENABLED,
+} from "../../src/services/artifactAvailability.js";
+
+describe("artifactAvailability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should default to disabled while the frame backend is not live", () => {
+    expect(ARTIFACT_DEFAULT_ENABLED).toBe(false);
+  });
+
+  it("should follow the code default when no workdir is given", () => {
+    expect(isArtifactEnabled(undefined)).toBe(ARTIFACT_DEFAULT_ENABLED);
+    expect(loadMergedWaveConfig).not.toHaveBeenCalled();
+  });
+
+  it("should follow the code default when no config exists for the workdir", () => {
+    (loadMergedWaveConfig as Mock).mockReturnValue(null);
+    expect(isArtifactEnabled("/test/workdir")).toBe(ARTIFACT_DEFAULT_ENABLED);
+    expect(loadMergedWaveConfig).toHaveBeenCalledWith("/test/workdir");
+  });
+
+  it("should enable when settings.json sets enableArtifact: true", () => {
+    (loadMergedWaveConfig as Mock).mockReturnValue({ enableArtifact: true });
+    expect(isArtifactEnabled("/test/workdir")).toBe(true);
+  });
+
+  it("should disable when settings.json sets enableArtifact: false", () => {
+    (loadMergedWaveConfig as Mock).mockReturnValue({ enableArtifact: false });
+    expect(isArtifactEnabled("/test/workdir")).toBe(false);
+  });
+});

--- a/packages/agent-sdk/tests/services/artifactSession.test.ts
+++ b/packages/agent-sdk/tests/services/artifactSession.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  recordArtifact,
+  getArtifactByFilePath,
+  getRecordedVersion,
+  recordVersion,
+  clearArtifactSession,
+} from "../../src/services/artifactSession.js";
+
+describe("artifactSession", () => {
+  beforeEach(() => {
+    clearArtifactSession("session-a");
+    clearArtifactSession("session-b");
+  });
+
+  it("should record a publish by file path and slug version", () => {
+    recordArtifact("session-a", "docs/guide.md", {
+      url: "https://server.test/code/artifact/abc",
+      slug: "abc",
+      version: "v1",
+    });
+
+    expect(getArtifactByFilePath("session-a", "docs/guide.md")).toEqual({
+      url: "https://server.test/code/artifact/abc",
+      slug: "abc",
+      version: "v1",
+    });
+    expect(getRecordedVersion("session-a", "abc")).toBe("v1");
+  });
+
+  it("should keep sessions isolated", () => {
+    recordArtifact("session-a", "doc.md", {
+      url: "https://server.test/code/artifact/abc",
+      slug: "abc",
+      version: "v1",
+    });
+
+    expect(getArtifactByFilePath("session-b", "doc.md")).toBeUndefined();
+    expect(getRecordedVersion("session-b", "abc")).toBeUndefined();
+  });
+
+  it("should overwrite the record on republish", () => {
+    recordArtifact("session-a", "doc.md", {
+      url: "https://server.test/code/artifact/abc",
+      slug: "abc",
+      version: "v1",
+    });
+    recordArtifact("session-a", "doc.md", {
+      url: "https://server.test/code/artifact/abc",
+      slug: "abc",
+      version: "v2",
+    });
+
+    expect(getArtifactByFilePath("session-a", "doc.md")?.version).toBe("v2");
+    expect(getRecordedVersion("session-a", "abc")).toBe("v2");
+  });
+
+  it("should track versions observed outside publishes (conflicts / reads)", () => {
+    recordVersion("session-a", "abc", "v5");
+    expect(getRecordedVersion("session-a", "abc")).toBe("v5");
+  });
+
+  it("should clear all state for a session", () => {
+    recordArtifact("session-a", "doc.md", {
+      url: "https://server.test/code/artifact/abc",
+      slug: "abc",
+      version: "v1",
+    });
+    clearArtifactSession("session-a");
+
+    expect(getArtifactByFilePath("session-a", "doc.md")).toBeUndefined();
+    expect(getRecordedVersion("session-a", "abc")).toBeUndefined();
+  });
+});

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -1175,6 +1175,55 @@ describe("ConfigurationService", () => {
     });
   });
 
+  describe("loadMergedWaveConfig — enableArtifact field", () => {
+    it("should propagate enableArtifact from project settings", async () => {
+      const userSettingsPath = path.join(userHome, ".wave", "settings.json");
+      const projectSettingsPath = path.join(tempDir, ".wave", "settings.json");
+
+      mockExistsSync.mockImplementation((p) => {
+        const pathStr = p.toString();
+        return [userSettingsPath, projectSettingsPath].some((expected) =>
+          pathStr.includes(expected),
+        );
+      });
+
+      mockReadFileSync.mockImplementation((p) => {
+        const pathStr = p.toString();
+        if (pathStr.includes(userSettingsPath))
+          return JSON.stringify({ enableArtifact: false });
+        if (pathStr.includes(projectSettingsPath))
+          return JSON.stringify({ enableArtifact: true });
+        return "";
+      });
+
+      const result = loadMergedWaveConfig(tempDir);
+      expect(result?.enableArtifact).toBe(true);
+    });
+
+    it("should propagate enableArtifact from user settings when project has none", async () => {
+      const userSettingsPath = path.join(userHome, ".wave", "settings.json");
+      const projectSettingsPath = path.join(tempDir, ".wave", "settings.json");
+
+      mockExistsSync.mockImplementation((p) => {
+        const pathStr = p.toString();
+        return [userSettingsPath, projectSettingsPath].some((expected) =>
+          pathStr.includes(expected),
+        );
+      });
+
+      mockReadFileSync.mockImplementation((p) => {
+        const pathStr = p.toString();
+        if (pathStr.includes(userSettingsPath))
+          return JSON.stringify({ enableArtifact: true });
+        if (pathStr.includes(projectSettingsPath)) return JSON.stringify({});
+        return "";
+      });
+
+      const result = loadMergedWaveConfig(tempDir);
+      expect(result?.enableArtifact).toBe(true);
+    });
+  });
+
   describe("loadWaveConfigFromFile — read tolerance", () => {
     it("should return null for empty file (not throw)", () => {
       const configPath = path.join(tempDir, "settings.json");

--- a/packages/agent-sdk/tests/tools/artifactTool.test.ts
+++ b/packages/agent-sdk/tests/tools/artifactTool.test.ts
@@ -1,0 +1,674 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Mock } from "vitest";
+import { readFileSync } from "fs";
+import { ARTIFACT_TOOL_NAME } from "../../src/constants/tools.js";
+
+vi.mock("../../src/services/authService.js", () => ({
+  authService: {
+    getServerUrl: vi.fn(),
+    getSSOToken: vi.fn(),
+  },
+  createAuthAwareFetch: vi.fn((innerFetch: typeof fetch) => innerFetch),
+}));
+
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("fs", async () => {
+  const actual = await vi.importActual("fs");
+  return {
+    ...actual,
+    readFileSync: vi.fn(),
+  };
+});
+
+import { authService } from "../../src/services/authService.js";
+import { artifactTool } from "../../src/tools/artifactTool.js";
+import type { ToolContext } from "../../src/tools/types.js";
+import {
+  clearArtifactSession,
+  getArtifactByFilePath,
+  getRecordedVersion,
+  recordArtifact,
+  recordVersion,
+} from "../../src/services/artifactSession.js";
+
+const SESSION_ID = "test-session";
+const SERVER_URL = "https://server.test";
+const MD_CONTENT = "# Hello World\n\nSome **bold** text.";
+const HTML_CONTENT =
+  "<!DOCTYPE html><html><body><h1>Plain HTML</h1></body></html>";
+
+function jsonResponse(status: number, body: unknown): Partial<Response> {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 201 ? "Created" : status === 409 ? "Conflict" : "OK",
+    json: vi.fn().mockResolvedValue(body),
+  };
+}
+
+/**
+ * Stub global fetch with a URL-routing mock. Each route's `match` inspects the
+ * request URL (and optionally init), returning its response for the first match.
+ */
+function stubFetchRoutes(
+  routes: Array<{
+    match: (url: string, init?: RequestInit) => boolean;
+    respond: () => Partial<Response>;
+  }>,
+): Mock {
+  const impl = vi.fn((url: string, init?: RequestInit) => {
+    const route = routes.find((r) => r.match(url, init));
+    if (!route) {
+      throw new Error(`No mock route for ${url}`);
+    }
+    return Promise.resolve(route.respond());
+  });
+  vi.stubGlobal("fetch", impl);
+  return impl;
+}
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workdir: "/test/workdir",
+    sessionId: SESSION_ID,
+    permissionMode: "default",
+    ...overrides,
+  } as ToolContext;
+}
+
+function makePermissionManager(behavior: "allow" | "deny" = "allow") {
+  const permissionContext: Record<string, unknown> = {};
+  return {
+    permissionContext,
+    manager: {
+      createContext: vi.fn().mockReturnValue(permissionContext),
+      checkPermission: vi
+        .fn()
+        .mockResolvedValue(
+          behavior === "allow"
+            ? { behavior: "allow" as const }
+            : { behavior: "deny" as const, message: "No way" },
+        ),
+    },
+  };
+}
+
+describe("artifactTool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    clearArtifactSession(SESSION_ID);
+    (authService.getServerUrl as Mock).mockReturnValue(SERVER_URL);
+    (authService.getSSOToken as Mock).mockReturnValue("token123");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearArtifactSession(SESSION_ID);
+  });
+
+  describe("config", () => {
+    it("should declare name, non-concurrent execution and required file_path", () => {
+      expect(artifactTool.name).toBe(ARTIFACT_TOOL_NAME);
+      expect(artifactTool.isConcurrencySafe).toBe(false);
+      const fn = artifactTool.config.function;
+      expect(fn.name).toBe(ARTIFACT_TOOL_NAME);
+      expect(fn.parameters?.required).toEqual(["file_path"]);
+    });
+
+    it("should format compact params as file → url", () => {
+      expect(
+        artifactTool.formatCompactParams!(
+          {
+            file_path: "docs/guide.md",
+            url: "https://server.test/code/artifact/abc",
+          },
+          makeContext(),
+        ),
+      ).toBe("Artifact(docs/guide.md → https://server.test/code/artifact/abc)");
+    });
+  });
+
+  describe("argument validation", () => {
+    it("should reject a missing file_path", async () => {
+      const result = await artifactTool.execute({}, makeContext());
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('missing required parameter "file_path"');
+    });
+
+    it("should reject a non-emoji favicon", async () => {
+      (readFileSync as Mock).mockReturnValue(MD_CONTENT);
+      const result = await artifactTool.execute(
+        { file_path: "doc.md", favicon: "AB" },
+        makeContext(),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("favicon must be 1-2 emoji characters");
+    });
+
+    it("should reject a multi-codepoint emoji sequence (family counts as 3)", async () => {
+      (readFileSync as Mock).mockReturnValue(MD_CONTENT);
+      const result = await artifactTool.execute(
+        { file_path: "doc.md", favicon: "👨‍👩‍👧" },
+        makeContext(),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("favicon must be 1-2 emoji characters");
+    });
+
+    it("should accept a 2-emoji favicon including variation selectors", async () => {
+      (readFileSync as Mock).mockReturnValue(MD_CONTENT);
+      const fetchMock = stubFetchRoutes([
+        {
+          match: (url) => url.endsWith("/api/frame/deploy/direct"),
+          respond: () =>
+            jsonResponse(201, {
+              url: "https://server.test/code/artifact/abc",
+              slug: "abc",
+              path: "doc.md",
+              title: "Doc",
+              version: "v1",
+            }),
+        },
+      ]);
+      const result = await artifactTool.execute(
+        { file_path: "doc.md", favicon: "📄✨️" },
+        makeContext(),
+      );
+      expect(result.success).toBe(true);
+      const body = JSON.parse(fetchMock.mock.calls[0][1]!.body as string);
+      expect(body.favicon).toBe("📄✨️");
+    });
+
+    it("should reject a label longer than 60 characters", async () => {
+      (readFileSync as Mock).mockReturnValue(MD_CONTENT);
+      const result = await artifactTool.execute(
+        { file_path: "doc.md", label: "x".repeat(61) },
+        makeContext(),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("label must be at most 60 characters");
+    });
+
+    it("should reject a url that is not an artifact URL", async () => {
+      (readFileSync as Mock).mockReturnValue(MD_CONTENT);
+      const result = await artifactTool.execute(
+        { file_path: "doc.md", url: "https://server.test/other/page" },
+        makeContext(),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("url must point to an artifact page");
+    });
+
+    it("should reject non-html/md files", async () => {
+      const result = await artifactTool.execute(
+        { file_path: "notes.txt" },
+        makeContext(),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain(
+        "only .html and .md files can be published",
+      );
+    });
+
+    it("should reject extension-less files", async () => {
+      const result = await artifactTool.execute(
+        { file_path: "README" },
+        makeContext(),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('(got "no extension")');
+    });
+
+    it("should report an unreadable file", async () => {
+      (readFileSync as Mock).mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+      const result = await artifactTool.execute(
+        { file_path: "doc.md" },
+        makeContext(),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("file not found or unreadable: doc.md");
+    });
+
+    it("should reject content over the 16MB server limit", async () => {
+      (readFileSync as Mock).mockReturnValue("a".repeat(17 * 1024 * 1024));
+      const result = await artifactTool.execute(
+        { file_path: "big.html" },
+        makeContext(),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("16MB server limit");
+    });
+
+    it("should reject unauthenticated publishes", async () => {
+      (readFileSync as Mock).mockReturnValue(MD_CONTENT);
+      (authService.getSSOToken as Mock).mockReturnValue(undefined);
+      const result = await artifactTool.execute(
+        { file_path: "doc.md" },
+        makeContext(),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("not authenticated. Run /login");
+    });
+  });
+
+  describe("fresh publish", () => {
+    it("should render markdown to HTML and POST to deploy/direct", async () => {
+      (readFileSync as Mock).mockReturnValue(MD_CONTENT);
+      const fetchMock = stubFetchRoutes([
+        {
+          match: (url) => url.endsWith("/api/frame/deploy/direct"),
+          respond: () =>
+            jsonResponse(201, {
+              url: "https://server.test/code/artifact/abc",
+              slug: "abc",
+              path: "doc.md",
+              title: "Doc",
+              version: "v1",
+            }),
+        },
+      ]);
+
+      const result = await artifactTool.execute(
+        { file_path: "doc.md", label: "My Doc" },
+        makeContext(),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.content).toContain(
+        "Artifact published: https://server.test/code/artifact/abc",
+      );
+      expect(result.content).toContain("Path: doc.md");
+      expect(result.content).toContain("Title: Doc");
+      expect(result.content).toContain("Version: v1");
+      expect(result.shortResult).toBe(
+        "Published doc.md → https://server.test/code/artifact/abc",
+      );
+
+      const [deployUrl, init] = fetchMock.mock.calls[0];
+      expect(deployUrl).toBe(`${SERVER_URL}/api/frame/deploy/direct`);
+      expect(init!.method).toBe("POST");
+      const body = JSON.parse(init!.body as string);
+      expect(body.content).toContain("<h1>Hello World</h1>");
+      expect(body.content).toContain("<!DOCTYPE html>");
+      expect(body.content).toContain("<title>My Doc</title>");
+      expect(body.favicon).toBe("📄");
+      expect(body.label).toBe("My Doc");
+      expect(body.url).toBeUndefined();
+      expect(body.baseVersion).toBeUndefined();
+      expect(body.force).toBeUndefined();
+
+      // Same-session state recorded for auto-allow on republish.
+      expect(getArtifactByFilePath(SESSION_ID, "doc.md")).toEqual({
+        url: "https://server.test/code/artifact/abc",
+        slug: "abc",
+        version: "v1",
+      });
+      expect(getRecordedVersion(SESSION_ID, "abc")).toBe("v1");
+    });
+
+    it("should pass .html files through without rendering", async () => {
+      (readFileSync as Mock).mockReturnValue(HTML_CONTENT);
+      const fetchMock = stubFetchRoutes([
+        {
+          match: (url) => url.endsWith("/api/frame/deploy/direct"),
+          respond: () =>
+            jsonResponse(201, {
+              url: "https://server.test/code/artifact/html1",
+              slug: "html1",
+              version: "v1",
+            }),
+        },
+      ]);
+
+      const result = await artifactTool.execute(
+        { file_path: "page.html" },
+        makeContext(),
+      );
+
+      expect(result.success).toBe(true);
+      const body = JSON.parse(fetchMock.mock.calls[0][1]!.body as string);
+      expect(body.content).toBe(HTML_CONTENT);
+    });
+
+    it("should ask for permission on the first publish and deny correctly", async () => {
+      (readFileSync as Mock).mockReturnValue(MD_CONTENT);
+      const { manager, permissionContext } = makePermissionManager("deny");
+
+      const result = await artifactTool.execute(
+        { file_path: "doc.md" },
+        makeContext({
+          permissionManager:
+            manager as unknown as ToolContext["permissionManager"],
+        }),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain(
+        "operation denied by user, reason: No way",
+      );
+      expect(manager.createContext).toHaveBeenCalledWith(
+        ARTIFACT_TOOL_NAME,
+        "default",
+        undefined,
+        expect.objectContaining({ file_path: "doc.md" }),
+        undefined,
+      );
+      expect(permissionContext.warning).toBeUndefined();
+      expect(permissionContext.hidePersistentOption).toBeUndefined();
+    });
+
+    it("should auto-allow republishing a file already published this session", async () => {
+      (readFileSync as Mock).mockReturnValue(MD_CONTENT);
+      recordArtifact(SESSION_ID, "doc.md", {
+        url: "https://server.test/code/artifact/abc",
+        slug: "abc",
+        version: "v1",
+      });
+      const { manager } = makePermissionManager();
+      const fetchMock = stubFetchRoutes([
+        {
+          match: (url) => url.endsWith("/api/frame/deploy/direct"),
+          respond: () =>
+            jsonResponse(201, {
+              url: "https://server.test/code/artifact/abc",
+              slug: "abc",
+              version: "v2",
+            }),
+        },
+      ]);
+
+      const result = await artifactTool.execute(
+        { file_path: "doc.md" },
+        makeContext({
+          permissionManager:
+            manager as unknown as ToolContext["permissionManager"],
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      expect(manager.createContext).not.toHaveBeenCalled();
+      expect(manager.checkPermission).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("should surface 409 conflicts with the live version and record it", async () => {
+      (readFileSync as Mock).mockReturnValue(MD_CONTENT);
+      stubFetchRoutes([
+        {
+          match: (url) => url.includes("/api/frame/abc?via=model_read"),
+          respond: () =>
+            jsonResponse(200, {
+              slug: "abc",
+              version: "v4",
+              perm: { mode: "owner" },
+            }),
+        },
+        {
+          match: (url) => url.endsWith("/api/frame/deploy/direct"),
+          respond: () => jsonResponse(409, { live: "v5", message: "conflict" }),
+        },
+      ]);
+
+      const result = await artifactTool.execute(
+        {
+          file_path: "doc.md",
+          url: "https://server.test/code/artifact/abc",
+        },
+        makeContext(),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("conflict detected");
+      expect(result.error).toContain("(live version: v5)");
+      expect(result.error).toContain('Pass "force": true');
+      // The observed live version is recorded so a follow-up republish knows it.
+      expect(getRecordedVersion(SESSION_ID, "abc")).toBe("v5");
+    });
+
+    it("should surface 413 as a size error", async () => {
+      (readFileSync as Mock).mockReturnValue(MD_CONTENT);
+      stubFetchRoutes([
+        {
+          match: () => true,
+          respond: () => jsonResponse(413, {}),
+        },
+      ]);
+      const result = await artifactTool.execute(
+        { file_path: "doc.md" },
+        makeContext(),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("too large");
+    });
+
+    it("should surface 400 with the server message", async () => {
+      (readFileSync as Mock).mockReturnValue(MD_CONTENT);
+      stubFetchRoutes([
+        {
+          match: () => true,
+          respond: () => jsonResponse(400, { message: "bad content" }),
+        },
+      ]);
+      const result = await artifactTool.execute(
+        { file_path: "doc.md" },
+        makeContext(),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("server rejected the publish");
+      expect(result.error).toContain("bad content");
+    });
+
+    it("should surface 401/403 auth failures", async () => {
+      (readFileSync as Mock).mockReturnValue(MD_CONTENT);
+      stubFetchRoutes([
+        {
+          match: () => true,
+          respond: () => jsonResponse(401, {}),
+        },
+      ]);
+      const result = await artifactTool.execute(
+        { file_path: "doc.md" },
+        makeContext(),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("authentication failed (HTTP 401)");
+    });
+
+    it("should report network failures", async () => {
+      (readFileSync as Mock).mockReturnValue(MD_CONTENT);
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockRejectedValue(new Error("ECONNREFUSED")),
+      );
+      const result = await artifactTool.execute(
+        { file_path: "doc.md" },
+        makeContext(),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain(
+        "failed to reach the server: ECONNREFUSED",
+      );
+    });
+  });
+
+  describe("redeploy (with url)", () => {
+    it("should probe current metadata and pass baseVersion", async () => {
+      (readFileSync as Mock).mockReturnValue(MD_CONTENT);
+      const fetchMock = stubFetchRoutes([
+        {
+          match: (url) => url.includes("/api/frame/abc?via=model_read"),
+          respond: () =>
+            jsonResponse(200, {
+              slug: "abc",
+              version: "v2",
+              perm: { mode: "owner" },
+            }),
+        },
+        {
+          match: (url) => url.endsWith("/api/frame/deploy/direct"),
+          respond: () =>
+            jsonResponse(201, {
+              url: "https://server.test/code/artifact/abc",
+              slug: "abc",
+              version: "v3",
+            }),
+        },
+      ]);
+
+      const result = await artifactTool.execute(
+        {
+          file_path: "doc.md",
+          url: "https://server.test/code/artifact/abc",
+        },
+        makeContext(),
+      );
+
+      expect(result.success).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const body = JSON.parse(fetchMock.mock.calls[1][1]!.body as string);
+      expect(body.url).toBe("https://server.test/code/artifact/abc");
+      expect(body.baseVersion).toBe("v2");
+      expect(getRecordedVersion(SESSION_ID, "abc")).toBe("v3");
+    });
+
+    it("should fail when the artifact no longer exists", async () => {
+      (readFileSync as Mock).mockReturnValue(MD_CONTENT);
+      stubFetchRoutes([
+        {
+          match: () => true,
+          respond: () => jsonResponse(404, {}),
+        },
+      ]);
+      const result = await artifactTool.execute(
+        {
+          file_path: "doc.md",
+          url: "https://server.test/code/artifact/abc",
+        },
+        makeContext(),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain(
+        "artifact not found at https://server.test/code/artifact/abc",
+      );
+    });
+
+    it("should block stale redeploys unless force is set", async () => {
+      (readFileSync as Mock).mockReturnValue(MD_CONTENT);
+      recordVersion(SESSION_ID, "abc", "v1");
+      stubFetchRoutes([
+        {
+          match: (url) => url.includes("/api/frame/abc?via=model_read"),
+          respond: () =>
+            jsonResponse(200, {
+              slug: "abc",
+              version: "v2",
+              perm: { mode: "owner" },
+            }),
+        },
+      ]);
+      const result = await artifactTool.execute(
+        {
+          file_path: "doc.md",
+          url: "https://server.test/code/artifact/abc",
+        },
+        makeContext(),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("stale version");
+      expect(result.error).toContain('Pass "force": true');
+    });
+
+    it("should redeploy with force when the version is stale", async () => {
+      (readFileSync as Mock).mockReturnValue(MD_CONTENT);
+      recordVersion(SESSION_ID, "abc", "v1");
+      const fetchMock = stubFetchRoutes([
+        {
+          match: (url) => url.includes("/api/frame/abc?via=model_read"),
+          respond: () =>
+            jsonResponse(200, {
+              slug: "abc",
+              version: "v2",
+              perm: { mode: "owner" },
+            }),
+        },
+        {
+          match: (url) => url.endsWith("/api/frame/deploy/direct"),
+          respond: () =>
+            jsonResponse(201, {
+              url: "https://server.test/code/artifact/abc",
+              slug: "abc",
+              version: "v3",
+            }),
+        },
+      ]);
+      const result = await artifactTool.execute(
+        {
+          file_path: "doc.md",
+          url: "https://server.test/code/artifact/abc",
+          force: true,
+        },
+        makeContext(),
+      );
+      expect(result.success).toBe(true);
+      const body = JSON.parse(fetchMock.mock.calls[1][1]!.body as string);
+      expect(body.force).toBe(true);
+      expect(body.baseVersion).toBe("v2");
+    });
+
+    it("should warn + force confirmation on shared-live redeploys", async () => {
+      (readFileSync as Mock).mockReturnValue(MD_CONTENT);
+      // Version matches what this session last saw so the stale guard passes
+      // and the shared-live confirmation is what blocks the redeploy.
+      recordVersion(SESSION_ID, "abc", "v2");
+      const { manager, permissionContext } = makePermissionManager("allow");
+      stubFetchRoutes([
+        {
+          match: (url) => url.includes("/api/frame/abc?via=model_read"),
+          respond: () =>
+            jsonResponse(200, {
+              slug: "abc",
+              version: "v2",
+              perm: { mode: "users" },
+            }),
+        },
+        {
+          match: (url) => url.endsWith("/api/frame/deploy/direct"),
+          respond: () =>
+            jsonResponse(201, {
+              url: "https://server.test/code/artifact/abc",
+              slug: "abc",
+              version: "v3",
+            }),
+        },
+      ]);
+
+      const result = await artifactTool.execute(
+        {
+          file_path: "doc.md",
+          url: "https://server.test/code/artifact/abc",
+        },
+        makeContext({
+          permissionManager:
+            manager as unknown as ToolContext["permissionManager"],
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      expect(manager.createContext).toHaveBeenCalledTimes(1);
+      expect(permissionContext.warning).toContain("shared-live");
+      expect(permissionContext.hidePersistentOption).toBe(true);
+      expect(manager.checkPermission).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/agent-sdk/tests/tools/webFetchTool.artifact.test.ts
+++ b/packages/agent-sdk/tests/tools/webFetchTool.artifact.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Mock } from "vitest";
+
+vi.mock("../../src/services/authService.js", () => ({
+  authService: {
+    getServerUrl: vi.fn(),
+  },
+  createAuthAwareFetch: vi.fn((innerFetch: typeof fetch) => innerFetch),
+}));
+
+vi.mock("../../src/services/artifactAvailability.js", () => ({
+  isArtifactEnabled: vi.fn(),
+}));
+
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/utils/toolResultStorage.js", () => ({
+  persistToolResult: vi
+    .fn()
+    .mockReturnValue("/tmp/wave-tool-results/artifact_1.txt"),
+  buildPersistedOutputMessage: vi.fn(
+    (len: number, filePath: string, preview: string) =>
+      `<persisted-output>${len} chars -> ${filePath} preview: ${preview}</persisted-output>`,
+  ),
+  generatePreview: vi.fn((s: string) => s.substring(0, 100)),
+}));
+
+import { authService } from "../../src/services/authService.js";
+import { isArtifactEnabled } from "../../src/services/artifactAvailability.js";
+import { webFetchTool } from "../../src/tools/webFetchTool.js";
+import type { ToolContext } from "../../src/tools/types.js";
+import {
+  clearArtifactSession,
+  getRecordedVersion,
+} from "../../src/services/artifactSession.js";
+
+const SESSION_ID = "test-session";
+const SERVER_URL = "https://server.test";
+const ARTIFACT_URL = "https://server.test/code/artifact/abc";
+const CONTENT_URL = "/api/frame/abc/content";
+
+function jsonResponse(status: number, body: unknown): Partial<Response> {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Not Found",
+    json: vi.fn().mockResolvedValue(body),
+    text: vi.fn().mockResolvedValue(body as string),
+  };
+}
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workdir: "/test/workdir",
+    sessionId: SESSION_ID,
+    aiManager: {
+      getModelConfig: vi.fn().mockReturnValue({
+        model: "gpt-4",
+        fastModel: "gpt-3.5-turbo",
+      }),
+      getGatewayConfig: vi.fn().mockReturnValue({
+        apiKey: "test-key",
+        baseURL: "https://api.openai.com/v1",
+      }),
+    } as unknown as ToolContext["aiManager"],
+    aiService: {
+      processWebContent: vi.fn().mockResolvedValue({
+        content: "This is a summary of the artifact.",
+      }),
+    } as unknown as ToolContext["aiService"],
+    ...overrides,
+  } as ToolContext;
+}
+
+describe("webFetchTool artifact interception", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    clearArtifactSession(SESSION_ID);
+    (authService.getServerUrl as Mock).mockReturnValue(SERVER_URL);
+    (isArtifactEnabled as Mock).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearArtifactSession(SESSION_ID);
+  });
+
+  it("should read via the dedicated channel and summarize the markdown", async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.includes("/api/frame/abc?via=model_read")) {
+        return Promise.resolve(
+          jsonResponse(200, {
+            slug: "abc",
+            version: "v3",
+            contentUrl: CONTENT_URL,
+          }),
+        );
+      }
+      if (url === `${SERVER_URL}${CONTENT_URL}`) {
+        return Promise.resolve(
+          jsonResponse(
+            200,
+            "<html><body><h1>Artifact Title</h1><p>Body text</p></body></html>",
+          ),
+        );
+      }
+      return Promise.resolve(jsonResponse(404, {}));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const context = makeContext();
+    const result = await webFetchTool.execute(
+      { url: ARTIFACT_URL, prompt: "Summarize" },
+      context,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.content).toBe("This is a summary of the artifact.");
+    expect(result.metadata).toEqual({
+      artifactRead: { slug: "abc", ver: "v3" },
+    });
+    // Metadata probe goes through via=model_read, content through the Bearer URL.
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${SERVER_URL}/api/frame/abc?via=model_read`,
+      expect.any(Object),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${SERVER_URL}${CONTENT_URL}`,
+      expect.any(Object),
+    );
+    // The AI sees the converted markdown, not raw HTML.
+    expect(context.aiService!.processWebContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining("Artifact Title"),
+        prompt: "Summarize",
+      }),
+    );
+    // The read version is recorded for the stale-version guard.
+    expect(getRecordedVersion(SESSION_ID, "abc")).toBe("v3");
+  });
+
+  it("should report a 404 artifact as deleted", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(404, {})));
+    const result = await webFetchTool.execute(
+      { url: ARTIFACT_URL, prompt: "Summarize" },
+      makeContext(),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain(
+      "Artifact not found: https://server.test/code/artifact/abc",
+    );
+  });
+
+  it("should persist large artifact content and surface the persisted-output message", async () => {
+    const largeHtml = `<html><body><p>${"x".repeat(5000)}</p></body></html>`;
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.includes("/api/frame/abc?via=model_read")) {
+        return Promise.resolve(
+          jsonResponse(200, {
+            slug: "abc",
+            version: "v1",
+            contentUrl: CONTENT_URL,
+          }),
+        );
+      }
+      return Promise.resolve(jsonResponse(200, largeHtml));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const context = makeContext();
+    const result = await webFetchTool.execute(
+      { url: ARTIFACT_URL, prompt: "Summarize" },
+      context,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.content).toContain("<persisted-output>");
+    // The model is fed the persisted-output message, not 5KB of raw content.
+    expect(context.aiService!.processWebContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining("<persisted-output>"),
+      }),
+    );
+    expect(result.metadata).toEqual({
+      artifactRead: { slug: "abc", ver: "v1" },
+    });
+  });
+
+  it("should NOT intercept artifact URLs when the feature is disabled", async () => {
+    (isArtifactEnabled as Mock).mockReturnValue(false);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: vi
+        .fn()
+        .mockResolvedValue("<html><body><h1>Direct fetch</h1></body></html>"),
+      headers: new Headers(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await webFetchTool.execute(
+      { url: ARTIFACT_URL, prompt: "Summarize" },
+      makeContext(),
+    );
+
+    expect(result.success).toBe(true);
+    // Falls through to the normal fetch path with the raw artifact URL.
+    expect(fetchMock).toHaveBeenCalledWith(ARTIFACT_URL, expect.any(Object));
+    expect(result.metadata).toBeUndefined();
+  });
+});

--- a/packages/code/src/components/ChatInterface.tsx
+++ b/packages/code/src/components/ChatInterface.tsx
@@ -142,6 +142,7 @@ export const ChatInterface: React.FC = () => {
                   toolName={confirmingTool!.name}
                   toolInput={confirmingTool!.input}
                   planContent={confirmingTool!.planContent}
+                  warning={confirmingTool!.warning}
                   isExpanded={isExpanded}
                 />
               )}
@@ -151,6 +152,7 @@ export const ChatInterface: React.FC = () => {
               toolName={confirmingTool!.name}
               toolInput={confirmingTool!.input}
               planContent={confirmingTool!.planContent}
+              warning={confirmingTool!.warning}
               isExpanded={isExpanded}
             />
           )}

--- a/packages/code/src/components/ConfirmationDetails.tsx
+++ b/packages/code/src/components/ConfirmationDetails.tsx
@@ -7,6 +7,7 @@ import {
   EXIT_PLAN_MODE_TOOL_NAME,
   ENTER_PLAN_MODE_TOOL_NAME,
   ASK_USER_QUESTION_TOOL_NAME,
+  ARTIFACT_TOOL_NAME,
 } from "wave-agent-sdk";
 import { DiffDisplay } from "./DiffDisplay.js";
 import { PlanDisplay } from "./PlanDisplay.js";
@@ -34,6 +35,8 @@ const getActionDescription = (
       return "Enter plan mode for complex task planning";
     case ASK_USER_QUESTION_TOOL_NAME:
       return "Answer questions to clarify intent";
+    case ARTIFACT_TOOL_NAME:
+      return `Publish file: ${toolInput.file_path || "unknown file"}`;
     default:
       return "Execute operation";
   }
@@ -43,6 +46,7 @@ export interface ConfirmationDetailsProps {
   toolName: string;
   toolInput?: Record<string, unknown>;
   planContent?: string;
+  warning?: string;
   isExpanded?: boolean;
 }
 
@@ -50,6 +54,7 @@ export const ConfirmationDetails: React.FC<ConfirmationDetailsProps> = ({
   toolName,
   toolInput,
   planContent,
+  warning,
   isExpanded = false,
 }) => {
   const startLineNumber =
@@ -69,6 +74,7 @@ export const ConfirmationDetails: React.FC<ConfirmationDetailsProps> = ({
         Tool: {toolName}
       </Text>
       <Text color="yellow">{getActionDescription(toolName, toolInput)}</Text>
+      {warning && <Text color="red">⚠ {warning}</Text>}
 
       <DiffDisplay
         toolName={toolName}

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -112,6 +112,7 @@ export interface ChatContextType {
     hidePersistentOption?: boolean;
     planContent?: string;
     permissionMode?: PermissionMode;
+    warning?: string;
   };
   showConfirmation: (
     toolName: string,
@@ -120,6 +121,7 @@ export interface ChatContextType {
     hidePersistentOption?: boolean,
     planContent?: string,
     permissionMode?: PermissionMode,
+    warning?: string,
   ) => Promise<PermissionDecision>;
   hideConfirmation: () => void;
   handleConfirmationDecision: (decision: PermissionDecision) => void;
@@ -443,6 +445,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         hidePersistentOption?: boolean;
         planContent?: string;
         permissionMode?: PermissionMode;
+        warning?: string;
       }
     | undefined
   >();
@@ -454,6 +457,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
       hidePersistentOption?: boolean;
       planContent?: string;
       permissionMode?: PermissionMode;
+      warning?: string;
       resolver: (decision: PermissionDecision) => void;
       reject: () => void;
     }>
@@ -465,6 +469,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
     hidePersistentOption?: boolean;
     planContent?: string;
     permissionMode?: PermissionMode;
+    warning?: string;
     resolver: (decision: PermissionDecision) => void;
     reject: () => void;
   } | null>(null);
@@ -506,6 +511,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
       hidePersistentOption?: boolean,
       planContent?: string,
       permissionMode?: PermissionMode,
+      warning?: string,
     ): Promise<PermissionDecision> => {
       return new Promise<PermissionDecision>((resolve, reject) => {
         const queueItem = {
@@ -515,6 +521,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
           hidePersistentOption,
           planContent,
           permissionMode,
+          warning,
           resolver: resolve,
           reject,
         };
@@ -723,6 +730,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
               context.hidePersistentOption,
               context.planContent,
               context.permissionMode,
+              context.warning,
             );
           } catch {
             // If confirmation was cancelled or failed, deny the operation
@@ -1070,6 +1078,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         hidePersistentOption: next.hidePersistentOption,
         planContent: next.planContent,
         permissionMode: next.permissionMode,
+        warning: next.warning,
       });
       setIsConfirmationVisible(true);
       setConfirmationQueue((prev) => prev.slice(1));

--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -78,6 +78,7 @@ interface PendingConfirmation {
   suggestedPrefix?: string;
   hidePersistentOption?: boolean;
   permissionMode?: PermissionMode;
+  warning?: string;
 }
 
 interface WorktreeInfo {
@@ -1746,6 +1747,7 @@ export class DesktopHost {
       suggestedPrefix: context.suggestedPrefix,
       hidePersistentOption: context.hidePersistentOption,
       permissionMode: context.permissionMode,
+      warning: context.warning,
     });
     this.refreshSessionTree();
 
@@ -1764,6 +1766,7 @@ export class DesktopHost {
         suggestedPrefix: context.suggestedPrefix,
         hidePersistentOption: context.hidePersistentOption,
         permissionMode: context.permissionMode,
+        warning: context.warning,
       });
     }
   }

--- a/packages/vscode/src/chatProvider.ts
+++ b/packages/vscode/src/chatProvider.ts
@@ -495,6 +495,7 @@ export class ChatProvider implements vscode.WebviewViewProvider {
                 planContent: context.planContent,
                 suggestedPrefix: context.suggestedPrefix,
                 hidePersistentOption: context.hidePersistentOption,
+                warning: context.warning,
                 permissionMode: context.permissionMode
             });
 
@@ -507,6 +508,7 @@ export class ChatProvider implements vscode.WebviewViewProvider {
                 planContent: context.planContent,
                 suggestedPrefix: context.suggestedPrefix,
                 hidePersistentOption: context.hidePersistentOption,
+                warning: context.warning,
                 permissionMode: context.permissionMode
             }, viewType, windowId);
         });

--- a/packages/vscode/src/session/chatSession.ts
+++ b/packages/vscode/src/session/chatSession.ts
@@ -53,6 +53,7 @@ export class ChatSession {
         planContent?: string;
         suggestedPrefix?: string;
         hidePersistentOption?: boolean;
+        warning?: string;
         permissionMode?: PermissionMode;
     }> = new Map();
 

--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -597,7 +597,8 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
               planContent: message.planContent,
               suggestedPrefix: message.suggestedPrefix,
               hidePersistentOption: message.hidePersistentOption,
-              permissionMode: message.permissionMode
+              permissionMode: message.permissionMode,
+              warning: message.warning
             }
           });
           // Scroll to bottom when confirmation is shown

--- a/packages/webview/src/components/ConfirmationDialog.tsx
+++ b/packages/webview/src/components/ConfirmationDialog.tsx
@@ -535,6 +535,9 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
               <strong>文件:</strong> {String(confirmation.toolInput.file_path)}
             </div>
           )}
+          {confirmation.warning && (
+            <div className="confirmation-warning">⚠ {confirmation.warning}</div>
+          )}
         </div>
 
         {renderPlanContent()}

--- a/packages/webview/src/styles/ConfirmationDialog.css
+++ b/packages/webview/src/styles/ConfirmationDialog.css
@@ -119,6 +119,15 @@
   word-break: break-all;
 }
 
+/* Warning line (e.g. shared-live redeploy impact) */
+.confirmation-warning {
+  margin-top: 8px;
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--vscode-editorWarning-foreground, #cca700);
+  word-break: break-all;
+}
+
 /* Ask User Questions Styles */
 .ask-user-questions {
   display: flex;

--- a/packages/webview/src/types/index.ts
+++ b/packages/webview/src/types/index.ts
@@ -542,6 +542,7 @@ export interface ConfirmationRequest {
   suggestedPrefix?: string;
   hidePersistentOption?: boolean;
   permissionMode?: PermissionMode;
+  warning?: string;
 }
 
 export interface ConfirmationDecision {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       lru-cache:
         specifier: ^11.3.5
         version: 11.3.5
+      marked:
+        specifier: ^17.0.2
+        version: 17.0.2
       minimatch:
         specifier: ^10.0.3
         version: 10.0.3


### PR DESCRIPTION
Implements the Artifact feature (spec `docs/specs/core/artifact-tool.md`, issue #1694).

## What's new

- **Artifact tool** (`packages/agent-sdk/src/tools/artifactTool.ts`): publishes local `.md`/`.html` files via `POST /api/frame/deploy/direct`, returns the artifact URL, supports same-session republish (version bump) and shared-live permission confirmation
- **WebFetch interception**: artifact URLs (`{host}/code/artifact/{slug}`) are read through the authenticated `via=model_read` channel instead of the public page
- **enableArtifact gating** (default off until the frame backend goes live): the tool is registered only when merged settings opt in (`src/services/artifactAvailability.ts`)
- **Confirmation UI** for first publish / shared-live republish across CLI, webview, VS Code, and desktop hosts
- **Bug fix**: `loadWaveConfigFromFile` now propagates `enableArtifact` and `autoMemoryFrequency` — previously dropped by the field whitelist, so the tool never registered despite `enableArtifact: true`
- **Tests**: artifactTool (27), artifactAvailability, artifactSession, WebFetch artifact interception, permissionManager `RESTRICTED_TOOLS`, configurationService enableArtifact regression tests
- **Real end-to-end example** (`examples/tools/artifact-demo.ts`) verified against the live test server: publish, content probe, WebFetch read, same-session republish (version 1 → 2)

## Verification

- Full agent-sdk suite: 253 files / 3467 tests passed (1 skipped)
- Monorepo type-check, lint, prettier, and docs link check all green
- End-to-end demo passed all 4 steps against `https://codechat.codewave-test.163yun.com`