### PR TITLE
test(e2e)+fix: 补 webview 切换/状态机 e2e 与真 host 集成层，并修其暴露的未处理 rejection 与 --stdio stdout 污染

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,3 +532,94 @@ jobs:
       - name: Real-browser e2e tests
         if: steps.filter.outputs.code == 'true'
         run: pnpm -F wave-webview run test:e2e
+
+  real-host-e2e:
+    runs-on: ubuntu-latest
+    # Post-merge real-host tests (packages/desktop/tests/integration/*.integration.test.ts):
+    # the real DesktopHost driving a real `wave --stdio` child process, with a
+    # local OpenAI-compatible model server instead of a real LLM. NOT a PR gate —
+    # the same timing as `integration`/`webview-e2e`: it needs a full build and a
+    # few minutes of process spawning, so it runs after merge to main (or via
+    # workflow_dispatch) and only reports through the CI run/mail.
+    # No display needed: the Electron shell is stubbed, the CLI is plain Node.
+    if: github.event_name != 'pull_request'
+
+    strategy:
+      matrix:
+        node-version: [22]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Detect code changes
+        uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            code:
+              - '!**/*.md'
+              - '!**/*.txt'
+              - '!docs/**'
+              - '!scripts/**'
+              - '!LICENSE'
+
+      # Cache pnpm/action-setup's install dir so concurrent jobs skip
+      # re-downloading the action tarball from codeload (429 rate limits,
+      # pnpm/action-setup#177). On hit we skip the action and prepend its bin
+      # dirs to PATH ourselves. The key pins the pnpm version — keep it in
+      # sync with the `version` input below (package.json "packageManager").
+      - name: Cache pnpm install
+        if: steps.filter.outputs.code == 'true'
+        id: pnpm-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/setup-pnpm
+          key: pnpm-setup-v5-${{ runner.os }}-${{ runner.arch }}-11.9.0
+
+      - name: Add cached pnpm to PATH
+        if: steps.filter.outputs.code == 'true' && steps.pnpm-cache.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          # Mirror pnpm/action-setup's env: node_modules/.bin/bin holds the
+          # self-updated target version (higher precedence), node_modules/.bin
+          # the bootstrap symlink. GITHUB_PATH is used verbatim, so write
+          # native Windows paths on Windows runners.
+          PNPM_HOME="${USERPROFILE:-$HOME}/.cache/setup-pnpm/node_modules/.bin"
+          PNPM_BIN="$PNPM_HOME/bin"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            PNPM_HOME="${PNPM_HOME//\//\\}"
+            PNPM_BIN="${PNPM_BIN//\//\\}"
+          fi
+          echo "$PNPM_HOME" >> "$GITHUB_PATH"
+          echo "$PNPM_BIN" >> "$GITHUB_PATH"
+          echo "PNPM_HOME=$PNPM_HOME" >> "$GITHUB_ENV"
+
+      - name: Setup pnpm (cache miss)
+        if: steps.filter.outputs.code == 'true' && steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: pnpm/action-setup@v5
+        with:
+          version: 11.9.0
+          dest: ~/.cache/setup-pnpm
+          run_install: false
+
+      - name: Setup Node.js
+        if: steps.filter.outputs.code == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+
+      - name: Install dependencies
+        if: steps.filter.outputs.code == 'true'
+        run: pnpm install --frozen-lockfile
+
+      # The suite drives the workspace CLI (packages/code/bin/wave-code.js →
+      # dist/bundle/wave.mjs) and imports the built SDK, so a full build is required.
+      - name: Build
+        if: steps.filter.outputs.code == 'true'
+        run: pnpm build
+
+      - name: Real-host integration tests
+        if: steps.filter.outputs.code == 'true'
+        run: pnpm -F wave-desktop run test:realhost

--- a/packages/agent-sdk/src/services/session.ts
+++ b/packages/agent-sdk/src/services/session.ts
@@ -1039,7 +1039,10 @@ export async function handleSessionRestoration(
     }
 
     if (sessionToRestore) {
-      console.log(`Restoring session: ${sessionToRestore.id}`);
+      // Diagnostics only — never stdout: `wave --stdio`'s stdout carries the
+      // JSON-RPC channel, and a stray line there makes the host log a parse
+      // failure for every restore (the logger writes to the log file).
+      logger.info(`Restoring session: ${sessionToRestore.id}`);
 
       // // Initialize from session data
       // this.initializeFromSession();

--- a/packages/agent-sdk/tests/services/session.extra.test.ts
+++ b/packages/agent-sdk/tests/services/session.extra.test.ts
@@ -439,5 +439,40 @@ describe("session service - additional coverage", () => {
       // the throw means the session truly does not exist anywhere.
       expect(fs.readdir).toHaveBeenCalled();
     });
+
+    it("reports the restore through the logger, never through stdout", async () => {
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      mockJsonlRead.mockResolvedValue([
+        {
+          id: "msg-1",
+          role: "user",
+          timestamp: "2026-07-27T10:00:00.000Z",
+          blocks: [],
+        },
+      ]);
+      // stdout is the `wave --stdio` JSON-RPC channel: one stray line there
+      // makes the host skip that line and log a parse failure for the whole
+      // payload (the restore diagnostic used to be a plain console.log).
+      const stdout = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+      const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      const restored = await handleSessionRestoration(
+        validSessionId,
+        false,
+        workdir,
+      );
+
+      expect(restored?.id).toBe(validSessionId);
+      expect(consoleLog).not.toHaveBeenCalled();
+      expect(stdout).not.toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(
+        `Restoring session: ${validSessionId}`,
+      );
+
+      consoleLog.mockRestore();
+      stdout.mockRestore();
+    });
   });
 });

--- a/packages/code/src/stdio-cli.ts
+++ b/packages/code/src/stdio-cli.ts
@@ -31,7 +31,29 @@ function crashHandler(kind: string, error: unknown): void {
   process.exit(1);
 }
 
+/**
+ * stdout carries the JSON-RPC channel in --stdio mode (one JSON object per
+ * line); stderr is reserved for logger output (see stdioServer.ts). A single
+ * stray `console.log` anywhere in the SDK/host dependency graph therefore
+ * corrupts that channel: the host skips the unparseable line, losing whatever
+ * JSON-RPC payload shared it (this is how `SessionService`'s
+ * `console.log("Restoring session: …")` showed up as
+ * `[wave-jsonrpc] Failed to parse: …` on every restore).
+ *
+ * Fixing individual call sites is a losing race against a graph this big, so
+ * stdio mode forces the contract instead: only `console.error`/`console.warn`
+ * (already stderr) may print, everything else is redirected to stderr.
+ */
+export function guardStdoutForJsonRpc(): void {
+  for (const level of ["log", "info", "debug"] as const) {
+    console[level] = (...args: unknown[]) => {
+      console.error(...args);
+    };
+  }
+}
+
 export async function startStdioCli(): Promise<void> {
+  guardStdoutForJsonRpc();
   // Registered here (stdio mode only): the interactive CLI keeps Node's
   // default behavior so the terminal shows the crash stack directly.
   process.on("uncaughtException", (error) =>

--- a/packages/code/tests/stdio/stdioStdoutGuard.test.ts
+++ b/packages/code/tests/stdio/stdioStdoutGuard.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, expect, it, vi } from "vitest";
+
+vi.mock("wave-agent-sdk");
+// stdio mode is only the wiring under test here — never start a real server
+// (it would attach readline to the worker's stdin and keep the process alive).
+const startSpy = vi.fn();
+vi.mock("../../src/stdio/stdioServer.js", () => ({
+  StdioServer: vi.fn().mockImplementation(function () {
+    return { start: startSpy, stop: vi.fn() };
+  }),
+}));
+
+import { guardStdoutForJsonRpc, startStdioCli } from "../../src/stdio-cli.js";
+
+/**
+ * `wave --stdio` speaks JSON-RPC on stdout (one JSON object per line) and
+ * reserves stderr for logger output, so any `console.log` in the dependency
+ * graph corrupts the channel: the host drops the unparseable line *and* the
+ * payload that shared it. `SessionService` used to do exactly that on every
+ * session restore, which the host surfaced as
+ * `[wave-jsonrpc] Failed to parse: Restoring session: <id>`.
+ *
+ * The console IS the subject under test, so it is reached through
+ * `consoleLevel()` instead of `console.x` member syntax (banned in tests by
+ * oxlint's no-console). Vitest intercepts `console.*` itself, so the
+ * assertions target the redirection the guard installs (console.log/info/debug
+ * → console.error, i.e. stderr) rather than the process stream.
+ */
+type ConsoleLevel = "log" | "info" | "debug" | "error" | "warn";
+const consoleLevel = (level: ConsoleLevel): unknown => console[level];
+const setConsoleLevel = (level: ConsoleLevel, value: unknown): void => {
+  console[level] = value as (...args: unknown[]) => void;
+};
+
+const LEVELS: ConsoleLevel[] = ["log", "info", "debug", "error", "warn"];
+const snapshot = () =>
+  Object.fromEntries(LEVELS.map((level) => [level, consoleLevel(level)]));
+
+/** Drop the crash handlers startStdioCli registers (they call process.exit). */
+function removeCrashHandlers(before: {
+  exception: NodeJS.UncaughtExceptionListener[];
+  rejection: NodeJS.UnhandledRejectionListener[];
+}): void {
+  for (const listener of process.listeners("uncaughtException")) {
+    if (!before.exception.includes(listener)) {
+      process.removeListener("uncaughtException", listener);
+    }
+  }
+  for (const listener of process.listeners("unhandledRejection")) {
+    if (!before.rejection.includes(listener)) {
+      process.removeListener("unhandledRejection", listener);
+    }
+  }
+}
+
+const originalConsole = snapshot();
+let listeners = {
+  exception: [] as NodeJS.UncaughtExceptionListener[],
+  rejection: [] as NodeJS.UnhandledRejectionListener[],
+};
+
+afterEach(() => {
+  for (const level of LEVELS) setConsoleLevel(level, originalConsole[level]);
+  removeCrashHandlers(listeners);
+  vi.clearAllMocks();
+});
+
+it("moves console.log/info/debug onto stderr when stdio mode starts", async () => {
+  listeners = {
+    exception: process.listeners("uncaughtException"),
+    rejection: process.listeners("unhandledRejection"),
+  };
+
+  await startStdioCli();
+
+  expect(startSpy).toHaveBeenCalled();
+  // The three stdout-bound levels are redirected…
+  expect(consoleLevel("log")).not.toBe(originalConsole.log);
+  expect(consoleLevel("info")).not.toBe(originalConsole.info);
+  expect(consoleLevel("debug")).not.toBe(originalConsole.debug);
+  // …and the stderr-bound ones are left exactly as they were.
+  expect(consoleLevel("error")).toBe(originalConsole.error);
+  expect(consoleLevel("warn")).toBe(originalConsole.warn);
+});
+
+it("forwards the redirected levels to console.error with their arguments", () => {
+  const forwarded: unknown[][] = [];
+  setConsoleLevel("error", (...args: unknown[]) => {
+    forwarded.push(args);
+  });
+
+  guardStdoutForJsonRpc();
+  (consoleLevel("log") as (...args: unknown[]) => void)(
+    "Restoring session: abc-123",
+  );
+  (consoleLevel("info") as (...args: unknown[]) => void)("info line");
+  (consoleLevel("debug") as (...args: unknown[]) => void)("debug line");
+
+  // Everything landed on the stderr-bound channel, in order, with its args.
+  expect(forwarded).toEqual([
+    ["Restoring session: abc-123"],
+    ["info line"],
+    ["debug line"],
+  ]);
+});
+
+it("does not touch the console just by importing the module", async () => {
+  // Guarding at import time would silently redirect the interactive Ink CLI's
+  // output — stdio mode is the only place the contract applies.
+  vi.resetModules();
+
+  await import("../../src/stdio-cli.js");
+
+  expect(snapshot()).toEqual(originalConsole);
+});

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -22,6 +22,7 @@
     "test:coverage": "vitest run --coverage",
     "test:unit": "vitest run",
     "test:unit:coverage": "vitest run --coverage",
+    "test:realhost": "vitest run --config vitest.integration.config.ts",
     "lint": "oxlint",
     "format": "prettier --write ."
   },

--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -2538,7 +2538,7 @@ export class DesktopHost {
     // round trip (SSH hop) must not delay the session switch. The cache shows
     // immediately; refreshWorkflowRuns supersedes it when the response lands.
     if (agent) {
-      void this.refreshWorkflowRuns(paneId).catch(() => {});
+      void this.refreshWorkflowRuns(paneId);
     }
     // The pane binding may have changed while a workflow-runs refresh was in
     // flight (a restore completed / a new session selected). Re-read everything
@@ -3015,7 +3015,19 @@ export class DesktopHost {
   private async refreshWorkflowRuns(paneId: string): Promise<void> {
     const agent = this.agentForPane(paneId);
     if (!agent) return;
-    const runs = await agent.getWorkflowRuns();
+    let runs: Awaited<ReturnType<typeof agent.getWorkflowRuns>>;
+    try {
+      runs = await agent.getWorkflowRuns();
+    } catch (error) {
+      // Best-effort refresh: both callers fire this without awaiting (a
+      // background-task notification and a session switch), so a rejection
+      // here used to surface as an unhandled promise rejection — fatal under
+      // Node's default policy, and reachable on every config write, which
+      // recreates the agents and kills the in-flight RPC's session
+      // ("Session not found"). The cached runs stay as the last known state.
+      console.warn("[DesktopHost] 获取工作流运行失败:", error);
+      return;
+    }
     // The pane may have switched to another session while the RPC was in
     // flight — never write a stale session's runs into the new one.
     if (this.agentForPane(paneId) !== agent) return;

--- a/packages/desktop/tests/integration/realHostHarness.ts
+++ b/packages/desktop/tests/integration/realHostHarness.ts
@@ -1,0 +1,382 @@
+/**
+ * Harness for the real-host integration suite (Part B).
+ *
+ * Boots the *real* `DesktopHost` (real fs, real JSON-RPC, real `wave --stdio`
+ * child process) and captures the host→webview message stream. Only the
+ * Electron shell is stubbed — see the vitest integration config.
+ *
+ * Also provides a throwaway local model server so a full turn
+ * (sendMessage → CLI → model HTTP → streamed reply → webview message) can run
+ * offline and deterministically instead of calling a real LLM.
+ */
+
+import * as fs from "fs";
+import * as http from "http";
+import * as os from "os";
+import * as path from "path";
+import type { BrowserWindow } from "electron";
+import { HOST_CHANNEL } from "../../src/main/channels";
+import { ConfigStore } from "../../src/main/configStore";
+import { DesktopHost } from "../../src/main/desktopHost";
+import { LOCAL_HOST } from "../../src/main/sshHosts";
+
+/** Must match `vitest.integration.config.ts`. */
+export const REALHOST_ROOT = path.join(os.tmpdir(), "wave-desktop-realhost");
+export const REALHOST_HOME = path.join(REALHOST_ROOT, "home");
+export const STORE_PATH = path.join(
+  REALHOST_ROOT,
+  "userData",
+  "wave-desktop.json",
+);
+
+export const DIR_A = path.join(REALHOST_ROOT, "ws", "project-a");
+export const DIR_B = path.join(REALHOST_ROOT, "ws", "project-b");
+
+/** A host→webview message (shape is asserted per test). */
+export type HostMessage = Record<string, unknown> & { command?: string };
+
+/**
+ * Wipe the throwaway HOME/userData and recreate the two workspaces. Returns
+ * the realpath'd workdirs: the CLI encodes the session directory from the
+ * resolved path, so tests must use the same form or transcript files land in
+ * an unexpected bucket.
+ */
+export function resetRealHostState(): { dirA: string; dirB: string } {
+  fs.rmSync(REALHOST_ROOT, { recursive: true, force: true });
+  fs.mkdirSync(REALHOST_HOME, { recursive: true });
+  fs.mkdirSync(DIR_A, { recursive: true });
+  fs.mkdirSync(DIR_B, { recursive: true });
+  return {
+    dirA: fs.realpathSync(DIR_A),
+    dirB: fs.realpathSync(DIR_B),
+  };
+}
+
+/**
+ * `<HOME>/.wave/projects/<encoded workdir>` — mirrors the CLI's
+ * `pathEncoder.encodeSync` (strip the leading separator, `/`→`-`, spaces→`_`).
+ */
+export function projectDir(workdir: string): string {
+  const encoded = workdir
+    .replace(/^[/\\]/, "")
+    .replace(/[/\\]/g, "-")
+    .replace(/\s+/g, "_");
+  return path.join(REALHOST_HOME, ".wave", "projects", encoded);
+}
+
+/** All transcript files for a workdir, newest last. */
+export function transcriptFiles(workdir: string): string[] {
+  const dir = projectDir(workdir);
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".jsonl"))
+    .map((f) => path.join(dir, f));
+}
+
+/** Rewrite a transcript with a truncated tail (a killed append — PR #2137). */
+export function truncateTranscriptTail(workdir: string): void {
+  const files = transcriptFiles(workdir);
+  const file = files[files.length - 1];
+  const content = fs.readFileSync(file, "utf-8");
+  fs.writeFileSync(
+    file,
+    `${content}{"type":"assistant","id":"cut-off","blocks":[{"type":"te`,
+    "utf-8",
+  );
+}
+
+/** Flat view of a `desktopSessionTree` push. */
+export interface TreeSession {
+  sessionId: string;
+  title: string;
+  workdir: string;
+}
+
+export interface RealHost {
+  host: DesktopHost;
+  store: ConfigStore;
+  /** Every host→webview message, in order. */
+  messages: HostMessage[];
+  /** Messages with the given command. */
+  of<M extends HostMessage = HostMessage>(command: string): M[];
+  /** Latest message with the given command. */
+  last<M extends HostMessage = HostMessage>(command: string): M | undefined;
+  /** Messages containing a command, in order, resolved when it appears. */
+  waitFor<M extends HostMessage = HostMessage>(
+    command: string,
+    opts?: { timeout?: number; predicate?: (m: M) => boolean },
+  ): Promise<M>;
+  /** Drop the recorded messages — call before an action so waits can't match a stale one. */
+  clear(): void;
+  /** The session the pane currently shows (undefined when unbound). */
+  paneSessionId(paneId?: string): string | undefined;
+  /** Sessions from the latest `desktopSessionTree`. */
+  tree(): TreeSession[];
+  /** Everything the host streamed into a pane (concatenated updateStreamingContent chunks). */
+  streamedText(paneId?: string): string;
+  /** Run one real turn in a pane; resolves with the messages it produced. */
+  turn(text: string, paneId?: string): Promise<HostMessage[]>;
+  close(): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Unhandled-rejection guard
+// ---------------------------------------------------------------------------
+
+/**
+ * The real CLI rejects in-flight RPCs with "Session not found" while it is
+ * recreating a session (`updateConfig` → destroy + `Agent.create`), which the
+ * host triggers for every live agent on a settings write / login / plugin
+ * change — and `backgroundTasksChange` notifications reach the host during that
+ * same window. Any host-side promise that forgets a catch therefore surfaces
+ * here as an unhandled rejection (fatal under Node's default policy), and the
+ * unit layer can never see it because every RPC is mocked there.
+ *
+ * The suite registers its own listener (so the leak survives long enough to be
+ * reported) and fails the test for *any* rejection — there is no allow-list:
+ * the one known leak (refreshWorkflowRuns) is fixed, so a new one must be red.
+ * Vitest additionally fails the run on unhandled errors, since
+ * `dangerouslyIgnoreUnhandledErrors` is NOT set in the integration config.
+ */
+const unexpectedRejections: unknown[] = [];
+
+process.on("unhandledRejection", (reason) => {
+  unexpectedRejections.push(reason);
+});
+
+/** Drops the rejections seen so far — call before the action under test. */
+export function takeUnexpectedRejections(): unknown[] {
+  return unexpectedRejections.splice(0, unexpectedRejections.length);
+}
+
+/** Call from `afterEach`: fails the test when the host leaked a rejection. */
+export function assertNoUnexpectedRejections(): void {
+  const leaked = takeUnexpectedRejections();
+  if (leaked.length === 0) return;
+  const details = leaked
+    .map((r) => (r instanceof Error ? (r.stack ?? r.message) : String(r)))
+    .join("\n---\n");
+  throw new Error(
+    `Unexpected unhandled rejection(s) from the host:\n${details}`,
+  );
+}
+
+export function createRealHost(): RealHost {
+  const store = new ConfigStore(STORE_PATH);
+  const host = new DesktopHost(store);
+  const messages: HostMessage[] = [];
+  /**
+   * pane → sessionId, kept OUTSIDE `messages` so it survives `clear()` (tests
+   * clear the buffer between turns to keep waits unambiguous, but still need
+   * to ask which session a pane shows).
+   */
+  const paneBindings = new Map<string, string | undefined>();
+  /** Survives `clear()` for the same reason as `paneBindings`. */
+  let focusedPane = "pane-1";
+  const win = {
+    webContents: {
+      send: (channel: string, msg: unknown) => {
+        if (channel !== HOST_CHANNEL) return;
+        const m = msg as HostMessage;
+        messages.push(m);
+        if (m.command === "desktopPanes") {
+          if (typeof m.focusedPaneId === "string")
+            focusedPane = m.focusedPaneId;
+          for (const p of m.panes as Array<{
+            paneId: string;
+            sessionId?: string;
+          }>) {
+            paneBindings.set(p.paneId, p.sessionId);
+          }
+        } else if (m.command === "updateCurrentSession") {
+          paneBindings.set(
+            m.paneId as string,
+            (m.session as { id?: string } | undefined)?.id,
+          );
+        }
+      },
+    },
+    isDestroyed: () => false,
+    getContentSize: () => [1440, 900],
+  } as unknown as BrowserWindow;
+  host.setMainWindow(win);
+
+  const of = <M extends HostMessage = HostMessage>(command: string) =>
+    messages.filter((m) => m.command === command) as M[];
+
+  const waitUntil = async (
+    label: string,
+    predicate: () => boolean,
+    opts: { timeout?: number } = {},
+  ): Promise<void> => {
+    const deadline = Date.now() + (opts.timeout ?? 30_000);
+    while (Date.now() < deadline) {
+      if (predicate()) return;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    throw new Error(
+      `Timed out waiting for ${label}. Messages: ${JSON.stringify(messages.slice(-12), null, 2)}`,
+    );
+  };
+
+  const waitFor = async <M extends HostMessage = HostMessage>(
+    command: string,
+    opts: { timeout?: number; predicate?: (m: M) => boolean } = {},
+  ): Promise<M> => {
+    const deadline = Date.now() + (opts.timeout ?? 30_000);
+    for (;;) {
+      const found = of<M>(command).find((m) => opts.predicate?.(m) ?? true);
+      if (found) return found;
+      if (Date.now() > deadline) break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    throw new Error(
+      `Timed out waiting for "${command}". Messages: ${JSON.stringify(messages.slice(-12), null, 2)}`,
+    );
+  };
+
+  const focusedPaneId = () => focusedPane;
+
+  const paneSessionId = (paneId?: string) =>
+    paneBindings.get(paneId ?? focusedPaneId());
+
+  const tree = (): TreeSession[] =>
+    (
+      (of("desktopSessionTree").at(-1)?.groups ?? []) as Array<{
+        workdir: string;
+        sessions: Array<{ sessionId: string; title: string }>;
+      }>
+    ).flatMap((g) =>
+      g.sessions.map((s) => ({
+        sessionId: s.sessionId,
+        title: s.title,
+        workdir: g.workdir,
+      })),
+    );
+
+  const streamedText = (paneId?: string) =>
+    messages
+      .filter(
+        (m) =>
+          m.command === "updateStreamingContent" &&
+          (paneId === undefined || m.paneId === paneId),
+      )
+      .map((m) => (m.chunk as string) ?? "")
+      .join("");
+
+  const turn = async (
+    text: string,
+    paneId?: string,
+  ): Promise<HostMessage[]> => {
+    await waitFor("setInitialState", {
+      predicate: (m) => paneId === undefined || m.paneId === paneId,
+    });
+    const start = messages.length;
+    await host.handleWebviewMessage({
+      command: "sendMessage",
+      text,
+      ...(paneId ? { paneId } : {}),
+    });
+    await waitUntil("turn end", () =>
+      messages
+        .slice(start)
+        .some(
+          (m) =>
+            m.command === "endStreaming" &&
+            (paneId === undefined || m.paneId === paneId),
+        ),
+    );
+    return messages.slice(start);
+  };
+
+  const clear = () => {
+    messages.length = 0;
+  };
+
+  return {
+    host,
+    store,
+    messages,
+    of,
+    last: (command: string) => of(command).at(-1),
+    waitFor,
+    clear,
+    paneSessionId,
+    tree,
+    streamedText,
+    turn,
+    close: async () => {
+      await host.dispose();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Local model server — an OpenAI-compatible /chat/completions endpoint
+// ---------------------------------------------------------------------------
+
+export interface FakeModelServer {
+  /** Point configuration.baseURL here. */
+  baseURL: string;
+  /** Raw request bodies the CLI sent (order = call order). */
+  requests: Array<Record<string, unknown>>;
+  /** Queue the text the model streams back; the last reply repeats. */
+  reply(...texts: string[]): void;
+  /** Requests received so far that carried this substring in the payload. */
+  sawRequest(match: string): boolean;
+  close(): Promise<void>;
+}
+
+export async function startFakeModelServer(): Promise<FakeModelServer> {
+  const requests: Array<Record<string, unknown>> = [];
+  let replies: string[] = ["OK"];
+
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (c) => (body += c));
+    req.on("end", () => {
+      try {
+        requests.push(JSON.parse(body) as Record<string, unknown>);
+      } catch {
+        requests.push({ raw: body });
+      }
+      const text =
+        replies.length > 1 ? (replies.shift() as string) : replies[0];
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+      });
+      const chunk = (delta: unknown, extra: Record<string, unknown> = {}) =>
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-realhost",
+            object: "chat.completion.chunk",
+            created: 1_700_000_000,
+            model: "test-model",
+            choices: [{ index: 0, delta, finish_reason: null }],
+            ...extra,
+          })}\n\n`,
+        );
+      chunk({ role: "assistant", content: text });
+      chunk({}, { choices: [{ index: 0, delta: {}, finish_reason: "stop" }] });
+      res.write("data: [DONE]\n\n");
+      res.end();
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as { port: number }).port;
+  return {
+    baseURL: `http://127.0.0.1:${port}/v1`,
+    requests,
+    reply: (...texts: string[]) => {
+      replies = texts;
+    },
+    sawRequest: (match: string) =>
+      requests.some((r) => JSON.stringify(r).includes(match)),
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+export { LOCAL_HOST };

--- a/packages/desktop/tests/integration/realHostSessionFlow.integration.test.ts
+++ b/packages/desktop/tests/integration/realHostSessionFlow.integration.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Real-host integration suite (Part B) — session lifecycle.
+ *
+ * Every case drives the real DesktopHost against a real `wave --stdio` child
+ * process and a real local model server, so it covers the cross-process seams
+ * the webview e2e layer (mock host) cannot: JSON-RPC round trips, transcript
+ * files on disk, and host↔CLI state convergence.
+ *
+ * Regressions guarded here (the webview-side halves live in `packages/webview/e2e`):
+ *  - session restore from a real transcript, including a truncated tail (#2137)
+ *  - deleting a session must not be revived by the Ctrl+Tab cycle (#2150)
+ *  - multi-pane / multi-project sessions stay isolated (FR-031/FR-020)
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import {
+  assertNoUnexpectedRejections,
+  createRealHost,
+  projectDir,
+  resetRealHostState,
+  startFakeModelServer,
+  transcriptFiles,
+  truncateTranscriptTail,
+  type FakeModelServer,
+  type RealHost,
+} from "./realHostHarness";
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+let ctx: RealHost;
+let model: FakeModelServer;
+let dirA: string;
+let dirB: string;
+
+beforeEach(async () => {
+  const dirs = resetRealHostState();
+  dirA = dirs.dirA;
+  dirB = dirs.dirB;
+  model = await startFakeModelServer();
+  model.reply("回复：A-OK");
+  ctx = createRealHost();
+  // Point the real CLI at the local model server — no real LLM, no network.
+  ctx.store.setConfiguration({
+    apiKey: "test-key",
+    baseURL: model.baseURL,
+    model: "test-model",
+    fastModel: "test-model",
+  });
+});
+
+afterEach(async () => {
+  await ctx.close();
+  await model.close();
+  assertNoUnexpectedRejections();
+});
+
+/** `desktopReady` → pick a workdir → first real session bound to the pane. */
+async function openProject(dir: string): Promise<void> {
+  await ctx.host.handleWebviewMessage({ command: "desktopReady" });
+  await ctx.host.handleWebviewMessage({
+    command: "desktopSelectRecentWorkdir",
+    path: dir,
+    host: "local",
+  });
+  await ctx.waitFor("setInitialState");
+}
+
+describe("real host · session lifecycle", () => {
+  it("boots the CLI and binds a real session to the pane", async () => {
+    await ctx.host.handleWebviewMessage({ command: "desktopReady" });
+
+    // One unbound pane, no workdir — the launch placeholder.
+    expect(ctx.of("desktopPanes")).toHaveLength(1);
+    expect(ctx.paneSessionId()).toBeUndefined();
+    expect(ctx.last("desktopWorkdirState")?.workdir).toBeUndefined();
+
+    await ctx.host.handleWebviewMessage({
+      command: "desktopSelectRecentWorkdir",
+      path: dirA,
+      host: "local",
+    });
+    const state = await ctx.waitFor("setInitialState");
+    const sessionId = (state.session as { id: string }).id;
+
+    // The sessionId and workdir are the real CLI's answers to `initialize`.
+    expect(sessionId).toMatch(UUID);
+    expect(state.workdir).toBe(dirA);
+    expect(state.messages).toEqual([]);
+    expect(state.isAuthenticated).toBe(false);
+    expect(ctx.paneSessionId()).toBe(sessionId);
+  });
+
+  it("runs a real turn: CLI → model HTTP → streamed reply → transcript on disk", async () => {
+    await openProject(dirA);
+    model.reply("这是真实回复。");
+
+    await ctx.turn("你好");
+
+    // The user message and the streamed assistant reply reached the webview.
+    const userPushes = ctx
+      .of("appendMessage")
+      .filter((m) => (m.message as { role?: string }).role === "user");
+    expect(userPushes).toHaveLength(1);
+    expect(JSON.stringify(userPushes[0].message)).toContain("你好");
+    expect(ctx.streamedText()).toContain("这是真实回复。");
+    expect(ctx.of("endStreaming").length).toBeGreaterThan(0);
+
+    // The model received the user text (the request really left the process).
+    expect(model.sawRequest("你好")).toBe(true);
+
+    // …and the turn was flushed to a real transcript file.
+    const files = transcriptFiles(dirA);
+    expect(files).toHaveLength(1);
+    const lines = readFileSync(files[0], "utf-8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    expect(lines[0]).toMatchObject({ type: "metadata", workdir: dirA });
+    const turns = lines.filter((l) => l.role);
+    expect(turns.map((l) => l.role)).toEqual(["user", "assistant"]);
+    expect(JSON.stringify(turns[0])).toContain("你好");
+    expect(JSON.stringify(turns[1])).toContain("这是真实回复。");
+
+    // The sidebar entry is derived from the real transcript's first message.
+    const mine = ctx.tree().find((s) => s.sessionId === ctx.paneSessionId());
+    expect(mine).toMatchObject({ title: "你好", workdir: dirA });
+  });
+
+  it("restores a historical session's context from its transcript", async () => {
+    await openProject(dirA);
+    await ctx.turn("第一条");
+    const firstId = ctx.paneSessionId() as string;
+
+    await ctx.host.handleWebviewMessage({ command: "newSession" });
+    await ctx.waitFor("setInitialState", {
+      predicate: (m) => (m.session as { id?: string }).id !== firstId,
+    });
+    await ctx.turn("第二条");
+    const secondId = ctx.paneSessionId() as string;
+    expect(secondId).not.toBe(firstId);
+    expect(ctx.tree().map((s) => s.sessionId)).toEqual([secondId, firstId]);
+
+    // Switch back: the host spawns a fresh agent + real `restoreSession` RPC.
+    ctx.clear();
+    await ctx.host.handleWebviewMessage({
+      command: "desktopSelectSession",
+      workdir: dirA,
+      sessionId: firstId,
+    });
+    const restored = await ctx.waitFor("setInitialState", {
+      predicate: (m) => (m.session as { id?: string }).id === firstId,
+    });
+
+    expect(ctx.paneSessionId()).toBe(firstId);
+    const restoredMessages = JSON.stringify(restored.messages);
+    expect(restoredMessages).toContain("第一条");
+    expect(restoredMessages).toContain("回复：A-OK");
+    expect(restoredMessages).not.toContain("第二条");
+  });
+
+  it("recovers a session whose transcript tail was cut off by a kill (#2137)", async () => {
+    await openProject(dirA);
+    await ctx.turn("截断前的消息");
+    const id = ctx.paneSessionId() as string;
+
+    // A new session to switch away to, then simulate a killed append (no
+    // trailing newline, unparseable last line).
+    await ctx.host.handleWebviewMessage({ command: "newSession" });
+    await ctx.waitFor("setInitialState", {
+      predicate: (m) => (m.session as { id?: string }).id !== id,
+    });
+    truncateTranscriptTail(dirA);
+
+    ctx.clear();
+    await ctx.host.handleWebviewMessage({
+      command: "desktopSelectSession",
+      workdir: dirA,
+      sessionId: id,
+    });
+    const restored = await ctx.waitFor("setInitialState", {
+      predicate: (m) => (m.session as { id?: string }).id === id,
+    });
+
+    // The truncated tail is dropped, the readable history survives — the
+    // session is NOT reported as missing.
+    expect(JSON.stringify(restored.messages)).toContain("截断前的消息");
+    expect(ctx.store.getSessionIndex().some((e) => e.sessionId === id)).toBe(
+      true,
+    );
+    expect(
+      ctx
+        .of("showToast")
+        .some((m) => JSON.stringify(m.toast).includes("加载失败")),
+    ).toBe(false);
+  });
+
+  it("never revives a deleted session through the Ctrl+Tab cycle (#2150)", async () => {
+    await openProject(dirA);
+    await ctx.turn("会话一");
+    const firstId = ctx.paneSessionId() as string;
+
+    await ctx.host.handleWebviewMessage({ command: "newSession" });
+    await ctx.waitFor("setInitialState", {
+      predicate: (m) => (m.session as { id?: string }).id !== firstId,
+    });
+    await ctx.turn("会话二");
+    const secondId = ctx.paneSessionId() as string;
+
+    // Ctrl+Tab / Ctrl+Shift+Tab are Electron menu accelerators wired straight
+    // to the host — not reachable from the webview harness.
+    await ctx.host.activateAdjacentSession(1);
+    await ctx.waitFor("setInitialState", {
+      predicate: (m) => (m.session as { id?: string }).id === firstId,
+    });
+    expect(ctx.paneSessionId()).toBe(firstId);
+
+    // Delete the session the frozen cycle order would return next…
+    ctx.clear();
+    await ctx.host.handleWebviewMessage({
+      command: "desktopDeleteSession",
+      sessionId: firstId,
+    });
+    await ctx.waitFor("desktopSessionTree", {
+      predicate: (m) => !JSON.stringify(m.groups).includes(firstId),
+    });
+    expect(
+      ctx.store.getSessionIndex().some((e) => e.sessionId === firstId),
+    ).toBe(false);
+
+    // …and press again: the deleted session must never come back.
+    await ctx.host.activateAdjacentSession(1);
+    await new Promise((r) => setTimeout(r, 1_500));
+    expect(ctx.paneSessionId()).not.toBe(firstId);
+    expect(JSON.stringify(ctx.messages)).not.toContain(firstId);
+    expect(
+      ctx.store.getSessionIndex().some((e) => e.sessionId === firstId),
+    ).toBe(false);
+    expect(ctx.paneSessionId()).toBe(secondId);
+  });
+
+  it("keeps two panes on different projects isolated", async () => {
+    await openProject(dirA);
+    const turnA = await ctx.turn("A 项目消息");
+    const idA = ctx.paneSessionId() as string;
+    expect(JSON.stringify(turnA)).toContain("A 项目消息");
+
+    await ctx.host.handleWebviewMessage({ command: "desktopNewSessionInPane" });
+    const panes = await ctx.waitFor("desktopPanes", {
+      predicate: (m) => (m.panes as unknown[]).length === 2,
+    });
+    const pane2 = (panes.panes as Array<{ paneId: string }>).find(
+      (p) => p.paneId !== "pane-1",
+    )?.paneId as string;
+
+    await ctx.host.handleWebviewMessage({
+      command: "desktopSelectRecentWorkdir",
+      path: dirB,
+      host: "local",
+      paneId: pane2,
+    });
+    await ctx.waitFor("setInitialState", {
+      predicate: (m) => m.paneId === pane2,
+    });
+    model.reply("B-REPLY");
+    const turnB = await ctx.turn("B 项目消息", pane2);
+    const idB = ctx.paneSessionId(pane2) as string;
+    expect(JSON.stringify(turnB)).toContain("B-REPLY");
+
+    // Two projects, two transcripts, two independent sessions.
+    expect(idA).not.toBe(idB);
+    expect(projectDir(dirA)).not.toBe(projectDir(dirB));
+    expect(transcriptFiles(dirA)).toHaveLength(1);
+    expect(transcriptFiles(dirB)).toHaveLength(1);
+    expect(readFileSync(transcriptFiles(dirA)[0], "utf-8")).not.toContain(
+      "B 项目消息",
+    );
+    expect(readFileSync(transcriptFiles(dirB)[0], "utf-8")).toContain(
+      "B 项目消息",
+    );
+    // The second pane's turn touched only its own pane.
+    expect(
+      turnB.every((m) => m.paneId === undefined || m.paneId === pane2),
+    ).toBe(true);
+
+    // Focusing the other pane does not touch the first pane's binding.
+    ctx.clear();
+    await ctx.host.handleWebviewMessage({
+      command: "desktopFocusPane",
+      paneId: "pane-1",
+    });
+    await ctx.waitFor("desktopPanes", {
+      predicate: (m) => m.focusedPaneId === "pane-1",
+    });
+    expect(ctx.paneSessionId("pane-1")).toBe(idA);
+    expect(ctx.paneSessionId(pane2)).toBe(idB);
+  });
+});

--- a/packages/desktop/tests/integration/realHostSettings.integration.test.ts
+++ b/packages/desktop/tests/integration/realHostSettings.integration.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Real-host integration suite (Part B) — per-pane project settings.
+ *
+ * `getProjectSettings` / `setBuiltinPluginEnabled` / `getAgentsContent` /
+ * `setAgentsContent` are the RPCs whose workdir must follow the *focused pane*
+ * (PR #2152/#2155). Here the host runs against the real CLI, so the write can
+ * be verified against the real files of each project on disk.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import * as path from "path";
+import {
+  assertNoUnexpectedRejections,
+  createRealHost,
+  resetRealHostState,
+  startFakeModelServer,
+  takeUnexpectedRejections,
+  type FakeModelServer,
+  type RealHost,
+} from "./realHostHarness";
+
+let ctx: RealHost;
+let model: FakeModelServer;
+let dirA: string;
+let dirB: string;
+
+beforeEach(async () => {
+  const dirs = resetRealHostState();
+  dirA = dirs.dirA;
+  dirB = dirs.dirB;
+  model = await startFakeModelServer();
+  model.reply("OK");
+  ctx = createRealHost();
+  ctx.store.setConfiguration({
+    apiKey: "test-key",
+    baseURL: model.baseURL,
+    model: "test-model",
+    fastModel: "test-model",
+  });
+});
+
+afterEach(async () => {
+  await ctx.close();
+  await model.close();
+  assertNoUnexpectedRejections();
+});
+
+/** pane-1 on dirA plus a second pane on dirB (two projects side by side). */
+async function twoPanes(): Promise<string> {
+  await ctx.host.handleWebviewMessage({ command: "desktopReady" });
+  await ctx.host.handleWebviewMessage({
+    command: "desktopSelectRecentWorkdir",
+    path: dirA,
+    host: "local",
+  });
+  await ctx.waitFor("setInitialState");
+  // A split only makes sense once the first pane holds a conversation
+  // (`desktopNewSessionInPane` no-ops on an empty session).
+  await ctx.turn("pane-1 首条");
+
+  await ctx.host.handleWebviewMessage({ command: "desktopNewSessionInPane" });
+  const panes = await ctx.waitFor("desktopPanes", {
+    predicate: (m) => (m.panes as unknown[]).length === 2,
+  });
+  const pane2 = (panes.panes as Array<{ paneId: string }>).find(
+    (p) => p.paneId !== "pane-1",
+  )?.paneId as string;
+
+  await ctx.host.handleWebviewMessage({
+    command: "desktopSelectRecentWorkdir",
+    path: dirB,
+    host: "local",
+    paneId: pane2,
+  });
+  await ctx.waitFor("setInitialState", {
+    predicate: (m) => m.paneId === pane2,
+  });
+  return pane2;
+}
+
+/** Project settings as the real CLI sees them for one pane. */
+async function projectSettings(paneId: string) {
+  ctx.clear();
+  await ctx.host.handleWebviewMessage({
+    command: "getProjectSettings",
+    paneId,
+  });
+  return ctx.waitFor("projectSettings", {
+    predicate: (m) => m.paneId === paneId,
+  });
+}
+
+function projectSettingsFile(dir: string): string {
+  return path.join(dir, ".wave", "settings.json");
+}
+
+describe("real host · project settings follow the pane's project", () => {
+  it("reads each pane's own project settings", async () => {
+    const pane2 = await twoPanes();
+
+    const a = await projectSettings("pane-1");
+    const b = await projectSettings(pane2);
+
+    expect(a.workdir).toBe(dirA);
+    expect(b.workdir).toBe(dirB);
+    expect(a.enabledPlugins).toEqual({});
+    expect(b.enabledPlugins).toEqual({});
+  });
+
+  it("writes the setting into the focused pane's project only", async () => {
+    const pane2 = await twoPanes();
+
+    ctx.clear();
+    await ctx.host.handleWebviewMessage({
+      command: "setBuiltinPluginEnabled",
+      paneId: pane2,
+      pluginId: "sdd@builtin",
+      enabled: true,
+      scope: "project",
+    });
+    const written = await ctx.waitFor("projectSettings", {
+      predicate: (m) => m.paneId === pane2,
+    });
+
+    expect(written.workdir).toBe(dirB);
+    expect(written.enabledPlugins).toEqual({ "sdd@builtin": true });
+
+    // The real project file of the focused pane's project changed…
+    expect(
+      JSON.parse(readFileSync(projectSettingsFile(dirB), "utf-8")),
+    ).toEqual({ enabledPlugins: { "sdd@builtin": true } });
+    // …and the other project was left untouched.
+    expect(existsSync(projectSettingsFile(dirA))).toBe(false);
+
+    // The other pane still reports its own project's (empty) settings.
+    const a = await projectSettings("pane-1");
+    expect(a.workdir).toBe(dirA);
+    expect(a.enabledPlugins).toEqual({});
+  });
+
+  it("keeps both panes usable after the config write recreates their agents", async () => {
+    const pane2 = await twoPanes();
+
+    await ctx.host.handleWebviewMessage({
+      command: "setBuiltinPluginEnabled",
+      paneId: pane2,
+      pluginId: "sdd@builtin",
+      enabled: true,
+      scope: "project",
+    });
+    await ctx.waitFor("projectSettings", {
+      predicate: (m) => m.paneId === pane2,
+    });
+
+    // `setBuiltinPluginEnabled` recreates every live agent (destroy +
+    // Agent.create with restoreSessionId). Both panes must survive it.
+    model.reply("重建后仍可用");
+    const first = await ctx.turn("重建后 pane-1 消息");
+    const second = await ctx.turn("重建后 pane-2 消息", pane2);
+
+    expect(JSON.stringify(first)).toContain("重建后仍可用");
+    expect(JSON.stringify(second)).toContain("重建后仍可用");
+    expect(ctx.paneSessionId("pane-1")).toBeTruthy();
+    expect(ctx.paneSessionId(pane2)).toBeTruthy();
+  });
+
+  /**
+   * The settings write is the widest host-side state change there is: it
+   * recreates *every* live agent (`updateConfig` → destroy + `Agent.create`),
+   * so in-flight RPCs reject with "Session not found" while
+   * `backgroundTasksChange` notifications keep arriving. Any host promise
+   * without a catch on that path leaks an unhandled rejection — fatal under
+   * Node's default policy, and invisible to the unit layer (all RPCs mocked).
+   *
+   * The invariant asserted here is "the host never leaks": `afterEach` fails on
+   * any rejection (no allow-list), and vitest fails the run for unhandled
+   * errors. Reverting the `refreshWorkflowRuns` catch turns this suite red
+   * ("Session not found: <id>" reaching `process.on("unhandledRejection")`).
+   */
+  it("does not leak an unhandled rejection when the write recreates the agents", async () => {
+    const pane2 = await twoPanes();
+    // The recreation does reject an in-flight refresh, and the host now reports
+    // it instead of dropping it — silence the expected warning.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Only rejections from here on count.
+    takeUnexpectedRejections();
+
+    await ctx.host.handleWebviewMessage({
+      command: "setBuiltinPluginEnabled",
+      paneId: pane2,
+      pluginId: "sdd@builtin",
+      enabled: true,
+      scope: "project",
+    });
+    await ctx.waitFor("projectSettings", {
+      predicate: (m) => m.paneId === pane2,
+    });
+
+    // Both panes go through another full turn, so every rejection the
+    // recreation kicked off has resolved by the time we look.
+    model.reply("重建后仍可用");
+    await ctx.turn("重建后 pane-1 消息");
+    await ctx.turn("重建后 pane-2 消息", pane2);
+
+    assertNoUnexpectedRejections();
+    warn.mockRestore();
+  });
+
+  it("reads and writes project-level AGENTS.md per pane", async () => {
+    writeFileSync(path.join(dirA, "AGENTS.md"), "A 项目规则\n", "utf-8");
+    const pane2 = await twoPanes();
+
+    ctx.clear();
+    await ctx.host.handleWebviewMessage({
+      command: "getAgentsContent",
+      scope: "project",
+      paneId: "pane-1",
+    });
+    const read = await ctx.waitFor("agentsContentResponse", {
+      predicate: (m) => m.scope === "project",
+    });
+    expect(read.content).toBe("A 项目规则\n");
+
+    // Save from the *other* pane → the other project's file.
+    ctx.clear();
+    await ctx.host.handleWebviewMessage({
+      command: "setAgentsContent",
+      scope: "project",
+      paneId: pane2,
+      content: "B 项目规则\n",
+    });
+    await ctx.waitFor("agentsContentSaved", {
+      predicate: (m) => m.scope === "project",
+    });
+
+    expect(readFileSync(path.join(dirB, "AGENTS.md"), "utf-8")).toBe(
+      "B 项目规则\n",
+    );
+    expect(readFileSync(path.join(dirA, "AGENTS.md"), "utf-8")).toBe(
+      "A 项目规则\n",
+    );
+    expect(
+      ctx
+        .of("showToast")
+        .some((m) => JSON.stringify(m.toast).includes("保存成功")),
+    ).toBe(true);
+
+    // Read back through the same pane — the CLI serves the project file.
+    ctx.clear();
+    await ctx.host.handleWebviewMessage({
+      command: "getAgentsContent",
+      scope: "project",
+      paneId: pane2,
+    });
+    const reread = await ctx.waitFor("agentsContentResponse", {
+      predicate: (m) => m.scope === "project",
+    });
+    expect(reread.content).toBe("B 项目规则\n");
+  });
+});

--- a/packages/desktop/vitest.config.ts
+++ b/packages/desktop/vitest.config.ts
@@ -12,7 +12,10 @@ export default defineConfig({
     reporter: "dot",
     environment: "node",
     include: ["tests/**/*.test.ts"],
-    exclude: ["node_modules"],
+    // Real-host integration tests spawn the real `wave --stdio` CLI and a local
+    // model server — they run in their own config/job (vitest.integration.config.ts,
+    // `pnpm -F wave-desktop run test:realhost`), never in the unit gate.
+    exclude: ["node_modules", "tests/integration/**"],
     env: {
       // Keep the file logger out of the user's real ~/.wave/logs during tests.
       DISABLE_LOGGER_IO: "true",

--- a/packages/desktop/vitest.integration.config.ts
+++ b/packages/desktop/vitest.integration.config.ts
@@ -1,0 +1,58 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+import os from "os";
+
+/**
+ * Real-host integration config (Part B).
+ *
+ * Unlike `vitest.config.ts` (which mocks fs + StdioClient + the SDK), these
+ * tests boot the *real* DesktopHost against the *real* `wave --stdio` CLI
+ * child process: real JSON-RPC over stdin/stdout, real session transcripts on
+ * disk. Only the Electron shell is stubbed (there is no display in CI) — see
+ * `tests/__mocks__/electron.ts`.
+ *
+ * Everything runs against a throwaway HOME so the CLI never touches the
+ * developer's ~/.wave state.
+ */
+
+const REALHOST_ROOT = path.join(os.tmpdir(), "wave-desktop-realhost");
+const REALHOST_HOME = path.join(REALHOST_ROOT, "home");
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      electron: path.resolve(__dirname, "tests/__mocks__/electron.ts"),
+    },
+  },
+  test: {
+    globals: true,
+    reporter: "dot",
+    environment: "node",
+    include: ["tests/integration/**/*.integration.test.ts"],
+    exclude: ["node_modules"],
+    // Each suite spawns a real CLI subprocess and runs a real Agent.create.
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+    // One child process pool at a time keeps port/socket and HOME contention out.
+    fileParallelism: false,
+    // No `dangerouslyIgnoreUnhandledErrors`: a host-side promise that forgets a
+    // catch must make this suite red (the unit layer can never see it — every
+    // RPC is mocked there). The harness additionally registers its own
+    // `unhandledRejection` listener so the leak is attributed to a test
+    // (`assertNoUnexpectedRejections`) instead of only failing the file.
+    env: {
+      HOME: REALHOST_HOME,
+      USERPROFILE: REALHOST_HOME,
+      WAVE_LOGS_DIR: path.join(REALHOST_HOME, ".wave", "logs"),
+      DISABLE_LOGGER_IO: "true",
+      // Short-circuits binaryResolver: no CLI copy into ~/.wave/cli, no
+      // ripgrep download — the workspace CLI is used directly.
+      WAVE_CLI_PATH: path.resolve(__dirname, "../code/bin/wave-code.js"),
+    },
+    server: {
+      deps: {
+        inline: ["wave-agent-sdk", "wave-webview-fixtures"],
+      },
+    },
+  },
+});

--- a/packages/webview/e2e/desktop-delete-session.e2e.ts
+++ b/packages/webview/e2e/desktop-delete-session.e2e.ts
@@ -1,0 +1,188 @@
+import { test, expect } from "./utils/desktopTestHarness.js";
+import type { Page } from "@playwright/test";
+import { MessageInjector } from "./utils/messageInjector.js";
+
+/**
+ * Regression e2e (real browser, desktop mode) — 删除会话的用户可见行为。
+ *
+ * 出处：
+ *  - PR #2150：删除会话后不得被 Ctrl+Tab 复活。Anti-revival 的权威修复在
+ *    desktopHost（handleDeleteSession 里清空 sessionCycleSnapshot + 取消 in-flight
+ *    restore + refreshSessionTree），webview 侧只观察「确认 → 发 desktopDeleteSession
+ *    → 树刷新移除该行 + 面板记忆被 prune」。Ctrl+Tab 是主进程菜单 accelerator，
+ *    窗口级 webview harness 无法触达，其「不得复活」断言在 packages/desktop
+ *    desktopHost.test.ts 覆盖（另见 Part B 真 host 集成层）。
+ *  - 面板记忆清理：删除后 DesktopApp.prunePanels 会丢掉该会话的 per-session 面板组
+ *    （chatAppPanels.test.tsx「a deleted session forgets its panel group」的浏览器版）。
+ */
+
+const DIR_A = "/Users/dev/projects/wave-agent";
+
+const initialState = {
+  messages: [],
+  isStreaming: false,
+  sessions: [],
+  isAuthenticated: true,
+  configurationData: {
+    baseURL: "https://api.anthropic.com/v1",
+    model: "claude-sonnet-4-20250514",
+  },
+  permissionMode: "default",
+};
+
+function treeGroup(sessionIds: string[]) {
+  return [
+    {
+      workdir: DIR_A,
+      sessions: sessionIds.map((sessionId) => ({
+        sessionId,
+        title: `会话 ${sessionId}`,
+        lastActiveAt: new Date("2026-07-27T10:00:00Z").getTime(),
+        hasWorktree: false,
+        running: false,
+        waitingConfirmation: false,
+      })),
+    },
+  ];
+}
+
+async function setupTree(webviewPage: Page, sessionIds: string[]) {
+  const injector = new MessageInjector(webviewPage);
+  await webviewPage.setViewportSize({ width: 1280, height: 800 });
+  await injector.simulateExtensionMessage("desktopWorkdirState", {
+    workdir: DIR_A,
+    recentWorkdirs: [DIR_A],
+  });
+  await injector.waitForChatAppReady();
+  await injector.simulateExtensionMessage("setInitialState", initialState);
+  await injector.simulateExtensionMessage("desktopSessionTree", {
+    groups: treeGroup(sessionIds),
+  });
+  await injector.simulateExtensionMessage("desktopPanes", {
+    panes: [
+      { paneId: "pane-1", sessionId: sessionIds[0], host: "local", row: 0 },
+    ],
+    focusedPaneId: "pane-1",
+  });
+  await expect(webviewPage.getByTestId("desktop-sidebar")).toBeVisible();
+  return injector;
+}
+
+async function openDeleteConfirm(webviewPage: Page, sessionId: string) {
+  // The row's hover tooltip overlays the row (position:fixed) and would
+  // intercept a normal click; the more button is always mounted (tabIndex -1),
+  // so force-click it.
+  await webviewPage
+    .getByTestId(`desktop-session-more-${sessionId}`)
+    .click({ force: true });
+  await expect(webviewPage.getByTestId("desktop-session-menu")).toBeVisible();
+  await webviewPage.getByTestId("desktop-session-menu-delete").click();
+  await expect(webviewPage.getByTestId("confirm-dialog-overlay")).toBeVisible();
+}
+
+async function deleteMessages(webviewPage: Page) {
+  return webviewPage.evaluate(() =>
+    (
+      (
+        window as unknown as { getTestMessages?: () => unknown[] }
+      ).getTestMessages?.() ?? []
+    ).filter(
+      (m) => (m as { command?: string }).command === "desktopDeleteSession",
+    ),
+  );
+}
+
+test.describe("桌面删除会话", () => {
+  test("确认删除发出 desktopDeleteSession，树刷新后该行消失、其它会话保留", async ({
+    webviewPage,
+  }) => {
+    const injector = await setupTree(webviewPage, [
+      "sess-a1",
+      "sess-a2",
+      "sess-b1",
+    ]);
+    await expect(
+      webviewPage.getByTestId("desktop-session-item-sess-a2"),
+    ).toBeVisible();
+
+    await openDeleteConfirm(webviewPage, "sess-a2");
+    await webviewPage.getByTestId("confirm-dialog-confirm").click();
+
+    await expect
+      .poll(() => deleteMessages(webviewPage))
+      .toContainEqual({
+        command: "desktopDeleteSession",
+        sessionId: "sess-a2",
+      });
+
+    // host 刷新会话树（不再含 sess-a2）→ 行消失，其它会话仍在
+    await injector.simulateExtensionMessage("desktopSessionTree", {
+      groups: treeGroup(["sess-a1", "sess-b1"]),
+    });
+    await expect(
+      webviewPage.getByTestId("desktop-session-item-sess-a2"),
+    ).toHaveCount(0);
+    await expect(
+      webviewPage.getByTestId("desktop-session-item-sess-a1"),
+    ).toBeVisible();
+    await expect(
+      webviewPage.getByTestId("desktop-session-item-sess-b1"),
+    ).toBeVisible();
+  });
+
+  test("取消确认不发删除消息、会话保留", async ({ webviewPage }) => {
+    await setupTree(webviewPage, ["sess-a1", "sess-a2"]);
+
+    await openDeleteConfirm(webviewPage, "sess-a2");
+    await webviewPage.getByTestId("confirm-dialog-cancel").click();
+    await expect(webviewPage.getByTestId("confirm-dialog-overlay")).toHaveCount(
+      0,
+    );
+    await webviewPage.waitForTimeout(100);
+    expect(await deleteMessages(webviewPage)).toHaveLength(0);
+    await expect(
+      webviewPage.getByTestId("desktop-session-item-sess-a2"),
+    ).toBeVisible();
+  });
+
+  test("删除带面板记忆的会话后，其面板组不复活、也不渗给当前会话", async ({
+    webviewPage,
+  }) => {
+    const injector = await setupTree(webviewPage, ["sess-a1", "sess-a2"]);
+    const pane = webviewPage.getByTestId("desktop-pane-pane-1");
+    const toggle = pane.getByTestId("panel-toggle-btn");
+
+    // 切到 sess-a2 并给它开一个 diff 面板（写入 per-session 记忆）
+    await injector.simulateExtensionMessage("desktopPanes", {
+      panes: [
+        { paneId: "pane-1", sessionId: "sess-a2", host: "local", row: 0 },
+      ],
+      focusedPaneId: "pane-1",
+    });
+    await toggle.click();
+    await pane.getByTestId("panel-empty-item-diff").click();
+    await expect(pane.locator(".desktop-panel-tab")).toHaveCount(1);
+
+    // 切回 sess-a1（无面板记忆）
+    await injector.simulateExtensionMessage("desktopPanes", {
+      panes: [
+        { paneId: "pane-1", sessionId: "sess-a1", host: "local", row: 0 },
+      ],
+      focusedPaneId: "pane-1",
+    });
+    await expect(pane.getByTestId("desktop-panel-slot")).toHaveCount(0);
+
+    // 删除 sess-a2 + 树刷新（prunePanels 丢掉它的面板组）
+    await openDeleteConfirm(webviewPage, "sess-a2");
+    await webviewPage.getByTestId("confirm-dialog-confirm").click();
+    await injector.simulateExtensionMessage("desktopSessionTree", {
+      groups: treeGroup(["sess-a1"]),
+    });
+    await expect(
+      webviewPage.getByTestId("desktop-session-item-sess-a2"),
+    ).toHaveCount(0);
+
+    // 删后当前会话仍无面板（被删会话的 diff tab 没有渗过来）
+    await expect(pane.getByTestId("desktop-panel-slot")).toHaveCount(0);
+  });
+});

--- a/packages/webview/e2e/desktop-pane-focus-switch.e2e.ts
+++ b/packages/webview/e2e/desktop-pane-focus-switch.e2e.ts
@@ -1,0 +1,194 @@
+import { test, expect } from "./utils/desktopTestHarness.js";
+import type { Page } from "@playwright/test";
+import { MessageInjector } from "./utils/messageInjector.js";
+import { MockDataGenerator } from "./fixtures/mockData.js";
+
+/**
+ * Regression e2e (real browser, desktop mode) — pane/会话焦点切换的联动。
+ *
+ * 语义出处（FR-031/FR-032 + spec desktop-sessions.md 场景 4）：
+ *  - 侧边栏「当前会话」行由聚焦 pane 的绑定会话决定（DesktopShell 读
+ *    panes.find(focusedPaneId)?.sessionId），切会话后 current 高亮必须跟着走。
+ *  - 点击非聚焦 pane → 发 desktopFocusPane；host 再推 desktopPanes 更新聚焦
+ *    pane。焦点切换不得影响另一 pane 的会话内容（并行会话模型）。
+ */
+
+const DIR_A = "/Users/dev/projects/wave-agent";
+
+const initialState = {
+  messages: [],
+  isStreaming: false,
+  sessions: [],
+  isAuthenticated: true,
+  configurationData: {
+    baseURL: "https://api.anthropic.com/v1",
+    model: "claude-sonnet-4-20250514",
+  },
+  permissionMode: "default",
+};
+
+function treeGroup(sessionIds: string[]) {
+  return [
+    {
+      workdir: DIR_A,
+      sessions: sessionIds.map((sessionId) => ({
+        sessionId,
+        title: `会话 ${sessionId}`,
+        lastActiveAt: new Date("2026-07-27T10:00:00Z").getTime(),
+        hasWorktree: false,
+        running: false,
+        waitingConfirmation: false,
+      })),
+    },
+  ];
+}
+
+async function setup(
+  webviewPage: Page,
+  sessionIds: string[],
+  paneIds: string[],
+) {
+  const injector = new MessageInjector(webviewPage);
+  await webviewPage.setViewportSize({ width: 1280, height: 800 });
+  await injector.simulateExtensionMessage("desktopWorkdirState", {
+    workdir: DIR_A,
+    recentWorkdirs: [DIR_A],
+  });
+  await injector.waitForChatAppReady();
+  await injector.simulateExtensionMessage("setInitialState", initialState);
+  await injector.simulateExtensionMessage("desktopSessionTree", {
+    groups: treeGroup(sessionIds),
+  });
+  await injector.simulateExtensionMessage("desktopPanes", {
+    panes: paneIds.map((paneId, i) => ({
+      paneId,
+      sessionId: sessionIds[i],
+      host: "local",
+      row: 0,
+    })),
+    focusedPaneId: paneIds[0],
+  });
+  for (const [i, paneId] of paneIds.entries()) {
+    await injector.simulateExtensionMessage("setInitialState", {
+      ...initialState,
+      paneId,
+      session: { id: sessionIds[i] },
+    });
+    await injector.simulateExtensionMessage("updateMessages", {
+      paneId,
+      messages: [
+        MockDataGenerator.createUserMessage(`来自 ${paneId}`, `u-${paneId}`),
+      ],
+    });
+  }
+  await expect(webviewPage.getByTestId("desktop-sidebar")).toBeVisible();
+  return injector;
+}
+
+function sentCommands(webviewPage: Page): Promise<string[]> {
+  return webviewPage.evaluate(() =>
+    (
+      (
+        window as unknown as { getTestMessages?: () => unknown[] }
+      ).getTestMessages?.() ?? []
+    ).map((m) => (m as { command?: string }).command ?? ""),
+  );
+}
+
+test.describe("桌面 pane/会话焦点切换联动", () => {
+  test("点击非聚焦 pane 发出 desktopFocusPane，另一 pane 内容不受影响", async ({
+    webviewPage,
+  }) => {
+    const injector = await setup(
+      webviewPage,
+      ["sess-a1", "sess-b1"],
+      ["pane-1", "pane-2"],
+    );
+    await injector.clearMessageLog();
+
+    await webviewPage.getByTestId("desktop-pane-pane-2").click();
+    await expect
+      .poll(async () => {
+        const messages = await webviewPage.evaluate(() =>
+          (
+            (
+              window as unknown as { getTestMessages?: () => unknown[] }
+            ).getTestMessages?.() ?? []
+          ).find(
+            (m) => (m as { command?: string }).command === "desktopFocusPane",
+          ),
+        );
+        return messages;
+      })
+      .toMatchObject({ command: "desktopFocusPane", paneId: "pane-2" });
+
+    // 两个 pane 的会话内容都还在（焦点切换不重挂载/清空兄弟 pane）
+    await expect(webviewPage.getByTestId("desktop-pane-pane-1")).toContainText(
+      "来自 pane-1",
+    );
+    await expect(webviewPage.getByTestId("desktop-pane-pane-2")).toContainText(
+      "来自 pane-2",
+    );
+    expect(await sentCommands(webviewPage)).not.toContain(
+      "desktopSelectSession",
+    );
+  });
+
+  test("切换 pane 绑定会话后，侧边栏当前行跟随聚焦 pane", async ({
+    webviewPage,
+  }) => {
+    const injector = await setup(
+      webviewPage,
+      ["sess-a1", "sess-a2"],
+      ["pane-1"],
+    );
+
+    await expect(
+      webviewPage.getByTestId("desktop-session-item-sess-a1"),
+    ).toHaveClass(/desktop-session-item--current/);
+
+    // 聚焦 pane 换绑会话 → current 高亮迁移
+    await injector.simulateExtensionMessage("desktopPanes", {
+      panes: [
+        { paneId: "pane-1", sessionId: "sess-a2", host: "local", row: 0 },
+      ],
+      focusedPaneId: "pane-1",
+    });
+    await expect(
+      webviewPage.getByTestId("desktop-session-item-sess-a2"),
+    ).toHaveClass(/desktop-session-item--current/);
+    await expect(
+      webviewPage.getByTestId("desktop-session-item-sess-a1"),
+    ).not.toHaveClass(/desktop-session-item--current/);
+  });
+
+  test("聚焦 pane 变化时 current 行看聚焦 pane 而非其它 pane", async ({
+    webviewPage,
+  }) => {
+    await setup(webviewPage, ["sess-a1", "sess-b1"], ["pane-1", "pane-2"]);
+
+    // 聚焦 pane-1（sess-a1）
+    await expect(
+      webviewPage.getByTestId("desktop-session-item-sess-a1"),
+    ).toHaveClass(/desktop-session-item--current/);
+    await expect(
+      webviewPage.getByTestId("desktop-session-item-sess-b1"),
+    ).not.toHaveClass(/desktop-session-item--current/);
+
+    // host 确认焦点切到 pane-2 → current 行必须跟着聚焦 pane 走
+    const injector = new MessageInjector(webviewPage);
+    await injector.simulateExtensionMessage("desktopPanes", {
+      panes: [
+        { paneId: "pane-1", sessionId: "sess-a1", host: "local", row: 0 },
+        { paneId: "pane-2", sessionId: "sess-b1", host: "local", row: 0 },
+      ],
+      focusedPaneId: "pane-2",
+    });
+    await expect(
+      webviewPage.getByTestId("desktop-session-item-sess-b1"),
+    ).toHaveClass(/desktop-session-item--current/);
+    await expect(
+      webviewPage.getByTestId("desktop-session-item-sess-a1"),
+    ).not.toHaveClass(/desktop-session-item--current/);
+  });
+});

--- a/packages/webview/e2e/desktop-project-switch-settings.e2e.ts
+++ b/packages/webview/e2e/desktop-project-switch-settings.e2e.ts
@@ -1,0 +1,361 @@
+import { test, expect } from "./utils/desktopTestHarness.js";
+import type { Page } from "@playwright/test";
+import { MessageInjector } from "./utils/messageInjector.js";
+
+/**
+ * Regression e2e (real browser, desktop mode) — 多项目切换时「项目设置 / 个性化」
+ * 显示的是当前聚焦项目，而不是 recents 头部或上一个项目的旧快照。
+ *
+ * 出处：
+ *  - PR #2155 桌面「项目设置 → SDD 开关」不随聚焦会话的项目切换（host 已按聚焦
+ *    pane 回包，但 webview 归属守卫用 effectiveWorkdir = recents 头优先，把正确
+ *    回包当过期丢弃、SettingsPage 继续信任上一项目快照）。
+ *  - PR #2152 桌面「个性化 → 项目级 AGENTS.md」只显示第一个项目的值（编辑器缓存
+ *    不按 workdir 键控、只随首次加载填充且从不失效 → 每次打开重读当前项目）。
+ *
+ * 关键：host.workdir（desktopWorkdirState.workdir）是「当前聚焦项目」的权威
+ * 来源；recents 头（recentWorkdirs[0]）恢复历史会话时不更新，因此这里刻意让
+ * recents 头停在项目 A，把聚焦项目切到 B。
+ */
+
+const DIR_A = "/Users/dev/projects/wave-agent";
+const DIR_B = "/Users/dev/projects/shop-server";
+
+const initialState = {
+  messages: [],
+  isStreaming: false,
+  sessions: [],
+  isAuthenticated: true,
+  configurationData: {
+    baseURL: "https://api.anthropic.com/v1",
+    model: "claude-sonnet-4-20250514",
+  },
+  permissionMode: "default",
+};
+
+const accountInfo = {
+  isAuthenticated: true,
+  user: { id: "user-1", email: "alice@example.com" },
+  plan: null,
+  apiQuota: null,
+};
+
+const sessionTree = [
+  {
+    workdir: DIR_A,
+    sessions: [
+      {
+        sessionId: "sess-a1",
+        title: "项目 A 的会话",
+        lastActiveAt: new Date("2026-07-27T10:12:00Z").getTime(),
+        hasWorktree: false,
+        running: false,
+        waitingConfirmation: false,
+      },
+    ],
+  },
+  {
+    workdir: DIR_B,
+    sessions: [
+      {
+        sessionId: "sess-b1",
+        title: "项目 B 的会话",
+        lastActiveAt: new Date("2026-07-27T09:12:00Z").getTime(),
+        hasWorktree: false,
+        running: false,
+        waitingConfirmation: false,
+      },
+    ],
+  },
+];
+
+/** 启动到「聚焦 pane 已在项目 A」的稳定态。 */
+async function setupFocusedOnA(webviewPage: Page) {
+  const injector = new MessageInjector(webviewPage);
+  await webviewPage.setViewportSize({ width: 1280, height: 800 });
+  await injector.simulateExtensionMessage("desktopWorkdirState", {
+    workdir: DIR_A,
+    recentWorkdirs: [DIR_A],
+  });
+  await injector.waitForChatAppReady();
+  await injector.simulateExtensionMessage("setInitialState", initialState);
+  await injector.simulateExtensionMessage("desktopSessionTree", {
+    groups: sessionTree,
+  });
+  await injector.simulateExtensionMessage("desktopPanes", {
+    panes: [{ paneId: "pane-1", sessionId: "sess-a1", host: "local", row: 0 }],
+    focusedPaneId: "pane-1",
+  });
+  await injector.simulateExtensionMessage("desktopAccountInfo", accountInfo);
+  await expect(webviewPage.getByTestId("desktop-sidebar")).toBeVisible();
+  return injector;
+}
+
+/** 聚焦 pane 切到项目 B 的会话（recents 头保持 A，模拟恢复历史会话）。 */
+async function focusProjectB(injector: MessageInjector) {
+  await injector.simulateExtensionMessage("desktopWorkdirState", {
+    workdir: DIR_B,
+    recentWorkdirs: [DIR_A],
+  });
+  await injector.simulateExtensionMessage("desktopPanes", {
+    panes: [{ paneId: "pane-1", sessionId: "sess-b1", host: "local", row: 0 }],
+    focusedPaneId: "pane-1",
+  });
+}
+
+async function openSettings(webviewPage: Page) {
+  await webviewPage.getByTestId("account-card-hotzone").click();
+  await expect(webviewPage.getByTestId("more-menu")).toBeVisible();
+  await webviewPage.getByTestId("more-menu-settings").click();
+  await expect(webviewPage.locator(".settings-page")).toBeVisible();
+}
+
+async function closeSettings(webviewPage: Page) {
+  await webviewPage.getByRole("button", { name: "返回" }).click();
+  await expect(webviewPage.locator(".settings-page")).toHaveCount(0);
+}
+
+async function enterProjectSettings(webviewPage: Page) {
+  await webviewPage
+    .locator(".settings-nav-item", { hasText: "项目设置" })
+    .click();
+  await expect(
+    webviewPage.getByRole("heading", { name: "项目设置" }),
+  ).toBeVisible();
+}
+
+function sddSwitch(webviewPage: Page) {
+  return webviewPage.locator(
+    '.settings-switch input[aria-label="启用 SDD 插件"]',
+  );
+}
+
+function projectSettingsRequests(webviewPage: Page): Promise<number> {
+  return webviewPage.evaluate(
+    () =>
+      (
+        (
+          window as unknown as { getTestMessages?: () => unknown[] }
+        ).getTestMessages?.() ?? []
+      ).filter(
+        (m) => (m as { command?: string }).command === "getProjectSettings",
+      ).length,
+  );
+}
+
+test.describe("桌面多项目切换：项目设置 / AGENTS.md 跟随聚焦项目", () => {
+  test("SDD 开关随聚焦项目切换：B 回包生效、A 旧快照不回显、过期回包被丢弃", async ({
+    webviewPage,
+  }) => {
+    const injector = await setupFocusedOnA(webviewPage);
+
+    await openSettings(webviewPage);
+    await enterProjectSettings(webviewPage);
+
+    // 进入项目设置视图触发拉取
+    await expect.poll(() => projectSettingsRequests(webviewPage)).toBe(1);
+
+    // 项目 A 启用 SDD → 开关勾选且可用
+    await injector.simulateExtensionMessage("projectSettings", {
+      workdir: DIR_A,
+      enabledPlugins: { "sdd@builtin": true },
+    });
+    const sdd = sddSwitch(webviewPage);
+    await expect(sdd).toBeEnabled();
+    await expect(sdd).toBeChecked();
+
+    // 聚焦项目切到 B（recents 头仍为 A）→ 设置页按新 workdir 重拉
+    await focusProjectB(injector);
+    await expect.poll(() => projectSettingsRequests(webviewPage)).toBe(2);
+
+    // 若此刻切项目但 B 的回包还没到：开关不得继续显示 A 的勾选（按未加载禁用）
+    await expect(sdd).toBeDisabled();
+    await expect(sdd).not.toBeChecked();
+
+    // B 回包（未启用）→ 开关未勾选且可用
+    await injector.simulateExtensionMessage("projectSettings", {
+      workdir: DIR_B,
+      enabledPlugins: {},
+    });
+    await expect(sdd).toBeEnabled();
+    await expect(sdd).not.toBeChecked();
+
+    // 迟到的 A 旧回包（归属不匹配）→ 被归属守卫丢弃，不得把开关翻回勾选
+    await injector.simulateExtensionMessage("projectSettings", {
+      workdir: DIR_A,
+      enabledPlugins: { "sdd@builtin": true },
+    });
+    await webviewPage.waitForTimeout(150);
+    await expect(sdd).not.toBeChecked();
+    await expect(sdd).toBeEnabled();
+  });
+
+  test("切回项目 A 时重新显示 A 的 SDD 值（往返切换不残留）", async ({
+    webviewPage,
+  }) => {
+    const injector = await setupFocusedOnA(webviewPage);
+    await openSettings(webviewPage);
+    await enterProjectSettings(webviewPage);
+
+    await injector.simulateExtensionMessage("projectSettings", {
+      workdir: DIR_A,
+      enabledPlugins: { "sdd@builtin": true },
+    });
+    const sdd = sddSwitch(webviewPage);
+    await expect(sdd).toBeChecked();
+
+    // A → B
+    await focusProjectB(injector);
+    await injector.simulateExtensionMessage("projectSettings", {
+      workdir: DIR_B,
+      enabledPlugins: { "sdd@builtin": false },
+    });
+    await expect(sdd).not.toBeChecked();
+
+    // B → A（recents 头一直是 A；切回靠 host.workdir 变化）
+    await injector.simulateExtensionMessage("desktopWorkdirState", {
+      workdir: DIR_A,
+      recentWorkdirs: [DIR_A],
+    });
+    await injector.simulateExtensionMessage("desktopPanes", {
+      panes: [
+        { paneId: "pane-1", sessionId: "sess-a1", host: "local", row: 0 },
+      ],
+      focusedPaneId: "pane-1",
+    });
+    await injector.simulateExtensionMessage("projectSettings", {
+      workdir: DIR_A,
+      enabledPlugins: { "sdd@builtin": true },
+    });
+    await expect(sdd).toBeChecked();
+    await expect(sdd).toBeEnabled();
+  });
+
+  test("点击开关按当前项目 scope 提交（切到 B 后点击仍 post setBuiltinPluginEnabled project）", async ({
+    webviewPage,
+  }) => {
+    const injector = await setupFocusedOnA(webviewPage);
+    await openSettings(webviewPage);
+    await enterProjectSettings(webviewPage);
+
+    await focusProjectB(injector);
+    // 切项目后必须等 webview 认下新「当前项目」再注入回包：settingsWorkdir 的
+    // ref 同步在 passive effect 里（ChatApp.tsx:643-649），紧接着注入的回包会
+    // 撞上旧身份被归属守卫当过期丢弃且不会重发，开关恒禁用（真机不会——host
+    // 只在 webview 按新 workdir 重拉后才回包）。重拉本身即「已切项目」的信号。
+    await expect.poll(() => projectSettingsRequests(webviewPage)).toBe(2);
+    await injector.simulateExtensionMessage("projectSettings", {
+      workdir: DIR_B,
+      enabledPlugins: {},
+    });
+    const sdd = sddSwitch(webviewPage);
+    await expect(sdd).toBeEnabled();
+    await injector.clearMessageLog();
+
+    await webviewPage
+      .locator('.settings-switch:has(input[aria-label="启用 SDD 插件"])')
+      .click();
+
+    await expect
+      .poll(async () =>
+        webviewPage.evaluate(() =>
+          (
+            (
+              window as unknown as { getTestMessages?: () => unknown[] }
+            ).getTestMessages?.() ?? []
+          ).find(
+            (m) =>
+              (m as { command?: string }).command === "setBuiltinPluginEnabled",
+          ),
+        ),
+      )
+      .toMatchObject({
+        command: "setBuiltinPluginEnabled",
+        pluginId: "sdd@builtin",
+        enabled: true,
+        scope: "project",
+      });
+  });
+
+  test("个性化 → 项目级 AGENTS.md：关闭重开设置后按当前项目重读，不残留上一项目内容", async ({
+    webviewPage,
+  }) => {
+    const injector = await setupFocusedOnA(webviewPage);
+
+    // 第一次打开：项目 A。项目级 tab 请求 A 的文件
+    await openSettings(webviewPage);
+    await webviewPage
+      .locator(".settings-nav-item", { hasText: "个性化" })
+      .click();
+    await webviewPage.getByRole("tab", { name: "项目级" }).click();
+
+    await expect
+      .poll(async () =>
+        webviewPage.evaluate(() =>
+          (
+            (
+              window as unknown as { getTestMessages?: () => unknown[] }
+            ).getTestMessages?.() ?? []
+          ).find(
+            (m) =>
+              (m as { command?: string }).command === "getAgentsContent" &&
+              (m as { scope?: string }).scope === "project",
+          ),
+        ),
+      )
+      .toMatchObject({
+        command: "getAgentsContent",
+        scope: "project",
+        workdir: DIR_A,
+      });
+
+    await injector.simulateExtensionMessage("agentsContentResponse", {
+      scope: "project",
+      content: "# 项目 A 规范\n",
+    });
+    await expect(webviewPage.getByLabel("项目级 AGENTS.md 内容")).toHaveValue(
+      "# 项目 A 规范\n",
+    );
+
+    // 关闭设置 → 聚焦切到项目 B（缓存须在每次打开时重置，否则继续显示 A）
+    await closeSettings(webviewPage);
+    await focusProjectB(injector);
+    await injector.clearMessageLog();
+
+    await openSettings(webviewPage);
+    await webviewPage
+      .locator(".settings-nav-item", { hasText: "个性化" })
+      .click();
+    await webviewPage.getByRole("tab", { name: "项目级" }).click();
+
+    // 重开后按当前项目 B 请求，workdir 归属键必须是 B
+    await expect
+      .poll(async () =>
+        webviewPage.evaluate(() =>
+          (
+            (
+              window as unknown as { getTestMessages?: () => unknown[] }
+            ).getTestMessages?.() ?? []
+          ).find(
+            (m) =>
+              (m as { command?: string }).command === "getAgentsContent" &&
+              (m as { scope?: string }).scope === "project",
+          ),
+        ),
+      )
+      .toMatchObject({
+        command: "getAgentsContent",
+        scope: "project",
+        workdir: DIR_B,
+      });
+
+    await injector.simulateExtensionMessage("agentsContentResponse", {
+      scope: "project",
+      content: "# 项目 B 规范\n",
+    });
+    // 修复前：编辑器缓存不失效 → 仍显示 A 的内容，断言先红
+    await expect(webviewPage.getByLabel("项目级 AGENTS.md 内容")).toHaveValue(
+      "# 项目 B 规范\n",
+    );
+  });
+});

--- a/packages/webview/e2e/desktop-session-switch-state.e2e.ts
+++ b/packages/webview/e2e/desktop-session-switch-state.e2e.ts
@@ -1,0 +1,317 @@
+import { test, expect } from "./utils/desktopTestHarness.js";
+import type { Page } from "@playwright/test";
+import { MessageInjector } from "./utils/messageInjector.js";
+import { MockDataGenerator } from "./fixtures/mockData.js";
+
+/**
+ * Regression e2e (real browser, desktop mode) — 会话切换时的状态收敛。
+ *
+ * 出处：
+ *  - PR #2140 / #2149（contextUsage 第三轮）：「切会话后上下文用量」必须清空再接
+ *    新会话的 replay（同值会话刷新不清空、桌面 host 在 pane 绑定时 replay 缓存的
+ *    用量）——usageSessionRef 同步清空修复了「上一会话的百分比泄漏到下一会话」。
+ *  - PR #2109：右面板折叠/展开逐会话记忆（面板 tab + 折叠态 + 宽度整体入
+ *    SessionUiStore 的 per-session group cache），切走再切回必须恢复原样。
+ *  - longchat-switch.e2e.ts（#2142 家族）：切到长对话后必须落在底部，用户上一会话
+ *    的滚动位置不得残留。
+ */
+
+const DIR_A = "/Users/dev/projects/wave-agent";
+
+const initialState = {
+  messages: [],
+  isStreaming: false,
+  sessions: [],
+  isAuthenticated: true,
+  configurationData: {
+    baseURL: "https://api.anthropic.com/v1",
+    model: "claude-sonnet-4-20250514",
+  },
+  permissionMode: "default",
+};
+
+function paneMessages(paneId: string, sessionId: string) {
+  return [
+    MockDataGenerator.createUserMessage("看看这个 bug", `u-${paneId}`),
+    MockDataGenerator.createAssistantMessage(
+      "我先读一下代码。",
+      `a-${sessionId}`,
+    ),
+  ];
+}
+
+async function setupPane(
+  webviewPage: Page,
+  panes: Array<{ paneId: string; sessionId: string }>,
+) {
+  const injector = new MessageInjector(webviewPage);
+  await webviewPage.setViewportSize({ width: 1280, height: 800 });
+  await injector.simulateExtensionMessage("desktopWorkdirState", {
+    workdir: DIR_A,
+    recentWorkdirs: [DIR_A],
+  });
+  await injector.waitForChatAppReady();
+  await injector.simulateExtensionMessage("setInitialState", initialState);
+  await injector.simulateExtensionMessage("desktopPanes", {
+    panes: panes.map((p) => ({ ...p, host: "local", row: 0 })),
+    focusedPaneId: panes[0].paneId,
+  });
+  // Panel groups are pruned against the session tree (DesktopApp.prunePanels):
+  // every session we switch between must exist in the tree or its per-session
+  // panel memory is dropped on the next desktopPanes push.
+  await injector.simulateExtensionMessage("desktopSessionTree", {
+    groups: [
+      {
+        workdir: DIR_A,
+        sessions: panes.map((p) => ({
+          sessionId: p.sessionId,
+          title: p.sessionId,
+          lastActiveAt: Date.now(),
+          hasWorktree: false,
+          running: false,
+          waitingConfirmation: false,
+        })),
+      },
+    ],
+  });
+  for (const p of panes) {
+    await injector.simulateExtensionMessage("setInitialState", {
+      ...initialState,
+      paneId: p.paneId,
+      session: { id: p.sessionId },
+    });
+    await injector.simulateExtensionMessage("updateMessages", {
+      paneId: p.paneId,
+      messages: paneMessages(p.paneId, p.sessionId),
+    });
+  }
+  return injector;
+}
+
+async function switchPaneSession(
+  injector: MessageInjector,
+  paneId: string,
+  sessionId: string,
+) {
+  await injector.simulateExtensionMessage("desktopPanes", {
+    panes: [{ paneId, sessionId, host: "local", row: 0 }],
+    focusedPaneId: paneId,
+  });
+  await injector.simulateExtensionMessage("setInitialState", {
+    ...initialState,
+    paneId,
+    session: { id: sessionId },
+    messages: paneMessages(paneId, sessionId),
+  });
+}
+
+function contextPct(webviewPage: Page, paneId: string) {
+  return webviewPage
+    .getByTestId(`desktop-pane-${paneId}`)
+    .locator(".compress-context-pct");
+}
+
+function contextButton(webviewPage: Page, paneId: string) {
+  return webviewPage
+    .getByTestId(`desktop-pane-${paneId}`)
+    .locator(".compress-context-button");
+}
+
+async function dragHandle(webviewPage: Page, dx: number) {
+  const handle = webviewPage.getByTestId("panel-slot-drag-handle");
+  const h = await handle.boundingBox();
+  if (!h) throw new Error("panel-slot-drag-handle not visible");
+  const y = h.y + h.height / 2;
+  const x0 = h.x + h.width / 2;
+  await webviewPage.mouse.move(x0, y);
+  await webviewPage.mouse.down();
+  await webviewPage.mouse.move(x0 + dx, y, { steps: 16 });
+  await webviewPage.mouse.up();
+}
+
+async function slotWidth(webviewPage: Page): Promise<number> {
+  const box = await webviewPage.getByTestId("desktop-panel-slot").boundingBox();
+  if (!box) throw new Error("desktop-panel-slot not visible");
+  return Math.round(box.width);
+}
+
+test.describe("桌面会话切换状态收敛", () => {
+  test("上下文用量：切会话先清空再接新会话 replay，同会话重推保持不变", async ({
+    webviewPage,
+  }) => {
+    const injector = await setupPane(webviewPage, [
+      { paneId: "pane-1", sessionId: "sess-a1" },
+    ]);
+
+    await injector.simulateExtensionMessage("contextUsage", {
+      paneId: "pane-1",
+      percent: 45,
+    });
+    await expect(contextPct(webviewPage, "pane-1")).toHaveText("45%");
+
+    // 切到会话 B：host 先推 setInitialState（同步清空用量）再 replay 缓存用量
+    await switchPaneSession(injector, "pane-1", "sess-b1");
+    await expect(contextPct(webviewPage, "pane-1")).toHaveCount(0);
+    await expect(contextButton(webviewPage, "pane-1")).toHaveAttribute(
+      "title",
+      "",
+    );
+
+    await injector.simulateExtensionMessage("contextUsage", {
+      paneId: "pane-1",
+      percent: 12,
+    });
+    await expect(contextPct(webviewPage, "pane-1")).toHaveText("12%");
+
+    // 同一会话重推 setInitialState（host 刷新）不得把用量清掉
+    await switchPaneSession(injector, "pane-1", "sess-b1");
+    await expect(contextPct(webviewPage, "pane-1")).toHaveText("12%");
+  });
+
+  test("上下文用量：双 pane 各自独立，不互相泄漏", async ({ webviewPage }) => {
+    const injector = await setupPane(webviewPage, [
+      { paneId: "pane-1", sessionId: "sess-a1" },
+      { paneId: "pane-2", sessionId: "sess-b1" },
+    ]);
+
+    await injector.simulateExtensionMessage("contextUsage", {
+      paneId: "pane-1",
+      percent: 30,
+    });
+    await injector.simulateExtensionMessage("contextUsage", {
+      paneId: "pane-2",
+      percent: 88,
+    });
+
+    await expect(contextPct(webviewPage, "pane-1")).toHaveText("30%");
+    await expect(contextPct(webviewPage, "pane-2")).toHaveText("88%");
+
+    // 切换焦点 pane 不改变任一 pane 的用量
+    await webviewPage.getByTestId("desktop-pane-pane-2").click();
+    await expect(contextPct(webviewPage, "pane-1")).toHaveText("30%");
+    await expect(contextPct(webviewPage, "pane-2")).toHaveText("88%");
+  });
+
+  test("右面板 tab + 折叠态逐会话记忆：切走再切回恢复", async ({
+    webviewPage,
+  }) => {
+    const injector = await setupPane(webviewPage, [
+      { paneId: "pane-1", sessionId: "sess-a1" },
+    ]);
+    const pane = webviewPage.getByTestId("desktop-pane-pane-1");
+    const toggle = pane.getByTestId("panel-toggle-btn");
+
+    // 会话 A 打开 diff 面板再收起
+    await toggle.click();
+    await pane.getByTestId("panel-empty-item-diff").click();
+    await expect(pane.locator(".desktop-panel-tab")).toHaveCount(1);
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await expect(pane.getByTestId("desktop-panel-slot")).toHaveCSS(
+      "display",
+      "none",
+    );
+
+    // 切到会话 B：空会话不继承 A 的面板（槽位不渲染）
+    await switchPaneSession(injector, "pane-1", "sess-b1");
+    await expect(pane.getByTestId("desktop-panel-slot")).toHaveCount(0);
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    // 切回会话 A：diff tab 与折叠态一并恢复
+    await switchPaneSession(injector, "pane-1", "sess-a1");
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await expect(pane.getByTestId("desktop-panel-slot")).toHaveCSS(
+      "display",
+      "none",
+    );
+    await expect(pane.locator(".desktop-panel-tab")).toHaveCount(1);
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    await expect(pane.locator(".desktop-panel-tab")).toBeVisible();
+  });
+
+  test("右面板宽度逐会话记忆：拖动后切走再切回恢复手动宽度", async ({
+    webviewPage,
+  }) => {
+    const injector = await setupPane(webviewPage, [
+      { paneId: "pane-1", sessionId: "sess-a1" },
+    ]);
+    const pane = webviewPage.getByTestId("desktop-pane-pane-1");
+
+    await pane.getByTestId("panel-toggle-btn").click();
+    await pane.getByTestId("panel-empty-item-diff").click();
+    await expect(pane.locator(".desktop-panel-tab")).toHaveCount(1);
+
+    const initialWidth = await slotWidth(webviewPage);
+    // 向右拖 = 变窄（宽度上限受「对话列不小于 360」钳制，变窄方向空间更大）
+    await dragHandle(webviewPage, 160);
+    const narrowed = await slotWidth(webviewPage);
+    expect(narrowed).toBeLessThan(initialWidth - 100);
+
+    // 切到会话 B → 该会话用自己的默认宽度，不继承 A 的手动宽度
+    await switchPaneSession(injector, "pane-1", "sess-b1");
+    await pane.getByTestId("panel-toggle-btn").click();
+    await pane.getByTestId("panel-empty-item-preview").click();
+    const sessionBWidth = await slotWidth(webviewPage);
+    expect(Math.abs(sessionBWidth - narrowed)).toBeGreaterThan(50);
+
+    // 切回会话 A → 恢复手动宽度
+    await switchPaneSession(injector, "pane-1", "sess-a1");
+    expect(await slotWidth(webviewPage)).toBe(narrowed);
+  });
+
+  test("长对话切换：短→长→短 每次切换都落在底部", async ({ webviewPage }) => {
+    const injector = await setupPane(webviewPage, [
+      { paneId: "pane-1", sessionId: "sess-a1" },
+    ]);
+
+    const longMessages = [];
+    for (let i = 0; i < 60; i++) {
+      longMessages.push(
+        MockDataGenerator.createUserMessage(`user ${i}`, `u-${i}`),
+        MockDataGenerator.createAssistantMessage(`reply ${i}`, `a-${i}`),
+      );
+    }
+    const shortMessages = longMessages.slice(0, 8);
+
+    const bottomGap = () =>
+      webviewPage.evaluate(() => {
+        const c = document.getElementById("messagesContainer");
+        if (!c) return 9999;
+        return c.scrollHeight - c.scrollTop - c.clientHeight;
+      });
+
+    // 长会话 → 落底
+    await injector.simulateExtensionMessage("updateMessages", {
+      paneId: "pane-1",
+      messages: longMessages,
+    });
+    await webviewPage.waitForTimeout(500);
+    expect(await bottomGap()).toBeLessThan(2);
+
+    // 用户上滚后切到短会话 → 必须落底，不继承上会话滚动位置
+    await webviewPage.evaluate(() => {
+      const c = document.getElementById("messagesContainer");
+      if (c) {
+        c.scrollTop = 0;
+        c.dispatchEvent(new Event("scroll"));
+      }
+    });
+    await switchPaneSession(injector, "pane-1", "sess-a2");
+    await injector.simulateExtensionMessage("updateMessages", {
+      paneId: "pane-1",
+      messages: shortMessages,
+    });
+    await webviewPage.waitForTimeout(500);
+    expect(await bottomGap()).toBeLessThan(2);
+
+    // 再切回长会话 → 仍落底
+    await switchPaneSession(injector, "pane-1", "sess-a1");
+    await injector.simulateExtensionMessage("updateMessages", {
+      paneId: "pane-1",
+      messages: longMessages,
+    });
+    await webviewPage.waitForTimeout(700);
+    expect(await bottomGap()).toBeLessThan(2);
+  });
+});

--- a/packages/webview/e2e/session-switch-background-task-gate.e2e.ts
+++ b/packages/webview/e2e/session-switch-background-task-gate.e2e.ts
@@ -1,0 +1,255 @@
+import { test, expect } from "./utils/webviewTestHarness.js";
+import { MessageInjector } from "./utils/messageInjector.js";
+
+/**
+ * Regression e2e (real browser) — 「后台任务运行期禁止原地切会话」状态机。
+ *
+ * 出处：
+ *  - PR #2144 `hasRunningBackgroundTask` 门禁（新建对话按钮禁用 + 历史会话选择被
+ *    忽略 + /clear 被忽略），防清空/替换会话中断正在跑的后台任务。
+ *  - PR #2154 后台子代理/workflow 终态只改 in-map task 从不 notifyTasksChange，
+ *    webview 侧 `backgroundTasks` 最后一份快照恒 running → 门禁锁死到重启。
+ *    修好后终态快照会补推，门禁必须立即恢复 —— 本用例断言 webview 对「终态快照
+ *    到达」的契约（真机上「快照会不会到」由 agent-sdk 侧 subagentManager /
+ *    workflowManager 的 notify 保证，见 packages/agent-sdk 回归）。
+ *
+ * 语义对照单测 packages/webview/tests/webview/backgroundTaskBlocksSessionSwitch.test.tsx；
+ * 这里跑在真实浏览器 + 真实 webview bundle 上，覆盖 contenteditable / 弹窗 / 焦点
+ * 等 jsdom 测不到的交互路径。
+ */
+
+const runningShell = {
+  id: "bg-shell-1",
+  type: "shell",
+  status: "running",
+  startTime: 1000,
+  command: "sleep 300",
+  description: "long-running build",
+};
+
+const runningSubagent = {
+  id: "bg-subagent-1",
+  type: "subagent",
+  status: "running",
+  startTime: 1000,
+  description: "background subagent exploration",
+};
+
+const initialState = {
+  messages: [],
+  isStreaming: false,
+  sessions: [],
+  isAuthenticated: true,
+  configurationData: {
+    baseURL: "https://api.anthropic.com/v1",
+    model: "claude-sonnet-4-20250514",
+  },
+  permissionMode: "default",
+};
+
+const historySessions = [
+  {
+    id: "session-1",
+    sessionType: "main",
+    workdir: "/test/project",
+    firstMessage: "First session hello",
+    lastActiveAt: "2023-12-01T10:00:00Z",
+    latestTotalTokens: 150,
+  },
+  {
+    id: "session-2",
+    sessionType: "main",
+    workdir: "/test/project",
+    firstMessage: "Second session world",
+    lastActiveAt: "2023-12-01T11:00:00Z",
+    latestTotalTokens: 250,
+  },
+];
+
+async function setup(webviewPage: import("@playwright/test").Page) {
+  const injector = new MessageInjector(webviewPage);
+  await injector.waitForChatAppReady();
+  await injector.simulateExtensionMessage("setInitialState", initialState);
+  return injector;
+}
+
+function sentCommands(
+  webviewPage: import("@playwright/test").Page,
+): Promise<string[]> {
+  return webviewPage.evaluate(() =>
+    (
+      (
+        window as unknown as { getTestMessages?: () => unknown[] }
+      ).getTestMessages?.() ?? []
+    ).map((m) => (m as { command?: string }).command ?? ""),
+  );
+}
+
+test.describe("后台任务门禁（新建对话 / 加载历史）", () => {
+  test("running 后台 shell 禁用「新建对话」，终态快照到达后恢复并可发 clearChat", async ({
+    webviewPage,
+  }) => {
+    const injector = await setup(webviewPage);
+    const newSessionBtn = webviewPage.getByTestId("new-session-btn");
+    await expect(newSessionBtn).toBeEnabled();
+
+    // running → 禁用
+    await injector.simulateExtensionMessage("updateBackgroundTasks", {
+      tasks: [runningShell],
+    });
+    await expect(newSessionBtn).toBeDisabled();
+
+    // 点击禁用按钮不得发出 clearChat（守卫 + 原生 disabled 双保险）
+    await injector.clearMessageLog();
+    await newSessionBtn.click({ force: true });
+    await webviewPage.waitForTimeout(100);
+    expect(await sentCommands(webviewPage)).not.toContain("clearChat");
+
+    // 终态快照（completed）到达 → 立即恢复（回归 #2154 锁死到重启）
+    await injector.simulateExtensionMessage("updateBackgroundTasks", {
+      tasks: [
+        { ...runningShell, status: "completed", endTime: 2000, exitCode: 0 },
+      ],
+    });
+    await expect(newSessionBtn).toBeEnabled();
+
+    // 恢复后点击 → clearChat 真的发出
+    await injector.clearMessageLog();
+    await newSessionBtn.click();
+    await expect
+      .poll(async () => sentCommands(webviewPage))
+      .toContain("clearChat");
+  });
+
+  test("终态快照 semantic：subagent 仍 running 则继续禁用，全部终态才放行", async ({
+    webviewPage,
+  }) => {
+    const injector = await setup(webviewPage);
+    const newSessionBtn = webviewPage.getByTestId("new-session-btn");
+
+    // 一 shell + 一 subagent 都在跑
+    await injector.simulateExtensionMessage("updateBackgroundTasks", {
+      tasks: [runningShell, runningSubagent],
+    });
+    await expect(newSessionBtn).toBeDisabled();
+
+    // shell 完成但 subagent 还跑 → 仍禁用（不是「有终态项就放行」）
+    await injector.simulateExtensionMessage("updateBackgroundTasks", {
+      tasks: [{ ...runningShell, status: "completed" }, runningSubagent],
+    });
+    await expect(newSessionBtn).toBeDisabled();
+
+    // subagent 变 failed 也是终态 → 放行
+    await injector.simulateExtensionMessage("updateBackgroundTasks", {
+      tasks: [
+        { ...runningShell, status: "completed" },
+        { ...runningSubagent, status: "failed", endTime: 3000 },
+      ],
+    });
+    await expect(newSessionBtn).toBeEnabled();
+
+    // killed 同样视为终态：重新注入一个 killed 项仍放行
+    await injector.simulateExtensionMessage("updateBackgroundTasks", {
+      tasks: [{ ...runningSubagent, status: "killed" }],
+    });
+    await expect(newSessionBtn).toBeEnabled();
+
+    // 清空列表 → 放行
+    await injector.simulateExtensionMessage("updateBackgroundTasks", {
+      tasks: [],
+    });
+    await expect(newSessionBtn).toBeEnabled();
+  });
+
+  test("running 时历史会话选择被忽略（弹窗仍关闭、会话不被替换），终态后恢复", async ({
+    webviewPage,
+  }) => {
+    const injector = await setup(webviewPage);
+    await injector.simulateExtensionMessage("updateSessions", {
+      sessions: historySessions,
+    });
+
+    await injector.simulateExtensionMessage("updateBackgroundTasks", {
+      tasks: [runningSubagent],
+    });
+    await injector.clearMessageLog();
+
+    await webviewPage.getByTestId("history-btn").click();
+    await expect(webviewPage.getByTestId("session-list-popup")).toBeVisible();
+    await webviewPage.getByTestId("session-list-item-session-2").click();
+
+    // 守卫拦截 restoreSession；弹窗按既有 UX 关闭
+    await expect(webviewPage.getByTestId("session-list-popup")).toHaveCount(0);
+    await webviewPage.waitForTimeout(100);
+    expect(await sentCommands(webviewPage)).not.toContain("restoreSession");
+
+    // 终态后同一路径恢复可用
+    await injector.simulateExtensionMessage("updateBackgroundTasks", {
+      tasks: [{ ...runningSubagent, status: "completed" }],
+    });
+    await injector.clearMessageLog();
+    await webviewPage.getByTestId("history-btn").click();
+    await webviewPage.getByTestId("session-list-item-session-2").click();
+
+    await expect
+      .poll(async () =>
+        webviewPage.evaluate(() =>
+          (
+            (
+              window as unknown as { getTestMessages?: () => unknown[] }
+            ).getTestMessages?.() ?? []
+          ).find(
+            (m) => (m as { command?: string }).command === "restoreSession",
+          ),
+        ),
+      )
+      .toMatchObject({ command: "restoreSession", sessionId: "session-2" });
+  });
+
+  test("running 时 /clear 斜杠命令被忽略，终态后可清空", async ({
+    webviewPage,
+  }) => {
+    const injector = await setup(webviewPage);
+    await injector.simulateExtensionMessage("updateBackgroundTasks", {
+      tasks: [runningShell],
+    });
+    await injector.clearMessageLog();
+
+    const input = webviewPage.getByTestId("message-input");
+    await input.click();
+    await input.focus();
+    await webviewPage.keyboard.type("/clear");
+    await webviewPage.keyboard.press("Enter");
+    await webviewPage.waitForTimeout(150);
+
+    let sent = await sentCommands(webviewPage);
+    expect(sent).not.toContain("clearChat");
+    expect(sent).not.toContain("sendMessage");
+
+    // 终态后 /clear 生效
+    await injector.simulateExtensionMessage("updateBackgroundTasks", {
+      tasks: [{ ...runningShell, status: "killed" }],
+    });
+    await injector.clearMessageLog();
+    await input.click();
+    await input.focus();
+    await webviewPage.keyboard.type("/clear");
+    await webviewPage.keyboard.press("Enter");
+
+    await expect
+      .poll(async () => sentCommands(webviewPage))
+      .toContain("clearChat");
+  });
+
+  test("setInitialState 携带 running 任务时开局即禁用（冷启动快照路径）", async ({
+    webviewPage,
+  }) => {
+    const injector = new MessageInjector(webviewPage);
+    await injector.waitForChatAppReady();
+    await injector.simulateExtensionMessage("setInitialState", {
+      ...initialState,
+      backgroundTasks: [runningShell, runningSubagent],
+    });
+    await expect(webviewPage.getByTestId("new-session-btn")).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## 背景

近期缺陷集中在跨进程 / 多分屏 / 多项目切换 / 平台差异，而测试分布偏斜：webview e2e 全部跑在 mock host 上（没有真 desktopHost / 真 stdio JSON-RPC / 真 Electron），且缺「切换/状态机」维度。本 PR 按 A+B 两阶段补强，并顺带修掉真 host 层首次暴露的两个上游缺陷。

## A. webview e2e 切换/状态机用例（20 例，复用既有 harness，零基建改动）

自动进既有 `webview-e2e` job，`ci.yml` 无改动：

| 文件 | 例 | 对应已修缺陷 |
| --- | --- | --- |
| `desktop-project-switch-settings.e2e.ts` | 4 | #2155 / #2152：SDD 开关、项目级 AGENTS.md 随聚焦项目切换；迟到回包被归属守卫丢弃 |
| `session-switch-background-task-gate.e2e.ts` | 5 | #2144 / #2154：后台任务运行期禁「新建对话」/加载历史，终态恢复；semantic 快照、历史选择被忽略、`/clear` 被忽略、冷启动即禁 |
| `desktop-session-switch-state.e2e.ts` | 5 | #2140/#2149/#2109：上下文用量清空+replay 与双 pane 隔离、面板 tab+折叠态/宽度逐会话记忆、长对话切回落底 |
| `desktop-pane-focus-switch.e2e.ts` | 3 | 聚焦 pane 切换不扰动兄弟 pane、侧边栏 current 行跟随聚焦 pane |
| `desktop-delete-session.e2e.ts` | 3 | #2150：删除会话的 webview 侧契约（确认/取消、树刷新、面板记忆不复活） |

> 用例踩坑记录：切项目后立刻注入 `projectSettings` 回包会撞上「已过期即弃」——`settingsWorkdir` 的 ref 同步在 passive effect 里（`ChatApp.tsx:643-649`），回包被丢且不会重发，开关恒禁用（真机不会，host 只在 webview 按新 workdir 重拉后才回包）。用例改为等「重拉请求数」到达后再注入。

## B. 真 host 集成层（11 例）+ main-only CI job

**路线选择**：首选 `_electron` 驱真桌面应用，但本机无 display → `--headless`/`--ozone-platform=headless`/`--headless=new` 全部 `FAIL_FIRSTWINDOW`，直起得 `Gtk-ERROR … without a display connection`（exit 133，本机无 xvfb 无 sudo）。该路线只能跑 CI，违反「测试必须本地可跑」→ 采用 **Node 级真 host 层**：真 `DesktopHost` + 真 `StdioClient` JSON-RPC + 真 `wave --stdio` 子进程 + 真 fs，仅桩 Electron 壳/electron-updater，模型侧用本地 OpenAI 兼容 SSE 服务（离线、确定）。唯一无法覆盖的是渲染与 Electron 主进程工具，那部分仍由 webview e2e 与真机走查守。

用例（`packages/desktop/tests/integration/`）：

- 启动真 CLI 并绑定真会话 → 真 turn（user → CLI → 模型 HTTP → 流式回包 → 磁盘 transcript）
- 从 transcript 恢复历史会话；被 kill 截断的 transcript 可恢复（#2137）
- 删除的会话不被 Ctrl+Tab 复活（#2150，harness 到不了的主进程路径）
- 双 pane 跨项目隔离；两 pane 各读自己的项目设置、写设置只落地聚焦 pane 的项目、配置写入重建 agent 后两 pane 仍可用、项目级 AGENTS.md 逐 pane 读写

CI：`.github/workflows/ci.yml` 新增 `real-host-e2e` job，`if: github.event_name != 'pull_request'`（main push / dispatch 才跑，与 `integration`/`webview-e2e` 同时机，**非 PR 门禁**，job 注释已写明）；无需 display。命令 `pnpm -F wave-desktop run test:realhost`；unit 门禁通过 `vitest.config.ts` exclude 排除 integration。

## 修复 1（该层首次暴露）：`DesktopHost.refreshWorkflowRuns` 泄漏未处理 rejection

`await agent.getWorkflowRuns()` 无 catch，而它由 `backgroundTasksChange` 通知 fire-and-forget 调用；设置保存/登录/插件变更会重建全部 agent，重建窗口内该 RPC 以 `Session not found` 拒绝 → 未处理 promise rejection（Node 默认策略下致进程退出）。unit 层 RPC 全 mock，永远看不到。改为就地 catch + 上报（缓存保持上次已知状态），并去掉 fire-and-forget 调用点的空 catch。

**回归**：`realHostSettings` 新增用例 + harness 的 `unhandledRejection` 收集器（**无白名单**，且 `vitest.integration.config.ts` 已移除 `dangerouslyIgnoreUnhandledErrors`）→ 还原该 catch 时该套件 3 例失败（`Session not found` 泄漏），修复后 11 例全绿。

## 修复 2：`--stdio` 的 stdout 不再被 `console.log` 污染

`wave --stdio` 的 stdout 是 JSON-RPC 通道、stderr 才留给日志。`SessionService.handleSessionRestoration` 每次恢复会话都往 stdout 打 `Restoring session: <id>`，真机表现为 `[wave-jsonrpc] Failed to parse: …`（真 host 层抓到）。

- `session.ts`：改走 SDK logger（与同文件既有 `logger.warn` 一致）
- `stdio-cli.ts`：新增 `guardStdoutForJsonRpc()`，stdio 模式下把 `console.log/info/debug` 重定向到 stderr——把契约固化成一次性保证，而不是逐个调用点追
- 横向排查：agent-sdk src 仅此一处（`builtin/plugins.ts` 里的 `console.log` 是内嵌插件脚本字符串，子进程执行，不入本进程 stdout）；`packages/code` 75 处 console.log 均不在 stdio 模块图内（stdio 只额外引入 logger/worktree/rewindCheckpoints，均无 console）；hooks/bash/git 等子进程全部 pipe，不继承 stdout
- 回归：agent-sdk `session.extra.test.ts`（恢复路径不写 stdout/console.log，只经 `logger.info`）+ code `stdioStdoutGuard.test.ts`（stdio 启动装上重定向、只动 log/info/debug、导入模块本身不改 console），均先红后绿

## 验证（本机全绿）

- webview e2e：`playwright --project=e2e` 连跑 3 次 **65 passed**；`tsc -p e2e` / oxlint 绿
- desktop：`test:realhost` **11 passed**（EXIT=0，无 Errors 段；无 `Failed to parse: Restoring session`）、`test:unit` **600 passed**
- agent-sdk：`test:unit` 256 文件 / **3705 passed**（+1 新用例）；code `tests/stdio` **173 passed**
- 全仓 `type-check` / `oxlint` / `prettier` 全绿
- 两处修复均做过 fail-without-fix 双验（还原修复即红）

无新增依赖；`.github/workflows` 仅新增上述 `real-host-e2e` job（main-only、非门禁）。
