### PR TITLE
refactor(webview,hosts): hooksResponse 回带 scope + historyResponse 回带 requestId（旧温床 2/4）

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -3535,6 +3535,8 @@ export class DesktopHost {
         this.postMessage({
           command: "hooksResponse",
           paneId: pid,
+          // 归属键：请求 scope 恒回带（webview 切 Tab 过期即弃）
+          scope: msg.scope as "user" | "project" | "plugin",
           hooks,
         });
         break;
@@ -3553,6 +3555,8 @@ export class DesktopHost {
           this.postMessage({
             command: "hooksResponse",
             paneId: pid,
+            // 归属键：请求 scope 恒回带（同 getHooksByScope）
+            scope: msg.scope as "user" | "project" | "plugin",
             hooks: hooks3,
           });
         } catch (error) {
@@ -3703,11 +3707,14 @@ export class DesktopHost {
 
       // -- prompt history --------------------------------------------------------------
       case "requestHistory":
-        await this.handleRequestHistory();
+        await this.handleRequestHistory(msg.requestId as string);
         break;
 
       case "searchHistory":
-        await this.handleSearchHistory(msg.query as string);
+        await this.handleSearchHistory(
+          msg.query as string,
+          msg.requestId as string,
+        );
         break;
 
       // -- file suggestions / uploads ---------------------------------------------------
@@ -5246,12 +5253,17 @@ export class DesktopHost {
     }
   }
 
-  private async handleRequestHistory(): Promise<void> {
+  private async handleRequestHistory(requestId: string): Promise<void> {
     try {
       const result = (await this.utilityClientFor(this.currentHost).request(
         "getPromptHistory",
       )) as { history: unknown[] };
-      this.postMessage({ command: "historyResponse", history: result.history });
+      this.postMessage({
+        command: "historyResponse",
+        // 归属键：请求 requestId 原样带回（webview 过期即弃）
+        requestId,
+        history: result.history,
+      });
     } catch (error) {
       console.error("[DesktopHost] 获取历史记录失败:", error);
       this.postMessage({
@@ -5261,13 +5273,21 @@ export class DesktopHost {
     }
   }
 
-  private async handleSearchHistory(query: string): Promise<void> {
+  private async handleSearchHistory(
+    query: string,
+    requestId: string,
+  ): Promise<void> {
     try {
       const result = (await this.utilityClientFor(this.currentHost).request(
         "searchPromptHistory",
         { query },
       )) as { history: unknown[] };
-      this.postMessage({ command: "historyResponse", history: result.history });
+      this.postMessage({
+        command: "historyResponse",
+        // 归属键：请求 requestId 原样带回（webview 过期即弃）
+        requestId,
+        history: result.history,
+      });
     } catch (error) {
       console.error("[DesktopHost] 搜索历史记录失败:", error);
       this.postMessage({

--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/session/MessageHandler.kt
@@ -193,8 +193,10 @@ class MessageHandler(
             }
 
             // ── Prompt history ─────────────────────────────────────────
-            // VSCE :137/:171 → historyResponse { history }
+            // VSCE :137/:171 → historyResponse { requestId, history }
+            // requestId 归属键：请求原样带回（webview 过期即弃）
             "requestHistory" -> {
+                val requestId = msg["requestId"]?.jsonPrimitive?.content ?: ""
                 val history = try {
                     session.agent?.getPromptHistory()?.jsonObject?.get("history") ?: JsonArray(emptyList())
                 } catch (e: StdioClientException) {
@@ -202,11 +204,15 @@ class MessageHandler(
                     postMessage("historyError", buildJsonObject { put("error", "获取历史记录失败: ${e.message}") })
                     return
                 }
-                postMessage("historyResponse", buildJsonObject { put("history", history) })
+                postMessage("historyResponse", buildJsonObject {
+                    put("requestId", requestId)
+                    put("history", history)
+                })
             }
-            // VSCE :140/:185 → historyResponse { history }
+            // VSCE :140/:185 → historyResponse { requestId, history }
             "searchHistory" -> {
                 val query = msg["query"]?.jsonPrimitive?.content ?: ""
+                val requestId = msg["requestId"]?.jsonPrimitive?.content ?: ""
                 val history = try {
                     session.agent?.searchPromptHistory(query)?.jsonObject?.get("history") ?: JsonArray(emptyList())
                 } catch (e: StdioClientException) {
@@ -214,7 +220,10 @@ class MessageHandler(
                     postMessage("historyError", buildJsonObject { put("error", "搜索历史记录失败: ${e.message}") })
                     return
                 }
-                postMessage("historyResponse", buildJsonObject { put("history", history) })
+                postMessage("historyResponse", buildJsonObject {
+                    put("requestId", requestId)
+                    put("history", history)
+                })
             }
 
             // ── File suggestions ───────────────────────────────────────
@@ -736,7 +745,11 @@ class MessageHandler(
                     LOG.warn("getHooksByScope failed: ${e.message}")
                     JsonObject(emptyMap())
                 }
-                postMessage("hooksResponse", buildJsonObject { put("hooks", hooks) })
+                // scope 归属键：请求 scope 恒回带（webview 切 Tab 过期即弃）
+                postMessage("hooksResponse", buildJsonObject {
+                    put("scope", scope)
+                    put("hooks", hooks)
+                })
             }
             "deleteHook" -> {
                 val scope = msg["scope"]?.jsonPrimitive?.content ?: return
@@ -744,7 +757,10 @@ class MessageHandler(
                 try {
                     session.agent?.deleteHook(scope, hookName)
                     val hooks = session.agent?.getHooksByScope(scope) ?: JsonObject(emptyMap())
-                    postMessage("hooksResponse", buildJsonObject { put("hooks", hooks) })
+                    postMessage("hooksResponse", buildJsonObject {
+                        put("scope", scope)
+                        put("hooks", hooks)
+                    })
                 } catch (e: StdioClientException) {
                     LOG.warn("deleteHook failed: ${e.message}")
                     IdeService.showError(project, "删除钩子失败: ${e.message}")

--- a/packages/vscode/src/session/messageHandler.ts
+++ b/packages/vscode/src/session/messageHandler.ts
@@ -314,10 +314,19 @@ export class MessageHandler {
         await this.handleAskBtw(msg.question as string, viewType, windowId);
         break;
       case "requestHistory":
-        await this.handleRequestHistory(viewType, windowId);
+        await this.handleRequestHistory(
+          msg.requestId as string,
+          viewType,
+          windowId,
+        );
         break;
       case "searchHistory":
-        await this.handleSearchHistory(msg.query as string, viewType, windowId);
+        await this.handleSearchHistory(
+          msg.query as string,
+          msg.requestId as string,
+          viewType,
+          windowId,
+        );
         break;
       case "getAuthStatus":
         await this.handleGetAuthStatus(viewType, windowId);
@@ -853,6 +862,8 @@ export class MessageHandler {
       const hooks = await session.getHooksByScope(scope);
       this.context.postSettingsMessage({
         command: "hooksResponse",
+        // 归属键：请求 scope 恒回带（webview 切 Tab 过期即弃）
+        scope,
         hooks,
       });
     } catch (error) {
@@ -870,6 +881,8 @@ export class MessageHandler {
       const hooks = await session.getHooksByScope(scope);
       this.context.postSettingsMessage({
         command: "hooksResponse",
+        // 归属键：请求 scope 恒回带（同 handleSettingsGetHooksByScope）
+        scope,
         hooks,
       });
     } catch (error) {
@@ -961,6 +974,7 @@ export class MessageHandler {
   }
 
   private async handleRequestHistory(
+    requestId: string,
     viewType?: "sidebar" | "tab" | "window",
     windowId?: string,
   ) {
@@ -971,6 +985,8 @@ export class MessageHandler {
       this.context.postMessage(
         {
           command: "historyResponse",
+          // 归属键：请求 requestId 原样带回（webview 过期即弃）
+          requestId,
           history: result.history,
         },
         viewType,
@@ -991,6 +1007,7 @@ export class MessageHandler {
 
   private async handleSearchHistory(
     query: string,
+    requestId: string,
     viewType?: "sidebar" | "tab" | "window",
     windowId?: string,
   ) {
@@ -1001,6 +1018,8 @@ export class MessageHandler {
       this.context.postMessage(
         {
           command: "historyResponse",
+          // 归属键：请求 requestId 原样带回（webview 过期即弃）
+          requestId,
           history: result.history,
         },
         viewType,
@@ -2245,6 +2264,8 @@ export class MessageHandler {
     this.context.postMessage(
       {
         command: "hooksResponse",
+        // 归属键：请求 scope 恒回带（webview 切 Tab 过期即弃）
+        scope,
         hooks,
       },
       viewType,
@@ -2265,6 +2286,8 @@ export class MessageHandler {
       this.context.postMessage(
         {
           command: "hooksResponse",
+          // 归属键：请求 scope 恒回带（同 handleGetHooksByScope）
+          scope,
           hooks,
         },
         viewType,

--- a/packages/webview-fixtures/src/index.ts
+++ b/packages/webview-fixtures/src/index.ts
@@ -334,6 +334,8 @@ export const fixtures: Fixtures = {
 
   hooksResponse: (hooks, overrides = {}) => ({
     command: "hooksResponse",
+    // 归属键默认 user（host 以请求 scope 恒回带；切 Tab 场景显式 override）
+    scope: "user",
     hooks,
     ...overrides,
   }),

--- a/packages/webview-fixtures/src/types.ts
+++ b/packages/webview-fixtures/src/types.ts
@@ -677,6 +677,9 @@ export interface SkillMetadataResponseMessage extends HostToWebviewMessageBase {
 
 export interface HooksResponseMessage extends HostToWebviewMessageBase {
   command: "hooksResponse";
+  /** 归属键：回复所属的配置作用域（host 端以请求 scope 恒回带），消费侧
+   *  （useSettingsList attributionKey）据此丢弃切 Tab 前发出的慢回复。 */
+  scope: "user" | "project" | "plugin";
   hooks: Record<string, unknown[]>;
   /** 该 scope 钩子所在 settings.json 路径（删除确认框展示用），可空 */
   configPath?: string | null;
@@ -691,6 +694,10 @@ export interface McpConfigPathsResponseMessage
 
 export interface HistoryResponseMessage extends HostToWebviewMessageBase {
   command: "historyResponse";
+  /** 归属键：请求生成的 id（requestHistory/searchHistory 原样带回）。历史
+   *  弹窗按 debounce 连续发查询，晚到的旧查询回复会被 requestId 比对丢弃
+   *  （过期即弃，fileSuggestionsResponse 同款范例）。 */
+  requestId: string;
   history: SessionMetadata[];
 }
 
@@ -895,6 +902,11 @@ type ReplyAttribution = {
   mcpConfigResponse: "scope";
   agentsContentResponse: "scope";
   agentsContentSaved: "scope";
+  // 四视图钩子列表：scope 作归属键（useSettingsList 与 fetchKey 比对，
+  // 切 Tab 前的慢回复即弃）。
+  hooksResponse: "scope";
+  // 一次性查询：历史弹窗 debounce 连续查询，requestId 比对弃旧回复。
+  historyResponse: "requestId";
   // 问题文本作键：btw 面板比对 in-flight question，晚到的旧回复即弃。
   btwStream: "question";
   btwResponse: "question";
@@ -933,6 +945,8 @@ export const replyAttributionLocked = {
   mcpConfigResponse: true,
   agentsContentResponse: true,
   agentsContentSaved: true,
+  hooksResponse: true,
+  historyResponse: true,
   btwStream: true,
   btwResponse: true,
   btwError: true,

--- a/packages/webview/demo/desktop-conversation.demo.ts
+++ b/packages/webview/demo/desktop-conversation.demo.ts
@@ -204,7 +204,13 @@ test.describe("Desktop 2.1 对话 screenshots", () => {
       el.dispatchEvent(ev);
     });
     await injector.waitForMessage("requestHistory", 5000);
+    // 归属键：回带刚发出的 requestId（无归属的 historyResponse 会被过期即弃）
+    const sent = await injector.getMessagesSentToExtension();
+    const historyRequest = sent
+      .filter((m) => m.command === "requestHistory")
+      .pop() as { requestId?: string };
     await injector.simulateExtensionMessage("historyResponse", {
+      requestId: historyRequest?.requestId,
       history: [
         {
           prompt:

--- a/packages/webview/demo/desktop-settings-manage.demo.ts
+++ b/packages/webview/demo/desktop-settings-manage.demo.ts
@@ -195,6 +195,8 @@ test.describe("Desktop settings manage views screenshots", () => {
     await webviewPage.getByRole("button", { name: "钩子" }).click();
     await expect(webviewPage.getByText("用户级钩子")).toBeVisible();
     await injector.simulateExtensionMessage("hooksResponse", {
+      // 归属键：当前 Tab 为「用户级钩子」，回带 scope 才能通过过期即弃
+      scope: "user",
       hooks: {
         PreToolUse: [
           {

--- a/packages/webview/demo/product-spec-history-search.demo.ts
+++ b/packages/webview/demo/product-spec-history-search.demo.ts
@@ -52,8 +52,16 @@ test.describe("Product Spec: History Search", () => {
       },
     ];
 
+    // 归属键：回带 webview 刚发出的 requestId（无归属的 historyResponse 会被丢弃）
+    await injector.waitForMessage("requestHistory", 5000);
+    const sent = await injector.getMessagesSentToExtension();
+    const historyRequest = sent
+      .filter((m) => m.command === "requestHistory")
+      .pop() as { requestId?: string };
+
     await injector.simulateExtensionMessage("historyResponse", {
       history: mockHistory,
+      requestId: historyRequest?.requestId,
     });
 
     // 4. Wait for popup to be visible and loading to finish

--- a/packages/webview/demo/settings-manage.demo.ts
+++ b/packages/webview/demo/settings-manage.demo.ts
@@ -108,6 +108,8 @@ test.describe("设置页钩子选项卡 Demo", () => {
     await webviewPage.evaluate((hooks) => {
       window.simulateExtensionMessage({
         command: "hooksResponse",
+        // 归属键：当前 Tab 为「用户级钩子」，回带 scope 才能通过过期即弃
+        scope: "user",
         hooks,
         configPath: "~/.wave/settings.json",
       });

--- a/packages/webview/src/components/HistorySearchPopup.tsx
+++ b/packages/webview/src/components/HistorySearchPopup.tsx
@@ -25,6 +25,11 @@ export const HistorySearchPopup: React.FC<HistorySearchPopupProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const popupRef = useRef<HTMLDivElement>(null);
+  // 一次性查询归属键（webview-fixtures ReplyAttribution: historyResponse →
+  // requestId）：每次请求换 id，晚到的旧查询回复按比对丢弃（fileSuggestions
+  // 的 requestIdRef 同款范例）。debounce 连续输入 + CLI 慢查询下，旧回复
+  // 覆盖新结果会让搜索"越搜越旧"。
+  const requestIdRef = useRef<string>("");
 
   // Handle clicks outside to close popup (listener registered one tick later
   // inside useClickOutside so a mousedown that just opened this popup is not
@@ -41,7 +46,11 @@ export const HistorySearchPopup: React.FC<HistorySearchPopupProps> = ({
       inputRef.current.focus();
       // Request initial history
       setIsLoading(true);
-      vscode.postMessage({ command: "requestHistory" });
+      requestIdRef.current = Date.now().toString();
+      vscode.postMessage({
+        command: "requestHistory",
+        requestId: requestIdRef.current,
+      });
     } else {
       setQuery("");
       setItems([]);
@@ -52,6 +61,8 @@ export const HistorySearchPopup: React.FC<HistorySearchPopupProps> = ({
   // Handle messages from extension
   useHostMessage((data) => {
     if (data.command === "historyResponse") {
+      // 过期即弃：非当前请求的晚到回复直接丢弃
+      if (data.requestId !== requestIdRef.current) return;
       setItems(data.history || []);
       setSelectedIndex(0);
       setIsLoading(false);
@@ -77,12 +88,21 @@ export const HistorySearchPopup: React.FC<HistorySearchPopupProps> = ({
     if (isVisible && query.trim()) {
       const timer = setTimeout(() => {
         setIsLoading(true);
-        vscode.postMessage({ command: "searchHistory", query });
+        requestIdRef.current = Date.now().toString();
+        vscode.postMessage({
+          command: "searchHistory",
+          query,
+          requestId: requestIdRef.current,
+        });
       }, 300);
       return () => clearTimeout(timer);
     } else if (isVisible && !query.trim()) {
       setIsLoading(true);
-      vscode.postMessage({ command: "requestHistory" });
+      requestIdRef.current = Date.now().toString();
+      vscode.postMessage({
+        command: "requestHistory",
+        requestId: requestIdRef.current,
+      });
     }
   }, [query, isVisible, vscode]);
 

--- a/packages/webview/src/components/SettingsHooksView.tsx
+++ b/packages/webview/src/components/SettingsHooksView.tsx
@@ -99,6 +99,9 @@ const SettingsHooksView: React.FC<SettingsHooksViewProps> = ({
     fetchKey: activeTab,
     responseCommands: ["hooksResponse"],
     pickItems: (message) => (message.hooks as HooksByEvent) || {},
+    // 归属键（webview-fixtures ReplyAttribution: hooksResponse→scope）：
+    // 切 Tab 前发出的慢回复与当前 Tab 不符即弃。
+    attributionKey: (message) => message.scope as string,
     onResponse: (message) => {
       setConfigPath(
         typeof message.configPath === "string" ? message.configPath : null,

--- a/packages/webview/src/utils/useSettingsList.ts
+++ b/packages/webview/src/utils/useSettingsList.ts
@@ -15,6 +15,13 @@ export interface UseSettingsListOptions<TList> {
   responseCommands: string[];
   /** 从响应消息提取列表状态（含 || [] / || {} 兜底）。 */
   pickItems: (message: HostMessage) => TList;
+  /**
+   * 响应归属键提取（过期即弃，webview-fixtures ReplyAttribution 契约）：
+   * 提取值 ≠ fetchKey 的回复直接丢弃（切 Tab 前发出的慢回复不得覆盖当前
+   * Tab 的列表）。钩子视图传 `(message) => message.scope`；fetchKey 缺省
+   * （挂载拉取一次的视图）不传本项即无归属过滤。
+   */
+  attributionKey?: (message: HostMessage) => string;
   /** 命中响应后的附加视图状态更新（钩子 configPath / MCP connecting 清零）。 */
   onResponse?: (message: HostMessage) => void;
 }
@@ -49,6 +56,11 @@ export function useSettingsList<TList, TItem>(
   useHostMessage((message) => {
     const current = latest.current;
     if (!current.responseCommands.includes(message.command)) return;
+    // 过期即弃：归属键与当前 fetchKey 不一致的回复（切 Tab 前发出的慢回复）
+    // 直接丢弃——不写列表、不解 loading（当前 Tab 的拉取仍在途）。
+    if (current.attributionKey && current.fetchKey !== undefined) {
+      if (current.attributionKey(message) !== current.fetchKey) return;
+    }
     setItems(current.pickItems(message));
     current.onResponse?.(message);
     setLoading(false);

--- a/packages/webview/tests/utils/useSettingsList.test.tsx
+++ b/packages/webview/tests/utils/useSettingsList.test.tsx
@@ -64,6 +64,45 @@ describe("useSettingsList", () => {
     expect(result.current.loading).toBe(false);
   });
 
+  it("attributionKey mismatch drops the stale reply (过期即弃，hooksResponse→scope)", () => {
+    const fetchRequest = vi.fn();
+    const { result } = renderHook(
+      ({ fetchKey }: { fetchKey: string }) =>
+        useSettingsList<string[], string>({
+          initialItems: [],
+          fetchRequest,
+          fetchKey,
+          responseCommands: ["listResponse"],
+          pickItems: (message) => message.items || [],
+          attributionKey: (message) => message.scope as string,
+        }),
+      { initialProps: { fetchKey: "project" } },
+    );
+    // 切 Tab 前发出的 user 慢回复：归属不符 → 丢弃，loading 保持（当前拉取在途）
+    dispatch({ command: "listResponse", scope: "user", items: ["stale"] });
+    expect(result.current.items).toEqual([]);
+    expect(result.current.loading).toBe(true);
+    // 归属相符的回复正常生效
+    dispatch({ command: "listResponse", scope: "project", items: ["fresh"] });
+    expect(result.current.items).toEqual(["fresh"]);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("attributionKey without fetchKey does not filter (挂载拉取一次的视图)", () => {
+    const { result } = renderHook(() =>
+      useSettingsList<string[], string>({
+        initialItems: [],
+        fetchRequest: () => {},
+        responseCommands: ["listResponse"],
+        pickItems: (message) => message.items || [],
+        attributionKey: (message) => message.scope as string,
+      }),
+    );
+    dispatch({ command: "listResponse", scope: "user", items: ["a"] });
+    expect(result.current.items).toEqual(["a"]);
+    expect(result.current.loading).toBe(false);
+  });
+
   it("calls onResponse with the matched message for view-specific state", () => {
     let extra: string | null = null;
     const { result } = renderHook(() =>

--- a/packages/webview/tests/webview/historySearch.test.tsx
+++ b/packages/webview/tests/webview/historySearch.test.tsx
@@ -8,13 +8,26 @@ import {
   sendCommand,
 } from "./test-utils";
 
+/** 提取 webview 最近一次发出的 requestId（requestHistory/searchHistory）。 */
+function sentRequestId(
+  vscode: { postMessage: ReturnType<typeof vi.fn> },
+  command: string,
+): string {
+  const calls = vscode.postMessage.mock.calls as Array<
+    [{ command?: string; requestId?: string }]
+  >;
+  return (
+    calls.filter((c) => c[0]?.command === command).pop()?.[0]?.requestId ?? ""
+  );
+}
+
 describe("History Search Feature", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("should open history search popup on Ctrl+R and select a prompt", async () => {
-    renderChatApp();
+    const { vscode } = renderChatApp();
 
     const messageInput = screen.getByTestId("message-input");
     messageInput.focus();
@@ -29,14 +42,17 @@ describe("History Search Feature", () => {
       expect(screen.getByTestId("history-search-popup")).toBeInTheDocument();
     });
 
-    // 3. Simulate history response from extension
+    // 3. Simulate history response from extension（归属键 = 请求 requestId）
     const mockHistory = [
       { prompt: "First prompt", timestamp: Date.now() - 10000 },
       { prompt: "Second prompt", timestamp: Date.now() - 5000 },
       { prompt: "Third prompt", timestamp: Date.now() },
     ];
 
-    sendCommand("historyResponse", { history: mockHistory });
+    sendCommand("historyResponse", {
+      history: mockHistory,
+      requestId: sentRequestId(vscode, "requestHistory"),
+    });
 
     // 4. Verify history items are displayed
     await waitFor(() => {
@@ -109,13 +125,16 @@ describe("History Search Feature", () => {
       expect.objectContaining({ command: "searchHistory", query: "test" }),
     );
 
-    // 4. Simulate filtered response
+    // 4. Simulate filtered response（归属键 = 请求 requestId）
     const filteredHistory = [
       { prompt: "test prompt 1", timestamp: Date.now() - 1000 },
       { prompt: "another test", timestamp: Date.now() },
     ];
 
-    sendCommand("historyResponse", { history: filteredHistory });
+    sendCommand("historyResponse", {
+      history: filteredHistory,
+      requestId: sentRequestId(vscode, "searchHistory"),
+    });
 
     // 5. Verify filtered items
     await waitFor(() => {
@@ -124,6 +143,42 @@ describe("History Search Feature", () => {
         .querySelectorAll(".history-search-item");
       expect(items).toHaveLength(2);
       expect(items[0]).toHaveTextContent(/test prompt 1/);
+    });
+  });
+
+  it("drops a stale historyResponse whose requestId belongs to an older query (过期即弃)", async () => {
+    const { vscode } = renderChatApp();
+
+    const messageInput = screen.getByTestId("message-input");
+    messageInput.focus();
+
+    await act(async () => {
+      fireEvent.keyDown(messageInput, { key: "r", ctrlKey: true });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("history-search-popup")).toBeInTheDocument();
+    });
+
+    // 晚到的旧查询回复（requestId 不匹配）→ 丢弃：列表为空、loading 保持
+    sendCommand("historyResponse", {
+      history: [{ prompt: "stale", timestamp: Date.now() }],
+      requestId: "stale-request-id",
+    });
+    expect(screen.getByTestId("history-search-popup").textContent).toContain(
+      "正在加载...",
+    );
+
+    // 当前请求的回复 → 正常渲染
+    sendCommand("historyResponse", {
+      history: [{ prompt: "fresh", timestamp: Date.now() }],
+      requestId: sentRequestId(vscode, "requestHistory"),
+    });
+    await waitFor(() => {
+      const items = screen
+        .getByTestId("history-search-popup")
+        .querySelectorAll(".history-search-item");
+      expect(items).toHaveLength(1);
+      expect(items[0]).toHaveTextContent(/fresh/);
     });
   });
 

--- a/packages/webview/tests/webview/settingsHooks.test.tsx
+++ b/packages/webview/tests/webview/settingsHooks.test.tsx
@@ -129,7 +129,29 @@ describe("SettingsPage 钩子选项卡视图（用户/项目/插件 Tab）", () 
       command: "getHooksByScope",
       scope: "project",
     });
-    sendHostMessage(fixtures.hooksResponse({}));
+    // 归属键：回复 scope 必须与当前 Tab 一致（过期即弃）
+    sendHostMessage(fixtures.hooksResponse({}, { scope: "project" }));
+    expect(await screen.findByText("项目级钩子暂无内容")).toBeInTheDocument();
+  });
+
+  it("切 Tab 前发出的旧 scope 慢回复被过期即弃，不覆盖当前 Tab 列表", async () => {
+    renderSettingsPage();
+    sendHostMessage(fixtures.hooksResponse(userHooks));
+    await screen.findByText("PreToolUse:Write");
+
+    // 切到项目级 Tab（触发重拉、loading）后，一个 user scope 的慢回复到达：
+    // 归属不符 → 丢弃，列表不被覆盖（修复前会闪现用户级数据 + 解除 loading）
+    await act(async () => {
+      fireEvent.click(await screen.findByText("项目级钩子"));
+    });
+    await act(async () => {
+      sendHostMessage(fixtures.hooksResponse(userHooks, { scope: "user" }));
+    });
+    expect(screen.queryByText("PreToolUse:Write")).not.toBeInTheDocument();
+    expect(screen.getByText("加载中...")).toBeInTheDocument();
+
+    // 项目级回复到达 → 正常渲染
+    sendHostMessage(fixtures.hooksResponse({}, { scope: "project" }));
     expect(await screen.findByText("项目级钩子暂无内容")).toBeInTheDocument();
   });
 
@@ -140,8 +162,8 @@ describe("SettingsPage 钩子选项卡视图（用户/项目/插件 Tab）", () 
     await act(async () => {
       fireEvent.click(await screen.findByText("插件钩子"));
     });
-    // tab 切换触发重新请求，回发插件钩子数据
-    sendHostMessage(fixtures.hooksResponse(pluginHooks));
+    // tab 切换触发重新请求，回发插件钩子数据（归属键 scope=plugin）
+    sendHostMessage(fixtures.hooksResponse(pluginHooks, { scope: "plugin" }));
     expect(await screen.findByText("SessionStart")).toBeInTheDocument();
     expect(screen.getByText("echo plugin-start")).toBeInTheDocument();
     expect(
@@ -247,7 +269,7 @@ describe("SettingsPage 钩子选项卡视图（用户/项目/插件 Tab）", () 
     await act(async () => {
       fireEvent.click(await screen.findByText("项目级钩子"));
     });
-    // tab 切换触发重新请求，回发项目钩子数据
+    // tab 切换触发重新请求，回发项目钩子数据（归属键 scope=project）
     sendHostMessage(
       fixtures.hooksResponse(
         {
@@ -258,7 +280,7 @@ describe("SettingsPage 钩子选项卡视图（用户/项目/插件 Tab）", () 
             },
           ],
         },
-        { configPath: "/work/a/.wave/settings.json" },
+        { configPath: "/work/a/.wave/settings.json", scope: "project" },
       ),
     );
     expect(await screen.findByText("PostToolUse:Bash")).toBeInTheDocument();


### PR DESCRIPTION
## 旧温床消除 2/4：hooksResponse / historyResponse 回复归属补全

### 问题背景
webview→host 的 RPC 缺乏回复归属契约，晚到回复会污染当前视图：
- **hooksResponse**：设置页「钩子」三来源 Tab（user/project/plugin）切换时，切 Tab 前发出的慢回复可能晚到并渲染到新 Tab 下（useSettingsList 无 scope 过滤）。
- **historyResponse**：历史弹窗每次 Ctrl+R / 搜索都发起新请求，旧查询的慢回复可能覆盖新查询结果（无 requestId 关联）。

host 端读取这些数据是无状态的即时快照，**不存在 host 侧 cache**，因此采用与 fileSuggestions 相同的 requestId 模式 / 与 projectSettings（#2131）相同的归属键模式。

### 变更
1. **fixtures 先行**（webview-fixtures rebuild）
   - `HooksResponseMessage` 新增必填 `scope: "user" | "project" | "plugin"`（attribution key）
   - `HistoryResponseMessage` 新增必填 `requestId: string`（attribution key）
   - `ReplyAttribution` 注册表 + `replyAttributionLocked` 两条同步收紧；`hooksResponse` factory 默认 `scope: "user"`
2. **host 回带归属键**（三端）
   - desktopHost.ts：getHooksByScope / deleteHook 回带 `scope: msg.scope`；requestHistory / searchHistory 回带 `requestId`（方法签名透传）
   - vscode messageHandler.ts：chat + settings 双 switch 的 4 处 hooks 发送位回带 scope；requestHistory / searchHistory 回带 requestId
   - jetbrains MessageHandler.kt：getHooksByScope / deleteHook 回带 scope；requestHistory / searchHistory 读取并回带 requestId
3. **webview 过期即弃消费**
   - `useSettingsList` 新增 `attributionKey` option：`fetchKey !== undefined` 时按归属键过滤回复（匹配「fetch-on-fetchKey-change」语义，挂载拉取一次的视图不启用）
   - `SettingsHooksView` 传入 `attributionKey: scope`（fetchKey = 当前 Tab scope）
   - `HistorySearchPopup` 每次请求前生成 `requestIdRef` 随消息上送，回复 handler 校验 `requestId` 不符即弃
4. **demo 同步**：4 个 demo 文件（settings-manage / desktop-settings-manage / product-spec-history-search / desktop-conversation）回带归属键，否则截图流程被过期即弃丢弃而空渲染

### ⚠️ 行为修正（有意为之）
- 切 Tab 前发出的 **scope 不符的晚到 hooksResponse 现在会被丢弃**（此前会覆盖当前 Tab 列表）
- 旧查询发出的 **requestId 不符的晚到 historyResponse 现在会被丢弃**（此前会覆盖新查询结果）
- 此修正同时是契约强制：ReplyAttribution lock 保证新增/漏发归属键在编译期报错

### 验证
- fixtures rebuild 后 6 包 type-check 全绿（webview/vscode/desktop/jetbrains compileKotlin）
- webview 1029 passed（112 files）｜vscode 191 passed ｜ desktop 587 passed
- lint（oxlint 全仓 0 error）+ prettier check 全变更文件 clean + `audit-webview-commands.mjs` exit 0
- fail-without-fix 双验：stash 两个实现文件（useSettingsList.ts + HistorySearchPopup.tsx）后 3 条新回归测试转红（3 failed | 22 passed），恢复后 25 passed
- demo 受影响 4 文件子集跑通

关联：#2131（旧温床 1/4：projectSettings 收编 SessionUiStore + workdir 归属键）
