### PR TITLE
fix(agent-sdk): keep pre-compaction history in displayMessages after new messages

### DIFF
--- a/packages/agent-sdk/src/managers/messageManager.ts
+++ b/packages/agent-sdk/src/managers/messageManager.ts
@@ -328,7 +328,25 @@ export class MessageManager {
     // explicitly (the display stream must keep the full pre-compaction
     // history while the context folds at the last compact boundary).
     if (!opts?.keepDisplay) {
-      this.displayMessages = [...messages];
+      if (messages.length === 0) {
+        // Clear path — nothing to merge.
+        this.displayMessages = [...messages];
+      } else {
+        // Routine changes (new messages, tool block updates) still touch the
+        // display stream, but after compaction the display holds the full
+        // pre-compaction history while the context is folded. Merge by id so
+        // new messages append to the display stream and updated messages
+        // replace their display copy without dropping that history.
+        const byId = new Map(messages.map((m) => [m.id, m]));
+        const merged = this.displayMessages.map((m) => byId.get(m.id) ?? m);
+        const known = new Set(this.displayMessages.map((m) => m.id));
+        for (const m of messages) {
+          if (!known.has(m.id)) {
+            merged.push(m);
+          }
+        }
+        this.displayMessages = merged;
+      }
     }
 
     // Incrementally extract metadata from new messages

--- a/packages/agent-sdk/tests/managers/messageManager.coverage.test.ts
+++ b/packages/agent-sdk/tests/managers/messageManager.coverage.test.ts
@@ -313,6 +313,65 @@ describe("MessageManager Coverage Improvements", () => {
     expect(display.map((m) => m.id)).toEqual(["u1", "a1", "c1", "u2", "a2"]);
   });
 
+  it("compaction then new messages keep the pre-compaction history in displayMessages", async () => {
+    messageManager.addUserMessage({ content: "q1" });
+    messageManager.addAssistantMessage("a1");
+    messageManager.addUserMessage({ content: "q2" });
+    messageManager.addAssistantMessage("a2");
+
+    await messageManager.compactMessagesAndUpdateSession("summary");
+
+    // A new round after compaction must not clobber the display stream with
+    // the folded context ([compact, ...last rounds]).
+    messageManager.addUserMessage({ content: "q3" });
+    messageManager.addAssistantMessage("a3");
+
+    const display = messageManager.getDisplayMessages();
+    expect(
+      display.map((m) => (m.blocks[0] as { content: string }).content),
+    ).toEqual(["q1", "a1", "q2", "a2", "summary", "q3", "a3"]);
+  });
+
+  it("compaction then tool block updates sync the display stream without dropping history", async () => {
+    messageManager.addUserMessage({ content: "q1" });
+    messageManager.addAssistantMessage("a1");
+    messageManager.addUserMessage({ content: "q2" });
+    messageManager.addAssistantMessage("a2");
+
+    await messageManager.compactMessagesAndUpdateSession("summary");
+
+    const lastAssistantId = [...messageManager.getMessages()]
+      .reverse()
+      .find(
+        (m) =>
+          m.role === "assistant" && !m.blocks.some((b) => b.type === "compact"),
+      )!.id;
+    messageManager.addToolBlockToMessage(lastAssistantId, {
+      name: "Write",
+      parameters: '{"path": "/tmp/a"}',
+      stage: "start",
+    } as Parameters<MessageManager["addToolBlockToMessage"]>[1]);
+
+    const display = messageManager.getDisplayMessages();
+    expect(
+      display.map((m) => (m.blocks[0] as { content: string }).content),
+    ).toEqual(["q1", "a1", "q2", "a2", "summary"]);
+    // The updated message (not the trailing compact block) carries the tool
+    // block in the display stream too.
+    const updated = display.find((m) => m.id === lastAssistantId)!;
+    expect(
+      updated.blocks.some((b) => b.type === "tool" && b.name === "Write"),
+    ).toBe(true);
+  });
+
+  it("clearMessages after compaction empties the display stream", async () => {
+    messageManager.addUserMessage({ content: "q1" });
+    messageManager.addAssistantMessage("a1");
+    await messageManager.compactMessagesAndUpdateSession("summary");
+    messageManager.clearMessages();
+    expect(messageManager.getDisplayMessages()).toEqual([]);
+  });
+
   it("should handle addFileHistoryBlock", () => {
     messageManager.addAssistantMessage("hello");
     messageManager.addFileHistoryBlock([


### PR DESCRIPTION
## Problem

PR #1953 split the UI display stream (displayMessages, full history) from the API context (messages, folded at the last compact boundary). But setMessages()'s default branch overwrote displayMessages with the folded context on any routine change (addUserMessage, tool block updates, etc.), so once the user sent a new message after compaction, the pre-compaction history vanished from the UI and the sticky bar lost its candidates.

Reported symptom: pre-compaction messages not loaded, pre-compaction user messages no longer pin the sticky bar.

## Fix

setMessages() now merges displayMessages by message id instead of replacing it:
- messages already in the display stream keep their position, replaced with the updated copy
- new messages append at the end
- empty messages (clearMessages) still clears the display stream

## Verification

- 3 regression tests (new round after compaction, tool block update, clearMessages)
- agent-sdk unit: 3544 passed
- code unit: 1440 passed (1 known flaky Ink UI timeout, passes standalone)
- agent-sdk type-check clean