### PR TITLE
fix: 桌面端同版本重装跑陈旧 CLI + 旧压缩转录重复消息去重

### DIFF
--- a/packages/agent-sdk/src/services/session.ts
+++ b/packages/agent-sdk/src/services/session.ts
@@ -302,12 +302,18 @@ export async function loadSessionFromJsonl(
 
     const allMessages = await jsonlHandler.read(resolvedPath);
 
-    // Return the FULL transcript. The transcript is append-only and compaction
-    // writes only the compact block (preserved last rounds are dedup-skipped),
-    // so every message id appears exactly once — the UI renders the whole
-    // history including pre-compaction messages. The API context folding at
-    // the last compact boundary happens in MessageManager.initializeFromSession.
-    const messages = allMessages;
+    // Transcripts written by older CLI versions re-appended the preserved
+    // rounds at each compaction point, so a message id can appear twice.
+    // Keep the first occurrence — duplicates would render twice once the
+    // full-history restore below feeds them to displayMessages. Append-only
+    // transcripts (current write side) have unique ids, making this a no-op.
+    const seenIds = new Set<string>();
+    const messages: Message[] = [];
+    for (const message of allMessages) {
+      if (message.id && seenIds.has(message.id)) continue;
+      if (message.id) seenIds.add(message.id);
+      messages.push(message);
+    }
 
     // Extract metadata from messages
     const lastMessage =

--- a/packages/agent-sdk/tests/services/session.compact.test.ts
+++ b/packages/agent-sdk/tests/services/session.compact.test.ts
@@ -207,6 +207,34 @@ describe("Session Append-Only Compaction", () => {
     );
   });
 
+  it("loadSessionFromJsonl dedups duplicate ids from legacy transcripts (old compaction re-appended preserved rounds)", async () => {
+    const sessionId = "test-session-dup";
+
+    const oldUser = makeMessage("user", "old_user");
+    const retainedUser = makeMessage("user", "retained");
+    // Legacy write side re-appended the preserved rounds at each compaction
+    // point, so an id can appear twice with identical content.
+    const allMessagesInFile: Message[] = [
+      oldUser,
+      retainedUser,
+      makeCompactMessage("summary"),
+      { ...retainedUser },
+      makeMessage("user", "fresh after compact"),
+    ];
+
+    mockRead.mockResolvedValue(allMessagesInFile);
+
+    const result = await loadSessionFromJsonl(sessionId, testWorkdir, "main");
+
+    expect(result!.messages.length).toBe(4);
+    // The first occurrence (original pre-compaction position) survives,
+    // and the duplicated id appears exactly once.
+    expect(result!.messages[1].id).toBe(retainedUser.id);
+    expect(
+      result!.messages.filter((m) => m.id === retainedUser.id).length,
+    ).toBe(1);
+  });
+
   it("loadFullMessageThread returns the complete message thread including pre-compact messages", async () => {
     const sessionId = "test-session-5";
 

--- a/packages/desktop/src/main/stdio/binaryResolver.ts
+++ b/packages/desktop/src/main/stdio/binaryResolver.ts
@@ -5,9 +5,10 @@
  * 2. The CLI bundled inside the app (resources/wave-cli, shipped in the
  *    installer) is copied into `~/.wave/cli/desktop` — the packaged install
  *    dir is read-only on macOS/Windows, so the runtime copy lives under the
- *    user home. The CLI version tracks the app version (shipped with the
- *    app). Each frontend (vscode/desktop/jetbrains) keeps its own subdir so
- *    different versions never overwrite each other.
+ *    user home. The runtime copy is refreshed whenever its bundle bytes drift
+ *    from the app's (app upgrades AND same-version dev reinstalls like
+ *    `desktop:install`). Each frontend (vscode/desktop/jetbrains) keeps its
+ *    own subdir so different versions never overwrite each other.
  * 3. The grep tool's runtime dependency `@vscode/ripgrep` (JS wrapper +
  *    platform rg binary, ~5MB) is downloaded from the npmmirror registry on
  *    first use and cached in the shared `~/.wave/cli/node_modules/@vscode`
@@ -20,6 +21,7 @@
  * cached for the app lifetime.
  */
 
+import { createHash } from "node:crypto";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -194,7 +196,10 @@ export async function ensureRipgrep(
 
 /**
  * Copy the bundled CLI into the runtime dir when missing or when the bundled
- * version differs (app upgrade). The cached rg download lives in the shared
+ * bundle bytes differ from the runtime copy. Content comparison instead of a
+ * version-string check: local dev reinstalls (`desktop:install`) refresh the
+ * app without bumping its version, so an unchanged version number cannot be
+ * trusted as "same CLI". The cached rg download lives in the shared
  * `~/.wave/cli/node_modules/@vscode` dir — outside this per-end dir — so an
  * already-downloaded rg is never re-downloaded after an upgrade. Returns the
  * runtime entry path.
@@ -207,10 +212,17 @@ function prepareCli(): string {
     throw new Error(`内置 CLI 缺失（${bundledEntry}）。请重新安装应用。`);
   }
 
+  const runtimeBundle = path.join(
+    cliInstallDir(),
+    "dist",
+    "bundle",
+    "wave.mjs",
+  );
   const needCopy =
     !fileExists(entry) ||
-    bundledVersion() !== runtimeVersion() ||
-    !fileExists(path.join(cliInstallDir(), "dist", "bundle", "wave.mjs"));
+    !fileExists(runtimeBundle) ||
+    fileHash(path.join(bundledCliDir(), "dist", "bundle", "wave.mjs")) !==
+      fileHash(runtimeBundle);
 
   if (needCopy) {
     fs.mkdirSync(cliInstallDir(), { recursive: true });
@@ -227,23 +239,10 @@ function prepareCli(): string {
   return entry;
 }
 
-function bundledVersion(): string {
+/** sha256 of a file's bytes, or "" when it can't be read (missing/corrupt). */
+function fileHash(p: string): string {
   try {
-    const pkg = JSON.parse(
-      fs.readFileSync(path.join(bundledCliDir(), "package.json"), "utf-8"),
-    ) as { version?: string };
-    return pkg.version ?? "";
-  } catch {
-    return "";
-  }
-}
-
-function runtimeVersion(): string {
-  try {
-    const pkg = JSON.parse(
-      fs.readFileSync(path.join(cliInstallDir(), "package.json"), "utf-8"),
-    ) as { version?: string };
-    return pkg.version ?? "";
+    return createHash("sha256").update(fs.readFileSync(p)).digest("hex");
   } catch {
     return "";
   }

--- a/packages/desktop/tests/binaryResolver.test.ts
+++ b/packages/desktop/tests/binaryResolver.test.ts
@@ -90,17 +90,17 @@ const PKG_JSON = (version: string) =>
   });
 
 /** Seed the bundled CLI (as bundleCli.mjs would). */
-function seedBundledCli(version = "1.0.0") {
+function seedBundledCli(version = "1.0.0", content = "bundle") {
   memFs.set(bundledEntry(), "shim");
   memFs.set(path.join(bundledDir(), "package.json"), PKG_JSON(version));
-  memFs.set(path.join(bundledDir(), "dist", "bundle", "wave.mjs"), "bundle");
+  memFs.set(path.join(bundledDir(), "dist", "bundle", "wave.mjs"), content);
 }
 
-/** Seed a fully installed runtime CLI (same version → no re-copy). */
-function seedRuntimeCli(version = "1.0.0") {
+/** Seed a fully installed runtime CLI (same version + bytes → no re-copy). */
+function seedRuntimeCli(version = "1.0.0", content = "bundle") {
   memFs.set(entry(), "shim");
   memFs.set(path.join(cliInstallDir(), "package.json"), PKG_JSON(version));
-  memFs.set(path.join(cliInstallDir(), "dist", "bundle", "wave.mjs"), "bundle");
+  memFs.set(path.join(cliInstallDir(), "dist", "bundle", "wave.mjs"), content);
 }
 
 /** Seed an already-downloaded rg binary (→ cached, no fetch). */
@@ -230,8 +230,8 @@ describe("binaryResolver (bundled CLI + downloaded rg)", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("re-copies the CLI but keeps the cached rg when the version changes", async () => {
-    seedBundledCli("1.1.0"); // app upgraded
+  it("re-copies the CLI but keeps the cached rg when the bundle content changes (app upgrade)", async () => {
+    seedBundledCli("1.1.0", "upgraded-bundle"); // app upgraded
     seedRuntimeCli("1.0.0");
     seedRg(); // rg already downloaded
 
@@ -242,6 +242,24 @@ describe("binaryResolver (bundled CLI + downloaded rg)", () => {
     // node_modules (rg) preserved: no fetch happened.
     expect(mockFetch).not.toHaveBeenCalled();
     expect(memFs.has(rgBin())).toBe(true);
+  });
+
+  it("re-copies when a same-version reinstall ships different bundle bytes (desktop:install)", async () => {
+    // desktop:install refreshes the app without bumping the version — a
+    // version-only staleness check would keep running the old runtime copy
+    // forever (regression: stale CLI missed the compaction display fix).
+    seedBundledCli("1.1.5", "rebuilt-with-fix");
+    seedRuntimeCli("1.1.5", "stale-aug26-copy");
+    seedRg();
+
+    const result = await resolveWaveBinary("1.1.5");
+
+    expect(result).toBe(entry());
+    expect(mockFs.cpSync).toHaveBeenCalled();
+    expect(
+      memFs.get(path.join(cliInstallDir(), "dist", "bundle", "wave.mjs")),
+    ).toBe("rebuilt-with-fix");
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("does not download rg when the CLI has no grep dependency", async () => {


### PR DESCRIPTION
## 背景

用户反馈：桌面端打开会话 a822b42b 后只显示最后一次压缩点之后的消息，压缩前的历史没有加载。

## 根因

排查确认磁盘转录完整（1081 行，5 个 compact 标记前后历史齐全），问题在运行链路：

1. **`desktop:install` 本地重装不升版本号**，但 `prepareCli()`（binaryResolver.ts）的重拷贝条件是 `bundledVersion() !== runtimeVersion()`——两边都是 1.1.5 → 跳过拷贝 → 桌面端实际 spawn 的仍是旧副本（`~/.wave/cli/desktop`，8月26日构建，无 displayMessages 实现、加载时直接 sliceFromLastCompact 截断）。
2. 已安装应用内捆绑的 wave-cli 其实已含 PR #1953 修复（恢复时 displayMessages=全量转录），只是被版本号相等挡住没有替换运行时副本。

**每次不带版本号提升的 desktop:install 都会踩这个坑。**

## 改动

### fix 1：binaryResolver 内容 hash 校验（根因）
- 重拷贝条件改为对 `dist/bundle/wave.mjs` 做 sha256 内容比对，字节不一致即重拷贝；版本号不再作为新鲜度判据。
- 删除失效的 bundledVersion/runtimeVersion 辅助函数。
- 测试：新增「同版本、不同 bundle 字节 → 重拷贝且保留 rg 缓存」回归用例。

### fix 2：恢复时按消息 id 去重（旧转录兜底）
- 旧写入侧在压缩点会把保留轮次重复追加进转录（实例：12 条重复 ID），#1953 全量恢复会把它们渲染两遍。
- `loadSessionFromJsonl` 保首去重；新 append-only 写入侧 id 唯一，此改动为幂等 no-op。
- rewind 的 `loadFullMessageThread` 保持文件级全量语义不动。

## 验证

- agent-sdk 单测 250 文件 / 3545 全过 + rewind 集成测试通过
- desktop 测试 20 文件 / 554 全过
- type-check（全 workspace）+ oxlint 干净
- 真机解锁：删除 `~/.wave/cli/desktop` 后重启 Wave 即触发重新拷贝（打包逻辑无需等待本 PR 合并）

🤖 Generated with [Wave](https://github.com/netease-lcap/wave-agent)