### PR TITLE
fix(desktop): Windows 上经 SSH 连接远端 wave daemon 改用 TCP 端口转发

### DIFF
--- a/packages/desktop/src/main/remoteCli.ts
+++ b/packages/desktop/src/main/remoteCli.ts
@@ -404,8 +404,10 @@ export async function readRemoteFile(
 //
 // 远端 daemon = `nohup wave --daemon <socket>` 常驻进程（nohup+重定向使 ssh
 // 只等启动器 fork 即返回，见 specs「SSH 远程主机」）。桌面端通过
-// `ssh -N -L 本地socket:远端socket` 转发后复用同一套 JSON-RPC 客户端，因此
-// 断线重连只换传输层，会话与挂起审批都在 daemon 进程里存活。
+// `ssh -N -L` 转发后复用同一套 JSON-RPC 客户端，因此断线重连只换传输层，
+// 会话与挂起审批都在 daemon 进程里存活。本地转发端在 POSIX 是 unix socket、
+// Windows 是 127.0.0.1 的 TCP 端口（Windows OpenSSH 无法 bind 本地 unix
+// socket，见 connectRemoteDaemon）。
 
 export const DAEMON_START_TIMEOUT_MS = 10_000;
 export const DAEMON_POLL_INTERVAL_MS = 500;
@@ -599,13 +601,46 @@ export interface RemoteDaemonConnection {
 }
 
 /**
- * Forward the remote daemon socket to a local unix socket via `ssh -N -L`,
- * then wrap the local socket in a SocketClient. The tunnel keeps running until
- * the caller disposes both — killing only the client would close the socket
- * but leave the ssh process lingering. Plain `spawn('ssh', …)` (no login
- * shell): `-N` tunnels never run a remote command.
+ * Pick a free 127.0.0.1 TCP port for the tunnel's local end. The close-then-
+ * spawn window is tiny; on a collision ssh exits with "local port forwarding
+ * failed" and the tunnel-exit path in connectRemoteDaemonTcp surfaces it.
+ */
+async function allocateLoopbackPort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address() as net.AddressInfo;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return address.port;
+}
+
+/**
+ * Connect to the remote wave daemon over an ssh tunnel, choosing the transport
+ * per platform. Windows OpenSSH cannot bind a local unix socket for `-L`: its
+ * parser rejects drive-letter paths (`C:\...`) and its AF_UNIX bind rejects
+ * drive-less paths (`/Users/...`), so the local end there is a 127.0.0.1 TCP
+ * port (`-L port:remote_socket`, supported by OpenSSH on every platform).
+ * POSIX keeps the unix-socket forward.
  */
 export async function connectRemoteDaemon(
+  host: string,
+  remoteSocketPath: string,
+): Promise<RemoteDaemonConnection> {
+  return process.platform === "win32"
+    ? connectRemoteDaemonTcp(host, remoteSocketPath)
+    : connectRemoteDaemonSocket(host, remoteSocketPath);
+}
+
+/**
+ * `connectRemoteDaemon` for POSIX: forward the remote daemon socket to a local
+ * unix socket via `ssh -N -L`, then wrap the local socket in a SocketClient.
+ * The tunnel keeps running until the caller disposes both — killing only the
+ * client would close the socket but leave the ssh process lingering. Plain
+ * `spawn('ssh', …)` (no login shell): `-N` tunnels never run a remote command.
+ */
+export async function connectRemoteDaemonSocket(
   host: string,
   remoteSocketPath: string,
 ): Promise<RemoteDaemonConnection> {
@@ -654,6 +689,69 @@ export async function connectRemoteDaemon(
         return;
       }
       const sock = net.createConnection(localSocket);
+      sock.once("connect", () => {
+        settled = true;
+        resolve(sock);
+      });
+      sock.once("error", () => {
+        setTimeout(attempt, 100);
+      });
+    };
+    attempt();
+  }).catch((error) => {
+    tunnel.kill();
+    throw new Error(`无法连接远端 wave daemon（${describeError(error)}）`);
+  });
+
+  return { client: new SocketClient(socket), tunnel };
+}
+
+/**
+ * `connectRemoteDaemon` for Windows: forward the remote daemon socket to a
+ * local loopback TCP port (`ssh -N -L 127.0.0.1:<port>:<remote socket>`) and
+ * wrap the port connection in a SocketClient. Same lifecycle as the socket
+ * variant — the tunnel keeps running until the caller disposes both.
+ */
+export async function connectRemoteDaemonTcp(
+  host: string,
+  remoteSocketPath: string,
+): Promise<RemoteDaemonConnection> {
+  const port = await allocateLoopbackPort();
+  const tunnel = spawn(
+    "ssh",
+    buildSshTunnelArgs(host, `127.0.0.1:${port}`, remoteSocketPath),
+    {
+      stdio: ["ignore", "ignore", "pipe"],
+    },
+  );
+  let tunnelStderr = "";
+  tunnel.stderr?.on("data", (data: Buffer) => {
+    tunnelStderr = (tunnelStderr + data.toString()).slice(-1024);
+  });
+
+  const socket = await new Promise<net.Socket>((resolve, reject) => {
+    let settled = false;
+    const fail = (error: Error) => {
+      if (!settled) {
+        settled = true;
+        reject(error);
+      }
+    };
+    tunnel.once("exit", (code, signal) => {
+      fail(
+        new Error(
+          `ssh 隧道退出（code: ${code}, signal: ${signal}${tunnelStderr.trim() ? `: ${tunnelStderr.trim()}` : ""}）`,
+        ),
+      );
+    });
+    const deadline = Date.now() + TUNNEL_READY_TIMEOUT_MS;
+    const attempt = () => {
+      if (settled) return;
+      if (Date.now() >= deadline) {
+        fail(new Error(`本地转发端口未就绪（127.0.0.1:${port}）`));
+        return;
+      }
+      const sock = net.createConnection({ host: "127.0.0.1", port });
       sock.once("connect", () => {
         settled = true;
         resolve(sock);

--- a/packages/desktop/src/main/sshHosts.ts
+++ b/packages/desktop/src/main/sshHosts.ts
@@ -175,20 +175,26 @@ export function buildSshSpawnArgs(
 }
 
 /**
- * Spawn args for an `ssh -N` unix-socket forward: `localSocket:remoteSocket`.
- * `-N` means no remote command — the tunnel just forwards. ExitOnForwardFailure
- * makes ssh exit (instead of idling) when the remote end refuses the forward,
- * so a missing daemon socket surfaces as a tunnel exit rather than a silent
- * half-open connection. ServerAliveInterval/CountMax send application-level
- * keepalives through the encrypted channel: after a machine sleep the TCP
- * connection is often half-open (no RST/FIN), and only these probes make ssh
- * detect the dead tunnel in bounded time instead of idling on SO_KEEPALIVE
- * (macOS probes after ~2h idle by default). No login shell is needed: `-N`
- * tunnels never run a remote command.
+ * Spawn args for an `ssh -N` forward to the remote daemon socket:
+ * `localForward:remoteSocket`. `-N` means no remote command — the tunnel just
+ * forwards. `localForward` is the tunnel's local end: a unix socket path on
+ * POSIX, or `127.0.0.1:<port>` on Windows (Windows OpenSSH cannot bind a local
+ * unix socket — its `-L` parser rejects drive-letter paths like `C:\...`, and
+ * its AF_UNIX bind rejects drive-less paths — so the desktop forwards to a
+ * loopback TCP port there; OpenSSH's `-L port:remote_socket` form works on
+ * every platform). ExitOnForwardFailure makes ssh exit (instead of idling)
+ * when a forward cannot be established, so a missing daemon socket surfaces as
+ * a tunnel exit rather than a silent half-open connection.
+ * ServerAliveInterval/CountMax send application-level keepalives through the
+ * encrypted channel: after a machine sleep the TCP connection is often
+ * half-open (no RST/FIN), and only these probes make ssh detect the dead
+ * tunnel in bounded time instead of idling on SO_KEEPALIVE (macOS probes after
+ * ~2h idle by default). No login shell is needed: `-N` tunnels never run a
+ * remote command.
  */
 export function buildSshTunnelArgs(
   host: string,
-  localSocketPath: string,
+  localForward: string,
   remoteSocketPath: string,
 ): string[] {
   return [
@@ -201,7 +207,7 @@ export function buildSshTunnelArgs(
     "ServerAliveCountMax=4",
     "-N",
     "-L",
-    `${localSocketPath}:${remoteSocketPath}`,
+    `${localForward}:${remoteSocketPath}`,
     host,
   ];
 }

--- a/packages/desktop/tests/remoteDaemon.test.ts
+++ b/packages/desktop/tests/remoteDaemon.test.ts
@@ -7,6 +7,7 @@ const h = vi.hoisted(() => ({
   existsSync: vi.fn(),
   unlinkSync: vi.fn(),
   createConnection: vi.fn(),
+  createServer: vi.fn(),
   SocketClient: vi.fn(),
 }));
 
@@ -22,6 +23,7 @@ vi.mock("fs", () => ({
 
 vi.mock("net", () => ({
   createConnection: h.createConnection,
+  createServer: h.createServer,
 }));
 
 vi.mock("../src/main/stdio/socketClient", () => ({
@@ -37,6 +39,8 @@ import {
   waitForRemoteDaemon,
   ensureRemoteDaemon,
   connectRemoteDaemon,
+  connectRemoteDaemonSocket,
+  connectRemoteDaemonTcp,
   DAEMON_START_TIMEOUT_MS,
   DAEMON_POLL_INTERVAL_MS,
 } from "../src/main/remoteCli";
@@ -86,12 +90,23 @@ function makeSocket() {
   return sock;
 }
 
+/** Fake `net.createServer` used by allocateLoopbackPort to pick a free port. */
+function makePortAllocator(port: number) {
+  return {
+    once: vi.fn(),
+    listen: vi.fn((_port: number, _host: string, cb: () => void) => cb()),
+    address: vi.fn(() => ({ port, address: "127.0.0.1", family: "IPv4" })),
+    close: vi.fn((cb: () => void) => cb()),
+  };
+}
+
 beforeEach(() => {
   h.execFile.mockReset();
   h.spawn.mockReset();
   h.existsSync.mockReset();
   h.unlinkSync.mockReset();
   h.createConnection.mockReset();
+  h.createServer.mockReset();
   h.SocketClient.mockReset();
   resetRemoteShellCache();
 });
@@ -262,7 +277,7 @@ describe("ensureRemoteDaemon", () => {
   });
 });
 
-describe("connectRemoteDaemon", () => {
+describe("connectRemoteDaemonSocket", () => {
   it("forwards the remote socket over ssh -N -L and wraps it in a SocketClient", async () => {
     const tunnel = makeTunnel();
     h.spawn.mockReturnValue(tunnel);
@@ -271,7 +286,7 @@ describe("connectRemoteDaemon", () => {
     h.createConnection.mockReturnValue(sock);
     setTimeout(() => sock.emit("connect"), 0);
 
-    const result = await connectRemoteDaemon(
+    const result = await connectRemoteDaemonSocket(
       "prod",
       "/home/alice/.wave/daemon.sock",
     );
@@ -298,7 +313,7 @@ describe("connectRemoteDaemon", () => {
     h.createConnection.mockReturnValue(sock);
     setTimeout(() => sock.emit("connect"), 0);
 
-    await connectRemoteDaemon("prod", "/home/alice/.wave/daemon.sock");
+    await connectRemoteDaemonSocket("prod", "/home/alice/.wave/daemon.sock");
     expect(h.unlinkSync).toHaveBeenCalledWith(localDaemonSocketPath("prod"));
   });
 
@@ -307,12 +322,113 @@ describe("connectRemoteDaemon", () => {
     h.spawn.mockReturnValue(tunnel);
     h.existsSync.mockReturnValue(false); // forward never materializes
 
-    const pending = connectRemoteDaemon(
+    const pending = connectRemoteDaemonSocket(
       "prod",
       "/home/alice/.wave/daemon.sock",
     );
     tunnel.emit("exit", 255, null);
     await expect(pending).rejects.toThrow("无法连接远端 wave daemon");
     expect(tunnel.kill).toHaveBeenCalled();
+  });
+});
+
+describe("connectRemoteDaemonTcp", () => {
+  it("forwards to a free loopback port and wraps the connection in a SocketClient", async () => {
+    const tunnel = makeTunnel();
+    h.spawn.mockReturnValue(tunnel);
+    h.createServer.mockReturnValue(makePortAllocator(43211));
+    const sock = makeSocket();
+    h.createConnection.mockReturnValue(sock);
+    setTimeout(() => sock.emit("connect"), 0);
+
+    const result = await connectRemoteDaemonTcp(
+      "prod",
+      "/home/alice/.wave/daemon.sock",
+    );
+    expect(result.tunnel).toBe(tunnel);
+    expect(h.SocketClient).toHaveBeenCalledWith(sock);
+    expect(result.client).toBe(h.SocketClient.mock.instances[0]);
+
+    expect(h.createServer).toHaveBeenCalled();
+    expect(h.spawn).toHaveBeenCalledWith(
+      "ssh",
+      buildSshTunnelArgs(
+        "prod",
+        "127.0.0.1:43211",
+        "/home/alice/.wave/daemon.sock",
+      ),
+      expect.any(Object),
+    );
+    expect(h.createConnection).toHaveBeenCalledWith({
+      host: "127.0.0.1",
+      port: 43211,
+    });
+  });
+
+  it("kills the tunnel and throws when ssh exits before the port is ready", async () => {
+    const tunnel = makeTunnel();
+    h.spawn.mockReturnValue(tunnel);
+    h.createServer.mockReturnValue(makePortAllocator(43211));
+
+    const pending = connectRemoteDaemonTcp(
+      "prod",
+      "/home/alice/.wave/daemon.sock",
+    );
+    tunnel.emit("exit", 255, null);
+    await expect(pending).rejects.toThrow("无法连接远端 wave daemon");
+    expect(tunnel.kill).toHaveBeenCalled();
+  });
+});
+
+describe("connectRemoteDaemon transport selection", () => {
+  it("uses the TCP transport on Windows", async () => {
+    const original = process.platform;
+    try {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      const tunnel = makeTunnel();
+      h.spawn.mockReturnValue(tunnel);
+      h.createServer.mockReturnValue(makePortAllocator(43211));
+      const sock = makeSocket();
+      h.createConnection.mockReturnValue(sock);
+      setTimeout(() => sock.emit("connect"), 0);
+
+      await connectRemoteDaemon("prod", "/home/alice/.wave/daemon.sock");
+      expect(h.createServer).toHaveBeenCalled();
+      expect(h.spawn).toHaveBeenCalledWith(
+        "ssh",
+        buildSshTunnelArgs(
+          "prod",
+          "127.0.0.1:43211",
+          "/home/alice/.wave/daemon.sock",
+        ),
+        expect.any(Object),
+      );
+    } finally {
+      Object.defineProperty(process, "platform", { value: original });
+    }
+  });
+
+  it("uses the unix-socket transport on POSIX", async () => {
+    const original = process.platform;
+    try {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      const tunnel = makeTunnel();
+      h.spawn.mockReturnValue(tunnel);
+      h.existsSync.mockReturnValue(true);
+      const sock = makeSocket();
+      h.createConnection.mockReturnValue(sock);
+      setTimeout(() => sock.emit("connect"), 0);
+
+      await connectRemoteDaemon("prod", "/home/alice/.wave/daemon.sock");
+      expect(h.createServer).not.toHaveBeenCalled();
+      const localSocket = localDaemonSocketPath("prod");
+      expect(h.spawn).toHaveBeenCalledWith(
+        "ssh",
+        buildSshTunnelArgs("prod", localSocket, "/home/alice/.wave/daemon.sock"),
+        expect.any(Object),
+      );
+    } finally {
+      Object.defineProperty(process, "platform", { value: original });
+    }
   });
 });


### PR DESCRIPTION
## 问题

Windows 上选择 devbox 远程主机目录时报错:

```
初始化失败:无法连接远端 wave daemon(ssh 隧道退出(code: 255, signal: null: Bad local forwarding specification 'C:\Users\刘一奇\AppData\Local\Temp\wave-daemon-devbox.sock:/home/liuyiqi/.wave/daemon.sock'))
```

## 根因

Windows OpenSSH 的 `-L` 解析器要求本地部分含 `/` 才按 unix socket 处理,但 Windows AF_UNIX bind 又要求盘符绝对路径——两者矛盾。经实证:盘符路径(`C:\...`)、正斜杠、相对路径(`./x`)、POSIX 路径(`/Users/...`)均无法建立本地 unix socket 转发(解析或 bind 失败)。

## 方案

与 VS Code Remote-SSH 的 `remoteServerListenOnSocket` 模式一致:本地转发端改用 TCP。

- `buildSshTunnelArgs` 参数 `localSocketPath` → `localForward`
- `connectRemoteDaemon` 按平台分派:Windows → `connectRemoteDaemonTcp`(先 `net.createServer().listen(0)` 分配空闲回环端口,再 `ssh -L 127.0.0.1:<port>:<remote_socket>`,轮询端口就绪);POSIX → `connectRemoteDaemonSocket`(原 unix socket 转发不变)
- 调用方 `desktopHost.ts` 只解构 `{client, tunnel}`,接口不变

## 验证

- `remoteDaemon` + `sshHosts` 44 个测试通过(新增 TCP 分支与平台选择测试)
- 完整桌面包 497 个测试通过;type-check、lint 通过