### PR TITLE
test(agent-sdk): make async-hook timing test deterministic (fix Windows CI flake)

### DIFF
--- a/packages/agent-sdk/tests/integration/hook-real-execution.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/hook-real-execution.integration.test.ts
@@ -226,13 +226,14 @@ describe("Hook real-command execution (spec automation/hooks.md)", () => {
   });
 
   it("runs async hooks in the background without blocking the turn (hooks.md / 异步 Hook 执行 / 场景 1)", async () => {
-    const markerFile = path.join(workdir, "async-hook-done.txt");
-    // The hook's own delay is the observable signal that the turn was not
-    // blocked: a blocking hook would make sendMessage take >= delayMs. 3s
-    // keeps a wide margin over the turn's post-hook work even when the
-    // Windows CI job runs the whole suite in parallel forks (600ms was
-    // flaky under that contention).
-    const delayMs = 3000;
+    // Deterministic handshake instead of a wall-clock race: the async hook
+    // blocks on releaseFile, so when sendMessage returns the done file CANNOT
+    // exist yet — the test has not written release. No fixed delay is part of
+    // the verified behavior; a blocking hook would hang sendMessage on the
+    // same wait and fail via the test timeout. The 15s hook timeout only
+    // guards against a failed test leaving the child process behind.
+    const releaseFile = path.join(workdir, "async-hook-release.txt");
+    const doneFile = path.join(workdir, "async-hook-done.txt");
     const hooks: PartialHookConfiguration = {
       Stop: [
         {
@@ -240,7 +241,13 @@ describe("Hook real-command execution (spec automation/hooks.md)", () => {
             {
               type: "command",
               async: true,
-              command: `node -e 'setTimeout(() => require("fs").writeFileSync(process.argv[1], "done"), ${delayMs})' ${markerFile}`,
+              timeout: 15,
+              command: [
+                `node -e 'const fs=require("fs");const r=process.argv[1],d=process.argv[2];`,
+                `const t=setInterval(()=>{if(fs.existsSync(r)){clearInterval(t);fs.writeFileSync(d,"done")}},10)'`,
+                releaseFile,
+                doneFile,
+              ].join(" "),
             },
           ],
         },
@@ -249,20 +256,18 @@ describe("Hook real-command execution (spec automation/hooks.md)", () => {
     agent = await Agent.create({ workdir, hooks });
     callAgent.mockResolvedValue({ content: "finished", finish_reason: "stop" });
 
-    const turnStart = Date.now();
     await agent.sendMessage("wrap up");
-    const turnElapsed = Date.now() - turnStart;
 
-    // The turn returned before the async hook finished: the marker is not yet
-    // written and the turn itself was far shorter than the hook's delay.
-    expect(fs.existsSync(markerFile)).toBe(false);
-    expect(turnElapsed).toBeLessThan(delayMs);
+    // The turn returned while the hook was still waiting on releaseFile, so
+    // the done marker is guaranteed to be absent — no timing is assumed.
+    expect(fs.existsSync(doneFile)).toBe(false);
 
-    // The async hook completes in the background afterwards.
+    // Release the hook; it completes in the background afterwards.
+    fs.writeFileSync(releaseFile, "go");
     const start = Date.now();
-    while (!fs.existsSync(markerFile) && Date.now() - start < delayMs + 3000) {
-      await new Promise((resolve) => setTimeout(resolve, 50));
+    while (!fs.existsSync(doneFile) && Date.now() - start < 5000) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
     }
-    expect(fs.existsSync(markerFile)).toBe(true);
+    expect(fs.existsSync(doneFile)).toBe(true);
   });
 });

--- a/packages/agent-sdk/tests/integration/hook-real-execution.integration.test.ts
+++ b/packages/agent-sdk/tests/integration/hook-real-execution.integration.test.ts
@@ -227,6 +227,12 @@ describe("Hook real-command execution (spec automation/hooks.md)", () => {
 
   it("runs async hooks in the background without blocking the turn (hooks.md / 异步 Hook 执行 / 场景 1)", async () => {
     const markerFile = path.join(workdir, "async-hook-done.txt");
+    // The hook's own delay is the observable signal that the turn was not
+    // blocked: a blocking hook would make sendMessage take >= delayMs. 3s
+    // keeps a wide margin over the turn's post-hook work even when the
+    // Windows CI job runs the whole suite in parallel forks (600ms was
+    // flaky under that contention).
+    const delayMs = 3000;
     const hooks: PartialHookConfiguration = {
       Stop: [
         {
@@ -234,7 +240,7 @@ describe("Hook real-command execution (spec automation/hooks.md)", () => {
             {
               type: "command",
               async: true,
-              command: `node -e 'setTimeout(() => require("fs").writeFileSync(process.argv[1], "done"), 600)' ${markerFile}`,
+              command: `node -e 'setTimeout(() => require("fs").writeFileSync(process.argv[1], "done"), ${delayMs})' ${markerFile}`,
             },
           ],
         },
@@ -243,14 +249,18 @@ describe("Hook real-command execution (spec automation/hooks.md)", () => {
     agent = await Agent.create({ workdir, hooks });
     callAgent.mockResolvedValue({ content: "finished", finish_reason: "stop" });
 
+    const turnStart = Date.now();
     await agent.sendMessage("wrap up");
+    const turnElapsed = Date.now() - turnStart;
 
-    // The turn returned before the 600ms async hook finished.
+    // The turn returned before the async hook finished: the marker is not yet
+    // written and the turn itself was far shorter than the hook's delay.
     expect(fs.existsSync(markerFile)).toBe(false);
+    expect(turnElapsed).toBeLessThan(delayMs);
 
     // The async hook completes in the background afterwards.
     const start = Date.now();
-    while (!fs.existsSync(markerFile) && Date.now() - start < 5000) {
+    while (!fs.existsSync(markerFile) && Date.now() - start < delayMs + 3000) {
       await new Promise((resolve) => setTimeout(resolve, 50));
     }
     expect(fs.existsSync(markerFile)).toBe(true);


### PR DESCRIPTION
## Problem

[ci-windows run 32716631832](https://github.com/netease-lcap/wave-agent/actions/runs/32716631832) failed on main:

```
AssertionError: expected true to be false
❯ tests/integration/hook-real-execution.integration.test.ts:249:39
```

The async-hook test asserted the marker file is absent when `sendMessage` returns, which required the turn to finish within **600ms** of spawning the hook. The Windows CI job runs the whole agent-sdk suite in parallel vitest forks on a 2-vCPU runner — under CPU contention the post-hook turn work can exceed 600ms, so the marker is already written and the assertion fails. The hook code is correct (fire-and-forget at `hookManager.ts:218`); the test's wall-clock margin was too tight.

## Fix: deterministic handshake, no fixed delay, no slowdown

Instead of widening the wall-clock race (600ms → 3s sleep, which slows the test), the async hook now **blocks on a release file** instead of sleeping:

1. Hook waits (10ms poll) for `async-hook-release.txt`
2. `sendMessage` returns — the done marker is **guaranteed** absent, because the test hasn't written the release file yet. This is a logical guarantee, not a timing assumption, so it holds under any parallel-fork load
3. Test writes the release file → hook finishes in the background → poll for the done marker

A blocking-hook regression now fails via the 5s vitest test timeout (the hook would hang `sendMessage` on the same wait). The 15s hook `timeout` is only a guard rail against a failed test leaving the child process behind.

Result: deterministic under load, and the file runs **faster** than the original 600ms test (4.5s vs 5.0s test time).

## Verification

- `pnpm test tests/integration/hook-real-execution.integration.test.ts` → 4/4 pass, 3 consecutive runs
- Full agent-sdk suite → 274 files green
- `pnpm run type-check` → clean