### PR TITLE
fix(code): remove CLI streaming throttle to eliminate first-word duplication

### DIFF
--- a/docs/specs/core/stream-content-updates.md
+++ b/docs/specs/core/stream-content-updates.md
@@ -6,9 +6,9 @@ order: 110
 
 # 功能规格说明：实时内容流式传输
 
-**创建日期**：2025-11-19  
+**创建日期**：2025-11-19
 
-## 用户场景与测试 *（必填）*
+## 用户场景与测试 _（必填）_
 
 ### 用户故事：实时助手消息流式传输（优先级：P1）
 
@@ -128,7 +128,7 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 6. **假设**子代理（subagent）运行中，**当**其消息变更时，**则** `SubagentManager` 通过 `instance.messageManager.getMessages()` 拉取最新列表维护 `instance.messages` 与 `usedTools`，并继续转发 `onSubagentMessagesChange`，不再依赖子代理的 `onMessagesChange`
 7. **假设**助手响应正在流式传输，**当**每个内容/推理 chunk 到达时，**则**增量回调与 stdio 增量通知都只携带 `chunk`（增量片段）+ `messageId` + `stage`，不再携带 `accumulated` 累积值；进程内消费者（CLI、print-cli）与跨进程宿主（agentBridge）统一消费纯 chunk，自行累积追加
 8. **假设**工具参数正在经 stdio 流式传输，**当** `stage="streaming"` 通知到达时，**则**只携带 `parametersChunk`（增量），不再携带累积 `parameters`；**当** `stage="end"` 通知到达时，**则**携带全量 `parameters` + `result` 作为一次性权威值
-9. **假设**宿主（VSCE/桌面/CLI）对增量通知做了节流（如 16ms/500ms 窗口），**当**窗口内累积了多个 chunk 时，**则**按到达顺序将窗口内所有 chunks 拼接为一个合并 delta 发送，而非 last-value-wins 丢弃中间值——丢弃中间 chunk 会造成内容永久缺失，只能由后续 `getMessages` 拉取自愈
+9. **假设**除 CLI 外的宿主（VSCE/桌面）对增量通知做了节流（如 16ms 窗口），**当**窗口内累积了多个 chunk 时，**则**按到达顺序将窗口内所有 chunks 拼接为一个合并 delta 发送，而非 last-value-wins 丢弃中间值——丢弃中间 chunk 会造成内容永久缺失，只能由后续 `getMessages` 拉取自愈；CLI 进程内消费端已移除节流（见「CLI 以原始频率渲染流式内容」用户故事），每个 delta 立即应用
 10. **假设**webview 正在追加流式 delta，**当**触发 `getMessages` 拉取全量列表时，**则**全量响应整体替换消息块为权威快照，随后到达的 delta 继续追加；管道 FIFO 保证拉取响应包含其之前发出的所有 chunk，不发生重复或错乱
 
 ---
@@ -150,6 +150,24 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 
 ---
 
+### 用户故事：CLI 以原始频率渲染流式内容（优先级：P1）
+
+作为 CLI 使用者，我希望助手流式输出时每个内容 delta 都以原始频率立即渲染，而不是被 500ms 窗口节流合并后再渲染，以便界面反馈与模型生成节奏一致，且彻底消除节流窗口引入的内容重复竞态。
+
+**为什么是这个优先级**：CLI 之前的 500ms window-concat 节流保留了一个残留竞态——节流器 trailing edge 冲刷 pending 窗口内已合并的 chunk 时，若期间发生了一次全量列表替换（`refreshMessages`，由 /clear、/compact、/rewind、Ctrl+O 折叠触发），pending 内旧 delta 会被追加到已含全部内容的新快照之上，造成内容重复。移除节流后每个 delta 同步立即应用，不存在 pending 窗口，竞态从机制上消失。渲染性能不受影响：Ink 内置 30fps（~34ms）输出节流兜底终端写入频率，`<Static>` append-only 使历史消息永不重绘，动态部分仅剩最后一条消息的 running blocks，每次 commit 的 React 重建成本对典型会话规模（≤30 条可见消息）为亚毫秒级。
+
+**独立测试**：构造带 reasoning 流式的会话，在流式期间触发一次全量刷新（/clear、/compact、/rewind 或折叠切换），验证最终消息内容与 SDK 权威内容逐字节一致、无重复片段；同时观察流式期间界面即时更新且无整屏闪烁。
+
+**验收场景**：
+
+1. **假设** CLI 正在消费流式 delta，**当**每个 `onAssistantContentUpdated`/`onAssistantReasoningUpdated` 回调到达时，**则**该 delta 被立即应用于消息状态，不再经过 500ms 窗口节流合并（`createStreamingWindowThrottle` 对内容/reasoning 通道移除）
+2. **假设**流式期间发生了全量列表替换（`refreshMessages`），**当**替换前后均有 delta 到达时，**则**最终消息内容与 SDK 权威内容一致，不出现任何重复片段（旧 pending delta 不会叠加到新快照上）
+3. **假设** CLI 以原始频率触发 React commit，**当**模型以高频（如 30ms/chunk）产出 delta 时，**则**终端输出写入仍受 Ink 内置 `maxFps: 30` 节流约束，不出现逐 chunk 整屏重绘或闪烁
+4. **假设**长会话中流式输出，**当**消息不断积累时，**则**界面依然平滑即时更新，不因移除节流而卡顿（与「长会话流式输出保持流畅」验收场景 1 一致）
+5. **假设**存在内容重复的回归测试，**当**运行现有双计数回归测试（content/reasoning double-count）时，**则**测试继续通过，且不依赖节流窗口语义
+
+---
+
 ### 边界情况
 
 - 当网络连接较差且流式块乱序到达或延迟时会发生什么？
@@ -167,8 +185,8 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 - **增量回调用途**：为第三方集成、扩展、CLI 与示例（如 `packages/code/src/print-cli.ts` 和 `packages/agent-sdk/examples`）提供实时流式数据；增量回调是消息状态同步的唯一推送通道
 - **SDK 回调负载**：`onAssistantContentUpdated`/`onAssistantReasoningUpdated` 只提供 `chunk`（增量）+ `messageId` + `stage`，不再携带 `accumulated` 累积值，进程内消费者（CLI、print-cli）自行累积追加；`onToolBlockUpdated` 在 `stage="streaming"` 时只提供 `parametersChunk`（增量），`start`/`running`/`end` 阶段携带权威 `parameters`（end 为最终值，一次性权威）。SDK 内部仍将 chunk 追加进内存 `toolBlock.parameters` 保持累积，只是累积值不再暴露到外部回调
 - **跨进程 wire 负载（纯 delta）**：agentBridge 原样透传增量回调负载——`assistantContentUpdated`/`assistantReasoningUpdated` 只携带 `{messageId, chunk, stage}`（SDK 回调本身已无累积字段，无需剥离）；`toolBlockUpdated` 在 `stage="streaming"` 时只携带 `parametersChunk`，`stage="end"` 时携带全量 `parameters` + `result` 作为权威值。消费端负责累积（追加），丢失的 delta 由 `getMessages` 拉取的全量快照自愈
-- **UI 状态流**：CLI 直接订阅增量回调就地更新消息（chunk 追加 + 500ms 窗口拼接节流）；插件/桌面经 stdio 增量通知（`userMessageAdded`、`assistantContentUpdated`、`toolBlockUpdated` 等，纯 delta 负载）驱动 webview 增量 reducer——文本/推理块追加 chunk、工具块追加 `parametersChunk`，end 时以权威值终结；需要完整列表的场景（初始化、compact、rewind、clear、bang）主动拉取，拉取响应整体替换为权威快照。进程内消费端把 SDK 消息对象推入自有状态时**必须克隆**（消息 + blocks 至少一层），不得持有 SDK 内部活引用——SDK 会就地更新共享块，与消费端累积追加叠加会重复计数（见"增量消费端以快照推入消息"用户故事）
-- **节流语义**：SDK 回调与 wire 通知均只携带纯 delta，节流器一律按到达顺序拼接窗口内所有 chunks 为一个合并 delta（window-concat），绝不能 last-value-wins 丢弃中间值。为配合该语义，SDK 必须在每次 running 事件中重复携带 `compactParams` 等稳定展示字段（见"工具块阶段更新"验收场景 4），保证丢弃中间事件不丢失这些字段
+- **UI 状态流**：CLI 直接订阅增量回调就地更新消息（chunk 追加，原始频率无节流——见「CLI 以原始频率渲染流式内容」用户故事；渲染频率由 Ink 内置 30fps 输出节流兜底）；插件/桌面经 stdio 增量通知（`userMessageAdded`、`assistantContentUpdated`、`toolBlockUpdated` 等，纯 delta 负载）驱动 webview 增量 reducer——文本/推理块追加 chunk、工具块追加 `parametersChunk`，end 时以权威值终结；需要完整列表的场景（初始化、compact、rewind、clear、bang）主动拉取，拉取响应整体替换为权威快照。进程内消费端把 SDK 消息对象推入自有状态时**必须克隆**（消息 + blocks 至少一层），不得持有 SDK 内部活引用——SDK 会就地更新共享块，与消费端累积追加叠加会重复计数（见"增量消费端以快照推入消息"用户故事）
+- **节流语义**：SDK 回调与 wire 通知均只携带纯 delta。CLI 进程内消费端不再节流（原始频率立即应用，见「CLI 以原始频率渲染流式内容」用户故事）；其余仍选择节流的宿主（如 VSCE/桌面 webview 通道），节流器一律按到达顺序拼接窗口内所有 chunks 为一个合并 delta（window-concat），绝不能 last-value-wins 丢弃中间值。为配合该语义，SDK 必须在每次 running 事件中重复携带 `compactParams` 等稳定展示字段（见"工具块阶段更新"验收场景 4），保证丢弃中间事件不丢失这些字段
 - **清晰分离**：增量回调是消息状态管理的正式对外通道；全量数据按需获取，避免随每次流式 chunk 序列化整个列表
 
 ## 澄清
@@ -239,11 +257,18 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 - 问：修复位置 → 答：消费端边界。CLI 在推入消息时必须克隆（`{ ...m, blocks: m.blocks.map(b => ({ ...b })) }`），不得持有 SDK 内部消息对象活引用；SDK 就地更新与回调顺序（先写全量、再回 delta）不变。覆盖所有推入点：`onAssistantMessageAdded`、`onUserMessageAdded`、拉取全量（`refreshMessages`、初始 `setMessages(agent.messages)`）
 - 问：为什么不在 SDK 侧改 → 答：SDK 就地更新是 `getMessages` 权威快照的基础，先写全量再回 delta 保证回调时刻 SDK 状态已一致；改为先回调再写会让拉取与回调交错时读到过期值。快照克隆成本只在消息创建时发生一次，与流式 delta 数量无关
 
-## 假设 *（必填）*
+### 2026-08-17 会议（CLI 移除 500ms 节流、原始频率渲染）
+
+- 问：为什么移除 CLI 的 500ms window-concat 节流 → 答：2026-08-12 修复（快照推入）解决了首词重复的活引用根因，但调研复现了另一残留竞态：节流器 trailing edge 冲刷 pending 窗口内已合并 chunk 时，若期间发生全量列表替换（`refreshMessages`，/clear、/compact、/rewind、Ctrl+O 折叠触发），pending 内旧 delta 会追加到已含全部内容的权威快照之上，造成内容重复（如 `Let me think about me think about this...`）。移除节流后每个 delta 同步立即应用、无 pending 窗口，竞态从机制上消除——用忠实复刻 throttle+reducer 逻辑的模拟脚本验证：500ms 节流 + 流中刷新稳定复现重复，wait=0（无节流）同场景永不重复
+- 问：渲染性能是否受影响 → 答：不会。Ink 7.1.1 内置输出节流（`maxFps: 30` → ~34ms，leading+trailing）约束终端写入频率，与消费端节流无关；`<Static>` append-only 使历史消息永不重绘（`fullStaticOutput += staticOutput`）；`renderInteractiveFrame` 仅在 `output !== lastOutput` 时写入，log-update 再做增量 diff。React commit 频率等于 delta 到达频率，每次 commit 对全量可见消息做 `flatMap` + 元素重建，典型会话规模（≤30 条可见消息）为亚毫秒级
+- 问：受影响范围 → 答：仅 CLI 进程内消费端（`packages/code/src/contexts/useChat.tsx`）——移除内容/reasoning 通道的 `createStreamingWindowThrottle`（500ms）与 tool 通道的 `createToolStreamingThrottle`（同一 pending 窗口 + 全量刷新竞态结构、同一逐 token 高频来源），每个 delta 立即经 reducer 应用。VSCE/桌面跨进程通道保留 window-concat 节流语义不变（wire 通知频率较低，非首词重复来源）
+- 问：原「每秒 2-3 次内容更新」假设为何移除 → 答：该假设是 500ms 节流的设计依据；移除节流后更新频率由模型产出速率决定，终端写入频率由 Ink 30fps 兜底，无需人为限频
+
+## 假设 _（必填）_
 
 - 底层 AI 服务支持流式响应（增量内容传递）
 - 网络连接对大多数用户通常稳定
-- 终端/CLI 界面可以以 OpenAI 的流式速率处理实时文本更新（目标：每秒 2-3 次内容更新）
+- 终端/CLI 界面可以以 OpenAI 的流式速率处理实时文本更新（CLI 以原始 delta 频率渲染，终端写入频率由 Ink 内置 30fps 节流约束）
 - 用户通常使用支持实时文本渲染的标准终端模拟器
 - 在正常网络条件下内容流按时间顺序到达
 - 消息变更通过增量回调对外发布，完整列表按需拉取（`agent.messages` / `getMessages` 请求）；每次流式 chunk 不触发全量列表推送

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -5,7 +5,6 @@ import React, {
   useRef,
   useEffect,
   useState,
-  useMemo,
 } from "react";
 import { useInput, useStdout } from "ink";
 import { useAppConfig } from "./useAppConfig.js";
@@ -184,171 +183,6 @@ const snapshotMessage = (message: Message): Message => ({
   blocks: message.blocks.map((block) => ({ ...block })),
 });
 
-/**
- * Window-concat throttle for pure-delta streaming updates: chunks arriving
- * within the cooldown window are merged so no delta is lost (a dropped delta
- * would permanently lose content, unlike the accumulated-payload throttle it
- * replaces). Leading edge fires immediately; the trailing edge carries only
- * chunks that arrived within the window. `end` flushes any pending deltas
- * first, then forwards the end signal right away.
- */
-function createStreamingWindowThrottle(
-  fn: (params: StreamingUpdateParams) => void,
-  wait: number,
-): {
-  (params: StreamingUpdateParams): void;
-  cancel: () => void;
-  flush: () => void;
-} {
-  let timer: NodeJS.Timeout | null = null;
-  let pending: { messageId: string; chunk: string } | null = null;
-
-  const fire = (stage: "streaming" | "end") => {
-    if (pending) {
-      fn({ ...pending, stage });
-      pending = null;
-    }
-  };
-
-  const throttled = (params: StreamingUpdateParams) => {
-    if (params.stage === "end") {
-      // Flush any deltas still pending inside the cooldown window first
-      if (timer) {
-        clearTimeout(timer);
-        timer = null;
-      }
-      fire("streaming");
-      fn(params);
-      return;
-    }
-    if (pending) {
-      pending.chunk += params.chunk;
-    } else {
-      pending = { messageId: params.messageId, chunk: params.chunk };
-    }
-    if (!timer) {
-      // Leading edge: fire the current delta immediately, then reset pending so
-      // the trailing edge only carries chunks arriving within this window
-      fire("streaming");
-      timer = setTimeout(() => {
-        timer = null;
-        fire("streaming");
-      }, wait);
-    }
-  };
-
-  throttled.cancel = () => {
-    if (timer) {
-      clearTimeout(timer);
-      timer = null;
-    }
-    pending = null;
-  };
-
-  throttled.flush = () => {
-    if (timer) {
-      clearTimeout(timer);
-      timer = null;
-    }
-    fire("streaming");
-  };
-
-  return throttled;
-}
-
-/**
- * Per-tool window-concat throttle for pure-delta tool parameter streaming:
- * `parametersChunk` deltas are accumulated independently per tool block id
- * within the cooldown window, so interleaved multi-tool streams lose no delta
- * (a plain throttle's single last-args slot would drop every earlier tool's
- * deltas, leaving the first tool without streaming parameters). `start` /
- * `running` apply immediately (one-shot snapshots); `end` flushes pending
- * streaming deltas first, then applies the authoritative parameters/result.
- */
-export function createToolStreamingThrottle(
-  fn: (params: ToolBlockUpdateCallbackParams) => void,
-  wait: number,
-): {
-  (params: ToolBlockUpdateCallbackParams): void;
-  cancel: () => void;
-  flush: () => void;
-} {
-  let timer: NodeJS.Timeout | null = null;
-  let pending: { messageId: string; chunks: Map<string, string> } | null = null;
-
-  const fire = () => {
-    if (pending && pending.chunks.size > 0) {
-      const { messageId, chunks } = pending;
-      pending = null;
-      for (const [id, chunk] of chunks) {
-        fn({ messageId, id, parametersChunk: chunk, stage: "streaming" });
-      }
-    }
-  };
-
-  const throttled = (params: ToolBlockUpdateCallbackParams) => {
-    if (params.stage === "end") {
-      // Flush any deltas still pending inside the cooldown window first
-      if (timer) {
-        clearTimeout(timer);
-        timer = null;
-      }
-      fire();
-      fn(params);
-      return;
-    }
-    if (params.stage === "streaming") {
-      if (!pending) {
-        pending = { messageId: params.messageId, chunks: new Map() };
-      }
-      const prev = pending.chunks.get(params.id) || "";
-      pending.chunks.set(params.id, prev + (params.parametersChunk || ""));
-      if (!timer) {
-        timer = setTimeout(() => {
-          timer = null;
-          fire();
-        }, wait);
-      }
-      return;
-    }
-    // start / running — one-shot snapshots applied immediately. Drop this
-    // tool's buffered streaming deltas first: start/running carry the
-    // authoritative parameters, and a pending timer would otherwise fire late
-    // with a stale `streaming` event, regressing this tool block's stage back
-    // to streaming (yellow dot -> gray) mid-execution. Other tools' in-flight
-    // chunks are kept so interleaved multi-tool streaming still accumulates.
-    if (pending) {
-      pending.chunks.delete(params.id);
-      if (pending.chunks.size === 0) {
-        pending = null;
-        if (timer) {
-          clearTimeout(timer);
-          timer = null;
-        }
-      }
-    }
-    fn(params);
-  };
-
-  throttled.cancel = () => {
-    if (timer) {
-      clearTimeout(timer);
-      timer = null;
-    }
-    pending = null;
-  };
-
-  throttled.flush = () => {
-    if (timer) {
-      clearTimeout(timer);
-      timer = null;
-    }
-    fire();
-  };
-
-  return throttled;
-}
-
 export const ChatProvider: React.FC<ChatProviderProps> = ({
   children,
   bypassPermissions,
@@ -379,152 +213,132 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   const [latestTotalTokens, setLatestTotalTokens] = useState(0);
   const [maxInputTokens, setMaxInputTokens] = useState(200000);
 
-  // Throttled incremental streaming updaters — 500ms window-concat, the same
-  // interval as the pre-incremental throttledSetMessages. Chunks are pure
-  // deltas: within-window chunks are merged so none is dropped, and
-  // `stage === "end"` flushes pending deltas + applies the end signal
-  // immediately so completion results are never delayed.
-  const throttledContentUpdate = useMemo(
-    () =>
-      createStreamingWindowThrottle((params) => {
-        const { messageId, chunk, stage } = params;
-        setMessages((prev) =>
-          prev.map((m) => {
-            if (m.id !== messageId) return m;
-            const textBlockIndex = m.blocks.findIndex((b) => b.type === "text");
-            if (textBlockIndex === -1) {
-              return {
-                ...m,
-                blocks: [...m.blocks, { type: "text", content: chunk, stage }],
-              };
-            }
+  // Direct incremental streaming updaters — every delta is applied to the
+  // message state immediately, without a cooldown window. The former 500ms
+  // window-concat throttle is gone: its trailing-edge flush could interleave
+  // with a full-list `refreshMessages` snapshot replacement mid-stream and
+  // re-append old deltas on top of the authoritative content (first-word
+  // duplication). Terminal write frequency is bounded downstream by Ink's
+  // built-in ~30fps output throttle. See
+  // docs/specs/core/stream-content-updates.md.
+  const applyContentUpdate = useCallback((params: StreamingUpdateParams) => {
+    const { messageId, chunk, stage } = params;
+    setMessages((prev) =>
+      prev.map((m) => {
+        if (m.id !== messageId) return m;
+        const textBlockIndex = m.blocks.findIndex((b) => b.type === "text");
+        if (textBlockIndex === -1) {
+          return {
+            ...m,
+            blocks: [...m.blocks, { type: "text", content: chunk, stage }],
+          };
+        }
+        return {
+          ...m,
+          blocks: m.blocks.map((b, idx) =>
+            idx === textBlockIndex && b.type === "text"
+              ? {
+                  ...b,
+                  content: (b.content || "") + chunk,
+                  stage,
+                }
+              : b,
+          ),
+        };
+      }),
+    );
+  }, []);
+
+  const applyReasoningUpdate = useCallback((params: StreamingUpdateParams) => {
+    const { messageId, chunk, stage } = params;
+    setMessages((prev) =>
+      prev.map((m) => {
+        if (m.id !== messageId) return m;
+        const reasoningBlockIndex = m.blocks.findIndex(
+          (b) => b.type === "reasoning",
+        );
+        if (reasoningBlockIndex === -1) {
+          return {
+            ...m,
+            blocks: [...m.blocks, { type: "reasoning", content: chunk, stage }],
+          };
+        }
+        return {
+          ...m,
+          blocks: m.blocks.map((b, idx) =>
+            idx === reasoningBlockIndex && b.type === "reasoning"
+              ? {
+                  ...b,
+                  content: (b.content || "") + chunk,
+                  stage,
+                }
+              : b,
+          ),
+        };
+      }),
+    );
+  }, []);
+
+  const applyToolBlockUpdate = useCallback(
+    (params: ToolBlockUpdateCallbackParams) => {
+      const {
+        messageId,
+        id: toolBlockId,
+        parametersChunk,
+        ...updates
+      } = params;
+      setMessages((prev) =>
+        prev.map((m) => {
+          if (m.id !== messageId) return m;
+          const toolBlockIndex = m.blocks.findIndex(
+            (b) => b.type === "tool" && b.id === toolBlockId,
+          );
+          if (toolBlockIndex === -1) {
             return {
               ...m,
-              blocks: m.blocks.map((b, idx) =>
-                idx === textBlockIndex && b.type === "text"
-                  ? {
-                      ...b,
-                      content: (b.content || "") + chunk,
-                      stage,
-                    }
-                  : b,
-              ),
+              blocks: [
+                ...m.blocks,
+                {
+                  type: "tool",
+                  id: toolBlockId,
+                  name: updates.name || "",
+                  stage: updates.stage || "start",
+                  parameters:
+                    (updates.parameters || "") + (parametersChunk || ""),
+                  result: updates.result || "",
+                  ...updates,
+                },
+              ],
             };
-          }),
-        );
-      }, 500),
-    [],
-  );
-
-  const throttledReasoningUpdate = useMemo(
-    () =>
-      createStreamingWindowThrottle((params) => {
-        const { messageId, chunk, stage } = params;
-        setMessages((prev) =>
-          prev.map((m) => {
-            if (m.id !== messageId) return m;
-            const reasoningBlockIndex = m.blocks.findIndex(
-              (b) => b.type === "reasoning",
-            );
-            if (reasoningBlockIndex === -1) {
-              return {
-                ...m,
-                blocks: [
-                  ...m.blocks,
-                  { type: "reasoning", content: chunk, stage },
-                ],
-              };
-            }
-            return {
-              ...m,
-              blocks: m.blocks.map((b, idx) =>
-                idx === reasoningBlockIndex && b.type === "reasoning"
-                  ? {
-                      ...b,
-                      content: (b.content || "") + chunk,
-                      stage,
-                    }
-                  : b,
-              ),
-            };
-          }),
-        );
-      }, 500),
-    [],
-  );
-
-  const throttledToolBlockUpdate = useMemo(
-    () =>
-      createToolStreamingThrottle((params) => {
-        const {
-          messageId,
-          id: toolBlockId,
-          parametersChunk,
-          ...updates
-        } = params;
-        setMessages((prev) =>
-          prev.map((m) => {
-            if (m.id !== messageId) return m;
-            const toolBlockIndex = m.blocks.findIndex(
-              (b) => b.type === "tool" && b.id === toolBlockId,
-            );
-            if (toolBlockIndex === -1) {
-              return {
-                ...m,
-                blocks: [
-                  ...m.blocks,
-                  {
-                    type: "tool",
-                    id: toolBlockId,
-                    name: updates.name || "",
-                    stage: updates.stage || "start",
-                    parameters:
-                      (updates.parameters || "") + (parametersChunk || ""),
-                    result: updates.result || "",
+          }
+          return {
+            ...m,
+            blocks: m.blocks.map((b, idx) =>
+              idx === toolBlockIndex && b.type === "tool"
+                ? {
+                    ...b,
                     ...updates,
-                  },
-                ],
-              };
-            }
-            return {
-              ...m,
-              blocks: m.blocks.map((b, idx) =>
-                idx === toolBlockIndex && b.type === "tool"
-                  ? {
-                      ...b,
-                      ...updates,
-                      // Streaming carries only the delta; append it to the
-                      // accumulated parameters. start/running/end carry the
-                      // authoritative value and replace wholesale.
-                      parameters: parametersChunk
-                        ? (b.parameters || "") + parametersChunk
-                        : updates.parameters !== undefined
-                          ? updates.parameters
-                          : b.parameters,
-                    }
-                  : b,
-              ),
-            };
-          }),
-        );
-      }, 500),
+                    // Streaming carries only the delta; append it to the
+                    // accumulated parameters. start/running/end carry the
+                    // authoritative value and replace wholesale.
+                    parameters: parametersChunk
+                      ? (b.parameters || "") + parametersChunk
+                      : updates.parameters !== undefined
+                        ? updates.parameters
+                        : b.parameters,
+                  }
+                : b,
+            ),
+          };
+        }),
+      );
+    },
     [],
   );
 
   useEffect(() => {
     isExpandedRef.current = isExpanded;
-    if (isExpanded) {
-      // Cancel pending throttled updates so the frozen expanded view isn't overwritten
-      throttledContentUpdate.cancel();
-      throttledReasoningUpdate.cancel();
-      throttledToolBlockUpdate.cancel();
-    }
-  }, [
-    isExpanded,
-    throttledContentUpdate,
-    throttledReasoningUpdate,
-    throttledToolBlockUpdate,
-  ]);
+  }, [isExpanded]);
 
   const [isLoading, setIsLoading] = useState(false);
   const [sessionId, setSessionId] = useState("");
@@ -689,16 +503,15 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         },
         onAssistantContentUpdated: (params) => {
           if (isExpandedRef.current) return;
-          throttledContentUpdate(params);
+          applyContentUpdate(params);
         },
         onAssistantReasoningUpdated: (params) => {
           if (isExpandedRef.current) return;
-          throttledReasoningUpdate(params);
+          applyReasoningUpdate(params);
         },
         onToolBlockUpdated: (params) => {
           if (isExpandedRef.current) return;
-          throttledToolBlockUpdate(params);
-          if (params.stage === "end") throttledToolBlockUpdate.flush();
+          applyToolBlockUpdate(params);
         },
         onErrorBlockAdded: (error: string) => {
           if (isExpandedRef.current) return;
@@ -955,9 +768,9 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
       originalCwd,
       model,
       initialPermissionMode,
-      throttledContentUpdate,
-      throttledReasoningUpdate,
-      throttledToolBlockUpdate,
+      applyContentUpdate,
+      applyReasoningUpdate,
+      applyToolBlockUpdate,
       mcpServers,
     ],
   );
@@ -996,9 +809,6 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   // Cleanup on unmount
   useEffect(() => {
     return () => {
-      throttledContentUpdate.cancel();
-      throttledReasoningUpdate.cancel();
-      throttledToolBlockUpdate.cancel();
       if (agentRef.current) {
         try {
           // Display usage summary before cleanup
@@ -1012,11 +822,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         agentRef.current.destroy();
       }
     };
-  }, [
-    throttledContentUpdate,
-    throttledReasoningUpdate,
-    throttledToolBlockUpdate,
-  ]);
+  }, []);
 
   // Trigger WorktreeRemove hook BEFORE agent destruction
   const triggerWorktreeRemoveHook = useCallback(

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -5,7 +5,6 @@ import {
   ChatProvider,
   useChat,
   ChatContextType,
-  createToolStreamingThrottle,
 } from "../../src/contexts/useChat.js";
 import { Agent, BackgroundShell, Task } from "wave-agent-sdk";
 import { AppProvider } from "../../src/contexts/useAppConfig.js";
@@ -1626,88 +1625,7 @@ describe("ChatProvider", () => {
     });
   });
 
-  describe("createToolStreamingThrottle", () => {
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it("drops a tool's buffered streaming deltas when running arrives so no stale flush regresses the stage", () => {
-      vi.useFakeTimers();
-      const fn = vi.fn();
-      const throttled = createToolStreamingThrottle(fn, 500);
-
-      throttled({
-        messageId: "m",
-        id: "bash",
-        name: "bash",
-        stage: "start",
-        parameters: "",
-      });
-      throttled({
-        messageId: "m",
-        id: "bash",
-        stage: "streaming",
-        parametersChunk: "{",
-      });
-      throttled({
-        messageId: "m",
-        id: "bash",
-        name: "bash",
-        stage: "running",
-        parameters: '{"cmd":"ls"}',
-      });
-
-      // The throttle window elapses — the stale streaming chunk must NOT fire
-      // late and regress the block back to "streaming"
-      vi.advanceTimersByTime(600);
-      expect(fn).toHaveBeenCalledTimes(2);
-      expect(fn.mock.calls.map((c) => c[0].stage)).toEqual([
-        "start",
-        "running",
-      ]);
-      expect(fn).not.toHaveBeenCalledWith(
-        expect.objectContaining({ stage: "streaming", parametersChunk: "{" }),
-      );
-    });
-
-    it("keeps other tools' in-flight streaming deltas when one tool goes running", () => {
-      vi.useFakeTimers();
-      const fn = vi.fn();
-      const throttled = createToolStreamingThrottle(fn, 500);
-
-      throttled({
-        messageId: "m",
-        id: "tool-a",
-        stage: "streaming",
-        parametersChunk: '{"fi',
-      });
-      throttled({
-        messageId: "m",
-        id: "tool-b",
-        stage: "streaming",
-        parametersChunk: '{"file',
-      });
-      throttled({
-        messageId: "m",
-        id: "tool-a",
-        name: "bash",
-        stage: "running",
-        parameters: '{"file": "a.txt"}',
-      });
-
-      // tool-a's stale chunk is dropped, but tool-b's still flushes at the
-      // window boundary — interleaved multi-tool streaming keeps working
-      vi.advanceTimersByTime(500);
-      const streamingCalls = fn.mock.calls
-        .map((c) => c[0] as { stage: string; id: string })
-        .filter((c) => c.stage === "streaming");
-      expect(streamingCalls).toEqual([
-        expect.objectContaining({ id: "tool-b", parametersChunk: '{"file' }),
-      ]);
-    });
-  });
-
-  it("throttles reasoning streaming updates and flushes on end", async () => {
+  it("applies reasoning streaming updates immediately without throttling", async () => {
     let lastValue: ChatContextType | undefined;
     const onHookValue = (val: ChatContextType) => {
       lastValue = val;
@@ -1736,20 +1654,13 @@ describe("ChatProvider", () => {
       expect(lastValue?.messages).toHaveLength(1);
     });
 
-    // Leading edge appends a new reasoning block immediately
+    // Every delta applies immediately — no 500ms cooldown window coalesces
+    // chunks (the former window-concat throttle is removed)
     callbacks.onAssistantReasoningUpdated!({
       messageId: "msg-reason",
       chunk: "Th",
       stage: "streaming",
     });
-    await vi.waitFor(() => {
-      const reasoning = lastValue?.messages[0].blocks.find(
-        (b) => b.type === "reasoning",
-      ) as { content: string } | undefined;
-      expect(reasoning?.content).toBe("Th");
-    });
-
-    // Subsequent chunks within the 500ms window are coalesced (trailing)
     callbacks.onAssistantReasoningUpdated!({
       messageId: "msg-reason",
       chunk: "ink",
@@ -1760,12 +1671,14 @@ describe("ChatProvider", () => {
       chunk: "ing",
       stage: "streaming",
     });
-    const beforeFlush = lastValue?.messages[0].blocks.find(
-      (b) => b.type === "reasoning",
-    ) as { content: string } | undefined;
-    expect(beforeFlush?.content).toBe("Th");
+    await vi.waitFor(() => {
+      const reasoning = lastValue?.messages[0].blocks.find(
+        (b) => b.type === "reasoning",
+      ) as { content: string } | undefined;
+      expect(reasoning?.content).toBe("Thinking");
+    });
 
-    // stage === "end" flushes pending deltas and applies the end signal
+    // stage === "end" appends its delta and applies the end signal
     callbacks.onAssistantReasoningUpdated!({
       messageId: "msg-reason",
       chunk: "…",
@@ -1904,6 +1817,98 @@ describe("ChatProvider", () => {
 
     // State must not share the SDK's message object (live reference)
     expect(lastValue?.messages[0]).not.toBe(mockAgent.messages[0]);
+  });
+
+  it("does not duplicate content when a full-list refresh interleaves mid-stream", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
+    const callbacks = agentCreateArgs.callbacks!;
+
+    const assistantMsg = {
+      id: "msg-refresh",
+      role: "assistant" as const,
+      blocks: [],
+      timestamp: new Date().toISOString(),
+    };
+    Object.assign(mockAgent, { messages: [assistantMsg] });
+    callbacks.onAssistantMessageAdded!("msg-refresh");
+    await vi.waitFor(() => {
+      expect(lastValue?.messages).toHaveLength(1);
+    });
+
+    // Regression (docs/specs/core/stream-content-updates.md, 2026-08-17): the
+    // removed 500ms window-concat throttle could carry a pending delta across
+    // a full-list refresh — the trailing-edge flush then re-appended the
+    // pre-refresh chunk on top of the authoritative snapshot ("Let me me").
+    // With the throttle gone every delta applies immediately, so no pending
+    // window exists for this interleaving to double-count through.
+    const sdkMsg = mockAgent.messages[0] as unknown as {
+      blocks: Array<{ type: string; content: string; stage: string }>;
+    };
+    sdkMsg.blocks.push({
+      type: "reasoning",
+      content: "Let",
+      stage: "streaming",
+    });
+    callbacks.onAssistantReasoningUpdated!({
+      messageId: "msg-refresh",
+      chunk: "Let",
+      stage: "streaming",
+    });
+    await vi.waitFor(() => {
+      const reasoning = lastValue?.messages[0].blocks.find(
+        (b) => b.type === "reasoning",
+      ) as { content: string } | undefined;
+      expect(reasoning?.content).toBe("Let");
+    });
+
+    // SDK accumulates to "Let me" and fires the delta — under the old
+    // throttle this chunk would sit in the pending cooldown window
+    sdkMsg.blocks[0].content = "Let me";
+    callbacks.onAssistantReasoningUpdated!({
+      messageId: "msg-refresh",
+      chunk: " me",
+      stage: "streaming",
+    });
+    await vi.waitFor(() => {
+      const reasoning = lastValue?.messages[0].blocks.find(
+        (b) => b.type === "reasoning",
+      ) as { content: string } | undefined;
+      expect(reasoning?.content).toBe("Let me");
+    });
+
+    // A structural action (e.g. /clear) replaces CLI state with a full
+    // snapshot of the SDK's authoritative messages mid-stream
+    Object.assign(mockAgent, {
+      clearMessages: vi.fn().mockResolvedValue(undefined),
+    });
+    await lastValue?.clearMessages();
+    await vi.waitFor(() => {
+      const reasoning = lastValue?.messages[0].blocks.find(
+        (b) => b.type === "reasoning",
+      ) as { content: string } | undefined;
+      expect(reasoning?.content).toBe("Let me");
+    });
+
+    // Let any leftover cooldown timer (old code) fire — the content must stay
+    // byte-identical to the SDK's authoritative content, never "Let me me"
+    vi.advanceTimersByTime(1000);
+    await vi.waitFor(() => {
+      const reasoning = lastValue?.messages[0].blocks.find(
+        (b) => b.type === "reasoning",
+      ) as { content: string } | undefined;
+      expect(reasoning?.content).toBe("Let me");
+    });
   });
 
   it("handles bang message callbacks", async () => {


### PR DESCRIPTION
## 背景
CLI 流式输出(reasoning/text/tool 参数)在 500ms window-concat 节流器下仍偶发首词重复(`LetLet me think...`)。根因:节流器的 pending 窗口 + `refreshMessages` 全量快照替换交错——trailing flush 把 refresh 前的旧 delta 追加到权威快照之上。

## 改动
- 移除 `createStreamingWindowThrottle`(content/reasoning 通道)与 `createToolStreamingThrottle`(tool 通道),每个 delta 立即经 reducer 应用
- 终端写入频率由 Ink 内置 ~30fps 输出节流兜底(已调研确认)
- spec 更新:`docs/specs/core/stream-content-updates.md` 新增用户故事「CLI 以原始频率渲染流式内容」+ 2026-08-17 会议记录

## 测试
- reasoning 流式改为立即应用语义
- 新增 refresh 交错无重复回归测试
- 既有双计数回归测试保持通过
- 55 tests passed, type-check 通过