### PR TITLE
fix(vscode): 项目设置内置插件 SDD 开关插件端可切换

### DIFF
--- a/packages/vscode/src/session/messageHandler.ts
+++ b/packages/vscode/src/session/messageHandler.ts
@@ -498,6 +498,21 @@ export class MessageHandler {
           msg.workdir as string | undefined,
         );
         break;
+      case "getProjectSettings":
+        // 项目设置视图（内置插件 SDD 开关）：读取项目 .wave/settings.json 合并
+        // 后的 enabledPlugins。chat 路由 handleMessage 也有同名命令，但设置页在
+        // 独立 settings tab（settings-preview-entry）里渲染，必须走本路由并把
+        // 回包发给设置面板本身（postSettingsMessage）——漏掉时 webview 的
+        // projectSettings 恒为 undefined，SDD 开关被 !projectSettings 永久禁用。
+        await this.handleSettingsGetProjectSettings();
+        break;
+      case "setBuiltinPluginEnabled":
+        await this.handleSettingsSetBuiltinPluginEnabled(
+          msg.pluginId as string,
+          msg.enabled as boolean,
+          msg.scope as string,
+        );
+        break;
       case "getHooksConfig":
         await this.handleSettingsGetHooksConfig(
           msg.scope as "user" | "project" | undefined,
@@ -720,6 +735,49 @@ export class MessageHandler {
    *   sidebar 会话的 CLI agent 读取（getSubagentConfigurations 等同源）。 */
   private getSettingsSession(): ChatSession {
     return this.context.getChatSession("sidebar");
+  }
+
+  /** 项目设置视图（内置插件 SDD 开关）：读取项目 .wave/settings.json 合并后的
+   *  enabledPlugins，回包发给设置面板（pluginService 以工作区根目录为 workdir）。 */
+  private async handleSettingsGetProjectSettings(): Promise<void> {
+    try {
+      const result = await this.pluginService.getProjectSettings();
+      this.context.postSettingsMessage({
+        command: "projectSettings",
+        enabledPlugins: result.enabledPlugins,
+      });
+    } catch (error) {
+      console.error("获取项目设置失败:", error);
+      vscode.window.showErrorMessage("获取项目设置失败: " + error);
+    }
+  }
+
+  /** 切换项目级内置插件（sdd@builtin 等）：写回 .wave/settings.json 后回发
+   *  projectSettings 刷新开关，并重载配置重建 agent 使插件立即生效
+   *  （与 chat 路由 handleSetBuiltinPluginEnabled 同语义）。 */
+  private async handleSettingsSetBuiltinPluginEnabled(
+    pluginId: string,
+    enabled: boolean,
+    scope: string,
+  ): Promise<void> {
+    try {
+      const result = await this.pluginService.setBuiltinPluginEnabled(
+        pluginId,
+        enabled,
+        scope as Scope,
+      );
+      this.context.postSettingsMessage({
+        command: "projectSettings",
+        enabledPlugins: result.enabledPlugins,
+      });
+
+      // Reload config and recreate agents to apply plugin changes
+      const config = await this.configService.loadConfiguration();
+      this.context.updateAllSessionsConfig(config);
+    } catch (error) {
+      console.error("修改项目设置失败:", error);
+      vscode.window.showErrorMessage("修改项目设置失败: " + error);
+    }
   }
 
   private async handleSettingsGetSubagentConfigurations(): Promise<void> {

--- a/packages/vscode/tests/session/messageHandler.test.ts
+++ b/packages/vscode/tests/session/messageHandler.test.ts
@@ -801,6 +801,115 @@ describe("MessageHandler settings tab", () => {
     expect(posted.error).toContain("boom");
   });
 
+  // Regression (VS Code 插件端 SDD 开关永久置灰): 设置页在独立 settings tab
+  // (settings-preview-entry) 里渲染，消息走 handleSettingsMessage —— 该路由若
+  // 不实现 getProjectSettings，webview 的 projectSettings 恒为 undefined，
+  // SettingsPage 的开关被 `disabled={... || !projectSettings}` 禁用且永不加载。
+  test("getProjectSettings posts projectSettings to the settings panel", async () => {
+    const configService = {
+      loadConfiguration: vi.fn(),
+      saveConfiguration: vi.fn(),
+    };
+    const pluginService = {
+      getProjectSettings: vi
+        .fn()
+        .mockResolvedValue({ enabledPlugins: { "sdd@builtin": true } }),
+    };
+    const context: MessageHandlerContext = {
+      getChatSession: vi.fn().mockReturnValue(createMockSession()),
+      postMessage: vi.fn(),
+      initializeAgent: vi.fn(),
+      listSessions: vi.fn(),
+      updateAllSessionsConfig: vi.fn(),
+      getVersion: vi.fn().mockReturnValue("1.2.3"),
+      openPlanPreview: vi.fn(),
+      openSettings: vi.fn(),
+      postSettingsMessage: vi.fn(),
+      closeSettings: vi.fn(),
+    };
+    const handler = new MessageHandler(
+      configService as unknown as ConfigurationService,
+      {} as unknown as FileService,
+      {} as unknown as SessionService,
+      pluginService as unknown as PluginService,
+      {} as unknown as StdioClient,
+      context,
+    );
+
+    await handler.handleSettingsMessage({ command: "getProjectSettings" });
+
+    expect(pluginService.getProjectSettings).toHaveBeenCalled();
+    const posted = (context.postSettingsMessage as ReturnType<typeof vi.fn>)
+      .mock.calls[0][0] as {
+      command: string;
+      enabledPlugins: Record<string, boolean>;
+    };
+    expect(posted.command).toBe("projectSettings");
+    expect(posted.enabledPlugins).toEqual({ "sdd@builtin": true });
+    // Response goes to the settings panel, never the chat webviews
+    expect(context.postMessage).not.toHaveBeenCalled();
+  });
+
+  test("setBuiltinPluginEnabled from the settings panel reloads config, recreates agents and replies to the settings panel", async () => {
+    const configService = {
+      loadConfiguration: vi
+        .fn()
+        .mockResolvedValue({ serverUrl: "", language: "Chinese" }),
+      saveConfiguration: vi.fn(),
+    };
+    const pluginService = {
+      setBuiltinPluginEnabled: vi
+        .fn()
+        .mockResolvedValue({ enabledPlugins: { "sdd@builtin": true } }),
+    };
+    const context: MessageHandlerContext = {
+      getChatSession: vi.fn().mockReturnValue(createMockSession()),
+      postMessage: vi.fn(),
+      initializeAgent: vi.fn(),
+      listSessions: vi.fn(),
+      updateAllSessionsConfig: vi.fn(),
+      getVersion: vi.fn().mockReturnValue("1.2.3"),
+      openPlanPreview: vi.fn(),
+      openSettings: vi.fn(),
+      postSettingsMessage: vi.fn(),
+      closeSettings: vi.fn(),
+    };
+    const handler = new MessageHandler(
+      configService as unknown as ConfigurationService,
+      {} as unknown as FileService,
+      {} as unknown as SessionService,
+      pluginService as unknown as PluginService,
+      {} as unknown as StdioClient,
+      context,
+    );
+
+    await handler.handleSettingsMessage({
+      command: "setBuiltinPluginEnabled",
+      pluginId: "sdd@builtin",
+      enabled: true,
+      scope: "project",
+    });
+
+    expect(pluginService.setBuiltinPluginEnabled).toHaveBeenCalledWith(
+      "sdd@builtin",
+      true,
+      "project",
+    );
+    expect(configService.loadConfiguration).toHaveBeenCalled();
+    expect(context.updateAllSessionsConfig).toHaveBeenCalledWith({
+      serverUrl: "",
+      language: "Chinese",
+    });
+    const posted = (context.postSettingsMessage as ReturnType<typeof vi.fn>)
+      .mock.calls[0][0] as {
+      command: string;
+      enabledPlugins: Record<string, boolean>;
+    };
+    expect(posted.command).toBe("projectSettings");
+    expect(posted.enabledPlugins).toEqual({ "sdd@builtin": true });
+    expect(context.postMessage).not.toHaveBeenCalled();
+  });
+
   test("closeSettings closes the settings panel", async () => {
     const session = createReadySession();
     const { handler, context } = createReadyHandler(session);

--- a/packages/webview/e2e/settings-project-toggle.e2e.ts
+++ b/packages/webview/e2e/settings-project-toggle.e2e.ts
@@ -1,0 +1,135 @@
+import type { Page } from "@playwright/test";
+import { test, expect } from "./utils/webviewTestHarness.js";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Regression (VS Code 插件端「项目设置 → 内置插件」SDD 开关永久置灰):
+ *
+ * 设置页由独立 settings tab（settings-preview-entry，settings.js bundle）渲染。
+ * 若入口不传 onLoadProjectSettings / 不监听 host 的 projectSettings 回包，
+ * SettingsPage 的 projectSettings 恒为 undefined → 开关被
+ * `disabled={pluginToggling || !projectSettings}` 禁用且永不加载。
+ *
+ * 本用例驱动真实 settings.js bundle：进入「项目设置」视图应发出 getProjectSettings；
+ * host 回 projectSettings 后开关应可点，点击应发出 setBuiltinPluginEnabled(project)。
+ * 修复前：不发 getProjectSettings、开关保持禁用、点击无消息 —— 三段断言全部失败。
+ */
+
+// SettingsPage 的颜色全部走 --vscode-* 变量，独立 settings.html 没有宿主注入，
+// 必须手动带上深色主题变量集，否则页面为白底浅色（与 settings-manage.demo.ts 同法）。
+const themeStyles = fs.readFileSync(
+  path.join(process.cwd(), "theme", "theme-base-dark.css"),
+  "utf8",
+);
+
+const mockVscodeApiJs = `
+    window.process = { env: { NODE_ENV: 'production' } };
+    window.acquireVsCodeApi = () => ({
+        postMessage: (message) => {
+            if (!window.testMessages) window.testMessages = [];
+            window.testMessages.push(message);
+        },
+        setState: () => {},
+        getState: () => ({})
+    });
+    window.simulateExtensionMessage = (message) => {
+        window.dispatchEvent(new MessageEvent('message', { data: message }));
+    };
+`;
+
+const settingsHtml = `
+<!DOCTYPE html>
+<html lang="zh-CN" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wave Settings</title>
+    <style>${themeStyles}</style>
+    <link rel="stylesheet" href="vscode-webview://mock-extension-id/settings.css">
+</head>
+<body>
+    <div id="root"></div>
+    <script>${mockVscodeApiJs}</script>
+    <script src="vscode-webview://mock-extension-id/settings.js"></script>
+</body>
+</html>`;
+
+async function openSettings(webviewPage: Page) {
+  await webviewPage.setViewportSize({ width: 1000, height: 760 });
+  await webviewPage.setContent(settingsHtml);
+  await expect(webviewPage.locator(".settings-page")).toBeVisible();
+  // 初始化配置（settings entry 挂载时会请求 getConfiguration）
+  await webviewPage.evaluate(() => {
+    window.simulateExtensionMessage({
+      command: "configurationResponse",
+      configurationData: { language: "zh-CN", contextLength: 200 },
+    });
+  });
+}
+
+function sentToHost(webviewPage: Page) {
+  return webviewPage.evaluate(() => (window.testMessages ?? []) as unknown[]);
+}
+
+test.describe("设置页项目设置内置插件开关（settings tab）", () => {
+  test("进入项目设置视图请求并回填 enabledPlugins，SDD 开关可切换", async ({
+    webviewPage,
+  }) => {
+    await openSettings(webviewPage);
+
+    // 进入「项目设置」视图（工作区组第一个导航项）
+    await webviewPage
+      .locator(".settings-nav-item", { hasText: "项目设置" })
+      .click();
+    // 自定义开关：input 视觉隐藏（opacity/尺寸为 0），真实可点区域是外层 label
+    // .settings-switch；状态断言直接打在 input 的 disabled/checked 属性上。
+    const sddSwitch = webviewPage.locator(
+      '.settings-switch input[aria-label="启用 SDD 插件"]',
+    );
+    await expect(sddSwitch).toHaveCount(1);
+
+    // 开关未拿到项目设置前保持禁用
+    await expect(sddSwitch).toBeDisabled();
+
+    // 视图进入时应向 host 请求项目级 enabledPlugins（修复前永不发出）
+    await expect
+      .poll(async () => {
+        const messages = (await sentToHost(webviewPage)) as Array<{
+          command?: string;
+        }>;
+        return messages.some((m) => m.command === "getProjectSettings");
+      })
+      .toBe(true);
+
+    // host 回发 projectSettings（.wave/settings.json 合并后，sdd@builtin 未启用）
+    await webviewPage.evaluate(() => {
+      window.simulateExtensionMessage({
+        command: "projectSettings",
+        enabledPlugins: {},
+      });
+    });
+    await expect(sddSwitch).toBeEnabled();
+
+    // 点击开关 → 发出 setBuiltinPluginEnabled（project scope）
+    await webviewPage
+      .locator('.settings-switch:has(input[aria-label="启用 SDD 插件"])')
+      .click();
+    await expect
+      .poll(async () => {
+        const messages = (await sentToHost(webviewPage)) as Array<{
+          command?: string;
+          pluginId?: string;
+          enabled?: boolean;
+          scope?: string;
+        }>;
+        return messages.find((m) => m.command === "setBuiltinPluginEnabled");
+      })
+      .toEqual({
+        command: "setBuiltinPluginEnabled",
+        pluginId: "sdd@builtin",
+        enabled: true,
+        scope: "project",
+      });
+  });
+});

--- a/packages/webview/src/settings-preview-entry.tsx
+++ b/packages/webview/src/settings-preview-entry.tsx
@@ -9,10 +9,11 @@
  *
  * Protocol (same command names the chat webview already uses):
  * - webview → host: `settingsReady`, `getConfiguration`, `getAgentsContent`,
- *   `setAgentsContent`, `closeSettings`, `prefillPrompt`（编辑操作随附
- *   `openFile`，host 在自身编辑器打开对应配置文件）
+ *   `setAgentsContent`, `getProjectSettings`, `setBuiltinPluginEnabled`,
+ *   `closeSettings`, `prefillPrompt`（编辑操作随附 `openFile`，host 在自身
+ *   编辑器打开对应配置文件）
  * - host → webview: `configurationResponse`, `agentsContentResponse`,
- *   `agentsContentSaved`, `settingsState` (workdir push on open)
+ *   `agentsContentSaved`, `projectSettings`, `settingsState` (workdir push on open)
  */
 import React, { useEffect, useState } from "react";
 import ReactDOM from "react-dom/client";
@@ -50,6 +51,11 @@ function SettingsPreview() {
   } | null>(null);
   // /agents、/skills 斜杠命令经 openSettings(nav) → settingsState 下发，选中对应选项卡
   const [initialNav, setInitialNav] = useState<NavKey | undefined>(undefined);
+  // 项目级 enabledPlugins（「项目设置」视图 SDD 开关）；进入该视图时才向 host
+  // 请求（onLoadProjectSettings），host 回发 projectSettings 消息后回填。
+  const [projectSettings, setProjectSettings] = useState<
+    { enabledPlugins: Record<string, boolean> } | undefined
+  >(undefined);
 
   useEffect(() => {
     // Report readiness before pulling data: the host re-serves the cached
@@ -103,6 +109,13 @@ function SettingsPreview() {
             error: typeof msg.error === "string" ? msg.error : undefined,
           });
           break;
+        case "projectSettings":
+          if (msg.enabledPlugins && typeof msg.enabledPlugins === "object") {
+            setProjectSettings({
+              enabledPlugins: msg.enabledPlugins as Record<string, boolean>,
+            });
+          }
+          break;
       }
     };
     window.addEventListener("message", handleMessage);
@@ -147,6 +160,18 @@ function SettingsPreview() {
       configurationError={configurationError}
       initialNav={initialNav}
       vscode={vscode}
+      projectSettings={projectSettings}
+      onLoadProjectSettings={() =>
+        vscode.postMessage({ command: "getProjectSettings" })
+      }
+      onToggleBuiltinPlugin={(pluginId, enabled) =>
+        vscode.postMessage({
+          command: "setBuiltinPluginEnabled",
+          pluginId,
+          enabled,
+          scope: "project",
+        })
+      }
       onPrefillPrompt={(prompt, openFile) => {
         vscode.postMessage({ command: "prefillPrompt", prompt });
         // 编辑操作：配置文件交给 IDE 自身打开（聊天输入框 prefill 之外，host 在


### PR DESCRIPTION
## 背景
VS Code 插件端 设置 → 项目设置 → 内置插件 的 SDD 开关置灰不可点（桌面端同页正常）。截图确认 + 链路核实。

## 根因（双缺口，均只影响 IDE 设置 tab）
设置页在**独立 settings tab**（`settings-preview-entry.tsx` → `settings.js` bundle，VSCE/JetBrains 共用）渲染 `SettingsPage`，不是 chat webview：

1. **webview 入口未接线**：`settings-preview-entry.tsx` 没传 `projectSettings` / `onLoadProjectSettings` / `onToggleBuiltinPlugin`，也不监听 host 回发的 `projectSettings` → `SettingsPage.tsx:419` 的 `disabled={pluginToggling || !projectSettings}` 恒为 true，且 `:217` 的加载 effect 因回调缺失永不触发。
2. **VSCE host 设置路由缺命令**：设置 tab 消息走 `handleSettingsMessage`，其 switch 无 `getProjectSettings` / `setBuiltinPluginEnabled`（同名命令只在 chat 路由 `handleMessage`，而 chat webview 从不渲染整页 SettingsPage → 死路径）。即使入口接线也会无人响应。

对照：desktop 由 ChatApp+desktopHost 全链实现（正常）；JetBrains host `MessageHandler` 单路由已实现两命令，只缺共享 webview 接线（本修复后一并受益）。

## 修复
- `packages/webview/src/settings-preview-entry.tsx`：补 `projectSettings` state + 监听 `projectSettings` 回包 + 接上 `onLoadProjectSettings`（发 `getProjectSettings`）与 `onToggleBuiltinPlugin`（发 `setBuiltinPluginEnabled` scope=project）。
- `packages/vscode/src/session/messageHandler.ts`：`handleSettingsMessage` 增加两命令路由 + 两个 settings 版处理方法，回包走 `postSettingsMessage`（发回设置面板本身，非 chat webview）；toggle 后 `loadConfiguration` + `updateAllSessionsConfig` 重建 agent，插件立即生效（与 chat 路由同语义）。

## 测试
- vscode `messageHandler.test.ts` +2（getProjectSettings / setBuiltinPluginEnabled 经设置路由 → 回包发设置面板，不走 chat postMessage）。
- 新增 e2e `settings-project-toggle.e2e.ts`（真实 settings.js bundle：进项目设置视图发 getProjectSettings → host 回 projectSettings → 开关启用 → 点击发 setBuiltinPluginEnabled）。**fail-without-fix 已验证**（revert 入口修复后测试失败：不发请求、开关保持禁用）。

验证：vscode 183 单测 / webview 977 单测 / e2e 新用例通过；vscode+webview type-check、oxlint、prettier 全绿；spec-count 85/468/2046（无 spec 改动——desktop-account-and-settings.md 场景 8 与 builtin-sdd-plugin.md 场景 3 本就主机无关，纯实现缺陷）。