### PR TITLE
fix(code): stop printing worktree removal fallback to the user

### DIFF
--- a/packages/code/src/utils/worktree.ts
+++ b/packages/code/src/utils/worktree.ts
@@ -7,6 +7,7 @@ import {
   getGitMainRepoRoot,
   performPostCreationSetup,
 } from "wave-agent-sdk";
+import { logger } from "./logger.js";
 
 // Never use execFileSync here: the shared `wave --stdio` process handles all
 // desktop sessions, so a synchronous git call (especially a multi-second
@@ -325,10 +326,9 @@ export async function removeWorktree(session: WorktreeSession): Promise<void> {
       },
     );
   } catch (error: unknown) {
-    console.warn(
-      `git worktree remove failed, falling back to fs.rmSync: ${
-        (error as Error).message
-      }`,
+    logger.warn(
+      "git worktree remove failed, falling back to fs.rmSync:",
+      error,
     );
     try {
       fs.rmSync(toExtendedLengthPath(session.path), {
@@ -336,9 +336,7 @@ export async function removeWorktree(session: WorktreeSession): Promise<void> {
         force: true,
       });
     } catch (rmError: unknown) {
-      console.error(
-        `Failed to remove worktree or branch: ${(rmError as Error).message}`,
-      );
+      logger.error("Failed to remove worktree or branch:", rmError);
     }
     // git removes worktree metadata before the working directory; prune any
     // leftovers in case git failed before deleting them.

--- a/packages/code/tests/utils/worktree.test.ts
+++ b/packages/code/tests/utils/worktree.test.ts
@@ -7,6 +7,7 @@ import {
   removeWorktree,
   validateWorktreeSlug,
 } from "../../src/utils/worktree.js";
+import { logger } from "../../src/utils/logger.js";
 import {
   getDefaultRemoteBranch,
   getGitMainRepoRoot,
@@ -379,7 +380,7 @@ describe("worktree utils", () => {
     });
 
     it("should fall back to fs.rmSync and still delete the branch when git removal fails", async () => {
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
       git.handler = (_cmd, args) => {
         if (args[0] === "worktree" && args[1] === "remove") {
           throw gitError("Filename too long", "");
@@ -389,9 +390,7 @@ describe("worktree utils", () => {
 
       await removeWorktree(session);
 
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("falling back to fs.rmSync"),
-      );
+      expect(warnSpy.mock.calls[0][0]).toContain("falling back to fs.rmSync");
       const rmCalls = vi.mocked(fs.rmSync).mock.calls;
       expect(rmCalls).toHaveLength(1);
       expect(rmCalls[0][1]).toMatchObject({ recursive: true, force: true });
@@ -410,10 +409,8 @@ describe("worktree utils", () => {
     });
 
     it("should log error but still delete the branch when git and fs.rmSync both fail", async () => {
-      const consoleSpy = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const loggerSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
       git.handler = (_cmd, args) => {
         if (args[0] === "worktree" && args[1] === "remove") {
           throw gitError("Filename too long", "");
@@ -426,14 +423,14 @@ describe("worktree utils", () => {
 
       await removeWorktree(session);
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to remove worktree or branch"),
+      expect(loggerSpy.mock.calls[0][0]).toContain(
+        "Failed to remove worktree or branch",
       );
       // Branch deletion still runs even when both removal attempts fail
       expect(gitCallsWith(["branch", "-D", "worktree-my-feat"])).toHaveLength(
         1,
       );
-      consoleSpy.mockRestore();
+      loggerSpy.mockRestore();
       warnSpy.mockRestore();
     });
   });


### PR DESCRIPTION
When `git worktree remove` fails on Windows (MAX_PATH / `Filename too long`), `removeWorktree` falls back to `fs.rmSync` with an extended-length path. The fallback message was written to the terminal via `console.warn`/`console.error`, surfacing in the desktop UI whenever a worktree session exit needs the fallback.

Route it through the file logger instead: removal stays best-effort and silent (matching Claude Code's silent degradation), and the failure remains traceable in the log file.

- `packages/code/src/utils/worktree.ts`: `console.warn`/error → `logger.warn`/error
- `packages/code/tests/utils/worktree.test.ts`: assertions updated to spy on the logger
- 26 tests pass, tsc + eslint clean