### PR TITLE
test(agent-sdk): 修 Windows 8.3 短路径导致的 tilde 断言误报（main Windows CI 连续 4 红）

### DIFF
--- a/packages/agent-sdk/tests/services/configurationService.test.ts
+++ b/packages/agent-sdk/tests/services/configurationService.test.ts
@@ -1632,8 +1632,10 @@ describe("ConfigurationService", () => {
       expect(configService.getHookConfigPath(tempDir, "project")).toBe(
         path.join(tempDir, ".wave", "settings.json"),
       );
-      expect(configService.getHookConfigPath(tempDir, "user")).not.toContain(
-        "~",
+      // 只拒绝「未展开的前导 ~」：不能断言整条路径不含 `~`，因为 Windows
+      // 8.3 短路径（C:\Users\RUNNER~1\...）里的 `~` 是合法路径字符。
+      expect(configService.getHookConfigPath(tempDir, "user")).not.toMatch(
+        /^~/,
       );
     });
 


### PR DESCRIPTION
## 根因

`packages/agent-sdk/tests/services/configurationService.test.ts` 的
`getHookConfigPath returns the absolute settings.json path for both scopes` 用例里那句

```ts
expect(configService.getHookConfigPath(tempDir, "user")).not.toContain("~");
```

本意是「宿主 GUI 拿到的必须是 OS 绝对路径，不能是未展开的 shell `~` 字面量」。
但断言写成了对**整条路径**做子串匹配：Windows runner 的 TEMP / 家目录是 8.3 短路径
`C:\Users\RUNNER~1\AppData\Local\Temp\...`，`~` 在那里是**合法路径字符** → 误报。

main 的 CI (Windows) 自 PR #2160 合入后连续 4 次红（04:51 / 04:20 / 03:45 / 03:39Z），
唯一失败用例就是这个，报错：

```
AssertionError: expected 'C:\Users\RUNNER~1\AppData\Local\Temp\…' not to contain '~'
```

## 影响范围

- 仅 Windows job（`ci-windows.yml`，非阻塞、push 到 main 后跑）受影响；
- **不是产品缺陷**：`getHookConfigPath` 返回的就是 `path.join(os.homedir(), ".wave", "settings.json")`，
  Windows 上同样正确，只是测试断言过宽；
- Linux / macOS 侧 CI 与产品行为零变化。

## 改动

- 断言改为 `not.toMatch(/^~/)`（只拒绝未展开的**前导** `~`），并补注释说明
  「Windows 8.3 短路径含 `~` 属合法，这里只拒绝未展开的前导 `~`」；
- 同一用例里 project scope 的两条断言是 `toBe(path.join(tempDir, ".wave", "settings.json"))`
  的精确相等比较，没有 `~` 子串判断 → 无同类问题，未改动；
- `packages/webview/e2e/settings-edit-openfile.e2e.ts:102` 的 `.not.toContain("~")` **有意不动**：
  该断言跑在 `webview-e2e` job（`ubuntu-latest`，固定 fixture 常量 `/home/u/.wave/settings.json`，
  非 `os.tmpdir()`/`homedir()` 插值），Windows 短路径不会出现；且它前面紧邻 `toBe(expectedPath)`，
  作用是兜住 fixture 本身别硬编码成 `~` 字面量，保留有意义。
- 全仓 grep 同类写法（`not.toContain("~")` / `not.toMatch(/~/`）后，其余命中均为
  **正向断言**（`code/tests/components/HooksManager.test.tsx:114` 断言 UI 里硬编码的
  `~/.wave/settings.json` 提示文案、`MessageBlockItem.test.tsx:53` 断言 tilde 缩写展示、
  `desktop/tests/remoteCli.test.ts:803` 断言远端 shell 命令保留 `~`）或与 tilde 无关的
  bracketed-paste 转义序列（`[200~` / `[201~`），均不涉及本问题，未改动。

## 验证

在 worktree 里执行（`cd .wave/worktrees/fix-win-tilde-assert`）：

| 命令 | 结果 |
| --- | --- |
| `pnpm -F wave-agent-sdk test tests/services/configurationService.test.ts` | 1 file / **91 passed**，exit 0 |
| `TMPDIR="/tmp/wave~short" pnpm -F wave-agent-sdk exec vitest run tests/services/configurationService.test.ts -t "getHookConfigPath"` | exit 0（模拟 Windows 8.3 短路径）|
| `pnpm -F wave-agent-sdk test:unit` | 256 files / **3718 passed**，2 skipped，exit 0 |
| `pnpm run type-check` | 6 包全 Done，exit 0 |
| `pnpm lint`（oxlint）| 0 warnings / 0 errors，exit 0 |
| `pnpm exec prettier --check <改动的测试文件>` | All matched files use Prettier code style!，exit 0 |

**fail-without-fix 复现**：把 `TMPDIR` 指到含 `~` 的目录（`/tmp/wave~short`）后，
改动前的断言（`not.toContain("~")`）稳定失败
（`1 failed | 90 skipped`），与 Windows runner 上的报错同形；改成 `not.toMatch(/^~/)` 后同一
条件下转绿 —— 说明这条断言确实被走到、且误报已消除。

## 备注

纯测试断言修复，不涉及产品代码，无需改 spec。**等确认后再合并。**
