### PR TITLE
fix/publish ci windows vsix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,7 +137,11 @@ jobs:
       # versions, so workflow_dispatch (asset re-upload) must not re-publish.
       - name: Publish to VS Code Marketplace
         if: startsWith(github.ref, 'refs/tags/wave-vscode@')
-        run: pnpm -F wave-vscode exec vsce publish --packagePath releases/*.vsix
+        # pnpm exec spawns vsce without a shell, so the glob must be expanded
+        # here (bash) and passed as an absolute path (vsce cwd = package dir).
+        run: |
+          VSIX=$(ls "$(pwd)/packages/vscode/releases/"*.vsix | head -1)
+          pnpm -F wave-vscode exec vsce publish --packagePath "$VSIX"
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -328,6 +328,9 @@ jobs:
       # so create/update don't race on the release body.
       - name: Get previous tag
         id: prev-tag
+        # bash syntax (pipe, $GITHUB_OUTPUT) — the Windows runner's default
+        # shell is PowerShell, so pin bash explicitly.
+        shell: bash
         run: |
           PREV_TAG=$(git tag --sort=-v:refname --list 'wave-desktop@*' | grep -v "^${GITHUB_REF_NAME}$" | head -1)
           echo "tag=${PREV_TAG}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
- **fix(ci): pin bash shell for desktop previous-tag step on Windows runner**
- **fix(ci): pass exact vsix path to vsce publish (pnpm exec skips glob expansion)**
