### PR TITLE
附加目录支持 ~ 前缀展开并合并本机权限规则进项目配置

### DIFF
--- a/.wave/settings.json
+++ b/.wave/settings.json
@@ -25,12 +25,12 @@
       "Bash(wave *)",
       "Bash(acpx *)",
       "Bash(rm *packages/*/tests/*)",
-      "Bash(node scripts*)"
+      "Bash(node scripts*)",
+      "Bash(git fetch*)",
+      "Bash(gh run view*)",
+      "Bash(gh run list*)"
     ],
-    "additionalDirectories": [
-      "../wave-plugins-official",
-      "../../../wave-plugins-official"
-    ]
+    "additionalDirectories": ["~/github"]
   },
   "enabledPlugins": {
     "sdd@builtin": true

--- a/docs/specs/core/tool-permission-system.md
+++ b/docs/specs/core/tool-permission-system.md
@@ -183,6 +183,7 @@ order: 130
 6. **假设** 用户输入 `/add-dir --remember /data/exports`，**当** 命令执行后，**则** `/data/exports` 除当前会话生效外，还被追加到 `.wave/settings.local.json` 的 `permissions.additionalDirectories`，后续会话自动加载。
 7. **假设** 用户输入无参数的 `/add-dir`，**当** 命令执行时，**则** 显示用法说明及当前会话的附加目录列表。
 8. **假设** agent 派生子 agent，**当** 子 agent 的系统提示词构建时，**则** `<env>` 中包含单行 `Additional working directories: /data/exports`（附加目录并集），且子 agent 的权限检查同样将附加目录视为安全区域。
+9. **假设** `permissions.additionalDirectories` 的某项路径以 `~` 或 `~/` 开头（如 `~/github`），**当** 该路径被解析进安全区域时，**则** 按当前用户主目录展开为绝对路径（`~/github` → `<主目录>/github`，对齐 Claude Code），安全区域判定与系统提示词均使用展开后的路径；配置文件中保留 `~` 写法，不暴露本机用户名。
 
 ### 用户故事：CLI 模式切换（优先级：P2）
 
@@ -238,7 +239,7 @@ _已移除。基于 Heredoc 的 bash 命令不再被自动拒绝。用户应依�
 - **智能通配符**：用 `*` 替换动态参数的启发式生成模式。
 - **PermissionDecision**：权限检查的结果，扩展为包含可选的 `newPermissionMode` 和 `newPermissionRule` 以通知系统更新其状态。
 - **安全区域**：允许 agent 执行文件操作而无需每次操作都经用户明确确认的文件系统路径集合。
-- **附加目录**：用户可配置的路径列表，将安全区域扩展到默认工作目录之外。可通过 `settings.json` 的 `permissions.additionalDirectories`、CLI 的 `--add-dir` 启动选项或 `/add-dir` 斜杠命令（会话级）加入；其中 `--add-dir` 与 `/add-dir` 为 CLI 专属入口。
+- **附加目录**：用户可配置的路径列表，将安全区域扩展到默认工作目录之外。可通过 `settings.json` 的 `permissions.additionalDirectories`、CLI 的 `--add-dir` 启动选项或 `/add-dir` 斜杠命令（会话级）加入；其中 `--add-dir` 与 `/add-dir` 为 CLI 专属入口。路径支持相对路径（相对工作目录解析）与 `~`/`~/` 前缀（按用户主目录展开）。
 
 ## 边界情况
 

--- a/packages/agent-sdk/src/managers/permissionManager.ts
+++ b/packages/agent-sdk/src/managers/permissionManager.ts
@@ -7,6 +7,7 @@
  */
 
 import path from "node:path";
+import os from "node:os";
 import { minimatch } from "minimatch";
 import type {
   PermissionDecision,
@@ -89,6 +90,27 @@ const DEFAULT_ALLOWED_RULES = [
 ];
 
 import { logger } from "../utils/globalLogger.js";
+
+/**
+ * Resolve an additional-directory config entry to an absolute path.
+ * Supports `~` / `~/` prefixes (expanded against the user home directory,
+ * aligned with Claude Code's expandPath) alongside absolute paths and paths
+ * relative to the working directory.
+ */
+export function resolveAdditionalDirectory(
+  dir: string,
+  workdir: string | undefined,
+): string {
+  if (dir === "~" || dir.startsWith("~/")) {
+    const expanded =
+      dir === "~" ? os.homedir() : path.join(os.homedir(), dir.slice(2));
+    return path.resolve(expanded);
+  }
+  if (workdir && !path.isAbsolute(dir)) {
+    return path.resolve(workdir, dir);
+  }
+  return path.resolve(dir);
+}
 
 export interface PermissionManagerOptions {
   /** Configured permission mode from settings */
@@ -313,24 +335,16 @@ export class PermissionManager {
    * Update the additional directories (e.g., when configuration reloads)
    */
   updateAdditionalDirectories(directories: string[]): void {
-    const workdir = this.workdir;
-    this.additionalDirectories = directories.map((dir) => {
-      if (workdir && !path.isAbsolute(dir)) {
-        return path.resolve(workdir, dir);
-      }
-      return path.resolve(dir);
-    });
+    this.additionalDirectories = directories.map((dir) =>
+      resolveAdditionalDirectory(dir, this.workdir),
+    );
   }
 
   /**
    * Add an instance-level additional directory (session-level, e.g. /add-dir command)
    */
   public addInstanceAdditionalDirectory(directory: string): void {
-    const workdir = this.workdir;
-    const resolvedPath =
-      workdir && !path.isAbsolute(directory)
-        ? path.resolve(workdir, directory)
-        : path.resolve(directory);
+    const resolvedPath = resolveAdditionalDirectory(directory, this.workdir);
 
     if (!this.instanceAdditionalDirectories.includes(resolvedPath)) {
       this.instanceAdditionalDirectories.push(resolvedPath);
@@ -341,11 +355,7 @@ export class PermissionManager {
    * Add a system-level additional directory that is persistent across configuration reloads
    */
   public addSystemAdditionalDirectory(directory: string): void {
-    const workdir = this.workdir;
-    const resolvedPath =
-      workdir && !path.isAbsolute(directory)
-        ? path.resolve(workdir, directory)
-        : path.resolve(directory);
+    const resolvedPath = resolveAdditionalDirectory(directory, this.workdir);
 
     if (!this.systemAdditionalDirectories.includes(resolvedPath)) {
       this.systemAdditionalDirectories.push(resolvedPath);

--- a/packages/agent-sdk/tests/managers/permissionManager.additionalDirectories.test.ts
+++ b/packages/agent-sdk/tests/managers/permissionManager.additionalDirectories.test.ts
@@ -13,6 +13,14 @@ vi.mock("../../src/utils/globalLogger.js", () => ({
   },
 }));
 
+const HOME = "/home/tester";
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  const mockOs = { ...actual, homedir: () => HOME };
+  return { ...mockOs, default: mockOs };
+});
+
 function createContainer(workdir?: string): Container {
   const c = new Container();
   if (workdir) {
@@ -52,6 +60,56 @@ describe("PermissionManager - instance additional directories", () => {
       expect(manager.getInstanceAdditionalDirectories()).toContain(
         path.resolve("/b/absolute"),
       );
+    });
+  });
+
+  describe("home directory (~) expansion", () => {
+    it("should expand a bare ~ to the user home directory", () => {
+      const manager = new PermissionManager(createContainer("/a"), {
+        additionalDirectories: ["~"],
+      });
+
+      expect(manager.getAdditionalDirectories()).toEqual([path.resolve(HOME)]);
+    });
+
+    it("should expand ~/ prefixed paths against the home directory", () => {
+      const manager = new PermissionManager(createContainer("/a"), {
+        additionalDirectories: ["~/github"],
+      });
+
+      expect(manager.getAdditionalDirectories()).toEqual([
+        path.resolve(HOME, "github"),
+      ]);
+    });
+
+    it("should expand ~ in instance additional directories", () => {
+      const manager = new PermissionManager(createContainer("/a"), {
+        instanceAdditionalDirectories: ["~/session"],
+      });
+
+      expect(manager.getInstanceAdditionalDirectories()).toEqual([
+        path.resolve(HOME, "session"),
+      ]);
+    });
+
+    it("should not resolve ~-prefixed paths against the workdir", () => {
+      const manager = new PermissionManager(createContainer("/a"), {
+        additionalDirectories: ["~/data"],
+      });
+
+      expect(manager.getAdditionalDirectories()).not.toContain(
+        path.resolve("/a", "~", "data"),
+      );
+    });
+
+    it("should expand ~ in system additional directories", () => {
+      const container = createContainer("/a");
+      const manager = new PermissionManager(container);
+      manager.addSystemAdditionalDirectory("~/tools");
+
+      expect(manager.getSystemAdditionalDirectories()).toEqual([
+        path.resolve(HOME, "tools"),
+      ]);
     });
   });
 


### PR DESCRIPTION
## 概要

`permissions.additionalDirectories` 新增 `~` / `~/` 前缀展开支持（对齐 Claude Code `expandPath`），并将本机 `settings.local.json` 中累积的权限规则用通配符优化合并进项目 `settings.json`。

## 改动

### agent-sdk
- `permissionManager.ts` 新增 `resolveAdditionalDirectory()` helper：`~` → 用户主目录、`~/xxx` → `<主目录>/xxx`；原相对路径（resolve 到 workdir）与绝对路径行为不变
- 三处解析点统一接入（配置更新 / instance / system additionalDirectories），覆盖 settings.json、`--add-dir` 启动选项、`/add-dir` 斜杠命令全部入口

### spec
- `tool-permission-system.md`「附加工作目录」故事新增场景 9（~ 前缀按主目录展开、配置文件保留 ~ 写法）+ 关键实体「附加目录」定义补充（spec-count 77/432/1796）

### 配置合并
- `.wave/settings.json` allow 新增三条通配符规则：`Bash(git fetch*)` / `Bash(gh run view*)` / `Bash(gh run list*)`（原 local 中 5 条具体命令）
- `additionalDirectories` 改用 `~/github`（不暴露本机用户名；展开后覆盖原两条相对路径的所有有效落点），原两条相对路径删除
- `.wave/settings.local.json` 清空

## 测试

- 新增 5 条单测（~ / ~/ / instance / system 展开、不误走 workdir 相对解析）
- permissionManager 相关 7 个测试文件 255/255 全绿
- 全仓 type-check / lint 0 错