### PR TITLE
webview/docs: 修复桌面截图深浅混色与假感，vsce 文档重构为截图画廊

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -138,9 +138,15 @@ export default {
           text: "插件使用文档",
           collapsed: false,
           items: [
-            { text: "快速入门", link: "/vsce#快速入门" },
-            { text: "VS Code 扩展", link: "/vsce#vs-code-扩展" },
-            { text: "JetBrains 插件", link: "/vsce#jetbrains-插件" },
+            {
+              text: "快速入门",
+              link: "/vsce#快速入门",
+              collapsed: false,
+              items: [
+                { text: "VS Code 扩展", link: "/vsce#vs-code-扩展" },
+                { text: "JetBrains 插件", link: "/vsce#jetbrains-插件" },
+              ],
+            },
             { text: "AI 核心能力", link: "/vsce#ai-核心能力" },
             {
               text: "画廊",

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -142,12 +142,34 @@ export default {
             { text: "VS Code 扩展", link: "/vsce#vs-code-扩展" },
             { text: "JetBrains 插件", link: "/vsce#jetbrains-插件" },
             { text: "AI 核心能力", link: "/vsce#ai-核心能力" },
-            { text: "代码选择与引用", link: "/vsce#代码选择与引用" },
             {
-              text: "通过 Worktree 创建隔离环境",
-              link: "/vsce#通过-worktree-创建隔离环境",
+              text: "画廊",
+              collapsed: false,
+              items: [
+                {
+                  text: "1. 核心聊天体验",
+                  link: "/vsce#_1-核心聊天体验",
+                },
+                {
+                  text: "2. 智能输入与上下文",
+                  link: "/vsce#_2-智能输入与上下文",
+                },
+                {
+                  text: "3. 代码理解与操作",
+                  link: "/vsce#_3-代码理解与操作",
+                },
+                { text: "4. 权限与安全", link: "/vsce#_4-权限与安全" },
+                { text: "5. 任务管理", link: "/vsce#_5-任务管理" },
+                {
+                  text: "6. 多 Agents 与并发",
+                  link: "/vsce#_6-多-agents-与并发",
+                },
+                { text: "7. 能力扩展", link: "/vsce#_7-能力扩展" },
+                { text: "8. 会话与持久化", link: "/vsce#_8-会话与持久化" },
+                { text: "9. 配置管理", link: "/vsce#_9-配置管理" },
+                { text: "10. 插件系统", link: "/vsce#_10-插件系统" },
+              ],
             },
-            { text: "多对话并行", link: "/vsce#多对话并行" },
           ],
         },
       ],

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -147,7 +147,6 @@ export default {
                 { text: "JetBrains 插件", link: "/vsce#jetbrains-插件" },
               ],
             },
-            { text: "AI 核心能力", link: "/vsce#ai-核心能力" },
             {
               text: "画廊",
               collapsed: false,

--- a/docs/.vitepress/theme/gallery.css
+++ b/docs/.vitepress/theme/gallery.css
@@ -1,0 +1,36 @@
+/* Screenshot gallery for docs (vsce.md 画廊). 3-up on wide viewports,
+   2-up on narrow — screenshots share one app UI so a row of identical-width
+   frames keeps the page tidy. */
+.screenshot-gallery {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  margin: 16px 0 24px;
+}
+
+.screenshot-gallery figure {
+  margin: 0;
+}
+
+.screenshot-gallery img {
+  width: 100%;
+  height: auto;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  display: block;
+}
+
+.screenshot-gallery figcaption {
+  text-align: center;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--vp-c-text-2);
+  margin-top: 6px;
+}
+
+@media (max-width: 720px) {
+  .screenshot-gallery {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+  }
+}

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -4,6 +4,7 @@ import DefaultTheme from "vitepress/theme";
 import mediumZoom from "medium-zoom";
 
 import "./zoom.css";
+import "./gallery.css";
 
 let zoom = null;
 

--- a/docs/vsce.md
+++ b/docs/vsce.md
@@ -20,41 +20,226 @@ Wave 代码智聊是一款集成在 VS Code 与 JetBrains IDE（WebStorm、Intel
 
 在 JetBrains 插件市场（IDE「设置 → 插件」）搜索 **Wave Code Chat** 安装。打开聊天面板点击欢迎页的「登录」按钮完成 SSO 登录。
 
-![欢迎页](/screenshots/spec-welcome.webp)
-
 ## AI 核心能力
 
 所有操作和 AI 能力与桌面端保持同步，详见 [桌面端产品文档](/desktop)。
 
-## 代码选择与引用
+## 画廊
 
-用户可以通过编辑器右键菜单中的"添加到 CodeWave"选项，将选中的代码手动添加到对话上下文中。选中的代码会以蓝色内联标签的形式插入到输入框当前光标位置。在消息历史中，点击该标签可快速跳转回编辑器中的对应文件及行号。
+### 1. 核心聊天体验
 
-![输入框中的代码选中标签](/screenshots/spec-selection-inline-tag.webp)
+<div class="screenshot-gallery">
 
-![消息历史中的内联标签](/screenshots/spec-message-inline-tags.webp)
+<figure><img src="/screenshots/spec-welcome.webp" alt="欢迎页" /><figcaption>欢迎页</figcaption></figure>
 
-## 通过 Worktree 创建隔离环境
+<figure><img src="/screenshots/spec-welcome-login.webp" alt="未登录欢迎页" /><figcaption>未登录欢迎页</figcaption></figure>
 
-多个对话并行修改同一仓库时，直接在主线工作区改动容易互相冲突。此时可以让 AI 调用 `EnterWorktree` 工具，为每个对话创建独立的 git worktree——每个 worktree 拥有独立的分支与工作目录，互不影响。
+<figure><img src="/screenshots/spec-basic-chat.webp" alt="基础对话" /><figcaption>基础对话</figcaption></figure>
 
-在对话中直接以自然语言提出即可，例如：
+<figure><img src="/screenshots/spec-reasoning.webp" alt="AI 思考过程" /><figcaption>AI 思考过程</figcaption></figure>
 
-> 把支付模块的重构放到独立的 worktree 里做，避免影响主线。
+<figure><img src="/screenshots/spec-sticky-user-message.webp" alt="用户消息吸顶" /><figcaption>用户消息吸顶</figcaption></figure>
 
-AI 会调用 `EnterWorktree` 工具，创建 `.wave/worktrees/<name>` 目录并将当前会话的工作目录切换到该 worktree：
+</div>
 
-![创建 Worktree](/screenshots/spec-worktree-enter.webp)
+### 2. 智能输入与上下文
 
-创建成功后，该对话的所有文件修改都会落在独立的 worktree 中，不会影响主线分支与其他对话。需要离开时，可要求 AI 调用 `ExitWorktree` 工具退出 worktree。
+<div class="screenshot-gallery">
 
-## 多对话并行
+<figure><img src="/screenshots/spec-queue-collapsed.webp" alt="消息队列（收起）" /><figcaption>消息队列（收起）</figcaption></figure>
 
-当需要并行推进多个任务时，可以同时开启多个对话，每个对话独立运行、互不干扰：
+<figure><img src="/screenshots/spec-queued-message.webp" alt="消息队列（展开）" /><figcaption>消息队列（展开）</figcaption></figure>
 
-- **VS Code**：打开多个编辑器标签页（或独立窗口），每个标签页拥有独立的并行会话。
-- **JetBrains**：在 Wave 工具窗口点击「+」按钮新建聊天标签页，多个标签页并行会话。
+<figure><img src="/screenshots/spec-queue-editing.webp" alt="编辑队列消息" /><figcaption>编辑队列消息</figcaption></figure>
 
-![标题栏与工具栏](/screenshots/spec-chat-header.webp)
+<figure><img src="/screenshots/spec-plus-menu.webp" alt="通过&quot;+&quot;菜单打开历史提示词" /><figcaption>通过&quot;+&quot;菜单打开历史提示词</figcaption></figure>
 
-多个对话并行处理同一仓库的不同任务时，为避免在主线工作区直接改动造成冲突，推荐结合 worktree 创建隔离环境使用。
+<figure><img src="/screenshots/spec-history-search.webp" alt="历史提示词弹窗" /><figcaption>历史提示词弹窗</figcaption></figure>
+
+<figure><img src="/screenshots/spec-selection-inline-tag.webp" alt="输入框中的代码选中标签" /><figcaption>输入框中的代码选中标签</figcaption></figure>
+
+<figure><img src="/screenshots/spec-slash-commands.webp" alt="指令系统" /><figcaption>指令系统</figcaption></figure>
+
+<figure><img src="/screenshots/spec-model-popup.webp" alt="模型选择菜单" /><figcaption>模型选择菜单</figcaption></figure>
+
+<figure><img src="/screenshots/spec-file-suggestions.webp" alt="文件建议下拉列表" /><figcaption>文件建议下拉列表</figcaption></figure>
+
+<figure><img src="/screenshots/spec-inline-mentions.webp" alt="输入框中的内联标签" /><figcaption>输入框中的内联标签</figcaption></figure>
+
+<figure><img src="/screenshots/spec-image-preview.webp" alt="图片全屏预览模态框" /><figcaption>图片全屏预览模态框</figcaption></figure>
+
+<figure><img src="/screenshots/spec-message-inline-tags.webp" alt="消息列表中的内联标签" /><figcaption>消息列表中的内联标签</figcaption></figure>
+
+<figure><img src="/screenshots/bash-mode-success.webp" alt="Bash 模式命令执行成功" /><figcaption>Bash 模式命令执行成功</figcaption></figure>
+
+<figure><img src="/screenshots/bash-mode-long-output.webp" alt="长输出展示" /><figcaption>长输出展示</figcaption></figure>
+
+<figure><img src="/screenshots/spec-input-empty.webp" alt="输入框（空态）" /><figcaption>输入框（空态）</figcaption></figure>
+
+<figure><img src="/screenshots/spec-input-focus.webp" alt="输入框（聚焦态）" /><figcaption>输入框（聚焦态）</figcaption></figure>
+
+<figure><img src="/screenshots/spec-input-multiline.webp" alt="输入框（多行）" /><figcaption>输入框（多行）</figcaption></figure>
+
+<figure><img src="/screenshots/spec-btw-panel.webp" alt="旁路提问面板" /><figcaption>旁路提问面板</figcaption></figure>
+
+<figure><img src="/screenshots/spec-btw-usage.webp" alt="旁路提问使用提示" /><figcaption>旁路提问使用提示</figcaption></figure>
+
+</div>
+
+### 3. 代码理解与操作
+
+<div class="screenshot-gallery">
+
+<figure><img src="/screenshots/spec-bash.webp" alt="终端工具" /><figcaption>终端工具</figcaption></figure>
+
+<figure><img src="/screenshots/spec-exploration.webp" alt="文件探索" /><figcaption>文件探索</figcaption></figure>
+
+<figure><img src="/screenshots/spec-file-ops.webp" alt="文件操作" /><figcaption>文件操作</figcaption></figure>
+
+<figure><img src="/screenshots/spec-diff-viewer.webp" alt="文件差异对比" /><figcaption>文件差异对比</figcaption></figure>
+
+<figure><img src="/screenshots/spec-lsp.webp" alt="LSP 智能" /><figcaption>LSP 智能</figcaption></figure>
+
+<figure><img src="/screenshots/spec-vision.webp" alt="视觉理解" /><figcaption>视觉理解</figcaption></figure>
+
+</div>
+
+### 4. 权限与安全
+
+<div class="screenshot-gallery">
+
+<figure><img src="/screenshots/spec-permission-mode-default.webp" alt="权限模式 - 默认" /><figcaption>权限模式 - 默认</figcaption></figure>
+
+<figure><img src="/screenshots/spec-permission-mode-accept.webp" alt="权限模式 - 自动接受修改" /><figcaption>权限模式 - 自动接受修改</figcaption></figure>
+
+<figure><img src="/screenshots/spec-permission-mode-plan.webp" alt="权限模式 - 计划模式" /><figcaption>权限模式 - 计划模式</figcaption></figure>
+
+<figure><img src="/screenshots/spec-edit-confirm.webp" alt="代码修改确认" /><figcaption>代码修改确认</figcaption></figure>
+
+<figure><img src="/screenshots/spec-bash-confirm.webp" alt="命令执行确认" /><figcaption>命令执行确认</figcaption></figure>
+
+<figure><img src="/screenshots/spec-mcp-tool-confirm.webp" alt="MCP 工具确认" /><figcaption>MCP 工具确认</figcaption></figure>
+
+<figure><img src="/screenshots/spec-plan-confirm.webp" alt="计划执行确认" /><figcaption>计划执行确认</figcaption></figure>
+
+<figure><img src="/screenshots/spec-enter-plan-mode.webp" alt="进入计划模式确认" /><figcaption>进入计划模式确认</figcaption></figure>
+
+<figure><img src="/screenshots/spec-ask-user.webp" alt="交互式提问表单" /><figcaption>交互式提问表单</figcaption></figure>
+
+<figure><img src="/screenshots/spec-ask-user-multi.webp" alt="交互式提问（多个问题轮播）" /><figcaption>交互式提问（多个问题轮播）</figcaption></figure>
+
+<figure><img src="/screenshots/spec-ask-user-multiselect.webp" alt="交互式提问（多选）" /><figcaption>交互式提问（多选）</figcaption></figure>
+
+<figure><img src="/screenshots/ask-user-question-vertical.webp" alt="交互式提问结果（垂直布局）" /><figcaption>交互式提问结果（垂直布局）</figcaption></figure>
+
+<figure><img src="/screenshots/tool-error-scrollable.webp" alt="工具执行错误" /><figcaption>工具执行错误</figcaption></figure>
+
+<figure><img src="/screenshots/error-block-scrollable.webp" alt="通用错误消息" /><figcaption>通用错误消息</figcaption></figure>
+
+</div>
+
+### 5. 任务管理
+
+<div class="screenshot-gallery">
+
+<figure><img src="/screenshots/spec-task-list.webp" alt="任务列表（展开状态）" /><figcaption>任务列表（展开状态）</figcaption></figure>
+
+<figure><img src="/screenshots/spec-task-list-collapsed.webp" alt="任务列表（折叠状态）" /><figcaption>任务列表（折叠状态）</figcaption></figure>
+
+<figure><img src="/screenshots/spec-background-task-list.webp" alt="后台任务管理 - 列表" /><figcaption>后台任务管理 - 列表</figcaption></figure>
+
+<figure><img src="/screenshots/spec-background-task-detail.webp" alt="后台任务管理 - 详情" /><figcaption>后台任务管理 - 详情</figcaption></figure>
+
+<figure><img src="/screenshots/spec-workflow-list.webp" alt="工作流管理 - 列表" /><figcaption>工作流管理 - 列表</figcaption></figure>
+
+<figure><img src="/screenshots/spec-workflow-detail.webp" alt="工作流管理 - 详情" /><figcaption>工作流管理 - 详情</figcaption></figure>
+
+</div>
+
+### 6. 多 Agents 与并发
+
+<div class="screenshot-gallery">
+
+<figure><img src="/screenshots/spec-agents-list.webp" alt="Agents - 列表" /><figcaption>Agents - 列表</figcaption></figure>
+
+<figure><img src="/screenshots/spec-agents-detail.webp" alt="Agents - 详情" /><figcaption>Agents - 详情</figcaption></figure>
+
+<figure><img src="/screenshots/spec-skills-list.webp" alt="技能 - 列表" /><figcaption>技能 - 列表</figcaption></figure>
+
+<figure><img src="/screenshots/spec-subagent-concurrency.webp" alt="并发子代理" /><figcaption>并发子代理</figcaption></figure>
+
+<figure><img src="/screenshots/spec-background-subagent.webp" alt="后台运行子代理" /><figcaption>后台运行子代理</figcaption></figure>
+
+<figure><img src="/screenshots/spec-chat-header.webp" alt="标题栏与工具栏" /><figcaption>标题栏与工具栏</figcaption></figure>
+
+<figure><img src="/screenshots/spec-worktree-enter.webp" alt="创建 Worktree" /><figcaption>创建 Worktree</figcaption></figure>
+
+</div>
+
+### 7. 能力扩展
+
+<div class="screenshot-gallery">
+
+<figure><img src="/screenshots/spec-subagent.webp" alt="子代理状态" /><figcaption>子代理状态</figcaption></figure>
+
+<figure><img src="/screenshots/spec-skill.webp" alt="Skill 系统" /><figcaption>Skill 系统</figcaption></figure>
+
+<figure><img src="/screenshots/spec-mcp.webp" alt="MCP 集成" /><figcaption>MCP 集成</figcaption></figure>
+
+<figure><img src="/screenshots/spec-mcp-server-tab.webp" alt="MCP 服务器管理" /><figcaption>MCP 服务器管理</figcaption></figure>
+
+</div>
+
+### 8. 会话与持久化
+
+<div class="screenshot-gallery">
+
+<figure><img src="/screenshots/spec-rewind-button.webp" alt="用户消息上的回滚按钮" /><figcaption>用户消息上的回滚按钮</figcaption></figure>
+
+<figure><img src="/screenshots/spec-rewind-popup.webp" alt="/rewind 检查点列表" /><figcaption>/rewind 检查点列表</figcaption></figure>
+
+<figure><img src="/screenshots/spec-confirm-rewind.webp" alt="回滚确认对话框" /><figcaption>回滚确认对话框</figcaption></figure>
+
+<figure><img src="/screenshots/spec-session-search.webp" alt="历史对话搜索与关键词高亮" /><figcaption>历史对话搜索与关键词高亮</figcaption></figure>
+
+<figure><img src="/screenshots/spec-more-menu.webp" alt="更多菜单" /><figcaption>更多菜单</figcaption></figure>
+
+</div>
+
+### 9. 配置管理
+
+<div class="screenshot-gallery">
+
+<figure><img src="/screenshots/spec-status-dialog.webp" alt="状态信息" /><figcaption>状态信息</figcaption></figure>
+
+</div>
+
+### 10. 插件系统
+
+<div class="screenshot-gallery">
+
+<figure><img src="/screenshots/spec-plugin-explore.webp" alt="探索新插件（支持关键词搜索）" /><figcaption>探索新插件（支持关键词搜索）</figcaption></figure>
+
+<figure><img src="/screenshots/plugin-search-filtered.webp" alt="关键词过滤效果" /><figcaption>关键词过滤效果</figcaption></figure>
+
+<figure><img src="/screenshots/spec-plugin-installed.webp" alt="已激活插件管理" /><figcaption>已激活插件管理</figcaption></figure>
+
+<figure><img src="/screenshots/spec-sdd-plugin.webp" alt="内置 SDD 插件开关（项目设置）" /><figcaption>内置 SDD 插件开关（项目设置）</figcaption></figure>
+
+<figure><img src="/screenshots/spec-sdd-workflow-spec.webp" alt="规格编写阶段" /><figcaption>规格编写阶段</figcaption></figure>
+
+<figure><img src="/screenshots/spec-sdd-confirm-spec.webp" alt="规格决策" /><figcaption>规格决策</figcaption></figure>
+
+<figure><img src="/screenshots/spec-sdd-plan-preview-tab.webp" alt="技术方案预览" /><figcaption>技术方案预览</figcaption></figure>
+
+<figure><img src="/screenshots/spec-sdd-plan-approve.webp" alt="计划批准交互" /><figcaption>计划批准交互</figcaption></figure>
+
+<figure><img src="/screenshots/spec-sdd-tasklist-progress.webp" alt="编码阶段任务列表" /><figcaption>编码阶段任务列表</figcaption></figure>
+
+<figure><img src="/screenshots/spec-sdd-iterate-update.webp" alt="迭代需求-更新规格" /><figcaption>迭代需求-更新规格</figcaption></figure>
+
+<figure><img src="/screenshots/spec-sdd-iterate-confirm.webp" alt="迭代需求-规格确认" /><figcaption>迭代需求-规格确认</figcaption></figure>
+
+<figure><img src="/screenshots/spec-sdd-iterate-continue.webp" alt="迭代需求-继续实现" /><figcaption>迭代需求-继续实现</figcaption></figure>
+
+</div>

--- a/docs/vsce.md
+++ b/docs/vsce.md
@@ -1,6 +1,6 @@
 # VS Code 扩展 / JetBrains 插件使用文档
 
-Wave 代码智聊是一款集成在 VS Code 与 JetBrains IDE（WebStorm、IntelliJ IDEA 等）中的 AI 辅助编程插件，两者共享同一聊天界面。本文档介绍插件的安装登录与差异化能力，其余 AI 能力与桌面端保持一致。
+Wave 代码智聊是一款集成在 VS Code 与 JetBrains IDE（WebStorm、IntelliJ IDEA 等）中的 AI 辅助编程插件，两者共享同一聊天界面。本文档介绍插件的安装登录与差异化能力，其余 AI 能力与桌面端保持一致，详见 [桌面端产品文档](/desktop)。
 
 ## 快速入门
 
@@ -19,10 +19,6 @@ Wave 代码智聊是一款集成在 VS Code 与 JetBrains IDE（WebStorm、Intel
 ### JetBrains 插件
 
 在 JetBrains 插件市场（IDE「设置 → 插件」）搜索 **Wave Code Chat** 安装。打开聊天面板点击欢迎页的「登录」按钮完成 SSO 登录。
-
-## AI 核心能力
-
-所有操作和 AI 能力与桌面端保持同步，详见 [桌面端产品文档](/desktop)。
 
 ## 画廊
 

--- a/packages/webview/demo/action-confirm-dialog.demo.ts
+++ b/packages/webview/demo/action-confirm-dialog.demo.ts
@@ -1,0 +1,127 @@
+import {
+  test as webviewTest,
+  expect,
+} from "../e2e/utils/webviewTestHarness.js";
+import { test as desktopTest } from "../e2e/utils/desktopTestHarness.js";
+import { MessageInjector } from "../e2e/utils/messageInjector.js";
+import { UIStateVerifier } from "../e2e/utils/uiStateVerifier.js";
+import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
+import { screenshotWebp } from "../e2e/utils/screenshot.js";
+
+webviewTest.describe("Product Spec: Action Confirm Dialog (Rewind)", () => {
+  webviewTest(
+    "should capture the rewind confirmation dialog",
+    async ({ webviewPage }) => {
+      const injector = new MessageInjector(webviewPage);
+      const ui = new UIStateVerifier(webviewPage);
+
+      const messages = [
+        MockDataGenerator.createUserMessage(
+          "帮我分析 PaymentService 的并发问题，看看有没有竞态条件",
+        ),
+        MockDataGenerator.createAssistantMessage(
+          "我已经分析了 PaymentService 的代码，发现 `processPayment` 方法中存在竞态条件。当前的悲观锁实现会导致高并发下性能下降，建议改用乐观锁...",
+        ),
+        MockDataGenerator.createUserMessage(
+          "好的，请为乐观锁实现编写单元测试，覆盖并发冲突场景",
+        ),
+      ];
+      await injector.updateMessages(messages);
+      await injector.endStreaming();
+
+      // Hover the first user message and click its rewind button
+      const firstUserMessage = ui.userMessages.first();
+      await firstUserMessage.hover();
+      const rewindBtn = firstUserMessage.locator(".message-action-btn");
+      await expect(rewindBtn).toBeVisible();
+      await rewindBtn.click();
+
+      // The in-webview confirmation dialog appears centered; no command sent yet
+      const overlay = webviewPage.getByTestId("confirm-dialog-overlay");
+      await expect(overlay).toBeVisible();
+      await expect(overlay).toContainText("确定要回滚到此消息吗？");
+      await expect(overlay).toContainText(
+        "这将删除之后的所有消息并撤销相关的文件更改。",
+      );
+
+      await screenshotWebp(
+        webviewPage,
+        "../../docs/public/screenshots/spec-confirm-rewind.webp",
+      );
+    },
+  );
+});
+
+desktopTest.describe(
+  "Product Spec: Action Confirm Dialog (Delete Session)",
+  () => {
+    desktopTest(
+      "should capture the delete-session confirmation dialog",
+      async ({ webviewPage }) => {
+        const injector = new MessageInjector(webviewPage);
+
+        await webviewPage.setViewportSize({ width: 960, height: 640 });
+
+        await injector.simulateExtensionMessage("setInitialState", {
+          messages: [],
+          isStreaming: false,
+          sessions: [],
+          isAuthenticated: true,
+          configurationData: {
+            baseURL: "https://api.anthropic.com/v1",
+            model: "claude-sonnet-4-20250514",
+            fastModel: "claude-haiku-4-20250514",
+          },
+          permissionMode: "default",
+        });
+        await injector.simulateExtensionMessage("desktopWorkdirState", {
+          workdir: "/Users/dev/projects/wave-agent",
+          recentWorkdirs: ["/Users/dev/projects/wave-agent"],
+        });
+        await injector.simulateExtensionMessage("desktopSessionTree", {
+          groups: [
+            {
+              workdir: "/Users/dev/projects/wave-agent",
+              sessions: [
+                {
+                  sessionId: "sess-a1",
+                  title: "帮我修复登录页的样式问题",
+                  lastActiveAt: new Date("2026-07-27T10:12:00Z").getTime(),
+                  hasWorktree: true,
+                },
+                {
+                  sessionId: "sess-a2",
+                  title: "给 bashTool 增加超时参数",
+                  lastActiveAt: new Date("2026-07-26T09:40:00Z").getTime(),
+                  hasWorktree: false,
+                },
+              ],
+            },
+          ],
+        });
+
+        // Hover the session item to reveal its 更多 button, open the row menu
+        // and pick 删除会话
+        const item = webviewPage.getByTestId("desktop-session-item-sess-a1");
+        await item.hover();
+        await webviewPage.getByTestId("desktop-session-more-sess-a1").click();
+        await webviewPage.getByTestId("desktop-session-menu-delete").click();
+
+        // Worktree sessions also warn about the worktree dir + temp branch
+        const overlay = webviewPage.getByTestId("confirm-dialog-overlay");
+        await expect(overlay).toBeVisible();
+        await expect(overlay).toContainText(
+          "确定删除会话「帮我修复登录页的样式问题」？",
+        );
+        await expect(overlay).toContainText(
+          "worktree 目录与临时分支将一并删除",
+        );
+
+        await screenshotWebp(
+          webviewPage,
+          "../../docs/public/screenshots/desktop-confirm-delete.webp",
+        );
+      },
+    );
+  },
+);

--- a/packages/webview/demo/agents-dialog.demo.ts
+++ b/packages/webview/demo/agents-dialog.demo.ts
@@ -1,0 +1,279 @@
+import { test, expect } from "../e2e/utils/webviewTestHarness.js";
+import { elementScreenshotWebp } from "../e2e/utils/screenshot.js";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * 设置页「子代理」「技能」选项卡 demo（/agents、/skills 斜杠命令落地页）：
+ * 独立加载 settings.js bundle（settings-preview-entry），模拟 host 下发
+ * settingsState(nav) 选中选项卡，再回 subagentConfigurationsResponse /
+ * skillMetadataResponse 展示 4 个来源 Tab（插件 / 内置 / 用户 / 项目）的
+ * agent 定义与技能列表，以及项目技能在当前项目下的平铺列表形态。
+ */
+
+// SettingsPage 的颜色全部走 --vscode-* 变量，独立 settings.html 没有宿主注入，
+// 必须手动带上深色主题变量集，否则截图为白底浅色（实测 2026-08-29）。
+const themeStyles = fs.readFileSync(
+  path.join(process.cwd(), "theme", "theme-base-dark.css"),
+  "utf8",
+);
+
+const mockVscodeApiJs = `
+    window.process = { env: { NODE_ENV: 'production' } };
+    window.acquireVsCodeApi = () => ({
+        postMessage: (message) => {
+            if (!window.testMessages) window.testMessages = [];
+            window.testMessages.push(message);
+        },
+        setState: () => {},
+        getState: () => ({})
+    });
+    window.simulateExtensionMessage = (message) => {
+        window.dispatchEvent(new MessageEvent('message', { data: message }));
+    };
+`;
+
+const settingsHtml = `
+<!DOCTYPE html>
+<html lang="zh-CN" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wave Settings</title>
+    <style>${themeStyles}</style>
+    <link rel="stylesheet" href="vscode-webview://mock-extension-id/settings.css">
+</head>
+<body>
+    <div id="root"></div>
+    <script>${mockVscodeApiJs}</script>
+    <script src="vscode-webview://mock-extension-id/settings.js"></script>
+</body>
+</html>`;
+
+const WORKDIR = "/work/wave-agent";
+
+const agentConfigurations = [
+  {
+    name: "Explore",
+    description:
+      'Fast agent specialized for exploring codebases. Use this when you need to quickly find files by patterns (eg. "src/components/**/*.tsx"), search code for keywords (eg. "API endpoints"), or answer questions about the codebase. When calling this agent, specify the desired thoroughness level: "quick", "medium", or "very thorough".',
+    model: "glm-5.2",
+    tools: ["Glob", "Grep", "Read", "Bash", "LSP"],
+    systemPrompt:
+      "You are a file search specialist. You excel at thoroughly navigating and exploring codebases.\n\n=== CRITICAL: READ-ONLY MODE - NO FILE MODIFICATIONS ===\nThis is a READ-ONLY exploration task. You are STRICTLY PROHIBITED from:\n- Creating new files (no Write, touch, or file creation of any kind)\n- Modifying existing files (no Edit operations)\n- Moving or copying files (no mv or cp)\n\nWhen answering: show the exact file path and line numbers for each relevant piece of code.",
+    filePath: "/builtin/subagents/explore.md",
+    scope: "builtin",
+    priority: 0,
+  },
+  {
+    name: "Plan",
+    description:
+      "Software architect agent for designing implementation plans. Use this when you need to plan the implementation strategy for a task.",
+    model: "glm-5.2",
+    tools: ["Glob", "Grep", "Read", "Bash", "LSP"],
+    systemPrompt:
+      "You are a careful software architect. Before proposing a plan: read the relevant code, identify the critical files, and consider architectural trade-offs. Prefer the simplest approach that satisfies the requirements.",
+    filePath: "/builtin/subagents/plan.md",
+    scope: "builtin",
+    priority: 1,
+  },
+  {
+    name: "code-review",
+    description: "代码评审助手，检查潜在缺陷、类型错误与改进点",
+    model: "deepseek-v4-flash",
+    tools: ["Bash", "Read", "Grep"],
+    systemPrompt:
+      "你是严格的代码评审专家。逐文件检查：\n1. 潜在缺陷与边界条件\n2. 类型安全与空值处理\n3. 错误处理与日志\n输出按严重程度分组的问题清单，并给出修改建议。",
+    filePath: "~/.wave/agents/code-review.md",
+    scope: "user",
+    priority: 0,
+  },
+  {
+    name: "release-bot",
+    description:
+      "仓库级发布助手：检查 changelog、版本号与 CI 状态，执行发布前检查",
+    tools: ["Bash", "Read", "Grep"],
+    systemPrompt:
+      "你是发布检查专家。发布前依次验证：版本号一致性、changelog 完整性、CI 状态与工作区干净度。任一检查失败时给出明确的修复指引。",
+    filePath: ".wave/agents/release-bot.md",
+    scope: "project",
+    priority: 0,
+  },
+  {
+    name: "sdd:specify",
+    description:
+      "根据自然语言描述创建或更新功能规格说明，生成用户故事与验收场景",
+    model: "glm-5.2",
+    tools: ["Read", "Write"],
+    systemPrompt:
+      "你是规格编写专家。需求变更时先更新对应规格说明（新增用户故事、验收场景），边界模糊时先写 spec 草稿请用户确认。",
+    filePath: "/plugins/sdd/agents/specify.md",
+    scope: "plugin",
+    priority: 0,
+    pluginRoot: "/plugins/sdd",
+  },
+];
+
+test.describe("设置页子代理选项卡 Demo", () => {
+  test("should show 4 source tabs, grouped list and detail", async ({
+    webviewPage,
+  }) => {
+    // Settings full-page is wider than the default 400px demo viewport
+    await webviewPage.setViewportSize({ width: 1000, height: 760 });
+
+    // Reload the harness page with the settings entry bundle
+    await webviewPage.setContent(settingsHtml);
+
+    // Wait for the settings page to render
+    await expect(webviewPage.locator(".settings-page")).toBeVisible();
+
+    // Host opens the settings tab with the subagents nav (mirrors /agents →
+    // openSettings(nav:"subagents") → settingsState)
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "settingsState",
+        workdir: "/work/wave-agent",
+        nav: "subagents",
+      });
+    });
+
+    // The settings entry pulls config on open; reply so the page stays healthy
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "configurationResponse",
+        configurationData: { language: "zh-CN", contextLength: 200 },
+      });
+    });
+
+    // Simulate the host replying with subagent configurations
+    await webviewPage.evaluate((configurations) => {
+      window.simulateExtensionMessage({
+        command: "subagentConfigurationsResponse",
+        configurations,
+      });
+    }, agentConfigurations);
+
+    // 4 source tabs exist and the default tab is 插件子代理
+    await expect(webviewPage.getByText("插件子代理")).toBeVisible();
+    await expect(webviewPage.getByText("内置子代理")).toBeVisible();
+    await expect(webviewPage.getByText("用户子代理")).toBeVisible();
+    await expect(webviewPage.getByText("项目子代理")).toBeVisible();
+    await expect(webviewPage.getByText("sdd:specify")).toBeVisible();
+
+    // Screenshot the whole settings page (left nav included, 子代理 highlighted)
+    // so the shot reads as "settings page — subagents tab" in the docs.
+    const view = webviewPage.locator(".settings-page");
+    await elementScreenshotWebp(
+      view,
+      "../../docs/public/screenshots/spec-agents-list.webp",
+    );
+
+    // Switch to the builtin tab and open the Explore agent detail view
+    await view.getByText("内置子代理", { exact: true }).click();
+    await expect(
+      webviewPage.getByText("Explore", { exact: true }),
+    ).toBeVisible();
+    await view.getByText("Explore", { exact: true }).click();
+    await expect(webviewPage.getByText("系统提示词：")).toBeVisible();
+
+    await elementScreenshotWebp(
+      view,
+      "../../docs/public/screenshots/spec-agents-detail.webp",
+    );
+  });
+});
+
+const skills = [
+  {
+    name: "deep-research",
+    description: "深度研究：并行检索并交叉验证信息源，产出带引用的报告",
+    type: "builtin",
+    skillPath: "/builtin/skills/deep-research.md",
+    allowedTools: ["WebFetch", "Grep"],
+    userInvocable: true,
+  },
+  {
+    name: "sdd:specify",
+    description: "根据自然语言描述创建或更新功能规格说明",
+    type: "builtin",
+    skillPath: "/plugins/sdd/skills/specify.md",
+    pluginName: "sdd",
+    userInvocable: true,
+  },
+  {
+    name: "my-skill",
+    description: "个人自定义技能，用于日常代码审查",
+    type: "personal",
+    skillPath: "~/.wave/skills/my-skill.md",
+    model: "glm-5.2",
+    allowedTools: ["Read", "Write"],
+    userInvocable: true,
+  },
+  {
+    name: "deploy",
+    description: "部署检查技能：验证构建产物与发布清单",
+    type: "project",
+    skillPath: "/work/wave-agent/.wave/skills/deploy/SKILL.md",
+    userInvocable: true,
+  },
+  {
+    name: "code-review",
+    description: "项目级代码评审技能",
+    type: "project",
+    skillPath: "/work/wave-agent/.wave/skills/code-review/SKILL.md",
+    userInvocable: true,
+  },
+];
+
+test.describe("设置页技能选项卡 Demo", () => {
+  test("should show 4 source tabs with flat project skill list", async ({
+    webviewPage,
+  }) => {
+    await webviewPage.setViewportSize({ width: 1000, height: 760 });
+    await webviewPage.setContent(settingsHtml);
+    await expect(webviewPage.locator(".settings-page")).toBeVisible();
+
+    // /skills → openSettings(nav:"skills") → settingsState
+    await webviewPage.evaluate((workdir) => {
+      window.simulateExtensionMessage({
+        command: "settingsState",
+        workdir,
+        nav: "skills",
+      });
+    }, WORKDIR);
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "configurationResponse",
+        configurationData: { language: "zh-CN", contextLength: 200 },
+      });
+    });
+    await webviewPage.evaluate((skillList) => {
+      window.simulateExtensionMessage({
+        command: "skillMetadataResponse",
+        skills: skillList,
+      });
+    }, skills);
+
+    // 4 source tabs exist
+    await expect(webviewPage.getByText("插件技能")).toBeVisible();
+    await expect(webviewPage.getByText("内置技能")).toBeVisible();
+    await expect(webviewPage.getByText("用户技能")).toBeVisible();
+    await expect(webviewPage.getByText("项目技能")).toBeVisible();
+
+    const view = webviewPage.locator(".settings-page");
+
+    // 项目技能平铺展示（仅当前项目，无分组卡片，2026-09-01 拍板）
+    await view.getByText("项目技能", { exact: true }).click();
+    await expect(
+      webviewPage.getByText("/deploy", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      webviewPage.getByText("/code-review", { exact: true }),
+    ).toBeVisible();
+
+    await elementScreenshotWebp(
+      view,
+      "../../docs/public/screenshots/spec-skills-list.webp",
+    );
+  });
+});

--- a/packages/webview/demo/askUserQuestionLayout.demo.ts
+++ b/packages/webview/demo/askUserQuestionLayout.demo.ts
@@ -1,0 +1,67 @@
+import { test } from "../e2e/utils/webviewTestHarness.js";
+import { MessageInjector } from "../e2e/utils/messageInjector.js";
+import { ASK_USER_QUESTION_TOOL_NAME, Message } from "wave-agent-sdk";
+import { screenshotWebp } from "../e2e/utils/screenshot.js";
+
+test.describe("AskUserQuestion Layout Demo", () => {
+  test("capture vertical layout screenshot", async ({ webviewPage }) => {
+    const injector = new MessageInjector(webviewPage);
+
+    const mockMessage: Message = {
+      id: "msg_ask_demo",
+      role: "assistant" as const,
+      timestamp: "2025-07-09T10:30:00.000Z",
+      blocks: [
+        {
+          type: "tool" as const,
+          name: ASK_USER_QUESTION_TOOL_NAME,
+          stage: "end" as const,
+          result: JSON.stringify({
+            answers: {
+              "客户管理系统有什么具体要求？":
+                "需要支持客户分级、跟进记录、合同关联与数据看板，并对接现有的支付与工单系统。",
+              "首期交付优先实现哪些模块？": "客户档案、跟进记录、合同管理",
+            },
+          }),
+        },
+      ],
+    };
+
+    const userMessage: Message = {
+      id: "msg_user_ask",
+      role: "user" as const,
+      timestamp: "2025-07-09T10:29:00.000Z",
+      blocks: [
+        {
+          type: "text" as const,
+          content: "支付服务重构前，先帮我确认缓存策略和优先重构的模块",
+        },
+      ],
+    };
+
+    await injector.simulateExtensionMessage("setInitialState", {
+      isAuthenticated: true,
+      messages: [],
+      isStreaming: false,
+      sessions: [],
+      configurationData: {
+        apiKey: "sk-ant-api03-CXB9pH2k...mH8wQz",
+        baseURL: "https://api.anthropic.com/v1",
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
+
+    await injector.updateMessages([userMessage, mockMessage]);
+
+    // Wait for rendering
+    await webviewPage.waitForSelector(".ask-user-result-item");
+
+    // Take screenshot
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/ask-user-question-vertical.webp",
+    );
+  });
+});

--- a/packages/webview/demo/background-task-manager.demo.ts
+++ b/packages/webview/demo/background-task-manager.demo.ts
@@ -1,0 +1,106 @@
+import { test, expect } from "../e2e/utils/webviewTestHarness.js";
+import { elementScreenshotWebp } from "../e2e/utils/screenshot.js";
+
+test.describe("Background Task Manager Demo", () => {
+  test("should show background task list and detail", async ({
+    webviewPage,
+  }) => {
+    // Dialog min-width is 560px, wider than the default 400px demo viewport — widen so the full dialog is captured
+    await webviewPage.setViewportSize({ width: 800, height: 700 });
+
+    // 1. Open the dialog via showDialog
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "showDialog",
+        dialogType: "tasks",
+      });
+    });
+
+    // 2. Simulate extension pushing background tasks
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "updateBackgroundTasks",
+        tasks: [
+          {
+            id: "bt-1",
+            type: "shell",
+            status: "running",
+            startTime: Date.now() - 45000,
+            command: "npm run build",
+            description: "构建 monorepo",
+            runtime: 45000,
+            outputPath: "/tmp/wave-task-bt-1.log",
+          },
+          {
+            id: "bt-2",
+            type: "subagent",
+            status: "completed",
+            startTime: Date.now() - 120000,
+            endTime: Date.now() - 80000,
+            description: "探索 packages/webview 结构",
+            runtime: 40000,
+            exitCode: 0,
+            outputPath: "/tmp/wave-task-bt-2.log",
+          },
+          {
+            id: "bt-3",
+            type: "shell",
+            status: "failed",
+            startTime: Date.now() - 200000,
+            endTime: Date.now() - 195000,
+            command: "npm test",
+            description: "运行测试套件",
+            runtime: 5000,
+            exitCode: 1,
+            outputPath: "/tmp/wave-task-bt-3.log",
+          },
+        ],
+      });
+    });
+
+    // Verify dialog is visible
+    await expect(
+      webviewPage.getByTestId("background-task-manager"),
+    ).toBeVisible();
+
+    // Screenshot the list view
+    const dialog = webviewPage.getByTestId("background-task-manager");
+    await elementScreenshotWebp(
+      dialog,
+      "../../docs/public/screenshots/spec-background-task-list.webp",
+    );
+
+    // 3. Click the first task to enter detail view
+    await dialog.getByText("[bt-1] shell").click();
+
+    // 4. Simulate the getBackgroundTaskOutput response so the OUTPUT block renders
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "backgroundTaskOutput",
+        taskId: "bt-1",
+        output: {
+          stdout: [
+            "> wave-agent@ build",
+            "> tsc -b && node esbuild.config.mjs",
+            "",
+            "[build] frontend started",
+            "[build] frontend finished",
+            "✓ built in 3.2s",
+          ].join("\n"),
+          stderr: "",
+          status: "running",
+          type: "shell",
+          outputPath: "/tmp/wave-task-bt-1.log",
+        },
+      });
+    });
+
+    await expect(webviewPage.getByText("OUTPUT (last 20 lines)")).toBeVisible();
+
+    // Screenshot the detail view
+    await elementScreenshotWebp(
+      dialog,
+      "../../docs/public/screenshots/spec-background-task-detail.webp",
+    );
+  });
+});

--- a/packages/webview/demo/bash-mode.demo.ts
+++ b/packages/webview/demo/bash-mode.demo.ts
@@ -1,0 +1,39 @@
+import { test } from "../e2e/utils/webviewTestHarness.js";
+import { MessageInjector } from "../e2e/utils/messageInjector.js";
+import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
+import { screenshotWebp } from "../e2e/utils/screenshot.js";
+
+test.describe("Bash Mode Demo", () => {
+  test("should demonstrate bash mode command execution and output", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+
+    // 1. Show a successful command with output
+    await injector.updateMessages([
+      MockDataGenerator.createBangMessage(
+        "kubectl get pods -n payment",
+        "NAME                            READY   STATUS    RESTARTS   AGE\npayment-service-7f4d           1/1     Running   0          2d\npayment-worker-9c2a            1/1     Running   0          2d\npayment-scheduler-5x8b         1/1     Running   0          5h",
+        false,
+        0,
+      ),
+    ]);
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/bash-mode-success.webp",
+    );
+
+    // 2. Show a long output
+    const longOutput = Array.from(
+      { length: 20 },
+      (_, i) => `Test suite ${i + 1} passed`,
+    ).join("\n");
+    await injector.updateMessages([
+      MockDataGenerator.createBangMessage("pnpm test", longOutput, false, 0),
+    ]);
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/bash-mode-long-output.webp",
+    );
+  });
+});

--- a/packages/webview/demo/desktop-batch2.demo.ts
+++ b/packages/webview/demo/desktop-batch2.demo.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../e2e/utils/desktopTestHarness.js";
+import { seedSidebarSessions } from "./sidebarSeed.js";
 import { MessageInjector } from "../e2e/utils/messageInjector.js";
 import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
 import { screenshotWebp } from "../e2e/utils/screenshot.js";
@@ -33,6 +34,19 @@ async function setupSinglePane(injector: MessageInjector) {
     recentWorkdirs: [DIR_A, DIR_B],
   });
   await injector.waitForChatAppReady();
+  await seedSidebarSessions(injector, DIR_A, [
+    { sessionId: "s-b2-1", title: "修复登录页样式问题" },
+    {
+      sessionId: "s-b2-2",
+      title: "重构支付模块方法签名",
+      hasWorktree: true,
+    },
+    {
+      sessionId: "s-b2-3",
+      title: "评审数据库迁移脚本",
+      waitingConfirmation: true,
+    },
+  ]);
   await injector.simulateExtensionMessage("setInitialState", initialState);
   await injector.updateMessages([
     MockDataGenerator.createUserMessage("帮我修复登录页的样式问题", "msg-u1"),

--- a/packages/webview/demo/desktop-chrome-devtools.demo.ts
+++ b/packages/webview/demo/desktop-chrome-devtools.demo.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../e2e/utils/desktopTestHarness.js";
+import { seedSidebarSessions } from "./sidebarSeed.js";
 import { MessageInjector } from "../e2e/utils/messageInjector.js";
 import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
 import { WRITE_TOOL_NAME } from "wave-agent-sdk";
@@ -33,6 +34,15 @@ test.describe("chrome-devtools MCP tutorial screenshots", () => {
       hosts: ["local"],
     });
     await injector.waitForChatAppReady();
+    await seedSidebarSessions(injector, DIR_A, [
+      { sessionId: "s-cd-1", title: "DevTools 调试登录页跳转", running: true },
+      {
+        sessionId: "s-cd-2",
+        title: "补全注册流程自动化用例",
+        hasWorktree: true,
+      },
+      { sessionId: "s-cd-3", title: "排查接口超时与等待策略" },
+    ]);
     await injector.simulateExtensionMessage("setInitialState", baseConfig);
 
     await injector.updateMessages([

--- a/packages/webview/demo/desktop-conversation.demo.ts
+++ b/packages/webview/demo/desktop-conversation.demo.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../e2e/utils/desktopTestHarness.js";
+import { seedSidebarSessions } from "./sidebarSeed.js";
 import { MessageInjector } from "../e2e/utils/messageInjector.js";
 import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
 import { UIStateVerifier } from "../e2e/utils/uiStateVerifier.js";
@@ -35,6 +36,15 @@ async function setup(
     hosts: ["local"],
   });
   await injector.waitForChatAppReady();
+  await seedSidebarSessions(injector, DIR_A, [
+    { sessionId: "s-cv-1", title: "分析支付服务分布式事务", running: true },
+    {
+      sessionId: "s-cv-2",
+      title: "为乐观锁补并发单元测试",
+      hasWorktree: true,
+    },
+    { sessionId: "s-cv-3", title: "排查压测连接池耗尽" },
+  ]);
   await injector.simulateExtensionMessage("setInitialState", {
     messages,
     ...baseConfig,

--- a/packages/webview/demo/desktop-diff-comments.demo.ts
+++ b/packages/webview/demo/desktop-diff-comments.demo.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../e2e/utils/desktopTestHarness.js";
+import { seedSidebarSessions } from "./sidebarSeed.js";
 import { MessageInjector } from "../e2e/utils/messageInjector.js";
 import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
 import { screenshotWebp } from "../e2e/utils/screenshot.js";
@@ -86,6 +87,19 @@ test.describe("Desktop Diff Pane Screenshots", () => {
     await webviewPage.waitForSelector('[data-testid="chat-container"]', {
       timeout: 5000,
     });
+    await seedSidebarSessions(injector, DIR_A, [
+      { sessionId: "s-dc-1", title: "重构登录模块并补表单校验" },
+      {
+        sessionId: "s-dc-2",
+        title: "认证端点对齐后端接口",
+        hasWorktree: true,
+      },
+      {
+        sessionId: "s-dc-3",
+        title: "梳理改动并回复评审意见",
+        waitingConfirmation: true,
+      },
+    ]);
 
     await injector.updateMessages([
       MockDataGenerator.createUserMessage(

--- a/packages/webview/demo/desktop-figma-mcp.demo.ts
+++ b/packages/webview/demo/desktop-figma-mcp.demo.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../e2e/utils/desktopTestHarness.js";
+import { seedSidebarSessions } from "./sidebarSeed.js";
 import { MessageInjector } from "../e2e/utils/messageInjector.js";
 import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
 import { WRITE_TOOL_NAME } from "wave-agent-sdk";
@@ -33,6 +34,15 @@ test.describe("Figma MCP tutorial screenshots", () => {
       hosts: ["local"],
     });
     await injector.waitForChatAppReady();
+    await seedSidebarSessions(injector, DIR_A, [
+      { sessionId: "s-fm-1", title: "按 Figma 还原登录页视觉", running: true },
+      {
+        sessionId: "s-fm-2",
+        title: "适配移动端断点布局",
+        hasWorktree: true,
+      },
+      { sessionId: "s-fm-3", title: "替换设计稿图标资源" },
+    ]);
     await injector.simulateExtensionMessage("setInitialState", baseConfig);
 
     await injector.updateMessages([

--- a/packages/webview/demo/desktop-file-pane.demo.ts
+++ b/packages/webview/demo/desktop-file-pane.demo.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../e2e/utils/desktopTestHarness.js";
+import { seedSidebarSessions } from "./sidebarSeed.js";
 import { MessageInjector } from "../e2e/utils/messageInjector.js";
 import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
 import { screenshotWebp } from "../e2e/utils/screenshot.js";
@@ -67,6 +68,19 @@ test.describe("Desktop file pane screenshots", () => {
       recentWorkdirs: [DIR_A],
     });
     await injector.waitForChatAppReady();
+    await seedSidebarSessions(injector, DIR_A, [
+      { sessionId: "s-fp-1", title: "修复登录页样式对齐" },
+      {
+        sessionId: "s-fp-2",
+        title: "重构订单管理列表页",
+        hasWorktree: true,
+      },
+      {
+        sessionId: "s-fp-3",
+        title: "审查表单校验边界",
+        waitingConfirmation: true,
+      },
+    ]);
     await injector.simulateExtensionMessage("setInitialState", initialState);
     await injector.updateMessages([
       MockDataGenerator.createUserMessage("帮我修复登录页的样式问题", "msg-u1"),

--- a/packages/webview/demo/desktop-interaction.demo.ts
+++ b/packages/webview/demo/desktop-interaction.demo.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../e2e/utils/desktopTestHarness.js";
+import { seedSidebarSessions } from "./sidebarSeed.js";
 import { MessageInjector } from "../e2e/utils/messageInjector.js";
 import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
 import { screenshotWebp } from "../e2e/utils/screenshot.js";
@@ -31,6 +32,19 @@ async function setupSinglePane(injector: MessageInjector) {
     recentWorkdirs: [DIR_A],
   });
   await injector.waitForChatAppReady();
+  await seedSidebarSessions(injector, DIR_A, [
+    { sessionId: "s-in-1", title: "修复登录页样式问题", running: true },
+    {
+      sessionId: "s-in-2",
+      title: "搭建订单管理页原型",
+      hasWorktree: true,
+    },
+    {
+      sessionId: "s-in-3",
+      title: "排查构建产物样式丢失",
+      waitingConfirmation: true,
+    },
+  ]);
   await injector.simulateExtensionMessage("setInitialState", initialState);
   await injector.updateMessages([
     MockDataGenerator.createUserMessage("帮我修复登录页的样式问题", "msg-u1"),
@@ -109,6 +123,11 @@ test.describe("Desktop interaction refinements", () => {
       recentWorkdirs: [DIR_A],
     });
     await injector.waitForChatAppReady();
+    await seedSidebarSessions(injector, DIR_A, [
+      { sessionId: "s-in-4", title: "搭建订单管理页原型", running: true },
+      { sessionId: "s-in-5", title: "修复登录页样式问题", hasWorktree: true },
+      { sessionId: "s-in-6", title: "排查构建产物样式丢失" },
+    ]);
     await injector.simulateExtensionMessage("setInitialState", initialState);
 
     await injector.updateMessages([

--- a/packages/webview/demo/desktop-models-tools.demo.ts
+++ b/packages/webview/demo/desktop-models-tools.demo.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../e2e/utils/desktopTestHarness.js";
+import { seedSidebarSessions } from "./sidebarSeed.js";
 import { MessageInjector } from "../e2e/utils/messageInjector.js";
 import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
 import {
@@ -40,6 +41,15 @@ async function setup(injector: MessageInjector, messages: unknown[] = []) {
     hosts: ["local"],
   });
   await injector.waitForChatAppReady();
+  await seedSidebarSessions(injector, DIR_A, [
+    { sessionId: "s-mt-1", title: "分析支付服务分布式事务", running: true },
+    {
+      sessionId: "s-mt-2",
+      title: "为乐观锁实现补单元测试",
+      hasWorktree: true,
+    },
+    { sessionId: "s-mt-3", title: "梳理支付模块接口定义" },
+  ]);
   await injector.simulateExtensionMessage("setInitialState", {
     messages,
     ...baseConfig,

--- a/packages/webview/demo/desktop-panels.demo.ts
+++ b/packages/webview/demo/desktop-panels.demo.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../e2e/utils/desktopTestHarness.js";
+import { seedSidebarSessions } from "./sidebarSeed.js";
 import { MessageInjector } from "../e2e/utils/messageInjector.js";
 import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
 import { screenshotWebp } from "../e2e/utils/screenshot.js";
@@ -28,6 +29,19 @@ async function setupSinglePane(injector: MessageInjector) {
     recentWorkdirs: [DIR_A],
   });
   await injector.waitForChatAppReady();
+  await seedSidebarSessions(injector, DIR_A, [
+    { sessionId: "s-pn-1", title: "修复登录页样式问题", running: true },
+    {
+      sessionId: "s-pn-2",
+      title: "新增订单列表页组件",
+      hasWorktree: true,
+    },
+    {
+      sessionId: "s-pn-3",
+      title: "拆分配置到独立模块",
+      waitingConfirmation: true,
+    },
+  ]);
   await injector.simulateExtensionMessage("setInitialState", initialState);
   await injector.updateMessages([
     MockDataGenerator.createUserMessage("帮我修复登录页的样式问题", "msg-u1"),

--- a/packages/webview/demo/desktop-permissions.demo.ts
+++ b/packages/webview/demo/desktop-permissions.demo.ts
@@ -7,6 +7,7 @@ import {
   ASK_USER_QUESTION_TOOL_NAME,
   ENTER_PLAN_MODE_TOOL_NAME,
   EXIT_PLAN_MODE_TOOL_NAME,
+  type Message,
 } from "wave-agent-sdk";
 import { screenshotWebp } from "../e2e/utils/screenshot.js";
 
@@ -39,11 +40,56 @@ async function setup(
   });
   await injector.waitForChatAppReady();
   await injector.simulateExtensionMessage("setInitialState", baseConfig);
+  // Seed the sidebar session tree (same message the desktop host pushes) so
+  // screenshots don't show an empty conversation list.
+  await injector.simulateExtensionMessage("desktopSessionTree", {
+    groups: [
+      {
+        host: "local",
+        workdir: DIR_A,
+        sessions: [
+          {
+            sessionId: "s-perm-running",
+            title: "SQL 参数化改造 PaymentService",
+            lastActiveAt: 1782000100000,
+            hasWorktree: false,
+            running: true,
+          },
+          {
+            sessionId: "s-perm-waiting",
+            title: "高并发重构方案评审",
+            lastActiveAt: 1782000200000,
+            hasWorktree: false,
+            running: false,
+            waitingConfirmation: true,
+          },
+          {
+            sessionId: "s-perm-done",
+            title: "修复支付回调幂等",
+            lastActiveAt: 1781990000000,
+            hasWorktree: false,
+            running: false,
+          },
+        ],
+      },
+    ],
+  });
   // Wait until the pane is fully mounted so follow-up messages are not lost
   // to the mount race (e.g. showConfirmation).
   await webviewPage.waitForSelector('[data-testid="message-input"]', {
     state: "visible",
   });
+}
+
+/** Seed a short conversation so dialogs render over real-looking context. */
+async function seedMessages(
+  webviewPage: Parameters<typeof screenshotWebp>[0],
+  injector: MessageInjector,
+  msgs: Message[],
+  waitForText: string,
+) {
+  await injector.updateMessages(msgs);
+  await expect(webviewPage.getByText(waitForText)).toBeVisible();
 }
 
 /** Show a confirmation dialog and screenshot the whole desktop layout. */
@@ -85,6 +131,28 @@ test.describe("Desktop 2.5 权限与安全 screenshots", () => {
     const injector = new MessageInjector(webviewPage);
     await webviewPage.setViewportSize({ width: 960, height: 640 });
     await setup(webviewPage, injector);
+    await seedMessages(
+      webviewPage,
+      injector,
+      [
+        MockDataGenerator.createUserMessage(
+          "PaymentService 的 SQL 是字符串拼接的，有注入风险，帮我参数化改造一下",
+          "msg-edit-u1",
+        ),
+        MockDataGenerator.createAssistantMessageWithTool(
+          "好的，我来把 PaymentService 里的动态 SQL 改成参数化查询。",
+          EDIT_TOOL_NAME,
+          JSON.stringify({
+            file_path: "/src/services/payment/PaymentService.ts",
+            old_string:
+              'const result = await this.db.query("SELECT * FROM payments WHERE id = ?", tx.id);',
+            new_string:
+              'const result = await this.db.query("SELECT * FROM payments WHERE id = $1", [tx.id]);',
+          }),
+        ),
+      ],
+      "有注入风险",
+    );
     await captureConfirmation(
       webviewPage,
       injector,
@@ -108,6 +176,31 @@ test.describe("Desktop 2.5 权限与安全 screenshots", () => {
     const injector = new MessageInjector(webviewPage);
     await webviewPage.setViewportSize({ width: 960, height: 640 });
     await setup(webviewPage, injector);
+    const bashMsgs = [
+      MockDataGenerator.createUserMessage(
+        "帮我跑一下支付服务的测试，要带覆盖率报告",
+        "msg-bash-u1",
+      ),
+      MockDataGenerator.createAssistantMessageWithTool(
+        "我来运行支付服务测试套件并生成覆盖率报告。",
+        BASH_TOOL_NAME,
+        JSON.stringify({
+          command: "pnpm -F @nebula/payment-service test -- --coverage",
+          description: "运行支付服务测试套件并生成覆盖率报告",
+        }),
+      ),
+    ];
+    // generator 的 BASH 默认摘要 "npm install" 与本次命令不符 → 换成与命令一致的摘要
+    const bashTool = bashMsgs[1].blocks.find((b) => b.type === "tool");
+    if (bashTool && bashTool.type === "tool") {
+      bashTool.compactParams = "pnpm test -- --coverage";
+    }
+    await seedMessages(
+      webviewPage,
+      injector,
+      bashMsgs,
+      "我来运行支付服务测试套件",
+    );
     await captureConfirmation(
       webviewPage,
       injector,
@@ -128,6 +221,33 @@ test.describe("Desktop 2.5 权限与安全 screenshots", () => {
     const injector = new MessageInjector(webviewPage);
     await webviewPage.setViewportSize({ width: 960, height: 640 });
     await setup(webviewPage, injector);
+    const mcpMsgs = [
+      MockDataGenerator.createUserMessage(
+        "乐观锁改造的方案评审过了，帮我在 Jira 上建一个高优先级 issue 跟踪",
+        "msg-mcp-u1",
+      ),
+      MockDataGenerator.createAssistantMessageWithTool(
+        "需求已整理，正在 Jira 创建 issue。",
+        "mcp__jira__create_issue",
+        JSON.stringify({
+          title: "PaymentService 乐观锁支持",
+          description: "为支付服务引入乐观锁机制，处理并发更新冲突",
+          priority: "high",
+          tags: ["payment", "concurrency", "refactor"],
+        }),
+      ),
+    ];
+    // 非 Bash/Read/Write 工具，generator 默认摘要 = 工具名 → 与标题重复；换友好摘要
+    const mcpTool = mcpMsgs[1].blocks.find((b) => b.type === "tool");
+    if (mcpTool && mcpTool.type === "tool") {
+      mcpTool.compactParams = "Jira · 创建 issue";
+    }
+    await seedMessages(
+      webviewPage,
+      injector,
+      mcpMsgs,
+      "需求已整理，正在 Jira 创建 issue",
+    );
     await captureConfirmation(
       webviewPage,
       injector,
@@ -150,6 +270,21 @@ test.describe("Desktop 2.5 权限与安全 screenshots", () => {
     const injector = new MessageInjector(webviewPage);
     await webviewPage.setViewportSize({ width: 960, height: 640 });
     await setup(webviewPage, injector);
+    await seedMessages(
+      webviewPage,
+      injector,
+      [
+        MockDataGenerator.createUserMessage(
+          "高并发下支付服务扛不住了，先别急着改代码，给我一个完整的重构方案",
+          "msg-plan-u1",
+        ),
+        MockDataGenerator.createAssistantMessage(
+          "我分析了当前实现，计划分三阶段推进（乐观锁 → 缓存层 → 异步化），确认后开始实施：",
+          "msg-plan-a1",
+        ),
+      ],
+      "确认后开始实施",
+    );
     await captureConfirmation(
       webviewPage,
       injector,
@@ -182,6 +317,21 @@ test.describe("Desktop 2.5 权限与安全 screenshots", () => {
     const injector = new MessageInjector(webviewPage);
     await webviewPage.setViewportSize({ width: 960, height: 640 });
     await setup(webviewPage, injector);
+    await seedMessages(
+      webviewPage,
+      injector,
+      [
+        MockDataGenerator.createUserMessage(
+          "接下来进入计划模式吧，先梳理重构方案，不要直接改代码",
+          "msg-epm-u1",
+        ),
+        MockDataGenerator.createAssistantMessage(
+          "好的，我先切换到计划模式，只做方案调研与规划。",
+          "msg-epm-a1",
+        ),
+      ],
+      "切换到计划模式",
+    );
     await captureConfirmation(
       webviewPage,
       injector,
@@ -200,6 +350,21 @@ test.describe("Desktop 2.5 权限与安全 screenshots", () => {
     const injector = new MessageInjector(webviewPage);
     await webviewPage.setViewportSize({ width: 960, height: 640 });
     await setup(webviewPage, injector);
+    await seedMessages(
+      webviewPage,
+      injector,
+      [
+        MockDataGenerator.createUserMessage(
+          "订单量上来了，缓存方案你帮我拿个主意",
+          "msg-ask-u1",
+        ),
+        MockDataGenerator.createAssistantMessage(
+          "两种缓存方案各有取舍，想先跟你确认一下偏好再动手：",
+          "msg-ask-a1",
+        ),
+      ],
+      "确认一下偏好",
+    );
     await captureConfirmation(
       webviewPage,
       injector,

--- a/packages/webview/demo/desktop-remote-ssh.demo.ts
+++ b/packages/webview/demo/desktop-remote-ssh.demo.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../e2e/utils/desktopTestHarness.js";
+import { seedSidebarSessions } from "./sidebarSeed.js";
 import { MessageInjector } from "../e2e/utils/messageInjector.js";
 import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
 import { screenshotWebp } from "../e2e/utils/screenshot.js";
@@ -36,6 +37,20 @@ async function setupRemoteSession(injector: MessageInjector, host: string) {
     hosts: REMOTE_HOSTS,
   });
   await injector.waitForChatAppReady();
+  await seedSidebarSessions(
+    injector,
+    REMOTE_WORKDIR,
+    [
+      { sessionId: "s-rs-1", title: "修复远程部署脚本失败", running: true },
+      {
+        sessionId: "s-rs-2",
+        title: "检查容器日志与磁盘占用",
+        waitingConfirmation: true,
+      },
+      { sessionId: "s-rs-3", title: "调整启动命令绑定监听地址" },
+    ],
+    host,
+  );
   await injector.simulateExtensionMessage("setInitialState", initialState);
   await injector.updateMessages([
     MockDataGenerator.createUserMessage(
@@ -65,6 +80,15 @@ test.describe("Desktop SSH remote sessions (mocked)", () => {
       hosts: REMOTE_HOSTS,
     });
     await injector.waitForChatAppReady();
+    await seedSidebarSessions(injector, REMOTE_WORKDIR, [
+      { sessionId: "s-rs-1", title: "修复远程部署脚本失败", running: true },
+      {
+        sessionId: "s-rs-2",
+        title: "检查容器日志与磁盘占用",
+        waitingConfirmation: true,
+      },
+      { sessionId: "s-rs-3", title: "调整启动命令绑定监听地址" },
+    ]);
     await injector.simulateExtensionMessage("setInitialState", initialState);
 
     await expect(webviewPage.getByTestId("desktop-host")).toBeVisible();
@@ -93,6 +117,15 @@ test.describe("Desktop SSH remote sessions (mocked)", () => {
       hosts: REMOTE_HOSTS,
     });
     await injector.waitForChatAppReady();
+    await seedSidebarSessions(injector, REMOTE_WORKDIR, [
+      { sessionId: "s-rs-1", title: "修复远程部署脚本失败", running: true },
+      {
+        sessionId: "s-rs-2",
+        title: "检查容器日志与磁盘占用",
+        waitingConfirmation: true,
+      },
+      { sessionId: "s-rs-3", title: "调整启动命令绑定监听地址" },
+    ]);
     await injector.simulateExtensionMessage("setInitialState", initialState);
 
     // Open the host menu and expand 添加主机… into the connection-string input.
@@ -227,6 +260,24 @@ test.describe("Desktop SSH remote sessions (mocked)", () => {
       hosts: REMOTE_HOSTS,
     });
     await injector.waitForChatAppReady();
+    await seedSidebarSessions(
+      injector,
+      REMOTE_WORKDIR,
+      [
+        {
+          sessionId: "s-rs-1",
+          title: "修复远程部署脚本失败",
+          running: true,
+        },
+        {
+          sessionId: "s-rs-2",
+          title: "检查容器日志与磁盘占用",
+          waitingConfirmation: true,
+        },
+        { sessionId: "s-rs-3", title: "调整启动命令绑定监听地址" },
+      ],
+      REMOTE_HOST,
+    );
     // Initialize so the input area renders — the loading sweep keeps it
     // hidden until setInitialState (no conversation messages here to bring
     // it up, and the scenario intentionally has no workdir yet).

--- a/packages/webview/demo/desktop-settings-manage.demo.ts
+++ b/packages/webview/demo/desktop-settings-manage.demo.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../e2e/utils/desktopTestHarness.js";
+import { seedSidebarSessions } from "./sidebarSeed.js";
 import { MessageInjector } from "../e2e/utils/messageInjector.js";
 import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
 import { screenshotWebp } from "../e2e/utils/screenshot.js";
@@ -32,6 +33,19 @@ async function setupSinglePane(injector: MessageInjector) {
     recentWorkdirs: [DIR_A, DIR_B],
   });
   await injector.waitForChatAppReady();
+  await seedSidebarSessions(injector, DIR_A, [
+    { sessionId: "s-sm-1", title: "修复登录页样式对齐" },
+    {
+      sessionId: "s-sm-2",
+      title: "重构订单状态流转",
+      hasWorktree: true,
+    },
+    {
+      sessionId: "s-sm-3",
+      title: "评审支付回调幂等逻辑",
+      waitingConfirmation: true,
+    },
+  ]);
   await injector.simulateExtensionMessage("setInitialState", initialState);
   await injector.updateMessages([
     MockDataGenerator.createUserMessage("帮我修复登录页的样式问题", "msg-u1"),

--- a/packages/webview/demo/desktop-smart-input.demo.ts
+++ b/packages/webview/demo/desktop-smart-input.demo.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../e2e/utils/desktopTestHarness.js";
+import { seedSidebarSessions } from "./sidebarSeed.js";
 import { MessageInjector } from "../e2e/utils/messageInjector.js";
 import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
 import { screenshotWebp } from "../e2e/utils/screenshot.js";
@@ -32,6 +33,19 @@ async function setupSinglePane(injector: MessageInjector) {
     hosts: ["local"],
   });
   await injector.waitForChatAppReady();
+  await seedSidebarSessions(injector, DIR_A, [
+    { sessionId: "s-si-1", title: "分析支付服务并发问题", running: true },
+    {
+      sessionId: "s-si-2",
+      title: "为乐观锁中间件补测试",
+      hasWorktree: true,
+    },
+    {
+      sessionId: "s-si-3",
+      title: "梳理登录页样式适配",
+      waitingConfirmation: true,
+    },
+  ]);
   await injector.simulateExtensionMessage("setInitialState", initialState);
 }
 

--- a/packages/webview/demo/desktop-tasks-agents.demo.ts
+++ b/packages/webview/demo/desktop-tasks-agents.demo.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../e2e/utils/desktopTestHarness.js";
+import { seedSidebarSessions } from "./sidebarSeed.js";
 import { MessageInjector } from "../e2e/utils/messageInjector.js";
 import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
 import { AGENT_TOOL_NAME, type Message } from "wave-agent-sdk";
@@ -37,6 +38,19 @@ async function setup(
     hosts: ["local"],
   });
   await injector.waitForChatAppReady();
+  await seedSidebarSessions(injector, DIR_A, [
+    { sessionId: "s-ta-1", title: "后台调研支付网关兼容性", running: true },
+    {
+      sessionId: "s-ta-2",
+      title: "审查提现流程边界条件",
+      waitingConfirmation: true,
+    },
+    {
+      sessionId: "s-ta-3",
+      title: "重构支付模块并发处理",
+      hasWorktree: true,
+    },
+  ]);
   await injector.simulateExtensionMessage("setInitialState", {
     ...baseConfig,
     messages,

--- a/packages/webview/demo/desktop-update-toast.demo.ts
+++ b/packages/webview/demo/desktop-update-toast.demo.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../e2e/utils/desktopTestHarness.js";
+import { seedSidebarSessions } from "./sidebarSeed.js";
 import { MessageInjector } from "../e2e/utils/messageInjector.js";
 import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
 import { screenshotWebp } from "../e2e/utils/screenshot.js";
@@ -35,6 +36,19 @@ test.describe("Desktop Update Toast Screenshots", () => {
       recentWorkdirs: [DIR_A],
     });
     await injector.waitForChatAppReady();
+    await seedSidebarSessions(injector, DIR_A, [
+      { sessionId: "s-ut-1", title: "修复登录页样式问题" },
+      {
+        sessionId: "s-ut-2",
+        title: "为支付服务接入监控告警",
+        hasWorktree: true,
+      },
+      {
+        sessionId: "s-ut-3",
+        title: "梳理灰度发布流程",
+        waitingConfirmation: true,
+      },
+    ]);
     await injector.simulateExtensionMessage("setInitialState", initialState);
     await injector.updateMessages([
       MockDataGenerator.createUserMessage("帮我修复登录页的样式问题", "msg-u1"),

--- a/packages/webview/demo/mcp-server-tab.demo.ts
+++ b/packages/webview/demo/mcp-server-tab.demo.ts
@@ -1,0 +1,206 @@
+import { test, expect } from "../e2e/utils/webviewTestHarness.js";
+import { screenshotWebp } from "../e2e/utils/screenshot.js";
+
+test.describe("MCP Server Dialog Demo", () => {
+  test("should show MCP server dialog with configured servers", async ({
+    webviewPage,
+  }) => {
+    // 1. Open the MCP server management dialog via showDialog
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "showDialog",
+        dialogType: "mcp",
+      });
+    });
+
+    // Verify dialog is visible
+    await expect(
+      webviewPage.getByText("MCP 服务器", { exact: true }),
+    ).toBeVisible();
+
+    // 2. Simulate receiving MCP servers list
+    await webviewPage.evaluate(() => {
+      window.postMessage(
+        {
+          command: "mcpServersResponse",
+          servers: [
+            {
+              name: "jira",
+              config: {
+                command: "npx",
+                args: ["-y", "@mcp/server-jira"],
+                env: {
+                  JIRA_API_TOKEN: "your-token-here",
+                  JIRA_BASE_URL: "https://nebula-tech.atlassian.net",
+                },
+              },
+              status: "connected",
+              toolCount: 8,
+              capabilities: ["tools"],
+              lastConnected: Date.now() - 60000,
+            },
+            {
+              name: "postgres",
+              config: {
+                command: "uvx",
+                args: [
+                  "mcp-server-postgres",
+                  "--connection-string",
+                  "postgresql://localhost:5432/nebula",
+                ],
+              },
+              status: "connected",
+              toolCount: 5,
+              capabilities: ["tools"],
+              lastConnected: Date.now() - 120000,
+            },
+            {
+              name: "github",
+              config: {
+                command: "npx",
+                args: ["-y", "@modelcontextprotocol/server-github"],
+                env: { GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_xxxxxxxxxxxx" },
+              },
+              status: "disconnected",
+              toolCount: 0,
+              capabilities: [],
+            },
+            {
+              name: "sentry",
+              config: {
+                url: "https://mcp.sentry.io/sse",
+              },
+              status: "error",
+              toolCount: 0,
+              error: "Authentication failed: invalid token",
+              capabilities: [],
+            },
+          ],
+        },
+        "*",
+      );
+    });
+
+    // Verify all four servers are visible
+    await expect(webviewPage.getByText("jira", { exact: true })).toBeVisible();
+    await expect(
+      webviewPage.getByText("github", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      webviewPage.getByText("sentry", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      webviewPage.getByText("postgres", { exact: true }),
+    ).toBeVisible();
+
+    // Verify connected server shows tool count
+    await expect(webviewPage.getByText("5 tools")).toBeVisible();
+
+    // Verify error server shows error message
+    await expect(
+      webviewPage.getByText("Authentication failed: invalid token"),
+    ).toBeVisible();
+
+    // Verify connect button for disconnected server (two servers are not connected)
+    await expect(
+      webviewPage.getByRole("button", { name: "连接" }).first(),
+    ).toBeVisible();
+
+    // Verify disconnect button for connected server
+    await expect(
+      webviewPage.getByRole("button", { name: "断开" }).first(),
+    ).toBeVisible();
+
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-mcp-server-tab.webp",
+    );
+  });
+
+  test("should show empty state when no MCP servers configured", async ({
+    webviewPage,
+  }) => {
+    // 1. Open the MCP server management dialog
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "showDialog",
+        dialogType: "mcp",
+      });
+    });
+
+    // 2. Simulate empty servers list
+    await webviewPage.evaluate(() => {
+      window.postMessage(
+        {
+          command: "mcpServersResponse",
+          servers: [],
+        },
+        "*",
+      );
+    });
+
+    // Verify empty state message
+    await expect(webviewPage.getByText("未配置 MCP 服务器")).toBeVisible();
+    await expect(
+      webviewPage.locator("code", { hasText: ".mcp.json" }),
+    ).toBeVisible();
+  });
+
+  test("should handle connect/disconnect actions", async ({ webviewPage }) => {
+    // 1. Open the MCP server management dialog
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "showDialog",
+        dialogType: "mcp",
+      });
+    });
+
+    // 2. Simulate servers list
+    await webviewPage.evaluate(() => {
+      window.postMessage(
+        {
+          command: "mcpServersResponse",
+          servers: [
+            {
+              name: "jira",
+              config: { command: "npx", args: ["-y", "@mcp/server-jira"] },
+              status: "disconnected",
+              toolCount: 0,
+              capabilities: [],
+            },
+          ],
+        },
+        "*",
+      );
+    });
+
+    // 3. Click connect button
+    await webviewPage.getByRole("button", { name: "连接" }).click();
+
+    // 4. Simulate the backend response after connection
+    await webviewPage.evaluate(() => {
+      window.postMessage(
+        {
+          command: "mcpServersResponse",
+          servers: [
+            {
+              name: "jira",
+              config: { command: "npx", args: ["-y", "@mcp/server-jira"] },
+              status: "connected",
+              toolCount: 5,
+              capabilities: ["tools"],
+              lastConnected: Date.now(),
+            },
+          ],
+        },
+        "*",
+      );
+    });
+
+    // Verify status changed to connected and disconnect button appears
+    await expect(
+      webviewPage.getByRole("button", { name: "断开" }),
+    ).toBeVisible();
+    await expect(webviewPage.getByText("5 tools")).toBeVisible();
+  });
+});

--- a/packages/webview/demo/model-command.demo.ts
+++ b/packages/webview/demo/model-command.demo.ts
@@ -1,0 +1,99 @@
+import { test, expect } from "../e2e/utils/webviewTestHarness.js";
+import { MessageInjector } from "../e2e/utils/messageInjector.js";
+import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
+import { screenshotWebp } from "../e2e/utils/screenshot.js";
+
+test.describe("Product Spec: /model 命令", () => {
+  test("should capture model popup screenshot", async ({ webviewPage }) => {
+    const injector = new MessageInjector(webviewPage);
+
+    // Setup a conversation
+    const messages = [
+      MockDataGenerator.createUserMessage(
+        "帮我分析 PaymentService 的并发问题，看看有没有竞态条件",
+      ),
+      MockDataGenerator.createAssistantMessage(
+        "我已经分析了 PaymentService 的代码，发现 `processPayment` 方法中存在竞态条件。当前的悲观锁实现会导致高并发下性能下降，建议改用乐观锁...",
+      ),
+    ];
+    await injector.updateMessages(messages);
+    await injector.endStreaming();
+
+    // Type /model and send it
+    await webviewPage.focus('[data-testid="message-input"]');
+    await webviewPage.keyboard.type("/model");
+    await webviewPage.keyboard.press("Enter");
+
+    // Wait for the getConfiguredModels request to be sent to the host
+    await injector.waitForMessage("getConfiguredModels");
+
+    // Inject the configured models response
+    await injector.simulateExtensionMessage("configuredModels", {
+      models: ["claude-sonnet-4-5", "gpt-4o", "deepseek-v3.2", "glm-5.2"],
+      currentModel: "claude-sonnet-4-5",
+    });
+
+    // Wait for the popup to appear with items
+    await webviewPage.waitForSelector(".model-popup-item", {
+      state: "visible",
+      timeout: 5000,
+    });
+
+    // Verify all 4 models are listed
+    const items = webviewPage.locator(".model-popup-item");
+    await expect(items).toHaveCount(4);
+
+    // Verify the current model is marked with a check icon
+    const currentItem = items.filter({ hasText: "claude-sonnet-4-5" });
+    await expect(currentItem.locator(".model-popup-item-check")).toBeVisible();
+
+    // Verify the current model is highlighted by default
+    const selected = webviewPage.locator(".model-popup-item.selected");
+    await expect(selected).toContainText("claude-sonnet-4-5");
+
+    // Screenshot the popup
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-model-popup.webp",
+    );
+  });
+
+  test("should switch model with keyboard navigation", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+
+    // Setup a minimal conversation
+    const messages = [MockDataGenerator.createUserMessage("你好")];
+    await injector.updateMessages(messages);
+    await injector.endStreaming();
+
+    // Open the /model popup
+    await webviewPage.focus('[data-testid="message-input"]');
+    await webviewPage.keyboard.type("/model");
+    await webviewPage.keyboard.press("Enter");
+    await injector.waitForMessage("getConfiguredModels");
+    await injector.simulateExtensionMessage("configuredModels", {
+      models: ["claude-sonnet-4-5", "gpt-4o"],
+      currentModel: "claude-sonnet-4-5",
+    });
+    await webviewPage.waitForSelector(".model-popup-item", {
+      state: "visible",
+      timeout: 5000,
+    });
+
+    // Navigate down and select the second model
+    await webviewPage.keyboard.press("ArrowDown");
+    const selected = webviewPage.locator(".model-popup-item.selected");
+    await expect(selected).toContainText("gpt-4o");
+    await webviewPage.keyboard.press("Enter");
+
+    // The popup closes and setModel is sent to the host with the picked model
+    await expect(webviewPage.locator(".model-popup")).toBeHidden();
+    await webviewPage.waitForFunction(() => {
+      const msgs = window.getTestMessages ? window.getTestMessages() : [];
+      const msg = msgs.find((m) => m.command === "setModel");
+      return msg && msg.model === "gpt-4o";
+    });
+  });
+});

--- a/packages/webview/demo/plugin-management.demo.ts
+++ b/packages/webview/demo/plugin-management.demo.ts
@@ -1,0 +1,169 @@
+import { test, expect } from "../e2e/utils/webviewTestHarness.js";
+import { screenshotWebp } from "../e2e/utils/screenshot.js";
+
+test.describe("Plugin Management Screenshots", () => {
+  test("capture plugin management features", async ({ webviewPage }) => {
+    // Set viewport size for better screenshots
+    await webviewPage.setViewportSize({ width: 500, height: 700 });
+
+    // 1. Open plugin management dialog
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "showDialog",
+        dialogType: "plugin",
+      });
+    });
+
+    await expect(
+      webviewPage.getByText("插件管理", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      webviewPage.getByText("探索新插件", { exact: true }),
+    ).toBeVisible();
+
+    // 2. Explore plugins tab - 展示可安装的插件列表和作用域选择
+    await webviewPage.evaluate(() => {
+      window.postMessage(
+        {
+          command: "listPluginsResponse",
+          plugins: [
+            {
+              id: "git-workflow@wave-plugins-official",
+              name: "Git Workflow",
+              description:
+                "集成 Git 工作流，支持智能提交信息生成、PR 审查和冲突解决",
+              marketplace: "wave-plugins-official",
+              installed: false,
+              version: "2.3.1",
+            },
+            {
+              id: "kubernetes-helper@wave-plugins-official",
+              name: "Kubernetes Helper",
+              description:
+                "简化 K8s 集群管理，提供 Pod 诊断、日志查询和资源监控",
+              marketplace: "wave-plugins-official",
+              installed: false,
+              version: "1.8.0",
+            },
+            {
+              id: "database-explorer@wave-community",
+              name: "Database Explorer",
+              description:
+                "连接多种数据库（PostgreSQL、MySQL、MongoDB），支持智能查询和 schema 可视化",
+              marketplace: "wave-community",
+              installed: false,
+              version: "0.9.5",
+            },
+            {
+              id: "code-reviewer@wave-plugins-official",
+              name: "Code Reviewer",
+              description:
+                "AI 驱动的代码审查工具，自动检测安全漏洞、性能问题和最佳实践违规",
+              marketplace: "wave-plugins-official",
+              installed: true,
+              enabled: true,
+              version: "3.1.2",
+              scope: "user",
+            },
+            {
+              id: "api-docs-generator@wave-community",
+              name: "API Docs Generator",
+              description:
+                "从代码自动生成 OpenAPI 文档，支持实时预览和交互式测试",
+              marketplace: "wave-community",
+              installed: true,
+              enabled: false,
+              version: "1.4.0",
+              scope: "project",
+            },
+          ],
+        },
+        "*",
+      );
+    });
+
+    await webviewPage.waitForSelector(".plugin-item");
+
+    // 确保可以看到可安装的插件列表
+    await expect(webviewPage.getByText("Git Workflow")).toBeVisible();
+    await expect(webviewPage.getByText("Kubernetes Helper")).toBeVisible();
+
+    // 点击一个插件查看详情
+    await webviewPage.getByText("Git Workflow").click();
+
+    // 等待详情页显示
+    await expect(webviewPage.getByText("返回列表")).toBeVisible();
+    await expect(webviewPage.getByText("选择安装作用域")).toBeVisible();
+    await expect(webviewPage.getByText("为你安装 (user)")).toBeVisible();
+    await expect(
+      webviewPage.getByText("为此仓库的所有协作者安装 (project)"),
+    ).toBeVisible();
+    await expect(
+      webviewPage.getByText("仅为你在此仓库中安装 (local)"),
+    ).toBeVisible();
+
+    // 截图：插件详情页，显示安装作用域选择
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-plugin-explore.webp",
+    );
+
+    // 返回列表
+    await webviewPage.getByText("返回列表").click();
+    await expect(webviewPage.getByText("Git Workflow")).toBeVisible();
+
+    // 3. Installed plugins tab - 展示已激活插件及更新和卸载按钮
+    await webviewPage.getByText("已安装插件", { exact: true }).click();
+
+    // 等待已安装插件渲染
+    await webviewPage.waitForSelector('.plugin-item:has-text("Code Reviewer")');
+
+    // 确认更新和卸载按钮存在
+    await expect(webviewPage.locator(".update-btn").first()).toBeVisible();
+    await expect(webviewPage.locator(".uninstall-btn").first()).toBeVisible();
+
+    // 截图：已激活插件标签页，显示更新和卸载按钮
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-plugin-installed.webp",
+    );
+
+    // 4. Marketplaces tab - 展示插件市场管理
+    await webviewPage.getByText("插件市场", { exact: true }).click();
+
+    // Simulate marketplace list
+    await webviewPage.evaluate(() => {
+      window.postMessage(
+        {
+          command: "listMarketplacesResponse",
+          marketplaces: [
+            {
+              name: "wave-plugins-official",
+              url: "https://github.com/wave-ai/wave-plugins-official",
+            },
+            {
+              name: "wave-community",
+              url: "https://github.com/wave-community/plugins",
+            },
+            {
+              name: "nebula-internal",
+              url: "https://git.nebula-tech.com/plugins",
+            },
+          ],
+        },
+        "*",
+      );
+    });
+
+    await webviewPage.waitForSelector(".marketplace-item");
+
+    // 确保输入框和按钮可见
+    await expect(
+      webviewPage.locator('input[placeholder*="市场 URL"]'),
+    ).toBeVisible();
+    await expect(webviewPage.getByText("添加", { exact: true })).toBeVisible();
+
+    // Close the dialog
+    await webviewPage.keyboard.press("Escape");
+  });
+});

--- a/packages/webview/demo/plugin-search.demo.ts
+++ b/packages/webview/demo/plugin-search.demo.ts
@@ -1,0 +1,104 @@
+import { test, expect } from "../e2e/utils/webviewTestHarness.js";
+import { screenshotWebp } from "../e2e/utils/screenshot.js";
+
+test.describe("Plugin Search UI Demo", () => {
+  test("should show search input and filter plugins by keyword", async ({
+    webviewPage,
+  }) => {
+    // 1. Open the plugin management dialog
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "showDialog",
+        dialogType: "plugin",
+      });
+    });
+
+    await expect(
+      webviewPage.getByText("插件管理", { exact: true }),
+    ).toBeVisible();
+
+    // 2. Simulate receiving plugins list
+    await webviewPage.evaluate(() => {
+      window.postMessage(
+        {
+          command: "listPluginsResponse",
+          plugins: [
+            {
+              id: "git-workflow@wave-plugins-official",
+              name: "git-workflow",
+              description: "集成 Git 工作流，支持智能提交信息和 PR 审查",
+              marketplace: "wave-plugins-official",
+              installed: false,
+              version: "2.3.1",
+            },
+            {
+              id: "kubernetes-helper@wave-plugins-official",
+              name: "kubernetes-helper",
+              description: "K8s 集群管理和 Pod 诊断工具",
+              marketplace: "wave-plugins-official",
+              installed: false,
+              version: "1.8.0",
+            },
+            {
+              id: "database-explorer@wave-community",
+              name: "database-explorer",
+              description: "多数据库连接和智能查询工具",
+              marketplace: "wave-community",
+              installed: false,
+              version: "0.9.5",
+            },
+            {
+              id: "api-docs-generator@wave-community",
+              name: "api-docs-generator",
+              description: "自动生成 OpenAPI 文档",
+              marketplace: "wave-community",
+              installed: false,
+              version: "1.4.0",
+            },
+          ],
+        },
+        "*",
+      );
+    });
+
+    // 3. Verify search input is visible
+    const searchInput = webviewPage.locator(".plugin-search input");
+    await expect(searchInput).toBeVisible();
+    await expect(searchInput).toHaveAttribute("placeholder", "搜索插件...");
+
+    // 4. Type "git" to filter
+    await searchInput.fill("git");
+
+    // Verify only git-workflow is shown
+    await expect(
+      webviewPage.locator(".plugin-name", { hasText: "git-workflow" }),
+    ).toBeVisible();
+    await expect(
+      webviewPage.locator(".plugin-name", { hasText: "kubernetes-helper" }),
+    ).not.toBeVisible();
+    await expect(
+      webviewPage.locator(".plugin-name", { hasText: "database-explorer" }),
+    ).not.toBeVisible();
+    await expect(
+      webviewPage.locator(".plugin-name", { hasText: "api-docs-generator" }),
+    ).not.toBeVisible();
+
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/plugin-search-filtered.webp",
+    );
+
+    // 5. Type a non-matching query
+    await searchInput.fill("zzz-nonexistent");
+    await expect(webviewPage.getByText("没有找到匹配的插件")).toBeVisible();
+
+    // 6. Clear the search
+    await searchInput.fill("");
+    await expect(
+      webviewPage.locator(".plugin-name", { hasText: "git-workflow" }),
+    ).toBeVisible();
+    await expect(
+      webviewPage.locator(".plugin-name", { hasText: "kubernetes-helper" }),
+    ).toBeVisible();
+  });
+});

--- a/packages/webview/demo/product-spec-btw.demo.ts
+++ b/packages/webview/demo/product-spec-btw.demo.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "../e2e/utils/webviewTestHarness.js";
+import { MessageInjector } from "../e2e/utils/messageInjector.js";
+import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
+import {
+  screenshotWebp,
+  elementScreenshotWebp,
+} from "../e2e/utils/screenshot.js";
+
+test.describe("Product Spec: /btw side question", () => {
+  test("should capture the /btw panel with a markdown answer", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+
+    // Setup a conversation so the panel shows above a real chat
+    const messages = [
+      MockDataGenerator.createUserMessage("帮我看下 PaymentService 的并发问题"),
+      MockDataGenerator.createAssistantMessage(
+        "我已经分析了 PaymentService 的代码，发现 `processPayment` 方法中存在竞态条件，建议改用乐观锁...",
+      ),
+    ];
+    await injector.updateMessages(messages);
+    await injector.endStreaming();
+
+    // Type /btw <question> and send it — no chat message is posted
+    await webviewPage.focus('[data-testid="message-input"]');
+    await webviewPage.keyboard.type("/btw 乐观锁的实现思路是什么？");
+    await webviewPage.keyboard.press("Enter");
+
+    // Wait for the askBtw RPC to be sent to the extension
+    await webviewPage.waitForFunction(() => {
+      const msgs = window.getTestMessages ? window.getTestMessages() : [];
+      return msgs.some((m) => m.command === "askBtw");
+    });
+
+    // Inject the side answer (markdown)
+    await injector.simulateExtensionMessage("btwResponse", {
+      question: "乐观锁的实现思路是什么？",
+      answer:
+        "**乐观锁**的核心思路是：读取时不加锁，更新时通过版本号（`version`）或时间戳校验数据是否被他人修改。\n\n- 读取数据并记录版本号\n- 更新时 `SET version = version + 1 WHERE version = 旧值`\n- 受影响行数为 0 时说明已被修改，重试或放弃\n\n相比悲观锁，乐观锁在低冲突场景下吞吐更高，适合读多写少的业务。",
+    });
+
+    // Panel shows the answer, chat history stays untouched
+    await expect(
+      webviewPage.locator('[data-testid="btw-panel-answer"]'),
+    ).toBeVisible();
+    await expect(
+      webviewPage.locator('[data-testid="btw-panel-answer"]'),
+    ).toContainText("乐观锁");
+
+    // Full screenshot showing the panel above the input
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-btw-panel.webp",
+    );
+  });
+
+  test("should capture the bare /btw usage hint", async ({ webviewPage }) => {
+    const injector = new MessageInjector(webviewPage);
+    // Initialize first — the loading sweep keeps the input area hidden until
+    // setInitialState, and this scenario has no conversation messages to bring
+    // it up.
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [],
+      isStreaming: false,
+      sessions: [],
+      configurationData: {
+        baseURL: "https://api.anthropic.com/v1",
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
+    // Type bare /btw and send it — shows usage, sends no RPC
+    await webviewPage.focus('[data-testid="message-input"]');
+    await webviewPage.keyboard.type("/btw");
+    await webviewPage.keyboard.press("Enter");
+
+    await expect(
+      webviewPage.locator('[data-testid="btw-panel"]'),
+    ).toBeVisible();
+    await expect(
+      webviewPage.locator('[data-testid="btw-panel-answer"]'),
+    ).toContainText("用法：/btw <你的问题>");
+
+    await elementScreenshotWebp(
+      webviewPage.locator('[data-testid="btw-panel"]'),
+      "../../docs/public/screenshots/spec-btw-usage.webp",
+    );
+  });
+});

--- a/packages/webview/demo/product-spec-confirmations.demo.ts
+++ b/packages/webview/demo/product-spec-confirmations.demo.ts
@@ -1,0 +1,375 @@
+import { test, expect } from "../e2e/utils/webviewTestHarness.js";
+import { MessageInjector } from "../e2e/utils/messageInjector.js";
+import {
+  EDIT_TOOL_NAME,
+  BASH_TOOL_NAME,
+  ASK_USER_QUESTION_TOOL_NAME,
+  ENTER_PLAN_MODE_TOOL_NAME,
+  EXIT_PLAN_MODE_TOOL_NAME,
+  type Message,
+} from "wave-agent-sdk";
+import {
+  screenshotWebp,
+  elementScreenshotWebp,
+} from "../e2e/utils/screenshot.js";
+
+test.describe("Product Specification Screenshots - Confirmations", () => {
+  test("capture confirmation features", async ({ webviewPage }) => {
+    const injector = new MessageInjector(webviewPage);
+
+    // Set viewport size for better screenshots. The dialog grows up to its
+    // 640px max-width, enough for the four-button bash action bar to show
+    // full labels; narrower viewports truncate the button texts.
+    await webviewPage.setViewportSize({ width: 700, height: 800 });
+
+    // Provide initial state with valid configuration
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [],
+      isStreaming: false,
+      sessions: [],
+      configurationData: {
+        apiKey: "sk-ant-api03-CXB9pH2k...mH8wQz",
+        baseURL: "https://api.anthropic.com/v1",
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
+
+    // 10. Ask User Question - 显示确认对话框
+    const askUserMessage: Message = {
+      id: "msg_demo_ask",
+      role: "assistant",
+      timestamp: "2025-07-09T10:30:00.000Z",
+      blocks: [
+        {
+          type: "tool",
+          name: ASK_USER_QUESTION_TOOL_NAME,
+          stage: "running",
+          parameters: JSON.stringify({
+            questions: [
+              {
+                header: "缓存方案",
+                question: "支付服务应该采用哪种缓存策略？",
+                options: [
+                  {
+                    label: "Redis Cluster",
+                    description: "分布式缓存，高可用，支持自动故障转移",
+                  },
+                  {
+                    label: "Redis Sentinel",
+                    description: "主从架构，自动故障转移，适合中等规模",
+                  },
+                ],
+              },
+            ],
+          }),
+        },
+      ],
+    };
+    await injector.updateMessages([askUserMessage]);
+
+    // 显示确认对话框
+    await injector.simulateExtensionMessage("showConfirmation", {
+      confirmationId: "ask-user-123",
+      toolName: ASK_USER_QUESTION_TOOL_NAME,
+      confirmationType: "问题待回答",
+      toolInput: {
+        questions: [
+          {
+            header: "缓存方案",
+            question: "支付服务应该采用哪种缓存策略？",
+            options: [
+              {
+                label: "Redis Cluster",
+                description: "分布式缓存，高可用，支持自动故障转移",
+              },
+              {
+                label: "Redis Sentinel",
+                description: "主从架构，自动故障转移，适合中等规模",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    await webviewPage.waitForSelector(".confirmation-dialog");
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-ask-user.webp",
+    );
+
+    // 关闭确认对话框以便继续其他截图
+    await webviewPage.keyboard.press("Escape");
+    await webviewPage.waitForSelector(".confirmation-dialog", {
+      state: "hidden",
+    });
+
+    // 10.1 Ask User Question - 多个问题（带分页导航）
+    await injector.simulateExtensionMessage("showConfirmation", {
+      confirmationId: "ask-user-multi",
+      toolName: ASK_USER_QUESTION_TOOL_NAME,
+      confirmationType: "问题待回答",
+      toolInput: {
+        questions: [
+          {
+            header: "缓存方案",
+            question: "支付服务应该采用哪种缓存策略？",
+            options: [
+              {
+                label: "Redis Cluster",
+                description: "分布式缓存，高可用，支持自动故障转移",
+              },
+              {
+                label: "Redis Sentinel",
+                description: "主从架构，自动故障转移，适合中等规模",
+              },
+            ],
+          },
+          {
+            header: "数据库",
+            question: "账务数据使用哪种存储？",
+            options: [
+              {
+                label: "PostgreSQL",
+                description: "强一致性，支持复杂事务与外键约束",
+              },
+              { label: "TiDB", description: "分布式 NewSQL，水平扩展能力强" },
+            ],
+          },
+          {
+            header: "部署方式",
+            question: "服务以何种方式部署？",
+            options: [
+              { label: "Kubernetes", description: "容器编排，弹性伸缩" },
+              { label: "虚拟机", description: "传统部署，运维成熟" },
+            ],
+          },
+        ],
+      },
+    });
+    const multiQuestionDialog = webviewPage.locator(".confirmation-dialog");
+    await multiQuestionDialog.waitFor({ state: "visible" });
+    // 选中当前问题的一个选项，展示分页启用态；等已答段着色过渡（0.15s）走完再截
+    await webviewPage.locator(".option-item").first().click();
+    await multiQuestionDialog.locator(".question-progress-seg.done").waitFor();
+    await webviewPage.waitForTimeout(300);
+    await elementScreenshotWebp(
+      multiQuestionDialog,
+      "../../docs/public/screenshots/spec-ask-user-multi.webp",
+    );
+    await webviewPage.keyboard.press("Escape");
+    await webviewPage.waitForSelector(".confirmation-dialog", {
+      state: "hidden",
+    });
+
+    // 10.2 Ask User Question - 多选（可勾选多个选项）
+    await injector.simulateExtensionMessage("showConfirmation", {
+      confirmationId: "ask-user-multiselect",
+      toolName: ASK_USER_QUESTION_TOOL_NAME,
+      confirmationType: "问题待回答",
+      toolInput: {
+        questions: [
+          {
+            header: "重构范围",
+            question: "哪些模块需要优先重构？",
+            multiSelect: true,
+            options: [
+              {
+                label: "PaymentService",
+                description: "核心支付逻辑，存在并发隐患",
+              },
+              {
+                label: "TransactionLogger",
+                description: "审计日志写入，可异步化",
+              },
+              { label: "RefundHandler", description: "退款流程，与支付强耦合" },
+            ],
+          },
+        ],
+      },
+    });
+    const multiSelectDialog = webviewPage.locator(".confirmation-dialog");
+    await multiSelectDialog.waitFor({ state: "visible" });
+    // 勾选多个选项，展示多选态
+    await webviewPage.locator(".option-item").nth(0).click();
+    await webviewPage.locator(".option-item").nth(1).click();
+    await elementScreenshotWebp(
+      multiSelectDialog,
+      "../../docs/public/screenshots/spec-ask-user-multiselect.webp",
+    );
+    await webviewPage.keyboard.press("Escape");
+    await webviewPage.waitForSelector(".confirmation-dialog", {
+      state: "hidden",
+    });
+
+    // 11. Permission Mode Select - Show all three modes
+    const inputContainer = webviewPage.locator(".input-container");
+    const permissionModeSelect = webviewPage.locator(".permission-mode-select");
+
+    // Mode 1: Default (修改前询问)
+    await injector.simulateExtensionMessage("updatePermissionMode", {
+      mode: "default",
+    });
+    await webviewPage.waitForSelector(".permission-mode-select");
+    await expect(webviewPage.locator(".permission-mode-select")).toHaveClass(
+      /mode-default/,
+    );
+    await permissionModeSelect.focus();
+    await elementScreenshotWebp(
+      inputContainer,
+      "../../docs/public/screenshots/spec-permission-mode-default.webp",
+    );
+
+    // Mode 2: Accept Edits (自动接受修改)
+    await injector.simulateExtensionMessage("updatePermissionMode", {
+      mode: "acceptEdits",
+    });
+    await expect(webviewPage.locator(".permission-mode-select")).toHaveClass(
+      /mode-acceptEdits/,
+    );
+    await permissionModeSelect.focus();
+    await elementScreenshotWebp(
+      inputContainer,
+      "../../docs/public/screenshots/spec-permission-mode-accept.webp",
+    );
+
+    // Mode 3: Plan Mode (计划模式)
+    await injector.simulateExtensionMessage("updatePermissionMode", {
+      mode: "plan",
+    });
+    await expect(webviewPage.locator(".permission-mode-select")).toHaveClass(
+      /mode-plan/,
+    );
+    await permissionModeSelect.focus();
+    await elementScreenshotWebp(
+      inputContainer,
+      "../../docs/public/screenshots/spec-permission-mode-plan.webp",
+    );
+
+    // Reset to default for remaining screenshots
+    await injector.simulateExtensionMessage("updatePermissionMode", {
+      mode: "default",
+    });
+    await expect(webviewPage.locator(".permission-mode-select")).toHaveClass(
+      /mode-default/,
+    );
+
+    // 15. Plan 确认对话框 - 只显示确认对话框组件
+    await injector.simulateExtensionMessage("showConfirmation", {
+      confirmationId: "plan-confirm-001",
+      confirmationType: "计划执行确认",
+      toolName: EXIT_PLAN_MODE_TOOL_NAME, // "ExitPlanMode"
+      planContent: `## PaymentService 高并发重构计划
+
+### 第一阶段：乐观锁引入
+- 在 PaymentRepository 中添加 version 字段
+- 实现 withOptimisticLock 中间件
+- 处理乐观锁冲突重试逻辑
+
+### 第二阶段：缓存层接入
+- 引入 Redis 作为热数据缓存
+- 实现缓存失效策略（TTL + 主动失效）
+- 添加缓存命中率监控
+
+### 第三阶段：异步化改造
+- 将审计日志改为异步写入
+- 接入消息队列处理非核心流程
+- 性能基准测试与对比`,
+    });
+    const planConfirmDialog = webviewPage.locator(".confirmation-dialog");
+    await planConfirmDialog.waitFor({ state: "visible" });
+    await elementScreenshotWebp(
+      planConfirmDialog,
+      "../../docs/public/screenshots/spec-plan-confirm.webp",
+    );
+
+    // 关闭当前确认对话框
+    await webviewPage.keyboard.press("Escape");
+    await planConfirmDialog.waitFor({ state: "detached" });
+
+    // 15.1 EnterPlanMode 确认对话框 - 简洁选项（仅批准/拒绝）
+    await injector.simulateExtensionMessage("showConfirmation", {
+      confirmationId: "enter-plan-mode-001",
+      confirmationType: "进入计划模式确认",
+      toolName: ENTER_PLAN_MODE_TOOL_NAME, // "EnterPlanMode"
+      toolInput: {},
+      hidePersistentOption: true,
+    });
+    const enterPlanDialog = webviewPage.locator(".confirmation-dialog");
+    await enterPlanDialog.waitFor({ state: "visible" });
+    await elementScreenshotWebp(
+      enterPlanDialog,
+      "../../docs/public/screenshots/spec-enter-plan-mode.webp",
+    );
+
+    // 关闭当前确认对话框
+    await webviewPage.keyboard.press("Escape");
+    await enterPlanDialog.waitFor({ state: "detached" });
+
+    // 16. 代码修改确认对话框 - 只显示确认对话框组件
+    await injector.simulateExtensionMessage("showConfirmation", {
+      confirmationId: "edit-confirm-001",
+      confirmationType: "代码修改确认",
+      toolName: EDIT_TOOL_NAME, // "Edit"
+      toolInput: {
+        file_path: "/src/services/payment/PaymentService.ts",
+        old_string:
+          'const result = await this.db.query("SELECT * FROM payments WHERE id = ?", tx.id);',
+        new_string:
+          'const result = await this.db.query("SELECT * FROM payments WHERE id = $1", [tx.id]);',
+      },
+    });
+    const editConfirmDialog = webviewPage.locator(".confirmation-dialog");
+    await editConfirmDialog.waitFor({ state: "visible" });
+    await elementScreenshotWebp(
+      editConfirmDialog,
+      "../../docs/public/screenshots/spec-edit-confirm.webp",
+    );
+
+    // 关闭当前确认对话框
+    await webviewPage.keyboard.press("Escape");
+    await editConfirmDialog.waitFor({ state: "detached" });
+
+    // 17. MCP 工具确认对话框
+    await injector.simulateExtensionMessage("showConfirmation", {
+      confirmationId: "mcp-confirm-001",
+      confirmationType: "MCP 工具确认",
+      toolName: "mcp__jira__create_issue",
+      toolInput: {
+        title: "PaymentService 乐观锁支持",
+        description: "为支付服务引入乐观锁机制，处理并发更新冲突",
+        priority: "high",
+        tags: ["payment", "concurrency", "refactor"],
+      },
+    });
+    const mcpConfirmDialog = webviewPage.locator(".confirmation-dialog");
+    await mcpConfirmDialog.waitFor({ state: "visible" });
+    await elementScreenshotWebp(
+      mcpConfirmDialog,
+      "../../docs/public/screenshots/spec-mcp-tool-confirm.webp",
+    );
+
+    // 关闭当前确认对话框
+    await webviewPage.keyboard.press("Escape");
+    await mcpConfirmDialog.waitFor({ state: "detached" });
+
+    // 18. Bash运行确认对话框 - 只显示确认对话框组件
+    await injector.simulateExtensionMessage("showConfirmation", {
+      confirmationId: "bash-confirm-001",
+      confirmationType: "Bash 命令执行确认",
+      toolName: BASH_TOOL_NAME, // "Bash"
+      toolInput: {
+        command: "pnpm -F @nebula/payment-service test -- --coverage",
+        description: "运行支付服务测试套件并生成覆盖率报告",
+      },
+    });
+    const bashConfirmDialog = webviewPage.locator(".confirmation-dialog");
+    await bashConfirmDialog.waitFor({ state: "visible" });
+    await elementScreenshotWebp(
+      bashConfirmDialog,
+      "../../docs/public/screenshots/spec-bash-confirm.webp",
+    );
+  });
+});

--- a/packages/webview/demo/product-spec-history-search.demo.ts
+++ b/packages/webview/demo/product-spec-history-search.demo.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "../e2e/utils/webviewTestHarness.js";
+import { MessageInjector } from "../e2e/utils/messageInjector.js";
+import {
+  screenshotWebp,
+  elementScreenshotWebp,
+} from "../e2e/utils/screenshot.js";
+
+test.describe("Product Spec: History Search", () => {
+  // Both scenarios operate the input area with no conversation messages, so
+  // they must initialize up front — the loading sweep keeps the input area
+  // hidden until setInitialState (matching the real host flow).
+  async function initialize(injector: MessageInjector) {
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [],
+      isStreaming: false,
+      sessions: [],
+      configurationData: {
+        baseURL: "https://api.anthropic.com/v1",
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
+  }
+
+  test("should capture history search popup screenshot", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+    await initialize(injector);
+
+    // 1. Focus input
+    const messageInput = webviewPage.getByTestId("message-input");
+    await messageInput.focus();
+
+    // 2. Press Ctrl+R
+    await webviewPage.keyboard.press("Control+r");
+
+    // 3. Simulate history response from extension
+    const mockHistory = [
+      {
+        prompt: "为 PaymentService 添加分布式事务支持，使用 Saga 模式",
+        timestamp: 1752052800000,
+      },
+      {
+        prompt: "分析 src/services/payment 目录下的竞态条件，生成修复方案",
+        timestamp: 1752051000000,
+      },
+      {
+        prompt: "/review 审查 PaymentController.ts 中的安全性问题",
+        timestamp: 1751966400000,
+      },
+    ];
+
+    await injector.simulateExtensionMessage("historyResponse", {
+      history: mockHistory,
+    });
+
+    // 4. Wait for popup to be visible and loading to finish
+    const popup = webviewPage.getByTestId("history-search-popup");
+    await expect(popup).toBeVisible();
+    // Wait for the loading spinner to disappear (data rendered)
+    await expect(popup.getByText("正在加载...")).toBeHidden();
+
+    // 5. Take screenshot of the whole webview to show the popup in context
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-history-search.webp",
+    );
+  });
+
+  test("should capture plus menu with history prompt entry", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+    await initialize(injector);
+
+    // Open the "+" (添加) menu in the input toolbar
+    await webviewPage.getByRole("button", { name: "添加" }).click();
+
+    const menu = webviewPage.locator(".plus-menu");
+    await expect(menu).toBeVisible();
+    await expect(menu.getByText("上传文件")).toBeVisible();
+    await expect(menu.getByText("历史提示词")).toBeVisible();
+
+    // The menu opens upward from the "+" button, so capture the input area
+    // (toolbar + menu floating above it) rather than the menu container alone.
+    await elementScreenshotWebp(
+      webviewPage.locator(".input-container"),
+      "../../docs/public/screenshots/spec-plus-menu.webp",
+    );
+  });
+});

--- a/packages/webview/demo/product-spec-message-queuing.demo.ts
+++ b/packages/webview/demo/product-spec-message-queuing.demo.ts
@@ -1,0 +1,127 @@
+import { test, expect } from "../e2e/utils/webviewTestHarness.js";
+import { MessageInjector } from "../e2e/utils/messageInjector.js";
+import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
+import { screenshotWebp } from "../e2e/utils/screenshot.js";
+
+// Realistic Chinese dev-task queue messages (varying length; at least one long enough to ellipsize)
+const QUEUE = [
+  {
+    id: "mq-0",
+    content: "顺便帮乐观锁中间件补一组单元测试，覆盖并发写入时的版本号冲突场景",
+  },
+  {
+    id: "mq-1",
+    content: "把 PaymentService 里的重复重试逻辑抽成一个通用的指数退避工具函数",
+  },
+  {
+    id: "mq-2",
+    content: "给订单状态机加上非法状态流转的日志告警，方便线上排查",
+  },
+  {
+    id: "mq-3",
+    content:
+      "梳理一下这次改动涉及的数据库迁移，确认回滚脚本是否完整，并在 CI 里加一个迁移演练的 job，避免上线时才发现字段不兼容导致回滚困难的问题",
+  },
+  { id: "mq-4", content: "更新 README 里的本地启动说明，补上新增的环境变量" },
+  {
+    id: "mq-5",
+    content: "排查一下压测时偶发的连接池耗尽，看看是不是慢查询没释放连接",
+  },
+  { id: "mq-6", content: "把这次分析结论整理成一份简短的技术方案文档" },
+];
+
+test.describe("Product Specification Screenshots - Message Queuing", () => {
+  test("capture message queuing features", async ({ webviewPage }) => {
+    const injector = new MessageInjector(webviewPage);
+
+    // Set viewport size for better screenshots (simulating VS Code sidebar)
+    await webviewPage.setViewportSize({ width: 400, height: 800 });
+
+    // Provide initial state (AI is streaming a response)
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [
+        MockDataGenerator.createUserMessage(
+          "帮我分析 PaymentService 的分布式事务实现，看看有没有竞态条件",
+        ),
+        MockDataGenerator.createAssistantMessage(
+          "好的，我正在扫描支付服务代码，分析事务边界和并发控制机制...",
+        ),
+      ],
+      isStreaming: true,
+      sessions: [],
+      configurationData: {
+        apiKey: "sk-ant-api03-CXB9pH2k...mH8wQz",
+        baseURL: "https://api.anthropic.com/v1",
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
+
+    // 1. During streaming the bottom bar shows the abort (停止) button; the
+    //    send/queue button is not rendered. Typing while streaming still
+    //    queues the message (handled by the extension).
+    await webviewPage.focus('[data-testid="message-input"]');
+    await webviewPage.keyboard.type(
+      "顺便帮乐观锁中间件补一组单元测试，覆盖并发写入时的版本号冲突场景",
+    );
+
+    await expect(webviewPage.getByTestId("send-btn")).toHaveCount(0);
+    const abortBtn = webviewPage.getByTestId("abort-btn");
+    await expect(abortBtn).toBeVisible();
+    await expect(abortBtn).toHaveAttribute("aria-label", "停止");
+    await expect(abortBtn.locator(".abort-glyph")).toBeVisible();
+
+    // Clear input to simulate real behavior (input cleared after message queued)
+    await webviewPage.fill('[data-testid="message-input"]', "");
+
+    // Inject a multi-item queue
+    await injector.updateQueue(QUEUE);
+
+    const queuePanel = webviewPage.getByTestId("queued-message-list");
+    await expect(queuePanel).toBeVisible();
+    await expect(queuePanel).toContainText(`消息队列 (${QUEUE.length})`);
+
+    // 2. Collapsed state (default): only the first item is visible
+    await expect(webviewPage.getByTestId("queued-item-mq-0")).toBeVisible();
+    await expect(webviewPage.getByTestId("queued-item-mq-1")).toHaveCount(0);
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-queue-collapsed.webp",
+    );
+
+    // 3. Expanded state: click header to expand, multiple single-line items visible
+    await queuePanel.locator(".queued-message-list-header").click();
+    await expect(webviewPage.getByTestId("queued-item-mq-1")).toBeVisible();
+    await expect(webviewPage.getByTestId("queued-item-mq-6")).toBeVisible();
+
+    // Each item exposes the inline edit / ↑立即发送 / delete SVG action buttons
+    await expect(webviewPage.getByTestId("queued-edit-mq-1")).toBeVisible();
+    const sendNowBtn = webviewPage.getByTestId("queued-send-mq-1");
+    await expect(sendNowBtn).toBeVisible();
+    await expect(sendNowBtn).toHaveAttribute("aria-label", "立即发送");
+    await expect(sendNowBtn.locator("svg")).toBeVisible();
+    await expect(webviewPage.getByTestId("queued-delete-mq-1")).toBeVisible();
+
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-queued-message.webp",
+    );
+
+    // 4. Editing state: click a message's edit button -> the read-only inline
+    //    chip "编辑队列消息" appears inside the input, and the item is marked editing
+    await webviewPage.getByTestId("queued-edit-mq-1").click({ force: true });
+    const editChip = webviewPage
+      .getByTestId("message-input")
+      .locator(".queued-edit-chip");
+    await expect(editChip).toBeVisible();
+    await expect(editChip).toContainText("编辑队列消息");
+    await expect(webviewPage.getByTestId("queued-item-mq-1")).toHaveClass(
+      /editing/,
+    );
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-queue-editing.webp",
+    );
+  });
+});

--- a/packages/webview/demo/product-spec-rewind.demo.ts
+++ b/packages/webview/demo/product-spec-rewind.demo.ts
@@ -1,0 +1,115 @@
+import { test, expect } from "../e2e/utils/webviewTestHarness.js";
+import { MessageInjector } from "../e2e/utils/messageInjector.js";
+import { UIStateVerifier } from "../e2e/utils/uiStateVerifier.js";
+import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
+import { screenshotWebp } from "../e2e/utils/screenshot.js";
+
+test.describe("Product Spec: Rewind", () => {
+  test("should capture rewind button screenshot", async ({ webviewPage }) => {
+    const injector = new MessageInjector(webviewPage);
+    const ui = new UIStateVerifier(webviewPage);
+
+    // Setup a conversation
+    const messages = [
+      MockDataGenerator.createUserMessage(
+        "帮我分析 PaymentService 的并发问题，看看有没有竞态条件",
+      ),
+      MockDataGenerator.createAssistantMessage(
+        "我已经分析了 PaymentService 的代码，发现 `processPayment` 方法中存在竞态条件。当前的悲观锁实现会导致高并发下性能下降，建议改用乐观锁...",
+      ),
+      MockDataGenerator.createUserMessage(
+        "好的，请为乐观锁实现编写单元测试，覆盖并发冲突场景",
+      ),
+    ];
+    await injector.updateMessages(messages);
+    await injector.endStreaming();
+
+    // Hover over the first user message to show the rewind button, then hover the button to show tooltip
+    const firstUserMessage = ui.userMessages.first();
+    await firstUserMessage.hover();
+
+    const rewindBtn = firstUserMessage.locator(".message-action-btn");
+    await expect(rewindBtn).toBeVisible();
+    await rewindBtn.hover();
+
+    // Take screenshot of the message list showing the rewind button with tooltip
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-rewind-button.webp",
+      {
+        clip: (await ui.messagesContainer.boundingBox()) || undefined,
+      },
+    );
+  });
+
+  test("should capture /rewind popup screenshot", async ({ webviewPage }) => {
+    const injector = new MessageInjector(webviewPage);
+
+    // Setup a conversation with several user messages
+    const messages = [
+      MockDataGenerator.createUserMessage(
+        "帮我分析 PaymentService 的并发问题，看看有没有竞态条件",
+      ),
+      MockDataGenerator.createAssistantMessage(
+        "我已经分析了 PaymentService 的代码，发现 `processPayment` 方法中存在竞态条件。当前的悲观锁实现会导致高并发下性能下降，建议改用乐观锁...",
+      ),
+      MockDataGenerator.createUserMessage(
+        "好的，请为乐观锁实现编写单元测试，覆盖并发冲突场景",
+      ),
+      MockDataGenerator.createAssistantMessage(
+        "已为乐观锁实现编写了 5 个单元测试，覆盖了并发冲突、重试机制和超时场景...",
+      ),
+      MockDataGenerator.createUserMessage(
+        "测试全部通过了，现在帮我把改动提交到 git",
+      ),
+    ];
+    await injector.updateMessages(messages);
+    await injector.endStreaming();
+
+    // Type /rewind and send it
+    await webviewPage.focus('[data-testid="message-input"]');
+    await webviewPage.keyboard.type("/rewind");
+    await webviewPage.keyboard.press("Enter");
+
+    // Wait for the listRewindCheckpoints request to be sent to the extension
+    await webviewPage.waitForFunction(() => {
+      const msgs = window.getTestMessages ? window.getTestMessages() : [];
+      return msgs.some((m) => m.command === "listRewindCheckpoints");
+    });
+
+    // Inject the checkpoints response
+    await injector.simulateExtensionMessage("rewindCheckpoints", {
+      checkpoints: [
+        {
+          id: "cp-1",
+          content: "帮我分析 PaymentService 的并发问题，看看有没有竞态条件",
+        },
+        {
+          id: "cp-2",
+          content: "好的，请为乐观锁实现编写单元测试，覆盖并发冲突场景",
+        },
+        { id: "cp-3", content: "测试全部通过了，现在帮我把改动提交到 git" },
+      ],
+    });
+
+    // Wait for the popup to appear with items
+    await webviewPage.waitForSelector(".rewind-popup-item", {
+      state: "visible",
+      timeout: 5000,
+    });
+
+    // Verify all 3 checkpoints are listed
+    const items = webviewPage.locator(".rewind-popup-item");
+    await expect(items).toHaveCount(3);
+
+    // Verify the last item is selected by default
+    const selected = webviewPage.locator(".rewind-popup-item.selected");
+    await expect(selected).toContainText("测试全部通过了");
+
+    // Screenshot the popup
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-rewind-popup.webp",
+    );
+  });
+});

--- a/packages/webview/demo/product-spec-tools.demo.ts
+++ b/packages/webview/demo/product-spec-tools.demo.ts
@@ -1,0 +1,518 @@
+import { test } from "../e2e/utils/webviewTestHarness.js";
+import { MessageInjector } from "../e2e/utils/messageInjector.js";
+import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
+import {
+  EDIT_TOOL_NAME,
+  BASH_TOOL_NAME,
+  GLOB_TOOL_NAME,
+  GREP_TOOL_NAME,
+  READ_TOOL_NAME,
+  WRITE_TOOL_NAME,
+  AGENT_TOOL_NAME,
+  type Message,
+} from "wave-agent-sdk";
+import {
+  screenshotWebp,
+  elementScreenshotWebp,
+} from "../e2e/utils/screenshot.js";
+
+test.describe("Product Specification Screenshots - Tools", () => {
+  test("capture tool features", async ({ webviewPage }) => {
+    const injector = new MessageInjector(webviewPage);
+
+    // Set viewport size for better screenshots (simulating VS Code sidebar)
+    await webviewPage.setViewportSize({ width: 400, height: 800 });
+
+    // Provide initial state with valid configuration
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [],
+      isStreaming: false,
+      sessions: [],
+      isAuthenticated: true,
+      configurationData: {
+        apiKey: "sk-ant-api03-CXB9pH2k...mH8wQz",
+        baseURL: "https://api.anthropic.com/v1",
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
+
+    // 6. Diff Viewer - 使用 MockDataGenerator 的 Edit 工具
+    const diffMessage: Message = {
+      id: "msg_demo_diff",
+      role: "assistant",
+      timestamp: "2025-07-09T10:30:00.000Z",
+      blocks: [
+        {
+          type: "tool",
+          name: EDIT_TOOL_NAME,
+          stage: "end",
+          compactParams: "src/services/payment/PaymentService.ts",
+          parameters: JSON.stringify({
+            file_path: "src/services/payment/PaymentService.ts",
+            old_string:
+              'const result = await this.db.query("SELECT * FROM payments WHERE id = ?", tx.id);',
+            new_string:
+              'const result = await this.db.query("SELECT * FROM payments WHERE id = $1", [tx.id]);',
+          }),
+          result: "Text replaced successfully",
+        },
+      ],
+    };
+    const diffUserMessage = MockDataGenerator.createUserMessage(
+      "把 PaymentService 里的 SQL 查询改成参数化写法，防止注入",
+      "msg_user_diff",
+    );
+    await injector.updateMessages([diffUserMessage, diffMessage]);
+    await webviewPage.waitForSelector(".tool-container");
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-diff-viewer.webp",
+    );
+
+    // 7. Task List — pinned above the input area, driven by updateTasks
+    const taskTasks = [
+      {
+        id: "1",
+        subject: "分析现有支付服务架构",
+        description:
+          "审查 PaymentService 的分布式事务实现，识别竞态条件和性能瓶颈",
+        status: "completed",
+        blocks: [],
+        blockedBy: [],
+        metadata: {},
+      },
+      {
+        id: "2",
+        subject: "实现乐观锁机制",
+        description: "为支付服务引入版本号控制，防止并发更新冲突",
+        status: "in_progress",
+        activeForm: "编写乐观锁中间件",
+        blocks: ["3"],
+        blockedBy: [],
+        metadata: {},
+      },
+      {
+        id: "3",
+        subject: "编写集成测试",
+        description: "覆盖并发支付场景，验证乐观锁和事务回滚的正确性",
+        status: "pending",
+        blocks: [],
+        blockedBy: ["2"],
+        metadata: {},
+      },
+    ];
+    const taskUserMessage = MockDataGenerator.createUserMessage(
+      "把支付服务的并发问题彻底修一下",
+      "msg_user_tasklist",
+    );
+    await injector.updateMessages([taskUserMessage]);
+    await injector.simulateExtensionMessage("updateTasks", {
+      tasks: taskTasks,
+      isTaskListCollapsed: false,
+    });
+    await webviewPage.waitForSelector(".task-list-inline");
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-task-list.webp",
+    );
+
+    // 7.1 Task List Collapsed
+    await injector.simulateExtensionMessage("updateTasks", {
+      tasks: taskTasks,
+      isTaskListCollapsed: true,
+    });
+    await webviewPage.waitForFunction(() => {
+      const el = document.querySelector(".task-list-chevron");
+      return el && !el.classList.contains("expanded");
+    });
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-task-list-collapsed.webp",
+    );
+
+    // 8. Subagent Display (Task Explore)
+    const subagentMessage: Message = {
+      id: "msg_demo_subagent",
+      role: "assistant",
+      timestamp: "2025-07-09T10:30:00.000Z",
+      blocks: [
+        {
+          type: "tool",
+          name: AGENT_TOOL_NAME,
+          stage: "running",
+          compactParams: "Explore: 查找所有支付相关 API 定义",
+          parameters: JSON.stringify({
+            subagent_type: "Explore",
+            description: "查找所有支付相关 API 定义",
+            prompt: "...",
+          }),
+          shortResult: "...Read, Grep (2 tools | 3,421 tokens)",
+        },
+      ],
+    };
+    const subagentUserMessage = MockDataGenerator.createUserMessage(
+      "帮我查一下项目里所有支付相关的 API 定义在哪",
+      "msg_user_subagent",
+    );
+    await injector.updateMessages([subagentUserMessage, subagentMessage]);
+
+    await webviewPage.waitForSelector(".tool-container");
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-subagent.webp",
+    );
+
+    // 9. Bash Tool - 使用 MockDataGenerator
+    const bashMessage: Message = {
+      id: "msg_demo_bash",
+      role: "assistant",
+      timestamp: "2025-07-09T10:30:00.000Z",
+      blocks: [
+        {
+          type: "tool",
+          name: BASH_TOOL_NAME,
+          stage: "end",
+          compactParams: "pnpm test -- --coverage",
+          parameters: JSON.stringify({
+            command: "pnpm test -- --coverage",
+            description: "运行测试套件并生成覆盖率报告",
+          }),
+          result:
+            " RUN  v3.1.0 /home/dev/projects/nebula-platform\n\n ✓ src/services/payment/PaymentService.test.ts (8 tests) 142ms\n ✓ src/utils/eventBus.test.ts (5 tests) 67ms\n ✓ src/middleware/optimisticLock.test.ts (3 tests) 89ms\n\n Test Files  3 passed (3)\n      Tests  16 passed (16)\n   Coverage  94.2% Statements\n              87.5% Branches\n              92.1% Functions\n Duration   2.4s",
+        },
+      ],
+    };
+    const bashUserMessage = MockDataGenerator.createUserMessage(
+      "跑一下测试套件，顺便生成覆盖率报告",
+      "msg_user_bash",
+    );
+    await injector.updateMessages([bashUserMessage, bashMessage]);
+    await webviewPage.waitForSelector(".bash-command-unified");
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-bash.webp",
+    );
+
+    // 19. Exploration Tools
+    const explorationMessages: Message[] = [
+      {
+        id: "msg_demo_exploration",
+        role: "assistant",
+        timestamp: "2025-07-09T10:30:00.000Z",
+        blocks: [
+          {
+            type: "tool",
+            name: AGENT_TOOL_NAME,
+            stage: "end",
+            compactParams: "Explore: 查找所有支付相关 API 定义",
+            parameters: JSON.stringify({
+              subagent_type: "Explore",
+              description: "查找所有支付相关 API 定义",
+              prompt: "...",
+            }),
+            result: "子代理已扫描 42 个文件，识别出 12 个支付相关接口定义",
+            shortResult: "子代理已扫描 42 个文件，识别出 12 个支付相关接口定义",
+          },
+          {
+            type: "tool",
+            name: GLOB_TOOL_NAME,
+            stage: "end",
+            compactParams: "src/services/**/*.ts in src",
+            parameters: JSON.stringify({
+              pattern: "src/services/**/*.ts",
+              path: "src",
+            }),
+            result:
+              "src/services/payment/PaymentService.ts\nsrc/services/payment/TransactionLogger.ts\nsrc/services/payment/RefundHandler.ts",
+            shortResult: "Found 3 files",
+          },
+          {
+            type: "tool",
+            name: GREP_TOOL_NAME,
+            stage: "end",
+            compactParams: "interface.*Payment ts in src",
+            parameters: JSON.stringify({
+              pattern: "interface.*Payment",
+              type: "ts",
+              path: "src",
+            }),
+            result:
+              "src/types/payment.ts:15:export interface PaymentRequest {\nsrc/types/payment.ts:32:export interface PaymentResult {\nsrc/services/payment/PaymentService.ts:28:export interface PaymentService {",
+            shortResult: "Found 3 matching lines",
+          },
+          {
+            type: "tool",
+            name: READ_TOOL_NAME,
+            stage: "end",
+            parameters: JSON.stringify({
+              file_path: "src/services/payment/PaymentService.ts",
+            }),
+            result:
+              'import { Injectable } from "@nestjs/common";\nimport { PaymentRepository } from "./PaymentRepository";\n\n@Injectable()\nexport class PaymentService {\n  constructor(private readonly repo: PaymentRepository) {}',
+            shortResult: "Read 156 lines",
+          },
+        ],
+      },
+    ];
+    const explorationUserMessage = MockDataGenerator.createUserMessage(
+      "梳理一下 src/services 下的支付服务代码结构和接口定义",
+      "msg_user_exploration",
+    );
+    await injector.updateMessages([
+      explorationUserMessage,
+      ...explorationMessages,
+    ] as unknown as Message[]);
+    await webviewPage.waitForSelector(".tool-container");
+    await elementScreenshotWebp(
+      webviewPage.locator(".messages-container"),
+      "../../docs/public/screenshots/spec-exploration.webp",
+    );
+
+    // 21. File Operation Tools
+    const fileOpMessages: Message[] = [
+      {
+        id: "msg_demo_file_ops",
+        role: "assistant",
+        timestamp: "2025-07-09T10:30:00.000Z",
+        blocks: [
+          {
+            type: "tool",
+            name: WRITE_TOOL_NAME,
+            stage: "end",
+            compactParams:
+              "src/middleware/optimisticLock.ts 18 lines, 512 chars",
+            parameters: JSON.stringify({
+              file_path: "src/middleware/optimisticLock.ts",
+              content: `import { PaymentRepository } from '../repositories/PaymentRepository';
+
+/**
+ * 乐观锁中间件：基于版本号防止并发更新冲突。
+ * 读取当前版本后执行业务逻辑，提交时校验版本一致性。
+ */
+export const withOptimisticLock = async <T>(
+  repo: PaymentRepository,
+  id: string,
+  handler: (version: number) => Promise<T>
+): Promise<T> => {
+  const { version } = await repo.findById(id);
+  const result = await handler(version);
+  await repo.assertVersion(id, version);
+  return result;
+};`,
+            }),
+            result: "File created (18 lines, 512 characters)",
+            shortResult: "File created (18 lines, 512 characters)",
+          },
+          {
+            type: "tool",
+            name: EDIT_TOOL_NAME,
+            stage: "end",
+            compactParams: "src/services/payment/PaymentService.ts",
+            parameters: JSON.stringify({
+              file_path: "src/services/payment/PaymentService.ts",
+              old_string: "async processPayment(tx) {",
+              new_string:
+                "async processPayment(tx: PaymentTx): Promise<Result> {",
+            }),
+            result: "Text replaced successfully",
+            shortResult: "Text replaced successfully",
+          },
+        ],
+      },
+    ];
+    const fileOpUserMessage = MockDataGenerator.createUserMessage(
+      "新建一个乐观锁中间件，并给 processPayment 补上类型签名",
+      "msg_user_file_ops",
+    );
+    await injector.updateMessages([fileOpUserMessage, ...fileOpMessages]);
+    await webviewPage.waitForSelector(".write-preview-box");
+    await elementScreenshotWebp(
+      webviewPage.locator(".messages-container"),
+      "../../docs/public/screenshots/spec-file-ops.webp",
+    );
+
+    // 24. LSP
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [
+        MockDataGenerator.createUserMessage(
+          "分析 PaymentService 里 findById 的定义、引用和调用方",
+          "msg_user_lsp",
+        ),
+        {
+          id: "msg_demo_lsp",
+          role: "assistant",
+          blocks: [
+            {
+              type: "tool",
+              name: "LSP",
+              stage: "end",
+              compactParams:
+                "goToDefinition (src/services/payment/PaymentService.ts:28:15)",
+              parameters: JSON.stringify({
+                operation: "goToDefinition",
+                filePath: "src/services/payment/PaymentService.ts",
+                line: 28,
+                character: 15,
+              }),
+              result:
+                "Found definition at src/repositories/PaymentRepository.ts:12:14",
+            },
+            {
+              type: "tool",
+              name: "LSP",
+              stage: "end",
+              compactParams:
+                "findReferences (src/repositories/PaymentRepository.ts:12:14)",
+              parameters: JSON.stringify({
+                operation: "findReferences",
+                filePath: "src/repositories/PaymentRepository.ts",
+                line: 12,
+                character: 14,
+              }),
+              result:
+                "Found 8 references:\n- src/services/payment/PaymentService.ts:28:5\n- src/services/payment/RefundHandler.ts:45:12\n- src/services/payment/TransactionLogger.ts:67:8\n- src/controllers/PaymentController.ts:33:22\n- src/middleware/paymentGuard.ts:18:3\n- tests/payment/PaymentService.test.ts:92:14\n- tests/payment/integration.test.ts:28:9\n- e2e/payment.spec.ts:15:7",
+            },
+            {
+              type: "tool",
+              name: "LSP",
+              stage: "end",
+              compactParams:
+                "hover (src/services/payment/PaymentService.ts:28:15)",
+              parameters: JSON.stringify({
+                operation: "hover",
+                filePath: "src/services/payment/PaymentService.ts",
+                line: 28,
+                character: 15,
+              }),
+              result:
+                "class PaymentService\n\nHandles payment processing with distributed transaction support. Implements optimistic locking and automatic retry logic for concurrent operations.\n\n@Injectable()",
+            },
+            {
+              type: "tool",
+              name: "LSP",
+              stage: "end",
+              compactParams:
+                "incomingCalls (src/repositories/PaymentRepository.ts:12:14)",
+              parameters: JSON.stringify({
+                operation: "incomingCalls",
+                filePath: "src/repositories/PaymentRepository.ts",
+                line: 12,
+                character: 14,
+              }),
+              result:
+                "Callers of findById:\n- PaymentService.processPayment (src/services/payment/PaymentService.ts:45)\n- RefundHandler.processRefund (src/services/payment/RefundHandler.ts:78)\n- TransactionLogger.audit (src/services/payment/TransactionLogger.ts:112)\n- PaymentController.getStatus (src/controllers/PaymentController.ts:55)",
+            },
+          ],
+        },
+      ],
+    });
+    await elementScreenshotWebp(
+      webviewPage.locator(".messages-container"),
+      "../../docs/public/screenshots/spec-lsp.webp",
+    );
+
+    // 25. Skill
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [
+        MockDataGenerator.createUserMessage(
+          "帮我调研一下主流支付网关的方案对比",
+          "msg_user_skill",
+        ),
+        {
+          id: "msg_demo_skill",
+          role: "assistant",
+          blocks: [
+            {
+              type: "tool",
+              name: "Skill",
+              stage: "end",
+              compactParams: "deep-research",
+              parameters: JSON.stringify({ skill_name: "deep-research" }),
+              result:
+                "Research complete: analyzed 15 sources, generated comprehensive report at ./reports/payment-gateway-comparison.md",
+              shortResult: "Invoked skill: deep-research",
+            },
+          ],
+        },
+      ],
+    });
+    await elementScreenshotWebp(
+      webviewPage.locator(".messages-container"),
+      "../../docs/public/screenshots/spec-skill.webp",
+    );
+
+    // 26. MCP
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [
+        MockDataGenerator.createUserMessage(
+          "帮我在 Jira 里查一下进行中的支付相关需求",
+          "msg_user_mcp",
+        ),
+        MockDataGenerator.createAssistantMessageWithTool(
+          "正在通过 MCP 服务器查询 Jira 中的支付相关需求...",
+          "mcp__jira__search_issues",
+          JSON.stringify({
+            jql: 'project = PAY AND status = "In Progress"',
+            maxResults: 5,
+          }),
+          "Found 5 issues: PAY-142 (Optimistic Lock), PAY-138 (Retry Logic), PAY-135 (Webhook), PAY-129 (Refund Flow), PAY-121 (Multi-currency)",
+        ),
+      ],
+    });
+    await elementScreenshotWebp(
+      webviewPage.locator(".messages-container"),
+      "../../docs/public/screenshots/spec-mcp.webp",
+    );
+
+    // 27. Sticky user message (吸顶) — pin the most recent user message scrolled above the viewport top
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [
+        MockDataGenerator.createUserMessage(
+          "帮我分析 PaymentService 的分布式事务实现，看看有没有竞态条件，并给出一个可落地的乐观锁改造方案，覆盖并发退款与重复回调的场景。",
+          "msg_user_sticky",
+        ),
+        MockDataGenerator.createAssistantMessage(
+          "好的，我已通读 `PaymentService`。核心问题在于扣款与状态更新未在同一事务内串行化：\n\n1. 并发退款可能读到同一条 `payment` 行的旧版本，导致重复退款。\n2. 支付网关的重复回调没有幂等键，会触发二次状态跃迁。\n3. 事务隔离级别为 READ COMMITTED，缺少行级版本校验。\n\n建议引入版本号乐观锁：给 `payments` 表增加 `version` 列，更新时带 `WHERE id = ? AND version = ?`，冲突则重试。回调侧以 `gateway_event_id` 建唯一索引实现幂等。",
+          "msg_assistant_sticky_1",
+        ),
+        MockDataGenerator.createUserMessage(
+          "乐观锁重试次数怎么设置？会不会在高并发下一直失败？",
+          "msg_user_sticky_2",
+        ),
+        MockDataGenerator.createAssistantMessage(
+          "建议采用有上限的指数退避重试：初始 20ms，最多重试 3 次，每次翻倍并叠加随机抖动，避免惊群。若 3 次仍冲突则返回 409 让上游决定是否重试。\n\n在实测的 200 QPS 退款压力下，单行冲突率约 4%，三次重试后失败率降到 0.01% 以下，尾延迟 P99 增加约 8ms，属于可接受范围。同时给 `payments(id)` 加覆盖索引减少回表。",
+          "msg_assistant_sticky_2",
+        ),
+        MockDataGenerator.createUserMessage(
+          "那重复回调的幂等键具体怎么设计？",
+          "msg_user_sticky_3",
+        ),
+        MockDataGenerator.createAssistantMessage(
+          "以网关事件 ID 作为幂等键：新增 `payment_events(gateway_event_id UNIQUE, payment_id, status, created_at)`。回调进来先尝试插入该事件，唯一冲突即视为重复回调直接忽略；插入成功再执行状态跃迁。这样即使网关重发，也只会处理一次。整个流程放进同一事务，配合前面的版本号乐观锁，即可同时防住并发退款与重复回调两类竞态。",
+          "msg_assistant_sticky_3",
+        ),
+      ],
+      isAuthenticated: true,
+      configurationData: {
+        apiKey: "sk-ant-api03-CXB9pH2k...mH8wQz",
+        baseURL: "https://api.anthropic.com/v1",
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
+    await webviewPage.waitForSelector(".messages-container");
+    // Scroll so an earlier user message is pushed above the viewport top, triggering the sticky header.
+    await webviewPage.evaluate(() => {
+      const el = document.querySelector(".messages-container") as HTMLElement;
+      el.scrollTop = el.scrollHeight;
+    });
+    await webviewPage.waitForSelector('[data-testid="sticky-user-message"]');
+    await elementScreenshotWebp(
+      webviewPage.locator(".messages-container"),
+      "../../docs/public/screenshots/spec-sticky-user-message.webp",
+    );
+  });
+});

--- a/packages/webview/demo/sdd-plan-preview.demo.ts
+++ b/packages/webview/demo/sdd-plan-preview.demo.ts
@@ -1,0 +1,218 @@
+import { test, expect } from "../e2e/utils/webviewTestHarness.js";
+import { MessageInjector } from "../e2e/utils/messageInjector.js";
+import { EXIT_PLAN_MODE_TOOL_NAME, type Message } from "wave-agent-sdk";
+import { screenshotWebp } from "../e2e/utils/screenshot.js";
+import fs from "fs";
+import path from "path";
+
+const PLAN_CONTENT = `# 客户管理系统（CRM）技术方案
+
+## 1. 项目背景与目标
+
+本系统面向销售团队核心业务场景，旨在解决客户信息分散、跟进过程不可追溯、合同与客户数据割裂等问题。通过统一客户档案、跟进记录、合同管理与数据看板，建立以客户为中心的运营闭环，提升销售转化率与管理效率。
+
+## 2. 需求范围
+
+- 客户档案：客户分级、联系人管理、行为标签
+- 跟进记录：跟进时间线、下次跟进提醒
+- 合同管理：合同关联、到期提醒
+- 数据看板：销售漏斗、转化统计
+- 系统管理：组织架构、角色权限、审计日志
+
+## 3. 技术选型
+
+- 前端框架：React 18 + TypeScript + Vite。选择理由：类型安全、组件生态成熟；对比 Vue 3，React Hooks 更适合复杂状态管理，Vite 冷启动与热更新显著快于 Webpack。
+- 后端框架：Node.js 22 + Fastify。选择理由：与前端统一 TypeScript 技术栈，性能约为 Express 的 2 倍；对比 NestJS，Fastify 更轻量，按需引入校验与插件。
+- 数据库：PostgreSQL 16。选择理由：强事务保障合同与跟进数据一致性，JSONB 支持灵活标签存储，内置全文检索与窗口函数；对比 MySQL，更适合复杂报表查询。
+- 认证授权：JWT + RBAC 角色权限模型。选择理由：无状态、易水平扩展；RBAC 满足销售、主管、管理员分级权限控制。
+
+## 4. 系统架构设计
+
+- 前端：客户档案、跟进记录、合同管理、数据看板四个业务模块，叠加通用组件层（表格、表单、权限指令）
+- 后端：模块化单体（认证、客户、跟进、合同、报表五域），按域拆分代码，便于后续演进微服务
+- 数据流：终端 → API 网关 → 业务服务 → 关系数据库；写操作走事务提交，读操作经查询优化与缓存加速
+- 缓存：Redis 承载会话与热点数据（看板统计、客户列表），失效策略按业务容忍度分级
+
+## 5. 数据模型设计
+
+- customers：客户主数据（id、name、level、owner_id、tags、created_at）
+- customer_contacts：联系人（id、customer_id、name、phone、email）
+- follow_ups：跟进记录（id、customer_id、owner_id、type、content、next_follow_at）
+- contracts：合同（id、customer_id、amount、status、start_date、end_date）
+- users、roles、permissions：组织架构与权限体系
+
+## 6. 接口设计
+
+- GET /api/customers：客户列表（支持分级、标签筛选与分页）
+- POST /api/customers：新建客户（自动触发分级计算）
+- POST /api/follow-ups：新增跟进记录（联动下次提醒）
+- GET /api/dashboard/sales-funnel：销售漏斗统计
+- 统一响应格式 { code, message, data }，错误码分段定义
+
+## 7. 安全设计
+
+- 认证：JWT 短时效 + Refresh Token 轮换；RBAC 按角色校验接口权限
+- 数据安全：客户数据按归属人行级权限过滤，敏感字段加密存储
+- 传输安全：全链路 HTTPS，接口限流与防暴力破解
+- 审计：导出、删除、权限变更等关键操作写入审计日志
+
+## 8. 分阶段实施计划
+
+- 阶段一（第 1-2 周）：工程骨架 + 认证与 RBAC + 客户档案 CRUD
+- 阶段二（第 3-4 周）：跟进时间线与下次提醒
+- 阶段三（第 5 周）：合同管理与到期提醒
+- 阶段四（第 6 周）：数据看板与统计报表
+- 阶段五（第 7 周）：联调、性能优化与上线
+
+## 9. 测试与验收
+
+- 单元测试：分级计算、提醒触发等核心业务规则覆盖率不低于 80%
+- 接口测试：全部 RESTful 接口自动化用例
+- 验收标准：对照规格说明的 12 个验收场景逐条通过，核心页面响应小于 500ms
+
+## 10. 风险与应对
+
+- 客户数据迁移与清洗成本高：提供导入模板与工具，上线前完成字段映射评审
+- 标签规则频繁变化：规则配置化，由管理员后台维护，避免发版
+- 分级口径理解不一致：分级规则在规格中明确约定，并纳入验收场景`;
+
+test.describe("SDD Plan Preview Tab Screenshot", () => {
+  test("capture VS Code plan-preview tab + compact confirmation", async ({
+    webviewPage,
+    context,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+    await webviewPage.setViewportSize({ width: 400, height: 800 });
+
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [],
+      isStreaming: false,
+      sessions: [],
+      configurationData: {
+        apiKey: "sk-ant-api03-CXB9pH2k...mH8wQz",
+        baseURL: "https://api.anthropic.com/v1",
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
+
+    // SDD 流程推进到 plan 阶段：需求 → 规格决策选择「制定技术方案」→ 方案产出
+    const messages: Message[] = [
+      {
+        id: "msg_plan_user",
+        role: "user",
+        timestamp: "2025-07-10T09:00:00.000Z",
+        blocks: [
+          {
+            type: "text",
+            content:
+              "我们想做一个客户管理系统（CRM），核心是客户档案、跟进记录、合同管理和数据看板，帮我按规格优先的流程来推进。",
+          },
+        ],
+      },
+      {
+        id: "msg_plan_spec_ok",
+        role: "user",
+        timestamp: "2025-07-10T09:00:08.000Z",
+        blocks: [
+          {
+            type: "text",
+            content: "规格确认了，进入技术方案模式制定技术方案吧。",
+          },
+        ],
+      },
+      {
+        id: "msg_plan_ready",
+        role: "assistant",
+        timestamp: "2025-07-10T09:00:15.000Z",
+        blocks: [
+          {
+            type: "text",
+            content:
+              "技术方案已制定完成，已在新标签页的计划预览中打开，请审阅后批准。",
+          },
+        ],
+      },
+    ];
+    await injector.updateMessages(messages);
+
+    // ExitPlanMode：方案正文不进入对话 webview（由宿主另开的 plan-preview 面板承载），
+    // 确认框保持紧凑，仅保留批准交互。
+    await injector.simulateExtensionMessage("showConfirmation", {
+      confirmationId: "sdd-plan-preview-approve",
+      confirmationType: "计划执行确认",
+      toolName: EXIT_PLAN_MODE_TOOL_NAME,
+      planContent: PLAN_CONTENT,
+    });
+    const planDialog = webviewPage.locator(".confirmation-dialog");
+    await planDialog.waitFor({ state: "visible" });
+    // 紧凑确认框：批准按钮在，方案正文不在
+    await expect(planDialog).toContainText("批准并继续");
+    await expect(planDialog).not.toContainText("技术选型");
+
+    // 计划预览「新标签页」：镜像 webviewManager.getPlanPreviewContent 渲染的
+    // wavePlanPreview WebviewPanel（ViewColumn.Beside 打开）——同一份
+    // chat.css + plan-preview.js，宿主 postMessage({command:"planPreview"}) 注入正文。
+    const planPage = await context.newPage();
+    await planPage.setViewportSize({ width: 560, height: 760 });
+    const themeCss = fs.readFileSync(
+      path.join(process.cwd(), "theme", "theme-base-dark.css"),
+      "utf8",
+    );
+    const chatCss = fs.readFileSync(
+      path.join(process.cwd(), "dist", "chat.css"),
+      "utf8",
+    );
+    const planPreviewJs = fs.readFileSync(
+      path.join(process.cwd(), "dist", "plan-preview.js"),
+      "utf8",
+    );
+    await planPage.setContent(`<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <title>计划预览</title>
+    <style>${themeCss}</style>
+    <style>${chatCss}</style>
+    <style>
+      body { margin: 0; background: var(--vscode-editor-background); color: var(--vscode-editor-foreground); font-family: var(--vscode-font-family); }
+      .tab-strip { display: flex; height: 42px; flex-shrink: 0; background: var(--vscode-editorGroupHeader-tabsBackground, #252526); border-bottom: 1px solid var(--vscode-tab-border, #454545); padding: 0 8px; }
+      .tab { display: flex; align-items: center; padding: 0 14px; font-size: 13px; line-height: 1.4; }
+      .tab.active { background: var(--vscode-tab-activeBackground, #1e1e1e); color: var(--vscode-tab-activeForeground, #ffffff); border-top: 1px solid var(--vscode-tab-activeBorderTop, #007fd4); }
+      .plan-body { padding: 16px; }
+      #plan-preview h1 { font-size: 1.4em; }
+    </style>
+</head>
+<body>
+    <div class="tab-strip">
+      <div class="tab active">计划预览</div>
+    </div>
+    <div class="plan-body"><div id="plan-preview" class="markdown-body"></div></div>
+    <script>${planPreviewJs}</script>
+</body>
+</html>`);
+    await planPage.evaluate((content) => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { command: "planPreview", content },
+        }),
+      );
+    }, PLAN_CONTENT);
+    await expect(planPage.locator("#plan-preview")).toContainText(
+      "客户管理系统（CRM）技术方案",
+    );
+    await expect(planPage.locator("#plan-preview")).toContainText("技术选型");
+    await expect(planPage.locator("#plan-preview")).toContainText("风险与应对");
+    await screenshotWebp(
+      planPage,
+      "../../docs/public/screenshots/spec-sdd-plan-preview-tab.webp",
+    );
+    await planPage.close();
+
+    // 对话 webview 中的紧凑确认框（批准交互）由 sdd-workflow.demo.ts 的
+    // spec-sdd-plan-approve.webp 覆盖，这里仅验证后关闭。
+    await webviewPage.keyboard.press("Escape");
+    await planDialog.waitFor({ state: "detached" });
+  });
+});

--- a/packages/webview/demo/sdd-plugin.demo.ts
+++ b/packages/webview/demo/sdd-plugin.demo.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "../e2e/utils/desktopTestHarness.js";
+import { MessageInjector } from "../e2e/utils/messageInjector.js";
+import { MockDataGenerator } from "../e2e/fixtures/mockData.js";
+import { screenshotWebp } from "../e2e/utils/screenshot.js";
+
+/**
+ * Built-in SDD plugin toggle in the settings page 项目设置 view (spec
+ * builtin-sdd-plugin.md 按需启用内置插件 + desktop-app.md 设置页场景 11).
+ * The shared webview bundle must be rebuilt first (node esbuild.config.mjs)
+ * or these shots capture the old UI.
+ */
+const DIR_A = "/Users/dev/projects/wave-agent";
+
+const initialState = {
+  messages: [],
+  isStreaming: false,
+  sessions: [],
+  isAuthenticated: true,
+  configurationData: {
+    baseURL: "https://api.anthropic.com/v1",
+    model: "claude-sonnet-4-20250514",
+    fastModel: "claude-haiku-4-20250514",
+  },
+  permissionMode: "default",
+};
+
+test.describe("Built-in SDD Plugin Demo", () => {
+  test("should show SDD builtin plugin toggle in settings project view", async ({
+    webviewPage,
+  }) => {
+    await webviewPage.setViewportSize({ width: 1000, height: 720 });
+    const injector = new MessageInjector(webviewPage);
+
+    await injector.simulateExtensionMessage("desktopWorkdirState", {
+      workdir: DIR_A,
+      recentWorkdirs: [DIR_A],
+    });
+    await injector.waitForChatAppReady();
+    await injector.simulateExtensionMessage("setInitialState", initialState);
+    await injector.updateMessages([
+      MockDataGenerator.createUserMessage("帮我修复登录页的样式问题", "msg-u1"),
+      MockDataGenerator.createAssistantMessage(
+        "我先看一下登录页组件的样式文件，找出对齐问题的原因。",
+        "msg-a1",
+      ),
+    ]);
+
+    // 账户卡片（设置页入口）依赖 host 下发账户信息。
+    await injector.simulateExtensionMessage("desktopAccountInfo", {
+      isAuthenticated: true,
+      user: { id: "user-1", email: "alice@example.com" },
+      plan: { monthlyQuota: 100, months: 12, used: 240 },
+      apiQuota: { limit: null, used: 1153.14 },
+      update: undefined,
+    });
+
+    // 打开设置页 → 「项目设置」视图。
+    await webviewPage.getByTestId("account-card-more").click();
+    await webviewPage.getByTestId("more-menu-settings").click();
+    await expect(
+      webviewPage.getByRole("heading", { name: "全局设置" }),
+    ).toBeVisible();
+    await webviewPage.getByRole("button", { name: "项目设置" }).click();
+    await expect(
+      webviewPage.getByRole("heading", { name: "项目设置" }),
+    ).toBeVisible();
+
+    // Host 回发项目设置（sdd@builtin 已启用）→ 开关为勾选态。
+    await injector.simulateExtensionMessage("projectSettings", {
+      enabledPlugins: { "sdd@builtin": true },
+    });
+    const sddToggle = webviewPage.getByLabel("启用 SDD 插件");
+    await expect(sddToggle).toBeChecked();
+    await expect(webviewPage.getByText("SDD（规格驱动开发）")).toBeVisible();
+
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-sdd-plugin.webp",
+    );
+  });
+});

--- a/packages/webview/demo/sdd-workflow-iterate.demo.ts
+++ b/packages/webview/demo/sdd-workflow-iterate.demo.ts
@@ -1,0 +1,241 @@
+import { test, expect } from "../e2e/utils/webviewTestHarness.js";
+import { MessageInjector } from "../e2e/utils/messageInjector.js";
+import {
+  ASK_USER_QUESTION_TOOL_NAME,
+  EDIT_TOOL_NAME,
+  type Message,
+  type Task,
+} from "wave-agent-sdk";
+import {
+  screenshotWebp,
+  elementScreenshotWebp,
+} from "../e2e/utils/screenshot.js";
+
+test.describe("SDD Workflow Iterate Screenshots", () => {
+  test("capture iterating-an-existing-spec stages with mock data", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+    await webviewPage.setViewportSize({ width: 400, height: 800 });
+
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [],
+      isStreaming: false,
+      sessions: [],
+      configurationData: {
+        apiKey: "sk-ant-api03-CXB9pH2k...mH8wQz",
+        baseURL: "https://api.anthropic.com/v1",
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
+
+    // ---- Stage 1: updating the existing spec ----
+    const userMessage: Message = {
+      id: "msg_sdd_iterate_user",
+      role: "user",
+      timestamp: "2025-07-10T10:00:00.000Z",
+      blocks: [
+        {
+          type: "text",
+          content:
+            "我们已有客户管理系统（CRM）的规格说明 `docs/specs/crm/customer-management.md`（4 个用户故事、12 个验收场景）。现在想新增一个客户自动分级的功能：根据跟进频率和合同金额自动计算客户等级；另外把客户档案的标签从手动维护改成根据行为自动生成。",
+        },
+      ],
+    };
+    const specUpdateReply: Message = {
+      id: "msg_sdd_iterate_spec",
+      role: "assistant",
+      timestamp: "2025-07-10T10:00:02.000Z",
+      blocks: [
+        {
+          type: "text",
+          content:
+            "好的，我更新既有规格 `docs/specs/crm/customer-management.md`。\n\n**本次变更：**\n- 新增用户故事：客户自动分级（按跟进频率、合同金额自动计算客户等级）\n- 修改用户故事：客户档案标签由手动维护改为行为自动生成\n\n更新后共 5 个用户故事、15 个验收场景，稍后请你确认。",
+        },
+      ],
+    };
+    // 更新规格文件的 Edit 工具卡：消息列表内联展示修改 diff
+    const editSpecMsg: Message = {
+      id: "msg_sdd_iterate_edit",
+      role: "assistant",
+      timestamp: "2025-07-10T10:00:03.000Z",
+      blocks: [
+        {
+          type: "tool",
+          name: EDIT_TOOL_NAME,
+          stage: "end",
+          compactParams: "docs/specs/crm/customer-management.md",
+          parameters: JSON.stringify({
+            file_path: "docs/specs/crm/customer-management.md",
+            old_string:
+              "## 用户故事\n\n- P1 客户档案管理：作为销售，我希望维护客户档案（标签手动维护），以便集中管理客户信息\n- P2 跟进记录：作为销售，我希望记录跟进时间线，以便掌握客户沟通进展\n- P2 合同管理：作为销售，我希望管理合同信息，以便跟踪合同状态\n- P2 数据看板：作为管理者，我希望查看销售漏斗，以便了解转化情况",
+            new_string:
+              "## 用户故事\n\n- P1 客户档案管理：作为销售，我希望维护客户档案（标签按客户行为自动生成），以便集中管理客户信息\n- P1 客户自动分级：作为销售，我希望系统按跟进频率和合同金额自动计算客户等级，以便优先服务高价值客户\n- P2 跟进记录：作为销售，我希望记录跟进时间线，以便掌握客户沟通进展\n- P2 合同管理：作为销售，我希望管理合同信息，以便跟踪合同状态\n- P2 数据看板：作为管理者，我希望查看销售漏斗，以便了解转化情况",
+          }),
+          result: "Text replaced successfully",
+        },
+      ],
+    };
+    await injector.updateMessages([userMessage, specUpdateReply, editSpecMsg]);
+    await expect(
+      webviewPage.locator(".tool-container", {
+        hasText: "customer-management.md",
+      }),
+    ).toBeVisible();
+
+    // 任务列表：规格更新进行中
+    await injector.simulateExtensionMessage("updateTasks", {
+      tasks: [
+        {
+          id: "1",
+          subject: "更新功能规格",
+          description:
+            "更新客户管理系统的功能规格说明（新增客户自动分级、调整标签规则）",
+          status: "in_progress",
+          blocks: [],
+          blockedBy: [],
+          metadata: {},
+        },
+      ],
+    });
+    await expect(webviewPage.getByTestId("task-list")).toBeVisible();
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-sdd-iterate-update.webp",
+    );
+
+    // ---- Stage 2: spec confirmation via AskUserQuestion ----
+    const confirmMsg: Message = {
+      id: "msg_sdd_iterate_confirm",
+      role: "assistant",
+      timestamp: "2025-07-10T10:00:05.000Z",
+      blocks: [
+        {
+          type: "tool",
+          name: ASK_USER_QUESTION_TOOL_NAME,
+          stage: "running",
+          parameters: JSON.stringify({
+            questions: [
+              {
+                header: "规格确认",
+                question:
+                  "已更新《客户管理系统》规格：新增「客户自动分级」用户故事、修改「标签自动生成」描述（现共 5 个用户故事、15 个验收场景），请选择后续流程（如需调整规格，选「其他」并输入修改意见）：",
+                options: [
+                  {
+                    label: "直接实现",
+                    description: "跳过技术方案，直接开始编码",
+                  },
+                  {
+                    label: "制定技术方案",
+                    description: "制定技术选型、架构设计与实现步骤后请你批准",
+                  },
+                ],
+              },
+            ],
+          }),
+        },
+      ],
+    };
+    await injector.updateMessages([
+      userMessage,
+      specUpdateReply,
+      editSpecMsg,
+      confirmMsg,
+    ]);
+    await injector.simulateExtensionMessage("showConfirmation", {
+      confirmationId: "sdd-iterate-confirm",
+      toolName: ASK_USER_QUESTION_TOOL_NAME,
+      confirmationType: "问题待回答",
+      toolInput: {
+        questions: [
+          {
+            header: "规格确认",
+            question:
+              "已更新《客户管理系统》规格：新增「客户自动分级」用户故事、修改「标签自动生成」描述（现共 5 个用户故事、15 个验收场景），请选择后续流程（如需调整规格，选「其他」并输入修改意见）：",
+            options: [
+              {
+                label: "直接实现",
+                description: "跳过技术方案，直接开始编码",
+              },
+              {
+                label: "制定技术方案",
+                description: "制定技术选型、架构设计与实现步骤后请你批准",
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const specDialog = webviewPage.locator(".confirmation-dialog");
+    await specDialog.waitFor({ state: "visible" });
+    await elementScreenshotWebp(
+      specDialog,
+      "../../docs/public/screenshots/spec-sdd-iterate-confirm.webp",
+    );
+    await webviewPage.keyboard.press("Escape");
+    await specDialog.waitFor({ state: "detached" });
+
+    // ---- Stage 3: re-enter implementation after confirmation ----
+    const confirmUserMessage: Message = {
+      id: "msg_sdd_iterate_confirm_user",
+      role: "user",
+      timestamp: "2025-07-10T10:00:08.000Z",
+      blocks: [
+        {
+          type: "text",
+          content: "直接实现，开始吧。",
+        },
+      ],
+    };
+    const codingReply: Message = {
+      id: "msg_sdd_iterate_coding",
+      role: "assistant",
+      timestamp: "2025-07-10T10:00:20.000Z",
+      blocks: [
+        {
+          type: "text",
+          content:
+            "规格已确认。按更新后的规格开始实现：先做客户自动分级（等级计算规则 + 分级结果展示），再把客户档案的标签改为行为自动生成。",
+        },
+      ],
+    };
+    await injector.updateMessages([
+      userMessage,
+      specUpdateReply,
+      editSpecMsg,
+      confirmUserMessage,
+      codingReply,
+    ]);
+    const stageTasks: Task[] = [
+      {
+        id: "1",
+        subject: "更新功能规格",
+        description:
+          "更新客户管理系统的功能规格说明（新增客户自动分级、调整标签规则）",
+        status: "completed",
+        blocks: [],
+        blockedBy: [],
+        metadata: {},
+      },
+      {
+        id: "2",
+        subject: "实现变更",
+        description: "按更新后的规格实现客户自动分级与标签自动生成",
+        status: "in_progress",
+        blocks: [],
+        blockedBy: [],
+        metadata: {},
+      },
+    ];
+    await injector.simulateExtensionMessage("updateTasks", {
+      tasks: stageTasks,
+    });
+    await expect(webviewPage.getByTestId("task-list")).toBeVisible();
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-sdd-iterate-continue.webp",
+    );
+  });
+});

--- a/packages/webview/demo/sdd-workflow.demo.ts
+++ b/packages/webview/demo/sdd-workflow.demo.ts
@@ -1,0 +1,343 @@
+import { test, expect } from "../e2e/utils/webviewTestHarness.js";
+import { MessageInjector } from "../e2e/utils/messageInjector.js";
+import {
+  ASK_USER_QUESTION_TOOL_NAME,
+  EXIT_PLAN_MODE_TOOL_NAME,
+  WRITE_TOOL_NAME,
+  type Message,
+  type Task,
+} from "wave-agent-sdk";
+import {
+  screenshotWebp,
+  elementScreenshotWebp,
+} from "../e2e/utils/screenshot.js";
+
+test.describe("SDD Workflow Screenshots", () => {
+  test("capture spec-first workflow stages with mock data", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+    await webviewPage.setViewportSize({ width: 400, height: 800 });
+
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [],
+      isStreaming: false,
+      sessions: [],
+      configurationData: {
+        apiKey: "sk-ant-api03-CXB9pH2k...mH8wQz",
+        baseURL: "https://api.anthropic.com/v1",
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
+
+    // ---- Stage 1: specification writing ----
+    const userMessage: Message = {
+      id: "msg_sdd_user",
+      role: "user",
+      timestamp: "2025-07-10T09:00:00.000Z",
+      blocks: [
+        {
+          type: "text",
+          content:
+            "我们想做一个客户管理系统（CRM），核心是客户档案、跟进记录、合同管理和数据看板，帮我按规格优先的流程来推进。",
+        },
+      ],
+    };
+    const specReply: Message = {
+      id: "msg_sdd_spec",
+      role: "assistant",
+      timestamp: "2025-07-10T09:00:02.000Z",
+      blocks: [
+        {
+          type: "text",
+          content:
+            "好的，我先编写功能规格说明 `docs/specs/crm/customer-management.md`。\n\n**核心模块：**\n- 客户档案：分级管理、联系人、标签\n- 跟进记录：时间线、下次跟进提醒\n- 合同管理：合同关联、到期提醒\n- 数据看板：销售漏斗、转化统计\n\n规格共 4 个用户故事、12 个验收场景，稍后请你确认。",
+        },
+      ],
+    };
+    // 编写规格文件的 Write 工具卡：消息列表展示写入的文件内容预览
+    const writeSpecMsg: Message = {
+      id: "msg_sdd_write_spec",
+      role: "assistant",
+      timestamp: "2025-07-10T09:00:03.000Z",
+      blocks: [
+        {
+          type: "tool",
+          name: WRITE_TOOL_NAME,
+          stage: "end",
+          compactParams:
+            "docs/specs/crm/customer-management.md 19 lines, 380 chars",
+          parameters: JSON.stringify({
+            file_path: "docs/specs/crm/customer-management.md",
+            content: `---
+name: 客户管理系统
+description: 客户档案、跟进记录、合同管理与数据看板的统一规格说明
+order: 1
+---
+
+# 客户管理系统功能规格
+
+## 用户场景与测试
+
+- P1 客户档案管理：作为销售，我希望维护客户档案，以便集中管理客户信息
+- P1 跟进记录：作为销售，我希望记录跟进时间线，以便掌握客户沟通进展
+- P2 合同管理：作为销售，我希望管理合同信息，以便跟踪合同状态
+- P2 数据看板：作为管理者，我希望查看销售漏斗，以便了解转化情况`,
+          }),
+          result: "File created (19 lines, 380 characters)",
+          shortResult: "File created (19 lines, 380 characters)",
+        },
+      ],
+    };
+    await injector.updateMessages([userMessage, specReply, writeSpecMsg]);
+    await expect(webviewPage.locator(".write-preview-box")).toBeVisible();
+
+    // 任务列表：规格编写进行中
+    await injector.simulateExtensionMessage("updateTasks", {
+      tasks: [
+        {
+          id: "1",
+          subject: "编写功能规格",
+          description: "编写客户管理系统的功能规格说明",
+          status: "in_progress",
+          blocks: [],
+          blockedBy: [],
+          metadata: {},
+        },
+      ],
+    });
+    await expect(webviewPage.getByTestId("task-list")).toBeVisible();
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-sdd-workflow-spec.webp",
+    );
+
+    // ---- Stage 2: spec confirmation via AskUserQuestion ----
+    const confirmMsg: Message = {
+      id: "msg_sdd_confirm",
+      role: "assistant",
+      timestamp: "2025-07-10T09:00:05.000Z",
+      blocks: [
+        {
+          type: "tool",
+          name: ASK_USER_QUESTION_TOOL_NAME,
+          stage: "running",
+          parameters: JSON.stringify({
+            questions: [
+              {
+                header: "规格确认",
+                question:
+                  "功能规格《客户管理系统》已完成（4 个用户故事、12 个验收场景），请选择后续流程（如需调整规格，选「其他」并输入修改意见）：",
+                options: [
+                  {
+                    label: "直接实现",
+                    description: "跳过技术方案，直接开始编码",
+                  },
+                  {
+                    label: "制定技术方案",
+                    description: "制定技术选型、架构设计与实现步骤后请你批准",
+                  },
+                ],
+              },
+            ],
+          }),
+        },
+      ],
+    };
+    await injector.updateMessages([
+      userMessage,
+      specReply,
+      writeSpecMsg,
+      confirmMsg,
+    ]);
+    await injector.simulateExtensionMessage("showConfirmation", {
+      confirmationId: "sdd-confirm-spec",
+      toolName: ASK_USER_QUESTION_TOOL_NAME,
+      confirmationType: "问题待回答",
+      toolInput: {
+        questions: [
+          {
+            header: "规格确认",
+            question:
+              "功能规格《客户管理系统》已完成（4 个用户故事、12 个验收场景），请选择后续流程（如需调整规格，选「其他」并输入修改意见）：",
+            options: [
+              {
+                label: "直接实现",
+                description: "跳过技术方案，直接开始编码",
+              },
+              {
+                label: "制定技术方案",
+                description: "制定技术选型、架构设计与实现步骤后请你批准",
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const specDialog = webviewPage.locator(".confirmation-dialog");
+    await specDialog.waitFor({ state: "visible" });
+    await elementScreenshotWebp(
+      specDialog,
+      "../../docs/public/screenshots/spec-sdd-confirm-spec.webp",
+    );
+    await webviewPage.keyboard.press("Escape");
+    await specDialog.waitFor({ state: "detached" });
+
+    // ---- Stage 3: plan approval (ExitPlanMode) ----
+
+    await injector.simulateExtensionMessage("showConfirmation", {
+      confirmationId: "sdd-plan-approve",
+      confirmationType: "计划执行确认",
+      toolName: EXIT_PLAN_MODE_TOOL_NAME,
+      planContent: `# 客户管理系统（CRM）技术方案
+
+## 1. 项目背景与目标
+
+本系统面向销售团队核心业务场景，旨在解决客户信息分散、跟进过程不可追溯、合同与客户数据割裂等问题。通过统一客户档案、跟进记录、合同管理与数据看板，建立以客户为中心的运营闭环，提升销售转化率与管理效率。
+
+## 2. 需求范围
+
+- 客户档案：客户分级、联系人管理、行为标签
+- 跟进记录：跟进时间线、下次跟进提醒
+- 合同管理：合同关联、到期提醒
+- 数据看板：销售漏斗、转化统计
+- 系统管理：组织架构、角色权限、审计日志
+
+## 3. 技术选型
+
+- 前端框架：React 18 + TypeScript + Vite。选择理由：类型安全、组件生态成熟；对比 Vue 3，React Hooks 更适合复杂状态管理，Vite 冷启动与热更新显著快于 Webpack。
+- 后端框架：Node.js 22 + Fastify。选择理由：与前端统一 TypeScript 技术栈，性能约为 Express 的 2 倍；对比 NestJS，Fastify 更轻量，按需引入校验与插件。
+- 数据库：PostgreSQL 16。选择理由：强事务保障合同与跟进数据一致性，JSONB 支持灵活标签存储，内置全文检索与窗口函数；对比 MySQL，更适合复杂报表查询。
+- 认证授权：JWT + RBAC 角色权限模型。选择理由：无状态、易水平扩展；RBAC 满足销售、主管、管理员分级权限控制。
+
+## 4. 系统架构设计
+
+- 前端：客户档案、跟进记录、合同管理、数据看板四个业务模块，叠加通用组件层（表格、表单、权限指令）
+- 后端：模块化单体（认证、客户、跟进、合同、报表五域），按域拆分代码，便于后续演进微服务
+- 数据流：终端 → API 网关 → 业务服务 → 关系数据库；写操作走事务提交，读操作经查询优化与缓存加速
+- 缓存：Redis 承载会话与热点数据（看板统计、客户列表），失效策略按业务容忍度分级
+
+## 5. 数据模型设计
+
+- customers：客户主数据（id、name、level、owner_id、tags、created_at）
+- customer_contacts：联系人（id、customer_id、name、phone、email）
+- follow_ups：跟进记录（id、customer_id、owner_id、type、content、next_follow_at）
+- contracts：合同（id、customer_id、amount、status、start_date、end_date）
+- users、roles、permissions：组织架构与权限体系
+
+## 6. 接口设计
+
+- GET /api/customers：客户列表（支持分级、标签筛选与分页）
+- POST /api/customers：新建客户（自动触发分级计算）
+- POST /api/follow-ups：新增跟进记录（联动下次提醒）
+- GET /api/dashboard/sales-funnel：销售漏斗统计
+- 统一响应格式 { code, message, data }，错误码分段定义
+
+## 7. 安全设计
+
+- 认证：JWT 短时效 + Refresh Token 轮换；RBAC 按角色校验接口权限
+- 数据安全：客户数据按归属人行级权限过滤，敏感字段加密存储
+- 传输安全：全链路 HTTPS，接口限流与防暴力破解
+- 审计：导出、删除、权限变更等关键操作写入审计日志
+
+## 8. 分阶段实施计划
+
+- 阶段一（第 1-2 周）：工程骨架 + 认证与 RBAC + 客户档案 CRUD
+- 阶段二（第 3-4 周）：跟进时间线与下次提醒
+- 阶段三（第 5 周）：合同管理与到期提醒
+- 阶段四（第 6 周）：数据看板与统计报表
+- 阶段五（第 7 周）：联调、性能优化与上线
+
+## 9. 测试与验收
+
+- 单元测试：分级计算、提醒触发等核心业务规则覆盖率不低于 80%
+- 接口测试：全部 RESTful 接口自动化用例
+- 验收标准：对照规格说明的 12 个验收场景逐条通过，核心页面响应小于 500ms
+
+## 10. 风险与应对
+
+- 客户数据迁移与清洗成本高：提供导入模板与工具，上线前完成字段映射评审
+- 标签规则频繁变化：规则配置化，由管理员后台维护，避免发版
+- 分级口径理解不一致：分级规则在规格中明确约定，并纳入验收场景`,
+    });
+    const planApproveDialog = webviewPage.locator(".confirmation-dialog");
+    await planApproveDialog.waitFor({ state: "visible" });
+    await elementScreenshotWebp(
+      planApproveDialog,
+      "../../docs/public/screenshots/spec-sdd-plan-approve.webp",
+    );
+    await webviewPage.keyboard.press("Escape");
+    await planApproveDialog.waitFor({ state: "detached" });
+
+    // ---- Stage 4: coding stage with full task progress ----
+    const codingReply: Message = {
+      id: "msg_sdd_coding",
+      role: "assistant",
+      timestamp: "2025-07-10T09:00:20.000Z",
+      blocks: [
+        {
+          type: "text",
+          content:
+            "技术方案已批准，开始编码。先搭建前后端工程骨架，然后按模块依次实现：客户档案 → 跟进记录 → 合同管理 → 数据看板。",
+        },
+      ],
+    };
+    const codeUserMessage: Message = {
+      id: "msg_sdd_code_user",
+      role: "user",
+      timestamp: "2025-07-10T09:00:18.000Z",
+      blocks: [
+        {
+          type: "text",
+          content: "规格和技术方案都确认了，开始实现吧。",
+        },
+      ],
+    };
+    await injector.updateMessages([
+      userMessage,
+      specReply,
+      writeSpecMsg,
+      codeUserMessage,
+      codingReply,
+    ]);
+    const stageTasks: Task[] = [
+      {
+        id: "1",
+        subject: "编写功能规格",
+        description: "编写客户管理系统的功能规格说明",
+        status: "completed",
+        blocks: [],
+        blockedBy: [],
+        metadata: {},
+      },
+      {
+        id: "2",
+        subject: "制定技术方案",
+        description: "技术选型、架构设计与实现步骤",
+        status: "completed",
+        blocks: [],
+        blockedBy: [],
+        metadata: {},
+      },
+      {
+        id: "3",
+        subject: "实现功能",
+        description: "按规格与方案实现客户管理系统",
+        status: "in_progress",
+        blocks: [],
+        blockedBy: [],
+        metadata: {},
+      },
+    ];
+    await injector.simulateExtensionMessage("updateTasks", {
+      tasks: stageTasks,
+    });
+    await expect(webviewPage.getByTestId("task-list")).toBeVisible();
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/spec-sdd-tasklist-progress.webp",
+    );
+  });
+});

--- a/packages/webview/demo/settings-manage.demo.ts
+++ b/packages/webview/demo/settings-manage.demo.ts
@@ -1,0 +1,216 @@
+import type { Page } from "@playwright/test";
+import { test, expect } from "../e2e/utils/webviewTestHarness.js";
+import { elementScreenshotWebp } from "../e2e/utils/screenshot.js";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * 设置页「钩子」「MCP 服务」选项卡 demo（/hooks、/mcp 斜杠命令落地页）：
+ * 独立加载 settings.js bundle（settings-preview-entry），模拟 host 下发
+ * settingsState(nav) 选中选项卡，再回 hooksResponse / mcpServersResponse +
+ * mcpConfigPathsResponse 展示来源 Tab 列表、钩子事件摘要与 MCP 连接状态。
+ */
+
+// SettingsPage 的颜色全部走 --vscode-* 变量，独立 settings.html 没有宿主注入，
+// 必须手动带上深色主题变量集，否则截图为白底浅色（实测 2026-08-29）。
+const themeStyles = fs.readFileSync(
+  path.join(process.cwd(), "theme", "theme-base-dark.css"),
+  "utf8",
+);
+
+const mockVscodeApiJs = `
+    window.process = { env: { NODE_ENV: 'production' } };
+    window.acquireVsCodeApi = () => ({
+        postMessage: (message) => {
+            if (!window.testMessages) window.testMessages = [];
+            window.testMessages.push(message);
+        },
+        setState: () => {},
+        getState: () => ({})
+    });
+    window.simulateExtensionMessage = (message) => {
+        window.dispatchEvent(new MessageEvent('message', { data: message }));
+    };
+`;
+
+const settingsHtml = `
+<!DOCTYPE html>
+<html lang="zh-CN" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wave Settings</title>
+    <style>${themeStyles}</style>
+    <link rel="stylesheet" href="vscode-webview://mock-extension-id/settings.css">
+</head>
+<body>
+    <div id="root"></div>
+    <script>${mockVscodeApiJs}</script>
+    <script src="vscode-webview://mock-extension-id/settings.js"></script>
+</body>
+</html>`;
+
+/** 打开设置页 + 初始化配置（settings entry 挂载时会请求 getConfiguration） */
+async function openSettings(webviewPage: Page, nav: string) {
+  await webviewPage.setViewportSize({ width: 1000, height: 760 });
+  await webviewPage.setContent(settingsHtml);
+  await expect(webviewPage.locator(".settings-page")).toBeVisible();
+  await webviewPage.evaluate((targetNav) => {
+    window.simulateExtensionMessage({
+      command: "settingsState",
+      workdir: "/work/wave-agent",
+      nav: targetNav,
+    });
+    window.simulateExtensionMessage({
+      command: "configurationResponse",
+      configurationData: { language: "zh-CN", contextLength: 200 },
+    });
+  }, nav);
+}
+
+const userHooks = {
+  PreToolUse: [
+    {
+      matcher: "Write",
+      hooks: [{ type: "command", command: "node scripts/lint-check.js" }],
+    },
+    {
+      matcher: "Read",
+      hooks: [
+        {
+          type: "command",
+          command: "node scripts/audit-read.js --scope=$FILE",
+        },
+      ],
+    },
+  ],
+  SessionStart: [
+    {
+      hooks: [
+        {
+          type: "command",
+          command: "node scripts/load-project-context.js",
+          timeout: 30,
+        },
+      ],
+    },
+  ],
+};
+
+test.describe("设置页钩子选项卡 Demo", () => {
+  test("should show hook entries with event summary and actions", async ({
+    webviewPage,
+  }) => {
+    await openSettings(webviewPage, "hooks");
+
+    // 等视图挂载（发出 getHooksByScope 请求）后再回数据，避免响应先于 listener
+    await expect(webviewPage.getByText("新增钩子")).toBeVisible();
+    await webviewPage.evaluate((hooks) => {
+      window.simulateExtensionMessage({
+        command: "hooksResponse",
+        hooks,
+        configPath: "~/.wave/settings.json",
+      });
+    }, userHooks);
+
+    // 3 source tabs + 钩子条目、事件摘要与命令
+    await expect(webviewPage.getByText("用户级钩子")).toBeVisible();
+    await expect(webviewPage.getByText("项目级钩子")).toBeVisible();
+    await expect(webviewPage.getByText("插件钩子")).toBeVisible();
+    await expect(webviewPage.getByText("PreToolUse:Write")).toBeVisible();
+    await expect(webviewPage.getByText("工具执行前").first()).toBeVisible();
+    await expect(webviewPage.getByText("新会话启动时").first()).toBeVisible();
+    await expect(
+      webviewPage.getByText("node scripts/load-project-context.js"),
+    ).toBeVisible();
+
+    const view = webviewPage.locator(".settings-page");
+    await elementScreenshotWebp(
+      view,
+      "../../docs/public/screenshots/spec-hooks-list.webp",
+    );
+  });
+});
+
+const mcpServers = [
+  {
+    name: "jira",
+    scope: "user",
+    config: {
+      command: "npx",
+      args: ["-y", "@mcp/server-jira"],
+      env: { JIRA_API_TOKEN: "your-token-here" },
+    },
+    status: "connected",
+    toolCount: 8,
+    capabilities: ["tools"],
+    lastConnected: Date.now() - 60000,
+  },
+  {
+    name: "github",
+    scope: "user",
+    config: {
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-github"],
+    },
+    status: "disconnected",
+    toolCount: 0,
+    capabilities: [],
+  },
+  {
+    name: "sentry",
+    scope: "user",
+    config: { url: "https://mcp.sentry.io/sse" },
+    status: "error",
+    toolCount: 0,
+    error: "Authentication failed: invalid token",
+    capabilities: [],
+  },
+];
+
+test.describe("设置页 MCP 服务选项卡 Demo", () => {
+  test("should show MCP servers by scope with connection status", async ({
+    webviewPage,
+  }) => {
+    await openSettings(webviewPage, "mcp");
+
+    // 等视图挂载（发出 getMcpServers / getMcpConfigPaths 请求）后再回数据
+    await expect(webviewPage.getByText("新增用户级 MCP 服务")).toBeVisible();
+    await webviewPage.evaluate((servers) => {
+      window.simulateExtensionMessage({
+        command: "mcpServersResponse",
+        servers,
+      });
+      window.simulateExtensionMessage({
+        command: "mcpConfigPathsResponse",
+        userPath: "~/.wave/mcp.json",
+        projectPath: null,
+      });
+    }, mcpServers);
+
+    // 3 source tabs + 服务器连接状态
+    await expect(
+      webviewPage.getByRole("tab", { name: "用户级 MCP" }),
+    ).toBeVisible();
+    await expect(
+      webviewPage.getByRole("tab", { name: "项目级 MCP" }),
+    ).toBeVisible();
+    await expect(
+      webviewPage.getByRole("tab", { name: "插件 MCP" }),
+    ).toBeVisible();
+    await expect(webviewPage.getByText("jira", { exact: true })).toBeVisible();
+    await expect(webviewPage.getByText("8 tools")).toBeVisible();
+    await expect(
+      webviewPage.getByRole("button", { name: "连接" }).first(),
+    ).toBeVisible();
+    await expect(
+      webviewPage.getByText("Authentication failed: invalid token"),
+    ).toBeVisible();
+
+    const view = webviewPage.locator(".settings-page");
+    await elementScreenshotWebp(
+      view,
+      "../../docs/public/screenshots/spec-mcp-settings.webp",
+    );
+  });
+});

--- a/packages/webview/demo/sidebarSeed.ts
+++ b/packages/webview/demo/sidebarSeed.ts
@@ -1,0 +1,48 @@
+import type { MessageInjector } from "../e2e/utils/messageInjector.js";
+
+/**
+ * Sidebar session-tree seeding for desktop screenshots.
+ *
+ * The desktop host pushes `desktopSessionTree` to fill the sidebar session
+ * list; screenshots that show a conversation list without it render an empty
+ * sidebar ("太假"). Call after `desktopWorkdirState` + `waitForChatAppReady`
+ * (DesktopApp's message listener must be live) and before screenshots.
+ * Demo-specific titles keep the list matching each workdir/context.
+ */
+
+export interface SeedSession {
+  sessionId: string;
+  title: string;
+  running?: boolean;
+  waitingConfirmation?: boolean;
+  hasWorktree?: boolean;
+  /** Optional override; default = fixed demo clock, newest first. */
+  lastActiveAt?: number;
+}
+
+// Fixed demo clock so screenshots are deterministic (newest session first).
+const DEMO_CLOCK = 1782000000000;
+
+export async function seedSidebarSessions(
+  injector: MessageInjector,
+  workdir: string,
+  sessions: SeedSession[],
+  host = "local",
+): Promise<void> {
+  await injector.simulateExtensionMessage("desktopSessionTree", {
+    groups: [
+      {
+        host,
+        workdir,
+        sessions: sessions.map((s, i) => ({
+          sessionId: s.sessionId,
+          title: s.title,
+          lastActiveAt: s.lastActiveAt ?? DEMO_CLOCK - i * 60_000,
+          hasWorktree: s.hasWorktree ?? false,
+          running: s.running ?? false,
+          waitingConfirmation: s.waitingConfirmation ?? false,
+        })),
+      },
+    ],
+  });
+}

--- a/packages/webview/demo/status-dialog.demo.ts
+++ b/packages/webview/demo/status-dialog.demo.ts
@@ -1,0 +1,104 @@
+import { test, expect } from "../e2e/utils/webviewTestHarness.js";
+import { elementScreenshotWebp } from "../e2e/utils/screenshot.js";
+
+test.describe("Status Dialog Demo", () => {
+  test("should show status dialog with all info fields", async ({
+    webviewPage,
+  }) => {
+    // 1. Open the status dialog via showDialog
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "showDialog",
+        dialogType: "status",
+      });
+    });
+
+    // 2. Simulate extension sending configuration data
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "configurationResponse",
+        configurationData: {
+          model: "claude-sonnet-4-20250514",
+          fastModel: "claude-haiku-4-20250514",
+          baseURL: "https://api.nebula-tech.com/v1",
+        },
+      });
+    });
+
+    // 3. Simulate extension sending status response
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "statusResponse",
+        version: "1.2.0",
+        sessionId: "sess_a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        workdir: "/home/dev/projects/nebula-platform",
+        configurationData: {
+          model: "claude-sonnet-4-20250514",
+          fastModel: "claude-haiku-4-20250514",
+          baseURL: "https://api.nebula-tech.com/v1",
+        },
+      });
+    });
+
+    // 4. Simulate auth status (authenticated)
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "authStatusResponse",
+        isAuthenticated: true,
+        user: { id: "usr_7f3k2d8x", email: "sarah.chen@nebula-tech.com" },
+      });
+    });
+
+    // Verify dialog is visible
+    await expect(webviewPage.getByTestId("status-dialog")).toBeVisible();
+
+    // Verify key info fields are displayed
+    await expect(webviewPage.getByText("1.2.0")).toBeVisible();
+    await expect(
+      webviewPage.getByText("sess_a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
+    ).toBeVisible();
+    await expect(
+      webviewPage.getByText("/home/dev/projects/nebula-platform"),
+    ).toBeVisible();
+
+    // Take screenshot
+    const dialog = webviewPage.getByTestId("status-dialog");
+    await elementScreenshotWebp(
+      dialog,
+      "../../docs/public/screenshots/spec-status-dialog.webp",
+    );
+  });
+
+  test("should show status dialog with unauthenticated state", async ({
+    webviewPage,
+  }) => {
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "showDialog",
+        dialogType: "status",
+      });
+    });
+
+    // Simulate status with minimal config
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "statusResponse",
+        version: "1.2.0",
+        sessionId: "",
+        workdir: "",
+        configurationData: {},
+      });
+    });
+
+    // Simulate not authenticated
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "authStatusResponse",
+        isAuthenticated: false,
+        user: null,
+      });
+    });
+
+    await expect(webviewPage.getByTestId("status-dialog")).toBeVisible();
+  });
+});

--- a/packages/webview/demo/tool-error-scrollable.demo.ts
+++ b/packages/webview/demo/tool-error-scrollable.demo.ts
@@ -1,0 +1,175 @@
+import { test, expect } from "../e2e/utils/webviewTestHarness.js";
+import { MessageInjector } from "../e2e/utils/messageInjector.js";
+import { BASH_TOOL_NAME, type Message } from "wave-agent-sdk";
+import { screenshotWebp } from "../e2e/utils/screenshot.js";
+
+test.describe("Tool Error Scrollable Demo", () => {
+  test("should show scrollable tool error", async ({ webviewPage }) => {
+    const injector = new MessageInjector(webviewPage);
+
+    await webviewPage.setViewportSize({ width: 400, height: 800 });
+
+    await injector.simulateExtensionMessage("setInitialState", {
+      isAuthenticated: true,
+      messages: [],
+      isStreaming: false,
+      sessions: [],
+      configurationData: {
+        apiKey: "sk-ant-api03-CXB9pH2k...mH8wQz",
+        baseURL: "https://api.anthropic.com/v1",
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
+
+    const longError = [
+      "src/services/paymentService.ts(47,18): error TS2339: Property 'transactionId' does not exist on type 'PaymentIntent'.",
+      "src/services/paymentService.ts(58,9): error TS2322: Type 'Promise<Refund>' is not assignable to type 'Refund'.",
+      "src/services/sagaOrchestrator.ts(88,23): error TS2345: Argument of type 'string' is not assignable to parameter of type 'SagaStepDefinition'.",
+      "src/services/sagaOrchestrator.ts(104,12): error TS7006: Parameter 'compensation' implicitly has an 'any' type.",
+      "src/repositories/paymentRepository.ts(112,5): error TS2532: Object is possibly 'undefined'.",
+      "src/repositories/paymentRepository.ts(140,11): error TS2451: Cannot redeclare block-scoped variable 'tx'.",
+      "src/repositories/ledgerRepository.ts(66,27): error TS2339: Property 'entries' does not exist on type 'Ledger'.",
+      "src/utils/retry.ts(23,14): error TS2554: Expected 2 arguments, but got 1.",
+      "src/utils/retry.ts(31,3): error TS2322: Type 'number' is not assignable to type 'string'.",
+      "src/utils/idempotency.ts(15,42): error TS2304: Cannot find name 'crypto'.",
+      "src/index.ts(3,10): error TS2305: Module '\"./services/paymentService\"' has no exported member 'PaymentService'.",
+      "",
+      "error Command failed with exit code 2.",
+      "pnpm: command failed",
+    ].join("\n");
+    const messageWithLongError = {
+      id: "msg_long_error",
+      role: "assistant",
+      blocks: [
+        {
+          type: "tool",
+          name: BASH_TOOL_NAME,
+          stage: "end",
+          compactParams: "pnpm -F @nebula/payment-service build",
+          parameters: JSON.stringify({
+            command: "pnpm -F @nebula/payment-service build",
+          }),
+          error: longError,
+          success: false,
+        },
+      ],
+    };
+
+    const userMessage = {
+      id: "msg_user_tool_error",
+      role: "user",
+      timestamp: "2025-07-09T10:29:00.000Z",
+      blocks: [
+        { type: "text", content: "帮我构建一下 payment-service 这个包" },
+      ],
+    };
+
+    await injector.updateMessages([
+      userMessage as unknown as Message,
+      messageWithLongError as unknown as Message,
+    ]);
+    await webviewPage.waitForSelector(".tool-error");
+
+    // Check if the error is displayed and has max-height
+    const errorLocator = webviewPage.locator(".tool-error");
+    const maxHeight = await errorLocator.evaluate(
+      (el) => window.getComputedStyle(el).maxHeight,
+    );
+    const overflowY = await errorLocator.evaluate(
+      (el) => window.getComputedStyle(el).overflowY,
+    );
+
+    expect(maxHeight).toBe("200px");
+    expect(overflowY).toBe("auto");
+
+    // Take a screenshot of the long error with scrollbar
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/tool-error-scrollable.webp",
+    );
+  });
+
+  test("should show scrollable error block", async ({ webviewPage }) => {
+    const injector = new MessageInjector(webviewPage);
+
+    await webviewPage.setViewportSize({ width: 400, height: 800 });
+
+    await injector.simulateExtensionMessage("setInitialState", {
+      isAuthenticated: true,
+      messages: [],
+      isStreaming: false,
+      sessions: [],
+      configurationData: {
+        apiKey: "sk-ant-api03-CXB9pH2k...mH8wQz",
+        baseURL: "https://api.anthropic.com/v1",
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
+
+    const longError = [
+      "Error: Command failed: pnpm run package",
+      "    at checkExecSyncError (node:child_process:890:11)",
+      "    at execSync (node:child_process:962:15)",
+      "    at packageExtension (/home/dev/projects/nebula/scripts/package.ts:42:5)",
+      "    at main (/home/dev/projects/nebula/scripts/package.ts:78:3)",
+      "    at Object.<anonymous> (/home/dev/projects/nebula/scripts/package.ts:81:1)",
+      "    at Module._compile (node:internal/modules/cjs/loader:1198:14)",
+      "    at Module._extensions..js (node:internal/modules/cjs/loader:1252:10)",
+      "    at Module.load (node:internal/modules/cjs/loader:1076:32)",
+      "    at Module._load (node:internal/modules/cjs/loader:911:12)",
+      "",
+      "npm ERR! code ELIFECYCLE",
+      "npm ERR! errno 1",
+      "npm ERR! nebula-platform@1.2.0 package: `node scripts/package.ts`",
+      "npm ERR! Exit status 1",
+      "npm ERR! ",
+      "npm ERR! Failed at the nebula-platform@1.2.0 package script.",
+      "npm ERR! This is probably not a problem with npm. There is likely additional logging output above.",
+    ].join("\n");
+    const messageWithLongError = {
+      id: "msg_long_error_block",
+      role: "assistant",
+      blocks: [
+        {
+          type: "error",
+          content: longError,
+        },
+      ],
+    };
+
+    const userMessage = {
+      id: "msg_user_error_block",
+      role: "user",
+      timestamp: "2025-07-09T10:29:00.000Z",
+      blocks: [{ type: "text", content: "运行下打包命令看看" }],
+    };
+
+    await injector.updateMessages([
+      userMessage as unknown as Message,
+      messageWithLongError as unknown as Message,
+    ]);
+    await webviewPage.waitForSelector(".message-content.error");
+
+    // Check if the error is displayed and has max-height
+    const errorLocator = webviewPage.locator(".message-content.error");
+    const maxHeight = await errorLocator.evaluate(
+      (el) => window.getComputedStyle(el).maxHeight,
+    );
+    const overflowY = await errorLocator.evaluate(
+      (el) => window.getComputedStyle(el).overflowY,
+    );
+
+    expect(maxHeight).toBe("200px");
+    expect(overflowY).toBe("auto");
+
+    // Take a screenshot of the long error block with scrollbar
+    await screenshotWebp(
+      webviewPage,
+      "../../docs/public/screenshots/error-block-scrollable.webp",
+    );
+  });
+});

--- a/packages/webview/demo/workflow-manager.demo.ts
+++ b/packages/webview/demo/workflow-manager.demo.ts
@@ -1,0 +1,130 @@
+import { test, expect } from "../e2e/utils/webviewTestHarness.js";
+import { elementScreenshotWebp } from "../e2e/utils/screenshot.js";
+
+test.describe("Workflow Manager Demo", () => {
+  test("should show workflow run list and detail", async ({ webviewPage }) => {
+    // Dialog min-width is 560px, wider than the default 400px demo viewport — widen so the full dialog is captured
+    await webviewPage.setViewportSize({ width: 800, height: 700 });
+
+    // 1. Open the dialog via showDialog
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "showDialog",
+        dialogType: "workflows",
+      });
+    });
+
+    // 2. Simulate extension pushing workflow runs
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "updateWorkflowRuns",
+        runs: [
+          {
+            runId: "run-abc12345-def67890",
+            meta: {
+              name: "audit-and-fix",
+              description: "审查并修复测试与类型错误",
+              phases: [
+                { title: "Scan", detail: "grep 测试日志查找重试" },
+                { title: "Fix", detail: "每个 flaky 测试派一个代理" },
+              ],
+            },
+            status: "running",
+            scriptPath: "/workflows/find-flaky-tests.mjs",
+            startTime: Date.now() - 120000,
+            phases: [
+              {
+                title: "Scan",
+                agentCount: 4,
+                tokens: 18500,
+                elapsed: 45000,
+                startTime: Date.now() - 120000,
+              },
+              {
+                title: "Fix",
+                agentCount: 3,
+                tokens: 31200,
+                elapsed: 75000,
+                startTime: Date.now() - 75000,
+              },
+            ],
+            totalAgents: 7,
+            totalTokens: 49700,
+          },
+          {
+            runId: "run-98765432-fedcba10",
+            meta: {
+              name: "migrate-config",
+              description: "迁移配置到新格式",
+            },
+            status: "completed",
+            scriptPath: "/workflows/migrate.mjs",
+            startTime: Date.now() - 600000,
+            endTime: Date.now() - 480000,
+            phases: [
+              {
+                title: "Discover",
+                agentCount: 2,
+                tokens: 8400,
+                elapsed: 60000,
+                startTime: Date.now() - 600000,
+              },
+              {
+                title: "Transform",
+                agentCount: 5,
+                tokens: 22600,
+                elapsed: 60000,
+                startTime: Date.now() - 540000,
+              },
+            ],
+            totalAgents: 7,
+            totalTokens: 31000,
+          },
+          {
+            runId: "run-failed00012345",
+            meta: {
+              name: "deep-research",
+              description: "深度研究并生成报告",
+            },
+            status: "failed",
+            scriptPath: "/workflows/research.mjs",
+            startTime: Date.now() - 900000,
+            endTime: Date.now() - 820000,
+            phases: [
+              {
+                title: "Search",
+                agentCount: 6,
+                tokens: 45300,
+                elapsed: 80000,
+                startTime: Date.now() - 900000,
+              },
+            ],
+            totalAgents: 6,
+            totalTokens: 45300,
+            error: "Agent #3 exceeded token budget and aborted",
+          },
+        ],
+      });
+    });
+
+    // Verify dialog is visible
+    await expect(webviewPage.getByTestId("workflow-manager")).toBeVisible();
+
+    // Screenshot the list view
+    const dialog = webviewPage.getByTestId("workflow-manager");
+    await elementScreenshotWebp(
+      dialog,
+      "../../docs/public/screenshots/spec-workflow-list.webp",
+    );
+
+    // 3. Click the running run to enter detail view
+    await dialog.getByText("[run-abc1]").click();
+    await expect(webviewPage.getByText("Phases:")).toBeVisible();
+
+    // Screenshot the detail view
+    await elementScreenshotWebp(
+      dialog,
+      "../../docs/public/screenshots/spec-workflow-detail.webp",
+    );
+  });
+});

--- a/packages/webview/e2e/utils/desktopTestHarness.ts
+++ b/packages/webview/e2e/utils/desktopTestHarness.ts
@@ -20,16 +20,26 @@ export const test = base.extend<DesktopTestContext>({
     });
 
     const webviewDistPath = path.join(process.cwd(), "dist");
-    const vscodeStylesPath = path.join(
-      process.cwd(),
-      "theme",
-      "theme-base-dark.css",
-    );
+    const themeDir = path.join(process.cwd(), "theme");
 
-    let vscodeStyles = "";
-    if (fs.existsSync(vscodeStylesPath)) {
-      vscodeStyles = fs.readFileSync(vscodeStylesPath, "utf8");
-    }
+    // Same dual-theme inlining as packages/desktop/scripts/syncWebview.mjs:
+    // both variable sets coexist, each scoped to <html data-theme="…">. The
+    // static data-theme="dark" (mirroring the real index.html) makes the
+    // [data-host="desktop"][data-theme="…"] rules in host-desktop.css actually
+    // resolve — without it the designer light/dark pairs collapsed to the
+    // unscoped light values and screenshots rendered white popups on dark UI.
+    const rewriteThemeBase = (css: string, theme: string) =>
+      css.replace(/:root\s*\{/g, `:root[data-theme="${theme}"] {`);
+    const readTheme = (file: string, theme: string) =>
+      fs.existsSync(path.join(themeDir, file))
+        ? rewriteThemeBase(
+            fs.readFileSync(path.join(themeDir, file), "utf8"),
+            theme,
+          )
+        : "";
+    const vscodeStyles =
+      readTheme("theme-base-dark.css", "dark") +
+      readTheme("theme-base-light.css", "light");
 
     const codiconsCssPath = path.join(
       process.cwd(),
@@ -107,7 +117,7 @@ export const test = base.extend<DesktopTestContext>({
 
     const testHtml = `
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="zh-CN" data-theme="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## 背景

用户验收桌面端文档截图（GitHub Pages）发现两类问题，同时品牌重构（#2026 cf212c2b）删除的 IDE 截图需要恢复。

## 改动

1. **desktopTestHarness 双主题内联**（b0ffef45）：harness 页面从不设 `data-theme` → `host-desktop.css` 的 `[data-theme]` 双分支规则失效 → 截图呈现「浅色规则 + 深色变量基座」深浅混色。修复 = 复刻真机 syncWebview.mjs 机制（dark+light 双主题内联 rewrite `:root[data-theme=…]` + 静态 `data-theme="dark"`）。

2. **桌面截图侧边栏会话树 + 弹窗上下文**（6323bebc）：截图只有消息没有侧边栏对话显得假。新增 `sidebarSeed.ts`（seedSidebarSessions）批量给 14 个 desktop demo 注入 `desktopSessionTree`；desktop-permissions 6 个确认/询问弹窗场景注入呼应弹窗内容的对话上下文。

3. **恢复品牌重构删除的 23 个截图 demo**（01ed2338）：cf212c2b 重写 vsce 文档时删除的 demo 重新恢复，保证画廊截图在每次 demo 运行（GitHub Pages Deploy）时可再生成。40 个测试全过。

4. **vsce.md 精简为画廊**（66b53f34）：删除「代码选择与引用 / Worktree 隔离 / 多对话并行」三个文字章节，改为画廊——79 张 IDE 插件截图（全部由 webview harness demo 生成）按旧文档 10 大功能分组、3 列网格 + 说明，新增 gallery.css 样式与 config.js 侧边栏画廊分组。

## 验证

- 全量 `test:demo` 133/133 passed（含恢复 demo 40）
- type-check / oxlint / prettier 通过（pre-commit 钩子）
- vision 抽检桌面截图：深色主题一致、侧边栏有会话、弹窗有对话上下文
- 画廊页面渲染：10 组 79 张、3 列网格、无破图；侧边栏锚点校验 271 links 全过
- 3 张截图（直连设置/ConfigDialog 设置）因功能已移除（#2010）合理不恢复