### PR TITLE
ci: refresh-jetbrains 补 wave-code 构建

### DIFF
--- a/.github/workflows/refresh-release-assets.yml
+++ b/.github/workflows/refresh-release-assets.yml
@@ -87,6 +87,11 @@ jobs:
       # syncTargets, shipping the unminified dev bundle and bloating the .zip.
       - run: pnpm -F wave-webview run compile -- --production
 
+      # Gradle's bundleCli task requires the CLI dist (packages/code/dist/
+      # bundle/wave.mjs) — same upstream build publish.yml's jetbrains job
+      # depends on; without it bundleCli fails on "缺少 wave CLI 构建产物".
+      - run: pnpm -F wave-code build
+
       - name: Build plugin distribution (.zip)
         run: ./packages/jetbrains/gradlew -p packages/jetbrains buildPlugin --no-daemon
 


### PR DESCRIPTION
refresh-release-assets.yml 的 refresh-jetbrains job 漏了 `pnpm -F wave-code build`：Gradle bundleCli 任务需要 packages/code/dist/bundle/wave.mjs，运行报「缺少 wave CLI 构建产物」失败（run 33054286167）。与 publish.yml jetbrains job 的上游构建对齐。