### PR TITLE
refactor(webview): 收敛 19 处 window message 监听到 useHostMessage hook（P2 A 类去重第 1 步）

### DIFF
--- a/packages/webview/src/components/BackgroundTaskManager.tsx
+++ b/packages/webview/src/components/BackgroundTaskManager.tsx
@@ -8,6 +8,7 @@
 
 import React, { useState, useEffect, useRef } from "react";
 import { useClickOutside } from "../utils/useClickOutside";
+import { useHostMessage } from "../utils/useHostMessage";
 import { BackgroundTaskManagerProps, BackgroundTaskSummary } from "../types";
 import "../styles/ConfigurationDialog.css";
 
@@ -80,24 +81,19 @@ const BackgroundTaskManager: React.FC<
     }
   }, [selectedTask, selectedTaskId, output, vscode]);
 
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      const message = event.data;
-      switch (message.command) {
-        case "backgroundTaskOutput":
-          if (message.taskId === selectedTaskId) {
-            setOutput(message.output || null);
-            setLoadingOutput(false);
-          }
-          break;
-        case "backgroundTaskStopped":
-          setStoppingId(null);
-          break;
-      }
-    };
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, [selectedTaskId]);
+  useHostMessage((message) => {
+    switch (message.command) {
+      case "backgroundTaskOutput":
+        if (message.taskId === selectedTaskId) {
+          setOutput(message.output || null);
+          setLoadingOutput(false);
+        }
+        break;
+      case "backgroundTaskStopped":
+        setStoppingId(null);
+        break;
+    }
+  });
 
   const handleStop = (taskId: string) => {
     setStoppingId(taskId);

--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -29,6 +29,7 @@ import WelcomeView from "./WelcomeView";
 import LoadingLogo from "./LoadingLogo";
 import { SidebarExpandIcon, CloseIcon } from "./HeaderIcons";
 import { useDesktopChrome } from "./DesktopChromeContext";
+import { useHostMessage } from "../utils/useHostMessage";
 import { DesktopHostSelector } from "./DesktopHostSelector";
 import { DesktopShell } from "./DesktopShell";
 import type { AccountCardAccount } from "./AccountCard";
@@ -868,677 +869,659 @@ export const ChatApp: React.FC<ChatAppProps> = ({
     setWorktreeChecked(true);
   }, [gitBranches]);
 
-  // Handle messages from VS Code extension
-  useEffect(() => {
-    // The pane this instance consumes a message when it is tagged with its own
-    // id; messages tagged for a sibling pane are ignored here.
-    //
-    // The root instance (myPane === undefined) consumes window-global UNTAGGED
-    // messages (workdir/sessions/panes/account/toast…) — the sidebar's data.
-    // Pane-tagged pushes go to the pane that owns the session; the root only
-    // consumes them while the pane rows are hidden (settings page / session
-    // board replace the rows and unmount the pane ChatApps), because the host
-    // still tags those replies (project settings, hooks/mcp config) to the
-    // focused pane. While the rows are visible the target pane is mounted and
-    // owns its tagged pushes — the root must not ALSO consume them or the same
-    // dialog/toast would render twice, once over the shell and once inside the
-    // pane (spec「启动即单个分屏」).
-    const myPane = paneIdRef.current;
-    const forThisPane = (message: { paneId?: string }): boolean => {
-      if (myPane !== undefined) return message.paneId === myPane;
-      if (message.paneId === undefined) return true;
-      // While the rows are visible, tagged pushes belong to the mounted pane
-      // instance; once the rows are hidden the target pane is unmounted and
-      // only the root can take the reply (see the rationale above).
-      return !rowsVisibleRef.current;
+  // Handle messages from VS Code extension. The listener is registered once
+  // via useHostMessage (stable listener, latest handler per render); every
+  // mutable capture below is a ref or a stable setState, so per-render
+  // recreation is behavior-identical to the previous once-registered closure.
+  //
+  // The pane this instance consumes a message when it is tagged with its own
+  // id; messages tagged for a sibling pane are ignored here.
+  //
+  // The root instance (myPane === undefined) consumes window-global UNTAGGED
+  // messages (workdir/sessions/panes/account/toast…) — the sidebar's data.
+  // Pane-tagged pushes go to the pane that owns the session; the root only
+  // consumes them while the pane rows are hidden (settings page / session
+  // board replace the rows and unmount the pane ChatApps), because the host
+  // still tags those replies (project settings, hooks/mcp config) to the
+  // focused pane. While the rows are visible the target pane is mounted and
+  // owns its tagged pushes — the root must not ALSO consume them or the same
+  // dialog/toast would render twice, once over the shell and once inside the
+  // pane (spec「启动即单个分屏」).
+  const myPane = paneIdRef.current;
+  const forThisPane = (message: { paneId?: string }): boolean => {
+    if (myPane !== undefined) return message.paneId === myPane;
+    if (message.paneId === undefined) return true;
+    // While the rows are visible, tagged pushes belong to the mounted pane
+    // instance; once the rows are hidden the target pane is unmounted and
+    // only the root can take the reply (see the rationale above).
+    return !rowsVisibleRef.current;
+  };
+  const handleMessage = (message: MessageEvent["data"]) => {
+    // Desktop plan panel: route an ExitPlanMode plan to the plan pane (opens
+    // it on the first plan, then keeps the latest plan until the user closes
+    // the pane). Shared by showConfirmation and the setInitialState replay.
+    const routePlanToPanel = (planContent: unknown) => {
+      if (typeof planContent !== "string" || planContent.trim() === "") return;
+      setPlanContent(planContent);
+      // The plan tab is unique — only open it when none is open yet, so an
+      // updated plan never yanks the active tab away mid-conversation.
+      if (!tabsRef.current.some((t) => t.kind === "plan")) {
+        ensureTabRef.current("plan");
+      }
     };
 
-    const handleMessage = (event: MessageEvent) => {
-      const message = event.data;
-
-      // Desktop plan panel: route an ExitPlanMode plan to the plan pane (opens
-      // it on the first plan, then keeps the latest plan until the user closes
-      // the pane). Shared by showConfirmation and the setInitialState replay.
-      const routePlanToPanel = (planContent: unknown) => {
-        if (typeof planContent !== "string" || planContent.trim() === "")
-          return;
-        setPlanContent(planContent);
-        // The plan tab is unique — only open it when none is open yet, so an
-        // updated plan never yanks the active tab away mid-conversation.
-        if (!tabsRef.current.some((t) => t.kind === "plan")) {
-          ensureTabRef.current("plan");
+    switch (message.command) {
+      case "updateMessages":
+        if (!forThisPane(message)) break;
+        dispatch({ type: "SET_MESSAGES", payload: message.messages });
+        break;
+      case "updateTasks":
+        if (!forThisPane(message)) break;
+        dispatch({ type: "SET_TASKS", payload: message.tasks });
+        if (message.isTaskListCollapsed !== undefined) {
+          dispatch({
+            type: "SET_TASK_LIST_COLLAPSED",
+            payload: message.isTaskListCollapsed,
+          });
         }
-      };
-
-      switch (message.command) {
-        case "updateMessages":
-          if (!forThisPane(message)) break;
-          dispatch({ type: "SET_MESSAGES", payload: message.messages });
-          break;
-        case "updateTasks":
-          if (!forThisPane(message)) break;
-          dispatch({ type: "SET_TASKS", payload: message.tasks });
-          if (message.isTaskListCollapsed !== undefined) {
-            dispatch({
-              type: "SET_TASK_LIST_COLLAPSED",
-              payload: message.isTaskListCollapsed,
-            });
-          }
-          break;
-        case "updateBackgroundTasks":
-          if (!forThisPane(message)) break;
-          dispatch({ type: "SET_BACKGROUND_TASKS", payload: message.tasks });
-          break;
-        case "updateWorkflowRuns":
-          if (!forThisPane(message)) break;
-          dispatch({ type: "SET_WORKFLOW_RUNS", payload: message.runs });
-          break;
-        case "updateSelection":
-          if (!forThisPane(message)) break;
-          dispatch({ type: "UPDATE_SELECTION", payload: message.selection });
-          break;
-        case "updatePermissionMode":
-          if (!forThisPane(message)) break;
-          dispatch({ type: "SET_PERMISSION_MODE", payload: message.mode });
-          break;
-        case "updateWorkdir":
-          if (!forThisPane(message)) break;
-          dispatch({ type: "SET_WORKDIR", payload: message.workdir });
-          break;
-        case "desktopGitBranches":
-          // Per-pane branch list reply (FR-052). Routed by paneId so a sibling
-          // pane's reply never overwrites this pane's selector. The result is
-          // keyed by the workdir it was queried for (null = not a git repo), so
-          // a stale reply for a directory the user has since switched away from
-          // is quarantined instead of shown over the current directory.
-          if (!forThisPane(message)) break;
-          setPaneGitBranches(
-            message.result
-              ? {
-                  workdir: message.workdir,
-                  branches: message.result.branches ?? [],
-                  current: message.result.current ?? "",
-                }
-              : null,
-          );
-          break;
-        case "desktopWorktreeCreated":
-          // Worktree creation finished (success or failure) — clear the
-          // "worktree 创建中" indicator.
-          if (!forThisPane(message)) break;
-          setWorktreeCreating(false);
-          break;
-        case "desktopForwardPortResult":
-          // Remote preview port-forward reply (scenario 15/16). The forward is
-          // session-scoped, so the reply is matched against the session whose
-          // cached forward carries this requestId — a reply that lands after
-          // the pane rebinds to another session still updates the owning
-          // session's cached forward instead of being dropped. The forwarded
-          // URL is applied to the preview TAB that requested the tunnel (map in
-          // forwardTabIdRef) so a sibling preview tab's URL is never clobbered.
-          if (!forThisPane(message)) break;
-          {
-            let targetKey: string | undefined;
-            panelGroupCache.forEach((g, key) => {
-              if (g.forward?.requestId === message.requestId) targetKey = key;
-            });
-            if (targetKey === undefined) break;
-            const target = panelGroupCache.get(targetKey);
-            if (!target) break;
-            const tabId = message.requestId
-              ? forwardTabIdRef.current.get(message.requestId)
-              : undefined;
-            const patchCachedTabUrl = (url: string) => {
-              // Keep the cached group's tabs in sync for remounts/session
-              // switches even when this pane is not the current one.
-              target.checked = target.checked.map((t) =>
-                t.id === tabId ? { ...t, previewUrl: url } : t,
-              );
-            };
-            if (message.error) {
-              target.forwardError = String(message.error);
-              if (targetKey === groupKeyRef.current)
-                setPreviewForwardError(String(message.error));
-            } else {
-              target.forwardError = null;
-              if (targetKey === groupKeyRef.current) {
-                setPreviewForwardError(null);
-                if (tabId) {
-                  const prevUrl = tabsRef.current.find(
-                    (t) => t.id === tabId,
-                  )?.previewUrl;
-                  setTabs((prev) =>
-                    prev.map((t) =>
-                      t.id === tabId
-                        ? { ...t, previewUrl: message.url as string }
-                        : t,
-                    ),
-                  );
-                  patchCachedTabUrl(message.url as string);
-                  // Same URL as before (re-acquire after a guest load failure):
-                  // remount so the webview actually reloads instead of the [url]
-                  // effect early-returning on an unchanged prop.
-                  if (message.url === prevUrl) setPreviewEpoch((e) => e + 1);
-                }
-              } else if (tabId) {
-                // A reply for a session this pane is NOT bound to only touches
-                // that session's cached tabs — never this pane's live tabs.
-                patchCachedTabUrl(message.url as string);
+        break;
+      case "updateBackgroundTasks":
+        if (!forThisPane(message)) break;
+        dispatch({ type: "SET_BACKGROUND_TASKS", payload: message.tasks });
+        break;
+      case "updateWorkflowRuns":
+        if (!forThisPane(message)) break;
+        dispatch({ type: "SET_WORKFLOW_RUNS", payload: message.runs });
+        break;
+      case "updateSelection":
+        if (!forThisPane(message)) break;
+        dispatch({ type: "UPDATE_SELECTION", payload: message.selection });
+        break;
+      case "updatePermissionMode":
+        if (!forThisPane(message)) break;
+        dispatch({ type: "SET_PERMISSION_MODE", payload: message.mode });
+        break;
+      case "updateWorkdir":
+        if (!forThisPane(message)) break;
+        dispatch({ type: "SET_WORKDIR", payload: message.workdir });
+        break;
+      case "desktopGitBranches":
+        // Per-pane branch list reply (FR-052). Routed by paneId so a sibling
+        // pane's reply never overwrites this pane's selector. The result is
+        // keyed by the workdir it was queried for (null = not a git repo), so
+        // a stale reply for a directory the user has since switched away from
+        // is quarantined instead of shown over the current directory.
+        if (!forThisPane(message)) break;
+        setPaneGitBranches(
+          message.result
+            ? {
+                workdir: message.workdir,
+                branches: message.result.branches ?? [],
+                current: message.result.current ?? "",
               }
-            }
-          }
-          break;
-        case "desktopFileContent":
-          // File panel content reply (file panel spec scenario 1/2). Routed by
-          // paneId so a sibling pane's reply never overwrites this pane's view;
-          // within the pane it lands on the file tab showing the same path. When
-          // no tab shows that path yet (a blank tab opened from "＋" before the
-          // host resolved a path), the reply binds the ACTIVE file tab to it.
-          if (!forThisPane(message)) break;
-          {
-            const fv = message.fileView as FileViewState;
-            setTabs((prev) =>
-              prev.some((t) => t.kind === "file" && t.filePath === fv.path)
-                ? prev.map((t) =>
-                    t.kind === "file" && t.filePath === fv.path
-                      ? { ...t, fileView: fv }
-                      : t,
-                  )
-                : prev.map((t) =>
-                    t.id === activeTabIdRef.current && t.kind === "file"
-                      ? { ...t, filePath: fv.path, fileView: fv }
+            : null,
+        );
+        break;
+      case "desktopWorktreeCreated":
+        // Worktree creation finished (success or failure) — clear the
+        // "worktree 创建中" indicator.
+        if (!forThisPane(message)) break;
+        setWorktreeCreating(false);
+        break;
+      case "desktopForwardPortResult":
+        // Remote preview port-forward reply (scenario 15/16). The forward is
+        // session-scoped, so the reply is matched against the session whose
+        // cached forward carries this requestId — a reply that lands after
+        // the pane rebinds to another session still updates the owning
+        // session's cached forward instead of being dropped. The forwarded
+        // URL is applied to the preview TAB that requested the tunnel (map in
+        // forwardTabIdRef) so a sibling preview tab's URL is never clobbered.
+        if (!forThisPane(message)) break;
+        {
+          let targetKey: string | undefined;
+          panelGroupCache.forEach((g, key) => {
+            if (g.forward?.requestId === message.requestId) targetKey = key;
+          });
+          if (targetKey === undefined) break;
+          const target = panelGroupCache.get(targetKey);
+          if (!target) break;
+          const tabId = message.requestId
+            ? forwardTabIdRef.current.get(message.requestId)
+            : undefined;
+          const patchCachedTabUrl = (url: string) => {
+            // Keep the cached group's tabs in sync for remounts/session
+            // switches even when this pane is not the current one.
+            target.checked = target.checked.map((t) =>
+              t.id === tabId ? { ...t, previewUrl: url } : t,
+            );
+          };
+          if (message.error) {
+            target.forwardError = String(message.error);
+            if (targetKey === groupKeyRef.current)
+              setPreviewForwardError(String(message.error));
+          } else {
+            target.forwardError = null;
+            if (targetKey === groupKeyRef.current) {
+              setPreviewForwardError(null);
+              if (tabId) {
+                const prevUrl = tabsRef.current.find(
+                  (t) => t.id === tabId,
+                )?.previewUrl;
+                setTabs((prev) =>
+                  prev.map((t) =>
+                    t.id === tabId
+                      ? { ...t, previewUrl: message.url as string }
                       : t,
                   ),
-            );
-          }
-          break;
-        case "updateQueue":
-          if (!forThisPane(message)) break;
-          dispatch({ type: "SET_QUEUED_MESSAGES", payload: message.queue });
-          break;
-        case "updateQueuedMessageMissing":
-          if (!forThisPane(message)) break;
-          // The edited queue message no longer exists. Keep input content, exit editing.
-          dispatch({ type: "SET_EDITING_QUEUED_ID", payload: null });
-          setQueueEditWarning("编辑的队列消息已不存在！");
-          break;
-        case "updateCommandRunning":
-          if (!forThisPane(message)) break;
-          dispatch({ type: "SET_COMMAND_RUNNING", payload: message.running });
-          break;
-        case "rewindCheckpoints":
-          if (!forThisPane(message)) break;
-          setRewindCheckpoints(message.checkpoints || []);
-          setRewindCheckpointsLoading(false);
-          break;
-        case "configuredModels":
-          if (!forThisPane(message)) break;
-          setConfiguredModels(message.models || []);
-          setCurrentModel(message.currentModel);
-          setModelLoading(false);
-          break;
-        case "btwStream":
-          if (!forThisPane(message)) break;
-          // Streaming chunks from the askBtw RPC (spec scenario 6): thinking
-          // chunks show live while they stream, but once the first content
-          // chunk arrives the accumulated thinking text is discarded and only
-          // content is kept (user decision: thinking is not shown after the
-          // thinking phase ends).
-          if (
-            !btwActiveRef.current ||
-            message.question !== btwActiveRef.current
-          )
-            break;
-          setBtwPanel((panel) => {
-            if (!panel) return panel;
-            const content =
-              typeof message.content === "string" ? message.content : "";
-            if (message.type === "content") {
-              const base = panel.contentStarted ? panel.answer : "";
-              return { ...panel, contentStarted: true, answer: base + content };
-            }
-            if (panel.contentStarted) return panel;
-            return { ...panel, answer: panel.answer + content };
-          });
-          break;
-        case "btwResponse":
-          if (!forThisPane(message)) break;
-          // Drop late replies: the panel must be open, the panel's question must
-          // still match the in-flight one, and the reply must echo the same question.
-          if (
-            btwActiveRef.current &&
-            message.question === btwActiveRef.current
-          ) {
-            setBtwPanel((panel) =>
-              panel
-                ? { ...panel, answer: message.answer ?? "", loading: false }
-                : panel,
-            );
-          }
-          break;
-        case "btwError":
-          if (!forThisPane(message)) break;
-          if (
-            btwActiveRef.current &&
-            message.question === btwActiveRef.current
-          ) {
-            setBtwPanel((panel) =>
-              panel
-                ? {
-                    ...panel,
-                    answer: `(API error: ${message.error ?? "unknown"})`,
-                    loading: false,
-                  }
-                : panel,
-            );
-          }
-          break;
-        // Test-only handlers
-        case "startStreaming":
-          if (!forThisPane(message)) break;
-          dispatch({ type: "START_STREAMING" });
-          break;
-        case "endStreaming":
-          if (!forThisPane(message)) break;
-          dispatch({ type: "END_STREAMING" });
-          break;
-        case "ensureUIReset":
-          if (!forThisPane(message)) break;
-          dispatch({ type: "END_STREAMING" });
-          break;
-        case "updateSessions":
-          dispatch({ type: "SET_SESSIONS", payload: message.sessions });
-          break;
-        case "updateCurrentSession":
-          if (!forThisPane(message)) break;
-          dispatch({ type: "SET_CURRENT_SESSION", payload: message.session });
-          break;
-        case "showConfirmation":
-          if (!forThisPane(message)) break;
-          // Plan panel (desktop): the ExitPlanMode plan full text lives in the
-          // plan pane, not the (compact) confirmation dialog — mirror the VSCE
-          // claudePlanPreview panel and the JB editor column. The dialog gets
-          // the plan stripped so it stays small.
-          if (message.toolName === EXIT_PLAN_MODE_TOOL_NAME) {
-            routePlanToPanel(message.planContent);
-          }
-          dispatch({
-            type: "SHOW_CONFIRMATION",
-            payload: {
-              confirmationId: message.confirmationId,
-              toolName: message.toolName,
-              confirmationType: message.confirmationType,
-              toolInput: message.toolInput,
-              planContent:
-                message.toolName === EXIT_PLAN_MODE_TOOL_NAME
-                  ? undefined
-                  : message.planContent,
-              suggestedPrefix: message.suggestedPrefix,
-              hidePersistentOption: message.hidePersistentOption,
-              permissionMode: message.permissionMode,
-              warning: message.warning,
-            },
-          });
-          // Scroll to bottom when confirmation is shown
-          setTimeout(() => {
-            if (
-              messageListRef.current &&
-              typeof messageListRef.current.scrollToBottom === "function"
-            ) {
-              messageListRef.current.scrollToBottom("smooth");
-            }
-          }, 0);
-          break;
-        case "planContent":
-          // Desktop /plan display: host pushes the current plan file contents
-          // to the shared Plan pane (same routing as an ExitPlanMode plan).
-          if (!forThisPane(message)) break;
-          routePlanToPanel(message.content);
-          break;
-        case "configurationResponse":
-          dispatch({
-            type: "SET_CONFIGURATION_DATA",
-            payload: message.configurationData,
-          });
-          break;
-        case "projectSettings":
-          // Project settings (.wave/settings.json merged enabledPlugins) are
-          // per-workdir, so on Desktop each pane may hold a different value —
-          // must be pane-guarded (unlike the shared global configurationResponse).
-          // The reply is stamped with the workdir active when it lands so the
-          // 项目设置 view can tell whether the cached value still belongs to the
-          // current project (a stale reply for a switched-away directory must
-          // never masquerade as the current project's state).
-          if (!forThisPane(message)) break;
-          dispatch({
-            type: "SET_PROJECT_SETTINGS",
-            payload: {
-              enabledPlugins: message.enabledPlugins,
-              workdir: effectiveWorkdirRef.current,
-            },
-          });
-          break;
-        case "setInitialState":
-          if (!forThisPane(message)) break;
-          // Desktop plan panel: replayed pending confirmations (pane rebind to a
-          // session with confirmations in flight) also carry an ExitPlanMode
-          // plan. It is staged — not routed here — because a same-batch pane
-          // rebind re-seeds tabs from the incoming cache after this handler runs
-          // and would wipe an eagerly opened plan tab (see the routing effect).
-          for (const c of message.pendingConfirmations ||
-            (message.pendingConfirmation
-              ? [message.pendingConfirmation]
-              : [])) {
-            if (
-              c.toolName === EXIT_PLAN_MODE_TOOL_NAME &&
-              typeof c.planContent === "string" &&
-              c.planContent.trim() !== ""
-            ) {
-              setPlanReplayContent(c.planContent);
+                );
+                patchCachedTabUrl(message.url as string);
+                // Same URL as before (re-acquire after a guest load failure):
+                // remount so the webview actually reloads instead of the [url]
+                // effect early-returning on an unchanged prop.
+                if (message.url === prevUrl) setPreviewEpoch((e) => e + 1);
+              }
+            } else if (tabId) {
+              // A reply for a session this pane is NOT bound to only touches
+              // that session's cached tabs — never this pane's live tabs.
+              patchCachedTabUrl(message.url as string);
             }
           }
-          dispatch({
-            type: "SET_INITIAL_STATE",
-            payload: {
-              messages: message.messages,
-              tasks: message.tasks,
-              isStreaming: message.isStreaming,
-              isCommandRunning: message.isCommandRunning,
-              isTaskListCollapsed: message.isTaskListCollapsed,
-              isRestoring: message.isRestoring,
-              sessions: message.sessions,
-              currentSession: message.session,
-              configurationData: message.configurationData,
-              pendingConfirmations:
-                message.pendingConfirmations ||
-                (message.pendingConfirmation
-                  ? [message.pendingConfirmation]
-                  : []),
-              selection: message.selection,
-              inputContent: message.inputContent,
-              permissionMode: message.permissionMode,
-              attachedImages: message.attachedImages,
-              queuedMessages: message.queuedMessages,
-              isAuthenticated: message.isAuthenticated,
-              workdir: message.workdir,
-              theme: message.theme,
-              updateChannel: message.updateChannel,
-              // Hosts (VSCE messageHandler / Desktop desktopHost) include the
-              // running background tasks + workflow runs in the snapshot so a
-              // webview re-init / pane switch does not wipe them. Without this
-              // the reducer falls back to [] and /tasks shows "暂无后台任务"
-              // until the next incremental updateBackgroundTasks (e.g. stop).
-              backgroundTasks: message.backgroundTasks,
-              workflowRuns: message.workflowRuns,
-            },
-          });
-          break;
-        case "desktopThemeChange":
-          document.documentElement.setAttribute(
-            "data-theme",
-            message.effective,
+        }
+        break;
+      case "desktopFileContent":
+        // File panel content reply (file panel spec scenario 1/2). Routed by
+        // paneId so a sibling pane's reply never overwrites this pane's view;
+        // within the pane it lands on the file tab showing the same path. When
+        // no tab shows that path yet (a blank tab opened from "＋" before the
+        // host resolved a path), the reply binds the ACTIVE file tab to it.
+        if (!forThisPane(message)) break;
+        {
+          const fv = message.fileView as FileViewState;
+          setTabs((prev) =>
+            prev.some((t) => t.kind === "file" && t.filePath === fv.path)
+              ? prev.map((t) =>
+                  t.kind === "file" && t.filePath === fv.path
+                    ? { ...t, fileView: fv }
+                    : t,
+                )
+              : prev.map((t) =>
+                  t.id === activeTabIdRef.current && t.kind === "file"
+                    ? { ...t, filePath: fv.path, fileView: fv }
+                    : t,
+                ),
           );
+        }
+        break;
+      case "updateQueue":
+        if (!forThisPane(message)) break;
+        dispatch({ type: "SET_QUEUED_MESSAGES", payload: message.queue });
+        break;
+      case "updateQueuedMessageMissing":
+        if (!forThisPane(message)) break;
+        // The edited queue message no longer exists. Keep input content, exit editing.
+        dispatch({ type: "SET_EDITING_QUEUED_ID", payload: null });
+        setQueueEditWarning("编辑的队列消息已不存在！");
+        break;
+      case "updateCommandRunning":
+        if (!forThisPane(message)) break;
+        dispatch({ type: "SET_COMMAND_RUNNING", payload: message.running });
+        break;
+      case "rewindCheckpoints":
+        if (!forThisPane(message)) break;
+        setRewindCheckpoints(message.checkpoints || []);
+        setRewindCheckpointsLoading(false);
+        break;
+      case "configuredModels":
+        if (!forThisPane(message)) break;
+        setConfiguredModels(message.models || []);
+        setCurrentModel(message.currentModel);
+        setModelLoading(false);
+        break;
+      case "btwStream":
+        if (!forThisPane(message)) break;
+        // Streaming chunks from the askBtw RPC (spec scenario 6): thinking
+        // chunks show live while they stream, but once the first content
+        // chunk arrives the accumulated thinking text is discarded and only
+        // content is kept (user decision: thinking is not shown after the
+        // thinking phase ends).
+        if (!btwActiveRef.current || message.question !== btwActiveRef.current)
           break;
-        case "desktopThemeSource":
-          // Theme preference broadcast — keeps the settings selection in sync
-          // on every instance after 跟随系统/浅色/深色 is picked (the theme
-          // itself was already applied by the desktopThemeChange above).
-          setThemeSource(message.source);
-          break;
-        case "desktopUpdateChannel":
-          // Update-channel broadcast — keeps the 设置页「接收 Beta 版更新」开关
-          // 选中态 in sync on every instance after the toggle is flipped.
-          if (message.channel === "beta" || message.channel === "stable") {
-            setUpdateChannel(message.channel);
+        setBtwPanel((panel) => {
+          if (!panel) return panel;
+          const content =
+            typeof message.content === "string" ? message.content : "";
+          if (message.type === "content") {
+            const base = panel.contentStarted ? panel.answer : "";
+            return { ...panel, contentStarted: true, answer: base + content };
           }
-          break;
-        case "showToast":
-          // Toasts are window-global (no paneId) — only the root instance (the
-          // one that renders the shell/sidebar, never a split-view pane) tracks
-          // them, so a multi-pane desktop never stacks duplicates.
-          if (myPane !== undefined) break;
-          setToasts((prev) => [
-            ...prev.filter((t) => t.id !== message.toast.id),
-            message.toast,
-          ]);
-          break;
-        case "desktopAccountInfo":
-          // Sidebar account card — window-global like showToast (the sidebar
-          // renders on the root instance only), so pane instances ignore it.
-          if (myPane !== undefined) break;
-          setAccountInfo({
-            isAuthenticated: message.isAuthenticated === true,
-            user: message.user ?? null,
-            plan: message.plan ?? null,
-            apiQuota: message.apiQuota ?? null,
-            update: message.update ?? null,
-          });
-          break;
-        case "desktopTogglePanel":
-          if (!forThisPane(message)) break;
-          togglePanelRef.current(message.kind as DesktopPanelKind);
-          break;
-        case "showDialog":
-          if (!forThisPane(message)) break;
-          dispatch({
-            type: "SHOW_DIALOG",
-            payload: { type: message.dialogType },
-          });
-          break;
-        case "configurationUpdated":
-          dispatch({ type: "HIDE_DIALOG" });
-          break;
-        case "statusResponse":
-          if (!forThisPane(message)) break;
-          if (message.configurationData) {
-            dispatch({
-              type: "SET_CONFIGURATION_DATA",
-              payload: message.configurationData,
-            });
-          }
-          break;
-        case "configurationError":
-          if (!forThisPane(message)) break;
-          dispatch({ type: "SET_CONFIGURATION_ERROR", payload: message.error });
-          break;
-        case "prefillPrompt":
-          if (!forThisPane(message)) break;
-          // IDE 设置页（settings-preview-entry）「新建/编辑」经 host 转发：
-          // 关闭设置 tab 后向聊天 webview 下发预填提示词（spec：AI 对话框
-          // 在当前会话继续，预填文本可编辑）。
-          if (typeof message.prompt === "string") {
-            messageInputRef.current?.loadDraft(message.prompt);
-          }
-          break;
-        case "focusInput":
-          if (!forThisPane(message)) break;
-          // When a confirm/rewind dialog is open in this pane, focus its
-          // primary action instead of the message input. The input is hidden
-          // (display:none) during a tool-permission confirmation, so focusing it
-          // silently no-ops; a rewind modal also covers it. Landing focus on
-          // the dialog lets the user act on it immediately (Enter to confirm,
-          // Esc to cancel) right after the pane switch. Falls back to the
-          // message input when no dialog is open.
-          {
-            const root = chatContainerRef.current ?? document;
-            const rewindBtn = root.querySelector<HTMLElement>(
-              ".confirm-dialog-btn-confirm:not([disabled])",
-            );
-            if (rewindBtn) {
-              rewindBtn.focus();
-              break;
-            }
-            const applyBtn = root.querySelector<HTMLElement>(
-              ".confirmation-btn-apply:not([disabled])",
-            );
-            if (applyBtn) {
-              applyBtn.focus();
-              break;
-            }
-            if (
-              messageInputRef.current &&
-              typeof messageInputRef.current.focus === "function"
-            ) {
-              messageInputRef.current.focus();
-            }
-          }
-          break;
-        case "triggerShortcut":
-          if (!forThisPane(message)) break;
-          // Forwarded IDE keymap shortcut (JetBrains): the component-scoped AnAction
-          // intercepts the IDE action and forwards the intended operation here, since
-          // registerCustomShortcutSet consumes the AWT event before CEF can see it.
-          if (
-            messageInputRef.current &&
-            typeof messageInputRef.current.triggerShortcut === "function"
-          ) {
-            messageInputRef.current.triggerShortcut(message.name);
-          }
-          break;
-        case "scrollToBottom":
-          if (!forThisPane(message)) break;
-          // Scroll the message list to bottom
+          if (panel.contentStarted) return panel;
+          return { ...panel, answer: panel.answer + content };
+        });
+        break;
+      case "btwResponse":
+        if (!forThisPane(message)) break;
+        // Drop late replies: the panel must be open, the panel's question must
+        // still match the in-flight one, and the reply must echo the same question.
+        if (btwActiveRef.current && message.question === btwActiveRef.current) {
+          setBtwPanel((panel) =>
+            panel
+              ? { ...panel, answer: message.answer ?? "", loading: false }
+              : panel,
+          );
+        }
+        break;
+      case "btwError":
+        if (!forThisPane(message)) break;
+        if (btwActiveRef.current && message.question === btwActiveRef.current) {
+          setBtwPanel((panel) =>
+            panel
+              ? {
+                  ...panel,
+                  answer: `(API error: ${message.error ?? "unknown"})`,
+                  loading: false,
+                }
+              : panel,
+          );
+        }
+        break;
+      // Test-only handlers
+      case "startStreaming":
+        if (!forThisPane(message)) break;
+        dispatch({ type: "START_STREAMING" });
+        break;
+      case "endStreaming":
+        if (!forThisPane(message)) break;
+        dispatch({ type: "END_STREAMING" });
+        break;
+      case "ensureUIReset":
+        if (!forThisPane(message)) break;
+        dispatch({ type: "END_STREAMING" });
+        break;
+      case "updateSessions":
+        dispatch({ type: "SET_SESSIONS", payload: message.sessions });
+        break;
+      case "updateCurrentSession":
+        if (!forThisPane(message)) break;
+        dispatch({ type: "SET_CURRENT_SESSION", payload: message.session });
+        break;
+      case "showConfirmation":
+        if (!forThisPane(message)) break;
+        // Plan panel (desktop): the ExitPlanMode plan full text lives in the
+        // plan pane, not the (compact) confirmation dialog — mirror the VSCE
+        // claudePlanPreview panel and the JB editor column. The dialog gets
+        // the plan stripped so it stays small.
+        if (message.toolName === EXIT_PLAN_MODE_TOOL_NAME) {
+          routePlanToPanel(message.planContent);
+        }
+        dispatch({
+          type: "SHOW_CONFIRMATION",
+          payload: {
+            confirmationId: message.confirmationId,
+            toolName: message.toolName,
+            confirmationType: message.confirmationType,
+            toolInput: message.toolInput,
+            planContent:
+              message.toolName === EXIT_PLAN_MODE_TOOL_NAME
+                ? undefined
+                : message.planContent,
+            suggestedPrefix: message.suggestedPrefix,
+            hidePersistentOption: message.hidePersistentOption,
+            permissionMode: message.permissionMode,
+            warning: message.warning,
+          },
+        });
+        // Scroll to bottom when confirmation is shown
+        setTimeout(() => {
           if (
             messageListRef.current &&
             typeof messageListRef.current.scrollToBottom === "function"
           ) {
             messageListRef.current.scrollToBottom("smooth");
           }
-          break;
-        // Incremental update commands for streaming optimization
-        case "appendMessage":
-          if (!forThisPane(message)) break;
-          dispatch({ type: "APPEND_MESSAGE", payload: message.message });
-          break;
-        case "compactionStateChange":
-          if (!forThisPane(message)) break;
+        }, 0);
+        break;
+      case "planContent":
+        // Desktop /plan display: host pushes the current plan file contents
+        // to the shared Plan pane (same routing as an ExitPlanMode plan).
+        if (!forThisPane(message)) break;
+        routePlanToPanel(message.content);
+        break;
+      case "configurationResponse":
+        dispatch({
+          type: "SET_CONFIGURATION_DATA",
+          payload: message.configurationData,
+        });
+        break;
+      case "projectSettings":
+        // Project settings (.wave/settings.json merged enabledPlugins) are
+        // per-workdir, so on Desktop each pane may hold a different value —
+        // must be pane-guarded (unlike the shared global configurationResponse).
+        // The reply is stamped with the workdir active when it lands so the
+        // 项目设置 view can tell whether the cached value still belongs to the
+        // current project (a stale reply for a switched-away directory must
+        // never masquerade as the current project's state).
+        if (!forThisPane(message)) break;
+        dispatch({
+          type: "SET_PROJECT_SETTINGS",
+          payload: {
+            enabledPlugins: message.enabledPlugins,
+            workdir: effectiveWorkdirRef.current,
+          },
+        });
+        break;
+      case "setInitialState":
+        if (!forThisPane(message)) break;
+        // Desktop plan panel: replayed pending confirmations (pane rebind to a
+        // session with confirmations in flight) also carry an ExitPlanMode
+        // plan. It is staged — not routed here — because a same-batch pane
+        // rebind re-seeds tabs from the incoming cache after this handler runs
+        // and would wipe an eagerly opened plan tab (see the routing effect).
+        for (const c of message.pendingConfirmations ||
+          (message.pendingConfirmation ? [message.pendingConfirmation] : [])) {
+          if (
+            c.toolName === EXIT_PLAN_MODE_TOOL_NAME &&
+            typeof c.planContent === "string" &&
+            c.planContent.trim() !== ""
+          ) {
+            setPlanReplayContent(c.planContent);
+          }
+        }
+        dispatch({
+          type: "SET_INITIAL_STATE",
+          payload: {
+            messages: message.messages,
+            tasks: message.tasks,
+            isStreaming: message.isStreaming,
+            isCommandRunning: message.isCommandRunning,
+            isTaskListCollapsed: message.isTaskListCollapsed,
+            isRestoring: message.isRestoring,
+            sessions: message.sessions,
+            currentSession: message.session,
+            configurationData: message.configurationData,
+            pendingConfirmations:
+              message.pendingConfirmations ||
+              (message.pendingConfirmation
+                ? [message.pendingConfirmation]
+                : []),
+            selection: message.selection,
+            inputContent: message.inputContent,
+            permissionMode: message.permissionMode,
+            attachedImages: message.attachedImages,
+            queuedMessages: message.queuedMessages,
+            isAuthenticated: message.isAuthenticated,
+            workdir: message.workdir,
+            theme: message.theme,
+            updateChannel: message.updateChannel,
+            // Hosts (VSCE messageHandler / Desktop desktopHost) include the
+            // running background tasks + workflow runs in the snapshot so a
+            // webview re-init / pane switch does not wipe them. Without this
+            // the reducer falls back to [] and /tasks shows "暂无后台任务"
+            // until the next incremental updateBackgroundTasks (e.g. stop).
+            backgroundTasks: message.backgroundTasks,
+            workflowRuns: message.workflowRuns,
+          },
+        });
+        break;
+      case "desktopThemeChange":
+        document.documentElement.setAttribute("data-theme", message.effective);
+        break;
+      case "desktopThemeSource":
+        // Theme preference broadcast — keeps the settings selection in sync
+        // on every instance after 跟随系统/浅色/深色 is picked (the theme
+        // itself was already applied by the desktopThemeChange above).
+        setThemeSource(message.source);
+        break;
+      case "desktopUpdateChannel":
+        // Update-channel broadcast — keeps the 设置页「接收 Beta 版更新」开关
+        // 选中态 in sync on every instance after the toggle is flipped.
+        if (message.channel === "beta" || message.channel === "stable") {
+          setUpdateChannel(message.channel);
+        }
+        break;
+      case "showToast":
+        // Toasts are window-global (no paneId) — only the root instance (the
+        // one that renders the shell/sidebar, never a split-view pane) tracks
+        // them, so a multi-pane desktop never stacks duplicates.
+        if (myPane !== undefined) break;
+        setToasts((prev) => [
+          ...prev.filter((t) => t.id !== message.toast.id),
+          message.toast,
+        ]);
+        break;
+      case "desktopAccountInfo":
+        // Sidebar account card — window-global like showToast (the sidebar
+        // renders on the root instance only), so pane instances ignore it.
+        if (myPane !== undefined) break;
+        setAccountInfo({
+          isAuthenticated: message.isAuthenticated === true,
+          user: message.user ?? null,
+          plan: message.plan ?? null,
+          apiQuota: message.apiQuota ?? null,
+          update: message.update ?? null,
+        });
+        break;
+      case "desktopTogglePanel":
+        if (!forThisPane(message)) break;
+        togglePanelRef.current(message.kind as DesktopPanelKind);
+        break;
+      case "showDialog":
+        if (!forThisPane(message)) break;
+        dispatch({
+          type: "SHOW_DIALOG",
+          payload: { type: message.dialogType },
+        });
+        break;
+      case "configurationUpdated":
+        dispatch({ type: "HIDE_DIALOG" });
+        break;
+      case "statusResponse":
+        if (!forThisPane(message)) break;
+        if (message.configurationData) {
           dispatch({
-            type: "SET_COMPACTING",
-            payload: message.isCompacting === true,
+            type: "SET_CONFIGURATION_DATA",
+            payload: message.configurationData,
           });
-          if (!message.isCompacting) setCompactionStream("");
-          break;
-        case "compactionContentUpdate":
-          if (!forThisPane(message)) break;
-          // The CLI delivers the accumulated compaction text; the hint renders
-          // only its last 30 characters (streaming tail).
-          setCompactionStream(message.content);
-          break;
-        case "updateStreamingContent":
-          if (!forThisPane(message)) break;
-          dispatch({
-            type: "UPDATE_STREAMING_CONTENT",
-            payload: {
-              messageId: message.messageId,
-              chunk: message.chunk,
-              stage: message.stage,
-            },
-          });
-          break;
-        case "updateStreamingReasoning":
-          if (!forThisPane(message)) break;
-          dispatch({
-            type: "UPDATE_STREAMING_REASONING",
-            payload: {
-              messageId: message.messageId as string,
-              chunk: message.chunk as string,
-              stage: message.stage as "end" | "streaming",
-            },
-          });
-          break;
-        case "updateToolBlock":
-          if (!forThisPane(message)) break;
-          dispatch({
-            type: "UPDATE_TOOL_BLOCK",
-            payload: message.params as ToolBlockUpdateCallbackParams,
-          });
-          break;
-        case "updateErrorBlock":
-          if (!forThisPane(message)) break;
-          dispatch({
-            type: "APPEND_ERROR_BLOCK",
-            payload: { error: message.error },
-          });
-          break;
-        case "authStatusResponse":
-          dispatch({
-            type: "SET_AUTHENTICATED",
-            payload: message.isAuthenticated || false,
-          });
-          // The account card mirrors the host's per-host auth state; the user
-          // came along with the response (desktop host forwards it).
-          setAccountInfo((prev) => ({
-            ...(prev ?? { isAuthenticated: false }),
-            isAuthenticated: message.isAuthenticated === true,
-            user: message.user ?? prev?.user ?? null,
-          }));
-          break;
-        case "contextUsage":
-          // Context-window usage push (batch 2 上下文用量指示器). Session-scoped
-          // on desktop (each pane's session reports its own usage), so the reply
-          // is pane-routed like the other per-session pushes.
-          if (!forThisPane(message)) break;
-          setContextUsage(
-            typeof message.percent === "number"
-              ? Math.min(100, Math.max(0, message.percent))
-              : undefined,
+        }
+        break;
+      case "configurationError":
+        if (!forThisPane(message)) break;
+        dispatch({ type: "SET_CONFIGURATION_ERROR", payload: message.error });
+        break;
+      case "prefillPrompt":
+        if (!forThisPane(message)) break;
+        // IDE 设置页（settings-preview-entry）「新建/编辑」经 host 转发：
+        // 关闭设置 tab 后向聊天 webview 下发预填提示词（spec：AI 对话框
+        // 在当前会话继续，预填文本可编辑）。
+        if (typeof message.prompt === "string") {
+          messageInputRef.current?.loadDraft(message.prompt);
+        }
+        break;
+      case "focusInput":
+        if (!forThisPane(message)) break;
+        // When a confirm/rewind dialog is open in this pane, focus its
+        // primary action instead of the message input. The input is hidden
+        // (display:none) during a tool-permission confirmation, so focusing it
+        // silently no-ops; a rewind modal also covers it. Landing focus on
+        // the dialog lets the user act on it immediately (Enter to confirm,
+        // Esc to cancel) right after the pane switch. Falls back to the
+        // message input when no dialog is open.
+        {
+          const root = chatContainerRef.current ?? document;
+          const rewindBtn = root.querySelector<HTMLElement>(
+            ".confirm-dialog-btn-confirm:not([disabled])",
           );
-          break;
-        case "agentsContentResponse":
-          // AGENTS.md editor contents (settings 个性化 view). Requested by the
-          // settings page (root instance only), so replies are untagged — the
-          // pane guard below would drop them in a split-view pane, which is
-          // correct: panes never render the settings page.
-          if (message.scope === "project") {
-            setProjectAgentsContent(
-              typeof message.content === "string" ? message.content : "",
-            );
-          } else {
-            setUserAgentsContent(
-              typeof message.content === "string" ? message.content : "",
-            );
+          if (rewindBtn) {
+            rewindBtn.focus();
+            break;
           }
-          break;
-        case "agentsContentSaved":
-          // AGENTS.md save outcome push (setAgentsContent RPC reply), untagged
-          // like agentsContentResponse — consumed only by the settings page.
-          setAgentsSaving(false);
-          setAgentsSaveResult({
-            scope: message.scope === "project" ? "project" : "user",
-            ok: message.ok === true,
-            error:
-              typeof message.error === "string" ? message.error : undefined,
+          const applyBtn = root.querySelector<HTMLElement>(
+            ".confirmation-btn-apply:not([disabled])",
+          );
+          if (applyBtn) {
+            applyBtn.focus();
+            break;
+          }
+          if (
+            messageInputRef.current &&
+            typeof messageInputRef.current.focus === "function"
+          ) {
+            messageInputRef.current.focus();
+          }
+        }
+        break;
+      case "triggerShortcut":
+        if (!forThisPane(message)) break;
+        // Forwarded IDE keymap shortcut (JetBrains): the component-scoped AnAction
+        // intercepts the IDE action and forwards the intended operation here, since
+        // registerCustomShortcutSet consumes the AWT event before CEF can see it.
+        if (
+          messageInputRef.current &&
+          typeof messageInputRef.current.triggerShortcut === "function"
+        ) {
+          messageInputRef.current.triggerShortcut(message.name);
+        }
+        break;
+      case "scrollToBottom":
+        if (!forThisPane(message)) break;
+        // Scroll the message list to bottom
+        if (
+          messageListRef.current &&
+          typeof messageListRef.current.scrollToBottom === "function"
+        ) {
+          messageListRef.current.scrollToBottom("smooth");
+        }
+        break;
+      // Incremental update commands for streaming optimization
+      case "appendMessage":
+        if (!forThisPane(message)) break;
+        dispatch({ type: "APPEND_MESSAGE", payload: message.message });
+        break;
+      case "compactionStateChange":
+        if (!forThisPane(message)) break;
+        dispatch({
+          type: "SET_COMPACTING",
+          payload: message.isCompacting === true,
+        });
+        if (!message.isCompacting) setCompactionStream("");
+        break;
+      case "compactionContentUpdate":
+        if (!forThisPane(message)) break;
+        // The CLI delivers the accumulated compaction text; the hint renders
+        // only its last 30 characters (streaming tail).
+        setCompactionStream(message.content);
+        break;
+      case "updateStreamingContent":
+        if (!forThisPane(message)) break;
+        dispatch({
+          type: "UPDATE_STREAMING_CONTENT",
+          payload: {
+            messageId: message.messageId,
+            chunk: message.chunk,
+            stage: message.stage,
+          },
+        });
+        break;
+      case "updateStreamingReasoning":
+        if (!forThisPane(message)) break;
+        dispatch({
+          type: "UPDATE_STREAMING_REASONING",
+          payload: {
+            messageId: message.messageId as string,
+            chunk: message.chunk as string,
+            stage: message.stage as "end" | "streaming",
+          },
+        });
+        break;
+      case "updateToolBlock":
+        if (!forThisPane(message)) break;
+        dispatch({
+          type: "UPDATE_TOOL_BLOCK",
+          payload: message.params as ToolBlockUpdateCallbackParams,
+        });
+        break;
+      case "updateErrorBlock":
+        if (!forThisPane(message)) break;
+        dispatch({
+          type: "APPEND_ERROR_BLOCK",
+          payload: { error: message.error },
+        });
+        break;
+      case "authStatusResponse":
+        dispatch({
+          type: "SET_AUTHENTICATED",
+          payload: message.isAuthenticated || false,
+        });
+        // The account card mirrors the host's per-host auth state; the user
+        // came along with the response (desktop host forwards it).
+        setAccountInfo((prev) => ({
+          ...(prev ?? { isAuthenticated: false }),
+          isAuthenticated: message.isAuthenticated === true,
+          user: message.user ?? prev?.user ?? null,
+        }));
+        break;
+      case "contextUsage":
+        // Context-window usage push (batch 2 上下文用量指示器). Session-scoped
+        // on desktop (each pane's session reports its own usage), so the reply
+        // is pane-routed like the other per-session pushes.
+        if (!forThisPane(message)) break;
+        setContextUsage(
+          typeof message.percent === "number"
+            ? Math.min(100, Math.max(0, message.percent))
+            : undefined,
+        );
+        break;
+      case "agentsContentResponse":
+        // AGENTS.md editor contents (settings 个性化 view). Requested by the
+        // settings page (root instance only), so replies are untagged — the
+        // pane guard below would drop them in a split-view pane, which is
+        // correct: panes never render the settings page.
+        if (message.scope === "project") {
+          setProjectAgentsContent(
+            typeof message.content === "string" ? message.content : "",
+          );
+        } else {
+          setUserAgentsContent(
+            typeof message.content === "string" ? message.content : "",
+          );
+        }
+        break;
+      case "agentsContentSaved":
+        // AGENTS.md save outcome push (setAgentsContent RPC reply), untagged
+        // like agentsContentResponse — consumed only by the settings page.
+        setAgentsSaving(false);
+        setAgentsSaveResult({
+          scope: message.scope === "project" ? "project" : "user",
+          ok: message.ok === true,
+          error: typeof message.error === "string" ? message.error : undefined,
+        });
+        break;
+      case "loginResponse":
+        if (message.success) {
+          dispatch({ type: "SET_AUTHENTICATED", payload: true });
+          setAccountInfo((prev) => ({
+            isAuthenticated: true,
+            user: message.user ?? prev?.user ?? null,
+            plan: prev?.plan ?? null,
+            apiQuota: prev?.apiQuota ?? null,
+          }));
+        }
+        break;
+      case "logoutResponse":
+        if (message.success) {
+          dispatch({ type: "SET_AUTHENTICATED", payload: false });
+          // 登出即清空用量 —— host 随后会推 desktopAccountInfo 全量快照。
+          setAccountInfo({
+            isAuthenticated: false,
+            user: null,
+            plan: null,
+            apiQuota: null,
           });
-          break;
-        case "loginResponse":
-          if (message.success) {
-            dispatch({ type: "SET_AUTHENTICATED", payload: true });
-            setAccountInfo((prev) => ({
-              isAuthenticated: true,
-              user: message.user ?? prev?.user ?? null,
-              plan: prev?.plan ?? null,
-              apiQuota: prev?.apiQuota ?? null,
-            }));
-          }
-          break;
-        case "logoutResponse":
-          if (message.success) {
-            dispatch({ type: "SET_AUTHENTICATED", payload: false });
-            // 登出即清空用量 —— host 随后会推 desktopAccountInfo 全量快照。
-            setAccountInfo({
-              isAuthenticated: false,
-              user: null,
-              plan: null,
-              apiQuota: null,
-            });
-          }
-          break;
-      }
-    };
+        }
+        break;
+    }
+  };
 
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, []);
+  useHostMessage(handleMessage);
 
   // Desktop multi-pane (FR-032): session-scoped commands carry this pane's id
   // so the host routes them to the agent bound to this pane. Untagged when

--- a/packages/webview/src/components/DesktopApp.tsx
+++ b/packages/webview/src/components/DesktopApp.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { ChatApp, prunePanelGroupCache } from "./ChatApp";
 import { DesktopChromeProvider } from "./DesktopChromeContext";
+import { useHostMessage } from "../utils/useHostMessage";
 import {
   VsCodeApi,
   DesktopWorkdirState,
@@ -37,46 +38,45 @@ export const DesktopApp: React.FC<DesktopAppProps> = ({ vscode }) => {
   const panesRef = useRef<DesktopPane[]>([]);
   const sessionTreeRef = useRef<DesktopSessionGroup[]>([]);
 
+  // Panel groups are remembered per session: keep entries for live pane
+  // buckets, pane-bound sessions, and sessions still in the sidebar tree —
+  // a deleted session forgets its panel group here.
+  const prunePanels = () => {
+    const keep = new Set<string>();
+    for (const p of panesRef.current) {
+      keep.add(`new:${p.paneId}`);
+      if (p.sessionId) keep.add(p.sessionId);
+    }
+    for (const g of sessionTreeRef.current) {
+      for (const s of g.sessions) keep.add(s.sessionId);
+    }
+    prunePanelGroupCache(keep);
+  };
+
+  useHostMessage((message) => {
+    if (message.command === "desktopWorkdirState") {
+      setWorkdirState({
+        workdir: message.workdir,
+        recentWorkdirs: message.recentWorkdirs ?? [],
+        host: message.host ?? "local",
+        hosts: message.hosts ?? [],
+      });
+    } else if (message.command === "desktopSessionTree") {
+      sessionTreeRef.current = message.groups ?? [];
+      setSessionTree(sessionTreeRef.current);
+      prunePanels();
+    } else if (message.command === "desktopPanes") {
+      const nextPanes: DesktopPane[] = message.panes ?? [];
+      panesRef.current = nextPanes;
+      setPanes(nextPanes);
+      prunePanels();
+      setRowHeights(message.rowHeights);
+      setFocusedPaneId(message.focusedPaneId ?? null);
+    }
+  });
+
   useEffect(() => {
-    // Panel groups are remembered per session: keep entries for live pane
-    // buckets, pane-bound sessions, and sessions still in the sidebar tree —
-    // a deleted session forgets its panel group here.
-    const prunePanels = () => {
-      const keep = new Set<string>();
-      for (const p of panesRef.current) {
-        keep.add(`new:${p.paneId}`);
-        if (p.sessionId) keep.add(p.sessionId);
-      }
-      for (const g of sessionTreeRef.current) {
-        for (const s of g.sessions) keep.add(s.sessionId);
-      }
-      prunePanelGroupCache(keep);
-    };
-    const handleMessage = (event: MessageEvent) => {
-      const message = event.data;
-      if (message.command === "desktopWorkdirState") {
-        setWorkdirState({
-          workdir: message.workdir,
-          recentWorkdirs: message.recentWorkdirs ?? [],
-          host: message.host ?? "local",
-          hosts: message.hosts ?? [],
-        });
-      } else if (message.command === "desktopSessionTree") {
-        sessionTreeRef.current = message.groups ?? [];
-        setSessionTree(sessionTreeRef.current);
-        prunePanels();
-      } else if (message.command === "desktopPanes") {
-        const nextPanes: DesktopPane[] = message.panes ?? [];
-        panesRef.current = nextPanes;
-        setPanes(nextPanes);
-        prunePanels();
-        setRowHeights(message.rowHeights);
-        setFocusedPaneId(message.focusedPaneId ?? null);
-      }
-    };
-    window.addEventListener("message", handleMessage);
     vscode.postMessage({ command: "desktopReady" });
-    return () => window.removeEventListener("message", handleMessage);
   }, [vscode]);
 
   const handleSelectWorkdir = useCallback(() => {

--- a/packages/webview/src/components/DesktopChromeContext.tsx
+++ b/packages/webview/src/components/DesktopChromeContext.tsx
@@ -2,10 +2,10 @@ import React, {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useState,
 } from "react";
+import { useHostMessage } from "../utils/useHostMessage";
 
 /**
  * 窗口级（chrome）UI 状态单一权威 —— 解决「root 单布局 与 DesktopShell pane
@@ -53,15 +53,11 @@ export const DesktopChromeProvider: React.FC<{ children: React.ReactNode }> = ({
     useState<boolean>(readCollapsed);
   const [fullScreen, setFullScreen] = useState(false);
 
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      if (event.data?.command === "desktopFullScreen") {
-        setFullScreen(event.data.fullScreen === true);
-      }
-    };
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, []);
+  useHostMessage((message) => {
+    if (message?.command === "desktopFullScreen") {
+      setFullScreen(message.fullScreen === true);
+    }
+  });
 
   const setSidebarCollapsed = useCallback((collapsed: boolean) => {
     setSidebarCollapsedState(collapsed);

--- a/packages/webview/src/components/DesktopWorkdirSelector.tsx
+++ b/packages/webview/src/components/DesktopWorkdirSelector.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { useRovingMenu } from "../utils/useRovingMenu";
 import { useClickOutside } from "../utils/useClickOutside";
+import { useHostMessage } from "../utils/useHostMessage";
 import { ContextDirectoryIcon, PermCaretIcon, CloseIcon } from "./HeaderIcons";
 import "../styles/DesktopApp.css";
 
@@ -140,11 +141,10 @@ export const DesktopWorkdirSelector: React.FC<DesktopWorkdirSelectorProps> = ({
   );
 
   // Consume requestId-matched replies. Stale replies (panel closed, a newer
-  // request superseded this one) are dropped.
-  useEffect(() => {
-    if (!browsing) return;
-    const onMessage = (e: MessageEvent) => {
-      const message = e.data;
+  // request superseded this one) are dropped. Routing is by requestId (request
+  // correlation), not message.paneId; listener only active while browsing.
+  useHostMessage(
+    (message) => {
       if (message.command !== "desktopRemoteDirList") return;
       if (String(message.requestId) !== String(requestIdRef.current)) return;
       setLoading(false);
@@ -155,10 +155,9 @@ export const DesktopWorkdirSelector: React.FC<DesktopWorkdirSelectorProps> = ({
       setCurrentPath(message.resolvedPath);
       setDirs(message.dirs ?? []);
       lastPathRef.current = message.resolvedPath;
-    };
-    window.addEventListener("message", onMessage);
-    return () => window.removeEventListener("message", onMessage);
-  }, [browsing]);
+    },
+    { enabled: browsing },
+  );
 
   const handleBrowse = useCallback(() => {
     onSelectWorkdir();

--- a/packages/webview/src/components/DiffPane.tsx
+++ b/packages/webview/src/components/DiffPane.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import type { VsCodeApi } from "../types";
+import { useHostMessage } from "../utils/useHostMessage";
 import { renderWordLevelDiff } from "../utils/diffHighlight";
 import { RefreshIcon } from "./HeaderIcons";
 import "../styles/DiffViewer.css";
@@ -156,12 +157,12 @@ export const DiffPane: React.FC<DiffPaneProps> = ({
     [vscode, paneId],
   );
 
-  useEffect(() => {
-    const onMessage = (event: MessageEvent) => {
-      const msg = event.data;
-      if (msg?.command !== "desktopWorkspaceDiff") return;
-      if (paneId !== undefined && msg.paneId !== paneId) return;
-      const result = msg.result;
+  // Pane routing lives in the hook (paneId option): a pane instance only
+  // consumes replies tagged with its own id.
+  useHostMessage(
+    (message) => {
+      if (message?.command !== "desktopWorkspaceDiff") return;
+      const result = message.result;
       setRefreshing(false);
       setState(
         result?.kind === "ok"
@@ -171,10 +172,9 @@ export const DiffPane: React.FC<DiffPaneProps> = ({
       // Default the first file to expanded on the first diff; keep the
       // currently expanded file across refreshes once the user has chosen one.
       setExpandedPath((prev) => prev ?? result?.files?.[0]?.path ?? null);
-    };
-    window.addEventListener("message", onMessage);
-    return () => window.removeEventListener("message", onMessage);
-  }, [paneId]);
+    },
+    { paneId },
+  );
 
   // Refresh triggers: first mount (prev.visible starts false), re-show,
   // session/workdir change while visible, generation end while visible.

--- a/packages/webview/src/components/FilePane.tsx
+++ b/packages/webview/src/components/FilePane.tsx
@@ -11,6 +11,7 @@ import hljs from "highlight.js/lib/common";
 import type { FileItem, FileViewState, VsCodeApi } from "../types";
 import { toRelativePath } from "../utils/messageUtils";
 import { useClickOutside } from "../utils/useClickOutside";
+import { useHostMessage } from "../utils/useHostMessage";
 import { FileSuggestionDropdown } from "./FileSuggestionDropdown";
 import { PanelKindIcon } from "./PanelKindIcon";
 import "../styles/FilePane.css";
@@ -367,28 +368,30 @@ export const FilePane: React.FC<FilePaneProps> = ({
   );
 
   // Listen for the host's file suggestions reply (same channel as @ mention).
-  useEffect(() => {
+  // Routing is by requestId (request correlation), not message.paneId.
+  useHostMessage((data) => {
     if (!vscode) return;
-    const handleMessage = (event: MessageEvent) => {
-      const data = event.data;
-      if (data.command === "fileSuggestionsResponse") {
-        if (data.requestId !== searchRequestIdRef.current) return;
-        setSearchSuggestions(data.suggestions || []);
-        setSearchSelectedIndex(0);
-        setSearchLoading(false);
-      } else if (data.command === "fileSuggestionsError") {
-        if (data.requestId !== searchRequestIdRef.current) return;
-        setSearchSuggestions([]);
-        setSearchLoading(false);
-        console.error("文件搜索失败:", data.error);
-      }
-    };
-    window.addEventListener("message", handleMessage);
-    return () => {
-      window.removeEventListener("message", handleMessage);
+    if (data.command === "fileSuggestionsResponse") {
+      if (data.requestId !== searchRequestIdRef.current) return;
+      setSearchSuggestions(data.suggestions || []);
+      setSearchSelectedIndex(0);
+      setSearchLoading(false);
+    } else if (data.command === "fileSuggestionsError") {
+      if (data.requestId !== searchRequestIdRef.current) return;
+      setSearchSuggestions([]);
+      setSearchLoading(false);
+      console.error("文件搜索失败:", data.error);
+    }
+  });
+
+  // Clear a pending search debounce on unmount (was the listener effect's
+  // cleanup before the message listener moved into useHostMessage).
+  useEffect(
+    () => () => {
       if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
-    };
-  }, [vscode]);
+    },
+    [],
+  );
 
   // Per-line fragments: syntax-highlighted (balanced spans) or plain text.
   const contentLines = useMemo(() => {

--- a/packages/webview/src/components/HistorySearchPopup.tsx
+++ b/packages/webview/src/components/HistorySearchPopup.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState, useCallback } from "react";
 import { useClickOutside } from "../utils/useClickOutside";
+import { useHostMessage } from "../utils/useHostMessage";
 import "../styles/HistorySearchPopup.css";
 import { HistoryItem, VsCodeApi } from "../types";
 
@@ -49,22 +50,16 @@ export const HistorySearchPopup: React.FC<HistorySearchPopupProps> = ({
   }, [isVisible, vscode]);
 
   // Handle messages from extension
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      const data = event.data;
-      if (data.command === "historyResponse") {
-        setItems(data.history || []);
-        setSelectedIndex(0);
-        setIsLoading(false);
-      } else if (data.command === "historyError") {
-        console.error("History error:", data.error);
-        setIsLoading(false);
-      }
-    };
-
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, []);
+  useHostMessage((data) => {
+    if (data.command === "historyResponse") {
+      setItems(data.history || []);
+      setSelectedIndex(0);
+      setIsLoading(false);
+    } else if (data.command === "historyError") {
+      console.error("History error:", data.error);
+      setIsLoading(false);
+    }
+  });
 
   // Auto-scroll selected item into view when navigation happens
   useEffect(() => {

--- a/packages/webview/src/components/McpDialog.tsx
+++ b/packages/webview/src/components/McpDialog.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState, useEffect, useRef } from "react";
 import { useClickOutside } from "../utils/useClickOutside";
+import { useHostMessage } from "../utils/useHostMessage";
 import { McpDialogProps, McpServerStatus } from "../types";
 import "../styles/ConfigurationDialog.css";
 
@@ -23,23 +24,15 @@ const McpDialog: React.FC<
     vscode?.postMessage({ command: "getMcpServers" });
   }, [vscode]);
 
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      const message = event.data;
-      switch (message.command) {
-        case "mcpServersResponse":
-          setMcpServers(message.servers || []);
-          setMcpConnecting({});
-          break;
-        case "mcpServersUpdate":
-          setMcpServers(message.servers || []);
-          setMcpConnecting({});
-          break;
-      }
-    };
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, []);
+  useHostMessage((message) => {
+    switch (message.command) {
+      case "mcpServersResponse":
+      case "mcpServersUpdate":
+        setMcpServers(message.servers || []);
+        setMcpConnecting({});
+        break;
+    }
+  });
 
   const handleConnectMcpServer = (serverName: string) => {
     setMcpConnecting((prev) => ({ ...prev, [serverName]: true }));

--- a/packages/webview/src/components/MessageInput.tsx
+++ b/packages/webview/src/components/MessageInput.tsx
@@ -9,6 +9,7 @@ import React, {
 } from "react";
 import { convertToMarkdown } from "../utils/messageUtils";
 import { useRovingMenu } from "../utils/useRovingMenu";
+import { useHostMessage } from "../utils/useHostMessage";
 import { ContextTag } from "./ContextTag";
 import { Tooltip } from "./Tooltip";
 import ReactDOM from "react-dom/client";
@@ -846,48 +847,43 @@ export const MessageInput = forwardRef<
   );
 
   // Listen for file suggestions response from extension
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      const data = event.data;
-
-      if (data.command === "fileSuggestionsResponse") {
-        // Only process if this is the latest request
-        if (data.requestId === requestIdRef.current) {
-          setSuggestions(data.suggestions || []);
-          setSelectedIndex(0);
-          setIsLoadingSuggestions(false);
-        }
-      } else if (data.command === "fileSuggestionsError") {
-        if (data.requestId === requestIdRef.current) {
-          setSuggestions([]);
-          setIsLoadingSuggestions(false);
-          console.error("File suggestions error:", data.error);
-        }
-      } else if (data.command === "slashCommandsResponse") {
-        setSlashCommands(data.commands || []);
-        setSelectedSlashIndex(0);
-      } else if (data.command === "slashCommandsError") {
-        setSlashCommands([]);
-        console.error("指令错误:", data.error);
-      } else if (data.command === "uploadSuccess") {
-        // Insert uploaded file paths into the input after the @ symbol.
-        // In split view the host echoes the originating paneId; a reply for
-        // another pane must not insert into this input.
-        if (paneId !== undefined && data.paneId !== paneId) return;
-        if (data.uploadedFiles && data.uploadedFiles.length > 0) {
-          insertUploadedFilePaths(data.uploadedFiles);
-        }
-      } else if (data.command === "uploadError") {
-        console.error("文件上传失败:", data.error);
-        // Could show an error notification here if needed
-      } else if (data.command === "addSelectionToInput") {
-        insertSelectionTag(data.selection);
+  useHostMessage((data) => {
+    if (data.command === "fileSuggestionsResponse") {
+      // Only process if this is the latest request
+      if (data.requestId === requestIdRef.current) {
+        setSuggestions(data.suggestions || []);
+        setSelectedIndex(0);
+        setIsLoadingSuggestions(false);
       }
-    };
-
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, [insertUploadedFilePaths, insertSelectionTag, closeDropdown, paneId]);
+    } else if (data.command === "fileSuggestionsError") {
+      if (data.requestId === requestIdRef.current) {
+        setSuggestions([]);
+        setIsLoadingSuggestions(false);
+        console.error("File suggestions error:", data.error);
+      }
+    } else if (data.command === "slashCommandsResponse") {
+      setSlashCommands(data.commands || []);
+      setSelectedSlashIndex(0);
+    } else if (data.command === "slashCommandsError") {
+      setSlashCommands([]);
+      console.error("指令错误:", data.error);
+    } else if (data.command === "uploadSuccess") {
+      // Insert uploaded file paths into the input after the @ symbol.
+      // In split view the host echoes the originating paneId; a reply for
+      // another pane must not insert into this input. Inline (not the hook's
+      // paneId option): the other commands here are untagged and pane
+      // instances must still receive them.
+      if (paneId !== undefined && data.paneId !== paneId) return;
+      if (data.uploadedFiles && data.uploadedFiles.length > 0) {
+        insertUploadedFilePaths(data.uploadedFiles);
+      }
+    } else if (data.command === "uploadError") {
+      console.error("文件上传失败:", data.error);
+      // Could show an error notification here if needed
+    } else if (data.command === "addSelectionToInput") {
+      insertSelectionTag(data.selection);
+    }
+  });
 
   // Handle image preview
   const handleImagePreview = useCallback((url: string, name: string) => {

--- a/packages/webview/src/components/PluginDialog.tsx
+++ b/packages/webview/src/components/PluginDialog.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState, useEffect, useRef } from "react";
 import { useClickOutside } from "../utils/useClickOutside";
+import { useHostMessage } from "../utils/useHostMessage";
 import {
   PluginDialogProps,
   PluginInfo,
@@ -40,21 +41,16 @@ const PluginDialog: React.FC<
     setSelectedPlugin(null);
   }, [activePluginTab, vscode]);
 
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      const message = event.data;
-      switch (message.command) {
-        case "listPluginsResponse":
-          setPlugins(message.plugins || []);
-          break;
-        case "listMarketplacesResponse":
-          setMarketplaces(message.marketplaces || []);
-          break;
-      }
-    };
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, []);
+  useHostMessage((message) => {
+    switch (message.command) {
+      case "listPluginsResponse":
+        setPlugins(message.plugins || []);
+        break;
+      case "listMarketplacesResponse":
+        setMarketplaces(message.marketplaces || []);
+        break;
+    }
+  });
 
   const handleInstallPlugin = (pluginId: string, scope: PluginScope) => {
     vscode?.postMessage({ command: "installPlugin", pluginId, scope });

--- a/packages/webview/src/components/SettingsHooksView.tsx
+++ b/packages/webview/src/components/SettingsHooksView.tsx
@@ -10,6 +10,7 @@
  */
 
 import React, { useState, useEffect, useCallback } from "react";
+import { useHostMessage } from "../utils/useHostMessage";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { SettingsAddIcon } from "./HeaderIcons";
 import { SettingsTabs, type SettingsTabDef } from "./SettingsManageComponents";
@@ -105,22 +106,17 @@ const SettingsHooksView: React.FC<SettingsHooksViewProps> = ({
     fetchHooks(activeTab);
   }, [activeTab, fetchHooks]);
 
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      const message = event.data;
-      if (message.command === "hooksResponse") {
-        setHooks((message.hooks as HooksByEvent) || {});
-        if (typeof message.configPath === "string") {
-          setConfigPath(message.configPath);
-        } else {
-          setConfigPath(null);
-        }
-        setLoading(false);
+  useHostMessage((message) => {
+    if (message.command === "hooksResponse") {
+      setHooks((message.hooks as HooksByEvent) || {});
+      if (typeof message.configPath === "string") {
+        setConfigPath(message.configPath);
+      } else {
+        setConfigPath(null);
       }
-    };
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, []);
+      setLoading(false);
+    }
+  });
 
   // 平铺所有条目：{event, matcher, entry}
   const entries = Object.entries(hooks).flatMap(([event, configs]) =>

--- a/packages/webview/src/components/SettingsMcpView.tsx
+++ b/packages/webview/src/components/SettingsMcpView.tsx
@@ -11,6 +11,7 @@
 
 import React, { useState, useEffect, useCallback } from "react";
 import { McpServerStatus } from "../types";
+import { useHostMessage } from "../utils/useHostMessage";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { SettingsAddIcon } from "./HeaderIcons";
 import { SettingsTabs, type SettingsTabDef } from "./SettingsManageComponents";
@@ -65,31 +66,26 @@ const SettingsMcpView: React.FC<SettingsMcpViewProps> = ({
     fetchServers();
   }, [fetchServers]);
 
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      const message = event.data;
-      switch (message.command) {
-        case "mcpServersResponse":
-        case "mcpServersUpdate":
-          setMcpServers(message.servers || []);
-          setMcpConnecting({});
-          setLoading(false);
-          break;
-        case "mcpConfigPathsResponse":
-          setMcpConfigPaths({
-            userPath:
-              typeof message.userPath === "string" ? message.userPath : null,
-            projectPath:
-              typeof message.projectPath === "string"
-                ? message.projectPath
-                : null,
-          });
-          break;
-      }
-    };
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, []);
+  useHostMessage((message) => {
+    switch (message.command) {
+      case "mcpServersResponse":
+      case "mcpServersUpdate":
+        setMcpServers(message.servers || []);
+        setMcpConnecting({});
+        setLoading(false);
+        break;
+      case "mcpConfigPathsResponse":
+        setMcpConfigPaths({
+          userPath:
+            typeof message.userPath === "string" ? message.userPath : null,
+          projectPath:
+            typeof message.projectPath === "string"
+              ? message.projectPath
+              : null,
+        });
+        break;
+    }
+  });
 
   const handleConnect = (serverName: string) => {
     setMcpConnecting((prev) => ({ ...prev, [serverName]: true }));

--- a/packages/webview/src/components/SettingsSkillsView.tsx
+++ b/packages/webview/src/components/SettingsSkillsView.tsx
@@ -10,6 +10,7 @@
 
 import React, { useState, useEffect, useCallback } from "react";
 import { SkillMetadata } from "../types";
+import { useHostMessage } from "../utils/useHostMessage";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { SettingsAddIcon } from "./HeaderIcons";
 import { SettingsTabs, type SettingsTabDef } from "./SettingsManageComponents";
@@ -82,17 +83,12 @@ const SettingsSkillsView: React.FC<SettingsSkillsViewProps> = ({
     fetchSkills();
   }, [fetchSkills]);
 
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      const message = event.data;
-      if (message.command === "skillMetadataResponse") {
-        setSkills(message.skills || []);
-        setLoading(false);
-      }
-    };
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, []);
+  useHostMessage((message) => {
+    if (message.command === "skillMetadataResponse") {
+      setSkills(message.skills || []);
+      setLoading(false);
+    }
+  });
 
   const selectedSkill = skills.find((s) => s.name === selectedName) || null;
 

--- a/packages/webview/src/components/SettingsSubagentsView.tsx
+++ b/packages/webview/src/components/SettingsSubagentsView.tsx
@@ -10,6 +10,7 @@
 
 import React, { useState, useEffect, useCallback } from "react";
 import { SubagentConfiguration } from "../types";
+import { useHostMessage } from "../utils/useHostMessage";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { SettingsAddIcon } from "./HeaderIcons";
 import { SettingsTabs, type SettingsTabDef } from "./SettingsManageComponents";
@@ -65,17 +66,12 @@ const SettingsSubagentsView: React.FC<SettingsSubagentsViewProps> = ({
     fetchConfigurations();
   }, [fetchConfigurations]);
 
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      const message = event.data;
-      if (message.command === "subagentConfigurationsResponse") {
-        setConfigurations(message.configurations || []);
-        setLoading(false);
-      }
-    };
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, []);
+  useHostMessage((message) => {
+    if (message.command === "subagentConfigurationsResponse") {
+      setConfigurations(message.configurations || []);
+      setLoading(false);
+    }
+  });
 
   const selectedAgent =
     configurations.find((c) => c.name === selectedName) || null;

--- a/packages/webview/src/components/StatusDialog.tsx
+++ b/packages/webview/src/components/StatusDialog.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState, useEffect, useRef } from "react";
 import { useClickOutside } from "../utils/useClickOutside";
+import { useHostMessage } from "../utils/useHostMessage";
 import { StatusDialogProps } from "../types";
 import "../styles/ConfigurationDialog.css";
 
@@ -25,20 +26,15 @@ const StatusDialog: React.FC<
     vscode?.postMessage({ command: "getStatus" });
   }, [vscode]);
 
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      const message = event.data;
-      switch (message.command) {
-        case "statusResponse":
-          setVersion(message.version || "");
-          setSessionId(message.sessionId || "");
-          setWorkdir(message.workdir || "");
-          break;
-      }
-    };
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, []);
+  useHostMessage((message) => {
+    switch (message.command) {
+      case "statusResponse":
+        setVersion(message.version || "");
+        setSessionId(message.sessionId || "");
+        setWorkdir(message.workdir || "");
+        break;
+    }
+  });
 
   // Click-outside close (listener registered one tick later inside the hook,
   // so the click that opened this dialog doesn't immediately close it).

--- a/packages/webview/src/components/TerminalPane.tsx
+++ b/packages/webview/src/components/TerminalPane.tsx
@@ -4,6 +4,7 @@ import type { Terminal as XtermTerminal } from "@xterm/xterm";
 import type { FitAddon } from "@xterm/addon-fit";
 import type { WebLinksAddon } from "@xterm/addon-web-links";
 import { isLocalhostUrl } from "../utils/isLocalhostUrl";
+import { useHostMessage } from "../utils/useHostMessage";
 import { RefreshIcon } from "./HeaderIcons";
 import "../styles/TerminalPane.css";
 
@@ -157,6 +158,31 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({
     createPty();
   }, [killPty, createPty]);
 
+  // Host→PTY output stream + exit/theme pushes. Registered ahead of the mount
+  // effect below so early output is never missed while the xterm chunk loads;
+  // routing is by termId (derived pane identity), not message.paneId.
+  useHostMessage((message) => {
+    if (
+      message?.command === "desktopTerminalData" &&
+      message.termId === termIdRef.current
+    ) {
+      termRef.current?.write(message.data);
+    } else if (
+      message?.command === "desktopTerminalExit" &&
+      message.termId === termIdRef.current
+    ) {
+      liveRef.current = false;
+      setStatus({
+        kind: "exited",
+        detail:
+          message.error ?? `进程已退出（退出码 ${message.exitCode ?? "未知"}）`,
+      });
+    } else if (message?.command === "desktopThemeChange") {
+      // Follow the app theme live.
+      if (termRef.current) termRef.current.options.theme = readTerminalTheme();
+    }
+  });
+
   // Mount: load the xterm chunk, build the terminal, wire IO. Unmount does
   // NOT kill the PTY — the host owns its lifecycle (pane close, session
   // switch, app quit) — so a pane moved across rows remounts this component
@@ -164,30 +190,6 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({
   useEffect(() => {
     let disposed = false;
     let resizeObserver: ResizeObserver | null = null;
-
-    const onMessage = (event: MessageEvent) => {
-      const msg = event.data;
-      if (
-        msg?.command === "desktopTerminalData" &&
-        msg.termId === termIdRef.current
-      ) {
-        termRef.current?.write(msg.data);
-      } else if (
-        msg?.command === "desktopTerminalExit" &&
-        msg.termId === termIdRef.current
-      ) {
-        liveRef.current = false;
-        setStatus({
-          kind: "exited",
-          detail: msg.error ?? `进程已退出（退出码 ${msg.exitCode ?? "未知"}）`,
-        });
-      } else if (msg?.command === "desktopThemeChange") {
-        // Follow the app theme live.
-        if (termRef.current)
-          termRef.current.options.theme = readTerminalTheme();
-      }
-    };
-    window.addEventListener("message", onMessage);
 
     loadTerminalLib()
       .then((lib) => {
@@ -261,7 +263,6 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({
     return () => {
       disposed = true;
       resizeObserver?.disconnect();
-      window.removeEventListener("message", onMessage);
       termRef.current?.dispose();
       termRef.current = null;
       fitRef.current = null;

--- a/packages/webview/src/components/WorkflowManager.tsx
+++ b/packages/webview/src/components/WorkflowManager.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useClickOutside } from "../utils/useClickOutside";
+import { useHostMessage } from "../utils/useHostMessage";
 import { WorkflowManagerProps, SerializableWorkflowRun } from "../types";
 import "../styles/ConfigurationDialog.css";
 
@@ -48,16 +49,11 @@ const WorkflowManager: React.FC<
 
   const selectedRun = runs.find((r) => r.runId === selectedRunId) || null;
 
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      const message = event.data;
-      if (message.command === "workflowRunStopped") {
-        setStoppingId(null);
-      }
-    };
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, []);
+  useHostMessage((message) => {
+    if (message.command === "workflowRunStopped") {
+      setStoppingId(null);
+    }
+  });
 
   const handleStop = (runId: string) => {
     setStoppingId(runId);

--- a/packages/webview/src/settings-preview-entry.tsx
+++ b/packages/webview/src/settings-preview-entry.tsx
@@ -20,6 +20,7 @@ import ReactDOM from "react-dom/client";
 import SettingsPage from "./components/SettingsPage";
 import type { NavKey } from "./components/SettingsPage";
 import type { ConfigurationData } from "./types";
+import { useHostMessage } from "./utils/useHostMessage";
 import "./styles/globals.css";
 import "@vscode/codicons/dist/codicon.css";
 
@@ -78,62 +79,59 @@ function SettingsPreview() {
     // desktop full-page does via ChatApp).
     vscode.postMessage({ command: "getConfiguration" });
     vscode.postMessage({ command: "getAgentsContent", scope: "user" });
-
-    const handleMessage = (event: MessageEvent) => {
-      const msg = event.data as Record<string, unknown> | undefined;
-      if (!msg || typeof msg !== "object") return;
-      switch (msg.command) {
-        case "settingsState":
-          if (typeof msg.workdir === "string") {
-            setWorkdir(msg.workdir);
-            workdirRef.current = msg.workdir;
-          }
-          if (typeof msg.nav === "string") {
-            setInitialNav(msg.nav as NavKey);
-          }
-          break;
-        case "configurationResponse":
-          setConfigurationData(msg.configurationData as ConfigurationData);
-          setSaving(false);
-          break;
-        case "configurationError":
-          setConfigurationError(
-            typeof msg.error === "string" ? msg.error : "未知错误",
-          );
-          setSaving(false);
-          break;
-        case "agentsContentResponse":
-          if (msg.scope === "project") {
-            setProjectAgentsContent(
-              typeof msg.content === "string" ? msg.content : "",
-            );
-          } else {
-            setUserAgentsContent(
-              typeof msg.content === "string" ? msg.content : "",
-            );
-          }
-          break;
-        case "agentsContentSaved":
-          setAgentsSaving(false);
-          setAgentsSaveResult({
-            scope: msg.scope === "project" ? "project" : "user",
-            ok: msg.ok === true,
-            error: typeof msg.error === "string" ? msg.error : undefined,
-          });
-          break;
-        case "projectSettings":
-          if (msg.enabledPlugins && typeof msg.enabledPlugins === "object") {
-            setProjectSettings({
-              enabledPlugins: msg.enabledPlugins as Record<string, boolean>,
-            });
-            setProjectSettingsWorkdir(workdirRef.current);
-          }
-          break;
-      }
-    };
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
   }, []);
+
+  useHostMessage((msg) => {
+    if (!msg || typeof msg !== "object") return;
+    switch (msg.command) {
+      case "settingsState":
+        if (typeof msg.workdir === "string") {
+          setWorkdir(msg.workdir);
+          workdirRef.current = msg.workdir;
+        }
+        if (typeof msg.nav === "string") {
+          setInitialNav(msg.nav as NavKey);
+        }
+        break;
+      case "configurationResponse":
+        setConfigurationData(msg.configurationData as ConfigurationData);
+        setSaving(false);
+        break;
+      case "configurationError":
+        setConfigurationError(
+          typeof msg.error === "string" ? msg.error : "未知错误",
+        );
+        setSaving(false);
+        break;
+      case "agentsContentResponse":
+        if (msg.scope === "project") {
+          setProjectAgentsContent(
+            typeof msg.content === "string" ? msg.content : "",
+          );
+        } else {
+          setUserAgentsContent(
+            typeof msg.content === "string" ? msg.content : "",
+          );
+        }
+        break;
+      case "agentsContentSaved":
+        setAgentsSaving(false);
+        setAgentsSaveResult({
+          scope: msg.scope === "project" ? "project" : "user",
+          ok: msg.ok === true,
+          error: typeof msg.error === "string" ? msg.error : undefined,
+        });
+        break;
+      case "projectSettings":
+        if (msg.enabledPlugins && typeof msg.enabledPlugins === "object") {
+          setProjectSettings({
+            enabledPlugins: msg.enabledPlugins as Record<string, boolean>,
+          });
+          setProjectSettingsWorkdir(workdirRef.current);
+        }
+        break;
+    }
+  });
 
   return (
     <SettingsPage

--- a/packages/webview/src/utils/useHostMessage.ts
+++ b/packages/webview/src/utils/useHostMessage.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from "react";
+
+/** host→webview 消息负载（window "message" 事件的 event.data）。 */
+type HostMessage = MessageEvent["data"];
+
+export interface UseHostMessageOptions {
+  /**
+   * 分屏 pane 路由（DiffPane 语义）：设置后仅放行 `message.paneId === paneId`
+   * 的消息（未打标签的消息会被丢弃）；不设置（undefined）时不过滤。
+   *
+   * 注意这只覆盖「pane 实例只收自己的标签」这一种语义。以下站点的过滤语义
+   * 不同，保持各自内联处理，不得改用本选项：
+   * - ChatApp 根实例：未打标签的窗口级消息 + pane rows 隐藏期间代收标签消息
+   *   （forThisPane，见 ChatApp.tsx 内注释）。
+   * - TerminalPane：按 termId（`term-${paneId}` 派生身份）过滤，不是
+   *   message.paneId。
+   * - FilePane / MessageInput / DesktopWorkdirSelector：按 requestId 做
+   *   请求关联过滤；MessageInput 仅 uploadSuccess 单条命令按 paneId 过滤
+   *   （全局过滤会误杀 pane 实例要收的未打标签消息）。
+   */
+  paneId?: string;
+  /** false 时事件直接忽略、不进入 handler（默认 true）。 */
+  enabled?: boolean;
+}
+
+/**
+ * 订阅 host → webview 的 window "message" 通道。
+ *
+ * useClickOutside 同款先例模式：监听器只在挂载时注册一次、卸载时移除；每次
+ * 渲染传入的 onMessage 与 options 都是（可能）新引用，经 latest ref 在事件
+ * 到达时读取最新值——调用方无需把它们排进依赖数组，也不会出现「闭包冻结在
+ * 首帧」或「随渲染反复移除重挂监听器」。语义上等价于旧的「依赖数组变化时
+ * 重挂 + 新闭包」写法：消息永远由最新注册的处理逻辑消费。
+ *
+ * handler 收到的是 event.data（host 消息负载），命令分发（switch/if）由
+ * 调用方自理——各组件监听的命令集合与过滤条件差异较大，不在 hook 里建模。
+ */
+export function useHostMessage(
+  onMessage: (message: HostMessage) => void,
+  options: UseHostMessageOptions = {},
+): void {
+  // 最新值经 ref 读取：调用方每次渲染传入的 onMessage 与 options 都是新引用，
+  // 若直接进 effect 依赖会导致监听器每次渲染后重建。
+  const latest = useRef({ onMessage, options });
+  latest.current = { onMessage, options };
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      const { onMessage: handle, options: current } = latest.current;
+      if (current.enabled === false) return;
+      // 分屏 pane 路由：pane 实例只消费打了自己标签的消息（DiffPane 语义）。
+      const { paneId } = current;
+      if (paneId !== undefined && event.data?.paneId !== paneId) return;
+      handle(event.data);
+    };
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, []);
+}

--- a/packages/webview/tests/utils/useHostMessage.test.tsx
+++ b/packages/webview/tests/utils/useHostMessage.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useHostMessage } from "../../src/utils/useHostMessage";
+
+const dispatch = (data: unknown) => {
+  act(() => {
+    window.dispatchEvent(new MessageEvent("message", { data }));
+  });
+};
+
+describe("useHostMessage", () => {
+  it("dispatches host messages (event.data) to the handler", () => {
+    const handler = vi.fn();
+    renderHook(() => useHostMessage(handler));
+    dispatch({ command: "statusResponse", version: "1.0" });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({
+      command: "statusResponse",
+      version: "1.0",
+    });
+  });
+
+  it("always invokes the latest handler after re-renders", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(
+      ({ handler }: { handler: (message: unknown) => void }) =>
+        useHostMessage(handler),
+      { initialProps: { handler: first } },
+    );
+    rerender({ handler: second });
+    dispatch({ command: "ping" });
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("paneId set: drops untagged and sibling-tagged messages, keeps own tag", () => {
+    const handler = vi.fn();
+    renderHook(() => useHostMessage(handler, { paneId: "pane-a" }));
+    // 未打标签 → 丢弃（pane 实例只收自己的标签）
+    dispatch({ command: "desktopWorkspaceDiff" });
+    // 兄弟 pane 的标签 → 丢弃
+    dispatch({ command: "desktopWorkspaceDiff", paneId: "pane-b" });
+    expect(handler).not.toHaveBeenCalled();
+    // 自己的标签 → 放行
+    dispatch({ command: "desktopWorkspaceDiff", paneId: "pane-a" });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("paneId undefined: passes everything through unfiltered", () => {
+    const handler = vi.fn();
+    renderHook(() => useHostMessage(handler));
+    dispatch({ command: "desktopWorkspaceDiff" });
+    dispatch({ command: "desktopWorkspaceDiff", paneId: "pane-b" });
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it("enabled=false ignores events until enabled again", () => {
+    const handler = vi.fn();
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useHostMessage(handler, { enabled }),
+      { initialProps: { enabled: false } },
+    );
+    dispatch({ command: "ping" });
+    expect(handler).not.toHaveBeenCalled();
+    rerender({ enabled: true });
+    dispatch({ command: "ping" });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops listening after unmount", () => {
+    const handler = vi.fn();
+    const { unmount } = renderHook(() => useHostMessage(handler));
+    unmount();
+    dispatch({ command: "ping" });
+    expect(handler).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 背景

host_route_audit 调研报告（2026-09-04）既定下一步 P2 第 1 步：webview A 类去重。P0（#2088）/ P1（#2089 审计脚本 CI 门）已合并。**纯重构，零行为变化。**

## 收敛统计：19 处 → 1 处共享 hook

新增 `packages/webview/src/utils/useHostMessage.ts`（参照 `utils/useClickOutside` 先例模式：**稳定监听 + latest-ref**——监听器只在挂载时注册一次、卸载时移除；每次渲染传入的 handler/options 经 latest ref 在事件到达时读取最新值）。

迁移站点（18 个组件 19 处 useEffect + `addEventListener("message")` 样板；DiffPane 1 处 + 其余 18 处）：

| 站点 | 选项 |
|---|---|
| DiffPane | `paneId`（hook 收敛 pane 过滤：pane 实例只收打了自己标签的消息） |
| DesktopWorkdirSelector | `enabled: browsing` |
| ChatApp / DesktopApp / DesktopChromeContext / WorkflowManager / FilePane / MessageInput / PluginDialog / StatusDialog / McpDialog / HistorySearchPopup / SettingsHooksView / SettingsSubagentsView / SettingsSkillsView / SettingsMcpView / BackgroundTaskManager / TerminalPane / settings-preview-entry | 纯注册收敛 |

ChatApp 处理器提升到渲染作用域（原为 effect 内 once-registered 闭包）：所有可变捕获均为 ref 或稳定 setState，per-render 重建语义等价。switch 体零改动（`git diff -w` 仅 import/注释/签名/注册四处）。

## 豁免清单（特殊语义，保持内联 + 注释说明）

1. **plan-preview-entry.ts** —— 非 React 入口脚本（无组件生命周期），无法使用 hook。
2. **ChatApp `forThisPane`** —— 根实例双路路由（未打标签的窗口级消息 + pane rows 隐藏期间代收标签消息），不是 hook `paneId` 选项的简单等值语义，强行套用会改变行为。
3. **TerminalPane `termId` 过滤** —— 按 `term-${paneId}` 派生身份过滤，不是 `message.paneId`。
4. **FilePane / MessageInput / DesktopWorkdirSelector `requestId` 过滤** —— 请求关联过滤，非 pane 路由。
5. **MessageInput `uploadSuccess` 单命令 paneId 检查** —— 仅该命令按 paneId 过滤；若用 hook 全局 paneId 选项，会误杀 pane 实例必须接收的未打标签消息（slashCommandsResponse 等）。

## 语义说明（唯一需评审注意点）

- hook 采用 latest-ref：handler 总以最新渲染的闭包执行。与旧「依赖数组变化重挂 + 新闭包」等价；差异仅在 commit→passive-effect 之间的微竞态窗口内消息按新值处理（更可预测，无用户可观察行为变化）。
- ChatApp `myPane = paneIdRef.current` 从 effect 一次性读取改为渲染期读取：分屏 ChatApp 以 `pane.paneId` 为 key（DesktopShell.tsx:755）、根实例 paneId 恒 undefined，等价。

## 验证

- webview 全量单测：**109 文件 / 1006 测试全绿**（基线 1000 + hook 新增 6 例：命令派发/latest handler/paneId 过滤/enabled/卸载移除）
- type-check 4 配置绿（webview pre-commit 另跑全仓 6 包绿）
- oxlint 0 warnings 0 errors；prettier clean（ts/tsx；4 个 CSS warn 为既有基线，未触碰）
- e2e **44/44**；demo **99/99**
- `node scripts/audit-webview-commands.mjs` exit 0（P1 护栏未破坏）