### PR TITLE
refactor(webview): 会话级 UI 状态快照收敛为 SessionUiStore（试点：折叠状态+预览 URL）

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -63,6 +63,8 @@ import { EXIT_PLAN_MODE_TOOL_NAME } from "wave-agent-sdk/dist/constants/tools.js
 import { collectWriteEditBlocks, pathsMatch } from "../utils/fileAutoRefresh";
 import { isMacHiddenTitlebar } from "../utils/platform";
 import { chatReducer, initialState } from "../reducers/chatReducer";
+import { sessionUi, PANEL_DEFAULT_WIDTH } from "../utils/sessionUiStore";
+import type { SessionUiState, RemoteForwardRef } from "../utils/sessionUiStore";
 import "../styles/ChatApp.css";
 
 /** Chinese names shown in the panel tabs / space hints. */
@@ -73,7 +75,6 @@ export const PANEL_LABELS: Record<DesktopPanelKind, string> = {
   terminal: "终端",
   file: "文件",
 };
-const PANEL_DEFAULT_WIDTH = 420;
 const PANEL_MIN_WIDTH = 320;
 /** The conversation (message) area never shrinks below this when opening/dragging panels. */
 const CHAT_MAIN_MIN_WIDTH = 360;
@@ -128,94 +129,11 @@ function isFileDragEvent(e: React.DragEvent): boolean {
   return e.dataTransfer.types.includes("Files");
 }
 
-/**
- * Panel group snapshot, remembered per session. Keys are session ids, plus one
- * `new:<paneId>` bucket per pane for the new-session state (no session bound
- * yet); the bucket migrates to the session id once the first message binds
- * one. The cache also carries a pane's group across the unmount/remount a
- * move between window rows forces (React cannot reparent) — the remount reads
- * the same session's entry. DesktopApp prunes entries whose owner is gone.
- */
-interface PanelGroupState {
-  /** Open panel tabs in tab order (multi-instance kinds may repeat). */
-  checked: PanelTab[];
-  /** Shared panel-slot width (tabbed layout: one slot, one width). */
-  panelWidth: number;
-  /**
-   * True once the user manually dragged the shared slot width off its default.
-   * A slot never dragged auto-fills the space beyond the conversation's minimum
-   * when the panel opens (spec desktop-panels.md「右侧面板 · 展开/折叠、空间
-   * 守卫与欢迎页共存」场景 7-9: never-dragged slots auto-fill); a manual one
-   * keeps its width from then on. Stored per group so the flag survives session
-   * switches the same way the width does.
-   */
-  panelWidthManual: boolean;
-  /** Currently active tab id; null when no tab is open. */
-  activePanel: string | null;
-  /**
-   * Whether the panel slot is expanded for this session (spec
-   * desktop-panels.md「右侧面板 · 展开/折叠、空间守卫与欢迎页共存」场景 10:
-   * 折叠/展开逐会话记忆，与 tab 集合/宽度同级). Collapsing hides the slot but
-   * keeps the open tabs mounted, so a session collapsed with tabs open must
-   * come back collapsed after a switch — restoring it must not re-derive
-   * expanded from the presence of tabs.
-   */
-  panelExpanded: boolean;
-  /** Plan panel markdown (ExitPlanMode content); null = no plan yet. */
-  planContent: string | null;
-  /**
-   * This session's remote port forward (scenario 18). The tunnel is owned by
-   * the session, not the pane: it survives panel close, host switches, pane
-   * rebinding and unmount/remount — only session deletion, ssh process death
-   * or app exit release it. This reference is display bookkeeping only.
-   */
-  forward: RemoteForwardRef | null;
-  /** Last forward failure for this session, shown in the preview stub. */
-  forwardError: string | null;
-}
-
-/**
- * The in-flight/established remote port forward requested by this session. Set
- * when a remote localhost link is clicked (before the host replies). A pane
- * rebinding to another session must keep the previous session's forward held
- * (the host tunnels stay alive independently), so references live in the
- * per-session panel-group cache rather than a single pane ref.
- */
-interface RemoteForwardRef {
-  host: string;
-  remotePort: number;
-  /** The original remote URL the user clicked (kept for comment rewriting). */
-  originalUrl: string;
-  /** Matches the desktopForwardPortResult reply; stale replies are dropped. */
-  requestId: string;
-}
-
-const panelGroupCache = new Map<string, PanelGroupState>();
-
-/** Fresh panel-group state, used when a session gets its first forward. */
-function emptyPanelGroup(): PanelGroupState {
-  return {
-    checked: [],
-    panelWidth: PANEL_DEFAULT_WIDTH,
-    panelWidthManual: false,
-    activePanel: null,
-    panelExpanded: false,
-    planContent: null,
-    forward: null,
-    forwardError: null,
-  };
-}
-
-/**
- * Drop cached panel groups whose owner is gone. The keep-set covers live pane
- * buckets and the sessions in the sidebar tree / pane bindings, so a deleted
- * session forgets its panel group while a merely hidden one keeps it.
- */
-export function prunePanelGroupCache(keepKeys: Set<string>): void {
-  for (const key of [...panelGroupCache.keys()]) {
-    if (!keepKeys.has(key)) panelGroupCache.delete(key);
-  }
-}
+// Panel-group snapshot storage (per session) moved to utils/sessionUiStore —
+// the unified session-UI-state store (存取/迁移/失效一套代码). ChatApp keeps
+// the React 编排 (useState mirror + swap/sync effects below); tests import
+// prunePanelGroupCache from here for backward compatibility.
+export { prunePanelGroupCache } from "../utils/sessionUiStore";
 
 /**
  * Desktop sidebar collapsed → the leftmost chat header shows this expand button
@@ -484,8 +402,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   // session's cached group so a pane rebinding away and back keeps the error.
   const [previewForwardError, setPreviewForwardError] = useState<string | null>(
     () =>
-      (groupKey ? panelGroupCache.get(groupKey)?.forwardError : undefined) ??
-      null,
+      (groupKey ? sessionUi.get(groupKey)?.forwardError : undefined) ?? null,
   );
   // Bumped when a re-acquire returns the SAME forwarded URL — the [url] effect
   // in PreviewPane would otherwise early-return and skip the forced reload a
@@ -496,9 +413,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   // remounts restore it from the group cache. The plan tab is unique, so the
   // content stays a single per-conversation value rather than per-tab.
   const [planContent, setPlanContent] = useState<string | null>(
-    () =>
-      (groupKey ? panelGroupCache.get(groupKey)?.planContent : undefined) ??
-      null,
+    () => (groupKey ? sessionUi.get(groupKey)?.planContent : undefined) ?? null,
   );
   // Desktop plan panel: the ExitPlanMode plan content a setInitialState replay
   // carried for a re-activated session, staged until the swap-effect ordering
@@ -510,11 +425,10 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   // rather than a ref because a pane rebinding to another session must drop its
   // own current forward WITHOUT dropping the previous session's (the host
   // tunnels stay alive independently, scenario 18): the per-session references
-  // live in panelGroupCache, this state only mirrors the bound session's one
+  // live in the sessionUi store, this state only mirrors the bound session's one
   // for rendering the preview stub.
   const [currentForward, setCurrentForward] = useState<RemoteForwardRef | null>(
-    () =>
-      (groupKey ? panelGroupCache.get(groupKey)?.forward : undefined) ?? null,
+    () => (groupKey ? sessionUi.get(groupKey)?.forward : undefined) ?? null,
   );
   // Mirrors of the forward state, refreshed on every render. Message is a
   // React.memo component whose DOM click handler captures props.onOpenPreview
@@ -537,7 +451,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   // handlers read the current tabs at click time without pinning the first
   // render's values (same pattern as the forward refs above).
   const [tabs, setTabs] = useState<PanelTab[]>(
-    () => (groupKey ? panelGroupCache.get(groupKey)?.checked : undefined) ?? [],
+    () => (groupKey ? sessionUi.get(groupKey)?.checked : undefined) ?? [],
   );
   const tabsRef = useRef(tabs);
   tabsRef.current = tabs;
@@ -551,7 +465,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   // 保持折叠，不因还有 tab 而自动展开); a group with no cached entry yet starts
   // collapsed so the empty-state page only appears after an explicit expand.
   const [panelExpanded, setPanelExpanded] = useState<boolean>(() => {
-    const cached = groupKey ? panelGroupCache.get(groupKey) : undefined;
+    const cached = groupKey ? sessionUi.get(groupKey) : undefined;
     return cached
       ? (cached.panelExpanded ?? (cached.checked?.length ?? 0) > 0)
       : false;
@@ -588,7 +502,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   // Tabbed panels: one shared slot width for every panel type.
   const [panelWidth, setPanelWidth] = useState<number>(
     () =>
-      (groupKey ? panelGroupCache.get(groupKey)?.panelWidth : undefined) ??
+      (groupKey ? sessionUi.get(groupKey)?.panelWidth : undefined) ??
       PANEL_DEFAULT_WIDTH,
   );
   // True once the user manually dragged the slot width; a slot never dragged
@@ -596,15 +510,12 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   // PanelGroupState.panelWidthManual).
   const [panelWidthManual, setPanelWidthManual] = useState<boolean>(
     () =>
-      (groupKey
-        ? panelGroupCache.get(groupKey)?.panelWidthManual
-        : undefined) ?? false,
+      (groupKey ? sessionUi.get(groupKey)?.panelWidthManual : undefined) ??
+      false,
   );
   // The active panel tab id; null when no panel is open.
   const [activeTabId, setActiveTabId] = useState<string | null>(
-    () =>
-      (groupKey ? panelGroupCache.get(groupKey)?.activePanel : undefined) ??
-      null,
+    () => (groupKey ? sessionUi.get(groupKey)?.activePanel : undefined) ?? null,
   );
   const activeTabIdRef = useRef(activeTabId);
   activeTabIdRef.current = activeTabId;
@@ -717,7 +628,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   // flips — the swap effect below re-seeds the state from the new key first.
   useEffect(() => {
     if (!groupKey || groupKey !== groupKeyRef.current) return;
-    panelGroupCache.set(groupKey, {
+    const snapshot: SessionUiState = {
       checked: tabs,
       panelWidth,
       panelWidthManual,
@@ -726,7 +637,8 @@ export const ChatApp: React.FC<ChatAppProps> = ({
       planContent,
       forward: currentForward,
       forwardError: previewForwardError,
-    });
+    };
+    sessionUi.set(groupKey, snapshot);
   }, [
     groupKey,
     tabs,
@@ -749,18 +661,17 @@ export const ChatApp: React.FC<ChatAppProps> = ({
     if (!paneId || !groupKey || groupKey === groupKeyRef.current) return;
     const prevKey = groupKeyRef.current;
     groupKeyRef.current = groupKey;
-    let group = panelGroupCache.get(groupKey);
+    // First try the incoming session's own entry; when this switch is the
+    // first message binding a session to a `new:<paneId>` bucket, that bucket
+    // migrates to the session id (move) so the pre-send setup survives.
+    let group = sessionUi.get(groupKey);
     if (
       !group &&
       prevKey?.startsWith("new:") &&
       !groupKey.startsWith("new:") &&
       sentFromNewSessionRef.current
     ) {
-      group = panelGroupCache.get(prevKey);
-      if (group) {
-        panelGroupCache.set(groupKey, group);
-        panelGroupCache.delete(prevKey);
-      }
+      group = sessionUi.move(prevKey, groupKey);
     }
     sentFromNewSessionRef.current = false;
     // Fullscreen belongs to the outgoing session's preview tab — switching
@@ -812,7 +723,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({
       }
       return;
     }
-    const restored = panelGroupCache.get(groupKey)?.checked;
+    const restored = sessionUi.get(groupKey)?.checked;
     const planInCache = restored?.some((t) => t.kind === "plan") ?? false;
     const planInCommitted = tabsRef.current.some((t) => t.kind === "plan");
     if (planInCache) {
@@ -978,29 +889,31 @@ export const ChatApp: React.FC<ChatAppProps> = ({
         // forwardTabIdRef) so a sibling preview tab's URL is never clobbered.
         if (!forThisPane(message)) break;
         {
-          let targetKey: string | undefined;
-          panelGroupCache.forEach((g, key) => {
-            if (g.forward?.requestId === message.requestId) targetKey = key;
-          });
+          const targetKey = sessionUi.keyByForwardRequestId(message.requestId);
           if (targetKey === undefined) break;
-          const target = panelGroupCache.get(targetKey);
-          if (!target) break;
           const tabId = message.requestId
             ? forwardTabIdRef.current.get(message.requestId)
             : undefined;
           const patchCachedTabUrl = (url: string) => {
             // Keep the cached group's tabs in sync for remounts/session
-            // switches even when this pane is not the current one.
-            target.checked = target.checked.map((t) =>
-              t.id === tabId ? { ...t, previewUrl: url } : t,
-            );
+            // switches even when this pane is not the current one — via the
+            // store's patch (direct cache mutation is banned).
+            const cached = sessionUi.get(targetKey);
+            if (!cached) return;
+            sessionUi.patch(targetKey, {
+              checked: cached.checked.map((t) =>
+                t.id === tabId ? { ...t, previewUrl: url } : t,
+              ),
+            });
           };
           if (message.error) {
-            target.forwardError = String(message.error);
+            sessionUi.patch(targetKey, {
+              forwardError: String(message.error),
+            });
             if (targetKey === groupKeyRef.current)
               setPreviewForwardError(String(message.error));
           } else {
-            target.forwardError = null;
+            sessionUi.patch(targetKey, { forwardError: null });
             if (targetKey === groupKeyRef.current) {
               setPreviewForwardError(null);
               if (tabId) {
@@ -2312,12 +2225,7 @@ export const ChatApp: React.FC<ChatAppProps> = ({
       // arrive on the very next event-loop turn — can match this forward even if
       // the effect hasn't flushed yet. A pane rebinding to another session then
       // keeps THIS session's forward cached for when it comes back.
-      let group = panelGroupCache.get(groupKey);
-      if (!group) {
-        group = emptyPanelGroup();
-        panelGroupCache.set(groupKey, group);
-      }
-      group.forward = fwd;
+      sessionUi.patch(groupKey, { forward: fwd });
       // The session id scopes the tunnel's lifetime on the host — it stays alive
       // across UI actions and is only released when the session is deleted
       // (scenario 18).

--- a/packages/webview/src/components/DesktopApp.tsx
+++ b/packages/webview/src/components/DesktopApp.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { ChatApp, prunePanelGroupCache } from "./ChatApp";
+import { ChatApp } from "./ChatApp";
+import { sessionUi } from "../utils/sessionUiStore";
 import { DesktopChromeProvider } from "./DesktopChromeContext";
 import { useHostMessage } from "../utils/useHostMessage";
 import {
@@ -50,7 +51,7 @@ export const DesktopApp: React.FC<DesktopAppProps> = ({ vscode }) => {
     for (const g of sessionTreeRef.current) {
       for (const s of g.sessions) keep.add(s.sessionId);
     }
-    prunePanelGroupCache(keep);
+    sessionUi.prune(keep);
   };
 
   useHostMessage((message) => {

--- a/packages/webview/src/utils/sessionUiStore.ts
+++ b/packages/webview/src/utils/sessionUiStore.ts
@@ -1,0 +1,158 @@
+import type { PanelTab } from "../types";
+
+/** Shared panel-slot default width (also the fresh-group default below). */
+export const PANEL_DEFAULT_WIDTH = 420;
+
+/**
+ * 会话级 UI 状态快照 store（P3-B 统一契约）。
+ *
+ * 「某块 UI 状态属于哪个会话、何时恢复、何时失效」此前由各病点自造土办法
+ * （panelGroupCache 模块级 Map、#2081 desktopHost WeakMap、a3043966 到达时
+ * 盖章……）。本模块把 webview 侧的会话级快照收敛为一套存取代码：
+ *
+ * ## key 维度
+ *
+ * 键 = 会话键（groupKey 语义）：已绑定会话用 sessionId，未绑定的新会话用
+ * `new:<paneId>`（首个消息绑定会话后经 move 迁移到 sessionId）。不用
+ * workdir：同一目录可开多个会话，各会话的面板布局互不相干，会话是 UI 状态
+ * 的最小归属单位。
+ *
+ * ## 失效规则
+ *
+ * pruneSessionUi 由 DesktopApp 在会话树/分屏更新时调用：owner 消失（会话被
+ * 删、pane 被拆）的键整体删除；仅隐藏（后台会话）的键保留——折叠面板、预
+ * 览 URL、forward 引用等都随会话存活，直到会话消失。
+ *
+ * ## 写入纪律
+ *
+ * 组件持有 useState mirror；「何时恢复/写回」的编排（换会话 swap effect、
+ * 每次渲染后的快照 sync effect）留在 ChatApp——它们与 React 提交时序强耦
+ * 合，不适合下沉。store 只回答「存哪、怎么存、何时失效」。**禁止直接
+ * mutate 缓存对象**（先例 #2049 的 patchCachedTabUrl 与 forward 即时写都
+ * 是土办法）：一律走 set/patch，为将来换持久化/订阅机制留单一咽喉。
+ */
+
+/** 本会话在 remote host 上的端口转发引用（preview 面板场景 18）。 */
+export interface RemoteForwardRef {
+  host: string;
+  remotePort: number;
+  /** The original remote URL the user clicked (kept for comment rewriting). */
+  originalUrl: string;
+  /** Matches the desktopForwardPortResult reply; stale replies are dropped. */
+  requestId: string;
+}
+
+/** 单个会话的 UI 状态快照。新字段按「折叠状态（80db706b）/ 预览 URL（#2049）
+ *  的先例」直接加在这里——声明即纳入快照/恢复/失效的全套机制。 */
+export interface SessionUiState {
+  /** Open panel tabs in tab order (multi-instance kinds may repeat). */
+  checked: PanelTab[];
+  /** Shared panel-slot width (tabbed layout: one slot, one width). */
+  panelWidth: number;
+  /**
+   * True once the user manually dragged the shared slot width off its default.
+   * A slot never dragged auto-fills the space beyond the conversation's minimum
+   * when the panel opens (spec desktop-panels.md 场景 7-9); a manual one keeps
+   * its width from then on.
+   */
+  panelWidthManual: boolean;
+  /** Currently active tab id; null when no tab is open. */
+  activePanel: string | null;
+  /**
+   * Whether the panel slot is expanded for this session (spec
+   * desktop-panels.md「展开/折叠」场景 10: 折叠/展开逐会话记忆，与 tab 集合/
+   * 宽度同级). Collapsing hides the slot but keeps the open tabs mounted, so a
+   * session collapsed with tabs open must come back collapsed after a switch.
+   */
+  panelExpanded: boolean;
+  /** Plan panel markdown (ExitPlanMode content); null = no plan yet. */
+  planContent: string | null;
+  /**
+   * This session's remote port forward (scenario 18). The tunnel is owned by
+   * the session, not the pane: it survives panel close, host switches, pane
+   * rebinding and unmount/remount — only session deletion, ssh process death
+   * or app exit release it. Display bookkeeping only.
+   */
+  forward: RemoteForwardRef | null;
+  /** Last forward failure for this session, shown in the preview stub. */
+  forwardError: string | null;
+}
+
+export type SessionUiKey = string;
+
+export function emptySessionUiState(): SessionUiState {
+  return {
+    checked: [],
+    panelWidth: PANEL_DEFAULT_WIDTH,
+    panelWidthManual: false,
+    activePanel: null,
+    panelExpanded: false,
+    planContent: null,
+    forward: null,
+    forwardError: null,
+  };
+}
+
+/** Patch 对象或基于当前状态的 updater（返回要合并的部分字段）。 */
+export type SessionUiPatch = Partial<SessionUiState>;
+
+class SessionUiStore {
+  private cache = new Map<SessionUiKey, SessionUiState>();
+
+  get(key: SessionUiKey): SessionUiState | undefined {
+    return this.cache.get(key);
+  }
+
+  /** 全量快照写入（ChatApp 的 state-sync effect 每次提交后调用）。 */
+  set(key: SessionUiKey, state: SessionUiState): void {
+    this.cache.set(key, state);
+  }
+
+  /** 局部写入；键尚无条目时以空组起底（先例：forward 请求即时落缓存）。 */
+  patch(key: SessionUiKey, patch: SessionUiPatch): void {
+    const prev = this.cache.get(key) ?? emptySessionUiState();
+    this.cache.set(key, { ...prev, ...patch });
+  }
+
+  /**
+   * 新会话桶迁移：`new:<paneId>` 的 setup（首个消息绑定会话前做的面板布局）
+   * 搬到 sessionId 名下。目标键已有自己的条目时不搬（返回既有条目）；
+   * 「何时允许迁移」（仅首个消息绑定会话那一次）由调用方判断。返回目标键
+   * 生效的条目（无则 undefined）。
+   */
+  move(from: SessionUiKey, to: SessionUiKey): SessionUiState | undefined {
+    const existing = this.cache.get(to);
+    if (existing) return existing;
+    const group = this.cache.get(from);
+    if (group) {
+      this.cache.set(to, group);
+      this.cache.delete(from);
+    }
+    return group;
+  }
+
+  /** 失效清理：owner 消失的键整体删除（见模块头「失效规则」）。 */
+  prune(keepKeys: Set<string>): void {
+    for (const key of [...this.cache.keys()]) {
+      if (!keepKeys.has(key)) this.cache.delete(key);
+    }
+  }
+
+  /**
+   * 按 forward requestId 反查归属会话键（desktopForwardPortResult 回复的
+   * 归属匹配：tunnel 属于会话而非 pane，晚到的回复仍更新所属会话的缓存）。
+   */
+  keyByForwardRequestId(requestId: string): SessionUiKey | undefined {
+    for (const [key, state] of this.cache) {
+      if (state.forward?.requestId === requestId) return key;
+    }
+    return undefined;
+  }
+}
+
+export const sessionUi = new SessionUiStore();
+
+/** 旧名兼容（tests/DesktopApp 既有 import）：失效清理的具名导出。 */
+export function prunePanelGroupCache(keepKeys: Set<string>): void {
+  sessionUi.prune(keepKeys);
+}

--- a/packages/webview/tests/webview/sessionUiStore.test.ts
+++ b/packages/webview/tests/webview/sessionUiStore.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  sessionUi,
+  emptySessionUiState,
+  prunePanelGroupCache,
+} from "../../src/utils/sessionUiStore";
+
+describe("sessionUiStore", () => {
+  beforeEach(() => {
+    sessionUi.prune(new Set());
+  });
+
+  it("set + get round-trips a snapshot; missing keys read undefined", () => {
+    expect(sessionUi.get("s1")).toBeUndefined();
+
+    sessionUi.set("s1", {
+      ...emptySessionUiState(),
+      panelExpanded: true,
+      planContent: "## plan",
+    });
+    expect(sessionUi.get("s1")?.panelExpanded).toBe(true);
+    expect(sessionUi.get("s1")?.planContent).toBe("## plan");
+  });
+
+  it("patch merges into the existing snapshot (previewUrl write-back path)", () => {
+    sessionUi.set("s1", {
+      ...emptySessionUiState(),
+      checked: [{ id: "p1", kind: "preview", previewUrl: "http://a" }] as never,
+    });
+
+    sessionUi.patch("s1", { panelExpanded: true });
+    expect(sessionUi.get("s1")?.panelExpanded).toBe(true);
+    expect(sessionUi.get("s1")?.checked).toHaveLength(1);
+
+    // tab-level patch: update only the matching tab's URL, keep the rest
+    const cached = sessionUi.get("s1")!;
+    sessionUi.patch("s1", {
+      checked: cached.checked.map((t) =>
+        t.id === "p1" ? { ...t, previewUrl: "http://b" } : t,
+      ),
+    });
+    expect(sessionUi.get("s1")?.checked[0]).toMatchObject({
+      previewUrl: "http://b",
+    });
+  });
+
+  it("patch creates an empty group when the key has no entry (forward 即时落缓存)", () => {
+    sessionUi.patch("new:pane-1", {
+      forward: {
+        host: "local",
+        remotePort: 5173,
+        originalUrl: "http://localhost:5173",
+        requestId: "fwd-1",
+      },
+    });
+    const group = sessionUi.get("new:pane-1");
+    expect(group?.forward?.requestId).toBe("fwd-1");
+    // fields untouched by the patch start from the empty defaults
+    expect(group?.panelWidth).toBe(420);
+    expect(group?.panelExpanded).toBe(false);
+  });
+
+  it("move migrates the new-session bucket to the session id (swap effect)", () => {
+    sessionUi.set("new:pane-1", {
+      ...emptySessionUiState(),
+      panelExpanded: true,
+    });
+
+    // no own entry → the bucket migrates and is returned
+    const moved = sessionUi.move("new:pane-1", "s1");
+    expect(moved?.panelExpanded).toBe(true);
+    expect(sessionUi.get("s1")?.panelExpanded).toBe(true);
+    expect(sessionUi.get("new:pane-1")).toBeUndefined();
+
+    // an existing entry at the target wins (no clobber, source kept)
+    sessionUi.set("new:pane-2", {
+      ...emptySessionUiState(),
+      planContent: "from",
+    });
+    sessionUi.set("s2", { ...emptySessionUiState(), planContent: "target" });
+    expect(sessionUi.move("new:pane-2", "s2")?.planContent).toBe("target");
+    expect(sessionUi.get("s2")?.planContent).toBe("target");
+    expect(sessionUi.get("new:pane-2")?.planContent).toBe("from");
+  });
+
+  it("keyByForwardRequestId finds the owning session; unknown ids miss", () => {
+    sessionUi.patch("s1", {
+      forward: {
+        host: "local",
+        remotePort: 80,
+        originalUrl: "http://x",
+        requestId: "fwd-9",
+      },
+    });
+    sessionUi.patch("s2", {
+      forward: {
+        host: "local",
+        remotePort: 81,
+        originalUrl: "http://y",
+        requestId: "fwd-10",
+      },
+    });
+    expect(sessionUi.keyByForwardRequestId("fwd-9")).toBe("s1");
+    expect(sessionUi.keyByForwardRequestId("fwd-10")).toBe("s2");
+    expect(sessionUi.keyByForwardRequestId("fwd-404")).toBeUndefined();
+  });
+
+  it("prune drops keys whose owner is gone and keeps live ones (失效规则)", () => {
+    sessionUi.set("s-live", emptySessionUiState());
+    sessionUi.set("s-deleted", emptySessionUiState());
+    sessionUi.set("new:pane-live", emptySessionUiState());
+
+    prunePanelGroupCache(new Set(["s-live", "new:pane-live"]));
+
+    expect(sessionUi.get("s-live")).toBeDefined();
+    expect(sessionUi.get("new:pane-live")).toBeDefined();
+    expect(sessionUi.get("s-deleted")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
# PR 第 2 步：会话级 UI 状态快照 store（SessionUiStore）

## 设计要点

**病根**：会话级 UI 状态（面板布局/预览 URL/forward 引用…）「属于谁、何时失效」没有统一管——四个先例各造各的：#2049 预览 URL 写回（patchCachedTabUrl 直接 mutate 缓存对象）、#2081 上下文用量（desktopHost WeakMap）、80db706b 折叠状态（往 panelGroupCache 加字段）、a3043966 SDD projectSettings（到达时盖章）。

**形态**：`packages/webview/src/utils/sessionUiStore.ts`——模块级单例 store（非 hook），ChatApp 保留 React 编排（useState mirror + swap/sync effect），store 只回答三件事：

1. **key 维度** = 会话键（sessionId ｜ `new:<paneId>` 新会话桶，首个消息绑定后 move 迁移）。不用 workdir：同目录多会话互不相干，会话是 UI 状态最小归属单位。
2. **失效规则** = `prune(keepKeys)`：owner 消失（会话删/pane 拆）的键整体删除，仅隐藏（后台会话）的键保留——语义与原 prunePanelGroupCache 完全一致，调用方 DesktopApp 不变。
3. **存取 API** = `get` / `set`（全量快照，sync effect 用）/ `patch`（局部写，键不存在时空组起底）/ `move`（new:桶→sessionId 迁移）/ `keyByForwardRequestId`（forward 回复按会话归属反查）。

**写入纪律**（删双轨的关键）：**禁止直接 mutate 缓存对象**。先例土办法的两处直接改写全部收口：
- #2049 的 `patchCachedTabUrl`（`target.checked = ...`）→ `sessionUi.patch`
- forward 请求的即时落缓存（`group.forward = fwd` + get-or-create 五行）→ `sessionUi.patch(groupKey, { forward: fwd })` 一行

**不抽 hook 的缘由**：ChatApp 的 mirror 模式与 swap effect（换会话时 8 字段整组恢复）强耦合，per-field `useSessionUiState(key, field)` 会拆散整组恢复或造成双份编排；hook 形态等后续病点迁移时按需引入。

## 试点迁移（行为等价，原路径删除）

| 状态 | 迁移前 | 迁移后 |
|---|---|---|
| 折叠状态（80db706b） | PanelGroupState.panelExpanded + 模块级 Map | SessionUiState.panelExpanded + sessionUi.set（sync effect）——读写路径不变，存储归一 |
| 预览 URL（#2049 写回） | setTabs 后靠 sync effect 全量覆盖 + forwardPortResult 直接 mutate cache | forwardPortResult 改走 `keyByForwardRequestId` + `patch`；forward 请求改走 `patch` |

`PanelGroupState`/`RemoteForwardRef`/`panelGroupCache`/`emptyPanelGroup`/`prunePanelGroupCache` 在 ChatApp 的定义全部删除，单一来源在 sessionUiStore.ts。`prunePanelGroupCache` 以具名函数从 store 模块导出（ChatApp re-export 保留、DesktopApp 改直连），4 个测试文件的既有 import 零改动。

## 渐进迁移清单（后续 PR，本批不动）

| 病点 | 现状 | 缘由 |
|---|---|---|
| #2081 上下文用量 | desktopHost `contextUsageByAgent WeakMap`（host 侧缓存重放） | 超本次边界（不动 desktop host）；webview 侧消费已是纯展示 |
| a3043966 SDD projectSettings | reducer + 到达时 workdir 盖章 | 正确闭合需 host 回带 workdir（第 1 步 PR 暂缓清单同款） |
| panelGroupCache 其余字段（panelWidth/activeTabId/planContent/forward） | 已随本次整体入 store | 无需单独迁移——SessionUiState 声明即覆盖 |

## 有意行为变更标注

无。全部 1015 个既有 webview 测试（含折叠状态逐会话记忆、面板拖宽、预览 URL 回归、swap 迁移）零修改通过；新增 store 单测 6 例只测新 API 的等价语义。

## 验证

- webview 全量单测 111 文件 / 1021 tests ✓（含 sessionUiStore 新单测 6/6）
- 全仓 type-check 4 配置 ✓ / oxlint 0 ✓ / prettier ✓
- e2e desktop-app + desktop-panel-drag-resize 44 passed ✓
- audit-webview-commands exit 0 ✓
