### PR TITLE
fix(code): drop stale streaming flush when tool block turns running

### DIFF
--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -249,7 +249,7 @@ function createStreamingWindowThrottle(
  * `running` apply immediately (one-shot snapshots); `end` flushes pending
  * streaming deltas first, then applies the authoritative parameters/result.
  */
-function createToolStreamingThrottle(
+export function createToolStreamingThrottle(
   fn: (params: ToolBlockUpdateCallbackParams) => void,
   wait: number,
 ): {
@@ -295,7 +295,22 @@ function createToolStreamingThrottle(
       }
       return;
     }
-    // start / running — one-shot snapshots applied immediately
+    // start / running — one-shot snapshots applied immediately. Drop this
+    // tool's buffered streaming deltas first: start/running carry the
+    // authoritative parameters, and a pending timer would otherwise fire late
+    // with a stale `streaming` event, regressing this tool block's stage back
+    // to streaming (yellow dot -> gray) mid-execution. Other tools' in-flight
+    // chunks are kept so interleaved multi-tool streaming still accumulates.
+    if (pending) {
+      pending.chunks.delete(params.id);
+      if (pending.chunks.size === 0) {
+        pending = null;
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+      }
+    }
     fn(params);
   };
 

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -5,6 +5,7 @@ import {
   ChatProvider,
   useChat,
   ChatContextType,
+  createToolStreamingThrottle,
 } from "../../src/contexts/useChat.js";
 import { Agent, BackgroundShell, Task } from "wave-agent-sdk";
 import { AppProvider } from "../../src/contexts/useAppConfig.js";
@@ -1458,6 +1459,186 @@ describe("ChatProvider", () => {
       // deltas, so the FIRST tool never showed streaming parameters
       expect(params["tool-a"]).toBe('{"file": "a.txt"}');
       expect(params["tool-b"]).toBe('{"file_path": "b.txt"}');
+    });
+  });
+
+  it("keeps a tool block running when the throttle window straddles streaming→running", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
+    const callbacks = agentCreateArgs.callbacks!;
+
+    const assistantMsg = {
+      id: "msg-dot",
+      role: "assistant" as const,
+      blocks: [],
+      timestamp: new Date().toISOString(),
+    };
+    Object.assign(mockAgent, { messages: [assistantMsg] });
+    callbacks.onAssistantMessageAdded!("msg-dot");
+    await vi.waitFor(() => {
+      expect(lastValue?.messages).toHaveLength(1);
+    });
+
+    // Tool args start streaming; the last chunk lands inside the 500ms
+    // throttle window (buffered, timer still armed)
+    callbacks.onToolBlockUpdated!({
+      messageId: "msg-dot",
+      id: "tool-dot",
+      name: "bash",
+      stage: "start",
+      parameters: "",
+    });
+    await vi.waitFor(() => {
+      expect(
+        lastValue?.messages[0].blocks.some(
+          (b) => b.type === "tool" && b.id === "tool-dot",
+        ),
+      ).toBe(true);
+    });
+
+    callbacks.onToolBlockUpdated!({
+      messageId: "msg-dot",
+      id: "tool-dot",
+      stage: "streaming",
+      parametersChunk: "{",
+    });
+
+    // running arrives before the window elapses — applied immediately with
+    // the authoritative parameters
+    callbacks.onToolBlockUpdated!({
+      messageId: "msg-dot",
+      id: "tool-dot",
+      name: "bash",
+      stage: "running",
+      parameters: '{"cmd":"ls"}',
+    });
+    await vi.waitFor(() => {
+      const toolBlock = lastValue?.messages[0].blocks.find(
+        (b) => b.type === "tool" && b.id === "tool-dot",
+      );
+      expect(toolBlock).toMatchObject({ stage: "running" });
+    });
+
+    // Regression: the pending streaming flush must not fire late and regress
+    // the block back to "streaming" (yellow dot → gray mid-execution), nor
+    // append the stale buffered chunk to the authoritative parameters.
+    // The stale flush (if armed) fires as soon as the 500ms window elapses;
+    // a waitFor asserting "running" would early-resolve on the not-yet-committed
+    // state, so instead assert the opposite: a short poll for a regressed
+    // "streaming" stage must NEVER resolve.
+    await vi.advanceTimersByTimeAsync(600);
+    await expect(
+      vi.waitFor(
+        () => {
+          const tb = lastValue?.messages[0].blocks.find(
+            (b) => b.type === "tool" && b.id === "tool-dot",
+          );
+          expect((tb as { stage?: string } | undefined)?.stage).toBe(
+            "streaming",
+          );
+        },
+        { timeout: 300, interval: 50 },
+      ),
+    ).rejects.toThrow();
+    // The block is still running with the authoritative parameters, and the
+    // stale chunk was never appended
+    const toolBlock = lastValue?.messages[0].blocks.find(
+      (b) => b.type === "tool" && b.id === "tool-dot",
+    );
+    expect(toolBlock).toMatchObject({
+      stage: "running",
+      parameters: '{"cmd":"ls"}',
+    });
+  });
+
+  describe("createToolStreamingThrottle", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("drops a tool's buffered streaming deltas when running arrives so no stale flush regresses the stage", () => {
+      vi.useFakeTimers();
+      const fn = vi.fn();
+      const throttled = createToolStreamingThrottle(fn, 500);
+
+      throttled({
+        messageId: "m",
+        id: "bash",
+        name: "bash",
+        stage: "start",
+        parameters: "",
+      });
+      throttled({
+        messageId: "m",
+        id: "bash",
+        stage: "streaming",
+        parametersChunk: "{",
+      });
+      throttled({
+        messageId: "m",
+        id: "bash",
+        name: "bash",
+        stage: "running",
+        parameters: '{"cmd":"ls"}',
+      });
+
+      // The throttle window elapses — the stale streaming chunk must NOT fire
+      // late and regress the block back to "streaming"
+      vi.advanceTimersByTime(600);
+      expect(fn).toHaveBeenCalledTimes(2);
+      expect(fn.mock.calls.map((c) => c[0].stage)).toEqual([
+        "start",
+        "running",
+      ]);
+      expect(fn).not.toHaveBeenCalledWith(
+        expect.objectContaining({ stage: "streaming", parametersChunk: "{" }),
+      );
+    });
+
+    it("keeps other tools' in-flight streaming deltas when one tool goes running", () => {
+      vi.useFakeTimers();
+      const fn = vi.fn();
+      const throttled = createToolStreamingThrottle(fn, 500);
+
+      throttled({
+        messageId: "m",
+        id: "tool-a",
+        stage: "streaming",
+        parametersChunk: '{"fi',
+      });
+      throttled({
+        messageId: "m",
+        id: "tool-b",
+        stage: "streaming",
+        parametersChunk: '{"file',
+      });
+      throttled({
+        messageId: "m",
+        id: "tool-a",
+        name: "bash",
+        stage: "running",
+        parameters: '{"file": "a.txt"}',
+      });
+
+      // tool-a's stale chunk is dropped, but tool-b's still flushes at the
+      // window boundary — interleaved multi-tool streaming keeps working
+      vi.advanceTimersByTime(500);
+      const streamingCalls = fn.mock.calls
+        .map((c) => c[0] as { stage: string; id: string })
+        .filter((c) => c.stage === "streaming");
+      expect(streamingCalls).toEqual([
+        expect.objectContaining({ id: "tool-b", parametersChunk: '{"file' }),
+      ]);
     });
   });
 


### PR DESCRIPTION
## 问题

bash tool 的状态圆点偶现闪烁：先变黄（running）→ 快速变灰（streaming）→ 再变黄。纯 UI stage 回退，数据不受影响。

## 根因

`createToolStreamingThrottle`（packages/code/src/contexts/useChat.tsx）的 start/running 分支直接应用快照，但不清理已武装的 timer 和缓冲的 streaming chunk。当 bash 工具 args 最后一个 chunk 落在 500ms 节流窗口内时：

1. `running` 事件立即应用 → 黄点
2. 窗口结束后 timer 触发，带出过期的 `{stage:"streaming", parametersChunk}` → 块被改回 streaming → 灰点
3. bash 执行中的进度回调重新 emit `running` → 再变黄

## 修复

start/running 分支先丢弃**本工具**的缓冲 chunk（缓冲区清空时取消 timer），再应用权威快照。其他工具在途的 chunk 保留，交错多工具 streaming 不受影响。

## 验证

- 3 个回归测试（1 集成 + 2 单元）在无修复时全部失败，修复后全部通过
- packages/code 全量 95 文件 / 1339 测试通过，type-check / lint 干净