### PR TITLE
feat(webview): 桌面端弹出下拉统一 roving 方向键导航

### DIFF
--- a/packages/webview/e2e/desktop-selector-keyboard.e2e.ts
+++ b/packages/webview/e2e/desktop-selector-keyboard.e2e.ts
@@ -1,0 +1,272 @@
+import { test, expect } from "./utils/desktopTestHarness.js";
+import { MessageInjector } from "./utils/messageInjector.js";
+
+const DIR_A = "/Users/dev/projects/wave-agent";
+const DIR_B = "/Users/dev/projects/shop-server";
+const DIR_C = "/Users/dev/projects/notes-app";
+
+const initialState = {
+  messages: [],
+  isStreaming: false,
+  sessions: [],
+  isAuthenticated: true,
+  configurationData: {
+    baseURL: "https://api.anthropic.com/v1",
+    model: "claude-sonnet-4-20250514",
+    fastModel: "claude-haiku-4-20250514",
+  },
+  permissionMode: "default",
+};
+
+/**
+ * Real-browser keyboard verification for the shared roving-tabindex model of
+ * the desktop dropdowns (host / workdir / branch selectors, the sidebar more
+ * menu, and the header panel-toggle menu). jsdom tests can only simulate
+ * focus() by hand — here every keystroke is a real keyboard event and every
+ * focus assertion goes through Playwright's toBeFocused, which is what
+ * actually validates: opening auto-focuses an item, Arrow keys move real
+ * focus, Enter/Space activate the focused item, Escape closes back to the
+ * trigger, and Tab closes the menu.
+ */
+test.describe("Desktop dropdown roving keyboard", () => {
+  test("workdir menu: opens focused, arrows move, Enter selects, Escape returns to trigger", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+    await webviewPage.setViewportSize({ width: 960, height: 640 });
+
+    await injector.simulateExtensionMessage("desktopWorkdirState", {
+      workdir: DIR_A,
+      recentWorkdirs: [DIR_A, DIR_B, DIR_C],
+    });
+    await injector.waitForChatAppReady();
+    await injector.simulateExtensionMessage("setInitialState", {
+      ...initialState,
+    });
+
+    const trigger = webviewPage.getByTestId("desktop-workdir");
+    await trigger.focus();
+    await webviewPage.keyboard.press("Enter");
+    const menu = webviewPage.getByTestId("desktop-workdir-menu");
+    await expect(menu).toBeVisible();
+
+    // Opening focuses the first recent item (hook's rAF-deferred focus).
+    const recents = webviewPage.getByTestId("desktop-workdir-recent-item");
+    await expect(recents.first()).toBeFocused();
+
+    // ArrowDown moves real focus to the next recent entry.
+    await webviewPage.keyboard.press("ArrowDown");
+    await expect(recents.nth(1)).toBeFocused();
+
+    // Enter activates the focused entry: posts the selection and closes.
+    await webviewPage.keyboard.press("Enter");
+    await injector.waitForMessage("desktopSelectRecentWorkdir");
+    await expect(menu).toBeHidden();
+    await expect(trigger).toBeFocused();
+  });
+
+  test("workdir menu: Escape returns focus, Tab closes without activating", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+    await webviewPage.setViewportSize({ width: 960, height: 640 });
+
+    await injector.simulateExtensionMessage("desktopWorkdirState", {
+      workdir: DIR_A,
+      recentWorkdirs: [DIR_A, DIR_B, DIR_C],
+    });
+    await injector.waitForChatAppReady();
+    await injector.simulateExtensionMessage("setInitialState", {
+      ...initialState,
+    });
+
+    const trigger = webviewPage.getByTestId("desktop-workdir");
+    const menu = webviewPage.getByTestId("desktop-workdir-menu");
+
+    await trigger.focus();
+    await webviewPage.keyboard.press("Enter");
+    await expect(webviewPage.getByTestId("desktop-workdir-menu")).toBeVisible();
+    await expect(
+      webviewPage.getByTestId("desktop-workdir-recent-item").first(),
+    ).toBeFocused();
+
+    await webviewPage.keyboard.press("Escape");
+    await expect(menu).toBeHidden();
+    await expect(trigger).toBeFocused();
+
+    // Reopen and leave with Tab: the menu closes, nothing gets activated
+    // (no desktopSelectRecentWorkdir / desktopSelectWorkdir posted).
+    await webviewPage.keyboard.press("Enter");
+    await expect(menu).toBeVisible();
+    // Wait for the open auto-focus to land on the first item first — Tab
+    // closes the menu only from an item (from the trigger it would just move
+    // focus to the next tab stop with the menu open).
+    await expect(
+      webviewPage.getByTestId("desktop-workdir-recent-item").first(),
+    ).toBeFocused();
+    await webviewPage.keyboard.press("Tab");
+    await expect(menu).toBeHidden();
+  });
+
+  test("host menu: arrows rove over 本地/SSH hosts and Enter selects", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+    await webviewPage.setViewportSize({ width: 960, height: 640 });
+
+    await injector.simulateExtensionMessage("desktopWorkdirState", {
+      host: "prod",
+      hosts: ["prod", "stage"],
+      workdir: DIR_A,
+      recentWorkdirs: [DIR_A],
+    });
+    await injector.waitForChatAppReady();
+    await injector.simulateExtensionMessage("setInitialState", {
+      ...initialState,
+    });
+
+    const trigger = webviewPage.getByTestId("desktop-host");
+    await trigger.focus();
+    await webviewPage.keyboard.press("Enter");
+    const menu = webviewPage.getByTestId("desktop-host-menu");
+    await expect(menu).toBeVisible();
+
+    // Opens focused on 本地, then arrows walk prod → stage (no wrap below).
+    const localItem = webviewPage.getByTestId("desktop-host-local");
+    const sshItems = webviewPage.getByTestId("desktop-host-item");
+    const addItem = webviewPage.getByTestId("desktop-host-add-entry");
+    await expect(localItem).toBeFocused();
+    await webviewPage.keyboard.press("ArrowDown");
+    await expect(sshItems.first()).toBeFocused();
+    await webviewPage.keyboard.press("ArrowDown");
+    await expect(sshItems.nth(1)).toBeFocused();
+    // Next stop is the 添加主机… entry; pressing it again clamps there.
+    await webviewPage.keyboard.press("ArrowDown");
+    await expect(addItem).toBeFocused();
+    await webviewPage.keyboard.press("ArrowDown");
+    await expect(addItem).toBeFocused();
+
+    // ArrowUp back to the last SSH host; Enter selects it and closes back to
+    // the trigger.
+    await webviewPage.keyboard.press("ArrowUp");
+    await expect(sshItems.nth(1)).toBeFocused();
+    await webviewPage.keyboard.press("Enter");
+    await injector.waitForMessage("desktopSelectHost");
+    await expect(menu).toBeHidden();
+    await expect(trigger).toBeFocused();
+  });
+
+  test("branch menu: opens focused on the current branch (not necessarily first)", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+    await webviewPage.setViewportSize({ width: 960, height: 640 });
+
+    await injector.simulateExtensionMessage("desktopWorkdirState", {
+      workdir: DIR_A,
+      recentWorkdirs: [DIR_A],
+    });
+    await injector.waitForChatAppReady();
+    await injector.simulateExtensionMessage("setInitialState", {
+      ...initialState,
+    });
+
+    // The new-session page asks for the repo's branches; current is the LAST
+    // item so the auto-focus must land there, not on the first option.
+    await injector.waitForMessage("desktopListGitBranches");
+    await injector.simulateExtensionMessage("desktopGitBranches", {
+      result: {
+        branches: ["main", "feature/login", "develop"],
+        current: "develop",
+      },
+    });
+
+    const trigger = webviewPage.getByTestId("desktop-branch-selector");
+    await expect(
+      webviewPage.getByTestId("desktop-worktree-controls"),
+    ).toBeVisible();
+
+    await trigger.focus();
+    await webviewPage.keyboard.press("Enter");
+    const items = webviewPage.getByTestId("desktop-branch-item");
+    await expect(items.nth(2)).toBeFocused();
+
+    // ArrowUp walks back to feature/login; Escape closes back to the trigger.
+    await webviewPage.keyboard.press("ArrowUp");
+    await expect(items.nth(1)).toBeFocused();
+    await webviewPage.keyboard.press("Escape");
+    await expect(webviewPage.getByTestId("desktop-branch-menu")).toBeHidden();
+    await expect(trigger).toBeFocused();
+  });
+
+  test("sidebar more menu: auto-focus on open, arrows move, Escape returns", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+    await webviewPage.setViewportSize({ width: 960, height: 640 });
+
+    await injector.simulateExtensionMessage("desktopWorkdirState", {
+      workdir: DIR_A,
+      recentWorkdirs: [DIR_A],
+    });
+    await injector.waitForChatAppReady();
+    await injector.simulateExtensionMessage("setInitialState", {
+      ...initialState,
+      isAuthenticated: true,
+    });
+
+    const trigger = webviewPage.getByTestId("desktop-more-btn");
+    await trigger.click();
+    const menu = webviewPage.getByTestId("more-menu");
+    await expect(menu).toBeVisible();
+
+    // Controlled menu mounts already open: the first item gets real focus.
+    const settings = webviewPage.getByTestId("more-menu-settings");
+    await expect(settings).toBeFocused();
+
+    await webviewPage.keyboard.press("ArrowDown");
+    await expect(webviewPage.getByTestId("more-menu-enterprise")).toBeFocused();
+
+    await webviewPage.keyboard.press("Escape");
+    await expect(menu).toBeHidden();
+    await expect(trigger).toBeFocused();
+  });
+
+  test("panel toggle menu: Space toggles without closing, arrows move, Escape returns", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+    await webviewPage.setViewportSize({ width: 960, height: 640 });
+
+    await injector.simulateExtensionMessage("desktopWorkdirState", {
+      workdir: DIR_A,
+      recentWorkdirs: [DIR_A],
+    });
+    await injector.waitForChatAppReady();
+    await injector.simulateExtensionMessage("setInitialState", {
+      ...initialState,
+    });
+
+    const trigger = webviewPage.getByTestId("panel-toggle-btn");
+    await trigger.click();
+    const menu = webviewPage.getByTestId("panel-toggle-menu");
+    await expect(menu).toBeVisible();
+
+    // Opening focuses the first item (预览); Space checks it WITHOUT closing
+    // (multi-select menu) and posts the toggle.
+    const preview = webviewPage.getByTestId("panel-toggle-item-preview");
+    await expect(preview).toBeFocused();
+    await webviewPage.keyboard.press(" ");
+    await expect(preview).toHaveAttribute("aria-checked", "true");
+    await expect(menu).toBeVisible();
+
+    await webviewPage.keyboard.press("ArrowDown");
+    await expect(
+      webviewPage.getByTestId("panel-toggle-item-plan"),
+    ).toBeFocused();
+
+    await webviewPage.keyboard.press("Escape");
+    await expect(menu).toBeHidden();
+    await expect(trigger).toBeFocused();
+  });
+});

--- a/packages/webview/src/components/ChatHeader.tsx
+++ b/packages/webview/src/components/ChatHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { Tooltip } from "./Tooltip";
 import { NewSessionIcon, HistoryIcon, MoreIcon } from "./HeaderIcons";
 import { SessionListPopup } from "./SessionListPopup";
@@ -29,6 +29,9 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
   const [showSessionList, setShowSessionList] = useState(false);
   const [showMoreMenu, setShowMoreMenu] = useState(false);
   const [showPanelMenu, setShowPanelMenu] = useState(false);
+  // Menu triggers; the popups return focus here on Escape / item activation.
+  const moreBtnRef = useRef<HTMLButtonElement>(null);
+  const panelBtnRef = useRef<HTMLButtonElement>(null);
 
   const title = getSessionTitle(currentSession, messages);
 
@@ -65,10 +68,13 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
         {!hideMoreButton && (
           <Tooltip text="更多" position="bottom">
             <button
+              ref={moreBtnRef}
               className="header-button"
               onClick={() => setShowMoreMenu((prev) => !prev)}
               data-testid="more-btn"
               aria-label="更多"
+              aria-haspopup="menu"
+              aria-expanded={showMoreMenu}
             >
               <MoreIcon />
             </button>
@@ -77,10 +83,13 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
         {panelToggle && (
           <Tooltip text="面板" position="bottom">
             <button
+              ref={panelBtnRef}
               className="header-button header-panel-toggle"
               onClick={() => setShowPanelMenu((prev) => !prev)}
               data-testid="panel-toggle-btn"
               aria-label="面板"
+              aria-haspopup="menu"
+              aria-expanded={showPanelMenu}
             >
               <i className="codicon codicon-layout-sidebar-right" />
               <i className="codicon codicon-chevron-down header-panel-toggle-caret" />
@@ -105,6 +114,7 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
           onLogout={onLogout}
           isAuthenticated={isAuthenticated}
           onClose={() => setShowMoreMenu(false)}
+          triggerRef={moreBtnRef}
         />
       )}
       {showPanelMenu && panelToggle && (
@@ -113,6 +123,7 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
           onToggle={panelToggle.onToggle}
           disabled={panelToggle.disabled}
           onClose={() => setShowPanelMenu(false)}
+          triggerRef={panelBtnRef}
         />
       )}
     </div>

--- a/packages/webview/src/components/DesktopHostSelector.tsx
+++ b/packages/webview/src/components/DesktopHostSelector.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
+import { useRovingMenu } from "../utils/useRovingMenu";
 import "../styles/DesktopApp.css";
 
 export interface DesktopHostSelectorProps {
@@ -23,6 +24,7 @@ export interface DesktopHostSelectorProps {
  * Same dropdown pattern as DesktopWorkdirSelector: relative container, trigger,
  * absolutely-positioned menu expanding UPWARD (bottom:100%) — the input sits at
  * the bottom of the viewport and a native <select> popup would be clipped.
+ * Keyboard model shared too: roving tabindex + Arrow keys via useRovingMenu.
  */
 export const DesktopHostSelector: React.FC<DesktopHostSelectorProps> = ({
   host,
@@ -30,34 +32,40 @@ export const DesktopHostSelector: React.FC<DesktopHostSelectorProps> = ({
   onSelectHost,
   onAddHost,
 }) => {
-  const [menuOpen, setMenuOpen] = useState(false);
   const [adding, setAdding] = useState(false);
   const [connectionString, setConnectionString] = useState("");
   const menuRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const triggerRef = useRef<HTMLDivElement>(null);
 
-  // Close the dropdown when clicking outside of it.
-  useEffect(() => {
-    if (!menuOpen) return;
-    const onMouseDown = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenuOpen(false);
-        setAdding(false);
-      }
-    };
-    document.addEventListener("mousedown", onMouseDown);
-    return () => document.removeEventListener("mousedown", onMouseDown);
-  }, [menuOpen]);
+  // Selectable SSH host entries; some mount paths render before the host
+  // list arrives (undefined), so default here rather than only in the menu.
+  const sshHosts = hosts ?? [];
 
-  const handleSelect = useCallback(
+  // 添加主机… expands inline with the menu staying open — selection branches
+  // close explicitly (closeOnActivate stays off).
+  const { open, openMenu, closeReturningFocus, getItemProps } = useRovingMenu(
+    menuRef,
+    {
+      itemSelector: ".desktop-workdir-menu-item",
+      itemCount: sshHosts.length + (adding ? 1 : 2),
+      triggerRef,
+      closeOnActivate: false,
+      onActivate: (i) => {
+        if (i === 0) selectHost("local");
+        else if (i <= sshHosts.length) selectHost(sshHosts[i - 1]);
+        else openAdd();
+      },
+    },
+  );
+
+  const selectHost = useCallback(
     (h: string) => {
-      setMenuOpen(false);
       setAdding(false);
       if (h !== host) onSelectHost(h);
-      triggerRef.current?.focus();
+      closeReturningFocus();
     },
-    [host, onSelectHost],
+    [host, onSelectHost, closeReturningFocus],
   );
 
   const openAdd = useCallback(() => {
@@ -71,12 +79,17 @@ export const DesktopHostSelector: React.FC<DesktopHostSelectorProps> = ({
   const submitAdd = useCallback(() => {
     const s = connectionString.trim();
     if (!s) return;
-    setMenuOpen(false);
     setAdding(false);
     setConnectionString("");
     onAddHost(s);
-    triggerRef.current?.focus();
-  }, [connectionString, onAddHost]);
+    closeReturningFocus();
+  }, [connectionString, onAddHost, closeReturningFocus]);
+
+  // Leaving the menu (any close path, including click-outside in the hook)
+  // also collapses an in-progress add-host input.
+  useEffect(() => {
+    if (!open && adding) setAdding(false);
+  }, [open, adding]);
 
   const isLocal = host === "local";
 
@@ -85,19 +98,22 @@ export const DesktopHostSelector: React.FC<DesktopHostSelectorProps> = ({
       <div
         className="desktop-host-trigger"
         ref={triggerRef}
-        onClick={() => setMenuOpen((o) => !o)}
+        onClick={() => {
+          if (open) closeReturningFocus();
+          else openMenu();
+        }}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
-            setMenuOpen((o) => !o);
-          } else if (e.key === "Escape" && menuOpen) {
+            openMenu();
+          } else if (e.key === "Escape" && open) {
             e.preventDefault();
-            setMenuOpen(false);
+            closeReturningFocus();
           }
         }}
         title={isLocal ? "本地" : host}
         data-testid="desktop-host"
-        aria-expanded={menuOpen}
+        aria-expanded={open}
         aria-haspopup="listbox"
         role="button"
         tabIndex={0}
@@ -108,7 +124,7 @@ export const DesktopHostSelector: React.FC<DesktopHostSelectorProps> = ({
         <span className="desktop-host-name">{isLocal ? "本地" : host}</span>
         <span className="codicon codicon-chevron-down desktop-host-caret"></span>
       </div>
-      {menuOpen && (
+      {open && (
         <div
           className="desktop-workdir-menu"
           role="listbox"
@@ -117,45 +133,23 @@ export const DesktopHostSelector: React.FC<DesktopHostSelectorProps> = ({
           <div
             className="desktop-workdir-menu-item"
             role="option"
-            tabIndex={0}
-            onClick={() => handleSelect("local")}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                handleSelect("local");
-              } else if (e.key === "Escape") {
-                e.preventDefault();
-                setMenuOpen(false);
-                setAdding(false);
-                triggerRef.current?.focus();
-              }
-            }}
+            aria-selected={isLocal}
+            {...getItemProps(0)}
             data-testid="desktop-host-local"
           >
             <span className="codicon codicon-device-desktop"></span>
             <span>本地</span>
           </div>
-          {hosts.length > 0 && (
+          {sshHosts.length > 0 && (
             <div className="desktop-workdir-menu-label">SSH 主机</div>
           )}
-          {hosts.map((h) => (
+          {sshHosts.map((h, i) => (
             <div
               key={h}
               className="desktop-workdir-menu-item"
               role="option"
-              tabIndex={0}
-              onClick={() => handleSelect(h)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  handleSelect(h);
-                } else if (e.key === "Escape") {
-                  e.preventDefault();
-                  setMenuOpen(false);
-                  setAdding(false);
-                  triggerRef.current?.focus();
-                }
-              }}
+              aria-selected={h === host}
+              {...getItemProps(i + 1)}
               title={h}
               data-testid="desktop-host-item"
             >
@@ -176,7 +170,7 @@ export const DesktopHostSelector: React.FC<DesktopHostSelectorProps> = ({
                   if (e.key === "Enter") submitAdd();
                   else if (e.key === "Escape") {
                     setAdding(false);
-                    triggerRef.current?.focus();
+                    closeReturningFocus();
                   }
                 }}
               />
@@ -185,19 +179,8 @@ export const DesktopHostSelector: React.FC<DesktopHostSelectorProps> = ({
             <div
               className="desktop-workdir-menu-item"
               role="option"
-              tabIndex={0}
-              onClick={openAdd}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  openAdd();
-                } else if (e.key === "Escape") {
-                  e.preventDefault();
-                  setMenuOpen(false);
-                  setAdding(false);
-                  triggerRef.current?.focus();
-                }
-              }}
+              aria-selected={false}
+              {...getItemProps(sshHosts.length + 1)}
               data-testid="desktop-host-add-entry"
             >
               <span className="codicon codicon-add"></span>

--- a/packages/webview/src/components/DesktopSidebar.tsx
+++ b/packages/webview/src/components/DesktopSidebar.tsx
@@ -112,6 +112,8 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
     return anchor;
   };
   const newChatAnchorRef = useRef<HTMLButtonElement | null>(null);
+  // 更多 trigger; the menu returns focus here on Escape / item activation.
+  const moreBtnRef = useRef<HTMLButtonElement>(null);
 
   const isExpanded = (group: DesktopSessionGroup): boolean =>
     overrides[groupKey(group)] ?? true;
@@ -242,10 +244,13 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
         <div className="desktop-sidebar-actions">
           <Tooltip text="更多" position="bottom">
             <button
+              ref={moreBtnRef}
               className="desktop-sidebar-more-btn"
               onClick={() => setShowMoreMenu((prev) => !prev)}
               data-testid="desktop-more-btn"
               aria-label="更多"
+              aria-haspopup="menu"
+              aria-expanded={showMoreMenu}
             >
               <MoreIcon />
             </button>
@@ -276,6 +281,7 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
           // subject, so its 登录/退出登录 entry stays unlabeled.
           hostLabel={hostLabel === "local" ? undefined : hostLabel}
           onClose={() => setShowMoreMenu(false)}
+          triggerRef={moreBtnRef}
         />
       )}
       <Tooltip

--- a/packages/webview/src/components/DesktopWorkdirSelector.tsx
+++ b/packages/webview/src/components/DesktopWorkdirSelector.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
+import { useRovingMenu } from "../utils/useRovingMenu";
 import "../styles/DesktopApp.css";
 
 export interface DesktopWorkdirSelectorProps {
@@ -61,7 +62,6 @@ export const DesktopWorkdirSelector: React.FC<DesktopWorkdirSelectorProps> = ({
   onSelectRecentWorkdir,
   onRemoveRecentWorkdir,
 }) => {
-  const [menuOpen, setMenuOpen] = useState(false);
   const [browsing, setBrowsing] = useState(false);
   const [currentPath, setCurrentPath] = useState("~");
   const [filterKeyword, setFilterKeyword] = useState("");
@@ -77,19 +77,48 @@ export const DesktopWorkdirSelector: React.FC<DesktopWorkdirSelectorProps> = ({
   const requestIdRef = useRef(0);
   const lastPathRef = useRef("~");
   const isRemote = host !== undefined && host !== "local";
+  // Some mount paths render before the recents list arrives (undefined), so
+  // default here rather than only inside the menu JSX.
+  const recents = recentWorkdirs ?? [];
 
-  // Close the dropdown / browser when clicking outside of it.
+  // The recents menu runs the shared roving-tabindex keyboard model (Arrow
+  // keys move the focused item). Item order: 最近打开 entries, then 浏览….
+  // Activation closes explicitly per branch (remote 浏览… opens the browser
+  // panel instead of returning focus), so closeOnActivate stays off.
+  const {
+    open: menuOpen,
+    openMenu,
+    closeMenu,
+    closeReturningFocus,
+    getItemProps,
+  } = useRovingMenu(menuRef, {
+    itemSelector: ".desktop-workdir-menu-item",
+    itemCount: recents.length + 1,
+    triggerRef,
+    closeOnActivate: false,
+    onActivate: (i) => {
+      if (i < recents.length) {
+        handleSelectRecent(recents[i]);
+      } else if (isRemote) {
+        openBrowser();
+      } else {
+        handleBrowse();
+      }
+    },
+  });
+
+  // Only the remote browser owns click-outside here — closing the main menu
+  // on outside clicks is handled inside useRovingMenu.
   useEffect(() => {
-    if (!menuOpen && !browsing) return;
+    if (!browsing) return;
     const onMouseDown = (e: MouseEvent) => {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenuOpen(false);
         setBrowsing(false);
       }
     };
     document.addEventListener("mousedown", onMouseDown);
     return () => document.removeEventListener("mousedown", onMouseDown);
-  }, [menuOpen, browsing]);
+  }, [browsing]);
 
   const dirName = workdir
     ? workdir.split(/[\\/]/).filter(Boolean).pop() || workdir
@@ -134,19 +163,18 @@ export const DesktopWorkdirSelector: React.FC<DesktopWorkdirSelectorProps> = ({
   }, [browsing]);
 
   const handleBrowse = useCallback(() => {
-    setMenuOpen(false);
     onSelectWorkdir();
-    triggerRef.current?.focus();
-  }, [onSelectWorkdir]);
+    closeReturningFocus();
+  }, [onSelectWorkdir, closeReturningFocus]);
 
   const openBrowser = useCallback(() => {
-    setMenuOpen(false);
+    closeMenu();
     setBrowsing(true);
     // Location memory: reopen at the last visited directory (or home on the
     // first open of a session), spec scenario 22.
     requestList(lastPathRef.current || "~");
     requestAnimationFrame(() => filterInputRef.current?.focus());
-  }, [requestList]);
+  }, [closeMenu, requestList]);
 
   const selectCurrent = useCallback(() => {
     if (!currentPath || loading || error) return;
@@ -169,11 +197,10 @@ export const DesktopWorkdirSelector: React.FC<DesktopWorkdirSelectorProps> = ({
 
   const handleSelectRecent = useCallback(
     (path: string) => {
-      setMenuOpen(false);
       onSelectRecentWorkdir(path, host);
-      triggerRef.current?.focus();
+      closeReturningFocus();
     },
-    [host, onSelectRecentWorkdir],
+    [host, onSelectRecentWorkdir, closeReturningFocus],
   );
 
   const handleRemoveRecent = useCallback(
@@ -243,14 +270,17 @@ export const DesktopWorkdirSelector: React.FC<DesktopWorkdirSelectorProps> = ({
       <div
         className="desktop-workdir-trigger"
         ref={triggerRef}
-        onClick={() => setMenuOpen((o) => !o)}
+        onClick={() => {
+          if (menuOpen) closeReturningFocus();
+          else openMenu();
+        }}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
-            setMenuOpen((o) => !o);
+            openMenu();
           } else if (e.key === "Escape" && menuOpen) {
             e.preventDefault();
-            setMenuOpen(false);
+            closeReturningFocus();
           }
         }}
         title={workdir ?? (isRemote ? "选择远程目录…" : "选择工作目录…")}
@@ -270,10 +300,10 @@ export const DesktopWorkdirSelector: React.FC<DesktopWorkdirSelectorProps> = ({
           role="listbox"
           data-testid="desktop-workdir-menu"
         >
-          {recentWorkdirs.length > 0 && (
+          {recents.length > 0 && (
             <div className="desktop-workdir-menu-label">最近打开</div>
           )}
-          {recentWorkdirs.map((dir) => {
+          {recents.map((dir, i) => {
             // VS Code-style two-line entry: basename on top, parent path
             // below in de-emphasized text (keeps long paths readable and
             // disambiguates same-named folders).
@@ -282,25 +312,18 @@ export const DesktopWorkdirSelector: React.FC<DesktopWorkdirSelectorProps> = ({
             const parent = dir
               .slice(0, dir.length - base.length)
               .replace(/[\\/]+$/, "");
+            // Nested remove button owns its own keys — the row's roving key
+            // handling must ignore events bubbling up from it.
+            const itemProps = getItemProps(i);
             return (
               <div
                 key={dir}
                 className="desktop-workdir-menu-item"
                 role="option"
-                tabIndex={0}
-                onClick={() => handleSelectRecent(dir)}
+                {...itemProps}
                 onKeyDown={(e) => {
-                  // Let the nested remove button handle its own keys.
                   if (e.target !== e.currentTarget) return;
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    handleSelectRecent(dir);
-                  } else if (e.key === "Escape") {
-                    e.preventDefault();
-                    setMenuOpen(false);
-                    setBrowsing(false);
-                    triggerRef.current?.focus();
-                  }
+                  itemProps.onKeyDown(e);
                 }}
                 title={dir}
                 data-testid="desktop-workdir-recent-item"
@@ -329,20 +352,7 @@ export const DesktopWorkdirSelector: React.FC<DesktopWorkdirSelectorProps> = ({
           <div
             className="desktop-workdir-menu-item"
             role="option"
-            tabIndex={0}
-            onClick={isRemote ? openBrowser : handleBrowse}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                if (isRemote) openBrowser();
-                else handleBrowse();
-              } else if (e.key === "Escape") {
-                e.preventDefault();
-                setMenuOpen(false);
-                setBrowsing(false);
-                triggerRef.current?.focus();
-              }
-            }}
+            {...getItemProps(recents.length)}
             data-testid="desktop-workdir-browse"
           >
             <span className="codicon codicon-folder-opened"></span>

--- a/packages/webview/src/components/DesktopWorktreeControls.tsx
+++ b/packages/webview/src/components/DesktopWorktreeControls.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import React, { useRef } from "react";
+import { useRovingMenu } from "../utils/useRovingMenu";
 import "../styles/DesktopApp.css";
 
 export interface DesktopWorktreeControlsProps {
@@ -19,7 +20,8 @@ export interface DesktopWorktreeControlsProps {
  * Branch selector + worktree checkbox shown next to the workdir selector on
  * the new-session page (FR-022/FR-023). Only rendered when the current workdir
  * is a git repo. Same dropdown pattern as DesktopWorkdirSelector: relative
- * container, menu expands upward, click-outside closes.
+ * container, menu expands upward, click-outside closes. Keyboard: roving
+ * tabindex + Arrow keys via useRovingMenu; opening focuses the current branch.
  */
 export const DesktopWorktreeControls: React.FC<
   DesktopWorktreeControlsProps
@@ -32,28 +34,22 @@ export const DesktopWorktreeControls: React.FC<
   onBranchChange,
   onWorktreeChange,
 }) => {
-  const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!menuOpen) return;
-    const onMouseDown = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenuOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", onMouseDown);
-    return () => document.removeEventListener("mousedown", onMouseDown);
-  }, [menuOpen]);
+  // Opening focuses the currently selected branch (permission-mode dropdown
+  // precedent), so Enter re-confirms it and Arrow keys move from there.
+  const selectedBranchIndex = Math.max(0, branches.indexOf(branch));
 
-  const handleSelectBranch = useCallback(
-    (b: string) => {
-      setMenuOpen(false);
-      onBranchChange(b);
-      triggerRef.current?.focus();
+  const { open, openMenu, closeReturningFocus, getItemProps } = useRovingMenu(
+    menuRef,
+    {
+      itemSelector: ".desktop-workdir-menu-item",
+      itemCount: branches.length,
+      triggerRef,
+      closeOnActivate: true,
+      onActivate: (i) => onBranchChange(branches[i]),
     },
-    [onBranchChange],
   );
 
   return (
@@ -65,23 +61,30 @@ export const DesktopWorktreeControls: React.FC<
         <div
           className="desktop-workdir-trigger"
           ref={triggerRef}
-          onClick={loading ? undefined : () => setMenuOpen((o) => !o)}
+          onClick={
+            loading
+              ? undefined
+              : () => {
+                  if (open) closeReturningFocus();
+                  else openMenu(selectedBranchIndex);
+                }
+          }
           onKeyDown={
             loading
               ? undefined
               : (e) => {
                   if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
-                    setMenuOpen((o) => !o);
-                  } else if (e.key === "Escape" && menuOpen) {
+                    openMenu(selectedBranchIndex);
+                  } else if (e.key === "Escape" && open) {
                     e.preventDefault();
-                    setMenuOpen(false);
+                    closeReturningFocus();
                   }
                 }
           }
           title={loading ? "分支获取中…" : `基准分支：${branch}`}
           data-testid="desktop-branch-selector"
-          aria-expanded={menuOpen}
+          aria-expanded={open}
           aria-haspopup="listbox"
           role="button"
           tabIndex={loading ? -1 : 0}
@@ -96,29 +99,19 @@ export const DesktopWorktreeControls: React.FC<
           )}
           <span className="codicon codicon-chevron-down desktop-workdir-caret"></span>
         </div>
-        {menuOpen && (
+        {open && (
           <div
             className="desktop-workdir-menu"
             role="listbox"
             data-testid="desktop-branch-menu"
           >
-            {branches.map((b) => (
+            {branches.map((b, i) => (
               <div
                 key={b}
                 className={`desktop-workdir-menu-item${b === branch ? " desktop-branch-active" : ""}`}
                 role="option"
-                tabIndex={0}
-                onClick={() => handleSelectBranch(b)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    handleSelectBranch(b);
-                  } else if (e.key === "Escape") {
-                    e.preventDefault();
-                    setMenuOpen(false);
-                    triggerRef.current?.focus();
-                  }
-                }}
+                aria-selected={b === branch}
+                {...getItemProps(i)}
                 title={b}
                 data-testid="desktop-branch-item"
               >

--- a/packages/webview/src/components/MoreMenu.tsx
+++ b/packages/webview/src/components/MoreMenu.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useRef } from "react";
+import type { RefObject } from "react";
+import { useRovingMenu } from "../utils/useRovingMenu";
 import { ExternalLinkIcon } from "./HeaderIcons";
 import "../styles/MoreMenu.css";
 
@@ -16,6 +18,11 @@ interface MoreMenuProps {
    * case the entry shows no annotation.
    */
   hostLabel?: string;
+  /**
+   * Trigger button (更多 in the header); Escape and item activation return
+   * focus here.
+   */
+  triggerRef?: RefObject<HTMLElement | null>;
 }
 
 export const MoreMenu: React.FC<MoreMenuProps> = ({
@@ -26,10 +33,61 @@ export const MoreMenu: React.FC<MoreMenuProps> = ({
   onClose,
   isAuthenticated,
   hostLabel,
+  triggerRef,
 }) => {
   const menuRef = useRef<HTMLDivElement>(null);
 
-  // Click outside + Escape to close
+  // Roving keyboard model shared with the other custom dropdowns: Arrow keys
+  // move, Enter/Space activate, Escape closes back to the trigger. The hook
+  // calls onRequestClose for the in-menu close paths; this component keeps
+  // its own click-outside / global-Escape listeners (see below).
+  const { getItemProps } = useRovingMenu(menuRef, {
+    itemSelector: ".more-menu-item",
+    itemCount: 3,
+    triggerRef,
+    closeOnActivate: true,
+    onRequestClose: onClose,
+    onActivate: (i) => entries[i].run(),
+  });
+
+  const handleSettings = () => onOpenSettings();
+  const handleEnterprise = () => onOpenEnterpriseConsole();
+  const authLabelSuffix = hostLabel ? `（${hostLabel}）` : "";
+
+  // Entry order matches focus order; the third slot is 登录/退出登录 by auth.
+  // 设置 and 登录/退出登录 name the subject host they act on; 企业控制台 stays global.
+  const entries = [
+    {
+      id: "more-menu-settings",
+      run: handleSettings,
+      content: <span>设置{authLabelSuffix}</span>,
+    },
+    {
+      id: "more-menu-enterprise",
+      className: "more-menu-item--between",
+      run: handleEnterprise,
+      content: (
+        <>
+          <span>企业控制台</span>
+          <ExternalLinkIcon className="more-menu-item-icon" />
+        </>
+      ),
+    },
+    isAuthenticated
+      ? {
+          id: "more-menu-logout",
+          run: onLogout,
+          content: <span>退出登录{authLabelSuffix}</span>,
+        }
+      : {
+          id: "more-menu-login",
+          run: onLogin,
+          content: <span>登录{authLabelSuffix}</span>,
+        },
+  ];
+
+  // Click-outside + global Escape fallback (the hook only handles Escape from
+  // a focused item). Focus returns to the trigger on those in-menu paths.
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
@@ -49,104 +107,19 @@ export const MoreMenu: React.FC<MoreMenuProps> = ({
     };
   }, [onClose]);
 
-  const handleSettings = () => {
-    onOpenSettings();
-    onClose();
-  };
-
-  const handleEnterprise = () => {
-    onOpenEnterpriseConsole();
-    onClose();
-  };
-
-  const handleLogout = () => {
-    onLogout();
-    onClose();
-  };
-
-  const handleLogin = () => {
-    onLogin();
-    onClose();
-  };
-
   return (
     <div ref={menuRef} className="more-menu" data-testid="more-menu">
-      <div
-        className="more-menu-item"
-        role="menuitem"
-        tabIndex={0}
-        onClick={handleSettings}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            handleSettings();
-          } else if (e.key === "Escape") {
-            e.preventDefault();
-            onClose();
-          }
-        }}
-        data-testid="more-menu-settings"
-      >
-        设置{hostLabel ? `（${hostLabel}）` : ""}
-      </div>
-      <div
-        className="more-menu-item more-menu-item--between"
-        role="menuitem"
-        tabIndex={0}
-        onClick={handleEnterprise}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            handleEnterprise();
-          } else if (e.key === "Escape") {
-            e.preventDefault();
-            onClose();
-          }
-        }}
-        data-testid="more-menu-enterprise"
-      >
-        <span>企业控制台</span>
-        <ExternalLinkIcon className="more-menu-item-icon" />
-      </div>
-      {isAuthenticated ? (
+      {entries.map((entry, i) => (
         <div
-          className="more-menu-item"
+          key={entry.id}
+          {...getItemProps(i)}
+          className={`more-menu-item${entry.className ? ` ${entry.className}` : ""}`}
           role="menuitem"
-          tabIndex={0}
-          onClick={handleLogout}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              handleLogout();
-            } else if (e.key === "Escape") {
-              e.preventDefault();
-              onClose();
-            }
-          }}
-          data-testid="more-menu-logout"
+          data-testid={entry.id}
         >
-          退出登录{hostLabel ? `（${hostLabel}）` : ""}
+          {entry.content}
         </div>
-      ) : (
-        <div
-          className="more-menu-item"
-          role="menuitem"
-          tabIndex={0}
-          onClick={handleLogin}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              handleLogin();
-            } else if (e.key === "Escape") {
-              e.preventDefault();
-              onClose();
-            }
-          }}
-          data-testid="more-menu-login"
-        >
-          登录{hostLabel ? `（${hostLabel}）` : ""}
-        </div>
-      )}
+      ))}
     </div>
   );
 };

--- a/packages/webview/src/components/PanelToggleMenu.tsx
+++ b/packages/webview/src/components/PanelToggleMenu.tsx
@@ -1,9 +1,13 @@
 import React, { useEffect, useRef } from "react";
+import type { RefObject } from "react";
+import { useRovingMenu } from "../utils/useRovingMenu";
 import type { DesktopPanelKind, PanelToggleProps } from "../types";
 import "../styles/PanelToggleMenu.css";
 
 interface PanelToggleMenuProps extends PanelToggleProps {
   onClose: () => void;
+  /** Trigger button (面板 in the header); Escape returns focus here. */
+  triggerRef?: RefObject<HTMLElement | null>;
 }
 
 const isMac =
@@ -29,15 +33,35 @@ const PANEL_ITEMS: Array<{
  * Desktop header panel-toggle dropdown: multi-select checkboxes for the
  * conversation-level side panels. Clicking an item toggles it WITHOUT closing
  * the menu (consecutive multi-select); click-outside / Esc closes.
+ *
+ * Keyboard: roving tabindex + Arrow keys via useRovingMenu. Disabled items
+ * stay arrow-key reachable (perceivable) but activation is a no-op.
  */
 export const PanelToggleMenu: React.FC<PanelToggleMenuProps> = ({
   checked,
   onToggle,
   disabled = [],
   onClose,
+  triggerRef,
 }) => {
   const menuRef = useRef<HTMLDivElement>(null);
 
+  // Roving keyboard model shared with the other custom dropdowns; toggling
+  // keeps the menu open (closeOnActivate off), Escape returns to the trigger.
+  const { getItemProps } = useRovingMenu(menuRef, {
+    itemSelector: ".panel-toggle-menu-item",
+    itemCount: PANEL_ITEMS.length,
+    triggerRef,
+    closeOnActivate: false,
+    onRequestClose: onClose,
+    onActivate: (i) => {
+      const kind = PANEL_ITEMS[i].kind;
+      if (!disabled.includes(kind)) onToggle(kind);
+    },
+  });
+
+  // Click-outside + global Escape fallback (the hook only handles Escape from
+  // a focused item).
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
@@ -63,31 +87,17 @@ export const PanelToggleMenu: React.FC<PanelToggleMenuProps> = ({
       className="panel-toggle-menu"
       data-testid="panel-toggle-menu"
     >
-      {PANEL_ITEMS.map(({ kind, label, shortcut }) => {
+      {PANEL_ITEMS.map(({ kind, label, shortcut }, i) => {
         const isChecked = checked.includes(kind);
         const isDisabled = disabled.includes(kind);
         return (
           <div
             key={kind}
+            {...getItemProps(i)}
             className={`panel-toggle-menu-item${isDisabled ? " panel-toggle-menu-item--disabled" : ""}`}
-            onClick={isDisabled ? undefined : () => onToggle(kind)}
-            onKeyDown={
-              isDisabled
-                ? undefined
-                : (e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      onToggle(kind);
-                    } else if (e.key === "Escape") {
-                      e.preventDefault();
-                      onClose();
-                    }
-                  }
-            }
             role="checkbox"
             aria-checked={isChecked}
             aria-disabled={isDisabled}
-            tabIndex={isDisabled ? -1 : 0}
             data-testid={`panel-toggle-item-${kind}`}
           >
             <i

--- a/packages/webview/src/utils/useRovingMenu.ts
+++ b/packages/webview/src/utils/useRovingMenu.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type {
   KeyboardEvent as ReactKeyboardEvent,
   MouseEventHandler,
@@ -16,8 +16,8 @@ interface UseRovingMenuOptions {
   itemSelector: string;
   /** Number of menu items; bounds Arrow-key roving. */
   itemCount: number;
-  /** Trigger button; focus returns here on Escape. */
-  triggerRef: RefObject<HTMLElement | null>;
+  /** Trigger button; focus returns here on Escape / activation-close. */
+  triggerRef?: RefObject<HTMLElement | null>;
   /**
    * When true (the usual case), activation also closes the menu and returns
    * focus to the trigger button, so onActivate stays a pure side effect
@@ -28,64 +28,110 @@ interface UseRovingMenuOptions {
   closeOnActivate?: boolean;
   /** Activates the focused item (Enter/Space/click). */
   onActivate: (index: number) => void;
+  /**
+   * Controlled menus (parent owns rendering and mounts the menu already
+   * open — MoreMenu, PanelToggleMenu): in-menu close paths (activation with
+   * closeOnActivate, Escape, Tab) call this instead of flipping an internal
+   * flag. Click-outside and global Escape stay owned by the parent, which
+   * already has its own listeners for those.
+   */
+  onRequestClose?: () => void;
 }
 
 /**
- * Shared keyboard model for the message-input dropdowns (roving tabindex):
- * opening focuses an item which becomes the single tab stop, Arrow keys move
- * between items without wrapping, Enter/Space activate via onActivate,
- * Escape closes and returns focus to the trigger button, and Tab closes the
- * menu letting focus move to the next tab stop naturally. Clicking outside
- * also closes the menu.
+ * Shared keyboard model for custom dropdowns (roving tabindex): opening
+ * focuses an item which becomes the single tab stop, Arrow keys move between
+ * items without wrapping, Enter/Space activate via onActivate, Escape closes
+ * and returns focus to the trigger button, and Tab closes the menu letting
+ * focus move to the next tab stop naturally.
+ *
+ * Uncontrolled instances manage their own open flag (opened via openMenu,
+ * closed on click-outside); controlled instances (onRequestClose) mount
+ * already open and auto-focus their initial item.
  */
 export function useRovingMenu(
   containerRef: RefObject<HTMLDivElement | null>,
   options: UseRovingMenuOptions,
 ) {
-  const { itemSelector, itemCount, triggerRef, closeOnActivate, onActivate } =
-    options;
+  const { itemCount, closeOnActivate, onActivate } = options;
+
+  // Effects and event handlers read callbacks/options through a ref so the
+  // hook does not re-subscribe or rebuild closures when callers pass inline
+  // arrow functions (which are new on every render).
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  // Focus target for the open effect: set by openMenu (uncontrolled) or left
+  // at 0 (controlled menus mount already open and focus their first item).
+  const pendingFocusRef = useRef(0);
+
   const [open, setOpen] = useState(false);
   const [focusIndex, setFocusIndex] = useState(0);
 
+  // Controlled instances have no internal open lifecycle — they exist only
+  // while the parent renders them.
+  const isOpen = open || options.onRequestClose !== undefined;
+
+  const requestClose = useCallback(() => {
+    if (optionsRef.current.onRequestClose) optionsRef.current.onRequestClose();
+    else setOpen(false);
+  }, []);
+
+  // Roving DOM focus: index drives the rendered tabIndex values; the element
+  // gets real focus so typing keys immediately land on it.
   const focusItem = useCallback(
     (index: number) => {
       setFocusIndex(index);
       containerRef.current
-        ?.querySelectorAll<HTMLElement>(itemSelector)
+        ?.querySelectorAll<HTMLElement>(optionsRef.current.itemSelector)
         [index]?.focus();
     },
-    [containerRef, itemSelector],
+    [containerRef],
   );
 
-  const openMenu = useCallback(
-    (initialIndex = 0) => {
-      setOpen(true);
-      requestAnimationFrame(() => focusItem(initialIndex));
-    },
-    [focusItem],
-  );
+  const openMenu = useCallback((initialIndex = 0) => {
+    pendingFocusRef.current = initialIndex;
+    setFocusIndex(initialIndex);
+    setOpen(true);
+  }, []);
 
-  const closeMenu = useCallback(() => setOpen(false), []);
+  const closeMenu = useCallback(() => requestClose(), [requestClose]);
 
   const closeReturningFocus = useCallback(() => {
-    setOpen(false);
-    triggerRef.current?.focus();
-  }, [triggerRef]);
+    requestClose();
+    optionsRef.current.triggerRef?.current?.focus();
+  }, [requestClose]);
 
-  // Close the menu when clicking outside of it.
+  // Close the menu when clicking outside of it. Controlled instances let
+  // their owner handle this (the owner already has its own listener).
   useEffect(() => {
-    if (!open) return;
+    if (!isOpen || optionsRef.current.onRequestClose) return;
     const onMouseDown = (e: MouseEvent) => {
       if (
         containerRef.current &&
         !containerRef.current.contains(e.target as Node)
       ) {
-        setOpen(false);
+        requestClose();
       }
     };
     document.addEventListener("mousedown", onMouseDown);
     return () => document.removeEventListener("mousedown", onMouseDown);
-  }, [open, containerRef]);
+  }, [isOpen, containerRef, requestClose]);
+
+  // Move real focus onto the current item once the menu is open. rAF waits
+  // one frame so conditionally-rendered items exist in the DOM.
+  useEffect(() => {
+    if (!isOpen) return;
+    const raf = requestAnimationFrame(() => {
+      const items = containerRef.current?.querySelectorAll<HTMLElement>(
+        optionsRef.current.itemSelector,
+      );
+      items?.[
+        Math.max(0, Math.min(pendingFocusRef.current, items.length - 1))
+      ]?.focus();
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [isOpen, containerRef]);
 
   const getItemProps = useCallback(
     (index: number): RovingMenuItemProps => ({

--- a/packages/webview/tests/webview/desktopSelectorsKeyboard.test.tsx
+++ b/packages/webview/tests/webview/desktopSelectorsKeyboard.test.tsx
@@ -12,11 +12,15 @@ function renderDesktopApp() {
   return { ...result, vscode };
 }
 
+/** Flushes the hook's rAF-deferred initial item focus. */
+const flushOpenFocus = () =>
+  new Promise((resolve) => requestAnimationFrame(resolve));
+
 /**
  * Keyboard accessibility of the desktop new-session selectors (host, workdir,
  * branch): triggers must be Tab-focusable, menu items activatable with
- * Enter/Space, and Escape must close the menu and return focus to the trigger.
- * Same pattern as the + / permission-mode dropdowns (plusMenuKeyboard.test.tsx).
+ * Enter/Space, Escape must close the menu and return focus to the trigger,
+ * and Arrow keys move the roving-tabindex focus without wrapping.
  */
 describe("desktop selector keyboard accessibility", () => {
   it("host trigger opens the menu with Enter and host items are Tab-focusable", () => {
@@ -38,10 +42,71 @@ describe("desktop selector keyboard accessibility", () => {
     const localItem = screen.getByTestId("desktop-host-local");
     const sshItems = screen.getAllByTestId("desktop-host-item");
     const addItem = screen.getByTestId("desktop-host-add-entry");
+    // Roving tabindex: the initially-focused item (本地) is the only tab stop.
     expect(localItem).toHaveProperty("tabIndex", 0);
     expect(sshItems).toHaveLength(2);
-    expect(sshItems[0]).toHaveProperty("tabIndex", 0);
-    expect(addItem).toHaveProperty("tabIndex", 0);
+    expect(sshItems[0]).toHaveProperty("tabIndex", -1);
+    expect(addItem).toHaveProperty("tabIndex", -1);
+  });
+
+  it("opens with focus on the first item which is activatable right away", async () => {
+    const { vscode } = renderDesktopApp();
+    sendCommand("desktopWorkdirState", {
+      host: "prod",
+      hosts: ["prod"],
+      recentWorkdirs: [],
+    });
+    vscode.postMessage.mockClear();
+
+    fireEvent.click(screen.getByTestId("desktop-host"));
+    await flushOpenFocus();
+
+    // Opening focuses 本地 so Enter immediately selects it.
+    expect(document.activeElement).toBe(
+      screen.getByTestId("desktop-host-local"),
+    );
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: "Enter" });
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "desktopSelectHost",
+      host: "local",
+    });
+    expect(screen.queryByTestId("desktop-host-menu")).not.toBeInTheDocument();
+  });
+
+  it("moves the roving focus with Arrow keys without wrapping at the edges", () => {
+    renderDesktopApp();
+    sendCommand("desktopWorkdirState", {
+      host: "prod",
+      hosts: ["prod"],
+      recentWorkdirs: [],
+    });
+
+    fireEvent.click(screen.getByTestId("desktop-host"));
+    const localItem = screen.getByTestId("desktop-host-local");
+    const sshItem = screen.getAllByTestId("desktop-host-item")[0];
+    const addItem = screen.getByTestId("desktop-host-add-entry");
+
+    localItem.focus();
+    fireEvent.keyDown(localItem, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(sshItem);
+    expect(sshItem).toHaveProperty("tabIndex", 0);
+    expect(localItem).toHaveProperty("tabIndex", -1);
+
+    fireEvent.keyDown(sshItem, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(addItem);
+
+    // Below the last item: clamped, focus stays on 添加主机….
+    fireEvent.keyDown(addItem, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(addItem);
+
+    fireEvent.keyDown(addItem, { key: "ArrowUp" });
+    fireEvent.keyDown(document.activeElement as HTMLElement, {
+      key: "ArrowUp",
+    });
+    expect(document.activeElement).toBe(localItem);
+    // Above the first item: clamped too.
+    fireEvent.keyDown(localItem, { key: "ArrowUp" });
+    expect(document.activeElement).toBe(localItem);
   });
 
   it("selects a host item with Enter and returns focus to the trigger", () => {
@@ -230,7 +295,39 @@ describe("desktop selector keyboard accessibility", () => {
 
     const items = screen.getAllByTestId("desktop-branch-item");
     expect(items).toHaveLength(2);
+    // Roving tabindex: the initially-focused item (main, the current branch)
+    // is the only tab stop.
     expect(items[0]).toHaveProperty("tabIndex", 0);
+    expect(items[1]).toHaveProperty("tabIndex", -1);
+  });
+
+  it("opens focused on the currently selected branch even when it is not first", async () => {
+    renderDesktopApp();
+    sendCommand("desktopWorkdirState", {
+      workdir: "/work/a",
+      recentWorkdirs: ["/work/a"],
+    });
+    sendCommand("desktopGitBranches", {
+      workdir: "/work/a",
+      result: { branches: ["main", "dev"], current: "dev" },
+    });
+
+    fireEvent.click(screen.getByTestId("desktop-branch-selector"));
+    await flushOpenFocus();
+
+    const items = screen.getAllByTestId("desktop-branch-item");
+    // Opening focuses the current branch (permission-mode dropdown precedent).
+    expect(document.activeElement).toBe(items[1]);
+
+    fireEvent.keyDown(items[1], { key: "ArrowUp" });
+    expect(document.activeElement).toBe(items[0]);
+    expect(items[0]).toHaveProperty("tabIndex", 0);
+
+    fireEvent.keyDown(items[0], { key: "Escape" });
+    expect(screen.queryByTestId("desktop-branch-menu")).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(
+      screen.getByTestId("desktop-branch-selector"),
+    );
   });
 
   it("selects a branch with Enter and returns focus to the trigger", () => {

--- a/packages/webview/tests/webview/moreSelectorsKeyboard.test.tsx
+++ b/packages/webview/tests/webview/moreSelectorsKeyboard.test.tsx
@@ -14,11 +14,16 @@ import { fixtures } from "wave-webview-fixtures";
 
 vi.mock("../../src/styles/DesktopApp.css", () => ({}));
 
+/** Flushes the hook's rAF-deferred initial item focus. */
+const flushOpenFocus = () =>
+  new Promise((resolve) => requestAnimationFrame(resolve));
+
 /**
  * Keyboard accessibility of the remaining custom interactive elements:
  * MoreMenu items, panel-toggle checkboxes, session-history list, context tags,
- * and tool file paths. Same pattern as plusMenuKeyboard.test.tsx: Tab-focusable
- * + Enter/Space activation, Escape closes menus.
+ * and tool file paths. Popup dropdowns (MoreMenu/PanelToggleMenu) share the
+ * roving-tabindex keyboard model: Arrow keys move, Enter/Space activate,
+ * Escape closes back to the trigger.
  */
 describe("remaining keyboard accessibility", () => {
   beforeEach(() => {
@@ -41,6 +46,27 @@ describe("remaining keyboard accessibility", () => {
         command: "getConfiguration",
       });
       expect(screen.queryByTestId("more-menu")).not.toBeInTheDocument();
+    });
+
+    it("opens focused on the first item; ArrowDown moves roving focus; Escape returns to the trigger", async () => {
+      renderChatApp();
+      const trigger = screen.getByTestId("more-btn");
+      fireEvent.click(trigger);
+      await flushOpenFocus();
+
+      // Controlled menus auto-focus their first item after the open frame.
+      const settings = screen.getByTestId("more-menu-settings");
+      const enterprise = screen.getByTestId("more-menu-enterprise");
+      expect(document.activeElement).toBe(settings);
+
+      fireEvent.keyDown(settings, { key: "ArrowDown" });
+      expect(document.activeElement).toBe(enterprise);
+      expect(enterprise).toHaveProperty("tabIndex", 0);
+      expect(settings).toHaveProperty("tabIndex", -1);
+
+      fireEvent.keyDown(enterprise, { key: "Escape" });
+      expect(screen.queryByTestId("more-menu")).not.toBeInTheDocument();
+      expect(document.activeElement).toBe(trigger);
     });
 
     it("activates the logout item with Space", () => {
@@ -87,7 +113,8 @@ describe("remaining keyboard accessibility", () => {
 
       fireEvent.click(screen.getByTestId("panel-toggle-btn"));
       const diffItem = screen.getByTestId("panel-toggle-item-diff");
-      expect(diffItem).toHaveProperty("tabIndex", 0);
+      // Roving tabindex: only the focused item is a tab stop.
+      expect(diffItem).toHaveProperty("tabIndex", -1);
 
       diffItem.focus();
       fireEvent.keyDown(diffItem, { key: " " });
@@ -98,6 +125,29 @@ describe("remaining keyboard accessibility", () => {
       expect(diffItem).toHaveAttribute("aria-checked", "true");
       // Multi-select menu stays open after toggling.
       expect(screen.getByTestId("panel-toggle-menu")).toBeInTheDocument();
+    });
+
+    it("moves with Arrow keys without wrapping and skips nothing (disabled stays reachable but inert)", async () => {
+      window.waveHostType = "desktop";
+      renderDesktop();
+
+      fireEvent.click(screen.getByTestId("panel-toggle-btn"));
+      await flushOpenFocus();
+
+      // Opening focuses the first item (预览).
+      const preview = screen.getByTestId("panel-toggle-item-preview");
+      expect(document.activeElement).toBe(preview);
+
+      const kinds = ["preview", "plan", "diff", "terminal", "file"].map(
+        (kind) => screen.getByTestId(`panel-toggle-item-${kind}`),
+      );
+      for (let i = 0; i < kinds.length - 1; i++) {
+        fireEvent.keyDown(kinds[i], { key: "ArrowDown" });
+        expect(document.activeElement).toBe(kinds[i + 1]);
+      }
+      // Below the last item: clamped (no wrap to the top).
+      fireEvent.keyDown(kinds[kinds.length - 1], { key: "ArrowDown" });
+      expect(document.activeElement).toBe(kinds[kinds.length - 1]);
     });
 
     it("closes the panel menu with Escape", () => {


### PR DESCRIPTION
## 概要

将剩余 5 个自绘弹出下拉接入共享的 roving-tabindex 键盘模型（与权限模式菜单、+ 菜单、SessionList 一致）：↑↓ 移动（不回绕）、Enter/Space 激活、Escape 关闭并归还焦点、Tab 关闭菜单。

## 改动

- **useRovingMenu**：新增受控模式（onRequestClose），服务挂载即开的菜单；triggerRef 变可选；MessageInput 现有调用零改动（其测试原样全绿）
- **桌面三选择器**：DesktopHostSelector / DesktopWorktreeControls / DesktopWorkdirSelector 主菜单接入；分支菜单打开即聚焦当前选中分支（权限模式先例）；远程目录浏览器的子列表保持原有 index 高亮模式不动
- **MoreMenu / PanelToggleMenu**（更多/面板菜单）：受控接入；保留组件自身的 click-outside 与全局 Escape 兜底；PanelToggle 多选切换不关菜单，disabled 项方向键可达但激活无效
- **ChatHeader / DesktopSidebar**：传入 trigger refs，Escape/激活后焦点归还触发按钮；触发按钮补 aria-haspopup / aria-expanded

## 测试

- jsdom：desktopSelectorsKeyboard / moreSelectorsKeyboard 断言更新为 roving 语义 + 新增方向键/边界用例，webview 全量 **793/793** 全绿
- 新增真实浏览器 e2e `desktop-selector-keyboard.e2e.ts`（6 用例）：真实键盘事件验证打开自动聚焦、方向键 roving 与 clamp、Enter 激活、Escape 还焦；demo+e2e 全量 **75/75**
- type-check / oxlint 全绿