### PR TITLE
docs: add lightbox image viewer to docs site

### DIFF
--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,0 +1,26 @@
+import { onMounted, watch, nextTick } from "vue";
+import { useRoute } from "vitepress";
+import DefaultTheme from "vitepress/theme";
+import mediumZoom from "medium-zoom";
+
+import "./zoom.css";
+
+let zoom = null;
+
+export default {
+  extends: DefaultTheme,
+  setup() {
+    const route = useRoute();
+    const initZoom = () => {
+      zoom?.dispose();
+      zoom = mediumZoom(".vp-doc img", {
+        background: "var(--vp-c-bg)",
+      });
+    };
+    onMounted(initZoom);
+    watch(
+      () => route.path,
+      () => nextTick(initZoom),
+    );
+  },
+};

--- a/docs/.vitepress/theme/zoom.css
+++ b/docs/.vitepress/theme/zoom.css
@@ -1,0 +1,12 @@
+.vp-doc img {
+  cursor: zoom-in;
+}
+
+/* medium-zoom overlay 图片带阴影以贴合浅色/深色主题 */
+.medium-zoom-overlay {
+  z-index: 30;
+}
+
+.medium-zoom-image {
+  z-index: 31;
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@vitest/coverage-v8": "^4.1.7",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.5",
+    "medium-zoom": "^1.1.0",
     "oxlint": "^1.79.0",
     "prettier": "3.6.2",
     "tsx": "^4.20.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       lint-staged:
         specifier: ^16.1.5
         version: 16.1.5
+      medium-zoom:
+        specifier: ^1.1.0
+        version: 1.1.0
       oxlint:
         specifier: ^1.79.0
         version: 1.79.0
@@ -4454,6 +4457,9 @@ packages:
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
+
+  medium-zoom@1.1.0:
+    resolution: {integrity: sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ==}
 
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
@@ -10390,6 +10396,8 @@ snapshots:
   mdurl@2.0.0: {}
 
   media-typer@1.1.0: {}
+
+  medium-zoom@1.1.0: {}
 
   merge-descriptors@2.0.0: {}
 


### PR DESCRIPTION
Register medium-zoom in the VitePress theme so images in the docs site (guide/desktop/vsce screenshots) can be clicked to view at full size; Esc/click-away to close.

- `medium-zoom@^1.1.0` devDependency
- `docs/.vitepress/theme/index.js` — init medium-zoom on `.vp-doc img`, re-init on route change
- `docs/.vitepress/theme/zoom.css` — zoom-in cursor + overlay z-index

Verified: `pnpm run docs:build` green (59 demo/e2e tests + vitepress build); Playwright check confirms 624px → 960px zoom, overlay appears, Esc closes.