### PR TITLE
fix(desktop): 分屏关闭按钮并入 header 按钮流垂直居中

### DIFF
--- a/packages/webview/e2e/desktop-split-view.e2e.ts
+++ b/packages/webview/e2e/desktop-split-view.e2e.ts
@@ -59,6 +59,12 @@ test.describe("Desktop split-view panes", () => {
       closeBox!.y + closeBox!.height > toggleBox!.y;
     expect(intersects).toBe(false);
 
+    // The close button must be vertically centered with the header buttons
+    // (44px header, 22px button) — not pinned to the top edge.
+    const closeCenterY = closeBox!.y + closeBox!.height / 2;
+    const toggleCenterY = toggleBox!.y + toggleBox!.height / 2;
+    expect(Math.abs(closeCenterY - toggleCenterY)).toBeLessThanOrEqual(1.5);
+
     await screenshotWebp(
       webviewPage,
       "../../docs/public/screenshots/desktop-split-view.webp",

--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -245,6 +245,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   host,
   paneId,
   sidebarExpandButton,
+  headerActions,
 }) => {
   const [state, dispatch] = useReducer(chatReducer, initialState);
   const [queueEditWarning, setQueueEditWarning] = useState<string | null>(null);
@@ -2776,6 +2777,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({
               }
             : undefined
         }
+        headerActions={headerActions}
       />
       {isDesktop ? (
         <div

--- a/packages/webview/src/components/ChatHeader.tsx
+++ b/packages/webview/src/components/ChatHeader.tsx
@@ -27,6 +27,7 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
   showLoginButton = false,
   panelToggle,
   leading,
+  headerActions,
 }) => {
   const [showSessionList, setShowSessionList] = useState(false);
   const [showMoreMenu, setShowMoreMenu] = useState(false);
@@ -109,6 +110,7 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
             </button>
           </Tooltip>
         )}
+        {headerActions}
       </div>
       {showSessionList && (
         <SessionListPopup

--- a/packages/webview/src/components/DesktopShell.tsx
+++ b/packages/webview/src/components/DesktopShell.tsx
@@ -758,7 +758,7 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
                               if (el) paneNodes.current.set(pane.paneId, el);
                               else paneNodes.current.delete(pane.paneId);
                             }}
-                            className={`desktop-pane${pane.paneId === focusedPaneId ? " desktop-pane--focused" : ""}${panes.length > 1 ? " desktop-pane--closable" : ""}`}
+                            className={`desktop-pane${pane.paneId === focusedPaneId ? " desktop-pane--focused" : ""}`}
                             style={paneStyle}
                             onMouseDown={() => handleFocusPane(pane.paneId)}
                             onDragOver={(e) =>
@@ -767,17 +767,6 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
                             onDrop={(e) => handlePaneDrop(e, rowIdx)}
                             data-testid={`desktop-pane-${pane.paneId}`}
                           >
-                            {panes.length > 1 && (
-                              <button
-                                className="desktop-pane-close"
-                                title="关闭分屏"
-                                onMouseDown={(e) => e.stopPropagation()}
-                                onClick={() => handleClosePane(pane.paneId)}
-                                data-testid={`desktop-pane-close-${pane.paneId}`}
-                              >
-                                <span className="codicon codicon-close"></span>
-                              </button>
-                            )}
                             <ChatApp
                               vscode={vscode}
                               host={host}
@@ -786,6 +775,18 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
                                 rowIdx === 0 && index === 0
                                   ? sidebarExpandButton
                                   : undefined
+                              }
+                              headerActions={
+                                panes.length > 1 ? (
+                                  <button
+                                    className="desktop-pane-close"
+                                    title="关闭分屏"
+                                    onClick={() => handleClosePane(pane.paneId)}
+                                    data-testid={`desktop-pane-close-${pane.paneId}`}
+                                  >
+                                    <span className="codicon codicon-close"></span>
+                                  </button>
+                                ) : undefined
                               }
                             />
                           </div>

--- a/packages/webview/src/styles/DesktopApp.css
+++ b/packages/webview/src/styles/DesktopApp.css
@@ -1183,32 +1183,27 @@ body.is-panel-resizing webview {
   pointer-events: none;
 }
 
-/* Multi-pane: reserve top-right header space for the overlay close button so
-   it never covers the header's right-most button (panel toggle). */
-.desktop-pane--closable .chat-header {
-  padding-right: 34px;
-}
-
+/* Pane close button lives inside the header's button row (flex, vertically
+   centered like every other header button) — threaded in via ChatApp's
+   headerActions slot. Slightly dimmed: closing a split is a secondary action. */
 .desktop-pane-close {
-  position: absolute;
-  top: 6px;
-  right: 6px;
-  z-index: 6;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  background-color: transparent;
+  color: var(--vscode-foreground);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 3px;
-  border: none;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--vscode-foreground);
-  opacity: 0.6;
-  cursor: pointer;
+  opacity: 0.7;
 }
 
 .desktop-pane-close:hover {
   opacity: 1;
-  background: var(--vscode-list-hoverBackground);
+  background-color: var(--vscode-toolbar-hoverBackground);
 }
 
 /* ---- Conversation-level panel group: message column + side panels ----

--- a/packages/webview/src/types/index.ts
+++ b/packages/webview/src/types/index.ts
@@ -204,6 +204,12 @@ export interface ChatAppProps {
    * instance that owns the collapse state and threaded through DesktopShell.
    */
   sidebarExpandButton?: React.ReactNode;
+  /**
+   * Desktop split-view: extra actions rendered at the right edge of the chat
+   * header's button row (pane close button). Kept out of the shared header's
+   * own JSX so split-view concerns stay in the desktop layer.
+   */
+  headerActions?: React.ReactNode;
 }
 
 /**
@@ -549,6 +555,8 @@ export interface ChatHeaderProps {
   panelToggle?: PanelToggleProps;
   /** Optional slot at the header's left edge (desktop sidebar expand button). */
   leading?: React.ReactNode;
+  /** Extra actions at the right edge of the button row (desktop pane close). */
+  headerActions?: React.ReactNode;
 }
 
 // Matches wave-agent-sdk's QueuedMessage type


### PR DESCRIPTION
## 问题

并排分屏时顶栏 close 图标未垂直居中（偏上约 5px）。根因：close 按钮以 absolute 叠加在 pane 顶栏并手算 `top: 6px`，而 header 其他按钮在 flex 流内由 `align-items: center` 居中。

## 改动

- close 按钮改经 `ChatApp headerActions` 插槽注入 `header-buttons` flex 流（与 `panelToggle` 同款先例），垂直居中由 flex 天然保证
- `.desktop-pane-close` 改为与 `.header-button` 同款样式（22×22、hover `--vscode-toolbar-hoverBackground`）
- 删除两个 hack：`padding-right: 34px` 预留空间、手算 `top`
- 删除无 CSS 规则的 `desktop-pane--closable` 死类
- e2e 新增垂直居中断言（close 按钮中心与 header 按钮中心差 ≤1.5px）作回归保护

## 验证

- type-check / build 通过
- `desktop-split-view` e2e 2/2
- `desktopApp.test.tsx` 102/102
- oxlint 0 警告 0 错误