### PR TITLE
fix(webview): 会话状态看板点击卡片关闭看板并恢复会话

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -2866,7 +2866,9 @@ export const ChatApp: React.FC<ChatAppProps> = ({
 
   // Batch 2 session board (desktop): rendered in place of chatContainer when
   // sessionBoardOpen. Clicking a card restores that session — workdir resolved
-  // from the board's own group data so the host can route the switch.
+  // from the board's own group data so the host can route the switch. The board
+  // must also close (spec desktop-app.md 场景 3：点击卡片恢复会话并退出看板
+  // 视图)——否则视图被 sessionBoardOpen 替换，停留在看板看不到会话。
   const sessionBoard = isDesktop ? (
     <SessionBoard
       groups={host?.sessionTree ?? []}
@@ -2875,6 +2877,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({
           g.sessions.some((s) => s.sessionId === sessionId),
         );
         const workdir = group?.workdir ?? host?.workdir;
+        handleCloseSessionBoard();
         if (workdir) host?.onSelectSession(workdir, sessionId);
       }}
       onBack={handleCloseSessionBoard}

--- a/packages/webview/tests/webview/sessionBoard.test.tsx
+++ b/packages/webview/tests/webview/sessionBoard.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import { DesktopApp } from "../../src/components/DesktopApp";
+import { createMockVscode, sendCommand } from "./test-utils";
+
+vi.mock("../../src/styles/DesktopApp.css", () => ({}));
+vi.mock("../../src/styles/SessionBoard.css", () => ({}));
+
+// 与 desktopApp.test.tsx 同构的 DesktopApp 全流程渲染：workdir →
+// 会话树 →（可选）打开「活动」看板。
+function renderReady(groups: unknown) {
+  const vscode = createMockVscode();
+  render(<DesktopApp vscode={vscode} />);
+  sendCommand("desktopWorkdirState", {
+    workdir: "/work/a",
+    recentWorkdirs: ["/work/a"],
+  });
+  sendCommand("setInitialState", { messages: [] });
+  sendCommand("desktopSessionTree", { groups });
+  return vscode;
+}
+
+const session = (sessionId: string, title: string) => ({
+  sessionId,
+  title,
+  lastActiveAt: Date.now(),
+  hasWorktree: false,
+});
+
+describe("会话状态看板（活动）", () => {
+  it("点击「活动」按钮进入看板，点击卡片关闭看板并恢复该会话（spec 场景 3）", () => {
+    const vscode = renderReady([
+      {
+        host: "local",
+        workdir: "/work/a",
+        sessions: [session("s1", "chat one"), session("s2", "chat two")],
+      },
+    ]);
+    expect(screen.getByTestId("chat-container")).toBeInTheDocument();
+
+    // 活动按钮 → 看板替换会话区
+    fireEvent.click(screen.getByTestId("desktop-sidebar-activity"));
+    expect(screen.getByTestId("session-board")).toBeInTheDocument();
+    expect(screen.queryByTestId("chat-container")).not.toBeInTheDocument();
+
+    // 点击卡片：恢复会话（desktopSelectSession）+ 退出看板视图
+    vscode.postMessage.mockClear();
+    fireEvent.click(screen.getByTestId("session-card-s2"));
+
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "desktopSelectSession",
+      workdir: "/work/a",
+      sessionId: "s2",
+    });
+    expect(screen.queryByTestId("session-board")).not.toBeInTheDocument();
+    expect(screen.getByTestId("chat-container")).toBeInTheDocument();
+    // 「活动」按钮高亮态取消
+    expect(screen.getByTestId("desktop-sidebar-activity")).not.toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("看板「返回当前会话」直接退出看板（spec 场景 6），不发送切换命令", () => {
+    const vscode = renderReady([
+      {
+        host: "local",
+        workdir: "/work/a",
+        sessions: [session("s1", "chat one")],
+      },
+    ]);
+
+    fireEvent.click(screen.getByTestId("desktop-sidebar-activity"));
+    expect(screen.getByTestId("session-board")).toBeInTheDocument();
+
+    vscode.postMessage.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: "返回当前会话" }));
+
+    expect(
+      vscode.postMessage.mock.calls.some(
+        (c) =>
+          (c[0] as Record<string, unknown>).command === "desktopSelectSession",
+      ),
+    ).toBe(false);
+    expect(screen.queryByTestId("session-board")).not.toBeInTheDocument();
+    expect(screen.getByTestId("chat-container")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
点击「活动」看板内的会话卡片此前只调用 host.onSelectSession 恢复会话，
sessionBoardOpen 保持 true——看板视图替换会话区，界面停留在看板看不到
目标会话（spec desktop-app.md 场景 3 要求点击卡片退出看板视图）。卡片
回调先 handleCloseSessionBoard() 再恢复会话，单布局与 DesktopShell 共用
同一 sessionBoard JSX 一处修复两处生效。新增 sessionBoard.test.tsx 2 例
回归（fail-without-fix 已验证）。
