### PR TITLE
fix(desktop): 删除会话后不得经 Ctrl+Tab 复活

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -1974,6 +1974,15 @@ export class DesktopHost {
       } catch (error) {
         console.warn("[DesktopHost] getMessages failed:", error);
       }
+      // The getMessages await above is past the last token check, and
+      // handleDeleteSession cancels a restore of a deleted session by removing
+      // its pendingRestores entry — so re-check here, otherwise the restore
+      // would re-register a conversation the user deleted mid-flight (spec
+      // 「恢复加载期间删除会话」: 会话索引以删除为准).
+      if (this.pendingRestores.get(paneId)?.token !== token) {
+        await this.discardAgent(agent);
+        return true;
+      }
       this.rekeyAgent(agent, opts.sessionId);
       // activateAgentInPane clears the pending entry — the pane is now live.
       await this.activateAgentInPane(paneId, agent);
@@ -2757,6 +2766,27 @@ export class DesktopHost {
       this.agents.delete(this.agentKey(host, sessionId));
       this.agentHosts.delete(target);
       this.agentWorktreeInfo.delete(target);
+    }
+
+    // A deleted session must never come back. Two stale references can still
+    // point at it and would re-register it on the next action:
+    //  1. The frozen Ctrl+Tab cycle order (sessionCycleSnapshot) — its only
+    //     invalidation is the current-session comparison in
+    //     activateAdjacentSession, which does NOT fire when the deleted
+    //     session is not the focused pane's current one. Drop the whole
+    //     snapshot so the next press re-derives from the refreshed tree.
+    //  2. An in-flight restore still heading for the deleted id (spec
+    //     「恢复加载期间删除会话」) — runPaneRestore re-registers on landing.
+    //     Cancelling the pending entry makes its token checks discard the
+    //     half-spawned agent instead.
+    this.sessionCycleSnapshot = null;
+    this.sessionCycleIndex = -1;
+    for (const pane of this.panes) {
+      if (this.pendingRestores.get(pane.paneId)?.sessionId === sessionId) {
+        this.pendingRestores.delete(pane.paneId);
+        // Drop the sweep overlay and fall back to the pane's previous agent.
+        void this.pushPaneSessionState(pane.paneId);
+      }
     }
 
     // Every pane showing the deleted session closes; a sole pane resets to a

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -4233,6 +4233,90 @@ describe("session switch shortcut (FR-038)", () => {
     });
   });
 
+  it("deleting a session drops it from the cycle — Ctrl+Tab must not resurrect it", async () => {
+    const { host, store, sent } = await hostWithTree();
+    await host.activateAdjacentSession(1); // s3, snapshot frozen at [s3, s2, s1]
+    await vi.waitFor(() => {
+      expect(sent("setInitialState").at(-1)?.isRestoring).toBe(false);
+      expect(sent("setInitialState").at(-1)?.session).toMatchObject({
+        id: "s3",
+      });
+    });
+
+    // Delete s2 — a historical session that is NOT the focused pane's current
+    // one. The frozen snapshot (whose invalidation only fires on a current
+    // session change) must not keep it selectable.
+    await host.handleWebviewMessage({
+      command: "desktopDeleteSession",
+      sessionId: "s2",
+    });
+    await vi.waitFor(() => {
+      expect(store.getSessionIndex().some((e) => e.sessionId === "s2")).toBe(
+        false,
+      );
+    });
+
+    // Continue cycling: the fresh order [s3, s1] steps from s3 to s1. The
+    // stale snapshot would instead step onto the deleted s2 and re-restore it.
+    await host.activateAdjacentSession(1);
+    await vi.waitFor(() => {
+      expect(sent("setInitialState").at(-1)?.isRestoring).toBe(false);
+      expect(sent("setInitialState").at(-1)?.session).toMatchObject({
+        id: "s1",
+      });
+    });
+
+    // The deleted session was never restored or re-registered.
+    expect(
+      h.agentInstances.some((a) =>
+        (a.restoreSession as ReturnType<typeof vi.fn>).mock.calls.some(
+          ([id]) => id === "s2",
+        ),
+      ),
+    ).toBe(false);
+    expect(store.getSessionIndex().some((e) => e.sessionId === "s2")).toBe(
+      false,
+    );
+  });
+
+  it("deleting a session mid-restore cancels the restore (spec 恢复加载期间删除会话)", async () => {
+    const { host, store, sent } = await hostWithTree();
+    // Park the restore's agent at initialize so the delete can land mid-flight.
+    let releaseInit: () => void = () => {};
+    h.initializeGate = new Promise<void>((resolve) => {
+      releaseInit = resolve;
+    });
+    const before = h.agentInstances.length;
+
+    await host.activateAdjacentSession(1); // starts restoring s3, parked
+    await vi.waitFor(() => {
+      expect(h.agentInstances.length).toBe(before + 1);
+    });
+
+    // Delete s3 while its restore is still in flight.
+    await host.handleWebviewMessage({
+      command: "desktopDeleteSession",
+      sessionId: "s3",
+    });
+    await vi.waitFor(() => {
+      expect(store.getSessionIndex().some((e) => e.sessionId === "s3")).toBe(
+        false,
+      );
+    });
+
+    releaseInit();
+    // The restore completes past initialize but must discard the agent and
+    // never land the deleted session (it stays on the pane's previous agent).
+    await vi.waitFor(() => {
+      const restoredAgent = h.agentInstances.at(-1);
+      expect(restoredAgent?.destroy).toHaveBeenCalled();
+      expect(store.getSessionIndex().some((e) => e.sessionId === "s3")).toBe(
+        false,
+      );
+    });
+    expect(sent("setInitialState").at(-1)?.session?.id).not.toBe("s3");
+  });
+
   it("is a no-op on an empty tree", async () => {
     const { host } = createHost();
     await host.activateAdjacentSession(1);


### PR DESCRIPTION
handleDeleteSession 只清理索引/agent 池/worktree, 遗漏两处持 sessionId 的结构:
1) sessionCycleSnapshot(Ctrl+Tab 冻结顺序) 的失效只靠 currentId 比较,
   删除非当前会话时不触发 → 快照残留被删 id → Ctrl+Tab 走到 → 恢复 → 重注册;
2) 指向被删会话的在途 pendingRestores(恢复加载期间删除不取消)。

修复=删除时置空 cycle snapshot + 清除匹配的 pendingRestores 条目; runPaneRestore
在 getMessages 之后补 token 复检堵最后竞态窗口。补 2 个回归测试(红绿验证)。
