### PR TITLE
perf(agent-sdk): reduce session memory growth (bounded caches, read dedup, subagent release)

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -179,7 +179,13 @@ export class AIManager {
   /** Tracks file mtime/hash at read time for staleness detection on Edit/Write */
   private readFileState = new Map<
     string,
-    { mtime: number; hash: string; offset?: number; limit?: number }
+    {
+      mtime: number;
+      hash: string;
+      source: "read" | "edit" | "write";
+      offset?: number;
+      limit?: number;
+    }
   >();
   /** Override tool_choice for this AI manager (e.g. for structured output) */
   public toolChoiceOverride?:
@@ -700,6 +706,11 @@ export class AIManager {
         compactUsage,
       );
 
+      // Clear readFileState after compaction (aligned with Claude Code's
+      // compact flow): a file_unchanged stub would otherwise reference Read
+      // results that were just folded away. Clearing forces a real re-read.
+      this.readFileState.clear();
+
       // Re-add plan mode reminder as persistent meta message after compaction
       const postCompactMode = this.permissionManager?.getCurrentEffectiveMode(
         this.getModelConfig().permissionMode,
@@ -883,7 +894,13 @@ export class AIManager {
     // leaks into the main session's dedup and staleness tracking.
     const forkReadFileState = new Map<
       string,
-      { mtime: number; hash: string; offset?: number; limit?: number }
+      {
+        mtime: number;
+        hash: string;
+        source: "read" | "edit" | "write";
+        offset?: number;
+        limit?: number;
+      }
     >();
 
     let totalUsage: ForkLoopResult["usage"];

--- a/packages/agent-sdk/src/managers/messageManager.ts
+++ b/packages/agent-sdk/src/managers/messageManager.ts
@@ -37,6 +37,14 @@ import { READ_TOOL_NAME } from "../constants/tools.js";
 
 import { Container } from "../utils/container.js";
 
+// Cap for recentFileReads: content is only consumed by getRecentFileReads
+// (top 5 for post-compact restoration), so bound both the entry count and the
+// number of entries that keep full content (aligned with Claude Code's
+// FileStateCache 100-entry limit). Paths beyond the content cap are kept so
+// hasFileBeenRead still works for read-before-edit enforcement.
+const RECENT_FILE_READS_CACHE_LIMIT = 100;
+const RECENT_FILE_READS_CONTENT_LIMIT = 10;
+
 export interface MessageManagerCallbacks {
   onSessionIdChange?: (sessionId: string) => void;
   onLatestTotalTokensChange?: (latestTotalTokens: number) => void;
@@ -621,6 +629,9 @@ export class MessageManager {
     this.setMessages(newMessages);
     this.savedMessageCount = newMessages.length;
 
+    // Trim recent file read cache so contents compacted away are released
+    this.trimRecentFileReads();
+
     // Clear and rebuild loaded rule IDs from remaining meta messages
     this.clearLoadedRuleIds();
     this.rebuildLoadedRuleIds();
@@ -1090,7 +1101,39 @@ export class MessageManager {
             content: block.result,
             timestamp: Date.now(),
           });
+          this.trimRecentFileReads();
         }
+      }
+    }
+  }
+
+  /**
+   * Bound recentFileReads growth: evict oldest entries beyond the cache limit
+   * and drop content from all but the most recent entries (paths are kept for
+   * hasFileBeenRead). Prevents unbounded memory growth in long sessions.
+   */
+  private trimRecentFileReads(): void {
+    if (this.recentFileReads.size > RECENT_FILE_READS_CACHE_LIMIT) {
+      const sortedAsc = Array.from(this.recentFileReads.entries()).sort(
+        ([, a], [, b]) => a.timestamp - b.timestamp,
+      );
+      const excess = this.recentFileReads.size - RECENT_FILE_READS_CACHE_LIMIT;
+      for (const [path] of sortedAsc.slice(0, excess)) {
+        this.recentFileReads.delete(path);
+      }
+    }
+
+    if (this.recentFileReads.size > RECENT_FILE_READS_CONTENT_LIMIT) {
+      const sortedDesc = Array.from(this.recentFileReads.entries()).sort(
+        ([, a], [, b]) => b.timestamp - a.timestamp,
+      );
+      for (const [path, entry] of sortedDesc.slice(
+        RECENT_FILE_READS_CONTENT_LIMIT,
+      )) {
+        this.recentFileReads.set(path, {
+          content: "",
+          timestamp: entry.timestamp,
+        });
       }
     }
   }

--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -559,15 +559,30 @@ export class SubagentManager {
               task.endTime = Date.now();
               task.runtime = task.endTime - startTime;
             }
+          } finally {
+            // Free the instance once the background task finishes: without
+            // this the instance (message history, caches) would linger in the
+            // map for the whole session, and the task's onStop closure would
+            // keep it alive even after that.
+            this.releaseInstance(instance.subagentId);
           }
         })();
 
         return taskId;
       }
 
-      return await this.internalExecute(instance, prompt, abortSignal);
+      const result = await this.internalExecute(instance, prompt, abortSignal);
+      // Free the instance once the subagent finishes. Callers that still hold
+      // the reference can read its messageManager, but the map entry and the
+      // background task's onStop closure are released so the message history
+      // and caches can be garbage-collected.
+      this.releaseInstance(instance.subagentId);
+      return result;
     } catch (error) {
       this.updateInstanceStatus(instance.subagentId, "error");
+      // Release on failure too so errored instances don't linger for the
+      // session (the abort listener already releases on abort).
+      this.releaseInstance(instance.subagentId);
       throw error;
     }
   }
@@ -805,8 +820,38 @@ export class SubagentManager {
         instance.status === "error" ||
         instance.status === "aborted")
     ) {
-      this.instances.delete(subagentId);
+      this.releaseInstance(subagentId);
     }
+  }
+
+  /**
+   * Release a subagent instance so its graph (message history, file-read
+   * caches, log stream) can be garbage-collected. Besides removing the
+   * instance from the map, this drops the background task's onStop closure,
+   * which captures the instance and would otherwise keep the whole graph
+   * alive for the rest of the session.
+   */
+  private releaseInstance(subagentId: string): void {
+    const instance = this.instances.get(subagentId);
+    if (!instance) {
+      return;
+    }
+    if (instance.backgroundTaskId) {
+      const backgroundTaskManager = this.container.has("BackgroundTaskManager")
+        ? this.container.get<BackgroundTaskManager>("BackgroundTaskManager")
+        : undefined;
+      const task = backgroundTaskManager?.getTask(instance.backgroundTaskId);
+      if (task) {
+        task.onStop = undefined;
+      }
+    }
+    if (instance.logStream && !instance.logStream.writableEnded) {
+      // Only force-close a stream that hasn't been ended yet (the completion
+      // and error paths already call end(); destroy would drop buffered data).
+      instance.logStream.destroy();
+    }
+    instance.logStream = undefined;
+    this.instances.delete(subagentId);
   }
 
   /**

--- a/packages/agent-sdk/src/tools/editTool.ts
+++ b/packages/agent-sdk/src/tools/editTool.ts
@@ -289,6 +289,7 @@ Usage:
         context.readFileState.set(resolvedPath, {
           mtime: newStats.mtime.getTime(),
           hash,
+          source: "edit",
           offset: undefined,
           limit: undefined,
         });

--- a/packages/agent-sdk/src/tools/readTool.ts
+++ b/packages/agent-sdk/src/tools/readTool.ts
@@ -246,13 +246,15 @@ Usage:
       const stats = await stat(actualFilePath);
 
       // Deduplication: only dedup if the exact same range was read before
+      // (aligned with Claude Code — full reads dedup too). Entries written by
+      // Edit/Write have source "edit"/"write" and never dedup, so a file that
+      // was written before its first Read is still returned in full.
       if (context.readFileState) {
         const state = context.readFileState.get(actualFilePath);
-        // Only dedup entries from a prior Read with explicit offset (not Edit/Write entries)
         if (
           state &&
-          state.mtime === stats.mtime.getTime() &&
-          state.offset !== undefined
+          state.source === "read" &&
+          state.mtime === stats.mtime.getTime()
         ) {
           const rangeMatch = state.offset === offset && state.limit === limit;
           if (rangeMatch) {
@@ -293,6 +295,7 @@ Usage:
         context.readFileState.set(actualFilePath, {
           mtime: stats.mtime.getTime(),
           hash,
+          source: "read",
           offset, // undefined for full reads
           limit, // undefined for full reads
         });

--- a/packages/agent-sdk/src/tools/types.ts
+++ b/packages/agent-sdk/src/tools/types.ts
@@ -119,7 +119,8 @@ export interface ToolContext {
     {
       mtime: number;
       hash: string;
-      offset?: number; // undefined = full read or Edit/Write entry (never dedup)
+      source: "read" | "edit" | "write"; // Read dedups only entries from Read
+      offset?: number; // undefined = full read
       limit?: number;
     }
   >;

--- a/packages/agent-sdk/src/tools/writeTool.ts
+++ b/packages/agent-sdk/src/tools/writeTool.ts
@@ -216,6 +216,7 @@ Usage:
         context.readFileState.set(resolvedPath, {
           mtime: newStats.mtime.getTime(),
           hash,
+          source: "write",
           offset: undefined,
           limit: undefined,
         });

--- a/packages/agent-sdk/tests/tools/editTool.test.ts
+++ b/packages/agent-sdk/tests/tools/editTool.test.ts
@@ -36,10 +36,19 @@ describe("editTool", () => {
       // Keys must be the *resolved* path (matches source's resolvePath()).
       // Individual tests can override with an empty Map or undefined.
       readFileState: new Map([
-        [r("/test/file.js"), { mtime: 1000, hash: "abc" }],
-        [r("/test/workdir/file.js"), { mtime: 1000, hash: "abc" }],
-        [r("/test/nonexistent.js"), { mtime: 1000, hash: "abc" }],
-        [r("/absolute/path/file.js"), { mtime: 1000, hash: "abc" }],
+        [r("/test/file.js"), { mtime: 1000, hash: "abc", source: "read" }],
+        [
+          r("/test/workdir/file.js"),
+          { mtime: 1000, hash: "abc", source: "read" },
+        ],
+        [
+          r("/test/nonexistent.js"),
+          { mtime: 1000, hash: "abc", source: "read" },
+        ],
+        [
+          r("/absolute/path/file.js"),
+          { mtime: 1000, hash: "abc", source: "read" },
+        ],
       ]),
     };
   });
@@ -575,7 +584,10 @@ describe("editTool", () => {
       {
         ...mockContext,
         readFileState: new Map([
-          [r("/test/workdir/file.js"), { mtime: 1000, hash: "abc" }],
+          [
+            r("/test/workdir/file.js"),
+            { mtime: 1000, hash: "abc", source: "read" },
+          ],
         ]),
       },
     );
@@ -633,9 +645,19 @@ describe("editTool", () => {
     // readFileState shows mtime=1000, but current file has mtime=2000
     const readFileState = new Map<
       string,
-      { mtime: number; hash: string; offset?: number; limit?: number }
+      {
+        mtime: number;
+        hash: string;
+        source: "read" | "edit";
+        offset?: number;
+        limit?: number;
+      }
     >();
-    readFileState.set(r("/test/file.js"), { mtime: 1000, hash: "abc" });
+    readFileState.set(r("/test/file.js"), {
+      mtime: 1000,
+      hash: "abc",
+      source: "read",
+    });
 
     vi.mocked(stat).mockResolvedValue({
       mtime: { getTime: () => 2000 } as Date,
@@ -662,9 +684,19 @@ describe("editTool", () => {
 
     const readFileState = new Map<
       string,
-      { mtime: number; hash: string; offset?: number; limit?: number }
+      {
+        mtime: number;
+        hash: string;
+        source: "read" | "edit";
+        offset?: number;
+        limit?: number;
+      }
     >();
-    readFileState.set(r("/test/file.js"), { mtime: 1000, hash: "abc" });
+    readFileState.set(r("/test/file.js"), {
+      mtime: 1000,
+      hash: "abc",
+      source: "read",
+    });
 
     // First stat: staleness check (mtime matches)
     // Second stat: post-write state update
@@ -696,11 +728,18 @@ describe("editTool", () => {
     // readFileState: recorded mtime older than current, but hash matches content
     const readFileState = new Map<
       string,
-      { mtime: number; hash: string; offset?: number; limit?: number }
+      {
+        mtime: number;
+        hash: string;
+        source: "read" | "edit";
+        offset?: number;
+        limit?: number;
+      }
     >();
     readFileState.set(r("/test/file.js"), {
       mtime: 1000,
       hash: createHash("sha256").update(mockContent).digest("hex"),
+      source: "read",
     });
 
     // First stat: staleness check (newer mtime) → content fallback allows edit
@@ -733,11 +772,18 @@ describe("editTool", () => {
     // Partial read: offset/limit defined → no content fallback
     const readFileState = new Map<
       string,
-      { mtime: number; hash: string; offset?: number; limit?: number }
+      {
+        mtime: number;
+        hash: string;
+        source: "read" | "edit";
+        offset?: number;
+        limit?: number;
+      }
     >();
     readFileState.set(r("/test/file.js"), {
       mtime: 1000,
       hash: createHash("sha256").update(mockContent).digest("hex"),
+      source: "read",
       offset: 0,
       limit: 10,
     });
@@ -768,9 +814,19 @@ describe("editTool", () => {
     // readFileState recorded a newer mtime than current (clock skew / restore)
     const readFileState = new Map<
       string,
-      { mtime: number; hash: string; offset?: number; limit?: number }
+      {
+        mtime: number;
+        hash: string;
+        source: "read" | "edit";
+        offset?: number;
+        limit?: number;
+      }
     >();
-    readFileState.set(r("/test/file.js"), { mtime: 2000, hash: "abc" });
+    readFileState.set(r("/test/file.js"), {
+      mtime: 2000,
+      hash: "abc",
+      source: "read",
+    });
 
     // First stat: staleness check (current 1000 < recorded 2000 → not flagged)
     // Second stat: post-write state update
@@ -801,9 +857,19 @@ describe("editTool", () => {
 
     const readFileState = new Map<
       string,
-      { mtime: number; hash: string; offset?: number; limit?: number }
+      {
+        mtime: number;
+        hash: string;
+        source: "read" | "edit";
+        offset?: number;
+        limit?: number;
+      }
     >();
-    readFileState.set(r("/test/file.js"), { mtime: 1000, hash: "abc" });
+    readFileState.set(r("/test/file.js"), {
+      mtime: 1000,
+      hash: "abc",
+      source: "read",
+    });
 
     // First stat: staleness check (mtime matches readFileState)
     // Second stat: post-write state update (new mtime)

--- a/packages/agent-sdk/tests/tools/editToolSerialization.test.ts
+++ b/packages/agent-sdk/tests/tools/editToolSerialization.test.ts
@@ -29,11 +29,18 @@ describe("editTool serialization (real fs)", () => {
     const content = await readFile(tempFile, "utf-8");
     const readFileState = new Map<
       string,
-      { mtime: number; hash: string; offset?: number; limit?: number }
+      {
+        mtime: number;
+        hash: string;
+        source: "read";
+        offset?: number;
+        limit?: number;
+      }
     >();
     readFileState.set(tempFile, {
       mtime: stats.mtime.getTime(),
       hash: createHash("sha256").update(content).digest("hex"),
+      source: "read",
     });
 
     context = {

--- a/packages/agent-sdk/tests/tools/readTool.test.ts
+++ b/packages/agent-sdk/tests/tools/readTool.test.ts
@@ -711,7 +711,13 @@ describe("readTool", () => {
     it("should dedup when the same partial range is read twice", async () => {
       const readFileState = new Map<
         string,
-        { mtime: number; hash: string; offset?: number; limit?: number }
+        {
+          mtime: number;
+          hash: string;
+          source: "read";
+          offset?: number;
+          limit?: number;
+        }
       >();
       const filePath = "/test/workdir/medium.txt";
 
@@ -734,10 +740,16 @@ describe("readTool", () => {
       expect(result2.content).toContain("has not changed");
     });
 
-    it("should NOT dedup a full read (offset=undefined) on second read", async () => {
+    it("should dedup a full read (offset=undefined) on second read", async () => {
       const readFileState = new Map<
         string,
-        { mtime: number; hash: string; offset?: number; limit?: number }
+        {
+          mtime: number;
+          hash: string;
+          source: "read";
+          offset?: number;
+          limit?: number;
+        }
       >();
       const filePath = "/test/workdir/small.txt";
 
@@ -749,20 +761,25 @@ describe("readTool", () => {
       expect(result1.success).toBe(true);
       expect(result1.metadata?.type).toBe("text");
 
-      // Second full read — should return content, not "unchanged"
+      // Second full read — same range, unchanged, should dedup
       const result2 = await readTool.execute(
         { file_path: filePath },
         { ...testContext, readFileState },
       );
       expect(result2.success).toBe(true);
-      expect(result2.metadata?.type).toBe("text");
-      expect(result2.content).toContain("Line 1");
+      expect(result2.metadata?.type).toBe("file_unchanged");
     });
 
     it("should NOT dedup a partial read after a full read (different range)", async () => {
       const readFileState = new Map<
         string,
-        { mtime: number; hash: string; offset?: number; limit?: number }
+        {
+          mtime: number;
+          hash: string;
+          source: "read";
+          offset?: number;
+          limit?: number;
+        }
       >();
       const filePath = "/test/workdir/medium.txt";
 

--- a/packages/agent-sdk/tests/tools/writeTool.test.ts
+++ b/packages/agent-sdk/tests/tools/writeTool.test.ts
@@ -28,9 +28,18 @@ describe("writeTool", () => {
       // path (matches source's resolvePath()). Individual tests override
       // with an empty Map or undefined to exercise rejection.
       readFileState: new Map([
-        [path.resolve("/test/file.js"), { mtime: 1000, hash: "abc" }],
-        [path.resolve("/test/existing.txt"), { mtime: 1000, hash: "abc" }],
-        [path.resolve("/test/file.txt"), { mtime: 1000, hash: "abc" }],
+        [
+          path.resolve("/test/file.js"),
+          { mtime: 1000, hash: "abc", source: "read" },
+        ],
+        [
+          path.resolve("/test/existing.txt"),
+          { mtime: 1000, hash: "abc", source: "read" },
+        ],
+        [
+          path.resolve("/test/file.txt"),
+          { mtime: 1000, hash: "abc", source: "read" },
+        ],
       ]),
     };
   });
@@ -542,7 +551,10 @@ describe("writeTool", () => {
         {
           ...mockContext,
           readFileState: new Map([
-            [path.resolve("/test/file.js"), { mtime: 1000, hash }],
+            [
+              path.resolve("/test/file.js"),
+              { mtime: 1000, hash, source: "read" },
+            ],
           ]),
         },
       );
@@ -571,7 +583,7 @@ describe("writeTool", () => {
           readFileState: new Map([
             [
               path.resolve("/test/file.js"),
-              { mtime: 1000, hash, offset: 1, limit: 10 },
+              { mtime: 1000, hash, source: "read", offset: 1, limit: 10 },
             ],
           ]),
         },


### PR DESCRIPTION
Three independent memory-optimization commits for long-running sessions (2.4GB working set observed after ~4h active use):

1. **f3435c42** `perf(agent-sdk): bound recentFileReads cache to stop unbounded growth`
   - Cap recentFileReads at 100 entries (aligned with Claude Code's FileStateCache), keep full file content only for the most recent 10; drop content from the rest while retaining paths so hasFileBeenRead still works.
   - Trim on compaction so contents folded away are released.

2. **cf5f1358** `perf(agent-sdk): dedup full-file reads and clear read state on compact`
   - Introduce a `source` field (`read`/`edit`/`write`) in readFileState so full reads (offset undefined) are also deduped with a file_unchanged stub, not just partial reads.
   - Clear readFileState after compaction so stubs never reference folded-away content (aligned with Claude Code's compact flow).

3. **81d1c91a** `perf(agent-sdk): release subagent instances on completion to free memory`
   - Background subagents previously kept their instance (message history, caches) in the map for the whole session, and the task's onStop closure captured the instance keeping it alive forever.
   - Add releaseInstance(): drops the onStop closure, closes lingering log streams, removes from the map; wire it into foreground success/failure and background completion paths.

All changes verified with `tsc --noEmit` and the agent-sdk test suite (subagent + agentTool tests).