### PR TITLE
fix(desktop): 切换对话立即补发本会话上下文用量（live 重激活与恢复重放均覆盖）

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -199,6 +199,16 @@ export class DesktopHost {
   private agents = new Map<string, StdioAgent>();
   /** Side table: agent → host (local or an ssh config host name). */
   private agentHosts = new Map<StdioAgent, string>();
+  /**
+   * Last context-usage percent each agent reported, cached regardless of pane
+   * binding. The restore/attach-time replay typically arrives while the agent
+   * is still mid-restore (no pane yet, see runPaneRestore) or never fires for a
+   * pool-resident agent re-activated in place, so activateAgentInPane replays
+   * this once the pane binds — the usage ring shows the session's real usage
+   * right after a conversation switch instead of staying empty until the next
+   * turn (spec「上下文用量指示器」场景 6). Weak keys: entries die with the agent.
+   */
+  private contextUsageByAgent = new WeakMap<StdioAgent, number>();
   /** Pending host selected in each pane's new-session workdir picker. */
   private hostState = new Map<string, string>();
   // Split panes, ordered left→right. Each pane binds at most one agent (none
@@ -1201,6 +1211,13 @@ export class DesktopHost {
         this.refreshSessionTree();
       },
       onContextUsage: (percent: number) => {
+        // Cache before the pane check: the replay that follows a session
+        // restore typically lands while the agent is still mid-restore — not
+        // yet bound to any pane (runPaneRestore restores, then activates) — so
+        // forwarding alone would drop it. activateAgentInPane replays the cache
+        // once the pane binds (spec「上下文用量指示器」场景 6: the ring shows the
+        // session's usage right after the switch, no need to wait for a turn).
+        this.contextUsageByAgent.set(agentRef, percent);
         const paneId = paneIdOf();
         if (paneId)
           this.postMessage({ command: "contextUsage", paneId, percent });
@@ -1372,6 +1389,19 @@ export class DesktopHost {
     this.refreshSessionTree();
     this.pushPanes();
     await this.pushPaneSessionState(paneId);
+    // Replay the session's last known usage now that this pane shows the agent.
+    // Without it the webview — which clears the ring on every conversation
+    // switch to stay isolated (ChatApp usage-session effect) — stays empty
+    // until the next turn reports fresh tokens. The cache covers both switch
+    // paths: a pool-resident agent re-activated in place (no CLI round trip
+    // fires a usage push at all) and a mid-restore replay that arrived before
+    // the pane bound (spec「上下文用量指示器」场景 6). Must follow
+    // pushPaneSessionState so the setInitialState lands first and the push is
+    // attributed to the incoming session.
+    const usage = this.contextUsageByAgent.get(agent);
+    if (usage !== undefined) {
+      this.postMessage({ command: "contextUsage", paneId, percent: usage });
+    }
     this.postMessage({ command: "scrollToBottom", paneId });
     this.postMessage({ command: "focusInput", paneId });
   }

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -4609,6 +4609,102 @@ describe("theme", () => {
 // multi-session parallel (FR-031)
 // ---------------------------------------------------------------------------
 
+describe("context usage across conversation switches", () => {
+  const entry = (sessionId: string, createdAt: number) => ({
+    sessionId,
+    title: `Session ${sessionId}`,
+    host: "local",
+    workdir: "/work/a",
+    cwd: "/work/a",
+    createdAt,
+    lastActiveAt: createdAt,
+  });
+
+  /** desktopReady + webviewReady with a ready-to-select index of /work/a. */
+  async function hostWithTree(
+    ...sessions: Array<{ sessionId: string; createdAt: number }>
+  ) {
+    const ctx = createHost();
+    ctx.store.addRecentWorkdir({ host: "local", path: "/work/a" });
+    h.existingPaths.add("/work/a");
+    for (const s of sessions)
+      ctx.store.upsertSession(entry(s.sessionId, s.createdAt));
+    await ctx.host.handleWebviewMessage({ command: "desktopReady" });
+    await ctx.host.handleWebviewMessage({ command: "webviewReady" });
+    return ctx;
+  }
+
+  it("keeps the usage of a restored session whose replay landed mid-restore (no pane bound yet)", async () => {
+    const ctx = await hostWithTree({ sessionId: "sess-x", createdAt: 3000 });
+    // Hold the restore mid-initialize: the spawned agent exists but is not yet
+    // bound to any pane — exactly when the CLI's usage replay lands
+    // (runPaneRestore restores the session, then activates it in the pane).
+    let release: () => void;
+    h.initializeGate = new Promise<void>((resolve) => (release = resolve));
+
+    await ctx.host.handleWebviewMessage({
+      command: "desktopSelectSession",
+      workdir: "/work/a",
+      sessionId: "sess-x",
+    });
+    await vi.waitFor(() => {
+      expect(h.agentInstances.length).toBeGreaterThan(0);
+    });
+    const restoring = lastAgent();
+    restoring.callbacks.onContextUsage(37); // replay while the pane is still empty
+
+    expect(ctx.sent("contextUsage")).toHaveLength(0); // nothing to show yet
+
+    // The pane-less replay must not be dropped: once the restore finishes and
+    // binds the pane, the ring shows 37% without waiting for a new turn.
+    release!();
+    await vi.waitFor(() => {
+      expect(ctx.sent("contextUsage").at(-1)).toEqual(
+        expect.objectContaining({ percent: 37, paneId: "pane-1" }),
+      );
+    });
+  });
+
+  it("re-activating a pool-resident session replays its last known usage", async () => {
+    const ctx = await hostWithTree(
+      { sessionId: "s3", createdAt: 3000 },
+      { sessionId: "s1", createdAt: 1000 },
+    );
+
+    // Activate s3 (spawn + restore), then report live usage from its pane.
+    await ctx.host.activateAdjacentSession(1);
+    await vi.waitFor(() => {
+      const last = ctx.sent("setInitialState").at(-1);
+      expect(last?.isRestoring).toBe(false);
+      expect(last?.session).toMatchObject({ id: "s3" });
+    });
+    const agent3 = lastAgent();
+    agent3.callbacks.onContextUsage(45);
+    expect(ctx.sent("contextUsage").at(-1)).toEqual(
+      expect.objectContaining({ percent: 45 }),
+    );
+
+    // Switch to s1 (a second agent), leaving s3 live in the pool.
+    await ctx.host.activateAdjacentSession(1);
+    await vi.waitFor(() => {
+      const last = ctx.sent("setInitialState").at(-1);
+      expect(last?.isRestoring).toBe(false);
+      expect(last?.session).toMatchObject({ id: "s1" });
+    });
+
+    // Switching back to s3 activates the live agent in place — no CLI round
+    // trip fires a usage push, so the host must replay the cached percent.
+    const before = ctx.sent("contextUsage").length;
+    await ctx.host.activateAdjacentSession(1);
+    await vi.waitFor(() => {
+      expect(ctx.sent("contextUsage").length).toBeGreaterThan(before);
+    });
+    expect(ctx.sent("contextUsage").at(-1)).toEqual(
+      expect.objectContaining({ percent: 45 }),
+    );
+  });
+});
+
 describe("multi-session parallel (FR-031)", () => {
   /** Give the active agent content + register its session in the index. */
   const seedActiveSession = (sessionId: string) => {


### PR DESCRIPTION
桌面端两条切会话路径都不下发 contextUsage：池中 live 会话重激活
（activateAgentInPane）只做本地 rebind + 快照，无 usage 重放；恢复历史
会话时 CLI 的重放（restoreSession re-attach）到达于 pane 绑定之前，
paneIdOf 为空被丢弃。webview 切换会话时按隔离逻辑清空百分比，于是环
一直空到新一轮 token 变化（spec desktop 上下文用量指示器场景 6：切换
历史会话恢复完成即显示上次用量，无需等待新一轮）。

修复：desktopHost 用 WeakMap 缓存每个 agent 最近一次 contextUsage
（onContextUsage 先缓存再按 pane 转发，未绑定不丢），activateAgentInPane
在 pushPaneSessionState（setInitialState）之后重放缓存值，保证消息归属
新会话、环立即显示。新测试 2 例（mid-restore 重放不丢 / live 会话切换
立即重放），均验证 fail-without-fix。
