### PR TITLE
fix(webview): 技能「编辑」打开 SKILL.md 文件而非技能目录（缺陷单 3466438649392128）

### DIFF
--- a/packages/webview/src/components/SettingsSkillsView.tsx
+++ b/packages/webview/src/components/SettingsSkillsView.tsx
@@ -46,6 +46,17 @@ function getSkillScope(skill: SkillMetadata): string {
   return skill.type;
 }
 
+/** 「编辑」要打开的文件：SDK 的 skillPath 语义是技能目录（内含 SKILL.md），
+ *  解析成 SKILL.md 文件路径才能被桌面文件面板 / IDE 编辑器打开；个别已直接
+ *  指向 SKILL.md/.md 文件的形态原样返回，避免重复拼接。 */
+function skillFileFor(
+  skill: Pick<SkillMetadata, "skillPath">,
+): string | undefined {
+  const p = skill.skillPath;
+  if (!p) return undefined;
+  return /\.md$/i.test(p) ? p : `${p.replace(/[\\/]+$/, "")}/SKILL.md`;
+}
+
 const SettingsSkillsView: React.FC<SettingsSkillsViewProps> = ({
   vscode,
   workdir,
@@ -103,11 +114,13 @@ const SettingsSkillsView: React.FC<SettingsSkillsViewProps> = ({
   };
 
   const handleEdit = (skill: SkillMetadata) => {
-    // 关闭设置页预填编辑提示词；同带 skillPath —— desktop 在会话视图右侧文件
-    // 面板打开该 SKILL.md、IDE 用自身编辑器打开，便于对照修改。
+    // 关闭设置页预填编辑提示词；同带 SKILL.md 文件路径 —— desktop 在会话视图
+    // 右侧文件面板打开、IDE 用自身编辑器打开，便于对照修改。SDK 下发的
+    // skillPath 是技能目录（内含 SKILL.md，删除也按目录递归），host 的文件
+    // 面板/编辑器只能打开文件，直接传目录会报「无法显示目录」而打不开技能。
     onPrefillPrompt?.(
       `/settings 帮我改技能${skill.name}：把<要改的地方>改成<新内容/新行为>`,
-      skill.skillPath,
+      skillFileFor(skill),
     );
   };
 

--- a/packages/webview/tests/webview/settingsSkills.test.tsx
+++ b/packages/webview/tests/webview/settingsSkills.test.tsx
@@ -35,7 +35,8 @@ const userSkill: SkillMetadata = {
   name: "my-skill",
   description: "个人自定义技能，用于日常代码审查",
   type: "personal",
-  skillPath: "~/.wave/skills/my-skill.md",
+  // SDK 的 skillPath 指向技能目录（内含 SKILL.md），非 SKILL.md 文件本身
+  skillPath: "~/.wave/skills/my-skill",
   model: "glm-5.2",
   allowedTools: ["Read", "Write"],
   userInvocable: true,
@@ -45,7 +46,7 @@ const projectSkill: SkillMetadata = {
   name: "deploy",
   description: "项目专用部署技能",
   type: "project",
-  skillPath: "/work/a/.wave/skills/deploy/SKILL.md",
+  skillPath: "/work/a/.wave/skills/deploy",
   userInvocable: true,
 };
 
@@ -191,7 +192,7 @@ describe("SettingsPage 技能选项卡视图（4 Tab + 项目 Tab 平铺）", ()
     const sourceField = screen.getByText("来源：").parentElement;
     expect(sourceField).toHaveTextContent("用户");
     expect(screen.getByText("路径：")).toBeInTheDocument();
-    expect(screen.getByText("~/.wave/skills/my-skill.md")).toBeInTheDocument();
+    expect(screen.getByText("~/.wave/skills/my-skill")).toBeInTheDocument();
     expect(screen.getByText("模型：")).toBeInTheDocument();
     expect(screen.getByText("glm-5.2")).toBeInTheDocument();
     expect(screen.getByText("允许的工具：")).toBeInTheDocument();
@@ -272,9 +273,11 @@ describe("SettingsPage 技能选项卡视图（4 Tab + 项目 Tab 平铺）", ()
       fireEvent.click(screen.getByRole("button", { name: /编辑/ }));
     });
 
+    // 编辑传 SKILL.md 文件本身（skillPath 是技能目录，host 面板/编辑器
+    // 打不开目录 —— bug 3466438649392128 回归护栏）
     expect(onPrefillPrompt).toHaveBeenCalledWith(
       expect.stringContaining("帮我改技能my-skill"),
-      "~/.wave/skills/my-skill.md",
+      "~/.wave/skills/my-skill/SKILL.md",
     );
     expect(vscode.postMessage).not.toHaveBeenCalledWith(
       expect.objectContaining({ command: "openFile" }),
@@ -292,11 +295,9 @@ describe("SettingsPage 技能选项卡视图（4 Tab + 项目 Tab 平铺）", ()
       fireEvent.click(screen.getByRole("button", { name: /删除/ }));
     });
 
-    // 确认框出现（含技能名与路径）
+    // 确认框出现（含技能名与路径 —— 目录形态，删除按目录递归）
     expect(await screen.findByText("删除技能「my-skill」")).toBeInTheDocument();
-    expect(
-      screen.getByText(/~\/\.wave\/skills\/my-skill\.md/),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/~\/\.wave\/skills\/my-skill/)).toBeInTheDocument();
 
     // 取消不删除
     await act(async () => {


### PR DESCRIPTION
## 缺陷单 3466438649392128：技能点击编辑时没打开对应的 skill 文件

### 根因
设置页「技能」Tab 点「编辑」时，把 SDK 下发的 `skillPath`（**技能目录**，如 `~/.wave/skills/<name>` / `<workdir>/.wave/skills/<name>`，内含 SKILL.md；删除也按目录递归）直接当 SKILL.md 文件路径透传给 host 打开：
- 桌面文件面板：目录直接抛「无法在面板中显示目录」（desktopHost.ts `readLocalFileForPanel`），SKILL.md 内容不显示；
- VS Code / JetBrains：`openTextDocument` 打不开目录，回退 `vscode.open` 只开目录导航。

MCP / 子代理 / 钩子三个视图传的都是真文件（mcp.json / agent .md / settings.json），唯独技能传目录，因此只有技能出现此问题。spec `skills-command.md`「编辑技能」场景 2 本就声明应打开 SKILL.md —— 纯实现缺陷。

### 修复
`SettingsSkillsView` 新增 `skillFileFor()`：`skillPath` 解析为技能文件本身（去尾分隔符拼 `/SKILL.md`；已 `.md` 结尾的旧形态数据原样返回防重复拼接）。`handleEdit` 的 openFile 参数改用解析结果，桌面右侧文件面板 / IDE 编辑器随之打开真实的 SKILL.md。

### 测试
- fixture 改为 SDK 真实形态（`skillPath` 为目录并加注释说明契约），详情/删除确认断言同步；
- 「编辑」用例断言 `onPrefillPrompt` 第二参 = `…/SKILL.md`，**fail-without-fix 已验**（还原修复 1 failed）；
- settingsSkills + settingsPaneDelegate + subagents + mcp + hooks 49 例全绿；webview type-check（src/tests/e2e/demo）与 oxlint 0 error。