### PR TITLE
fix: dedupe rewind checkpoints and keep last occurrence after compaction

### DIFF
--- a/packages/agent-sdk/src/managers/messageManager.ts
+++ b/packages/agent-sdk/src/managers/messageManager.ts
@@ -1035,7 +1035,11 @@ export class MessageManager {
     // only sees messages from the latest compact summary forward — matching
     // the compact and resume behaviors (which also fold memory).
     this.setMessages(sliceFromLastCompact(newMessages));
-    this.savedMessageCount = newMessages.length;
+    // savedMessageCount tracks in-memory progress, so it must be the folded
+    // length. Using the full disk count here would make saveSession's
+    // slice(savedMessageCount) empty after a rewind past a compact boundary
+    // and silently drop every subsequent message from the session file.
+    this.savedMessageCount = this.messages.length;
   }
 
   /**

--- a/packages/agent-sdk/tests/managers/messageManager.rewind.test.ts
+++ b/packages/agent-sdk/tests/managers/messageManager.rewind.test.ts
@@ -294,6 +294,104 @@ describe("MessageManager Single-Session Rewind", () => {
     expect(writtenIds).toEqual(messages.slice(0, 18).map((m) => m.id));
   });
 
+  it("should keep savedMessageCount folded after rewinding past a compact boundary so new messages still persist", async () => {
+    // 与上一条相同的多压缩磁盘布局
+    const messages = [
+      { id: "u1", role: "user", blocks: [{ type: "text", content: "one" }] },
+      {
+        id: "a1",
+        role: "assistant",
+        blocks: [{ type: "text", content: "hi1" }],
+      },
+      { id: "u2", role: "user", blocks: [{ type: "text", content: "two" }] },
+      {
+        id: "a2",
+        role: "assistant",
+        blocks: [{ type: "text", content: "hi2" }],
+      },
+      { id: "u3", role: "user", blocks: [{ type: "text", content: "three" }] },
+      {
+        id: "a3",
+        role: "assistant",
+        blocks: [{ type: "text", content: "hi3" }],
+      },
+      {
+        id: "c1",
+        role: "assistant",
+        blocks: [{ type: "compact", content: "summary 1" }],
+      },
+      { id: "u2b", role: "user", blocks: [{ type: "text", content: "two" }] },
+      {
+        id: "a2b",
+        role: "assistant",
+        blocks: [{ type: "text", content: "hi2" }],
+      },
+      { id: "u3b", role: "user", blocks: [{ type: "text", content: "three" }] },
+      {
+        id: "a3b",
+        role: "assistant",
+        blocks: [{ type: "text", content: "hi3" }],
+      },
+      { id: "u4", role: "user", blocks: [{ type: "text", content: "four" }] },
+      {
+        id: "a4",
+        role: "assistant",
+        blocks: [{ type: "text", content: "hi4" }],
+      },
+      {
+        id: "c2",
+        role: "assistant",
+        blocks: [{ type: "compact", content: "summary 2" }],
+      },
+      { id: "u3c", role: "user", blocks: [{ type: "text", content: "three" }] },
+      {
+        id: "a3c",
+        role: "assistant",
+        blocks: [{ type: "text", content: "hi3" }],
+      },
+      { id: "u4b", role: "user", blocks: [{ type: "text", content: "four" }] },
+      {
+        id: "a4b",
+        role: "assistant",
+        blocks: [{ type: "text", content: "hi4" }],
+      },
+      { id: "u5", role: "user", blocks: [{ type: "text", content: "five" }] },
+      {
+        id: "a5",
+        role: "assistant",
+        blocks: [{ type: "text", content: "hi5" }],
+      },
+    ] as Message[];
+
+    vi.mocked(sessionService.loadFullMessageThread).mockResolvedValue({
+      messages,
+      sessionIds: [messageManager.getSessionId()],
+    });
+
+    // Rewind to u5 (index 18)：磁盘截断到 18 条，内存折叠到 [c2, u3c, a3c, u4b, a4b]
+    await messageManager.truncateHistory(18);
+    expect(messageManager.getMessages().map((m) => m.id)).toEqual([
+      "c2",
+      "u3c",
+      "a3c",
+      "u4b",
+      "a4b",
+    ]);
+
+    // 回滚后新增一条消息并保存：必须通过 appendMessages 落到磁盘。
+    // 若 savedMessageCount 仍等于磁盘截断数(18)而内存已折叠(5)，
+    // slice(savedMessageCount) 会为空，新消息永远不会持久化。
+    messageManager.addUserMessage({ content: "six" });
+    await messageManager.saveSession();
+
+    expect(sessionService.appendMessages).toHaveBeenCalledTimes(1);
+    const saved = vi.mocked(sessionService.appendMessages).mock
+      .calls[0][1] as Message[];
+    expect(saved.map((m) => (m.blocks[0] as TextBlock).content)).toEqual([
+      "six",
+    ]);
+  });
+
   it("should not fold in-memory messages when no compact block exists", async () => {
     const messages = [
       { id: "u1", role: "user", blocks: [{ type: "text", content: "one" }] },

--- a/packages/code/src/components/RewindCommand.tsx
+++ b/packages/code/src/components/RewindCommand.tsx
@@ -34,10 +34,16 @@ export const RewindCommand: React.FC<RewindCommandProps> = ({
   }, [getFullMessageThread]);
 
   // Filter user messages as checkpoints, excluding meta messages and
-  // system-generated user-role messages (task notifications, hook injections)
-  const checkpoints = messages
-    .map((msg, index) => ({ msg, index }))
-    .filter(({ msg }) => isUserCheckpointMessage(msg));
+  // system-generated user-role messages (task notifications, hook injections).
+  // Compaction is append-only: the same message id appears twice on the full
+  // thread (pre-compact history + post-compact append), so dedupe by id and
+  // keep the last occurrence (matching the folded view the user sees).
+  const checkpointMap = new Map<string, { msg: Message; index: number }>();
+  messages.forEach((msg, index) => {
+    if (!isUserCheckpointMessage(msg)) return;
+    checkpointMap.set(msg.id ?? `index:${index}`, { msg, index });
+  });
+  const checkpoints = Array.from(checkpointMap.values());
 
   const MAX_VISIBLE_ITEMS = 3;
 

--- a/packages/code/src/stdio/agentBridge.ts
+++ b/packages/code/src/stdio/agentBridge.ts
@@ -884,7 +884,10 @@ export class AgentBridge {
   }> {
     const entry = this.requireSession(sessionId);
     const { messages } = await entry.agent.getFullMessageThread();
-    const index = messages.findIndex((m) => m.id === messageId);
+    // 压缩是 append-only：同 id 消息（压缩前历史 + 压缩后 append 的重复）会
+    // 在磁盘完整线程中出现多次。用户看到的折叠视图对应最后一次出现，
+    // 因此匹配最后一个而非第一个，避免回滚时连压缩摘要一起删掉。
+    const index = messages.map((m) => m.id).lastIndexOf(messageId);
     if (index === -1) {
       throw new RpcError(
         PROTOCOL_INTERNAL_ERROR,
@@ -904,13 +907,19 @@ export class AgentBridge {
   }> {
     const entry = this.requireSession(sessionId);
     const { messages } = await entry.agent.getFullMessageThread();
-    const checkpoints = messages
-      .filter((m) => isUserCheckpointMessage(m) && m.id)
-      .map((m) => ({
-        id: m.id as string,
-        content: getMessageContent(m).replace(/\s+/g, " ").trim(),
-      }));
-    return { checkpoints };
+    // 压缩 append-only 后同 id 消息在磁盘完整线程中重复出现（压缩前历史 +
+    // 压缩后 append 的重复）。按 id 去重并保留最后一次出现（与折叠后的
+    // UI/内存视图一致），避免弹窗把同一条用户消息显示两遍。
+    const checkpointMap = new Map<string, { id: string; content: string }>();
+    for (const m of messages) {
+      if (isUserCheckpointMessage(m) && m.id) {
+        checkpointMap.set(m.id, {
+          id: m.id,
+          content: getMessageContent(m).replace(/\s+/g, " ").trim(),
+        });
+      }
+    }
+    return { checkpoints: Array.from(checkpointMap.values()) };
   }
 
   private deleteQueuedMessage(index: number, sessionId?: string): null {

--- a/packages/code/tests/components/RewindCommand.test.tsx
+++ b/packages/code/tests/components/RewindCommand.test.tsx
@@ -135,4 +135,86 @@ describe("RewindCommand Content", () => {
       expect(output).not.toContain("(No text content)");
     });
   });
+
+  it("should dedupe user messages by id after compaction", async () => {
+    // 压缩 append-only 后磁盘完整线程保留压缩前历史 + 压缩后 append 的重复消息
+    //（同 id 同内容）。CLI 只应展示每个用户消息一次。
+    const mockMessages: Partial<Message>[] = [
+      {
+        id: "u1",
+        role: "user",
+        blocks: [{ type: "text", content: "one" }],
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        blocks: [{ type: "text", content: "hi1" }],
+      },
+      {
+        id: "u2",
+        role: "user",
+        blocks: [{ type: "text", content: "two" }],
+      },
+      {
+        id: "a2",
+        role: "assistant",
+        blocks: [{ type: "text", content: "hi2" }],
+      },
+      {
+        id: "u3",
+        role: "user",
+        blocks: [{ type: "text", content: "three" }],
+      },
+      {
+        id: "a3",
+        role: "assistant",
+        blocks: [{ type: "text", content: "hi3" }],
+      },
+      {
+        id: "c1",
+        role: "assistant",
+        blocks: [{ type: "compact", content: "summary" }],
+      },
+      {
+        id: "u2",
+        role: "user",
+        blocks: [{ type: "text", content: "two" }],
+      },
+      {
+        id: "a2",
+        role: "assistant",
+        blocks: [{ type: "text", content: "hi2" }],
+      },
+      {
+        id: "u3",
+        role: "user",
+        blocks: [{ type: "text", content: "three" }],
+      },
+      {
+        id: "a3",
+        role: "assistant",
+        blocks: [{ type: "text", content: "hi3" }],
+      },
+    ];
+
+    const { lastFrame } = render(
+      <RewindCommand
+        messages={mockMessages as Message[]}
+        onSelect={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await vi.waitFor(() => {
+      const output = stripAnsiColors(lastFrame() || "");
+      expect(output).toContain("one");
+      expect(output).toContain("two");
+      expect(output).toContain("three");
+      // 重复 id 只渲染一次（出现两次说明压缩后重复没去重）
+      const twoCount = output.split("two").length - 1;
+      const threeCount = output.split("three").length - 1;
+      expect(twoCount).toBe(1);
+      expect(threeCount).toBe(1);
+    });
+  });
 });

--- a/packages/code/tests/stdio/agentBridge.test.ts
+++ b/packages/code/tests/stdio/agentBridge.test.ts
@@ -958,6 +958,53 @@ test("listRewindCheckpoints filters to real user messages and flattens content",
   });
 });
 
+test("listRewindCheckpoints dedupes user messages by id after compaction", async () => {
+  const { bridge } = createBridge();
+  vi.mocked(getMessageContent).mockImplementation((m) => {
+    const block = m.blocks.find((b) => b.type === "text");
+    return block && "content" in block ? (block.content as string) : "";
+  });
+  // 压缩是 append-only：磁盘完整线程会保留压缩前的历史，同时把
+  // [compact, ...lastTwoRounds] 追加到末尾 —— 因此 u2/u3 同 id 出现两次。
+  const threadMessages = [
+    { role: "user", id: "u1", blocks: [{ type: "text", content: "one" }] },
+    { role: "assistant", id: "a1", blocks: [{ type: "text", content: "hi1" }] },
+    { role: "user", id: "u2", blocks: [{ type: "text", content: "two" }] },
+    { role: "assistant", id: "a2", blocks: [{ type: "text", content: "hi2" }] },
+    { role: "user", id: "u3", blocks: [{ type: "text", content: "three" }] },
+    { role: "assistant", id: "a3", blocks: [{ type: "text", content: "hi3" }] },
+    {
+      role: "assistant",
+      id: "c1",
+      blocks: [{ type: "compact", content: "summary" }],
+    },
+    { role: "user", id: "u2", blocks: [{ type: "text", content: "two" }] },
+    { role: "assistant", id: "a2", blocks: [{ type: "text", content: "hi2" }] },
+    { role: "user", id: "u3", blocks: [{ type: "text", content: "three" }] },
+    { role: "assistant", id: "a3", blocks: [{ type: "text", content: "hi3" }] },
+  ] as unknown as Message[];
+  const mockAgent = createMockAgent({
+    getFullMessageThread: vi.fn().mockResolvedValue({
+      messages: threadMessages,
+      sessionIds: ["test-session-id"],
+    }),
+  });
+  vi.mocked(Agent.create).mockResolvedValue(mockAgent);
+
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  const r = await bridge.handleRequest("listRewindCheckpoints", {}, sessionId);
+
+  // 压缩后的重复条目（同 id）只应出现一次，避免 UI 弹窗显示"两条"
+  expect(r).toEqual({
+    checkpoints: [
+      { id: "u1", content: "one" },
+      { id: "u2", content: "two" },
+      { id: "u3", content: "three" },
+    ],
+  });
+});
+
 test("listRewindCheckpoints returns empty list when no user messages", async () => {
   const { bridge } = createBridge();
   const mockAgent = createMockAgent();
@@ -1205,6 +1252,44 @@ test("rewindToMessage truncates history and returns input content", async () => 
 
   expect(mockAgent.truncateHistory).toHaveBeenCalledWith(0);
   expect(r).toEqual({ inputContent: "hello" });
+});
+
+test("rewindToMessage uses the LAST occurrence of a duplicated id after compaction", async () => {
+  const { bridge } = createBridge();
+  // 压缩 append-only：u3 同 id 出现两次（压缩前 index 4、压缩后 index 9）。
+  // 用户从 UI 看到的折叠后消息对应最后一次出现，回滚索引必须指向它，
+  // 否则会连压缩摘要一起回滚掉。
+  const messages = [
+    { id: "u1", role: "user", blocks: [{ type: "text", content: "one" }] },
+    { id: "a1", role: "assistant", blocks: [{ type: "text", content: "hi1" }] },
+    { id: "u2", role: "user", blocks: [{ type: "text", content: "two" }] },
+    { id: "a2", role: "assistant", blocks: [{ type: "text", content: "hi2" }] },
+    { id: "u3", role: "user", blocks: [{ type: "text", content: "three" }] },
+    { id: "a3", role: "assistant", blocks: [{ type: "text", content: "hi3" }] },
+    {
+      id: "c1",
+      role: "assistant",
+      blocks: [{ type: "compact", content: "summary" }],
+    },
+    { id: "u2", role: "user", blocks: [{ type: "text", content: "two" }] },
+    { id: "a2", role: "assistant", blocks: [{ type: "text", content: "hi2" }] },
+    { id: "u3", role: "user", blocks: [{ type: "text", content: "three" }] },
+    { id: "a3", role: "assistant", blocks: [{ type: "text", content: "hi3" }] },
+  ] as unknown as Message[];
+  const mockAgent = createMockAgent({
+    getFullMessageThread: vi.fn().mockResolvedValue({
+      messages,
+      sessionIds: ["test-session-id"],
+    }),
+  });
+  vi.mocked(Agent.create).mockResolvedValue(mockAgent);
+
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  await bridge.handleRequest("rewindToMessage", { messageId: "u3" }, sessionId);
+
+  // 最后一次出现的 u3 在 index 9（而非第一次的 4）
+  expect(mockAgent.truncateHistory).toHaveBeenCalledWith(9);
 });
 
 test("deleteQueuedMessage calls removeQueuedMessage", async () => {


### PR DESCRIPTION
## 问题

压缩（compaction）是 append-only：compactMessagesAndUpdateSession 将 [compact, ...最后两轮] 追加到磁盘 JSONL，同 id 消息在磁盘完整线程中重复出现（压缩前历史 + 压缩后 append 的重复）。导致：

1. 桌面端 /rewind 弹窗（listRewindCheckpoints）显示同一条用户消息两遍
2. CLI /rewind（RewindCommand）同样显示重复
3. rewindToMessage 用 findIndex 匹配第一个出现 → 回滚到压缩前位置，连压缩摘要一起删
4. truncateHistory 的 savedMessageCount 设磁盘截断数而内存已折叠 → rewind 后新消息永不落盘

## 修复

- agentBridge.listRewindCheckpoints：按 id 去重，保留最后一次出现（与折叠视图一致）
- CLI RewindCommand：同样按 id 去重
- agentBridge.rewindToMessage：改为匹配最后一次出现的 id（map + lastIndexOf）
- messageManager.truncateHistory：savedMessageCount 改为折叠后内存长度

## 验证

TDD 4 个新测试先红后绿；agent-sdk 3505 / code 1342 / webview 640 / desktop 485 / vscode 166 全绿；type-check + lint 通过；agent-sdk dist 已重建。