### PR TITLE
fix(agent-sdk): Edit tool $ mangling (#1752) + Windows GBK mojibake (#1753)

### DIFF
--- a/packages/agent-sdk/src/managers/backgroundTaskManager.ts
+++ b/packages/agent-sdk/src/managers/backgroundTaskManager.ts
@@ -4,6 +4,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { BackgroundTask, BackgroundShell } from "../types/processes.js";
 import { stripAnsiColors } from "../utils/stringUtils.js";
+import { WindowsStreamDecoder } from "../utils/encoding.js";
 import { logger } from "../utils/globalLogger.js";
 import { Container } from "../utils/container.js";
 import { MessageQueue } from "./messageQueue.js";
@@ -153,8 +154,17 @@ export class BackgroundTaskManager {
       }, timeout);
     }
 
+    // On Windows, native tools (taskkill, powershell, ...) write GBK (cp936)
+    // instead of UTF-8; decode their byte streams accordingly (issue #1753).
+    const stdoutDecoder =
+      process.platform === "win32" ? new WindowsStreamDecoder() : null;
+    const stderrDecoder =
+      process.platform === "win32" ? new WindowsStreamDecoder() : null;
+
     const onStdout = (data: Buffer | string) => {
-      const stripped = stripAnsiColors(data.toString());
+      const stripped = stripAnsiColors(
+        stdoutDecoder ? stdoutDecoder.push(data as Buffer) : data.toString(),
+      );
       shell.stdout += stripped;
       if (logStream.writable) {
         logStream.write(stripped);
@@ -163,7 +173,9 @@ export class BackgroundTaskManager {
     };
 
     const onStderr = (data: Buffer | string) => {
-      const stripped = stripAnsiColors(data.toString());
+      const stripped = stripAnsiColors(
+        stderrDecoder ? stderrDecoder.push(data as Buffer) : data.toString(),
+      );
       shell.stderr += stripped;
       if (logStream.writable) {
         logStream.write(stripped);
@@ -174,6 +186,26 @@ export class BackgroundTaskManager {
     const onExit = (code: number | null) => {
       if (timeoutHandle) {
         clearTimeout(timeoutHandle);
+      }
+      // Decode any bytes still held at stream end (e.g. a trailing UTF-8
+      // character split across the last chunk).
+      if (stdoutDecoder) {
+        const rest = stdoutDecoder.flush();
+        if (rest) {
+          shell.stdout += rest;
+          if (logStream.writable) {
+            logStream.write(rest);
+          }
+        }
+      }
+      if (stderrDecoder) {
+        const rest = stderrDecoder.flush();
+        if (rest) {
+          shell.stderr += rest;
+          if (logStream.writable) {
+            logStream.write(rest);
+          }
+        }
       }
       if (logStream.writable) {
         logStream.end();
@@ -315,8 +347,17 @@ export class BackgroundTaskManager {
     this.tasks.set(id, shell);
     this.notifyTasksChange();
 
+    // On Windows, native tools write GBK (cp936) instead of UTF-8; decode
+    // their byte streams accordingly (issue #1753).
+    const stdoutDecoder =
+      process.platform === "win32" ? new WindowsStreamDecoder() : null;
+    const stderrDecoder =
+      process.platform === "win32" ? new WindowsStreamDecoder() : null;
+
     child.stdout?.on("data", (data) => {
-      const stripped = stripAnsiColors(data.toString());
+      const stripped = stripAnsiColors(
+        stdoutDecoder ? stdoutDecoder.push(data) : data.toString(),
+      );
       shell.stdout += stripped;
       if (logStream.writable) {
         logStream.write(stripped);
@@ -325,7 +366,9 @@ export class BackgroundTaskManager {
     });
 
     child.stderr?.on("data", (data) => {
-      const stripped = stripAnsiColors(data.toString());
+      const stripped = stripAnsiColors(
+        stderrDecoder ? stderrDecoder.push(data) : data.toString(),
+      );
       shell.stderr += stripped;
       if (logStream.writable) {
         logStream.write(stripped);
@@ -334,6 +377,25 @@ export class BackgroundTaskManager {
     });
 
     child.on("exit", (code) => {
+      // Decode any bytes still held at stream end
+      if (stdoutDecoder) {
+        const rest = stdoutDecoder.flush();
+        if (rest) {
+          shell.stdout += rest;
+          if (logStream.writable) {
+            logStream.write(rest);
+          }
+        }
+      }
+      if (stderrDecoder) {
+        const rest = stderrDecoder.flush();
+        if (rest) {
+          shell.stderr += rest;
+          if (logStream.writable) {
+            logStream.write(rest);
+          }
+        }
+      }
       if (logStream.writable) {
         logStream.end();
       }

--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -6,6 +6,7 @@ import { logger } from "../utils/globalLogger.js";
 import { resolveShellPath } from "../utils/shellResolver.js";
 import { toPosixPath } from "../utils/path.js";
 import { stripAnsiColors } from "../utils/stringUtils.js";
+import { WindowsStreamDecoder } from "../utils/encoding.js";
 import { processToolResult } from "../utils/toolResultStorage.js";
 import { BASH_MAX_OUTPUT_CHARS } from "../constants/toolLimits.js";
 import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
@@ -300,6 +301,13 @@ The working directory persists between commands. Try to maintain your current wo
       let isBackgrounded = false;
       let isFinished = false;
 
+      // On Windows, native tools (taskkill, powershell, ...) write GBK (cp936)
+      // instead of UTF-8; decode their byte streams accordingly (issue #1753).
+      const stdoutDecoder =
+        process.platform === "win32" ? new WindowsStreamDecoder() : null;
+      const stderrDecoder =
+        process.platform === "win32" ? new WindowsStreamDecoder() : null;
+
       // Best-effort cleanup of the temp CWD file — used by abort/error/exit paths
       const cleanupTempFile = () => {
         try {
@@ -503,7 +511,9 @@ The working directory persists between commands. Try to maintain your current wo
 
       child.stdout?.on("data", (data) => {
         if (!isAborted && !isBackgrounded && !runInBackground) {
-          const chunk = stripAnsiColors(data.toString());
+          const chunk = stripAnsiColors(
+            stdoutDecoder ? stdoutDecoder.push(data) : data.toString(),
+          );
           outputBuffer += chunk;
           updateRealtimeResults();
         }
@@ -511,7 +521,9 @@ The working directory persists between commands. Try to maintain your current wo
 
       child.stderr?.on("data", (data) => {
         if (!isAborted && !isBackgrounded && !runInBackground) {
-          const chunk = stripAnsiColors(data.toString());
+          const chunk = stripAnsiColors(
+            stderrDecoder ? stderrDecoder.push(data) : data.toString(),
+          );
           errorBuffer += chunk;
           updateRealtimeResults();
         }
@@ -564,6 +576,10 @@ The working directory persists between commands. Try to maintain your current wo
           }
 
           const exitCode = code ?? 0;
+          // Decode any bytes still held at stream end (e.g. a trailing UTF-8
+          // character split across the last chunk).
+          if (stdoutDecoder) outputBuffer += stdoutDecoder.flush();
+          if (stderrDecoder) errorBuffer += stderrDecoder.flush();
           const combinedOutput =
             outputBuffer + (errorBuffer ? "\n" + errorBuffer : "");
 

--- a/packages/agent-sdk/src/tools/editTool.ts
+++ b/packages/agent-sdk/src/tools/editTool.ts
@@ -197,7 +197,11 @@ Usage:
       if (replaceAll) {
         // Replace all matches
         const regex = new RegExp(escapeRegExp(matchedOldString), "g");
-        newContent = normalizedContent.replace(regex, newString);
+        // Function replacer (claude-code's applyEditToFile approach): newString
+        // is inserted literally, never parsed as a $ replacement template. A
+        // string replacer would expand $& to the matched text, $$ to a single
+        // $, and `$` could even truncate and duplicate the file (issue #1752).
+        newContent = normalizedContent.replace(regex, () => newString);
         replacementCount = (normalizedContent.match(regex) || []).length;
       } else {
         // Replace only the first match, but first check if it's unique
@@ -210,7 +214,11 @@ Usage:
           };
         }
 
-        newContent = normalizedContent.replace(matchedOldString, newString);
+        // Function replacer: see note above — $ in newString stays literal
+        newContent = normalizedContent.replace(
+          matchedOldString,
+          () => newString,
+        );
         replacementCount = 1;
       }
 

--- a/packages/agent-sdk/src/utils/encoding.ts
+++ b/packages/agent-sdk/src/utils/encoding.ts
@@ -1,0 +1,100 @@
+/**
+ * Streaming byte-to-text decoder for bash tool output on Windows.
+ *
+ * Git Bash (MSYS) tools emit UTF-8, but native Windows programs (taskkill,
+ * powershell, ping, ...) write the system OEM code page — GBK (cp936) on
+ * zh-CN systems. Node's default `data.toString()` decodes every stream as
+ * UTF-8, so GBK bytes turn into U+FFFD mojibake (issue #1753).
+ *
+ * Strategy (per-chunk buffering, decide-once):
+ * - Accumulate raw bytes; try strict UTF-8 (`fatal: true`) over everything
+ *   buffered so far. If it decodes cleanly, emit the text.
+ * - If strict UTF-8 fails, hold back up to 3 trailing bytes (a UTF-8
+ *   character split across chunk boundaries) and retry on the next chunk.
+ * - Once even the head is not valid UTF-8, the stream is GBK: re-decode all
+ *   buffered bytes with GBK and switch to GBK for every subsequent chunk.
+ * - `flush()` decodes any leftover buffered bytes (leniently) at stream end.
+ */
+export class WindowsStreamDecoder {
+  private pending = Buffer.alloc(0);
+  private gbkDecoder: TextDecoder | null = null;
+
+  /** Longest possible incomplete UTF-8 tail at a chunk boundary is 3 bytes. */
+  private static readonly MAX_UTF8_TRAIL_BYTES = 3;
+
+  push(data: Buffer): string {
+    // Already determined GBK: decode each chunk as it arrives.
+    if (this.gbkDecoder) {
+      return this.gbkDecoder.decode(data);
+    }
+
+    this.pending = Buffer.concat([this.pending, data]);
+
+    try {
+      const text = new TextDecoder("utf-8", { fatal: true }).decode(
+        this.pending,
+      );
+      this.pending = Buffer.alloc(0);
+      return text;
+    } catch {
+      // Strict UTF-8 failed. The trailing bytes may be a UTF-8 sequence split
+      // across chunks: hold only the trailing run of non-ASCII bytes (max 3,
+      // the longest incomplete UTF-8 tail). Everything before it is already
+      // decodable and is emitted immediately.
+      const n = this.pending.length;
+      let keep = 0;
+      while (
+        keep < WindowsStreamDecoder.MAX_UTF8_TRAIL_BYTES &&
+        keep < n &&
+        this.pending[n - 1 - keep] >= 0x80
+      ) {
+        keep++;
+      }
+      const head = this.pending.subarray(0, n - keep);
+      if (head.length > 0) {
+        try {
+          const text = new TextDecoder("utf-8", { fatal: true }).decode(head);
+          this.pending = Buffer.from(this.pending.subarray(n - keep));
+          return text;
+        } catch {
+          // Head is not valid UTF-8 → the whole stream is GBK. Re-decode
+          // everything accumulated so far and commit to GBK.
+          this.gbkDecoder = new TextDecoder("gbk");
+          const text = this.gbkDecoder.decode(this.pending);
+          this.pending = Buffer.alloc(0);
+          return text;
+        }
+      }
+      // Only the trailing bytes are suspect: hold them for the next chunk.
+      return "";
+    }
+  }
+
+  /** Decode any bytes still held at stream end (lenient UTF-8, else GBK). */
+  flush(): string {
+    if (this.pending.length === 0) return "";
+    const rest = this.pending;
+    this.pending = Buffer.alloc(0);
+    if (this.gbkDecoder) {
+      return this.gbkDecoder.decode(rest);
+    }
+    const utf8 = rest.toString("utf-8");
+    if (!utf8.includes("\uFFFD")) return utf8;
+    try {
+      return new TextDecoder("gbk").decode(rest);
+    } catch {
+      return utf8;
+    }
+  }
+}
+
+/** Decode a single complete byte sequence (used for non-streaming reads). */
+export function decodeBytes(buf: Buffer): string {
+  const utf8 = buf.toString("utf-8");
+  if (!utf8.includes("\uFFFD")) return utf8;
+  try {
+    return new TextDecoder("gbk").decode(buf);
+  } catch {
+    return utf8;
+  }
+}

--- a/packages/agent-sdk/tests/tools/bashTool.test.ts
+++ b/packages/agent-sdk/tests/tools/bashTool.test.ts
@@ -27,10 +27,15 @@ vi.mock("fs", async () => {
 });
 
 vi.mock("os", async () => {
-  const actual = await vi.importActual("os");
+  const actual = await vi.importActual<typeof import("os")>("os");
   return {
     ...actual,
-    tmpdir: vi.fn().mockReturnValue("/tmp"),
+    // Use the real temp dir: BackgroundTaskManager writes its log files via
+    // fs.createWriteStream(path.join(os.tmpdir(), ...)). A hardcoded "/tmp"
+    // resolves to C:\tmp on Windows (usually absent), making the stream's
+    // open fail with ENOENT — surfaced as unhandled errors under the dot
+    // reporter on Windows CI (issue: pre-existing test flakiness).
+    tmpdir: vi.fn().mockReturnValue(actual.tmpdir()),
   };
 });
 
@@ -710,7 +715,9 @@ describe("bashTool", () => {
       const wrapped = spawnCallArgs[0] as string;
       expect(wrapped).toContain("eval 'echo hello'");
       expect(wrapped).toContain("pwd -P");
-      expect(wrapped).toMatch(/&& pwd -P >\| \/tmp\/wave_cwd_.*\.tmp$/);
+      // Temp file path is platform-specific (C:/tmp on a "/tmp" mock, the real
+      // temp dir otherwise) — only assert the file naming pattern.
+      expect(wrapped).toMatch(/&& pwd -P >\| .*wave_cwd_.*\.tmp$/);
     });
 
     it("should escape single quotes in the user command", async () => {
@@ -723,9 +730,7 @@ describe("bashTool", () => {
       const wrapped = mockSpawn.mock.calls[0][0] as string;
       // Each single quote in the user command is replaced with '"'"'
       expect(wrapped).toContain(`eval 'echo '"'"'hi'"'"''`);
-      expect(wrapped).toMatch(
-        /^eval '.*' && pwd -P >\| \/tmp\/wave_cwd_.*\.tmp$/,
-      );
+      expect(wrapped).toMatch(/^eval '.*' && pwd -P >\| .*wave_cwd_.*\.tmp$/);
     });
 
     it("should keep && pwd -P outside the eval quotes for a heredoc command", async () => {
@@ -750,7 +755,7 @@ EOF
       const evalStart = wrapped.lastIndexOf("eval '");
       const pwdIndex = wrapped.indexOf("&& pwd -P");
       expect(pwdIndex).toBeGreaterThan(evalStart);
-      expect(wrapped).toMatch(/&& pwd -P >\| \/tmp\/wave_cwd_.*\.tmp$/);
+      expect(wrapped).toMatch(/&& pwd -P >\| .*wave_cwd_.*\.tmp$/);
     });
   });
 

--- a/packages/agent-sdk/tests/tools/editTool.test.ts
+++ b/packages/agent-sdk/tests/tools/editTool.test.ts
@@ -133,6 +133,84 @@ describe("editTool", () => {
     );
   });
 
+  it("should keep $ sequences in new_string literal (issue #1752)", async () => {
+    const mockContent = "line one\nline two\nline three";
+    const expectedContent = "line one\nA$&B A$$B A$1B A$xB\nline three";
+
+    vi.mocked(readFile).mockResolvedValue(mockContent);
+    vi.mocked(writeFile).mockResolvedValue(undefined);
+
+    const result = await editTool.execute(
+      {
+        file_path: "/test/file.js",
+        old_string: "line two",
+        new_string: "A$&B A$$B A$1B A$xB",
+      },
+      mockContext,
+    );
+
+    expect(result.success).toBe(true);
+    expect(writeFile).toHaveBeenCalledWith(
+      r("/test/file.js"),
+      expectedContent,
+      "utf-8",
+    );
+  });
+
+  it("should keep $ literal with backticks in new_string (issue #1752)", async () => {
+    const mockContent =
+      "// neither `.` nor `$` matches in a non-multiline regex — headings would";
+    const expectedContent =
+      "// neither `.` nor `$` matches in a non-multiline regex — headings would\n// `$` matches — note added line";
+
+    vi.mocked(readFile).mockResolvedValue(mockContent);
+    vi.mocked(writeFile).mockResolvedValue(undefined);
+
+    const result = await editTool.execute(
+      {
+        file_path: "/test/file.js",
+        old_string:
+          "// neither `.` nor `$` matches in a non-multiline regex — headings would",
+        new_string:
+          "// neither `.` nor `$` matches in a non-multiline regex — headings would\n// `$` matches — note added line",
+      },
+      mockContext,
+    );
+
+    expect(result.success).toBe(true);
+    expect(writeFile).toHaveBeenCalledWith(
+      r("/test/file.js"),
+      expectedContent,
+      "utf-8",
+    );
+  });
+
+  it("should keep $ literal in replace_all mode (issue #1752)", async () => {
+    const mockContent = "a $x b\na $x b";
+    const expectedContent = "a A$&B b\na A$&B b";
+
+    vi.mocked(readFile).mockResolvedValue(mockContent);
+    vi.mocked(writeFile).mockResolvedValue(undefined);
+
+    const result = await editTool.execute(
+      {
+        file_path: "/test/file.js",
+        old_string: "$x",
+        new_string: "A$&B",
+        replace_all: true,
+      },
+      mockContext,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.content).toContain("Replaced 2 instances");
+    expect(writeFile).toHaveBeenCalledWith(
+      r("/test/file.js"),
+      expectedContent,
+      "utf-8",
+    );
+  });
+
   it("should fail when old_string is not unique and replace_all is false", async () => {
     const mockContent = "var x = 1;\nvar y = 2;\nvar z = 3;";
 

--- a/packages/agent-sdk/tests/utils/encoding.test.ts
+++ b/packages/agent-sdk/tests/utils/encoding.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { WindowsStreamDecoder, decodeBytes } from "@/utils/encoding.js";
+
+function toBuffer(str: string): Buffer {
+  return Buffer.from(str, "utf-8");
+}
+
+// GBK bytes for "成功: 已终止 PID 123" — the classic `taskkill` output on
+// a zh-CN Windows system. Encoded as literal bytes so the test does not
+// depend on the machine's own code page.
+const GBK_TASKKILL = Buffer.from([
+  0xb3, 0xc9, 0xb9, 0xa6, 0x3a, 0x20, 0xd2, 0xd1, 0xd6, 0xd5, 0xd6, 0xb9, 0x20,
+  0x50, 0x49, 0x44, 0x20, 0x31, 0x32, 0x33,
+]);
+
+describe("decodeBytes", () => {
+  it("decodes UTF-8 as-is", () => {
+    expect(decodeBytes(toBuffer("hello 世界"))).toBe("hello 世界");
+  });
+
+  it("decodes GBK bytes with the U+FFFD fallback", () => {
+    expect(decodeBytes(GBK_TASKKILL)).toBe("成功: 已终止 PID 123");
+  });
+
+  it("keeps ASCII and GBK mixed output intact", () => {
+    const mixed = Buffer.concat([toBuffer("taskkill: "), GBK_TASKKILL]);
+    expect(decodeBytes(mixed)).toBe("taskkill: 成功: 已终止 PID 123");
+  });
+});
+
+describe("WindowsStreamDecoder", () => {
+  it("decodes a pure UTF-8 stream chunk by chunk", () => {
+    const decoder = new WindowsStreamDecoder();
+    const out =
+      decoder.push(toBuffer("line one\n")) +
+      decoder.push(toBuffer("line two 世界\n")) +
+      decoder.push(toBuffer("line three"));
+    expect(out).toBe("line one\nline two 世界\nline three");
+  });
+
+  it("decodes a pure GBK stream chunk by chunk", () => {
+    const decoder = new WindowsStreamDecoder();
+    const out =
+      decoder.push(GBK_TASKKILL.subarray(0, 5)) +
+      decoder.push(GBK_TASKKILL.subarray(5));
+    expect(out).toBe("成功: 已终止 PID 123");
+  });
+
+  it("does not misjudge a UTF-8 character split across chunk boundaries", () => {
+    const decoder = new WindowsStreamDecoder();
+    const utf8 = toBuffer("成功");
+    // "成" and "功" are 3 bytes each: feed every byte one at a time
+    let out = "";
+    for (let i = 0; i < utf8.length; i++) {
+      out += decoder.push(utf8.subarray(i, i + 1));
+    }
+    out += decoder.push(toBuffer(": ok"));
+    expect(out).toBe("成功: ok");
+  });
+
+  it("switches to GBK mid-stream without losing earlier output", () => {
+    const decoder = new WindowsStreamDecoder();
+    const out = decoder.push(toBuffer("done\n")) + decoder.push(GBK_TASKKILL);
+    expect(out).toBe("done\n成功: 已终止 PID 123");
+  });
+
+  it("flush() decodes a trailing split UTF-8 sequence", () => {
+    const decoder = new WindowsStreamDecoder();
+    const utf8 = toBuffer("ok 世");
+    // "世" (3 bytes) split across chunks: "ok " is confirmed and emitted
+    // immediately, the incomplete tail is held and decoded once complete
+    const out =
+      decoder.push(utf8.subarray(0, 4)) + // "ok " + first byte of 世
+      decoder.push(utf8.subarray(4)) + // remaining 2 bytes of 世
+      decoder.flush();
+    expect(out).toBe("ok 世");
+  });
+
+  it("flush() decodes leftover GBK bytes after a switch", () => {
+    const decoder = new WindowsStreamDecoder();
+    decoder.push(GBK_TASKKILL);
+    // GBK character "功" (0xB9 0xA6) split at the end of the stream
+    expect(decoder.flush()).toBe("");
+  });
+});

--- a/scripts/check-sidebar-anchors.mjs
+++ b/scripts/check-sidebar-anchors.mjs
@@ -36,7 +36,7 @@ function stripCodeBlocks(content) {
 
 function collectHeadings(content) {
   const headings = [];
-  for (const line of stripCodeBlocks(content).split('\n')) {
+  for (const line of stripCodeBlocks(content).split(/\r?\n/)) {
     const m = line.match(/^(#{1,6})\s+(.*)$/);
     if (m) {
       let text = m[2];


### PR DESCRIPTION
## Summary

Fixes three issues found on Windows:

### #1752 — Edit tool mangles `$` sequences in replacement text
`editTool.ts` passed the new text as a plain string to `String.prototype.replace`, so `$&`/`$$`/`$1`… were parsed as replacement templates. Now the replacement is a function `() => newString` (mirrors Claude Code's `applyEditToFile`), so the new text is inserted literally. 3 regression tests added.

### #1753 — bash tool output mojibake on Windows zh-CN
Native Windows programs (taskkill, powershell, …) emit GBK (cp936) bytes; Node decoded them as UTF-8 producing `�`. New `WindowsStreamDecoder` (`packages/agent-sdk/src/utils/encoding.ts`) tries strict UTF-8 first and falls back to GBK, handling multi-byte chars split across stream chunks. Integrated in `bashTool.ts` and `backgroundTaskManager.ts` (both spawn sites), gated on `win32`. 9 unit tests added.

### bashTool tests ENOENT + platform-agnostic assertions
The tests mocked `os.tmpdir` to `/tmp`; on Windows `path.join("/tmp", …)` resolves to a nonexistent `C:\tmp`, so the real `fs.createWriteStream` fired async unhandled ENOENT errors. The mock now returns the real tmpdir and the CWD-file path assertions match any temp path instead of hardcoding `/tmp`.

### Sidebar anchor check CRLF tolerance
`scripts/check-sidebar-anchors.mjs` failed on Windows worktrees (CRLF checkouts): heading lines end in CR, which the heading regex can't cross, so every heading was missed. Split on `/\r?\n/`.

## Verification
- Full agent-sdk suite on Windows: 255 files, 3524 passed, 1 skipped — no unhandled errors.
- Both dot and default (CI-style) reporters pass the touched test files.

Closes #1752
Closes #1753
