### PR TITLE
fix(desktop): echo paneId on uploadSuccess so pane-scoped inputs insert the chip

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -3506,6 +3506,7 @@ export class DesktopHost {
       case "uploadFilesToArtifacts":
         await this.handleUploadFilesToArtifacts(
           msg.files as Array<{ name: string; data: ArrayBuffer }>,
+          pid,
         );
         break;
 
@@ -5058,6 +5059,7 @@ export class DesktopHost {
 
   private async handleUploadFilesToArtifacts(
     files: Array<{ name: string; data: ArrayBuffer }>,
+    paneId?: string,
   ): Promise<void> {
     try {
       const host = this.currentHost;
@@ -5109,6 +5111,7 @@ export class DesktopHost {
           command: "uploadSuccess",
           uploadedFiles,
           message: `成功上传 ${uploadedFiles.length} 个文件到临时目录`,
+          ...(paneId !== undefined ? { paneId } : {}),
         });
       }
       if (errors.length > 0) {
@@ -5116,6 +5119,7 @@ export class DesktopHost {
           command: "uploadError",
           errors,
           message: `部分文件上传失败: ${errors.length} 个错误`,
+          ...(paneId !== undefined ? { paneId } : {}),
         });
       }
     } catch (error) {
@@ -5123,6 +5127,7 @@ export class DesktopHost {
       this.postMessage({
         command: "uploadError",
         error: `文件上传处理失败: ${error}`,
+        ...(paneId !== undefined ? { paneId } : {}),
       });
     }
   }

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -850,6 +850,47 @@ describe("uploadFilesToArtifacts", () => {
       h.files.has(path.join(os.tmpdir(), "wave-artifacts", "note.txt")),
     ).toBe(false);
   });
+
+  it("echoes the originating paneId on uploadSuccess so a pane-scoped input can insert the chip", async () => {
+    // Regression: the reply must carry the request's paneId — the webview's
+    // MessageInput rejects uploadSuccess without a matching paneId for
+    // pane-scoped ChatApp instances (the desktop app renders every chat
+    // pane-scoped once a session is bound, so the chip silently never
+    // appeared in conversations with messages).
+    const { host, sent } = await readyHost();
+    const data = new TextEncoder().encode("hello").buffer;
+
+    await host.handleWebviewMessage({
+      command: "uploadFilesToArtifacts",
+      paneId: "pane-1",
+      files: [{ name: "note.txt", data }],
+    });
+
+    const success = sent("uploadSuccess").at(-1) as {
+      uploadedFiles: string[];
+      paneId?: string;
+    };
+    expect(success.paneId).toBe("pane-1");
+  });
+
+  it("falls back to the focused pane when the request carries no paneId", async () => {
+    // A request without paneId (e.g. the root, pre-pane instance) routes the
+    // reply to the focused pane — still deliverable because the root input's
+    // paneId guard only applies to pane-scoped instances.
+    const { host, sent } = await readyHost();
+    const data = new TextEncoder().encode("hello").buffer;
+
+    await host.handleWebviewMessage({
+      command: "uploadFilesToArtifacts",
+      files: [{ name: "note.txt", data }],
+    });
+
+    const success = sent("uploadSuccess").at(-1) as {
+      uploadedFiles: string[];
+      paneId?: string;
+    };
+    expect(success.paneId).toBe("pane-1");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
修复桌面端「有消息的对话」中 + → 上传文件后输入框不出现文件 chip（无反应）的回归。

## 根因
PR #1962 给 MessageInput 的 uploadSuccess 处理加了 paneId guard（split-view 防串），但主进程 uploadFilesToArtifacts 回执没带 paneId。桌面端会话一旦绑定（发消息/选会话），webview 的 panes 非空 → 所有聊天都是 pane-scoped ChatApp（paneId 定义）→ 回执被 guard 永远拒绝，chip 不插入。新对话因未绑定会话（无 panes、根实例 paneId undefined）不受影响——此前 dev/自动化验证全在初始态测，掩盖了回归。

## 修复
desktopHost.handleUploadFilesToArtifacts 接收 paneId（msg.paneId || focusedPaneId），uploadSuccess/uploadError 回执带上 paneId（成功/部分失败/outer catch 三处）。

## 测试
+2 回归用例（带 paneId 请求回执 echo 同值；无 paneId 请求回落 focusedPaneId）；desktop 566/566、type-check 全绿；desktop run + desktop:install 双验证通过。