### PR TITLE
fix(sdk): await skill reload during Agent.create to close empty-skill race

### DIFF
--- a/packages/agent-sdk/src/managers/liveConfigManager.ts
+++ b/packages/agent-sdk/src/managers/liveConfigManager.ts
@@ -28,7 +28,7 @@ import { logger } from "../utils/globalLogger.js";
 
 export interface LiveConfigManagerOptions {
   workdir: string;
-  onReload?: (config: WaveConfiguration) => void;
+  onReload?: (config: WaveConfiguration) => void | Promise<void>;
 }
 
 export class LiveConfigManager {
@@ -269,8 +269,11 @@ export class LiveConfigManager {
         );
       }
 
-      // Trigger reload callback
-      this.options.onReload?.(this.currentConfiguration);
+      // Trigger reload callback. Awaited so fire-and-forget work spawned by the
+      // callback (e.g. skill rediscovery) completes before the reload resolves —
+      // otherwise Agent.create() can return with a cleared skill map (see race
+      // where refreshSkills() clears skillMetadata before async discoverSkills).
+      await this.options.onReload?.(this.currentConfiguration);
 
       return this.currentConfiguration;
     } catch (error) {

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -306,15 +306,19 @@ export function setupAgentContainer(
 
   const liveConfigManager = new LiveConfigManager(container, {
     workdir,
-    onReload: () => {
+    onReload: async () => {
       const models = configurationService.getConfiguredModels();
       callbacks.onConfiguredModelsChange?.(models);
       // Re-evaluate feature-gated tools (e.g. Artifact behind
       // enableArtifact) so toggling the flag applies without a restart.
       toolManager.reloadFeatureGatedTools();
       // Same gate for the builtin /artifact skill: refresh emits "refreshed"
-      // so slash-command registration follows enableArtifact.
-      void skillManager.reloadFeatureGatedSkills().catch((error) => {
+      // so slash-command registration follows enableArtifact. Awaited (via the
+      // awaited onReload) so skills are re-populated before Agent.create()
+      // returns — reloadFeatureGatedSkills() clears the skill map before
+      // rediscovering asynchronously, which would otherwise expose an empty
+      // skill list to callers right after create().
+      await skillManager.reloadFeatureGatedSkills().catch((error) => {
         logger.error("Failed to reload feature-gated skills:", error);
       });
     },


### PR DESCRIPTION
## 问题

`Agent.create()` 返回后立刻 `getSkillMetadata()` 返回 **0 个技能**，UI 显示"没有任何技能"，~1-2ms 后恢复为完整数量。slash 命令不受影响（绑定在注册/`refreshed` 事件，不经被清空的 map）。

**根因链**（全部经代码核实）：
- `liveConfigManager.initialize()` → `reloadConfiguration()` 成功路径**无条件**调用 `onReload`（liveConfigManager.ts:273）
- `onReload` 里 `void skillManager.reloadFeatureGatedSkills()` fire-and-forget（containerSetup.ts:317）
- `refreshSkills()` **先同步清空** `skillMetadata`，再异步 `discoverSkills()` 重新填充（skillManager.ts:88-93）
- `Agent.create()` 随即返回 → 调用方看到空 map，1-2ms 后异步恢复

空 workdir 下复现 **7/8 次命中**（本地 src 与 npm wave-agent-sdk@1.1.2 均验证）。

## 修复

`onReload` 改为 async 并被 `LiveConfigManager.reloadConfiguration` **await**（回调类型扩宽为 `void | Promise<void>`），`reloadFeatureGatedSkills()` 在其中 await（保留 `.catch` 错误捕获）。技能在 `Agent.create()` 返回前重新填充完毕。

## 验证

- 复现脚本 8 次循环：**7/8 → 0/8** 命中（create 返回时技能已就绪）
- agent-sdk 全量单元套件：**248 files / 3531 passed, 2 skipped, 0 failed**