### PR TITLE
fix(webview): make sticky user message an absolute overlay

### DIFF
--- a/packages/webview/src/components/MessageList.tsx
+++ b/packages/webview/src/components/MessageList.tsx
@@ -502,28 +502,6 @@ export const MessageList = forwardRef<
     return () => container.removeEventListener("load", repin, true);
   }, [doScrollToBottom]);
 
-  // Re-pin once the sticky user message renders. The sticky bar is a normal
-  // in-flow child (position: sticky keeps its space), inserted as the first
-  // element AFTER the initial load's scroll ran — so it grows scrollHeight by
-  // its own height and pushes the true bottom ~30-70px below the parked
-  // viewport. That happens after the main effect (stickyMessage isn't one of
-  // its deps) and often before fonts.ready/load fire, leaving the viewport
-  // short of the real bottom. Re-pin here, gated on being near the bottom
-  // (the push is far smaller than the 300px threshold) and on the user not
-  // having scrolled up, so a sticky change while reading history is ignored.
-  // The virtualized branch renders the sticky bar as an overlay (no flow
-  // space), so nothing pushes the bottom there.
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container || !stickyMessage || virtualizedRef.current) return;
-    const isNearBottom =
-      container.scrollTop + container.clientHeight >=
-      container.scrollHeight - 300;
-    if (isNearBottom && !userScrolledUpRef.current) {
-      doScrollToBottom("auto");
-    }
-  }, [stickyMessage, doScrollToBottom]);
-
   // Plain path (small chats): group consecutive assistant messages into a
   // single .assistant-group wrapper so the timeline vertical line runs
   // continuously through all their dots. User messages break the timeline
@@ -592,9 +570,7 @@ export const MessageList = forwardRef<
       data-testid="messages-container"
     >
       {stickyMessage && (
-        <div
-          className={`sticky-user-wrapper${virtualized ? " sticky-user-wrapper--overlay" : ""}`}
-        >
+        <div className="sticky-user-wrapper">
           <div className="sticky-user-cap" />
           <div
             className="sticky-user-message"

--- a/packages/webview/src/styles/MessageList.css
+++ b/packages/webview/src/styles/MessageList.css
@@ -20,12 +20,16 @@
   position: relative;
 }
 
-/* Sticky user message pinned at the top of the viewport (设计稿 2248-9471) */
+/* Sticky user message overlaid at the top of the viewport (设计稿 2248-9471).
+   Absolute rather than sticky: the bar is an overlay and must not consume flow
+   space. In-flow it rendered only after the initial load's scroll ran and grew
+   scrollHeight by its own height, pushing the true bottom ~30-70px below the
+   parked viewport. */
 .sticky-user-wrapper {
-  position: sticky;
+  position: absolute;
   top: 0;
-  align-self: stretch;
-  margin-bottom: -10px;
+  left: 0;
+  right: 0;
   z-index: 20;
 }
 
@@ -152,15 +156,4 @@
 
 .messages-container--virtual .timeline-run--single .timeline-row::after {
   display: none;
-}
-
-/* Sticky user message as an overlay in the virtualized list: it must not
-   consume flow space — the virtualizer's offsets and the spacer height assume
-   the scroll content starts at the container's content box. */
-.sticky-user-wrapper--overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  margin-bottom: 0;
 }

--- a/packages/webview/tests/webview/autoScrollFollow.test.tsx
+++ b/packages/webview/tests/webview/autoScrollFollow.test.tsx
@@ -172,9 +172,9 @@ describe("auto-scroll follow during streaming", () => {
       await new Promise((r) => setTimeout(r, 50));
     });
 
-    // Park the viewport at the bottom. (The sticky user-message re-pin fires
-    // here and re-arms the programmatic-scroll flag — let it clear before the
-    // upward gesture below so that gesture is read as user intent.)
+    // Park the viewport at the bottom. (This also renders the sticky user
+    // message — let it settle before the upward gesture below so that gesture
+    // is read as user intent.)
     setGeometryAndScroll(1600, 2000);
     await act(async () => {
       await new Promise((r) => setTimeout(r, 50));

--- a/packages/webview/tests/webview/initialLoadScroll.test.tsx
+++ b/packages/webview/tests/webview/initialLoadScroll.test.tsx
@@ -125,9 +125,8 @@ describe("initial load scroll + async-content re-pin", () => {
     });
 
     // Genuine user scroll-up: scrollTop decreases with geometry unchanged.
-    // The first geometry set also makes the sticky user message render (and the
-    // sticky re-pin fires, re-arming the programmatic-scroll flag) — let that
-    // flag clear again so the upward scroll below is read as user intent.
+    // The first geometry set also makes the sticky user message render — let
+    // that settle so the upward scroll below is read as user intent.
     setGeometryAndScroll(1600, 2000);
     await act(async () => {
       await new Promise((r) => setTimeout(r, 50));
@@ -175,7 +174,7 @@ describe("initial load scroll + async-content re-pin", () => {
     expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "auto" });
   });
 
-  it("re-pins to the true bottom when the sticky user message appears after initial scroll", async () => {
+  it("does not scroll when the sticky user message appears (it's an overlay, no flow space)", async () => {
     const scrollIntoView = vi.fn();
     window.Element.prototype.scrollIntoView = scrollIntoView;
 
@@ -201,22 +200,19 @@ describe("initial load scroll + async-content re-pin", () => {
     scrollIntoView.mockClear();
 
     // Initial load has pinned the viewport at the true bottom: scrollTop is at
-    // the end of a (sticky-free) scrollHeight.
+    // the end of the scrollHeight.
     setGeometryAndScroll(1600, 2000);
 
     // The sticky user message appears once the viewport has scrolled past it
     // (jsdom: all offsetTop are 0 < scrollTop, so the last user message wins).
-    // In a real layout this inserts ~30-70px of in-flow height at the top of
-    // the list, pushing the true bottom below the viewport.
+    // The bar is absolutely positioned — an overlay that takes no flow space —
+    // so scrollHeight is untouched and the parked viewport stays at the true
+    // bottom. No re-pin scroll may fire (regression guard for the removed
+    // in-flow sticky bar, which used to grow scrollHeight ~30-70px).
     await waitFor(() =>
       expect(screen.getByTestId("sticky-user-message")).toBeInTheDocument(),
     );
 
-    // Simulate the scrollHeight growth the sticky bar causes in a real layout.
-    setGeometryAndScroll(1600, 2070);
-
-    // Without a re-pin the viewport stays parked ~70px short of the real
-    // bottom; the list must re-pin to the true bottom instead.
-    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "auto" });
+    expect(scrollIntoView).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 背景

会话恢复初始钉底后，plain 路径（< 200 条消息）的 sticky 用户消息条（`position: sticky` 保留文档流空间）在初始滚动之后才渲染，把 `scrollHeight` 撑高 ~30-70px，导致视口到不了真底部。之前的 re-pin 补丁 effect 只是掩盖问题；虚拟化路径本来就用 absolute overlay（无此问题）。

## 改动

- `MessageList.css`：`.sticky-user-wrapper` 从 `position: sticky` 改为 `position: absolute; top:0; left:0; right:0`（overlay，不占文档流），并删除已冗余的 `.sticky-user-wrapper--overlay` 修饰类（基础类已覆盖两分支）
- `MessageList.tsx`：删除 sticky re-pin 补丁 effect 及其注释；className 拼接简化为无条件 `sticky-user-wrapper`
- 测试：原 "sticky 出现后 re-pin" 测试反转为新契约（overlay 不触发滚动）；修正 2 处过期注释

## 验证

- 单测 658/658 + type-check + lint 全绿
- 真实 Chromium demo 冒烟（临时文件，未提交）：初始加载 bottomGap=0、bar 流空间影响 delta=0；运行时注入旧 sticky 样式复现 60px 撑高（对照组）
- 虚拟化路径回归：virtual-message-list demo 3/3 通过；全量 demo 套件 60/60