### PR TITLE
fix(session): persist real workdir, createdAt and gitBranch in session metadata header

### DIFF
--- a/docs/specs/ui/session-management.md
+++ b/docs/specs/ui/session-management.md
@@ -148,6 +148,24 @@ order: 10
 
 ---
 
+### 用户故事：会话元数据头：真实创建时间与 git 分支（优先级：P1）
+
+作为 `wave -r` 用户，我希望会话文件的 metadata header 持久化真实创建时间（`createdAt`）与创建时的 git 分支（`gitBranch`），以便列表能使用真实创建时间，并在多 worktree 场景区分同一仓库不同分支的会话。
+
+**为什么是这个优先级**：`SessionMetadata.createdAt` 目前是列表扫描时即时生成的 `new Date()`（恒等于"当前时间"，完全失真）；多 worktree 场景的会话无法显示所属分支，只能靠目录名猜测。
+
+**独立测试**：创建会话后检查 JSONL 首行为 metadata header 且含 `workdir`、`createdAt`、`gitBranch` 字段；列表返回的 `createdAt` 与 header 一致；非 git 目录创建会话时 header 不含 `gitBranch`。
+
+**验收场景**：
+
+1. **假设**创建新会话，**当** session 文件写入时，**则**首行为 metadata header，含 `workdir` 与 `createdAt`（ISO 8601，会话创建时刻）；目录为 git 仓库时含 `gitBranch`（`git branch --show-current` 结果），非 git 目录或执行失败时省略 `gitBranch`。
+2. **假设**会话文件带 metadata header，**当**会话列表（当前目录 / 全项目 / worktree 模式）返回 `SessionMetadata` 时，**则** `createdAt` 取 header 中的真实创建时间，而非每次扫描生成当前时间。
+3. **假设**会话文件带 `gitBranch`，**当** `wave -r` 选择器渲染会话行时，**则**行尾显示该分支标签（如 `[main]`）；无分支信息时不显示。
+4. **假设**旧版会话文件（无 header 或 header 缺 `createdAt`），**当**列表返回时，**则** `createdAt` 回退为列表生成时的当前时间（legacy 文件无创建时间记录，行为不劣化）。
+5. **假设**git 命令执行失败或超时（非 git 目录、git 不可用、目录被删除），**当**创建会话时，**则** header 省略 `gitBranch`，创建流程不中断、不报错。
+
+---
+
 ### 边界情况
 
 - **权限问题**：如果无法创建或写入会话目录，系统应优雅地失败并给出清晰的错误提示。
@@ -162,3 +180,6 @@ order: 10
 - **长路径解码兜底**：项目目录名被哈希截断时，全项目模式展示编码名兜底；恢复仍按目录内文件定位，不受展示影响。
 - **剪贴板不可用**：跨项目提示的 `cd` 命令复制失败时仍显示命令文本，用户可手动复制。
 - **worktree 目录已删除**：选中的会话属于已删除的 worktree 时按"其他项目"处理，给出 `cd` 命令提示而非报错。
+- **metadata header 向后兼容**：`createSession` 不传 metadata 时仍写空文件（旧调用方不变）；读取侧缺 header 的 legacy 文件走 decodeSync/当前时间回退。
+- **metadata header 只读**：header 是 append-only 文件的首行，创建后不重写；`gitBranch` 为创建时刻快照，不随后续分支切换更新。
+- **gitBranch 为 per-session 数据**：同一 workdir 不同时间创建的会话可能在不同分支，`gitBranch` 按会话文件逐一读取，不做目录级缓存。

--- a/packages/agent-sdk/src/services/jsonlHandler.ts
+++ b/packages/agent-sdk/src/services/jsonlHandler.ts
@@ -19,6 +19,21 @@ export interface JsonlWriteOptions {
 }
 
 /**
+ * Creation-time metadata persisted in the session file's header line
+ * (`{"type":"metadata",...}`). The header is append-only — written once on
+ * session creation and never rewritten — so only fields that are fixed at
+ * creation time belong here.
+ */
+export interface SessionMetadataHeader {
+  /** Real working directory (the encoded project dir name is lossy for paths containing "-"). */
+  workdir?: string;
+  /** ISO 8601 creation timestamp. */
+  createdAt?: string;
+  /** Git branch at creation time (`git branch --show-current`), when the directory is a git repo. */
+  gitBranch?: string;
+}
+
+/**
  * JSONL handler class for message persistence operations
  */
 export class JsonlHandler {
@@ -33,21 +48,28 @@ export class JsonlHandler {
   /**
    * Create a new session file.
    *
-   * When `workdir` is provided, the first line is a metadata header recording
-   * the real working directory: `{"type":"metadata","workdir":"..."}`. The
+   * When `metadata` is provided, the first line is a metadata header
+   * recording creation-time facts about the session:
+   * `{"type":"metadata","workdir":...,"createdAt":...,"gitBranch":...}`. The
    * encoded project dir name is lossy for paths containing "-", so persisting
-   * the real path lets session listing show it without decoding. The header
-   * carries no `timestamp`, so message readers filter it out naturally.
+   * the real path lets session listing show it without decoding; `createdAt`
+   * and `gitBranch` similarly avoid lossy/fabricated reconstruction later.
+   * The header carries no `timestamp`, so message readers filter it out
+   * naturally.
    *
-   * Legacy callers that omit `workdir` still get an empty file.
+   * Legacy callers that omit `metadata` still get an empty file.
    */
-  async createSession(filePath: string, workdir?: string): Promise<void> {
+  async createSession(
+    filePath: string,
+    metadata?: SessionMetadataHeader,
+  ): Promise<void> {
     // Ensure directory exists
     await this.ensureDirectory(dirname(filePath));
 
-    const content = workdir
-      ? `${JSON.stringify({ type: "metadata", workdir })}\n`
-      : "";
+    const content =
+      metadata && Object.keys(metadata).length > 0
+        ? `${JSON.stringify({ type: "metadata", ...metadata })}\n`
+        : "";
     await writeFile(filePath, content, "utf8");
   }
 
@@ -194,26 +216,29 @@ export class JsonlHandler {
   }
 
   /**
-   * Read the real workdir from the session file's metadata header line.
+   * Read the creation-time metadata from the session file's header line.
    *
-   * Newer session files start with a `{"type":"metadata","workdir":...}` line
-   * (see `createSession`). Legacy files have no header.
+   * Newer session files start with a `{"type":"metadata",...}` line (see
+   * `createSession`). Legacy files have no header.
    *
    * @param filePath - Path to the session JSONL file
-   * @returns The persisted workdir, or null when the file has no header
+   * @returns The persisted metadata, or null when the file has no header
    */
-  async readWorkdirMetadata(filePath: string): Promise<string | null> {
+  async readMetadata(filePath: string): Promise<SessionMetadataHeader | null> {
     try {
       const lines = await readFirstNLines(filePath, 1);
       if (lines.length === 0) {
         return null;
       }
-      const header = JSON.parse(lines[0]) as {
-        type?: string;
-        workdir?: string;
-      };
-      if (header.type === "metadata" && typeof header.workdir === "string") {
-        return header.workdir;
+      const header = JSON.parse(lines[0]) as
+        | ({ type?: string } & SessionMetadataHeader)
+        | null;
+      if (header?.type === "metadata") {
+        return {
+          workdir: header.workdir,
+          createdAt: header.createdAt,
+          gitBranch: header.gitBranch,
+        };
       }
     } catch {
       // Unreadable or invalid first line — treat as a legacy file

--- a/packages/agent-sdk/src/services/jsonlHandler.ts
+++ b/packages/agent-sdk/src/services/jsonlHandler.ts
@@ -5,7 +5,7 @@
 
 import { appendFile, readFile, writeFile, stat, mkdir } from "fs/promises";
 import { dirname } from "path";
-import { getLastLine } from "../utils/fileUtils.js";
+import { getLastLine, readFirstNLines } from "../utils/fileUtils.js";
 
 import type { Message } from "../types/index.js";
 import type { SessionFilename } from "../types/session.js";
@@ -31,14 +31,24 @@ export class JsonlHandler {
   }
 
   /**
-   * Create a new session file (simplified - no metadata header)
+   * Create a new session file.
+   *
+   * When `workdir` is provided, the first line is a metadata header recording
+   * the real working directory: `{"type":"metadata","workdir":"..."}`. The
+   * encoded project dir name is lossy for paths containing "-", so persisting
+   * the real path lets session listing show it without decoding. The header
+   * carries no `timestamp`, so message readers filter it out naturally.
+   *
+   * Legacy callers that omit `workdir` still get an empty file.
    */
-  async createSession(filePath: string): Promise<void> {
+  async createSession(filePath: string, workdir?: string): Promise<void> {
     // Ensure directory exists
     await this.ensureDirectory(dirname(filePath));
 
-    // Create empty file (no metadata line needed)
-    await writeFile(filePath, "", "utf8");
+    const content = workdir
+      ? `${JSON.stringify({ type: "metadata", workdir })}\n`
+      : "";
+    await writeFile(filePath, content, "utf8");
   }
 
   /**
@@ -118,12 +128,16 @@ export class JsonlHandler {
 
       const allMessages: Message[] = [];
 
-      // Parse all messages (no metadata line to skip)
+      // Parse all messages, skipping the metadata header line (if any)
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
 
         try {
-          const message = JSON.parse(line) as Message;
+          const message = JSON.parse(line) as Message & {
+            type?: string;
+          };
+          // Metadata header line: not a message, skip
+          if (message.type === "metadata") continue;
           if (message.timestamp) allMessages.push(message);
         } catch (error) {
           // Throw error for invalid JSON lines with line number
@@ -163,7 +177,11 @@ export class JsonlHandler {
       }
 
       try {
-        const parsed = JSON.parse(lastLine);
+        const parsed = JSON.parse(lastLine) as Message & { type?: string };
+        // A file whose only line is the metadata header has no messages yet
+        if (parsed.type === "metadata") {
+          return null;
+        }
         return parsed as Message;
       } catch (error) {
         throw new Error(`Invalid JSON in last line of "${filePath}": ${error}`);
@@ -173,6 +191,34 @@ export class JsonlHandler {
         `Failed to get last message from "${filePath}": ${error}`,
       );
     }
+  }
+
+  /**
+   * Read the real workdir from the session file's metadata header line.
+   *
+   * Newer session files start with a `{"type":"metadata","workdir":...}` line
+   * (see `createSession`). Legacy files have no header.
+   *
+   * @param filePath - Path to the session JSONL file
+   * @returns The persisted workdir, or null when the file has no header
+   */
+  async readWorkdirMetadata(filePath: string): Promise<string | null> {
+    try {
+      const lines = await readFirstNLines(filePath, 1);
+      if (lines.length === 0) {
+        return null;
+      }
+      const header = JSON.parse(lines[0]) as {
+        type?: string;
+        workdir?: string;
+      };
+      if (header.type === "metadata" && typeof header.workdir === "string") {
+        return header.workdir;
+      }
+    } catch {
+      // Unreadable or invalid first line — treat as a legacy file
+    }
+    return null;
   }
 
   /**

--- a/packages/agent-sdk/src/services/session.ts
+++ b/packages/agent-sdk/src/services/session.ts
@@ -139,7 +139,9 @@ export async function createSession(
 ): Promise<void> {
   const jsonlHandler = new JsonlHandler();
   const filePath = await getSessionFilePath(sessionId, workdir, sessionType);
-  await jsonlHandler.createSession(filePath);
+  // Persist the real workdir in a metadata header so session listing can
+  // display it without the lossy decodeSync of the encoded dir name.
+  await jsonlHandler.createSession(filePath, workdir);
 }
 
 /**
@@ -508,9 +510,11 @@ export async function listAllSessions(options?: {
     // "home-user-repo" cannot swallow "home-user-repo-wt" (short paths require
     // exact match; prefix + "-" matching only kicks in for paths truncated by
     // the 200-char encoding limit, mirroring Claude Code's session listing).
+    // Each entry also carries the real path so matching dirs can display it
+    // instead of the lossy decodeSync of the encoded name.
     const encoder = new PathEncoder();
     const caseInsensitive = process.platform === "win32";
-    let indexed: { prefix: string }[] | null = null;
+    let indexed: { prefix: string; path?: string }[] | null = null;
     if (worktreePaths && worktreePaths.length > 0) {
       indexed = [];
       const seen = new Set<string>();
@@ -524,7 +528,7 @@ export async function listAllSessions(options?: {
         const prefix = caseInsensitive ? encoded.toLowerCase() : encoded;
         if (seen.has(prefix)) continue;
         seen.add(prefix);
-        indexed.push({ prefix });
+        indexed.push({ prefix, path: wt });
       }
       indexed.sort((a, b) => b.prefix.length - a.prefix.length);
       // Always include the current working directory's own project dir —
@@ -540,7 +544,7 @@ export async function listAllSessions(options?: {
         const prefix = caseInsensitive ? encodedCwd.toLowerCase() : encodedCwd;
         if (!seen.has(prefix)) {
           seen.add(prefix);
-          indexed.push({ prefix });
+          indexed.push({ prefix, path: workdir });
         }
       }
     }
@@ -556,17 +560,20 @@ export async function listAllSessions(options?: {
           continue;
         }
 
+        // The indexed match (worktree mode) carries the real path of the
+        // worktree / cwd that encoded to this dir name.
+        let matchedIndexed: { prefix: string; path?: string } | undefined;
         if (indexed) {
           const dirName = caseInsensitive
             ? projectDirName.toLowerCase()
             : projectDirName;
-          const matchesWorktree = indexed.some(
+          matchedIndexed = indexed.find(
             ({ prefix }) =>
               dirName === prefix ||
               (prefix.length >= MAX_ENCODED_PREFIX_LENGTH &&
                 dirName.startsWith(prefix + "-")),
           );
-          if (!matchesWorktree) continue;
+          if (!matchedIndexed) continue;
         }
 
         // Decode the encoded directory name back to the original project
@@ -577,6 +584,11 @@ export async function listAllSessions(options?: {
 
         // Scan .jsonl files in the project directory
         const files = await fs.readdir(projectPath);
+
+        // All sessions in one encoded dir share the same workdir, so probe
+        // the persisted metadata header at most once per dir (newer files
+        // only — legacy files have no header).
+        let realWorkdir: string | null | undefined;
 
         for (const file of files) {
           if (!file.endsWith(".jsonl") || file.startsWith("subagent-")) {
@@ -593,6 +605,10 @@ export async function listAllSessions(options?: {
             const sessionId = uuidMatch[1];
             const jsonlHandler = new JsonlHandler();
             const lastMessage = await jsonlHandler.getLastMessage(filePath);
+
+            if (realWorkdir === undefined) {
+              realWorkdir = await jsonlHandler.readWorkdirMetadata(filePath);
+            }
 
             let lastActiveAt: Date;
             if (lastMessage) {
@@ -616,11 +632,16 @@ export async function listAllSessions(options?: {
               // Ignore errors getting first message
             }
 
+            // Prefer the real worktree path, then the persisted metadata
+            // header, then the lossy decodeSync fallback for legacy files.
+            const workdir =
+              matchedIndexed?.path ?? realWorkdir ?? decodedWorkdir;
+
             allSessions.push({
               id: sessionId,
               sessionType: "main" as const,
               subagentType: undefined,
-              workdir: decodedWorkdir,
+              workdir,
               createdAt: new Date(),
               lastActiveAt,
               latestTotalTokens: lastMessage?.usage
@@ -893,10 +914,10 @@ export async function getFirstMessageContentFromFile(
 
     for (const line of lines) {
       try {
-        const message = JSON.parse(line) as Message;
+        const message = JSON.parse(line) as Message & { type?: string };
 
-        // Skip meta messages
-        if (message.isMeta) {
+        // Skip the metadata header line and meta messages
+        if (message.type === "metadata" || message.isMeta) {
           continue;
         }
 

--- a/packages/agent-sdk/src/services/session.ts
+++ b/packages/agent-sdk/src/services/session.ts
@@ -19,6 +19,8 @@ import { promises as fs } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { randomUUID } from "crypto";
+import { execFile } from "child_process";
+import { promisify } from "util";
 import type { Message } from "../types/index.js";
 import { PathEncoder } from "../utils/pathEncoder.js";
 import { JsonlHandler } from "../services/jsonlHandler.js";
@@ -28,6 +30,8 @@ import {
   getMessageContent,
   sliceFromLastCompact,
 } from "../utils/messageOperations.js";
+
+const execFileAsync = promisify(execFile);
 
 export interface SessionData {
   id: string;
@@ -48,6 +52,8 @@ export interface SessionMetadata {
   lastActiveAt: Date;
   latestTotalTokens: number;
   firstMessage?: string;
+  /** Git branch at session creation time (from the metadata header). */
+  branch?: string;
 }
 
 /**
@@ -127,6 +133,26 @@ export async function getSessionFilePath(
 }
 
 /**
+ * Resolve the current git branch for a working directory, if any.
+ *
+ * Returns undefined when the directory is not inside a git repo, git is
+ * unavailable, or the command fails/times out — the session can still be
+ * created, its metadata header just omits the branch.
+ */
+async function getGitBranch(workdir: string): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", workdir, "branch", "--show-current"],
+      { timeout: 2000, windowsHide: true },
+    );
+    return stdout.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Create a new session
  * @param sessionId - UUID session identifier
  * @param workdir - Working directory for the session
@@ -139,9 +165,15 @@ export async function createSession(
 ): Promise<void> {
   const jsonlHandler = new JsonlHandler();
   const filePath = await getSessionFilePath(sessionId, workdir, sessionType);
-  // Persist the real workdir in a metadata header so session listing can
-  // display it without the lossy decodeSync of the encoded dir name.
-  await jsonlHandler.createSession(filePath, workdir);
+  // Persist creation-time metadata in the header line: the real workdir
+  // (lossy via decodeSync), the real creation timestamp, and the git branch
+  // at creation time. The header is append-only — written once, never
+  // rewritten — so only creation-time-constant fields belong here.
+  await jsonlHandler.createSession(filePath, {
+    workdir,
+    createdAt: new Date().toISOString(),
+    gitBranch: await getGitBranch(workdir),
+  });
 }
 
 /**
@@ -416,6 +448,10 @@ export async function listSessionsFromJsonl(
         const jsonlHandler = new JsonlHandler();
         const lastMessage = await jsonlHandler.getLastMessage(filePath);
 
+        // Creation-time metadata (workdir is not needed here — the project
+        // dir gives the original path — but createdAt / branch are).
+        const header = await jsonlHandler.readMetadata(filePath);
+
         // Handle timing information efficiently
         let lastActiveAt: Date;
 
@@ -433,11 +469,14 @@ export async function listSessionsFromJsonl(
           sessionType: "main",
           subagentType: undefined,
           workdir: projectDir.originalPath,
-          createdAt: new Date(),
+          createdAt: header?.createdAt
+            ? new Date(header.createdAt)
+            : new Date(),
           lastActiveAt,
           latestTotalTokens: lastMessage?.usage
             ? extractLatestTotalTokens([lastMessage])
             : 0,
+          branch: header?.gitBranch,
         };
 
         // Try to get first message content for display
@@ -585,11 +624,6 @@ export async function listAllSessions(options?: {
         // Scan .jsonl files in the project directory
         const files = await fs.readdir(projectPath);
 
-        // All sessions in one encoded dir share the same workdir, so probe
-        // the persisted metadata header at most once per dir (newer files
-        // only — legacy files have no header).
-        let realWorkdir: string | null | undefined;
-
         for (const file of files) {
           if (!file.endsWith(".jsonl") || file.startsWith("subagent-")) {
             continue;
@@ -606,9 +640,9 @@ export async function listAllSessions(options?: {
             const jsonlHandler = new JsonlHandler();
             const lastMessage = await jsonlHandler.getLastMessage(filePath);
 
-            if (realWorkdir === undefined) {
-              realWorkdir = await jsonlHandler.readWorkdirMetadata(filePath);
-            }
+            // Creation-time metadata — read per file: branch can differ
+            // between sessions created in the same directory over time.
+            const header = await jsonlHandler.readMetadata(filePath);
 
             let lastActiveAt: Date;
             if (lastMessage) {
@@ -635,19 +669,22 @@ export async function listAllSessions(options?: {
             // Prefer the real worktree path, then the persisted metadata
             // header, then the lossy decodeSync fallback for legacy files.
             const workdir =
-              matchedIndexed?.path ?? realWorkdir ?? decodedWorkdir;
+              matchedIndexed?.path ?? header?.workdir ?? decodedWorkdir;
 
             allSessions.push({
               id: sessionId,
               sessionType: "main" as const,
               subagentType: undefined,
               workdir,
-              createdAt: new Date(),
+              createdAt: header?.createdAt
+                ? new Date(header.createdAt)
+                : new Date(),
               lastActiveAt,
               latestTotalTokens: lastMessage?.usage
                 ? extractLatestTotalTokens([lastMessage])
                 : 0,
               firstMessage,
+              branch: header?.gitBranch,
             });
           } catch {
             continue;

--- a/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
+++ b/packages/agent-sdk/tests/managers/slashCommandManager.test.ts
@@ -18,6 +18,7 @@ import type { MemoryService } from "../../src/services/memory.js";
 const mockExec = vi.hoisted(() => vi.fn());
 vi.mock("child_process", () => ({
   exec: mockExec,
+  execFile: mockExec,
 }));
 vi.mock("util", () => ({
   promisify: vi.fn(() => mockExec),

--- a/packages/agent-sdk/tests/services/jsonlHandler.test.ts
+++ b/packages/agent-sdk/tests/services/jsonlHandler.test.ts
@@ -21,6 +21,7 @@ vi.mock("fs/promises", () => ({
 vi.mock("@/utils/fileUtils.js", () => ({
   getLastLine: vi.fn(),
   readFirstLine: vi.fn(),
+  readFirstNLines: vi.fn(),
 }));
 
 describe("JsonlHandler.append()", () => {
@@ -597,6 +598,100 @@ describe("JsonlHandler.createSession() - TDD Tests for User Story 1", () => {
       // Verify file is created with empty content (no metadata header)
       expect(mockWriteFile).toHaveBeenCalledOnce();
       expect(mockWriteFile).toHaveBeenCalledWith(filePath, "", "utf8");
+    });
+  });
+
+  describe("Session creation with workdir metadata header", () => {
+    it("writes a metadata header line when a workdir is provided", async () => {
+      const filePath =
+        "/test/sessions/12345678-1234-1234-1234-123456789abc.jsonl";
+
+      await handler.createSession(filePath, "/home/u/repo-wt-1");
+
+      expect(mockWriteFile).toHaveBeenCalledOnce();
+      const writtenContent = mockWriteFile.mock.calls[0][1] as string;
+      expect(writtenContent).toBe(
+        `${JSON.stringify({ type: "metadata", workdir: "/home/u/repo-wt-1" })}\n`,
+      );
+    });
+
+    it("does not add a metadata header when workdir is omitted", async () => {
+      const filePath =
+        "/test/sessions/12345678-1234-1234-1234-123456789abc.jsonl";
+
+      await handler.createSession(filePath);
+
+      expect(mockWriteFile).toHaveBeenCalledWith(filePath, "", "utf8");
+    });
+  });
+
+  describe("Metadata header handling on read", () => {
+    it("read() skips the metadata header line", async () => {
+      const header = JSON.stringify({
+        type: "metadata",
+        workdir: "/home/u/repo",
+      });
+      const message = {
+        timestamp: "2024-01-01T00:00:00.000Z",
+        id: generateMessageId(),
+        role: "user" as const,
+        blocks: [{ type: "text" as const, content: "hello" }],
+      };
+      mockReadFile.mockResolvedValue(`${header}\n${JSON.stringify(message)}\n`);
+
+      const result = await handler.read("/test/session.jsonl");
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.role).toBe("user");
+    });
+
+    it("getLastMessage returns null when the file holds only the metadata header", async () => {
+      const { getLastLine } = await import("@/utils/fileUtils.js");
+      vi.mocked(getLastLine).mockResolvedValue(
+        JSON.stringify({ type: "metadata", workdir: "/home/u/repo" }),
+      );
+      const { stat } = await import("fs/promises");
+      vi.mocked(stat).mockResolvedValue({} as Awaited<ReturnType<typeof stat>>);
+
+      const result = await handler.getLastMessage("/test/session.jsonl");
+
+      expect(result).toBeNull();
+    });
+
+    it("readWorkdirMetadata returns the persisted workdir", async () => {
+      const { readFirstNLines } = await import("@/utils/fileUtils.js");
+      vi.mocked(readFirstNLines).mockResolvedValue([
+        JSON.stringify({ type: "metadata", workdir: "/home/u/repo-wt-1" }),
+      ]);
+
+      const result = await handler.readWorkdirMetadata("/test/session.jsonl");
+
+      expect(result).toBe("/home/u/repo-wt-1");
+    });
+
+    it("readWorkdirMetadata returns null for legacy files without a header", async () => {
+      const { readFirstNLines } = await import("@/utils/fileUtils.js");
+      vi.mocked(readFirstNLines).mockResolvedValue([
+        JSON.stringify({
+          timestamp: "2024-01-01T00:00:00.000Z",
+          id: generateMessageId(),
+          role: "user" as const,
+          blocks: [{ type: "text" as const, content: "hello" }],
+        }),
+      ]);
+
+      const result = await handler.readWorkdirMetadata("/test/session.jsonl");
+
+      expect(result).toBeNull();
+    });
+
+    it("readWorkdirMetadata returns null when the file has no lines", async () => {
+      const { readFirstNLines } = await import("@/utils/fileUtils.js");
+      vi.mocked(readFirstNLines).mockResolvedValue([]);
+
+      const result = await handler.readWorkdirMetadata("/test/session.jsonl");
+
+      expect(result).toBeNull();
     });
   });
 

--- a/packages/agent-sdk/tests/services/jsonlHandler.test.ts
+++ b/packages/agent-sdk/tests/services/jsonlHandler.test.ts
@@ -601,12 +601,12 @@ describe("JsonlHandler.createSession() - TDD Tests for User Story 1", () => {
     });
   });
 
-  describe("Session creation with workdir metadata header", () => {
+  describe("Session creation with metadata header", () => {
     it("writes a metadata header line when a workdir is provided", async () => {
       const filePath =
         "/test/sessions/12345678-1234-1234-1234-123456789abc.jsonl";
 
-      await handler.createSession(filePath, "/home/u/repo-wt-1");
+      await handler.createSession(filePath, { workdir: "/home/u/repo-wt-1" });
 
       expect(mockWriteFile).toHaveBeenCalledOnce();
       const writtenContent = mockWriteFile.mock.calls[0][1] as string;
@@ -615,7 +615,50 @@ describe("JsonlHandler.createSession() - TDD Tests for User Story 1", () => {
       );
     });
 
-    it("does not add a metadata header when workdir is omitted", async () => {
+    it("writes createdAt and gitBranch into the metadata header", async () => {
+      const filePath =
+        "/test/sessions/12345678-1234-1234-1234-123456789abc.jsonl";
+
+      await handler.createSession(filePath, {
+        workdir: "/home/u/repo",
+        createdAt: "2026-08-14T00:00:00.000Z",
+        gitBranch: "feature/x",
+      });
+
+      expect(mockWriteFile).toHaveBeenCalledOnce();
+      const writtenContent = mockWriteFile.mock.calls[0][1] as string;
+      expect(writtenContent).toBe(
+        `${JSON.stringify({
+          type: "metadata",
+          workdir: "/home/u/repo",
+          createdAt: "2026-08-14T00:00:00.000Z",
+          gitBranch: "feature/x",
+        })}\n`,
+      );
+    });
+
+    it("omits undefined metadata fields from the header", async () => {
+      const filePath =
+        "/test/sessions/12345678-1234-1234-1234-123456789abc.jsonl";
+
+      await handler.createSession(filePath, {
+        workdir: "/home/u/repo",
+        createdAt: "2026-08-14T00:00:00.000Z",
+        gitBranch: undefined,
+      });
+
+      expect(mockWriteFile).toHaveBeenCalledOnce();
+      const writtenContent = mockWriteFile.mock.calls[0][1] as string;
+      expect(writtenContent).toBe(
+        `${JSON.stringify({
+          type: "metadata",
+          workdir: "/home/u/repo",
+          createdAt: "2026-08-14T00:00:00.000Z",
+        })}\n`,
+      );
+    });
+
+    it("does not add a metadata header when metadata is omitted", async () => {
       const filePath =
         "/test/sessions/12345678-1234-1234-1234-123456789abc.jsonl";
 
@@ -658,18 +701,27 @@ describe("JsonlHandler.createSession() - TDD Tests for User Story 1", () => {
       expect(result).toBeNull();
     });
 
-    it("readWorkdirMetadata returns the persisted workdir", async () => {
+    it("readMetadata returns the persisted metadata", async () => {
       const { readFirstNLines } = await import("@/utils/fileUtils.js");
       vi.mocked(readFirstNLines).mockResolvedValue([
-        JSON.stringify({ type: "metadata", workdir: "/home/u/repo-wt-1" }),
+        JSON.stringify({
+          type: "metadata",
+          workdir: "/home/u/repo-wt-1",
+          createdAt: "2026-08-14T00:00:00.000Z",
+          gitBranch: "feature/x",
+        }),
       ]);
 
-      const result = await handler.readWorkdirMetadata("/test/session.jsonl");
+      const result = await handler.readMetadata("/test/session.jsonl");
 
-      expect(result).toBe("/home/u/repo-wt-1");
+      expect(result).toEqual({
+        workdir: "/home/u/repo-wt-1",
+        createdAt: "2026-08-14T00:00:00.000Z",
+        gitBranch: "feature/x",
+      });
     });
 
-    it("readWorkdirMetadata returns null for legacy files without a header", async () => {
+    it("readMetadata returns null for legacy files without a header", async () => {
       const { readFirstNLines } = await import("@/utils/fileUtils.js");
       vi.mocked(readFirstNLines).mockResolvedValue([
         JSON.stringify({
@@ -680,16 +732,16 @@ describe("JsonlHandler.createSession() - TDD Tests for User Story 1", () => {
         }),
       ]);
 
-      const result = await handler.readWorkdirMetadata("/test/session.jsonl");
+      const result = await handler.readMetadata("/test/session.jsonl");
 
       expect(result).toBeNull();
     });
 
-    it("readWorkdirMetadata returns null when the file has no lines", async () => {
+    it("readMetadata returns null when the file has no lines", async () => {
       const { readFirstNLines } = await import("@/utils/fileUtils.js");
       vi.mocked(readFirstNLines).mockResolvedValue([]);
 
-      const result = await handler.readWorkdirMetadata("/test/session.jsonl");
+      const result = await handler.readMetadata("/test/session.jsonl");
 
       expect(result).toBeNull();
     });

--- a/packages/agent-sdk/tests/services/session.compact.test.ts
+++ b/packages/agent-sdk/tests/services/session.compact.test.ts
@@ -50,6 +50,7 @@ vi.mock("@/services/jsonlHandler.js", () => ({
         .mockImplementation((sessionId: string) => `${sessionId}.jsonl`),
       getLastMessage: vi.fn(),
       createSession: vi.fn().mockResolvedValue(undefined),
+      readWorkdirMetadata: vi.fn().mockResolvedValue(null),
     };
   }),
 }));

--- a/packages/agent-sdk/tests/services/session.compact.test.ts
+++ b/packages/agent-sdk/tests/services/session.compact.test.ts
@@ -50,7 +50,7 @@ vi.mock("@/services/jsonlHandler.js", () => ({
         .mockImplementation((sessionId: string) => `${sessionId}.jsonl`),
       getLastMessage: vi.fn(),
       createSession: vi.fn().mockResolvedValue(undefined),
-      readWorkdirMetadata: vi.fn().mockResolvedValue(null),
+      readMetadata: vi.fn().mockResolvedValue(null),
     };
   }),
 }));

--- a/packages/agent-sdk/tests/services/session.core.test.ts
+++ b/packages/agent-sdk/tests/services/session.core.test.ts
@@ -45,7 +45,7 @@ vi.mock("@/services/jsonlHandler.js", () => ({
       generateSessionFilename: vi.fn(),
       getLastMessage: vi.fn(),
       createSession: vi.fn(),
-      readWorkdirMetadata: vi.fn().mockResolvedValue(null),
+      readMetadata: vi.fn().mockResolvedValue(null),
     };
   }),
 }));
@@ -86,7 +86,19 @@ describe("Session Core Functionality", () => {
       (sessionId: string, sessionType?: "main" | "subagent") => string
     >;
     getLastMessage: Mock<(filePath: string) => Promise<Message | null>>;
-    createSession: Mock<(filePath: string) => Promise<void>>;
+    createSession: Mock<
+      (
+        filePath: string,
+        metadata?: { workdir?: string; createdAt?: string; gitBranch?: string },
+      ) => Promise<void>
+    >;
+    readMetadata: Mock<
+      (filePath: string) => Promise<{
+        workdir?: string;
+        createdAt?: string;
+        gitBranch?: string;
+      } | null>
+    >;
   };
   let mockPathEncoder: {
     createProjectDirectory: Mock<
@@ -176,6 +188,7 @@ describe("Session Core Functionality", () => {
         ), // Default implementation for testing
       getLastMessage: vi.fn().mockResolvedValue(null), // Default: no last message
       createSession: vi.fn().mockResolvedValue(undefined), // Default: successful session creation
+      readMetadata: vi.fn().mockResolvedValue(null),
     };
 
     mockPathEncoder = {

--- a/packages/agent-sdk/tests/services/session.core.test.ts
+++ b/packages/agent-sdk/tests/services/session.core.test.ts
@@ -45,6 +45,7 @@ vi.mock("@/services/jsonlHandler.js", () => ({
       generateSessionFilename: vi.fn(),
       getLastMessage: vi.fn(),
       createSession: vi.fn(),
+      readWorkdirMetadata: vi.fn().mockResolvedValue(null),
     };
   }),
 }));

--- a/packages/agent-sdk/tests/services/session.errors.test.ts
+++ b/packages/agent-sdk/tests/services/session.errors.test.ts
@@ -38,6 +38,7 @@ vi.mock("@/services/jsonlHandler.js", () => ({
       generateSessionFilename: vi.fn(),
       getLastMessage: vi.fn(),
       createSession: vi.fn(),
+      readMetadata: vi.fn().mockResolvedValue(null),
     };
   }),
 }));
@@ -73,6 +74,13 @@ describe("Session Error Handling and Edge Cases", () => {
     >;
     getLastMessage: Mock<(filePath: string) => Promise<Message | null>>;
     createSession: Mock<(filePath: string) => Promise<void>>;
+    readMetadata: Mock<
+      (filePath: string) => Promise<{
+        workdir?: string;
+        createdAt?: string;
+        gitBranch?: string;
+      } | null>
+    >;
   };
   let mockPathEncoder: {
     createProjectDirectory: Mock<
@@ -134,6 +142,7 @@ describe("Session Error Handling and Edge Cases", () => {
         ),
       getLastMessage: vi.fn().mockResolvedValue(null),
       createSession: vi.fn().mockResolvedValue(undefined),
+      readMetadata: vi.fn().mockResolvedValue(null),
     };
 
     mockPathEncoder = {

--- a/packages/agent-sdk/tests/services/session.integration.test.ts
+++ b/packages/agent-sdk/tests/services/session.integration.test.ts
@@ -41,6 +41,7 @@ vi.mock("@/services/jsonlHandler.js", () => ({
       generateSessionFilename: vi.fn(),
       getLastMessage: vi.fn(),
       createSession: vi.fn(),
+      readMetadata: vi.fn().mockResolvedValue(null),
     };
   }),
 }));
@@ -80,6 +81,13 @@ describe("Session Integration Tests", () => {
     >;
     getLastMessage: Mock<(filePath: string) => Promise<Message | null>>;
     createSession: Mock<(filePath: string) => Promise<void>>;
+    readMetadata: Mock<
+      (filePath: string) => Promise<{
+        workdir?: string;
+        createdAt?: string;
+        gitBranch?: string;
+      } | null>
+    >;
   };
   let mockPathEncoder: {
     createProjectDirectory: Mock<
@@ -141,6 +149,7 @@ describe("Session Integration Tests", () => {
         ),
       getLastMessage: vi.fn().mockResolvedValue(null),
       createSession: vi.fn().mockResolvedValue(undefined),
+      readMetadata: vi.fn().mockResolvedValue(null),
     };
 
     mockPathEncoder = {

--- a/packages/agent-sdk/tests/services/session.performance.test.ts
+++ b/packages/agent-sdk/tests/services/session.performance.test.ts
@@ -40,6 +40,7 @@ vi.mock("@/services/jsonlHandler.js", () => ({
     generateSessionFilename: vi.fn(),
     getLastMessage: vi.fn(),
     createSession: vi.fn(),
+    readMetadata: vi.fn().mockResolvedValue(null),
   })),
 }));
 
@@ -71,6 +72,13 @@ describe("Session Performance Optimization", () => {
     >;
     getLastMessage: Mock<(filePath: string) => Promise<Message | null>>;
     createSession: Mock<(filePath: string) => Promise<void>>;
+    readMetadata: Mock<
+      (filePath: string) => Promise<{
+        workdir?: string;
+        createdAt?: string;
+        gitBranch?: string;
+      } | null>
+    >;
   };
   let mockPathEncoder: {
     createProjectDirectory: Mock<
@@ -132,6 +140,7 @@ describe("Session Performance Optimization", () => {
         ),
       getLastMessage: vi.fn().mockResolvedValue(null),
       createSession: vi.fn().mockResolvedValue(undefined),
+      readMetadata: vi.fn().mockResolvedValue(null),
     };
 
     mockPathEncoder = {

--- a/packages/agent-sdk/tests/services/session.resume.test.ts
+++ b/packages/agent-sdk/tests/services/session.resume.test.ts
@@ -54,6 +54,7 @@ describe("Session resume: cross-directory listing & restore", () => {
     read: ReturnType<typeof vi.fn>;
     getLastMessage: ReturnType<typeof vi.fn>;
     generateSessionFilename: ReturnType<typeof vi.fn>;
+    readWorkdirMetadata: ReturnType<typeof vi.fn>;
   };
 
   const makeMessage = (timestamp: string): Message =>
@@ -95,6 +96,7 @@ describe("Session resume: cross-directory listing & restore", () => {
               ? `${sessionId}.jsonl`
               : `subagent-${sessionId}.jsonl`,
         ),
+      readWorkdirMetadata: vi.fn().mockResolvedValue(null),
     };
 
     // Point the mocked constructors at our per-test instances
@@ -302,6 +304,76 @@ describe("Session resume: cross-directory listing & restore", () => {
       const workdirs = sessions.map((s) => s.workdir);
       expect(workdirs).toContain("/home-u-repo");
       expect(workdirs).toContain("home-u-hashed-abc12345");
+    });
+
+    it("prefers the persisted metadata header over the lossy decodeSync", async () => {
+      const fs = await import("fs");
+      const sessionId = randomUUID();
+
+      // The encoded dir name is lossy for paths containing "-": decodeSync
+      // turns every dash into a slash. The persisted header keeps the real
+      // path, so it must win.
+      mockPathEncoder.decodeSync.mockImplementation((name: string) =>
+        name === "home-u-repo-wt-1" ? "/home-u-repo-wt-1" : `/${name}`,
+      );
+      mockJsonlHandler.readWorkdirMetadata.mockResolvedValue(
+        "/home/u/repo-wt-1",
+      );
+
+      vi.mocked(fs.promises.readdir)
+        .mockResolvedValueOnce(["home-u-repo-wt-1"] as unknown as Awaited<
+          ReturnType<typeof fs.promises.readdir>
+        >)
+        .mockResolvedValueOnce([`${sessionId}.jsonl`] as unknown as Awaited<
+          ReturnType<typeof fs.promises.readdir>
+        >);
+      vi.mocked(fs.promises.stat).mockResolvedValue({
+        isDirectory: () => true,
+      } as unknown as Awaited<ReturnType<typeof fs.promises.stat>>);
+      mockJsonlHandler.getLastMessage.mockResolvedValue(
+        makeMessage(new Date().toISOString()),
+      );
+
+      const sessions = await listAllSessions();
+
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]!.workdir).toBe("/home/u/repo-wt-1");
+    });
+
+    it("shows the real worktree path in worktree mode (indexed path wins)", async () => {
+      const fs = await import("fs");
+      const sessionId = randomUUID();
+
+      mockPathEncoder.encode.mockImplementation(async (p: string) =>
+        p === "/home/u/repo" ? "home-u-repo" : p,
+      );
+      // decodeSync is lossy, but the indexed worktree path must be used
+      // verbatim instead.
+      mockPathEncoder.decodeSync.mockImplementation((name: string) =>
+        name === "home-u-repo" ? "/home-u-repo" : `/${name}`,
+      );
+
+      vi.mocked(fs.promises.readdir)
+        .mockResolvedValueOnce(["home-u-repo"] as unknown as Awaited<
+          ReturnType<typeof fs.promises.readdir>
+        >)
+        .mockResolvedValueOnce([`${sessionId}.jsonl`] as unknown as Awaited<
+          ReturnType<typeof fs.promises.readdir>
+        >);
+      vi.mocked(fs.promises.stat).mockResolvedValue({
+        isDirectory: () => true,
+      } as unknown as Awaited<ReturnType<typeof fs.promises.stat>>);
+      mockJsonlHandler.getLastMessage.mockResolvedValue(
+        makeMessage(new Date().toISOString()),
+      );
+
+      const sessions = await listAllSessions({
+        worktreePaths: ["/home/u/repo"],
+        workdir: "/home/u/repo",
+      });
+
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]!.workdir).toBe("/home/u/repo");
     });
   });
 

--- a/packages/agent-sdk/tests/services/session.resume.test.ts
+++ b/packages/agent-sdk/tests/services/session.resume.test.ts
@@ -54,7 +54,7 @@ describe("Session resume: cross-directory listing & restore", () => {
     read: ReturnType<typeof vi.fn>;
     getLastMessage: ReturnType<typeof vi.fn>;
     generateSessionFilename: ReturnType<typeof vi.fn>;
-    readWorkdirMetadata: ReturnType<typeof vi.fn>;
+    readMetadata: ReturnType<typeof vi.fn>;
   };
 
   const makeMessage = (timestamp: string): Message =>
@@ -96,7 +96,7 @@ describe("Session resume: cross-directory listing & restore", () => {
               ? `${sessionId}.jsonl`
               : `subagent-${sessionId}.jsonl`,
         ),
-      readWorkdirMetadata: vi.fn().mockResolvedValue(null),
+      readMetadata: vi.fn().mockResolvedValue(null),
     };
 
     // Point the mocked constructors at our per-test instances
@@ -316,9 +316,9 @@ describe("Session resume: cross-directory listing & restore", () => {
       mockPathEncoder.decodeSync.mockImplementation((name: string) =>
         name === "home-u-repo-wt-1" ? "/home-u-repo-wt-1" : `/${name}`,
       );
-      mockJsonlHandler.readWorkdirMetadata.mockResolvedValue(
-        "/home/u/repo-wt-1",
-      );
+      mockJsonlHandler.readMetadata.mockResolvedValue({
+        workdir: "/home/u/repo-wt-1",
+      });
 
       vi.mocked(fs.promises.readdir)
         .mockResolvedValueOnce(["home-u-repo-wt-1"] as unknown as Awaited<
@@ -338,6 +338,38 @@ describe("Session resume: cross-directory listing & restore", () => {
 
       expect(sessions).toHaveLength(1);
       expect(sessions[0]!.workdir).toBe("/home/u/repo-wt-1");
+    });
+
+    it("reads createdAt and gitBranch from the metadata header", async () => {
+      const fs = await import("fs");
+      const sessionId = randomUUID();
+      const createdAt = "2026-08-14T00:00:00.000Z";
+
+      mockJsonlHandler.readMetadata.mockResolvedValue({
+        workdir: "/home/u/repo",
+        createdAt,
+        gitBranch: "feature/x",
+      });
+
+      vi.mocked(fs.promises.readdir)
+        .mockResolvedValueOnce(["home-u-repo"] as unknown as Awaited<
+          ReturnType<typeof fs.promises.readdir>
+        >)
+        .mockResolvedValueOnce([`${sessionId}.jsonl`] as unknown as Awaited<
+          ReturnType<typeof fs.promises.readdir>
+        >);
+      vi.mocked(fs.promises.stat).mockResolvedValue({
+        isDirectory: () => true,
+      } as unknown as Awaited<ReturnType<typeof fs.promises.stat>>);
+      mockJsonlHandler.getLastMessage.mockResolvedValue(
+        makeMessage(new Date().toISOString()),
+      );
+
+      const sessions = await listAllSessions();
+
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]!.createdAt.toISOString()).toBe(createdAt);
+      expect(sessions[0]!.branch).toBe("feature/x");
     });
 
     it("shows the real worktree path in worktree mode (indexed path wins)", async () => {

--- a/packages/agent-sdk/tests/services/session.subagent.test.ts
+++ b/packages/agent-sdk/tests/services/session.subagent.test.ts
@@ -43,6 +43,7 @@ vi.mock("@/services/jsonlHandler.js", () => ({
       generateSessionFilename: vi.fn(),
       getLastMessage: vi.fn(),
       createSession: vi.fn(),
+      readMetadata: vi.fn().mockResolvedValue(null),
     };
   }),
 }));
@@ -80,6 +81,13 @@ describe("Subagent Session Tests", () => {
     >;
     getLastMessage: Mock<(filePath: string) => Promise<Message | null>>;
     createSession: Mock<(filePath: string) => Promise<void>>;
+    readMetadata: Mock<
+      (filePath: string) => Promise<{
+        workdir?: string;
+        createdAt?: string;
+        gitBranch?: string;
+      } | null>
+    >;
   };
   let mockPathEncoder: {
     createProjectDirectory: Mock<
@@ -141,6 +149,7 @@ describe("Subagent Session Tests", () => {
         ),
       getLastMessage: vi.fn().mockResolvedValue(null),
       createSession: vi.fn().mockResolvedValue(undefined),
+      readMetadata: vi.fn().mockResolvedValue(null),
     };
 
     mockPathEncoder = {

--- a/packages/code/src/components/SessionSelector.tsx
+++ b/packages/code/src/components/SessionSelector.tsx
@@ -193,6 +193,7 @@ export const SessionSelector: React.FC<SessionSelectorProps> = ({
                   >
                     {session.id.slice(0, 8)} | {lastActiveAt} |{" "}
                     {session.latestTotalTokens} tokens
+                    {session.branch ? ` | [${session.branch}]` : ""}
                     {showProjectPath && session.workdir
                       ? ` | ${session.workdir}`
                       : ""}

--- a/packages/code/src/session-selector-cli.tsx
+++ b/packages/code/src/session-selector-cli.tsx
@@ -49,7 +49,15 @@ export async function resolveSessionOwnership(
   opts: { worktreePaths: string[]; currentWorkdir: string },
 ): Promise<SessionOwnership> {
   const encoder = new PathEncoder();
-  const sessionEncoded = await encoder.encode(session.workdir);
+  // encode() resolves the path via realpath and throws ENOENT when the
+  // directory no longer exists (e.g. a deleted worktree); fall back to the
+  // pure string encodeSync so the picker still works for ghost sessions.
+  let sessionEncoded: string;
+  try {
+    sessionEncoded = await encoder.encode(session.workdir);
+  } catch {
+    sessionEncoded = encoder.encodeSync(session.workdir);
+  }
   const cwdEncoded = await encoder.encode(opts.currentWorkdir);
 
   if (sessionEncoded === cwdEncoded) {

--- a/packages/code/tests/components/SessionSelector.test.tsx
+++ b/packages/code/tests/components/SessionSelector.test.tsx
@@ -175,6 +175,18 @@ describe("SessionSelector", () => {
     expect(output).toContain("| /test");
   });
 
+  it("should render the git branch tag when the session has a branch", () => {
+    const sessions = mockSessions.map((s, i) => ({
+      ...s,
+      branch: i === 0 ? "feature/x" : undefined,
+    }));
+    const { lastFrame } = render(
+      <SessionSelector {...mockProps} sessions={sessions} />,
+    );
+    const output = lastFrame();
+    expect(output).toContain("| [feature/x]");
+  });
+
   it("should show Ctrl+A / Ctrl+W hints when their toggles are available", () => {
     // No toggles → no shortcut hints
     const { lastFrame: plainFrame } = render(

--- a/packages/code/tests/session-selector-cli.test.ts
+++ b/packages/code/tests/session-selector-cli.test.ts
@@ -66,6 +66,28 @@ describe("resolveSessionOwnership", () => {
     });
   });
 
+  it("falls back to encodeSync when the session workdir no longer exists", async () => {
+    // A deleted worktree makes encode() (realpath-based) throw ENOENT; the
+    // picker must still decide ownership via the lossy-but-safe encodeSync.
+    mockEncoder.encode.mockImplementation(async (p: string) => {
+      if (p === "/mock/repo-wt")
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      return p;
+    });
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    const result = await resolveSessionOwnership(
+      { id: "s6", workdir: "/mock/repo-wt" },
+      { worktreePaths: ["/mock/repo-wt"], currentWorkdir: "/mock/workdir" },
+    );
+
+    expect(mockEncoder.encodeSync).toHaveBeenCalledWith("/mock/repo-wt");
+    expect(result.kind).toBe("cross-project");
+    if (result.kind === "cross-project") {
+      expect(result.command).toContain("wave --restore s6");
+    }
+  });
+
   it("falls through to cross-project when the worktree directory no longer exists", async () => {
     mockEncoder.encode.mockImplementation(async (p: string) =>
       p === "/mock/repo-wt" || p === "/mock/encoded-repo-wt"


### PR DESCRIPTION
Fixes the `wave -r` (restore session picker) crash caused by realpath ENOENT on deleted worktree paths, and extends the session metadata header with creation-time info.

## Changes
- **Metadata header**: session JSONL files now persist a `{"type":"metadata","workdir":...,"createdAt":...,"gitBranch":...}` header line (append-only, immutable, backward compatible)
- **A — real workdir**: `listAllSessions` reads the real workdir from the header instead of the lossy `decodeSync` (`/home/u/repo-wt-1` no longer becomes `/home-u-repo-wt-1`)
- **B — worktree scope**: `Ctrl+W` scope passes real worktree paths via indexed entries (`{prefix, path}`)
- **C — guard**: `resolveSessionOwnership` falls back to `encodeSync` when realpath throws ENOENT, so deleted worktrees no longer crash the picker
- **createdAt**: real creation timestamp (ISO 8601) stored in the header; the picker no longer fabricates `new Date()` at scan time
- **gitBranch**: branch at session creation (`git branch --show-current`), shown as `[branch]` tag in `wave -r`; omitted when git is unavailable/not a repo/timeout
- Legacy session files (no header) keep the previous behavior (decodeSync fallback + current-time createdAt)

## Spec
docs/specs/ui/session-management.md — new user story「会话元数据头：真实创建时间与 git 分支」(P1) with 5 acceptance scenarios; spec-count check passed.

## Tests
- jsonlHandler: metadata header write/read, undefined-field omission
- session.resume/core/compact/performance/subagent/errors/integration: updated mocks for `readMetadata`, new createdAt/branch assertions
- SessionSelector: branch tag rendering test

Closes the deleted-worktree crash reported in the restore picker.