### PR TITLE
fix(webview): show compaction loading hint and streaming tail again

### DIFF
--- a/packages/webview/e2e/compaction-hint-visible.e2e.ts
+++ b/packages/webview/e2e/compaction-hint-visible.e2e.ts
@@ -1,0 +1,155 @@
+import { test, expect } from "./utils/webviewTestHarness.js";
+import { MessageInjector } from "./utils/messageInjector.js";
+import type { Message } from "wave-agent-sdk";
+
+/**
+ * Compaction loading hint visibility in real Chromium.
+ *
+ * Regression: the hint (and its streaming tail) rendered with ZERO height —
+ * the `.compaction-hint` was the only shrinkable flex item after the
+ * virtualizer's in-flow spacer (flex-shrink: 0) filled the column, so it
+ * absorbed all the negative free space and collapsed (overflow: hidden then
+ * clipped the tail). The hint must keep its own height (flex-shrink: 0) and
+ * be re-pinned into the viewport when compaction starts (scrollToEnd only
+ * accounts for row heights, leaving the hint below the fold).
+ */
+
+function buildMessages(): Message[] {
+  const msgs: Message[] = [];
+  for (let i = 0; i < 12; i++) {
+    msgs.push({
+      id: `u${i}`,
+      role: "user",
+      timestamp: new Date(Date.UTC(2026, 0, 1) + i * 120000).toISOString(),
+      blocks: [
+        {
+          type: "text",
+          content: `第 ${i + 1} 个问题：如何优化这个系统的性能？`,
+        },
+      ],
+    });
+    msgs.push({
+      id: `a${i}`,
+      role: "assistant",
+      timestamp: new Date(
+        Date.UTC(2026, 0, 1) + i * 120000 + 60000,
+      ).toISOString(),
+      blocks: [
+        {
+          type: "text",
+          content: `这是第 ${i + 1} 个回答。需要从缓存、数据库索引、请求合并三个方向入手，同时考虑水平扩展与降级策略。`,
+        },
+      ],
+    });
+  }
+  return msgs;
+}
+
+async function initWithMessages(injector: MessageInjector) {
+  await injector.simulateExtensionMessage("setInitialState", {
+    isAuthenticated: true,
+    messages: [],
+    isStreaming: false,
+    sessions: [],
+    configurationData: {
+      apiKey: "sk-ant-api03-test",
+      baseURL: "https://api.anthropic.com/v1",
+      model: "claude-sonnet-4-20250514",
+    },
+    permissionMode: "default",
+  });
+  await injector.updateMessages(buildMessages());
+  await injector.endStreaming();
+}
+
+test.describe("compaction loading hint visibility", () => {
+  test("hint has height, sits inside the viewport, and shows the streaming tail", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+    await initWithMessages(injector);
+
+    await webviewPage.waitForSelector('[data-message-id="a11"]');
+    // Let the initial pin-to-bottom settle (estimate→measure waves).
+    await webviewPage.waitForFunction(() => {
+      const c = document.getElementById("messagesContainer") as HTMLElement;
+      return c.scrollHeight - c.scrollTop - c.clientHeight <= 2;
+    });
+
+    // ── Compaction starts: hint only (no streamed text yet) ──
+    await injector.simulateExtensionMessage("compactionStateChange", {
+      isCompacting: true,
+    });
+    await webviewPage.waitForFunction(() => {
+      const h = document.querySelector(
+        '[data-testid="compaction-hint"]',
+      ) as HTMLElement;
+      return Boolean(h && h.getBoundingClientRect().height > 0);
+    });
+
+    const hintGeometry = await webviewPage.evaluate(() => {
+      const h = document.querySelector(
+        '[data-testid="compaction-hint"]',
+      ) as HTMLElement;
+      const c = document.getElementById("messagesContainer") as HTMLElement;
+      if (!h) return { hintExists: false };
+      const hr = h.getBoundingClientRect();
+      const cr = c.getBoundingClientRect();
+      return {
+        hintExists: true,
+        height: hr.height,
+        // The hint must be inside the container's scroll viewport — the
+        // original bug left it zero-height, and even with a height it was
+        // 3px below the fold (no re-pin on compaction start).
+        fullyInsideViewport: hr.top >= cr.top && hr.bottom <= cr.bottom + 0.5,
+      };
+    });
+    expect(hintGeometry.hintExists).toBe(true);
+    expect(hintGeometry.height).toBeGreaterThan(0);
+    expect(hintGeometry.fullyInsideViewport).toBe(true);
+    expect(webviewPage.locator('[data-testid="compaction-hint"]')).toHaveText(
+      /正在压缩对话/,
+    );
+
+    // ── Streamed summary arrives: tail shows, also inside the viewport ──
+    const longContent =
+      "这是一个非常长的压缩总结，包含了对整个会话所有关键决策与结论的浓缩……" +
+      "接下来是更多的尾部文本，用于验证最后三十个字符的流式尾部预览效果是否正常显示。";
+    await injector.simulateExtensionMessage("compactionContentUpdate", {
+      content: longContent,
+    });
+
+    const tailGeometry = await webviewPage.evaluate(() => {
+      const t = document.querySelector(
+        '[data-testid="compaction-hint-tail"]',
+      ) as HTMLElement;
+      const c = document.getElementById("messagesContainer") as HTMLElement;
+      if (!t) return { tailExists: false };
+      const tr = t.getBoundingClientRect();
+      const cr = c.getBoundingClientRect();
+      return {
+        tailExists: true,
+        height: tr.height,
+        fullyInsideViewport: tr.top >= cr.top && tr.bottom <= cr.bottom + 0.5,
+      };
+    });
+    expect(tailGeometry.tailExists).toBe(true);
+    expect(tailGeometry.height).toBeGreaterThan(0);
+    expect(tailGeometry.fullyInsideViewport).toBe(true);
+    // Last-30-chars truncation behind an ellipsis (mirrors streamingTail).
+    await expect(
+      webviewPage.locator('[data-testid="compaction-hint-tail"]'),
+    ).toHaveText(/^…/);
+
+    // ── Compaction ends: hint and tail disappear ──
+    await injector.simulateExtensionMessage("compactionStateChange", {
+      isCompacting: false,
+    });
+    await expect(
+      webviewPage.locator('[data-testid="compaction-hint"]'),
+    ).toHaveCount(0);
+    await expect(
+      webviewPage.locator('[data-testid="compaction-hint-tail"]'),
+    ).toHaveCount(0);
+  });
+});

--- a/packages/webview/src/components/MessageList.tsx
+++ b/packages/webview/src/components/MessageList.tsx
@@ -689,6 +689,19 @@ export const MessageList = forwardRef<
     return () => observer.disconnect();
   }, [doScrollToBottom]);
 
+  // The compaction hint mounts below the last message (after the virtualizer's
+  // in-flow spacer). scrollToEnd only accounts for row heights, so a pinned
+  // viewport stays short by the hint's own height — the loading text and its
+  // streaming tail would sit just below the fold. Re-pin to the true bottom
+  // (scrollHeight includes the hint) when compaction starts; the hint is a
+  // static one-liner, so no re-pin is needed as its tail grows. Respect an
+  // opt-out: a user reading history isn't yanked back down.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!isCompacting || !container || userScrolledUpRef.current) return;
+    container.scrollTop = container.scrollHeight;
+  }, [isCompacting]);
+
   return (
     <div
       ref={containerRef}

--- a/packages/webview/src/styles/Message.css
+++ b/packages/webview/src/styles/Message.css
@@ -149,6 +149,13 @@
 }
 
 .compaction-hint {
+  /* The hint sits after the virtualizer's in-flow spacer (flex-shrink: 0) in
+     the flex-column message container. Without an explicit flex-shrink: 0 the
+     hint — the only remaining shrinkable item once the spacer fills the
+     column — absorbs all the negative free space and collapses to zero height
+     (overflow: hidden then clips the streaming tail too), making the loading
+     text and tail invisible. */
+  flex-shrink: 0;
   align-self: flex-start;
   max-width: 100%;
   padding-left: 2px;


### PR DESCRIPTION
## 症状

桌面端（VSCE/JB 共享同一 webview）压缩期间的 loading 文案「正在压缩对话」和「最后 30 字符流式尾部」预览不可见。

## 根因（双因子叠加）

1. **flexbox 压缩成 0 高（主因）**：`.messages-container` 是 flex column；虚拟化 spacer（`flex-shrink: 0`，承载全部行高）占满容器后，`.compaction-hint` 是唯一可压缩项（默认 `flex-shrink: 1`）→ 吸收全部负自由空间塌成 0 高；hint 自身 `overflow: hidden` 连带把流式尾部也裁掉。
2. **挂载后不重钉（次因）**：`virtualizer.scrollToEnd` 只计算行高、不含 hint（spacer 之后 +15px），hint 即使有高度仍停在视口下缘外。

回归判定：非 #1876 虚拟化回归——旧版 plain 分支长聊天同样 0 高（仅短聊天无溢出时可见），pre-existing bug 被全量虚拟化放大。

## 修复（2 处，webview 共享三端）

- `Message.css`：`.compaction-hint` 加 `flex-shrink: 0`，保持自身高度、不再被裁剪
- `MessageList.tsx`：新增 `useEffect([isCompacting])`，compaction 开始时 `container.scrollTop = container.scrollHeight` 重钉真底部（尊重 `userScrolledUpRef`）

## 验证

- 新增 e2e 回归测试 `packages/webview/e2e/compaction-hint-visible.e2e.ts`（真实 Chromium 断言 hint 高度 > 0、完全在视口内、尾部同样可见、结束消失；**fail-without-fix 验证过**）
- 全量测试：webview 单测 797/797、webview e2e 30/30、desktop 556/556、type-check、lint 0 错
- UI 截图（/tmp/compaction-loading-state1.png 仅提示、state2.png 提示+尾部）+ 像素非空校验 + vision 逐字确认