### PR TITLE
fix(update): run install detached on Windows to avoid locked bin shims

### DIFF
--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -31,6 +31,7 @@ import {
   READ_ONLY_COMMANDS,
 } from "../utils/bashParser.js";
 import { isPathInside } from "../utils/pathSafety.js";
+import { toWindowsPath } from "../utils/path.js";
 import {
   BASH_TOOL_NAME,
   EDIT_TOOL_NAME,
@@ -395,34 +396,45 @@ export class PermissionManager {
   ): { isInside: boolean; resolvedPath: string } {
     const effectiveWorkdir = this.workdir || workdir;
 
+    // Convert MSYS/git-bash style paths (/c/Users/...) to native Windows form
+    // so `cd /c/...` and file args resolve correctly on win32 instead of
+    // becoming bogus C:\c\... paths that never match the Safe Zone.
+    const normalizedTarget = toWindowsPath(targetPath);
+    const normalizedWorkdir = effectiveWorkdir
+      ? toWindowsPath(effectiveWorkdir)
+      : undefined;
+
     // Resolve the target path relative to effectiveWorkdir if it's not absolute
     const absolutePath =
-      effectiveWorkdir && !path.isAbsolute(targetPath)
-        ? path.resolve(effectiveWorkdir, targetPath)
-        : path.resolve(targetPath);
+      normalizedWorkdir && !path.isAbsolute(normalizedTarget)
+        ? path.resolve(normalizedWorkdir, normalizedTarget)
+        : path.resolve(normalizedTarget);
 
     // Check workdir
-    if (effectiveWorkdir && isPathInside(absolutePath, effectiveWorkdir)) {
+    if (
+      effectiveWorkdir &&
+      isPathInside(absolutePath, toWindowsPath(effectiveWorkdir))
+    ) {
       return { isInside: true, resolvedPath: absolutePath };
     }
 
     // Check additional directories
     for (const dir of this.additionalDirectories) {
-      if (isPathInside(absolutePath, dir)) {
+      if (isPathInside(absolutePath, toWindowsPath(dir))) {
         return { isInside: true, resolvedPath: absolutePath };
       }
     }
 
     // Check instance additional directories
     for (const dir of this.instanceAdditionalDirectories) {
-      if (isPathInside(absolutePath, dir)) {
+      if (isPathInside(absolutePath, toWindowsPath(dir))) {
         return { isInside: true, resolvedPath: absolutePath };
       }
     }
 
     // Check system additional directories
     for (const dir of this.systemAdditionalDirectories) {
-      if (isPathInside(absolutePath, dir)) {
+      if (isPathInside(absolutePath, toWindowsPath(dir))) {
         return { isInside: true, resolvedPath: absolutePath };
       }
     }


### PR DESCRIPTION
## Summary

Fixes Windows-specific issues in the wave CLI:

1. **Detached self-update on Windows** (`wave update`): the running `wave` process keeps the global bin shims (e.g. `%APPDATA%\npm\wave.cmd`) locked, so npm cannot overwrite them while we are alive. The update now exits first and lets a detached child process perform the install.
2. **Direct-run detection on Windows**: `import.meta.url` uses forward-slash file:// URLs while `process.argv[1]` keeps backslashes — a naive string comparison silently skipped `main()`. Fixed by comparing via `pathToFileURL(path.resolve(argv[1])).href`.
3. **Drop Unix-style inline `NODE_OPTIONS` from the wave script** (fails in cmd.exe) and remove the `wave:debug` script.
4. **Normalize MSYS/git-bash paths in Safe Zone checks**: on Windows, `cd /c/Users/...` resolved to a bogus `C:\c\Users\...` so permission prompts appeared even for allowed commands (e.g. skills with allowed-tools). `isInsideSafeZone` now converts via the existing `toWindowsPath` before resolving.

## Changes

- `packages/code/src/commands/update.ts` — detached install branch on win32
- `packages/code/src/index.ts` — pathToFileURL direct-run check
- `package.json` / `AGENTS.md` — remove NODE_OPTIONS prefix and wave:debug
- `docs/specs/ui/update-command.md` — spec for Windows background update
- `packages/agent-sdk/src/managers/permissionManager.ts` — MSYS path normalization in `isInsideSafeZone`

## Verification

- `pnpm -r type-check`, oxlint, and unit tests pass
- Probe confirmed `/c/Users/...` now matches the Safe Zone on win32