### PR TITLE
chore(ci): 文档 Pages 部署改为手动触发

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,14 +1,9 @@
 name: Deploy VitePress to GitHub Pages
 
+# Manual-only deploy: docs push no longer auto-triggers a GitHub Pages build
+# (docs:build installs Playwright and regenerates all screenshots every run,
+# which is wasteful). Trigger manually via "Run workflow" in the Actions tab.
 on:
-  push:
-    branches: [main]
-    paths:
-      - "docs/**"
-      - "packages/webview/demo/**"
-      - "packages/webview/e2e/**"
-      - "packages/vscode/LOGO.png"
-      - ".github/workflows/pages.yml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 变更

移除 `.github/workflows/pages.yml` 的 `on.push` 触发（branches: [main] + paths 过滤），只保留 `workflow_dispatch` 手动触发，并在文件顶部注释说明。

## 背景

docs 推送不再自动跑 GitHub Pages 构建部署——每次 `docs:build` 需安装 Playwright 并重生成全部截图，成本浪费。需要时在 Actions 页手动点 Run workflow。

## 验证

`git diff` 仅改动 pages.yml 一个文件；type-check 与 lint-staged 通过。