### PR TITLE
fix(webview): span sticky user bar edge-to-edge across the message list

### DIFF
--- a/packages/webview/e2e/virtual-message-list.e2e.ts
+++ b/packages/webview/e2e/virtual-message-list.e2e.ts
@@ -117,6 +117,26 @@ async function containerState(webviewPage: Page) {
   });
 }
 
+// The sticky bar must span the message list edge-to-edge: the container's 10px
+// padding would otherwise leave left/right gutters (stretch only reaches the
+// content box; the wrapper's negative margins cancel the padding).
+async function expectStickyBarEdgeToEdge(webviewPage: Page) {
+  const rects = await webviewPage.evaluate(() => {
+    const c = document.getElementById("messagesContainer") as HTMLElement;
+    const w = document.querySelector(
+      ".sticky-user-wrapper",
+    ) as HTMLElement | null;
+    if (!w) return null;
+    const cr = c.getBoundingClientRect();
+    const wr = w.getBoundingClientRect();
+    return { cr, wr };
+  });
+  expect(rects).not.toBeNull();
+  if (!rects) return;
+  expect(Math.abs(rects.wr.left - rects.cr.left)).toBeLessThanOrEqual(1);
+  expect(Math.abs(rects.wr.right - rects.cr.right)).toBeLessThanOrEqual(1);
+}
+
 test.describe("Virtualized message list demo", () => {
   test("bounded DOM rows, real spacer height, scrollable, pinned to bottom", async ({
     webviewPage,
@@ -176,6 +196,8 @@ test.describe("Virtualized message list demo", () => {
       c.scrollTop = Math.max(0, c.scrollTop - 3000);
     });
     await webviewPage.waitForSelector('[data-testid="sticky-user-message"]');
+    // The bar must cover the list edge-to-edge (no 10px padding gutters).
+    await expectStickyBarEdgeToEdge(webviewPage);
     // While row measurements are still converging (estimate 200px → real
     // heights), the sticky candidate can briefly flip between two adjacent
     // user messages. Reading the text in that window would pick a target that

--- a/packages/webview/src/styles/MessageList.css
+++ b/packages/webview/src/styles/MessageList.css
@@ -39,7 +39,12 @@
   margin-bottom: -10px;
   /* Stretch across the cross axis (the container is flex column with
      align-items: flex-start) so the bar spans the list width like the old
-     absolute left/right: 0. */
+     absolute left/right: 0. Stretch alone only reaches the content box (the
+     container's 10px padding insets it), so negative horizontal margins cancel
+     that padding and the bar covers the container edge-to-edge with no
+     left/right gutters. */
+  margin-left: -10px;
+  margin-right: -10px;
   align-self: stretch;
   z-index: 20;
 }


### PR DESCRIPTION
## Problem

The sticky user bar (吸顶条) shows a ~10px empty gutter on each side instead of covering the message list edge-to-edge.

Root cause: when #1855 was fixed by switching the bar from `position: absolute; left:0; right:0` (spans the padding box) to `position: sticky`, the replacement `align-self: stretch` only reaches the container's **content box** — the container's 10px padding insets the bar on both sides.

## Fix

`packages/webview/src/styles/MessageList.css`: add `margin-left/-right: -10px` to `.sticky-user-wrapper` to cancel the container padding and restore the edge-to-edge overlay.

## Verification

- Probe test (browser-measured): wrapper/cap/card/scrim all match the container edges (240→1040px, ≤1px tolerance) at both 400px and 1280px viewports
- New e2e assertion in `virtual-message-list.e2e.ts` guards against regression
- Regenerated demo screenshot pixel-verified: the bar's full row is card color x=0..399, no background gutter
- webview unit 676/676, e2e 16/16, demo 42/42, type-check clean