### PR TITLE
chore(code): drop esbuild 1MB size warning from bundle output

### DIFF
--- a/packages/code/scripts/bundle.mjs
+++ b/packages/code/scripts/bundle.mjs
@@ -47,7 +47,11 @@ await build({
   // development-mode builds, which cuts Node parse/compile time at startup.
   minify: true,
   define: { "process.env.NODE_ENV": '"production"' },
-  logLevel: "info",
+  // "warning" (not "info") skips esbuild's output summary table, whose
+  // "2.8mb ⚠️" size warning is hardcoded at a 1MB threshold and cannot be
+  // suppressed via logOverride. The script's own console.log below already
+  // reports the output size; real warnings/errors still print.
+  logLevel: "warning",
 });
 
 const size = fs.statSync(outfile).size;


### PR DESCRIPTION
Remove the hardcoded `⚠️` size warning from esbuild's build summary by setting `logLevel: "warning"` in `packages/code/scripts/bundle.mjs` (was `"info"`).

The ⚠️ icon is not a configurable warning — esbuild hardcodes a 1MB threshold (`sizeWarningThreshold` in `internal/logger/logger.go`) and renders it in the info-level summary table. It's not in `result.warnings`, so `logOverride` cannot suppress it. Lowering to `warning` keeps real warnings/errors while the script's own `bundled wave-code in ...` line already reports output size — same pattern evanw recommends (evanw/esbuild#512) and tsup uses (`logLevel: 'error'` + custom logging).