### PR TITLE
fix(desktop): drop userData pin to legacy Wave — default to CodeWave IDE dir

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,5 +1,6 @@
 {
   "name": "wave-desktop",
+  "productName": "CodeWave IDE",
   "private": true,
   "description": "Wave code desktop app (Electron)",
   "version": "1.1.7",

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -145,11 +145,10 @@ process.on("unhandledRejection", (reason) => {
   hostLog.error("[Wave Desktop] unhandledRejection:", reason);
 });
 
-// userData 固定为旧目录名 "Wave"：OS 产品名已改为 CodeWave IDE（electron-builder
-// productName），若放任由 app 名派生的默认 userData 漂移，存量安装的配置/会话索引
-// 会被孤立（configStore 与会话树都在 userData 下），且 single-instance 锁随 userData
-// 移动会让新旧版本同时运行（锁作用域 = userData，见 RequestSingleInstanceLock）。
-// 必须在 requestSingleInstanceLock() 与 new ConfigStore() 之前设置。
+// userData 走 Electron 默认派生（appData + app 顶层 productName "CodeWave IDE"，
+// 即 %APPDATA%\CodeWave IDE）。品牌改名是 clean break（客户手动卸载旧版重装，
+// 见 f1feed70 决策）——不沿用 wave-desktop/Wave 旧目录，配置/会话索引全新开始；
+// 卸载器默认不删 %APPDATA% 数据，旧数据若需清理由客户手动删。
 // Dev instances get their own userData so they can run alongside an installed
 // app (the single-instance lock is scoped to the userData directory) and never
 // touch the real config/session index.
@@ -158,8 +157,6 @@ if (!app.isPackaged) {
     "userData",
     path.join(app.getPath("appData"), "wave-desktop-dev"),
   );
-} else {
-  app.setPath("userData", path.join(app.getPath("appData"), "Wave"));
 }
 
 let mainWindow: BrowserWindow | null = null;


### PR DESCRIPTION
fix(desktop): drop userData pin to legacy Wave — default to CodeWave IDE dir

移除 f1feed70 的 packaged userData 固定（%APPDATA%\Wave）。实测打包 asar 内
package.json 无顶层 productName，Electron 回落用 name（wave-desktop），老版
1.1.6 数据一直在 %APPDATA%\wave-desktop，并不存在'随 exe 名漂移'；原 pin 反把
1.1.7 数据引向孤儿目录 %APPDATA%\Wave，导致升级后旧会话消失、且与运行中旧版
本 single-instance 锁不互斥可双开（'升级后还是老版本'根因之一）。

品牌改名定为 clean break（客户手动卸载重装）：package.json 顶层补
productName CodeWave IDE，打包后 Electron 默认 userData 落
%APPDATA%\CodeWave IDE（全新目录），与 wave-desktop 旧数据彻底隔离；dev 实例
的 wave-desktop-dev 隔离保留。卸载器默认不删 %APPDATA% 数据，旧数据由客户手动清理。