### PR TITLE
feat(code): show deleting/done progress when removing worktree

### DIFF
--- a/docs/specs/multi-agent/worktree.md
+++ b/docs/specs/multi-agent/worktree.md
@@ -85,6 +85,26 @@ order: 90
 
 ---
 
+### 用户故事：Worktree 删除进度提示（优先级：P2）
+
+作为在 Windows 上使用 Wave 的开发者，我希望删除 worktree 时能看到"正在删除"和"完成"的进度提示，以便我了解 CLI 正在执行删除而不是卡死。
+
+**为什么是这个优先级**：Windows 上递归删除 worktree 目录（尤其含 node_modules 等深路径时，git 删除失败后的 fs.rmSync 兜底）可能耗时数十秒。CLI 退出对话框选择 "Remove worktree" 后 Ink 界面已卸载，删除是同步阻塞的，完成前终端无任何输出，用户会误以为 CLI 挂死。放弃 Windows 删除速度优化，改为提供明确的进度反馈（`WorktreeRemove` hook 接管删除同理可能耗时）。
+
+**独立测试**：在 Windows 上进入含深路径依赖的 worktree 会话，Ctrl+C 退出并选择 "Remove worktree"，验证终端先显示 "Deleting worktree ..."、删除完成后显示 "Done." 并退出；再运行 `wave -p` 打印模式，clean worktree 退出时验证同样显示两种提示。
+
+**验收场景**：
+
+1. **假设** CLI 退出对话框选择 "Remove worktree"，**当** 删除执行前，**则** 终端显示删除进度提示（如 `Deleting worktree ...`），且提示持续显示直到删除完成。
+2. **假设** 删除成功完成，**当** 删除结束时，**则** 终端显示完成提示（如 `Done.`），随后进程退出。
+3. **假设** 删除失败（git 与 fs.rmSync 兜底均失败），**当** 删除结束时，**则** 显示错误信息而非完成提示，进程照常退出（删除为 best-effort，不阻塞退出）。
+4. **假设** 由 `WorktreeRemove` hook 接管删除（hook 脚本可能耗时），**当** CLI 退出对话框选择 "Remove worktree" 时，**则** 同样显示删除进度提示与完成提示。
+5. **假设** print 模式（`wave -p`）下 clean worktree 自动删除，**当** 删除执行时，**则** 同样显示删除进度提示与完成提示。
+6. **假设** 退出对话框选择 "Keep worktree"，**当** 退出时，**则** 不显示任何删除提示（worktree 未被删除）。
+7. **假设** 会话中 AI 调用 ExitWorktree 工具（`action: "remove"`），**当** 删除执行时，**则** 行为不变——工具结果文本本身就是反馈，不引入终端进度提示。
+
+---
+
 ### 用户故事：会话中 EnterWorktree 工具（优先级：P1）
 
 作为使用 Wave 的开发者，我希望在会话中通过向 AI 请求来创建 worktree，以便在不重启会话的情况下隔离我的工作。

--- a/packages/code/src/cli.tsx
+++ b/packages/code/src/cli.tsx
@@ -88,10 +88,15 @@ export async function startCli(options: CliOptions): Promise<void> {
       console.warn("Failed to cleanup old logs:", error);
     });
 
-    // Cleanup worktree if requested
+    // Cleanup worktree if requested. The Ink UI is already unmounted, and on
+    // Windows recursive deletion can take a long time (deep paths, Defender
+    // scanning), so show explicit progress feedback instead of leaving the
+    // terminal looking frozen.
     if (shouldRemoveWorktree && worktreeSession) {
+      process.stdout.write("\nDeleting worktree ...\n");
       process.chdir(worktreeSession.repoRoot);
       await removeWorktree(worktreeSession);
+      process.stdout.write("Done.\n");
     }
 
     process.exit(0);

--- a/packages/code/src/print-cli.ts
+++ b/packages/code/src/print-cli.ts
@@ -217,7 +217,9 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
             worktreeSession.repoRoot,
           );
         }
+        process.stdout.write("\nDeleting worktree ...\n");
         await removeWorktree(worktreeSession);
+        process.stdout.write("Done.\n");
       } catch (error) {
         // Never block print-mode exit on worktree cleanup failures
         process.stdout.write(
@@ -273,7 +275,9 @@ export async function startPrintCli(options: PrintCliOptions): Promise<void> {
               worktreeSession.repoRoot,
             );
           }
+          process.stdout.write("\nDeleting worktree ...\n");
           await removeWorktree(worktreeSession);
+          process.stdout.write("Done.\n");
         } catch (error) {
           process.stdout.write(
             `\n⚠️ Skipping worktree removal: ${(error as Error).message}\n`,

--- a/packages/code/tests/cli.test.tsx
+++ b/packages/code/tests/cli.test.tsx
@@ -68,6 +68,54 @@ describe("startCli", () => {
     consoleErrorSpy.mockRestore();
   });
 
+  it("shows deleting progress and done messages when removing worktree", async () => {
+    const chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    const worktreeSession = {
+      name: "test",
+      path: "/repo/root.worktrees/test",
+      branch: "worktree-test",
+      repoRoot: "/repo/root",
+      hasUncommittedChanges: false,
+      hasNewCommits: false,
+      isNew: true,
+    };
+
+    // Mock render to call onExit with true (Remove worktree)
+    vi.mocked(render).mockImplementationOnce((element: unknown) => {
+      const { onExit } = (
+        element as { props: { onExit: (shouldRemove: boolean) => void } }
+      ).props;
+      return {
+        unmount: vi.fn(),
+        waitUntilExit: async () => {
+          onExit(true);
+        },
+      } as unknown as ReturnType<typeof render>;
+    });
+
+    await expect(startCli({ worktreeSession })).rejects.toThrow(
+      "process.exit called",
+    );
+
+    expect(stdoutSpy).toHaveBeenCalledWith("\nDeleting worktree ...\n");
+    expect(stdoutSpy).toHaveBeenCalledWith("Done.\n");
+
+    chdirSpy.mockRestore();
+    exitSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    stdoutSpy.mockRestore();
+  });
+
   it("enables and disables bracketed paste when stdout is a TTY", async () => {
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit called");

--- a/packages/code/tests/print-cli.test.ts
+++ b/packages/code/tests/print-cli.test.ts
@@ -636,6 +636,10 @@ test("startPrintCli removes clean worktree after destroy", async () => {
     hasNewCommits: false,
   };
 
+  const stdoutSpy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation(() => true);
+
   await startPrintCli({
     message: "test",
     worktreeSession,
@@ -647,7 +651,17 @@ test("startPrintCli removes clean worktree after destroy", async () => {
   const removeOrder = vi.mocked(removeWorktree).mock.invocationCallOrder[0];
   expect(destroyOrder).toBeLessThan(removeOrder);
   expect(removeWorktree).toHaveBeenCalledWith(worktreeSession);
+  expect(
+    stdoutSpy.mock.calls.some((call) =>
+      String(call[0]).includes("Deleting worktree ..."),
+    ),
+  ).toBe(true);
+  expect(
+    stdoutSpy.mock.calls.some((call) => String(call[0]).includes("Done.")),
+  ).toBe(true);
   expect(mockExit).toHaveBeenCalledWith(0);
+
+  stdoutSpy.mockRestore();
 });
 
 test("startPrintCli keeps dirty worktree with a warning", async () => {
@@ -820,6 +834,14 @@ test("startPrintCli removes clean worktree after destroy on sendMessage error", 
   const removeOrder = vi.mocked(removeWorktree).mock.invocationCallOrder[0];
   expect(destroyOrder).toBeLessThan(removeOrder);
   expect(removeWorktree).toHaveBeenCalledTimes(1);
+  expect(
+    stdoutSpy.mock.calls.some((call) =>
+      String(call[0]).includes("Deleting worktree ..."),
+    ),
+  ).toBe(true);
+  expect(
+    stdoutSpy.mock.calls.some((call) => String(call[0]).includes("Done.")),
+  ).toBe(true);
   expect(mockExit).toHaveBeenCalledWith(1);
 
   consoleErrorSpy.mockRestore();


### PR DESCRIPTION
Windows 上递归删除 worktree 目录（深路径、Defender 扫描）可能耗时很久。此前 CLI 退出对话框选 `Remove worktree` 与 `wave -p` 打印模式清理时，删除过程终端无任何输出，界面看起来像卡死。

本次放弃速度优化，改为在删除前输出 `Deleting worktree ...`、完成后输出 `Done.`：

- `packages/code/src/cli.tsx` — 退出对话框 `Remove worktree` 清理路径
- `packages/code/src/print-cli.ts` — 打印模式成功/失败两条清理路径
- `docs/specs/multi-agent/worktree.md` — 新增 P2 用户故事「Worktree 删除进度提示」（7 个验收场景）
- 测试：`cli.test.tsx` 新增用例，`print-cli.test.ts` 两个删除用例补充提示断言（23/23 通过）