### PR TITLE
fix(marketplace): route update diagnostics through logger on interactive terminals

### DIFF
--- a/packages/agent-sdk/src/services/MarketplaceService.ts
+++ b/packages/agent-sdk/src/services/MarketplaceService.ts
@@ -13,7 +13,7 @@ import {
 import { GitService } from "./GitService.js";
 import { ConfigurationService } from "./configurationService.js";
 import type { MarketplaceConfig, Scope } from "../types/configuration.js";
-import { logger } from "../utils/globalLogger.js";
+import { logger, logError, logWarn } from "../utils/globalLogger.js";
 
 /**
  * Marketplace Service
@@ -368,7 +368,7 @@ export class MarketplaceService {
       }
       return JSON.parse(content);
     } catch (error) {
-      console.error("Failed to load installed plugins:", error);
+      logError("Failed to load installed plugins:", error);
       return { plugins: [] };
     }
   }
@@ -711,7 +711,7 @@ export class MarketplaceService {
             marketplace.source.source === "git"
           ) {
             if (!isGitAvailable) {
-              console.warn(
+              logWarn(
                 `Skipping update for Git/GitHub marketplace "${marketplace.name}" because Git is not installed.`,
               );
               continue;
@@ -763,7 +763,7 @@ export class MarketplaceService {
                     plugin.projectPath,
                   );
                 } catch (error) {
-                  console.error(
+                  logError(
                     `Failed to uninstall orphaned plugin "${plugin.name}" from marketplace "${marketplace.name}":`,
                     error,
                   );
@@ -776,7 +776,7 @@ export class MarketplaceService {
                   plugin.projectPath,
                 );
               } catch (error) {
-                console.error(
+                logError(
                   `Failed to update plugin "${plugin.name}" from marketplace "${marketplace.name}":`,
                   error,
                 );
@@ -785,7 +785,7 @@ export class MarketplaceService {
           }
         } catch (error) {
           const msg = `Failed to update marketplace "${marketplace.name}": ${error instanceof Error ? error.message : String(error)}`;
-          console.error(msg);
+          logError(msg);
           errors.push(msg);
         }
       }
@@ -815,7 +815,7 @@ export class MarketplaceService {
             updatePlugins: true,
           });
         } catch (error) {
-          console.error(
+          logError(
             `Auto-update failed for marketplace "${marketplaceName}":`,
             error,
           );

--- a/packages/agent-sdk/src/utils/globalLogger.ts
+++ b/packages/agent-sdk/src/utils/globalLogger.ts
@@ -126,3 +126,30 @@ export const logger = {
     globalLogger.error(...args);
   },
 } as const;
+
+/**
+ * Log an error through the channel matching the execution context:
+ * - Interactive terminals (stdout is a TTY) with a configured global logger
+ *   route through the logger (e.g. a log file), keeping the terminal UI clean.
+ * - Non-interactive hosts (stdio pipes, scripts) and contexts without a
+ *   configured logger fall back to stderr via console.error.
+ */
+export function logError(...args: unknown[]): void {
+  if (process.stdout.isTTY && isLoggerConfigured()) {
+    logger.error(...args);
+  } else {
+    console.error(...args);
+  }
+}
+
+/**
+ * Log a warning through the channel matching the execution context
+ * (see logError for the routing rule).
+ */
+export function logWarn(...args: unknown[]): void {
+  if (process.stdout.isTTY && isLoggerConfigured()) {
+    logger.warn(...args);
+  } else {
+    console.warn(...args);
+  }
+}

--- a/packages/agent-sdk/tests/utils/globalLogger.test.ts
+++ b/packages/agent-sdk/tests/utils/globalLogger.test.ts
@@ -15,6 +15,8 @@ import {
   clearGlobalLogger,
   isLoggerConfigured,
   logger,
+  logError,
+  logWarn,
 } from "../../src/utils/globalLogger.js";
 import {
   createMockLogger,
@@ -595,6 +597,92 @@ describe("Global Logger Registry", () => {
       expect(returningLogger.info).toHaveBeenCalledWith("test");
       expect(returningLogger.warn).toHaveBeenCalledWith("test");
       expect(returningLogger.error).toHaveBeenCalledWith("test");
+    });
+  });
+
+  // =============================================================================
+  // Context-Aware logError/logWarn Tests
+  // =============================================================================
+
+  describe("logError/logWarn context routing", () => {
+    const originalIsTTY = process.stdout.isTTY;
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+    let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: originalIsTTY,
+        configurable: true,
+      });
+      consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
+    });
+
+    it("should route to the global logger on a TTY with a configured logger", () => {
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: true,
+        configurable: true,
+      });
+      setGlobalLogger(mockLogger);
+
+      const error = new Error("bad");
+      logError("boom", error);
+      logWarn("heads up");
+
+      expectLoggerCall(mockLogger, "error", ["boom", error]);
+      expectLoggerCall(mockLogger, "warn", ["heads up"]);
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it("should fall back to stderr on a TTY without a configured logger", () => {
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: true,
+        configurable: true,
+      });
+      clearGlobalLogger();
+
+      logError("boom");
+      logWarn("heads up");
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith("boom");
+      expect(consoleWarnSpy).toHaveBeenCalledWith("heads up");
+      expectNoLoggerCalls(mockLogger);
+    });
+
+    it("should use stderr on a non-TTY even with a configured logger", () => {
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: false,
+        configurable: true,
+      });
+      setGlobalLogger(mockLogger);
+
+      logError("boom");
+      logWarn("heads up");
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith("boom");
+      expect(consoleWarnSpy).toHaveBeenCalledWith("heads up");
+      expectNoLoggerCalls(mockLogger);
+    });
+
+    it("should use stderr on a non-TTY without a configured logger", () => {
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: false,
+        configurable: true,
+      });
+      clearGlobalLogger();
+
+      logError("boom");
+      logWarn("heads up");
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith("boom");
+      expect(consoleWarnSpy).toHaveBeenCalledWith("heads up");
+      expectNoLoggerCalls(mockLogger);
     });
   });
 });


### PR DESCRIPTION
## 问题

Marketplace 自动更新失败时（如 github.com 网络不可达），`MarketplaceService` 用 `console.error`/`console.warn` 无条件输出到 stderr，在交互式 Ink 终端下会把原始错误堆栈直接打到 UI 上。

## 修复

- `packages/agent-sdk/src/utils/globalLogger.ts`：新增 `logError`/`logWarn`，按场景路由：
  - **交互式**（stdout 为 TTY 且已配置全局 logger）→ 走 logger（写入日志文件，终端 UI 保持干净）
  - **非交互式**（stdio 管道、脚本、未配置 logger）→ 回落 `console.error`/`console.warn`（stderr），外部宿主（VS Code 输出通道、桌面、脚本）仍可捕获
- `packages/agent-sdk/src/services/MarketplaceService.ts`：6 处 `console.error`/`console.warn` 全部替换为 `logError`/`logWarn`
- 新增 4 个路由单测覆盖 TTY/非 TTY × logger 配置/未配置

## 验证

- agent-sdk 全量单测：249 文件 / 3539 passed
- type-check、oxlint、prettier 通过