### PR TITLE
feat(agent-sdk): 只读命令访问安全区域外路径时提示权限确认（对齐 Claude Code）

### DIFF
--- a/docs/specs/core/tool-permission-system.md
+++ b/docs/specs/core/tool-permission-system.md
@@ -78,7 +78,7 @@ order: 130
 
 ### 用户故事：内置安全命令与只读命令自动放行（优先级：P2）
 
-作为用户，我希望常见的只读命令（如 `cat`、`sed`、`grep`、`awk`、`jq`、`find`）默认自动允许执行而无需逐次确认，以便代理在探查代码库时不被频繁打断；但能改写文件系统或执行任意命令的变体（如 `sed -i`、`find -delete`、写重定向、命令替换）仍须提示确认。`cd` 应限制在当前工作目录内。
+作为用户，我希望常见的只读命令（如 `cat`、`sed`、`grep`、`awk`、`jq`、`find`）默认自动允许执行而无需逐次确认，以便代理在探查代码库时不被频繁打断；但能改写文件系统或执行任意命令的变体（如 `sed -i`、`find -delete`、写重定向、命令替换）仍须提示确认。只读命令（含 `cd`、`ls`、`cat`、`grep` 等）访问安全区域（工作目录 + 附加目录）之外的路径时须提示确认（对齐 Claude Code 的路径范围检查）；路径在安全区域内、或命令不访问任何文件系统路径时自动允许。
 
 **验收场景**：
 
@@ -93,6 +93,12 @@ order: 130
 9. **假设**链式命令 `sed -n '1,10p' a.txt | grep foo`，**当** 执行时，**则** 系统应该自动允许（每段均为只读）。
 10. **假设**任何 git 仓库，**当**用户执行 `git -C /path/to/repo status`、`git -C /path/to/repo diff --stat` 或 `git -C /path/to/repo log --oneline` 时，**则** 系统应该自动允许（`git` 的全局作用域选项如 `-C <path>`、`-c <key>=<value>`、`--git-dir <path>` 只改变目标仓库或配置，不改变子命令的只读属性；匹配 `Bash(git status*)` 等规则时忽略这些前缀）。
 11. **假设**任何目录，**当**用户执行 `git -C /path/to/repo commit -m "msg"`、`git -C /path/to/repo push` 或 `git -C /path/to/repo branch -D feature` 时，**则** 系统不得自动允许，必须提示权限确认。
+12. **假设** CWD 是 `/home/user/project`，**当**用户执行 `ls src` 时，**则**系统应该自动允许（相对路径解析后在工作目录内）。
+13. **假设** CWD 是 `/home/user/project`，**当**用户执行 `ls /etc` 时，**则**系统不得自动允许，必须提示权限确认（只读命令访问工作目录外路径）。
+14. **假设** CWD 是 `/home/user/project`，**当**用户执行 `cat /etc/passwd` 或 `grep root /etc/passwd` 时，**则**系统不得自动允许，必须提示权限确认（只读命令访问工作目录外路径，与 `ls` 一致）。
+15. **假设** CWD 是 `/home/user/project`，**当**用户执行 `cat ../secret.txt` 时，**则**系统不得自动允许（`..` 解析到真实路径后在工作目录外）。
+16. **假设** `permissions.additionalDirectories` 包含 `/data/exports`，**当**用户执行 `ls /data/exports` 时，**则**系统应该自动允许（路径在附加目录内，属于安全区域）。
+17. **假设** CWD 是 `/home/user/project`，**当**用户执行 `pwd` 或 `echo hello` 时，**则**系统应该自动允许（不访问文件系统路径，无路径范围可检查）。
 
 ### 用户故事：MCP 工具权限（优先级：P1）
 

--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -1104,31 +1104,14 @@ export class PermissionManager {
         const commandMatch = processedPart.match(/^(\w+)(\s+.*)?$/);
         if (commandMatch) {
           const cmd = commandMatch[1];
-          const args = commandMatch[2]?.trim() || "";
 
           if (
             DANGEROUS_COMMANDS.includes(cmd) ||
             isDangerousFind(part) ||
-            hasSedInPlace(part)
+            hasSedInPlace(part) ||
+            this.isOutOfSafeZonePart(part, workdir)
           ) {
             continue;
-          }
-
-          if (cmd === "cd") {
-            const pathArgs =
-              (args.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || []).filter(
-                (arg) => !arg.startsWith("-"),
-              ) || [];
-
-            const isOutOfBounds = pathArgs.some((pathArg) => {
-              const cleanPath = pathArg.replace(/^['"](.*)['"]$/, "$1");
-              const { isInside } = this.isInsideSafeZone(cleanPath, workdir);
-              return !isInside;
-            });
-
-            if (isOutOfBounds) {
-              continue;
-            }
           }
         }
 

--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -29,6 +29,8 @@ import {
   stripGitScopePrefix,
   DANGEROUS_COMMANDS,
   READ_ONLY_COMMANDS,
+  PATH_COMMANDS,
+  extractPathArgs,
 } from "../utils/bashParser.js";
 import { isPathInside } from "../utils/pathSafety.js";
 import { toWindowsPath } from "../utils/path.js";
@@ -825,26 +827,14 @@ export class PermissionManager {
         const commandMatch = processedPart.match(/^(\w+)(\s+.*)?$/);
         if (commandMatch) {
           const cmd = commandMatch[1];
-          const args = commandMatch[2]?.trim() || "";
 
           // Check blacklist
           if (DANGEROUS_COMMANDS.includes(cmd)) {
             return true;
           }
 
-          // Check out-of-bounds for cd
-          if (cmd === "cd") {
-            const pathArgs =
-              (args.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || []).filter(
-                (arg) => !arg.startsWith("-"),
-              ) || [];
-
-            return pathArgs.some((pathArg) => {
-              const cleanPath = pathArg.replace(/^['"](.*)['"]$/, "$1");
-              const { isInside } = this.isInsideSafeZone(cleanPath, workdir);
-              return !isInside;
-            });
-          }
+          // Check out-of-bounds for cd and path-taking read-only commands
+          return this.isOutOfSafeZonePart(part, workdir);
         }
         return false;
       });
@@ -969,6 +959,22 @@ export class PermissionManager {
     if (READ_ONLY_COMMANDS.includes(cmd)) {
       // find with dangerous flags (e.g. -exec, -delete) disqualifies
       if (cmd === "find" && isDangerousFind(part)) return false;
+      // Path-taking read-only commands must stay within the Safe Zone:
+      // accessing a path outside workdir / additional directories
+      // disqualifies (aligned with Claude Code's path constraints)
+      if (PATH_COMMANDS.includes(cmd)) {
+        const pathArgs = extractPathArgs(args);
+        if (pathArgs.length > 0) {
+          if (!workdir) return false;
+          if (
+            !pathArgs.every(
+              (pathArg) => this.isInsideSafeZone(pathArg, workdir).isInside,
+            )
+          ) {
+            return false;
+          }
+        }
+      }
       return true;
     }
 
@@ -988,6 +994,26 @@ export class PermissionManager {
     }
 
     return false;
+  }
+
+  /**
+   * Check whether a bash command part takes path arguments (cd or a
+   * path-taking read-only command) that escape the Safe Zone. Used to
+   * disqualify auto-allow via DEFAULT_ALLOWED_RULES and to hide the
+   * "don't ask again" persistence option for out-of-bounds access.
+   */
+  private isOutOfSafeZonePart(part: string, workdir?: string): boolean {
+    const processedPart = stripRedirections(stripEnvVars(part));
+    const commandMatch = processedPart.match(/^(\w+)(\s+.*)?$/);
+    if (!commandMatch) return false;
+    const cmd = commandMatch[1];
+    if (cmd !== "cd" && !PATH_COMMANDS.includes(cmd)) return false;
+    const args = commandMatch[2]?.trim() || "";
+    const pathArgs = extractPathArgs(args);
+    if (pathArgs.length === 0) return false;
+    return pathArgs.some(
+      (pathArg) => !this.isInsideSafeZone(pathArg, workdir).isInside,
+    );
   }
 
   /**
@@ -1027,14 +1053,15 @@ export class PermissionManager {
         }
 
         // Default rules must not auto-allow dangerous variants (write
-        // redirections, substitutions, sed -i, dangerous find) through broad
-        // rules like Bash(echo*) or Bash(cat*)
+        // redirections, substitutions, sed -i, dangerous find, out-of-safe-zone
+        // paths) through broad rules like Bash(echo*) or Bash(cat*)
         const isDangerousVariant =
           hasWriteRedirections(part) ||
           isDangerousFind(part) ||
           hasCommandSubstitution(part) ||
           hasProcessSubstitution(part) ||
-          hasSedInPlace(part);
+          hasSedInPlace(part) ||
+          this.isOutOfSafeZonePart(part, workdir);
         if (
           !isDangerousVariant &&
           DEFAULT_ALLOWED_RULES.some((rule) =>

--- a/packages/agent-sdk/src/utils/bashParser.ts
+++ b/packages/agent-sdk/src/utils/bashParser.ts
@@ -548,6 +548,80 @@ export const READ_ONLY_COMMANDS = [
 ];
 
 /**
+ * Subset of READ_ONLY_COMMANDS whose arguments are file paths (as opposed to
+ * strings, names, or flags, e.g. echo, pwd, which, basename). These commands
+ * must stay within the Safe Zone: a read-only command accessing a path outside
+ * the working directory / additional directories requires confirmation.
+ * Aligned with Claude Code's PathCommand list.
+ */
+export const PATH_COMMANDS = [
+  "ls",
+  "find",
+  "cat",
+  "head",
+  "tail",
+  "wc",
+  "sort",
+  "uniq",
+  "grep",
+  "egrep",
+  "fgrep",
+  "rg",
+  "file",
+  "stat",
+  "du",
+  "df",
+  "tree",
+  "diff",
+  "cmp",
+  "md5sum",
+  "sha256sum",
+  "sha1sum",
+  "xxd",
+  "od",
+  "hexdump",
+  "strings",
+  "readlink",
+  "realpath",
+  "jq",
+  "yq",
+  "cut",
+  "paste",
+  "column",
+  "tr",
+  "awk",
+  "sed",
+];
+
+/**
+ * Extract file path arguments from a command's argument string.
+ * Tokens starting with "-" are treated as flags and skipped; everything after
+ * a "--" separator counts as a path. Quoted path arguments are unquoted.
+ * Non-path tokens (e.g. a grep pattern) are harmless: they resolve against the
+ * working directory and typically do not exist, so isPathInside falls back to
+ * the nearest existing parent (the workdir itself) and stays inside.
+ */
+export function extractPathArgs(args: string): string[] {
+  const tokens = args.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || [];
+  const pathArgs: string[] = [];
+  let afterDoubleDash = false;
+  for (const token of tokens) {
+    if (afterDoubleDash) {
+      pathArgs.push(token);
+      continue;
+    }
+    if (token === "--") {
+      afterDoubleDash = true;
+      continue;
+    }
+    if (!token.startsWith("-")) {
+      pathArgs.push(token);
+    }
+  }
+  return pathArgs.map((p) => p.replace(/^['"](.*)['"]$/, "$1"));
+}
+
+/**
  * Registry of commands and their expected subcommand depth for smart prefix extraction.
  * For example, 'git: 2' means 'git commit' is a valid prefix, but 'git' alone is not.
  * Multi-word keys can be used for more specific rules.

--- a/packages/agent-sdk/tests/managers/permissionManager.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.test.ts
@@ -54,22 +54,24 @@ describe("PermissionManager", () => {
 
   describe("checkPermission method", () => {
     describe("find command", () => {
+      const workdir = "/home/user/project";
+
       it("should allow safe find commands by default", async () => {
         const contexts = [
           {
             toolName: "Bash",
             permissionMode: "default",
-            toolInput: { command: "find ." },
+            toolInput: { command: "find .", workdir },
           },
           {
             toolName: "Bash",
             permissionMode: "default",
-            toolInput: { command: "find . -name '*.ts'" },
+            toolInput: { command: "find . -name '*.ts'", workdir },
           },
           {
             toolName: "Bash",
             permissionMode: "default",
-            toolInput: { command: "find src -type f" },
+            toolInput: { command: "find src -type f", workdir },
           },
         ];
 
@@ -1706,10 +1708,14 @@ describe("PermissionManager", () => {
         expect(context.hidePersistentOption).toBe(true);
       });
 
-      it("should NOT set hidePersistentOption for out-of-bounds ls", () => {
+      it("should set hidePersistentOption for out-of-bounds ls", () => {
         vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
-          if (p.toString() === "/etc") return "/etc";
-          return "/home/user/project";
+          const resolved = path.resolve(p.toString());
+          const workdirResolved = path.resolve(workdir);
+          if (path.relative(workdirResolved, resolved).startsWith("..")) {
+            return resolved;
+          }
+          return workdirResolved;
         });
 
         const context = permissionManager.createContext(
@@ -1722,7 +1728,7 @@ describe("PermissionManager", () => {
           },
         );
 
-        expect(context.hidePersistentOption).toBeFalsy();
+        expect(context.hidePersistentOption).toBe(true);
       });
 
       it("should NOT set hidePersistentOption for safe commands", () => {
@@ -2130,11 +2136,14 @@ describe("PermissionManager", () => {
       expect(result.behavior).toBe("deny");
     });
 
-    it("should allow 'ls /etc' even if it is outside workdir because of default allowed rule", async () => {
+    it("should NOT allow 'ls /etc' when it is outside workdir", async () => {
       vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
-        const pathStr = p.toString();
-        if (pathStr === "/etc") return "/etc";
-        return "/home/user/project";
+        const resolved = path.resolve(p.toString());
+        const workdirResolved = path.resolve(workdir);
+        if (path.relative(workdirResolved, resolved).startsWith("..")) {
+          return resolved;
+        }
+        return workdirResolved;
       });
 
       const context: ToolPermissionContext = {
@@ -2144,7 +2153,140 @@ describe("PermissionManager", () => {
       };
 
       const result = await permissionManager.checkPermission(context);
+      expect(result.behavior).toBe("deny");
+    });
+
+    it("should allow 'ls src' when inside workdir", async () => {
+      vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
+        const resolved = path.resolve(p.toString());
+        const workdirResolved = path.resolve(workdir);
+        if (path.relative(workdirResolved, resolved).startsWith("..")) {
+          return resolved;
+        }
+        return workdirResolved;
+      });
+
+      const context: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command: "ls src", workdir },
+      };
+
+      const result = await permissionManager.checkPermission(context);
       expect(result.behavior).toBe("allow");
+    });
+
+    it("should allow 'ls -l src' with flags when inside workdir", async () => {
+      vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
+        const resolved = path.resolve(p.toString());
+        const workdirResolved = path.resolve(workdir);
+        if (path.relative(workdirResolved, resolved).startsWith("..")) {
+          return resolved;
+        }
+        return workdirResolved;
+      });
+
+      const context: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command: "ls -l src", workdir },
+      };
+
+      const result = await permissionManager.checkPermission(context);
+      expect(result.behavior).toBe("allow");
+    });
+
+    it("should NOT allow 'cat /etc/passwd' when outside workdir", async () => {
+      vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
+        const resolved = path.resolve(p.toString());
+        const workdirResolved = path.resolve(workdir);
+        if (path.relative(workdirResolved, resolved).startsWith("..")) {
+          return resolved;
+        }
+        return workdirResolved;
+      });
+
+      const context: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command: "cat /etc/passwd", workdir },
+      };
+
+      const result = await permissionManager.checkPermission(context);
+      expect(result.behavior).toBe("deny");
+    });
+
+    it("should NOT allow 'grep root /etc/passwd' when outside workdir", async () => {
+      vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
+        const resolved = path.resolve(p.toString());
+        const workdirResolved = path.resolve(workdir);
+        if (path.relative(workdirResolved, resolved).startsWith("..")) {
+          return resolved;
+        }
+        return workdirResolved;
+      });
+
+      const context: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command: "grep root /etc/passwd", workdir },
+      };
+
+      const result = await permissionManager.checkPermission(context);
+      expect(result.behavior).toBe("deny");
+    });
+
+    it("should NOT allow 'cat ../secret.txt' when escaping workdir", async () => {
+      vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
+        const resolved = path.resolve(p.toString());
+        const workdirResolved = path.resolve(workdir);
+        if (path.relative(workdirResolved, resolved).startsWith("..")) {
+          return resolved;
+        }
+        return workdirResolved;
+      });
+
+      const context: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command: "cat ../secret.txt", workdir },
+      };
+
+      const result = await permissionManager.checkPermission(context);
+      expect(result.behavior).toBe("deny");
+    });
+
+    it("should allow 'ls /data/exports' when in additional directories", async () => {
+      const container = createContainer(workdir);
+      const manager = new PermissionManager(container, {
+        additionalDirectories: ["/data/exports"],
+      });
+      vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
+        const pathStr = p.toString();
+        if (pathStr.includes("exports")) return pathStr;
+        return path.resolve(workdir);
+      });
+
+      const context: ToolPermissionContext = {
+        toolName: "Bash",
+        permissionMode: "default",
+        toolInput: { command: "ls /data/exports", workdir },
+      };
+
+      const result = await manager.checkPermission(context);
+      expect(result.behavior).toBe("allow");
+    });
+
+    it("should allow 'echo hello' and 'pwd' by default", async () => {
+      for (const command of ["echo hello", "pwd"]) {
+        const context: ToolPermissionContext = {
+          toolName: "Bash",
+          permissionMode: "default",
+          toolInput: { command, workdir },
+        };
+        const result = await permissionManager.checkPermission(context);
+        expect(result.behavior).toBe("allow");
+      }
     });
 
     it("should allow 'cd src && ls' if both are safe", async () => {
@@ -2183,7 +2325,7 @@ describe("PermissionManager", () => {
       const context: ToolPermissionContext = {
         toolName: "Bash",
         permissionMode: "default",
-        toolInput: { command: "grep pattern file" },
+        toolInput: { command: "grep pattern file", workdir },
       };
 
       const result = await permissionManager.checkPermission(context);
@@ -2194,7 +2336,7 @@ describe("PermissionManager", () => {
       const context: ToolPermissionContext = {
         toolName: "Bash",
         permissionMode: "default",
-        toolInput: { command: "rg pattern" },
+        toolInput: { command: "rg pattern", workdir },
       };
 
       const result = await permissionManager.checkPermission(context);
@@ -2205,7 +2347,7 @@ describe("PermissionManager", () => {
       const context: ToolPermissionContext = {
         toolName: "Bash",
         permissionMode: "default",
-        toolInput: { command: "cat file" },
+        toolInput: { command: "cat file", workdir },
       };
 
       const result = await permissionManager.checkPermission(context);
@@ -2216,7 +2358,7 @@ describe("PermissionManager", () => {
       const context: ToolPermissionContext = {
         toolName: "Bash",
         permissionMode: "default",
-        toolInput: { command: "head file" },
+        toolInput: { command: "head file", workdir },
       };
 
       const result = await permissionManager.checkPermission(context);
@@ -2227,7 +2369,7 @@ describe("PermissionManager", () => {
       const context: ToolPermissionContext = {
         toolName: "Bash",
         permissionMode: "default",
-        toolInput: { command: "tail file" },
+        toolInput: { command: "tail file", workdir },
       };
 
       const result = await permissionManager.checkPermission(context);
@@ -2238,7 +2380,7 @@ describe("PermissionManager", () => {
       const context: ToolPermissionContext = {
         toolName: "Bash",
         permissionMode: "default",
-        toolInput: { command: "wc file" },
+        toolInput: { command: "wc file", workdir },
       };
 
       const result = await permissionManager.checkPermission(context);
@@ -2450,11 +2592,13 @@ describe("PermissionManager", () => {
   });
 
   describe("Default Allowed Rules", () => {
+    const workdir = "/home/user/project";
+
     it("should allow 'wc -l *' by default", async () => {
       const context: ToolPermissionContext = {
         toolName: "Bash",
         permissionMode: "default",
-        toolInput: { command: "wc -l *" },
+        toolInput: { command: "wc -l *", workdir },
       };
 
       const result = await permissionManager.checkPermission(context);
@@ -2465,7 +2609,7 @@ describe("PermissionManager", () => {
       const context: ToolPermissionContext = {
         toolName: "Bash",
         permissionMode: "default",
-        toolInput: { command: "wc -l file.txt" },
+        toolInput: { command: "wc -l file.txt", workdir },
       };
 
       const result = await permissionManager.checkPermission(context);
@@ -2474,6 +2618,8 @@ describe("PermissionManager", () => {
   });
 
   describe("sort command", () => {
+    const workdir = "/home/user/project";
+
     it("should allow 'sort' by default", async () => {
       const context: ToolPermissionContext = {
         toolName: "Bash",
@@ -2489,7 +2635,7 @@ describe("PermissionManager", () => {
       const context: ToolPermissionContext = {
         toolName: "Bash",
         permissionMode: "default",
-        toolInput: { command: "sort -n file.txt" },
+        toolInput: { command: "sort -n file.txt", workdir },
       };
 
       const result = await permissionManager.checkPermission(context);
@@ -2500,7 +2646,7 @@ describe("PermissionManager", () => {
       const context: ToolPermissionContext = {
         toolName: "Bash",
         permissionMode: "default",
-        toolInput: { command: "sort file.txt | head" },
+        toolInput: { command: "sort file.txt | head", workdir },
       };
 
       const result = await permissionManager.checkPermission(context);

--- a/packages/agent-sdk/tests/managers/permissionManager.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.test.ts
@@ -2437,12 +2437,11 @@ describe("PermissionManager", () => {
 
     beforeEach(() => {
       vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
-        const pathStr = p.toString();
-        if (pathStr.includes("src")) return "/home/user/project/src";
-        if (pathStr.includes("..") || pathStr === "/home/user")
-          return "/home/user";
-        if (pathStr === "/etc") return "/etc";
-        return "/home/user/project";
+        const resolved = path.resolve(p.toString());
+        if (resolved.includes("src")) return path.resolve(workdir, "src");
+        if (resolved === path.resolve(workdir, "..")) return resolved;
+        if (resolved === path.resolve("/etc")) return resolved;
+        return path.resolve(workdir);
       });
     });
 


### PR DESCRIPTION
## 背景

对比 Claude Code 后发现：CC 的 `checkPathConstraints` 对所有路径命令（cd/ls/cat/grep 等）出界都弹权限确认（read 操作也不例外），而 wave 只对 `cd` 做出界检查，其他只读命令（ls/cat/grep 等）无条件放行。spec 已更新（docs/specs/core/tool-permission-system.md「内置安全命令与只读命令自动放行」故事，新增验收场景 12-17）并经用户确认。

## 改动

- **bashParser.ts**：新增 `PATH_COMMANDS`（35 个路径类只读命令子集，对齐 CC PathCommand 列表）+ `extractPathArgs` 工具（flag 剥离、`--` 分隔符、引号解包）
- **permissionManager.ts**：
  - `isAutoAllowedPart` READ_ONLY 分支加 Safe Zone 出界检查（cd 已有，扩展至所有路径命令）
  - 新增 `isOutOfSafeZonePart`（含 cd），接入 `isAllowedByRule` 的 isDangerousVariant——堵住 `Bash(cat*)` 等默认规则对出界命令的绕过
  - `createContext` hidePersistentOption 扩展至只读命令出界（出界确认不提供「不再询问」持久化，与 cd 语义一致）

## 验证

- agent-sdk 全量单测 3552 passed（反转 2 个旧断言 + 新增 8 个用例）
- type-check / oxlint 0 错误
- 真机（worktree bundle）：`ls /etc` 权限拒绝未执行；`ls src` 放行