### PR TITLE
feat(webview): sidebar session/new-chat hover tooltips

### DIFF
--- a/packages/webview/src/components/DesktopSidebar.tsx
+++ b/packages/webview/src/components/DesktopSidebar.tsx
@@ -82,6 +82,9 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
   const [showMoreMenu, setShowMoreMenu] = useState(false);
   // Session awaiting delete confirmation; non-null shows the ConfirmDialog.
   const [pendingDelete, setPendingDelete] = useState<{ sessionId: string; title: string; description?: string } | null>(null);
+  // Modifier key label for the side-by-side hints, same platform branch as the
+  // click handlers below (Cmd on macOS / Ctrl elsewhere).
+  const modKeyLabel = isMacPlatform() ? 'Cmd' : 'Ctrl';
 
   const isExpanded = (group: DesktopSessionGroup): boolean =>
     overrides[groupKey(group)] ?? true;
@@ -130,16 +133,29 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
         }}
         data-testid={`desktop-session-item-${session.sessionId}`}
       >
-        {running || waiting ? (
-          <i
-            className={`codicon codicon-${waiting ? 'bell' : 'loading codicon-modifier-spin'} desktop-session-status-icon`}
-            style={{ color: waiting ? 'var(--vscode-charts-purple, #b180d7)' : 'var(--vscode-charts-blue, #59a4f9)' }}
-            title={waiting ? '等待确认' : '正在运行'}
-          />
-        ) : (
-          <span className="desktop-session-dot" aria-hidden="true" />
-        )}
-        <span className="desktop-session-title">{session.title || '新对话'}</span>
+        {/*
+          The tooltip wraps the row content only (dot + title) — the delete
+          button stays a sibling so it keeps its own hover affordance, and the
+          li remains the ul's direct child (no span-wrapped li, invalid DOM).
+        */}
+        <Tooltip
+          text={`可拖拽或 ${modKeyLabel}+点击 并排打开`}
+          position="right"
+          className="desktop-session-item-tooltip"
+        >
+          <div className="desktop-session-item-main">
+            {running || waiting ? (
+              <i
+                className={`codicon codicon-${waiting ? 'bell' : 'loading codicon-modifier-spin'} desktop-session-status-icon`}
+                style={{ color: waiting ? 'var(--vscode-charts-purple, #b180d7)' : 'var(--vscode-charts-blue, #59a4f9)' }}
+                title={waiting ? '等待确认' : '正在运行'}
+              />
+            ) : (
+              <span className="desktop-session-dot" aria-hidden="true" />
+            )}
+            <span className="desktop-session-title">{session.title || '新对话'}</span>
+          </div>
+        </Tooltip>
         <button
           className="desktop-session-delete"
           title="删除会话"
@@ -192,26 +208,31 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
           onClose={() => setShowMoreMenu(false)}
         />
       )}
-      <button
-        className="desktop-sidebar-new-chat"
-        onClick={(e) => {
-          // Cmd on macOS / Ctrl elsewhere opens the new session side-by-side
-          // in a fresh pane; a plain click keeps the replace-focused-pane
-          // behavior (same branching as session items above).
-          if (isMacPlatform() ? e.metaKey : e.ctrlKey) {
-            onNewSessionInPane();
-          } else {
-            onNewSession();
-          }
-        }}
-        // 新对话在会话运行（streaming）期间也可用 — 多会话并行，旧会话在后台继续生成（FR-031）。
-        disabled={disabled}
-        title={isMacPlatform() ? '新对话（Cmd+Click 并排打开）' : '新对话（Ctrl+Click 并排打开）'}
-        data-testid="desktop-new-session"
+      <Tooltip
+        text={isMacPlatform() ? '新对话（Cmd+Click 并排打开）' : '新对话（Ctrl+Click 并排打开）'}
+        position="right"
+        className="desktop-sidebar-new-chat-tooltip"
       >
-        <span className="codicon codicon-add"></span>
-        <span>新对话</span>
-      </button>
+        <button
+          className="desktop-sidebar-new-chat"
+          onClick={(e) => {
+            // Cmd on macOS / Ctrl elsewhere opens the new session side-by-side
+            // in a fresh pane; a plain click keeps the replace-focused-pane
+            // behavior (same branching as session items above).
+            if (isMacPlatform() ? e.metaKey : e.ctrlKey) {
+              onNewSessionInPane();
+            } else {
+              onNewSession();
+            }
+          }}
+          // 新对话在会话运行（streaming）期间也可用 — 多会话并行，旧会话在后台继续生成（FR-031）。
+          disabled={disabled}
+          data-testid="desktop-new-session"
+        >
+          <span className="codicon codicon-add"></span>
+          <span>新对话</span>
+        </button>
+      </Tooltip>
       <div className="desktop-session-tree" data-testid="desktop-session-tree">
         {sessionTree.map((group) => {
           const expanded = isExpanded(group);

--- a/packages/webview/src/styles/DesktopApp.css
+++ b/packages/webview/src/styles/DesktopApp.css
@@ -61,7 +61,13 @@
     display: flex;
     align-items: center;
     gap: 4px;
-    margin: 8px 6px;
+    /* Vertical spacing only — the 6px side insets moved to the tooltip anchor
+       span (.desktop-sidebar-new-chat-tooltip) so the button can stretch to
+       the full row (width:100%) and its hover background covers it. <button>
+       elements shrink-fit their content even with display:flex, so an explicit
+       width is required. */
+    margin: 8px 0;
+    width: 100%;
     padding: 6px 6px;
     border: none;
     border-radius: 4px;
@@ -218,6 +224,33 @@
 .desktop-session-delete:hover {
     opacity: 1;
     color: var(--vscode-errorForeground, #f14c4c);
+}
+
+/* Drag-or-Cmd/Ctrl hint tooltip (Tooltip.tsx): the anchor wraps the row content
+   (dot + title) — the delete button stays a sibling so it keeps its own hover
+   affordance. The anchor must grow to fill the row for the title's ellipsis,
+   overriding .tooltip-container's flex-shrink:0 (DesktopApp.css loads after
+   Tooltip.css, so this class wins the cascade). */
+.desktop-session-item-tooltip {
+    flex: 1 1 0%;
+    min-width: 0;
+}
+
+/* New-chat hint tooltip: the Tooltip wrapper span defaults to inline-flex and
+   shrink-fits the button — block-level makes it fill the row, and the 6px
+   side padding keeps the button's hover background aligned with the session
+   items' inset. The two selectors beat .tooltip-container's single-class rule
+   regardless of the bundled CSS order. */
+.desktop-sidebar .desktop-sidebar-new-chat-tooltip {
+    display: block;
+    padding: 0 6px;
+}
+
+.desktop-session-item-main {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
 }
 
 .desktop-session-empty {

--- a/packages/webview/tests/webview/desktopApp.test.tsx
+++ b/packages/webview/tests/webview/desktopApp.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, fireEvent, createEvent, screen, within } from '@testing-library/react';
+import { render, fireEvent, createEvent, screen, within, act, waitFor } from '@testing-library/react';
 import React from 'react';
 import { DesktopApp } from '../../src/components/DesktopApp';
 import { createMockVscode, sendCommand, fireInput } from './test-utils';
@@ -468,6 +468,27 @@ describe('DesktopApp', () => {
         expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'newSession' });
     });
 
+    it('shows the side-by-side hint tooltip when hovering the new-chat button', async () => {
+        renderDesktopApp();
+        sendCommand('desktopWorkdirState', { workdir: '/home/user/project', recentWorkdirs: [] });
+
+        const btn = screen.getByTestId('desktop-new-session');
+        // The hint moved off the native title attribute onto the Tooltip.
+        expect(btn.getAttribute('title')).toBeNull();
+        const container = btn.closest('.tooltip-container') as HTMLElement;
+        expect(container).not.toBeNull();
+
+        await act(async () => {
+            fireEvent.mouseEnter(container);
+        });
+
+        await waitFor(() => {
+            const tooltip = document.querySelector('.tooltip-box.visible');
+            expect(tooltip).not.toBeNull();
+            expect(tooltip).toHaveTextContent('新对话（Ctrl+Click 并排打开）');
+        });
+    });
+
     it('should update the workdir name and enable new-chat when a new workdir state arrives', () => {
         renderDesktopApp();
         sendCommand('desktopWorkdirState', { recentWorkdirs: [] });
@@ -716,6 +737,57 @@ describe('DesktopApp', () => {
                 workdir: '/work/a',
                 sessionId: 's1',
             });
+        });
+
+        it('shows a drag-or-Ctrl hint tooltip on hover over a session item (non-mac)', async () => {
+            renderDesktopApp();
+            sendCommand('desktopWorkdirState', { workdir: '/work/a', recentWorkdirs: ['/work/a'] });
+            sendCommand('desktopSessionTree', {
+                groups: [{ host: 'local', workdir: '/work/a', sessions: [session('s1', 'hello a')] }],
+            });
+
+            const item = screen.getByTestId('desktop-session-item-s1');
+            // The tooltip wraps the row content, NOT the li — ul > li stays valid DOM.
+            expect(item.tagName).toBe('LI');
+            expect(item.parentElement?.className).toContain('desktop-session-items');
+            const container = item.querySelector('.tooltip-container') as HTMLElement;
+            expect(container).not.toBeNull();
+
+            await act(async () => {
+                fireEvent.mouseEnter(container);
+            });
+
+            await waitFor(() => {
+                const tooltip = document.querySelector('.tooltip-box.visible');
+                expect(tooltip).not.toBeNull();
+                expect(tooltip).toHaveTextContent('可拖拽或 Ctrl+点击 并排打开');
+            });
+        });
+
+        it('shows the Cmd variant of the session hint on macOS', async () => {
+            const originalPlatform = navigator.platform;
+            Object.defineProperty(navigator, 'platform', { value: 'MacIntel', configurable: true });
+            try {
+                renderDesktopApp();
+                sendCommand('desktopWorkdirState', { workdir: '/work/a', recentWorkdirs: ['/work/a'] });
+                sendCommand('desktopSessionTree', {
+                    groups: [{ host: 'local', workdir: '/work/a', sessions: [session('s1', 'hello a')] }],
+                });
+
+                const container = screen
+                    .getByTestId('desktop-session-item-s1')
+                    .querySelector('.tooltip-container') as HTMLElement;
+
+                await act(async () => {
+                    fireEvent.mouseEnter(container);
+                });
+
+                await waitFor(() => {
+                    expect(document.querySelector('.tooltip-box.visible')).toHaveTextContent('可拖拽或 Cmd+点击 并排打开');
+                });
+            } finally {
+                Object.defineProperty(navigator, 'platform', { value: originalPlatform, configurable: true });
+            }
         });
 
         it('shows a running dot on the streaming current session and marks it current', () => {


### PR DESCRIPTION
## 改动内容

桌面端侧边栏（`DesktopSidebar`）的会话项与「新对话」按钮增加悬停提示，说明「拖拽或 Cmd/Ctrl+点击 并排打开」的操作（对应 `docs/specs/ui/desktop-app.md` 的「并排多对话」与 FR-020 会话树）。

### 悬停提示（复用现有 Tooltip 组件，非原生 title）

- **会话项**：悬停显示「可拖拽或 Cmd/Ctrl+点击 并排打开」（macOS 显示 Cmd，其他平台 Ctrl，与现有点击分支 `isMacPlatform() ? e.metaKey : e.ctrlKey` 一致），tooltip 位于右侧。
- **新对话按钮**：悬停显示「新对话（Cmd/Ctrl+Click 并排打开）」，tooltip 同样改为右侧（原先 bottom，与会话项不一致）。

### 结构 / 样式要点

- 会话项为 `li`，Tooltip 渲染 `span.tooltip-container` 包裹 children —— 为避免 `ul > li` 中插入 span 造成非法 DOM，tooltip 只包裹行内容（状态点 + 标题），删除按钮仍为 `li` 的直接子元素（保留自身 hover 表现与「删除会话」提示）。
- 新对话按钮：tooltip 锚点 span 撑满整行（2 类选择器覆盖 `.tooltip-container` 的 inline-flex + 按钮 `width:100%`，修复 hover 背景未占满整行的问题），hover 背景与会话树条目的 6px 内缩对齐。
- 保持现有交互不变：拖拽、单击、Cmd/Ctrl+Click 并排、删除。

### 测试

新增 3 个用例（`desktopApp.test.tsx`）：新对话按钮提示、会话项拖拽/Ctrl 提示、macOS 下 Cmd 文案变体。`packages/webview` 全量测试通过（644/644），type-check 干净。

> 说明：hover 提示是对 spec 已定义交互（拖拽 / Cmd+Click 并排）的 UI 提示补充，未改动交互行为本身。