### PR TITLE
feat(webview): 工具/思考/文本块状态圆点四色语义着色，桌面节点跟随状态色

### DIFF
--- a/packages/webview/src/components/FileToolHeader.tsx
+++ b/packages/webview/src/components/FileToolHeader.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { ToolBlock } from "../types";
+import { getToolStatusColor } from "../utils/statusColors";
 
 interface FileToolHeaderProps {
   toolBlock: ToolBlock;
@@ -12,18 +13,12 @@ export const FileToolHeader: React.FC<FileToolHeaderProps> = ({
   filePath,
   onOpenFile,
 }) => {
-  const toolStatusColor =
-    toolBlock.stage === "running" || toolBlock.stage === "streaming"
-      ? "var(--vscode-editorWarning-foreground, #cca700)"
-      : toolBlock.success === true
-        ? "var(--vscode-testing-iconPassed, #73c991)"
-        : toolBlock.error || toolBlock.success === false
-          ? "var(--vscode-testing-iconFailed, #f14c4c)"
-          : "var(--vscode-descriptionForeground, #888)";
-
   return (
     <div className="write-tool-header">
-      <span className="tool-status-dot" style={{ color: toolStatusColor }}>
+      <span
+        className="tool-status-dot"
+        style={{ color: getToolStatusColor(toolBlock) }}
+      >
         ●
       </span>
       <span className="write-tool-label">{toolBlock.name || "Tool"}</span>

--- a/packages/webview/src/components/Message.tsx
+++ b/packages/webview/src/components/Message.tsx
@@ -43,6 +43,7 @@ import { ReasoningBlockView } from "./ReasoningBlockView";
 import { CompactBlockView } from "./CompactBlockView";
 import { WriteToolPreview } from "./WriteToolPreview";
 import { FileToolHeader } from "./FileToolHeader";
+import { getStageColor, getToolStatusColor } from "../utils/statusColors";
 import "../styles/Message.css";
 
 // Configure marked for VS Code webview context
@@ -480,23 +481,6 @@ export const Message: React.FC<MessageProps> = React.memo(
       // For all other cases, return null (no additional content)
       return null;
     };
-
-    // Running/streaming dots are neutral gray (prototype: running = gray,
-    // red/green reserved for outcome states).
-    const getToolStatusColor = (toolBlock: ToolBlock) =>
-      toolBlock.stage === "running" || toolBlock.stage === "streaming"
-        ? "var(--vscode-descriptionForeground, #888)"
-        : toolBlock.success === true
-          ? "var(--vscode-testing-iconPassed, #73c991)"
-          : toolBlock.error || toolBlock.success === false
-            ? "var(--vscode-testing-iconFailed, #f14c4c)"
-            : "var(--vscode-descriptionForeground, #888)";
-
-    // Dot color for text/reasoning blocks: gray while streaming, green once done.
-    const getStageColor = (stage?: "streaming" | "end") =>
-      stage === "streaming"
-        ? "var(--vscode-descriptionForeground, #888)"
-        : "var(--vscode-testing-iconPassed, #73c991)";
 
     const renderToolBlock = (toolBlock: ToolBlock, index: number) => {
       // Default tool rendering for all tools (including Bash)

--- a/packages/webview/src/styles/host-desktop.css
+++ b/packages/webview/src/styles/host-desktop.css
@@ -613,7 +613,9 @@
 }
 
 /* 消息流时间线节点：Figma design-node 12px / #16A34A / 白描边（覆盖此前
-   codechat 推断的 8px 灰点）；行 padding-left 12px → 20px（节点 12 + gap 8） */
+   codechat 推断的 8px 灰点）；行 padding-left 12px → 20px（节点 12 + gap 8）。
+   颜色跟随 --dot-color（工具运行蓝/流式橙/成功绿/失败红，思考与文本
+   流式橙/结束绿），无状态时回落 Figma 绿 #16A34A。 */
 [data-host="desktop"] .timeline-row {
   padding-left: 20px;
 }
@@ -622,7 +624,7 @@
   height: 12px;
   left: 0;
   top: 15px;
-  background: #16a34a;
+  background: var(--dot-color, #16a34a);
   border: 2px solid #ffffff;
   box-sizing: border-box;
 }

--- a/packages/webview/src/utils/statusColors.ts
+++ b/packages/webview/src/utils/statusColors.ts
@@ -1,0 +1,37 @@
+import type { ToolBlock } from "../types";
+
+/**
+ * 工具/思考/文本块的圆点状态色（codechat 语义色）：
+ * 成功 #16A34A / 失败 #D92D20 / 流式 #E6A23C / 运行 #2F5EDB。
+ * 时间线行首节点（.timeline-row::before）与块内圆点共用同一套映射。
+ */
+export const TOOL_STATUS_COLORS = {
+  /** 参数/内容流式传输中 */
+  streaming: "#E6A23C",
+  /** 工具执行中 */
+  running: "#2F5EDB",
+  /** 成功完成 */
+  success: "#16A34A",
+  /** 失败 */
+  error: "#D92D20",
+  /** 未知/中立（无状态标记的历史记录） */
+  idle: "var(--vscode-descriptionForeground, #888)",
+} as const;
+
+/** 工具块状态圆点颜色（流式橙 / 运行蓝 / 成功绿 / 失败红）。 */
+export const getToolStatusColor = (
+  toolBlock: Pick<ToolBlock, "stage" | "success" | "error">,
+): string => {
+  if (toolBlock.stage === "streaming") return TOOL_STATUS_COLORS.streaming;
+  if (toolBlock.stage === "running") return TOOL_STATUS_COLORS.running;
+  if (toolBlock.success === true) return TOOL_STATUS_COLORS.success;
+  if (toolBlock.error || toolBlock.success === false)
+    return TOOL_STATUS_COLORS.error;
+  return TOOL_STATUS_COLORS.idle;
+};
+
+/** 思考/普通文本块节点颜色：流式中橙，结束后绿。 */
+export const getStageColor = (stage?: "streaming" | "end"): string =>
+  stage === "streaming"
+    ? TOOL_STATUS_COLORS.streaming
+    : TOOL_STATUS_COLORS.success;

--- a/packages/webview/tests/webview/timelineDotColor.test.tsx
+++ b/packages/webview/tests/webview/timelineDotColor.test.tsx
@@ -14,10 +14,10 @@ describe("timeline dot color by stage", () => {
     vi.clearAllMocks();
   });
 
-  it("text block dot is yellow while streaming and green when done", () => {
+  it("text block dot is orange while streaming and green when done", () => {
     renderChatApp();
 
-    // streaming text → neutral gray dot
+    // streaming text → orange (流式传输 #E6A23C)
     sendCommand("updateMessages", {
       messages: [
         {
@@ -31,11 +31,9 @@ describe("timeline dot color by stage", () => {
     const streamingRow = getLastMessage().querySelector(
       ".timeline-row",
     ) as HTMLElement;
-    expect(streamingRow.style.getPropertyValue("--dot-color")).toContain(
-      "descriptionForeground",
-    );
+    expect(streamingRow.style.getPropertyValue("--dot-color")).toBe("#E6A23C");
 
-    // finished text → green dot
+    // finished text → green (成功 #16A34A)
     sendCommand("updateMessages", {
       messages: [
         {
@@ -49,10 +47,10 @@ describe("timeline dot color by stage", () => {
     const doneRow = getLastMessage().querySelector(
       ".timeline-row",
     ) as HTMLElement;
-    expect(doneRow.style.getPropertyValue("--dot-color")).toContain("Passed");
+    expect(doneRow.style.getPropertyValue("--dot-color")).toBe("#16A34A");
   });
 
-  it("reasoning block dot is gray while streaming and green when done", () => {
+  it("reasoning block dot is orange while streaming and green when done", () => {
     renderChatApp();
 
     sendCommand("updateMessages", {
@@ -70,9 +68,7 @@ describe("timeline dot color by stage", () => {
     const streamingRow = getLastMessage().querySelector(
       ".timeline-row",
     ) as HTMLElement;
-    expect(streamingRow.style.getPropertyValue("--dot-color")).toContain(
-      "descriptionForeground",
-    );
+    expect(streamingRow.style.getPropertyValue("--dot-color")).toBe("#E6A23C");
 
     sendCommand("updateMessages", {
       messages: [
@@ -87,7 +83,40 @@ describe("timeline dot color by stage", () => {
     const doneRow = getLastMessage().querySelector(
       ".timeline-row",
     ) as HTMLElement;
-    expect(doneRow.style.getPropertyValue("--dot-color")).toContain("Passed");
+    expect(doneRow.style.getPropertyValue("--dot-color")).toBe("#16A34A");
+  });
+
+  it("tool block dot follows tool status: streaming orange / running blue / success green / error red", () => {
+    renderChatApp();
+
+    const sendBlock = (block: Record<string, unknown>) => {
+      sendCommand("updateMessages", {
+        messages: [
+          {
+            id: "m5",
+            role: "assistant",
+            timestamp: "2024-01-01T00:00:00.000Z",
+            blocks: [block],
+          },
+        ],
+      });
+    };
+    const dotColor = () =>
+      (
+        getLastMessage().querySelector(".timeline-row") as HTMLElement
+      ).style.getPropertyValue("--dot-color");
+
+    sendBlock({ type: "tool", name: "bash", stage: "streaming" });
+    expect(dotColor()).toBe("#E6A23C");
+
+    sendBlock({ type: "tool", name: "bash", stage: "running" });
+    expect(dotColor()).toBe("#2F5EDB");
+
+    sendBlock({ type: "tool", name: "bash", stage: "end", success: true });
+    expect(dotColor()).toBe("#16A34A");
+
+    sendBlock({ type: "tool", name: "bash", stage: "end", error: "boom" });
+    expect(dotColor()).toBe("#D92D20");
   });
 
   it("history text block without stage defaults to green dot", () => {
@@ -105,7 +134,7 @@ describe("timeline dot color by stage", () => {
       ],
     });
     const row = getLastMessage().querySelector(".timeline-row") as HTMLElement;
-    expect(row.style.getPropertyValue("--dot-color")).toContain("Passed");
+    expect(row.style.getPropertyValue("--dot-color")).toBe("#16A34A");
   });
 
   it("compact block is wrapped in a timeline row with the link-accent dot", () => {


### PR DESCRIPTION
用户拍板状态色板：成功 #16A34A / 失败 #D92D20 / 流式 #E6A23C / 运行 #2F5EDB。
- 新增 utils/statusColors.ts 共享映射 getToolStatusColor（工具块：流式橙/运行蓝/
  成功绿/失败红）与 getStageColor（思考/文本：流式橙/结束后绿）
- FileToolHeader.tsx、Message.tsx 改用共享函数，删除两处重复且不一致的
  内联逻辑（原 running/流式合一：FileToolHeader 黄 #cca700、Message 灰）
- host-desktop.css 时间线节点 background #16a34a → var(--dot-color, #16a34a)，
  桌面端放开 Figma 恒绿覆盖跟随状态色（保留 12px 白描边规格）
- timelineDotColor.test.tsx 断言同步新色并新增工具四态用例
