### PR TITLE
docs: document WAVE_VISION_MODEL in settings skill

### DIFF
--- a/packages/agent-sdk/builtin/skills/settings/ENV.md
+++ b/packages/agent-sdk/builtin/skills/settings/ENV.md
@@ -27,6 +27,7 @@ Wave uses several environment variables to control its core functionality. Varia
 | `WAVE_CUSTOM_HEADERS` | Custom HTTP headers for the AI gateway. Newline-separated `Key: Value` pairs (e.g., `"X-Foo: bar\nAuthorization: Bearer xxx"`). | - |
 | `WAVE_MODEL` | The primary AI model to use for the agent. | `gemini-3-flash` |
 | `WAVE_FAST_MODEL` | The fast AI model to use for quick tasks. | `gemini-2.5-flash` |
+| `WAVE_VISION_MODEL` | Vision-capable model used by the built-in `vision` subagent for image recognition. When set, the built-in `vision` subagent is registered (its frontmatter `model: visionModel` resolves to this value); when unset, the subagent is not loaded. Useful when the main model is fast but non-vision (e.g. DeepSeek). | - (not registered) |
 | `WAVE_MAX_INPUT_TOKENS` | Maximum number of input tokens allowed. | `200000` |
 | `WAVE_MAX_OUTPUT_TOKENS` | Maximum number of output tokens allowed. | `32000` |
 | `WAVE_DISABLE_AUTO_MEMORY` | Set to `1` or `true` to disable the auto-memory feature. | `false` |

--- a/packages/agent-sdk/builtin/skills/settings/MODELS.md
+++ b/packages/agent-sdk/builtin/skills/settings/MODELS.md
@@ -105,11 +105,14 @@ You can also set the default models Wave uses via environment variables in `sett
   "env": {
     "WAVE_MODEL": "gemini-3-flash",
     "WAVE_FAST_MODEL": "gemini-2.5-flash",
+    "WAVE_VISION_MODEL": "qwen-vl-max",
     "WAVE_MAX_INPUT_TOKENS": "100000",
     "WAVE_MAX_OUTPUT_TOKENS": "4096"
   }
 }
 ```
+
+`WAVE_VISION_MODEL` names a vision-capable model for the built-in `vision` subagent. Setting it registers the subagent, whose frontmatter `model: visionModel` resolves to this value — so a fast non-vision main model can delegate image recognition. Leave it unset to disable the built-in `vision` subagent.
 
 ## Live Reload
 


### PR DESCRIPTION
Add the `WAVE_VISION_MODEL` env var to the settings skill docs (ENV.md, MODELS.md), including the `model: visionModel` subagent frontmatter resolution.

The env var was added in 12ff9589 (builtin vision subagent) but the settings docs were never updated. Setting `WAVE_VISION_MODEL` registers the built-in `vision` subagent for image recognition on a vision-capable model.