### PR TITLE
fix(code,webview): 上下文用量指示器会话隔离 + 恢复会话补发本会话用量

### DIFF
--- a/packages/code/src/stdio/agentBridge.ts
+++ b/packages/code/src/stdio/agentBridge.ts
@@ -610,6 +610,19 @@ export class AgentBridge {
         },
         entry.agent.sessionId,
       );
+      // Same story for the context-usage indicator: the SDK's restore-time
+      // onLatestTotalTokensChange fired inside initialize — before this
+      // client's router registered — so replay the current usage or the
+      // webview keeps the previous session's (or no) percentage until the
+      // next turn pushes a fresh value (spec desktop-app 上下文用量指示器
+      // 场景 6: 恢复即显示该会话上次用量). A zero total means no real usage
+      // to report; the host keeps the empty ring until the first push.
+      const tokens = entry.agent.latestTotalTokens;
+      const max = entry.agent.getMaxInputTokens();
+      if (tokens > 0 && max > 0) {
+        const percent = Math.min(100, Math.round((tokens / max) * 100));
+        this.emit("contextUsage", { percent }, entry.agent.sessionId);
+      }
       return null;
     }
     await entry.agent.restoreSession(restoreId);

--- a/packages/code/tests/stdio/agentBridge.test.ts
+++ b/packages/code/tests/stdio/agentBridge.test.ts
@@ -2012,6 +2012,40 @@ test("restoreSession to the live session emits a messagesChange snapshot without
   });
 });
 
+test("restoreSession to the live session replays the current contextUsage so the re-attached client shows this session's usage", async () => {
+  const { bridge, notifications } = createBridge();
+  const mockAgent = createMockAgent({ latestTotalTokens: 50000 });
+  vi.mocked(Agent.create).mockResolvedValue(mockAgent);
+
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+
+  await bridge.handleRequest("restoreSession", { sessionId }, sessionId);
+
+  expect(mockAgent.restoreSession).not.toHaveBeenCalled();
+  expect(notifications).toContainEqual({
+    method: "contextUsage",
+    params: { percent: 25 }, // 50000 / 200000 (default getMaxInputTokens)
+    sessionId,
+  });
+});
+
+test("restoreSession replay skips contextUsage when the live session has no tokens yet", async () => {
+  const { bridge, notifications } = createBridge();
+  const mockAgent = createMockAgent({ latestTotalTokens: 0 });
+  vi.mocked(Agent.create).mockResolvedValue(mockAgent);
+
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+
+  await bridge.handleRequest("restoreSession", { sessionId }, sessionId);
+
+  expect(mockAgent.restoreSession).not.toHaveBeenCalled();
+  expect(notifications.filter((n) => n.method === "contextUsage")).toHaveLength(
+    0,
+  );
+});
+
 test("listSessions with workdir delegates to listSessions SDK", async () => {
   const { bridge } = createBridge();
   vi.mocked(Agent.create).mockResolvedValue(createMockAgent());

--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -276,6 +276,11 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   // conversation switches (ChatApp is keyed by paneId, not sessionId), so a
   // local useState alone would leak the previous conversation's panel.
   const btwSessionRef = useRef<string | undefined>(undefined);
+  // Session whose context-usage percentage contextUsage currently holds.
+  // Compared against state.currentSession.id in an effect below — same
+  // paneId-keyed-mount reasoning as btwSessionRef, so the usage indicator is
+  // conversation-isolated instead of leaking the previous session's number.
+  const usageSessionRef = useRef<string | undefined>(undefined);
   // Accumulated streaming text from the compaction fork; its last 30 characters
   // render after the "正在压缩对话" hint (streaming tail, same style as the
   // CLI loading indicator). Cleared when compaction ends.
@@ -1973,6 +1978,23 @@ export const ChatApp: React.FC<ChatAppProps> = ({
     btwSessionRef.current = sessionId;
     if (previous !== undefined && previous !== sessionId) handleBtwClose();
   }, [state.currentSession?.id, handleBtwClose]);
+
+  // The context-usage percentage is conversation-scoped (spec desktop-app
+  // 上下文用量指示器 场景 6 + session isolation): switching conversations must
+  // not carry the previous session's usage over. Desktop panes key ChatApp by
+  // paneId (not sessionId), so a sidebar session switch leaves this component
+  // mounted — without this effect the local contextUsage state would survive
+  // the switch (setInitialState only resets reducer state, not local state)
+  // and show the old session's percentage until the new session's first push.
+  // `previous !== undefined` keeps the initial mount a no-op.
+  useEffect(() => {
+    const sessionId = state.currentSession?.id;
+    const previous = usageSessionRef.current;
+    usageSessionRef.current = sessionId;
+    if (previous !== undefined && previous !== sessionId) {
+      setContextUsage(undefined);
+    }
+  }, [state.currentSession?.id]);
 
   const handleRewindConfirm = useCallback(() => {
     const messageId = pendingRewindId;

--- a/packages/webview/tests/webview/contextUsageIsolation.test.tsx
+++ b/packages/webview/tests/webview/contextUsageIsolation.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderChatApp, screen, sendHostMessage, fixtures } from "./test-utils";
+import { MockDataGenerator } from "../fixtures/mockData";
+
+/** A minimal SessionMetadata for conversation-switch tests. */
+function session(id: string) {
+  return {
+    id,
+    sessionType: "main" as const,
+    workdir: "/tmp/test",
+    createdAt: new Date(),
+    lastActiveAt: new Date(),
+    latestTotalTokens: 0,
+  };
+}
+
+/** A non-welcome conversation (has messages) so the indicator renders. */
+function conversationState(id: string) {
+  return {
+    session: session(id),
+    messages: [MockDataGenerator.createUserMessage("hello", `msg-${id}`)],
+  };
+}
+
+describe("context usage indicator conversation isolation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("switching conversations drops the previous session's percentage", () => {
+    renderChatApp();
+    // Establish conversation A and receive its usage push.
+    sendHostMessage(fixtures.setInitialState(conversationState("session-a")));
+    sendHostMessage(fixtures.contextUsage(45));
+    expect(screen.getByText("45%")).toBeInTheDocument();
+
+    // Switch to conversation B: the percentage is conversation-scoped and
+    // must not carry A's number over. Desktop panes key ChatApp by paneId
+    // (not sessionId), so this component stays mounted — only the session-id
+    // change in setInitialState can clear the local contextUsage state.
+    sendHostMessage(fixtures.setInitialState(conversationState("session-b")));
+    expect(screen.queryByText("45%")).not.toBeInTheDocument();
+    // Back to the empty ring (spec 场景 4: no usage info yet → no number).
+    expect(
+      document.querySelector(".compress-context-button")?.getAttribute("title"),
+    ).toBe("");
+
+    // B's own usage arrives only after the next turn/restore push.
+    sendHostMessage(fixtures.contextUsage(12));
+    expect(screen.getByText("12%")).toBeInTheDocument();
+  });
+
+  it("keeps the percentage when the host re-pushes the SAME conversation (state refresh)", () => {
+    renderChatApp();
+    sendHostMessage(fixtures.setInitialState(conversationState("session-a")));
+    sendHostMessage(fixtures.contextUsage(45));
+    expect(screen.getByText("45%")).toBeInTheDocument();
+
+    // A host re-push with the same session id (e.g. a pane state refresh)
+    // must not clear the usage — only a real conversation switch does.
+    sendHostMessage(fixtures.setInitialState(conversationState("session-a")));
+    expect(screen.getByText("45%")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
切换对话不再残留上一对话的上下文百分比（ChatApp 按 paneId 挂载，setInitialState
不重置本地 state，新增会话切换清理）；CLI agentBridge restoreSession re-attach
分支补发 contextUsage，恢复会话完成即显示该会话上次用量（spec desktop-app
上下文用量指示器场景 6），无需等新一轮对话。
