### PR TITLE
fix: 桌面侧边栏头部按钮相邻排布

### DIFF
--- a/packages/webview/src/components/DesktopSidebar.tsx
+++ b/packages/webview/src/components/DesktopSidebar.tsx
@@ -237,29 +237,33 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
     <div className="desktop-sidebar" data-testid="desktop-sidebar">
       <div className="desktop-sidebar-header">
         <span className="desktop-sidebar-title">Wave 代码智聊</span>
-        <Tooltip text="更多" position="bottom">
-          <button
-            className="desktop-sidebar-more-btn"
-            onClick={() => setShowMoreMenu((prev) => !prev)}
-            data-testid="desktop-more-btn"
-            aria-label="更多"
-          >
-            <MoreIcon />
-          </button>
-        </Tooltip>
-        <Tooltip text="收起侧边栏" position="bottom">
-          <button
-            className="desktop-sidebar-more-btn"
-            onClick={() => {
-              setShowMoreMenu(false);
-              onCollapsedChange(true);
-            }}
-            data-testid="desktop-sidebar-collapse"
-            aria-label="收起侧边栏"
-          >
-            <span className="codicon codicon-layout-panel-left"></span>
-          </button>
-        </Tooltip>
+        {/* The header is space-between, so both buttons must live in one
+            grouped flex row — otherwise "更多" gets pushed to the middle. */}
+        <div className="desktop-sidebar-actions">
+          <Tooltip text="更多" position="bottom">
+            <button
+              className="desktop-sidebar-more-btn"
+              onClick={() => setShowMoreMenu((prev) => !prev)}
+              data-testid="desktop-more-btn"
+              aria-label="更多"
+            >
+              <MoreIcon />
+            </button>
+          </Tooltip>
+          <Tooltip text="收起侧边栏" position="bottom">
+            <button
+              className="desktop-sidebar-more-btn"
+              onClick={() => {
+                setShowMoreMenu(false);
+                onCollapsedChange(true);
+              }}
+              data-testid="desktop-sidebar-collapse"
+              aria-label="收起侧边栏"
+            >
+              <span className="codicon codicon-layout-panel-left"></span>
+            </button>
+          </Tooltip>
+        </div>
       </div>
       {showMoreMenu && (
         <MoreMenu

--- a/packages/webview/src/styles/DesktopApp.css
+++ b/packages/webview/src/styles/DesktopApp.css
@@ -34,6 +34,14 @@
   padding: 12px 12px 4px;
 }
 
+/* Grouped header buttons (gap matches the chat header's .header-buttons) —
+   keeps them adjacent under the space-between title. */
+.desktop-sidebar-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .desktop-sidebar-more-btn {
   width: 22px;
   height: 22px;


### PR DESCRIPTION
## 问题

「收起侧边栏」按钮（PR #1962）加入后，侧边栏头部 `.desktop-sidebar-header` 的 `justify-content: space-between` 从 2 个子项变 3 个：

| 标题 | 更多 | 收起 |
|---|---|---|

space-between 把「更多」按钮推到容器中部，「更多」与「收起」之间撑出 ~100px 空白，视觉很奇怪。

## 修复

对照 ChatHeader 的正确做法（右侧按钮包在 `.header-buttons` 组内，gap 4px）：

- `DesktopSidebar.tsx`：两个按钮包进一层 `.desktop-sidebar-actions` 分组容器
- `DesktopApp.css`：新增该容器样式 `display: flex; gap: 4px`

标题靠左、按钮组整体靠右、组内间距 4px。

## 验证

- jsdom 单测：desktopApp 108/108；webview 全量 788/788
- type-check + oxlint 全绿
- 真实浏览器坐标探针：「更多」x=180、「收起」x=206，间距精确 4.0px
- 桌面端 dev 真机人工验证通过