### PR TITLE
fix(webview): 设置页新增/编辑提示词预填到 focused 对话输入框（桌面 pane 布局）

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -51,6 +51,7 @@ import type {
   DesktopPanelKind,
   FileViewState,
   PanelTab,
+  PrefillDraftRequest,
   ThemeSource,
   ToolBlock,
   ToolBlockUpdateCallbackParams,
@@ -240,6 +241,8 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   sidebarExpandButton,
   headerActions,
   onOpenSettingsFromPane,
+  prefillRequest,
+  onPrefillApplied,
 }) => {
   const [state, dispatch] = useReducer(chatReducer, initialState);
   const [queueEditWarning, setQueueEditWarning] = useState<string | null>(null);
@@ -374,10 +377,15 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   // initialNav 传入；IDE 由 openSettings message 的 nav 走 host 下发。
   const [settingsNav, setSettingsNav] = useState<NavKey>("global");
   // 设置页「新建/编辑」预填的 AI 对话框提示词（desktop 关设置页后写入输入框；
-  // 见 handlePrefillPrompt）。
-  const [pendingPrefillPrompt, setPendingPrefillPrompt] = useState<
-    string | null
-  >(null);
+  // 见 handlePrefillPrompt）。无 pane 单布局 targetPaneId 为空、由本实例 effect
+  // 直接写本地输入框；pane 布局（FR-032）targetPaneId = 点击瞬间的 focused pane，
+  // 请求经 DesktopShell 下行给该 pane 的 ChatApp 写回（prefillRequest prop）。
+  // 内部状态名 pendingPrefill 与 prefillRequest prop（pane ChatApp 收到的下行
+  // 请求）区分——root 自己发请求、pane-scoped 实例收请求。
+  const [pendingPrefill, setPendingPrefill] =
+    useState<PrefillDraftRequest | null>(null);
+  // 每次「新建/编辑」点击递增，作 pane ChatApp effect 识别「新请求」的 nonce。
+  const prefillNonceRef = useRef(0);
   const [sessionBoardOpen, setSessionBoardOpen] = useState(false);
   // 桌面端主题偏好（host 为真源）：初值取 setInitialState.theme.source，此后随
   // host 广播（desktopThemeSource / 重推快照）同步，设置页「全局设置」主题行据此
@@ -1634,20 +1642,44 @@ export const ChatApp: React.FC<ChatAppProps> = ({
 
   // 设置页「新建/编辑」→ 关闭设置页并预填 AI 对话框提示词（desktop）。设置页
   // 打开期间 chatContainer 卸载（settingsOpen 替换视图），MessageInput 重挂载
-  // 后才能写入——用 pendingPrefillPrompt + effect 在渲染后写入并聚焦。
-  const handlePrefillPrompt = useCallback((prompt: string) => {
-    setSettingsOpen(false);
-    setSessionBoardOpen(false);
-    setPendingPrefillPrompt(prompt);
-  }, []);
+  // 后才能写入——用 prefillRequest + effect 在渲染后写入并聚焦。
+  //
+  // FR-032 桌面 pane 布局：设置页全页挂在 root 实例（paneId undefined），而各
+  // pane 的输入框在 DesktopShell 内的 pane-scoped ChatApp（ref 各自独立），root
+  // 的 messageInputRef 恒 null——直接写会静默丢 prompt。此时捕获点击瞬间的
+  // focused pane 作 targetPaneId，把请求留给 DesktopShell 下行到匹配 pane。
+  const handlePrefillPrompt = useCallback(
+    (prompt: string) => {
+      setSettingsOpen(false);
+      setSessionBoardOpen(false);
+      const panes = host?.panes;
+      if ((panes?.length ?? 0) > 0) {
+        setPendingPrefill({
+          prompt,
+          nonce: ++prefillNonceRef.current,
+          targetPaneId: host?.focusedPaneId ?? panes?.[0]?.paneId,
+        });
+      } else {
+        setPendingPrefill({ prompt, nonce: ++prefillNonceRef.current });
+      }
+    },
+    [host?.focusedPaneId, host?.panes],
+  );
 
-  // chatContainer 重挂载完成后把待填提示词写入输入框
+  // root 单布局（无 pane）：chatContainer 重挂载完成后把待填提示词写入本地输入框。
+  // pane 布局的请求带 targetPaneId，改由 pane ChatApp 写回并回调清除，这里跳过。
   useEffect(() => {
-    if (!settingsOpen && pendingPrefillPrompt !== null) {
-      messageInputRef.current?.loadDraft(pendingPrefillPrompt);
-      setPendingPrefillPrompt(null);
-    }
-  }, [settingsOpen, pendingPrefillPrompt]);
+    if (settingsOpen || pendingPrefill === null) return;
+    if (pendingPrefill.targetPaneId !== undefined) return;
+    messageInputRef.current?.loadDraft(pendingPrefill.prompt);
+    setPendingPrefill(null);
+  }, [settingsOpen, pendingPrefill]);
+
+  // DesktopShell 下行 prefillRequest 到 pane 后清除 root pending。pane ChatApp
+  // 应用时回调（带 nonce）——nonce 不匹配则忽略（防旧回执清掉更新的请求）。
+  const handlePrefillApplied = useCallback((nonce: number) => {
+    setPendingPrefill((prev) => (prev?.nonce === nonce ? null : prev));
+  }, []);
 
   // Batch 2 session board (desktop): 活动 button toggles the board view; the
   // board's 返回当前会话 closes it (spec 场景 6). Settings and board are
@@ -1942,6 +1974,33 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   // arrived, otherwise logged-in users see the login CTA flash before
   // setInitialState updates isAuthenticated to true.
   const showWelcomeReady = showWelcome && state.initialized;
+  // MessageInput 是否已挂载（输入区在欢迎页就绪或已有消息时渲染）。pane-scoped
+  // ChatApp 在设置页关闭后重挂载，初始收不到 snapshot（LoadingLogo 无输入框），
+  // 需等宿主 webviewReady 回放 setInitialState 后才真正挂载输入框。
+  const inputAreaMounted = showWelcomeReady || !showWelcome;
+
+  // pane-scoped ChatApp（paneId 非空，DesktopShell 内）：收到指向本 pane 的
+  // prefillRequest（settings 关闭、pane 行重挂载后随行下发）→ 输入框就绪后
+  // loadDraft 并回调 root 清除。effect 以 nonce 变化识别新请求；仅匹配 pane
+  // 收到请求（DesktopShell 过滤 targetPaneId），故此 effect 无跨 pane 竞态。
+  // 若请求到达时输入框尚未挂载（宿主 snapshot 未回放），pending 保持不下发、
+  // 待 inputAreaMounted 翻转后本 effect 重跑补写。
+  const prefillRequestNonce = prefillRequest?.nonce;
+  useEffect(() => {
+    if (paneId === undefined) return;
+    if (!prefillRequest || prefillRequestNonce === undefined) return;
+    if (!inputAreaMounted) return;
+    const input = messageInputRef.current;
+    if (!input) return;
+    input.loadDraft(prefillRequest.prompt);
+    onPrefillApplied?.(prefillRequest.nonce);
+  }, [
+    prefillRequest,
+    prefillRequestNonce,
+    paneId,
+    onPrefillApplied,
+    inputAreaMounted,
+  ]);
 
   // Initialize webview and load sessions on component mount
   useEffect(() => {
@@ -3230,6 +3289,8 @@ export const ChatApp: React.FC<ChatAppProps> = ({
             sessionBoard={sessionBoard}
             sessionBoardActive={sessionBoardOpen}
             onOpenSessionBoard={handleOpenSessionBoard}
+            prefillRequest={pendingPrefill}
+            onPrefillApplied={handlePrefillApplied}
           />
           {dialogs}
         </>

--- a/packages/webview/src/components/DesktopShell.tsx
+++ b/packages/webview/src/components/DesktopShell.tsx
@@ -14,6 +14,7 @@ import type {
   DesktopHostProps,
   DesktopPane,
   OpenPaneOptions,
+  PrefillDraftRequest,
   VsCodeApi,
 } from "../types";
 import type { NavKey } from "./SettingsPage";
@@ -66,6 +67,14 @@ interface DesktopShellProps {
   /** 活动 button highlight while the board view is open (spec 场景 1). */
   sessionBoardActive?: boolean;
   onOpenSessionBoard?: () => void;
+  /**
+   * root 设置页「新建/编辑」预填提示词请求（FR-032：root 不挂 MessageInput）。
+   * 仅 targetPaneId 匹配的 pane-scoped ChatApp 收到（settings 关闭、pane 行
+   * 重挂载后随行下发），写输入框后回调 onPrefillApplied 清 root pending。
+   */
+  prefillRequest?: PrefillDraftRequest | null;
+  /** pane ChatApp 已把预填提示词写入输入框（携带 nonce）。 */
+  onPrefillApplied?: (nonce: number) => void;
 }
 
 /**
@@ -107,6 +116,8 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
   sessionBoard,
   sessionBoardActive = false,
   onOpenSessionBoard,
+  prefillRequest = null,
+  onPrefillApplied,
 }) => {
   const panes: DesktopPane[] = useMemo(() => host.panes ?? [], [host.panes]);
   const focusedPaneId = host.focusedPaneId ?? panes[0]?.paneId ?? null;
@@ -786,6 +797,12 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
                                   : undefined
                               }
                               onOpenSettingsFromPane={onOpenSettings}
+                              prefillRequest={
+                                prefillRequest?.targetPaneId === pane.paneId
+                                  ? prefillRequest
+                                  : null
+                              }
+                              onPrefillApplied={onPrefillApplied}
                               headerActions={
                                 panes.length > 1 ? (
                                   <button

--- a/packages/webview/src/types/index.ts
+++ b/packages/webview/src/types/index.ts
@@ -225,6 +225,38 @@ export interface ChatAppProps {
    * renders the full-page settings (spec agent-config.md scenario 5).
    */
   onOpenSettingsFromPane?: (nav?: NavKey) => void;
+  /**
+   * Desktop pane layout: a settings-page「新建/编辑」prefill draft handed down
+   * from the root instance (which renders the full-page settings but, in pane
+   * mode, no MessageInput of its own). DesktopShell threads the request only to
+   * the pane-scoped ChatApp whose paneId === targetPaneId (captured from the
+   * host's focused pane at click time). The receiving ChatApp loadDrafts the
+   * prompt once its input is mounted and reports back via onPrefillApplied.
+   * Undefined/null = no pending request. Root single-layout instances never
+   * receive this prop — they write their own input via the plain effect.
+   */
+  prefillRequest?: PrefillDraftRequest | null;
+  /** 收到 pane ChatApp 已写入输入框的回执（携带 nonce，root 据此清 pending）。 */
+  onPrefillApplied?: (nonce: number) => void;
+}
+
+/**
+ * 设置页「新建/编辑」→ 关闭设置页并把提示词预填进 AI 对话框（desktop）。
+ * 无 pane 单布局下 root ChatApp 自带 MessageInput，直接写本地 ref；桌面 pane
+ * 布局（FR-032）下设置页挂在 root 实例而输入框在 pane-scoped ChatApp —— root
+ * 在点击瞬间捕获 targetPaneId，请求经 DesktopShell 下行给匹配 pane。
+ */
+export interface PrefillDraftRequest {
+  /** 预填提示词全文（设置页各「新建/编辑」模板生成，调用方不动）。 */
+  prompt: string;
+  /** 请求序号，每次点击递增：pane ChatApp 的 effect 以 nonce 变化识别新请求。 */
+  nonce: number;
+  /**
+   * Desktop pane 布局下点击瞬间的目标 pane id（host.focusedPaneId 兜底
+   * panes[0]，与 host 侧「无 paneId RPC 落到 focused pane」同一锚点）。
+   * undefined = 无 pane 单布局，由 root 自己的 effect 写入本地输入框。
+   */
+  targetPaneId?: string;
 }
 
 /**

--- a/packages/webview/tests/webview/settingsPaneDelegate.test.tsx
+++ b/packages/webview/tests/webview/settingsPaneDelegate.test.tsx
@@ -5,6 +5,7 @@ import {
   fireEvent,
   waitFor,
   act,
+  within,
   sendHostMessage,
   fixtures,
   createMockVscode,
@@ -41,6 +42,28 @@ function desktopHost(
 
 async function typeAndSend(text: string) {
   const input = screen.getByTestId("message-input");
+  input.focus();
+  await act(async () => {
+    input.textContent = text;
+    const range = document.createRange();
+    range.selectNodeContents(input);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+    fireEvent.input(input, { data: text, inputType: "insertText" });
+  });
+  fireEvent.keyDown(input, { key: "Enter" });
+}
+
+// Split view 下每个 pane 有自己的输入框——用 within(pane 容器) 定位目标 pane。
+function paneInput(paneId: string): HTMLElement {
+  return within(screen.getByTestId(`desktop-pane-${paneId}`)).getByTestId(
+    "message-input",
+  );
+}
+
+async function typeInPane(paneId: string, text: string) {
+  const input = paneInput(paneId);
   input.focus();
   await act(async () => {
     input.textContent = text;
@@ -143,5 +166,81 @@ describe("desktop pane 布局斜杠命令打开设置页", () => {
     ).toBeInTheDocument();
     const navItem = screen.getByRole("button", { name: /全局设置/ });
     expect(navItem).toHaveClass("is-active");
+  });
+});
+
+// spec docs/specs/ecosystem/mcp.md「新增/编辑 MCP」：设置页点「+ 新增 MCP 服务」后
+// 关闭设置页、把 /settings 提示词预填进 focused 对话输入框。Bug 3466212216530432
+// 根因：FR-032 pane 布局下设置页挂在 root 实例（paneId undefined）而输入框在各
+// pane-scoped ChatApp——root 的 messageInputRef 恒 null，open 方向委托
+// （onOpenSettingsFromPane）已实现、close/prefill 反向缺失 → 提示词被 root 静默
+// 丢弃。修复 = root 捕获点击瞬间 focusedPaneId 作 targetPaneId，请求经 DesktopShell
+// 下行给匹配 pane 的 ChatApp，输入框就绪后 loadDraft + 回调清除。
+describe("desktop pane 布局：设置页「新增/编辑」提示词预填进 focused 对话输入框", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("pane-1（focused）开 MCP 设置点项目级「新增 MCP 服务」→ /settings 提示词写入 pane-1 输入框", async () => {
+    render(
+      <ChatApp
+        vscode={createMockVscode() as unknown as VsCodeApi}
+        host={desktopHost([{ paneId: "pane-1" }, { paneId: "pane-2" }])}
+      />,
+    );
+    sendHostMessage(fixtures.authStatusResponse());
+
+    // pane-1（focused）输入 /mcp → 委托 root 打开设置页「MCP 服务」选项卡
+    await typeInPane("pane-1", "/mcp");
+    // SettingsTabs 的 Tab 是 role="tab"（非 button）
+    expect(
+      await screen.findByRole("tab", { name: /项目级 MCP/ }),
+    ).toBeInTheDocument();
+
+    // 切到项目级 Tab，点「新增 MCP 服务」→ 关设置页并预填项目级 /settings 提示词
+    await act(async () => {
+      fireEvent.click(await screen.findByRole("tab", { name: /项目级 MCP/ }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /新增 MCP 服务/ }));
+    });
+
+    // 设置页关闭 → pane 行重挂载（ChatApp 状态复位，输入框未就绪）。宿主收到
+    // webviewReady 后回放 snapshot——此处模拟：authStatusResponse 置 initialized，
+    // 输入框挂载后下行请求才真正 loadDraft（此前保持 pending 不清除）。
+    sendHostMessage(fixtures.authStatusResponse());
+
+    await waitFor(() => {
+      expect(paneInput("pane-1").textContent ?? "").toMatch(
+        /^\/settings 帮我在/,
+      );
+    });
+    // 非目标 pane（pane-2）不受影响
+    expect(paneInput("pane-2").textContent ?? "").not.toContain("/settings");
+  });
+
+  it("无 pane 单布局回归：新增用户级 MCP 服务 → 提示词写入本实例输入框", async () => {
+    render(
+      <ChatApp
+        vscode={createMockVscode() as unknown as VsCodeApi}
+        host={desktopHost([])}
+      />,
+    );
+    sendHostMessage(fixtures.authStatusResponse());
+
+    await typeAndSend("/mcp");
+    const addUserServerBtn = await screen.findByRole("button", {
+      name: /新增用户级 MCP 服务/,
+    });
+    await act(async () => {
+      fireEvent.click(addUserServerBtn);
+    });
+
+    // 关设置页后本实例（root，无 pane）chatContainer 重挂载 → 本地输入框写入
+    await waitFor(() => {
+      expect(screen.getByTestId("message-input").textContent ?? "").toMatch(
+        /^\/settings 帮我配个用户级/,
+      );
+    });
   });
 });


### PR DESCRIPTION
## 背景

Bug 3466212216530432：桌面端设置页「新增/编辑」（MCP/子代理/技能/钩子配置页）关闭设置页后不把提示词预填进 focused 对话输入框。

## 根因

FR-032 桌面 pane 布局（desktopPanes 推送后）下，设置页全页挂在 **root 实例**（paneId undefined，DesktopShell 渲染），而对话输入框在各 **pane-scoped ChatApp** 内——root 的 `messageInputRef` 恒 null，原 `handlePrefillPrompt`（ChatApp.tsx）把提示词写给自己的 ref 被静默丢弃。

open 方向委托（`onOpenSettingsFromPane`，c984ed74）早已实现；close/prefill 反向从未实现，故斜杠命令打开的设置页与既有绑定会话的 pane 布局下四配置页全部受影响。

## 修复（纯 webview 三处接线，无 host/协议改动）

1. **root ChatApp**：`handlePrefillPrompt` 在点击瞬间捕获 `targetPaneId = host.focusedPaneId ?? panes[0]?.paneId`（与 desktopHost.ts 无 paneId RPC 落到 focused pane 同一锚点），pending 升级为 `{ prompt, nonce, targetPaneId }`；无 pane 单布局保持原行为（root 自带输入框，effect 直写本地 ref）。
2. **DesktopShell**：透传 `prefillRequest`（仅 `targetPaneId` 匹配的 pane-scoped ChatApp 收到，无跨 pane 竞态）+ `onPrefillApplied` 回调清 root pending（按 nonce 匹配，防旧回执清掉更新请求）。
3. **pane-scoped ChatApp**：新 effect 与 root 原 effect 同构——`inputAreaMounted`（欢迎页就绪或已有消息）为 gate：设置页关闭 → pane 行重挂载 → 宿主 `webviewReady` 回放 snapshot 后输入框才真正挂载，此前请求保持 pending 不清除、待输入区挂载后补写 `loadDraft` + 回调。

## 测试

- `settingsPaneDelegate.test.tsx` +2：双 pane 下 pane-1（focused）`/mcp` → 项目级「新增 MCP 服务」→ `/settings 帮我在…` 预填进 pane-1 输入框、pane-2 不受影响（**修复前 fail**，已 stash 源码头验证）；无 pane 单布局新增用户级回归 1 例。
- 验证：webview oxlint 0/0、type-check 四项目全过、全量单测 **105 文件 / 967 用例通过**；pre-commit（monorepo 全包 type-check + lint-staged）绿。