### PR TITLE
fix(webview): re-activate file panel search dropdown when typing after selecting a file

### DIFF
--- a/packages/webview/src/components/FilePane.tsx
+++ b/packages/webview/src/components/FilePane.tsx
@@ -287,6 +287,10 @@ export const FilePane: React.FC<FilePaneProps> = ({
     (value: string) => {
       setSearchFilter(value);
       setSearchSelectedIndex(0);
+      // Selecting a file resets the search (searchActive=false) while focus
+      // stays in the input, so typing again must re-activate the dropdown —
+      // onFocus won't fire again until the input loses and regains focus.
+      setSearchActive(true);
       if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
       searchDebounceRef.current = setTimeout(() => {
         searchDebounceRef.current = null;

--- a/packages/webview/tests/webview/filePane.test.tsx
+++ b/packages/webview/tests/webview/filePane.test.tsx
@@ -465,6 +465,32 @@ describe("FilePane", () => {
       expect(input).toHaveValue("");
     });
 
+    it("re-opens the dropdown when typing again after selecting a file", async () => {
+      const vscode = makeVscode();
+      const onOpenFileInPanel = vi.fn();
+      renderPane({ vscode, onOpenFileInPanel });
+      const input = screen.getByTestId("file-pane-search-input");
+      fireEvent.focus(input);
+      let reqId = await waitForSearchRequest(vscode, "");
+      sendSuggestionsResponse(reqId, [
+        makeFileItem("App.tsx", "/work/a/src/App.tsx", "src/App.tsx"),
+      ]);
+      await screen.findByText("App.tsx");
+
+      // Select the file; focus stays in the input (no blur event fires).
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(onOpenFileInPanel).toHaveBeenCalledWith("/work/a/src/App.tsx");
+      expect(screen.queryByText("App.tsx")).not.toBeInTheDocument();
+
+      // Type again without refocusing — the dropdown must come back.
+      fireEvent.change(input, { target: { value: "main" } });
+      reqId = await waitForSearchRequest(vscode, "main");
+      sendSuggestionsResponse(reqId, [
+        makeFileItem("main.ts", "/work/a/src/main.ts", "src/main.ts"),
+      ]);
+      expect(await screen.findByText("src/main.ts")).toBeInTheDocument();
+    });
+
     it("closes the dropdown and clears the search on Escape", async () => {
       const vscode = makeVscode();
       renderPane({ vscode });


### PR DESCRIPTION
修复文件面板搜索框 bug：搜索选中一个文件后焦点仍在搜索框内，再次输入关键词搜索无结果显示，必须先失焦再聚焦。

## 根因

FilePane.tsx 中选中文件后 handleSearchSelect 调用 resetSearch()，将 searchActive 置为 false 并关闭下拉，但焦点仍留在输入框内（不触发 onFocus）。再次输入时 handleSearchChange 只更新 filter 并发出 requestFileSuggestions，下拉显示条件 `searchActive && (...)` 不满足——搜索结果实际已返回但下拉不渲染。失焦再聚焦会触发 onFocus 重新激活，因此表现为必须重聚焦才能搜出。

## 修复

FilePane.tsx handleSearchChange 中补一行 `setSearchActive(true)`，输入时下拉自动重新激活，与消息输入框 @ 提及行为一致。

## 验证

- 新增回归测试（选中文件后不重新聚焦直接输入，下拉重新出现）
- FilePane 34/34、webview 全量 781/781
- type-check 0 错、oxlint 0 警告