### PR TITLE
feat(agent-sdk): show streaming text tail with last tool in subagent shortResult

### DIFF
--- a/packages/agent-sdk/src/tools/agentTool.ts
+++ b/packages/agent-sdk/src/tools/agentTool.ts
@@ -2,10 +2,36 @@ import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
 import { EXPLORE_SUBAGENT_TYPE } from "../constants/subagents.js";
 import { AGENT_TOOL_NAME } from "../constants/tools.js";
 import type { SubagentConfiguration } from "../utils/subagentParser.js";
+import type { Message, ReasoningBlock, TextBlock } from "../types/messaging.js";
 import {
   countToolBlocks,
   formatToolTokenSummary,
 } from "../utils/messageOperations.js";
+
+/**
+ * Find the last streaming text/reasoning block across the subagent's messages.
+ * The message manager finalizes streaming content blocks (stage → "end")
+ * before a tool call begins, so at most one block is "streaming" at a time:
+ * its presence means the subagent is currently generating content (thinking or
+ * answering), its absence means it is in a tool phase (streaming/running/idle).
+ */
+function findActiveStreamingBlock(
+  messages: Message[],
+): TextBlock | ReasoningBlock | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const blocks = messages[i].blocks;
+    for (let j = blocks.length - 1; j >= 0; j--) {
+      const block = blocks[j];
+      if (
+        (block.type === "text" || block.type === "reasoning") &&
+        block.stage === "streaming"
+      ) {
+        return block;
+      }
+    }
+  }
+  return undefined;
+}
 
 /**
  * Agent tool plugin for launching specialized agents to handle complex tasks
@@ -159,7 +185,13 @@ When using the Agent tool, you must specify a subagent_type parameter to select 
 
           const messages = instance.messageManager.getMessages();
           const tokens = instance.messageManager.getLatestTotalTokens();
-          const usedTools = instance.usedTools;
+          // While the subagent is streaming content (reasoning or reply text),
+          // show the last ONE tool plus the streaming content tail; otherwise
+          // (tool streaming/running/idle) keep the last two tools.
+          const activeStreaming = findActiveStreamingBlock(messages);
+          const usedTools = activeStreaming
+            ? instance.usedTools.slice(-1)
+            : instance.usedTools;
 
           const toolCount = countToolBlocks(messages);
           const summary = formatToolTokenSummary(toolCount, tokens);
@@ -191,6 +223,16 @@ When using the Agent tool, you must specify a subagent_type parameter to select 
               usedTools
                 .map((t) => `${t.name} ${getDisplayParam(t)}`)
                 .join("\n");
+          }
+
+          // Streaming content tail, on its own line below the tool lines
+          // (compact style, mirroring the tool's truncated compact params).
+          if (activeStreaming) {
+            const flat = activeStreaming.content.replace(/\s+/g, " ").trim();
+            if (flat) {
+              const tail = flat.length > 30 ? `…${flat.slice(-30)}` : flat;
+              shortResult += (shortResult ? "\n" : "") + tail;
+            }
           }
 
           context.onShortResultUpdate?.(shortResult);

--- a/packages/agent-sdk/tests/tools/agentTool.test.ts
+++ b/packages/agent-sdk/tests/tools/agentTool.test.ts
@@ -211,6 +211,308 @@ describe("Agent Tool Background Execution", () => {
     });
   });
 
+  it("should show last ONE tool plus the streaming text tail while text is streaming", async () => {
+    const mockInstance = {
+      subagentId: "gp-test-id",
+      usedTools: [
+        {
+          name: "Read",
+          parameters: '{"file_path":"file1.txt"}',
+          compactParams: "file1.txt",
+          stage: "running",
+        },
+        {
+          name: "Write",
+          parameters: '{"file_path":"file2.txt"}',
+          compactParams: "file2.txt",
+          stage: "running",
+        },
+      ],
+      messageManager: {
+        getMessages: vi.fn(() => [
+          { blocks: [{ type: "tool" }, { type: "tool" }] },
+          {
+            blocks: [
+              {
+                type: "text",
+                content: "Let me verify the fix now",
+                stage: "streaming",
+              },
+            ],
+          },
+        ]),
+        getLatestTotalTokens: vi.fn(() => 1000),
+      },
+    };
+
+    let capturedShortResult = "";
+    const contextWithCallback: ToolContext = {
+      ...mockToolContext,
+      onShortResultUpdate: (sr) => {
+        capturedShortResult = sr;
+      },
+    };
+
+    vi.mocked(mockSubagentManager.findSubagent).mockResolvedValue(gpConfig);
+    vi.mocked(mockSubagentManager.createInstance).mockImplementation(
+      async (config, args, background, updateShortResult) => {
+        setTimeout(() => updateShortResult?.(), 0);
+        return mockInstance as unknown as SubagentInstance;
+      },
+    );
+    vi.mocked(mockSubagentManager.executeAgent).mockResolvedValue("done");
+
+    await agentTool.execute(
+      {
+        description: "Test",
+        prompt: "Test",
+        subagent_type: "general-purpose",
+      },
+      contextWithCallback,
+    );
+
+    await vi.waitFor(() => {
+      // Last ONE tool only (Write), tail on its own line after "\n"
+      expect(capturedShortResult).toBe(
+        "(2 tools | 1,000 tokens)\nWrite file2.txt\nLet me verify the fix now",
+      );
+    });
+  });
+
+  it("should show last ONE tool plus the streaming reasoning tail while reasoning is streaming", async () => {
+    const mockInstance = {
+      subagentId: "gp-test-id",
+      usedTools: [
+        {
+          name: "Read",
+          parameters: '{"file_path":"file1.txt"}',
+          compactParams: "file1.txt",
+          stage: "running",
+        },
+        {
+          name: "Write",
+          parameters: '{"file_path":"file2.txt"}',
+          compactParams: "file2.txt",
+          stage: "running",
+        },
+      ],
+      messageManager: {
+        getMessages: vi.fn(() => [
+          { blocks: [{ type: "tool" }, { type: "tool" }] },
+          {
+            blocks: [
+              {
+                type: "reasoning",
+                content: "Checking block streaming flow",
+                stage: "streaming",
+              },
+            ],
+          },
+        ]),
+        getLatestTotalTokens: vi.fn(() => 1000),
+      },
+    };
+
+    let capturedShortResult = "";
+    const contextWithCallback: ToolContext = {
+      ...mockToolContext,
+      onShortResultUpdate: (sr) => {
+        capturedShortResult = sr;
+      },
+    };
+
+    vi.mocked(mockSubagentManager.findSubagent).mockResolvedValue(gpConfig);
+    vi.mocked(mockSubagentManager.createInstance).mockImplementation(
+      async (config, args, background, updateShortResult) => {
+        setTimeout(() => updateShortResult?.(), 0);
+        return mockInstance as unknown as SubagentInstance;
+      },
+    );
+    vi.mocked(mockSubagentManager.executeAgent).mockResolvedValue("done");
+
+    await agentTool.execute(
+      {
+        description: "Test",
+        prompt: "Test",
+        subagent_type: "general-purpose",
+      },
+      contextWithCallback,
+    );
+
+    await vi.waitFor(() => {
+      // Reasoning tail on its own line, last ONE tool only
+      expect(capturedShortResult).toBe(
+        "(2 tools | 1,000 tokens)\nWrite file2.txt\nChecking block streaming flow",
+      );
+    });
+  });
+
+  it("should truncate the streaming tail to the last 30 chars with a '...' prefix", async () => {
+    const longContent =
+      "This is a very long streaming reply text that definitely exceeds thirty characters";
+    const shortContent = "Short reply";
+
+    let mockInstance: unknown;
+    let capturedShortResult = "";
+    const contextWithCallback: ToolContext = {
+      ...mockToolContext,
+      onShortResultUpdate: (sr) => {
+        capturedShortResult = sr;
+      },
+    };
+
+    vi.mocked(mockSubagentManager.findSubagent).mockResolvedValue(gpConfig);
+    vi.mocked(mockSubagentManager.createInstance).mockImplementation(
+      async (config, args, background, updateShortResult) => {
+        setTimeout(() => updateShortResult?.(), 0);
+        return mockInstance as unknown as SubagentInstance;
+      },
+    );
+    vi.mocked(mockSubagentManager.executeAgent).mockResolvedValue("done");
+
+    const baseInstance = {
+      subagentId: "gp-test-id",
+      usedTools: [
+        {
+          name: "Read",
+          parameters: '{"file_path":"file1.txt"}',
+          compactParams: "file1.txt",
+          stage: "running",
+        },
+        {
+          name: "Write",
+          parameters: '{"file_path":"file2.txt"}',
+          compactParams: "file2.txt",
+          stage: "running",
+        },
+      ],
+    };
+
+    // Long streaming content (> 30 chars) -> truncated tail
+    mockInstance = {
+      ...baseInstance,
+      messageManager: {
+        getMessages: vi.fn(() => [
+          { blocks: [{ type: "tool" }, { type: "tool" }] },
+          {
+            blocks: [
+              { type: "text", content: longContent, stage: "streaming" },
+            ],
+          },
+        ]),
+        getLatestTotalTokens: vi.fn(() => 1000),
+      },
+    };
+
+    await agentTool.execute(
+      {
+        description: "Test",
+        prompt: "Test",
+        subagent_type: "general-purpose",
+      },
+      contextWithCallback,
+    );
+
+    await vi.waitFor(() => {
+      expect(capturedShortResult).toBe(
+        `(2 tools | 1,000 tokens)\nWrite file2.txt\n…${longContent.slice(-30)}`,
+      );
+    });
+
+    // Short streaming content (<= 30 chars) -> full tail
+    capturedShortResult = "";
+    mockInstance = {
+      ...baseInstance,
+      messageManager: {
+        getMessages: vi.fn(() => [
+          { blocks: [{ type: "tool" }, { type: "tool" }] },
+          {
+            blocks: [
+              { type: "text", content: shortContent, stage: "streaming" },
+            ],
+          },
+        ]),
+        getLatestTotalTokens: vi.fn(() => 1000),
+      },
+    };
+
+    await agentTool.execute(
+      {
+        description: "Test",
+        prompt: "Test",
+        subagent_type: "general-purpose",
+      },
+      contextWithCallback,
+    );
+
+    await vi.waitFor(() => {
+      expect(capturedShortResult).toBe(
+        "(2 tools | 1,000 tokens)\nWrite file2.txt\nShort reply",
+      );
+    });
+  });
+
+  it("should keep the last TWO tools when the text block is finalized (stage end)", async () => {
+    const mockInstance = {
+      subagentId: "gp-test-id",
+      usedTools: [
+        {
+          name: "Read",
+          parameters: '{"file_path":"file1.txt"}',
+          compactParams: "file1.txt",
+          stage: "running",
+        },
+        {
+          name: "Write",
+          parameters: '{"file_path":"file2.txt"}',
+          compactParams: "file2.txt",
+          stage: "running",
+        },
+      ],
+      messageManager: {
+        getMessages: vi.fn(() => [
+          { blocks: [{ type: "tool" }, { type: "tool" }] },
+          {
+            blocks: [{ type: "text", content: "Done", stage: "end" }],
+          },
+        ]),
+        getLatestTotalTokens: vi.fn(() => 1000),
+      },
+    };
+
+    let capturedShortResult = "";
+    const contextWithCallback: ToolContext = {
+      ...mockToolContext,
+      onShortResultUpdate: (sr) => {
+        capturedShortResult = sr;
+      },
+    };
+
+    vi.mocked(mockSubagentManager.findSubagent).mockResolvedValue(gpConfig);
+    vi.mocked(mockSubagentManager.createInstance).mockImplementation(
+      async (config, args, background, updateShortResult) => {
+        setTimeout(() => updateShortResult?.(), 0);
+        return mockInstance as unknown as SubagentInstance;
+      },
+    );
+    vi.mocked(mockSubagentManager.executeAgent).mockResolvedValue("done");
+
+    await agentTool.execute(
+      {
+        description: "Test",
+        prompt: "Test",
+        subagent_type: "general-purpose",
+      },
+      contextWithCallback,
+    );
+
+    await vi.waitFor(() => {
+      expect(capturedShortResult).toBe(
+        "(2 tools | 1,000 tokens)\nRead file1.txt\nWrite file2.txt",
+      );
+    });
+  });
+
   it("should handle missing parameters", async () => {
     const result = await agentTool.execute({}, mockToolContext);
     expect(result.success).toBe(false);


### PR DESCRIPTION
## Summary

While a subagent is streaming content (reasoning or reply text), its Agent tool `shortResult` now shows the **last ONE tool plus the current streaming content tail** (compact style, on its own line) instead of the last two tools. Tool streaming/running phases keep showing the last two tools (unchanged).

The active phase is detected from the subagent's messages: the message manager finalizes streaming text/reasoning blocks (stage → end) before a tool call begins, so at most one block is in `streaming` at a time.

## Changes

- `packages/agent-sdk/src/tools/agentTool.ts`: new `findActiveStreamingBlock()` helper; onUpdate callback slices `usedTools` to the last tool and appends the streaming content tail (newline-separated, >30 chars truncated with `…` prefix) while content is streaming
- `packages/agent-sdk/tests/tools/agentTool.test.ts`: +4 test cases (text streaming / reasoning streaming / truncation format / finalized block keeps two tools)

## Verification

- agent-sdk: 268 files / 3617 passed
- webview: 79 files / 648 passed
- type-check + lint green (agent-sdk, webview)