### PR TITLE
feat(agent-sdk): align Git Bash login shell with Claude Code

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -50,6 +50,7 @@ import {
 } from "./telemetry/instrumentation.js";
 import { logOTelEvent } from "./telemetry/events.js";
 import { remoteSettingsService } from "./services/remoteSettingsService.js";
+import { setShellIfWindows } from "./utils/shellResolver.js";
 
 export class Agent {
   private messageManager: MessageManager;
@@ -595,6 +596,11 @@ export class Agent {
     continueLastSession?: boolean;
     messages?: Message[];
   }): Promise<void> {
+    // On Windows, expose the Git Bash path as $SHELL so child processes
+    // spawned by the Bash tool use bash instead of cmd.exe (aligned with
+    // Claude Code's init.ts setShellIfWindows; COMSPEC is left untouched).
+    setShellIfWindows();
+
     await InitializationService.initialize(
       {
         skillManager: this.skillManager,

--- a/packages/agent-sdk/src/managers/backgroundTaskManager.ts
+++ b/packages/agent-sdk/src/managers/backgroundTaskManager.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from "child_process";
+import { spawn, type ChildProcess, type SpawnOptions } from "child_process";
 import * as os from "os";
 import * as fs from "fs";
 import * as path from "path";
@@ -9,6 +9,7 @@ import { logger } from "../utils/globalLogger.js";
 import { Container } from "../utils/container.js";
 import { MessageQueue } from "./messageQueue.js";
 import { resolveShellPath } from "../utils/shellResolver.js";
+import { buildShellSpawnArgs } from "../utils/shellSnapshot.js";
 import type { ConfigurationService } from "../services/configurationService.js";
 
 export interface BackgroundTaskManagerCallbacks {
@@ -81,8 +82,7 @@ export class BackgroundTaskManager {
     const id = this.generateId();
     const startTime = Date.now();
 
-    const child = spawn(command, {
-      shell: resolveShellPath() ?? true,
+    const spawnOptions: SpawnOptions = {
       stdio: "pipe",
       detached: true,
       cwd: cwd ?? this.workdir,
@@ -90,7 +90,23 @@ export class BackgroundTaskManager {
         ...process.env,
         ...this.sessionEnv,
       },
-    });
+    };
+
+    // Aligned with the Bash tool: spawn the resolved bash/zsh with -c -l
+    // (login shell) until a shell snapshot is available, then reuse the cached
+    // login-shell PATH without -l. Falls back to the platform default shell
+    // (`shell: true`) when no bash/zsh is installed.
+    const shellPath = resolveShellPath();
+    let child: ChildProcess;
+    if (shellPath) {
+      child = spawn(
+        shellPath,
+        buildShellSpawnArgs(shellPath, command),
+        spawnOptions,
+      );
+    } else {
+      child = spawn(command, { ...spawnOptions, shell: true });
+    }
 
     // Create log file
     const logPath = path.join(os.tmpdir(), `wave-task-${id}.log`);

--- a/packages/agent-sdk/src/managers/bangManager.ts
+++ b/packages/agent-sdk/src/managers/bangManager.ts
@@ -1,7 +1,8 @@
-import { spawn, type ChildProcess } from "child_process";
+import { spawn, type ChildProcess, type SpawnOptions } from "child_process";
 import type { MessageManager } from "./messageManager.js";
 import { Container } from "../utils/container.js";
 import { resolveShellPath } from "../utils/shellResolver.js";
+import { buildShellSpawnArgs } from "../utils/shellSnapshot.js";
 import type { ConfigurationService } from "../services/configurationService.js";
 
 export interface BangManagerOptions {
@@ -59,15 +60,30 @@ export class BangManager {
     this.messageManager.addBangMessage(command);
 
     return new Promise<number>((resolve) => {
-      const child = spawn(command, {
-        shell: resolveShellPath() ?? true,
+      const spawnOptions: SpawnOptions = {
         stdio: "pipe",
         cwd: this.workdir,
         env: {
           ...process.env,
           ...this.sessionEnv,
         },
-      });
+      };
+
+      // Aligned with the Bash tool: spawn the resolved bash/zsh with -c -l
+      // (login shell) until a shell snapshot is available, then reuse the
+      // cached login-shell PATH without -l. Falls back to the platform
+      // default shell (`shell: true`) when no bash/zsh is installed.
+      const shellPath = resolveShellPath();
+      let child: ChildProcess;
+      if (shellPath) {
+        child = spawn(
+          shellPath,
+          buildShellSpawnArgs(shellPath, command),
+          spawnOptions,
+        );
+      } else {
+        child = spawn(command, { ...spawnOptions, shell: true });
+      }
 
       this.currentProcess = child;
       let outputBuffer = "";

--- a/packages/agent-sdk/src/tools/bashTool.ts
+++ b/packages/agent-sdk/src/tools/bashTool.ts
@@ -4,6 +4,10 @@ import * as path from "path";
 import * as os from "os";
 import { logger } from "../utils/globalLogger.js";
 import { resolveShellPath } from "../utils/shellResolver.js";
+import {
+  buildShellSpawnArgs,
+  shellSingleQuote,
+} from "../utils/shellSnapshot.js";
 import { toPosixPath } from "../utils/path.js";
 import { stripAnsiColors } from "../utils/stringUtils.js";
 import { WindowsStreamDecoder } from "../utils/encoding.js";
@@ -36,8 +40,7 @@ function wrapCommandForCwdTracking(
   command: string,
   cwdFileForBash: string,
 ): string {
-  const escaped = command.replace(/'/g, `'"'"'`);
-  return `eval '${escaped}' && pwd -P >| ${cwdFileForBash}`;
+  return `eval ${shellSingleQuote(command)} && pwd -P >| ${cwdFileForBash}`;
 }
 
 // Commands that should not be auto-backgrounded on timeout (e.g. sleep should just be killed)
@@ -272,6 +275,12 @@ The working directory persists between commands. Try to maintain your current wo
     }
 
     // Foreground execution (original behavior)
+
+    // Shell spawn (aligned with Claude Code's bash provider): the user's
+    // profile is sourced once per session and the resulting login-shell PATH
+    // is cached. Until the snapshot is ready the shell is spawned as a login
+    // shell (`-c -l`); once ready, later commands skip `-l` and reuse the
+    // cached PATH instead of re-loading the profile.
     return new Promise((resolve) => {
       // Create a temporary file to store the CWD
       const tempCwdFile = path.join(
@@ -284,16 +293,19 @@ The working directory persists between commands. Try to maintain your current wo
         tempCwdFileForBash,
       );
 
-      const child: ChildProcess = spawn(wrappedCommand, {
-        shell: shellPath,
-        stdio: "pipe",
-        detached: true,
-        cwd: context.workdir,
-        env: {
-          ...process.env,
-          ...context.sessionEnv,
+      const child: ChildProcess = spawn(
+        shellPath,
+        buildShellSpawnArgs(shellPath, wrappedCommand),
+        {
+          stdio: "pipe",
+          detached: true,
+          cwd: context.workdir,
+          env: {
+            ...process.env,
+            ...context.sessionEnv,
+          },
         },
-      });
+      );
 
       let outputBuffer = "";
       let errorBuffer = "";

--- a/packages/agent-sdk/src/utils/shellResolver.ts
+++ b/packages/agent-sdk/src/utils/shellResolver.ts
@@ -188,3 +188,21 @@ export function resolveShellPath(): string | undefined {
 
   return resolveUnixShell();
 }
+
+/**
+ * On Windows, expose the Git Bash path as the `SHELL` environment variable so
+ * child processes spawned by the Bash tool (make, git hooks, npm scripts, ...)
+ * use bash instead of cmd.exe when they invoke `$SHELL -c`. COMSPEC is left
+ * unchanged for system process execution. No-op elsewhere or when no Git Bash
+ * is found (aligned with Claude Code's setShellIfWindows, without exiting the
+ * process on failure).
+ */
+export function setShellIfWindows(): void {
+  if (process.platform !== "win32") {
+    return;
+  }
+  const gitBashPath = resolveShellPath();
+  if (gitBashPath) {
+    process.env.SHELL = gitBashPath;
+  }
+}

--- a/packages/agent-sdk/src/utils/shellSnapshot.ts
+++ b/packages/agent-sdk/src/utils/shellSnapshot.ts
@@ -1,0 +1,142 @@
+import { execFile } from "child_process";
+import { logger } from "./globalLogger.js";
+
+const SNAPSHOT_CREATION_TIMEOUT_MS = 10000;
+
+// Marker line written before `echo $PATH` so profile banner output that leaks
+// to stdout (motd, fortune, ...) is not mistaken for the PATH value.
+const SNAPSHOT_PATH_MARKER = "WAVE_SHELL_SNAPSHOT";
+
+// Cache: shellPath → settled snapshot promise. A snapshot is captured once per
+// shell path and reused by every later command, so the user's profile is only
+// sourced once per session instead of once per command. A failed capture is
+// cached as `undefined` (settled) — callers then fall back to spawning a login
+// shell per command (matching Claude Code's behavior).
+const snapshotCache = new Map<string, Promise<string | undefined>>();
+// Settled values: shellPath → captured PATH (or undefined on failure). Populated
+// when the corresponding snapshot promise settles, so callers can check the
+// snapshot synchronously without awaiting creation.
+const snapshotValues = new Map<string, string | undefined>();
+
+/**
+ * Capture the login-shell PATH for `shellPath`: spawn the shell as a login
+ * shell (`-l`, which sources the user's profile) once and cache the resulting
+ * `echo $PATH` output. Subsequent commands reuse this cached PATH instead of
+ * re-loading the profile.
+ *
+ * @returns the login-shell PATH string, or `undefined` if the snapshot could
+ *   not be captured (timeout, missing shell, ...).
+ */
+export function getShellSnapshotPath(
+  shellPath: string,
+): Promise<string | undefined> {
+  const cached = snapshotCache.get(shellPath);
+  if (cached) {
+    return cached;
+  }
+
+  const snapshotPromise = captureSnapshotPath(shellPath).then((pathValue) => {
+    snapshotValues.set(shellPath, pathValue);
+    return pathValue;
+  });
+  snapshotCache.set(shellPath, snapshotPromise);
+  return snapshotPromise;
+}
+
+/**
+ * Synchronously return the cached login-shell PATH for `shellPath`, without
+ * triggering or awaiting snapshot creation. Returns `undefined` when the
+ * snapshot has not been captured yet (or failed) — callers should then spawn a
+ * login shell (`-l`) for this command and let the next command reuse the
+ * snapshot once `getShellSnapshotPath` has been called.
+ */
+export function getCachedShellSnapshotPath(
+  shellPath: string,
+): string | undefined {
+  return snapshotValues.get(shellPath);
+}
+
+/** Clear the snapshot cache (used by tests). */
+export function resetShellSnapshotCache(): void {
+  snapshotCache.clear();
+  snapshotValues.clear();
+}
+
+/** Wrap a string for single-quoted shell usage (embedded quotes become `'"'"'`). */
+export function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+/**
+ * Build the complete spawn args for running `command` in `shellPath`, using
+ * the login-shell + snapshot strategy shared by all shell executors (Bash
+ * tool, background tasks, bang commands):
+ *   - snapshot captured: `-c` with the cached login-shell PATH re-exported
+ *     (`export PATH=...; command`) — the user profile is not re-loaded;
+ *   - otherwise: `-c -l` (login shell loads the profile) and the memoized
+ *     snapshot capture is kicked off for later commands.
+ */
+export function buildShellSpawnArgs(
+  shellPath: string,
+  command: string,
+): string[] {
+  const snapshotPath = getCachedShellSnapshotPath(shellPath);
+  if (snapshotPath !== undefined) {
+    return ["-c", `export PATH=${shellSingleQuote(snapshotPath)}; ${command}`];
+  }
+  void getShellSnapshotPath(shellPath);
+  return ["-c", "-l", command];
+}
+
+function captureSnapshotPath(shellPath: string): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    try {
+      execFile(
+        shellPath,
+        ["-c", "-l", `echo ${SNAPSHOT_PATH_MARKER}; echo "$PATH"`],
+        {
+          timeout: SNAPSHOT_CREATION_TIMEOUT_MS,
+          maxBuffer: 1024 * 1024,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            SHELL: shellPath,
+          },
+        },
+        (error, stdout) => {
+          if (error) {
+            logger.debug(
+              `[ShellSnapshot] creation failed for ${shellPath}: ${error.message}`,
+            );
+            resolve(undefined);
+            return;
+          }
+          // Take everything after the marker line; profile output before it is
+          // ignored.
+          const markerIndex = stdout.lastIndexOf(SNAPSHOT_PATH_MARKER);
+          const pathValue = (
+            markerIndex >= 0
+              ? stdout.slice(markerIndex + SNAPSHOT_PATH_MARKER.length)
+              : stdout
+          ).trim();
+          if (!pathValue) {
+            logger.debug(
+              `[ShellSnapshot] empty PATH captured for ${shellPath}`,
+            );
+            resolve(undefined);
+            return;
+          }
+          logger.debug(`[ShellSnapshot] created for ${shellPath}`);
+          resolve(pathValue);
+        },
+      );
+    } catch (error) {
+      // execFile throws synchronously on invalid arguments — never reject, so
+      // the fire-and-forget call site cannot produce an unhandled rejection.
+      logger.debug(
+        `[ShellSnapshot] creation failed for ${shellPath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      resolve(undefined);
+    }
+  });
+}

--- a/packages/agent-sdk/tests/managers/backgroundTaskManager.notification.test.ts
+++ b/packages/agent-sdk/tests/managers/backgroundTaskManager.notification.test.ts
@@ -17,6 +17,13 @@ vi.mock("child_process", () => ({
     };
     return child;
   }),
+  execFile: vi.fn(),
+}));
+
+// Deterministic shell path for the spawn-shape assertions.
+vi.mock("../../src/utils/shellResolver.js", () => ({
+  resolveShellPath: vi.fn(() => "/bin/bash"),
+  setShellIfWindows: vi.fn(),
 }));
 
 // Mock fs. Both named exports (namespace-imported by backgroundTaskManager)
@@ -36,8 +43,15 @@ vi.mock("fs", () => {
   };
 });
 
+import { execFile, spawn } from "child_process";
 import { BackgroundTaskManager } from "../../src/managers/backgroundTaskManager.js";
 import { MessageQueue } from "../../src/managers/messageQueue.js";
+import {
+  getShellSnapshotPath,
+  resetShellSnapshotCache,
+} from "../../src/utils/shellSnapshot.js";
+const mockSpawn = vi.mocked(spawn);
+const mockExecFile = vi.mocked(execFile);
 
 describe("BackgroundTaskManager - Message Queue", () => {
   let container: Container;
@@ -46,6 +60,7 @@ describe("BackgroundTaskManager - Message Queue", () => {
 
   beforeEach(() => {
     handlers.clear();
+    resetShellSnapshotCache();
     container = new Container();
     messageQueue = new MessageQueue();
     container.register("MessageQueue", messageQueue);
@@ -198,5 +213,62 @@ describe("BackgroundTaskManager - Message Queue", () => {
     // Status must remain "killed", not overwritten to "completed"
     expect(tasks[0].status).toBe("killed");
     expect(messageQueue.hasNotifications()).toBe(false);
+  });
+
+  describe("startShell shell invocation", () => {
+    it("spawns the shell with -c -l (login shell) and kicks off snapshot creation", () => {
+      manager.startShell("echo hello");
+
+      // Explicit spawn: [shellPath, args, options].
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "/bin/bash",
+        ["-c", "-l", "echo hello"],
+        expect.objectContaining({
+          stdio: "pipe",
+          detached: true,
+          cwd: "/test/workdir",
+          env: expect.any(Object),
+        }),
+      );
+      // Snapshot capture kicked off (fire-and-forget) for later commands.
+      expect(mockExecFile).toHaveBeenCalledWith(
+        "/bin/bash",
+        ["-c", "-l", expect.stringContaining('echo "$PATH"')],
+        expect.anything(),
+        expect.any(Function),
+      );
+    });
+
+    it("skips -l and reuses the cached snapshot PATH once it is ready", async () => {
+      // Settle the real snapshot for /bin/bash via the mocked execFile.
+      mockExecFile.mockImplementation(((
+        _file: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        callback(
+          null,
+          "WAVE_SHELL_SNAPSHOT\n/usr/local/bin:/usr/bin:/bin\n",
+          "",
+        );
+      }) as unknown as typeof execFile);
+      await getShellSnapshotPath("/bin/bash");
+      mockExecFile.mockClear();
+
+      manager.startShell("echo hello");
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "/bin/bash",
+        ["-c", "export PATH='/usr/local/bin:/usr/bin:/bin'; echo hello"],
+        expect.objectContaining({
+          stdio: "pipe",
+          detached: true,
+          cwd: "/test/workdir",
+        }),
+      );
+      // Snapshot already cached — no new capture kicked off.
+      expect(mockExecFile).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/agent-sdk/tests/managers/bangManager.test.ts
+++ b/packages/agent-sdk/tests/managers/bangManager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { spawn, type ChildProcess } from "child_process";
+import { execFile, spawn, type ChildProcess } from "child_process";
 import { EventEmitter } from "events";
 
 // Mock child_process
@@ -16,6 +16,10 @@ vi.mock("@/utils/shellResolver", () => ({
 import { BangManager } from "@/managers/bangManager.js";
 import type { MessageManager } from "@/managers/messageManager.js";
 import { Container } from "@/utils/container.js";
+import {
+  getShellSnapshotPath,
+  resetShellSnapshotCache,
+} from "@/utils/shellSnapshot.js";
 
 // Mock MessageManager
 const createMockMessageManager = (): MessageManager => {
@@ -28,6 +32,7 @@ const createMockMessageManager = (): MessageManager => {
 };
 
 const mockSpawn = vi.mocked(spawn);
+const mockExecFile = vi.mocked(execFile);
 
 // Mock ChildProcess
 class MockChildProcess extends EventEmitter {
@@ -64,6 +69,7 @@ describe("BangManager", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetShellSnapshotCache();
     mockMessageManager = createMockMessageManager();
     mockChildProcess = new MockChildProcess();
 
@@ -109,12 +115,17 @@ describe("BangManager", () => {
       expect(bangManager.isCommandRunning).toBe(true);
 
       // Verify spawn was called with correct arguments
-      expect(mockSpawn).toHaveBeenCalledWith(command, {
-        shell: "/bin/bash",
-        stdio: "pipe",
-        cwd: testWorkdir,
-        env: expect.any(Object),
-      });
+      // Explicit spawn: shell is spawned with -c -l (login shell) since no
+      // shell snapshot is cached yet.
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "/bin/bash",
+        ["-c", "-l", command],
+        {
+          stdio: "pipe",
+          cwd: testWorkdir,
+          env: expect.any(Object),
+        },
+      );
 
       // Verify initial command message was added
       expect(mockMessageManager.addBangMessage).toHaveBeenCalledWith(command);
@@ -206,6 +217,39 @@ describe("BangManager", () => {
         130,
         "",
       );
+    });
+
+    it("reuses the cached snapshot PATH (skips -l) once the snapshot is ready", async () => {
+      // Settle the real shell snapshot for the resolved shell path via the
+      // mocked execFile.
+      mockExecFile.mockImplementation(((
+        _file: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        callback(
+          null,
+          "WAVE_SHELL_SNAPSHOT\n/usr/local/bin:/usr/bin:/bin\n",
+          "",
+        );
+      }) as unknown as typeof execFile);
+      await getShellSnapshotPath("/bin/bash");
+
+      const executePromise = bangManager.executeCommand("echo hi");
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "/bin/bash",
+        ["-c", "export PATH='/usr/local/bin:/usr/bin:/bin'; echo hi"],
+        expect.objectContaining({
+          stdio: "pipe",
+          cwd: testWorkdir,
+          env: expect.any(Object),
+        }),
+      );
+
+      mockChildProcess.simulateExit(0);
+      await executePromise;
     });
 
     it("should prevent multiple concurrent commands", async () => {

--- a/packages/agent-sdk/tests/tools/bashTool.test.ts
+++ b/packages/agent-sdk/tests/tools/bashTool.test.ts
@@ -61,10 +61,21 @@ vi.mock("../../src/utils/globalLogger.js", () => ({
   isLoggerConfigured: vi.fn(),
 }));
 
-import { spawn } from "child_process";
+// The shell snapshot module is NOT mocked here: its real chain runs against
+// the auto-mocked child_process.execFile (below), so tests exercise the real
+// login-shell/snapshot wiring. By default execFile never invokes its callback
+// (snapshot stays pending → bashTool spawns `-c -l`); tests that need a
+// snapshot settle the capture via the mocked execFile callback.
+
+import { execFile, spawn } from "child_process";
 import { logger } from "../../src/utils/globalLogger.js";
 import { resolveShellPath } from "../../src/utils/shellResolver.js";
+import {
+  getShellSnapshotPath,
+  resetShellSnapshotCache,
+} from "../../src/utils/shellSnapshot.js";
 const mockSpawn = vi.mocked(spawn);
+const mockExecFile = vi.mocked(execFile);
 
 describe("bashTool", () => {
   let backgroundTaskManager: BackgroundTaskManager;
@@ -72,6 +83,7 @@ describe("bashTool", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetShellSnapshotCache();
     const container = new Container();
     backgroundTaskManager = new BackgroundTaskManager(container, {
       workdir: "/test/workdir",
@@ -125,11 +137,17 @@ describe("bashTool", () => {
       expect(result.shortResult).toBe("test output");
       expect(mockSpawn).toHaveBeenCalledTimes(1);
       const spawnCallArgs = mockSpawn.mock.calls[0];
-      expect(typeof spawnCallArgs[0]).toBe("string");
-      expect(spawnCallArgs[0]).toContain("echo hello");
-      expect(spawnCallArgs[0]).toContain("pwd -P");
-      expect(spawnCallArgs[1]).toMatchObject({
-        shell: resolveShellPath() || true,
+      // Explicit spawn: [shellPath, args, options] — no shell option anymore.
+      expect(spawnCallArgs[0]).toBe(resolveShellPath());
+      const shellArgs = spawnCallArgs[1] as string[];
+      // No snapshot → login shell (-l) so the user profile is loaded.
+      expect(shellArgs).toEqual([
+        "-c",
+        "-l",
+        expect.stringContaining("echo hello"),
+      ]);
+      expect(shellArgs[2]).toContain("pwd -P");
+      expect(spawnCallArgs[2]).toMatchObject({
         stdio: "pipe",
         cwd: "/test/workdir",
       });
@@ -270,7 +288,14 @@ describe("bashTool", () => {
       const spawnCallArgs = mockSpawn.mock.calls[0];
       // Background shell must inherit the session current workdir (worktree),
       // NOT fall back to the BTM construction-time workdir (base repo root).
-      expect(spawnCallArgs[1]).toMatchObject({
+      // Explicit spawn: [shellPath, args, options].
+      expect(spawnCallArgs[0]).toBe(resolveShellPath());
+      expect(spawnCallArgs[1]).toEqual([
+        "-c",
+        "-l",
+        expect.stringContaining("pwd"),
+      ]);
+      expect(spawnCallArgs[2]).toMatchObject({
         cwd: "/base/repo/root/.wave/worktrees/feat-x",
       });
 
@@ -711,8 +736,7 @@ describe("bashTool", () => {
       await bashTool.execute({ command: "echo hello" }, context);
 
       const spawnCallArgs = mockSpawn.mock.calls[0];
-      expect(typeof spawnCallArgs[0]).toBe("string");
-      const wrapped = spawnCallArgs[0] as string;
+      const wrapped = (spawnCallArgs[1] as string[])[2];
       expect(wrapped).toContain("eval 'echo hello'");
       expect(wrapped).toContain("pwd -P");
       // Temp file path is platform-specific (C:/tmp on a "/tmp" mock, the real
@@ -727,7 +751,7 @@ describe("bashTool", () => {
 
       await bashTool.execute({ command: "echo 'hi'" }, context);
 
-      const wrapped = mockSpawn.mock.calls[0][0] as string;
+      const wrapped = (mockSpawn.mock.calls[0][1] as string[])[2];
       // Each single quote in the user command is replaced with '"'"'
       expect(wrapped).toContain(`eval 'echo '"'"'hi'"'"''`);
       expect(wrapped).toMatch(/^eval '.*' && pwd -P >\| .*wave_cwd_.*\.tmp$/);
@@ -745,7 +769,7 @@ EOF
 
       await bashTool.execute({ command }, context);
 
-      const wrapped = mockSpawn.mock.calls[0][0] as string;
+      const wrapped = (mockSpawn.mock.calls[0][1] as string[])[2];
       // Whole user command wrapped in eval '...'
       expect(wrapped.startsWith("eval '")).toBe(true);
       expect(wrapped).toContain("pwd -P");
@@ -756,6 +780,113 @@ EOF
       const pwdIndex = wrapped.indexOf("&& pwd -P");
       expect(pwdIndex).toBeGreaterThan(evalStart);
       expect(wrapped).toMatch(/&& pwd -P >\| .*wave_cwd_.*\.tmp$/);
+    });
+  });
+
+  describe("Shell snapshot integration", () => {
+    const makeExitingProcess = () => ({
+      pid: 1234,
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() },
+      on: vi.fn((event: string, callback: (code: number) => void) => {
+        if (event === "exit") {
+          setTimeout(() => callback(0), 10);
+        }
+      }),
+      kill: vi.fn(),
+      killed: false,
+    });
+
+    /**
+     * Settle the real shell snapshot for the resolved shell path: the mocked
+     * execFile invokes its callback with the given login-shell PATH.
+     */
+    const settleSnapshot = async (pathValue: string) => {
+      mockExecFile.mockImplementation(((
+        _file: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        callback(null, `WAVE_SHELL_SNAPSHOT\n${pathValue}\n`, "");
+      }) as unknown as typeof execFile);
+      await getShellSnapshotPath(resolveShellPath()!);
+      // Clear the settle call so "not kicked off again" assertions hold.
+      mockExecFile.mockClear();
+    };
+
+    it("spawns a login shell (-c -l) and kicks off snapshot creation when none cached", async () => {
+      // execFile default (never calls back) → snapshot stays pending.
+      mockSpawn.mockReturnValue(
+        makeExitingProcess() as unknown as ChildProcess,
+      );
+
+      await bashTool.execute({ command: "echo hi" }, context);
+
+      const [shell, args] = mockSpawn.mock.calls[0];
+      expect(shell).toBe(resolveShellPath());
+      const shellArgs = args as string[];
+      expect(shellArgs[0]).toBe("-c");
+      expect(shellArgs[1]).toBe("-l");
+      expect(shellArgs[2]).toContain("echo hi");
+      // The first command kicks off snapshot creation (fire-and-forget) so
+      // later commands can reuse the cached PATH.
+      expect(mockExecFile).toHaveBeenCalledWith(
+        resolveShellPath(),
+        ["-c", "-l", expect.stringContaining('echo "$PATH"')],
+        expect.anything(),
+        expect.any(Function),
+      );
+    });
+
+    it("skips -l and reuses the cached snapshot PATH once it is ready", async () => {
+      await settleSnapshot("/usr/local/bin:/usr/bin:/bin");
+      mockSpawn.mockReturnValue(
+        makeExitingProcess() as unknown as ChildProcess,
+      );
+
+      await bashTool.execute({ command: "echo hi" }, context);
+
+      const [, args] = mockSpawn.mock.calls[0];
+      const shellArgs = args as string[];
+      // The command string is always the last argument.
+      const command = shellArgs[shellArgs.length - 1];
+      expect(shellArgs[0]).toBe("-c");
+      expect(shellArgs).not.toContain("-l");
+      expect(command).toContain(
+        "export PATH='/usr/local/bin:/usr/bin:/bin'; eval 'echo hi'",
+      );
+      expect(command).toContain("pwd -P");
+      // Snapshot already cached — no need to kick off creation again.
+      expect(mockExecFile).not.toHaveBeenCalled();
+    });
+
+    it("quotes a snapshot PATH containing spaces", async () => {
+      await settleSnapshot("/c/Program Files/Git/usr/bin:/usr/bin");
+      mockSpawn.mockReturnValue(
+        makeExitingProcess() as unknown as ChildProcess,
+      );
+
+      await bashTool.execute({ command: "echo hi" }, context);
+
+      const shellArgs = mockSpawn.mock.calls[0][1] as string[];
+      expect(shellArgs[shellArgs.length - 1]).toContain(
+        "export PATH='/c/Program Files/Git/usr/bin:/usr/bin';",
+      );
+    });
+
+    it("escapes embedded single quotes in the snapshot PATH", async () => {
+      await settleSnapshot("/usr/bin:/opt/my'x");
+      mockSpawn.mockReturnValue(
+        makeExitingProcess() as unknown as ChildProcess,
+      );
+
+      await bashTool.execute({ command: "echo hi" }, context);
+
+      const shellArgs = mockSpawn.mock.calls[0][1] as string[];
+      expect(shellArgs[shellArgs.length - 1]).toContain(
+        `export PATH='/usr/bin:/opt/my'"'"'x';`,
+      );
     });
   });
 

--- a/packages/agent-sdk/tests/utils/shellResolver.test.ts
+++ b/packages/agent-sdk/tests/utils/shellResolver.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   resolveShellPath,
+  setShellIfWindows,
   WINDOWS_GIT_BASH_PATHS,
 } from "../../src/utils/shellResolver.js";
 import fs from "node:fs";
@@ -245,6 +246,41 @@ describe("shellResolver", () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       expect(resolveShellPath()).toBe("D:\\custom\\git\\bash.exe");
       expect(execFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("setShellIfWindows", () => {
+    it("sets SHELL to the resolved Git Bash path on Windows, leaving COMSPEC untouched", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      process.env.WAVE_GIT_BASH_PATH = "C:\\Program Files\\Git\\bin\\bash.exe";
+      process.env.COMSPEC = "C:\\Windows\\system32\\cmd.exe";
+
+      setShellIfWindows();
+
+      expect(process.env.SHELL).toBe("C:\\Program Files\\Git\\bin\\bash.exe");
+      expect(process.env.COMSPEC).toBe("C:\\Windows\\system32\\cmd.exe");
+    });
+
+    it("leaves SHELL unchanged when no Git Bash is found on Windows", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      process.env.SHELL = "C:\\Windows\\system32\\cmd.exe";
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(execFileSync).mockImplementation(() => {
+        throw new Error("not found");
+      });
+
+      setShellIfWindows();
+
+      expect(process.env.SHELL).toBe("C:\\Windows\\system32\\cmd.exe");
+    });
+
+    it("is a no-op on non-Windows platforms", () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      process.env.SHELL = "/bin/bash";
+
+      setShellIfWindows();
+
+      expect(process.env.SHELL).toBe("/bin/bash");
     });
   });
 });

--- a/packages/agent-sdk/tests/utils/shellSnapshot.test.ts
+++ b/packages/agent-sdk/tests/utils/shellSnapshot.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { execFile } from "child_process";
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import {
+  buildShellSpawnArgs,
+  getCachedShellSnapshotPath,
+  getShellSnapshotPath,
+  resetShellSnapshotCache,
+  shellSingleQuote,
+} from "../../src/utils/shellSnapshot.js";
+
+const mockExecFile = vi.mocked(execFile);
+
+type ExecFileCallback = (
+  error: Error | null,
+  stdout: string,
+  stderr: string,
+) => void;
+
+describe("shellSnapshot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetShellSnapshotCache();
+  });
+
+  it("captures the login-shell PATH via `-c -l` and parses the marker line", async () => {
+    mockExecFile.mockImplementation(((
+      _file: string,
+      _args: string[],
+      _options: unknown,
+      callback: ExecFileCallback,
+    ) => {
+      callback(
+        null,
+        "Welcome to your profile!\nWAVE_SHELL_SNAPSHOT\n/usr/local/bin:/usr/bin:/bin\n",
+        "",
+      );
+    }) as typeof execFile);
+
+    const result = await getShellSnapshotPath("/bin/bash");
+
+    expect(result).toBe("/usr/local/bin:/usr/bin:/bin");
+    expect(mockExecFile).toHaveBeenCalledWith(
+      "/bin/bash",
+      ["-c", "-l", expect.stringContaining('echo "$PATH"')],
+      expect.objectContaining({ timeout: 10000, encoding: "utf8" }),
+      expect.any(Function),
+    );
+    // The login shell must inherit the SHELL env pointing at itself so the
+    // user profile sees the right shell.
+    const options = mockExecFile.mock.calls[0][2] as {
+      env: Record<string, string>;
+    };
+    expect(options.env.SHELL).toBe("/bin/bash");
+  });
+
+  it("caches the snapshot per shell path — a second call does not re-exec", async () => {
+    mockExecFile.mockImplementation(((
+      _file: string,
+      _args: string[],
+      _options: unknown,
+      callback: ExecFileCallback,
+    ) => {
+      callback(null, "WAVE_SHELL_SNAPSHOT\n/usr/bin:/bin\n", "");
+    }) as typeof execFile);
+
+    const first = await getShellSnapshotPath("/bin/bash");
+    const second = await getShellSnapshotPath("/bin/bash");
+
+    expect(first).toBe("/usr/bin:/bin");
+    expect(second).toBe("/usr/bin:/bin");
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps independent snapshots for different shell paths", async () => {
+    mockExecFile.mockImplementation(((
+      file: string,
+      _args: string[],
+      _options: unknown,
+      callback: ExecFileCallback,
+    ) => {
+      callback(
+        null,
+        `WAVE_SHELL_SNAPSHOT\n${file === "/bin/bash" ? "/usr/bin:/bin" : "/opt/homebrew/bin"}\n`,
+        "",
+      );
+    }) as typeof execFile);
+
+    const bash = await getShellSnapshotPath("/bin/bash");
+    const zsh = await getShellSnapshotPath("/bin/zsh");
+
+    expect(bash).toBe("/usr/bin:/bin");
+    expect(zsh).toBe("/opt/homebrew/bin");
+    expect(mockExecFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns undefined and caches the failure when the shell errors", async () => {
+    mockExecFile.mockImplementation(((
+      _file: string,
+      _args: string[],
+      _options: unknown,
+      callback: ExecFileCallback,
+    ) => {
+      callback(new Error("spawn ENOENT"), "", "");
+    }) as typeof execFile);
+
+    const first = await getShellSnapshotPath("/bin/bash");
+    const second = await getShellSnapshotPath("/bin/bash");
+
+    expect(first).toBeUndefined();
+    expect(second).toBeUndefined();
+    // Failure is cached (settled undefined) — no retry per command, matching
+    // Claude Code: commands then fall back to `-l` login shells.
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns undefined for an empty PATH", async () => {
+    mockExecFile.mockImplementation(((
+      _file: string,
+      _args: string[],
+      _options: unknown,
+      callback: ExecFileCallback,
+    ) => {
+      callback(null, "WAVE_SHELL_SNAPSHOT\n", "");
+    }) as typeof execFile);
+
+    expect(await getShellSnapshotPath("/bin/bash")).toBeUndefined();
+  });
+
+  it("returns undefined when execFile throws synchronously (no unhandled rejection)", async () => {
+    mockExecFile.mockImplementation(() => {
+      throw new TypeError("invalid arguments");
+    });
+
+    expect(await getShellSnapshotPath("/bin/bash")).toBeUndefined();
+  });
+
+  it("resetShellSnapshotCache clears the cache so the snapshot is re-captured", async () => {
+    mockExecFile.mockImplementation(((
+      _file: string,
+      _args: string[],
+      _options: unknown,
+      callback: ExecFileCallback,
+    ) => {
+      callback(null, "WAVE_SHELL_SNAPSHOT\n/usr/bin:/bin\n", "");
+    }) as typeof execFile);
+
+    await getShellSnapshotPath("/bin/bash");
+    resetShellSnapshotCache();
+    await getShellSnapshotPath("/bin/bash");
+
+    expect(mockExecFile).toHaveBeenCalledTimes(2);
+  });
+
+  describe("getCachedShellSnapshotPath", () => {
+    it("returns undefined before the snapshot capture has settled", async () => {
+      let settleCallback: ExecFileCallback | undefined;
+      mockExecFile.mockImplementation(((
+        _file: string,
+        _args: string[],
+        _options: unknown,
+        callback: ExecFileCallback,
+      ) => {
+        settleCallback = callback;
+      }) as typeof execFile);
+
+      const promise = getShellSnapshotPath("/bin/bash");
+      expect(getCachedShellSnapshotPath("/bin/bash")).toBeUndefined();
+
+      // Let the capture settle — the synchronous getter now returns the PATH.
+      settleCallback?.(null, "WAVE_SHELL_SNAPSHOT\n/usr/bin:/bin\n", "");
+      await promise;
+      expect(getCachedShellSnapshotPath("/bin/bash")).toBe("/usr/bin:/bin");
+    });
+
+    it("returns the captured PATH synchronously once the snapshot is ready", async () => {
+      mockExecFile.mockImplementation(((
+        _file: string,
+        _args: string[],
+        _options: unknown,
+        callback: ExecFileCallback,
+      ) => {
+        callback(
+          null,
+          "WAVE_SHELL_SNAPSHOT\n/usr/local/bin:/usr/bin:/bin\n",
+          "",
+        );
+      }) as typeof execFile);
+
+      await getShellSnapshotPath("/bin/bash");
+
+      expect(getCachedShellSnapshotPath("/bin/bash")).toBe(
+        "/usr/local/bin:/usr/bin:/bin",
+      );
+    });
+
+    it("returns undefined for a failed capture", async () => {
+      mockExecFile.mockImplementation(((
+        _file: string,
+        _args: string[],
+        _options: unknown,
+        callback: ExecFileCallback,
+      ) => {
+        callback(new Error("spawn ENOENT"), "", "");
+      }) as typeof execFile);
+
+      await getShellSnapshotPath("/bin/bash");
+
+      expect(getCachedShellSnapshotPath("/bin/bash")).toBeUndefined();
+    });
+  });
+
+  describe("buildShellSpawnArgs", () => {
+    it("returns -c -l and kicks off snapshot creation when none cached", () => {
+      mockExecFile.mockImplementation((() => {
+        // Never invoke the callback — the capture stays pending.
+      }) as unknown as typeof execFile);
+
+      expect(buildShellSpawnArgs("/bin/bash", "echo hi")).toEqual([
+        "-c",
+        "-l",
+        "echo hi",
+      ]);
+      // Capture kicked off (fire-and-forget) for later commands.
+      expect(mockExecFile).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns -c with the cached PATH re-exported once the snapshot is ready", async () => {
+      mockExecFile.mockImplementation(((
+        _file: string,
+        _args: string[],
+        _options: unknown,
+        callback: ExecFileCallback,
+      ) => {
+        callback(
+          null,
+          "WAVE_SHELL_SNAPSHOT\n/usr/local/bin:/usr/bin:/bin\n",
+          "",
+        );
+      }) as typeof execFile);
+      await getShellSnapshotPath("/bin/bash");
+      mockExecFile.mockClear();
+
+      expect(buildShellSpawnArgs("/bin/bash", "echo hi")).toEqual([
+        "-c",
+        "export PATH='/usr/local/bin:/usr/bin:/bin'; echo hi",
+      ]);
+      // Snapshot already cached — no new capture kicked off.
+      expect(mockExecFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("shellSingleQuote", () => {
+    it("wraps the value in single quotes", () => {
+      expect(shellSingleQuote("/usr/bin:/bin")).toBe("'/usr/bin:/bin'");
+    });
+
+    it("escapes embedded single quotes", () => {
+      expect(shellSingleQuote("a'b")).toBe(`'a'"'"'b'`);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

对齐 Claude Code 在 Windows 上的 Git Bash 使用方式（wave-agent SDK），补齐三项缺失：

1. **BashTool / 后台任务 / bang 命令以 login shell 执行** — spawn 显式 `-c -l`（读用户 profile），与 CC `getSpawnArgs` 一致（`['-c', '-l', cmd]` 顺序已在 bash 实测生效）
2. **启动时设置 `process.env.SHELL = gitBashPath`** — `setShellIfWindows()` 在 `Agent.initialize()` 调用（对齐 CC init.ts:186），COMSPEC 不动
3. **shell snapshot** — 新增 `shellSnapshot.ts`：会话内只 source profile 一次并缓存 `echo $PATH` 结果，后续命令复用（省 `-l` + `export PATH=<快照>`），三个执行器通过共享 `buildShellSpawnArgs()` 统一走此策略（对齐 CC bashProvider/ShellSnapshot）

## Changes

- `packages/agent-sdk/src/utils/shellSnapshot.ts`（新增）：快照捕获/缓存 + `buildShellSpawnArgs` + `shellSingleQuote`
- `packages/agent-sdk/src/utils/shellResolver.ts`：新增 `setShellIfWindows()`
- `packages/agent-sdk/src/tools/bashTool.ts`：前台命令显式 spawn `-c -l` / 快照复用
- `packages/agent-sdk/src/managers/backgroundTaskManager.ts`、`bangManager.ts`：同策略对齐（无 bash/zsh 时保留 `shell: true` 回退）
- `packages/agent-sdk/src/agent.ts`：init 时调用 `setShellIfWindows()`
- 测试：`shellSnapshot.test.ts`（新增 14 用例）、bashTool/bangManager/BTM 测试更新与新增（快照集成走真实链路）

## Verification

- agent-sdk 全量测试：**261 files passed，3586 tests passed**
- type-check / lint / prettier 全绿
- 真实环境冒烟：login profile 的 PATH 正确捕获并缓存

不做 PowerShell 工具（与任务范围一致）；hooks 已走 Git Bash，未改动。