### PR TITLE
fix(jetbrains): 补 backgroundCurrentTask 命令漏接（流式 Ctrl+B 转后台任务）

### DIFF
--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
@@ -623,6 +623,16 @@ class MessageHandler(
                     put("success", success)
                 })
             }
+            // 流式期间 Ctrl+B：把前台任务转后台。回包语义同 VSCE chat 路由
+            // (messageHandler.ts case "backgroundCurrentTask") 与 desktopHost.ts
+            // —— 无 ack；任务状态随后经 updateBackgroundTasks/updateTasks 推送。
+            "backgroundCurrentTask" -> {
+                try {
+                    session.agent?.backgroundCurrentTask()
+                } catch (e: StdioClientException) {
+                    LOG.warn("backgroundCurrentTask failed: ${e.message}")
+                }
+            }
             "getWorkflowRuns" -> {
                 val runs = try {
                     session.agent?.getWorkflowRuns()

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioAgent.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/StdioAgent.kt
@@ -279,6 +279,11 @@ class StdioAgent(
         return result?.jsonObject?.get("success")?.jsonPrimitive?.booleanOrNull ?: false
     }
 
+    /** 流式期间把前台任务转后台（无返回内容；mirrors vscode stdioAgent.backgroundCurrentTask）。 */
+    suspend fun backgroundCurrentTask() {
+        client.request("backgroundCurrentTask", sessionId = sessionId)
+    }
+
     suspend fun getWorkflowRuns(): JsonElement? =
         client.request("getWorkflowRuns", sessionId = sessionId)?.jsonObject?.get("runs")
 


### PR DESCRIPTION
fix(jetbrains): 补 backgroundCurrentTask 命令漏接

流式期间 Ctrl+B 把前台任务转后台：MessageHandler.kt when() 无此分支、
StdioAgent.kt 无对应 RPC 封装，JetBrains 端静默无动作（vscode
messageHandler.ts:434 / desktopHost.ts:3620 / CLI agentBridge.ts:432
均已有）。补转发分支 + StdioAgent.backgroundCurrentTask()，回包语义与
vscode 一致（无 ack，任务状态经 updateBackgroundTasks 推送）。