### PR TITLE
refactor(webview): 窗口级 chrome 状态收敛进 DesktopChromeContext（族1 架构优化）

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -28,6 +28,7 @@ import WorkflowManager from "./WorkflowManager";
 import WelcomeView from "./WelcomeView";
 import LoadingLogo from "./LoadingLogo";
 import { SidebarExpandIcon, CloseIcon } from "./HeaderIcons";
+import { useDesktopChrome } from "./DesktopChromeContext";
 import { DesktopHostSelector } from "./DesktopHostSelector";
 import { DesktopSidebar } from "./DesktopSidebar";
 import { DesktopShell } from "./DesktopShell";
@@ -214,8 +215,9 @@ export function prunePanelGroupCache(keepKeys: Set<string>): void {
 
 /**
  * Desktop sidebar collapsed → the leftmost chat header shows this expand button
- * (spec 「侧边栏收起/展开」scenario 4). In split view the root instance builds it
- * once and DesktopShell threads it into the first pane of the top row.
+ * (spec 「侧边栏收起/展开」scenario 4). Built by every instance that occupies the
+ * window's left edge — the root single layout or the first top-row pane — from
+ * the window-level sidebarCollapsed (DesktopChromeContext).
  * Icon = Figma sidebar-expand（外框 + 朝右箭头 →，与侧栏内收起按钮的
  * sidebar-collapse 外框+左条区分方向）。
  */
@@ -238,7 +240,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   vscode,
   host,
   paneId,
-  sidebarExpandButton,
+  firstPane,
   headerActions,
   onOpenSettingsFromPane,
   prefillRequest,
@@ -254,9 +256,11 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   const [accountInfo, setAccountInfo] = useState<AccountCardAccount | null>(
     null,
   );
-  // macOS 窗口全屏状态（desktopFullScreen push；spec「macOS 隐藏标题栏」场景 7）。
-  // 全屏下系统红绿灯隐藏 → 红绿灯让位（窗口行按钮 / 收起态顶栏让位段）随之收起。
-  const [fullScreen, setFullScreen] = useState(false);
+  // 窗口级 chrome 状态（侧边栏收起 + macOS 全屏）单一权威在 DesktopChromeContext
+  //（DesktopApp 根提供）：root 单布局 / DesktopShell pane 各实例同源读取，不再
+  // 各自持有副本或 props 下行（见 DesktopChromeContext.tsx 头注释）。
+  const { sidebarCollapsed, setSidebarCollapsed, fullScreen } =
+    useDesktopChrome();
   // Message id awaiting rewind confirmation; non-null shows the ConfirmDialog.
   const [pendingRewindId, setPendingRewindId] = useState<string | null>(null);
   // /rewind popup: checkpoint list requested from the host on open.
@@ -344,31 +348,6 @@ export const ChatApp: React.FC<ChatAppProps> = ({
         : (host?.recentWorkdirs?.[0] ?? host?.workdir)
       : effectiveWorkdir;
   const isDesktop = host?.type === "desktop";
-  // Desktop sidebar collapsed (spec 「侧边栏收起/展开」): fully hidden, chat takes
-  // the whole width; the leftmost chat header's expand button restores it.
-  // Persisted so a restart keeps the choice (scenario 7). Only the root
-  // instance (paneId undefined) owns this — panes receive the expand button
-  // as a ready-made ReactNode via sidebarExpandButton.
-  const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(() => {
-    try {
-      return localStorage.getItem("wave.desktopSidebarCollapsed") === "1";
-    } catch {
-      // localStorage unavailable (sandboxed webview): default to expanded.
-      return false;
-    }
-  });
-  const handleSidebarCollapsedChange = useCallback((collapsed: boolean) => {
-    setSidebarCollapsed(collapsed);
-    try {
-      localStorage.setItem(
-        "wave.desktopSidebarCollapsed",
-        collapsed ? "1" : "0",
-      );
-    } catch {
-      // localStorage unavailable (sandboxed webview): the collapse still works
-      // for this session, it just won't persist.
-    }
-  }, []);
   // Batch 2 (designer prototype): desktop settings full-page and session board
   // view switches. Only the root instance (paneId undefined) owns these — a
   // split-view pane never renders them. settingsOpen covers the desktop
@@ -411,11 +390,14 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   const [projectAgentsContent, setProjectAgentsContent] = useState<
     string | null
   >(null);
+  // 该实例是否占据窗口最左侧（其顶栏需承载「侧边栏收起 → 展开按钮 + 红绿灯让
+  // 位段」）：root 单布局（paneId undefined），或 DesktopShell 首行首 pane
+  //（firstPane 由 shell 显式标记）。身份与收起状态都同源于 context —— 运行期
+  // 收起/展开（含全屏让位）即时反映，不再有 pane 快照过期的问题。
+  const isLeftmostChatHeader = paneId === undefined || firstPane === true;
   const expandBtn =
-    paneId === undefined && sidebarCollapsed ? (
-      <SidebarExpandButton
-        onClick={() => handleSidebarCollapsedChange(false)}
-      />
+    sidebarCollapsed && isLeftmostChatHeader ? (
+      <SidebarExpandButton onClick={() => setSidebarCollapsed(false)} />
     ) : null;
   // 收起态 header leading：展开侧边栏 + 分割线（评论 2026-09：header 里的
   // 「新建对话」图标钮与功能已拿掉——展开后该入口在侧边栏/新会话处提供）。
@@ -429,17 +411,13 @@ export const ChatApp: React.FC<ChatAppProps> = ({
       </div>
     ) : null;
   // macOS 隐藏标题栏 + 侧边栏收起：最左侧顶栏的收起态 leading 正处于窗口左上角
-  // 系统红绿灯的落位。该实例若占据窗口最左侧（root 单布局，或 DesktopShell 中
-  // 拿到 sidebarExpandButton 的首行首 pane），就让 ChatHeader 在左端让出一段
-  // 76px 拖拽区（spec「macOS 隐藏标题栏」场景 3）。
-  // 收起信号须与展开按钮同源：root 单布局读自身 sidebarCollapsed（点击即时更
-  // 新）；pane 实例的 state 只是挂载时快照、运行期收起会过期，而 shell 仅在
-  // 全局收起时向首行首 pane 下发 sidebarExpandButton——两者同源，让位段才会
-  // 与展开按钮一起出现，否则展开按钮直接压在红绿灯上。
-  const sidebarHidden =
-    paneId === undefined ? sidebarCollapsed : sidebarExpandButton != null;
+  // 系统红绿灯的落位，让出一段 76px 拖拽区（spec「macOS 隐藏标题栏」场景 3）。
+  // 让位与展开按钮同源（上面同一条件），展开按钮不会压在红绿灯上。
   const macTrafficSpacer =
-    isMacHiddenTitlebar() && sidebarHidden && !fullScreen;
+    isMacHiddenTitlebar() &&
+    sidebarCollapsed &&
+    isLeftmostChatHeader &&
+    !fullScreen;
   // The pane's effective host ('local' or an SSH host name): a pane-bound
   // session's host (authoritative `desktopPanes` push) wins; the single-pane
   // layout reads the host-level current host. Remote sessions run the whole
@@ -1245,11 +1223,6 @@ export const ChatApp: React.FC<ChatAppProps> = ({
             apiQuota: message.apiQuota ?? null,
             update: message.update ?? null,
           });
-          break;
-        case "desktopFullScreen":
-          // macOS fullscreen state — window-global; every ChatApp instance
-          // (root sidebar + split panes) consumes it for its own spacer/row.
-          setFullScreen(message.fullScreen === true);
           break;
         case "desktopTogglePanel":
           if (!forThisPane(message)) break;
@@ -3070,7 +3043,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({
       }}
       onBack={handleCloseSessionBoard}
       collapsed={sidebarCollapsed}
-      onExpandSidebar={() => handleSidebarCollapsedChange(false)}
+      onExpandSidebar={() => setSidebarCollapsed(false)}
     />
   ) : null;
 
@@ -3163,11 +3136,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({
         </div>
       )}
       <ChatHeader
-        leading={
-          paneId !== undefined
-            ? collapsedLeading(sidebarExpandButton)
-            : collapsedLeading(expandBtn)
-        }
+        leading={collapsedLeading(expandBtn)}
         macTrafficSpacer={macTrafficSpacer}
         onNewSession={handleClearChat}
         newSessionDisabled={state.isStreaming}
@@ -3290,10 +3259,6 @@ export const ChatApp: React.FC<ChatAppProps> = ({
             onDownloadUpdate={handleDownloadUpdate}
             onRestartApp={handleRestartApp}
             account={accountInfo}
-            sidebarExpandButton={expandBtn}
-            collapsed={sidebarCollapsed}
-            onCollapsedChange={handleSidebarCollapsedChange}
-            fullScreen={fullScreen}
             settingsOpen={settingsOpen}
             onCloseSettings={handleCloseSettings}
             sessionBoardOpen={sessionBoardOpen}
@@ -3342,9 +3307,6 @@ export const ChatApp: React.FC<ChatAppProps> = ({
           onSelectSession={host.onSelectSession}
           onOpenPane={host.onOpenPane}
           onDeleteSession={host.onDeleteSession}
-          collapsed={sidebarCollapsed}
-          onCollapsedChange={handleSidebarCollapsedChange}
-          fullScreen={fullScreen}
           sessionBoardActive={sessionBoardOpen}
           onOpenSessionBoard={handleOpenSessionBoard}
         />

--- a/packages/webview/src/components/DesktopApp.tsx
+++ b/packages/webview/src/components/DesktopApp.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { ChatApp, prunePanelGroupCache } from "./ChatApp";
+import { DesktopChromeProvider } from "./DesktopChromeContext";
 import {
   VsCodeApi,
   DesktopWorkdirState,
@@ -169,30 +170,35 @@ export const DesktopApp: React.FC<DesktopAppProps> = ({ vscode }) => {
   const { workdir, recentWorkdirs, host, hosts } = workdirState;
 
   return (
-    <ChatApp
-      vscode={vscode}
-      host={{
-        type: "desktop",
-        host,
-        hosts,
-        workdir,
-        recentWorkdirs,
-        onSelectWorkdir: handleSelectWorkdir,
-        onSelectRecentWorkdir: handleSelectRecentWorkdir,
-        onRemoveRecentWorkdir: handleRemoveRecentWorkdir,
-        onSelectHost: handleSelectHost,
-        onAddHost: handleAddHost,
-        onSelectRemotePath: handleSelectRemotePath,
-        onListRemoteDir: handleListRemoteDir,
-        sessionTree,
-        onSelectSession: handleSelectSession,
-        onDeleteSession: handleDeleteSession,
-        onOpenPane: handleOpenPane,
-        panes,
-        rowHeights,
-        focusedPaneId,
-      }}
-    />
+    // 窗口级 chrome 状态（sidebarCollapsed/fullScreen）单一权威：root、pane
+    // 任何 ChatApp 实例与 DesktopShell/DesktopSidebar 同源读取（不再逐层
+    // props 透传 / 各实例留本地副本）。见 DesktopChromeContext.tsx。
+    <DesktopChromeProvider>
+      <ChatApp
+        vscode={vscode}
+        host={{
+          type: "desktop",
+          host,
+          hosts,
+          workdir,
+          recentWorkdirs,
+          onSelectWorkdir: handleSelectWorkdir,
+          onSelectRecentWorkdir: handleSelectRecentWorkdir,
+          onRemoveRecentWorkdir: handleRemoveRecentWorkdir,
+          onSelectHost: handleSelectHost,
+          onAddHost: handleAddHost,
+          onSelectRemotePath: handleSelectRemotePath,
+          onListRemoteDir: handleListRemoteDir,
+          sessionTree,
+          onSelectSession: handleSelectSession,
+          onDeleteSession: handleDeleteSession,
+          onOpenPane: handleOpenPane,
+          panes,
+          rowHeights,
+          focusedPaneId,
+        }}
+      />
+    </DesktopChromeProvider>
   );
 };
 

--- a/packages/webview/src/components/DesktopChromeContext.tsx
+++ b/packages/webview/src/components/DesktopChromeContext.tsx
@@ -1,0 +1,90 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+/**
+ * 窗口级（chrome）UI 状态单一权威 —— 解决「root 单布局 与 DesktopShell pane
+ * 渲染路径共享窗口级状态却各自维护/漏下行」的一类 bug（spec「macOS 隐藏标题
+ * 栏」场景 3/7、「侧边栏收起/展开」场景 7）：
+ * - sidebarCollapsed：侧边栏整条收起/展开，localStorage 持久化（原 root
+ *   ChatApp 私有 state——pane 实例只拿到挂载时快照、运行期收起会过期）。
+ * - fullScreen：macOS 系统全屏（desktopFullScreen host push，原各 ChatApp
+ *   实例各自 setState——DesktopShell 渲染的侧边栏收不到）。
+ *
+ * Provider 挂在 DesktopApp（窗口根），root/pane 任何 ChatApp 实例及其子树
+ * （DesktopShell/DesktopSidebar/ChatHeader）都从 Context 同源读取，不再存在
+ * 两条渲染路径、两份副本。IDE（VSCE/JetBrains）不渲染 Provider → 读默认值
+ * （false），不影响其现有行为。
+ */
+export interface DesktopChromeValue {
+  /** 侧边栏整条收起（true）= 对话占满全宽，最左顶栏显示展开按钮。 */
+  sidebarCollapsed: boolean;
+  setSidebarCollapsed: (collapsed: boolean) => void;
+  /** macOS 全屏（系统红绿灯隐藏，红绿灯让位收起）。非 macOS 恒 false。 */
+  fullScreen: boolean;
+}
+
+const DesktopChromeContext = createContext<DesktopChromeValue>({
+  sidebarCollapsed: false,
+  setSidebarCollapsed: () => {},
+  fullScreen: false,
+});
+
+const SIDEBAR_COLLAPSED_KEY = "wave.desktopSidebarCollapsed";
+
+const readCollapsed = (): boolean => {
+  try {
+    return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "1";
+  } catch {
+    // localStorage unavailable (sandboxed webview): default to expanded.
+    return false;
+  }
+};
+
+export const DesktopChromeProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [sidebarCollapsed, setSidebarCollapsedState] =
+    useState<boolean>(readCollapsed);
+  const [fullScreen, setFullScreen] = useState(false);
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data?.command === "desktopFullScreen") {
+        setFullScreen(event.data.fullScreen === true);
+      }
+    };
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, []);
+
+  const setSidebarCollapsed = useCallback((collapsed: boolean) => {
+    setSidebarCollapsedState(collapsed);
+    try {
+      localStorage.setItem(SIDEBAR_COLLAPSED_KEY, collapsed ? "1" : "0");
+    } catch {
+      // localStorage unavailable (sandboxed webview): the collapse still works
+      // for this session, it just won't persist.
+    }
+  }, []);
+
+  const value = useMemo<DesktopChromeValue>(
+    () => ({ sidebarCollapsed, setSidebarCollapsed, fullScreen }),
+    [sidebarCollapsed, setSidebarCollapsed, fullScreen],
+  );
+
+  return (
+    <DesktopChromeContext.Provider value={value}>
+      {children}
+    </DesktopChromeContext.Provider>
+  );
+};
+
+/** 读取窗口级 chrome 状态（无 Provider 的 IDE/测试场景回退默认 false）。 */
+export const useDesktopChrome = (): DesktopChromeValue =>
+  useContext(DesktopChromeContext);

--- a/packages/webview/src/components/DesktopShell.tsx
+++ b/packages/webview/src/components/DesktopShell.tsx
@@ -47,19 +47,6 @@ interface DesktopShellProps {
   /** 账户卡片更新按钮 S0–S6（spec desktop-account-card-and-panel-tabs.md）. */
   onDownloadUpdate?: () => void;
   onRestartApp?: () => void;
-  /**
-   * Sidebar collapsed → the first pane of the top row shows an expand button.
-   * A ready-made ReactNode built by the delegating ChatApp (it owns the
-   * collapse state); undefined when the sidebar is expanded.
-   */
-  sidebarExpandButton?: React.ReactNode;
-  /** Sidebar fully hidden — threaded through to the shell's own DesktopSidebar. */
-  collapsed?: boolean;
-  onCollapsedChange: (collapsed: boolean) => void;
-  /** macOS 窗口全屏（desktopFullScreen push，root 经 shell 下行）：全屏下红绿
-   *  灯隐藏，shell 的侧边栏窗口行「收起侧边栏」按钮左移至行起点（spec
-   *  「macOS 隐藏标题栏」场景 7）。 */
-  fullScreen?: boolean;
   /** Batch 2 settings full-page: rendered over the pane rows when open. */
   settingsOpen?: boolean;
   onCloseSettings?: () => void;
@@ -111,10 +98,6 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
   account,
   onDownloadUpdate,
   onRestartApp,
-  sidebarExpandButton,
-  collapsed = false,
-  onCollapsedChange,
-  fullScreen = false,
   settingsOpen = false,
   settingsPage,
   sessionBoardOpen = false,
@@ -700,9 +683,6 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
         onSelectSession={host.onSelectSession}
         onOpenPane={handleOpenPane}
         onDeleteSession={host.onDeleteSession}
-        collapsed={collapsed}
-        onCollapsedChange={onCollapsedChange}
-        fullScreen={fullScreen}
         sessionBoardActive={sessionBoardActive}
         onOpenSessionBoard={onOpenSessionBoard}
       />
@@ -797,11 +777,7 @@ export const DesktopShell: React.FC<DesktopShellProps> = ({
                               vscode={vscode}
                               host={host}
                               paneId={pane.paneId}
-                              sidebarExpandButton={
-                                rowIdx === 0 && index === 0
-                                  ? sidebarExpandButton
-                                  : undefined
-                              }
+                              firstPane={rowIdx === 0 && index === 0}
                               onOpenSettingsFromPane={onOpenSettings}
                               prefillRequest={
                                 prefillRequest?.targetPaneId === pane.paneId

--- a/packages/webview/src/components/DesktopSidebar.tsx
+++ b/packages/webview/src/components/DesktopSidebar.tsx
@@ -13,6 +13,7 @@ import {
 import { useRovingMenu } from "../utils/useRovingMenu";
 import { useClickOutside } from "../utils/useClickOutside";
 import { isMacHiddenTitlebar } from "../utils/platform";
+import { useDesktopChrome } from "./DesktopChromeContext";
 import type { DesktopSessionGroup, DesktopSessionEntry } from "../types";
 import "../styles/DesktopApp.css";
 
@@ -139,12 +140,6 @@ export interface DesktopSidebarProps {
   onOpenPane: (workdir: string, sessionId: string) => void;
   /** Delete a session from the index (also cleans up worktree if applicable). */
   onDeleteSession: (sessionId: string) => void;
-  /** Sidebar fully hidden (chat takes the whole width); the header's expand
-   *  button restores it. */
-  collapsed?: boolean;
-  onCollapsedChange: (collapsed: boolean) => void;
-  /** macOS 窗口全屏（desktopFullScreen push）：全屏下红绿灯隐藏，窗口行收起让位。 */
-  fullScreen?: boolean;
   /** Batch 2 会话状态看板: brand-row 活动 button opens the board view. When
    *  active the icon renders brand-red (spec 场景 1 highlight state). */
   sessionBoardActive?: boolean;
@@ -190,12 +185,13 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
   onSelectSession,
   onOpenPane,
   onDeleteSession,
-  collapsed = false,
-  onCollapsedChange,
-  fullScreen = false,
   sessionBoardActive = false,
   onOpenSessionBoard,
 }) => {
+  // 窗口级 chrome 状态（收起/全屏）单一权威在 DesktopChromeContext —— 任何渲染
+  // 路径（root 单布局 / DesktopShell）的侧边栏都同源读取，不再 props 下行。
+  const { sidebarCollapsed, setSidebarCollapsed, fullScreen } =
+    useDesktopChrome();
   // Explicit expand/collapse overrides; groups without an entry are expanded
   // by default — the tree starts fully expanded on every app launch (expansion
   // state is not persisted).
@@ -488,7 +484,7 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
 
   // Fully collapsed: nothing renders, no reserved width, no overlay — the chat
   // takes the whole pane width (spec 「侧边栏收起/展开」scenario 1).
-  if (collapsed) return null;
+  if (sidebarCollapsed) return null;
 
   // 「收起侧边栏」按钮：有窗口行（macOS 真机 + 原型预览）时随红绿灯坐进窗口行；
   // Windows/Linux 真机仍放品牌行右侧图标组。真机窗口行整行为 drag 区，按钮需
@@ -498,7 +494,7 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
       <button
         type="button"
         className="desktop-sidebar-more-btn"
-        onClick={() => onCollapsedChange(true)}
+        onClick={() => setSidebarCollapsed(true)}
         data-testid="desktop-sidebar-collapse"
         aria-label="收起侧边栏"
       >

--- a/packages/webview/src/types/index.ts
+++ b/packages/webview/src/types/index.ts
@@ -206,11 +206,13 @@ export interface ChatAppProps {
    */
   paneId?: string;
   /**
-   * Desktop sidebar collapsed → the leftmost chat header (first pane of the
-   * top row in split view) shows an expand button. Built by the root ChatApp
-   * instance that owns the collapse state and threaded through DesktopShell.
+   * Desktop split-view: the first pane of the top row (window's left edge).
+   * When the window-level sidebar is collapsed it shows the expand button and
+   * (macOS hidden titlebar) reserves the traffic-light clearance — both read
+   * from DesktopChromeContext. Only that pane carries them, so DesktopShell
+   * marks it explicitly instead of threading ready-made ReactNodes.
    */
-  sidebarExpandButton?: React.ReactNode;
+  firstPane?: boolean;
   /**
    * Desktop split-view: extra actions rendered at the right edge of the chat
    * header's button row (pane close button). Kept out of the shared header's


### PR DESCRIPTION
## 背景

沿 PR #2074 两次 bugfix（分屏收起侧边栏与红绿灯重叠 / 全屏时收起按钮不贴行起点）追问的架构优化：历史「选中了历史对话才复现」类 bug 三个根因族之一 —— **窗口级 UI 状态存在于两条 webview 渲染路径、各自维护/stale 快照/props 下行丢失**。

- sidebarCollapsed 原本是 root ChatApp 私有 state：pane 实例只在挂载时拿到快照（收起按钮已由 shell 下发），运行期收起时 pane 的让位段判定过期 → 展开按钮压红绿灯。
- fullScreen 靠每个 ChatApp 实例自己 setState（desktopFullScreen push）+ ChatApp→DesktopShell→DesktopSidebar props 透传；DesktopShell 渲染路径曾收不到 → 全屏时收起按钮不贴行起点。

## 改动

- 新增 `DesktopChromeContext.tsx`：窗口级 chrome 状态单一权威。Provider 挂在 DesktopApp 窗口根，持有 sidebarCollapsed（localStorage 持久化，原 root 逻辑迁移）+ fullScreen（desktopFullScreen host push）。IDE 宿主（VSCE/JB）无 Provider，读默认值兜底、行为不变。
- ChatApp：删除本地 sidebarCollapsed/fullScreen state 与 handleSidebarCollapsedChange、desktopFullScreen message case，改经 `useDesktopChrome()` 同源读取。
- DesktopShell / DesktopSidebar：删除 collapsed/onCollapsedChange/fullScreen props 透传，内部直接消费 context。
- 首行首 pane 身份从 sidebarExpandButton（就绪 ReactNode）解耦为显式 `firstPane` prop；展开按钮与红绿灯让位段同源于 context + firstPane，运行期收起/展开即时同步。

## 验证

- webview 全套 974 测试通过（含 macTitlebar 13 个防回归矩阵，全绿）
- 全仓 `pnpm -r type-check` 通过
- prettier / oxlint（lint-staged pre-commit）通过