### PR TITLE
chore: stop enabling typescript-lsp plugin in repo settings

### DIFF
--- a/.wave/settings.json
+++ b/.wave/settings.json
@@ -33,7 +33,6 @@
     ]
   },
   "enabledPlugins": {
-    "typescript-lsp@wave-plugins-official": true,
     "sdd@builtin": true
   },
   "hooks": {


### PR DESCRIPTION
Remove the `typescript-lsp@wave-plugins-official` entry from `.wave/settings.json` `enabledPlugins` — this repo no longer uses the LSP plugin. The LSP feature code/docs remain untouched; only the repo-level enablement config is dropped. Plugin was uninstalled via `wave plugin uninstall` (installed_plugins.json cleaned).