### PR TITLE
fix(desktop): ack worktree creation before the first message's AI turn

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -2529,6 +2529,15 @@ export class DesktopHost {
     paneId?: string,
   ): Promise<void> {
     const h = host ?? this.currentHost;
+    // Success and failure both end the "worktree 创建中" state in the webview
+    // (failure surfaces an error message / toast instead). One-shot so the
+    // success path can ack early without the finally duplicating it.
+    let acked = false;
+    const ackCreated = (): void => {
+      if (acked) return;
+      acked = true;
+      this.postMessage({ command: "desktopWorktreeCreated", paneId });
+    };
     try {
       let result: {
         name: string;
@@ -2575,13 +2584,19 @@ export class DesktopHost {
         });
         return;
       }
+      // Ack now — the worktree exists and the session is live in the pane.
+      // Forwarding the first message must not delay it: the sendMessage RPC
+      // resolves only when the whole AI turn finishes (InteractionService
+      // awaits sendAIMessage), so awaiting it first would keep the webview's
+      // "worktree 创建中…" indicator stuck for the entire first response —
+      // and a pane switched to a new session meanwhile inherits that stale
+      // state until the ack finally lands.
+      ackCreated();
       if (text) {
         await this.handleSendMessage(text, images);
       }
     } finally {
-      // Success and failure both end the "worktree 创建中" state in the webview
-      // (failure surfaces an error message / toast instead).
-      this.postMessage({ command: "desktopWorktreeCreated", paneId });
+      ackCreated();
     }
   }
 

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -3167,6 +3167,55 @@ describe("worktree flow", () => {
     );
   });
 
+  it("desktopCreateWorktree acks before the first message's AI turn finishes", async () => {
+    const { host, sent } = await readyHost();
+    h.worktreeResult = worktree;
+    h.existingPaths.add(worktree.path);
+    let resolveInit!: () => void;
+    h.initializeGate = new Promise<void>((r) => {
+      resolveInit = r;
+    });
+
+    const done = host.handleWebviewMessage({
+      command: "desktopCreateWorktree",
+      workdir: "/work/a",
+      baseBranch: "main",
+      text: "hello worktree",
+    });
+    // Pause agent initialization so we can swap in a sendMessage that stays
+    // open — mirroring the real RPC, which resolves only when the whole AI
+    // turn finishes (InteractionService awaits sendAIMessage).
+    await vi.waitFor(() => {
+      expect(h.agentInstances).toHaveLength(2);
+    });
+    const spawned = lastAgent();
+    let releaseSend!: () => void;
+    const sendHeld = new Promise<void>((r) => {
+      releaseSend = r;
+    });
+    spawned.sendMessage = vi.fn(async () => {
+      await sendHeld;
+    });
+
+    h.initializeGate = null;
+    resolveInit();
+    // The worktree is created and the session is live — the ack must already
+    // be out even though the forwarded first message is still in flight.
+    await vi.waitFor(() => {
+      expect(sent("desktopWorktreeCreated").at(-1)).toMatchObject({
+        paneId: "pane-1",
+      });
+    });
+    expect(spawned.sendMessage).toHaveBeenCalledWith(
+      "hello worktree",
+      undefined,
+      false,
+    );
+
+    releaseSend();
+    await done;
+  });
+
   it("desktopCreateWorktree on an existing worktree (isNew: false) does not mark it new", async () => {
     const { host } = await readyHost();
     h.worktreeResult = { ...worktree, isNew: false };


### PR DESCRIPTION
## 问题

桌面端勾选 worktree 复选框发送第一条消息后，"worktree 创建中…"指示器会一直显示到**整个 AI 响应结束**。此时从该 worktree 对话切换到新对话，新对话界面继承残留的 `worktreeCreating` 状态，且 ack 迟迟不来，表现为"一直显示 worktree 创建中"。

## 根因

`handleCreateWorktree` 中 ack（`desktopWorktreeCreated`）放在 `finally` 里，而成功路径先 `await this.handleSendMessage(text, images)`。`sendMessage` RPC 的语义是**等整个 AI turn 完成才 resolve**（agentBridge → `InteractionService.sendMessage` → `await aiManager.sendAIMessage()`，见 daemon/commands.ts 注释），所以 ack 被第一条消息的完整响应阻塞，worktree 早已建好但指示器不消失。

## 修复

ack 提前到 `spawnAgent` + `activateAgentInPane` 之后（worktree 已建好、会话已就绪）立即发出；第一条消息改为在其后转发。失败路径仍发 ack（one-shot，避免 finally 重复）。

## 验证

- 新增测试：模拟 sendMessage 挂起（AI turn 进行中），断言 `desktopWorktreeCreated` ack 已发出
- `desktopHost.test.ts` 258/258 通过；desktop type-check 通过