### PR TITLE
ci(desktop): build wave-code dist before bundling CLI into installers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -182,6 +182,11 @@ jobs:
       - name: Build webview dist
         run: pnpm -F wave-webview run compile -- --production
 
+      # bundleCli (packages/desktop/scripts/bundleCli.mjs) ships the CLI's
+      # dist/bundle/wave.mjs into the app resources, so build wave-code first.
+      - name: Build wave-code dist
+        run: pnpm -F wave-code build
+
       # `--publish never`: electron-builder only produces the installers; the
       # release upload is handled by action-gh-release below. Apple signing +
       # notarization env vars are injected only on macOS (the p12 and App Store

--- a/.github/workflows/refresh-release-assets.yml
+++ b/.github/workflows/refresh-release-assets.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write  # upload assets to an existing release
+  contents: write # upload assets to an existing release
 
 concurrency:
   group: refresh-release-assets
@@ -40,8 +40,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
-          cache: 'pnpm'
+          node-version: "22"
+          cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
@@ -64,7 +64,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: "17"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -74,8 +74,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
-          cache: 'pnpm'
+          node-version: "22"
+          cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile
 
@@ -113,8 +113,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
-          cache: 'pnpm'
+          node-version: "22"
+          cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile
 
@@ -123,6 +123,9 @@ jobs:
       # `compile -- --production` so the webview bundle is minified; the
       # desktop app's syncWebview step copies dist verbatim.
       - run: pnpm -F wave-webview run compile -- --production
+
+      # bundleCli ships the CLI's dist/bundle/wave.mjs into the app resources.
+      - run: pnpm -F wave-code build
 
       # `--publish never`: electron-builder only produces the installers;
       # the release upload is handled below. Apple signing + notarization


### PR DESCRIPTION
## Problem

The v1.1.2 publish run (32252469745) failed on both desktop runners:

```
[bundleCli] 缺少 wave CLI 构建产物：packages/code/dist/bundle/wave.mjs。请先构建 packages/code（pnpm -F wave-code build）。
```

`packages/desktop/scripts/bundleCli.mjs` (added in 0acefbe7, "bundle wave CLI into desktop/vscode") requires `packages/code/dist/bundle/wave.mjs`, but the desktop build jobs only built agent-sdk + webview — the `wave-code` build step was never added.

## Fix

Add `pnpm -F wave-code build` after the webview build step in:
- `.github/workflows/publish.yml` → `build-desktop` job
- `.github/workflows/refresh-release-assets.yml` → `refresh-desktop` job

Both produce `packages/code/dist/bundle/wave.mjs` for bundleCli to copy into the app resources.

## Verification

- YAML lint passes on both files
- Local `pnpm -r type-check` passes (pre-commit hook)