### PR TITLE
chore(prototype): 原型预览移除「全功能」mock 用例，默认改为「桌面端-新对话」

### DIFF
--- a/.wave/skills/prototype-preview/SKILL.md
+++ b/.wave/skills/prototype-preview/SKILL.md
@@ -21,7 +21,7 @@ pnpm -F wave-webview preview
 
 页面右上角固定工具条（可拖拽移开）：
 
-- **用例下拉**：切换 mock 用例（state 驱动 + key 重挂载，**无整页 reload**；dev 下记住上次选择，沙箱无存储则回默认 desktop-full）
+- **用例下拉**：切换 mock 用例（state 驱动 + key 重挂载，**无整页 reload**；dev 下记住上次选择，沙箱无存储则回默认 desktop-new-chat）
 - **深色/浅色按钮**：切 `<html data-theme>`，与真机 desktop 主题机制一致
 - **拖拽手柄**：拖动工具条位置，避免遮挡 header（位置存 `sessionStorage["wave-preview-bar-pos"]`，沙箱无存储时静默降级）
 

--- a/packages/webview/prototype/preview-entry.tsx
+++ b/packages/webview/prototype/preview-entry.tsx
@@ -71,14 +71,14 @@ const writeSession = (k: string, v: string) => {
 };
 
 // ── 初始用例（模块顶层，render 前确定；responders 先于子树挂载注册）──
-// 默认加载「桌面端：全功能」用例，避免打开原型预览看到无限扫光 loading
+// 默认加载「桌面端-新对话」用例，避免打开原型预览看到无限扫光 loading
 // （ChatApp 无任何宿主消息时停留在 showWelcome）。dev 下记住上次选择；
 // 若存储的用例文件已不存在（mock/ 是 gitignore 的本地目录），回退到默认。
 const getCase = (key: string) =>
   key ? mockModules[`./mock/${key}.ts`]?.default : undefined;
 const mockKeys = Object.keys(mockModules);
-const defaultKey = mockKeys.includes("./mock/desktop-full.ts")
-  ? "desktop-full"
+const defaultKey = mockKeys.includes("./mock/desktop-new-chat.ts")
+  ? "desktop-new-chat"
   : (mockKeys[0]?.slice("./mock/".length, -3) ?? "");
 const initialKey = (() => {
   const candidate = readSession("wave-preview-case");


### PR DESCRIPTION
原型预览默认用例从 desktop-full（全功能模拟，mock 数据无法覆盖真实全功能）改为 desktop-new-chat（部分功能：未选目录 + 空会话欢迎页 + 会话树含 running 会话 + 账户卡片）。

改动：
- `packages/webview/prototype/preview-entry.tsx`：注释去除「全功能」描述；默认用例 key 从 desktop-full 改为 desktop-new-chat（无该文件时回退首个用例）
- `.wave/skills/prototype-preview/SKILL.md`：默认用例引用同步更新
- 新建 `packages/webview/prototype/mock/desktop-new-chat.ts`（gitignore 本地文件，不随提交）：桌面端新对话场景的部分功能 mock

验证：webview type-check 通过；preview dev server 实测用例下拉显示「桌面端-新对话」并默认选中，截图确认欢迎页/会话树/账户卡片渲染正确。