### PR TITLE
desktop host 补 newCompleted 接线——后台会话完成未读绿点置位/打开清除

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -248,6 +248,8 @@ export class DesktopHost {
       lastActiveAt: number;
       hasWorktree: boolean;
       running: boolean;
+      waitingConfirmation: boolean;
+      newCompleted: boolean;
     }>;
   }> = [];
   private pendingConfirmations = new Map<string, PendingConfirmation>();
@@ -267,6 +269,18 @@ export class DesktopHost {
    *  toasts every historical session the user clicks. Consumed (deleted) by
    *  each loading:false; a fresh loading:true re-adds for the next turn. */
   private streamedAgents = new WeakSet<StdioAgent>();
+  /**
+   * Agents whose last real turn finished while no pane displayed the session —
+   * drives the sidebar「已完成未读」green dot (DesktopSessionEntry.newCompleted,
+   * Figma 13656:5470). Set in onLoadingChange(false) on exactly the same
+   * boundary as the background-completion toast: a real finished turn (loading:
+   * true observed), not an abort or a restore-replayed idle snapshot. Cleared
+   * once the session is opened/focused in a pane (bindAgentToPane — the single
+   * path that brings a session into view) or starts a new turn, so a session
+   * the user already viewed never re-lights just because they switched away.
+   * Weak keys: entries die with the agent.
+   */
+  private newCompletedAgents = new WeakSet<StdioAgent>();
   /**
    * Optimistic session restores in flight (spec「历史会话即时进入与恢复加载动画」):
    * keyed by paneId, holding the target session + a monotonic token. While an
@@ -1194,6 +1208,9 @@ export class DesktopHost {
           // have aborted the previous turn, then sent a fresh prompt).
           this.userAbortedAgents.delete(agentRef);
           this.streamedAgents.add(agentRef);
+          // Activity supersedes an unread-completion dot: the session is no
+          // longer "completed & unviewed", it is producing again.
+          this.newCompletedAgents.delete(agentRef);
         } else {
           this.touchSessionInIndex(agentRef);
           // Announce a background turn that finished on its own — only for
@@ -1206,6 +1223,9 @@ export class DesktopHost {
           const aborted = this.userAbortedAgents.delete(agentRef);
           const finishedTurn = this.streamedAgents.delete(agentRef);
           if (!paneId && !aborted && finishedTurn && agentRef.sessionId) {
+            // Same boundary as the toast below — the completion is real and the
+            // session is on no pane, so flag it as unread for the sidebar dot.
+            this.newCompletedAgents.add(agentRef);
             this.showToast({
               message: `会话「${this.sessionTitleFor(agentRef)}」已完成`,
               actionLabel: "查看",
@@ -1350,7 +1370,14 @@ export class DesktopHost {
     this.clearThrottleState(paneId);
     pane.agent = agent;
     this.focusedPaneId = paneId;
-    if (agent) this.touchAgentAsRecent(agent);
+    if (agent) {
+      // The session is now displayed in a pane — its unread-completion dot is
+      // cleared for real (not merely hidden by the webview's current/visible
+      // filter), so switching away later does not re-light it without a fresh
+      // completion.
+      this.newCompletedAgents.delete(agent);
+      this.touchAgentAsRecent(agent);
+    }
     // The pane may now run on a different host — the sidebar account card
     // follows the focused pane's host (spec 场景 8).
     this.syncAccountCard();
@@ -2583,6 +2610,7 @@ export class DesktopHost {
           waitingConfirmation: agent
             ? agentsWithPendingConfirmation.has(agent)
             : false,
+          newCompleted: agent ? this.newCompletedAgents.has(agent) : false,
         };
       }),
     }));

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -4786,6 +4786,7 @@ describe("multi-session parallel (FR-031)", () => {
           sessionId: string;
           running: boolean;
           waitingConfirmation?: boolean;
+          newCompleted?: boolean;
         }>;
       }>) ?? []
     ).flatMap((g) => g.sessions);
@@ -4871,6 +4872,102 @@ describe("multi-session parallel (FR-031)", () => {
     const after = treeSessions(sent("desktopSessionTree").at(-1));
     expect(after.find((s) => s.sessionId === "sess-1")?.running).toBe(false);
     expect(after.find((s) => s.sessionId === "sess-2")?.running).toBe(true);
+  });
+
+  it("flags a pane-less background session new-completed when its turn ends, then clears it once opened", async () => {
+    const { host, sent } = await readyHost();
+    const agent1 = seedActiveSession("sess-1");
+    // pane-1 now shows sess-2; sess-1 keeps running with no pane.
+    await host.handleWebviewMessage({ command: "newSession" });
+    seedActiveSession("sess-2");
+
+    agent1.callbacks.onLoadingChange(true);
+    agent1.callbacks.onLoadingChange(false);
+
+    const flagged = treeSessions(sent("desktopSessionTree").at(-1));
+    expect(flagged.find((s) => s.sessionId === "sess-1")?.newCompleted).toBe(
+      true,
+    );
+    // The session in the focused pane is being watched — no unread dot.
+    expect(flagged.find((s) => s.sessionId === "sess-2")?.newCompleted).toBe(
+      false,
+    );
+
+    // Opening the session into the focused pane clears the flag for real — the
+    // tree must stop advertising an unread completion the user just saw.
+    await host.handleWebviewMessage({
+      command: "desktopSelectSession",
+      workdir: "/work/a",
+      sessionId: "sess-1",
+    });
+    const cleared = treeSessions(sent("desktopSessionTree").at(-1));
+    expect(cleared.find((s) => s.sessionId === "sess-1")?.newCompleted).toBe(
+      false,
+    );
+  });
+
+  it("does not flag a turn finished in a session visible in a non-focused pane", async () => {
+    const { host, sent } = await readyHost();
+    seedActiveSession("sess-1");
+    await host.handleWebviewMessage({ command: "newSession" });
+    const agent2 = seedActiveSession("sess-2"); // bound to pane-1, focused
+
+    // Show sess-1 in a second pane: pane-2 takes focus, sess-2 stays visible
+    // in pane-1 but is no longer focused. Its completion is still on screen,
+    // so no unread dot is needed.
+    await host.handleWebviewMessage({
+      command: "desktopOpenPane",
+      workdir: "/work/a",
+      sessionId: "sess-1",
+    });
+    expect(
+      sent("desktopPanes")
+        .at(-1)
+        ?.panes?.some((p) => p.sessionId === "sess-1" && p.paneId === "pane-2"),
+    ).toBe(true);
+
+    agent2.callbacks.onLoadingChange(true);
+    agent2.callbacks.onLoadingChange(false);
+
+    const after = treeSessions(sent("desktopSessionTree").at(-1));
+    expect(after.find((s) => s.sessionId === "sess-2")?.newCompleted).toBe(
+      false,
+    );
+    expect(after.find((s) => s.sessionId === "sess-1")?.newCompleted).toBe(
+      false,
+    );
+  });
+
+  it("does not re-light the new-completed dot for a session the user opened then left", async () => {
+    const { host, sent } = await readyHost();
+    const agent1 = seedActiveSession("sess-1");
+    await host.handleWebviewMessage({ command: "newSession" });
+    seedActiveSession("sess-2");
+
+    agent1.callbacks.onLoadingChange(true);
+    agent1.callbacks.onLoadingChange(false);
+    const flagged = treeSessions(sent("desktopSessionTree").at(-1));
+    expect(flagged.find((s) => s.sessionId === "sess-1")?.newCompleted).toBe(
+      true,
+    );
+
+    // View sess-1, then leave it for sess-2: sess-1 returns to the background
+    // but must not re-light — its flag was cleared when opened, not merely
+    // hidden by the webview for as long as the session stays in view.
+    await host.handleWebviewMessage({
+      command: "desktopSelectSession",
+      workdir: "/work/a",
+      sessionId: "sess-1",
+    });
+    await host.handleWebviewMessage({
+      command: "desktopSelectSession",
+      workdir: "/work/a",
+      sessionId: "sess-2",
+    });
+    const after = treeSessions(sent("desktopSessionTree").at(-1));
+    expect(after.find((s) => s.sessionId === "sess-1")?.newCompleted).toBe(
+      false,
+    );
   });
 
   it("flags a background session waiting-confirmation in the tree until resolved", async () => {


### PR DESCRIPTION
## 背景
PR #2090 引入的 `DesktopSessionEntry.newCompleted`（侧边栏「已完成未读」绿点，Figma 13656:5470）webview 已消费但 desktop host 从未写入——后台会话完成时绿点不出现，功能半成品。

## 改动（仅 desktop 包 2 文件）
- `desktopHost.ts`：turn 真实结束（复用既有后台完成 toast 的完全同一边界：`loading:true` 后终态，排除 abort / restore 重放快照）且该会话无任何 pane 显示时，标记 `newCompletedAgents`（WeakSet\<StdioAgent\>）；`bindAgentToPane` 绑定（打开/聚焦会话的唯一收敛点）与新一轮 `loading:true` 时清除——真清除非仅 UI 隐藏，看完 A 切到 B 后 A 不再复发亮点；`refreshSessionTree()` 下发 `newCompleted`。
- `desktopHost.test.ts`：3 例新测试（置位+打开清除 / 可见于非聚焦 pane 不置位 / 打开后切走不再亮），均 fail-without-fix 验证过。

## 验证
desktop 全量 584/584、type-check（含 tests）、oxlint、prettier 全绿。