### PR TITLE
fix(wave): worktree hooks for Windows (jq-free create + WorktreeRemove cleanup)

### DIFF
--- a/.wave/hooks/worktree-create.mjs
+++ b/.wave/hooks/worktree-create.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// WorktreeCreate hook: reads { name } from stdin, creates a git worktree at
+// <repo-root>/.wave/worktrees/<name>, prints the worktree path to stdout,
+// then kicks off pnpm install + build in the background.
+import { spawn, spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// Resolve the repo root from git (git-common-dir may be relative to CWD)
+const gitCommonDir = spawnSync("git", ["rev-parse", "--git-common-dir"], {
+  encoding: "utf8",
+});
+if (gitCommonDir.error || gitCommonDir.status !== 0) {
+  console.error("worktree-create: not inside a git repository");
+  process.exit(1);
+}
+const repoRoot = path.resolve(gitCommonDir.stdout.trim(), "..");
+
+// --- Read payload { name } from stdin -------------------------------------
+let name;
+try {
+  name = JSON.parse(readFileSync(0, "utf8")).name;
+} catch {
+  console.error("worktree-create: failed to parse hook payload from stdin");
+  process.exit(1);
+}
+if (typeof name !== "string" || !/^[A-Za-z0-9._-]+$/.test(name)) {
+  console.error(`worktree-create: invalid worktree name: ${name}`);
+  process.exit(1);
+}
+
+// --- Create the worktree --------------------------------------------------
+const worktreePath = path.join(repoRoot, ".wave", "worktrees", name);
+const add = spawnSync(
+  "git",
+  ["worktree", "add", "-B", `worktree-${name}`, worktreePath],
+  {
+    cwd: repoRoot,
+    stdio: ["inherit", 2, 2], // keep git output off stdout; stdout is the hook result
+  },
+);
+if (add.error) {
+  console.error(`worktree-create: failed to run git: ${add.error.message}`);
+  process.exit(1);
+}
+if (add.status !== 0) process.exit(add.status);
+
+// --- Kick off install + build in the background ---------------------------
+const bg = spawn(
+  "sh",
+  [
+    "-c",
+    `cd "${worktreePath.replaceAll("\\", "/")}" && pnpm install && pnpm build || true`,
+  ],
+  { cwd: repoRoot, detached: true, stdio: "ignore", windowsHide: true },
+);
+bg.unref();
+
+// --- Report the worktree path to wave --------------------------------------
+process.stdout.write(`${worktreePath}\n`);

--- a/.wave/hooks/worktree-remove.mjs
+++ b/.wave/hooks/worktree-remove.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// WorktreeRemove hook: reads { worktree_path } from stdin and removes the
+// worktree. Best-effort, mirroring the git removal wave uses for non-hook
+// worktrees: `git worktree remove --force` + branch delete + prune, with an
+// fs.rmSync fallback for Windows MAX_PATH-limited removals.
+import { spawnSync } from "node:child_process";
+import { readFileSync, existsSync, rmSync } from "node:fs";
+import path from "node:path";
+
+// --- Read payload { worktree_path } from stdin -----------------------------
+let payload;
+try {
+  payload = JSON.parse(readFileSync(0, "utf8"));
+} catch {
+  console.error("worktree-remove: failed to parse hook payload from stdin");
+  process.exit(1);
+}
+
+const worktreePath = payload.worktree_path;
+if (typeof worktreePath !== "string" || worktreePath.length === 0) {
+  console.error(
+    `worktree-remove: missing worktree_path in payload: ${JSON.stringify(payload)}`,
+  );
+  process.exit(1);
+}
+
+// --- Resolve the repo root from git (git-common-dir may be relative to CWD) -
+const gitCommonDir = spawnSync("git", ["rev-parse", "--git-common-dir"], {
+  encoding: "utf8",
+});
+if (gitCommonDir.error || gitCommonDir.status !== 0) {
+  console.error("worktree-remove: not inside a git repository");
+  process.exit(1);
+}
+const repoRoot = path.resolve(gitCommonDir.stdout.trim(), "..");
+
+// --- Remove the worktree (best-effort, non-blocking like wave's git path) ---
+const name = path.basename(worktreePath);
+const branch = `worktree-${name}`;
+
+// 1. git worktree remove --force (deletes working dir + metadata)
+let removed = existsSync(worktreePath)
+  ? spawnSync("git", ["worktree", "remove", "--force", worktreePath], {
+      cwd: repoRoot,
+      stdio: "inherit",
+    }).status === 0
+  : true;
+
+// 2. fs.rmSync fallback for MAX_PATH-limited removals (git leaves an orphan dir)
+if (!removed && existsSync(worktreePath)) {
+  try {
+    rmSync(worktreePath, { recursive: true, force: true });
+    removed = true;
+  } catch (error) {
+    console.error(
+      `worktree-remove: fs.rmSync failed for ${worktreePath}: ${error.message}`,
+    );
+  }
+}
+
+// 3. Prune stale metadata and delete the worktree branch
+spawnSync("git", ["worktree", "prune"], { cwd: repoRoot });
+spawnSync("git", ["branch", "-D", "--", branch], { cwd: repoRoot });
+
+if (!removed) {
+  console.error(
+    `worktree-remove: failed to remove worktree at: ${worktreePath}`,
+  );
+  process.exit(1);
+}

--- a/.wave/settings.json
+++ b/.wave/settings.json
@@ -46,6 +46,16 @@
           }
         ]
       }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .wave/hooks/worktree-remove.mjs"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.wave/settings.json
+++ b/.wave/settings.json
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(dirname \"$(git rev-parse --git-common-dir)\")\" && name=$(jq -r '.name') && export name && git worktree add -B \"worktree-$name\" \".wave/worktrees/$name\" >&2 && echo \"$(pwd)/.wave/worktrees/$name\" && (nohup sh -c 'cd \".wave/worktrees/$name\" && pnpm install >> \"/tmp/wave-wt-$name.log\" 2>&1 && pnpm build >> \"/tmp/wave-wt-$name.log\" 2>&1 || true' </dev/null >/dev/null 2>&1 &)"
+            "command": "node .wave/hooks/worktree-create.mjs"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Two fixes to the repo's wave worktree hook config, needed on Windows:

1. **WorktreeCreate hook no longer requires `jq`** (not installed in Windows Git Bash). The long inline command is replaced by `.wave/hooks/worktree-create.mjs` (Node): reads `{name}` from stdin, runs `git worktree add -B worktree-<name> .wave/worktrees/<name>`, prints the worktree path to stdout, and kicks off `pnpm install && pnpm build` detached in the background.

2. **Add WorktreeRemove hook** — fixes the leak where hook-based worktrees (created via the WorktreeCreate hook) were left on disk with their `worktree-<name>` branch when removed, because wave delegates removal to the WorktreeRemove hook and leaves + warns when none is configured (aligned with Claude Code semantics). The new `.wave/hooks/worktree-remove.mjs` reads `{worktree_path}` from stdin and runs: `git worktree remove --force` → `fs.rmSync` fallback (Windows MAX_PATH, `\?\` extended path — same pattern as taskplane#543 / ds-platform#335) → `git worktree prune` → `git branch -D worktree-<name>`.

## Verification

- Create + remove hooks tested end-to-end on Windows: worktree created, background install/build completed, removal cleaned up worktree dir + branch + metadata.
- Pre-commit hooks (type-check all packages + prettier) pass.

Closes #1827