### PR TITLE
refactor(webview): 5 个右面板骨架收敛为 PaneShell + PanePlaceholder（P2 A 类去重第 2 步）

### DIFF
--- a/packages/webview/src/components/DiffPane.tsx
+++ b/packages/webview/src/components/DiffPane.tsx
@@ -3,6 +3,7 @@ import type { VsCodeApi } from "../types";
 import { useHostMessage } from "../utils/useHostMessage";
 import { renderWordLevelDiff } from "../utils/diffHighlight";
 import { RefreshIcon } from "./HeaderIcons";
+import { PanePlaceholder, PaneShell } from "./PaneShell";
 import "../styles/DiffViewer.css";
 import "../styles/DiffPane.css";
 
@@ -445,13 +446,12 @@ export const DiffPane: React.FC<DiffPaneProps> = ({
   };
 
   return (
-    <aside
-      className="preview-pane diff-pane"
-      style={{ width }}
-      data-testid="diff-pane"
-    >
-      <div className="preview-pane-inner">
-        <div className="preview-pane-toolbar">
+    <PaneShell
+      kind="diff-pane"
+      dataTestId="diff-pane"
+      width={width}
+      toolbar={
+        <>
           <span className="desktop-panel-toolbar-title">差异</span>
           <button
             className="preview-pane-button"
@@ -463,21 +463,19 @@ export const DiffPane: React.FC<DiffPaneProps> = ({
               className={`preview-pane-icon${refreshing ? " is-spinning" : ""}`}
             />
           </button>
-        </div>
-        <div className="diff-pane-body">
-          {state.kind === "loading" && (
-            <div className="desktop-panel-placeholder">加载中…</div>
-          )}
-          {state.kind === "not-a-repo" && (
-            <div className="desktop-panel-placeholder">非 git 仓库</div>
-          )}
-          {state.kind === "ok" && state.files.length === 0 && (
-            <div className="desktop-panel-placeholder">无改动</div>
-          )}
-          {state.kind === "ok" && state.files.map(renderFile)}
-        </div>
-      </div>
-    </aside>
+        </>
+      }
+      bodyClassName="diff-pane-body"
+    >
+      {state.kind === "loading" && <PanePlaceholder>加载中…</PanePlaceholder>}
+      {state.kind === "not-a-repo" && (
+        <PanePlaceholder>非 git 仓库</PanePlaceholder>
+      )}
+      {state.kind === "ok" && state.files.length === 0 && (
+        <PanePlaceholder>无改动</PanePlaceholder>
+      )}
+      {state.kind === "ok" && state.files.map(renderFile)}
+    </PaneShell>
   );
 };
 

--- a/packages/webview/src/components/FilePane.tsx
+++ b/packages/webview/src/components/FilePane.tsx
@@ -14,6 +14,7 @@ import { useClickOutside } from "../utils/useClickOutside";
 import { useHostMessage } from "../utils/useHostMessage";
 import { FileSuggestionDropdown } from "./FileSuggestionDropdown";
 import { PanelKindIcon } from "./PanelKindIcon";
+import { PanePlaceholder, PaneShell } from "./PaneShell";
 import "../styles/FilePane.css";
 
 /** Debounce for the panel search requests, matching the message input's. */
@@ -434,13 +435,13 @@ export const FilePane: React.FC<FilePaneProps> = ({
   const markdown = fileView?.content ? isMarkdownPath(fileView.path) : false;
 
   return (
-    <aside
-      className="preview-pane file-pane"
-      style={{ width }}
-      data-testid="file-pane"
-    >
-      <div className="preview-pane-inner">
-        <div className="preview-pane-toolbar" ref={toolbarRef}>
+    <PaneShell
+      kind="file-pane"
+      dataTestId="file-pane"
+      width={width}
+      toolbarRef={toolbarRef}
+      toolbar={
+        <>
           {fileView ? (
             <>
               <span className="file-pane-host">
@@ -477,8 +478,11 @@ export const FilePane: React.FC<FilePaneProps> = ({
               <i className="codicon codicon-search" />
             </button>
           )}
-        </div>
-        {vscode && searchOpen && (
+        </>
+      }
+      betweenToolbarAndBody={
+        vscode &&
+        searchOpen && (
           <div
             className="file-pane-search-popover"
             ref={searchPopoverRef}
@@ -521,90 +525,84 @@ export const FilePane: React.FC<FilePaneProps> = ({
               direction="down"
             />
           </div>
-        )}
-        <div className="preview-pane-body file-pane-body" ref={scrollRef}>
-          {!fileView && (
-            <div className="desktop-panel-placeholder file-pane-placeholder-empty">
-              {/* Figma 文件面板空态：图标在上 24px、文案在下（评论 2026-09）。 */}
-              <PanelKindIcon
-                kind="file"
-                size={24}
-                className="file-pane-placeholder-icon"
-              />
-              <span>点击消息中的文件路径，在此查看文件内容</span>
-            </div>
-          )}
-          {fileView?.error && (
-            <div className="file-pane-status">
-              <i className="codicon codicon-error file-pane-status-icon" />
-              <span>{fileView.error}</span>
-            </div>
-          )}
-          {fileView &&
-            !fileView.error &&
-            !fileView.content &&
-            !fileView.imageBase64 && (
-              <div className="desktop-panel-placeholder">
-                <i className="codicon codicon-loading codicon-modifier-spin" />
-                <span>正在读取文件…</span>
-              </div>
-            )}
-          {fileView?.imageBase64 && !fileView.error && (
-            <img
-              className="file-pane-image"
-              src={fileView.imageBase64}
-              alt={relativePath || fileView.path}
-            />
-          )}
-          {fileView?.content && !fileView.error && markdown && (
-            <div
-              className="message-content markdown-content file-pane-markdown"
-              dangerouslySetInnerHTML={{
-                __html: renderFileMarkdown(fileView.content),
-              }}
-            />
-          )}
-          {fileView?.content &&
-            !fileView.error &&
-            !markdown &&
-            contentLines && (
-              <div className="file-pane-code">
-                {fileView.truncated && fileView.totalLines !== undefined && (
-                  <div className="file-pane-truncated-hint">
-                    文件共 {fileView.totalLines} 行，仅显示前{" "}
-                    {contentLines.length} 行
-                  </div>
-                )}
-                {contentLines.map((line, i) => {
-                  const lineNo = i + 1;
-                  const active =
-                    fileView.startLine !== undefined &&
-                    lineNo >= fileView.startLine &&
-                    (fileView.endLine === undefined ||
-                      lineNo <= fileView.endLine);
-                  return (
-                    <div
-                      key={i}
-                      className={`file-pane-line${active ? " file-pane-line--active" : ""}`}
-                    >
-                      <span className="file-pane-line-no">{lineNo}</span>
-                      <span
-                        className="file-pane-line-code"
-                        dangerouslySetInnerHTML={{ __html: line || "&nbsp;" }}
-                      />
-                    </div>
-                  );
-                })}
-                {fileView.truncated && fileView.totalLines === undefined && (
-                  <div className="file-pane-truncated-hint">
-                    文件较大，内容已截断
-                  </div>
-                )}
-              </div>
-            )}
+        )
+      }
+      bodyClassName="preview-pane-body file-pane-body"
+      bodyRef={scrollRef}
+    >
+      {!fileView && (
+        <PanePlaceholder className="file-pane-placeholder-empty">
+          {/* Figma 文件面板空态：图标在上 24px、文案在下（评论 2026-09）。 */}
+          <PanelKindIcon
+            kind="file"
+            size={24}
+            className="file-pane-placeholder-icon"
+          />
+          <span>点击消息中的文件路径，在此查看文件内容</span>
+        </PanePlaceholder>
+      )}
+      {fileView?.error && (
+        <div className="file-pane-status">
+          <i className="codicon codicon-error file-pane-status-icon" />
+          <span>{fileView.error}</span>
         </div>
-      </div>
-    </aside>
+      )}
+      {fileView &&
+        !fileView.error &&
+        !fileView.content &&
+        !fileView.imageBase64 && (
+          <PanePlaceholder>
+            <i className="codicon codicon-loading codicon-modifier-spin" />
+            <span>正在读取文件…</span>
+          </PanePlaceholder>
+        )}
+      {fileView?.imageBase64 && !fileView.error && (
+        <img
+          className="file-pane-image"
+          src={fileView.imageBase64}
+          alt={relativePath || fileView.path}
+        />
+      )}
+      {fileView?.content && !fileView.error && markdown && (
+        <div
+          className="message-content markdown-content file-pane-markdown"
+          dangerouslySetInnerHTML={{
+            __html: renderFileMarkdown(fileView.content),
+          }}
+        />
+      )}
+      {fileView?.content && !fileView.error && !markdown && contentLines && (
+        <div className="file-pane-code">
+          {fileView.truncated && fileView.totalLines !== undefined && (
+            <div className="file-pane-truncated-hint">
+              文件共 {fileView.totalLines} 行，仅显示前 {contentLines.length} 行
+            </div>
+          )}
+          {contentLines.map((line, i) => {
+            const lineNo = i + 1;
+            const active =
+              fileView.startLine !== undefined &&
+              lineNo >= fileView.startLine &&
+              (fileView.endLine === undefined || lineNo <= fileView.endLine);
+            return (
+              <div
+                key={i}
+                className={`file-pane-line${active ? " file-pane-line--active" : ""}`}
+              >
+                <span className="file-pane-line-no">{lineNo}</span>
+                <span
+                  className="file-pane-line-code"
+                  dangerouslySetInnerHTML={{ __html: line || "&nbsp;" }}
+                />
+              </div>
+            );
+          })}
+          {fileView.truncated && fileView.totalLines === undefined && (
+            <div className="file-pane-truncated-hint">文件较大，内容已截断</div>
+          )}
+        </div>
+      )}
+    </PaneShell>
   );
 };
 

--- a/packages/webview/src/components/PaneShell.tsx
+++ b/packages/webview/src/components/PaneShell.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+
+export interface PaneShellProps {
+  /** aside 附加的 pane 类型类（如 "diff-pane"）；预览 pane 无附加类。 */
+  kind?: string;
+  dataTestId: string;
+  width: number;
+  /** aside ref（PreviewPane 拖拽把手几何测量用）。 */
+  asideRef?: React.Ref<HTMLElement>;
+  toolbarRef?: React.Ref<HTMLDivElement>;
+  toolbar: React.ReactNode;
+  /** 工具栏与内容区之间的可选元素（FilePane 搜索弹层 / PreviewPane 拾取
+   * 不支持提示——两类面板的 body 之前还有一层与工具栏同级的浮层）。 */
+  betweenToolbarAndBody?: React.ReactNode;
+  /** body 类名（diff-pane-body / terminal-pane-body / preview-pane-body …）。 */
+  bodyClassName: string;
+  bodyTestId?: string;
+  bodyRef?: React.Ref<HTMLDivElement>;
+  children: React.ReactNode;
+}
+
+/**
+ * 桌面右面板通用骨架：`aside.preview-pane > .preview-pane-inner >
+ * (.preview-pane-toolbar + 可选浮层 + body)`。DOM 结构与类名和各 Pane 原本
+ * 手写的结构一致（视觉零变化、测试断言零变化）。
+ */
+export function PaneShell({
+  kind,
+  dataTestId,
+  width,
+  asideRef,
+  toolbarRef,
+  toolbar,
+  betweenToolbarAndBody,
+  bodyClassName,
+  bodyTestId,
+  bodyRef,
+  children,
+}: PaneShellProps) {
+  return (
+    <aside
+      ref={asideRef}
+      className={`preview-pane${kind ? ` ${kind}` : ""}`}
+      style={{ width }}
+      data-testid={dataTestId}
+    >
+      <div className="preview-pane-inner">
+        <div className="preview-pane-toolbar" ref={toolbarRef}>
+          {toolbar}
+        </div>
+        {betweenToolbarAndBody}
+        <div className={bodyClassName} ref={bodyRef} data-testid={bodyTestId}>
+          {children}
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+export interface PanePlaceholderProps {
+  /** 附加类（如 "plan-pane-placeholder-empty"）。 */
+  className?: string;
+  children: React.ReactNode;
+}
+
+/** 面板空态/加载占位（`.desktop-panel-placeholder`，图标+文案竖排居中）。 */
+export function PanePlaceholder({ className, children }: PanePlaceholderProps) {
+  return (
+    <div
+      className={`desktop-panel-placeholder${className ? ` ${className}` : ""}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/webview/src/components/PlanPane.tsx
+++ b/packages/webview/src/components/PlanPane.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { renderFileMarkdown } from "./FilePane";
 import { PanelKindIcon } from "./PanelKindIcon";
+import { PanePlaceholder, PaneShell } from "./PaneShell";
 import "../styles/PlanPane.css";
 
 export interface PlanPaneProps {
@@ -17,37 +18,32 @@ export interface PlanPaneProps {
  * claudePlanPreview panel and the JB editor column).
  */
 export const PlanPane: React.FC<PlanPaneProps> = ({ content, width }) => (
-  <aside
-    className="preview-pane plan-pane"
-    style={{ width }}
-    data-testid="plan-pane"
+  <PaneShell
+    kind="plan-pane"
+    dataTestId="plan-pane"
+    width={width}
+    toolbar={<span className="desktop-panel-toolbar-title">计划</span>}
+    bodyClassName="preview-pane-body"
   >
-    <div className="preview-pane-inner">
-      <div className="preview-pane-toolbar">
-        <span className="desktop-panel-toolbar-title">计划</span>
-      </div>
-      <div className="preview-pane-body">
-        {content ? (
-          <div
-            className="message-content markdown-content plan-pane-markdown"
-            data-testid="plan-pane-content"
-            dangerouslySetInnerHTML={{ __html: renderFileMarkdown(content) }}
-          />
-        ) : (
-          <div className="desktop-panel-placeholder plan-pane-placeholder-empty">
-            {/* 计划 pane 空态（评论 2026-09）：与文件/预览 pane 空态同格式
-                ——图标在上、文案在下竖排居中，图标 24px。 */}
-            <PanelKindIcon
-              kind="plan"
-              size={24}
-              className="plan-pane-placeholder-icon"
-            />
-            <span>等待计划生成…</span>
-          </div>
-        )}
-      </div>
-    </div>
-  </aside>
+    {content ? (
+      <div
+        className="message-content markdown-content plan-pane-markdown"
+        data-testid="plan-pane-content"
+        dangerouslySetInnerHTML={{ __html: renderFileMarkdown(content) }}
+      />
+    ) : (
+      <PanePlaceholder className="plan-pane-placeholder-empty">
+        {/* 计划 pane 空态（评论 2026-09）：与文件/预览 pane 空态同格式
+            ——图标在上、文案在下竖排居中，图标 24px。 */}
+        <PanelKindIcon
+          kind="plan"
+          size={24}
+          className="plan-pane-placeholder-icon"
+        />
+        <span>等待计划生成…</span>
+      </PanePlaceholder>
+    )}
+  </PaneShell>
 );
 
 export default PlanPane;

--- a/packages/webview/src/components/PreviewPane.tsx
+++ b/packages/webview/src/components/PreviewPane.tsx
@@ -6,6 +6,7 @@ import {
   RefreshIcon,
 } from "./HeaderIcons";
 import { PanelKindIcon } from "./PanelKindIcon";
+import { PaneShell } from "./PaneShell";
 
 /**
  * Desktop-only preview pane: renders localhost dev servers in a sandboxed
@@ -570,14 +571,12 @@ export const PreviewPane: React.FC<PreviewPaneProps> = ({
   const asideRef = useRef<HTMLElement | null>(null);
 
   return (
-    <aside
-      ref={asideRef}
-      className="preview-pane"
-      style={{ width }}
-      data-testid="preview-pane"
-    >
-      <div className="preview-pane-inner">
-        <div className="preview-pane-toolbar">
+    <PaneShell
+      dataTestId="preview-pane"
+      width={width}
+      asideRef={asideRef}
+      toolbar={
+        <>
           {addressEditing || !displayUrl ? (
             <input
               ref={addressInputRef}
@@ -628,50 +627,52 @@ export const PreviewPane: React.FC<PreviewPaneProps> = ({
           >
             <OpenBrowserIcon className="preview-pane-icon" />
           </button>
-        </div>
-        {pickerUnsupported && (
+        </>
+      }
+      betweenToolbarAndBody={
+        pickerUnsupported && (
           <div
             className="preview-pane-hint"
             data-testid="preview-picker-unsupported"
           >
             该页面暂不支持元素拾取
           </div>
-        )}
-        <div className="preview-pane-body">
-          <webview
-            ref={webviewRef}
-            className="preview-pane-webview"
-            preload={window.wavePickerPreloadPath}
-            webpreferences="sandbox=yes, contextIsolation=yes"
+        )
+      }
+      bodyClassName="preview-pane-body"
+    >
+      <webview
+        ref={webviewRef}
+        className="preview-pane-webview"
+        preload={window.wavePickerPreloadPath}
+        webpreferences="sandbox=yes, contextIsolation=yes"
+      />
+      {!displayUrl && (
+        <div className="preview-tab-new" data-testid="preview-tab-new">
+          <PanelKindIcon
+            kind="preview"
+            size={28}
+            className="preview-tab-new-icon"
           />
-          {!displayUrl && (
-            <div className="preview-tab-new" data-testid="preview-tab-new">
-              <PanelKindIcon
-                kind="preview"
-                size={28}
-                className="preview-tab-new-icon"
-              />
-              <span>在上方地址栏输入网址开始预览</span>
-            </div>
-          )}
-          {loadError && (
-            <div className="preview-pane-error" data-testid="preview-error">
-              <span>页面加载失败：{loadError}</span>
-              <button
-                className="preview-pane-button"
-                data-testid="preview-retry"
-                onClick={() => {
-                  setLoadError(null);
-                  (onRetry ?? handleRefresh)();
-                }}
-              >
-                重试
-              </button>
-            </div>
-          )}
+          <span>在上方地址栏输入网址开始预览</span>
         </div>
-      </div>
-    </aside>
+      )}
+      {loadError && (
+        <div className="preview-pane-error" data-testid="preview-error">
+          <span>页面加载失败：{loadError}</span>
+          <button
+            className="preview-pane-button"
+            data-testid="preview-retry"
+            onClick={() => {
+              setLoadError(null);
+              (onRetry ?? handleRefresh)();
+            }}
+          >
+            重试
+          </button>
+        </div>
+      )}
+    </PaneShell>
   );
 };
 

--- a/packages/webview/src/components/TerminalPane.tsx
+++ b/packages/webview/src/components/TerminalPane.tsx
@@ -6,6 +6,7 @@ import type { WebLinksAddon } from "@xterm/addon-web-links";
 import { isLocalhostUrl } from "../utils/isLocalhostUrl";
 import { useHostMessage } from "../utils/useHostMessage";
 import { RefreshIcon } from "./HeaderIcons";
+import { PanePlaceholder, PaneShell } from "./PaneShell";
 import "../styles/TerminalPane.css";
 
 declare global {
@@ -290,13 +291,12 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({
   }, [visible, sessionId, workdir, killPty, createPty]);
 
   return (
-    <aside
-      className="preview-pane terminal-pane"
-      style={{ width }}
-      data-testid="terminal-pane"
-    >
-      <div className="preview-pane-inner">
-        <div className="preview-pane-toolbar">
+    <PaneShell
+      kind="terminal-pane"
+      dataTestId="terminal-pane"
+      width={width}
+      toolbar={
+        <>
           <span className="desktop-panel-toolbar-title">终端</span>
           <button
             className="preview-pane-button"
@@ -306,30 +306,28 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({
           >
             <RefreshIcon className="desktop-panel-toolbar-icon" />
           </button>
-        </div>
-        <div
-          className="terminal-pane-body"
-          ref={containerRef}
-          data-testid="terminal-body"
-        >
-          {status.kind === "loading" && (
-            <div className="desktop-panel-placeholder">终端加载中…</div>
-          )}
-          {status.kind === "exited" && (
-            <div className="desktop-panel-placeholder terminal-pane-exited">
-              <span>{status.detail}</span>
-              <button
-                className="preview-pane-button"
-                data-testid="terminal-retry"
-                onClick={restart}
-              >
-                重启终端
-              </button>
-            </div>
-          )}
-        </div>
-      </div>
-    </aside>
+        </>
+      }
+      bodyClassName="terminal-pane-body"
+      bodyRef={containerRef}
+      bodyTestId="terminal-body"
+    >
+      {status.kind === "loading" && (
+        <PanePlaceholder>终端加载中…</PanePlaceholder>
+      )}
+      {status.kind === "exited" && (
+        <PanePlaceholder className="terminal-pane-exited">
+          <span>{status.detail}</span>
+          <button
+            className="preview-pane-button"
+            data-testid="terminal-retry"
+            onClick={restart}
+          >
+            重启终端
+          </button>
+        </PanePlaceholder>
+      )}
+    </PaneShell>
   );
 };
 


### PR DESCRIPTION
## 背景

host_route_audit P2 第 2 步（A 类去重，纯重构零行为变化）。第 1 步 #2124 已合并。

## 收敛统计

新增 `packages/webview/src/components/PaneShell.tsx`：

- **PaneShell**：右面板通用骨架 `aside.preview-pane[ kind] > .preview-pane-inner > (.preview-pane-toolbar + 可选浮层 + body)`。
- **PanePlaceholder**：`.desktop-panel-placeholder` 空态/加载占位。

| Pane | 收敛点 |
|---|---|
| PlanPane | 骨架 + 1 个占位 |
| DiffPane | 骨架 + 3 个占位 |
| TerminalPane | 骨架（body 带 ref/testId）+ 2 个占位 |
| FilePane | 骨架（toolbarRef、搜索弹层经 betweenToolbarAndBody、body 双类+ref）+ 2 个占位 |
| PreviewPane | 骨架（asideRef、拾取提示浮层）— 无占位 |

**5 处 aside/inner/toolbar 手写骨架 → 1 处 PaneShell；8 处 desktop-panel-placeholder → 1 处 PanePlaceholder。**

## 零行为变化保障

- 类名、DOM 层级、`data-testid`、ref 挂点逐项保持原样（CSS 选择器与测试断言不受影响；filePane.test.tsx 仅有的 2 处 `.preview-pane-toolbar` 断言继续成立）。
- FilePane 搜索弹层 / PreviewPane 拾取不支持提示原本就渲染在工具栏与 body 之间，与 PaneShell 的 `betweenToolbarAndBody` 插槽同级同序。
- 新增 0 个 CSS、0 个 className 变更。

## 验证

- webview 全量单测 **1006 全绿**；type-check 4 配置绿；oxlint 0/0；prettier clean
- e2e + demo 全量 **143/143**（含 desktop-panel-drag-resize / desktop-preview / desktop-file-panel / desktop-plan-pane 等直接覆盖 5 Pane 的用例）
- `node scripts/audit-webview-commands.mjs` exit 0