### PR TITLE
fix(desktop): 项目设置开关 SDD 报 Session not found 改为跳过+串行重建

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -209,6 +209,15 @@ export class DesktopHost {
    * turn (spec「上下文用量指示器」场景 6). Weak keys: entries die with the agent.
    */
   private contextUsageByAgent = new WeakMap<StdioAgent, number>();
+  /**
+   * Tail of the agent-recreation promise chain (see updateAgentConfig). Config
+   * and plugin applies destroy + recreate every live session on the CLI, and
+   * the bridge removes a session while it is being recreated — an overlapping
+   * run on the same session would hit "Session not found" and leave the entry
+   * permanently missing (the same race the VSCE host guards in
+   * updateAllSessionsConfig). Chaining makes recreates strictly serial.
+   */
+  private configRecreateTail: Promise<unknown> = Promise.resolve();
   /** Pending host selected in each pane's new-session workdir picker. */
   private hostState = new Map<string, string>();
   // Split panes, ordered left→right. Each pane binds at most one agent (none
@@ -4382,7 +4391,13 @@ export class DesktopHost {
     for (const pane of this.panes) {
       const agent = pane.agent;
       if (agent && agent.queuedMessages.length > 0) {
-        await agent.abortMessage();
+        try {
+          await agent.abortMessage();
+        } catch (error) {
+          // The pane's session may be gone (recreate failed above) — one dead
+          // session must not fail the rest of the queue drain.
+          console.error("[DesktopHost] 中止排队消息失败:", error);
+        }
       }
     }
   }
@@ -4545,8 +4560,30 @@ export class DesktopHost {
     this.postMessage({ command: "desktopThemeSource", source });
   }
 
-  /** Server-side destroy + recreate with restored session, applied to every live agent (FR-031). */
-  private async updateAgentConfig(config: DesktopConfigData): Promise<void> {
+  /**
+   * Server-side destroy + recreate with restored session, applied to every live
+   * agent (FR-031). Runs are serialized on `configRecreateTail`: the CLI bridge
+   * deletes a session entry while its updateConfig recreates it, so two
+   * overlapping applies (plugin toggle + config save / rapid re-toggle) on the
+   * same session would make the second fail with "Session not found" and leave
+   * the session permanently gone. A session that is already absent on the CLI
+   * (stale pool entry) is skipped and logged instead of aborting the whole
+   * apply — the write that triggered the apply has already succeeded.
+   */
+  private updateAgentConfig(config: DesktopConfigData): Promise<void> {
+    // Defer starting the run inside the chain: an async body executes
+    // synchronously up to its first await, so invoking recreateAgentsForConfig
+    // eagerly here would let overlapping calls interleave despite the chain.
+    const chained = this.configRecreateTail.then(() =>
+      this.recreateAgentsForConfig(config),
+    );
+    this.configRecreateTail = chained.catch(() => {});
+    return chained;
+  }
+
+  private async recreateAgentsForConfig(
+    config: DesktopConfigData,
+  ): Promise<void> {
     const params = {
       apiKey: config.apiKey || undefined,
       baseURL: config.baseURL || undefined,
@@ -4560,7 +4597,29 @@ export class DesktopHost {
     };
     for (const [oldSid, agent] of [...this.agents]) {
       const wasStreaming = agent.isStreaming;
-      await agent.updateConfig(params);
+      try {
+        await agent.updateConfig(params);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (
+          message.startsWith("Session not found") ||
+          message.includes("not found on disk")
+        ) {
+          // The CLI no longer hosts this session (a stale pool entry, or a
+          // session destroyed by an earlier failed recreate). Keep applying to
+          // the remaining healthy sessions — the pane restores a dead session
+          // from disk when it is re-selected. Do NOT surface this as a failed
+          // settings write: the plugin/config change itself already succeeded.
+          console.error(
+            `[DesktopHost] 会话 ${oldSid} 不在 CLI 上，跳过重建:`,
+            error,
+          );
+          continue;
+        }
+        // Genuine config errors (bad baseURL/model …) still abort the apply so
+        // the caller can report them.
+        throw error;
+      }
       if (agent.sessionId && agent.sessionId !== oldSid) {
         this.rekeyAgent(agent, agent.sessionId);
       }

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -2953,6 +2953,71 @@ describe("misc commands", () => {
     expect(sent("appendMessage")).toHaveLength(0);
   });
 
+  it("setBuiltinPluginEnabled does not toast when a session is already gone on the CLI (recreate skip after a successful write)", async () => {
+    const { host, sent } = await readyHost();
+    const agent = lastAgent();
+    agent.updateConfig.mockRejectedValueOnce(
+      new Error("Session not found: sess-1"),
+    );
+    const orig = h.handleClientRequest;
+    h.handleClientRequest = (m: string, params?: unknown) =>
+      m === "setBuiltinPluginEnabled"
+        ? { enabledPlugins: { "sdd@builtin": true } }
+        : orig(m, params);
+    try {
+      await host.handleWebviewMessage({
+        command: "setBuiltinPluginEnabled",
+        pluginId: "sdd@builtin",
+        enabled: true,
+        scope: "project",
+      });
+      // The plugin write + projectSettings push (which flips the switch ON)
+      // precede the recreate — a session that is absent on the CLI must be
+      // skipped, not fail the successful settings write with an error toast.
+      expect(sent("projectSettings")).toHaveLength(1);
+      expect(
+        shownToasts().some((t) => t.message.includes("修改项目设置失败")),
+      ).toBe(false);
+      // The dead session is logged (global console.error spy from beforeEach),
+      // not surfaced as a settings failure.
+      expect(consoleSpies[0]).toHaveBeenCalled();
+    } finally {
+      h.handleClientRequest = orig;
+    }
+  });
+
+  it("serializes agent recreation across overlapping plugin applies", async () => {
+    const { host, sent } = await readyHost();
+    const agent = lastAgent();
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    agent.updateConfig.mockImplementation(() => gate);
+    const first = host.handleWebviewMessage({
+      command: "setBuiltinPluginEnabled",
+      pluginId: "sdd@builtin",
+      enabled: true,
+      scope: "project",
+    });
+    await vi.waitFor(() => expect(agent.updateConfig).toHaveBeenCalledTimes(1));
+    const second = host.handleWebviewMessage({
+      command: "setBuiltinPluginEnabled",
+      pluginId: "sdd@builtin",
+      enabled: false,
+      scope: "project",
+    });
+    // The second write completes (its projectSettings push) before its recreate
+    // runs — the recreate must stay queued behind the first's in-flight one
+    // instead of racing it on the same session (which would delete the CLI
+    // entry mid-recreate and throw "Session not found").
+    await vi.waitFor(() => expect(sent("projectSettings")).toHaveLength(2));
+    expect(agent.updateConfig).toHaveBeenCalledTimes(1);
+    release?.();
+    await Promise.all([first, second]);
+    expect(agent.updateConfig).toHaveBeenCalledTimes(2);
+  });
+
   it("listMarketplaces failure surfaces as a toast, not a chat message", async () => {
     const { host, sent } = await readyHost();
     const restore = failRpc("listMarketplaces", "marketplace down");


### PR DESCRIPTION
CLI updateConfig 在同一会话 destroy+recreate 期间会先删除 sessions 入口，
而 stdio 请求并发处理（非串行）——桌面端 settings/插件切换各自独立调用
updateAgentConfig，重叠执行会互删对方入口并抛 "Session not found"，
让后续该会话所有请求永久失败（VSCE updateAllSessionsConfig 已注释并防护
同一竞态，desktop 缺同步）。单次报错场景=切换先写成功、postMessage 后
updateAgentConfig 全有或全无，任一 agent 重建失败即把已成功的写标签为
"修改项目设置失败"（截图开关已 ON 仍弹错）。

修复=updateAgentConfig 重建跑严格串行（configRecreateTail 链）+ 每 agent
重建 try/catch 内含 "Session not found" 类错误（跳过并记录，真实配置
错误仍上抛）+ clearQueue 按 pane 容错。
