### PR TITLE
refactor(webview,hosts): projectSettings 快照收编 SessionUiStore + 回复归属键 workdir（旧温床 1/4）

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -5131,6 +5131,8 @@ export class DesktopHost {
         command: "projectSettings",
         paneId,
         enabledPlugins: result.enabledPlugins,
+        // 归属键：请求所用 workdir 恒回带（webview 据此过期即弃 + 键控缓存）
+        workdir,
       });
     } catch (error) {
       this.showToast({ message: `获取项目设置失败: ${error}` });
@@ -5208,6 +5210,8 @@ export class DesktopHost {
         command: "projectSettings",
         paneId,
         enabledPlugins: result.enabledPlugins,
+        // 归属键：请求所用 workdir 恒回带（同 handleGetProjectSettings）
+        workdir,
       });
       // Recreate agents so the plugin change applies immediately (mirrors handlePluginMutation)
       await this.updateAgentConfig(this.configStore.getConfiguration());

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
@@ -320,14 +320,19 @@ class MessageHandler(
             }
             // Read merged enabledPlugins (.wave/settings.json) for the 项目设置 tab.
             // Unlike enable/disable, this persists-only and does NOT reload the agent.
+            // workdir 归属键：请求所用 workdir 恒回带（webview 过期即弃 + 键控缓存）。
             "getProjectSettings" -> {
+                val workdir = currentWorkdir()
                 val enabledPlugins = try {
-                    session.agent?.getProjectSettings(currentWorkdir())?.jsonObject?.get("enabledPlugins") ?: JsonObject(emptyMap())
+                    session.agent?.getProjectSettings(workdir)?.jsonObject?.get("enabledPlugins") ?: JsonObject(emptyMap())
                 } catch (e: StdioClientException) {
                     LOG.warn("getProjectSettings failed: ${e.message}")
                     JsonObject(emptyMap())
                 }
-                postMessage("projectSettings", buildJsonObject { put("enabledPlugins", enabledPlugins) })
+                postMessage("projectSettings", buildJsonObject {
+                    put("enabledPlugins", enabledPlugins)
+                    put("workdir", workdir ?: "")
+                })
             }
             // Settings page hooks read-only view: fetch scope-scoped settings.json hooks.
             "getHooksConfig" -> {
@@ -370,15 +375,19 @@ class MessageHandler(
                 val pluginId = msg["pluginId"]?.jsonPrimitive?.content ?: return
                 val enabled = msg["enabled"]?.jsonPrimitive?.content?.toBoolean() ?: false
                 val scope = msg["scope"]?.jsonPrimitive?.content
+                val workdir = currentWorkdir()
                 val enabledPlugins = try {
-                    session.agent?.setBuiltinPluginEnabled(pluginId, enabled, currentWorkdir(), scope)?.jsonObject?.get("enabledPlugins")
+                    session.agent?.setBuiltinPluginEnabled(pluginId, enabled, workdir, scope)?.jsonObject?.get("enabledPlugins")
                 } catch (e: StdioClientException) {
                     LOG.warn("setBuiltinPluginEnabled failed: ${e.message}")
                     IdeService.showError(project, "修改项目设置失败: ${e.message}")
                     null
                 }
                 if (enabledPlugins != null) {
-                    postMessage("projectSettings", buildJsonObject { put("enabledPlugins", enabledPlugins) })
+                    postMessage("projectSettings", buildJsonObject {
+                        put("enabledPlugins", enabledPlugins)
+                        put("workdir", workdir ?: "")
+                    })
                     reloadAgentConfig()
                 }
             }

--- a/packages/vscode/src/services/pluginService.ts
+++ b/packages/vscode/src/services/pluginService.ts
@@ -5,7 +5,10 @@ import type { StdioClient } from "../stdio/stdioClient";
 export class PluginService {
   constructor(private utilityClient: StdioClient) {}
 
-  private getWorkdir(): string | undefined {
+  /** Workspace root the plugin/project-settings RPCs run against. Reply
+   *  attribution: hosts echo it on projectSettings so the webview can drop
+   *  stale replies (webview-fixtures ReplyAttribution). */
+  public getWorkdir(): string | undefined {
     return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
   }
 

--- a/packages/vscode/src/session/messageHandler.ts
+++ b/packages/vscode/src/session/messageHandler.ts
@@ -738,13 +738,15 @@ export class MessageHandler {
   }
 
   /** 项目设置视图（内置插件 SDD 开关）：读取项目 .wave/settings.json 合并后的
-   *  enabledPlugins，回包发给设置面板（pluginService 以工作区根目录为 workdir）。 */
+   *  enabledPlugins，回包发给设置面板（pluginService 以工作区根目录为 workdir，
+   *  归属键随包回带；无工作区窗口回 ""——webview 按不匹配丢弃=未加载）。 */
   private async handleSettingsGetProjectSettings(): Promise<void> {
     try {
       const result = await this.pluginService.getProjectSettings();
       this.context.postSettingsMessage({
         command: "projectSettings",
         enabledPlugins: result.enabledPlugins,
+        workdir: this.pluginService.getWorkdir() ?? "",
       });
     } catch (error) {
       console.error("获取项目设置失败:", error);
@@ -769,6 +771,7 @@ export class MessageHandler {
       this.context.postSettingsMessage({
         command: "projectSettings",
         enabledPlugins: result.enabledPlugins,
+        workdir: this.pluginService.getWorkdir() ?? "",
       });
 
       // Reload config and recreate agents to apply plugin changes
@@ -1282,7 +1285,12 @@ export class MessageHandler {
     try {
       const result = await this.pluginService.getProjectSettings();
       this.context.postMessage(
-        { command: "projectSettings", enabledPlugins: result.enabledPlugins },
+        {
+          command: "projectSettings",
+          enabledPlugins: result.enabledPlugins,
+          // 归属键：请求所用 workdir（pluginService = 工作区根目录）恒回带
+          workdir: this.pluginService.getWorkdir() ?? "",
+        },
         viewType,
         windowId,
       );
@@ -1305,7 +1313,12 @@ export class MessageHandler {
         scope as Scope,
       );
       this.context.postMessage(
-        { command: "projectSettings", enabledPlugins: result.enabledPlugins },
+        {
+          command: "projectSettings",
+          enabledPlugins: result.enabledPlugins,
+          // 归属键：同 chat 路由 handleGetProjectSettings
+          workdir: this.pluginService.getWorkdir() ?? "",
+        },
         viewType,
         windowId,
       );

--- a/packages/vscode/tests/session/messageHandler.test.ts
+++ b/packages/vscode/tests/session/messageHandler.test.ts
@@ -548,6 +548,7 @@ describe("MessageHandler MCP handlers", () => {
       setBuiltinPluginEnabled: vi
         .fn()
         .mockResolvedValue({ enabledPlugins: { "sdd@builtin": true } }),
+      getWorkdir: vi.fn().mockReturnValue("/ws/root"),
     };
     const context: MessageHandlerContext = {
       getChatSession: vi.fn().mockReturnValue(createMockSession()),
@@ -595,9 +596,12 @@ describe("MessageHandler MCP handlers", () => {
       .calls[0][0] as {
       command: string;
       enabledPlugins: Record<string, boolean>;
+      workdir?: string;
     };
     expect(posted.command).toBe("projectSettings");
     expect(posted.enabledPlugins).toEqual({ "sdd@builtin": true });
+    // 归属键：请求所用 workdir 恒回带（webview 过期即弃依据）
+    expect(posted.workdir).toBe("/ws/root");
   });
 });
 
@@ -849,6 +853,7 @@ describe("MessageHandler settings tab", () => {
       getProjectSettings: vi
         .fn()
         .mockResolvedValue({ enabledPlugins: { "sdd@builtin": true } }),
+      getWorkdir: vi.fn().mockReturnValue("/ws/root"),
     };
     const context: MessageHandlerContext = {
       getChatSession: vi.fn().mockReturnValue(createMockSession()),
@@ -878,9 +883,12 @@ describe("MessageHandler settings tab", () => {
       .mock.calls[0][0] as {
       command: string;
       enabledPlugins: Record<string, boolean>;
+      workdir?: string;
     };
     expect(posted.command).toBe("projectSettings");
     expect(posted.enabledPlugins).toEqual({ "sdd@builtin": true });
+    // 归属键：请求所用 workdir 恒回带（webview 过期即弃依据）
+    expect(posted.workdir).toBe("/ws/root");
     // Response goes to the settings panel, never the chat webviews
     expect(context.postMessage).not.toHaveBeenCalled();
   });
@@ -896,6 +904,7 @@ describe("MessageHandler settings tab", () => {
       setBuiltinPluginEnabled: vi
         .fn()
         .mockResolvedValue({ enabledPlugins: { "sdd@builtin": true } }),
+      getWorkdir: vi.fn().mockReturnValue("/ws/root"),
     };
     const context: MessageHandlerContext = {
       getChatSession: vi.fn().mockReturnValue(createMockSession()),
@@ -939,9 +948,12 @@ describe("MessageHandler settings tab", () => {
       .mock.calls[0][0] as {
       command: string;
       enabledPlugins: Record<string, boolean>;
+      workdir?: string;
     };
     expect(posted.command).toBe("projectSettings");
     expect(posted.enabledPlugins).toEqual({ "sdd@builtin": true });
+    // 归属键：请求所用 workdir 恒回带（webview 过期即弃依据）
+    expect(posted.workdir).toBe("/ws/root");
     expect(context.postMessage).not.toHaveBeenCalled();
   });
 

--- a/packages/webview-fixtures/src/types.ts
+++ b/packages/webview-fixtures/src/types.ts
@@ -362,9 +362,14 @@ export interface ConfigurationResponseMessage extends HostToWebviewMessageBase {
   configurationData: ConfigurationData;
 }
 
+/** Reply to getProjectSettings / setBuiltinPluginEnabled（项目设置视图 SDD 开关）. */
 export interface ProjectSettingsMessage extends HostToWebviewMessageBase {
   command: "projectSettings";
   enabledPlugins: Record<string, boolean>;
+  /** 归属键：本回复对应的项目工作目录（host 端以请求所用 workdir 恒回带）。
+   *  消费侧据此丢弃切目录/切会话后才落地的慢回复（过期即弃），并以此作为
+   *  缓存键（SessionUiStore projectSettings 快照按 workdir 维度存放）。 */
+  workdir: string;
 }
 
 /** Settings page hooks read-only view: scope-scoped settings.json hooks. */
@@ -885,6 +890,7 @@ export type HostToWebviewMessage =
 type ReplyAttribution = {
   // 作用域查询：作用域字段作归属键（渲染期键控过滤或过期即弃均可）。
   desktopGitBranches: "workdir";
+  projectSettings: "workdir";
   hooksConfigResponse: "scope";
   mcpConfigResponse: "scope";
   agentsContentResponse: "scope";
@@ -922,6 +928,7 @@ type ReplyAttributionSatisfied = {
 // 吸收，整体检查恒绿（probe 验证过的坑）。
 export const replyAttributionLocked = {
   desktopGitBranches: true,
+  projectSettings: true,
   hooksConfigResponse: true,
   mcpConfigResponse: true,
   agentsContentResponse: true,

--- a/packages/webview/demo/desktop-settings-manage.demo.ts
+++ b/packages/webview/demo/desktop-settings-manage.demo.ts
@@ -86,9 +86,11 @@ test.describe("Desktop settings manage views screenshots", () => {
     await expect(
       webviewPage.getByRole("heading", { name: "项目设置" }),
     ).toBeVisible();
-    // Host 回发项目设置（sdd@builtin 已启用）→ 开关为勾选态。
+    // Host 回发项目设置（sdd@builtin 已启用）→ 开关为勾选态。workdir 归属键
+    // 必须匹配当前目录，否则回复被过期即弃丢弃（ChatApp projectSettings 消费）。
     await injector.simulateExtensionMessage("projectSettings", {
       enabledPlugins: { "sdd@builtin": true },
+      workdir: DIR_A,
     });
     const sddToggle = webviewPage.getByLabel("启用 SDD 插件");
     await expect(sddToggle).toBeChecked();

--- a/packages/webview/demo/sdd-plugin.demo.ts
+++ b/packages/webview/demo/sdd-plugin.demo.ts
@@ -65,9 +65,11 @@ test.describe("Built-in SDD Plugin Demo", () => {
       webviewPage.getByRole("heading", { name: "项目设置" }),
     ).toBeVisible();
 
-    // Host 回发项目设置（sdd@builtin 已启用）→ 开关为勾选态。
+    // Host 回发项目设置（sdd@builtin 已启用）→ 开关为勾选态。workdir 归属键
+    // 必须匹配当前目录，否则回复被过期即弃丢弃（ChatApp projectSettings 消费）。
     await injector.simulateExtensionMessage("projectSettings", {
       enabledPlugins: { "sdd@builtin": true },
+      workdir: DIR_A,
     });
     const sddToggle = webviewPage.getByLabel("启用 SDD 插件");
     await expect(sddToggle).toBeChecked();

--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -1109,16 +1109,21 @@ export const ChatApp: React.FC<ChatAppProps> = ({
         // Project settings (.wave/settings.json merged enabledPlugins) are
         // per-workdir, so on Desktop each pane may hold a different value —
         // must be pane-guarded (unlike the shared global configurationResponse).
-        // The reply is stamped with the workdir active when it lands so the
-        // 项目设置 view can tell whether the cached value still belongs to the
-        // current project (a stale reply for a switched-away directory must
-        // never masquerade as the current project's state).
+        // The reply carries its own workdir (host 归属键)：归属目录已不是当前
+        // 目录（切目录/切会话后才落地）的慢回复直接丢弃（过期即弃），不再按
+        // 到达时目录盖章（a3043966 土办法会把上个项目的数据标成当前项目）。
         if (!forThisPane(message)) break;
+        if (message.workdir !== effectiveWorkdirRef.current) break;
+        // workdir 键控快照存 SessionUiStore；reducer 只镜像本次接受的值供
+        // 项目设置视图渲染（镜像自身的归属守卫见 SettingsPage）。
+        sessionUi.setProjectSettings(message.workdir, {
+          enabledPlugins: message.enabledPlugins,
+        });
         dispatch({
           type: "SET_PROJECT_SETTINGS",
           payload: {
             enabledPlugins: message.enabledPlugins,
-            workdir: effectiveWorkdirRef.current,
+            workdir: message.workdir,
           },
         });
         break;

--- a/packages/webview/src/reducers/chatReducer.ts
+++ b/packages/webview/src/reducers/chatReducer.ts
@@ -33,9 +33,10 @@ export const initialState: ChatState = {
   configurationLoading: false,
   configurationError: undefined,
   projectSettings: undefined,
-  // The workdir the cached projectSettings was fetched for (project settings are
-  // per-workdir; the 项目设置 view must not show one project's toggle under
-  // another's directory — see SET_PROJECT_SETTINGS / SettingsPage).
+  // Mirror of the last accepted projectSettings reply: the value plus the
+  // workdir it belongs to (host 归属键原样带回). Keyed snapshots live in
+  // SessionUiStore (workdir 维度); this pair only feeds the 项目设置 view's
+  // render-time guard (SettingsPage: mismatch = treat as unloaded).
   projectSettingsWorkdir: undefined,
   // Permission mode state
   permissionMode: "default",
@@ -188,9 +189,9 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
         projectSettings: {
           enabledPlugins: action.payload.enabledPlugins,
         },
-        // Stamp the workdir the reply corresponds to: the webview derives it from
-        // the pane/session active when the reply lands. The 项目设置 view only
-        // trusts the cached value while it matches the current workdir.
+        // Mirror write: only reached for replies whose attribution workdir
+        // matched the pane's current workdir (ChatApp 过期即弃已过滤)，workdir
+        // 原样落镜像供 SettingsPage 渲染期守卫比对。
         projectSettingsWorkdir: action.payload.workdir,
       };
     case "SET_INITIAL_STATE":

--- a/packages/webview/src/settings-preview-entry.tsx
+++ b/packages/webview/src/settings-preview-entry.tsx
@@ -124,10 +124,13 @@ function SettingsPreview() {
         break;
       case "projectSettings":
         if (msg.enabledPlugins && typeof msg.enabledPlugins === "object") {
+          // host 回带 workdir（归属键）：归属目录与当前目录不一致（settingsState
+          // 切换后才落地）的慢回复直接丢弃（过期即弃），不再按到达时目录盖章。
+          if (msg.workdir !== workdirRef.current) break;
           setProjectSettings({
             enabledPlugins: msg.enabledPlugins as Record<string, boolean>,
           });
-          setProjectSettingsWorkdir(workdirRef.current);
+          setProjectSettingsWorkdir(msg.workdir);
         }
         break;
     }

--- a/packages/webview/src/types/index.ts
+++ b/packages/webview/src/types/index.ts
@@ -734,9 +734,11 @@ export interface ChatState {
   // Project-scoped settings (read from .wave/settings.json merged config via
   // stdio RPC). Holds the merged enabledPlugins map for the 项目设置 view.
   projectSettings?: { enabledPlugins: Record<string, boolean> };
-  // The workdir projectSettings above was fetched for. The 项目设置 view keys
-  // the cached toggle state to this directory so switching sessions/projects
-  // forces a fresh read instead of showing another project's state.
+  // Mirror of the last accepted projectSettings reply: the value plus the
+  // workdir it belongs to (host 归属键原样带回；键控快照在 SessionUiStore)。
+  // The 项目设置 view keys the cached toggle state to this directory so
+  // switching sessions/projects forces a fresh read instead of showing
+  // another project's state.
   projectSettingsWorkdir?: string;
   // Permission mode state
   permissionMode?: PermissionMode;

--- a/packages/webview/src/utils/sessionUiStore.ts
+++ b/packages/webview/src/utils/sessionUiStore.ts
@@ -42,6 +42,11 @@ export interface RemoteForwardRef {
   requestId: string;
 }
 
+/** 项目设置快照（.wave/settings.json 合并后的 enabledPlugins）。 */
+export interface ProjectSettingsSnapshot {
+  enabledPlugins: Record<string, boolean>;
+}
+
 /** 单个会话的 UI 状态快照。新字段按「折叠状态（80db706b）/ 预览 URL（#2049）
  *  的先例」直接加在这里——声明即纳入快照/恢复/失效的全套机制。 */
 export interface SessionUiState {
@@ -98,6 +103,22 @@ export type SessionUiPatch = Partial<SessionUiState>;
 
 class SessionUiStore {
   private cache = new Map<SessionUiKey, SessionUiState>();
+
+  // projectSettings 快照区：**workdir 维度**（与上方会话键区分开的另一张
+  // Map）。项目设置本身按项目作用域（.wave/settings.json 随目录走），同一
+  // 目录的多个会话共享同一份，会话不是它的归属单位——a3043966 的 chatReducer
+  // 单槽 stamp（到达时盖章）迁入于此，key 由 store 统一管理。条目极小且以
+  // webview 实例一生访问过的目录数为上界，随实例销毁整体释放。
+  private projectSettingsByWorkdir = new Map<string, ProjectSettingsSnapshot>();
+
+  getProjectSettings(workdir: string): ProjectSettingsSnapshot | undefined {
+    return this.projectSettingsByWorkdir.get(workdir);
+  }
+
+  /** 回复落地且归属匹配当前目录时写入（ChatApp projectSettings 消费处）。 */
+  setProjectSettings(workdir: string, snapshot: ProjectSettingsSnapshot): void {
+    this.projectSettingsByWorkdir.set(workdir, snapshot);
+  }
 
   get(key: SessionUiKey): SessionUiState | undefined {
     return this.cache.get(key);

--- a/packages/webview/tests/webview/projectSettingsAttribution.test.tsx
+++ b/packages/webview/tests/webview/projectSettingsAttribution.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  sendHostMessage,
+  fixtures,
+  createMockVscode,
+} from "./test-utils";
+import React from "react";
+import { ChatApp } from "../../src/components/ChatApp";
+import { sessionUi } from "../../src/utils/sessionUiStore";
+import type { VsCodeApi } from "../../src/types";
+
+// 与 desktopThemeSource.test.tsx 同构的 desktop host props。
+function desktopHost() {
+  return {
+    type: "desktop",
+    host: "local",
+    hosts: ["local"],
+    recentWorkdirs: [],
+    workdir: "/work/a",
+    sessionTree: [],
+    panes: [{ paneId: "pane-1" }],
+    focusedPaneId: "pane-1",
+    onSelectWorkdir: () => {},
+    onSelectRecentWorkdir: () => {},
+    onRemoveRecentWorkdir: () => {},
+    onSelectHost: () => {},
+    onAddHost: () => {},
+    onSelectRemotePath: () => {},
+    onListRemoteDir: () => {},
+    onSelectSession: () => {},
+    onDeleteSession: () => {},
+    onOpenPane: () => {},
+  } as unknown as React.ComponentProps<typeof ChatApp>["host"];
+}
+
+/** 打开设置页（/config → 根实例 settingsOpen）并进入「项目设置」视图。 */
+async function openProjectSettingsView() {
+  const input = await screen.findByTestId("message-input");
+  input.focus();
+  await act(async () => {
+    input.textContent = "/config";
+    const range = document.createRange();
+    range.selectNodeContents(input);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+    fireEvent.input(input, { data: "/config", inputType: "insertText" });
+  });
+  fireEvent.keyDown(input, { key: "Enter" });
+  await screen.findByText("管理 CodeWave IDE 的界面、模型和基础行为。");
+  fireEvent.click(screen.getByRole("button", { name: "项目设置" }));
+  await screen.findByRole("heading", { name: "项目设置" });
+}
+
+function sddToggle(): HTMLInputElement {
+  return screen.getByLabelText("启用 SDD 插件") as HTMLInputElement;
+}
+
+/**
+ * projectSettings 回复归属契约（webview-fixtures ReplyAttribution: projectSettings
+ * → workdir）：host 回带请求所用 workdir，ChatApp 过期即弃 + SessionUiStore
+ * 按 workdir 键控缓存；reducer 只留镜像（a3043966「到达时盖章」土办法迁出）。
+ */
+describe("projectSettings 回复归属（过期即弃 + workdir 键控）", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionUi.prune(new Set());
+  });
+
+  it("归属目录不匹配的慢回复被丢弃，不回显为当前项目状态、不进缓存", async () => {
+    const mockVscode = createMockVscode();
+    render(
+      <ChatApp
+        vscode={mockVscode as unknown as VsCodeApi}
+        host={desktopHost()}
+      />,
+    );
+    sendHostMessage(fixtures.authStatusResponse());
+    // 当前活动目录 /work/a
+    sendHostMessage(fixtures.setInitialState({ workdir: "/work/a" }));
+    await openProjectSettingsView();
+
+    // 进入视图触发 getProjectSettings 拉取
+    expect(mockVscode.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ command: "getProjectSettings" }),
+    );
+
+    // 切目录后才落地的慢回复（数据属 /work/b）→ 丢弃：开关按未加载处理
+    // （修复前：到达时按当前目录 /work/a 盖章 → 开关错误回显 /work/b 的开）
+    act(() => {
+      sendHostMessage({
+        command: "projectSettings",
+        workdir: "/work/b",
+        enabledPlugins: { "sdd@builtin": true },
+      });
+    });
+    expect(sddToggle().disabled).toBe(true);
+    expect(sddToggle().checked).toBe(false);
+    expect(sessionUi.getProjectSettings("/work/b")).toBeUndefined();
+
+    // 归属当前目录的回复正常生效：镜像 + 键控缓存双写
+    act(() => {
+      sendHostMessage({
+        command: "projectSettings",
+        workdir: "/work/a",
+        enabledPlugins: { "sdd@builtin": true },
+      });
+    });
+    expect(sddToggle().disabled).toBe(false);
+    expect(sddToggle().checked).toBe(true);
+    expect(sessionUi.getProjectSettings("/work/a")).toEqual({
+      enabledPlugins: { "sdd@builtin": true },
+    });
+  });
+
+  it("归属目录匹配时镜像与缓存一致（SET_PROJECT_SETTINGS payload 用回包自带 workdir）", async () => {
+    const mockVscode = createMockVscode();
+    render(
+      <ChatApp
+        vscode={mockVscode as unknown as VsCodeApi}
+        host={desktopHost()}
+      />,
+    );
+    sendHostMessage(fixtures.authStatusResponse());
+    sendHostMessage(fixtures.setInitialState({ workdir: "/work/a" }));
+    await openProjectSettingsView();
+
+    act(() => {
+      sendHostMessage({
+        command: "projectSettings",
+        workdir: "/work/a",
+        enabledPlugins: {},
+      });
+    });
+    // 未启用 = 缓存写入但开关保持关闭且可用
+    expect(sddToggle().disabled).toBe(false);
+    expect(sddToggle().checked).toBe(false);
+    expect(sessionUi.getProjectSettings("/work/a")).toEqual({
+      enabledPlugins: {},
+    });
+  });
+});

--- a/packages/webview/tests/webview/sessionUiStore.test.ts
+++ b/packages/webview/tests/webview/sessionUiStore.test.ts
@@ -116,4 +116,36 @@ describe("sessionUiStore", () => {
     expect(sessionUi.get("new:pane-live")).toBeDefined();
     expect(sessionUi.get("s-deleted")).toBeUndefined();
   });
+
+  // ── projectSettings 快照区（workdir 维度，a3043966 stamp 迁入） ──
+
+  it("projectSettings round-trips per workdir key; other directories miss", () => {
+    expect(sessionUi.getProjectSettings("/proj/A")).toBeUndefined();
+
+    sessionUi.setProjectSettings("/proj/A", {
+      enabledPlugins: { "sdd@builtin": true },
+    });
+    expect(sessionUi.getProjectSettings("/proj/A")).toEqual({
+      enabledPlugins: { "sdd@builtin": true },
+    });
+    // key = workdir：另一目录读不到 A 的快照（数据按项目作用域隔离）
+    expect(sessionUi.getProjectSettings("/proj/B")).toBeUndefined();
+
+    sessionUi.setProjectSettings("/proj/A", { enabledPlugins: {} });
+    expect(sessionUi.getProjectSettings("/proj/A")).toEqual({
+      enabledPlugins: {},
+    });
+  });
+
+  it("projectSettings section is independent of the session-keyed cache (prune 不波及)", () => {
+    sessionUi.setProjectSettings("/proj/A", { enabledPlugins: {} });
+    sessionUi.set("s1", emptySessionUiState());
+
+    sessionUi.prune(new Set());
+
+    // workdir 维度条目不受会话键失效清理影响（寿命 = webview 实例）
+    expect(sessionUi.getProjectSettings("/proj/A")).toEqual({
+      enabledPlugins: {},
+    });
+  });
 });


### PR DESCRIPTION
## 改动面（旧温床消除 1/4：projectSettings 收编）

四步任务的第 1 步（后三步独立 PR）：webview 侧 projectSettings 快照迁入 SessionUiStore（workdir 维度 key 由 store 统一管，chatReducer 只留镜像），host 侧 projectSettings 回复补归属键 workdir（#2127 PR 描述暂缓项），fixtures ReplyAttribution 收编为编译期强制。

### webview

- `sessionUiStore.ts`：新增 projectSettings 快照区（workdir 维度独立 Map + `ProjectSettingsSnapshot`）。a3043966 的 chatReducer 单槽 stamp（到达时盖章）迁入于此；数据按项目作用域（.wave/settings.json 随目录走）而非会话归属，故与会话键区隔离、`prune` 不波及，条目寿命 = webview 实例。
- `ChatApp.tsx` projectSettings 消费改**过期即弃**：`message.workdir !== effectiveWorkdirRef.current` 直接丢弃；接受时 `sessionUi.setProjectSettings(workdir, …)` 键控缓存 + `SET_PROJECT_SETTINGS` 镜像双写。
- `chatReducer.ts` `SET_PROJECT_SETTINGS` 只留镜像：`payload.workdir` 改用回包自带归属（原为 `effectiveWorkdirRef.current` 到达时推导）；SettingsPage 渲染期守卫与 props 契约不变。
- `settings-preview-entry.tsx`（IDE 设置 tab）同改过期即弃。
- 测试：新增 `projectSettingsAttribution.test.tsx` 2 例（ChatApp 级：过期即弃 + 键控缓存双写；fail-without-fix 双验：stash ChatApp 实现后 2 例全红）+ `sessionUiStore.test.ts` 2 例（workdir 键控读写 / prune 隔离）。

### host（fixtures 先行，已 rebuild）

- `webview-fixtures`：`ProjectSettingsMessage.workdir` **必填** + `ReplyAttribution` 注册 `projectSettings: "workdir"` + `replyAttributionLocked` 逐键断言（weak 化即类型报错）。
- `desktopHost.ts`：`handleGetProjectSettings` / `handleSetBuiltinPluginEnabled` 回带请求所用 workdir（agent workingDirectory ?? host workdir）。
- `vscode messageHandler.ts`：chat 路由 + settings 路由（双 switch 现状保留，本步只同步补字段，不合并路由）四处回发补 workdir；`PluginService.getWorkdir` 转 public 供归属回带。
- `JetBrains MessageHandler.kt`：`getProjectSettings` / `setBuiltinPluginEnabled` 同步回带 `currentWorkdir()`（契约一致性，JB 不在 CI fixtures 类型检查内但 webview 过期即弃依赖该字段）。

## 行为变更标注（有意修正）

1. **晚到且归属不匹配的回复不再显示**：旧实现把回复按到达时目录盖章——切目录后才落地的慢回复会把上个项目的 enabledPlugins 错标成当前项目（直到重拉回包覆盖）；新实现直接丢弃。归属匹配路径行为不变（settingsProject 既有 6 测试零修改通过）。
2. 无工作区窗口（vscode 单文件）：host 回 `""`（契约要求 string 且永不被真实目录匹配）→ 回复按不匹配丢弃 = 项目设置开关按未加载禁用。旧实现 undefined 盖章可短暂回显，属同向修正；degenerate 场景（无项目）语义更正确。

## 验证数据

- `wave-webview-fixtures` build + 测试 7 通过
- type-check 6 包全绿（含 webview tests/e2e/demo 三个 tsconfig）
- webview 112 文件 / **1025** 测试全绿；desktop **587** 全绿；vscode **191** 全绿
- oxlint 0 warnings；prettier 改动文件 clean；`audit-webview-commands.mjs` exit 0（97 命令 / 225 路由覆盖完整）
- e2e `settings-project-toggle` 绿；demo `sdd-plugin` / `desktop-settings-manage` 绿（注入补 workdir 归属键）
- JB `compileKotlin` BUILD SUCCESSFUL
- fail-without-fix 双验：仅 stash `ChatApp.tsx` 实现跑新回归 → 2/2 红；pop 后恢复绿
