### PR TITLE
fix(desktop): silent Windows update install, drop download toast

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -4104,10 +4104,6 @@ export class DesktopHost {
     if (serverUrl) {
       if (!this.autoUpdaterService) {
         this.autoUpdaterService = new AutoUpdaterService({
-          onUpdateAvailable: (info) =>
-            this.showToast({
-              message: `发现新版本 v${info.version}（当前 v${app.getVersion()}），正在后台下载…`,
-            }),
           onUpdateDownloaded: (info) =>
             void this.handleUpdateDownloaded(info.version),
           onError: (error) =>

--- a/packages/desktop/src/main/updateAutoUpdater.ts
+++ b/packages/desktop/src/main/updateAutoUpdater.ts
@@ -2,16 +2,14 @@
  * AutoUpdaterService — electron-updater wrapper for logged-in (serverUrl)
  * installs. The update feed is the codechat downloads endpoint served in
  * electron-builder metadata format (latest-mac.yml / latest.yml), NOT GitHub
- * Releases. Hosts the update-available / update-downloaded callbacks so the
- * desktop host can surface them as chat system messages.
+ * Releases. Hosts the update-downloaded / error callbacks so the desktop host
+ * can surface them as chat system messages. Download progress stays silent.
  */
 
 import { app } from "electron";
 import { autoUpdater, type UpdateInfo } from "electron-updater";
 
 export interface AutoUpdaterCallbacks {
-  /** A newer version was found and the background download has started. */
-  onUpdateAvailable: (info: UpdateInfo) => void;
   /** The new version finished downloading — the host decides whether to install. */
   onUpdateDownloaded: (info: UpdateInfo) => void;
   /** The check or background download failed — the host degrades to the manual flow. */
@@ -33,9 +31,6 @@ export class AutoUpdaterService {
   private attachListeners(): void {
     if (this.listenersAttached) return;
     this.listenersAttached = true;
-    autoUpdater.on("update-available", (info) =>
-      this.callbacks.onUpdateAvailable(info),
-    );
     autoUpdater.on("update-downloaded", (info) =>
       this.callbacks.onUpdateDownloaded(info),
     );
@@ -57,6 +52,8 @@ export class AutoUpdaterService {
   }
 
   quitAndInstall(): void {
-    autoUpdater.quitAndInstall();
+    // isSilent=true → NSIS installer runs with /S (no wizard UI), then the app
+    // relaunches automatically. Without it Windows pops the full installer UI.
+    autoUpdater.quitAndInstall(true);
   }
 }

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -339,8 +339,8 @@ vi.mock("../src/main/updateChecker", () => ({
 }));
 
 // electron-updater — the auto-update service for logged-in (serverUrl) installs.
-// The on() mock records listeners so tests can fire update-available /
-// update-downloaded to assert the host's system-message wiring.
+// The on() mock records listeners so tests can fire update-downloaded /
+// error to assert the host's system-message wiring.
 const auListeners: Record<string, Array<(info: unknown) => void>> = {};
 vi.mock("electron-updater", () => ({
   autoUpdater: {
@@ -1684,25 +1684,6 @@ describe("checkForUpdates with a configured serverUrl", () => {
     expect(autoUpdater.checkForUpdates).toHaveBeenCalled();
     // The electron-updater path is authoritative when logged in — no GitHub fallback.
     expect(checkForUpdate).not.toHaveBeenCalled();
-  });
-
-  it("announces the update via a toast on update-available", async () => {
-    vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
-      updateInfo: { version: "0.20.0", files: [], path: "wave-0.20.0.dmg" },
-      isUpdateAvailable: true,
-    } as never);
-    const { host } = await readyHostWithServerUrl();
-
-    await host.handleWebviewMessage({ command: "checkForUpdates" });
-    for (const cb of auListeners["update-available"] ?? []) {
-      cb({ version: "0.20.0" });
-    }
-
-    const toasts = shownToasts().filter((n) => n.message.includes("0.20.0"));
-    expect(toasts).toHaveLength(1);
-    expect(toasts[0].message).toContain("正在后台下载");
-    // Informational only — no action button; the user acts once downloaded.
-    expect(toasts[0].action).toBeUndefined();
   });
 
   it("shows a restart-install toast once the update is downloaded, and quitAndInstall fires on its action", async () => {

--- a/packages/desktop/tests/updateAutoUpdater.test.ts
+++ b/packages/desktop/tests/updateAutoUpdater.test.ts
@@ -81,7 +81,6 @@ describe("AutoUpdaterService.checkForUpdates", () => {
       isUpdateAvailable: true,
     } as never);
     const service = new AutoUpdaterService({
-      onUpdateAvailable: vi.fn(),
       onUpdateDownloaded: vi.fn(),
       onError: vi.fn(),
     });
@@ -106,7 +105,6 @@ describe("AutoUpdaterService.checkForUpdates", () => {
       isUpdateAvailable: false,
     } as never);
     const service = new AutoUpdaterService({
-      onUpdateAvailable: vi.fn(),
       onUpdateDownloaded: vi.fn(),
       onError: vi.fn(),
     });
@@ -119,7 +117,6 @@ describe("AutoUpdaterService.checkForUpdates", () => {
   it('returns "error" when the check rejects', async () => {
     vi.mocked(h.checkForUpdates).mockRejectedValue(new Error("ECONNREFUSED"));
     const service = new AutoUpdaterService({
-      onUpdateAvailable: vi.fn(),
       onUpdateDownloaded: vi.fn(),
       onError: vi.fn(),
     });
@@ -131,25 +128,9 @@ describe("AutoUpdaterService.checkForUpdates", () => {
 });
 
 describe("AutoUpdaterService events and quitAndInstall", () => {
-  it("fires onUpdateAvailable when the update-available event arrives", () => {
-    const onUpdateAvailable = vi.fn();
-    const service = new AutoUpdaterService({
-      onUpdateAvailable,
-      onUpdateDownloaded: vi.fn(),
-      onError: vi.fn(),
-    });
-    // Attach listeners through a check so the wiring is exercised for real.
-    service.checkForUpdates("https://codechat.example.com");
-    service.checkForUpdates("https://codechat.example.com");
-
-    fire("update-available", { version: "0.20.0" });
-    expect(onUpdateAvailable).toHaveBeenCalledWith({ version: "0.20.0" });
-  });
-
   it("fires onUpdateDownloaded when the update-downloaded event arrives", () => {
     const onUpdateDownloaded = vi.fn();
     const service = new AutoUpdaterService({
-      onUpdateAvailable: vi.fn(),
       onUpdateDownloaded,
       onError: vi.fn(),
     });
@@ -162,7 +143,6 @@ describe("AutoUpdaterService events and quitAndInstall", () => {
   it("fires onError when the error event arrives", () => {
     const onError = vi.fn();
     const service = new AutoUpdaterService({
-      onUpdateAvailable: vi.fn(),
       onUpdateDownloaded: vi.fn(),
       onError,
     });
@@ -175,7 +155,6 @@ describe("AutoUpdaterService events and quitAndInstall", () => {
   it("registers each event listener only once across repeated checks", async () => {
     vi.mocked(h.checkForUpdates).mockResolvedValue(null);
     const service = new AutoUpdaterService({
-      onUpdateAvailable: vi.fn(),
       onUpdateDownloaded: vi.fn(),
       onError: vi.fn(),
     });
@@ -183,13 +162,12 @@ describe("AutoUpdaterService events and quitAndInstall", () => {
     await service.checkForUpdates("https://codechat.example.com");
 
     const registered = Object.values(h.listeners);
-    expect(registered.length).toBe(3); // update-available + update-downloaded + error
-    expect(h.on).toHaveBeenCalledTimes(3);
+    expect(registered.length).toBe(2); // update-downloaded + error
+    expect(h.on).toHaveBeenCalledTimes(2);
   });
 
   it("forwards quitAndInstall to electron-updater", () => {
     const service = new AutoUpdaterService({
-      onUpdateAvailable: vi.fn(),
       onUpdateDownloaded: vi.fn(),
       onError: vi.fn(),
     });


### PR DESCRIPTION
## 变更

Windows 桌面端自动更新体验改进（electron-updater）：

1. **静默安装**：点击「重启安装」后调用 `autoUpdater.quitAndInstall(true)`，NSIS 安装器以 `/S` 参数运行，不再弹出安装向导界面；装完自动重启应用。
2. **移除「正在后台下载」toast**：更新在后台静默下载，不再打扰用户；仅在新版本下载完成后弹出「重启安装」提示。

## 测试

- `packages/desktop` 相关单测 266/266 通过
- 全仓 type-check 通过