### PR TITLE
fix(webview): scroll long session to bottom on session switch

### DIFF
--- a/packages/webview/e2e/longchat-switch.e2e.ts
+++ b/packages/webview/e2e/longchat-switch.e2e.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "./utils/webviewTestHarness.js";
+import { MessageInjector } from "./utils/messageInjector.js";
+import { MockDataGenerator } from "./fixtures/mockData.js";
+import type { Message } from "wave-agent-sdk";
+
+// 220 messages (> VIRTUAL_SCROLL_THRESHOLD=200 → virtualized branch),
+// ending on an assistant message (isUserMessage=false).
+const longMessages: Message[] = [];
+for (let i = 0; i < 110; i++) {
+  longMessages.push(
+    MockDataGenerator.createUserMessage(`user message ${i}`, `u-${i}`),
+    MockDataGenerator.createAssistantMessage(`assistant reply ${i}`, `a-${i}`),
+  );
+}
+const shortMessages = longMessages.slice(0, 20);
+
+test.describe("session switch into long chat scrolls to bottom", () => {
+  test("switch after user scrolled up in the previous session", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [],
+      isStreaming: false,
+      sessions: [],
+      isAuthenticated: true,
+      configurationData: {
+        apiKey: "sk-ant-api03-test",
+        baseURL: "https://api.anthropic.com/v1",
+        model: "claude-sonnet-4-20250514",
+      },
+      permissionMode: "default",
+    });
+
+    // Phase 1: a short session loads and lands at the bottom.
+    await injector.simulateExtensionMessage("updateCurrentSession", {
+      session: { id: "sess-short" },
+    });
+    await injector.updateMessages(shortMessages);
+    await webviewPage.waitForTimeout(400);
+
+    // The user scrolls up in the current session (reading history) — this
+    // must NOT leak into the next session's load.
+    await webviewPage.evaluate(() => {
+      const c = document.getElementById("messagesContainer")!;
+      c.scrollTop = 100;
+      c.dispatchEvent(new Event("scroll"));
+    });
+    await webviewPage.waitForTimeout(100);
+
+    // Phase 2: user clicks the long session -> session id changes, then
+    // SET_MESSAGES replaces the list. Must land at the bottom.
+    await injector.simulateExtensionMessage("updateCurrentSession", {
+      session: { id: "sess-long" },
+    });
+    await injector.updateMessages(longMessages);
+    await webviewPage.waitForTimeout(1200);
+
+    const phase2 = await webviewPage.evaluate(() => {
+      const c = document.getElementById("messagesContainer")!;
+      return {
+        scrollTop: c.scrollTop,
+        scrollHeight: c.scrollHeight,
+        clientHeight: c.clientHeight,
+      };
+    });
+    const gap = phase2.scrollHeight - phase2.scrollTop - phase2.clientHeight;
+    expect(gap).toBeLessThan(2);
+  });
+});

--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -1900,6 +1900,10 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
         <LoadingLogo />
       ) : (
         <MessageList
+          // 按会话 id 重挂载：切换会话是全新上下文，初始加载强制滚到底，
+          // 并重置上一会话遗留的 userScrolledUp（否则在旧会话向上翻过历史后
+          // 点开长会话，force 滚动被否决、停在新列表中间——见 longchat-switch e2e）。
+          key={state.currentSession?.id}
           ref={messageListRef}
           messages={state.messages}
           queuedMessages={state.queuedMessages}


### PR DESCRIPTION
## Problem

Loading a long (>200 msgs, virtualized) session after switching from another session sometimes does not scroll to the bottom — the list lands mid-transcript.

## Root cause

`MessageList` is reused across session switches, so `userScrolledUpRef` from the previous session survives. On load:

- `shouldForce = force && (isUserMessage || !userScrolledUp)` is `false`: the long session ends in an assistant message, and the user had scrolled up in the old session.
- `(isStreaming || isNearBottom) && !userScrolledUp` is `false`: history load is not streaming, and the retained scrollTop sits at the top of the new list.

Nothing scrolls. Reproduced with a real 238-message session: gap = 42282px.

## Fix

Key `MessageList` by `currentSession.id` (same pattern as `TaskList`, chatReducer switch-reset). A session switch remounts the list as a fresh context: initial load force-scrolls to the bottom and `userScrolledUpRef` resets. All three hosts (VS Code / desktop / JetBrains) send `updateCurrentSession` on switch.

## Verification

- New e2e regression test `e2e/longchat-switch.e2e.ts`: short session → user scrolls up → switch to 220-message session; fails with gap=42282 before the fix, passes after.
- 660 unit tests, type-check, lint pass.