### PR TITLE
fix(desktop,vscode,jb): register btwContent in notification router

### DIFF
--- a/packages/desktop/src/main/stdio/notificationRouter.ts
+++ b/packages/desktop/src/main/stdio/notificationRouter.ts
@@ -43,6 +43,7 @@ const ALL_NOTIFICATION_METHODS = [
   "notificationMessageAdded",
   "permissionRequest",
   "authUrl",
+  "btwContent",
   "compactBlockAdded",
   "compactionStateChange",
   "compactionContentUpdate",

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/NotificationRouter.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/NotificationRouter.kt
@@ -82,6 +82,7 @@ class NotificationRouter(private val client: StdioClient) {
             "notificationMessageAdded",
             "permissionRequest",
             "authUrl",
+            "btwContent",
             "compactBlockAdded",
             "compactionStateChange",
             "compactionContentUpdate",

--- a/packages/vscode/src/stdio/notificationRouter.ts
+++ b/packages/vscode/src/stdio/notificationRouter.ts
@@ -43,6 +43,7 @@ const ALL_NOTIFICATION_METHODS = [
   "notificationMessageAdded",
   "permissionRequest",
   "authUrl",
+  "btwContent",
   "compactBlockAdded",
   "compactionStateChange",
   "compactionContentUpdate",


### PR DESCRIPTION
## 问题

桌面端 / VS Code / JetBrains 的 btw（旁路提问）尾部流式效果（"正在回答"后的流式尾部文字）不生效。

## 根因

CLI 侧 agentBridge 的 askBtw 流式回调会 emit `btwContent` 通知，但三端 notificationRouter 的 `ALL_NOTIFICATION_METHODS` 注册表均未包含 `btwContent`。未注册的通知方法被 router 静默丢弃，导致 `btwStream` 消息永远到不了 webview。

## 修复

三端 notificationRouter 各补注册一行 `"btwContent"`（desktop / vscode / jetbrains）。

## 验证

- desktop dev 真机（Electron + CDP）验证：输入 /btw 后采样到 loading-tail（`t=1535ms loading-tail tailText="TheThe user"`），随后完整回答渲染，修复生效
- compact（对话压缩）尾部流式经真机模拟消息验证链路完好（notificationRouter 已注册 compaction 方法），无需修复
- vscode stdio 测试 68/68 通过，desktop stdioAgent 测试通过，jetbrains compileKotlin 通过，全仓 type-check 通过