### PR TITLE
fix(webview): 切会话时同步清空 contextUsage,消除与 host 用量重放的竞态

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -218,10 +218,9 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   // conversation switches (ChatApp is keyed by paneId, not sessionId), so a
   // local useState alone would leak the previous conversation's panel.
   const btwSessionRef = useRef<string | undefined>(undefined);
-  // Session whose context-usage percentage contextUsage currently holds.
-  // Compared against state.currentSession.id in an effect below — same
-  // paneId-keyed-mount reasoning as btwSessionRef, so the usage indicator is
-  // conversation-isolated instead of leaking the previous session's number.
+  // Session whose context-usage percentage contextUsage currently holds. Kept
+  // in sync synchronously by the setInitialState / updateCurrentSession message
+  // handlers (not by a passive effect — see the race note at those handlers).
   const usageSessionRef = useRef<string | undefined>(undefined);
   // Accumulated streaming text from the compaction fork; its last 30 characters
   // render after the "正在压缩对话" hint (streaming tail, same style as the
@@ -1051,6 +1050,19 @@ export const ChatApp: React.FC<ChatAppProps> = ({
         break;
       case "updateCurrentSession":
         if (!forThisPane(message)) break;
+        // Same synchronous conversation-scoped usage clear as setInitialState:
+        // the desktop host pushes updateCurrentSession when an agent's session
+        // id changes (onSessionIdChange rekey) while this pane stays mounted.
+        {
+          const nextSessionId = message.session?.id;
+          if (
+            usageSessionRef.current !== undefined &&
+            usageSessionRef.current !== nextSessionId
+          ) {
+            setContextUsage(undefined);
+          }
+          usageSessionRef.current = nextSessionId;
+        }
         dispatch({ type: "SET_CURRENT_SESSION", payload: message.session });
         break;
       case "showConfirmation":
@@ -1125,6 +1137,27 @@ export const ChatApp: React.FC<ChatAppProps> = ({
         break;
       case "setInitialState":
         if (!forThisPane(message)) break;
+        // The context-usage percentage is conversation-scoped (spec「上下文用量
+        // 指示器」场景 6 + session isolation), and desktop panes key ChatApp by
+        // paneId, so a session switch must drop the previous session's number
+        // here — synchronously in the message handler, NOT in a passive
+        // useEffect. The desktop host posts setInitialState and its cached
+        // usage replay (activateAgentInPane) as consecutive IPC messages; a
+        // passive effect flushing after that replay would wipe the number just
+        // posted and leave an empty ring until the next turn (race — the ring
+        // intermittently stays blank when flipping between two remote-host
+        // conversations). Semantics kept: clear only on a real session change,
+        // keep on same-session refreshes, initial mount is a no-op.
+        {
+          const nextSessionId = message.session?.id;
+          if (
+            usageSessionRef.current !== undefined &&
+            usageSessionRef.current !== nextSessionId
+          ) {
+            setContextUsage(undefined);
+          }
+          usageSessionRef.current = nextSessionId;
+        }
         // Desktop plan panel: replayed pending confirmations (pane rebind to a
         // session with confirmations in flight) also carry an ExitPlanMode
         // plan. It is staged — not routed here — because a same-batch pane
@@ -2131,25 +2164,8 @@ export const ChatApp: React.FC<ChatAppProps> = ({
     if (previous !== undefined && previous !== sessionId) handleBtwClose();
   }, [state.currentSession?.id, handleBtwClose]);
 
-  // The context-usage percentage is conversation-scoped (spec desktop-app
-  // 上下文用量指示器 场景 6 + session isolation): switching conversations must
-  // not carry the previous session's usage over. Desktop panes key ChatApp by
-  // paneId (not sessionId), so a sidebar session switch leaves this component
-  // mounted — without this effect the local contextUsage state would survive
-  // the switch (setInitialState only resets reducer state, not local state)
-  // and show the old session's percentage until the new session's first push.
-  // `previous !== undefined` keeps the initial mount a no-op.
-  useEffect(() => {
-    const sessionId = state.currentSession?.id;
-    const previous = usageSessionRef.current;
-    usageSessionRef.current = sessionId;
-    if (previous !== undefined && previous !== sessionId) {
-      setContextUsage(undefined);
-    }
-  }, [state.currentSession?.id]);
-
   // Preview fullscreen is conversation-scoped, same pattern as the btw panel
-  // and context-usage effects above: the single root layout (no panes) keeps
+  // effect above: the single root layout (no panes) keeps
   // ChatApp mounted across sidebar session switches, so the local fullscreen
   // state would otherwise survive into the next conversation. Fullscreen
   // belongs to the outgoing session's preview tab — a stale true hides the

--- a/packages/webview/tests/webview/contextUsageIsolation.test.tsx
+++ b/packages/webview/tests/webview/contextUsageIsolation.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { act } from "@testing-library/react";
 import { renderChatApp, screen, sendHostMessage, fixtures } from "./test-utils";
 import { MockDataGenerator } from "../fixtures/mockData";
 
@@ -60,5 +61,48 @@ describe("context usage indicator conversation isolation", () => {
     // must not clear the usage — only a real conversation switch does.
     sendHostMessage(fixtures.setInitialState(conversationState("session-a")));
     expect(screen.getByText("45%")).toBeInTheDocument();
+  });
+
+  it("shows the usage pushed right after a session switch (host back-to-back replay race)", async () => {
+    renderChatApp();
+    sendHostMessage(fixtures.setInitialState(conversationState("session-a")));
+    sendHostMessage(fixtures.contextUsage(45));
+    expect(screen.getByText("45%")).toBeInTheDocument();
+
+    // Real-desktop back-to-back replay: activateAgentInPane posts
+    // setInitialState and the cached usage replay as two consecutive IPC
+    // messages with no await between them (desktopHost activateAgentInPane).
+    // In Electron they land as separate message events, so the
+    // conversation-switch clear must run synchronously inside the message
+    // handler — a passive useEffect flushing after the usage push would wipe
+    // the number just posted and the ring stays empty until the next turn.
+    // The test dispatches without act() so React batches both updates ahead of
+    // its passive-effect flush, reproducing that ordering (test-utils'
+    // sendHostMessage wraps every message in act(), which flushes effects
+    // synchronously and hides the race). Leaving the act environment for these
+    // two raw dispatches keeps React from warning about the unwrapped updates
+    // while preserving the non-act scheduling they are meant to simulate.
+    const prevActEnv = (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+      .IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = false;
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: fixtures.setInitialState(conversationState("session-b")),
+      }),
+    );
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: fixtures.contextUsage(12),
+      }),
+    );
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = prevActEnv;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(screen.getByText("12%")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 现象
两个远程主机(desktop SSH hosts)的对话来回切换时,上下文用量数值仍有一定概率不显示,须等下一轮 token 变化才出现。

## 根因
- desktopHost `activateAgentInPane` 把 setInitialState(切会话)与缓存的 contextUsage 重放作为两条背靠背 IPC 连续发出(pushPaneSessionState 同步、无真实 await 间隔)。
- ChatApp 原用被动 useEffect 监听会话 id 变化来清空上一会话的用量,而 passive effect 由 React scheduler 异步 flush —— 真实 Electron 中可能晚于第二条 contextUsage 消息执行,把刚重放的新会话数值当「上一会话残留」清掉,空环直到下一轮。
- jsdom 单测此前掩盖该竞态:test-utils 每条消息都包 act(),同步 flush effect,时序被固定为「清空→push→终值正确」。

## 修复
- 把清空逻辑从被动 effect 移入 setInitialState / updateCurrentSession 消息处理的同步路径(dispatch 前按 usageSessionRef 判断并更新 ref),删除原 effect。
- 语义不变:真换会话才清、同会话重推保留、初始 mount no-op。
- 新增 race 回归测试:不带 act 连续 dispatch 两条消息(setInitialState B + contextUsage 12)模拟 host 背靠背重放,fail-without-fix 先红后绿;临时切换 IS_REACT_ACT_ENVIRONMENT 消除 act 警告噪声。

## 验证
- contextUsageIsolation 3/3、相关会话切换测试组 196/196
- 全量 webview 单元测试 106 文件 / 925 测试全绿
- type-check(src+tests+e2e+demo)/oxlint/prettier 干净
