### PR TITLE
refactor(webview): useSettingsList 收敛 4 个设置列表视图状态机 + readRootCssVar 收敛 3 处主题变量读取

### DIFF
--- a/packages/webview/src/components/PreviewPane.tsx
+++ b/packages/webview/src/components/PreviewPane.tsx
@@ -7,6 +7,7 @@ import {
 } from "./HeaderIcons";
 import { PanelKindIcon } from "./PanelKindIcon";
 import { PaneShell } from "./PaneShell";
+import { readRootCssVar } from "../utils/cssVars";
 
 /**
  * Desktop-only preview pane: renders localhost dev servers in a sandboxed
@@ -111,26 +112,26 @@ const clampFitZoom = (z: number): number =>
 
 /** Colors the guest picker can't read cross-origin — sampled from the host theme. */
 const readPalette = (): Record<string, string> => {
-  const styles = getComputedStyle(document.documentElement);
-  const pick = (name: string, fallback: string) =>
-    styles.getPropertyValue(name).trim() || fallback;
   return {
-    accent: pick("--vscode-button-background", "#0e639c"),
-    accentForeground: pick("--vscode-button-foreground", "#ffffff"),
+    accent: readRootCssVar("--vscode-button-background", "#0e639c"),
+    accentForeground: readRootCssVar("--vscode-button-foreground", "#ffffff"),
     // 元素高亮框用链接蓝：桌面 host 取 --cc-text-link（Figma cc 蓝
     // #2f5edb/#4daafc），插件端回退 --vscode-textLink-foreground。
     // 桌面主按钮已被中性化成炭黑，若沿用 accent（button-background）
     // 选取框会变黑（评论跟进：不用 vscode focusBorder 色、与 link 一致）。
     accentOutline:
-      pick("--cc-text-link", "") ||
-      pick("--vscode-textLink-foreground", "#0069cc"),
-    foreground: pick("--vscode-foreground", "#cccccc"),
+      readRootCssVar("--cc-text-link") ||
+      readRootCssVar("--vscode-textLink-foreground", "#0069cc"),
+    foreground: readRootCssVar("--vscode-foreground", "#cccccc"),
     background:
-      pick("--vscode-panel-background", "") ||
-      pick("--vscode-editor-background", "#1e1e1e"),
-    border: pick("--vscode-panel-border", "rgba(128, 128, 128, 0.35)"),
-    inputBackground: pick("--vscode-input-background", "#3c3c3c"),
-    inputForeground: pick("--vscode-input-foreground", "#cccccc"),
+      readRootCssVar("--vscode-panel-background") ||
+      readRootCssVar("--vscode-editor-background", "#1e1e1e"),
+    border: readRootCssVar(
+      "--vscode-panel-border",
+      "rgba(128, 128, 128, 0.35)",
+    ),
+    inputBackground: readRootCssVar("--vscode-input-background", "#3c3c3c"),
+    inputForeground: readRootCssVar("--vscode-input-foreground", "#cccccc"),
   };
 };
 

--- a/packages/webview/src/components/SettingsHooksView.tsx
+++ b/packages/webview/src/components/SettingsHooksView.tsx
@@ -9,8 +9,8 @@
  * 2026-09-02：移除钩子启停开关与 enabled 字段（对齐 CC，钩子始终执行）。
  */
 
-import React, { useState, useEffect, useCallback } from "react";
-import { useHostMessage } from "../utils/useHostMessage";
+import React, { useState } from "react";
+import { useSettingsList } from "../utils/useSettingsList";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { SettingsAddIcon } from "./HeaderIcons";
 import { SettingsTabs, type SettingsTabDef } from "./SettingsManageComponents";
@@ -82,40 +82,28 @@ const SettingsHooksView: React.FC<SettingsHooksViewProps> = ({
   workdir,
   onPrefillPrompt,
 }) => {
-  const [hooks, setHooks] = useState<HooksByEvent>({});
   const [configPath, setConfigPath] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<string>(TABS[0].key);
-  // 待删除钩子（event+matcher 标识，null = 无确认框）
-  const [pendingDelete, setPendingDelete] = useState<{
-    event: string;
-    matcher?: string;
-  } | null>(null);
-
-  const fetchHooks = useCallback(
-    (scope: string) => {
-      setLoading(true);
-      vscode?.postMessage({ command: "getHooksByScope", scope });
+  const {
+    items: hooks,
+    setItems: setHooks,
+    loading,
+    pendingDelete,
+    setPendingDelete,
+    cancelDelete,
+    confirmDelete,
+  } = useSettingsList<HooksByEvent, { event: string; matcher?: string }>({
+    initialItems: {},
+    fetchRequest: () =>
+      vscode?.postMessage({ command: "getHooksByScope", scope: activeTab }),
+    fetchKey: activeTab,
+    responseCommands: ["hooksResponse"],
+    pickItems: (message) => (message.hooks as HooksByEvent) || {},
+    onResponse: (message) => {
+      setConfigPath(
+        typeof message.configPath === "string" ? message.configPath : null,
+      );
     },
-    [vscode],
-  );
-
-  // Fetch on mount and when the tab changes
-  useEffect(() => {
-    setPendingDelete(null);
-    fetchHooks(activeTab);
-  }, [activeTab, fetchHooks]);
-
-  useHostMessage((message) => {
-    if (message.command === "hooksResponse") {
-      setHooks((message.hooks as HooksByEvent) || {});
-      if (typeof message.configPath === "string") {
-        setConfigPath(message.configPath);
-      } else {
-        setConfigPath(null);
-      }
-      setLoading(false);
-    }
   });
 
   // 平铺所有条目：{event, matcher, entry}
@@ -149,25 +137,26 @@ const SettingsHooksView: React.FC<SettingsHooksViewProps> = ({
   };
 
   const handleConfirmDelete = () => {
-    if (!pendingDelete) return;
-    const name = formatHookName(pendingDelete.event, pendingDelete.matcher);
-    vscode?.postMessage({
-      command: "deleteHook",
-      scope: activeTab,
-      hookName: name,
-    });
-    setPendingDelete(null);
-    setHooks((prev) => {
-      const next: HooksByEvent = { ...prev };
-      const remaining = (next[pendingDelete.event] ?? []).filter(
-        (entry) => (entry.matcher || "") !== (pendingDelete.matcher || ""),
-      );
-      if (remaining.length > 0) {
-        next[pendingDelete.event] = remaining;
-      } else {
-        delete next[pendingDelete.event];
-      }
-      return next;
+    confirmDelete((target) => {
+      const name = formatHookName(target.event, target.matcher);
+      vscode?.postMessage({
+        command: "deleteHook",
+        scope: activeTab,
+        hookName: name,
+      });
+      // 乐观移除；host 回发 hooksResponse 后最终一致
+      setHooks((prev) => {
+        const next: HooksByEvent = { ...prev };
+        const remaining = (next[target.event] ?? []).filter(
+          (entry) => (entry.matcher || "") !== (target.matcher || ""),
+        );
+        if (remaining.length > 0) {
+          next[target.event] = remaining;
+        } else {
+          delete next[target.event];
+        }
+        return next;
+      });
     });
   };
 
@@ -281,7 +270,7 @@ const SettingsHooksView: React.FC<SettingsHooksViewProps> = ({
           confirmText="确认删除"
           cancelText="取消"
           onConfirm={handleConfirmDelete}
-          onCancel={() => setPendingDelete(null)}
+          onCancel={cancelDelete}
         />
       )}
     </div>

--- a/packages/webview/src/components/SettingsMcpView.tsx
+++ b/packages/webview/src/components/SettingsMcpView.tsx
@@ -9,9 +9,10 @@
  * （含 scope 字段）。
  */
 
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState } from "react";
 import { McpServerStatus } from "../types";
 import { useHostMessage } from "../utils/useHostMessage";
+import { useSettingsList } from "../utils/useSettingsList";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { SettingsAddIcon } from "./HeaderIcons";
 import { SettingsTabs, type SettingsTabDef } from "./SettingsManageComponents";
@@ -39,8 +40,24 @@ const SettingsMcpView: React.FC<SettingsMcpViewProps> = ({
   workdir,
   onPrefillPrompt,
 }) => {
-  const [mcpServers, setMcpServers] = useState<McpServerStatus[]>([]);
-  const [loading, setLoading] = useState(true);
+  const {
+    items: mcpServers,
+    setItems: setMcpServers,
+    loading,
+    pendingDelete,
+    setPendingDelete,
+    cancelDelete,
+    confirmDelete,
+  } = useSettingsList<McpServerStatus[], McpServerStatus>({
+    initialItems: [],
+    fetchRequest: () => {
+      vscode?.postMessage({ command: "getMcpServers" });
+      vscode?.postMessage({ command: "getMcpConfigPaths" });
+    },
+    responseCommands: ["mcpServersResponse", "mcpServersUpdate"],
+    pickItems: (message) => message.servers || [],
+    onResponse: () => setMcpConnecting({}),
+  });
   const [activeTab, setActiveTab] = useState<string>(TABS[0].key);
   const [mcpConnecting, setMcpConnecting] = useState<Record<string, boolean>>(
     {},
@@ -50,40 +67,15 @@ const SettingsMcpView: React.FC<SettingsMcpViewProps> = ({
     userPath: string | null;
     projectPath: string | null;
   } | null>(null);
-  // 待删除服务器（null = 无确认框）
-  const [pendingDelete, setPendingDelete] = useState<McpServerStatus | null>(
-    null,
-  );
-
-  const fetchServers = useCallback(() => {
-    vscode?.postMessage({ command: "getMcpServers" });
-    vscode?.postMessage({ command: "getMcpConfigPaths" });
-  }, [vscode]);
-
-  // Fetch MCP servers on mount
-  useEffect(() => {
-    setLoading(true);
-    fetchServers();
-  }, [fetchServers]);
 
   useHostMessage((message) => {
-    switch (message.command) {
-      case "mcpServersResponse":
-      case "mcpServersUpdate":
-        setMcpServers(message.servers || []);
-        setMcpConnecting({});
-        setLoading(false);
-        break;
-      case "mcpConfigPathsResponse":
-        setMcpConfigPaths({
-          userPath:
-            typeof message.userPath === "string" ? message.userPath : null,
-          projectPath:
-            typeof message.projectPath === "string"
-              ? message.projectPath
-              : null,
-        });
-        break;
+    if (message.command === "mcpConfigPathsResponse") {
+      setMcpConfigPaths({
+        userPath:
+          typeof message.userPath === "string" ? message.userPath : null,
+        projectPath:
+          typeof message.projectPath === "string" ? message.projectPath : null,
+      });
     }
   });
 
@@ -133,16 +125,16 @@ const SettingsMcpView: React.FC<SettingsMcpViewProps> = ({
   };
 
   const handleConfirmDelete = () => {
-    if (!pendingDelete) return;
-    const scope = (pendingDelete.scope ?? "project") as "user" | "project";
-    vscode?.postMessage({
-      command: "removeMcpServer",
-      scope,
-      serverName: pendingDelete.name,
+    confirmDelete((server) => {
+      const scope = (server.scope ?? "project") as "user" | "project";
+      vscode?.postMessage({
+        command: "removeMcpServer",
+        scope,
+        serverName: server.name,
+      });
+      // 乐观移除；host 回发 mcpServersResponse 后最终一致
+      setMcpServers((prev) => prev.filter((s) => s.name !== server.name));
     });
-    setPendingDelete(null);
-    // 乐观移除；host 回发 mcpServersResponse 后最终一致
-    setMcpServers((prev) => prev.filter((s) => s.name !== pendingDelete.name));
   };
 
   const configLabel = (server: McpServerStatus): string => {
@@ -294,7 +286,7 @@ const SettingsMcpView: React.FC<SettingsMcpViewProps> = ({
           confirmText="确认删除"
           cancelText="取消"
           onConfirm={handleConfirmDelete}
-          onCancel={() => setPendingDelete(null)}
+          onCancel={cancelDelete}
         />
       )}
     </div>

--- a/packages/webview/src/components/SettingsSkillsView.tsx
+++ b/packages/webview/src/components/SettingsSkillsView.tsx
@@ -8,9 +8,9 @@
  * 确认 + 直接删文件）。数据通过 getSkillMetadata RPC 由 host 下发。
  */
 
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState } from "react";
 import { SkillMetadata } from "../types";
-import { useHostMessage } from "../utils/useHostMessage";
+import { useSettingsList } from "../utils/useSettingsList";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { SettingsAddIcon } from "./HeaderIcons";
 import { SettingsTabs, type SettingsTabDef } from "./SettingsManageComponents";
@@ -64,31 +64,22 @@ const SettingsSkillsView: React.FC<SettingsSkillsViewProps> = ({
   workdir,
   onPrefillPrompt,
 }) => {
-  const [skills, setSkills] = useState<SkillMetadata[]>([]);
-  const [loading, setLoading] = useState(true);
+  const {
+    items: skills,
+    loading,
+    refresh,
+    pendingDelete,
+    setPendingDelete,
+    cancelDelete,
+    confirmDelete,
+  } = useSettingsList<SkillMetadata[], SkillMetadata>({
+    initialItems: [],
+    fetchRequest: () => vscode?.postMessage({ command: "getSkillMetadata" }),
+    responseCommands: ["skillMetadataResponse"],
+    pickItems: (message) => message.skills || [],
+  });
   const [activeTab, setActiveTab] = useState<string>(TABS[0].key);
   const [selectedName, setSelectedName] = useState<string | null>(null);
-  // 待删除技能（null = 无确认框）
-  const [pendingDelete, setPendingDelete] = useState<SkillMetadata | null>(
-    null,
-  );
-
-  const fetchSkills = useCallback(() => {
-    vscode?.postMessage({ command: "getSkillMetadata" });
-  }, [vscode]);
-
-  // Fetch skill metadata on mount (fresh each time the tab opens)
-  useEffect(() => {
-    setLoading(true);
-    fetchSkills();
-  }, [fetchSkills]);
-
-  useHostMessage((message) => {
-    if (message.command === "skillMetadataResponse") {
-      setSkills(message.skills || []);
-      setLoading(false);
-    }
-  });
 
   const selectedSkill = skills.find((s) => s.name === selectedName) || null;
 
@@ -122,11 +113,11 @@ const SettingsSkillsView: React.FC<SettingsSkillsViewProps> = ({
   };
 
   const handleConfirmDelete = () => {
-    if (!pendingDelete) return;
-    vscode?.postMessage({ command: "deleteSkill", name: pendingDelete.name });
-    setPendingDelete(null);
-    // 列表刷新依赖 host 回发 skillMetadataResponse（删除后重新拉取）
-    fetchSkills();
+    confirmDelete((skill) => {
+      vscode?.postMessage({ command: "deleteSkill", name: skill.name });
+      // 列表刷新依赖 host 回发 skillMetadataResponse（删除后重新拉取）
+      refresh();
+    });
   };
 
   const invocationLabel = (skill: SkillMetadata): string => {
@@ -332,7 +323,7 @@ const SettingsSkillsView: React.FC<SettingsSkillsViewProps> = ({
           confirmText="确认删除"
           cancelText="取消"
           onConfirm={handleConfirmDelete}
-          onCancel={() => setPendingDelete(null)}
+          onCancel={cancelDelete}
         />
       )}
     </div>

--- a/packages/webview/src/components/SettingsSubagentsView.tsx
+++ b/packages/webview/src/components/SettingsSubagentsView.tsx
@@ -8,9 +8,9 @@
  * （二次确认 + 直接删文件）。数据通过 getSubagentConfigurations RPC 由 host 下发。
  */
 
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState } from "react";
 import { SubagentConfiguration } from "../types";
-import { useHostMessage } from "../utils/useHostMessage";
+import { useSettingsList } from "../utils/useSettingsList";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { SettingsAddIcon } from "./HeaderIcons";
 import { SettingsTabs, type SettingsTabDef } from "./SettingsManageComponents";
@@ -46,32 +46,23 @@ const SettingsSubagentsView: React.FC<SettingsSubagentsViewProps> = ({
   workdir,
   onPrefillPrompt,
 }) => {
-  const [configurations, setConfigurations] = useState<SubagentConfiguration[]>(
-    [],
-  );
-  const [loading, setLoading] = useState(true);
+  const {
+    items: configurations,
+    loading,
+    refresh,
+    pendingDelete,
+    setPendingDelete,
+    cancelDelete,
+    confirmDelete,
+  } = useSettingsList<SubagentConfiguration[], SubagentConfiguration>({
+    initialItems: [],
+    fetchRequest: () =>
+      vscode?.postMessage({ command: "getSubagentConfigurations" }),
+    responseCommands: ["subagentConfigurationsResponse"],
+    pickItems: (message) => message.configurations || [],
+  });
   const [activeTab, setActiveTab] = useState<string>(TABS[0].key);
   const [selectedName, setSelectedName] = useState<string | null>(null);
-  // 待删除子代理（null = 无确认框）
-  const [pendingDelete, setPendingDelete] =
-    useState<SubagentConfiguration | null>(null);
-
-  const fetchConfigurations = useCallback(() => {
-    vscode?.postMessage({ command: "getSubagentConfigurations" });
-  }, [vscode]);
-
-  // Fetch agent definitions on mount (fresh each time the tab opens)
-  useEffect(() => {
-    setLoading(true);
-    fetchConfigurations();
-  }, [fetchConfigurations]);
-
-  useHostMessage((message) => {
-    if (message.command === "subagentConfigurationsResponse") {
-      setConfigurations(message.configurations || []);
-      setLoading(false);
-    }
-  });
 
   const selectedAgent =
     configurations.find((c) => c.name === selectedName) || null;
@@ -104,13 +95,13 @@ const SettingsSubagentsView: React.FC<SettingsSubagentsViewProps> = ({
   };
 
   const handleConfirmDelete = () => {
-    if (!pendingDelete) return;
-    vscode?.postMessage({
-      command: "deleteSubagent",
-      name: pendingDelete.name,
+    confirmDelete((agent) => {
+      vscode?.postMessage({
+        command: "deleteSubagent",
+        name: agent.name,
+      });
+      refresh();
     });
-    setPendingDelete(null);
-    fetchConfigurations();
   };
 
   const isEditable = (agent: SubagentConfiguration) =>
@@ -306,7 +297,7 @@ const SettingsSubagentsView: React.FC<SettingsSubagentsViewProps> = ({
           confirmText="确认删除"
           cancelText="取消"
           onConfirm={handleConfirmDelete}
-          onCancel={() => setPendingDelete(null)}
+          onCancel={cancelDelete}
         />
       )}
     </div>

--- a/packages/webview/src/components/TerminalPane.tsx
+++ b/packages/webview/src/components/TerminalPane.tsx
@@ -5,6 +5,7 @@ import type { FitAddon } from "@xterm/addon-fit";
 import type { WebLinksAddon } from "@xterm/addon-web-links";
 import { isLocalhostUrl } from "../utils/isLocalhostUrl";
 import { useHostMessage } from "../utils/useHostMessage";
+import { readRootCssVar } from "../utils/cssVars";
 import { RefreshIcon } from "./HeaderIcons";
 import { PanePlaceholder, PaneShell } from "./PaneShell";
 import "../styles/TerminalPane.css";
@@ -51,18 +52,15 @@ export function prefetchTerminalLib(): void {
 
 /** Terminal colors follow the app theme via --vscode-* variables. */
 const readTerminalTheme = () => {
-  const styles = getComputedStyle(document.documentElement);
-  const pick = (name: string, fallback: string) =>
-    styles.getPropertyValue(name).trim() || fallback;
   const background =
-    pick("--vscode-panel-background", "") ||
-    pick("--vscode-editor-background", "#1e1e1e");
-  const foreground = pick("--vscode-foreground", "#cccccc");
+    readRootCssVar("--vscode-panel-background") ||
+    readRootCssVar("--vscode-editor-background", "#1e1e1e");
+  const foreground = readRootCssVar("--vscode-foreground", "#cccccc");
   return {
     background,
     foreground,
-    cursor: pick("--vscode-editorCursor-foreground", foreground),
-    selectionBackground: pick(
+    cursor: readRootCssVar("--vscode-editorCursor-foreground", foreground),
+    selectionBackground: readRootCssVar(
       "--vscode-editor-selectionBackground",
       "rgba(255, 255, 255, 0.25)",
     ),
@@ -196,10 +194,10 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({
       .then((lib) => {
         if (disposed || !containerRef.current) return;
         const term = new lib.Terminal({
-          fontFamily:
-            getComputedStyle(document.documentElement)
-              .getPropertyValue("--vscode-editor-font-family")
-              .trim() || 'Menlo, Monaco, "Courier New", monospace',
+          fontFamily: readRootCssVar(
+            "--vscode-editor-font-family",
+            'Menlo, Monaco, "Courier New", monospace',
+          ),
           fontSize: 12,
           cursorBlink: true,
           theme: readTerminalTheme(),

--- a/packages/webview/src/utils/cssVars.ts
+++ b/packages/webview/src/utils/cssVars.ts
@@ -1,0 +1,10 @@
+/**
+ * 读取 :root 上的 CSS 自定义属性并去掉首尾空白；取值为空时回退 fallback。
+ * 主题变量（--vscode-* / --cc-*）随 <html data-theme> 切换，每次调用实时读取。
+ */
+export function readRootCssVar(name: string, fallback = ""): string {
+  const value = getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
+  return value || fallback;
+}

--- a/packages/webview/src/utils/useSettingsList.ts
+++ b/packages/webview/src/utils/useSettingsList.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState } from "react";
+import { useHostMessage } from "./useHostMessage";
+
+type HostMessage = MessageEvent["data"];
+
+export interface UseSettingsListOptions<TList> {
+  /** 列表状态初始值（与视图原 useState 初值一致：数组视图传 []，钩子视图传 {}）。 */
+  initialItems: TList;
+  /** 发送拉取请求（闭包 vscode；vscode 缺省时可选链自然不发）。经 latest ref
+   *  读取，调用方无需 useCallback，也无需担心闭包过期。 */
+  fetchRequest: () => void;
+  /** 变化时重新置 loading 并重新拉取（钩子视图传 activeTab；缺省仅挂载拉取一次）。 */
+  fetchKey?: string;
+  /** 命中即消费的响应命令（一到多条，如 mcpServersResponse + mcpServersUpdate）。 */
+  responseCommands: string[];
+  /** 从响应消息提取列表状态（含 || [] / || {} 兜底）。 */
+  pickItems: (message: HostMessage) => TList;
+  /** 命中响应后的附加视图状态更新（钩子 configPath / MCP connecting 清零）。 */
+  onResponse?: (message: HostMessage) => void;
+}
+
+/**
+ * 设置页「列表视图」共用状态机（host_route_audit P2-A 收敛）：
+ * 挂载/fetchKey 变化 → 置 loading + 发拉取请求（fetchKey 变化时同时收起未
+ * 确认的删除框，即切来源 Tab）→ Response 到达 → 写列表 + onResponse +
+ * 解除 loading；外加「删除二次确认」pendingDelete 状态。
+ * Skills / Subagents / Hooks / Mcp 四视图的相同骨架收敛于此；真正删除动作
+ * 由视图在 confirmDelete(send) 的 send 回调里闭包（乐观更新 or 重新拉取
+ * 各视图不同）。refresh() 仅重发拉取请求、不动 loading（对齐删除后重新
+ * 拉取时加载占位不闪现的原行为）。
+ */
+export function useSettingsList<TList, TItem>(
+  options: UseSettingsListOptions<TList>,
+) {
+  const [items, setItems] = useState<TList>(options.initialItems);
+  const [loading, setLoading] = useState(true);
+  const [pendingDelete, setPendingDelete] = useState<TItem | null>(null);
+  const latest = useRef(options);
+  latest.current = options;
+  const { fetchKey } = options;
+
+  useEffect(() => {
+    // fetchKey 变化（切来源 Tab）时顺手收起未确认的删除框
+    setPendingDelete(null);
+    setLoading(true);
+    latest.current.fetchRequest();
+  }, [fetchKey]);
+
+  useHostMessage((message) => {
+    const current = latest.current;
+    if (!current.responseCommands.includes(message.command)) return;
+    setItems(current.pickItems(message));
+    current.onResponse?.(message);
+    setLoading(false);
+  });
+
+  const refresh = () => latest.current.fetchRequest();
+  const cancelDelete = () => setPendingDelete(null);
+  const confirmDelete = (send: (item: TItem) => void) => {
+    const item = pendingDelete;
+    if (!item) return;
+    send(item);
+    setPendingDelete(null);
+  };
+
+  return {
+    items,
+    setItems,
+    loading,
+    refresh,
+    pendingDelete,
+    setPendingDelete,
+    cancelDelete,
+    confirmDelete,
+  };
+}

--- a/packages/webview/tests/utils/useSettingsList.test.tsx
+++ b/packages/webview/tests/utils/useSettingsList.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSettingsList } from "../../src/utils/useSettingsList";
+
+const dispatch = (data: unknown) => {
+  act(() => {
+    window.dispatchEvent(new MessageEvent("message", { data }));
+  });
+};
+
+describe("useSettingsList", () => {
+  it("fetches on mount, writes picked items and clears loading on response", () => {
+    const fetchRequest = vi.fn();
+    const { result } = renderHook(() =>
+      useSettingsList<string[], string>({
+        initialItems: [],
+        fetchRequest,
+        responseCommands: ["listResponse"],
+        pickItems: (message) => message.items || [],
+      }),
+    );
+    expect(fetchRequest).toHaveBeenCalledTimes(1);
+    expect(result.current.loading).toBe(true);
+    expect(result.current.items).toEqual([]);
+    dispatch({ command: "listResponse", items: ["a", "b"] });
+    expect(result.current.items).toEqual(["a", "b"]);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("ignores commands outside responseCommands", () => {
+    const { result } = renderHook(() =>
+      useSettingsList<string[], string>({
+        initialItems: [],
+        fetchRequest: () => {},
+        responseCommands: ["listResponse"],
+        pickItems: (message) => message.items || [],
+      }),
+    );
+    dispatch({ command: "otherResponse", items: ["x"] });
+    expect(result.current.items).toEqual([]);
+    expect(result.current.loading).toBe(true);
+  });
+
+  it("re-fetches and re-enters loading when fetchKey changes", () => {
+    const fetchRequest = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ fetchKey }: { fetchKey: string }) =>
+        useSettingsList<string[], string>({
+          initialItems: [],
+          fetchRequest,
+          fetchKey,
+          responseCommands: ["listResponse"],
+          pickItems: (message) => message.items || [],
+        }),
+      { initialProps: { fetchKey: "user" } },
+    );
+    dispatch({ command: "listResponse", items: ["a"] });
+    expect(result.current.loading).toBe(false);
+    rerender({ fetchKey: "project" });
+    expect(result.current.loading).toBe(true);
+    expect(fetchRequest).toHaveBeenCalledTimes(2);
+    dispatch({ command: "listResponse", items: ["b"] });
+    expect(result.current.items).toEqual(["b"]);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("calls onResponse with the matched message for view-specific state", () => {
+    let extra: string | null = null;
+    const { result } = renderHook(() =>
+      useSettingsList<string[], string>({
+        initialItems: [],
+        fetchRequest: () => {},
+        responseCommands: ["listResponse"],
+        pickItems: (message) => message.items || [],
+        onResponse: (message) => {
+          extra = message.configPath ?? null;
+        },
+      }),
+    );
+    dispatch({
+      command: "listResponse",
+      items: [],
+      configPath: "/p/settings.json",
+    });
+    expect(result.current.loading).toBe(false);
+    expect(extra).toBe("/p/settings.json");
+  });
+
+  it("confirmDelete passes the pending item to send and closes the dialog", () => {
+    const { result } = renderHook(() =>
+      useSettingsList<string[], string>({
+        initialItems: [],
+        fetchRequest: () => {},
+        responseCommands: ["listResponse"],
+        pickItems: (message) => message.items || [],
+      }),
+    );
+    act(() => result.current.setPendingDelete("a"));
+    const send = vi.fn();
+    act(() => result.current.confirmDelete(send));
+    expect(send).toHaveBeenCalledWith("a");
+    expect(result.current.pendingDelete).toBeNull();
+  });
+
+  it("confirmDelete without a pending item never calls send", () => {
+    const { result } = renderHook(() =>
+      useSettingsList<string[], string>({
+        initialItems: [],
+        fetchRequest: () => {},
+        responseCommands: ["listResponse"],
+        pickItems: (message) => message.items || [],
+      }),
+    );
+    const send = vi.fn();
+    act(() => result.current.confirmDelete(send));
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("cancelDelete closes the dialog without calling send", () => {
+    const { result } = renderHook(() =>
+      useSettingsList<string[], string>({
+        initialItems: [],
+        fetchRequest: () => {},
+        responseCommands: ["listResponse"],
+        pickItems: (message) => message.items || [],
+      }),
+    );
+    act(() => result.current.setPendingDelete("a"));
+    const send = vi.fn();
+    act(() => result.current.cancelDelete());
+    expect(result.current.pendingDelete).toBeNull();
+    act(() => result.current.confirmDelete(send));
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("refresh re-sends the latest fetchRequest without toggling loading", () => {
+    const fetchRequest = vi.fn();
+    const { result } = renderHook(() =>
+      useSettingsList<string[], string>({
+        initialItems: [],
+        fetchRequest,
+        responseCommands: ["listResponse"],
+        pickItems: (message) => message.items || [],
+      }),
+    );
+    dispatch({ command: "listResponse", items: ["a"] });
+    expect(result.current.loading).toBe(false);
+    act(() => result.current.refresh());
+    expect(fetchRequest).toHaveBeenCalledTimes(2);
+    expect(result.current.loading).toBe(false);
+  });
+});


### PR DESCRIPTION
## P2 webview A 类去重 · 第 3 步（最后一步）

延续 #2124（useHostMessage）、#2125（PaneShell）。纯重构零行为变化。

## 收敛统计

**useSettingsList（新 hook，src/utils/useSettingsList.ts）**：4 个设置列表视图的「挂载/fetchKey 变化 → 拉取 → Response → 删除二次确认」状态机收敛：
- SettingsSkillsView：useState×3 + useEffect 拉取 + useHostMessage 响应 + handleConfirmDelete → hook（refresh 用于删除后重新拉取）
- SettingsSubagentsView：同上结构 → hook（同 Skills）
- SettingsHooksView：useState×4 + fetchHooks + hooksResponse 响应（含 configPath）→ hook（fetchKey=activeTab；configPath 走 onResponse）
- SettingsMcpView：useState×5 + fetchServers + mcpServersResponse/Update 响应 → hook（双响应命令；mcpConnecting 走 onResponse）

**4→1**：删除确认框 pendingDelete 状态 + confirmDelete/cancelDelete 也随 hook 收敛（send 回调承载各视图差异：Skills/Subagents 删除后 refresh 重拉，Hooks/Mcp 乐观移除）。

**readRootCssVar（新工具，src/utils/cssVars.ts）**：3 处手写 getComputedStyle(--vscode-*/--cc-*) 主题变量读取收敛：
- TerminalPane readTerminalTheme（4 变量）
- TerminalPane xterm fontFamily（1 变量）
- PreviewPane readPalette（9 变量，含 --cc-text-link 双回退链）

## 视图内保留（非豁免，本就视图特有）

- Hooks configPath 状态（onResponse 写入）
- Mcp mcpConnecting 状态 + mcpConfigPathsResponse 监听（useHostMessage，hook 只管 servers 列表）
- 各视图 ConfirmDialog 的 title/description 文案

## 行为保持说明

- confirmDelete 内 send(item) → setPendingDelete(null) 的顺序与原「post → 清空 → 乐观更新/重拉」在 React 批处理下不可区分
- fetchKey 变化时 hook 收起 pendingDelete（原 Hooks 视图 effect 语义，其他视图 fetchKey 恒 undefined 不触发）
- refresh() 不动 loading（对齐删除后重拉不闪加载占位的原行为）

## 验证

- 全量单测 1014 passed（1006 基线 + 8 新 hook 测试）
- type-check 4 tsconfig 绿；oxlint 0 warning 0 error；prettier clean
- node scripts/audit-webview-commands.mjs exit 0（97 命令 225 路由全覆盖）
- e2e 子集 44 passed（settings-command/settings-project-toggle/desktop-preview）；demo 子集 143 passed（settings-manage×2/mcp-server-tab）