### PR TITLE
fix(webview): 修正引用不存在的 codicon 图标名

### DIFF
--- a/packages/webview/src/components/DesktopHostSelector.tsx
+++ b/packages/webview/src/components/DesktopHostSelector.tsx
@@ -103,7 +103,7 @@ export const DesktopHostSelector: React.FC<DesktopHostSelectorProps> = ({
         tabIndex={0}
       >
         <span
-          className={`codicon ${isLocal ? "codicon-laptop" : "codicon-remote"}`}
+          className={`codicon ${isLocal ? "codicon-device-desktop" : "codicon-remote"}`}
         ></span>
         <span className="desktop-host-name">{isLocal ? "本地" : host}</span>
         <span className="codicon codicon-chevron-down desktop-host-caret"></span>
@@ -132,7 +132,7 @@ export const DesktopHostSelector: React.FC<DesktopHostSelectorProps> = ({
             }}
             data-testid="desktop-host-local"
           >
-            <span className="codicon codicon-laptop"></span>
+            <span className="codicon codicon-device-desktop"></span>
             <span>本地</span>
           </div>
           {hosts.length > 0 && (

--- a/packages/webview/src/components/FilePane.tsx
+++ b/packages/webview/src/components/FilePane.tsx
@@ -454,7 +454,7 @@ export const FilePane: React.FC<FilePaneProps> = ({
               data-testid="file-open-external"
               onClick={() => onOpenExternal(fileView.path)}
             >
-              <i className="codicon codicon-open-external" />
+              <i className="codicon codicon-link-external" />
             </button>
           )}
           <button


### PR DESCRIPTION
## 问题

桌面端文件面板的「在默认应用中打开」按钮可聚焦、hover 有高亮，但看不见任何图标（空白按钮）。

## 根因

JSX 引用了 `@vscode/codicons` 包中**不存在**的图标名。codicon 通过 `:before { content: "\ebXX" }` 字形渲染，类名不存在 → 无 content → inline 盒塌缩为空。

- `FilePane.tsx`: `codicon-open-external` 不存在（正确名：**codicon-link-external**）
- `DesktopHostSelector.tsx` 两处: `codicon-laptop` 不存在（改用真实存在的 **codicon-device-desktop**）

全库对照包内 640 个真实图标名扫描确认仅这两处错名（chevron-/modifier-spin 为动态拼接/修饰类，非错名）。

## 验证

- 浏览器加载真实打包产物 `packages/desktop/webview/index.html`：修复前按钮图标盒 0×0、无字形；修复后按钮区域像素采样 77 个亮色字形墨点、`document.fonts.check("16px codicon")=true`；错误类名对照按钮仍无字形（复现用户症状）
- 相关单测全绿（FilePane 34 + desktop selectors 120），type-check/lint/pre-commit 全绿

## 生效途径

纯 webview 层修正，随下次构建/发布进入各端。