### PR TITLE
fix(worktree): 不再相信 git 退出码，删完校验目录并兜底（修 junction 静默残留）

### DIFF
--- a/.wave/hooks/worktree-remove.mjs
+++ b/.wave/hooks/worktree-remove.mjs
@@ -2,7 +2,9 @@
 // WorktreeRemove hook: reads { worktree_path } from stdin and removes the
 // worktree. Best-effort, mirroring the git removal wave uses for non-hook
 // worktrees: `git worktree remove --force` + branch delete + prune, with an
-// fs.rmSync fallback for Windows MAX_PATH-limited removals.
+// fs.rmSync fallback. The fallback is not only for MAX_PATH: git reports
+// success after failing to delete directory symlinks/junctions (what pnpm's
+// node_modules consists of on Windows), so removal is verified on disk.
 import { spawnSync } from "node:child_process";
 import {
   readFileSync,
@@ -114,7 +116,20 @@ const gitResult = existsSync(worktreePath)
       stdio: "inherit",
     })
   : null;
-let removed = gitResult === null || gitResult.status === 0;
+const gitOk = gitResult === null || gitResult.status === 0;
+// git exits 0 even when it did not delete the directory: on Windows it cannot
+// remove the directory symlinks/junctions that pnpm's node_modules is made of,
+// so it deletes the files, leaves the skeleton behind and still reports
+// success. Verify on disk instead of trusting the exit status.
+const gitLeftResidue = gitOk && gitResult !== null && existsSync(worktreePath);
+if (gitLeftResidue) {
+  console.error(
+    `worktree-remove: git reported success but the directory survived ` +
+      `(junction residue?): path=${worktreePath} ` +
+      `residue=${describeResidue(worktreePath)} — falling back to fs.rmSync`,
+  );
+}
+let removed = gitOk && !gitLeftResidue;
 // git's own message goes to stderr via stdio:inherit; without its exit status
 // the log cannot tell a MAX_PATH refusal from a locked directory.
 const gitSummary =
@@ -122,7 +137,8 @@ const gitSummary =
     ? "skipped(missing)"
     : `exit=${gitResult.status ?? "null"}` +
       (gitResult.signal ? ` signal=${gitResult.signal}` : "") +
-      (gitResult.error ? ` error=${gitResult.error.message}` : "");
+      (gitResult.error ? ` error=${gitResult.error.message}` : "") +
+      ` leftResidue=${gitLeftResidue}`;
 
 // 2. fs.rmSync fallback for MAX_PATH-limited removals (git leaves an orphan dir)
 let fsSummary = "skipped";
@@ -142,6 +158,9 @@ if (!removed && existsSync(worktreePath)) {
 // 3. Prune stale metadata and delete the worktree branch
 spawnSync("git", ["worktree", "prune"], { cwd: repoRoot });
 spawnSync("git", ["branch", "-D", "--", branch], { cwd: repoRoot });
+
+// Final word: what is on disk, not what any tool reported.
+removed = !existsSync(worktreePath);
 
 if (!removed) {
   console.error(

--- a/packages/code/src/utils/worktree.ts
+++ b/packages/code/src/utils/worktree.ts
@@ -368,6 +368,23 @@ function describeFsFailure(error: unknown): string {
 }
 
 /**
+ * Delete the worktree directory with `fs.rmSync`, returning the error when it
+ * fails (null on success). Node removes directory symlinks/junctions properly,
+ * which is exactly where git gives up on Windows.
+ */
+function rmWorktreeDirWithFs(worktreePath: string): unknown | null {
+  try {
+    fs.rmSync(toExtendedLengthPath(worktreePath), {
+      recursive: true,
+      force: true,
+    });
+    return null;
+  } catch (error) {
+    return error;
+  }
+}
+
+/**
  * Describe what is still on disk after a failed removal. Without this a
  * failure log cannot distinguish "directory already gone" from "the whole
  * checkout is still sitting there".
@@ -444,17 +461,33 @@ export async function removeWorktree(session: WorktreeSession): Promise<void> {
         cwd: repoRoot,
       },
     );
+    // git exits 0 even when it did not delete the directory: on Windows it
+    // cannot remove directory symlinks/junctions, which is exactly what pnpm's
+    // node_modules is made of — so it deletes the files, leaves the skeleton
+    // behind and still reports success. Trust the filesystem, not the exit code.
+    if (fs.existsSync(session.path)) {
+      logger.warn(
+        `git worktree remove reported success but the directory survived: ` +
+          `path=${session.path} residue=${probeResidue(session.path)} — ` +
+          `deleting with fs.rmSync instead`,
+      );
+      const rmError = rmWorktreeDirWithFs(session.path);
+      if (rmError) {
+        logger.error(
+          `Failed to remove worktree or branch: path=${session.path} ` +
+            `stage=fs(after git success) ${describeFsFailure(rmError)} ` +
+            `residue=${probeResidue(session.path)}`,
+          rmError,
+        );
+      }
+    }
   } catch (error: unknown) {
     logger.warn(
       `git worktree remove failed, falling back to fs.rmSync: ${describeGitFailure(error)}`,
       error,
     );
-    try {
-      fs.rmSync(toExtendedLengthPath(session.path), {
-        recursive: true,
-        force: true,
-      });
-    } catch (rmError: unknown) {
+    const rmError = rmWorktreeDirWithFs(session.path);
+    if (rmError) {
       // Removal failures are best-effort, so this line is often the only trace
       // of an orphaned worktree directory: record which stage failed, why, and
       // whether anything was left behind.

--- a/packages/code/tests/utils/worktree.test.ts
+++ b/packages/code/tests/utils/worktree.test.ts
@@ -565,6 +565,54 @@ describe("worktree utils", () => {
       warnSpy.mockRestore();
     });
 
+    it("should fall back to fs.rmSync when git reports success but the directory survived", async () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+      git.handler = (_cmd, args) => {
+        if (args[0] === "rev-parse") {
+          return { stdout: "worktree-my-feat\n", stderr: "" };
+        }
+        // git exits 0 even when it could not delete the directory: on Windows
+        // it cannot remove the directory symlinks/junctions pnpm's node_modules
+        // is made of.
+        return { stdout: "", stderr: "" };
+      };
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        "node_modules",
+      ] as unknown as Awaited<ReturnType<typeof fs.readdirSync>>);
+
+      await removeWorktree(session);
+
+      const rmCalls = vi.mocked(fs.rmSync).mock.calls;
+      expect(rmCalls).toHaveLength(1);
+      expect(rmCalls[0][1]).toMatchObject({ recursive: true, force: true });
+      if (process.platform === "win32") {
+        expect(String(rmCalls[0][0])).toMatch(/^\\\\\?\\/);
+      }
+      expect(warnSpy.mock.calls[0][0]).toContain(
+        "git worktree remove reported success but the directory survived",
+      );
+      // Branch handling is unchanged
+      expect(gitCallsWith(["branch", "-D", "worktree-my-feat"])).toHaveLength(
+        1,
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("should not touch the filesystem when git succeeds and the directory is gone", async () => {
+      git.handler = (_cmd, args) => {
+        if (args[0] === "rev-parse") {
+          return { stdout: "worktree-my-feat\n", stderr: "" };
+        }
+        return { stdout: "", stderr: "" };
+      };
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      await removeWorktree(session);
+
+      expect(vi.mocked(fs.rmSync)).not.toHaveBeenCalled();
+    });
+
     it("should report the residue as none when the directory is already gone", async () => {
       const loggerSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
       const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});


### PR DESCRIPTION
## 根因（受控实验复现）

`git worktree remove --force` **删不掉目录符号链接/junction**——pnpm 在 Windows 正是用 junction 铺 `node_modules/<pkg> → .pnpm/<pkg>@<ver>/node_modules/<pkg>`。git 把普通文件删光、junction 留下、父目录因此非空，**却返回 exit 0 + stderr 为空**。

wave 只在 git **非 0** 时才跑 `fs.rmSync` 兜底，于是这类失败**完全静默**：一行日志都没有，残留骨架无人知晓地越积越多。

实机影响：本机 `.wave/worktrees/` 96 个目录里 **90 个是残留**，其中 **84 个正是这种「0 文件 + junction 骨架」**（另有 6 个「整棵 checkout 留下」是另一类：目录被活进程 CWD 锁住，git 会真的报错并已有日志）。

最小复现（scratch worktree + 一个 junction + 一个普通文件）：

```
=== git worktree remove --force ===
exit status: 0
stderr: ""
dir still exists: true
residue:
node_modules
  @types
    a  <- symlink        ← 普通文件被删了，junction 留下，父目录因此非空
```

对照实验：树里**没有 junction** 时，哪怕路径 385 字符（超 MAX_PATH，本仓库 `core.longpaths=true`）也删得干干净净、exit 0 → **既不是 MAX_PATH 也不是锁**。二次确认：删 6 个「在用」worktree 时，6/6 报成功、注册表清空、分支删除，但 6/6 都留下骨架。

## 修复

- `packages/code/src/utils/worktree.ts`（非 hook 路径）：git 成功后**仍 `fs.existsSync` 校验**，目录还在就 warn 并落到抽出的 `rmWorktreeDirWithFs()`（Node 能正常删 junction），失败才 `logger.error`
- `.wave/hooks/worktree-remove.mjs`：同样不信退出码（`gitOk && existsSync` 判为静默失败 → 告警 + `fs.rmSync` 兜底），且**最终以 `!existsSync(worktreePath)` 作为唯一的成功判据**；摘要行补 `leftResidue=`

## 验证

- TDD 先红后绿 2 例：git 报成功但目录还在 → 必须 fallback + 告警；git 成功且目录已消失 → 不许碰文件系统。`worktree.test.ts` 36/36
- **真机（junction 场景，正是根因）**：hook 现输出 `git reported success but the directory survived (junction residue?): path=… residue=1[node_modules] — falling back to fs.rmSync`，退出码 0，**目录确实删净**（修复前=静默留骨架、零日志）
- 回归：code 1474 passed / desktop 603 passed / `lint` 0-0 / `type-check` 全绿