### PR TITLE
fix(code): make temp image path assertions platform-agnostic + windows CI after merge

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,14 +1,23 @@
 name: CI (Windows)
 
 # Non-blocking Windows compatibility check.
-# Manually triggered only (workflow_dispatch) — does NOT run on every PR to
-# avoid burning Windows runner minutes on routine changes. Run it manually
-# from the Actions tab when a change touches platform-specific code paths
-# (subprocess spawning, fs, .cmd/.exe resolution).
+# Runs after PRs merge to main (push), like the docs deploy workflow — it does
+# NOT gate PRs, so Windows runner minutes are only spent on merged changes that
+# touch platform-specific code paths (subprocess spawning, fs, .cmd/.exe
+# resolution). workflow_dispatch remains for manual runs from the Actions tab.
 # NOT a required check: configure in repo Settings → Branches → main
 # protection rule to keep only the Linux `check` job as required.
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/agent-sdk/**'
+      - 'packages/code/**'
+      - 'packages/vscode/**'
+      - 'pnpm-lock.yaml'
+      - 'package.json'
+      - '.github/workflows/ci-windows.yml'
   workflow_dispatch:
 
 concurrency:

--- a/packages/code/tests/stdio/agentBridge.test.ts
+++ b/packages/code/tests/stdio/agentBridge.test.ts
@@ -770,7 +770,12 @@ test("sendMessage persists dataURL images to temp files so the model gets a real
     | Array<{ path: string; mimeType: string }>
     | undefined;
   expect(forwarded).toHaveLength(1);
-  expect(forwarded![0].path).toMatch(/^\/tmp\/wave-image-.*\.png$/);
+  // tmpdir is mocked to "/tmp"; path.join renders platform-native separators,
+  // so assert via path helpers instead of a hardcoded POSIX regex.
+  expect(path.dirname(forwarded![0].path)).toBe(
+    path.dirname(path.join(tmpdir(), "x")),
+  );
+  expect(path.basename(forwarded![0].path)).toMatch(/^wave-image-.*\.png$/);
   expect(forwarded![0].mimeType).toBe("image/png");
   // "aGVsbG8=" base64-decodes to "hello"
   expect(writeFileSync).toHaveBeenCalledWith(
@@ -810,7 +815,12 @@ test("updateQueuedMessage persists dataURL images to temp files", async () => {
   const forwarded = updateQueuedMessageById.mock.calls[0][1];
   expect(forwarded.content).toBe("updated");
   expect(forwarded.images).toHaveLength(1);
-  expect(forwarded.images![0].path).toMatch(/^\/tmp\/wave-image-.*\.jpg$/);
+  expect(path.dirname(forwarded.images![0].path)).toBe(
+    path.dirname(path.join(tmpdir(), "x")),
+  );
+  expect(path.basename(forwarded.images![0].path)).toMatch(
+    /^wave-image-.*\.jpg$/,
+  );
   expect(forwarded.images![0].mimeType).toBe("image/jpeg");
   expect(writeFileSync).toHaveBeenCalledWith(
     forwarded.images![0].path,


### PR DESCRIPTION
## Changes

- **fix(code)**: agentBridge.test.ts 两处硬编码 POSIX 正则 `/^\/tmp\/wave-image-.*\.(png|jpg)$/` 在 Windows 上失败（`path.join` 产出反斜杠路径 `\tmp\...`），改为平台无关的 `path.dirname` + `path.basename` 断言，修复 Windows CI Tests 步骤
- **ci(windows)**: Windows CI 触发方式从纯手动（workflow_dispatch）改为 PR merge 后（push 到 main）自动运行，带 paths 过滤（agent-sdk/code/vscode + pnpm-lock.yaml + package.json + workflow 自身），保留 workflow_dispatch 手动兜底，行为同 docs deploy

## 验证

- 本地 code 包 134 测试通过
- 用 path.win32 模拟验证断言在 Windows 语义下成立
- 分支上 Windows CI 全绿（run 31660988705）