### PR TITLE
fix: add tsx to root devDependencies, remove redundant tsx from agent-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.1.5",
     "prettier": "3.6.2",
+    "tsx": "^4.20.4",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.39.0",
     "vitepress": "^1.6.4",

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -76,7 +76,6 @@
     "@vitest/coverage-v8": "^4.1.7",
     "rimraf": "^6.1.2",
     "tsc-alias": "^1.8.16",
-    "tsx": "^4.20.4",
     "vitest": "^4.1.7"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       prettier:
         specifier: 3.6.2
         version: 3.6.2
+      tsx:
+        specifier: ^4.20.4
+        version: 4.20.6
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
@@ -120,9 +123,6 @@ importers:
       tsc-alias:
         specifier: ^1.8.16
         version: 1.8.16
-      tsx:
-        specifier: ^4.20.4
-        version: 4.20.6
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.3)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.8.1))
@@ -7620,7 +7620,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.3)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.8.1))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.3)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@22.19.3)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.8.1))
 
   '@vitest/expect@4.1.7':
     dependencies:


### PR DESCRIPTION
## Problem

Root `package.json` scripts `wave` / `wave:debug` invoke `tsx` directly, but the root `tsx` devDependency was dropped in the pnpm workspace migration (`536be88b`). pnpm's isolated installs don't hoist subpackage bins to root, so `pnpm run wave` failed with `sh: 1: tsx: not found`.

## Changes

- `package.json`: add `tsx: ^4.20.4` to root devDependencies (matches subpackage version)
- `packages/agent-sdk/package.json`: remove redundant `tsx` — no script or config in agent-sdk consumes it
- `packages/code` keeps its `tsx` — its `wave` script runs `tsx --tsconfig tsconfig.dev.json src/index.ts`
- `pnpm-lock.yaml` updated via `pnpm install`

## Verification

- `pnpm run wave -- --version` under a PTY now prints `WAVE v1.0.10` (previously `tsx: not found`)
- type-check passes across all packages (lint-staged ran on commit)