### PR TITLE
feat(sdk): align session jsonl retention with Claude Code cleanupPeriodDays

### DIFF
--- a/docs/specs/core/session-retention.md
+++ b/docs/specs/core/session-retention.md
@@ -1,0 +1,84 @@
+---
+name: "会话文件保留清理"
+description: "按可配置保留期清理过期的会话 jsonl 文件（对齐 Claude Code）"
+order: 160
+---
+
+# 功能规格说明：会话文件保留清理
+
+**创建日期**：2026-08-22
+
+## 澄清
+
+### 2026-08-22 决策确认（用户拍板）
+
+- **触发位置**：`setupAgentContainer`（containerSetup.ts）fire-and-forget 后台执行，模块级 flag 保证每进程只扫一次（对齐 CC「启动时后台执行一次」）
+- **旧机制**：删除 `cleanupExpiredSessionsFromJsonl`（14 天硬编码、per-workdir、session restore 时触发），统一由新的全局 30 天清理覆盖
+- **`cleanupPeriodDays: 0`**：跳过清理（永不删除会话文件），防止 cutoff=now 误删全部历史
+- **配置范围**：user → project → local 三 scope 合并（last-wins），与其他 scalar 配置（language/model 等）模式一致
+
+## 用户场景与测试 _（必填）_
+
+### 用户故事：过期会话文件后台清理（优先级：P1，对齐 Claude Code）
+
+作为用户，我希望过期的会话记录被自动清理，以便 `~/.wave/projects` 不会无限膨胀。
+
+**为什么是这个优先级**：对齐 Claude Code 的 `cleanupOldSessionFiles()`（默认 30 天保留期），是磁盘占用治理的基础能力；当前 jsonl 仅靠 14 天 per-workdir 清理兜底，无法覆盖全部项目目录。
+
+**独立测试**：可以构造一个含旧 jsonl（mtime 早于 cutoff）与新 jsonl（mtime 晚于 cutoff）的项目目录，执行清理函数，验证只有旧文件被删除、新文件保留、删除计数正确。
+
+**验收场景**：
+
+1. **假设** `~/.wave/projects` 下存在 mtime 早于保留期 cutoff 的会话 jsonl（主会话 `<uuid>.jsonl` 与子代理 `subagent-<uuid>.jsonl`），**当**启动时后台清理执行，**则**这些文件必须被删除
+2. **假设**会话 jsonl 的 mtime 晚于 cutoff，**当**清理执行，**则**该文件必须被保留（jsonl 追加写会使 mtime 反映最后活动时间，与 CC 的文件 mtime 判断一致）
+3. **假设**项目目录在清理后为空，**当**清理执行完毕，**则**空项目目录必须被删除；目录中仍有文件（如 `memory/`）时必须保留
+4. **假设**`~/.wave/projects` 目录不存在或不可读，**当**清理执行，**则**必须静默跳过，不得报错中断启动
+
+---
+
+### 用户故事：可配置保留期（优先级：P1，对齐 Claude Code）
+
+作为用户，我希望通过 `settings.json` 的 `cleanupPeriodDays` 控制保留天数，以便按需延长或缩短会话保留期。
+
+**为什么是这个优先级**：对齐 CC 的 `settings.cleanupPeriodDays ?? DEFAULT_CLEANUP_PERIOD_DAYS(30)`；默认 30 天，用户可覆盖。
+
+**独立测试**：可以在 settings.json 中设置 `cleanupPeriodDays` 为不同值，验证清理 cutoff 随之变化；设置 `0` 时验证清理整体跳过。
+
+**验收场景**：
+
+1. **假设**用户未设置 `cleanupPeriodDays`，**当**清理执行，**则**保留期必须为默认 30 天
+2. **假设**用户在 `~/.wave/settings.json` 设置 `cleanupPeriodDays: 60`，**当**清理执行，**则**保留期必须为 60 天（仅删 mtime 早于 60 天前 cutoff 的文件）
+3. **假设**用户设置 `cleanupPeriodDays: 0`，**当**清理执行，**则**必须跳过清理，不得删除任何会话文件
+4. **假设**project/local scope 的 settings.json 也设置了 `cleanupPeriodDays`，**当**清理执行，**则**按 user → project → local 优先级取最后一个非 undefined 值（last-wins）
+
+---
+
+### 用户故事：误删守卫（优先级：P1，对齐 Claude Code）
+
+作为用户，我希望在 settings 配置异常时清理被安全跳过，以便不会因解析失败导致会话被误删。
+
+**为什么是这个优先级**：对齐 CC 的守卫（`getSettingsWithAllErrors().errors.length > 0 && rawSettingsContainsKey('cleanupPeriodDays')` → 跳过清理）；用户显式设过保留期时，配置损坏回退默认值可能删除用户本想保留的文件。
+
+**独立测试**：可以构造「settings.json 校验失败且含 cleanupPeriodDays 键」与「校验失败但无该键」两种场景，验证前者跳过清理、后者按默认值清理。
+
+**验收场景**：
+
+1. **假设**settings 校验存在错误且用户显式设置过 `cleanupPeriodDays`，**当**启动触发清理，**则**必须整体跳过清理（日志提示修复 settings 后清理才会启用）
+2. **假设**settings 校验存在错误但用户未设置 `cleanupPeriodDays`，**当**启动触发清理，**则**按默认 30 天执行（用户未表达保留意图，默认值安全）
+3. **假设**settings 文件为损坏的 JSON（无法解析），**当**启动触发清理，**则**必须跳过清理，不得基于残缺配置删除任何文件
+4. **假设**清理仅记录删除/错误计数并输出 debug 日志，**当**执行完毕，**则**不得抛出异常影响 Agent 启动
+
+---
+
+### 用户故事：auto-memory 保护（优先级：P1）
+
+作为用户，我希望会话清理只删除 jsonl 会话文件，不触碰项目的 auto-memory 文件，以便长期记忆不丢失。
+
+**为什么是这个优先级**：`~/.wave/projects/<project>/memory/` 存放 auto-memory（`MEMORY.md` 等），是跨会话记忆的载体，一旦误删无法恢复。
+
+**独立测试**：可以构造含 `memory/` 子目录与过期 jsonl 的项目目录，执行清理，验证 jsonl 被删、`memory/` 内容完整保留、目录不被删除。
+
+**验收场景**：
+
+1. **假设**项目目录含 `memory/` 子目录（内含 `MEMORY.md`），**当**清理执行，**则**`memory/` 及其内容必须原样保留
+2. **假设**项目目录在删除所有过期 jsonl 后仍含 `memory/`，**当**清理执行完毕，**则**项目目录不得被删除（空目录清理只针对无残留内容的目录）

--- a/packages/agent-sdk/src/services/configurationService.ts
+++ b/packages/agent-sdk/src/services/configurationService.ts
@@ -52,6 +52,216 @@ import { ensureWaveRuntimeFilesExcluded } from "../utils/gitUtils.js";
 import { atomicWriteFile } from "../utils/atomicWrite.js";
 
 /**
+ * Validate a configuration object's structure and values. Module-level so it
+ * can be reused without instantiating ConfigurationService (e.g. background
+ * session cleanup runs before config is loaded).
+ */
+export function validateConfigurationObject(
+  config: WaveConfiguration,
+): ValidationResult {
+  const result: ValidationResult = {
+    isValid: true,
+    errors: [],
+    warnings: [],
+  };
+
+  // Validate basic structure
+  if (!config || typeof config !== "object") {
+    result.isValid = false;
+    result.errors.push("Configuration must be a valid object");
+    return result;
+  }
+
+  // Validate hooks if present
+  if (config.hooks !== undefined) {
+    if (typeof config.hooks !== "object" || config.hooks === null) {
+      result.isValid = false;
+      result.errors.push("Hooks configuration must be an object");
+    } else {
+      for (const [event, eventConfigs] of Object.entries(config.hooks)) {
+        if (!isValidHookEvent(event)) {
+          result.warnings.push(`Unknown hook event: ${event}`);
+          continue;
+        }
+
+        if (!Array.isArray(eventConfigs)) {
+          result.isValid = false;
+          result.errors.push(`Hook event '${event}' must be an array`);
+          continue;
+        }
+
+        // Validate individual hook configurations
+        for (let i = 0; i < eventConfigs.length; i++) {
+          const hookConfig = eventConfigs[i];
+          if (!hookConfig || typeof hookConfig !== "object") {
+            result.isValid = false;
+            result.errors.push(
+              `Hook configuration ${i} for event '${event}' must be an object`,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  // Validate enabledPlugins if present
+  if (config.enabledPlugins !== undefined) {
+    if (
+      typeof config.enabledPlugins !== "object" ||
+      config.enabledPlugins === null
+    ) {
+      result.isValid = false;
+      result.errors.push("enabledPlugins configuration must be an object");
+    } else {
+      for (const [pluginId, enabled] of Object.entries(config.enabledPlugins)) {
+        if (typeof enabled !== "boolean") {
+          result.isValid = false;
+          result.errors.push(
+            `Value for plugin '${pluginId}' in enabledPlugins must be a boolean`,
+          );
+        }
+        if (!pluginId.includes("@")) {
+          result.warnings.push(
+            `Plugin ID '${pluginId}' in enabledPlugins should follow 'name@marketplace' format`,
+          );
+        }
+      }
+    }
+  }
+
+  // Validate environment variables if present
+  if (config.env !== undefined) {
+    const envValidation = validateEnvironmentConfig(config.env);
+    if (!envValidation.isValid) {
+      result.isValid = false;
+      result.errors.push(...envValidation.errors);
+    }
+    result.warnings.push(...envValidation.warnings);
+  }
+
+  // Validate permissions if present
+  if (config.permissions !== undefined) {
+    if (typeof config.permissions !== "object" || config.permissions === null) {
+      result.isValid = false;
+      result.errors.push("Permissions configuration must be an object");
+    } else {
+      // Validate allow if present
+      if (config.permissions.allow !== undefined) {
+        if (!Array.isArray(config.permissions.allow)) {
+          result.isValid = false;
+          result.errors.push("Permissions allow must be an array of strings");
+        } else if (
+          !config.permissions.allow.every((rule) => typeof rule === "string")
+        ) {
+          result.isValid = false;
+          result.errors.push("All permission allow rules must be strings");
+        }
+      }
+
+      // Validate deny if present
+      if (config.permissions.deny !== undefined) {
+        if (!Array.isArray(config.permissions.deny)) {
+          result.isValid = false;
+          result.errors.push("Permissions deny must be an array of strings");
+        } else if (
+          !config.permissions.deny.every((rule) => typeof rule === "string")
+        ) {
+          result.isValid = false;
+          result.errors.push("All permission deny rules must be strings");
+        }
+      }
+
+      // Validate permissionMode if present
+      if (config.permissions.permissionMode !== undefined) {
+        const validModes: PermissionMode[] = [
+          "default",
+          "bypassPermissions",
+          "acceptEdits",
+          "plan",
+          "dontAsk",
+        ];
+        if (!validModes.includes(config.permissions.permissionMode)) {
+          result.isValid = false;
+          result.errors.push(
+            `Invalid permissionMode: "${config.permissions.permissionMode}". Must be one of: ${validModes.join(", ")}`,
+          );
+        }
+      }
+    }
+  }
+
+  // Validate autoMemoryEnabled if present
+  if (
+    config.autoMemoryEnabled !== undefined &&
+    typeof config.autoMemoryEnabled !== "boolean"
+  ) {
+    result.isValid = false;
+    result.errors.push("autoMemoryEnabled configuration must be a boolean");
+  }
+
+  // Validate autoMemoryFrequency if present
+  if (
+    config.autoMemoryFrequency !== undefined &&
+    (typeof config.autoMemoryFrequency !== "number" ||
+      config.autoMemoryFrequency <= 0)
+  ) {
+    result.isValid = false;
+    result.errors.push(
+      "autoMemoryFrequency configuration must be a positive number",
+    );
+  }
+
+  // Validate cleanupPeriodDays if present
+  if (
+    config.cleanupPeriodDays !== undefined &&
+    (typeof config.cleanupPeriodDays !== "number" ||
+      !Number.isInteger(config.cleanupPeriodDays) ||
+      config.cleanupPeriodDays < 0)
+  ) {
+    result.isValid = false;
+    result.errors.push(
+      "cleanupPeriodDays configuration must be a non-negative integer",
+    );
+  }
+
+  // Validate models if present
+  if (config.models !== undefined) {
+    if (typeof config.models !== "object" || config.models === null) {
+      result.isValid = false;
+      result.errors.push("models configuration must be an object");
+    } else {
+      for (const [modelName, modelConfig] of Object.entries(config.models)) {
+        if (typeof modelConfig !== "object" || modelConfig === null) {
+          result.isValid = false;
+          result.errors.push(
+            `Configuration for model '${modelName}' must be an object`,
+          );
+        }
+      }
+    }
+  }
+
+  // Validate worktree if present
+  if (config.worktree !== undefined) {
+    if (typeof config.worktree !== "object" || config.worktree === null) {
+      result.isValid = false;
+      result.errors.push("worktree configuration must be an object");
+    } else if (
+      config.worktree.baseRef !== undefined &&
+      config.worktree.baseRef !== "fresh" &&
+      config.worktree.baseRef !== "head"
+    ) {
+      result.isValid = false;
+      result.errors.push(
+        `Invalid worktree.baseRef: "${config.worktree.baseRef}". Must be "fresh" or "head".`,
+      );
+    }
+  }
+
+  return result;
+}
+
+/**
  * Default ConfigurationService implementation
  *
  * Provides centralized configuration loading, validation, and management.
@@ -172,198 +382,7 @@ export class ConfigurationService {
    * Validate configuration object structure and values
    */
   validateConfiguration(config: WaveConfiguration): ValidationResult {
-    const result: ValidationResult = {
-      isValid: true,
-      errors: [],
-      warnings: [],
-    };
-
-    // Validate basic structure
-    if (!config || typeof config !== "object") {
-      result.isValid = false;
-      result.errors.push("Configuration must be a valid object");
-      return result;
-    }
-
-    // Validate hooks if present
-    if (config.hooks !== undefined) {
-      if (typeof config.hooks !== "object" || config.hooks === null) {
-        result.isValid = false;
-        result.errors.push("Hooks configuration must be an object");
-      } else {
-        for (const [event, eventConfigs] of Object.entries(config.hooks)) {
-          if (!isValidHookEvent(event)) {
-            result.warnings.push(`Unknown hook event: ${event}`);
-            continue;
-          }
-
-          if (!Array.isArray(eventConfigs)) {
-            result.isValid = false;
-            result.errors.push(`Hook event '${event}' must be an array`);
-            continue;
-          }
-
-          // Validate individual hook configurations
-          for (let i = 0; i < eventConfigs.length; i++) {
-            const hookConfig = eventConfigs[i];
-            if (!hookConfig || typeof hookConfig !== "object") {
-              result.isValid = false;
-              result.errors.push(
-                `Hook configuration ${i} for event '${event}' must be an object`,
-              );
-            }
-          }
-        }
-      }
-    }
-
-    // Validate enabledPlugins if present
-    if (config.enabledPlugins !== undefined) {
-      if (
-        typeof config.enabledPlugins !== "object" ||
-        config.enabledPlugins === null
-      ) {
-        result.isValid = false;
-        result.errors.push("enabledPlugins configuration must be an object");
-      } else {
-        for (const [pluginId, enabled] of Object.entries(
-          config.enabledPlugins,
-        )) {
-          if (typeof enabled !== "boolean") {
-            result.isValid = false;
-            result.errors.push(
-              `Value for plugin '${pluginId}' in enabledPlugins must be a boolean`,
-            );
-          }
-          if (!pluginId.includes("@")) {
-            result.warnings.push(
-              `Plugin ID '${pluginId}' in enabledPlugins should follow 'name@marketplace' format`,
-            );
-          }
-        }
-      }
-    }
-
-    // Validate environment variables if present
-    if (config.env !== undefined) {
-      const envValidation = validateEnvironmentConfig(config.env);
-      if (!envValidation.isValid) {
-        result.isValid = false;
-        result.errors.push(...envValidation.errors);
-      }
-      result.warnings.push(...envValidation.warnings);
-    }
-
-    // Validate permissions if present
-    if (config.permissions !== undefined) {
-      if (
-        typeof config.permissions !== "object" ||
-        config.permissions === null
-      ) {
-        result.isValid = false;
-        result.errors.push("Permissions configuration must be an object");
-      } else {
-        // Validate allow if present
-        if (config.permissions.allow !== undefined) {
-          if (!Array.isArray(config.permissions.allow)) {
-            result.isValid = false;
-            result.errors.push("Permissions allow must be an array of strings");
-          } else if (
-            !config.permissions.allow.every((rule) => typeof rule === "string")
-          ) {
-            result.isValid = false;
-            result.errors.push("All permission allow rules must be strings");
-          }
-        }
-
-        // Validate deny if present
-        if (config.permissions.deny !== undefined) {
-          if (!Array.isArray(config.permissions.deny)) {
-            result.isValid = false;
-            result.errors.push("Permissions deny must be an array of strings");
-          } else if (
-            !config.permissions.deny.every((rule) => typeof rule === "string")
-          ) {
-            result.isValid = false;
-            result.errors.push("All permission deny rules must be strings");
-          }
-        }
-
-        // Validate permissionMode if present
-        if (config.permissions.permissionMode !== undefined) {
-          const validModes: PermissionMode[] = [
-            "default",
-            "bypassPermissions",
-            "acceptEdits",
-            "plan",
-            "dontAsk",
-          ];
-          if (!validModes.includes(config.permissions.permissionMode)) {
-            result.isValid = false;
-            result.errors.push(
-              `Invalid permissionMode: "${config.permissions.permissionMode}". Must be one of: ${validModes.join(", ")}`,
-            );
-          }
-        }
-      }
-    }
-
-    // Validate autoMemoryEnabled if present
-    if (
-      config.autoMemoryEnabled !== undefined &&
-      typeof config.autoMemoryEnabled !== "boolean"
-    ) {
-      result.isValid = false;
-      result.errors.push("autoMemoryEnabled configuration must be a boolean");
-    }
-
-    // Validate autoMemoryFrequency if present
-    if (
-      config.autoMemoryFrequency !== undefined &&
-      (typeof config.autoMemoryFrequency !== "number" ||
-        config.autoMemoryFrequency <= 0)
-    ) {
-      result.isValid = false;
-      result.errors.push(
-        "autoMemoryFrequency configuration must be a positive number",
-      );
-    }
-
-    // Validate models if present
-    if (config.models !== undefined) {
-      if (typeof config.models !== "object" || config.models === null) {
-        result.isValid = false;
-        result.errors.push("models configuration must be an object");
-      } else {
-        for (const [modelName, modelConfig] of Object.entries(config.models)) {
-          if (typeof modelConfig !== "object" || modelConfig === null) {
-            result.isValid = false;
-            result.errors.push(
-              `Configuration for model '${modelName}' must be an object`,
-            );
-          }
-        }
-      }
-    }
-
-    // Validate worktree if present
-    if (config.worktree !== undefined) {
-      if (typeof config.worktree !== "object" || config.worktree === null) {
-        result.isValid = false;
-        result.errors.push("worktree configuration must be an object");
-      } else if (
-        config.worktree.baseRef !== undefined &&
-        config.worktree.baseRef !== "fresh" &&
-        config.worktree.baseRef !== "head"
-      ) {
-        result.isValid = false;
-        result.errors.push(
-          `Invalid worktree.baseRef: "${config.worktree.baseRef}". Must be "fresh" or "head".`,
-        );
-      }
-    }
-
-    return result;
+    return validateConfigurationObject(config);
   }
 
   /**
@@ -1337,6 +1356,10 @@ export function loadWaveConfigFromFile(
         config.autoMemoryFrequency !== undefined
           ? config.autoMemoryFrequency
           : undefined,
+      cleanupPeriodDays:
+        config.cleanupPeriodDays !== undefined
+          ? config.cleanupPeriodDays
+          : undefined,
       models: config.models || undefined,
       marketplaces: config.marketplaces || undefined,
       worktree: config.worktree || undefined,
@@ -1495,6 +1518,11 @@ export function loadMergedWaveConfig(
       mergedConfig.autoMemoryFrequency = config.autoMemoryFrequency;
     }
 
+    // Merge cleanupPeriodDays (last one wins)
+    if (config.cleanupPeriodDays !== undefined) {
+      mergedConfig.cleanupPeriodDays = config.cleanupPeriodDays;
+    }
+
     // Merge marketplaces (last one wins for same key)
     if (config.marketplaces) {
       if (!mergedConfig.marketplaces) mergedConfig.marketplaces = {};
@@ -1545,6 +1573,7 @@ export function loadMergedWaveConfig(
     language: mergedConfig.language,
     model: mergedConfig.model,
     autoMemoryEnabled: mergedConfig.autoMemoryEnabled,
+    cleanupPeriodDays: mergedConfig.cleanupPeriodDays,
     marketplaces:
       mergedConfig.marketplaces &&
       Object.keys(mergedConfig.marketplaces).length > 0

--- a/packages/agent-sdk/src/services/session.ts
+++ b/packages/agent-sdk/src/services/session.ts
@@ -75,7 +75,6 @@ export function generateSubagentFilename(sessionId: string): string {
 
 // Constants
 export const SESSION_DIR = join(homedir(), ".wave", "projects");
-const MAX_SESSION_AGE_DAYS = 14;
 
 /**
  * Ensure session directory exists
@@ -717,67 +716,6 @@ export async function listAllSessions(options?: {
 }
 
 /**
- * Clean up expired sessions older than 14 days based on file modification time
- *
- * @param workdir - Working directory to clean up sessions for
- * @returns Promise that resolves to the number of sessions that were deleted
- */
-export async function cleanupExpiredSessionsFromJsonl(
-  workdir: string,
-): Promise<number> {
-  // Do not perform cleanup operations in test environment
-  if (process.env.NODE_ENV === "test") {
-    return 0;
-  }
-
-  try {
-    const encoder = new PathEncoder();
-    const projectDir = await encoder.getProjectDirectory(workdir, SESSION_DIR);
-    const files = await fs.readdir(projectDir.encodedPath);
-
-    const now = new Date();
-    const maxAge = MAX_SESSION_AGE_DAYS * 24 * 60 * 60 * 1000; // Convert to milliseconds
-    let deletedCount = 0;
-
-    for (const file of files) {
-      if (!file.endsWith(".jsonl")) {
-        continue;
-      }
-
-      const filePath = join(projectDir.encodedPath, file);
-
-      try {
-        const stat = await fs.stat(filePath);
-        const fileAge = now.getTime() - stat.mtime.getTime();
-
-        if (fileAge > maxAge) {
-          await fs.unlink(filePath);
-          deletedCount++;
-        }
-      } catch {
-        // Skip failed operations and continue processing other files
-        continue;
-      }
-    }
-
-    // Clean up empty project directory if no files remain
-    try {
-      const remainingFiles = await fs.readdir(projectDir.encodedPath);
-      if (remainingFiles.length === 0) {
-        await fs.rmdir(projectDir.encodedPath);
-      }
-    } catch {
-      // Ignore errors if directory is not empty or can't be removed
-    }
-
-    return deletedCount;
-  } catch {
-    // Return 0 if project directory doesn't exist or can't be accessed
-    return 0;
-  }
-}
-
-/**
  * Clean up empty project directories in the session directory
  */
 export async function cleanupEmptyProjectDirectories(): Promise<void> {
@@ -1068,11 +1006,6 @@ export async function handleSessionRestoration(
   if (!workdir) {
     throw new Error("Working directory is required for session restoration");
   }
-
-  // Clean up expired sessions first
-  cleanupExpiredSessionsFromJsonl(workdir).catch((error) => {
-    logger.warn("Failed to cleanup expired sessions:", error);
-  });
 
   if (!restoreSessionId && !continueLastSession) {
     return;

--- a/packages/agent-sdk/src/types/configuration.ts
+++ b/packages/agent-sdk/src/types/configuration.ts
@@ -61,6 +61,13 @@ export interface WaveConfiguration {
   };
   /** Whether the Artifact tool is enabled. Unset follows the code default constant (ARTIFACT_DEFAULT_ENABLED). */
   enableArtifact?: boolean;
+  /**
+   * Session transcript retention in days (aligned with Claude Code's
+   * cleanupPeriodDays). Session jsonl files in ~/.wave/projects older than
+   * this many days are cleaned up in the background at startup.
+   * Default: 30. 0 disables cleanup entirely.
+   */
+  cleanupPeriodDays?: number;
 }
 
 /**

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -24,6 +24,7 @@ import { LiveConfigManager } from "../managers/liveConfigManager.js";
 import { ConfigurationService } from "../services/configurationService.js";
 import { ReversionService } from "../services/reversionService.js";
 import { cleanupMetaOnlySessions } from "../services/session.js";
+import { runSessionCleanupInBackground } from "./sessionCleanup.js";
 import { MemoryService } from "../services/memory.js";
 import { AutoMemoryService } from "../services/autoMemoryService.js";
 import { USER_MEMORY_FILE } from "./constants.js";
@@ -227,6 +228,9 @@ export function setupAgentContainer(
     .catch((error) => {
       logger.error("Failed to cleanup meta-only session files:", error);
     });
+  // Global session retention cleanup (cleanupPeriodDays, default 30 days).
+  // Once per process; reads settings itself since config isn't loaded yet.
+  runSessionCleanupInBackground(workdir);
   const reversionManager = new ReversionManager(container);
   container.register("ReversionManager", reversionManager);
 

--- a/packages/agent-sdk/src/utils/sessionCleanup.ts
+++ b/packages/agent-sdk/src/utils/sessionCleanup.ts
@@ -1,0 +1,207 @@
+/**
+ * Session retention cleanup — aligned with Claude Code's cleanupOldSessionFiles()
+ * (~/.claude-code/src/utils/cleanup.ts).
+ *
+ * Scans ~/.wave/projects for session .jsonl files (main `<uuid>.jsonl` and
+ * `subagent-<uuid>.jsonl`) whose mtime is older than the retention cutoff and
+ * deletes them, then removes project directories left empty. Auto-memory
+ * (`memory/` subdirectories) is never touched.
+ *
+ * Retention is configurable via settings `cleanupPeriodDays` (default 30).
+ * `0` disables cleanup. If settings are corrupt or fail validation while the
+ * user explicitly set `cleanupPeriodDays`, cleanup is skipped entirely — the
+ * same guard Claude Code uses to avoid deleting files when the configured
+ * retention period cannot be trusted.
+ */
+
+import { existsSync, promises as fs } from "fs";
+import { join } from "path";
+import { logger } from "./globalLogger.js";
+import { SESSION_DIR } from "../services/session.js";
+import {
+  loadMergedWaveConfig,
+  validateConfigurationObject,
+} from "../services/configurationService.js";
+import { getProjectConfigPaths, getUserConfigPaths } from "./configPaths.js";
+
+/** Default retention period in days (Claude Code DEFAULT_CLEANUP_PERIOD_DAYS). */
+export const DEFAULT_CLEANUP_PERIOD_DAYS = 30;
+
+export interface SessionCleanupResult {
+  /** Number of session files deleted */
+  deleted: number;
+  /** Number of files/directories that failed to process */
+  errors: number;
+}
+
+// Module-level flag: session cleanup runs once per process, on first agent
+// container setup — aligned with CC's once-per-process startup housekeeping.
+let cleanupScheduled = false;
+
+/**
+ * Resolve the effective cleanup period in days, or null to skip cleanup.
+ *
+ * null (skip) happens when:
+ * - settings files exist but cannot be parsed/loaded (corrupt JSON, mid-write)
+ * - settings validation fails AND the user explicitly set cleanupPeriodDays
+ *
+ * Missing settings entirely is NOT a skip: the default 30 days applies.
+ */
+export function resolveCleanupPeriodDays(workdir: string): number | null {
+  let merged;
+  try {
+    merged = loadMergedWaveConfig(workdir);
+  } catch (error) {
+    logger.debug(
+      `Session cleanup: skipping (failed to load settings: ${(error as Error).message})`,
+    );
+    return null;
+  }
+
+  // No config file at all → default retention. Config files exist but merged
+  // config is null (corrupt JSON / empty file) → skip conservatively rather
+  // than deleting based on a partial config.
+  if (merged === null) {
+    if (hasAnySettingsFile(workdir)) {
+      logger.debug(
+        "Session cleanup: skipping (settings file exists but could not be parsed)",
+      );
+      return null;
+    }
+    return DEFAULT_CLEANUP_PERIOD_DAYS;
+  }
+
+  // Guard (CC): validation errors + explicit cleanupPeriodDays → skip entirely.
+  const validation = validateConfigurationObject(merged);
+  if (validation.errors.length > 0 && merged.cleanupPeriodDays !== undefined) {
+    logger.debug(
+      "Session cleanup: skipping (settings have validation errors but cleanupPeriodDays was explicitly set). Fix settings errors to enable cleanup.",
+    );
+    return null;
+  }
+
+  return merged.cleanupPeriodDays ?? DEFAULT_CLEANUP_PERIOD_DAYS;
+}
+
+/**
+ * Delete session .jsonl files in ~/.wave/projects older than periodDays,
+ * then remove project directories left empty. Directories that still contain
+ * anything (e.g. `memory/` auto-memory) are preserved. Never throws; errors
+ * are counted and skipped, and a missing/unreadable projects dir is a silent
+ * no-op.
+ */
+export async function cleanupOldSessionFiles(
+  periodDays: number,
+): Promise<SessionCleanupResult> {
+  const result: SessionCleanupResult = { deleted: 0, errors: 0 };
+  const cutoffDate = new Date(Date.now() - periodDays * 24 * 60 * 60 * 1000);
+
+  let projectEntries;
+  try {
+    projectEntries = await fs.readdir(SESSION_DIR, { withFileTypes: true });
+  } catch {
+    // Projects dir doesn't exist or is unreadable — nothing to clean
+    return result;
+  }
+
+  for (const projectEntry of projectEntries) {
+    if (!projectEntry.isDirectory()) continue;
+    const projectDir = join(SESSION_DIR, projectEntry.name);
+
+    let entries;
+    try {
+      entries = await fs.readdir(projectDir, { withFileTypes: true });
+    } catch {
+      result.errors++;
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+      try {
+        if (await unlinkIfOld(join(projectDir, entry.name), cutoffDate)) {
+          result.deleted++;
+        }
+      } catch {
+        result.errors++;
+      }
+    }
+
+    // Removes the project dir only if it is now empty; dirs still containing
+    // files (e.g. memory/) or subdirectories are left untouched.
+    await tryRmdir(projectDir);
+  }
+
+  return result;
+}
+
+/**
+ * Kick off session cleanup in the background, once per process. Fire-and-forget:
+ * never throws, never blocks agent startup. In test environments cleanup is a
+ * no-op (same convention as the other startup cleanups in session.ts).
+ */
+export function runSessionCleanupInBackground(workdir: string): void {
+  if (process.env.NODE_ENV === "test") return;
+  if (cleanupScheduled) return;
+  cleanupScheduled = true;
+
+  void (async () => {
+    try {
+      const periodDays = resolveCleanupPeriodDays(workdir);
+      if (periodDays === null) {
+        return; // skip reason already logged in resolveCleanupPeriodDays
+      }
+      if (periodDays === 0) {
+        logger.debug("Session cleanup: disabled (cleanupPeriodDays is 0)");
+        return;
+      }
+      const result = await cleanupOldSessionFiles(periodDays);
+      if (result.deleted > 0) {
+        logger.debug(
+          `Session cleanup: removed ${result.deleted} session file(s)`,
+        );
+      }
+      if (result.errors > 0) {
+        logger.warn(
+          `Session cleanup: encountered ${result.errors} error(s) while cleaning session files`,
+        );
+      }
+    } catch (error) {
+      logger.warn(
+        `Session cleanup failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  })();
+}
+
+/**
+ * Whether any settings file exists that loadMergedWaveConfig would consider
+ * (user settings.json + project settings.json/local.json).
+ */
+function hasAnySettingsFile(workdir: string): boolean {
+  const userPaths = getUserConfigPaths();
+  const projectPaths = getProjectConfigPaths(workdir);
+  return [userPaths[0], projectPaths[1], projectPaths[0]].some((p) =>
+    existsSync(p),
+  );
+}
+
+async function unlinkIfOld(
+  filePath: string,
+  cutoffDate: Date,
+): Promise<boolean> {
+  const stats = await fs.stat(filePath);
+  if (stats.mtime < cutoffDate) {
+    await fs.unlink(filePath);
+    return true;
+  }
+  return false;
+}
+
+async function tryRmdir(dirPath: string): Promise<void> {
+  try {
+    await fs.rmdir(dirPath);
+  } catch {
+    // Not empty or doesn't exist
+  }
+}

--- a/packages/agent-sdk/tests/agent/agent.taskListId.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.taskListId.test.ts
@@ -15,7 +15,6 @@ vi.mock("../../src/services/session.js", () => ({
   listSessionsFromJsonl: vi.fn(),
   deleteSessionFromJsonl: vi.fn(),
   sessionExistsInJsonl: vi.fn(),
-  cleanupExpiredSessionsFromJsonl: vi.fn(() => Promise.resolve(0)),
   cleanupMetaOnlySessions: vi.fn(() => Promise.resolve(0)),
   getSessionFilePath: vi.fn(),
   ensureSessionDir: vi.fn(),

--- a/packages/agent-sdk/tests/agent/agent.taskSessionRestore.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.taskSessionRestore.test.ts
@@ -18,7 +18,6 @@ vi.mock("../../src/services/session.js", () => ({
   listSessionsFromJsonl: vi.fn(),
   deleteSessionFromJsonl: vi.fn(),
   sessionExistsInJsonl: vi.fn(),
-  cleanupExpiredSessionsFromJsonl: vi.fn(() => Promise.resolve(0)),
   cleanupMetaOnlySessions: vi.fn(() => Promise.resolve(0)),
   getSessionFilePath: vi.fn(),
   ensureSessionDir: vi.fn(),

--- a/packages/agent-sdk/tests/managers/subagentManager.sessions.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.sessions.test.ts
@@ -62,7 +62,6 @@ vi.mock("../../src/services/session.js", () => ({
   listSessions: vi.fn().mockResolvedValue([]),
   listSessionsFromJsonl: vi.fn().mockResolvedValue([]),
   deleteSessionFromJsonl: vi.fn().mockResolvedValue(true),
-  cleanupExpiredSessionsFromJsonl: vi.fn().mockResolvedValue(0),
   sessionExistsInJsonl: vi.fn().mockResolvedValue(false),
   getSessionFilePath: vi.fn().mockImplementation((sessionId, workdir) => {
     const baseDir = `/mock/session/dir/encoded-${encodeURIComponent(workdir)}`;

--- a/packages/agent-sdk/tests/services/session.extra.test.ts
+++ b/packages/agent-sdk/tests/services/session.extra.test.ts
@@ -4,7 +4,6 @@ import {
   truncateContent,
   getFirstMessageContent,
   cleanupEmptyProjectDirectories,
-  cleanupExpiredSessionsFromJsonl,
   cleanupMetaOnlySessions,
   ensureSessionDir,
   SESSION_DIR,
@@ -292,45 +291,6 @@ describe("session service - additional coverage", () => {
     });
   });
 
-  describe("cleanupExpiredSessionsFromJsonl", () => {
-    it("should delete expired files and update index", async () => {
-      const workdir = "/test/workdir";
-      const sessionId = "12345678-1234-4321-8765-123456789012";
-      const filename = `${sessionId}.jsonl`;
-
-      // Reset NODE_ENV to development to allow cleanup
-      const oldEnv = process.env.NODE_ENV;
-      process.env.NODE_ENV = "development";
-
-      vi.mocked(fs.readdir).mockResolvedValueOnce([
-        filename,
-      ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
-      vi.mocked(fs.stat).mockResolvedValue({
-        mtime: new Date(Date.now() - 20 * 24 * 60 * 60 * 1000), // 20 days old
-      } as unknown as Awaited<ReturnType<typeof fs.stat>>);
-
-      vi.mocked(fs.readFile).mockResolvedValue(
-        JSON.stringify({
-          sessions: {
-            [sessionId]: {
-              lastActiveAt: new Date().toISOString(),
-              createdAt: new Date().toISOString(),
-            },
-          },
-          lastUpdated: new Date().toISOString(),
-        }),
-      );
-
-      const deleted = await cleanupExpiredSessionsFromJsonl(workdir);
-
-      expect(deleted).toBe(1);
-      expect(fs.unlink).toHaveBeenCalled();
-      // expect(fs.writeFile).toHaveBeenCalled(); // Index updated - might fail if sessionId doesn't match exactly or other issues
-
-      process.env.NODE_ENV = oldEnv;
-    });
-  });
-
   describe("cleanupMetaOnlySessions", () => {
     const metaMessage = {
       role: "user",
@@ -467,7 +427,9 @@ describe("session service - additional coverage", () => {
     });
 
     it("should throw when restoreSessionId is not found (no silent fresh session)", async () => {
-      vi.mocked(fs.access).mockRejectedValue(new Error("ENOENT"));
+      vi.mocked(fs.access).mockRejectedValue(
+        Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+      );
 
       await expect(
         handleSessionRestoration(validSessionId, false, workdir),

--- a/packages/agent-sdk/tests/services/session.integration.test.ts
+++ b/packages/agent-sdk/tests/services/session.integration.test.ts
@@ -64,7 +64,6 @@ import {
   loadSessionFromJsonl,
   listSessionsFromJsonl,
   getLatestSessionFromJsonl,
-  cleanupExpiredSessionsFromJsonl,
 } from "@/services/session.js";
 import type { Message } from "@/types/index.js";
 import { generateMessageId } from "@/utils/messageOperations.js";
@@ -360,14 +359,6 @@ describe("Session Integration Tests", () => {
 
       expect(latestSession).toBeTruthy();
       expect(latestSession!.id).toBe(session1Id); // Session1 has more recent activity
-    });
-
-    it("should cleanup expired sessions", async () => {
-      // Since cleanup is disabled in test environment, it should return 0
-      const deletedCount = await cleanupExpiredSessionsFromJsonl(testWorkdir);
-
-      // Should be 0 since cleanup is disabled in test environment
-      expect(deletedCount).toBe(0);
     });
   });
 

--- a/packages/agent-sdk/tests/utils/sessionCleanup.test.ts
+++ b/packages/agent-sdk/tests/utils/sessionCleanup.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { existsSync, promises as fs } from "fs";
+import { join } from "path";
+import {
+  DEFAULT_CLEANUP_PERIOD_DAYS,
+  cleanupOldSessionFiles,
+  resolveCleanupPeriodDays,
+  runSessionCleanupInBackground,
+} from "../../src/utils/sessionCleanup.js";
+import { SESSION_DIR } from "../../src/services/session.js";
+import { loadMergedWaveConfig } from "../../src/services/configurationService.js";
+
+vi.mock("fs", () => ({
+  existsSync: vi.fn(),
+  promises: {
+    readdir: vi.fn(),
+    stat: vi.fn(),
+    unlink: vi.fn(),
+    rmdir: vi.fn(),
+  },
+}));
+
+vi.mock(
+  "../../src/services/configurationService.js",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../src/services/configurationService.js")
+      >();
+    return {
+      ...actual,
+      loadMergedWaveConfig: vi.fn(),
+    };
+  },
+);
+
+vi.mock("../../src/utils/configPaths.js", () => ({
+  getUserConfigPaths: vi.fn(() => ["/mock/user/settings.json"]),
+  getProjectConfigPaths: vi.fn(() => [
+    "/mock/project/settings.local.json",
+    "/mock/project/settings.json",
+  ]),
+}));
+
+// Dirent-shaped stand-in for fs.readdir withFileTypes results
+function dirent(
+  name: string,
+  isFile: boolean,
+): Awaited<ReturnType<typeof fs.readdir>>[number] {
+  return {
+    name,
+    isFile: () => isFile,
+    isDirectory: () => !isFile,
+  } as unknown as Awaited<ReturnType<typeof fs.readdir>>[number];
+}
+
+const daysAgo = (days: number): Date =>
+  new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+describe("cleanupOldSessionFiles", () => {
+  beforeEach(() => {
+    vi.mocked(loadMergedWaveConfig).mockReset();
+    vi.mocked(fs.readdir).mockReset();
+    vi.mocked(fs.stat).mockReset();
+    vi.mocked(fs.unlink).mockReset();
+    vi.mocked(fs.rmdir).mockReset();
+  });
+
+  it("deletes expired jsonl files (main + subagent) and keeps fresh ones", async () => {
+    vi.mocked(fs.readdir).mockResolvedValueOnce([
+      dirent("project1", false),
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+    vi.mocked(fs.readdir).mockResolvedValueOnce([
+      dirent("abc.jsonl", true),
+      dirent("subagent-def.jsonl", true),
+      dirent("fresh.jsonl", true),
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+    vi.mocked(fs.stat).mockImplementation(async (filePath) => {
+      const age = String(filePath).includes("fresh") ? 1 : 40;
+      return { mtime: daysAgo(age) } as Awaited<ReturnType<typeof fs.stat>>;
+    });
+
+    const result = await cleanupOldSessionFiles(30);
+
+    expect(result).toEqual({ deleted: 2, errors: 0 });
+    expect(fs.unlink).toHaveBeenCalledWith(
+      join(SESSION_DIR, "project1", "abc.jsonl"),
+    );
+    expect(fs.unlink).toHaveBeenCalledWith(
+      join(SESSION_DIR, "project1", "subagent-def.jsonl"),
+    );
+    expect(fs.unlink).not.toHaveBeenCalledWith(
+      join(SESSION_DIR, "project1", "fresh.jsonl"),
+    );
+  });
+
+  it("preserves memory/ subdirectories and never touches their contents", async () => {
+    vi.mocked(fs.readdir).mockResolvedValueOnce([
+      dirent("project1", false),
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+    vi.mocked(fs.readdir).mockResolvedValueOnce([
+      dirent("old.jsonl", true),
+      dirent("memory", false),
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+    vi.mocked(fs.stat).mockResolvedValue({
+      mtime: daysAgo(40),
+    } as Awaited<ReturnType<typeof fs.stat>>);
+    // Project dir still holds memory/ → rmdir fails, swallowed silently
+    vi.mocked(fs.rmdir).mockRejectedValueOnce(
+      Object.assign(new Error("ENOTEMPTY"), { code: "ENOTEMPTY" }),
+    );
+
+    const result = await cleanupOldSessionFiles(30);
+
+    expect(result).toEqual({ deleted: 1, errors: 0 });
+    expect(fs.unlink).toHaveBeenCalledTimes(1);
+    expect(fs.rmdir).toHaveBeenCalledWith(join(SESSION_DIR, "project1"));
+  });
+
+  it("removes project directories left empty after cleanup", async () => {
+    vi.mocked(fs.readdir).mockResolvedValueOnce([
+      dirent("empty1", false),
+      dirent("empty2", false),
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+    vi.mocked(fs.readdir).mockResolvedValueOnce([]);
+    vi.mocked(fs.readdir).mockResolvedValueOnce([]);
+
+    const result = await cleanupOldSessionFiles(30);
+
+    expect(result).toEqual({ deleted: 0, errors: 0 });
+    expect(fs.rmdir).toHaveBeenCalledWith(join(SESSION_DIR, "empty1"));
+    expect(fs.rmdir).toHaveBeenCalledWith(join(SESSION_DIR, "empty2"));
+  });
+
+  it("silently no-ops when the projects dir does not exist", async () => {
+    vi.mocked(fs.readdir).mockRejectedValueOnce(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+    );
+
+    const result = await cleanupOldSessionFiles(30);
+
+    expect(result).toEqual({ deleted: 0, errors: 0 });
+    expect(fs.unlink).not.toHaveBeenCalled();
+    expect(fs.rmdir).not.toHaveBeenCalled();
+  });
+
+  it("counts errors for unreadable project dirs", async () => {
+    vi.mocked(fs.readdir).mockResolvedValueOnce([
+      dirent("broken", false),
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+    vi.mocked(fs.readdir).mockRejectedValueOnce(new Error("EACCES"));
+
+    const result = await cleanupOldSessionFiles(30);
+
+    expect(result).toEqual({ deleted: 0, errors: 1 });
+  });
+
+  it("counts errors when stat fails on a session file", async () => {
+    vi.mocked(fs.readdir).mockResolvedValueOnce([
+      dirent("project1", false),
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+    vi.mocked(fs.readdir).mockResolvedValueOnce([
+      dirent("abc.jsonl", true),
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+    vi.mocked(fs.stat).mockRejectedValueOnce(new Error("ENOENT"));
+
+    const result = await cleanupOldSessionFiles(30);
+
+    expect(result).toEqual({ deleted: 0, errors: 1 });
+  });
+});
+
+describe("resolveCleanupPeriodDays", () => {
+  beforeEach(() => {
+    vi.mocked(loadMergedWaveConfig).mockReset();
+    vi.mocked(existsSync).mockReset();
+  });
+
+  it("returns the default 30 days when no settings files exist", () => {
+    vi.mocked(loadMergedWaveConfig).mockReturnValue(null);
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    expect(resolveCleanupPeriodDays("/mock/workdir")).toBe(
+      DEFAULT_CLEANUP_PERIOD_DAYS,
+    );
+  });
+
+  it("returns the configured cleanupPeriodDays", () => {
+    vi.mocked(loadMergedWaveConfig).mockReturnValue({ cleanupPeriodDays: 60 });
+
+    expect(resolveCleanupPeriodDays("/mock/workdir")).toBe(60);
+  });
+
+  it("returns 0 when cleanupPeriodDays is 0 (cleanup disabled)", () => {
+    vi.mocked(loadMergedWaveConfig).mockReturnValue({ cleanupPeriodDays: 0 });
+
+    expect(resolveCleanupPeriodDays("/mock/workdir")).toBe(0);
+  });
+
+  it("returns null (skip) when settings exist but cannot be parsed", () => {
+    vi.mocked(loadMergedWaveConfig).mockReturnValue(null);
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    expect(resolveCleanupPeriodDays("/mock/workdir")).toBeNull();
+  });
+
+  it("returns null (skip) when validation fails and cleanupPeriodDays was set", () => {
+    // Negative value is invalid → validation errors + explicit key → guard
+    vi.mocked(loadMergedWaveConfig).mockReturnValue({ cleanupPeriodDays: -5 });
+
+    expect(resolveCleanupPeriodDays("/mock/workdir")).toBeNull();
+  });
+
+  it("returns the default when validation fails but cleanupPeriodDays was not set", () => {
+    // autoMemoryFrequency must be positive → validation errors, no explicit key
+    vi.mocked(loadMergedWaveConfig).mockReturnValue({
+      autoMemoryFrequency: -1,
+    });
+
+    expect(resolveCleanupPeriodDays("/mock/workdir")).toBe(
+      DEFAULT_CLEANUP_PERIOD_DAYS,
+    );
+  });
+});
+
+describe("runSessionCleanupInBackground", () => {
+  beforeEach(() => {
+    vi.mocked(loadMergedWaveConfig).mockReset();
+    vi.mocked(fs.readdir).mockReset();
+  });
+
+  it("is a no-op in test environment", () => {
+    runSessionCleanupInBackground("/mock/workdir");
+
+    expect(loadMergedWaveConfig).not.toHaveBeenCalled();
+  });
+
+  it("runs cleanup at most once per process", async () => {
+    const oldEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+    vi.mocked(loadMergedWaveConfig).mockReturnValue(null);
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(fs.readdir).mockResolvedValue(
+      [] as unknown as Awaited<ReturnType<typeof fs.readdir>>,
+    );
+
+    try {
+      runSessionCleanupInBackground("/mock/workdir");
+      runSessionCleanupInBackground("/mock/other");
+
+      await vi.waitFor(() => {
+        expect(loadMergedWaveConfig).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      process.env.NODE_ENV = oldEnv;
+    }
+  });
+});


### PR DESCRIPTION
## 背景

Wave 会话 jsonl 保留期对齐 Claude Code（`~/claude-code/src/utils/cleanup.ts`）。此前 Wave 仅靠 14 天 per-workdir 清理（`cleanupExpiredSessionsFromJsonl`，session restore 时触发），无法覆盖全部项目目录，且保留期硬编码。

## 改动

- **新模块 `packages/agent-sdk/src/utils/sessionCleanup.ts`**：全局扫描 `~/.wave/projects`，删除 mtime 早于 cutoff 的会话 jsonl（主会话 `<uuid>.jsonl` + `subagent-<uuid>.jsonl`），随后清理空项目目录；`memory/`（auto-memory）绝不触碰
  - 保留期默认 **30 天**，可通过 `settings.json` 的 `cleanupPeriodDays` 配置（user → project → local 三 scope，last-wins）；`0` = 禁用清理
  - **误删守卫**（对齐 CC）：settings 解析失败（corrupt JSON）→ 跳过；校验存在错误且用户显式设置过 `cleanupPeriodDays` → 整体跳过
  - 触发：`setupAgentContainer` fire-and-forget 后台执行，模块级 flag 保证每进程只跑一次；测试环境 no-op
- **配置通道**：`WaveConfiguration.cleanupPeriodDays` 字段；`validateConfiguration` 校验体提取为模块级 `validateConfigurationObject`（供清理模块在配置加载前复用），load/merge 均含新字段
- **删除旧机制**：`cleanupExpiredSessionsFromJsonl`（14 天硬编码、per-workdir）+ `MAX_SESSION_AGE_DAYS` + restore 时触发点
- **spec**：`docs/specs/core/session-retention.md`（4 用户故事：过期清理 / 可配置保留期 / 误删守卫 / auto-memory 保护）

## 验证

- agent-sdk 全量测试（含 integration）：3678 passed / 4 skipped
- `tsc --noEmit`（全仓 pre-commit type-check 通过）、oxlint 0 警告 0 错误、prettier 通过
- spec-count：77 specs / 408 US / 1622 AC

## 测试

- 新增 `tests/utils/sessionCleanup.test.ts`（14 个）：删旧留新、memory 保护、空目录移除、缺失目录静默、错误计数、守卫 6 场景、每进程一次
- 既有测试清理对已删函数的引用；`session.extra.test.ts` 修复 restore-fallback 测试（mock error 补 `.code: "ENOENT"`，此前依赖被删的 cleanup 调用才通过）
