### PR TITLE
fix(code): force React production build to stop perf_hooks measure leak

### DIFF
--- a/packages/code/bin/wave-code.js
+++ b/packages/code/bin/wave-code.js
@@ -21,6 +21,14 @@ if (process.argv.slice(2).some((a) => versionArgs.includes(a))) {
   process.exit(0);
 }
 
+// Force React's production build. react-reconciler picks its development build
+// unless NODE_ENV === "production"; the dev build records a performance.measure()
+// entry for every component render into Node's global perf buffer (never
+// cleared), so long CLI sessions accumulate ~150MB per million entries and
+// eventually trigger MaxPerformanceEntryBufferExceededWarning. Must be set
+// before the dynamic import below evaluates the app graph.
+process.env.NODE_ENV ||= "production";
+
 // Import and start the CLI
 import("../dist/index.js")
   .then(async ({ main }) => {

--- a/packages/code/package.json
+++ b/packages/code/package.json
@@ -29,7 +29,7 @@
     "README.md"
   ],
   "scripts": {
-    "wave": "NODE_OPTIONS='--heapsnapshot-near-heap-limit=1' tsx --tsconfig tsconfig.dev.json src/index.ts",
+    "wave": "NODE_OPTIONS='--heapsnapshot-near-heap-limit=1' tsx --tsconfig tsconfig.dev.json src/dev-entry.ts",
     "build": "rimraf dist && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "type-check": "tsc --noEmit --incremental",
     "watch": "tsc -p tsconfig.build.json --watch & tsc-alias -p tsconfig.build.json --watch",

--- a/packages/code/src/dev-entry.ts
+++ b/packages/code/src/dev-entry.ts
@@ -1,0 +1,22 @@
+// Dev bootstrap for `pnpm run wave` (tsx).
+//
+// React/ink (via react-reconciler) load their development build when NODE_ENV
+// is not "production"; that build records a performance.measure() entry for
+// every component render into Node's global perf buffer (never cleared), which
+// after 1M entries triggers MaxPerformanceEntryBufferExceededWarning and leaks
+// ~150MB per million entries. The production build has no such instrumentation.
+//
+// This must run BEFORE importing ./index.js: ESM static imports are hoisted, so
+// setting NODE_ENV inside index.ts itself would be too late (react-reconciler
+// is already evaluated). An explicit NODE_ENV (e.g. NODE_ENV=development) is
+// respected, to allow debugging with React dev-only diagnostics when needed.
+if (!process.env.NODE_ENV) {
+  process.env.NODE_ENV = "production";
+}
+
+const { main } = await import("./index.js");
+
+main().catch((error) => {
+  console.error("Failed to start WAVE Code:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

During long CLI sessions, Node emits `MaxPerformanceEntryBufferExceededWarning` (`1000001 measure entries added to the global performance entry buffer`).

### Root cause

- ink renders through `react-reconciler`, which loads its **development build** whenever `NODE_ENV !== 'production'` (wave never set it).
- The dev build records a `performance.measure()` entry for **every component render** (User Timing instrumentation, gated on `console.timeStamp` + `performance.measure` — both present in Node).
- After the streaming throttle removal (#1795) the CLI re-renders at raw LLM output frequency, so long sessions accumulate millions of entries. Nothing ever calls `performance.clearMeasures()`, so the global buffer (default max 1,000,000) overflows — ~150MB RSS per million entries, growing for the lifetime of the process.

### Change

Force React's production build (which has no such instrumentation) by setting `process.env.NODE_ENV ||= 'production'` before the app graph loads:

- `bin/wave-code.js`: covers the installed CLI, desktop-spawned stdio (binaryResolver → bin), and npm-link.
- `src/dev-entry.ts` (new): dev bootstrap for `pnpm run wave` — ESM static imports are hoisted, so setting NODE_ENV inside `index.ts` itself would be too late; the bootstrap sets it before dynamically importing `index.js`. An explicit `NODE_ENV` is still respected (e.g. `NODE_ENV=development` keeps React dev diagnostics).

### Verification

- 50 ink renders: 156 measure entries with NODE_ENV unset vs **0** with `NODE_ENV=production`.
- `tsx src/dev-entry.ts -v` and `node bin/wave-code.js --help` both load the full graph fine.
- No wave code branches on `NODE_ENV === 'development'` (only `'test'`, set by vitest); ink itself doesn't read NODE_ENV.