### PR TITLE
feat(logging): unify CLI and host error logs under ~/.wave/logs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -371,10 +371,10 @@ wave -p --show-stats "分析这个项目的依赖关系"
 
 ## 8. 环境变量 {#environment-variables}
 
-| 变量           | 默认值            | 描述                                       |
-| -------------- | ----------------- | ------------------------------------------ |
-| `LOG_LEVEL`    | `INFO`            | 日志级别：`DEBUG`、`INFO`、`WARN`、`ERROR` |
-| `LOG_KEYWORDS` | -                 | 日志关键词过滤，仅输出包含指定关键词的日志 |
-| `LOG_FILE`     | `~/.wave/app.log` | 日志文件路径                               |
+| 变量           | 默认值                 | 描述                                                                       |
+| -------------- | ---------------------- | -------------------------------------------------------------------------- |
+| `LOG_LEVEL`    | `INFO`                 | 日志级别：`DEBUG`、`INFO`、`WARN`、`ERROR`                                 |
+| `LOG_KEYWORDS` | -                      | 日志关键词过滤，仅输出包含指定关键词的日志                                 |
+| `LOG_FILE`     | `~/.wave/logs/cli.log` | 日志文件路径（桌面端/IDE 插件分别为 desktop.log/vscode.log/jetbrains.log） |
 
 > 了解更多：详见 [SDK 文档 - 环境变量](/sdk#settings-env)

--- a/docs/specs/enterprise/opentelemetry.md
+++ b/docs/specs/enterprise/opentelemetry.md
@@ -8,7 +8,7 @@ order: 30
 
 **创建日期**：2026-05-09
 
-## 用户场景与测试 *（必填）*
+## 用户场景与测试 _（必填）_
 
 ### 用户故事：使用 OTLP 导出器的远程遥测（优先级：P1）
 
@@ -30,14 +30,14 @@ order: 30
 
 作为开发者，我希望遥测数据写入专用的 JSONL 文件（`~/.wave/telemetry.jsonl`），以便通过 tail 文件观察 span 和 metric，而无需外部收集器。
 
-**为什么是这个优先级**：JSONL 匹配 Wave 现有的会话文件格式——每行是一个自包含的 JSON 记录，易于 `tail -f`、用 `jq` 解析或流式传输到下游工具。与 `~/.wave/app.log`（文本日志）和 `~/.wave/sessions/*.jsonl`（会话数据）解耦。
+**为什么是这个优先级**：JSONL 匹配 Wave 现有的会话文件格式——每行是一个自包含的 JSON 记录，易于 `tail -f`、用 `jq` 解析或流式传输到下游工具。与 `~/.wave/logs/`（文本日志，cli.log/desktop.log/vscode.log/jetbrains.log）和 `~/.wave/sessions/*.jsonl`（会话数据）解耦。
 
 **独立测试**：使用 `OTEL_METRICS_EXPORTER=jsonl OTEL_TRACES_EXPORTER=jsonl` 运行 Wave，与 agent 交互，并观察 `~/.wave/telemetry.jsonl` 中的结构化 JSONL 记录。
 
 **验收场景**：
 
-1. **假设** Wave 使用 `OTEL_TRACES_EXPORTER=jsonl` 启动，**当** agent 处理消息时，**则** `~/.wave/telemetry.jsonl` 包含每个 span 一行 JSON（交互、LLM 请求、工具）。`~/.wave/app.log` 不受影响。
-2. **假设** Wave 使用 `OTEL_METRICS_EXPORTER=jsonl` 启动，**当** agent 完成一轮时，**则** `~/.wave/telemetry.jsonl` 包含 metric JSON 行。`~/.wave/app.log` 不受影响。
+1. **假设** Wave 使用 `OTEL_TRACES_EXPORTER=jsonl` 启动，**当** agent 处理消息时，**则** `~/.wave/telemetry.jsonl` 包含每个 span 一行 JSON（交互、LLM 请求、工具）。`~/.wave/logs/cli.log` 不受影响。
+2. **假设** Wave 使用 `OTEL_METRICS_EXPORTER=jsonl` 启动，**当** agent 完成一轮时，**则** `~/.wave/telemetry.jsonl` 包含 metric JSON 行。`~/.wave/logs/cli.log` 不受影响。
 3. **假设**有遥测 JSONL 文件，**当**通过 `jq` 管道传输时，**则**每行独立解析为有效 JSON。
 
 ---
@@ -66,4 +66,3 @@ order: 30
 - **并行工具执行期间会怎样？** 每个工具调用必须使用 AsyncLocalStorage 在正确的父交互 span 下创建自己的子 span，以防止 span 上下文混合。
 - **在 100+ 轮的长时间运行会话中会怎样？** 超过 30 分钟的活动 span 必须被清理以防止内存泄漏。
 - **如果遥测初始化失败会怎样？** agent 必须在没有遥测的情况下正常启动；记录警告但不崩溃。
-

--- a/packages/code/src/utils/constants.ts
+++ b/packages/code/src/utils/constants.ts
@@ -12,9 +12,14 @@ import os from "os";
 export const DATA_DIRECTORY = path.join(os.homedir(), ".wave");
 
 /**
- * Application log file path
+ * Log directory — one file per surface (cli/desktop/vscode/jetbrains).
  */
-export const LOG_FILE = path.join(DATA_DIRECTORY, "app.log");
+export const LOGS_DIRECTORY = path.join(DATA_DIRECTORY, "logs");
+
+/**
+ * CLI log file path
+ */
+export const LOG_FILE = path.join(LOGS_DIRECTORY, "cli.log");
 
 /**
  * Pagination related constants

--- a/packages/code/src/utils/logger.ts
+++ b/packages/code/src/utils/logger.ts
@@ -9,9 +9,10 @@
  */
 
 import * as fs from "fs";
+import * as path from "path";
 import { Chalk } from "chalk";
 import { getLastLines } from "wave-agent-sdk";
-import { LOG_FILE, DATA_DIRECTORY } from "./constants.js";
+import { LOG_FILE } from "./constants.js";
 
 const chalk = new Chalk({ level: 3 });
 
@@ -166,9 +167,10 @@ const logMessage = (level: LogLevel, ...args: unknown[]): void => {
   const formattedMessage = `[${chalk.gray(timestamp)}] [${color(levelName)}] ${messageText}\n`;
 
   try {
-    // Ensure directory exists
-    if (!fs.existsSync(DATA_DIRECTORY)) {
-      fs.mkdirSync(DATA_DIRECTORY, { recursive: true });
+    // Ensure the log file's directory exists (LOG_FILE moved to ~/.wave/logs)
+    const logDir = path.dirname(logFile);
+    if (!fs.existsSync(logDir)) {
+      fs.mkdirSync(logDir, { recursive: true });
     }
 
     // Write log to file

--- a/packages/code/tests/utils/logger.test.ts
+++ b/packages/code/tests/utils/logger.test.ts
@@ -7,7 +7,7 @@ import {
   getLogFile,
   cleanupLogs,
 } from "../../src/utils/logger.js";
-import { DATA_DIRECTORY } from "../../src/utils/constants.js";
+import { LOGS_DIRECTORY } from "../../src/utils/constants.js";
 import { stripAnsiColors } from "wave-agent-sdk";
 
 // Mock fs
@@ -175,7 +175,7 @@ describe("Logger Utility", () => {
 
       logger.info("test message");
 
-      expect(fs.mkdirSync).toHaveBeenCalledWith(DATA_DIRECTORY, {
+      expect(fs.mkdirSync).toHaveBeenCalledWith(LOGS_DIRECTORY, {
         recursive: true,
       });
       expect(fs.appendFileSync).toHaveBeenCalled();

--- a/packages/desktop/src/main/hostLog.ts
+++ b/packages/desktop/src/main/hostLog.ts
@@ -1,0 +1,70 @@
+/**
+ * Host-side file logger for the Electron main process (desktop.log).
+ *
+ * Appends plain-text `[ISO-8601] [LEVEL] message` lines to
+ * ~/.wave/logs/desktop.log; the wave --stdio child writes its own cli.log via
+ * the CLI logger. No level filtering and no console patching — callers use it
+ * explicitly at chokepoints. Files are kept bounded: after each append the
+ * file is truncated to the last 1000 lines when it exceeds 1MB, mirroring
+ * the CLI logger (which keeps 10MB — it is a high-volume session log).
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const LOG_FILE = path.join(
+  process.env.WAVE_LOGS_DIR || path.join(os.homedir(), ".wave", "logs"),
+  "desktop.log",
+);
+const MAX_FILE_SIZE = 1024 * 1024;
+const KEEP_LINES = 1000;
+
+const safeJson = (arg: object): string => {
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
+};
+
+const formatArg = (arg: unknown): string => {
+  let text: string;
+  if (arg instanceof Error) {
+    text = arg.stack || arg.message;
+  } else if (arg && typeof arg === "object") {
+    text = safeJson(arg);
+  } else {
+    text = String(arg);
+  }
+  return text.replace(/[\n\r]+/g, " ");
+};
+
+function append(level: string, ...args: unknown[]): void {
+  // Test environments opt out of real file I/O (same flag as the CLI logger).
+  if (process.env.DISABLE_LOGGER_IO === "true") return;
+  const line = `[${new Date().toISOString()}] [${level}] ${args.map(formatArg).join(" ")}\n`;
+  try {
+    fs.mkdirSync(path.dirname(LOG_FILE), { recursive: true });
+    fs.appendFileSync(LOG_FILE, line);
+    if (fs.existsSync(LOG_FILE) && fs.statSync(LOG_FILE).size > MAX_FILE_SIZE) {
+      const kept = fs
+        .readFileSync(LOG_FILE, "utf8")
+        .split("\n")
+        .slice(-KEEP_LINES)
+        .join("\n");
+      fs.writeFileSync(LOG_FILE, kept);
+    }
+  } catch (error) {
+    process.stderr.write(
+      `[${level}] Failed to write ${LOG_FILE}: ${formatArg(error)}\n`,
+    );
+  }
+}
+
+export const hostLog = {
+  debug: (...args: unknown[]) => append("DEBUG", ...args),
+  info: (...args: unknown[]) => append("INFO", ...args),
+  warn: (...args: unknown[]) => append("WARN", ...args),
+  error: (...args: unknown[]) => append("ERROR", ...args),
+};

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -10,6 +10,7 @@ import { app, BrowserWindow, ipcMain, nativeImage, shell } from "electron";
 import { execFileSync } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
+import { hostLog } from "./hostLog";
 import { WEBVIEW_CHANNEL } from "./channels";
 import { ConfigStore } from "./configStore";
 import { DesktopHost } from "./desktopHost";
@@ -129,6 +130,20 @@ function adoptLoginShellPath(): void {
 
 adoptLoginShellPath();
 
+// Host-side error logging: the wave --stdio children already write cli.log via
+// the CLI logger; these handlers cover the Electron main process itself
+// (desktop.log). uncaughtException keeps the existing crash semantics (log,
+// then exit) — registering a handler otherwise suppresses Node's default
+// termination.
+process.on("uncaughtException", (error) => {
+  hostLog.error("[Wave Desktop] uncaughtException:", error);
+  process.exit(1);
+});
+
+process.on("unhandledRejection", (reason) => {
+  hostLog.error("[Wave Desktop] unhandledRejection:", reason);
+});
+
 // Dev instances get their own userData so they can run alongside an installed
 // app (the single-instance lock is scoped to the userData directory) and never
 // touch the real config/session index.
@@ -197,6 +212,10 @@ if (!gotLock) {
     ipcMain.on(WEBVIEW_CHANNEL, (_event, message: Record<string, unknown>) => {
       void host?.handleWebviewMessage(message).catch((error) => {
         console.error(
+          "[Wave Desktop] Failed to handle webview message:",
+          error,
+        );
+        hostLog.error(
           "[Wave Desktop] Failed to handle webview message:",
           error,
         );
@@ -330,7 +349,11 @@ function createWindow(): void {
 
   // webview/ lives at the package root (synced by scripts/syncWebview.mjs);
   // dist/main → ../.. reaches the package root both in dev and inside app.asar.
-  void mainWindow.loadFile(
-    path.join(__dirname, "..", "..", "webview", "index.html"),
-  );
+  void mainWindow
+    .loadFile(path.join(__dirname, "..", "..", "webview", "index.html"))
+    .catch((error) => {
+      // A failed webview load is otherwise silent — surface it to desktop.log.
+      console.error("[Wave Desktop] Failed to load webview:", error);
+      hostLog.error("[Wave Desktop] Failed to load webview:", error);
+    });
 }

--- a/packages/desktop/src/main/stdio/stdioClient.ts
+++ b/packages/desktop/src/main/stdio/stdioClient.ts
@@ -8,6 +8,7 @@
  */
 
 import { type ChildProcess, spawn } from "child_process";
+import { hostLog } from "../hostLog";
 import { JsonRpcClient } from "./jsonRpcClient";
 
 export type { NotificationHandler } from "./jsonRpcClient";
@@ -91,7 +92,12 @@ export class StdioClient extends JsonRpcClient {
         this.stderrChunks.shift();
       }
       const trimmed = decodeStderr(data).trimEnd();
-      if (trimmed) this.onStderr?.(trimmed);
+      if (trimmed) {
+        this.onStderr?.(trimmed);
+        // The CLI child writes its own logs to cli.log; anything on stderr is
+        // runtime noise worth capturing at the host boundary.
+        hostLog.warn("[wave-stdio]", trimmed);
+      }
     });
 
     this.proc.on("exit", (code, signal) => {
@@ -100,11 +106,14 @@ export class StdioClient extends JsonRpcClient {
         `wave --stdio process exited (code: ${code}, signal: ${signal})`,
       ];
       if (stderr) parts.push(`stderr:\n${stderr}`);
-      this.handleClosed(parts.join("\n"));
+      const message = parts.join("\n");
+      hostLog.error("[wave-stdio]", message);
+      this.handleClosed(message);
     });
 
     this.proc.on("error", (err) => {
       console.error("[wave-stdio] Process error:", err);
+      hostLog.error("[wave-stdio] Process error:", err);
     });
   }
 

--- a/packages/desktop/tests/stdioClient.test.ts
+++ b/packages/desktop/tests/stdioClient.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+import { Readable } from "stream";
+import * as fs from "fs";
+import type { ChildProcess } from "child_process";
+import { StdioClient } from "../src/main/stdio/stdioClient.js";
+
+const h = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+}));
+
+vi.mock("child_process", () => ({
+  spawn: h.spawnMock,
+}));
+
+vi.mock("fs", () => ({
+  mkdirSync: vi.fn(),
+  appendFileSync: vi.fn(),
+  existsSync: vi.fn(),
+  statSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+const appendSpy = vi.mocked(fs.appendFileSync);
+
+interface FakeChild {
+  proc: ChildProcess;
+  stdin: EventEmitter & { write: ReturnType<typeof vi.fn> };
+  stdout: Readable;
+  stderr: EventEmitter;
+}
+
+function createFakeChild(): FakeChild {
+  const stdin = new EventEmitter() as FakeChild["stdin"];
+  stdin.write = vi.fn();
+  // readline's createInterface calls resume() on the input stream.
+  const stdout = new Readable({ read: () => {} });
+  const stderr = new EventEmitter();
+  const proc = new EventEmitter() as ChildProcess;
+  (proc as unknown as Record<string, unknown>).stdin = stdin;
+  (proc as unknown as Record<string, unknown>).stdout = stdout;
+  (proc as unknown as Record<string, unknown>).stderr = stderr;
+  (proc as unknown as Record<string, unknown>).kill = vi.fn();
+  return { proc, stdin, stdout, stderr };
+}
+
+describe("StdioClient host logging (desktop.log)", () => {
+  let child: FakeChild;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    delete process.env.DISABLE_LOGGER_IO;
+    child = createFakeChild();
+    h.spawnMock.mockReturnValue(child.proc);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const lastAppend = () => appendSpy.mock.calls.at(-1)!;
+
+  it("logs spawn errors to desktop.log at ERROR level", () => {
+    new StdioClient("wave", ["--stdio"]);
+
+    child.proc.emit("error", new Error("ENOENT: no such file"));
+
+    const [file, content] = lastAppend();
+    expect(String(file)).toContain("desktop.log");
+    expect(String(content)).toContain("[ERROR]");
+    expect(String(content)).toContain("[wave-stdio] Process error");
+    expect(String(content)).toContain("ENOENT");
+  });
+
+  it("logs process exit with code/signal and stderr tail at ERROR level", () => {
+    new StdioClient("wave", ["--stdio"]);
+
+    child.stderr.emit("data", Buffer.from("boom line\n"));
+    child.proc.emit("exit", 1, null);
+
+    const [file, content] = lastAppend();
+    expect(String(file)).toContain("desktop.log");
+    expect(String(content)).toContain("[ERROR]");
+    expect(String(content)).toContain("process exited (code: 1, signal: null)");
+    expect(String(content)).toContain("boom line");
+  });
+
+  it("logs child stderr lines at WARN level", () => {
+    new StdioClient("wave", ["--stdio"]);
+
+    child.stderr.emit("data", Buffer.from("runtime warning\n"));
+
+    const [file, content] = lastAppend();
+    expect(String(file)).toContain("desktop.log");
+    expect(String(content)).toContain("[WARN]");
+    expect(String(content)).toContain("runtime warning");
+  });
+});

--- a/packages/desktop/vitest.config.ts
+++ b/packages/desktop/vitest.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
     environment: "node",
     include: ["tests/**/*.test.ts"],
     exclude: ["node_modules"],
+    env: {
+      // Keep the file logger out of the user's real ~/.wave/logs during tests.
+      DISABLE_LOGGER_IO: "true",
+    },
     server: {
       deps: {
         inline: ["wave-agent-sdk", "wave-webview-fixtures"],

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/WaveBackendService.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/WaveBackendService.kt
@@ -12,6 +12,7 @@ import com.wave.jetbrains.stdio.BinaryResolver
 import com.wave.jetbrains.stdio.NotificationRouter
 import com.wave.jetbrains.stdio.StdioClient
 import com.wave.jetbrains.util.Edt
+import com.wave.jetbrains.util.WaveAppLog
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.JsonElement
@@ -87,6 +88,12 @@ class WaveBackendService(private val project: Project) : Disposable {
                     }
                     sharedClient = c
                     router = r
+                } catch (e: Exception) {
+                    // Single chokepoint for every CLI preparation failure (node
+                    // resolution, CLI copy, ripgrep download): record in
+                    // jetbrains.log, then let the caller surface the error.
+                    WaveAppLog.error("ensureClient failed", e)
+                    throw e
                 } finally {
                     // Dismiss the install-progress notification once the CLI is ready —
                     // it never auto-expires and would linger forever, making the user

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/WavePanel.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/WavePanel.kt
@@ -16,6 +16,7 @@ import com.wave.jetbrains.bridge.WebviewContentBuilder
 import com.wave.jetbrains.session.MessageHandler
 import com.wave.jetbrains.session.WaveSession
 import com.wave.jetbrains.util.Edt
+import com.wave.jetbrains.util.WaveAppLog
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.buildJsonObject
@@ -121,6 +122,7 @@ class WavePanel(private val project: Project, val tabId: String) : Disposable {
             bridge.loadUrl(assets.indexUrl)
         } catch (e: Exception) {
             LOG.error("Failed to load wave webview", e)
+            WaveAppLog.error("Failed to load wave webview", e)
         }
     }
 

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
@@ -1,6 +1,7 @@
 package com.wave.jetbrains.stdio
 
 import com.intellij.openapi.diagnostic.logger
+import com.wave.jetbrains.util.WaveAppLog
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -298,6 +299,7 @@ object BinaryResolver {
             File(rgBinaryPath()).exists()
         } catch (e: Exception) {
             LOG.warn("[Wave] ripgrep 下载失败，grep 工具暂不可用：", e)
+            WaveAppLog.warn("[Wave] ripgrep 下载失败，grep 工具暂不可用：${e.message}")
             false
         }
     }

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioClient.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioClient.kt
@@ -1,6 +1,7 @@
 package com.wave.jetbrains.stdio
 
 import com.intellij.openapi.diagnostic.logger
+import com.wave.jetbrains.util.WaveAppLog
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -64,6 +65,7 @@ class StdioClient(
         environment().putAll(env)
     }.also {
         LOG.info("Starting wave stdio: ${(command + args).joinToString(" ")}")
+        WaveAppLog.info("Starting wave stdio: ${(command + args).joinToString(" ")}")
     }.start()
 
     private val stdin: PrintWriter = PrintWriter(
@@ -94,6 +96,7 @@ class StdioClient(
                     var line = reader.readLine()
                     while (line != null) {
                         LOG.warn("[wave-stdio] $line")
+                        WaveAppLog.warn("[wave-stdio] $line")
                         synchronized(stderrBuffer) {
                             stderrBuffer.append(line).append('\n')
                             if (stderrBuffer.length > 4096) {
@@ -113,6 +116,7 @@ class StdioClient(
             val parts = mutableListOf("wave --stdio process exited (code: $code)")
             if (stderr.isNotEmpty()) parts.add("stderr:\n$stderr")
             val error = StdioClientException(parts.joinToString("\n"))
+            WaveAppLog.error(parts.joinToString("\n"))
             pending.values.forEach { it.completeExceptionally(error) }
             pending.clear()
             disposed = true

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/util/WaveAppLog.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/util/WaveAppLog.kt
@@ -1,0 +1,63 @@
+package com.wave.jetbrains.util
+
+import java.io.File
+import java.io.FileOutputStream
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+
+/**
+ * Host-side file logger for the JetBrains plugin.
+ *
+ * Appends one line per entry to `~/.wave/logs/jetbrains.log`, mirroring the
+ * CLI / other hosts convention (`cli.log` / `desktop.log` / `vscode.log`).
+ * The `wave --stdio` child writes its own `cli.log`; this object covers the
+ * plugin (IDE) process itself. Format is `[ISO-8601] [LEVEL] message` — plain
+ * text, single line per entry, matching the Node host loggers.
+ *
+ * The path uses `user.home` (like the CLI's `$HOME` and BinaryResolver's
+ * `~/.wave/cli`) — the XDG_CONFIG_HOME variable is intentionally ignored, so
+ * the directory stays consistent with the CLI on every OS.
+ *
+ * Files are kept bounded: after each append the file is truncated to the last
+ * [KEEP_LINES] lines when it exceeds [MAX_FILE_SIZE] bytes.
+ */
+object WaveAppLog {
+
+    private const val MAX_FILE_SIZE = 1L * 1024 * 1024
+    private const val KEEP_LINES = 1000
+
+    /**
+     * Log file path. `var` so tests can redirect to a temp file.
+     */
+    @Volatile
+    var logFile: File = File(System.getProperty("user.home"), ".wave/logs/jetbrains.log")
+
+    fun info(message: String) = log("INFO", message)
+
+    fun warn(message: String) = log("WARN", message)
+
+    fun error(message: String) = log("ERROR", message)
+
+    fun error(message: String, t: Throwable?) = log("ERROR", message + if (t != null) ": ${t.stackTraceToString()}" else "")
+
+    /**
+     * Append a single-line entry. Never throws — logging must never break the
+     * caller; write failures are silently skipped.
+     */
+    fun log(level: String, message: String) {
+        try {
+            logFile.parentFile?.mkdirs()
+            val line = "[${Instant.now()}] [$level] ${message.replace('\n', ' ').replace('\r', ' ')}\n"
+            FileOutputStream(logFile, true).bufferedWriter(StandardCharsets.UTF_8).use { it.write(line) }
+            truncateIfNeeded()
+        } catch (_: Exception) {
+            // Never break the caller.
+        }
+    }
+
+    private fun truncateIfNeeded() {
+        if (!logFile.exists() || logFile.length() <= MAX_FILE_SIZE) return
+        val kept = logFile.readLines().takeLast(KEEP_LINES)
+        logFile.writeText(kept.joinToString("\n") + "\n")
+    }
+}

--- a/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/util/WaveAppLogTest.kt
+++ b/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/util/WaveAppLogTest.kt
@@ -56,7 +56,7 @@ class WaveAppLogTest {
     fun `newlines in the message collapse to a single line`() {
         val f = newLogFile()
         WaveAppLog.logFile = f
-        WaveAppLog.error("line one\nline two\r\nline three")
+        WaveAppLog.error("line one\nline two\nline three")
 
         val lines = f.readLines()
         assertEquals(1, lines.size)

--- a/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/util/WaveAppLogTest.kt
+++ b/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/util/WaveAppLogTest.kt
@@ -1,0 +1,110 @@
+package com.wave.jetbrains.util
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+
+/**
+ * Tests for the host-side file logger [WaveAppLog].
+ *
+ * The object is a singleton, so every test redirects [WaveAppLog.logFile] to a
+ * temp file and restores the default afterwards.
+ */
+class WaveAppLogTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private fun newLogFile(): File = File(tempDir.toFile(), "jetbrains.log")
+
+    @AfterEach
+    fun restoreLogFile() {
+        WaveAppLog.logFile = File(System.getProperty("user.home"), ".wave/logs/jetbrains.log")
+    }
+
+    @Test
+    fun `log writes ISO-8601 LEVEL message format`() {
+        val f = newLogFile()
+        WaveAppLog.logFile = f
+        WaveAppLog.info("hello")
+
+        val line = f.readLines().single()
+        assertTrue(
+            line.matches(Regex("""^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z] \[INFO\] hello$""")),
+            "line was: $line",
+        )
+    }
+
+    @Test
+    fun `warn and error use their levels`() {
+        val f = newLogFile()
+        WaveAppLog.logFile = f
+        WaveAppLog.warn("careful")
+        WaveAppLog.error("boom")
+
+        val lines = f.readLines()
+        assertTrue(lines[0].contains(" [WARN] careful"))
+        assertTrue(lines[1].contains(" [ERROR] boom"))
+    }
+
+    @Test
+    fun `newlines in the message collapse to a single line`() {
+        val f = newLogFile()
+        WaveAppLog.logFile = f
+        WaveAppLog.error("line one\nline two\r\nline three")
+
+        val lines = f.readLines()
+        assertEquals(1, lines.size)
+        assertEquals("line one line two line three", lines.single().substringAfter("] "))
+    }
+
+    @Test
+    fun `appends across calls preserving order`() {
+        val f = newLogFile()
+        WaveAppLog.logFile = f
+        WaveAppLog.info("first")
+        WaveAppLog.info("second")
+        WaveAppLog.info("third")
+
+        val lines = f.readLines()
+        assertEquals(3, lines.size)
+        assertTrue(lines[0].endsWith("first"))
+        assertTrue(lines[1].endsWith("second"))
+        assertTrue(lines[2].endsWith("third"))
+    }
+
+    @Test
+    fun `error with throwable includes the stack trace`() {
+        val f = newLogFile()
+        WaveAppLog.logFile = f
+        WaveAppLog.error("failed", IllegalStateException("kaput"))
+
+        val text = f.readText()
+        assertTrue(text.contains("failed: java.lang.IllegalStateException: kaput"))
+        assertTrue(text.contains("WaveAppLogTest"))
+    }
+
+    @Test
+    fun `oversized file is truncated to the last keep lines`() {
+        val f = newLogFile()
+        WaveAppLog.logFile = f
+
+        // Pre-fill a file that exceeds the 1MB cap (1100 lines x 12KB).
+        val lineBody = "x".repeat(12 * 1024)
+        val prefill = (0 until 1100).joinToString("\n") { "line-$it-$lineBody" }
+        f.writeText(prefill + "\n")
+
+        WaveAppLog.info("after-truncate")
+
+        val kept = f.readLines()
+        assertEquals(1000, kept.size)
+        assertTrue(kept.first().endsWith("line-101-$lineBody"))
+        assertTrue(kept.last().endsWith("after-truncate"))
+        assertFalse(kept.any { it.contains("line-100-") })
+    }
+}

--- a/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/util/WaveAppLogTest.kt
+++ b/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/util/WaveAppLogTest.kt
@@ -60,7 +60,8 @@ class WaveAppLogTest {
 
         val lines = f.readLines()
         assertEquals(1, lines.size)
-        assertEquals("line one line two line three", lines.single().substringAfter("] "))
+        // The line is `[ts] [ERROR] msg` — the message starts after the last `] `.
+        assertEquals("line one line two line three", lines.single().substringAfterLast("] "))
     }
 
     @Test

--- a/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/util/WaveAppLogTest.kt
+++ b/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/util/WaveAppLogTest.kt
@@ -34,8 +34,9 @@ class WaveAppLogTest {
         WaveAppLog.info("hello")
 
         val line = f.readLines().single()
+        // Fractional seconds are optional — Instant.toString omits them on whole seconds.
         assertTrue(
-            line.matches(Regex("""^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z] \[INFO\] hello$""")),
+            line.matches(Regex("""^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z] \[INFO\] hello$""")),
             "line was: $line",
         )
     }

--- a/packages/vscode/src/chatProvider.ts
+++ b/packages/vscode/src/chatProvider.ts
@@ -26,6 +26,7 @@ import { MessageHandler } from "./session/messageHandler";
 import { StdioClient } from "./stdio/stdioClient";
 import { NotificationRouter } from "./stdio/notificationRouter";
 import { ensureCliUpToDate, setExtensionPath } from "./stdio/binaryResolver";
+import { hostLog } from "./hostLog";
 
 export class ChatProvider implements vscode.WebviewViewProvider {
   private static formatConfigError(error: unknown): string {
@@ -217,6 +218,7 @@ export class ChatProvider implements vscode.WebviewViewProvider {
       this.outputChannel.appendLine(
         `[Wave] Failed to initialize shared client: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`,
       );
+      hostLog.error("[Wave] Failed to initialize shared client:", err);
       vscode.window.showErrorMessage(
         err instanceof Error
           ? err.message

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { ChatProvider } from "./chatProvider";
 import { adoptLoginPathIntoEnv } from "./stdio/loginPath";
+import { hostLog } from "./hostLog";
 
 let chatProvider: ChatProvider | undefined;
 
@@ -15,7 +16,15 @@ export function activate(context: vscode.ExtensionContext) {
   adoptLoginPathIntoEnv();
 
   // Create a single ChatProvider instance for the extension lifecycle
-  chatProvider = new ChatProvider(context);
+  try {
+    chatProvider = new ChatProvider(context);
+  } catch (error) {
+    // The extension host catches what escapes activate(), but record the
+    // failure in vscode.log — the developer console is invisible to users.
+    console.error("Wave AI 扩展初始化失败:", error);
+    hostLog.error("[Wave] Extension activation failed:", error);
+    throw error;
+  }
 
   // Register sidebar command
   const openChatSidebarCommand = vscode.commands.registerCommand(
@@ -101,9 +110,14 @@ export async function deactivate() {
   console.log("Wave AI 聊天扩展正在停用");
 
   // Clean up the chat provider and its agent
-  if (chatProvider) {
-    await chatProvider.destroy();
-    chatProvider = undefined;
+  try {
+    if (chatProvider) {
+      await chatProvider.destroy();
+      chatProvider = undefined;
+    }
+  } catch (error) {
+    console.error("停用 Wave 扩展时出错:", error);
+    hostLog.error("[Wave] Extension deactivation failed:", error);
   }
 
   console.log("Wave AI 聊天扩展已停用");

--- a/packages/vscode/src/hostLog.ts
+++ b/packages/vscode/src/hostLog.ts
@@ -1,0 +1,70 @@
+/**
+ * Host-side file logger for the VS Code extension (vscode.log).
+ *
+ * Appends plain-text `[ISO-8601] [LEVEL] message` lines to
+ * ~/.wave/logs/vscode.log; the wave --stdio child writes its own cli.log via
+ * the CLI logger. No level filtering and no console patching — callers use it
+ * explicitly at chokepoints. Files are kept bounded: after each append the
+ * file is truncated to the last 1000 lines when it exceeds 1MB, mirroring
+ * the CLI logger (which keeps 10MB — it is a high-volume session log).
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const LOG_FILE = path.join(
+  process.env.WAVE_LOGS_DIR || path.join(os.homedir(), ".wave", "logs"),
+  "vscode.log",
+);
+const MAX_FILE_SIZE = 1024 * 1024;
+const KEEP_LINES = 1000;
+
+const safeJson = (arg: object): string => {
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
+};
+
+const formatArg = (arg: unknown): string => {
+  let text: string;
+  if (arg instanceof Error) {
+    text = arg.stack || arg.message;
+  } else if (arg && typeof arg === "object") {
+    text = safeJson(arg);
+  } else {
+    text = String(arg);
+  }
+  return text.replace(/[\n\r]+/g, " ");
+};
+
+function append(level: string, ...args: unknown[]): void {
+  // Test environments opt out of real file I/O (same flag as the CLI logger).
+  if (process.env.DISABLE_LOGGER_IO === "true") return;
+  const line = `[${new Date().toISOString()}] [${level}] ${args.map(formatArg).join(" ")}\n`;
+  try {
+    fs.mkdirSync(path.dirname(LOG_FILE), { recursive: true });
+    fs.appendFileSync(LOG_FILE, line);
+    if (fs.existsSync(LOG_FILE) && fs.statSync(LOG_FILE).size > MAX_FILE_SIZE) {
+      const kept = fs
+        .readFileSync(LOG_FILE, "utf8")
+        .split("\n")
+        .slice(-KEEP_LINES)
+        .join("\n");
+      fs.writeFileSync(LOG_FILE, kept);
+    }
+  } catch (error) {
+    process.stderr.write(
+      `[${level}] Failed to write ${LOG_FILE}: ${formatArg(error)}\n`,
+    );
+  }
+}
+
+export const hostLog = {
+  debug: (...args: unknown[]) => append("DEBUG", ...args),
+  info: (...args: unknown[]) => append("INFO", ...args),
+  warn: (...args: unknown[]) => append("WARN", ...args),
+  error: (...args: unknown[]) => append("ERROR", ...args),
+};

--- a/packages/vscode/src/stdio/stdioClient.ts
+++ b/packages/vscode/src/stdio/stdioClient.ts
@@ -7,6 +7,7 @@
 
 import { type ChildProcess, spawn } from "child_process";
 import { createInterface } from "readline";
+import { hostLog } from "../hostLog";
 
 export type NotificationHandler = (params: unknown, sessionId?: string) => void;
 export type StderrHandler = (data: string) => void;
@@ -90,7 +91,12 @@ export class StdioClient {
         this.stderrChunks.shift();
       }
       const trimmed = decodeStderr(data).trimEnd();
-      if (trimmed) this.onStderr?.(trimmed);
+      if (trimmed) {
+        this.onStderr?.(trimmed);
+        // The CLI child writes its own logs to cli.log; anything on stderr is
+        // runtime noise worth capturing at the host boundary.
+        hostLog.warn("[wave-stdio]", trimmed);
+      }
     });
 
     this.proc.on("exit", (code, signal) => {
@@ -100,6 +106,7 @@ export class StdioClient {
       ];
       if (stderr) parts.push(`stderr:\n${stderr}`);
       const error = new Error(parts.join("\n"));
+      hostLog.error("[wave-stdio]", parts.join("\n"));
       for (const p of this.pending.values()) {
         p.reject(error);
       }
@@ -109,6 +116,7 @@ export class StdioClient {
 
     this.proc.on("error", (err) => {
       console.error("[wave-stdio] Process error:", err);
+      hostLog.error("[wave-stdio] Process error:", err);
     });
   }
 
@@ -170,6 +178,7 @@ export class StdioClient {
       msg = JSON.parse(line);
     } catch {
       console.error("[wave-stdio] Failed to parse:", line);
+      hostLog.error("[wave-stdio] Failed to parse:", line);
       return;
     }
 

--- a/packages/vscode/tests/stdio/stdioClientLogging.test.ts
+++ b/packages/vscode/tests/stdio/stdioClientLogging.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+import * as fs from "fs";
+
+// ── Mocks ──────────────────────────────────────────────────────
+
+const mockSpawn = vi.hoisted(() => vi.fn());
+const mockCreateInterface = vi.hoisted(() => vi.fn());
+
+vi.mock("child_process", () => ({
+  default: { spawn: mockSpawn },
+  spawn: mockSpawn,
+}));
+
+vi.mock("readline", () => ({
+  default: { createInterface: mockCreateInterface },
+  createInterface: mockCreateInterface,
+}));
+
+vi.mock("fs", () => ({
+  mkdirSync: vi.fn(),
+  appendFileSync: vi.fn(),
+  existsSync: vi.fn(),
+  statSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+const appendSpy = vi.mocked(fs.appendFileSync);
+
+interface MockProc extends EventEmitter {
+  stdin: { write: ReturnType<typeof vi.fn> };
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: ReturnType<typeof vi.fn>;
+}
+
+function createMockProc(): MockProc {
+  const proc = new EventEmitter() as MockProc;
+  proc.stdin = { write: vi.fn() };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  return proc;
+}
+
+// ── Import after mocks ─────────────────────────────────────────
+
+import { StdioClient } from "../../src/stdio/stdioClient";
+
+describe("StdioClient host logging (vscode.log)", () => {
+  let proc: MockProc;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    delete process.env.DISABLE_LOGGER_IO;
+    proc = createMockProc();
+    mockSpawn.mockReturnValue(proc);
+    mockCreateInterface.mockReturnValue(new EventEmitter());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const lastAppend = () =>
+    appendSpy.mock.calls[appendSpy.mock.calls.length - 1]!;
+
+  it("logs spawn errors to vscode.log at ERROR level", () => {
+    new StdioClient("/fake/wave", ["--stdio"]);
+
+    proc.emit("error", new Error("ENOENT"));
+
+    const [file, content] = lastAppend();
+    expect(String(file)).toContain("vscode.log");
+    expect(String(content)).toContain("[ERROR]");
+    expect(String(content)).toContain("Process error");
+    expect(String(content)).toContain("ENOENT");
+  });
+
+  it("logs process exit with code/signal and stderr tail at ERROR level", () => {
+    new StdioClient("/fake/wave", ["--stdio"]);
+
+    proc.stderr.emit("data", Buffer.from("boom line\n"));
+    proc.emit("exit", 1, null);
+
+    const [file, content] = lastAppend();
+    expect(String(file)).toContain("vscode.log");
+    expect(String(content)).toContain("[ERROR]");
+    expect(String(content)).toContain("process exited (code: 1, signal: null)");
+    expect(String(content)).toContain("boom line");
+  });
+
+  it("logs child stderr lines at WARN level", () => {
+    new StdioClient("/fake/wave", ["--stdio"]);
+
+    proc.stderr.emit("data", Buffer.from("runtime warning\n"));
+
+    const [file, content] = lastAppend();
+    expect(String(file)).toContain("vscode.log");
+    expect(String(content)).toContain("[WARN]");
+    expect(String(content)).toContain("runtime warning");
+  });
+
+  it("logs unparseable stdout lines at ERROR level", () => {
+    const rl = new EventEmitter() as EventEmitter & {
+      on: (event: string, cb: (line: string) => void) => EventEmitter;
+    };
+    mockCreateInterface.mockReturnValue(rl);
+
+    new StdioClient("/fake/wave", ["--stdio"]);
+
+    const lineHandler = rl.listeners("line")[0] as (line: string) => void;
+    lineHandler("not-json");
+
+    const [file, content] = lastAppend();
+    expect(String(file)).toContain("vscode.log");
+    expect(String(content)).toContain("[ERROR]");
+    expect(String(content)).toContain("Failed to parse");
+  });
+});

--- a/packages/vscode/vitest.config.ts
+++ b/packages/vscode/vitest.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
     include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
     exclude: ["node_modules"],
     setupFiles: ["tests/setup.ts"],
+    env: {
+      // Keep the file logger out of the user's real ~/.wave/logs during tests.
+      DISABLE_LOGGER_IO: "true",
+    },
     server: {
       deps: {
         inline: ["wave-agent-sdk", "wave-webview-fixtures"],


### PR DESCRIPTION
## 背景

desktop / VS Code / JetBrains 插件的 host 层错误日志此前只进 IDE 控制台，用户不可见；CLI 日志在 ~/.wave/app.log。本 PR 统一到 ~/.wave/logs/ 目录下按端分文件。

## 改动

- **CLI**：日志从 ~/.wave/app.log 迁移到 ~/.wave/logs/cli.log（破坏性变更，无迁移逻辑）
- **desktop/vscode/jetbrains**：chokepoint 方式写 ~/.wave/logs/{desktop,vscode,jetbrains}.log——uncaughtException/unhandledRejection、stdio spawn/exit/stderr 行、webview 加载失败、activate/init 失败。不 patch console
- **格式**：纯文本 `[ISO-8601] [LEVEL] message`，与 CLI 结构一致但不含 ANSI
- **截断**：host 日志 1MB 留尾 1000 行（低频错误日志）；CLI 保持 10MB（高频会话日志，LOG_MAX_FILE_SIZE env 可调）
- **jetbrains** 新增 WaveAppLog.kt；desktop/vscode 各自包内内联 hostLog 模块（agent-sdk 零改动，无共享 helper）
- uncaughtException 保持崩溃语义：log 后 process.exit(1)

## 验证

- desktop 524 tests / vscode 159 tests / code logger 12 tests 通过（含新增 stdioClient 日志测试）
- type-check、lint 全绿
- jetbrains 本机无 JDK，靠 check-jetbrains