### PR TITLE
refactor(webview): drop dead target guard on AskUserQuestion options

### DIFF
--- a/packages/webview/src/components/ConfirmationDialog.tsx
+++ b/packages/webview/src/components/ConfirmationDialog.tsx
@@ -524,9 +524,6 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
                 }`}
                 tabIndex={0}
                 onKeyDown={(e) => {
-                  // Keys pressed inside a child (e.g. a textarea) are text
-                  // editing, not option selection.
-                  if (e.target !== e.currentTarget) return;
                   if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
                     handleOptionChange(
@@ -595,9 +592,8 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
                   }`}
                   tabIndex={0}
                   onKeyDown={(e) => {
-                    // Keys pressed inside the Other textarea are text
-                    // editing, not option selection.
-                    if (e.target !== e.currentTarget) return;
+                    // The Other textarea stopPropagation's its own keys, so
+                    // keydown here always originates from the label itself.
                     if (e.key === "Enter" || e.key === " ") {
                       e.preventDefault();
                       if (q.multiSelect) {


### PR DESCRIPTION
跟随 PR #1959（选项改 Tab 遍历）的清理：选项 label 已无子元素可聚焦（「其他」textarea 自行 stopPropagation 所有按键），`e.target !== e.currentTarget` 守卫永远不会触发，属死代码。从普通选项与 Other 选项两处 onKeyDown 删除（含过时注释），Other 处注释改为说明 stopPropagation 保证。

验证：webview confirmationDialog 40/40、type-check、oxlint 全绿。