### PR TITLE
Fix virtualized message rows butting against pane edges on narrow panes

### DIFF
--- a/packages/webview/e2e/virtual-message-list.e2e.ts
+++ b/packages/webview/e2e/virtual-message-list.e2e.ts
@@ -138,6 +138,36 @@ async function expectStickyBarEdgeToEdge(webviewPage: Page) {
 }
 
 test.describe("Virtualized message list demo", () => {
+  test("narrow pane: rows keep the container's 10px side padding (match the input)", async ({
+    webviewPage,
+  }) => {
+    // Regression guard: rows are absolutely positioned against the container's
+    // padding box, so left: 0 + width: 100% covered the container's 10px
+    // padding and butted against the pane edges whenever the pane is narrower
+    // than the 800px column (the input area keeps 10px gutters there).
+    await webviewPage.setViewportSize({ width: 480, height: 720 });
+    const injector = new MessageInjector(webviewPage);
+    await initWithMessages(injector, buildMessages(40));
+
+    await webviewPage.waitForSelector('[data-message-id="u39"]');
+    const rects = await webviewPage.evaluate(() => {
+      const c = document.getElementById("messagesContainer") as HTMLElement;
+      const row = c.querySelector<HTMLElement>(".virtual-row");
+      if (!row) return null;
+      const cr = c.getBoundingClientRect();
+      const rr = row.getBoundingClientRect();
+      return { cr, rr };
+    });
+    expect(rects).not.toBeNull();
+    if (!rects) return;
+    expect(Math.abs(rects.rr.left - (rects.cr.left + 10))).toBeLessThanOrEqual(
+      1,
+    );
+    expect(
+      Math.abs(rects.rr.right - (rects.cr.right - 10)),
+    ).toBeLessThanOrEqual(1);
+  });
+
   test("bounded DOM rows, real spacer height, scrollable, pinned to bottom", async ({
     webviewPage,
   }) => {

--- a/packages/webview/src/styles/MessageList.css
+++ b/packages/webview/src/styles/MessageList.css
@@ -135,8 +135,13 @@
 .virtual-row {
   position: absolute;
   top: 0;
-  left: 0;
-  width: 100%;
+  /* Absolute rows resolve against the container's padding box, so left: 0 +
+     width: 100% would cover the container's 10px padding and butt against
+     the pane edges whenever the pane is narrower than the 800px column.
+     Inset both sides instead so rows stay inside the padding, matching the
+     input area's 10px gutters. */
+  left: 10px;
+  right: 10px;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Problem

When the chat pane is narrower than the 800px message column, message rows butt against the pane's left/right edges, while the input area keeps 10px gutters — visually inconsistent.

## Root cause

`.virtual-row` is `position: absolute; left: 0; width: 100%`. An absolutely positioned element resolves against the nearest positioned ancestor's **padding box**, so the container `.messages-container`'s 10px padding had no effect on message rows. On wide panes the 800px max-width + centered margin produce large side gutters and the bug is invisible; on narrow panes the container spans the full pane width and the rows touch the edges.

## Fix

- `packages/webview/src/styles/MessageList.css`: inset `.virtual-row` with `left: 10px; right: 10px` (replacing `left: 0; width: 100%`) so rows stay inside the container's 10px padding, matching the input area's 10px gutters.
- The sticky user bar keeps its intentional edge-to-edge overlay (negative margins cancel the padding so the cap/scrim masks scrolling content) — unchanged.
- `packages/webview/e2e/virtual-message-list.e2e.ts`: new narrow-viewport (480px) regression test asserting rows sit 10px inside the container edges (the old behavior misses by 10px and fails).

## Verification

- Target e2e file: 5/5 passed.
- Full e2e+demo suite: 70 tests, 69 passed; 1 pre-existing flake in `desktop-update-toast.demo.ts` (opacity fade-in timing, 0.92 mid-transition) — passed on rerun, unrelated to this change.
- `pnpm run type-check` (webview) passed.