### PR TITLE
fix(webview): 本地斜杠指令执行不再清空输入框已有草稿

### DIFF
--- a/packages/webview/src/components/MessageInput.tsx
+++ b/packages/webview/src/components/MessageInput.tsx
@@ -1163,9 +1163,33 @@ export const MessageInput = forwardRef<
         "plan",
       ];
       if (localCommands.includes(command.name)) {
-        textareaRef.current.innerHTML = "";
-        setMessage("");
-        vscode.postMessage({ command: "updateInputContent", content: "" });
+        // 本地指令不能把 '/' 前的草稿整条清掉（历史 bug：无条件 innerHTML=""
+        // 静默丢弃草稿）。与下方技能指令分支一致：仅删除 [startPos, endPos)
+        // 的指令 token，保留其余文本，并把剩余文本上报宿主会话记忆。
+        textareaRef.current.focus();
+
+        const start = findTextOffset(
+          textareaRef.current,
+          slashCommand.startPos,
+        );
+        const end = findTextOffset(textareaRef.current, slashCommand.endPos);
+        if (start && end) {
+          const range = document.createRange();
+          range.setStart(start.node, start.offset);
+          range.setEnd(end.node, end.offset);
+          range.deleteContents();
+
+          const remaining = textareaRef.current.innerText;
+          setMessage(remaining);
+          // 立即持久化剩余草稿：随后打开的对话框/设置页可能卸载本输入框，
+          // 会取消 handleInput 里 150ms 防抖的保存。
+          vscode.postMessage({
+            command: "updateInputContent",
+            sessionId,
+            content: remaining,
+          });
+        }
+
         closeSlashCommandPopup();
         onSendMessage(`/${command.name}`);
         return;
@@ -1206,7 +1230,7 @@ export const MessageInput = forwardRef<
 
       closeSlashCommandPopup();
     },
-    [closeSlashCommandPopup, onSendMessage, vscode, slashCommand],
+    [closeSlashCommandPopup, onSendMessage, vscode, slashCommand, sessionId],
   );
 
   const handleSend = useCallback(() => {

--- a/packages/webview/tests/webview/slashCommandDraftPreserved.test.tsx
+++ b/packages/webview/tests/webview/slashCommandDraftPreserved.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  renderChatApp,
+  screen,
+  waitFor,
+  fireEvent,
+  act,
+  sendCommand,
+  fireInput,
+} from "./test-utils";
+
+/**
+ * 回归测试：从快捷指令弹窗选中「本地指令」（config/mcp/status/rewind/model…
+ * 打开对话框或设置页、不依赖光标位置的指令）时，不得把 '/' 前的输入框草稿
+ * 整条清空。
+ *
+ * 历史 bug：handleSlashCommandSelect 的本地指令分支无条件
+ * textareaRef.current.innerHTML = "" + setMessage("") +
+ * updateInputContent("") —— 用户在 '/' 前打的草稿被静默丢弃。修复后与技能
+ * 指令分支一致：只删除 [startPos, endPos) 的指令 token，剩余草稿留在输入框
+ * 并上报宿主会话记忆（updateInputContent 传剩余文本而非空串）。
+ */
+
+// jsdom 未实现 innerText。给 message-input 挂一个实时 getter/setter 模拟
+// 浏览器行为（textContent 是 jsdom 里可写的真实文本），使 MessageInput 内
+// 读 innerText / 写 innerText 的地方与 DOM 保持一致。
+function mockInnerText(el: HTMLElement) {
+  Object.defineProperty(el, "innerText", {
+    configurable: true,
+    get: () => el.textContent ?? "",
+    set: (value: string) => {
+      el.textContent = value;
+    },
+  });
+}
+
+/** 把输入框内容设为 text（光标移到末尾），触发快捷指令检测并等弹窗出现。 */
+async function openSlashPopup(text: string) {
+  const { vscode } = renderChatApp();
+  const input = screen.getByTestId("message-input");
+  input.focus();
+  mockInnerText(input);
+
+  input.textContent = text;
+  const range = document.createRange();
+  range.selectNodeContents(input);
+  range.collapse(false);
+  const sel = window.getSelection();
+  sel?.removeAllRanges();
+  sel?.addRange(range);
+  await fireInput(input, { data: text, inputType: "insertText" });
+
+  await waitFor(
+    () => {
+      expect(vscode.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ command: "requestSlashCommands" }),
+      );
+    },
+    { timeout: 3000 },
+  );
+
+  act(() => {
+    sendCommand("slashCommandsResponse", {
+      commands: [{ id: "model", name: "model", description: "选择模型" }],
+    });
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId("slash-commands-popup")).toBeInTheDocument();
+  });
+
+  // 清掉输入/弹窗检测期间产生的 postMessage 噪音，便于对选中后的行为精确断言。
+  vscode.postMessage.mockClear();
+  return { vscode, input };
+}
+
+describe("本地快捷指令选中不丢 '/' 前草稿（回归）", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("草稿 + 空格 + /model：Enter 选中后草稿保留、指令照常发出、剩余文本上报宿主", async () => {
+    const draft = "帮我分析这个报错";
+    const { vscode, input } = await openSlashPopup(`${draft} /model`);
+
+    // 弹窗打开时按 Enter → 选中本地指令 /model
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Enter" });
+    });
+
+    // 1) 本地指令照常执行（打开模型选择弹层，而非把含草稿的文本发给 agent）
+    expect(vscode.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ command: "getConfiguredModels" }),
+    );
+    expect(vscode.postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ command: "sendMessage" }),
+    );
+    expect(screen.getByTestId("model-popup")).toBeInTheDocument();
+
+    // 2) 输入框只剩 '/' 前的草稿（/model token 被删除）
+    expect(input.textContent).toBe(`${draft} `);
+
+    // 3) updateInputContent 上报剩余草稿而非空串 → 宿主会话记忆/切会话恢复不丢
+    expect(vscode.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "updateInputContent",
+        content: `${draft} `,
+      }),
+    );
+  });
+
+  it("空框只输 /model：Enter 选中后输入框清空，行为与修复前一致", async () => {
+    const { vscode, input } = await openSlashPopup("/model");
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Enter" });
+    });
+
+    expect(vscode.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ command: "getConfiguredModels" }),
+    );
+    expect(input.textContent).toBe("");
+    expect(vscode.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "updateInputContent",
+        content: "",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## 背景

Bug 3466227783198208：输入框已有草稿时使用本地斜杠指令（/config、/mcp、/rewind、/model 等）会把整条草稿清空。

## 根因

`MessageInput.tsx` `handleSlashCommandSelect` 的本地指令分支（原 :1165-1172）命中后无条件执行：

- `textareaRef.current.innerHTML = ""`
- `setMessage("")`
- `updateInputContent` 上报空串

不管 `/` 前是否有草稿都整条清掉。触发面：空格后的 `/` 同样弹窗（`detectSlashCommand` 允许行首或被空白隔开的 `/`），草稿被静默丢弃。

对照：技能指令分支只删 `[startPos, endPos)` 的 `/cmd` token、保留其余文本；本地指令分支是该模式的漏网之鱼。

## 修复

本地指令分支对齐技能指令分支：用 `findTextOffset` 定位 `slashCommand.startPos ~ endPos`，`range.deleteContents()` 只删指令 token，不清 `/` 前草稿；随后 `onSendMessage(\`/${command.name}\`)` 照发。

`updateInputContent` 上报删除指令 token 后的剩余文本（而非空串），保证草稿在宿主侧会话记忆/切会话恢复不丢。空框只输 `/cmd` 的行为与修复前一致（删后为空）。

## 测试

新增 `slashCommandDraftPreserved.test.tsx` 2 例（fail-without-fix 已验证）：
- 草稿 + 空格 + `/model` → Enter 选中：草稿保留在输入框、`getConfiguredModels` 指令照发、`updateInputContent` 上报剩余草稿
- 空框只输 `/model` → Enter 选中：输入框清空，行为与修复前一致

验证：webview 全量单测 106 文件 / 967 测试全绿 + 相关 6 文件 27 测试 + type-check（tsc main/tests/e2e/demo）+ oxlint 0 error + prettier 全过。