### PR TITLE
fix(webview): 桌面端工具确认弹窗按钮恢复水平布局（保留设计师三态配色）

### DIFF
--- a/packages/webview/src/styles/host-desktop.css
+++ b/packages/webview/src/styles/host-desktop.css
@@ -1407,18 +1407,16 @@
   padding: 0;
 }
 
-/* ② 按钮布局：codechat approval-actions —— flex-direction column / gap 8 /
-   margin-top 16；按钮全宽（width 100%）min-height 32 / pad 0 12 / 字重 500。
-   DOM 顺序即视觉顺序：自动类(secondary) → 批准并继续(primary) → 提供反馈
-   (ghost) 在底（第三十轮按用户反馈把提供反馈移到最下面）。 */
+/* ② 按钮布局：按钮保持水平并排（用户拍板：工具确认弹窗按钮维持既有水平对齐，
+   不随 codechat approval-dialog 改竖排全宽——2026-09-02 反馈）；其余视觉按
+   codechat 节奏：margin-top 16、按钮 min-height 32 / pad 0 12 / 字重 500 /
+   r6、secondary/primary/ghost 三态配色（见下）。DOM 顺序即视觉顺序：
+   自动类(secondary) → 批准并继续(primary) → 提供反馈(ghost)。 */
 [data-host="desktop"] .confirmation-actions {
-  flex-direction: column;
-  align-items: stretch;
   gap: 8px;
   margin-top: 16px;
 }
 [data-host="desktop"] .confirmation-actions .confirmation-btn {
-  width: 100%;
   min-height: 32px;
   padding: 0 12px;
   font-weight: 500;


### PR DESCRIPTION
用户反馈（2026-09-02 截图走查）：工具确认弹窗按钮被第 22 轮设计改动（对齐 codechat approval-dialog）改成竖排全宽，但此前验收的是**水平布局**——期望保留水平对齐。

修复：host-desktop.css 去掉 desktop 作用域的 `flex-direction: column / width: 100%`（恢复 base 水平 flex-wrap 右对齐），保留设计师其余视觉：
- 三态配色：secondary（`是，并跳过权限确认` 深灰浅底）/ primary（`批准并继续` 蓝）/ ghost（`提供反馈` 文本样式）
- r6 圆角、min-height 32px、pad 0 12px、字重 500、margin-top 16 间距

验证：webview 单测 865/865、e2e 33/33 全绿；desktop harness 真机截图确认按钮水平同行右对齐、主按钮蓝色突出（/tmp/desktop-confirm-horizontal.png）。