### PR TITLE
perf: speed up pre-commit type-check and lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ node_modules/
 dist/
 build/
 .eslintcache
-tsconfig.tsbuildinfo
+*.tsbuildinfo
 *.log
 .env*
 coverage/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,3 @@
 pnpm run type-check
-pnpm -r lint
 pnpm exec lint-staged
 node scripts/check-docs-links.mjs --skip-images && node scripts/check-sidebar-anchors.mjs

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,5 @@
 pnpm run type-check
 pnpm exec lint-staged
-node scripts/check-docs-links.mjs --skip-images && node scripts/check-sidebar-anchors.mjs
+if git diff --cached --name-only | grep -q '^docs/'; then
+  node scripts/check-docs-links.mjs --skip-images && node scripts/check-sidebar-anchors.mjs
+fi

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,4 @@
 {
-  "*.json": ["prettier --write"]
+  "*.{js,ts,tsx,mjs,cjs}": ["prettier --write"],
+  "*.{json,md,yml,yaml}": ["prettier --write"]
 }

--- a/packages/desktop/.lintstagedrc.json
+++ b/packages/desktop/.lintstagedrc.json
@@ -1,0 +1,4 @@
+{
+  "*.{js,ts,tsx}": ["eslint --fix", "prettier --write"],
+  "*.json": ["prettier --write"]
+}

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -16,7 +16,7 @@
     "dev": "pnpm run compile && node scripts/dev.mjs",
     "dist": "pnpm run compile && electron-builder",
     "clean": "node -e \"import('fs').then(fs => ['dist', 'release', 'webview'].forEach(d => {try{fs.rmSync(d, {recursive:true, force:true})}catch(e){}}))\"",
-    "type-check": "tsc --noEmit && tsc -p tests --noEmit",
+    "type-check": "tsc --noEmit --incremental && tsc -p tests --noEmit --incremental",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint --cache",

--- a/packages/desktop/tests/tsconfig.json
+++ b/packages/desktop/tests/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "rootDir": "..",
+    "tsBuildInfoFile": "./tsconfig.tests.tsbuildinfo",
     "types": ["node", "vitest/globals"]
   },
   "include": ["../src/**/*", "./**/*"]

--- a/packages/vscode/.lintstagedrc.json
+++ b/packages/vscode/.lintstagedrc.json
@@ -1,0 +1,4 @@
+{
+  "*.{js,ts,tsx}": ["eslint --fix", "prettier --write"],
+  "*.json": ["prettier --write"]
+}

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -95,7 +95,7 @@
     "sync:webview": "node scripts/syncWebview.mjs",
     "esbuild:prod": "node esbuild.config.mjs --production && node scripts/syncWebview.mjs --production",
     "package": "node scripts/package.mjs",
-    "type-check": "tsc --noEmit && tsc -p tests --noEmit",
+    "type-check": "tsc --noEmit --incremental && tsc -p tests --noEmit --incremental",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "preinstall:vsix": "pnpm run package",

--- a/packages/webview-fixtures/.lintstagedrc.json
+++ b/packages/webview-fixtures/.lintstagedrc.json
@@ -1,0 +1,4 @@
+{
+  "*.{js,ts,tsx}": ["prettier --write"],
+  "*.json": ["prettier --write"]
+}

--- a/packages/webview/.lintstagedrc.json
+++ b/packages/webview/.lintstagedrc.json
@@ -1,0 +1,4 @@
+{
+  "*.{js,ts,tsx}": ["eslint --fix", "prettier --write"],
+  "*.json": ["prettier --write"]
+}

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -17,7 +17,7 @@
     "clean": "node -e \"import('fs').then(fs => {try{fs.rmSync('dist', {recursive:true, force:true})}catch(e){}})\"",
     "compile": "node esbuild.config.mjs",
     "watch": "node esbuild.config.mjs --watch",
-    "type-check": "tsc --noEmit && tsc -p tests --noEmit",
+    "type-check": "tsc --noEmit --incremental && tsc -p tests --noEmit --incremental",
     "lint": "eslint --cache",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
Speed up the pre-commit hook by caching, incrementality and narrowing the work done per commit.

- perf: enable incremental tsc for desktop/vscode/webview type-check
  `tsc --noEmit --incremental` for the three packages that were still full runs (each runs twice: main + tests configs); desktop tests tsBuildInfoFile separated from the main build; `.gitignore` now covers `*.tsbuildinfo`.
- perf: lint only staged files via per-package lint-staged configs
  Removed the full-repo `pnpm -r lint` from the pre-commit hook. Each package now has its own `.lintstagedrc.json` so eslint+prettier run only on staged files, in the package directory (flat config CWD resolution). Full lint still runs in CI (`pnpm ci`).
- perf: run docs link checks only when docs change
  `scripts/check-docs-links.mjs` and `check-sidebar-anchors.mjs` now only run when the staged diff touches `docs/`.