### PR TITLE
fix(ci): pin macOS desktop build to macos-15 — macos-latest keychain signing regression

### DIFF
--- a/.github/workflows/beta-build.yml
+++ b/.github/workflows/beta-build.yml
@@ -101,7 +101,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        # macOS is pinned to macos-15 (not macos-latest): the macos-latest
+        # image rolling forward (os=25.6.0) broke electron-builder's keychain
+        # signing — `security set-key-partition-list` fails with
+        # "SecKeychainUnlock: passphrase not correct" while the same secrets
+        # succeeded on the previous image. When the runner image catches up,
+        # bump the label back to macos-latest and verify with a Beta Build.
+        os: [macos-15, windows-latest]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -241,7 +241,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        # macOS is pinned to macos-15 (not macos-latest): the macos-latest
+        # image rolling forward (os=25.6.0) broke electron-builder's keychain
+        # signing — `security set-key-partition-list` fails with
+        # "SecKeychainUnlock: passphrase not correct" while the same secrets
+        # succeeded on the previous image. When the runner image catches up,
+        # bump the label back to macos-latest and verify with a release.
+        os: [macos-15, windows-latest]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## 问题

macOS desktop 构建在 macos-latest runner 上确定性失败：

- 失败 run [34072926825](https://github.com/netease-lcap/wave-agent/actions/runs/34072926825) — `beta-desktop (macos-latest)` job，electron-builder 26.15.3 在 `security set-key-partition-list -S apple-tool:,apple: -s -k <pw> <temp.keychain>` 报 `SecKeychainUnlock: passphrase not correct`（failedTask=build）。
- 失败日志 `os=25.6.0`，而 09-04 同一 workflow 成功 run [33840131969](https://github.com/netease-lcap/wave-agent/actions/runs/33840131969)（签名 env CSC_LINK / CSC_KEY_PASSWORD / APPLE_API_KEY* 自 08-10 未变）。

判定：macos-latest 镜像滚动引入 keychain 签名回归（runner-images 上游已知问题），非 secret / 证书问题。

## 修复

beta-build.yml 与 publish.yml 的 build-desktop 矩阵 macOS runner 由 `macos-latest` 钉为 **`macos-15`**（darwin arm64 标准镜像），并附注释说明原因与镜像滚动后回迁检查方法。

## 实测验证

分支 [fix/macos-runner-signing](https://github.com/netease-lcap/wave-agent/tree/fix/macos-runner-signing) 上 dispatch Beta Build run [34076326796](https://github.com/netease-lcap/wave-agent/actions/runs/34076326796)：

- `beta-desktop (macos-15)` job **success**（Image: `macos-15-arm64` 20260829.0321.1，macOS 15.7.9）
- 关键日志：
  - `• packaging platform=darwin arch=arm64`
  - `• signing file=release/mac-arm64/Wave.app platform=darwin type=distribution identityName=Developer ID Application: Hangzhou Langhe Technology Company Limited (86Y5QKVXN9)`
  - `• notarization successful`
  - `.dmg` / `.zip` 产物正常生成

## 范围

只改两文件 runner 矩阵行 + 注释，无其它改动。