### PR TITLE
fix(desktop): 修复自动更新缺失 app-update.yml 导致降级下载页

### DIFF
--- a/docs/specs/ui/desktop-app.md
+++ b/docs/specs/ui/desktop-app.md
@@ -294,6 +294,7 @@ desktop 还支持**并排多对话**：`Cmd/Ctrl+Click` 或拖拽侧边栏中的
 6. **假设**用户打开状态对话框点击「检查更新」，**当**手动检查触发，**则**必须复用自动更新链路：已登录走 electron-updater（无更新时 toast 提示「当前已是最新版本」，有更新按场景 3-4 下载安装），未登录回退 GitHub 提示。
 7. **假设**已登录企业版且 codechat 端点返回更新信息，**当**updateChecker 构造下载地址，**则** downloadUrl 必须指向真实下载入口（安装包 / 下载页），不得指向 manifest.json 自身（修复 updateChecker.ts:99）。
 8. **假设**macOS 上应用运行于不可写位置（如非 /Applications），**当**更新下载完成但无法原地安装，**则**必须通过应用内 toast 提示用户手动下载安装（带「打开下载页」按钮）并给出下载 URL，不得静默失败。
+9. **假设**构建安装包（mac/win），**当**electron-builder 打包完成，**则**产物 `resources/app-update.yml` 必须存在（afterPack 写入 `updaterCacheDirName`）——electron-updater 下载前会读取该文件（`configOnDisk`），缺失时下载阶段抛 ENOENT 并降级为下载页提示（修复：构建未声明 publish 配置时 electron-builder 不生成该文件）。
 
 ---
 

--- a/packages/desktop/scripts/afterPack.js
+++ b/packages/desktop/scripts/afterPack.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
- * electron-builder afterPack hook — re-seal the macOS bundle for ad-hoc
- * (development) installs.
+ * electron-builder afterPack hook — write the electron-updater config that
+ * electron-builder skips (no publish config) and re-seal the macOS bundle for
+ * ad-hoc (development) installs.
  *
  * Two signing modes coexist:
  * - Developer ID (release): electron-builder signs every file individually
@@ -17,9 +18,33 @@
  * them) — both must carry a signature consistent with the bundle.
  */
 import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import path from "node:path";
 
 export default async function afterPack(context) {
-  if (context.electronPlatformName !== "darwin") return;
+  const { electronPlatformName, appOutDir, packager } = context;
+
+  // electron-builder only writes resources/app-update.yml when a publish
+  // config is declared (or the repo resolves to GitHub). Without it
+  // electron-updater's download step throws ENOENT and the app degrades to
+  // the manual "download page" toast. The feed URL is injected at runtime
+  // via setFeedURL, so this file only needs to exist; updaterCacheDirName
+  // is what electron-updater reads from it.
+  const resourcesDir =
+    electronPlatformName === "darwin"
+      ? path.join(
+          appOutDir,
+          `${packager.appInfo.productFilename}.app`,
+          "Contents",
+          "Resources",
+        )
+      : path.join(appOutDir, "resources");
+  writeFileSync(
+    path.join(resourcesDir, "app-update.yml"),
+    "updaterCacheDirName: wave-desktop-updater\n",
+  );
+
+  if (electronPlatformName !== "darwin") return;
   const identity = context.packager.config?.mac?.identity;
   // Developer ID mode signs everything itself — an ad-hoc pass would be
   // redundant (and would be overwritten anyway).

--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -4117,7 +4117,8 @@ export class DesktopHost {
             }),
           onUpdateDownloaded: (info) =>
             void this.handleUpdateDownloaded(info.version),
-          onError: () => void this.handleAutoUpdaterError(serverUrl),
+          onError: (error) =>
+            void this.handleAutoUpdaterError(serverUrl, error),
         });
       }
       const outcome = await this.autoUpdaterService.checkForUpdates(serverUrl);
@@ -4158,10 +4159,28 @@ export class DesktopHost {
 
   /** The background download (or a later check) errored — degrade to the
    *  manual checker so the user still learns about the update with a URL. */
-  private async handleAutoUpdaterError(serverUrl: string): Promise<void> {
+  private async handleAutoUpdaterError(
+    serverUrl: string,
+    error?: unknown,
+  ): Promise<void> {
     console.warn(
-      "[DesktopHost] Auto updater errored, falling back to manual check",
+      "[DesktopHost] Auto updater errored, falling back to manual check:",
+      error instanceof Error ? error.stack : error,
     );
+    // The packaged app has no visible console — persist the error so it can be
+    // collected from the machine that reproduces the failed download.
+    try {
+      fs.appendFileSync(
+        path.join(app.getPath("userData"), "updater-error.log"),
+        `${new Date().toISOString()} ${error instanceof Error ? error.stack : error}\n`,
+      );
+    } catch (logError) {
+      // Logging must never break the fallback flow.
+      console.warn(
+        "[DesktopHost] Failed to write updater error log:",
+        logError,
+      );
+    }
     let info: ManualUpdateInfo | null = null;
     try {
       info = await checkForUpdate(app.getVersion(), serverUrl);


### PR DESCRIPTION
## 背景

Windows 桌面端已登录用户检查更新时，出现两个 toast 同时弹出：\「正在后台下载…\」+ \「发现新版本 + 打开下载页\」——自动更新链路在下载阶段中断，降级为手动下载页提示。

## 根因

electron-updater 下载前必须读取 `resources/app-update.yml`（`configOnDisk`，`getOrCreateDownloadHelper`），即使代码通过 `setFeedURL` 覆盖了 provider 也不例外。而 electron-builder **仅在声明 `publish` 配置（或仓库解析为 GitHub）时才生成该文件**，`packages/desktop/package.json` 未声明 `publish` → 打包产物缺 `app-update.yml` → 下载阶段抛 ENOENT → `error` 事件 → 降级「打开下载页」。

mac 产物存在同样问题（同一条 electron-updater 路径）。

## 修复

- `scripts/afterPack.js`：跨平台（mac/win）写入 `resources/app-update.yml`（`updaterCacheDirName: wave-desktop-updater`）；feed URL 仍由运行时 `setFeedURL` 注入，文件只需存在
- `desktopHost.ts`：`onError` 不再丢弃 error 参数，打印 stack 并落盘 `userData/updater-error.log`，便于真机定位
- `docs/specs/ui/desktop-app.md`：新增验收场景 9 防回归

## 验证

- 本机 dev 复现：缺配置文件 → ENOENT → 降级（与真机同路径）
- 补上配置文件：差分下载 404 自动回退全量 → `New version 1.1.1 has been downloaded`（sha512 校验通过）
- `electron-builder --win nsis --dir` 产物确认包含 `app-update.yml`
- 桌面端 269 测试、type-check、lint、spec 校验全过

## 注意

修复仅对**新发布的安装包**生效：需重新 `dist` 发布；已装旧版的用户本次仍需走一次下载页手动升级。