### PR TITLE
fix(desktop): cross-platform dev/install scripts + CRLF sidebar checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "desktop:dev": "pnpm -F wave-webview build && pnpm -F wave-desktop run dev",
     "desktop:build": "pnpm -F wave-webview build && pnpm -F wave-desktop run compile",
     "desktop:package": "pnpm -F wave-webview build && pnpm -F wave-desktop run dist",
-    "desktop:install": "pnpm build && pnpm -F wave-desktop exec electron-builder --dir --config.mac.identity=null && rsync -a --delete packages/desktop/release/mac-arm64/Wave.app/ /Applications/Wave.app/",
+    "desktop:install": "node packages/desktop/scripts/install.mjs",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -13,7 +13,7 @@
     "compile": "pnpm run sync:webview && tsup",
     "sync:webview": "node scripts/syncWebview.mjs",
     "predev": "node scripts/predev.mjs",
-    "dev": "pnpm run compile && env -u ELECTRON_RUN_AS_NODE electron . --no-sandbox",
+    "dev": "pnpm run compile && node scripts/dev.mjs",
     "dist": "pnpm run compile && electron-builder",
     "clean": "node -e \"import('fs').then(fs => ['dist', 'release', 'webview'].forEach(d => {try{fs.rmSync(d, {recursive:true, force:true})}catch(e){}}))\"",
     "type-check": "tsc --noEmit && tsc -p tests --noEmit",

--- a/packages/desktop/scripts/dev.mjs
+++ b/packages/desktop/scripts/dev.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+/**
+ * dev — cross-platform launcher for `pnpm run dev`.
+ *
+ * The previous one-liner (`env -u ELECTRON_RUN_AS_NODE electron .`) used
+ * POSIX-only syntax: on Windows pnpm executes scripts with cmd.exe, which has
+ * no `env`, so the command failed. Unsetting the variable in-process works
+ * everywhere — with ELECTRON_RUN_AS_NODE=1 (set whenever Electron runs a node
+ * script, e.g. via the binary resolver) Electron would start in Node mode
+ * instead of showing the app window.
+ */
+import { spawn } from "node:child_process";
+import electron from "electron";
+
+delete process.env.ELECTRON_RUN_AS_NODE;
+
+const child = spawn(electron, [".", "--no-sandbox"], { stdio: "inherit" });
+
+child.on("exit", (code) => process.exit(code ?? 0));

--- a/packages/desktop/scripts/install.mjs
+++ b/packages/desktop/scripts/install.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform "install/update the installed Wave desktop app".
+ *
+ * - macOS: package the app dir and rsync it over /Applications/Wave.app
+ *   (safe to do while the app is running).
+ * - Windows: package win-unpacked and copy it over the detected install
+ *   directory (%LOCALAPPDATA%\Programs\Wave — the NSIS default — falling
+ *   back to the registry InstallLocation, or WAVE_INSTALL_DIR). Windows
+ *   locks a running exe, so quit Wave first if the copy fails.
+ *
+ * A full `pnpm build` runs first (required: the user consumes wave-code
+ * via npm link).
+ */
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const isWin = process.platform === "win32";
+const isMac = process.platform === "darwin";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const desktopDir = path.resolve(scriptDir, "..");
+const repoDir = path.resolve(desktopDir, "../..");
+
+function runPnpm(args, cwd) {
+  // On Windows, pnpm is pnpm.cmd; spawn it via the shell as a string command
+  // (array + shell:true would trigger the DEP0190 warning).
+  const r = isWin
+    ? spawnSync(`pnpm.cmd ${args.join(" ")}`, { stdio: "inherit", shell: true, cwd })
+    : spawnSync("pnpm", args, { stdio: "inherit", cwd });
+  if (r.status !== 0) process.exit(r.status ?? 1);
+}
+
+/** reg.exe emits OEM code page (GBK on zh-CN) — decode like the bash tool does. */
+function decodeRegOutput(buf) {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(buf);
+  } catch {
+    return new TextDecoder("gbk").decode(buf);
+  }
+}
+
+function queryRegistryInstallLocation() {
+  // electron-builder NSIS writes the uninstaller key by productName ("Wave").
+  for (const hive of ["HKCU", "HKLM"]) {
+    const key = `${hive}\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Wave`;
+    const r = spawnSync("reg", ["query", key, "/v", "InstallLocation"], {
+      encoding: "buffer",
+    });
+    if (r.status === 0) {
+      const m = decodeRegOutput(r.stdout).match(
+        /InstallLocation\s+REG_SZ\s+(.+)/i,
+      );
+      if (m && m[1].trim()) return m[1].trim();
+    }
+  }
+  return null;
+}
+
+function findInstallDir() {
+  if (process.env.WAVE_INSTALL_DIR) return process.env.WAVE_INSTALL_DIR;
+  const def = path.join(
+    process.env.LOCALAPPDATA || path.join(os.homedir(), "AppData", "Local"),
+    "Programs",
+    "Wave",
+  );
+  if (fs.existsSync(def)) return def;
+  const fromRegistry = queryRegistryInstallLocation();
+  if (fromRegistry) return fromRegistry;
+  console.error(
+    "Could not locate an existing Wave installation. Install once with the NSIS installer (`pnpm run dist`), or set WAVE_INSTALL_DIR to the install folder.",
+  );
+  process.exit(1);
+}
+
+// 1. Full build
+console.log("[desktop:install] Building all packages…");
+runPnpm(["build"], repoDir);
+
+// 2. Package the app dir. macOS needs identity=null for ad-hoc installs;
+// Windows skips the native-module rebuild (node-pty ships N-API prebuilds that
+// Electron loads directly — avoids a node-gyp/Python toolchain requirement).
+console.log("[desktop:install] Packaging app dir…");
+if (isMac) {
+  runPnpm(
+    ["-F", "wave-desktop", "exec", "electron-builder", "--dir", "--config.mac.identity=null"],
+    repoDir,
+  );
+} else {
+  runPnpm(
+    ["-F", "wave-desktop", "exec", "electron-builder", "--dir", "--config.npmRebuild=false"],
+    repoDir,
+  );
+}
+
+// 3. Copy over the installed app
+if (isMac) {
+  const src = path.join(desktopDir, "release", "mac-arm64", "Wave.app");
+  const dest = "/Applications/Wave.app";
+  console.log(`[desktop:install] Syncing ${src} → ${dest}`);
+  const r = spawnSync("rsync", ["-a", "--delete", `${src}/`, `${dest}/`], {
+    stdio: "inherit",
+    cwd: repoDir,
+  });
+  process.exit(r.status ?? 0);
+}
+
+if (isWin) {
+  const src = path.join(desktopDir, "release", "win-unpacked");
+  const dest = findInstallDir();
+  console.log(`[desktop:install] Copying ${src} → ${dest}`);
+  if (!fs.existsSync(src)) {
+    console.error(`Expected app dir not found: ${src}`);
+    process.exit(1);
+  }
+  // Remove stale files first (mirror of rsync --delete). Windows locks a
+  // running exe, so a locked Wave.exe fails here — tell the user to quit.
+  try {
+    fs.rmSync(dest, { recursive: true, force: true });
+  } catch (err) {
+    console.error(
+      `Failed to clear ${dest}: ${err.message}\n` +
+        "Wave is probably still running — quit it and re-run `pnpm run desktop:install`.",
+    );
+    process.exit(1);
+  }
+  fs.cpSync(src, dest, { recursive: true, force: true });
+  console.log("[desktop:install] Done.");
+  process.exit(0);
+}
+
+console.error(`Unsupported platform: ${process.platform}`);
+process.exit(1);

--- a/packages/desktop/scripts/predev.mjs
+++ b/packages/desktop/scripts/predev.mjs
@@ -20,13 +20,12 @@ const me = process.pid;
 
 function buildWebview() {
   const isWin = process.platform === "win32";
-  const r = spawnSync(
-    isWin ? "pnpm.cmd" : "pnpm",
-    ["-F", "wave-webview", "build"],
-    {
-      stdio: "inherit",
-    },
-  );
+  // Windows: Node cannot spawn .cmd directly (EINVAL) and shell:true with an
+  // args array emits DEP0190 — pass the fixed literal command as a string
+  // instead. macOS/Linux keep the args-array form (no shell involved).
+  const r = isWin
+    ? spawnSync("pnpm.cmd -F wave-webview build", { stdio: "inherit", shell: true })
+    : spawnSync("pnpm", ["-F", "wave-webview", "build"], { stdio: "inherit" });
   if (r.error) {
     console.error(`[predev] failed to spawn pnpm: ${r.error.message}`);
     process.exit(1);

--- a/scripts/check-sidebar-anchors.mjs
+++ b/scripts/check-sidebar-anchors.mjs
@@ -35,6 +35,9 @@ function stripCodeBlocks(content) {
 }
 
 function collectHeadings(content) {
+  // CRLF (Windows autocrlf) breaks the heading regex: "." and "$" do not match
+  // "\r", so every line would be skipped. Strip carriage returns first.
+  content = content.replace(/\r/g, "");
   const headings = [];
   for (const line of stripCodeBlocks(content).split('\n')) {
     const m = line.match(/^(#{1,6})\s+(.*)$/);


### PR DESCRIPTION
## 描述

Windows OS 兼容性修复,3 个 commit:

### 1. `fix(desktop): make dev script cross-platform` (b35d68e5)
`pnpm run dev` 原为 `env -u ELECTRON_RUN_AS_NODE electron . --no-sandbox`(POSIX 专属,Windows cmd 无法执行)。改为 `node scripts/dev.mjs` 跨平台启动器 + predev.mjs 用 `pnpm.cmd`(Windows 直接 spawn .cmd 报 EINVAL)。

### 2. `fix(scripts): sidebar anchor check fails on CRLF docs` (352bcd1a)
Windows autocrlf 使 docs 为 CRLF,heading 正则 `.`/`$` 不匹配 `\r`,导致 sidebar anchor 检查全部失败(16 个误报)。修复:collectHeadings 先 `content.replace(/\r/g, "")`。

### 3. `fix(desktop): make desktop:install cross-platform` (745338dd)
原为 mac-only(rsync + /Applications)。新建 `packages/desktop/scripts/install.mjs`:
- macOS:保留原 rsync 覆盖 `/Applications/Wave.app` 行为
- Windows:构建 `win-unpacked` 后复制到安装位置(`WAVE_INSTALL_DIR` → `%LOCALAPPDATA%\Programs\Wave` → 注册表 `InstallLocation`),复制前清空旧目录(等效 rsync --delete)
- Windows 打包用 `--config.npmRebuild=false`:node-pty 是 N-API prebuild,Electron 43 可直接加载(已验证),避免 node-gyp/Python 工具链依赖

## 验证

- desktop:dev:Windows 端到端启动验证通过
- desktop:install:本机临时目录全流程冒烟(全量 build → electron-builder --dir → 复制 → Wave.exe 存在),未触碰真实安装
- CRLF checker:pre-commit 中 159 链接 OK、262 sidebar anchors OK