### PR TITLE
ci: remove marketplace auto-publish steps until vsce OIDC lands

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,26 +37,6 @@ jobs:
       - name: Package .vsix
         run: pnpm -F wave-vscode run package
 
-      # --- VS Code Marketplace (Entra ID, no PAT) ---
-      # PATs retire 2026-12-01; publish via Azure OIDC federated credentials
-      # instead: azure/login@v2 exchanges the Actions id-token (federated
-      # credential Subject: repo:netease-lcap/wave-agent:ref:refs/tags/v*),
-      # and `vsce publish --azure-credential` reuses the resulting az login
-      # cache — no PAT secret involved.
-      # Only runs on tag pushes; workflow_dispatch (asset re-upload) must not
-      # re-publish because the marketplace rejects duplicate versions.
-      - name: Azure login
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Publish to VS Code Marketplace
-        if: startsWith(github.ref, 'refs/tags/')
-        run: pnpm -F wave-vscode exec vsce publish --azure-credential --packagePath releases/*.vsix
-
       # --- Docs (docs-<version>.tar.gz) ---
       - name: Cache Playwright browsers
         uses: actions/cache@v6
@@ -164,15 +144,6 @@ jobs:
           prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # --- JetBrains Marketplace ---
-      # publishPlugin uploads the distribution built above (plugin id
-      # com.wave.jetbrains read from plugin.xml). JetBrains has no OIDC
-      # equivalent, so this needs a permanent marketplace token.
-      # Same duplicate-version guard as the VS Code step: tag pushes only.
-      - name: Publish to JetBrains Marketplace
-        if: startsWith(github.ref, 'refs/tags/')
-        run: ./packages/jetbrains/gradlew -p packages/jetbrains publishPlugin --no-daemon -PintellijPublishToken=${{ secrets.JETBRAINS_TOKEN }}
 
   # --- Desktop app (Electron) ---
   # Builds the desktop installers and attaches them to the same GitHub Release

--- a/packages/jetbrains/build.gradle.kts
+++ b/packages/jetbrains/build.gradle.kts
@@ -36,11 +36,6 @@ intellijPlatform {
             untilBuild = provider { null }
         }
     }
-    publishing {
-        // Supplied as -PintellijPublishToken (GitHub Actions secret); orNull so
-        // local builds without the property still configure fine.
-        token = providers.gradleProperty("intellijPublishToken").orNull
-    }
 }
 
 // Copy webview assets (chat.js/chat.css) from packages/webview/dist into resources.


### PR DESCRIPTION
回退 PR #1772 的市场发布部分，恢复纯 GitHub Release：

- VS Code 市场：vsce --oidc（trusted publishing）客户端已就绪（3.9.3-5），但 Marketplace 侧 trusted publishing policy 配置界面尚未上线（microsoft/vscode-vsce#1291 中有人问同样问题无回复）→ 现在配不了白名单，发布必然失败，先移除 azure-credential 步骤
- JetBrains 市场：publishPlugin 步骤一并移除，等 VSCE OIDC 落地后一起做
- 同时移除 build.gradle.kts 的 publishing block
- tag 发布仍会构建 .vsix/.zip 并挂到 GitHub Release，只是不再发市场

等 Marketplace trusted publishing policy 上线后，切 --oidc（vsce 已支持）并恢复 JB publishPlugin。