### PR TITLE
fix(webview): 重启安装 toast 点击后原地切换加载态，消除退出前空窗期

### DIFF
--- a/docs/specs/ui/desktop-app.md
+++ b/docs/specs/ui/desktop-app.md
@@ -299,6 +299,7 @@ desktop 还支持**并排多对话**：`Cmd/Ctrl+Click` 或拖拽侧边栏中的
 7. **假设**已登录企业版且 codechat 端点返回更新信息，**当**updateChecker 构造下载地址，**则** downloadUrl 必须指向真实下载入口（安装包 / 下载页），不得指向 manifest.json 自身（修复 updateChecker.ts:99）。
 8. **假设**macOS 上应用运行于不可写位置（如非 /Applications），**当**更新下载完成但无法原地安装，**则**必须通过应用内 toast 提示用户手动下载安装（带「打开下载页」按钮）并给出下载 URL，不得静默失败。
 9. **假设**构建安装包（mac/win），**当**electron-builder 打包完成，**则**产物 `resources/app-update.yml` 必须存在（afterPack 写入 `updaterCacheDirName`）——electron-updater 下载前会读取该文件（`configOnDisk`），缺失时下载阶段抛 ENOENT 并降级为下载页提示（修复：构建未声明 publish 配置时 electron-builder 不生成该文件）。
+10. **假设**用户点击「重启安装」按钮，**当**应用正在退出以安装新版本（Windows 上退出前耗时数秒），**则**原 toast 必须立即原地切换为「正在重启应用以完成安装…」的加载状态（带 loading 指示、无操作按钮），直至应用退出，点击与退出之间的空窗期不得表现为无任何反馈。
 
 ---
 

--- a/packages/webview-fixtures/src/types.ts
+++ b/packages/webview-fixtures/src/types.ts
@@ -353,6 +353,9 @@ export interface UpdateToast {
   message: string;
   actionLabel?: string;
   action?: ToastAction;
+  /** The toast's action is being performed — render a loading state instead of
+   *  the action button (e.g. quit-and-install waiting for the app to exit). */
+  loading?: boolean;
 }
 
 export interface ShowToastMessage extends HostToWebviewMessageBase {

--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -1063,7 +1063,20 @@ export const ChatApp: React.FC<ChatAppProps> = ({ vscode, host, paneId }) => {
         toastId: toast.id,
         action: toast.action,
       });
-      setToasts((prev) => prev.filter((t) => t.id !== toast.id));
+      if (toast.action.type === "quitAndInstall") {
+        // Windows 上 quitAndInstall 要等应用完全退出才启动安装器（数秒）——
+        // 原地把 toast 切成 loading 态，避免退出前的空窗期无反馈（spec「桌面端
+        // 自动更新」场景 10）。loading toast 保留 action 字段，不会自动关闭。
+        setToasts((prev) =>
+          prev.map((t) =>
+            t.id === toast.id
+              ? { ...t, loading: true, message: "正在重启应用以完成安装…" }
+              : t,
+          ),
+        );
+      } else {
+        setToasts((prev) => prev.filter((t) => t.id !== toast.id));
+      }
     },
     [postToHost],
   );

--- a/packages/webview/src/components/ToastStack.tsx
+++ b/packages/webview/src/components/ToastStack.tsx
@@ -27,8 +27,9 @@ const Toast: React.FC<{
 
   return (
     <div className="toast" role="status" data-testid="toast">
+      {toast.loading && <span className="toast-spinner" aria-hidden="true" />}
       <span className="toast-message">{toast.message}</span>
-      {toast.actionLabel && toast.action && (
+      {toast.actionLabel && toast.action && !toast.loading && (
         <button className="toast-action" onClick={() => onAction(toast)}>
           {toast.actionLabel}
         </button>

--- a/packages/webview/src/styles/ToastStack.css
+++ b/packages/webview/src/styles/ToastStack.css
@@ -45,6 +45,24 @@
   word-break: break-word;
 }
 
+/* Loading indicator shown while the toast's action is being performed
+ * (e.g. quit-and-install waiting for the app to exit). */
+.toast-spinner {
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--vscode-notifications-foreground, #cccccc);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: toast-spin 0.8s linear infinite;
+}
+
+@keyframes toast-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .toast-action {
   flex-shrink: 0;
   padding: 3px 10px;

--- a/packages/webview/src/types/index.ts
+++ b/packages/webview/src/types/index.ts
@@ -345,6 +345,9 @@ export interface UpdateToast {
   message: string;
   actionLabel?: string;
   action?: ToastAction;
+  /** The toast's action is being performed — render a loading state instead of
+   *  the action button (e.g. quit-and-install waiting for the app to exit). */
+  loading?: boolean;
 }
 
 // Pushed by the desktop main process in response to `desktopReady` and after

--- a/packages/webview/tests/webview/chatAppToast.test.tsx
+++ b/packages/webview/tests/webview/chatAppToast.test.tsx
@@ -33,10 +33,11 @@ describe("ChatApp showToast integration", () => {
       toastId: "t1",
       action: { type: "quitAndInstall" },
     });
-    // The toast is removed once acted upon.
-    expect(
-      screen.queryByText("新版本 v0.20.0 已下载完成，重启应用以完成安装。"),
-    ).not.toBeInTheDocument();
+    // quitAndInstall waits for the app to exit (seconds on Windows) — the toast
+    // stays up as a loading state instead of vanishing (spec scenario 10).
+    expect(screen.getByText("正在重启应用以完成安装…")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "重启安装" })).toBeNull();
+    expect(document.querySelector(".toast-spinner")).not.toBeNull();
   });
 
   it("dismisses a toast via its close button without echoing an action", () => {

--- a/packages/webview/tests/webview/toastStack.test.tsx
+++ b/packages/webview/tests/webview/toastStack.test.tsx
@@ -50,6 +50,47 @@ describe("ToastStack", () => {
     expect(screen.queryByRole("button", { name: "重启安装" })).toBeNull();
   });
 
+  it("renders a loading state (spinner, no action button) while the action is in flight", () => {
+    render(
+      <ToastStack
+        toasts={[
+          toast({
+            loading: true,
+            message: "正在重启应用以完成安装…",
+            actionLabel: "重启安装",
+            action: { type: "quitAndInstall" },
+          }),
+        ]}
+        onDismiss={vi.fn()}
+        onAction={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("正在重启应用以完成安装…")).toBeInTheDocument();
+    expect(document.querySelector(".toast-spinner")).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "重启安装" })).toBeNull();
+    expect(screen.getByRole("button", { name: "关闭" })).toBeInTheDocument();
+  });
+
+  it("does not auto-dismiss a loading toast (the action is still in flight)", () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+    render(
+      <ToastStack
+        toasts={[
+          toast({
+            loading: true,
+            actionLabel: "重启安装",
+            action: { type: "quitAndInstall" },
+          }),
+        ]}
+        onDismiss={onDismiss}
+        onAction={vi.fn()}
+      />,
+    );
+    vi.advanceTimersByTime(60000);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
   it("stacks multiple toasts vertically", () => {
     render(
       <ToastStack


### PR DESCRIPTION
## 背景

Windows 上点击更新 toast 的「重启安装」后，quitAndInstall 需等应用完全退出才启动安装器（耗时数秒），而此前 webview 点击按钮的瞬间就移除了 toast——等待期无任何反馈，用户容易以为卡住了。

## 改动

- spec「桌面端自动更新」新增验收场景 10（docs/specs/ui/desktop-app.md）
- `UpdateToast` 新增可选 `loading` 字段（webview-fixtures + webview types 同步）
- ChatApp `handleToastAction`：`quitAndInstall` 点击后不再移除 toast，原地切换为 loading 态（文案「正在重启应用以完成安装…」）；其余类型（打开下载页/聚焦会话）保持点击即消失
- ToastStack 渲染 loading 态：旋转 spinner + 隐藏操作按钮；保留 action 字段故不触发 8s 自动关闭，常驻到应用退出

主进程零改动。行为反馈即时，不依赖主进程 IPC 往返。

## 验证

- webview 单测 745/745（含更新后的集成断言 + 2 条新增 loading 渲染/不自动关闭测试）
- desktopHost 269/269、全仓 type-check、lint 全过