### PR TITLE
fix(webview): 确认弹窗「提供反馈」移回按钮行首——撤销第 30 轮竖排 DOM 位移（用户验收）

### DIFF
--- a/packages/webview/e2e/confirm-actions-wrap.e2e.ts
+++ b/packages/webview/e2e/confirm-actions-wrap.e2e.ts
@@ -115,29 +115,24 @@ test.describe("Confirmation actions wrap", () => {
     const rowTops = [...new Set(boxes.map((b) => Math.round(b.top)))];
     expect(rowTops.length).toBeGreaterThan(1);
 
-    // 第 30 轮对齐 codechat ApprovalDialog：ghost 提供反馈 移到 actions 最
-    // 底部（DOM/visual 顺序 [自动类][主按钮][提供反馈]），narrow 换行后独占
-    // 最底行并保持右对齐；主按钮「批准并继续」在其上一行的右端。
+    // The primary button is last in the DOM/visual order ([提供反馈] [自动类]
+    // [批准并继续] — primary last, aligned with Claude's confirm UIs; the
+    // 第 30 轮 ghost-to-bottom reorder served the vertical layout and was
+    // reverted when the bar went horizontal again), so on a narrow bar it
+    // wraps onto the bottom line and stays pinned right.
     const maxTop = Math.max(...boxes.map((b) => b.top));
     const bottomRow = boxes.filter(
       (b) => Math.round(b.top) === Math.round(maxTop),
     );
-    const feedback = bottomRow.find((b) => b.label === "提供反馈");
-    expect(feedback).toBeDefined();
+    const primary = bottomRow.find((b) => b.label === "批准并继续");
+    expect(primary).toBeDefined();
     const bottomMaxRight = Math.max(...bottomRow.map((b) => b.right));
-    expect(Math.abs(feedback!.right - bottomMaxRight)).toBeLessThan(2);
-
-    const applyBtn = boxes.find((b) => b.label === "批准并继续")!;
-    const applyRow = boxes.filter(
-      (b) => Math.round(b.top) === Math.round(applyBtn.top),
-    );
-    const applyMaxRight = Math.max(...applyRow.map((b) => b.right));
-    expect(Math.abs(applyBtn.right - applyMaxRight)).toBeLessThan(2);
+    expect(Math.abs(primary!.right - bottomMaxRight)).toBeLessThan(2);
 
     // Every occupied row ends flush with the same right edge (right-aligned).
-    // Row identity comes from the 32px buttons only — the 24px 提供反馈 ghost
-    // (第 30 轮起独占最底行) 与最近高按钮行垂直中线相近，归组到该行，避免
-    // 按 raw top 分组造出幻影行。
+    // Row identity comes from the 32px buttons only — the shorter 提供反馈
+    // button shares a row's vertical middle (align-items:center) but its top
+    // differs, so grouping on raw tops would invent an extra phantom row.
     const rowKeyOf = (b: BtnBox) => {
       if (b.height >= 32) return Math.round(b.top);
       const mid = b.top + b.height / 2;

--- a/packages/webview/src/components/ConfirmationDialog.tsx
+++ b/packages/webview/src/components/ConfirmationDialog.tsx
@@ -880,6 +880,20 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
             {!showFeedbackInput ? (
               <>
                 {(confirmation.toolName === EXIT_PLAN_MODE_TOOL_NAME ||
+                  confirmation.toolName === BASH_TOOL_NAME ||
+                  [EDIT_TOOL_NAME, WRITE_TOOL_NAME].includes(
+                    confirmation.toolName,
+                  ) ||
+                  confirmation.toolName.startsWith("mcp__")) && (
+                  <button
+                    className="confirmation-btn confirmation-btn-feedback"
+                    onClick={() => setShowFeedbackInput(true)}
+                  >
+                    <span className="btn-text">提供反馈</span>
+                  </button>
+                )}
+
+                {(confirmation.toolName === EXIT_PLAN_MODE_TOOL_NAME ||
                   (confirmation.toolName === BASH_TOOL_NAME &&
                     confirmation.permissionMode !== "plan")) && (
                   <button
@@ -938,20 +952,6 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
                       : "是"}
                   </span>
                 </button>
-
-                {(confirmation.toolName === EXIT_PLAN_MODE_TOOL_NAME ||
-                  confirmation.toolName === BASH_TOOL_NAME ||
-                  [EDIT_TOOL_NAME, WRITE_TOOL_NAME].includes(
-                    confirmation.toolName,
-                  ) ||
-                  confirmation.toolName.startsWith("mcp__")) && (
-                  <button
-                    className="confirmation-btn confirmation-btn-feedback"
-                    onClick={() => setShowFeedbackInput(true)}
-                  >
-                    <span className="btn-text">提供反馈</span>
-                  </button>
-                )}
               </>
             ) : (
               <div className="feedback-flow">

--- a/packages/webview/src/styles/ConfirmationDialog.css
+++ b/packages/webview/src/styles/ConfirmationDialog.css
@@ -403,10 +403,10 @@
 }
 
 /* Actions: pinned to the dialog bottom (sibling of the scrollable body).
-   DOM order matches the visual top-to-bottom order — [自动类] [主按钮]
-   [提供反馈] — so the Tab cycle also runs top-to-bottom with the ghost
-   提供反馈 button last (desktop: feedback below the primary action).
-   justify-content: flex-end pins the row right, including
+   DOM order matches the visual left-to-right order — [提供反馈] [自动类]
+   [主按钮] — so the Tab cycle also runs left-to-right with the primary
+   button last (aligned with Claude's confirm UIs: Deny/Cancel first,
+   Allow last). justify-content: flex-end pins the row right, including
    the overflow line when wrapped (same as claude.ai's confirm action row;
    ellipsis stays as the extreme-narrow fallback).
    align-items: center keeps the shorter text-style 提供反馈 button on the

--- a/packages/webview/src/styles/host-desktop.css
+++ b/packages/webview/src/styles/host-desktop.css
@@ -1410,8 +1410,10 @@
 /* ② 按钮布局：按钮保持水平并排（用户拍板：工具确认弹窗按钮维持既有水平对齐，
    不随 codechat approval-dialog 改竖排全宽——2026-09-02 反馈）；其余视觉按
    codechat 节奏：margin-top 16、按钮 min-height 32 / pad 0 12 / 字重 500 /
-   r6、secondary/primary/ghost 三态配色（见下）。DOM 顺序即视觉顺序：
-   自动类(secondary) → 批准并继续(primary) → 提供反馈(ghost)。 */
+   r6、secondary/primary/ghost 三态配色（见下）。DOM 顺序即视觉顺序（水平
+   从左到右）：提供反馈(ghost) → 自动类(secondary) → 批准并继续(primary)
+   最右（对齐 Claude 确认 UI primary-last，spec confirm-ui.md 场景 1；
+   第 30 轮为竖排布局把提供反馈移到末尾的 DOM 位移已随水平布局恢复撤销）。 */
 [data-host="desktop"] .confirmation-actions {
   gap: 8px;
   margin-top: 16px;

--- a/packages/webview/tests/webview/confirmationDialog.test.tsx
+++ b/packages/webview/tests/webview/confirmationDialog.test.tsx
@@ -132,20 +132,21 @@ describe("Confirmation Dialog", () => {
     // up, in this pane or a sibling one.
     expect(document.activeElement).toBe(initialFocus);
 
-    // The primary action is second-to-last in the Tab cycle within the
-    // action bar: DOM order matches the visual top-to-bottom order
-    // ([自动类] [主按钮] [提供反馈] — 第 30 轮将 ghost 提供反馈 移到 actions
-    // 最底部，对齐 codechat ApprovalDialog), so Tab reaches the primary
-    // button before the trailing 提供反馈 ghost.
+    // The primary action is last in the Tab cycle within the action bar:
+    // DOM order matches the visual left-to-right order ([提供反馈] [自动类]
+    // [主按钮] — primary last, aligned with Claude's confirm UIs; the 第 30 轮
+    // ghost-to-bottom reorder served the vertical layout and was reverted when
+    // the bar went horizontal again), so Tab reaches the primary button last.
     const actionBar = document.querySelector(".confirmation-actions")!;
     const buttons = Array.from(
       actionBar.querySelectorAll<HTMLButtonElement>("button:not([disabled])"),
     );
-    const primary = buttons[buttons.length - 2]!;
+    const feedback = buttons[0]!;
+    expect(feedback).toHaveClass("confirmation-btn-feedback");
+    expect(feedback).toHaveTextContent("提供反馈");
+    const primary = buttons[buttons.length - 1]!;
     expect(primary).toHaveClass("confirmation-btn-apply");
     expect(primary).toHaveTextContent("批准并继续");
-    const feedback = buttons[buttons.length - 1]!;
-    expect(feedback).toHaveTextContent("提供反馈");
   });
 
   it("should send approval response when clicking apply button", async () => {


### PR DESCRIPTION
29fae457（第 30 轮）为竖排全宽布局把提供反馈从按钮首位移到末尾；f3cdbf9c 恢复水平布局时只撤 CSS 未还原 DOM 顺序，导致水平下提供反馈视觉落到最右、主按钮「批准并继续」被挤到中间。

恢复 spec confirm-ui.md 场景 1/2 语义：水平从左到右 [提供反馈] [自动类] [批准并继续]（primary 最右），DOM 顺序即视觉/Tab 顺序。

同步两处 CSS 注释与单测/e2e 断言（feedback 首位、apply 末尾）。
