### PR TITLE
fix: append plugin error blocks below the latest user message

### DIFF
--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -703,21 +703,22 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         onErrorBlockAdded: (error: string) => {
           if (isExpandedRef.current) return;
           setMessages((prev) => {
-            // Append to the last assistant message, or create one if none exists
-            for (let i = prev.length - 1; i >= 0; i--) {
-              if (prev[i].role === "assistant") {
-                return prev.map((m, idx) =>
-                  idx === i
-                    ? {
-                        ...m,
-                        blocks: [
-                          ...m.blocks,
-                          { type: "error", content: error },
-                        ],
-                      }
-                    : m,
-                );
-              }
+            // Append to the LAST message only if it is an assistant message
+            // (the current turn's in-flight reply). If the last message is a
+            // user message, the error belongs BELOW it — create a new
+            // assistant message instead of polluting the stale assistant from
+            // an earlier turn (which surfaced the error above the latest
+            // user message and accumulated it there).
+            const last = prev[prev.length - 1];
+            if (last && last.role === "assistant") {
+              return prev.map((m, idx) =>
+                idx === prev.length - 1
+                  ? {
+                      ...m,
+                      blocks: [...m.blocks, { type: "error", content: error }],
+                    }
+                  : m,
+              );
             }
             return [
               ...prev,

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -1251,6 +1251,71 @@ describe("ChatProvider", () => {
     });
   });
 
+  it("onErrorBlockAdded creates a NEW assistant message when the last message is a user message (regression: stale assistant from a previous turn)", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
+    const callbacks = agentCreateArgs.callbacks!;
+
+    // Build [user, assistant, user] in the UI via incremental callbacks — the
+    // latest user message has no assistant reply yet when the error fires.
+    const userMsg = {
+      id: "u1",
+      role: "user" as const,
+      blocks: [{ type: "text" as const, content: "你好" }],
+      timestamp: new Date().toISOString(),
+    };
+    Object.assign(mockAgent, { messages: [userMsg] });
+    callbacks.onUserMessageAdded!({ content: "你好" });
+    await vi.waitFor(() => expect(lastValue?.messages).toHaveLength(1));
+
+    const assistantMsg = {
+      id: "a1",
+      role: "assistant" as const,
+      blocks: [{ type: "text" as const, content: "好的" }],
+      timestamp: new Date().toISOString(),
+    };
+    Object.assign(mockAgent, { messages: [userMsg, assistantMsg] });
+    callbacks.onAssistantMessageAdded!("a1");
+    await vi.waitFor(() => expect(lastValue?.messages).toHaveLength(2));
+
+    const latestUserMsg = {
+      id: "u2",
+      role: "user" as const,
+      blocks: [{ type: "text" as const, content: "帮我执行 X" }],
+      timestamp: new Date().toISOString(),
+    };
+    Object.assign(mockAgent, {
+      messages: [userMsg, assistantMsg, latestUserMsg],
+    });
+    callbacks.onUserMessageAdded!({ content: "帮我执行 X" });
+    await vi.waitFor(() => expect(lastValue?.messages).toHaveLength(3));
+
+    // The error belongs BELOW the latest user message: appending to the
+    // previous turn's assistant would surface it above the newest message
+    // and accumulate there across repeated errors.
+    callbacks.onErrorBlockAdded!("boom");
+    await vi.waitFor(() => {
+      expect(lastValue?.messages).toHaveLength(4);
+    });
+    const errorMessage = lastValue!.messages[3];
+    expect(errorMessage.role).toBe("assistant");
+    expect(errorMessage.blocks).toEqual([{ type: "error", content: "boom" }]);
+    // Previous turn's assistant message is left untouched.
+    expect(lastValue!.messages[1].blocks).toEqual([
+      { type: "text", content: "好的" },
+    ]);
+  });
+
   it("throttles streaming updates to 500ms and flushes immediately on end", async () => {
     let lastValue: ChatContextType | undefined;
     const onHookValue = (val: ChatContextType) => {

--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -904,17 +904,18 @@ export class DesktopHost {
       },
       onErrorBlockAdded: (error: string) => {
         // Mirror the error block into the cache too (APPEND_ERROR_BLOCK
-        // semantics: append to the last assistant message, creating one if no
-        // assistant message exists yet).
+        // semantics: append to the LAST message if it is an assistant message,
+        // otherwise create a new assistant message below the latest user
+        // message — never attach to a stale assistant from an earlier turn).
         const newErrorBlock: ErrorBlock = { type: "error", content: error };
-        let targetIndex = -1;
-        for (let i = agentRef.messages.length - 1; i >= 0; i--) {
-          if (agentRef.messages[i].role === "assistant") {
-            targetIndex = i;
-            break;
-          }
-        }
-        if (targetIndex === -1) {
+        const lastMessage = agentRef.messages[agentRef.messages.length - 1];
+        if (lastMessage && lastMessage.role === "assistant") {
+          agentRef.messages = agentRef.messages.map((m, idx) =>
+            idx === agentRef.messages.length - 1
+              ? { ...m, blocks: [...m.blocks, newErrorBlock] }
+              : m,
+          );
+        } else {
           agentRef.messages = [
             ...agentRef.messages,
             {
@@ -924,12 +925,6 @@ export class DesktopHost {
               blocks: [newErrorBlock],
             },
           ];
-        } else {
-          agentRef.messages = agentRef.messages.map((m, idx) =>
-            idx === targetIndex
-              ? { ...m, blocks: [...m.blocks, newErrorBlock] }
-              : m,
-          );
         }
         const paneId = paneIdOf();
         if (paneId)

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -1134,6 +1134,49 @@ describe("agent notifications", () => {
     ]);
   });
 
+  it("mirrors an error block under the LATEST user message — new assistant message, not the stale one from a previous turn", async () => {
+    const { sent } = await readyHost();
+    const agent = lastAgent();
+    const userMsg = {
+      id: "u1",
+      role: "user",
+      blocks: [{ type: "text", content: "你好" }],
+    };
+    const assistantMsg = {
+      id: "a1",
+      role: "assistant",
+      blocks: [{ type: "text", content: "好的" }],
+    };
+    const latestUserMsg = {
+      id: "u2",
+      role: "user",
+      blocks: [{ type: "text", content: "帮我执行 X" }],
+    };
+    agent.messages = [userMsg, assistantMsg, latestUserMsg];
+
+    agent.callbacks.onErrorBlockAdded("插件执行失败");
+
+    // The error belongs below the LATEST user message: appending to the
+    // previous turn's assistant would surface it above the newest message
+    // and accumulate there across repeated errors.
+    expect(agent.messages).toHaveLength(4);
+    const errorMessage = agent.messages[3] as {
+      role: string;
+      blocks: Array<{ type: string; content: string }>;
+    };
+    expect(errorMessage.role).toBe("assistant");
+    expect(errorMessage.blocks).toEqual([
+      { type: "error", content: "插件执行失败" },
+    ]);
+    // Previous turn's assistant message is left untouched.
+    expect(
+      (agent.messages[1] as { blocks: unknown[] }).blocks,
+    ).toHaveLength(1);
+    expect(sent("updateErrorBlock")).toEqual([
+      expect.objectContaining({ error: "插件执行失败" }),
+    ]);
+  });
+
   it("streaming content deltas are mirrored into the agent cache so a session switch shows the full assistant reply", async () => {
     const { host, sent } = await readyHost();
     const agent = lastAgent();

--- a/packages/webview/src/reducers/chatReducer.ts
+++ b/packages/webview/src/reducers/chatReducer.ts
@@ -441,43 +441,36 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
       const { error } = action.payload;
       const newErrorBlock: ErrorBlock = { type: "error", content: error };
 
-      // Find the last assistant message
-      let targetIndex = -1;
-      for (let i = state.messages.length - 1; i >= 0; i--) {
-        if (state.messages[i].role === "assistant") {
-          targetIndex = i;
-          break;
-        }
-      }
-
-      // No assistant message yet (e.g. API error before any streaming chunk).
-      // Create one to carry the error block instead of silently dropping it.
-      if (targetIndex === -1) {
-        const errorMessage: Message = {
-          id: `msg-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
-          role: "assistant",
-          timestamp: new Date().toISOString(),
-          blocks: [newErrorBlock],
-        };
+      // Append to the LAST message only if it is an assistant message — that
+      // message is the current turn's in-flight reply. If the last message is
+      // a user message (the previous turn's assistant already finished), the
+      // error belongs BELOW that user message: create a new assistant message
+      // to carry it instead of polluting the stale assistant from an earlier
+      // turn (which surfaced the error above the latest user message).
+      const lastMessage = state.messages[state.messages.length - 1];
+      if (lastMessage && lastMessage.role === "assistant") {
+        const newBlocks = [...lastMessage.blocks, newErrorBlock];
         return {
           ...state,
-          messages: [...state.messages, errorMessage],
+          messages: state.messages.map((m, idx) =>
+            idx === state.messages.length - 1
+              ? { ...m, blocks: newBlocks }
+              : m,
+          ),
         };
       }
 
-      const message = state.messages[targetIndex];
-      const newBlocks = [...message.blocks, newErrorBlock];
-
-      const newMessages = state.messages.map((m, idx) => {
-        if (idx === targetIndex) {
-          return { ...m, blocks: newBlocks };
-        }
-        return m;
-      });
-
+      // Last message is a user message (or none yet). Create a new assistant
+      // message to carry the error block instead of silently dropping it.
+      const errorMessage: Message = {
+        id: `msg-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
+        role: "assistant",
+        timestamp: new Date().toISOString(),
+        blocks: [newErrorBlock],
+      };
       return {
         ...state,
-        messages: newMessages,
+        messages: [...state.messages, errorMessage],
       };
     }
     // Bang message incremental updates (keyed by messageId). Mirrors the CLI's

--- a/packages/webview/tests/reducers/chatReducer.test.ts
+++ b/packages/webview/tests/reducers/chatReducer.test.ts
@@ -716,6 +716,50 @@ describe("chatReducer", () => {
       expect(newState.messages[0].blocks).toHaveLength(1);
     });
 
+    it("appends the error to a NEW assistant message when the last message is a user message (regression: stale assistant from a previous turn)", () => {
+      const userMsg: Message = {
+        id: "msg-1",
+        role: "user",
+        timestamp: "0",
+        blocks: [{ type: "text", content: "Hi", stage: "end" }],
+      };
+      const assistantMsg: Message = {
+        id: "msg-2",
+        role: "assistant",
+        timestamp: "0",
+        blocks: [{ type: "text", content: "Hello", stage: "end" }],
+      };
+      const latestUserMsg: Message = {
+        id: "msg-3",
+        role: "user",
+        timestamp: "0",
+        blocks: [{ type: "text", content: "帮我执行 X", stage: "end" }],
+      };
+      const state = {
+        ...initialState,
+        messages: [userMsg, assistantMsg, latestUserMsg],
+      };
+
+      const newState = chatReducer(state, {
+        type: "APPEND_ERROR_BLOCK",
+        payload: { error: "插件执行失败" },
+      });
+
+      // The error belongs under the LATEST user message, so a new assistant
+      // message must be created — appending to the previous turn's assistant
+      // would surface the error above the latest user message and accumulate.
+      expect(newState.messages).toHaveLength(4);
+      const errorMessage = newState.messages[3];
+      expect(errorMessage.role).toBe("assistant");
+      expect(errorMessage.blocks).toHaveLength(1);
+      const errorBlock = errorMessage.blocks[0] as ErrorBlock;
+      expect(errorBlock.type).toBe("error");
+      expect(errorBlock.content).toBe("插件执行失败");
+      // Previous turn's assistant message is left untouched.
+      expect(newState.messages[1].blocks).toHaveLength(1);
+      expect(newState.messages[2]).toBe(latestUserMsg);
+    });
+
     it("should create a new assistant message with error block if no assistant message exists", () => {
       const userMessage: Message = {
         id: "msg-1",


### PR DESCRIPTION
Error blocks from AI plugin conversations were appended to the last assistant message found by scanning backwards, even when that assistant message belonged to a previous turn. With the latest user message above it, errors surfaced ABOVE the user message and accumulated there across turns.

Align all three message-mutation sites with the agent-sdk addErrorBlockToMessage semantics: append to the last message only when it is an assistant message (the in-flight reply); otherwise create a new assistant message carrying the error block, so it renders directly below the latest user message.

- webview reducer APPEND_ERROR_BLOCK (all hosts)
- desktopHost onErrorBlockAdded cache mirror (session switch/restore)
- CLI useChat onErrorBlockAdded UI snapshot

Regression tests cover user-assistant-user message states across all three layers. Webview 666 / desktop 494 / code 1372 tests green; type-check and lint pass.