### PR TITLE
fix(jetbrains): 解包 ripgrep 保留执行位，修复 Grep 工具 EACCES

### DIFF
--- a/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
+++ b/packages/jetbrains/src/main/kotlin/com/wave/jetbrains/stdio/BinaryResolver.kt
@@ -370,6 +370,13 @@ object BinaryResolver {
                         } else {
                             out.parentFile?.mkdirs()
                             FileOutputStream(out).use { tar.transferTo(it) }
+                            // npm tarballs ship the rg binary with the exec bit set
+                            // (0755); FileOutputStream creates plain 0644 files, so
+                            // without mirroring the entry's x bits the binary lands
+                            // non-executable and spawning it fails with EACCES (the
+                            // Grep tool silently breaks). Apply the exec bits for all
+                            // three classes — the shape npm install leaves behind.
+                            if ((entry.mode and 0x49) != 0) out.setExecutable(true, false) // 0x49 = 0o111 exec bits
                         }
                     }
                     entry = tar.nextEntry

--- a/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/stdio/BinaryResolverTest.kt
+++ b/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/stdio/BinaryResolverTest.kt
@@ -183,6 +183,26 @@ class BinaryResolverTest {
         assertTrue(out.readBytes().contentEquals(payload))
     }
 
+    @Test
+    fun `extractTarball keeps the exec bit of executable entries`() {
+        // Regression: the @vscode/ripgrep-<platform> tarball ships bin/rg 0755.
+        // The extractor wrote it as a plain 0644 file, so spawning rg failed
+        // with EACCES and the Grep tool was broken (Linux hosts where the JB
+        // plugin cached rg shared the poisoned ~/.wave/cli/node_modules with
+        // the desktop/vscode CLIs).
+        val tarGz = buildTarGz(
+            entries = mapOf("package/bin/rg" to "binary-bytes".toByteArray()),
+            modes = mapOf("package/bin/rg" to 0x1ed), // 0755
+        )
+        val dest = File(tempDir.toFile(), "extract-${shimCounter++}")
+        BinaryResolver.extractTarball(tarGz, dest)
+
+        val rg = File(dest, "bin/rg")
+        assertTrue(rg.isFile)
+        assertTrue(rg.canExecute(), "rg must stay executable after extraction")
+        assertEquals("binary-bytes", rg.readText())
+    }
+
     // ---- decodeCommandOutput / readProcessOutput -----------------------
     //
     // Customer repro: on Chinese Windows, cmd.exe builtins (`where`) and
@@ -401,12 +421,16 @@ class BinaryResolverTest {
     }
 
     /** Builds a `.tar.gz` byte array from `package/...` entries (npm tarball shape). */
-    private fun buildTarGz(entries: Map<String, ByteArray>): ByteArray {
+    private fun buildTarGz(
+        entries: Map<String, ByteArray>,
+        modes: Map<String, Int> = emptyMap(),
+    ): ByteArray {
         java.io.ByteArrayOutputStream().use { bos ->
             org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream(bos).use { gz ->
                 org.apache.commons.compress.archivers.tar.TarArchiveOutputStream(gz).use { tar ->
                     entries.forEach { (name, data) ->
                         val entry = org.apache.commons.compress.archivers.tar.TarArchiveEntry(name)
+                        modes[name]?.let { entry.setMode(it) }
                         entry.size = data.size.toLong()
                         tar.putArchiveEntry(entry)
                         tar.write(data)


### PR DESCRIPTION
## 问题

桌面端连远程主机（Linux）时 Grep 工具报错：`ripgrep failed: spawn .../bin/rg EACCES`。

## 根因

`@vscode/ripgrep-<platform>` 的 npm tarball 内 `bin/rg` 权限是 **0755**，但 JB 插件 `BinaryResolver.extractTarball` 用 `FileOutputStream` 逐文件落盘，**完全忽略 tar entry 的权限位** → rg 以 **0644** 写入，spawn 时 EACCES。

影响链：JB 插件跑过的机器会把共享 rg 缓存 `~/.wave/cli/node_modules/@vscode` 写成 0644 → 桌面/vscode/远端会话复用同一缓存全部踩雷；且各端「存在性检查」只看文件存在不看可执行位，污染永不自愈。

桌面/vscode 本地路径用 node-tar 解包、远端走 `npm install`，均能保留执行位，不受影响——缺陷只在 JB 解包器。

## 修复

`extractTarball` 写文件后按 entry 的 exec 位（`mode and 0o111`）补 `setExecutable(true, false)`，rg 落盘 0755。Kotlin 无八进制字面量，代码用 `0x49`（=0o111）。

## 验证

- 新增回归测试 `extractTarball keeps the exec bit of executable entries`（0755 条目解包后 `canExecute`），修复前先红后绿
- `gradle test` 全量 BUILD SUCCESSFUL