### PR TITLE
feat(agent-sdk): pre-request auto-compaction using total_tokens only

### DIFF
--- a/docs/specs/core/message-compact.md
+++ b/docs/specs/core/message-compact.md
@@ -7,7 +7,7 @@ order: 70
 # 功能规格说明：消息压缩
 
 **创建日期**：2026-01-22  
-**更新日期**：2026-08-18
+**更新日期**：2026-08-19
 
 ## 用户场景与测试 _（必填）_
 
@@ -21,9 +21,46 @@ order: 70
 
 **验收场景**：
 
-1. **假设**总 token 计数超过 `getMaxInputTokens()`，**当**处理下一条消息时，**则**代理必须识别要压缩的消息
+1. **假设**估算的上下文 token 数超过 `getMaxInputTokens()`，**当**发送下一个 API 请求前执行检查时，**则**代理必须识别要压缩的消息并在请求发出前触发压缩
 2. **假设**消息被识别用于压缩，**当**总结完成时，**则**原始消息必须被 `compress` 块替换，后跟旧消息列表的最后 2 个 API 轮次
 3. **假设**存在 `compress` 块，**当**向 API 发送消息时，**则**它必须被转换为 **user** 消息（匹配 Claude Code 的自动压缩行为）
+
+---
+
+### 用户故事：请求前自动压缩触发（对齐 Claude Code）（优先级：P1）
+
+作为 AI 代理，我希望在发送 API 请求之前基于估算的上下文大小判断是否压缩，而不是在响应返回后才发现超限，以便超限请求永远不会真正发出。
+
+**为什么是这个优先级**：当前实现是在每次 API 响应返回后检查该次响应的 `usage`，超限时才压缩——判断慢一拍，导致输入超过 `maxInputTokens` 的请求真实发出（可能直接撞上模型 context length / 413 错误）。对齐 Claude Code 的 proactive 机制：请求前用「上次响应的真实 usage + 其后新增消息的估算」预测本次请求的上下文大小，超过阈值先压缩再发。
+
+**独立测试**：模拟一次巨大工具输出后，验证下一次请求发出前即触发压缩（而非等响应返回）；模拟 fork 路径（压缩、auto-memory 提取），验证不触发自动压缩；验证压缩完成后同一轮循环内不再重复触发。
+
+**验收场景**：
+
+1. **假设**存在上次 API 响应的 `usage`，**当**构造本次请求前执行上下文估算时，**则**估算值 = 上次响应的 `total_tokens` + 上次响应之后新增消息的字符估算（CJK 感知，与 `estimateTokens` 一致）
+2. **假设**估算的上下文 token 数超过 `getMaxInputTokens()`，**当**发送请求前检查时，**则**必须触发压缩，超限请求不得发出
+3. **假设**估算的上下文 token 数未超过阈值，**当**发送请求前检查时，**则**请求正常发出，不触发压缩
+4. **假设**agent 循环中一轮工具调用结束、下一轮请求将要发出，**当**发送请求前检查时，**则**每次请求前（包括工具调用后的后续轮次）都必须重新估算并检查
+5. **假设**当前请求是压缩 fork 或 auto-memory 提取等 fork 路径，**当**发送请求前检查时，**则**必须跳过自动压缩判断（fork 继承完整历史，触发压缩会造成递归死锁）
+6. **假设**压缩刚完成、同一轮 agent 循环继续，**当**发送请求前检查时，**则**不得基于压缩前的估算值再次触发压缩（压缩结果已保证在阈值内）
+7. **假设**上次响应后的新消息估算与真实 token 数存在偏差，**当**请求真实发出后返回 413 / context length 错误时，**则**走既有错误处理路径（`invalid_request` + 友好错误消息），不引入新的响应后主动压缩检查
+
+---
+
+### 用户故事：压缩触发仅使用 total_tokens（去除缓存 token 双重计数）（优先级：P1）
+
+作为 AI 代理，我希望自动压缩的判断只依据 `total_tokens`（已包含缓存命中 token），不再叠加 `cache_read_input_tokens` 和 `cache_creation_input_tokens`，以便上下文占用度量准确，压缩不会过早触发。
+
+**为什么是这个优先级**：wave 走 OpenAI 兼容接口（OpenAI SDK + 网关），该格式下 `prompt_tokens = 缓存命中 + 未命中`、`total_tokens = prompt_tokens + completion_tokens`，缓存命中已计入 `total_tokens`（DeepSeek 官方文档明确 `prompt_tokens` 等于 `prompt_cache_hit_tokens + prompt_cache_miss_tokens`）。原实现把 `prompt_tokens_details.cached_tokens` 规范化后与 `total_tokens` 相加，造成缓存命中双重计数——缓存命中通常占上下文绝大部分，导致压缩过早触发（实际上下文远未到 `maxInputTokens` 就压缩）。该加法源自 Anthropic 原生格式（其 `input_tokens` 不含缓存字段），与 wave 实际使用的 OpenAI 兼容格式错配。
+
+**独立测试**：构造含 `cache_read_input_tokens`（大值）和 `cache_creation_input_tokens` 的 usage，验证压缩判断仅使用 `total_tokens`，缓存字段不参与判断；验证 `latestTotalTokens` 展示语义（含缓存，供计费/成本展示）不受影响。
+
+**验收场景**：
+
+1. **假设**响应的 `usage` 包含 `total_tokens`、`cache_read_input_tokens`、`cache_creation_input_tokens`，**当**判断是否超过 `getMaxInputTokens()` 时，**则**只使用 `total_tokens`（OpenAI 兼容格式下已含缓存命中），缓存字段不得叠加
+2. **假设**响应仅含 `cache_read_input_tokens`（缓存命中极大）而 `total_tokens` 远低于阈值，**当**判断是否触发压缩时，**则**不得触发压缩
+3. **假设**`usage` 中 `total_tokens` 未超阈值但叠加缓存字段后超过，**当**判断是否触发压缩时，**则**不得触发压缩
+4. **假设**`latestTotalTokens` 仍按含缓存的综合值展示（供 CLI / webview 成本展示），**当**展示 token 使用量时，**则**展示语义保持不变，与压缩触发判断解耦
 
 ---
 
@@ -191,6 +228,8 @@ order: 70
 - **API 轮次边界**：压缩绝对不能将 tool_use/tool_result 对分割在压缩边界两侧
 - **fork 循环无文本输出**：达到最大轮次（3 轮）或 fork 请求抛异常（用户中止除外）即判定压缩失败，计入熔断器；压缩无 fallback 降级路径（快速模型稳定性不足，且 fork 失败多为上下文本身不可恢复）
 - **模型将工具调用语法作为文本输出**：不做内容级拦截，原样透传（与 Claude Code 一致的已知限制——Claude Code 依靠 agent loop 在协议层拒绝真实工具调用，对文本中的乱码双方均不拦截）
+- **无上次响应的 usage 锚点**：会话第一轮请求（或清空后）尚无真实 usage，请求前估算退化为纯字符估算（全部消息按 `estimateTokens` 计算），不得因缺失锚点而跳过检查
+- **请求前估算偏差**：估算可能低于真实 token 数，真实超限由 413 / context length 错误路径兜底；不引入响应后主动压缩检查
 
 ## 假设
 

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -7,7 +7,10 @@ import {
   parseTaskNotificationXml,
   taskNotificationToXml,
 } from "../utils/notificationXml.js";
-import { calculateComprehensiveTotalTokens } from "../utils/tokenCalculation.js";
+import {
+  calculateComprehensiveTotalTokens,
+  estimateContextTokens,
+} from "../utils/tokenCalculation.js";
 import { estimateTokens } from "../utils/tokenEstimate.js";
 import {
   getTaskReminderTurnCounts,
@@ -587,42 +590,51 @@ export class AIManager {
     return "";
   }
 
-  // Private method to handle token statistics and message compaction
-  private async handleTokenUsageAndCompaction(
-    usage: Usage | undefined,
-    abortController: AbortController,
-  ): Promise<void> {
+  // Private method to update the displayed token statistics from a response.
+  // The comprehensive value (including cache tokens) is intentionally kept:
+  // it drives cost/usage display. Auto-compaction is NOT decided here — it
+  // happens pre-request via maybeAutoCompactBeforeRequest so that over-limit
+  // requests never go out (aligned with Claude Code's proactive autocompact).
+  private updateLatestTotalTokens(usage: Usage | undefined): void {
     if (!usage) return;
 
     // Update token statistics - display comprehensive token usage including cache tokens
     const comprehensiveTotalTokens = calculateComprehensiveTotalTokens(usage);
     this.messageManager.setlatestTotalTokens(comprehensiveTotalTokens);
+  }
 
-    // Check if token limit exceeded - use injected configuration
-    if (
-      usage.total_tokens +
-        (usage.cache_read_input_tokens || 0) +
-        (usage.cache_creation_input_tokens || 0) >
-      this.getMaxInputTokens()
-    ) {
-      logger?.debug(
-        `Token usage exceeded ${this.getMaxInputTokens()}, compacting messages...`,
+  /**
+   * Pre-request auto-compaction check (aligned with Claude Code's
+   * autoCompactIfNeeded). Runs before every API request is issued: estimates
+   * the context that is about to be sent (last response's total_tokens plus
+   * character estimates for newer messages) and compacts first when it
+   * exceeds maxInputTokens, so over-limit requests are never sent. Only
+   * total_tokens is used — under OpenAI-compatible usage it already includes
+   * cache hits; adding cache fields would double-count and fire early.
+   * Fork paths (compaction / auto-memory) never reach here: they run in
+   * runForkLoop, not sendAIMessage.
+   */
+  private async maybeAutoCompactBeforeRequest(
+    abortController: AbortController,
+  ): Promise<void> {
+    // Circuit breaker: skip compaction after 3 consecutive failures
+    if (this.consecutiveCompactionFailures >= 3) {
+      logger?.warn(
+        `Skipping compaction: ${this.consecutiveCompactionFailures} consecutive failures`,
       );
+      return;
+    }
 
-      const messagesToCompact = this.messageManager.getMessages();
-      if (messagesToCompact.length === 0) return;
+    const messages = this.messageManager.getMessages();
+    if (messages.length === 0) return;
 
-      // Circuit breaker: skip compaction after 3 consecutive failures
-      if (this.consecutiveCompactionFailures >= 3) {
-        logger?.warn(
-          `Skipping compaction: ${this.consecutiveCompactionFailures} consecutive failures`,
-        );
-        return;
-      }
-
-      await this.compactConversation({
-        abortSignal: abortController.signal,
-      });
+    const maxTokens = this.getMaxInputTokens();
+    const estimatedTokens = estimateContextTokens(messages);
+    if (estimatedTokens > maxTokens) {
+      logger?.debug(
+        `Estimated context tokens ${estimatedTokens} exceeded ${maxTokens}, compacting before request...`,
+      );
+      await this.compactConversation({ abortSignal: abortController.signal });
     }
   }
 
@@ -1780,6 +1792,11 @@ ${question}`;
             });
           }
 
+          // Pre-request auto-compaction: estimate the context about to be sent
+          // and compact BEFORE issuing the request, so an over-limit request
+          // never goes out. Skipped on fork paths (they use runForkLoop).
+          await this.maybeAutoCompactBeforeRequest(abortController);
+
           // Get recent message history
           const rawMessages = this.messageManager.getMessages();
           const currentModelConfig = this.getModelConfig();
@@ -2053,11 +2070,9 @@ ${question}`;
             }
           }
 
-          // Handle token statistics and message compaction
-          await this.handleTokenUsageAndCompaction(
-            result.usage,
-            abortController,
-          );
+          // Update token statistics for display (compaction decision is
+          // pre-request, see maybeAutoCompactBeforeRequest)
+          this.updateLatestTotalTokens(result.usage);
 
           // Finalize text/reasoning blocks for the final response (no tools)
           this.messageManager.finalizeStreamingBlocks();

--- a/packages/agent-sdk/src/utils/tokenCalculation.ts
+++ b/packages/agent-sdk/src/utils/tokenCalculation.ts
@@ -1,4 +1,5 @@
-import type { Usage } from "../types/index.js";
+import type { Message, Usage } from "../types/index.js";
+import { estimateTokens } from "./tokenEstimate.js";
 
 /**
  * Calculate comprehensive total tokens including cache-related tokens
@@ -40,4 +41,71 @@ export function extractLatestTotalTokens(
   }
 
   return 0; // No usage data found
+}
+
+/**
+ * Estimate the full context size of a message list for pre-request
+ * auto-compaction checks (aligned with Claude Code's tokenCountWithEstimation).
+ *
+ * Anchors on the most recent message carrying real usage (the last API
+ * response): that response's total_tokens (OpenAI-compatible semantics —
+ * already includes cache hits) plus a rough character-based estimate for
+ * every message added after it. Falls back to a pure character estimate
+ * when no usage anchor exists yet (e.g. the first request of a session).
+ */
+export function estimateContextTokens(messages: Message[]): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const usage = messages[i].usage;
+    if (usage) {
+      return (
+        usage.total_tokens + roughTokenCountForMessages(messages.slice(i + 1))
+      );
+    }
+  }
+  return roughTokenCountForMessages(messages);
+}
+
+/**
+ * Rough per-message token estimate over all message blocks.
+ * Used to estimate the messages added since the last usage-bearing response.
+ * Image blocks are ignored (images are stripped before compaction) and file
+ * history snapshots live on disk, so their content is not in the context.
+ */
+export function roughTokenCountForMessages(messages: Message[]): number {
+  let total = 0;
+  for (const message of messages) {
+    for (const block of message.blocks) {
+      switch (block.type) {
+        case "text":
+        case "reasoning":
+        case "error":
+        case "compact":
+          total += estimateTokens(block.content);
+          break;
+        case "tool":
+          if (block.parameters) {
+            total += estimateTokens(block.parameters, "json");
+          }
+          if (block.result) {
+            total += estimateTokens(block.result);
+          }
+          break;
+        case "bang":
+          if (block.command) {
+            total += estimateTokens(block.command);
+          }
+          if (block.output) {
+            total += estimateTokens(block.output);
+          }
+          break;
+        case "task_notification":
+          total += estimateTokens(block.summary);
+          break;
+        case "image":
+        case "file_history":
+          break;
+      }
+    }
+  }
+  return total;
 }

--- a/packages/agent-sdk/tests/agent/agent.compaction.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.compaction.test.ts
@@ -37,7 +37,10 @@ describe("Agent Message Compaction Tests", () => {
   });
 
   // Helper function: generate specified number of message conversations
-  const generateMessages = (count: number): Message[] => {
+  // Pass usageTokens to attach a large total_tokens usage to the last
+  // assistant message — the pre-request estimate anchors on it and triggers
+  // compaction before the request is sent.
+  const generateMessages = (count: number, usageTokens?: number): Message[] => {
     const messages: Message[] = [];
     for (let i = 0; i < count; i++) {
       messages.push({
@@ -60,6 +63,15 @@ describe("Agent Message Compaction Tests", () => {
             content: `Assistant response ${i + 1}: I'll help you with task ${i + 1}`,
           },
         ],
+        ...(usageTokens !== undefined
+          ? {
+              usage: {
+                prompt_tokens: Math.floor(usageTokens * 0.8),
+                completion_tokens: Math.floor(usageTokens * 0.2),
+                total_tokens: usageTokens,
+              },
+            }
+          : {}),
         timestamp: new Date().toISOString(),
       });
     }
@@ -80,9 +92,10 @@ describe("Agent Message Compaction Tests", () => {
     );
   };
 
-  it("should trigger compaction when token usage exceeds 96k", async () => {
-    // Create message history with enough messages (generate 8 pairs of messages, total 16)
-    const messages = generateMessages(8);
+  it("should trigger compaction before the request when the estimated context exceeds the limit", async () => {
+    // Create message history whose last response usage exceeds the limit —
+    // the pre-request estimate anchors on it and compacts before sending.
+    const messages = generateMessages(8, DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000);
 
     // Add a new user message to trigger AI call
     const newUserMessage: Message = {
@@ -121,26 +134,27 @@ describe("Agent Message Compaction Tests", () => {
           },
         };
       }
-      // Main loop: return high token usage to trigger compaction
+      // Main loop: normal response (the compaction decision is pre-request)
       return {
         content: "I understand your request. Let me help you with that.",
         usage: {
-          prompt_tokens: 50000,
-          completion_tokens: 20000,
-          total_tokens: DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000, // Exceed default limit to trigger compaction
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
         },
       };
     });
 
-    // Call sendMessage to trigger AI call (this will trigger compaction)
+    // Call sendMessage to trigger AI call (this will trigger compaction
+    // before the request is issued)
     await agent.sendMessage("Test message");
 
-    // Verify AI service was called: main loop + compaction fork
+    // Verify AI service was called: compaction fork + main loop
     expect(mockCallAgent).toHaveBeenCalledTimes(2);
-    expect(isCompactForkCall(mockCallAgent.mock.calls[1][0])).toBe(true);
+    expect(isCompactForkCall(mockCallAgent.mock.calls[0][0])).toBe(true);
 
     // Verify fork call parameters when called
-    const forkCall = mockCallAgent.mock.calls[1];
+    const forkCall = mockCallAgent.mock.calls[0];
     expect(forkCall[0]).toHaveProperty("messages");
     expect(Array.isArray(forkCall[0].messages)).toBe(true);
     expect(forkCall[0].messages.length).toBeGreaterThan(0);
@@ -226,8 +240,8 @@ describe("Agent Message Compaction Tests", () => {
   });
 
   it("should handle compaction errors gracefully", async () => {
-    // Create message history with enough messages (generate 10 pairs of messages, total 20)
-    const messages = generateMessages(10);
+    // Create message history whose last response usage exceeds the limit
+    const messages = generateMessages(10, DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000);
 
     // Add a new user message to trigger AI call
     const newUserMessage: Message = {
@@ -260,25 +274,27 @@ describe("Agent Message Compaction Tests", () => {
       return {
         content: "Response",
         usage: {
-          prompt_tokens: 50000,
-          completion_tokens: 20000,
-          total_tokens: DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000, // Exceed default limit to trigger compaction
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
         },
       };
     });
 
-    // Call sendMessage to trigger compaction
+    // Call sendMessage to trigger compaction before the request
     await agent.sendMessage("Test message");
 
-    // Verify call details: main loop + failed fork attempt (no fallback)
+    // Verify call details: failed fork attempt + main loop (no fallback)
     expect(mockCallAgent).toHaveBeenCalledTimes(2);
 
-    // Verify that an error block was added to the messages
-    const lastMessage = agent.messages[agent.messages.length - 1];
-    expect(lastMessage.blocks.some((block) => block.type === "error")).toBe(
-      true,
+    // Verify that an error block was added to the messages (the failed fork
+    // runs before the main-loop request, so the error lands on the user
+    // message, not the final assistant response)
+    const errorMessage = agent.messages.find((msg) =>
+      msg.blocks.some((block) => block.type === "error"),
     );
-    const errorBlock = lastMessage.blocks.find(
+    expect(errorMessage).toBeDefined();
+    const errorBlock = errorMessage!.blocks.find(
       (block) => block.type === "error",
     ) as {
       type: "error";
@@ -301,8 +317,12 @@ describe("Agent Message Compaction Tests", () => {
   it("should compact all messages when session already contains compaction", async () => {
     // Test scenario: When session already contains compaction message, new compaction should compact all content including previous compaction point
 
-    // Create initial 15 pairs of messages (30 messages)
-    const initialMessages = generateMessages(15);
+    // Create initial 15 pairs of messages (30 messages) with an over-limit
+    // last response usage so the pre-request estimate triggers compaction
+    const initialMessages = generateMessages(
+      15,
+      DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000,
+    );
 
     // Insert a compaction message at position 9 (representing previous compaction)
     const messagesWithCompaction: Message[] = [
@@ -436,8 +456,8 @@ describe("Agent Message Compaction Tests", () => {
   });
 
   it("should send compacted message plus subsequent messages to callAgent", async () => {
-    // Create 10 pairs of messages (20 messages) to trigger compaction
-    const messages = generateMessages(10);
+    // Create 10 pairs of messages (20 messages) with over-limit last usage
+    const messages = generateMessages(10, DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000);
 
     // Add the first user message to trigger compaction
     const firstUserMessage: Message = {
@@ -481,27 +501,15 @@ describe("Agent Message Compaction Tests", () => {
         };
       }
 
-      if (callAgentCallCount === 1) {
-        // First call returns high token usage to trigger compaction
-        return {
-          content: "I understand. Let me help you with that task.",
-          usage: {
-            prompt_tokens: 50000,
-            completion_tokens: 20000,
-            total_tokens: DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000, // Exceeds default limit to trigger compaction
-          },
-        };
-      } else {
-        // Subsequent main-loop calls return normal responses
-        return {
-          content: "Here's my response to your second message.",
-          usage: {
-            prompt_tokens: 1000,
-            completion_tokens: 500,
-            total_tokens: 1500,
-          },
-        };
-      }
+      // Main loop: normal response (compaction decision is pre-request)
+      return {
+        content: "Here's my response.",
+        usage: {
+          prompt_tokens: 1000,
+          completion_tokens: 500,
+          total_tokens: 1500,
+        },
+      };
     });
 
     // First call to sendMessage triggers compaction
@@ -562,8 +570,8 @@ describe("Agent Message Compaction Tests", () => {
   });
 
   it("should save session before compaction to preserve original messages", async () => {
-    // Create message history with enough messages to trigger compaction
-    const messages = generateMessages(8);
+    // Create message history whose last response usage exceeds the limit
+    const messages = generateMessages(8, DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000);
 
     // Add a new user message to trigger AI call
     const newUserMessage: Message = {
@@ -593,19 +601,31 @@ describe("Agent Message Compaction Tests", () => {
     // Mock AI service
     const mockCallAgent = vi.mocked(aiService.callAgent);
 
-    mockCallAgent.mockImplementation(async () => {
-      // Return high token usage to trigger compaction
+    mockCallAgent.mockImplementation(async (params) => {
+      if (isCompactForkCall(params)) {
+        // Compaction fork: return the summary text
+        return {
+          content: "Compacted summary",
+          usage: {
+            prompt_tokens: 100,
+            completion_tokens: 50,
+            total_tokens: 150,
+          },
+        };
+      }
+      // Main loop: normal response
       return {
         content: "I understand your request. Let me help you with that.",
         usage: {
-          prompt_tokens: 50000,
-          completion_tokens: 20000,
-          total_tokens: DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000, // Exceed default limit to trigger compaction
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
         },
       };
     });
 
-    // Call sendMessage to trigger AI call (this will trigger compaction)
+    // Call sendMessage to trigger AI call (this will trigger compaction
+    // before the request is issued)
     await agent.sendMessage("Test message");
 
     // Verify saveSession was called at least 3rd:
@@ -614,20 +634,20 @@ describe("Agent Message Compaction Tests", () => {
     // 2. At the end of sendAIMessage (normal session save)
     expect(saveSessionSpy).toHaveBeenCalledTimes(3);
 
-    // Verify the order: the pre-compaction saveSession should happen after
-    // the main-loop callAgent call and before the compaction fork call
+    // Verify the order: the pre-compaction saveSession should happen before
+    // the compaction fork call (compaction runs pre-request, so the fork is
+    // the first callAgent call)
     const saveSessionCalls = saveSessionSpy.mock.invocationCallOrder;
     const callAgentCalls = mockCallAgent.mock.invocationCallOrder;
 
     expect(mockCallAgent).toHaveBeenCalledTimes(2);
-    expect(isCompactForkCall(mockCallAgent.mock.calls[1][0])).toBe(true);
-    expect(saveSessionCalls[1]).toBeGreaterThan(callAgentCalls[0]);
-    expect(saveSessionCalls[1]).toBeLessThan(callAgentCalls[1]);
+    expect(isCompactForkCall(mockCallAgent.mock.calls[0][0])).toBe(true);
+    expect(saveSessionCalls[1]).toBeLessThan(callAgentCalls[0]);
   });
 
   it("should skip compaction after 3 consecutive failures (circuit breaker)", async () => {
-    // Create message history with enough messages to trigger compaction
-    const messages = generateMessages(8);
+    // Create message history whose last response usage exceeds the limit
+    const messages = generateMessages(8, DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000);
 
     // Add a new user message to trigger AI call
     const newUserMessage: Message = {
@@ -649,8 +669,10 @@ describe("Agent Message Compaction Tests", () => {
 
     const mockCallAgent = vi.mocked(aiService.callAgent);
 
-    // The main loop always returns high token usage to trigger compaction;
-    // the fork always fails, driving consecutiveCompactionFailures upward.
+    // The over-limit history triggers compaction before each request; the
+    // fork always fails, driving consecutiveCompactionFailures upward. The
+    // main loop also returns over-limit usage so it becomes the new
+    // estimate anchor and keeps triggering on subsequent messages.
     mockCallAgent.mockImplementation(async (params) => {
       if (isCompactForkCall(params)) {
         throw new Error("Fork failed");
@@ -685,7 +707,7 @@ describe("Agent Message Compaction Tests", () => {
   });
 
   it("should reset circuit breaker counter on successful compaction", async () => {
-    const messages = generateMessages(8);
+    const messages = generateMessages(8, DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000);
     const newUserMessage: Message = {
       id: generateMessageId(),
       role: "user",
@@ -803,7 +825,10 @@ describe("Agent Message Compaction Tests", () => {
 
   describe("Background Tasks in Compact Context", () => {
     it("should render killed status with description and id", async () => {
-      const messages = generateMessages(8);
+      const messages = generateMessages(
+        8,
+        DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000,
+      );
       const newUserMessage: Message = {
         id: generateMessageId(),
         role: "user",
@@ -838,7 +863,10 @@ describe("Agent Message Compaction Tests", () => {
     });
 
     it("should render running status with duplicate warning", async () => {
-      const messages = generateMessages(8);
+      const messages = generateMessages(
+        8,
+        DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000,
+      );
       const newUserMessage: Message = {
         id: generateMessageId(),
         role: "user",
@@ -877,7 +905,10 @@ describe("Agent Message Compaction Tests", () => {
     });
 
     it("should include outputPath for running tasks", async () => {
-      const messages = generateMessages(8);
+      const messages = generateMessages(
+        8,
+        DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000,
+      );
       const newUserMessage: Message = {
         id: generateMessageId(),
         role: "user",
@@ -912,7 +943,10 @@ describe("Agent Message Compaction Tests", () => {
     });
 
     it("should render completed status with stdout delta", async () => {
-      const messages = generateMessages(8);
+      const messages = generateMessages(
+        8,
+        DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000,
+      );
       const newUserMessage: Message = {
         id: generateMessageId(),
         role: "user",
@@ -948,7 +982,10 @@ describe("Agent Message Compaction Tests", () => {
     });
 
     it("should render failed status with stderr delta", async () => {
-      const messages = generateMessages(8);
+      const messages = generateMessages(
+        8,
+        DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000,
+      );
       const newUserMessage: Message = {
         id: generateMessageId(),
         role: "user",
@@ -986,7 +1023,10 @@ describe("Agent Message Compaction Tests", () => {
     });
 
     it("should truncate delta text to 500 characters", async () => {
-      const messages = generateMessages(8);
+      const messages = generateMessages(
+        8,
+        DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000,
+      );
       const newUserMessage: Message = {
         id: generateMessageId(),
         role: "user",
@@ -1029,7 +1069,10 @@ describe("Agent Message Compaction Tests", () => {
     });
 
     it("should include outputPath for completed and failed tasks", async () => {
-      const messages = generateMessages(8);
+      const messages = generateMessages(
+        8,
+        DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000,
+      );
       const newUserMessage: Message = {
         id: generateMessageId(),
         role: "user",
@@ -1077,7 +1120,10 @@ describe("Agent Message Compaction Tests", () => {
     });
 
     it("should render multiple agents with mixed statuses", async () => {
-      const messages = generateMessages(8);
+      const messages = generateMessages(
+        8,
+        DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000,
+      );
       const newUserMessage: Message = {
         id: generateMessageId(),
         role: "user",
@@ -1136,7 +1182,10 @@ describe("Agent Message Compaction Tests", () => {
     });
 
     it("should exclude shell tasks from background tasks section", async () => {
-      const messages = generateMessages(8);
+      const messages = generateMessages(
+        8,
+        DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000,
+      );
       const newUserMessage: Message = {
         id: generateMessageId(),
         role: "user",
@@ -1189,7 +1238,10 @@ describe("Agent Message Compaction Tests", () => {
     });
 
     it("should not include background tasks section when no agents exist", async () => {
-      const messages = generateMessages(8);
+      const messages = generateMessages(
+        8,
+        DEFAULT_WAVE_MAX_INPUT_TOKENS + 6000,
+      );
       const newUserMessage: Message = {
         id: generateMessageId(),
         role: "user",

--- a/packages/agent-sdk/tests/agent/agent.usages.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.usages.test.ts
@@ -3,7 +3,6 @@ import { Agent } from "@/agent.js";
 import * as aiService from "@/services/aiService.js";
 import { createMockToolManager } from "../helpers/mockFactories.js";
 import type { Usage } from "@/types/index.js";
-import { DEFAULT_WAVE_MAX_INPUT_TOKENS } from "@/utils/constants.js";
 import { generateMessageId } from "@/utils/messageOperations.js";
 
 // Mock AI Service
@@ -301,6 +300,10 @@ describe("Agent Usage Tracking", () => {
     it("should track compaction usage when it occurs", async () => {
       const mockCallAgent = vi.mocked(aiService.callAgent);
 
+      // Lower the input token limit so the short message history exceeds it
+      // and the pre-request estimate triggers compaction
+      process.env.WAVE_MAX_INPUT_TOKENS = "30";
+
       // Set up an agent instance with initial messages to have enough content for compaction
       const initialMessages = [
         {
@@ -374,22 +377,25 @@ describe("Agent Usage Tracking", () => {
 
       vi.clearAllMocks();
 
-      // Mock high token usage to trigger compaction
+      // Both the compaction fork and the main loop reuse callAgent; the
+      // fork result content is used as the summary.
       mockCallAgent.mockResolvedValue({
         content: "Response that triggers compaction",
         usage: {
-          prompt_tokens: DEFAULT_WAVE_MAX_INPUT_TOKENS - 20000,
-          completion_tokens: 30000,
-          total_tokens: DEFAULT_WAVE_MAX_INPUT_TOKENS + 10000, // Exceeds default token limit
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
         },
       });
 
       await agent.sendMessage("Message that triggers compaction");
 
-      // Should track both agent and compaction usage
+      // Should track both compaction and agent usage — the fork runs before
+      // the main-loop request (pre-request compaction), so it is recorded
+      // first
       expect(agent.usages).toHaveLength(2);
-      expect(agent.usages[0].operation_type).toBe("agent");
-      expect(agent.usages[1].operation_type).toBe("compact");
+      expect(agent.usages[0].operation_type).toBe("compact");
+      expect(agent.usages[1].operation_type).toBe("agent");
     });
   });
 });

--- a/packages/agent-sdk/tests/managers/aiManager.autoCompactBeforeRequest.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.autoCompactBeforeRequest.test.ts
@@ -1,0 +1,420 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Container } from "../../src/utils/container.js";
+import { TaskManager } from "../../src/services/taskManager.js";
+import { AIManager } from "../../src/managers/aiManager.js";
+import type { MessageManager } from "../../src/managers/messageManager.js";
+import type { ToolManager } from "../../src/managers/toolManager.js";
+import type { GatewayConfig, ModelConfig } from "../../src/types/index.js";
+import * as aiService from "../../src/services/aiService.js";
+
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../../src/services/aiService.js", () => ({
+  callAgent: vi.fn().mockImplementation(async () => ({
+    content: "ok",
+    usage: { prompt_tokens: 10, completion_tokens: 10, total_tokens: 20 },
+    tool_calls: [],
+    finish_reason: "stop",
+  })),
+  compactMessages: vi.fn().mockResolvedValue({
+    content: "Compacted",
+    usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+  }),
+  transformMessagesForExplicitCache: vi.fn((m) => m),
+  extendUsageWithCacheMetrics: vi.fn((u) => u),
+}));
+
+vi.mock("../../src/services/memory.js", () => ({
+  MemoryService: vi.fn().mockImplementation(() => ({
+    getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+    getAutoMemoryDirectory: vi.fn().mockReturnValue("/mock/auto-memory"),
+    ensureAutoMemoryDirectory: vi.fn().mockResolvedValue(undefined),
+    getAutoMemoryContent: vi.fn().mockResolvedValue(""),
+  })),
+}));
+
+vi.mock("../../src/utils/convertMessagesForAPI.js", () => ({
+  convertMessagesForAPI: vi.fn().mockReturnValue([]),
+}));
+
+const mockGatewayConfig: GatewayConfig = {
+  apiKey: "test-key",
+  baseURL: "https://test.com",
+};
+const mockModelConfig: ModelConfig = {
+  model: "test-model",
+  fastModel: "test-fast",
+};
+
+function mockMsgManager(overrides = {}) {
+  return {
+    getSessionId: vi.fn().mockReturnValue("test-session"),
+    getMessages: vi.fn().mockReturnValue([]),
+    addAssistantMessage: vi.fn(),
+    addUserMessage: vi.fn(),
+    updateCurrentMessageContent: vi.fn(),
+    updateToolBlock: vi.fn(),
+    mergeAssistantAdditionalFields: vi.fn(),
+    setMessages: vi.fn(),
+    getLatestTotalTokens: vi.fn().mockReturnValue(0),
+    getCombinedMemory: vi.fn().mockResolvedValue(""),
+    getMemoryForInjection: vi.fn().mockResolvedValue({ prependContent: "" }),
+    processTriggeredRules: vi.fn().mockReturnValue([]),
+    addErrorBlock: vi.fn(),
+    setlatestTotalTokens: vi.fn(),
+    saveSession: vi.fn().mockResolvedValue(undefined),
+    compactMessagesAndUpdateSession: vi.fn(),
+    getTranscriptPath: vi.fn().mockReturnValue("/test/transcript.md"),
+    triggerFileRead: vi.fn(),
+    finalizeStreamingBlocks: vi.fn(),
+    finalizeAbortedToolBlocks: vi.fn(),
+    addFileHistoryBlock: vi.fn(),
+    updateCurrentMessageReasoning: vi.fn(),
+    ...overrides,
+  } as unknown as MessageManager;
+}
+
+function makeContainer(
+  overrides: Record<string, unknown> = {},
+  maxInputTokens = 96000,
+) {
+  const c = new Container();
+  c.register("ConfigurationService", {
+    resolveGatewayConfig: vi.fn().mockReturnValue(mockGatewayConfig),
+    resolveModelConfig: vi.fn().mockReturnValue(mockModelConfig),
+    resolveMaxInputTokens: vi.fn().mockReturnValue(maxInputTokens),
+    resolveAutoMemoryEnabled: vi.fn().mockReturnValue(true),
+    resolveLanguage: vi.fn().mockReturnValue(undefined),
+    getEnvironmentVars: vi.fn().mockReturnValue({}),
+  });
+  c.register("MessageManager", mockMsgManager());
+  c.register("ToolManager", {
+    getToolsConfig: vi.fn().mockReturnValue([]),
+    getTools: vi.fn().mockReturnValue([]),
+    list: vi.fn().mockReturnValue([]),
+    isConcurrencySafe: vi.fn().mockReturnValue(true),
+    execute: vi.fn().mockResolvedValue({ success: true, content: "result" }),
+  } as unknown as ToolManager);
+  c.register("TaskManager", {
+    on: vi.fn(),
+    listTasks: vi.fn().mockResolvedValue([]),
+  } as unknown as TaskManager);
+  c.register("MemoryService", {
+    getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+    getAutoMemoryDirectory: vi.fn().mockReturnValue("/mock/auto-memory"),
+    ensureAutoMemoryDirectory: vi.fn().mockResolvedValue(undefined),
+    getAutoMemoryContent: vi.fn().mockResolvedValue(""),
+  });
+  c.register("PermissionManager", {
+    getCurrentEffectiveMode: vi.fn().mockReturnValue("normal"),
+    clearTemporaryRules: vi.fn(),
+    getPlanFilePath: vi.fn().mockReturnValue(undefined),
+    getAllowedRules: vi.fn().mockReturnValue([]),
+    getDeniedRules: vi.fn().mockReturnValue([]),
+    getAdditionalDirectories: vi.fn().mockReturnValue([]),
+    getSystemAdditionalDirectories: vi.fn().mockReturnValue([]),
+    setHasExitedPlanMode: vi.fn(),
+    hasExitedPlanModeInSession: vi.fn(() => false),
+    setNeedsPlanModeExitAttachment: vi.fn(),
+    getNeedsPlanModeExitAttachment: vi.fn(() => false),
+  });
+  c.register("SubagentManager", {
+    getConfigurations: vi.fn().mockReturnValue([]),
+  });
+  c.register("SkillManager", {
+    getAvailableSkills: vi.fn().mockReturnValue([]),
+  });
+  c.register("MessageQueue", {
+    hasNotifications: vi.fn().mockReturnValue(false),
+    drainNotifications: vi.fn().mockReturnValue([]),
+  });
+  c.register("ReversionManager", null);
+  c.register("HookManager", null);
+  Object.entries(overrides).forEach(([k, v]) => c.register(k, v));
+  return c;
+}
+
+describe("AIManager - pre-request auto compaction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should compact BEFORE the request when the estimated context exceeds maxInputTokens", async () => {
+    // Anchor usage total = 1500, plus a large tool result message after it.
+    const messages = [
+      {
+        role: "user",
+        blocks: [{ type: "text", content: "hello" }],
+      },
+      {
+        role: "assistant",
+        blocks: [{ type: "text", content: "hi" }],
+        usage: {
+          prompt_tokens: 1000,
+          completion_tokens: 500,
+          total_tokens: 1500,
+        },
+      },
+      {
+        role: "user",
+        blocks: [
+          {
+            type: "tool",
+            name: "Read",
+            stage: "end",
+            result: "x".repeat(10000),
+          },
+        ],
+      },
+    ];
+    const aiManager = new AIManager(
+      makeContainer(
+        {
+          MessageManager: mockMsgManager({
+            getMessages: vi.fn().mockReturnValue(messages),
+          }),
+        },
+        2000, // maxInputTokens: 1500 anchor + ~2500 estimated tool result > 2000
+      ),
+      { workdir: "/test", stream: false },
+    );
+    const compactSpy = vi
+      .spyOn(aiManager, "compactConversation")
+      .mockResolvedValue(undefined);
+
+    await aiManager.sendAIMessage();
+
+    expect(compactSpy).toHaveBeenCalledTimes(1);
+    // Compaction decision happens pre-request: it must fire before callAgent.
+    expect(compactSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      (aiService.callAgent as ReturnType<typeof vi.fn>).mock
+        .invocationCallOrder[0],
+    );
+  });
+
+  it("should NOT compact when the estimated context is under maxInputTokens", async () => {
+    const messages = [
+      {
+        role: "user",
+        blocks: [{ type: "text", content: "hello" }],
+      },
+      {
+        role: "assistant",
+        blocks: [{ type: "text", content: "hi" }],
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
+        },
+      },
+    ];
+    const aiManager = new AIManager(
+      makeContainer(
+        {
+          MessageManager: mockMsgManager({
+            getMessages: vi.fn().mockReturnValue(messages),
+          }),
+        },
+        2000,
+      ),
+      { workdir: "/test", stream: false },
+    );
+    const compactSpy = vi
+      .spyOn(aiManager, "compactConversation")
+      .mockResolvedValue(undefined);
+
+    await aiManager.sendAIMessage();
+
+    expect(compactSpy).not.toHaveBeenCalled();
+  });
+
+  it("should ignore cache fields — large cache_read with small total_tokens must NOT trigger", async () => {
+    // Under the old formula (total + cache_read) this would fire (150 + 100000
+    // > 2000). With total_tokens-only semantics it must not.
+    const messages = [
+      {
+        role: "user",
+        blocks: [{ type: "text", content: "hello" }],
+      },
+      {
+        role: "assistant",
+        blocks: [{ type: "text", content: "hi" }],
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
+          cache_read_input_tokens: 100000,
+          cache_creation_input_tokens: 100000,
+        },
+      },
+    ];
+    const aiManager = new AIManager(
+      makeContainer(
+        {
+          MessageManager: mockMsgManager({
+            getMessages: vi.fn().mockReturnValue(messages),
+          }),
+        },
+        2000,
+      ),
+      { workdir: "/test", stream: false },
+    );
+    const compactSpy = vi
+      .spyOn(aiManager, "compactConversation")
+      .mockResolvedValue(undefined);
+
+    await aiManager.sendAIMessage();
+
+    expect(compactSpy).not.toHaveBeenCalled();
+  });
+
+  it("should compact on the first request (no usage anchor) when the pure character estimate exceeds the limit", async () => {
+    // No usage on any message: estimateContextTokens falls back to a pure
+    // character estimate of all messages (~500 tokens for 2000 chars).
+    const messages = [
+      {
+        role: "user",
+        blocks: [{ type: "text", content: "a".repeat(2000) }],
+      },
+    ];
+    const aiManager = new AIManager(
+      makeContainer(
+        {
+          MessageManager: mockMsgManager({
+            getMessages: vi.fn().mockReturnValue(messages),
+          }),
+        },
+        300,
+      ),
+      { workdir: "/test", stream: false },
+    );
+    const compactSpy = vi
+      .spyOn(aiManager, "compactConversation")
+      .mockResolvedValue(undefined);
+
+    await aiManager.sendAIMessage();
+
+    expect(compactSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should skip compaction when the circuit breaker has 3 consecutive failures", async () => {
+    const messages = [
+      {
+        role: "user",
+        blocks: [{ type: "text", content: "hello" }],
+      },
+      {
+        role: "assistant",
+        blocks: [{ type: "text", content: "hi" }],
+        usage: {
+          prompt_tokens: 1000,
+          completion_tokens: 500,
+          total_tokens: 1500,
+        },
+      },
+    ];
+    const aiManager = new AIManager(
+      makeContainer(
+        {
+          MessageManager: mockMsgManager({
+            getMessages: vi.fn().mockReturnValue(messages),
+          }),
+        },
+        1000,
+      ),
+      { workdir: "/test", stream: false },
+    );
+    const compactSpy = vi
+      .spyOn(aiManager, "compactConversation")
+      .mockResolvedValue(undefined);
+    (
+      aiManager as unknown as { consecutiveCompactionFailures: number }
+    ).consecutiveCompactionFailures = 3;
+
+    await aiManager.sendAIMessage();
+
+    expect(compactSpy).not.toHaveBeenCalled();
+  });
+
+  it("should re-check before every request in the loop (tool calls grow the context)", async () => {
+    // Before the tool executes: small context (no compaction). After the tool
+    // result lands: large context — the next request must compact first.
+    const smallMessages = [
+      {
+        role: "assistant",
+        blocks: [{ type: "text", content: "hi" }],
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
+        },
+      },
+    ];
+    const largeMessages = [
+      ...smallMessages,
+      {
+        role: "user",
+        blocks: [
+          {
+            type: "tool",
+            name: "Read",
+            stage: "end",
+            result: "x".repeat(20000),
+          },
+        ],
+      },
+    ];
+    let hasToolResult = false;
+    const getMessages = vi
+      .fn()
+      .mockImplementation(() =>
+        hasToolResult ? largeMessages : smallMessages,
+      );
+    const mm = mockMsgManager({ getMessages });
+    const aiManager = new AIManager(
+      makeContainer(
+        {
+          MessageManager: mm,
+          ToolManager: {
+            getToolsConfig: vi.fn().mockReturnValue([]),
+            getTools: vi.fn().mockReturnValue([]),
+            list: vi.fn().mockReturnValue([]),
+            isConcurrencySafe: vi.fn().mockReturnValue(true),
+            // Flipping the flag here simulates the tool result being added to
+            // the conversation history by executeToolCall.
+            execute: vi.fn().mockImplementation(async () => {
+              hasToolResult = true;
+              return { success: true, content: "result" };
+            }),
+          },
+        },
+        300,
+      ),
+      { workdir: "/test", stream: false },
+    );
+    const compactSpy = vi
+      .spyOn(aiManager, "compactConversation")
+      .mockResolvedValue(undefined);
+    // First response makes a tool call so the loop iterates again.
+    (aiService.callAgent as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      content: "",
+      usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+      tool_calls: [
+        {
+          id: "t1",
+          type: "function" as const,
+          function: { name: "Read", arguments: "{}" },
+        },
+      ],
+      finish_reason: "tool_calls",
+    });
+
+    await aiManager.sendAIMessage();
+
+    // Tool call round: no compaction; second round (after tool result): compacts.
+    expect(compactSpy).toHaveBeenCalledTimes(1);
+    expect(aiService.callAgent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/agent-sdk/tests/utils/tokenCalculation.test.ts
+++ b/packages/agent-sdk/tests/utils/tokenCalculation.test.ts
@@ -2,8 +2,24 @@ import { describe, it, expect } from "vitest";
 import {
   calculateComprehensiveTotalTokens,
   extractLatestTotalTokens,
+  estimateContextTokens,
+  roughTokenCountForMessages,
 } from "@/utils/tokenCalculation.js";
-import type { Usage } from "@/types/index.js";
+import type { Message, Usage } from "@/types/index.js";
+
+function makeMessage(overrides: Partial<Message>): Message {
+  return {
+    id: "m1",
+    role: "user",
+    blocks: [],
+    timestamp: "2026-08-19T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+// 4 non-CJK chars ≈ 1 token; 2 chars/token for json
+const TEXT_TOKENS = 100;
+const text400 = "a".repeat(400);
 
 describe("calculateComprehensiveTotalTokens", () => {
   it("should calculate basic total tokens without cache tokens", () => {
@@ -355,5 +371,154 @@ describe("extractLatestTotalTokens", () => {
     // Should use laterUsage (30 + 5 = 35), not earlyUsage (75 + 100 = 175)
     const result = extractLatestTotalTokens(messages);
     expect(result).toBe(35);
+  });
+});
+
+describe("roughTokenCountForMessages", () => {
+  it("should return 0 for messages without blocks", () => {
+    expect(roughTokenCountForMessages([makeMessage({})])).toBe(0);
+    expect(roughTokenCountForMessages([])).toBe(0);
+  });
+
+  it("should count text, reasoning, error and compact block content", () => {
+    const messages = [
+      makeMessage({
+        blocks: [
+          { type: "text", content: text400 },
+          { type: "reasoning", content: text400 },
+          { type: "error", content: text400 },
+          { type: "compact", content: text400 },
+        ],
+      }),
+    ];
+    expect(roughTokenCountForMessages(messages)).toBe(TEXT_TOKENS * 4);
+  });
+
+  it("should count tool parameters (json ratio) and result", () => {
+    const messages = [
+      makeMessage({
+        blocks: [
+          {
+            type: "tool",
+            name: "Read",
+            stage: "end",
+            parameters: "b".repeat(400), // json: 400/2 = 200
+            result: "c".repeat(400), // 400/4 = 100
+          },
+        ],
+      }),
+    ];
+    expect(roughTokenCountForMessages(messages)).toBe(300);
+  });
+
+  it("should count bang command and output", () => {
+    const messages = [
+      makeMessage({
+        role: "assistant",
+        blocks: [
+          {
+            type: "bang",
+            command: "d".repeat(400),
+            output: "e".repeat(400),
+            stage: "end",
+            exitCode: 0,
+          },
+        ],
+      }),
+    ];
+    expect(roughTokenCountForMessages(messages)).toBe(TEXT_TOKENS * 2);
+  });
+
+  it("should count task_notification summary", () => {
+    const messages = [
+      makeMessage({
+        blocks: [
+          {
+            type: "task_notification",
+            taskId: "t1",
+            taskType: "shell",
+            status: "completed",
+            summary: "f".repeat(400),
+          },
+        ],
+      }),
+    ];
+    expect(roughTokenCountForMessages(messages)).toBe(TEXT_TOKENS);
+  });
+
+  it("should ignore image and file_history blocks", () => {
+    const messages = [
+      makeMessage({
+        blocks: [
+          { type: "image", imageUrls: ["http://example.com/x.png"] },
+          { type: "file_history", snapshots: [] },
+          { type: "text", content: text400 },
+        ],
+      }),
+    ];
+    expect(roughTokenCountForMessages(messages)).toBe(TEXT_TOKENS);
+  });
+});
+
+describe("estimateContextTokens", () => {
+  it("should fall back to pure character estimate when no usage anchor exists", () => {
+    const messages = [
+      makeMessage({ blocks: [{ type: "text", content: text400 }] }),
+    ];
+    expect(estimateContextTokens(messages)).toBe(TEXT_TOKENS);
+  });
+
+  it("should anchor on latest usage total_tokens plus messages after it", () => {
+    const anchorUsage: Usage = {
+      prompt_tokens: 400,
+      completion_tokens: 100,
+      total_tokens: 500,
+      cache_read_input_tokens: 3000, // must NOT be added (OpenAI semantics)
+    };
+    const messages = [
+      // Before the anchor — ignored
+      makeMessage({ blocks: [{ type: "text", content: text400 }] }),
+      // The usage anchor itself — contributes total_tokens only
+      makeMessage({
+        role: "assistant",
+        usage: anchorUsage,
+        blocks: [{ type: "text", content: text400 }],
+      }),
+      // After the anchor — rough estimate
+      makeMessage({ blocks: [{ type: "text", content: text400 }] }),
+      makeMessage({
+        blocks: [
+          { type: "tool", name: "Bash", stage: "end", result: "c".repeat(400) },
+        ],
+      }),
+    ];
+    // 500 (total_tokens) + 100 (post-anchor text) + 100 (tool result)
+    expect(estimateContextTokens(messages)).toBe(700);
+  });
+
+  it("should use the most recent usage anchor only", () => {
+    const messages = [
+      makeMessage({
+        role: "assistant",
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
+        },
+        blocks: [],
+      }),
+      makeMessage({ blocks: [{ type: "text", content: text400 }] }),
+      makeMessage({
+        role: "assistant",
+        usage: {
+          prompt_tokens: 200,
+          completion_tokens: 100,
+          total_tokens: 300,
+        },
+        blocks: [],
+      }),
+      makeMessage({ blocks: [{ type: "text", content: text400 }] }),
+    ];
+    expect(estimateContextTokens(messages)).toBe(300 + TEXT_TOKENS);
   });
 });


### PR DESCRIPTION
Trigger auto-compaction before issuing the request by estimating the
context size (last response's total_tokens + rough character estimate
for messages after it), aligned with Claude Code's
tokenCountWithEstimation. Removes the post-response usage check that
let over-limit requests go out, and drops cache token double-counting:
OpenAI-compatible total_tokens already includes cache hits, so
cache_read/cache_creation are no longer added to the threshold.

- aiManager: maybeAutoCompactBeforeRequest before each request in the
  loop; handleTokenUsageAndCompaction reduced to display-only
- tokenCalculation: add estimateContextTokens / roughTokenCountForMessages
- message-compact spec updated (pre-request trigger + total_tokens only)
- tests: aiManager.autoCompactBeforeRequest (6), tokenCalculation (13),
  compaction/usages suites rewritten for the new trigger semantics
