### PR TITLE
chore(desktop): rename window title to Codewave IDE

### DIFF
--- a/packages/desktop/scripts/syncWebview.mjs
+++ b/packages/desktop/scripts/syncWebview.mjs
@@ -82,7 +82,7 @@ const html = `<!DOCTYPE html>
   <meta charset="UTF-8" />
   <meta http-equiv="Content-Security-Policy" content="${CSP}" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Wave 代码智聊</title>
+  <title>Codewave IDE</title>
   <style>
 ${darkThemeCss}
 ${lightThemeCss}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -273,7 +273,7 @@ function createWindow(): void {
     height: 840,
     minWidth: 720,
     minHeight: 480,
-    title: "Wave",
+    title: "Codewave IDE",
     backgroundColor: "#1e1e1e",
     webPreferences: {
       preload: path.join(__dirname, "preload.cjs"),


### PR DESCRIPTION
桌面端窗口标题从「Wave 代码智聊」改为「Codewave IDE」：

- `packages/desktop/scripts/syncWebview.mjs` — 生成的 index.html `<title>`（页面加载后覆盖窗口标题，用户实际看到的）
- `packages/desktop/src/main/index.ts` — BrowserWindow fallback title（页面加载前的瞬间）