### PR TITLE
fix(agent-sdk): 忽略 agent 销毁后的流式回调避免崩溃

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -1865,6 +1865,8 @@ ${question}`;
           // Add streaming callbacks only if streaming is enabled
           if (this.stream) {
             callAgentOptions.onContentUpdate = (content: string) => {
+              // Agent may have been destroyed mid-stream; ignore in-flight updates.
+              if (!this.messageManager) return;
               // Create assistant message on first chunk if not already created
               if (!assistantMessageCreated) {
                 this.messageManager.addAssistantMessage();
@@ -1873,6 +1875,8 @@ ${question}`;
               this.messageManager.updateCurrentMessageContent(content);
             };
             callAgentOptions.onToolUpdate = (toolCall) => {
+              // Agent may have been destroyed mid-stream; ignore in-flight updates.
+              if (!this.messageManager) return;
               // Create assistant message on first tool update if not already created
               if (!assistantMessageCreated) {
                 this.messageManager.addAssistantMessage();
@@ -1897,6 +1901,8 @@ ${question}`;
               });
             };
             callAgentOptions.onReasoningUpdate = (reasoning: string) => {
+              // Agent may have been destroyed mid-stream; ignore in-flight updates.
+              if (!this.messageManager) return;
               // Create assistant message on first reasoning update if not already created
               if (!assistantMessageCreated) {
                 this.messageManager.addAssistantMessage();


### PR DESCRIPTION
## 背景

CI 上 `check (agent-sdk)` shard 偶发失败：所有 1613 个测试通过，但 vitest 报 1 个 unhandled error：

```
TypeError: Cannot read properties of undefined (reading 'updateToolBlock')
 ❯ Object.callAgentOptions.onToolUpdate src/managers/aiManager.ts:1889
 ❯ Timeout._onTimeout tests/agent/agent.streaming.tools.test.ts:445
```

## 根因

- `agent.destroy()` 会 `container.clear()`（PR #1906），此后 `messageManager` getter 返回 `undefined`
- `agent.streaming.tools.test.ts` 用裸 `setTimeout`（10ms/20ms）模拟流式 tool 参数 chunk；mock 全同步 resolve 时 `sendMessage` 可能 <10ms 完成，测试收尾 destroy 后定时器才触发
- destroy 后的 in-flight 回调访问 `messageManager` 直接抛 TypeError，vitest 记为 unhandled error → shard 失败

## 修复

三个流式回调（`onToolUpdate` / `onContentUpdate` / `onReasoningUpdate`）开头加判空：agent 销毁后的 in-flight 更新静默忽略，不再崩溃。

真实场景同样受益：destroy 与模型流式回调的竞态（删除会话/新会话替换时的残留回调）不再抛错。

## 验证

- agent-sdk 全量单测 3541/3541 通过（含 agent.streaming.tools.test.ts）
- 临时复现测试（destroy 后手动触发三个回调）通过后已删除
- 本地 type-check / lint 通过