### PR TITLE
feat(code): wave daemon create/destroy 子命令——worktree 创建/移除、按需自动拉起 daemon

### DIFF
--- a/docs/specs/ui/daemon-command.md
+++ b/docs/specs/ui/daemon-command.md
@@ -1,6 +1,6 @@
 ---
 name: "Daemon 客户端命令"
-description: "`wave daemon list/status/send/respond/abort` — 查看、续聊、审批与中断 daemon 托管的远端后台会话"
+description: "`wave daemon create/list/status/send/respond/abort/destroy` — 按需创建、查看、续聊、审批、中断与销毁 daemon 托管的远端后台会话"
 order: 270
 ---
 
@@ -10,24 +10,42 @@ order: 270
 
 ## 概述
 
-`wave --daemon <socket>` 在远端主机上启动一个 JSON-RPC over unix socket 的 daemon，托管后台 agent 会话（桌面端经 SSH 隧道访问）。目前除了 `--daemon` 启动标志外，没有任何面向用户的 CLI 命令可以查看 daemon 里托管了哪些会话、会话进度如何、或向会话注入消息继续对话——这些能力只存在于 JSON-RPC 协议层，普通用户与脚本无法直接使用。本规格定义 `wave daemon` 子命令组，将已验证的协议流程（attach → 读消息 → 注入消息 → 审批挂起的权限请求 → 中断生成）封装为五条命令，供用户在远端主机直接执行（或经 `ssh <host> wave daemon ...` 在远端主机上执行）。
+`wave --daemon <socket>` 在远端主机上启动一个 JSON-RPC over unix socket 的 daemon，托管后台 agent 会话（桌面端经 SSH 隧道访问）。目前除了 `--daemon` 启动标志外，没有任何面向用户的 CLI 命令可以查看 daemon 里托管了哪些会话、会话进度如何、或向会话注入消息继续对话——这些能力只存在于 JSON-RPC 协议层，普通用户与脚本无法直接使用。本规格定义 `wave daemon` 子命令组，将已验证的协议流程（创建会话 → attach → 读消息 → 注入消息 → 审批挂起的权限请求 → 中断生成 → 销毁会话）封装为七条命令（`create` / `list` / `status` / `send` / `respond` / `abort` / `destroy`），供用户在远端主机直接执行（或经 `ssh <host> wave daemon ...` 在远端主机上执行）。daemon 无需常驻托管——任一子命令连接 socket 失败时自动以 nohup 方式拉起 daemon（`wave --daemon ~/.wave/daemon.sock`）并重试连接，按需即用。
 
 ## 用户场景与测试 _（必填）_
 
 ### 用户故事：Daemon 命令组与默认 socket（优先级：P0）
 
-作为在远端主机上使用 daemon 的用户，我希望通过 `wave daemon` 子命令组（`list` / `status` / `send` / `respond` / `abort`）访问 daemon，固定连接默认 socket，以便无需了解 JSON-RPC 协议即可查看、续聊、审批与中断后台会话。
+作为在远端主机上使用 daemon 的用户，我希望通过 `wave daemon` 子命令组（`create` / `list` / `status` / `send` / `respond` / `abort` / `destroy`）访问 daemon，固定连接默认 socket，以便无需了解 JSON-RPC 协议即可创建、查看、续聊、审批、中断与销毁后台会话。
 
-**为什么是这个优先级**：这是整个命令组的地基——没有统一的命令入口与 socket 寻址规则，list/status/send/respond/abort 无从谈起；daemon 只监听本地 unix socket、不暴露网络端口，且只允许在远端主机上运行，因此客户端命令一律连接默认 socket（`~/.wave/daemon.sock`），不提供 `--socket` 覆盖参数，避免支持本地转发 socket 等非目标用法。
+**为什么是这个优先级**：这是整个命令组的地基——没有统一的命令入口与 socket 寻址规则，create/list/status/send/respond/abort/destroy 无从谈起；daemon 只监听本地 unix socket、不暴露网络端口，且只允许在远端主机上运行，因此客户端命令一律连接默认 socket（`~/.wave/daemon.sock`），不提供 `--socket` 覆盖参数，避免支持本地转发 socket 等非目标用法。daemon 不要求常驻托管：任一子命令连接失败时自动以 nohup 方式拉起 daemon（`wave --daemon ~/.wave/daemon.sock`，nohup+重定向使启动器立即返回）并重试连接，按需即用。
 
-**独立测试**：在远端启动 daemon 后运行 `wave daemon list` 能列出会话；daemon 未运行时运行任一子命令会得到明确错误提示。
+**独立测试**：在远端启动 daemon 后运行 `wave daemon list` 能列出会话；daemon 未运行时运行任一子命令会自动拉起 daemon 并重试连接（成功则命令照常执行，失败则给出明确错误提示）。
 
 **验收场景**：
 
 1. **假设** 远端 daemon 正在运行，**当** 用户运行 `wave daemon list` 时，**则** 命令连接默认 socket（`~/.wave/daemon.sock`）并列出该 daemon 当前托管的全部会话（进程内存中 live 的会话）。
-2. **假设** daemon 未运行或 socket 文件不存在（含 daemon 空闲自动退出后），**当** 用户运行任一 `wave daemon` 子命令时，**则** 命令以非零退出码退出并给出明确错误（如「Cannot connect to daemon socket <路径>: is the daemon running?」，附空闲自动退出提示），不进入 TUI、不挂起。
+2. **假设** daemon 未运行或 socket 文件不存在（含 daemon 空闲自动退出后、机器重启后），**当** 用户运行任一 `wave daemon` 子命令时，**则** 命令自动以 nohup 方式拉起 daemon（`wave --daemon ~/.wave/daemon.sock`，nohup+重定向使启动器立即返回）并重试连接——daemon 无需常驻托管、按需即用；仅当拉起的 daemon 在启动超时内仍未就绪时，命令才以非零退出码退出并给出明确错误，不进入 TUI、不挂起。
 3. **假设** 用户运行 `wave daemon list` 时，**当** 命令执行期间没有需要交互的输入，**则** 命令运行完即退出（非交互式），stdout 输出结果、stderr 输出诊断，便于脚本与管道消费。
 4. **假设** 用户误以为 `wave daemon` 与 `wave --daemon <socket>` 相同，**当** 对比两者行为时，**则** `wave --daemon` 启动 daemon（服务端），`wave daemon <子命令>` 访问 daemon（客户端），两者语义不同、互不干扰，帮助文本中明确区分。
+
+---
+
+### 用户故事：创建新会话（优先级：P0）
+
+作为在远端主机启动后台任务的用户，我希望 `wave daemon create` 在 daemon 中创建一个新会话（可指定 `--worktree` 把会话建在新的 git worktree 里）并输出 sessionId，以便将后续的 send/abort/destroy 等操作指向该会话。
+
+**为什么是这个优先级**：在原有命令之外补全会话生命周期——此前会话只能由桌面端/IDE 经 `initialize` 创建，纯 CLI 用户没有入口；协议层 `initialize` 不带 `restoreSessionId` 即无条件新建会话（无 attach 分支，无需存在性检查），命令是参数转发 + 输出 sessionId 的薄封装。默认 `workdir=当前目录`、`permissionMode=bypassPermissions` 对齐 daemon 后台任务用例（与 `wave -p --dangerously-skip-permissions` 的批处理心智一致）。
+
+**独立测试**：运行 `wave daemon create` 输出新 sessionId，随后 `wave daemon status <sessionId>` 能看到该会话；`--workdir` / `--permission-mode` / `--model` 参数正确透传到新会话；`--worktree [name]` 会先经协议 `createWorktree` 创建 git worktree，再用 worktree 路径作为 workdir 创建会话。
+
+**验收场景**：
+
+1. **假设** daemon 正在运行，**当** 用户运行 `wave daemon create` 时，**则** 命令经协议 `initialize`（不带 `restoreSessionId`，因此总是新建而非 attach）在 daemon 中创建一个新会话，stdout 输出新会话的 sessionId（退出码 0），供后续 `status` / `send` / `abort` / `destroy` 使用。
+2. **假设** 用户未显式传参，**当** 运行 `wave daemon create` 时，**则** 新会话默认 `workdir` 为命令运行时的当前目录、默认 `permissionMode` 为 `bypassPermissions`（无需审批即可后台执行，对齐 `wave -p --dangerously-skip-permissions` 批处理心智）。
+3. **假设** 用户传入 `--workdir <路径>` / `--permission-mode <模式>` / `--model <模型>`，**当** 运行 `wave daemon create` 时，**则** 新会话以对应值创建（`permissionMode` 支持 default/bypassPermissions/acceptEdits/plan/dontAsk，非法值报错并以非零退出码退出，校验先于连接、不会拉起 daemon）。
+4. **假设** daemon 未运行，**当** 用户运行 `wave daemon create` 时，**则** 命令自动拉起 daemon 并重试连接（与其余子命令一致的按需启动语义）；仅当拉起的 daemon 在启动超时内未就绪时才以非零退出码退出。
+5. **假设** 用户传入 `--worktree [name]`，**当** 运行 `wave daemon create --worktree` 时，**则** 命令先经协议 `createWorktree`（params: workdir + name，name 缺省时由服务端自动生成）在目标仓库创建新的 git worktree，再用返回的 worktree path 作为 workdir 调 `initialize` 创建会话；stdout 依次输出 sessionId（第一行，保持脚本兼容）与 `Worktree: <path> (branch: <branch>)`。会话的 workdir 是 worktree 路径本身（`git rev-parse --show-toplevel` 从该目录的返回，即链接 worktree 的顶层），与 `--workdir` 不共存（同时给出时 `--worktree` 优先）。
 
 ---
 
@@ -106,6 +124,7 @@ order: 270
 4. **假设** 目标会话挂起等待权限审批，**当** 用户运行 `wave daemon send <sessionId> "消息"` 时，**则** 命令不无限期挂起：等待超过 `--timeout`（默认 600 秒，`0` 表示不限制）后以非零退出码退出，并提示「Session is waiting for permission approval; handle it with `wave daemon respond <sessionId> <requestId>` and retry」。
 5. **假设** 指定的 sessionId 不存在于该 daemon，**当** 用户运行 `wave daemon send <sessionId> "消息"` 时，**则** 以非零退出码退出并给出明确错误，不注入任何消息。
 6. **假设** send 命令完成或失败退出后，**当** 命令结束时，**则** 断开与 daemon 的连接，会话在 daemon 中继续存活、不因客户端退出而终止（与 attach 语义一致）。
+7. **假设** 等待期间回复被中断（如另一客户端对该会话运行 `wave daemon abort`，最终 assistant 消息只有 reasoning、无正文），**当** 命令收尾时，**则** 命令明确提示已中断（stderr 输出「Message aborted before producing a reply」）并以非零退出码退出，而不是静默以退出码 0 退出且无输出。
 
 ---
 
@@ -126,15 +145,38 @@ order: 270
 
 ---
 
+### 用户故事：销毁会话（优先级：P0）
+
+作为在远端主机清理后台任务的用户，我希望 `wave daemon destroy <sessionId>` 销毁 daemon 中托管的指定会话（幂等，可加 `--remove-worktree` 连同会话所在 git worktree 一并移除），以便不再需要的后台会话能被及时清理、不占用资源。
+
+**为什么是这个优先级**：补全会话生命周期闭环（create → 使用 → destroy）；协议层 `destroy` 已是幂等的纯注册表操作（按信封 sessionId 直接删除，未知会话静默 no-op），无需 attach，命令是薄封装。与桌面端「删除会话」入口共用同一协议方法。
+
+**独立测试**：创建一条会话后运行 `wave daemon destroy <sessionId>`，验证 `wave daemon list` 不再列出该会话；对不存在的 sessionId 运行 destroy，验证命令仍以退出码 0 成功（幂等 no-op）。对建在 worktree 里的会话运行 `destroy --remove-worktree`，验证 git worktree 与分支被移除后会话被销毁；对普通会话（非 worktree）运行 `--remove-worktree` 会明确拒绝、不误删仓库。
+
+**验收场景**：
+
+1. **假设** 目标会话托管于该 daemon，**当** 用户运行 `wave daemon destroy <sessionId>` 时，**则** 命令经协议 `destroy` 销毁该会话（agent destroy + 从注册表移除），输出确认信息并以退出码 0 结束，随后 `list` 不再显示该会话。
+2. **假设** 指定的 sessionId 不存在（会话已销毁、daemon 重启后内存清空或从未存在），**当** 用户运行 `wave daemon destroy <sessionId>` 时，**则** 销毁是幂等 no-op（无 attach、不会创建会话），命令仍输出确认信息并以退出码 0 结束。
+3. **假设** destroy 命令完成后，**当** 命令退出时，**则** 断开与 daemon 的连接；其余会话不受影响、继续运行。
+4. **假设** 用户运行 `wave daemon destroy <sessionId> --remove-worktree` 且会话的 workingDirectory 位于某个 git worktree 内，**当** 命令执行时，**则** 命令先经 `getSessionInfo` 拿会话工作目录，用 git 反查其 worktree 路径（`rev-parse --show-toplevel`）、分支（`branch --show-current`）与主仓根（`git worktree list` 第一项，repoRoot 语义与 `createWorktree` 返回值一致），随后调协议 `removeWorktree`（params: path/branch/repoRoot，hookBased 按该仓库是否配置 WorktreeCreate hook 判定，与 createWorktree 的返回一致）移除 worktree 与分支，最后销毁会话；stdout 依次输出 `Removed worktree: <path> (branch: <branch>)` 与 `Destroyed session: <sessionId>`，退出码 0。
+5. **假设** `--remove-worktree` 解析出的 worktree 路径等于主仓根（该会话是普通工作目录、并非链接 worktree），**当** 命令执行时，**则** 命令明确拒绝（报错「Refusing to remove the main working tree」）并以非零退出码退出，不调用 `removeWorktree`、不销毁会话——防止误删整个仓库。
+6. **假设** 会话工作目录不在任何 git 仓库内（`rev-parse` 失败），**当** 用户运行 `wave daemon destroy <sessionId> --remove-worktree` 时，**则** 命令报错（「Cannot remove worktree: <路径> is not inside a git repository」）并以非零退出码退出，不调用 `removeWorktree`、不销毁会话。
+
+---
+
 ### 边界情况
 
-- **daemon 未运行 / socket 不存在**：任一子命令均应快速报错退出（非零退出码 + stderr 明确提示），不得挂起或进入 TUI；提示须覆盖「daemon 空闲 60 秒自动退出」这一正常现象。
+- **daemon 未运行 / socket 不存在（按需即用）**：任一子命令连接失败时自动以 nohup 方式拉起 daemon（`wave --daemon ~/.wave/daemon.sock`，nohup+重定向分离会话）并重试连接，daemon 无需常驻托管；拉起的 daemon 在启动超时（默认 10 秒）内仍未就绪时，命令才以非零退出码 + stderr 明确提示退出，不得挂起或进入 TUI。daemon 空闲 60 秒自动退出后，下一次子命令会再次自动拉起。
 - **默认 socket 固定**：所有 `wave daemon` 子命令一律连接 `~/.wave/daemon.sock`，不提供 `--socket` 覆盖参数；命令只在远端主机上运行，不面向本地转发的 socket。
-- **`wave daemon` 与 `wave --daemon` 语义冲突**：前者是客户端子命令组（list/status/send/respond/abort），后者是服务端启动标志；帮助文本须写明差异，避免误用。
+- **`wave daemon` 与 `wave --daemon` 语义冲突**：前者是客户端子命令组（create/list/status/send/respond/abort/destroy），后者是服务端启动标志（也是客户端连接失败时自动拉起的后台进程）；帮助文本须写明差异，避免误用。
 - **list 仅反映当前进程内存态**：`list` 展示的是当前 daemon 进程内 live 的会话（`initialize`/`restoreSession` 载入且仍存活），不扫磁盘索引；daemon 空闲退出/重启后内存清空、列表为空是正常现象。磁盘上的历史会话（含普通 `wave` TUI 创建的）不在列表中，但知道 sessionId 仍可经 `status`/`send` attach（`restoreSession` 重新载入），无需依赖 `list` 找回。
+- **create 新建 vs attach 恢复**：`initialize` 不带 `restoreSessionId` 时总是新建会话（无 attach 分支，无需存在性检查）；`create` 打印的 sessionId 是后续 `status` / `send` / `respond` / `abort` / `destroy` 的寻址依据。`--permission-mode` 非法值校验先于连接——不会因参数错误拉起 daemon。
+- **destroy 是幂等注册表操作**：协议 `destroy` 按信封 sessionId 直接删除注册表项（未知会话静默 no-op），无 attach、不创建会话；与 `abort` 不同，destroy 不检查会话是否存活、也不关心是否生成中，只负责销毁。
+- **create --worktree 的 workdir 语义**：worktree 路径是链接 worktree 的顶层（`git rev-parse --show-toplevel` 从该目录的返回），而非主仓根；`--worktree` 与 `--workdir` 同时给出时以 `--worktree` 为准（workdir 仅作为 createWorktree 的源仓库起点）。name 缺省（裸 `--worktree`）时由服务端自动生成随机名。
+- **destroy --remove-worktree 的守卫**：repoRoot 语义与 `createWorktree` 返回值一致（主仓根，`git worktree list --porcelain` 第一项），worktree 路径用 `rev-parse --show-toplevel`（从链接 worktree 返回其自身路径）；两者相等即普通工作目录而非链接 worktree——拒绝移除主工作树，防止 removeWorktree 的 fs.rmSync 回退删掉整个仓库。hookBased 按该仓库是否配置 WorktreeCreate hook 判定（与 createWorktree 的返回一致），hook 管理的工作树交给 WorktreeRemove hook 清理、wave 不跑 `git worktree remove`。git 反查失败（非 git 仓库）时报错退出，不销毁会话。
 - **会话挂起等待审批**：daemon 语义下「等待审批」的会话保持 loading 状态（等同未空闲）；消息中该工具块冻结在 `stage: "running"`（有工具名与参数、无结果字段，结果字段只在 `stage: "end"` 写入），单凭消息无法区分「等审批」与「执行中」，须结合 `listPendingPermissions` 判断；`send` 须有 `--timeout` 兜底避免无限挂起，`status` 应如实显示该状态，`respond` 是处理挂起请求的入口。
 - **respond 的决策并非单一 allow/deny**：`PermissionDecision` 含 behavior/message/newPermissionMode/newPermissionRule 四个字段；EnterPlanMode 的 allow 必须附带 `newPermissionMode:"plan"`（按工具智能补全），AskUserQuestion 必须用 `--answer` 提供答案（allow 且 message 为答案 JSON），Bash/Edit 可选 `--rule`/`--mode`；命令须与桌面端行为一致，不得把多选项压成裸 allow/deny。
 - **requestId 幂等与过期**：服务端对未知 requestId 的 `permissionResponse` 静默忽略；respond 应先行校验（如经 `listPendingPermissions`）并在 requestId 已处理时明确提示，避免用户误以为审批已生效。
 - **`send` 输出纯净性**：命令输出助手最终回复文本，流式通知与子代理内部信息不得泄漏到 stdout（与打印模式一致），诊断信息走 stderr。
 - **`abort` 中断是幂等操作**：在空闲会话上是无害 no-op，命令仍成功返回；对正在生成（含子代理、bash 命令、slash 命令）或挂起审批的会话，中断后回到空闲（与桌面端中断按钮语义一致）。`abort` 不清除已完成的对话历史，只打断进行中的生成并清空消息队列；无需先经 `status` 确认是否正在生成。
-- **attach 是短暂访问**：`status` / `send` / `respond` / `abort` 完成即断开连接，不常驻客户端；daemon 与会话的生命周期不受客户端连接影响（attach/detach 语义，会话持续运行至空闲自动退出或用户删除）。
+- **attach 是短暂访问**：`status` / `send` / `respond` / `abort` 完成即断开连接，不常驻客户端（`create` 为纯注册表操作、`destroy` 按信封 sessionId 无需 attach，仅 `destroy --remove-worktree` 额外调用 `getSessionInfo` 取工作目录）；daemon 与会话的生命周期不受客户端连接影响（attach/detach 语义，会话持续运行至空闲自动退出或用户销毁）。

--- a/packages/code/src/daemon/commands.ts
+++ b/packages/code/src/daemon/commands.ts
@@ -1,8 +1,11 @@
 /**
  * `wave daemon` client subcommands — talk to the wave daemon's unix socket
- * (JSON-RPC over newline-delimited JSON) to list hosted sessions, inspect
- * progress, inject messages, respond to pending permission requests and abort
- * in-flight message generation.
+ * (JSON-RPC over newline-delimited JSON) to create/destroy sessions, list
+ * hosted sessions, inspect progress, inject messages, respond to pending
+ * permission requests and abort in-flight message generation. When the daemon
+ * is not running, any subcommand starts one on demand (detached --daemon
+ * spawn, the local equivalent of the remote nohup launcher) and retries the
+ * connection — the daemon needs no permanent host, it is used on demand.
  *
  * All subcommands are non-interactive: results go to stdout, diagnostics to
  * stderr, and every handler calls process.exit() itself (yargs would fall
@@ -19,6 +22,7 @@
  * must be destroyed via the envelope sessionId returned by `initialize`.
  */
 
+import { execFile, spawn } from "node:child_process";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -26,7 +30,10 @@ import {
   ASK_USER_QUESTION_TOOL_NAME,
   ENTER_PLAN_MODE_TOOL_NAME,
   EXIT_PLAN_MODE_TOOL_NAME,
+  getGitMainRepoRoot,
   getMessageContent,
+  hasWorktreeCreateHook,
+  loadMergedWaveConfig,
   type Message,
   type PermissionDecision,
   type PermissionMode,
@@ -49,6 +56,10 @@ const PERMISSION_MODES: PermissionMode[] = [
   "dontAsk",
 ];
 
+/** How long to wait for an auto-started daemon's socket to come up (mutable so tests can shorten it). */
+export const daemonStartTimeout = { ms: 10_000 };
+const DAEMON_POLL_INTERVAL_MS = 500;
+
 // ── Connection helpers ─────────────────────────────────────────
 
 function connectDaemon(socketPath: string): Promise<SocketClient> {
@@ -62,14 +73,49 @@ function connectDaemon(socketPath: string): Promise<SocketClient> {
   });
 }
 
-/** Connect or fail fast with the spec'd error; daemon idle-exits after 60s. */
+/**
+ * Start a wave daemon on demand, detached — the local equivalent of the remote
+ * nohup launcher `nohup <wave> --daemon <socket> </dev/null >/dev/null 2>&1 &`
+ * (spec: daemon-command.md 按需即用). Re-execs the current wave CLI (`node
+ * <this script> --daemon <socket>`) with no stdio and unrefs the child so the
+ * client exits without waiting; the daemon cleans stale socket files itself on
+ * start.
+ */
+function startDaemon(socketPath: string): void {
+  const entry = process.argv[1];
+  if (!entry) {
+    fail("Cannot start the wave daemon: unknown CLI entry path");
+  }
+  const child = spawn(process.execPath, [entry, "--daemon", socketPath], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+}
+
+/**
+ * Connect or start the daemon on demand: try the socket, and when the daemon is
+ * not running, launch one detached and retry until its socket accepts a
+ * connection (or daemonStartTimeout.ms elapses). Exits (nonzero) with the
+ * spec'd error when the daemon cannot be started/reached.
+ */
 async function connectDaemonOrExit(socketPath: string): Promise<SocketClient> {
   try {
     return await connectDaemon(socketPath);
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
+    startDaemon(socketPath);
+    const deadline = Date.now() + daemonStartTimeout.ms;
+    while (Date.now() < deadline) {
+      await sleep(DAEMON_POLL_INTERVAL_MS);
+      try {
+        return await connectDaemon(socketPath);
+      } catch {
+        // Daemon still coming up — keep polling.
+      }
+    }
     console.error(
-      `Cannot connect to daemon socket ${socketPath}: is the daemon running? (it auto-exits after 60s idle)` +
+      `Cannot connect to daemon socket ${socketPath}: started a daemon but it did not come up` +
         (code ? ` (${code})` : ""),
     );
     process.exit(1);
@@ -134,6 +180,70 @@ async function listPendingPermissions(
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ── create ─────────────────────────────────────────────────────
+
+export interface CreateOptions {
+  /** Working directory for the new session (default: current directory). */
+  workdir?: string;
+  /** Permission mode for the new session (default: bypassPermissions). */
+  permissionMode?: string;
+  /** Model override for the new session (default: configured model). */
+  model?: string;
+  /** Create the session in a new git worktree (name auto-generated when omitted). */
+  worktree?: string;
+}
+
+/**
+ * Create a fresh session in the daemon. initialize WITHOUT restoreSessionId
+ * always creates a brand-new session (never an attach), so no existence checks
+ * are needed. Defaults mirror the daemon's background-task use case: workdir =
+ * current directory, permissionMode = bypassPermissions. With --worktree the
+ * daemon first creates a git worktree (protocol createWorktree) and the session
+ * is created inside it. Prints the new sessionId (first line, for scripts),
+ * plus the worktree path/branch when --worktree was used.
+ */
+export async function daemonCreateCommand(
+  socketPath: string,
+  options: CreateOptions = {},
+): Promise<void> {
+  const mode = options.permissionMode ?? "bypassPermissions";
+  if (!PERMISSION_MODES.includes(mode as PermissionMode)) {
+    fail(
+      `Invalid permission mode: ${mode} (options: ${PERMISSION_MODES.join(", ")})`,
+    );
+  }
+  let client: SocketClient | undefined;
+  try {
+    client = await connectDaemonOrExit(socketPath);
+    let workdir = options.workdir ?? process.cwd();
+    let worktreePath: string | undefined;
+    let worktreeBranch: string | undefined;
+    if (options.worktree !== undefined) {
+      const wt = (await client.request("createWorktree", {
+        workdir,
+        name: options.worktree,
+      })) as { name: string; path: string; branch: string; repoRoot: string };
+      workdir = wt.path;
+      worktreePath = wt.path;
+      worktreeBranch = wt.branch;
+    }
+    const result = (await client.request("initialize", {
+      workdir,
+      permissionMode: mode,
+      model: options.model,
+    })) as { sessionId: string };
+    console.log(result.sessionId);
+    if (worktreePath !== undefined) {
+      console.log(`Worktree: ${worktreePath} (branch: ${worktreeBranch})`);
+    }
+  } catch (err) {
+    fail(`wave daemon create failed: ${(err as Error).message}`);
+  } finally {
+    await client?.dispose();
+  }
+  process.exit(0);
 }
 
 // ── list ───────────────────────────────────────────────────────
@@ -353,7 +463,16 @@ export async function daemonSendCommand(
     // reach stdout (spec: send 输出纯净性).
     if (reply) {
       const content = getMessageContent(reply).replace(/\s+/g, " ").trim();
-      if (content) console.log(content);
+      if (content) {
+        console.log(content);
+      } else if (reply.blocks.some((b) => b.type === "reasoning")) {
+        // Interrupted mid-generation (e.g. `wave daemon abort`): the reply was
+        // finalized with reasoning but no text. Surface the interruption
+        // instead of silently exiting 0 with no output (spec: 中断需明确提示).
+        fail("Message aborted before producing a reply");
+      }
+    } else {
+      fail("No reply received for the message");
     }
   } catch (err) {
     fail(`wave daemon send failed: ${(err as Error).message}`);
@@ -467,6 +586,109 @@ export async function daemonAbortCommand(
     console.log(`Aborted session: ${sessionId}`);
   } catch (err) {
     fail(`wave daemon abort failed: ${(err as Error).message}`);
+  } finally {
+    await client?.dispose();
+  }
+  process.exit(0);
+}
+
+// ── destroy ────────────────────────────────────────────────────
+
+export interface DestroyOptions {
+  /** Also remove the session's git worktree before destroying (protocol removeWorktree). */
+  removeWorktree?: boolean;
+}
+
+/** Run one git command and return trimmed stdout (rejects on git failure). */
+function runGit(cwd: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile("git", args, { cwd }, (err, stdout) => {
+      if (err) reject(err);
+      else resolve(stdout.trim());
+    });
+  });
+}
+
+/**
+ * Resolve the worktree hosting `workingDirectory` for removal, mirroring the
+ * values protocol createWorktree returns: worktree path via
+ * `git rev-parse --show-toplevel`, branch via `git branch --show-current`, and
+ * repoRoot = the MAIN repo root (first entry of `git worktree list` — where
+ * git worktree/branch operations run from). Refuses to remove the main working
+ * tree: a plain session is not a worktree, and the protocol's path-containment
+ * check would pass trivially while removeWorktree's fs.rmSync fallback could
+ * delete the whole repository.
+ */
+async function resolveWorktreeForRemoval(workingDirectory: string): Promise<{
+  path: string;
+  branch: string;
+  repoRoot: string;
+  hookBased: boolean;
+}> {
+  let worktreePath: string;
+  let branch: string;
+  try {
+    const [toplevel, current] = await Promise.all([
+      runGit(workingDirectory, ["rev-parse", "--show-toplevel"]),
+      runGit(workingDirectory, ["branch", "--show-current"]),
+    ]);
+    worktreePath = toplevel;
+    branch = current;
+  } catch {
+    throw new Error(
+      `Cannot remove worktree: ${workingDirectory} is not inside a git repository`,
+    );
+  }
+  const repoRoot = getGitMainRepoRoot(workingDirectory);
+  if (path.resolve(worktreePath) === path.resolve(repoRoot)) {
+    throw new Error(
+      `Refusing to remove the main working tree: ${repoRoot} (not a linked worktree)`,
+    );
+  }
+  // Hook-based worktrees (created via a WorktreeCreate hook) are removed by the
+  // WorktreeRemove hook — mirror createWorktree's own hookBased decision so
+  // removal never runs `git worktree remove` on a hook-managed worktree.
+  const config = loadMergedWaveConfig(repoRoot);
+  const hookBased = hasWorktreeCreateHook(config?.hooks);
+  return { path: worktreePath, branch, repoRoot, hookBased };
+}
+
+/**
+ * Destroy a hosted session (protocol destroy, idempotent — a session not in
+ * the daemon's in-memory registry is a harmless no-op). Unlike status / send /
+ * abort there is no attach step: destroy is a pure registry operation keyed by
+ * the envelope sessionId, so unknown sessions succeed without touching disk.
+ * With --remove-worktree the session's git worktree is resolved from its
+ * workingDirectory (getSessionInfo) and removed via protocol removeWorktree
+ * first, then the session is destroyed.
+ */
+export async function daemonDestroyCommand(
+  socketPath: string,
+  sessionId: string,
+  options: DestroyOptions = {},
+): Promise<void> {
+  let client: SocketClient | undefined;
+  try {
+    client = await connectDaemonOrExit(socketPath);
+    if (options.removeWorktree) {
+      const info = (await client.request(
+        "getSessionInfo",
+        undefined,
+        sessionId,
+      )) as { workingDirectory: string };
+      const wt = await resolveWorktreeForRemoval(info.workingDirectory);
+      await client.request("removeWorktree", {
+        path: wt.path,
+        branch: wt.branch,
+        repoRoot: wt.repoRoot,
+        hookBased: wt.hookBased,
+      });
+      console.log(`Removed worktree: ${wt.path} (branch: ${wt.branch})`);
+    }
+    await client.request("destroy", undefined, sessionId);
+    console.log(`Destroyed session: ${sessionId}`);
+  } catch (err) {
+    fail(`wave daemon destroy failed: ${(err as Error).message}`);
   } finally {
     await client?.dispose();
   }

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -256,6 +256,43 @@ export async function main() {
           return yargs
             .help()
             .command(
+              "create",
+              "Create a new session hosted by the daemon and print its sessionId",
+              (yargs) => {
+                return yargs
+                  .option("workdir", {
+                    describe:
+                      "Working directory for the new session (default: current directory)",
+                    type: "string",
+                  })
+                  .option("permission-mode", {
+                    describe:
+                      "Permission mode for the new session (default: bypassPermissions; options: default, bypassPermissions, acceptEdits, plan, dontAsk)",
+                    type: "string",
+                  })
+                  .option("model", {
+                    describe:
+                      "Model override for the new session (default: configured model)",
+                    type: "string",
+                  })
+                  .option("worktree", {
+                    describe:
+                      "Create the session in a new git worktree (name optional — auto-generated when omitted)",
+                    type: "string",
+                  });
+              },
+              async (argv) => {
+                const { daemonCreateCommand, DEFAULT_DAEMON_SOCKET } =
+                  await import("./daemon/commands.js");
+                await daemonCreateCommand(DEFAULT_DAEMON_SOCKET, {
+                  workdir: argv.workdir as string | undefined,
+                  permissionMode: argv.permissionMode as string | undefined,
+                  model: argv.model as string | undefined,
+                  worktree: argv.worktree as string | undefined,
+                });
+              },
+            )
+            .command(
               "list",
               "List sessions hosted by the daemon (in-memory registry)",
               {},
@@ -391,6 +428,33 @@ export async function main() {
                 await daemonAbortCommand(
                   DEFAULT_DAEMON_SOCKET,
                   argv.sessionId as string,
+                );
+              },
+            )
+            .command(
+              "destroy <sessionId>",
+              "Destroy a daemon session (idempotent)",
+              (yargs) => {
+                return yargs
+                  .positional("sessionId", {
+                    describe: "Session ID of the session to destroy",
+                    type: "string",
+                  })
+                  .option("remove-worktree", {
+                    describe:
+                      "Also remove the session's git worktree (resolved via git, removed via protocol removeWorktree) before destroying",
+                    type: "boolean",
+                  });
+              },
+              async (argv) => {
+                const { daemonDestroyCommand, DEFAULT_DAEMON_SOCKET } =
+                  await import("./daemon/commands.js");
+                await daemonDestroyCommand(
+                  DEFAULT_DAEMON_SOCKET,
+                  argv.sessionId as string,
+                  {
+                    removeWorktree: argv.removeWorktree as boolean | undefined,
+                  },
                 );
               },
             )

--- a/packages/code/tests/daemon/commands.test.ts
+++ b/packages/code/tests/daemon/commands.test.ts
@@ -17,8 +17,10 @@ import * as net from "net";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
 import {
   Agent,
+  hasWorktreeCreateHook,
   loadUserConfigEnv,
   type AgentCallbacks,
   type Message,
@@ -36,8 +38,54 @@ vi.mock("wave-agent-sdk", async (importOriginal) => {
     ...actual,
     Agent: { create: vi.fn() },
     loadUserConfigEnv: vi.fn(() => ({})),
+    getGitMainRepoRoot: vi.fn(() => "/repo/main"),
+    hasWorktreeCreateHook: vi.fn(() => false),
+    loadMergedWaveConfig: vi.fn(() => ({})),
+    validateWorktreeRemovalPath: vi.fn(),
   };
 });
+
+// Daemon commands auto-start a daemon on connect failure (spec: 按需即用);
+// stub spawn so tests never launch a real `wave --daemon` child process.
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, spawn: vi.fn(), execFile: vi.fn() };
+});
+
+// destroy --remove-worktree runs git lookups through execFile; these
+// module-level variables drive the mock per-test (set inside each test).
+let gitTopLevel = "";
+let gitBranch = "";
+let gitLookupError: Error | null = null;
+const execFileMock = vi.mocked(execFile) as unknown as ReturnType<typeof vi.fn>;
+execFileMock.mockImplementation(
+  (
+    cmd: string,
+    args: readonly string[] | null | undefined,
+    _opts: unknown,
+    cb: ((err: Error | null, stdout: string) => void) | null | undefined,
+  ) => {
+    if (!cb) return;
+    if (gitLookupError) {
+      cb(gitLookupError, "");
+      return;
+    }
+    if (cmd === "git" && args?.[0] === "rev-parse") {
+      cb(null, gitTopLevel + "\n");
+      return;
+    }
+    if (cmd === "git" && args?.[0] === "branch") {
+      cb(null, gitBranch + "\n");
+      return;
+    }
+    cb(null, "");
+  },
+);
+
+vi.mock("../../src/utils/worktree.js", () => ({
+  createWorktree: vi.fn(),
+  removeWorktree: vi.fn(),
+}));
 
 // vitest.config onConsoleLog throws on any stderr console output — commands use
 // console.error for diagnostics, so capture it (and raw writes) here.
@@ -64,12 +112,32 @@ const exitSpy = vi
 
 import { DaemonServer } from "../../src/stdio/daemonServer.js";
 import {
+  daemonCreateCommand,
+  daemonDestroyCommand,
   daemonListCommand,
   daemonStatusCommand,
   daemonSendCommand,
   daemonRespondCommand,
   daemonAbortCommand,
+  daemonStartTimeout,
 } from "../../src/daemon/commands.js";
+import { createWorktree, removeWorktree } from "../../src/utils/worktree.js";
+
+/** When set, the spawn mock starts a real daemon here so the retry succeeds. */
+let autoStartSocket: string | undefined;
+let autoStartServer: DaemonServer | undefined;
+// Simulate the detached `wave --daemon` child the commands spawn: start a real
+// DaemonServer at autoStartSocket (success path); without one the daemon never
+// comes up (failure path).
+vi.mocked(spawn).mockImplementation(() => {
+  if (autoStartSocket) {
+    const s = new DaemonServer({ socketPath: autoStartSocket });
+    void s.start().then(() => {
+      autoStartServer = s;
+    });
+  }
+  return { unref: () => {} } as unknown as ChildProcess;
+});
 
 function userMsg(id: string, content: string): Message {
   return {
@@ -192,6 +260,9 @@ let socketPath: string;
 
 beforeEach(async () => {
   vi.clearAllMocks();
+  gitTopLevel = "";
+  gitBranch = "";
+  gitLookupError = null;
   vi.mocked(loadUserConfigEnv).mockReturnValue({});
   vi.mocked(Agent.create).mockResolvedValue(createMockAgent());
   socketPath = path.join(
@@ -204,6 +275,10 @@ beforeEach(async () => {
 
 afterEach(async () => {
   stderrWriteSpy.mockRestore();
+  daemonStartTimeout.ms = 10_000;
+  await autoStartServer?.stop();
+  autoStartServer = undefined;
+  autoStartSocket = undefined;
   await server.stop();
   try {
     fs.unlinkSync(socketPath);
@@ -254,17 +329,86 @@ test("list: prints a padded table of hosted sessions (in-memory registry)", asyn
   expect(exitSpy).toHaveBeenCalledWith(0);
 });
 
-test("list: daemon not running exits 1 with the spec'd hint", async () => {
+test("list: auto-starts a daemon on demand and retries when the socket is missing", async () => {
+  const missing = path.join(
+    os.tmpdir(),
+    `wave-daemon-autostart-${process.pid}-${Date.now()}.sock`,
+  );
+  autoStartSocket = missing;
+  await expect(daemonListCommand(missing)).rejects.toThrow("exit(0)");
+  expect(spawn).toHaveBeenCalledWith(
+    process.execPath,
+    [process.argv[1], "--daemon", missing],
+    expect.objectContaining({ detached: true }),
+  );
+  // The on-demand daemon is now live — an empty registry is not an error.
+  expect(stdoutLines()).toEqual(["No sessions"]);
+  expect(exitSpy).toHaveBeenCalledWith(0);
+});
+
+test("list: daemon that never comes up after auto-start exits 1 with the spec'd hint", async () => {
   const missing = path.join(
     os.tmpdir(),
     `wave-daemon-missing-${process.pid}-${Date.now()}.sock`,
   );
+  daemonStartTimeout.ms = 200;
   await expect(daemonListCommand(missing)).rejects.toThrow("exit(1)");
-  expect(stderrText()).toContain(`Cannot connect to daemon socket ${missing}`);
-  expect(stderrText()).toContain(
-    "is the daemon running? (it auto-exits after 60s idle)",
+  expect(spawn).toHaveBeenCalledWith(
+    process.execPath,
+    [process.argv[1], "--daemon", missing],
+    expect.objectContaining({ detached: true }),
   );
+  expect(stderrText()).toContain(`Cannot connect to daemon socket ${missing}`);
+  expect(stderrText()).toContain("started a daemon but it did not come up");
   expect(stderrText()).toContain("(ENOENT)");
+  expect(exitSpy).toHaveBeenCalledWith(1);
+});
+
+// ── create ─────────────────────────────────────────────────────
+
+test("create: prints the new sessionId, uses defaults, and hosts the session", async () => {
+  await expect(daemonCreateCommand(socketPath)).rejects.toThrow("exit(0)");
+  expect(stdoutLines()).toEqual(["test-session-id"]);
+  const options = vi.mocked(Agent.create).mock.calls[0][0];
+  expect(options.workdir).toBe(process.cwd());
+  expect(options.permissionMode).toBe("bypassPermissions");
+  expect(exitSpy).toHaveBeenCalledWith(0);
+
+  // The new session is hosted in the daemon's registry.
+  const client = connectClient(socketPath);
+  const msgs = await client.send({
+    id: 9,
+    method: "listDaemonSessions",
+    params: {},
+  });
+  const result = msgs[0] as { result: { sessions: unknown[] } };
+  expect(result.result.sessions).toHaveLength(1);
+  client.close();
+});
+
+test("create: --workdir / --permission-mode / --model are forwarded", async () => {
+  await expect(
+    daemonCreateCommand(socketPath, {
+      workdir: "/tmp/wave-create-test",
+      permissionMode: "acceptEdits",
+      model: "gpt-test",
+    }),
+  ).rejects.toThrow("exit(0)");
+  const options = vi.mocked(Agent.create).mock.calls[0][0];
+  expect(options.workdir).toBe("/tmp/wave-create-test");
+  expect(options.permissionMode).toBe("acceptEdits");
+  expect(options.model).toBe("gpt-test");
+  expect(exitSpy).toHaveBeenCalledWith(0);
+});
+
+test("create: invalid --permission-mode fails without connecting or creating", async () => {
+  await expect(
+    daemonCreateCommand(socketPath, { permissionMode: "bogus" }),
+  ).rejects.toThrow("exit(1)");
+  expect(stderrText()).toContain(
+    "Invalid permission mode: bogus (options: default, bypassPermissions, acceptEdits, plan, dontAsk)",
+  );
+  expect(vi.mocked(Agent.create)).not.toHaveBeenCalled();
   expect(exitSpy).toHaveBeenCalledWith(1);
 });
 
@@ -459,6 +603,40 @@ test("send: times out with the generic message when nothing is pending", async (
   expect(stderrText()).toContain(
     "Timed out waiting for a reply (0.2s), no assistant reply received",
   );
+  expect(exitSpy).toHaveBeenCalledWith(1);
+});
+
+test("send: an interrupted reply (reasoning only, no text) exits 1 with an interruption hint", async () => {
+  let agent!: ReturnType<typeof createMockAgent>;
+  let callbacks!: AgentCallbacks;
+  vi.mocked(Agent.create).mockImplementation(async (options) => {
+    callbacks = options.callbacks!;
+    agent = createMockAgent();
+    agent.sendMessage = vi.fn(async () => {
+      agent.messages.push(userMsg("u1", "继续"));
+      // Aborted mid-generation: the final reply carries only reasoning.
+      agent.messages.push({
+        id: "a1",
+        role: "assistant",
+        blocks: [{ type: "reasoning", content: "思考了一半…" }],
+        timestamp: "t",
+      });
+      callbacks.onUserMessageAdded?.({ content: "继续" });
+      callbacks.onAssistantMessageAdded?.("a1");
+      callbacks.onLoadingChange?.(false);
+    });
+    return agent;
+  });
+
+  const client = connectClient(socketPath);
+  await client.send({ id: 1, method: "initialize", params: {} });
+  client.close();
+
+  await expect(
+    daemonSendCommand(socketPath, "test-session-id", "继续", { timeout: 5 }),
+  ).rejects.toThrow("exit(1)");
+  expect(stderrText()).toContain("Message aborted before producing a reply");
+  expect(stdoutLines()).toEqual([]);
   expect(exitSpy).toHaveBeenCalledWith(1);
 });
 
@@ -761,4 +939,213 @@ test("abort: nonexistent session fails, destroys the junk fresh session, no abor
   expect(exitSpy).toHaveBeenCalledWith(1);
   expect(junk.destroy).toHaveBeenCalled();
   expect(junk.abortMessage).not.toHaveBeenCalled();
+});
+
+// ── destroy ────────────────────────────────────────────────────
+
+test("destroy: removes a hosted session from the registry", async () => {
+  const client = connectClient(socketPath);
+  await client.send({ id: 1, method: "initialize", params: {} });
+  client.close();
+
+  await expect(
+    daemonDestroyCommand(socketPath, "test-session-id"),
+  ).rejects.toThrow("exit(0)");
+  expect(logSpy).toHaveBeenCalledWith("Destroyed session: test-session-id");
+  expect(exitSpy).toHaveBeenCalledWith(0);
+
+  // The registry is now empty — the session is gone.
+  const b = connectClient(socketPath);
+  const msgs = await b.send({
+    id: 9,
+    method: "listDaemonSessions",
+    params: {},
+  });
+  const result = msgs[0] as { result: { sessions: unknown[] } };
+  expect(result.result.sessions).toEqual([]);
+  b.close();
+});
+
+test("destroy: unknown session is an idempotent no-op that still exits 0", async () => {
+  await expect(daemonDestroyCommand(socketPath, "ghost")).rejects.toThrow(
+    "exit(0)",
+  );
+  expect(logSpy).toHaveBeenCalledWith("Destroyed session: ghost");
+  expect(exitSpy).toHaveBeenCalledWith(0);
+  expect(vi.mocked(Agent.create)).not.toHaveBeenCalled();
+});
+
+// ── create --worktree ──────────────────────────────────────────
+
+test("create: --worktree creates a worktree first, then the session inside it", async () => {
+  vi.mocked(createWorktree).mockResolvedValue({
+    name: "feature-x",
+    path: "/repo/main/.wave/worktrees/feature-x",
+    branch: "feature-x",
+    repoRoot: "/repo/main",
+    hasUncommittedChanges: false,
+    hasNewCommits: false,
+    isNew: true,
+    hookBased: false,
+  });
+  await expect(
+    daemonCreateCommand(socketPath, { worktree: "feature-x" }),
+  ).rejects.toThrow("exit(0)");
+  // sessionId first (script-compatible), worktree info second.
+  expect(stdoutLines()).toEqual([
+    "test-session-id",
+    "Worktree: /repo/main/.wave/worktrees/feature-x (branch: feature-x)",
+  ]);
+  expect(vi.mocked(createWorktree)).toHaveBeenCalledWith(
+    "feature-x",
+    process.cwd(),
+    { baseBranch: undefined },
+  );
+  const options = vi.mocked(Agent.create).mock.calls[0][0];
+  expect(options.workdir).toBe("/repo/main/.wave/worktrees/feature-x");
+  expect(exitSpy).toHaveBeenCalledWith(0);
+});
+
+test("create: bare --worktree auto-generates the worktree name", async () => {
+  vi.mocked(createWorktree).mockResolvedValue({
+    name: "generated-name",
+    path: "/repo/main/.wave/worktrees/generated-name",
+    branch: "generated-name",
+    repoRoot: "/repo/main",
+    hasUncommittedChanges: false,
+    hasNewCommits: false,
+    isNew: true,
+    hookBased: false,
+  });
+  await expect(
+    daemonCreateCommand(socketPath, { worktree: "" }),
+  ).rejects.toThrow("exit(0)");
+  // The daemon normalizes the empty name to a generated one.
+  expect(vi.mocked(createWorktree)).toHaveBeenCalledWith(
+    expect.any(String),
+    process.cwd(),
+    { baseBranch: undefined },
+  );
+  expect(vi.mocked(createWorktree).mock.calls[0][0]).not.toBe("");
+  expect(stdoutLines()[0]).toBe("test-session-id");
+  expect(exitSpy).toHaveBeenCalledWith(0);
+});
+
+// ── destroy --remove-worktree ──────────────────────────────────
+
+test("destroy: --remove-worktree resolves the worktree via git and removes it before destroying", async () => {
+  gitTopLevel = "/repo/main/.wave/worktrees/feature-x";
+  gitBranch = "feature-x";
+  const client = connectClient(socketPath);
+  await client.send({ id: 1, method: "initialize", params: {} });
+  client.close();
+
+  await expect(
+    daemonDestroyCommand(socketPath, "test-session-id", {
+      removeWorktree: true,
+    }),
+  ).rejects.toThrow("exit(0)");
+  // git lookups ran against the session's workingDirectory.
+  expect(execFile).toHaveBeenCalledWith(
+    "git",
+    ["rev-parse", "--show-toplevel"],
+    { cwd: "/test/workdir" },
+    expect.any(Function),
+  );
+  expect(execFile).toHaveBeenCalledWith(
+    "git",
+    ["branch", "--show-current"],
+    { cwd: "/test/workdir" },
+    expect.any(Function),
+  );
+  // The daemon's removeWorktree ran with the resolved values (bridge fills the
+  // remaining WorktreeSession fields).
+  expect(vi.mocked(removeWorktree)).toHaveBeenCalledWith({
+    name: "",
+    path: "/repo/main/.wave/worktrees/feature-x",
+    branch: "feature-x",
+    repoRoot: "/repo/main",
+    hasUncommittedChanges: false,
+    hasNewCommits: false,
+    isNew: false,
+    hookBased: false,
+  });
+  expect(stdoutLines()).toEqual([
+    "Removed worktree: /repo/main/.wave/worktrees/feature-x (branch: feature-x)",
+    "Destroyed session: test-session-id",
+  ]);
+  expect(exitSpy).toHaveBeenCalledWith(0);
+});
+
+test("destroy: --remove-worktree refuses to remove the main working tree", async () => {
+  // rev-parse resolves to the main repo root itself (a plain session).
+  gitTopLevel = "/repo/main";
+  gitBranch = "main";
+  const client = connectClient(socketPath);
+  await client.send({ id: 1, method: "initialize", params: {} });
+  client.close();
+
+  await expect(
+    daemonDestroyCommand(socketPath, "test-session-id", {
+      removeWorktree: true,
+    }),
+  ).rejects.toThrow("exit(1)");
+  expect(stderrText()).toContain(
+    "wave daemon destroy failed: Refusing to remove the main working tree: /repo/main (not a linked worktree)",
+  );
+  expect(vi.mocked(removeWorktree)).not.toHaveBeenCalled();
+  expect(exitSpy).toHaveBeenCalledWith(1);
+
+  // The session is still hosted — nothing was removed or destroyed.
+  const b = connectClient(socketPath);
+  const msgs = await b.send({
+    id: 9,
+    method: "listDaemonSessions",
+    params: {},
+  });
+  const result = msgs[0] as { result: { sessions: unknown[] } };
+  expect(result.result.sessions).toHaveLength(1);
+  b.close();
+});
+
+test("destroy: --remove-worktree forwards hookBased when the repo uses a WorktreeCreate hook", async () => {
+  gitTopLevel = "/repo/main/.wave/worktrees/feature-x";
+  gitBranch = "feature-x";
+  vi.mocked(hasWorktreeCreateHook).mockReturnValue(true);
+  const client = connectClient(socketPath);
+  await client.send({ id: 1, method: "initialize", params: {} });
+  client.close();
+
+  await expect(
+    daemonDestroyCommand(socketPath, "test-session-id", {
+      removeWorktree: true,
+    }),
+  ).rejects.toThrow("exit(0)");
+  expect(vi.mocked(removeWorktree)).toHaveBeenCalledWith(
+    expect.objectContaining({ hookBased: true }),
+  );
+  expect(stdoutLines()).toContain(
+    "Removed worktree: /repo/main/.wave/worktrees/feature-x (branch: feature-x)",
+  );
+  expect(exitSpy).toHaveBeenCalledWith(0);
+});
+
+test("destroy: --remove-worktree on a non-git working directory fails with a clear message", async () => {
+  gitLookupError = new Error(
+    "fatal: not a git repository (or any of the parent directories): .git",
+  );
+  const client = connectClient(socketPath);
+  await client.send({ id: 1, method: "initialize", params: {} });
+  client.close();
+
+  await expect(
+    daemonDestroyCommand(socketPath, "test-session-id", {
+      removeWorktree: true,
+    }),
+  ).rejects.toThrow("exit(1)");
+  expect(stderrText()).toContain(
+    "wave daemon destroy failed: Cannot remove worktree: /test/workdir is not inside a git repository",
+  );
+  expect(vi.mocked(removeWorktree)).not.toHaveBeenCalled();
+  expect(exitSpy).toHaveBeenCalledWith(1);
 });


### PR DESCRIPTION
## 需求背景

`wave daemon` 此前只有 list/status/send/respond/abort 五个客户端子命令，会话只能由桌面端/IDE 经协议创建，纯 CLI 用户没有创建与销毁入口。本次补全会话生命周期：新增 `create` / `destroy` 子命令，并给 create 增加 `--worktree`（会话建在新建 git worktree 内）、destroy 增加 `--remove-worktree`（连同会话所在 worktree 一并移除）。同时修复 send 被中断时静默退出的瑕疵，并去掉常驻托管依赖——任一子命令连接失败时自动按需拉起 daemon。

## 规格

docs/specs/ui/daemon-command.md 更新：

- 新增用户故事「创建新会话」（P0）：`create` 走协议 `initialize`（无 restoreSessionId=新建），默认 workdir=当前目录 / permissionMode=bypassPermissions；验收场景 5 条（含 `--worktree` 流程）
- 新增用户故事「销毁会话」（P0）：`destroy` 幂等纯注册表操作；验收场景 6 条（含 `--remove-worktree` 全流程、主工作树拒绝、非 git 仓库报错）
- 命令组故事补「按需即用」：所有子命令连接失败自动 nohup 式拉起 daemon 并重试
- 边界情况 +4 bullets；spec-count 77/463/1967

## 实现

- **create**（commands.ts）：`--worktree [name]` 先调协议 `createWorktree`（params workdir+name，name 缺省服务端自动生成），再用返回的 worktree path 调 `initialize`；stdout 输出 sessionId（第一行，脚本兼容）+ `Worktree: <path> (branch: <branch>)`
- **destroy --remove-worktree**：先 `getSessionInfo` 拿 workingDirectory → git 反查 worktree 路径（`rev-parse --show-toplevel`）、分支（`branch --show-current`）、主仓根（SDK `getGitMainRepoRoot`，语义与 createWorktree 返回一致）→ 协议 `removeWorktree`（hookBased 按 WorktreeCreate hook 配置判定，与 createWorktree 一致）→ 再 `destroy`
- **主工作树守卫**：path==repoRoot 时拒绝（防 removeWorktree 的 fs.rmSync 回退删整个仓库）；非 git 仓库明确报错
- **send 中断修复**：等待期间回复被 abort（最终消息只有 reasoning 无正文）时，stderr 提示「Message aborted before producing a reply」并以退出码 1 退出，不再静默 exit 0 无输出
- **按需拉起 daemon**：所有子命令连接失败时 detached spawn `node <cli> --daemon <socket>`（stdio ignore + unref，本地等价于远程 nohup），轮询等待 socket 就绪（默认 10s），超时才报错退出
- **index.ts**：create/destroy 子命令注册 `--worktree` / `--remove-worktree` 选项

## 验证

- code 单测 1511/1511（102 文件，daemon 命令 41/41：create --worktree 具名/裸用、destroy --remove-worktree 全流程/主工作树拒绝/hookBased 透传/非 git 报错）
- 全仓 type-check + lint 全绿
- 真实冒烟：临时 git 仓库 `create --worktree` → worktree+分支生成、会话建在其内 → `destroy --remove-worktree` → worktree/分支/会话全清；主工作树守卫拒绝（exit 1、仓库完好）；裸 `--worktree` 自动命名
