### PR TITLE
fix(agent-sdk): run skill bash interpolation via Git Bash on Windows

### DIFF
--- a/packages/agent-sdk/src/managers/backgroundTaskManager.ts
+++ b/packages/agent-sdk/src/managers/backgroundTaskManager.ts
@@ -95,6 +95,13 @@ export class BackgroundTaskManager {
     // Create log file
     const logPath = path.join(os.tmpdir(), `wave-task-${id}.log`);
     const logStream = fs.createWriteStream(logPath, { flags: "w" });
+    // A failed open/write of the log file (e.g. EBUSY on Windows when a stale
+    // handle from a previous run still locks the temp file) must not surface as
+    // an uncaught stream error — the log is best-effort side output and the
+    // task itself keeps running regardless.
+    logStream.on("error", (error: Error) => {
+      logger.warn(`Failed to write background task log ${logPath}:`, error);
+    });
 
     const shell: BackgroundShell = {
       id,
@@ -295,6 +302,11 @@ export class BackgroundTaskManager {
     // Create log file
     const logPath = path.join(os.tmpdir(), `wave-task-${id}.log`);
     const logStream = fs.createWriteStream(logPath, { flags: "w" });
+    // Same best-effort handling as startShell: a locked temp file (EBUSY on
+    // Windows) must not become an uncaught stream error.
+    logStream.on("error", (error: Error) => {
+      logger.warn(`Failed to write background task log ${logPath}:`, error);
+    });
 
     // Write initial output to log file
     if (initialStdout) {

--- a/packages/agent-sdk/src/utils/markdownParser.ts
+++ b/packages/agent-sdk/src/utils/markdownParser.ts
@@ -9,6 +9,7 @@ import {
   PREVIEW_SIZE_BYTES,
 } from "../constants/toolLimits.js";
 import { logger } from "./globalLogger.js";
+import { resolveShellPath } from "./shellResolver.js";
 
 const execAsync = promisify(exec);
 
@@ -278,12 +279,30 @@ export async function executeBashCommands(
 ): Promise<BashCommandResult[]> {
   const results: BashCommandResult[] = [];
 
-  for (const command of commands) {
+  for (const originalCommand of commands) {
+    let command = originalCommand;
+    const execOptions: { cwd: string; timeout: number; shell?: string } = {
+      cwd: workdir,
+      timeout,
+    };
+
+    // Skill templates (e.g. !`gh pr view ... 2>/dev/null || echo '{}'`) use
+    // bash-only syntax. On Windows, child_process.exec defaults to cmd.exe,
+    // where `/dev/null` fails with a localized "path not found" error whose
+    // GBK bytes get mis-decoded as UTF-8 (mojibake). Run through Git Bash
+    // when available (same contract as the bash tool); otherwise force the
+    // UTF-8 codepage so cmd's own messages decode correctly.
+    if (process.platform === "win32") {
+      const bashPath = resolveShellPath();
+      if (bashPath) {
+        execOptions.shell = bashPath;
+      } else {
+        command = `chcp 65001 >NUL && ${command}`;
+      }
+    }
+
     try {
-      const { stdout, stderr } = await execAsync(command, {
-        cwd: workdir,
-        timeout,
-      });
+      const { stdout, stderr } = await execAsync(command, execOptions);
       results.push({
         command,
         output: (stdout + (stderr || "")).trim(),

--- a/packages/agent-sdk/tests/agent/agent.autoAccept.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.autoAccept.test.ts
@@ -8,6 +8,7 @@ import { ToolManager } from "../../src/managers/toolManager.js";
 import type { PermissionCallback } from "../../src/types/permissions.js";
 import * as fs from "fs/promises";
 import * as path from "path";
+import { longFormTempDir } from "../helpers/tempDir.js";
 
 // Mock child_process to prevent real command execution (e.g. npm install triggers network I/O)
 vi.mock("child_process");
@@ -20,13 +21,15 @@ describe("Agent Auto-Accept Permissions Integration", () => {
   let activeAgent: Agent | undefined;
 
   beforeEach(async () => {
-    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "wave-agent-test-"));
+    tempDir = await fs.mkdtemp(
+      path.join(longFormTempDir(), "wave-agent-test-"),
+    );
     process.env = {
       ...originalEnv,
       WAVE_API_KEY: "test-token",
       WAVE_BASE_URL: "https://test.api",
     };
-    vi.mocked(os.homedir).mockReturnValue(os.tmpdir());
+    vi.mocked(os.homedir).mockReturnValue(longFormTempDir());
 
     // Return a mock process that exits successfully without executing anything
     mockSpawn.mockReturnValue({
@@ -167,7 +170,7 @@ describe("Agent Auto-Accept Permissions Integration", () => {
   it("should merge global and local rules", async () => {
     // 1. Setup global config
     const userHome = await fs.mkdtemp(
-      path.join(os.tmpdir(), "wave-user-home-"),
+      path.join(longFormTempDir(), "wave-user-home-"),
     );
     vi.mocked(os.homedir).mockReturnValue(userHome);
 

--- a/packages/agent-sdk/tests/helpers/tempDir.ts
+++ b/packages/agent-sdk/tests/helpers/tempDir.ts
@@ -1,0 +1,22 @@
+import * as os from "os";
+import * as path from "path";
+
+/**
+ * %TEMP% on some Windows machines resolves through an 8.3 short name
+ * (e.g. C:\Users\LIUYIQ~1\...). libuv's Windows fs-event backend asserts
+ * (src\win\fs-event.c) when ReadDirectoryChangesW reports long-form event
+ * names that don't prefix-match the short-form watch dir — the whole process
+ * aborts when a watched file is created then deleted. Tests that run real
+ * watchers (chokidar/FileWatcherService) or real Agents under the temp dir
+ * must use a long-form temp dir instead when the default one contains a
+ * short name.
+ */
+export function longFormTempDir(): string {
+  const tmp = os.tmpdir();
+  // 8.3 short names always match `~N` (e.g. LIUYIQ~1); healthy temp dirs
+  // don't contain that pattern.
+  if (process.platform === "win32" && /~\d/.test(tmp)) {
+    return path.join(process.env.LOCALAPPDATA ?? os.homedir(), "Temp");
+  }
+  return tmp;
+}

--- a/packages/agent-sdk/tests/integration/fileWatcher-real-watch.test.ts
+++ b/packages/agent-sdk/tests/integration/fileWatcher-real-watch.test.ts
@@ -9,13 +9,13 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import * as fs from "fs";
-import * as os from "os";
 import * as path from "path";
 
 import {
   FileWatcherService,
   type FileWatchEvent,
 } from "../../src/services/fileWatcher.js";
+import { longFormTempDir } from "../helpers/tempDir.js";
 
 /** Poll for `count` events; real fs events have no deterministic latency. */
 async function waitForEvents(
@@ -39,7 +39,7 @@ describe("FileWatcherService with real chokidar", () => {
   let service: FileWatcherService;
 
   beforeAll(() => {
-    dir = fs.mkdtempSync(path.join(os.tmpdir(), "wave-watch-real-"));
+    dir = fs.mkdtempSync(path.join(longFormTempDir(), "wave-watch-real-"));
     service = new FileWatcherService(undefined, {
       // Keep the test fast: lower the awaitWriteFinish stability window.
       stabilityThreshold: 100,

--- a/packages/agent-sdk/tests/integration/hook-real-execution.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/hook-real-execution.integration.test.ts
@@ -15,12 +15,12 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as fs from "fs";
-import * as os from "os";
 import * as path from "path";
 
 import { Agent } from "../../src/agent.js";
 import * as aiService from "../../src/services/aiService.js";
 import type { PartialHookConfiguration } from "../../src/types/hooks.js";
+import { longFormTempDir } from "../helpers/tempDir.js";
 
 vi.mock("../../src/services/aiService.js", async (importOriginal) => {
   const actual =
@@ -51,7 +51,7 @@ describe("Hook real-command execution (spec automation/hooks.md)", () => {
   let workdir: string;
 
   beforeEach(async () => {
-    workdir = fs.mkdtempSync(path.join(os.tmpdir(), "wave-hook-real-"));
+    workdir = fs.mkdtempSync(path.join(longFormTempDir(), "wave-hook-real-"));
     callAgent = vi.mocked(aiService.callAgent);
     callAgent.mockClear();
   });

--- a/packages/agent-sdk/tests/managers/backgroundTaskManager.notification.test.ts
+++ b/packages/agent-sdk/tests/managers/backgroundTaskManager.notification.test.ts
@@ -27,6 +27,7 @@ vi.mock("fs", () => {
     writable: true,
     write: vi.fn(),
     end: vi.fn(),
+    on: vi.fn(),
   }));
   const existsSync = vi.fn(() => false);
   return {

--- a/packages/agent-sdk/tests/utils/markdownParser.test.ts
+++ b/packages/agent-sdk/tests/utils/markdownParser.test.ts
@@ -298,6 +298,23 @@ describe("markdownParser", () => {
       expect(results[0].output).toBe("one");
       expect(results[1].output).toBe("two");
     });
+
+    it.runIf(process.platform === "win32")(
+      "runs bash-only syntax via Git Bash on Windows",
+      async () => {
+        // Regression: skill templates use bash syntax (2>/dev/null, ||).
+        // Under cmd.exe `/dev/null` fails with a localized path-not-found
+        // error (and `true` is not a command); the command must run through
+        // Git Bash instead, where `true 2>/dev/null` succeeds silently.
+        const results = await executeBashCommands(
+          ["true 2>/dev/null || echo fallback"],
+          process.cwd(),
+        );
+        expect(results).toHaveLength(1);
+        expect(results[0].exitCode).toBe(0);
+        expect(results[0].output).toBe("");
+      },
+    );
   });
 
   describe("performance gate", () => {


### PR DESCRIPTION
## Summary

Fixes skill `!` command interpolation on Windows. Skill templates (e.g. `!`gh pr view ... 2>/dev/null || echo '{}'``) use bash-only syntax, but `executeBashCommands` ran commands through `child_process.exec`, which defaults to **cmd.exe** on Windows. Under cmd.exe:

- `/dev/null` fails with a localized "path not found" error — the skill command never executes
- The GBK-encoded Chinese error message gets mis-decoded as UTF-8 (mojibake), e.g. `ϵͳ�Ҳ���ָ����·����`

## Fix

`packages/agent-sdk/src/utils/markdownParser.ts` — `executeBashCommands` on win32 now resolves Git Bash via `resolveShellPath()` (same contract as the bash tool, /! bang command, background tasks, and hooks) and runs the command through `bash -c`; when Git Bash is unavailable it falls back to cmd with a `chcp 65001` prefix so cmd's own messages decode correctly.

## Verification

- Win32 regression test: `true 2>/dev/null || echo fallback` now exits 0 with empty output (previously cmd printed the localized path-not-found error)
- `markdownParser.test.ts` 34/34, plus skillManager/parser suites 102/102 pass; monorepo type-check green
- Empirically confirmed the exact failing template command now returns real PR JSON through `executeBashCommands`