### PR TITLE
fix: fall back to fs.rmSync when git worktree remove fails on Windows long paths

### DIFF
--- a/packages/agent-sdk/src/utils/worktreeUtils.ts
+++ b/packages/agent-sdk/src/utils/worktreeUtils.ts
@@ -605,74 +605,117 @@ export async function performPostCreationSetup(
 }
 
 /**
+ * On Windows, prefix an absolute path with the extended-length marker (`\\?\`)
+ * so recursive removal bypasses the 260-char MAX_PATH limit. POSIX paths are
+ * returned unchanged.
+ */
+function toExtendedLengthPath(worktreePath: string): string {
+  if (process.platform !== "win32") {
+    return worktreePath;
+  }
+  const absolute = path.win32.resolve(worktreePath);
+  if (absolute.startsWith("\\\\?\\")) {
+    return absolute;
+  }
+  if (absolute.startsWith("\\\\")) {
+    // UNC path: \\server\share -> \\?\UNC\server\share
+    return `\\\\?\\UNC\\${absolute.slice(2)}`;
+  }
+  return `\\\\?\\${absolute}`;
+}
+
+/**
  * Remove a git worktree and its branch.
+ *
+ * Removal is best-effort: `git worktree remove --force` deletes the worktree
+ * metadata before the working directory, and on Windows its recursive deletion
+ * is MAX_PATH-limited — deep paths (e.g. node_modules) can fail with "Filename
+ * too long", leaving an orphan directory. When git fails we fall back to
+ * fs.rmSync with an extended-length path (bypasses MAX_PATH) and prune stale
+ * metadata. Failures are logged but never block branch deletion.
  */
 export function removeWorktree(info: WorktreeInfo): void {
   const repoRoot = info.repoRoot;
 
+  // Get current branch in worktree before removing
+  let currentBranch: string | undefined;
   try {
-    // Get current branch in worktree before removing
-    let currentBranch: string | undefined;
-    try {
-      currentBranch = execFileSync(
-        "git",
-        ["rev-parse", "--abbrev-ref", "HEAD"],
-        {
-          cwd: info.path,
-          encoding: "utf8",
-          stdio: ["ignore", "pipe", "ignore"],
-        },
-      ).trim();
-    } catch {
-      // Ignore errors
-    }
+    currentBranch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+      cwd: info.path,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    // Ignore errors
+  }
 
-    // Remove worktree
+  // Remove worktree
+  try {
     execFileSync("git", ["worktree", "remove", "--force", info.path], {
       cwd: repoRoot,
       stdio: ["ignore", "pipe", "pipe"],
     });
-
-    // Delete worktree branch
+  } catch (error: unknown) {
+    logger.warn("git worktree remove failed, falling back to fs.rmSync:", {
+      error: error instanceof Error ? error.message : String(error),
+      worktreePath: info.path,
+    });
     try {
-      execFileSync("git", ["branch", "-D", info.branch], {
+      fs.rmSync(toExtendedLengthPath(info.path), {
+        recursive: true,
+        force: true,
+      });
+    } catch (rmError: unknown) {
+      logger.error("Failed to remove worktree or branch:", {
+        error: rmError instanceof Error ? rmError.message : String(rmError),
+        worktreePath: info.path,
+      });
+    }
+    // git removes worktree metadata before the working directory; prune any
+    // leftovers in case git failed before deleting them.
+    try {
+      execFileSync("git", ["worktree", "prune"], {
         cwd: repoRoot,
         stdio: ["ignore", "pipe", "pipe"],
       });
     } catch {
       // Ignore errors
     }
+  }
 
-    // Delete current branch if different and not protected
+  // Delete worktree branch
+  try {
+    execFileSync("git", ["branch", "-D", info.branch], {
+      cwd: repoRoot,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch {
+    // Ignore errors
+  }
+
+  // Delete current branch if different and not protected
+  if (
+    currentBranch &&
+    currentBranch !== info.branch &&
+    currentBranch !== "HEAD"
+  ) {
+    const defaultRemoteBranch = getDefaultRemoteBranch(repoRoot);
+    const defaultBranchName = defaultRemoteBranch.split("/").pop();
+
     if (
-      currentBranch &&
-      currentBranch !== info.branch &&
-      currentBranch !== "HEAD"
+      currentBranch !== defaultBranchName &&
+      currentBranch !== "main" &&
+      currentBranch !== "master"
     ) {
-      const defaultRemoteBranch = getDefaultRemoteBranch(repoRoot);
-      const defaultBranchName = defaultRemoteBranch.split("/").pop();
-
-      if (
-        currentBranch !== defaultBranchName &&
-        currentBranch !== "main" &&
-        currentBranch !== "master"
-      ) {
-        try {
-          execFileSync("git", ["branch", "-D", currentBranch], {
-            cwd: repoRoot,
-            stdio: ["ignore", "pipe", "pipe"],
-          });
-        } catch {
-          // Ignore errors
-        }
+      try {
+        execFileSync("git", ["branch", "-D", currentBranch], {
+          cwd: repoRoot,
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+      } catch {
+        // Ignore errors
       }
     }
-  } catch (error: unknown) {
-    logger.error("Failed to remove worktree or branch:", {
-      error: error instanceof Error ? error.message : String(error),
-      worktreePath: info.path,
-    });
-    throw error;
   }
 }
 

--- a/packages/agent-sdk/tests/utils/worktreeUtils.test.ts
+++ b/packages/agent-sdk/tests/utils/worktreeUtils.test.ts
@@ -50,6 +50,7 @@ vi.mock("node:fs", () => ({
   realpathSync: vi.fn(),
   readFileSync: vi.fn(),
   appendFileSync: vi.fn(),
+  rmSync: vi.fn(),
   promises: {
     readFile: vi.fn(),
     writeFile: vi.fn(),
@@ -398,6 +399,7 @@ describe("worktreeUtils", () => {
     beforeEach(() => {
       vi.mocked(execFileSync).mockReturnValue("");
       vi.mocked(gitUtils.getDefaultRemoteBranch).mockReturnValue("origin/main");
+      vi.mocked(fs.rmSync).mockImplementation(() => {});
     });
 
     it("removes worktree and branch", () => {
@@ -419,12 +421,15 @@ describe("worktreeUtils", () => {
         expect.arrayContaining(["branch", "-D", "worktree-feat"]),
         expect.anything(),
       );
+      expect(fs.rmSync).not.toHaveBeenCalled();
     });
 
-    it("logs and rethrows on failure", () => {
-      const error = new Error("git failed");
-      vi.mocked(execFileSync).mockImplementation(() => {
-        throw error;
+    it("falls back to fs.rmSync and still deletes the branch when git removal fails", () => {
+      vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+        if (args?.includes("remove") && args?.includes("worktree")) {
+          throw new Error("git failed");
+        }
+        return "";
       });
 
       expect(() =>
@@ -435,7 +440,60 @@ describe("worktreeUtils", () => {
           repoRoot: "/test/repo",
           isNew: true,
         }),
-      ).toThrow("git failed");
+      ).not.toThrow();
+
+      const [rmPath] = vi.mocked(fs.rmSync).mock.calls[0];
+      if (process.platform === "win32") {
+        // Extended-length path bypasses the Windows MAX_PATH limit
+        expect(String(rmPath)).toMatch(/^\\\\\?\\/);
+      } else {
+        expect(rmPath).toBe("/test/repo/.wave/worktrees/feat");
+      }
+      expect(fs.rmSync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ recursive: true, force: true }),
+      );
+      // Branch deletion still runs despite the git failure
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["branch", "-D", "worktree-feat"]),
+        expect.anything(),
+      );
+      // Stale metadata is pruned after the fallback removal
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["worktree", "prune"]),
+        expect.anything(),
+      );
+    });
+
+    it("logs and still deletes the branch when git and fs.rmSync both fail", () => {
+      vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+        if (args?.includes("remove") && args?.includes("worktree")) {
+          throw new Error("git failed");
+        }
+        return "";
+      });
+      vi.mocked(fs.rmSync).mockImplementation(() => {
+        throw new Error("rm failed");
+      });
+
+      expect(() =>
+        worktreeUtils.removeWorktree({
+          name: "feat",
+          path: "/test/repo/.wave/worktrees/feat",
+          branch: "worktree-feat",
+          repoRoot: "/test/repo",
+          isNew: true,
+        }),
+      ).not.toThrow();
+
+      // Branch deletion still runs even when both removal attempts fail
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["branch", "-D", "worktree-feat"]),
+        expect.anything(),
+      );
     });
   });
 

--- a/packages/code/src/utils/worktree.ts
+++ b/packages/code/src/utils/worktree.ts
@@ -266,30 +266,57 @@ async function createWorktreeInternal(
 }
 
 /**
+ * On Windows, prefix an absolute path with the extended-length marker (`\\?\`)
+ * so recursive removal bypasses the 260-char MAX_PATH limit. POSIX paths are
+ * returned unchanged.
+ */
+function toExtendedLengthPath(worktreePath: string): string {
+  if (process.platform !== "win32") {
+    return worktreePath;
+  }
+  const absolute = path.win32.resolve(worktreePath);
+  if (absolute.startsWith("\\\\?\\")) {
+    return absolute;
+  }
+  if (absolute.startsWith("\\\\")) {
+    // UNC path: \\server\share -> \\?\UNC\server\share
+    return `\\\\?\\UNC\\${absolute.slice(2)}`;
+  }
+  return `\\\\?\\${absolute}`;
+}
+
+/**
  * Remove a git worktree and its associated branch
  * @param session Worktree session details
+ *
+ * Removal is best-effort: `git worktree remove --force` deletes the worktree
+ * metadata before the working directory, and on Windows its recursive deletion
+ * is MAX_PATH-limited — deep paths (e.g. node_modules) can fail with "Filename
+ * too long", leaving an orphan directory. When git fails we fall back to
+ * fs.rmSync with an extended-length path (bypasses MAX_PATH) and prune stale
+ * metadata. Failures are logged but never block branch deletion.
  */
 export async function removeWorktree(session: WorktreeSession): Promise<void> {
   const repoRoot = session.repoRoot;
 
+  // Get current branch in worktree before removing it
+  let currentBranch: string | undefined;
   try {
-    // Get current branch in worktree before removing it
-    let currentBranch: string | undefined;
-    try {
-      const { stdout } = await execFileAsync(
-        "git",
-        ["rev-parse", "--abbrev-ref", "HEAD"],
-        {
-          cwd: session.path,
-          encoding: "utf8",
-        },
-      );
-      currentBranch = stdout.trim();
-    } catch {
-      // Ignore errors getting current branch
-    }
+    const { stdout } = await execFileAsync(
+      "git",
+      ["rev-parse", "--abbrev-ref", "HEAD"],
+      {
+        cwd: session.path,
+        encoding: "utf8",
+      },
+    );
+    currentBranch = stdout.trim();
+  } catch {
+    // Ignore errors getting current branch
+  }
 
-    // Remove worktree
+  // Remove worktree
+  try {
     await execFileAsync(
       "git",
       ["worktree", "remove", "--force", session.path],
@@ -297,42 +324,63 @@ export async function removeWorktree(session: WorktreeSession): Promise<void> {
         cwd: repoRoot,
       },
     );
-
-    // Delete original branch
+  } catch (error: unknown) {
+    console.warn(
+      `git worktree remove failed, falling back to fs.rmSync: ${
+        (error as Error).message
+      }`,
+    );
     try {
-      await execFileAsync("git", ["branch", "-D", session.branch], {
+      fs.rmSync(toExtendedLengthPath(session.path), {
+        recursive: true,
+        force: true,
+      });
+    } catch (rmError: unknown) {
+      console.error(
+        `Failed to remove worktree or branch: ${(rmError as Error).message}`,
+      );
+    }
+    // git removes worktree metadata before the working directory; prune any
+    // leftovers in case git failed before deleting them.
+    try {
+      await execFileAsync("git", ["worktree", "prune"], {
         cwd: repoRoot,
       });
     } catch {
-      // Ignore errors deleting original branch
+      // Ignore errors pruning stale metadata
     }
+  }
 
-    // Delete current branch if it's different and not a protected branch
+  // Delete original branch
+  try {
+    await execFileAsync("git", ["branch", "-D", session.branch], {
+      cwd: repoRoot,
+    });
+  } catch {
+    // Ignore errors deleting original branch
+  }
+
+  // Delete current branch if it's different and not a protected branch
+  if (
+    currentBranch &&
+    currentBranch !== session.branch &&
+    currentBranch !== "HEAD"
+  ) {
+    const defaultRemoteBranch = getDefaultRemoteBranch(repoRoot);
+    const defaultBranchName = defaultRemoteBranch.split("/").pop();
+
     if (
-      currentBranch &&
-      currentBranch !== session.branch &&
-      currentBranch !== "HEAD"
+      currentBranch !== defaultBranchName &&
+      currentBranch !== "main" &&
+      currentBranch !== "master"
     ) {
-      const defaultRemoteBranch = getDefaultRemoteBranch(repoRoot);
-      const defaultBranchName = defaultRemoteBranch.split("/").pop();
-
-      if (
-        currentBranch !== defaultBranchName &&
-        currentBranch !== "main" &&
-        currentBranch !== "master"
-      ) {
-        try {
-          await execFileAsync("git", ["branch", "-D", currentBranch], {
-            cwd: repoRoot,
-          });
-        } catch {
-          // Ignore errors deleting current branch
-        }
+      try {
+        await execFileAsync("git", ["branch", "-D", currentBranch], {
+          cwd: repoRoot,
+        });
+      } catch {
+        // Ignore errors deleting current branch
       }
     }
-  } catch (error: unknown) {
-    console.error(
-      `Failed to remove worktree or branch: ${(error as Error).message}`,
-    );
   }
 }

--- a/packages/code/tests/utils/worktree.test.ts
+++ b/packages/code/tests/utils/worktree.test.ts
@@ -54,6 +54,7 @@ vi.mock("node:child_process", async () => {
 vi.mock("node:fs", () => ({
   existsSync: vi.fn(),
   mkdirSync: vi.fn(),
+  rmSync: vi.fn(),
   promises: {
     readFile: vi.fn(),
     writeFile: vi.fn(),
@@ -377,20 +378,63 @@ describe("worktree utils", () => {
       expect(gitCallsWith(["branch", "-D", "main"])).toHaveLength(0);
     });
 
-    it("should log error if removal fails", async () => {
+    it("should fall back to fs.rmSync and still delete the branch when git removal fails", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      git.handler = (_cmd, args) => {
+        if (args[0] === "worktree" && args[1] === "remove") {
+          throw gitError("Filename too long", "");
+        }
+        return { stdout: "", stderr: "" };
+      };
+
+      await removeWorktree(session);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("falling back to fs.rmSync"),
+      );
+      const rmCalls = vi.mocked(fs.rmSync).mock.calls;
+      expect(rmCalls).toHaveLength(1);
+      expect(rmCalls[0][1]).toMatchObject({ recursive: true, force: true });
+      if (process.platform === "win32") {
+        // Extended-length path bypasses the Windows MAX_PATH limit
+        expect(String(rmCalls[0][0])).toMatch(/^\\\\\?\\/);
+      } else {
+        expect(rmCalls[0][0]).toBe("/repo/root/.wave/worktrees/my-feat");
+      }
+      // Branch deletion and stale-metadata pruning still run despite the failure
+      expect(gitCallsWith(["branch", "-D", "worktree-my-feat"])).toHaveLength(
+        1,
+      );
+      expect(gitCallsWith(["worktree", "prune"])).toHaveLength(1);
+      warnSpy.mockRestore();
+    });
+
+    it("should log error but still delete the branch when git and fs.rmSync both fail", async () => {
       const consoleSpy = vi
         .spyOn(console, "error")
         .mockImplementation(() => {});
-      git.handler = () => {
-        throw gitError("Removal failed", "");
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      git.handler = (_cmd, args) => {
+        if (args[0] === "worktree" && args[1] === "remove") {
+          throw gitError("Filename too long", "");
+        }
+        return { stdout: "", stderr: "" };
       };
+      vi.mocked(fs.rmSync).mockImplementation(() => {
+        throw new Error("rm failed");
+      });
 
       await removeWorktree(session);
 
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining("Failed to remove worktree or branch"),
       );
+      // Branch deletion still runs even when both removal attempts fail
+      expect(gitCallsWith(["branch", "-D", "worktree-my-feat"])).toHaveLength(
+        1,
+      );
       consoleSpy.mockRestore();
+      warnSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Problem

On Windows, deleting a worktree via Ctrl+C exit fails with:

```
Failed to remove worktree or branch: Command failed: git worktree remove --force C:\...\weak-short-cloud
error: failed to delete 'C:/.../weak-short-cloud': Filename too long
```

Git's recursive directory removal (used by `git worktree remove`) is MAX_PATH-limited on Windows. It deletes the worktree metadata first, then the working directory — so the failure leaves an orphan directory, and wave's code skipped branch deletion (threw / console.error'd) on the failure.

## Fix

Best-effort removal aligned with Claude Code's non-blocking semantics, applied to both removal implementations (`packages/agent-sdk/src/utils/worktreeUtils.ts` and `packages/code/src/utils/worktree.ts`):

- When `git worktree remove --force` fails, fall back to `fs.rmSync` with an extended-length path (`\\?\` prefix, Windows only) which bypasses MAX_PATH.
- Run `git worktree prune` afterwards to clean stale metadata.
- Log the failure but never block branch deletion / session exit (previously the branch was left undeleted).

## Tests

- `packages/agent-sdk`: worktreeUtils tests + real-git integration tests pass (41).
- `packages/code`: worktree tests pass (26).
- Prettier + tsc clean; lint-staged passed on commit.
