### PR TITLE
fix(webview): restore sidebar hover tooltips lost in prettier format commit

### DIFF
--- a/packages/webview/src/components/DesktopSidebar.tsx
+++ b/packages/webview/src/components/DesktopSidebar.tsx
@@ -88,6 +88,9 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
     title: string;
     description?: string;
   } | null>(null);
+  // Modifier key label for the side-by-side hints, same platform branch as the
+  // click handlers below (Cmd on macOS / Ctrl elsewhere).
+  const modKeyLabel = isMacPlatform() ? "Cmd" : "Ctrl";
 
   const isExpanded = (group: DesktopSessionGroup): boolean =>
     overrides[groupKey(group)] ?? true;
@@ -148,22 +151,35 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
         }}
         data-testid={`desktop-session-item-${session.sessionId}`}
       >
-        {running || waiting ? (
-          <i
-            className={`codicon codicon-${waiting ? "bell" : "loading codicon-modifier-spin"} desktop-session-status-icon`}
-            style={{
-              color: waiting
-                ? "var(--vscode-charts-purple, #b180d7)"
-                : "var(--vscode-charts-blue, #59a4f9)",
-            }}
-            title={waiting ? "等待确认" : "正在运行"}
-          />
-        ) : (
-          <span className="desktop-session-dot" aria-hidden="true" />
-        )}
-        <span className="desktop-session-title">
-          {session.title || "新对话"}
-        </span>
+        {/*
+          The tooltip wraps the row content only (dot + title) — the delete
+          button stays a sibling so it keeps its own hover affordance, and the
+          li remains the ul's direct child (no span-wrapped li, invalid DOM).
+        */}
+        <Tooltip
+          text={`可拖拽或 ${modKeyLabel}+点击 并排打开`}
+          position="right"
+          className="desktop-session-item-tooltip"
+        >
+          <div className="desktop-session-item-main">
+            {running || waiting ? (
+              <i
+                className={`codicon codicon-${waiting ? "bell" : "loading codicon-modifier-spin"} desktop-session-status-icon`}
+                style={{
+                  color: waiting
+                    ? "var(--vscode-charts-purple, #b180d7)"
+                    : "var(--vscode-charts-blue, #59a4f9)",
+                }}
+                title={waiting ? "等待确认" : "正在运行"}
+              />
+            ) : (
+              <span className="desktop-session-dot" aria-hidden="true" />
+            )}
+            <span className="desktop-session-title">
+              {session.title || "新对话"}
+            </span>
+          </div>
+        </Tooltip>
         <button
           className="desktop-session-delete"
           title="删除会话"
@@ -216,30 +232,35 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
           onClose={() => setShowMoreMenu(false)}
         />
       )}
-      <button
-        className="desktop-sidebar-new-chat"
-        onClick={(e) => {
-          // Cmd on macOS / Ctrl elsewhere opens the new session side-by-side
-          // in a fresh pane; a plain click keeps the replace-focused-pane
-          // behavior (same branching as session items above).
-          if (isMacPlatform() ? e.metaKey : e.ctrlKey) {
-            onNewSessionInPane();
-          } else {
-            onNewSession();
-          }
-        }}
-        // 新对话在会话运行（streaming）期间也可用 — 多会话并行，旧会话在后台继续生成（FR-031）。
-        disabled={disabled}
-        title={
+      <Tooltip
+        text={
           isMacPlatform()
             ? "新对话（Cmd+Click 并排打开）"
             : "新对话（Ctrl+Click 并排打开）"
         }
-        data-testid="desktop-new-session"
+        position="right"
+        className="desktop-sidebar-new-chat-tooltip"
       >
-        <span className="codicon codicon-add"></span>
-        <span>新对话</span>
-      </button>
+        <button
+          className="desktop-sidebar-new-chat"
+          onClick={(e) => {
+            // Cmd on macOS / Ctrl elsewhere opens the new session side-by-side
+            // in a fresh pane; a plain click keeps the replace-focused-pane
+            // behavior (same branching as session items above).
+            if (isMacPlatform() ? e.metaKey : e.ctrlKey) {
+              onNewSessionInPane();
+            } else {
+              onNewSession();
+            }
+          }}
+          // 新对话在会话运行（streaming）期间也可用 — 多会话并行，旧会话在后台继续生成（FR-031）。
+          disabled={disabled}
+          data-testid="desktop-new-session"
+        >
+          <span className="codicon codicon-add"></span>
+          <span>新对话</span>
+        </button>
+      </Tooltip>
       <div className="desktop-session-tree" data-testid="desktop-session-tree">
         {sessionTree.map((group) => {
           const expanded = isExpanded(group);

--- a/packages/webview/src/styles/DesktopApp.css
+++ b/packages/webview/src/styles/DesktopApp.css
@@ -61,7 +61,13 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  margin: 8px 6px;
+  /* Vertical spacing only — the 6px side insets moved to the tooltip anchor
+     span (.desktop-sidebar-new-chat-tooltip) so the button can stretch to
+     the full row (width:100%) and its hover background covers it. <button>
+     elements shrink-fit their content even with display:flex, so an explicit
+     width is required. */
+  margin: 8px 0;
+  width: 100%;
   padding: 6px 6px;
   border: none;
   border-radius: 4px;
@@ -218,6 +224,33 @@
 .desktop-session-delete:hover {
   opacity: 1;
   color: var(--vscode-errorForeground, #f14c4c);
+}
+
+/* Drag-or-Cmd/Ctrl hint tooltip (Tooltip.tsx): the anchor wraps the row content
+   (dot + title) — the delete button stays a sibling so it keeps its own hover
+   affordance. The anchor must grow to fill the row for the title's ellipsis,
+   overriding .tooltip-container's flex-shrink:0 (DesktopApp.css loads after
+   Tooltip.css, so this class wins the cascade). */
+.desktop-session-item-tooltip {
+  flex: 1 1 0%;
+  min-width: 0;
+}
+
+/* New-chat hint tooltip: the Tooltip wrapper span defaults to inline-flex and
+   shrink-fits the button — block-level makes it fill the row, and the 6px
+   side padding keeps the button's hover background aligned with the session
+   items' inset. The two selectors beat .tooltip-container's single-class rule
+   regardless of the bundled CSS order. */
+.desktop-sidebar .desktop-sidebar-new-chat-tooltip {
+  display: block;
+  padding: 0 6px;
+}
+
+.desktop-session-item-main {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
 }
 
 .desktop-session-empty {
@@ -684,7 +717,10 @@ body.is-panel-resizing * {
 }
 
 .preview-pane-address::placeholder {
-  color: var(--vscode-input-placeholderForeground, var(--vscode-descriptionForeground, #999));
+  color: var(
+    --vscode-input-placeholderForeground,
+    var(--vscode-descriptionForeground, #999)
+  );
 }
 
 .preview-pane-button {

--- a/packages/webview/tests/webview/desktopApp.test.tsx
+++ b/packages/webview/tests/webview/desktopApp.test.tsx
@@ -5,6 +5,8 @@ import {
   createEvent,
   screen,
   within,
+  act,
+  waitFor,
 } from "@testing-library/react";
 import React from "react";
 import { DesktopApp } from "../../src/components/DesktopApp";
@@ -753,6 +755,30 @@ describe("DesktopApp", () => {
     expect(vscode.postMessage).toHaveBeenCalledWith({ command: "newSession" });
   });
 
+  it("shows the side-by-side hint tooltip when hovering the new-chat button", async () => {
+    renderDesktopApp();
+    sendCommand("desktopWorkdirState", {
+      workdir: "/home/user/project",
+      recentWorkdirs: [],
+    });
+
+    const btn = screen.getByTestId("desktop-new-session");
+    // The hint moved off the native title attribute onto the Tooltip.
+    expect(btn.getAttribute("title")).toBeNull();
+    const container = btn.closest(".tooltip-container") as HTMLElement;
+    expect(container).not.toBeNull();
+
+    await act(async () => {
+      fireEvent.mouseEnter(container);
+    });
+
+    await waitFor(() => {
+      const tooltip = document.querySelector(".tooltip-box.visible");
+      expect(tooltip).not.toBeNull();
+      expect(tooltip).toHaveTextContent("新对话（Ctrl+Click 并排打开）");
+    });
+  });
+
   it("should update the workdir name and enable new-chat when a new workdir state arrives", () => {
     renderDesktopApp();
     sendCommand("desktopWorkdirState", { recentWorkdirs: [] });
@@ -1114,6 +1140,83 @@ describe("DesktopApp", () => {
         workdir: "/work/a",
         sessionId: "s1",
       });
+    });
+
+    it("shows a drag-or-Ctrl hint tooltip on hover over a session item (non-mac)", async () => {
+      renderDesktopApp();
+      sendCommand("desktopWorkdirState", {
+        workdir: "/work/a",
+        recentWorkdirs: ["/work/a"],
+      });
+      sendCommand("desktopSessionTree", {
+        groups: [
+          {
+            host: "local",
+            workdir: "/work/a",
+            sessions: [session("s1", "hello a")],
+          },
+        ],
+      });
+
+      const item = screen.getByTestId("desktop-session-item-s1");
+      // The tooltip wraps the row content, NOT the li — ul > li stays valid DOM.
+      expect(item.tagName).toBe("LI");
+      expect(item.parentElement?.className).toContain("desktop-session-items");
+      const container = item.querySelector(".tooltip-container") as HTMLElement;
+      expect(container).not.toBeNull();
+
+      await act(async () => {
+        fireEvent.mouseEnter(container);
+      });
+
+      await waitFor(() => {
+        const tooltip = document.querySelector(".tooltip-box.visible");
+        expect(tooltip).not.toBeNull();
+        expect(tooltip).toHaveTextContent("可拖拽或 Ctrl+点击 并排打开");
+      });
+    });
+
+    it("shows the Cmd variant of the session hint on macOS", async () => {
+      const originalPlatform = navigator.platform;
+      Object.defineProperty(navigator, "platform", {
+        value: "MacIntel",
+        configurable: true,
+      });
+      try {
+        renderDesktopApp();
+        sendCommand("desktopWorkdirState", {
+          workdir: "/work/a",
+          recentWorkdirs: ["/work/a"],
+        });
+        sendCommand("desktopSessionTree", {
+          groups: [
+            {
+              host: "local",
+              workdir: "/work/a",
+              sessions: [session("s1", "hello a")],
+            },
+          ],
+        });
+
+        const container = screen
+          .getByTestId("desktop-session-item-s1")
+          .querySelector(".tooltip-container") as HTMLElement;
+
+        await act(async () => {
+          fireEvent.mouseEnter(container);
+        });
+
+        await waitFor(() => {
+          expect(
+            document.querySelector(".tooltip-box.visible"),
+          ).toHaveTextContent("可拖拽或 Cmd+点击 并排打开");
+        });
+      } finally {
+        Object.defineProperty(navigator, "platform", {
+          value: originalPlatform,
+          configurable: true,
+        });
+      }
     });
 
     it("shows a running dot on the streaming current session and marks it current", () => {


### PR DESCRIPTION
## 问题
桌面端「新对话」和对话条目的鼠标悬停提示（并排打开 hint）不见了。

## 根因
昨天合并的 hover 提示功能（6c5e160e, PR #1721）随后被 prettier 格式化提交 c52cefea 覆盖：该提交基于不含该功能的文件内容重写了 DesktopSidebar.tsx / DesktopApp.css / desktopApp.test.tsx 三个文件，导致功能在 main 上静默消失（已装 app 的 app.asar 内也确认是旧实现，仅有原生 title 属性）。

## 修复
恢复 6c5e160e 的功能代码（Tooltip anchor + CSS 布局），并适配 prettier 之后的格式；同时恢复被删的 3 个测试。

TDD：3 个测试先红（功能缺失）后绿；webview desktopApp 101/101，全量 webview 659/659，tsc clean。

合入 main 后需重新运行 pnpm run desktop:install 才能在已安装应用中生效。