### PR TITLE
fix(code): delete LongText/Image placeholder tokens as whole blocks on backspace

### DIFF
--- a/docs/specs/ui/input-editing-keys.md
+++ b/docs/specs/ui/input-editing-keys.md
@@ -77,12 +77,33 @@ order: 215
 
 ---
 
+### 用户故事：长文本/图片占位符参与删除键（优先级：P1）
+
+作为粘贴了长文本（被折叠为 `[LongText#N]`）或附加了图片（`[Image #N]`）的用户，我希望 Backspace 能整块删除占位符、Ctrl+U/K/W 将其作为普通字符串参与切片删除，以便粘贴的长文本能被编辑键可靠清除，而不是只能按 Enter 提交或留下残缺占位符片段。
+
+**为什么是这个优先级**：当前 Backspace 对 `[LongText#N]` 逐字符删除，一次只删一个字符，且会留下 `[LongText#1` 这类残缺文本，随后按 Enter 会把残缺占位符当字面文本发送，原文（已存入 `longTextMap`）丢失。对齐 Claude Code：Backspace 走 `deleteTokenBefore` 正则整块删除（`Cursor.ts:937-969`，正则覆盖 `[Pasted text #N]`/`[Image #N]` 等 token，且仅当光标位于 token 末尾、后随空白或行尾时触发）；Ctrl+U/K/W 为纯文本切片/词删除（`useTextInput.ts:224-238` 的 `killToLineStart`/`killToLineEnd`/`killWordBefore`），占位符就是 input text 里的普通字符串，光标位于占位符中间时切片会留下残缺片段（与 CC 一致）；原始 DEL 字符（`\x7f`，SSH/tmux 退格）同样按 token 优先删除（`useTextInput.ts:442-465`）。不修复则长文本粘贴后编辑不可用。
+
+**独立测试**：粘贴超长文本折叠为 `[LongText#1]` 后按 Backspace，验证一次删除整个占位符且 `longTextMap` 条目被清理；光标位于占位符中间时 Backspace 仅删除单字符；Ctrl+U/K/W 按普通文本切片删除。
+
+**验收场景**：
+
+1. **假设**输入框中有 `prefix [LongText#1]` 且光标位于占位符之后（行尾），**当**按 Backspace 时，**则**整个 `[LongText#1]` 占位符被删除，文本变为 `prefix `，且 `longTextMap` 中对应条目被清理。
+2. **假设**输入框中有 `[LongText#1] suffix` 且光标位于占位符之后（占位符后随空白），**当**按 Backspace 时，**则**整个 `[LongText#1]` 占位符被删除，文本变为 ` suffix`。
+3. **假设**光标位于 `[LongText#1]` 占位符中间，**当**按 Backspace 时，**则**仅删除光标前一个字符，不触发整块删除（对齐 CC 的 word-boundary 守卫）。
+4. **假设**输入框中有 `[LongText#1]x`（占位符后紧跟非空白字符）且光标位于 `]` 之后，**当**按 Backspace 时，**则**仅删除光标前一个字符（CC 仅当光标后是空白或行尾时触发整块删除）。
+5. **假设**输入框中有 `[LongText#1]` 且光标位于行尾，**当**按 Ctrl+U 时，**则**占位符作为普通字符串随整行删除，输入框清空。
+6. **假设**输入框中有 `hello [LongText#1]` 且光标位于行尾，**当**按 Ctrl+W 时，**则**删除光标前一个词（含无空格的整个占位符），文本变为 `hello `。
+7. **假设**光标位于 `[LongText#1]` 占位符中间，**当**按 Ctrl+K 时，**则**纯文本切片删除光标后内容，占位符可能被切成残缺片段（如 `[Long`），与 CC 行为一致。
+8. **假设**输入框中有 `[LongText#1]` 且光标位于行尾，**当**收到含 `\x7f` 的原始 DEL chunk 时，**则**每个 DEL 按 token 优先整块删除占位符（对齐 CC `useTextInput.ts:442-465`）。
+
+---
+
 ### 边界情况
 
 - **粘贴与退格判定**：`isPasteOperation`（输入长度 > 1 且不含退格语义）与 `\x7f` 过滤需要互斥——包含 `\x7f` 的多字符 chunk 必须走退格路径而非粘贴路径。
 - **Ctrl 组合键与现有快捷键冲突**：Ctrl+A/E 与终端行编辑默认行为一致；Ctrl+C 保留现有中止语义不纳入本次范围。
 - **历史导航**：Esc 双击清空保存原内容到历史后，上/下方向键应能找回该内容。
-- **长文本占位符**：输入框含 `[LongText#N]` 占位符时，Ctrl+U/K 按占位符整体为单位删除（对齐 CC 的 `deleteTokenBefore`），不删除占位符内部字符。
+- **长文本/图片占位符**：`[LongText#N]`/`[Image #N]` 是输入框中的普通字符串。Ctrl+U/K/W 走纯文本切片/词删除（光标在占位符中间时留下残缺片段，与 CC 一致）；Backspace 与原始 DEL 走 `deleteTokenBefore` 正则整块删除（对齐 CC `Cursor.ts:937-969`）——光标位于占位符末尾且后随空白或行尾时触发，并清理 `longTextMap` 条目。
 - **待澄清**：空闲状态下输入框有内容但存在排队消息（`hasQueuedMessages`）时，Esc 是否应中止排队消息？[待澄清]
 
 ## 假设

--- a/packages/code/src/managers/inputReducer.ts
+++ b/packages/code/src/managers/inputReducer.ts
@@ -256,6 +256,53 @@ function insertTextWithPlaceholder(
 }
 
 /**
+ * Delete a placeholder token ([LongText#N] / [Image #N]) as a whole block
+ * when the cursor sits at the token's end, aligned with Claude Code's
+ * Cursor.deleteTokenBefore (Cursor.ts:937-969): the token must be preceded
+ * by start-of-input or whitespace and followed by whitespace or EOL, so a
+ * mid-token cursor or a token glued to following text falls back to
+ * one-character deletion. Also drops the deleted token's longTextMap entry.
+ * Returns null when no token is at the cursor position.
+ */
+function deleteTokenBefore(
+  inputText: string,
+  cursorPosition: number,
+  longTextMap: Record<string, string>,
+): {
+  inputText: string;
+  cursorPosition: number;
+  longTextMap: Record<string, string>;
+} | null {
+  if (cursorPosition <= 0) {
+    return null;
+  }
+
+  // Word-boundary guard (aligned with CC): only trigger when the char after
+  // the cursor is whitespace or the end of the string.
+  const charAfter = inputText[cursorPosition];
+  if (charAfter !== undefined && !/\s/.test(charAfter)) {
+    return null;
+  }
+
+  const textBefore = inputText.slice(0, cursorPosition);
+  const tokenMatch = textBefore.match(/(^|\s)\[(LongText#\d+|Image #\d+)\]$/);
+  if (!tokenMatch) {
+    return null;
+  }
+
+  const tokenStart = tokenMatch.index! + tokenMatch[1]!.length;
+  const token = tokenMatch[0].slice(tokenMatch[1]!.length);
+  const newLongTextMap = { ...longTextMap };
+  delete newLongTextMap[token];
+
+  return {
+    inputText: inputText.slice(0, tokenStart) + inputText.slice(cursorPosition),
+    cursorPosition: tokenStart,
+    longTextMap: newLongTextMap,
+  };
+}
+
+/**
  * Submit the current input text: extract [Image #N] references, route /btw
  * and CLI-internal slash commands, otherwise send as a message. Returns null
  * when there is nothing to submit (empty text).
@@ -823,7 +870,9 @@ export function inputReducer(
       // chunk (e.g. "\x7f\x7f") that ink cannot parse into a key event, so it
       // arrives as raw input and would otherwise be treated as a paste and
       // inserted literally. Treat each DEL as a synchronous backspace instead
-      // (aligned with Claude Code Issue #1853).
+      // (aligned with Claude Code Issue #1853). Each DEL deletes a placeholder
+      // token as a whole block first, falling back to one character (aligned
+      // with Claude Code's useTextInput.ts:442-465).
       if (!key.backspace && !key.delete && input.includes("\x7f")) {
         const delCount = (input.match(/\x7f/g) || []).length;
 
@@ -834,74 +883,92 @@ export function inputReducer(
           };
         }
 
-        if (state.cursorPosition > 0) {
-          const newCursorPosition = Math.max(
-            0,
-            state.cursorPosition - delCount,
-          );
-          const newInputText =
-            state.inputText.substring(0, newCursorPosition) +
-            state.inputText.substring(state.cursorPosition);
-
-          const newState = {
-            ...state,
-            inputText: newInputText,
-            cursorPosition: newCursorPosition,
-            historyIndex: -1,
-          };
-
-          // Deactivate selectors if their trigger character was deleted
-          if (
-            newState.showFileSelector &&
-            newCursorPosition <= newState.atPosition
-          ) {
-            newState.showFileSelector = false;
-            newState.atPosition = -1;
-            newState.fileSearchQuery = "";
-            newState.isFileSearching = false;
-          }
-          if (
-            newState.showCommandSelector &&
-            newCursorPosition <= newState.slashPosition
-          ) {
-            newState.showCommandSelector = false;
-            newState.slashPosition = -1;
-            newState.commandSearchQuery = "";
-          }
-
-          // Reactivate selectors if cursor is within a trigger word
-          const atPos = getAtSelectorPosition(newInputText, newCursorPosition);
-          if (atPos !== -1 && !state.showFileSelector) {
-            newState.showFileSelector = true;
-            newState.atPosition = atPos;
-            newState.isFileSearching = true;
-          }
-          const slashPos = getSlashSelectorPosition(
+        let newInputText = state.inputText;
+        let newCursorPosition = state.cursorPosition;
+        let newLongTextMap = state.longTextMap;
+        for (let i = 0; i < delCount; i++) {
+          const tokenDeletion = deleteTokenBefore(
             newInputText,
             newCursorPosition,
+            newLongTextMap,
           );
-          if (slashPos !== -1 && !state.showCommandSelector) {
-            newState.showCommandSelector = true;
-            newState.slashPosition = slashPos;
+          if (tokenDeletion) {
+            newInputText = tokenDeletion.inputText;
+            newCursorPosition = tokenDeletion.cursorPosition;
+            newLongTextMap = tokenDeletion.longTextMap;
+          } else if (newCursorPosition > 0) {
+            newInputText =
+              newInputText.substring(0, newCursorPosition - 1) +
+              newInputText.substring(newCursorPosition);
+            newCursorPosition -= 1;
           }
-
-          // Update queries
-          if (newState.showFileSelector && newState.atPosition >= 0) {
-            newState.fileSearchQuery = newInputText.substring(
-              newState.atPosition + 1,
-              newCursorPosition,
-            );
-          }
-          if (newState.showCommandSelector && newState.slashPosition >= 0) {
-            newState.commandSearchQuery = newInputText.substring(
-              newState.slashPosition + 1,
-              newCursorPosition,
-            );
-          }
-
-          return newState;
         }
-        return state;
+
+        if (
+          newInputText === state.inputText &&
+          newCursorPosition === state.cursorPosition
+        ) {
+          return state;
+        }
+
+        const newState = {
+          ...state,
+          inputText: newInputText,
+          cursorPosition: newCursorPosition,
+          longTextMap: newLongTextMap,
+          historyIndex: -1,
+        };
+
+        // Deactivate selectors if their trigger character was deleted
+        if (
+          newState.showFileSelector &&
+          newCursorPosition <= newState.atPosition
+        ) {
+          newState.showFileSelector = false;
+          newState.atPosition = -1;
+          newState.fileSearchQuery = "";
+          newState.isFileSearching = false;
+        }
+        if (
+          newState.showCommandSelector &&
+          newCursorPosition <= newState.slashPosition
+        ) {
+          newState.showCommandSelector = false;
+          newState.slashPosition = -1;
+          newState.commandSearchQuery = "";
+        }
+
+        // Reactivate selectors if cursor is within a trigger word
+        const atPos = getAtSelectorPosition(newInputText, newCursorPosition);
+        if (atPos !== -1 && !state.showFileSelector) {
+          newState.showFileSelector = true;
+          newState.atPosition = atPos;
+          newState.isFileSearching = true;
+        }
+        const slashPos = getSlashSelectorPosition(
+          newInputText,
+          newCursorPosition,
+        );
+        if (slashPos !== -1 && !state.showCommandSelector) {
+          newState.showCommandSelector = true;
+          newState.slashPosition = slashPos;
+        }
+
+        // Update queries
+        if (newState.showFileSelector && newState.atPosition >= 0) {
+          newState.fileSearchQuery = newInputText.substring(
+            newState.atPosition + 1,
+            newCursorPosition,
+          );
+        }
+        if (newState.showCommandSelector && newState.slashPosition >= 0) {
+          newState.commandSearchQuery = newInputText.substring(
+            newState.slashPosition + 1,
+            newCursorPosition,
+          );
+        }
+
+        return newState;
       }
 
       // 1. /btw overlay handling (active while a question is displayed, or
@@ -1425,54 +1492,69 @@ export function inputReducer(
 
       // 8. Backspace / Delete (Normal Mode)
       if (key.backspace || key.delete) {
-        if (state.cursorPosition > 0) {
-          const newCursorPosition = state.cursorPosition - 1;
-          const beforeCursor = state.inputText.substring(
-            0,
-            state.cursorPosition - 1,
-          );
-          const afterCursor = state.inputText.substring(state.cursorPosition);
-          const newInputText = beforeCursor + afterCursor;
+        // Placeholder token deletion first (aligned with Claude Code's
+        // deleteTokenBefore, Cursor.ts:937-969): backspace at the end of a
+        // [LongText#N] / [Image #N] token removes the whole token in one
+        // press (and drops its longTextMap entry); otherwise delete one
+        // character. Selector backspace (section 5) stays character-wise —
+        // @mention and /command words are intentionally not tokenized.
+        const tokenDeletion = deleteTokenBefore(
+          state.inputText,
+          state.cursorPosition,
+          state.longTextMap,
+        );
+        if (!tokenDeletion && state.cursorPosition <= 0) {
+          return state;
+        }
+        const newInputText = tokenDeletion
+          ? tokenDeletion.inputText
+          : state.inputText.substring(0, state.cursorPosition - 1) +
+            state.inputText.substring(state.cursorPosition);
+        const newCursorPosition = tokenDeletion
+          ? tokenDeletion.cursorPosition
+          : state.cursorPosition - 1;
 
-          const newState = {
-            ...state,
-            inputText: newInputText,
-            cursorPosition: newCursorPosition,
-            historyIndex: -1,
-          };
+        const newState = {
+          ...state,
+          inputText: newInputText,
+          cursorPosition: newCursorPosition,
+          longTextMap: tokenDeletion
+            ? tokenDeletion.longTextMap
+            : state.longTextMap,
+          historyIndex: -1,
+        };
 
-          // Reactivate selectors if cursor is within word
-          const atPos = getAtSelectorPosition(newInputText, newCursorPosition);
-          if (atPos !== -1 && !state.showFileSelector) {
-            newState.showFileSelector = true;
-            newState.atPosition = atPos;
-            newState.isFileSearching = true;
-          }
+        // Reactivate selectors if cursor is within word
+        const atPos = getAtSelectorPosition(newInputText, newCursorPosition);
+        if (atPos !== -1 && !state.showFileSelector) {
+          newState.showFileSelector = true;
+          newState.atPosition = atPos;
+          newState.isFileSearching = true;
+        }
 
-          const slashPos = getSlashSelectorPosition(
-            newInputText,
+        const slashPos = getSlashSelectorPosition(
+          newInputText,
+          newCursorPosition,
+        );
+        if (slashPos !== -1 && !state.showCommandSelector) {
+          newState.showCommandSelector = true;
+          newState.slashPosition = slashPos;
+        }
+
+        // Update queries
+        if (newState.showFileSelector && newState.atPosition >= 0) {
+          newState.fileSearchQuery = newInputText.substring(
+            newState.atPosition + 1,
             newCursorPosition,
           );
-          if (slashPos !== -1 && !state.showCommandSelector) {
-            newState.showCommandSelector = true;
-            newState.slashPosition = slashPos;
-          }
-
-          // Update queries
-          if (newState.showFileSelector && newState.atPosition >= 0) {
-            newState.fileSearchQuery = newInputText.substring(
-              newState.atPosition + 1,
-              newCursorPosition,
-            );
-          }
-          if (newState.showCommandSelector && newState.slashPosition >= 0) {
-            newState.commandSearchQuery = newInputText.substring(
-              newState.slashPosition + 1,
-              newCursorPosition,
-            );
-          }
-          return newState;
         }
+        if (newState.showCommandSelector && newState.slashPosition >= 0) {
+          newState.commandSearchQuery = newInputText.substring(
+            newState.slashPosition + 1,
+            newCursorPosition,
+          );
+        }
+        return newState;
       }
 
       // 9. Cursor Movement (Normal Mode)

--- a/packages/code/tests/managers/inputReducer.test.ts
+++ b/packages/code/tests/managers/inputReducer.test.ts
@@ -1097,6 +1097,198 @@ describe("inputReducer", () => {
       });
     });
 
+    describe("placeholder token deletion (aligned with CC deleteTokenBefore)", () => {
+      const backspaceKey = { backspace: true } as unknown as Key;
+      const longTextMap = { "[LongText#1]": "some very long pasted text" };
+
+      it("should delete a whole [LongText#N] token on backspace at line end", () => {
+        const state = {
+          ...initialState,
+          inputText: "prefix [LongText#1]",
+          cursorPosition: "prefix [LongText#1]".length,
+          longTextMap,
+        };
+        const result = inputReducer(state, {
+          type: "HANDLE_KEY",
+          payload: { input: "", key: backspaceKey, hasSlashCommand },
+        });
+        expect(result.inputText).toBe("prefix ");
+        expect(result.cursorPosition).toBe(7);
+        expect(result.longTextMap).toEqual({});
+      });
+
+      it("should delete a whole [LongText#N] token when followed by whitespace", () => {
+        const state = {
+          ...initialState,
+          inputText: "[LongText#1] suffix",
+          cursorPosition: "[LongText#1]".length,
+          longTextMap,
+        };
+        const result = inputReducer(state, {
+          type: "HANDLE_KEY",
+          payload: { input: "", key: backspaceKey, hasSlashCommand },
+        });
+        expect(result.inputText).toBe(" suffix");
+        expect(result.cursorPosition).toBe(0);
+        expect(result.longTextMap).toEqual({});
+      });
+
+      it("should fall back to single-char delete when cursor is mid-token", () => {
+        const state = {
+          ...initialState,
+          inputText: "[LongText#1]",
+          cursorPosition: 5,
+          longTextMap,
+        };
+        const result = inputReducer(state, {
+          type: "HANDLE_KEY",
+          payload: { input: "", key: backspaceKey, hasSlashCommand },
+        });
+        expect(result.inputText).toBe("[LonText#1]");
+        expect(result.cursorPosition).toBe(4);
+        expect(result.longTextMap).toEqual(longTextMap);
+      });
+
+      it("should fall back to single-char delete when token is glued to following text", () => {
+        const state = {
+          ...initialState,
+          inputText: "[LongText#1]x",
+          cursorPosition: "[LongText#1]".length,
+          longTextMap,
+        };
+        const result = inputReducer(state, {
+          type: "HANDLE_KEY",
+          payload: { input: "", key: backspaceKey, hasSlashCommand },
+        });
+        expect(result.inputText).toBe("[LongText#1x");
+        expect(result.cursorPosition).toBe(11);
+        expect(result.longTextMap).toEqual(longTextMap);
+      });
+
+      it("should delete a whole [Image #N] token on backspace", () => {
+        const state = {
+          ...initialState,
+          inputText: "see [Image #1] here",
+          cursorPosition: "see [Image #1]".length,
+        };
+        const result = inputReducer(state, {
+          type: "HANDLE_KEY",
+          payload: { input: "", key: backspaceKey, hasSlashCommand },
+        });
+        expect(result.inputText).toBe("see  here");
+        expect(result.cursorPosition).toBe(4);
+      });
+
+      it("should not delete anything when backspace at line start", () => {
+        const state = {
+          ...initialState,
+          inputText: "[LongText#1]",
+          cursorPosition: 0,
+          longTextMap,
+        };
+        const result = inputReducer(state, {
+          type: "HANDLE_KEY",
+          payload: { input: "", key: backspaceKey, hasSlashCommand },
+        });
+        expect(result.inputText).toBe("[LongText#1]");
+        expect(result.cursorPosition).toBe(0);
+        expect(result.longTextMap).toEqual(longTextMap);
+      });
+
+      it("should delete a whole [LongText#N] token per raw DEL byte", () => {
+        const state = {
+          ...initialState,
+          inputText: "[LongText#1]",
+          cursorPosition: "[LongText#1]".length,
+          longTextMap,
+        };
+        const result = inputReducer(state, {
+          type: "HANDLE_KEY",
+          payload: {
+            input: "\x7f\x7f",
+            key: {} as unknown as Key,
+            hasSlashCommand,
+          },
+        });
+        expect(result.inputText).toBe("");
+        expect(result.cursorPosition).toBe(0);
+        expect(result.longTextMap).toEqual({});
+      });
+
+      it("should handle Ctrl+U clearing a placeholder like ordinary text", () => {
+        const state = {
+          ...initialState,
+          inputText: "[LongText#1] tail",
+          cursorPosition: "[LongText#1] tail".length,
+          longTextMap,
+        };
+        const result = inputReducer(state, {
+          type: "HANDLE_KEY",
+          payload: {
+            input: "u",
+            key: { ctrl: true } as unknown as Key,
+            hasSlashCommand,
+          },
+        });
+        expect(result.inputText).toBe("");
+        expect(result.cursorPosition).toBe(0);
+      });
+
+      it("should leave a slice fragment when Ctrl+U cuts mid-placeholder", () => {
+        const state = {
+          ...initialState,
+          inputText: "[LongText#1]",
+          cursorPosition: 5,
+        };
+        const result = inputReducer(state, {
+          type: "HANDLE_KEY",
+          payload: {
+            input: "u",
+            key: { ctrl: true } as unknown as Key,
+            hasSlashCommand,
+          },
+        });
+        expect(result.inputText).toBe("Text#1]");
+        expect(result.cursorPosition).toBe(0);
+      });
+
+      it("should handle Ctrl+W deleting the placeholder as one word", () => {
+        const state = {
+          ...initialState,
+          inputText: "hello [LongText#1]",
+          cursorPosition: "hello [LongText#1]".length,
+        };
+        const result = inputReducer(state, {
+          type: "HANDLE_KEY",
+          payload: {
+            input: "w",
+            key: { ctrl: true } as unknown as Key,
+            hasSlashCommand,
+          },
+        });
+        expect(result.inputText).toBe("hello ");
+        expect(result.cursorPosition).toBe(6);
+      });
+
+      it("should leave a fragment when Ctrl+K cuts mid-placeholder", () => {
+        const state = {
+          ...initialState,
+          inputText: "[LongText#1]",
+          cursorPosition: 5,
+        };
+        const result = inputReducer(state, {
+          type: "HANDLE_KEY",
+          payload: {
+            input: "k",
+            key: { ctrl: true } as unknown as Key,
+            hasSlashCommand,
+          },
+        });
+        expect(result.inputText).toBe("[Long");
+        expect(result.cursorPosition).toBe(5);
+      });
+    });
+
     describe("idle Esc double-press clear", () => {
       const escapeKey = { escape: true } as unknown as Key;
 


### PR DESCRIPTION
## Summary

对齐 Claude Code 的 `deleteTokenBefore`（`Cursor.ts:937-969`）：`[LongText#N]`（>200 字符折叠，原文存 `longTextMap`）与 `[Image #N]` 占位符现在参与删除键，而不是只能按 Enter 提交。

- **Backspace / 原始 DEL（`\x7f`，SSH/tmux 退格）**：光标位于占位符末尾（后随空白或行尾，word-boundary 守卫）时整块删除 token，并清理 `longTextMap` 条目；否则退回单字符删除
- **Ctrl+U/K/W**：占位符即普通字符串，纯文本切片/词删除（与 CC 一致，光标在中间时留残缺片段）

修复前 Backspace 对 `[LongText#1]` 逐字符删除，留下 `[LongText#1` 残缺文本，Enter 后当作字面量发送、原文丢失。

## Spec

`docs/specs/ui/input-editing-keys.md` 新增第 5 个用户故事（8 验收场景），并纠正旧边界描述（旧文误称 Ctrl+U/K 按占位符整体删除）。spec-count：本 spec 4→5 stories / 15→23 scenarios。

## 测试

- 新增 11 个 reducer 测试（整块删除、map 清理、word-boundary 守卫回退、Ctrl+U/K/W 切片）
- `packages/code` 全量 1410 tests 通过；type-check / lint / prettier / 文档 link check 通过