### PR TITLE
fix(docs): escape bare <path> tag in worktree spec breaking vitepress build

### DIFF
--- a/docs/specs/multi-agent/worktree.md
+++ b/docs/specs/multi-agent/worktree.md
@@ -66,7 +66,7 @@ order: 90
 
 **验收场景**：
 
-1. **假设**我在 worktree 会话中有 1 个新提交，**当**我退出 CLI 时，**则**我看到提示："You have 1 commit on worktree-\<name\>. The branch will be deleted if you remove the worktree."
+1. **假设**我在 worktree 会话中有 1 个新提交，**当**我退出 CLI 时，**则**我看到提示："You have 1 commit on worktree-`<name>`. The branch will be deleted if you remove the worktree."
 2. **假设**退出提示已显示，**当**我选择"Remove worktree"时，**则** worktree 及其关联分支被删除。
 
 ---
@@ -162,7 +162,7 @@ order: 90
 5. **假设** hook-based worktree 属于 stdio 后台会话，**当** 前端通过 RPC 删除其 worktree 时，**则** hook 被触发并接管删除；RPC 校验跳过 repo-root containment 检查（repoRoot 是兜底值，hook 拥有路径）。
 6. **假设** `WorktreeRemove` hook 执行时，**当** stdin JSON 被构造时，**则** 包含 `hook_event_name: "WorktreeRemove"` 与 `worktree_path`（worktree 绝对路径），不含 `name` 字段（名称由 hook 通过 `basename "$worktree_path"` 派生，与 Claude Code 官方输入格式一致）。
 7. **假设** `WorktreeRemove` hook 失败（非 0 退出码）或超时，**当** 删除发生时，**则** 错误仅被记录（不显示为阻止性错误、不重试），worktree 目录是否残留由 hook 脚本负责（对齐 Claude Code：仅记录错误日志）。
-8. **假设** worktree 创建时配置了 `WorktreeCreate` hook（hook-based）但删除时未配置 `WorktreeRemove` hook，**当** 删除发生时，**则** wave 不执行 `git worktree remove`，仅记录警告 "No WorktreeRemove hook configured, hook-based worktree left at: <path>"（对齐 Claude Code）。
+8. **假设** worktree 创建时配置了 `WorktreeCreate` hook（hook-based）但删除时未配置 `WorktreeRemove` hook，**当** 删除发生时，**则** wave 不执行 `git worktree remove`，仅记录警告 "No WorktreeRemove hook configured, hook-based worktree left at: `<path>`"（对齐 Claude Code）。
 9. **假设** worktree 由 wave 通过 git 创建（未配置 `WorktreeCreate` hook），**当** 任何入口删除该 worktree 时，**则** `WorktreeRemove` hook 不触发，wave 照常执行 `git worktree remove --force` 与 `git branch -D`（现有行为不变）。
 
 ---


### PR DESCRIPTION
## 问题

Deploy VitePress workflow（run 32108679300）在 main push 时失败：`vitepress build` 报 `docs/specs/multi-agent/worktree.md (115:288): Element is missing end tag`。

## 根因

不是第 69 行（`worktree-\\<name\\>`，反斜杠转义后 markdown-it 输出 `&lt;name&gt;` 实体，安全）。真正问题在第 165 行：`hook-based worktree left at: <path>` 中的 `<path>` 在引号内、未用反引号包裹，markdown-it（html: true）把它当作 `html_inline` 原样输出，Vue 模板编译器将其解析为永不闭合的 `<path>` 元素。

验证方法：用 vitepress 自带 markdown renderer 渲染该 md，全文档仅发现一个未闭合裸标签 `<path>`（HTML 输出第 112 行 col 288，CI 报 115:288 因构建管线行号有偏移）。

## 修复

- 165 行：`<path>` 用反引号包裹（与同文件其他占位符一致）
- 69 行：顺手把 `worktree-\\<name\\>` 反斜杠转义改为反引号包裹，消除误导性写法

## 验证

- 用脚本扫全部 docs/**/*.md（vitepress renderer 渲染 + 检查未闭合标签 + 检查 prose 文本 token 裸尖括号）：全仓库仅此一处
- 修复后 `vitepress build docs` 全绿（本地缺 gitignored 截图，用占位 webp 验证完整构建通过后已清理；CI 的 `docs:build` 会先跑 demo 测试重新生成截图）
- spec-count: 73 规格 / 390 用户故事 / 1517 验收场景