### PR TITLE
fix: background pnpm install/build in WorktreeCreate hook (wave -w ENAMETOOLONG + minutes-long startup)

### DIFF
--- a/.wave/settings.json
+++ b/.wave/settings.json
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(dirname \"$(git rev-parse --git-common-dir)\")\" && name=$(jq -r '.name') && git worktree add -B \"worktree-$name\" \".wave/worktrees/$name\" >&2 && echo \"$(pwd)/.wave/worktrees/$name\" && (cd \".wave/worktrees/$name\" && pnpm install && pnpm build >&2 || true)"
+            "command": "cd \"$(dirname \"$(git rev-parse --git-common-dir)\")\" && name=$(jq -r '.name') && export name && git worktree add -B \"worktree-$name\" \".wave/worktrees/$name\" >&2 && echo \"$(pwd)/.wave/worktrees/$name\" && (nohup sh -c 'cd \".wave/worktrees/$name\" && pnpm install >> \"/tmp/wave-wt-$name.log\" 2>&1 && pnpm build >> \"/tmp/wave-wt-$name.log\" 2>&1 || true' </dev/null >/dev/null 2>&1 &)"
           }
         ]
       }


### PR DESCRIPTION
## 问题

在主仓库跑 `wave -w` 有两个问题：

1. **ENAMETOOLONG**：WorktreeCreate hook 的 stdout 协议是「stdout 即 worktree 路径」（`worktreeHooks.ts:92` 整段 `trim()`，与 Claude Code 一致），但 `pnpm install` 的进度输出未重定向，混入 hook stdout，导致 `process.chdir` 收到「路径 + pnpm 整段输出」→ `ENAMETOOLONG: name too long`。
2. **启动卡分钟级**：hook 尾部 `(cd ... && pnpm install && pnpm build ...)` 是同步的，hook 要等 install+build 全部完成才 echo 路径返回。

## 修复（一行命令）

```
git worktree add ... >&2 && echo "$(pwd)/.wave/worktrees/$name" && (nohup sh -c 'cd ".wave/worktrees/$name" && pnpm install >> "/tmp/wave-wt-$name.log" 2>&1 && pnpm build >> "/tmp/wave-wt-$name.log" 2>&1 || true' </dev/null >/dev/null 2>&1 &)
```

- hook 立即 echo 路径返回，`wave -w` 秒进会话
- install/build 后台**串行**执行（install 必须先完成，依赖 node_modules），输出写入 `/tmp/wave-wt-<name>.log`
- `nohup` + `(cmd &)` + stdio 重定向（`</dev/null >/dev/null 2>&1`）：hook 进程退出后后台任务不被杀，且不持有 hook 的 stdout/stderr 管道（否则 executeCommand 的 close 事件会等管道关闭，仍然卡住）
- `export name` 供后台 shell 使用；`|| true` 保持原语义（install/build 失败不阻断 worktree 使用）

## 验证

- 隔离 hook 测试：stdout 仅路径一行，**0.114s 返回**（原为分钟级）；后台日志正常推进（+1211 包 → build 完成）
- 真实 `wave -w --permission-mode bypassPermissions`（script PTY）：**~4s 进入交互会话**（原为等完 install+build 数分钟），会话正常；`/tmp/wave-wt-<name>.log` 并发推进、node_modules 边跑边填充
- 无 ENAMETOOLONG