### PR TITLE
fix(webview): 输入框 + 菜单与权限菜单项支持键盘 Tab 聚焦与操作

### DIFF
--- a/packages/webview/src/components/MessageInput.tsx
+++ b/packages/webview/src/components/MessageInput.tsx
@@ -145,6 +145,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     // Permission mode custom dropdown state
     const [permMenuOpen, setPermMenuOpen] = useState(false);
     const permMenuRef = useRef<HTMLDivElement>(null);
+    const permMenuButtonRef = useRef<HTMLButtonElement>(null);
 
     const handlePermissionModeSelect = useCallback(
       (mode: PermissionMode) => {
@@ -210,6 +211,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     // "+" (add) custom dropdown state
     const [plusMenuOpen, setPlusMenuOpen] = useState(false);
     const plusMenuRef = useRef<HTMLDivElement>(null);
+    const plusMenuButtonRef = useRef<HTMLButtonElement>(null);
 
     // Close the "+" dropdown when clicking outside of it.
     useEffect(() => {
@@ -1660,6 +1662,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
                 <div className="plus-menu-container" ref={plusMenuRef}>
                   <button
                     type="button"
+                    ref={plusMenuButtonRef}
                     className="toolbar-icon-button"
                     aria-label="添加"
                     aria-expanded={plusMenuOpen}
@@ -1672,20 +1675,45 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
                     <ul className="plus-menu" role="menu">
                       <li
                         role="menuitem"
+                        tabIndex={0}
                         className="plus-menu-item"
                         onClick={() => {
                           handleFileUpload();
                           setPlusMenuOpen(false);
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            handleFileUpload();
+                            setPlusMenuOpen(false);
+                            plusMenuButtonRef.current?.focus();
+                          } else if (e.key === "Escape") {
+                            e.preventDefault();
+                            setPlusMenuOpen(false);
+                            plusMenuButtonRef.current?.focus();
+                          }
                         }}
                       >
                         上传文件
                       </li>
                       <li
                         role="menuitem"
+                        tabIndex={0}
                         className="plus-menu-item"
                         onClick={() => {
                           openHistorySearch();
                           setPlusMenuOpen(false);
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            openHistorySearch();
+                            setPlusMenuOpen(false);
+                          } else if (e.key === "Escape") {
+                            e.preventDefault();
+                            setPlusMenuOpen(false);
+                            plusMenuButtonRef.current?.focus();
+                          }
                         }}
                       >
                         历史提示词
@@ -1712,6 +1740,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
               <div className="permission-mode-container" ref={permMenuRef}>
                 <button
                   type="button"
+                  ref={permMenuButtonRef}
                   className={`permission-mode-select mode-${permissionMode || "default"}`}
                   aria-label="权限模式"
                   aria-expanded={permMenuOpen}
@@ -1728,12 +1757,24 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
                       <li
                         key={m.value}
                         role="option"
+                        tabIndex={0}
                         data-value={m.value}
                         aria-selected={
                           m.value === (permissionMode || "default")
                         }
                         className={`permission-mode-item${m.value === (permissionMode || "default") ? " selected" : ""}`}
                         onClick={() => handlePermissionModeSelect(m.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            handlePermissionModeSelect(m.value);
+                            permMenuButtonRef.current?.focus();
+                          } else if (e.key === "Escape") {
+                            e.preventDefault();
+                            setPermMenuOpen(false);
+                            permMenuButtonRef.current?.focus();
+                          }
+                        }}
                       >
                         {m.label}
                       </li>

--- a/packages/webview/src/styles/MessageInput.css
+++ b/packages/webview/src/styles/MessageInput.css
@@ -278,7 +278,8 @@
 }
 
 .permission-mode-item:hover,
-.permission-mode-item.selected {
+.permission-mode-item.selected,
+.permission-mode-item:focus-visible {
   background: var(--vscode-list-hoverBackground);
   color: var(--vscode-list-activeSelectionForeground);
 }
@@ -350,7 +351,8 @@
   color: var(--vscode-menu-foreground);
 }
 
-.plus-menu-item:hover {
+.plus-menu-item:hover,
+.plus-menu-item:focus-visible {
   background: var(--vscode-list-hoverBackground);
   color: var(--vscode-list-activeSelectionForeground);
 }

--- a/packages/webview/tests/webview/plusMenuKeyboard.test.tsx
+++ b/packages/webview/tests/webview/plusMenuKeyboard.test.tsx
@@ -1,0 +1,98 @@
+import { renderChatApp, screen, fireEvent } from "./test-utils";
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+/**
+ * Keyboard accessibility of the custom dropdowns in the message input:
+ * items must be Tab-focusable and activatable with Enter/Space, and Escape
+ * must close the menu and return focus to its trigger button.
+ */
+describe("Message input dropdown keyboard accessibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const openPlusMenu = () => {
+    fireEvent.click(screen.getByRole("button", { name: "添加" }));
+  };
+
+  it("should make + menu items Tab-focusable and activate them with Enter", () => {
+    renderChatApp();
+    // jsdom has no real file dialog; silence the hidden file input click.
+    const clickSpy = vi
+      .spyOn(HTMLInputElement.prototype, "click")
+      .mockImplementation(() => {});
+    openPlusMenu();
+
+    const uploadItem = screen.getByRole("menuitem", { name: "上传文件" });
+    const historyItem = screen.getByRole("menuitem", { name: "历史提示词" });
+    expect(uploadItem).toHaveProperty("tabIndex", 0);
+    expect(historyItem).toHaveProperty("tabIndex", 0);
+
+    // Enter activates the item and closes the menu.
+    uploadItem.focus();
+    fireEvent.keyDown(uploadItem, { key: "Enter" });
+    expect(clickSpy).toHaveBeenCalled();
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("should activate + menu items with Space and open the history popup", async () => {
+    renderChatApp();
+    openPlusMenu();
+
+    const historyItem = screen.getByRole("menuitem", { name: "历史提示词" });
+    historyItem.focus();
+    fireEvent.keyDown(historyItem, { key: " " });
+
+    await screen.findByTestId("history-search-popup");
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("should close the + menu with Escape and return focus to the + button", () => {
+    renderChatApp();
+    openPlusMenu();
+
+    const uploadItem = screen.getByRole("menuitem", { name: "上传文件" });
+    uploadItem.focus();
+    fireEvent.keyDown(uploadItem, { key: "Escape" });
+
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "添加" }),
+    );
+  });
+
+  it("should make permission-mode options focusable and selectable via keyboard", () => {
+    const { vscode } = renderChatApp();
+    fireEvent.click(screen.getByRole("button", { name: "权限模式" }));
+
+    const option = screen.getByRole("option", { name: "自动接受修改" });
+    expect(option).toHaveProperty("tabIndex", 0);
+
+    option.focus();
+    fireEvent.keyDown(option, { key: "Enter" });
+
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "setPermissionMode",
+      mode: "acceptEdits",
+    });
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("should close the permission menu with Escape and return focus to its button", () => {
+    renderChatApp();
+    fireEvent.click(screen.getByRole("button", { name: "权限模式" }));
+
+    const option = screen.getByRole("option", { name: "计划模式" });
+    option.focus();
+    fireEvent.keyDown(option, { key: "Escape" });
+
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "权限模式" }),
+    );
+  });
+});


### PR DESCRIPTION
## 问题

用 Tab 聚焦到输入框的「+」按钮并打开菜单后，弹出的「上传文件 / 历史提示词」菜单项无法继续用 Tab 选中——菜单项是裸 `<li role=menuitem>`，没有 `tabIndex`，键盘焦点直接跳过。

同类问题：权限模式下拉菜单的选项同样无法键盘聚焦。

## 修复

- `MessageInput.tsx`：`+ ` 菜单与权限模式菜单的选项加 `tabIndex={0}` + `onKeyDown`——Enter/Space 激活、Escape 关闭菜单并把焦点归还触发按钮
- `MessageInput.css`：菜单项加 `:focus-visible` 高亮（与 hover 一致）

## 验证

- 新增 jsdom 单测 `plusMenuKeyboard.test.tsx` 5 个用例：菜单项可聚焦、Enter/Space 激活、Escape 关闭并还焦
- webview 单测 699/699 通过，type-check、lint 0 错误
- 真实 Edge 探针验证焦点序列：Tab 到「+」→ Enter 打开 → Tab 依次进入「上传文件」「历史提示词」→ Enter 激活历史提示词弹窗 → 菜单项 Escape 关闭菜单且焦点回「+」按钮