### PR TITLE
fix(webview): 面板分隔条拖拽把手锚回槽位左缘（补 .desktop-panel-slot position:relative）

### DIFF
--- a/packages/webview/e2e/desktop-panel-drag-resize.e2e.ts
+++ b/packages/webview/e2e/desktop-panel-drag-resize.e2e.ts
@@ -1,0 +1,193 @@
+import { test, expect } from "./utils/desktopTestHarness.js";
+import { MessageInjector } from "./utils/messageInjector.js";
+
+const DIR_A = "/Users/dev/projects/wave-agent";
+
+const initialState = {
+  messages: [],
+  isStreaming: false,
+  sessions: [],
+  isAuthenticated: true,
+  configurationData: {
+    baseURL: "https://api.anthropic.com/v1",
+    model: "claude-sonnet-4-20250514",
+    fastModel: "claude-haiku-4-20250514",
+  },
+  permissionMode: "default",
+};
+
+// Real-browser geometry regression for the panel divider drag. PR #2083
+// (b7510480) hoisted the drag handle out of each pane onto .desktop-panel-slot,
+// whose CSS had no `position` — so the handle's absolute positioning anchored
+// to .desktop-chat-body instead and rendered at the far LEFT of the whole row
+// (x≈257 vs the slot at x≈620): hover showed no divider highlight, cursor
+// stayed default, dragging was a no-op. jsdom unit tests cannot catch this
+// (they fire mousemove straight on window); these tests assert the real
+// geometry: handle bbox on the slot's left edge + col-resize cursor + an
+// actual width change after a mouse drag.
+async function setupSinglePane(page: any, injector: MessageInjector) {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await injector.simulateExtensionMessage("desktopWorkdirState", {
+    workdir: DIR_A,
+    recentWorkdirs: [DIR_A],
+  });
+  await injector.waitForChatAppReady();
+  await injector.simulateExtensionMessage("setInitialState", initialState);
+  await injector.simulateExtensionMessage("desktopPanes", {
+    panes: [{ paneId: "pane-1", sessionId: "sess-dr-1" }],
+    focusedPaneId: "pane-1",
+  });
+  await page
+    .getByTestId("desktop-pane-pane-1")
+    .getByTestId("panel-toggle-btn")
+    .click();
+  await page
+    .getByTestId("desktop-pane-pane-1")
+    .getByTestId("panel-empty-item-diff")
+    .click();
+  await expect(page.getByTestId("desktop-panel-slot")).toBeVisible();
+}
+
+async function slotWidth(page: any): Promise<number> {
+  const box = await page.getByTestId("desktop-panel-slot").boundingBox();
+  if (!box) throw new Error("desktop-panel-slot not visible");
+  return box.width;
+}
+
+// Drag the shared slot divider by dx (left-negative = widen, positive = narrow).
+async function dragHandle(page: any, dx: number, steps = 24) {
+  const handle = page.getByTestId("panel-slot-drag-handle");
+  const h = await handle.boundingBox();
+  if (!h) throw new Error("panel-slot-drag-handle not visible");
+  const y = h.y + h.height / 2;
+  const x0 = h.x + h.width / 2;
+  await page.mouse.move(x0, y);
+  await page.mouse.down();
+  await page.mouse.move(x0 + dx, y, { steps });
+  await page.mouse.up();
+}
+
+const near = (got: number, want: number, tol: number) =>
+  expect(Math.abs(got - want)).toBeLessThanOrEqual(tol);
+
+test.describe("Desktop panel divider drag (real geometry)", () => {
+  test("divider handle sits on the slot's left edge, shows col-resize, and drags live", async ({
+    webviewPage,
+  }) => {
+    const page = webviewPage as any;
+    const injector = new MessageInjector(page);
+    await setupSinglePane(page, injector);
+
+    const slot = page.getByTestId("desktop-panel-slot");
+    const handle = page.getByTestId("panel-slot-drag-handle");
+    await expect(handle).toBeVisible();
+    const slotBox = (await slot.boundingBox())!;
+    const handleBox = (await handle.boundingBox())!;
+
+    // Regression guard: the handle is absolutely positioned on the slot's left
+    // edge (left:-3px) and spans the slot height — NOT the chat row's far left.
+    near(handleBox.x, slotBox.x - 3, 2);
+    near(handleBox.height, slotBox.height, 2);
+
+    // Hover affordance: col-resize cursor on the divider (and while dragging).
+    await handle.hover();
+    const cursor = await handle.evaluate(
+      (el: HTMLElement) => getComputedStyle(el).cursor,
+    );
+    expect(cursor).toBe("col-resize");
+
+    // A real mouse drag narrows the slot while the button is still held.
+    const S0 = slotBox.width;
+    await handle.hover();
+    const hb = (await handle.boundingBox())!;
+    const y = hb.y + hb.height / 2;
+    const x0 = hb.x + hb.width / 2;
+    await page.mouse.move(x0, y);
+    await page.mouse.down();
+    const draggingCursor = await page.evaluate(
+      () => getComputedStyle(document.body).cursor,
+    );
+    expect(draggingCursor).toBe("col-resize");
+    await page.mouse.move(x0 + 90, y, { steps: 12 }); // mid-drag, button held
+    await expect.poll(() => slotWidth(page)).toBeLessThanOrEqual(S0 - 80);
+    near(await slotWidth(page), S0 - 90, 8);
+    await page.mouse.move(x0 + 120, y, { steps: 6 });
+    await page.mouse.up();
+    await expect.poll(() => slotWidth(page)).toBeLessThanOrEqual(S0 - 110);
+    near(await slotWidth(page), S0 - 120, 8);
+
+    // Drag far right clamps at the panel minimum instead of collapsing.
+    await dragHandle(page, 2000);
+    near(await slotWidth(page), 320, 4);
+    await expect(slot).toBeVisible();
+    await expect(page.getByTestId("diff-pane")).toBeVisible();
+  });
+
+  test("manual drag locks the width against auto-fill; collapse/expand remembers it", async ({
+    webviewPage,
+  }) => {
+    const page = webviewPage as any;
+    const injector = new MessageInjector(page);
+    await setupSinglePane(page, injector);
+
+    const pane = page.getByTestId("desktop-pane-pane-1");
+    const S_auto = await slotWidth(page);
+
+    // Second tab while never manually dragged: still auto-filled (same width).
+    await pane.getByTestId("panel-tabs-add").click();
+    await pane.getByTestId("panel-toggle-item-preview").click();
+    near(await slotWidth(page), S_auto, 3);
+
+    // Manual drag narrows the slot and locks the width from then on.
+    await dragHandle(page, 140);
+    const S_manual = await slotWidth(page);
+    near(S_manual, S_auto - 140, 8);
+
+    // A new tab must NOT re-auto-fill a manually-dragged slot.
+    await pane.getByTestId("panel-tabs-add").click();
+    await pane.getByTestId("panel-toggle-item-diff").click();
+    await expect.poll(() => slotWidth(page)).toBeLessThanOrEqual(S_manual + 3);
+    near(await slotWidth(page), S_manual, 3);
+
+    // Collapse → expand: the manual width comes back from the group cache.
+    await pane.getByTestId("panel-toggle-btn").click();
+    await expect(page.getByTestId("desktop-panel-slot")).toBeHidden();
+    await pane.getByTestId("panel-toggle-btn").click();
+    await expect(page.getByTestId("desktop-panel-slot")).toBeVisible();
+    await expect.poll(() => slotWidth(page)).toBeLessThanOrEqual(S_manual + 3);
+    near(await slotWidth(page), S_manual, 3);
+  });
+
+  test("empty state (no tabs) keeps the divider draggable", async ({
+    webviewPage,
+  }) => {
+    const page = webviewPage as any;
+    const injector = new MessageInjector(page);
+    await setupSinglePane(page, injector);
+
+    const S0 = await slotWidth(page);
+    await page.getByTestId("panel-tab-close-diff-1").click();
+
+    // Closing the last tab leaves the slot mounted in its empty state — the
+    // divider handle must stay on the slot's left edge and still drag.
+    await expect(page.getByTestId("panel-empty-state")).toBeVisible();
+    await expect(page.getByTestId("panel-slot-drag-handle")).toBeVisible();
+    const slotBox = (await page
+      .getByTestId("desktop-panel-slot")
+      .boundingBox())!;
+    const handleBox = (await page
+      .getByTestId("panel-slot-drag-handle")
+      .boundingBox())!;
+    near(handleBox.x, slotBox.x - 3, 2);
+
+    // Auto-fill width is the maximum, so prove dragging by narrowing first,
+    // then widening again (both directions move the empty-state slot).
+    await dragHandle(page, 90);
+    near(await slotWidth(page), S0 - 90, 8);
+    await expect(page.getByTestId("panel-empty-state")).toBeVisible();
+
+    await dragHandle(page, -45);
+    near(await slotWidth(page), S0 - 45, 8);
+    await expect(page.getByTestId("desktop-panel-slot")).toBeVisible();
+  });
+});

--- a/packages/webview/src/styles/DesktopApp.css
+++ b/packages/webview/src/styles/DesktopApp.css
@@ -1389,8 +1389,15 @@ body.is-panel-resizing webview {
 
 /* Tabbed panel slot (spec「面板 tab 化」): the single slot hosts the tab strip
    (DesktopPanelTabs) above the active panel body. Inline width from ChatApp
-   drives the slot; fullscreen (below) widens it via flex. */
+   drives the slot; fullscreen (below) widens it via flex.
+
+   position:relative anchors the absolutely-positioned .panel-slot-drag-handle
+   (left:-3px, its first child) to THIS slot's left edge — the divider between
+   the conversation column and the panel. Without it the containing block
+   degrades to .desktop-chat-body and the divider renders at the far left of
+   the whole row (regression from PR #2083's handle hoist). */
 .desktop-panel-slot {
+  position: relative;
   display: flex;
   flex-direction: column;
   flex: 0 0 auto;


### PR DESCRIPTION
## 现象

右侧面板分隔条拖拽调宽不可用：悬停分割线鼠标形状不变（非 col-resize）、无高亮条、拖不动。设计师与多名终端用户均反馈。

## 根因（回归自 PR #2083 b7510480）

#2083 把左缘拖拽把手从 5 个 Pane 内部上提到 `.desktop-panel-slot` 统一渲染（空态也能拖，spec「面板空态」场景 9），但 `.desktop-panel-slot`（DesktopApp.css:1393）**没有 `position`**。

`.panel-slot-drag-handle` 是 `position:absolute; left:-3px; top:0; bottom:0`——绝对定位以最近定位祖先为包含块。改前把手在 `.preview-pane` 内（有 `position:relative`），改后最近定位祖先退化为 `.desktop-chat-body`（整条消息列+面板行的 flex 容器）→ 把手被锚到消息列**左端**而不是槽位左缘。

真实浏览器实测（1280×720）：
- 槽位 `.desktop-panel-slot`：x=620，宽 660
- 把手实际渲染：x=257（=整行左缘 −3），高 720（整视口）

即把手离分割线几百像素远，悬停/拖拽全落在聊天区上 → 全部 no-op。

## 修复

`.desktop-panel-slot` 补一行 `position: relative`（含注释说明包含块）。修复后实测：handle x=617（=槽位左缘 620 − 3）、高=槽位高 675，悬停 col-resize、真鼠标拖拽实时调宽。

## 回归测试

新增 `e2e/desktop-panel-drag-resize.e2e.ts`（真实 Chromium 几何断言，jsdom 单测 fireEvent 直发 window mousemove 补不出此类定位回归）：

1. handle bbox 贴槽位左缘（±2px）+ 高度=槽位高；hover/拖拽中 `cursor: col-resize`
2. 真鼠标拖拽：按下未松开时宽度已实时变化；拖右收窄；min 钳制 320 不塌
3. manual 拖宽锁定：新开 tab 不被 auto-fill 覆盖（520 保持，不弹回 660）
4. 收起 → 展开宽度从 panelGroupCache 恢复
5. 空态（关最后 tab，无 tab 展开）把手仍在槽位左缘、可双向拖

3 例均做 fail-without-fix 双验：临时去掉 position:relative → 3 failed；恢复 → 3 passed。

## 验证

- webview 单测 107 文件 / 985 全绿
- webview demo+e2e 141 passed；**1 failed 为既有问题与本 PR 无关**：`e2e/desktop-app.e2e.ts "capture desktop-specific features"` 期望运行中会话显示 `.codicon-loading`，在 clean main HEAD（stash 本改动后复测）同样失败——待单独排查
- webview type-check（src/tests/e2e/demo 四 tsconfig）+ oxlint + prettier 全绿
- 无需 spec 变更（空态场景 9 已存在，纯实现定位回归）

## 复现自查

还原旧几何：拖拽把手当前渲染位置距离面板分隔线约 360px；修复后把手即分隔线本身。