### PR TITLE
feat(code): add wave daemon abort subcommand

### DIFF
--- a/docs/specs/ui/daemon-command.md
+++ b/docs/specs/ui/daemon-command.md
@@ -1,6 +1,6 @@
 ---
 name: "Daemon 客户端命令"
-description: "`wave daemon list/status/send/respond` — 查看、续聊与审批 daemon 托管的远端后台会话"
+description: "`wave daemon list/status/send/respond/abort` — 查看、续聊、审批与中断 daemon 托管的远端后台会话"
 order: 270
 ---
 
@@ -10,15 +10,15 @@ order: 270
 
 ## 概述
 
-`wave --daemon <socket>` 在远端主机上启动一个 JSON-RPC over unix socket 的 daemon，托管后台 agent 会话（桌面端经 SSH 隧道访问）。目前除了 `--daemon` 启动标志外，没有任何面向用户的 CLI 命令可以查看 daemon 里托管了哪些会话、会话进度如何、或向会话注入消息继续对话——这些能力只存在于 JSON-RPC 协议层，普通用户与脚本无法直接使用。本规格定义 `wave daemon` 子命令组，将已验证的协议流程（attach → 读消息 → 注入消息 → 审批挂起的权限请求）封装为四条命令，供用户在远端主机直接执行（或经 `ssh <host> wave daemon ...` 在远端主机上执行）。
+`wave --daemon <socket>` 在远端主机上启动一个 JSON-RPC over unix socket 的 daemon，托管后台 agent 会话（桌面端经 SSH 隧道访问）。目前除了 `--daemon` 启动标志外，没有任何面向用户的 CLI 命令可以查看 daemon 里托管了哪些会话、会话进度如何、或向会话注入消息继续对话——这些能力只存在于 JSON-RPC 协议层，普通用户与脚本无法直接使用。本规格定义 `wave daemon` 子命令组，将已验证的协议流程（attach → 读消息 → 注入消息 → 审批挂起的权限请求 → 中断生成）封装为五条命令，供用户在远端主机直接执行（或经 `ssh <host> wave daemon ...` 在远端主机上执行）。
 
 ## 用户场景与测试 _（必填）_
 
 ### 用户故事：Daemon 命令组与默认 socket（优先级：P0）
 
-作为在远端主机上使用 daemon 的用户，我希望通过 `wave daemon` 子命令组（`list` / `status` / `send` / `respond`）访问 daemon，固定连接默认 socket，以便无需了解 JSON-RPC 协议即可查看、续聊与审批后台会话。
+作为在远端主机上使用 daemon 的用户，我希望通过 `wave daemon` 子命令组（`list` / `status` / `send` / `respond` / `abort`）访问 daemon，固定连接默认 socket，以便无需了解 JSON-RPC 协议即可查看、续聊、审批与中断后台会话。
 
-**为什么是这个优先级**：这是整个命令组的地基——没有统一的命令入口与 socket 寻址规则，list/status/send/respond 无从谈起；daemon 只监听本地 unix socket、不暴露网络端口，且只允许在远端主机上运行，因此客户端命令一律连接默认 socket（`~/.wave/daemon.sock`），不提供 `--socket` 覆盖参数，避免支持本地转发 socket 等非目标用法。
+**为什么是这个优先级**：这是整个命令组的地基——没有统一的命令入口与 socket 寻址规则，list/status/send/respond/abort 无从谈起；daemon 只监听本地 unix socket、不暴露网络端口，且只允许在远端主机上运行，因此客户端命令一律连接默认 socket（`~/.wave/daemon.sock`），不提供 `--socket` 覆盖参数，避免支持本地转发 socket 等非目标用法。
 
 **独立测试**：在远端启动 daemon 后运行 `wave daemon list` 能列出会话；daemon 未运行时运行任一子命令会得到明确错误提示。
 
@@ -109,14 +109,32 @@ order: 270
 
 ---
 
+### 用户故事：中断会话正在生成的消息（优先级：P0）
+
+作为在远端主机驱动后台会话的用户，我希望 `wave daemon abort <sessionId>` 中断指定会话正在生成的回复（含子代理、bash 命令与排队消息），以便在模型走偏、回复过长或需要及时止损时打断当前生成，而不必等待其自然完成。
+
+**为什么是这个优先级**：这是「控制后台会话」的核心能力——`send` 能注入消息但无法打断；协议层已有 `abortMessage` 方法（agentBridge 已实现：统一中断 AI 消息、bash 命令、slash 命令与子代理，并清空消息队列，见 protocol.ts / agentBridge.ts），只缺 CLI 封装。中断是幂等操作——在空闲会话上调用是安全 no-op，命令仍成功返回，因此无需校验会话是否正在生成，`abort` 是短暂的 attach 访问、随用随断。
+
+**独立测试**：对一条正在生成回复的会话运行 `wave daemon abort <sessionId>`，验证会话停止生成回到空闲、命令输出确认并以退出码 0 结束；对一条空闲会话运行同一命令，验证命令同样成功退出（幂等 no-op）且不报错。
+
+**验收场景**：
+
+1. **假设** 目标会话正在生成回复（含子代理运行中），**当** 用户运行 `wave daemon abort <sessionId>` 时，**则** 命令经 attach（`initialize {restoreSessionId}` + `restoreSession`）后调用协议 `abortMessage` 方法，会话中断当前生成（含子代理与排队消息）回到空闲，命令输出确认信息并以退出码 0 结束。
+2. **假设** 目标会话空闲（未在生成），**当** 用户运行 `wave daemon abort <sessionId>` 时，**则** 中断是幂等 no-op，命令仍输出确认信息并以退出码 0 结束，不报错。
+3. **假设** 指定的 sessionId 不存在于该 daemon，**当** 用户运行 `wave daemon abort <sessionId>` 时，**则** 以非零退出码退出并给出明确错误（Session not found or not hosted by this daemon），不调用中断。
+4. **假设** abort 命令完成（成功或失败）后，**当** 命令退出时，**则** 断开与 daemon 的连接（attach 是短暂访问，不常驻），会话在 daemon 中继续存活、不因客户端退出而终止；中断不清除已完成的对话历史，只打断进行中的生成与排队消息。
+
+---
+
 ### 边界情况
 
 - **daemon 未运行 / socket 不存在**：任一子命令均应快速报错退出（非零退出码 + stderr 明确提示），不得挂起或进入 TUI；提示须覆盖「daemon 空闲 60 秒自动退出」这一正常现象。
 - **默认 socket 固定**：所有 `wave daemon` 子命令一律连接 `~/.wave/daemon.sock`，不提供 `--socket` 覆盖参数；命令只在远端主机上运行，不面向本地转发的 socket。
-- **`wave daemon` 与 `wave --daemon` 语义冲突**：前者是客户端子命令组（list/status/send/respond），后者是服务端启动标志；帮助文本须写明差异，避免误用。
+- **`wave daemon` 与 `wave --daemon` 语义冲突**：前者是客户端子命令组（list/status/send/respond/abort），后者是服务端启动标志；帮助文本须写明差异，避免误用。
 - **list 仅反映当前进程内存态**：`list` 展示的是当前 daemon 进程内 live 的会话（`initialize`/`restoreSession` 载入且仍存活），不扫磁盘索引；daemon 空闲退出/重启后内存清空、列表为空是正常现象。磁盘上的历史会话（含普通 `wave` TUI 创建的）不在列表中，但知道 sessionId 仍可经 `status`/`send` attach（`restoreSession` 重新载入），无需依赖 `list` 找回。
 - **会话挂起等待审批**：daemon 语义下「等待审批」的会话保持 loading 状态（等同未空闲）；消息中该工具块冻结在 `stage: "running"`（有工具名与参数、无结果字段，结果字段只在 `stage: "end"` 写入），单凭消息无法区分「等审批」与「执行中」，须结合 `listPendingPermissions` 判断；`send` 须有 `--timeout` 兜底避免无限挂起，`status` 应如实显示该状态，`respond` 是处理挂起请求的入口。
 - **respond 的决策并非单一 allow/deny**：`PermissionDecision` 含 behavior/message/newPermissionMode/newPermissionRule 四个字段；EnterPlanMode 的 allow 必须附带 `newPermissionMode:"plan"`（按工具智能补全），AskUserQuestion 必须用 `--answer` 提供答案（allow 且 message 为答案 JSON），Bash/Edit 可选 `--rule`/`--mode`；命令须与桌面端行为一致，不得把多选项压成裸 allow/deny。
 - **requestId 幂等与过期**：服务端对未知 requestId 的 `permissionResponse` 静默忽略；respond 应先行校验（如经 `listPendingPermissions`）并在 requestId 已处理时明确提示，避免用户误以为审批已生效。
 - **`send` 输出纯净性**：命令输出助手最终回复文本，流式通知与子代理内部信息不得泄漏到 stdout（与打印模式一致），诊断信息走 stderr。
-- **attach 是短暂访问**：`status` / `send` / `respond` 完成即断开连接，不常驻客户端；daemon 与会话的生命周期不受客户端连接影响（attach/detach 语义，会话持续运行至空闲自动退出或用户删除）。
+- **`abort` 中断是幂等操作**：在空闲会话上是无害 no-op，命令仍成功返回；对正在生成（含子代理、bash 命令、slash 命令）或挂起审批的会话，中断后回到空闲（与桌面端中断按钮语义一致）。`abort` 不清除已完成的对话历史，只打断进行中的生成并清空消息队列；无需先经 `status` 确认是否正在生成。
+- **attach 是短暂访问**：`status` / `send` / `respond` / `abort` 完成即断开连接，不常驻客户端；daemon 与会话的生命周期不受客户端连接影响（attach/detach 语义，会话持续运行至空闲自动退出或用户删除）。

--- a/packages/code/src/daemon/commands.ts
+++ b/packages/code/src/daemon/commands.ts
@@ -1,7 +1,8 @@
 /**
  * `wave daemon` client subcommands — talk to the wave daemon's unix socket
  * (JSON-RPC over newline-delimited JSON) to list hosted sessions, inspect
- * progress, inject messages and respond to pending permission requests.
+ * progress, inject messages, respond to pending permission requests and abort
+ * in-flight message generation.
  *
  * All subcommands are non-interactive: results go to stdout, diagnostics to
  * stderr, and every handler calls process.exit() itself (yargs would fall
@@ -443,6 +444,29 @@ export async function daemonRespondCommand(
     console.log(`Handled approval request: ${requestId}`);
   } catch (err) {
     fail(`wave daemon respond failed: ${(err as Error).message}`);
+  } finally {
+    await client?.dispose();
+  }
+  process.exit(0);
+}
+
+// ── abort ─────────────────────────────────────────────────────
+
+export async function daemonAbortCommand(
+  socketPath: string,
+  sessionId: string,
+): Promise<void> {
+  let client: SocketClient | undefined;
+  try {
+    client = await connectDaemonOrExit(socketPath);
+    const init = await attachSession(client, sessionId);
+    // abortMessage is idempotent: a no-op on idle sessions, interrupts
+    // in-flight generation (incl. subagents / bash / slash / queued messages)
+    // otherwise (spec: 中断幂等，无需先确认是否正在生成).
+    await client.request("abortMessage", undefined, init.sessionId);
+    console.log(`Aborted session: ${sessionId}`);
+  } catch (err) {
+    fail(`wave daemon abort failed: ${(err as Error).message}`);
   } finally {
     await client?.dispose();
   }

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -375,6 +375,24 @@ export async function main() {
                 );
               },
             )
+            .command(
+              "abort <sessionId>",
+              "Abort the session's in-flight message generation",
+              (yargs) => {
+                return yargs.positional("sessionId", {
+                  describe: "Session ID hosted by the daemon",
+                  type: "string",
+                });
+              },
+              async (argv) => {
+                const { daemonAbortCommand, DEFAULT_DAEMON_SOCKET } =
+                  await import("./daemon/commands.js");
+                await daemonAbortCommand(
+                  DEFAULT_DAEMON_SOCKET,
+                  argv.sessionId as string,
+                );
+              },
+            )
             .demandCommand(1, "Please specify a daemon subcommand");
         },
       )

--- a/packages/code/tests/daemon/commands.test.ts
+++ b/packages/code/tests/daemon/commands.test.ts
@@ -1,8 +1,9 @@
 /**
- * `wave daemon` client subcommands (list / status / send / respond) — end-to-end
- * against a real DaemonServer: the commands' SocketClient connects to the unix
- * socket, initialize+restoreSession re-attach to live sessions in the daemon's
- * in-memory registry, and respond resolves in-process permission promises.
+ * `wave daemon` client subcommands (list / status / send / respond / abort) —
+ * end-to-end against a real DaemonServer: the commands' SocketClient connects
+ * to the unix socket, initialize+restoreSession re-attach to live sessions in
+ * the daemon's in-memory registry, respond resolves in-process permission
+ * promises and abort forwards to the agent's abortMessage.
  *
  * The SDK is mocked with a factory (NOT auto-mock) so the real
  * getMessageContent / tool-name constants used by commands.ts stay intact while
@@ -67,6 +68,7 @@ import {
   daemonStatusCommand,
   daemonSendCommand,
   daemonRespondCommand,
+  daemonAbortCommand,
 } from "../../src/daemon/commands.js";
 
 function userMsg(id: string, content: string): Message {
@@ -687,4 +689,69 @@ test("respond: requires exactly one of --allow / --deny", async () => {
   ).rejects.toThrow("exit(1)");
   expect(stderrText()).toContain("Specify either --allow or --deny");
   expect(exitSpy).toHaveBeenCalledWith(1);
+});
+
+// ── abort ─────────────────────────────────────────────────────
+
+test("abort: forwards abortMessage on a generating session, prints confirmation and exits 0", async () => {
+  const agent = createMockAgent({ isLoading: true });
+  vi.mocked(Agent.create).mockResolvedValue(agent);
+
+  const client = connectClient(socketPath);
+  await client.send({ id: 1, method: "initialize", params: {} });
+  client.close();
+
+  await expect(
+    daemonAbortCommand(socketPath, "test-session-id"),
+  ).rejects.toThrow("exit(0)");
+  expect(agent.abortMessage).toHaveBeenCalled();
+  expect(logSpy).toHaveBeenCalledWith("Aborted session: test-session-id");
+  expect(exitSpy).toHaveBeenCalledWith(0);
+
+  // Abort is a transient attach — the session stays hosted.
+  const b = connectClient(socketPath);
+  const msgs = await b.send({
+    id: 9,
+    method: "listDaemonSessions",
+    params: {},
+  });
+  const result = msgs[0] as { result: { sessions: unknown[] } };
+  expect(result.result.sessions).toHaveLength(1);
+  b.close();
+});
+
+test("abort: idle session is an idempotent no-op that still exits 0", async () => {
+  const agent = createMockAgent();
+  vi.mocked(Agent.create).mockResolvedValue(agent);
+
+  const client = connectClient(socketPath);
+  await client.send({ id: 1, method: "initialize", params: {} });
+  client.close();
+
+  await expect(
+    daemonAbortCommand(socketPath, "test-session-id"),
+  ).rejects.toThrow("exit(0)");
+  expect(agent.abortMessage).toHaveBeenCalled();
+  expect(logSpy).toHaveBeenCalledWith("Aborted session: test-session-id");
+  expect(exitSpy).toHaveBeenCalledWith(0);
+});
+
+test("abort: nonexistent session fails, destroys the junk fresh session, no abort sent", async () => {
+  const junk = createMockAgent({
+    sessionId: "fresh",
+    restoreSession: vi
+      .fn()
+      .mockRejectedValue(new Error("Session not found: ghost")),
+  });
+  vi.mocked(Agent.create).mockResolvedValue(junk);
+
+  await expect(daemonAbortCommand(socketPath, "ghost")).rejects.toThrow(
+    "exit(1)",
+  );
+  expect(stderrText()).toContain(
+    "Session not found or not hosted by this daemon: ghost",
+  );
+  expect(exitSpy).toHaveBeenCalledWith(1);
+  expect(junk.destroy).toHaveBeenCalled();
+  expect(junk.abortMessage).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
## 变更内容

新增 `wave daemon abort <sessionId>` 子命令：中断 daemon 托管的远端后台会话正在生成的消息。

- **协议层已就绪**：`abortMessage` 请求方法（protocol.ts:58）在 agentBridge.ts:869-871 已实现（统一中断 AI 消息、bash/slash 命令、子代理并清空消息队列），本 PR 补齐 CLI 封装。
- **实现**：`packages/code/src/daemon/commands.ts` 新增 `daemonAbortCommand`，复用现有 `attachSession` + request 模式；`packages/code/src/index.ts` 注册 `abort <sessionId>`。
- **幂等**：空闲会话上调用是安全 no-op，命令仍退出 0。
- **Spec**：`docs/specs/ui/daemon-command.md` 新增 abort 用户故事（4 个验收场景），更新命令组/概述/边界情况。
- **测试**：`packages/code/tests/daemon/commands.test.ts` 新增 3 用例（generating 会话转发 abortMessage 且会话仍托管、空闲幂等、会话不存在报错并销毁 junk session）。

## 验证
- packages/code：1402/1402 通过（含 28 个 daemon 测试）
- type-check / lint / prettier：全过
- spec-count：72 规格 / 382 用户故事 / 1474 验收场景

注：agent-sdk 的 `bashTool-real-spawn.test.ts` 第 1 个用例在本机环境失败（首次 `zsh -c -l` login shell spawn 丢失 stdout 的时序竞态），与本次改动无关（agent-sdk 未被修改），CI 上应不受影响。