### PR TITLE
fix(webview): initialize e2e/demo tests before touching the input area

### DIFF
--- a/packages/webview/demo/desktop-remote-ssh.demo.ts
+++ b/packages/webview/demo/desktop-remote-ssh.demo.ts
@@ -195,6 +195,10 @@ test.describe("Desktop SSH remote sessions (mocked)", () => {
       hosts: REMOTE_HOSTS,
     });
     await injector.waitForChatAppReady();
+    // Initialize so the input area renders — the loading sweep keeps it
+    // hidden until setInitialState (no conversation messages here to bring
+    // it up, and the scenario intentionally has no workdir yet).
+    await injector.simulateExtensionMessage("setInitialState", initialState);
 
     await webviewPage.getByTestId("desktop-workdir").click();
     await webviewPage.getByTestId("desktop-workdir-browse").click();

--- a/packages/webview/demo/product-spec-btw.demo.ts
+++ b/packages/webview/demo/product-spec-btw.demo.ts
@@ -56,6 +56,21 @@ test.describe("Product Spec: /btw side question", () => {
   });
 
   test("should capture the bare /btw usage hint", async ({ webviewPage }) => {
+    const injector = new MessageInjector(webviewPage);
+    // Initialize first — the loading sweep keeps the input area hidden until
+    // setInitialState, and this scenario has no conversation messages to bring
+    // it up.
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [],
+      isStreaming: false,
+      sessions: [],
+      configurationData: {
+        baseURL: "https://api.anthropic.com/v1",
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
     // Type bare /btw and send it — shows usage, sends no RPC
     await webviewPage.focus('[data-testid="message-input"]');
     await webviewPage.keyboard.type("/btw");

--- a/packages/webview/demo/product-spec-history-search.demo.ts
+++ b/packages/webview/demo/product-spec-history-search.demo.ts
@@ -6,10 +6,28 @@ import {
 } from "../e2e/utils/screenshot.js";
 
 test.describe("Product Spec: History Search", () => {
+  // Both scenarios operate the input area with no conversation messages, so
+  // they must initialize up front — the loading sweep keeps the input area
+  // hidden until setInitialState (matching the real host flow).
+  async function initialize(injector: MessageInjector) {
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [],
+      isStreaming: false,
+      sessions: [],
+      configurationData: {
+        baseURL: "https://api.anthropic.com/v1",
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
+  }
+
   test("should capture history search popup screenshot", async ({
     webviewPage,
   }) => {
     const injector = new MessageInjector(webviewPage);
+    await initialize(injector);
 
     // 1. Focus input
     const messageInput = webviewPage.getByTestId("message-input");
@@ -54,6 +72,9 @@ test.describe("Product Spec: History Search", () => {
   test("should capture plus menu with history prompt entry", async ({
     webviewPage,
   }) => {
+    const injector = new MessageInjector(webviewPage);
+    await initialize(injector);
+
     // Open the "+" (添加) menu in the input toolbar
     await webviewPage.getByRole("button", { name: "添加" }).click();
 

--- a/packages/webview/e2e/confirm-actions-wrap.e2e.ts
+++ b/packages/webview/e2e/confirm-actions-wrap.e2e.ts
@@ -15,19 +15,22 @@ test.describe("Confirmation actions wrap", () => {
     first: boolean,
   ) {
     const injector = new MessageInjector(webviewPage);
+    // ChatApp renders the input area (and the confirmation dialog) only once
+    // initialized — the loading sweep keeps it hidden until setInitialState —
+    // so both tests initialize up front, matching the real host flow.
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [],
+      isStreaming: false,
+      sessions: [],
+      configurationData: {
+        apiKey: "sk-ant-api03-CXB9pH2k...mH8wQz",
+        baseURL: "https://api.anthropic.com/v1",
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
     if (first) {
-      await injector.simulateExtensionMessage("setInitialState", {
-        messages: [],
-        isStreaming: false,
-        sessions: [],
-        configurationData: {
-          apiKey: "sk-ant-api03-CXB9pH2k...mH8wQz",
-          baseURL: "https://api.anthropic.com/v1",
-          model: "claude-sonnet-4-20250514",
-          fastModel: "claude-haiku-4-20250514",
-        },
-        permissionMode: "default",
-      });
       const msg: Message = {
         id: "msg_wrap_bash",
         role: "assistant",

--- a/packages/webview/e2e/desktop-message-width.e2e.ts
+++ b/packages/webview/e2e/desktop-message-width.e2e.ts
@@ -30,15 +30,21 @@ test.describe("Desktop message column width", () => {
     // Wide window so the 800px cap leaves visible gutters on both sides.
     await webviewPage.setViewportSize({ width: 1280, height: 800 });
 
-    await injector.simulateExtensionMessage("setInitialState", initialState);
+    // The desktop layout only mounts ChatApp after desktopWorkdirState, so
+    // push the initial state only once the mount's message listener exists
+    // (webviewReady) — a setInitialState sent before that lands in the gap
+    // and is dropped, leaving ChatApp uninitialized with the input area
+    // hidden behind the loading sweep.
     await injector.simulateExtensionMessage("desktopWorkdirState", {
       workdir: WORKDIR,
       recentWorkdirs: [WORKDIR],
     });
+    await injector.waitForChatAppReady();
+    await injector.simulateExtensionMessage("setInitialState", initialState);
 
-    // Wait for the desktop layout to mount ChatApp and attach its message
-    // listener before pushing messages — otherwise updateMessages lands in
-    // the gap before workdirState triggers the mount and is dropped.
+    // Wait for the layout to attach its message listener before pushing
+    // messages — otherwise updateMessages lands in the gap before workdirState
+    // triggers the mount and is dropped.
     await expect(webviewPage.getByTestId("desktop-workdir")).toBeVisible();
 
     await injector.updateMessages([


### PR DESCRIPTION
## 背景

c0fe6075（扫光加载动画显示期间不展示输入区域）后，输入区域（含 ConfirmationDialog）仅在 `initialized || hasVisibleMessages` 时渲染。6 个 e2e/demo 测试依赖旧行为（未初始化时输入区域仍渲染）导致 main 上 CI 连续失败：

- **CI（main push）**：webview-e2e 2 个失败（`confirm-actions-wrap` narrow 测试 + `desktop-message-width`），连续 3 次 main push 失败
- **Deploy VitePress**：`test:demo` 6 个失败（4 demo + 2 e2e）

PR 的 webview-e2e job 是 skipped（ci.yml 只在 main push 跑 e2e），所以回归未被 PR 阶段拦截。

## 修复（仅测试，未动产品代码）

按真实宿主流程补初始化，对齐 `desktop-remote-ssh.demo.ts` 已有范式（`desktopWorkdirState` → `waitForChatAppReady` → `setInitialState`）：

| 文件 | 改动 |
|---|---|
| e2e/confirm-actions-wrap.e2e.ts | `setInitialState` 从 `if(first)` 提出，两个测试都先初始化 |
| e2e/desktop-message-width.e2e.ts | 消息顺序修正：先 `desktopWorkdirState` 触发挂载 + `waitForChatAppReady`，再 `setInitialState`（此前在挂载前发出被丢弃） |
| demo/product-spec-btw.demo.ts | bare /btw 测试补 `setInitialState` |
| demo/product-spec-history-search.demo.ts | 两个测试加共享 `initialize()` helper |
| demo/desktop-remote-ssh.demo.ts | filter 测试 `waitForChatAppReady` 后补 `setInitialState` |

## 验证

- 原失败 6 个测试全部通过
- 全量回归：e2e 30/30、demo 49/49
- oxlint 0 错误