### PR TITLE
fix(code): eliminate first-word duplication on reasoning/content streaming (state-layer batch snapshot + render-layer static reopen)

### DIFF
--- a/docs/specs/core/stream-content-updates.md
+++ b/docs/specs/core/stream-content-updates.md
@@ -139,7 +139,9 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 
 **为什么是这个优先级**：2026-08-08 起 SDK 回调只携带纯 chunk delta，消费端必须自行累积追加（`content += chunk`）；而 SDK 内部仍将累积全文写入消息块（先写全量、再按"新值 slice 当前长度"计算并回调 chunk delta）。若消费端在 `onAssistantMessageAdded`/`onUserMessageAdded` 时直接把 `agent.messages` 中的消息对象活引用推入自己的状态，第一个 delta 到达时 SDK 已把共享块内容替换为完整累积值，消费端追加逻辑会读到此已更新值再拼接该 delta——首个 delta 被重复计数，表现为"reasoning 第一个单词重复"（如 `LetLet me think about this.`）。文本内容同理受影响，只是文本流通常在消息解耦后才出现而不易暴露。
 
-**独立测试**：构造一个带 reasoning 流式的会话，用与 CLI 相同的消费模式（推入活引用 + 追加 reducer）验证出现首词重复；改用快照推入（`{ ...m, blocks: m.blocks.map(b => ({ ...b })) }`）后同一断言通过。
+2026-08-17 补充：快照必须**在回调触发时刻立即捕获**（`onAssistantMessageAdded`/`onUserMessageAdded` 被调用时同步执行 `snapshotMessage(msg)` 并保存结果），不能在 React state updater 内延迟执行。原因是 React 会把同一同步 tick 内的多次 `setMessages` 批处理，updater 函数到 flush 时才运行——而 SDK 的 `addAssistantMessage()` → 就地写入首个 chunk → 首个 delta 回调恰好处于同一同步 tick（`aiManager.ts` 的 `onContentUpdate`/`onReasoningUpdate`），flush 时延迟快照复制到的已是变异后的消息块，首个 delta 再追加即翻倍（`HelloHello`）。该竞态表现为"推理流结束后正文首个单词重复"（首个 content delta 与 messageAdded 落入同一批时），或首个 reasoning delta 重复（reasoning 折叠区，不易察觉）。
+
+**独立测试**：构造一个带 reasoning 流式的会话，用与 CLI 相同的消费模式（推入活引用 + 追加 reducer）验证出现首词重复；改用快照推入（`{ ...m, blocks: m.blocks.map(b => ({ ...b })) }`）后同一断言通过。另有同批回归测试：在**同一同步 tick** 内连续调用 `onAssistantMessageAdded` → 就地变异消息块 → 首个 delta 回调（无 await 间隔，与真实 SDK 顺序一致），断言消息内容不翻倍（content `Hello` 非 `HelloHello`、reasoning `Let` 非 `LetLet`、reasoning 收尾后首个 content chunk 同批时两通道均不重复）。
 
 **验收场景**：
 
@@ -147,6 +149,7 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 2. **假设**助手消息流式输出 reasoning，**当**消费端按 `chunk` delta 累积追加时，**则**追加结果与 SDK 存储的完整推理内容一致，首个 delta 不重复（首个单词不翻倍）
 3. **假设**消费端通过拉取通道（`agent.messages` / `getMessages`）获取全量列表，**当**把拉取结果推入状态时，**则**同样以快照推入，不与 SDK 内部对象共享引用
 4. **假设**消费端已按快照推入消息，**当** SDK 继续就地更新其内部消息块时，**则**消费端状态不受影响，仅通过后续 delta 回调获得更新
+5. **假设**消息创建回调与首个 delta 回调落在同一 React 批处理内（同一同步 tick：`addAssistantMessage()` → 就地写入首个 chunk → 首个 delta 回调），**当**消费端把快照推入状态时，**则**快照在回调触发时刻立即捕获（updater 外），复制的是变异前的空块；首个 delta 追加后首个单词不翻倍
 
 ---
 
@@ -168,6 +171,25 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 
 ---
 
+### 用户故事：CLI 静态块 reopen 不重复渲染冻结前缀（优先级：P1）
+
+作为 CLI 使用者，我希望推理/正文块在一次 AI 调用内交错续写（同块 `end` → `streaming` 重新打开）时，屏幕上已显示的内容不重复，流式增量继续实时可见。
+
+**为什么是这个优先级**：CLI 用 Ink `<Static>` 渲染历史消息，其 append-only 语义（`items.slice(index)` 只追加新项、已渲染项永不更新）与消息列表的"静态/动态分区"叠加产生渲染层重复：文本/推理块一旦进入静态区，其内容就冻结在终端输出中；当同一块因模型交错输出（如 `T→R→T` 或 `R→T→R`）重新打开（`stage` 从 `end` 回到 `streaming`）时，该块从静态区迁移回动态区，动态区以**全量累积内容**重新渲染——屏幕上"冻结前缀 + 全量内容"首词重复（如正文 `The answer is 42` 的 `The answer` 出现两次）。这是第三类首词重复（前两类为状态层：活引用/批处理快照、节流残留竞态），根因在渲染层而非状态层——SDK→CLI 状态始终一致，纯 delta 追加无重复，重复发生在 Ink 输出拼接。
+
+**独立测试**：构造单条消息的阶段序列（推理流 → 收尾 → 正文流 → 推理 reopen 续写 → 收尾），逐阶段 `rerender` 并收集 `ink-testing-library` 全部帧，断言每一帧中每个块内容至多出现一次（`MessageList.block-reopen-duplication.test.tsx`：推理 reopen、正文 reopen=用户症状、reopen 期间增量可见三类用例）。无修复时断言失败（冻结前缀 + 动态全量 → 计数 2），修复后通过。
+
+**验收场景**：
+
+1. **假设**推理块已收尾（`stage="end"`，内容已进入静态区），**当**同一块重新打开流式续写（`stage="streaming"`）时，**则**屏幕上该块已显示的前缀不重复出现，动态区只渲染续写增量（`content` 超出冻结前缀的部分）
+2. **假设**正文块已收尾（如模型先输出正文、再推理、再继续正文，正文块 `end` → `streaming`），**当**正文续写流式输出时，**则**正文首词不重复（用户可感知症状：推理流结束后正文首个单词重复）
+3. **假设**reopen 块在动态区以增量渲染，**当**新增量到达时，**则**续写内容实时可见（增量 + 冻结前缀拼接后等于完整内容，视觉上无跳变）
+4. **假设**reopen 块再次收尾，**当**其回到静态区时，**则**不因位置已被冻结项占据而重新渲染全量内容，屏幕保持稳定
+5. **假设**reopen 块曾被静态写入过多次（多次 reopen），**当**后续续写流式输出时，**则**增量始终相对**首次**冻结内容计算（静态区永不更新已渲染项），多轮续写拼接正确
+6. **假设**消息被 rewind/clear 移除，**当**再次渲染时，**则**冻结内容记录随块移除而清理，不残留过期键
+
+---
+
 ### 边界情况
 
 - 当网络连接较差且流式块乱序到达或延迟时会发生什么？
@@ -185,7 +207,7 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 - **增量回调用途**：为第三方集成、扩展、CLI 与示例（如 `packages/code/src/print-cli.ts` 和 `packages/agent-sdk/examples`）提供实时流式数据；增量回调是消息状态同步的唯一推送通道
 - **SDK 回调负载**：`onAssistantContentUpdated`/`onAssistantReasoningUpdated` 只提供 `chunk`（增量）+ `messageId` + `stage`，不再携带 `accumulated` 累积值，进程内消费者（CLI、print-cli）自行累积追加；`onToolBlockUpdated` 在 `stage="streaming"` 时只提供 `parametersChunk`（增量），`start`/`running`/`end` 阶段携带权威 `parameters`（end 为最终值，一次性权威）。SDK 内部仍将 chunk 追加进内存 `toolBlock.parameters` 保持累积，只是累积值不再暴露到外部回调
 - **跨进程 wire 负载（纯 delta）**：agentBridge 原样透传增量回调负载——`assistantContentUpdated`/`assistantReasoningUpdated` 只携带 `{messageId, chunk, stage}`（SDK 回调本身已无累积字段，无需剥离）；`toolBlockUpdated` 在 `stage="streaming"` 时只携带 `parametersChunk`，`stage="end"` 时携带全量 `parameters` + `result` 作为权威值。消费端负责累积（追加），丢失的 delta 由 `getMessages` 拉取的全量快照自愈
-- **UI 状态流**：CLI 直接订阅增量回调就地更新消息（chunk 追加，原始频率无节流——见「CLI 以原始频率渲染流式内容」用户故事；渲染频率由 Ink 内置 30fps 输出节流兜底）；插件/桌面经 stdio 增量通知（`userMessageAdded`、`assistantContentUpdated`、`toolBlockUpdated` 等，纯 delta 负载）驱动 webview 增量 reducer——文本/推理块追加 chunk、工具块追加 `parametersChunk`，end 时以权威值终结；需要完整列表的场景（初始化、compact、rewind、clear、bang）主动拉取，拉取响应整体替换为权威快照。进程内消费端把 SDK 消息对象推入自有状态时**必须克隆**（消息 + blocks 至少一层），不得持有 SDK 内部活引用——SDK 会就地更新共享块，与消费端累积追加叠加会重复计数（见"增量消费端以快照推入消息"用户故事）
+- **UI 状态流**：CLI 直接订阅增量回调就地更新消息（chunk 追加，原始频率无节流——见「CLI 以原始频率渲染流式内容」用户故事；渲染频率由 Ink 内置 30fps 输出节流兜底）；插件/桌面经 stdio 增量通知（`userMessageAdded`、`assistantContentUpdated`、`toolBlockUpdated` 等，纯 delta 负载）驱动 webview 增量 reducer——文本/推理块追加 chunk、工具块追加 `parametersChunk`，end 时以权威值终结；需要完整列表的场景（初始化、compact、rewind、clear、bang）主动拉取，拉取响应整体替换为权威快照。进程内消费端把 SDK 消息对象推入自有状态时**必须克隆**（消息 + blocks 至少一层）且**在回调触发时刻立即捕获**（不得在 React state updater 内延迟求值——批处理 flush 晚于 SDK 就地变异，见"增量消费端以快照推入消息"用户故事），不得持有 SDK 内部活引用——SDK 会就地更新共享块，与消费端累积追加叠加会重复计数（见"增量消费端以快照推入消息"用户故事）。**渲染层**：CLI 消息列表的静态/动态分区必须遵守 append-only 约束——进入 `<Static>` 区的块（其内容已冻结在终端输出中）若因同块 reopen（`end` → `streaming`）回到动态区，动态区只能渲染"超出冻结前缀"的增量（`content.slice(冻结长度)`），否则冻结前缀与全量重渲染叠加造成首词重复（见「CLI 静态块 reopen 不重复渲染冻结前缀」用户故事）；冻结内容按块 key 记录（写入静态区的时刻），多轮 reopen 恒相对首次冻结内容计算
 - **节流语义**：SDK 回调与 wire 通知均只携带纯 delta。CLI 进程内消费端不再节流（原始频率立即应用，见「CLI 以原始频率渲染流式内容」用户故事）；其余仍选择节流的宿主（如 VSCE/桌面 webview 通道），节流器一律按到达顺序拼接窗口内所有 chunks 为一个合并 delta（window-concat），绝不能 last-value-wins 丢弃中间值。为配合该语义，SDK 必须在每次 running 事件中重复携带 `compactParams` 等稳定展示字段（见"工具块阶段更新"验收场景 4），保证丢弃中间事件不丢失这些字段
 - **清晰分离**：增量回调是消息状态管理的正式对外通道；全量数据按需获取，避免随每次流式 chunk 序列化整个列表
 
@@ -255,6 +277,7 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 
 - 问：CLI 中所有 reasoning 第一个单词重复的根因 → 答：进程内增量消费端（CLI useChat）在 `onAssistantMessageAdded` 时把 `agent.messages` 中的 SDK 消息对象**活引用**推入 React 状态；`updateCurrentMessageReasoning` 先就地替换共享块为完整累积值、再按"新值 slice 当前长度"计算并回调 chunk delta。首个 delta 到达时消费端追加逻辑（`content += chunk`）读到已被 SDK 更新的完整值再拼接该 chunk → 首词翻倍（`Let` + `Let me think about this.`）；首个 delta 处理完成、消息与 SDK 解耦后，后续 delta 正常
 - 问：修复位置 → 答：消费端边界。CLI 在推入消息时必须克隆（`{ ...m, blocks: m.blocks.map(b => ({ ...b })) }`），不得持有 SDK 内部消息对象活引用；SDK 就地更新与回调顺序（先写全量、再回 delta）不变。覆盖所有推入点：`onAssistantMessageAdded`、`onUserMessageAdded`、拉取全量（`refreshMessages`、初始 `setMessages(agent.messages)`）
+- 问：快照放在 React state updater 里执行行不行 → 答：不行。`onAssistantMessageAdded` 与首个 delta 回调落在同一同步 tick（`addAssistantMessage()` → 就地写入 → delta 回调），React 将同一 tick 的 `setMessages` 批处理，updater 到 flush 时才运行——此时快照复制的是已被 SDK 写入首个 chunk 的消息块，首个 delta 追加后首词翻倍（`HelloHello`）。快照必须在**回调触发时刻**（`snapshotMessage(msg)` 在 `setMessages` 之外、`onAssistantMessageAdded` 内立即执行）捕获变异前状态。同批回归测试：同一 tick 内依次调用 messageAdded → 变异 → 首个 delta（无 await 间隔），断言不翻倍
 - 问：为什么不在 SDK 侧改 → 答：SDK 就地更新是 `getMessages` 权威快照的基础，先写全量再回 delta 保证回调时刻 SDK 状态已一致；改为先回调再写会让拉取与回调交错时读到过期值。快照克隆成本只在消息创建时发生一次，与流式 delta 数量无关
 
 ### 2026-08-17 会议（CLI 移除 500ms 节流、原始频率渲染）
@@ -263,6 +286,15 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 - 问：渲染性能是否受影响 → 答：不会。Ink 7.1.1 内置输出节流（`maxFps: 30` → ~34ms，leading+trailing）约束终端写入频率，与消费端节流无关；`<Static>` append-only 使历史消息永不重绘（`fullStaticOutput += staticOutput`）；`renderInteractiveFrame` 仅在 `output !== lastOutput` 时写入，log-update 再做增量 diff。React commit 频率等于 delta 到达频率，每次 commit 对全量可见消息做 `flatMap` + 元素重建，典型会话规模（≤30 条可见消息）为亚毫秒级
 - 问：受影响范围 → 答：仅 CLI 进程内消费端（`packages/code/src/contexts/useChat.tsx`）——移除内容/reasoning 通道的 `createStreamingWindowThrottle`（500ms）与 tool 通道的 `createToolStreamingThrottle`（同一 pending 窗口 + 全量刷新竞态结构、同一逐 token 高频来源），每个 delta 立即经 reducer 应用。VSCE/桌面跨进程通道保留 window-concat 节流语义不变（wire 通知频率较低，非首词重复来源）
 - 问：原「每秒 2-3 次内容更新」假设为何移除 → 答：该假设是 500ms 节流的设计依据；移除节流后更新频率由模型产出速率决定，终端写入频率由 Ink 30fps 兜底，无需人为限频
+
+### 2026-08-18 会议（CLI Static 块 reopen 渲染层首词重复）
+
+- 问：本次（第三类）首词重复与之前两类的区别 → 答：前两类在状态层——活引用/批处理快照（2026-08-12）与节流残留竞态（2026-08-17），状态先重复再渲染；本次在渲染层——SDK→CLI 状态始终一致（纯 delta 追加、逐帧对账无重复），重复只出现在 Ink 输出拼接。根因：CLI 消息列表的静态/动态分区中，文本/推理块一旦收尾就进入 `<Static>` 区被冻结；同块因模型交错输出（`T→R→T` 或 `R→T→R`）重新打开（`end`→`streaming`）时迁移回动态区，动态区以全量累积内容渲染，与屏幕上已冻结的前缀叠加 → 首词重复。复现概率低，因为需要单次调用内交错续写
+- 问：为什么不能用"reopen 块永久留在静态区"修复 → 答：静态区 append-only、永不更新已渲染项，块留在静态区后续写内容永远不会显示，消息后半段的流式反馈会整体冻结（屏幕停在首个 reopen 时刻），流式体验退化
+- 问：为什么不能整条消息动态化 → 答：reopen 只发生在消息运行期，但"消息运行"包含长工具执行（分钟级）——整条消息动态化会让已完成的超长文本块在每次工具状态更新时全量重建（性能回归），且冻结过的块回到动态区同样重复
+- 问：修复方案 → 答：按块 key 记录"写入静态区时刻的内容"（冻结前缀，镜像 `<Static>` 内部 index 判断哪些项真正被追加）；reopen 块在动态区只渲染 `content.slice(冻结长度)` 增量——冻结前缀 + 动态增量拼接等于完整内容，无重叠、无重复、续写实时可见。多轮 reopen 恒相对首次冻结内容计算（静态区从不更新已渲染项）
+- 问：如何确定哪些静态项真正被写入终端 → 答：镜像 `<Static>` 的 index 语义（`useLayoutEffect` 后 index = 上次 `items.length`），静态列表位置 ≥ index 的项在本 pass 被追加写入，其内容才记录为冻结；位置 < index 的项（reopen 时被顶到已占用位置的"填充块"）从未写入，不记录——它们后续 reopen 时仍以全量渲染（从未显示过，无重复问题）
+- 问：回归测试如何捕获转瞬重复 → 答：逐阶段 `rerender` 后断言**每一帧**（ink-testing-library `frames`）中每个块内容至多出现一次，而非只断言末帧——重复只在 reopen 流式窗口内存在，末帧（块回到静态区）已无重复。无修复时全部 3 用例失败（帧计数 2），修复后通过
 
 ## 假设 _（必填）_
 

--- a/packages/code/src/components/MessageList.tsx
+++ b/packages/code/src/components/MessageList.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useLayoutEffect, useRef } from "react";
 import os from "os";
 import { Box, Text, Static, useWindowSize } from "ink";
 import type { Message, MessageBlock } from "wave-agent-sdk";
@@ -103,6 +103,67 @@ export const MessageList = React.memo(
       ...staticBlocks.map((b) => ({ ...b, isWelcome: false })),
     ];
 
+    // Track the content that was written into the append-only <Static> zone for
+    // each block. Ink's <Static> never updates an already-rendered item, so when
+    // a text/reasoning block reopens (stage "end" -> "streaming") the frozen
+    // prefix stays on screen while the dynamic zone would re-render the FULL
+    // accumulated content — duplicating the first words. Rendering only the
+    // delta (content beyond the frozen prefix) in the dynamic zone avoids the
+    // overlap.
+    const frozenContentRef = useRef(new Map<string, string>());
+    // Mirrors <Static>'s internal index (the previous static items.length) so we
+    // know which static items are actually appended to the terminal output in
+    // this render pass. Only those items get their content frozen.
+    const staticIndexRef = useRef(0);
+
+    useLayoutEffect(() => {
+      staticIndexRef.current = staticItems.length;
+    }, [staticItems.length]);
+
+    // Record the content of static items being appended this pass, and prune
+    // keys for blocks that no longer exist (e.g. rewound or cleared messages).
+    // Only text/reasoning blocks carry content and can reopen (end -> streaming).
+    const currentKeys = new Set<string>();
+    staticItems.forEach((item, position) => {
+      if (item.isWelcome) return;
+      currentKeys.add(item.key);
+      if (
+        position >= staticIndexRef.current &&
+        (item.block!.type === "text" || item.block!.type === "reasoning")
+      ) {
+        frozenContentRef.current.set(item.key, item.block!.content);
+      }
+    });
+    for (const item of dynamicBlocks) {
+      currentKeys.add(item.key);
+    }
+    for (const key of frozenContentRef.current.keys()) {
+      if (!currentKeys.has(key)) {
+        frozenContentRef.current.delete(key);
+      }
+    }
+
+    // Reopened blocks (in the dynamic zone but previously written to static)
+    // must render only the content beyond the frozen prefix, otherwise the
+    // already-displayed prefix appears twice on screen.
+    const dynamicBlocksWithDelta = dynamicBlocks.map((item) => {
+      const frozen = frozenContentRef.current.get(item.key);
+      if (
+        frozen !== undefined &&
+        (item.block.type === "text" || item.block.type === "reasoning") &&
+        item.block.content.length > frozen.length
+      ) {
+        return {
+          ...item,
+          block: {
+            ...item.block,
+            content: item.block.content.slice(frozen.length),
+          },
+        };
+      }
+      return item;
+    });
+
     return (
       <Box flexDirection="column" paddingBottom={1}>
         {/* Static items (Welcome message + Static blocks) */}
@@ -136,9 +197,9 @@ export const MessageList = React.memo(
         )}
 
         {/* Dynamic blocks */}
-        {dynamicBlocks.length > 0 && (
+        {dynamicBlocksWithDelta.length > 0 && (
           <Box flexDirection="column">
-            {dynamicBlocks.map((item) => (
+            {dynamicBlocksWithDelta.map((item) => (
               <MessageBlockItem
                 key={item.key}
                 block={item.block}

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -177,6 +177,15 @@ interface StreamingUpdateParams {
  * reasoning and text content alike. See docs/specs/core/stream-content-updates.md.
  * The clone must be at least one layer deep (message + blocks) so the in-place
  * block mutation never leaks into consumer state.
+ *
+ * IMPORTANT: the caller must invoke this EAGERLY at callback time and capture
+ * the result before scheduling any state update. React batches setState calls
+ * that happen in the same synchronous tick and runs the updater functions only
+ * at flush time — after the SDK has already written the first chunk into the
+ * shared message. A snapshot evaluated inside the updater (lazily) would copy
+ * the post-mutation blocks, and the first delta append would then double-count
+ * the first word ("HelloHello") whenever `onAssistantMessageAdded` and the
+ * first delta callback land in the same batch.
  */
 const snapshotMessage = (message: Message): Message => ({
   ...message,
@@ -485,20 +494,24 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
           const msgs = agentRef.current.messages;
           const last = msgs[msgs.length - 1];
           if (!last || last.role !== "user") return;
+          // Eager snapshot at callback time — React defers updater execution to
+          // the batch flush, so evaluating snapshotMessage inside setMessages
+          // would read the SDK message after its in-place mutations.
+          const snapshot = snapshotMessage(last);
           setMessages((prev) =>
-            prev.some((m) => m.id === last.id)
-              ? prev
-              : [...prev, snapshotMessage(last)],
+            prev.some((m) => m.id === last.id) ? prev : [...prev, snapshot],
           );
         },
         onAssistantMessageAdded: (messageId: string) => {
           if (isExpandedRef.current || !agentRef.current) return;
           const msg = agentRef.current.messages.find((m) => m.id === messageId);
           if (!msg) return;
+          // Eager snapshot (see onUserMessageAdded): `addAssistantMessage()`
+          // fires this callback BEFORE the first delta writes into the shared
+          // message, so capturing here copies the pre-mutation (empty) blocks.
+          const snapshot = snapshotMessage(msg);
           setMessages((prev) =>
-            prev.some((m) => m.id === messageId)
-              ? prev
-              : [...prev, snapshotMessage(msg)],
+            prev.some((m) => m.id === messageId) ? prev : [...prev, snapshot],
           );
         },
         onAssistantContentUpdated: (params) => {

--- a/packages/code/tests/components/MessageList.block-reopen-duplication.test.tsx
+++ b/packages/code/tests/components/MessageList.block-reopen-duplication.test.tsx
@@ -1,0 +1,172 @@
+import React from "react";
+import { render } from "ink-testing-library";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { MessageList } from "../../src/components/MessageList.js";
+import { useTasks } from "../../src/hooks/useTasks.js";
+import { ChatContextType, useChat } from "../../src/contexts/useChat.js";
+import type { Message, MessageBlock } from "wave-agent-sdk";
+
+vi.mock("ink", async () => {
+  const actual = await vi.importActual("ink");
+  return {
+    ...actual,
+    useInput: vi.fn(),
+  };
+});
+
+vi.mock("../../src/hooks/useTasks.js", () => ({
+  useTasks: vi.fn(),
+}));
+
+vi.mock("../../src/contexts/useChat.js", () => ({
+  useChat: vi.fn(),
+}));
+
+describe("MessageList block reopen duplication", () => {
+  beforeEach(() => {
+    vi.mocked(useTasks).mockReturnValue([]);
+    vi.mocked(useChat).mockReturnValue({
+      isTaskListVisible: true,
+    } as unknown as ChatContextType);
+  });
+
+  const msg = (id: string, blocks: MessageBlock[]): Message => ({
+    id,
+    role: "assistant",
+    blocks,
+    timestamp: new Date().toISOString(),
+  });
+
+  const r = (content: string, stage: "streaming" | "end"): MessageBlock => ({
+    type: "reasoning",
+    content,
+    stage,
+  });
+  const t = (content: string, stage: "streaming" | "end"): MessageBlock => ({
+    type: "text",
+    content,
+    stage,
+  });
+  const tool = (stage: string, id = "tool-1"): MessageBlock =>
+    ({
+      type: "tool",
+      id,
+      name: "Grep",
+      parameters: '{"path":"/tmp"}',
+      compactParams: "Grep /tmp",
+      stage,
+      success: true,
+    }) as unknown as MessageBlock;
+
+  const countOccurrences = (frame: string, needle: string): number =>
+    frame.split(needle).length - 1;
+
+  const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+  // When a text/reasoning block reopens (stage "end" -> "streaming") it
+  // migrates from Ink's append-only <Static> zone back to the dynamic zone.
+  // The frozen prefix stays on screen while the dynamic render re-displays the
+  // full accumulated content, so the first words appear twice. Regression:
+  // every frame must show each block content at most once.
+  const runStages = async (stages: MessageBlock[][]) => {
+    const { rerender, frames } = render(
+      <MessageList messages={[msg("m1", stages[0])]} isExpanded={false} />,
+    );
+    await flush();
+    for (let i = 1; i < stages.length; i++) {
+      rerender(
+        <MessageList messages={[msg("m1", stages[i])]} isExpanded={false} />,
+      );
+      await flush();
+    }
+    return frames;
+  };
+
+  const expectAtMostOnce = (frames: string[], needles: string[]) => {
+    for (const [i, frame] of frames.entries()) {
+      for (const needle of needles) {
+        expect(
+          countOccurrences(frame, needle),
+          `frame ${i} contains "${needle}" more than once:\n${frame}`,
+        ).toBeLessThanOrEqual(1);
+      }
+    }
+  };
+
+  it("reasoning block reopen after tool does not duplicate frozen prefix", async () => {
+    // R1 streams -> T1 streams (R finalized) -> tool runs/completes -> R2
+    // arrives and reopens the finalized reasoning block -> re-finalizes -> end
+    const stages: MessageBlock[][] = [
+      [r("Think step one", "streaming")],
+      [r("Think step one", "end"), t("Answer text", "streaming")],
+      [
+        r("Think step one", "end"),
+        t("Answer text", "streaming"),
+        tool("running"),
+      ],
+      [r("Think step one", "end"), t("Answer text", "streaming"), tool("end")],
+      [
+        r("Think step one Think step two", "streaming"),
+        t("Answer text", "end"),
+        tool("end"),
+      ],
+      [
+        r("Think step one Think step two", "end"),
+        t("Answer text", "streaming"),
+        tool("end"),
+      ],
+      [
+        r("Think step one Think step two", "end"),
+        t("Answer text", "end"),
+        tool("end"),
+      ],
+    ];
+
+    const frames = await runStages(stages);
+    expectAtMostOnce(frames, ["Think step one", "Answer text", "Grep /tmp"]);
+    const final = frames[frames.length - 1];
+    expect(countOccurrences(final, "Think step one")).toBe(1);
+    expect(countOccurrences(final, "Answer text")).toBe(1);
+  });
+
+  it("text block reopen after reasoning does not duplicate first words", async () => {
+    // The reported symptom: reasoning streams after the text has started, then
+    // the text resumes — the text block reopens and its already-displayed first
+    // words are rendered again by the dynamic zone.
+    const stages: MessageBlock[][] = [
+      [t("The answer", "streaming")],
+      [t("The answer", "end"), r("Let me think", "streaming")],
+      [t("The answer is 42", "streaming"), r("Let me think", "end")],
+      [t("The answer is 42", "end"), r("Let me think", "end")],
+    ];
+
+    const frames = await runStages(stages);
+    expectAtMostOnce(frames, ["The answer", "Let me think"]);
+    const final = frames[frames.length - 1];
+    expect(countOccurrences(final, "The answer")).toBe(1);
+  });
+
+  it("reopened block streams new content without overlapping the frozen prefix", async () => {
+    // During the reopen window the dynamic zone must render only the delta
+    // (content beyond the frozen prefix), so the new reasoning suffix is
+    // visible while the already-displayed prefix is not repeated.
+    const stages: MessageBlock[][] = [
+      [r("Think step one", "streaming")],
+      [r("Think step one", "end"), t("Answer text", "streaming")],
+      [r("Think step one", "end"), t("Answer text", "end")],
+      [
+        r("Think step one Think step two", "streaming"),
+        t("Answer text", "end"),
+      ],
+      [r("Think step one Think step two", "end"), t("Answer text", "end")],
+    ];
+
+    const frames = await runStages(stages);
+    // The reopen-streaming frame (index for stage 3) must show the suffix
+    // "Think step two" (via the delta) but never the repeated prefix.
+    const reopenFrame = frames.findIndex((f) => f.includes("Think step two"));
+    expect(reopenFrame).toBeGreaterThan(-1);
+    expect(countOccurrences(frames[reopenFrame], "Think step one")).toBe(1);
+    expect(countOccurrences(frames[reopenFrame], "Think step two")).toBe(1);
+  });
+});

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -1819,6 +1819,208 @@ describe("ChatProvider", () => {
     expect(lastValue?.messages[0]).not.toBe(mockAgent.messages[0]);
   });
 
+  it("does not double-count the first content chunk when messageAdded and the first delta land in the same React batch", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
+    const callbacks = agentCreateArgs.callbacks!;
+
+    const assistantMsg = {
+      id: "msg-same-batch-text",
+      role: "assistant" as const,
+      blocks: [] as Array<{
+        type: string;
+        content: string;
+        stage: string;
+      }>,
+      timestamp: new Date().toISOString(),
+    };
+    Object.assign(mockAgent, { messages: [assistantMsg] });
+
+    // Regression (2026-08-17): the real SDK fires addAssistantMessage() →
+    // updateCurrentMessageContent() back-to-back in the SAME synchronous tick
+    // (aiManager.ts onContentUpdate). React batches the two setMessages calls
+    // and runs the updater functions only at flush time — AFTER the SDK has
+    // written the first chunk into the shared message. A snapshot evaluated
+    // lazily inside the updater then copies the post-mutation blocks, and the
+    // first delta append double-counts the first word ("HelloHello"). The
+    // snapshot must be captured eagerly at callback time, pre-mutation. The
+    // older double-count tests above await between messageAdded and the delta,
+    // which commits the batch before the mutation and misses this hole.
+    const sdkMsg = mockAgent.messages[0] as unknown as {
+      blocks: Array<{ type: string; content: string; stage: string }>;
+    };
+    // ── no await between these three calls (real SDK order) ──
+    callbacks.onAssistantMessageAdded!("msg-same-batch-text");
+    sdkMsg.blocks.push({
+      type: "text",
+      content: "Hello",
+      stage: "streaming",
+    });
+    callbacks.onAssistantContentUpdated!({
+      messageId: "msg-same-batch-text",
+      chunk: "Hello",
+      stage: "streaming",
+    });
+    // ───────────────────────────────────────────────────────────
+
+    await vi.waitFor(() => {
+      expect(lastValue?.messages).toHaveLength(1);
+      const text = lastValue?.messages[0].blocks[0] as
+        | { content: string }
+        | undefined;
+      // Single "Hello", never "HelloHello"
+      expect(text?.content).toBe("Hello");
+    });
+  });
+
+  it("does not double-count the first reasoning chunk when messageAdded and the first delta land in the same React batch", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
+    const callbacks = agentCreateArgs.callbacks!;
+
+    const assistantMsg = {
+      id: "msg-same-batch-reason",
+      role: "assistant" as const,
+      blocks: [] as Array<{
+        type: string;
+        content: string;
+        stage: string;
+      }>,
+      timestamp: new Date().toISOString(),
+    };
+    Object.assign(mockAgent, { messages: [assistantMsg] });
+
+    // Same same-tick scenario as the content case, for the reasoning channel.
+    // The user-visible symptom: the reasoning stream ends and the CONTENT's
+    // first word shows duplicated when the first content delta joins the same
+    // batch as messageAdded (short reasoning + immediate content, or coalesced
+    // stream reads) — the reasoning first word double-counts under the same
+    // mechanism whenever the reasoning delta opens the batch.
+    const sdkMsg = mockAgent.messages[0] as unknown as {
+      blocks: Array<{ type: string; content: string; stage: string }>;
+    };
+    callbacks.onAssistantMessageAdded!("msg-same-batch-reason");
+    sdkMsg.blocks.push({
+      type: "reasoning",
+      content: "Let",
+      stage: "streaming",
+    });
+    callbacks.onAssistantReasoningUpdated!({
+      messageId: "msg-same-batch-reason",
+      chunk: "Let",
+      stage: "streaming",
+    });
+
+    await vi.waitFor(() => {
+      expect(lastValue?.messages).toHaveLength(1);
+      const reasoning = lastValue?.messages[0].blocks.find(
+        (b) => b.type === "reasoning",
+      ) as { content: string } | undefined;
+      // Single "Let", never "LetLet"
+      expect(reasoning?.content).toBe("Let");
+    });
+  });
+
+  it("does not double-count when reasoning ends and the first content chunk joins the same batch", async () => {
+    let lastValue: ChatContextType | undefined;
+    const onHookValue = (val: ChatContextType) => {
+      lastValue = val;
+    };
+
+    renderWithProvider(onHookValue);
+
+    await vi.waitFor(() => {
+      expect(Agent.create).toHaveBeenCalled();
+    });
+
+    const agentCreateArgs = vi.mocked(Agent.create).mock.calls[0][0];
+    const callbacks = agentCreateArgs.callbacks!;
+
+    const assistantMsg = {
+      id: "msg-reason-to-content",
+      role: "assistant" as const,
+      blocks: [] as Array<{
+        type: string;
+        content: string;
+        stage: string;
+      }>,
+      timestamp: new Date().toISOString(),
+    };
+    Object.assign(mockAgent, { messages: [assistantMsg] });
+
+    // User's reported scenario: reasoning stream ends, the content that follows
+    // shows its first word duplicated. All SDK calls below are synchronous in
+    // one tick — messageAdded, reasoning mutation + delta, then the reasoning
+    // finalize + content mutation + first content delta (updateCurrentMessage
+    // Content finalizes the reasoning block first). Neither channel may
+    // double-count.
+    const sdkMsg = mockAgent.messages[0] as unknown as {
+      blocks: Array<{ type: string; content: string; stage: string }>;
+    };
+    callbacks.onAssistantMessageAdded!("msg-reason-to-content");
+    sdkMsg.blocks.push({
+      type: "reasoning",
+      content: "Let me think",
+      stage: "streaming",
+    });
+    callbacks.onAssistantReasoningUpdated!({
+      messageId: "msg-reason-to-content",
+      chunk: "Let me think",
+      stage: "streaming",
+    });
+    // Reasoning finalized, content begins (updateCurrentMessageContent)
+    sdkMsg.blocks[0].stage = "end";
+    callbacks.onAssistantReasoningUpdated!({
+      messageId: "msg-reason-to-content",
+      chunk: "",
+      stage: "end",
+    });
+    sdkMsg.blocks.push({
+      type: "text",
+      content: "Hello world",
+      stage: "streaming",
+    });
+    callbacks.onAssistantContentUpdated!({
+      messageId: "msg-reason-to-content",
+      chunk: "Hello world",
+      stage: "streaming",
+    });
+
+    await vi.waitFor(() => {
+      expect(lastValue?.messages).toHaveLength(1);
+      const reasoning = lastValue?.messages[0].blocks.find(
+        (b) => b.type === "reasoning",
+      ) as { content: string; stage: string } | undefined;
+      expect(reasoning?.content).toBe("Let me think");
+      expect(reasoning?.stage).toBe("end");
+      const text = lastValue?.messages[0].blocks.find(
+        (b) => b.type === "text",
+      ) as { content: string } | undefined;
+      // "Hello world", never "HelloHello world"
+      expect(text?.content).toBe("Hello world");
+    });
+  });
+
   it("does not duplicate content when a full-list refresh interleaves mid-stream", async () => {
     let lastValue: ChatContextType | undefined;
     const onHookValue = (val: ChatContextType) => {


### PR DESCRIPTION
## 背景

wave CLI 推理流式传输结束后显示的内容，第一个单词有一定概率重复。调研确认这是**同一症状的两个独立根因**，分别位于状态层与渲染层，本 PR 一并修复。

## 根因 1：状态层 —— 同批 messageAdded + 首个 delta 的延迟快照（提交 1）

`packages/code/src/contexts/useChat.tsx`

React 会把同一同步 tick 内的多次 `setMessages` 批处理，updater 到 flush 时才执行；而 SDK 在同一个 tick 内依次执行 `addAssistantMessage()` → 就地写入首个 chunk → delta 回调（`aiManager.ts` onContentUpdate/onReasoningUpdate）。在 updater 内**延迟**求值的 `snapshotMessage()` 复制到的是已被 SDK 变异后的消息块，消费端再追加首个 delta → 首词翻倍（`HelloHello` / `LetLet`）。

**修复**：快照改为在回调触发时刻**急切捕获**（`snapshotMessage()` 在 `setMessages` 之外、回调内立即执行），复制变异前的空块。

**回归测试**（`useChat.test.tsx` +202 行，3 用例，无 await 按真实 SDK 顺序驱动）：content 通道、reasoning 通道、以及用户报告场景（推理收尾 + 首个 content chunk 同批）——均断言首词不翻倍。

## 根因 2：渲染层 —— Ink `<Static>` append-only + 块 reopen 迁移（提交 2）

`packages/code/src/components/MessageList.tsx`

Ink `<Static>` 只追加、已渲染项永不更新：文本/推理块一旦收尾（`stage="end"`）进入静态区，内容即冻结在终端输出中。单次调用内交错续写（T→R→T 或 R→T→R；`messageManager.ts:831/887` 在对方通道到达时 finalize 当前块）会让同一块 reopen（`end→streaming`）迁回动态区，动态区以**全量累积内容**渲染 → 冻结前缀 + 全量内容 = 首词重复（低概率：需要单次调用内交错续写）。

**修复**：按块 key 记录写入静态区时刻的冻结内容（镜像 `<Static>` 内部 index 判断哪些项真正被追加），reopen 块在动态区只渲染 `content.slice(冻结长度)` 增量——无重叠、续写实时可见；多轮 reopen 恒相对首次冻结内容计算；rewind/clear 后过期键随块移除清理。

**回归测试**（`MessageList.block-reopen-duplication.test.tsx`，3 用例）：逐阶段 rerender 断言**每一帧**内容至多出现一次（重复只在 reopen 流式窗口内存在）；无修复时全部失败。

## 验证

- `pnpm -F wave-code test`：1419/1419 通过（100 文件）
- useChat.test.tsx 58/58；新增 3 用例 fail-without-fix 已确认（stash 验证）
- type-check（全仓）、eslint、prettier、docs 链接检查全绿
- spec-count：72 规格 / 385 用户故事 / 1493 验收场景

## Spec

`docs/specs/core/stream-content-updates.md`：
- 状态层补充「快照须在回调触发时刻立即捕获」根因、独立测试、验收场景 5、QA 记录
- 新增「CLI 静态块 reopen 不重复渲染冻结前缀」用户故事（6 验收场景）+ 状态管理架构渲染层规则 + QA 记录