### PR TITLE
fix(webview): restore sticky user message pinning broken by absolute overlay

### DIFF
--- a/packages/webview/src/styles/MessageList.css
+++ b/packages/webview/src/styles/MessageList.css
@@ -20,16 +20,27 @@
   position: relative;
 }
 
-/* Sticky user message overlaid at the top of the viewport (设计稿 2248-9471).
-   Absolute rather than sticky: the bar is an overlay and must not consume flow
-   space. In-flow it rendered only after the initial load's scroll ran and grew
-   scrollHeight by its own height, pushing the true bottom ~30-70px below the
-   parked viewport. */
+/* Sticky user message pinned at the top of the viewport (设计稿 2248-9471).
+   position: sticky (not absolute) so the bar stays pinned to the top of the
+   scrollport while the user scrolls history — an absolute bar inside a
+   scrolling container moves away with the content and never sticks (#1855
+   regression). height: 0 keeps the bar an overlay: it consumes no flow space
+   (sticky keeps its flow space by default), so the initial load's pin-to-bottom
+   scroll is not pushed off by the bar's own height. The cap/card/scrim are
+   in-flow children overflowing the zero-height wrapper (overflow visible), so
+   the bar renders below the wrapper's top edge.
+   margin-bottom: -10px cancels the .messages-container flex gap on the plain
+   branch (gap is 0 on the virtualized branch, overridden below), so
+   mounting/unmounting the bar never shifts the message list. */
 .sticky-user-wrapper {
-  position: absolute;
+  position: sticky;
   top: 0;
-  left: 0;
-  right: 0;
+  height: 0;
+  margin-bottom: -10px;
+  /* Stretch across the cross axis (the container is flex column with
+     align-items: flex-start) so the bar spans the list width like the old
+     absolute left/right: 0. */
+  align-self: stretch;
   z-index: 20;
 }
 
@@ -103,6 +114,12 @@
    the flex gap would add extra space around the spacer/compaction hint. */
 .messages-container--virtual {
   gap: 0;
+}
+
+/* No flex gap to cancel on the virtualized branch (gap: 0 above); a negative
+   margin would pull the virtualizer's spacer 10px up out of the container. */
+.messages-container--virtual .sticky-user-wrapper {
+  margin-bottom: 0;
 }
 
 .virtual-spacer {


### PR DESCRIPTION
## 问题

桌面端「上一条用户消息吸顶条」不再吸顶（滚动浏览历史时顶部不再固定最近一条滚出视口的用户消息）。

## 根因

#1855 (b4a95f6d) 为修复「吸顶条占用 flow 空间导致初始加载钉底偏差」，把 `.sticky-user-wrapper` 从 `position: sticky` 改成了 `position: absolute`。

但 absolute 定位元素在滚动容器内会随内容一起滚出视口，**永远不会吸顶**。当时验证只测了底部 gap（absolute 不再顶高底部），没有验证滚动时吸顶条是否固定在视口顶部；demo 测试的 `waitForSelector` 只检查 DOM 存在、不检查视口内可见性，因此回归被掩盖，安装版 1.1.2 已含此回归。

## 修复

`position: sticky` + `height: 0`：

- `sticky` 恢复滚动吸顶语义（吸顶条固定在 scrollport 顶部）
- `height: 0` 保留 #1855 的 overlay 目标（sticky 默认占 flow 空间，零高度 wrapper 不占），cap/card/scrim 作为 in-flow 子元素从零高度 wrapper 溢出显示
- `margin-bottom: -10px` 抵消 plain 分支 flex gap，吸顶条挂载/卸载不引起消息列表位移；虚拟化分支（gap: 0）覆盖回 0
- `align-self: stretch` 恢复横跨列表宽度（absolute 版用 left/right: 0）

## 验证

- webview demo 3/3 通过（含此前失败的「点击吸顶条跳转」——吸顶条现在真实固定在视口内可点击）
- webview 单元测试 658/658、type-check、lint 通过
- 根因确认：安装版 app.asar 内联 CSS 为 `position: absolute`，与 main 一致