### PR TITLE
fix(desktop): 修复更新检查误报「已是最新版本」

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -71,7 +71,10 @@ import type { ChildProcess } from "child_process";
 import { getWorkspaceDiff } from "./gitDiff";
 import { TerminalManager } from "./terminal";
 import { PortForwardManager, type AuthCallbackForward } from "./portForward";
-import { checkForUpdate } from "./updateChecker";
+import {
+  checkForUpdate,
+  type UpdateInfo as ManualUpdateInfo,
+} from "./updateChecker";
 import { AutoUpdaterService } from "./updateAutoUpdater";
 import { HOST_CHANNEL } from "./channels";
 import type { PanelKind } from "./menu";
@@ -4102,7 +4105,18 @@ export class DesktopHost {
       );
     }
 
-    const info = await checkForUpdate(app.getVersion(), serverUrl);
+    // checkForUpdate throws when the check itself failed — don't present that
+    // as "already up to date".
+    let info: ManualUpdateInfo | null = null;
+    try {
+      info = await checkForUpdate(app.getVersion(), serverUrl);
+    } catch (error) {
+      console.warn("[DesktopHost] Update check failed:", error);
+      if (manual) {
+        this.showToast({ message: "检查更新失败，请稍后重试" });
+      }
+      return;
+    }
     if (info) {
       this.showToast({
         message: `发现新版本 v${info.latestVersion}（当前 v${info.currentVersion}）`,
@@ -4120,7 +4134,13 @@ export class DesktopHost {
     console.warn(
       "[DesktopHost] Auto updater errored, falling back to manual check",
     );
-    const info = await checkForUpdate(app.getVersion(), serverUrl);
+    let info: ManualUpdateInfo | null = null;
+    try {
+      info = await checkForUpdate(app.getVersion(), serverUrl);
+    } catch (error) {
+      console.warn("[DesktopHost] Update check failed:", error);
+      return;
+    }
     if (info) {
       this.showToast({
         message: `发现新版本 v${info.latestVersion}（当前 v${info.currentVersion}）`,

--- a/packages/desktop/src/main/updateChecker.ts
+++ b/packages/desktop/src/main/updateChecker.ts
@@ -14,13 +14,12 @@ export interface UpdateInfo {
   latestVersion: string;
   currentVersion: string;
   downloadUrl: string;
-  releaseNotes?: string;
 }
 
 function httpGet(
   url: string,
   timeout = 10000,
-): Promise<{ statusCode: number; body: string }> {
+): Promise<{ statusCode: number; body: string; headers: NodeJS.Dict<string | string[]> }> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       reject(new Error("Request timed out"));
@@ -38,7 +37,7 @@ function httpGet(
         res.on("data", (chunk) => (body += chunk));
         res.on("end", () => {
           clearTimeout(timer);
-          resolve({ statusCode: res.statusCode || 0, body });
+          resolve({ statusCode: res.statusCode || 0, body, headers: res.headers });
         });
       },
     ).on("error", (err) => {
@@ -48,45 +47,47 @@ function httpGet(
   });
 }
 
+/**
+ * Check the latest release via the HTML endpoint instead of the REST API:
+ * `https://github.com/<owner>/<repo>/releases/latest` 302-redirects to the
+ * newest non-prerelease tag (same semantics as the API) but is NOT subject to
+ * the unauthenticated API rate limit (60 req/h per IP) that made the old check
+ * fail with 403 from shared/CGNAT addresses — which was reported as "no
+ * update". Throws when the redirect can't be resolved so callers can
+ * distinguish "check failed" from "already up to date".
+ */
 async function checkViaGitHub(
   currentVersion: string,
   current: ParsedVersion,
 ): Promise<UpdateInfo | null> {
-  const { statusCode, body } = await httpGet(
-    "https://api.github.com/repos/netease-lcap/wave-agent/releases/latest",
+  const { statusCode, headers } = await httpGet(
+    "https://github.com/netease-lcap/wave-agent/releases/latest",
   );
-
-  if (statusCode !== 200) {
-    console.warn(
-      "[UpdateChecker] GitHub API returned non-OK status:",
-      statusCode,
+  const location =
+    typeof headers.location === "string" ? headers.location : "";
+  if (statusCode < 300 || statusCode >= 400 || !location) {
+    throw new Error(
+      `GitHub releases redirect failed with status ${statusCode}`,
     );
-    return null;
   }
 
-  const data = JSON.parse(body) as {
-    tag_name: string;
-    html_url: string;
-    body?: string;
-  };
-
-  const latestTag = data.tag_name.replace(/^v/, "");
+  // location: https://github.com/netease-lcap/wave-agent/releases/tag/v1.0.8
+  const latestTag = location.slice(location.lastIndexOf("/") + 1);
   const latest = parseVersion(latestTag);
 
   if (!latest) {
     console.warn(
       "[UpdateChecker] Invalid latest version from GitHub:",
-      data.tag_name,
+      latestTag,
     );
     return null;
   }
 
   if (compareVersions(latest, current) > 0) {
     return {
-      latestVersion: latestTag,
+      latestVersion: latestTag.replace(/^v/, ""),
       currentVersion,
-      downloadUrl: data.html_url,
-      releaseNotes: data.body,
+      downloadUrl: location,
     };
   }
 
@@ -151,11 +152,14 @@ async function checkViaCodeChat(
     latestVersion: data.version,
     currentVersion,
     downloadUrl: typeof data.path === "string" ? data.path : feedUrl,
-    releaseNotes: undefined,
   };
 }
 
-/** Returns UpdateInfo when a newer desktop version exists, null otherwise. */
+/**
+ * Returns UpdateInfo when a newer desktop version exists, null when the check
+ * succeeded and the app is up to date. Throws when the check failed (network
+ * error, non-OK status) so callers don't mistake a failure for "no update".
+ */
 export async function checkForUpdate(
   currentVersion: string,
   serverUrl?: string,
@@ -166,20 +170,15 @@ export async function checkForUpdate(
     return null;
   }
 
-  try {
-    if (serverUrl) {
-      try {
-        return await checkViaCodeChat(currentVersion, current, serverUrl);
-      } catch (error) {
-        console.warn(
-          "[UpdateChecker] CodeChat download feed check failed, falling back to GitHub:",
-          error,
-        );
-      }
+  if (serverUrl) {
+    try {
+      return await checkViaCodeChat(currentVersion, current, serverUrl);
+    } catch (error) {
+      console.warn(
+        "[UpdateChecker] CodeChat download feed check failed, falling back to GitHub:",
+        error,
+      );
     }
-    return await checkViaGitHub(currentVersion, current);
-  } catch (error) {
-    console.warn("[UpdateChecker] Failed to check for updates:", error);
-    return null;
   }
+  return await checkViaGitHub(currentVersion, current);
 }

--- a/packages/desktop/tests/updateAutoUpdater.test.ts
+++ b/packages/desktop/tests/updateAutoUpdater.test.ts
@@ -44,6 +44,10 @@ describe("feedUrlFor", () => {
   });
 
   it("uses the mac channel on darwin", () => {
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      configurable: true,
+    });
     expect(feedUrlFor("https://codechat.example.com")).toBe(
       "https://codechat.example.com/api/downloads/desktop/mac/",
     );
@@ -60,6 +64,10 @@ describe("feedUrlFor", () => {
   });
 
   it("strips trailing slashes from the serverUrl", () => {
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      configurable: true,
+    });
     expect(feedUrlFor("https://codechat.example.com///")).toBe(
       "https://codechat.example.com/api/downloads/desktop/mac/",
     );
@@ -85,11 +93,12 @@ describe("AutoUpdaterService.checkForUpdates", () => {
     expect(outcome).toBe("update");
     expect(h.setFeedURL).toHaveBeenCalledWith({
       provider: "generic",
-      url: "https://codechat.example.com/api/downloads/desktop/mac/",
+      url: `https://codechat.example.com/api/downloads/desktop/${
+        process.platform === "win32" ? "win" : "mac"
+      }/`,
     });
     expect(h.checkForUpdates).toHaveBeenCalledTimes(1);
   });
-
   it('returns "no-update" when the feed version equals the running version', async () => {
     // electron mock app.getVersion() is 0.19.7
     vi.mocked(h.checkForUpdates).mockResolvedValue({

--- a/packages/desktop/tests/updateChecker.test.ts
+++ b/packages/desktop/tests/updateChecker.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { EventEmitter } from "events";
 
-type Handler = (url: string) => { statusCode: number; body: string } | Error;
+type Handler = (
+  url: string,
+) =>
+  | { statusCode: number; body: string; headers?: Record<string, string> }
+  | Error;
 
 const h = vi.hoisted(() => ({
   handler: null as Handler | null,
@@ -18,8 +22,12 @@ function makeRequest(module: "http" | "https") {
         queueMicrotask(() => req.emit("error", result));
         return req;
       }
-      const res = new EventEmitter() as EventEmitter & { statusCode: number };
+      const res = new EventEmitter() as EventEmitter & {
+        statusCode: number;
+        headers: Record<string, string>;
+      };
       res.statusCode = result.statusCode;
+      res.headers = result.headers ?? {};
       queueMicrotask(() => {
         callback(res);
         res.emit("data", result.body);
@@ -36,7 +44,16 @@ vi.mock("http", () => ({ get: makeRequest("http") }));
 import { checkForUpdate } from "../src/main/updateChecker";
 
 const GITHUB_LATEST =
-  "https://api.github.com/repos/netease-lcap/wave-agent/releases/latest";
+  "https://github.com/netease-lcap/wave-agent/releases/latest";
+
+/** A 302 redirect to the given release tag, as GitHub serves for /releases/latest. */
+function githubRedirect(tag: string) {
+  return {
+    statusCode: 302,
+    body: "",
+    headers: { location: `https://github.com/netease-lcap/wave-agent/releases/tag/${tag}` },
+  };
+}
 
 beforeEach(() => {
   h.handler = null;
@@ -45,48 +62,36 @@ beforeEach(() => {
 
 describe("checkForUpdate via GitHub", () => {
   it("returns UpdateInfo when the latest release is newer", async () => {
-    h.handler = () => ({
-      statusCode: 200,
-      body: JSON.stringify({
-        tag_name: "v0.20.0",
-        html_url: "https://github.com/release/v0.20.0",
-        body: "notes",
-      }),
-    });
+    h.handler = () => githubRedirect("v1.0.8");
 
-    const info = await checkForUpdate("0.19.7");
+    const info = await checkForUpdate("1.0.7");
     expect(info).toEqual({
-      latestVersion: "0.20.0",
-      currentVersion: "0.19.7",
-      downloadUrl: "https://github.com/release/v0.20.0",
-      releaseNotes: "notes",
+      latestVersion: "1.0.8",
+      currentVersion: "1.0.7",
+      downloadUrl:
+        "https://github.com/netease-lcap/wave-agent/releases/tag/v1.0.8",
     });
   });
 
   it("returns null when already up to date", async () => {
-    h.handler = () => ({
-      statusCode: 200,
-      body: JSON.stringify({ tag_name: "v0.19.7", html_url: "x" }),
-    });
-    expect(await checkForUpdate("0.19.7")).toBeNull();
+    h.handler = () => githubRedirect("v1.0.7");
+    expect(await checkForUpdate("1.0.7")).toBeNull();
   });
 
   it("returns null when the latest release is older", async () => {
-    h.handler = () => ({
-      statusCode: 200,
-      body: JSON.stringify({ tag_name: "v0.19.0", html_url: "x" }),
-    });
-    expect(await checkForUpdate("0.19.7")).toBeNull();
+    h.handler = () => githubRedirect("v1.0.6");
+    expect(await checkForUpdate("1.0.7")).toBeNull();
   });
 
-  it("returns null on non-200 status", async () => {
-    h.handler = () => ({ statusCode: 404, body: "{}" });
-    expect(await checkForUpdate("0.19.7")).toBeNull();
+  it("throws when the redirect cannot be resolved", async () => {
+    // e.g. a non-3xx status (the old API endpoint would 403 rate-limit)
+    h.handler = () => ({ statusCode: 403, body: "{}" });
+    await expect(checkForUpdate("1.0.7")).rejects.toThrow();
   });
 
-  it("returns null on network error", async () => {
+  it("throws on network error", async () => {
     h.handler = () => new Error("ECONNREFUSED");
-    expect(await checkForUpdate("0.19.7")).toBeNull();
+    await expect(checkForUpdate("1.0.7")).rejects.toThrow();
   });
 
   it("returns null for an invalid current version", async () => {
@@ -97,8 +102,11 @@ describe("checkForUpdate via GitHub", () => {
 
 describe("checkForUpdate via CodeChat download feed", () => {
   const SERVER = "https://codechat.example.com";
-  // The test host is macOS, so the feed is the electron-builder mac metadata.
-  const FEED_URL = `${SERVER}/api/downloads/desktop/mac/latest-mac.yml`;
+  // Mirror checkViaCodeChat: the feed file depends on the host platform.
+  const platform = process.platform === "win32" ? "win" : "mac";
+  const fileName =
+    process.platform === "win32" ? "latest.yml" : "latest-mac.yml";
+  const FEED_URL = `${SERVER}/api/downloads/desktop/${platform}/${fileName}`;
 
   it("returns UpdateInfo parsed from the YAML feed when newer", async () => {
     h.handler = (url) => {
@@ -139,10 +147,7 @@ describe("checkForUpdate via CodeChat download feed", () => {
         return { statusCode: 500, body: "" };
       }
       if (url === GITHUB_LATEST) {
-        return {
-          statusCode: 200,
-          body: JSON.stringify({ tag_name: "v0.20.0", html_url: "gh" }),
-        };
+        return githubRedirect("v0.20.0");
       }
       return new Error(`unexpected url: ${url}`);
     };


### PR DESCRIPTION
## 问题

桌面端 v1.0.7 手动检查更新时误报「当前已是最新版本」，即使 v1.0.8 已发布数分钟。

## 根因

未登录路径使用未认证的 GitHub REST API（`api.github.com/.../releases/latest`）检查更新，限制为**每 IP 每小时 60 次**。共享/CGNAT 出口 IP（如国内网络）极易触发 403。旧的实现把检查失败静默当作「无更新」，于是误报最新版本。

## 修复

- `checkViaGitHub` 改为请求 HTML 端点 `github.com/netease-lcap/wave-agent/releases/latest`（302 重定向到最新 tag），与官方 electron-updater GitHub provider 相同的非 API 方案，无速率限制。
- `checkForUpdate` 检查失败时改为**抛错**而不是返回 null；`desktopHost` 收到异常时展示「检查更新失败，请稍后重试」，不再误报「已是最新版本」。
- 测试同步更新（302 重定向 mock、失败抛错断言、平台相关的 CodeChat feed URL）。

## 测试

- `pnpm -F wave-desktop test` 通过。
- 全仓 type-check / lint 通过（pre-commit 钩子）。