### PR TITLE
feat(webview): virtualize MessageList with @tanstack/react-virtual (#1790)

### DIFF
--- a/packages/webview/e2e/demo/virtual-message-list.demo.ts
+++ b/packages/webview/e2e/demo/virtual-message-list.demo.ts
@@ -1,0 +1,248 @@
+import { Page } from "@playwright/test";
+import { test, expect } from "../utils/webviewTestHarness.js";
+import { MessageInjector } from "../utils/messageInjector.js";
+import { Message } from "wave-agent-sdk";
+
+/**
+ * Virtualized MessageList (VIRTUAL_SCROLL_THRESHOLD = 200) in real Chromium.
+ *
+ * jsdom cannot validate layout — every geometry assertion here (bounded DOM
+ * row count, spacer height, scroll round trip, sticky jump, streaming
+ * bottom-pinning) only makes sense against a real browser.
+ */
+
+const VIRTUAL_MESSAGE_COUNT = 300; // > VIRTUAL_SCROLL_THRESHOLD (200)
+
+function buildMessages(count: number): Message[] {
+  const msgs: Message[] = [];
+  for (let i = 0; i < count; i++) {
+    const timestamp = new Date(Date.UTC(2026, 0, 1) + i * 60000).toISOString();
+    if (i % 4 === 0 || i % 4 === 3) {
+      msgs.push({
+        id: `u${i}`,
+        role: "user",
+        timestamp,
+        blocks: [
+          { type: "text", content: `问题 ${i}：请检查这个文件的实现细节。` },
+        ],
+      });
+    } else {
+      msgs.push({
+        id: `a${i}`,
+        role: "assistant",
+        timestamp,
+        blocks: [{ type: "text", content: `回答 ${i}：好的，我来看一下。` }],
+      });
+    }
+  }
+  return msgs;
+}
+
+async function initWithMessages(
+  injector: MessageInjector,
+  messages: Message[],
+) {
+  await injector.simulateExtensionMessage("setInitialState", {
+    isAuthenticated: true,
+    messages: [],
+    isStreaming: false,
+    sessions: [],
+    configurationData: {
+      apiKey: "sk-ant-api03-CXB9pH2k...mH8wQz",
+      baseURL: "https://api.anthropic.com/v1",
+      model: "claude-sonnet-4-20250514",
+      fastModel: "claude-haiku-4-20250514",
+    },
+    permissionMode: "default",
+  });
+  await injector.updateMessages(messages);
+  await injector.endStreaming();
+}
+
+async function containerState(webviewPage: Page) {
+  return webviewPage.evaluate(() => {
+    const c = document.getElementById("messagesContainer") as HTMLElement;
+    const spacer = c.querySelector<HTMLElement>(".virtual-spacer");
+    return {
+      virtualClass: c.classList.contains("messages-container--virtual"),
+      rowCount: c.querySelectorAll(".virtual-row").length,
+      spacerHeight: spacer ? spacer.getBoundingClientRect().height : 0,
+      scrollHeight: c.scrollHeight,
+      clientHeight: c.clientHeight,
+      scrollTop: c.scrollTop,
+      bottomGap: c.scrollHeight - c.scrollTop - c.clientHeight,
+    };
+  });
+}
+
+test.describe("Virtualized message list demo", () => {
+  test("bounded DOM rows, real spacer height, scrollable, pinned to bottom", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+    await initWithMessages(injector, buildMessages(VIRTUAL_MESSAGE_COUNT));
+
+    // The last row must be rendered (initial load pinned to the bottom) before
+    // geometry settles.
+    await webviewPage.waitForSelector('[data-message-id="u299"]');
+    await webviewPage.waitForFunction(() => {
+      const c = document.getElementById("messagesContainer") as HTMLElement;
+      return c.scrollHeight - c.scrollTop - c.clientHeight <= 2;
+    });
+
+    const state = await containerState(webviewPage);
+    expect(state.virtualClass).toBe(true);
+    // 300 messages must NOT render 300 rows: the virtualized window is
+    // viewport/estimate + 2 × overscan (~50 rows here).
+    expect(state.rowCount).toBeGreaterThan(0);
+    expect(state.rowCount).toBeLessThan(120);
+    // The spacer carries the real total height, not the container's height.
+    expect(state.spacerHeight).toBeGreaterThan(1000);
+    expect(state.scrollHeight).toBeGreaterThan(state.clientHeight);
+    // Pinned to the true bottom (paddingStart/paddingEnd accounted).
+    expect(state.bottomGap).toBeLessThanOrEqual(2);
+  });
+
+  test("scroll round trip renders both ends; sticky jump centers the target", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+    await initWithMessages(injector, buildMessages(VIRTUAL_MESSAGE_COUNT));
+    await webviewPage.waitForSelector('[data-message-id="u299"]');
+
+    // Top of the list.
+    await webviewPage.evaluate(() => {
+      const c = document.getElementById("messagesContainer") as HTMLElement;
+      c.scrollTop = 0;
+    });
+    await webviewPage.waitForSelector('[data-message-id="u0"]');
+    // Only the top rows are in the DOM now — the bottom row must be unmounted.
+    expect(await webviewPage.$('[data-message-id="u299"]')).toBeNull();
+
+    // Back to the bottom.
+    await webviewPage.evaluate(() => {
+      const c = document.getElementById("messagesContainer") as HTMLElement;
+      c.scrollTop = c.scrollHeight;
+    });
+    await webviewPage.waitForSelector('[data-message-id="u299"]');
+    expect(await webviewPage.$('[data-message-id="u0"]')).toBeNull();
+
+    // Scroll up a couple of thousand px so several user messages pass above
+    // the viewport → the sticky bar pins the most recent one.
+    await webviewPage.evaluate(() => {
+      const c = document.getElementById("messagesContainer") as HTMLElement;
+      c.scrollTop = Math.max(0, c.scrollTop - 3000);
+    });
+    await webviewPage.waitForSelector('[data-testid="sticky-user-message"]');
+    // While row measurements are still converging (estimate 200px → real
+    // heights), the sticky candidate can briefly flip between two adjacent
+    // user messages. Reading the text in that window would pick a target that
+    // no longer matches the onClick closure by click time. Wait until the
+    // sticky text is stable across two samples before trusting it.
+    const stickyText = await webviewPage.evaluate(async () => {
+      const sel = '[data-testid="sticky-user-message"] .sticky-user-content';
+      let prev = "";
+      for (let i = 0; i < 20; i++) {
+        const cur = document.querySelector(sel)?.textContent?.trim() ?? "";
+        if (cur && cur === prev) return cur;
+        prev = cur;
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
+      return prev;
+    });
+    expect(stickyText.length).toBeGreaterThan(0);
+
+    const targetId = buildMessages(VIRTUAL_MESSAGE_COUNT).find(
+      (m) =>
+        m.role === "user" &&
+        m.blocks
+          .filter((b) => b.type === "text")
+          .map((b) => b.content || "")
+          .join(" ")
+          .trim() === stickyText,
+    )?.id;
+    expect(targetId).toBeTruthy();
+
+    // Clicking the sticky bar jumps (virtualizer.scrollToIndex) to the target
+    // message and centers it in the viewport.
+    await webviewPage.click('[data-testid="sticky-user-message"]');
+    await webviewPage.waitForSelector(`[data-message-id="${targetId}"]`);
+    await webviewPage.waitForFunction(
+      (id) => {
+        const c = document.getElementById("messagesContainer") as HTMLElement;
+        const row = c.querySelector<HTMLElement>(`[data-message-id="${id}"]`);
+        if (!row) return false;
+        const cb = c.getBoundingClientRect();
+        const rb = row.getBoundingClientRect();
+        return Math.abs(rb.top - cb.top - (cb.height - rb.height) / 2) < 40;
+      },
+      targetId,
+      { timeout: 3000 },
+    );
+  });
+
+  test("streaming bottom-pinning: settled dist ≤ 2, no upward jumps", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+    const msgs = buildMessages(VIRTUAL_MESSAGE_COUNT);
+    msgs.push({
+      id: "stream-msg",
+      role: "assistant",
+      timestamp: new Date().toISOString(),
+      blocks: [{ type: "text", content: "开始流式输出：", stage: "streaming" }],
+    });
+    await initWithMessages(injector, msgs);
+    await injector.startStreaming();
+    await webviewPage.waitForSelector('[data-message-id="stream-msg"]');
+    await webviewPage.waitForFunction(() => {
+      const c = document.getElementById("messagesContainer") as HTMLElement;
+      return c.scrollHeight - c.scrollTop - c.clientHeight <= 2;
+    });
+
+    // Grow the streaming last row chunk by chunk (the incremental
+    // updateStreamingContent path). The viewport must stay pinned to the
+    // bottom: settled dist ≤ 2 and scrollTop never goes backward.
+    const chunks = [
+      "第一段内容",
+      "第二段内容，继续增长",
+      "第三段：添加更多说明文字",
+      "第四段：继续输出详细的分析",
+      "第五段：保持视口钉在底部",
+      "第六段：测量与滚动补偿",
+      "第七段：不得向上回跳",
+      "第八段：流式内容持续增长",
+      "第九段：再补一行验证",
+      "第十段：收尾结束流式输出",
+    ];
+    let prevScrollTop = (await containerState(webviewPage)).scrollTop;
+    for (const chunk of chunks) {
+      await injector.simulateExtensionMessage("updateStreamingContent", {
+        messageId: "stream-msg",
+        chunk,
+        stage: "streaming",
+      });
+      // The streaming row grows in stages (text render → resizeItem → spacer
+      // write → scroll compensation), so a single instant may read dist ≤ 2
+      // mid-flight and then grow again. Require the pinned state to hold for
+      // 200ms before trusting it.
+      await webviewPage.waitForFunction(
+        async ({ id, suffix }) => {
+          const c = document.getElementById("messagesContainer") as HTMLElement;
+          const row = c.querySelector(`[data-message-id="${id}"]`);
+          if (!row || !row.textContent?.includes(suffix)) return false;
+          const dist = () => c.scrollHeight - c.scrollTop - c.clientHeight;
+          if (dist() > 2) return false;
+          await new Promise((resolve) => setTimeout(resolve, 200));
+          return dist() <= 2;
+        },
+        { id: "stream-msg", suffix: chunk },
+        { timeout: 5000 },
+      );
+      const state = await containerState(webviewPage);
+      expect(state.bottomGap).toBeLessThanOrEqual(2);
+      expect(state.scrollTop).toBeGreaterThanOrEqual(prevScrollTop - 2);
+      prevScrollTop = state.scrollTop;
+    }
+  });
+});

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -45,6 +45,7 @@
     "wave-webview-fixtures": "workspace:*"
   },
   "dependencies": {
+    "@tanstack/react-virtual": "^3.14.10",
     "@vscode/codicons": "^0.0.43",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",

--- a/packages/webview/src/components/MessageList.tsx
+++ b/packages/webview/src/components/MessageList.tsx
@@ -7,10 +7,17 @@ import React, {
   useCallback,
   useState,
 } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { Message } from "./Message";
 import type { MessageListProps } from "../types";
 import type { Message as MessageType } from "wave-agent-sdk";
 import "../styles/MessageList.css";
+
+// Above this many visible messages the list switches to the virtualized
+// branch (@tanstack/react-virtual); below it the plain render path stays
+// byte-for-byte identical. The threshold keeps small chats (the common case
+// for unit tests and demo harnesses) on the plain path.
+const VIRTUAL_SCROLL_THRESHOLD = 200;
 
 // Count the blocks in an assistant message that Message.tsx wraps in a `.timeline-row`
 // (i.e. that carry a timeline dot): non-empty text/compact, tool, and reasoning blocks.
@@ -94,6 +101,104 @@ export const MessageList = forwardRef<
     text: string;
   } | null>(null);
 
+  // Filter out user messages with isMeta (hidden from the list). Extracted from
+  // the render path so both the plain and the virtualized branch index the same
+  // data.
+  const visibleMessages = useMemo(() => {
+    const out: MessageType[] = [];
+    for (const msg of messages) {
+      if (msg.role === "user" && msg.isMeta) continue;
+      out.push(msg);
+    }
+    return out;
+  }, [messages]);
+
+  const virtualized = visibleMessages.length > VIRTUAL_SCROLL_THRESHOLD;
+
+  // Refs mirroring the branch state for stable callbacks (event handlers and
+  // imperative handle must not capture a stale render).
+  const virtualizedRef = useRef(virtualized);
+  virtualizedRef.current = virtualized;
+  const visibleMessagesRef = useRef(visibleMessages);
+  visibleMessagesRef.current = visibleMessages;
+
+  const virtualizer = useVirtualizer({
+    // count: 0 keeps the virtualizer inert on the plain path (it still mounts
+    // its observers, but renders no rows).
+    count: virtualized ? visibleMessages.length : 0,
+    getScrollElement: () => containerRef.current,
+    estimateSize: () => 200,
+    overscan: 20,
+    // Inter-row spacing is baked into each row's padding-bottom (see
+    // timelineRuns) instead of the virtualizer's `gap`: the plain path renders
+    // consecutive assistant messages flush (gap 0) so the timeline line is
+    // continuous through a run — a uniform `gap` would break the line at every
+    // message boundary.
+    paddingStart: 10, // .messages-container padding
+    paddingEnd: 10,
+    // Keep the reading position anchored on appends; follow new content only
+    // when the user is already at the end (streaming bottom-pin).
+    anchorTo: "end",
+    followOnAppend: true,
+    getItemKey: (i) => visibleMessages[i].id,
+    // Skip React re-renders for scroll-only updates: the virtualizer writes
+    // row transforms and the spacer height straight to the DOM, re-rendering
+    // only when the visible range or isScrolling changes.
+    directDomUpdates: true,
+    // Defer measurement resize callbacks to animation frames so streaming row
+    // growth doesn't trigger layout thrash mid-frame.
+    useAnimationFrameWithResizeObserver: true,
+  });
+
+  // Per-message timeline run data for the virtualized branch. A run is a
+  // maximal sequence of consecutive assistant messages (mirrors the
+  // .assistant-group logic of the plain path). Multi-dot runs draw a
+  // continuous vertical line: the run's first row starts it at its first dot,
+  // the last row ends it at its last dot; single-dot runs hide the line.
+  // paddingBottom is the row's bottom spacing: 0 inside a multi-dot run so the
+  // line segments abut (flush, like the plain path's gap:0 group), 10 after
+  // every other row (the plain path's 10px container gap).
+  const timelineRuns = useMemo(() => {
+    const classes: string[] = [];
+    const paddings: number[] = [];
+    let runStart = -1;
+    let dots = 0;
+    const flushRun = (end: number) => {
+      if (runStart === -1) return;
+      if (dots <= 1) {
+        for (let i = runStart; i <= end; i++) {
+          classes[i] = "timeline-run--single";
+          paddings[i] = 10;
+        }
+      } else {
+        classes[runStart] = "timeline-run--start";
+        paddings[runStart] = 0;
+        classes[end] = "timeline-run--end";
+        paddings[end] = 10;
+        for (let i = runStart + 1; i < end; i++) {
+          paddings[i] = 0;
+        }
+        if (runStart === end) {
+          classes[runStart] = "timeline-run--start timeline-run--end";
+        }
+      }
+      runStart = -1;
+      dots = 0;
+    };
+    visibleMessages.forEach((m, i) => {
+      if (m.role === "assistant") {
+        if (runStart === -1) runStart = i;
+        dots += countTimelineBlocks(m);
+      } else {
+        flushRun(i - 1);
+        classes[i] = "";
+        paddings[i] = 10;
+      }
+    });
+    flushRun(visibleMessages.length - 1);
+    return { classes, paddings };
+  }, [visibleMessages]);
+
   const computeSticky = useCallback(() => {
     const container = containerRef.current;
     if (!container) {
@@ -101,25 +206,66 @@ export const MessageList = forwardRef<
       return;
     }
     const scrollTop = container.scrollTop;
+    if (virtualizedRef.current) {
+      // Virtualized branch: the DOM only holds the visible window, so the
+      // sticky candidate is derived from the data + the virtualizer's offset
+      // table. The candidate is the last user message whose top edge sits
+      // above the viewport top, i.e. the last user message at or before the
+      // item currently at the top of the viewport (which is itself a
+      // candidate only when its top edge is strictly above the fold).
+      const at = virtualizer.getVirtualItemForOffset(scrollTop);
+      let idx = at ? at.index : -1;
+      if (at && at.start >= scrollTop) idx = at.index - 1;
+      const rows = visibleMessagesRef.current;
+      let candidate = -1;
+      while (idx >= 0) {
+        if (rows[idx].role === "user") {
+          candidate = idx;
+          break;
+        }
+        idx--;
+      }
+      if (candidate < 0) {
+        setStickyMessage(null);
+        return;
+      }
+      const msg = rows[candidate];
+      const text = (msg.blocks ?? [])
+        .filter((b) => b.type === "text")
+        .map((b) => b.content || "")
+        .join(" ")
+        .trim();
+      if (!msg.id || !text) {
+        setStickyMessage(null);
+        return;
+      }
+      setStickyMessage((prev) =>
+        prev && prev.id === msg.id && prev.text === text
+          ? prev
+          : { id: msg.id, text },
+      );
+      return;
+    }
+    // Plain path: scan the fully-rendered DOM, as before.
     const nodes = container.querySelectorAll<HTMLElement>(
       '[data-role="user"][data-message-id]',
     );
-    let candidate: HTMLElement | null = null;
+    let candidateNode: HTMLElement | null = null;
     // Find the last user message whose top edge has scrolled above the viewport top.
     for (const node of nodes) {
       if (node.offsetTop < scrollTop) {
-        candidate = node;
+        candidateNode = node;
       } else {
         break;
       }
     }
-    if (!candidate) {
+    if (!candidateNode) {
       setStickyMessage(null);
       return;
     }
-    const id = candidate.getAttribute("data-message-id") || "";
+    const id = candidateNode.getAttribute("data-message-id") || "";
     const text =
-      candidate.querySelector(".user-content")?.textContent?.trim() || "";
+      candidateNode.querySelector(".user-content")?.textContent?.trim() || "";
     if (!id || !text) {
       setStickyMessage(null);
       return;
@@ -127,29 +273,87 @@ export const MessageList = forwardRef<
     setStickyMessage((prev) =>
       prev && prev.id === id && prev.text === text ? prev : { id, text },
     );
-  }, []);
+  }, [virtualizer]);
 
-  const scrollToMessage = useCallback((id: string) => {
-    const container = containerRef.current;
-    const node = container?.querySelector<HTMLElement>(
-      `[data-message-id="${id}"]`,
-    );
-    node?.scrollIntoView({ behavior: "smooth", block: "center" });
-  }, []);
+  const scrollToMessage = useCallback(
+    (id: string) => {
+      const container = containerRef.current;
+      if (!container) return;
+      if (virtualizedRef.current) {
+        // The target row is likely not mounted (it scrolled far above the
+        // viewport), so jump via the virtualizer's offset table instead of
+        // querying the DOM.
+        const index = visibleMessagesRef.current.findIndex((m) => m.id === id);
+        if (index >= 0) {
+          virtualizer.scrollToIndex(index, {
+            align: "center",
+            behavior: "smooth",
+          });
+        }
+        return;
+      }
+      const node = container.querySelector<HTMLElement>(
+        `[data-message-id="${id}"]`,
+      );
+      node?.scrollIntoView({ behavior: "smooth", block: "center" });
+    },
+    [virtualizer],
+  );
 
   // Perform a programmatic scroll-to-bottom, guarding it with the
   // isProgrammaticScroll flag so the scroll handler treats the resulting
   // 'scroll' event as ours (not the user's) and leaves userScrolledUp alone.
-  const doScrollToBottom = useCallback((behavior: ScrollBehavior) => {
-    const messagesEnd = messagesEndRef.current;
-    if (!messagesEnd) return;
-    isProgrammaticScrollRef.current = true;
-    messagesEnd.scrollIntoView({ behavior });
-    // 'auto' is instant (single 'scroll' fire); reset on the next frame.
-    requestAnimationFrame(() => {
-      isProgrammaticScrollRef.current = false;
-    });
-  }, []);
+  const doScrollToBottom = useCallback(
+    (behavior: ScrollBehavior) => {
+      const container = containerRef.current;
+      if (!container) return;
+      isProgrammaticScrollRef.current = true;
+      if (virtualizedRef.current) {
+        virtualizer.scrollToEnd({ behavior });
+        // The virtualizer's resizeItem compensation and the scrollToEnd above
+        // both target offsets computed before the spacer height lands in the
+        // DOM (the spacer write happens later in the frame, after the scrollTo
+        // was clamped against the stale scrollHeight; the ResizeObserver →
+        // animation-frame measurement can even trail by a full frame). Keep
+        // re-checking for a few frames and finish the jump once the spacer is
+        // in place, so streaming row growth still pins the viewport.
+        let attempts = 0;
+        const finishPin = () => {
+          if (attempts++ >= 8) return;
+          // Only chase the bottom while the viewport is still parked there; if
+          // the user scrolls away during the compensation window, stop so we
+          // don't yank them back to the bottom.
+          if (
+            container.scrollTop + container.clientHeight <
+            container.scrollHeight - 300
+          ) {
+            return;
+          }
+          if (
+            container.scrollHeight -
+              container.scrollTop -
+              container.clientHeight >
+            2
+          ) {
+            isProgrammaticScrollRef.current = true;
+            virtualizer.scrollToEnd({ behavior: "auto" });
+            requestAnimationFrame(() => {
+              isProgrammaticScrollRef.current = false;
+            });
+          }
+          requestAnimationFrame(finishPin);
+        };
+        requestAnimationFrame(finishPin);
+      } else {
+        messagesEndRef.current?.scrollIntoView({ behavior });
+      }
+      // 'auto' is instant (single 'scroll' fire); reset on the next frame.
+      requestAnimationFrame(() => {
+        isProgrammaticScrollRef.current = false;
+      });
+    },
+    [virtualizer],
+  );
 
   const scrollToBottom = useCallback(
     (behavior: ScrollBehavior = "smooth", force = false) => {
@@ -307,9 +511,11 @@ export const MessageList = forwardRef<
   // short of the real bottom. Re-pin here, gated on being near the bottom
   // (the push is far smaller than the 300px threshold) and on the user not
   // having scrolled up, so a sticky change while reading history is ignored.
+  // The virtualized branch renders the sticky bar as an overlay (no flow
+  // space), so nothing pushes the bottom there.
   useEffect(() => {
     const container = containerRef.current;
-    if (!container || !stickyMessage) return;
+    if (!container || !stickyMessage || virtualizedRef.current) return;
     const isNearBottom =
       container.scrollTop + container.clientHeight >=
       container.scrollHeight - 300;
@@ -318,15 +524,77 @@ export const MessageList = forwardRef<
     }
   }, [stickyMessage, doScrollToBottom]);
 
+  // Plain path (small chats): group consecutive assistant messages into a
+  // single .assistant-group wrapper so the timeline vertical line runs
+  // continuously through all their dots. User messages break the timeline
+  // (rendered as bare bubbles outside any group).
+  const renderedPlain = useMemo(() => {
+    const renderMessage = (message: MessageType) => {
+      return (
+        <Message
+          key={message.id}
+          message={message}
+          vscode={vscode}
+          onRewindToMessage={onRewindToMessage}
+          workdir={workdir}
+          onOpenPreview={onOpenPreview}
+          onOpenFile={onOpenFile}
+        />
+      );
+    };
+
+    const rendered: React.ReactNode[] = [];
+    let group: { message: MessageType }[] = [];
+
+    const flushGroup = () => {
+      if (group.length === 0) return;
+      const dotCount = group.reduce(
+        (sum, g) => sum + countTimelineBlocks(g.message),
+        0,
+      );
+      const single = dotCount <= 1;
+      rendered.push(
+        <div
+          key={group[0].message.id}
+          className={`assistant-group${single ? " assistant-group--single" : ""}`}
+        >
+          {group.map((g) => renderMessage(g.message))}
+        </div>,
+      );
+      group = [];
+    };
+
+    visibleMessages.forEach((message) => {
+      if (message.role === "assistant") {
+        group.push({ message });
+      } else {
+        flushGroup();
+        rendered.push(renderMessage(message));
+      }
+    });
+    flushGroup();
+
+    return rendered;
+  }, [
+    visibleMessages,
+    vscode,
+    onRewindToMessage,
+    workdir,
+    onOpenPreview,
+    onOpenFile,
+  ]);
+
   return (
     <div
       ref={containerRef}
       id="messagesContainer"
-      className={`messages-container${isStreaming ? " streaming" : ""}${isCompacting ? " compacting" : ""}`}
+      className={`messages-container${isStreaming ? " streaming" : ""}${isCompacting ? " compacting" : ""}${virtualized ? " messages-container--virtual" : ""}`}
       data-testid="messages-container"
     >
       {stickyMessage && (
-        <div className="sticky-user-wrapper">
+        <div
+          className={`sticky-user-wrapper${virtualized ? " sticky-user-wrapper--overlay" : ""}`}
+        >
           <div className="sticky-user-cap" />
           <div
             className="sticky-user-message"
@@ -338,73 +606,44 @@ export const MessageList = forwardRef<
           <div className="sticky-user-scrim" />
         </div>
       )}
-      {/* Chat messages - filter out user meta messages */}
-      {useMemo(() => {
-        // Filter out user messages with isMeta (hidden from the list)
-        const visibleMessages: MessageType[] = [];
-        for (const msg of messages) {
-          if (msg.role === "user" && msg.isMeta) continue;
-          visibleMessages.push(msg);
-        }
-
-        const renderMessage = (message: MessageType) => {
-          return (
-            <Message
-              key={message.id}
-              message={message}
-              vscode={vscode}
-              onRewindToMessage={onRewindToMessage}
-              workdir={workdir}
-              onOpenPreview={onOpenPreview}
-              onOpenFile={onOpenFile}
-            />
-          );
-        };
-
-        // Group consecutive assistant messages into a single .assistant-group wrapper so
-        // the timeline vertical line runs continuously through all their dots. User
-        // messages break the timeline (rendered as bare bubbles outside any group).
-        const rendered: React.ReactNode[] = [];
-        let group: { message: MessageType }[] = [];
-
-        const flushGroup = () => {
-          if (group.length === 0) return;
-          const dotCount = group.reduce(
-            (sum, g) => sum + countTimelineBlocks(g.message),
-            0,
-          );
-          const single = dotCount <= 1;
-          rendered.push(
-            <div
-              key={group[0].message.id}
-              className={`assistant-group${single ? " assistant-group--single" : ""}`}
-            >
-              {group.map((g) => renderMessage(g.message))}
-            </div>,
-          );
-          group = [];
-        };
-
-        visibleMessages.forEach((message) => {
-          if (message.role === "assistant") {
-            group.push({ message });
-          } else {
-            flushGroup();
-            rendered.push(renderMessage(message));
-          }
-        });
-        flushGroup();
-
-        return rendered;
-      }, [
-        messages,
-        vscode,
-        onRewindToMessage,
-        workdir,
-        onOpenPreview,
-        onOpenFile,
-      ])}
-
+      {virtualized ? (
+        <>
+          {/* In-flow spacer carrying the virtualized total height. The
+              virtualizer writes its height directly (directDomUpdates); it
+              must keep its space in the flex column (flex-shrink: 0). */}
+          <div ref={virtualizer.containerRef} className="virtual-spacer" />
+          {virtualizer.getVirtualItems().map((virtualRow) => {
+            const message = visibleMessages[virtualRow.index];
+            const runClass = timelineRuns.classes[virtualRow.index];
+            return (
+              <div
+                key={virtualRow.key}
+                data-index={virtualRow.index}
+                ref={virtualizer.measureElement}
+                className={`virtual-row${runClass ? ` ${runClass}` : ""}`}
+                style={{
+                  paddingBottom: timelineRuns.paddings[virtualRow.index],
+                }}
+              >
+                <Message
+                  key={message.id}
+                  message={message}
+                  vscode={vscode}
+                  onRewindToMessage={onRewindToMessage}
+                  workdir={workdir}
+                  onOpenPreview={onOpenPreview}
+                  onOpenFile={onOpenFile}
+                />
+              </div>
+            );
+          })}
+        </>
+      ) : (
+        // Plain path (small chats): byte-for-byte the original render, with
+        // consecutive assistant messages grouped into a .assistant-group so
+        // the timeline line runs continuously through their dots.
+        <>{renderedPlain}</>
+      )}
       {/* Compaction hint: blinking cursor + label pinned to the end of the
           message list, independent of isStreaming (auto-compaction runs between
           turns, after the streaming cursor is gone). */}

--- a/packages/webview/src/styles/MessageList.css
+++ b/packages/webview/src/styles/MessageList.css
@@ -90,3 +90,77 @@
   );
   pointer-events: none;
 }
+
+/* ---------- Virtualized list (VIRTUAL_SCROLL_THRESHOLD branch) ---------- */
+
+/* The virtualizer positions rows absolutely; the in-flow spacer carries the
+   total height. Row spacing lives in each row's padding-bottom (see
+   MessageList timelineRuns), so the container gap must be zeroed — otherwise
+   the flex gap would add extra space around the spacer/compaction hint. */
+.messages-container--virtual {
+  gap: 0;
+}
+
+.virtual-spacer {
+  width: 100%;
+  flex-shrink: 0;
+}
+
+.virtual-row {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* The full-width row wrapper would stretch user bubbles across the whole
+   column; keep the plain path's shrink-to-fit look. */
+.messages-container--virtual .message.user {
+  width: fit-content;
+  max-width: 100%;
+}
+
+/* Timeline vertical line as per-message segments (the plain path draws it via
+   .assistant-group). A run of consecutive assistant messages is a row
+   sequence: the run's first row starts the line at its first dot, the last
+   row ends it at its last dot; interior rows span their full height so the
+   segments abut into a continuous line; single-dot runs hide it. */
+.messages-container--virtual .timeline-row::after {
+  content: "";
+  position: absolute;
+  left: 3px;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--vscode-widget-border);
+  z-index: 0;
+}
+
+.messages-container--virtual
+  .timeline-run--start
+  .timeline-row:first-child::after {
+  top: 18px;
+}
+
+.messages-container--virtual
+  .timeline-run--end
+  .timeline-row:last-child::after {
+  bottom: auto;
+  height: 18px;
+}
+
+.messages-container--virtual .timeline-run--single .timeline-row::after {
+  display: none;
+}
+
+/* Sticky user message as an overlay in the virtualized list: it must not
+   consume flow space — the virtualizer's offsets and the spacer height assume
+   the scroll content starts at the container's content box. */
+.sticky-user-wrapper--overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  margin-bottom: 0;
+}

--- a/packages/webview/tests/webview/messageListVirtualization.test.tsx
+++ b/packages/webview/tests/webview/messageListVirtualization.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  renderChatApp,
+  screen,
+  waitFor,
+  act,
+  sendCommand,
+  fireEvent,
+} from "./test-utils";
+import { MockDataGenerator } from "../fixtures/mockData";
+
+/**
+ * Virtualized MessageList branch (VIRTUAL_SCROLL_THRESHOLD = 200).
+ *
+ * jsdom cannot do layout, so geometry assertions (spacer height, scroll
+ * pinning, bounded row counts in a real viewport) live in the Playwright demo
+ * harness (e2e/demo/virtual-message-list.demo.ts). Here we only pin the
+ * structural contract of the virtualized branch: the branch is taken above
+ * the threshold, rows are message-granularity with timeline run classes, and
+ * the DOM row count stays bounded (never all messages).
+ */
+describe("MessageList virtualization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function buildMessages(count: number) {
+    const messages: ReturnType<typeof MockDataGenerator.createUserMessage>[] =
+      [];
+    for (let i = 0; i < count; i++) {
+      // Runs of two consecutive assistant messages (multi-dot timeline runs),
+      // so the virtualized branch exercises the run classes.
+      if (i % 4 === 0 || i % 4 === 3) {
+        messages.push(
+          MockDataGenerator.createUserMessage(`问题 ${i}`, `u${i}`),
+        );
+      } else {
+        messages.push(
+          MockDataGenerator.createAssistantMessage(`回答 ${i}`, `a${i}`),
+        );
+      }
+    }
+    return messages;
+  }
+
+  it("keeps small chats on the plain path (no virtualization)", async () => {
+    renderChatApp();
+    act(() => {
+      sendCommand("updateMessages", {
+        messages: buildMessages(10),
+      });
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("messages-container")).toBeInTheDocument(),
+    );
+    const container = screen.getByTestId("messages-container");
+    expect(container.classList.contains("messages-container--virtual")).toBe(
+      false,
+    );
+    expect(container.querySelector(".virtual-spacer")).toBeNull();
+    expect(container.querySelector(".virtual-row")).toBeNull();
+    // Plain path keeps the assistant-group wrapper.
+    expect(container.querySelector(".assistant-group")).not.toBeNull();
+  });
+
+  it("virtualizes large message lists with bounded DOM rows", async () => {
+    // jsdom has no layout: the virtualizer reads the viewport from
+    // offsetWidth/offsetHeight (always 0 in jsdom), so it would render no
+    // rows. Stub a fake viewport size so the window math produces rows.
+    const hDesc = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "offsetHeight",
+    );
+    const wDesc = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "offsetWidth",
+    );
+    try {
+      Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+        configurable: true,
+        get: () => 600,
+      });
+      Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+        configurable: true,
+        get: () => 800,
+      });
+      renderChatApp();
+      act(() => {
+        sendCommand("updateMessages", {
+          messages: buildMessages(250),
+        });
+      });
+      await waitFor(() =>
+        expect(
+          screen
+            .getByTestId("messages-container")
+            .querySelector(".virtual-spacer"),
+        ).not.toBeNull(),
+      );
+
+      const container = screen.getByTestId("messages-container");
+      expect(container.classList.contains("messages-container--virtual")).toBe(
+        true,
+      );
+
+      // In-flow spacer carries the total virtualized height; rows are the
+      // message-granularity virtual rows.
+      const spacer = container.querySelector(".virtual-spacer") as HTMLElement;
+      expect(spacer).not.toBeNull();
+      expect(parseFloat(spacer.style.height)).toBeGreaterThan(0);
+      const rows = container.querySelectorAll(".virtual-row");
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rows.length).toBeLessThan(100);
+
+      // The initial load pinned the viewport to the bottom; scroll back to the
+      // top so the run-start row enters the rendered window.
+      act(() => {
+        container.scrollTop = 0;
+        fireEvent.scroll(container);
+      });
+      await waitFor(() =>
+        expect(container.querySelector(".timeline-run--start")).not.toBeNull(),
+      );
+
+      // Timeline run classes are assigned to consecutive assistant messages.
+      expect(container.querySelector(".timeline-run--end")).not.toBeNull();
+      // Run-interior rows are flush (no bottom padding) so the timeline line
+      // stays continuous; standalone rows keep the 10px spacing.
+      const startRow = container.querySelector(
+        ".timeline-run--start",
+      ) as HTMLElement;
+      expect(startRow.style.paddingBottom).toBe("0px");
+    } finally {
+      if (hDesc)
+        Object.defineProperty(HTMLElement.prototype, "offsetHeight", hDesc);
+      if (wDesc)
+        Object.defineProperty(HTMLElement.prototype, "offsetWidth", wDesc);
+    }
+  });
+
+  it("falls back to the plain path when a large chat compacts below the threshold", async () => {
+    renderChatApp();
+    act(() => {
+      sendCommand("updateMessages", {
+        messages: buildMessages(250),
+      });
+    });
+    await waitFor(() =>
+      expect(
+        screen
+          .getByTestId("messages-container")
+          .querySelector(".virtual-spacer"),
+      ).not.toBeNull(),
+    );
+
+    // Compaction replaces the list with a small summary.
+    act(() => {
+      sendCommand("updateMessages", {
+        messages: [
+          MockDataGenerator.createUserMessage("继续", "u0"),
+          MockDataGenerator.createAssistantMessage("已压缩", "c1"),
+        ],
+      });
+    });
+    await waitFor(() => {
+      const container = screen.getByTestId("messages-container");
+      expect(container.classList.contains("messages-container--virtual")).toBe(
+        false,
+      );
+      expect(container.querySelector(".assistant-group")).not.toBeNull();
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,6 +305,9 @@ importers:
 
   packages/webview:
     dependencies:
+      '@tanstack/react-virtual':
+        specifier: ^3.14.10
+        version: 3.14.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@vscode/codicons':
         specifier: ^0.0.43
         version: 0.0.43
@@ -1768,6 +1771,15 @@ packages:
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
+
+  '@tanstack/react-virtual@3.14.10':
+    resolution: {integrity: sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.17.8':
+    resolution: {integrity: sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -7222,6 +7234,14 @@ snapshots:
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
+
+  '@tanstack/react-virtual@3.14.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.8
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@tanstack/virtual-core@3.17.8': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
Closes #1790 — Virtualize webview MessageList.

## What

Dual-branch virtualization with `@tanstack/react-virtual` (`VIRTUAL_SCROLL_THRESHOLD = 200`):
- **Small sessions (≤ 200 visible messages)**: keep the existing plain path byte-identical.
- **Large sessions**: virtualize rows (spacer carries the total height, only the viewport window + overscan is in the DOM).

Key implementation points:
- `useVirtualizer` with `anchorTo: "end"` + `followOnAppend: true` + `directDomUpdates` + `useAnimationFrameWithResizeObserver`; `getItemKey` = message id.
- **Sticky user-message bar** in the virtual branch: absolute overlay + backward scan over the data index (via `getVirtualItemForOffset`) + `scrollToIndex(..., { align: "center" })` jump — the old DOM scan is impossible once rows are unmounted.
- **Timeline continuity**: per-row `timeline-run--start/--end/--single` classes + padding-based spacing instead of the virtualizer `gap`, so the timeline line stays continuous through assistant runs.
- **Streaming bottom-pin fix**: the virtualizer's `wasAtEnd` compensation and the `scrollToEnd` effect fallback both run before the spacer height lands in the DOM, so the scroll is clamped by the stale `scrollHeight` (leaves a ~19px gap that never converges). `doScrollToBottom` now re-pins recursively over a few animation frames (only while the viewport is still near the bottom).

## Tests

- jsdom unit tests: `tests/webview/messageListVirtualization.test.tsx` (structure, spacer, bounded rows, run classes, compaction fallback).
- Playwright demo tests (real Chromium): `e2e/demo/virtual-message-list.demo.ts` — bounded DOM rows, spacer height, scroll round trip, sticky jump centering, streaming bottom-pin (settled dist ≤ 2 with a 200ms stability window; sticky text read after it stabilizes to avoid the measurement-convergence flip).
- Verified: webview unit 658/658, demo 57/57, type-check and lint clean. `--repeat-each=6` on the new demo file passes 18/18.