### PR TITLE
fix(desktop,vscode,jetbrains): 文件面板/打开文件支持相对路径按会话 cwd 解析

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -4683,6 +4683,29 @@ export class DesktopHost {
   };
 
   /**
+   * Resolve a message-relative path against the pane agent's cwd. Agent
+   * markdown (行内代码路径, spec markdown-links) routinely writes paths
+   * relative to its working directory; without this the host would stat them
+   * against the Electron process cwd and report 文件不存在. Absolute paths pass
+   * through untouched; remote hosts resolve with posix rules (the agent's cwd
+   * is an absolute path on that host).
+   */
+  private resolvePanelPath(
+    paneId: string,
+    host: string,
+    filePath: string,
+  ): string {
+    const p = host === LOCAL_HOST ? path : path.posix;
+    // Pass absolute paths through untouched: on Windows path.resolve would
+    // rewrite /work/x.ts to C:\work\x.ts (drive-root prefixing).
+    if (p.isAbsolute(filePath)) return filePath;
+    const agent = this.agentForPane(paneId);
+    const cwd = agent?.workingDirectory;
+    if (!cwd) return filePath;
+    return p.resolve(cwd, filePath);
+  }
+
+  /**
    * Read a file for the file panel and push desktopFileContent to its pane.
    * Local files are read straight from disk; remote ones over ssh (base64 for
    * images, NUL-detected text otherwise). Failures land in fileView.error and
@@ -4696,11 +4719,12 @@ export class DesktopHost {
   ): Promise<void> {
     if (!filePath) return;
     const host = this.hostForPane(paneId);
+    const resolved = this.resolvePanelPath(paneId, host, filePath);
     try {
       const fileView =
         host === LOCAL_HOST
-          ? await this.readLocalFileForPanel(filePath)
-          : await this.readRemoteFileForPanel(host, filePath);
+          ? await this.readLocalFileForPanel(resolved)
+          : await this.readRemoteFileForPanel(host, resolved);
       this.postMessage({
         command: "desktopFileContent",
         paneId,
@@ -4711,7 +4735,7 @@ export class DesktopHost {
         command: "desktopFileContent",
         paneId,
         fileView: {
-          path: filePath,
+          path: resolved,
           host,
           error: error instanceof Error ? error.message : String(error),
         },

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -7090,6 +7090,26 @@ describe("file panel", () => {
     ]);
   });
 
+  it("openFile resolves a relative path against the pane agent's cwd", async () => {
+    // Agent markdown writes paths relative to its working directory; the host
+    // must resolve them before reading, not stat against the process cwd.
+    const { host, sent } = await readyHost();
+    const resolved = path.resolve("/work/a", "src.ts"); // platform-correct
+    seedLocalFile(resolved, "const x = 1;\n");
+
+    await host.handleWebviewMessage({ command: "openFile", path: "src.ts" });
+
+    const fv = (
+      sent("desktopFileContent").at(-1) as { fileView: Record<string, unknown> }
+    ).fileView;
+    expect(fv).toMatchObject({
+      path: resolved,
+      host: "local",
+      content: "const x = 1;\n",
+      truncated: false,
+    });
+  });
+
   it("openFile truncates text files past the line cap and still reports the total", async () => {
     const { host, sent } = await readyHost();
     const content = `${"a\n".repeat(REMOTE_FILE_MAX_LINES)}b`; // 2001 lines
@@ -7252,6 +7272,30 @@ describe("file panel", () => {
       startLine: 5,
       endLine: 10,
     });
+  });
+
+  it("openFile on a remote pane resolves a relative path with posix rules", async () => {
+    seedSshConfig("Host prod\n  HostName 10.0.0.1\n");
+    const { host } = createHost();
+    await host.handleWebviewMessage({
+      command: "desktopSelectHost",
+      host: "prod",
+    });
+    // Bind a remote agent whose cwd is the remote absolute path, so the
+    // relative message path resolves against it (never against a local drive).
+    await host.handleWebviewMessage({
+      command: "desktopSelectRecentWorkdir",
+      path: "/remote/repo",
+      host: "prod",
+    });
+    vi.mocked(readRemoteFile).mockClear();
+
+    await host.handleWebviewMessage({ command: "openFile", path: "src.ts" });
+
+    expect(vi.mocked(readRemoteFile)).toHaveBeenCalledWith(
+      "prod",
+      "/remote/repo/src.ts",
+    );
   });
 
   it("openFile on a remote pane maps an image result to base64", async () => {

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/ide/IdeService.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/ide/IdeService.kt
@@ -20,6 +20,7 @@ import kotlinx.serialization.json.put
 import java.awt.Desktop
 import java.io.File
 import java.nio.file.Files
+import java.nio.file.Paths
 
 /**
  * IDE integration service: handles webview commands that touch IntelliJ IDE capabilities
@@ -40,6 +41,20 @@ object IdeService {
     data class UploadResult(val uploadedFiles: List<String>, val errors: List<String>)
 
     /**
+     * Resolve a message-relative path against the project root. The agent's
+     * real cwd (sessionCwd, possibly cd'd into a subdirectory) is only known
+     * to MessageHandler — IdeService only receives the project, so the project
+     * root is the closest base. Absolute paths (drive-letter or /-rooted)
+     * pass through untouched.
+     */
+    private fun resolveProjectPath(project: Project, path: String): String =
+        if (Paths.get(path).isAbsolute) {
+            path
+        } else {
+            project.basePath?.let { Paths.get(it, path).normalize().toString() } ?: path
+        }
+
+    /**
      * openFile — mirrors VSCE handleOpenFile (messageHandler.ts:221).
      * Params: path (String), optional startLine / endLine (1-based).
      * Opens the file and positions the caret / selection, revealing the range in center.
@@ -49,12 +64,13 @@ object IdeService {
         if (path.isNullOrEmpty()) return
         val startLine = params["startLine"]?.jsonPrimitive?.content?.toIntOrNull()
         val endLine = params["endLine"]?.jsonPrimitive?.content?.toIntOrNull()
+        val resolvedPath = resolveProjectPath(project, path)
 
         Edt.invokeLater {
             try {
-                val file = LocalFileSystem.getInstance().findFileByPath(path)
+                val file = LocalFileSystem.getInstance().findFileByPath(resolvedPath)
                 if (file == null) {
-                    showError(project, "打开文件失败: 文件不存在 $path")
+                    showError(project, "打开文件失败: 文件不存在 $resolvedPath")
                     return@invokeLater
                 }
                 val editors = FileEditorManager.getInstance(project).openFile(file, true)
@@ -86,11 +102,12 @@ object IdeService {
     fun previewImage(project: Project, params: JsonObject) {
         val path = params["path"]?.jsonPrimitive?.content
         if (path.isNullOrEmpty()) return
+        val resolvedPath = resolveProjectPath(project, path)
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
-                val file = File(path)
+                val file = File(resolvedPath)
                 if (!file.exists()) {
-                    showError(project, "预览图片失败: 文件不存在 $path")
+                    showError(project, "预览图片失败: 文件不存在 $resolvedPath")
                     return@executeOnPooledThread
                 }
                 if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.OPEN)) {

--- a/packages/vscode/src/session/messageHandler.ts
+++ b/packages/vscode/src/session/messageHandler.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import * as path from "path";
 import { ChatSession } from "./chatSession";
 import {
   ConfigurationService,
@@ -585,6 +586,19 @@ export class MessageHandler {
     }
   }
 
+  /**
+   * Resolve a message-relative path against the workspace root — the agent's
+   * seeded cwd (chatSession.ts) — without touching the session registry, which
+   * would lazily materialize a tab/window session just to read a file path.
+   * Absolute paths pass through untouched.
+   */
+  private resolveFilePath(filePath: string): string {
+    if (path.isAbsolute(filePath)) return filePath;
+    const workdir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    if (!workdir) return filePath;
+    return path.resolve(workdir, filePath);
+  }
+
   private async handleOpenFile(
     filePath: string,
     startLine?: number,
@@ -592,7 +606,7 @@ export class MessageHandler {
   ) {
     if (!filePath) return;
 
-    const uri = vscode.Uri.file(filePath);
+    const uri = vscode.Uri.file(this.resolveFilePath(filePath));
     try {
       const document = await vscode.workspace.openTextDocument(uri);
       const editor = await vscode.window.showTextDocument(document);
@@ -636,7 +650,7 @@ export class MessageHandler {
     if (!filePath) return;
 
     try {
-      const uri = vscode.Uri.file(filePath);
+      const uri = vscode.Uri.file(this.resolveFilePath(filePath));
       await vscode.commands.executeCommand("vscode.open", uri);
     } catch (error) {
       console.error("预览图片失败:", error);


### PR DESCRIPTION
## 概述

修复 PR #1898 引入的相对路径 bug：消息 markdown 中反引号包裹的**相对路径**（如 `src/main.ts`）点击后无法打开——三端此前把路径原样传给读取/打开逻辑：

- **desktop**：fs.stat("src/main.ts") 相对 Electron 进程 cwd 解析（非 agent cwd）→ 报「文件不存在」
- **vscode**：Uri.file("src/main.ts") 解析到盘根/进程 cwd
- **jetbrains**：findFileByPath(相对路径) 相对 JVM cwd

绝对路径（含 Windows 盘符、/work/x.ts）不受影响，原样透传。

## 改动

| 端 | 文件 | 说明 |
|---|---|---|
| desktop | desktopHost.ts | 新增 resolvePanelPath：相对路径按 pane agent workingDirectory 解析（本地运行时 path、远程 posix），handleFilePanelOpen（openFile/previewImage 共用）使用 resolve 后路径 |
| vscode | messageHandler.ts | 新增 resolveFilePath：基准 workspaceFolders[0]（agent 播种 cwd），handleOpenFile/handlePreviewImage 使用；不触碰 session registry（避免 tab/window 惰性创建会话副作用） |
| jetbrains | IdeService.kt | 新增 resolveProjectPath：基准 project.basePath，openFile/previewImage 使用 |

## 测试

- desktop：+2 用例（本地相对路径按 cwd 解析、远程相对路径 posix 解析），file panel 15 个 + 全量 desktopHost 261 全过
- vscode：159 全过
- jetbrains：compileKotlin 通过
- 三端 type-check 通过