### PR TITLE
fix(webview): 桌面「项目设置」SDD 开关随聚焦会话的项目切换

### DIFF
--- a/packages/webview/src/components/ChatApp.tsx
+++ b/packages/webview/src/components/ChatApp.tsx
@@ -283,6 +283,19 @@ export const ChatApp: React.FC<ChatAppProps> = ({
     (host?.type === "desktop"
       ? (host?.recentWorkdirs?.[0] ?? host?.workdir)
       : undefined);
+  // Desktop settings full-page 的「当前项目」：设置页挂在 root 实例（paneId
+  // undefined，无自己会话），其当前项目 = 聚焦 pane 的会话目录，host 以
+  // desktopWorkdirState.workdir（= desktopHost this.workdir，每次聚焦/激活更新）
+  // 权威推送。不能复用 effectiveWorkdir：它把窗口 recents 头优先于 host.workdir
+  // （该回退专为新会话 pane 防兄弟 pane 路径渗入而写）——recents 头 ≠ 当前聚焦
+  // 会话的项目时（恢复历史会话不写 recents），以 recents 头作「当前项目」会把
+  // host 按聚焦 pane 解析并回发的项目设置（workdir 归属键=聚焦 pane）当过期回复
+  // 丢弃，开关恒显另一项目的旧快照（与 PR #2152 AGENTS.md 同族：webview 端
+  // 「当前项目」身份取错）。pane 实例（有自己会话/新建会话）维持 effectiveWorkdir。
+  const settingsWorkdir =
+    paneId === undefined && host?.type === "desktop"
+      ? (host?.workdir ?? host?.recentWorkdirs?.[0])
+      : effectiveWorkdir;
   // The new-session pickers (workdir selector + worktree controls) show a
   // directory the USER chose, decoupled from the pane's session cwd: the
   // session cwd only wins when it is itself a user-chosen directory (it sits
@@ -407,6 +420,9 @@ export const ChatApp: React.FC<ChatAppProps> = ({
       ? paneGitBranches
       : null;
   const effectiveWorkdirRef = useRef(effectiveWorkdir);
+  // Settings full-page 归属守卫用的「当前项目」镜像（root 实例与 host.workdir
+  // 一致，见 settingsWorkdir 注释；pane 实例 == effectiveWorkdirRef）。
+  const settingsWorkdirRef = useRef(settingsWorkdir);
   // Desktop only: the panel group follows the session bound to this pane. The
   // cache key is the session id from the host-authoritative `desktopPanes`
   // push, or the pane's new-session bucket while no session is bound.
@@ -627,6 +643,10 @@ export const ChatApp: React.FC<ChatAppProps> = ({
   useEffect(() => {
     effectiveWorkdirRef.current = effectiveWorkdir;
   }, [effectiveWorkdir]);
+
+  useEffect(() => {
+    settingsWorkdirRef.current = settingsWorkdir;
+  }, [settingsWorkdir]);
 
   useEffect(() => {
     effectiveHostRef.current = effectiveHost;
@@ -1148,7 +1168,11 @@ export const ChatApp: React.FC<ChatAppProps> = ({
         // 目录（切目录/切会话后才落地）的慢回复直接丢弃（过期即弃），不再按
         // 到达时目录盖章（a3043966 土办法会把上个项目的数据标成当前项目）。
         if (!forThisPane(message)) break;
-        if (message.workdir !== effectiveWorkdirRef.current) break;
+        // 归属比对用本实例的「当前项目」：pane 实例 = 其会话目录（effectiveWorkdir）；
+        // root 全页设置实例 = host.workdir（聚焦 pane 目录，host 权威）——以窗口
+        // recents 头作比对会让聚焦会话已切项目后的回包被误判过期而丢弃（见
+        // settingsWorkdir 注释），设置页将一直显示上一项目快照。
+        if (message.workdir !== settingsWorkdirRef.current) break;
         // workdir 键控快照存 SessionUiStore；reducer 只镜像本次接受的值供
         // 项目设置视图渲染（镜像自身的归属守卫见 SettingsPage）。
         sessionUi.setProjectSettings(message.workdir, {
@@ -3097,12 +3121,15 @@ export const ChatApp: React.FC<ChatAppProps> = ({
         vscode.postMessage({
           command: "getAgentsContent",
           scope,
-          workdir: scope === "project" ? effectiveWorkdir : undefined,
+          // desktop host 按聚焦 pane 自行解析项目目录（见 desktopHost
+          // handleGetAgentsContent），此处 workdir 仅作 IDE 宿主备用一致性字段——
+          // 用与归属守卫同一「当前项目」身份，避免往线上传 recents 头的旧路径。
+          workdir: scope === "project" ? settingsWorkdir : undefined,
         })
       }
       onSaveAgentsContent={handleSaveAgentsContent}
       agentsSaving={agentsSaving}
-      workdir={effectiveWorkdir}
+      workdir={settingsWorkdir}
       saving={state.configurationLoading}
       initialNav={settingsNav}
       vscode={vscode}

--- a/packages/webview/tests/webview/projectSettingsAttribution.test.tsx
+++ b/packages/webview/tests/webview/projectSettingsAttribution.test.tsx
@@ -4,6 +4,7 @@ import {
   screen,
   fireEvent,
   act,
+  waitFor,
   sendHostMessage,
   fixtures,
   createMockVscode,
@@ -141,6 +142,90 @@ describe("projectSettings 回复归属（过期即弃 + workdir 键控）", () =
     expect(sddToggle().checked).toBe(false);
     expect(sessionUi.getProjectSettings("/work/a")).toEqual({
       enabledPlugins: {},
+    });
+  });
+});
+
+/**
+ * Bug 回归（客户反馈 Windows 桌面端，与 PR #2152 AGENTS.md 同族）：两个项目各
+ * 有对话，用户聚焦第二个项目的会话后进设置，「项目设置」的 SDD 开关仍显示第一个
+ * 项目的值。
+ *
+ * 根因：设置全页挂在 root 实例（无自己会话），其「当前项目」由 effectiveWorkdir
+ * 推导 = `state.workdir ?? recentWorkdirs[0] ?? host.workdir`——recents 头优先于
+ * host.workdir。该回退是为「新会话 pane 不得渗入兄弟 pane 路径」写的；但 recents
+ * 头 ≠ 用户当前聚焦的会话项目（恢复会话不写 recents），于是 host 按聚焦 pane 解析
+ * 并回发的项目设置（workdir=当前项目）被 ChatApp 归属守卫当成「过期项目」丢弃，
+ * SettingsPage 又以同一错误 workdir 信任并继续显示上一项目的快照。root 的「当前
+ * 项目」应以 host 推送的聚焦 pane workdir（desktopWorkdirState.workdir）为准。
+ */
+describe("desktop 设置页「项目设置」SDD 开关随聚焦会话的项目切换", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionUi.prune(new Set());
+  });
+
+  it("recents 头为项目 A 而聚焦会话已切到项目 B 时，开关显示 B 而非 A 的旧快照", async () => {
+    const mockVscode = createMockVscode();
+    const host = {
+      ...desktopHost(),
+      recentWorkdirs: ["/work/a"],
+    } as unknown as React.ComponentProps<typeof ChatApp>["host"];
+    const renderHost = (overrides: { workdir?: string }) =>
+      ({
+        ...host,
+        ...overrides,
+      }) as unknown as React.ComponentProps<typeof ChatApp>["host"];
+    const { rerender } = render(
+      <ChatApp vscode={mockVscode as unknown as VsCodeApi} host={host} />,
+    );
+    sendHostMessage(fixtures.authStatusResponse());
+
+    // 首次进入设置时聚焦项目 A 会话（host.workdir=/work/a）：加载 A 的启用快照
+    await openProjectSettingsView();
+    expect(mockVscode.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ command: "getProjectSettings" }),
+    );
+    act(() => {
+      sendHostMessage({
+        command: "projectSettings",
+        workdir: "/work/a",
+        enabledPlugins: { "sdd@builtin": true },
+      });
+    });
+    expect(sddToggle().disabled).toBe(false);
+    expect(sddToggle().checked).toBe(true);
+
+    // 关闭设置，聚焦切到项目 B 的会话：host 推送 workdir=/work/b（recents 头
+    // 不变——恢复历史会话不写 recents，见 desktopHost activateAgentInPane 注释）。
+    fireEvent.click(screen.getByRole("button", { name: "返回" }));
+    rerender(
+      <ChatApp
+        vscode={mockVscode as unknown as VsCodeApi}
+        host={renderHost({ workdir: "/work/b" })}
+      />,
+    );
+    // 设置页关闭期间 pane ChatApp 重挂载，需宿主重推 auth 快照才有输入框
+    // （与 settingsAgentsProjectSwitch.test.tsx 同因）。
+    sendHostMessage(fixtures.authStatusResponse());
+    await screen.findByTestId("message-input");
+
+    // 重开设置进入项目设置：host 按聚焦 pane 解析到项目 B，回包 workdir=/work/b
+    // （项目 B 未启用 SDD）。
+    await openProjectSettingsView();
+    act(() => {
+      sendHostMessage({
+        command: "projectSettings",
+        workdir: "/work/b",
+        enabledPlugins: {},
+      });
+    });
+    // 修复前：root 以 recents 头（/work/a）充当「当前项目」→ B 回包被归属守卫
+    // 丢弃，开关继续显示项目 A 旧快照（勾选 + 启用），断言先红。修复后：root 以
+    // host.workdir（聚焦 pane 的 /work/b）为当前项目，B 回包生效 → 开关未勾选。
+    await waitFor(() => {
+      expect(sddToggle().disabled).toBe(false);
+      expect(sddToggle().checked).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## 现象（客户反馈，Windows 桌面端）
两个项目各有对话（pane），用户打开/聚焦第二个项目的会话后进设置，「项目设置」内置 SDD 插件开关始终显示第一个项目的值，不随项目切换。

## 根因
与刚合 main 的 PR #2152（项目级 AGENTS.md 不随项目切换）**同族但漏在 webview 侧**：

- 桌面设置全页挂在 root 实例（paneId undefined，无自己会话），其「当前项目」身份此前 = `effectiveWorkdir` = `state.workdir ?? recentWorkdirs[0] ?? host.workdir`（**窗口 recents 头优先于 host.workdir**，该回退专为新会话 pane 防兄弟 pane 路径渗入而写）。
- host 侧已按 #2152 的 `agentForPane(pid)` 语义解析项目（pid 缺省回落 focusedPaneId），`projectSettings` 回包携带聚焦 pane 的真实 workdir。
- 恢复/聚焦历史会话**不写 recents**（desktopHost activateAgentInPane）→ recents 头 ≠ 当前聚焦会话的项目时，host 回发的 B 项目数据被 ChatApp 归属守卫（workdir 过期即弃）**误判为过期项目丢弃**，SettingsPage 又以同一错误 recents 头身份信任并**继续渲染项目 A 的旧快照**。

跨平台缺陷（非 Windows 专属；路径比对两端同源）。

## 修复
`packages/webview/src/components/ChatApp.tsx`：新增 `settingsWorkdir`——root desktop 设置实例的「当前项目」= **host.workdir（desktopHost 权威推送的聚焦 pane 目录，与回包 workdir 同源）**；pane/IDE 实例恒等于原 effectiveWorkdir。应用于：
1. `projectSettings` 归属守卫比对（不再误丢聚焦 pane 的回包）
2. `SettingsPage` `workdir` prop（渲染期归属守卫同步）
3. `getAgentsContent` project 参数（IDE 备用一致性字段）

desktop 包零改动（host 侧 #2152 已就绪）。

## 回归测试
`packages/webview/tests/webview/projectSettingsAttribution.test.tsx` 新增用例：recents 头为 A、聚焦会话切到 B → SDD 开关显示 B 而非 A 的旧快照。**fail-without-fix 先红**（B 回包被丢弃、开关仍勾选 A）→ 修复后绿。

## 验证
- webview 全量单测：114 文件 / 1048 tests 全绿
- webview type-check（tsc 4 tsconfig）/ oxlint / prettier / git diff --check 全绿
