### PR TITLE
fix(worktree): 补齐 worktree 删除失败的日志

### DIFF
--- a/.wave/hooks/worktree-remove.mjs
+++ b/.wave/hooks/worktree-remove.mjs
@@ -4,8 +4,29 @@
 // worktrees: `git worktree remove --force` + branch delete + prune, with an
 // fs.rmSync fallback for Windows MAX_PATH-limited removals.
 import { spawnSync } from "node:child_process";
-import { readFileSync, existsSync, rmSync, writeFileSync } from "node:fs";
+import {
+  readFileSync,
+  readdirSync,
+  existsSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
+
+/**
+ * Describe what is still on disk after a failed removal: without it a failure
+ * line cannot tell "already gone" apart from "the whole checkout survived".
+ */
+function describeResidue(target) {
+  try {
+    if (!existsSync(target)) return "none";
+    const entries = readdirSync(target);
+    const head = entries.slice(0, 5).join(",");
+    return `${entries.length}[${head}${entries.length > 5 ? ",…" : ""}]`;
+  } catch (error) {
+    return `unknown(${error.code ?? "error"})`;
+  }
+}
 
 // --- Read payload { worktree_path } from stdin -----------------------------
 let payload;
@@ -87,19 +108,31 @@ const name = path.basename(worktreePath);
 const branch = `worktree-${name}`;
 
 // 1. git worktree remove --force (deletes working dir + metadata)
-let removed = existsSync(worktreePath)
+const gitResult = existsSync(worktreePath)
   ? spawnSync("git", ["worktree", "remove", "--force", worktreePath], {
       cwd: repoRoot,
       stdio: "inherit",
-    }).status === 0
-  : true;
+    })
+  : null;
+let removed = gitResult === null || gitResult.status === 0;
+// git's own message goes to stderr via stdio:inherit; without its exit status
+// the log cannot tell a MAX_PATH refusal from a locked directory.
+const gitSummary =
+  gitResult === null
+    ? "skipped(missing)"
+    : `exit=${gitResult.status ?? "null"}` +
+      (gitResult.signal ? ` signal=${gitResult.signal}` : "") +
+      (gitResult.error ? ` error=${gitResult.error.message}` : "");
 
 // 2. fs.rmSync fallback for MAX_PATH-limited removals (git leaves an orphan dir)
+let fsSummary = "skipped";
 if (!removed && existsSync(worktreePath)) {
   try {
     rmSync(worktreePath, { recursive: true, force: true });
     removed = true;
+    fsSummary = "ok";
   } catch (error) {
+    fsSummary = `code=${error.code ?? "?"} syscall=${error.syscall ?? "?"} at=${error.path ?? "?"}`;
     console.error(
       `worktree-remove: fs.rmSync failed for ${worktreePath}: ${error.message}`,
     );
@@ -112,7 +145,8 @@ spawnSync("git", ["branch", "-D", "--", branch], { cwd: repoRoot });
 
 if (!removed) {
   console.error(
-    `worktree-remove: failed to remove worktree at: ${worktreePath}`,
+    `worktree-remove: FAILED name=${name} path=${worktreePath} branch=${branch} ` +
+      `git(${gitSummary}) fs(${fsSummary}) residue=${describeResidue(worktreePath)}`,
   );
   process.exit(1);
 }

--- a/packages/agent-sdk/src/services/worktreeHooks.ts
+++ b/packages/agent-sdk/src/services/worktreeHooks.ts
@@ -116,8 +116,13 @@ export async function executeWorktreeRemoveHook(
 
   for (const result of results) {
     if (!result.success) {
+      // The path identifies which worktree survived; exit/timeout/duration tell
+      // apart "the hook failed on its own" from "the hook was killed by the
+      // hook timeout" when failures are aggregated later.
       logger?.error(
-        `WorktreeRemove hook failed [${result.command}]: ${result.stderr || "no output"}`,
+        `WorktreeRemove hook failed [${result.command}] worktree=${worktreePath} ` +
+          `exit=${result.exitCode ?? "n/a"} timedOut=${result.timedOut} ` +
+          `durationMs=${result.duration}: ${result.stderr || "no output"}`,
       );
     }
   }

--- a/packages/agent-sdk/tests/services/worktreeHooks.test.ts
+++ b/packages/agent-sdk/tests/services/worktreeHooks.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   hasWorktreeCreateHook,
   hasWorktreeRemoveHook,
@@ -6,6 +6,7 @@ import {
   executeWorktreeRemoveHook,
 } from "@/services/worktreeHooks.js";
 import { executeCommand } from "@/services/hook.js";
+import { clearGlobalLogger, setGlobalLogger } from "@/utils/globalLogger.js";
 import type { HookExecutionResult } from "@/types/hooks.js";
 
 vi.mock("@/services/hook.js", async (importOriginal) => {
@@ -55,6 +56,10 @@ const baseContext = {
 describe("worktreeHooks", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    clearGlobalLogger();
   });
 
   describe("hasWorktreeCreateHook / hasWorktreeRemoveHook", () => {
@@ -325,6 +330,40 @@ describe("worktreeHooks", () => {
       );
 
       expect(hookRan).toBe(true);
+    });
+
+    it("logs the worktree path, exit code and timeout state when the hook fails", async () => {
+      const errorSpy = vi.fn();
+      setGlobalLogger({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: errorSpy,
+      } as unknown as Parameters<typeof setGlobalLogger>[0]);
+      vi.mocked(executeCommand).mockResolvedValue(
+        result({
+          success: false,
+          exitCode: 137,
+          stderr: "Filename too long",
+          timedOut: true,
+          duration: 1234,
+        }),
+      );
+
+      await executeWorktreeRemoveHook(
+        "/repo/.wave/worktrees/feature",
+        removeConfig(["cleanup-a"]),
+        baseContext,
+      );
+
+      // Without the path the line is un-actionable when aggregating failures
+      // from several worktrees; without exit/timeout it is unclear whether the
+      // hook failed on its own or was killed by the hook timeout.
+      const message = String(errorSpy.mock.calls[0][0]);
+      expect(message).toContain("/repo/.wave/worktrees/feature");
+      expect(message).toContain("exit=137");
+      expect(message).toContain("timedOut=true");
+      expect(message).toContain("Filename too long");
     });
   });
 });

--- a/packages/code/src/utils/worktree.ts
+++ b/packages/code/src/utils/worktree.ts
@@ -323,6 +323,66 @@ function toExtendedLengthPath(worktreePath: string): string {
   return `\\\\?\\${absolute}`;
 }
 
+/** First line of a captured stderr/message, trimmed and length-capped. */
+function firstLine(text: string | undefined, max = 200): string {
+  if (!text) return "";
+  const line = text.trim().split("\n")[0].trim();
+  return line.length > max ? `${line.slice(0, max)}…` : line;
+}
+
+/**
+ * Summarise why `git worktree remove` failed. execFile rejections carry the
+ * exit code and the child's stderr; without them a removal failure is
+ * indistinguishable from a MAX_PATH refusal, a locking process, or a git error.
+ */
+function describeGitFailure(error: unknown): string {
+  const e = error as {
+    code?: number | string;
+    signal?: string;
+    stderr?: string;
+    message?: string;
+  };
+  const parts: string[] = [];
+  if (e.code !== undefined) parts.push(`code=${e.code}`);
+  if (e.signal) parts.push(`signal=${e.signal}`);
+  const stderr = firstLine(e.stderr);
+  if (stderr) parts.push(`stderr=${stderr}`);
+  if (parts.length === 0) parts.push(`message=${firstLine(e.message)}`);
+  return parts.join(" ");
+}
+
+/** Summarise why the `fs.rmSync` fallback failed (code + offending path). */
+function describeFsFailure(error: unknown): string {
+  const e = error as {
+    code?: string;
+    syscall?: string;
+    path?: string;
+    message?: string;
+  };
+  const parts: string[] = [];
+  if (e.code) parts.push(`code=${e.code}`);
+  if (e.syscall) parts.push(`syscall=${e.syscall}`);
+  if (e.path) parts.push(`at=${e.path}`);
+  if (parts.length === 0) parts.push(`message=${firstLine(e.message)}`);
+  return parts.join(" ");
+}
+
+/**
+ * Describe what is still on disk after a failed removal. Without this a
+ * failure log cannot distinguish "directory already gone" from "the whole
+ * checkout is still sitting there".
+ */
+function probeResidue(worktreePath: string): string {
+  try {
+    if (!fs.existsSync(worktreePath)) return "none";
+    const entries = fs.readdirSync(worktreePath) as string[];
+    const head = entries.slice(0, 5).join(",");
+    return `${entries.length}[${head}${entries.length > 5 ? ",…" : ""}]`;
+  } catch (error) {
+    return `unknown(${(error as { code?: string }).code ?? "error"})`;
+  }
+}
+
 /**
  * Remove a git worktree and its associated branch
  * @param session Worktree session details
@@ -386,7 +446,7 @@ export async function removeWorktree(session: WorktreeSession): Promise<void> {
     );
   } catch (error: unknown) {
     logger.warn(
-      "git worktree remove failed, falling back to fs.rmSync:",
+      `git worktree remove failed, falling back to fs.rmSync: ${describeGitFailure(error)}`,
       error,
     );
     try {
@@ -395,7 +455,15 @@ export async function removeWorktree(session: WorktreeSession): Promise<void> {
         force: true,
       });
     } catch (rmError: unknown) {
-      logger.error("Failed to remove worktree or branch:", rmError);
+      // Removal failures are best-effort, so this line is often the only trace
+      // of an orphaned worktree directory: record which stage failed, why, and
+      // whether anything was left behind.
+      logger.error(
+        `Failed to remove worktree or branch: path=${session.path} stage=fs ` +
+          `${describeFsFailure(rmError)} residue=${probeResidue(session.path)} ` +
+          `git(${describeGitFailure(error)})`,
+        rmError,
+      );
     }
     // git removes worktree metadata before the working directory; prune any
     // leftovers in case git failed before deleting them.

--- a/packages/code/tests/utils/worktree.test.ts
+++ b/packages/code/tests/utils/worktree.test.ts
@@ -59,6 +59,7 @@ vi.mock("node:child_process", async () => {
 vi.mock("node:fs", () => ({
   existsSync: vi.fn(),
   mkdirSync: vi.fn(),
+  readdirSync: vi.fn(),
   rmSync: vi.fn(),
   promises: {
     readFile: vi.fn(),
@@ -516,6 +517,71 @@ describe("worktree utils", () => {
       expect(gitCallsWith(["branch", "-D", "worktree-my-feat"])).toHaveLength(
         1,
       );
+      loggerSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("should log the failing stage, error details and the residue left behind", async () => {
+      const loggerSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+      git.handler = (_cmd, args) => {
+        if (args[0] === "worktree" && args[1] === "remove") {
+          throw gitError(
+            "Filename too long",
+            "error: failed to delete 'my-feat': Filename too long",
+          );
+        }
+        return { stdout: "", stderr: "" };
+      };
+      vi.mocked(fs.rmSync).mockImplementation(() => {
+        throw Object.assign(new Error("EPERM: operation not permitted"), {
+          code: "EPERM",
+          syscall: "rmdir",
+          path: "C:\\repo\\root\\.wave\\worktrees\\my-feat\\node_modules",
+        });
+      });
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        "node_modules",
+        "packages",
+      ] as unknown as Awaited<ReturnType<typeof fs.readdirSync>>);
+
+      await removeWorktree(session);
+
+      const message = loggerSpy.mock.calls[0].join(" ");
+      expect(message).toContain("Failed to remove worktree or branch");
+      expect(message).toContain(`path=${session.path}`);
+      // Which stage failed, with the OS error code and the offending path
+      expect(message).toContain("stage=fs");
+      expect(message).toContain("code=EPERM");
+      expect(message).toContain(
+        "at=C:\\repo\\root\\.wave\\worktrees\\my-feat\\node_modules",
+      );
+      // What git said before the fallback took over
+      expect(message).toContain("Filename too long");
+      // What is still on disk after both attempts
+      expect(message).toContain("residue=2[node_modules,packages]");
+      loggerSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("should report the residue as none when the directory is already gone", async () => {
+      const loggerSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+      git.handler = (_cmd, args) => {
+        if (args[0] === "worktree" && args[1] === "remove") {
+          throw gitError("Filename too long", "");
+        }
+        return { stdout: "", stderr: "" };
+      };
+      vi.mocked(fs.rmSync).mockImplementation(() => {
+        throw new Error("rm failed");
+      });
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      await removeWorktree(session);
+
+      expect(loggerSpy.mock.calls[0].join(" ")).toContain("residue=none");
       loggerSpy.mockRestore();
       warnSpy.mockRestore();
     });

--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -3007,8 +3007,15 @@ export class DesktopHost {
   ): Promise<void> {
     try {
       await this.utilityClientFor(host).request("removeWorktree", params);
-    } catch {
-      // best-effort — stdio removeWorktree never throws
+    } catch (error) {
+      // Best-effort: the session is already gone, so a failure here only costs
+      // a leftover directory. Log it anyway — swallowing the request error is
+      // why an orphaned worktree had no trace at all when the RPC itself
+      // failed (host unreachable, stale CLI without the method, refused path).
+      console.warn(
+        `[DesktopHost] worktree 清理请求失败 host=${host} path=${params.path} branch=${params.branch}:`,
+        error,
+      );
     }
   }
 

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -56,6 +56,7 @@ const h = vi.hoisted(() => ({
         return h.worktreeResult;
       }
       case "removeWorktree":
+        if (h.removeWorktreeError) throw h.removeWorktreeError;
         if (h.removeWorktreeGate)
           return h.removeWorktreeGate.then(() => ({ removed: true }));
         return { removed: true };
@@ -85,6 +86,10 @@ const h = vi.hoisted(() => ({
   // When set, the removeWorktree RPC awaits this promise (simulates a slow
   // multi-second git worktree remove in the shared stdio process).
   removeWorktreeGate: null as Promise<void> | null,
+  // When set, the removeWorktree RPC rejects (host unreachable, stale CLI
+  // without the method, path validation refused) — the host must log why
+  // instead of swallowing the worktree cleanup failure.
+  removeWorktreeError: null as Error | null,
   // When set, agent.initialize awaits this promise (simulates the multi-second
   // stdio startup so a real webview re-fires webviewReady while the new pane's
   // agent is still mid-spawn and not yet bound to the pane).
@@ -573,6 +578,7 @@ beforeEach(() => {
   h.worktreeError = null;
   h.branchesResult = null;
   h.removeWorktreeGate = null;
+  h.removeWorktreeError = null;
   h.initializeGate = null;
   h.agentCounter = 0;
   h.closedHandlers.length = 0;
@@ -4986,6 +4992,40 @@ describe("worktree flow", () => {
         repoRoot: worktree.repoRoot,
       },
     });
+  });
+
+  it("logs a failed removeWorktree request instead of swallowing it", async () => {
+    const { host, store } = await readyHost();
+    h.removeWorktreeError = new Error("Host unreachable");
+    store.upsertSession({
+      sessionId: "sess-wt-fail",
+      title: "wt",
+      workdir: worktree.repoRoot,
+      cwd: worktree.path,
+      createdAt: Date.now(),
+      lastActiveAt: Date.now(),
+      worktree: {
+        path: worktree.path,
+        branch: worktree.branch,
+        baseBranch: "main",
+        repoRoot: worktree.repoRoot,
+      },
+    });
+
+    await host.handleWebviewMessage({
+      command: "desktopDeleteSession",
+      sessionId: "sess-wt-fail",
+    });
+
+    // consoleSpies[1] is the console.warn spy installed in beforeEach — the
+    // request failing here used to be an empty catch, leaving no trace at all
+    // of why a worktree directory survived the session delete.
+    await vi.waitFor(() => expect(consoleSpies[1]).toHaveBeenCalled());
+    const logged = consoleSpies[1].mock.calls
+      .map((c) => c.join(" "))
+      .join("\n");
+    expect(logged).toContain(worktree.path);
+    expect(logged).toContain("Host unreachable");
   });
 
   it("desktopDeleteSession refreshes the tree without waiting for worktree removal", async () => {


### PR DESCRIPTION
## 背景

本地 `.wave/worktrees/` 下积累了约 90 个残留目录（96 个里只有 6 个是在用的 worktree，残留约 1.6GB）。排查确认：删除会话时 worktree 清理**有触发**（`handleDeleteSession` → `destroy()` → `removeWorktree` RPC → hook），但目录删除是 best-effort——失败只写日志、不重试、无兜底清扫；而原来的失败日志只有一句 `failed to remove worktree at: <path>`，既没有失败阶段/错误码，也没有残留清单，事后无法汇总。

本次**只补日志，不改任何行为**（不重试、不调整删除顺序、分支删除时机也未改动）。

## 改动

- `.wave/hooks/worktree-remove.mjs`：失败时输出结构化单行 `FAILED name=… path=… branch=… git(exit=…) fs(code=… syscall=… at=…) residue=N[前5项,…]`，并新增残留探测 `describeResidue()`；退出码仍为 1
- `packages/code/src/utils/worktree.ts`（非 hook 路径）：git 失败带 `code/signal/stderr 首行`；fs 失败带 `stage=fs/code/syscall/at/residue`，并保留 error 对象（stack 不丢）
- `packages/agent-sdk/src/services/worktreeHooks.ts`：hook 失败日志补 `worktree=<path> exit=… timedOut=… durationMs=…`，区分为 hook 自身失败还是被 hook 超时杀掉
- `packages/desktop/src/main/desktopHost.ts`：`removeWorktree` 原本是空 `catch {}`（完全静默），补 `console.warn`

## 验证

- 3 处新增用例走 TDD（先红后绿）；hook 用「临时 worktree + 把进程 CWD 钉进目录」真机复现真实 EPERM，实测输出：
  `worktree-remove: FAILED name=zz-hooklog-test … git(exit=255) fs(code=EPERM syscall=rm at=\?\C:\…\zz-hooklog-test) residue=8[node_modules,package.json,packages,pnpm-lock.yaml,pnpm-workspace.yaml,…]`
- agent-sdk 256 文件 / 3718 passed，code 101 文件 / 1470 passed，desktop 601 passed；`type-check` 与 `lint` 全绿