### PR TITLE
fix(webview): keep sticky user bar when a text-less user message scrolls past

### DIFF
--- a/packages/webview/src/components/MessageList.tsx
+++ b/packages/webview/src/components/MessageList.tsx
@@ -319,28 +319,31 @@ export const MessageList = forwardRef<
       if (at && at.start >= scrollTop) idx = at.index - 1;
       const rows = visibleMessagesRef.current;
       let candidate = -1;
+      let candidateText = "";
       while (idx >= 0) {
-        if (rows[idx].role === "user") {
-          candidate = idx;
-          break;
+        const row = rows[idx];
+        if (row.role === "user") {
+          // Skip text-less user messages (task notifications): they cannot
+          // render a sticky label, so keep scanning upward for an earlier
+          // text-bearing user message instead of clearing the bar.
+          const text = (row.blocks ?? [])
+            .filter((b) => b.type === "text")
+            .map((b) => b.content || "")
+            .join(" ")
+            .trim();
+          if (text) {
+            candidate = idx;
+            candidateText = text;
+            break;
+          }
         }
         idx--;
       }
-      if (candidate < 0) {
+      if (candidate < 0 || !rows[candidate].id) {
         setSticky(null);
         return;
       }
-      const msg = rows[candidate];
-      const text = (msg.blocks ?? [])
-        .filter((b) => b.type === "text")
-        .map((b) => b.content || "")
-        .join(" ")
-        .trim();
-      if (!msg.id || !text) {
-        setSticky(null);
-        return;
-      }
-      setSticky({ id: msg.id, text });
+      setSticky({ id: rows[candidate].id, text: candidateText });
       return;
     }
     // Plain path: scan the fully-rendered DOM, as before.
@@ -348,12 +351,15 @@ export const MessageList = forwardRef<
       '[data-role="user"][data-message-id]',
     );
     let candidateNode: HTMLElement | null = null;
-    // Find the last user message whose top edge has scrolled above the viewport top.
+    // Find the last user message whose top edge has scrolled above the viewport
+    // top AND that renders user text. Text-less user messages (background task
+    // notifications) carry no .user-content and would otherwise clear the
+    // sticky bar the moment they scroll past — keep the previous text-bearing
+    // candidate instead so the bar never blinks out between real questions.
     for (const node of nodes) {
-      if (node.offsetTop < scrollTop) {
+      if (node.offsetTop >= scrollTop) break;
+      if (node.querySelector(".user-content")?.textContent?.trim()) {
         candidateNode = node;
-      } else {
-        break;
       }
     }
     if (!candidateNode) {

--- a/packages/webview/tests/webview/stickyUserMessage.test.tsx
+++ b/packages/webview/tests/webview/stickyUserMessage.test.tsx
@@ -15,6 +15,24 @@ const userMsg = (content: string, id: string) => ({
   blocks: [{ type: "text", content }],
 });
 
+// A background task notification: user role but NO text block, so it renders
+// no .user-content and must never become the sticky candidate.
+const notifMsg = (id: string) => ({
+  id,
+  role: "user" as const,
+  timestamp: "2025-01-01T00:00:00.000Z",
+  blocks: [
+    {
+      type: "task_notification" as const,
+      taskId: "task_1",
+      taskType: "shell" as const,
+      status: "completed" as const,
+      summary: "Command completed with exit code 0",
+      outputFile: "/tmp/task.log",
+    },
+  ],
+});
+
 /**
  * jsdom does not do layout, so offsetTop/scrollTop/clientHeight are all 0.
  * Fake the geometry: assign an increasing offsetTop to each user message node,
@@ -156,5 +174,67 @@ describe("sticky user message", () => {
       expect(screen.getByTestId("sticky-user-message")).toBeInTheDocument(),
     );
     expect(document.querySelector(".sticky-user-content")).toBeInTheDocument();
+  });
+
+  it("keeps the bar when a text-less notification user message scrolls past", async () => {
+    renderChatApp();
+    act(() => {
+      sendCommand("updateMessages", {
+        messages: [
+          userMsg("第一条问题", "u1"),
+          userMsg("第二条问题", "u2"),
+          notifMsg("n3"),
+          userMsg("第四条问题", "u4"),
+        ],
+      });
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("messages-container")).toBeInTheDocument(),
+    );
+
+    // scrollTop 1200 → u1(0), u2(500) and n3(1000) are all above the fold;
+    // the notification has no text, so the bar must stay on u2 ("第二条问题")
+    // instead of vanishing (regression: it used to clear the sticky state).
+    fakeGeometryAndScroll(1200);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("sticky-user-message")).toHaveTextContent(
+        "第二条问题",
+      );
+    });
+
+    // Once the text-bearing u4 (1500) also scrolls past, it becomes the
+    // candidate.
+    fakeGeometryAndScroll(1800);
+    await waitFor(() => {
+      expect(screen.getByTestId("sticky-user-message")).toHaveTextContent(
+        "第四条问题",
+      );
+    });
+  });
+
+  it("keeps the bar when the last user message has no text", async () => {
+    renderChatApp();
+    act(() => {
+      sendCommand("updateMessages", {
+        messages: [
+          userMsg("第一条问题", "u1"),
+          notifMsg("n2"),
+          userMsg("第三条问题", "u3"),
+        ],
+      });
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("messages-container")).toBeInTheDocument(),
+    );
+
+    // scrollTop 1600 → u1(0), n2(500) and u3(1000) are all above the fold;
+    // the newest text-bearing user is u3.
+    fakeGeometryAndScroll(1600);
+    await waitFor(() => {
+      expect(screen.getByTestId("sticky-user-message")).toHaveTextContent(
+        "第三条问题",
+      );
+    });
   });
 });


### PR DESCRIPTION
Background task notifications (task_notification blocks) render as cards with
no .user-content. When such a message became the sticky candidate,
computeSticky's text extraction returned empty and cleared the sticky bar,
blinking it out between real questions. Skip text-less user messages when
picking the candidate (both the plain DOM scan and the virtualized
data-driven branch) so the bar stays pinned to the most recent text-bearing
user question.

Regression tests in stickyUserMessage.test.tsx (jsdom + faked geometry):
the bar must survive scrolling past a task_notification user message.
