### PR TITLE
feat(agent-sdk): 内置 /artifact 技能，与 Artifact 工具构成双通道触发

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -397,6 +397,7 @@ export default {
             { text: 'simplify — 代码简化与清理', link: '/sdk#skill-simplify' },
             { text: 'code-review — 代码审查', link: '/sdk#skill-code-review' },
             { text: 'deep-research — 深度主题调研', link: '/sdk#skill-deep-research' },
+            { text: 'artifact — 发布可分享网页', link: '/sdk#skill-artifact' },
           ],
         },
         {

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -439,7 +439,12 @@ Wave 提供 25 个内置工具，涵盖代码探索、文件操作、任务管�
 
 #### Artifact — 发布可分享网页 {#tool-artifact}
 
-将本地已写好的 `.html`/`.md` 文件发布为**默认私有**的可分享网页（Claude Code 风格），返回可传播的 URL。默认禁用，需在设置中开启 `enableArtifact` 后才注册该工具。
+将本地已写好的 `.html`/`.md` 文件发布为**默认私有**的可分享网页（Claude Code 风格），返回可传播的 URL。默认禁用，需在设置中开启 `enableArtifact` 后才注册该工具与 `/artifact` 技能。
+
+**双通道触发**：
+
+- **自然语言触发（工具）**：模型可自动调用 `Artifact` 工具，工具描述覆盖「发布 / 分享 / 做成网页 / 给链接」等语义（含中文提示词），无需用户记忆特定命令。
+- **人工触发（内置技能 `/artifact`）**：输入 `/` 即可在命令选择器中看到，适合不熟悉提示词编写的用户。技能内容仅指示模型调用 `Artifact` 工具（参数经 `$ARGUMENTS` 透传），**不含任何发布逻辑**——发布 / 校验 / 权限确认 / 会话映射全部由工具完成。技能声明了 `disable-model-invocation: true`，模型不会自行调用该技能，两个通道互不干扰。
 
 | 参数 | 类型 | 说明 |
 |------|------|------|
@@ -1128,6 +1133,14 @@ await agent.triggerWorktreeRemoveHook('/path/to/worktree');
 
 运行后可通过 `/workflows` 跟踪工作流进度。
 
+### artifact — 发布可分享网页 {#skill-artifact}
+
+将本地 `.html`/`.md` 文件发布为**默认私有**的可分享网页，并返回可传播的 URL。
+
+- **名称**: `artifact`
+- **使用方式**: `/artifact` 或 `/artifact <文件路径>`
+- **特性**: 与 [Artifact 工具](#tool-artifact) 同 gate（`enableArtifact`），禁用时不注册；声明 `disable-model-invocation: true`，仅人工触发、模型不可自动调用。技能内容仅指示模型调用 `Artifact` 工具——无参数时由模型根据对话上下文推断要发布的文件（不确定则询问用户），带参数时经 `$ARGUMENTS` 原样透传给工具的 `file_path`；发布 / 校验 / 权限确认 / 会话映射全部由工具完成，技能不含也不绕过这些逻辑。
+
 ## 13. 内置 Subagents {#builtin-subagents}
 
 ### Bash — 命令执行 {#subagent-bash}
@@ -1335,7 +1348,7 @@ Wave 提供了一个强大的内置 `/settings` skill，作为用户与 Wave 配
 - `language`：AI 通信首选语言（如 `"zh"`、`"en"`）。
 - `autoMemoryEnabled`：启用或禁用自动记忆（默认：`true`）。
 - `autoMemoryFrequency`：自动记忆提取频率（默认：`1`）。
-- `enableArtifact`：启用 Artifact 工具（默认：`false`）。未设置时跟随代码默认值（当前默认禁用）；设为 `true` 后注册 [Artifact 工具](#tool-artifact)，将本地 HTML/Markdown 发布为可分享网页。
+- `enableArtifact`：启用 Artifact 工具（默认：`false`）。未设置时跟随代码默认值（当前默认禁用）；设为 `true` 后注册 [Artifact 工具](#tool-artifact) 与 `/artifact` 内置技能，将本地 HTML/Markdown 发布为可分享网页。
 - `worktree.baseRef`：新建 worktree 的基准引用。`"fresh"`（默认）基于 `origin/<默认分支>` 创建新分支；`"head"` 基于当前本地 HEAD 创建，跳过 origin 解析与网络 fetch。适用于基于尚未推送的本地分支工作的场景。
 
 ## 15. 官方插件市场 {#plugin-marketplaces}

--- a/docs/specs/core/artifact-tool.md
+++ b/docs/specs/core/artifact-tool.md
@@ -11,6 +11,7 @@ order: 35
 > 对齐 Claude Code 的内建 Artifact 工具：把本地 `.html`/`.md` 文件发布为默认私有的可分享网页（claude.ai 风格），并通过 WebFetch 拦截读取已发布的 artifact 页面。
 > 服务端契约已落地（codechat 自托管同源实现）：`POST /api/frame/deploy/direct`（发布）、`GET /api/frame/{slug}?via=model_read`（元数据）、`GET /api/frame/{slug}/content?v={version}`（正文，同源 + Bearer 鉴权，无独立域名/assetToken 流程）。
 > 已拍板的简化决定：零新增配置（API 端点复用 Server URL origin：`options.serverUrl > WAVE_SERVER_URL > 默认值`，不新增 baseUrl 配置项）；客户端只实现 inline 直传一条路径（无 signed URL / DIRECT_UPLOAD）；无 AUTO_OPEN / FRAME_TIMING / OWNERSHIP_FRAME 遥测；**启用开关 `enableArtifact`（未设置时跟随代码默认值常量，当前默认禁用**——后端未上线先不发功能，内测/灰度通过 `enableArtifact: true` 显式打开；后端上线后翻转默认值常量为启用）。`disableArtifact` opt-out 开关等 GA 后再对齐 CC，本期不实现。
+> 触发方式定案（双通道并存，2026-08-13）：**模型经自然语言自动调用 `Artifact` 工具**（description 覆盖"发布/分享/做成网页/给链接"语义，中文提示词同样触发）+ **内置技能 `/artifact` 人工斜杠触发**（builtin SKILL.md，`disable-model-invocation: true` 仅人工、模型不可经 Skill 工具调用该技能）。用户在输入框输入 `/` 即可在技能列表看到该命令并一键触发，无需知道怎么写提示词。**技能本身不含任何发布逻辑**——其内容仅指示模型调用 `Artifact` 工具（参数经 `$ARGUMENTS`/`$1` 透传），发布/校验/权限确认/会话映射全部由工具完成，技能不绕过也不复制这些逻辑。
 > 范围：wave-agent 客户端侧工具 + WebFetch 拦截。分享管理（`POST /api/frame/{slug}/share`、pinned_version）由服务端/网页外壳承担，客户端仅发布私有页面并探测分享状态。
 
 ## 用户场景与测试 *（必填）*
@@ -32,6 +33,24 @@ order: 35
 5. **假设** `favicon` 包含非 emoji 字符（如文字、URL、HTML markup），**当** 工具执行时，**则** 返回 `success: false` 与错误提示。
 6. **假设** 发布内容超过 16MB（服务端返回 413），**当** 工具执行时，**则** 返回 `success: false` 与大小超限的错误。
 7. **假设** 客户端未登录（无有效 token），**当** 工具执行时，**则** 返回鉴权错误并提示先登录。
+
+### 用户故事：内置技能 /artifact 人工触发（优先级：P1）
+
+作为用户，我希望在不知道如何用自然语言描述发布需求时，通过在输入框输入 `/` 看到并选择 `artifact` 命令来触发发布，以便一键使用而不依赖提示词技巧。
+
+**为什么是这个优先级**：技能是"不会写提示词"用户的入口，与模型自动调用工具构成双通道，均为发布核心路径。**技能只是给用户的快捷入口**：其内容仅指示模型调用 `Artifact` 工具，不含任何发布逻辑——发布、校验、权限确认、会话映射全部由工具完成。
+
+**独立测试**：`enableArtifact` 开启时断言 `getSlashCommands()` 包含 `artifact` 技能命令（描述带 `Skill: ` 前缀、归入 popup 技能分组）；模型经 Skill 工具调用 artifact 技能被拒绝（`disable-model-invocation`）。
+
+**验收场景**：
+
+1. **假设** `enableArtifact` 已开启，**当** 用户在输入框输入 `/` 时，**则** popup 技能列表显示 `artifact` 命令（描述形如"发布本地 HTML/Markdown 为可分享网页"），用户选择即可触发。
+2. **假设** 用户输入 `/artifact`（无参数），**当** 命令执行时，**则** 技能内容注入主 agent（内容仅指示调用 `Artifact` 工具），agent 从会话上下文推断要发布的文件（不明确时先询问用户），随后调用 `Artifact` 工具发布并返回 URL。
+3. **假设** 用户输入 `/artifact <file_path>`（带参数），**当** 命令执行时，**则** 文件路径作为参数（`$ARGUMENTS`/`$1` 语义）透传给技能内容，agent 直接以该路径为 `file_path` 调用 `Artifact` 工具，不再询问。
+4. **假设** 模型试图通过 `Skill` 工具调用 artifact 技能，**当** 调用时，**则** 返回 "not available for model invocation"（`disable-model-invocation: true`）；模型的发布入口只有 `Artifact` 工具，两通道不重叠。
+5. **假设** 用户经 `/artifact` 触发发布，**当** `Artifact` 工具执行时，**则** 与自然语言路径走完全相同的工具调用：文件存在性/扩展名/大小校验、权限确认（首次）与同会话自动允许（重复发布）、409 冲突与 stale_version_guard 全部生效——技能不含任何绕过或复制这些逻辑的实现。
+6. **假设** `enableArtifact` 未开启（默认禁用），**当** 会话初始化时，**则** artifact 技能不注册，popup 不显示 `/artifact`（与工具注册同 gate）。
+7. **假设** 运行中的会话中 `enableArtifact` 由禁用热重载为启用，**当** 配置重载时，**则** `/artifact` 技能命令即时注册、popup 可见；反向关闭时即时注销（与工具注册同 gate）。
 
 ### 用户故事：WebFetch 读取 artifact 页面（优先级：P1）
 
@@ -93,18 +112,19 @@ order: 35
 
 **验收场景**：
 
-1. **假设** 未配置 `enableArtifact`（默认状态，后端上线前），**当** 会话初始化时，**则** `Artifact` 工具不注册、不可调用。
-2. **假设** settings.json 配置 `enableArtifact: true`，**当** 会话初始化时，**则** `Artifact` 工具注册、可调用（内测/灰度入口）。
-3. **假设** 后端已上线、代码默认值常量已翻转为启用，**当** 会话初始化时，**则** 未配置 `enableArtifact` 也默认启用。
+1. **假设** 未配置 `enableArtifact`（默认状态，后端上线前），**当** 会话初始化时，**则** `Artifact` 工具不注册、不可调用，`/artifact` 技能命令同样不注册、popup 不显示。
+2. **假设** settings.json 配置 `enableArtifact: true`，**当** 会话初始化时，**则** `Artifact` 工具注册、可调用，`/artifact` 技能命令同步注册、popup 可见（内测/灰度入口）。
+3. **假设** 后端已上线、代码默认值常量已翻转为启用，**当** 会话初始化时，**则** 未配置 `enableArtifact` 也默认启用（工具与技能命令均注册）。
 4. **假设** Artifact 被禁用（默认或显式），**当** WebFetch 收到 artifact URL 时，**则** 不进入专用读取通道（按普通 URL 处理或报错），不执行 `via=model_read` 调用。
-5. **假设** 运行中的会话未配置 `enableArtifact`（工具未注册），**当** 用户在 settings.json 中改为 `enableArtifact: true` 触发配置热重载时，**则** `Artifact` 工具即时注册、可调用，无需重启会话。
-6. **假设** 运行中的会话已启用 `enableArtifact`，**当** 用户改为 `false` 触发配置热重载时，**则** `Artifact` 工具即时注销、不可调用，同时 WebFetch 的 artifact URL 拦截（逐调用检查 `isArtifactEnabled`）同步失效。
-7. **假设** 服务端 `GET /api/wave/settings` 下发了 `enableArtifact: true`（remote settings），**当** 会话初始化或轮询（60min + 304 checksum）检测到变更时，**则** remote 值优先于本地 settings.json 与代码默认值，`Artifact` 工具按 remote 值注册，WebFetch 拦截同样生效（管理员远程灰度/回滚入口）。
-8. **假设** 服务端下发的 remote `enableArtifact` 与本地 settings.json 冲突，**当** 合并配置时，**则** remote 胜出（last-write-wins，与 `model`、`permissions.permissionMode` 等 managed 字段语义一致）；未下发时回退本地/默认值。
+5. **假设** 运行中的会话未配置 `enableArtifact`（工具未注册），**当** 用户在 settings.json 中改为 `enableArtifact: true` 触发配置热重载时，**则** `Artifact` 工具即时注册、可调用，`/artifact` 技能命令同步注册、popup 可见，无需重启会话。
+6. **假设** 运行中的会话已启用 `enableArtifact`，**当** 用户改为 `false` 触发配置热重载时，**则** `Artifact` 工具即时注销、不可调用，`/artifact` 技能命令同步注销、popup 隐藏，同时 WebFetch 的 artifact URL 拦截（逐调用检查 `isArtifactEnabled`）同步失效。
+7. **假设** 服务端 `GET /api/wave/settings` 下发了 `enableArtifact: true`（remote settings），**当** 会话初始化或轮询（60min + 304 checksum）检测到变更时，**则** remote 值优先于本地 settings.json 与代码默认值，`Artifact` 工具按 remote 值注册，`/artifact` 技能命令按同 gate 注册，WebFetch 拦截同样生效（管理员远程灰度/回滚入口）。
+8. **假设** 服务端下发的 remote `enableArtifact` 与本地 settings.json 冲突，**当** 合并配置时，**则** remote 胜出（last-write-wins，与 `model`、`permissions.permissionMode` 等 managed 字段语义一致），工具与技能命令均按 remote 值注册/注销；未下发时回退本地/默认值。
 
 ### 非功能需求
 
 - **零新增配置**：API 端点相对 Server URL origin 硬编码（`options.serverUrl > WAVE_SERVER_URL > 默认值`，经 authService.getServerUrl() 获取），不新增 baseUrl/artifactUrl 配置项。
+- **双通道不重叠**：`Artifact` 工具保留模型自动调用（自然语言触发）；内置技能 `/artifact`（builtin SKILL.md，`disable-model-invocation: true`）仅人工斜杠触发。技能仅指示模型调用 `Artifact` 工具，不含任何发布逻辑，与自然语言路径走完全相同的工具调用；技能注册与工具注册同 gate（`isArtifactEnabled`），禁用时两者都不暴露。
 - **鉴权**：发布（deploy/direct）与读取（model_read、contentUrl）请求均携带当前登录 token（Bearer）；未登录返回明确错误。
 - **大小上限**：发布内容上限 16MB（413 透传为友好错误）。
 - **文件大小策略**：读取时 >~2KB 的 HTML 落盘到临时文件（返回路径 + head 预览），避免工具结果膨胀。

--- a/packages/agent-sdk/builtin/skills/artifact/SKILL.md
+++ b/packages/agent-sdk/builtin/skills/artifact/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: artifact
+description: Publish a local HTML or Markdown file as a shareable web page
+disable-model-invocation: true
+---
+
+# Artifact: Publish a File as a Shareable Web Page
+
+Publish a local `.html` or `.md` file as a default-private, shareable web page.
+
+- If a file path was provided ($ARGUMENTS / $1), use it directly as the `file_path`.
+- Otherwise, infer which file to publish from the conversation context; if it is not clear, ask the user which file to publish.
+
+Call the `Artifact` tool with the resolved `file_path` (and `favicon` if relevant), then report the resulting URL to the user.

--- a/packages/agent-sdk/src/managers/skillManager.ts
+++ b/packages/agent-sdk/src/managers/skillManager.ts
@@ -20,6 +20,7 @@ import {
   executeBashCommands,
 } from "../utils/markdownParser.js";
 import { getBuiltinSkillsDir } from "../utils/configPaths.js";
+import { isArtifactEnabled } from "../services/artifactAvailability.js";
 
 import { Container } from "../utils/container.js";
 import { logger } from "../utils/globalLogger.js";
@@ -341,6 +342,13 @@ export class SkillManager extends EventEmitter {
             type: collection.type,
           };
 
+          // Feature-gated builtin skills (e.g. artifact behind
+          // enableArtifact) are skipped while the gate is off, mirroring
+          // ToolManager's registration gate for the Artifact tool.
+          if (this.isSkillGatedOff(skillMetadata)) {
+            continue;
+          }
+
           // Create full skill object with content
           const skill: Skill = {
             ...skillMetadata,
@@ -397,6 +405,31 @@ export class SkillManager extends EventEmitter {
     }
 
     return directories;
+  }
+
+  /**
+   * Whether a discovered skill is a feature-gated builtin skill whose gate
+   * is currently off. Mirrors ToolManager's gate for the Artifact tool so
+   * the /artifact skill command stays in sync with enableArtifact.
+   */
+  private isSkillGatedOff(metadata: SkillMetadata): boolean {
+    if (metadata.type !== "builtin") {
+      return false;
+    }
+    if (metadata.name === "artifact") {
+      return !isArtifactEnabled(this.workdir);
+    }
+    return false;
+  }
+
+  /**
+   * Re-evaluate feature-gated builtin skills after a live configuration
+   * reload (same hook as ToolManager.reloadFeatureGatedTools). Re-scans
+   * skill directories and emits "refreshed" so slash-command registration
+   * follows the gate.
+   */
+  async reloadFeatureGatedSkills(): Promise<void> {
+    await this.refreshSkills();
   }
 
   /**

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -306,6 +306,11 @@ export function setupAgentContainer(
       // Re-evaluate feature-gated tools (e.g. Artifact behind
       // enableArtifact) so toggling the flag applies without a restart.
       toolManager.reloadFeatureGatedTools();
+      // Same gate for the builtin /artifact skill: refresh emits "refreshed"
+      // so slash-command registration follows enableArtifact.
+      void skillManager.reloadFeatureGatedSkills().catch((error) => {
+        logger.error("Failed to reload feature-gated skills:", error);
+      });
     },
   });
   container.register("LiveConfigManager", liveConfigManager);

--- a/packages/agent-sdk/tests/managers/skillManager.test.ts
+++ b/packages/agent-sdk/tests/managers/skillManager.test.ts
@@ -34,6 +34,7 @@ import {
   formatSkillError,
 } from "../../src/utils/skillParser.js";
 import { executeBashCommands } from "../../src/utils/markdownParser.js";
+import { isArtifactEnabled } from "../../src/services/artifactAvailability.js";
 
 vi.mock("fs/promises");
 vi.mock("../../src/services/fileWatcher.js");
@@ -54,6 +55,10 @@ vi.mock("../../src/utils/markdownParser.js", async () => {
   };
 });
 
+vi.mock("../../src/services/artifactAvailability.js", () => ({
+  isArtifactEnabled: vi.fn(),
+}));
+
 describe("SkillManager", () => {
   let skillManager: SkillManager;
   let container: Container;
@@ -65,6 +70,7 @@ describe("SkillManager", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(isArtifactEnabled).mockReturnValue(false);
 
     mockFileWatcher = {
       watchFile: vi.fn().mockResolvedValue(undefined),
@@ -1471,6 +1477,98 @@ describe("SkillManager", () => {
       expect(watchedPaths).toContain("/home/user/.agents/skills");
 
       await manager.destroy();
+    });
+  });
+
+  describe("feature-gated artifact skill", () => {
+    function mockArtifactSkillDiscovery() {
+      vi.mocked(readdir).mockImplementation(async (path) => {
+        const p = path.toString().replace(/\\/g, "/");
+        if (p.includes("builtin-skills")) {
+          return [
+            { name: "artifact", isDirectory: () => true },
+          ] as unknown as Awaited<ReturnType<typeof readdir>>;
+        }
+        return [] as unknown as Awaited<ReturnType<typeof readdir>>;
+      });
+      vi.mocked(stat).mockResolvedValue(
+        {} as unknown as Awaited<ReturnType<typeof stat>>,
+      );
+      vi.mocked(parseSkillFile).mockReturnValue({
+        isValid: true,
+        skillMetadata: {
+          name: "artifact",
+          description:
+            "Publish a local HTML or Markdown file as a shareable web page",
+          type: "builtin",
+          skillPath: "/test/builtin-skills/artifact/SKILL.md",
+          disableModelInvocation: true,
+        },
+        content: "---\nname: artifact\n---\ncontent",
+        frontmatter: { name: "artifact" },
+        validationErrors: [],
+      } as unknown as ReturnType<typeof parseSkillFile>);
+    }
+
+    it("should skip the artifact skill while the gate is off", async () => {
+      vi.mocked(isArtifactEnabled).mockReturnValue(false);
+      mockArtifactSkillDiscovery();
+
+      await skillManager.initialize();
+
+      expect(skillManager.getSkillMetadata("artifact")).toBeUndefined();
+      expect(
+        skillManager.getAvailableSkills().find((s) => s.name === "artifact"),
+      ).toBeUndefined();
+      expect(await skillManager.loadSkill("artifact")).toBeNull();
+    });
+
+    it("should register the artifact skill when the gate is on", async () => {
+      vi.mocked(isArtifactEnabled).mockReturnValue(true);
+      mockArtifactSkillDiscovery();
+
+      await skillManager.initialize();
+
+      const metadata = skillManager.getSkillMetadata("artifact");
+      expect(metadata).toBeDefined();
+      expect(metadata?.disableModelInvocation).toBe(true);
+      expect(await skillManager.loadSkill("artifact")).not.toBeNull();
+    });
+
+    it("should register/unregister the artifact skill on reloadFeatureGatedSkills", async () => {
+      vi.mocked(isArtifactEnabled).mockReturnValue(false);
+      mockArtifactSkillDiscovery();
+      await skillManager.initialize();
+      expect(skillManager.getSkillMetadata("artifact")).toBeUndefined();
+
+      vi.mocked(isArtifactEnabled).mockReturnValue(true);
+      await skillManager.reloadFeatureGatedSkills();
+      expect(skillManager.getSkillMetadata("artifact")).toBeDefined();
+
+      vi.mocked(isArtifactEnabled).mockReturnValue(false);
+      await skillManager.reloadFeatureGatedSkills();
+      expect(skillManager.getSkillMetadata("artifact")).toBeUndefined();
+    });
+
+    it("should register /artifact slash command only while the gate is on", async () => {
+      vi.mocked(isArtifactEnabled).mockReturnValue(false);
+      mockArtifactSkillDiscovery();
+      container.register("SkillManager", skillManager);
+      const slashCommandManager = new SlashCommandManager(container, {
+        workdir: "/test/workdir",
+      });
+      slashCommandManager.initialize();
+
+      await skillManager.initialize();
+      expect(slashCommandManager.hasCommand("artifact")).toBe(false);
+
+      vi.mocked(isArtifactEnabled).mockReturnValue(true);
+      await skillManager.reloadFeatureGatedSkills();
+      expect(slashCommandManager.hasCommand("artifact")).toBe(true);
+
+      vi.mocked(isArtifactEnabled).mockReturnValue(false);
+      await skillManager.reloadFeatureGatedSkills();
+      expect(slashCommandManager.hasCommand("artifact")).toBe(false);
     });
   });
 });

--- a/packages/agent-sdk/tests/tools/skillTool.test.ts
+++ b/packages/agent-sdk/tests/tools/skillTool.test.ts
@@ -13,9 +13,13 @@ vi.mock("fs/promises", () => ({
 }));
 
 // Mock os module
-vi.mock("os", () => ({
-  homedir: vi.fn(() => "/mock/home"),
-}));
+vi.mock("os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("os")>();
+  return {
+    ...actual,
+    homedir: vi.fn(() => "/mock/home"),
+  };
+});
 
 // Mock path module
 vi.mock("path", async () => {

--- a/packages/agent-sdk/tests/tools/skillTool_fork.test.ts
+++ b/packages/agent-sdk/tests/tools/skillTool_fork.test.ts
@@ -12,9 +12,13 @@ vi.mock("fs/promises", () => ({
 }));
 
 // Mock os module
-vi.mock("os", () => ({
-  homedir: vi.fn(() => "/mock/home"),
-}));
+vi.mock("os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("os")>();
+  return {
+    ...actual,
+    homedir: vi.fn(() => "/mock/home"),
+  };
+});
 
 // Mock path module
 vi.mock("path", async () => {


### PR DESCRIPTION
为 Artifact 发布能力新增人工触发通道：内置技能 /artifact，与既有的 Artifact 工具（自然语言自动触发）并存、互不干扰。

## 变更内容

- **新增内置技能** packages/agent-sdk/builtin/skills/artifact/SKILL.md：`disable-model-invocation: true`（仅人工斜杠触发，模型不可经 Skill 工具调用）；内容仅指示模型调用 Artifact 工具，参数经 `$ARGUMENTS`/`$1` 透传，不含任何发布逻辑
- **SkillManager 门控**：新增 `isSkillGatedOff()` + `reloadFeatureGatedSkills()`，内置 artifact 技能与 Artifact 工具同 gate（`isArtifactEnabled`，enableArtifact 设置），禁用时不注册
- **热重载**：containerSetup onReload 回调 fire-and-forget 刷新技能（emit refreshed → SlashCommandManager 重新注册），enableArtifact 动态开关即时生效
- **测试**：gate off/on/热切换 + SlashCommandManager 集成（refreshed 事件驱动）、skillTool os mock 修复保留 default export；全量 255 文件 / 3528 测试通过
- **spec**：新增用户故事「内置技能 /artifact 人工触发」（7 个验收场景），功能开关故事同步补充技能注册/注销场景
- **文档**：sdk.md 工具章节新增双通道触发说明 + 内置技能章节 + enableArtifact 设置行，docs 侧边栏同步