### PR TITLE
feat(webview): linkify URLs in bash command output

### DIFF
--- a/docs/specs/ui/markdown-links.md
+++ b/docs/specs/ui/markdown-links.md
@@ -1,6 +1,6 @@
 ---
 name: "Webview 链接解析"
-description: "webview 消息 markdown 中链接的解析与点击行为：普通链接、行内代码内的 URL 提升为可点击链接"
+description: "webview 中链接的解析与点击行为：消息 markdown、行内代码内的 URL、bash 命令输出中的 URL"
 order: 245
 ---
 
@@ -8,7 +8,9 @@ order: 245
 
 **创建日期**：2026-08-21
 
-> 本规格覆盖 VS Code / JetBrains / Desktop 共享 webview（`packages/webview`）中消息 markdown 渲染的链接行为。链接点击后的宿主路由（desktop 的 localhost 预览面板分流）见 [桌面应用](desktop-app.md)，此处不重复。
+**最近更新**：2026-08-28（新增 bash 命令输出中的 URL 链接化）
+
+> 本规格覆盖 VS Code / JetBrains / Desktop 共享 webview（`packages/webview`）中链接的解析与点击行为，包括消息 markdown 渲染与 bash 命令输出。链接点击后的宿主路由（desktop 的 localhost 预览面板分流）见 [桌面应用](desktop-app.md)，此处不重复。
 
 ## 用户场景与测试 _（必填）_
 
@@ -30,9 +32,29 @@ order: 245
 
 ---
 
+## 用户故事：bash 命令输出中的 URL 可点击（优先级：P1）
+
+作为用户，我希望 bash 命令输出（`.bash-command-output`）中的 http(s) URL 被解析为可点击链接，且点击行为与消息文本链接一致（desktop 上 localhost 链接在预览面板打开、其余链接用系统浏览器，IDE 上按原生链接处理），以便运行本地服务或查看命令日志时直接点击访问，无需手动复制。
+
+**为什么是这个优先级**：运行 `python -m http.server`、`npm run dev` 等命令时，输出中的 `http://localhost:8000/` 类地址是高频操作目标；当前 bash 输出为纯文本、不可点击，用户只能复制粘贴。
+
+**独立测试**：渲染包含裸 URL（如 `Server running at http://localhost:8000/`）的 bash tool result，验证 URL 渲染为可点击链接、其余文本保持原样，点击行为与消息文本链接一致。
+
+**验收场景**：
+
+1. **假设** bash 命令输出含裸 http(s) URL（如 `Server started at http://localhost:8000/`），**当**渲染时，**则** URL 渲染为可点击链接，其余文本保持原样；点击行为与消息文本链接一致——desktop 上 localhost 链接在预览面板打开、其余链接用系统浏览器，IDE 上按原生链接处理。
+2. **假设** URL 首尾带标点（如 `visit https://example.com.` 或 `（https://example.com）`），**当**渲染时，**则**链接可点击，且首尾标点（含中文标点）不进入链接目标。
+3. **假设**输出含 `javascript:`、`file:` 等非 http(s) 协议、`<script>` 等 HTML 片段或 `&`、`<` 等需转义字符，**当**渲染时，**则**不生成链接，非 URL 文本经 HTML 转义后按原文展示，无注入风险。
+4. **假设**输出为纯文本无 URL（如错误信息），**当**渲染时，**则**保持原样展示，渲染路径无行为变化。
+5. **假设**命令输出为多行且部分行含 URL，**当**渲染时，**则**仅含 URL 的行内生成链接，其余行保持原样，换行结构不变。
+
+---
+
 ## 边界情况
 
+- **bash 命令输入行（`.bash-command-input`）里的 URL 怎么办？** 不处理——仅链接化输出（result），命令本身保持代码样式原文。命令是 agent 执行的代码而非用户阅读的地址。
+- **其他工具 result（`.result-raw`、`.lsp-output` 等）里的 URL 怎么办？** 不在本次范围内，保持纯文本；如后续需要可复用同一链接化函数扩展。
 - **行内代码内含多个 URL（如 `` `https://a.com https://b.com` ``）怎么办？** 内容整体不是单个 URL，保持代码原文、不生成链接，避免歧义。
 - **围栏代码块中的 URL 怎么办？** 不处理，保持代码块原文，用户仅期望行内代码场景。
 - **推理（reasoning）文本块中的行内代码怎么办？** 与助手文本一致——共用同一 markdown 渲染路径，行为自然对齐。
-- **安全如何保证？** 仅 http(s) 协议被提升为链接，`javascript:` 等危险协议不生成链接；渲染结果仍经 DOMPurify 过滤。
+- **安全如何保证？** 仅 http(s) 协议被提升为链接，`javascript:` 等危险协议不生成链接；非 URL 文本在注入前完整 HTML 转义；渲染结果仍经 DOMPurify 过滤。

--- a/packages/webview/src/components/Message.tsx
+++ b/packages/webview/src/components/Message.tsx
@@ -2,6 +2,10 @@ import React from "react";
 import { ContextTag } from "./ContextTag";
 import { parseMentions, toRelativePath } from "../utils/messageUtils";
 import { isLocalhostUrl } from "../utils/isLocalhostUrl";
+import {
+  linkifyPlainText,
+  stripTrailingUrlPunct,
+} from "../utils/linkifyPlainText";
 import { marked } from "marked";
 import { Tooltip } from "./Tooltip";
 
@@ -49,48 +53,9 @@ marked.use({
   },
 });
 
-// 剥离裸 URL 尾部的中文标点。marked 默认 url tokenizer 的 _backpedal 正则只
-// 剔除 ASCII 标点（?!.,:;*_'"~()&），中文标点（。、（ 等）会被百分号编码进
-// href，点击打开错误链接（如 "https://example.com。" → href 带 %E3%80%82）。
-// 标点集合对齐 extractClickableUrl；成对中文括号（如 "（帮助文档）"）整体
-// 剥离，孤立的开括号（如 "（"）也剥掉。
-const stripTrailingCjkPunct = (url: string): string => {
-  const closingPairs: Record<string, string> = {
-    "）": "（",
-    "」": "「",
-    "』": "『",
-    "】": "【",
-  };
-  const plainPunct = "，。、；：！？…";
-  let s = url;
-  for (;;) {
-    const last = s[s.length - 1];
-    if (!last) break;
-    if (plainPunct.includes(last)) {
-      s = s.slice(0, -1);
-      continue;
-    }
-    const open = closingPairs[last];
-    if (open) {
-      const openIdx = s.lastIndexOf(open);
-      if (openIdx >= 0) {
-        s = s.slice(0, openIdx); // 成对中文括号（注释/说明）整体剥离
-        continue;
-      }
-      s = s.slice(0, -1);
-      continue;
-    }
-    if (Object.values(closingPairs).includes(last)) {
-      s = s.slice(0, -1); // 孤立中文开括号
-      continue;
-    }
-    break;
-  }
-  return s;
-};
-
 // 在默认 url tokenizer 之上剥离尾部中文标点；返回 false 时 marked.use 会
 // 回退到默认实现（url tokenizer 被 marked.use 包装，实例共享默认 rules）。
+// ASCII 标点已由默认实现的 _backpedal 剔除，剥离函数对 ASCII 是 no-op。
 const baseUrlTokenizer = new marked.Tokenizer();
 
 marked.use({
@@ -98,7 +63,7 @@ marked.use({
     url(src: string) {
       const token = baseUrlTokenizer.url.call(this, src);
       if (!token) return false;
-      const raw = stripTrailingCjkPunct(token.raw);
+      const raw = stripTrailingUrlPunct(token.raw);
       if (raw === token.raw) return token;
       // href 可能是 raw 加前缀的形式（www. → "http://" + raw）；token.text
       // 是 raw 的转义形式（默认实现 escape(cap[0])），中文标点在转义中
@@ -108,7 +73,7 @@ marked.use({
         : "";
       token.raw = raw;
       token.href = prefix + raw;
-      token.text = stripTrailingCjkPunct(token.text);
+      token.text = stripTrailingUrlPunct(token.text);
       token.tokens = [{ type: "text", raw: token.text, text: token.text }];
       return token;
     },
@@ -410,11 +375,19 @@ export const Message: React.FC<MessageProps> = React.memo(
         if (result) {
           // Show both input and output if result is present (even if running)
           return (
-            <div className="bash-command-unified">
+            <div className="bash-command-unified" onClick={handleContentClick}>
               <div className="bash-command-input">
                 <span className="bash-command">{command}</span>
               </div>
-              <div className="bash-command-output">{result}</div>
+              {/* 输出中的裸 http(s) URL 链接化（见 specs/ui/markdown-links.md），
+                  点击路由复用 handleContentClick：desktop 上 localhost → 预览
+                  面板、其余 → 系统浏览器；IDE 保持原生链接处理。 */}
+              <div
+                className="bash-command-output"
+                dangerouslySetInnerHTML={{
+                  __html: linkifyPlainText(result),
+                }}
+              />
             </div>
           );
         } else {

--- a/packages/webview/src/styles/Message.css
+++ b/packages/webview/src/styles/Message.css
@@ -567,6 +567,16 @@
   font-family: var(--vscode-editor-font-family);
 }
 
+.bash-command-output a {
+  color: var(--vscode-textLink-foreground);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.bash-command-output a:hover {
+  color: var(--vscode-textLink-activeForeground);
+}
+
 .lsp-output {
   padding: 4px 8px;
   background-color: var(--vscode-textCodeBlock-background);

--- a/packages/webview/src/utils/linkifyPlainText.ts
+++ b/packages/webview/src/utils/linkifyPlainText.ts
@@ -1,0 +1,106 @@
+// 纯文本区域（bash 命令输出等）的裸 http(s) URL 链接化。与消息 markdown
+// 不同，这里不经过 marked——输出是终端风格的纯文本，注入 HTML 前必须完整
+// 转义非 URL 文本，且仅 http(s) 协议生成链接（javascript: 等危险协议不生成，
+// 防注入）。
+//
+// 点击路由不在本文件处理：生成的 <a> 由容器上的 handleContentClick（desktop
+// 上 localhost → 预览面板、其余 → 系统浏览器；IDE 原生处理）统一接管。
+
+// 剥离裸 URL 尾部的 ASCII/中文标点。marked 默认 url tokenizer 的
+// _backpedal 正则只剔除 ASCII 标点（?!.,:;*_'"~()&），中文标点（。、（ 等）
+// 会被百分号编码进 href，点击打开错误链接（如 "https://example.com。" →
+// href 带 %E3%80%82）。这里对纯文本链接化同时处理两类标点。
+//
+// 注意括号语义差异：ASCII 括号成对时是 URL 内容（如 "/foo(bar)"、
+// "wiki_(disambiguation)"），保留；孤立闭括号（如 "(https://a.com)" 中的
+// ")"）剥离。中文括号成对时多为注释（如 "（帮助）"），整体剥离。
+const asciiPunct = "!?.,:;*_~'\"&";
+const plainCjkPunct = "，。、；：！？…";
+
+// 成对中文括号整体剥离（如 "（帮助文档）"），孤立开括号（如 "（"）也剥掉。
+const closingPairs: Record<string, string> = {
+  "）": "（",
+  "」": "「",
+  "』": "『",
+  "】": "【",
+};
+
+export function stripTrailingUrlPunct(url: string): string {
+  let s = url;
+  for (;;) {
+    const last = s[s.length - 1];
+    if (!last) break;
+    if (asciiPunct.includes(last) || plainCjkPunct.includes(last)) {
+      s = s.slice(0, -1);
+      continue;
+    }
+    if (last === ")") {
+      // ASCII 成对括号是 URL 内容，保留；孤立闭括号剥离
+      if (s.lastIndexOf("(", s.length - 1) >= 0) break;
+      s = s.slice(0, -1);
+      continue;
+    }
+    if (last === "(") {
+      s = s.slice(0, -1);
+      continue;
+    }
+    const open = closingPairs[last];
+    if (open) {
+      const openIdx = s.lastIndexOf(open);
+      if (openIdx >= 0) {
+        s = s.slice(0, openIdx); // 成对中文括号（注释/说明）整体剥离
+        continue;
+      }
+      s = s.slice(0, -1);
+      continue;
+    }
+    if (Object.values(closingPairs).includes(last)) {
+      s = s.slice(0, -1); // 孤立中文开括号
+      continue;
+    }
+    break;
+  }
+  return s;
+}
+
+const escapeHtml = (s: string): string =>
+  s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+// 非空白序列。URL 尾部标点由 stripTrailingUrlPunct 在候选上剥离。
+const URL_RE = /https?:\/\/\S+/g;
+
+// 将纯文本中的裸 http(s) URL 转为 <a> 链接，其余文本完整 HTML 转义后按
+// 原文返回。返回的 HTML 字符串可安全用于 dangerouslySetInnerHTML。
+export function linkifyPlainText(text: string): string {
+  if (!text) return "";
+  let html = "";
+  let lastIndex = 0;
+  for (const match of text.matchAll(URL_RE)) {
+    const rawUrl = match[0];
+    const index = match.index!;
+    html += escapeHtml(text.slice(lastIndex, index));
+    const url = stripTrailingUrlPunct(rawUrl);
+    if (/^https?:\/\/\S+$/i.test(url)) {
+      html += `<a href="${escapeHtml(url)}">${escapeHtml(url)}</a>`;
+      // 剥离掉的后缀：含开括号的成对中文括号（注释/说明，如
+      // "（帮助）"）整体丢弃，纯尾部标点（如 "。"、"）"）作为普通文本
+      // 保留显示——标点不进链接目标，但输出原文保持可见。
+      const remainder = rawUrl.slice(url.length);
+      const hasOpeningBracket = Object.values(closingPairs).some((open) =>
+        remainder.includes(open),
+      );
+      if (!hasOpeningBracket) html += escapeHtml(remainder);
+    } else {
+      // 剥离后不再是合法 http(s) URL（极端情况），原样转义整段
+      html += escapeHtml(rawUrl);
+    }
+    lastIndex = index + rawUrl.length;
+  }
+  html += escapeHtml(text.slice(lastIndex));
+  return html;
+}

--- a/packages/webview/tests/utils/linkifyPlainText.test.ts
+++ b/packages/webview/tests/utils/linkifyPlainText.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  linkifyPlainText,
+  stripTrailingUrlPunct,
+} from "../../src/utils/linkifyPlainText";
+
+describe("linkifyPlainText", () => {
+  it("links bare http(s) URLs and escapes surrounding text", () => {
+    expect(
+      linkifyPlainText("Server started at http://localhost:8000/ now"),
+    ).toBe(
+      'Server started at <a href="http://localhost:8000/">http://localhost:8000/</a> now',
+    );
+  });
+
+  it("links https URLs too", () => {
+    expect(linkifyPlainText("see https://example.com/docs")).toBe(
+      'see <a href="https://example.com/docs">https://example.com/docs</a>',
+    );
+  });
+
+  it("keeps text without URLs unchanged (escaped)", () => {
+    expect(linkifyPlainText("plain output <x> & y")).toBe(
+      "plain output &lt;x&gt; &amp; y",
+    );
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(linkifyPlainText("")).toBe("");
+  });
+
+  it("strips trailing ASCII punctuation from the link target", () => {
+    expect(linkifyPlainText("visit https://example.com.")).toBe(
+      'visit <a href="https://example.com">https://example.com</a>.',
+    );
+    expect(linkifyPlainText("(https://example.com)")).toBe(
+      '(<a href="https://example.com">https://example.com</a>)',
+    );
+  });
+
+  it("strips trailing CJK punctuation from the link target", () => {
+    expect(linkifyPlainText("打开 https://example.com。")).toBe(
+      '打开 <a href="https://example.com">https://example.com</a>。',
+    );
+    expect(linkifyPlainText("（https://example.com）")).toBe(
+      '（<a href="https://example.com">https://example.com</a>）',
+    );
+    // 成对中文括号（注释/说明）整体剥离，不保留显示
+    expect(linkifyPlainText("见 https://example.com（帮助）")).toBe(
+      '见 <a href="https://example.com">https://example.com</a>',
+    );
+  });
+
+  it("keeps balanced ASCII parens as part of the URL", () => {
+    expect(linkifyPlainText("read https://example.com/foo(bar)")).toBe(
+      'read <a href="https://example.com/foo(bar)">https://example.com/foo(bar)</a>',
+    );
+    expect(
+      linkifyPlainText("https://en.wikipedia.org/wiki/Hello_(disambiguation)"),
+    ).toBe(
+      '<a href="https://en.wikipedia.org/wiki/Hello_(disambiguation)">https://en.wikipedia.org/wiki/Hello_(disambiguation)</a>',
+    );
+  });
+
+  it("does not link non-http(s) protocols", () => {
+    expect(
+      linkifyPlainText("run javascript:alert(1) or file:///etc/passwd"),
+    ).toBe("run javascript:alert(1) or file:///etc/passwd");
+  });
+
+  it("escapes quotes in URLs so the href attribute cannot be broken out", () => {
+    const html = linkifyPlainText('x https://a.com/?q="1" y');
+    // 尾部标点剥离会去掉一个闭合引号，剩余引号转义为 &quot;，属性值不会提前闭合
+    expect(html).not.toContain('href="https://a.com/?q="'); // 原始引号闭合属性
+    expect(html).toContain('href="https://a.com/?q=&quot;1"');
+  });
+
+  it("escapes HTML in non-URL segments so scripts are inert", () => {
+    const html = linkifyPlainText("<script>alert(1)</script> http://a.com");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).not.toContain("<script>");
+    expect(html).toContain('href="http://a.com"');
+  });
+
+  it("links every URL in multi-line output preserving line breaks", () => {
+    const html = linkifyPlainText(
+      "line1 http://a.com\nline2 https://b.com/x\nend",
+    );
+    expect(html).toBe(
+      'line1 <a href="http://a.com">http://a.com</a>\nline2 <a href="https://b.com/x">https://b.com/x</a>\nend',
+    );
+  });
+
+  it("keeps URLs with query strings and fragments intact", () => {
+    expect(linkifyPlainText("http://a.com/p?x=1&y=2#frag")).toContain(
+      'href="http://a.com/p?x=1&amp;y=2#frag"',
+    );
+  });
+});
+
+describe("stripTrailingUrlPunct", () => {
+  it("strips ASCII and CJK punctuation only from the end", () => {
+    expect(stripTrailingUrlPunct("https://a.com/b?x=1.")).toBe(
+      "https://a.com/b?x=1",
+    );
+    expect(stripTrailingUrlPunct("https://a.com。")).toBe("https://a.com");
+    expect(stripTrailingUrlPunct("https://a.com/b")).toBe("https://a.com/b");
+  });
+
+  it("strips paired CJK parentheses as a whole", () => {
+    expect(stripTrailingUrlPunct("https://a.com（说明）")).toBe(
+      "https://a.com",
+    );
+    expect(stripTrailingUrlPunct("https://a.com（")).toBe("https://a.com");
+  });
+
+  it("keeps balanced ASCII parens but strips an orphan closing paren", () => {
+    expect(stripTrailingUrlPunct("https://a.com/foo(bar)")).toBe(
+      "https://a.com/foo(bar)",
+    );
+    expect(stripTrailingUrlPunct("https://a.com/b)")).toBe("https://a.com/b");
+  });
+});

--- a/packages/webview/tests/webview/bashResultLink.test.tsx
+++ b/packages/webview/tests/webview/bashResultLink.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import React from "react";
+import { Message } from "../../src/components/Message";
+import { createMockVscode } from "./test-utils";
+import { BASH_TOOL_NAME } from "wave-agent-sdk";
+import type { Message as MessageType } from "../../src/types";
+
+// bash 命令输出中的裸 http(s) URL 应被链接化（见 specs/ui/markdown-links.md），
+// 点击路由与消息文本链接一致：desktop 上 localhost → 预览面板、其余 → 系统
+// 浏览器；IDE 保持原生链接处理。
+
+function renderBashMessage(
+  result: string,
+  options?: {
+    hostType?: string;
+    onOpenPreview?: (url: string) => void;
+  },
+) {
+  const vscode = createMockVscode();
+  if (options?.hostType) {
+    window.waveHostType = options.hostType;
+  }
+  const message = {
+    id: "msg-bash-1",
+    role: "assistant",
+    blocks: [
+      {
+        type: "tool",
+        name: BASH_TOOL_NAME,
+        parameters: JSON.stringify({ command: "python -m http.server 8000" }),
+        compactParams: "python -m http.server 8000",
+        stage: "end",
+        success: true,
+        result,
+      },
+    ],
+  } as unknown as MessageType;
+  const rendered = render(
+    <Message
+      message={message}
+      vscode={vscode}
+      onOpenPreview={options?.onOpenPreview}
+    />,
+  );
+  const output = rendered.container.querySelector(".bash-command-output");
+  return {
+    ...rendered,
+    vscode,
+    output,
+    link: output?.querySelector("a") as HTMLElement | null,
+  };
+}
+
+afterEach(() => {
+  delete window.waveHostType;
+});
+
+describe("bash result URL linkification", () => {
+  it("renders a bare http URL in the output as a clickable link", () => {
+    const { output, link } = renderBashMessage(
+      "Serving HTTP on 0.0.0.0 port 8000 (http://localhost:8000/) ...",
+    );
+    expect(output).toBeInTheDocument();
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute("href")).toBe("http://localhost:8000/");
+    // 其余文本保持原样
+    expect(output).toHaveTextContent(
+      "Serving HTTP on 0.0.0.0 port 8000 (http://localhost:8000/) ...",
+    );
+  });
+
+  it("desktop host: localhost link opens the preview pane", () => {
+    const onOpenPreview = vi.fn();
+    const { vscode, link } = renderBashMessage(
+      "Server started at http://localhost:5173/app",
+      { onOpenPreview, hostType: "desktop" },
+    );
+
+    const notPrevented = fireEvent.click(link!);
+
+    expect(onOpenPreview).toHaveBeenCalledWith("http://localhost:5173/app");
+    expect(vscode.postMessage).not.toHaveBeenCalled();
+    expect(notPrevented).toBe(false);
+  });
+
+  it("desktop host: non-localhost link goes to the system browser", () => {
+    const onOpenPreview = vi.fn();
+    const { vscode, link } = renderBashMessage("curl https://example.com/api", {
+      onOpenPreview,
+      hostType: "desktop",
+    });
+
+    fireEvent.click(link!);
+
+    expect(onOpenPreview).not.toHaveBeenCalled();
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "openExternal",
+      url: "https://example.com/api",
+    });
+  });
+
+  it("IDE host: links are not intercepted", () => {
+    const onOpenPreview = vi.fn();
+    const { vscode, link } = renderBashMessage("see https://example.com/docs", {
+      onOpenPreview,
+    });
+
+    const notPrevented = fireEvent.click(link!);
+
+    expect(onOpenPreview).not.toHaveBeenCalled();
+    expect(vscode.postMessage).not.toHaveBeenCalled();
+    expect(notPrevented).toBe(true); // default navigation preserved
+  });
+
+  it("strips trailing punctuation from the link target", () => {
+    const { link } = renderBashMessage("visit https://example.com. 继续");
+    expect(link!.getAttribute("href")).toBe("https://example.com");
+    expect(link!.textContent).toBe("https://example.com");
+  });
+
+  it("keeps non-URL output as plain text without links", () => {
+    const { output, link } = renderBashMessage("error: command not found");
+    expect(output).toHaveTextContent("error: command not found");
+    expect(link).toBeNull();
+  });
+
+  it("escapes HTML in the output so scripts are inert", () => {
+    const { output, link } = renderBashMessage(
+      "<script>alert(1)</script>\nhttp://a.com",
+    );
+    expect(output!.querySelector("script")).toBeNull();
+    expect(output).toHaveTextContent("<script>alert(1)</script>");
+    expect(link!.getAttribute("href")).toBe("http://a.com");
+  });
+});


### PR DESCRIPTION
Bash 命令输出中的裸 http(s) URL 渲染为可点击链接，点击路由与消息文本一致：
desktop 上 localhost 打开预览面板、其余走系统浏览器，IDE 保持原生链接处理。
新增 linkifyPlainText 工具（含 ASCII/中文尾部标点剥离，标点剥离函数与
marked tokenizer 共享实现），spec 新增「bash 命令输出中的 URL 可点击」故事。
