### PR TITLE
docs: 首页补充桌面端使用方式与安装说明

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,9 @@ title: CodeChat
 
 # CodeChat AI辅助编程工具
 
-AI 辅助编程工具链，提供 SDK、CLI 终端界面、VS Code 扩展与 JetBrains 插件四种使用方式。
+AI 辅助编程工具链，提供 SDK、CLI 终端界面、VS Code 扩展、JetBrains 插件与桌面端五种使用方式。
 
-[企业管控台](/guide) · [VS Code 扩展 / JetBrains 插件](/vsce) · [CLI](/cli) · [SDK](/sdk)
+[企业管控台](/guide) · [VS Code 扩展 / JetBrains 插件](/vsce) · [桌面版](/desktop) · [CLI](/cli) · [SDK](/sdk)
 
 ## 快速开始
 
@@ -18,6 +18,10 @@ AI 辅助编程工具链，提供 SDK、CLI 终端界面、VS Code 扩展与 Jet
 ### JetBrains 插件
 
 在 JetBrains 插件市场（IDE「设置 → 插件」）搜索 **Wave Code Chat** 安装。打开聊天面板点击欢迎页的「登录」按钮完成 SSO 登录。
+
+### 桌面端
+
+在管控台「产品下载」页面下载 Wave 桌面版安装包（macOS / Windows）并安装。桌面端是独立应用，无需安装 IDE，安装后直接使用。
 
 ### CLI 终端
 
@@ -39,12 +43,12 @@ npm install wave-agent-sdk
 ```
 
 ```typescript
-import { Agent } from 'wave-agent-sdk';
+import { Agent } from "wave-agent-sdk";
 
 const agent = await Agent.create({
-  model: 'gpt-4',
-  apiKey: 'your-key',
-  baseURL: 'https://api.example.com/v1',
+  model: "gpt-4",
+  apiKey: "your-key",
+  baseURL: "https://api.example.com/v1",
   callbacks: {
     onAssistantContentUpdated: ({ chunk }) => {
       process.stdout.write(chunk);
@@ -52,6 +56,5 @@ const agent = await Agent.create({
   },
 });
 
-await agent.sendMessage('Hello!');
+await agent.sendMessage("Hello!");
 ```
-


### PR DESCRIPTION
## 变更内容

- 首页使用方式从四种改为五种：补充桌面端（SDK、CLI 终端界面、VS Code 扩展、JetBrains 插件、桌面端）
- 首页导航补充桌面版链接 /desktop
- 新增桌面端安装说明：在管控台「产品下载」页面下载安装包（macOS / Windows）并安装