### PR TITLE
fix(webview): 快捷键切换的会话现在可被 Tab 导航到

### DIFF
--- a/packages/webview/e2e/desktop-sidebar-keyboard.e2e.ts
+++ b/packages/webview/e2e/desktop-sidebar-keyboard.e2e.ts
@@ -131,6 +131,32 @@ test.describe("Desktop sidebar keyboard navigation", () => {
     await webviewPage.keyboard.press("End");
     expect(await activeTestId(webviewPage)).toBe("desktop-session-main-s3");
 
+    // ── Ctrl+Tab regression: a session switched in WITHOUT a focus event ──
+    // (host-driven shortcut switch) must still host the Tab stop. The roving
+    // record above sits on s2; switching the current session to s3 drops it.
+    await injector.simulateExtensionMessage("updateCurrentSession", {
+      session: {
+        id: "s3",
+        sessionType: "main",
+        workdir: DIR_B,
+        createdAt: "2026-08-28T00:00:00.000Z",
+        lastActiveAt: "2026-08-28T00:00:00.000Z",
+        latestTotalTokens: 0,
+        firstMessage: "会话三",
+      },
+    });
+    await expect(mainS3).toHaveAttribute("tabindex", "0");
+    await expect(mainS2).toHaveAttribute("tabindex", "-1");
+    // Tab from outside the tree lands on the newly current session. With s1/s2
+    // now at -1 the sweep is: group header A → group header B → s3.
+    await webviewPage.getByTestId("desktop-new-session").focus();
+    await webviewPage.keyboard.press("Tab"); // group header A
+    await webviewPage.keyboard.press("Tab"); // group header B
+    await webviewPage.keyboard.press("Tab");
+    expect(await activeTestId(webviewPage)).toBe("desktop-session-main-s3");
+    // Put the roving stop back on s1 for the Enter section below.
+    await mainS1.focus();
+
     // ── Scenario 17 (first half): Enter on the main button restores ──
     await webviewPage.evaluate(() => window.clearTestMessages());
     await mainS1.focus();

--- a/packages/webview/src/components/DesktopSidebar.tsx
+++ b/packages/webview/src/components/DesktopSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, RefObject } from "react";
+import React, { useEffect, useState, useRef, RefObject } from "react";
 import { Tooltip } from "./Tooltip";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { MoreIcon } from "./HeaderIcons";
@@ -101,6 +101,13 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
   // the Tab order entirely and are reached with ←/→ instead.
   const [rovingSessionId, setRovingSessionId] = useState<string | null>(null);
   const treeRef = useRef<HTMLDivElement | null>(null);
+  // Sessions switched in without a focus event (Ctrl+Tab, host-driven pane
+  // changes) must still become the Tab stop: drop the roving record when the
+  // current session changes so the fallback chain lands on the new session.
+  // Arrow-key navigation keeps currentSessionId unchanged, so it is unaffected.
+  useEffect(() => {
+    setRovingSessionId(null);
+  }, [currentSessionId]);
   // Modifier key label for the side-by-side hints, same platform branch as the
   // click handlers below (Cmd on macOS / Ctrl elsewhere).
   const modKeyLabel = isMacPlatform() ? "Cmd" : "Ctrl";
@@ -142,11 +149,15 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
       }
     }
   }
+  // A stale roving record (its row was deleted or its group collapsed) must
+  // not leave the tree without any Tab stop — fall through to the current
+  // session, else the first rendered session.
   const tabStopId =
-    rovingSessionId ??
-    (currentSessionId && orderedSessionIds.includes(currentSessionId)
-      ? currentSessionId
-      : orderedSessionIds[0]);
+    rovingSessionId && orderedSessionIds.includes(rovingSessionId)
+      ? rovingSessionId
+      : currentSessionId && orderedSessionIds.includes(currentSessionId)
+        ? currentSessionId
+        : orderedSessionIds[0];
 
   // Tree-level keyboard navigation, mirroring Claude's sidebar model:
   // - ↑/↓/Home/End move focus between session main buttons (skipping group

--- a/packages/webview/tests/webview/desktopApp.test.tsx
+++ b/packages/webview/tests/webview/desktopApp.test.tsx
@@ -1391,6 +1391,126 @@ describe("DesktopApp", () => {
       );
     });
 
+    it("re-points the Tab stop at a session switched in without a focus event (e.g. Ctrl+Tab)", () => {
+      renderDesktopApp();
+      sendCommand("desktopWorkdirState", {
+        workdir: "/work/a",
+        recentWorkdirs: ["/work/a"],
+      });
+      sendCommand("desktopSessionTree", {
+        groups: [
+          {
+            host: "local",
+            workdir: "/work/a",
+            sessions: [session("s1", "hello a"), session("s2", "hello b")],
+          },
+        ],
+      });
+      sendCommand("updateCurrentSession", {
+        session: {
+          id: "s1",
+          sessionType: "main",
+          workdir: "/work/a",
+          createdAt: "2026-08-28T00:00:00.000Z",
+          lastActiveAt: "2026-08-28T00:00:00.000Z",
+          latestTotalTokens: 0,
+          firstMessage: "hello a",
+        },
+      });
+      expect(screen.getByTestId("desktop-session-main-s1")).toHaveAttribute(
+        "tabindex",
+        "0",
+      );
+
+      // Clicking s2 focuses its row (the host then switches the current
+      // session to s2), pinning the roving record on s2.
+      act(() => {
+        screen.getByTestId("desktop-session-main-s2").focus();
+      });
+      sendCommand("updateCurrentSession", {
+        session: {
+          id: "s2",
+          sessionType: "main",
+          workdir: "/work/a",
+          createdAt: "2026-08-28T00:00:00.000Z",
+          lastActiveAt: "2026-08-28T00:00:00.000Z",
+          latestTotalTokens: 0,
+          firstMessage: "hello b",
+        },
+      });
+      expect(screen.getByTestId("desktop-session-main-s2")).toHaveAttribute(
+        "tabindex",
+        "0",
+      );
+
+      // Ctrl+Tab back to s1: no focus event fires on the sidebar, yet the
+      // Tab stop must follow the newly current session.
+      sendCommand("updateCurrentSession", {
+        session: {
+          id: "s1",
+          sessionType: "main",
+          workdir: "/work/a",
+          createdAt: "2026-08-28T00:00:00.000Z",
+          lastActiveAt: "2026-08-28T00:00:00.000Z",
+          latestTotalTokens: 0,
+          firstMessage: "hello a",
+        },
+      });
+      expect(screen.getByTestId("desktop-session-main-s1")).toHaveAttribute(
+        "tabindex",
+        "0",
+      );
+      expect(screen.getByTestId("desktop-session-main-s2")).toHaveAttribute(
+        "tabindex",
+        "-1",
+      );
+    });
+
+    it("keeps a Tab stop when the roving record points at a removed row", () => {
+      renderDesktopApp();
+      sendCommand("desktopWorkdirState", {
+        workdir: "/work/a",
+        recentWorkdirs: ["/work/a"],
+      });
+      sendCommand("desktopSessionTree", {
+        groups: [
+          {
+            host: "local",
+            workdir: "/work/a",
+            sessions: [session("s1", "hello a"), session("s2", "hello b")],
+          },
+        ],
+      });
+
+      // Arrow onto s2 — the roving record now sits on s2.
+      act(() => {
+        screen.getByTestId("desktop-session-main-s1").focus();
+      });
+      fireEvent.keyDown(screen.getByTestId("desktop-session-main-s1"), {
+        key: "ArrowDown",
+      });
+      expect(screen.getByTestId("desktop-session-main-s2")).toHaveAttribute(
+        "tabindex",
+        "0",
+      );
+
+      // s2 leaves the tree (deleted / group collapsed): the stop must fall
+      // back instead of leaving the tree without any tabbable row.
+      sendCommand("desktopSessionTree", {
+        groups: [
+          {
+            host: "local",
+            workdir: "/work/a",
+            sessions: [session("s1", "hello a")],
+          },
+        ],
+      });
+      expect(screen.getByTestId("desktop-session-main-s1")).toHaveAttribute(
+        "tabindex",
+        "0",
+      );
+    });
+
     it("moves focus between rows with ↑/↓ including wrap-around, and follows with Home/End", () => {
       renderDesktopApp();
       sendCommand("desktopWorkdirState", {


### PR DESCRIPTION
## 问题

桌面端侧边栏采用 roving tabindex 模型（PR #1970）：整棵会话树只有一个 Tab 停靠点。但该停靠点只在 DOM focus 事件时更新（`onFocus`）——快捷键切换会话（Ctrl+Tab → 宿主推 `updateCurrentSession`）不产生 focus 事件，导致 `rovingSessionId` 一旦被设置过（点过/方向键导航过侧边栏）就钉死在旧行上：

- 鼠标点击会话 A → 停靠点=A，Tab 能到 ✓
- Ctrl+Tab 切到会话 B → 停靠点仍是 A，B 无法 Tab 导航到 ✗

## 修复（DesktopSidebar.tsx）

1. **currentSessionId 变化时清空 rovingSessionId**（useEffect）：停靠点回退链落到新的当前会话；方向键导航期间 currentSessionId 不变，roving 跟随行为不受影响。
2. **停靠点校验仍在渲染列表**：顺带修一个同根问题——停靠行被删除/分组折叠后整棵树会变成 0 个 `tabindex=0`（Tab 完全进不来），现在回落到当前会话/首条。

## 测试

- jsdom 新增 2 个回归用例：Ctrl+Tab 式切换后停靠点跟随新的当前会话；停靠行被删后回落（desktopApp.test.tsx 112/112）
- e2e 真浏览器补 Ctrl+Tab 回归段（desktop-sidebar-keyboard.e2e.ts），全量 demo+e2e 77/77
- 全量 webview 单测 799/799、type-check 0 错、oxlint 0/0