### PR TITLE
fix(desktop): strip ANSI/OSC escapes from remote probe output

### DIFF
--- a/packages/desktop/src/main/remoteCli.ts
+++ b/packages/desktop/src/main/remoteCli.ts
@@ -70,6 +70,29 @@ function describeError(error: unknown): string {
   return lines.find((line) => !JOB_CONTROL_NOISE.test(line.trim())) ?? lines[0];
 }
 
+/**
+ * Strip ANSI/OSC escape sequences from remote probe output. Some login shells
+ * (zsh with iTerm2/WezTerm-style shell integration) write OSC 1337 markers to
+ * stdout on every `-lic` invocation — without a TTY the shell never hides
+ * them. They would break every strict parser below (`^v?\d+` version match,
+ * first-line home dir, the WAVE_REMOTE_FILE_V1 header…).
+ * ESC/BEL are interpolated by char code so the regex source carries no
+ * control-character escapes (the no-control-regex lint rejects them).
+ */
+const ESC = String.fromCharCode(27);
+const BEL = String.fromCharCode(7);
+const ANSI_ESCAPE_RE = new RegExp(
+  `${ESC}\\]` +
+    `[^${BEL}${ESC}]*` +
+    `(?:${BEL}|${ESC}\\\\)` +
+    `|${ESC}\\[[0-9;?]*[ -/]*[@-~]`,
+  "g",
+);
+
+export function stripAnsiEscapes(text: string): string {
+  return text.replace(ANSI_ESCAPE_RE, "");
+}
+
 /** Run a remote probe command under the host's login shell. */
 async function remoteCommand(host: string, command: string): Promise<string[]> {
   return buildSshSpawnArgs(host, await withRemoteLoginShell(host, command));
@@ -96,7 +119,7 @@ export async function resolveRemoteWaveBinary(
         timeout: PROBE_TIMEOUT_MS,
       },
     );
-    nodeVersion = stdout.trim();
+    nodeVersion = stripAnsiEscapes(stdout).trim();
   } catch {
     throw new Error(
       `主机 ${host} 上未检测到 Node.js。请先在远端安装 Node.js ≥ ${REMOTE_NODE_MIN_MAJOR}（https://nodejs.org）后重试`,
@@ -118,7 +141,7 @@ export async function resolveRemoteWaveBinary(
           timeout: PROBE_TIMEOUT_MS,
         },
       );
-      return stdout.trim();
+      return stripAnsiEscapes(stdout).trim();
     } catch {
       return "";
     }
@@ -167,7 +190,7 @@ async function getRemoteCliVersion(
         timeout: PROBE_TIMEOUT_MS,
       },
     );
-    const line = stdout.trim().split("\n")[0]?.trim();
+    const line = stripAnsiEscapes(stdout).trim().split("\n")[0]?.trim();
     if (!line) return null;
     // `wave -v` prints the bare version; tolerate a leading "v" just in case.
     return line.replace(/^v/, "");
@@ -296,7 +319,9 @@ export async function listRemoteDirs(
         timeout: PROBE_TIMEOUT_MS,
       },
     );
-    const lines = stdout.split("\n").filter((line) => line.length > 0);
+    const lines = stripAnsiEscapes(stdout)
+      .split("\n")
+      .filter((line) => line.length > 0);
     const resolvedPath = lines[0] ?? dir;
     const dirs = lines
       .slice(1)
@@ -373,7 +398,7 @@ export async function readRemoteFile(
         maxBuffer: 4 * 1024 * 1024,
       },
     );
-    const lines = stdout.split("\n");
+    const lines = stripAnsiEscapes(stdout).split("\n");
     if (lines[0] !== "WAVE_REMOTE_FILE_V1") {
       throw new Error("远端返回了无法识别的响应");
     }
@@ -428,7 +453,7 @@ export async function getRemoteHomeDir(host: string): Promise<string> {
         timeout: PROBE_TIMEOUT_MS,
       },
     );
-    const home = stdout.trim();
+    const home = stripAnsiEscapes(stdout).trim();
     if (!home) throw new Error("empty");
     return home;
   } catch {

--- a/packages/desktop/tests/remoteCli.test.ts
+++ b/packages/desktop/tests/remoteCli.test.ts
@@ -55,6 +55,16 @@ function stubExec(results: StubResult[]) {
 const CONNECT_FAIL = new Error("ssh: connect to host failed");
 CONNECT_FAIL.name = "Error";
 
+/**
+ * Real stdout pollution from `zsh -lic` without a TTY on the user's remote
+ * hosts: iTerm2/WezTerm-style shell integration writes OSC 1337 markers before
+ * every command's output. Verified against liuyiqi@matrix 2026-08-15.
+ */
+const OSC1337_PREFIX =
+  "\x1b]1337;RemoteHost=liuyiqi@ubuntu.ubuntu-domain\x07" +
+  "\x1b]1337;CurrentDir=/home/liuyiqi\x07" +
+  "\x1b]1337;ShellIntegrationVersion=14;shell=zsh\x07";
+
 beforeEach(() => {
   h.execFile.mockReset();
   resetRemoteShellCache();
@@ -71,6 +81,22 @@ describe("resolveRemoteWaveBinary", () => {
     expect(info).toEqual({
       binaryPath: "/usr/local/bin/wave",
       nodeVersion: "v22.3.0",
+    });
+  });
+
+  it("strips OSC shell-integration markers from node -v and command -v output", async () => {
+    // `zsh -lic` on matrix prints OSC 1337 markers to stdout before each
+    // command's real output; the strict `^v?\d+` version parse used to hit the
+    // marker line and misreport a healthy v22.23.2 as "版本过低".
+    stubExec([
+      LOGIN_SHELL,
+      { stdout: `${OSC1337_PREFIX}v22.23.2\n` },
+      { stdout: `${OSC1337_PREFIX}/usr/local/bin/wave\n` },
+    ]);
+    const info = await resolveRemoteWaveBinary("prod");
+    expect(info).toEqual({
+      binaryPath: "/usr/local/bin/wave",
+      nodeVersion: "v22.23.2",
     });
   });
 
@@ -258,6 +284,20 @@ describe("ensureRemoteCliUpToDate", () => {
     });
   });
 
+  it("parses a polluted wave -v line (OSC prefix) so the up-to-date binary is kept", async () => {
+    stubExec([
+      LOGIN_SHELL,
+      { stdout: "v22.0.0" },
+      { stdout: "/usr/local/bin/wave" },
+      { stdout: `${OSC1337_PREFIX}1.0.0\n` },
+    ]);
+    const result = await ensureRemoteCliUpToDate("prod", "1.0.0");
+    expect(result).toEqual({
+      binaryPath: "/usr/local/bin/wave",
+      upgraded: false,
+    });
+  });
+
   it("upgrades via npm when the remote version is older than the target", async () => {
     stubExec([
       LOGIN_SHELL,
@@ -328,6 +368,20 @@ describe("ensureRemoteDaemon", () => {
       ((c[1] as string[]).at(-1) as string).includes("nohup"),
     );
     expect(start).toBeUndefined();
+  });
+
+  it("strips OSC markers from $HOME so the daemon socket path stays clean", async () => {
+    stubExec([
+      LOGIN_SHELL,
+      { stdout: `${OSC1337_PREFIX}/home/user\n` }, // echo $HOME
+      { stdout: "v22.0.0" }, // node -v
+      { stdout: "/usr/local/bin/wave" }, // command -v
+      { stdout: "1.0.0\n" }, // wave -v
+      { stdout: "" }, // daemon socket probe — alive
+    ]);
+    await expect(ensureRemoteDaemon("prod", "1.0.0")).resolves.toBe(
+      "/home/user/.wave/daemon.sock",
+    );
   });
 
   it("launches the daemon when none is running", async () => {
@@ -435,6 +489,18 @@ describe("listRemoteDirs", () => {
     });
   });
 
+  it("strips OSC markers from the listing before parsing", async () => {
+    stubExec([
+      LOGIN_SHELL,
+      { stdout: `${OSC1337_PREFIX}/home/user/repo\nb-dir\nA-dir\n` },
+    ]);
+    const result = await listRemoteDirs("prod", "/home/user/repo");
+    expect(result).toEqual({
+      resolvedPath: "/home/user/repo",
+      dirs: ["A-dir", "b-dir"],
+    });
+  });
+
   it("normalizes ~ and relative components via cd + pwd", async () => {
     stubExec([LOGIN_SHELL, { stdout: "/home/alice\nproj\n" }]);
     const result = await listRemoteDirs("prod", "~/code/..");
@@ -508,6 +574,23 @@ describe("readRemoteFile", () => {
     expect(
       Buffer.from(result.contentBase64 ?? "", "base64").toString("utf8"),
     ).toBe(content);
+  });
+
+  it("strips OSC markers before matching the V1 header", async () => {
+    stubExec([
+      LOGIN_SHELL,
+      {
+        stdout: `${OSC1337_PREFIX}WAVE_REMOTE_FILE_V1\ntype=text\nmime=text/plain\ntotal=1\ntruncated=0\n${base64("hi\n")}\n`,
+      },
+    ]);
+    const result = await readRemoteFile("prod", "/home/user/a.md");
+    expect(result).toEqual({
+      type: "text",
+      mime: "text/plain",
+      totalLines: 1,
+      truncated: false,
+      contentBase64: base64("hi\n"),
+    });
   });
 
   it("marks the payload truncated when the header says so", async () => {


### PR DESCRIPTION
## 背景

桌面端在 matrix 远程主机恢复对话时报错：远端 Node.js 版本过低（v22.23.2，需要 >= 22），并提示手动升级 wave-code。

## 根因

matrix 主机的 zsh 以 login+interactive（zsh -lic）启动时，iTerm2 shell integration 会向 stdout 打印 OSC 1337 序列（RemoteHost/CurrentDir/ShellIntegrationVersion，官方脚本设计为无条件输出）。桌面端远程探测恰好用 zsh -lic（为了加载 nvm 的 node 22），序列混入 node -v 输出，使 remoteCli.ts 用 ^v?\d+ 从第一行提取主版本号时解析失败（匹配到转义序列，major 为 NaN），v22.23.2 被误判为版本过低。实际 node 与 wave-code 均已满足要求。

## 修复

- remoteCli.ts 新增 stripAnsiEscapes，清洗所有远程 stdout 解析点：node -v / command -v wave / wave -v / echo $HOME / 目录列表 / 文件读取 V1 header
- ESC/BEL 通过 String.fromCharCode 插值构造正则，规避 no-control-regex lint
- 5 个 TDD 用例覆盖（使用从 matrix 实测的真实 OSC 1337 fixture），全量 desktop 测试 511 通过