### PR TITLE
fix: sync GBK command-output decoding to desktop and jetbrains resolvers

### DIFF
--- a/packages/desktop/src/main/stdio/binaryResolver.ts
+++ b/packages/desktop/src/main/stdio/binaryResolver.ts
@@ -39,6 +39,26 @@ function waveCodeSpec(targetVersion?: string): string {
 let cachedPath: string | undefined;
 
 /**
+ * Decode output of cmd.exe builtins (`where`, `which`, `npm prefix -g`). On
+ * Chinese Windows those write the system OEM code page (CP936/GBK); decoding
+ * GBK bytes as UTF-8 corrupts non-ASCII path segments (`C:\Users\刘一奇\...`
+ * → U+FFFD), and spawning the corrupted path fails with ERROR_PATH_NOT_FOUND
+ * — the stdio process dies before initialize, surfacing as「初始化失败：连接
+ * 已断开」. Try UTF-8 first (covers non-Windows and chcp 65001), fall back to
+ * GBK on U+FFFD — same policy as stdioClient.decodeStderr.
+ */
+function decodeCommandOutput(out: string | Buffer): string {
+  const buf = Buffer.isBuffer(out) ? out : Buffer.from(out);
+  const utf8 = buf.toString("utf-8");
+  if (!utf8.includes("\uFFFD")) return utf8;
+  try {
+    return new TextDecoder("gbk").decode(buf);
+  } catch {
+    return utf8;
+  }
+}
+
+/**
  * Pick the executable line from `which`/`where` output. On Windows `where`
  * lists the extensionless bash launcher first (e.g. `C:\Program Files\nodejs\npm`)
  * followed by `npm.cmd` — cmd.exe cannot execute the bash launcher, so prefer
@@ -104,7 +124,9 @@ export class NodeJsVersionError extends Error {
 function findNode(): string {
   const cmd = process.platform === "win32" ? "where node" : "which node";
   try {
-    const result = execSync(cmd, { encoding: "utf-8", stdio: "pipe" }).trim();
+    const result = decodeCommandOutput(
+      execSync(cmd, { encoding: "buffer", stdio: "pipe" }),
+    ).trim();
     if (result) return result.split("\n")[0].trim();
   } catch {
     // not on PATH
@@ -145,7 +167,9 @@ function checkNodeVersion(): void {
 function findNpm(): string {
   const cmd = process.platform === "win32" ? "where npm" : "which npm";
   try {
-    const result = execSync(cmd, { encoding: "utf-8", stdio: "pipe" }).trim();
+    const result = decodeCommandOutput(
+      execSync(cmd, { encoding: "buffer", stdio: "pipe" }),
+    ).trim();
     if (result) return pickExecutableLine(result);
   } catch {
     // not on PATH
@@ -168,10 +192,12 @@ function findNpm(): string {
 /** Resolve the npm global bin directory. */
 function getNpmGlobalBin(): string {
   const npm = findNpm();
-  const prefix = execSync(`"${npm}" prefix -g`, {
-    encoding: "utf-8",
-    stdio: "pipe",
-  }).trim();
+  const prefix = decodeCommandOutput(
+    execSync(`"${npm}" prefix -g`, {
+      encoding: "buffer",
+      stdio: "pipe",
+    }),
+  ).trim();
   return process.platform === "win32" ? prefix : path.join(prefix, "bin");
 }
 
@@ -206,10 +232,9 @@ export function resolveWaveBinary(
   // 1. Try PATH
   const whichCmd = process.platform === "win32" ? "where wave" : "which wave";
   try {
-    const result = execSync(whichCmd, {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
+    const result = decodeCommandOutput(
+      execSync(whichCmd, { encoding: "buffer", stdio: "pipe" }),
+    ).trim();
     if (result) {
       cachedPath = pickExecutableLine(result);
       return cachedPath;
@@ -260,10 +285,9 @@ export function resolveWaveBinary(
 
   // 5. Try PATH again (install may have added it)
   try {
-    const result = execSync(whichCmd, {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
+    const result = decodeCommandOutput(
+      execSync(whichCmd, { encoding: "buffer", stdio: "pipe" }),
+    ).trim();
     if (result) {
       cachedPath = pickExecutableLine(result);
       return cachedPath;

--- a/packages/desktop/tests/binaryResolver.test.ts
+++ b/packages/desktop/tests/binaryResolver.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import path from "path";
+
+// ── Mocks ──────────────────────────────────────────────────────
+
+const mockExecSync = vi.hoisted(() => vi.fn());
+const mockExistsSync = vi.hoisted(() => vi.fn());
+const mockExecFile = vi.hoisted(() => vi.fn());
+const mockExecFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock("child_process", () => ({
+  default: {
+    execSync: mockExecSync,
+    execFile: mockExecFile,
+    execFileSync: mockExecFileSync,
+  },
+  execSync: mockExecSync,
+  execFile: mockExecFile,
+  execFileSync: mockExecFileSync,
+}));
+
+vi.mock("fs", () => ({
+  default: { existsSync: mockExistsSync },
+  existsSync: mockExistsSync,
+}));
+
+// ── Import after mocks ─────────────────────────────────────────
+
+import {
+  resolveWaveBinary,
+  _resetCacheForTesting,
+} from "../src/main/stdio/binaryResolver";
+
+describe("binaryResolver", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExistsSync.mockReturnValue(false);
+    // checkNodeVersion(): `where node`/`which node` first, then
+    // execFileSync(<node>, ["-v"]) — the desktop main process runs inside
+    // Electron, so that call also carries ELECTRON_RUN_AS_NODE=1.
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.includes("where node") || cmd.includes("which node")) {
+        return process.platform === "win32"
+          ? "C:\\nodejs\\node.exe\n"
+          : "/usr/bin/node\n";
+      }
+      throw new Error(`unexpected: ${cmd}`);
+    });
+    mockExecFileSync.mockReturnValue("v20.0.0\n");
+    _resetCacheForTesting();
+  });
+
+  afterEach(() => {
+    _resetCacheForTesting();
+  });
+
+  // ── Windows: cmd.exe builtins output GBK on Chinese systems ──
+  // `where` is a cmd.exe builtin — on a Chinese system its stdout is in the
+  // OEM code page (CP936/GBK), NOT UTF-8. Decoding those bytes as UTF-8
+  // corrupts non-ASCII path segments (`C:\Users\刘一奇\...` → U+FFFD
+  // garbage); spawning the corrupted wave.cmd path then fails with
+  // ERROR_PATH_NOT_FOUND and the stdio process dies before initialize —
+  // surfacing as「初始化失败：连接已断开」on Windows (desktop parity with
+  // the vsce fix 08f2c0dc, which only patched packages/vscode).
+
+  it("on Windows, decodes GBK-encoded Chinese username paths from where output", async () => {
+    // GBK (CP936) bytes of `刘一奇` — what cmd.exe actually writes when
+    // the username contains Chinese characters.
+    const gbkUsername = Buffer.from([0xc1, 0xf5, 0xd2, 0xbb, 0xc6, 0xe6]);
+    const gbkLine = (suffix: string) =>
+      Buffer.concat([
+        Buffer.from("C:\\Users\\", "ascii"),
+        gbkUsername,
+        Buffer.from(suffix, "ascii"),
+      ]);
+    const whereOutput = Buffer.concat([
+      gbkLine("\\AppData\\Roaming\\npm\\wave\r\n"),
+      gbkLine("\\AppData\\Roaming\\npm\\wave.cmd\r\n"),
+    ]);
+
+    await withPlatform("win32", async () => {
+      mockExecSync.mockImplementation(
+        (cmd: string, opts?: { encoding?: string }) => {
+          if (cmd.includes("where wave")) {
+            // Mirror Node's real behaviour: `encoding: "buffer"` yields the
+            // raw cmd.exe bytes, "utf-8" yields them already corrupted.
+            return opts?.encoding === "buffer"
+              ? whereOutput
+              : whereOutput.toString("utf-8");
+          }
+          if (cmd.includes("where node")) return "C:\\nodejs\\node.exe\n";
+          throw new Error(`unexpected: ${cmd}`);
+        },
+      );
+
+      const result = await resolveWaveBinary();
+      expect(result).toBe(
+        "C:\\Users\\刘一奇\\AppData\\Roaming\\npm\\wave.cmd",
+      );
+    });
+  });
+
+  it("on Windows, decodes GBK-encoded Chinese npm global prefix", async () => {
+    // `npm prefix -g` on a Chinese system echoes the prefix in GBK — a
+    // UTF-8 decode turns `C:\Users\刘一奇\AppData\Roaming\npm` into garbage
+    // and the wave.cmd lookup inside it misses even after a fresh install.
+    const gbkUsername = Buffer.from([0xc1, 0xf5, 0xd2, 0xbb, 0xc6, 0xe6]);
+    const prefix = Buffer.concat([
+      Buffer.from("C:\\Users\\", "ascii"),
+      gbkUsername,
+      Buffer.from("\\AppData\\Roaming\\npm", "ascii"),
+    ]);
+    // Mirror the resolver's own join so the assertion matches on every OS
+    // (path.join follows the host platform, not the faked process.platform).
+    const waveCmd = path.join(
+      "C:\\Users\\刘一奇\\AppData\\Roaming\\npm",
+      "wave.cmd",
+    );
+
+    await withPlatform("win32", async () => {
+      mockExecSync.mockImplementation(
+        (cmd: string, opts?: { encoding?: string }) => {
+          if (cmd.includes("where wave")) throw new Error("not found");
+          if (cmd.includes("where npm")) return "C:\\nodejs\\npm.cmd\n";
+          if (cmd.includes("prefix -g")) {
+            return opts?.encoding === "buffer"
+              ? prefix
+              : prefix.toString("utf-8");
+          }
+          throw new Error(`unexpected: ${cmd}`);
+        },
+      );
+      mockExistsSync.mockImplementation((p: string) => p === waveCmd);
+
+      const result = await resolveWaveBinary();
+      expect(result).toBe(waveCmd);
+    });
+  });
+
+  // ── Found on PATH ──────────────────────────────────────────
+
+  it("returns wave path from where/which command", async () => {
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.includes("where wave") || cmd.includes("which wave")) {
+        return process.platform === "win32"
+          ? "C:\\nodejs\\wave.cmd\n"
+          : "/usr/bin/wave\n";
+      }
+      throw new Error("unexpected");
+    });
+
+    const result = await resolveWaveBinary();
+    expect(result).toBe(
+      process.platform === "win32" ? "C:\\nodejs\\wave.cmd" : "/usr/bin/wave",
+    );
+  });
+});
+
+/** Temporarily fake process.platform (desktop tests run on any OS). */
+function withPlatform<T>(platform: string, fn: () => Promise<T>): Promise<T> {
+  const original = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value: platform });
+  const restore = () => {
+    if (original) Object.defineProperty(process, "platform", original);
+  };
+  try {
+    return fn().finally(restore);
+  } catch (e) {
+    restore();
+    throw e;
+  }
+}

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
@@ -2,6 +2,7 @@ package com.wave.jetbrains.stdio
 
 import com.intellij.openapi.diagnostic.logger
 import java.io.File
+import java.nio.charset.Charset
 
 /** Minimum Node.js major version required by `wave --stdio`. */
 private const val MIN_NODE_MAJOR = 20
@@ -381,13 +382,41 @@ object BinaryResolver {
         return 0
     }
 
+    /**
+     * Decode output of cmd.exe builtins (`where`, `which`, `npm prefix -g`). On
+     * Chinese Windows those write the system OEM code page (CP936/GBK); decoding
+     * GBK bytes as UTF-8 corrupts non-ASCII path segments (`C:\Users\刘一奇\...`
+     * → U+FFFD), and spawning the corrupted path fails with ERROR_PATH_NOT_FOUND.
+     * Try UTF-8 first (covers non-Windows and chcp 65001), fall back to GBK on
+     * U+FFFD — same policy as packages/vscode and packages/desktop binaryResolver.
+     */
+    internal fun decodeCommandOutput(bytes: ByteArray): String {
+        val utf8 = String(bytes, Charsets.UTF_8)
+        if ('\uFFFD' !in utf8) return utf8
+        return try {
+            String(bytes, Charset.forName("GBK"))
+        } catch (_: Exception) {
+            utf8
+        }
+    }
+
+    /**
+     * Reads a child process' combined stdout/stderr as text via
+     * [decodeCommandOutput]. Explicitly decodes the raw bytes (not the JVM
+     * default charset) so `where`/`npm prefix -g` output survives on
+     * non-UTF-8 Windows systems.
+     */
+    internal fun readProcessOutput(proc: Process): String {
+        return proc.inputStream.use { decodeCommandOutput(it.readBytes()) }
+    }
+
     /** Runs a command without injecting [resolveEnv] — used by the login-shell
      *  PATH probe to avoid infinite recursion. Inherits the parent env as-is. */
     private fun runCommandRaw(vararg cmd: String): String {
         val proc = ProcessBuilder(cmd.toList()).apply {
             redirectErrorStream(true)
         }.start()
-        val out = proc.inputStream.bufferedReader().readText()
+        val out = readProcessOutput(proc)
         val code = proc.waitFor()
         if (code != 0) {
             throw StdioClientException("Command failed (${cmd.joinToString(" ")}): $out")
@@ -400,7 +429,7 @@ object BinaryResolver {
             redirectErrorStream(true)
             environment().putAll(resolveEnv())
         }.start()
-        val out = proc.inputStream.bufferedReader().readText()
+        val out = readProcessOutput(proc)
         val code = proc.waitFor()
         if (code != 0) {
             throw StdioClientException("Command failed (${cmd.joinToString(" ")}): $out")

--- a/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/stdio/BinaryResolverTest.kt
+++ b/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/stdio/BinaryResolverTest.kt
@@ -142,6 +142,55 @@ class BinaryResolverTest {
         assertNull(BinaryResolver.getCliVersion(missing))
     }
 
+    // ---- decodeCommandOutput / readProcessOutput -----------------------
+    //
+    // Customer repro: on Chinese Windows, cmd.exe builtins (`where`) and
+    // `npm prefix -g` write the system OEM code page (CP936/GBK) bytes, NOT
+    // UTF-8. Decoding those bytes with the JVM default charset (UTF-8 on
+    // JBR 21 / JEP 400) corrupts non-ASCII path segments (`C:\Users\刘一奇\...`
+    // → U+FFFD), and spawning the corrupted path fails with
+    // ERROR_PATH_NOT_FOUND — the stdio process dies before initialize. The
+    // decoder must try UTF-8 first and fall back to GBK on U+FFFD (same
+    // policy as packages/vscode and packages/desktop binaryResolver).
+
+    @Test
+    fun `decodeCommandOutput decodes GBK bytes to a Chinese path`() {
+        val bytes =
+            "C:\\Users\\".toByteArray(Charsets.US_ASCII) +
+            byteArrayOf(
+                0xC1.toByte(), 0xF5.toByte(), 0xD2.toByte(), 0xBB.toByte(),
+                0xC6.toByte(), 0xE6.toByte()
+            ) +
+            "\\npm\\wave.cmd".toByteArray(Charsets.US_ASCII)
+        assertEquals("C:\\Users\\刘一奇\\npm\\wave.cmd", BinaryResolver.decodeCommandOutput(bytes))
+    }
+
+    @Test
+    fun `decodeCommandOutput passes valid UTF-8 through unchanged`() {
+        val bytes = "C:\\Users\\刘一奇\\npm\\wave.cmd".toByteArray(Charsets.UTF_8)
+        assertEquals("C:\\Users\\刘一奇\\npm\\wave.cmd", BinaryResolver.decodeCommandOutput(bytes))
+    }
+
+    @Test
+    fun `readProcessOutput decodes GBK bytes from a real subprocess`() {
+        org.junit.jupiter.api.Assumptions.assumeFalse(
+            System.getProperty("os.name").lowercase().startsWith("win"),
+            "POSIX shell shim not available on Windows CI"
+        )
+        // printf emits the raw GBK bytes for 刘一奇 (\301\365\322\273\306\346)
+        // inside an otherwise-ASCII Windows path line, exactly like `where wave`
+        // on a Chinese Windows box.
+        val script = File(tempDir.toFile(), "gbk-shim-${shimCounter++}.sh").apply {
+            writeText("#!/bin/sh\nprintf 'C:\\\\Users\\\\\\301\\365\\322\\273\\306\\346\\\\npm\\\\wave.cmd'")
+            setExecutable(true)
+        }
+        val proc = ProcessBuilder(script.absolutePath).start()
+        assertEquals(
+            "C:\\Users\\刘一奇\\npm\\wave.cmd",
+            BinaryResolver.readProcessOutput(proc)
+        )
+    }
+
     // ---- pickExecutableLine --------------------------------------------
     //
     // Customer repro: a default Node.js install on Windows lives at


### PR DESCRIPTION
## Problem

Chinese-Windows users report 初始化失败：连接已断开 after install: selecting a directory kills the stdio process before initialize.

Root cause: 08f2c0dc fixed the GBK (CP936/OEM code page) output decoding bug only in the VS Code binary resolver. Desktop and JetBrains still decode where wave / where npm / where node / npm prefix -g output with the wrong charset (UTF-8). On a Chinese Windows username (C:\Users\刘一奇\...), GBK bytes decoded as UTF-8 yield U+FFFD replacement chars, the corrupted path fails with ERROR_PATH_NOT_FOUND, and wave --stdio dies before initialize.

JetBrains was additionally at risk because its resolver used the JVM default charset (UTF-8 on JBR 21 / JEP 400) with no explicit decoding.

## Fix

Apply the same UTF-8-first, GBK-fallback policy (decodeCommandOutput) already used by VS Code to the two remaining resolver copies:

- packages/desktop/src/main/stdio/binaryResolver.ts: all 4 execSync call sites now use encoding: buffer + decodeCommandOutput
- packages/jetbrains .../stdio/BinaryResolver.kt: new decodeCommandOutput + readProcessOutput, runCommand/runCommandRaw switched to raw-byte reads

## Tests (TDD: failing tests first)

- desktop tests/binaryResolver.test.ts: 3 tests, GBK bytes 0xC1F5D2BBC6E6 = 刘一奇, mocked to Node real encoding behavior
- jetbrains BinaryResolverTest.kt: 3 tests incl. a real-subprocess shim emitting raw GBK bytes

Verified: desktop 490/490, jetbrains 24/24, type-check + lint green.