### PR TITLE
fix: register vision subagent from settings.json env at startup

### DIFF
--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -192,6 +192,30 @@ export class SubagentManager {
   }
 
   /**
+   * Rebuild the cached subagent configurations. Called after settings.json
+   * env becomes available (post loadMergedConfiguration) so conditional
+   * builtin subagents (e.g. `model: visionModel` requiring WAVE_VISION_MODEL)
+   * register correctly. Plugin agents are preserved across the rebuild.
+   */
+  async refreshConfigurations(): Promise<SubagentConfiguration[]> {
+    // Preserve plugin agents (namespaced `pluginName:agentName`) across the rebuild
+    const pluginAgents = (this.cachedConfigurations ?? []).filter((config) =>
+      config.name.includes(":"),
+    );
+    this.cachedConfigurations = null;
+    await this.loadConfigurations();
+    for (const agent of pluginAgents) {
+      this.cachedConfigurations!.push(agent);
+    }
+    // Re-sort by priority then name (matches registerPluginAgents)
+    this.cachedConfigurations!.sort((a, b) => {
+      if (a.priority !== b.priority) return a.priority - b.priority;
+      return a.name.localeCompare(b.name);
+    });
+    return this.cachedConfigurations!;
+  }
+
+  /**
    * Get the merged environment (OS env overlaid with settings.json env) used
    * for conditional subagent registration (e.g. WAVE_VISION_MODEL).
    */

--- a/packages/agent-sdk/src/services/initializationService.ts
+++ b/packages/agent-sdk/src/services/initializationService.ts
@@ -150,6 +150,12 @@ export class InitializationService {
       const configResult =
         await configurationService.loadMergedConfiguration(workdir);
 
+      // Rebuild subagent configurations now that settings.json env is loaded
+      // into the snapshot: conditional builtin subagents (model: visionModel
+      // → WAVE_VISION_MODEL) can only register once the env is available.
+      // Plugin agents are preserved by refreshConfigurations.
+      await subagentManager.refreshConfigurations();
+
       hookManager.loadConfigurationFromWaveConfig(configResult.configuration);
 
       // Update plugin manager with enabled plugins configuration

--- a/packages/agent-sdk/tests/managers/subagentManager.refreshConfigurations.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.refreshConfigurations.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Container } from "../../src/utils/container.js";
+import { SubagentManager } from "../../src/managers/subagentManager.js";
+import type { SubagentConfiguration } from "../../src/utils/subagentParser.js";
+
+const baseConfig = (
+  name: string,
+  extra: Partial<SubagentConfiguration> = {},
+): SubagentConfiguration => ({
+  name,
+  description: name,
+  systemPrompt: "p",
+  filePath: `/tmp/subagents/${name}.md`,
+  scope: "builtin",
+  priority: 100,
+  ...extra,
+});
+
+// Simulates the real conditional registration in subagentParser.ts: builtin
+// subagents with `model: visionModel` are only included when the merged env
+// carries WAVE_VISION_MODEL.
+const mockLoadSubagentConfigurations = vi.fn(
+  async (_workdir: string, env: Record<string, string>) => {
+    const configs: SubagentConfiguration[] = [baseConfig("bash")];
+    if (env.WAVE_VISION_MODEL) {
+      configs.push(
+        baseConfig("vision", { tools: ["Read"], model: "visionModel" }),
+      );
+    }
+    return configs;
+  },
+);
+
+vi.mock("../../src/utils/subagentParser.js", () => ({
+  loadSubagentConfigurations: (workdir: string, env: Record<string, string>) =>
+    mockLoadSubagentConfigurations(workdir, env),
+  findSubagentByName: vi.fn().mockResolvedValue(null),
+}));
+
+const mockGetMergedEnv = vi.fn();
+vi.mock("../../src/services/configurationService.js", () => ({
+  ConfigurationService: vi.fn().mockImplementation(function () {
+    return { getMergedEnv: mockGetMergedEnv };
+  }),
+}));
+
+import { ConfigurationService } from "../../src/services/configurationService.js";
+
+describe("SubagentManager.refreshConfigurations", () => {
+  let container: Container;
+  let subagentManager: SubagentManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    container = new Container();
+    container.register(
+      "ConfigurationService",
+      new ConfigurationService() as unknown as ConfigurationService,
+    );
+    subagentManager = new SubagentManager(container, {
+      workdir: "/tmp/test",
+      stream: false,
+    });
+  });
+
+  it("registers vision subagent after settings env becomes available, preserving plugin agents", async () => {
+    // Session start: settings.json env not yet loaded → no WAVE_VISION_MODEL
+    mockGetMergedEnv.mockReturnValue({});
+    await subagentManager.loadConfigurations();
+    expect(
+      subagentManager.getConfigurations().map((c) => c.name),
+    ).not.toContain("vision");
+
+    // Plugin agents registered before config load
+    subagentManager.registerPluginAgents("my-plugin", [
+      baseConfig("helper", { scope: "plugin" }),
+    ]);
+    expect(subagentManager.getConfigurations().map((c) => c.name)).toContain(
+      "my-plugin:helper",
+    );
+
+    // After loadMergedConfiguration, env snapshot carries WAVE_VISION_MODEL
+    mockGetMergedEnv.mockReturnValue({ WAVE_VISION_MODEL: "qwen-vl-max" });
+    await subagentManager.refreshConfigurations();
+
+    const names = subagentManager.getConfigurations().map((c) => c.name);
+    expect(names).toContain("vision");
+    // Plugin agent survives the rebuild, exactly once
+    expect(names.filter((n) => n === "my-plugin:helper")).toHaveLength(1);
+  });
+
+  it("keeps vision filtered out when env still lacks WAVE_VISION_MODEL", async () => {
+    mockGetMergedEnv.mockReturnValue({});
+    await subagentManager.loadConfigurations();
+    await subagentManager.refreshConfigurations();
+    expect(
+      subagentManager.getConfigurations().map((c) => c.name),
+    ).not.toContain("vision");
+  });
+});


### PR DESCRIPTION
## 背景

内置 vision 子代理（frontmatter `model: visionModel` → `WAVE_VISION_MODEL`）在 settings.json 的 `env` 中配置时，新会话中从未注册：`/agents` 列表看不到、Agent 工具描述里也没有，主模型无法发现并委托。

## 根因

初始化顺序问题（`initializationService.ts`）：
- `subagentManager.initialize()`（:90）先于 `loadMergedConfiguration()`（:151）执行，而后者才把 settings.json 的 `env` 载入快照
- `subagentParser.ts` 在 env 缺少 `WAVE_VISION_MODEL` 时过滤掉 `model: visionModel` 的内置子代理
- 子代理缓存只在会话启动时构建一次，无失效机制 → 新会话也永远注册不上

## 修复

- **`subagentManager.ts`**：新增 `refreshConfigurations()`，清空缓存后重建，保留已注册的插件代理（`pluginName:agentName`）并重新按 priority/name 排序
- **`initializationService.ts`**：在 `loadMergedConfiguration(workdir)` 之后调用 `refreshConfigurations()`，此时 env 快照已含 `WAVE_VISION_MODEL`，vision 子代理正确注册
- 未做全量初始化重排：插件加载需在 subagent 之后写入缓存、又需在 MCP 之前注册插件 MCP server，局部刷新风险最小

## 测试

- 新增 `subagentManager.refreshConfigurations.test.ts`（2 例）：模拟「初始无 env → 注册插件代理 → env 就绪后刷新」时序，断言 vision 出现且插件代理恰好保留一次；env 仍缺失时 vision 保持过滤
- agent-sdk 全量 254 文件 / 3504 测试通过；全仓 type-check 通过