### PR TITLE
fix: 退出时不再遗留孤儿 wave --stdio 进程

### DIFF
--- a/packages/code/src/stdio/jsonRpcConnection.ts
+++ b/packages/code/src/stdio/jsonRpcConnection.ts
@@ -22,15 +22,28 @@ import {
   isNotification,
 } from "./protocol.js";
 
+export interface JsonRpcConnectionOptions {
+  /** Called when the input stream reaches EOF (parent closed the pipe). Only
+   * stdio mode passes it — it must exit the process when its client dies;
+   * daemon mode never passes it (a detached client must not kill the daemon,
+   * see daemonServer.ts). */
+  onClose?: () => void;
+}
+
 export class JsonRpcConnection {
   private rl: readline.Interface | undefined;
   private started = false;
+  private stoppedByOwner = false;
+  private onClose?: () => void;
 
   constructor(
     private input: Readable,
     private output: Writable,
     private bridge: AgentBridge,
-  ) {}
+    options: JsonRpcConnectionOptions = {},
+  ) {
+    this.onClose = options.onClose;
+  }
 
   start(): void {
     if (this.started) return;
@@ -58,10 +71,15 @@ export class JsonRpcConnection {
 
     this.rl.on("close", () => {
       this.started = false;
+      // stdin EOF from the owning client — not a deliberate stop(). stdio
+      // mode reacts by exiting the process (its parent is gone); daemon mode
+      // has no onClose so a detached client reset never kills the daemon.
+      if (!this.stoppedByOwner) this.onClose?.();
     });
   }
 
   stop(): void {
+    this.stoppedByOwner = true;
     this.rl?.close();
     this.rl = undefined;
     this.started = false;

--- a/packages/code/src/stdio/stdioServer.ts
+++ b/packages/code/src/stdio/stdioServer.ts
@@ -30,6 +30,7 @@ export class StdioServer {
       options.input ?? process.stdin,
       options.output ?? process.stdout,
       this.bridge,
+      { onClose: () => this.onConnectionClosed() },
     );
   }
 
@@ -43,6 +44,22 @@ export class StdioServer {
 
   stop(): void {
     this.conn.stop();
+  }
+
+  /**
+   * The owning client closed stdin (EOF) — it's gone, so this process must
+   * follow it. destroyAll() saves each session's transcript and drains
+   * auto-memory first; a timeout bounds it so a stuck agent can't orphan the
+   * exit. This is the real-world "parent died" path: without it the process
+   * lingers forever whenever an agent keeps event-loop handles alive.
+   */
+  private async onConnectionClosed(): Promise<void> {
+    const SHUTDOWN_TIMEOUT_MS = 5_000;
+    await Promise.race([
+      this.bridge.destroyAll(),
+      new Promise((resolve) => setTimeout(resolve, SHUTDOWN_TIMEOUT_MS)),
+    ]);
+    process.exit(0);
   }
 
   handleLine(line: string): Promise<void> {

--- a/packages/code/tests/stdio/stdioServer.test.ts
+++ b/packages/code/tests/stdio/stdioServer.test.ts
@@ -366,6 +366,44 @@ test("stop() closes the readline interface", async () => {
   expect(true).toBe(true);
 });
 
+// ── stdin EOF (parent died) ──────────────────────────────────────
+
+test("stdin EOF (parent closed the pipe) triggers process.exit", async () => {
+  const exitSpy = vi
+    .spyOn(process, "exit")
+    .mockImplementation(() => undefined as never);
+  const { server, input } = createServer();
+  server.start();
+
+  // Parent is gone — stdin reaches EOF, the readline interface emits 'close',
+  // and stdio mode must follow the client by exiting the process.
+  input.end();
+
+  await vi.waitFor(() => {
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  exitSpy.mockRestore();
+  server.stop();
+});
+
+test("stop() does not trigger process.exit", async () => {
+  const exitSpy = vi
+    .spyOn(process, "exit")
+    .mockImplementation(() => undefined as never);
+  const { server, input } = createServer();
+  server.start();
+
+  server.stop();
+  // rl.close() emits 'close' asynchronously — give the event loop a tick.
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  expect(exitSpy).not.toHaveBeenCalled();
+
+  exitSpy.mockRestore();
+  input.end();
+});
+
 // ── sendNotification sessionId envelope ──────────────────────────
 
 test("sendNotification includes sessionId in envelope when provided", () => {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -143,10 +143,25 @@ if (!gotLock) {
     }
   });
 
-  app.on("before-quit", () => {
-    void host?.dispose();
+  app.on("before-quit", (event) => {
+    // Never fire-and-forget the dispose: quitting before the destroy RPC
+    // reaches the agent would orphan the wave --stdio child (the other half
+    // of the fix is stdioServer's stdin-EOF self-exit). Hold the quit, await
+    // dispose bounded by a timeout, then exit explicitly. app.exit() skips the
+    // quit events, so this handler can't re-enter.
+    if (quitting) return;
+    quitting = true;
+    if (!host) return;
+    event.preventDefault();
+    void Promise.race([
+      host.dispose(),
+      new Promise((resolve) => setTimeout(resolve, SHUTDOWN_TIMEOUT_MS)),
+    ]).finally(() => app.exit(0));
   });
 }
+
+const SHUTDOWN_TIMEOUT_MS = 5_000;
+let quitting = false;
 
 function createWindow(): void {
   mainWindow = new BrowserWindow({

--- a/scripts/check-docs-links.mjs
+++ b/scripts/check-docs-links.mjs
@@ -38,7 +38,11 @@ function collectHeadings(content) {
   const headings = [];
   const lines = content.split('\n');
   for (const line of lines) {
-    const m = line.match(/^(#{1,6})\s+(.*)$/);
+    // Windows CRLF checkouts leave a trailing \r. `.` does not match \r (it is
+    // a line terminator), so without stripping it every heading regex fails on
+    // CRLF files — strip it once here instead of in every regex.
+    const clean = line.endsWith('\r') ? line.slice(0, -1) : line;
+    const m = clean.match(/^(#{1,6})\s+(.*)$/);
     if (m) {
       let text = m[2];
       let explicitId = null;
@@ -49,9 +53,9 @@ function collectHeadings(content) {
       }
       headings.push({ text, explicitId, slug: slugify(text) });
     } else {
-      const idMatch = line.match(/\{#([^}]+)\}/);
+      const idMatch = clean.match(/\{#([^}]+)\}/);
       if (idMatch) {
-        headings.push({ text: line, explicitId: idMatch[1], slug: idMatch[1] });
+        headings.push({ text: clean, explicitId: idMatch[1], slug: idMatch[1] });
       }
     }
   }


### PR DESCRIPTION
## 背景
桌面端退出后, 任务管理器会遗留高 CPU 的 nodejs 孤儿进程(实测 3 个进程 ≈3.7 核)。
根因是两层 bug 叠加:

1. **桌面端** before-quit 里 `void host?.dispose()` fire-and-forget —— Electron 在 destroy RPC 完成前就退出
2. **stdio 侧** `rl.on("close")` 只置 `started = false`, 不主动退出 —— 父进程死后, 只要 agent 还持有事件循环句柄, 进程永不退出(忙循环烧 CPU)

## 修复(双保险)
- **stdio 侧(根治)**: stdin EOF(父进程已死)时 `destroyAll()`(保存 transcript, 5s 超时兜底)后 `process.exit(0)`。父进程一死子进程必退
  - `jsonRpcConnection` 新增可选 `onClose` 回调 + `stoppedByOwner` 标志; daemon 模式不传 `onClose`, 客户端断开不会误杀 daemon
- **桌面端(源头)**: before-quit 改为 `preventDefault` + 等待 `host.dispose()`(5s 超时) + `app.exit(0)`, 带重入保护。`app.exit()` 不会重触发 before-quit

## 测试
- stdioServer: 18 passed(新增 2 个: EOF 触发 exit / stop 不触发 exit)
- desktop: 493 passed
- 两包 type-check + lint 通过

## 附带修复
scripts/check-docs-links.mjs + check-sidebar-anchors.mjs 的 `collectHeadings` 兼容 Windows CRLF 检出: JS 正则 `.` 不匹配 `\r`, 导致 CRLF 文件所有 heading 匹配失败(此前反复出现的中文 anchor 误报)。