### PR TITLE
feat(permission): auto-allow read-only git commands with scope flags (git -C)

### DIFF
--- a/docs/specs/core/tool-permission-system.md
+++ b/docs/specs/core/tool-permission-system.md
@@ -83,6 +83,8 @@ order: 130
 7. **假设**任何文件，**当**用户执行 `awk '{print $1}' file` 或 `jq '.x' file.json` 时，**则**系统应该自动允许。
 8. **假设**任何命令，**当**用户执行 `cat $(rm important)` 或 `grep x \`whoami\`` 时，**则**系统不得自动允许（含命令替换/进程替换，可能触发隐藏的破坏性执行），必须提示权限确认。
 9. **假设**链式命令 `sed -n '1,10p' a.txt | grep foo`，**当** 执行时，**则** 系统应该自动允许（每段均为只读）。
+10. **假设**任何 git 仓库，**当**用户执行 `git -C /path/to/repo status`、`git -C /path/to/repo diff --stat` 或 `git -C /path/to/repo log --oneline` 时，**则** 系统应该自动允许（`git` 的全局作用域选项如 `-C <path>`、`-c <key>=<value>`、`--git-dir <path>` 只改变目标仓库或配置，不改变子命令的只读属性；匹配 `Bash(git status*)` 等规则时忽略这些前缀）。
+11. **假设**任何目录，**当**用户执行 `git -C /path/to/repo commit -m "msg"`、`git -C /path/to/repo push` 或 `git -C /path/to/repo branch -D feature` 时，**则** 系统不得自动允许，必须提示权限确认。
 
 ### 用户故事：MCP 工具权限（优先级：P1）
 

--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -26,6 +26,7 @@ import {
   hasCommandSubstitution,
   hasProcessSubstitution,
   hasSedInPlace,
+  stripGitScopePrefix,
   DANGEROUS_COMMANDS,
   READ_ONLY_COMMANDS,
 } from "../utils/bashParser.js";
@@ -876,7 +877,13 @@ export class PermissionManager {
         .replace(/\*/g, ".*"); // Replace * with .*
       const regex = new RegExp(`^${regexPattern}$`, "s");
       const matched = regex.test(processedPart);
-      return matched;
+      if (matched) return true;
+      // Leading git global scope flags (e.g. `git -C <path>`) only change the
+      // target repository, not the subcommand being run, so rules like
+      // Bash(git status*) also cover `git -C <path> status`. The raw command
+      // is checked first so path-specific rules (e.g. deny rules on
+      // `git -C /secret status`) still match.
+      return regex.test(stripGitScopePrefix(processedPart));
     }
 
     // Handle path-based rules (e.g., "Read(**/*.env)")

--- a/packages/agent-sdk/src/utils/bashParser.ts
+++ b/packages/agent-sdk/src/utils/bashParser.ts
@@ -557,6 +557,19 @@ export interface ToolRule {
   scopeFlags?: string[];
 }
 
+/**
+ * Global scope flags for git that only change the target repository or
+ * configuration, not the subcommand being run. Shared by TOOL_RULES (smart
+ * prefix extraction) and stripGitScopePrefix (rule matching).
+ */
+export const GIT_SCOPE_FLAGS = [
+  "-C",
+  "-c",
+  "--directory",
+  "--work-tree",
+  "--git-dir",
+];
+
 export const TOOL_RULES: Record<string, ToolRule> = {
   // Node/JS
   npm: { depth: 2, scopeFlags: ["--prefix", "-C", "--registry"] },
@@ -575,7 +588,7 @@ export const TOOL_RULES: Record<string, ToolRule> = {
   // Git
   git: {
     depth: 2,
-    scopeFlags: ["-C", "-c", "--directory", "--work-tree", "--git-dir"],
+    scopeFlags: GIT_SCOPE_FLAGS,
   },
 
   // Python
@@ -738,6 +751,37 @@ export function hasSedInPlace(command: string): boolean {
   const tokens = stripped.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || [];
   if (tokens.length === 0 || tokens[0] !== "sed") return false;
   return tokens.some((token) => /^-i(\..*)?$/.test(token));
+}
+
+/**
+ * Removes leading git global scope flags (e.g. `git -C <path>`, `git -c <key>=<value>`,
+ * `git --git-dir <path>`) from a command string, so that `git -C /tmp/foo status` is
+ * classified the same as `git status`. Only the leading sequence before the git
+ * subcommand is stripped; the remainder is re-joined with single spaces.
+ * Returns the input unchanged when nothing is stripped.
+ */
+export function stripGitScopePrefix(command: string): string {
+  const trimmed = command.trim();
+  if (!/^git(?:\s|$)/.test(trimmed)) return command;
+
+  const tokens = trimmed.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || [];
+  if (tokens.length === 0 || tokens[0] !== "git") return command;
+
+  let i = 1;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    const eqIndex = token.indexOf("=");
+    const flag = eqIndex > 0 ? token.slice(0, eqIndex) : token;
+    if (!GIT_SCOPE_FLAGS.includes(flag)) break;
+    if (eqIndex > 0) {
+      i++; // --flag=value form carries its own value
+    } else {
+      i += 2; // skip the flag and its argument
+    }
+  }
+
+  if (i === 1) return command;
+  return ["git", ...tokens.slice(i)].join(" ");
 }
 
 /**

--- a/packages/agent-sdk/tests/managers/permissionManager.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.test.ts
@@ -2714,5 +2714,116 @@ describe("PermissionManager", () => {
       const result = await permissionManager.checkPermission(context);
       expect(result.behavior).toBe("deny");
     });
+
+    describe("git with scope flags", () => {
+      it("should auto-allow 'git -C <path> status'", async () => {
+        const context: ToolPermissionContext = {
+          toolName: "Bash",
+          permissionMode: "default",
+          toolInput: { command: "git -C /home/user/project status", workdir },
+        };
+        const result = await permissionManager.checkPermission(context);
+        expect(result.behavior).toBe("allow");
+      });
+
+      it("should auto-allow 'git -C <path> diff --stat'", async () => {
+        const context: ToolPermissionContext = {
+          toolName: "Bash",
+          permissionMode: "default",
+          toolInput: {
+            command: "git -C /home/user/project diff --stat",
+            workdir,
+          },
+        };
+        const result = await permissionManager.checkPermission(context);
+        expect(result.behavior).toBe("allow");
+      });
+
+      it("should auto-allow 'git -C <path> log --oneline'", async () => {
+        const context: ToolPermissionContext = {
+          toolName: "Bash",
+          permissionMode: "default",
+          toolInput: {
+            command: "git -C /home/user/project log --oneline",
+            workdir,
+          },
+        };
+        const result = await permissionManager.checkPermission(context);
+        expect(result.behavior).toBe("allow");
+      });
+
+      it("should auto-allow 'git -C <path> branch --show-current'", async () => {
+        const context: ToolPermissionContext = {
+          toolName: "Bash",
+          permissionMode: "default",
+          toolInput: {
+            command: "git -C /home/user/project branch --show-current",
+            workdir,
+          },
+        };
+        const result = await permissionManager.checkPermission(context);
+        expect(result.behavior).toBe("allow");
+      });
+
+      it("should deny 'git -C <path> push'", async () => {
+        const context: ToolPermissionContext = {
+          toolName: "Bash",
+          permissionMode: "default",
+          toolInput: { command: "git -C /home/user/project push", workdir },
+        };
+        const result = await permissionManager.checkPermission(context);
+        expect(result.behavior).toBe("deny");
+      });
+
+      it("should deny 'git -C <path> commit'", async () => {
+        const context: ToolPermissionContext = {
+          toolName: "Bash",
+          permissionMode: "default",
+          toolInput: {
+            command: 'git -C /home/user/project commit -m "msg"',
+            workdir,
+          },
+        };
+        const result = await permissionManager.checkPermission(context);
+        expect(result.behavior).toBe("deny");
+      });
+
+      it("should deny 'git -C <path> branch -D'", async () => {
+        const context: ToolPermissionContext = {
+          toolName: "Bash",
+          permissionMode: "default",
+          toolInput: {
+            command: "git -C /home/user/project branch -D feature",
+            workdir,
+          },
+        };
+        const result = await permissionManager.checkPermission(context);
+        expect(result.behavior).toBe("deny");
+      });
+
+      it("should still deny via path-specific deny rule (raw match checked first)", async () => {
+        permissionManager.updateDeniedRules(["Bash(git -C /secret status)"]);
+
+        const context: ToolPermissionContext = {
+          toolName: "Bash",
+          permissionMode: "default",
+          toolInput: { command: "git -C /secret status", workdir },
+        };
+        const result = await permissionManager.checkPermission(context);
+        expect(result.behavior).toBe("deny");
+      });
+
+      it("should apply deny rule without path to 'git -C <path>' commands", async () => {
+        permissionManager.updateDeniedRules(["Bash(git status)"]);
+
+        const context: ToolPermissionContext = {
+          toolName: "Bash",
+          permissionMode: "default",
+          toolInput: { command: "git -C /home/user/project status", workdir },
+        };
+        const result = await permissionManager.checkPermission(context);
+        expect(result.behavior).toBe("deny");
+      });
+    });
   });
 });

--- a/packages/agent-sdk/tests/utils/bashParser.test.ts
+++ b/packages/agent-sdk/tests/utils/bashParser.test.ts
@@ -11,6 +11,7 @@ import {
   hasCommandSubstitution,
   hasProcessSubstitution,
   hasSedInPlace,
+  stripGitScopePrefix,
   READ_ONLY_COMMANDS,
 } from "../../src/utils/bashParser.js";
 
@@ -333,6 +334,56 @@ describe("bashParser", () => {
       expect(getSmartPrefix("sudo apt update")).toBe(null); // apt is dangerous
       expect(getSmartPrefix("sudo npm install")).toBe("sudo npm install");
       expect(getSmartPrefix("sudo git status")).toBe("sudo git status");
+    });
+  });
+
+  describe("stripGitScopePrefix", () => {
+    it("should strip leading -C <path>", () => {
+      expect(stripGitScopePrefix("git -C /tmp/foo status")).toBe("git status");
+      expect(stripGitScopePrefix("git -C /tmp/foo diff --stat")).toBe(
+        "git diff --stat",
+      );
+    });
+
+    it("should strip quoted -C <path>", () => {
+      expect(stripGitScopePrefix('git -C "/tmp/my repo" status')).toBe(
+        "git status",
+      );
+      expect(stripGitScopePrefix("git -C '/tmp/my repo' log --oneline")).toBe(
+        "git log --oneline",
+      );
+    });
+
+    it("should strip --flag=value and other scope flags", () => {
+      expect(stripGitScopePrefix("git --git-dir=/tmp/foo status")).toBe(
+        "git status",
+      );
+      expect(stripGitScopePrefix("git -c core.pager=cat log --oneline")).toBe(
+        "git log --oneline",
+      );
+      expect(stripGitScopePrefix("git --work-tree /tmp/foo status")).toBe(
+        "git status",
+      );
+    });
+
+    it("should strip multiple consecutive scope flags", () => {
+      expect(
+        stripGitScopePrefix("git -C /tmp/foo -c core.pager=cat status"),
+      ).toBe("git status");
+    });
+
+    it("should return the command unchanged when nothing is stripped", () => {
+      const cmd = "git status";
+      expect(stripGitScopePrefix(cmd)).toBe(cmd);
+      expect(stripGitScopePrefix("git commit -m 'msg'")).toBe(
+        "git commit -m 'msg'",
+      );
+      expect(stripGitScopePrefix("npm -C /tmp run build")).toBe(
+        "npm -C /tmp run build",
+      );
+      expect(stripGitScopePrefix("echo git -C /tmp status")).toBe(
+        "echo git -C /tmp status",
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Read-only bash commands using the `git -C <path>` form are now auto-allowed, matching plain `git status`/`git diff`/`git log` via the existing default rules (FR-019).

## Changes

- **`packages/agent-sdk/src/utils/bashParser.ts`**: add `GIT_SCOPE_FLAGS` (`-C`, `-c`, `--directory`, `--work-tree`, `--git-dir`) and `stripGitScopePrefix()` which strips leading git global scope flags before the subcommand (supports `-C <path>`, quoted paths, `--flag=value`, multiple consecutive flags).
- **`packages/agent-sdk/src/managers/permissionManager.ts`**: `matchesRule()` Bash branch now falls back to matching the stripped command. The raw command is checked first so path-specific deny rules (e.g. `Bash(git -C /secret status)`) keep precedence.
- **Spec**: FR-019 (内置安全命令与只读命令自动放行) gains acceptance scenarios 10–11: `git -C <path> status/diff --stat/log --oneline` auto-allowed; `git -C <path> commit/push/branch -D` still require confirmation.
- **Tests**: 5 `stripGitScopePrefix` unit tests + 9 permission-manager integration tests (auto-allow status/diff/log/branch --show-current; deny push/commit/branch -D; deny-rule precedence both with and without path).

## Verification

- `bashParser.test.ts` + `permissionManager.test.ts`: 259 passed
- Fail-without-fix verified: 4 auto-allow tests fail when the matchesRule change is reverted
- `tsc --noEmit` (agent-sdk): clean
- spec-count: 71 specs / 365 stories / 1376 scenarios