### PR TITLE
fix(webview): anchor sidebar tooltips to hover-highlight containers

### DIFF
--- a/packages/webview/src/components/DesktopSidebar.tsx
+++ b/packages/webview/src/components/DesktopSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef, RefObject } from "react";
 import { Tooltip } from "./Tooltip";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { MoreIcon } from "./HeaderIcons";
@@ -92,6 +92,23 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
   // click handlers below (Cmd on macOS / Ctrl elsewhere).
   const modKeyLabel = isMacPlatform() ? "Cmd" : "Ctrl";
 
+  // Tooltip anchors live on the hover-highlight containers themselves (li for
+  // session rows, the button for 新对话), so both hints start at the row's
+  // visual right edge. Per-session ref objects are created lazily and reused
+  // across renders — a fresh object per render would re-attach the refs.
+  const sessionAnchorsRef = useRef(
+    new Map<string, RefObject<HTMLLIElement>>(),
+  );
+  const getAnchorRef = (sessionId: string) => {
+    let anchor = sessionAnchorsRef.current.get(sessionId);
+    if (!anchor) {
+      anchor = { current: null };
+      sessionAnchorsRef.current.set(sessionId, anchor);
+    }
+    return anchor;
+  };
+  const newChatAnchorRef = useRef<HTMLButtonElement | null>(null);
+
   const isExpanded = (group: DesktopSessionGroup): boolean =>
     overrides[groupKey(group)] ?? true;
 
@@ -150,16 +167,20 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
           }
         }}
         data-testid={`desktop-session-item-${session.sessionId}`}
+        ref={getAnchorRef(session.sessionId)}
       >
         {/*
-          The tooltip wraps the row content only (dot + title) — the delete
-          button stays a sibling so it keeps its own hover affordance, and the
-          li remains the ul's direct child (no span-wrapped li, invalid DOM).
+          Tooltip anchor = the li's hover-highlight container (via anchorRef),
+          so the hint starts at the row's right edge (position="right", offset
+          8px). The wrapper span only carries the row content + hover events.
+          The delete button stays a sibling so hovering it shows its own
+          "删除会话" title instead of the drag hint.
         */}
         <Tooltip
           text={`可拖拽或 ${modKeyLabel}+点击 并排打开`}
           position="right"
           className="desktop-session-item-tooltip"
+          anchorRef={getAnchorRef(session.sessionId)}
         >
           <div className="desktop-session-item-main">
             {running || waiting ? (
@@ -240,8 +261,10 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
         }
         position="right"
         className="desktop-sidebar-new-chat-tooltip"
+        anchorRef={newChatAnchorRef}
       >
         <button
+          ref={newChatAnchorRef}
           className="desktop-sidebar-new-chat"
           onClick={(e) => {
             // Cmd on macOS / Ctrl elsewhere opens the new session side-by-side
@@ -310,6 +333,7 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
           description={pendingDelete.description}
           onConfirm={() => {
             onDeleteSession(pendingDelete.sessionId);
+            sessionAnchorsRef.current.delete(pendingDelete.sessionId);
             setPendingDelete(null);
           }}
           onCancel={() => setPendingDelete(null)}

--- a/packages/webview/src/components/Tooltip.tsx
+++ b/packages/webview/src/components/Tooltip.tsx
@@ -2,6 +2,7 @@ import React, {
   useState,
   useId,
   ReactElement,
+  RefObject,
   useRef,
   useCallback,
 } from "react";
@@ -22,6 +23,12 @@ interface TooltipProps {
   offset?: number;
   disabled?: boolean;
   className?: string;
+  /**
+   * Optional external anchor: the tooltip positions against this element
+   * instead of the wrapper span (e.g. a row's hover-highlight container, so
+   * the hint starts at the row's visual edge rather than the content's).
+   */
+  anchorRef?: RefObject<HTMLElement>;
 }
 
 export const Tooltip: React.FC<TooltipProps> = ({
@@ -31,6 +38,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
   offset = 8,
   disabled = false,
   className = "",
+  anchorRef,
 }) => {
   const [isVisible, setIsVisible] = useState(false);
   const [tooltipStyle, setTooltipStyle] = useState<React.CSSProperties>({});
@@ -39,9 +47,10 @@ export const Tooltip: React.FC<TooltipProps> = ({
   const tooltipRef = useRef<HTMLDivElement>(null);
 
   const calculatePosition = useCallback(() => {
-    if (!containerRef.current || !tooltipRef.current) return;
+    const anchor = anchorRef?.current ?? containerRef.current;
+    if (!anchor || !tooltipRef.current) return;
 
-    const containerRect = containerRef.current.getBoundingClientRect();
+    const containerRect = anchor.getBoundingClientRect();
     const tooltipRect = tooltipRef.current.getBoundingClientRect();
 
     let left = 0;
@@ -101,7 +110,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
     top = Math.min(Math.max(top, margin), maxTop);
 
     setTooltipStyle({ left, top });
-  }, [position, offset]);
+  }, [position, offset, anchorRef]);
 
   // When disabled, render children without tooltip wrapper
   if (disabled) {

--- a/packages/webview/src/styles/DesktopApp.css
+++ b/packages/webview/src/styles/DesktopApp.css
@@ -226,20 +226,23 @@
   color: var(--vscode-errorForeground, #f14c4c);
 }
 
-/* Drag-or-Cmd/Ctrl hint tooltip (Tooltip.tsx): the anchor wraps the row content
-   (dot + title) — the delete button stays a sibling so it keeps its own hover
-   affordance. The anchor must grow to fill the row for the title's ellipsis,
-   overriding .tooltip-container's flex-shrink:0 (DesktopApp.css loads after
-   Tooltip.css, so this class wins the cascade). */
+/* Drag-or-Cmd/Ctrl hint tooltip (Tooltip.tsx): the tooltip positions against
+   the row's hover-highlight container (the li, passed via Tooltip anchorRef),
+   so the hint starts at the row's visual right edge. This wrapper span only
+   carries the row content + hover events; it must grow to fill the row for the
+   title's ellipsis, overriding .tooltip-container's flex-shrink:0
+   (DesktopApp.css loads after Tooltip.css, so this class wins the cascade). */
 .desktop-session-item-tooltip {
   flex: 1 1 0%;
   min-width: 0;
 }
 
-/* New-chat hint tooltip: the Tooltip wrapper span defaults to inline-flex and
-   shrink-fits the button — block-level makes it fill the row, and the 6px
-   side padding keeps the button's hover background aligned with the session
-   items' inset. The two selectors beat .tooltip-container's single-class rule
+/* New-chat hint tooltip: the tooltip positions against the button itself (its
+   hover-highlight container, passed via Tooltip anchorRef) — same row-edge x
+   as the session-item tooltips. This wrapper span defaults to inline-flex and
+   shrink-fits the button; block-level makes it fill the row, and the side
+   padding keeps the button's hover background aligned with the session items'
+   inset. The two selectors beat .tooltip-container's single-class rule
    regardless of the bundled CSS order. */
 .desktop-sidebar .desktop-sidebar-new-chat-tooltip {
   display: block;
@@ -250,6 +253,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
+  flex: 1 1 0%;
   min-width: 0;
 }
 


### PR DESCRIPTION
两个悬停提示（会话条目 / 新对话）此前靠 CSS margin hack 对齐到同一水平起点，用户反馈不够优雅。改用 Tooltip 新增的可选 anchorRef 属性，把提示锚定到悬停高亮容器本身：会话条目锚定 li，新对话锚定 button，两提示都从行右缘（234+8=242）起始，天然对齐。

同时：
- 删除按钮恢复为 li 兄弟（原本移入锚点 span 以覆盖右缘），hover 它只显示自己的「删除会话」title，不再与拖拽提示竞争
- 每会话锚点 ref 对象在 Map 中缓存复用（每渲染新建对象会导致 ref 重挂），删除会话时释放
- calculatePosition deps 补上 anchorRef（防非穷尽依赖）

验证：desktopApp.test.tsx 101 全绿、type-check 过、Playwright 几何测量两 tooltip left 均 242 无重叠、真机 dev 用户验证通过。