### PR TITLE
fix(jetbrains): replace internal PluginManager.findEnabledPlugin with public API

### DIFF
--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
@@ -2,6 +2,7 @@ package com.wave.jetbrains.session
 
 import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.wave.jetbrains.WaveBackendService
 import com.wave.jetbrains.config.WavePluginService
@@ -677,7 +678,7 @@ class MessageHandler(
         session.agent?.sessionCwd ?: session.agent?.workingDirectory ?: project.basePath ?: System.getProperty("user.dir")
 
     private fun pluginVersion(): String =
-        PluginManagerCore.getPlugin(WavePluginService::class.java)?.version ?: ""
+        PluginManagerCore.getPlugin(PluginId.findId("com.wave.jetbrains"))?.version ?: ""
 
     /** Decode webview file payload → bytes. data may be a base64/data-url string (best effort). */
     private fun decodeFileData(data: JsonElement?): ByteArray {

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
@@ -1,8 +1,7 @@
 package com.wave.jetbrains.session
 
-import com.intellij.ide.plugins.PluginManager
+import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.wave.jetbrains.WaveBackendService
 import com.wave.jetbrains.config.WavePluginService
@@ -678,7 +677,7 @@ class MessageHandler(
         session.agent?.sessionCwd ?: session.agent?.workingDirectory ?: project.basePath ?: System.getProperty("user.dir")
 
     private fun pluginVersion(): String =
-        PluginManager.getInstance().findEnabledPlugin(PluginId.getId("com.wave.jetbrains"))?.version ?: ""
+        PluginManagerCore.getPlugin(WavePluginService::class.java)?.version ?: ""
 
     /** Decode webview file payload → bytes. data may be a base64/data-url string (best effort). */
     private fun decodeFileData(data: JsonElement?): ByteArray {

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
@@ -1,8 +1,7 @@
 package com.wave.jetbrains.session
 
-import com.intellij.ide.plugins.PluginManager
+import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.wave.jetbrains.WaveBackendService
 import com.wave.jetbrains.config.WavePluginService
@@ -537,7 +536,7 @@ class WaveSession(
 
     companion object {
         fun pluginVersion(): String =
-            PluginManager.getInstance().findEnabledPlugin(PluginId.getId("com.wave.jetbrains"))?.version ?: ""
+            PluginManagerCore.getPlugin(WavePluginService::class.java)?.version ?: ""
 
         fun parseHeaders(text: String): JsonObject? {
             if (text.isBlank()) return null

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
@@ -2,6 +2,7 @@ package com.wave.jetbrains.session
 
 import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.wave.jetbrains.WaveBackendService
 import com.wave.jetbrains.config.WavePluginService
@@ -536,7 +537,7 @@ class WaveSession(
 
     companion object {
         fun pluginVersion(): String =
-            PluginManagerCore.getPlugin(WavePluginService::class.java)?.version ?: ""
+            PluginManagerCore.getPlugin(PluginId.findId("com.wave.jetbrains"))?.version ?: ""
 
         fun parseHeaders(text: String): JsonObject? {
             if (text.isBlank()) return null


### PR DESCRIPTION
JetBrains plugin verification flagged 2 internal API usages: `PluginManager.findEnabledPlugin(PluginId)` (WaveSession.kt, MessageHandler.kt).

Replaced with the public `PluginManagerCore.getPlugin(PluginId)` overload, using the non-deprecated `PluginId.findId("com.wave.jetbrains")` factory. No internal or deprecated platform API remains in either file.

- WaveSession.kt:539 `pluginVersion()`
- MessageHandler.kt:680 `pluginVersion()`

Both call sites return the same plugin version string; behavior unchanged. Verified with `./gradlew compileKotlin` (BUILD SUCCESSFUL) against IC-2024.2.