### PR TITLE
fix(agent-sdk): run hooks via Git Bash on Windows to fix cmd.exe quote stripping (#1773)

### DIFF
--- a/packages/agent-sdk/src/services/hook.ts
+++ b/packages/agent-sdk/src/services/hook.ts
@@ -15,6 +15,8 @@ import {
   type HookJsonInput,
 } from "../types/hooks.js";
 import { generateSessionFilePath } from "./session.js";
+import { resolveShellPath } from "../utils/shellResolver.js";
+import { toPosixCommand } from "../utils/windowsPaths.js";
 
 // =============================================================================
 // Hook Execution Functions
@@ -177,12 +179,42 @@ export async function executeCommand(
     let stderr = "";
     let timedOut = false;
 
-    // Parse command for shell execution
+    // Parse command for shell execution.
+    //
+    // Windows uses Git Bash (POSIX shell) instead of cmd.exe: cmd.exe's `/c`
+    // does not strip quotes from arguments after the first token, so commands
+    // like `node "C:\path\script.js"` silently fail (issue #1773). Git Bash
+    // parses quotes correctly, and Windows paths in the command are converted
+    // to POSIX form first (Git Bash resolves `/c/Users/...` and translates it
+    // back to a Windows path when spawning native executables like node.exe).
+    // Falls back to cmd.exe when no Git Bash is installed.
     const isWindows = process.platform === "win32";
-    const shell = isWindows ? "cmd.exe" : "/bin/sh";
-    const shellFlag = isWindows ? "/c" : "-c";
+    const bashPath = isWindows ? resolveShellPath() : undefined;
+    let shell: string;
+    let shellFlag: string;
+    let finalCommand: string;
+    if (bashPath) {
+      shell = bashPath;
+      shellFlag = "-c";
+      finalCommand = toPosixCommand(command);
+      // Windows .sh scripts aren't directly executable — run them via bash
+      // when the command itself is a .sh file (e.g. `${WAVE_PLUGIN_ROOT}/x.sh`).
+      const trimmed = finalCommand.trim();
+      const firstToken = trimmed.match(/^("([^"]*)"|'([^']*)'|\S+)/)?.[0] ?? "";
+      if (firstToken.endsWith(".sh") && !trimmed.startsWith("bash ")) {
+        finalCommand = `bash ${finalCommand}`;
+      }
+    } else if (isWindows) {
+      shell = "cmd.exe";
+      shellFlag = "/c";
+      finalCommand = command;
+    } else {
+      shell = "/bin/sh";
+      shellFlag = "-c";
+      finalCommand = command;
+    }
 
-    const childProcess: ChildProcess = spawn(shell, [shellFlag, command], {
+    const childProcess: ChildProcess = spawn(shell, [shellFlag, finalCommand], {
       stdio: ["pipe", "pipe", "pipe"],
       cwd: context.projectDir,
       env: {

--- a/packages/agent-sdk/src/utils/windowsPaths.ts
+++ b/packages/agent-sdk/src/utils/windowsPaths.ts
@@ -1,0 +1,55 @@
+/**
+ * Windows path conversion utilities for Git Bash (POSIX shell) execution.
+ *
+ * Hook commands on Windows are executed via Git Bash instead of cmd.exe
+ * (cmd.exe does not strip quotes from arguments after the first token, so
+ * `node "C:\path\script.js"` silently fails — see issue #1773). Git Bash
+ * cannot resolve Windows paths like `C:\Users\foo`: backslashes are treated
+ * as escape characters and the drive letter breaks POSIX semantics. These
+ * helpers convert Windows paths to the POSIX form Git Bash expects
+ * (`C:\Users\foo` → `/c/Users/foo`), matching Claude Code's
+ * `windowsPathToPosixPath`.
+ */
+
+/**
+ * Convert a single Windows path to POSIX form for Git Bash:
+ *   - `C:\Users\foo`  → `/c/Users/foo`
+ *   - `C:/Users/foo`  → `/c/Users/foo`
+ *   - `\\server\share` → `//server/share` (UNC preserved)
+ *   - Already POSIX or relative paths are returned with slashes flipped.
+ */
+export function windowsPathToPosixPath(p: string): string {
+  // UNC paths: \\server\share -> //server/share
+  if (p.startsWith("\\\\")) {
+    return p.replace(/\\/g, "/");
+  }
+  // Drive letter paths: C:\Users\foo -> /c/Users/foo
+  const match = p.match(/^([A-Za-z]):[\\/]/);
+  if (match) {
+    const driveLetter = match[1]!.toLowerCase();
+    return `/${driveLetter}${p.slice(2).replace(/\\/g, "/")}`;
+  }
+  // Already POSIX or relative — just flip slashes
+  return p.replace(/\\/g, "/");
+}
+
+/**
+ * Convert every Windows absolute path inside a shell command string to POSIX
+ * form so Git Bash can parse it. Handles both quoted paths (which may contain
+ * spaces, e.g. `node "C:\Program Files\script.js"`) and bare paths
+ * (`cd C:\path\x`). Drive letters preceded by another alphanumeric character
+ * (e.g. URLs like `http://`) are left untouched.
+ */
+export function toPosixCommand(command: string): string {
+  // Quoted paths first (may contain spaces) — keep the surrounding quotes.
+  let converted = command.replace(
+    /"([A-Za-z]):[\\/][^"]*"/g,
+    (quoted) => `"${windowsPathToPosixPath(quoted.slice(1, -1))}"`,
+  );
+  // Bare (unquoted) paths.
+  converted = converted.replace(
+    /(?<![A-Za-z0-9])([A-Za-z]):[\\/][^\s"']*/g,
+    (match) => windowsPathToPosixPath(match),
+  );
+  return converted;
+}

--- a/packages/agent-sdk/tests/fixtures/hook-script.js
+++ b/packages/agent-sdk/tests/fixtures/hook-script.js
@@ -1,0 +1,3 @@
+// Fixture for tests/integration/hook-windows-execution.test.ts — a real,
+// spawnable script whose execution proves hook commands run through the OS.
+console.log("hook-ok");

--- a/packages/agent-sdk/tests/integration/hook-windows-execution.test.ts
+++ b/packages/agent-sdk/tests/integration/hook-windows-execution.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Real-spawn hook execution tests (Windows only).
+ *
+ * Unlike the mocked unit tests in tests/services/hook.test.ts, child_process is
+ * NOT mocked here: hook commands are executed through the real OS shell. This
+ * guards the cmd.exe quote-handling issue (issue #1773) that mocked tests can
+ * never catch — a command like `node "C:\path\script.js"` must succeed when
+ * executed via Git Bash on Windows. Skipped on non-Windows machines or when no
+ * Git Bash is installed.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import path from "path";
+import { fileURLToPath } from "url";
+
+import { executeCommand } from "../../src/services/hook.js";
+import { resolveShellPath } from "../../src/utils/shellResolver.js";
+import type { HookExecutionContext } from "../../src/types/hooks.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const isWindows = process.platform === "win32";
+// Resolved at module load so skipIf runs before any test executes.
+const gitBashPath = isWindows ? resolveShellPath() : undefined;
+
+describe.skipIf(!isWindows || !gitBashPath)(
+  "hook execution with real spawn on Windows",
+  () => {
+    beforeAll(() => {
+      // escape hatch: executeCommand short-circuits when NODE_ENV === "test"
+      // (returns a fake success), so opt into a real spawn here.
+      process.env.TEST_HOOK_EXECUTION = "true";
+    });
+
+    afterAll(() => {
+      delete process.env.TEST_HOOK_EXECUTION;
+    });
+
+    it("executes a quoted Windows-path command via Git Bash", async () => {
+      const scriptPath = path.join(
+        __dirname,
+        "..",
+        "fixtures",
+        "hook-script.js",
+      );
+      const context: HookExecutionContext = {
+        event: "PostToolUse",
+        toolName: "Edit",
+        projectDir: process.cwd(),
+        timestamp: new Date(),
+      };
+
+      const result = await executeCommand(`node "${scriptPath}"`, context, {
+        timeout: 30000,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.stdout).toContain("hook-ok");
+    });
+  },
+);

--- a/packages/agent-sdk/tests/services/hook.test.ts
+++ b/packages/agent-sdk/tests/services/hook.test.ts
@@ -22,6 +22,7 @@ import {
   executeCommands,
   isCommandSafe,
 } from "../../src/services/hook.js";
+import { resolveShellPath } from "../../src/utils/shellResolver.js";
 import type {
   HookExecutionContext,
   ExtendedHookExecutionContext,
@@ -37,6 +38,11 @@ vi.mock("../../src/services/session.js", () => ({
 // Mock child_process module
 vi.mock("child_process", () => ({
   spawn: vi.fn(),
+}));
+
+// Mock shell resolver so Git Bash detection is deterministic in tests
+vi.mock("../../src/utils/shellResolver.js", () => ({
+  resolveShellPath: vi.fn(),
 }));
 
 const mockSpawn = spawn as unknown as MockedFunction<
@@ -442,9 +448,82 @@ describe("Hook Services", () => {
   });
 
   describe("cross-platform support", () => {
-    it("should use correct shell for Windows", async () => {
+    it("should use Git Bash with POSIX command on Windows when available", async () => {
       const originalPlatform = process.platform;
       Object.defineProperty(process, "platform", { value: "win32" });
+      vi.mocked(resolveShellPath).mockReturnValue(
+        "C:\\Program Files\\Git\\bin\\bash.exe",
+      );
+
+      const mockProcess = new MockChildProcess();
+      mockProcess.stdin = new MockStdin();
+      let spawnArgs: Parameters<typeof spawn> | undefined;
+
+      mockSpawn.mockImplementation((...args) => {
+        spawnArgs = args as Parameters<typeof spawn>;
+        return mockProcess;
+      });
+
+      const resultPromise = executeCommand(
+        'node "C:\\path\\script.js"',
+        mockContext,
+      );
+
+      setImmediate(() => {
+        mockProcess.emit("close", 0);
+      });
+
+      await resultPromise;
+
+      expect(spawnArgs).toBeDefined();
+      expect(spawnArgs![0]).toBe("C:\\Program Files\\Git\\bin\\bash.exe");
+      expect(spawnArgs![1]).toEqual(["-c", 'node "/c/path/script.js"']);
+
+      // Restore original platform
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    });
+
+    it("should prepend bash for .sh hook commands on Windows", async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, "platform", { value: "win32" });
+      vi.mocked(resolveShellPath).mockReturnValue(
+        "C:\\Program Files\\Git\\bin\\bash.exe",
+      );
+
+      const mockProcess = new MockChildProcess();
+      mockProcess.stdin = new MockStdin();
+      let spawnArgs: Parameters<typeof spawn> | undefined;
+
+      mockSpawn.mockImplementation((...args) => {
+        spawnArgs = args as Parameters<typeof spawn>;
+        return mockProcess;
+      });
+
+      const resultPromise = executeCommand(
+        "C:\\plugins\\setup-worktree.sh",
+        mockContext,
+      );
+
+      setImmediate(() => {
+        mockProcess.emit("close", 0);
+      });
+
+      await resultPromise;
+
+      expect(spawnArgs).toBeDefined();
+      expect(spawnArgs![1]).toEqual([
+        "-c",
+        "bash /c/plugins/setup-worktree.sh",
+      ]);
+
+      // Restore original platform
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    });
+
+    it("should fall back to cmd.exe on Windows when Git Bash is missing", async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, "platform", { value: "win32" });
+      vi.mocked(resolveShellPath).mockReturnValue(undefined);
 
       const mockProcess = new MockChildProcess();
       mockProcess.stdin = new MockStdin();

--- a/packages/agent-sdk/tests/utils/windowsPaths.test.ts
+++ b/packages/agent-sdk/tests/utils/windowsPaths.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Windows path → POSIX conversion utilities unit tests.
+ *
+ * Pure functions — no child_process involved. The real-spawn behavior these
+ * utilities feed into is covered by tests/services/hook.integration.test.ts.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  windowsPathToPosixPath,
+  toPosixCommand,
+} from "../../src/utils/windowsPaths.js";
+
+describe("windowsPathToPosixPath", () => {
+  it("converts backslash drive-letter paths", () => {
+    expect(windowsPathToPosixPath("C:\\Users\\foo")).toBe("/c/Users/foo");
+    expect(windowsPathToPosixPath("D:\\a\\repo\\x.js")).toBe("/d/a/repo/x.js");
+  });
+
+  it("converts forward-slash drive-letter paths", () => {
+    expect(windowsPathToPosixPath("C:/Users/foo")).toBe("/c/Users/foo");
+  });
+
+  it("lowercases the drive letter", () => {
+    expect(windowsPathToPosixPath("c:\\Users\\foo")).toBe("/c/Users/foo");
+  });
+
+  it("preserves UNC paths", () => {
+    expect(windowsPathToPosixPath("\\\\server\\share\\dir")).toBe(
+      "//server/share/dir",
+    );
+  });
+
+  it("leaves already-POSIX paths intact", () => {
+    expect(windowsPathToPosixPath("/home/user/file.js")).toBe(
+      "/home/user/file.js",
+    );
+  });
+});
+
+describe("toPosixCommand", () => {
+  it("converts quoted Windows paths", () => {
+    expect(toPosixCommand('node "C:\\path\\script.js"')).toBe(
+      'node "/c/path/script.js"',
+    );
+  });
+
+  it("converts quoted Windows paths containing spaces", () => {
+    expect(
+      toPosixCommand('node "C:\\Program Files\\node\\script.js" arg'),
+    ).toBe('node "/c/Program Files/node/script.js" arg');
+  });
+
+  it("converts bare (unquoted) Windows paths", () => {
+    expect(toPosixCommand("cd C:\\repo\\src")).toBe("cd /c/repo/src");
+  });
+
+  it("leaves URLs and already-POSIX commands untouched", () => {
+    expect(toPosixCommand('grep -n "x" http://example.com')).toBe(
+      'grep -n "x" http://example.com',
+    );
+    expect(toPosixCommand("node /home/user/script.js")).toBe(
+      "node /home/user/script.js",
+    );
+  });
+
+  it("converts multiple Windows paths in one command", () => {
+    expect(
+      toPosixCommand(
+        'node "C:\\a\\b.js" --config "C:\\cfg\\config.json" C:\\output',
+      ),
+    ).toBe('node "/c/a/b.js" --config "/c/cfg/config.json" /c/output');
+  });
+});


### PR DESCRIPTION
## 背景
Issue #1773：Windows 下 hook 命令执行失败。根因是 `cmd.exe /c` 不剥除第一个 token 之后参数的引号，`node "C:\path\script.js"` 的引号会原样传给 node → Cannot find module → 插件钩子静默失效（非阻塞，无报错）。

## 修复（对齐 Claude Code）
- Windows 下优先用 **Git Bash（POSIX shell）** 执行 hook 命令：`resolveShellPath()` 按 `WAVE_GIT_BASH_PATH` env → git.exe 推断 → 常见安装路径找 bash.exe
- 命令中的 Windows 路径转换为 POSIX 形式（`C:\Users\foo` → `/c/Users/foo`），新增 `packages/agent-sdk/src/utils/windowsPaths.ts`
- `.sh` 命令自动加 `bash ` 前缀
- 无 Git Bash 时退回 `cmd.exe /c`（原行为）

## 权衡说明
- `WAVE_PLUGIN_ROOT` 等 env 保持 Windows 原生形式：sdd 的 session-start.js 用 `path.join(root, "scripts", ...)`，POSIX 形式会产出坏路径；只转换命令字符串
- 转换正则用负向后行断言排除 URL（`http://` 不误转）
- Unix 分支保持 `/bin/sh` 不变

## 测试
- 单元测试：Windows 分支三个用例（Git Bash + POSIX 命令 / .sh 前缀 / cmd.exe 回退），mock shellResolver 保证确定性
- **真实 spawn 集成测试**（`tests/integration/hook-windows-execution.test.ts`，不 mock child_process）：在未修复代码上复现失败（cmd.exe 引号 bug），修复后通过；Windows 无 Git Bash 时自动 skip
- 本机验证：47 个相关测试全过；全量 suite 3558 过（既有 fs-event.c 崩溃为环境级 flaky，与本次改动无关，干净树同样复现）