### PR TITLE
fix(agent-sdk): fix Windows flaky tests (EBUSY log stream + libuv fs-event crash)

### DIFF
--- a/packages/agent-sdk/src/managers/backgroundTaskManager.ts
+++ b/packages/agent-sdk/src/managers/backgroundTaskManager.ts
@@ -95,6 +95,13 @@ export class BackgroundTaskManager {
     // Create log file
     const logPath = path.join(os.tmpdir(), `wave-task-${id}.log`);
     const logStream = fs.createWriteStream(logPath, { flags: "w" });
+    // A failed open/write of the log file (e.g. EBUSY on Windows when a stale
+    // handle from a previous run still locks the temp file) must not surface as
+    // an uncaught stream error — the log is best-effort side output and the
+    // task itself keeps running regardless.
+    logStream.on("error", (error: Error) => {
+      logger.warn(`Failed to write background task log ${logPath}:`, error);
+    });
 
     const shell: BackgroundShell = {
       id,
@@ -295,6 +302,11 @@ export class BackgroundTaskManager {
     // Create log file
     const logPath = path.join(os.tmpdir(), `wave-task-${id}.log`);
     const logStream = fs.createWriteStream(logPath, { flags: "w" });
+    // Same best-effort handling as startShell: a locked temp file (EBUSY on
+    // Windows) must not become an uncaught stream error.
+    logStream.on("error", (error: Error) => {
+      logger.warn(`Failed to write background task log ${logPath}:`, error);
+    });
 
     // Write initial output to log file
     if (initialStdout) {

--- a/packages/agent-sdk/tests/agent/agent.autoAccept.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.autoAccept.test.ts
@@ -8,6 +8,7 @@ import { ToolManager } from "../../src/managers/toolManager.js";
 import type { PermissionCallback } from "../../src/types/permissions.js";
 import * as fs from "fs/promises";
 import * as path from "path";
+import { longFormTempDir } from "../helpers/tempDir.js";
 
 // Mock child_process to prevent real command execution (e.g. npm install triggers network I/O)
 vi.mock("child_process");
@@ -20,13 +21,15 @@ describe("Agent Auto-Accept Permissions Integration", () => {
   let activeAgent: Agent | undefined;
 
   beforeEach(async () => {
-    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "wave-agent-test-"));
+    tempDir = await fs.mkdtemp(
+      path.join(longFormTempDir(), "wave-agent-test-"),
+    );
     process.env = {
       ...originalEnv,
       WAVE_API_KEY: "test-token",
       WAVE_BASE_URL: "https://test.api",
     };
-    vi.mocked(os.homedir).mockReturnValue(os.tmpdir());
+    vi.mocked(os.homedir).mockReturnValue(longFormTempDir());
 
     // Return a mock process that exits successfully without executing anything
     mockSpawn.mockReturnValue({
@@ -167,7 +170,7 @@ describe("Agent Auto-Accept Permissions Integration", () => {
   it("should merge global and local rules", async () => {
     // 1. Setup global config
     const userHome = await fs.mkdtemp(
-      path.join(os.tmpdir(), "wave-user-home-"),
+      path.join(longFormTempDir(), "wave-user-home-"),
     );
     vi.mocked(os.homedir).mockReturnValue(userHome);
 

--- a/packages/agent-sdk/tests/helpers/tempDir.ts
+++ b/packages/agent-sdk/tests/helpers/tempDir.ts
@@ -1,0 +1,22 @@
+import * as os from "os";
+import * as path from "path";
+
+/**
+ * %TEMP% on some Windows machines resolves through an 8.3 short name
+ * (e.g. C:\Users\LIUYIQ~1\...). libuv's Windows fs-event backend asserts
+ * (src\win\fs-event.c) when ReadDirectoryChangesW reports long-form event
+ * names that don't prefix-match the short-form watch dir — the whole process
+ * aborts when a watched file is created then deleted. Tests that run real
+ * watchers (chokidar/FileWatcherService) or real Agents under the temp dir
+ * must use a long-form temp dir instead when the default one contains a
+ * short name.
+ */
+export function longFormTempDir(): string {
+  const tmp = os.tmpdir();
+  // 8.3 short names always match `~N` (e.g. LIUYIQ~1); healthy temp dirs
+  // don't contain that pattern.
+  if (process.platform === "win32" && /~\d/.test(tmp)) {
+    return path.join(process.env.LOCALAPPDATA ?? os.homedir(), "Temp");
+  }
+  return tmp;
+}

--- a/packages/agent-sdk/tests/integration/fileWatcher-real-watch.test.ts
+++ b/packages/agent-sdk/tests/integration/fileWatcher-real-watch.test.ts
@@ -9,13 +9,13 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import * as fs from "fs";
-import * as os from "os";
 import * as path from "path";
 
 import {
   FileWatcherService,
   type FileWatchEvent,
 } from "../../src/services/fileWatcher.js";
+import { longFormTempDir } from "../helpers/tempDir.js";
 
 /** Poll for `count` events; real fs events have no deterministic latency. */
 async function waitForEvents(
@@ -39,7 +39,7 @@ describe("FileWatcherService with real chokidar", () => {
   let service: FileWatcherService;
 
   beforeAll(() => {
-    dir = fs.mkdtempSync(path.join(os.tmpdir(), "wave-watch-real-"));
+    dir = fs.mkdtempSync(path.join(longFormTempDir(), "wave-watch-real-"));
     service = new FileWatcherService(undefined, {
       // Keep the test fast: lower the awaitWriteFinish stability window.
       stabilityThreshold: 100,

--- a/packages/agent-sdk/tests/integration/hook-real-execution.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/hook-real-execution.integration.test.ts
@@ -15,12 +15,12 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as fs from "fs";
-import * as os from "os";
 import * as path from "path";
 
 import { Agent } from "../../src/agent.js";
 import * as aiService from "../../src/services/aiService.js";
 import type { PartialHookConfiguration } from "../../src/types/hooks.js";
+import { longFormTempDir } from "../helpers/tempDir.js";
 
 vi.mock("../../src/services/aiService.js", async (importOriginal) => {
   const actual =
@@ -51,7 +51,7 @@ describe("Hook real-command execution (spec automation/hooks.md)", () => {
   let workdir: string;
 
   beforeEach(async () => {
-    workdir = fs.mkdtempSync(path.join(os.tmpdir(), "wave-hook-real-"));
+    workdir = fs.mkdtempSync(path.join(longFormTempDir(), "wave-hook-real-"));
     callAgent = vi.mocked(aiService.callAgent);
     callAgent.mockClear();
   });

--- a/packages/agent-sdk/tests/managers/backgroundTaskManager.notification.test.ts
+++ b/packages/agent-sdk/tests/managers/backgroundTaskManager.notification.test.ts
@@ -27,6 +27,7 @@ vi.mock("fs", () => {
     writable: true,
     write: vi.fn(),
     end: vi.fn(),
+    on: vi.fn(),
   }));
   const existsSync = vi.fn(() => false);
   return {


### PR DESCRIPTION
## Summary

Fixes two pre-existing Windows-only flaky test failures in agent-sdk:

### 1. Unhandled EBUSY stream error in bashTool.test.ts
`BackgroundTaskManager` created background-task log streams via `fs.createWriteStream` without an error listener. When the temp log file was locked (EBUSY on Windows), the stream error surfaced as an uncaught exception and vitest exited 1 despite all tests passing.

**Fix:** attach `logStream.on("error", ...)` in both `startShell` and `adoptProcess` — the log is best-effort side output; on failure it logs a warning and the task keeps running.

### 2. libuv fs-event assertion crash (exit 127)
`Assertion failed: !_wcsnicmp(filename, dir, dirlen), file src\win\fs-event.c, line 72` — on this machine `%TEMP%` contains an 8.3 short name (`LIUYIQ~1`), and libuv's ReadDirectoryChangesW delivers long-form names that don't prefix-match the short-form watch dir, triggering a native abort. Verified NOT fixable by upgrading chokidar (3.6.0 / 4.0.3 / 5.0.0 all crash identically; the bug is in libuv).

**Fix:** new `longFormTempDir()` helper (`tests/helpers/tempDir.ts`) detects 8.3 short-name temp dirs on win32 and falls back to `%LOCALAPPDATA%\Temp` (long form). Applied to the 3 tests that run real watchers/Agents under tmpdir:
- `fileWatcher-real-watch.test.ts`
- `agent.autoAccept.test.ts`
- `hook-real-execution.integration.test.ts`

Also added `on()` to the `createWriteStream` mock in `backgroundTaskManager.notification.test.ts` so the error-listener change is covered.

## Verification
- Full agent-sdk suite green locally twice: 271 files, 3653 passed, 0 errors (no EBUSY, no assertion crash)
- Monorepo type-check passes