### PR TITLE
fix(webview): 预览面板加载失败态重试按钮坍缩竖排

### DIFF
--- a/packages/webview/e2e/desktop-preview.e2e.ts
+++ b/packages/webview/e2e/desktop-preview.e2e.ts
@@ -202,4 +202,69 @@ test.describe("Desktop Preview Pane Screenshots", () => {
       "这里改成主要按钮样式",
     );
   });
+
+  test("load-failure retry button stays a single-line button", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+    await webviewPage.setViewportSize({ width: 1100, height: 680 });
+
+    await injector.simulateExtensionMessage("desktopWorkdirState", {
+      workdir: DIR_A,
+      recentWorkdirs: [DIR_A],
+    });
+    await injector.waitForChatAppReady();
+    await injector.simulateExtensionMessage("setInitialState", initialState);
+
+    await injector.updateMessages([
+      MockDataGenerator.createUserMessage("帮我预览一下页面", "msg-u1"),
+      MockDataGenerator.createAssistantMessage(
+        "开发服务器已启动，点击 [http://localhost:5173](http://localhost:5173) 预览。",
+        "msg-a1",
+      ),
+    ]);
+
+    // Open the preview pane, then stub the guest IPC surface (the harness
+    // cannot host a real Electron <webview>).
+    await webviewPage.locator('a[href="http://localhost:5173"]').click();
+    await expect(webviewPage.getByTestId("preview-pane")).toBeVisible();
+    await webviewPage.evaluate(() => {
+      const wv = document.querySelector("webview") as unknown as Record<
+        string,
+        unknown
+      > &
+        HTMLElement;
+      wv.send = () => {};
+      wv.loadURL = async () => {};
+      wv.reload = () => {};
+      wv.dispatchEvent(new Event("dom-ready"));
+    });
+
+    // Simulate the dev server going away: the guest fires did-fail-load and
+    // PreviewPane shows the load-error state with a "重试" button.
+    await webviewPage.evaluate(() => {
+      const wv = document.querySelector("webview") as HTMLElement;
+      const fail = new Event("did-fail-load") as Event & {
+        errorCode?: number;
+        errorDescription?: string;
+        isMainFrame?: boolean;
+      };
+      fail.errorCode = -324; // ERR_EMPTY_RESPONSE
+      fail.errorDescription = "ERR_EMPTY_RESPONSE";
+      fail.isMainFrame = true;
+      wv.dispatchEvent(fail);
+    });
+
+    const errorBox = webviewPage.getByTestId("preview-error");
+    await expect(errorBox).toBeVisible();
+    await expect(errorBox).toContainText("页面加载失败：ERR_EMPTY_RESPONSE");
+
+    // Regression: the retry text button reuses the toolbar icon-button class
+    // (24×24, no wrap). The error-state override must widen it to fit its
+    // label — otherwise "重试" stacks vertically into a narrow pill.
+    const retry = webviewPage.getByTestId("preview-retry");
+    const box = (await retry.boundingBox())!;
+    expect(box.width).toBeGreaterThan(box.height);
+    await expect(retry).toHaveText("重试");
+  });
 });

--- a/packages/webview/src/styles/DesktopApp.css
+++ b/packages/webview/src/styles/DesktopApp.css
@@ -1109,7 +1109,9 @@ body.is-panel-resizing webview {
 }
 
 .preview-pane-error .preview-pane-button {
+  width: auto;
   padding: 4px 12px;
+  white-space: nowrap;
   background: var(--vscode-button-background);
   color: var(--vscode-button-foreground, #ffffff);
 }


### PR DESCRIPTION
错误态「重试」文字按钮复用了工具栏图标按钮基类 .preview-pane-button（width:24px 固定宽、padding:0），错误态规则未覆盖宽度且文字可换行，导致关闭开发服务后重试按钮被压成窄竖条、「重试」两字竖排。

修复：.preview-pane-error .preview-pane-button 加 width:auto + white-space:nowrap，宽度随内容自适应、文字保持单行。

回归测试：desktop-preview.e2e.ts 新增场景，dispatch did-fail-load 触发错误态，断言按钮 width > height（竖排时失败，已验证 fail-without-fix）。
