### PR TITLE
style(webview): 桌面权限按钮 Tab 聚焦恢复高亮，工具行按钮补同款键盘提示

### DIFF
--- a/packages/webview/src/styles/host-desktop.css
+++ b/packages/webview/src/styles/host-desktop.css
@@ -219,14 +219,20 @@
   border-radius: 6px;
   color: #565a60;
 }
-[data-host="desktop"] .toolbar-icon-button:hover {
+/* 工具行图标按钮键盘提示：focus-visible 复用 hover 底色（与行/下拉族
+   一致），并去掉浏览器默认焦点环 */
+[data-host="desktop"] .toolbar-icon-button:hover,
+[data-host="desktop"] .toolbar-icon-button:focus-visible {
   background: #f0f2f5;
+  outline: none;
 }
 [data-host="desktop"][data-theme="dark"] .toolbar-icon-button {
   color: #9a9ea5;
 }
-[data-host="desktop"][data-theme="dark"] .toolbar-icon-button:hover {
+[data-host="desktop"][data-theme="dark"] .toolbar-icon-button:hover,
+[data-host="desktop"][data-theme="dark"] .toolbar-icon-button:focus-visible {
   background: rgba(255, 255, 255, 0.08);
+  outline: none;
 }
 
 /* 压缩上下文按钮：32px 高，整体 59×32（codechat 图形按钮）：
@@ -302,7 +308,10 @@
 }
 /* 切换选择后按钮仍持 focus，不再常驻 hover 底色（用户 0904 走查：切换后
    不要保留 hover 态）；键盘 focus 提示走 :focus-visible 同底色。 */
-[data-host="desktop"] .permission-mode-select:focus {
+/* :focus 复位须排除 :focus-visible：键盘 Tab 聚焦同时命中两者、且本规则
+   声明在后（特异性相同），否则透明背景会盖掉上方的键盘高亮（回归）——
+   复位只针对鼠标点选带来的 focus。 */
+[data-host="desktop"] .permission-mode-select:focus:not(:focus-visible) {
   background: transparent;
   border-color: transparent;
 }
@@ -321,7 +330,8 @@
   background: rgba(255, 255, 255, 0.08);
   color: #fff;
 }
-[data-host="desktop"][data-theme="dark"] .permission-mode-select:focus {
+[data-host="desktop"][data-theme="dark"]
+  .permission-mode-select:focus:not(:focus-visible) {
   background: transparent;
 }
 [data-host="desktop"][data-theme="dark"]
@@ -438,8 +448,17 @@
   background: var(--cc-action-primary, #1f2329);
   color: var(--cc-action-primary-text, #ffffff);
 }
-[data-host="desktop"] .ai-send-btn:not(:disabled):hover {
+[data-host="desktop"] .ai-send-btn:not(:disabled):hover,
+[data-host="desktop"] .ai-send-btn:not(:disabled):focus-visible {
   background: var(--cc-action-primary-hover, #34383f);
+  outline: none;
+}
+/* 停止钮同族键盘提示：host 无独立覆盖，hover 走 base 的 button-hoverBackground
+   token（桌面映射同发送钮深档），此处只补 focus-visible + 去默认环 */
+[data-host="desktop"] .abort-button:hover,
+[data-host="desktop"] .abort-button:focus-visible {
+  background: var(--vscode-button-hoverBackground, var(--vscode-button-background));
+  outline: none;
 }
 [data-host="desktop"][data-theme="dark"] .ai-send-btn,
 [data-host="desktop"][data-theme="dark"] .ai-send-btn:disabled {
@@ -451,8 +470,10 @@
   background: var(--cc-action-primary, #e0e3e5);
   color: var(--cc-action-primary-text, #191c1e);
 }
-[data-host="desktop"][data-theme="dark"] .ai-send-btn:not(:disabled):hover {
+[data-host="desktop"][data-theme="dark"] .ai-send-btn:not(:disabled):hover,
+[data-host="desktop"][data-theme="dark"] .ai-send-btn:not(:disabled):focus-visible {
   background: var(--cc-action-primary-hover, #f0f2f3);
+  outline: none;
 }
 
 /* 新会话上下文栏：Figma 13439-9245 —— 卡片外独立横条（非卡片脚条）。
@@ -530,16 +551,20 @@
   color: #565a60;
   box-sizing: border-box;
 }
-[data-host="desktop"] .desktop-worktree-checkbox:hover {
+[data-host="desktop"] .desktop-worktree-checkbox:hover,
+[data-host="desktop"] .desktop-worktree-checkbox:focus-visible {
   background: #eef0f3;
   color: #1f2329;
+  outline: none;
 }
 [data-host="desktop"][data-theme="dark"] .desktop-worktree-checkbox {
   color: #9a9ea5;
 }
-[data-host="desktop"][data-theme="dark"] .desktop-worktree-checkbox:hover {
+[data-host="desktop"][data-theme="dark"] .desktop-worktree-checkbox:hover,
+[data-host="desktop"][data-theme="dark"] .desktop-worktree-checkbox:focus-visible {
   background: rgba(255, 255, 255, 0.08);
   color: #ffffff;
+  outline: none;
 }
 [data-host="desktop"] .desktop-host-trigger:hover,
 [data-host="desktop"] .desktop-host-trigger:focus-visible,


### PR DESCRIPTION
## 问题

桌面端权限模式选择器按钮通过 Tab 键聚焦时无任何高亮。

**根因**：`host-desktop.css` 中键盘高亮（`:hover, :focus-visible` → `background: #eef0f3`）声明在前，#2090 为满足「鼠标点选后不残留 hover 底色」新增的 `:focus { background: transparent }` 复位声明在后。两条规则特异性相同，键盘 Tab 聚焦时元素**同时命中** `:focus` 与 `:focus-visible`，后声明的透明背景胜出 → 键盘焦点提示被盖掉（浅/深色均受影响）。

## 修复

1. **权限按钮**：`:focus` 复位收窄为 `:focus:not(:focus-visible)` —— 只对鼠标点选产生的 focus 复位透明，Tab 键盘聚焦正常走 `:focus-visible` 高亮，0904「点击后不留常驻底色」意图不变。
2. **对齐同族缺口**：桌面键盘目标统一为「focus-visible 复用各自 hover 底色 + `outline:none`」（与行/下拉族一致，不再漏浏览器默认焦点环）：
   - 工具行「+ /」图标钮（浅 `#f0f2f5` / 深 8% 白）
   - 发送钮（`--cc-action-primary-hover` 深档 / 深色反转档）
   - 停止钮（新增 host 覆盖，背景走 `--vscode-button-hoverBackground` token）
   - 欢迎态 worktree 复选框（`#eef0f3` / 8% 白）

改动仅作用于 `[data-host="desktop"]`，IDE 端不受影响。

## 验证

Chromium 实测（等 0.2s background 过渡结束后取终值），Tab 聚焦全部命中 `:focus-visible`、`outline-style: none`：

| 控件 | 修复前 | 修复后浅色 | 修复后深色 |
|---|---|---|---|
| 权限按钮 | 透明（bug） | `#eef0f3` | 8% 白 |
| + / 图标钮 | 默认焦点环 | `#f0f2f5` | 8% 白 |
| 发送钮 | 默认焦点环 | `#34383f` | `#f0f2f3` |
| 停止钮 | 默认焦点环 | token 深档 | token 反转档 |
| worktree 复选框 | 默认焦点环 | `#eef0f3` | 8% 白 |

type-check 6 包全绿（pre-commit 门）。