### PR TITLE
fix(webview): plan panel content scrolls instead of being clipped

### DIFF
--- a/packages/webview/src/styles/PlanPane.css
+++ b/packages/webview/src/styles/PlanPane.css
@@ -1,6 +1,13 @@
 /* Plan panel (desktop): plan full text beside the conversation. Reuses the
    shared preview-pane frame (drag handle / toolbar) from DesktopApp.css. */
 
+/* The shared .preview-pane-body has no overflow (its iframe-based panels
+   scroll internally); the plan text is a static div, so scroll here or the
+   .preview-pane-inner overflow:hidden clips it. */
+.plan-pane .preview-pane-body {
+  overflow-y: auto;
+}
+
 .plan-pane-markdown {
   padding: 12px 16px;
 }


### PR DESCRIPTION
## 问题

桌面端 plan 面板（ExitPlanMode 计划全文预览）内容超出面板高度时无法滚动，内容被裁切；文件面板（FilePane）可以正常滚动。

## 根因

PlanPane 复用的共享面板框架里，`.preview-pane-body`（DesktopApp.css）没有设置 overflow，而父容器 `.preview-pane-inner` 是 `overflow: hidden`，所以 plan 内容超出时被直接裁掉。FilePane 没有复用该框架，自己的 `.file-pane-body` 带 `overflow: auto`，因此能滚动。

## 修复

`packages/webview/src/styles/PlanPane.css` 给 `.plan-pane .preview-pane-body` 加 `overflow-y: auto`，toolbar 保持固定、内容区域滚动（与 FilePane 同模式）。

## 验证

- `chatAppPanels.test.tsx` 44 个测试通过
- 真实浏览器（Playwright + Edge）实测：body clientHeight 575 / scrollHeight 1168，overflowY auto，可滚动