### PR TITLE
feat(code): add wave daemon client subcommands (list/status/send/respond)

### DIFF
--- a/docs/specs/ui/daemon-command.md
+++ b/docs/specs/ui/daemon-command.md
@@ -1,0 +1,122 @@
+---
+name: "Daemon 客户端命令"
+description: "`wave daemon list/status/send/respond` — 查看、续聊与审批 daemon 托管的远端后台会话"
+order: 270
+---
+
+# 功能规格说明：Daemon 客户端命令
+
+**创建日期**：2026-08-12
+
+## 概述
+
+`wave --daemon <socket>` 在远端主机上启动一个 JSON-RPC over unix socket 的 daemon，托管后台 agent 会话（桌面端经 SSH 隧道访问）。目前除了 `--daemon` 启动标志外，没有任何面向用户的 CLI 命令可以查看 daemon 里托管了哪些会话、会话进度如何、或向会话注入消息继续对话——这些能力只存在于 JSON-RPC 协议层，普通用户与脚本无法直接使用。本规格定义 `wave daemon` 子命令组，将已验证的协议流程（attach → 读消息 → 注入消息 → 审批挂起的权限请求）封装为四条命令，供用户在远端主机直接执行（或经 `ssh <host> wave daemon ...` 在远端主机上执行）。
+
+## 用户场景与测试 *（必填）*
+
+### 用户故事：Daemon 命令组与默认 socket（优先级：P0）
+
+作为在远端主机上使用 daemon 的用户，我希望通过 `wave daemon` 子命令组（`list` / `status` / `send` / `respond`）访问 daemon，固定连接默认 socket，以便无需了解 JSON-RPC 协议即可查看、续聊与审批后台会话。
+
+**为什么是这个优先级**：这是整个命令组的地基——没有统一的命令入口与 socket 寻址规则，list/status/send/respond 无从谈起；daemon 只监听本地 unix socket、不暴露网络端口，且只允许在远端主机上运行，因此客户端命令一律连接默认 socket（`~/.wave/daemon.sock`），不提供 `--socket` 覆盖参数，避免支持本地转发 socket 等非目标用法。
+
+**独立测试**：在远端启动 daemon 后运行 `wave daemon list` 能列出会话；daemon 未运行时运行任一子命令会得到明确错误提示。
+
+**验收场景**：
+
+1. **假设** 远端 daemon 正在运行，**当** 用户运行 `wave daemon list` 时，**则** 命令连接默认 socket（`~/.wave/daemon.sock`）并列出该 daemon 当前托管的全部会话（进程内存中 live 的会话）。
+2. **假设** daemon 未运行或 socket 文件不存在（含 daemon 空闲自动退出后），**当** 用户运行任一 `wave daemon` 子命令时，**则** 命令以非零退出码退出并给出明确错误（如「无法连接 daemon socket <路径>：daemon 未运行？」，附空闲自动退出提示），不进入 TUI、不挂起。
+3. **假设** 用户运行 `wave daemon list` 时，**当** 命令执行期间没有需要交互的输入，**则** 命令运行完即退出（非交互式），stdout 输出结果、stderr 输出诊断，便于脚本与管道消费。
+4. **假设** 用户误以为 `wave daemon` 与 `wave --daemon <socket>` 相同，**当** 对比两者行为时，**则** `wave --daemon` 启动 daemon（服务端），`wave daemon <子命令>` 访问 daemon（客户端），两者语义不同、互不干扰，帮助文本中明确区分。
+
+---
+
+### 用户故事：列出 daemon 托管的会话（优先级：P0）
+
+作为在远端主机检查后台任务进度的用户，我希望 `wave daemon list` 列出当前 daemon 托管的会话（会话 ID、工作目录、状态、消息数），以便找到目标会话并决定查看或续聊哪一条。
+
+**为什么是这个优先级**：查看进度与继续对话都先要找到会话。会话不归属于某个 daemon 进程——daemon 空闲 60 秒自动退出是正常现象，退出后进程重启、内存清空，磁盘上的历史会话不会随 daemon 常驻。因此「daemon 托管」的准确语义是「当前 daemon 进程内存中 live 的会话」（经 `initialize`/`restoreSession` 载入且仍存活于该进程，即 agentBridge 的会话注册表），`list` 直接暴露该注册表即可，不扫磁盘索引、不需要新增 `listAllSessions` 协议方法，也天然不会列出 daemon 之外的对话（普通 `wave` TUI 创建的会话不在列表中）。
+
+**独立测试**：在 daemon 中创建/恢复两条会话后运行 `wave daemon list`，验证两条会话都出现，且每条含会话 ID、工作目录、状态与消息数；daemon 空闲退出重启后运行 `wave daemon list` 显示无会话（退出码 0）。
+
+**验收场景**：
+
+1. **假设** daemon 进程内存中托管了多条会话（不同 workdir 下经 `initialize`/`restoreSession` 载入且仍存活），**当** 用户运行 `wave daemon list` 时，**则** 列出当前进程内存中的全部会话，每条显示会话 ID、工作目录、状态（生成中/空闲）与消息数，不扫磁盘索引、不列出 daemon 之外的对话。
+2. **假设** daemon 托管了多条会话，**当** 用户运行 `wave daemon list` 时，**则** 会话按注册顺序展示（内存态无磁盘索引的 lastActiveAt，不做最后活跃时间排序）。
+3. **假设** daemon 空闲退出后重启（进程内存清空）或尚无任何会话，**当** 用户运行 `wave daemon list` 时，**则** 输出空结果（显示无会话），退出码为 0——daemon 空闲自动退出是正常现象，列表为空符合预期而非错误。
+4. **假设** 磁盘上存在历史会话（含 daemon 空闲退出前托管过、或普通 `wave` TUI 创建的会话），**当** 用户运行 `wave daemon list` 时，**则** 这些会话不出现于列表；用户知道 sessionId 时仍可经 `wave daemon status <sessionId>` / `send <sessionId>` attach（`restoreSession` 会重新载入内存），无需依赖 `list` 找回。
+
+---
+
+### 用户故事：查看会话进度与最近消息（优先级：P0）
+
+作为在远端主机检查后台任务进度的用户，我希望 `wave daemon status <sessionId>` 展示指定会话的实时状态（是否正在生成）与最近消息，以便确认任务进展、判断是否可以继续对话。
+
+**为什么是这个优先级**：这是「查看进度」的核心命令；实时状态只能通过 attach（`initialize {restoreSessionId}` → `restoreSession`）获取——restoreSession 会重放 `loadingChange` 快照，`getMessages` 返回全量消息，磁盘索引不提供这两个信息，因此该命令必须走 attach 流程。
+
+**独立测试**：对一条正在生成回复的会话运行 `wave daemon status <sessionId>`，验证输出包含「正在生成」状态与最近消息文本；对一条空闲会话运行则显示空闲状态。
+
+**验收场景**：
+
+1. **假设** 目标会话正在生成回复，**当** 用户运行 `wave daemon status <sessionId>` 时，**则** 命令经 `initialize {restoreSessionId}` + `restoreSession` attach 该会话，依据重放的 `loadingChange` 快照显示「正在生成/执行任务」状态。
+2. **假设** 目标会话空闲（未在生成、无排队消息、无后台任务），**当** 用户运行 `wave daemon status <sessionId>` 时，**则** 显示空闲状态。
+3. **假设** 目标会话挂起等待权限审批，**当** 用户运行 `wave daemon status <sessionId>` 时，**则** 状态显示为等待审批（`loadingChange` 保持 loading 即视为未空闲），与桌面端「待确认」语义一致。
+4. **假设** 目标会话挂起等待权限审批，**当** 查看最近消息时，**则** 最后一条 assistant 消息含一个冻结在 `stage: "running"` 的 tool 块：有工具名与参数（`name`/`parameters`/`compactParams`），但无 `result`/`success`/`error`/`shortResult`/`timestamp`——这些字段只在工具完成后（`stage: "end"`）写入，无独立的 pending stage；消息形态上「等审批」与「执行中」无法区分，status 须同时列出 `listPendingPermissions` 返回的待审批请求（工具名 + 参数摘要），作为审批态的确凿信号。
+5. **假设** 会话已有历史消息，**当** 用户运行 `wave daemon status <sessionId>` 时，**则** 经 `getMessages` 拉取并显示最近若干条消息的文本（含用户消息与助手回复，默认数量可经参数调整，如 `--lines 20`），足以判断任务进展。
+6. **假设** 指定的 sessionId 不存在于该 daemon，**当** 用户运行 `wave daemon status <sessionId>` 时，**则** 以非零退出码退出并给出明确错误（会话不存在或未被该 daemon 托管）。
+7. **假设** status 命令完成展示后，**当** 命令退出时，**则** 断开与 daemon 的连接（attach 是短暂查看，不常驻），daemon 与目标会话不受影响、继续运行。
+
+---
+
+### 用户故事：响应会话挂起的权限审批（优先级：P0）
+
+作为在远端主机驱动后台会话的用户，我希望 `wave daemon respond <sessionId> <requestId> [--allow|--deny] [--answer <答案JSON>] [--rule <规则>] [--mode <模式>]` 处理会话挂起的权限请求（允许/拒绝、回答提问、记住规则、切换权限模式），以便推进卡在等待审批的会话。
+
+**为什么是这个优先级**：等待审批的会话会一直保持 loading（等同未空闲），不处理就无法继续；协议已有 `permissionResponse` 通知方法（客户端 → 服务端，requestId 进程内全局唯一，见 protocol.ts / agentBridge.ts），无需新增协议方法，纯 CLI 封装即可解锁。审批决策并非单一 allow/deny——`PermissionDecision` 含 behavior/message/newPermissionMode/newPermissionRule 四个字段（桌面端按工具类型组合：EnterPlanMode 附带 `newPermissionMode:"plan"`、AskUserQuestion 用 message 携带答案 JSON、Bash 可带 `newPermissionRule`），命令须按工具智能补全并与桌面端语义一致。
+
+**独立测试**：对一条挂起 Bash 审批的会话运行 `wave daemon respond <sessionId> <requestId> --allow`，验证工具继续执行、会话恢复生成；对一条挂起 AskUserQuestion 的会话运行 `--answer '{"问题":"答案"}'`，验证答案送达；对 EnterPlanMode 运行 `--allow`，验证自动附带 plan 模式切换。
+
+**验收场景**：
+
+1. **假设** 目标会话挂起 Edit/Bash/Write/mcp 等常规工具审批，**当** 用户运行 `wave daemon respond <sessionId> <requestId> --allow` 时，**则** 命令发送 `permissionResponse` 通知（`{requestId, decision:{behavior:"allow"}}`），工具继续执行、会话恢复生成。
+2. **假设** 用户运行 `wave daemon respond <sessionId> <requestId> --deny [--reason "原因"]` 时，**则** 发送 `{behavior:"deny", message}`，工具返回「operation denied」错误结束该工具，会话回到空闲。
+3. **假设** 目标会话挂起 EnterPlanMode 审批，**当** 用户运行 `wave daemon respond <sessionId> <requestId> --allow` 时，**则** 命令按工具智能补全为 `{behavior:"allow", newPermissionMode:"plan"}`，与会话的权限模式切换为 plan（与桌面端行为一致，无需用户显式传 `--mode`）。
+4. **假设** 目标会话挂起 AskUserQuestion 审批，**当** 用户运行 `wave daemon respond <sessionId> <requestId> --answer '{"问题":"答案"}'` 时，**则** 发送 `{behavior:"allow", message: JSON.stringify(答案对象)}`，如同桌面端填写答案后确认；若只传 `--allow` 未传 `--answer`，命令报错提示需要提供答案。
+5. **假设** 用户运行 `wave daemon respond <sessionId> <requestId> --allow --rule "Bash(ls)"` 时，**则** 决策附带 `newPermissionRule`，该规则被持久化为允许规则、后续同类调用不再询问（与桌面端「不再询问」语义一致）。
+6. **假设** 用户运行 `wave daemon respond <sessionId> <requestId> --allow --mode acceptEdits` 时，**则** 决策附带 `newPermissionMode`，会话权限模式切换为 acceptEdits（后续 Edit/Write 不再询问，与桌面端「自动接受修改」语义一致）。
+7. **假设** 指定的 requestId 不存在（已被其他客户端处理或已过期），**当** 用户运行 respond 时，**则** 命令提示「该请求不存在或已处理」并以非零退出码退出（服务端对未知 requestId 静默忽略，命令应先行校验避免误导）。
+8. **假设** 指定的 sessionId 不存在于该 daemon，**当** 用户运行 `wave daemon respond <sessionId> <requestId> --allow` 时，**则** 以非零退出码退出并给出明确错误（会话不存在或未被该 daemon 托管），不发送任何通知。
+9. **假设** respond 命令完成（成功或失败）后，**当** 命令退出时，**则** 断开与 daemon 的连接；会话恢复生成或回到空闲，不因客户端退出而终止。
+
+---
+
+### 用户故事：向会话注入消息继续对话（优先级：P0）
+
+作为在远端主机续聊后台任务的用户，我希望 `wave daemon send <sessionId> <消息>` 向指定会话注入一条用户消息、等待回复完成，并输出助手最终回复，以便不打开完整 UI 即可驱动后台 agent 继续工作。
+
+**为什么是这个优先级**：这是「继续对话」的核心命令，也是用户「本地电脑关机后从另一台机器驱动 daemon 会话」场景的最终诉求；复用已验证的 attach → `sendMessage` → 流式通知 → `loadingChange:false` 收尾流程，非交互式运行便于脚本调用。
+
+**独立测试**：对一条空闲会话运行 `wave daemon send <sessionId> "继续"`，验证会话收到该消息、助手产出回复、命令输出最终回复文本后退出；对正在生成中的会话发送则消息进入队列、命令等待该消息对应的回复完成后退出。
+
+**验收场景**：
+
+1. **假设** 目标会话空闲，**当** 用户运行 `wave daemon send <sessionId> "继续"` 时，**则** 命令经 attach 后调用 `sendMessage` 注入消息，订阅流式通知（`assistantContentUpdated` 等），直到 `loadingChange:false` 表示该回复完成。
+2. **假设** 助手回复完成，**当** 命令结束时，**则** stdout 输出该条消息对应的助手最终回复文本（与 `wave -p` 的纯净输出一致，不含子代理内部信息与流式杂讯），退出码为 0。
+3. **假设** 目标会话正在生成中，**当** 用户运行 `wave daemon send <sessionId> "消息"` 时，**则** 消息按现有队列语义入队等待，命令持续等待直到该消息对应的回复完成（依据 `loadingChange` 与消息 ID 对应）后输出最终回复。
+4. **假设** 目标会话挂起等待权限审批，**当** 用户运行 `wave daemon send <sessionId> "消息"` 时，**则** 命令不无限期挂起：等待超过 `--timeout`（默认 600 秒，`0` 表示不限制）后以非零退出码退出，并提示「会话等待权限审批，请通过 `wave daemon respond <sessionId> <requestId>` 处理后重试」。
+5. **假设** 指定的 sessionId 不存在于该 daemon，**当** 用户运行 `wave daemon send <sessionId> "消息"` 时，**则** 以非零退出码退出并给出明确错误，不注入任何消息。
+6. **假设** send 命令完成或失败退出后，**当** 命令结束时，**则** 断开与 daemon 的连接，会话在 daemon 中继续存活、不因客户端退出而终止（与 attach 语义一致）。
+
+---
+
+### 边界情况
+
+- **daemon 未运行 / socket 不存在**：任一子命令均应快速报错退出（非零退出码 + stderr 明确提示），不得挂起或进入 TUI；提示须覆盖「daemon 空闲 60 秒自动退出」这一正常现象。
+- **默认 socket 固定**：所有 `wave daemon` 子命令一律连接 `~/.wave/daemon.sock`，不提供 `--socket` 覆盖参数；命令只在远端主机上运行，不面向本地转发的 socket。
+- **`wave daemon` 与 `wave --daemon` 语义冲突**：前者是客户端子命令组（list/status/send/respond），后者是服务端启动标志；帮助文本须写明差异，避免误用。
+- **list 仅反映当前进程内存态**：`list` 展示的是当前 daemon 进程内 live 的会话（`initialize`/`restoreSession` 载入且仍存活），不扫磁盘索引；daemon 空闲退出/重启后内存清空、列表为空是正常现象。磁盘上的历史会话（含普通 `wave` TUI 创建的）不在列表中，但知道 sessionId 仍可经 `status`/`send` attach（`restoreSession` 重新载入），无需依赖 `list` 找回。
+- **会话挂起等待审批**：daemon 语义下「等待审批」的会话保持 loading 状态（等同未空闲）；消息中该工具块冻结在 `stage: "running"`（有工具名与参数、无结果字段，结果字段只在 `stage: "end"` 写入），单凭消息无法区分「等审批」与「执行中」，须结合 `listPendingPermissions` 判断；`send` 须有 `--timeout` 兜底避免无限挂起，`status` 应如实显示该状态，`respond` 是处理挂起请求的入口。
+- **respond 的决策并非单一 allow/deny**：`PermissionDecision` 含 behavior/message/newPermissionMode/newPermissionRule 四个字段；EnterPlanMode 的 allow 必须附带 `newPermissionMode:"plan"`（按工具智能补全），AskUserQuestion 必须用 `--answer` 提供答案（allow 且 message 为答案 JSON），Bash/Edit 可选 `--rule`/`--mode`；命令须与桌面端行为一致，不得把多选项压成裸 allow/deny。
+- **requestId 幂等与过期**：服务端对未知 requestId 的 `permissionResponse` 静默忽略；respond 应先行校验（如经 `listPendingPermissions`）并在 requestId 已处理时明确提示，避免用户误以为审批已生效。
+- **`send` 输出纯净性**：命令输出助手最终回复文本，流式通知与子代理内部信息不得泄漏到 stdout（与打印模式一致），诊断信息走 stderr。
+- **attach 是短暂访问**：`status` / `send` / `respond` 完成即断开连接，不常驻客户端；daemon 与会话的生命周期不受客户端连接影响（attach/detach 语义，会话持续运行至空闲自动退出或用户删除）。

--- a/packages/code/src/daemon/commands.ts
+++ b/packages/code/src/daemon/commands.ts
@@ -1,0 +1,444 @@
+/**
+ * `wave daemon` client subcommands — talk to the wave daemon's unix socket
+ * (JSON-RPC over newline-delimited JSON) to list hosted sessions, inspect
+ * progress, inject messages and respond to pending permission requests.
+ *
+ * All subcommands are non-interactive: results go to stdout, diagnostics to
+ * stderr, and every handler calls process.exit() itself (yargs would fall
+ * through to the TUI otherwise). Every command connects to the fixed default
+ * socket `~/.wave/daemon.sock` — the daemon only runs on remote hosts, so no
+ * `--socket` override is offered (spec: daemon-command.md).
+ *
+ * Attach semantics: `initialize {workdir, restoreSessionId}` + `restoreSession`
+ * re-attach to a live session in the daemon's in-memory registry, or reload a
+ * transcript from disk under the current working directory. A session that is
+ * nowhere (live registry or disk) silently starts a FRESH session under a
+ * different id — the only reliable existence check is the `restoreSession`
+ * rejection ("Session not found: <id>"), after which the junk fresh session
+ * must be destroyed via the envelope sessionId returned by `initialize`.
+ */
+
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import {
+  ASK_USER_QUESTION_TOOL_NAME,
+  ENTER_PLAN_MODE_TOOL_NAME,
+  EXIT_PLAN_MODE_TOOL_NAME,
+  getMessageContent,
+  type Message,
+  type PermissionDecision,
+  type PermissionMode,
+  type ToolPermissionContext,
+} from "wave-agent-sdk";
+import { SocketClient } from "./socketClient.js";
+
+/** Fixed default daemon socket (spec: 默认 socket 固定，无 --socket 覆盖). */
+export const DEFAULT_DAEMON_SOCKET = path.join(
+  os.homedir(),
+  ".wave",
+  "daemon.sock",
+);
+
+const PERMISSION_MODES: PermissionMode[] = [
+  "default",
+  "bypassPermissions",
+  "acceptEdits",
+  "plan",
+  "dontAsk",
+];
+
+// ── Connection helpers ─────────────────────────────────────────
+
+function connectDaemon(socketPath: string): Promise<SocketClient> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(socketPath);
+    socket.once("connect", () => resolve(new SocketClient(socket)));
+    socket.once("error", (err) => {
+      socket.destroy();
+      reject(err);
+    });
+  });
+}
+
+/** Connect or fail fast with the spec'd error; daemon idle-exits after 60s. */
+async function connectDaemonOrExit(socketPath: string): Promise<SocketClient> {
+  try {
+    return await connectDaemon(socketPath);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    console.error(
+      `无法连接 daemon socket ${socketPath}：daemon 未运行？（daemon 空闲 60 秒自动退出）` +
+        (code ? ` (${code})` : ""),
+    );
+    process.exit(1);
+  }
+}
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+interface DaemonSessionEntry {
+  sessionId: string;
+  workingDirectory: string;
+  isLoading: boolean;
+  messageCount: number;
+}
+
+interface PendingPermission {
+  requestId: string;
+  sessionId?: string;
+  context: ToolPermissionContext;
+}
+
+/**
+ * Attach to a session; returns the initialized sessionId + working directory.
+ * Exits (nonzero) with the spec'd error when the session exists neither in the
+ * daemon registry nor on disk, destroying the fresh session that `initialize`
+ * silently created.
+ */
+async function attachSession(
+  client: SocketClient,
+  sessionId: string,
+): Promise<{ sessionId: string; workingDirectory: string }> {
+  const init = (await client.request("initialize", {
+    workdir: process.cwd(),
+    restoreSessionId: sessionId,
+  })) as { sessionId: string; workingDirectory: string };
+  const initId = init.sessionId;
+  try {
+    await client.request("restoreSession", { sessionId }, initId);
+  } catch (err) {
+    if ((err as Error).message.includes("Session not found")) {
+      // initialize silently started a junk fresh session — remove it from the
+      // registry so the failed attach leaves no trace (spec: 会话不存在错误).
+      await client.request("destroy", undefined, initId).catch(() => {});
+      fail(`会话不存在或未被该 daemon 托管：${sessionId}`);
+    }
+    throw err;
+  }
+  return init;
+}
+
+async function listPendingPermissions(
+  client: SocketClient,
+): Promise<PendingPermission[]> {
+  const result = (await client.request("listPendingPermissions")) as {
+    requests: PendingPermission[];
+  };
+  return result.requests ?? [];
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ── list ───────────────────────────────────────────────────────
+
+export async function daemonListCommand(socketPath: string): Promise<void> {
+  let client: SocketClient | undefined;
+  try {
+    client = await connectDaemonOrExit(socketPath);
+    const result = (await client.request("listDaemonSessions")) as {
+      sessions: DaemonSessionEntry[];
+    };
+    const sessions = result.sessions ?? [];
+
+    if (sessions.length > 0) {
+      const rows = sessions.map((s) => ({
+        sessionId: s.sessionId,
+        status: s.isLoading ? "生成中" : "空闲",
+        messageCount: String(s.messageCount),
+        workingDirectory: s.workingDirectory,
+      }));
+      const width = (key: keyof (typeof rows)[number]) =>
+        Math.max(...rows.map((r) => r[key].length), key.length);
+      const pad = (value: string, w: number) => value.padEnd(w);
+
+      console.log(
+        `${pad("会话", width("sessionId"))}  ${pad("状态", width("status"))}  ${pad("消息数", width("messageCount"))}  工作目录`,
+      );
+      for (const r of rows) {
+        console.log(
+          `${pad(r.sessionId, width("sessionId"))}  ${pad(r.status, width("status"))}  ${pad(r.messageCount, width("messageCount"))}  ${r.workingDirectory}`,
+        );
+      }
+    } else {
+      // Daemon idle-exit is normal — an empty registry is not an error.
+      console.log("无会话");
+    }
+  } catch (err) {
+    fail(`wave daemon list 失败：${(err as Error).message}`);
+  } finally {
+    await client?.dispose();
+  }
+  // Exits outside the try so the success path's exit is never re-wrapped by the
+  // error handler above.
+  process.exit(0);
+}
+
+// ── status ─────────────────────────────────────────────────────
+
+function summarizeToolInput(context: ToolPermissionContext): string {
+  const input = context.toolInput;
+  if (!input || Object.keys(input).length === 0) return "";
+  let text: string;
+  try {
+    text = JSON.stringify(input);
+  } catch {
+    text = "";
+  }
+  return text.length > 80 ? `${text.slice(0, 80)}…` : text;
+}
+
+export async function daemonStatusCommand(
+  socketPath: string,
+  sessionId: string,
+  lines = 20,
+): Promise<void> {
+  let client: SocketClient | undefined;
+  try {
+    client = await connectDaemonOrExit(socketPath);
+
+    // Subscribe BEFORE initialize/restoreSession so the replayed loadingChange
+    // snapshot is captured (spec: 依据重放的 loadingChange 快照显示状态).
+    let loading = false;
+    client.onNotification("loadingChange", (params) => {
+      loading = (params as { loading: boolean }).loading;
+    });
+
+    const init = await attachSession(client, sessionId);
+    const initId = init.sessionId;
+
+    // listPendingPermissions is the authoritative "waiting for approval" signal
+    // (spec: 单凭消息无法区分等审批与执行中，须结合 listPendingPermissions).
+    const pending = (await listPendingPermissions(client)).filter(
+      (r) => r.sessionId === initId || r.sessionId === sessionId,
+    );
+    const messages = (await client.request(
+      "getMessages",
+      undefined,
+      initId,
+    )) as {
+      messages: Message[];
+    };
+
+    const status =
+      pending.length > 0 ? "等待审批" : loading ? "生成中" : "空闲";
+    console.log(`会话: ${initId}`);
+    console.log(`工作目录: ${init.workingDirectory}`);
+    console.log(`状态: ${status}`);
+
+    if (pending.length > 0) {
+      console.log("");
+      console.log("待审批请求:");
+      for (const r of pending) {
+        const params = summarizeToolInput(r.context);
+        console.log(
+          `  ${r.requestId}  ${r.context.toolName}${params ? `  ${params}` : ""}`,
+        );
+      }
+    }
+
+    const recent = messages.messages.slice(-lines);
+    if (recent.length > 0) {
+      console.log("");
+      console.log(`最近消息 (${recent.length}):`);
+      for (const m of recent) {
+        const text = getMessageContent(m).replace(/\s+/g, " ").trim();
+        if (!text) continue; // tool-only messages carry no readable text
+        console.log(`  [${m.role}] ${text}`);
+      }
+    }
+  } catch (err) {
+    fail(`wave daemon status 失败：${(err as Error).message}`);
+  } finally {
+    await client?.dispose();
+  }
+  process.exit(0);
+}
+
+// ── send ───────────────────────────────────────────────────────
+
+export interface SendOptions {
+  timeout: number; // seconds; 0 = no limit (default 600)
+}
+
+/**
+ * Send a message and wait for the reply that corresponds to it.
+ *
+ * Completion detection: `sendMessage` on an idle session resolves only after
+ * the whole turn finishes (InteractionService awaits sendAIMessage), while on a
+ * busy session it enqueues and returns immediately — so stopping on a bare
+ * `loadingChange:false` would exit early on the PREVIOUS turn's completion when
+ * queued behind a busy session. Instead, track the message IDs: `ourUserMessage`
+ * is the user message added when OUR turn starts (userMessageAdded), and the
+ * reply is the last assistantMessageAdded observed after it. A stale
+ * loading:false can then never satisfy the wait condition early (the reply has
+ * not been added yet).
+ */
+export async function daemonSendCommand(
+  socketPath: string,
+  sessionId: string,
+  message: string,
+  options: SendOptions = { timeout: 600 },
+): Promise<void> {
+  // connectDaemonOrExit exits on failure — no client to dispose in that case.
+  const client = await connectDaemonOrExit(socketPath);
+
+  let loading = false;
+  let sent = false;
+  let ourUserMessageId: string | undefined;
+  let replyMessageId: string | undefined;
+  client.onNotification("userMessageAdded", (params) => {
+    if (!sent) return; // ignore messages added during attach
+    ourUserMessageId = (params as { message: Message }).message.id;
+  });
+  client.onNotification("assistantMessageAdded", (params) => {
+    if (!sent || ourUserMessageId === undefined) return; // not our turn yet
+    replyMessageId = (params as { message: Message }).message.id;
+  });
+  client.onNotification("loadingChange", (params) => {
+    loading = (params as { loading: boolean }).loading;
+  });
+
+  let initId: string;
+  try {
+    initId = (await attachSession(client, sessionId)).sessionId;
+    sent = true;
+    await client.request("sendMessage", { text: message }, initId);
+  } catch (err) {
+    client.dispose();
+    fail(`wave daemon send 失败：${(err as Error).message}`);
+  }
+
+  // Wait for the reply that corresponds to our message.
+  const started = Date.now();
+  const timeoutMs = options.timeout === 0 ? Infinity : options.timeout * 1000;
+  while (!(loading === false && replyMessageId !== undefined)) {
+    if (Date.now() - started > timeoutMs) {
+      // Timeout backstop: the most likely cause is a session waiting on a
+      // permission approval — point the user at respond (spec: 不无限期挂起).
+      const pending = (await listPendingPermissions(client)).filter(
+        (r) => r.sessionId === sessionId || r.sessionId === initId,
+      );
+      client.dispose();
+      if (pending.length > 0) {
+        fail(
+          `会话等待权限审批，请通过 \`wave daemon respond ${sessionId} ${pending[0].requestId}\` 处理后重试`,
+        );
+      }
+      fail(
+        options.timeout === 0
+          ? "等待回复超时"
+          : `等待回复超时（${options.timeout} 秒），未收到助手回复`,
+      );
+    }
+    await sleep(200);
+  }
+
+  try {
+    const result = (await client.request("getMessages", undefined, initId)) as {
+      messages: Message[];
+    };
+    const reply = result.messages.find((m) => m.id === replyMessageId);
+    // Pure final-reply text only; streaming deltas / subagent internals never
+    // reach stdout (spec: send 输出纯净性).
+    if (reply) {
+      const content = getMessageContent(reply).replace(/\s+/g, " ").trim();
+      if (content) console.log(content);
+    }
+  } catch (err) {
+    fail(`wave daemon send 失败：${(err as Error).message}`);
+  } finally {
+    client.dispose();
+  }
+  process.exit(0);
+}
+
+// ── respond ────────────────────────────────────────────────────
+
+export interface RespondOptions {
+  allow?: boolean;
+  deny?: boolean;
+  reason?: string;
+  answer?: string;
+  rule?: string;
+  mode?: string;
+}
+
+export async function daemonRespondCommand(
+  socketPath: string,
+  sessionId: string,
+  requestId: string,
+  options: RespondOptions,
+): Promise<void> {
+  if (!!options.allow === !!options.deny) {
+    fail("请指定 --allow 或 --deny（二选一）");
+  }
+  let client: SocketClient | undefined;
+  try {
+    client = await connectDaemonOrExit(socketPath);
+
+    // The server silently ignores permissionResponse for unknown requestIds —
+    // validate first so the user is never misled into thinking approval landed.
+    const pending = await listPendingPermissions(client);
+    const req = pending.find((r) => r.requestId === requestId);
+    if (!req) {
+      fail("该请求不存在或已处理");
+    }
+    if (req.sessionId && req.sessionId !== sessionId) {
+      // Cross-check before notifying; never touch another session's request.
+      fail("会话不存在或未被该 daemon 托管");
+    }
+
+    let decision: PermissionDecision;
+    if (options.deny) {
+      decision = { behavior: "deny", message: options.reason };
+    } else {
+      // Per-tool auto-completion, mirroring the desktop ConfirmationDialog
+      // semantics (spec: 决策并非单一 allow/deny，须按工具智能补全).
+      const toolName = req.context.toolName;
+      if (toolName === ENTER_PLAN_MODE_TOOL_NAME) {
+        decision = { behavior: "allow", newPermissionMode: "plan" };
+      } else if (toolName === EXIT_PLAN_MODE_TOOL_NAME) {
+        decision = { behavior: "allow", newPermissionMode: "default" };
+      } else if (toolName === ASK_USER_QUESTION_TOOL_NAME) {
+        if (!options.answer) {
+          fail("AskUserQuestion 请求需要 --answer 提供答案 JSON");
+        }
+        let answers: unknown;
+        try {
+          answers = JSON.parse(options.answer);
+        } catch {
+          fail("--answer 不是合法的 JSON");
+        }
+        decision = { behavior: "allow", message: JSON.stringify(answers) };
+      } else {
+        decision = { behavior: "allow" };
+      }
+
+      if (options.rule) decision.newPermissionRule = options.rule;
+      if (options.mode) {
+        if (!PERMISSION_MODES.includes(options.mode as PermissionMode)) {
+          fail(
+            `无效的权限模式：${options.mode}（可选：${PERMISSION_MODES.join("、")}）`,
+          );
+        }
+        decision.newPermissionMode = options.mode as PermissionMode;
+      }
+    }
+
+    // Mirror desktop stdioAgent.sendPermissionResponse: envelope sessionId
+    // present, decision built from the pending request's tool.
+    client.notify("permissionResponse", { requestId, decision }, sessionId);
+    console.log(`已处理审批请求：${requestId}`);
+  } catch (err) {
+    fail(`wave daemon respond 失败：${(err as Error).message}`);
+  } finally {
+    await client?.dispose();
+  }
+  process.exit(0);
+}

--- a/packages/code/src/daemon/jsonRpcClient.ts
+++ b/packages/code/src/daemon/jsonRpcClient.ts
@@ -1,0 +1,158 @@
+/**
+ * JsonRpcClient — minimal JSON-RPC transport over a line-delimited duplex
+ * stream (one JSON object per line).
+ *
+ * Used by `wave daemon` subcommands to talk to the wave daemon's unix socket.
+ * Mirrors packages/desktop/src/main/stdio/jsonRpcClient.ts (packages/code
+ * cannot import from packages/desktop). Subclasses own the transport and hook
+ * in:
+ * - `writeLine(message)` writes one JSON line to the peer.
+ * - `attachReadable(readable)` wires the inbound half (socket).
+ * - `handleClosed(reason)` marks the transport dead and rejects every pending
+ *   request. Idempotent — safe to call from both dispose() and an exit/close
+ *   event on the underlying transport.
+ */
+
+import { createInterface } from "readline";
+import type { Readable } from "stream";
+
+export type NotificationHandler = (params: unknown, sessionId?: string) => void;
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+}
+
+export abstract class JsonRpcClient {
+  private nextId = 1;
+  private pending = new Map<number, PendingRequest>();
+  private handlers = new Map<string, Set<NotificationHandler>>();
+  private closedHandlers: Array<() => void> = [];
+  private closed = false;
+
+  // ── Transport hooks (subclass) ─────────────────────────────────
+
+  protected abstract writeLine(message: string): void;
+
+  /** Wire an inbound Readable (socket) to the line parser. */
+  protected attachReadable(readable: Readable): void {
+    const rl = createInterface({ input: readable });
+    rl.on("line", (line) => this.handleLine(line));
+    // readline re-emits input errors on the Interface; the transport subclass
+    // already handles errors on the underlying stream, swallow them here so
+    // they never surface as an uncaught 'error' on the Interface.
+    rl.on("error", () => {});
+  }
+
+  /** Mark the transport closed: reject every pending request. Idempotent. */
+  protected handleClosed(reason: string): void {
+    if (this.closed) return;
+    this.closed = true;
+    const error = new Error(reason);
+    for (const p of this.pending.values()) p.reject(error);
+    this.pending.clear();
+    for (const handler of this.closedHandlers) handler();
+    this.closedHandlers = [];
+  }
+
+  protected get isClosed(): boolean {
+    return this.closed;
+  }
+
+  // ── Public API ─────────────────────────────────────────────────
+
+  /** Close the transport and reject pending requests (subclass tears down its stream). */
+  abstract dispose(): void;
+
+  /** Observe transport teardown (dispose or unexpected close), fired once. */
+  onClosed(handler: () => void): void {
+    this.closedHandlers.push(handler);
+  }
+
+  async request(
+    method: string,
+    params?: unknown,
+    sessionId?: string,
+  ): Promise<unknown> {
+    if (this.closed) {
+      throw new Error(
+        "连接已断开。wave 进程已退出，请重启编辑器或检查 CLI 安装。",
+      );
+    }
+    const id = this.nextId++;
+    const envelope: Record<string, unknown> = { id, method, params };
+    if (sessionId) envelope.sessionId = sessionId;
+    const message = JSON.stringify(envelope) + "\n";
+
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.writeLine(message);
+    });
+  }
+
+  notify(method: string, params?: unknown, sessionId?: string): void {
+    if (this.closed) return;
+    const envelope: Record<string, unknown> = { method, params };
+    if (sessionId) envelope.sessionId = sessionId;
+    this.writeLine(JSON.stringify(envelope) + "\n");
+  }
+
+  onNotification(method: string, handler: NotificationHandler): void {
+    let set = this.handlers.get(method);
+    if (!set) {
+      set = new Set();
+      this.handlers.set(method, set);
+    }
+    set.add(handler);
+  }
+
+  offNotification(method: string, handler: NotificationHandler): void {
+    this.handlers.get(method)?.delete(handler);
+  }
+
+  // ── Internal ──────────────────────────────────────────────────
+
+  private handleLine(line: string): void {
+    let msg: unknown;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      console.error("[wave-jsonrpc] Failed to parse:", line);
+      return;
+    }
+
+    if (typeof msg !== "object" || msg === null) return;
+    const obj = msg as Record<string, unknown>;
+
+    // Response (has id + result/error)
+    if ("id" in obj && ("result" in obj || "error" in obj)) {
+      const id = Number(obj.id);
+      const pending = this.pending.get(id);
+      if (pending) {
+        this.pending.delete(id);
+        if (obj.error) {
+          const err = obj.error as { code: number; message: string };
+          pending.reject(new Error(err.message));
+        } else {
+          pending.resolve(obj.result);
+        }
+      }
+      return;
+    }
+
+    // Notification (has method, no id)
+    if ("method" in obj && !("id" in obj)) {
+      const method = obj.method as string;
+      const params = obj.params;
+      const sessionId =
+        typeof obj.sessionId === "string" ? obj.sessionId : undefined;
+      const set = this.handlers.get(method);
+      if (set) {
+        for (const handler of set) {
+          handler(params, sessionId);
+        }
+      }
+      return;
+    }
+  }
+}

--- a/packages/code/src/daemon/socketClient.ts
+++ b/packages/code/src/daemon/socketClient.ts
@@ -1,0 +1,34 @@
+/**
+ * SocketClient — JSON-RPC transport over a unix socket connection to the wave
+ * daemon. Mirrors packages/desktop/src/main/stdio/socketClient.ts (packages/code
+ * cannot import from packages/desktop).
+ */
+
+import type { Socket } from "net";
+import { JsonRpcClient } from "./jsonRpcClient.js";
+
+export class SocketClient extends JsonRpcClient {
+  private socket: Socket;
+
+  constructor(socket: Socket) {
+    super();
+    this.socket = socket;
+    this.attachReadable(socket);
+
+    socket.on("close", () => {
+      this.handleClosed("远端连接已断开。");
+    });
+    socket.on("error", (err) => {
+      console.error("[wave-daemon] Socket error:", err.message);
+    });
+  }
+
+  protected writeLine(message: string): void {
+    this.socket.write(message);
+  }
+
+  dispose(): void {
+    this.handleClosed("远端连接已断开。");
+    this.socket.destroy();
+  }
+}

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -253,6 +253,136 @@ export async function main() {
           );
       })
       .command(
+        "daemon",
+        "Manage the wave daemon (client subcommands — to START a daemon use `wave --daemon <socket>` instead)",
+        (yargs) => {
+          return yargs
+            .help()
+            .command(
+              "list",
+              "List sessions hosted by the daemon (in-memory registry)",
+              {},
+              async () => {
+                const { daemonListCommand, DEFAULT_DAEMON_SOCKET } =
+                  await import("./daemon/commands.js");
+                await daemonListCommand(DEFAULT_DAEMON_SOCKET);
+              },
+            )
+            .command(
+              "status <sessionId>",
+              "Show a session's progress and recent messages",
+              (yargs) => {
+                return yargs
+                  .positional("sessionId", {
+                    describe: "Session ID hosted by the daemon",
+                    type: "string",
+                  })
+                  .option("lines", {
+                    describe: "Number of recent messages to show",
+                    default: 20,
+                    type: "number",
+                  });
+              },
+              async (argv) => {
+                const { daemonStatusCommand, DEFAULT_DAEMON_SOCKET } =
+                  await import("./daemon/commands.js");
+                await daemonStatusCommand(
+                  DEFAULT_DAEMON_SOCKET,
+                  argv.sessionId as string,
+                  argv.lines as number,
+                );
+              },
+            )
+            .command(
+              "send <sessionId> <message>",
+              "Inject a message into a session and wait for the reply",
+              (yargs) => {
+                return yargs
+                  .positional("sessionId", {
+                    describe: "Session ID hosted by the daemon",
+                    type: "string",
+                  })
+                  .positional("message", {
+                    describe: "Message to send",
+                    type: "string",
+                  })
+                  .option("timeout", {
+                    describe: "Seconds to wait for the reply (0 = no limit)",
+                    default: 600,
+                    type: "number",
+                  });
+              },
+              async (argv) => {
+                const { daemonSendCommand, DEFAULT_DAEMON_SOCKET } =
+                  await import("./daemon/commands.js");
+                await daemonSendCommand(
+                  DEFAULT_DAEMON_SOCKET,
+                  argv.sessionId as string,
+                  argv.message as string,
+                  { timeout: argv.timeout as number },
+                );
+              },
+            )
+            .command(
+              "respond <sessionId> <requestId>",
+              "Respond to a pending permission request",
+              (yargs) => {
+                return yargs
+                  .positional("sessionId", {
+                    describe: "Session ID hosting the pending request",
+                    type: "string",
+                  })
+                  .positional("requestId", {
+                    describe: "Pending permission request ID",
+                    type: "string",
+                  })
+                  .option("allow", {
+                    describe: "Allow the operation",
+                    type: "boolean",
+                  })
+                  .option("deny", {
+                    describe: "Deny the operation",
+                    type: "boolean",
+                  })
+                  .option("reason", {
+                    describe: "Reason for the decision (deny)",
+                    type: "string",
+                  })
+                  .option("answer", {
+                    describe: "Answers JSON for AskUserQuestion requests",
+                    type: "string",
+                  })
+                  .option("rule", {
+                    describe: "Persist an allowed rule (e.g. Bash(ls))",
+                    type: "string",
+                  })
+                  .option("mode", {
+                    describe: "Switch the session's permission mode",
+                    type: "string",
+                  });
+              },
+              async (argv) => {
+                const { daemonRespondCommand, DEFAULT_DAEMON_SOCKET } =
+                  await import("./daemon/commands.js");
+                await daemonRespondCommand(
+                  DEFAULT_DAEMON_SOCKET,
+                  argv.sessionId as string,
+                  argv.requestId as string,
+                  {
+                    allow: argv.allow as boolean | undefined,
+                    deny: argv.deny as boolean | undefined,
+                    reason: argv.reason as string | undefined,
+                    answer: argv.answer as string | undefined,
+                    rule: argv.rule as string | undefined,
+                    mode: argv.mode as string | undefined,
+                  },
+                );
+              },
+            )
+            .demandCommand(1, "Please specify a daemon subcommand");
+        },
+      )
+      .command(
         "update",
         "Update WAVE Code to the latest version",
         {},

--- a/packages/code/src/stdio/agentBridge.ts
+++ b/packages/code/src/stdio/agentBridge.ts
@@ -175,6 +175,8 @@ export class AgentBridge {
         return this.getSessionInfo(sessionId);
       case "listPendingPermissions":
         return this.listPendingPermissions();
+      case "listDaemonSessions":
+        return this.listDaemonSessions();
       case "updateConfig":
         return this.updateConfig(p as unknown as UpdateConfigParams, sessionId);
       case "getConfiguredModels":
@@ -1176,6 +1178,26 @@ export class AgentBridge {
           context: entry.context,
         }),
       ),
+    };
+  }
+
+  /** Daemon list: expose the in-memory session registry (live sessions only,
+   * not disk-scanning). Registration order is preserved. */
+  private listDaemonSessions(): {
+    sessions: Array<{
+      sessionId: string;
+      workingDirectory: string;
+      isLoading: boolean;
+      messageCount: number;
+    }>;
+  } {
+    return {
+      sessions: [...this.sessions.entries()].map(([sessionId, entry]) => ({
+        sessionId,
+        workingDirectory: entry.agent.workingDirectory,
+        isLoading: entry.agent.isLoading,
+        messageCount: entry.agent.messages.length,
+      })),
     };
   }
 

--- a/packages/code/src/stdio/protocol.ts
+++ b/packages/code/src/stdio/protocol.ts
@@ -79,6 +79,8 @@ export type RequestMethod =
   | "setModel"
   // Permissions (daemon attach: re-surface pending approvals after reconnect)
   | "listPendingPermissions"
+  // Daemon (global — list in-memory session registry, no session required)
+  | "listDaemonSessions"
   // Auth
   | "getAuthStatus"
   | "login"

--- a/packages/code/tests/daemon/commands.test.ts
+++ b/packages/code/tests/daemon/commands.test.ts
@@ -1,0 +1,682 @@
+/**
+ * `wave daemon` client subcommands (list / status / send / respond) — end-to-end
+ * against a real DaemonServer: the commands' SocketClient connects to the unix
+ * socket, initialize+restoreSession re-attach to live sessions in the daemon's
+ * in-memory registry, and respond resolves in-process permission promises.
+ *
+ * The SDK is mocked with a factory (NOT auto-mock) so the real
+ * getMessageContent / tool-name constants used by commands.ts stay intact while
+ * Agent.create + loadUserConfigEnv are stubbed.
+ */
+
+import { test as vitestTest, expect, vi, beforeEach, afterEach } from "vitest";
+import { createInterface } from "readline";
+import { PassThrough } from "stream";
+import * as net from "net";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  Agent,
+  loadUserConfigEnv,
+  type AgentCallbacks,
+  type Message,
+  type PermissionDecision,
+} from "wave-agent-sdk";
+
+// Unix-domain sockets are unreliable on Windows (libuv rejects non-"\\.\pipe\"
+// paths with EACCES); the daemon protocol logic is covered on Linux CI.
+const test = process.platform === "win32" ? vitestTest.skip : vitestTest;
+
+// Factory mock: keep the real SDK utils/constants, stub only the entry points.
+vi.mock("wave-agent-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("wave-agent-sdk")>();
+  return {
+    ...actual,
+    Agent: { create: vi.fn() },
+    loadUserConfigEnv: vi.fn(() => ({})),
+  };
+});
+
+// vitest.config onConsoleLog throws on any stderr console output — commands use
+// console.error for diagnostics, so capture it (and raw writes) here.
+const stderrWriteSpy = vi
+  .spyOn(process.stderr, "write")
+  .mockImplementation(() => true);
+const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+/** Every command terminates via process.exit; throwing keeps the flow terminal
+ * (a no-op exit would let the command "continue" past the fail and pollute
+ * assertions with double execution). */
+class ExitSignal extends Error {
+  constructor(public readonly code: number) {
+    super(`process.exit(${code})`);
+    this.name = "ExitSignal";
+  }
+}
+const exitSpy = vi
+  .spyOn(process, "exit")
+  .mockImplementation((code?: string | number | null) => {
+    throw new ExitSignal(Number(code ?? 0));
+  });
+
+import { DaemonServer } from "../../src/stdio/daemonServer.js";
+import {
+  daemonListCommand,
+  daemonStatusCommand,
+  daemonSendCommand,
+  daemonRespondCommand,
+} from "../../src/daemon/commands.js";
+
+function userMsg(id: string, content: string): Message {
+  return {
+    id,
+    role: "user",
+    blocks: [{ type: "text", content }],
+    timestamp: "t",
+  };
+}
+
+function assistantMsg(id: string, content: string): Message {
+  return {
+    id,
+    role: "assistant",
+    blocks: [{ type: "text", content }],
+    timestamp: "t",
+  };
+}
+
+function createMockAgent(overrides: Record<string, unknown> = {}) {
+  const messages: Message[] = [];
+  return {
+    sessionId: "test-session-id",
+    workingDirectory: "/test/workdir",
+    latestTotalTokens: 0,
+    messages,
+    destroy: vi.fn().mockResolvedValue(undefined),
+    restoreSession: vi.fn(),
+    sendMessage: vi.fn(),
+    bang: vi.fn(),
+    abortMessage: vi.fn(),
+    clearMessages: vi.fn(),
+    truncateHistory: vi.fn(),
+    removeQueuedMessage: vi.fn(),
+    getFullMessageThread: vi
+      .fn()
+      .mockResolvedValue({ messages, sessionIds: ["test-session-id"] }),
+    getPermissionMode: vi.fn().mockReturnValue("default"),
+    setPermissionMode: vi.fn(),
+    getMcpServers: vi.fn().mockReturnValue([]),
+    connectMcpServer: vi.fn().mockResolvedValue(true),
+    disconnectMcpServer: vi.fn().mockResolvedValue(true),
+    getSlashCommands: vi.fn().mockReturnValue([]),
+    getAvailableToolNames: vi.fn().mockReturnValue(["Bash"]),
+    isLoading: false,
+    hasPendingMessages: false,
+    hasRunningBackgroundWork: false,
+    ...overrides,
+  } as unknown as import("wave-agent-sdk").Agent;
+}
+
+/** Connect a JSON-RPC client socket to the daemon; resolves once a response arrives. */
+function connectClient(socketPath: string) {
+  const socket = net.connect(socketPath);
+  const input = new PassThrough();
+  socket.pipe(input);
+  const rl = createInterface({ input });
+  const lines: string[] = [];
+  rl.on("line", (line: string) => {
+    if (line.trim()) lines.push(line);
+  });
+
+  const ready = new Promise<void>((resolve, reject) => {
+    socket.once("connect", resolve);
+    socket.once("error", reject);
+  });
+
+  return {
+    socket,
+    lines,
+    async send(obj: unknown): Promise<unknown[]> {
+      await ready;
+      const before = lines.length;
+      socket.write(JSON.stringify(obj) + "\n");
+      await vi.waitFor(() => {
+        expect(lines.length).toBeGreaterThan(before);
+      });
+      return lines.slice(before).map((l) => JSON.parse(l));
+    },
+    close(): void {
+      socket.destroy();
+    },
+  };
+}
+
+/** Create a session via a raw client and trigger a pending permission request. */
+async function createPendingRequest(
+  toolName: string,
+  toolInput: Record<string, unknown> = {},
+): Promise<{ permissionPromise: Promise<PermissionDecision> }> {
+  const client = connectClient(socketPath);
+  await client.send({ id: 1, method: "initialize", params: {} });
+  const options = vi.mocked(Agent.create).mock.calls[0][0];
+  const permissionPromise = options.canUseTool!({
+    toolName,
+    permissionMode: "default",
+    toolInput,
+  }) as Promise<PermissionDecision>;
+  await vi.waitFor(() => {
+    expect(
+      client.lines.some((l) => JSON.parse(l).method === "permissionRequest"),
+    ).toBe(true);
+  });
+  client.close();
+  return { permissionPromise };
+}
+
+const stdoutLines = () => logSpy.mock.calls.map((c) => c.join(" "));
+const stderrText = () => errorSpy.mock.calls.map((c) => c.join(" ")).join("");
+
+let server: DaemonServer;
+let socketPath: string;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.mocked(loadUserConfigEnv).mockReturnValue({});
+  vi.mocked(Agent.create).mockResolvedValue(createMockAgent());
+  socketPath = path.join(
+    os.tmpdir(),
+    `wave-daemon-test-${process.pid}-${Date.now()}.sock`,
+  );
+  server = new DaemonServer({ socketPath });
+  await server.start();
+});
+
+afterEach(async () => {
+  stderrWriteSpy.mockRestore();
+  await server.stop();
+  try {
+    fs.unlinkSync(socketPath);
+  } catch {
+    // already gone
+  }
+});
+
+// ── list ───────────────────────────────────────────────────────
+
+test("list: empty daemon prints 无会话 and exits 0 (idle exit is not an error)", async () => {
+  await expect(daemonListCommand(socketPath)).rejects.toThrow("exit(0)");
+  expect(logSpy).toHaveBeenCalledWith("无会话");
+  expect(exitSpy).toHaveBeenCalledWith(0);
+});
+
+test("list: prints a padded table of hosted sessions (in-memory registry)", async () => {
+  const busy = createMockAgent({
+    sessionId: "session-busy",
+    workingDirectory: "/repo/a",
+    isLoading: true,
+  });
+  busy.messages.push(userMsg("u1", "你好"));
+  const idle = createMockAgent({
+    sessionId: "session-idle",
+    workingDirectory: "/repo/b",
+  });
+  idle.messages.push(userMsg("u2", "x"), assistantMsg("a2", "y"));
+  const agents = [busy, idle];
+  let i = 0;
+  vi.mocked(Agent.create).mockImplementation(async () => agents[i++]);
+
+  const client = connectClient(socketPath);
+  await client.send({ id: 1, method: "initialize", params: {} });
+  await client.send({ id: 2, method: "initialize", params: {} });
+  client.close();
+
+  await expect(daemonListCommand(socketPath)).rejects.toThrow("exit(0)");
+  const out = stdoutLines();
+  expect(out[0]).toContain("会话");
+  expect(out[0]).toContain("工作目录");
+  expect(out.join("\n")).toContain("session-busy");
+  expect(out.join("\n")).toContain("生成中");
+  expect(out.join("\n")).toContain("/repo/a");
+  expect(out.join("\n")).toContain("session-idle");
+  expect(out.join("\n")).toContain("空闲");
+  expect(out.join("\n")).toContain("/repo/b");
+  expect(exitSpy).toHaveBeenCalledWith(0);
+});
+
+test("list: daemon not running exits 1 with the spec'd hint", async () => {
+  const missing = path.join(
+    os.tmpdir(),
+    `wave-daemon-missing-${process.pid}-${Date.now()}.sock`,
+  );
+  await expect(daemonListCommand(missing)).rejects.toThrow("exit(1)");
+  expect(stderrText()).toContain(`无法连接 daemon socket ${missing}`);
+  expect(stderrText()).toContain(
+    "daemon 未运行？（daemon 空闲 60 秒自动退出）",
+  );
+  expect(stderrText()).toContain("(ENOENT)");
+  expect(exitSpy).toHaveBeenCalledWith(1);
+});
+
+// ── status ─────────────────────────────────────────────────────
+
+test("status: busy session prints session/workdir/status + recent messages, stays hosted", async () => {
+  const agent = createMockAgent({ isLoading: true });
+  agent.messages.push(userMsg("u1", "你好"), assistantMsg("a1", "正在处理…"));
+  vi.mocked(Agent.create).mockResolvedValue(agent);
+
+  const client = connectClient(socketPath);
+  await client.send({ id: 1, method: "initialize", params: {} });
+  client.close();
+
+  await expect(
+    daemonStatusCommand(socketPath, "test-session-id"),
+  ).rejects.toThrow("exit(0)");
+  const out = stdoutLines();
+  expect(out).toContain("会话: test-session-id");
+  expect(out).toContain("工作目录: /test/workdir");
+  expect(out).toContain("状态: 生成中");
+  expect(out).toContain("最近消息 (2):");
+  expect(out.join("\n")).toContain("[user] 你好");
+  expect(out.join("\n")).toContain("[assistant] 正在处理…");
+  expect(exitSpy).toHaveBeenCalledWith(0);
+
+  // Attach is transient — the daemon still hosts the session afterwards.
+  const b = connectClient(socketPath);
+  const msgs = await b.send({
+    id: 9,
+    method: "listDaemonSessions",
+    params: {},
+  });
+  const result = msgs[0] as { result: { sessions: unknown[] } };
+  expect(result.result.sessions).toHaveLength(1);
+  b.close();
+});
+
+test("status: idle session shows 空闲", async () => {
+  const client = connectClient(socketPath);
+  await client.send({ id: 1, method: "initialize", params: {} });
+  client.close();
+
+  await expect(
+    daemonStatusCommand(socketPath, "test-session-id"),
+  ).rejects.toThrow("exit(0)");
+  expect(stdoutLines()).toContain("状态: 空闲");
+  expect(exitSpy).toHaveBeenCalledWith(0);
+});
+
+test("status: pending approval shows 等待审批 + the request list", async () => {
+  await createPendingRequest("Bash", { command: "ls -la" });
+
+  await expect(
+    daemonStatusCommand(socketPath, "test-session-id"),
+  ).rejects.toThrow("exit(0)");
+  const out = stdoutLines();
+  expect(out).toContain("状态: 等待审批");
+  expect(out).toContain("待审批请求:");
+  expect(
+    out.some(
+      (l) => l.includes("perm_1") && l.includes("Bash") && l.includes("ls -la"),
+    ),
+  ).toBe(true);
+  expect(exitSpy).toHaveBeenCalledWith(0);
+});
+
+test("status: nonexistent session fails, destroys the junk fresh session, registry stays clean", async () => {
+  const junk = createMockAgent({
+    sessionId: "fresh",
+    restoreSession: vi
+      .fn()
+      .mockRejectedValue(new Error("Session not found: ghost")),
+  });
+  vi.mocked(Agent.create).mockResolvedValue(junk);
+
+  await expect(daemonStatusCommand(socketPath, "ghost")).rejects.toThrow(
+    "exit(1)",
+  );
+  expect(stderrText()).toContain("会话不存在或未被该 daemon 托管：ghost");
+  expect(exitSpy).toHaveBeenCalledWith(1);
+  expect(junk.destroy).toHaveBeenCalled();
+
+  const client = connectClient(socketPath);
+  const msgs = await client.send({
+    id: 9,
+    method: "listDaemonSessions",
+    params: {},
+  });
+  const result = msgs[0] as { result: { sessions: unknown[] } };
+  expect(result.result.sessions).toEqual([]);
+  client.close();
+});
+
+// ── send ───────────────────────────────────────────────────────
+
+test("send: prints the pure final reply text and exits 0 (idle session)", async () => {
+  let agent!: ReturnType<typeof createMockAgent>;
+  let callbacks!: AgentCallbacks;
+  vi.mocked(Agent.create).mockImplementation(async (options) => {
+    callbacks = options.callbacks!;
+    agent = createMockAgent();
+    agent.sendMessage = vi.fn(async () => {
+      agent.messages.push(userMsg("u1", "继续"));
+      agent.messages.push(assistantMsg("a1", "好的，我继续。"));
+      callbacks.onUserMessageAdded?.({ content: "继续" });
+      callbacks.onAssistantMessageAdded?.("a1");
+      callbacks.onLoadingChange?.(false);
+    });
+    return agent;
+  });
+
+  const client = connectClient(socketPath);
+  await client.send({ id: 1, method: "initialize", params: {} });
+  client.close();
+
+  await expect(
+    daemonSendCommand(socketPath, "test-session-id", "继续", { timeout: 5 }),
+  ).rejects.toThrow("exit(0)");
+  expect(stdoutLines()).toEqual(["好的，我继续。"]);
+  expect(exitSpy).toHaveBeenCalledWith(0);
+  expect(agent.sendMessage).toHaveBeenCalledWith("继续", undefined);
+
+  // send is transient — the session stays hosted.
+  const b = connectClient(socketPath);
+  const msgs = await b.send({
+    id: 9,
+    method: "listDaemonSessions",
+    params: {},
+  });
+  const result = msgs[0] as { result: { sessions: unknown[] } };
+  expect(result.result.sessions).toHaveLength(1);
+  b.close();
+});
+
+test("send: a stale loading:false from the previous turn must not end the wait", async () => {
+  let agent!: ReturnType<typeof createMockAgent>;
+  let callbacks!: AgentCallbacks;
+  vi.mocked(Agent.create).mockImplementation(async (options) => {
+    callbacks = options.callbacks!;
+    agent = createMockAgent({ isLoading: true });
+    agent.sendMessage = vi.fn(async () => {
+      // The PREVIOUS turn completes right after our message is enqueued — a
+      // loading:false arrives before OUR reply exists. The wait must continue.
+      callbacks.onLoadingChange?.(false);
+      setTimeout(() => {
+        agent.messages.push(userMsg("u1", "继续"));
+        agent.messages.push(
+          assistantMsg("a1", "好，等前一个任务结束我就开始。"),
+        );
+        callbacks.onUserMessageAdded?.({ content: "继续" });
+        callbacks.onAssistantMessageAdded?.("a1");
+        callbacks.onLoadingChange?.(false);
+      }, 50);
+    });
+    return agent;
+  });
+
+  const client = connectClient(socketPath);
+  await client.send({ id: 1, method: "initialize", params: {} });
+  client.close();
+
+  await expect(
+    daemonSendCommand(socketPath, "test-session-id", "继续", { timeout: 5 }),
+  ).rejects.toThrow("exit(0)");
+  expect(stdoutLines()).toEqual(["好，等前一个任务结束我就开始。"]);
+  expect(exitSpy).toHaveBeenCalledWith(0);
+});
+
+test("send: times out and points at respond when a permission approval is pending", async () => {
+  await createPendingRequest("Bash", { command: "ls" });
+
+  await expect(
+    daemonSendCommand(socketPath, "test-session-id", "继续", { timeout: 0.2 }),
+  ).rejects.toThrow("exit(1)");
+  expect(stderrText()).toContain(
+    "会话等待权限审批，请通过 `wave daemon respond test-session-id perm_1` 处理后重试",
+  );
+  expect(exitSpy).toHaveBeenCalledWith(1);
+});
+
+test("send: times out with the generic message when nothing is pending", async () => {
+  const client = connectClient(socketPath);
+  await client.send({ id: 1, method: "initialize", params: {} });
+  client.close();
+
+  await expect(
+    daemonSendCommand(socketPath, "test-session-id", "继续", { timeout: 0.2 }),
+  ).rejects.toThrow("exit(1)");
+  expect(stderrText()).toContain("等待回复超时（0.2 秒），未收到助手回复");
+  expect(exitSpy).toHaveBeenCalledWith(1);
+});
+
+test("send: nonexistent session fails without injecting a message", async () => {
+  const junk = createMockAgent({
+    sessionId: "fresh",
+    restoreSession: vi
+      .fn()
+      .mockRejectedValue(new Error("Session not found: ghost")),
+  });
+  vi.mocked(Agent.create).mockResolvedValue(junk);
+
+  await expect(daemonSendCommand(socketPath, "ghost", "hi")).rejects.toThrow(
+    "exit(1)",
+  );
+  expect(stderrText()).toContain("会话不存在或未被该 daemon 托管：ghost");
+  expect(exitSpy).toHaveBeenCalledWith(1);
+  expect(junk.sendMessage).not.toHaveBeenCalled();
+});
+
+// ── respond ────────────────────────────────────────────────────
+
+test("respond: --allow resolves a Bash request with behavior allow", async () => {
+  const { permissionPromise } = await createPendingRequest("Bash", {
+    command: "ls",
+  });
+
+  await expect(
+    daemonRespondCommand(socketPath, "test-session-id", "perm_1", {
+      allow: true,
+    }),
+  ).rejects.toThrow("exit(0)");
+  expect(logSpy).toHaveBeenCalledWith("已处理审批请求：perm_1");
+  await expect(permissionPromise).resolves.toEqual({ behavior: "allow" });
+  expect(exitSpy).toHaveBeenCalledWith(0);
+});
+
+test("respond: --deny with --reason resolves with deny + message", async () => {
+  const { permissionPromise } = await createPendingRequest("Bash", {
+    command: "rm -rf /",
+  });
+
+  await expect(
+    daemonRespondCommand(socketPath, "test-session-id", "perm_1", {
+      deny: true,
+      reason: "危险操作",
+    }),
+  ).rejects.toThrow("exit(0)");
+  await expect(permissionPromise).resolves.toEqual({
+    behavior: "deny",
+    message: "危险操作",
+  });
+  expect(exitSpy).toHaveBeenCalledWith(0);
+});
+
+test("respond: --allow on EnterPlanMode auto-completes newPermissionMode plan", async () => {
+  const { permissionPromise } = await createPendingRequest("EnterPlanMode");
+
+  await expect(
+    daemonRespondCommand(socketPath, "test-session-id", "perm_1", {
+      allow: true,
+    }),
+  ).rejects.toThrow("exit(0)");
+  await expect(permissionPromise).resolves.toEqual({
+    behavior: "allow",
+    newPermissionMode: "plan",
+  });
+});
+
+test("respond: --allow on ExitPlanMode auto-completes newPermissionMode default", async () => {
+  const { permissionPromise } = await createPendingRequest("ExitPlanMode");
+
+  await expect(
+    daemonRespondCommand(socketPath, "test-session-id", "perm_1", {
+      allow: true,
+    }),
+  ).rejects.toThrow("exit(0)");
+  await expect(permissionPromise).resolves.toEqual({
+    behavior: "allow",
+    newPermissionMode: "default",
+  });
+});
+
+test("respond: --answer provides the AskUserQuestion answers as JSON message", async () => {
+  const { permissionPromise } = await createPendingRequest("AskUserQuestion", {
+    question: "继续吗",
+  });
+
+  await expect(
+    daemonRespondCommand(socketPath, "test-session-id", "perm_1", {
+      allow: true,
+      answer: '{"继续吗":"继续"}',
+    }),
+  ).rejects.toThrow("exit(0)");
+  await expect(permissionPromise).resolves.toEqual({
+    behavior: "allow",
+    message: '{"继续吗":"继续"}',
+  });
+});
+
+test("respond: AskUserQuestion without --answer fails", async () => {
+  await createPendingRequest("AskUserQuestion", { question: "继续吗" });
+
+  await expect(
+    daemonRespondCommand(socketPath, "test-session-id", "perm_1", {
+      allow: true,
+    }),
+  ).rejects.toThrow("exit(1)");
+  expect(stderrText()).toContain(
+    "AskUserQuestion 请求需要 --answer 提供答案 JSON",
+  );
+  expect(exitSpy).toHaveBeenCalledWith(1);
+});
+
+test("respond: AskUserQuestion with invalid JSON --answer fails", async () => {
+  await createPendingRequest("AskUserQuestion", { question: "继续吗" });
+
+  await expect(
+    daemonRespondCommand(socketPath, "test-session-id", "perm_1", {
+      allow: true,
+      answer: "not-json",
+    }),
+  ).rejects.toThrow("exit(1)");
+  expect(stderrText()).toContain("--answer 不是合法的 JSON");
+  expect(exitSpy).toHaveBeenCalledWith(1);
+});
+
+test("respond: --rule persists an allowed rule on the decision", async () => {
+  const { permissionPromise } = await createPendingRequest("Bash", {
+    command: "ls",
+  });
+
+  await expect(
+    daemonRespondCommand(socketPath, "test-session-id", "perm_1", {
+      allow: true,
+      rule: "Bash(ls)",
+    }),
+  ).rejects.toThrow("exit(0)");
+  await expect(permissionPromise).resolves.toEqual({
+    behavior: "allow",
+    newPermissionRule: "Bash(ls)",
+  });
+});
+
+test("respond: --mode switches the session's permission mode", async () => {
+  const { permissionPromise } = await createPendingRequest("Bash", {
+    command: "ls",
+  });
+
+  await expect(
+    daemonRespondCommand(socketPath, "test-session-id", "perm_1", {
+      allow: true,
+      mode: "acceptEdits",
+    }),
+  ).rejects.toThrow("exit(0)");
+  await expect(permissionPromise).resolves.toEqual({
+    behavior: "allow",
+    newPermissionMode: "acceptEdits",
+  });
+});
+
+test("respond: invalid --mode fails with the accepted modes listed", async () => {
+  await createPendingRequest("Bash", { command: "ls" });
+
+  await expect(
+    daemonRespondCommand(socketPath, "test-session-id", "perm_1", {
+      allow: true,
+      mode: "bogus",
+    }),
+  ).rejects.toThrow("exit(1)");
+  expect(stderrText()).toContain(
+    "无效的权限模式：bogus（可选：default、bypassPermissions、acceptEdits、plan、dontAsk）",
+  );
+  expect(exitSpy).toHaveBeenCalledWith(1);
+});
+
+test("respond: unknown requestId fails — the server would silently ignore it", async () => {
+  await createPendingRequest("Bash", { command: "ls" });
+
+  await expect(
+    daemonRespondCommand(socketPath, "test-session-id", "perm_999", {
+      allow: true,
+    }),
+  ).rejects.toThrow("exit(1)");
+  expect(stderrText()).toContain("该请求不存在或已处理");
+  expect(exitSpy).toHaveBeenCalledWith(1);
+});
+
+test("respond: another session's request is refused and left untouched", async () => {
+  const agents = [
+    createMockAgent({ sessionId: "s1" }),
+    createMockAgent({ sessionId: "s2" }),
+  ];
+  let i = 0;
+  vi.mocked(Agent.create).mockImplementation(async () => agents[i++]);
+
+  const client = connectClient(socketPath);
+  await client.send({ id: 1, method: "initialize", params: {} });
+  await client.send({ id: 2, method: "initialize", params: {} });
+  const options = vi.mocked(Agent.create).mock.calls[0][0]!;
+  const permissionPromise = options.canUseTool!({
+    toolName: "Bash",
+    permissionMode: "default",
+    toolInput: { command: "ls" },
+  }) as Promise<PermissionDecision>;
+  await vi.waitFor(() => {
+    expect(
+      client.lines.some((l) => JSON.parse(l).method === "permissionRequest"),
+    ).toBe(true);
+  });
+  client.close();
+
+  await expect(
+    daemonRespondCommand(socketPath, "s2", "perm_1", { allow: true }),
+  ).rejects.toThrow("exit(1)");
+  expect(stderrText()).toContain("会话不存在或未被该 daemon 托管");
+  expect(exitSpy).toHaveBeenCalledWith(1);
+
+  // The s1 request was never answered.
+  let resolved = false;
+  permissionPromise.then(() => {
+    resolved = true;
+  });
+  await new Promise((r) => setTimeout(r, 50));
+  expect(resolved).toBe(false);
+});
+
+test("respond: requires exactly one of --allow / --deny", async () => {
+  await expect(
+    daemonRespondCommand(socketPath, "test-session-id", "perm_1", {}),
+  ).rejects.toThrow("exit(1)");
+  expect(stderrText()).toContain("请指定 --allow 或 --deny（二选一）");
+  expect(exitSpy).toHaveBeenCalledWith(1);
+});


### PR DESCRIPTION
Wire the wave daemon JSON-RPC (unix socket) protocol from the CLI:
- new daemon client layer: jsonRpcClient.ts (JSON-RPC 2.0, requests/
  notifications, pending mapping) + socketClient.ts (unix socket transport)
- list/status/send/respond all connect to the fixed ~/.wave/daemon.sock
  (no --socket/--json flags); stdout results, stderr diagnostics, exit codes
- attach flow: initialize -> restoreSession; missing sessions are detected
  by catching restoreSession rejection and destroying the junk fresh session
- send prints the pure final reply text: idle path waits for the full turn
  via userMessageAdded/assistantMessageAdded/loadingChange notifications
  with replyMessageId tracking; busy path enqueues and returns immediately
- respond covers the full PermissionDecision space: EnterPlanMode/ExitPlanMode
  auto mode switches, AskUserQuestion --answer, allow/deny with message,
  --rule newPermissionRule, --mode newPermissionMode
- agentBridge: add listDaemonSessions wire method over the in-memory session
  registry; protocol.ts declares the method
- spec docs/specs/ui/daemon-command.md (5 stories, 30 scenarios)
- tests/daemon/commands.test.ts: 25 end-to-end tests against a real
  DaemonServer over a unix socket
