### PR TITLE
fix(webview): 分屏布局收起侧边栏后让位段与展开按钮同源，不再压红绿灯

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -432,11 +432,14 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   // 系统红绿灯的落位。该实例若占据窗口最左侧（root 单布局，或 DesktopShell 中
   // 拿到 sidebarExpandButton 的首行首 pane），就让 ChatHeader 在左端让出一段
   // 76px 拖拽区（spec「macOS 隐藏标题栏」场景 3）。
+  // 收起信号须与展开按钮同源：root 单布局读自身 sidebarCollapsed（点击即时更
+  // 新）；pane 实例的 state 只是挂载时快照、运行期收起会过期，而 shell 仅在
+  // 全局收起时向首行首 pane 下发 sidebarExpandButton——两者同源，让位段才会
+  // 与展开按钮一起出现，否则展开按钮直接压在红绿灯上。
+  const sidebarHidden =
+    paneId === undefined ? sidebarCollapsed : sidebarExpandButton != null;
   const macTrafficSpacer =
-    isMacHiddenTitlebar() &&
-    sidebarCollapsed &&
-    !fullScreen &&
-    (paneId === undefined || sidebarExpandButton != null);
+    isMacHiddenTitlebar() && sidebarHidden && !fullScreen;
   // The pane's effective host ('local' or an SSH host name): a pane-bound
   // session's host (authoritative `desktopPanes` push) wins; the single-pane
   // layout reads the host-level current host. Remote sessions run the whole

--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -3293,6 +3293,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({
             sidebarExpandButton={expandBtn}
             collapsed={sidebarCollapsed}
             onCollapsedChange={handleSidebarCollapsedChange}
+            fullScreen={fullScreen}
             settingsOpen={settingsOpen}
             onCloseSettings={handleCloseSettings}
             sessionBoardOpen={sessionBoardOpen}

--- a/packages/webview/src/components/DesktopShell.tsx
+++ b/packages/webview/src/components/DesktopShell.tsx
@@ -56,6 +56,10 @@ interface DesktopShellProps {
   /** Sidebar fully hidden — threaded through to the shell's own DesktopSidebar. */
   collapsed?: boolean;
   onCollapsedChange: (collapsed: boolean) => void;
+  /** macOS 窗口全屏（desktopFullScreen push，root 经 shell 下行）：全屏下红绿
+   *  灯隐藏，shell 的侧边栏窗口行「收起侧边栏」按钮左移至行起点（spec
+   *  「macOS 隐藏标题栏」场景 7）。 */
+  fullScreen?: boolean;
   /** Batch 2 settings full-page: rendered over the pane rows when open. */
   settingsOpen?: boolean;
   onCloseSettings?: () => void;
@@ -110,6 +114,7 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
   sidebarExpandButton,
   collapsed = false,
   onCollapsedChange,
+  fullScreen = false,
   settingsOpen = false,
   settingsPage,
   sessionBoardOpen = false,
@@ -697,6 +702,7 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
         onDeleteSession={host.onDeleteSession}
         collapsed={collapsed}
         onCollapsedChange={onCollapsedChange}
+        fullScreen={fullScreen}
         sessionBoardActive={sessionBoardActive}
         onOpenSessionBoard={onOpenSessionBoard}
       />

--- a/packages/webview/tests/webview/macTitlebar.test.tsx
+++ b/packages/webview/tests/webview/macTitlebar.test.tsx
@@ -3,8 +3,9 @@ import { render, fireEvent, screen } from "@testing-library/react";
 import React from "react";
 import { DesktopApp } from "../../src/components/DesktopApp";
 import { isMacHiddenTitlebar } from "../../src/utils/platform";
-import { createMockVscode, sendHostMessage } from "./test-utils";
+import { createMockVscode, sendHostMessage, sendCommand } from "./test-utils";
 import { fixtures } from "wave-webview-fixtures";
+import { MockDataGenerator } from "../fixtures/mockData";
 
 vi.mock("../../src/styles/DesktopApp.css", () => ({}));
 
@@ -187,5 +188,103 @@ describe("collapsed sidebar traffic-light clearance (real macOS)", () => {
     expect(
       document.querySelector('[data-testid="desktop-sidebar-expand"]'),
     ).not.toBeNull();
+  });
+});
+
+describe("split-view: collapsed gutter follows the shell's expand-button signal", () => {
+  it("reserves the traffic-light gutter on the first pane after a runtime collapse", () => {
+    window.waveHostType = "desktop";
+    window.wavePlatform = "darwin";
+    // localStorage starts expanded (the default) — the collapse happens at
+    // runtime, after the pane-scoped ChatApp already mounted.
+    renderDesktopApp();
+    sendCommand("desktopSessionTree", {
+      groups: [
+        {
+          workdir: "/work/a",
+          sessions: [
+            {
+              sessionId: "s1",
+              title: "chat one",
+              lastActiveAt: Date.now(),
+              hasWorktree: false,
+            },
+          ],
+        },
+      ],
+    });
+    sendCommand("desktopPanes", {
+      panes: [{ paneId: "p1", sessionId: "s1", width: 1 }],
+      focusedPaneId: "p1",
+    });
+    sendCommand("setInitialState", {
+      messages: [MockDataGenerator.createUserMessage("hi")],
+      paneId: "p1",
+    });
+
+    // Sidebar expanded → no gutter yet.
+    expect(querySidebar()).not.toBeNull();
+    expect(queryTrafficSpacer()).toBeNull();
+
+    fireEvent.click(screen.getByTestId("desktop-sidebar-collapse"));
+
+    // The first pane is flush with the window's left edge now: its header must
+    // reserve the traffic-light gutter next to the expand button it received.
+    expect(querySidebar()).toBeNull();
+    expect(queryTrafficSpacer()).not.toBeNull();
+    expect(
+      document.querySelector('[data-testid="desktop-sidebar-expand"]'),
+    ).not.toBeNull();
+  });
+
+  it("drops the gutter for a non-first pane (no expand button received)", () => {
+    window.waveHostType = "desktop";
+    window.wavePlatform = "darwin";
+    localStorage.setItem("wave.desktopSidebarCollapsed", "1");
+    renderDesktopApp();
+    sendCommand("desktopSessionTree", {
+      groups: [
+        {
+          workdir: "/work/a",
+          sessions: [
+            {
+              sessionId: "s1",
+              title: "chat one",
+              lastActiveAt: Date.now(),
+              hasWorktree: false,
+            },
+            {
+              sessionId: "s2",
+              title: "chat two",
+              lastActiveAt: Date.now(),
+              hasWorktree: false,
+            },
+          ],
+        },
+      ],
+    });
+    // Two panes: the second is not flush with the window's left edge, so the
+    // shell hands the expand button to the first pane only.
+    sendCommand("desktopPanes", {
+      panes: [
+        { paneId: "p1", sessionId: "s1", width: 0.5 },
+        { paneId: "p2", sessionId: "s2", width: 0.5 },
+      ],
+      focusedPaneId: "p1",
+    });
+    sendCommand("setInitialState", {
+      messages: [],
+      paneId: "p1",
+    });
+    sendCommand("setInitialState", {
+      messages: [MockDataGenerator.createUserMessage("hi")],
+      paneId: "p2",
+    });
+
+    expect(querySidebar()).toBeNull();
+    // Only one gutter for the first pane; the second pane's header stays clear.
+    expect(document.querySelectorAll(".chat-header-mac-traffic")).toHaveLength(
+      1,
+    );
   });
 });

--- a/packages/webview/tests/webview/macTitlebar.test.tsx
+++ b/packages/webview/tests/webview/macTitlebar.test.tsx
@@ -287,4 +287,42 @@ describe("split-view: collapsed gutter follows the shell's expand-button signal"
       1,
     );
   });
+
+  it("slides the window-row collapse button to the row start on fullscreen", () => {
+    window.waveHostType = "desktop";
+    window.wavePlatform = "darwin";
+    // Any session activation runs through the pane model, so the shell owns the
+    // sidebar window row — fullscreen must reach it through the shell too.
+    renderDesktopApp();
+    sendCommand("desktopSessionTree", {
+      groups: [
+        {
+          workdir: "/work/a",
+          sessions: [
+            {
+              sessionId: "s1",
+              title: "chat one",
+              lastActiveAt: Date.now(),
+              hasWorktree: false,
+            },
+          ],
+        },
+      ],
+    });
+    sendCommand("desktopPanes", {
+      panes: [{ paneId: "p1", sessionId: "s1", width: 1 }],
+      focusedPaneId: "p1",
+    });
+    sendCommand("setInitialState", {
+      messages: [MockDataGenerator.createUserMessage("hi")],
+      paneId: "p1",
+    });
+
+    const row = queryDragRow();
+    expect(row).not.toBeNull();
+    expect(row!.classList.contains("is-fullscreen")).toBe(false);
+
+    sendHostMessage(fixtures.desktopFullScreen({ fullScreen: true }));
+    expect(row!.classList.contains("is-fullscreen")).toBe(true);
+  });
 });


### PR DESCRIPTION
分屏（split-view）布局里，pane-scoped ChatApp 的 macTrafficSpacer 此前读自身 sidebarCollapsed——该 state 只是挂载时从 localStorage 读的快照，运行期点击「收起侧边栏」不会更新它；而展开按钮由 shell 仅在全局收起时下发给首行首 pane（sidebarExpandButton prop）。两者不同源导致：展开按钮已渲染、76px 红绿灯让位段缺失，按钮直接压系统红绿灯。

修复：让位段与展开按钮同源——root 单布局读自身 sidebarCollapsed；pane 实例改读 sidebarExpandButton != null（shell 只在全局收起时下发该按钮）。

TDD：split 场景运行期收起后让位段出现；双 pane 时仅首 pane 让位。macTitlebar 12 测试全绿，webview 全量 973 绿。