### PR TITLE
fix(desktop): 自动更新失败时重复弹出「发现新版本」toast

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -4099,10 +4099,11 @@ export class DesktopHost {
         if (manual) this.showToast({ message: "当前已是最新版本" });
         return;
       }
-      // outcome === 'error': degrade to the manual checker below.
-      console.warn(
-        "[DesktopHost] Auto update check failed, falling back to manual check",
-      );
+      // outcome === 'error': electron-updater already emitted 'error' on this
+      // failure (routed above to handleAutoUpdaterError, the single manual
+      // fallback). Falling back again here would show two identical
+      // "发现新版本" toasts.
+      return;
     }
 
     // checkForUpdate throws when the check itself failed — don't present that

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -1738,7 +1738,7 @@ describe("checkForUpdates with a configured serverUrl", () => {
     );
   });
 
-  it("falls back to the manual checker when electron-updater fails", async () => {
+  it("falls back to the manual checker exactly once when electron-updater fails", async () => {
     vi.mocked(autoUpdater.checkForUpdates).mockRejectedValue(
       new Error("ECONNREFUSED"),
     );
@@ -1749,11 +1749,18 @@ describe("checkForUpdates with a configured serverUrl", () => {
     });
     const { host } = await readyHostWithServerUrl();
 
+    // electron-updater emits 'error' and then rejects the check — both signal
+    // the same failure. The host must fall back once, not twice.
     await host.handleWebviewMessage({ command: "checkForUpdates" });
+    for (const cb of auListeners["error"] ?? []) {
+      cb(new Error("ECONNREFUSED"));
+    }
 
-    expect(checkForUpdate).toHaveBeenCalledWith("0.19.7", SERVER);
+    await vi.waitFor(() =>
+      expect(checkForUpdate).toHaveBeenCalledWith("0.19.7", SERVER),
+    );
     const toasts = shownToasts().filter((n) => n.message.includes("0.20.0"));
-    expect(toasts.length).toBeGreaterThanOrEqual(1);
+    expect(toasts).toHaveLength(1);
     expect(toasts[0].action).toEqual({
       type: "openDownloadPage",
       url: "https://github.com/release",
@@ -1785,7 +1792,7 @@ describe("checkForUpdates with a configured serverUrl", () => {
       expect(checkForUpdate).toHaveBeenCalledWith("0.19.7", SERVER),
     );
     const toasts = shownToasts().filter((n) => n.message.includes("0.20.0"));
-    expect(toasts.length).toBeGreaterThanOrEqual(1);
+    expect(toasts).toHaveLength(1);
     expect(toasts[0].action).toEqual({
       type: "openDownloadPage",
       url: "https://codechat.example.com/api/downloads/manifest.json",


### PR DESCRIPTION
## 问题

登录状态下自动更新链路失败（端点不可达 / 下载失败）时，会弹出两个相同的「发现新版本 vX（当前 vY）打开下载页」toast。

## 根因

electron-updater 的 `checkForUpdates()` 失败时先 emit `error` 事件，再 reject：

1. `error` 事件 → `onError` → `handleAutoUpdaterError`（desktopHost.ts:4133）→ 手动 fallback → toast #1
2. promise reject → `checkForUpdates` 返回 `"error"` → `handleCheckForUpdates` 内联 fallback → toast #2

两条路径各自执行手动检查并弹 toast。

## 修复

`handleCheckForUpdates` 在 outcome 为 `"error"` 时直接返回，让 `handleAutoUpdaterError` 成为唯一的手动 fallback 入口（它本就覆盖检查失败与后台下载失败两种场景）。