### PR TITLE
fix(agent-sdk): don't inject truncation note when turn has tool calls

### DIFF
--- a/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
+++ b/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
@@ -230,9 +230,11 @@ export function convertMessagesForAPI(
         // field (the channel reasoning models natively continue from), and
         // content carries an explanatory note so the request stays valid and
         // the model knows the thinking was cut off and auto-preserved.
+        // Tool calls are meaningful content of their own — a reasoning +
+        // tool-call turn is not truncated, so no note is injected.
         const fallbackContent = hasContent
           ? content
-          : hasReasoning
+          : hasReasoning && !hasToolCalls
             ? "[Note: The reasoning above was cut off before completion. It was auto-preserved from an interrupted or truncated turn — continue from where it left off, or disregard it if no longer relevant.]"
             : undefined;
 

--- a/packages/agent-sdk/tests/utils/convertMessagesForAPI.test.ts
+++ b/packages/agent-sdk/tests/utils/convertMessagesForAPI.test.ts
@@ -284,6 +284,53 @@ describe("convertMessagesForAPI", () => {
     expect(apiMessages[2].content).toBe("hello");
   });
 
+  it("should not inject truncation note when assistant message has tool calls but no text content", () => {
+    const messages: Message[] = [
+      {
+        id: generateMessageId(),
+        role: "user",
+        blocks: [{ type: "text", content: "Run a tool for me" }],
+        timestamp: new Date().toISOString(),
+      },
+      {
+        id: generateMessageId(),
+        role: "assistant",
+        blocks: [
+          {
+            type: "reasoning",
+            content: "I need to call the bash tool to check the directory.",
+          },
+          {
+            type: "tool",
+            id: "tool1",
+            name: "bash",
+            parameters: '{"command": "ls"}',
+            stage: "end",
+            result: "file.txt",
+            success: true,
+          },
+        ],
+        timestamp: new Date().toISOString(),
+      },
+    ];
+
+    const apiMessages = convertMessagesForAPI(messages);
+
+    expect(apiMessages).toHaveLength(3);
+
+    const assistantMessage = apiMessages[1] as ChatCompletionMessageParam & {
+      tool_calls?: ChatCompletionMessageToolCall[];
+      reasoning_content?: string;
+    };
+    // Tool calls make the request valid — the truncation note must not be
+    // injected (the turn is not truncated, it produced a tool call).
+    expect(assistantMessage.content).toBeUndefined();
+    expect(assistantMessage.tool_calls).toHaveLength(1);
+    expect(assistantMessage.reasoning_content).toBe(
+      "I need to call the bash tool to check the directory.",
+    );
+  });
+
   it("should filter out ErrorBlock content to ensure user-visible only (FR-020)", () => {
     // FR-020: System MUST ensure ErrorBlock content is not processed by
     // convertMessagesForAPI so it remains user-visible only and is not sent to the agent


### PR DESCRIPTION
## 问题

会话中出现大量 "[Note: The reasoning above was cut off...]" 消息。根因：e5889755 对"有 reasoning 无 content"的 assistant 消息注入截断 note 作为 content，但 deepseek-v4-flash 的工具调用轮次本来就只输出 reasoning + tool_calls、无正文——这是正常行为，不是截断。注入后模型在后续轮次中复述该 note，雪球式累积。

## 修复

仅当消息既无 content 也无 tool_calls 时才注入 note（真正的截断/中断思考）；有工具调用的轮次不再注入。

## 测试

TDD：新增测试覆盖 reasoning + tool_calls 无 content 场景（content 为 undefined、不注入 note），26 passed。