### PR TITLE
ci: bump upload-artifact to v7 in beta-build workflow

### DIFF
--- a/.github/workflows/beta-build.yml
+++ b/.github/workflows/beta-build.yml
@@ -44,7 +44,7 @@ jobs:
       - run: pnpm -F wave-vscode run package
 
       - name: Upload .vsix artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wave-vscode-beta
           path: packages/vscode/releases/*.vsix
@@ -90,7 +90,7 @@ jobs:
         run: ./packages/jetbrains/gradlew -p packages/jetbrains buildPlugin --no-daemon
 
       - name: Upload .zip artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wave-jetbrains-beta
           path: packages/jetbrains/build/distributions/*.zip
@@ -153,7 +153,7 @@ jobs:
         run: pnpm -F wave-desktop run dist -- --publish never
 
       - name: Upload installer artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wave-desktop-beta-${{ runner.os }}
           # Only files existing on this OS match — macOS produces .dmg + .zip,


### PR DESCRIPTION
Bumps `actions/upload-artifact` from v4 to v7 in `.github/workflows/beta-build.yml` (3 occurrences), matching the version already used in `ci.yml`.

Fixes the GitHub Actions deprecation warning: v4 targets Node.js 20 (forced onto Node 24), while v7 runs on Node 24 natively. No functional change to the workflow.