### PR TITLE
feat(agent-sdk): enableArtifact 热更新 + 服务端配置分发

### DIFF
--- a/docs/specs/core/artifact-tool.md
+++ b/docs/specs/core/artifact-tool.md
@@ -89,7 +89,7 @@ order: 35
 
 作为管理员或内测用户，我希望 Artifact 功能默认不可用、但可显式开启，以便在后端上线前不暴露无效工具，同时支持内测/灰度先行体验。
 
-**为什么是这个优先级**：当前 frame 后端尚未上线，功能需默认禁用（不注册工具、不拦截读取）；内测/灰度通过 `enableArtifact: true` 显式打开（无需改代码）；后端上线后把代码默认值常量翻转为启用（未设置 = 启用，对齐 CC `enableArtifact` 的"未设置跟随功能可用性"语义）。
+**为什么是这个优先级**：当前 frame 后端尚未上线，功能需默认禁用（不注册工具、不拦截读取）；内测/灰度通过 `enableArtifact: true` 显式打开（无需改代码）；后端上线后把代码默认值常量翻转为启用（未设置 = 启用，对齐 CC `enableArtifact` 的"未设置跟随功能可用性"语义）。开关支持热更新：运行中的会话修改 settings.json 后，配置重载会即时重评估工具注册（无需重启会话）。
 
 **验收场景**：
 
@@ -97,6 +97,10 @@ order: 35
 2. **假设** settings.json 配置 `enableArtifact: true`，**当** 会话初始化时，**则** `Artifact` 工具注册、可调用（内测/灰度入口）。
 3. **假设** 后端已上线、代码默认值常量已翻转为启用，**当** 会话初始化时，**则** 未配置 `enableArtifact` 也默认启用。
 4. **假设** Artifact 被禁用（默认或显式），**当** WebFetch 收到 artifact URL 时，**则** 不进入专用读取通道（按普通 URL 处理或报错），不执行 `via=model_read` 调用。
+5. **假设** 运行中的会话未配置 `enableArtifact`（工具未注册），**当** 用户在 settings.json 中改为 `enableArtifact: true` 触发配置热重载时，**则** `Artifact` 工具即时注册、可调用，无需重启会话。
+6. **假设** 运行中的会话已启用 `enableArtifact`，**当** 用户改为 `false` 触发配置热重载时，**则** `Artifact` 工具即时注销、不可调用，同时 WebFetch 的 artifact URL 拦截（逐调用检查 `isArtifactEnabled`）同步失效。
+7. **假设** 服务端 `GET /api/wave/settings` 下发了 `enableArtifact: true`（remote settings），**当** 会话初始化或轮询（60min + 304 checksum）检测到变更时，**则** remote 值优先于本地 settings.json 与代码默认值，`Artifact` 工具按 remote 值注册，WebFetch 拦截同样生效（管理员远程灰度/回滚入口）。
+8. **假设** 服务端下发的 remote `enableArtifact` 与本地 settings.json 冲突，**当** 合并配置时，**则** remote 胜出（last-write-wins，与 `model`、`permissions.permissionMode` 等 managed 字段语义一致）；未下发时回退本地/默认值。
 
 ### 非功能需求
 

--- a/packages/agent-sdk/builtin/skills/settings/ENV.md
+++ b/packages/agent-sdk/builtin/skills/settings/ENV.md
@@ -23,7 +23,7 @@ Wave uses several environment variables to control its core functionality. Varia
 | :--- | :--- | :--- |
 | `WAVE_API_KEY` | API key for the AI gateway. | - |
 | `WAVE_BASE_URL` | Base URL for the AI gateway. | - |
-| `WAVE_SERVER_URL` | Server URL for SSO authentication. **OS env only** — set via OS env or `options.serverUrl`; not read from settings.json `env` (avoids a startup 401 race). | `https://codechat.codewave.163.com` |
+| `WAVE_SERVER_URL` | Server URL for SSO authentication. Resolution order: `options.serverUrl` → `process.env.WAVE_SERVER_URL` → default. Unlike other `WAVE_*` vars, a settings.json `env` value is also mirrored to `process.env` so process-level singletons (AuthService) see it without a per-session snapshot. | `https://codechat.codewave.163.com` |
 | `WAVE_CUSTOM_HEADERS` | Custom HTTP headers for the AI gateway. Newline-separated `Key: Value` pairs (e.g., `"X-Foo: bar\nAuthorization: Bearer xxx"`). | - |
 | `WAVE_MODEL` | The primary AI model to use for the agent. | `gemini-3-flash` |
 | `WAVE_FAST_MODEL` | The fast AI model to use for quick tasks. | `gemini-2.5-flash` |

--- a/packages/agent-sdk/builtin/skills/settings/SKILL.md
+++ b/packages/agent-sdk/builtin/skills/settings/SKILL.md
@@ -104,6 +104,13 @@ For detailed guidance on creating plugins and marketplaces, see [PLUGINS.md](${W
 - `language`: Preferred language for agent communication (e.g., `"en"`, `"zh"`).
 - `autoMemoryEnabled`: Enable or disable auto-memory (default: `true`).
 - `autoMemoryFrequency`: Frequency of auto-memory extraction turns (default: `1`).
+- `enableArtifact`: Enable the Artifact tool, which publishes local `.html`/`.md` files as shareable (default-private) web pages. Defaults to `false` while the frame backend is not live; set to `true` to register the tool and enable WebFetch interception for artifact URLs. Toggling it hot-reloads the tool registry.
+
+```json
+{
+  "enableArtifact": true
+}
+```
 
 ## How to use this skill
 

--- a/packages/agent-sdk/builtin/skills/settings/SUBAGENTS.md
+++ b/packages/agent-sdk/builtin/skills/settings/SUBAGENTS.md
@@ -35,7 +35,7 @@ You are a specialized subagent for a specific task. Your goal is to:
 - `name`: (Required) Unique identifier.
 - `description`: (Required) Explains the subagent's expertise and when to use it.
 - `tools`: (Optional) List of tools the subagent can use.
-- `model`: (Optional) Overrides the default model for this subagent.
+- `model`: (Optional) Overrides the default model for this subagent. The special values `fastModel` and `visionModel` resolve to the `WAVE_FAST_MODEL` / `WAVE_VISION_MODEL` env vars respectively. Built-in subagents declaring `model: visionModel` (e.g. the built-in `vision` agent) are only registered when `WAVE_VISION_MODEL` is set; for user-defined subagents the value simply resolves to the configured vision model.
 
 ## Subagent Locations
 

--- a/packages/agent-sdk/src/managers/toolManager.ts
+++ b/packages/agent-sdk/src/managers/toolManager.ts
@@ -159,6 +159,18 @@ class ToolManager {
   }
 
   /**
+   * Re-evaluate feature-gated built-in tools after a live configuration
+   * reload. Currently gates the Artifact tool on settings.json
+   * `enableArtifact`. Safe to call multiple times: gated tools are removed
+   * from the registry first, then initializeBuiltInTools() re-registers them
+   * only if still enabled (so toggling the flag off actually unregisters).
+   */
+  public reloadFeatureGatedTools(): void {
+    this.toolsRegistry.delete(artifactTool.name);
+    this.initializeBuiltInTools();
+  }
+
+  /**
    * Check if a tool should be enabled based on tools configuration and permission rules
    */
   private shouldEnableTool(name: string): boolean {

--- a/packages/agent-sdk/src/services/artifactAvailability.ts
+++ b/packages/agent-sdk/src/services/artifactAvailability.ts
@@ -9,15 +9,23 @@
  * "unset follows feature availability" semantics).
  */
 import { loadMergedWaveConfig } from "./configurationService.js";
+import { getRemoteSettingsSync } from "./remoteSettingsService.js";
 
 /** Code default for Artifact availability. Flip to true after the frame backend goes live. */
 export const ARTIFACT_DEFAULT_ENABLED = false;
 
 /**
  * Whether the Artifact tool should be registered / usable for the given workdir.
- * Explicit `enableArtifact` in merged settings wins over the code default.
+ * Resolution order: remote managed settings (`enableArtifact` from
+ * `GET /api/wave/settings`, admin override) → explicit `enableArtifact` in local
+ * merged settings → code default.
  */
 export function isArtifactEnabled(workdir?: string): boolean {
+  // Remote managed settings win (same last-write-wins semantics as `model`).
+  const remote = getRemoteSettingsSync();
+  if (remote?.enableArtifact !== undefined) {
+    return remote.enableArtifact;
+  }
   if (workdir) {
     const config = loadMergedWaveConfig(workdir);
     if (config?.enableArtifact !== undefined) {

--- a/packages/agent-sdk/src/services/remoteSettingsService.ts
+++ b/packages/agent-sdk/src/services/remoteSettingsService.ts
@@ -346,6 +346,8 @@ export function mergeRemoteSettings(
     result.marketplaces = remote.marketplaces;
   if (remote.enabledPlugins !== undefined)
     result.enabledPlugins = remote.enabledPlugins;
+  if (remote.enableArtifact !== undefined)
+    result.enableArtifact = remote.enableArtifact;
 
   return result;
 }

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -303,6 +303,9 @@ export function setupAgentContainer(
     onReload: () => {
       const models = configurationService.getConfiguredModels();
       callbacks.onConfiguredModelsChange?.(models);
+      // Re-evaluate feature-gated tools (e.g. Artifact behind
+      // enableArtifact) so toggling the flag applies without a restart.
+      toolManager.reloadFeatureGatedTools();
     },
   });
   container.register("LiveConfigManager", liveConfigManager);

--- a/packages/agent-sdk/tests/managers/toolManager.test.ts
+++ b/packages/agent-sdk/tests/managers/toolManager.test.ts
@@ -1,9 +1,19 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Mock } from "vitest";
 import { ToolManager } from "@/managers/toolManager.js";
 import { McpManager } from "@/managers/mcpManager.js";
 import { Container } from "@/utils/container.js";
 
+vi.mock("@/services/artifactAvailability.js", () => ({
+  isArtifactEnabled: vi.fn().mockReturnValue(false),
+}));
+
+import { isArtifactEnabled } from "@/services/artifactAvailability.js";
+
 describe("ToolManager tool filtering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
   const mockMcpManager = {
     isMcpTool: vi.fn().mockReturnValue(false),
     executeMcpToolByRegistry: vi.fn(),
@@ -104,5 +114,69 @@ describe("ToolManager tool filtering", () => {
     expect(toolNames).not.toContain("Bash");
     expect(toolNames).toContain("Read");
     expect(toolNames).toContain("Write");
+  });
+});
+
+describe("ToolManager feature-gated tools (Artifact)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const createContainer = () => {
+    const container = new Container();
+    container.register("PermissionManager", {
+      isToolDenied: vi.fn().mockReturnValue(false),
+      getCurrentEffectiveMode: vi.fn().mockReturnValue("default"),
+    });
+    container.register("TaskManager", {} as unknown as Record<string, unknown>);
+    container.register(
+      "ReversionManager",
+      {} as unknown as Record<string, unknown>,
+    );
+    container.register(
+      "BackgroundTaskManager",
+      {} as unknown as Record<string, unknown>,
+    );
+    container.register(
+      "ForegroundTaskManager",
+      {} as unknown as Record<string, unknown>,
+    );
+    container.register("LspManager", {} as unknown as Record<string, unknown>);
+    container.register("McpManager", {
+      isMcpTool: vi.fn().mockReturnValue(false),
+      executeMcpToolByRegistry: vi.fn(),
+      getAllConnectedTools: vi.fn().mockReturnValue([]),
+      getMcpToolsConfig: vi.fn().mockReturnValue([]),
+      getMcpToolPlugins: vi.fn().mockReturnValue([]),
+    } as unknown as McpManager);
+    return container;
+  };
+
+  it("should not register Artifact while enableArtifact is off", () => {
+    (isArtifactEnabled as Mock).mockReturnValue(false);
+    const toolManager = new ToolManager({ container: createContainer() });
+    toolManager.initializeBuiltInTools();
+    expect(toolManager.list().map((t) => t.name)).not.toContain("Artifact");
+  });
+
+  it("should register Artifact after reloadFeatureGatedTools when enableArtifact turns on", () => {
+    const toolManager = new ToolManager({ container: createContainer() });
+    toolManager.initializeBuiltInTools();
+    expect(toolManager.list().map((t) => t.name)).not.toContain("Artifact");
+
+    (isArtifactEnabled as Mock).mockReturnValue(true);
+    toolManager.reloadFeatureGatedTools();
+    expect(toolManager.list().map((t) => t.name)).toContain("Artifact");
+  });
+
+  it("should unregister Artifact after reloadFeatureGatedTools when enableArtifact turns off", () => {
+    (isArtifactEnabled as Mock).mockReturnValue(true);
+    const toolManager = new ToolManager({ container: createContainer() });
+    toolManager.initializeBuiltInTools();
+    expect(toolManager.list().map((t) => t.name)).toContain("Artifact");
+
+    (isArtifactEnabled as Mock).mockReturnValue(false);
+    toolManager.reloadFeatureGatedTools();
+    expect(toolManager.list().map((t) => t.name)).not.toContain("Artifact");
   });
 });

--- a/packages/agent-sdk/tests/services/artifactAvailability.test.ts
+++ b/packages/agent-sdk/tests/services/artifactAvailability.test.ts
@@ -5,7 +5,12 @@ vi.mock("../../src/services/configurationService.js", () => ({
   loadMergedWaveConfig: vi.fn(),
 }));
 
+vi.mock("../../src/services/remoteSettingsService.js", () => ({
+  getRemoteSettingsSync: vi.fn(),
+}));
+
 import { loadMergedWaveConfig } from "../../src/services/configurationService.js";
+import { getRemoteSettingsSync } from "../../src/services/remoteSettingsService.js";
 import {
   isArtifactEnabled,
   ARTIFACT_DEFAULT_ENABLED,
@@ -39,5 +44,23 @@ describe("artifactAvailability", () => {
   it("should disable when settings.json sets enableArtifact: false", () => {
     (loadMergedWaveConfig as Mock).mockReturnValue({ enableArtifact: false });
     expect(isArtifactEnabled("/test/workdir")).toBe(false);
+  });
+
+  it("should prefer remote managed settings over local settings", () => {
+    (getRemoteSettingsSync as Mock).mockReturnValue({ enableArtifact: true });
+    (loadMergedWaveConfig as Mock).mockReturnValue({ enableArtifact: false });
+    expect(isArtifactEnabled("/test/workdir")).toBe(true);
+  });
+
+  it("should follow remote managed settings even when no workdir is given", () => {
+    (getRemoteSettingsSync as Mock).mockReturnValue({ enableArtifact: true });
+    expect(isArtifactEnabled(undefined)).toBe(true);
+    expect(loadMergedWaveConfig).not.toHaveBeenCalled();
+  });
+
+  it("should fall back to local settings when remote does not define enableArtifact", () => {
+    (getRemoteSettingsSync as Mock).mockReturnValue({ language: "en" });
+    (loadMergedWaveConfig as Mock).mockReturnValue({ enableArtifact: true });
+    expect(isArtifactEnabled("/test/workdir")).toBe(true);
   });
 });

--- a/packages/agent-sdk/tests/services/remoteSettingsService.test.ts
+++ b/packages/agent-sdk/tests/services/remoteSettingsService.test.ts
@@ -893,6 +893,7 @@ describe("remoteSettingsService", () => {
         models: { model: { maxTokens: 50 } },
         marketplaces: { m1: { source: "url" as const } },
         enabledPlugins: { p1: true },
+        enableArtifact: false,
       };
       const remote = {
         language: "ja",
@@ -901,6 +902,7 @@ describe("remoteSettingsService", () => {
         models: { model: { maxTokens: 100 } },
         marketplaces: { m2: { source: "url" as const } },
         enabledPlugins: { p2: true },
+        enableArtifact: true,
       };
       const result = mergeRemoteSettings(
         local as unknown as WaveConfiguration,
@@ -912,6 +914,7 @@ describe("remoteSettingsService", () => {
       expect(result.models).toEqual({ model: { maxTokens: 100 } });
       expect(result.marketplaces).toEqual({ m2: { source: "url" } });
       expect(result.enabledPlugins).toEqual({ p2: true });
+      expect(result.enableArtifact).toBe(true);
     });
 
     it("preserves local scalar fields when remote doesn't define them", () => {
@@ -922,6 +925,7 @@ describe("remoteSettingsService", () => {
         models: { model: { maxTokens: 50 } },
         marketplaces: { m1: { source: "url" as const } },
         enabledPlugins: { p1: true },
+        enableArtifact: false,
       };
       const remote = {};
       const result = mergeRemoteSettings(
@@ -934,6 +938,7 @@ describe("remoteSettingsService", () => {
       expect(result.models).toEqual({ model: { maxTokens: 50 } });
       expect(result.marketplaces).toEqual({ m1: { source: "url" } });
       expect(result.enabledPlugins).toEqual({ p1: true });
+      expect(result.enableArtifact).toBe(false);
     });
 
     it("handles both empty objects", () => {


### PR DESCRIPTION
## 概述

为 `enableArtifact` 开关补齐两项能力：**配置热更新**（运行中切换开关即时生效，无需重启会话）与**服务端配置分发**（remote settings 下发，管理员远程灰度/回滚）。

### 热更新

- `ToolManager.reloadFeatureGatedTools()`：先移除 `artifactTool` 再重跑 `initializeBuiltInTools()`，关闭开关会真正注销工具（而非只注册不注销）
- `containerSetup.ts` 的 LiveConfigManager `onReload` 回调接入该方法，本地 settings.json 修改即时生效
- WebFetch 的 artifact URL 拦截本就逐调用检查 `isArtifactEnabled()`，天然热更新

### 服务端配置分发

- `mergeRemoteSettings()` 白名单新增 `enableArtifact`（remote wins，与 `model`/`permissionMode` 同语义）
- `isArtifactEnabled()` 解析顺序：remote managed → 本地 settings → 代码默认值（工具注册与 WebFetch 拦截一处改全生效）
- 分发链路复用现有轮询机制（60min + 304 checksum）→ `onSettingsUpdate` → `liveConfigManager.reload()`，客户端协议零改动

### 文档与 Spec

- `settings` 技能：SKILL.md 新增 `enableArtifact` 条目；ENV.md 修正 `WAVE_SERVER_URL` 的 env 镜像说明；SUBAGENTS.md 补充 `model: fastModel/visionModel` 特殊值
- `docs/specs/core/artifact-tool.md`：新增热更新与远程分发验收场景（5-8）

### 测试

- toolManager +3（注册/注销/热更新）、artifactAvailability +3（remote 优先）、remoteSettingsService 标量 merge 补 `enableArtifact`
- 相关测试 73/73 通过，agent-sdk type-check 通过，spec-count 72/372/1420