### PR TITLE
fix(webview): include demo/e2e dirs in type-check and fix settings-manage demo param types

### DIFF
--- a/packages/webview/demo/settings-manage.demo.ts
+++ b/packages/webview/demo/settings-manage.demo.ts
@@ -1,3 +1,4 @@
+import type { Page } from "@playwright/test";
 import { test, expect } from "../e2e/utils/webviewTestHarness.js";
 import { elementScreenshotWebp } from "../e2e/utils/screenshot.js";
 import fs from "node:fs";
@@ -50,7 +51,7 @@ const settingsHtml = `
 </html>`;
 
 /** 打开设置页 + 初始化配置（settings entry 挂载时会请求 getConfiguration） */
-async function openSettings(webviewPage, nav: string) {
+async function openSettings(webviewPage: Page, nav: string) {
   await webviewPage.setViewportSize({ width: 1000, height: 760 });
   await webviewPage.setContent(settingsHtml);
   await expect(webviewPage.locator(".settings-page")).toBeVisible();

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -19,7 +19,7 @@
     "watch": "node esbuild.config.mjs --watch",
     "preview": "vite --config prototype/vite.config.ts",
     "build:prototype": "vite build --config prototype/vite.config.ts",
-    "type-check": "tsc --noEmit --incremental && tsc -p tests --noEmit --incremental",
+    "type-check": "tsc --noEmit --incremental && tsc -p tests --noEmit --incremental && tsc -p e2e --noEmit && tsc -p demo --noEmit",
     "lint": "oxlint",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
## 背景

最近的 Deploy VitePress to GitHub Pages CI 两次失败（`33378677832` / `33386258640`），根因是 `demo/settings-manage.demo.ts` 的 TS7006 隐式 any 错误。

## 为什么 type-check 没拦住

- webview 的 `type-check` script 只检查 `src/` + `tests/`（`tsconfig.json` include 仅 `src/**/*`）
- `demo/` 与 `e2e/` 的类型检查只挂在 `pretest:demo` 里，仅在 docs 构建（Deploy VitePress）时触发
- CI type-check job（`pnpm -r type-check`）因此完全覆盖不到 demo/e2e，错误从 8671d3a2（配置界面化）起潜伏

## 改动

1. `demo/settings-manage.demo.ts`：模块级 helper `openSettings` 的 `webviewPage` 参数补 `Page` 类型标注（57 行 `targetNav` 报错是级联）
2. `packages/webview/package.json`：`type-check` 追加 `tsc -p e2e --noEmit && tsc -p demo --noEmit`，demo/e2e 纳入 CI type-check job

## 验证

- 本地 `pnpm -F wave-webview type-check`（src + tests + e2e + demo）全绿
- pre-commit 钩子全仓库 `pnpm -r type-check` 全绿