### PR TITLE
feat(sdk): agent 生命周期确定性排空与 destroy 后公开 API 抛错

### DIFF
--- a/docs/specs/core/agent-lifecycle.md
+++ b/docs/specs/core/agent-lifecycle.md
@@ -1,0 +1,79 @@
+---
+name: "Agent 生命周期"
+description: "destroy() 的确定性排空语义：存活工作注册表、destroy 后公开 API 抛错、destroy 终态守卫（防幽灵 dispatch）"
+order: 145
+---
+
+# 功能规格说明：Agent 生命周期
+
+**创建日期**：2026-08-18
+
+## 用户场景与测试 _（必填）_
+
+### 用户故事：destroy 后公开 API 抛错（优先级：P1）
+
+作为 Agent SDK 的使用者，我希望在调用 `destroy()` 之后继续调用 `sendMessage` / `bang` / `askBtw` / `forkSubagent` 等公开 API 时得到一个明确的 `Agent destroyed` 错误，而不是被静默丢弃或在新生命周期上执行，以便在开发阶段就能立即发现生命周期误用（destroy 是终态操作，之后不允许任何新工作开始）。
+
+**为什么是这个优先级**：这是生命周期契约显式化的最小改动（几行 guard）。当前 destroy 后 `sendMessage` 会因 `isLoading=false` 直接走 `InteractionService.sendMessage` 在已销毁的 agent 上启动新的 AI 回合（幽灵的另一条路径），静默丢弃只会让误用靠幽灵暴露。
+
+**独立测试**：创建 Agent、调用 `destroy()`，随后分别调用 `sendMessage`、`bang`、`askBtw`、`forkSubagent`，验证每个调用都同步抛出 `Error("Agent destroyed")`，且不产生任何 AI 调用。
+
+**验收场景**：
+
+1. **假设** agent 已调用 `destroy()`，**当** 调用 `sendMessage("hello")` 时，**则** 抛出 `Error("Agent destroyed")`，且不会调用 `InteractionService.sendMessage` / `aiManager.sendAIMessage`
+2. **假设** agent 已调用 `destroy()`，**当** 调用 `bang("ls")` 时，**则** 抛出 `Error("Agent destroyed")`，且不会执行 bash 命令
+3. **假设** agent 已调用 `destroy()`，**当** 调用 `askBtw("question")` 时，**则** 抛出 `Error("Agent destroyed")`
+4. **假设** agent 已调用 `destroy()`，**当** 调用 `forkSubagent(prompt, { description })` 时，**则** 抛出 `Error("Agent destroyed")`
+5. **假设** agent 尚未销毁，**当** 调用上述任一公开 API 时，**则** 行为与现状完全一致（不抛错，正常入队或执行）
+
+---
+
+### 用户故事：destroy 确定性排空存活工作（优先级：P1）
+
+作为 Agent SDK 的使用者，我希望 `destroy()` 在返回前等待所有已注册的存活异步工作（dispatch、subagent、fork subagent 等 fire-and-forget 工作）排空，以便销毁后不存在任何跨生命周期存活的异步副作用（幽灵物理上不可能存在）。
+
+**为什么是这个优先级**：这是 #1808（destroy 后幽灵 dispatch）的治本方案。当前 destroy 仅等待 `dispatchPromise`，subagent / fork subagent 的 fire-and-forget IIFE（`subagentManager.executeAgent` 后台执行、`aiManager.runForkSubagent`）不在等待范围内——它们通过 `backgroundTaskManager.cleanup()` 被中止但未被 await。将「尽力清理」升级为「注册 → 中止 → await 排空（带超时兜底）→ 断言工作集为空」。
+
+**独立测试**：注册一个手动控制的存活工作（延迟 resolve 的 promise），调用 `destroy()`，验证 destroy 在控制 promise resolve 之前不返回；resolve 后 destroy 正常返回且工作集为空。
+
+**验收场景**：
+
+1. **假设** agent 有已注册的存活异步工作（如进行中的 fork subagent），**当** 调用 `destroy()` 时，**则** destroy 等待所有存活工作排空后才返回，工作集最终为空
+2. **假设** 存活工作在超时时间内未排空（如挂起的 promise），**当** destroy 等待超时后，**则** destroy 仍返回（超时兜底），但记录错误日志说明仍有 N 个存活工作（`Async work did not drain`）
+3. **假设** 存活工作排空后又有新的工作被注册（注册发生在 await 点之后），**当** destroy 的排空循环运行时，**则** 排空循环持续等待直到工作集为空或超时（循环直到空）
+4. **假设** agent 无任何存活工作，**当** 调用 `destroy()` 时，**则** 排空步骤立即返回，不引入额外延迟
+5. **假设** 注册的工作 promise reject，**当** 排空等待时，**则** reject 不产生未处理的 promise rejection（注册器吞掉错误，不影响工作集移除）
+
+---
+
+### 用户故事：destroy 终态守卫防止幽灵 dispatch（优先级：P1，回归保护）
+
+作为 Agent SDK 的使用者，我希望 `destroy()` 置为终态后不再触发任何新的 dispatch，以便 destroy 期间由 `abortAIMessage()` 触发的 `onLoadingChange(false)` 或 dispatch `.finally` 重查不会把遗留的排队消息作为新 AI 回合派发出去（#1808 幽灵回归）。
+
+**为什么是这个优先级**：这是 #1817 已修复行为的回归保护。destroy 是终态：`isDestroyed` 一旦设置永不重置，区别于 `abortMessage()` 的临时 `isAborting` 守卫。
+
+**独立测试**：在 message queue 中遗留一条未投递消息（断开 enqueue 回调），调用 `destroy()`，验证 `sendAIMessage` 未被调用、队列保持原样（回归测试已在 agent.abort.test.ts）。
+
+**验收场景**：
+
+1. **假设** message queue 有遗留消息且 agent 调用 `destroy()`，**当** destroy 内 `abortAIMessage()` 触发 `onLoadingChange(false)` 时，**则** `tryDispatch` 被 `isDestroyed` 守卫拦截，不派发新 AI 回合（`sendAIMessage` 调用次数为 0）
+2. **假设** dispatch 正在运行中调用 `destroy()`，**当** dispatch `.finally` 执行重查时，**则** 重查被 `isDestroyed` 拦截，不启动新 dispatch
+3. **假设** agent 调用 `abortMessage()`（非 destroy），**当** abort 完成后，**则** 若队列有遗留消息仍可正常恢复 dispatch（`isDestroyed` 为 false 时 `isAborting` 复位后行为不变）
+
+---
+
+## 边界情况
+
+- `destroy()` 可被多次调用：第二次调用不抛错（幂等），已置位的 `isDestroyed` 保持为 true
+- `sendMessage` 在 destroy 后调用：立即抛错，不修改消息队列、不调用 `InteractionService`
+- 存活工作注册表不限制工作数量；排空使用 deadline 超时（默认 10s）避免 destroy 无限挂起
+- 注册的 promise 在排空前 reject：注册器内部吞掉错误（保证不产生 unhandled rejection），工作集条目正常移除
+- 排空循环在 await 点之间可能注册新工作：循环条件为「工作集非空」，持续排空直到空或超时
+- 超时后仍存在的存活工作：destroy 照常返回（兜底），记录错误日志便于排查；这些工作不再受 agent 生命周期管理
+- destroy 与 abortMessage 的守卫区分：`isDestroyed` 是终态（destroy 设置后永不重置），`isAborting` 是瞬时态（abortMessage 设置、finally 复位）
+
+### 测试验证需求
+
+- 必须通过 spy `aiManager.sendAIMessage` / `InteractionService.sendMessage` / `bangManager.executeCommand` 验证 destroy 后公开 API 抛错且不产生调用
+- 必须通过注册一个手动控制 resolve 的 promise 验证 destroy 等待排空；通过永不 resolve 的 promise + 短超时验证超时兜底与错误日志
+- 必须通过 message queue 遗留消息场景验证 destroy 后 `sendAIMessage` 调用次数为 0（#1817 回归测试保留）

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -75,6 +75,7 @@ export class Agent {
   private isAborting = false; // Transient guard: prevents tryDispatch from firing during abortMessage (reset when the abort completes)
   private isDestroyed = false; // Terminal guard: set in destroy(), never reset — no dispatch may ever start after destroy
   private dispatchAborted = false; // Set on abort while a dispatch is running: suppress the .finally re-check so preserved notifications don't get dispatched after abort
+  private asyncWorkRegistry: import("./utils/asyncWorkRegistry.js").AsyncWorkRegistry; // Registry of live async work that destroy() drains before returning
   private memoryRuleManager: MemoryRuleManager; // Add memory rule manager instance
   private liveConfigManager: LiveConfigManager; // Add live configuration manager
   private taskManager: TaskManager;
@@ -204,6 +205,7 @@ export class Agent {
     this.bangManager = this.container.get("BangManager")!;
     this.cronManager = this.container.get("CronManager")!;
     this.messageQueue = this.container.get("MessageQueue")!;
+    this.asyncWorkRegistry = this.container.get("AsyncWorkRegistry")!;
 
     // Wire up CWD change callback from AIManager to sync Agent's workdir
     this.aiManager.setOnCwdChange((newCwd) => {
@@ -384,6 +386,18 @@ export class Agent {
   }
 
   /**
+   * Terminal-lifecycle guard for public APIs. destroy() is terminal: after it
+   * returns, no new work may start on this agent. Silent drops hid misuse until
+   * a ghost async side effect surfaced later (issue #1808); throwing surfaces
+   * the contract violation immediately at the call site.
+   */
+  private assertNotDestroyed(): void {
+    if (this.isDestroyed) {
+      throw new Error("Agent destroyed");
+    }
+  }
+
+  /**
    * Unified dispatch trigger — checks state machine before processing.
    * Handles user messages, bang commands, and background task notifications
    * through a single serialized path. Called from onMessageEnqueued,
@@ -398,18 +412,20 @@ export class Agent {
     if (this.aiManager.isLoading || this.isCommandRunning) return;
 
     this.messageQueue.transitionTo("dispatching");
-    this.dispatchPromise = this.processQueuedMessage()
-      .catch((error) => {
-        this.logger?.error("Failed to process queued message:", error);
-      })
-      .finally(() => {
-        this.messageQueue.transitionTo("idle");
-        this.dispatchPromise = null;
-        if (!this.dispatchAborted) {
-          this.tryDispatch(); // Re-check after processing
-        }
-        this.dispatchAborted = false;
-      });
+    this.dispatchPromise = this.asyncWorkRegistry.track(
+      this.processQueuedMessage()
+        .catch((error) => {
+          this.logger?.error("Failed to process queued message:", error);
+        })
+        .finally(() => {
+          this.messageQueue.transitionTo("idle");
+          this.dispatchPromise = null;
+          if (!this.dispatchAborted) {
+            this.tryDispatch(); // Re-check after processing
+          }
+          this.dispatchAborted = false;
+        }),
+    );
   }
 
   /**
@@ -674,6 +690,8 @@ export class Agent {
 
   /** Execute bash command (bang command) */
   public async bang(command: string): Promise<void> {
+    this.assertNotDestroyed();
+
     // If the agent is busy, enqueue the bang command
     if (this.aiManager.isLoading || this.isCommandRunning) {
       this.messageQueue.enqueue({ type: "bang", content: command });
@@ -954,7 +972,15 @@ export class Agent {
     }
     // Cleanup remote settings polling
     remoteSettingsService.shutdown();
-    // Cleanup memory store
+    // Drain live async work (dispatch, background subagents, fork subagents):
+    // abort steps above make them settle; wait for them so no async side
+    // effect outlives the agent. Timeout fallback keeps destroy bounded.
+    const drained = await this.asyncWorkRegistry.drain();
+    if (!drained) {
+      this.logger?.error(
+        `Async work did not drain: ${this.asyncWorkRegistry.size} live work item(s) remain after destroy`,
+      );
+    }
   }
 
   /**
@@ -982,6 +1008,7 @@ export class Agent {
     onContent?: (content: string) => void,
     onReasoning?: (content: string) => void,
   ): Promise<string> {
+    this.assertNotDestroyed();
     const result = await this.aiManager.runBtwFork(
       question,
       abortSignal,
@@ -1017,6 +1044,7 @@ export class Agent {
     },
     abortSignal?: AbortSignal,
   ): Promise<string> {
+    this.assertNotDestroyed();
     return this.aiManager.runForkSubagent(prompt, options, abortSignal);
   }
 
@@ -1050,6 +1078,8 @@ export class Agent {
     content: string,
     images?: Array<{ path: string; mimeType: string }>,
   ): Promise<void> {
+    this.assertNotDestroyed();
+
     // If the agent is busy, enqueue the message — unless it's an immediate
     // slash command (e.g., /clear, /compact) that should execute
     // right away even while AI is processing

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -52,6 +52,7 @@ import {
   wrapInSystemReminder,
 } from "../prompts/planModeReminders.js";
 import { Container } from "../utils/container.js";
+import { AsyncWorkRegistry } from "../utils/asyncWorkRegistry.js";
 import type { WorktreeSession } from "../utils/worktreeSession.js";
 import { recoverTruncatedJson } from "../utils/stringUtils.js";
 import { ConfigurationService } from "../services/configurationService.js";
@@ -240,6 +241,10 @@ export class AIManager {
 
   private get backgroundTaskManager(): BackgroundTaskManager | undefined {
     return this.container.get<BackgroundTaskManager>("BackgroundTaskManager");
+  }
+
+  private get asyncWorkRegistry(): AsyncWorkRegistry | undefined {
+    return this.container.get<AsyncWorkRegistry>("AsyncWorkRegistry");
   }
 
   private get hookManager(): HookManager | undefined {
@@ -1241,8 +1246,10 @@ export class AIManager {
     };
 
     // Fire-and-forget: the fork runs to completion in the background; the
-    // caller gets the task ID immediately.
-    (async () => {
+    // caller gets the task ID immediately. Tracked in the async work registry
+    // so destroy() drains it before returning (abort via the task's onStop
+    // makes the loop settle).
+    const forkPromise = (async () => {
       try {
         const result = await this.runForkLoop(
           historyMessages,
@@ -1294,6 +1301,7 @@ export class AIManager {
         abortCleanup?.();
       }
     })();
+    this.asyncWorkRegistry?.track(forkPromise);
 
     return taskId;
   }

--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -27,6 +27,7 @@ import {
 } from "../utils/messageOperations.js";
 
 import { Container } from "../utils/container.js";
+import { AsyncWorkRegistry } from "../utils/asyncWorkRegistry.js";
 import type { PermissionManager } from "./permissionManager.js";
 import type { PermissionMode } from "../types/permissions.js";
 import { ConfigurationService } from "../services/configurationService.js";
@@ -123,6 +124,10 @@ export class SubagentManager {
 
   private get configurationService(): ConfigurationService {
     return this.container.get<ConfigurationService>("ConfigurationService")!;
+  }
+
+  private get asyncWorkRegistry(): AsyncWorkRegistry | undefined {
+    return this.container.get<AsyncWorkRegistry>("AsyncWorkRegistry");
   }
 
   /**
@@ -536,7 +541,7 @@ export class SubagentManager {
 
         // Execute in background
         // Note: notification enqueueing is handled by internalExecute when instance.backgroundTaskId is set
-        (async () => {
+        const backgroundPromise = (async () => {
           try {
             const result = await this.internalExecute(
               instance,
@@ -567,6 +572,7 @@ export class SubagentManager {
             this.releaseInstance(instance.subagentId);
           }
         })();
+        this.asyncWorkRegistry?.track(backgroundPromise);
 
         return taskId;
       }

--- a/packages/agent-sdk/src/utils/asyncWorkRegistry.ts
+++ b/packages/agent-sdk/src/utils/asyncWorkRegistry.ts
@@ -1,0 +1,86 @@
+/**
+ * Registry of live async work that must drain before the agent is destroyed.
+ *
+ * Fire-and-forget work (dispatch, background subagents, fork subagents)
+ * registers its promise here so destroy() can wait deterministically instead
+ * of silently abandoning it (the "ghost work" class of #1808). The registry
+ * swallows rejections so an unregistered fire-and-forget caller can't turn a
+ * settled-then-removed promise into an unhandled rejection.
+ */
+export class AsyncWorkRegistry {
+  private work = new Set<Promise<unknown>>();
+  private waiters: Array<() => void> = [];
+
+  constructor(private readonly drainTimeoutMs: number = 10_000) {}
+
+  get size(): number {
+    return this.work.size;
+  }
+
+  isEmpty(): boolean {
+    return this.work.size === 0;
+  }
+
+  /**
+   * Register a promise as live work. The promise is removed when it settles
+   * (fulfilled or rejected); rejections are consumed here so tracking never
+   * produces an unhandled rejection. Returns the original promise unchanged
+   * so the caller can still await it.
+   */
+  track<T>(promise: Promise<T>): Promise<T> {
+    this.work.add(promise);
+    promise.then(
+      () => this.remove(promise),
+      () => this.remove(promise),
+    );
+    return promise;
+  }
+
+  private remove(promise: Promise<unknown>): void {
+    this.work.delete(promise);
+    if (this.work.size === 0) {
+      const waiters = this.waiters;
+      this.waiters = [];
+      for (const resolve of waiters) {
+        resolve();
+      }
+    }
+  }
+
+  /**
+   * Wait until the registry is empty, or until the timeout elapses. Loops
+   * until empty: work registered after an await point is still drained.
+   * Returns true if drained, false on timeout (leftover work is no longer
+   * lifecycle-managed).
+   */
+  async drain(timeoutMs: number = this.drainTimeoutMs): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (this.work.size > 0) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        return false;
+      }
+      // Wait for the registry to empty, or for the timeout — whichever comes
+      // first (a tracked promise may never settle).
+      let waiter: (() => void) | undefined;
+      const notified = new Promise<void>((resolve) => {
+        waiter = resolve;
+        this.waiters.push(resolve);
+      });
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timedOut = new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, remaining);
+      });
+      await Promise.race([notified, timedOut]);
+      if (timer) clearTimeout(timer);
+      // If the timer won, the work set is still non-empty: drop our waiter so
+      // a later drain isn't woken by a stale notification. If notified won,
+      // remove() already cleared the waiters array.
+      if (waiter && this.work.size > 0) {
+        const idx = this.waiters.indexOf(waiter);
+        if (idx >= 0) this.waiters.splice(idx, 1);
+      }
+    }
+    return true;
+  }
+}

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -28,6 +28,7 @@ import { MemoryService } from "../services/memory.js";
 import { AutoMemoryService } from "../services/autoMemoryService.js";
 import { USER_MEMORY_FILE } from "./constants.js";
 import { getGitMainRepoRoot } from "./gitUtils.js";
+import { AsyncWorkRegistry } from "./asyncWorkRegistry.js";
 import type { AgentOptions, McpServerConfig } from "../types/index.js";
 import type {
   PermissionMode,
@@ -92,6 +93,11 @@ export function setupAgentContainer(
 
   const messageQueue = new MessageQueue();
   container.register("MessageQueue", messageQueue);
+
+  // Registry of live async work that must drain before the agent is destroyed
+  // (dispatch, background subagents, fork subagents — the fire-and-forget work
+  // sites). destroy() awaits its drain() so no async work can outlive the agent.
+  container.register("AsyncWorkRegistry", new AsyncWorkRegistry());
 
   const foregroundTaskManager = new ForegroundTaskManager(container);
   container.register("ForegroundTaskManager", foregroundTaskManager);

--- a/packages/agent-sdk/tests/agent/agent.abort.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.abort.test.ts
@@ -774,6 +774,211 @@ describe("Agent - Abort Handling", () => {
       sendSpy.mockRestore();
     });
 
+    it("public APIs must throw after destroy", async () => {
+      const testAgent = await Agent.create({
+        apiKey: "test-key",
+        workdir: "/tmp/test-destroy-public-api",
+        callbacks: { onLoadingChange: vi.fn() },
+      });
+      activeTestAgent = testAgent;
+      const container = (testAgent as unknown as { container: Container })
+        .container;
+      container.register("ToolManager", mockToolManagerInstance);
+      container.register("McpManager", {
+        isMcpTool: vi.fn().mockReturnValue(false),
+        getMcpToolPlugins: vi.fn().mockReturnValue([]),
+        getMcpToolsConfig: vi.fn().mockReturnValue([]),
+      });
+      container.register("SubagentManager", {
+        getConfigurations: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("SkillManager", {
+        getAvailableSkills: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("ConfigurationService", {
+        resolveGatewayConfig: () => testAgent.getGatewayConfig(),
+        resolveModelConfig: () => testAgent.getModelConfig(),
+        resolveMaxInputTokens: () => testAgent.getMaxInputTokens(),
+        resolveAutoMemoryEnabled: () => true,
+        resolveLanguage: () => testAgent.getLanguage(),
+        getEnvironmentVars: () =>
+          (
+            testAgent as unknown as {
+              configurationService: {
+                getEnvironmentVars: () => Record<string, string>;
+              };
+            }
+          ).configurationService.getEnvironmentVars(),
+      });
+
+      const aiManager = (testAgent as unknown as { aiManager: AIManager })
+        .aiManager;
+      const sendSpy = vi
+        .spyOn(aiManager, "sendAIMessage")
+        .mockResolvedValue(undefined);
+
+      await testAgent.destroy();
+      activeTestAgent = undefined; // already destroyed above
+
+      // destroy() is terminal: every public entry point must reject loudly
+      // instead of silently dropping or starting new work on a dead agent.
+      await expect(testAgent.sendMessage("hello")).rejects.toThrow(
+        "Agent destroyed",
+      );
+      await expect(testAgent.bang("ls")).rejects.toThrow("Agent destroyed");
+      await expect(testAgent.askBtw("question")).rejects.toThrow(
+        "Agent destroyed",
+      );
+      await expect(
+        testAgent.forkSubagent("task", { description: "d" }),
+      ).rejects.toThrow("Agent destroyed");
+
+      expect(sendSpy).not.toHaveBeenCalled();
+
+      sendSpy.mockRestore();
+    });
+
+    it("destroy must wait for registered async work to drain", async () => {
+      const testAgent = await Agent.create({
+        apiKey: "test-key",
+        workdir: "/tmp/test-destroy-drain",
+        callbacks: { onLoadingChange: vi.fn() },
+      });
+      activeTestAgent = testAgent;
+      const container = (testAgent as unknown as { container: Container })
+        .container;
+      container.register("ToolManager", mockToolManagerInstance);
+      container.register("McpManager", {
+        isMcpTool: vi.fn().mockReturnValue(false),
+        getMcpToolPlugins: vi.fn().mockReturnValue([]),
+        getMcpToolsConfig: vi.fn().mockReturnValue([]),
+      });
+      container.register("SubagentManager", {
+        getConfigurations: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("SkillManager", {
+        getAvailableSkills: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("ConfigurationService", {
+        resolveGatewayConfig: () => testAgent.getGatewayConfig(),
+        resolveModelConfig: () => testAgent.getModelConfig(),
+        resolveMaxInputTokens: () => testAgent.getMaxInputTokens(),
+        resolveAutoMemoryEnabled: () => true,
+        resolveLanguage: () => testAgent.getLanguage(),
+        getEnvironmentVars: () =>
+          (
+            testAgent as unknown as {
+              configurationService: {
+                getEnvironmentVars: () => Record<string, string>;
+              };
+            }
+          ).configurationService.getEnvironmentVars(),
+      });
+
+      const asyncWorkRegistry = (
+        testAgent as unknown as {
+          asyncWorkRegistry: import("@/utils/asyncWorkRegistry.js").AsyncWorkRegistry;
+        }
+      ).asyncWorkRegistry;
+
+      // Register a manually-controlled live work item (e.g. an in-flight fork
+      // subagent). destroy() must not return until it settles.
+      let resolveWork!: () => void;
+      const work = new Promise<void>((resolve) => {
+        resolveWork = resolve;
+      });
+      asyncWorkRegistry.track(work);
+      expect(asyncWorkRegistry.size).toBe(1);
+
+      let destroyResolved = false;
+      const destroyPromise = testAgent.destroy().then(() => {
+        destroyResolved = true;
+      });
+      activeTestAgent = undefined; // already destroyed above
+
+      // destroy() must be blocked while the live work is pending
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(destroyResolved).toBe(false);
+
+      // Settle the work: destroy() must now complete and the registry must be empty
+      resolveWork();
+      await destroyPromise;
+      expect(destroyResolved).toBe(true);
+      expect(asyncWorkRegistry.size).toBe(0);
+    });
+
+    it("destroy must return with an error log when async work does not drain", async () => {
+      const testAgent = await Agent.create({
+        apiKey: "test-key",
+        workdir: "/tmp/test-destroy-drain-timeout",
+        callbacks: { onLoadingChange: vi.fn() },
+      });
+      activeTestAgent = testAgent;
+      const container = (testAgent as unknown as { container: Container })
+        .container;
+      container.register("ToolManager", mockToolManagerInstance);
+      container.register("McpManager", {
+        isMcpTool: vi.fn().mockReturnValue(false),
+        getMcpToolPlugins: vi.fn().mockReturnValue([]),
+        getMcpToolsConfig: vi.fn().mockReturnValue([]),
+      });
+      container.register("SubagentManager", {
+        getConfigurations: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("SkillManager", {
+        getAvailableSkills: vi.fn().mockReturnValue([]),
+        initialize: vi.fn().mockResolvedValue(undefined),
+      });
+      container.register("ConfigurationService", {
+        resolveGatewayConfig: () => testAgent.getGatewayConfig(),
+        resolveModelConfig: () => testAgent.getModelConfig(),
+        resolveMaxInputTokens: () => testAgent.getMaxInputTokens(),
+        resolveAutoMemoryEnabled: () => true,
+        resolveLanguage: () => testAgent.getLanguage(),
+        getEnvironmentVars: () =>
+          (
+            testAgent as unknown as {
+              configurationService: {
+                getEnvironmentVars: () => Record<string, string>;
+              };
+            }
+          ).configurationService.getEnvironmentVars(),
+      });
+
+      // Swap in a short-timeout registry so the timeout fallback fires fast.
+      const loggerError = vi.fn();
+      (
+        testAgent as unknown as {
+          asyncWorkRegistry: import("@/utils/asyncWorkRegistry.js").AsyncWorkRegistry;
+          logger: { error: (msg: string) => void };
+        }
+      ).asyncWorkRegistry = new (
+        await import("@/utils/asyncWorkRegistry.js")
+      ).AsyncWorkRegistry(50);
+      (
+        testAgent as unknown as { logger: { error: typeof loggerError } }
+      ).logger = { error: loggerError };
+
+      // Never-resolving work: destroy must still return after the drain timeout
+      (
+        testAgent as unknown as {
+          asyncWorkRegistry: import("@/utils/asyncWorkRegistry.js").AsyncWorkRegistry;
+        }
+      ).asyncWorkRegistry.track(new Promise<void>(() => {}));
+
+      await testAgent.destroy();
+      activeTestAgent = undefined; // already destroyed above
+
+      expect(loggerError).toHaveBeenCalledWith(
+        expect.stringContaining("Async work did not drain"),
+      );
+    });
+
     it("should reset queue state to idle on abort", async () => {
       const testAgent = await Agent.create({
         apiKey: "test-key",

--- a/packages/agent-sdk/tests/agent/asyncWorkRegistry.test.ts
+++ b/packages/agent-sdk/tests/agent/asyncWorkRegistry.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { AsyncWorkRegistry } from "@/utils/asyncWorkRegistry.js";
+
+describe("AsyncWorkRegistry", () => {
+  it("drains immediately when no work is registered", async () => {
+    const registry = new AsyncWorkRegistry(1_000);
+    expect(registry.size).toBe(0);
+    const started = Date.now();
+    const drained = await registry.drain();
+    expect(drained).toBe(true);
+    // No extra delay when empty: drain returns without waiting
+    expect(Date.now() - started).toBeLessThan(50);
+  });
+
+  it("waits for tracked work to settle before draining", async () => {
+    const registry = new AsyncWorkRegistry(1_000);
+    let resolveWork!: () => void;
+    const work = new Promise<void>((resolve) => {
+      resolveWork = resolve;
+    });
+    registry.track(work);
+
+    let drained = false;
+    const drainPromise = registry.drain().then((result) => {
+      drained = result;
+    });
+    // Drain must not resolve while the work is pending
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(drained).toBe(false);
+
+    resolveWork();
+    await drainPromise;
+    expect(drained).toBe(true);
+    expect(registry.size).toBe(0);
+    expect(registry.isEmpty()).toBe(true);
+  });
+
+  it("removes work when the tracked promise rejects (no unhandled rejection)", async () => {
+    const registry = new AsyncWorkRegistry(1_000);
+    // Track a rejecting promise fire-and-forget: vitest fails the test if an
+    // unhandled rejection escapes, so passing here proves track() swallows it.
+    registry.track(Promise.reject(new Error("boom")));
+    await registry.drain();
+    expect(registry.size).toBe(0);
+    await new Promise((resolve) => setImmediate(resolve));
+  });
+
+  it("keeps draining work registered after an await point", async () => {
+    const registry = new AsyncWorkRegistry(1_000);
+    let resolveFirst!: () => void;
+    const first = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    registry.track(first);
+
+    let resolveSecond!: () => void;
+    const second = new Promise<void>((resolve) => {
+      resolveSecond = resolve;
+    });
+
+    let drained = false;
+    const drainPromise = registry.drain().then((result) => {
+      drained = result;
+    });
+
+    // New work starts at an await point inside the first tracked task — i.e.
+    // in the same synchronous flow that settles it, before the registry can
+    // observe an empty set. The drain loop must keep waiting for it.
+    resolveFirst();
+    registry.track(second);
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(drained).toBe(false); // drain must keep waiting for the new work
+    expect(registry.size).toBe(1);
+
+    resolveSecond();
+    await drainPromise;
+    expect(drained).toBe(true);
+    expect(registry.size).toBe(0);
+  });
+
+  it("times out with false when work never settles", async () => {
+    const registry = new AsyncWorkRegistry(30);
+    // Never-resolving promise: drain must fall back to the timeout
+    registry.track(new Promise<void>(() => {}));
+    const drained = await registry.drain();
+    expect(drained).toBe(false);
+    expect(registry.size).toBe(1);
+  });
+
+  it("track returns the original promise unchanged", async () => {
+    const registry = new AsyncWorkRegistry(1_000);
+    const work = Promise.resolve("result");
+    const tracked = registry.track(work);
+    expect(tracked).toBe(work);
+    await tracked;
+    expect(registry.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## 背景

处理 issue #1818「refactor: agent 生命周期架构演进」。#1808（destroy 后幽灵 dispatch）已由 #1817 修复，本 PR 落地架构方案中的两项：

1. **方案 3（先落地，最小改动）**：destroy 后公开 API 抛错
2. **方案 1（治本，最高优先）**：异步工作注册表 + destroy 确定性排空

方案 2（单一 pump 循环）与方案 4（AsyncLocalStorage 上下文贯穿）评估为独立里程碑，后续单独实施。

## 改动

### 方案 3：destroy 后公开 API 抛错

- `agent.ts` 新增 `assertNotDestroyed()` 终态守卫，接入 `bang` / `askBtw` / `forkSubagent` / `sendMessage` 四个公开 API
- 关闭幽灵路径：destroy 后 `isLoading=false` 时 `sendMessage` 不再直接走 `InteractionService` 启动新 AI 回合，而是抛 `Error("Agent destroyed")`

### 方案 1：异步工作注册表 + destroy 确定性排空

- 新增 `AsyncWorkRegistry`（`src/utils/asyncWorkRegistry.ts`）：`track()` 注册 promise、settle 移除、吞掉 rejection；`drain(timeoutMs)` 循环排空直到空或超时（默认 10s）
- 注册进 DI 容器，Agent / SubagentManager / AIManager 共享
- 三个 fire-and-forget 站点全部注册：dispatchPromise、后台 subagent IIFE、fork subagent IIFE
- `destroy()` 末尾置终态 → 中止可中止项 → `await registry.drain()` → 未排空记录错误日志

## 测试

- 新增 `asyncWorkRegistry.test.ts`（6 个单测）
- `agent.abort.test.ts` 新增 7 个用例：destroy 后 4 个公开 API 抛错（spy 验证零 AI 调用）、destroy 等待排空、超时兜底+错误日志、#1817 遗留队列幽灵回归保留
- 验证：agent-sdk 3630 passed、code 1427 passed、type-check / lint / prettier 全绿、spec-count 73/389/1510 无警告

## Spec

- 新增 `docs/specs/core/agent-lifecycle.md`（order 145）：3 用户故事 13 验收场景