### PR TITLE
fix(webview): 自绘下拉与可点击元素补齐 Tab 键盘可达性

### DIFF
--- a/packages/webview/src/components/ContextTag.css
+++ b/packages/webview/src/components/ContextTag.css
@@ -26,7 +26,8 @@
   transition: all 0.2s ease;
 }
 
-.context-tag.clickable:hover {
+.context-tag.clickable:hover,
+.context-tag.clickable:focus-visible {
   background-color: var(--vscode-editor-selectionBackground);
   color: var(--vscode-button-foreground);
   text-decoration: none;

--- a/packages/webview/src/components/ContextTag.tsx
+++ b/packages/webview/src/components/ContextTag.tsx
@@ -25,12 +25,23 @@ export const ContextTag: React.FC<ContextTagProps> = ({
     }
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      e.stopPropagation();
+      if (isClickable) onClick();
+    }
+  };
+
   return (
     <Tooltip text={isClickable ? `点击查看 ${name}` : path} position="top">
       <span
         className={`context-tag ${isClickable ? "clickable" : ""} ${isImage ? "is-image" : ""}`}
         onClick={handlePreview}
+        onKeyDown={isClickable ? handleKeyDown : undefined}
         aria-label={isClickable ? `点击查看 ${name}` : path}
+        role={isClickable ? "button" : undefined}
+        tabIndex={isClickable ? 0 : undefined}
         data-path={path}
       >
         <span className="tag-at">@</span>

--- a/packages/webview/src/components/DesktopHostSelector.tsx
+++ b/packages/webview/src/components/DesktopHostSelector.tsx
@@ -35,6 +35,7 @@ export const DesktopHostSelector: React.FC<DesktopHostSelectorProps> = ({
   const [connectionString, setConnectionString] = useState("");
   const menuRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
 
   // Close the dropdown when clicking outside of it.
   useEffect(() => {
@@ -54,6 +55,7 @@ export const DesktopHostSelector: React.FC<DesktopHostSelectorProps> = ({
       setMenuOpen(false);
       setAdding(false);
       if (h !== host) onSelectHost(h);
+      triggerRef.current?.focus();
     },
     [host, onSelectHost],
   );
@@ -73,6 +75,7 @@ export const DesktopHostSelector: React.FC<DesktopHostSelectorProps> = ({
     setAdding(false);
     setConnectionString("");
     onAddHost(s);
+    triggerRef.current?.focus();
   }, [connectionString, onAddHost]);
 
   const isLocal = host === "local";
@@ -81,11 +84,23 @@ export const DesktopHostSelector: React.FC<DesktopHostSelectorProps> = ({
     <div className="desktop-host-container" ref={menuRef}>
       <div
         className="desktop-host-trigger"
+        ref={triggerRef}
         onClick={() => setMenuOpen((o) => !o)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setMenuOpen((o) => !o);
+          } else if (e.key === "Escape" && menuOpen) {
+            e.preventDefault();
+            setMenuOpen(false);
+          }
+        }}
         title={isLocal ? "本地" : host}
         data-testid="desktop-host"
         aria-expanded={menuOpen}
+        aria-haspopup="listbox"
         role="button"
+        tabIndex={0}
       >
         <span
           className={`codicon ${isLocal ? "codicon-laptop" : "codicon-remote"}`}
@@ -102,7 +117,19 @@ export const DesktopHostSelector: React.FC<DesktopHostSelectorProps> = ({
           <div
             className="desktop-workdir-menu-item"
             role="option"
+            tabIndex={0}
             onClick={() => handleSelect("local")}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                handleSelect("local");
+              } else if (e.key === "Escape") {
+                e.preventDefault();
+                setMenuOpen(false);
+                setAdding(false);
+                triggerRef.current?.focus();
+              }
+            }}
             data-testid="desktop-host-local"
           >
             <span className="codicon codicon-laptop"></span>
@@ -116,7 +143,19 @@ export const DesktopHostSelector: React.FC<DesktopHostSelectorProps> = ({
               key={h}
               className="desktop-workdir-menu-item"
               role="option"
+              tabIndex={0}
               onClick={() => handleSelect(h)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  handleSelect(h);
+                } else if (e.key === "Escape") {
+                  e.preventDefault();
+                  setMenuOpen(false);
+                  setAdding(false);
+                  triggerRef.current?.focus();
+                }
+              }}
               title={h}
               data-testid="desktop-host-item"
             >
@@ -135,7 +174,10 @@ export const DesktopHostSelector: React.FC<DesktopHostSelectorProps> = ({
                 onChange={(e) => setConnectionString(e.target.value)}
                 onKeyDown={(e) => {
                   if (e.key === "Enter") submitAdd();
-                  else if (e.key === "Escape") setAdding(false);
+                  else if (e.key === "Escape") {
+                    setAdding(false);
+                    triggerRef.current?.focus();
+                  }
                 }}
               />
             </div>
@@ -143,7 +185,19 @@ export const DesktopHostSelector: React.FC<DesktopHostSelectorProps> = ({
             <div
               className="desktop-workdir-menu-item"
               role="option"
+              tabIndex={0}
               onClick={openAdd}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  openAdd();
+                } else if (e.key === "Escape") {
+                  e.preventDefault();
+                  setMenuOpen(false);
+                  setAdding(false);
+                  triggerRef.current?.focus();
+                }
+              }}
               data-testid="desktop-host-add-entry"
             >
               <span className="codicon codicon-add"></span>

--- a/packages/webview/src/components/DesktopWorkdirSelector.tsx
+++ b/packages/webview/src/components/DesktopWorkdirSelector.tsx
@@ -73,6 +73,7 @@ export const DesktopWorkdirSelector: React.FC<DesktopWorkdirSelectorProps> = ({
   const menuRef = useRef<HTMLDivElement>(null);
   const filterInputRef = useRef<HTMLInputElement>(null);
   const selectedItemRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
   const requestIdRef = useRef(0);
   const lastPathRef = useRef("~");
   const isRemote = host !== undefined && host !== "local";
@@ -135,6 +136,7 @@ export const DesktopWorkdirSelector: React.FC<DesktopWorkdirSelectorProps> = ({
   const handleBrowse = useCallback(() => {
     setMenuOpen(false);
     onSelectWorkdir();
+    triggerRef.current?.focus();
   }, [onSelectWorkdir]);
 
   const openBrowser = useCallback(() => {
@@ -169,6 +171,7 @@ export const DesktopWorkdirSelector: React.FC<DesktopWorkdirSelectorProps> = ({
     (path: string) => {
       setMenuOpen(false);
       onSelectRecentWorkdir(path, host);
+      triggerRef.current?.focus();
     },
     [host, onSelectRecentWorkdir],
   );
@@ -239,11 +242,23 @@ export const DesktopWorkdirSelector: React.FC<DesktopWorkdirSelectorProps> = ({
     <div className="desktop-workdir-container" ref={menuRef}>
       <div
         className="desktop-workdir-trigger"
+        ref={triggerRef}
         onClick={() => setMenuOpen((o) => !o)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setMenuOpen((o) => !o);
+          } else if (e.key === "Escape" && menuOpen) {
+            e.preventDefault();
+            setMenuOpen(false);
+          }
+        }}
         title={workdir ?? (isRemote ? "选择远程目录…" : "选择工作目录…")}
         data-testid="desktop-workdir"
         aria-expanded={menuOpen}
+        aria-haspopup="listbox"
         role="button"
+        tabIndex={0}
       >
         <span className="codicon codicon-folder-opened"></span>
         <span className="desktop-workdir-name">{dirName}</span>
@@ -272,7 +287,21 @@ export const DesktopWorkdirSelector: React.FC<DesktopWorkdirSelectorProps> = ({
                 key={dir}
                 className="desktop-workdir-menu-item"
                 role="option"
+                tabIndex={0}
                 onClick={() => handleSelectRecent(dir)}
+                onKeyDown={(e) => {
+                  // Let the nested remove button handle its own keys.
+                  if (e.target !== e.currentTarget) return;
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    handleSelectRecent(dir);
+                  } else if (e.key === "Escape") {
+                    e.preventDefault();
+                    setMenuOpen(false);
+                    setBrowsing(false);
+                    triggerRef.current?.focus();
+                  }
+                }}
                 title={dir}
                 data-testid="desktop-workdir-recent-item"
               >
@@ -300,7 +329,20 @@ export const DesktopWorkdirSelector: React.FC<DesktopWorkdirSelectorProps> = ({
           <div
             className="desktop-workdir-menu-item"
             role="option"
+            tabIndex={0}
             onClick={isRemote ? openBrowser : handleBrowse}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                if (isRemote) openBrowser();
+                else handleBrowse();
+              } else if (e.key === "Escape") {
+                e.preventDefault();
+                setMenuOpen(false);
+                setBrowsing(false);
+                triggerRef.current?.focus();
+              }
+            }}
             data-testid="desktop-workdir-browse"
           >
             <span className="codicon codicon-folder-opened"></span>
@@ -324,7 +366,18 @@ export const DesktopWorkdirSelector: React.FC<DesktopWorkdirSelectorProps> = ({
                 <span
                   key={`${seg}-${i}`}
                   className={`desktop-remote-browser-crumb${i === crumbs.length - 1 ? " active" : ""}`}
+                  tabIndex={0}
                   onClick={() => requestList(target)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      requestList(target);
+                    } else if (e.key === "Escape") {
+                      e.preventDefault();
+                      setBrowsing(false);
+                      triggerRef.current?.focus();
+                    }
+                  }}
                 >
                   {seg}
                 </span>
@@ -416,7 +469,9 @@ export const DesktopWorkdirSelector: React.FC<DesktopWorkdirSelectorProps> = ({
                     submitFilterInput();
                   }
                 } else if (e.key === "Escape") {
+                  e.preventDefault();
                   setBrowsing(false);
+                  triggerRef.current?.focus();
                 }
               }}
               data-testid="desktop-remote-browser-input"

--- a/packages/webview/src/components/DesktopWorktreeControls.tsx
+++ b/packages/webview/src/components/DesktopWorktreeControls.tsx
@@ -34,6 +34,7 @@ export const DesktopWorktreeControls: React.FC<
 }) => {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!menuOpen) return;
@@ -50,6 +51,7 @@ export const DesktopWorktreeControls: React.FC<
     (b: string) => {
       setMenuOpen(false);
       onBranchChange(b);
+      triggerRef.current?.focus();
     },
     [onBranchChange],
   );
@@ -62,11 +64,27 @@ export const DesktopWorktreeControls: React.FC<
       <div className="desktop-workdir-container" ref={menuRef}>
         <div
           className="desktop-workdir-trigger"
+          ref={triggerRef}
           onClick={loading ? undefined : () => setMenuOpen((o) => !o)}
+          onKeyDown={
+            loading
+              ? undefined
+              : (e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setMenuOpen((o) => !o);
+                  } else if (e.key === "Escape" && menuOpen) {
+                    e.preventDefault();
+                    setMenuOpen(false);
+                  }
+                }
+          }
           title={loading ? "分支获取中…" : `基准分支：${branch}`}
           data-testid="desktop-branch-selector"
           aria-expanded={menuOpen}
+          aria-haspopup="listbox"
           role="button"
+          tabIndex={loading ? -1 : 0}
         >
           <span className="codicon codicon-git-branch"></span>
           {loading ? (
@@ -89,7 +107,18 @@ export const DesktopWorktreeControls: React.FC<
                 key={b}
                 className={`desktop-workdir-menu-item${b === branch ? " desktop-branch-active" : ""}`}
                 role="option"
+                tabIndex={0}
                 onClick={() => handleSelectBranch(b)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    handleSelectBranch(b);
+                  } else if (e.key === "Escape") {
+                    e.preventDefault();
+                    setMenuOpen(false);
+                    triggerRef.current?.focus();
+                  }
+                }}
                 title={b}
                 data-testid="desktop-branch-item"
               >

--- a/packages/webview/src/components/FileToolHeader.tsx
+++ b/packages/webview/src/components/FileToolHeader.tsx
@@ -28,7 +28,18 @@ export const FileToolHeader: React.FC<FileToolHeaderProps> = ({
       </span>
       <span className="write-tool-label">{toolBlock.name || "Tool"}</span>
       {filePath && (
-        <span className="write-tool-path" onClick={onOpenFile}>
+        <span
+          className="write-tool-path"
+          role="button"
+          tabIndex={0}
+          onClick={onOpenFile}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              onOpenFile();
+            }
+          }}
+        >
           {filePath}
         </span>
       )}

--- a/packages/webview/src/components/MoreMenu.tsx
+++ b/packages/webview/src/components/MoreMenu.tsx
@@ -73,14 +73,36 @@ export const MoreMenu: React.FC<MoreMenuProps> = ({
     <div ref={menuRef} className="more-menu" data-testid="more-menu">
       <div
         className="more-menu-item"
+        role="menuitem"
+        tabIndex={0}
         onClick={handleSettings}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            handleSettings();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            onClose();
+          }
+        }}
         data-testid="more-menu-settings"
       >
         设置{hostLabel ? `（${hostLabel}）` : ""}
       </div>
       <div
         className="more-menu-item more-menu-item--between"
+        role="menuitem"
+        tabIndex={0}
         onClick={handleEnterprise}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            handleEnterprise();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            onClose();
+          }
+        }}
         data-testid="more-menu-enterprise"
       >
         <span>企业控制台</span>
@@ -89,7 +111,18 @@ export const MoreMenu: React.FC<MoreMenuProps> = ({
       {isAuthenticated ? (
         <div
           className="more-menu-item"
+          role="menuitem"
+          tabIndex={0}
           onClick={handleLogout}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              handleLogout();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              onClose();
+            }
+          }}
           data-testid="more-menu-logout"
         >
           退出登录{hostLabel ? `（${hostLabel}）` : ""}
@@ -97,7 +130,18 @@ export const MoreMenu: React.FC<MoreMenuProps> = ({
       ) : (
         <div
           className="more-menu-item"
+          role="menuitem"
+          tabIndex={0}
           onClick={handleLogin}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              handleLogin();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              onClose();
+            }
+          }}
           data-testid="more-menu-login"
         >
           登录{hostLabel ? `（${hostLabel}）` : ""}

--- a/packages/webview/src/components/PanelToggleMenu.tsx
+++ b/packages/webview/src/components/PanelToggleMenu.tsx
@@ -69,9 +69,23 @@ export const PanelToggleMenu: React.FC<PanelToggleMenuProps> = ({
             key={kind}
             className={`panel-toggle-menu-item${isDisabled ? " panel-toggle-menu-item--disabled" : ""}`}
             onClick={isDisabled ? undefined : () => onToggle(kind)}
+            onKeyDown={
+              isDisabled
+                ? undefined
+                : (e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      onToggle(kind);
+                    } else if (e.key === "Escape") {
+                      e.preventDefault();
+                      onClose();
+                    }
+                  }
+            }
             role="checkbox"
             aria-checked={isChecked}
             aria-disabled={isDisabled}
+            tabIndex={isDisabled ? -1 : 0}
             data-testid={`panel-toggle-item-${kind}`}
           >
             <i

--- a/packages/webview/src/components/SessionList.tsx
+++ b/packages/webview/src/components/SessionList.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import type { SessionMetadata } from "wave-agent-sdk";
 import { formatSessionLabel } from "../utils/session";
 
@@ -9,6 +9,9 @@ export interface SessionListProps {
   loading?: boolean;
   // When set, matching fragments of each session label are highlighted.
   highlightQuery?: string;
+  /** Keyboard selection index (roving tabindex); the item at this index gets
+   *  aria-selected + tabIndex 0. Managed by the popup's search input. */
+  selectedIndex?: number;
 }
 
 /**
@@ -57,7 +60,18 @@ export const SessionList: React.FC<SessionListProps> = ({
   onSessionSelect,
   loading = false,
   highlightQuery = "",
+  selectedIndex = 0,
 }) => {
+  const selectedItemRef = useRef<HTMLLIElement>(null);
+
+  // Keep the keyboard-selected item in view while moving with the arrows.
+  useEffect(() => {
+    const el = selectedItemRef.current;
+    if (el && typeof el.scrollIntoView === "function") {
+      el.scrollIntoView({ block: "nearest" });
+    }
+  }, [selectedIndex]);
+
   return (
     <div className="session-list-results">
       {loading ? (
@@ -68,12 +82,22 @@ export const SessionList: React.FC<SessionListProps> = ({
       ) : sessions.length === 0 ? (
         <div className="session-list-empty">未找到匹配的历史记录</div>
       ) : (
-        <ul className="session-list-items">
-          {sessions.map((session) => (
+        <ul className="session-list-items" role="listbox">
+          {sessions.map((session, i) => (
             <li
               key={session.id}
-              className={`session-list-item ${session.id === currentSession?.id ? "session-list-item--current" : ""}`}
+              ref={i === selectedIndex ? selectedItemRef : undefined}
+              className={`session-list-item ${session.id === currentSession?.id ? "session-list-item--current" : ""} ${i === selectedIndex ? "session-list-item--selected" : ""}`}
+              role="option"
+              aria-selected={i === selectedIndex}
+              tabIndex={i === selectedIndex ? 0 : -1}
               onClick={() => onSessionSelect(session.id)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onSessionSelect(session.id);
+                }
+              }}
               data-testid={`session-list-item-${session.id}`}
             >
               <div className="session-list-item-title">

--- a/packages/webview/src/components/SessionListPopup.tsx
+++ b/packages/webview/src/components/SessionListPopup.tsx
@@ -20,6 +20,8 @@ export const SessionListPopup: React.FC<SessionListPopupProps> = ({
   loading,
 }) => {
   const [query, setQuery] = useState("");
+  // Keyboard selection index into the filtered list; 0 = first item.
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const popupRef = useRef<HTMLDivElement>(null);
 
@@ -59,9 +61,31 @@ export const SessionListPopup: React.FC<SessionListPopupProps> = ({
     );
   }, [sessions, query]);
 
+  // A new query or session list resets the keyboard selection to the first
+  // match, and the index is clamped so Enter always picks a real item.
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query, sessions]);
+
   const handleSelect = (sessionId: string) => {
     onSessionSelect(sessionId);
     onClose();
+  };
+
+  const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (filteredSessions.length > 0) {
+        setSelectedIndex((i) => Math.min(i + 1, filteredSessions.length - 1));
+      }
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const session = filteredSessions[selectedIndex];
+      if (session) handleSelect(session.id);
+    }
   };
 
   return (
@@ -76,7 +100,11 @@ export const SessionListPopup: React.FC<SessionListPopupProps> = ({
         className="session-list-search"
         placeholder="搜索关键词"
         value={query}
-        onChange={(e) => setQuery(e.target.value)}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setSelectedIndex(0);
+        }}
+        onKeyDown={handleSearchKeyDown}
       />
       <div className="session-list-label">历史对话</div>
       <SessionList
@@ -85,6 +113,7 @@ export const SessionListPopup: React.FC<SessionListPopupProps> = ({
         onSessionSelect={handleSelect}
         loading={loading}
         highlightQuery={query}
+        selectedIndex={selectedIndex}
       />
     </div>
   );

--- a/packages/webview/src/styles/DesktopApp.css
+++ b/packages/webview/src/styles/DesktopApp.css
@@ -338,7 +338,8 @@
   color: var(--vscode-foreground);
 }
 
-.desktop-workdir-trigger:hover {
+.desktop-workdir-trigger:hover,
+.desktop-workdir-trigger:focus-visible {
   background: var(--vscode-list-hoverBackground);
 }
 
@@ -392,7 +393,8 @@
   color: var(--vscode-dropdown-foreground);
 }
 
-.desktop-workdir-menu-item:hover {
+.desktop-workdir-menu-item:hover,
+.desktop-workdir-menu-item:focus-visible {
   background: var(--vscode-list-hoverBackground);
 }
 
@@ -431,7 +433,8 @@
   flex-shrink: 0;
 }
 
-.desktop-workdir-menu-remove:hover {
+.desktop-workdir-menu-remove:hover,
+.desktop-workdir-menu-remove:focus-visible {
   opacity: 1;
 }
 
@@ -464,7 +467,8 @@
   color: var(--vscode-foreground);
 }
 
-.desktop-host-trigger:hover {
+.desktop-host-trigger:hover,
+.desktop-host-trigger:focus-visible {
   background: var(--vscode-list-hoverBackground);
 }
 
@@ -544,7 +548,8 @@
   color: var(--vscode-dropdown-foreground);
 }
 
-.desktop-remote-browser-crumb:hover {
+.desktop-remote-browser-crumb:hover,
+.desktop-remote-browser-crumb:focus-visible {
   background: var(--vscode-list-hoverBackground);
 }
 
@@ -615,7 +620,8 @@
   background: var(--vscode-button-background);
 }
 
-.desktop-remote-browser-retry:hover {
+.desktop-remote-browser-retry:hover,
+.desktop-remote-browser-retry:focus-visible {
   background: var(--vscode-button-hoverBackground);
 }
 
@@ -653,7 +659,8 @@
   background: var(--vscode-button-background);
 }
 
-.desktop-remote-browser-select:hover:not(:disabled) {
+.desktop-remote-browser-select:hover:not(:disabled),
+.desktop-remote-browser-select:focus-visible:not(:disabled) {
   background: var(--vscode-button-hoverBackground);
 }
 

--- a/packages/webview/src/styles/Message.css
+++ b/packages/webview/src/styles/Message.css
@@ -349,6 +349,12 @@
   line-height: 16px;
 }
 
+.write-tool-path:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: 1px;
+  border-radius: 2px;
+}
+
 .write-tool-stats {
   margin-top: 2px;
   font-size: 11px;

--- a/packages/webview/src/styles/MoreMenu.css
+++ b/packages/webview/src/styles/MoreMenu.css
@@ -27,7 +27,8 @@
   cursor: pointer;
 }
 
-.more-menu-item:hover {
+.more-menu-item:hover,
+.more-menu-item:focus-visible {
   background-color: var(--vscode-list-hoverBackground);
 }
 

--- a/packages/webview/src/styles/PanelToggleMenu.css
+++ b/packages/webview/src/styles/PanelToggleMenu.css
@@ -30,7 +30,8 @@
   cursor: pointer;
 }
 
-.panel-toggle-menu-item:hover {
+.panel-toggle-menu-item:hover,
+.panel-toggle-menu-item:focus-visible {
   background-color: var(--vscode-list-hoverBackground);
 }
 

--- a/packages/webview/src/styles/SessionListPopup.css
+++ b/packages/webview/src/styles/SessionListPopup.css
@@ -61,7 +61,9 @@
   gap: 2px;
 }
 
-.session-list-item:hover {
+.session-list-item:hover,
+.session-list-item:focus-visible,
+.session-list-item--selected {
   background-color: var(--vscode-list-hoverBackground);
 }
 

--- a/packages/webview/tests/webview/desktopSelectorsKeyboard.test.tsx
+++ b/packages/webview/tests/webview/desktopSelectorsKeyboard.test.tsx
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+import React from "react";
+import { DesktopApp } from "../../src/components/DesktopApp";
+import { createMockVscode, sendCommand } from "./test-utils";
+
+vi.mock("../../src/styles/DesktopApp.css", () => ({}));
+
+function renderDesktopApp() {
+  const vscode = createMockVscode();
+  const result = render(<DesktopApp vscode={vscode} />);
+  return { ...result, vscode };
+}
+
+/**
+ * Keyboard accessibility of the desktop new-session selectors (host, workdir,
+ * branch): triggers must be Tab-focusable, menu items activatable with
+ * Enter/Space, and Escape must close the menu and return focus to the trigger.
+ * Same pattern as the + / permission-mode dropdowns (plusMenuKeyboard.test.tsx).
+ */
+describe("desktop selector keyboard accessibility", () => {
+  it("host trigger opens the menu with Enter and host items are Tab-focusable", () => {
+    const { vscode } = renderDesktopApp();
+    sendCommand("desktopWorkdirState", {
+      host: "prod",
+      hosts: ["prod", "stage"],
+      recentWorkdirs: [],
+    });
+    vscode.postMessage.mockClear();
+
+    const trigger = screen.getByTestId("desktop-host");
+    expect(trigger).toHaveProperty("tabIndex", 0);
+
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "Enter" });
+    expect(screen.getByTestId("desktop-host-menu")).toBeInTheDocument();
+
+    const localItem = screen.getByTestId("desktop-host-local");
+    const sshItems = screen.getAllByTestId("desktop-host-item");
+    const addItem = screen.getByTestId("desktop-host-add-entry");
+    expect(localItem).toHaveProperty("tabIndex", 0);
+    expect(sshItems).toHaveLength(2);
+    expect(sshItems[0]).toHaveProperty("tabIndex", 0);
+    expect(addItem).toHaveProperty("tabIndex", 0);
+  });
+
+  it("selects a host item with Enter and returns focus to the trigger", () => {
+    const { vscode } = renderDesktopApp();
+    sendCommand("desktopWorkdirState", {
+      host: "prod",
+      hosts: ["prod", "stage"],
+      recentWorkdirs: [],
+    });
+    vscode.postMessage.mockClear();
+
+    fireEvent.click(screen.getByTestId("desktop-host"));
+    const sshItem = screen.getAllByTestId("desktop-host-item")[1];
+    sshItem.focus();
+    fireEvent.keyDown(sshItem, { key: "Enter" });
+
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "desktopSelectHost",
+      host: "stage",
+    });
+    expect(screen.queryByTestId("desktop-host-menu")).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(screen.getByTestId("desktop-host"));
+  });
+
+  it("selects the local host item with Space", () => {
+    const { vscode } = renderDesktopApp();
+    sendCommand("desktopWorkdirState", {
+      host: "prod",
+      hosts: ["prod"],
+      recentWorkdirs: [],
+    });
+    vscode.postMessage.mockClear();
+
+    fireEvent.click(screen.getByTestId("desktop-host"));
+    const localItem = screen.getByTestId("desktop-host-local");
+    localItem.focus();
+    fireEvent.keyDown(localItem, { key: " " });
+
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "desktopSelectHost",
+      host: "local",
+    });
+  });
+
+  it("closes the host menu with Escape and returns focus to the trigger", () => {
+    renderDesktopApp();
+    sendCommand("desktopWorkdirState", {
+      host: "prod",
+      hosts: ["prod"],
+      recentWorkdirs: [],
+    });
+
+    fireEvent.click(screen.getByTestId("desktop-host"));
+    const sshItem = screen.getAllByTestId("desktop-host-item")[0];
+    sshItem.focus();
+    fireEvent.keyDown(sshItem, { key: "Escape" });
+
+    expect(screen.queryByTestId("desktop-host-menu")).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(screen.getByTestId("desktop-host"));
+  });
+
+  it("opens the add-host input from the keyboard and submits with Enter", () => {
+    const { vscode } = renderDesktopApp();
+    sendCommand("desktopWorkdirState", {
+      host: "local",
+      hosts: [],
+      recentWorkdirs: [],
+    });
+    vscode.postMessage.mockClear();
+
+    fireEvent.click(screen.getByTestId("desktop-host"));
+    const addItem = screen.getByTestId("desktop-host-add-entry");
+    addItem.focus();
+    fireEvent.keyDown(addItem, { key: "Enter" });
+
+    const input = screen.getByPlaceholderText("ssh user@hostname -p port");
+    fireEvent.change(input, {
+      target: { value: "ssh user@example.com -p 2222" },
+    });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "desktopAddHost",
+      connectionString: "ssh user@example.com -p 2222",
+    });
+    expect(screen.queryByTestId("desktop-host-menu")).not.toBeInTheDocument();
+  });
+
+  it("workdir trigger opens the menu with Enter and recent items are Tab-focusable", () => {
+    const { vscode } = renderDesktopApp();
+    sendCommand("desktopWorkdirState", {
+      workdir: "/home/user/project",
+      recentWorkdirs: ["/home/user/project-a", "/home/user/project-b"],
+    });
+    vscode.postMessage.mockClear();
+
+    const trigger = screen.getByTestId("desktop-workdir");
+    expect(trigger).toHaveProperty("tabIndex", 0);
+
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "Enter" });
+    expect(screen.getByTestId("desktop-workdir-menu")).toBeInTheDocument();
+
+    const items = screen.getAllByTestId("desktop-workdir-recent-item");
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveProperty("tabIndex", 0);
+  });
+
+  it("selects a recent workdir with Enter and returns focus to the trigger", () => {
+    const { vscode } = renderDesktopApp();
+    sendCommand("desktopWorkdirState", {
+      workdir: "/home/user/project",
+      recentWorkdirs: ["/home/user/project-a"],
+    });
+    vscode.postMessage.mockClear();
+
+    fireEvent.click(screen.getByTestId("desktop-workdir"));
+    const item = screen.getByTestId("desktop-workdir-recent-item");
+    item.focus();
+    fireEvent.keyDown(item, { key: "Enter" });
+
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "desktopSelectRecentWorkdir",
+      path: "/home/user/project-a",
+      host: "local",
+    });
+    expect(
+      screen.queryByTestId("desktop-workdir-menu"),
+    ).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(screen.getByTestId("desktop-workdir"));
+  });
+
+  it("closes the workdir menu with Escape and returns focus to the trigger", () => {
+    renderDesktopApp();
+    sendCommand("desktopWorkdirState", {
+      workdir: "/home/user/project",
+      recentWorkdirs: ["/home/user/project-a"],
+    });
+
+    fireEvent.click(screen.getByTestId("desktop-workdir"));
+    const item = screen.getByTestId("desktop-workdir-recent-item");
+    item.focus();
+    fireEvent.keyDown(item, { key: "Escape" });
+
+    expect(
+      screen.queryByTestId("desktop-workdir-menu"),
+    ).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(screen.getByTestId("desktop-workdir"));
+  });
+
+  it("activates 浏览… with Enter and posts desktopSelectWorkdir", () => {
+    const { vscode } = renderDesktopApp();
+    sendCommand("desktopWorkdirState", { recentWorkdirs: [] });
+    vscode.postMessage.mockClear();
+
+    fireEvent.click(screen.getByTestId("desktop-workdir"));
+    const browse = screen.getByTestId("desktop-workdir-browse");
+    browse.focus();
+    fireEvent.keyDown(browse, { key: "Enter" });
+
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "desktopSelectWorkdir",
+    });
+    expect(
+      screen.queryByTestId("desktop-workdir-menu"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("branch trigger opens the menu with Enter and items are Tab-focusable", () => {
+    renderDesktopApp();
+    sendCommand("desktopWorkdirState", {
+      workdir: "/work/a",
+      recentWorkdirs: ["/work/a"],
+    });
+    sendCommand("desktopGitBranches", {
+      workdir: "/work/a",
+      result: { branches: ["main", "dev"], current: "main" },
+    });
+
+    const trigger = screen.getByTestId("desktop-branch-selector");
+    expect(trigger).toHaveProperty("tabIndex", 0);
+
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "Enter" });
+    expect(screen.getByTestId("desktop-branch-menu")).toBeInTheDocument();
+
+    const items = screen.getAllByTestId("desktop-branch-item");
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveProperty("tabIndex", 0);
+  });
+
+  it("selects a branch with Enter and returns focus to the trigger", () => {
+    renderDesktopApp();
+    sendCommand("desktopWorkdirState", {
+      workdir: "/work/a",
+      recentWorkdirs: ["/work/a"],
+    });
+    sendCommand("desktopGitBranches", {
+      workdir: "/work/a",
+      result: { branches: ["main", "dev"], current: "main" },
+    });
+
+    fireEvent.click(screen.getByTestId("desktop-branch-selector"));
+    const items = screen.getAllByTestId("desktop-branch-item");
+    items[1].focus();
+    fireEvent.keyDown(items[1], { key: "Enter" });
+
+    expect(screen.getByTestId("desktop-branch-selector")).toHaveTextContent(
+      "dev",
+    );
+    expect(screen.queryByTestId("desktop-branch-menu")).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(
+      screen.getByTestId("desktop-branch-selector"),
+    );
+  });
+
+  it("closes the branch menu with Escape and returns focus to the trigger", () => {
+    renderDesktopApp();
+    sendCommand("desktopWorkdirState", {
+      workdir: "/work/a",
+      recentWorkdirs: ["/work/a"],
+    });
+    sendCommand("desktopGitBranches", {
+      workdir: "/work/a",
+      result: { branches: ["main", "dev"], current: "main" },
+    });
+
+    fireEvent.click(screen.getByTestId("desktop-branch-selector"));
+    const items = screen.getAllByTestId("desktop-branch-item");
+    items[0].focus();
+    fireEvent.keyDown(items[0], { key: "Escape" });
+
+    expect(screen.queryByTestId("desktop-branch-menu")).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(
+      screen.getByTestId("desktop-branch-selector"),
+    );
+  });
+});

--- a/packages/webview/tests/webview/moreSelectorsKeyboard.test.tsx
+++ b/packages/webview/tests/webview/moreSelectorsKeyboard.test.tsx
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+import React from "react";
+import { DesktopApp } from "../../src/components/DesktopApp";
+import { ContextTag } from "../../src/components/ContextTag";
+import { FileToolHeader } from "../../src/components/FileToolHeader";
+import {
+  createMockVscode,
+  sendCommand,
+  sendHostMessage,
+  renderChatApp,
+} from "./test-utils";
+import { fixtures } from "wave-webview-fixtures";
+
+vi.mock("../../src/styles/DesktopApp.css", () => ({}));
+
+/**
+ * Keyboard accessibility of the remaining custom interactive elements:
+ * MoreMenu items, panel-toggle checkboxes, session-history list, context tags,
+ * and tool file paths. Same pattern as plusMenuKeyboard.test.tsx: Tab-focusable
+ * + Enter/Space activation, Escape closes menus.
+ */
+describe("remaining keyboard accessibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete window.waveHostType;
+  });
+
+  describe("MoreMenu", () => {
+    it("makes menu items Tab-focusable and activates 设置 with Enter", () => {
+      const { vscode } = renderChatApp();
+      fireEvent.click(screen.getByTestId("more-btn"));
+
+      const settings = screen.getByTestId("more-menu-settings");
+      expect(settings).toHaveProperty("tabIndex", 0);
+
+      settings.focus();
+      fireEvent.keyDown(settings, { key: "Enter" });
+
+      expect(vscode.postMessage).toHaveBeenCalledWith({
+        command: "getConfiguration",
+      });
+      expect(screen.queryByTestId("more-menu")).not.toBeInTheDocument();
+    });
+
+    it("activates the logout item with Space", () => {
+      const { vscode } = renderChatApp();
+      fireEvent.click(screen.getByTestId("more-btn"));
+
+      const logout = screen.getByTestId("more-menu-logout");
+      logout.focus();
+      fireEvent.keyDown(logout, { key: " " });
+
+      expect(vscode.postMessage).toHaveBeenCalledWith({ command: "logout" });
+    });
+
+    it("closes the menu with Escape", () => {
+      renderChatApp();
+      fireEvent.click(screen.getByTestId("more-btn"));
+
+      const enterprise = screen.getByTestId("more-menu-enterprise");
+      enterprise.focus();
+      fireEvent.keyDown(enterprise, { key: "Escape" });
+
+      expect(screen.queryByTestId("more-menu")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("PanelToggleMenu", () => {
+    const renderDesktop = () => {
+      const vscode = createMockVscode();
+      const view = render(<DesktopApp vscode={vscode} />);
+      sendHostMessage(
+        fixtures.desktopWorkdirState({
+          workdir: "/work/a",
+          recentWorkdirs: ["/work/a"],
+        }),
+      );
+      sendHostMessage(fixtures.authStatusResponse());
+      return { vscode, unmount: view.unmount };
+    };
+
+    it("makes items Tab-focusable and toggles a panel with Space", () => {
+      window.waveHostType = "desktop";
+      const { vscode } = renderDesktop();
+      vscode.postMessage.mockClear();
+
+      fireEvent.click(screen.getByTestId("panel-toggle-btn"));
+      const diffItem = screen.getByTestId("panel-toggle-item-diff");
+      expect(diffItem).toHaveProperty("tabIndex", 0);
+
+      diffItem.focus();
+      fireEvent.keyDown(diffItem, { key: " " });
+
+      expect(vscode.postMessage).toHaveBeenCalledWith({
+        command: "desktopGetWorkspaceDiff",
+      });
+      expect(diffItem).toHaveAttribute("aria-checked", "true");
+      // Multi-select menu stays open after toggling.
+      expect(screen.getByTestId("panel-toggle-menu")).toBeInTheDocument();
+    });
+
+    it("closes the panel menu with Escape", () => {
+      window.waveHostType = "desktop";
+      renderDesktop();
+
+      fireEvent.click(screen.getByTestId("panel-toggle-btn"));
+      const previewItem = screen.getByTestId("panel-toggle-item-preview");
+      previewItem.focus();
+      fireEvent.keyDown(previewItem, { key: "Escape" });
+
+      expect(screen.queryByTestId("panel-toggle-menu")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("SessionListPopup", () => {
+    const sessions = [
+      {
+        id: "session-1",
+        sessionType: "main",
+        workdir: "/test/project",
+        firstMessage: "First session hello",
+        lastActiveAt: new Date("2023-12-01T10:00:00Z"),
+        latestTotalTokens: 150,
+      },
+      {
+        id: "session-2",
+        sessionType: "main",
+        workdir: "/test/project",
+        firstMessage: "Second session world",
+        lastActiveAt: new Date("2023-12-02T10:00:00Z"),
+        latestTotalTokens: 200,
+      },
+    ];
+
+    const openPopup = () => {
+      sendCommand("updateSessions", { sessions });
+      fireEvent.click(screen.getByTestId("history-btn"));
+      return screen.getByTestId("session-list-popup");
+    };
+
+    it("moves the roving selection with arrows and restores the session with Enter", () => {
+      const { vscode } = renderChatApp();
+      openPopup();
+      vscode.postMessage.mockClear();
+
+      const search = screen.getByPlaceholderText("搜索关键词");
+      // First item selected by default; Enter restores it.
+      fireEvent.keyDown(search, { key: "Enter" });
+      expect(vscode.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "restoreSession",
+          sessionId: "session-1",
+        }),
+      );
+    });
+
+    it("ArrowDown moves selection to the next item", () => {
+      const { vscode } = renderChatApp();
+      openPopup();
+      vscode.postMessage.mockClear();
+
+      const search = screen.getByPlaceholderText("搜索关键词");
+      fireEvent.keyDown(search, { key: "ArrowDown" });
+
+      const secondItem = screen.getByTestId("session-list-item-session-2");
+      expect(secondItem).toHaveAttribute("aria-selected", "true");
+      expect(secondItem).toHaveProperty("tabIndex", 0);
+      const firstItem = screen.getByTestId("session-list-item-session-1");
+      expect(firstItem).toHaveProperty("tabIndex", -1);
+
+      fireEvent.keyDown(search, { key: "Enter" });
+      expect(vscode.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "restoreSession",
+          sessionId: "session-2",
+        }),
+      );
+    });
+
+    it("activates a session item with Enter directly", () => {
+      const { vscode } = renderChatApp();
+      openPopup();
+      vscode.postMessage.mockClear();
+
+      const secondItem = screen.getByTestId("session-list-item-session-2");
+      secondItem.focus();
+      fireEvent.keyDown(secondItem, { key: "Enter" });
+
+      expect(vscode.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "restoreSession",
+          sessionId: "session-2",
+        }),
+      );
+      expect(
+        screen.queryByTestId("session-list-popup"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("ContextTag", () => {
+    it("is Tab-focusable and opens the preview with Enter when clickable", () => {
+      const onPreview = vi.fn();
+      render(
+        <ContextTag
+          name="img.png"
+          path="/a/img.png"
+          isImage
+          onClick={onPreview}
+        />,
+      );
+
+      const tag = screen.getByRole("button");
+      expect(tag).toHaveProperty("tabIndex", 0);
+
+      tag.focus();
+      fireEvent.keyDown(tag, { key: "Enter" });
+      expect(onPreview).toHaveBeenCalledTimes(1);
+
+      fireEvent.keyDown(tag, { key: " " });
+      expect(onPreview).toHaveBeenCalledTimes(2);
+    });
+
+    it("stays out of the tab order when not clickable", () => {
+      render(<ContextTag name="file.ts" path="/a/file.ts" />);
+
+      const tag = screen.getByLabelText("/a/file.ts");
+      expect(tag).not.toHaveProperty("tabIndex", 0);
+      expect(tag.getAttribute("role")).toBeNull();
+    });
+  });
+
+  describe("FileToolHeader", () => {
+    it("makes the file path Tab-focusable and opens it with Enter/Space", () => {
+      const onOpenFile = vi.fn();
+      render(
+        <FileToolHeader
+          toolBlock={
+            {
+              id: "tool-1",
+              name: "read",
+              stage: "end",
+              success: true,
+            } as unknown as Parameters<typeof FileToolHeader>[0]["toolBlock"]
+          }
+          filePath="/home/user/project/src/foo.ts"
+          onOpenFile={onOpenFile}
+        />,
+      );
+
+      const pathEl = document.querySelector(".write-tool-path") as HTMLElement;
+      expect(pathEl).toHaveProperty("tabIndex", 0);
+
+      pathEl.focus();
+      fireEvent.keyDown(pathEl, { key: "Enter" });
+      expect(onOpenFile).toHaveBeenCalledTimes(1);
+
+      fireEvent.keyDown(pathEl, { key: " " });
+      expect(onOpenFile).toHaveBeenCalledTimes(2);
+    });
+  });
+});


### PR DESCRIPTION
## 概述

延续 PR #1920（+ 菜单/权限菜单）的键盘可达性模式，为桌面端三个新会话选择器及其余 5 个自绘可点击元素补齐 Tab 聚焦与键盘操作。

## 改动

**桌面选择器（new-session 状态）**
- host 选择器：trigger Tab 聚焦（Enter/Space 开合、Escape 关闭）；本地/SSH 主机/添加主机… 菜单项 Enter/Space 激活 + Escape 还焦
- 目录选择器：trigger + 最近打开项 + 浏览… 同模式；远程目录浏览器面包屑 Tab 可聚焦；filter 输入框 Escape 还焦；最近项移除按钮键盘事件不冒泡到选中
- 分支选择器：trigger + 分支项同模式（分支获取中时 trigger 禁用）

**其余组件**
- MoreMenu：菜单项 role=menuitem + Tab + Enter/Space + Escape
- PanelToggleMenu：开关项 Tab + Enter/Space 切换（多选不关菜单）、disabled 项不进 Tab
- SessionListPopup：搜索框方向键 + Enter 选择，列表项 roving tabindex + aria-selected + 选中滚入视野
- ContextTag：可点击 @ 标签 role=button + Enter/Space（不可点击不进 Tab）
- FileToolHeader：工具文件路径 role=button + Enter/Space

CSS 统一补 :focus-visible（与 hover 同样式；文件路径用 focusBorder outline）。

## 验证

- 新增 23 个 jsdom 键盘测试（desktopSelectorsKeyboard + moreSelectorsKeyboard）
- webview 全量 737/737 通过
- type-check、lint 0 错