### PR TITLE
fix(desktop): AGENTS.md 项目级编辑器读回/展示随项目切换失效

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -3414,17 +3414,14 @@ export class DesktopHost {
 
       // -- AGENTS.md (memory files) -------------------------------------------
       case "getAgentsContent":
-        await this.handleGetAgentsContent(
-          msg.scope as "user" | "project",
-          msg.workdir as string | undefined,
-        );
+        await this.handleGetAgentsContent(pid, msg.scope as "user" | "project");
         break;
 
       case "setAgentsContent":
         await this.handleSetAgentsContent(
+          pid,
           msg.scope as "user" | "project",
           msg.content as string,
-          msg.workdir as string | undefined,
         );
         break;
 
@@ -4990,16 +4987,35 @@ export class DesktopHost {
     }
   }
 
-  /** AGENTS.md settings UI: fetch user (~/.wave/AGENTS.md) or project (<workdir>/AGENTS.md) memory file content. */
+  /**
+   * AGENTS.md settings UI: fetch user (~/.wave/AGENTS.md) or project
+   * (<workdir>/AGENTS.md) memory file content.
+   *
+   * The project scope is resolved against the target pane's bound session
+   * (agentForPane(paneId)?.workingDirectory ?? this.workdir), mirroring the
+   * other project-scoped settings RPCs (getProjectSettings/getHooksConfig/
+   * getMcpConfig) — the webview cannot supply a trustworthy workdir because
+   * the desktop settings full-page lives on the root instance, which owns no
+   * session of its own and must follow the focused pane. Trusting a
+   * webview-sent path made the editor read/write whichever directory happened
+   * to sit at the head of the window's recents instead of the current
+   * project's file.
+   */
   private async handleGetAgentsContent(
+    paneId: string,
     scope: "user" | "project",
-    workdir?: string,
   ): Promise<void> {
     try {
-      const result = (await this.utilityClientFor(this.currentHost).request(
-        "getAgentsContent",
-        { scope, workdir },
-      )) as { content: string; path?: string };
+      const workdir =
+        scope === "project"
+          ? (this.agentForPane(paneId)?.workingDirectory ?? this.workdir)
+          : undefined;
+      const result = (await this.utilityClientFor(
+        this.hostForPane(paneId),
+      ).request("getAgentsContent", { scope, workdir })) as {
+        content: string;
+        path?: string;
+      };
       this.postMessage({
         command: "agentsContentResponse",
         scope,
@@ -5015,14 +5031,22 @@ export class DesktopHost {
     }
   }
 
-  /** AGENTS.md settings UI: persist content via the stdio setAgentsContent RPC. */
+  /**
+   * AGENTS.md settings UI: persist content via the stdio setAgentsContent RPC.
+   * The project workdir is resolved from the target pane's bound session, same
+   * as handleGetAgentsContent (see above).
+   */
   private async handleSetAgentsContent(
+    paneId: string,
     scope: "user" | "project",
     content: string,
-    workdir?: string,
   ): Promise<void> {
     try {
-      await this.utilityClientFor(this.currentHost).request(
+      const workdir =
+        scope === "project"
+          ? (this.agentForPane(paneId)?.workingDirectory ?? this.workdir)
+          : undefined;
+      await this.utilityClientFor(this.hostForPane(paneId)).request(
         "setAgentsContent",
         {
           scope,

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -3226,6 +3226,82 @@ describe("misc commands", () => {
     });
   });
 
+  it("getAgentsContent project scope reads the focused pane session's workdir, not the webview-sent path", async () => {
+    const { host, sent } = await readyHost();
+    // readyHost binds pane-1 to a session whose agent workingDirectory is /work/a.
+    const orig = h.handleClientRequest;
+    const seen: Array<{ method: string; params: unknown }> = [];
+    h.handleClientRequest = (method, params) => {
+      if (method === "getAgentsContent") {
+        seen.push({ method, params });
+        return { content: "# from the bound session" };
+      }
+      return orig(method, params);
+    };
+    try {
+      await host.handleWebviewMessage({
+        command: "getAgentsContent",
+        scope: "project",
+        // The settings full-page runs on the root webview instance, which has
+        // no session of its own — it used to forward the head of the window's
+        // recents here, so reads hit the wrong (non-current) project.
+        workdir: "/work/recents-head",
+      });
+    } finally {
+      h.handleClientRequest = orig;
+    }
+
+    expect(seen).toEqual([
+      {
+        method: "getAgentsContent",
+        params: { scope: "project", workdir: "/work/a" },
+      },
+    ]);
+    expect(sent("agentsContentResponse")[0]).toMatchObject({
+      scope: "project",
+      content: "# from the bound session",
+    });
+  });
+
+  it("setAgentsContent project scope writes to the focused pane session's workdir, not the webview-sent path", async () => {
+    const { host, sent } = await readyHost();
+    const orig = h.handleClientRequest;
+    const seen: Array<{ method: string; params: unknown }> = [];
+    h.handleClientRequest = (method, params) => {
+      if (method === "setAgentsContent") {
+        seen.push({ method, params });
+        return { ok: true };
+      }
+      return orig(method, params);
+    };
+    try {
+      await host.handleWebviewMessage({
+        command: "setAgentsContent",
+        scope: "project",
+        content: "# new project rules",
+        workdir: "/work/recents-head",
+      });
+    } finally {
+      h.handleClientRequest = orig;
+    }
+
+    expect(seen).toEqual([
+      {
+        method: "setAgentsContent",
+        params: {
+          scope: "project",
+          content: "# new project rules",
+          workdir: "/work/a",
+        },
+      },
+    ]);
+    expect(shownToasts().some((t) => t.message === "保存成功")).toBe(true);
+    expect(sent("agentsContentSaved")[0]).toMatchObject({
+      scope: "project",
+      ok: true,
+    });
+  });
+
   it("listPlugins failure surfaces as a toast, not a chat message", async () => {
     const { host, sent } = await readyHost();
     const restore = failRpc("listPlugins", "plugin service down");

--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -1618,14 +1618,24 @@ export const ChatApp: React.FC<ChatAppProps> = ({
           return;
         }
         // Batch 2: desktop opens the settings full-page (spec 场景 1). Load the
-        // configuration + AGENTS.md editor contents on entry; the page reads the
-        // latest from its own props when it renders. /agents、/skills、/hooks
-        // 斜杠命令携带 nav（subagents/skills/hooks）选中对应选项卡
-        // （spec agents-command.md / hooks-command.md）。
+        // configuration on entry; the settings page requests the AGENTS.md
+        // editor contents itself (its own mount effect pulls each scope while
+        // the value is null — user immediately, project when the 项目级 tab is
+        // first activated). /agents、/skills、/hooks 斜杠命令携带 nav
+        // (subagents/skills/hooks) 选中对应选项卡（spec agents-command.md /
+        // hooks-command.md）。
+        //
+        // 重置 AGENTS.md 编辑器缓存：缓存不按 workdir 键控、只随首次加载填充
+        // 且从不失效——关闭设置 → 切换项目/会话 → 再打开会继续显示上一份加载
+        // 的（旧值/别项目）文件。每次打开置 null 后由设置页按需重新读取当前
+        // 项目的文件（host 按聚焦 pane 解析 workdir，见 desktopHost
+        // handleGetAgentsContent）。
+        setUserAgentsContent(null);
+        setProjectAgentsContent(null);
+        setAgentsSaving(false);
         setSettingsOpen(true);
         if (nav) setSettingsNav(nav);
         vscode.postMessage({ command: "getConfiguration" });
-        vscode.postMessage({ command: "getAgentsContent", scope: "user" });
         return;
       }
       // IDE hosts (VSCE/JetBrains): the host opens the settings tab webview in

--- a/packages/webview/tests/webview/settingsAgentsProjectSwitch.test.tsx
+++ b/packages/webview/tests/webview/settingsAgentsProjectSwitch.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  render,
+  screen,
+  waitFor,
+  act,
+  fireEvent,
+  sendHostMessage,
+  fixtures,
+  createMockVscode,
+} from "./test-utils";
+import React from "react";
+import { ChatApp } from "../../src/components/ChatApp";
+import type { VsCodeApi } from "../../src/types";
+
+// 与 settingsPaneDelegate.test.tsx 同构的 desktop host props（root 实例）。
+function desktopHost() {
+  return {
+    type: "desktop",
+    host: "local",
+    hosts: ["local"],
+    recentWorkdirs: ["/work/a"],
+    workdir: "/work/a",
+    sessionTree: [],
+    panes: [{ paneId: "pane-1" }],
+    focusedPaneId: "pane-1",
+    onSelectWorkdir: () => {},
+    onSelectRecentWorkdir: () => {},
+    onRemoveRecentWorkdir: () => {},
+    onSelectHost: () => {},
+    onAddHost: () => {},
+    onSelectRemotePath: () => {},
+    onListRemoteDir: () => {},
+    onSelectSession: () => {},
+    onDeleteSession: () => {},
+    onOpenPane: () => {},
+  } as unknown as React.ComponentProps<typeof ChatApp>["host"];
+}
+
+async function openSettings() {
+  const input = await screen.findByTestId("message-input");
+  input.focus();
+  await act(async () => {
+    input.textContent = "/config";
+    const range = document.createRange();
+    range.selectNodeContents(input);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+    fireEvent.input(input, { data: "/config", inputType: "insertText" });
+  });
+  fireEvent.keyDown(input, { key: "Enter" });
+  await screen.findByText("管理 CodeWave IDE 的界面、模型和基础行为。");
+}
+
+/** 进入个性化视图并把作用域切到「项目级」。 */
+async function openProjectTab() {
+  fireEvent.click(screen.getByRole("button", { name: "个性化" }));
+  const tab = await screen.findByRole("tab", { name: "项目级" });
+  fireEvent.click(tab);
+  await screen.findByLabelText("项目级 AGENTS.md 内容");
+}
+
+/** mockVscode.postMessage 中 getAgentsContent(project) 的发出次数。 */
+function projectRequests(mockVscode: ReturnType<typeof createMockVscode>) {
+  return mockVscode.postMessage.mock.calls.filter(
+    ([msg]) =>
+      (msg as { command?: string }).command === "getAgentsContent" &&
+      (msg as { scope?: string }).scope === "project",
+  );
+}
+
+/**
+ * Bug 回归：desktop 设置页「个性化」项目级 AGENTS.md 编辑器。
+ *
+ * 根因 1（读回旧值）：AGENTS.md 内容缓存在 root ChatApp state，只在值为 null
+ * 时（设置页首次挂载）才向 host 请求——保存后关闭再打开设置页不重新读取磁盘，
+ * 一直显示上一次加载的快照。修复：每次打开设置页重置缓存为 null，设置页挂载
+ * 后按需重新读取（项目级在「项目级」tab 首次激活时读取）。
+ *
+ * 根因 2（不随项目切换）：同一缓存与「当前项目」解耦——切换项目/会话后重开
+ * 设置页仍显示上一个项目那份文件。与根因 1 同一修复点（逐次打开按当前项目
+ * 重读；workdir 归属由 desktopHost 按聚焦 pane 解析，见 desktopHost.test）。
+ */
+describe("desktop 设置页「个性化」项目级 AGENTS.md 随项目切换刷新", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("保存后关闭再打开设置页会重新拉取项目级内容并显示磁盘新值", async () => {
+    const mockVscode = createMockVscode();
+    render(
+      <ChatApp
+        vscode={mockVscode as unknown as VsCodeApi}
+        host={desktopHost()}
+      />,
+    );
+    // Root 单实例就绪（非 desktopPanes 路由——host 消息保持 untagged 直达 root）。
+    sendHostMessage(fixtures.authStatusResponse());
+    sendHostMessage(fixtures.setInitialState());
+
+    // 第一次打开：进入 项目级 tab → host 拉取 → 回包落盘快照 A
+    await openSettings();
+    await openProjectTab();
+    expect(projectRequests(mockVscode)).toHaveLength(1);
+    act(() => {
+      sendHostMessage({
+        command: "agentsContentResponse",
+        scope: "project",
+        content: "# 版本 A",
+      });
+    });
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("项目级 AGENTS.md 内容") as HTMLTextAreaElement)
+          .value,
+      ).toBe("# 版本 A");
+    });
+
+    // 关闭设置页（等同客户「关掉」）。设置页全页打开期间 DesktopShell 卸载了
+    // pane 的 ChatApp；关闭后重挂载需宿主重推 auth 快照才会进入 welcome 态并
+    // 挂载输入框（真实 desktopHost 对重挂载 pane 的 webviewReady 会回放快照，
+    // 这里手动补推 authStatusResponse 以模拟宿主）。
+    fireEvent.click(screen.getByRole("button", { name: "返回" }));
+    sendHostMessage(fixtures.authStatusResponse());
+    await screen.findByTestId("message-input");
+
+    // 磁盘已更新（模拟保存成功后的文件新值）；再次打开设置页
+    await openSettings();
+    await openProjectTab();
+
+    // 修复前：projectAgentsContent 缓存未重置（仍非 null）→ 不重新请求，
+    // 文本区继续显示旧快照「# 版本 A」——此处 count 仍为 1，测试先红。
+    expect(projectRequests(mockVscode)).toHaveLength(2);
+    // host 回发磁盘新值（当前项目文件）
+    act(() => {
+      sendHostMessage({
+        command: "agentsContentResponse",
+        scope: "project",
+        content: "# 版本 B",
+      });
+    });
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("项目级 AGENTS.md 内容") as HTMLTextAreaElement)
+          .value,
+      ).toBe("# 版本 B");
+    });
+  });
+});


### PR DESCRIPTION
## 根因与修复

桌面设置页「个性化」项目级 AGENTS.md 编辑器两处失效（保存后重开显示旧值 / 不随项目切换，恒显示第一个项目文件）：

- **读回旧值（症状 1）**：内容缓存在 root ChatApp state，只在 null 时（设置页挂载/首次进 tab）请求一次、从不失效；关闭再打开沿用上次快照。修复：每次打开设置页重置 `userAgentsContent/projectAgentsContent` 为 null，由设置页按需重读磁盘。
- **不随项目切换（症状 2）**：设置全页跑在 root 实例（无会话，`state.workdir` 恒 undefined → 回退 `recentWorkdirs[0]`），desktopHost 是唯一信任 webview 传入 path 的项目级 RPC，直接透传 `msg.workdir` 读写 recents 头项目。修复：`handleGetAgentsContent/handleSetAgentsContent` 的 project scope 改为经 `agentForPane(paneId)?.workingDirectory ?? this.workdir` 解析（与 getProjectSettings/getHooksConfig/getMcpConfig 同款），客户端走 `hostForPane(paneId)`。

## 变更文件（4）

1. `packages/webview/src/components/ChatApp.tsx` — `handleOpenSettings` desktop root 分支重置 AGENTS 内容缓存（并移除冗余的显式 user 拉取，改由设置页挂载 effect 负责）
2. `packages/desktop/src/main/desktopHost.ts` — AGENTS get/set project scope workdir 改由聚焦 pane 会话解析
3. `packages/desktop/tests/desktopHost.test.ts` — +2 回归（get/set project scope 断言落到 pane 会话 workdir）
4. `packages/webview/tests/webview/settingsAgentsProjectSwitch.test.tsx`（新）— 回归「关闭→重开设置页须重新拉取项目级内容并显示磁盘新值」

## 验证

- fail-without-fix 双验：stash 修复后新 webview 测试红（`expected length 2 but got 1`）、2 个 host 测试红；恢复全绿
- desktopHost 全量 319 passed；webview 全量 108 文件 / 931 passed（settings 相关 7 套件 33 passed）
- type-check（webview + desktop）绿；oxlint 变更文件 0 警告；prettier clean
- PR #2139（保存 toast）复查：setAgentsContent 回执/toast 链路未触碰（settingsAgentsEditor 套件全绿），本次纯读回/展示侧修复
