### PR TITLE
fix(agent-sdk): 后台子代理/workflow 终态后补推 backgroundTasksChange 快照，解除 IDE 新建/切历史门禁锁死

### DIFF
--- a/packages/agent-sdk/src/managers/subagentManager.ts
+++ b/packages/agent-sdk/src/managers/subagentManager.ts
@@ -580,17 +580,26 @@ export class SubagentManager {
             );
             const task = backgroundTaskManager?.getTask(taskId);
             if (task) {
-              task.status = "completed";
-              task.stdout = result;
+              // internalExecute already recorded the terminal state; only fill
+              // in a "completed" status when the task was not concurrently
+              // killed (mirrors the catch branch below).
+              if (task.status !== "killed") {
+                task.status = "completed";
+                task.stdout = result;
+              }
               task.endTime = Date.now();
               task.runtime = task.endTime - startTime;
             }
           } catch (error) {
             const task = backgroundTaskManager?.getTask(taskId);
             if (task) {
-              task.status = "failed";
-              task.stderr =
-                error instanceof Error ? error.message : String(error);
+              // Preserve a "killed" terminal state (internalExecute already
+              // notified it) instead of flipping the in-map task to failed.
+              if (task.status !== "killed") {
+                task.status = "failed";
+                task.stderr =
+                  error instanceof Error ? error.message : String(error);
+              }
               task.endTime = Date.now();
               task.runtime = task.endTime - startTime;
             }
@@ -747,8 +756,13 @@ export class SubagentManager {
         const task = backgroundTaskManager.getTask(instance.backgroundTaskId);
         if (task) {
           const wasAlreadyKilled = task.status === "killed";
-          task.status = "completed";
-          task.stdout = response || "Agent completed with no text response";
+          // Preserve a "killed" terminal state (stopTask already notified it)
+          // instead of overwriting it with "completed" — mirrors shell exit
+          // semantics in BackgroundTaskManager.onExit.
+          if (!wasAlreadyKilled) {
+            task.status = "completed";
+            task.stdout = response || "Agent completed with no text response";
+          }
           task.endTime = Date.now();
           if (task.startTime) {
             task.runtime = task.endTime - task.startTime;
@@ -765,6 +779,11 @@ export class SubagentManager {
               );
             }
           }
+          // Push a terminal snapshot: SubagentManager mutates the task object in
+          // place, so without an explicit notify the UI/hosts keep the last
+          // snapshot — the task created with status "running" — and the IDE
+          // background-task gate (new chat / history restore) stays locked.
+          backgroundTaskManager.notifyTasksChange();
         }
       }
 
@@ -784,12 +803,20 @@ export class SubagentManager {
         const task = backgroundTaskManager.getTask(instance.backgroundTaskId);
         if (task) {
           const wasAlreadyKilled = task.status === "killed";
-          task.status = "failed";
-          task.stderr = error instanceof Error ? error.message : String(error);
+          // Preserve a user/agent-initiated "killed" terminal state instead of
+          // overwriting it with "failed" (mirrors shell exit semantics) — the
+          // abort that stopped the task surfaces here as a thrown error.
+          if (!wasAlreadyKilled) {
+            task.status = "failed";
+            task.stderr =
+              error instanceof Error ? error.message : String(error);
+          }
           task.endTime = Date.now();
           if (task.startTime) {
             task.runtime = task.endTime - task.startTime;
           }
+          // Push a terminal snapshot (see the completion branch above).
+          backgroundTaskManager.notifyTasksChange();
           // Skip notification if task was already stopped (e.g. by main agent shutdown)
           if (!wasAlreadyKilled) {
             const messageQueue = this.container.has("MessageQueue")

--- a/packages/agent-sdk/src/managers/workflowManager.ts
+++ b/packages/agent-sdk/src/managers/workflowManager.ts
@@ -292,6 +292,10 @@ export class WorkflowManager {
           task.status = "completed";
           task.endTime = Date.now();
         }
+        // Push the terminal snapshot: without it the last snapshot holds the
+        // "running" registration and UI consumers (background-task gate) never
+        // see the workflow finish.
+        this.backgroundTaskManager.notifyTasksChange();
 
         // Enqueue completion notification
         const journalPath = journal.filePath;
@@ -336,6 +340,8 @@ export class WorkflowManager {
           task.stderr = run.error || "";
           task.endTime = Date.now();
         }
+        // Push the terminal snapshot (see the completion branch above).
+        this.backgroundTaskManager.notifyTasksChange();
 
         this.messageQueue.enqueueNotification(
           taskNotificationToXml({

--- a/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.background.test.ts
@@ -63,6 +63,7 @@ describe("SubagentManager - Backgrounding Coverage", () => {
       generateId: vi.fn().mockImplementation(() => `task_${++taskIdCounter}`),
       addTask: vi.fn(),
       getTask: vi.fn(),
+      notifyTasksChange: vi.fn(),
     } as unknown as BackgroundTaskManager;
 
     const taskManager = {
@@ -439,6 +440,7 @@ describe("SubagentManager - Backgrounding Coverage", () => {
     const noNotifyBgTaskManager = {
       generateId: vi.fn().mockReturnValue("task_456"),
       addTask: vi.fn(),
+      notifyTasksChange: vi.fn(),
       getTask: vi.fn().mockReturnValue({
         id: "task_456",
         status: "running",
@@ -503,6 +505,7 @@ describe("SubagentManager - Backgrounding Coverage", () => {
     const noNotifyBgTaskManager = {
       generateId: vi.fn().mockReturnValue("task_789"),
       addTask: vi.fn(),
+      notifyTasksChange: vi.fn(),
       getTask: vi.fn().mockReturnValue({
         id: "task_789",
         status: "running",

--- a/packages/agent-sdk/tests/managers/subagentManager.backgroundSnapshot.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.backgroundSnapshot.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import { TaskManager } from "../../src/services/taskManager.js";
+import { SubagentManager } from "../../src/managers/subagentManager.js";
+import { ToolManager } from "../../src/managers/toolManager.js";
+import { BackgroundTaskManager } from "../../src/managers/backgroundTaskManager.js";
+import { AIManager } from "../../src/managers/aiManager.js";
+import { Container } from "../../src/utils/container.js";
+import type { BackgroundTask } from "../../src/types/processes.js";
+import type { SubagentConfiguration } from "../../src/utils/subagentParser.js";
+
+// Mock the managers whose real implementations are not needed here — but keep
+// the BackgroundTaskManager REAL: the regression under test is that finishing a
+// background subagent must push a fresh snapshot (onBackgroundTasksChange) with
+// the terminal status, exactly like shell tasks do on exit.
+vi.mock("../../src/managers/messageManager.js");
+vi.mock("../../src/managers/toolManager.js");
+vi.mock("../../src/managers/aiManager.js", () => ({
+  AIManager: vi.fn().mockImplementation(function () {
+    return {
+      sendAIMessage: vi.fn().mockResolvedValue("Test response"),
+      abortAIMessage: vi.fn(),
+    };
+  }),
+}));
+
+// Mock the memory service
+vi.mock("../../src/services/memory.js", () => ({
+  MemoryService: vi.fn().mockImplementation(() => ({
+    getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+    getAutoMemoryDirectory: vi.fn().mockReturnValue("/mock/auto-memory"),
+    ensureAutoMemoryDirectory: vi.fn().mockResolvedValue(undefined),
+    getAutoMemoryContent: vi.fn().mockResolvedValue(""),
+  })),
+  getCombinedMemoryContent: vi.fn().mockResolvedValue(""),
+}));
+
+describe("SubagentManager - background task terminal snapshots", () => {
+  let subagentManager: SubagentManager;
+  let container: Container;
+  let backgroundTaskManager: BackgroundTaskManager;
+  let snapshots: BackgroundTask[][];
+  let logFiles: string[] = [];
+
+  const testConfig: SubagentConfiguration = {
+    name: "TestAgent",
+    description: "Test agent",
+    systemPrompt: "System prompt",
+    tools: ["Read"],
+    model: "inherit",
+    filePath: "/test/agent.md",
+    scope: "user",
+    priority: 1,
+  };
+
+  const captureStatusFor = (taskId: string): string | undefined => {
+    const last = snapshots[snapshots.length - 1];
+    return last?.find((t) => t.id === taskId)?.status;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    snapshots = [];
+    logFiles = [];
+
+    container = new Container();
+
+    // Real BackgroundTaskManager whose snapshots are recorded. The task objects
+    // it hands out are mutated in place by SubagentManager; only notifyTasksChange
+    // pushes a snapshot to UI consumers (webview gate + hosts).
+    backgroundTaskManager = new BackgroundTaskManager(container, {
+      workdir: "/test",
+      callbacks: {
+        onBackgroundTasksChange: (tasks) => {
+          // Deep-copy at push time: SubagentManager mutates the SAME task
+          // objects in place, so retaining references would mask a missing
+          // terminal notify (the in-map status flips without a snapshot).
+          snapshots.push(tasks.map((t) => ({ ...t })));
+        },
+      },
+    });
+    container.register("BackgroundTaskManager", backgroundTaskManager);
+
+    container.register("ToolManager", {
+      list: vi.fn(() => [{ name: "Read" }]),
+      getPermissionManager: vi.fn(),
+    } as unknown as ToolManager);
+
+    const taskManager = {
+      on: vi.fn(),
+      listTasks: vi.fn().mockResolvedValue([]),
+      getTaskListId: vi.fn().mockReturnValue("test-task-list"),
+    } as unknown as TaskManager;
+    container.register("TaskManager", taskManager);
+
+    container.register("ConfigurationService", {
+      resolveGatewayConfig: () => ({ apiKey: "test", baseURL: "test" }),
+      resolveModelConfig: () => ({
+        model: "test-model",
+        fastModel: "test-fast-model",
+      }),
+      resolveMaxInputTokens: () => 1000,
+      resolveAutoMemoryEnabled: () => true,
+      resolveLanguage: () => "en",
+    });
+
+    subagentManager = new SubagentManager(container, {
+      workdir: "/test",
+      stream: false,
+    });
+  });
+
+  const createInstance = async () => {
+    const instance = await subagentManager.createInstance(testConfig, {
+      description: "d",
+      prompt: "p",
+      subagent_type: "t",
+    });
+    // Stub the (auto-mocked) MessageManager to return a completed assistant
+    // text message, which internalExecute turns into the background-task result.
+    vi.mocked(instance.messageManager.getMessages).mockReturnValue([
+      { role: "assistant", blocks: [{ type: "text", content: "Done" }] },
+    ] as unknown as ReturnType<typeof instance.messageManager.getMessages>);
+    return instance;
+  };
+
+  afterEach(() => {
+    for (const file of logFiles) {
+      if (fs.existsSync(file)) {
+        try {
+          fs.unlinkSync(file);
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    }
+  });
+
+  it("pushes a completed snapshot when a backgrounded subagent finishes (regression)", async () => {
+    const instance = await createInstance();
+    const taskId = await subagentManager.backgroundInstance(
+      instance.subagentId,
+    );
+    logFiles.push(backgroundTaskManager.getTask(taskId)!.outputPath!);
+
+    // The running snapshot was pushed when the task was registered.
+    expect(captureStatusFor(taskId)).toBe("running");
+
+    // Run the (backgrounded) subagent to completion.
+    await subagentManager.executeAgent(instance, "test prompt");
+
+    // Without the fix the last snapshot still says "running", permanently
+    // blocking IDE new-chat / history restore (hasRunningBackgroundTask).
+    expect(captureStatusFor(taskId)).toBe("completed");
+  });
+
+  it("pushes a completed snapshot when a runInBackground subagent finishes (regression)", async () => {
+    const instance = await createInstance();
+    const taskId = await subagentManager.executeAgent(
+      instance,
+      "test prompt",
+      undefined,
+      true,
+    );
+    expect(taskId).toBeTruthy();
+    logFiles.push(backgroundTaskManager.getTask(taskId)!.outputPath!);
+
+    // executeAgent returns before the background run finishes — the terminal
+    // snapshot must arrive once it does.
+    await vi.waitFor(() => expect(captureStatusFor(taskId)).toBe("completed"));
+  });
+
+  it("pushes a failed snapshot when a backgrounded subagent errors (regression)", async () => {
+    const instance = await createInstance();
+    const taskId = await subagentManager.backgroundInstance(
+      instance.subagentId,
+    );
+    logFiles.push(backgroundTaskManager.getTask(taskId)!.outputPath!);
+
+    const aiManager = (instance as unknown as { aiManager: AIManager })
+      .aiManager;
+    vi.spyOn(aiManager, "sendAIMessage").mockRejectedValue(
+      new Error("AI Error"),
+    );
+    vi.mocked(instance.messageManager.getMessages).mockReturnValue([]);
+
+    await expect(
+      subagentManager.executeAgent(instance, "test prompt"),
+    ).rejects.toThrow("AI Error");
+
+    expect(captureStatusFor(taskId)).toBe("failed");
+  });
+
+  it("keeps a stopped subagent task as killed instead of overwriting with failed", async () => {
+    const instance = await createInstance();
+    const taskId = await subagentManager.backgroundInstance(
+      instance.subagentId,
+    );
+    logFiles.push(backgroundTaskManager.getTask(taskId)!.outputPath!);
+
+    // User stops the task: stopTask marks it killed and pushes a snapshot.
+    expect(backgroundTaskManager.stopTask(taskId)).toBe(true);
+    expect(captureStatusFor(taskId)).toBe("killed");
+
+    // The in-flight AI run then aborts — surfaced as a thrown error inside
+    // internalExecute — which must NOT flip the terminal state to "failed".
+    const aiManager = (instance as unknown as { aiManager: AIManager })
+      .aiManager;
+    vi.spyOn(aiManager, "sendAIMessage").mockRejectedValue(
+      new Error("Aborted"),
+    );
+    vi.mocked(instance.messageManager.getMessages).mockReturnValue([]);
+
+    await expect(
+      subagentManager.executeAgent(instance, "test prompt"),
+    ).rejects.toThrow("Aborted");
+
+    expect(captureStatusFor(taskId)).toBe("killed");
+  });
+
+  it("keeps a killed runInBackground subagent as killed after its run resolves", async () => {
+    const instance = await createInstance();
+    // Make the AI call complete only after the test has a chance to stop it.
+    const aiManager = (instance as unknown as { aiManager: AIManager })
+      .aiManager;
+    vi.spyOn(aiManager, "sendAIMessage").mockImplementation(
+      () => new Promise<void>((r) => setTimeout(() => r(), 40)),
+    );
+
+    const taskId = await subagentManager.executeAgent(
+      instance,
+      "test prompt",
+      undefined,
+      true,
+    );
+    logFiles.push(backgroundTaskManager.getTask(taskId)!.outputPath!);
+
+    // User stops the task while it is still running.
+    expect(backgroundTaskManager.stopTask(taskId)).toBe(true);
+
+    // Once the in-flight run resolves, the terminal snapshot must still say
+    // killed — neither the internalExecute completion nor the executeAgent
+    // background wrapper may flip it back to "completed".
+    await vi.waitFor(() => expect(captureStatusFor(taskId)).toBe("killed"));
+    expect(backgroundTaskManager.getTask(taskId)?.status).toBe("killed");
+  });
+});

--- a/packages/agent-sdk/tests/managers/subagentManager.notification.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.notification.test.ts
@@ -62,6 +62,7 @@ describe("SubagentManager - Notification Deduplication", () => {
       generateId: vi.fn().mockReturnValue("task_123"),
       addTask: vi.fn(),
       getTask: vi.fn(),
+      notifyTasksChange: vi.fn(),
     } as unknown as BackgroundTaskManager;
 
     messageQueue = new MessageQueue();

--- a/packages/agent-sdk/tests/managers/subagentManager.test.ts
+++ b/packages/agent-sdk/tests/managers/subagentManager.test.ts
@@ -114,6 +114,7 @@ describe("SubagentManager background notification deduplication", () => {
         tasks.set(task.id, task);
       }),
       stopTask: stopTaskFn as unknown as (id: string) => boolean,
+      notifyTasksChange: vi.fn(),
     };
     container.register(
       "BackgroundTaskManager",
@@ -226,6 +227,7 @@ describe("SubagentManager registerPluginAgents", () => {
 
     const mockBackgroundTaskManager: Partial<BackgroundTaskManager> = {
       generateId: vi.fn().mockReturnValue("task_1"),
+      notifyTasksChange: vi.fn(),
     };
     container.register(
       "BackgroundTaskManager",
@@ -391,6 +393,7 @@ describe("SubagentManager.cleanup()", () => {
     const mockBackgroundTaskManager: Partial<BackgroundTaskManager> = {
       generateId: vi.fn().mockReturnValue("task_1"),
       cleanup: mockBackgroundTaskManagerCleanup as unknown as () => void,
+      notifyTasksChange: vi.fn(),
     };
     container.register(
       "BackgroundTaskManager",
@@ -460,6 +463,7 @@ describe("SubagentManager.deleteSubagent()", () => {
     container = new Container();
     container.register("BackgroundTaskManager", {
       generateId: vi.fn().mockReturnValue("task_1"),
+      notifyTasksChange: vi.fn(),
     });
     container.register("ToolManager", {
       initializeBuiltInTools: vi.fn(),


### PR DESCRIPTION
## 根因

后台子代理(background subagent)完成/失败时，SDK 只在内存里把 `BackgroundTaskManager` 的 task 对象改成 `completed`/`failed`，**从不调用 `notifyTasksChange()` 推新快照**（workflow 完成/失败同型缺陷）。UI 侧（webview `hasRunningBackgroundTask` gate + vscode/jb host 双防线）只消费 `updateBackgroundTasks` 快照，最后一次快照停在 addTask 时的 `running` → `some(running)` 恒真 → e2956015 引入的「后台任务运行期间禁止新建对话/加载历史」永久锁死，直到重启。

- 任务注册（running 快照）：`subagentManager.ts` runInBackground / backgroundInstance → `addTask`
- 终态只改不推：`subagentManager.ts` internalExecute 完成/失败分支；`executeAgent` 后台包装同型
- 宿主四端（vscode chatSession / jb StdioAgent / desktop desktopHost / CLI agentBridge）仅镜像 CLI `backgroundTasksChange`，无 host 侧自清——单点修复在 agent-sdk

## 修复

- subagentManager：internalExecute 完成/失败置终态后补 `notifyTasksChange()`（runInBackground 与用户转后台两条路径均汇于此）；kill 语义对齐 shell onExit——已 `killed` 的 task 不再被覆盖成 `completed`/`failed`
- workflowManager：完成/失败分支同补终态 notify（同类 gate 类型）
- webview 端额外收敛点按评审判定不补

## 验证

- 新回归测试 5 例（真实 BackgroundTaskManager + 深拷贝捕获快照）fail-without-fix 先红后绿
- agent-sdk `test:unit` 全量 256 文件 / 3704 passed / 2 skipped
- type-check / oxlint / prettier 全绿
- 3 个既有测试文件 partial BTM mock 补 `notifyTasksChange`（修复触发的夹具维护）
