### PR TITLE
ci: cache pnpm/action-setup install dir to avoid codeload 429s

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -3,18 +3,18 @@ name: Docs Checks
 on:
   pull_request:
     paths:
-      - 'docs/**'
-      - '.github/workflows/check-docs.yml'
-      - 'scripts/check-docs-links.mjs'
-      - 'scripts/check-sidebar-anchors.mjs'
+      - "docs/**"
+      - ".github/workflows/check-docs.yml"
+      - "scripts/check-docs-links.mjs"
+      - "scripts/check-sidebar-anchors.mjs"
   push:
     branches:
       - main
     paths:
-      - 'docs/**'
-      - '.github/workflows/check-docs.yml'
-      - 'scripts/check-docs-links.mjs'
-      - 'scripts/check-sidebar-anchors.mjs'
+      - "docs/**"
+      - ".github/workflows/check-docs.yml"
+      - "scripts/check-docs-links.mjs"
+      - "scripts/check-sidebar-anchors.mjs"
 
 jobs:
   check-docs:
@@ -22,12 +22,40 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
+      # Cache pnpm/action-setup's install dir so jobs skip re-downloading the
+      # action tarball from codeload (429 rate limits, pnpm/action-setup#177).
+      # On hit we skip the action and prepend its bin dir to PATH ourselves.
+      # The key pins the pnpm version — keep it in sync with the `version`
+      # input below (package.json "packageManager").
+      - name: Cache pnpm install
+        id: pnpm-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/setup-pnpm
+          key: pnpm-setup-v4-${{ runner.os }}-${{ runner.arch }}-11.9.0
+
+      - name: Add cached pnpm to PATH
+        if: steps.pnpm-cache.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          # Mirror pnpm/action-setup v4's env: the requested pnpm version is
+          # installed directly into node_modules/.bin.
+          PNPM_HOME="$HOME/.cache/setup-pnpm/node_modules/.bin"
+          echo "$PNPM_HOME" >> "$GITHUB_PATH"
+          echo "PNPM_HOME=$PNPM_HOME" >> "$GITHUB_ENV"
+
+      - name: Setup pnpm (cache miss)
+        if: steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.9.0
+          dest: ~/.cache/setup-pnpm
+          run_install: false
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'pnpm'
+          node-version: "22"
+          cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -12,12 +12,12 @@ on:
   push:
     branches: [main]
     paths:
-      - 'packages/agent-sdk/**'
-      - 'packages/code/**'
-      - 'packages/vscode/**'
-      - 'pnpm-lock.yaml'
-      - 'package.json'
-      - '.github/workflows/ci-windows.yml'
+      - "packages/agent-sdk/**"
+      - "packages/code/**"
+      - "packages/vscode/**"
+      - "pnpm-lock.yaml"
+      - "package.json"
+      - ".github/workflows/ci-windows.yml"
   workflow_dispatch:
 
 concurrency:
@@ -31,8 +31,43 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
+      # Cache pnpm/action-setup's install dir so jobs skip re-downloading the
+      # action tarball from codeload (429 rate limits, pnpm/action-setup#177).
+      # On hit we skip the action and prepend its bin dirs to PATH ourselves.
+      # The key pins the pnpm version — keep it in sync with the `version`
+      # input below (package.json "packageManager").
+      - name: Cache pnpm install
+        id: pnpm-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/setup-pnpm
+          key: pnpm-setup-v5-${{ runner.os }}-${{ runner.arch }}-11.9.0
+
+      - name: Add cached pnpm to PATH
+        if: steps.pnpm-cache.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          # Mirror pnpm/action-setup's env: node_modules/.bin/bin holds the
+          # self-updated target version (higher precedence), node_modules/.bin
+          # the bootstrap symlink. GITHUB_PATH is used verbatim, so write
+          # native Windows paths on Windows runners.
+          PNPM_HOME="${USERPROFILE:-$HOME}/.cache/setup-pnpm/node_modules/.bin"
+          PNPM_BIN="$PNPM_HOME/bin"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            PNPM_HOME="${PNPM_HOME//\//\\}"
+            PNPM_BIN="${PNPM_BIN//\//\\}"
+          fi
+          echo "$PNPM_HOME" >> "$GITHUB_PATH"
+          echo "$PNPM_BIN" >> "$GITHUB_PATH"
+          echo "PNPM_HOME=$PNPM_HOME" >> "$GITHUB_ENV"
+
+      - name: Setup pnpm (cache miss)
+        if: steps.pnpm-cache.outputs.cache-hit != 'true'
         uses: pnpm/action-setup@v5
+        with:
+          version: 11.9.0
+          dest: ~/.cache/setup-pnpm
+          run_install: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,44 @@ jobs:
               - '!packages/webview/e2e/**'
               - '!LICENSE'
 
-      - name: Setup pnpm
+      # Cache pnpm/action-setup's install dir so concurrent jobs skip
+      # re-downloading the action tarball from codeload (429 rate limits,
+      # pnpm/action-setup#177). On hit we skip the action and prepend its bin
+      # dirs to PATH ourselves. The key pins the pnpm version — keep it in
+      # sync with the `version` input below (package.json "packageManager").
+      - name: Cache pnpm install
         if: steps.filter.outputs.code == 'true'
+        id: pnpm-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/setup-pnpm
+          key: pnpm-setup-v5-${{ runner.os }}-${{ runner.arch }}-11.9.0
+
+      - name: Add cached pnpm to PATH
+        if: steps.filter.outputs.code == 'true' && steps.pnpm-cache.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          # Mirror pnpm/action-setup's env: node_modules/.bin/bin holds the
+          # self-updated target version (higher precedence), node_modules/.bin
+          # the bootstrap symlink. GITHUB_PATH is used verbatim, so write
+          # native Windows paths on Windows runners.
+          PNPM_HOME="${USERPROFILE:-$HOME}/.cache/setup-pnpm/node_modules/.bin"
+          PNPM_BIN="$PNPM_HOME/bin"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            PNPM_HOME="${PNPM_HOME//\//\\}"
+            PNPM_BIN="${PNPM_BIN//\//\\}"
+          fi
+          echo "$PNPM_HOME" >> "$GITHUB_PATH"
+          echo "$PNPM_BIN" >> "$GITHUB_PATH"
+          echo "PNPM_HOME=$PNPM_HOME" >> "$GITHUB_ENV"
+
+      - name: Setup pnpm (cache miss)
+        if: steps.filter.outputs.code == 'true' && steps.pnpm-cache.outputs.cache-hit != 'true'
         uses: pnpm/action-setup@v5
+        with:
+          version: 11.9.0
+          dest: ~/.cache/setup-pnpm
+          run_install: false
 
       - name: Setup Node.js
         if: steps.filter.outputs.code == 'true'
@@ -115,9 +150,44 @@ jobs:
               - '!packages/webview/e2e/**'
               - '!LICENSE'
 
-      - name: Setup pnpm
+      # Cache pnpm/action-setup's install dir so concurrent jobs skip
+      # re-downloading the action tarball from codeload (429 rate limits,
+      # pnpm/action-setup#177). On hit we skip the action and prepend its bin
+      # dirs to PATH ourselves. The key pins the pnpm version — keep it in
+      # sync with the `version` input below (package.json "packageManager").
+      - name: Cache pnpm install
         if: steps.filter.outputs.code == 'true'
+        id: pnpm-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/setup-pnpm
+          key: pnpm-setup-v5-${{ runner.os }}-${{ runner.arch }}-11.9.0
+
+      - name: Add cached pnpm to PATH
+        if: steps.filter.outputs.code == 'true' && steps.pnpm-cache.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          # Mirror pnpm/action-setup's env: node_modules/.bin/bin holds the
+          # self-updated target version (higher precedence), node_modules/.bin
+          # the bootstrap symlink. GITHUB_PATH is used verbatim, so write
+          # native Windows paths on Windows runners.
+          PNPM_HOME="${USERPROFILE:-$HOME}/.cache/setup-pnpm/node_modules/.bin"
+          PNPM_BIN="$PNPM_HOME/bin"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            PNPM_HOME="${PNPM_HOME//\//\\}"
+            PNPM_BIN="${PNPM_BIN//\//\\}"
+          fi
+          echo "$PNPM_HOME" >> "$GITHUB_PATH"
+          echo "$PNPM_BIN" >> "$GITHUB_PATH"
+          echo "PNPM_HOME=$PNPM_HOME" >> "$GITHUB_ENV"
+
+      - name: Setup pnpm (cache miss)
+        if: steps.filter.outputs.code == 'true' && steps.pnpm-cache.outputs.cache-hit != 'true'
         uses: pnpm/action-setup@v5
+        with:
+          version: 11.9.0
+          dest: ~/.cache/setup-pnpm
+          run_install: false
 
       - name: Setup Node.js
         if: steps.filter.outputs.code == 'true'
@@ -166,9 +236,44 @@ jobs:
               - '!packages/webview/e2e/**'
               - '!LICENSE'
 
-      - name: Setup pnpm
+      # Cache pnpm/action-setup's install dir so concurrent jobs skip
+      # re-downloading the action tarball from codeload (429 rate limits,
+      # pnpm/action-setup#177). On hit we skip the action and prepend its bin
+      # dirs to PATH ourselves. The key pins the pnpm version — keep it in
+      # sync with the `version` input below (package.json "packageManager").
+      - name: Cache pnpm install
         if: steps.filter.outputs.code == 'true'
+        id: pnpm-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/setup-pnpm
+          key: pnpm-setup-v5-${{ runner.os }}-${{ runner.arch }}-11.9.0
+
+      - name: Add cached pnpm to PATH
+        if: steps.filter.outputs.code == 'true' && steps.pnpm-cache.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          # Mirror pnpm/action-setup's env: node_modules/.bin/bin holds the
+          # self-updated target version (higher precedence), node_modules/.bin
+          # the bootstrap symlink. GITHUB_PATH is used verbatim, so write
+          # native Windows paths on Windows runners.
+          PNPM_HOME="${USERPROFILE:-$HOME}/.cache/setup-pnpm/node_modules/.bin"
+          PNPM_BIN="$PNPM_HOME/bin"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            PNPM_HOME="${PNPM_HOME//\//\\}"
+            PNPM_BIN="${PNPM_BIN//\//\\}"
+          fi
+          echo "$PNPM_HOME" >> "$GITHUB_PATH"
+          echo "$PNPM_BIN" >> "$GITHUB_PATH"
+          echo "PNPM_HOME=$PNPM_HOME" >> "$GITHUB_ENV"
+
+      - name: Setup pnpm (cache miss)
+        if: steps.filter.outputs.code == 'true' && steps.pnpm-cache.outputs.cache-hit != 'true'
         uses: pnpm/action-setup@v5
+        with:
+          version: 11.9.0
+          dest: ~/.cache/setup-pnpm
+          run_install: false
 
       - name: Setup Node.js
         if: steps.filter.outputs.code == 'true'
@@ -239,9 +344,44 @@ jobs:
               - '!packages/webview/e2e/**'
               - '!LICENSE'
 
-      - name: Setup pnpm
+      # Cache pnpm/action-setup's install dir so concurrent jobs skip
+      # re-downloading the action tarball from codeload (429 rate limits,
+      # pnpm/action-setup#177). On hit we skip the action and prepend its bin
+      # dirs to PATH ourselves. The key pins the pnpm version — keep it in
+      # sync with the `version` input below (package.json "packageManager").
+      - name: Cache pnpm install
         if: steps.filter.outputs.code == 'true'
+        id: pnpm-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/setup-pnpm
+          key: pnpm-setup-v5-${{ runner.os }}-${{ runner.arch }}-11.9.0
+
+      - name: Add cached pnpm to PATH
+        if: steps.filter.outputs.code == 'true' && steps.pnpm-cache.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          # Mirror pnpm/action-setup's env: node_modules/.bin/bin holds the
+          # self-updated target version (higher precedence), node_modules/.bin
+          # the bootstrap symlink. GITHUB_PATH is used verbatim, so write
+          # native Windows paths on Windows runners.
+          PNPM_HOME="${USERPROFILE:-$HOME}/.cache/setup-pnpm/node_modules/.bin"
+          PNPM_BIN="$PNPM_HOME/bin"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            PNPM_HOME="${PNPM_HOME//\//\\}"
+            PNPM_BIN="${PNPM_BIN//\//\\}"
+          fi
+          echo "$PNPM_HOME" >> "$GITHUB_PATH"
+          echo "$PNPM_BIN" >> "$GITHUB_PATH"
+          echo "PNPM_HOME=$PNPM_HOME" >> "$GITHUB_ENV"
+
+      - name: Setup pnpm (cache miss)
+        if: steps.filter.outputs.code == 'true' && steps.pnpm-cache.outputs.cache-hit != 'true'
         uses: pnpm/action-setup@v5
+        with:
+          version: 11.9.0
+          dest: ~/.cache/setup-pnpm
+          run_install: false
 
       - name: Setup Node.js
         if: steps.filter.outputs.code == 'true'


### PR DESCRIPTION
## Problem

Every job uses `pnpm/action-setup@v5`, which makes the runner download the action tarball from `codeload.github.com` on each job start. On PRs, the 6-job matrix in `ci.yml` + `check-extras` + `check-coverage` start concurrently → codeload 429 rate limits.

## Fix

Follow the community pattern from [pnpm/action-setup#177](https://github.com/pnpm/action-setup/issues/177) (matanper): cache the action's install dir (`~/.cache/setup-pnpm`) with `actions/cache`.

- **Cache hit** → skip the action, prepend its bin dirs to PATH ourselves
- **Cache miss** → run the action with `dest: ~/.cache/setup-pnpm` + `run_install: false`; the action's post-step saves the cache for next time

Covered: `ci.yml` (check matrix, check-extras, check-coverage, integration), `ci-windows.yml`, `check-docs.yml`. `setup-node`'s `cache: pnpm` (store cache) untouched — unrelated to the action download.

## Details verified against action source

- **v5 layout**: bootstrap pnpm installed via `npm ci` into `node_modules/.bin` (bootstrap is 11.19.0), then self-updated to the pinned version into `node_modules/.bin/bin`. The cache-hit PATH step mirrors both entries in the action's precedence order + exports `PNPM_HOME`.
- **v4 layout** (check-docs): target version installed directly into `node_modules/.bin` — single PATH entry.
- **Cache key** pins the pnpm version (`11.9.0` from `package.json` `packageManager`) + action major + OS + arch. Explicit `version: 11.9.0` passed to the action so key and installed version can't drift.
- **Windows**: `$GITHUB_PATH` entries are used verbatim (no MSYS conversion in the runner), so the PATH step writes native paths via `$USERPROFILE`.

## Skipped intentionally

`pages.yml` / `publish.yml` / `refresh-release-assets.yml` — trigger-type workflows (not PR gates), low frequency, few jobs. `ci-jetbrains.yml` has no pnpm action.
