### PR TITLE
fix(sdk): prevent destroy() from dispatching leftover queued messages

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -72,7 +72,8 @@ export class Agent {
   private reversionManager: ReversionManager;
   private messageQueue: MessageQueue; // Unified queue for messages, bang commands, and notifications
   private dispatchPromise: Promise<void> | null = null; // Track current dispatch for teardown
-  private isAborting = false; // Guard: prevents tryDispatch from firing during abortMessage
+  private isAborting = false; // Transient guard: prevents tryDispatch from firing during abortMessage (reset when the abort completes)
+  private isDestroyed = false; // Terminal guard: set in destroy(), never reset — no dispatch may ever start after destroy
   private dispatchAborted = false; // Set on abort while a dispatch is running: suppress the .finally re-check so preserved notifications don't get dispatched after abort
   private memoryRuleManager: MemoryRuleManager; // Add memory rule manager instance
   private liveConfigManager: LiveConfigManager; // Add live configuration manager
@@ -389,6 +390,7 @@ export class Agent {
    * onLoadingChange(false), and onCommandRunningChange(false).
    */
   private tryDispatch(): void {
+    if (this.isDestroyed) return; // Terminal: agent destroyed, never dispatch again
     if (this.isAborting) return; // Suppress dispatch during abort to prevent queued notifications from being dispatched as a side-effect
     if (this.dispatchAborted) return; // Aborted mid-dispatch: don't start a new dispatch (the user interrupted this turn)
     if (this.messageQueue.state !== "idle") return;
@@ -871,6 +873,13 @@ export class Agent {
 
   /** Destroy managers, clean up resources */
   public async destroy(): Promise<void> {
+    // Terminal guard: suppress any dispatch triggered during teardown (e.g. the
+    // onLoadingChange(false) fired by abortAIMessage() below, or the dispatch
+    // .finally re-check). Without this, leftover queued messages would be
+    // dispatched fire-and-forget and outlive the agent. Never reset: destroy()
+    // is terminal, no dispatch should ever start afterwards.
+    this.isDestroyed = true;
+
     // Log session_end event and shutdown telemetry
     await logOTelEvent("session_end", {
       duration: String(Math.round((Date.now() - this.sessionStartTime) / 1000)),

--- a/packages/agent-sdk/tests/agent/agent.abort.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.abort.test.ts
@@ -700,6 +700,80 @@ describe("Agent - Abort Handling", () => {
       sendSpy.mockRestore();
     });
 
+    it("destroy must not dispatch leftover queued messages", async () => {
+      const testAgent = await Agent.create({
+        apiKey: "test-key",
+        workdir: "/tmp/test-destroy-leftover",
+        callbacks: { onLoadingChange: vi.fn() },
+      });
+      activeTestAgent = testAgent;
+      const container = (testAgent as unknown as { container: Container })
+        .container;
+      container.register("ToolManager", mockToolManagerInstance);
+      container.register("McpManager", {
+        isMcpTool: vi.fn().mockReturnValue(false),
+        getMcpToolPlugins: vi.fn().mockReturnValue([]),
+        getMcpToolsConfig: vi.fn().mockReturnValue([]),
+      });
+      container.register("SubagentManager", {
+        getConfigurations: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("SkillManager", {
+        getAvailableSkills: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("ConfigurationService", {
+        resolveGatewayConfig: () => testAgent.getGatewayConfig(),
+        resolveModelConfig: () => testAgent.getModelConfig(),
+        resolveMaxInputTokens: () => testAgent.getMaxInputTokens(),
+        resolveAutoMemoryEnabled: () => true,
+        resolveLanguage: () => testAgent.getLanguage(),
+        getEnvironmentVars: () =>
+          (
+            testAgent as unknown as {
+              configurationService: {
+                getEnvironmentVars: () => Record<string, string>;
+              };
+            }
+          ).configurationService.getEnvironmentVars(),
+      });
+
+      const messageQueue = (
+        testAgent as unknown as {
+          messageQueue: import("@/managers/messageQueue.js").MessageQueue;
+        }
+      ).messageQueue;
+      const aiManager = (testAgent as unknown as { aiManager: AIManager })
+        .aiManager;
+
+      // Leave a queued message undelivered: disconnect the enqueue callback so
+      // it never auto-dispatches (same pattern as the queue-recall tests).
+      messageQueue.onMessageEnqueued = undefined;
+      messageQueue.enqueue({ content: "leftover message" });
+      expect(messageQueue.hasPending()).toBe(true);
+
+      // Spy on sendAIMessage to detect a leaked fire-and-forget dispatch
+      // triggered by destroy()'s abortAIMessage → onLoadingChange(false).
+      const sendSpy = vi
+        .spyOn(aiManager, "sendAIMessage")
+        .mockResolvedValue(undefined);
+
+      await testAgent.destroy();
+      activeTestAgent = undefined; // already destroyed above
+
+      // Let any leaked async dispatch settle before asserting
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // destroy() is terminal: leftover queued messages must NOT be dispatched
+      // as a new AI turn that outlives the agent (regression for #1808).
+      expect(sendSpy).not.toHaveBeenCalled();
+      expect(messageQueue.hasPending()).toBe(true);
+      expect(messageQueue.getQueue()).toHaveLength(1);
+
+      sendSpy.mockRestore();
+    });
+
     it("should reset queue state to idle on abort", async () => {
       const testAgent = await Agent.create({
         apiKey: "test-key",


### PR DESCRIPTION
## Problem

Windows CI intermittently fails with an "aborted queued dispatch ghost resurrection" (issue #1808): a callAgent fires with no corresponding sendAIMessage enter log.

Root cause: `destroy()` calls `abortAIMessage()` which fires `onLoadingChange(false)` → `tryDispatch()`. Unlike `abortMessage()`, `destroy()` never guarded dispatch, so leftover queued messages (e.g. notifications preserved from a session that ended while busy) were dispatched fire-and-forget as a new AI turn. That turn outlived the agent (fresh AbortController, blocked on pre-callAgent awaits) and fired callAgent during a later test window — the ghost.

## Fix

Add a terminal `isDestroyed` guard: set at the start of `destroy()`, never reset (destroy is terminal). Distinct from the transient `isAborting` guard used by `abortMessage()` (set then reset in finally). Blocks both the `onLoadingChange(false)` trigger and the in-flight dispatch `.finally` re-check.

## Verification

- New regression test: leftover queued messages are NOT dispatched on destroy (fails deterministically without the fix — sendAIMessage called 1×; passes with it)
- `tests/agent`: 37 files / 199 tests pass
- type-check + lint-staged hooks pass