### PR TITLE
fix(webview): more icon 帮助文档链接补结尾斜杠

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -1464,7 +1464,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({
     if (url) {
       vscode.postMessage({
         command: "openExternal",
-        url: `${url.replace(/\/+$/, "")}/docs`,
+        url: `${url.replace(/\/+$/, "")}/docs/`,
       });
     }
   }, [vscode]);

--- a/packages/webview/tests/webview/accountCard.test.tsx
+++ b/packages/webview/tests/webview/accountCard.test.tsx
@@ -202,7 +202,7 @@ describe("AccountCard (desktop sidebar)", () => {
     expect(vscode.postMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         command: "openExternal",
-        url: "https://codechat.example.com/docs",
+        url: "https://codechat.example.com/docs/",
       }),
     );
     expect(screen.queryByTestId("more-menu")).not.toBeInTheDocument();

--- a/packages/webview/tests/webview/moreMenu.test.tsx
+++ b/packages/webview/tests/webview/moreMenu.test.tsx
@@ -147,7 +147,7 @@ describe("More Menu", () => {
     expect(vscode.postMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         command: "openExternal",
-        url: "https://codechat.example.com/docs",
+        url: "https://codechat.example.com/docs/",
       }),
     );
     expect(screen.queryByTestId("more-menu")).not.toBeInTheDocument();


### PR DESCRIPTION
more icon（更多菜单）里的「帮助文档」入口打开 `serverUrl + /docs` 缺少结尾斜杠，改为 `/docs/`（https://codechat.codewave.163.com/docs/ 需结尾斜杠）。

改动：
- `packages/webview/src/components/ChatApp.tsx` `handleOpenHelpDocs` 拼 URL 补 `/`
- 同步更新 `moreMenu.test.tsx`、`accountCard.test.tsx` 断言

验证：moreMenu + accountCard 单测 22/22 通过，type-check 全绿。