### PR TITLE
fix(jetbrains): 移除 PluginManagerCore.getPlugin Internal API，改读自身 plugin.xml 的 <version>

### DIFF
--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
@@ -1,8 +1,6 @@
 package com.wave.jetbrains.session
 
-import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.wave.jetbrains.WaveBackendService
 import com.wave.jetbrains.config.WavePluginService
@@ -677,8 +675,24 @@ class MessageHandler(
     private fun currentWorkdir(): String =
         session.agent?.sessionCwd ?: session.agent?.workingDirectory ?: project.basePath ?: System.getProperty("user.dir")
 
-    private fun pluginVersion(): String =
-        PluginManagerCore.getPlugin(PluginId.findId("com.wave.jetbrains"))?.version ?: ""
+    private fun pluginVersion(): String {
+        // Read the <version> tag from our own META-INF/plugin.xml: the IntelliJ
+        // Platform Gradle Plugin injects the build version there at package time,
+        // so this avoids the platform's plugin-descriptor APIs (which became
+        // @ApiStatus.Internal in 2026.2).
+        val url = javaClass.classLoader.getResource("META-INF/plugin.xml") ?: return ""
+        return try {
+            url.openStream().use { stream ->
+                stream.bufferedReader().useLines { lines ->
+                    lines.firstOrNull { it.trimStart().startsWith("<version>") }
+                        ?.substringAfter("<version>")?.substringBefore("</version>")?.trim() ?: ""
+                }
+            }
+        } catch (e: Exception) {
+            LOG.warn("Failed to read plugin version: ${e.message}")
+            ""
+        }
+    }
 
     /** Decode webview file payload → bytes. data may be a base64/data-url string (best effort). */
     private fun decodeFileData(data: JsonElement?): ByteArray {

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
@@ -1,8 +1,6 @@
 package com.wave.jetbrains.session
 
-import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.wave.jetbrains.WaveBackendService
 import com.wave.jetbrains.config.WavePluginService
@@ -543,9 +541,6 @@ class WaveSession(
     }
 
     companion object {
-        fun pluginVersion(): String =
-            PluginManagerCore.getPlugin(PluginId.findId("com.wave.jetbrains"))?.version ?: ""
-
         fun parseHeaders(text: String): JsonObject? {
             if (text.isBlank()) return null
             return try {


### PR DESCRIPTION
2026.2.2 EAP 校验把 PluginManagerCore.getPlugin(PluginId) 标为 @ApiStatus.Internal（2 处），
marketplace 验证报告报 Internal API usage。改为运行时读 classpath META-INF/plugin.xml 的
<version>（IntelliJ Platform Gradle Plugin 打包时注入），零 platform API 依赖。
WaveSession.companion.pluginVersion() 无调用点，删除。
