### PR TITLE
fix(agent-sdk): resolve user-level subagent dirs via os.homedir() — Bug 3468358404099072 新建子代理调用不了

### DIFF
--- a/packages/agent-sdk/src/utils/subagentParser.ts
+++ b/packages/agent-sdk/src/utils/subagentParser.ts
@@ -1,4 +1,5 @@
 import { readFileSync, readdirSync, statSync } from "fs";
+import { homedir } from "os";
 import { join, extname, basename } from "path";
 import { logger } from "./globalLogger.js";
 import { getBuiltinSubagentsDir } from "./configPaths.js";
@@ -236,8 +237,14 @@ export async function loadSubagentConfigurations(
 ): Promise<SubagentConfiguration[]> {
   const projectWaveDir = join(workdir, ".wave", "agents");
   const projectClaudeDir = join(workdir, ".claude", "agents");
-  const userWaveDir = join(process.env.HOME || "~", ".wave", "agents");
-  const userClaudeDir = join(process.env.HOME || "~", ".claude", "agents");
+  // Resolve user-level dirs via os.homedir() (NOT process.env.HOME): every
+  // other user-path resolver in the SDK (settings, skills, MCP, rules, ~/
+  // expansion in the Write tool) uses os.homedir(), which on Windows falls
+  // back to USERPROFILE. Windows GUI-launched processes (Electron desktop)
+  // typically have no HOME set, so process.env.HOME made user-level subagents
+  // silently invisible there (`~/.wave/agents` resolved as a relative path).
+  const userWaveDir = join(homedir(), ".wave", "agents");
+  const userClaudeDir = join(homedir(), ".claude", "agents");
   const builtinDir = getBuiltinSubagentsDir();
 
   // Load configurations from all sources

--- a/packages/agent-sdk/tests/utils/subagentParser.test.ts
+++ b/packages/agent-sdk/tests/utils/subagentParser.test.ts
@@ -24,6 +24,14 @@ vi.mock("../../src/utils/globalLogger.js", () => ({
   },
 }));
 
+// User-level agent dirs are resolved via os.homedir() (the same portable
+// resolution every other user-path resolver in the SDK uses). Pin it so the
+// tests below are deterministic regardless of the machine running them.
+vi.mock("os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("os")>();
+  return { ...actual, homedir: () => "/home/testuser" };
+});
+
 describe("SubagentParser with Built-ins", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -219,10 +227,6 @@ test`;
     it("should handle priority override correctly", async () => {
       const mockFs = await import("fs");
 
-      // Mock HOME environment variable
-      const originalHome = process.env.HOME;
-      process.env.HOME = "/home/testuser";
-
       vi.mocked(mockFs.readdirSync).mockImplementation((dirPath) => {
         if (dirPath === "/builtin/subagents") {
           return ["explore.md"] as unknown as ReturnType<
@@ -263,9 +267,6 @@ Custom system prompt for user override`;
 
       const configs = await loadSubagentConfigurations("/test/workdir");
 
-      // Restore HOME
-      process.env.HOME = originalHome;
-
       // Should find the user config, not the built-in (higher priority)
       const exploreConfig = configs.find((c) => c.name === "explore");
       expect(exploreConfig?.scope).toBe("user"); // User config overrides built-in
@@ -277,8 +278,6 @@ Custom system prompt for user override`;
 
     it("should load subagents from .claude/agents directories", async () => {
       const mockFs = await import("fs");
-      const originalHome = process.env.HOME;
-      process.env.HOME = "/home/testuser";
 
       vi.mocked(mockFs.readdirSync).mockImplementation((dirPath) => {
         if (dirPath === path.join("/home/testuser", ".claude", "agents")) {
@@ -327,8 +326,6 @@ Project Claude agent system prompt`;
 
       const configs = await loadSubagentConfigurations("/test/workdir");
 
-      process.env.HOME = originalHome;
-
       const userClaudeAgent = configs.find((c) => c.name === "claude-agent");
       expect(userClaudeAgent).toBeDefined();
       expect(userClaudeAgent?.scope).toBe("user");
@@ -346,8 +343,6 @@ Project Claude agent system prompt`;
 
     it("should let .wave/agents override .claude/agents for same-named agent", async () => {
       const mockFs = await import("fs");
-      const originalHome = process.env.HOME;
-      process.env.HOME = "/home/testuser";
 
       vi.mocked(mockFs.readdirSync).mockImplementation((dirPath) => {
         if (
@@ -391,12 +386,62 @@ Wave version prompt`;
 
       const configs = await loadSubagentConfigurations("/test/workdir");
 
-      process.env.HOME = originalHome;
-
       const agent = configs.find((c) => c.name === "shared-agent");
       expect(agent).toBeDefined();
       expect(agent?.description).toBe("Wave version");
       expect(agent?.systemPrompt).toBe("Wave version prompt");
+    });
+
+    it("should find user-level subagents when HOME is unset (Windows desktop)", async () => {
+      // Windows GUI-launched processes (Electron desktop app) have no HOME env
+      // var. Regression: user-level agents must resolve via os.homedir() (which
+      // falls back to USERPROFILE on Windows), NOT process.env.HOME — otherwise
+      // `~/.wave/agents` is treated as a literal relative path and a newly
+      // created subagent (written to the real home by the Write tool) is
+      // invisible to the Agent tool.
+      const originalHome = process.env.HOME;
+      delete process.env.HOME;
+      try {
+        const mockFs = await import("fs");
+
+        vi.mocked(mockFs.readdirSync).mockImplementation((dirPath) => {
+          if (dirPath === path.join("/home/testuser", ".wave", "agents")) {
+            return ["arch-explorer.md"] as unknown as ReturnType<
+              typeof import("fs").readdirSync
+            >;
+          }
+          return [] as unknown as ReturnType<typeof import("fs").readdirSync>;
+        });
+
+        vi.mocked(mockFs.statSync).mockReturnValue({
+          isFile: () => true,
+        } as import("fs").Stats);
+
+        vi.mocked(mockFs.readFileSync).mockImplementation((filePath) => {
+          if (
+            filePath ===
+            path.join("/home/testuser", ".wave", "agents", "arch-explorer.md")
+          ) {
+            return `---
+name: arch-explorer
+description: Architecture exploration agent
+---
+Analyze the project architecture.`;
+          }
+          return "";
+        });
+
+        const configs = await loadSubagentConfigurations("/test/workdir");
+        const config = configs.find((c) => c.name === "arch-explorer");
+        expect(config).toBeDefined();
+        expect(config?.scope).toBe("user");
+      } finally {
+        if (originalHome === undefined) {
+          delete process.env.HOME;
+        } else {
+          process.env.HOME = originalHome;
+        }
+      }
     });
   });
 });


### PR DESCRIPTION
## 背景

Bug 3468358404099072「新建的子代理调用不了」：Codewave IDE（Windows）会话里新建用户级子代理 `~/.wave/agents/arch-explorer.md`（已确认落盘），另一会话让模型调用它时 Agent 工具报 `No agent found matching "arch-explorer". Available agents: Bash, Explore, general-purpose, Plan, vision`——可用列表只有内置 agent。

## 根因

用户级子代理目录扫描（`agent-sdk/src/utils/subagentParser.ts:loadSubagentConfigurations`）用 `process.env.HOME || "~"` 解析，而 SDK 其它所有用户路径（settings/skills/MCP/rules、Write 工具 `~` 展开）都用 `os.homedir()`。Windows GUI 启动进程（Electron 桌面）通常没有 `HOME` 环境变量（标准是 `USERPROFILE`）→ 目录解析成字面相对路径 `~/.wave/agents` → 扫描静默为空 → 用户级 agent 既不进启动缓存、Agent tool 的 FS 兜底重扫也扫不到。写文件侧（Write 工具 → homedir()）与读文件侧（env.HOME）解析不一致。macOS/Linux HOME 恒有值故从未暴露。

对照 Claude Code：`~/.claude` 根目录一律 `os.homedir()` 解析（`envUtils.ts`），Windows 由标准库兜底 USERPROFILE。

## 修复

`subagentParser.ts` 用户级 `.wave/.claude` agents 目录改用 `os.homedir()`，与 SDK 其余模块及 Claude Code 对齐。行为语义不变。

## 测试

- 新增回归用例：HOME 缺失（Windows 场景）时用户级子代理仍能被发现——stash 源码验证 fail（`expected undefined to be defined`），修复后绿。
- 原 3 个依赖 `process.env.HOME` 的用例改为 mock `os.homedir()`（同机制断言，无修复时同红）。

## 验证

- `subagentParser.test.ts` 9/9 绿；`tests/utils` + agentTool 相关 52 文件 933 测试绿
- agent-sdk type-check + oxlint（0 errors）+ prettier --check 通过
