### PR TITLE
ci: decouple GUI releases from the npm line

### DIFF
--- a/.github/workflows/ci-jetbrains.yml
+++ b/.github/workflows/ci-jetbrains.yml
@@ -45,6 +45,35 @@ jobs:
         if: steps.filter.outputs.jetbrains == 'true'
         uses: gradle/actions/setup-gradle@v6
 
+      # The Gradle `classes` task depends on copyWebviewAssets + bundleCli,
+      # which read from packages/webview/dist and packages/code/dist — without
+      # them the build fails (PR #1852's check-jetbrains failure).
+      - uses: pnpm/action-setup@v5
+        if: steps.filter.outputs.jetbrains == 'true'
+
+      - name: Setup Node.js
+        if: steps.filter.outputs.jetbrains == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install deps
+        if: steps.filter.outputs.jetbrains == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Build agent-sdk dist
+        if: steps.filter.outputs.jetbrains == 'true'
+        run: pnpm -F wave-agent-sdk build
+
+      - name: Build webview dist
+        if: steps.filter.outputs.jetbrains == 'true'
+        run: pnpm -F wave-webview run compile -- --production
+
+      - name: Build wave-code dist
+        if: steps.filter.outputs.jetbrains == 'true'
+        run: pnpm -F wave-code build
+
       - name: Run tests
         if: steps.filter.outputs.jetbrains == 'true'
         run: ./packages/jetbrains/gradlew -p packages/jetbrains test --no-daemon

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,22 @@
 name: Publish Package
 
+# 发布按 tag 命名空间路由到独立构建线：
+#   v*                → npm 线（wave-agent-sdk / wave-code 发布到 npm + docs 资产 + GitHub Release 创建）
+#   wave-desktop@*    → 桌面端安装器
+#   wave-vscode@*     → VS Code 扩展 .vsix
+#   wave-jetbrains@*  → JetBrains 插件 .zip
+# 各 GUI 已内置 CLI（构建时从 packages/code 源码拷贝），发布不依赖 npm 上的 wave-code，
+# 因此可单独发布任一 GUI 而无需 bump/发布 CLI 的 npm 包。workflow_dispatch 手动触发时跑全量。
+# 各构建线生成 release notes 时对比同命名空间的上一个 tag（如 wave-desktop@1.1.2 → 1.2.0），
+# 与 npm 线的 v* 历史互不混用。
+
 on:
   push:
     tags:
       - "v*"
+      - "wave-desktop@*"
+      - "wave-vscode@*"
+      - "wave-jetbrains@*"
   workflow_dispatch:
 
 permissions:
@@ -12,6 +25,7 @@ permissions:
 
 jobs:
   publish:
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:
@@ -31,11 +45,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm test
+      # `-r` 自动跳过 private 包，实际只发布 wave-agent-sdk 与 wave-code。
       - run: pnpm -r publish --no-git-checks --provenance --access public
-
-      # --- VS Code extension (.vsix) ---
-      - name: Package .vsix
-        run: pnpm -F wave-vscode run package
 
       # --- Docs (docs-<version>.tar.gz) ---
       - name: Cache Playwright browsers
@@ -74,7 +85,6 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           files: |
-            packages/vscode/releases/*.vsix
             docs-*.tar.gz
           draft: false
           prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
@@ -83,13 +93,72 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # --- VS Code extension (.vsix) ---
+  build-vscode:
+    if: startsWith(github.ref, 'refs/tags/wave-vscode@') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+
+      - uses: pnpm/action-setup@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      # The extension bundles from wave-agent-sdk/dist and packages/webview/dist
+      # (see syncWebview + bundleCli), so build all three upstreams first.
+      - name: Build agent-sdk dist
+        run: pnpm -F wave-agent-sdk build
+
+      - name: Build webview dist
+        run: pnpm -F wave-webview run compile -- --production
+
+      # bundleCli (packages/vscode/scripts/bundleCli.mjs) ships the CLI's
+      # dist/bundle/wave.mjs into the extension, so build wave-code first.
+      - name: Build wave-code dist
+        run: pnpm -F wave-code build
+
+      - name: Package .vsix
+        run: pnpm -F wave-vscode run package
+
+      # Release notes compare against the previous wave-vscode@ tag (same
+      # namespace), so "last release" means the previous extension release —
+      # not the npm line's v* tags.
+      - name: Get previous tag
+        id: prev-tag
+        run: |
+          PREV_TAG=$(git tag --sort=-v:refname --list 'wave-vscode@*' | grep -v "^${GITHUB_REF_NAME}$" | head -1)
+          echo "tag=${PREV_TAG}" >> $GITHUB_OUTPUT
+
+      - name: Attach .vsix to GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: packages/vscode/releases/*.vsix
+          draft: false
+          generate_release_notes: true
+          previous_tag: ${{ steps.prev-tag.outputs.tag }}
+          prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # --- JetBrains plugin (.zip) ---
   # Builds the JB plugin distribution and attaches it to the same GitHub Release.
-  # Runs in parallel with `publish`; action-gh-release is idempotent (create-or-update)
-  # and merges assets, so both jobs targeting the same tag's release is safe. Only
-  # `publish` generates release notes / sets the body — this job adds the .zip asset
-  # and mirrors the prerelease flag in case it creates the release first.
+  # Runs in parallel with the other lines; action-gh-release is idempotent
+  # (create-or-update) and merges assets, so multiple jobs targeting the same
+  # tag's release is safe. Only `publish` generates release notes / sets the
+  # body — this job adds the .zip asset and mirrors the prerelease flag in case
+  # it creates the release first.
   build-jetbrains:
+    if: startsWith(github.ref, 'refs/tags/wave-jetbrains@') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:
@@ -131,16 +200,31 @@ jobs:
       - name: Build webview dist
         run: pnpm -F wave-webview run compile -- --production
 
+      # bundleCli (build.gradle.kts) ships dist/bundle/wave.mjs into the plugin
+      # resources, so build wave-code first (the Gradle `classes` task depends on it).
+      - name: Build wave-code dist
+        run: pnpm -F wave-code build
+
       - name: Run Gradle tests
         run: ./packages/jetbrains/gradlew -p packages/jetbrains test --no-daemon
 
       - name: Build plugin distribution (.zip)
         run: ./packages/jetbrains/gradlew -p packages/jetbrains buildPlugin --no-daemon
 
+      # Release notes compare against the previous wave-jetbrains@ tag.
+      - name: Get previous tag
+        id: prev-tag
+        run: |
+          PREV_TAG=$(git tag --sort=-v:refname --list 'wave-jetbrains@*' | grep -v "^${GITHUB_REF_NAME}$" | head -1)
+          echo "tag=${PREV_TAG}" >> $GITHUB_OUTPUT
+
       - name: Attach .zip to GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           files: packages/jetbrains/build/distributions/*.zip
+          draft: false
+          generate_release_notes: true
+          previous_tag: ${{ steps.prev-tag.outputs.tag }}
           prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -152,6 +236,7 @@ jobs:
   # via CSC_LINK/CSC_KEY_PASSWORD (p12) + App Store Connect API key secrets;
   # Windows builds remain unsigned (no code-signing cert configured).
   build-desktop:
+    if: startsWith(github.ref, 'refs/tags/wave-desktop@') || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -160,6 +245,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
 
       - uses: pnpm/action-setup@v5
 
@@ -216,6 +303,15 @@ jobs:
         if: runner.os == 'Windows'
         run: pnpm -F wave-desktop run dist -- --publish never
 
+      # Release notes compare against the previous wave-desktop@ tag. Both
+      # matrix runners compute the same value; only Windows generates the notes
+      # so create/update don't race on the release body.
+      - name: Get previous tag
+        id: prev-tag
+        run: |
+          PREV_TAG=$(git tag --sort=-v:refname --list 'wave-desktop@*' | grep -v "^${GITHUB_REF_NAME}$" | head -1)
+          echo "tag=${PREV_TAG}" >> $GITHUB_OUTPUT
+
       - name: Attach installers to GitHub Release
         uses: softprops/action-gh-release@v3
         with:
@@ -223,6 +319,9 @@ jobs:
             packages/desktop/release/*.dmg
             packages/desktop/release/*.zip
             packages/desktop/release/*.exe
+          draft: false
+          generate_release_notes: ${{ runner.os == 'Windows' }}
+          previous_tag: ${{ steps.prev-tag.outputs.tag }}
           prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -222,6 +222,15 @@ jobs:
       - name: Build plugin distribution (.zip)
         run: ./packages/jetbrains/gradlew -p packages/jetbrains buildPlugin --no-daemon
 
+      # --- JetBrains Marketplace ---
+      # publishPlugin uploads the distribution built above (plugin id
+      # com.wave.jetbrains read from plugin.xml). JetBrains has no OIDC
+      # equivalent, so this needs a permanent marketplace token.
+      # Same duplicate-version guard as the VS Code step: tag pushes only.
+      - name: Publish to JetBrains Marketplace
+        if: startsWith(github.ref, 'refs/tags/wave-jetbrains@')
+        run: ./packages/jetbrains/gradlew -p packages/jetbrains publishPlugin --no-daemon -PintellijPublishToken=${{ secrets.JETBRAINS_TOKEN }}
+
       # Release notes compare against the previous wave-jetbrains@ tag.
       - name: Get previous tag
         id: prev-tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -130,6 +130,17 @@ jobs:
       - name: Package .vsix
         run: pnpm -F wave-vscode run package
 
+      # --- VS Code Marketplace (PAT, transitional until OIDC lands) ---
+      # PATs retire 2026-12-01; the OIDC route (vsce --oidc / --azure-credential)
+      # is blocked on the Marketplace-side trusted publishing policy config, so
+      # use a PAT meanwhile. Tag pushes only — the marketplace rejects duplicate
+      # versions, so workflow_dispatch (asset re-upload) must not re-publish.
+      - name: Publish to VS Code Marketplace
+        if: startsWith(github.ref, 'refs/tags/wave-vscode@')
+        run: pnpm -F wave-vscode exec vsce publish --packagePath releases/*.vsix
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
       # Release notes compare against the previous wave-vscode@ tag (same
       # namespace), so "last release" means the previous extension release —
       # not the npm line's v* tags.

--- a/packages/jetbrains/build.gradle.kts
+++ b/packages/jetbrains/build.gradle.kts
@@ -47,6 +47,11 @@ intellijPlatform {
             untilBuild = provider { null }
         }
     }
+    publishing {
+        // Supplied as -PintellijPublishToken (GitHub Actions secret); orNull so
+        // local builds without the property still configure fine.
+        token = providers.gradleProperty("intellijPublishToken").orNull
+    }
 }
 
 // Copy webview assets (chat.js/chat.css) from packages/webview/dist into resources.

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,47 +1,54 @@
-import { execSync } from 'node:child_process';
-
-const type = process.argv[2] || 'patch';
+import { execSync } from "node:child_process";
 
 try {
   // 1. Ensure we are on main and up to date
-  console.log('Checking git status...');
-  const currentBranch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' }).trim();
-  if (currentBranch !== 'main' && currentBranch !== 'master') {
-    console.error('Error: You must be on main or master branch to run this script.');
+  console.log("Checking git status...");
+  const currentBranch = execSync("git rev-parse --abbrev-ref HEAD", {
+    encoding: "utf8",
+  }).trim();
+  if (currentBranch !== "main" && currentBranch !== "master") {
+    console.error(
+      "Error: You must be on main or master branch to run this script.",
+    );
     process.exit(1);
   }
-  
-  execSync('git pull origin main', { stdio: 'inherit' });
+
+  execSync("git pull origin main", { stdio: "inherit" });
 
   // 2. Create a temporary branch
   const tempBranch = `release-${type}-${Date.now()}`;
   console.log(`Creating temporary branch: ${tempBranch}`);
-  execSync(`git checkout -b ${tempBranch}`, { stdio: 'inherit' });
+  execSync(`git checkout -b ${tempBranch}`, { stdio: "inherit" });
 
-  // 3. Run the existing version script
-  console.log(`Running version.js ${type} all...`);
-  execSync(`node scripts/version.js ${type} all`, { stdio: 'inherit' });
+  // 3. Run the existing version script. No --package = npm 线锁步发布；
+  //    --package <name> = 单独发布指定 GUI（如 wave-desktop）。
+  console.log(`Running version.js ${process.argv.slice(2).join(" ")}...`);
+  execSync(`node scripts/version.js ${process.argv.slice(2).join(" ")}`, {
+    stdio: "inherit",
+  });
 
   // 4. Push branch and tag
-  console.log('Pushing branch and tags...');
-  execSync('git push -u origin HEAD --follow-tags', { stdio: 'inherit' });
+  console.log("Pushing branch and tags...");
+  execSync("git push -u origin HEAD --follow-tags", { stdio: "inherit" });
 
   // 5. Create PR and set auto-merge
-  console.log('Creating Pull Request and enabling auto-merge...');
-  execSync('gh pr create --fill', { stdio: 'inherit' });
-  execSync('gh pr merge --auto --rebase', { stdio: 'inherit' });
+  console.log("Creating Pull Request and enabling auto-merge...");
+  execSync("gh pr create --fill", { stdio: "inherit" });
+  execSync("gh pr merge --auto --rebase", { stdio: "inherit" });
 
   // 6. Switch back to main and cleanup
-  console.log('Cleaning up...');
-  execSync('git checkout main', { stdio: 'inherit' });
-  execSync(`git branch -D ${tempBranch}`, { stdio: 'inherit' });
+  console.log("Cleaning up...");
+  execSync("git checkout main", { stdio: "inherit" });
+  execSync(`git branch -D ${tempBranch}`, { stdio: "inherit" });
 
-  console.log('\nDone! Your release PR has been created and set to auto-merge once CI passes.');
+  console.log(
+    "\nDone! Your release PR has been created and set to auto-merge once CI passes.",
+  );
 } catch (error) {
-  console.error('\nRelease failed:', error.message);
+  console.error("\nRelease failed:", error.message);
   // Try to get back to main if we failed
   try {
-    execSync('git checkout main', { stdio: 'ignore' });
+    execSync("git checkout main", { stdio: "ignore" });
   } catch (e) {}
   process.exit(1);
 }

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,18 +1,34 @@
-import fs from 'node:fs';
-import path from 'node:path';
-import { execSync } from 'node:child_process';
-import { pathToFileURL } from 'node:url';
+import fs from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
-const type = process.argv[2] || 'patch';
-const isAll = process.argv[3] === 'all';
+// GUI 包已内置 CLI，独立发版，不参与 npm 线锁步。
+const GUI_PACKAGES = new Set(["wave-desktop", "wave-vscode", "wave-jetbrains"]);
 
-export function bumpVersion(pkgPath) {
-  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-  const oldVersion = pkg.version;
+const type = process.argv[2] || "patch";
+
+// 解析 --package 后的包名列表（可多个）。
+function parsePackageArgs(argv) {
+  const out = [];
+  let collecting = false;
+  for (const arg of argv) {
+    if (arg === "--package") {
+      collecting = true;
+    } else if (arg.startsWith("-")) {
+      collecting = false;
+    } else if (collecting) {
+      out.push(arg);
+    }
+  }
+  return out;
+}
+
+// Compute the next version for a given bump type, or null for an invalid format.
+function nextVersion(oldVersion) {
   const versionMatch = oldVersion.match(/^(\d+)\.(\d+)\.(\d+)(.*)$/);
-
   if (!versionMatch) {
-    console.error(`Invalid version format in ${pkgPath}: ${oldVersion}`);
+    console.error(`Invalid version format: ${oldVersion}`);
     return null;
   }
 
@@ -23,102 +39,170 @@ export function bumpVersion(pkgPath) {
   ];
   const suffix = versionMatch[4];
 
-  if (type === 'major') {
+  if (type === "major") {
     parts[0]++;
     parts[1] = 0;
     parts[2] = 0;
-  } else if (type === 'minor') {
+  } else if (type === "minor") {
     parts[1]++;
     parts[2] = 0;
-  } else if (type === 'patch') {
+  } else if (type === "patch") {
     parts[2]++;
   } else {
     console.error(`Invalid version type: ${type}. Use major, minor, or patch.`);
     process.exit(1);
   }
 
-  const newVersion = parts.join('.') + (type === 'patch' ? suffix : '');
+  return parts.join(".") + (type === "patch" ? suffix : "");
+}
+
+export function bumpVersion(pkgPath) {
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+  const newVersion = nextVersion(pkg.version);
+  if (newVersion === null) {
+    return null;
+  }
   return setVersion(pkgPath, newVersion);
 }
 
 // Overwrite a package's version to an explicit target (used to keep all
 // packages in the monorepo on the same version as the root).
 export function setVersion(pkgPath, newVersion) {
-  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
   const oldVersion = pkg.version;
   if (oldVersion === newVersion) {
     return null;
   }
   pkg.version = newVersion;
-  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
   console.log(`${pkg.name}: ${oldVersion} -> ${newVersion}`);
   return { name: pkg.name, version: newVersion, path: pkgPath };
 }
 
 export function bumpGradleProperties(propsPath, newVersion) {
-  const content = fs.readFileSync(propsPath, 'utf8');
+  const content = fs.readFileSync(propsPath, "utf8");
   const oldMatch = content.match(/^pluginVersion=(.*)$/m);
-  const oldVersion = oldMatch ? oldMatch[1] : '';
-  const replaced = content.replace(/^pluginVersion=.*$/m, `pluginVersion=${newVersion}`);
+  const oldVersion = oldMatch ? oldMatch[1] : "";
+  const replaced = content.replace(
+    /^pluginVersion=.*$/m,
+    `pluginVersion=${newVersion}`,
+  );
   if (replaced !== content) {
     fs.writeFileSync(propsPath, replaced);
   }
   console.log(`wave-jetbrains: ${oldVersion} -> ${newVersion}`);
-  return { name: 'wave-jetbrains', version: newVersion, path: propsPath };
+  return { name: "wave-jetbrains", version: newVersion, path: propsPath };
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const results = [];
-  if (isAll) {
-    // Bump root first to determine the target version for the whole monorepo.
-    const rootPkg = bumpVersion(path.resolve(process.cwd(), 'package.json'));
-    if (rootPkg) results.push(rootPkg);
+// Bump jetbrains by one step based on its current pluginVersion.
+export function bumpGradleVersion(propsPath) {
+  const content = fs.readFileSync(propsPath, "utf8");
+  const match = content.match(/^pluginVersion=(.*)$/m);
+  if (!match) {
+    console.error(`Missing pluginVersion in ${propsPath}`);
+    return null;
+  }
+  const newVersion = nextVersion(match[1]);
+  if (newVersion === null) {
+    return null;
+  }
+  return bumpGradleProperties(propsPath, newVersion);
+}
 
-    // Sync every sub-package to the root's new version so the monorepo stays
-    // on a single consistent version (independent bumps drift when packages
-    // are added/removed mid-release).
-    const packagesDir = path.resolve(process.cwd(), 'packages');
-    const dirs = fs.readdirSync(packagesDir);
-    for (const dir of dirs) {
-      const pkgPath = path.resolve(packagesDir, dir, 'package.json');
-      if (fs.existsSync(pkgPath)) {
-        const res = setVersion(pkgPath, rootPkg.version);
-        if (res) results.push(res);
-      } else {
-        // Packages without package.json (e.g. jetbrains) may have a gradle.properties
-        // with a pluginVersion= field that must stay in sync with the monorepo version.
-        const propsPath = path.resolve(packagesDir, dir, 'gradle.properties');
-        if (fs.existsSync(propsPath)) {
-          const res = bumpGradleProperties(propsPath, rootPkg.version);
-          if (res) results.push(res);
-        }
-      }
+// Build a name -> { path, kind } map for every package in packages/.
+// Packages without package.json (e.g. jetbrains) use gradle.properties.
+function discoverPackages() {
+  const packagesDir = path.resolve(process.cwd(), "packages");
+  const map = new Map();
+  for (const dir of fs.readdirSync(packagesDir)) {
+    const pkgPath = path.resolve(packagesDir, dir, "package.json");
+    const propsPath = path.resolve(packagesDir, dir, "gradle.properties");
+    if (fs.existsSync(pkgPath)) {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+      map.set(pkg.name, { path: pkgPath, kind: "pkg" });
+    } else if (fs.existsSync(propsPath)) {
+      map.set("wave-jetbrains", { path: propsPath, kind: "gradle" });
+    }
+  }
+  return { map, packagesDir };
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  const packageArgs = parsePackageArgs(process.argv.slice(3));
+  const results = [];
+  const { map, packagesDir } = discoverPackages();
+
+  if (packageArgs.length === 0) {
+    // npm 线锁步：bump root 确定目标版本，其余非 GUI 包同步到该版本。
+    const rootPkg = bumpVersion(path.resolve(process.cwd(), "package.json"));
+    if (!rootPkg) {
+      console.error("Failed to bump root package version.");
+      process.exit(1);
+    }
+    results.push(rootPkg);
+
+    for (const [name, target] of map) {
+      if (GUI_PACKAGES.has(name)) continue;
+      const res =
+        target.kind === "pkg"
+          ? setVersion(target.path, rootPkg.version)
+          : bumpGradleProperties(target.path, rootPkg.version);
+      if (res) results.push(res);
     }
   } else {
-    const res = bumpVersion(path.resolve(process.cwd(), 'package.json'));
-    if (res) results.push(res);
+    // GUI 独立发布：各自基于当前版本 bump，版本互不联动。
+    for (const name of packageArgs) {
+      const target = map.get(name);
+      if (!target) {
+        console.error(
+          `Unknown package: ${name}. Available: ${[...map.keys()].join(", ")}`,
+        );
+        process.exit(1);
+      }
+      const res =
+        target.kind === "pkg"
+          ? bumpVersion(target.path)
+          : bumpGradleVersion(target.path);
+      if (res) results.push(res);
+    }
   }
 
   if (results.length > 0) {
     try {
-      execSync('git rev-parse --is-inside-work-tree', { stdio: 'ignore' });
+      execSync("git rev-parse --is-inside-work-tree", { stdio: "ignore" });
       for (const res of results) {
-        execSync(`git add ${res.path}`, { stdio: 'inherit' });
+        execSync(`git add ${res.path}`, { stdio: "inherit" });
       }
 
-      const mainPkg = results[0];
-      const tagName = isAll ? `v${mainPkg.version}` : `v${mainPkg.version}-${mainPkg.name}`;
-      const commitMsg = isAll
-        ? `chore: bump all versions to v${mainPkg.version}`
-        : `chore: bump ${mainPkg.name} to v${mainPkg.version}`;
+      // npm 线打 vX.Y.Z；GUI 独立打 wave-<name>@X.Y.Z（name 已含 wave- 前缀，多包时各打各的）。
+      const tags =
+        packageArgs.length === 0
+          ? [`v${results[0].version}`]
+          : results.map((r) => `${r.name}@${r.version}`);
+      const commitMsg =
+        packageArgs.length === 0
+          ? `chore: bump all versions to v${results[0].version}`
+          : `chore: bump ${results.map((r) => `${r.name} to v${r.version}`).join(", ")}`;
 
-      execSync(`git commit -m "${commitMsg}" --no-verify`, { stdio: 'inherit' });
+      execSync(`git commit -m "${commitMsg}" --no-verify`, {
+        stdio: "inherit",
+      });
 
-      execSync(`git tag -a ${tagName} -m "${commitMsg.replace(/"/g, '\\"')}"`, { stdio: 'inherit' });
-      console.log(`Created tag: ${tagName}`);
-      console.log(`\nTo publish this version, run:\n  git push origin ${tagName}\n`);
+      for (const tagName of tags) {
+        execSync(
+          `git tag -a ${tagName} -m "${commitMsg.replace(/"/g, '\\"')}"`,
+          { stdio: "inherit" },
+        );
+        console.log(`Created tag: ${tagName}`);
+      }
+      console.log(
+        `\nTo publish this version, run:\n  git push origin ${tags.join(" ")}\n`,
+      );
     } catch (error) {
-      console.error('Git operation failed:', error.message);
+      console.error("Git operation failed:", error.message);
       process.exit(1);
     }
   }


### PR DESCRIPTION
## 背景

desktop / vscode / jetbrains 已各自 bundle CLI（构建时从 packages/code 源码拷贝），GUI 发布不再需要 wave-code 的 npm 新版本。原发布链路是「全包锁步版本 + 单 `v*` tag 全量发布」，改任一包都会同步 bump 全部包并重跑全部构建线。

## 改动

**版本管理（scripts/version.js + scripts/release.js）**
- 无参 = npm 线锁步：agent-sdk / webview / webview-fixtures / code + root，tag `vX.Y.Z`
- `--package <name>` = GUI 独立自增（desktop / vscode / jetbrains），tag `wave-<name>@X.Y.Z`；jetbrains 无 package.json，版本走 gradle.properties（新增 bumpGradleVersion）
- 多包支持：`--package wave-desktop wave-vscode` 各打各的 tag

**发布管线（publish.yml）**
- 4 条构建线按 tag 路由：`v*` → 仅 npm 线（agent-sdk/code 发 npm + docs 资产，`pnpm -r publish` 自动跳过 private 包）；`wave-desktop@*` / `wave-vscode@*` / `wave-jetbrains@*` → 各自产物挂 GitHub Release
- desktop / vscode 不再 publish npm（均为 private，无人消费）
- 各 GUI job 生成 release notes：对比同命名空间上一个 tag（如 wave-desktop@1.1.2 → 1.1.3），与 npm 线 v* 历史隔离；desktop matrix 仅 Windows runner 生成避免竞争
- build-vscode / build-desktop 补 `fetch-tags: true`

**CI 修复（ci-jetbrains.yml）**
- 现存 bug：PR #1852 的 check-jetbrains 为 FAILURE 仍被合并——Gradle `classes` 依赖 bundleCli/copyWebviewAssets，需要 packages/code 与 packages/webview 的 dist，但 CI 未装 node/pnpm 也未构建上游。已补 node/pnpm/install + agent-sdk/webview/code 构建

## 验证

- version.test.mjs 5/5；YAML 解析通过
- 实测 4 种模式（npm 线锁步 / 单包 / 多包 / jetbrains）后清理恢复，工作区干净
- 发布命令：`pnpm release:patch`（npm 线）、`pnpm release:patch -- --package wave-desktop`（GUI 独立）