### PR TITLE
feat(daemon): AskUserQuestion 完整渲染与按序号应答

### DIFF
--- a/docs/specs/ui/daemon-command.md
+++ b/docs/specs/ui/daemon-command.md
@@ -79,7 +79,7 @@ order: 270
 1. **假设** 目标会话正在生成回复，**当** 用户运行 `wave daemon status <sessionId>` 时，**则** 命令经 `initialize {restoreSessionId}` + `restoreSession` attach 该会话，依据重放的 `loadingChange` 快照显示 generating（生成中）状态。
 2. **假设** 目标会话空闲（未在生成、无排队消息、无后台任务），**当** 用户运行 `wave daemon status <sessionId>` 时，**则** 显示 idle 状态。
 3. **假设** 目标会话挂起等待权限审批，**当** 用户运行 `wave daemon status <sessionId>` 时，**则** 状态显示为 waiting for approval（`loadingChange` 保持 loading 即视为未空闲），与桌面端「待确认」语义一致。
-4. **假设** 目标会话挂起等待权限审批，**当** 查看最近消息时，**则** 最后一条 assistant 消息含一个冻结在 `stage: "running"` 的 tool 块：有工具名与参数（`name`/`parameters`/`compactParams`），但无 `result`/`success`/`error`/`shortResult`/`timestamp`——这些字段只在工具完成后（`stage: "end"`）写入，无独立的 pending stage；消息形态上「等审批」与「执行中」无法区分，status 须同时列出 `listPendingPermissions` 返回的待审批请求（工具名 + 参数摘要），作为审批态的确凿信号。
+4. **假设** 目标会话挂起等待权限审批，**当** 查看最近消息时，**则** 最后一条 assistant 消息含一个冻结在 `stage: "running"` 的 tool 块：有工具名与参数（`name`/`parameters`/`compactParams`），但无 `result`/`success`/`error`/`shortResult`/`timestamp`——这些字段只在工具完成后（`stage: "end"`）写入，无独立的 pending stage；消息形态上「等审批」与「执行中」无法区分，status 须同时列出 `listPendingPermissions` 返回的待审批请求（工具名 + 参数摘要），作为审批态的确凿信号；其中 AskUserQuestion 请求不做单行截断，改为与桌面确认弹窗同构的多行完整渲染——每题一行标题（含题号与 header 标签，如 `Q1 [删除文案] 删除会话后转录…`）、每选项一行（含从 0 起的序号与说明，如 `  0. 更新文案明示可恢复（推荐） — 说明…`），完整展示问题与选项；其余工具的请求仍按单行参数摘要展示。
 5. **假设** 会话已有历史消息，**当** 用户运行 `wave daemon status <sessionId>` 时，**则** 经 `getMessages` 拉取并显示最近若干条消息的文本（含用户消息与助手回复，默认数量可经参数调整，如 `--lines 20`），足以判断任务进展。
 6. **假设** 指定的 sessionId 不存在于该 daemon，**当** 用户运行 `wave daemon status <sessionId>` 时，**则** 以非零退出码退出并给出明确错误（Session not found or not hosted by this daemon）。
 7. **假设** status 命令完成展示后，**当** 命令退出时，**则** 断开与 daemon 的连接（attach 是短暂查看，不常驻），daemon 与目标会话不受影响、继续运行。
@@ -88,11 +88,11 @@ order: 270
 
 ### 用户故事：响应会话挂起的权限审批（优先级：P0）
 
-作为在远端主机驱动后台会话的用户，我希望 `wave daemon respond <sessionId> <requestId> [--allow|--deny] [--answer <答案JSON>] [--rule <规则>] [--mode <模式>]` 处理会话挂起的权限请求（允许/拒绝、回答提问、记住规则、切换权限模式），以便推进卡在等待审批的会话。
+作为在远端主机驱动后台会话的用户，我希望 `wave daemon respond <sessionId> <requestId> [--allow|--deny] [--answer <答案JSON|选项序号>] [--rule <规则>] [--mode <模式>]` 处理会话挂起的权限请求（允许/拒绝、回答提问、记住规则、切换权限模式），以便推进卡在等待审批的会话。
 
 **为什么是这个优先级**：等待审批的会话会一直保持 loading（等同未空闲），不处理就无法继续；协议已有 `permissionResponse` 通知方法（客户端 → 服务端，requestId 进程内全局唯一，见 protocol.ts / agentBridge.ts），无需新增协议方法，纯 CLI 封装即可解锁。审批决策并非单一 allow/deny——`PermissionDecision` 含 behavior/message/newPermissionMode/newPermissionRule 四个字段（桌面端按工具类型组合：EnterPlanMode 附带 `newPermissionMode:"plan"`、AskUserQuestion 用 message 携带答案 JSON、Bash 可带 `newPermissionRule`），命令须按工具智能补全并与桌面端语义一致。
 
-**独立测试**：对一条挂起 Bash 审批的会话运行 `wave daemon respond <sessionId> <requestId> --allow`，验证工具继续执行、会话恢复生成；对一条挂起 AskUserQuestion 的会话运行 `--answer '{"问题":"答案"}'`，验证答案送达；对 EnterPlanMode 运行 `--allow`，验证自动附带 plan 模式切换。
+**独立测试**：对一条挂起 Bash 审批的会话运行 `wave daemon respond <sessionId> <requestId> --allow`，验证工具继续执行、会话恢复生成；对一条挂起 AskUserQuestion 的会话运行 `--answer '{"问题":"答案"}'` 或按 `wave daemon status` 渲染的选项序号运行 `--answer "0"`（多题逗号分隔，如 `--answer "1,0"`），验证答案送达且等价；对 EnterPlanMode 运行 `--allow`，验证自动附带 plan 模式切换。
 
 **验收场景**：
 
@@ -105,6 +105,7 @@ order: 270
 7. **假设** 指定的 requestId 不存在（已被其他客户端处理或已过期），**当** 用户运行 respond 时，**则** 命令提示「Request not found or already handled」并以非零退出码退出（服务端对未知 requestId 静默忽略，命令应先行校验避免误导）。
 8. **假设** 指定的 sessionId 不存在于该 daemon，**当** 用户运行 `wave daemon respond <sessionId> <requestId> --allow` 时，**则** 以非零退出码退出并给出明确错误（Session not found or not hosted by this daemon），不发送任何通知。
 9. **假设** respond 命令完成（成功或失败）后，**当** 命令退出时，**则** 断开与 daemon 的连接；会话恢复生成或回到空闲，不因客户端退出而终止。
+10. **假设** 目标会话挂起 AskUserQuestion 审批、`wave daemon status` 已多行渲染题目与带序号的选项，**当** 用户运行 `wave daemon respond <sessionId> <requestId> --answer "1,0"`（逗号分隔的选项序号，第 i 个数字 = 第 i 题的选项序号、从 0 起，与 status 渲染的序号一致）时，**则** 命令将序号映射为该题对应选项的 label，构造与桌面端一致的答案对象（key=问题原文、value=选项 label；multiSelect 题取 label 数组）并经 `{behavior:"allow", message: JSON.stringify(答案对象)}` 送达；序号数量与题目数不符、含非数字或越界时以非零退出码报错并提示合法范围；`--answer` 为合法 JSON 对象（key=问题原文）时仍按既有格式解析（向后兼容），仅 JSON 解析失败或非对象内容才走序号解析。
 
 ---
 
@@ -174,8 +175,8 @@ order: 270
 - **destroy 是幂等注册表操作**：协议 `destroy` 按信封 sessionId 直接删除注册表项（未知会话静默 no-op），无 attach、不创建会话；与 `abort` 不同，destroy 不检查会话是否存活、也不关心是否生成中，只负责销毁。
 - **create --worktree 的 workdir 语义**：worktree 路径是链接 worktree 的顶层（`git rev-parse --show-toplevel` 从该目录的返回），而非主仓根；`--worktree` 与 `--workdir` 同时给出时以 `--worktree` 为准（workdir 仅作为 createWorktree 的源仓库起点）。name 缺省（裸 `--worktree`）时由服务端自动生成随机名。
 - **destroy --remove-worktree 的守卫**：repoRoot 语义与 `createWorktree` 返回值一致（主仓根，`git worktree list --porcelain` 第一项），worktree 路径用 `rev-parse --show-toplevel`（从链接 worktree 返回其自身路径）；两者相等即普通工作目录而非链接 worktree——拒绝移除主工作树，防止 removeWorktree 的 fs.rmSync 回退删掉整个仓库。hookBased 按该仓库是否配置 WorktreeCreate hook 判定（与 createWorktree 的返回一致），hook 管理的工作树交给 WorktreeRemove hook 清理、wave 不跑 `git worktree remove`。git 反查失败（非 git 仓库）时报错退出，不销毁会话。
-- **会话挂起等待审批**：daemon 语义下「等待审批」的会话保持 loading 状态（等同未空闲）；消息中该工具块冻结在 `stage: "running"`（有工具名与参数、无结果字段，结果字段只在 `stage: "end"` 写入），单凭消息无法区分「等审批」与「执行中」，须结合 `listPendingPermissions` 判断；`send` 须有 `--timeout` 兜底避免无限挂起，`status` 应如实显示该状态，`respond` 是处理挂起请求的入口。
-- **respond 的决策并非单一 allow/deny**：`PermissionDecision` 含 behavior/message/newPermissionMode/newPermissionRule 四个字段；EnterPlanMode 的 allow 必须附带 `newPermissionMode:"plan"`（按工具智能补全），AskUserQuestion 必须用 `--answer` 提供答案（allow 且 message 为答案 JSON），Bash/Edit 可选 `--rule`/`--mode`；命令须与桌面端行为一致，不得把多选项压成裸 allow/deny。
+- **会话挂起等待审批**：daemon 语义下「等待审批」的会话保持 loading 状态（等同未空闲）；消息中该工具块冻结在 `stage: "running"`（有工具名与参数、无结果字段，结果字段只在 `stage: "end"` 写入），单凭消息无法区分「等审批」与「执行中」，须结合 `listPendingPermissions` 判断；`send` 须有 `--timeout` 兜底避免无限挂起，`status` 应如实显示该状态（AskUserQuestion 请求多行完整渲染、其余工具单行摘要，见「查看会话进度与最近消息」场景 4），`respond` 是处理挂起请求的入口。
+- **respond 的决策并非单一 allow/deny**：`PermissionDecision` 含 behavior/message/newPermissionMode/newPermissionRule 四个字段；EnterPlanMode 的 allow 必须附带 `newPermissionMode:"plan"`（按工具智能补全），AskUserQuestion 必须用 `--answer` 提供答案（allow 且 message 为答案 JSON），Bash/Edit 可选 `--rule`/`--mode`；命令须与桌面端行为一致，不得把多选项压成裸 allow/deny。`--answer` 支持两种格式：合法 JSON 对象（key=问题原文、value=选项 label，与桌面端提交的答案对象同构，向后兼容）或逗号分隔的选项序号（第 i 个数字 = 第 i 题的选项序号、从 0 起，与 `status` 渲染序号一致；仅 JSON 解析失败或非对象内容才走序号解析）。
 - **requestId 幂等与过期**：服务端对未知 requestId 的 `permissionResponse` 静默忽略；respond 应先行校验（如经 `listPendingPermissions`）并在 requestId 已处理时明确提示，避免用户误以为审批已生效。
 - **`send` 输出纯净性**：命令输出助手最终回复文本，流式通知与子代理内部信息不得泄漏到 stdout（与打印模式一致），诊断信息走 stderr。
 - **`abort` 中断是幂等操作**：在空闲会话上是无害 no-op，命令仍成功返回；对正在生成（含子代理、bash 命令、slash 命令）或挂起审批的会话，中断后回到空闲（与桌面端中断按钮语义一致）。`abort` 不清除已完成的对话历史，只打断进行中的生成并清空消息队列；无需先经 `status` 确认是否正在生成。

--- a/packages/code/src/daemon/commands.ts
+++ b/packages/code/src/daemon/commands.ts
@@ -34,6 +34,7 @@ import {
   getMessageContent,
   hasWorktreeCreateHook,
   loadMergedWaveConfig,
+  type AskUserQuestion,
   type Message,
   type PermissionDecision,
   type PermissionMode,
@@ -304,6 +305,96 @@ function summarizeToolInput(context: ToolPermissionContext): string {
   return text.length > 80 ? `${text.slice(0, 80)}…` : text;
 }
 
+/** The questions array of an AskUserQuestion toolInput (SDK schema), if any. */
+function getAskUserQuestions(
+  context: ToolPermissionContext,
+): AskUserQuestion[] | undefined {
+  const raw = context.toolInput?.questions;
+  return Array.isArray(raw) && raw.length > 0
+    ? (raw as AskUserQuestion[])
+    : undefined;
+}
+
+/**
+ * Multi-line full render of an AskUserQuestion tool input, mirroring the
+ * desktop ConfirmationDialog layout so the CLI user sees every question and
+ * option (spec: daemon-command.md AskUserQuestion 多行完整渲染). Question
+ * lines carry the 1-based question number + header; option lines carry the
+ * 0-based number that `respond --answer` accepts.
+ */
+function renderAskUserQuestions(context: ToolPermissionContext): string {
+  const questions = getAskUserQuestions(context);
+  if (!questions) return "";
+  return questions
+    .map((q, qi) => {
+      const title = `    Q${qi + 1} [${q.header}] ${q.question}`;
+      const options = (q.options ?? []).map(
+        (o, oi) =>
+          `      ${oi}. ${o.label}${o.description ? ` — ${o.description}` : ""}`,
+      );
+      return [title, ...options].join("\n");
+    })
+    .join("\n");
+}
+
+/**
+ * Parse `respond --answer` for an AskUserQuestion request. Legacy format — a
+ * valid JSON object keyed by the full question text (value = the option label,
+ * exactly what the desktop dialog would submit) — passes through untouched.
+ * Anything else is parsed as comma-separated option numbers: the i-th number
+ * answers the i-th question (as numbered Q1..Qn by `wave daemon status`),
+ * 0-based like the status rendering, and is mapped to that option's label so
+ * the model sees the same answers the GUI would produce.
+ */
+function parseAskUserQuestionAnswer(
+  raw: string,
+  context: ToolPermissionContext,
+): Record<string, unknown> {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed)
+    ) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Not JSON — fall through to per-question option numbers below.
+  }
+  const questions = getAskUserQuestions(context);
+  if (!questions) {
+    fail(
+      `Cannot parse --answer "${raw}": not a JSON object of {question: answer} and the pending request has no questions to answer by number`,
+    );
+  }
+  const numbers = raw.split(",").map((n) => n.trim());
+  if (numbers.length !== questions.length) {
+    fail(
+      `--answer must give one option number per question (${questions.length} question${questions.length > 1 ? "s" : ""}, comma-separated, matching the numbering in \`wave daemon status\`): got ${numbers.length} number${numbers.length > 1 ? "s" : ""} in "${raw}"`,
+    );
+  }
+  const answers: Record<string, unknown> = {};
+  numbers.forEach((n, qi) => {
+    const q = questions[qi];
+    if (!/^\d+$/.test(n)) {
+      fail(
+        `--answer contains a non-numeric option number "${n}" for question ${qi + 1} (${q.question})`,
+      );
+    }
+    const options = q.options ?? [];
+    const idx = Number(n);
+    if (idx >= options.length) {
+      fail(
+        `Option number ${n} is out of range for question ${qi + 1} (${q.question}): options are numbered 0..${options.length - 1}`,
+      );
+    }
+    const label = options[idx].label;
+    answers[q.question] = q.multiSelect ? [label] : label;
+  });
+  return answers;
+}
+
 export async function daemonStatusCommand(
   socketPath: string,
   sessionId: string,
@@ -350,6 +441,14 @@ export async function daemonStatusCommand(
       console.log("");
       console.log("Pending approval requests:");
       for (const r of pending) {
+        if (r.context.toolName === ASK_USER_QUESTION_TOOL_NAME) {
+          const questions = renderAskUserQuestions(r.context);
+          if (questions) {
+            console.log(`  ${r.requestId}  ${r.context.toolName}`);
+            console.log(questions);
+            continue;
+          }
+        }
         const params = summarizeToolInput(r.context);
         console.log(
           `  ${r.requestId}  ${r.context.toolName}${params ? `  ${params}` : ""}`,
@@ -532,15 +631,10 @@ export async function daemonRespondCommand(
       } else if (toolName === ASK_USER_QUESTION_TOOL_NAME) {
         if (!options.answer) {
           fail(
-            "AskUserQuestion requests require --answer with the answer JSON",
+            'AskUserQuestion requests require --answer: a JSON object of {question: answer}, or option numbers per question (e.g. "0" or "1,0", see the numbering in `wave daemon status`)',
           );
         }
-        let answers: unknown;
-        try {
-          answers = JSON.parse(options.answer);
-        } catch {
-          fail("--answer is not valid JSON");
-        }
+        const answers = parseAskUserQuestionAnswer(options.answer, req.context);
         decision = { behavior: "allow", message: JSON.stringify(answers) };
       } else {
         decision = { behavior: "allow" };

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -383,7 +383,8 @@ export async function main() {
                     type: "string",
                   })
                   .option("answer", {
-                    describe: "Answers JSON for AskUserQuestion requests",
+                    describe:
+                      'AskUserQuestion answers: JSON object of {question: answer} or option numbers per question (e.g. "0" or "1,0")',
                     type: "string",
                   })
                   .option("rule", {

--- a/packages/code/tests/daemon/commands.test.ts
+++ b/packages/code/tests/daemon/commands.test.ts
@@ -476,6 +476,58 @@ test("status: pending approval shows waiting for approval + the request list", a
   expect(exitSpy).toHaveBeenCalledWith(0);
 });
 
+test("status: AskUserQuestion pending renders every question + numbered option in full, not a truncated JSON summary", async () => {
+  await createPendingRequest("AskUserQuestion", {
+    questions: [
+      {
+        question: "删除会话后转录内容如何处理？",
+        header: "删除会话",
+        options: [
+          { label: "保留现状（推荐）", description: "jsonl 与目录共存" },
+          { label: "一并清理", description: "删除 jsonl 并清理痕迹" },
+        ],
+      },
+      {
+        question: "历史对话弹窗列出哪些会话？",
+        header: "恢复范围",
+        options: [{ label: "全部项目" }, { label: "仅当前项目" }],
+      },
+    ],
+  });
+
+  await expect(
+    daemonStatusCommand(socketPath, "test-session-id"),
+  ).rejects.toThrow("exit(0)");
+  const block = stdoutLines().join("\n");
+  expect(block).toContain("Status: waiting for approval");
+  expect(block).toContain("perm_1  AskUserQuestion");
+  expect(block).toContain("Q1 [删除会话] 删除会话后转录内容如何处理？");
+  expect(block).toContain("0. 保留现状（推荐） — jsonl 与目录共存");
+  expect(block).toContain("1. 一并清理 — 删除 jsonl 并清理痕迹");
+  expect(block).toContain("Q2 [恢复范围] 历史对话弹窗列出哪些会话？");
+  expect(block).toContain("0. 全部项目");
+  expect(block).toContain("1. 仅当前项目");
+  // Rendered as readable lines, never as the single-line truncated JSON blob.
+  expect(block).not.toContain('"questions":');
+  expect(exitSpy).toHaveBeenCalledWith(0);
+});
+
+test("status: malformed AskUserQuestion input falls back to the single-line summary", async () => {
+  await createPendingRequest("AskUserQuestion", {
+    question: "没有 questions 数组的旧形态",
+  });
+
+  await expect(
+    daemonStatusCommand(socketPath, "test-session-id"),
+  ).rejects.toThrow("exit(0)");
+  const out = stdoutLines();
+  expect(out).toContain("Status: waiting for approval");
+  expect(
+    out.some((l) => l.includes("perm_1") && l.includes("AskUserQuestion")),
+  ).toBe(true);
+  expect(exitSpy).toHaveBeenCalledWith(0);
+});
+
 test("status: nonexistent session fails, destroys the junk fresh session, registry stays clean", async () => {
   const junk = createMockAgent({
     sessionId: "fresh",
@@ -748,12 +800,12 @@ test("respond: AskUserQuestion without --answer fails", async () => {
     }),
   ).rejects.toThrow("exit(1)");
   expect(stderrText()).toContain(
-    "AskUserQuestion requests require --answer with the answer JSON",
+    "AskUserQuestion requests require --answer: a JSON object of {question: answer}, or option numbers per question",
   );
   expect(exitSpy).toHaveBeenCalledWith(1);
 });
 
-test("respond: AskUserQuestion with invalid JSON --answer fails", async () => {
+test("respond: AskUserQuestion with an unparseable --answer fails", async () => {
   await createPendingRequest("AskUserQuestion", { question: "继续吗" });
 
   await expect(
@@ -762,7 +814,141 @@ test("respond: AskUserQuestion with invalid JSON --answer fails", async () => {
       answer: "not-json",
     }),
   ).rejects.toThrow("exit(1)");
-  expect(stderrText()).toContain("--answer is not valid JSON");
+  expect(stderrText()).toContain(
+    'Cannot parse --answer "not-json": not a JSON object of {question: answer} and the pending request has no questions to answer by number',
+  );
+  expect(exitSpy).toHaveBeenCalledWith(1);
+});
+
+test("respond: --answer with comma-separated option numbers maps to the question option labels", async () => {
+  const { permissionPromise } = await createPendingRequest("AskUserQuestion", {
+    questions: [
+      {
+        question: "Q1 继续处理吗？",
+        header: "继续",
+        options: [{ label: "保留现状" }, { label: "一并清理" }],
+      },
+      {
+        question: "Q2 范围多大？",
+        header: "范围",
+        options: [
+          { label: "仅当前项目" },
+          { label: "全部项目" },
+          { label: "其他" },
+        ],
+      },
+    ],
+  });
+
+  await expect(
+    daemonRespondCommand(socketPath, "test-session-id", "perm_1", {
+      allow: true,
+      answer: "1,0",
+    }),
+  ).rejects.toThrow("exit(0)");
+  // The i-th number answers the i-th question (0-based options, matching the
+  // numbering `wave daemon status` renders): 1 -> 一并清理, 0 -> 仅当前项目.
+  await expect(permissionPromise).resolves.toEqual({
+    behavior: "allow",
+    message: JSON.stringify({
+      "Q1 继续处理吗？": "一并清理",
+      "Q2 范围多大？": "仅当前项目",
+    }),
+  });
+  expect(exitSpy).toHaveBeenCalledWith(0);
+});
+
+test("respond: --answer by option number on a multiSelect question submits a label array like the dialog", async () => {
+  const { permissionPromise } = await createPendingRequest("AskUserQuestion", {
+    questions: [
+      {
+        question: "开启哪些功能？",
+        header: "功能",
+        multiSelect: true,
+        options: [{ label: "钩子" }, { label: "技能" }],
+      },
+    ],
+  });
+
+  await expect(
+    daemonRespondCommand(socketPath, "test-session-id", "perm_1", {
+      allow: true,
+      answer: "1",
+    }),
+  ).rejects.toThrow("exit(0)");
+  await expect(permissionPromise).resolves.toEqual({
+    behavior: "allow",
+    message: JSON.stringify({ "开启哪些功能？": ["技能"] }),
+  });
+  expect(exitSpy).toHaveBeenCalledWith(0);
+});
+
+test("respond: --answer option numbers must match the question count", async () => {
+  await createPendingRequest("AskUserQuestion", {
+    questions: [
+      {
+        question: "Q1 继续吗？",
+        header: "继续",
+        options: [{ label: "是" }, { label: "否" }],
+      },
+    ],
+  });
+
+  await expect(
+    daemonRespondCommand(socketPath, "test-session-id", "perm_1", {
+      allow: true,
+      answer: "0,1",
+    }),
+  ).rejects.toThrow("exit(1)");
+  expect(stderrText()).toContain(
+    "--answer must give one option number per question (1 question",
+  );
+  expect(exitSpy).toHaveBeenCalledWith(1);
+});
+
+test("respond: --answer option number out of range fails with the valid range", async () => {
+  await createPendingRequest("AskUserQuestion", {
+    questions: [
+      {
+        question: "Q1 继续吗？",
+        header: "继续",
+        options: [{ label: "是" }, { label: "否" }],
+      },
+    ],
+  });
+
+  await expect(
+    daemonRespondCommand(socketPath, "test-session-id", "perm_1", {
+      allow: true,
+      answer: "5",
+    }),
+  ).rejects.toThrow("exit(1)");
+  expect(stderrText()).toContain(
+    "Option number 5 is out of range for question 1 (Q1 继续吗？): options are numbered 0..1",
+  );
+  expect(exitSpy).toHaveBeenCalledWith(1);
+});
+
+test("respond: --answer with a non-numeric option number fails", async () => {
+  await createPendingRequest("AskUserQuestion", {
+    questions: [
+      {
+        question: "Q1 继续吗？",
+        header: "继续",
+        options: [{ label: "是" }, { label: "否" }],
+      },
+    ],
+  });
+
+  await expect(
+    daemonRespondCommand(socketPath, "test-session-id", "perm_1", {
+      allow: true,
+      answer: "yes",
+    }),
+  ).rejects.toThrow("exit(1)");
+  expect(stderrText()).toContain(
+    '--answer contains a non-numeric option number "yes" for question 1 (Q1 继续吗？)',
+  );
   expect(exitSpy).toHaveBeenCalledWith(1);
 });
 


### PR DESCRIPTION
## 背景

CLI 场景下查看/应答 daemon 会话的 AskUserQuestion 很困难：
- `wave daemon status` 把待审批 toolInput 截断为 80 字符单行，看不到完整问题与选项
- `wave daemon respond` 需要手写 `{"问题全文":"选项label"}` JSON，选项要靠猜

## 改动

**packages/code/src/daemon/commands.ts**
- `status`：`toolName === "AskUserQuestion"` 的待审批请求不再走 `summarizeToolInput` 单行 80 字符截断，改为多行完整渲染——每题 `Q{n} [header] question`、每选项 `{0起序号}. label — description`（与桌面确认弹窗同构）；其余工具保持原摘要，畸形 toolInput 回退原摘要
- `respond`：`--answer` 新增按序号解析——逗号分隔，第 i 个数字 = 第 i 题的选项（与 status 渲染序号一致，0 起），映射为选项 label 构造 `{问题原文: label}`（multiSelect 题取 label 数组），与 GUI 提交同构；合法 JSON 对象（key=问题原文）仍走旧逻辑。序号数量不符/非数字/越界均明确报错
- `index.ts`：`--answer` help 文案同步

**docs/specs/ui/daemon-command.md**：status 故事场景 4 + respond 故事新增场景 10 + 测试/边界说明更新

## 验证

- commands 单测 48/48（新增 7 用例：完整渲染/畸形回退/序号应答含 multiSelect/数量不符/越界/非数字）
- wave-code 全量 unit 102 文件 1518/1518
- type-check + oxlint + prettier 全绿；pre-commit（lint-staged + docs links/anchors）通过
- 真实冒烟：私有 socket daemon + 真实模型触发 AskUserQuestion，`status` 完整渲染、`respond --answer "0,0"` 应答后会话恢复生成