### PR TITLE
build(jetbrains): support -PlocalIdePath override without editing build files

### DIFF
--- a/packages/jetbrains/build.gradle.kts
+++ b/packages/jetbrains/build.gradle.kts
@@ -9,7 +9,16 @@ version = providers.gradleProperty("pluginVersion").get()
 
 dependencies {
     intellijPlatform {
-        create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"))
+        // Local-IDE override for development: pass -PlocalIdePath=<dir> to use a
+        // locally installed/unpacked IDE instead of downloading the platform
+        // distribution (useful when JetBrains repos are unreachable). CI and
+        // normal builds omit the property and download via create(...).
+        val localIdePath = providers.gradleProperty("localIdePath")
+        if (localIdePath.isPresent && localIdePath.get().isNotBlank()) {
+            local(localIdePath)
+        } else {
+            create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"))
+        }
     }
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.9.0")


### PR DESCRIPTION
## Summary

Developers on machines where JetBrains repos are unreachable (e.g. GFW-blocked) previously had to hand-edit `dependencies { intellijPlatform { create(...) } }` to `local(path)` before every `runIde`, then revert it after — a recurring, error-prone dance.

## Change

`packages/jetbrains/build.gradle.kts` now switches on the `localIdePath` Gradle property:

- `./gradlew runIde -PlocalIdePath=<dir>` → uses a local unpacked IDE (no network)
- omit the property → standard `create(platformType, platformVersion)` download (CI, normal builds)

Verified on this machine:
- create() branch: compiles in 53s, Gradle downloads ideaIC-2024.2 fine (JetBrains domains reachable again)
- `-PlocalIdePath` branch: compiles against the local ideaIC-2024.2.4

No CI impact (property absent there).