### PR TITLE
ci: run JetBrains tests post-merge only

### DIFF
--- a/.github/workflows/ci-jetbrains.yml
+++ b/.github/workflows/ci-jetbrains.yml
@@ -3,13 +3,12 @@ name: CI (JetBrains)
 # Runs the JetBrains plugin's Gradle (JUnit) test suite.
 # The Node-based `pnpm -r test` in ci.yml skips this package (it has no
 # package.json), so without this workflow BinaryResolver and other Kotlin
-# logic has no merge gate.
+# logic has no test coverage.
 
 on:
-  # Merge gate on PRs and post-merge gate on main (aligned with ci.yml).
+  # Post-merge only (aligned with ci.yml's integration job and ci-windows.yml):
+  # not gating PRs; runs after merge to main or manually via workflow_dispatch.
   # dorny/paths-filter below skips all steps for non-JetBrains changes.
-  pull_request:
-    branches: [main, develop]
   push:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
Move `check-jetbrains` out of the PR gate: the JetBrains Gradle test suite now runs only after merge to main (push) or via workflow_dispatch, aligned with ci.yml's integration job and ci-windows.yml.

- Remove the `pull_request` trigger from ci-jetbrains.yml
- Update workflow header comment