### PR TITLE
fix: recover sessions when updateConfig recreation fails

### DIFF
--- a/packages/code/src/stdio/agentBridge.ts
+++ b/packages/code/src/stdio/agentBridge.ts
@@ -739,7 +739,26 @@ export class AgentBridge {
         this.canUseTool(context, ctx),
     };
 
-    const agent = await Agent.create(options);
+    let agent: Agent;
+    try {
+      agent = await Agent.create(options);
+    } catch (createError) {
+      // The old entry was already destroyed and removed above. If the session
+      // file is missing or unrecoverable (fresh session, cleared chat, or a
+      // never-persisted empty session), fail soft: recreate WITHOUT
+      // restoreSessionId so this session slot keeps working. Without this the
+      // client's sessionId still points at the destroyed entry and every later
+      // request fails with "Session not found" until the window is reloaded.
+      // Non-session errors (bad baseURL/apiKey/config) must surface unchanged.
+      if (!options.restoreSessionId || !isSessionRecoveryError(createError)) {
+        throw createError;
+      }
+      logger?.warn(
+        `updateConfig: failed to restore session ${currentSessionId}, recreating as a fresh session:`,
+        createError,
+      );
+      agent = await Agent.create({ ...options, restoreSessionId: undefined });
+    }
     ctx.agent = agent;
     ctx.registeredSessionId = agent.sessionId;
     this.sessions.set(agent.sessionId, {
@@ -1622,4 +1641,18 @@ export class RpcError extends Error {
   toJsonRpcError(): JsonRpcError {
     return { code: this.code, message: this.message };
   }
+}
+
+/**
+ * True when the error means the restoreSessionId session cannot be recovered
+ * from disk (missing file, corrupt transcript, etc.) — the recovery actions in
+ * updateConfig/restoreSession degrade to a fresh session for these. Anything
+ * else (config validation, plugin load, …) must surface to the client.
+ */
+function isSessionRecoveryError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("not found on disk") ||
+    message.startsWith("Session not found:")
+  );
 }

--- a/packages/code/tests/stdio/agentBridge.test.ts
+++ b/packages/code/tests/stdio/agentBridge.test.ts
@@ -2089,6 +2089,60 @@ test("updateConfig preserves worktreeName but never re-marks the worktree as new
   expect(secondCall.isNewWorktree).toBeUndefined();
 });
 
+test("updateConfig falls back to a fresh session when the session file is missing", async () => {
+  const { bridge } = createBridge();
+  vi.mocked(Agent.create)
+    .mockResolvedValueOnce(createMockAgent())
+    // Recreate with restoreSessionId fails: session file is gone
+    .mockRejectedValueOnce(
+      new Error("Session test-session-id not found on disk"),
+    )
+    // Fallback without restoreSessionId succeeds with a new session id
+    .mockResolvedValueOnce(createMockAgent({ sessionId: "fresh-session-id" }));
+
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  const r = await bridge.handleRequest(
+    "updateConfig",
+    { model: "gpt-4" },
+    sessionId,
+  );
+
+  // Downgraded to a fresh session — the session slot must survive so the
+  // client keeps working instead of hitting "Session not found" forever
+  expect(r).toEqual({ sessionId: "fresh-session-id" });
+  const fallbackCall = vi.mocked(Agent.create).mock.calls[2][0];
+  expect(fallbackCall.restoreSessionId).toBeUndefined();
+  // The fresh session is live under the new id
+  const info = await bridge.handleRequest(
+    "getSessionInfo",
+    {},
+    "fresh-session-id",
+  );
+  expect(info).toBeDefined();
+  // The old id no longer resolves (entry was re-keyed)
+  await expect(
+    bridge.handleRequest("getSessionInfo", {}, sessionId),
+  ).rejects.toThrow(`Session not found: ${sessionId}`);
+});
+
+test("updateConfig rethrows non-session errors without fallback", async () => {
+  const { bridge } = createBridge();
+  vi.mocked(Agent.create)
+    .mockResolvedValueOnce(createMockAgent())
+    .mockRejectedValueOnce(
+      new Error("Base URL must be a valid URL format. Received: not-a-url"),
+    );
+
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+  await expect(
+    bridge.handleRequest("updateConfig", { model: "gpt-4" }, sessionId),
+  ).rejects.toThrow("Base URL must be a valid URL format");
+  // No fallback attempt was made
+  expect(vi.mocked(Agent.create).mock.calls.length).toBe(2);
+});
+
 test("destroy without agent is a no-op", async () => {
   const { bridge } = createBridge();
   // Don't initialize — agent is undefined

--- a/packages/desktop/src/main/stdio/stdioAgent.ts
+++ b/packages/desktop/src/main/stdio/stdioAgent.ts
@@ -214,6 +214,11 @@ export class StdioAgent {
       this.router.unregister(oldSessionId);
       this.sessionId = result.sessionId;
       this.router.register(this.sessionId, this);
+      // Sync the host session state: the bridge may have downgraded to a
+      // fresh session (session file missing on recreate). Without this the
+      // host keeps the destroyed sessionId and every later request fails
+      // with "Session not found".
+      this.callbacks.onSessionIdChange?.(this.sessionId);
     }
     return result;
   }

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioAgent.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioAgent.kt
@@ -257,6 +257,11 @@ class StdioAgent(
             router.unregister(oldSessionId)
             sessionId = newSessionId
             router.register(newSessionId, this)
+            // Sync the host session state: the bridge may have downgraded to a
+            // fresh session (session file missing on recreate). Without this the
+            // host keeps the destroyed sessionId and every later request fails
+            // with "Session not found".
+            callbacks.onSessionIdChange(newSessionId)
         }
     }
 

--- a/packages/vscode/src/chatProvider.ts
+++ b/packages/vscode/src/chatProvider.ts
@@ -204,11 +204,35 @@ export class ChatProvider implements vscode.WebviewViewProvider {
             this.initializeAgent(viewType, windowId, restoreSessionId),
           listSessions: (viewType, windowId) =>
             this.listSessions(viewType, windowId),
-          updateAllSessionsConfig: (config) => {
+          updateAllSessionsConfig: async (config) => {
             const cfg = config as ConfigurationData;
-            this.sidebarSession.updateConfig(cfg);
-            this.tabSessions.forEach((session) => session.updateConfig(cfg));
-            this.windowSessions.forEach((session) => session.updateConfig(cfg));
+            // Serial: updateConfig destroys + recreates the agent in the bridge;
+            // concurrent calls on the same sessionId would delete each other's
+            // entry and leave it permanently missing ("Session not found" on
+            // every later request). Await + catch so failures are logged here
+            // instead of becoming unhandled rejections.
+            const sessions = [
+              this.sidebarSession,
+              ...this.tabSessions.values(),
+              ...this.windowSessions.values(),
+            ];
+            let failed = false;
+            for (const session of sessions) {
+              try {
+                await session.updateConfig(cfg);
+              } catch (error) {
+                failed = true;
+                console.error(
+                  `[Wave] ${session.viewType} 更新配置失败:`,
+                  error,
+                );
+              }
+            }
+            if (failed) {
+              vscode.window.showErrorMessage(
+                "部分会话配置更新失败，请重载窗口后重试。",
+              );
+            }
           },
           getVersion: () => this.context.extension.packageJSON?.version || "",
         },

--- a/packages/vscode/src/stdio/stdioAgent.ts
+++ b/packages/vscode/src/stdio/stdioAgent.ts
@@ -209,6 +209,11 @@ export class StdioAgent {
       this.router.unregister(oldSessionId);
       this.sessionId = result.sessionId;
       this.router.register(this.sessionId, this);
+      // Sync ChatSession/UI state: bridge may have downgraded to a fresh
+      // session (session file missing on recreate). Without this the ChatSession
+      // keeps the destroyed sessionId and every later request fails with
+      // "Session not found".
+      this.callbacks.onSessionIdChange?.(this.sessionId);
     }
     return result;
   }


### PR DESCRIPTION
## Problem

The bridge `updateConfig` destroys the old agent entry before recreating it with `restoreSessionId`. When `Agent.create` fails — session file missing (fresh session, cleared chat, or a never-persisted empty session) — the entry is permanently gone while clients (VSCode/desktop/JetBrains) still hold the old sessionId. Every later request (sendMessage, clearMessages) then fails with `Session not found: <id>` until the window is reloaded. Users hit this right after saving a new server URL / config, since that triggers an agent recreate.

## Fix

- **agentBridge (`updateConfig`)**: when recreation fails with a session-recovery error (`not found on disk` / `Session not found:`), fall back to recreating WITHOUT `restoreSessionId` so the session slot survives. Config errors (bad baseURL/apiKey) still surface unchanged.
- **vscode/desktop/jetbrains `stdioAgent.updateConfig`**: invoke `onSessionIdChange` after rekeying the router, so hosts drop the destroyed id and sync the fresh session id.
- **vscode `chatProvider.updateAllSessionsConfig`**: serialize the per-session `updateConfig` calls and catch errors — concurrent calls on the same sessionId would delete each other's bridge entry, and rejections previously became unhandled.

## Tests

- agentBridge: 136/136 (2 new: fallback to fresh session; non-session errors rethrown without fallback)
- vscode: 159/159, desktop: 524/524, jetbrains compileKotlin, type-check + lint all green