### PR TITLE
fix(vscode): /mcp 等斜杠命令打开设置页时透传 nav 选中对应选项卡

### DIFF
--- a/packages/vscode/src/chatProvider.ts
+++ b/packages/vscode/src/chatProvider.ts
@@ -22,7 +22,10 @@ import { SessionService } from "./services/sessionService";
 import { SelectionService } from "./services/selectionService";
 import { PluginService } from "./services/pluginService";
 import { WebviewManager } from "./session/webviewManager";
-import { MessageHandler } from "./session/messageHandler";
+import {
+  MessageHandler,
+  type MessageHandlerContext,
+} from "./session/messageHandler";
 import { StdioClient } from "./stdio/stdioClient";
 import { NotificationRouter } from "./stdio/notificationRouter";
 import { ensureCliUpToDate, setExtensionPath } from "./stdio/binaryResolver";
@@ -218,52 +221,7 @@ export class ChatProvider implements vscode.WebviewViewProvider {
         this.sessionService,
         this.pluginService,
         this.sharedClient,
-        {
-          getChatSession: (viewType, windowId) =>
-            this.getChatSession(viewType, windowId),
-          postMessage: (message, viewType, windowId) =>
-            this.webviewManager.postMessage(message, viewType, windowId),
-          initializeAgent: (viewType, windowId, restoreSessionId) =>
-            this.initializeAgent(viewType, windowId, restoreSessionId),
-          listSessions: (viewType, windowId) =>
-            this.listSessions(viewType, windowId),
-          updateAllSessionsConfig: async (config) => {
-            const cfg = config as ConfigurationData;
-            // Serial: updateConfig destroys + recreates the agent in the bridge;
-            // concurrent calls on the same sessionId would delete each other's
-            // entry and leave it permanently missing ("Session not found" on
-            // every later request). Await + catch so failures are logged here
-            // instead of becoming unhandled rejections.
-            const sessions = [
-              this.sidebarSession,
-              ...this.tabSessions.values(),
-              ...this.windowSessions.values(),
-            ];
-            let failed = false;
-            for (const session of sessions) {
-              try {
-                await session.updateConfig(cfg);
-              } catch (error) {
-                failed = true;
-                console.error(
-                  `[Wave] ${session.viewType} 更新配置失败:`,
-                  error,
-                );
-              }
-            }
-            if (failed) {
-              vscode.window.showErrorMessage(
-                "部分会话配置更新失败，请重载窗口后重试。",
-              );
-            }
-          },
-          getVersion: () => this.context.extension.packageJSON?.version || "",
-          openPlanPreview: (key, content) => this.openPlanPreview(key, content),
-          openSettings: () => this.openSettings(),
-          postSettingsMessage: (message) =>
-            this.webviewManager.postSettingsMessage(message),
-          closeSettings: () => this.webviewManager.disposeSettingsPanel(),
-        },
+        this.createMessageHandlerContext(),
       );
     } catch (err) {
       console.error("[Wave] Failed to initialize shared client:", err);
@@ -277,6 +235,58 @@ export class ChatProvider implements vscode.WebviewViewProvider {
           : "无法启动 wave CLI。请检查网络连接后重试。",
       );
     }
+  }
+
+  /**
+   * Builds the MessageHandler context (see init). Extracted as an instance
+   * method so the chat webview → openSettings(nav) forwarding can be covered by
+   * a unit test without instantiating a full ChatProvider (whose constructor
+   * spawns the CLI).
+   */
+  private createMessageHandlerContext(): MessageHandlerContext {
+    return {
+      getChatSession: (viewType, windowId) =>
+        this.getChatSession(viewType, windowId),
+      postMessage: (message, viewType, windowId) =>
+        this.webviewManager.postMessage(message, viewType, windowId),
+      initializeAgent: (viewType, windowId, restoreSessionId) =>
+        this.initializeAgent(viewType, windowId, restoreSessionId),
+      listSessions: (viewType, windowId) =>
+        this.listSessions(viewType, windowId),
+      updateAllSessionsConfig: async (config) => {
+        const cfg = config as ConfigurationData;
+        // Serial: updateConfig destroys + recreates the agent in the bridge;
+        // concurrent calls on the same sessionId would delete each other's
+        // entry and leave it permanently missing ("Session not found" on
+        // every later request). Await + catch so failures are logged here
+        // instead of becoming unhandled rejections.
+        const sessions = [
+          this.sidebarSession,
+          ...this.tabSessions.values(),
+          ...this.windowSessions.values(),
+        ];
+        let failed = false;
+        for (const session of sessions) {
+          try {
+            await session.updateConfig(cfg);
+          } catch (error) {
+            failed = true;
+            console.error(`[Wave] ${session.viewType} 更新配置失败:`, error);
+          }
+        }
+        if (failed) {
+          vscode.window.showErrorMessage(
+            "部分会话配置更新失败，请重载窗口后重试。",
+          );
+        }
+      },
+      getVersion: () => this.context.extension.packageJSON?.version || "",
+      openPlanPreview: (key, content) => this.openPlanPreview(key, content),
+      openSettings: (nav) => this.openSettings(nav),
+      postSettingsMessage: (message) =>
+        this.webviewManager.postSettingsMessage(message),
+      closeSettings: () => this.webviewManager.disposeSettingsPanel(),
+    };
   }
 
   public async addToWave() {

--- a/packages/vscode/tests/session/chatProviderContext.test.ts
+++ b/packages/vscode/tests/session/chatProviderContext.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+// ChatProvider's module graph imports the real "vscode" module; stub the API
+// surface reachable at import time / via the context methods under test.
+vi.mock("vscode", () => ({
+  window: {
+    showErrorMessage: vi.fn(),
+    showInformationMessage: vi.fn(),
+  },
+  commands: { executeCommand: vi.fn() },
+}));
+
+import { ChatProvider } from "../../src/chatProvider";
+import type { MessageHandlerContext } from "../../src/session/messageHandler";
+
+type BareProvider = {
+  createMessageHandlerContext: () => MessageHandlerContext;
+  openSettings: ReturnType<typeof vi.fn>;
+};
+
+function makeBareProvider(): BareProvider {
+  // Skip the real constructor (it spawns the CLI / downloads binaries). A
+  // prototype-only instance is enough to exercise createMessageHandlerContext,
+  // whose closures forward to `this` members we stub.
+  const provider = Object.create(
+    ChatProvider.prototype,
+  ) as unknown as BareProvider;
+  provider.openSettings = vi.fn();
+  return provider;
+}
+
+describe("ChatProvider message-handler context", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("openSettings forwards the nav payload to ChatProvider.openSettings", () => {
+    const provider = makeBareProvider();
+    const context = provider.createMessageHandlerContext();
+
+    context.openSettings("mcp");
+
+    expect(provider.openSettings).toHaveBeenCalledWith("mcp");
+  });
+
+  test("openSettings without nav calls ChatProvider.openSettings with undefined", () => {
+    const provider = makeBareProvider();
+    const context = provider.createMessageHandlerContext();
+
+    context.openSettings();
+
+    expect(provider.openSettings).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/packages/vscode/tests/session/messageHandler.test.ts
+++ b/packages/vscode/tests/session/messageHandler.test.ts
@@ -688,6 +688,18 @@ describe("MessageHandler settings tab", () => {
     expect(context.openSettings).toHaveBeenCalled();
   });
 
+  test("openSettings forwards the nav payload so /mcp etc. preselect their settings tab", async () => {
+    const session = createReadySession();
+    const { handler, context } = createReadyHandler(session);
+
+    await handler.handleMessage(
+      { command: "openSettings", nav: "mcp" },
+      "sidebar",
+    );
+
+    expect(context.openSettings).toHaveBeenCalledWith("mcp");
+  });
+
   test("getConfiguration posts configurationResponse to the settings panel, not the chat webviews", async () => {
     const session = createReadySession();
     const { handler, context } = createReadyHandler(session);


### PR DESCRIPTION
## 问题

VSC 中执行 `/mcp`、`/agents`、`/skills`、`/hooks`，设置页能打开但永远停在「全局设置」，不自动切换到对应选项卡（如 MCP 服务）。

## 根因

`ChatProvider` 传给 `MessageHandler` 的 context 写成 `openSettings: () => this.openSettings()`（chatProvider.ts），**丢弃了 webview 消息携带的 nav 参数**。JB 端 MessageHandler.kt 正确透传了 `msg["nav"]`，VSC 端却丢失——settingsState 下发时 nav 恒为 undefined。

先前 ac695f87 修复的是下游「新面板创建瞬间 settingsState 被 VS Code 丢弃」的时序问题（settingsReady 后重发缓存），但源头 context 丢参从未被发现——两条独立缺陷叠在同一链路，只修下游无法生效。

## 改动

- **chatProvider.ts**：context 构造从 `init()` 提取为 `createMessageHandlerContext()` 实例方法（行为不变重构），使其可脱离完整 ChatProvider 实例（构造函数会下载 CLI/spawn 子进程）单独测试；openSettings 改为 `(nav) => this.openSettings(nav)` 透传 nav
- **chatProviderContext.test.ts（新增）**：裸原型实例（Object.create）注入 openSettings stub，验证 `context.openSettings("mcp")` 转发 nav——bug 版写法（`() => this.openSettings()`）会使测试变红（红绿验证过）
- **messageHandler.test.ts**：补 openSettings 消息 nav 转发断言

## 验证

- vscode 单测 184 全过（12 文件）
- type-check、lint 全绿
- 真机 vsce:run 验证：`/mcp` 自动切到「MCP 服务」选项卡