### PR TITLE
chore(ci): 排除 macOS 自动更新 zip 出 beta artifact

### DIFF
--- a/.github/workflows/beta-build.yml
+++ b/.github/workflows/beta-build.yml
@@ -156,11 +156,13 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: wave-desktop-beta-${{ runner.os }}
-          # Only files existing on this OS match — macOS produces .dmg + .zip,
-          # Windows produces .exe; missing globs are simply skipped.
+          # Only files existing on this OS match — macOS produces .dmg, Windows
+          # produces .exe; missing globs are simply skipped. The macOS .zip is
+          # electron-updater's auto-update package (consumed via the serverUrl
+          # feed), useless for beta artifacts that colleagues install by hand,
+          # so it is not uploaded.
           path: |
             packages/desktop/release/*.dmg
-            packages/desktop/release/*.zip
             packages/desktop/release/*.exe
           retention-days: 30
 


### PR DESCRIPTION
beta-build 的 macOS 产物含 .zip，但该 zip 是 electron-updater 自动更新专用包（经 serverUrl feed 消费），beta 由同事从 run Artifacts 手动下载安装，zip 无消费方。artifact 仅保留 .dmg/.exe 上传；zip 仍会构建，不改 electron-builder 目标配置，避免影响 publish.yml 正式发布链路。