### PR TITLE
fix: silence MaxListenersExceededWarning and log stdio crash reasons

### DIFF
--- a/packages/agent-sdk/src/managers/aiManager.ts
+++ b/packages/agent-sdk/src/managers/aiManager.ts
@@ -1536,6 +1536,23 @@ ${question}`;
 
         toolAbortController = new AbortController();
         this.toolAbortController = toolAbortController;
+
+        // Every tool call in a turn wires its own abort listener onto the
+        // shared tool signal (see toolAbortController.signal in executeTool),
+        // so a fan-out of >=11 parallel calls trips Node's default 10-listener
+        // cap and spams MaxListenersExceededWarning. The signal dies with the
+        // turn (toolAbortController is cleared in the tool loop), so there is
+        // no real leak — raise the cap to silence the noise. Optional chaining
+        // keeps this a no-op on Node >=26, which removed the EventTarget
+        // warning mechanism (and the setMaxListeners method) entirely.
+        const toolSignal = toolAbortController.signal as EventTarget & {
+          setMaxListeners?: (n: number) => void;
+        };
+        const turnSignal = abortController.signal as EventTarget & {
+          setMaxListeners?: (n: number) => void;
+        };
+        toolSignal.setMaxListeners?.(0);
+        turnSignal.setMaxListeners?.(0);
       } else {
         // Reuse existing controllers
         abortController = this.abortController!;

--- a/packages/agent-sdk/tests/managers/aiManager.maxListenersWarning.test.ts
+++ b/packages/agent-sdk/tests/managers/aiManager.maxListenersWarning.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Container } from "../../src/utils/container.js";
+import { AIManager } from "../../src/managers/aiManager.js";
+import type { MessageManager } from "../../src/managers/messageManager.js";
+import type { ToolManager } from "../../src/managers/toolManager.js";
+import type { ToolContext } from "../../src/tools/types.js";
+import * as aiService from "../../src/services/aiService.js";
+
+vi.mock("../../src/utils/globalLogger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/services/aiService.js", () => ({
+  callAgent: vi.fn(),
+  compactMessages: vi.fn(),
+}));
+
+vi.mock("../../src/utils/convertMessagesForAPI.js", () => ({
+  convertMessagesForAPI: vi.fn().mockReturnValue([]),
+}));
+
+describe("AIManager - tool fan-out MaxListenersExceededWarning", () => {
+  let aiManager: AIManager;
+  let mockMessageManager: MessageManager;
+  let mockToolManager: ToolManager;
+  const warnings: Array<{ name?: string; message?: string }> = [];
+
+  const warningHandler = (warning: { name?: string; message?: string }) => {
+    warnings.push(warning);
+  };
+
+  beforeEach(() => {
+    warnings.length = 0;
+    process.on("warning", warningHandler);
+
+    mockMessageManager = {
+      getSessionId: vi.fn().mockReturnValue("test-session-id"),
+      getMessages: vi.fn().mockReturnValue([]),
+      addAssistantMessage: vi.fn(),
+      addUserMessage: vi.fn(),
+      updateCurrentMessageContent: vi.fn(),
+      updateToolBlock: vi.fn(),
+      setMessages: vi.fn(),
+      getLatestTotalTokens: vi.fn().mockReturnValue(0),
+      getCombinedMemory: vi.fn().mockResolvedValue(""),
+      getMemoryForInjection: vi.fn().mockResolvedValue({ prependContent: "" }),
+      processTriggeredRules: vi.fn().mockReturnValue([]),
+      saveSession: vi.fn().mockResolvedValue(undefined),
+      setlatestTotalTokens: vi.fn(),
+      addErrorBlock: vi.fn(),
+      finalizeStreamingBlocks: vi.fn(),
+      finalizeAbortedToolBlocks: vi.fn(),
+      mergeAssistantAdditionalFields: vi.fn(),
+    } as unknown as MessageManager;
+
+    // Mirror real tool implementations (bashTool/webFetchTool): every tool
+    // call wires its own abort listener onto the shared tool signal.
+    mockToolManager = {
+      getToolsConfig: vi.fn().mockReturnValue([]),
+      getTools: vi.fn().mockReturnValue([]),
+      list: vi.fn().mockReturnValue([]),
+      execute: vi
+        .fn()
+        .mockImplementation(
+          (_name: string, _args: string, context: ToolContext) => {
+            context.abortSignal?.addEventListener("abort", vi.fn(), {
+              once: true,
+            });
+            return Promise.resolve({ success: true, content: "test result" });
+          },
+        ),
+      isConcurrencySafe: vi.fn().mockReturnValue(true),
+    } as unknown as ToolManager;
+
+    const container = new Container();
+    container.register("ConfigurationService", {
+      resolveGatewayConfig: vi.fn().mockReturnValue({}),
+      resolveModelConfig: vi.fn().mockReturnValue({}),
+      resolveMaxInputTokens: vi.fn().mockReturnValue(100000),
+      resolveMaxOutputTokens: vi.fn().mockReturnValue(4096),
+      resolveAutoMemoryEnabled: vi.fn().mockReturnValue(false),
+      resolveLanguage: vi.fn().mockReturnValue(undefined),
+      getEnvironmentVars: vi.fn().mockReturnValue({}),
+    });
+    container.register("MessageManager", mockMessageManager);
+    container.register("ToolManager", mockToolManager);
+    container.register("TaskManager", {
+      on: vi.fn(),
+      listTasks: vi.fn().mockResolvedValue([]),
+    });
+    container.register("MemoryService", {
+      getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+      getAutoMemoryDirectory: vi.fn().mockReturnValue(""),
+      getAutoMemoryContent: vi.fn().mockResolvedValue(""),
+    });
+    container.register("PermissionManager", {
+      getCurrentEffectiveMode: vi.fn().mockReturnValue("normal"),
+      clearTemporaryRules: vi.fn(),
+      setHasExitedPlanMode: vi.fn(),
+      hasExitedPlanModeInSession: vi.fn(() => false),
+      setNeedsPlanModeExitAttachment: vi.fn(),
+      getNeedsPlanModeExitAttachment: vi.fn(() => false),
+    });
+
+    aiManager = new AIManager(container, {
+      workdir: "/test/workdir",
+      stream: false,
+    });
+  });
+
+  afterEach(() => {
+    process.removeListener("warning", warningHandler);
+  });
+
+  it("should not emit MaxListenersExceededWarning when a turn fans out 11+ parallel tool calls", async () => {
+    const toolCalls = Array.from({ length: 11 }, (_, i) => ({
+      id: `call_${i}`,
+      type: "function" as const,
+      function: { name: "test_tool", arguments: '{"arg": "val"}' },
+    }));
+
+    vi.mocked(aiService.callAgent)
+      .mockResolvedValueOnce({
+        content: "Calling tools in parallel",
+        tool_calls: toolCalls,
+        finish_reason: "tool_calls",
+      })
+      .mockResolvedValueOnce({
+        content: "Done",
+        finish_reason: "stop",
+      });
+
+    // Node >=26 removed EventTarget's MaxListenersExceededWarning mechanism
+    // (and the setMaxListeners method), so the warning below only fires on
+    // Node <26 — which is what customers run (22/24, incl. bundled Electron
+    // Node). The spy assertion covers the fix on those versions.
+    const prototypeSetMaxListeners = (
+      AbortSignal.prototype as unknown as {
+        setMaxListeners?: (n: number) => void;
+      }
+    ).setMaxListeners;
+    const setMaxListenersSpy =
+      typeof prototypeSetMaxListeners === "function"
+        ? vi.spyOn(
+            AbortSignal.prototype as unknown as {
+              setMaxListeners: (n: number) => void;
+            },
+            "setMaxListeners",
+          )
+        : undefined;
+
+    await aiManager.sendAIMessage();
+
+    if (setMaxListenersSpy) {
+      expect(setMaxListenersSpy).toHaveBeenCalledWith(0);
+      setMaxListenersSpy.mockRestore();
+    }
+
+    const maxListenersWarnings = warnings.filter(
+      (w) => w.name === "MaxListenersExceededWarning",
+    );
+    expect(maxListenersWarnings).toEqual([]);
+    expect(mockToolManager.execute).toHaveBeenCalledTimes(11);
+  });
+});

--- a/packages/code/src/stdio-cli.ts
+++ b/packages/code/src/stdio-cli.ts
@@ -7,8 +7,40 @@
  */
 
 import { StdioServer } from "./stdio/stdioServer.js";
+import { logger } from "./utils/logger.js";
+
+/**
+ * Uncaught exceptions / unhandled rejections only print to stderr by
+ * default, which the host truncates to a small tail (and the process exits
+ * right after, so queued stderr can be lost entirely) — the real crash
+ * reason often never reaches the user. Log the full error to cli.log
+ * (synchronous file append, never truncated), best-effort it to stderr,
+ * then keep the exit(1) semantics.
+ */
+function crashHandler(kind: string, error: unknown): void {
+  logger.error(`[stdio] ${kind}:`, error);
+  try {
+    process.stderr.write(
+      `[stdio] ${kind}: ${
+        error instanceof Error ? error.stack || error.message : String(error)
+      }\n`,
+    );
+  } catch {
+    // stderr failure must not mask the log-file entry above.
+  }
+  process.exit(1);
+}
 
 export async function startStdioCli(): Promise<void> {
+  // Registered here (stdio mode only): the interactive CLI keeps Node's
+  // default behavior so the terminal shows the crash stack directly.
+  process.on("uncaughtException", (error) =>
+    crashHandler("uncaughtException", error),
+  );
+  process.on("unhandledRejection", (reason) =>
+    crashHandler("unhandledRejection", reason),
+  );
+
   const server = new StdioServer();
   server.start();
 

--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -4189,7 +4189,10 @@ export class DesktopHost {
       }
     } catch (error) {
       console.error("[DesktopHost] 发送消息失败:", error);
-      this.pushSystemMessage(`发送消息失败: ${error}`, pid);
+      this.pushSystemMessage(
+        `发送消息失败: ${error}。详情见 ~/.wave/logs/cli.log`,
+        pid,
+      );
     }
   }
 

--- a/packages/vscode/src/session/messageHandler.ts
+++ b/packages/vscode/src/session/messageHandler.ts
@@ -1453,7 +1453,9 @@ export class MessageHandler {
       await session.sendMessage(text, images, force);
     } catch (error) {
       console.error(`发送消息给 ${viewType} 智能体时出错:`, error);
-      vscode.window.showErrorMessage("发送消息失败: " + error);
+      vscode.window.showErrorMessage(
+        `发送消息失败: ${error}。详情见 Wave 输出面板或 ~/.wave/logs/cli.log`,
+      );
     }
   }
 


### PR DESCRIPTION
Two fixes for the vscode/desktop `wave --stdio` child process:

**1. MaxListenersExceededWarning noise (7b0f0e8e)**
Every tool call in a turn wires its own abort listener onto the shared `toolAbortController.signal` (passed to every tool's context in executeTool), so a fan-out of >=11 parallel calls trips Node's default 10-listener cap on Node <26 and spams `MaxListenersExceededWarning` to stderr — which shows up in send-failure errors. The signal dies with the turn (controller is cleared in the tool loop), so there is no real leak. Raise the cap via optional `setMaxListeners(0)` (no-op on Node >=26, which removed the EventTarget warning mechanism and the method entirely).

Adds a regression test that runs a turn with 11 parallel tool calls and asserts no MaxListenersExceededWarning, plus a `setMaxListeners` spy for Node <26 environments.

**2. Crash reasons never reach the user (a349d774)**
Uncaught exceptions / unhandled rejections only print to stderr, which hosts truncate to a small tail (STDERR_TAIL_LIMIT=4096) and queued stderr can be lost on `process.exit` — the real crash reason often never surfaces. Register `uncaughtException`/`unhandledRejection` handlers in stdio mode that sync-append the full error to `~/.wave/logs/cli.log` (never truncated), best-effort it to stderr, then keep the exit(1) semantics. Interactive CLI keeps Node's default behavior.

Hosts (vscode toast + desktop system message) now append a `详情见 ~/.wave/logs/cli.log` hint to the send-message-failed error.

Verified: real-process test shows exit=1, full stack on stderr and in cli.log; type-check + lint 0 errors; vscode 179/179, desktop 565/565, code stdio 155/155 tests pass.