### PR TITLE
fix(desktop): relaunch app after silent update install

### DIFF
--- a/packages/desktop/src/main/updateAutoUpdater.ts
+++ b/packages/desktop/src/main/updateAutoUpdater.ts
@@ -52,8 +52,10 @@ export class AutoUpdaterService {
   }
 
   quitAndInstall(): void {
-    // isSilent=true → NSIS installer runs with /S (no wizard UI), then the app
-    // relaunches automatically. Without it Windows pops the full installer UI.
-    autoUpdater.quitAndInstall(true);
+    // isSilent=true → NSIS installer runs with /S (no wizard UI);
+    // isForceRunAfter=true → the installer gets --force-run, which is what
+    // makes the assisted installer relaunch the app after a silent install.
+    // Without it the update installs but the app never comes back.
+    autoUpdater.quitAndInstall(true, true);
   }
 }

--- a/packages/desktop/tests/updateAutoUpdater.test.ts
+++ b/packages/desktop/tests/updateAutoUpdater.test.ts
@@ -166,12 +166,15 @@ describe("AutoUpdaterService events and quitAndInstall", () => {
     expect(h.on).toHaveBeenCalledTimes(2);
   });
 
-  it("forwards quitAndInstall to electron-updater", () => {
+  it("forwards quitAndInstall with silent + force-run to electron-updater", () => {
     const service = new AutoUpdaterService({
       onUpdateDownloaded: vi.fn(),
       onError: vi.fn(),
     });
     service.quitAndInstall();
     expect(h.quitAndInstall).toHaveBeenCalledTimes(1);
+    // isSilent / isForceRunAfter: /S hides the wizard, --force-run makes the
+    // assisted NSIS installer relaunch the app after the silent install.
+    expect(h.quitAndInstall).toHaveBeenCalledWith(true, true);
   });
 });


### PR DESCRIPTION
## Problem

On Windows, after clicking 「重启安装」 the update installed successfully (the app was replaced with the new version) but the app never restarted.

## Root cause

`AutoUpdaterService.quitAndInstall()` called `autoUpdater.quitAndInstall(true)` — `isSilent` only. electron-updater's `NsisUpdater.doInstall` then spawned the NSIS installer with `["--updated", "/S"]` (no `--force-run`).

electron-builder's assisted installer (`oneClick: false`) only relaunches the app after a **silent** install when `isForceRun` is set (`templates/nsis/installSection.nsh`: `${if} ${isForceRun} ${andIf} ${Silent} → doStartApp`). Without `--force-run` the update installs and the app stays closed.

## Fix

Pass `isForceRunAfter=true`: `autoUpdater.quitAndInstall(true, true)` → installer args `["--updated", "/S", "--force-run"]` → the app relaunches automatically after the silent install.

mac is unaffected: `MacUpdater.quitAndInstall()` is a no-arg override that discards both args and goes through the Squirrel.Mac flow (which always relaunches after applying the update).

## Verification

- Real-device test: installed 1.1.1 → auto-update to 1.1.2 → clicked 「重启安装」 → app quit immediately, silent NSIS install completed, app relaunched with the new version (~30s).
- `updateAutoUpdater.test.ts` now asserts the call args `(true, true)`; desktop suite 266/266 pass.