### PR TITLE
ci: auto-publish IDE plugins to marketplaces on tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,12 +3,12 @@ name: Publish Package
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
   workflow_dispatch:
 
 permissions:
-  id-token: write  # Required for OIDC
-  contents: write  # Required for creating GitHub Release
+  id-token: write # Required for OIDC
+  contents: write # Required for creating GitHub Release
 
 jobs:
   publish:
@@ -24,9 +24,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
@@ -36,6 +36,26 @@ jobs:
       # --- VS Code extension (.vsix) ---
       - name: Package .vsix
         run: pnpm -F wave-vscode run package
+
+      # --- VS Code Marketplace (Entra ID, no PAT) ---
+      # PATs retire 2026-12-01; publish via Azure OIDC federated credentials
+      # instead: azure/login@v2 exchanges the Actions id-token (federated
+      # credential Subject: repo:netease-lcap/wave-agent:ref:refs/tags/v*),
+      # and `vsce publish --azure-credential` reuses the resulting az login
+      # cache — no PAT secret involved.
+      # Only runs on tag pushes; workflow_dispatch (asset re-upload) must not
+      # re-publish because the marketplace rejects duplicate versions.
+      - name: Azure login
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Publish to VS Code Marketplace
+        if: startsWith(github.ref, 'refs/tags/')
+        run: pnpm -F wave-vscode exec vsce publish --azure-credential --packagePath releases/*.vsix
 
       # --- Docs (docs-<version>.tar.gz) ---
       - name: Cache Playwright browsers
@@ -101,7 +121,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: "17"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -111,8 +131,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
-          cache: 'pnpm'
+          node-version: "22"
+          cache: "pnpm"
 
       - name: Install deps
         run: pnpm install --frozen-lockfile
@@ -145,6 +165,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # --- JetBrains Marketplace ---
+      # publishPlugin uploads the distribution built above (plugin id
+      # com.wave.jetbrains read from plugin.xml). JetBrains has no OIDC
+      # equivalent, so this needs a permanent marketplace token.
+      # Same duplicate-version guard as the VS Code step: tag pushes only.
+      - name: Publish to JetBrains Marketplace
+        if: startsWith(github.ref, 'refs/tags/')
+        run: ./packages/jetbrains/gradlew -p packages/jetbrains publishPlugin --no-daemon -PintellijPublishToken=${{ secrets.JETBRAINS_TOKEN }}
+
   # --- Desktop app (Electron) ---
   # Builds the desktop installers and attaches them to the same GitHub Release
   # (FR-021). macOS .dmg requires a macOS runner and Windows NSIS a Windows
@@ -166,8 +195,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
-          cache: 'pnpm'
+          node-version: "22"
+          cache: "pnpm"
 
       - name: Install deps
         run: pnpm install --frozen-lockfile

--- a/packages/jetbrains/build.gradle.kts
+++ b/packages/jetbrains/build.gradle.kts
@@ -36,6 +36,11 @@ intellijPlatform {
             untilBuild = provider { null }
         }
     }
+    publishing {
+        // Supplied as -PintellijPublishToken (GitHub Actions secret); orNull so
+        // local builds without the property still configure fine.
+        token = providers.gradleProperty("intellijPublishToken").orNull
+    }
 }
 
 // Copy webview assets (chat.js/chat.css) from packages/webview/dist into resources.


### PR DESCRIPTION
Tag 推送时自动把两个 IDE 插件发布到市场（原来只挂 GitHub Release）：

- VS Code Marketplace：走 Entra ID OIDC 联合凭据，无 PAT（PAT 2026-12-01 退役）。azure/login@v2 消费 AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_SUBSCRIPTION_ID，vsce publish --azure-credential 复用 az 缓存。
- JetBrains Marketplace：gradle publishPlugin + 永久 token（JETBRAINS_TOKEN secret），plugin id 从 plugin.xml 读取（com.wave.jetbrains）。
- 两个发布步骤仅 tag 推送触发，workflow_dispatch（资产重挂）不重发，避开市场重复版本拒绝。

账号侧前置（用户操作，已给指导）：Azure App Registration + federated credential（Subject repo:netease-lcap/wave-agent:ref:refs/tags/v*）+ DevOps org 加 Contributor + 4 个 GH secrets；JB 市场生成 permanent token。

已验证：YAML 解析通过、Gradle 配置可加载且 publishPlugin 任务存在、vsce 3.9.1 支持 --azure-credential/--packagePath。