### PR TITLE
fix(agent-sdk): display latestTotalTokens as total_tokens only

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -837,7 +837,7 @@ Wave 采用多层压缩机制管理对话历史，确保在长对话中不超出
 
 **自动压缩 (Auto-Compact)**
 
-- 每次 AI 响应后监控 token 使用量（含 cache 读取/写入 tokens）
+- 每次 AI 响应后监控 token 使用量（`latestTotalTokens` 为 `total_tokens`，不含 cache 读取/写入 tokens——与压缩判断口径一致，避免缓存命中双重计数导致 UI 显示虚高）
 - 当总 token 数超过 `getMaxInputTokens()` 时，自动触发压缩流程
 - 使用快速模型（fastModel）生成对话摘要，`max_tokens: 8192`，`temperature: 0.1`
 - 压缩前从消息中剥离图片以降低 token 消耗

--- a/docs/specs/core/message-compact.md
+++ b/docs/specs/core/message-compact.md
@@ -7,7 +7,7 @@ order: 70
 # 功能规格说明：消息压缩
 
 **创建日期**：2026-01-22  
-**更新日期**：2026-08-19
+**更新日期**：2026-08-22
 
 ## 用户场景与测试 _（必填）_
 
@@ -53,14 +53,14 @@ order: 70
 
 **为什么是这个优先级**：wave 走 OpenAI 兼容接口（OpenAI SDK + 网关），该格式下 `prompt_tokens = 缓存命中 + 未命中`、`total_tokens = prompt_tokens + completion_tokens`，缓存命中已计入 `total_tokens`（DeepSeek 官方文档明确 `prompt_tokens` 等于 `prompt_cache_hit_tokens + prompt_cache_miss_tokens`）。原实现把 `prompt_tokens_details.cached_tokens` 规范化后与 `total_tokens` 相加，造成缓存命中双重计数——缓存命中通常占上下文绝大部分，导致压缩过早触发（实际上下文远未到 `maxInputTokens` 就压缩）。该加法源自 Anthropic 原生格式（其 `input_tokens` 不含缓存字段），与 wave 实际使用的 OpenAI 兼容格式错配。
 
-**独立测试**：构造含 `cache_read_input_tokens`（大值）和 `cache_creation_input_tokens` 的 usage，验证压缩判断仅使用 `total_tokens`，缓存字段不参与判断；验证 `latestTotalTokens` 展示语义（含缓存，供计费/成本展示）不受影响。
+**独立测试**：构造含 `cache_read_input_tokens`（大值）和 `cache_creation_input_tokens` 的 usage，验证压缩判断仅使用 `total_tokens`，缓存字段不参与判断；验证 `latestTotalTokens` 展示语义同样仅使用 `total_tokens`（与压缩判断口径一致，缓存字段不参与展示）。
 
 **验收场景**：
 
 1. **假设**响应的 `usage` 包含 `total_tokens`、`cache_read_input_tokens`、`cache_creation_input_tokens`，**当**判断是否超过 `getMaxInputTokens()` 时，**则**只使用 `total_tokens`（OpenAI 兼容格式下已含缓存命中），缓存字段不得叠加
 2. **假设**响应仅含 `cache_read_input_tokens`（缓存命中极大）而 `total_tokens` 远低于阈值，**当**判断是否触发压缩时，**则**不得触发压缩
 3. **假设**`usage` 中 `total_tokens` 未超阈值但叠加缓存字段后超过，**当**判断是否触发压缩时，**则**不得触发压缩
-4. **假设**`latestTotalTokens` 仍按含缓存的综合值展示（供 CLI / webview 成本展示），**当**展示 token 使用量时，**则**展示语义保持不变，与压缩触发判断解耦
+4. **假设**`latestTotalTokens` 展示（CLI / webview 的 token 用量显示），**当**展示 token 使用量时，**则**同样只使用 `total_tokens`，缓存字段不叠加——与压缩触发判断口径一致，避免 UI 显示"100% context"而压缩迟迟不触发
 
 ---
 

--- a/docs/specs/core/prompt-cache-control.md
+++ b/docs/specs/core/prompt-cache-control.md
@@ -44,22 +44,22 @@ order: 90
 
 ---
 
-### 用户故事：启用缓存模型的全面 Token 追踪（优先级：P1）
+### 用户故事：启用缓存模型的 Token 追踪（优先级：P1）
 
-当使用启用缓存的模型（Claude 或其他如 Gemini/DeepSeek 等返回缓存 token 的模型）时，开发者需要准确的 token 追踪，包括所有缓存相关成本（缓存读取、缓存创建）以及基础提示和完成 token，以了解请求的真实成本和 token 使用。
+当使用启用缓存的模型（Claude 或其他如 Gemini/DeepSeek 等返回缓存 token 的模型）时，开发者需要准确的 token 追踪，以了解请求的实际上下文占用和 token 使用。
 
-**为什么是这个优先级**：准确的成本追踪对开发者了解缓存的财务影响并做出关于使用模式的明智决策至关重要。没有全面的 token 追踪，缓存的好处可能看起来具有误导性。
+**为什么是这个优先级**：wave 走 OpenAI 兼容接口（OpenAI SDK + 网关），该格式下 `total_tokens` 已包含缓存命中 token（`prompt_tokens = 缓存命中 + 未命中`）。若再将 `cache_read_input_tokens` / `cache_creation_input_tokens` 叠加进 `latestTotalTokens`，会造成缓存命中双重计数——缓存命中通常占上下文绝大部分，导致 UI 显示接近或超过 `maxInputTokens`（"100% context"）而实际上下文远未到阈值，与压缩判断（仅用 `total_tokens`）口径不一致。缓存字段仍从 usage 中提取并保留（供成本分析等用途），但 `latestTotalTokens` 展示不含它们。
 
-**独立测试**：可以通过使用任何启用缓存的模型进行缓存请求并验证显示的 token 计数包括 prompt_tokens + completion_tokens + cache_read_input_tokens + cache_creation_input_tokens 来完整测试。
+**独立测试**：可以通过使用任何启用缓存的模型进行缓存请求并验证显示的 token 计数为 `total_tokens`（不叠加 `cache_read_input_tokens` / `cache_creation_input_tokens`）来完整测试。
 
 **验收场景**：
 
-1. **假设**带缓存创建的 Claude 模型请求，**当**响应包含 cache_creation_input_tokens（在 usage 顶层）时，**则**latestTotalTokens 显示 total_tokens + cache_creation_input_tokens
-2. **假设**带缓存命中的 Claude 模型请求，**当**响应包含 cache_read_input_tokens（在 usage 顶层）时，**则**latestTotalTokens 显示 total_tokens + cache_read_input_tokens
-3. **假设**非 Claude 模型请求（如 Gemini、DeepSeek），**当**响应包含 prompt_tokens_details.cached_tokens 时，**则**cache_read_input_tokens 从 cached_tokens 填充且 latestTotalTokens 包含它
-4. **假设**非 Claude 模型请求，**当**响应包含 prompt_tokens_details.cache_creation_input_tokens 时，**则**cache_creation_input_tokens 从该字段填充且 latestTotalTokens 包含它
-5. **假设**模型响应同时包含 Claude 顶层缓存字段和 prompt_tokens_details，**当**两者都存在时，**则**Claude 顶层字段优先
-6. **假设**非缓存请求或无缓存 token 的模型，**当**没有缓存 token 时，**则**latestTotalTokens 仅显示 total_tokens
+1. **假设**带缓存创建的 Claude 模型请求，**当**响应包含 cache_creation_input_tokens（在 usage 顶层）时，**则**latestTotalTokens 显示 total_tokens（不叠加 cache_creation_input_tokens）
+2. **假设**带缓存命中的 Claude 模型请求，**当**响应包含 cache_read_input_tokens（在 usage 顶层）时，**则**latestTotalTokens 显示 total_tokens（不叠加 cache_read_input_tokens）
+3. **假设**非 Claude 模型请求（如 Gemini、DeepSeek），**当**响应包含 prompt_tokens_details.cached_tokens 时，**则**cache_read_input_tokens 从 cached_tokens 填充但 latestTotalTokens 不含它（仅 total_tokens）
+4. **假设**非 Claude 模型请求，**当**响应包含 prompt_tokens_details.cache_creation_input_tokens 时，**则**cache_creation_input_tokens 从该字段填充但 latestTotalTokens 不含它（仅 total_tokens）
+5. **假设**模型响应同时包含 Claude 顶层缓存字段和 prompt_tokens_details，**当**两者都存在时，**则**Claude 顶层字段优先（填充到 usage 缓存字段，不影响 latestTotalTokens 展示）
+6. **假设**非缓存请求或无缓存 token 的模型，**当**没有缓存 token 时，**则**latestTotalTokens 显示 total_tokens
 
 ---
 

--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -7,10 +7,7 @@ import {
   parseTaskNotificationXml,
   taskNotificationToXml,
 } from "../utils/notificationXml.js";
-import {
-  calculateComprehensiveTotalTokens,
-  estimateContextTokens,
-} from "../utils/tokenCalculation.js";
+import { estimateContextTokens } from "../utils/tokenCalculation.js";
 import { estimateTokens } from "../utils/tokenEstimate.js";
 import {
   getTaskReminderTurnCounts,
@@ -595,16 +592,16 @@ export class AIManager {
   }
 
   // Private method to update the displayed token statistics from a response.
-  // The comprehensive value (including cache tokens) is intentionally kept:
-  // it drives cost/usage display. Auto-compaction is NOT decided here — it
-  // happens pre-request via maybeAutoCompactBeforeRequest so that over-limit
-  // requests never go out (aligned with Claude Code's proactive autocompact).
+  // Uses only total_tokens — OpenAI-compatible usage already includes cache
+  // hits there, so adding cache fields would double-count and show an
+  // inflated context percentage. Same semantics as the auto-compaction
+  // threshold (maybeAutoCompactBeforeRequest), keeping display and
+  // compaction judgment consistent.
   private updateLatestTotalTokens(usage: Usage | undefined): void {
     if (!usage) return;
 
-    // Update token statistics - display comprehensive token usage including cache tokens
-    const comprehensiveTotalTokens = calculateComprehensiveTotalTokens(usage);
-    this.messageManager.setlatestTotalTokens(comprehensiveTotalTokens);
+    // Update token statistics - display total_tokens (cache fields excluded)
+    this.messageManager.setlatestTotalTokens(usage.total_tokens);
   }
 
   /**

--- a/packages/agent-sdk/src/utils/tokenCalculation.ts
+++ b/packages/agent-sdk/src/utils/tokenCalculation.ts
@@ -2,32 +2,13 @@ import type { Message, Usage } from "../types/index.js";
 import { estimateTokens } from "./tokenEstimate.js";
 
 /**
- * Calculate comprehensive total tokens including cache-related tokens
- *
- * This function computes the true total token cost by including:
- * - Base total_tokens (prompt + completion)
- * - Cache read tokens (cost savings indicator)
- * - Cache creation tokens (cache investment)
- *
- * For accurate cost tracking with Claude models that support cache control.
- *
- * @param usage - Usage statistics from AI operation
- * @returns Comprehensive total including all cache-related tokens
- */
-export function calculateComprehensiveTotalTokens(usage: Usage): number {
-  const baseTokens = usage.total_tokens;
-  const cacheReadTokens = usage.cache_read_input_tokens || 0;
-  const cacheCreateTokens = usage.cache_creation_input_tokens || 0;
-
-  return baseTokens + cacheReadTokens + cacheCreateTokens;
-}
-
-/**
- * Extract the latest total tokens from the last message with usage data
- * Uses comprehensive calculation that includes cache tokens for accurate tracking
+ * Extract the latest total tokens from the last message with usage data.
+ * Uses only `total_tokens` — OpenAI-compatible usage already includes cache
+ * hits there, so adding cache fields would double-count (same semantics as
+ * the auto-compaction threshold; keeps UI usage display aligned with it).
  *
  * @param messages - Array of messages to search
- * @returns Comprehensive total tokens from the most recent usage data, or 0 if none found
+ * @returns Total tokens from the most recent usage data, or 0 if none found
  */
 export function extractLatestTotalTokens(
   messages: Array<{ usage?: Usage }>,
@@ -36,7 +17,7 @@ export function extractLatestTotalTokens(
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i];
     if (message.usage) {
-      return calculateComprehensiveTotalTokens(message.usage);
+      return message.usage.total_tokens;
     }
   }
 

--- a/packages/agent-sdk/tests/managers/aiManager.latestTotalTokens.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.latestTotalTokens.test.ts
@@ -159,7 +159,7 @@ describe("AIManager - latestTotalTokens calculation", () => {
       expect(mockMessageManager.setlatestTotalTokens).toHaveBeenCalledWith(150);
     });
 
-    it("should include cache_read_input_tokens in latestTotalTokens calculation", async () => {
+    it("should ignore cache_read_input_tokens in latestTotalTokens calculation", async () => {
       const usage: Usage = {
         prompt_tokens: 100,
         completion_tokens: 50,
@@ -178,12 +178,12 @@ describe("AIManager - latestTotalTokens calculation", () => {
 
       await aiManager.sendAIMessage();
 
-      // Verify setlatestTotalTokens was called with total_tokens + cache_read_input_tokens
-      // Expected: 150 + 25 + 0 = 175
-      expect(mockMessageManager.setlatestTotalTokens).toHaveBeenCalledWith(175);
+      // Verify setlatestTotalTokens was called with total_tokens only (cache excluded)
+      // Expected: 150 (25 cache_read ignored)
+      expect(mockMessageManager.setlatestTotalTokens).toHaveBeenCalledWith(150);
     });
 
-    it("should include cache_creation_input_tokens in latestTotalTokens calculation", async () => {
+    it("should ignore cache_creation_input_tokens in latestTotalTokens calculation", async () => {
       const usage: Usage = {
         prompt_tokens: 100,
         completion_tokens: 50,
@@ -202,12 +202,12 @@ describe("AIManager - latestTotalTokens calculation", () => {
 
       await aiManager.sendAIMessage();
 
-      // Verify setlatestTotalTokens was called with total_tokens + cache_creation_input_tokens
-      // Expected: 150 + 0 + 30 = 180
-      expect(mockMessageManager.setlatestTotalTokens).toHaveBeenCalledWith(180);
+      // Verify setlatestTotalTokens was called with total_tokens only (cache excluded)
+      // Expected: 150 (30 cache_creation ignored)
+      expect(mockMessageManager.setlatestTotalTokens).toHaveBeenCalledWith(150);
     });
 
-    it("should include both cache token types in latestTotalTokens calculation", async () => {
+    it("should ignore both cache token types in latestTotalTokens calculation", async () => {
       const usage: Usage = {
         prompt_tokens: 100,
         completion_tokens: 50,
@@ -227,9 +227,9 @@ describe("AIManager - latestTotalTokens calculation", () => {
 
       await aiManager.sendAIMessage();
 
-      // Verify setlatestTotalTokens was called with total_tokens + both cache tokens
-      // Expected: 150 + 25 + 30 = 205
-      expect(mockMessageManager.setlatestTotalTokens).toHaveBeenCalledWith(205);
+      // Verify setlatestTotalTokens was called with total_tokens only (cache excluded)
+      // Expected: 150 (25 + 30 cache ignored)
+      expect(mockMessageManager.setlatestTotalTokens).toHaveBeenCalledWith(150);
     });
 
     it("should default undefined cache fields to 0 in latestTotalTokens calculation", async () => {
@@ -283,7 +283,7 @@ describe("AIManager - latestTotalTokens calculation", () => {
       expect(mockMessageManager.setlatestTotalTokens).toHaveBeenCalledWith(150);
     });
 
-    it("should handle large cache token values correctly", async () => {
+    it("should ignore large cache token values in latestTotalTokens calculation", async () => {
       const usage: Usage = {
         prompt_tokens: 1000,
         completion_tokens: 500,
@@ -303,10 +303,10 @@ describe("AIManager - latestTotalTokens calculation", () => {
 
       await aiManager.sendAIMessage();
 
-      // Verify setlatestTotalTokens was called with correct sum of large values
-      // Expected: 1500 + 2000 + 3000 = 6500
+      // Verify setlatestTotalTokens was called with total_tokens only (large cache ignored)
+      // Expected: 1500 (2000 + 3000 cache ignored)
       expect(mockMessageManager.setlatestTotalTokens).toHaveBeenCalledWith(
-        6500,
+        1500,
       );
     });
 
@@ -352,16 +352,16 @@ describe("AIManager - latestTotalTokens calculation", () => {
 
       await aiManager.sendAIMessage();
 
-      // Verify setlatestTotalTokens was called with comprehensive total including cache tokens
-      // Expected: 150000 + 5000 + 7000 = 162000
+      // Verify setlatestTotalTokens was called with total_tokens only (cache excluded)
+      // Expected: 150000 (5000 + 7000 cache ignored)
       expect(mockMessageManager.setlatestTotalTokens).toHaveBeenCalledWith(
-        162000,
+        150000,
       );
     });
   });
 
   describe("edge cases for latestTotalTokens calculation", () => {
-    it("should handle fractional cache token values by truncating to integers", async () => {
+    it("should ignore fractional cache token values in latestTotalTokens calculation", async () => {
       const usage = {
         prompt_tokens: 100,
         completion_tokens: 50,
@@ -381,12 +381,11 @@ describe("AIManager - latestTotalTokens calculation", () => {
 
       await aiManager.sendAIMessage();
 
-      // JavaScript addition will preserve decimals, so we expect the exact sum
-      // Expected: 150 + 25.7 + 30.3 = 206
-      expect(mockMessageManager.setlatestTotalTokens).toHaveBeenCalledWith(206);
+      // Expected: 150 (fractional cache values ignored)
+      expect(mockMessageManager.setlatestTotalTokens).toHaveBeenCalledWith(150);
     });
 
-    it("should handle negative cache token values (edge case)", async () => {
+    it("should ignore negative cache token values (edge case)", async () => {
       const usage: Usage = {
         prompt_tokens: 100,
         completion_tokens: 50,
@@ -406,9 +405,8 @@ describe("AIManager - latestTotalTokens calculation", () => {
 
       await aiManager.sendAIMessage();
 
-      // Verify setlatestTotalTokens handles negative values correctly
-      // Expected: 150 + (-10) + 30 = 170
-      expect(mockMessageManager.setlatestTotalTokens).toHaveBeenCalledWith(170);
+      // Expected: 150 (negative/positive cache values ignored)
+      expect(mockMessageManager.setlatestTotalTokens).toHaveBeenCalledWith(150);
     });
   });
 });

--- a/packages/agent-sdk/tests/utils/tokenCalculation.test.ts
+++ b/packages/agent-sdk/tests/utils/tokenCalculation.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import {
-  calculateComprehensiveTotalTokens,
   extractLatestTotalTokens,
   estimateContextTokens,
   roughTokenCountForMessages,
@@ -20,145 +19,6 @@ function makeMessage(overrides: Partial<Message>): Message {
 // 4 non-CJK chars ≈ 1 token; 2 chars/token for json
 const TEXT_TOKENS = 100;
 const text400 = "a".repeat(400);
-
-describe("calculateComprehensiveTotalTokens", () => {
-  it("should calculate basic total tokens without cache tokens", () => {
-    const usage: Usage = {
-      prompt_tokens: 100,
-      completion_tokens: 50,
-      total_tokens: 150,
-    };
-
-    const result = calculateComprehensiveTotalTokens(usage);
-    expect(result).toBe(150);
-  });
-
-  it("should include cache_read_input_tokens when present", () => {
-    const usage: Usage = {
-      prompt_tokens: 100,
-      completion_tokens: 50,
-      total_tokens: 150,
-      cache_read_input_tokens: 25,
-    };
-
-    const result = calculateComprehensiveTotalTokens(usage);
-    expect(result).toBe(175); // 150 + 25
-  });
-
-  it("should include cache_creation_input_tokens when present", () => {
-    const usage: Usage = {
-      prompt_tokens: 100,
-      completion_tokens: 50,
-      total_tokens: 150,
-      cache_creation_input_tokens: 30,
-    };
-
-    const result = calculateComprehensiveTotalTokens(usage);
-    expect(result).toBe(180); // 150 + 30
-  });
-
-  it("should include both cache token types when present", () => {
-    const usage: Usage = {
-      prompt_tokens: 100,
-      completion_tokens: 50,
-      total_tokens: 150,
-      cache_read_input_tokens: 25,
-      cache_creation_input_tokens: 30,
-    };
-
-    const result = calculateComprehensiveTotalTokens(usage);
-    expect(result).toBe(205); // 150 + 25 + 30
-  });
-
-  it("should handle zero cache tokens", () => {
-    const usage: Usage = {
-      prompt_tokens: 100,
-      completion_tokens: 50,
-      total_tokens: 150,
-      cache_read_input_tokens: 0,
-      cache_creation_input_tokens: 0,
-    };
-
-    const result = calculateComprehensiveTotalTokens(usage);
-    expect(result).toBe(150);
-  });
-
-  it("should handle undefined cache tokens as zero", () => {
-    const usage: Usage = {
-      prompt_tokens: 100,
-      completion_tokens: 50,
-      total_tokens: 150,
-      cache_read_input_tokens: undefined,
-      cache_creation_input_tokens: undefined,
-    };
-
-    const result = calculateComprehensiveTotalTokens(usage);
-    expect(result).toBe(150);
-  });
-
-  it("should handle mixed defined/undefined cache tokens", () => {
-    const usageWithReadOnly: Usage = {
-      prompt_tokens: 100,
-      completion_tokens: 50,
-      total_tokens: 150,
-      cache_read_input_tokens: 25,
-      cache_creation_input_tokens: undefined,
-    };
-
-    expect(calculateComprehensiveTotalTokens(usageWithReadOnly)).toBe(175);
-
-    const usageWithCreateOnly: Usage = {
-      prompt_tokens: 100,
-      completion_tokens: 50,
-      total_tokens: 150,
-      cache_read_input_tokens: undefined,
-      cache_creation_input_tokens: 30,
-    };
-
-    expect(calculateComprehensiveTotalTokens(usageWithCreateOnly)).toBe(180);
-  });
-
-  it("should handle usage with additional optional fields", () => {
-    const usage: Usage = {
-      prompt_tokens: 100,
-      completion_tokens: 50,
-      total_tokens: 150,
-      cache_read_input_tokens: 25,
-      cache_creation_input_tokens: 30,
-      model: "claude-3-sonnet",
-      operation_type: "agent",
-    };
-
-    const result = calculateComprehensiveTotalTokens(usage);
-    expect(result).toBe(205); // 150 + 25 + 30
-  });
-
-  it("should handle large token counts", () => {
-    const usage: Usage = {
-      prompt_tokens: 100000,
-      completion_tokens: 50000,
-      total_tokens: 150000,
-      cache_read_input_tokens: 25000,
-      cache_creation_input_tokens: 30000,
-    };
-
-    const result = calculateComprehensiveTotalTokens(usage);
-    expect(result).toBe(205000); // 150000 + 25000 + 30000
-  });
-
-  it("should handle zero total tokens with cache tokens", () => {
-    const usage: Usage = {
-      prompt_tokens: 0,
-      completion_tokens: 0,
-      total_tokens: 0,
-      cache_read_input_tokens: 25,
-      cache_creation_input_tokens: 30,
-    };
-
-    const result = calculateComprehensiveTotalTokens(usage);
-    expect(result).toBe(55); // 0 + 25 + 30
-  });
-});
 
 describe("extractLatestTotalTokens", () => {
   it("should return 0 for empty array", () => {
@@ -201,7 +61,7 @@ describe("extractLatestTotalTokens", () => {
     expect(result).toBe(150);
   });
 
-  it("should extract tokens from last message with usage when multiple messages have usage", () => {
+  it("should extract total_tokens from last message with usage when multiple messages have usage", () => {
     const usage1: Usage = {
       prompt_tokens: 100,
       completion_tokens: 50,
@@ -222,7 +82,7 @@ describe("extractLatestTotalTokens", () => {
     ];
 
     const result = extractLatestTotalTokens(messages);
-    expect(result).toBe(300); // 275 + 25 (from usage2)
+    expect(result).toBe(275); // total_tokens only (cache fields excluded)
   });
 
   it("should skip messages without usage and find the latest with usage", () => {
@@ -248,10 +108,10 @@ describe("extractLatestTotalTokens", () => {
     ];
 
     const result = extractLatestTotalTokens(messages);
-    expect(result).toBe(305); // 275 + 30 (from usage2, which is the latest with usage)
+    expect(result).toBe(275); // total_tokens only (cache fields excluded)
   });
 
-  it("should use comprehensive calculation including cache tokens", () => {
+  it("should use total_tokens only, ignoring cache tokens", () => {
     const usage: Usage = {
       prompt_tokens: 100,
       completion_tokens: 50,
@@ -267,7 +127,7 @@ describe("extractLatestTotalTokens", () => {
     ];
 
     const result = extractLatestTotalTokens(messages);
-    expect(result).toBe(205); // 150 + 25 + 30
+    expect(result).toBe(150); // 150 + 25 + 30 would be 205 if cache were added
   });
 
   it("should handle mixed message structures", () => {
@@ -293,7 +153,7 @@ describe("extractLatestTotalTokens", () => {
     ];
 
     const result = extractLatestTotalTokens(messages);
-    expect(result).toBe(290); // 250 + 40 (from usage2)
+    expect(result).toBe(250); // total_tokens only (cache fields excluded)
   });
 
   it("should handle large arrays efficiently", () => {
@@ -313,7 +173,7 @@ describe("extractLatestTotalTokens", () => {
     );
 
     const result = extractLatestTotalTokens(messages);
-    expect(result).toBe(170); // 150 + 20
+    expect(result).toBe(150); // total_tokens only (cache fields excluded)
   });
 
   it("should handle messages with zero tokens", () => {
@@ -327,7 +187,7 @@ describe("extractLatestTotalTokens", () => {
     const messages: Array<{ usage?: Usage }> = [{ usage }];
 
     const result = extractLatestTotalTokens(messages);
-    expect(result).toBe(10); // 0 + 10
+    expect(result).toBe(0); // total_tokens only (cache fields excluded)
   });
 
   it("should handle messages with only cache_creation_input_tokens", () => {
@@ -341,7 +201,7 @@ describe("extractLatestTotalTokens", () => {
     const messages: Array<{ usage?: Usage }> = [{ usage }];
 
     const result = extractLatestTotalTokens(messages);
-    expect(result).toBe(185); // 150 + 35
+    expect(result).toBe(150); // total_tokens only (cache fields excluded)
   });
 
   it("should prioritize most recent usage even with intervening messages", () => {
@@ -368,9 +228,9 @@ describe("extractLatestTotalTokens", () => {
       { usage: undefined },
     ];
 
-    // Should use laterUsage (30 + 5 = 35), not earlyUsage (75 + 100 = 175)
+    // Should use laterUsage total_tokens (30), not earlyUsage (75)
     const result = extractLatestTotalTokens(messages);
-    expect(result).toBe(35);
+    expect(result).toBe(30);
   });
 });
 


### PR DESCRIPTION
## 背景

UI 的 context 百分比（latestTotalTokens / maxInputTokens）此前按含缓存的综合值展示（total_tokens + cache_read_input_tokens + cache_creation_input_tokens）。但 wave 走 OpenAI 兼容接口，该格式下 total_tokens 已包含缓存命中（prompt_tokens = 缓存命中 + 未命中），叠加缓存字段造成双重计数——缓存命中通常占上下文绝大部分，导致：

- UI 显示 100% context 而实际输入远未到 maxInputTokens（如真实场景：显示 216k / 100%，实际 total_tokens 仅 113k）
- 自动压缩判断（maybeAutoCompactBeforeRequest 仅用 total_tokens）与展示口径不一致，用户困惑"显示 100% 却不压缩"

## 改动

- spec（先更新规格后实现）：
  - docs/specs/core/message-compact.md：验收场景 4 从"展示语义保持不变、与压缩解耦"改为"展示同样仅用 total_tokens"
  - docs/specs/core/prompt-cache-control.md：用户故事改为"Token 追踪（仅 total_tokens）"，重写优先级说明与验收场景 1-6
  - docs/sdk.md：同步描述
- 代码（packages/agent-sdk）：
  - src/utils/tokenCalculation.ts：extractLatestTotalTokens 直接返回 usage.total_tokens；删除不再有生产引用的 calculateComprehensiveTotalTokens
  - src/managers/aiManager.ts：updateLatestTotalTokens 改用 usage.total_tokens
  - 缓存字段仍从 usage 中提取并保留（供成本分析等用途），仅不再参与 latestTotalTokens 展示
- 测试：tokenCalculation.test.ts / aiManager.latestTotalTokens.test.ts 缓存场景期望值从"包含"改为"忽略"（如 150 而非 175/205/6500 等）

## 验证

- agent-sdk 全量单测：272 文件 / 3666 测试通过
- code useChat.test.tsx：63 通过（rebuild agent-sdk 后重跑）
- type-check（全仓 6 包）、lint 通过；spec 校验通过（76 规格 / 404 故事 / 1608 场景）