### PR TITLE
fix(code): populate firstMessage in listAllSessions and shorten session IDs

### DIFF
--- a/packages/agent-sdk/src/services/session.ts
+++ b/packages/agent-sdk/src/services/session.ts
@@ -602,6 +602,20 @@ export async function listAllSessions(options?: {
               lastActiveAt = stats.mtime;
             }
 
+            // Populate the first-message preview like listSessionsFromJsonl
+            // does, so aggregated modes (Ctrl+A / Ctrl+W) show real content
+            // instead of the "No content" fallback.
+            let firstMessage: string | undefined;
+            try {
+              const firstContent =
+                await getFirstMessageContentFromFile(filePath);
+              if (firstContent) {
+                firstMessage = firstContent;
+              }
+            } catch {
+              // Ignore errors getting first message
+            }
+
             allSessions.push({
               id: sessionId,
               sessionType: "main" as const,
@@ -612,6 +626,7 @@ export async function listAllSessions(options?: {
               latestTotalTokens: lastMessage?.usage
                 ? extractLatestTotalTokens([lastMessage])
                 : 0,
+              firstMessage,
             });
           } catch {
             continue;
@@ -861,6 +876,50 @@ export async function sessionExistsInJsonl(
 }
 
 /**
+ * Get the content of the first non-meta message in a session file
+ * For user role: get text block content
+ * For assistant role: get compact block content
+ * Skips meta messages (isMeta: true) to find the first meaningful message
+ * @param filePath - Path to the session JSONL file
+ * @returns Promise that resolves to the first non-meta message content or null if not found
+ */
+export async function getFirstMessageContentFromFile(
+  filePath: string,
+): Promise<string | null> {
+  try {
+    // Read first N lines to skip meta messages
+    const { readFirstNLines } = await import("../utils/fileUtils.js");
+    const lines = await readFirstNLines(filePath, 10);
+
+    for (const line of lines) {
+      try {
+        const message = JSON.parse(line) as Message;
+
+        // Skip meta messages
+        if (message.isMeta) {
+          continue;
+        }
+
+        const content = getMessageContent(message);
+        if (content) {
+          return content;
+        }
+      } catch (error) {
+        logger.warn(
+          `Failed to parse message in session file ${filePath}:`,
+          error,
+        );
+      }
+    }
+
+    return null;
+  } catch (error) {
+    logger.warn(`Failed to get first message content from ${filePath}:`, error);
+    return null;
+  }
+}
+
+/**
  * Get the content of the first non-meta message in a session
  * For user role: get text block content
  * For assistant role: get compact block content
@@ -880,29 +939,7 @@ export async function getFirstMessageContent(
     const projectDir = await encoder.getProjectDirectory(workdir, baseDir);
     const filePath = join(projectDir.encodedPath, `${sessionId}.jsonl`);
 
-    // Read first N lines to skip meta messages
-    const { readFirstNLines } = await import("../utils/fileUtils.js");
-    const lines = await readFirstNLines(filePath, 10);
-
-    for (const line of lines) {
-      try {
-        const message = JSON.parse(line) as Message;
-
-        // Skip meta messages
-        if (message.isMeta) {
-          continue;
-        }
-
-        const content = getMessageContent(message);
-        if (content) {
-          return content;
-        }
-      } catch (error) {
-        logger.warn(`Failed to parse message in session ${sessionId}:`, error);
-      }
-    }
-
-    return null;
+    return getFirstMessageContentFromFile(filePath);
   } catch (error) {
     logger.warn(
       `Failed to get first message content for session ${sessionId}:`,

--- a/packages/agent-sdk/tests/services/session.resume.test.ts
+++ b/packages/agent-sdk/tests/services/session.resume.test.ts
@@ -157,6 +157,44 @@ describe("Session resume: cross-directory listing & restore", () => {
     });
   });
 
+  describe("first-message preview in aggregated listing", () => {
+    it("populates firstMessage so Ctrl+A/Ctrl+W rows do not fall back to No content", async () => {
+      const fs = await import("fs");
+      const { readFirstNLines } = await import("../../src/utils/fileUtils.js");
+      const sessionId = randomUUID();
+
+      // Meta messages are skipped; the first real content is returned.
+      vi.mocked(readFirstNLines).mockResolvedValue([
+        JSON.stringify({
+          isMeta: true,
+          blocks: [{ type: "text", content: "system init" }],
+        }),
+        JSON.stringify({
+          blocks: [{ type: "text", content: "hello from another project" }],
+        }),
+      ]);
+
+      vi.mocked(fs.promises.readdir)
+        .mockResolvedValueOnce(["home-u-repo"] as unknown as Awaited<
+          ReturnType<typeof fs.promises.readdir>
+        >)
+        .mockResolvedValueOnce([`${sessionId}.jsonl`] as unknown as Awaited<
+          ReturnType<typeof fs.promises.readdir>
+        >);
+      vi.mocked(fs.promises.stat).mockResolvedValue({
+        isDirectory: () => true,
+      } as unknown as Awaited<ReturnType<typeof fs.promises.stat>>);
+      mockJsonlHandler.getLastMessage.mockResolvedValue(
+        makeMessage(new Date().toISOString()),
+      );
+
+      const sessions = await listAllSessions();
+
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]!.firstMessage).toBe("hello from another project");
+    });
+  });
+
   describe("worktree aggregation", () => {
     it("only scans project dirs matching the given worktree paths", async () => {
       const fs = await import("fs");

--- a/packages/code/src/components/SessionSelector.tsx
+++ b/packages/code/src/components/SessionSelector.tsx
@@ -191,8 +191,8 @@ export const SessionSelector: React.FC<SessionSelectorProps> = ({
                     color={isSelected ? "black" : "white"}
                     wrap="truncate-end"
                   >
-                    {session.id} | {lastActiveAt} | {session.latestTotalTokens}{" "}
-                    tokens
+                    {session.id.slice(0, 8)} | {lastActiveAt} |{" "}
+                    {session.latestTotalTokens} tokens
                     {showProjectPath && session.workdir
                       ? ` | ${session.workdir}`
                       : ""}

--- a/packages/code/tests/components/SessionSelector.test.tsx
+++ b/packages/code/tests/components/SessionSelector.test.tsx
@@ -7,7 +7,7 @@ import type { SessionMetadata } from "wave-agent-sdk";
 describe("SessionSelector", () => {
   const mockSessions: (SessionMetadata & { firstMessage?: string })[] = [
     {
-      id: "session-1",
+      id: "12345678-1234-4321-8765-123456789012",
       createdAt: new Date("2023-01-01T10:00:00Z"),
       lastActiveAt: new Date("2023-01-01T10:00:00Z"),
       latestTotalTokens: 100,
@@ -16,7 +16,7 @@ describe("SessionSelector", () => {
       workdir: "/test",
     },
     {
-      id: "session-2",
+      id: "87654321-4321-1234-5678-210987654321",
       createdAt: new Date("2023-01-01T11:00:00Z"),
       lastActiveAt: new Date("2023-01-01T11:00:00Z"),
       latestTotalTokens: 200,
@@ -36,8 +36,9 @@ describe("SessionSelector", () => {
     const { lastFrame } = render(<SessionSelector {...mockProps} />);
     const output = lastFrame();
     expect(output).toContain("Select a session to resume");
-    expect(output).toContain("session-1");
-    expect(output).toContain("session-2");
+    // Only the first 8 chars of the session id are shown
+    expect(output).toContain("12345678");
+    expect(output).toContain("87654321");
     expect(output).toContain("Hello world");
     // Only the selected session's first message is shown
     expect(output).not.toContain("How are you?");
@@ -56,20 +57,20 @@ describe("SessionSelector", () => {
     const { lastFrame, stdin } = render(<SessionSelector {...mockProps} />);
 
     // Initially first session is selected
-    expect(lastFrame()).toContain("▶ session-1");
+    expect(lastFrame()).toContain("▶ 12345678");
 
     // Press down arrow
     stdin.write("\u001B[B"); // Down arrow
 
     await vi.waitFor(() => {
-      expect(lastFrame()).toContain("▶ session-2");
+      expect(lastFrame()).toContain("▶ 87654321");
     });
 
     // Press up arrow
     stdin.write("\u001B[A"); // Up arrow
 
     await vi.waitFor(() => {
-      expect(lastFrame()).toContain("▶ session-1");
+      expect(lastFrame()).toContain("▶ 12345678");
     });
   });
 
@@ -81,7 +82,9 @@ describe("SessionSelector", () => {
 
     stdin.write("\r"); // Enter
     await vi.waitFor(() => {
-      expect(onSelect).toHaveBeenCalledWith("session-1");
+      expect(onSelect).toHaveBeenCalledWith(
+        "12345678-1234-4321-8765-123456789012",
+      );
     });
   });
 


### PR DESCRIPTION
## 问题

冒烟测试发现 `wave -r` 选择器在 Ctrl+A / Ctrl+W 聚合模式下所有会话都显示 "No content"，且行尾项目路径被截断：

1. **"No content"**：`listAllSessions`（Ctrl+A 全项目 / Ctrl+W worktree 模式）构造元数据时从不填充 `firstMessage`，而 `listSessionsFromJsonl`（默认当前目录模式）会——聚合模式下所有有真实首消息的会话都落到 `"No content"` 兜底。
2. **项目路径被截断**：行内容 `UUID(36) | 日期 | tokens | 路径` 过长，`wrap=\"truncate-end\"` 从行尾截断，正好切掉项目路径。

## 修复

- `listAllSessions` 通过新增的 `getFirstMessageContentFromFile(filePath)` helper 填充 `firstMessage`（与 `listSessionsFromJsonl` 行为一致；`getFirstMessageContent` 委托同一 helper）
- SessionSelector 行首显示 8 位短会话 ID（`c4c9e3dd`），给行尾项目路径腾空间；选中/恢复仍用完整 ID
- 额外清理：本机 55 个 0 字节历史空会话文件已手动删除（列表显示 "0 tokens / No content" 的空壳，14 天清理逻辑因触发面窄从未扫到它们所在目录）

## 验证

- 真实数据：聚合模式 0/858 有预览 → 802/803（剩余 1 个为 compress-only 旧会话，合理兜底）
- 新增 `listAllSessions` firstMessage 单测（含 meta 跳过）
- SDK 39/39 + code 52/52 测试通过；type-check 通过