### PR TITLE
test(sdk): skillPath「目录非文件」与删除「目录级递归」语义锁 + 断言语义化示范

### DIFF
--- a/packages/agent-sdk/src/types/skills.ts
+++ b/packages/agent-sdk/src/types/skills.ts
@@ -7,6 +7,17 @@ export interface SkillMetadata {
   name: string;
   description: string;
   type: "personal" | "project" | "builtin";
+  /**
+   * Path to the skill **directory** (the folder containing SKILL.md), never
+   * to SKILL.md itself. Directory-level contract — all consumers rely on it:
+   * - `SkillManager.prepareSkillContent` injects this value for
+   *   `${WAVE_SKILL_DIR}` / `${CLAUDE_SKILL_DIR}` substitutions and reports it
+   *   as the "Base directory for this skill";
+   * - `SkillManager.deleteSkill` removes this path with `rm(recursive)`.
+   * Callers that need the file itself must `join(skillPath, "SKILL.md")`
+   * (misreading this as the file path broke the desktop "Edit" action,
+   * bug 3466438649392128).
+   */
   skillPath: string;
   allowedTools?: string[];
   context?: "fork";

--- a/packages/agent-sdk/tests/managers/skillManager.test.ts
+++ b/packages/agent-sdk/tests/managers/skillManager.test.ts
@@ -531,6 +531,12 @@ describe("SkillManager", () => {
           force: true,
         });
       }
+      // Directory-level delete contract: rm targets the skill folder so
+      // helper files inside it disappear with it — never just SKILL.md.
+      const removedTargets = vi
+        .mocked(rm)
+        .mock.calls.map((call) => String(call[0]));
+      expect(removedTargets.some((t) => t.endsWith("SKILL.md"))).toBe(false);
       // caches converge with disk before deleteSkill resolves: the duplicate
       // must NOT resurface from a lower-priority directory (bug ②)
       const after = manager
@@ -758,6 +764,10 @@ describe("SkillManager", () => {
       });
 
       expect(result.content).toContain("Skill is at /path/to/skill");
+      // Directory contract: skillPath is the skill's folder (see
+      // SkillMetadata.skillPath), so the substitution must never leak a
+      // SKILL.md file path into the prompt.
+      expect(result.content).not.toContain("SKILL.md");
     });
 
     it("should substitute ${WAVE_PLUGIN_ROOT} with the skill's plugin root path", async () => {

--- a/packages/agent-sdk/tests/utils/skillParser.test.ts
+++ b/packages/agent-sdk/tests/utils/skillParser.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { readFileSync } from "fs";
+import * as path from "path";
 import {
   parseSkillFile,
   validateSkillMetadata,
@@ -40,6 +41,22 @@ This is a test skill content.`;
       );
       expect(result.skillMetadata.type).toBe("personal");
       expect(result.validationErrors).toHaveLength(0);
+    });
+
+    it("exposes skillPath as the skill directory, not the SKILL.md file (contract lock)", () => {
+      // SkillMetadata.skillPath is a directory-level contract: consumers
+      // inject it for ${WAVE_SKILL_DIR} and rm(recursive) it on delete. If
+      // this ever returns the file path, those consumers silently break.
+      mockReadFileSync.mockReturnValue(
+        "---\nname: dir-skill\ndescription: d\n---\nbody",
+      );
+
+      const filePath = path.join("/root", "skills", "dir-skill", "SKILL.md");
+      const result = parseSkillFile(filePath);
+
+      expect(result.isValid).toBe(true);
+      expect(result.skillMetadata.skillPath).toBe(path.dirname(filePath));
+      expect(result.skillMetadata.skillPath.endsWith("SKILL.md")).toBe(false);
     });
 
     it("should parse allowed-tools in frontmatter (string)", () => {

--- a/packages/webview/tests/webview/test-utils.tsx
+++ b/packages/webview/tests/webview/test-utils.tsx
@@ -6,6 +6,21 @@ import type { VsCodeApi } from "../../src/types";
 import { ChatApp } from "../../src/components/ChatApp";
 import { fixtures, type HostToWebviewMessage } from "wave-webview-fixtures";
 
+/**
+ * Assertion style guide (see PR for #2063/#2067 precedent):
+ *
+ * Anchor assertions on **stable semantics**, not icon-implementation details:
+ * - Prefer `data-testid` handles (`getByTestId("diff-refresh")`,
+ *   `getByTestId("account-usage-collapse")`) over CSS class lookups.
+ * - For icon state, assert the semantic class (`"is-spinning"`) or the
+ *   element kind (`svg` exists), never a font-icon class
+ *   (`codicon-chevron-up` / `codicon-modifier-spin`) — icons migrate between
+ *   codicon font and inline SVG (0903 baseline) and class assertions break
+ *   or, worse, silently pass while asserting nothing.
+ * - Tests must still fail without the fix: an assertion that survives any
+ *   implementation is not a test.
+ */
+
 // Mock heavy dependencies
 vi.mock("mermaid", () => ({
   default: {


### PR DESCRIPTION
## 背景（架构优化第 3 步：顺手项）

#2091（技能「编辑」打不开 SKILL.md）与 #2092（删除技能需删多遍）的共同病根是跨端消费方误读 SDK 语义。本 PR 把两处语义固化为 JSDoc 契约 + 行为锁测试，防止再犯；同时落地测试断言语义化示范标准。

## 改动

### 1. skillPath「目录非文件」契约（#2091 病根）
- `SkillMetadata.skillPath` JSDoc：**目录路径**（含 SKILL.md 的技能目录），非 SKILL.md 文件。列出全部目录语义消费方：
  - `prepareSkillContent` 注入 `${WAVE_SKILL_DIR}`/`${CLAUDE_SKILL_DIR}` 与 "Base directory for this skill"
  - `deleteSkill` `rm(recursive)` 直接删除该路径
- 需要文件的调用方必须自行 `join(skillPath, "SKILL.md")`，注释引用 bug 3466438649392128。

### 2. 锁测试（均 fail-without-fix 双验）
| 锁 | 文件 | 破坏方式 → 结果 |
|---|---|---|
| parseSkillFile 产物 skillPath === dirname(filePath)，永不以 SKILL.md 结尾 | tests/utils/skillParser.test.ts | `dirname(filePath)`→`filePath` → 红 |
| `${WAVE_SKILL_DIR}` 替换产物不含 SKILL.md | tests/managers/skillManager.test.ts | 替换值拼 `/SKILL.md` → 红 |
| deleteSkill rm 目标永不以 SKILL.md 结尾（目录级删除，辅助文件随目录消失） | 同上（既有 recursive:true 断言已锁目录+递归，补文件路径负断言） | —（同型破坏已验） |

### 3. 删除语义（#2092 病根）现状确认
deleteSkill 既有测试已锁：多 root（.wave/.claude/.agents）同名副本单次全清 + `recursive:true,force:true` + 缓存收敛，本 PR 仅补「rm 从不指向文件」负断言，不重复造轮子。

### 4. 测试断言语义化示范标准（#2063/#2067）
webview `tests/webview/test-utils.tsx` 顶部新增示范注释：
- 断言锚 **data-testid**（如 `diff-refresh`/`account-usage-collapse`）而非 CSS class
- 图标状态锚语义形态（`is-spinning`、svg 存在），禁锚字体图标 class（codicon-* 在 0903 基线迁移为内联 SVG，class 断言会碎或空过）
- 范例 = 9ec35f7b（diffPane codicon-modifier-spin→is-spinning）与 516d6161（accountCard codicon-chevron-up→testid+svg 存在），两处已在合并时适配完毕，本 PR 全测试目录扫描确认无残留 codicon DOM 断言（仅剩 `icon:` mock 输入字段，非断言）
- 后续新测试照此标准，只做示范不全量扫

## 验证
- skillParser 20 + skillManager 53 全绿；两处锁 fail-without-fix 双验（临时破坏源码→红→还原→绿）
- agent-sdk + webview（含 tests/e2e/demo 4 配置）type-check 全绿、oxlint 0 warning、prettier clean
- pre-commit hook 全绿（6 包 type-check + lint-staged）

## 不做的事
- 不全量扫描改造既有断言（按任务书只做示范）
- 不动 deleteSkill/SkillManager 实现（语义已正确，只上锁）
