### PR TITLE
fix(webview): route write tool preview open through host openFile handler

### DIFF
--- a/packages/webview/src/components/Message.tsx
+++ b/packages/webview/src/components/Message.tsx
@@ -421,6 +421,7 @@ export const Message: React.FC<MessageProps> = React.memo(
                 toolBlock={toolBlock}
                 vscode={props.vscode}
                 workdir={workdir}
+                onOpenFile={openFile}
               />
             )}
             {errorContent && toolHeader}

--- a/packages/webview/src/components/WriteToolPreview.tsx
+++ b/packages/webview/src/components/WriteToolPreview.tsx
@@ -8,12 +8,16 @@ interface WriteToolPreviewProps {
   toolBlock: ToolBlock;
   vscode: { postMessage: (message: unknown) => void };
   workdir?: string;
+  /** Host-routed open (desktop opens its file panel via ChatApp.handleOpenFile);
+   *  falls back to the plain openFile RPC when absent (IDE hosts). */
+  onOpenFile?: (path: string) => void;
 }
 
 export const WriteToolPreview: React.FC<WriteToolPreviewProps> = ({
   toolBlock,
   vscode,
   workdir,
+  onOpenFile,
 }) => {
   let filePath = "";
   let content: string | null = null;
@@ -29,7 +33,11 @@ export const WriteToolPreview: React.FC<WriteToolPreviewProps> = ({
 
   const openFile = () => {
     if (filePath) {
-      vscode.postMessage({ command: "openFile", path: filePath });
+      if (onOpenFile) {
+        onOpenFile(filePath);
+      } else {
+        vscode.postMessage({ command: "openFile", path: filePath });
+      }
     }
   };
 

--- a/packages/webview/tests/webview/writeToolPreview.test.tsx
+++ b/packages/webview/tests/webview/writeToolPreview.test.tsx
@@ -62,6 +62,33 @@ describe("WriteToolPreview", () => {
     });
   });
 
+  it("routes through onOpenFile when provided (desktop file panel)", async () => {
+    const user = userEvent.setup();
+    const vscode = { postMessage: vi.fn() };
+    const onOpenFile = vi.fn();
+    const block = makeBlock(
+      JSON.stringify({ file_path: "/a/b.md", content: "l1\nl2\nl3" }),
+    );
+    const { getByTestId, container } = render(
+      <WriteToolPreview
+        toolBlock={block}
+        vscode={vscode}
+        onOpenFile={onOpenFile}
+      />,
+    );
+
+    await user.click(getByTestId("write-preview-open"));
+    expect(onOpenFile).toHaveBeenCalledWith("/a/b.md");
+    expect(vscode.postMessage).not.toHaveBeenCalled();
+
+    onOpenFile.mockClear();
+    await user.click(
+      container.querySelector(".write-tool-path") as HTMLElement,
+    );
+    expect(onOpenFile).toHaveBeenCalledWith("/a/b.md");
+    expect(vscode.postMessage).not.toHaveBeenCalled();
+  });
+
   it("fires openFile when the path is clicked", async () => {
     const user = userEvent.setup();
     const vscode = { postMessage: vi.fn() };


### PR DESCRIPTION
## 问题

桌面端 write tool 输出区域右上角的悬停打开按钮（以及 header 路径点击）点击后无效果，期望打开文件。

## 根因

`WriteToolPreview` 的打开按钮/路径点击直接 `vscode.postMessage({ command: "openFile" })`，绕过了 `ChatApp.handleOpenFile`。桌面端正是该 handler 负责先 `tryOpenPanel("file")` 显示文件面板、再带 `paneId` 请求宿主读文件；直接 post 后宿主虽回 `desktopFileContent`，但面板从未打开，表现为点击无效。分屏场景下还会因缺少 `paneId` 路由到错误面板。

## 修复

- `WriteToolPreview` 新增 `onOpenFile` prop，优先走它；无则回退到原 `vscode.postMessage`（IDE 宿主行为不变）
- `Message` 传入路由后的 `openFile`（即 `props.onOpenFile` → 桌面文件面板 / IDE RPC）
- 新增单测：`onOpenFile` 存在时按钮与路径点击均走它，且不再直接 postMessage

## 验证

- writeToolPreview 单测 5/5 通过
- 全仓 type-check 通过（pre-push hook）
- `pnpm -F wave-webview build` 已重建并同步 vsce/jetbrains