### PR TITLE
feat: per-frontend CLI install dirs (vscode/desktop/jetbrains) with shared rg

### DIFF
--- a/packages/desktop/src/main/stdio/binaryResolver.ts
+++ b/packages/desktop/src/main/stdio/binaryResolver.ts
@@ -3,13 +3,17 @@
  *
  * 1. WAVE_CLI_PATH env override (development)
  * 2. The CLI bundled inside the app (resources/wave-cli, shipped in the
- *    installer) is copied into `~/.wave/cli` — the packaged install dir is
- *    read-only on macOS/Windows, so the runtime copy lives under the user
- *    home. The CLI version tracks the app version (shipped with the app).
+ *    installer) is copied into `~/.wave/cli/desktop` — the packaged install
+ *    dir is read-only on macOS/Windows, so the runtime copy lives under the
+ *    user home. The CLI version tracks the app version (shipped with the
+ *    app). Each frontend (vscode/desktop/jetbrains) keeps its own subdir so
+ *    different versions never overwrite each other.
  * 3. The grep tool's runtime dependency `@vscode/ripgrep` (JS wrapper +
  *    platform rg binary, ~5MB) is downloaded from the npmmirror registry on
- *    first use. A failed download does NOT block the CLI — grep simply
- *    reports "ripgrep is not available" until a later launch succeeds.
+ *    first use and cached in the shared `~/.wave/cli/node_modules/@vscode`
+ *    dir (shared by vscode/desktop/jetbrains). A failed download does NOT
+ *    block the CLI — grep simply reports "ripgrep is not available" until a
+ *    later launch succeeds.
  *
  * Everything runs on the Electron-bundled Node runtime (`process.execPath` +
  * `ELECTRON_RUN_AS_NODE=1`); no system Node.js/npm is required. Result is
@@ -38,9 +42,18 @@ export function bundledCliDir(): string {
     : path.join(app.getAppPath(), "resources", "wave-cli");
 }
 
-/** Runtime CLI dir under the user home (writable, mirrors a flat npm install). */
-export function cliInstallDir(): string {
+/** Shared root dir for all CLI runtime data under the user home. */
+function cliRootDir(): string {
   return path.join(os.homedir(), ".wave", "cli");
+}
+
+/**
+ * Runtime CLI dir under the user home (writable, mirrors a flat npm
+ * install). Per-end: vscode/desktop/jetbrains each own their own subdir so
+ * they never overwrite each other's CLI copy.
+ */
+export function cliInstallDir(): string {
+  return path.join(cliRootDir(), "desktop");
 }
 
 /** Entry point of the runtime CLI (the version-probe shim). */
@@ -48,9 +61,13 @@ export function cliEntryPath(): string {
   return path.join(cliInstallDir(), "bin", "wave-code.js");
 }
 
-/** Where the downloaded ripgrep packages live inside the runtime CLI dir. */
-function rgInstallDir(): string {
-  return path.join(cliInstallDir(), "node_modules", "@vscode");
+/**
+ * Where the downloaded ripgrep packages live. Shared by all three frontends
+ * (vscode/desktop/jetbrains) — deliberately outside the per-end CLI dir so
+ * each end's CLI copy never wipes the cached rg download.
+ */
+export function rgInstallDir(): string {
+  return path.join(cliRootDir(), "node_modules", "@vscode");
 }
 
 /** Current platform's rg binary path after install. */
@@ -177,9 +194,10 @@ export async function ensureRipgrep(
 
 /**
  * Copy the bundled CLI into the runtime dir when missing or when the bundled
- * version differs (app upgrade). The runtime `node_modules/` (downloaded
- * ripgrep) is preserved across copies so an already-downloaded rg is never
- * re-downloaded after an upgrade. Returns the runtime entry path.
+ * version differs (app upgrade). The cached rg download lives in the shared
+ * `~/.wave/cli/node_modules/@vscode` dir — outside this per-end dir — so an
+ * already-downloaded rg is never re-downloaded after an upgrade. Returns the
+ * runtime entry path.
  * @throws Error when the bundled CLI itself is missing (corrupt install).
  */
 function prepareCli(): string {
@@ -196,8 +214,8 @@ function prepareCli(): string {
 
   if (needCopy) {
     fs.mkdirSync(cliInstallDir(), { recursive: true });
-    // Replace the CLI files only — keep node_modules/ (the cached rg
-    // download) so an upgrade does not force re-downloading it.
+    // Replace the CLI files only — the cached rg download lives in the
+    // shared ~/.wave/cli dir, so an upgrade never forces re-downloading it.
     fs.rmSync(path.join(cliInstallDir(), "dist"), {
       recursive: true,
       force: true,
@@ -233,7 +251,7 @@ function runtimeVersion(): string {
 
 /**
  * Resolve the `wave` CLI for local sessions: WAVE_CLI_PATH override first
- * (development), then the CLI copied from the bundle into `~/.wave/cli`,
+ * (development), then the CLI copied from the bundle into `~/.wave/cli/desktop`,
  * ensuring the ripgrep search dependency is downloaded (best-effort).
  * @throws Error only when the bundled CLI is missing (corrupt install).
  */
@@ -266,8 +284,8 @@ export async function resolveWaveBinary(
 
 /**
  * Ensure the CLI for local sessions is ready: bundled CLI copied into
- * `~/.wave/cli` and ripgrep downloaded (best-effort). The CLI version tracks
- * the app version, so there is no separate upgrade step.
+ * `~/.wave/cli/desktop` and ripgrep downloaded (best-effort). The CLI
+ * version tracks the app version, so there is no separate upgrade step.
  */
 export async function ensureCliUpToDate(
   targetVersion?: string,

--- a/packages/desktop/tests/binaryResolver.test.ts
+++ b/packages/desktop/tests/binaryResolver.test.ts
@@ -64,6 +64,7 @@ import {
   ensureRipgrep,
   cliEntryPath,
   cliInstallDir,
+  rgInstallDir,
   bundledCliDir,
   NPM_REGISTRY,
   _resetCacheForTesting,
@@ -72,7 +73,7 @@ import {
 const bundledDir = () => path.join("/app/root", "resources", "wave-cli");
 const bundledEntry = () => path.join(bundledDir(), "bin", "wave-code.js");
 const entry = () =>
-  path.join("/fake/home", ".wave", "cli", "bin", "wave-code.js");
+  path.join("/fake/home", ".wave", "cli", "desktop", "bin", "wave-code.js");
 const rgBin = () =>
   path.join(
     "/fake/home/.wave/cli/node_modules/@vscode",
@@ -170,6 +171,20 @@ describe("binaryResolver (bundled CLI + downloaded rg)", () => {
     expect(cliEntryPath()).toBe(entry());
   });
 
+  it("cliInstallDir is per-end (desktop) while rg stays at the shared root", () => {
+    // Each frontend (vscode/desktop/jetbrains) owns its own subdir so they
+    // never overwrite each other's CLI copy.
+    expect(cliInstallDir()).toBe(
+      path.join("/fake/home", ".wave", "cli", "desktop"),
+    );
+    expect(entry()).toContain(path.join(".wave", "cli", "desktop"));
+    // rg is shared by all three frontends — a sibling of the per-end dir,
+    // not inside it, so a CLI re-copy never wipes the cached download.
+    expect(rgInstallDir()).toBe(
+      path.join("/fake/home", ".wave", "cli", "node_modules", "@vscode"),
+    );
+  });
+
   it("prefers WAVE_CLI_PATH override without touching bundle/rg", async () => {
     process.env.WAVE_CLI_PATH = "/dev/wave-code.js";
     memFs.set("/dev/wave-code.js", "dev shim");
@@ -188,7 +203,7 @@ describe("binaryResolver (bundled CLI + downloaded rg)", () => {
     await expect(resolveWaveBinary("1.0.0")).rejects.toThrow("内置 CLI 缺失");
   });
 
-  it("copies the bundled CLI into ~/.wave/cli on first use and downloads rg", async () => {
+  it("copies the bundled CLI into ~/.wave/cli/desktop on first use and downloads rg", async () => {
     seedBundledCli("1.0.0");
     mockRipgrepRegistry();
 

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
@@ -22,11 +22,13 @@ private const val MIN_NODE_MAJOR = 22
 /**
  * Resolves the `wave` CLI for local sessions. The CLI 三件套
  * (`bin/wave-code.js` + `package.json` + `dist/bundle/wave.mjs`) is bundled
- * inside the plugin jar, copied to the user-writable `~/.wave/cli` at runtime
- * and executed with the customer's system Node.js (>= 22) — no npm-global
- * `wave-code` package, no version check/upgrade. The grep dependency
- * `@vscode/ripgrep` is NOT bundled; it is downloaded from npmmirror on first
- * use into `~/.wave/cli/node_modules/` and cached.
+ * inside the plugin jar, copied to the user-writable `~/.wave/cli/jetbrains`
+ * at runtime and executed with the customer's system Node.js (>= 22) — no
+ * npm-global `wave-code` package, no version check/upgrade. Each frontend
+ * (vscode/desktop/jetbrains) keeps its own subdir so different versions
+ * never overwrite each other. The grep dependency `@vscode/ripgrep` is NOT
+ * bundled; it is downloaded from npmmirror on first use into the shared
+ * `~/.wave/cli/node_modules/` and cached.
  */
 object BinaryResolver {
     private val LOG = logger<BinaryResolver>()
@@ -71,9 +73,9 @@ object BinaryResolver {
     }
 
     /**
-     * Resolve the runtime CLI entry (`~/.wave/cli/bin/wave-code.js`), copying
-     * the bundled CLI on first use / version change and downloading ripgrep on
-     * demand. `WAVE_CLI_PATH` env override wins (development).
+     * Resolve the runtime CLI entry (`~/.wave/cli/jetbrains/bin/wave-code.js`),
+     * copying the bundled CLI on first use / version change and downloading
+     * ripgrep on demand. `WAVE_CLI_PATH` env override wins (development).
      * @throws StdioClientException when the bundled CLI is missing (corrupt
      * install) or ripgrep cannot be downloaded.
      */
@@ -88,9 +90,10 @@ object BinaryResolver {
         // 0. Node.js >= 22 is required to execute the bundled CLI.
         checkNodeVersion()
 
-        // 1. Copy the bundled CLI into ~/.wave/cli (plugin install dir is
-        //    read-only; version change re-copies but keeps node_modules/ so an
-        //    already-downloaded rg is never re-downloaded).
+        // 1. Copy the bundled CLI into ~/.wave/cli/jetbrains (plugin install
+        //    dir is read-only; version change re-copies but keeps the shared
+        //    rg download in ~/.wave/cli/node_modules so it is never
+        //    re-downloaded).
         val entry = prepareCli()
 
         // 2. `@vscode/ripgrep` is a top-level import of the bundled CLI —
@@ -167,18 +170,26 @@ object BinaryResolver {
     }
 
     // ------------------------------------------------------------------
-    // Bundled CLI → ~/.wave/cli
+    // Bundled CLI → ~/.wave/cli/jetbrains
     // ------------------------------------------------------------------
 
-    internal fun cliInstallDir(): File = File(System.getProperty("user.home"), ".wave/cli")
+    /** Shared root dir for all CLI runtime data under the user home. */
+    private fun cliRootDir(): File = File(System.getProperty("user.home"), ".wave/cli")
+
+    /**
+     * Per-end runtime CLI dir: `~/.wave/cli/jetbrains` — vscode/desktop keep
+     * their own subdirs so they never overwrite each other's CLI copy.
+     */
+    internal fun cliInstallDir(): File = File(cliRootDir(), "jetbrains")
 
     private fun cliEntryPath(): String = File(cliInstallDir(), "bin/wave-code.js").path
 
     /**
      * Copy the bundled CLI into the runtime dir when missing or when the bundled
-     * version differs (plugin upgrade). The runtime `node_modules/` (downloaded
-     * ripgrep) is preserved across copies so an already-downloaded rg is never
-     * re-downloaded after an upgrade. Returns the runtime entry path.
+     * version differs (plugin upgrade). The cached rg download lives in the
+     * shared `~/.wave/cli/node_modules/@vscode` dir — outside this per-end dir —
+     * so an already-downloaded rg is never re-downloaded after an upgrade.
+     * Returns the runtime entry path.
      * @throws StdioClientException when the bundled CLI itself is missing (corrupt install).
      */
     private fun prepareCli(): String {
@@ -190,8 +201,8 @@ object BinaryResolver {
 
         if (needCopy) {
             onInstall?.invoke("正在准备内置 wave CLI…")
-            // Replace the CLI files only — keep node_modules/ (the cached rg
-            // download) so an upgrade does not force re-downloading it.
+            // Replace the CLI files only — the cached rg download lives in the
+            // shared ~/.wave/cli dir, so an upgrade never forces re-downloading it.
             File(cliInstallDir(), "dist").deleteRecursively()
             File(entry).delete()
             File(cliInstallDir(), "package.json").delete()
@@ -223,7 +234,7 @@ object BinaryResolver {
         }
     }
 
-    /** Version of the runtime CLI in ~/.wave/cli. */
+    /** Version of the runtime CLI in ~/.wave/cli/jetbrains. */
     private fun runtimeVersion(): String {
         return try {
             val file = File(cliInstallDir(), "package.json")
@@ -246,17 +257,22 @@ object BinaryResolver {
     // ripgrep download + cache
     // ------------------------------------------------------------------
 
-    internal fun rgInstallDir(): File = File(cliInstallDir(), "node_modules/@vscode")
+    /**
+     * Where the downloaded ripgrep packages live. Shared by all three
+     * frontends (vscode/desktop/jetbrains) — deliberately outside the per-end
+     * CLI dir so each end's CLI copy never wipes the cached rg download.
+     */
+    internal fun rgInstallDir(): File = File(cliRootDir(), "node_modules/@vscode")
 
     internal fun rgBinaryPath(): String =
         File(rgInstallDir(), "$rgPlatformDir/bin/rg${if (isWindows) ".exe" else ""}").path
 
     /**
      * Download the ripgrep JS wrapper and the current platform's rg binary into
-     * the runtime CLI dir. Returns true when the rg binary is in place. Never
-     * throws — a failed download only disables the grep tool until a later
-     * launch retries (caller [resolveWaveBinary] turns failure into a hard
-     * init error).
+     * the shared `~/.wave/cli/node_modules/@vscode` dir. Returns true when the
+     * rg binary is in place. Never throws — a failed download only disables
+     * the grep tool until a later launch retries (caller [resolveWaveBinary]
+     * turns failure into a hard init error).
      */
     internal fun ensureRipgrep(): Boolean {
         if (File(rgBinaryPath()).exists()) return true

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioClient.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioClient.kt
@@ -35,7 +35,7 @@ class StdioClientException(message: String) : RuntimeException(message)
 /**
  * Pure transport layer: spawns `wave --stdio`, speaks line-delimited JSON-RPC 2.0.
  * Mirrors packages/vscode/src/stdio/stdioClient.ts. [command] is the full
- * executable + script prefix (e.g. `node ~/.wave/cli/bin/wave-code.js`) — the
+ * executable + script prefix (e.g. `node ~/.wave/cli/jetbrains/bin/wave-code.js`) — the
  * bundled CLI is a `.js` script executed by the system Node.js, so no shell /
  * `.cmd` shim is involved on Windows.
  */

--- a/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/stdio/BinaryResolverTest.kt
+++ b/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/stdio/BinaryResolverTest.kt
@@ -131,6 +131,26 @@ class BinaryResolverTest {
         )
     }
 
+    @Test
+    fun `cliInstallDir is per-end under the shared cli root`() {
+        // Each frontend (vscode/desktop/jetbrains) owns its own subdir so they
+        // never overwrite each other's CLI copy.
+        val home = System.getProperty("user.home")
+        val expected = File(home, ".wave/cli/jetbrains")
+        assertEquals(expected.absolutePath, BinaryResolver.cliInstallDir().absolutePath)
+    }
+
+    @Test
+    fun `rgInstallDir stays at the shared root not inside the per-end dir`() {
+        // rg is shared by all three frontends — a sibling of the per-end dir
+        // (under ~/.wave/cli), so a CLI re-copy never wipes the cached download.
+        val cliRoot = BinaryResolver.cliInstallDir().parentFile
+        assertEquals(
+            File(cliRoot, "node_modules/@vscode").absolutePath,
+            BinaryResolver.rgInstallDir().absolutePath,
+        )
+    }
+
 
     @Test
     fun `extractTarball strips the top package dir`() {

--- a/packages/vscode/src/stdio/binaryResolver.ts
+++ b/packages/vscode/src/stdio/binaryResolver.ts
@@ -3,12 +3,15 @@
  *
  * 1. WAVE_CLI_PATH env override (development)
  * 2. The CLI bundled inside the extension (dist/wave-cli, shipped in the
- *    vsix) is copied into `~/.wave/cli` — the extension dir is read-only, so
- *    the runtime copy lives under the user home. The CLI version tracks the
- *    extension version (shipped with the vsix).
+ *    vsix) is copied into `~/.wave/cli/vscode` — the extension dir is
+ *    read-only, so the runtime copy lives under the user home. The CLI
+ *    version tracks the extension version (shipped with the vsix). Each
+ *    frontend (vscode/desktop/jetbrains) keeps its own subdir so different
+ *    versions never overwrite each other.
  * 3. The grep tool's runtime dependency `@vscode/ripgrep` (JS wrapper +
  *    platform rg binary, ~5MB) is downloaded from the npmmirror registry on
- *    first use and cached in the runtime dir. A failed download does NOT
+ *    first use and cached in the shared `~/.wave/cli/node_modules/@vscode`
+ *    dir (shared by vscode/desktop/jetbrains). A failed download does NOT
  *    block the CLI — grep simply reports "ripgrep is not available" until a
  *    later launch succeeds.
  *
@@ -63,9 +66,18 @@ export function bundledCliDir(): string {
   return path.join(extensionPath, "dist", "wave-cli");
 }
 
-/** Runtime CLI dir under the user home (writable, mirrors a flat npm install). */
-export function cliInstallDir(): string {
+/** Shared root dir for all CLI runtime data under the user home. */
+function cliRootDir(): string {
   return path.join(os.homedir(), ".wave", "cli");
+}
+
+/**
+ * Runtime CLI dir under the user home (writable, mirrors a flat npm
+ * install). Per-end: vscode/desktop/jetbrains each own their own subdir so
+ * they never overwrite each other's CLI copy.
+ */
+export function cliInstallDir(): string {
+  return path.join(cliRootDir(), "vscode");
 }
 
 /** Entry point of the runtime CLI (the version-probe shim). */
@@ -73,9 +85,13 @@ export function cliEntryPath(): string {
   return path.join(cliInstallDir(), "bin", "wave-code.js");
 }
 
-/** Where the downloaded ripgrep packages live inside the runtime CLI dir. */
-function rgInstallDir(): string {
-  return path.join(cliInstallDir(), "node_modules", "@vscode");
+/**
+ * Where the downloaded ripgrep packages live. Shared by all three frontends
+ * (vscode/desktop/jetbrains) — deliberately outside the per-end CLI dir so
+ * each end's CLI copy never wipes the cached rg download.
+ */
+export function rgInstallDir(): string {
+  return path.join(cliRootDir(), "node_modules", "@vscode");
 }
 
 /** Current platform's rg binary path after install. */
@@ -202,9 +218,10 @@ export async function ensureRipgrep(
 
 /**
  * Copy the bundled CLI into the runtime dir when missing or when the bundled
- * version differs (extension upgrade). The runtime `node_modules/`
- * (downloaded ripgrep) is preserved across copies so an already-downloaded
- * rg is never re-downloaded after an upgrade. Returns the runtime entry path.
+ * version differs (extension upgrade). The cached rg download lives in the
+ * shared `~/.wave/cli/node_modules/@vscode` dir — outside this per-end dir —
+ * so an already-downloaded rg is never re-downloaded after an upgrade.
+ * Returns the runtime entry path.
  * @throws Error when the bundled CLI itself is missing (corrupt install).
  */
 function prepareCli(): string {
@@ -221,8 +238,8 @@ function prepareCli(): string {
 
   if (needCopy) {
     fs.mkdirSync(cliInstallDir(), { recursive: true });
-    // Replace the CLI files only — keep node_modules/ (the cached rg
-    // download) so an upgrade does not force re-downloading it.
+    // Replace the CLI files only — the cached rg download lives in the
+    // shared ~/.wave/cli dir, so an upgrade never forces re-downloading it.
     fs.rmSync(path.join(cliInstallDir(), "dist"), {
       recursive: true,
       force: true,
@@ -258,8 +275,8 @@ function runtimeVersion(): string {
 
 /**
  * Resolve the `wave` CLI: WAVE_CLI_PATH override first (development), then
- * the CLI copied from the extension bundle into `~/.wave/cli`, ensuring the
- * ripgrep search dependency is downloaded.
+ * the CLI copied from the extension bundle into `~/.wave/cli/vscode`,
+ * ensuring the ripgrep search dependency is downloaded.
  * @throws Error when the bundled CLI is missing (corrupt install) or the
  * ripgrep download fails — `@vscode/ripgrep` is a top-level import of the
  * bundled CLI, so without it wave.mjs cannot even start.
@@ -286,8 +303,8 @@ export async function resolveWaveBinary(
 }
 
 /**
- * Ensure the `wave` CLI is ready: bundled CLI copied into `~/.wave/cli` and
- * ripgrep downloaded (best-effort). The CLI version tracks the extension
+ * Ensure the `wave` CLI is ready: bundled CLI copied into `~/.wave/cli/vscode`
+ * and ripgrep downloaded (best-effort). The CLI version tracks the extension
  * version, so there is no separate upgrade step.
  */
 export async function ensureCliUpToDate(

--- a/packages/vscode/tests/stdio/binaryResolver.test.ts
+++ b/packages/vscode/tests/stdio/binaryResolver.test.ts
@@ -56,6 +56,7 @@ import {
   decodeCommandOutput,
   setExtensionPath,
   cliInstallDir,
+  rgInstallDir,
   NPM_REGISTRY,
   _resetCacheForTesting,
 } from "../../src/stdio/binaryResolver";
@@ -64,7 +65,7 @@ const EXT = "/ext/install";
 const bundledDir = () => path.join(EXT, "dist", "wave-cli");
 const bundledEntry = () => path.join(bundledDir(), "bin", "wave-code.js");
 const entry = () =>
-  path.join("/fake/home", ".wave", "cli", "bin", "wave-code.js");
+  path.join("/fake/home", ".wave", "cli", "vscode", "bin", "wave-code.js");
 const rgBin = () =>
   path.join(
     "/fake/home/.wave/cli/node_modules/@vscode",
@@ -153,6 +154,20 @@ describe("binaryResolver (bundled CLI + downloaded rg)", () => {
     vi.unstubAllGlobals();
   });
 
+  it("cliInstallDir is per-end (vscode) while rg stays at the shared root", () => {
+    // Each frontend (vscode/desktop/jetbrains) owns its own subdir so they
+    // never overwrite each other's CLI copy.
+    expect(cliInstallDir()).toBe(
+      path.join("/fake/home", ".wave", "cli", "vscode"),
+    );
+    expect(entry()).toContain(path.join(".wave", "cli", "vscode"));
+    // rg is shared by all three frontends — a sibling of the per-end dir,
+    // not inside it, so a CLI re-copy never wipes the cached download.
+    expect(rgInstallDir()).toBe(
+      path.join("/fake/home", ".wave", "cli", "node_modules", "@vscode"),
+    );
+  });
+
   it("prefers WAVE_CLI_PATH override without touching bundle/rg", async () => {
     process.env.WAVE_CLI_PATH = "/dev/wave-code.js";
     memFs.set("/dev/wave-code.js", "dev shim");
@@ -176,7 +191,7 @@ describe("binaryResolver (bundled CLI + downloaded rg)", () => {
     await expect(resolveWaveBinary("1.0.0")).rejects.toThrow("缺少扩展路径");
   });
 
-  it("copies the bundled CLI into ~/.wave/cli on first use and downloads rg", async () => {
+  it("copies the bundled CLI into ~/.wave/cli/vscode on first use and downloads rg", async () => {
     seedBundledCli("1.0.0");
     mockRipgrepRegistry();
 


### PR DESCRIPTION
## What

The three frontends (VS Code extension / JetBrains plugin / desktop app) previously copied their bundled `wave` CLI into the same `~/.wave/cli` dir. When their bundled CLI versions differed, each launch overwrote the other's copy — version churn between frontends.

Per user decision, each frontend now owns its own subdir:

- `~/.wave/cli/vscode`
- `~/.wave/cli/desktop`
- `~/.wave/cli/jetbrains`

Each keeps its own version-overwrite logic (`prepareCli`), so frontends no longer interfere with each other.

## rg stays shared

The `@vscode/ripgrep` download (JS wrapper + platform rg binary) remains at the shared `~/.wave/cli/node_modules/@vscode` — deliberately a sibling of the per-end dirs:

- already-downloaded rg on user machines is not re-downloaded (path unchanged)
- a per-end CLI re-copy never wipes the cached rg

## Files

- `packages/vscode/src/stdio/binaryResolver.ts` + tests
- `packages/desktop/src/main/stdio/binaryResolver.ts` + tests
- `packages/jetbrains/.../stdio/BinaryResolver.kt` + tests
- `packages/jetbrains/.../stdio/StdioClient.kt` (comment path update)

## Verification

- vscode unit tests: 9 files / 155 passed; type-check green
- desktop unit tests: 19 files / 521 passed; type-check green
- jetbrains: no JDK on this machine — Gradle tests not run locally (path-only assertion tests added; verified on CI)
