### PR TITLE
fix(code): stop console noise for unregistered code fence languages

### DIFF
--- a/packages/code/src/utils/highlightUtils.ts
+++ b/packages/code/src/utils/highlightUtils.ts
@@ -108,6 +108,12 @@ export function highlightToAnsi(code: string, language?: string): string {
   if (!code) {
     return "";
   }
+  // hljs.highlight logs a console.error (then throws) when the language is not
+  // registered. We bundle a trimmed language set, so check first and fall back
+  // to plain text instead of spamming stderr with LANGUAGE_NOT_FOUND noise.
+  if (language && !hljs.getLanguage(language)) {
+    return code;
+  }
   try {
     const highlighted = language
       ? hljs.highlight(code, { language }).value

--- a/packages/code/tests/utils/highlightUtils.test.ts
+++ b/packages/code/tests/utils/highlightUtils.test.ts
@@ -23,20 +23,21 @@ vi.mock("highlight.js", () => ({
       return { value: code };
     }),
     registerLanguage: vi.fn(),
-    getLanguage: vi.fn(),
+    getLanguage: vi.fn((language: string) => language === "ts"),
   },
 }));
 
 describe("highlightToAnsi", () => {
   let originalChalkLevel: typeof chalk.level;
   let originalForceColor: string | undefined;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeAll(() => {
     originalChalkLevel = chalk.level;
     originalForceColor = process.env.FORCE_COLOR;
     process.env.FORCE_COLOR = "1";
     chalk.level = 1;
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterAll(() => {
@@ -69,6 +70,13 @@ describe("highlightToAnsi", () => {
     const code = "some random text";
     const highlighted = highlightToAnsi(code, "nonexistent");
     expect(highlighted).toBe(code);
+  });
+
+  it("should not log console errors for unregistered languages", () => {
+    const code = "Get-Process wave";
+    const highlighted = highlightToAnsi(code, "powershell");
+    expect(highlighted).toBe(code);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
   it("should handle errors gracefully", () => {


### PR DESCRIPTION
## Problem

`wave -c` restored a session containing powershell code blocks and printed one error line per block:

```
Could not find the language 'powershell', did you forget to load/include a language module?
```

## Root cause

`packages/code/src/utils/highlightUtils.ts` calls `hljs.highlight(code, { language })` with the fence language verbatim. highlight.js core only registers the trimmed language set (~21 languages), and for an unregistered language it does `console.error('Could not find the language ...')` **before** throwing. The existing try/catch swallowed the throw but not the console.error, so the noise still hit stderr.

## Fix

Guard with `hljs.getLanguage(language)` before calling `hljs.highlight`; unregistered languages fall back to plain text — identical output to the old catch path, minus the stderr spam. Registered aliases (`ts`, `js`, `shell`, ...) still resolve via `getLanguage`.

## Verification

- Added regression test: `powershell` fence renders plain text and console.error is never called
- `pnpm -F wave-code run test:unit`: 1424 passed / 40 skipped
- `pnpm -F wave-code run type-check`: clean
