### PR TITLE
fix(code): drop NODE_OPTIONS prefix from wave dev script for Windows cmd

### DIFF
--- a/packages/code/package.json
+++ b/packages/code/package.json
@@ -29,7 +29,7 @@
     "README.md"
   ],
   "scripts": {
-    "wave": "NODE_OPTIONS='--heapsnapshot-near-heap-limit=1' tsx --tsconfig tsconfig.dev.json src/dev-entry.ts",
+    "wave": "tsx --tsconfig tsconfig.dev.json src/dev-entry.ts",
     "build": "rimraf dist && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "type-check": "tsc --noEmit --incremental",
     "watch": "tsc -p tsconfig.build.json --watch & tsc-alias -p tsconfig.build.json --watch",


### PR DESCRIPTION
## Summary

`pnpm run wave` failed on Windows: pnpm executes scripts via cmd.exe, which does not understand the bash-style inline env assignment in `NODE_OPTIONS='--heapsnapshot-near-heap-limit=1' tsx ...`, so cmd treated it as an unknown command (`'NODE_OPTIONS' 不是内部或外部命令`).

The `--heapsnapshot-near-heap-limit` flag was a debugging aid and is not required for normal dev runs — drop the prefix entirely instead of adding cross-env.

### Change

`packages/code/package.json`: `wave` script is now plain `tsx --tsconfig tsconfig.dev.json src/dev-entry.ts` — shell-agnostic, works in cmd and sh.

### Verification

- `cmd //c "pnpm run wave --help"`: script executes under real cmd.exe, yargs help prints (previously: command-not-found error).
- `tsx src/dev-entry.ts -v` prints 1.0.10, exit 0.
- Pre-commit hooks (full type-check + lint-staged) pass.