### PR TITLE
i18n(cli): translate user-facing CLI copy to English

### DIFF
--- a/docs/specs/ui/daemon-command.md
+++ b/docs/specs/ui/daemon-command.md
@@ -12,7 +12,7 @@ order: 270
 
 `wave --daemon <socket>` 在远端主机上启动一个 JSON-RPC over unix socket 的 daemon，托管后台 agent 会话（桌面端经 SSH 隧道访问）。目前除了 `--daemon` 启动标志外，没有任何面向用户的 CLI 命令可以查看 daemon 里托管了哪些会话、会话进度如何、或向会话注入消息继续对话——这些能力只存在于 JSON-RPC 协议层，普通用户与脚本无法直接使用。本规格定义 `wave daemon` 子命令组，将已验证的协议流程（attach → 读消息 → 注入消息 → 审批挂起的权限请求）封装为四条命令，供用户在远端主机直接执行（或经 `ssh <host> wave daemon ...` 在远端主机上执行）。
 
-## 用户场景与测试 *（必填）*
+## 用户场景与测试 _（必填）_
 
 ### 用户故事：Daemon 命令组与默认 socket（优先级：P0）
 
@@ -25,7 +25,7 @@ order: 270
 **验收场景**：
 
 1. **假设** 远端 daemon 正在运行，**当** 用户运行 `wave daemon list` 时，**则** 命令连接默认 socket（`~/.wave/daemon.sock`）并列出该 daemon 当前托管的全部会话（进程内存中 live 的会话）。
-2. **假设** daemon 未运行或 socket 文件不存在（含 daemon 空闲自动退出后），**当** 用户运行任一 `wave daemon` 子命令时，**则** 命令以非零退出码退出并给出明确错误（如「无法连接 daemon socket <路径>：daemon 未运行？」，附空闲自动退出提示），不进入 TUI、不挂起。
+2. **假设** daemon 未运行或 socket 文件不存在（含 daemon 空闲自动退出后），**当** 用户运行任一 `wave daemon` 子命令时，**则** 命令以非零退出码退出并给出明确错误（如「Cannot connect to daemon socket <路径>: is the daemon running?」，附空闲自动退出提示），不进入 TUI、不挂起。
 3. **假设** 用户运行 `wave daemon list` 时，**当** 命令执行期间没有需要交互的输入，**则** 命令运行完即退出（非交互式），stdout 输出结果、stderr 输出诊断，便于脚本与管道消费。
 4. **假设** 用户误以为 `wave daemon` 与 `wave --daemon <socket>` 相同，**当** 对比两者行为时，**则** `wave --daemon` 启动 daemon（服务端），`wave daemon <子命令>` 访问 daemon（客户端），两者语义不同、互不干扰，帮助文本中明确区分。
 
@@ -37,13 +37,13 @@ order: 270
 
 **为什么是这个优先级**：查看进度与继续对话都先要找到会话。会话不归属于某个 daemon 进程——daemon 空闲 60 秒自动退出是正常现象，退出后进程重启、内存清空，磁盘上的历史会话不会随 daemon 常驻。因此「daemon 托管」的准确语义是「当前 daemon 进程内存中 live 的会话」（经 `initialize`/`restoreSession` 载入且仍存活于该进程，即 agentBridge 的会话注册表），`list` 直接暴露该注册表即可，不扫磁盘索引、不需要新增 `listAllSessions` 协议方法，也天然不会列出 daemon 之外的对话（普通 `wave` TUI 创建的会话不在列表中）。
 
-**独立测试**：在 daemon 中创建/恢复两条会话后运行 `wave daemon list`，验证两条会话都出现，且每条含会话 ID、工作目录、状态与消息数；daemon 空闲退出重启后运行 `wave daemon list` 显示无会话（退出码 0）。
+**独立测试**：在 daemon 中创建/恢复两条会话后运行 `wave daemon list`，验证两条会话都出现，且每条含会话 ID、工作目录、状态与消息数；daemon 空闲退出重启后运行 `wave daemon list` 显示 No sessions（退出码 0）。
 
 **验收场景**：
 
-1. **假设** daemon 进程内存中托管了多条会话（不同 workdir 下经 `initialize`/`restoreSession` 载入且仍存活），**当** 用户运行 `wave daemon list` 时，**则** 列出当前进程内存中的全部会话，每条显示会话 ID、工作目录、状态（生成中/空闲）与消息数，不扫磁盘索引、不列出 daemon 之外的对话。
+1. **假设** daemon 进程内存中托管了多条会话（不同 workdir 下经 `initialize`/`restoreSession` 载入且仍存活），**当** 用户运行 `wave daemon list` 时，**则** 列出当前进程内存中的全部会话，每条显示会话 ID、工作目录、状态（generating/idle）与消息数，不扫磁盘索引、不列出 daemon 之外的对话。
 2. **假设** daemon 托管了多条会话，**当** 用户运行 `wave daemon list` 时，**则** 会话按注册顺序展示（内存态无磁盘索引的 lastActiveAt，不做最后活跃时间排序）。
-3. **假设** daemon 空闲退出后重启（进程内存清空）或尚无任何会话，**当** 用户运行 `wave daemon list` 时，**则** 输出空结果（显示无会话），退出码为 0——daemon 空闲自动退出是正常现象，列表为空符合预期而非错误。
+3. **假设** daemon 空闲退出后重启（进程内存清空）或尚无任何会话，**当** 用户运行 `wave daemon list` 时，**则** 输出空结果（显示 No sessions），退出码为 0——daemon 空闲自动退出是正常现象，列表为空符合预期而非错误。
 4. **假设** 磁盘上存在历史会话（含 daemon 空闲退出前托管过、或普通 `wave` TUI 创建的会话），**当** 用户运行 `wave daemon list` 时，**则** 这些会话不出现于列表；用户知道 sessionId 时仍可经 `wave daemon status <sessionId>` / `send <sessionId>` attach（`restoreSession` 会重新载入内存），无需依赖 `list` 找回。
 
 ---
@@ -54,16 +54,16 @@ order: 270
 
 **为什么是这个优先级**：这是「查看进度」的核心命令；实时状态只能通过 attach（`initialize {restoreSessionId}` → `restoreSession`）获取——restoreSession 会重放 `loadingChange` 快照，`getMessages` 返回全量消息，磁盘索引不提供这两个信息，因此该命令必须走 attach 流程。
 
-**独立测试**：对一条正在生成回复的会话运行 `wave daemon status <sessionId>`，验证输出包含「正在生成」状态与最近消息文本；对一条空闲会话运行则显示空闲状态。
+**独立测试**：对一条正在生成回复的会话运行 `wave daemon status <sessionId>`，验证输出包含 generating 状态与最近消息文本；对一条空闲会话运行则显示 idle 状态。
 
 **验收场景**：
 
-1. **假设** 目标会话正在生成回复，**当** 用户运行 `wave daemon status <sessionId>` 时，**则** 命令经 `initialize {restoreSessionId}` + `restoreSession` attach 该会话，依据重放的 `loadingChange` 快照显示「正在生成/执行任务」状态。
-2. **假设** 目标会话空闲（未在生成、无排队消息、无后台任务），**当** 用户运行 `wave daemon status <sessionId>` 时，**则** 显示空闲状态。
-3. **假设** 目标会话挂起等待权限审批，**当** 用户运行 `wave daemon status <sessionId>` 时，**则** 状态显示为等待审批（`loadingChange` 保持 loading 即视为未空闲），与桌面端「待确认」语义一致。
+1. **假设** 目标会话正在生成回复，**当** 用户运行 `wave daemon status <sessionId>` 时，**则** 命令经 `initialize {restoreSessionId}` + `restoreSession` attach 该会话，依据重放的 `loadingChange` 快照显示 generating（生成中）状态。
+2. **假设** 目标会话空闲（未在生成、无排队消息、无后台任务），**当** 用户运行 `wave daemon status <sessionId>` 时，**则** 显示 idle 状态。
+3. **假设** 目标会话挂起等待权限审批，**当** 用户运行 `wave daemon status <sessionId>` 时，**则** 状态显示为 waiting for approval（`loadingChange` 保持 loading 即视为未空闲），与桌面端「待确认」语义一致。
 4. **假设** 目标会话挂起等待权限审批，**当** 查看最近消息时，**则** 最后一条 assistant 消息含一个冻结在 `stage: "running"` 的 tool 块：有工具名与参数（`name`/`parameters`/`compactParams`），但无 `result`/`success`/`error`/`shortResult`/`timestamp`——这些字段只在工具完成后（`stage: "end"`）写入，无独立的 pending stage；消息形态上「等审批」与「执行中」无法区分，status 须同时列出 `listPendingPermissions` 返回的待审批请求（工具名 + 参数摘要），作为审批态的确凿信号。
 5. **假设** 会话已有历史消息，**当** 用户运行 `wave daemon status <sessionId>` 时，**则** 经 `getMessages` 拉取并显示最近若干条消息的文本（含用户消息与助手回复，默认数量可经参数调整，如 `--lines 20`），足以判断任务进展。
-6. **假设** 指定的 sessionId 不存在于该 daemon，**当** 用户运行 `wave daemon status <sessionId>` 时，**则** 以非零退出码退出并给出明确错误（会话不存在或未被该 daemon 托管）。
+6. **假设** 指定的 sessionId 不存在于该 daemon，**当** 用户运行 `wave daemon status <sessionId>` 时，**则** 以非零退出码退出并给出明确错误（Session not found or not hosted by this daemon）。
 7. **假设** status 命令完成展示后，**当** 命令退出时，**则** 断开与 daemon 的连接（attach 是短暂查看，不常驻），daemon 与目标会话不受影响、继续运行。
 
 ---
@@ -84,8 +84,8 @@ order: 270
 4. **假设** 目标会话挂起 AskUserQuestion 审批，**当** 用户运行 `wave daemon respond <sessionId> <requestId> --answer '{"问题":"答案"}'` 时，**则** 发送 `{behavior:"allow", message: JSON.stringify(答案对象)}`，如同桌面端填写答案后确认；若只传 `--allow` 未传 `--answer`，命令报错提示需要提供答案。
 5. **假设** 用户运行 `wave daemon respond <sessionId> <requestId> --allow --rule "Bash(ls)"` 时，**则** 决策附带 `newPermissionRule`，该规则被持久化为允许规则、后续同类调用不再询问（与桌面端「不再询问」语义一致）。
 6. **假设** 用户运行 `wave daemon respond <sessionId> <requestId> --allow --mode acceptEdits` 时，**则** 决策附带 `newPermissionMode`，会话权限模式切换为 acceptEdits（后续 Edit/Write 不再询问，与桌面端「自动接受修改」语义一致）。
-7. **假设** 指定的 requestId 不存在（已被其他客户端处理或已过期），**当** 用户运行 respond 时，**则** 命令提示「该请求不存在或已处理」并以非零退出码退出（服务端对未知 requestId 静默忽略，命令应先行校验避免误导）。
-8. **假设** 指定的 sessionId 不存在于该 daemon，**当** 用户运行 `wave daemon respond <sessionId> <requestId> --allow` 时，**则** 以非零退出码退出并给出明确错误（会话不存在或未被该 daemon 托管），不发送任何通知。
+7. **假设** 指定的 requestId 不存在（已被其他客户端处理或已过期），**当** 用户运行 respond 时，**则** 命令提示「Request not found or already handled」并以非零退出码退出（服务端对未知 requestId 静默忽略，命令应先行校验避免误导）。
+8. **假设** 指定的 sessionId 不存在于该 daemon，**当** 用户运行 `wave daemon respond <sessionId> <requestId> --allow` 时，**则** 以非零退出码退出并给出明确错误（Session not found or not hosted by this daemon），不发送任何通知。
 9. **假设** respond 命令完成（成功或失败）后，**当** 命令退出时，**则** 断开与 daemon 的连接；会话恢复生成或回到空闲，不因客户端退出而终止。
 
 ---
@@ -103,7 +103,7 @@ order: 270
 1. **假设** 目标会话空闲，**当** 用户运行 `wave daemon send <sessionId> "继续"` 时，**则** 命令经 attach 后调用 `sendMessage` 注入消息，订阅流式通知（`assistantContentUpdated` 等），直到 `loadingChange:false` 表示该回复完成。
 2. **假设** 助手回复完成，**当** 命令结束时，**则** stdout 输出该条消息对应的助手最终回复文本（与 `wave -p` 的纯净输出一致，不含子代理内部信息与流式杂讯），退出码为 0。
 3. **假设** 目标会话正在生成中，**当** 用户运行 `wave daemon send <sessionId> "消息"` 时，**则** 消息按现有队列语义入队等待，命令持续等待直到该消息对应的回复完成（依据 `loadingChange` 与消息 ID 对应）后输出最终回复。
-4. **假设** 目标会话挂起等待权限审批，**当** 用户运行 `wave daemon send <sessionId> "消息"` 时，**则** 命令不无限期挂起：等待超过 `--timeout`（默认 600 秒，`0` 表示不限制）后以非零退出码退出，并提示「会话等待权限审批，请通过 `wave daemon respond <sessionId> <requestId>` 处理后重试」。
+4. **假设** 目标会话挂起等待权限审批，**当** 用户运行 `wave daemon send <sessionId> "消息"` 时，**则** 命令不无限期挂起：等待超过 `--timeout`（默认 600 秒，`0` 表示不限制）后以非零退出码退出，并提示「Session is waiting for permission approval; handle it with `wave daemon respond <sessionId> <requestId>` and retry」。
 5. **假设** 指定的 sessionId 不存在于该 daemon，**当** 用户运行 `wave daemon send <sessionId> "消息"` 时，**则** 以非零退出码退出并给出明确错误，不注入任何消息。
 6. **假设** send 命令完成或失败退出后，**当** 命令结束时，**则** 断开与 daemon 的连接，会话在 daemon 中继续存活、不因客户端退出而终止（与 attach 语义一致）。
 

--- a/packages/code/src/components/InputBox.tsx
+++ b/packages/code/src/components/InputBox.tsx
@@ -369,7 +369,9 @@ export const InputBox: React.FC<InputBoxProps> = ({
           showModelSelector ||
           showWorkflowManager || (
             <Box flexDirection="column">
-              {escClearPending && <Text color="gray">再次按 Esc 清空输入</Text>}
+              {escClearPending && (
+                <Text color="gray">Press Esc again to clear input</Text>
+              )}
               <Box
                 borderStyle="single"
                 borderColor="gray"

--- a/packages/code/src/components/SessionSelector.tsx
+++ b/packages/code/src/components/SessionSelector.tsx
@@ -137,14 +137,14 @@ export const SessionSelector: React.FC<SessionSelectorProps> = ({
 
   const hints = [
     onToggleAllProjects
-      ? `Ctrl+A ${showAllProjects ? "当前目录" : "全部项目"}`
+      ? `Ctrl+A ${showAllProjects ? "current directory" : "all projects"}`
       : null,
     onToggleAllWorktrees && worktreePaths.length > 1
-      ? `Ctrl+W ${showAllWorktrees ? "当前 worktree" : "全部 worktree"}`
+      ? `Ctrl+W ${showAllWorktrees ? "current worktree" : "all worktrees"}`
       : null,
-    "↑↓ 选择",
-    "Enter 确认",
-    "Esc 取消",
+    "↑↓ select",
+    "Enter confirm",
+    "Esc cancel",
   ]
     .filter((hint): hint is string => hint !== null)
     .join("  ·  ");

--- a/packages/code/src/daemon/commands.ts
+++ b/packages/code/src/daemon/commands.ts
@@ -68,7 +68,7 @@ async function connectDaemonOrExit(socketPath: string): Promise<SocketClient> {
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     console.error(
-      `无法连接 daemon socket ${socketPath}：daemon 未运行？（daemon 空闲 60 秒自动退出）` +
+      `Cannot connect to daemon socket ${socketPath}: is the daemon running? (it auto-exits after 60s idle)` +
         (code ? ` (${code})` : ""),
     );
     process.exit(1);
@@ -115,7 +115,7 @@ async function attachSession(
       // initialize silently started a junk fresh session — remove it from the
       // registry so the failed attach leaves no trace (spec: 会话不存在错误).
       await client.request("destroy", undefined, initId).catch(() => {});
-      fail(`会话不存在或未被该 daemon 托管：${sessionId}`);
+      fail(`Session not found or not hosted by this daemon: ${sessionId}`);
     }
     throw err;
   }
@@ -149,7 +149,7 @@ export async function daemonListCommand(socketPath: string): Promise<void> {
     if (sessions.length > 0) {
       const rows = sessions.map((s) => ({
         sessionId: s.sessionId,
-        status: s.isLoading ? "生成中" : "空闲",
+        status: s.isLoading ? "generating" : "idle",
         messageCount: String(s.messageCount),
         workingDirectory: s.workingDirectory,
       }));
@@ -158,7 +158,7 @@ export async function daemonListCommand(socketPath: string): Promise<void> {
       const pad = (value: string, w: number) => value.padEnd(w);
 
       console.log(
-        `${pad("会话", width("sessionId"))}  ${pad("状态", width("status"))}  ${pad("消息数", width("messageCount"))}  工作目录`,
+        `${pad("Session", width("sessionId"))}  ${pad("Status", width("status"))}  ${pad("Messages", width("messageCount"))}  Working directory`,
       );
       for (const r of rows) {
         console.log(
@@ -167,10 +167,10 @@ export async function daemonListCommand(socketPath: string): Promise<void> {
       }
     } else {
       // Daemon idle-exit is normal — an empty registry is not an error.
-      console.log("无会话");
+      console.log("No sessions");
     }
   } catch (err) {
-    fail(`wave daemon list 失败：${(err as Error).message}`);
+    fail(`wave daemon list failed: ${(err as Error).message}`);
   } finally {
     await client?.dispose();
   }
@@ -226,14 +226,18 @@ export async function daemonStatusCommand(
     };
 
     const status =
-      pending.length > 0 ? "等待审批" : loading ? "生成中" : "空闲";
-    console.log(`会话: ${initId}`);
-    console.log(`工作目录: ${init.workingDirectory}`);
-    console.log(`状态: ${status}`);
+      pending.length > 0
+        ? "waiting for approval"
+        : loading
+          ? "generating"
+          : "idle";
+    console.log(`Session: ${initId}`);
+    console.log(`Working directory: ${init.workingDirectory}`);
+    console.log(`Status: ${status}`);
 
     if (pending.length > 0) {
       console.log("");
-      console.log("待审批请求:");
+      console.log("Pending approval requests:");
       for (const r of pending) {
         const params = summarizeToolInput(r.context);
         console.log(
@@ -245,7 +249,7 @@ export async function daemonStatusCommand(
     const recent = messages.messages.slice(-lines);
     if (recent.length > 0) {
       console.log("");
-      console.log(`最近消息 (${recent.length}):`);
+      console.log(`Recent messages (${recent.length}):`);
       for (const m of recent) {
         const text = getMessageContent(m).replace(/\s+/g, " ").trim();
         if (!text) continue; // tool-only messages carry no readable text
@@ -253,7 +257,7 @@ export async function daemonStatusCommand(
       }
     }
   } catch (err) {
-    fail(`wave daemon status 失败：${(err as Error).message}`);
+    fail(`wave daemon status failed: ${(err as Error).message}`);
   } finally {
     await client?.dispose();
   }
@@ -311,7 +315,7 @@ export async function daemonSendCommand(
     await client.request("sendMessage", { text: message }, initId);
   } catch (err) {
     client.dispose();
-    fail(`wave daemon send 失败：${(err as Error).message}`);
+    fail(`wave daemon send failed: ${(err as Error).message}`);
   }
 
   // Wait for the reply that corresponds to our message.
@@ -327,13 +331,13 @@ export async function daemonSendCommand(
       client.dispose();
       if (pending.length > 0) {
         fail(
-          `会话等待权限审批，请通过 \`wave daemon respond ${sessionId} ${pending[0].requestId}\` 处理后重试`,
+          `Session is waiting for permission approval; handle it with \`wave daemon respond ${sessionId} ${pending[0].requestId}\` and retry`,
         );
       }
       fail(
         options.timeout === 0
-          ? "等待回复超时"
-          : `等待回复超时（${options.timeout} 秒），未收到助手回复`,
+          ? "Timed out waiting for a reply"
+          : `Timed out waiting for a reply (${options.timeout}s), no assistant reply received`,
       );
     }
     await sleep(200);
@@ -351,7 +355,7 @@ export async function daemonSendCommand(
       if (content) console.log(content);
     }
   } catch (err) {
-    fail(`wave daemon send 失败：${(err as Error).message}`);
+    fail(`wave daemon send failed: ${(err as Error).message}`);
   } finally {
     client.dispose();
   }
@@ -376,7 +380,7 @@ export async function daemonRespondCommand(
   options: RespondOptions,
 ): Promise<void> {
   if (!!options.allow === !!options.deny) {
-    fail("请指定 --allow 或 --deny（二选一）");
+    fail("Specify either --allow or --deny");
   }
   let client: SocketClient | undefined;
   try {
@@ -387,11 +391,11 @@ export async function daemonRespondCommand(
     const pending = await listPendingPermissions(client);
     const req = pending.find((r) => r.requestId === requestId);
     if (!req) {
-      fail("该请求不存在或已处理");
+      fail("Request not found or already handled");
     }
     if (req.sessionId && req.sessionId !== sessionId) {
       // Cross-check before notifying; never touch another session's request.
-      fail("会话不存在或未被该 daemon 托管");
+      fail("Session not found or not hosted by this daemon");
     }
 
     let decision: PermissionDecision;
@@ -407,13 +411,15 @@ export async function daemonRespondCommand(
         decision = { behavior: "allow", newPermissionMode: "default" };
       } else if (toolName === ASK_USER_QUESTION_TOOL_NAME) {
         if (!options.answer) {
-          fail("AskUserQuestion 请求需要 --answer 提供答案 JSON");
+          fail(
+            "AskUserQuestion requests require --answer with the answer JSON",
+          );
         }
         let answers: unknown;
         try {
           answers = JSON.parse(options.answer);
         } catch {
-          fail("--answer 不是合法的 JSON");
+          fail("--answer is not valid JSON");
         }
         decision = { behavior: "allow", message: JSON.stringify(answers) };
       } else {
@@ -424,7 +430,7 @@ export async function daemonRespondCommand(
       if (options.mode) {
         if (!PERMISSION_MODES.includes(options.mode as PermissionMode)) {
           fail(
-            `无效的权限模式：${options.mode}（可选：${PERMISSION_MODES.join("、")}）`,
+            `Invalid permission mode: ${options.mode} (options: ${PERMISSION_MODES.join(", ")})`,
           );
         }
         decision.newPermissionMode = options.mode as PermissionMode;
@@ -434,9 +440,9 @@ export async function daemonRespondCommand(
     // Mirror desktop stdioAgent.sendPermissionResponse: envelope sessionId
     // present, decision built from the pending request's tool.
     client.notify("permissionResponse", { requestId, decision }, sessionId);
-    console.log(`已处理审批请求：${requestId}`);
+    console.log(`Handled approval request: ${requestId}`);
   } catch (err) {
-    fail(`wave daemon respond 失败：${(err as Error).message}`);
+    fail(`wave daemon respond failed: ${(err as Error).message}`);
   } finally {
     await client?.dispose();
   }

--- a/packages/code/src/daemon/jsonRpcClient.ts
+++ b/packages/code/src/daemon/jsonRpcClient.ts
@@ -76,7 +76,7 @@ export abstract class JsonRpcClient {
   ): Promise<unknown> {
     if (this.closed) {
       throw new Error(
-        "连接已断开。wave 进程已退出，请重启编辑器或检查 CLI 安装。",
+        "Connection closed. The wave process has exited; restart the editor or check your CLI installation.",
       );
     }
     const id = this.nextId++;

--- a/packages/code/src/daemon/socketClient.ts
+++ b/packages/code/src/daemon/socketClient.ts
@@ -16,7 +16,7 @@ export class SocketClient extends JsonRpcClient {
     this.attachReadable(socket);
 
     socket.on("close", () => {
-      this.handleClosed("远端连接已断开。");
+      this.handleClosed("Remote connection closed.");
     });
     socket.on("error", (err) => {
       console.error("[wave-daemon] Socket error:", err.message);
@@ -28,7 +28,7 @@ export class SocketClient extends JsonRpcClient {
   }
 
   dispose(): void {
-    this.handleClosed("远端连接已断开。");
+    this.handleClosed("Remote connection closed.");
     this.socket.destroy();
   }
 }

--- a/packages/code/src/stdio/daemonServer.ts
+++ b/packages/code/src/stdio/daemonServer.ts
@@ -104,7 +104,9 @@ export class DaemonServer {
           probe.once("connect", () => {
             probe.destroy();
             reject(
-              new Error(`另一个 wave daemon 已在 ${this.socketPath} 监听`),
+              new Error(
+                `Another wave daemon is already listening on ${this.socketPath}`,
+              ),
             );
           });
           probe.once("error", (err: NodeJS.ErrnoException) => {

--- a/packages/code/tests/components/InputBox.test.tsx
+++ b/packages/code/tests/components/InputBox.test.tsx
@@ -118,7 +118,7 @@ describe("InputBox Smoke Tests", () => {
 
       await vi.waitFor(() => {
         expect(stripAnsiColors(lastFrame() || "")).toContain(
-          "再次按 Esc 清空输入",
+          "Press Esc again to clear input",
         );
       });
 
@@ -128,7 +128,7 @@ describe("InputBox Smoke Tests", () => {
       await vi.waitFor(() => {
         const output = stripAnsiColors(lastFrame() || "");
         expect(output).not.toContain("hello world");
-        expect(output).not.toContain("再次按 Esc 清空输入");
+        expect(output).not.toContain("Press Esc again to clear input");
       });
     });
 
@@ -146,7 +146,7 @@ describe("InputBox Smoke Tests", () => {
       // The hint must not appear while busy; Esc keeps abort semantics
       await new Promise((resolve) => setTimeout(resolve, 100));
       expect(stripAnsiColors(lastFrame() || "")).not.toContain(
-        "再次按 Esc 清空输入",
+        "Press Esc again to clear input",
       );
     });
 

--- a/packages/code/tests/daemon/commands.test.ts
+++ b/packages/code/tests/daemon/commands.test.ts
@@ -205,9 +205,9 @@ afterEach(async () => {
 
 // ── list ───────────────────────────────────────────────────────
 
-test("list: empty daemon prints 无会话 and exits 0 (idle exit is not an error)", async () => {
+test("list: empty daemon prints No sessions and exits 0 (idle exit is not an error)", async () => {
   await expect(daemonListCommand(socketPath)).rejects.toThrow("exit(0)");
-  expect(logSpy).toHaveBeenCalledWith("无会话");
+  expect(logSpy).toHaveBeenCalledWith("No sessions");
   expect(exitSpy).toHaveBeenCalledWith(0);
 });
 
@@ -234,13 +234,13 @@ test("list: prints a padded table of hosted sessions (in-memory registry)", asyn
 
   await expect(daemonListCommand(socketPath)).rejects.toThrow("exit(0)");
   const out = stdoutLines();
-  expect(out[0]).toContain("会话");
-  expect(out[0]).toContain("工作目录");
+  expect(out[0]).toContain("Session");
+  expect(out[0]).toContain("Working directory");
   expect(out.join("\n")).toContain("session-busy");
-  expect(out.join("\n")).toContain("生成中");
+  expect(out.join("\n")).toContain("generating");
   expect(out.join("\n")).toContain("/repo/a");
   expect(out.join("\n")).toContain("session-idle");
-  expect(out.join("\n")).toContain("空闲");
+  expect(out.join("\n")).toContain("idle");
   expect(out.join("\n")).toContain("/repo/b");
   expect(exitSpy).toHaveBeenCalledWith(0);
 });
@@ -251,9 +251,9 @@ test("list: daemon not running exits 1 with the spec'd hint", async () => {
     `wave-daemon-missing-${process.pid}-${Date.now()}.sock`,
   );
   await expect(daemonListCommand(missing)).rejects.toThrow("exit(1)");
-  expect(stderrText()).toContain(`无法连接 daemon socket ${missing}`);
+  expect(stderrText()).toContain(`Cannot connect to daemon socket ${missing}`);
   expect(stderrText()).toContain(
-    "daemon 未运行？（daemon 空闲 60 秒自动退出）",
+    "is the daemon running? (it auto-exits after 60s idle)",
   );
   expect(stderrText()).toContain("(ENOENT)");
   expect(exitSpy).toHaveBeenCalledWith(1);
@@ -274,10 +274,10 @@ test("status: busy session prints session/workdir/status + recent messages, stay
     daemonStatusCommand(socketPath, "test-session-id"),
   ).rejects.toThrow("exit(0)");
   const out = stdoutLines();
-  expect(out).toContain("会话: test-session-id");
-  expect(out).toContain("工作目录: /test/workdir");
-  expect(out).toContain("状态: 生成中");
-  expect(out).toContain("最近消息 (2):");
+  expect(out).toContain("Session: test-session-id");
+  expect(out).toContain("Working directory: /test/workdir");
+  expect(out).toContain("Status: generating");
+  expect(out).toContain("Recent messages (2):");
   expect(out.join("\n")).toContain("[user] 你好");
   expect(out.join("\n")).toContain("[assistant] 正在处理…");
   expect(exitSpy).toHaveBeenCalledWith(0);
@@ -294,7 +294,7 @@ test("status: busy session prints session/workdir/status + recent messages, stay
   b.close();
 });
 
-test("status: idle session shows 空闲", async () => {
+test("status: idle session shows idle", async () => {
   const client = connectClient(socketPath);
   await client.send({ id: 1, method: "initialize", params: {} });
   client.close();
@@ -302,19 +302,19 @@ test("status: idle session shows 空闲", async () => {
   await expect(
     daemonStatusCommand(socketPath, "test-session-id"),
   ).rejects.toThrow("exit(0)");
-  expect(stdoutLines()).toContain("状态: 空闲");
+  expect(stdoutLines()).toContain("Status: idle");
   expect(exitSpy).toHaveBeenCalledWith(0);
 });
 
-test("status: pending approval shows 等待审批 + the request list", async () => {
+test("status: pending approval shows waiting for approval + the request list", async () => {
   await createPendingRequest("Bash", { command: "ls -la" });
 
   await expect(
     daemonStatusCommand(socketPath, "test-session-id"),
   ).rejects.toThrow("exit(0)");
   const out = stdoutLines();
-  expect(out).toContain("状态: 等待审批");
-  expect(out).toContain("待审批请求:");
+  expect(out).toContain("Status: waiting for approval");
+  expect(out).toContain("Pending approval requests:");
   expect(
     out.some(
       (l) => l.includes("perm_1") && l.includes("Bash") && l.includes("ls -la"),
@@ -335,7 +335,9 @@ test("status: nonexistent session fails, destroys the junk fresh session, regist
   await expect(daemonStatusCommand(socketPath, "ghost")).rejects.toThrow(
     "exit(1)",
   );
-  expect(stderrText()).toContain("会话不存在或未被该 daemon 托管：ghost");
+  expect(stderrText()).toContain(
+    "Session not found or not hosted by this daemon: ghost",
+  );
   expect(exitSpy).toHaveBeenCalledWith(1);
   expect(junk.destroy).toHaveBeenCalled();
 
@@ -432,7 +434,7 @@ test("send: times out and points at respond when a permission approval is pendin
     daemonSendCommand(socketPath, "test-session-id", "继续", { timeout: 0.2 }),
   ).rejects.toThrow("exit(1)");
   expect(stderrText()).toContain(
-    "会话等待权限审批，请通过 `wave daemon respond test-session-id perm_1` 处理后重试",
+    "Session is waiting for permission approval; handle it with `wave daemon respond test-session-id perm_1` and retry",
   );
   expect(exitSpy).toHaveBeenCalledWith(1);
 });
@@ -445,7 +447,9 @@ test("send: times out with the generic message when nothing is pending", async (
   await expect(
     daemonSendCommand(socketPath, "test-session-id", "继续", { timeout: 0.2 }),
   ).rejects.toThrow("exit(1)");
-  expect(stderrText()).toContain("等待回复超时（0.2 秒），未收到助手回复");
+  expect(stderrText()).toContain(
+    "Timed out waiting for a reply (0.2s), no assistant reply received",
+  );
   expect(exitSpy).toHaveBeenCalledWith(1);
 });
 
@@ -461,7 +465,9 @@ test("send: nonexistent session fails without injecting a message", async () => 
   await expect(daemonSendCommand(socketPath, "ghost", "hi")).rejects.toThrow(
     "exit(1)",
   );
-  expect(stderrText()).toContain("会话不存在或未被该 daemon 托管：ghost");
+  expect(stderrText()).toContain(
+    "Session not found or not hosted by this daemon: ghost",
+  );
   expect(exitSpy).toHaveBeenCalledWith(1);
   expect(junk.sendMessage).not.toHaveBeenCalled();
 });
@@ -478,7 +484,7 @@ test("respond: --allow resolves a Bash request with behavior allow", async () =>
       allow: true,
     }),
   ).rejects.toThrow("exit(0)");
-  expect(logSpy).toHaveBeenCalledWith("已处理审批请求：perm_1");
+  expect(logSpy).toHaveBeenCalledWith("Handled approval request: perm_1");
   await expect(permissionPromise).resolves.toEqual({ behavior: "allow" });
   expect(exitSpy).toHaveBeenCalledWith(0);
 });
@@ -555,7 +561,7 @@ test("respond: AskUserQuestion without --answer fails", async () => {
     }),
   ).rejects.toThrow("exit(1)");
   expect(stderrText()).toContain(
-    "AskUserQuestion 请求需要 --answer 提供答案 JSON",
+    "AskUserQuestion requests require --answer with the answer JSON",
   );
   expect(exitSpy).toHaveBeenCalledWith(1);
 });
@@ -569,7 +575,7 @@ test("respond: AskUserQuestion with invalid JSON --answer fails", async () => {
       answer: "not-json",
     }),
   ).rejects.toThrow("exit(1)");
-  expect(stderrText()).toContain("--answer 不是合法的 JSON");
+  expect(stderrText()).toContain("--answer is not valid JSON");
   expect(exitSpy).toHaveBeenCalledWith(1);
 });
 
@@ -617,7 +623,7 @@ test("respond: invalid --mode fails with the accepted modes listed", async () =>
     }),
   ).rejects.toThrow("exit(1)");
   expect(stderrText()).toContain(
-    "无效的权限模式：bogus（可选：default、bypassPermissions、acceptEdits、plan、dontAsk）",
+    "Invalid permission mode: bogus (options: default, bypassPermissions, acceptEdits, plan, dontAsk)",
   );
   expect(exitSpy).toHaveBeenCalledWith(1);
 });
@@ -630,7 +636,7 @@ test("respond: unknown requestId fails — the server would silently ignore it",
       allow: true,
     }),
   ).rejects.toThrow("exit(1)");
-  expect(stderrText()).toContain("该请求不存在或已处理");
+  expect(stderrText()).toContain("Request not found or already handled");
   expect(exitSpy).toHaveBeenCalledWith(1);
 });
 
@@ -661,7 +667,9 @@ test("respond: another session's request is refused and left untouched", async (
   await expect(
     daemonRespondCommand(socketPath, "s2", "perm_1", { allow: true }),
   ).rejects.toThrow("exit(1)");
-  expect(stderrText()).toContain("会话不存在或未被该 daemon 托管");
+  expect(stderrText()).toContain(
+    "Session not found or not hosted by this daemon",
+  );
   expect(exitSpy).toHaveBeenCalledWith(1);
 
   // The s1 request was never answered.
@@ -677,6 +685,6 @@ test("respond: requires exactly one of --allow / --deny", async () => {
   await expect(
     daemonRespondCommand(socketPath, "test-session-id", "perm_1", {}),
   ).rejects.toThrow("exit(1)");
-  expect(stderrText()).toContain("请指定 --allow 或 --deny（二选一）");
+  expect(stderrText()).toContain("Specify either --allow or --deny");
   expect(exitSpy).toHaveBeenCalledWith(1);
 });

--- a/packages/code/tests/stdio/daemonServer.test.ts
+++ b/packages/code/tests/stdio/daemonServer.test.ts
@@ -278,7 +278,7 @@ test("start() unlinks a non-socket stale file at the socket path", async () => {
 test("start() rejects when a live daemon already holds the socket", async () => {
   const second = new DaemonServer({ socketPath });
   await expect(second.start()).rejects.toThrow(
-    `另一个 wave daemon 已在 ${socketPath} 监听`,
+    `Another wave daemon is already listening on ${socketPath}`,
   );
 });
 


### PR DESCRIPTION
## Summary

CLI（packages/code）用户可见文案全部英文化，与 GUI（webview/desktop/vscode）保持中文的产品分工一致：语言跟界面走——终端开发者工具英文，GUI 产品中文。

## Changes

- `wave daemon list/status/send/respond` 全部输出与错误提示英文化（状态 generating/idle/waiting for approval、表头、超时、审批提示等 ~26 处）
- socket / JSON-RPC 连接错误、daemon server 启动错误英文化
- InputBox Esc 清空提示、SessionSelector 快捷键提示英文化
- 同步更新 3 个测试文件断言（消息内容等测试数据保持原样）
- `docs/specs/ui/daemon-command.md` 引用的 CLI 输出示例文案同步为英文

## Verification

- packages/code 全量测试 99 文件 / 1399 用例通过
- type-check 全仓库通过（pre-commit hook）
- docs 链接检查通过
- spec-count 校验通过（72 规格 / 380 故事 / 1465 场景）