### PR TITLE
fix(webview): wrap compact block in timeline row

### DIFF
--- a/packages/webview/src/components/Message.tsx
+++ b/packages/webview/src/components/Message.tsx
@@ -836,15 +836,12 @@ export const Message: React.FC<MessageProps> = React.memo(
       );
     };
 
-    const renderCompactBlock = (compactBlock: CompactBlock, index: number) => {
-      return (
-        <CompactBlockView
-          key={`compact-${index}`}
-          block={compactBlock}
-          renderContent={(content) => renderMarkdownContent(content, index)}
-        />
-      );
-    };
+    const renderCompactBlock = (compactBlock: CompactBlock, index: number) => (
+      <CompactBlockView
+        block={compactBlock}
+        renderContent={(content) => renderMarkdownContent(content, index)}
+      />
+    );
 
     const renderBlock = (block: MessageBlock, index: number) => {
       let rendered: React.ReactNode = null;
@@ -853,7 +850,12 @@ export const Message: React.FC<MessageProps> = React.memo(
 
       switch (block.type) {
         case "compact":
-          return renderCompactBlock(block, index);
+          // Same color as .compact-dot so the timeline dot matches the in-block dot.
+          rendered = renderCompactBlock(block, index);
+          wrap = true;
+          dotColor =
+            "var(--vscode-textLink-foreground, var(--vscode-descriptionForeground))";
+          break;
         case "text": {
           const content = block.content || "";
           if (!content.trim()) return null;

--- a/packages/webview/tests/webview/timelineDotColor.test.tsx
+++ b/packages/webview/tests/webview/timelineDotColor.test.tsx
@@ -107,4 +107,25 @@ describe("timeline dot color by stage", () => {
     const row = getLastMessage().querySelector(".timeline-row") as HTMLElement;
     expect(row.style.getPropertyValue("--dot-color")).toContain("Passed");
   });
+
+  it("compact block is wrapped in a timeline row with the link-accent dot", () => {
+    renderChatApp();
+
+    sendCommand("updateMessages", {
+      messages: [
+        {
+          id: "m4",
+          role: "assistant",
+          timestamp: "2024-01-01T00:00:00.000Z",
+          blocks: [{ type: "compact", content: "对话摘要" }],
+        },
+      ],
+    });
+    const row = getLastMessage().querySelector(".timeline-row") as HTMLElement;
+    // The compact block renders inside a .timeline-row so it gets the dot and
+    // the 10px top spacing like text/tool/reasoning blocks.
+    expect(row).not.toBeNull();
+    expect(row.querySelector(".compact-block")).not.toBeNull();
+    expect(row.style.getPropertyValue("--dot-color")).toContain("textLink");
+  });
 });


### PR DESCRIPTION
## Summary

- 「对话已压缩」compact 块此前在 Message.renderBlock 中直接 return，绕过了 text/tool/reasoning 块统一的 `.timeline-row` 包装——缺时间线圆点、缺连续竖线段、缺 `padding-top: 10px`。
- MessageList 的 `countTimelineBlocks` 早已把 compact 计入 timeline dot 数，竖线 run 判定与实际渲染不一致；本修复对齐两侧。
- 顺手清理 renderCompactBlock 中被外层 key 覆盖后多余的 key prop。

## Test plan

- [x] 新增回归用例：compact 块渲染在 `.timeline-row` 内且 dot 色为 textLink（timelineDotColor.test.tsx）
- [x] webview 全量单测 797/797 通过
- [x] type-check + oxlint 0 错