### PR TITLE
fix(agent-sdk): preserve truncated reasoning in assistant messages without triggering 400

### DIFF
--- a/docs/specs/core/ai-error-handling.md
+++ b/docs/specs/core/ai-error-handling.md
@@ -56,11 +56,11 @@ order: 120
 
 **为什么是这个优先级**：当前纯 Reasoning 段（无文本、无工具调用）的 assistant 消息在转换为 API 消息时被过滤，模型每轮续写都看不到自己上一轮的推理，只能重新推导出同量级的 reasoning 再次被截断——这是无限续写循环的放大器之一。Claude Code 要求 thinking 块在整个 assistant trajectory 内保留（_"Thinking blocks must be preserved for the duration of an assistant trajectory"_），其续写是接着上一轮思考继续的。
 
-**独立测试**：可以构造"user 任务 → assistant 纯 reasoning（截断）→ user 隐藏恢复消息"的消息序列，验证转换后的 API 消息包含带 `reasoning_content` 的 assistant 消息。
+**独立测试**：可以构造"user 任务 → assistant 纯 reasoning（截断）→ user 隐藏恢复消息"的消息序列，验证转换后的 API 消息包含 assistant 消息：推理内容保留在 `reasoning_content` 字段，`content` 为说明思考未完成、由系统自动保留的提示文案。
 
 **验收场景**：
 
-1. **假设**AI 响应因输出 token 限制被截断，且该轮只有 reasoning 内容（无文本、无工具调用），**当**代理发起下一轮续写调用时，**则**转换后的 API 消息应包含该 assistant 消息及其 `reasoning_content`，模型能看到自己上一轮的全部推理
+1. **假设**AI 响应因输出 token 限制被截断，且该轮只有 reasoning 内容（无文本、无工具调用），**当**代理发起下一轮续写调用时，**则**转换后的 API 消息应包含该 assistant 消息，推理内容保留在 `reasoning_content` 字段（推理模型原生续接通道），`content` 为一段说明文案——OpenAI 兼容上游拒绝无 `content`/`tool_calls` 的 assistant 消息（仅带 `reasoning_content` 会触发 400 "content or tool_calls must be set"），说明文案同时告知模型思考未完成、由系统自动保留，可续接或忽略——模型仍能看到自己上一轮的全部推理
 2. **假设**AI 响应因长度限制被截断但该轮包含文本内容，**当**代理发起下一轮续写调用时，**则**`reasoning_content` 照常随 assistant 消息一起发送（现有行为不变）
 3. **假设**某 assistant 轮次既无文本、无工具调用也无 reasoning 内容，**当**转换 API 消息时，**则**该消息继续被过滤，不产生空的 assistant 消息
 
@@ -119,7 +119,7 @@ order: 120
 - **无限递归**：如果 AI 不断被截断会发生什么？
   - _对齐 Claude Code_：连续截断恢复上限为 3 次（中间无工具调用则计数不重置），达到上限后终止回合并显示错误消息，不再无限续写；工具调用（正常进度）会重置计数
 - **截断恢复上下文**：纯 reasoning 截断轮（无文本、无工具调用）的推理内容是否应该保留到下一轮？
-  - _对齐 Claude Code_：保留。转换 API 消息时，带 `reasoning_content` 的 assistant 消息即使没有文本和工具调用也应包含在下一轮请求中，使续写能接着上一轮思考继续；既无文本、无工具调用也无 reasoning 的空消息仍被过滤
+  - _对齐 Claude Code_：保留。推理内容放在 `reasoning_content` 原生字段（推理模型天然从中续接），`content` 携带说明文案（思考未完成、系统自动保留，可续接或忽略）以满足 OpenAI 兼容上游"assistant 消息必须有 `content` 或 `tool_calls`"的校验（仅带 `reasoning_content` 会被剥离并触发 400 "content or tool_calls must be set"）；有文本的轮次 `reasoning_content` 照常随行、`content` 用真实文本；既无文本、无工具调用也无 reasoning 的空消息仍被过滤
 - **中断**：如果用户在截断响应期间中止会话会发生什么？
   - _假设_：代理应该尊重中止信号并停止递归
 - **后台工具**：如果工具在截断响应期间被放到后台会发生什么？

--- a/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
+++ b/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
@@ -221,10 +221,28 @@ export function convertMessagesForAPI(
         reasoning_content && reasoning_content.trim().length > 0;
 
       if (hasContent || hasToolCalls || hasReasoning) {
+        // OpenAI-compatible upstreams reject assistant messages where neither
+        // content nor tool_calls is set — a reasoning_content-only message
+        // gets stripped and returns 400 "content or tool_calls must be set"
+        // (this is fine for Claude Code, whose thinking blocks ARE content).
+        // When a turn produced only thinking (interrupted/truncated
+        // mid-reasoning), the thinking stays on its native reasoning_content
+        // field (the channel reasoning models natively continue from), and
+        // content carries an explanatory note so the request stays valid and
+        // the model knows the thinking was cut off and auto-preserved.
+        const fallbackContent = hasContent
+          ? content
+          : hasReasoning
+            ? "[Note: The reasoning above was cut off before completion. It was auto-preserved from an interrupted or truncated turn — continue from where it left off, or disregard it if no longer relevant.]"
+            : undefined;
+
         const assistantMessage: ChatCompletionMessageParam = {
           role: "assistant",
-          content: hasContent ? content : undefined,
+          content: fallbackContent,
           tool_calls,
+          // Sent whenever reasoning exists: alongside real text it is the
+          // turn's own thinking; in the fallback case it carries the
+          // preserved thinking itself (content only holds the note).
           ...(reasoning_content ? { reasoning_content } : {}),
           ...(message.additionalFields ? { ...message.additionalFields } : {}),
         } as ChatCompletionMessageParam;

--- a/packages/agent-sdk/tests/utils/convertMessagesForAPI.test.ts
+++ b/packages/agent-sdk/tests/utils/convertMessagesForAPI.test.ts
@@ -454,6 +454,13 @@ describe("convertMessagesForAPI", () => {
     const assistantMessage = apiMessages[1] as ChatCompletionMessageParam & {
       reasoning_content?: string;
     };
+    // Reasoning-only messages fall back to an explanatory note as content
+    // (OpenAI-compatible upstreams reject assistant messages without
+    // content/tool_calls), while the thinking itself stays on the native
+    // reasoning_content field so reasoning models continue from it.
+    expect(assistantMessage.content).toBe(
+      "[Note: The reasoning above was cut off before completion. It was auto-preserved from an interrupted or truncated turn — continue from where it left off, or disregard it if no longer relevant.]",
+    );
     expect(assistantMessage.reasoning_content).toBe(
       "Let me understand the task deeply... (truncated before any text or tool call)",
     );


### PR DESCRIPTION
## 问题

手动中断 thinking 流式输出后发送新消息，Wave 报错：

```
HTTP 400 Bad Request: Invalid assistant message: content or tool_calls must be set
```

## 根因

PR #1717 (commit ed4e619a) 让纯 reasoning 轮（无文本、无工具调用）的 assistant 消息保留在下一轮请求中，但 OpenAI 兼容上游会剥离 `reasoning_content` 字段，导致 assistant 消息既无 `content` 也无 `tool_calls`，返回 400。Claude Code 无此问题——其 thinking 块本身就是 content。截断自动续写路径（finish_reason === "length"）同样受影响。

## 修复

`convertMessagesForAPI` 是唯一序列化收口点，同时覆盖手动中断和截断自动续写两条路径：

- 纯 reasoning 轮：思考保留在原生 `reasoning_content` 字段（推理模型天然续接通道），`content` 携带说明文案（思考未完成、系统自动保留，可续接或忽略），满足上游校验
- 有文本的轮次：`content` 用真实文本，`reasoning_content` 照常随行（现有行为不变）
- 既无文本、无工具调用也无 reasoning 的空消息仍被过滤

## 验证

- convertMessagesForAPI.test.ts：25/25 通过
- aiManager_finishReason.test.ts：5/5 通过
- agent-sdk 全套：253 文件 / 3478 通过 / 1 跳过
- tsc --noEmit 干净
- spec-count：71 / 365 / 1374