### PR TITLE
fix(agent-sdk): marketplace update also reinstalls installed plugins

### DIFF
--- a/packages/agent-sdk/src/core/plugin.ts
+++ b/packages/agent-sdk/src/core/plugin.ts
@@ -173,9 +173,15 @@ export class PluginCore {
 
   /**
    * Updates a specific marketplace or all marketplaces
+   *
+   * Pulls the latest marketplace source and reinstalls any plugins that are
+   * already installed from it, so a manual "update marketplace" also brings
+   * installed plugins up to date (mirrors Claude Code's refresh-and-bump).
    */
   async updateMarketplace(name?: string): Promise<void> {
-    await this.marketplaceService.updateMarketplace(name);
+    await this.marketplaceService.updateMarketplace(name, {
+      updatePlugins: true,
+    });
   }
 
   /**

--- a/packages/agent-sdk/tests/core/plugin.test.ts
+++ b/packages/agent-sdk/tests/core/plugin.test.ts
@@ -202,7 +202,10 @@ describe("PluginCore", () => {
     );
 
     await pluginCore.updateMarketplace("m1");
-    expect(mockMarketplaceService.updateMarketplace).toHaveBeenCalledWith("m1");
+    expect(mockMarketplaceService.updateMarketplace).toHaveBeenCalledWith(
+      "m1",
+      { updatePlugins: true },
+    );
 
     await pluginCore.listMarketplaces();
     expect(mockMarketplaceService.listMarketplaces).toHaveBeenCalled();


### PR DESCRIPTION
## 背景

手动在 /plugin 界面点「插件市场 → 更新」只做了 git pull 本地市场 clone，没有把该市场已安装插件重装进 cache——远端有新 commit 但插件文件不会更新（version 不 bump 也不会覆盖）。对齐 Claude Code 的 refresh-and-bump 行为：更新市场后自动更新已装插件。

## 改动

- `PluginCore.updateMarketplace` 补传 `{ updatePlugins: true }`（packages/agent-sdk/src/core/plugin.ts:177）。这是所有手动入口的汇聚点：CLI 命令、CLI UI、vscode/jetbrains/desktop 三端 webview RPC 都经 agentBridge → PluginCore，一处生效。
- MarketplaceService 侧批量重装逻辑本就存在（autoUpdateAll 一直在用），此次只是让手动「更新市场」也走同一条路径。
- 同步更新 plugin.test.ts 断言。

## 验证

- agent-sdk: plugin.test 8/8、MarketplaceService.test 65/65、MarketplaceService.git.test 5/5
- code: agentBridge.test 138/138
- 全仓 type-check 通过（pre-commit）