### PR TITLE
fix(cli): first tool compact params missing under multi-tool streaming; SDK tool streaming now delta-only

### DIFF
--- a/docs/specs/core/stream-content-updates.md
+++ b/docs/specs/core/stream-content-updates.md
@@ -148,7 +148,7 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 
 - **Agent SDK 职责**：在内部管理所有消息状态并更新消息；变更通过增量回调（`onUserMessageAdded`、`onAssistantMessageAdded`、`onAssistantContentUpdated`、`onAssistantReasoningUpdated`、`onToolBlockUpdated`、`onErrorBlockAdded` 等）对外发布；完整列表通过 `agent.messages` getter（同进程）或 `getMessages` 请求（stdio 跨进程）按需获取。`onMessagesChange` 全量回调已移除
 - **增量回调用途**：为第三方集成、扩展、CLI 与示例（如 `packages/code/src/print-cli.ts` 和 `packages/agent-sdk/examples`）提供实时流式数据；增量回调是消息状态同步的唯一推送通道
-- **SDK 回调负载**：`onAssistantContentUpdated`/`onAssistantReasoningUpdated` 只提供 `chunk`（增量）+ `messageId` + `stage`，不再携带 `accumulated` 累积值，进程内消费者（CLI、print-cli）自行累积追加；`onToolBlockUpdated` 提供 `parametersChunk`（增量）与 `parameters`（累积）并存
+- **SDK 回调负载**：`onAssistantContentUpdated`/`onAssistantReasoningUpdated` 只提供 `chunk`（增量）+ `messageId` + `stage`，不再携带 `accumulated` 累积值，进程内消费者（CLI、print-cli）自行累积追加；`onToolBlockUpdated` 在 `stage="streaming"` 时只提供 `parametersChunk`（增量），`start`/`running`/`end` 阶段携带权威 `parameters`（end 为最终值，一次性权威）。SDK 内部仍将 chunk 追加进内存 `toolBlock.parameters` 保持累积，只是累积值不再暴露到外部回调
 - **跨进程 wire 负载（纯 delta）**：agentBridge 原样透传增量回调负载——`assistantContentUpdated`/`assistantReasoningUpdated` 只携带 `{messageId, chunk, stage}`（SDK 回调本身已无累积字段，无需剥离）；`toolBlockUpdated` 在 `stage="streaming"` 时只携带 `parametersChunk`，`stage="end"` 时携带全量 `parameters` + `result` 作为权威值。消费端负责累积（追加），丢失的 delta 由 `getMessages` 拉取的全量快照自愈
 - **UI 状态流**：CLI 直接订阅增量回调就地更新消息（chunk 追加 + 500ms 窗口拼接节流）；插件/桌面经 stdio 增量通知（`userMessageAdded`、`assistantContentUpdated`、`toolBlockUpdated` 等，纯 delta 负载）驱动 webview 增量 reducer——文本/推理块追加 chunk、工具块追加 `parametersChunk`，end 时以权威值终结；需要完整列表的场景（初始化、compact、rewind、clear、bang）主动拉取，拉取响应整体替换为权威快照
 - **节流语义**：SDK 回调与 wire 通知均只携带纯 delta，节流器一律按到达顺序拼接窗口内所有 chunks 为一个合并 delta（window-concat），绝不能 last-value-wins 丢弃中间值。为配合该语义，SDK 必须在每次 running 事件中重复携带 `compactParams` 等稳定展示字段（见"工具块阶段更新"验收场景 4），保证丢弃中间事件不丢失这些字段
@@ -209,6 +209,12 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 - 问：SDK 内部累积逻辑是否一并移除 → 答：不移除。aiService 仍内部累积全文，messageManager 仍以"新值 slice 当前长度"计算 chunk delta——只是累积值不再暴露到外部回调
 - 问：进程内消费者如何适配 → 答：CLI useChat 改为消费纯 chunk：新增窗口拼接节流器（window-concat，500ms），窗口内按到达顺序拼接 chunks 为一个合并 delta 发送，`stage="end"` 时先冲刷窗口内 pending 增量再转发 end 信号，最后一条 chunk 以空串 end 终结；print-cli 直接按 chunk 打印，无累积依赖
 - 问：为什么 `stage="end"` 事件以 `chunk: ""` 结尾 → 答：end 是流结束信号，权威最终值由消费端自行累积得到，end 事件不再重复携带全量值
+
+### 2026-08-11 会议（SDK tool 回调 streaming 移除累积 parameters）
+
+- 问：`onToolBlockUpdated` 的 `stage="streaming"` 是否继续携带累积 `parameters` → 答：移除（对齐 2026-08-08 content/reasoning 决策）。streaming 只携带 `parametersChunk`（增量）+ `messageId` + `stage`；`start`/`running`/`end` 仍携带权威 `parameters`（end 为最终值）。SDK 内部 messageOperations 仍将 chunk 追加进内存 `toolBlock.parameters` 保持累积，`getMessages` 快照对账自愈不回归——只是累积值不再暴露到外部回调
+- 问：CLI 多 tool 场景下第一个 tool 不显示 compact params 的根因 → 答：CLI useChat 对 tool 更新误用普通 throttle（last-value-wins，单 lastArgs 槽），多 tool 交错 streaming 时首 tool 的 chunks 被后续事件覆盖，trailing 只应用最后一个 tool 的累积值 → 违反"节流语义"（window-concat）；修复为按 tool id 的 window-concat 节流，窗口内各 tool 的 chunks 独立累积拼接，end 时先冲刷窗口内 pending 增量再应用权威参数
+- 问：受影响范围 → 答：aiService（streaming 不再发 `parameters`）、aiManager（`parameters` 条件转发，避免 `undefined` 泄漏进回调载荷）、messageOperations（chunk 追加进内存 `parameters`）、CLI useChat（按 tool 窗口拼接节流）；wire/agentBridge 自 2026-08-04 起已纯 delta，webview/desktop 消费端已按 `parametersChunk` 追加，均无需改动
 
 ## 假设 *（必填）*
 

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -1796,10 +1796,15 @@ ${question}`;
               // No need to extract params or generate compact params during streaming
 
               // Update tool block with streaming parameters using parametersChunk as compact param
+              // `parameters` is only present on start/running/end (authoritative); streaming
+              // carries only `parametersChunk`, so don't forward `parameters: undefined`
+              // (it would overwrite the accumulated block params in consumers)
               this.messageManager.updateToolBlock({
                 id: toolCall.id,
                 name: toolCall.name,
-                parameters: toolCall.parameters,
+                ...(toolCall.parameters !== undefined
+                  ? { parameters: toolCall.parameters }
+                  : {}),
                 parametersChunk: toolCall.parametersChunk,
                 stage: toolCall.stage || "streaming", // Default to streaming if stage not provided
               });

--- a/packages/agent-sdk/src/services/aiService.ts
+++ b/packages/agent-sdk/src/services/aiService.ts
@@ -188,7 +188,7 @@ export interface CallAgentOptions {
   onToolUpdate?: (toolCall: {
     id: string;
     name: string;
-    parameters: string;
+    parameters?: string;
     parametersChunk?: string;
     stage?: "start" | "streaming" | "running" | "end";
   }) => void;
@@ -577,7 +577,7 @@ async function processStreamingResponse(
   onToolUpdate?: (toolCall: {
     id: string;
     name: string;
-    parameters: string;
+    parameters?: string;
     parametersChunk?: string;
     stage?: "start" | "streaming" | "running" | "end";
   }) => void,
@@ -715,7 +715,9 @@ async function processStreamingResponse(
             existingCall.function.arguments += functionDelta.arguments;
           }
 
-          // Emit streaming updates for all chunks with actual content (including first chunk)
+          // Emit streaming updates for all chunks with actual content (including first chunk).
+          // Streaming carries only the delta `parametersChunk` — consumers accumulate it;
+          // authoritative `parameters` arrives at `start` (empty) / `running` / `end`.
           if (
             onToolUpdate &&
             existingCall.function.name &&
@@ -725,7 +727,6 @@ async function processStreamingResponse(
             onToolUpdate({
               id: existingCall.id,
               name: existingCall.function.name,
-              parameters: existingCall.function.arguments,
               parametersChunk: functionDelta.arguments,
               stage: "streaming",
             });

--- a/packages/agent-sdk/src/utils/messageOperations.ts
+++ b/packages/agent-sdk/src/utils/messageOperations.ts
@@ -316,6 +316,9 @@ export const updateToolBlockInMessage = ({
         const toolBlock = newMessages[messageIndex].blocks[toolBlockIndex];
         if (toolBlock.type === "tool") {
           if (parameters !== undefined) toolBlock.parameters = parameters;
+          else if (parametersChunk !== undefined)
+            toolBlock.parameters =
+              (toolBlock.parameters || "") + parametersChunk;
           if (result !== undefined) toolBlock.result = result;
           if (shortResult !== undefined) toolBlock.shortResult = shortResult;
           if (startLineNumber !== undefined)
@@ -351,6 +354,9 @@ export const updateToolBlockInMessage = ({
         const toolBlock = newMessages[i].blocks[toolBlockIndex];
         if (toolBlock.type === "tool") {
           if (parameters !== undefined) toolBlock.parameters = parameters;
+          else if (parametersChunk !== undefined)
+            toolBlock.parameters =
+              (toolBlock.parameters || "") + parametersChunk;
           if (result !== undefined) toolBlock.result = result;
           if (shortResult !== undefined) toolBlock.shortResult = shortResult;
           if (startLineNumber !== undefined)
@@ -377,7 +383,8 @@ export const updateToolBlockInMessage = ({
         // This handles cases where we're streaming tool parameters before execution
         newMessages[i].blocks.push({
           type: "tool",
-          parameters: parameters,
+          parameters:
+            parameters !== undefined ? parameters : (parametersChunk ?? ""),
           result: result || "",
           shortResult: shortResult,
           startLineNumber: startLineNumber,

--- a/packages/agent-sdk/tests/agent/agent.streaming.tools.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.streaming.tools.test.ts
@@ -262,7 +262,8 @@ describe("Agent Tool Streaming Tests", () => {
             options.onToolUpdate!({
               id: "call_streaming",
               name: "write_file",
-              parameters: '{"file_path":',
+              parametersChunk: '{"file_path": ',
+              stage: "streaming",
             });
 
             streamingCallbackExecuted = true;
@@ -271,7 +272,8 @@ describe("Agent Tool Streaming Tests", () => {
             options.onToolUpdate!({
               id: "call_streaming",
               name: "write_file",
-              parameters: '{"file_path": "/test.txt", "content": "hello"}',
+              parametersChunk: '"/test.txt", "content": "hello"}',
+              stage: "streaming",
             });
 
             // CRITICAL: Verify tool call is added to messages DURING streaming (before execution)
@@ -357,8 +359,8 @@ describe("Agent Tool Streaming Tests", () => {
             options.onToolUpdate({
               id: "call_lifecycle",
               name: "test_tool",
-              parameters: '{"param": "value"}',
               parametersChunk: '{"param": "value"}',
+              stage: "streaming",
             });
           }
 
@@ -412,7 +414,8 @@ describe("Agent Tool Streaming Tests", () => {
         onToolUpdate?: (update: {
           id: string;
           name: string;
-          parameters: string;
+          parametersChunk: string;
+          stage: string;
         }) => void;
         onContentUpdate?: (update: string) => void;
       } = {};
@@ -431,7 +434,8 @@ describe("Agent Tool Streaming Tests", () => {
                 options.onToolUpdate!({
                   id: "call_123",
                   name: "run_terminal_cmd",
-                  parameters: '{"com',
+                  parametersChunk: '{"com',
+                  stage: "streaming",
                 }),
               10,
             );
@@ -441,7 +445,8 @@ describe("Agent Tool Streaming Tests", () => {
                 options.onToolUpdate!({
                   id: "call_123",
                   name: "run_terminal_cmd",
-                  parameters: '{"command": "ls -la"}',
+                  parametersChunk: '"command": "ls -la"}',
+                  stage: "streaming",
                 }),
               20,
             );
@@ -502,7 +507,8 @@ describe("Agent Tool Streaming Tests", () => {
       const parameterUpdates: {
         id: string;
         name: string;
-        parameters: string;
+        parametersChunk: string;
+        stage: string;
       }[] = [];
       let aiCallCount = 0;
 
@@ -514,16 +520,17 @@ describe("Agent Tool Streaming Tests", () => {
             // Simulate parameter accumulation with different JSON states
             const updates = [
               '{"param1":',
-              '{"param1": "value1"',
-              '{"param1": "value1", "param2":',
-              '{"param1": "value1", "param2": ["item1", "item2"]}',
+              ' "value1"',
+              ', "param2":',
+              ' ["item1", "item2"]}',
             ];
 
             updates.forEach((params) => {
               const update = {
                 id: "call_accumulate",
                 name: "test_tool",
-                parameters: params,
+                parametersChunk: params,
+                stage: "streaming" as const,
               };
               parameterUpdates.push(update);
               options.onToolUpdate!(update);
@@ -564,11 +571,9 @@ describe("Agent Tool Streaming Tests", () => {
       // Verify parameter updates were received
       expect(parameterUpdates.length).toBe(4);
 
-      // Verify progressive parameter building
-      expect(parameterUpdates[0].parameters).toBe('{"param1":');
-      expect(parameterUpdates[3].parameters).toBe(
-        '{"param1": "value1", "param2": ["item1", "item2"]}',
-      );
+      // Verify progressive parameter building (delta-only chunks)
+      expect(parameterUpdates[0].parametersChunk).toBe('{"param1":');
+      expect(parameterUpdates[3].parametersChunk).toBe(' ["item1", "item2"]}');
 
       // Verify final tool execution used complete parameters
       expect(mockToolExecute).toHaveBeenCalledWith(
@@ -590,13 +595,15 @@ describe("Agent Tool Streaming Tests", () => {
             options.onToolUpdate!({
               id: "call_fast",
               name: "fast_tool",
-              parameters: '{"quick": true}',
+              parametersChunk: '{"quick": true}',
+              stage: "streaming",
             });
 
             options.onToolUpdate!({
               id: "call_slow",
               name: "slow_tool",
-              parameters: '{"complex": {"nested": "value"}}',
+              parametersChunk: '{"complex": {"nested": "value"}}',
+              stage: "streaming",
             });
           }
 

--- a/packages/agent-sdk/tests/agent/agent.toolStages.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.toolStages.test.ts
@@ -104,7 +104,6 @@ describe("Agent Tool Stage Tests", () => {
           onToolUpdate({
             id: "call_123",
             name: "test_tool",
-            parameters: JSON.stringify({ param: "value" }),
             parametersChunk: JSON.stringify({ param: "value" }),
             stage: "streaming",
           });
@@ -153,16 +152,26 @@ describe("Agent Tool Stage Tests", () => {
       }),
     );
 
-    // Verify that onToolBlockUpdated was called with streaming stage (actual content)
+    // Verify that onToolBlockUpdated was called with streaming stage (delta only)
     expect(onToolBlockUpdated).toHaveBeenCalledWith(
       expect.objectContaining({
         stage: "streaming",
         name: "test_tool",
         id: "call_123",
-        parameters: JSON.stringify({ param: "value" }),
         parametersChunk: JSON.stringify({ param: "value" }), // Should match the chunk content
       }),
     );
+
+    // Streaming stage must NOT carry the accumulated parameters (delta-only contract)
+    const streamingCall = onToolBlockUpdated.mock.calls.find(
+      (call: unknown[]) =>
+        call[0] &&
+        typeof call[0] === "object" &&
+        "stage" in call[0] &&
+        call[0].stage === "streaming",
+    ) as [Record<string, unknown>] | undefined;
+    expect(streamingCall).toBeDefined();
+    expect(streamingCall![0]).not.toHaveProperty("parameters");
 
     // Verify that isRunning field is not present
     const startCall = onToolBlockUpdated.mock.calls.find(
@@ -198,7 +207,6 @@ describe("Agent Tool Stage Tests", () => {
           onToolUpdate({
             id: "call_456",
             name: "calculator_tool",
-            parameters: JSON.stringify({ a: 5, b: 3 }),
             parametersChunk: JSON.stringify({ a: 5, b: 3 }),
             stage: "streaming",
           });
@@ -331,7 +339,6 @@ describe("Agent Tool Stage Tests", () => {
           onToolUpdate({
             id: "call_order",
             name: "order_tool",
-            parameters: JSON.stringify({ data: "test" }),
             parametersChunk: JSON.stringify({ data: "test" }),
             stage: "streaming",
           });
@@ -408,7 +415,6 @@ describe("Agent Tool Stage Tests", () => {
           onToolUpdate({
             id: "call_multi",
             name: "multi_tool",
-            parameters: '{"step":',
             parametersChunk: '{"step":',
             stage: "streaming",
           });
@@ -417,7 +423,6 @@ describe("Agent Tool Stage Tests", () => {
           onToolUpdate({
             id: "call_multi",
             name: "multi_tool",
-            parameters: '{"step": 1}',
             parametersChunk: " 1}",
             stage: "streaming",
           });
@@ -466,13 +471,12 @@ describe("Agent Tool Stage Tests", () => {
       }),
     );
 
-    // Verify that streaming stages were emitted with incremental content
+    // Verify that streaming stages were emitted with incremental content only
     expect(onToolBlockUpdated).toHaveBeenCalledWith(
       expect.objectContaining({
         stage: "streaming",
         name: "multi_tool",
         id: "call_multi",
-        parameters: '{"step":',
         parametersChunk: '{"step":',
       }),
     );
@@ -482,9 +486,21 @@ describe("Agent Tool Stage Tests", () => {
         stage: "streaming",
         name: "multi_tool",
         id: "call_multi",
-        parameters: '{"step": 1}',
         parametersChunk: " 1}",
       }),
     );
+
+    // Streaming stages must NOT carry accumulated parameters (delta-only contract)
+    const streamingCalls = onToolBlockUpdated.mock.calls.filter(
+      (call: unknown[]) =>
+        call[0] &&
+        typeof call[0] === "object" &&
+        "stage" in call[0] &&
+        call[0].stage === "streaming",
+    ) as [Record<string, unknown>][];
+    expect(streamingCalls.length).toBe(2);
+    for (const [payload] of streamingCalls) {
+      expect(payload).not.toHaveProperty("parameters");
+    }
   });
 });

--- a/packages/agent-sdk/tests/services/aiService.streaming.test.ts
+++ b/packages/agent-sdk/tests/services/aiService.streaming.test.ts
@@ -221,7 +221,9 @@ describe("AI Service - Streaming", () => {
       const toolUpdates: Array<{
         id: string;
         name: string;
-        parameters: string;
+        parameters?: string;
+        parametersChunk?: string;
+        stage?: "start" | "streaming" | "running" | "end";
       }> = [];
 
       const result = await callAgent({

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -31,7 +31,6 @@ import {
   extractLatestTotalTokens,
 } from "wave-agent-sdk";
 import { logger } from "../utils/logger.js";
-import { throttle } from "../utils/throttle.js";
 import { displayUsageSummary } from "../utils/usageSummary.js";
 import { expandLongTextPlaceholders } from "../managers/inputHandlers.js";
 
@@ -241,6 +240,84 @@ function createStreamingWindowThrottle(
   return throttled;
 }
 
+/**
+ * Per-tool window-concat throttle for pure-delta tool parameter streaming:
+ * `parametersChunk` deltas are accumulated independently per tool block id
+ * within the cooldown window, so interleaved multi-tool streams lose no delta
+ * (a plain throttle's single last-args slot would drop every earlier tool's
+ * deltas, leaving the first tool without streaming parameters). `start` /
+ * `running` apply immediately (one-shot snapshots); `end` flushes pending
+ * streaming deltas first, then applies the authoritative parameters/result.
+ */
+function createToolStreamingThrottle(
+  fn: (params: ToolBlockUpdateCallbackParams) => void,
+  wait: number,
+): {
+  (params: ToolBlockUpdateCallbackParams): void;
+  cancel: () => void;
+  flush: () => void;
+} {
+  let timer: NodeJS.Timeout | null = null;
+  let pending: { messageId: string; chunks: Map<string, string> } | null = null;
+
+  const fire = () => {
+    if (pending && pending.chunks.size > 0) {
+      const { messageId, chunks } = pending;
+      pending = null;
+      for (const [id, chunk] of chunks) {
+        fn({ messageId, id, parametersChunk: chunk, stage: "streaming" });
+      }
+    }
+  };
+
+  const throttled = (params: ToolBlockUpdateCallbackParams) => {
+    if (params.stage === "end") {
+      // Flush any deltas still pending inside the cooldown window first
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      fire();
+      fn(params);
+      return;
+    }
+    if (params.stage === "streaming") {
+      if (!pending) {
+        pending = { messageId: params.messageId, chunks: new Map() };
+      }
+      const prev = pending.chunks.get(params.id) || "";
+      pending.chunks.set(params.id, prev + (params.parametersChunk || ""));
+      if (!timer) {
+        timer = setTimeout(() => {
+          timer = null;
+          fire();
+        }, wait);
+      }
+      return;
+    }
+    // start / running — one-shot snapshots applied immediately
+    fn(params);
+  };
+
+  throttled.cancel = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    pending = null;
+  };
+
+  throttled.flush = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    fire();
+  };
+
+  return throttled;
+}
+
 export const ChatProvider: React.FC<ChatProviderProps> = ({
   children,
   bypassPermissions,
@@ -347,8 +424,13 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
 
   const throttledToolBlockUpdate = useMemo(
     () =>
-      throttle((params: ToolBlockUpdateCallbackParams) => {
-        const { messageId, id: toolBlockId, ...updates } = params;
+      createToolStreamingThrottle((params) => {
+        const {
+          messageId,
+          id: toolBlockId,
+          parametersChunk,
+          ...updates
+        } = params;
         setMessages((prev) =>
           prev.map((m) => {
             if (m.id !== messageId) return m;
@@ -365,7 +447,8 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
                     id: toolBlockId,
                     name: updates.name || "",
                     stage: updates.stage || "start",
-                    parameters: updates.parameters || "",
+                    parameters:
+                      (updates.parameters || "") + (parametersChunk || ""),
                     result: updates.result || "",
                     ...updates,
                   },
@@ -376,7 +459,18 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
               ...m,
               blocks: m.blocks.map((b, idx) =>
                 idx === toolBlockIndex && b.type === "tool"
-                  ? { ...b, ...updates }
+                  ? {
+                      ...b,
+                      ...updates,
+                      // Streaming carries only the delta; append it to the
+                      // accumulated parameters. start/running/end carry the
+                      // authoritative value and replace wholesale.
+                      parameters: parametersChunk
+                        ? (b.parameters || "") + parametersChunk
+                        : updates.parameters !== undefined
+                          ? updates.parameters
+                          : b.parameters,
+                    }
                   : b,
               ),
             };

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -1367,6 +1367,100 @@ describe("ChatProvider", () => {
     });
   });
 
+  it("accumulates parametersChunk per tool during multi-tool streaming", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
+    const callbacks = agentCreateArgs.callbacks!;
+
+    const assistantMsg = {
+      id: "msg-multi",
+      role: "assistant" as const,
+      blocks: [],
+      timestamp: new Date().toISOString(),
+    };
+    Object.assign(mockAgent, { messages: [assistantMsg] });
+    callbacks.onAssistantMessageAdded!("msg-multi");
+    await vi.waitFor(() => {
+      expect(lastValue?.messages).toHaveLength(1);
+    });
+
+    // Both tool blocks are created immediately via start
+    callbacks.onToolBlockUpdated!({
+      messageId: "msg-multi",
+      id: "tool-a",
+      name: "bash",
+      stage: "start",
+      parameters: "",
+    });
+    callbacks.onToolBlockUpdated!({
+      messageId: "msg-multi",
+      id: "tool-b",
+      name: "read",
+      stage: "start",
+      parameters: "",
+    });
+    await vi.waitFor(() => {
+      expect(
+        lastValue?.messages[0].blocks
+          .filter((b) => b.type === "tool")
+          .map((b) => b.id),
+      ).toEqual(["tool-a", "tool-b"]);
+    });
+
+    // Interleaved streaming deltas (pure parametersChunk, no accumulated
+    // parameters) — the first tool's deltas must survive the throttle window
+    callbacks.onToolBlockUpdated!({
+      messageId: "msg-multi",
+      id: "tool-a",
+      stage: "streaming",
+      parametersChunk: '{"fi',
+    });
+    callbacks.onToolBlockUpdated!({
+      messageId: "msg-multi",
+      id: "tool-b",
+      stage: "streaming",
+      parametersChunk: '{"file',
+    });
+    callbacks.onToolBlockUpdated!({
+      messageId: "msg-multi",
+      id: "tool-a",
+      stage: "streaming",
+      parametersChunk: 'le": "a.txt"}',
+    });
+    callbacks.onToolBlockUpdated!({
+      messageId: "msg-multi",
+      id: "tool-b",
+      stage: "streaming",
+      parametersChunk: '_path": "b.txt"}',
+    });
+
+    await vi.waitFor(() => {
+      const blocks = lastValue?.messages[0].blocks.filter(
+        (b) => b.type === "tool",
+      );
+      const params = Object.fromEntries(
+        (blocks ?? []).map((b) => [
+          b.id,
+          (b as { parameters?: string }).parameters,
+        ]),
+      );
+      // Regression: the plain throttle's single lastArgs slot dropped tool-a's
+      // deltas, so the FIRST tool never showed streaming parameters
+      expect(params["tool-a"]).toBe('{"file": "a.txt"}');
+      expect(params["tool-b"]).toBe('{"file_path": "b.txt"}');
+    });
+  });
+
   it("throttles reasoning streaming updates and flushes on end", async () => {
     let lastValue: ChatContextType | undefined;
     const onHookValue = (val: ChatContextType) => {


### PR DESCRIPTION
## 背景

两个相关问题一起修：

1. **CLI bug**：一条消息里有多个 tool 时，streaming 期间第一个 tool 总是不显示 compact params 区域。根因是旧 throttle（src/utils/throttle.ts）只有单个 lastArgs 槽（leading+trailing），多 tool 交错时第一个 tool 的 delta 被后续覆盖，trailing 只应用最后一个 tool 的数据。
2. **SDK 契约**：SDK streaming 事件此前一直带累计值 parameters，与增量设计不一致，改为纯增量。

## 改动

**SDK — tool 回调改增量（streaming 只带 parametersChunk）**
- aiService.ts：streaming onToolUpdate 只发 `{id, name, parametersChunk, stage:"streaming"}`，不再带累计 parameters；内部累计（existingCall.function.arguments）保留；processStreamingResponse 的 onToolUpdate 类型 parameters 改为可选
- aiManager.ts：onToolUpdate 处理条件转发 — parameters !== undefined 才带，parametersChunk 总是转发（避免 `{...b, ...updates}` 里 parameters: undefined 覆盖消费方状态）
- messageOperations.ts：合并路径 append chunk；create 路径补种子 — `parameters: parameters ?? (parametersChunk ?? "")`，否则第一个 delta chunk 丢失

**CLI — 按 tool 做 window-concat 节流**
- useChat.tsx：createToolStreamingThrottle — 每个 tool id 独立 pending Map，trailing 时把所有 pending chunk 逐个回调；start/running/end 带权威值直接透传

**Spec**
- stream-content-updates.md：写明 streaming 阶段 tool 只发增量（parametersChunk），并记录 2026-08-11 会议决策

## 验证
- agent-sdk 全量：3471 passed（toolStages 5/5、streaming.tools 8/8、aiService.streaming 11/11）
- wave-code 全量：1334 passed（含多 tool 交错 streaming 回归测试：首个 tool 的 chunk 不再丢失）
- `pnpm run type-check` 通过
- spec-count：70/361/1362
