### PR TITLE
fix(webview): IDE 插件欢迎页恢复旧 W logo 与副标题，品牌+输入卡成组居中

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -2413,7 +2413,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   ) : (
     <>
       {showWelcomeReady ? (
-        <WelcomeView />
+        <WelcomeView isDesktop={isDesktop} />
       ) : showWelcome ? (
         <LoadingLogo />
       ) : (
@@ -2696,7 +2696,11 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   const chatContainer = (
     <div
       className={`chat-container${
-        isDesktop && showWelcomeReady ? " chat-container--welcome" : ""
+        showWelcomeReady
+          ? isDesktop
+            ? " chat-container--welcome"
+            : " chat-container--welcome-ide"
+          : ""
       }${dragActive ? " drag-active" : ""}`}
       data-testid="chat-container"
       ref={isDesktop ? chatContainerRef : undefined}
@@ -2785,7 +2789,17 @@ export const ChatApp: React.FC<ChatAppProps> = ({
           ))}
         </div>
       ) : (
-        chatBodyContent
+        // IDE hosts: the chat body always renders inside two flex wrappers.
+        // Outside the welcome page they are plain flex-column pass-throughs
+        // (layout equivalent to the old flat fragment); on the welcome page the
+        // CSS switches them to group-centering (brand + input card together,
+        // same as the desktop welcome scene). The wrappers are always present
+        // so entering/leaving the welcome page never unmounts the input card
+        // (e.g. the abort button must survive clearing the chat while
+        // streaming).
+        <div className="ide-chat-wrap">
+          <div className="ide-chat-main">{chatBodyContent}</div>
+        </div>
       )}
     </div>
   );

--- a/packages/webview/src/components/WelcomeView.tsx
+++ b/packages/webview/src/components/WelcomeView.tsx
@@ -7,14 +7,37 @@
  * entry lives in the chat header (IDE hosts) or the sidebar account card
  * (desktop) instead of the welcome page.
  *
- * Design ref: designer welcome scene — large "Codewave. IDE" wordmark as the
- * sole visual focus above the input card (spec 场景 5).
+ * Brand mark differs by host: IDE plugins show the classic red rounded square
+ * with the Wave "W" (the original welcome logo); desktop keeps the designer
+ * "Codewave. IDE" wordmark (desktop-app spec 场景「品牌标识行」).
  */
 
 import React from "react";
 import { CodewaveLogo } from "./CodewaveLogo";
 
-const WelcomeView: React.FC = () => {
+export interface WelcomeViewProps {
+  /** Desktop renders the designer wordmark; IDE hosts render the classic W mark. */
+  isDesktop?: boolean;
+}
+
+// Wave "W" mark from the Figma design (node 2171:1482 logo vector).
+const WaveLogo: React.FC<{ size?: number }> = ({ size = 20 }) => (
+  <svg
+    width={size}
+    height={size * (15.104 / 25.5993)}
+    viewBox="0 0 25.5993 15.104"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    style={{ display: "block" }}
+  >
+    <path
+      d="M2.32466 12.9419C3.04151 13.6243 3.86207 14.1524 4.78633 14.526C5.7398 14.9113 6.73593 15.104 7.77473 15.104H12.5072C12.5851 15.104 12.6533 15.0752 12.7119 15.0176C12.7518 14.9782 12.7783 14.9344 12.7915 14.8859L13.9954 13.1584L14.0015 13.1465C14.0563 13.0384 14.0585 12.9345 14.0078 12.8348C13.951 12.7231 13.858 12.6672 13.7285 12.6672H7.67293C6.96043 12.6672 6.27962 12.5314 5.63051 12.2597C5.00214 11.9967 4.44748 11.6255 3.96652 11.1461C3.48429 10.6655 3.11394 10.1136 2.85544 9.49056C2.58707 8.84372 2.45889 8.16525 2.47092 7.45516C2.48292 6.7705 2.63214 6.11627 2.91857 5.49251C3.1943 4.89205 3.57848 4.35875 4.0711 3.89258C4.56134 3.42865 5.12142 3.0666 5.75134 2.8064C6.39978 2.53854 7.07532 2.39864 7.77799 2.38672H12.609C12.6953 2.38672 12.7741 2.35163 12.8454 2.28149L12.8581 2.26904L14.0972 0.49113L14.1032 0.479248C14.1581 0.371192 14.1603 0.267354 14.1096 0.167643C14.0528 0.0559081 13.9597 0 13.8303 0H7.67293C6.6227 0 5.61914 0.201072 4.66222 0.603272C3.73841 0.991561 2.92209 1.53936 2.21329 2.24658C1.50448 2.95381 0.958726 3.7651 0.576002 4.68042C0.179579 5.6285 -0.0122216 6.61985 0.000602802 7.65454C0.0054108 8.03761 0.038572 8.41397 0.10009 8.78361C0.134957 8.99312 0.178923 9.20052 0.232007 9.40576C0.335027 9.80398 0.472363 10.1941 0.643995 10.5761C1.04481 11.4682 1.60502 12.2568 2.32466 12.9419ZM16.7891 14.9207L13.9053 9.73324C13.7977 9.5397 13.7979 9.30431 13.9056 9.11084L16.7718 3.96533L16.7905 3.94661C16.861 3.87555 16.9395 3.84001 17.0258 3.84001H18.9098C19.0387 3.84001 19.1311 3.8963 19.1871 4.00895C19.236 4.10749 19.2339 4.21021 19.1809 4.31706L19.1789 4.32088L19.1769 4.32471L16.5245 9.1123C16.4177 9.3051 16.4176 9.53923 16.5243 9.7321L19.2286 14.6231L19.2305 14.627C19.2857 14.7382 19.2776 14.8477 19.2062 14.9556C19.1407 15.0545 19.0584 15.104 18.9593 15.104H17.0754C16.9064 15.104 16.811 15.0429 16.7891 14.9207ZM22.8995 9.1123L20.2471 4.32471L20.2451 4.32088L20.2431 4.31706C20.19 4.21021 20.188 4.10747 20.2369 4.00895C20.2929 3.8963 20.3853 3.84001 20.5143 3.84001H22.3982C22.4845 3.84001 22.563 3.87555 22.6336 3.94661L22.6522 3.96533L25.5185 9.11084C25.6262 9.30431 25.6263 9.5397 25.5187 9.73324L22.6349 14.9206C22.6131 15.0428 22.5176 15.104 22.3486 15.104H20.4647C20.3656 15.104 20.2834 15.0545 20.2179 14.9556C20.1464 14.8477 20.1383 14.7382 20.1935 14.627L20.1955 14.6231L22.8998 9.73218C23.0064 9.53931 23.0063 9.3051 22.8995 9.1123Z"
+      fill="white"
+    />
+  </svg>
+);
+
+const WelcomeView: React.FC<WelcomeViewProps> = ({ isDesktop = false }) => {
   return (
     <div
       style={{
@@ -38,10 +61,46 @@ const WelcomeView: React.FC = () => {
           padding: "0 16px",
         }}
       >
-        {/* Brand wordmark (same SVG as the designer welcome scene's logo) */}
+        {/* Brand mark */}
         <div data-testid="welcome-wordmark">
-          <CodewaveLogo height={24} />
+          {isDesktop ? (
+            <CodewaveLogo height={24} />
+          ) : (
+            <div
+              style={{
+                width: "32px",
+                height: "32px",
+                background: "var(--vscode-brand-primary, #c1292e)",
+                borderRadius: "8px",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+              }}
+            >
+              <WaveLogo size={20} />
+            </div>
+          )}
         </div>
+        {/* Product subtitle under the classic W mark (IDE hosts) — restored from
+            the pre-batch-2 welcome page, which paired the mark with the product
+            name line. The desktop wordmark already carries the brand name, so
+            no subtitle there. */}
+        {!isDesktop && (
+          <div
+            data-testid="welcome-subtitle"
+            style={{
+              fontSize: "13px",
+              fontFamily:
+                '"PingFang SC", var(--vscode-font-family, sans-serif)',
+              fontWeight: 600,
+              color: "var(--vscode-foreground, white)",
+              lineHeight: "18px",
+            }}
+          >
+            Hi~ 欢迎使用 Wave 代码智聊
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/webview/src/styles/ChatApp.css
+++ b/packages/webview/src/styles/ChatApp.css
@@ -51,6 +51,50 @@
   line-height: 20px;
 }
 
+/* IDE hosts (VS Code / JetBrains) chat body wrappers (.ide-chat-wrap/main):
+   always rendered — plain flex-column pass-throughs in normal chat, and
+   group-centering on the welcome page. Keeping the wrappers constant means
+   entering/leaving the welcome page never unmounts the input card (e.g. the
+   abort button survives clearing the chat while streaming). */
+.ide-chat-wrap,
+.ide-chat-main {
+  display: flex;
+  flex-direction: column;
+}
+.ide-chat-wrap {
+  flex: 1;
+  min-height: 0;
+}
+.ide-chat-main {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+}
+
+/* Welcome page (IDE hosts): brand mark + input card center as one group —
+   same layout as the desktop welcome scene. The header is taken out of flow
+   (pinned to the top) so the group centers against the whole viewport;
+   without this the mark would center in the area above the input and sit
+   ~280px away from it on a typical 800px window. */
+.chat-container--welcome-ide > .chat-header {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 5;
+}
+.chat-container--welcome-ide > .ide-chat-wrap {
+  height: auto;
+  align-items: center;
+  justify-content: center;
+}
+.chat-container--welcome-ide .ide-chat-main {
+  flex: none;
+  height: auto;
+  width: 100%;
+  gap: 44px;
+}
+
 /* Desktop drag-and-drop upload overlay, shown while a file hovers the pane.
    pointer-events: none keeps normal input working while dragging. Highlight
    uses the theme focus color (same semantics as the config dialog's active


### PR DESCRIPTION
## 背景

批次 2 视觉还原把欢迎页简化为设计师 Codewave 字标后，IDE 插件（VS Code/JetBrains）欢迎页需要回归之前的品牌形态：

- 换回之前的 logo：红色圆角方块 + 白色 Wave "W"（Figma 2171:1482）
- W logo 下方恢复副标题「Hi~ 欢迎使用 Wave 代码智聊」
- 桌面端按 spec（desktop-app.md:877「居中显示品牌标识」）保留设计师字标

## 改动

**packages/webview/src/components/WelcomeView.tsx**
- 新增 `isDesktop` prop：IDE 宿主显示旧 W logo + 副标题，desktop 保留 Codewave 字标（无副标题）

**packages/webview/src/components/ChatApp.tsx**
- IDE 聊天体恒渲染两层 flex 包装（`.ide-chat-wrap` > `.ide-chat-main`），非欢迎态为纯 flex 传递（布局与原先完全一致），欢迎态由 CSS 切换为成组居中

**packages/webview/src/styles/ChatApp.css**
- `.chat-container--welcome-ide`：header 不占流（钉顶），品牌+输入卡成组垂直居中（gap 44px），与桌面端 welcome 场景同款

## 关键设计

- 之前尝试「欢迎态分支切换包装结构」导致清空消息进入欢迎态时 React 卸载/重挂输入卡（abort 按钮闪断，clearChat 测试当场抓出）→ 改为恒渲染两层包装，树结构稳定，仅切 CSS 类
- 布局验证（原型预览 DOM 探针，1000x800）：欢迎态 logo+输入卡组中心 y=400；非欢迎态消息区+输入卡贴底与原布局逐像素一致

## 验证

- webview 单测 27/27（welcomeViewFlash / clearChat / basicMessageFlow / sessionManagement）
- type-check 全仓通过