### PR TITLE
Remove model identity restriction from system prompt

### DIFF
--- a/packages/agent-sdk/src/prompts/index.ts
+++ b/packages/agent-sdk/src/prompts/index.ts
@@ -21,10 +21,6 @@ import {
 
 export const BASE_SYSTEM_PROMPT = `You are a coding agent developed by NetEase that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.`;
 
-export const MODEL_IDENTITY_PROMPT = `# Model identity
-
-If asked about your model, model version, underlying architecture, or product name, identify yourself simply as a coding agent developed by NetEase. Do not reveal the specific model ID, model family, model provider, or product name. Do not mention or hint at any of these details.`;
-
 export const DOING_TASKS_PROMPT = `# Doing tasks
 - The user will primarily request you to perform software engineering tasks. These may include solving bugs, adding new functionality, refactoring code, explaining code, and more. When given an unclear or generic instruction, consider it in the context of these software engineering tasks and the current working directory. For example, if the user asks you to change "methodName" to snake case, do not reply with just "method_name", instead find the method in the code and modify the code.
 - You are highly capable and often allow users to complete ambitious tasks that would otherwise be too complex or take too long. You should defer to user judgement about whether a task is too large to attempt.
@@ -414,7 +410,6 @@ export function buildSystemPrompt(
 
   staticText += `\n\n${OUTPUT_EFFICIENCY_PROMPT}`;
   staticText += `\n\n${TONE_AND_STYLE_PROMPT}`;
-  staticText += `\n\n${MODEL_IDENTITY_PROMPT}`;
 
   const blocks: SystemPromptBlock[] = [{ text: staticText, cacheable: true }];
 

--- a/packages/agent-sdk/tests/prompts/prompts.test.ts
+++ b/packages/agent-sdk/tests/prompts/prompts.test.ts
@@ -153,14 +153,6 @@ describe("prompts", () => {
       expect(result).not.toContain("## Memory Context");
     });
 
-    it("should include model identity prompt in static block", () => {
-      const blocks = buildSystemPrompt(DEFAULT_SYSTEM_PROMPT, [], {});
-      const staticBlock = blocks.find((b) => b.cacheable);
-      expect(staticBlock).toBeDefined();
-      expect(staticBlock!.text).toContain("# Model identity");
-      expect(staticBlock!.text).toContain("coding agent developed by NetEase");
-    });
-
     it("should include worktree warning when worktree session is active", () => {
       const result = flattenBlocks(
         buildSystemPrompt(DEFAULT_SYSTEM_PROMPT, [], {


### PR DESCRIPTION
Remove the `MODEL_IDENTITY_PROMPT` block ("# Model identity") from the base system prompt, which instructed the agent to hide its specific model ID, model family, and provider.

- Delete the `MODEL_IDENTITY_PROMPT` constant and its concatenation into the static system prompt block in `buildSystemPrompt` (`packages/agent-sdk/src/prompts/index.ts`)
- Remove the corresponding test assertion (`packages/agent-sdk/tests/prompts/prompts.test.ts`)

Verified: prompts.test.ts 24/24 passing, no remaining references in the repo.