### PR TITLE
fix(desktop): setInitialState replay 携带 ExitPlanMode 的 planContent，修复后台会话切回后 plan 面板空「等待计划生成」

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -2344,6 +2344,7 @@ export class DesktopHost {
         toolName: p.toolName,
         confirmationType: p.confirmationType,
         toolInput: p.toolInput,
+        planContent: p.planContent,
         suggestedPrefix: p.suggestedPrefix,
         permissionMode: p.permissionMode,
       }));

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -1484,6 +1484,86 @@ describe("permission confirmations", () => {
     });
   });
 
+  it("ExitPlanMode showConfirmation carries the plan content to the webview", async () => {
+    const { sent } = await readyHost();
+    lastAgent().callbacks.onPermissionRequest("req-plan", {
+      toolName: "ExitPlanMode",
+      permissionMode: "plan",
+      planContent: "## 重构方案\n- 步骤一",
+    });
+    await vi.waitFor(() => {
+      expect(sent("showConfirmation")).toHaveLength(1);
+    });
+    const msg = sent("showConfirmation")[0];
+    expect(msg).toMatchObject({
+      toolName: "ExitPlanMode",
+      confirmationType: "计划待确认",
+      planContent: "## 重构方案\n- 步骤一",
+    });
+    expect(msg.paneId).toBeDefined();
+  });
+
+  it("a setInitialState snapshot carries the pending ExitPlanMode plan (pane rebind replay)", async () => {
+    const { host, store, sent } = await readyHost();
+    // Give the first agent a registered session entry (like seedSession).
+    const agent1 = lastAgent();
+    agent1.messages = [{ id: "m-sess-1" }];
+    fireSessionId(agent1, "sess-1");
+    store.upsertSession({
+      sessionId: "sess-1",
+      title: "任务A",
+      host: "local",
+      workdir: "/work/a",
+      cwd: "/work/a",
+      createdAt: Date.now(),
+      lastActiveAt: Date.now(),
+    });
+
+    // Open a second pane, then close the first: sess-1's agent drops out of
+    // the pane but stays live in the pool — an unbound background session,
+    // exactly the state where ExitPlanMode fires with no paneId (no dialog).
+    const before = h.agentInstances.length;
+    await host.handleWebviewMessage({
+      command: "desktopOpenPane",
+      workdir: "/work/a",
+      sessionId: "sess-2",
+    });
+    await vi.waitFor(() => {
+      expect(h.agentInstances).toHaveLength(before + 1);
+    });
+    await host.handleWebviewMessage({
+      command: "desktopClosePane",
+      paneId: "pane-1",
+    });
+
+    agent1.callbacks.onPermissionRequest("req-plan", {
+      toolName: "ExitPlanMode",
+      permissionMode: "plan",
+      planContent: "## 重构方案\n- 步骤一",
+    });
+    // Unbound agent → the request sits pending; no dialog can pop.
+    expect(sent("showConfirmation")).toHaveLength(0);
+
+    // Sidebar click on the session → activateAgentInPane pushes a fresh
+    // setInitialState snapshot. The replay must carry the pending plan, or the
+    // webview reopens the dialog over an empty「等待计划生成…」pane.
+    await host.handleWebviewMessage({
+      command: "desktopSelectSession",
+      workdir: "/work/a",
+      sessionId: "sess-1",
+    });
+
+    const last = sent("setInitialState").at(-1);
+    expect(last.paneId).toBe("pane-2");
+    expect(last.pendingConfirmations).toContainEqual(
+      expect.objectContaining({
+        toolName: "ExitPlanMode",
+        confirmationType: "计划待确认",
+        planContent: "## 重构方案\n- 步骤一",
+      }),
+    );
+  });
+
   it("approval resolves an allow decision", async () => {
     const { host, sent } = await readyHost();
     const confirmationId = await triggerPermission(sent, "Bash");

--- a/packages/webview/tests/webview/chatAppPanels.test.tsx
+++ b/packages/webview/tests/webview/chatAppPanels.test.tsx
@@ -1457,4 +1457,90 @@ describe("desktop plan panel", () => {
     expect(pane).toBeInTheDocument();
     expect(pane).toHaveTextContent("等待计划生成…");
   });
+
+  it("split-view pane: ExitPlanMode after AskUserQuestion/EnterPlanMode opens the plan panel with the plan", () => {
+    window.waveHostType = "desktop";
+    renderDesktop({ workdir: "/work/a" });
+    // Split-view layout: pane-1 is bound to session s1 (DesktopShell renders a
+    // paneId-scoped ChatApp; pane-tagged host messages route by paneId).
+    sendHostMessage(
+      fixtures.desktopSessionTree({
+        groups: [
+          {
+            host: "local",
+            workdir: "/work/a",
+            sessions: [
+              {
+                sessionId: "s1",
+                title: "s1",
+                lastActiveAt: Date.now(),
+                hasWorktree: false,
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    sendHostMessage(
+      fixtures.desktopPanes({
+        panes: [
+          {
+            paneId: "pane-1",
+            sessionId: "s1",
+            row: 0,
+            host: "local",
+            width: 0.5,
+          },
+        ],
+        focusedPaneId: "pane-1",
+      }),
+    );
+
+    const ask = (
+      toolName: string,
+      confirmationId: string,
+      extra: Record<string, unknown> = {},
+    ) =>
+      sendCommand("showConfirmation", {
+        confirmationId,
+        toolName,
+        confirmationType: "计划待确认",
+        paneId: "pane-1",
+        ...extra,
+      });
+    // Full permission sequence like the real agent flow: AskUserQuestion →
+    // approve → EnterPlanMode → approve → ExitPlanMode (carrying the plan).
+    ask("AskUserQuestion", "conf_q_1", {
+      toolInput: {
+        questions: [
+          {
+            question: "plan?",
+            options: [{ label: "先做 plan", description: "" }],
+            multiSelect: false,
+          },
+        ],
+      },
+    });
+    fireEvent.click(
+      document.querySelector(
+        '.option-item[data-option-index="0"] input[type="radio"]',
+      ) as HTMLElement,
+    );
+    fireEvent.click(
+      document.querySelector(
+        ".question-navigation .confirmation-btn-apply",
+      ) as HTMLElement,
+    );
+    ask("EnterPlanMode", "conf_epm_1");
+    fireEvent.click(
+      document.querySelector(".confirmation-btn-apply") as HTMLElement,
+    );
+    ask(EXIT_PLAN_MODE_TOOL_NAME, "conf_exit_1", {
+      planContent: "## 分屏方案\n- 步骤一",
+    });
+
+    const content = screen.getByTestId("plan-pane-content");
+    expect(content.querySelector("h2")).toHaveTextContent("分屏方案");
+    expect(content.querySelectorAll("li")).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## 问题

桌面端：会话在后台（未绑定 pane）触发 ExitPlanMode 时，plan 已生成但界面显示「等待plan 生成」；exit plan 时 plan 面板没有自动打开。

## 根因

1. ExitPlanMode 在未绑定 pane 的后台会话触发 → `paneIdForAgent` 返回 undefined → `pushPendingConfirmation` 不弹对话框，请求挂起
2. 用户从侧边栏切回该会话 → `handleSelectSession` → `activateAgentInPane` → `pushPaneSessionState` 推 `setInitialState` 快照
3. 快照序列化 `pendingConfirmations` 缺 `planContent` → webview 的 `routePlanToPanel(undefined)` 直接 return → 对话框弹出但 plan 面板为空（`等待计划生成…`）

对比：toast「查看」路径的 `replayPendingConfirmations`（`showConfirmation`）一直带 `planContent`，所以只有侧边栏切回这条 replay 路径会丢。

## 修复

`pushPaneSessionState` 的 `pendingConfirmations` 序列化补上 `planContent`，与 `replayPendingConfirmations` 保持一致。webview 侧 `setInitialState` case 已通过 `routePlanToPanel(c.planContent)` 处理该字段，无需改动。

## 测试

- desktopHost +2：showConfirmation 携带 planContent；setInitialState 快照重放携带 pending ExitPlanMode plan（完整复现：无 pane 后台会话触发 → 无对话框 → 侧边栏切回 → 快照带 plan）
- webview +1：分屏 pane 内 AskUserQuestion → EnterPlanMode → ExitPlanMode 全序列自动打开 plan 面板并显示内容
- desktopHost 271/271、webview 753/753、两包 type-check + lint 全绿