### PR TITLE
feat(agent-sdk): 官方插件市场镜像 zip 快照消费端（zip mirror + latest + 哨兵）

### DIFF
--- a/docs/specs/ecosystem/plugin.md
+++ b/docs/specs/ecosystem/plugin.md
@@ -12,12 +12,22 @@ order: 70
 
 ## 远程插件获取
 
-所有远程插件/市场获取都通过 `GitService` 使用 **`git clone --depth 1`**。没有直接的 HTTP 文件下载。获取流程：
+除内置官方市场（`wave-plugins-official`，走镜像 zip 快照，见下方「官方插件市场镜像 zip 快照获取与更新」用户故事）外，所有远程插件/市场获取都通过 `GitService` 使用 **`git clone --depth 1`**。没有直接的 HTTP 文件下载。Git 获取流程：
 
 1. **市场注册** → 将市场仓库 `git clone`（HTTP/HTTPS/SSH）到 `~/.wave/plugins/marketplaces/<repo>/`
 2. **插件安装** → 如果 `marketplace.json` 中插件条目的 `source` 是 Git URL（`http://`、`https://`、`git@`、`ssh://`），则单独克隆插件仓库到临时目录，然后移动到缓存。如果 `source` 是相对路径，则从市场检出目录解析。
 3. **插件加载** → `PluginLoader` 从缓存的本地副本读取 `.wave-plugin/plugin.json` 和组件子目录。
 4. **插件激活** → `PluginManager.loadSinglePlugin()` 向各自的管理器注册命令、技能、钩子等。
+
+内置官方市场 zip 快照镜像获取流程（内容寻址 zip + latest 指针 + 本地哨兵）：
+
+1. GET `{base}/latest`（~10s 超时）→ 得到内容寻址 sha
+2. 读市场目录哨兵 `.wave-market-sha`；与 sha 相等 → no-op（幂等，不做任何下载）
+3. GET `{base}/{sha}.zip`（~60s 超时）→ 解压到 `{市场目录}.staging`（拒绝路径穿越/绝对路径、文件与总量大小上限；按 zip external attrs 恢复可执行位）
+4. 原子换入：删除旧市场目录 + 重命名 staging → 市场目录；写回 `.wave-market-sha` 哨兵
+5. 任一步失败 → 本次镜像获取失败（不动现有市场内容）；若 git 兜底开关开启则回退既有 git pull/clone 路径（Git 不可用则跳过更新）
+
+镜像仅作为内置官方市场的获取通道替换，settings/缓存中的 `source` 字段保持 `github` 不变（按市场名称特判），存量数据零迁移。
 
 ## 用户场景与测试
 
@@ -82,6 +92,23 @@ order: 70
 3. **假设**带有有效 `marketplace.json` 的目录，**当**我运行 `wave plugin marketplace add [path]` 时，**则**市场成功注册。
 4. **假设**现有市场，**当**在 UI 中选中时，**则**用户可以选择"更新"（刷新插件列表）或"移除"市场。
 
+### 用户故事：官方插件市场镜像 zip 快照获取与更新（优先级：P1）
+
+作为用户，我希望内置官方插件市场（`wave-plugins-official`）通过网络可达的内容寻址 zip 快照镜像获取与增量更新（无需 git、无需访问 GitHub），以便在国内网络受限环境下也能获得官方插件市场内容。
+
+**为什么是这个优先级**：官方市场托管在 GitHub（国内访问受限），镜像 zip 快照是国内用户获取官方市场内容的可靠通道（对齐 Claude Code 的 GCS zip 镜像模型）；它只替换市场获取这一步（git clone/pull → 内容寻址 zip），下游插件安装/加载代码零改动。镜像未配置或失败时保留 git 兜底，不破坏现有用户。
+
+**验收场景**：
+
+1. **假设** 镜像 base URL 已配置（环境变量 `WAVE_OFFICIAL_MARKET_MIRROR_BASE_URL` 优先，否则代码内置常量），且市场目录内哨兵 `.wave-market-sha` 内容等于 `latest` 指针返回的 sha，**当** 官方市场更新时，**则** 客户端判定已是最新（no-op）：不下载 zip、不改动市场目录。
+2. **假设** 镜像 `latest` 指针返回新 sha，**当** 官方市场更新时，**则** 客户端下载 `{base}/{sha}.zip` 全量快照、解压到 staging 目录、原子换入市场目录并写回哨兵，市场 manifest 与 `plugins/` 目录结构原样保留、可被既有插件安装流程直接使用。
+3. **假设** 市场目录由早期 git clone 得到（目录内无哨兵），**当** 官方市场更新时，**则** 客户端下载镜像 zip 整体替换该目录，不依赖目录内 git 历史。
+4. **假设** 下载的 zip 损坏或解压被拒绝（路径穿越/绝对路径条目、单文件或总量超限），**当** 官方市场更新时，**则** 本次更新失败且不改动现有市场内容；git 兜底开启时回退既有 git pull/clone 路径，Git 不可用或兜底关闭则跳过本次更新。
+5. **假设** `latest` 返回空 body 或镜像网络请求失败，**当** 官方市场更新时，**则** 与 zip 失败同路径处理：本次镜像获取失败并回退 git（若兜底开启）。
+6. **假设** 镜像 URL 未配置（环境变量未设置且内置常量仍为占位空值），**当** 官方市场更新时，**则** 行为保持现状——直接走 git 路径，不发起任何 HTTP 请求。
+7. **假设** 官方市场为内置市场（`source` 字段保持 `github` 不变），**当** 消费端需要决定获取通道时，**则** 仅按市场名称 `wave-plugins-official` 特判优先尝试镜像；其他 github/git 市场不受影响。
+8. **假设** 镜像快照 zip 内含需要可执行位的脚本（hooks 等），**当** 解压落盘时，**则** 依据 zip external attrs 恢复可执行位（对齐 git clone 原生保留 +x），hooks 脚本可直接执行。
+
 ### 用户故事：IDE 插件管理对话框（优先级：P2）
 
 作为 IDE 插件用户，我希望通过 `/plugin` 打开插件管理对话框，浏览、安装、更新、卸载插件并管理插件市场，以便在不切换到 CLI 的情况下完成插件管理。
@@ -110,5 +137,5 @@ order: 70
 - **A-005**："项目作用域"安装涉及修改通常提交到版本控制的文件（如 `.wave/settings.json`）。
 - **A-006**：系统应安装 `git` 以使用 GitHub 或基于 Git 的市场。
 - **A-007**：本地市场存储在与 `wave` 安装相同的文件系统上。
-- **A-008**：所有远程获取使用 `git clone`——没有直接的 HTTP 下载插件文件机制。
+- **A-008**：除内置官方市场 `wave-plugins-official` 的镜像 zip 快照通道（见「官方插件市场镜像 zip 快照获取与更新」用户故事）外，所有远程获取使用 `git clone`——没有直接的 HTTP 下载插件文件机制。官方市场镜像失败或未配置时同样回退 git clone。
 - **A-009**：GitHub 简写（`owner/repo`）自动解析为 `https://github.com/owner/repo.git`。

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -63,6 +63,7 @@
     "@vscode/ripgrep": "^1.18.0",
     "chokidar": "^4.0.3",
     "cron-parser": "^5.5.0",
+    "fflate": "^0.8.3",
     "fuzzysort": "^3.1.0",
     "glob": "^13.0.0",
     "lru-cache": "^11.3.5",

--- a/packages/agent-sdk/src/services/MarketplaceService.ts
+++ b/packages/agent-sdk/src/services/MarketplaceService.ts
@@ -11,6 +11,11 @@ import {
   MarketplaceSource,
 } from "../types/marketplace.js";
 import { GitService } from "./GitService.js";
+import {
+  ALLOW_OFFICIAL_MARKET_GIT_FALLBACK,
+  fetchOfficialMarketplaceFromMirror,
+  resolveOfficialMarketplaceMirrorBaseUrl,
+} from "./officialMarketplaceMirror.js";
 import { ConfigurationService } from "./configurationService.js";
 import type { MarketplaceConfig, Scope } from "../types/configuration.js";
 import { logger, logError, logWarn } from "../utils/globalLogger.js";
@@ -706,31 +711,58 @@ export class MarketplaceService {
       const errors: string[] = [];
       for (const marketplace of toUpdate) {
         try {
+          // Builtin official marketplace: prefer the zip-snapshot mirror
+          // (content-addressed zip over a plain HTTP base, no git/GitHub
+          // needed). Only the builtin is special-cased by name — its
+          // `source` stays "github" in settings/cache, so there is zero
+          // data migration. On mirror failure fall back to the git path
+          // unless the kill switch forbids it.
+          const isOfficialBuiltin =
+            marketplace.name === MarketplaceService.BUILTIN_MARKETPLACE.name;
+          let mirrorUpdated = false;
+          if (isOfficialBuiltin && resolveOfficialMarketplaceMirrorBaseUrl()) {
+            const targetPath = this.getMarketplacePath(marketplace.source);
+            const mirrorSha = await fetchOfficialMarketplaceFromMirror(
+              targetPath,
+              this.marketplacesDir,
+            );
+            if (mirrorSha !== null) {
+              mirrorUpdated = true;
+            } else if (!ALLOW_OFFICIAL_MARKET_GIT_FALLBACK) {
+              logWarn(
+                `Skipping update for official marketplace "${marketplace.name}": mirror fetch failed and git fallback is disabled.`,
+              );
+              continue;
+            }
+          }
+
           if (
             marketplace.source.source === "github" ||
             marketplace.source.source === "git"
           ) {
-            if (!isGitAvailable) {
-              logWarn(
-                `Skipping update for Git/GitHub marketplace "${marketplace.name}" because Git is not installed.`,
-              );
-              continue;
-            }
-            const targetPath = this.getMarketplacePath(marketplace.source);
-            if (existsSync(targetPath)) {
-              await this.gitService.pull(targetPath);
-            } else {
-              let url: string;
-              if (marketplace.source.source === "github") {
-                url = marketplace.source.repo;
-              } else {
-                url = marketplace.source.url;
+            if (!mirrorUpdated) {
+              if (!isGitAvailable) {
+                logWarn(
+                  `Skipping update for Git/GitHub marketplace "${marketplace.name}" because Git is not installed.`,
+                );
+                continue;
               }
-              await this.gitService.clone(
-                url,
-                targetPath,
-                marketplace.source.ref,
-              );
+              const targetPath = this.getMarketplacePath(marketplace.source);
+              if (existsSync(targetPath)) {
+                await this.gitService.pull(targetPath);
+              } else {
+                let url: string;
+                if (marketplace.source.source === "github") {
+                  url = marketplace.source.repo;
+                } else {
+                  url = marketplace.source.url;
+                }
+                await this.gitService.clone(
+                  url,
+                  targetPath,
+                  marketplace.source.ref,
+                );
+              }
             }
           }
           const manifest = await this.loadMarketplaceManifest(

--- a/packages/agent-sdk/src/services/MarketplaceService.ts
+++ b/packages/agent-sdk/src/services/MarketplaceService.ts
@@ -14,7 +14,6 @@ import { GitService } from "./GitService.js";
 import {
   ALLOW_OFFICIAL_MARKET_GIT_FALLBACK,
   fetchOfficialMarketplaceFromMirror,
-  resolveOfficialMarketplaceMirrorBaseUrl,
 } from "./officialMarketplaceMirror.js";
 import { ConfigurationService } from "./configurationService.js";
 import type { MarketplaceConfig, Scope } from "../types/configuration.js";
@@ -715,12 +714,12 @@ export class MarketplaceService {
           // (content-addressed zip over a plain HTTP base, no git/GitHub
           // needed). Only the builtin is special-cased by name — its
           // `source` stays "github" in settings/cache, so there is zero
-          // data migration. On mirror failure fall back to the git path
-          // unless the kill switch forbids it.
+          // data migration. On mirror failure (e.g. prod URL not yet live)
+          // fall back to the git path unless the kill switch forbids it.
           const isOfficialBuiltin =
             marketplace.name === MarketplaceService.BUILTIN_MARKETPLACE.name;
           let mirrorUpdated = false;
-          if (isOfficialBuiltin && resolveOfficialMarketplaceMirrorBaseUrl()) {
+          if (isOfficialBuiltin) {
             const targetPath = this.getMarketplacePath(marketplace.source);
             const mirrorSha = await fetchOfficialMarketplaceFromMirror(
               targetPath,

--- a/packages/agent-sdk/src/services/officialMarketplaceMirror.ts
+++ b/packages/agent-sdk/src/services/officialMarketplaceMirror.ts
@@ -39,12 +39,19 @@ export const OFFICIAL_MARKET_SENTINEL_FILE = ".wave-market-sha";
 const STAGING_SUFFIX = ".staging";
 
 /**
- * Default mirror base URL. TODO(official-market-mirror): 发布侧（codechat file
- * center）的 URL 落地后回填，例如
- * `https://<file-center>/codechat/<wave-plugins-official>`。未回填（空串）时镜像
- * 通道关闭、官方市场保持既有 git 路径。
+ * Default mirror base URL (prod contract) — files hang directly off this base:
+ * `{base}/latest` (pure-text sha) and `{base}/{sha}.zip` (whole-tree snapshot).
+ * Trailing slash is normalized away when composing URLs.
+ *
+ * - PROD: `https://codechat.codewave.163.com/wave-plugins-official/`
+ * - TEST（验证用）: `https://codechat.codewave-test.163yun.com/wave-plugins-official/`
+ *
+ * Override with env var `WAVE_OFFICIAL_MARKET_MIRROR_BASE_URL` (highest
+ * precedence). 注意：prod 该 URL 的 ingress/内容尚未上线，镜像请求会 404 → 按既有
+ * 设计回退 git 兜底（ALLOW_OFFICIAL_MARKET_GIT_FALLBACK），行为安全。
  */
-const DEFAULT_OFFICIAL_MARKET_MIRROR_BASE_URL = "";
+const DEFAULT_OFFICIAL_MARKET_MIRROR_BASE_URL =
+  "https://codechat.codewave.163.com/wave-plugins-official/";
 
 /** Env var override for the mirror base URL (highest precedence). */
 export const OFFICIAL_MARKET_MIRROR_BASE_URL_ENV =

--- a/packages/agent-sdk/src/services/officialMarketplaceMirror.ts
+++ b/packages/agent-sdk/src/services/officialMarketplaceMirror.ts
@@ -1,0 +1,349 @@
+/**
+ * Builtin official marketplace zip-snapshot mirror fetch.
+ *
+ * The official marketplace (wave-plugins-official, BUILTIN in MarketplaceService)
+ * is hosted on GitHub, which is poorly reachable from CN networks. Instead of a
+ * dumb-HTTP git endpoint we mirror the "content-addressed zip + latest pointer +
+ * local sentinel" model Claude Code uses for its official marketplace
+ * (officialMarketplaceGcs.ts, inc-5046):
+ *
+ *   1. GET `{base}/latest` (10s timeout) → content-addressed sha
+ *   2. Compare against the local sentinel `.wave-market-sha` at the market root
+ *      — equal ⇒ no-op (idempotent, one ~40B request per run)
+ *   3. GET `{base}/{sha}.zip` (60s timeout) → extract into a `.staging` dir
+ *      (path-traversal/absolute-path rejection, size limits, exec-bit restore
+ *      from zip external attrs)
+ *   4. Atomic swap: rm old market dir + rename staging → market dir, write the
+ *      sentinel back
+ *
+ * Any failure returns null; the caller decides whether to fall through to the
+ * existing git path (guarded by a kill switch, mirroring Claude's
+ * tengu_plugin_official_mkt_git_fallback flag).
+ */
+
+import {
+  chmod,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { dirname, join, resolve, sep } from "node:path";
+import { unzipSync } from "fflate";
+import { logWarn } from "../utils/globalLogger.js";
+
+/** Sentinel file name stored at the market root holding the last fetched sha. */
+export const OFFICIAL_MARKET_SENTINEL_FILE = ".wave-market-sha";
+/** Suffix of the staging dir used for atomic swap into the market root. */
+const STAGING_SUFFIX = ".staging";
+
+/**
+ * Default mirror base URL. TODO(official-market-mirror): 发布侧（codechat file
+ * center）的 URL 落地后回填，例如
+ * `https://<file-center>/codechat/<wave-plugins-official>`。未回填（空串）时镜像
+ * 通道关闭、官方市场保持既有 git 路径。
+ */
+const DEFAULT_OFFICIAL_MARKET_MIRROR_BASE_URL = "";
+
+/** Env var override for the mirror base URL (highest precedence). */
+export const OFFICIAL_MARKET_MIRROR_BASE_URL_ENV =
+  "WAVE_OFFICIAL_MARKET_MIRROR_BASE_URL";
+
+/**
+ * Kill switch for the git fallback after a mirror failure (default: allowed).
+ * Mirrors Claude Code's `tengu_plugin_official_mkt_git_fallback` flag. When
+ * false and the mirror fails, the builtin marketplace update is skipped
+ * (retried on next run) instead of hitting GitHub.
+ */
+export const ALLOW_OFFICIAL_MARKET_GIT_FALLBACK = true;
+
+const LATEST_TIMEOUT_MS = 10_000;
+const ZIP_TIMEOUT_MS = 60_000;
+
+// Sanity limits against corrupt/malicious archives (zip bombs). The publisher
+// is first-party, so these are corruption guards rather than a trust boundary;
+// values follow the Claude Code reference (utils/dxt/zip.ts).
+const ZIP_LIMITS = {
+  MAX_SINGLE_FILE_SIZE: 512 * 1024 * 1024, // per-file uncompressed
+  MAX_TOTAL_SIZE: 1024 * 1024 * 1024, // total uncompressed
+  MAX_FILE_COUNT: 100_000,
+  MAX_COMPRESSION_RATIO: 50, // uncompressed : compressed
+} as const;
+
+/**
+ * Resolves the mirror base URL: env var wins, otherwise the built-in constant.
+ * Returns null when neither is configured (mirror channel disabled).
+ */
+export function resolveOfficialMarketplaceMirrorBaseUrl(): string | null {
+  const envUrl = process.env[OFFICIAL_MARKET_MIRROR_BASE_URL_ENV];
+  const candidate =
+    (envUrl && envUrl.trim()) || DEFAULT_OFFICIAL_MARKET_MIRROR_BASE_URL;
+  if (!candidate) return null;
+  return candidate.replace(/\/+$/, ""); // normalize trailing slashes
+}
+
+/**
+ * Rejects zip entry paths that would escape the extraction root: absolute
+ * paths (POSIX or Windows drive/UNC), `..` segments, and null bytes. Paths
+ * use either `/` or `\` as separator. Returns the normalized relative path on
+ * success or null for entries that must be skipped (empty/directory-only is
+ * handled by the caller via the trailing `/`).
+ */
+export function sanitizeZipEntryPath(entryPath: string): string | null {
+  if (!entryPath || entryPath.includes("\0")) return null;
+  if (entryPath.startsWith("/") || entryPath.startsWith("\\")) return null;
+  const segments = entryPath.split(/[\\/]/);
+  // A drive-letter prefix (Windows "C:/…") must not slip through as relative.
+  if (segments[0] && /^[A-Za-z]:$/.test(segments[0])) return null;
+  for (const seg of segments) {
+    if (seg === "..") return null;
+  }
+  return entryPath;
+}
+
+/**
+ * Fetches the official marketplace from the zip-snapshot mirror and extracts
+ * it to installLocation. Idempotent — compares the local `.wave-market-sha`
+ * sentinel before downloading.
+ *
+ * @param installLocation where to extract (must be inside marketplacesCacheDir)
+ * @param marketplacesCacheDir the marketplace cache root (defense-in-depth:
+ *   this function `rm`s installLocation during the atomic swap)
+ * @param baseUrl optional explicit base URL (tests); defaults to env/constant
+ * @returns the fetched sha on success (including no-op), null on any failure
+ *   (unconfigured mirror, network, 404, corrupt zip, unsafe entries). Caller
+ *   decides whether to fall through to git.
+ */
+export async function fetchOfficialMarketplaceFromMirror(
+  installLocation: string,
+  marketplacesCacheDir: string,
+  baseUrl?: string,
+): Promise<string | null> {
+  // Defense in depth: this function does `rm(installLocation, {recursive})`
+  // during the atomic swap. A corrupted known_marketplaces.json could point
+  // at the user's project. Refuse any path outside the marketplace cache dir.
+  // Same guard as Claude's officialMarketplaceGcs.ts:57-65.
+  const cacheDir = resolve(marketplacesCacheDir);
+  const resolvedLoc = resolve(installLocation);
+  if (resolvedLoc !== cacheDir && !resolvedLoc.startsWith(cacheDir + sep)) {
+    logWarn(
+      `Official marketplace mirror: refusing install location outside marketplaces cache dir: ${installLocation}`,
+    );
+    return null;
+  }
+
+  const effectiveBase = baseUrl ?? resolveOfficialMarketplaceMirrorBaseUrl();
+  if (!effectiveBase) return null; // mirror not configured
+
+  try {
+    // 1. Latest pointer — tiny request, hit on every startup.
+    const latestText = await httpGetText(
+      `${effectiveBase}/latest`,
+      LATEST_TIMEOUT_MS,
+    );
+    const sha = latestText.trim();
+    if (!sha) {
+      // Empty /latest body — mirror misconfigured. Bail (null), don't lock
+      // into a permanently-broken empty-sentinel state.
+      throw new Error(
+        "Official marketplace mirror: latest pointer returned empty body",
+      );
+    }
+    // sha is interpolated into a URL — keep it a sane opaque token.
+    if (!/^[^\s/\\]+$/.test(sha)) {
+      throw new Error(
+        `Official marketplace mirror: invalid sha from latest pointer`,
+      );
+    }
+
+    // 2. Sentinel check.
+    const currentSha = await readFile(
+      join(installLocation, OFFICIAL_MARKET_SENTINEL_FILE),
+      "utf8",
+    )
+      .then((s) => s.trim())
+      .catch(() => null); // ENOENT — first fetch, proceed to download
+    if (currentSha === sha) return sha;
+
+    // 3. Download zip and extract to a staging dir, then atomic-swap into
+    //    place. A crash mid-extract leaves a .staging dir (rm'd on the next
+    //    run) rather than a half-written installLocation.
+    const zipBuf = await httpGetBuffer(
+      `${effectiveBase}/${sha}.zip`,
+      ZIP_TIMEOUT_MS,
+    );
+    const zipState: ZipValidationState = {
+      fileCount: 0,
+      totalUncompressed: 0,
+      compressedSize: zipBuf.length,
+    };
+    const files = unzipSync(new Uint8Array(zipBuf), {
+      filter: (file) => {
+        validateZipEntry(file.name, file.originalSize, zipState);
+        return true;
+      },
+    });
+    // fflate doesn't surface external_attr, so parse the central directory
+    // ourselves to recover exec bits. Without this, hooks/scripts extract as
+    // 0644 and fail to execute — git clone preserves +x natively, so the zip
+    // path must too.
+    const modes = parseZipModes(zipBuf);
+
+    const staging = `${installLocation}${STAGING_SUFFIX}`;
+    await rm(staging, { recursive: true, force: true });
+    await mkdir(staging, { recursive: true });
+    for (const [entryName, data] of Object.entries(files)) {
+      if (!entryName || entryName.endsWith("/")) continue; // dir entries
+      const rel = sanitizeZipEntryPath(entryName);
+      if (!rel) continue; // validated in filter; skip defensively
+      const dest = join(staging, rel);
+      await mkdir(dirname(dest), { recursive: true });
+      await writeFile(dest, data);
+      const mode = modes[entryName];
+      if (mode && mode & 0o111) {
+        // Only chmod when an exec bit is set — skip plain files to save
+        // syscalls. Swallow EPERM/ENOTSUP (read-only mounts) — losing +x is
+        // better than aborting mid-extraction.
+        await chmod(dest, mode & 0o777).catch(() => {});
+      }
+    }
+    await writeFile(join(staging, OFFICIAL_MARKET_SENTINEL_FILE), sha);
+
+    // 4. Atomic swap: rm old, rename staging. Brief window where
+    //    installLocation doesn't exist — acceptable for a background refresh
+    //    (next run re-downloads if it crashes here).
+    await rm(installLocation, { recursive: true, force: true });
+    await rename(staging, installLocation);
+
+    return sha;
+  } catch (error) {
+    logWarn(
+      `Official marketplace mirror fetch failed (falling back per caller policy): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return null;
+  }
+}
+
+interface ZipValidationState {
+  fileCount: number;
+  totalUncompressed: number;
+  compressedSize: number;
+}
+
+/**
+ * Validates one zip entry (called from the fflate filter). Throws to abort the
+ * whole extraction when an entry is unsafe or the archive exceeds limits.
+ */
+export function validateZipEntry(
+  name: string,
+  originalSize: number,
+  state: ZipValidationState,
+): void {
+  state.fileCount++;
+  if (state.fileCount > ZIP_LIMITS.MAX_FILE_COUNT) {
+    throw new Error(
+      `Official marketplace zip contains too many files (${state.fileCount}, max ${ZIP_LIMITS.MAX_FILE_COUNT})`,
+    );
+  }
+  const clean = sanitizeZipEntryPath(name);
+  if (!clean) {
+    // Reject unsafe entries (path traversal, absolute paths, null bytes).
+    // Directory entries are validated too — a `../` dir entry aborts.
+    throw new Error(`Official marketplace zip contains unsafe path: "${name}"`);
+  }
+  if (originalSize > ZIP_LIMITS.MAX_SINGLE_FILE_SIZE) {
+    throw new Error(
+      `Official marketplace zip entry "${name}" too large (${originalSize} bytes, max ${ZIP_LIMITS.MAX_SINGLE_FILE_SIZE})`,
+    );
+  }
+  state.totalUncompressed += originalSize;
+  if (state.totalUncompressed > ZIP_LIMITS.MAX_TOTAL_SIZE) {
+    throw new Error(
+      `Official marketplace zip total size exceeds ${ZIP_LIMITS.MAX_TOTAL_SIZE} bytes`,
+    );
+  }
+  if (
+    state.compressedSize > 0 &&
+    state.totalUncompressed / state.compressedSize >
+      ZIP_LIMITS.MAX_COMPRESSION_RATIO
+  ) {
+    throw new Error(
+      `Official marketplace zip suspicious compression ratio (>${ZIP_LIMITS.MAX_COMPRESSION_RATIO}:1) — possible zip bomb`,
+    );
+  }
+}
+
+async function httpGetText(url: string, timeoutMs: number): Promise<string> {
+  const response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} fetching ${url}`);
+  }
+  return response.text();
+}
+
+async function httpGetBuffer(url: string, timeoutMs: number): Promise<Buffer> {
+  const response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} fetching ${url}`);
+  }
+  return Buffer.from(await response.arrayBuffer());
+}
+
+/**
+ * Parse Unix file modes from a zip's central directory.
+ *
+ * fflate's `unzipSync` returns only `Record<string, Uint8Array>` — it does not
+ * surface the external file attributes stored in the central directory, so
+ * executable bits would be lost (everything extracts as 0644). Returns
+ * `name → mode` for entries created on a Unix host (`versionMadeBy` high byte
+ * === 3); other entries are omitted and extract with default mode.
+ *
+ * Format per PKZIP APPNOTE.TXT §4.3.12 (central directory) and §4.3.16 (EOCD).
+ * ZIP64 is not handled — returns `{}` on archives >4GB or >65535 entries,
+ * which is fine for marketplace zips.
+ */
+export function parseZipModes(data: Uint8Array): Record<string, number> {
+  const buf = Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+  const modes: Record<string, number> = {};
+
+  // 1. Find the End of Central Directory record (sig 0x06054b50). Scan
+  //    backwards from the trailing 22 + max-comment bytes.
+  const minEocd = Math.max(0, buf.length - 22 - 0xffff);
+  let eocd = -1;
+  for (let i = buf.length - 22; i >= minEocd; i--) {
+    if (buf.readUInt32LE(i) === 0x06054b50) {
+      eocd = i;
+      break;
+    }
+  }
+  if (eocd < 0) return modes; // malformed — the unzip error surfaces separately
+
+  const entryCount = buf.readUInt16LE(eocd + 10);
+  let off = buf.readUInt32LE(eocd + 16);
+
+  // 2. Walk central directory entries (sig 0x02014b50). Each entry has a
+  //    46-byte fixed header followed by variable-length name/extra/comment.
+  for (let i = 0; i < entryCount; i++) {
+    if (off + 46 > buf.length || buf.readUInt32LE(off) !== 0x02014b50) break;
+    const versionMadeBy = buf.readUInt16LE(off + 4);
+    const nameLen = buf.readUInt16LE(off + 28);
+    const extraLen = buf.readUInt16LE(off + 30);
+    const commentLen = buf.readUInt16LE(off + 32);
+    const externalAttr = buf.readUInt32LE(off + 38);
+    const name = buf.toString("utf8", off + 46, off + 46 + nameLen);
+
+    // versionMadeBy high byte = host OS. 3 = Unix. For Unix zips the high 16
+    // bits of externalAttr hold st_mode (file type + permission bits).
+    if (versionMadeBy >> 8 === 3) {
+      const mode = (externalAttr >>> 16) & 0xffff;
+      if (mode) modes[name] = mode;
+    }
+
+    off += 46 + nameLen + extraLen + commentLen;
+  }
+
+  return modes;
+}

--- a/packages/agent-sdk/tests/services/MarketplaceService.mirror.test.ts
+++ b/packages/agent-sdk/tests/services/MarketplaceService.mirror.test.ts
@@ -122,6 +122,8 @@ let server: http.Server;
 let serverPort = 0;
 /** latest pointer body; empty string means "return empty". */
 let latestBody = "";
+/** HTTP status for /latest (200 default; 404 simulates prod not yet online). */
+let latestStatus = 200;
 const zipBySha = new Map<string, Buffer>();
 /** Request URLs hit on the server since the last clear. */
 let requestLog: string[] = [];
@@ -131,7 +133,7 @@ beforeAll(async () => {
     const url = req.url ?? "/";
     requestLog.push(url);
     if (url === "/latest") {
-      res.writeHead(200, { "content-type": "text/plain" });
+      res.writeHead(latestStatus, { "content-type": "text/plain" });
       res.end(latestBody);
       return;
     }
@@ -165,6 +167,7 @@ function mirrorBaseUrl(): string {
 
 function clearMirrorState(): void {
   latestBody = "";
+  latestStatus = 200;
   zipBySha.clear();
   requestLog = [];
 }
@@ -234,8 +237,10 @@ describe("officialMarketplaceMirror (zip snapshot)", () => {
   });
 
   describe("resolveOfficialMarketplaceMirrorBaseUrl", () => {
-    it("returns null when neither env nor constant is configured", () => {
-      expect(resolveOfficialMarketplaceMirrorBaseUrl()).toBeNull();
+    it("returns the prod default base URL when env is not configured", () => {
+      expect(resolveOfficialMarketplaceMirrorBaseUrl()).toBe(
+        "https://codechat.codewave.163.com/wave-plugins-official",
+      );
     });
 
     it("prefers the env var over the default constant", () => {
@@ -453,7 +458,8 @@ describe("officialMarketplaceMirror (zip snapshot)", () => {
   });
 
   describe("MarketplaceService.updateMarketplace mirror routing", () => {
-    it("keeps using the git path when the mirror URL is not configured", async () => {
+    it("falls back to git when the mirror 404s (prod content not yet online)", async () => {
+      process.env[OFFICIAL_MARKET_MIRROR_BASE_URL_ENV] = mirrorBaseUrl();
       await fs.mkdir(path.join(installLocation, ".wave-plugin"), {
         recursive: true,
       });
@@ -462,13 +468,14 @@ describe("officialMarketplaceMirror (zip snapshot)", () => {
         MARKETPLACE_MANIFEST,
       );
 
-      // No env var → resolveOfficialMarketplaceMirrorBaseUrl() is null.
+      // Prod ingress/content is not yet live → /latest returns 404.
+      latestStatus = 404;
       await service.updateMarketplace("wave-plugins-official");
 
+      // Mirror tried, failed → git fallback (kill switch defaults to allowed).
+      expect(requestLog).toEqual(["/latest"]);
       expect(mockGitService.pull).toHaveBeenCalledWith(installLocation);
       expect(mockGitService.clone).not.toHaveBeenCalled();
-      // No HTTP mirror request of any kind.
-      expect(requestLog).toHaveLength(0);
     });
 
     it("falls back to git pull when the mirror zip is corrupt", async () => {
@@ -531,9 +538,12 @@ describe("officialMarketplaceMirror (zip snapshot)", () => {
       expect(sentinel).toBe("sha-aaaa");
     });
 
-    it("skips the official marketplace when git is unavailable and no mirror is configured", async () => {
+    it("skips the official marketplace when the mirror fails and git is unavailable", async () => {
+      process.env[OFFICIAL_MARKET_MIRROR_BASE_URL_ENV] = mirrorBaseUrl();
       mockGitService.isGitAvailable.mockResolvedValue(false);
       await service.updateMarketplace("wave-plugins-official");
+      // Mirror probed (local server /latest 404s), then git skip applies.
+      expect(requestLog).toEqual(["/latest"]);
       expect(mockGitService.pull).not.toHaveBeenCalled();
       expect(mockGitService.clone).not.toHaveBeenCalled();
     });

--- a/packages/agent-sdk/tests/services/MarketplaceService.mirror.test.ts
+++ b/packages/agent-sdk/tests/services/MarketplaceService.mirror.test.ts
@@ -1,0 +1,541 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+} from "vitest";
+import * as http from "node:http";
+import { promises as fs, existsSync } from "node:fs";
+import * as path from "node:path";
+import { strToU8, zipSync } from "fflate";
+
+import { MarketplaceService } from "../../src/services/MarketplaceService.js";
+import { GitService } from "../../src/services/GitService.js";
+import {
+  fetchOfficialMarketplaceFromMirror,
+  parseZipModes,
+  resolveOfficialMarketplaceMirrorBaseUrl,
+  OFFICIAL_MARKET_MIRROR_BASE_URL_ENV,
+} from "../../src/services/officialMarketplaceMirror.js";
+import { getPluginsDir } from "../../src/utils/configPaths.js";
+
+vi.mock("../../src/services/GitService.js");
+
+vi.mock("../../src/utils/configPaths.js", () => ({
+  getPluginsDir: vi.fn(),
+}));
+
+vi.mock("../../src/services/configurationService.js", () => {
+  return {
+    ConfigurationService: class MockConfigService {
+      getMergedMarketplaces = vi.fn(() => ({
+        "wave-plugins-official": {
+          source: {
+            source: "github",
+            repo: "netease-lcap/wave-plugins-official",
+          },
+          autoUpdate: true,
+        },
+      }));
+      getScopedMarketplaces = vi.fn(() => ({}));
+      addMarketplaceToScope = vi.fn(() => Promise.resolve());
+      removeMarketplaceFromScope = vi.fn(() => Promise.resolve());
+      getMergedEnabledPlugins = vi.fn(() => ({}));
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+const MARKETPLACE_MANIFEST = JSON.stringify({
+  name: "wave-plugins-official",
+  owner: { name: "wave" },
+  plugins: [
+    { name: "demo-plugin", source: "./plugins/demo-plugin", description: "" },
+  ],
+});
+
+const PLUGIN_JSON = JSON.stringify({ name: "demo-plugin", version: "1.0.0" });
+
+/** Builds a zip via fflate (deflate) for the given { path: content } entries. */
+function buildZip(entries: Record<string, string>): Buffer {
+  const zippable: Record<string, Uint8Array> = {};
+  for (const [p, content] of Object.entries(entries)) {
+    zippable[p] = strToU8(content);
+  }
+  return Buffer.from(zipSync(zippable));
+}
+
+/** Builds a valid official-marketplace snapshot zip. */
+function buildMarketZip(extra?: Record<string, string>): Buffer {
+  return buildZip({
+    ".wave-plugin/marketplace.json": MARKETPLACE_MANIFEST,
+    "plugins/demo-plugin/.wave-plugin/plugin.json": PLUGIN_JSON,
+    ...(extra ?? {}),
+  });
+}
+
+/**
+ * Patches the central directory of an fflate-built zip so entries get Unix
+ * modes (versionMadeBy host=3, externalAttr = mode << 16) — fflate's zipSync
+ * doesn't expose external attrs, so parseZipModes/exec-bit restore can't be
+ * exercised without this.
+ */
+function withUnixModes(zip: Buffer, modes: Record<string, number>): Buffer {
+  const buf = Buffer.from(zip);
+  let eocd = -1;
+  for (let i = buf.length - 22; i >= 0; i--) {
+    if (buf.readUInt32LE(i) === 0x06054b50) {
+      eocd = i;
+      break;
+    }
+  }
+  if (eocd < 0) throw new Error("no EOCD");
+  const count = buf.readUInt16LE(eocd + 10);
+  let off = buf.readUInt32LE(eocd + 16);
+  for (let i = 0; i < count; i++) {
+    const nameLen = buf.readUInt16LE(off + 28);
+    const extraLen = buf.readUInt16LE(off + 30);
+    const commentLen = buf.readUInt16LE(off + 32);
+    const name = buf.toString("utf8", off + 46, off + 46 + nameLen);
+    const mode = modes[name];
+    if (mode !== undefined) {
+      buf.writeUInt16LE(3 << 8, off + 4); // versionMadeBy: host = Unix(3)
+      buf.writeUInt32LE(mode << 16, off + 38); // external attrs: st_mode
+    }
+    off += 46 + nameLen + extraLen + commentLen;
+  }
+  return buf;
+}
+
+// ---------------------------------------------------------------------------
+// Local HTTP mirror server
+// ---------------------------------------------------------------------------
+
+let server: http.Server;
+let serverPort = 0;
+/** latest pointer body; empty string means "return empty". */
+let latestBody = "";
+const zipBySha = new Map<string, Buffer>();
+/** Request URLs hit on the server since the last clear. */
+let requestLog: string[] = [];
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    const url = req.url ?? "/";
+    requestLog.push(url);
+    if (url === "/latest") {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end(latestBody);
+      return;
+    }
+    const m = url.match(/^\/(.+)\.zip$/);
+    const sha = m ? decodeURIComponent(m[1]) : null;
+    if (sha && zipBySha.has(sha)) {
+      res.writeHead(200, { "content-type": "application/octet-stream" });
+      res.end(zipBySha.get(sha));
+      return;
+    }
+    res.writeHead(404);
+    res.end("not found");
+  });
+  await new Promise<void>((resolve) =>
+    server.listen(0, "127.0.0.1", () => resolve()),
+  );
+  const addr = server.address();
+  if (!addr || typeof addr === "string") throw new Error("no server addr");
+  serverPort = addr.port;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve())),
+  );
+});
+
+function mirrorBaseUrl(): string {
+  return `http://127.0.0.1:${serverPort}`;
+}
+
+function clearMirrorState(): void {
+  latestBody = "";
+  zipBySha.clear();
+  requestLog = [];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("officialMarketplaceMirror (zip snapshot)", () => {
+  const mockPluginsDir = path.join(process.cwd(), "tmp-test-plugins-mirror");
+  const marketplacesDir = path.join(mockPluginsDir, "marketplaces");
+  const installLocation = path.join(
+    marketplacesDir,
+    "netease-lcap",
+    "wave-plugins-official",
+  );
+  let service: MarketplaceService;
+  let mockGitService: {
+    clone: ReturnType<typeof vi.fn>;
+    pull: ReturnType<typeof vi.fn>;
+    isGitAvailable: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(getPluginsDir).mockReturnValue(mockPluginsDir);
+    if (existsSync(mockPluginsDir)) {
+      await fs.rm(mockPluginsDir, { recursive: true, force: true });
+    }
+    await fs.mkdir(mockPluginsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(mockPluginsDir, "known_marketplaces.json"),
+      JSON.stringify({ builtinSeeded: true, marketplaces: [] }),
+    );
+
+    mockGitService = {
+      clone: vi.fn().mockResolvedValue(undefined),
+      pull: vi.fn().mockResolvedValue(undefined),
+      isGitAvailable: vi.fn().mockResolvedValue(true),
+    };
+    vi.mocked(GitService).mockImplementation(function () {
+      return mockGitService as unknown as GitService;
+    });
+
+    service = new MarketplaceService();
+    await (service as unknown as { _seedComplete: Promise<void> })
+      ._seedComplete;
+    (
+      MarketplaceService as unknown as { isLockedInProcess: boolean }
+    ).isLockedInProcess = false;
+
+    delete process.env[OFFICIAL_MARKET_MIRROR_BASE_URL_ENV];
+    clearMirrorState();
+  });
+
+  afterEach(async () => {
+    delete process.env[OFFICIAL_MARKET_MIRROR_BASE_URL_ENV];
+    try {
+      if (existsSync(mockPluginsDir)) {
+        await fs.rm(mockPluginsDir, { recursive: true, force: true });
+      }
+    } catch {
+      // ignore cleanup races with async constructor ops
+    }
+    vi.restoreAllMocks();
+  });
+
+  describe("resolveOfficialMarketplaceMirrorBaseUrl", () => {
+    it("returns null when neither env nor constant is configured", () => {
+      expect(resolveOfficialMarketplaceMirrorBaseUrl()).toBeNull();
+    });
+
+    it("prefers the env var over the default constant", () => {
+      process.env[OFFICIAL_MARKET_MIRROR_BASE_URL_ENV] =
+        "https://example.com/base/";
+      expect(resolveOfficialMarketplaceMirrorBaseUrl()).toBe(
+        "https://example.com/base",
+      );
+    });
+  });
+
+  describe("fetchOfficialMarketplaceFromMirror", () => {
+    it("no-ops when the local sentinel already matches the latest sha", async () => {
+      await fs.mkdir(installLocation, { recursive: true });
+      await fs.writeFile(
+        path.join(installLocation, ".wave-market-sha"),
+        "sha-aaaa",
+      );
+      latestBody = "sha-aaaa";
+      zipBySha.set("sha-aaaa", buildMarketZip());
+
+      const result = await fetchOfficialMarketplaceFromMirror(
+        installLocation,
+        marketplacesDir,
+        mirrorBaseUrl(),
+      );
+
+      expect(result).toBe("sha-aaaa");
+      // Only the tiny /latest probe — the zip must never be downloaded.
+      expect(requestLog).toEqual(["/latest"]);
+    });
+
+    it("downloads a new sha once and atomically swaps it into place", async () => {
+      // First fetch: full download.
+      latestBody = "sha-aaaa";
+      zipBySha.set("sha-aaaa", buildMarketZip({ "README.md": "v1" }));
+
+      const first = await fetchOfficialMarketplaceFromMirror(
+        installLocation,
+        marketplacesDir,
+        mirrorBaseUrl(),
+      );
+      expect(first).toBe("sha-aaaa");
+      expect(requestLog).toEqual(["/latest", "/sha-aaaa.zip"]);
+      expect(
+        await fs.readFile(path.join(installLocation, "README.md"), "utf8"),
+      ).toBe("v1");
+      expect(
+        await fs.readFile(
+          path.join(installLocation, ".wave-market-sha"),
+          "utf8",
+        ),
+      ).toBe("sha-aaaa");
+      expect(
+        existsSync(
+          path.join(installLocation, ".wave-plugin", "marketplace.json"),
+        ),
+      ).toBe(true);
+
+      // No stray staging residue after success.
+      expect(existsSync(`${installLocation}.staging`)).toBe(false);
+
+      // Second fetch with a changed sha replaces content atomically.
+      clearMirrorState();
+      latestBody = "sha-bbbb";
+      zipBySha.set("sha-bbbb", buildMarketZip({ "README.md": "v2" }));
+      const second = await fetchOfficialMarketplaceFromMirror(
+        installLocation,
+        marketplacesDir,
+        mirrorBaseUrl(),
+      );
+      expect(second).toBe("sha-bbbb");
+      expect(requestLog).toEqual(["/latest", "/sha-bbbb.zip"]);
+      expect(
+        await fs.readFile(path.join(installLocation, "README.md"), "utf8"),
+      ).toBe("v2");
+      expect(
+        await fs.readFile(
+          path.join(installLocation, ".wave-market-sha"),
+          "utf8",
+        ),
+      ).toBe("sha-bbbb");
+    });
+
+    it("returns null on an empty /latest body (mirror misconfigured)", async () => {
+      latestBody = "   \n"; // whitespace-only body trims to empty
+      const result = await fetchOfficialMarketplaceFromMirror(
+        installLocation,
+        marketplacesDir,
+        mirrorBaseUrl(),
+      );
+      expect(result).toBeNull();
+      expect(existsSync(installLocation)).toBe(false); // nothing installed
+    });
+
+    it("returns null on a 404 from /latest", async () => {
+      // No routes configured — server returns 404 for everything.
+      const result = await fetchOfficialMarketplaceFromMirror(
+        installLocation,
+        marketplacesDir,
+        mirrorBaseUrl(),
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns null on a corrupt zip and leaves existing content untouched", async () => {
+      await fs.mkdir(installLocation, { recursive: true });
+      await fs.writeFile(path.join(installLocation, "keep.txt"), "keep");
+      await fs.writeFile(
+        path.join(installLocation, ".wave-market-sha"),
+        "sha-aaaa",
+      );
+      latestBody = "sha-corrupt";
+      zipBySha.set("sha-corrupt", Buffer.from("this is not a zip archive"));
+
+      const result = await fetchOfficialMarketplaceFromMirror(
+        installLocation,
+        marketplacesDir,
+        mirrorBaseUrl(),
+      );
+      expect(result).toBeNull();
+      expect(
+        await fs.readFile(path.join(installLocation, "keep.txt"), "utf8"),
+      ).toBe("keep");
+      // Sentinel unchanged → sentinel mismatch persists → retry on next run.
+      expect(
+        await fs.readFile(
+          path.join(installLocation, ".wave-market-sha"),
+          "utf8",
+        ),
+      ).toBe("sha-aaaa");
+    });
+
+    it("rejects zips with path traversal entries", async () => {
+      const evil = buildZip({
+        "../escaped.txt": "oops",
+        ".wave-plugin/marketplace.json": MARKETPLACE_MANIFEST,
+      });
+      latestBody = "sha-evil";
+      zipBySha.set("sha-evil", evil);
+
+      const result = await fetchOfficialMarketplaceFromMirror(
+        installLocation,
+        marketplacesDir,
+        mirrorBaseUrl(),
+      );
+      expect(result).toBeNull();
+      // Nothing escaped into the plugins dir (or anywhere else).
+      expect(existsSync(path.join(mockPluginsDir, "escaped.txt"))).toBe(false);
+      expect(existsSync(path.join(marketplacesDir, "escaped.txt"))).toBe(false);
+      expect(existsSync(installLocation)).toBe(false);
+    });
+
+    it("rejects zips with absolute-path entries", async () => {
+      const evil = buildZip({
+        "/tmp/wave-escaped.txt": "oops",
+        ".wave-plugin/marketplace.json": MARKETPLACE_MANIFEST,
+      });
+      latestBody = "sha-abs";
+      zipBySha.set("sha-abs", evil);
+      const result = await fetchOfficialMarketplaceFromMirror(
+        installLocation,
+        marketplacesDir,
+        mirrorBaseUrl(),
+      );
+      expect(result).toBeNull();
+      expect(existsSync("/tmp/wave-escaped.txt")).toBe(false);
+    });
+
+    it("restores executable bits from zip external attrs (hooks/scripts)", async () => {
+      const zip = withUnixModes(
+        buildZip({
+          ".wave-plugin/marketplace.json": MARKETPLACE_MANIFEST,
+          "plugins/demo-plugin/hooks/run.sh": "#!/bin/sh\necho ok\n",
+        }),
+        { "plugins/demo-plugin/hooks/run.sh": 0o755 },
+      );
+      const modes = parseZipModes(zip);
+      expect(modes["plugins/demo-plugin/hooks/run.sh"] & 0o111).toBeTruthy();
+
+      latestBody = "sha-exec";
+      zipBySha.set("sha-exec", zip);
+      const result = await fetchOfficialMarketplaceFromMirror(
+        installLocation,
+        marketplacesDir,
+        mirrorBaseUrl(),
+      );
+      expect(result).toBe("sha-exec");
+
+      const scriptPath = path.join(
+        installLocation,
+        "plugins/demo-plugin/hooks/run.sh",
+      );
+      const stat = await fs.stat(scriptPath);
+      expect(stat.mode & 0o111).toBeTruthy();
+      // Plain file without exec bits stays non-executable.
+      const jsonStat = await fs.stat(
+        path.join(installLocation, ".wave-plugin", "marketplace.json"),
+      );
+      expect(jsonStat.mode & 0o111).toBeFalsy();
+    });
+
+    it("refuses an install location outside the marketplaces cache dir", async () => {
+      const outside = path.join(mockPluginsDir, "not-marketplaces", "evil");
+      latestBody = "sha-aaaa";
+      zipBySha.set("sha-aaaa", buildMarketZip());
+      const result = await fetchOfficialMarketplaceFromMirror(
+        outside,
+        marketplacesDir,
+        mirrorBaseUrl(),
+      );
+      expect(result).toBeNull();
+      expect(existsSync(outside)).toBe(false);
+    });
+  });
+
+  describe("MarketplaceService.updateMarketplace mirror routing", () => {
+    it("keeps using the git path when the mirror URL is not configured", async () => {
+      await fs.mkdir(path.join(installLocation, ".wave-plugin"), {
+        recursive: true,
+      });
+      await fs.writeFile(
+        path.join(installLocation, ".wave-plugin", "marketplace.json"),
+        MARKETPLACE_MANIFEST,
+      );
+
+      // No env var → resolveOfficialMarketplaceMirrorBaseUrl() is null.
+      await service.updateMarketplace("wave-plugins-official");
+
+      expect(mockGitService.pull).toHaveBeenCalledWith(installLocation);
+      expect(mockGitService.clone).not.toHaveBeenCalled();
+      // No HTTP mirror request of any kind.
+      expect(requestLog).toHaveLength(0);
+    });
+
+    it("falls back to git pull when the mirror zip is corrupt", async () => {
+      process.env[OFFICIAL_MARKET_MIRROR_BASE_URL_ENV] = mirrorBaseUrl();
+      await fs.mkdir(path.join(installLocation, ".wave-plugin"), {
+        recursive: true,
+      });
+      await fs.writeFile(
+        path.join(installLocation, ".wave-plugin", "marketplace.json"),
+        MARKETPLACE_MANIFEST,
+      );
+      latestBody = "sha-corrupt";
+      zipBySha.set("sha-corrupt", Buffer.from("garbage-not-a-zip"));
+
+      await service.updateMarketplace("wave-plugins-official");
+
+      // Mirror tried, failed → git fallback (kill switch defaults to allowed).
+      expect(requestLog).toEqual(["/latest", "/sha-corrupt.zip"]);
+      expect(mockGitService.pull).toHaveBeenCalledWith(installLocation);
+      expect(mockGitService.clone).not.toHaveBeenCalled();
+    });
+
+    it("falls back to git clone when the mirror fails and no local copy exists", async () => {
+      process.env[OFFICIAL_MARKET_MIRROR_BASE_URL_ENV] = mirrorBaseUrl();
+      latestBody = "sha-corrupt";
+      zipBySha.set("sha-corrupt", Buffer.from("garbage-not-a-zip"));
+
+      // No local copy → git clone is attempted (and fails here since the mock
+      // clone does not materialize a marketplace) → update reports failure.
+      mockGitService.clone.mockResolvedValue(undefined);
+      await expect(
+        service.updateMarketplace("wave-plugins-official"),
+      ).rejects.toThrow("Some marketplaces failed to update");
+      expect(mockGitService.clone).toHaveBeenCalledWith(
+        "netease-lcap/wave-plugins-official",
+        installLocation,
+        undefined,
+      );
+    });
+
+    it("updates the official marketplace entirely via the mirror when it succeeds", async () => {
+      process.env[OFFICIAL_MARKET_MIRROR_BASE_URL_ENV] = mirrorBaseUrl();
+      latestBody = "sha-aaaa";
+      zipBySha.set("sha-aaaa", buildMarketZip());
+
+      await service.updateMarketplace("wave-plugins-official");
+
+      expect(requestLog).toEqual(["/latest", "/sha-aaaa.zip"]);
+      // No git interaction at all.
+      expect(mockGitService.pull).not.toHaveBeenCalled();
+      expect(mockGitService.clone).not.toHaveBeenCalled();
+      // Marketplace usable by the existing plugin installation flow.
+      const manifest = await service.loadMarketplaceManifest(installLocation);
+      expect(manifest.name).toBe("wave-plugins-official");
+      expect(manifest.plugins).toHaveLength(1);
+      const sentinel = await fs.readFile(
+        path.join(installLocation, ".wave-market-sha"),
+        "utf8",
+      );
+      expect(sentinel).toBe("sha-aaaa");
+    });
+
+    it("skips the official marketplace when git is unavailable and no mirror is configured", async () => {
+      mockGitService.isGitAvailable.mockResolvedValue(false);
+      await service.updateMarketplace("wave-plugins-official");
+      expect(mockGitService.pull).not.toHaveBeenCalled();
+      expect(mockGitService.clone).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       cron-parser:
         specifier: ^5.5.0
         version: 5.5.0
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       fuzzysort:
         specifier: ^3.1.0
         version: 3.1.0
@@ -3643,6 +3646,7 @@ packages:
   eslint@9.33.0:
     resolution: {integrity: sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -3739,6 +3743,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -8081,7 +8088,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.8.1))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.3)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.8.1))
 
   '@vitest/expect@4.1.7':
     dependencies:
@@ -9804,6 +9811,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fflate@0.8.3: {}
 
   file-entry-cache@8.0.0:
     dependencies:


### PR DESCRIPTION
## 背景
官方插件市场 wave-plugins-official（GitHub，BUILTIN，autoUpdate）国内访问受限。对齐 Claude Code 的非 Git zip 快照镜像模型（officialMarketplaceGcs.ts），把「市场获取」这一步从 git clone/pull 换成内容寻址 zip + latest 指针 + 本地哨兵。发布侧（codechat file center）由另一会话负责；本 PR 只落消费端。

## 变更
- **新增 `packages/agent-sdk/src/services/officialMarketplaceMirror.ts`**：`fetchOfficialMarketplaceFromMirror` 五步流
  1. GET `{base}/latest`（10s 超时）→ sha
  2. 读市场目录 `.wave-market-sha` 哨兵，相等 → no-op（幂等）
  3. GET `{base}/{sha}.zip`（60s 超时）→ fflate 解压到 `{installLocation}.staging`
  4. 原子换入（rm 旧 + rename）+ 写哨兵
  - **zip 安全**：路径穿越/绝对路径/Windows 盘符拒绝、文件数/单文件/总量/压缩比上限（zip bomb）；解压后按中央目录 external attrs 恢复可执行位（`parseZipModes`，hooks 脚本 +x，对齐 git clone 原生保留）
  - **路径守卫**：installLocation 必须在 marketplaces 缓存目录内（防 known_marketplaces.json 被污染后 rm 用户目录，对齐 Claude :57-65）
  - 任何失败 logWarn + 返回 null
- **MarketplaceService.updateMarketplace 按名称特判**：`wave-plugins-official` 且镜像已配置 → 先试镜像；成功跳过 git；失败回退既有 git pull/clone，受常量 `ALLOW_OFFICIAL_MARKET_GIT_FALLBACK`（默认 true）门控。`source` 字段保持 `github` 不变 → 零数据迁移、getMarketplacePath 不变
- **base URL**：环境变量 `WAVE_OFFICIAL_MARKET_MIRROR_BASE_URL` 优先；代码常量留 TODO 占位（当前为空 → 未配置时行为 = 现有 git 路径，不破坏已有用户）
- 依赖：agent-sdk 新增 `fflate@^0.8.3`（zip 解压）
- **spec `docs/specs/ecosystem/plugin.md`**：「内置官方市场」改写为镜像 zip 快照用户故事（+1 故事/+8 场景），远程获取章节与 A-008 注明官方市场专属 zip 例外；spec-count 84/464/2023，0 警告（基线 84/463/2015）

## 测试与验证
- 新增 `MarketplaceService.mirror.test.ts` 16 例（本地 HTTP server fixture，零真实网络）：哨兵相等 no-op（仅 /latest）、新 sha 下载一次+原子换入（含二次替换、无 staging 残留）、损坏 zip 报错回退 git pull、镜像失败且无本地副本回退 git clone、latest 空 body/404 返回 null、路径穿越与绝对路径 zip 拒绝、exec 位恢复、缓存目录外拒绝、镜像未配置走 git（git 守卫）
- agent-sdk test:unit：252 文件 / 3615 通过 / 2 跳过
- type-check：agent-sdk + wave-code 绿；oxlint 0；prettier clean；spec-count exit 0
- pre-commit：lint-staged + 141 links OK / 0 broken

## 遗留
- **镜像 base URL 常量待发布侧回填**（代码 TODO 注释点）；未回填/未设环境变量时镜像通道关闭，官方市场保持既有 git 路径
- kill-switch 为编译期常量（无运行期 flag 基建），关闭需改代码