### PR TITLE
fix(agent-sdk): align ExitPlanMode rejection feedback with Claude Code

### DIFF
--- a/packages/agent-sdk/src/tools/exitPlanMode.ts
+++ b/packages/agent-sdk/src/tools/exitPlanMode.ts
@@ -4,6 +4,14 @@ import type { ToolPlugin, ToolResult, ToolContext } from "./types.js";
 import { EXIT_PLAN_MODE_TOOL_NAME } from "../constants/tools.js";
 import { OPERATION_CANCELLED_BY_USER } from "../types/permissions.js";
 
+// Rejection feedback format aligned with Claude Code (messages.ts):
+// the model reads the fixed prefix + the user's verbatim feedback, without
+// any additional prompt injection.
+const REJECT_MESSAGE =
+  "The user doesn't want to proceed with this tool use. The tool use was rejected (eg. if it was a file edit, the new_string was NOT written to the file). STOP what you are doing and wait for the user to tell you how to proceed.";
+const REJECT_MESSAGE_WITH_REASON_PREFIX =
+  "The user doesn't want to proceed with this tool use. The tool use was rejected (eg. if it was a file edit, the new_string was NOT written to the file). To tell you how to proceed, the user said:\n";
+
 /**
  * Exit Plan Mode Tool Plugin
  */
@@ -110,10 +118,13 @@ Ensure your plan is complete and unambiguous:
             content: OPERATION_CANCELLED_BY_USER,
           };
         }
+        const feedback = permissionResult.message?.trim();
         return {
           success: false,
-          content: `Please update your proposal based on the following user feedback: ${permissionResult.message || "Plan rejected by user"}`,
-          error: permissionResult.message ? undefined : "Plan rejected by user",
+          content: feedback
+            ? `${REJECT_MESSAGE_WITH_REASON_PREFIX}${feedback}`
+            : REJECT_MESSAGE,
+          error: feedback ? undefined : "Plan rejected by user",
         };
       }
 

--- a/packages/agent-sdk/tests/agent/exitPlanMode.integration.test.ts
+++ b/packages/agent-sdk/tests/agent/exitPlanMode.integration.test.ts
@@ -204,7 +204,7 @@ describe("ExitPlanMode Integration", () => {
 
     expect(result.success).toBe(false);
     expect(result.content).toBe(
-      `Please update your proposal based on the following user feedback: ${feedback}`,
+      `The user doesn't want to proceed with this tool use. The tool use was rejected (eg. if it was a file edit, the new_string was NOT written to the file). To tell you how to proceed, the user said:\n${feedback}`,
     );
     expect(agent.getPermissionMode()).toBe("plan");
   });

--- a/packages/agent-sdk/tests/tools/exitPlanMode.test.ts
+++ b/packages/agent-sdk/tests/tools/exitPlanMode.test.ts
@@ -144,7 +144,31 @@ describe("exitPlanModeTool", () => {
 
     expect(result.success).toBe(false);
     expect(result.content).toBe(
-      `Please update your proposal based on the following user feedback: ${feedback}`,
+      `The user doesn't want to proceed with this tool use. The tool use was rejected (eg. if it was a file edit, the new_string was NOT written to the file). To tell you how to proceed, the user said:\n${feedback}`,
+    );
+    expect(result.error).toBeUndefined();
+  });
+
+  it("should trim whitespace from rejection feedback", async () => {
+    const feedback = "  Needs more work  ";
+    vi.mocked(mockPermissionManager.getPlanFilePath).mockReturnValue(
+      "/test/plan.md",
+    );
+    vi.mocked(readFile).mockResolvedValue("My awesome plan");
+    vi.mocked(mockPermissionManager.createContext).mockReturnValue({
+      toolName: "ExitPlanMode",
+      permissionMode: "plan",
+    });
+    vi.mocked(mockPermissionManager.checkPermission).mockResolvedValue({
+      behavior: "deny",
+      message: feedback,
+    });
+
+    const result = await exitPlanModeTool.execute({}, mockContext);
+
+    expect(result.success).toBe(false);
+    expect(result.content).toBe(
+      `The user doesn't want to proceed with this tool use. The tool use was rejected (eg. if it was a file edit, the new_string was NOT written to the file). To tell you how to proceed, the user said:\nNeeds more work`,
     );
     expect(result.error).toBeUndefined();
   });
@@ -166,7 +190,7 @@ describe("exitPlanModeTool", () => {
 
     expect(result.success).toBe(false);
     expect(result.content).toBe(
-      "Please update your proposal based on the following user feedback: Plan rejected by user",
+      "The user doesn't want to proceed with this tool use. The tool use was rejected (eg. if it was a file edit, the new_string was NOT written to the file). STOP what you are doing and wait for the user to tell you how to proceed.",
     );
     expect(result.error).toBe("Plan rejected by user");
   });


### PR DESCRIPTION
## 背景
对齐 Claude Code 的 ExitPlanMode 拒绝路径反馈传递方式。CC 的『No, keep planning』+ 反馈 → tool_result 内容 = 固定前缀 + 用户反馈原文（is_error: true），模型直接读原文，无额外提示词注入。

## 改动
- `exitPlanMode.ts`：拒绝反馈文案改为 CC 风格
  - 有反馈：`REJECT_MESSAGE_WITH_REASON_PREFIX + 反馈原文`（反馈经 trim）
  - 无反馈：CC 的 `REJECT_MESSAGE` 全文兜底，`error: "Plan rejected by user"` 保留（Wave 特有 UI 展示字段）
  - `OPERATION_CANCELLED_BY_USER` 取消分支不变
- **不加 is_error**：Wave 保持 OpenAI tool 格式（`role: "tool"`），is_error 是 Anthropic 专有字段、对兼容 API 有 strict-schema 风险；`success: false` + 固定前缀已传达拒绝语义
- trim 统一在 SDK 侧做（一处覆盖 CLI/webview/JB/desktop 全部来源；CLI 已 trim 不受影响，webview 未 trim 反馈被统一）

## 测试
- `exitPlanMode.test.ts`：更新 2 处断言 + 新增 trim 用例，11/11 通过
- `exitPlanMode.integration.test.ts`：更新 1 处断言，4/4 通过
- type-check + lint 全绿