### PR TITLE
fix(code): snapshot SDK messages when pushing into CLI state

### DIFF
--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -169,6 +169,22 @@ interface StreamingUpdateParams {
 }
 
 /**
+ * Snapshot a SDK message for consumer state. The SDK mutates its internal
+ * message blocks in-place BEFORE firing the delta callback (it writes the full
+ * accumulated value to the shared block, then computes the chunk delta by
+ * slicing the new value). A consumer that pushed the SDK message object by
+ * live reference would read the already-updated block and append the delta
+ * again — the first delta is double-counted ("LetLet me think..."), affecting
+ * reasoning and text content alike. See docs/specs/core/stream-content-updates.md.
+ * The clone must be at least one layer deep (message + blocks) so the in-place
+ * block mutation never leaks into consumer state.
+ */
+const snapshotMessage = (message: Message): Message => ({
+  ...message,
+  blocks: message.blocks.map((block) => ({ ...block })),
+});
+
+/**
  * Window-concat throttle for pure-delta streaming updates: chunks arriving
  * within the cooldown window are merged so no delta is lost (a dropped delta
  * would permanently lose content, unlike the accumulated-payload throttle it
@@ -605,7 +621,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   // the incremental callbacks in initializeAgent below.
   const refreshMessages = useCallback(() => {
     if (!isExpandedRef.current && agentRef.current) {
-      const msgs = [...agentRef.current.messages];
+      const msgs = agentRef.current.messages.map(snapshotMessage);
       setMessages(msgs);
       setLatestTotalTokens(extractLatestTotalTokens(msgs));
     }
@@ -656,7 +672,9 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
           const last = msgs[msgs.length - 1];
           if (!last || last.role !== "user") return;
           setMessages((prev) =>
-            prev.some((m) => m.id === last.id) ? prev : [...prev, last],
+            prev.some((m) => m.id === last.id)
+              ? prev
+              : [...prev, snapshotMessage(last)],
           );
         },
         onAssistantMessageAdded: (messageId: string) => {
@@ -664,7 +682,9 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
           const msg = agentRef.current.messages.find((m) => m.id === messageId);
           if (!msg) return;
           setMessages((prev) =>
-            prev.some((m) => m.id === messageId) ? prev : [...prev, msg],
+            prev.some((m) => m.id === messageId)
+              ? prev
+              : [...prev, snapshotMessage(msg)],
           );
         },
         onAssistantContentUpdated: (params) => {
@@ -889,9 +909,10 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
           agent.setWorktreeSession(session);
         }
 
-        // Get initial state
+        // Get initial state — snapshot the SDK messages (never hold live
+        // references; see snapshotMessage)
         setSessionId(agent.sessionId);
-        setMessages(agent.messages);
+        setMessages(agent.messages.map(snapshotMessage));
         setIsLoading(agent.isLoading);
         setLatestTotalTokens(extractLatestTotalTokens(agent.messages));
         setIsCommandRunning(agent.isCommandRunning);

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -1722,6 +1722,125 @@ describe("ChatProvider", () => {
     expect(lastValue?.messages[0].blocks).toHaveLength(2);
   });
 
+  it("does not double-count the first content chunk when the SDK mutates the shared message in place", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
+    const callbacks = agentCreateArgs.callbacks!;
+
+    const assistantMsg = {
+      id: "msg-dup-text",
+      role: "assistant" as const,
+      blocks: [],
+      timestamp: new Date().toISOString(),
+    };
+    Object.assign(mockAgent, { messages: [assistantMsg] });
+    callbacks.onAssistantMessageAdded!("msg-dup-text");
+    await vi.waitFor(() => {
+      expect(lastValue?.messages).toHaveLength(1);
+    });
+
+    // Regression (docs/specs/core/stream-content-updates.md, 2026-08-12): the
+    // SDK writes the full accumulated value onto the SAME message block
+    // (in-place) BEFORE firing the chunk-delta callback. A consumer that
+    // pushed the SDK message object by live reference would read the already
+    // updated block and append the delta again — the first chunk ("Hello")
+    // appears twice. The consumer must snapshot the message at push time.
+    //
+    // Note: we must wait for the message object to be REPLACED (the delta
+    // reducer commits) before asserting content — a pre-commit render of a
+    // live-ref message already shows "Hello" via the in-place mutation, which
+    // would satisfy the content assertion without exercising the reducer.
+    const sdkMsg = mockAgent.messages[0] as unknown as {
+      blocks: Array<{ type: string; content: string; stage: string }>;
+    };
+    sdkMsg.blocks.push({ type: "text", content: "Hello", stage: "streaming" });
+    callbacks.onAssistantContentUpdated!({
+      messageId: "msg-dup-text",
+      chunk: "Hello",
+      stage: "streaming",
+    });
+    await vi.waitFor(() => {
+      // Reducer commit replaces the pushed message with a fresh object
+      expect(lastValue?.messages[0]).not.toBe(sdkMsg);
+      // Single "Hello", never "HelloHello" (first delta double-counted)
+      expect(lastValue?.messages[0].blocks[0]).toEqual({
+        type: "text",
+        content: "Hello",
+        stage: "streaming",
+      });
+    });
+
+    // State must not share the SDK's message object (live reference)
+    expect(lastValue?.messages[0]).not.toBe(mockAgent.messages[0]);
+  });
+
+  it("does not double-count the first reasoning chunk when the SDK mutates the shared message in place", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
+    const callbacks = agentCreateArgs.callbacks!;
+
+    const assistantMsg = {
+      id: "msg-dup-reason",
+      role: "assistant" as const,
+      blocks: [],
+      timestamp: new Date().toISOString(),
+    };
+    Object.assign(mockAgent, { messages: [assistantMsg] });
+    callbacks.onAssistantMessageAdded!("msg-dup-reason");
+    await vi.waitFor(() => {
+      expect(lastValue?.messages).toHaveLength(1);
+    });
+
+    // Same SDK in-place mutation as the content case — reasoning blocks are
+    // updated on the shared message before the delta callback fires
+    // ("Let" + accumulated slice → `LetLet me think...` on the CLI pre-fix).
+    // The identity wait guards against the pre-commit render already showing
+    // "Let" via the in-place mutation (see content test above).
+    const sdkMsg = mockAgent.messages[0] as unknown as {
+      blocks: Array<{ type: string; content: string; stage: string }>;
+    };
+    sdkMsg.blocks.push({
+      type: "reasoning",
+      content: "Let",
+      stage: "streaming",
+    });
+    callbacks.onAssistantReasoningUpdated!({
+      messageId: "msg-dup-reason",
+      chunk: "Let",
+      stage: "streaming",
+    });
+    await vi.waitFor(() => {
+      expect(lastValue?.messages[0]).not.toBe(sdkMsg);
+      const reasoning = lastValue?.messages[0].blocks.find(
+        (b) => b.type === "reasoning",
+      ) as { content: string } | undefined;
+      expect(reasoning?.content).toBe("Let");
+    });
+
+    // State must not share the SDK's message object (live reference)
+    expect(lastValue?.messages[0]).not.toBe(mockAgent.messages[0]);
+  });
+
   it("handles bang message callbacks", async () => {
     let lastValue: ChatContextType | undefined;
     const onHookValue = (val: ChatContextType) => {


### PR DESCRIPTION
## 背景

CLI 上 reasoning/content 内容第一个单词重复渲染（如 `LetLet me think about this.`）的问题依然存在。根因在 2026-08-12 已定位并写入 spec（docs/specs/core/stream-content-updates.md）：CLI 把 SDK 消息对象**活引用**推入 React 状态，而 SDK 先就地把完整累积值写入共享块、再按 slice 计算并回调 chunk delta，导致首个 delta 被重复计数。该修复此前只停留在 spec，从未实现。

## 修复

- 新增 `snapshotMessage`（`{ ...m, blocks: m.blocks.map(b => ({ ...b })) }`，消息 + blocks 至少一层深拷贝），应用到全部 4 个推入点：
  - `onAssistantMessageAdded`
  - `onUserMessageAdded`
  - `refreshMessages`（compact/clear/rewind/collapse 全量拉取）
  - 初始 `setMessages(agent.messages)`
- 消费端状态不再持有 SDK 内部对象活引用；SDK 就地更新只影响其内部对象，消费端仅通过后续 delta 回调获得更新

## 验证（TDD，reproduce-first）

- 新增 2 个回归测试，模拟 SDK 真实行为（先就地 push 块、再触发 delta 回调）
- 修复前：测试失败，精确复现 bug（content `HelloHello`、reasoning `LetLet`）
- 修复后：测试通过；useChat 55/55；wave-code 全量 96 文件 / 1369 测试通过；type-check 干净
- 排查确认无其他进程内消费端持有活引用（agentBridge 走序列化天然快照；print-cli 直接写 stdout）