### PR TITLE
fix(webview): 修复 agents-dialog demo 过期断言——设置页技能平铺化后删 project-grouped 卡片断言

### DIFF
--- a/packages/webview/demo/agents-dialog.demo.ts
+++ b/packages/webview/demo/agents-dialog.demo.ts
@@ -8,7 +8,7 @@ import path from "node:path";
  * 独立加载 settings.js bundle（settings-preview-entry），模拟 host 下发
  * settingsState(nav) 选中选项卡，再回 subagentConfigurationsResponse /
  * skillMetadataResponse 展示 4 个来源 Tab（插件 / 内置 / 用户 / 项目）的
- * agent 定义与技能列表，以及项目技能按项目分组的卡片形态。
+ * agent 定义与技能列表，以及项目技能在当前项目下的平铺列表形态。
  */
 
 // SettingsPage 的颜色全部走 --vscode-* 变量，独立 settings.html 没有宿主注入，
@@ -226,7 +226,7 @@ const skills = [
 ];
 
 test.describe("设置页技能选项卡 Demo", () => {
-  test("should show 4 source tabs with project-grouped cards", async ({
+  test("should show 4 source tabs with flat project skill list", async ({
     webviewPage,
   }) => {
     await webviewPage.setViewportSize({ width: 1000, height: 760 });
@@ -262,11 +262,8 @@ test.describe("设置页技能选项卡 Demo", () => {
 
     const view = webviewPage.locator(".settings-page");
 
-    // 项目技能按所属项目分组卡片展示（当前项目 = workdir 末段 wave-agent）
+    // 项目技能平铺展示（仅当前项目，无分组卡片，2026-09-01 拍板）
     await view.getByText("项目技能", { exact: true }).click();
-    await expect(
-      webviewPage.getByText("wave-agent", { exact: true }),
-    ).toBeVisible();
     await expect(
       webviewPage.getByText("/deploy", { exact: true }),
     ).toBeVisible();


### PR DESCRIPTION
## 背景

main 分支多次触发 **Deploy VitePress to GitHub Pages** 失败（最近 4 次：33477698368 / 33472418237 / 33386258640 及 08-31 的 type-check 瞬时失败），根因是 `packages/webview/demo/agents-dialog.demo.ts` 的过期断言：

- 681224ec（设置页可编辑化，`bba748e5`）已删除设置页技能「项目分组卡片」、改为平铺展示（仅当前项目，删 ProjectCard 分组/切换按钮）
- 但 `agents-dialog.demo.ts:229` 测试「should show 4 source tabs with project-grouped cards」仍断言分组头 `wave-agent` 文本可见 → demo 截图阶段必挂 → docs:build 失败 → VitePress 无法部署

## 变更

- 测试名改为 `flat project skill list`
- 删除 `wave-agent` 分组卡片可见性断言
- 保留 `/deploy`、`/code-review` 平铺断言；文件头注释同步更新

## 验证

- `pnpm run compile` 通过；demo 测试 2 passed（子代理 + 技能选项卡）
- `spec-skills-list.webp` 截图重新生成，vision 确认：项目技能 tab 平铺展示 `/deploy`、`/code-review`，无 wave-agent 分组头
- 本地 type-check + lint（pre-commit）全绿