### PR TITLE
fix(webview): 裸 URL 后跟中文标点时链接目标剥离标点

### DIFF
--- a/packages/webview/src/components/Message.tsx
+++ b/packages/webview/src/components/Message.tsx
@@ -50,6 +50,72 @@ marked.use({
   },
 });
 
+// 剥离裸 URL 尾部的中文标点。marked 默认 url tokenizer 的 _backpedal 正则只
+// 剔除 ASCII 标点（?!.,:;*_'"~()&），中文标点（。、（ 等）会被百分号编码进
+// href，点击打开错误链接（如 "https://example.com。" → href 带 %E3%80%82）。
+// 标点集合对齐 extractClickableUrl；成对中文括号（如 "（帮助文档）"）整体
+// 剥离，孤立的开括号（如 "（"）也剥掉。
+const stripTrailingCjkPunct = (url: string): string => {
+  const closingPairs: Record<string, string> = {
+    "）": "（",
+    "」": "「",
+    "』": "『",
+    "】": "【",
+  };
+  const plainPunct = "，。、；：！？…";
+  let s = url;
+  for (;;) {
+    const last = s[s.length - 1];
+    if (!last) break;
+    if (plainPunct.includes(last)) {
+      s = s.slice(0, -1);
+      continue;
+    }
+    const open = closingPairs[last];
+    if (open) {
+      const openIdx = s.lastIndexOf(open);
+      if (openIdx >= 0) {
+        s = s.slice(0, openIdx); // 成对中文括号（注释/说明）整体剥离
+        continue;
+      }
+      s = s.slice(0, -1);
+      continue;
+    }
+    if (Object.values(closingPairs).includes(last)) {
+      s = s.slice(0, -1); // 孤立中文开括号
+      continue;
+    }
+    break;
+  }
+  return s;
+};
+
+// 在默认 url tokenizer 之上剥离尾部中文标点；返回 false 时 marked.use 会
+// 回退到默认实现（url tokenizer 被 marked.use 包装，实例共享默认 rules）。
+const baseUrlTokenizer = new marked.Tokenizer();
+
+marked.use({
+  tokenizer: {
+    url(src: string) {
+      const token = baseUrlTokenizer.url.call(this, src);
+      if (!token) return false;
+      const raw = stripTrailingCjkPunct(token.raw);
+      if (raw === token.raw) return token;
+      // href 可能是 raw 加前缀的形式（www. → "http://" + raw）；token.text
+      // 是 raw 的转义形式（默认实现 escape(cap[0])），中文标点在转义中
+      // 保持不变，同样剥离即可。
+      const prefix = token.href.endsWith(token.raw)
+        ? token.href.slice(0, -token.raw.length)
+        : "";
+      token.raw = raw;
+      token.href = prefix + raw;
+      token.text = stripTrailingCjkPunct(token.text);
+      token.tokens = [{ type: "text", raw: token.text, text: token.text }];
+      return token;
+    },
+  },
+});
+
 // 行内代码（反引号）中的裸 http(s) URL 提升为可点击链接：仅当剥离首尾
 // 常见标点后整个内容是一个无空白的 URL 时才提升；多 URL、markdown 链接
 // 语法原文、非 http(s) 协议一律保持代码原文（见 specs/ui/markdown-links.md）。

--- a/packages/webview/tests/webview/markdownInlineLink.test.tsx
+++ b/packages/webview/tests/webview/markdownInlineLink.test.tsx
@@ -88,3 +88,55 @@ describe("inline-code link elevation (specs/ui/markdown-links.md)", () => {
     );
   });
 });
+
+describe("bare URL with trailing CJK punctuation (marked GFM autolink)", () => {
+  it("strips a trailing Chinese period from the link target", () => {
+    const { container } = renderAssistantMessage("访问 https://example.com。");
+    const link = container.querySelector(".markdown-content a");
+    expect(link?.getAttribute("href")).toBe("https://example.com");
+    expect(link?.textContent).toBe("https://example.com");
+  });
+
+  it("strips a trailing pair of Chinese brackets as a whole", () => {
+    const { container } = renderAssistantMessage(
+      "详见 https://example.com（帮助文档）。",
+    );
+    const link = container.querySelector(".markdown-content a");
+    expect(link?.getAttribute("href")).toBe("https://example.com");
+    expect(link?.textContent).toBe("https://example.com");
+    expect(container.querySelector(".markdown-content")?.textContent).toContain(
+      "（帮助文档）。",
+    );
+  });
+
+  it("strips a lone trailing Chinese opening bracket", () => {
+    const { container } = renderAssistantMessage("链接 https://example.com（");
+    const link = container.querySelector(".markdown-content a");
+    expect(link?.getAttribute("href")).toBe("https://example.com");
+  });
+
+  it("keeps ASCII punctuation behavior unchanged (trailing period is stripped)", () => {
+    const { container } = renderAssistantMessage("访问 https://example.com.");
+    const link = container.querySelector(".markdown-content a");
+    expect(link?.getAttribute("href")).toBe("https://example.com");
+  });
+
+  it("does not strip legitimate URL characters (underscore, fragment, ASCII parens)", () => {
+    const { container } = renderAssistantMessage(
+      "示例 https://example.com/a_b#frag 与 https://example.com/foo(bar)",
+    );
+    const links = container.querySelectorAll(".markdown-content a");
+    expect(links[0]?.getAttribute("href")).toBe("https://example.com/a_b#frag");
+    expect(links[1]?.getAttribute("href")).toBe("https://example.com/foo(bar)");
+  });
+
+  it("keeps Chinese text inside a query string (not trailing punctuation)", () => {
+    const { container } = renderAssistantMessage(
+      "搜索 https://example.com/search?q=你好",
+    );
+    const link = container.querySelector(".markdown-content a");
+    expect(link?.getAttribute("href")).toBe(
+      "https://example.com/search?q=%E4%BD%A0%E5%A5%BD",
+    );
+  });
+});


### PR DESCRIPTION
## 问题

marked 9 的 GFM 裸 URL autolink 尾部标点剔除正则 `_backpedal` 只含 ASCII 标点，中文标点（`。`、`（` 等）会被百分号编码进 href，点击打开错误链接：

- `https://example.com。` → href 变 `https://example.com%E3%80%82`
- `https://example.com（帮助文档）` → href 含 `%EF%BC%88...`

## 修复

在默认 `url` tokenizer 之上剥离裸 URL 尾部中文标点（Message.tsx）：

- 普通中文标点 `，。、；：！？…` 逐个剥离
- 成对中文括号整体剥离（如 `（帮助文档）`）
- 孤立中文开括号（`（`）也剥掉
- ASCII 行为不变：`_`、`#frag`、`foo(bar)`、`?q=你好` 等 URL 合法内容不误伤

行为与 GitHub 的 cmark-gfm 对齐（只剔 Unicode 标点，不剥尾随中文文本）。

## 验证

- 新增 6 个测试用例，`markdownInlineLink.test.tsx` 13/13 通过
- webview 全量 743/743 通过
- type-check、lint 通过