### PR TITLE
chore(worktree): sync .wave/settings.local.json with worktrees

### DIFF
--- a/.wave/hooks/worktree-create.mjs
+++ b/.wave/hooks/worktree-create.mjs
@@ -3,7 +3,7 @@
 // <repo-root>/.wave/worktrees/<name>, prints the worktree path to stdout,
 // then kicks off pnpm install + build in the background.
 import { spawn, spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, existsSync, mkdirSync, copyFileSync } from "node:fs";
 import path from "node:path";
 
 // Resolve the repo root from git (git-common-dir may be relative to CWD)
@@ -44,6 +44,18 @@ if (add.error) {
   process.exit(1);
 }
 if (add.status !== 0) process.exit(add.status);
+
+// --- Copy local settings into the worktree ---------------------------------
+// Mirrors wave's built-in post-creation setup (copyLocalSettingsToWorktree):
+// with a WorktreeCreate hook configured, wave skips that setup entirely, so
+// the hook must carry .wave/settings.local.json over itself or every session
+// would start without the main repo's local permissions/env.
+const localSettings = path.join(repoRoot, ".wave", "settings.local.json");
+if (existsSync(localSettings)) {
+  const destDir = path.join(worktreePath, ".wave");
+  mkdirSync(destDir, { recursive: true });
+  copyFileSync(localSettings, path.join(destDir, "settings.local.json"));
+}
 
 // --- Kick off install + build in the background ---------------------------
 const bg = spawn(

--- a/.wave/hooks/worktree-remove.mjs
+++ b/.wave/hooks/worktree-remove.mjs
@@ -4,7 +4,7 @@
 // worktrees: `git worktree remove --force` + branch delete + prune, with an
 // fs.rmSync fallback for Windows MAX_PATH-limited removals.
 import { spawnSync } from "node:child_process";
-import { readFileSync, existsSync, rmSync } from "node:fs";
+import { readFileSync, existsSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 // --- Read payload { worktree_path } from stdin -----------------------------
@@ -33,6 +33,54 @@ if (gitCommonDir.error || gitCommonDir.status !== 0) {
   process.exit(1);
 }
 const repoRoot = path.resolve(gitCommonDir.stdout.trim(), "..");
+
+// --- Sync .wave/settings.local.json back to the main repo ------------------
+// Local settings are gitignored, so any changes made inside the worktree
+// would otherwise be lost when the worktree is deleted. Merge into the
+// main repo's file (if any) instead of overwriting it: arrays are unioned,
+// scalars/objects from the worktree win. This mirrors how wave itself
+// merges local settings (read-modify-write with deduped rule arrays).
+function mergeSettings(base, override) {
+  const result = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    const current = result[key];
+    if (Array.isArray(value) && Array.isArray(current)) {
+      result[key] = [...new Set([...current, ...value])];
+    } else if (
+      value !== null &&
+      typeof value === "object" &&
+      current !== null &&
+      typeof current === "object"
+    ) {
+      result[key] = mergeSettings(current, value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function parseJsonFile(filePath) {
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8"));
+  } catch {
+    return null; // missing or corrupted -> treated as empty
+  }
+}
+
+const localSettingsPath = path.join(
+  worktreePath,
+  ".wave",
+  "settings.local.json",
+);
+if (existsSync(localSettingsPath)) {
+  const mainSettingsPath = path.join(repoRoot, ".wave", "settings.local.json");
+  const merged = mergeSettings(
+    parseJsonFile(mainSettingsPath) ?? {},
+    parseJsonFile(localSettingsPath) ?? {},
+  );
+  writeFileSync(mainSettingsPath, `${JSON.stringify(merged, null, 2)}\n`);
+}
 
 // --- Remove the worktree (best-effort, non-blocking like wave's git path) ---
 const name = path.basename(worktreePath);


### PR DESCRIPTION
## Summary

With a WorktreeCreate/WorktreeRemove hook configured, wave skips its built-in worktree post-creation setup entirely, so `.wave/settings.local.json` (gitignored) never crossed between the main repo and worktrees. This adds the missing sync to both repo hooks, forming a round trip:

- **create**: copy the main repo's `.wave/settings.local.json` into the newly created worktree (mirrors the SDK's `copyLocalSettingsToWorktree` semantics; silently skipped when the main repo has none) — sessions now inherit existing local permissions/env instead of re-authorizing from scratch.
- **remove**: merge the worktree's `.wave/settings.local.json` back into the main repo before deletion — arrays unioned and deduped (`permissions.allow`, `additionalDirectories`), objects deep merged, scalars from the worktree win. Merging (not overwriting) preserves main-repo entries since the worktree copy only holds session-accumulated rules.

## Test plan

- [x] create hook: ran it for real; the created worktree's `.wave/settings.local.json` is byte-identical to the main repo's; test worktree fully cleaned up
- [x] remove hook: fake worktree with session rules (new allow rule + extra additionalDirectories) merged into a main-repo file holding existing `additionalDirectories` — union deduped, both sides preserved; main repo file restored after test