### PR TITLE
fix(jetbrains): gate git-bash path tests on Windows, run JB CI on PR/main

### DIFF
--- a/.github/workflows/ci-jetbrains.yml
+++ b/.github/workflows/ci-jetbrains.yml
@@ -6,6 +6,12 @@ name: CI (JetBrains)
 # logic has no merge gate.
 
 on:
+  # Merge gate on PRs and post-merge gate on main (aligned with ci.yml).
+  # dorny/paths-filter below skips all steps for non-JetBrains changes.
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -33,7 +39,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: "17"
 
       - name: Setup Gradle
         if: steps.filter.outputs.jetbrains == 'true'

--- a/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/stdio/BinaryResolverTest.kt
+++ b/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/stdio/BinaryResolverTest.kt
@@ -256,6 +256,7 @@ class BinaryResolverTest {
 
     @Test
     fun `inferGitBashFromGitExe maps cmd git exe to bin bash exe`() {
+        assumeWindows()
         assertEquals(
             "C:\\Program Files\\Git\\bin\\bash.exe",
             BinaryResolver.inferGitBashFromGitExe("C:\\Program Files\\Git\\cmd\\git.exe"),
@@ -264,6 +265,7 @@ class BinaryResolverTest {
 
     @Test
     fun `inferGitBashFromGitExe handles a shallow git exe path`() {
+        assumeWindows()
         // e.g. git.exe two levels above a bin dir — parent chain collapses
         assertEquals(
             "C:\\tools\\bin\\bash.exe",
@@ -322,6 +324,19 @@ class BinaryResolverTest {
     }
 
     // ---- helpers -------------------------------------------------------
+
+    /**
+     * Skips the test on non-Windows hosts. [inferGitBashFromGitExe] operates on
+     * Windows drive paths (`C:\...\git.exe`); on POSIX JVMs `\` is an ordinary
+     * filename character, so `File.parentFile` sees a single-element path and
+     * the parent chain collapses to null. The mapping only exists on Windows.
+     */
+    private fun assumeWindows() {
+        org.junit.jupiter.api.Assumptions.assumeTrue(
+            System.getProperty("os.name").lowercase().startsWith("win"),
+            "Git Bash path inference is Windows-only"
+        )
+    }
 
     /**
      * Builds a fake nvm root under [tempDir]: `versions/node/` created, and


### PR DESCRIPTION
## Summary

Two fixes from the v1.1.0 release fallout, where the `build-jetbrains` job failed on the Linux runner and the JB zip never got uploaded:

### 1. `BinaryResolverTest` — Windows-only path assertions failed on Linux

`inferGitBashFromGitExe` operates on Windows drive paths (`C:\...\git.exe`). On POSIX JVMs `\` is an ordinary filename character, so `File.parentFile` sees a single-element path and the parent chain collapses to null — both assertions failed on the ubuntu-latest runner.

Fix: guard the two tests with `assumeTrue(isWindows)` (via a new `assumeWindows()` helper), matching the file's existing platform-assumption pattern. The third test (`returns null for a bare filename`) still runs everywhere.

Verified locally with temurin JDK 17: 27 tests, 0 failures, 2 skipped (message: "Git Bash path inference is Windows-only").

### 2. `ci-jetbrains.yml` — no merge gate

The workflow only had `workflow_dispatch`, so JB logic (BinaryResolver etc.) had no PR gate. Aligned with ci.yml:

```yaml
on:
  pull_request:
    branches: [main, develop]
  push:
    branches: [main]
  workflow_dispatch:
```

`dorny/paths-filter` already detects `packages/jetbrains/**` and skips all steps for non-JB changes, so unrelated PRs/pushes won't run it.
