### PR TITLE
fix(desktop): dedupe recent workdirs differing only in slash style

### DIFF
--- a/packages/desktop/src/main/configStore.ts
+++ b/packages/desktop/src/main/configStore.ts
@@ -74,10 +74,10 @@ export class ConfigStore {
       return {
         configuration: parsed.configuration ?? {},
         // Legacy plain-string entries (pre-remote) become local-host refs.
+        // Deduped on load so older data where one directory was persisted with
+        // two slash styles (e.g. `C:\a` and `C:/a`) collapses into one entry.
         recentWorkdirs: Array.isArray(parsed.recentWorkdirs)
-          ? parsed.recentWorkdirs
-              .map(normalizeWorkdirRef)
-              .filter((d): d is WorkdirRef => d !== null)
+          ? dedupeRecentWorkdirs(parsed.recentWorkdirs)
           : [],
         sessions: Array.isArray(parsed.sessions)
           ? parsed.sessions
@@ -147,16 +147,20 @@ export class ConfigStore {
   /**
    * Push a directory to the front of its host's recent list (MRU, deduped).
    * The list is per-host: the same path on two hosts are distinct entries.
+   * Paths are normalized (slash style) before comparing/storing so the same
+   * local directory entered with `\` or `/` never shows up twice.
    */
   addRecentWorkdir(ref: WorkdirRef): void {
+    const normalized = normalizeWorkdirRef(ref);
+    if (!normalized) return;
     const key = (d: string | WorkdirRef): string => {
       const w = normalizeWorkdirRef(d);
       return w ? `${w.host}\u0000${w.path}` : "";
     };
     this.data.recentWorkdirs = [
-      ref,
+      normalized,
       ...this.data.recentWorkdirs.filter(
-        (d) => key(d) !== `${ref.host}\u0000${ref.path}`,
+        (d) => key(d) !== `${normalized.host}\u0000${normalized.path}`,
       ),
     ].slice(0, MAX_RECENT_WORKDIRS);
     this.save();
@@ -231,7 +235,7 @@ function normalizeWorkdirRef(
   value: string | WorkdirRef | undefined | null,
 ): WorkdirRef | null {
   if (typeof value === "string") {
-    return value ? { host: LOCAL_HOST, path: value } : null;
+    return value ? { host: LOCAL_HOST, path: normalizeLocalPath(value) } : null;
   }
   if (
     typeof value === "object" &&
@@ -239,7 +243,52 @@ function normalizeWorkdirRef(
     typeof value.host === "string" &&
     typeof value.path === "string"
   ) {
-    return value;
+    return {
+      host: value.host,
+      // Remote paths are POSIX and case-sensitive; only local paths on Windows
+      // tolerate both slash styles and a trailing separator.
+      path:
+        value.host === LOCAL_HOST ? normalizeLocalPath(value.path) : value.path,
+    };
   }
   return null;
+}
+
+/**
+ * Dedupe by (host, path) after normalization, keeping the first (MRU-most)
+ * occurrence of each directory. Callers pass disk-form arrays; malformed
+ * entries are dropped.
+ */
+function dedupeRecentWorkdirs(
+  entries: Array<string | WorkdirRef>,
+): WorkdirRef[] {
+  const seen = new Set<string>();
+  const out: WorkdirRef[] = [];
+  for (const raw of entries) {
+    const w = normalizeWorkdirRef(raw);
+    if (!w) continue;
+    const key = `${w.host}\u0000${w.path}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(w);
+  }
+  return out;
+}
+
+/**
+ * Normalize a local Windows path so equivalent spellings of the same directory
+ * compare equal: unify separators (`C:/a` → `C:\a`) and drop a redundant
+ * trailing separator (`C:\a\` → `C:\a`, but drive roots keep it). POSIX paths
+ * (and remote-host paths, which stay POSIX) are returned unchanged — detection
+ * is purely by shape, so this is a no-op on non-Windows spellings everywhere.
+ */
+function normalizeLocalPath(p: string): string {
+  const hasDrive = /^[A-Za-z]:[\\/]/.test(p);
+  const hasUnc = /^[\\/]{2}[^\\/]/.test(p);
+  if (!hasDrive && !hasUnc) return p;
+  const normalized = path.win32.normalize(p);
+  // `C:\` (drive root) keeps its separator; everything else drops it.
+  return normalized.length > 3 && normalized.endsWith("\\")
+    ? normalized.slice(0, -1)
+    : normalized;
 }

--- a/packages/desktop/tests/configStore.test.ts
+++ b/packages/desktop/tests/configStore.test.ts
@@ -179,6 +179,44 @@ describe("ConfigStore", () => {
     ]);
   });
 
+  it("treats C:\\a and C:/a as the same local workdir", () => {
+    const store = new ConfigStore(STORE_PATH);
+    store.addRecentWorkdir({ host: "local", path: "C:\\Users\\foo" });
+    store.addRecentWorkdir({ host: "local", path: "C:/Users/foo" });
+    store.addRecentWorkdir({ host: "local", path: "C:\\Users\\foo\\" });
+
+    expect(store.getRecentWorkdirs()).toEqual([
+      { host: "local", path: "C:\\Users\\foo" },
+    ]);
+  });
+
+  it("merges pre-existing duplicates that differ only in slash style on load", () => {
+    h.files.set(
+      STORE_PATH,
+      JSON.stringify({
+        configuration: {},
+        recentWorkdirs: [
+          { host: "local", path: "C:\\Users\\foo" },
+          { host: "local", path: "C:/Users/foo" },
+          { host: "local", path: "D:/other" },
+        ],
+      }),
+    );
+    const store = new ConfigStore(STORE_PATH);
+    expect(store.getRecentWorkdirs()).toEqual([
+      { host: "local", path: "C:\\Users\\foo" },
+      { host: "local", path: "D:\\other" },
+    ]);
+  });
+
+  it("keeps remote POSIX paths untouched", () => {
+    const store = new ConfigStore(STORE_PATH);
+    store.addRecentWorkdir({ host: "devbox", path: "/home/dev/repo" });
+    expect(store.getRecentWorkdirs()).toEqual([
+      { host: "devbox", path: "/home/dev/repo" },
+    ]);
+  });
+
   // ── Session index ──────────────────────────────────────────────
 
   it("starts with empty session index", () => {


### PR DESCRIPTION
## 背景

Windows 桌面端最近目录出现两条相同路径，仅斜杠形式不同（如 `C:\Users\foo` 与 `C:/Users/foo`）。根因是 `ConfigStore.addRecentWorkdir` 的去重 key 使用原始字符串精确比较：系统目录对话框返回反斜杠路径，而 session/worktree 等其他来源携带正斜杠路径，同一目录被当作两个条目。

## 改动

`packages/desktop/src/main/configStore.ts`:
- 新增 `normalizeLocalPath()`：按路径形态（盘符/UNC）识别 Windows 路径，统一分隔符为反斜杠并去除冗余尾部斜杠（盘符根 `C:\` 保留）；POSIX/远端路径原样返回，跨平台安全
- `normalizeWorkdirRef()`：本地路径先规范化再用于比较与返回
- `addRecentWorkdir()`：存储规范化后的路径，保证去重 key 一致
- 新增 `dedupeRecentWorkdirs()`：加载旧数据时合并历史存量重复条目，已存在的重复项自愈为一条

## 验证

- 新增 4 个测试用例（正斜杠去重、存量合并、远端路径不受影响、尾部斜杠）
- configStore 29 个 + desktopHost 257 个测试全部通过
- tsc、eslint、prettier 通过