### PR TITLE
fix(webview): restore jsdom localStorage on Node 25+ (vitest 4.x)

### DIFF
--- a/packages/webview/vitest.config.ts
+++ b/packages/webview/vitest.config.ts
@@ -8,6 +8,15 @@ export default defineConfig({
     include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
     exclude: ["node_modules"],
     setupFiles: ["tests/setup.ts"],
+    // Node 25+ ships its own experimental localStorage accessor on
+    // globalThis; vitest 4.x's getWindowKeys then skips installing jsdom's
+    // working Storage (issue vitest-dev/vitest#10867), leaving window.
+    // localStorage undefined. Disable Node's accessor so jsdom's copy lands
+    // — the flag is rejected on older Node, hence the version guard.
+    execArgv:
+      Number(process.versions.node.split(".")[0]) >= 25
+        ? ["--no-webstorage"]
+        : [],
     server: {
       deps: {
         inline: ["wave-agent-sdk", "wave-webview-fixtures"],


### PR DESCRIPTION
## 背景

Node 25+ 在 globalThis 上自带了实验性的 localStorage accessor；vitest 4.x 的 `getWindowKeys` 因此跳过安装 jsdom 自己的 Storage 实现（vitest-dev/vitest#10867），导致本机 Node 26 下 `window.localStorage` 为 undefined，`messageListPersistence.test.tsx` 3 条测试失败（CI 用 Node 22 不受影响）。

## 改动

`packages/webview/vitest.config.ts`：Node ≥25 时给测试 worker 传 `--no-webstorage`，禁用 Node 自带的 localStorage accessor，让 jsdom 的实现正常落地；旧版 Node 不接受该 flag，故加版本守卫（Node 22 不传，CI 行为不变）。

## 为什么不用升级 vitest

vitest 5 的根因修复（PR #10293）仅进了 5.x，而 5 目前还是 beta/rc（latest 稳定版 4.1.11）；`--no-webstorage` 是 vitest 官方给 4.x 用户推荐的 workaround。升级到 5 需动全仓 7 个包 + lockfile + CI 全量重验，待 5 发稳定版后再升更稳妥。

## 验证

- 本机 Node 26.7.0 全量 webview 单测 676/676 通过（修复前 673/676）
- Node 22（CI）守卫跳过、flag 不传，无行为变化