### PR TITLE
fix(agent-sdk): mirror exec 位断言按平台门控，修 Windows CI (main) 红

### DIFF
--- a/packages/agent-sdk/tests/services/MarketplaceService.mirror.test.ts
+++ b/packages/agent-sdk/tests/services/MarketplaceService.mirror.test.ts
@@ -418,6 +418,8 @@ describe("officialMarketplaceMirror (zip snapshot)", () => {
         }),
         { "plugins/demo-plugin/hooks/run.sh": 0o755 },
       );
+      // Parsing layer — cross-platform: the zip's Unix external attrs must
+      // round-trip through the central-directory parser on any host OS.
       const modes = parseZipModes(zip);
       expect(modes["plugins/demo-plugin/hooks/run.sh"] & 0o111).toBeTruthy();
 
@@ -430,17 +432,29 @@ describe("officialMarketplaceMirror (zip snapshot)", () => {
       );
       expect(result).toBe("sha-exec");
 
+      // Both files must land on disk (exists on every platform); only the mode
+      // assertions below are POSIX-only.
       const scriptPath = path.join(
         installLocation,
         "plugins/demo-plugin/hooks/run.sh",
       );
       const stat = await fs.stat(scriptPath);
-      expect(stat.mode & 0o111).toBeTruthy();
-      // Plain file without exec bits stays non-executable.
       const jsonStat = await fs.stat(
         path.join(installLocation, ".wave-plugin", "marketplace.json"),
       );
-      expect(jsonStat.mode & 0o111).toBeFalsy();
+      // Filesystem layer — POSIX-only. Exec bits are a POSIX file-system
+      // concept: NTFS has no mode bits, so `stat().mode & 0o111` is always 0
+      // there and the chmod in officialMarketplaceMirror is a silent no-op.
+      // Windows also does not need the restored bit, because hooks are never
+      // executed by path — the hook runner always goes through a shell (Git
+      // Bash `bash.exe -c`, falling back to `cmd.exe /c`) and rewrites a `*.sh`
+      // command to `bash <script>` (src/services/hook.ts). So assert the
+      // on-disk bits only where the OS actually represents them.
+      if (process.platform !== "win32") {
+        expect(stat.mode & 0o111).toBeTruthy();
+        // Plain file without exec bits stays non-executable.
+        expect(jsonStat.mode & 0o111).toBeFalsy();
+      }
     });
 
     it("refuses an install location outside the marketplaces cache dir", async () => {


### PR DESCRIPTION
## 问题

`CI (Windows) [main]` 连续 4 次失败（每次 merge 后），全部同一原因：

- 文件：`packages/agent-sdk/tests/services/MarketplaceService.mirror.test.ts`
- 用例：`restores executable bits from zip external attrs (hooks/scripts)`
- 失败行：原 `:438` `expect(stat.mode & 0o111).toBeTruthy()`

NTFS 不表达 POSIX exec 位，Windows 上 `stat().mode & 0o111` 恒为 0 → 平台不兼容，非真 bug（该 commit 在 Linux job 通过）。

放大器：PR CI 不含 Windows job，`CI (Windows)` 只在 main push 跑 → 合并前无感、合并后必红。

## 修复

该用例有两层断言，只对 POSIX-only 的第二层做平台门控：

| 层 | 处理 |
| --- | --- |
| ① zip external attrs 解析（`parseZipModes` → `0o111`）、抽取成功、两个 `fs.stat`（文件落盘） | **所有平台都跑** |
| ② 落盘后文件系统 exec 位（`stat.mode & 0o111` 真/假） | 包进 `if (process.platform !== "win32")` |

不整例跳过：解析层是纯 buffer 逻辑，跨平台有效，且是该功能的核心不变式（external attrs 必须能解出 exec 位），跳过会白丢 Windows 上唯一还有意义的断言。原 `:443` 的 `toBeFalsy()` 在 Windows 上不是失败而是**恒真**（`mode & 0o111` 永远为 0），是空洞断言，故与 `:438` 一并门控。`fs.stat` 本身留在门控外——Windows 上同样验证文件已落盘。

Windows 不需要该 exec 位：hook runner 从不按路径执行，一律经 shell 调用（Git Bash `bash.exe -c`，无 Git Bash 退 `cmd.exe /c`），且把 `*.sh` 命令改写成 `bash <script>`（`src/services/hook.ts:182-215` / `:200-206`）。注释即按此准确表述，未写成「Windows 由插件 runner 另行处理」（runner 并不处理 exec 位）。

## 验证

- Linux 全量跑该文件：16/16 passed
- **Windows 分支双向探针**（临时副本 + `vi.spyOn(process, "platform", "get")` 强制 win32，探针已删除）：
  - mock win32 → 16/16 pass（门控被跳过，skip 生效）
  - 不 mock（真实 Linux）→ 同一探针 fail（证明断言非死代码、门控与平台强相关）
  - 说明：单纯 mock platform 无法本地复现原红（Linux 上 `chmod` 真生效，NTFS 行为不可模拟），故以「门控是否被走入」为观测量
- 相关子集：`MarketplaceService` 全家 + `pluginLoader` + `configurationService.plugins` + `hook.test` = 9 文件 178/178
- type-check / oxlint / prettier 全干净
- 横向扫同型隐患：全仓 `\.mode & 0o` 仅剩本次门控内两处

## 范围

仅测试文件，1 file changed, +17/−3，无产品代码改动。CI 配置未动（Windows job 进 PR 阶段的建议本期不采纳，保持现状）。
