### PR TITLE
fix(desktop,vscode,jb): resolve ~-prefixed file paths against home, not cwd

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -4699,6 +4699,17 @@ export class DesktopHost {
     // Pass absolute paths through untouched: on Windows path.resolve would
     // rewrite /work/x.ts to C:\work\x.ts (drive-root prefixing).
     if (p.isAbsolute(filePath)) return filePath;
+    // `~`-prefixed paths are home-relative, never cwd-relative (resolving
+    // them against the agent cwd would yield <cwd>/~/.wave/… and miss).
+    // Remote shells expand `~` themselves in readRemoteFile/listRemoteDirs,
+    // so pass them through; local hosts expand here (Node never does).
+    if (filePath === "~" || filePath.startsWith("~/")) {
+      if (host !== LOCAL_HOST) return filePath;
+      return path.resolve(
+        os.homedir(),
+        filePath === "~" ? "." : filePath.slice(2),
+      );
+    }
     const agent = this.agentForPane(paneId);
     const cwd = agent?.workingDirectory;
     if (!cwd) return filePath;

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -7298,6 +7298,51 @@ describe("file panel", () => {
     );
   });
 
+  it("openFile expands a ~-prefixed path against the home dir, not the agent cwd", async () => {
+    const { host, sent } = await readyHost();
+    const homeFile = path.join(os.homedir(), ".wave", "neteasecc.json");
+    seedLocalFile(homeFile, '{"token":"x"}\n');
+
+    await host.handleWebviewMessage({
+      command: "openFile",
+      path: "~/.wave/neteasecc.json",
+    });
+
+    const fv = (
+      sent("desktopFileContent").at(-1) as { fileView: Record<string, unknown> }
+    ).fileView;
+    expect(fv).toMatchObject({
+      path: homeFile,
+      host: "local",
+      content: '{"token":"x"}\n',
+    });
+  });
+
+  it("openFile on a remote pane passes a ~-prefixed path through for the shell to expand", async () => {
+    seedSshConfig("Host prod\n  HostName 10.0.0.1\n");
+    const { host } = createHost();
+    await host.handleWebviewMessage({
+      command: "desktopSelectHost",
+      host: "prod",
+    });
+    await host.handleWebviewMessage({
+      command: "desktopSelectRecentWorkdir",
+      path: "/remote/repo",
+      host: "prod",
+    });
+    vi.mocked(readRemoteFile).mockClear();
+
+    await host.handleWebviewMessage({
+      command: "openFile",
+      path: "~/.wave/neteasecc.json",
+    });
+
+    expect(vi.mocked(readRemoteFile)).toHaveBeenCalledWith(
+      "prod",
+      "~/.wave/neteasecc.json",
+    );
+  });
+
   it("openFile on a remote pane maps an image result to base64", async () => {
     seedSshConfig("Host prod\n  HostName 10.0.0.1\n");
     const { host, sent } = createHost();

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/ide/IdeService.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/ide/IdeService.kt
@@ -50,6 +50,10 @@ object IdeService {
     private fun resolveProjectPath(project: Project, path: String): String =
         if (Paths.get(path).isAbsolute) {
             path
+        } else if (path == "~" || path.startsWith("~/")) {
+            // `~`-prefixed paths are home-relative, never project-relative.
+            val home = System.getProperty("user.home")
+            if (path == "~") home else Paths.get(home, path.removePrefix("~/")).normalize().toString()
         } else {
             project.basePath?.let { Paths.get(it, path).normalize().toString() } ?: path
         }

--- a/packages/vscode/src/session/messageHandler.ts
+++ b/packages/vscode/src/session/messageHandler.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import * as path from "path";
+import * as os from "os";
 import { ChatSession } from "./chatSession";
 import {
   ConfigurationService,
@@ -594,6 +595,15 @@ export class MessageHandler {
    */
   private resolveFilePath(filePath: string): string {
     if (path.isAbsolute(filePath)) return filePath;
+    // `~`-prefixed paths are home-relative, never workspace-relative
+    // (the extension host runs on the same machine as the workspace, so
+    // os.homedir() is correct for both local and Remote-SSH scenarios).
+    if (filePath === "~" || filePath.startsWith("~/")) {
+      return path.resolve(
+        os.homedir(),
+        filePath === "~" ? "." : filePath.slice(2),
+      );
+    }
     const workdir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     if (!workdir) return filePath;
     return path.resolve(workdir, filePath);


### PR DESCRIPTION
## 背景

openFile/行内代码路径点击（文件面板）时，`~/.wave/neteasecc.json` 这类 `~` 开头路径被当作相对路径 resolve 到 agent cwd，拼成 `<cwd>/~/.wave/neteasecc.json`，远端/本地均报文件不存在。

`~` 开头表达的是 home 目录下的绝对位置，不是相对路径。

## 修复

三端路径解析函数统一补 `~` 前缀分支：

- **desktop** (`desktopHost.ts` `resolvePanelPath`)：本地 host 展开到 `os.homedir()`；远端 host 原样透传（`readRemoteFile`/`listRemoteDirs` 的远端 shell 自己展开 `~`）
- **vscode** (`messageHandler.ts` `resolveFilePath`)：展开到 `os.homedir()`（扩展宿主与工作区同机，Remote-SSH 亦正确）
- **jetbrains** (`IdeService.kt` `resolveProjectPath`)：展开到 `System.getProperty("user.home")`

## 验证

- desktop 新增 2 测试（本地展开 home、远端原样透传），file panel 块 17 个全过，tsc 0 错
- vscode compile 通过
- jetbrains `gradlew compileKotlin` BUILD SUCCESSFUL