### PR TITLE
docs: 修复 desktop-density-restore.md 死链（反引号包裹 localhost URL）

### DIFF
--- a/docs/desktop-density-restore.md
+++ b/docs/desktop-density-restore.md
@@ -757,7 +757,7 @@ welcome 态输入区：第十轮实测发现 `.chat-container--welcome .input-ar
 
 ## 第十八轮：预览面板工具栏图标/地址栏字号/背景色（1 项评论）
 
-评论：`div.preview-pane-toolbar`「http://localhost:8899/」图标不对，输入区域字号，背景色不对。
+评论：`div.preview-pane-toolbar`「`http://localhost:8899/`」图标不对，输入区域字号，背景色不对。
 
 ### 变更点清单
 
@@ -1076,8 +1076,8 @@ welcome 态输入区：第十轮实测发现 `.chat-container--welcome .input-ar
 
 ## 第二十七轮：预览头部背景（toolbar 深色去背景 / tab-bar 浅色补白底）（2 项评论）
 
-评论①：`div.preview-pane-toolbar`「http://localhost:8899/」——「深色模式下这里不应该有背景色」。
-评论②：`div.preview-tab-bar`「localhost:8899」——「浅色模式下这里不应该有背景色」。
+评论①：`div.preview-pane-toolbar`「`http://localhost:8899/`」——「深色模式下这里不应该有背景色」。
+评论②：`div.preview-tab-bar`「`localhost:8899`」——「浅色模式下这里不应该有背景色」。
 
 ### 背景：第 18 轮后头部状态与用户感知
 


### PR DESCRIPTION
Deploy VitePress 因 desktop-density-restore.md 中 2 个裸 `http://localhost:8899/中文评论…` 被 VitePress 当作链接并判 dead link 而失败（run 33598894965）。将 3 处 localhost 占位符（760/1079/1080 行）包进反引号 code span，不再参与 dead-link 检查。