### PR TITLE
fix(agent-sdk): release agent object graph on destroy

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -82,6 +82,8 @@ export class Agent {
   private taskManager: TaskManager;
   private foregroundTaskManager: ForegroundTaskManager;
   private container: Container;
+  /** Unregister module-level listeners registered during container setup; invoked at the end of destroy(). */
+  private teardown: () => void = () => {};
   private configurationService: ConfigurationService; // Add configuration service
   private workdir: string; // Working directory
   private systemPrompt?: string; // Custom system prompt
@@ -158,7 +160,7 @@ export class Agent {
     // Store options for dynamic configuration resolution
     this.options = options;
 
-    this.container = setupAgentContainer({
+    const { container, teardown } = setupAgentContainer({
       options,
       workdir: this.workdir,
       configurationService: this.configurationService,
@@ -182,6 +184,8 @@ export class Agent {
       addPermissionRule: (rule) => this.addPermissionRule(rule),
       addUsage: (usage) => this.messageManager.addUsage(usage),
     });
+    this.container = container;
+    this.teardown = teardown;
 
     // Retrieve managers from container
     this.foregroundTaskManager = this.container.get("ForegroundTaskManager")!;
@@ -941,6 +945,15 @@ export class Agent {
         `Async work did not drain: ${this.asyncWorkRegistry.size} live work item(s) remain after destroy`,
       );
     }
+
+    // Unregister module-level listeners (remote settings hot-update, auth
+    // change) so the agent's object graph becomes collectable. Without this,
+    // the module-level callback arrays pin every created agent via the
+    // per-agent closure contexts, even after the host drops its references.
+    this.teardown();
+    // Break the DI container's internal references (services/factories) so no
+    // per-agent manager is retained through it after destroy.
+    this.container.clear();
   }
 
   /**

--- a/packages/agent-sdk/src/utils/container.ts
+++ b/packages/agent-sdk/src/utils/container.ts
@@ -64,6 +64,16 @@ export class Container {
       (this.parent ? this.parent.has(token) : false)
     );
   }
+
+  /**
+   * Remove all registered services and factories. Call during teardown so the
+   * container does not retain references to per-agent services after the
+   * agent is destroyed (breaking the agent's object graph).
+   */
+  clear(): void {
+    this.services.clear();
+    this.factories.clear();
+  }
 }
 
 // Example usage for ToolManager:

--- a/packages/agent-sdk/src/utils/containerSetup.ts
+++ b/packages/agent-sdk/src/utils/containerSetup.ts
@@ -60,9 +60,20 @@ export interface AgentContainerSetupOptions {
   addUsage: (usage: Usage) => void;
 }
 
+export interface AgentContainerSetupResult {
+  container: Container;
+  /**
+   * Unregister module-level listeners registered during setup (remote settings
+   * hot-update, auth change). Must be called when the agent is destroyed;
+   * without it the module-level callback arrays pin the agent's object graph
+   * (the callback closures capture per-agent managers).
+   */
+  teardown: () => void;
+}
+
 export function setupAgentContainer(
   setupOptions: AgentContainerSetupOptions,
-): Container {
+): AgentContainerSetupResult {
   const {
     options,
     workdir,
@@ -82,6 +93,13 @@ export function setupAgentContainer(
   const container = new Container();
   container.register("AgentOptions", options);
   container.register("Workdir", workdir);
+
+  // Module-level listener teardowns collected during setup and returned to the
+  // agent, which invokes them in destroy(). The remote-settings callback
+  // strongly captures the per-agent LiveConfigManager: without unsubscribing
+  // it in destroy(), the module-level callback array keeps every created
+  // agent's object graph alive even after the host drops its references.
+  const teardowns: Array<() => void> = [];
 
   if (options.worktreeName) {
     container.register("WorktreeName", options.worktreeName);
@@ -168,13 +186,15 @@ export function setupAgentContainer(
   container.register("McpManager", mcpManager);
 
   // Wire up auth change callback to refresh/clear remote settings
-  authService.onAuthChange(async (event) => {
-    if (event === "login") {
-      await remoteSettingsService.refresh();
-    } else if (event === "logout") {
-      remoteSettingsService.clear();
-    }
-  });
+  teardowns.push(
+    authService.onAuthChange(async (event) => {
+      if (event === "login") {
+        await remoteSettingsService.refresh();
+      } else if (event === "logout") {
+        remoteSettingsService.clear();
+      }
+    }),
+  );
 
   const lspManager = options.lspManager || new LspManager(container);
   container.register("LspManager", lspManager);
@@ -331,9 +351,14 @@ export function setupAgentContainer(
 
   // Wire up remote settings hot-update: when polling detects changed settings,
   // reload configuration so admin changes propagate to the running agent.
-  remoteSettingsService.onSettingsUpdate(async () => {
-    await liveConfigManager.reload();
-  });
+  // The callback strongly captures the per-agent LiveConfigManager, so it MUST
+  // be unsubscribed in destroy() via teardown — otherwise the module-level
+  // callback array pins the whole agent object graph.
+  teardowns.push(
+    remoteSettingsService.onSettingsUpdate(async () => {
+      await liveConfigManager.reload();
+    }),
+  );
 
   const subagentManager = new SubagentManager(container, {
     workdir,
@@ -385,5 +410,12 @@ export function setupAgentContainer(
   const workflowManager = new WorkflowManager(container);
   container.register("WorkflowManager", workflowManager);
 
-  return container;
+  return {
+    container,
+    teardown: () => {
+      for (const unsubscribe of teardowns) {
+        unsubscribe();
+      }
+    },
+  };
 }

--- a/packages/agent-sdk/tests/agent/agent.destroyTeardown.test.ts
+++ b/packages/agent-sdk/tests/agent/agent.destroyTeardown.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Agent } from "@/agent.js";
+import { createMockToolManager } from "../helpers/mockFactories.js";
+import { remoteSettingsService } from "@/services/remoteSettingsService.js";
+import { authService } from "@/services/authService.js";
+import type { Container } from "@/utils/container.js";
+
+// Mock AI Service
+vi.mock("@/services/aiService");
+
+// Mock telemetry modules so Agent.create/destroy don't touch real OTEL
+vi.mock("@/telemetry/instrumentation.js", () => ({
+  initializeTelemetry: vi.fn().mockResolvedValue(undefined),
+  shutdownTelemetry: vi.fn().mockResolvedValue(undefined),
+  getCurrentConfig: vi.fn().mockReturnValue(undefined),
+  getOTELApi: vi.fn().mockReturnValue(undefined),
+  isInitialized: vi.fn().mockReturnValue(false),
+  JsonlSpanExporter: class {},
+  JsonlLogExporter: class {},
+}));
+
+vi.mock("@/telemetry/events.js", () => ({
+  logOTelEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock tool registry
+const { instance: mockToolManagerInstance } = createMockToolManager();
+
+vi.mock("@/managers/toolManager", () => ({
+  ToolManager: vi.fn().mockImplementation(function () {
+    return mockToolManagerInstance;
+  }),
+}));
+
+describe("Agent destroy teardown", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("destroy() unsubscribes module-level listeners registered during setup", async () => {
+    const unsubSettings = vi.fn();
+    const unsubAuth = vi.fn();
+    vi.spyOn(remoteSettingsService, "onSettingsUpdate").mockReturnValue(
+      unsubSettings,
+    );
+    vi.spyOn(authService, "onAuthChange").mockReturnValue(unsubAuth);
+
+    const agent = await Agent.create({
+      apiKey: "test-key",
+      workdir: "/tmp/test-destroy-teardown",
+    });
+
+    // Setup registered one listener per module-level structure
+    expect(remoteSettingsService.onSettingsUpdate).toHaveBeenCalledTimes(1);
+    expect(authService.onAuthChange).toHaveBeenCalledTimes(1);
+    expect(unsubSettings).not.toHaveBeenCalled();
+    expect(unsubAuth).not.toHaveBeenCalled();
+
+    await agent.destroy();
+
+    // destroy() must unregister both, otherwise the module-level callback
+    // arrays pin the agent's object graph forever
+    expect(unsubSettings).toHaveBeenCalledTimes(1);
+    expect(unsubAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("destroy() clears the DI container so per-agent services are released", async () => {
+    const agent = await Agent.create({
+      apiKey: "test-key",
+      workdir: "/tmp/test-destroy-container",
+    });
+    const container = (agent as unknown as { container: Container }).container;
+    expect(container.has("ToolManager")).toBe(true);
+
+    await agent.destroy();
+
+    expect(container.has("ToolManager")).toBe(false);
+    expect(container.has("MessageManager")).toBe(false);
+  });
+});


### PR DESCRIPTION
## 问题

Agent 内存泄漏：服务端进程内存只涨不降；创建 8 个 Agent 并 destroy 后，8 个实例仍被 GC 保留（heap snapshot 显示残留 agent 的唯一 incoming 边是函数 Context 的 `context:this` 槽位，持有链为 onSettingsUpdate 闭包 → LiveConfigManager → container → agent）。

## 根因

模块级监听注册，每次 `Agent.create` 注册、从不注销：

1. **`containerSetup.ts` 的 `remoteSettingsService.onSettingsUpdate`**（主泄漏点）——闭包强捕获 per-agent 的 `liveConfigManager`，整个 agent 对象图被模块级数组 `_onSettingsUpdateCallbacks` 永久持有。
2. **`containerSetup.ts` 的 `authService.onAuthChange`**——每次 create 注册一次，模块级数组无限膨胀。

原 `destroy()` 只做 isDestroyed 守卫 + async work drain，不注销任何模块级回调。

## 修复

- `utils/container.ts`：新增 `Container.clear()`，teardown 时移除全部 services/factories，切断容器内部引用。
- `utils/containerSetup.ts`：`setupAgentContainer` 返回 `{ container, teardown }`，收集两处监听器的 unsubscribe。
- `agent.ts`：`destroy()` 末尾调用 `teardown()`（注销模块级监听）+ `container.clear()`，agent 对象图可被完整回收。

## 验证

- 修复前：create 8 + destroy → GC 后仍残留 8 个；修复后：0 残留（立即 GC 有 ~百 ms 的暂时残留，来自 destroy 尾部 fs 异步 promise 链，非永久）。
- 不调用 destroy 时模块级 listener 仍持有实例——这是全局监听器的正确语义（与 Node `process.on` 同理），修复目标是 destroy 后对象图可回收。
- 新增回归测试 `agent.destroyTeardown.test.ts`（destroy 注销两处回调 + 容器清空），agent-sdk 全量单测 3541 passed。