### PR TITLE
feat(webview): 0902 新基线桌面视觉优化（第 1-6 轮）

### DIFF
--- a/docs/desktop-density-restore.md
+++ b/docs/desktop-density-restore.md
@@ -1611,3 +1611,45 @@ codechat 权威：`workspace-header-menu` / el-dropdown-menu 菜单项**连续�
 
 - `src/styles/host-desktop.css`（0902 新基线第 2 轮段：布局规格 + 颜色覆盖）
 - `src/components/TaskList.tsx`（stats 数组补 `is-succeeded/is-running/is-pending` 类并应用到 stat dot span）
+
+---
+
+## 0902 新基线第 3 轮（2026-09）：more-menu 菜单项前置图标（对齐 codechat TaskSidebar）
+
+用户预览评论 `div.more-menu`「设置/企业控制台/帮助文档/退出登录」：「参考 ccui 的项目，给这里添加图标，但是企业控制台、帮助文档 末尾的跳转图标保留」。
+
+### 母版（ccui TaskSidebar.vue sidebar-more 弹层）
+
+菜单项前置 lucide 图标（Settings/House/CircleHelp/LogOut，`<… :size="17"/>`，`.el-dropdown-menu__item` flex + gap）；wave 桌面菜单统一规格已在第十三/三十九轮对齐（32px 高 / 14px / r6 / fill-hover），图标按 wave 控件图标尺度 16×16 渲染、stroke currentColor 跟随文字色（危险项自动随红）。
+
+### 修改
+
+| 文件              | 内容                                                                                                                                                                                                     |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `HeaderIcons.tsx` | 新增 4 个 lucide 图标组件：SettingsGearIcon / HouseIcon / HelpCircleIcon / LogOutIcon（16×16 渲染、24 viewBox、stroke 2 currentColor，路径取自 ccui node_modules lucide 源）                             |
+| `MoreMenu.tsx`    | entries 前置图标：设置=齿轮；企业控制台=房子、帮助文档=问号圆圈，图标+文字包进 `more-menu-item-leading` 左组、行尾保留 ExternalLinkIcon（space-between 需两直接子）；退出登录=门+箭头（danger 红色跟随） |
+| `MoreMenu.css`    | `.more-menu-item` 补 `gap: 8px`；新增 `.more-menu-item-leading { display:inline-flex; align-items:center; gap:8px; min-width:0 }`                                                                        |
+
+### 验证（8899 Playwright 探针 + 截图，两主题）
+
+- 四行前置图标均可见，企业/帮助行尾 ↗ 保留 ✓
+- item 32px 高、图标 16×16、gap 8px、菜单宽 160px 文字无挤压溢出 ✓
+- 图标色跟随文字：light #565A60 / dark #9A9EA5；退出登录 light/dark 均 #D92D20 系（dark 稍柔）✓
+
+### 实现文件
+
+- `src/components/HeaderIcons.tsx`、`src/components/MoreMenu.tsx`、`src/styles/MoreMenu.css`
+
+---
+
+## 0902 新基线第 4 轮（2026-09）：bash 命令输出内链接深色补覆盖（dark #4daafc）
+
+用户预览评论 `#messagesContainer … a:nth-of-type(1)`（bash 输出内的 `http://localhost:8899/` 链接）：「检查下深色模式这里链接的颜色为什么和其他地方不一样」。
+
+- **根因**：第二十六轮消息内链接统一时 dark 覆盖组只写了 `.write-tool-path` 与 `.markdown-content a`，遗漏 `.bash-command-output a`——其第 768 行规则固定浅色链接蓝 #2f5edb，dark 下比 markdown 链接 #4daafc 暗且发蓝。
+- **修改**：dark 覆盖组补入 `.bash-command-output a` 及 `:hover` → #4daafc（与 write-tool-path / markdown 一致）；light 保持 #2f5edb 不变。
+- **验证**（8899 探针）：目标链接 dark = rgb(77,170,252) ✓，与容器内 markdown 链接同色；light 仍 #2f5edb ✓。
+
+### 实现文件
+
+- `src/styles/host-desktop.css`（第二十六轮链接统一段内补 dark bash 链接覆盖）

--- a/docs/desktop-density-restore.md
+++ b/docs/desktop-density-restore.md
@@ -1534,3 +1534,29 @@ codechat 权威：`workspace-header-menu` / el-dropdown-menu 菜单项**连续�
 ### 实现文件
 
 - `src/styles/host-desktop.css`（第三十九轮段：`.more-menu`/`.panel-toggle-menu` gap 0）
+
+---
+
+## 0902 新基线第 1 轮（2026-09）：41① 灰条去蓝偏 + 41③ 权限按钮深色 :focus 修复
+
+> **新基线说明**：本地 40-42 轮工作已删除，仓库重置回 `origin/main`（`129d1757`，第 39 轮为最新）。**本轮起为新代码基线上的第 1 轮**，内容对应桌面记录 `~/Desktop/CC02-wave-41a-41c-42-style-changes.md` 的 **41① + 41③**（该文件的 42 轮 MoreMenu 不在本轮范围，后续如需再应用）。
+
+### 41① 新会话上下文栏（灰条）深色背景中性化 `#27292b` → `#292929`
+
+用户评审「本地 CC02 main worktree」灰条：「深色模式的这里的灰感觉有些偏蓝，可以更中性一些」。
+
+- **根因**：深色背景原用 `#27292B` = rgb(39,41,43)，B 通道（43）比 R/G 偏高，紧邻中性卡片 `#313131` 时显偏蓝。
+- **修改**：`[data-host="desktop"][data-theme="dark"] .input-workdir-row` 的 `background` `#27292b` → `#292929`（等亮度中性灰，去蓝偏；「卡片 #313131 在上、灰条略深在下」层次保持）。
+- **验证**（8899 Playwright 探针）：dark computed `rgb(41, 41, 41)` ✓；light 仍 `#f5f7fa`（浅色规则不受影响）✓。
+
+### 41③ 权限按钮（permission-mode-select）深色 :focus 反白修复
+
+用户评审「自动接受修改」按钮：「深色模式这个按钮会有反白的情况，不应该出现」。
+
+- **根因**：深色规则只有 `:hover` 覆盖，`:focus` 落入浅色规则 `background:#EEF0F3 / color:#1F2329` → 点击按钮获得焦点后即浅底深字反白。
+- **修改**：深色段 `:hover` 扩展为 `:hover, :focus`（`.permission-mode-select` 与 `.mode-bypassPermissions` 两处），hover/focus 统一深色覆盖，bypass 红字保持。
+- **验证**（8899 Playwright 探针，focus 后等待 ≥400ms 覆盖 0.2s transition）：非 bypass focus = `rgba(255,255,255,0.08)` / `#fff` ✓；bypass focus 保持红字 `#f4655c` 且背景同深色覆盖 ✓；light `:focus` 浅色规则照旧无回归 ✓；0 console errors ✓。
+
+### 实现文件
+
+- `src/styles/host-desktop.css`（41① `.input-workdir-row` dark 背景段；41③ `.permission-mode-select` 深色 hover/focus 段）

--- a/docs/desktop-density-restore.md
+++ b/docs/desktop-density-restore.md
@@ -1653,3 +1653,30 @@ codechat 权威：`workspace-header-menu` / el-dropdown-menu 菜单项**连续�
 ### 实现文件
 
 - `src/styles/host-desktop.css`（第二十六轮链接统一段内补 dark bash 链接覆盖）
+
+---
+
+## 0902 新基线第 5 轮（2026-09）：账户更多按钮换问号圆 + 帮助文档图标改文档（对齐 ccui figma-icon-button）
+
+用户预览评论 `svg.account-card-more-icon`（账户卡片「更多」按钮三点图标）：「把这个三个点图标换成现在帮助文档的图标，把帮助文档的图标，换成类似文档的图标，再检查下这个区域背景色、圆角是否符合规范」。
+
+### 修改（图标职责对调 + 区域规格检查）
+
+| 文件               | 内容                                                                                                                                                                                                                   |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `HeaderIcons.tsx`  | 新增 `FileTextIcon`（lucide file-text 文档：纸页折角+文字横线，24 viewBox stroke 2，与既有 lucide 菜单图标同风格）                                                                                                     |
+| `AccountCard.tsx`  | 登录/未登录两处更多按钮 `MoreIcon`（三点）→ `HelpCircleIcon`（问号圆圈，即第 3 轮帮助文档图标）                                                                                                                        |
+| `MoreMenu.tsx`     | 帮助文档项图标 `HelpCircleIcon` → `FileTextIcon`（↗ 行尾跳转图标保留）                                                                                                                                                |
+| `host-desktop.css` | 更多按钮区域规格检查：base r4 + vscode list-hoverBackground 蓝灰 → 对齐热区 r6 + hover #E2E4E8 / dark 14% 白（ccui figma-icon-button / sidebar-account-more 32×32 r6 fill-hover；同排热区与按钮两档灰/两档圆角不一致） |
+
+背景/圆角检查结论：账户卡片整体仍透明贴合侧栏 + 上分隔线 #EBEEF5（ccui sidebar-account 同款，无独立卡片底），仅按钮自身规格补齐。
+
+### 验证（8899 Playwright 探针 + 截图，两主题）
+
+- 更多按钮图标 = 问号圆圈（circle×1 + path×2）✓；帮助文档 = 文档页（path×5）✓；企业/帮助行尾 ↗ 保留 ✓
+- 更多按钮 hover 与热区同色：light #E2E4E8 / dark 14% 白，同 r6 ✓（修改前按钮 hover 为 vscode list-hoverBackground 蓝灰、r4）
+- type-check + accountCard/moreMenu 21 测试全绿 ✓
+
+### 实现文件
+
+- `src/components/HeaderIcons.tsx`、`src/components/AccountCard.tsx`、`src/components/MoreMenu.tsx`、`src/styles/host-desktop.css`

--- a/docs/desktop-density-restore.md
+++ b/docs/desktop-density-restore.md
@@ -1680,3 +1680,17 @@ codechat 权威：`workspace-header-menu` / el-dropdown-menu 菜单项**连续�
 ### 实现文件
 
 - `src/components/HeaderIcons.tsx`、`src/components/AccountCard.tsx`、`src/components/MoreMenu.tsx`、`src/styles/host-desktop.css`
+
+---
+
+## 0902 新基线第 6 轮（2026-09）：预览标签 hover 底色对齐 fill-hover
+
+用户预览评论 `div.preview-tab`「localhost:8899」：「检查这里hover状态下的颜色是否符合规范」。
+
+- **根因**：`.preview-tab:hover` 用 base 的 `var(--vscode-list-hoverBackground)`——桌面下实际渲染 light `rgba(0,0,0,0.08)`（≈#EBEBEB）、dark `#2a2d2e`，是 VS Code 默认蓝灰/中性黑调，未纳入桌面设计系统色板（同类 hover 早已统一 `--cc-fill-hover`：queued-item/菜单项/账户热区）。
+- **修改**：host-desktop.css 预览标签段补 hover 覆盖 —— 非激活 hover light `#EEF0F3` / dark 8% 白；active 标签 hover 用 `:not(.active)` 限定保持激活底不漂移。
+- **验证**（8899 探针，注入真实 class 元素取 computed）：light hover = rgb(238,240,243) ✓、dark = rgba(255,255,255,0.08) ✓、active hover 保持 #F0F2F5 / dark 原激活色 ✓。
+
+### 实现文件
+
+- `src/styles/host-desktop.css`（预览标签段补 hover fill-hover 覆盖）

--- a/docs/desktop-density-restore.md
+++ b/docs/desktop-density-restore.md
@@ -1560,3 +1560,54 @@ codechat 权威：`workspace-header-menu` / el-dropdown-menu 菜单项**连续�
 ### 实现文件
 
 - `src/styles/host-desktop.css`（41① `.input-workdir-row` dark 背景段；41③ `.permission-mode-select` 深色 hover/focus 段）
+
+---
+
+## 0902 新基线第 2 轮（2026-09）：任务列表/消息队列卡片对齐输入框规格 + 状态色合规
+
+用户预览评论 `div.task-list-inline` / `div.queued-item` / `div.queued-message-list-container`：「任务列表和消息列队的整体宽度应该和下方的输入框保持一致，圆角也和下方输入框保持统一，字号14px，消息列队选项高度32px」「hover状态圆角等要符合规范」「整体卡片和下方对话框要有间距8px」；随后追加「检查任务列表、消息列表中的颜色，看看是否符合规范」。
+
+### A. 卡片布局对齐输入框规格（host-desktop.css）
+
+| 项               | base                             | 桌面规范（= 输入框）                          | 修复                                                      |
+| ---------------- | -------------------------------- | --------------------------------------------- | --------------------------------------------------------- |
+| 卡片宽度         | max-width 800px                  | 768px（input-wrapper）                        | 两卡统一 768                                              |
+| 圆角             | 8px                              | 16px（input-content r16）                     | 统一 16                                                   |
+| 主体字号         | 12px / lh16                      | 14px / lh20                                   | 标题/任务行/队列标题/队列条目统一 14                      |
+| 统计文字         | 12px / editor-foreground         | 12px 次级弱化（codechat xs + text-secondary） | #6C7076 / dark #9A9EA5                                    |
+| 队列选项高       | 24px / r4                        | 32px / r6                                     | height 32 + radius 6                                      |
+| 队列 hover 底    | vscode list-hoverBackground 蓝灰 | codechat fill-hover                           | #EEF0F3 / dark 8% 白                                      |
+| 卡片↔输入框间距 | 无                               | 8px                                           | queued 卡 margin-bottom 8；连体时 task 卡贴齐、归零连接处 |
+| 滚动上限         | 102px                            | 110px                                         | 4 任务 × 20px 行高 + 3 × 10px 间距                        |
+
+连体结构沿用 base `:has(+ .queued-message-list-container)` 归零逻辑，仅半径 8→16。
+
+### B. 状态色对齐 codechat state tokens（host-desktop.css + TaskList.tsx）
+
+权威：codechat TaskList.vue `task-stat-dot`/`task-list-item-icon` 共用 `--cc-state-succeeded #16a34a / --cc-state-running #2f5edb / --cc-state-idle #98a2b3`（dot 与行 icon 同状态同色）；wave 内部同色先例：时间线节点 #16a34a、SessionBoard dot 深浅同值、桌面链接 #2f5edb/#4daafc。
+
+| 元素                | base/修复前                       | 规范                         | 修复                                                                                                     |
+| ------------------- | --------------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------- |
+| stat dot 已完成     | #73C991（iconPassed token）       | #16a34a                      | TaskList.tsx stats 加 `is-succeeded/is-running/is-pending` 类，desktop 覆盖（inline style → !important） |
+| stat dot 进行中     | #75BEFF（--wave-blue 未定义回退） | #2f5edb                      | 同上                                                                                                     |
+| stat dot 待执行     | #606060/#ccc                      | #98a2b3                      | 同上                                                                                                     |
+| 行 icon 已完成      | svg fill #89D185 硬编码           | #16a34a                      | svg fill 为 presentation attribute，CSS `fill` 普通规则覆盖；按行内 title 状态 class 以 `:has()` 定位    |
+| 行 icon 进行中      | fill #CCCCCC                      | #2f5edb                      | 同上                                                                                                     |
+| 行 icon 待执行      | fill #CCCCCC                      | #98a2b3                      | 同上（mock 无待执行行，规则生效不可视验证）                                                              |
+| 依赖行「依赖 #x」   | textLink #0069cc                  | 链接 #2f5edb / dark #4daafc  | desktop 覆盖（mock 无依赖任务，规则生效不可视验证）                                                      |
+| 两卡 header chevron | vscode-foreground 黑              | 控件图标灰 #565A60 / #9A9EA5 | 并入第 38 轮图标清单同值                                                                                 |
+| queue action 图标   | icon-foreground #606060/#ccc      | 图标灰 #565A60 / #9A9EA5     | 常态灰；hover 底 #E7E9ED / 12% 白、字 #1F2329/#FFF（session-more-btn 先例）                              |
+
+深色不做单独状态色：codechat 无 dark token，状态色与时间线/会话看板一致深浅同值。
+
+### 验证结果（8899 Playwright 探针，两主题）
+
+- dot/行 icon 三状态 = rgb(22,163,74)/(47,94,219)/(152,162,179)，两主题一致 ✓
+- stat-text #6C7076（light）/ #9A9EA5（dark）✓；chevron/action 图标 #565A60 / #9A9EA5 ✓
+- action hover light #1F2329 + #E7E9ED、dark #FFF + 12% 白 ✓；队列项 hover #EEF0F3 / 8% 白 ✓
+- title 弱化：completed 行 #606060/#9D9D9D + 删除线（保持 base 语义）✓
+
+### 实现文件
+
+- `src/styles/host-desktop.css`（0902 新基线第 2 轮段：布局规格 + 颜色覆盖）
+- `src/components/TaskList.tsx`（stats 数组补 `is-succeeded/is-running/is-pending` 类并应用到 stat dot span）

--- a/packages/webview/src/components/AccountCard.tsx
+++ b/packages/webview/src/components/AccountCard.tsx
@@ -5,7 +5,9 @@ import type {
   AccountUpdateInfo,
 } from "wave-webview-fixtures";
 import { MoreMenu } from "./MoreMenu";
-import { MoreIcon } from "./HeaderIcons";
+// HelpCircleIcon：未登录态「更多」按钮图标（v3 已登录态改为个人信息热区唤
+// 菜单、不再有更多按钮；未登录态保留按钮结构，图标沿用 0902 第 5 轮问号圆）。
+import { HelpCircleIcon } from "./HeaderIcons";
 import { ConfirmDialog } from "./ConfirmDialog";
 import "../styles/AccountCard.css";
 import "../styles/ConfirmDialog.css";
@@ -225,7 +227,7 @@ export const AccountCard: React.FC<AccountCardProps> = ({
             setShowMenu((v) => !v);
           }}
         >
-          <MoreIcon className="account-card-more-icon" />
+          <HelpCircleIcon className="account-card-more-icon" />
         </button>
         {showMenu && menuAnchor && (
           <MoreMenu

--- a/packages/webview/src/components/HeaderIcons.tsx
+++ b/packages/webview/src/components/HeaderIcons.tsx
@@ -1187,7 +1187,30 @@ export const HouseIcon: React.FC<IconProps> = ({
   </svg>
 );
 
-/** 账户更多-帮助文档（lucide circle-help，24 viewBox stroke 2） */
+/** 账户更多-帮助文档（lucide file-text 文档，24 viewBox stroke 2） */
+export const FileTextIcon: React.FC<IconProps> = ({
+  className = "header-icon",
+}) => (
+  <svg
+    width={16}
+    height={16}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z" />
+    <path d="M14 2v5a1 1 0 0 0 1 1h5" />
+    <path d="M10 9H8" />
+    <path d="M16 13H8" />
+    <path d="M16 17H8" />
+  </svg>
+);
+
+/** 账户更多-帮助文档问号圆（lucide circle-help，24 viewBox stroke 2） */
 export const HelpCircleIcon: React.FC<IconProps> = ({
   className = "header-icon",
 }) => (

--- a/packages/webview/src/components/HeaderIcons.tsx
+++ b/packages/webview/src/components/HeaderIcons.tsx
@@ -1138,3 +1138,93 @@ export const SettingsBackIcon: React.FC<IconProps> = ({
     />
   </svg>
 );
+
+// ═══ 账户更多菜单项图标（0902 新基线第 3 轮：对齐 codechat TaskSidebar 账户
+// 更多菜单 el-dropdown-menu__item 前置 lucide 图标，17px 视觉对应这里 16×16
+// 渲染）════
+// 菜单四态：设置（lucide settings 齿轮）/ 企业控制台（lucide house）/
+// 帮助文档（lucide circle-help 问号圈）/ 退出登录（lucide log-out 出门箭头）。
+// 与 wave 其他图标一致 stroke currentColor（随菜单项文字色：常规 #565A60、
+// hover #1F2329、danger 红）。
+
+/** 账户更多-设置（lucide settings，24 viewBox stroke 2） */
+export const SettingsGearIcon: React.FC<IconProps> = ({
+  className = "header-icon",
+}) => (
+  <svg
+    width={16}
+    height={16}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
+/** 账户更多-企业控制台（lucide house，24 viewBox stroke 2） */
+export const HouseIcon: React.FC<IconProps> = ({
+  className = "header-icon",
+}) => (
+  <svg
+    width={16}
+    height={16}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8" />
+    <path d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+  </svg>
+);
+
+/** 账户更多-帮助文档（lucide circle-help，24 viewBox stroke 2） */
+export const HelpCircleIcon: React.FC<IconProps> = ({
+  className = "header-icon",
+}) => (
+  <svg
+    width={16}
+    height={16}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <circle cx="12" cy="12" r="10" />
+    <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+    <path d="M12 17h.01" />
+  </svg>
+);
+
+/** 账户更多-退出登录（lucide log-out，24 viewBox stroke 2） */
+export const LogOutIcon: React.FC<IconProps> = ({
+  className = "header-icon",
+}) => (
+  <svg
+    width={16}
+    height={16}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <path d="m16 17 5-5-5-5" />
+    <path d="M21 12H9" />
+    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+  </svg>
+);

--- a/packages/webview/src/components/MoreMenu.tsx
+++ b/packages/webview/src/components/MoreMenu.tsx
@@ -3,7 +3,7 @@ import type { RefObject } from "react";
 import { useRovingMenu } from "../utils/useRovingMenu";
 import {
   ExternalLinkIcon,
-  HelpCircleIcon,
+  FileTextIcon,
   HouseIcon,
   LogOutIcon,
   SettingsGearIcon,
@@ -112,7 +112,7 @@ export const MoreMenu: React.FC<MoreMenuProps> = ({
       content: (
         <>
           <span className="more-menu-item-leading">
-            <HelpCircleIcon className="more-menu-item-icon" />
+            <FileTextIcon className="more-menu-item-icon" />
             <span>帮助文档</span>
           </span>
           <ExternalLinkIcon className="more-menu-item-icon" />

--- a/packages/webview/src/components/MoreMenu.tsx
+++ b/packages/webview/src/components/MoreMenu.tsx
@@ -1,7 +1,13 @@
 import React, { useEffect, useRef } from "react";
 import type { RefObject } from "react";
 import { useRovingMenu } from "../utils/useRovingMenu";
-import { ExternalLinkIcon } from "./HeaderIcons";
+import {
+  ExternalLinkIcon,
+  HelpCircleIcon,
+  HouseIcon,
+  LogOutIcon,
+  SettingsGearIcon,
+} from "./HeaderIcons";
 import "../styles/MoreMenu.css";
 
 interface MoreMenuProps {
@@ -78,7 +84,12 @@ export const MoreMenu: React.FC<MoreMenuProps> = ({
     {
       id: "more-menu-settings",
       run: handleSettings,
-      content: <span>设置{authLabelSuffix}</span>,
+      content: (
+        <>
+          <SettingsGearIcon className="more-menu-item-icon" />
+          <span>设置{authLabelSuffix}</span>
+        </>
+      ),
     },
     {
       id: "more-menu-enterprise",
@@ -86,7 +97,10 @@ export const MoreMenu: React.FC<MoreMenuProps> = ({
       run: handleEnterprise,
       content: (
         <>
-          <span>企业控制台</span>
+          <span className="more-menu-item-leading">
+            <HouseIcon className="more-menu-item-icon" />
+            <span>企业控制台</span>
+          </span>
           <ExternalLinkIcon className="more-menu-item-icon" />
         </>
       ),
@@ -97,7 +111,10 @@ export const MoreMenu: React.FC<MoreMenuProps> = ({
       run: handleHelpDocs,
       content: (
         <>
-          <span>帮助文档</span>
+          <span className="more-menu-item-leading">
+            <HelpCircleIcon className="more-menu-item-icon" />
+            <span>帮助文档</span>
+          </span>
           <ExternalLinkIcon className="more-menu-item-icon" />
         </>
       ),
@@ -108,12 +125,22 @@ export const MoreMenu: React.FC<MoreMenuProps> = ({
           className: "more-menu-item--danger",
           separator: true,
           run: onLogout,
-          content: <span>退出登录{authLabelSuffix}</span>,
+          content: (
+            <>
+              <LogOutIcon className="more-menu-item-icon" />
+              <span>退出登录{authLabelSuffix}</span>
+            </>
+          ),
         }
       : {
           id: "more-menu-login",
           run: onLogin,
-          content: <span>登录{authLabelSuffix}</span>,
+          content: (
+            <>
+              <LogOutIcon className="more-menu-item-icon" />
+              <span>登录{authLabelSuffix}</span>
+            </>
+          ),
         },
   ];
 

--- a/packages/webview/src/components/TaskList.tsx
+++ b/packages/webview/src/components/TaskList.tsx
@@ -164,16 +164,25 @@ export const TaskList: React.FC<TaskListProps> = ({
   ).length;
   const pending = visibleTasks.filter((t) => t.status === "pending").length;
 
+  // 状态 class 对齐 codechat .task-list-stat-dot.is-succeeded/is-running/is-pending，
+  // 供桌面端 host-desktop.css 覆盖为 codechat state 色（--cc-state-succeeded/running/idle）。
   const stats = [
     {
       count: completed,
       label: "已完成",
+      cls: "is-succeeded",
       color: "var(--vscode-testing-iconPassed, #73c991)",
     },
-    { count: inProgress, label: "进行中", color: "var(--wave-blue, #75beff)" },
+    {
+      count: inProgress,
+      label: "进行中",
+      cls: "is-running",
+      color: "var(--wave-blue, #75beff)",
+    },
     {
       count: pending,
       label: "待执行",
+      cls: "is-pending",
       color: "var(--vscode-icon-foreground, #cccccc)",
     },
   ];
@@ -195,7 +204,7 @@ export const TaskList: React.FC<TaskListProps> = ({
           {stats.map((s) => (
             <div key={s.label} className="task-list-stat">
               <span
-                className="task-list-stat-dot"
+                className={`task-list-stat-dot ${s.cls}`}
                 style={{ backgroundColor: s.color }}
               />
               <span className="task-list-stat-text">

--- a/packages/webview/src/styles/MoreMenu.css
+++ b/packages/webview/src/styles/MoreMenu.css
@@ -18,6 +18,7 @@
 .more-menu-item {
   display: flex;
   align-items: center;
+  gap: 8px;
   height: 24px;
   padding: 0 12px;
   border-radius: 4px;
@@ -34,6 +35,15 @@
 
 .more-menu-item--between {
   justify-content: space-between;
+}
+
+/* 前置图标与文字组合（企业控制台/帮助文档带尾部跳转图标时，图标需和文字
+   组成左组，避免 space-between 将其散开） */
+.more-menu-item-leading {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
 }
 
 /* 退出登录：危险色 + 上分隔线（spec「账户卡片」场景 4）. */

--- a/packages/webview/src/styles/host-desktop.css
+++ b/packages/webview/src/styles/host-desktop.css
@@ -986,6 +986,19 @@
   color: #1f2329;
 }
 
+/* hover 底色对齐设计系统 fill-hover（base vscode list-hoverBackground 蓝灰
+   调 #2a2d2e / rgba(0,0,0,.08) 未入规范；桌面同类 hover 统一 #EEF0F3 /
+   dark 8% 白 —— queued-item/菜单项先例）。active 标签 hover 保持激活底
+   （激活色更浅，hover 不覆盖为深一档的 fill-hover）。 */
+[data-host="desktop"][data-theme="light"] .preview-tab:not(.active):hover,
+[data-host="desktop"][data-theme="light"] .preview-tab:not(.active):focus-visible {
+  background: #eef0f3;
+}
+[data-host="desktop"][data-theme="dark"] .preview-tab:not(.active):hover,
+[data-host="desktop"][data-theme="dark"] .preview-tab:not(.active):focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+}
+
 /* ═══ 第十八轮：预览面板工具栏（对齐原型 InspectorPanel.vue）═══════
    参考 codechat-ui InspectorPanel.vue + global.css：地址栏 44px 高 / 白底
    #FFF（--cc-bg-panel）/ 底分隔线 #EBEEF5（--cc-border-lighter）；地址输入框

--- a/packages/webview/src/styles/host-desktop.css
+++ b/packages/webview/src/styles/host-desktop.css
@@ -1633,3 +1633,165 @@
 [data-host="desktop"] .panel-toggle-menu {
   gap: 0;
 }
+
+/* ═══ 0902 新基线第 2 轮：任务列表/消息队列卡片对齐输入框规格 ═══
+   用户评论 div.task-list-inline「任务列表和消息列队的整体宽度应该和下方的
+   输入框保持一致，圆角也和下方输入框保持统一，字号14px，消息列队选项高度32px」。
+   desktop 输入框规格：.input-wrapper 768px / .input-content r16 / 字号 14；
+   base 两卡 max-width 800、r8、字号 12、队列项高 24 → 全部覆盖对齐。
+   注意：task 卡 + queued 卡连体（:has 归零）时外轮廓 = task 顶角 + queued
+   底角，中间连接处归零保持连体单卡外观（同 base 结构，仅半径 8 → 16）。 */
+
+[data-host="desktop"] .task-list-inline,
+[data-host="desktop"] .queued-message-list-container {
+  max-width: 768px;
+  border-radius: 16px;
+}
+
+/* 连体组合态（task 卡下缘 / queued 卡上缘）圆角归零——base 同结构规则
+   specificity (0,2,0) 会被上方简写 border-radius (0,2,0) 后加载覆盖，
+   此处加 [data-host] 提升到 (0,3,0) 显式重写归零。 */
+[data-host="desktop"]
+  .task-list-inline:has(+ .queued-message-list-container) {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+[data-host="desktop"] .task-list-inline + .queued-message-list-container {
+  border-top: none;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+/* 字号：主体文字 12 → 14（标题/任务行/队列标题/队列条目），行高同步 16 → 20。
+   注意：统计文字「已完成 3」等为次级信息，保持 codechat 层级弱化
+   （--cc-text-secondary #6C7076 + --cc-font-size-xs 12px），不并入 14px 组。 */
+[data-host="desktop"] .task-list-title,
+[data-host="desktop"] .task-title,
+[data-host="desktop"] .queued-message-list-title,
+[data-host="desktop"] .queued-item-text {
+  font-size: 14px;
+  line-height: 20px;
+}
+
+/* 统计文字「已完成 3 进行中 1 待执行 0」：12px 次级弱化（用户评论「字号应该是
+   12px，字体层级弱化」；codechat .task-list-stat 同值）。行高 16 保持 base。 */
+[data-host="desktop"] .task-list-stat-text {
+  font-size: 12px;
+  line-height: 16px;
+  color: #6c7076;
+}
+[data-host="desktop"][data-theme="dark"] .task-list-stat-text {
+  color: #9a9ea5;
+}
+
+/* 消息队列选项高 24 → 32（用户评论「消息列队选项高度32px」）；hover 底对齐
+   规范：r6（--cc-radius-sm，base 4px 过小）+ fill-hover 底色（light #EEF0F3 /
+   dark 8% 白），替换 base 的 vscode list-hoverBackground 蓝灰调。 */
+[data-host="desktop"] .queued-item {
+  height: 32px;
+  border-radius: 6px;
+}
+[data-host="desktop"] .queued-item:hover {
+  background: #eef0f3;
+}
+[data-host="desktop"][data-theme="dark"] .queued-item:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+/* 卡片组合与下方输入框间距 8px（用户评论「整体卡片和下方对话框要有间距8px」；
+   codechat .composer-task-list margin: 0 auto 8px 同值）。连体时 task 卡与
+   queued 卡之间不留间距（8px 由 queued 卡的 margin-bottom 提供），
+   单独出现（无连体兄弟）的卡自行带 8px。 */
+[data-host="desktop"] .queued-message-list-container {
+  margin-bottom: 8px;
+}
+[data-host="desktop"] .task-list-inline {
+  margin-bottom: 8px;
+}
+[data-host="desktop"]
+  .task-list-inline:has(+ .queued-message-list-container) {
+  margin-bottom: 0;
+}
+
+/* 任务列表滚动上限 102 → 110：字号 14 后行高 20px，保持「最多同屏 4 个
+   任务」（4 × 20 + 3 × 10 = 110），避免第 4 个任务被裁半。 */
+[data-host="desktop"] .task-list-items {
+  max-height: 110px;
+}
+
+/* ═══ 0902 新基线第 2 轮 · 颜色合规：任务/队列状态色对齐 codechat state tokens ═══
+   用户评论「检查任务列表、消息列表中的颜色，看看是否符合规范」。
+   权威值：codechat tokens.css --cc-state-succeeded #16a34a / --cc-state-running
+   #2f5edb / --cc-state-idle #98a2b3（TaskList.vue 的 dot 与行 icon 共用这三色）；
+   wave 内部同色系先例：时间线节点 #16a34a、桌面链接 #2f5edb/#4daafc。
+   base 违规点：① TaskList.tsx stats 内联色用 vscode token（完成 #73c991、
+   运行中 #75beff、待执行 #606060/#ccc，与 codechat 不同）；② 行 icon svg
+   fill 硬编码 PassIcon #89D185、Loading/Pending #cccccc，与 dot 同状态不同色。
+
+   修复：TaskList.tsx 为 dot 与行容器补 is-succeeded/is-running/is-pending
+   状态类（对齐 codechat task-stat-dot / task-list-item-icon 命名），此处按类
+   覆盖。dot 为组件内联 style，需 !important；svg fill 为 presentation
+   attribute，普通 fill 规则即可覆盖（无需 important）。深色沿用浅色值：
+   codechat 无 dark token，状态色与 wave 时间线/会话看板一致深浅同值。 */
+
+[data-host="desktop"] .task-list-stat-dot.is-succeeded {
+  background-color: #16a34a !important;
+}
+[data-host="desktop"] .task-list-stat-dot.is-running {
+  background-color: #2f5edb !important;
+}
+[data-host="desktop"] .task-list-stat-dot.is-pending {
+  background-color: #98a2b3 !important;
+}
+
+/* 行内状态图标与 dot 同色（codechat task-list-item-icon 三状态同 token）：
+   行容器 .task-status 无状态类，用行内标题状态 class 反推（:has） */
+[data-host="desktop"]
+  .task-row:has(.task-title.completed)
+  .task-status-svg
+  path {
+  fill: #16a34a;
+}
+[data-host="desktop"]
+  .task-row:has(.task-title.in_progress)
+  .task-status-svg
+  path {
+  fill: #2f5edb;
+}
+[data-host="desktop"] .task-row:has(.task-title.pending) .task-status-svg path {
+  fill: #98a2b3;
+}
+
+/* 依赖行「依赖 #x」：桌面链接蓝（base var(--vscode-textLink-foreground)
+   light #0069cc 偏深蓝，不符合桌面链接规范；dark #4daafc 已对） */
+[data-host="desktop"] .task-dep {
+  color: #2f5edb;
+}
+[data-host="desktop"][data-theme="dark"] .task-dep {
+  color: #4daafc;
+}
+
+/* 队列卡其余控件颜色：① 两卡 header 展开 chevron 加入「控件图标统一灰」
+   （base var(--vscode-foreground) 黑 → #565a60，同第 38 轮 sidebar 分组
+   chevron / header 图标清单）；② queued-action-button（hover 编辑图标等）
+   常态色 base icon-foreground #606060 → 图标灰 #565a60；hover 底色对齐
+   行内操作按钮先例（session-more-btn hover：#e7e9ed 在浅灰行上仍可辨，
+   深色 12% 白），hover 文字加深为 #1f2329/#ffffff。 */
+[data-host="desktop"] .task-list-chevron,
+[data-host="desktop"] .queued-chevron,
+[data-host="desktop"] .queued-action-button {
+  color: #565a60;
+}
+[data-host="desktop"][data-theme="dark"] .task-list-chevron,
+[data-host="desktop"][data-theme="dark"] .queued-chevron,
+[data-host="desktop"][data-theme="dark"] .queued-action-button {
+  color: #9a9ea5;
+}
+[data-host="desktop"][data-theme="light"] .queued-action-button:hover {
+  background-color: #e7e9ed;
+  color: #1f2329;
+}
+[data-host="desktop"][data-theme="dark"] .queued-action-button:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+}

--- a/packages/webview/src/styles/host-desktop.css
+++ b/packages/webview/src/styles/host-desktop.css
@@ -878,6 +878,13 @@
 [data-host="desktop"] .write-tool-path:hover {
   text-decoration: underline;
 }
+/* bash 命令输出内链接加入 dark 覆盖（第 26 轮遗漏：原规则仅覆盖
+   write-tool-path 与 markdown-content a，bash 输出链接 dark 下仍为浅色
+   #2f5edb，与 markdown 链接 #4daafc 不一致） */
+[data-host="desktop"][data-theme="dark"] .bash-command-output a,
+[data-host="desktop"][data-theme="dark"] .bash-command-output a:hover {
+  color: #4daafc;
+}
 [data-host="desktop"] .bash-command-output a:hover {
   color: #2f5edb;
   text-decoration: underline;

--- a/packages/webview/src/styles/host-desktop.css
+++ b/packages/webview/src/styles/host-desktop.css
@@ -218,12 +218,15 @@
   .permission-mode-select.mode-bypassPermissions {
   color: #f4655c;
 }
-[data-host="desktop"][data-theme="dark"] .permission-mode-select:hover {
+[data-host="desktop"][data-theme="dark"] .permission-mode-select:hover,
+[data-host="desktop"][data-theme="dark"] .permission-mode-select:focus {
   background: rgba(255, 255, 255, 0.08);
   color: #fff;
 }
 [data-host="desktop"][data-theme="dark"]
-  .permission-mode-select.mode-bypassPermissions:hover {
+  .permission-mode-select.mode-bypassPermissions:hover,
+[data-host="desktop"][data-theme="dark"]
+  .permission-mode-select.mode-bypassPermissions:focus {
   color: #f4655c;
 }
 
@@ -366,7 +369,7 @@
 /* 深色模式：--vscode-fill-light 未定义会回退浅灰 #f5f7fa 突兀；
    用比卡片(#313131)略深的灰形成「卡片在上、灰条在下」层次 */
 [data-host="desktop"][data-theme="dark"] .input-workdir-row {
-  background: #27292b;
+  background: #292929;
 }
 
 /* 灰条内控件按钮化：Figma「本地 / 选择工作目录」按钮 32 高、r8（base

--- a/packages/webview/src/styles/host-desktop.css
+++ b/packages/webview/src/styles/host-desktop.css
@@ -597,6 +597,21 @@
   background: rgba(255, 255, 255, 0.14);
 }
 
+/* 账户卡片「更多」按钮（问号圆图标）：与热区同行同规格——r6、hover 底同
+   热区（ccui figma-icon-button / sidebar-account-more 32×32 r6 fill-hover；
+   base r4 + vscode list-hoverBackground 蓝灰与热区两档灰不一致） */
+[data-host="desktop"] .account-card-more-btn {
+  border-radius: 6px;
+}
+[data-host="desktop"][data-theme="light"] .account-card-more-btn:hover,
+[data-host="desktop"][data-theme="light"] .account-card-more-btn:focus-visible {
+  background: #e2e4e8;
+}
+[data-host="desktop"][data-theme="dark"] .account-card-more-btn:hover,
+[data-host="desktop"][data-theme="dark"] .account-card-more-btn:focus-visible {
+  background: rgba(255, 255, 255, 0.14);
+}
+
 /* 消息流时间线节点：Figma design-node 12px / #16A34A / 白描边（覆盖此前
    codechat 推断的 8px 灰点）；行 padding-left 12px → 20px（节点 12 + gap 8） */
 [data-host="desktop"] .timeline-row {


### PR DESCRIPTION
## 概述

视觉设计师 Figma 走查桌面端 0902 新基线第 1-6 轮优化，rebase 至最新 main。

## 改动内容

**第 1 轮**：新会话上下文栏（灰条）深色背景去蓝偏 `#27292B` → `#292929`；权限按钮深色 `:focus` 反白修复（`permission-mode-select` 深色段 `:hover` 扩展为 `:hover, :focus`）。

**第 2 轮**：任务列表/消息队列卡片对齐输入框规格（宽 768 / r16 / 字号 14 / 队列项 32px 高 / 8px 间距）+ 状态色对齐 codechat state tokens（`#16a34a/#2f5edb/#98a2b3`，TaskList.tsx 补 `is-succeeded/is-running/is-pending` 类）。

**第 3+4 轮**：more-menu 菜单项前置 lucide 图标（设置齿轮/企业房子/帮助文档/退出箭头，对齐 ccui TaskSidebar，HeaderIcons 新增 5 个图标组件）；bash 输出内链接深色补覆盖 `#4daafc`。

**第 5 轮**：账户更多按钮三点 → 问号圆（HelpCircleIcon），帮助文档菜单项图标换文档图标（FileTextIcon）；更多按钮 hover 底/圆角对齐热区规格。

**第 6 轮**：预览标签 hover 底色对齐 fill-hover（light `#EEF0F3` / dark 8% 白，active 标签 hover 不漂移）。

docs/desktop-density-restore.md 同步记录各轮走查结论与验证。

## 影响范围

- `packages/webview/src`（共享组件 + host-desktop.css，CSS 覆盖均带 `[data-host="desktop"]` 门控，IDE 端不受样式影响）
- `docs/desktop-density-restore.md` 追加

## 验证

- webview type-check（4 工程）+ compile 通过
- webview 单测 95 files / 806 tests 全绿
- oxlint 0 warnings 0 errors
- rebase 最新 main 零冲突（main 侧 3 commits 在 host-desktop.css 仅动 ConfirmationDialog 注释段，无重叠）