### PR TITLE
webview: 加号菜单统一 roving 方向键并抽取 useRovingMenu

### DIFF
--- a/packages/webview/src/components/MessageInput.tsx
+++ b/packages/webview/src/components/MessageInput.tsx
@@ -8,6 +8,7 @@ import React, {
   KeyboardEvent,
 } from "react";
 import { convertToMarkdown } from "../utils/messageUtils";
+import { useRovingMenu } from "../utils/useRovingMenu";
 import { ContextTag } from "./ContextTag";
 import { Tooltip } from "./Tooltip";
 import ReactDOM from "react-dom/client";
@@ -146,61 +147,44 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     } = props;
     const [message, setMessage] = useState("");
 
-    // Permission mode custom dropdown state
-    const [permMenuOpen, setPermMenuOpen] = useState(false);
-    const [permMenuFocusIndex, setPermMenuFocusIndex] = useState(0);
+    // Permission mode custom dropdown (roving-tabindex listbox shared with
+    // the "+" menu via useRovingMenu; Escape returns to the trigger, Tab
+    // leaves without changing the mode).
     const permMenuRef = useRef<HTMLDivElement>(null);
     const permMenuButtonRef = useRef<HTMLButtonElement>(null);
 
-    const handlePermissionModeSelect = useCallback(
-      (mode: PermissionMode) => {
+    const selectedPermissionIndex = Math.max(
+      0,
+      PERMISSION_MODES.findIndex(
+        (m) => m.value === (permissionMode || "default"),
+      ),
+    );
+
+    const permMenu = useRovingMenu(permMenuRef, {
+      itemSelector: ".permission-mode-item",
+      itemCount: PERMISSION_MODES.length,
+      triggerRef: permMenuButtonRef,
+      closeOnActivate: true,
+      onActivate: (i) => {
         vscode.postMessage({
           command: "setPermissionMode",
-          mode: mode,
+          mode: PERMISSION_MODES[i].value,
         });
-        setPermMenuOpen(false);
       },
-      [vscode],
-    );
+    });
 
     // Open the permission-mode dropdown. Shared by the in-DOM Cmd/Ctrl+Shift+M
     // handler (VS Code / desktop when the key reaches the DOM) and the
     // JetBrains bridge, which forwards the key after swallowing the IDE's
     // "Move Caret to Matching Brace" action (same pattern as history-search,
-    // issue #1429). Kept as a plain function so the host can invoke it without
-    // a KeyEvent. Focus moves to the currently selected option so Enter/Space
+    // issue #1429). Focus moves to the currently selected option so Enter/Space
     // confirm and Escape closes without routing focus back through the
     // textarea first.
     const openPermissionModeMenu = useCallback(() => {
-      setPermMenuOpen(true);
-      const selectedIndex = Math.max(
-        0,
-        PERMISSION_MODES.findIndex(
-          (m) => m.value === (permissionMode || "default"),
-        ),
-      );
-      setPermMenuFocusIndex(selectedIndex);
-      requestAnimationFrame(() => {
-        permMenuRef.current
-          ?.querySelectorAll<HTMLElement>(".permission-mode-item")
-          [selectedIndex]?.focus();
-      });
-    }, [permissionMode]);
+      permMenu.openMenu(selectedPermissionIndex);
+    }, [permMenu, selectedPermissionIndex]);
 
-    // Close the permission dropdown when clicking outside of it.
-    useEffect(() => {
-      if (!permMenuOpen) return;
-      const onMouseDown = (e: MouseEvent) => {
-        if (
-          permMenuRef.current &&
-          !permMenuRef.current.contains(e.target as Node)
-        ) {
-          setPermMenuOpen(false);
-        }
-      };
-      document.addEventListener("mousedown", onMouseDown);
-      return () => document.removeEventListener("mousedown", onMouseDown);
-    }, [permMenuOpen]);
+    const { open: permMenuOpen } = permMenu;
 
     const [atMention, setAtMention] = useState<AtMentionState>({
       isActive: false,
@@ -236,26 +220,6 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     const [attachedImages, setAttachedImages] = useState<AttachedImage[]>(
       initialAttachedImages || [],
     );
-
-    // "+" (add) custom dropdown state
-    const [plusMenuOpen, setPlusMenuOpen] = useState(false);
-    const plusMenuRef = useRef<HTMLDivElement>(null);
-    const plusMenuButtonRef = useRef<HTMLButtonElement>(null);
-
-    // Close the "+" dropdown when clicking outside of it.
-    useEffect(() => {
-      if (!plusMenuOpen) return;
-      const onMouseDown = (e: MouseEvent) => {
-        if (
-          plusMenuRef.current &&
-          !plusMenuRef.current.contains(e.target as Node)
-        ) {
-          setPlusMenuOpen(false);
-        }
-      };
-      document.addEventListener("mousedown", onMouseDown);
-      return () => document.removeEventListener("mousedown", onMouseDown);
-    }, [plusMenuOpen]);
 
     const textareaRef = useRef<HTMLDivElement>(null);
     const requestIdRef = useRef<string>("");
@@ -1242,6 +1206,31 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
       setIsHistorySearchVisible(true);
     }, [calculateDropdownPosition]);
 
+    const plusMenuItems = [
+      {
+        label: "上传文件",
+        run: () => handleFileUpload(),
+      },
+      {
+        label: "历史提示词",
+        run: () => openHistorySearch(),
+      },
+    ];
+
+    // "+" (add) custom dropdown, same roving keyboard model as the
+    // permission-mode listbox via useRovingMenu. Declared after its
+    // collaborators so onActivate can close over them.
+    const plusMenuRef = useRef<HTMLDivElement>(null);
+    const plusMenuButtonRef = useRef<HTMLButtonElement>(null);
+
+    const plusMenu = useRovingMenu(plusMenuRef, {
+      itemSelector: ".plus-menu-item",
+      itemCount: plusMenuItems.length,
+      triggerRef: plusMenuButtonRef,
+      closeOnActivate: true,
+      onActivate: (i) => plusMenuItems[i].run(),
+    });
+
     const handleKeyDown = useCallback(
       (event: KeyboardEvent<HTMLDivElement>) => {
         // Handle Cmd/Ctrl+Shift+M to open the permission mode menu (aligned
@@ -1709,59 +1698,33 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
                     ref={plusMenuButtonRef}
                     className="toolbar-icon-button"
                     aria-label="添加"
-                    aria-expanded={plusMenuOpen}
+                    aria-haspopup="menu"
+                    aria-expanded={plusMenu.open}
                     disabled={disabled}
-                    onClick={() => setPlusMenuOpen((o) => !o)}
+                    onClick={() => {
+                      if (plusMenu.open) {
+                        plusMenu.closeMenu();
+                      } else {
+                        // Focus moves to the first item so Enter/Space
+                        // activate and Escape returns to this button.
+                        plusMenu.openMenu();
+                      }
+                    }}
                   >
                     <PlusIcon className="toolbar-icon" />
                   </button>
-                  {plusMenuOpen && (
+                  {plusMenu.open && (
                     <ul className="plus-menu" role="menu">
-                      <li
-                        role="menuitem"
-                        tabIndex={0}
-                        className="plus-menu-item"
-                        onClick={() => {
-                          handleFileUpload();
-                          setPlusMenuOpen(false);
-                        }}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter" || e.key === " ") {
-                            e.preventDefault();
-                            handleFileUpload();
-                            setPlusMenuOpen(false);
-                            plusMenuButtonRef.current?.focus();
-                          } else if (e.key === "Escape") {
-                            e.preventDefault();
-                            setPlusMenuOpen(false);
-                            plusMenuButtonRef.current?.focus();
-                          }
-                        }}
-                      >
-                        上传文件
-                      </li>
-                      <li
-                        role="menuitem"
-                        tabIndex={0}
-                        className="plus-menu-item"
-                        onClick={() => {
-                          openHistorySearch();
-                          setPlusMenuOpen(false);
-                        }}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter" || e.key === " ") {
-                            e.preventDefault();
-                            openHistorySearch();
-                            setPlusMenuOpen(false);
-                          } else if (e.key === "Escape") {
-                            e.preventDefault();
-                            setPlusMenuOpen(false);
-                            plusMenuButtonRef.current?.focus();
-                          }
-                        }}
-                      >
-                        历史提示词
-                      </li>
+                      {plusMenuItems.map((item, i) => (
+                        <li
+                          key={item.label}
+                          role="menuitem"
+                          className="plus-menu-item"
+                          {...plusMenu.getItemProps(i)}
+                        >
+                          {item.label}
+                        </li>
+                      ))}
                     </ul>
                   )}
                 </div>
@@ -1787,11 +1750,12 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
                   ref={permMenuButtonRef}
                   className={`permission-mode-select mode-${permissionMode || "default"}`}
                   aria-label="权限模式"
+                  aria-haspopup="listbox"
                   aria-expanded={permMenuOpen}
                   disabled={disabled}
                   onClick={() => {
-                    if (permMenuOpen) {
-                      setPermMenuOpen(false);
+                    if (permMenu.open) {
+                      permMenu.closeMenu();
                     } else {
                       openPermissionModeMenu();
                     }
@@ -1807,44 +1771,12 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
                       <li
                         key={m.value}
                         role="option"
-                        tabIndex={i === permMenuFocusIndex ? 0 : -1}
                         data-value={m.value}
                         aria-selected={
                           m.value === (permissionMode || "default")
                         }
                         className={`permission-mode-item${m.value === (permissionMode || "default") ? " selected" : ""}`}
-                        onClick={() => handlePermissionModeSelect(m.value)}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter" || e.key === " ") {
-                            e.preventDefault();
-                            handlePermissionModeSelect(m.value);
-                            permMenuButtonRef.current?.focus();
-                          } else if (e.key === "Escape") {
-                            e.preventDefault();
-                            setPermMenuOpen(false);
-                            permMenuButtonRef.current?.focus();
-                          } else if (
-                            e.key === "ArrowDown" ||
-                            e.key === "ArrowUp"
-                          ) {
-                            // Roving focus between options (standard listbox
-                            // navigation); Enter/Space confirm the selection.
-                            e.preventDefault();
-                            const next = i + (e.key === "ArrowDown" ? 1 : -1);
-                            if (next >= 0 && next < PERMISSION_MODES.length) {
-                              setPermMenuFocusIndex(next);
-                              permMenuRef.current
-                                ?.querySelectorAll<HTMLElement>(
-                                  ".permission-mode-item",
-                                )
-                                [next]?.focus();
-                            }
-                          } else if (e.key === "Tab") {
-                            // Leave the menu without changing the mode; the
-                            // focus moves on to the next tab stop naturally.
-                            setPermMenuOpen(false);
-                          }
-                        }}
+                        {...permMenu.getItemProps(i)}
                       >
                         {m.label}
                       </li>

--- a/packages/webview/src/utils/useRovingMenu.ts
+++ b/packages/webview/src/utils/useRovingMenu.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useState } from "react";
+import type {
+  KeyboardEvent as ReactKeyboardEvent,
+  MouseEventHandler,
+  RefObject,
+} from "react";
+
+export interface RovingMenuItemProps {
+  tabIndex: number;
+  onClick: MouseEventHandler<HTMLElement>;
+  onKeyDown: (e: ReactKeyboardEvent<HTMLElement>) => void;
+}
+
+interface UseRovingMenuOptions {
+  /** CSS selector matching the menu items inside the container. */
+  itemSelector: string;
+  /** Number of menu items; bounds Arrow-key roving. */
+  itemCount: number;
+  /** Trigger button; focus returns here on Escape. */
+  triggerRef: RefObject<HTMLElement | null>;
+  /**
+   * When true (the usual case), activation also closes the menu and returns
+   * focus to the trigger button, so onActivate stays a pure side effect
+   * (post a message, run an action). Items that route focus elsewhere (like
+   * opening another popup) should instead own closing inside onActivate with
+   * this flag off.
+   */
+  closeOnActivate?: boolean;
+  /** Activates the focused item (Enter/Space/click). */
+  onActivate: (index: number) => void;
+}
+
+/**
+ * Shared keyboard model for the message-input dropdowns (roving tabindex):
+ * opening focuses an item which becomes the single tab stop, Arrow keys move
+ * between items without wrapping, Enter/Space activate via onActivate,
+ * Escape closes and returns focus to the trigger button, and Tab closes the
+ * menu letting focus move to the next tab stop naturally. Clicking outside
+ * also closes the menu.
+ */
+export function useRovingMenu(
+  containerRef: RefObject<HTMLDivElement | null>,
+  options: UseRovingMenuOptions,
+) {
+  const { itemSelector, itemCount, triggerRef, closeOnActivate, onActivate } =
+    options;
+  const [open, setOpen] = useState(false);
+  const [focusIndex, setFocusIndex] = useState(0);
+
+  const focusItem = useCallback(
+    (index: number) => {
+      setFocusIndex(index);
+      containerRef.current
+        ?.querySelectorAll<HTMLElement>(itemSelector)
+        [index]?.focus();
+    },
+    [containerRef, itemSelector],
+  );
+
+  const openMenu = useCallback(
+    (initialIndex = 0) => {
+      setOpen(true);
+      requestAnimationFrame(() => focusItem(initialIndex));
+    },
+    [focusItem],
+  );
+
+  const closeMenu = useCallback(() => setOpen(false), []);
+
+  const closeReturningFocus = useCallback(() => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  }, [triggerRef]);
+
+  // Close the menu when clicking outside of it.
+  useEffect(() => {
+    if (!open) return;
+    const onMouseDown = (e: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    return () => document.removeEventListener("mousedown", onMouseDown);
+  }, [open, containerRef]);
+
+  const getItemProps = useCallback(
+    (index: number): RovingMenuItemProps => ({
+      // Roving tabindex: the focused item is the single tab stop, the rest
+      // are removed from the tab order but stay arrow-key reachable.
+      tabIndex: index === focusIndex ? 0 : -1,
+      onClick: () => {
+        onActivate(index);
+        if (closeOnActivate) closeReturningFocus();
+      },
+      onKeyDown: (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onActivate(index);
+          if (closeOnActivate) closeReturningFocus();
+        } else if (e.key === "Escape") {
+          e.preventDefault();
+          closeReturningFocus();
+        } else if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+          e.preventDefault();
+          const next = index + (e.key === "ArrowDown" ? 1 : -1);
+          if (next >= 0 && next < itemCount) {
+            focusItem(next);
+          }
+        } else if (e.key === "Tab") {
+          // Leave the menu without activating anything; the focus moves on
+          // to the next tab stop naturally.
+          closeMenu();
+        }
+      },
+    }),
+    [
+      focusIndex,
+      onActivate,
+      itemCount,
+      closeOnActivate,
+      closeReturningFocus,
+      closeMenu,
+      focusItem,
+    ],
+  );
+
+  return { open, openMenu, closeMenu, closeReturningFocus, getItemProps };
+}

--- a/packages/webview/tests/webview/plusMenuKeyboard.test.tsx
+++ b/packages/webview/tests/webview/plusMenuKeyboard.test.tsx
@@ -3,8 +3,10 @@ import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 
 /**
  * Keyboard accessibility of the custom dropdowns in the message input:
- * items must be Tab-focusable and activatable with Enter/Space, and Escape
- * must close the menu and return focus to its trigger button.
+ * both dropdowns use roving tabindex — opening focuses an item which becomes
+ * the single tab stop, Arrow keys move between items, Enter/Space activate,
+ * Escape closes and returns focus to the trigger button, and Tab leaves the
+ * menu without activating anything.
  */
 describe("Message input dropdown keyboard accessibility", () => {
   beforeEach(() => {
@@ -19,7 +21,48 @@ describe("Message input dropdown keyboard accessibility", () => {
     fireEvent.click(screen.getByRole("button", { name: "添加" }));
   };
 
-  it("should make + menu items Tab-focusable and activate them with Enter", () => {
+  it("should open the + menu focused on its first item as the single tab stop", async () => {
+    renderChatApp();
+    openPlusMenu();
+
+    const uploadItem = screen.getByRole("menuitem", { name: "上传文件" });
+    const historyItem = screen.getByRole("menuitem", { name: "历史提示词" });
+    expect(uploadItem).toHaveProperty("tabIndex", 0);
+    expect(historyItem).toHaveProperty("tabIndex", -1);
+
+    await waitFor(() => {
+      expect(uploadItem).toBe(document.activeElement);
+    });
+  });
+
+  it("should rove focus between + menu items with Arrow keys without leaving bounds", () => {
+    renderChatApp();
+    openPlusMenu();
+
+    const uploadItem = screen.getByRole("menuitem", { name: "上传文件" });
+    const historyItem = screen.getByRole("menuitem", { name: "历史提示词" });
+    uploadItem.focus();
+
+    // Already on the first item — ArrowUp does not wrap.
+    fireEvent.keyDown(uploadItem, { key: "ArrowUp" });
+    expect(uploadItem).toBe(document.activeElement);
+
+    // ArrowDown moves focus to the next item, which becomes the tab stop.
+    fireEvent.keyDown(uploadItem, { key: "ArrowDown" });
+    expect(historyItem).toBe(document.activeElement);
+    expect(historyItem).toHaveProperty("tabIndex", 0);
+    expect(uploadItem).toHaveProperty("tabIndex", -1);
+
+    // Already on the last item — ArrowDown does not wrap.
+    fireEvent.keyDown(historyItem, { key: "ArrowDown" });
+    expect(historyItem).toBe(document.activeElement);
+
+    fireEvent.keyDown(historyItem, { key: "ArrowUp" });
+    expect(uploadItem).toBe(document.activeElement);
+    expect(uploadItem).toHaveProperty("tabIndex", 0);
+  });
+
+  it("should trigger the hidden file input when pressing Enter on 上传文件", () => {
     renderChatApp();
     // jsdom has no real file dialog; silence the hidden file input click.
     const clickSpy = vi
@@ -28,11 +71,6 @@ describe("Message input dropdown keyboard accessibility", () => {
     openPlusMenu();
 
     const uploadItem = screen.getByRole("menuitem", { name: "上传文件" });
-    const historyItem = screen.getByRole("menuitem", { name: "历史提示词" });
-    expect(uploadItem).toHaveProperty("tabIndex", 0);
-    expect(historyItem).toHaveProperty("tabIndex", 0);
-
-    // Enter activates the item and closes the menu.
     uploadItem.focus();
     fireEvent.keyDown(uploadItem, { key: "Enter" });
     expect(clickSpy).toHaveBeenCalled();
@@ -63,6 +101,21 @@ describe("Message input dropdown keyboard accessibility", () => {
     expect(document.activeElement).toBe(
       screen.getByRole("button", { name: "添加" }),
     );
+  });
+
+  it("should close the + menu with Tab without activating any item", () => {
+    renderChatApp();
+    const clickSpy = vi
+      .spyOn(HTMLInputElement.prototype, "click")
+      .mockImplementation(() => {});
+    openPlusMenu();
+
+    const uploadItem = screen.getByRole("menuitem", { name: "上传文件" });
+    uploadItem.focus();
+    fireEvent.keyDown(uploadItem, { key: "Tab" });
+
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(clickSpy).not.toHaveBeenCalled();
   });
 
   it("should make the permission menu a roving-tabindex listbox (Arrow keys + Enter)", async () => {


### PR DESCRIPTION
## 背景

消息输入栏的两个自绘下拉（左下加号菜单：上传文件/历史提示词；权限模式列表框）视觉同构，但键盘模型不一致：权限模式已是 roving tabindex + 方向键，加号菜单却只有逐项 Tab 可达。且按 ARIA APG，`role="menu"` 的键盘正字法本就要求方向键导航，原实现与自身声明的语义相悖。

## 改动

- **加号菜单改 roving**：打开即聚焦首项（原焦点留在按钮上）、↑↓ 移动（边界不回绕，与权限模式一致）、Enter/Space 激活、Escape 关闭还焦按钮、Tab 关闭自然离开
- **抽取 `useRovingMenu` hook**：收敛两个菜单各自手写的开合 state、outside-click 关闭 effect 和几乎相同的 keyDown 分支；调用方只剩 itemSelector/itemCount/triggerRef/onActivate 四行声明，MessageInput.tsx 净删约 100 行
- **行为统一一处微调**：激活后焦点一律还给触发按钮（此前部分路径落在 body——被卸载的菜单项上）
- 触发按钮补 `aria-haspopup="menu" / "listbox"`

## 验证

- plusMenuKeyboard.test.tsx 重写为 roving 语义并新增方向键 roving / 边界 / Tab 用例：9/9
- webview 全量单测 788/788、type-check、oxlint 干净
- VS Code 扩展开发宿主真机验证通过（方向键导航生效）