### PR TITLE
feat(agent-sdk): per-model maxInputTokens input context window

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1304,6 +1304,19 @@ Wave 提供了一个强大的内置 `/settings` skill，作为用户与 Wave 配
 
 此外还支持 `fastModel` 配置，用于子代理（Explore）和网页抓取摘要等轻量场景。
 
+每个模型还可以通过 `maxInputTokens`（模型条目顶层，不在 `options` 内）设置其输入上下文窗口。该值覆盖全局的 `WAVE_MAX_INPUT_TOKENS`，压缩阈值和用量显示会按各模型自己的值生效：
+
+```json
+{
+  "models": {
+    "deepseek-v4-flash": { "maxInputTokens": 200000 },
+    "kimi-k3": { "maxInputTokens": 131072 }
+  }
+}
+```
+
+`maxInputTokens` 解析优先级：构造函数参数 > options > `models[模型].maxInputTokens` > `WAVE_MAX_INPUT_TOKENS` > 默认值。子代理（如 `fastModel`/`visionModel`）会按实际使用的模型查找对应值。
+
 ### 模型能力配置 {#settings-capabilities}
 
 在 `models` 字段中通过 `capabilities` 声明式配置每个模型的能力，支持以下字段：

--- a/packages/agent-sdk/src/builtin/skills/settings.ts
+++ b/packages/agent-sdk/src/builtin/skills/settings.ts
@@ -29,7 +29,7 @@ Wave uses several environment variables to control its core functionality. Varia
 | \`WAVE_MODEL\` | The primary AI model to use for the agent. | \`gemini-3-flash\` |
 | \`WAVE_FAST_MODEL\` | The fast AI model to use for quick tasks. | \`gemini-2.5-flash\` |
 | \`WAVE_VISION_MODEL\` | Vision-capable model used by the built-in \`vision\` subagent for image recognition. When set, the built-in \`vision\` subagent is registered (its frontmatter \`model: visionModel\` resolves to this value); when unset, the subagent is not loaded. Useful when the main model is fast but non-vision (e.g. DeepSeek). | - (not registered) |
-| \`WAVE_MAX_INPUT_TOKENS\` | Maximum number of input tokens allowed. | \`200000\` |
+| \`WAVE_MAX_INPUT_TOKENS\` | Maximum number of input tokens allowed. Overridden per-model by \`models[<model>].maxInputTokens\`. | \`200000\` |
 | \`WAVE_MAX_OUTPUT_TOKENS\` | Maximum number of output tokens allowed. | \`32000\` |
 | \`WAVE_DISABLE_AUTO_MEMORY\` | Set to \`1\` or \`true\` to disable the auto-memory feature. | \`false\` |
 | \`WAVE_AUTO_MEMORY_FREQUENCY\` | Auto memory update frequency. \`1\` = every turn, \`2\` = every 2 turns, etc. | \`1\` |
@@ -590,6 +590,21 @@ Generation parameters are nested under the \`options\` field within each model's
 - \`thinking\`: (Claude specific) Configures the thinking/reasoning capabilities for Claude 3.7+ models.
   - \`type\`: \`"enabled"\` or \`"disabled"\`.
   - \`budget_tokens\`: Maximum tokens to use for thinking.
+
+## Per-Model Input Context Window
+
+Set \`maxInputTokens\` at the top level of a model entry (not inside \`options\`) to define that model's input context window. It overrides the global \`WAVE_MAX_INPUT_TOKENS\`, so compaction thresholds and usage display follow each model's own value:
+
+\`\`\`json
+{
+  "models": {
+    "deepseek-v4-flash": { "maxInputTokens": 200000 },
+    "kimi-k3": { "maxInputTokens": 131072 }
+  }
+}
+\`\`\`
+
+Resolution priority: constructor > \`options\` > \`models[<model>].maxInputTokens\` > \`WAVE_MAX_INPUT_TOKENS\` > default. Subagents (\`fastModel\`/\`visionModel\`) resolve against the model they actually use.
 
 ## Model Capabilities
 

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -330,7 +330,13 @@ export class AIManager {
   }
 
   public getMaxInputTokens(): number {
-    return this.configurationService.resolveMaxInputTokens();
+    // Pass the resolved model (including fastModel/visionModel/override
+    // resolution) so subagents using a different model get that model's
+    // per-model maxInputTokens instead of the main model's value.
+    return this.configurationService.resolveMaxInputTokens(
+      undefined,
+      this.getModelConfig().model,
+    );
   }
 
   public getLanguage(): string | undefined {

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -660,11 +660,12 @@ export class ConfigurationService {
 
   /**
    * Resolves token limit with fallbacks
-   * Resolution priority: override > options > env (from settings.json) > process.env > default
+   * Resolution priority: override > options > models[model].maxInputTokens > env (from settings.json) > process.env > default
    * @param constructorLimit - Token limit override (optional)
+   * @param model - Model to resolve per-model maxInputTokens for (optional; falls back to the resolved agent model chain)
    * @returns Resolved token limit
    */
-  resolveMaxInputTokens(constructorLimit?: number): number {
+  resolveMaxInputTokens(constructorLimit?: number, model?: string): number {
     // If override value provided, use it
     if (constructorLimit !== undefined) {
       return constructorLimit;
@@ -673,6 +674,19 @@ export class ConfigurationService {
     // If options value provided, use it
     if (this.options.maxInputTokens !== undefined) {
       return this.options.maxInputTokens;
+    }
+
+    // Per-model config (models[X].maxInputTokens). Resolve the model with the
+    // same chain as resolveModelConfig: caller > options > currentConfiguration > env.
+    const resolvedModel =
+      model ||
+      this.options.model ||
+      this.currentConfiguration?.model ||
+      (this.envSnapshot.WAVE_MODEL ?? process.env.WAVE_MODEL);
+    const modelConfig =
+      resolvedModel && this.currentConfiguration?.models?.[resolvedModel];
+    if (modelConfig && modelConfig.maxInputTokens !== undefined) {
+      return modelConfig.maxInputTokens;
     }
 
     // Try env (settings.json snapshot) first, then process.env

--- a/packages/agent-sdk/src/types/config.ts
+++ b/packages/agent-sdk/src/types/config.ts
@@ -29,6 +29,8 @@ export interface ModelConfig {
   /** Vision-capable model for image recognition subagents (resolved from WAVE_VISION_MODEL env var). */
   visionModel?: string;
   maxTokens?: number;
+  /** Per-model input context window in tokens. Overrides the global `WAVE_MAX_INPUT_TOKENS` for this model. */
+  maxInputTokens?: number;
   permissionMode?: PermissionMode;
   capabilities?: ModelCapabilities;
   /** Generation params passed through to the API provider (temperature, thinking, etc.) */

--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -867,6 +867,101 @@ describe("ConfigurationService", () => {
       configService.setEnvironmentVars({ WAVE_MAX_INPUT_TOKENS: "5000" });
       expect(configService.resolveMaxInputTokens()).toBe(5000);
     });
+
+    it("should resolve from per-model config for the resolved model, beating env", async () => {
+      const config = {
+        model: "kimi-k3",
+        models: { "kimi-k3": { maxInputTokens: 131072 } },
+      };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      const origModel = process.env.WAVE_MODEL;
+      delete process.env.WAVE_MODEL;
+      try {
+        await configService.loadMergedConfiguration(tempDir);
+        configService.setEnvironmentVars({ WAVE_MAX_INPUT_TOKENS: "300000" });
+        expect(configService.resolveMaxInputTokens()).toBe(131072);
+      } finally {
+        if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
+        else delete process.env.WAVE_MODEL;
+      }
+    });
+
+    it("should resolve per-model config from env WAVE_MODEL when config has no model field", async () => {
+      const config = {
+        models: { "env-model": { maxInputTokens: 88888 } },
+      };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      const origModel = process.env.WAVE_MODEL;
+      process.env.WAVE_MODEL = "env-model";
+      try {
+        await configService.loadMergedConfiguration(tempDir);
+        expect(configService.resolveMaxInputTokens()).toBe(88888);
+      } finally {
+        if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
+        else delete process.env.WAVE_MODEL;
+      }
+    });
+
+    it("should use per-model config of the explicitly passed model (subagent scenario)", async () => {
+      const config = {
+        model: "deepseek-v4-flash",
+        models: {
+          "deepseek-v4-flash": { maxInputTokens: 200000 },
+          "kimi-k3": { maxInputTokens: 131072 },
+        },
+      };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      const origModel = process.env.WAVE_MODEL;
+      delete process.env.WAVE_MODEL;
+      try {
+        await configService.loadMergedConfiguration(tempDir);
+        expect(configService.resolveMaxInputTokens(undefined, "kimi-k3")).toBe(
+          131072,
+        );
+      } finally {
+        if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
+        else delete process.env.WAVE_MODEL;
+      }
+    });
+
+    it("should prioritize options.maxInputTokens over per-model config", async () => {
+      const config = {
+        model: "kimi-k3",
+        models: { "kimi-k3": { maxInputTokens: 131072 } },
+      };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      await configService.loadMergedConfiguration(tempDir);
+      configService.setOptions({ maxInputTokens: 400000 });
+      expect(configService.resolveMaxInputTokens()).toBe(400000);
+    });
+
+    it("should fall back to env when the model has no maxInputTokens", async () => {
+      const config = {
+        model: "plain-model",
+        models: { "plain-model": {} },
+      };
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(config));
+
+      const origModel = process.env.WAVE_MODEL;
+      delete process.env.WAVE_MODEL;
+      try {
+        await configService.loadMergedConfiguration(tempDir);
+        configService.setEnvironmentVars({ WAVE_MAX_INPUT_TOKENS: "5000" });
+        expect(configService.resolveMaxInputTokens()).toBe(5000);
+      } finally {
+        if (origModel !== undefined) process.env.WAVE_MODEL = origModel;
+        else delete process.env.WAVE_MODEL;
+      }
+    });
   });
 
   describe("resolveLanguage", () => {


### PR DESCRIPTION
## 背景

codechat remote_config 目前只有全局 `env.WAVE_MAX_INPUT_TOKENS=300000`，但每个模型上下文不同（如 kimi-k3 只有 131072）。需要在 `models` 条目里按模型配置 `maxInputTokens`，压缩阈值和用量显示自动按各模型生效。后端零改动。

## 改动

- **types/config.ts**：`ModelConfig` 新增 `maxInputTokens?: number`
- **configurationService.ts** `resolveMaxInputTokens()`：新增可选 `model` 参数；在 options 之后、env 之前插入 `models[resolvedModel].maxInputTokens` 查找。解析优先级：constructor > options > per-model > env (`WAVE_MAX_INPUT_TOKENS`) > 默认值，模型解析链与 `resolveModelConfig` 一致（caller > options > currentConfiguration.model > env WAVE_MODEL）
- **aiManager.ts** `getMaxInputTokens()`：传 `this.getModelConfig().model`（含 fastModel/visionModel/override 解析），subagent 用别的模型时按实际模型取 per-model 值
- **文档**：docs/sdk.md 模型配置小节 + builtin settings skill（ENV 表 + MODELS.md）
- **测试**：5 个新单测覆盖优先级链（options > per-model > env > 默认；显式 model 参数 subagent 场景；env WAVE_MODEL 路径）

## 验证

- agent-sdk 全量测试（含集成）：270 文件 / 3659 passed / 4 skipped
- 全仓 type-check + lint：全部通过
- prettier：通过

验收场景：`{models: {"deepseek-v4-flash": {maxInputTokens: 200000}, "kimi-k3": {maxInputTokens: 131072}}}` 时各模型压缩阈值按各自值生效。