### PR TITLE
feat(agent-sdk): persist MCP tool images for non-vision models

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -2,6 +2,7 @@ import { type CallAgentOptions } from "../services/aiService.js";
 import * as aiService from "../services/aiService.js";
 import { convertMessagesForAPI } from "../utils/convertMessagesForAPI.js";
 import { supportsVision } from "../utils/modelCapabilities.js";
+import { persistToolImages } from "../utils/toolImagePersistence.js";
 import {
   parseTaskNotificationXml,
   taskNotificationToXml,
@@ -2568,6 +2569,21 @@ ${question}`;
         context,
       );
 
+      // MCP tools can return images (e.g. Figma screenshots) as in-memory
+      // base64. When this agent's model cannot see them, persist each image to
+      // a temp file so the non-vision path in convertMessagesForAPI can attach
+      // `[Image source: <path>]` metadata and the main model can delegate
+      // recognition to the vision subagent. Vision-capable models keep the
+      // inline base64 — no disk writes.
+      let toolImages = toolResult.images;
+      if (
+        toolImages &&
+        toolImages.length > 0 &&
+        !supportsVision(this.getModelConfig().capabilities)
+      ) {
+        toolImages = persistToolImages(toolImages);
+      }
+
       // Build result content, adding truncation warning if JSON was recovered
       let toolResultContent =
         toolResult.content ||
@@ -2592,7 +2608,7 @@ ${question}`;
         backgroundedByUser: toolResult.backgroundedByUser,
         assistantAutoBackgrounded: toolResult.assistantAutoBackgrounded,
         startLineNumber: toolResult.startLineNumber,
-        images: toolResult.images,
+        images: toolImages,
         timestamp: Date.now(),
       });
 

--- a/packages/agent-sdk/src/managers/mcpManager.ts
+++ b/packages/agent-sdk/src/managers/mcpManager.ts
@@ -875,6 +875,7 @@ export class McpManager {
             type: string;
             text?: string;
             data?: string;
+            mimeType?: string;
             resource?: { uri: string };
             [key: string]: unknown;
           }) => {
@@ -883,7 +884,7 @@ export class McpManager {
             } else if (c.type === "image" && c.data) {
               images.push({
                 data: c.data,
-                mediaType: "image/png", // Default to PNG
+                mediaType: c.mimeType || "image/png", // MCP standard mimeType, PNG fallback
               });
             } else if (c.type === "resource") {
               textContent.push(`[Resource: ${c.resource?.uri || ""}]`);

--- a/packages/agent-sdk/src/types/messaging.ts
+++ b/packages/agent-sdk/src/types/messaging.ts
@@ -54,6 +54,7 @@ export interface ToolBlock {
     // Add image data support
     data: string; // Base64 encoded image data
     mediaType?: string; // Media type of the image
+    path?: string; // Persisted temp file path (MCP images under a non-vision model)
   }>;
   id?: string;
   name?: string;

--- a/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
+++ b/packages/agent-sdk/src/utils/convertMessagesForAPI.ts
@@ -136,11 +136,29 @@ export function convertMessagesForAPI(
                   content: contentParts,
                 });
               } else {
-                // Non-vision model: replace images with a text placeholder
+                // Non-vision model: replace images with a text placeholder and
+                // append [Image source: <path>] metadata for MCP images that
+                // were persisted to temp files, so the main model can delegate
+                // recognition to a vision subagent (which reads the path with
+                // the Read tool). Images without a persisted path (e.g. legacy
+                // history) fall back to the placeholder only.
+                const contentParts: ChatCompletionContentPart[] = [
+                  {
+                    type: "text",
+                    text: "[Tool returned an image, but the current model does not support image recognition]",
+                  },
+                ];
+                toolBlock.images.forEach((image) => {
+                  if (image.path) {
+                    contentParts.push({
+                      type: "text",
+                      text: `[Image source: ${image.path}]`,
+                    });
+                  }
+                });
                 imageUserMessages.push({
                   role: "user",
-                  content:
-                    "[Tool returned an image, but the current model does not support image recognition]",
+                  content: contentParts,
                 });
               }
             }

--- a/packages/agent-sdk/src/utils/messageOperations.ts
+++ b/packages/agent-sdk/src/utils/messageOperations.ts
@@ -45,7 +45,7 @@ export interface UpdateToolBlockParams {
   name?: string;
   shortResult?: string;
   startLineNumber?: number;
-  images?: Array<{ data: string; mediaType?: string }>;
+  images?: Array<{ data: string; mediaType?: string; path?: string }>;
   compactParams?: string;
   parametersChunk?: string; // Incremental parameter updates for streaming
   backgroundTaskId?: string;

--- a/packages/agent-sdk/src/utils/toolImagePersistence.ts
+++ b/packages/agent-sdk/src/utils/toolImagePersistence.ts
@@ -1,0 +1,67 @@
+/**
+ * Persistence for MCP tool-returned images.
+ *
+ * MCP tools can return image content blocks as in-memory base64. When the
+ * agent's model does not support vision, the image is written to a temp file
+ * so convertMessagesForAPI can attach `[Image source: <path>]` metadata and
+ * the main model can delegate recognition to the vision subagent (which reads
+ * the path with the Read tool). Vision-capable models keep the inline base64
+ * and never write to disk.
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { logger } from "./globalLogger.js";
+
+const MCP_IMAGES_DIR = path.join(os.tmpdir(), "wave-mcp-images");
+
+/** Map MCP mimeType to a file extension. Unknown types fall back to .png. */
+const MIME_TO_EXT: Record<string, string> = {
+  "image/png": ".png",
+  "image/jpeg": ".jpg",
+  "image/webp": ".webp",
+  "image/gif": ".gif",
+  "image/bmp": ".bmp",
+  "image/svg+xml": ".svg",
+  "image/avif": ".avif",
+  "image/x-icon": ".ico",
+  "image/tiff": ".tiff",
+};
+
+export interface PersistedToolImage {
+  data: string; // Base64 encoded image data
+  mediaType?: string; // Media type of the image
+  path?: string; // Temp file path, set when the image was persisted
+}
+
+/**
+ * Persist base64 images to temp files under /tmp/wave-mcp-images/.
+ * Uses the OS tmpdir for simplicity and automatic OS cleanup (same convention
+ * as /tmp/wave-tool-results/). Returns each image unchanged (no path) when the
+ * write fails, so the caller degrades to the placeholder-only behavior.
+ */
+export function persistToolImages(
+  images: Array<{ data: string; mediaType?: string }>,
+): PersistedToolImage[] {
+  return images.map((image) => {
+    try {
+      fs.mkdirSync(MCP_IMAGES_DIR, { recursive: true });
+      // Strip a data: URL prefix if present (MCP spec carries raw base64, but
+      // be defensive about dataURL-formatted data).
+      let data = image.data;
+      if (data.startsWith("data:")) {
+        const commaIndex = data.indexOf(",");
+        data = commaIndex >= 0 ? data.slice(commaIndex + 1) : data;
+      }
+      const ext = MIME_TO_EXT[image.mediaType || ""] || ".png";
+      const id = `${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+      const filePath = path.join(MCP_IMAGES_DIR, `mcp-image_${id}${ext}`);
+      fs.writeFileSync(filePath, Buffer.from(data, "base64"));
+      return { ...image, path: filePath };
+    } catch (error) {
+      logger?.error("Failed to persist MCP tool image:", error);
+      return image;
+    }
+  });
+}

--- a/packages/agent-sdk/tests/managers/aiManager.mcpImagePersistence.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.mcpImagePersistence.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Container } from "../../src/utils/container.js";
+import { TaskManager } from "../../src/services/taskManager.js";
+import { AIManager } from "../../src/managers/aiManager.js";
+import type { MessageManager } from "../../src/managers/messageManager.js";
+import type { ToolManager } from "../../src/managers/toolManager.js";
+import type { GatewayConfig, ModelConfig } from "../../src/types/index.js";
+import * as aiService from "../../src/services/aiService.js";
+import { persistToolImages } from "../../src/utils/toolImagePersistence.js";
+
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock node:fs
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock("../../src/utils/gitUtils.js", () => ({
+  isGitRepository: vi.fn(),
+}));
+
+// Mock the aiService module
+vi.mock("../../src/services/aiService.js", () => ({
+  callAgent: vi.fn().mockImplementation(async (options) => {
+    if (options.onContentUpdate) options.onContentUpdate("Test response");
+    return {
+      content: "Test response",
+      usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+      tool_calls: [],
+    };
+  }),
+  compactMessages: vi.fn().mockResolvedValue({
+    content: "Compacted content",
+    usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+  }),
+  transformMessagesForExplicitCache: vi.fn((m) => m),
+  extendUsageWithCacheMetrics: vi.fn((u) => u),
+}));
+
+// Mock the memory service
+vi.mock("../../src/services/memory.js", () => ({
+  MemoryService: vi.fn().mockImplementation(() => ({
+    getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+    getAutoMemoryDirectory: vi.fn().mockReturnValue("/mock/auto-memory"),
+    ensureAutoMemoryDirectory: vi.fn().mockResolvedValue(undefined),
+    getAutoMemoryContent: vi.fn().mockResolvedValue(""),
+  })),
+  getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+}));
+
+vi.mock("../../src/utils/messageOperations.js", () => ({}));
+
+vi.mock("../../src/utils/convertMessagesForAPI.js", () => ({
+  convertMessagesForAPI: vi.fn().mockReturnValue([]),
+}));
+
+// Mock the image persistence util so the unit-level file writes are isolated
+// in tests/utils/toolImagePersistence.test.ts
+vi.mock("../../src/utils/toolImagePersistence.js", () => ({
+  persistToolImages: vi.fn((images) =>
+    images.map((image: { data: string }) => ({
+      ...image,
+      path: `/tmp/wave-mcp-images/mcp-image_1_abc123.png`,
+    })),
+  ),
+}));
+
+const mockImages = [{ data: "aGVsbG8=", mediaType: "image/png" }];
+
+function createAIManager(modelConfig: ModelConfig) {
+  const container = new Container();
+
+  const mockMessageManager = {
+    getSessionId: vi.fn().mockReturnValue("test-session-id"),
+    getMessages: vi.fn().mockReturnValue([]),
+    addAssistantMessage: vi.fn(),
+    addUserMessage: vi.fn(),
+    updateCurrentMessageContent: vi.fn(),
+    updateToolBlock: vi.fn(),
+    mergeAssistantAdditionalFields: vi.fn(),
+    setMessages: vi.fn(),
+    getLatestTotalTokens: vi.fn().mockReturnValue(0),
+    getCombinedMemory: vi.fn().mockResolvedValue(""),
+    getMemoryForInjection: vi.fn().mockResolvedValue({ prependContent: "" }),
+    processTriggeredRules: vi.fn().mockReturnValue([]),
+    addErrorBlock: vi.fn(),
+    setlatestTotalTokens: vi.fn(),
+    saveSession: vi.fn().mockResolvedValue(undefined),
+    compactMessagesAndUpdateSession: vi.fn(),
+    getTranscriptPath: vi.fn().mockReturnValue("/test/transcript.md"),
+    triggerFileRead: vi.fn(),
+    finalizeStreamingBlocks: vi.fn(),
+    finalizeAbortedToolBlocks: vi.fn(),
+  } as unknown as MessageManager;
+
+  const mockToolManager = {
+    getToolsConfig: vi.fn().mockReturnValue([]),
+    getTools: vi.fn().mockReturnValue([]),
+    list: vi.fn().mockReturnValue([]),
+    execute: vi
+      .fn()
+      .mockResolvedValue({
+        success: true,
+        content: "test result",
+        images: mockImages,
+      }),
+    isConcurrencySafe: vi.fn().mockReturnValue(true),
+  } as unknown as ToolManager;
+
+  const taskManager = {
+    on: vi.fn(),
+    listTasks: vi.fn().mockResolvedValue([]),
+  } as unknown as TaskManager;
+
+  const mockConfigurationService = {
+    setOptions: vi.fn(),
+    resolveGatewayConfig: vi.fn().mockReturnValue({
+      apiKey: "test-api-key",
+      baseURL: "https://test-gateway.com",
+    } as GatewayConfig),
+    resolveModelConfig: vi.fn().mockReturnValue(modelConfig),
+    resolveMaxInputTokens: vi.fn().mockReturnValue(96000),
+    resolveAutoMemoryEnabled: vi.fn().mockReturnValue(true),
+    resolveLanguage: vi.fn().mockReturnValue(undefined),
+    getEnvironmentVars: vi.fn().mockReturnValue({}),
+  };
+
+  container.register("ConfigurationService", mockConfigurationService);
+  container.register("MessageManager", mockMessageManager);
+  container.register("ToolManager", mockToolManager);
+  container.register("TaskManager", taskManager);
+  container.register("MemoryService", {
+    getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+    getAutoMemoryDirectory: vi.fn().mockReturnValue("/mock/auto-memory"),
+    ensureAutoMemoryDirectory: vi.fn().mockResolvedValue(undefined),
+    getAutoMemoryContent: vi.fn().mockResolvedValue(""),
+  });
+  container.register("PermissionManager", {
+    getCurrentEffectiveMode: vi.fn().mockReturnValue("normal"),
+    clearTemporaryRules: vi.fn(),
+    getPlanFilePath: vi.fn().mockReturnValue(undefined),
+    setHasExitedPlanMode: vi.fn(),
+    hasExitedPlanModeInSession: vi.fn(() => false),
+    setNeedsPlanModeExitAttachment: vi.fn(),
+    getNeedsPlanModeExitAttachment: vi.fn(() => false),
+  } as unknown as Record<string, unknown>);
+  container.register("SubagentManager", {
+    getConfigurations: vi.fn().mockReturnValue([]),
+  });
+  container.register("SkillManager", {
+    getAvailableSkills: vi.fn().mockReturnValue([]),
+  });
+  container.register("MessageQueue", {
+    hasNotifications: vi.fn().mockReturnValue(false),
+    drainNotifications: vi.fn().mockReturnValue([]),
+  });
+
+  const aiManager = new AIManager(container, {
+    workdir: "/test/workdir",
+    stream: false,
+  });
+
+  // Mock addUserMessage to save session (simulating real behavior)
+  vi.mocked(mockMessageManager.addUserMessage).mockImplementation(() => {
+    mockMessageManager.saveSession();
+    return "msg-id";
+  });
+
+  return { aiManager, mockMessageManager, mockToolManager };
+}
+
+function triggerToolExecution() {
+  let callCount = 0;
+  vi.mocked(aiService.callAgent).mockImplementation(async () => {
+    callCount++;
+    if (callCount === 1) {
+      return {
+        content: "Test response with tools",
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+        tool_calls: [
+          {
+            type: "function" as const,
+            id: "test-tool-call",
+            function: { name: "test-tool", arguments: "{}" },
+          },
+        ],
+      };
+    }
+    return {
+      content: "Test response without tools",
+      usage: { prompt_tokens: 5, completion_tokens: 10, total_tokens: 15 },
+      tool_calls: [],
+    };
+  });
+}
+
+describe("AIManager MCP image persistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should persist tool images when the model does not support vision", async () => {
+    const { aiManager, mockMessageManager } = createAIManager({
+      model: "test-agent-model",
+      fastModel: "test-fast-model",
+      capabilities: { vision: false },
+    });
+    triggerToolExecution();
+
+    await aiManager.sendAIMessage({ recursionDepth: 0 });
+
+    expect(persistToolImages).toHaveBeenCalledWith(mockImages);
+    const updateCall = vi
+      .mocked(mockMessageManager.updateToolBlock)
+      .mock.calls.find((call) => call[0].stage === "end");
+    expect(updateCall).toBeDefined();
+    expect(updateCall![0].images).toEqual([
+      {
+        data: "aGVsbG8=",
+        mediaType: "image/png",
+        path: "/tmp/wave-mcp-images/mcp-image_1_abc123.png",
+      },
+    ]);
+  });
+
+  it("should not persist tool images when the model supports vision (default)", async () => {
+    const { aiManager, mockMessageManager } = createAIManager({
+      model: "test-agent-model",
+      fastModel: "test-fast-model",
+    });
+    triggerToolExecution();
+
+    await aiManager.sendAIMessage({ recursionDepth: 0 });
+
+    expect(persistToolImages).not.toHaveBeenCalled();
+    const updateCall = vi
+      .mocked(mockMessageManager.updateToolBlock)
+      .mock.calls.find((call) => call[0].stage === "end");
+    expect(updateCall).toBeDefined();
+    expect(updateCall![0].images).toEqual(mockImages);
+  });
+
+  it("should not call persistToolImages when the tool result has no images", async () => {
+    const { aiManager, mockToolManager } = createAIManager({
+      model: "test-agent-model",
+      fastModel: "test-fast-model",
+      capabilities: { vision: false },
+    });
+    vi.mocked(mockToolManager.execute).mockResolvedValue({
+      success: true,
+      content: "test result",
+    });
+    triggerToolExecution();
+
+    await aiManager.sendAIMessage({ recursionDepth: 0 });
+
+    expect(persistToolImages).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent-sdk/tests/managers/mcpManager.test.ts
+++ b/packages/agent-sdk/tests/managers/mcpManager.test.ts
@@ -1087,6 +1087,42 @@ describe("McpManager", () => {
       });
     });
 
+    it("should use the MCP standard mimeType field when provided", async () => {
+      // Mock tools list response
+      mockClient.listTools.mockResolvedValue({
+        tools: [
+          {
+            name: "jpeg_screenshot_tool",
+            description: "A JPEG screenshot tool",
+            inputSchema: { type: "object" },
+          },
+        ],
+      });
+
+      // Mock tool execution response with a mimeType on the image content
+      mockClient.callTool.mockResolvedValue({
+        content: [
+          { type: "text", text: "Screenshot captured" },
+          {
+            type: "image",
+            data: "jpeg_base64_data",
+            mimeType: "image/jpeg",
+          },
+        ],
+      });
+
+      await mcpManager.connectServer("test-server");
+
+      const result = await mcpManager.executeMcpTool(
+        "mcp__test-server__jpeg_screenshot_tool",
+        {},
+      );
+
+      expect(result.images).toEqual([
+        { data: "jpeg_base64_data", mediaType: "image/jpeg" },
+      ]);
+    });
+
     it("should handle tool result with multiple images", async () => {
       // Mock tools list response
       mockClient.listTools.mockResolvedValue({

--- a/packages/agent-sdk/tests/utils/convertMessagesForAPI.test.ts
+++ b/packages/agent-sdk/tests/utils/convertMessagesForAPI.test.ts
@@ -899,6 +899,161 @@ describe("convertMessagesForAPI", () => {
       expect(allContent).not.toContain("image_url");
     });
 
+    it("should append [Image source: <path>] for persisted tool images when supportsVision is false", () => {
+      const messages: Message[] = [
+        {
+          id: generateMessageId(),
+          role: "user",
+          blocks: [{ type: "text", content: "Take a screenshot" }],
+          timestamp: new Date().toISOString(),
+        },
+        {
+          id: generateMessageId(),
+          role: "assistant",
+          blocks: [
+            {
+              type: "tool",
+              id: "tool_img_1",
+              name: "get_screenshot",
+              parameters: '{"nodeId": "123"}',
+              stage: "end",
+              result: "Screenshot taken.",
+              success: true,
+              images: [
+                {
+                  data: "base64data",
+                  mediaType: "image/png",
+                  path: "/tmp/wave-mcp-images/mcp-image_1_abc123.png",
+                },
+              ],
+            },
+          ],
+          timestamp: new Date().toISOString(),
+        },
+      ];
+
+      const apiMessages = convertMessagesForAPI(messages, {
+        supportsVision: false,
+      });
+
+      type ContentPart = { type: string; text?: string };
+      const userMessages = apiMessages.filter((m) => m.role === "user");
+      const placeholderMessage = userMessages.find((m) => {
+        if (typeof m.content === "string") {
+          return m.content.includes("does not support image recognition");
+        }
+        if (Array.isArray(m.content)) {
+          const parts = m.content as ContentPart[];
+          return parts.some(
+            (p) =>
+              p.type === "text" &&
+              typeof p.text === "string" &&
+              p.text.includes("does not support image recognition"),
+          );
+        }
+        return false;
+      });
+      expect(placeholderMessage).toBeDefined();
+      const parts = placeholderMessage!.content as ContentPart[];
+      expect(parts).toHaveLength(2);
+      expect(parts[1]).toEqual({
+        type: "text",
+        text: "[Image source: /tmp/wave-mcp-images/mcp-image_1_abc123.png]",
+      });
+
+      // Ensure no image_url parts remain
+      const allContent = JSON.stringify(apiMessages);
+      expect(allContent).not.toContain("image_url");
+    });
+
+    it("should append one [Image source: <path>] line per persisted image when supportsVision is false", () => {
+      const messages: Message[] = [
+        {
+          id: generateMessageId(),
+          role: "assistant",
+          blocks: [
+            {
+              type: "tool",
+              id: "tool_img_2",
+              name: "get_screenshots",
+              parameters: "{}",
+              stage: "end",
+              result: "Two screenshots.",
+              success: true,
+              images: [
+                {
+                  data: "base64data",
+                  mediaType: "image/png",
+                  path: "/tmp/wave-mcp-images/mcp-image_1_abc123.png",
+                },
+                {
+                  data: "base64data",
+                  mediaType: "image/jpeg",
+                  path: "/tmp/wave-mcp-images/mcp-image_2_def456.jpg",
+                },
+              ],
+            },
+          ],
+          timestamp: new Date().toISOString(),
+        },
+      ];
+
+      const apiMessages = convertMessagesForAPI(messages, {
+        supportsVision: false,
+      });
+
+      type ContentPart = { type: string; text?: string };
+      const userMessages = apiMessages.filter((m) => m.role === "user");
+      expect(userMessages).toHaveLength(1);
+      const parts = userMessages[0].content as ContentPart[];
+      expect(parts).toHaveLength(3);
+      expect(parts[0].text).toContain("does not support image recognition");
+      expect(parts[1].text).toBe(
+        "[Image source: /tmp/wave-mcp-images/mcp-image_1_abc123.png]",
+      );
+      expect(parts[2].text).toBe(
+        "[Image source: /tmp/wave-mcp-images/mcp-image_2_def456.jpg]",
+      );
+    });
+
+    it("should keep sending persisted tool images as image_url when supportsVision is true", () => {
+      const messages: Message[] = [
+        {
+          id: generateMessageId(),
+          role: "assistant",
+          blocks: [
+            {
+              type: "tool",
+              id: "tool_img_3",
+              name: "get_screenshot",
+              parameters: "{}",
+              stage: "end",
+              result: "Screenshot taken.",
+              success: true,
+              images: [
+                {
+                  data: "base64data",
+                  mediaType: "image/png",
+                  path: "/tmp/wave-mcp-images/mcp-image_1_abc123.png",
+                },
+              ],
+            },
+          ],
+          timestamp: new Date().toISOString(),
+        },
+      ];
+
+      const apiMessages = convertMessagesForAPI(messages, {
+        supportsVision: true,
+      });
+
+      const allContent = JSON.stringify(apiMessages);
+      expect(allContent).toContain("image_url");
+      expect(allContent).toContain("data:image/png;base64,base64data");
+      // The persisted path is metadata for the non-vision path only
+      expect(allContent).not.toContain("[Image source:");
+    });
+
     it("should send images as image_url when supportsVision is true (default)", () => {
       const messages: Message[] = [
         {

--- a/packages/agent-sdk/tests/utils/imageSupport.test.ts
+++ b/packages/agent-sdk/tests/utils/imageSupport.test.ts
@@ -30,6 +30,7 @@ describe("Image Support in Tool Results", () => {
       {
         data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChAI9jU77vwAAAABJRU5ErkJggg==",
         mediaType: "image/png",
+        path: "/tmp/wave-mcp-images/mcp-image_1_abc123.png",
       },
     ];
 
@@ -54,6 +55,9 @@ describe("Image Support in Tool Results", () => {
       expect(toolBlock.images).toHaveLength(1);
       expect(toolBlock.images![0].data).toBe(mockImages[0].data);
       expect(toolBlock.images![0].mediaType).toBe("image/png");
+      expect(toolBlock.images![0].path).toBe(
+        "/tmp/wave-mcp-images/mcp-image_1_abc123.png",
+      );
       expect(toolBlock.result).toBe("Screenshot captured successfully");
     }
   });

--- a/packages/agent-sdk/tests/utils/toolImagePersistence.test.ts
+++ b/packages/agent-sdk/tests/utils/toolImagePersistence.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+// Mock fs
+vi.mock("fs", async () => {
+  const actual = await vi.importActual("fs");
+  return {
+    ...actual,
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+  };
+});
+
+// Mock os
+vi.mock("os", async () => {
+  const actual = await vi.importActual("os");
+  return {
+    ...actual,
+    tmpdir: vi.fn().mockReturnValue("/tmp"),
+  };
+});
+
+// Mock logger
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { persistToolImages } from "../../src/utils/toolImagePersistence.js";
+
+describe("toolImagePersistence", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("should persist an image to /tmp/wave-mcp-images with .png extension", () => {
+    const result = persistToolImages([
+      { data: "aGVsbG8=", mediaType: "image/png" },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].data).toBe("aGVsbG8=");
+    expect(result[0].mediaType).toBe("image/png");
+    expect(result[0].path).toMatch(
+      /[/\\]wave-mcp-images[/\\]mcp-image_\d+_[a-z0-9]+\.png$/,
+    );
+    expect(fs.mkdirSync).toHaveBeenCalledWith(
+      path.join("/tmp", "wave-mcp-images"),
+      { recursive: true },
+    );
+  });
+
+  it("should write the decoded base64 bytes to the file", () => {
+    const base64 = Buffer.from("test image bytes").toString("base64");
+    persistToolImages([{ data: base64, mediaType: "image/png" }]);
+
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+    const [filePath, content] = vi.mocked(fs.writeFileSync).mock.calls[0];
+    expect(filePath).toMatch(
+      /[/\\]wave-mcp-images[/\\]mcp-image_\d+_[a-z0-9]+\.png$/,
+    );
+    expect(Buffer.isBuffer(content)).toBe(true);
+    expect((content as Buffer).toString()).toBe("test image bytes");
+  });
+
+  it("should map mimeType to the correct extension", () => {
+    const result = persistToolImages([
+      { data: "aGVsbG8=", mediaType: "image/jpeg" },
+      { data: "aGVsbG8=", mediaType: "image/webp" },
+      { data: "aGVsbG8=", mediaType: "image/svg+xml" },
+    ]);
+
+    expect(result[0].path).toMatch(/\.jpg$/);
+    expect(result[1].path).toMatch(/\.webp$/);
+    expect(result[2].path).toMatch(/\.svg$/);
+  });
+
+  it("should fall back to .png for unknown or missing mimeType", () => {
+    const result = persistToolImages([
+      { data: "aGVsbG8=", mediaType: "application/octet-stream" },
+      { data: "aGVsbG8=" },
+    ]);
+
+    expect(result[0].path).toMatch(/\.png$/);
+    expect(result[1].path).toMatch(/\.png$/);
+  });
+
+  it("should strip a data: URL prefix before decoding", () => {
+    const base64 = Buffer.from("payload").toString("base64");
+    const result = persistToolImages([
+      { data: `data:image/png;base64,${base64}`, mediaType: "image/png" },
+    ]);
+
+    const [, content] = vi.mocked(fs.writeFileSync).mock.calls[0];
+    expect((content as Buffer).toString()).toBe("payload");
+    expect(result[0].path).toMatch(/\.png$/);
+  });
+
+  it("should persist multiple images with distinct paths", () => {
+    const result = persistToolImages([
+      { data: "YQ==", mediaType: "image/png" },
+      { data: "Yg==", mediaType: "image/jpeg" },
+    ]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].path).toBeDefined();
+    expect(result[1].path).toBeDefined();
+    expect(result[0].path).not.toBe(result[1].path);
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("should return the image without path on write failure", () => {
+    vi.mocked(fs.writeFileSync).mockImplementation(() => {
+      throw new Error("disk full");
+    });
+
+    const result = persistToolImages([
+      { data: "aGVsbG8=", mediaType: "image/png" },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBeUndefined();
+    expect(result[0].data).toBe("aGVsbG8=");
+  });
+
+  it("should return the image without path on mkdir failure", () => {
+    vi.mocked(fs.mkdirSync).mockImplementation(() => {
+      throw new Error("permission denied");
+    });
+
+    const result = persistToolImages([
+      { data: "aGVsbG8=", mediaType: "image/png" },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

MCP tools (e.g. Figma) return image content blocks as in-memory base64 that are invisible to non-vision main models. When the agent's model lacks vision, each image is persisted to a temp file under the OS tmpdir (`wave-mcp-images/`) and `convertMessagesForAPI` attaches `[Image source: <path>]` metadata after the placeholder, so the main model can delegate recognition to the vision subagent (which reads the path with the Read tool).

Vision-capable models keep the inline base64 — no disk writes (aligned with user-image handling).

## Changes

- **mcpManager**: image content blocks now read the MCP standard `mimeType` field, PNG fallback (was hardcoded `image/png`)
- **aiManager**: persist tool images at tool-result time when the model does not support vision; the persisted `path` is stored on the ToolBlock via `updateToolBlock`
- **convertMessagesForAPI**: non-vision branch emits the placeholder + one `[Image source: <path>]` text part per persisted image; images without a path fall back to placeholder-only
- **toolImagePersistence** (new util): base64 → temp file under `os.tmpdir()/wave-mcp-images/`, mimeType→extension mapping (unknown falls back to .png), strips `data:` prefix, write failures degrade to no-path (placeholder-only)
- **types**: `ToolBlock.images` gains an optional `path` field

## Tests

- New: `toolImagePersistence.test.ts`, `aiManager.mcpImagePersistence.test.ts`
- Extended: `convertMessagesForAPI.test.ts`, `mcpManager.test.ts`, `imageSupport.test.ts`

## Verification

- Full agent-sdk suite: 256 files, 3527 passed, 1 skipped
- type-check + lint: clean (agent-sdk + repo-wide via hooks)