### PR TITLE
chore(webview): remove dead preview tab-bar code (PANEL_ORDER / onLastTabClosed / pill-tab CSS)

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -64,14 +64,6 @@ import { isMacHiddenTitlebar } from "../utils/platform";
 import { chatReducer, initialState } from "../reducers/chatReducer";
 import "../styles/ChatApp.css";
 
-/** Desktop conversation-level panels: fixed left→right order regardless of check order. */
-export const PANEL_ORDER: DesktopPanelKind[] = [
-  "preview",
-  "plan",
-  "diff",
-  "terminal",
-  "file",
-];
 /** Chinese names shown in the panel tabs / space hints. */
 export const PANEL_LABELS: Record<DesktopPanelKind, string> = {
   preview: "预览",
@@ -2792,7 +2784,6 @@ export const ChatApp: React.FC<ChatAppProps> = ({
           onRetry={currentForward ? handleRemotePreviewRetry : undefined}
           vscode={vscode}
           onAddComment={handleAddComment}
-          onLastTabClosed={() => handleCloseTab(id)}
           onTitleChange={(title) => {
             setTabs((prev) =>
               prev.map((t) =>

--- a/packages/webview/src/components/PreviewPane.tsx
+++ b/packages/webview/src/components/PreviewPane.tsx
@@ -161,10 +161,6 @@ export interface PreviewPaneProps {
   /** Remote sessions: re-establish the port forward on error retry (scenario
    * 16). Undefined for local URLs, where the retry reloads the guest instead. */
   onRetry?: () => void;
-  /** Kept for parent API compatibility — single-window preview has no tab
-   * bar and no close button of its own (关闭统一由一级 tab 控制), so this
-   * never fires. */
-  onLastTabClosed?: () => void;
   /** The guest page's title (webview page-title-updated) — the parent shows
    * it on the panel tab like a regular browser tab. */
   onTitleChange?: (title: string) => void;

--- a/packages/webview/src/styles/DesktopApp.css
+++ b/packages/webview/src/styles/DesktopApp.css
@@ -1035,82 +1035,6 @@ body.is-panel-resizing webview {
   flex-shrink: 0;
 }
 
-/* ---- Preview tabs (spec desktop-preview.md 预览多标签页) ----
-   Prototype pill tabs: 26px capsules on a transparent strip; the active tab
-   gets a neutral fill; 1px separators sit between inactive neighbors. */
-
-.preview-tab-bar {
-  display: flex;
-  align-items: center;
-  gap: 2px;
-  padding: 4px 8px;
-  border-bottom: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.2));
-  flex-shrink: 0;
-  overflow-x: auto;
-  scrollbar-width: thin;
-}
-
-.preview-tab {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  height: 26px;
-  max-width: 160px;
-  min-width: 56px;
-  padding: 0 4px 0 10px;
-  border: none;
-  border-radius: 13px;
-  font-size: 12px;
-  color: var(--vscode-foreground);
-  background: transparent;
-  cursor: pointer;
-  user-select: none;
-  opacity: 0.8;
-}
-
-/* 1px separator between neighboring inactive tabs; hidden next to the
-   active (filled) pill so it doesn't touch its edges. */
-.preview-tab + .preview-tab::before {
-  content: "";
-  position: absolute;
-  left: -1.5px;
-  top: 6px;
-  bottom: 6px;
-  width: 1px;
-  background: var(--vscode-panel-border, rgba(128, 128, 128, 0.2));
-}
-
-.preview-tab.active + .preview-tab::before,
-.preview-tab.active::before {
-  display: none;
-}
-
-.preview-tab:hover {
-  background: var(--vscode-list-hoverBackground);
-  opacity: 1;
-}
-
-.preview-tab.active {
-  background: color-mix(in srgb, var(--vscode-foreground) 10%, transparent);
-  color: var(--vscode-foreground);
-  opacity: 1;
-}
-
-.preview-tab.active .preview-tab-label {
-  opacity: 1;
-  font-weight: 500;
-}
-
-.preview-tab-label {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  opacity: 0.85;
-}
-
 .preview-tab-close {
   display: flex;
   align-items: center;
@@ -1129,26 +1053,6 @@ body.is-panel-resizing webview {
 
 .preview-tab-close:hover {
   opacity: 1;
-  background: var(--vscode-list-hoverBackground);
-}
-
-.preview-tab-add {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  margin: 0 0 0 2px;
-  padding: 0;
-  border: none;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--vscode-foreground);
-  cursor: pointer;
-  flex-shrink: 0;
-}
-
-.preview-tab-add:hover {
   background: var(--vscode-list-hoverBackground);
 }
 

--- a/packages/webview/src/styles/host-desktop.css
+++ b/packages/webview/src/styles/host-desktop.css
@@ -1101,31 +1101,6 @@
   max-width: 768px;
 }
 
-/* 预览标签（Figma 13561:39645）：r8 圆角（非胶囊 r13）、文字 14px、
-   pad 左右 8、激活底色 #F0F2F5（--cc-fill）；深色保持中性 10% 前景 */
-[data-host="desktop"] .preview-tab {
-  border-radius: 8px;
-  font-size: 14px;
-  padding: 0 4px 0 8px;
-}
-[data-host="desktop"][data-theme="light"] .preview-tab.active {
-  background: #f0f2f5;
-  color: #1f2329;
-}
-
-/* hover 底色对齐设计系统 fill-hover（base vscode list-hoverBackground 蓝灰
-   调 #2a2d2e / rgba(0,0,0,.08) 未入规范；桌面同类 hover 统一 #EEF0F3 /
-   dark 8% 白 —— queued-item/菜单项先例）。active 标签 hover 保持激活底
-   （激活色更浅，hover 不覆盖为深一档的 fill-hover）。 */
-[data-host="desktop"][data-theme="light"] .preview-tab:not(.active):hover,
-[data-host="desktop"][data-theme="light"] .preview-tab:not(.active):focus-visible {
-  background: #eef0f3;
-}
-[data-host="desktop"][data-theme="dark"] .preview-tab:not(.active):hover,
-[data-host="desktop"][data-theme="dark"] .preview-tab:not(.active):focus-visible {
-  background: rgba(255, 255, 255, 0.08);
-}
-
 /* ═══ 第十八轮：预览面板工具栏（对齐原型 InspectorPanel.vue）═══════
    参考 codechat-ui InspectorPanel.vue + global.css：地址栏 44px 高 / 白底
    #FFF（--cc-bg-panel）/ 底分隔线 #EBEEF5（--cc-border-lighter）；地址输入框
@@ -1133,16 +1108,8 @@
    （figma-icon-button）/ r4 / 图标 #565A60 / hover #EEF0F3（--cc-fill-hover）；
    深色映射沿用 wave 约定：12% 白边 / 6% 白底 / 8% 白 hover。 */
 
-/* ═══ 第二十七轮：预览头部背景（用户评论 ①toolbar 深色不应有背景 ②tab-bar
-   浅色不应有背景）═══════
-   ① 深色 toolbar 去 #27292B 背景 → 透明，头部与 pane 底色 #181818 连为一体；
-   ② 浅色 tab-bar 透明时露出 pane 灰 #F7F8FB，被感知为背景色 → 补白底 #FFF，
-      与浅色 toolbar 白底连续成统一头部（对齐 codechat preview-tabbar 白底）。 */
-
-[data-host="desktop"][data-theme="light"] .preview-tab-bar {
-  background: #ffffff;
-  border-bottom-color: #ebeef5;
-}
+/* ═══ 第二十七轮：预览头部背景（用户评论 toolbar 深色不应有背景）═══════
+   深色 toolbar 去 #27292B 背景 → 透明，头部与 pane 底色 #181818 连为一体。 */
 
 [data-host="desktop"][data-theme="light"] .preview-pane-toolbar {
   background: #ffffff;

--- a/packages/webview/tests/webview/previewPane.test.tsx
+++ b/packages/webview/tests/webview/previewPane.test.tsx
@@ -51,7 +51,6 @@ function renderPane(options?: {
   onAddComment?: (text: string) => void;
   originalUrl?: string;
   onRetry?: () => void;
-  onLastTabClosed?: () => void;
   onTitleChange?: (title: string) => void;
   onNavigate?: (url: string) => void;
 }) {
@@ -60,7 +59,6 @@ function renderPane(options?: {
   const onAddComment = options?.onAddComment ?? vi.fn();
   const originalUrl = options?.originalUrl;
   const onRetry = options?.onRetry;
-  const onLastTabClosed = options?.onLastTabClosed ?? vi.fn();
   const onTitleChange = options?.onTitleChange ?? vi.fn();
   const onNavigate = options?.onNavigate ?? vi.fn();
   // Controlled-width harness: PreviewPane no longer owns its width state.
@@ -80,7 +78,6 @@ function renderPane(options?: {
       onAddComment={onAddComment}
       originalUrl={originalUrl}
       onRetry={onRetry}
-      onLastTabClosed={onLastTabClosed}
       onTitleChange={onTitleChange}
       onNavigate={onNavigate}
     />
@@ -106,7 +103,6 @@ function renderPane(options?: {
     wv,
     url,
     onAddComment,
-    onLastTabClosed,
     onTitleChange,
     onNavigate,
   };


### PR DESCRIPTION
Panel tab 化重构后残留的死代码清理，零行为变更：
- PANEL_ORDER 孤立 export（全仓唯一引用即定义处）
- PreviewPane.onLastTabClosed prop 链（接口注释自述 never fires，chatApp 传参 + 测试管道同步删）
- DesktopApp.css 预览多标签 pill tab 旧实现（.preview-tab-bar/.preview-tab/.preview-tab-label/.preview-tab-add）
- host-desktop.css 对应主题覆盖与 tab-bar 白底规则（第二十七轮注释仅留 toolbar ①）
保留 .preview-tab-close/-new（DesktopPanelTabs/PreviewPane 在用）
