### PR TITLE
style(webview): 键盘聚焦提示全面回归 Chromium 原生焦点环

### DIFF
--- a/packages/webview/src/styles/AccountCard.css
+++ b/packages/webview/src/styles/AccountCard.css
@@ -31,10 +31,9 @@
   cursor: pointer;
 }
 
-.account-card-login:hover,
-.account-card-login:focus-visible {
+/* 键盘聚焦提示交给浏览器原生焦点环（不补 focus-visible 底色，下同） */
+.account-card-login:hover {
   background: color-mix(in srgb, var(--vscode-brand-primary, #c1292e) 88%, black);
-  outline: none;
 }
 
 /* 已登录：头像+姓名热区 与 热区右侧「更新/用量显隐」按钮同行。 */
@@ -60,13 +59,11 @@
   cursor: pointer;
 }
 
-.account-card-update-btn:hover,
-.account-card-update-btn:focus-visible {
+.account-card-update-btn:hover {
   background: var(
     --vscode-button-secondaryHoverBackground,
     rgba(255, 255, 255, 0.1)
   );
-  outline: none;
 }
 
 .account-card-update-btn:disabled {
@@ -92,10 +89,8 @@
   cursor: pointer;
 }
 
-.account-card-collapse-btn:hover,
-.account-card-collapse-btn:focus-visible {
+.account-card-collapse-btn:hover {
   background-color: var(--vscode-list-hoverBackground);
-  outline: none;
 }
 
 /* 用量常驻概要区（个人信息行上方、横线之下与主行分隔）：套餐用量 + API 余额。 */
@@ -122,10 +117,8 @@
   cursor: pointer;
 }
 
-.account-card-hotzone:hover,
-.account-card-hotzone:focus-visible {
+.account-card-hotzone:hover {
   background-color: var(--vscode-list-hoverBackground);
-  outline: none;
 }
 
 .account-card-avatar {
@@ -175,10 +168,8 @@
   cursor: pointer;
 }
 
-.account-card-more-btn:hover,
-.account-card-more-btn:focus-visible {
+.account-card-more-btn:hover {
   background-color: var(--vscode-list-hoverBackground);
-  outline: none;
 }
 
 /* 套餐用量块。 */
@@ -290,11 +281,9 @@
   flex-shrink: 0;
 }
 
-.account-api-info-btn:hover,
-.account-api-info-btn:focus-visible {
+.account-api-info-btn:hover {
   color: var(--vscode-foreground);
   background-color: var(--vscode-list-hoverBackground, rgba(255, 255, 255, 0.06));
-  outline: none;
 }
 
 .account-api-info-btn .codicon {

--- a/packages/webview/src/styles/DesktopApp.css
+++ b/packages/webview/src/styles/DesktopApp.css
@@ -236,8 +236,8 @@ html[data-theme="dark"] .desktop-sidebar-more-btn.is-active {
   user-select: none;
 }
 
-.desktop-session-group-header:hover,
-.desktop-session-group-header:focus-visible {
+/* 键盘聚焦提示交给浏览器原生焦点环（鼠标键盘同底移除，下同） */
+.desktop-session-group-header:hover {
   background: #eef0f3;
 }
 
@@ -359,14 +359,12 @@ html[data-theme="dark"] .desktop-sidebar-more-btn.is-active {
   pointer-events: auto;
 }
 
-.desktop-session-more-btn:hover,
-.desktop-session-more-btn:focus-visible {
+.desktop-session-more-btn:hover {
   /* Figma 13656:5328：更多按钮自身 hover = 黑 8% 圆角底 */
   background: rgba(0, 0, 0, 0.08);
 }
 
-.desktop-session-more-btn:hover .desktop-session-more-icon,
-.desktop-session-more-btn:focus-visible .desktop-session-more-icon {
+.desktop-session-more-btn:hover .desktop-session-more-icon {
   color: inherit;
 }
 
@@ -413,8 +411,7 @@ html[data-theme="dark"] .desktop-session-group-header {
   color: #9a9ea5;
 }
 
-html[data-theme="dark"] .desktop-session-group-header:hover,
-html[data-theme="dark"] .desktop-session-group-header:focus-visible {
+html[data-theme="dark"] .desktop-session-group-header:hover {
   background: rgba(255, 255, 255, 0.08);
 }
 
@@ -439,8 +436,7 @@ html[data-theme="dark"] .desktop-session-more-btn {
   color: #9a9ea5;
 }
 
-html[data-theme="dark"] .desktop-session-more-btn:hover,
-html[data-theme="dark"] .desktop-session-more-btn:focus-visible {
+html[data-theme="dark"] .desktop-session-more-btn:hover {
   background: rgba(255, 255, 255, 0.12);
 }
 
@@ -476,10 +472,8 @@ html[data-theme="dark"] .desktop-session-status-slot {
   white-space: nowrap;
 }
 
-.desktop-session-menu-item:hover,
-.desktop-session-menu-item:focus-visible {
+.desktop-session-menu-item:hover {
   background: var(--vscode-list-hoverBackground);
-  outline: none;
 }
 
 .desktop-session-menu-item .codicon {
@@ -625,8 +619,7 @@ html[data-theme="dark"] .desktop-session-status-slot {
   color: var(--vscode-foreground);
 }
 
-.desktop-workdir-trigger:hover,
-.desktop-workdir-trigger:focus-visible {
+.desktop-workdir-trigger:hover {
   background: var(--vscode-list-hoverBackground);
 }
 
@@ -674,8 +667,7 @@ html[data-theme="dark"] .desktop-session-status-slot {
   color: var(--vscode-dropdown-foreground);
 }
 
-.desktop-workdir-menu-item:hover,
-.desktop-workdir-menu-item:focus-visible {
+.desktop-workdir-menu-item:hover {
   background: var(--vscode-list-hoverBackground);
 }
 
@@ -714,8 +706,7 @@ html[data-theme="dark"] .desktop-session-status-slot {
   flex-shrink: 0;
 }
 
-.desktop-workdir-menu-remove:hover,
-.desktop-workdir-menu-remove:focus-visible {
+.desktop-workdir-menu-remove:hover {
   opacity: 1;
 }
 
@@ -748,8 +739,7 @@ html[data-theme="dark"] .desktop-session-status-slot {
   color: var(--vscode-foreground);
 }
 
-.desktop-host-trigger:hover,
-.desktop-host-trigger:focus-visible {
+.desktop-host-trigger:hover {
   background: var(--vscode-list-hoverBackground);
 }
 
@@ -829,8 +819,7 @@ html[data-theme="dark"] .desktop-session-status-slot {
   color: var(--vscode-dropdown-foreground);
 }
 
-.desktop-remote-browser-crumb:hover,
-.desktop-remote-browser-crumb:focus-visible {
+.desktop-remote-browser-crumb:hover {
   background: var(--vscode-list-hoverBackground);
 }
 
@@ -901,8 +890,7 @@ html[data-theme="dark"] .desktop-session-status-slot {
   background: var(--vscode-button-background);
 }
 
-.desktop-remote-browser-retry:hover,
-.desktop-remote-browser-retry:focus-visible {
+.desktop-remote-browser-retry:hover {
   background: var(--vscode-button-hoverBackground);
 }
 
@@ -940,8 +928,7 @@ html[data-theme="dark"] .desktop-session-status-slot {
   background: var(--vscode-button-background);
 }
 
-.desktop-remote-browser-select:hover:not(:disabled),
-.desktop-remote-browser-select:focus-visible:not(:disabled) {
+.desktop-remote-browser-select:hover:not(:disabled) {
   background: var(--vscode-button-hoverBackground);
 }
 

--- a/packages/webview/src/styles/DiffViewer.css
+++ b/packages/webview/src/styles/DiffViewer.css
@@ -26,11 +26,6 @@
   line-height: 1.2;
 }
 
-.diff-viewer-content:focus-visible {
-  outline: 1px solid var(--vscode-focusBorder);
-  outline-offset: -1px;
-}
-
 /* Diff changes container */
 .diff-changes {
   display: flex;

--- a/packages/webview/src/styles/Message.css
+++ b/packages/webview/src/styles/Message.css
@@ -379,12 +379,6 @@
   line-height: 16px;
 }
 
-.write-tool-path:focus-visible {
-  outline: 1px solid var(--vscode-focusBorder);
-  outline-offset: 1px;
-  border-radius: 2px;
-}
-
 .write-tool-stats {
   margin-top: 2px;
   font-size: 11px;
@@ -862,11 +856,6 @@
   color: var(--vscode-textLink-activeForeground);
   text-decoration: underline;
   border-bottom-color: transparent;
-}
-
-.markdown-content a.file-path-link:focus-visible {
-  outline: 1px solid var(--vscode-focusBorder);
-  outline-offset: 1px;
 }
 
 /* Markdown Blockquotes */

--- a/packages/webview/src/styles/MessageInput.css
+++ b/packages/webview/src/styles/MessageInput.css
@@ -221,7 +221,8 @@
   color: var(--vscode-descriptionForeground);
   cursor: pointer;
   padding: 4px 6px;
-  outline: none;
+  /* 键盘聚焦提示走浏览器原生焦点环（与其余按钮/复选框一致），不在此关掉
+     outline；hover/focus 底色由下方 / desktop host 层各自定义 */
   font-family: inherit;
   transition:
     background-color 0.2s ease,
@@ -336,8 +337,7 @@
 }
 
 .permission-mode-item:hover,
-.permission-mode-item.selected,
-.permission-mode-item:focus-visible {
+.permission-mode-item.selected {
   background: var(--vscode-list-hoverBackground);
   color: var(--vscode-list-activeSelectionForeground);
 }
@@ -409,8 +409,7 @@
   color: var(--vscode-menu-foreground);
 }
 
-.plus-menu-item:hover,
-.plus-menu-item:focus-visible {
+.plus-menu-item:hover {
   background: var(--vscode-list-hoverBackground);
   color: var(--vscode-list-activeSelectionForeground);
 }
@@ -443,11 +442,8 @@
   opacity: 0.7;
 }
 
-.selection-tag:hover,
-.selection-tag:focus-visible {
+.selection-tag:hover {
   opacity: 0.9;
-  outline: 1px solid var(--vscode-focusBorder);
-  outline-offset: 1px;
 }
 
 /* Image Preview Modal */

--- a/packages/webview/src/styles/MoreMenu.css
+++ b/packages/webview/src/styles/MoreMenu.css
@@ -28,8 +28,7 @@
   cursor: pointer;
 }
 
-.more-menu-item:hover,
-.more-menu-item:focus-visible {
+.more-menu-item:hover {
   background-color: var(--vscode-list-hoverBackground);
 }
 
@@ -61,8 +60,7 @@
   color: var(--vscode-errorForeground, #f14c4c);
 }
 
-.more-menu-item--danger:hover,
-.more-menu-item--danger:focus-visible {
+.more-menu-item--danger:hover {
   background-color: var(--vscode-list-hoverBackground);
   color: var(--vscode-errorForeground, #f14c4c);
 }

--- a/packages/webview/src/styles/PanelToggleMenu.css
+++ b/packages/webview/src/styles/PanelToggleMenu.css
@@ -30,8 +30,7 @@
   cursor: pointer;
 }
 
-.panel-toggle-menu-item:hover,
-.panel-toggle-menu-item:focus-visible {
+.panel-toggle-menu-item:hover {
   background-color: var(--vscode-list-hoverBackground);
 }
 

--- a/packages/webview/src/styles/SessionBoard.css
+++ b/packages/webview/src/styles/SessionBoard.css
@@ -280,11 +280,6 @@
   box-shadow: 0 2px 8px rgb(31 35 41 / 8%);
 }
 
-.session-card:focus-visible {
-  outline: 1px solid #2f5edb;
-  outline-offset: -1px;
-}
-
 /* 标题行：独占一行（Figma Container 13656:5280 row1，高 26，超长省略） */
 .session-card-title-row {
   display: flex;

--- a/packages/webview/src/styles/SessionListPopup.css
+++ b/packages/webview/src/styles/SessionListPopup.css
@@ -62,7 +62,6 @@
 }
 
 .session-list-item:hover,
-.session-list-item:focus-visible,
 .session-list-item--selected {
   background-color: var(--vscode-list-hoverBackground);
 }

--- a/packages/webview/src/styles/host-desktop.css
+++ b/packages/webview/src/styles/host-desktop.css
@@ -294,14 +294,14 @@
   color: #d92d20;
   font-weight: 400;
 }
-[data-host="desktop"] .permission-mode-select:hover,
-[data-host="desktop"] .permission-mode-select:focus-visible {
+[data-host="desktop"] .permission-mode-select:hover {
   background: #eef0f3;
   color: #1f2329;
   border-color: transparent;
 }
-/* 切换选择后按钮仍持 focus，不再常驻 hover 底色（用户 0904 走查：切换后
-   不要保留 hover 态）；键盘 focus 提示走 :focus-visible 同底色。 */
+/* 点击后按钮仍持 focus，不再常驻 hover 底色（用户 0904 走查：切换后不要
+   保留 hover 态）；键盘聚焦提示交给浏览器原生焦点环——共享 base 的
+   outline:none 已移除（见 MessageInput.css），不再自绘 :focus-visible 底色 */
 [data-host="desktop"] .permission-mode-select:focus {
   background: transparent;
   border-color: transparent;
@@ -316,8 +316,7 @@
   .permission-mode-select.mode-bypassPermissions {
   color: #f4655c;
 }
-[data-host="desktop"][data-theme="dark"] .permission-mode-select:hover,
-[data-host="desktop"][data-theme="dark"] .permission-mode-select:focus-visible {
+[data-host="desktop"][data-theme="dark"] .permission-mode-select:hover {
   background: rgba(255, 255, 255, 0.08);
   color: #fff;
 }
@@ -542,9 +541,7 @@
   color: #ffffff;
 }
 [data-host="desktop"] .desktop-host-trigger:hover,
-[data-host="desktop"] .desktop-host-trigger:focus-visible,
-[data-host="desktop"] .desktop-workdir-trigger:hover,
-[data-host="desktop"] .desktop-workdir-trigger:focus-visible {
+[data-host="desktop"] .desktop-workdir-trigger:hover {
   background: #eef0f3;
   color: #1f2329;
 }
@@ -553,9 +550,7 @@
   color: #9a9ea5;
 }
 [data-host="desktop"][data-theme="dark"] .desktop-host-trigger:hover,
-[data-host="desktop"][data-theme="dark"] .desktop-host-trigger:focus-visible,
-[data-host="desktop"][data-theme="dark"] .desktop-workdir-trigger:hover,
-[data-host="desktop"][data-theme="dark"] .desktop-workdir-trigger:focus-visible {
+[data-host="desktop"][data-theme="dark"] .desktop-workdir-trigger:hover {
   background: rgba(255, 255, 255, 0.08);
   color: #ffffff;
 }
@@ -588,8 +583,7 @@
   font-weight: 500;
   box-sizing: border-box;
 }
-[data-host="desktop"] .plus-menu-item:hover,
-[data-host="desktop"] .plus-menu-item:focus-visible {
+[data-host="desktop"] .plus-menu-item:hover {
   background: #eef0f3;
   color: #1f2329;
 }
@@ -598,8 +592,7 @@
   border-color: rgba(255, 255, 255, 0.12);
   color: #9a9ea5;
 }
-[data-host="desktop"][data-theme="dark"] .plus-menu-item:hover,
-[data-host="desktop"][data-theme="dark"] .plus-menu-item:focus-visible {
+[data-host="desktop"][data-theme="dark"] .plus-menu-item:hover {
   background: rgba(255, 255, 255, 0.08);
   color: #ffffff;
 }
@@ -622,12 +615,10 @@
 /* hover：codechat --cc-fill-hover #eef0f3（浅色）；深色用中性 8% 白
    （替换 VS Code list-hoverBackground 的蓝灰调） */
 [data-host="desktop"][data-theme="light"] .desktop-session-group-header:hover,
-[data-host="desktop"][data-theme="light"] .desktop-session-group-header:focus-visible,
 [data-host="desktop"][data-theme="light"] .desktop-session-item:hover {
   background: #eef0f3;
 }
 [data-host="desktop"][data-theme="dark"] .desktop-session-group-header:hover,
-[data-host="desktop"][data-theme="dark"] .desktop-session-group-header:focus-visible,
 [data-host="desktop"][data-theme="dark"] .desktop-session-item:hover {
   background: rgba(255, 255, 255, 0.08);
 }
@@ -695,12 +686,10 @@
 
 /* 账户热区：常态透明底（用户反馈常驻实底 #EBEDF0 形似「始终选中」——
    第十二轮取消第三轮 Figma 实底化）；hover/focus 保留浅灰反馈 */
-[data-host="desktop"][data-theme="light"] .account-card-hotzone:hover,
-[data-host="desktop"][data-theme="light"] .account-card-hotzone:focus-visible {
+[data-host="desktop"][data-theme="light"] .account-card-hotzone:hover {
   background: #e2e4e8;
 }
-[data-host="desktop"][data-theme="dark"] .account-card-hotzone:hover,
-[data-host="desktop"][data-theme="dark"] .account-card-hotzone:focus-visible {
+[data-host="desktop"][data-theme="dark"] .account-card-hotzone:hover {
   background: rgba(255, 255, 255, 0.14);
 }
 
@@ -710,12 +699,10 @@
 [data-host="desktop"] .account-card-more-btn {
   border-radius: 6px;
 }
-[data-host="desktop"][data-theme="light"] .account-card-more-btn:hover,
-[data-host="desktop"][data-theme="light"] .account-card-more-btn:focus-visible {
+[data-host="desktop"][data-theme="light"] .account-card-more-btn:hover {
   background: #e2e4e8;
 }
-[data-host="desktop"][data-theme="dark"] .account-card-more-btn:hover,
-[data-host="desktop"][data-theme="dark"] .account-card-more-btn:focus-visible {
+[data-host="desktop"][data-theme="dark"] .account-card-more-btn:hover {
   background: rgba(255, 255, 255, 0.14);
 }
 
@@ -1164,8 +1151,7 @@
 [data-host="desktop"][data-theme="dark"] .account-api-info-btn {
   color: #9a9ea5;
 }
-[data-host="desktop"] .account-api-info-btn:hover,
-[data-host="desktop"] .account-api-info-btn:focus-visible {
+[data-host="desktop"] .account-api-info-btn:hover {
   background-color: transparent;
   color: var(--vscode-foreground);
 }
@@ -1284,12 +1270,10 @@
   width: 16px;
   height: 16px;
 }
-[data-host="desktop"][data-theme="light"] .desktop-session-more-btn:hover,
-[data-host="desktop"][data-theme="light"] .desktop-session-more-btn:focus-visible {
+[data-host="desktop"][data-theme="light"] .desktop-session-more-btn:hover {
   background: #e7e9ed;
 }
-[data-host="desktop"][data-theme="dark"] .desktop-session-more-btn:hover,
-[data-host="desktop"][data-theme="dark"] .desktop-session-more-btn:focus-visible {
+[data-host="desktop"][data-theme="dark"] .desktop-session-more-btn:hover {
   background: rgba(255, 255, 255, 0.12);
 }
 [data-host="desktop"] .desktop-session-menu-item svg {
@@ -1520,13 +1504,9 @@
   color: #858b8f;
 }
 [data-host="desktop"] .more-menu-item:hover,
-[data-host="desktop"] .more-menu-item:focus-visible,
 [data-host="desktop"] .panel-toggle-menu-item:hover,
-[data-host="desktop"] .panel-toggle-menu-item:focus-visible,
 [data-host="desktop"] .desktop-session-menu-item:hover,
-[data-host="desktop"] .desktop-session-menu-item:focus-visible,
-[data-host="desktop"] .desktop-workdir-menu-item:hover,
-[data-host="desktop"] .desktop-workdir-menu-item:focus-visible {
+[data-host="desktop"] .desktop-workdir-menu-item:hover {
   background: #eef0f3;
   color: #1f2329;
 }
@@ -1544,9 +1524,7 @@
   color: #d92d20;
 }
 [data-host="desktop"] .more-menu-item--danger:hover,
-[data-host="desktop"] .more-menu-item--danger:focus-visible,
-[data-host="desktop"] .desktop-session-menu-item--danger:hover,
-[data-host="desktop"] .desktop-session-menu-item--danger:focus-visible {
+[data-host="desktop"] .desktop-session-menu-item--danger:hover {
   background: #fff0ef;
   color: #d92d20;
 }
@@ -1560,7 +1538,6 @@
 /* 复杂弹层菜单项交互：hover #EEF0F3 / 选中 #E7E9ED（替换 vscode
    list-activeSelection 蓝灰）；面板内分隔线统一 #EBEEF5 */
 [data-host="desktop"] .session-list-item:hover,
-[data-host="desktop"] .session-list-item:focus-visible,
 [data-host="desktop"] .slash-command-item:hover,
 [data-host="desktop"] .suggestion-item:hover,
 [data-host="desktop"] .rewind-popup-item:hover,
@@ -1581,8 +1558,7 @@
 /* 第二十五轮：面板切换菜单选中态对齐 codechat workspace-header-menu-item.active
    （背景 #E7E9ED + 文字 #1F2329，无对号；active:hover 保持 pressed 不漂回 hover） */
 [data-host="desktop"] .panel-toggle-menu-item--active,
-[data-host="desktop"] .panel-toggle-menu-item--active:hover,
-[data-host="desktop"] .panel-toggle-menu-item--active:focus-visible {
+[data-host="desktop"] .panel-toggle-menu-item--active:hover {
   background-color: #e7e9ed;
   color: #1f2329;
 }
@@ -1644,15 +1620,10 @@
   color: #9a9ea5;
 }
 [data-host="desktop"][data-theme="dark"] .more-menu-item:hover,
-[data-host="desktop"][data-theme="dark"] .more-menu-item:focus-visible,
 [data-host="desktop"][data-theme="dark"] .panel-toggle-menu-item:hover,
-[data-host="desktop"][data-theme="dark"] .panel-toggle-menu-item:focus-visible,
 [data-host="desktop"][data-theme="dark"] .desktop-session-menu-item:hover,
-[data-host="desktop"][data-theme="dark"] .desktop-session-menu-item:focus-visible,
 [data-host="desktop"][data-theme="dark"] .desktop-workdir-menu-item:hover,
-[data-host="desktop"][data-theme="dark"] .desktop-workdir-menu-item:focus-visible,
 [data-host="desktop"][data-theme="dark"] .session-list-item:hover,
-[data-host="desktop"][data-theme="dark"] .session-list-item:focus-visible,
 [data-host="desktop"][data-theme="dark"] .slash-command-item:hover,
 [data-host="desktop"][data-theme="dark"] .suggestion-item:hover,
 [data-host="desktop"][data-theme="dark"] .rewind-popup-item:hover,
@@ -1673,8 +1644,7 @@
 }
 /* 第二十五轮：面板切换菜单选中态深色（12% 白底 + 白字） */
 [data-host="desktop"][data-theme="dark"] .panel-toggle-menu-item--active,
-[data-host="desktop"][data-theme="dark"] .panel-toggle-menu-item--active:hover,
-[data-host="desktop"][data-theme="dark"] .panel-toggle-menu-item--active:focus-visible {
+[data-host="desktop"][data-theme="dark"] .panel-toggle-menu-item--active:hover {
   background-color: rgba(255, 255, 255, 0.12);
   color: #ffffff;
 }
@@ -1683,9 +1653,7 @@
   color: #f4655c;
 }
 [data-host="desktop"][data-theme="dark"] .more-menu-item--danger:hover,
-[data-host="desktop"][data-theme="dark"] .more-menu-item--danger:focus-visible,
-[data-host="desktop"][data-theme="dark"] .desktop-session-menu-item--danger:hover,
-[data-host="desktop"][data-theme="dark"] .desktop-session-menu-item--danger:focus-visible {
+[data-host="desktop"][data-theme="dark"] .desktop-session-menu-item--danger:hover {
   background: rgb(217 45 32 / 20%);
   color: #f4655c;
 }
@@ -2221,12 +2189,11 @@
   color: #ffffff;
 }
 
-[data-host="desktop"][data-theme="light"] .desktop-panel-tab:not(.active):hover,
-[data-host="desktop"][data-theme="light"] .desktop-panel-tab:not(.active):focus-visible {
+/* 键盘聚焦提示交给浏览器原生焦点环（键盘 focus 不补 hover 底色） */
+[data-host="desktop"][data-theme="light"] .desktop-panel-tab:not(.active):hover {
   background: #eef0f3;
 }
-[data-host="desktop"][data-theme="dark"] .desktop-panel-tab:not(.active):hover,
-[data-host="desktop"][data-theme="dark"] .desktop-panel-tab:not(.active):focus-visible {
+[data-host="desktop"][data-theme="dark"] .desktop-panel-tab:not(.active):hover {
   background: rgba(255, 255, 255, 0.08);
 }
 
@@ -2367,12 +2334,10 @@
 [data-host="desktop"] .desktop-panel-empty-item {
   border-radius: 12px;
 }
-[data-host="desktop"][data-theme="light"] .desktop-panel-empty-item:hover:not(:disabled),
-[data-host="desktop"][data-theme="light"] .desktop-panel-empty-item:focus-visible {
+[data-host="desktop"][data-theme="light"] .desktop-panel-empty-item:hover:not(:disabled) {
   background: #eef0f3;
 }
-[data-host="desktop"][data-theme="dark"] .desktop-panel-empty-item:hover:not(:disabled),
-[data-host="desktop"][data-theme="dark"] .desktop-panel-empty-item:focus-visible {
+[data-host="desktop"][data-theme="dark"] .desktop-panel-empty-item:hover:not(:disabled) {
   background: rgba(255, 255, 255, 0.08);
 }
 

--- a/packages/webview/src/styles/host-desktop.css
+++ b/packages/webview/src/styles/host-desktop.css
@@ -219,20 +219,14 @@
   border-radius: 6px;
   color: #565a60;
 }
-/* 工具行图标按钮键盘提示：focus-visible 复用 hover 底色（与行/下拉族
-   一致），并去掉浏览器默认焦点环 */
-[data-host="desktop"] .toolbar-icon-button:hover,
-[data-host="desktop"] .toolbar-icon-button:focus-visible {
+[data-host="desktop"] .toolbar-icon-button:hover {
   background: #f0f2f5;
-  outline: none;
 }
 [data-host="desktop"][data-theme="dark"] .toolbar-icon-button {
   color: #9a9ea5;
 }
-[data-host="desktop"][data-theme="dark"] .toolbar-icon-button:hover,
-[data-host="desktop"][data-theme="dark"] .toolbar-icon-button:focus-visible {
+[data-host="desktop"][data-theme="dark"] .toolbar-icon-button:hover {
   background: rgba(255, 255, 255, 0.08);
-  outline: none;
 }
 
 /* 压缩上下文按钮：32px 高，整体 59×32（codechat 图形按钮）：
@@ -308,10 +302,7 @@
 }
 /* 切换选择后按钮仍持 focus，不再常驻 hover 底色（用户 0904 走查：切换后
    不要保留 hover 态）；键盘 focus 提示走 :focus-visible 同底色。 */
-/* :focus 复位须排除 :focus-visible：键盘 Tab 聚焦同时命中两者、且本规则
-   声明在后（特异性相同），否则透明背景会盖掉上方的键盘高亮（回归）——
-   复位只针对鼠标点选带来的 focus。 */
-[data-host="desktop"] .permission-mode-select:focus:not(:focus-visible) {
+[data-host="desktop"] .permission-mode-select:focus {
   background: transparent;
   border-color: transparent;
 }
@@ -330,8 +321,7 @@
   background: rgba(255, 255, 255, 0.08);
   color: #fff;
 }
-[data-host="desktop"][data-theme="dark"]
-  .permission-mode-select:focus:not(:focus-visible) {
+[data-host="desktop"][data-theme="dark"] .permission-mode-select:focus {
   background: transparent;
 }
 [data-host="desktop"][data-theme="dark"]
@@ -448,17 +438,8 @@
   background: var(--cc-action-primary, #1f2329);
   color: var(--cc-action-primary-text, #ffffff);
 }
-[data-host="desktop"] .ai-send-btn:not(:disabled):hover,
-[data-host="desktop"] .ai-send-btn:not(:disabled):focus-visible {
+[data-host="desktop"] .ai-send-btn:not(:disabled):hover {
   background: var(--cc-action-primary-hover, #34383f);
-  outline: none;
-}
-/* 停止钮同族键盘提示：host 无独立覆盖，hover 走 base 的 button-hoverBackground
-   token（桌面映射同发送钮深档），此处只补 focus-visible + 去默认环 */
-[data-host="desktop"] .abort-button:hover,
-[data-host="desktop"] .abort-button:focus-visible {
-  background: var(--vscode-button-hoverBackground, var(--vscode-button-background));
-  outline: none;
 }
 [data-host="desktop"][data-theme="dark"] .ai-send-btn,
 [data-host="desktop"][data-theme="dark"] .ai-send-btn:disabled {
@@ -470,10 +451,8 @@
   background: var(--cc-action-primary, #e0e3e5);
   color: var(--cc-action-primary-text, #191c1e);
 }
-[data-host="desktop"][data-theme="dark"] .ai-send-btn:not(:disabled):hover,
-[data-host="desktop"][data-theme="dark"] .ai-send-btn:not(:disabled):focus-visible {
+[data-host="desktop"][data-theme="dark"] .ai-send-btn:not(:disabled):hover {
   background: var(--cc-action-primary-hover, #f0f2f3);
-  outline: none;
 }
 
 /* 新会话上下文栏：Figma 13439-9245 —— 卡片外独立横条（非卡片脚条）。
@@ -551,20 +530,16 @@
   color: #565a60;
   box-sizing: border-box;
 }
-[data-host="desktop"] .desktop-worktree-checkbox:hover,
-[data-host="desktop"] .desktop-worktree-checkbox:focus-visible {
+[data-host="desktop"] .desktop-worktree-checkbox:hover {
   background: #eef0f3;
   color: #1f2329;
-  outline: none;
 }
 [data-host="desktop"][data-theme="dark"] .desktop-worktree-checkbox {
   color: #9a9ea5;
 }
-[data-host="desktop"][data-theme="dark"] .desktop-worktree-checkbox:hover,
-[data-host="desktop"][data-theme="dark"] .desktop-worktree-checkbox:focus-visible {
+[data-host="desktop"][data-theme="dark"] .desktop-worktree-checkbox:hover {
   background: rgba(255, 255, 255, 0.08);
   color: #ffffff;
-  outline: none;
 }
 [data-host="desktop"] .desktop-host-trigger:hover,
 [data-host="desktop"] .desktop-host-trigger:focus-visible,


### PR DESCRIPTION
## 背景

用户反馈桌面端下面一行 tab/context-bar 控件键盘 Tab 聚焦环与工具行按钮（`+`、`/`、权限选择器）不一致。经走查拍板：自定义 `:focus-visible` 视觉规则全部放弃，键盘聚焦一律走 Chromium UA 原生焦点环（`outline: auto`，Windows 黄白双描边 / Linux 白描边，devtools 无 CSS 可查）。

本 PR = revert #2143 的自绘样式（`c1a00f0e`）+ 第三轮全面清理（`1ef7adac`）：连账号卡片、侧边栏会话族、各类菜单等剩余全部键盘自绘也一并移除。

## 改动内容（纯 CSS，+55/−143，无逻辑变化）

- **host-desktop.css**：permission-mode-select、host/workdir trigger、plus-menu-item、account 卡片族、会话分组头/更多钮/菜单项、面板切换菜单、panel-tab/空态入口 —— `:hover,:focus-visible` → `:hover`
- **base 共享层**：
  - AccountCard.css：6 组 `outline:none` 移除、focus-visible 填充移除
  - DesktopApp.css：group-header/more-btn/session-menu-item/workdir 族/remote-browser 族 hover-only
  - MessageInput.css：permission/plus 菜单项与 selection-tag 自绘 outline 移除；`.permission-mode-select` 的 `outline:none` 移除
  - MoreMenu / PanelToggleMenu / SessionListPopup / SessionBoard / DiffViewer / Message.css 同步
- **保留**（结构性必需，非自绘视觉）：
  - settings-switch 隐藏 input（`opacity:0;width:0`）的 `:focus-visible` box-shadow 环 —— 原生环无法渲染，是唯一可见焦点提示
  - DesktopApp `.desktop-session-more-btn` reveal 与 `:has(.desktop-session-item-main:focus-visible)` 标题让位
  - 文本输入框 `outline:none` + `:focus { border-color }`（VS Code 惯例）

## 跨 host 影响说明

base 共享层由 desktop + VS Code + JetBrains 共同加载，本改动会使 IDE 端键盘聚焦同步回归原生环：菜单项/工具行不再有自绘灰底填充，权限钮移除 `outline:none` 后键盘聚焦出现原生描边。此为设计意图（三端键盘焦点视觉统一走浏览器原生）。

## 验证

- 截图走查（vision 逐张确认）：聚焦项 `focus-visible=true`，全部仅原生白描边、无自绘灰底 —— 工具行/权限钮/会话行/分组头/账户卡/菜单项视觉一致
- `pnpm -F wave-webview compile` ✓
- webview 单测 113 文件 / 1035 全绿 ✓
- webview type-check / oxlint 0 错 ✓
- pre-commit 全仓 type-check 6 包 ✓
- prettier 4 文件告警为既有基线（HEAD 同样不 clean），未整文件 --write
