### PR TITLE
fix(webview): /plan 归入斜杠命令弹窗系统指令组

### DIFF
--- a/packages/webview/src/components/SlashCommandsPopup.tsx
+++ b/packages/webview/src/components/SlashCommandsPopup.tsx
@@ -25,6 +25,7 @@ const SYSTEM_COMMANDS = [
   "workflows",
   "agents",
   "subtask",
+  "plan",
   "skills",
   "clear",
   "compact",

--- a/packages/webview/tests/webview/slashCommandsGrouping.test.tsx
+++ b/packages/webview/tests/webview/slashCommandsGrouping.test.tsx
@@ -44,6 +44,7 @@ describe("SlashCommandsPopup grouping", () => {
       { id: "clear", name: "clear", description: "清空" },
       { id: "compact", name: "compact", description: "压缩" },
       { id: "subtask", name: "subtask", description: "后台子任务" },
+      { id: "plan", name: "plan", description: "启用计划模式" },
       { id: "settings", name: "settings", description: "设置技能" },
       { id: "loop", name: "loop", description: "循环技能" },
       { id: "deepwiki:ask", name: "deepwiki:ask", description: "DeepWiki" },
@@ -71,7 +72,7 @@ describe("SlashCommandsPopup grouping", () => {
       within(pluginGroup).queryByTestId("slash-command-config"),
     ).not.toBeInTheDocument();
 
-    // config/mcp/status/clear/compact/subtask -> 系统指令
+    // config/mcp/status/clear/compact/subtask/plan -> 系统指令
     const systemGroup = getGroup("系统指令");
     for (const id of [
       "config",
@@ -80,6 +81,7 @@ describe("SlashCommandsPopup grouping", () => {
       "clear",
       "compact",
       "subtask",
+      "plan",
     ]) {
       expect(
         within(systemGroup).getByTestId(`slash-command-${id}`),


### PR DESCRIPTION
## 变更内容

PR #1943 将 `/plan` 注册为 slashCommandManager 内置命令后，webview 斜杠命令弹窗的分组白名单（`SYSTEM_COMMANDS`，SlashCommandsPopup.tsx）未同步——`/plan` 会被误分到「技能」组（与 `/subtask` 曾遗漏同源问题，见 #531faa46）。

- `SYSTEM_COMMANDS` 白名单补 `"plan"`（subtask 后、skills 前）
- 分组测试补 `/plan` 归「系统指令」断言

## 测试

- webview slashCommandsGrouping.test.tsx 8/8、全量 755 passed、type-check/lint 通过