### PR TITLE
fix(cli): restoreSession 后无条件补发 contextUsage,消除切到同值历史会话的空环

### DIFF
--- a/packages/code/src/stdio/agentBridge.ts
+++ b/packages/code/src/stdio/agentBridge.ts
@@ -653,18 +653,36 @@ export class AgentBridge {
       // client's router registered — so replay the current usage or the
       // webview keeps the previous session's (or no) percentage until the
       // next turn pushes a fresh value (spec desktop-app 上下文用量指示器
-      // 场景 6: 恢复即显示该会话上次用量). A zero total means no real usage
-      // to report; the host keeps the empty ring until the first push.
-      const tokens = entry.agent.latestTotalTokens;
-      const max = entry.agent.getMaxInputTokens();
-      if (tokens > 0 && max > 0) {
-        const percent = Math.min(100, Math.round((tokens / max) * 100));
-        this.emit("contextUsage", { percent }, entry.agent.sessionId);
-      }
+      // 场景 6: 恢复即显示该会话上次用量).
+      this.emitContextUsage(entry.agent);
       return null;
     }
     await entry.agent.restoreSession(restoreId);
+    // A real restore must also re-emit the usage unconditionally: the SDK
+    // only fires onLatestTotalTokensChange on a VALUE CHANGE, so restoring a
+    // conversation whose persisted total equals the agent's current one
+    // suppresses the change-push and the webview — which cleared the previous
+    // session's number on the switch — keeps a blank ring until the next turn
+    // (the change-push, when it does fire inside restoreSession, already
+    // delivered the same value; re-emitting is idempotent).
+    this.emitContextUsage(entry.agent);
     return null;
+  }
+
+  /**
+   * Push the session's current context-usage percentage to the client. Shared
+   * by every restore path so a conversation the client just switched to always
+   * shows its usage right away instead of waiting for the next token change
+   * (spec desktop-app 上下文用量指示器 场景 6). A zero total means no real
+   * usage to report; the host keeps the empty ring until the first push.
+   */
+  private emitContextUsage(agent: Agent): void {
+    const tokens = agent.latestTotalTokens;
+    const max = agent.getMaxInputTokens();
+    if (tokens > 0 && max > 0) {
+      const percent = Math.min(100, Math.round((tokens / max) * 100));
+      this.emit("contextUsage", { percent }, agent.sessionId);
+    }
   }
 
   private async listSessions(

--- a/packages/code/tests/stdio/agentBridge.test.ts
+++ b/packages/code/tests/stdio/agentBridge.test.ts
@@ -2099,6 +2099,35 @@ test("restoreSession to the live session replays the current contextUsage so the
   });
 });
 
+test("restoreSession to a DIFFERENT session re-emits contextUsage even when the token count is unchanged (no SDK change-push)", async () => {
+  const { bridge, notifications } = createBridge();
+  const mockAgent = createMockAgent({ latestTotalTokens: 50000 });
+  vi.mocked(Agent.create).mockResolvedValue(mockAgent);
+
+  const result = await bridge.handleRequest("initialize", {});
+  const sessionId = (result as { sessionId: string }).sessionId;
+
+  // Real restore (target != current). The SDK fires setlatestTotalTokens only
+  // on a VALUE CHANGE, so restoring a conversation whose persisted total
+  // equals the agent's current one (e.g. both 0, or the same count) suppresses
+  // the change-push — the webview cleared the old number on the session
+  // switch and keeps a blank ring until the next turn. The bridge must
+  // re-emit unconditionally instead of depending on the SDK callback (the
+  // re-attach branch below already does; this pins the real-restore branch).
+  await bridge.handleRequest(
+    "restoreSession",
+    { sessionId: "other-session" },
+    sessionId,
+  );
+
+  expect(mockAgent.restoreSession).toHaveBeenCalledWith("other-session");
+  expect(notifications).toContainEqual({
+    method: "contextUsage",
+    params: { percent: 25 }, // 50000 / 200000 (default getMaxInputTokens)
+    sessionId,
+  });
+});
+
 test("restoreSession replay skips contextUsage when the live session has no tokens yet", async () => {
   const { bridge, notifications } = createBridge();
   const mockAgent = createMockAgent({ latestTotalTokens: 0 });


### PR DESCRIPTION
## 现象

GUI 端（VS Code 插件为主，JB/desktop 同链路）切换几次历史对话后,上下文用量百分比有一定概率不显示,只剩空环,直到下一轮对话才恢复。

## 根因

会话切换走 `restoreSession` RPC,CLI 的 `agentBridge.restoreSession` 真实 restore 分支只依赖 SDK 的 `onLatestTotalTokensChange` 推送用量,而该回调**仅在 token 数值变化时触发**(`messageManager.setlatestTotalTokens` 有 `!==` 守卫)。当目标会话持久化的 `latestTotalTokens` 与当前 agent 的值相同(含同为 0)时:

- webview 在会话切换(updateCurrentSession)时同步清掉了上一个会话的数字
- CLI 因值未变不发 `contextUsage`
- → 空环持续到下一轮真实对话产生 token 变化

re-attach 分支(恢复当前会话)早有**无条件补发**,真实 restore 分支(切换到别的会话)却没有——客户在 v1.1.8(已含 webview 竞态修复 3b6ebad0)上仍复现,证实缺口在 CLI 侧。

## 修复

`agentBridge.ts`:

- 抽出 `emitContextUsage()`(tokens>0 && max>0 守卫,语义与 re-attach 分支一致)
- `restoreSession` 真实 restore 分支结束时**无条件补发**一次 contextUsage
- re-attach 分支改用同一 helper

CLI 一处改动,三端(VSCE/JB/desktop)切换历史会话都走这条 RPC,全端生效;零协议/宿主改动。token 变化时 SDK 回调与补发重复推送同值,幂等无害。

## 验证

- 新增回归测试:restore 到不同会话且 token 值不变 → 必须发出 `contextUsage`(修复前红、修复后绿)
- `agentBridge.test.ts` 139/139,`wave-code` 单测 1463 通过,type-check/lint 全绿