### PR TITLE
fix(desktop): suppress manual update fallback after restart-install toast

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -248,6 +248,10 @@ export class DesktopHost {
   private lastIsAuthenticated = false;
   /** electron-updater path, created lazily once a serverUrl is configured. */
   private autoUpdaterService: AutoUpdaterService | null = null;
+  /** True once the "已下载完成，重启安装" toast was announced — a later
+   *  install-stage error (e.g. Squirrel signature validation) must not
+   *  double-notify with a conflicting manual download-page toast. */
+  private updateDownloadedAnnounced = false;
 
   /** Latest panel toggle state reported by each pane's webview (drives the 面板 menu). */
   private panePanelState = new Map<string, PanelKind[]>();
@@ -4156,6 +4160,10 @@ export class DesktopHost {
       "[DesktopHost] Auto updater errored, falling back to manual check:",
       error instanceof Error ? error.stack : error,
     );
+    // The download already finished and the restart-install toast is showing —
+    // a later install-stage error (e.g. Squirrel signature validation) must not
+    // announce a conflicting manual download-page toast on top of it.
+    if (this.updateDownloadedAnnounced) return;
     // The packaged app has no visible console — persist the error so it can be
     // collected from the machine that reproduces the failed download.
     try {
@@ -4189,6 +4197,7 @@ export class DesktopHost {
   /** The new version finished downloading — announce it via a toast whose
    *  「重启安装」 button quits and installs directly (no second confirm dialog). */
   private handleUpdateDownloaded(version: string): void {
+    this.updateDownloadedAnnounced = true;
     this.showToast({
       message: `新版本 v${version} 已下载完成，重启应用以完成安装。`,
       actionLabel: "重启安装",

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -1791,6 +1791,43 @@ describe("checkForUpdates with a configured serverUrl", () => {
     vi.mocked(checkForUpdate).mockResolvedValue(null);
   });
 
+  it("does not announce a manual fallback once the restart-install toast is already shown", async () => {
+    vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
+      updateInfo: { version: "0.20.0", files: [], path: "wave-0.20.0.dmg" },
+      isUpdateAvailable: true,
+    } as never);
+    // If the fallback wrongly fired it would return this and announce a
+    // conflicting download-page toast next to the restart-install one.
+    vi.mocked(checkForUpdate).mockResolvedValue({
+      latestVersion: "0.20.0",
+      currentVersion: "0.19.7",
+      downloadUrl: "https://github.com/release",
+    });
+    const { host } = await readyHostWithServerUrl();
+
+    await host.handleWebviewMessage({ command: "checkForUpdates" });
+    // Download finished → the restart-install toast is announced.
+    for (const cb of auListeners["update-downloaded"] ?? []) {
+      cb({ version: "0.20.0" });
+    }
+    expect(
+      shownToasts().filter((n) => n.message.includes("已下载完成")),
+    ).toHaveLength(1);
+
+    // The install stage then fails (e.g. Squirrel signature validation) —
+    // the user already has the restart-install entry, so no manual fallback.
+    for (const cb of auListeners["error"] ?? []) {
+      cb(new Error("Code signature did not pass validation"));
+    }
+
+    await vi.waitFor(() => expect(checkForUpdate).not.toHaveBeenCalled());
+    const manual = shownToasts().filter((n) =>
+      n.message.includes("发现新版本"),
+    );
+    expect(manual).toHaveLength(0);
+    vi.mocked(checkForUpdate).mockResolvedValue(null);
+  });
+
   it('says "already latest" via a toast without a GitHub round trip when the feed has no update', async () => {
     vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
       updateInfo: { version: "0.19.7", files: [], path: "wave-0.19.7.dmg" },


### PR DESCRIPTION
## Problem

Real-device testing of the desktop auto-update flow revealed two conflicting toasts at once:

1. 新版本 v1.1.2 已下载完成，重启应用以完成安装。(restart-install)
2. 发现新版本 v1.1.2（当前 v1.1.1）(manual download-page fallback)

The download completing announces the restart-install toast; if the install stage then errors (e.g. Squirrel code-signature validation), the error handler falls back to the manual checker and announces a second, contradictory toast on top of it.

## Fix

Track whether the restart-install toast was already announced (updateDownloadedAnnounced). handleAutoUpdaterError returns early when it was, so the manual download-page fallback never double-notifies. When the check itself fails before any download, the fallback still runs as before.

TDD: new test covers download-done + install-error ordering; desktop suite 520 passed.