### PR TITLE
refactor(code): unify CLI message updates through a single throttled updateMessages

### DIFF
--- a/docs/specs/core/stream-content-updates.md
+++ b/docs/specs/core/stream-content-updates.md
@@ -128,7 +128,7 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 6. **假设**子代理（subagent）运行中，**当**其消息变更时，**则** `SubagentManager` 通过 `instance.messageManager.getMessages()` 拉取最新列表维护 `instance.messages` 与 `usedTools`，并继续转发 `onSubagentMessagesChange`，不再依赖子代理的 `onMessagesChange`
 7. **假设**助手响应正在流式传输，**当**每个内容/推理 chunk 到达时，**则**增量回调与 stdio 增量通知都只携带 `chunk`（增量片段）+ `messageId` + `stage`，不再携带 `accumulated` 累积值；进程内消费者（CLI、print-cli）与跨进程宿主（agentBridge）统一消费纯 chunk，自行累积追加
 8. **假设**工具参数正在经 stdio 流式传输，**当** `stage="streaming"` 通知到达时，**则**只携带 `parametersChunk`（增量），不再携带累积 `parameters`；**当** `stage="end"` 通知到达时，**则**携带全量 `parameters` + `result` 作为一次性权威值
-9. **假设**除 CLI 外的宿主（VSCE/桌面）对增量通知做了节流（如 16ms 窗口），**当**窗口内累积了多个 chunk 时，**则**按到达顺序将窗口内所有 chunks 拼接为一个合并 delta 发送，而非 last-value-wins 丢弃中间值——丢弃中间 chunk 会造成内容永久缺失，只能由后续 `getMessages` 拉取自愈；CLI 进程内消费端已移除节流（见「CLI 以原始频率渲染流式内容」用户故事），每个 delta 立即应用
+9. **假设**宿主（VSCE/桌面/CLI）对增量通知做了节流（如 16ms/500ms 窗口），**当**窗口内累积了多个 chunk 时，**则**按到达顺序将窗口内所有 chunks 拼接为一个合并 delta 发送，而非 last-value-wins 丢弃中间值——丢弃中间 chunk 会造成内容永久缺失，只能由后续 `getMessages` 拉取自愈
 10. **假设**webview 正在追加流式 delta，**当**触发 `getMessages` 拉取全量列表时，**则**全量响应整体替换消息块为权威快照，随后到达的 delta 继续追加；管道 FIFO 保证拉取响应包含其之前发出的所有 chunk，不发生重复或错乱
 
 ---
@@ -153,21 +153,26 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 
 ---
 
-### 用户故事：CLI 以原始频率渲染流式内容（优先级：P1）
+### 用户故事：CLI 消息状态经单一节流更新函数统一渲染，全量刷新时快照安全取消（优先级：P1）
 
-作为 CLI 使用者，我希望助手流式输出时每个内容 delta 都以原始频率立即渲染，而不是被 500ms 窗口节流合并后再渲染，以便界面反馈与模型生成节奏一致，且彻底消除节流窗口引入的内容重复竞态。
+作为 CLI 使用者，我希望助手流式输出、工具运行与所有消息状态更新经同一个 500ms 窗口节流入口合并渲染（leading edge 立即、窗口内更新按到达顺序排队、end 立即冲刷），使高频更新（含工具 running 阶段的 `shortResult`/`result`）不逐 chunk 触发 React commit 造成布局跳动，同时流式期间触发 /clear、/compact、/rewind 或折叠等全量刷新时内容不与权威快照重复。
 
-**为什么是这个优先级**：CLI 之前的 500ms window-concat 节流保留了一个残留竞态——节流器 trailing edge 冲刷 pending 窗口内已合并的 chunk 时，若期间发生了一次全量列表替换（`refreshMessages`，由 /clear、/compact、/rewind、Ctrl+O 折叠触发），pending 内旧 delta 会被追加到已含全部内容的新快照之上，造成内容重复。移除节流后每个 delta 同步立即应用，不存在 pending 窗口，竞态从机制上消失。渲染性能不受影响：Ink 内置 30fps（~34ms）输出节流兜底终端写入频率，`<Static>` append-only 使历史消息永不重绘，动态部分仅剩最后一条消息的 running blocks，每次 commit 的 React 重建成本对典型会话规模（≤30 条可见消息）为亚毫秒级。
+**为什么是这个优先级**：2026-08-17 曾因节流器 trailing edge 冲刷与全量列表替换（`refreshMessages`）交错导致内容重复而移除 CLI 节流（见下方 2026-08-17 会议记录）；2026-08-19 决定恢复节流并在竞态源头修复——`refreshMessages` 拉取权威快照后立即取消节流窗口：pending 内的旧更新在拉取前已写入 SDK 消息状态，必然已包含在快照中，丢弃无损失；拉取之后到达的更新开启全新窗口、追加在快照之上。2026-08-19 同次会议决定把三通道节流器（content/reasoning/tool）统一为一个 `updateMessages(updater)` 入口，`initializeAgent` 中全部消息状态更新回调（消息新增、文本/推理 delta、工具全阶段、error 块、bang 三回调）都经它排队——bash 等前台工具逐 chunk 的 running 阶段 `shortResult`/`result` 更新由此同样受 500ms 窗口约束，短结果行数（1-4 行）变化至多每窗口一次，消除高度跳动闪烁。节流恢复与统一带来渲染频率上限（React commit 由 500ms 窗口合并，终端写入由 Ink 内置 30fps 兜底），同时竞态从机制上消除。
 
-**独立测试**：构造带 reasoning 流式的会话，在流式期间触发一次全量刷新（/clear、/compact、/rewind 或折叠切换），验证最终消息内容与 SDK 权威内容逐字节一致、无重复片段；同时观察流式期间界面即时更新且无整屏闪烁。
+**独立测试**：构造带 reasoning 流式的会话，在流式期间触发一次全量刷新（/clear、/compact、/rewind 或折叠切换），验证最终消息内容与 SDK 权威内容逐字节一致、无重复片段（`useChat.test.tsx`：refresh-interleave 场景在节流恢复 + 快照取消下通过）；构造 bash 前台任务，连续触发 running 阶段 `shortResult` 更新，断言窗口内多次更新合并为一次渲染（`ToolDisplay` 行数不逐 chunk 跳变）；观察流式期间界面按节流频率平滑更新、无整屏闪烁。
 
 **验收场景**：
 
-1. **假设** CLI 正在消费流式 delta，**当**每个 `onAssistantContentUpdated`/`onAssistantReasoningUpdated` 回调到达时，**则**该 delta 被立即应用于消息状态，不再经过 500ms 窗口节流合并（`createStreamingWindowThrottle` 对内容/reasoning 通道移除）
-2. **假设**流式期间发生了全量列表替换（`refreshMessages`），**当**替换前后均有 delta 到达时，**则**最终消息内容与 SDK 权威内容一致，不出现任何重复片段（旧 pending delta 不会叠加到新快照上）
-3. **假设** CLI 以原始频率触发 React commit，**当**模型以高频（如 30ms/chunk）产出 delta 时，**则**终端输出写入仍受 Ink 内置 `maxFps: 30` 节流约束，不出现逐 chunk 整屏重绘或闪烁
-4. **假设**长会话中流式输出，**当**消息不断积累时，**则**界面依然平滑即时更新，不因移除节流而卡顿（与「长会话流式输出保持流畅」验收场景 1 一致）
-5. **假设**存在内容重复的回归测试，**当**运行现有双计数回归测试（content/reasoning double-count）时，**则**测试继续通过，且不依赖节流窗口语义
+1. **假设** CLI 正在消费消息状态更新，**当**任一消息更新回调到达时，**则**更新以 updater 形式（`(prev: Message[]) => Message[]`）经统一入口 `updateMessages` 处理：leading edge 立即应用首个更新并开启 500ms 窗口，窗口内后续更新按到达顺序排队，窗口关闭时以单个组合 updater 一次性应用（顺序 = 到达顺序，无更新丢失）；`stage="end"`/收尾事件先 `flush()` 冲刷排队更新再应用收尾信号
+2. **假设**流式期间发生了全量列表替换（`refreshMessages`，/clear、/compact、/rewind、Ctrl+O 折叠触发），**当**替换发生时，**则**统一节流窗口在拉取快照后立即 `cancel()`——排队中的旧更新被丢弃（其内容已包含在权威快照中），trailing edge 不会把刷新前的更新重新追加到快照之上
+3. **假设**全量刷新替换完成，**当**其后仍有流式 delta 到达时，**则**新 delta 开启全新节流窗口并追加在权威快照之上，内容不丢失、不重复
+4. **假设**工具参数流式传输中发生全量刷新，**当**替换发生时，**则**窗口内各 tool 的 pending `parametersChunk` 一并丢弃（SDK 内部已累积，快照含权威 `parameters`），不产生参数重复
+5. **假设**工具运行阶段逐 chunk 更新 `shortResult`/`result`（bash 前台任务经 `onToolBlockUpdated` `stage="running"` 高频到达），**当**同一窗口内到达多个更新时，**则**它们与文本/推理/tool 更新共用同一窗口排队合并，窗口内至多一次渲染，短结果行数不逐 chunk 跳变（工具卡片高度稳定）
+6. **假设**同一窗口内工具 streaming 参数 chunk 与 running 权威快照交错到达，**当**排队应用时，**则**按到达顺序先应用 chunk 追加、再应用 running 权威替换，最终 `stage="running"`、`parameters` 为权威值——FIFO 顺序从机制上杜绝"stale streaming 晚于 running 冲刷导致阶段回退"（取代 2026-08-12 `createToolStreamingThrottle` 的"running 丢弃该 tool buffered deltas"逻辑）
+7. **假设**窗口打开期间到达一次性结构更新（消息新增、error 块、bang 新增/完成），**当**其与流式更新同窗时，**则**结构更新经统一入口入队后**立即 `flush()` 冲刷**（按到达顺序与窗口内已有更新一起应用，不丢失、不重排）——结构性更新为一发式、无合并价值，且立即冲刷避免其以 leading edge 占用窗口导致随后首个流式 delta 被延迟；消息卡片/错误块即时可见
+8. **假设** CLI 以节流频率触发 React commit，**当**模型以高频（如 30ms/chunk）产出 delta 时，**则**终端输出写入仍受 Ink 内置 `maxFps: 30` 节流约束，不出现逐 chunk 整屏重绘或闪烁
+9. **假设**长会话中流式输出，**当**消息不断积累时，**则**界面依然平滑即时更新，不因节流统一而卡顿（与「长会话流式输出保持流畅」验收场景 1 一致）
+10. **假设**存在内容重复的回归测试，**当**运行现有双计数回归测试（content/reasoning 同批 double-count、refresh-interleave duplication）时，**则**测试继续通过，且不依赖移除节流后的无窗口语义
 
 ---
 
@@ -207,8 +212,8 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 - **增量回调用途**：为第三方集成、扩展、CLI 与示例（如 `packages/code/src/print-cli.ts` 和 `packages/agent-sdk/examples`）提供实时流式数据；增量回调是消息状态同步的唯一推送通道
 - **SDK 回调负载**：`onAssistantContentUpdated`/`onAssistantReasoningUpdated` 只提供 `chunk`（增量）+ `messageId` + `stage`，不再携带 `accumulated` 累积值，进程内消费者（CLI、print-cli）自行累积追加；`onToolBlockUpdated` 在 `stage="streaming"` 时只提供 `parametersChunk`（增量），`start`/`running`/`end` 阶段携带权威 `parameters`（end 为最终值，一次性权威）。SDK 内部仍将 chunk 追加进内存 `toolBlock.parameters` 保持累积，只是累积值不再暴露到外部回调
 - **跨进程 wire 负载（纯 delta）**：agentBridge 原样透传增量回调负载——`assistantContentUpdated`/`assistantReasoningUpdated` 只携带 `{messageId, chunk, stage}`（SDK 回调本身已无累积字段，无需剥离）；`toolBlockUpdated` 在 `stage="streaming"` 时只携带 `parametersChunk`，`stage="end"` 时携带全量 `parameters` + `result` 作为权威值。消费端负责累积（追加），丢失的 delta 由 `getMessages` 拉取的全量快照自愈
-- **UI 状态流**：CLI 直接订阅增量回调就地更新消息（chunk 追加，原始频率无节流——见「CLI 以原始频率渲染流式内容」用户故事；渲染频率由 Ink 内置 30fps 输出节流兜底）；插件/桌面经 stdio 增量通知（`userMessageAdded`、`assistantContentUpdated`、`toolBlockUpdated` 等，纯 delta 负载）驱动 webview 增量 reducer——文本/推理块追加 chunk、工具块追加 `parametersChunk`，end 时以权威值终结；需要完整列表的场景（初始化、compact、rewind、clear、bang）主动拉取，拉取响应整体替换为权威快照。进程内消费端把 SDK 消息对象推入自有状态时**必须克隆**（消息 + blocks 至少一层）且**在回调触发时刻立即捕获**（不得在 React state updater 内延迟求值——批处理 flush 晚于 SDK 就地变异，见"增量消费端以快照推入消息"用户故事），不得持有 SDK 内部活引用——SDK 会就地更新共享块，与消费端累积追加叠加会重复计数（见"增量消费端以快照推入消息"用户故事）。**渲染层**：CLI 消息列表的静态/动态分区必须遵守 append-only 约束——进入 `<Static>` 区的块（其内容已冻结在终端输出中）若因同块 reopen（`end` → `streaming`）回到动态区，动态区只能渲染"超出冻结前缀"的增量（`content.slice(冻结长度)`），否则冻结前缀与全量重渲染叠加造成首词重复（见「CLI 静态块 reopen 不重复渲染冻结前缀」用户故事）；冻结内容按块 key 记录（写入静态区的时刻），多轮 reopen 恒相对首次冻结内容计算
-- **节流语义**：SDK 回调与 wire 通知均只携带纯 delta。CLI 进程内消费端不再节流（原始频率立即应用，见「CLI 以原始频率渲染流式内容」用户故事）；其余仍选择节流的宿主（如 VSCE/桌面 webview 通道），节流器一律按到达顺序拼接窗口内所有 chunks 为一个合并 delta（window-concat），绝不能 last-value-wins 丢弃中间值。为配合该语义，SDK 必须在每次 running 事件中重复携带 `compactParams` 等稳定展示字段（见"工具块阶段更新"验收场景 4），保证丢弃中间事件不丢失这些字段
+- **UI 状态流**：CLI 直接订阅增量回调就地更新消息，全部消息状态更新（消息新增、文本/推理 delta、工具全阶段、error 块、bang 三回调）经**单一节流入口** `updateMessages(updater)` 排队应用——一个 500ms 窗口承载所有通道（含工具 running 阶段 `shortResult`/`result` 高频更新），leading edge 立即应用、窗口内更新按到达顺序 FIFO 排队、收尾时 `flush()` 冲刷，渲染频率由节流窗口与 Ink 内置 30fps 输出节流共同兜底（见「CLI 消息状态经单一节流更新函数统一渲染，全量刷新时快照安全取消」用户故事）；插件/桌面经 stdio 增量通知（`userMessageAdded`、`assistantContentUpdated`、`toolBlockUpdated` 等，纯 delta 负载）驱动 webview 增量 reducer——文本/推理块追加 chunk、工具块追加 `parametersChunk`，end 时以权威值终结；需要完整列表的场景（初始化、compact、rewind、clear、bang）主动拉取，拉取响应整体替换为权威快照。进程内消费端把 SDK 消息对象推入自有状态时**必须克隆**（消息 + blocks 至少一层）且**在回调触发时刻立即捕获**（不得在 React state updater 内延迟求值——批处理 flush 晚于 SDK 就地变异，见"增量消费端以快照推入消息"用户故事），不得持有 SDK 内部活引用——SDK 会就地更新共享块，与消费端累积追加叠加会重复计数（见"增量消费端以快照推入消息"用户故事）。**渲染层**：CLI 消息列表的静态/动态分区必须遵守 append-only 约束——进入 `<Static>` 区的块（其内容已冻结在终端输出中）若因同块 reopen（`end` → `streaming`）回到动态区，动态区只能渲染"超出冻结前缀"的增量（`content.slice(冻结长度)`），否则冻结前缀与全量重渲染叠加造成首词重复（见「CLI 静态块 reopen 不重复渲染冻结前缀」用户故事）；冻结内容按块 key 记录（写入静态区的时刻），多轮 reopen 恒相对首次冻结内容计算
+- **节流语义**：SDK 回调与 wire 通知均只携带纯 delta。CLI 进程内消费端使用**单一 500ms window-concat 节流入口** `updateMessages`（取代早期 content/reasoning/tool 三通道节流器，见「CLI 消息状态经单一节流更新函数统一渲染，全量刷新时快照安全取消」用户故事）：所有消息状态更新以 `(prev: Message[]) => Message[]` updater 形式提交，leading edge 立即应用并开启窗口，窗口内更新按到达顺序排队，窗口关闭时以单个组合 updater 一次性应用（顺序 = 到达顺序，无更新丢失、无 last-value-wins 丢弃中间值）；`stage="end"`/收尾事件先 `flush()` 冲刷排队更新再应用收尾信号。统一后 running 阶段 `shortResult`/`result` 更新与流式 delta 共用同一窗口，bash 短结果行数变化不逐 chunk 触发 React commit（消除闪烁）；FIFO 顺序保证 streaming chunk 与 running 权威值按到达顺序应用（streaming 先、running 后），从机制上杜绝 stale 冲刷晚于 running 的阶段回退（取代 `createToolStreamingThrottle` 的"running 丢弃该 tool buffered deltas"逻辑）。**全量刷新与节流窗口的交互**：任何把 CLI 消息状态整体替换为权威快照的操作（`refreshMessages`：/clear、/compact、/rewind、Ctrl+O 折叠）必须在拉取快照后 `cancel()` 节流窗口——pending 内更新已包含在快照中，丢弃无损失；拉取后的更新开启新窗口追加在快照之上，保证刷新前后内容既不重复也不丢失。为配合该语义，SDK 必须在每次 running 事件中重复携带 `compactParams` 等稳定展示字段（见"工具块阶段更新"验收场景 4），保证丢弃中间事件不丢失这些字段
 - **清晰分离**：增量回调是消息状态管理的正式对外通道；全量数据按需获取，避免随每次流式 chunk 序列化整个列表
 
 ## 澄清
@@ -296,11 +301,27 @@ SDK 集成者希望通过确定性阶段（start、streaming、running、end）�
 - 问：如何确定哪些静态项真正被写入终端 → 答：镜像 `<Static>` 的 index 语义（`useLayoutEffect` 后 index = 上次 `items.length`），静态列表位置 ≥ index 的项在本 pass 被追加写入，其内容才记录为冻结；位置 < index 的项（reopen 时被顶到已占用位置的"填充块"）从未写入，不记录——它们后续 reopen 时仍以全量渲染（从未显示过，无重复问题）
 - 问：回归测试如何捕获转瞬重复 → 答：逐阶段 `rerender` 后断言**每一帧**（ink-testing-library `frames`）中每个块内容至多出现一次，而非只断言末帧——重复只在 reopen 流式窗口内存在，末帧（块回到静态区）已无重复。无修复时全部 3 用例失败（帧计数 2），修复后通过
 
+### 2026-08-19 会议（CLI 恢复 500ms 窗口节流 + 全量刷新快照安全取消）
+
+- 问：为什么恢复 CLI 的 500ms window-concat 节流 → 答：移除节流后模型逐 token 高频产出（如 30ms/chunk）时每次 delta 都触发 React commit，bash 等长任务运行期间界面更新过密、短结果行数变化导致布局跳动（闪烁）。恢复 `createStreamingWindowThrottle`（content/reasoning，500ms）与 `createToolStreamingThrottle`（tool 参数，500ms）：leading edge 立即应用、窗口内 chunk 拼接、end 立即冲刷，渲染频率被节流窗口限制
+- 问：2026-08-17 记录的节流残留竞态如何解决 → 答：在竞态源头修复而非移除节流——`refreshMessages`（全量快照替换的唯一入口，/clear、/compact、/rewind、Ctrl+O 折叠均经此）在**拉取快照之后、应用快照之前** `cancel()` 三个节流窗口。pending 内旧 delta 在拉取前已写入 SDK 消息状态，必然已包含在权威快照中，丢弃无损失；拉取之后到达的 delta 开启全新窗口、按 React 入队顺序追加在快照之上。刷新前后内容既不重复也不丢失
+- 问：为什么 cancel 必须在拉取之后 → 答：若先 cancel 再拉取，cancel 与拉取之间到达的 delta 会同时出现在新窗口与快照中 → 重复；反之（先拉取后 cancel），cancel 与拉取之间不可能插入 delta（同步代码块），拉取前到达的 delta 要么已含于快照、要么在 pending 中被丢弃，两种情况下最终内容都与 SDK 权威状态一致
+- 问：tool 节流窗口的 pending 参数 chunk 被 cancel 丢弃是否安全 → 答：安全。SDK 内部始终累积 `toolBlock.parameters`，拉取的快照携带权威 `parameters`；丢弃的只是 CLI 侧尚未刷新的增量，内容不丢失
+- 问：受影响范围 → 答：仅 CLI 进程内消费端（`packages/code/src/contexts/useChat.tsx`）——恢复三个节流器并在 `refreshMessages` 中取消；VSCE/桌面跨进程通道的 window-concat 节流语义不变。回归测试：恢复后的 refresh-interleave 场景（流中 /clear 触发全量刷新 + 冲刷残留定时器）在快照取消下内容保持 `Let me`，无 `Let me me` 重复；同批 double-count 测试（2026-08-12 快照捕获修复）不受节流恢复影响，继续通过
+
+### 2026-08-19 会议（CLI 消息状态更新统一为单一节流函数）
+
+- 问：为什么把 content/reasoning/tool 三通道节流器统一为一个 `updateMessages` → 答：`initializeAgent` 中全部消息状态更新回调（`onUserMessageAdded`、`onAssistantMessageAdded`、`onAssistantContentUpdated`、`onAssistantReasoningUpdated`、`onToolBlockUpdated` 全阶段、`onErrorBlockAdded`、bang 三回调）本质都是"以更新函数改写 messages 状态"，此前只有文本/推理/tool 参数三通道走节流，而 bash 等前台工具逐 chunk 的 running 阶段 `shortResult`/`result` 更新走 `createToolStreamingThrottle` 的"running 立即应用"分支——不节流，行数（1-4 行）变化逐 chunk 触发 React commit 与 ToolDisplay 高度变化（闪烁源）。统一后全部更新经单一 500ms 窗口排队（FIFO、无 last-value-wins），running 高频更新与流式 delta 共用窗口，至多每窗口一次渲染，闪烁消除
+- 问：统一窗口后如何保证 streaming→running 不产生阶段回退（原 a4d5767e 语义） → 答：由 FIFO 排队顺序从机制上保证——窗口内 streaming 参数 chunk 与 running 权威快照按到达顺序应用（streaming 先追加、running 后权威替换），组合 updater 一次性应用，最终 `stage="running"`、`parameters` 为权威值，不存在"buffered stale streaming 晚于 running 冲刷"的窗口（两者同窗同 flush），原"running 丢弃该 tool buffered deltas"的特殊逻辑随之移除
+- 问：一次性结构更新（消息新增、error 块、bang 完成）经节流是否引入延迟 → 答：`updateMessages` 保留 leading edge 立即语义——窗口关闭时首个更新立即应用，窗口内到达的更新最多延迟 500ms 至窗口关闭冲刷；结构性更新（如消息新增）同窗排队时按到达顺序与流式 delta 一起应用，不丢失、不重排
+- 问：统一后 `refreshMessages` 的取消语义是否变化 → 答：不变，只是从 cancel 三个窗口变为 cancel 单一窗口——拉取快照后 `cancel()` 丢弃排队中的 pending 更新（内容已含于权威快照），拉取后的更新开启新窗口追加在快照之上，刷新前后不重复不丢失
+- 问：受影响范围 → 答：仅 CLI 进程内消费端（`packages/code/src/contexts/useChat.tsx`）——以单一 `updateMessages` 取代 `createStreamingWindowThrottle`（content/reasoning 两实例）与 `createToolStreamingThrottle`，`refreshMessages`、isExpanded 切换、卸载清理均改取消单一窗口；VSCE/桌面跨进程通道的 window-concat 节流语义不变。回归测试：既有 500ms 节流、tool 参数累积、同批 double-count、refresh-interleave 测试在统一入口下继续通过；`createToolStreamingThrottle` 单元测试改写为 `updateMessages` FIFO 排队语义测试（阶段回退防负断言保留）
+
 ## 假设 _（必填）_
 
 - 底层 AI 服务支持流式响应（增量内容传递）
 - 网络连接对大多数用户通常稳定
-- 终端/CLI 界面可以以 OpenAI 的流式速率处理实时文本更新（CLI 以原始 delta 频率渲染，终端写入频率由 Ink 内置 30fps 节流约束）
+- 终端/CLI 界面可以以 OpenAI 的流式速率处理实时文本更新（目标：每秒 2-3 次内容更新）
 - 用户通常使用支持实时文本渲染的标准终端模拟器
 - 在正常网络条件下内容流按时间顺序到达
 - 消息变更通过增量回调对外发布，完整列表按需拉取（`agent.messages` / `getMessages` 请求）；每次流式 chunk 不触发全量列表推送

--- a/packages/code/src/contexts/useChat.tsx
+++ b/packages/code/src/contexts/useChat.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useEffect,
   useState,
+  useMemo,
 } from "react";
 import { useInput, useStdout } from "ink";
 import { useAppConfig } from "./useAppConfig.js";
@@ -193,6 +194,200 @@ const snapshotMessage = (message: Message): Message => ({
   blocks: message.blocks.map((block) => ({ ...block })),
 });
 
+/**
+ * Pure updater: appends a text-content delta to the target message's text
+ * block (creating it on first delta), applying the stage signal.
+ */
+const applyContentDelta = (
+  prev: Message[],
+  params: StreamingUpdateParams,
+): Message[] => {
+  const { messageId, chunk, stage } = params;
+  return prev.map((m) => {
+    if (m.id !== messageId) return m;
+    const textBlockIndex = m.blocks.findIndex((b) => b.type === "text");
+    if (textBlockIndex === -1) {
+      return {
+        ...m,
+        blocks: [...m.blocks, { type: "text", content: chunk, stage }],
+      };
+    }
+    return {
+      ...m,
+      blocks: m.blocks.map((b, idx) =>
+        idx === textBlockIndex && b.type === "text"
+          ? {
+              ...b,
+              content: (b.content || "") + chunk,
+              stage,
+            }
+          : b,
+      ),
+    };
+  });
+};
+
+/**
+ * Pure updater: appends a reasoning delta to the target message's reasoning
+ * block (creating it on first delta), applying the stage signal.
+ */
+const applyReasoningDelta = (
+  prev: Message[],
+  params: StreamingUpdateParams,
+): Message[] => {
+  const { messageId, chunk, stage } = params;
+  return prev.map((m) => {
+    if (m.id !== messageId) return m;
+    const reasoningBlockIndex = m.blocks.findIndex(
+      (b) => b.type === "reasoning",
+    );
+    if (reasoningBlockIndex === -1) {
+      return {
+        ...m,
+        blocks: [...m.blocks, { type: "reasoning", content: chunk, stage }],
+      };
+    }
+    return {
+      ...m,
+      blocks: m.blocks.map((b, idx) =>
+        idx === reasoningBlockIndex && b.type === "reasoning"
+          ? {
+              ...b,
+              content: (b.content || "") + chunk,
+              stage,
+            }
+          : b,
+      ),
+    };
+  });
+};
+
+/**
+ * Pure updater: applies a tool block update. Streaming carries only the
+ * `parametersChunk` delta, appended to the accumulated parameters;
+ * start/running/end carry the authoritative value and replace wholesale.
+ */
+const applyToolBlockUpdate = (
+  prev: Message[],
+  params: ToolBlockUpdateCallbackParams,
+): Message[] => {
+  const { messageId, id: toolBlockId, parametersChunk, ...updates } = params;
+  return prev.map((m) => {
+    if (m.id !== messageId) return m;
+    const toolBlockIndex = m.blocks.findIndex(
+      (b) => b.type === "tool" && b.id === toolBlockId,
+    );
+    if (toolBlockIndex === -1) {
+      return {
+        ...m,
+        blocks: [
+          ...m.blocks,
+          {
+            type: "tool",
+            id: toolBlockId,
+            name: updates.name || "",
+            stage: updates.stage || "start",
+            parameters: (updates.parameters || "") + (parametersChunk || ""),
+            result: updates.result || "",
+            ...updates,
+          },
+        ],
+      };
+    }
+    return {
+      ...m,
+      blocks: m.blocks.map((b, idx) =>
+        idx === toolBlockIndex && b.type === "tool"
+          ? {
+              ...b,
+              ...updates,
+              parameters: parametersChunk
+                ? (b.parameters || "") + parametersChunk
+                : updates.parameters !== undefined
+                  ? updates.parameters
+                  : b.parameters,
+            }
+          : b,
+      ),
+    };
+  });
+};
+
+/**
+ * Single throttled updater entry for ALL message-state updates. The one
+ * 500ms window-concat window replaces the previous three-channel throttles
+ * (content/reasoning/tool), so every message-state update — including the
+ * tool `running` stage's high-frequency `shortResult`/`result` updates from
+ * bash — coalesces into the same window.
+ *
+ * Semantics: leading edge applies immediately and opens a window; updates
+ * arriving within the window are queued in arrival order (FIFO) and applied
+ * at the trailing edge as ONE composed updater, so no update is lost and no
+ * update is reordered. `flush` applies queued updates immediately (used by
+ * end signals and one-shot structural updates); `cancel` drops queued
+ * updates (used by refreshMessages after pulling the authoritative snapshot —
+ * the queued updates are already contained in it).
+ *
+ * The FIFO queue structurally replaces the old tool throttle's "drop a
+ * tool's buffered streaming deltas when running arrives" logic: a running
+ * updater is queued BEHIND the streaming chunks that preceded it and applies
+ * after them, so a stale streaming event can never flush after running and
+ * regress the stage (yellow dot -> gray). See
+ * docs/specs/core/stream-content-updates.md.
+ */
+export function createThrottledUpdater<T>(
+  apply: (updater: (prev: T) => T) => void,
+  wait: number,
+): {
+  (updater: (prev: T) => T): void;
+  cancel: () => void;
+  flush: () => void;
+} {
+  let timer: NodeJS.Timeout | null = null;
+  let queued: Array<(prev: T) => T> = [];
+
+  const fire = () => {
+    if (queued.length === 0) return;
+    const batch = queued;
+    queued = [];
+    // Compose the whole batch into a single updater applied in FIFO order —
+    // one state commit per trailing edge, no update dropped, no reordering.
+    apply((prev) => batch.reduce((acc, upd) => upd(acc), prev));
+  };
+
+  const throttled = (updater: (prev: T) => T) => {
+    if (timer) {
+      queued.push(updater);
+      return;
+    }
+    // Leading edge: apply immediately, then open a window whose trailing
+    // edge only carries updates arriving within the window.
+    apply(updater);
+    timer = setTimeout(() => {
+      timer = null;
+      fire();
+    }, wait);
+  };
+
+  throttled.cancel = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    queued = [];
+  };
+
+  throttled.flush = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    fire();
+  };
+
+  return throttled;
+}
+
 export const ChatProvider: React.FC<ChatProviderProps> = ({
   children,
   bypassPermissions,
@@ -223,132 +418,26 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   const [latestTotalTokens, setLatestTotalTokens] = useState(0);
   const [maxInputTokens, setMaxInputTokens] = useState(200000);
 
-  // Direct incremental streaming updaters — every delta is applied to the
-  // message state immediately, without a cooldown window. The former 500ms
-  // window-concat throttle is gone: its trailing-edge flush could interleave
-  // with a full-list `refreshMessages` snapshot replacement mid-stream and
-  // re-append old deltas on top of the authoritative content (first-word
-  // duplication). Terminal write frequency is bounded downstream by Ink's
-  // built-in ~30fps output throttle. See
-  // docs/specs/core/stream-content-updates.md.
-  const applyContentUpdate = useCallback((params: StreamingUpdateParams) => {
-    const { messageId, chunk, stage } = params;
-    setMessages((prev) =>
-      prev.map((m) => {
-        if (m.id !== messageId) return m;
-        const textBlockIndex = m.blocks.findIndex((b) => b.type === "text");
-        if (textBlockIndex === -1) {
-          return {
-            ...m,
-            blocks: [...m.blocks, { type: "text", content: chunk, stage }],
-          };
-        }
-        return {
-          ...m,
-          blocks: m.blocks.map((b, idx) =>
-            idx === textBlockIndex && b.type === "text"
-              ? {
-                  ...b,
-                  content: (b.content || "") + chunk,
-                  stage,
-                }
-              : b,
-          ),
-        };
-      }),
-    );
-  }, []);
-
-  const applyReasoningUpdate = useCallback((params: StreamingUpdateParams) => {
-    const { messageId, chunk, stage } = params;
-    setMessages((prev) =>
-      prev.map((m) => {
-        if (m.id !== messageId) return m;
-        const reasoningBlockIndex = m.blocks.findIndex(
-          (b) => b.type === "reasoning",
-        );
-        if (reasoningBlockIndex === -1) {
-          return {
-            ...m,
-            blocks: [...m.blocks, { type: "reasoning", content: chunk, stage }],
-          };
-        }
-        return {
-          ...m,
-          blocks: m.blocks.map((b, idx) =>
-            idx === reasoningBlockIndex && b.type === "reasoning"
-              ? {
-                  ...b,
-                  content: (b.content || "") + chunk,
-                  stage,
-                }
-              : b,
-          ),
-        };
-      }),
-    );
-  }, []);
-
-  const applyToolBlockUpdate = useCallback(
-    (params: ToolBlockUpdateCallbackParams) => {
-      const {
-        messageId,
-        id: toolBlockId,
-        parametersChunk,
-        ...updates
-      } = params;
-      setMessages((prev) =>
-        prev.map((m) => {
-          if (m.id !== messageId) return m;
-          const toolBlockIndex = m.blocks.findIndex(
-            (b) => b.type === "tool" && b.id === toolBlockId,
-          );
-          if (toolBlockIndex === -1) {
-            return {
-              ...m,
-              blocks: [
-                ...m.blocks,
-                {
-                  type: "tool",
-                  id: toolBlockId,
-                  name: updates.name || "",
-                  stage: updates.stage || "start",
-                  parameters:
-                    (updates.parameters || "") + (parametersChunk || ""),
-                  result: updates.result || "",
-                  ...updates,
-                },
-              ],
-            };
-          }
-          return {
-            ...m,
-            blocks: m.blocks.map((b, idx) =>
-              idx === toolBlockIndex && b.type === "tool"
-                ? {
-                    ...b,
-                    ...updates,
-                    // Streaming carries only the delta; append it to the
-                    // accumulated parameters. start/running/end carry the
-                    // authoritative value and replace wholesale.
-                    parameters: parametersChunk
-                      ? (b.parameters || "") + parametersChunk
-                      : updates.parameters !== undefined
-                        ? updates.parameters
-                        : b.parameters,
-                  }
-                : b,
-            ),
-          };
-        }),
-      );
-    },
+  // Single throttled entry for ALL message-state updates — one 500ms
+  // window-concat window shared by every callback (content/reasoning deltas,
+  // tool parametersChunk, tool `running` stage shortResult/result, one-shot
+  // structural updates). The tool `running` stage used to bypass throttling
+  // (bash shortResult height changes per chunk → layout flicker); routing it
+  // through the same window as streaming deltas coalesces it to ≤1 render per
+  // window. See createThrottledUpdater + docs/specs/core/stream-content-updates.md.
+  const updateMessages = useMemo(
+    () =>
+      createThrottledUpdater<Message[]>((updater) => setMessages(updater), 500),
     [],
   );
 
   useEffect(() => {
     isExpandedRef.current = isExpanded;
-  }, [isExpanded]);
+    if (isExpanded) {
+      // Cancel pending throttled updates so the frozen expanded view isn't overwritten
+      updateMessages.cancel();
+    }
+  }, [isExpanded, updateMessages]);
 
   const [isLoading, setIsLoading] = useState(false);
   const [sessionId, setSessionId] = useState("");
@@ -447,10 +536,19 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   const refreshMessages = useCallback(() => {
     if (!isExpandedRef.current && agentRef.current) {
       const msgs = agentRef.current.messages.map(snapshotMessage);
+      // Snapshot-safe: the full-list replacement makes the SDK state
+      // authoritative. Any update still queued inside the 500ms throttle
+      // window was applied to the SDK before this pull, so it is already
+      // contained in `msgs` — dropping it prevents the trailing-edge flush
+      // from re-appending the pre-refresh chunk on top of the snapshot
+      // (first-word duplication). Updates arriving after the pull start fresh
+      // windows and append on top of the snapshot. See
+      // docs/specs/core/stream-content-updates.md.
+      updateMessages.cancel();
       setMessages(msgs);
       setLatestTotalTokens(extractLatestTotalTokens(msgs));
     }
-  }, []);
+  }, [updateMessages]);
 
   // Permission confirmation methods with queue support
   const showConfirmation = useCallback(
@@ -491,18 +589,23 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
 
       const callbacks: AgentCallbacks = {
         // ── Incremental message updates (no full-list pushes) ──────
+        // All of these funnel through the single throttled `updateMessages`
+        // entry, so every message-state update shares one 500ms window.
         onUserMessageAdded: () => {
           if (isExpandedRef.current || !agentRef.current) return;
           const msgs = agentRef.current.messages;
           const last = msgs[msgs.length - 1];
           if (!last || last.role !== "user") return;
           // Eager snapshot at callback time — React defers updater execution to
-          // the batch flush, so evaluating snapshotMessage inside setMessages
+          // the batch flush, so evaluating snapshotMessage inside the updater
           // would read the SDK message after its in-place mutations.
           const snapshot = snapshotMessage(last);
-          setMessages((prev) =>
+          updateMessages((prev) =>
             prev.some((m) => m.id === last.id) ? prev : [...prev, snapshot],
           );
+          // One-shot structural update — flush immediately so the message
+          // card appears at once (queuing it gains no coalescing).
+          updateMessages.flush();
         },
         onAssistantMessageAdded: (messageId: string) => {
           if (isExpandedRef.current || !agentRef.current) return;
@@ -512,25 +615,29 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
           // fires this callback BEFORE the first delta writes into the shared
           // message, so capturing here copies the pre-mutation (empty) blocks.
           const snapshot = snapshotMessage(msg);
-          setMessages((prev) =>
+          updateMessages((prev) =>
             prev.some((m) => m.id === messageId) ? prev : [...prev, snapshot],
           );
+          updateMessages.flush();
         },
         onAssistantContentUpdated: (params) => {
           if (isExpandedRef.current) return;
-          applyContentUpdate(params);
+          updateMessages((prev) => applyContentDelta(prev, params));
+          if (params.stage === "end") updateMessages.flush();
         },
         onAssistantReasoningUpdated: (params) => {
           if (isExpandedRef.current) return;
-          applyReasoningUpdate(params);
+          updateMessages((prev) => applyReasoningDelta(prev, params));
+          if (params.stage === "end") updateMessages.flush();
         },
         onToolBlockUpdated: (params) => {
           if (isExpandedRef.current) return;
-          applyToolBlockUpdate(params);
+          updateMessages((prev) => applyToolBlockUpdate(prev, params));
+          if (params.stage === "end") updateMessages.flush();
         },
         onErrorBlockAdded: (error: string) => {
           if (isExpandedRef.current) return;
-          setMessages((prev) => {
+          updateMessages((prev) => {
             // Append to the LAST message only if it is an assistant message
             // (the current turn's in-flight reply). If the last message is a
             // user message, the error belongs BELOW it — create a new
@@ -558,10 +665,13 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
               },
             ];
           });
+          // One-shot structural update — flush immediately (errors must not be
+          // delayed by a streaming window).
+          updateMessages.flush();
         },
         onAddBangMessage: (command, messageId) => {
           if (isExpandedRef.current) return;
-          setMessages((prev) =>
+          updateMessages((prev) =>
             prev.some((m) => m.id === messageId)
               ? prev
               : [
@@ -582,10 +692,11 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
                   },
                 ],
           );
+          updateMessages.flush();
         },
         onUpdateBangMessage: (command, output, messageId) => {
           if (isExpandedRef.current) return;
-          setMessages((prev) =>
+          updateMessages((prev) =>
             prev.map((m) =>
               m.id === messageId
                 ? {
@@ -602,7 +713,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         },
         onCompleteBangMessage: (command, exitCode, messageId, output) => {
           if (isExpandedRef.current) return;
-          setMessages((prev) =>
+          updateMessages((prev) =>
             prev.map((m) =>
               m.id === messageId
                 ? {
@@ -622,6 +733,8 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
                 : m,
             ),
           );
+          // Completion signal — flush so the final state applies immediately.
+          updateMessages.flush();
         },
         onLatestTotalTokensChange: (tokens) => {
           setLatestTotalTokens(tokens);
@@ -791,9 +904,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
       originalCwd,
       model,
       initialPermissionMode,
-      applyContentUpdate,
-      applyReasoningUpdate,
-      applyToolBlockUpdate,
+      updateMessages,
       mcpServers,
     ],
   );
@@ -832,6 +943,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   // Cleanup on unmount
   useEffect(() => {
     return () => {
+      updateMessages.cancel();
       if (agentRef.current) {
         try {
           // Display usage summary before cleanup
@@ -845,7 +957,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         agentRef.current.destroy();
       }
     };
-  }, []);
+  }, [updateMessages]);
 
   // Send message function (including judgment logic)
   const sendMessage = useCallback(

--- a/packages/code/tests/contexts/useChat.test.tsx
+++ b/packages/code/tests/contexts/useChat.test.tsx
@@ -5,6 +5,7 @@ import {
   ChatProvider,
   useChat,
   ChatContextType,
+  createThrottledUpdater,
 } from "../../src/contexts/useChat.js";
 import { Agent, BackgroundShell, Task } from "wave-agent-sdk";
 import { AppProvider } from "../../src/contexts/useAppConfig.js";
@@ -1624,7 +1625,122 @@ describe("ChatProvider", () => {
     });
   });
 
-  it("applies reasoning streaming updates immediately without throttling", async () => {
+  describe("createThrottledUpdater", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("applies the leading edge immediately and composes within-window updates FIFO at the trailing edge", () => {
+      vi.useFakeTimers();
+      const applied: Array<(prev: number[]) => number[]> = [];
+      const apply = vi.fn((updater: (prev: number[]) => number[]) => {
+        applied.push(updater);
+      });
+      const throttled = createThrottledUpdater<number[]>(apply, 500);
+
+      throttled((prev) => [...prev, 1]); // leading edge — immediate
+      expect(apply).toHaveBeenCalledTimes(1);
+
+      throttled((prev) => [...prev, 2]);
+      throttled((prev) => [...prev, 3]);
+      // Queued inside the window, not applied yet
+      expect(apply).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(600);
+      expect(apply).toHaveBeenCalledTimes(2);
+      // Trailing edge applies the whole queue as one composed updater in FIFO
+      // order — no update dropped, no reordering
+      const state = applied[1](applied[0]([]));
+      expect(state).toEqual([1, 2, 3]);
+    });
+
+    it("keeps every queued update — no last-value-wins drop of interleaved updates", () => {
+      vi.useFakeTimers();
+      const applied: Array<(prev: string[]) => string[]> = [];
+      const apply = vi.fn((updater: (prev: string[]) => string[]) => {
+        applied.push(updater);
+      });
+      const throttled = createThrottledUpdater<string[]>(apply, 500);
+
+      throttled((prev) => [...prev, "tool-a:1"]);
+      throttled((prev) => [...prev, "tool-b:1"]);
+      throttled((prev) => [...prev, "tool-a:2"]);
+      throttled((prev) => [...prev, "tool-b:2"]);
+
+      vi.advanceTimersByTime(600);
+      expect(apply).toHaveBeenCalledTimes(2);
+      // All four updates survive in arrival order
+      const state = applied[1](applied[0]([]));
+      expect(state).toEqual(["tool-a:1", "tool-b:1", "tool-a:2", "tool-b:2"]);
+    });
+
+    it("queues a running update FIFO behind earlier streaming updates so the stage never regresses", () => {
+      vi.useFakeTimers();
+      let state = { stage: "start" as string, parameters: "" };
+      const apply = vi.fn((updater: (prev: typeof state) => typeof state) => {
+        state = updater(state);
+      });
+      const throttled = createThrottledUpdater<typeof state>(apply, 500);
+
+      throttled((s) => ({
+        ...s,
+        stage: "streaming",
+        parameters: s.parameters + "{",
+      }));
+      throttled((s) => ({
+        ...s,
+        stage: "running",
+        parameters: '{"cmd":"ls"}',
+      }));
+
+      vi.advanceTimersByTime(600);
+      expect(apply).toHaveBeenCalledTimes(2);
+      // The streaming chunk applies first, then the authoritative running
+      // values — no stale flush can regress the stage back to streaming
+      // (replaces the old createToolStreamingThrottle drop-on-running logic)
+      expect(state).toEqual({ stage: "running", parameters: '{"cmd":"ls"}' });
+    });
+
+    it("flush applies queued updates immediately (end signals)", () => {
+      vi.useFakeTimers();
+      const applied: Array<(prev: number[]) => number[]> = [];
+      const apply = vi.fn((updater: (prev: number[]) => number[]) => {
+        applied.push(updater);
+      });
+      const throttled = createThrottledUpdater<number[]>(apply, 500);
+
+      throttled((prev) => [...prev, 1]);
+      throttled((prev) => [...prev, 2]);
+      throttled.flush();
+      expect(apply).toHaveBeenCalledTimes(2);
+      const state = applied[1](applied[0]([]));
+      expect(state).toEqual([1, 2]);
+      // No timer remains armed — advancing time must not re-apply anything
+      vi.advanceTimersByTime(600);
+      expect(apply).toHaveBeenCalledTimes(2);
+    });
+
+    it("cancel drops queued updates so no stale flush re-appends pre-refresh content", () => {
+      vi.useFakeTimers();
+      let state = { content: "" };
+      const apply = vi.fn((updater: (prev: typeof state) => typeof state) => {
+        state = updater(state);
+      });
+      const throttled = createThrottledUpdater<typeof state>(apply, 500);
+
+      throttled((s) => ({ content: s.content + "Let" }));
+      throttled((s) => ({ content: s.content + " me" })); // queued
+      throttled.cancel();
+      vi.advanceTimersByTime(600);
+      // Only the leading edge applied; the queued " me" was dropped (its
+      // content is already contained in the authoritative snapshot pulled by
+      // refreshMessages) — no "Let me me"
+      expect(apply).toHaveBeenCalledTimes(1);
+      expect(state).toEqual({ content: "Let" });
+    });
+  });
+
+  it("throttles reasoning streaming updates and flushes on end", async () => {
     let lastValue: ChatContextType | undefined;
     const onHookValue = (val: ChatContextType) => {
       lastValue = val;
@@ -1653,13 +1769,20 @@ describe("ChatProvider", () => {
       expect(lastValue?.messages).toHaveLength(1);
     });
 
-    // Every delta applies immediately — no 500ms cooldown window coalesces
-    // chunks (the former window-concat throttle is removed)
+    // Leading edge appends a new reasoning block immediately
     callbacks.onAssistantReasoningUpdated!({
       messageId: "msg-reason",
       chunk: "Th",
       stage: "streaming",
     });
+    await vi.waitFor(() => {
+      const reasoning = lastValue?.messages[0].blocks.find(
+        (b) => b.type === "reasoning",
+      ) as { content: string } | undefined;
+      expect(reasoning?.content).toBe("Th");
+    });
+
+    // Subsequent chunks within the 500ms window are coalesced (trailing)
     callbacks.onAssistantReasoningUpdated!({
       messageId: "msg-reason",
       chunk: "ink",
@@ -1670,14 +1793,12 @@ describe("ChatProvider", () => {
       chunk: "ing",
       stage: "streaming",
     });
-    await vi.waitFor(() => {
-      const reasoning = lastValue?.messages[0].blocks.find(
-        (b) => b.type === "reasoning",
-      ) as { content: string } | undefined;
-      expect(reasoning?.content).toBe("Thinking");
-    });
+    const beforeFlush = lastValue?.messages[0].blocks.find(
+      (b) => b.type === "reasoning",
+    ) as { content: string } | undefined;
+    expect(beforeFlush?.content).toBe("Th");
 
-    // stage === "end" appends its delta and applies the end signal
+    // stage === "end" flushes pending deltas and applies the end signal
     callbacks.onAssistantReasoningUpdated!({
       messageId: "msg-reason",
       chunk: "…",
@@ -2047,12 +2168,14 @@ describe("ChatProvider", () => {
       expect(lastValue?.messages).toHaveLength(1);
     });
 
-    // Regression (docs/specs/core/stream-content-updates.md, 2026-08-17): the
-    // removed 500ms window-concat throttle could carry a pending delta across
-    // a full-list refresh — the trailing-edge flush then re-appended the
-    // pre-refresh chunk on top of the authoritative snapshot ("Let me me").
-    // With the throttle gone every delta applies immediately, so no pending
-    // window exists for this interleaving to double-count through.
+    // Regression (docs/specs/core/stream-content-updates.md, 2026-08-17
+    // 竞态 / 2026-08-19 修复): the 500ms window-concat throttle carries the
+    // pending " me" delta across the full-list refresh. The trailing-edge
+    // flush would then re-append the pre-refresh chunk on top of the
+    // authoritative snapshot ("Let me" + " me" = "Let me me"). `refreshMessages`
+    // cancels the throttle windows at snapshot time — the pending delta is
+    // already contained in the pulled snapshot, so dropping it is lossless and
+    // the duplication cannot occur.
     const sdkMsg = mockAgent.messages[0] as unknown as {
       blocks: Array<{ type: string; content: string; stage: string }>;
     };
@@ -2089,7 +2212,10 @@ describe("ChatProvider", () => {
     });
 
     // A structural action (e.g. /clear) replaces CLI state with a full
-    // snapshot of the SDK's authoritative messages mid-stream
+    // snapshot of the SDK's authoritative messages mid-stream. The snapshot
+    // pull happens before the throttle windows are cancelled, so the pending
+    // " me" delta (already written into the SDK's message) is dropped, not
+    // flushed on top of the snapshot.
     Object.assign(mockAgent, {
       clearMessages: vi.fn().mockResolvedValue(undefined),
     });
@@ -2101,8 +2227,9 @@ describe("ChatProvider", () => {
       expect(reasoning?.content).toBe("Let me");
     });
 
-    // Let any leftover cooldown timer (old code) fire — the content must stay
-    // byte-identical to the SDK's authoritative content, never "Let me me"
+    // Let any leftover cooldown timer (without the snapshot-safe cancel) fire —
+    // the content must stay byte-identical to the SDK's authoritative content,
+    // never "Let me me"
     vi.advanceTimersByTime(1000);
     await vi.waitFor(() => {
       const reasoning = lastValue?.messages[0].blocks.find(


### PR DESCRIPTION
## Summary

All message-updating callbacks in the CLI `ChatProvider` now route through **one** 500ms FIFO window-concat throttle (`createThrottledUpdater`), replacing the old 3-channel throttle design. The bash tool's `running`-stage updates (`shortResult`/`result` chunks) were previously applied immediately, bypassing throttling — the flicker source — and now share the same throttle window as content, reasoning, and tool-streaming updates.

## Design

- `createThrottledUpdater<T>(apply, wait)`: leading edge applies immediately + opens a window; within-window updates queue FIFO; the trailing edge applies the whole queue as **one composed updater** (`batch.reduce` in arrival order) — no update dropped, no reordering.
- `flush()` (end signals, one-shot structural updates) applies queued updates immediately; `cancel()` (refreshMessages after snapshot pull, isExpanded toggle, unmount) clears the timer and drops the queue.
- FIFO ordering structurally replaces the old `createToolStreamingThrottle` drop-on-running logic: a `running` updater queued *behind* earlier streaming deltas applies after them, so no stale streaming flush can regress the stage.
- `snapshotMessage` is still invoked eagerly at callback time (React batches same-tick `setMessages`; updaters run at flush after SDK in-place mutation).
- `refreshMessages` cancels the single window *after* pulling the snapshot — snapshot-safe, no re-appended pre-refresh chunks ("Let me me" class of bugs).

## Spec

`docs/specs/core/stream-content-updates.md` — user story retitled 「CLI 消息状态经单一节流更新函数统一渲染，全量刷新时快照安全取消」with 10 acceptance scenarios; meeting record 2026-08-19 added.

## Tests

- New unit tests for `createThrottledUpdater` FIFO semantics (no last-value-wins drop, running-never-regresses-stage, flush/cancel behavior).
- Existing suites unchanged and passing: throttle window, multi-tool accumulation, straddle streaming→running, reasoning throttle, double-count, refresh-interleave, bang messages.

Verified locally: `tsc --noEmit`, full useChat test suite (63 tests), ESLint.