### PR TITLE
fix(webview): 修复快捷指令 /rewind、/model 弹窗点击无效（click-outside 收敛到 useClickOutside）

### DIFF
--- a/packages/webview/src/components/AccountCard.tsx
+++ b/packages/webview/src/components/AccountCard.tsx
@@ -4,6 +4,7 @@ import type {
   AccountPlanInfo,
   AccountUpdateInfo,
 } from "wave-webview-fixtures";
+import { useClickOutside } from "../utils/useClickOutside";
 import { MoreMenu } from "./MoreMenu";
 import { ConfirmDialog } from "./ConfirmDialog";
 // 未登录态「更多」按钮沿用 0902 第 5 轮问号圆（ailsa 新基线）；已登录态不再
@@ -179,24 +180,21 @@ export const AccountCard: React.FC<AccountCardProps> = ({
     [apiHideTimer],
   );
 
-  // API 余额气泡：点击外部或 Esc 立即强制收起（悬停态也生效）。
+  // API 余额气泡：点击外部或 Esc 立即强制收起（悬停态也生效）。Click-outside
+  // 豁免气泡与 ⓘ 触发按钮本身（再点 ⓘ toggle）；listener 经 useClickOutside
+  // 延迟一帧注册，气泡被自身打开点击误关的防御见其注释。
+  useClickOutside({
+    refs: [apiPopoverRef, apiTriggerRef],
+    enabled: showApiPopover,
+    onClickOutside: () => setShowApiPopover(false),
+  });
   useEffect(() => {
     if (!showApiPopover) return;
-    const handlePointerDown = (event: MouseEvent) => {
-      const target = event.target as Node;
-      if (apiPopoverRef.current?.contains(target)) return;
-      if (apiTriggerRef.current?.contains(target)) return;
-      setShowApiPopover(false);
-    };
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") setShowApiPopover(false);
     };
-    document.addEventListener("mousedown", handlePointerDown);
     document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handlePointerDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
+    return () => document.removeEventListener("keydown", handleKeyDown);
   }, [showApiPopover]);
 
   // 未登录：整条登录按钮 + 右侧「更多」按钮（沿用当前基线视觉）。

--- a/packages/webview/src/components/BackgroundTaskManager.tsx
+++ b/packages/webview/src/components/BackgroundTaskManager.tsx
@@ -7,6 +7,7 @@
  */
 
 import React, { useState, useEffect, useRef } from "react";
+import { useClickOutside } from "../utils/useClickOutside";
 import { BackgroundTaskManagerProps, BackgroundTaskSummary } from "../types";
 import "../styles/ConfigurationDialog.css";
 
@@ -103,15 +104,14 @@ const BackgroundTaskManager: React.FC<
     vscode.postMessage({ command: "stopBackgroundTask", taskId });
   };
 
+  // Click-outside close (listener registered one tick later inside the hook,
+  // so the click that opened this dialog doesn't immediately close it).
+  useClickOutside({
+    refs: [dialogRef],
+    onClickOutside: onClose,
+  });
+
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        dialogRef.current &&
-        !dialogRef.current.contains(event.target as Node)
-      ) {
-        onClose();
-      }
-    };
     const handleEscapeKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         if (selectedTaskId) {
@@ -121,15 +121,8 @@ const BackgroundTaskManager: React.FC<
         }
       }
     };
-    const timer = setTimeout(() => {
-      document.addEventListener("mousedown", handleClickOutside);
-    }, 0);
     document.addEventListener("keydown", handleEscapeKey);
-    return () => {
-      clearTimeout(timer);
-      document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleEscapeKey);
-    };
+    return () => document.removeEventListener("keydown", handleEscapeKey);
   }, [onClose, selectedTaskId]);
 
   const statusColor = (status: string): string => {

--- a/packages/webview/src/components/DesktopSidebar.tsx
+++ b/packages/webview/src/components/DesktopSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, RefObject } from "react";
+import React, { useState, useRef, RefObject } from "react";
 import { Tooltip } from "./Tooltip";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { AccountCard, type AccountCardAccount } from "./AccountCard";
@@ -11,6 +11,7 @@ import {
   SplitIcon,
 } from "./HeaderIcons";
 import { useRovingMenu } from "../utils/useRovingMenu";
+import { useClickOutside } from "../utils/useClickOutside";
 import type { DesktopSessionGroup, DesktopSessionEntry } from "../types";
 import "../styles/DesktopApp.css";
 
@@ -54,15 +55,13 @@ const SessionItemMenu: React.FC<{
     onActivate: (i) => (i === 0 ? onSplit() : onDelete()),
   });
 
-  useEffect(() => {
-    const handleMouseDown = (event: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        onClose();
-      }
-    };
-    document.addEventListener("mousedown", handleMouseDown);
-    return () => document.removeEventListener("mousedown", handleMouseDown);
-  }, [onClose]);
+  // Click-outside close; listener registered one tick later (inside
+  // useClickOutside) so the mousedown that just opened the menu is not
+  // treated as an outside click.
+  useClickOutside({
+    refs: [menuRef],
+    onClickOutside: onClose,
+  });
 
   const menuWidth = 148;
   // Right-align the menu to the trigger, clamped to the viewport.

--- a/packages/webview/src/components/DesktopWorkdirSelector.tsx
+++ b/packages/webview/src/components/DesktopWorkdirSelector.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { useRovingMenu } from "../utils/useRovingMenu";
+import { useClickOutside } from "../utils/useClickOutside";
 import { ContextDirectoryIcon, PermCaretIcon, CloseIcon } from "./HeaderIcons";
 import "../styles/DesktopApp.css";
 
@@ -109,17 +110,13 @@ export const DesktopWorkdirSelector: React.FC<DesktopWorkdirSelectorProps> = ({
   });
 
   // Only the remote browser owns click-outside here — closing the main menu
-  // on outside clicks is handled inside useRovingMenu.
-  useEffect(() => {
-    if (!browsing) return;
-    const onMouseDown = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setBrowsing(false);
-      }
-    };
-    document.addEventListener("mousedown", onMouseDown);
-    return () => document.removeEventListener("mousedown", onMouseDown);
-  }, [browsing]);
+  // on outside clicks is handled inside useRovingMenu. Listener registered
+  // one tick later inside useClickOutside.
+  useClickOutside({
+    refs: [menuRef],
+    enabled: browsing,
+    onClickOutside: () => setBrowsing(false),
+  });
 
   const dirName = workdir
     ? workdir.split(/[\\/]/).filter(Boolean).pop() || workdir

--- a/packages/webview/src/components/FilePane.tsx
+++ b/packages/webview/src/components/FilePane.tsx
@@ -10,6 +10,7 @@ import DOMPurify from "dompurify";
 import hljs from "highlight.js/lib/common";
 import type { FileItem, FileViewState, VsCodeApi } from "../types";
 import { toRelativePath } from "../utils/messageUtils";
+import { useClickOutside } from "../utils/useClickOutside";
 import { FileSuggestionDropdown } from "./FileSuggestionDropdown";
 import "../styles/FilePane.css";
 
@@ -232,6 +233,7 @@ export const FilePane: React.FC<FilePaneProps> = ({
   const toolbarRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const searchPopoverRef = useRef<HTMLDivElement>(null);
+  const searchTriggerRef = useRef<HTMLButtonElement>(null);
   const searchInputRowRef = useRef<HTMLDivElement>(null);
 
   // Search popover: the toolbar's search icon toggles a floating panel (input +
@@ -302,20 +304,12 @@ export const FilePane: React.FC<FilePaneProps> = ({
   }, [searchOpen]);
 
   // Dismiss when clicking outside the popover (and not on the trigger button).
-  useEffect(() => {
-    if (!searchOpen) return;
-    const handlePointerDown = (event: MouseEvent) => {
-      const target = event.target as Node;
-      if (searchPopoverRef.current?.contains(target)) return;
-      const trigger = document.querySelector(
-        "[data-testid='file-pane-search-trigger']",
-      );
-      if (trigger?.contains(target)) return;
-      closeSearch();
-    };
-    document.addEventListener("mousedown", handlePointerDown);
-    return () => document.removeEventListener("mousedown", handlePointerDown);
-  }, [searchOpen, closeSearch]);
+  // Listener registered one tick later inside useClickOutside.
+  useClickOutside({
+    refs: [searchPopoverRef, searchTriggerRef],
+    enabled: searchOpen,
+    onClickOutside: closeSearch,
+  });
 
   const handleSearchFocus = useCallback(() => {
     setSearchActive(true);
@@ -499,6 +493,7 @@ export const FilePane: React.FC<FilePaneProps> = ({
           {vscode && (
             <button
               type="button"
+              ref={searchTriggerRef}
               className={`preview-pane-button file-pane-search-trigger${searchOpen ? " active" : ""}`}
               data-testid="file-pane-search-trigger"
               title={searchOpen ? "收起文件搜索" : "搜索文件"}

--- a/packages/webview/src/components/FileSuggestionDropdown.tsx
+++ b/packages/webview/src/components/FileSuggestionDropdown.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from "react";
+import { useClickOutside } from "../utils/useClickOutside";
 import { FileSuggestionDropdownProps, FileItem } from "../types";
 import "../styles/FileSuggestionDropdown.css";
 
@@ -23,24 +24,13 @@ export const FileSuggestionDropdown: React.FC<FileSuggestionDropdownProps> = ({
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Handle clicks outside dropdown to close it (skipped when the parent owns
-  // its own dismiss handling, e.g. the file-panel search popover).
-  useEffect(() => {
-    if (disableClickOutside) return;
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node)
-      ) {
-        onClose();
-      }
-    };
-
-    if (isVisible) {
-      document.addEventListener("mousedown", handleClickOutside);
-      return () =>
-        document.removeEventListener("mousedown", handleClickOutside);
-    }
-  }, [isVisible, onClose, disableClickOutside]);
+  // its own dismiss handling, e.g. the file-panel search popover). Listener
+  // registered one tick later inside useClickOutside.
+  useClickOutside({
+    refs: [dropdownRef],
+    enabled: isVisible && !disableClickOutside,
+    onClickOutside: onClose,
+  });
 
   // Scroll selected item into view
   useEffect(() => {

--- a/packages/webview/src/components/HistorySearchPopup.tsx
+++ b/packages/webview/src/components/HistorySearchPopup.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState, useCallback } from "react";
+import { useClickOutside } from "../utils/useClickOutside";
 import "../styles/HistorySearchPopup.css";
 import { HistoryItem, VsCodeApi } from "../types";
 
@@ -24,23 +25,14 @@ export const HistorySearchPopup: React.FC<HistorySearchPopupProps> = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const popupRef = useRef<HTMLDivElement>(null);
 
-  // Handle clicks outside to close popup
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        popupRef.current &&
-        !popupRef.current.contains(event.target as Node)
-      ) {
-        onClose();
-      }
-    };
-
-    if (isVisible) {
-      document.addEventListener("mousedown", handleClickOutside);
-      return () =>
-        document.removeEventListener("mousedown", handleClickOutside);
-    }
-  }, [isVisible, onClose]);
+  // Handle clicks outside to close popup (listener registered one tick later
+  // inside useClickOutside so a mousedown that just opened this popup is not
+  // treated as an outside click).
+  useClickOutside({
+    refs: [popupRef],
+    enabled: isVisible,
+    onClickOutside: onClose,
+  });
 
   // Focus input when popup opens
   useEffect(() => {

--- a/packages/webview/src/components/McpDialog.tsx
+++ b/packages/webview/src/components/McpDialog.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useState, useEffect, useRef } from "react";
+import { useClickOutside } from "../utils/useClickOutside";
 import { McpDialogProps, McpServerStatus } from "../types";
 import "../styles/ConfigurationDialog.css";
 
@@ -52,17 +53,14 @@ const McpDialog: React.FC<
 
   const dialogRef = useRef<HTMLDivElement>(null);
 
-  // Handle clicking outside to close dialog
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        dialogRef.current &&
-        !dialogRef.current.contains(event.target as Node)
-      ) {
-        onClose();
-      }
-    };
+  // Click-outside close (listener registered one tick later inside the hook,
+  // so the click that opened this dialog doesn't immediately close it).
+  useClickOutside({
+    refs: [dialogRef],
+    onClickOutside: onClose,
+  });
 
+  useEffect(() => {
     // Escape closes only the dialog. A capture-phase listener with
     // stopPropagation runs before React's synthetic onKeyDown (attached at the
     // root container), so the keypress never reaches MessageInput's
@@ -74,19 +72,8 @@ const McpDialog: React.FC<
         onClose();
       }
     };
-
-    // Defer registration to the next tick so the click that opened this dialog
-    // (still bubbling to document) doesn't immediately trigger the outside-close.
-    const timer = setTimeout(() => {
-      document.addEventListener("mousedown", handleClickOutside);
-    }, 0);
     document.addEventListener("keydown", handleEscapeKey, true);
-
-    return () => {
-      clearTimeout(timer);
-      document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleEscapeKey, true);
-    };
+    return () => document.removeEventListener("keydown", handleEscapeKey, true);
   }, [onClose]);
 
   return (

--- a/packages/webview/src/components/ModelPopup.tsx
+++ b/packages/webview/src/components/ModelPopup.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState, useCallback } from "react";
+import { useClickOutside } from "../utils/useClickOutside";
 import "../styles/ModelPopup.css";
 
 interface ModelPopupProps {
@@ -35,20 +36,15 @@ export const ModelPopup: React.FC<ModelPopupProps> = ({
     if (isVisible) popupRef.current?.focus();
   }, [isVisible]);
 
-  // Handle clicks outside to close popup
-  useEffect(() => {
-    if (!isVisible) return;
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        popupRef.current &&
-        !popupRef.current.contains(event.target as Node)
-      ) {
-        onClose();
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [isVisible, onClose]);
+  // Handle clicks outside to close popup. The listener is registered one tick
+  // later (inside useClickOutside) so the mousedown that just mounted this
+  // popup — e.g. clicking the /model entry in the slash-command popup — does
+  // not immediately count as an outside click and close it.
+  useClickOutside({
+    refs: [popupRef],
+    enabled: isVisible,
+    onClickOutside: onClose,
+  });
 
   // Auto-scroll selected item into view when navigation happens
   useEffect(() => {

--- a/packages/webview/src/components/MoreMenu.tsx
+++ b/packages/webview/src/components/MoreMenu.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from "react";
 import type { RefObject } from "react";
 import { useRovingMenu } from "../utils/useRovingMenu";
+import { useClickOutside } from "../utils/useClickOutside";
 import {
   ExternalLinkIcon,
   FileTextIcon,
@@ -146,29 +147,25 @@ export const MoreMenu: React.FC<MoreMenuProps> = ({
 
   // Click-outside + global Escape fallback (the hook only handles Escape from
   // a focused item). Focus returns to the trigger on those in-menu paths.
+  // The trigger is excluded from click-outside so clicking it again toggles
+  // the menu closed (AccountCard hotzone / header 更多). useClickOutside
+  // registers the mousedown listener one tick later so the click that just
+  // opened this menu is not treated as an outside click.
+  useClickOutside({
+    refs: [menuRef, ...(triggerRef ? [triggerRef] : [])],
+    onClickOutside: onClose,
+  });
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as Node;
-      if (menuRef.current && menuRef.current.contains(target)) return;
-      // The trigger itself is excluded from click-outside so clicking it again
-      // toggles the menu closed (AccountCard hotzone / header 更多).
-      if (triggerRef?.current?.contains(target)) return;
-      onClose();
-    };
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         onClose();
       }
     };
-    document.addEventListener("mousedown", handleClickOutside);
     document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
+    return () => document.removeEventListener("keydown", handleKeyDown);
     // triggerRef is a stable prop ref object (callers pass a useRef result), so
     // the listener set still only installs once per mount.
-  }, [onClose, triggerRef]);
+  }, [onClose]);
 
   return (
     <div

--- a/packages/webview/src/components/PanelToggleMenu.tsx
+++ b/packages/webview/src/components/PanelToggleMenu.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from "react";
 import type { RefObject } from "react";
 import { useRovingMenu } from "../utils/useRovingMenu";
+import { useClickOutside } from "../utils/useClickOutside";
 import type { DesktopPanelKind, PanelToggleProps } from "../types";
 import "../styles/PanelToggleMenu.css";
 
@@ -93,24 +94,20 @@ export const PanelToggleMenu: React.FC<PanelToggleMenuProps> = ({
   });
 
   // Click-outside + global Escape fallback (the hook only handles Escape from
-  // a focused item).
+  // a focused item). useClickOutside registers the mousedown listener one tick
+  // later so a mousedown that just mounted this menu is not an outside click.
+  useClickOutside({
+    refs: [menuRef],
+    onClickOutside: onClose,
+  });
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        onClose();
-      }
-    };
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         onClose();
       }
     };
-    document.addEventListener("mousedown", handleClickOutside);
     document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
+    return () => document.removeEventListener("keydown", handleKeyDown);
   }, [onClose]);
 
   return (

--- a/packages/webview/src/components/PluginDialog.tsx
+++ b/packages/webview/src/components/PluginDialog.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useState, useEffect, useRef } from "react";
+import { useClickOutside } from "../utils/useClickOutside";
 import {
   PluginDialogProps,
   PluginInfo,
@@ -97,17 +98,14 @@ const PluginDialog: React.FC<
 
   const dialogRef = useRef<HTMLDivElement>(null);
 
-  // Handle clicking outside to close dialog
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        dialogRef.current &&
-        !dialogRef.current.contains(event.target as Node)
-      ) {
-        onClose();
-      }
-    };
+  // Click-outside close (listener registered one tick later inside the hook,
+  // so the click that opened this dialog doesn't immediately close it).
+  useClickOutside({
+    refs: [dialogRef],
+    onClickOutside: onClose,
+  });
 
+  useEffect(() => {
     // Escape closes only the dialog. A capture-phase listener with
     // stopPropagation runs before React's synthetic onKeyDown (attached at the
     // root container), so the keypress never reaches MessageInput's
@@ -119,19 +117,8 @@ const PluginDialog: React.FC<
         onClose();
       }
     };
-
-    // Defer registration to the next tick so the click that opened this dialog
-    // (still bubbling to document) doesn't immediately trigger the outside-close.
-    const timer = setTimeout(() => {
-      document.addEventListener("mousedown", handleClickOutside);
-    }, 0);
     document.addEventListener("keydown", handleEscapeKey, true);
-
-    return () => {
-      clearTimeout(timer);
-      document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleEscapeKey, true);
-    };
+    return () => document.removeEventListener("keydown", handleEscapeKey, true);
   }, [onClose]);
 
   return (

--- a/packages/webview/src/components/RewindPopup.tsx
+++ b/packages/webview/src/components/RewindPopup.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState, useCallback } from "react";
+import { useClickOutside } from "../utils/useClickOutside";
 import "../styles/RewindPopup.css";
 
 export interface RewindCheckpoint {
@@ -37,20 +38,15 @@ export const RewindPopup: React.FC<RewindPopupProps> = ({
     if (isVisible) popupRef.current?.focus();
   }, [isVisible]);
 
-  // Handle clicks outside to close popup
-  useEffect(() => {
-    if (!isVisible) return;
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        popupRef.current &&
-        !popupRef.current.contains(event.target as Node)
-      ) {
-        onClose();
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [isVisible, onClose]);
+  // Handle clicks outside to close popup. The listener is registered one tick
+  // later (inside useClickOutside) so the mousedown that just mounted this
+  // popup — e.g. clicking the /rewind entry in the slash-command popup — does
+  // not immediately count as an outside click and close it.
+  useClickOutside({
+    refs: [popupRef],
+    enabled: isVisible,
+    onClickOutside: onClose,
+  });
 
   // Auto-scroll selected item into view when navigation happens
   useEffect(() => {

--- a/packages/webview/src/components/SessionListPopup.tsx
+++ b/packages/webview/src/components/SessionListPopup.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import type { SessionMetadata } from "wave-agent-sdk";
+import { useClickOutside } from "../utils/useClickOutside";
 import { formatSessionLabel } from "../utils/session";
 import { SessionList } from "./SessionList";
 import "../styles/SessionListPopup.css";
@@ -31,26 +32,18 @@ export const SessionListPopup: React.FC<SessionListPopupProps> = ({
   }, []);
 
   // Click outside + Escape to close
+  useClickOutside({
+    refs: [popupRef],
+    onClickOutside: onClose,
+  });
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        popupRef.current &&
-        !popupRef.current.contains(event.target as Node)
-      ) {
-        onClose();
-      }
-    };
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         onClose();
       }
     };
-    document.addEventListener("mousedown", handleClickOutside);
     document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
+    return () => document.removeEventListener("keydown", handleKeyDown);
   }, [onClose]);
 
   const filteredSessions = useMemo(() => {

--- a/packages/webview/src/components/SlashCommandsPopup.tsx
+++ b/packages/webview/src/components/SlashCommandsPopup.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from "react";
+import { useClickOutside } from "../utils/useClickOutside";
 import "../styles/SlashCommandsPopup.css";
 
 export interface SlashCommand {
@@ -78,23 +79,14 @@ export const SlashCommandsPopup: React.FC<SlashCommandsPopupProps> = ({
 }) => {
   const popupRef = useRef<HTMLDivElement>(null);
 
-  // Handle clicks outside to close popup
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        popupRef.current &&
-        !popupRef.current.contains(event.target as Node)
-      ) {
-        onClose();
-      }
-    };
-
-    if (isVisible) {
-      document.addEventListener("mousedown", handleClickOutside);
-      return () =>
-        document.removeEventListener("mousedown", handleClickOutside);
-    }
-  }, [isVisible, onClose]);
+  // Handle clicks outside to close popup (listener registered one tick later
+  // inside useClickOutside, so a mousedown that opens a nested popup — e.g.
+  // clicking /rewind — is not treated as an outside click of this popup).
+  useClickOutside({
+    refs: [popupRef],
+    enabled: isVisible,
+    onClickOutside: onClose,
+  });
 
   // Handle keyboard navigation
   useEffect(() => {

--- a/packages/webview/src/components/StatusDialog.tsx
+++ b/packages/webview/src/components/StatusDialog.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useState, useEffect, useRef } from "react";
+import { useClickOutside } from "../utils/useClickOutside";
 import { StatusDialogProps } from "../types";
 import "../styles/ConfigurationDialog.css";
 
@@ -39,15 +40,14 @@ const StatusDialog: React.FC<
     return () => window.removeEventListener("message", handleMessage);
   }, []);
 
+  // Click-outside close (listener registered one tick later inside the hook,
+  // so the click that opened this dialog doesn't immediately close it).
+  useClickOutside({
+    refs: [dialogRef],
+    onClickOutside: onClose,
+  });
+
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        dialogRef.current &&
-        !dialogRef.current.contains(event.target as Node)
-      ) {
-        onClose();
-      }
-    };
     // Escape closes only the dialog. A capture-phase listener with
     // stopPropagation runs before React's synthetic onKeyDown (attached at the
     // root container), so the keypress never reaches MessageInput's
@@ -59,17 +59,8 @@ const StatusDialog: React.FC<
         onClose();
       }
     };
-    // Defer registration to the next tick so the click that opened this dialog
-    // (still bubbling to document) doesn't immediately trigger the outside-close.
-    const timer = setTimeout(() => {
-      document.addEventListener("mousedown", handleClickOutside);
-    }, 0);
     document.addEventListener("keydown", handleEscapeKey, true);
-    return () => {
-      clearTimeout(timer);
-      document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleEscapeKey, true);
-    };
+    return () => document.removeEventListener("keydown", handleEscapeKey, true);
   }, [onClose]);
 
   const StatusRow = ({ label, value }: { label: string; value?: string }) => (

--- a/packages/webview/src/components/WorkflowManager.tsx
+++ b/packages/webview/src/components/WorkflowManager.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
+import { useClickOutside } from "../utils/useClickOutside";
 import { WorkflowManagerProps, SerializableWorkflowRun } from "../types";
 import "../styles/ConfigurationDialog.css";
 
@@ -63,15 +64,14 @@ const WorkflowManager: React.FC<
     vscode.postMessage({ command: "stopWorkflowRun", runId });
   };
 
+  // Click-outside close (listener registered one tick later inside the hook,
+  // so the click that opened this dialog doesn't immediately close it).
+  useClickOutside({
+    refs: [dialogRef],
+    onClickOutside: onCancel,
+  });
+
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        dialogRef.current &&
-        !dialogRef.current.contains(event.target as Node)
-      ) {
-        onCancel();
-      }
-    };
     const handleEscapeKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         if (selectedRunId) {
@@ -81,15 +81,8 @@ const WorkflowManager: React.FC<
         }
       }
     };
-    const timer = setTimeout(() => {
-      document.addEventListener("mousedown", handleClickOutside);
-    }, 0);
     document.addEventListener("keydown", handleEscapeKey);
-    return () => {
-      clearTimeout(timer);
-      document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleEscapeKey);
-    };
+    return () => document.removeEventListener("keydown", handleEscapeKey);
   }, [onCancel, selectedRunId]);
 
   const renderDetail = () => {

--- a/packages/webview/src/utils/useClickOutside.ts
+++ b/packages/webview/src/utils/useClickOutside.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from "react";
+import type { RefObject } from "react";
+
+export interface UseClickOutsideOptions {
+  /**
+   * 豁免节点：mousedown 落在任一节点内部（或就是节点本身）不算"外部"。
+   * 通常传弹层根 ref；若点击触发按钮也需要豁免（例如再点一次按钮 toggle
+   * 关闭），把按钮 ref 一并传入。
+   */
+  refs: Array<RefObject<HTMLElement | null>>;
+  /** 点击所有豁免节点之外时触发。 */
+  onClickOutside: (event: MouseEvent) => void;
+  /** false 时不注册监听（默认 true）。 */
+  enabled?: boolean;
+}
+
+/**
+ * 监听 document 上的 mousedown，实现"点击弹层外部关闭"。
+ *
+ * 监听器延迟一帧（setTimeout 0）再注册：当弹层由同一次 mousedown 触发挂载
+ * 时（例如鼠标点击快捷指令列表项打开 /rewind、/model 弹层），那次 mousedown
+ * 仍在冒泡到 document。若挂载 effect 同步注册监听器，事件会命中它而 target
+ * 又在弹层之外，弹层便会被自己的打开点击立即关闭——键盘选中回车没有 mousedown
+ * 所以正常。延迟注册让打开弹层的那次点击先冒泡结束。这是 DOM 事件机制下的
+ * 标准解法，与 Radix DismissableLayer 的处理一致。
+ */
+export function useClickOutside({
+  refs,
+  onClickOutside,
+  enabled = true,
+}: UseClickOutsideOptions): void {
+  // 最新值经 ref 读取：调用方每次渲染传入的 refs 数组与 onClickOutside 都是
+  // 新引用，若直接进 effect 依赖会导致监听器每次渲染后重建（并重新延迟注册）。
+  const latest = useRef({ refs, onClickOutside });
+  latest.current = { refs, onClickOutside };
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+      const { refs: currentRefs, onClickOutside: handleOutside } =
+        latest.current;
+      const isInside = currentRefs.some(
+        (ref) => !!ref.current && ref.current.contains(target),
+      );
+      if (!isInside) handleOutside(event);
+    };
+
+    const timer = setTimeout(() => {
+      document.addEventListener("mousedown", handleClickOutside);
+    }, 0);
+
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [enabled]);
+}

--- a/packages/webview/tests/webview/accountCard.test.tsx
+++ b/packages/webview/tests/webview/accountCard.test.tsx
@@ -198,7 +198,7 @@ describe("AccountCard (desktop sidebar)", () => {
   });
 
   describe("API 明细气泡（hover ⓘ）", () => {
-    it("opens on hover/focus of ⓘ, shows used/remaining amounts, closes on outside click and Esc", () => {
+    it("opens on hover/focus of ⓘ, shows used/remaining amounts, closes on outside click and Esc", async () => {
       renderDesktop();
       pushAccount({ ...loggedIn, plan: plan80, apiQuota: apiPlenty });
       const info = screen.getByTestId("api-quota-info");
@@ -216,6 +216,9 @@ describe("AccountCard (desktop sidebar)", () => {
 
       fireEvent.mouseEnter(info);
       popover = screen.getByTestId("api-quota-popover");
+      // Outside-click listener registers one tick after the popover mounts
+      // (useClickOutside defers it) — wait before simulating the outside click.
+      await new Promise((resolve) => setTimeout(resolve, 0));
       fireEvent.mouseDown(document.body);
       expect(screen.queryByTestId("api-quota-popover")).not.toBeInTheDocument();
     });
@@ -383,12 +386,15 @@ describe("AccountCard (desktop sidebar)", () => {
       expect(screen.queryByTestId("more-menu")).not.toBeInTheDocument();
     });
 
-    it("closes the menu on outside click and returns focus to the hotzone after item Escape", () => {
+    it("closes the menu on outside click and returns focus to the hotzone after item Escape", async () => {
       renderDesktop();
       pushAccount({ ...loggedIn, plan: plan80, apiQuota: apiPlenty });
       const hotzone = screen.getByTestId("account-card-hotzone");
 
       fireEvent.click(hotzone);
+      // Outside-click listener registers one tick after the menu mounts
+      // (useClickOutside defers it) — wait before simulating the outside click.
+      await new Promise((resolve) => setTimeout(resolve, 0));
       fireEvent.mouseDown(document.body);
       expect(screen.queryByTestId("more-menu")).not.toBeInTheDocument();
 

--- a/packages/webview/tests/webview/panelToggleMenu.test.tsx
+++ b/packages/webview/tests/webview/panelToggleMenu.test.tsx
@@ -109,10 +109,14 @@ describe("PanelToggleMenu", () => {
     );
   });
 
-  it("closes on click outside but not on click inside", () => {
+  it("closes on click outside but not on click inside", async () => {
     const { onClose } = renderMenu();
     fireEvent.mouseDown(screen.getByTestId("panel-toggle-item-preview"));
     expect(onClose).not.toHaveBeenCalled();
+    // The outside-click listener registers one tick after mount (useClickOutside
+    // defers it so the mousedown that opens a menu isn't treated as outside) —
+    // wait for registration before simulating the outside click.
+    await new Promise((resolve) => setTimeout(resolve, 0));
     fireEvent.mouseDown(document.body);
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/packages/webview/tests/webview/slashCommandPopupClick.test.tsx
+++ b/packages/webview/tests/webview/slashCommandPopupClick.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  renderChatApp,
+  screen,
+  waitFor,
+  fireEvent,
+  act,
+  sendCommand,
+  fireInput,
+} from "./test-utils";
+
+/**
+ * 回归测试：鼠标点击快捷指令弹窗中的 /rewind、/model 项，二级弹层必须打开
+ * 且不被打开它的那一次 mousedown 立即关闭。
+ *
+ * 历史 bug：弹层在 mount 时同步向 document 注册 click-outside mousedown
+ * 监听，而点击列表项的那次 mousedown 仍在冒泡 → 命中监听（target 是已卸载
+ * 的列表项，在弹层外）→ 弹层被自己的打开点击瞬间关闭。键盘选中+回车无
+ * mousedown 故正常。修复见 useClickOutside（延迟一帧注册）。
+ */
+async function clickSlashItem(trigger: string, itemTestId: string) {
+  const { vscode } = renderChatApp();
+  const input = screen.getByTestId("message-input");
+  input.focus();
+
+  input.textContent = trigger;
+  const range = document.createRange();
+  range.selectNodeContents(input);
+  range.collapse(false);
+  const sel = window.getSelection();
+  sel?.removeAllRanges();
+  sel?.addRange(range);
+  await fireInput(input, { data: trigger, inputType: "insertText" });
+
+  await waitFor(
+    () => {
+      expect(vscode.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ command: "requestSlashCommands" }),
+      );
+    },
+    { timeout: 3000 },
+  );
+
+  act(() => {
+    sendCommand("slashCommandsResponse", {
+      commands: [
+        { id: "rewind", name: "rewind", description: "回滚到检查点" },
+        { id: "model", name: "model", description: "选择模型" },
+      ],
+    });
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId("slash-commands-popup")).toBeInTheDocument();
+  });
+
+  // 模拟真实鼠标点击：列表项用 onMouseDown 选中（SlashCommandsPopup）。
+  await act(async () => {
+    fireEvent.mouseDown(screen.getByTestId(itemTestId));
+  });
+  return vscode;
+}
+
+describe("鼠标点击快捷指令打开二级弹层（回归）", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("/rewind：点击列表项后弹层打开，且不被同一次 mousedown 关闭", async () => {
+    const vscode = await clickSlashItem("/rewind", "slash-command-rewind");
+
+    await waitFor(
+      () => {
+        expect(vscode.postMessage).toHaveBeenCalledWith(
+          expect.objectContaining({ command: "listRewindCheckpoints" }),
+        );
+      },
+      { timeout: 3000 },
+    );
+    // 弹层仍可见（未被自身的打开点击关闭）。
+    expect(screen.getByTestId("rewind-popup")).toBeInTheDocument();
+  });
+
+  it("/model：点击列表项后弹层打开，且不被同一次 mousedown 关闭", async () => {
+    const vscode = await clickSlashItem("/model", "slash-command-model");
+
+    await waitFor(
+      () => {
+        expect(vscode.postMessage).toHaveBeenCalledWith(
+          expect.objectContaining({ command: "getConfiguredModels" }),
+        );
+      },
+      { timeout: 3000 },
+    );
+    expect(screen.getByTestId("model-popup")).toBeInTheDocument();
+  });
+});

--- a/packages/webview/tests/webview/useClickOutside.test.tsx
+++ b/packages/webview/tests/webview/useClickOutside.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { useRef } from "react";
+import { useClickOutside } from "../../src/utils/useClickOutside";
+
+/** 等待 useClickOutside 内部的 setTimeout(0) 延迟注册完成。 */
+async function flushDeferredRegistration() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function ClickOutsideHarness({
+  enabled = true,
+  onOutside,
+  refs = [],
+}: {
+  enabled?: boolean;
+  onOutside: () => void;
+  /** 额外的豁免节点（含 trigger 场景）。 */
+  refs?: Array<React.RefObject<HTMLElement | null>>;
+}) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const allRefs = [panelRef, ...refs];
+  useClickOutside({
+    refs: allRefs,
+    enabled,
+    onClickOutside: onOutside,
+  });
+  return (
+    <div>
+      <div ref={panelRef} data-testid="panel">
+        panel
+      </div>
+      <div data-testid="outside">outside</div>
+    </div>
+  );
+}
+
+describe("useClickOutside", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("注册延迟一帧：弹层挂载当次的同帧外部 mousedown 不触发", async () => {
+    const onOutside = vi.fn();
+    const { getByTestId } = render(
+      <ClickOutsideHarness onOutside={onOutside} />,
+    );
+
+    // 弹层刚挂载、setTimeout(0) 尚未执行 —— 模拟"挂载当次的打开点击"
+    // 仍在冒泡：listener 还未注册，不能被误触发。
+    fireEvent.mouseDown(getByTestId("outside"));
+    expect(onOutside).not.toHaveBeenCalled();
+
+    await flushDeferredRegistration();
+    expect(onOutside).not.toHaveBeenCalled();
+  });
+
+  it("注册完成后点击外部触发", async () => {
+    const onOutside = vi.fn();
+    const { getByTestId } = render(
+      <ClickOutsideHarness onOutside={onOutside} />,
+    );
+    await flushDeferredRegistration();
+
+    fireEvent.mouseDown(getByTestId("outside"));
+    expect(onOutside).toHaveBeenCalledTimes(1);
+  });
+
+  it("点击弹层内部不触发", async () => {
+    const onOutside = vi.fn();
+    const { getByTestId } = render(
+      <ClickOutsideHarness onOutside={onOutside} />,
+    );
+    await flushDeferredRegistration();
+
+    fireEvent.mouseDown(getByTestId("panel"));
+    expect(onOutside).not.toHaveBeenCalled();
+  });
+
+  it("额外豁免节点（trigger）内点击不触发", async () => {
+    const onOutside = vi.fn();
+    function HarnessWithTrigger() {
+      const panelRef = useRef<HTMLDivElement>(null);
+      const triggerRef = useRef<HTMLDivElement>(null);
+      useClickOutside({
+        refs: [panelRef, triggerRef],
+        onClickOutside: onOutside,
+      });
+      return (
+        <div>
+          <div ref={panelRef} data-testid="panel">
+            panel
+          </div>
+          <div ref={triggerRef} data-testid="trigger">
+            trigger
+          </div>
+          <div data-testid="outside">outside</div>
+        </div>
+      );
+    }
+    const { getByTestId } = render(<HarnessWithTrigger />);
+    await flushDeferredRegistration();
+
+    fireEvent.mouseDown(getByTestId("trigger"));
+    expect(onOutside).not.toHaveBeenCalled();
+
+    fireEvent.mouseDown(getByTestId("outside"));
+    expect(onOutside).toHaveBeenCalledTimes(1);
+  });
+
+  it("enabled=false 时不注册监听", async () => {
+    const onOutside = vi.fn();
+    const { getByTestId } = render(
+      <ClickOutsideHarness onOutside={onOutside} enabled={false} />,
+    );
+    await flushDeferredRegistration();
+
+    fireEvent.mouseDown(getByTestId("outside"));
+    expect(onOutside).not.toHaveBeenCalled();
+  });
+
+  it("enabled 从 false 变 true 后开始监听", async () => {
+    const onOutside = vi.fn();
+    const { getByTestId, rerender } = render(
+      <ClickOutsideHarness onOutside={onOutside} enabled={false} />,
+    );
+    await flushDeferredRegistration();
+    fireEvent.mouseDown(getByTestId("outside"));
+    expect(onOutside).not.toHaveBeenCalled();
+
+    rerender(<ClickOutsideHarness onOutside={onOutside} enabled={true} />);
+    await flushDeferredRegistration();
+    fireEvent.mouseDown(getByTestId("outside"));
+    expect(onOutside).toHaveBeenCalledTimes(1);
+  });
+
+  it("卸载后移除监听，不再触发", async () => {
+    const onOutside = vi.fn();
+    const { getByTestId, unmount } = render(
+      <ClickOutsideHarness onOutside={onOutside} />,
+    );
+    await flushDeferredRegistration();
+
+    fireEvent.mouseDown(getByTestId("outside"));
+    expect(onOutside).toHaveBeenCalledTimes(1);
+
+    unmount();
+    // 卸载后组件与节点已从 body 移除；对 document.body 派发 mousedown，
+    // 若监听器未清理仍会冒泡到 document 触发。
+    fireEvent.mouseDown(document.body);
+    expect(onOutside).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
fix(webview): 收敛弹层 click-outside 到共享 useClickOutside，修复快捷指令 /rewind、/model 点击无效

鼠标点击快捷指令弹窗中的 /rewind、/model 项后二级弹层闪开即被关闭
（键盘选中回车正常）：弹层 mount 时同步向 document 注册 click-outside
mousedown 监听，而点击列表项的那次 mousedown 仍在冒泡——target 是已卸载
的列表项、在弹层外，弹层被自己的打开点击瞬间关闭。这是 DOM 事件机制下的
已知问题，Radix DismissableLayer 采用延迟一帧注册规避；RewindPopup/
ModelPopup 在该模式（c3404d38，2026-07）修复之后新增，未套用。

- 新增共享 hook src/utils/useClickOutside.ts：内置 setTimeout(0) 延迟注册
  + clearTimeout、enabled 开关、多 ref 豁免（弹层 + trigger），避免弹层组件
  各自手写 document 监听而再次漏掉延迟注册。
- RewindPopup/ModelPopup 改用 hook（bug 修复）；其余 15 个手写同一模式的
  弹层（SlashCommandsPopup/SessionListPopup/PanelToggleMenu/SessionItemMenu/
  HistorySearchPopup/FileSuggestionDropdown/StatusDialog/PluginDialog/
  McpDialog/BackgroundTaskManager/WorkflowManager/MoreMenu/AccountCard/
  FilePane/DesktopWorkdirSelector）全量迁移，Esc 处理（capture/二级清选中）
  与 useRovingMenu 保持原样。
- FilePane 的 trigger 定位由 document.querySelector 改为 ref。
- 新增回归测试：点击 slash 弹窗 /rewind、/model 项后弹层保持打开；hook 级
  单测覆盖同帧误触发/内部点击/enabled/卸载清理。3 个既有测试改为等待
  click-outside 监听注册完成后再模拟外部点击（原同帧断言依赖已修复的时序）。
- 验证：webview type-check + oxlint + 全量单测 895/895 + build/sync 全绿。