### PR TITLE
fix(vscode,jetbrains): 移除历史对话 10 条上限

### DIFF
--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/WaveSession.kt
@@ -348,7 +348,8 @@ class WaveSession(
 
     /**
      * Pull the session list from the agent and push `updateSessions` to the webview.
-     * Mirrors VSCE chatProvider.ts:368 listSessions() (filter main sessions, take 10).
+     * Mirrors VSCE SessionService.getSessionsList() (filter main sessions, no cap —
+     * the SDK already sorts by lastActiveAt descending and excludes subagent files).
      */
     fun refreshSessions() {
         val workdir = agent?.workingDirectory ?: project.basePath ?: return
@@ -356,7 +357,7 @@ class WaveSession(
             val list: List<JsonElement> = try {
                 val res = agent?.listSessions(workdir)?.jsonObject
                 val all = res?.get("sessions")?.jsonArray ?: JsonArray(emptyList())
-                all.filter { it.jsonObject["sessionType"]?.jsonPrimitive?.content == "main" }.take(10)
+                all.filter { it.jsonObject["sessionType"]?.jsonPrimitive?.content == "main" }
             } catch (e: StdioClientException) {
                 LOG.warn("refreshSessions failed: ${e.message}")
                 JsonArray(emptyList()).toList()

--- a/packages/vscode/src/services/sessionService.ts
+++ b/packages/vscode/src/services/sessionService.ts
@@ -15,10 +15,12 @@ export class SessionService {
       })) as { sessions: SessionMetadata[] };
       const allSessions = result.sessions;
 
-      // Filter to get only main sessions and slice to get only first 10 sessions
-      return allSessions
-        .filter((session) => session.sessionType === "main")
-        .slice(0, 10);
+      // The SDK already returns only main sessions (subagent files are
+      // excluded by filename), sorted by lastActiveAt descending. Keep the
+      // explicit main filter as a defensive guard and return the full list —
+      // the history popup has no pagination, so capping here would make
+      // older sessions unreachable from the UI.
+      return allSessions.filter((session) => session.sessionType === "main");
     } catch (error) {
       console.error(`获取会话列表失败:`, error);
       throw error;

--- a/packages/vscode/tests/services/sessionService.test.ts
+++ b/packages/vscode/tests/services/sessionService.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect, vi } from "vitest";
+import type { SessionMetadata } from "wave-agent-sdk/types";
+import { SessionService } from "../../src/services/sessionService";
+import type { StdioClient } from "../../src/stdio/stdioClient";
+
+// The vitest config aliases "vscode" to tests/__mocks__/vscode.ts, whose
+// workspace.workspaceFolders[0].uri.fsPath is "/test-workspace" — the workdir
+// SessionService must pass through to the CLI listSessions RPC.
+
+function makeSession(
+  id: string,
+  sessionType: SessionMetadata["sessionType"] = "main",
+  seq = 0,
+): SessionMetadata {
+  return {
+    id,
+    sessionType,
+    workdir: "/test-workspace",
+    createdAt: new Date(2026, 0, 1, 0, 0, seq),
+    lastActiveAt: new Date(2026, 0, 1, 0, 0, seq),
+    latestTotalTokens: 0,
+    firstMessage: `first message ${id}`,
+  };
+}
+
+function createService(sessionList: SessionMetadata[]) {
+  const utilityClient = {
+    request: vi.fn().mockResolvedValue({ sessions: sessionList }),
+  };
+  const service = new SessionService(utilityClient as unknown as StdioClient);
+  return { service, utilityClient };
+}
+
+describe("SessionService.getSessionsList", () => {
+  test("requests sessions for the first workspace folder", async () => {
+    const { service, utilityClient } = createService([]);
+    await service.getSessionsList();
+    expect(utilityClient.request).toHaveBeenCalledWith("listSessions", {
+      workdir: "/test-workspace",
+    });
+  });
+
+  test("keeps only main sessions and preserves their order", async () => {
+    const sessions = [
+      makeSession("session-oldest", "main", 1),
+      makeSession("session-subagent", "subagent", 2),
+      makeSession("session-newest", "main", 3),
+    ];
+    const { service } = createService(sessions);
+    const result = await service.getSessionsList();
+    expect(result.map((s) => s.id)).toEqual([
+      "session-oldest",
+      "session-newest",
+    ]);
+  });
+
+  test("returns every main session — no cap hides sessions past the tenth", async () => {
+    // Regression: the history popup has no pagination, so a host-side slice
+    // would make sessions older than the cap unreachable from the UI.
+    const sessions = Array.from({ length: 12 }, (_, i) =>
+      makeSession(`session-${i + 1}`, "main", i),
+    );
+    sessions.push(makeSession("session-subagent", "subagent", 99));
+    const { service } = createService(sessions);
+    const result = await service.getSessionsList();
+    expect(result).toHaveLength(12);
+    expect(result.map((s) => s.id)).toEqual(
+      Array.from({ length: 12 }, (_, i) => `session-${i + 1}`),
+    );
+  });
+
+  test("propagates failures from the underlying CLI request", async () => {
+    const utilityClient = {
+      request: vi.fn().mockRejectedValue(new Error("boom")),
+    };
+    const service = new SessionService(utilityClient as unknown as StdioClient);
+    await expect(service.getSessionsList()).rejects.toThrow("boom");
+  });
+});


### PR DESCRIPTION
## 背景

Bug 3469218576657408：插件端（VSCE/JetBrains）「历史对话」弹窗最多只显示 10 条，更老的会话在 UI 不可达（弹窗无分页/查看全部）。

## 改动

- `packages/vscode/src/services/sessionService.ts`：去掉 `.slice(0, 10)`，保留 main 过滤（防御性守卫，SDK 已按文件名排除 subagent 并按 lastActiveAt 降序返回）
- `packages/jetbrains .../WaveSession.kt`：`refreshSessions()` 去掉 `.take(10)`，镜像注释同步为新语义
- 新增 `sessionService.test.ts` 4 例回归（12 main 全量返回保序 / subagent 过滤 / workdir 透传 / 错误传播），fail-without-fix 已验

存储层无上限（SDK 扫全部 `*.jsonl`，仅在用户删除时消失），去除 host 端 slice 后即全量显示。

## 验证

vscode 191 passed / JB BUILD SUCCESSFUL / monorepo type-check 6 包 / oxlint / prettier 全绿。