### PR TITLE
fix: 工具卡路径链接垂直居中（write-tool-header align-items center）

### DIFF
--- a/packages/webview/src/styles/Message.css
+++ b/packages/webview/src/styles/Message.css
@@ -355,7 +355,9 @@
 /* Write tool preview */
 .write-tool-header {
   display: flex;
-  align-items: flex-start;
+  /* 工具名（13px 加粗）与路径链接（12px monospace、line-height 16px）行高
+     不同，flex-start 顶部对齐会让链接视觉偏上，居中才在同一水平线上。 */
+  align-items: center;
   gap: 6px;
 }
 


### PR DESCRIPTION
工具名（13px 加粗）与路径链接（12px monospace、line-height 16px）
行高不同，flex-start 顶部对齐让链接视觉偏上。改 center 使工具名
与路径链接在同一水平线上，IDE 与桌面端同时生效。
