### PR TITLE
fix(code): plugin install defaults to user scope

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -127,10 +127,10 @@ wave plugin uninstall <plugin>               # 卸载插件
 wave plugin update <plugin>                  # 更新插件（卸载后重新安装）
 ```
 
-安装插件时支持指定作用域：
+安装插件时支持指定作用域（不指定时默认 user 作用域，安装即启用）：
 
 ```bash
-wave plugin install my-plugin@official --scope user     # 全局安装
+wave plugin install my-plugin@official --scope user     # 全局安装（默认）
 wave plugin install my-plugin@official --scope project  # 项目级安装
 wave plugin install my-plugin@official --scope local    # 本地安装
 ```

--- a/packages/code/src/commands/plugin/install.ts
+++ b/packages/code/src/commands/plugin/install.ts
@@ -14,11 +14,11 @@ export async function installPluginCommand(argv: {
     );
     console.log(`Cache path: ${installed.cachePath}`);
 
-    if (argv.scope) {
-      const pluginId = `${installed.name}@${installed.marketplace}`;
-      await pluginCore.enablePlugin(pluginId, argv.scope);
-      console.log(`Plugin ${pluginId} enabled in ${argv.scope} scope`);
-    }
+    // When no scope is given, default to user scope (matches Claude Code).
+    const scope = argv.scope ?? "user";
+    const pluginId = `${installed.name}@${installed.marketplace}`;
+    await pluginCore.enablePlugin(pluginId, scope);
+    console.log(`Plugin ${pluginId} enabled in ${scope} scope`);
 
     process.exit(0);
   } catch (error) {

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -188,7 +188,7 @@ export async function main() {
                 })
                 .option("scope", {
                   alias: "s",
-                  describe: "Scope to enable the plugin in",
+                  describe: "Scope to enable the plugin in (default: user)",
                   choices: ["user", "project", "local"],
                   type: "string",
                 });

--- a/packages/code/tests/commands/plugin/install.scope.test.ts
+++ b/packages/code/tests/commands/plugin/install.scope.test.ts
@@ -124,7 +124,8 @@ describe("Plugin Install Scope Integration Tests", () => {
     );
   });
 
-  it("should install without enabling if no scope is provided", async () => {
+  it("should default to user scope and enable when no scope is provided", async () => {
+    mockPluginCore.enablePlugin.mockResolvedValue("user");
     await installPluginCommand({ plugin: "test-plugin@market" });
 
     expect(mockLog).toHaveBeenCalledWith(
@@ -132,13 +133,18 @@ describe("Plugin Install Scope Integration Tests", () => {
         "Successfully installed plugin: test-plugin v1.0.0 from market",
       ),
     );
-    expect(mockLog).not.toHaveBeenCalledWith(
-      expect.stringContaining("enabled in"),
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Plugin test-plugin@market enabled in user scope",
+      ),
     );
 
     expect(mockPluginCore.installPlugin).toHaveBeenCalledWith(
       "test-plugin@market",
     );
-    expect(mockPluginCore.enablePlugin).not.toHaveBeenCalled();
+    expect(mockPluginCore.enablePlugin).toHaveBeenCalledWith(
+      "test-plugin@market",
+      "user",
+    );
   });
 });


### PR DESCRIPTION
## 背景

`wave plugin install <plugin>` 不带 `--scope` 时只安装不启用（不写入任何 scope 的 enabledPlugins），导致安装后技能/命令不可用且无提示。对齐 Claude Code：CC 的 pluginCliCommands install 命令 scope 参数默认 `user` 且安装即启用。

## 改动

- `packages/code/src/commands/plugin/install.ts`：scope 缺省时默认 `"user"` 且始终 enable（原为 `if (argv.scope)` 才 enable）
- `packages/code/src/index.ts`：`--scope` help 标注 `(default: user)`
- `packages/code/tests/commands/plugin/install.scope.test.ts`：第三用例从「不传 scope 不启用」改为「默认 user 且启用」
- `docs/cli.md`：标注默认 user、安装即启用

SDK 层 `PluginCore.installPlugin` 的可选 scope 语义保留（供 `pluginManager` auto-install 等内部场景复用），默认值加在命令层——与 CC 结构一致（CC 默认也在 CLI handler 层而非 op 层）。

## 验证

- install.scope + install_error 5/5、index.test 26/26
- 全仓 type-check + docs 链接校验通过（pre-commit）