### PR TITLE
fix(desktop): 删除唯一会话后「新对话」按钮不再失效

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -418,7 +418,12 @@ export class DesktopHost {
       return;
     }
     const pane = this.panes[0];
-    if (pane?.agent) await this.handleNewSession(pane.paneId);
+    // Closing a sole empty session is a no-op — it already is the fresh
+    // session that closing would reset to (and 新对话 / Cmd+N always spawn
+    // instead, so the button is never a dead click).
+    if (pane?.agent && (pane.agent.messages.length > 0 || pane.agent.isStreaming)) {
+      await this.handleNewSession(pane.paneId);
+    }
   }
 
   /**
@@ -3794,7 +3799,10 @@ export class DesktopHost {
     const host = this.hostState.get(pid) ?? LOCAL_HOST;
     const dir = this.configStore.getRecentWorkdirsForHost(host)[0];
     if (!dir) return;
-    if (active && active.messages.length === 0 && !active.isStreaming) return;
+    // No no-op guard for an already-empty active session: clicking 新对话 is an
+    // explicit intent, and the blank agent is discarded by bindAgentToPane when
+    // replaced (delete-sole-session auto-replacement used to make the button a
+    // silent dead click — user feedback "点不动").
     try {
       const agent = await this.spawnAgent({ host, workdir: dir });
       // Spawning is slow (agent init) — the user may have selected another

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -1774,11 +1774,19 @@ describe("misc commands", () => {
     expect(spawned.destroy).toHaveBeenCalledTimes(1);
   });
 
-  it("newSession on an empty active session is a no-op", async () => {
-    const { host } = await readyHost();
+  it("newSession on an empty active session spawns a fresh session (replaces the blank agent)", async () => {
+    const { host, sent } = await readyHost();
+    const blank = lastAgent();
     const before = h.agentInstances.length;
     await host.handleWebviewMessage({ command: "newSession" });
-    expect(h.agentInstances).toHaveLength(before);
+    await vi.waitFor(() => {
+      expect(h.agentInstances).toHaveLength(before + 1);
+    });
+    // The blank agent is replaced by the fresh one, not leaked into the pool.
+    expect(blank.destroy).toHaveBeenCalled();
+    expect(sent("setInitialState").at(-1)).toMatchObject({
+      session: { id: lastAgent().sessionId },
+    });
   });
 
   it("clearChat clears the active session in place instead of spawning a new agent", async () => {
@@ -2386,6 +2394,41 @@ describe("session tree", () => {
     expect(h.agentInstances).toHaveLength(before + 1);
   });
 
+  it("repro: 终止并删除唯一会话后再次新建对话立即生效（用户反馈「点不动」）", async () => {
+    const { host, store } = await readyHost();
+    const doomed = lastAgent();
+    doomed.messages = [
+      { id: "m1", role: "user", blocks: [{ type: "text", content: "hi" }] },
+    ];
+    doomed.callbacks.onUserMessageAdded(doomed.messages[0]);
+    fireSessionId(doomed, "live-1");
+    doomed.isStreaming = true;
+
+    // 终止（mock 的 abortMessage 不改变流式态，手动复位模拟真实行为）
+    await host.handleWebviewMessage({ command: "abortMessage" });
+    doomed.isStreaming = false;
+
+    // 删除唯一会话：pane 释放 → 自动补一个空白新会话（agent C）
+    await host.handleWebviewMessage({
+      command: "desktopDeleteSession",
+      sessionId: "live-1",
+    });
+    await vi.waitFor(() => {
+      expect(
+        store.getSessionIndex().some((e) => e.sessionId === "live-1"),
+      ).toBe(false);
+    });
+    expect(doomed.destroy).toHaveBeenCalled();
+
+    // 再次新建对话：必须立即生效（不再被空白 agent 的 no-op 守卫拦截），
+    // 空白 agent C 被替换销毁，不留孤儿
+    const before = h.agentInstances.length;
+    await host.handleWebviewMessage({ command: "newSession" });
+    await vi.waitFor(() => {
+      expect(h.agentInstances).toHaveLength(before + 1);
+    });
+  });
+
   it("desktopDeleteSession on the active session does not clobber a session selected while destroy is in flight", async () => {
     const { host, store, sent } = await readyHost();
     fireSessionId(lastAgent(), "live-1");
@@ -2970,7 +3013,7 @@ describe("worktree flow", () => {
       command: "desktopCreateWorktree",
       workdir: "/work/a",
     });
-    lastAgent().messages = [{ id: "m1" }]; // non-empty so newSession is not a no-op
+    lastAgent().messages = [{ id: "m1" }];
 
     await host.handleWebviewMessage({ command: "newSession" });
 


### PR DESCRIPTION
## 背景

用户反馈（weiyaohua）：先新建对话 → 终止 → 删除该对话 → 再点「新对话」没反应（点不动）。

## 根因

删除唯一会话时 `handleDeleteSession` 的 resetSolePane 分支会自动补一个空白 agent（spec「删除后回到新会话页」的实现）。此时再点「新对话」，`handleNewSession` 的 no-op 守卫（`active.messages.length === 0 && !active.isStreaming`）静默拦截，按钮点了无任何反馈。

## 修复

- `handleNewSession`：删除 no-op 守卫——用户显式点击「新对话」总是创建新会话，旧空白 agent 由 `bindAgentToPane` 自动 discard，不留孤儿。侧边栏按钮（`newSession` 消息）与 Cmd+N 均生效。
- `closeFocusedPane`：Cmd+W 关闭唯一空分屏的 no-op 语义移到此处保留（关闭空会话本就无需再重置）。

## 验证

- TDD：原复现测试改为断言「再次新建立即生效（agent +1）」，新增空会话点新建替换空白 agent 断言
- desktop 包 483/483 测试通过，type-check 通过