### PR TITLE
fix(webview): welcome 登录按钮收窄居中留水平外边距

### DIFF
--- a/packages/webview/src/components/WelcomeView.tsx
+++ b/packages/webview/src/components/WelcomeView.tsx
@@ -79,6 +79,16 @@ const WelcomeView: React.FC<WelcomeViewProps> = ({
           flexDirection: "column",
           alignItems: "center",
           gap: "24px",
+          /* Constrain the column and make the horizontal padding real: with
+             content-box sizing a fixed-width child (e.g. the 登录 button group)
+             widens the column beyond the viewport, so the group spilled to the
+             edges and the padding below was eaten. border-box + max-width 400
+             caps the column at the viewport (or 400px on wider panes) and
+             centers it, keeping 16px breathing room on both sides. */
+          width: "100%",
+          maxWidth: "400px",
+          boxSizing: "border-box",
+          minWidth: 0,
           padding: "0 16px",
         }}
       >
@@ -128,8 +138,11 @@ const WelcomeView: React.FC<WelcomeViewProps> = ({
         {showLogin && (
           <div
             style={{
-              width: "400px",
-              maxWidth: "100%",
+              /* Login CTA group: full column width up to 320px so the button
+                 stays centered with clear horizontal margins on both sides
+                 instead of stretching edge-to-edge like the input card. */
+              width: "100%",
+              maxWidth: "320px",
               display: "flex",
               flexDirection: "column",
               alignItems: "center",


### PR DESCRIPTION
## 背景

IDE 欢迎页（未登录）登录按钮截图反馈：宽度太大、距两侧无水平外边距。

## 根因

登录按钮组容器固定 `width:400px`，其父居中列在 `content-box` 下无宽度约束，列被内容撑到 432px 溢出视口，列上的 `padding: 0 16px` 形同虚设 → 按钮实际 400px 宽、左右贴边（实测 x=0 w=400）。

另发现 docs 中 `spec-welcome-login.webp`（16:26 产物）是 PR #2031 合并前的陈旧截图（登录按钮还在聊天头部），已在本次用当前 main 代码重新生成。

## 修复

- WelcomeView 居中列：加 `width:100% + maxWidth:400px + boxSizing:border-box + minWidth:0`，padding 生效、列不再溢出
- 登录组：固定 400px → `width:100% + maxWidth:320px` 居中，按钮两侧各留 ~40px 水平外边距
- demo 截图重生成（gitignored），实测按钮宽 320、垂直居中不变

## 验证

- 全量 demo 截图 100 passed（16.9s），几何断言通过
- type-check（6 包）+ oxlint + prettier 全绿