### PR TITLE
fix(webview): clamp panel divider width in root layout

### DIFF
--- a/packages/webview/e2e/desktop-panel-root-layout.e2e.ts
+++ b/packages/webview/e2e/desktop-panel-root-layout.e2e.ts
@@ -1,0 +1,134 @@
+import { test, expect } from "./utils/desktopTestHarness.js";
+import { MessageInjector } from "./utils/messageInjector.js";
+import fs from "fs";
+import path from "path";
+
+// Real-browser regression for the panel divider drag in the ROOT layout (no
+// split-view panes pushed — the default single-window layout). PR: the root
+// .chat-container is a direct flex child of .desktop-layout and — unlike the
+// pane-scoped one (.desktop-pane .chat-container) — had no min-width:0. Its
+// implicit flex min-width:auto let the conversation column's min-content (chat
+// main + fixed-width panel slot) widen the container itself, so the clamp's
+// `containerW - 360` ceiling grew with every drag → the panel kept widening and
+// its right edge ran off the window. Pane-shell e2es all mock ≥1 pane, so only
+// the root layout exercises the broken CSS path.
+async function setupRootLayout(page: any, injector: MessageInjector) {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  // The real desktop index.html loads host-desktop.css; the shared harness
+  // does not. Inject it so the [data-host="desktop"] rules (composer sizing,
+  // theme overrides) apply and the geometry matches a real desktop window.
+  const hostCss = fs.readFileSync(
+    path.join(process.cwd(), "src", "styles", "host-desktop.css"),
+    "utf8",
+  );
+  await page.addStyleTag({ content: hostCss });
+  await injector.simulateExtensionMessage("desktopWorkdirState", {
+    workdir: "/Users/dev/projects/wave-agent",
+    recentWorkdirs: ["/Users/dev/projects/wave-agent"],
+  });
+  await injector.waitForChatAppReady();
+  await injector.simulateExtensionMessage("setInitialState", {
+    messages: [],
+    isStreaming: false,
+    sessions: [],
+    isAuthenticated: true,
+    configurationData: {
+      baseURL: "https://api.anthropic.com/v1",
+      model: "claude-sonnet-4-20250514",
+      fastModel: "claude-haiku-4-20250514",
+    },
+    permissionMode: "default",
+  });
+  // NOTE: deliberately NO desktopPanes push — this exercises the root layout.
+}
+
+async function geometry(page: any) {
+  return page.evaluate(() => {
+    const r = (el: Element | null) => {
+      if (!el) return null;
+      const b = el.getBoundingClientRect();
+      return { x: b.x, w: b.width, right: b.right };
+    };
+    return {
+      layout: r(document.querySelector(".desktop-layout")),
+      chat: r(document.querySelector(".chat-container")),
+      main: r(document.querySelector(".desktop-chat-main")),
+      slot: r(document.querySelector(".desktop-panel-slot")),
+    };
+  });
+}
+
+async function dragWide(page: any, dx: number) {
+  const handle = page.getByTestId("panel-slot-drag-handle");
+  const h = await handle.boundingBox();
+  const y = h!.y + h!.height / 2;
+  const x0 = h!.x + h!.width / 2;
+  await page.mouse.move(x0, y);
+  await page.mouse.down();
+  await page.mouse.move(x0 + dx, y, { steps: 24 });
+  await page.mouse.up();
+}
+
+test("root layout: divider cannot widen the panel past the window edge", async ({
+  webviewPage,
+}) => {
+  const page = webviewPage as any;
+  const injector = new MessageInjector(page);
+  await setupRootLayout(page, injector);
+
+  // Open the side panel in the root layout (sidebar + chat, no pane shell).
+  // Keep it in its EMPTY state (no tab) — the reporter's repro used the empty
+  // panel; its placeholder content sets the slot's min-content.
+  await page.getByTestId("panel-toggle-btn").click();
+  await expect(page.getByTestId("desktop-panel-slot")).toBeVisible();
+  await expect(page.getByTestId("panel-empty-state")).toBeVisible();
+
+  const before = await geometry(page);
+  expect(before.chat!.w).toBeGreaterThan(0);
+  // Sanity: this must run in the ROOT layout (no split-view panes) on the
+  // empty/welcome chat — the pane-shell tests never exercise this CSS path.
+  expect(await page.locator(".desktop-pane").count()).toBe(0);
+  expect(await page.locator(".chat-container--welcome").count()).toBe(1);
+
+  // Narrow first (leaves headroom to widen), then try to widen far past the
+  // conversation minimum — pre-fix this grew the chat container itself and ran
+  // the slot's right edge off the window.
+  //
+  // Reproducing the real-Electron failure: in the user's session the welcome
+  // column's content min-content (~497px — the composer) could not shrink, so
+  // .desktop-chat-body's min-content (main + fixed-width slot) exceeded the
+  // container and — because the root .chat-container lacks the pane-scoped
+  // min-width:0 — stretched the chat container itself on every drag. Headless
+  // Chromium's composer has a smaller min-content so it never overflows; force
+  // the same condition by pinning an inline min-width on the chat main.
+  await page.evaluate(() => {
+    const main = document.querySelector(".desktop-chat-main") as HTMLElement;
+    main.style.minWidth = "500px";
+  });
+  await dragWide(page, 500);
+  const narrowed = await geometry(page);
+  expect(narrowed.slot!.w).toBeLessThan(before.slot!.w - 100);
+
+  // Two consecutive "widen far past the limit" drags: pre-fix each drag fed
+  // back into the chat container's own width (min-width:auto), so the clamp's
+  // `containerW - 360` ceiling grew with the panel and the slot widened with
+  // no bound. Post-fix the container stays fixed, the first drag clamps the
+  // slot to the ceiling, and a second drag must not widen it further.
+  await dragWide(page, -3000);
+  const after = await geometry(page);
+
+  await dragWide(page, -3000);
+  const after2 = await geometry(page);
+
+  // 1. The conversation column keeps its minimum width (clamp fired).
+  expect(after.main!.w).toBeGreaterThanOrEqual(356);
+  // 2. The chat container did NOT grow (no container-feedback loop).
+  expect(Math.abs(after.chat!.w - before.chat!.w)).toBeLessThanOrEqual(3);
+  // 3. The second drag does not widen the slot further (clamp holds, no
+  //    positive feedback) and the panel ended at the ceiling ≈ chat − 360.
+  expect(after2.slot!.w).toBeLessThanOrEqual(after.slot!.w + 1);
+  expect(Math.abs(after2.slot!.w - (after2.chat!.w - 360))).toBeLessThanOrEqual(
+    6,
+  );
+  expect(Math.abs(after2.chat!.w - before.chat!.w)).toBeLessThanOrEqual(3);
+});

--- a/packages/webview/src/styles/DesktopApp.css
+++ b/packages/webview/src/styles/DesktopApp.css
@@ -8,6 +8,19 @@
   overflow: hidden;
 }
 
+/* Root (single-window, no split-view panes) layout: the chat container is a
+   direct flex child of .desktop-layout — no .desktop-pane wrapper — so the
+   pane-scoped min-width:0 below never applies. Without it the container's
+   implicit flex min-width:auto lets .desktop-chat-body's min-content (chat
+   main's unshrinkable composer + the fixed-width panel slot) widen the
+   container itself; the panel divider clamp's `containerW - 360` ceiling then
+   grows with every drag, so dragging the panel divider left past the
+   conversation minimum keeps widening the panel instead of clamping it, and
+   its right edge runs off the window. */
+.desktop-layout > .chat-container {
+  min-width: 0;
+}
+
 .desktop-loading {
   flex: 1;
   height: 100vh;


### PR DESCRIPTION
## 问题

桌面端右侧面板拖拽把手向左拖到对话区最窄（360px）后继续左拖，面板宽度继续增大且其右缘向窗口之外移动（被 `.desktop-layout` 的 `overflow:hidden` 裁掉）。

根因：root（单窗口、无分屏 pane）布局下 `.chat-container` 是 `.desktop-layout` 的直接 flex 子项，缺少分屏场景 `.desktop-pane .chat-container{min-width:0}` 的同款保护。隐式 `min-width:auto` 使容器被 `.desktop-chat-body` 的 min-content（不可缩的对话主列 + 固定宽面板槽）撑大 → clamp 的 `containerW − 360` 上限随每次拖拽水涨船高 → clamp 永不触发 → 面板无限增宽出窗。真机日志实证：`containerW`/`bodyW` 与面板宽同步增长、main 恒定 496.66、chat-container 计算 `min-width` 等于其被撑宽度。

## 修复

`DesktopApp.css` 新增：

```css
.desktop-layout > .chat-container { min-width: 0; }
```

与分屏 pane 版规则对齐，切断正反馈循环。

## 测试

新增真浏览器回归 `e2e/desktop-panel-root-layout.e2e.ts`（root 布局 + 空态面板 + 对话主列钉住不可缩 min-width 以还原真实 composer 场景）：

- 修复前红：chat 被撑 3820→6820、slot 3320→6320（正反馈复现）
- 修复后绿：chat 恒定、slot 首次拖拽封顶 660、二次拖拽不再增

e2e 4/4、webview 单测 985/985、type-check 全绿；真机复现验证通过。