### PR TITLE
feat(fixtures): host→webview 消息归属键控契约（ReplyAttribution 注册表 + 编译期强制）

### DIFF
--- a/packages/webview-fixtures/src/types.ts
+++ b/packages/webview-fixtures/src/types.ts
@@ -11,6 +11,27 @@
  * `paneId` is optional: the desktop host tags every pane-scoped push with the
  * target pane's id; IDE hosts never send it (untagged messages are consumed by
  * the single webview instance / self-consumed per ChatApp).
+ *
+ * ## 归属契约（reply-to messages，P3 键控契约）
+ *
+ * host→webview 消息按归属语义分三类：
+ *
+ * 1. **快照/广播**（desktopSessionTree、contextUsage、updateStreamingContent、
+ *    mcpServersResponse…）：全量状态推送，晚到 = 更新的事实，消费侧无需过期
+ *    判断；pane 级推送由 base 的 `paneId` 路由。
+ * 2. **请求-响应（reply-to）**：webview 先请求、host 后回复。**必须携带归属
+ *    键**（见下方 `ReplyAttribution` 注册表），消费侧按两条标准模式处理：
+ *    - 过期即弃：一次性查询比对 `requestId`（MessageInput fileSuggestions）
+ *      或比对请求时登记的归属值（btw 面板比对 `question`）；
+ *    - 渲染期键控过滤：state 存归属值、渲染期派生比对当前作用域（#2073
+ *      desktopGitBranches 按 workdir），晚到的旧回复永不匹配当前作用域——
+ *      不在 effect 里清空 state，避免中间帧闪现。
+ * 3. **命令事件**（showToast、focusInput、prefillPrompt、triggerShortcut…）：
+ *    host 主动命令，无请求-响应配对，不需要归属键。
+ *
+ * 新增请求-响应消息时：接口把归属键声明为**必填**并把 `command → 键名` 登记
+ * 进 `ReplyAttribution`——漏带归属键会在 fixtures 的编译期断言处直接报类型
+ * 错误，而不是运行时才暴露「晚到回复覆盖新状态」。
  */
 
 // SDK types come from the light entry (same types the UI consumers import;
@@ -224,8 +245,10 @@ export interface UpdateWorkdirMessage extends HostToWebviewMessageBase {
 export interface DesktopGitBranchesMessage extends HostToWebviewMessageBase {
   command: "desktopGitBranches";
   /** The workdir this branch list was queried for — replies are keyed by it
-   * so the webview never shows a previous directory's result after a switch. */
-  workdir?: string;
+   *  so the webview never shows a previous directory's result after a switch
+   *  (render-time keying, #2073). Required: the desktop host echoes the
+   *  requested workdir on every reply. */
+  workdir: string;
   result?: GitBranchesResult;
 }
 
@@ -347,6 +370,8 @@ export interface ProjectSettingsMessage extends HostToWebviewMessageBase {
 /** Settings page hooks read-only view: scope-scoped settings.json hooks. */
 export interface HooksConfigResponseMessage extends HostToWebviewMessageBase {
   command: "hooksConfigResponse";
+  /** 归属键：回复所属的配置作用域（host 端以 `scope ?? "user"` 恒回带），
+   *  消费侧据此丢弃切 Tab 前发出的慢回复。 */
   scope: "user" | "project";
   hooks?: Record<string, unknown>;
 }
@@ -354,6 +379,7 @@ export interface HooksConfigResponseMessage extends HostToWebviewMessageBase {
 /** Settings page MCP read-only view: scope-scoped mcp.json servers config. */
 export interface McpConfigResponseMessage extends HostToWebviewMessageBase {
   command: "mcpConfigResponse";
+  /** 归属键：同 hooksConfigResponse.scope。 */
   scope: "user" | "project";
   mcpServers: Record<string, unknown>;
 }
@@ -665,8 +691,12 @@ export interface HistoryResponseMessage extends HostToWebviewMessageBase {
 
 // ---- MessageInput-owned replies (consumed outside the ChatApp switch). ----
 
-export interface FileSuggestionsMessage extends HostToWebviewMessageBase {
-  command: "fileSuggestions";
+/** Reply to a requestFileSuggestions query (@ 提及文件建议). MessageInput
+ *  keeps the latest request's id and drops replies whose requestId does not
+ *  match — 过期即弃（一次性查询归属键的标准范例）。 */
+export interface FileSuggestionsResponseMessage
+  extends HostToWebviewMessageBase {
+  command: "fileSuggestionsResponse";
   requestId: string;
   suggestions: unknown[];
 }
@@ -711,6 +741,56 @@ export interface DesktopRemoteDirListMessage extends HostToWebviewMessageBase {
   resolvedPath?: string;
   dirs?: string[];
   error?: unknown;
+}
+
+// ---- Contract gaps (commands hosts really send / the webview really
+// consumes, previously missing from the union). Registered so the fixtures
+// package stays the single authoritative contract (先例坑：新 host→webview
+// 消息必须先进 webview-fixtures). ----
+
+/** Reply to getConfiguredModels — the model picker's candidate list. */
+export interface ConfiguredModelsMessage extends HostToWebviewMessageBase {
+  command: "configuredModels";
+  models: string[];
+  currentModel?: string;
+}
+
+/** Full MCP server status push (connect/disconnect refresh). Snapshot
+ *  semantics, not reply-to: McpDialog / SettingsMcpView render-time filter by
+ *  each server's own `scope` field, so no attribution key beyond paneId. */
+export interface McpServersUpdateMessage extends HostToWebviewMessageBase {
+  command: "mcpServersUpdate";
+  servers: unknown[];
+}
+
+/** Settings tab open push (VS Code): workdir + optional nav key so
+ *  /mcp、/agents 等斜杠命令打开设置页可预选 tab. Early posts are dropped
+ *  by VS Code before the webview's listener registers — the host re-serves
+ *  the cached state on the webview's `settingsReady` handshake (#2044). */
+export interface SettingsStateMessage extends HostToWebviewMessageBase {
+  command: "settingsState";
+  workdir?: string;
+  nav?: string;
+}
+
+/** IDE selection toolbar → insert a code-selection context tag into the
+ *  chat input (VS Code sends on the ➕ action). */
+export interface AddSelectionToInputMessage extends HostToWebviewMessageBase {
+  command: "addSelectionToInput";
+  selection: SelectionInfo;
+}
+
+/** IDE settings page「新建/编辑」→ close settings tab and prefill the chat
+ *  input draft (ChatApp loadDraft). */
+export interface PrefillPromptMessage extends HostToWebviewMessageBase {
+  command: "prefillPrompt";
+  prompt: string;
+}
+
+/** Reply to a requestHistory / searchHistory query that failed. */
+export interface HistoryErrorMessage extends HostToWebviewMessageBase {
+  command: "historyError";
+  error: unknown;
 }
 
 export type HostToWebviewMessage =
@@ -779,10 +859,79 @@ export type HostToWebviewMessage =
   | HooksResponseMessage
   | McpConfigPathsResponseMessage
   | HistoryResponseMessage
-  | FileSuggestionsMessage
+  | HistoryErrorMessage
+  | ConfiguredModelsMessage
+  | McpServersUpdateMessage
+  | SettingsStateMessage
+  | AddSelectionToInputMessage
+  | PrefillPromptMessage
+  | FileSuggestionsResponseMessage
   | FileSuggestionsErrorMessage
   | SlashCommandsResponseMessage
   | SlashCommandsErrorMessage
   | UploadSuccessMessage
   | UploadErrorMessage
   | DesktopRemoteDirListMessage;
+
+/**
+ * Reply-to 消息归属键注册表（契约锁，见文件头部「归属契约」）。
+ *
+ * key = command，value = 该响应必须携带的归属字段名。注册表中的每一条都会被
+ * 下方的编译期断言校验：union 对应成员若把归属键声明为可选（或漏掉），类型
+ * 检查在 `_replyAttributionLocked` 处直接报错。
+ *
+ * 快照/广播与命令事件类消息不进本表（它们没有请求-响应配对，晚到 = 新事实）。
+ */
+type ReplyAttribution = {
+  // 作用域查询：作用域字段作归属键（渲染期键控过滤或过期即弃均可）。
+  desktopGitBranches: "workdir";
+  hooksConfigResponse: "scope";
+  mcpConfigResponse: "scope";
+  agentsContentResponse: "scope";
+  agentsContentSaved: "scope";
+  // 问题文本作键：btw 面板比对 in-flight question，晚到的旧回复即弃。
+  btwStream: "question";
+  btwResponse: "question";
+  btwError: "question";
+  // 一次性查询：请求生成 id，回复原样带回（MessageInput requestIdRef 范例）。
+  desktopForwardPortResult: "requestId";
+  desktopRemoteDirList: "requestId";
+  fileSuggestionsResponse: "requestId";
+};
+
+// ---- 编译期断言：注册表中的每条响应命令，union 成员必须必填其归属键。 ----
+// 探测语义：归属键的索引访问类型不得含 undefined（optional 或显式
+// `| undefined` 都算未满足）。
+type UnionMemberByCommand<C extends string> = Extract<
+  HostToWebviewMessage,
+  { command: C }
+>;
+type ReplyAttributionSatisfied = {
+  [C in keyof ReplyAttribution & string]: UnionMemberByCommand<C> extends {
+    [K in ReplyAttribution[C]]: infer V;
+  }
+    ? undefined extends V
+      ? never
+      : true
+    : never;
+};
+// 某条注册的响应漏带/弱化归属键（optional 或显式 `| undefined`）时，
+// Satisfied 对应键退化为 never，下方 satisfies 报
+// 「Type 'true' is not assignable to type 'never'」——从 fixtures 契约层
+// 拦下回归。逐键 satisfies 而非整体索引：never 会被 `true | never` union
+// 吸收，整体检查恒绿（probe 验证过的坑）。
+export const replyAttributionLocked = {
+  desktopGitBranches: true,
+  hooksConfigResponse: true,
+  mcpConfigResponse: true,
+  agentsContentResponse: true,
+  agentsContentSaved: true,
+  btwStream: true,
+  btwResponse: true,
+  btwError: true,
+  desktopForwardPortResult: true,
+  desktopRemoteDirList: true,
+  fileSuggestionsResponse: true,
+} satisfies {
+  [C in keyof ReplyAttribution & string]: ReplyAttributionSatisfied[C];
+};

--- a/packages/webview/tests/webview/fileMention.test.tsx
+++ b/packages/webview/tests/webview/fileMention.test.tsx
@@ -165,6 +165,80 @@ describe("File Mention Feature (@)", () => {
     expect(suggestionItems[0]).toHaveTextContent(/src/);
   });
 
+  it("drops a late reply whose requestId no longer matches the latest request (过期即弃)", async () => {
+    const { vscode } = renderChatApp();
+
+    // First query ("@"): its reply will arrive AFTER a newer query supersedes it.
+    await typeInInput("@");
+    const staleReqId = await waitForFileSuggestionRequest(vscode);
+
+    // User keeps typing — a newer request is issued and becomes the active one.
+    await typeInInput("@s");
+    // The debounced re-query takes a moment; wait until a request with a NEW
+    // requestId actually left the webview (the helper's .pop() would otherwise
+    // keep returning the first call).
+    let freshReqId = staleReqId;
+    await waitFor(() => {
+      const calls = (vscode.postMessage.mock.calls as unknown[][]).map(
+        (c) => c[0] as { command: string; requestId?: string },
+      );
+      const last = calls
+        .filter((c) => c.command === "requestFileSuggestions")
+        .pop();
+      expect(last?.requestId).toBeTruthy();
+      expect(last?.requestId).not.toBe(staleReqId);
+      freshReqId = last!.requestId!;
+    });
+
+    // The stale reply lands first — its suggestions must be quarantined
+    // (never rendered; the dropdown may already show an empty/loading state
+    // for the in-flight fresh query, so assert on the stale CONTENT).
+    act(() => {
+      sendCommand("fileSuggestionsResponse", {
+        suggestions: [
+          {
+            path: "/workspace/stale.ts",
+            relativePath: "stale.ts",
+            name: "stale.ts",
+            extension: "ts",
+            icon: "codicon-file",
+          },
+        ],
+        filterText: "",
+        requestId: staleReqId,
+      });
+    });
+    expect(screen.queryByText("stale.ts")).toBeNull();
+    expect(
+      document.querySelectorAll(".suggestion-item:not(.suggestion-empty)"),
+    ).toHaveLength(0);
+
+    // The fresh reply renders normally.
+    act(() => {
+      sendCommand("fileSuggestionsResponse", {
+        suggestions: [
+          {
+            path: "/workspace/src/components/MessageInput.tsx",
+            relativePath: "src/components/MessageInput.tsx",
+            name: "MessageInput.tsx",
+            extension: "tsx",
+            icon: "codicon-react",
+          },
+        ],
+        filterText: "s",
+        requestId: freshReqId,
+      });
+    });
+    await waitFor(() => {
+      expect(
+        document.querySelector(".file-suggestion-dropdown"),
+      ).toBeInTheDocument();
+    });
+    expect(document.querySelector(".suggestion-item")).toHaveTextContent(
+      "MessageInput.tsx",
+    );
+  });
+
   it("should insert the file tag on mouse click even when selection is on the popup item", async () => {
     const { vscode } = renderChatApp();
 


### PR DESCRIPTION
# PR 第 1 步：host→webview 消息归属键控契约

## 设计要点

调研三个先例 bug 的修法后，将其升格为统一契约（先例不是反面教材，是三种土办法的变体）：

| 先例 | 病根 | 修法（本次契约化的原型） |
|---|---|---|
| #2073 git 控件闪烁 | 晚到的旧目录分支回复覆写新目录 | **渲染期键控过滤**：state 存归属值（workdir），渲染期派生比对当前作用域；不在 effect 清空 state（零中间帧） |
| #2053 Plan 面板不开 | 背靠背消息被 React 合批，内联路由被 swap effect 抹掉 | stage-then-route（不属本次契约范围，属提交时序问题） |
| #2044 /mcp 不选中 tab | 面板未就绪消息必丢 | settingsReady 握手 + host 缓存重发（host 侧，#2044 已实现） |

**消息三分法**（写入 types.ts 头部 JSDoc）：
1. **快照/广播**：晚到=新事实，无需过期判断（desktopSessionTree、contextUsage、流式增量…）
2. **请求-响应（reply-to）**：必须带归属键，消费侧两种标准模式：
   - 过期即弃：requestId 比对（fileSuggestions）或归属值比对（btw question）
   - 渲染期键控：state 存归属值+渲染期派生比对（desktopGitBranches）
3. **命令事件**：showToast、prefillPrompt 等，无配对，不需要归属键

**fixtures 类型强制**：`ReplyAttribution` 注册表（11 条响应命令 → 归属键名）+ 逐键 satisfies 编译期断言。归属键被弱化为 optional / `| undefined` 时 tsc 直接报 `Type 'true' is not assignable to type 'never'`。

实现坑（probe 实验验证）：
- `Satisfied[keyof Registry]` 整体索引取 union 时 never 被 `true | never = true` 吸收，断言恒绿 → **必须逐键**
- `declare const x: never` 不报错；`x as never` 是逃生舱也不报错 → 用对象字面量 `satisfies`（assignability 检查）+ 每键显式 true
- optional source `extends Record<K, unknown>` 恒 true（unknown 含 undefined）→ infer 模式下 optional 直接 no-match，配合 `undefined extends V` 双信号

## 覆盖/迁移清单

**归属键收紧 required（host 三端已遵守，纯契约锁死）**：
- `desktopGitBranches.workdir`（#2073 后 host 恒回带）
- `hooksConfigResponse.scope` / `mcpConfigResponse.scope`（三端 host 均 `scope ?? "user"` 恒回带）
- 已 required 的登记入表：agentsContentResponse/agentsContentSaved（scope）、btwStream/btwResponse/btwError（question）、desktopForwardPortResult/desktopRemoteDirList/fileSuggestionsResponse（requestId）

**union 缺登记补齐（契约锁纪律）**：configuredModels、mcpServersUpdate、settingsState、addSelectionToInput、prefillPrompt、historyError（6 条 host 真实发送 / webview 真实消费但 union 缺失的消息）

**命名漂移修正**：union 的 `fileSuggestions` → `fileSuggestionsResponse`（host 实际发送与 webview 消费的真实命令名；webview 测试此前已全部用正确名，零破坏）

**新增回归**：fileMention stale requestId 晚到回复过期即弃（此前只有正例回显测试；btw 的 stale question 即弃已有覆盖 btwPopup.test.tsx:263/316）

## 暂不迁移清单及缘由（需动 host，等拍板后下批处理）

| 消息 | 竞态 | 闭合所需（超本次边界） |
|---|---|---|
| `hooksResponse` | 设置页钩子视图 user/project tab 快速切换，慢 scope 回复串台写入列表（useSettingsList 命中即消费、无 scope 比对） | 三端 host 回复回带请求里的 scope（desktop desktopHost:3535、vscode messageHandler:2231、JB）+ fixtures 收紧 + useSettingsList 加归属比对谓词 |
| `historyResponse`/`searchHistory` | 历史搜索防抖重查时旧查询响应晚到覆盖新结果（HistorySearchPopup:53） | host 回带 query 或 requestId |
| `projectSettings` | a3043966 的「到达时用 effectiveWorkdirRef 盖章」法：host 发送时目录 A、到达时 webview 已切到 B 会被标错归属 | desktopHost:5130 回带查询用 workdir（vscode 无 workdir 概念不受影响） |

孤儿响应（host 发送、webview 无消费者，不迁移，待清理提案）：`hooksConfigResponse`/`mcpConfigResponse` 在 webview src 无消费点（设置页实际消费的是 getHooksByScope→hooksResponse）；本轮仅收紧其类型。

## 有意行为变更标注

- 无运行时行为变化来自本次代码（fixtures 是测试基础设施；webview src 零改动）。「晚到消息仍显示」的消除已在先例 PR 实现，本次是契约层锁死防止回归。
- fileSuggestionsResponse 命名修正 = union 与真实 wire 协议对齐，无运行时影响（webview 消费侧本就只认 fileSuggestionsResponse）。

## 验证

- webview 全量单测 110 文件 / 1015 tests ✓（含新负例 fileMention 5/5）
- 全仓 type-check 4 配置 ✓ / oxlint 0 warning ✓ / prettier ✓
- e2e desktop-app + desktop-selector-keyboard 44 passed ✓ / demo 143 passed ✓
- audit-webview-commands exit 0（97 命令 225 路由）✓
- fixtures 断言双向验证：required 绿 / optional 红（probe 实验 + fixtures 就地验证）
