### PR TITLE
test(agent-sdk): stub resolveShellPath in safe-zone CWD tests

### DIFF
--- a/packages/agent-sdk/tests/tools/bashTool.test.ts
+++ b/packages/agent-sdk/tests/tools/bashTool.test.ts
@@ -64,6 +64,7 @@ vi.mock("../../src/utils/globalLogger.js", () => ({
 import { spawn } from "child_process";
 import { logger } from "../../src/utils/globalLogger.js";
 import { resolveShellPath } from "../../src/utils/shellResolver.js";
+import * as shellResolver from "../../src/utils/shellResolver.js";
 const mockSpawn = vi.mocked(spawn);
 
 describe("bashTool", () => {
@@ -762,17 +763,26 @@ EOF
   describe("CWD reset when outside safe zone", () => {
     // These tests mock `pwd -P` output as unix-style paths. Pin the platform to
     // non-Windows so the MSYS->Windows conversion (win32 only) doesn't rewrite
-    // them when the suite runs on a Windows machine/CI.
+    // them when the suite runs on a Windows machine/CI. resolveShellPath() is
+    // stubbed because the platform pin routes it to the unix resolver, which
+    // probes /bin/bash etc. — none exist on a Windows runner (Windows-only
+    // PATH, no $SHELL), and execute() would fail with "No suitable shell
+    // found" before the CWD logic runs.
     let platformSpy: ReturnType<typeof vi.spyOn>;
+    let resolveShellPathSpy: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {
       platformSpy = vi
         .spyOn(process, "platform", "get")
         .mockReturnValue("linux" as NodeJS.Platform);
+      resolveShellPathSpy = vi
+        .spyOn(shellResolver, "resolveShellPath")
+        .mockReturnValue("/bin/bash");
     });
 
     afterEach(() => {
       platformSpy.mockRestore();
+      resolveShellPathSpy.mockRestore();
     });
 
     const createMockProcess = (exitCode: number, newCwd: string) => {


### PR DESCRIPTION
## Problem

Windows CI on main is red (run 32224731647): 4 failures in `bashTool.test.ts` `CWD reset when outside safe zone` — all `expect(result.success).toBe(true)` getting `false`.

## Root cause

These tests mock `process.platform` to `linux` (so the win32 MSYS→Windows path conversion doesn't rewrite the unix-style paths). That routes `resolveShellPath()` into `resolveUnixShell()`, which probes `/bin/bash` etc. On the Windows CI runner (PowerShell, Windows-only PATH, no $SHELL) none of those exist, so the resolver returns `undefined` and `execute()` bails with `success: false`, error "No suitable shell found" — before the safe-zone logic even runs. They only passed on Linux CI because `/bin/bash` exists there.

## Fix

Stub `resolveShellPath()` → `/bin/bash` in the describe's `beforeEach` (mirrors existing patterns, e.g. `bangManager.test.ts`), making the tests platform-independent.

## Verification

- Reproduced the exact 4 failures locally with a CI-like env (`PATH` = Windows dirs only, `SHELL` unset)
- With the fix: all 36 bashTool tests pass in both normal and CI-like environments
- `tsc --noEmit` clean; pre-commit type-check + lint pass