### PR TITLE
fix(webview): 对话框 ESC 不再误触 abort 对话

### DIFF
--- a/packages/webview/src/components/AgentsDialog.tsx
+++ b/packages/webview/src/components/AgentsDialog.tsx
@@ -67,8 +67,14 @@ const AgentsDialog: React.FC<
       }
     };
 
+    // Escape closes only the dialog. A capture-phase listener with
+    // stopPropagation runs before React's synthetic onKeyDown (attached at the
+    // root container), so the keypress never reaches MessageInput's
+    // onAbortMessage and the in-flight agent loop keeps running.
     const handleEscapeKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
         if (selectedName) {
           setSelectedName(null);
         } else {
@@ -82,12 +88,12 @@ const AgentsDialog: React.FC<
     const timer = setTimeout(() => {
       document.addEventListener("mousedown", handleClickOutside);
     }, 0);
-    document.addEventListener("keydown", handleEscapeKey);
+    document.addEventListener("keydown", handleEscapeKey, true);
 
     return () => {
       clearTimeout(timer);
       document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleEscapeKey);
+      document.removeEventListener("keydown", handleEscapeKey, true);
     };
   }, [onClose, selectedName]);
 

--- a/packages/webview/src/components/ConfigDialog.tsx
+++ b/packages/webview/src/components/ConfigDialog.tsx
@@ -51,8 +51,14 @@ const ConfigDialog: React.FC<ConfigDialogProps & { vscode: VsCodeApi }> = ({
       }
     };
 
+    // Escape closes only the dialog. A capture-phase listener with
+    // stopPropagation runs before React's synthetic onKeyDown (attached at the
+    // root container), so the keypress never reaches MessageInput's
+    // onAbortMessage and the in-flight agent loop keeps running.
     const handleEscapeKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
         onCancel();
       }
     };
@@ -62,12 +68,12 @@ const ConfigDialog: React.FC<ConfigDialogProps & { vscode: VsCodeApi }> = ({
     const timer = setTimeout(() => {
       document.addEventListener("mousedown", handleClickOutside);
     }, 0);
-    document.addEventListener("keydown", handleEscapeKey);
+    document.addEventListener("keydown", handleEscapeKey, true);
 
     return () => {
       clearTimeout(timer);
       document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleEscapeKey);
+      document.removeEventListener("keydown", handleEscapeKey, true);
     };
   }, [onCancel]);
 

--- a/packages/webview/src/components/McpDialog.tsx
+++ b/packages/webview/src/components/McpDialog.tsx
@@ -63,8 +63,14 @@ const McpDialog: React.FC<
       }
     };
 
+    // Escape closes only the dialog. A capture-phase listener with
+    // stopPropagation runs before React's synthetic onKeyDown (attached at the
+    // root container), so the keypress never reaches MessageInput's
+    // onAbortMessage and the in-flight agent loop keeps running.
     const handleEscapeKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
         onClose();
       }
     };
@@ -74,12 +80,12 @@ const McpDialog: React.FC<
     const timer = setTimeout(() => {
       document.addEventListener("mousedown", handleClickOutside);
     }, 0);
-    document.addEventListener("keydown", handleEscapeKey);
+    document.addEventListener("keydown", handleEscapeKey, true);
 
     return () => {
       clearTimeout(timer);
       document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleEscapeKey);
+      document.removeEventListener("keydown", handleEscapeKey, true);
     };
   }, [onClose]);
 

--- a/packages/webview/src/components/PluginDialog.tsx
+++ b/packages/webview/src/components/PluginDialog.tsx
@@ -108,8 +108,14 @@ const PluginDialog: React.FC<
       }
     };
 
+    // Escape closes only the dialog. A capture-phase listener with
+    // stopPropagation runs before React's synthetic onKeyDown (attached at the
+    // root container), so the keypress never reaches MessageInput's
+    // onAbortMessage and the in-flight agent loop keeps running.
     const handleEscapeKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
         onClose();
       }
     };
@@ -119,12 +125,12 @@ const PluginDialog: React.FC<
     const timer = setTimeout(() => {
       document.addEventListener("mousedown", handleClickOutside);
     }, 0);
-    document.addEventListener("keydown", handleEscapeKey);
+    document.addEventListener("keydown", handleEscapeKey, true);
 
     return () => {
       clearTimeout(timer);
       document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleEscapeKey);
+      document.removeEventListener("keydown", handleEscapeKey, true);
     };
   }, [onClose]);
 

--- a/packages/webview/src/components/SkillsDialog.tsx
+++ b/packages/webview/src/components/SkillsDialog.tsx
@@ -76,8 +76,14 @@ const SkillsDialog: React.FC<
       }
     };
 
+    // Escape closes only the dialog. A capture-phase listener with
+    // stopPropagation runs before React's synthetic onKeyDown (attached at the
+    // root container), so the keypress never reaches MessageInput's
+    // onAbortMessage and the in-flight agent loop keeps running.
     const handleEscapeKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
         if (selectedName) {
           setSelectedName(null);
         } else {
@@ -91,12 +97,12 @@ const SkillsDialog: React.FC<
     const timer = setTimeout(() => {
       document.addEventListener("mousedown", handleClickOutside);
     }, 0);
-    document.addEventListener("keydown", handleEscapeKey);
+    document.addEventListener("keydown", handleEscapeKey, true);
 
     return () => {
       clearTimeout(timer);
       document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleEscapeKey);
+      document.removeEventListener("keydown", handleEscapeKey, true);
     };
   }, [onClose, selectedName]);
 

--- a/packages/webview/src/components/StatusDialog.tsx
+++ b/packages/webview/src/components/StatusDialog.tsx
@@ -48,8 +48,14 @@ const StatusDialog: React.FC<
         onClose();
       }
     };
+    // Escape closes only the dialog. A capture-phase listener with
+    // stopPropagation runs before React's synthetic onKeyDown (attached at the
+    // root container), so the keypress never reaches MessageInput's
+    // onAbortMessage and the in-flight agent loop keeps running.
     const handleEscapeKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
         onClose();
       }
     };
@@ -58,11 +64,11 @@ const StatusDialog: React.FC<
     const timer = setTimeout(() => {
       document.addEventListener("mousedown", handleClickOutside);
     }, 0);
-    document.addEventListener("keydown", handleEscapeKey);
+    document.addEventListener("keydown", handleEscapeKey, true);
     return () => {
       clearTimeout(timer);
       document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleEscapeKey);
+      document.removeEventListener("keydown", handleEscapeKey, true);
     };
   }, [onClose]);
 

--- a/packages/webview/tests/webview/model-status-login-commands.test.tsx
+++ b/packages/webview/tests/webview/model-status-login-commands.test.tsx
@@ -80,6 +80,41 @@ describe("Model, Status, and Login Commands", () => {
         ).not.toBeInTheDocument();
       });
     });
+
+    it("Escape while streaming closes the dialog without aborting the conversation", async () => {
+      const { vscode } = renderChatApp();
+
+      await act(async () => {
+        await typeAndSend("/status");
+      });
+
+      await waitFor(() => {
+        expect(
+          document.querySelector(".configuration-dialog-overlay"),
+        ).toBeInTheDocument();
+      });
+
+      // The main conversation is streaming — a plain Escape on the input would
+      // normally fire onAbortMessage (MessageInput.tsx). The dialog's
+      // capture-phase listener must swallow it first (same pattern as the btw
+      // panel), so only the dialog closes and the agent loop keeps running.
+      await act(async () => {
+        sendCommand("startStreaming");
+      });
+
+      const input = screen.getByTestId("message-input");
+      input.focus();
+      await act(async () => {
+        fireEvent.keyDown(input, { key: "Escape" });
+      });
+
+      expect(
+        document.querySelector(".configuration-dialog-overlay"),
+      ).not.toBeInTheDocument();
+      expect(vscode.postMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ command: "abortMessage" }),
+      );
+    });
   });
 
   describe("/config command", () => {


### PR DESCRIPTION
## 问题

桌面端 `/status` 等斜杠命令打开的对话框，流式进行中按 ESC 会把对话也 abort 掉。

## 根因

- `MessageInput.tsx` 的「流式中按 ESC → `onAbortMessage`」绑定在输入框 keydown 上
- 对话框（StatusDialog/McpDialog/ConfigDialog/PluginDialog/SkillsDialog/AgentsDialog）的 ESC 监听注册在 document 冒泡阶段，无 stopPropagation
- 弹窗打开时焦点仍在输入框，按 ESC 事件先触发输入框的 abort，再冒泡到 document 关闭弹窗

## 修复

6 个对话框的 ESC handler 改为 **capture 阶段 + `preventDefault/stopPropagation`**，在事件到达输入框前拦截——ESC 只关弹窗，不 abort。与 BtwPanel 既有修复（spec 场景 9，`btwPopup.test.tsx`）完全一致。

## 验证

- 新增回归测试：streaming 时打开 `/status` 按 ESC → 弹窗关闭且不发送 `abortMessage`
- webview 全量单测 695/695 通过，type-check 通过