### PR TITLE
fix(desktop): 升级与初始化提示改走全局 toast 而非聊天消息

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -591,7 +591,7 @@ export class DesktopHost {
       let binaryPath: string;
       try {
         binaryPath = await ensureCliUpToDate(targetVersion, (msg) =>
-          this.pushSystemMessage(msg),
+          this.showToast({ message: msg }),
         );
       } catch (error) {
         // Upgrade/install failure — fall back to whatever binary is resolvable.
@@ -599,9 +599,9 @@ export class DesktopHost {
           "[DesktopHost] ensureCliUpToDate failed, falling back:",
           error,
         );
-        this.pushSystemMessage(
-          `wave-code CLI 升级失败：${error instanceof Error ? error.message : String(error)}。可通过 npm install -g wave-code@${targetVersion} 手动升级`,
-        );
+        this.showToast({
+          message: `wave-code CLI 升级失败：${error instanceof Error ? error.message : String(error)}。可通过 npm install -g wave-code@${targetVersion} 手动升级`,
+        });
         binaryPath = resolveWaveBinary(undefined, targetVersion);
       }
       this.cliVersion = getCliVersion(binaryPath);
@@ -658,7 +658,7 @@ export class DesktopHost {
       const daemonSocket = await ensureRemoteDaemon(
         host,
         app.getVersion(),
-        (msg) => this.pushSystemMessage(msg),
+        (msg) => this.showToast({ message: msg }),
       );
       const { client, tunnel } = await connectRemoteDaemon(host, daemonSocket);
       const router = new NotificationRouter(client);
@@ -2029,10 +2029,9 @@ export class DesktopHost {
       const agent = await this.spawnAgent({ host, workdir: dir });
       await this.activateAgentInPane(paneId, agent);
     } catch (error) {
-      this.pushSystemMessage(
-        `初始化失败：${error instanceof Error ? error.message : String(error)}`,
-        paneId,
-      );
+      this.showToast({
+        message: `初始化失败：${error instanceof Error ? error.message : String(error)}`,
+      });
     }
   }
 
@@ -2568,9 +2567,9 @@ export class DesktopHost {
       });
       await this.activateAgentInPane(this.focusedPaneId, agent);
     } catch (error) {
-      this.pushSystemMessage(
-        `初始化失败：${error instanceof Error ? error.message : String(error)}`,
-      );
+      this.showToast({
+        message: `初始化失败：${error instanceof Error ? error.message : String(error)}`,
+      });
       return;
     }
     if (text) {
@@ -3350,9 +3349,9 @@ export class DesktopHost {
       }
     } catch (error) {
       console.error("[DesktopHost] 初始化智能体失败:", error);
-      this.pushSystemMessage(
-        `初始化失败：${error instanceof Error ? error.message : String(error)}。可通过侧边栏切换工作目录重试，或重启应用`,
-      );
+      this.showToast({
+        message: `初始化失败：${error instanceof Error ? error.message : String(error)}。可通过侧边栏切换工作目录重试，或重启应用`,
+      });
     }
   }
 

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -426,6 +426,7 @@ import { shell, dialog, nativeTheme, powerMonitor } from "electron";
 import { checkForUpdate } from "../src/main/updateChecker";
 import { autoUpdater } from "electron-updater";
 import {
+  ensureRemoteDaemon,
   connectRemoteDaemon,
   remotePathExists,
   listRemoteDirs,
@@ -887,7 +888,7 @@ describe("webviewReady / setInitialState", () => {
     );
   });
 
-  it("posts a system message instead of throwing when initialization fails", async () => {
+  it("shows a toast instead of throwing when initialization fails", async () => {
     const { ensureCliUpToDate } = await import(
       "../src/main/stdio/binaryResolver"
     );
@@ -910,10 +911,99 @@ describe("webviewReady / setInitialState", () => {
       path: "/work/a",
     });
 
-    const sysMsgs = sent("appendMessage").filter((m) =>
-      JSON.stringify(m).includes("初始化失败"),
+    const toasts = shownToasts().filter((t) =>
+      t.message.includes("初始化失败"),
     );
-    expect(sysMsgs).toHaveLength(1);
+    expect(toasts).toHaveLength(1);
+    expect(
+      sent("appendMessage").filter((m) =>
+        JSON.stringify(m).includes("初始化失败"),
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("surfaces the local CLI upgrade progress as a toast, not a chat message", async () => {
+    const { ensureCliUpToDate } = await import(
+      "../src/main/stdio/binaryResolver"
+    );
+    vi.mocked(ensureCliUpToDate).mockImplementationOnce(
+      async (_target, onInstall) => {
+        onInstall?.("正在升级 wave-code 到 v1.0.7，请稍候…");
+        return "/mock/wave";
+      },
+    );
+
+    const { host, store, sent } = createHost();
+    store.addRecentWorkdir({ host: "local", path: "/work/a" });
+    h.existingPaths.add("/work/a");
+    await host.handleWebviewMessage({ command: "desktopReady" });
+    await host.handleWebviewMessage({
+      command: "desktopSelectRecentWorkdir",
+      path: "/work/a",
+    });
+
+    expect(
+      shownToasts().some((t) => t.message.includes("正在升级 wave-code")),
+    ).toBe(true);
+    expect(
+      sent("appendMessage").filter((m) =>
+        JSON.stringify(m).includes("正在升级 wave-code"),
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("surfaces a CLI upgrade failure as a toast, not a chat message", async () => {
+    const { ensureCliUpToDate } = await import(
+      "../src/main/stdio/binaryResolver"
+    );
+    vi.mocked(ensureCliUpToDate).mockRejectedValueOnce(
+      new Error("install failed"),
+    );
+
+    const { host, store, sent } = createHost();
+    store.addRecentWorkdir({ host: "local", path: "/work/a" });
+    h.existingPaths.add("/work/a");
+    await host.handleWebviewMessage({ command: "desktopReady" });
+    await host.handleWebviewMessage({
+      command: "desktopSelectRecentWorkdir",
+      path: "/work/a",
+    });
+
+    expect(
+      shownToasts().some((t) => t.message.includes("wave-code CLI 升级失败")),
+    ).toBe(true);
+    expect(
+      sent("appendMessage").filter((m) =>
+        JSON.stringify(m).includes("wave-code CLI 升级失败"),
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("surfaces the remote daemon CLI upgrade progress as a toast, not a chat message", async () => {
+    seedSshConfig("Host prod\n  HostName 10.0.0.1\n");
+    const { host, sent } = createHost();
+    vi.mocked(ensureRemoteDaemon).mockImplementationOnce(
+      async (_host, _version, onNotice) => {
+        onNotice?.("正在升级 wave-code 到 v1.0.7，请稍候…");
+        return "/home/prod/.wave/daemon.sock";
+      },
+    );
+
+    await host.handleWebviewMessage({
+      command: "desktopSelectHost",
+      host: "prod",
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        shownToasts().some((t) => t.message.includes("正在升级 wave-code")),
+      ).toBe(true);
+    });
+    expect(
+      sent("appendMessage").filter((m) =>
+        JSON.stringify(m).includes("正在升级 wave-code"),
+      ),
+    ).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
升级 wave-code CLI 与初始化智能体失败等 host 生命周期提示此前走 pushSystemMessage 追加进聊天列表，与 2026-08-10 统一 toast（PR #1698）的原则不一致。

改动：desktopHost.ts 6 处 host 生命周期提示从消息列表改为全局 toast（showToast）：
- 本地 CLI 升级进度 onInstall（正在升级 wave-code…）
- 本地 CLI 升级失败提示（含 npm install -g 手动升级指引）
- 远程 daemon 升级进度 onInstall
- 初始化智能体失败（webviewReady 路径）
- 初始化失败（选目录 spawnAgent 失败）
- 初始化失败（新建 worktree 路径）

会话内错误（压缩/发送/新建对话/回滚失败等）仍留在聊天，维持 PR #1698 的边界。

测试：TDD 红转绿，改 1 个现有断言并新增 3 个用例（本地升级进度、升级失败、远程升级进度），均断言走 showToast 且 appendMessage 不含该文案。desktop 490 全绿，type-check + lint 通过。