### PR TITLE
fix(worktree): 目录没删掉就不再删分支，避免残留 checkout 脱离 git

### DIFF
--- a/.wave/hooks/worktree-remove.mjs
+++ b/.wave/hooks/worktree-remove.mjs
@@ -155,17 +155,24 @@ if (!removed && existsSync(worktreePath)) {
   }
 }
 
-// 3. Prune stale metadata and delete the worktree branch
+// 3. Prune stale metadata — harmless either way, it only drops entries whose
+// directory is already gone.
 spawnSync("git", ["worktree", "prune"], { cwd: repoRoot });
-spawnSync("git", ["branch", "-D", "--", branch], { cwd: repoRoot });
 
 // Final word: what is on disk, not what any tool reported.
 removed = !existsSync(worktreePath);
 
 if (!removed) {
+  // The branch is deliberately kept: the leftover checkout (and any uncommitted
+  // work in it) would otherwise be stranded outside git, with no ref left
+  // pointing at it.
   console.error(
     `worktree-remove: FAILED name=${name} path=${worktreePath} branch=${branch} ` +
-      `git(${gitSummary}) fs(${fsSummary}) residue=${describeResidue(worktreePath)}`,
+      `git(${gitSummary}) fs(${fsSummary}) residue=${describeResidue(worktreePath)} ` +
+      `branchKept=true`,
   );
   process.exit(1);
 }
+
+// 4. Delete the worktree branch — only now that the directory is really gone
+spawnSync("git", ["branch", "-D", "--", branch], { cwd: repoRoot });

--- a/packages/agent-sdk/src/utils/worktreeUtils.ts
+++ b/packages/agent-sdk/src/utils/worktreeUtils.ts
@@ -625,6 +625,35 @@ function toExtendedLengthPath(worktreePath: string): string {
 }
 
 /**
+ * Describe what is still on disk after a failed removal. Without this a log
+ * line cannot distinguish "directory already gone" from "the whole checkout is
+ * still sitting there".
+ */
+function probeResidue(worktreePath: string): string {
+  try {
+    if (!fs.existsSync(worktreePath)) return "none";
+    const entries = fs.readdirSync(worktreePath) as string[];
+    const head = entries.slice(0, 5).join(",");
+    return `${entries.length}[${head}${entries.length > 5 ? ",…" : ""}]`;
+  } catch (error) {
+    return `unknown(${(error as { code?: string }).code ?? "error"})`;
+  }
+}
+
+/** Delete the worktree directory with fs.rmSync; returns the error, if any. */
+function rmWorktreeDirWithFs(worktreePath: string): unknown | null {
+  try {
+    fs.rmSync(toExtendedLengthPath(worktreePath), {
+      recursive: true,
+      force: true,
+    });
+    return null;
+  } catch (error) {
+    return error;
+  }
+}
+
+/**
  * Remove a git worktree and its branch.
  *
  * Removal is best-effort: `git worktree remove --force` deletes the worktree
@@ -632,7 +661,8 @@ function toExtendedLengthPath(worktreePath: string): string {
  * is MAX_PATH-limited — deep paths (e.g. node_modules) can fail with "Filename
  * too long", leaving an orphan directory. When git fails we fall back to
  * fs.rmSync with an extended-length path (bypasses MAX_PATH) and prune stale
- * metadata. Failures are logged but never block branch deletion.
+ * metadata. Failures are logged; when the directory survives, its branch is
+ * deliberately kept so the leftover checkout stays reachable through git.
  */
 export function removeWorktree(info: WorktreeInfo): void {
   const repoRoot = info.repoRoot;
@@ -655,6 +685,28 @@ export function removeWorktree(info: WorktreeInfo): void {
       cwd: repoRoot,
       stdio: ["ignore", "pipe", "pipe"],
     });
+    // git exits 0 even when it did not delete the directory: on Windows it
+    // cannot remove the directory symlinks/junctions that pnpm's node_modules
+    // is made of, so it deletes the files, leaves the skeleton behind and still
+    // reports success. Verify on disk instead of trusting the exit status.
+    if (fs.existsSync(info.path)) {
+      logger.warn(
+        "git worktree remove reported success but the directory survived, falling back to fs.rmSync:",
+        {
+          worktreePath: info.path,
+          residue: probeResidue(info.path),
+        },
+      );
+      const rmError = rmWorktreeDirWithFs(info.path);
+      if (rmError !== null) {
+        logger.error("Failed to remove worktree or branch:", {
+          worktreePath: info.path,
+          stage: "fs(after git success)",
+          error: rmError instanceof Error ? rmError.message : String(rmError),
+          residue: probeResidue(info.path),
+        });
+      }
+    }
   } catch (error: unknown) {
     logger.warn("git worktree remove failed, falling back to fs.rmSync:", {
       error: error instanceof Error ? error.message : String(error),
@@ -681,6 +733,24 @@ export function removeWorktree(info: WorktreeInfo): void {
     } catch {
       // Ignore errors
     }
+  }
+
+  // The directory, not any exit code, decides whether the removal happened. A
+  // surviving directory means its checkout (and any uncommitted work in it) is
+  // still on disk, and the branch is the only ref still leading back to it.
+  if (fs.existsSync(info.path)) {
+    const keptBranches =
+      currentBranch && currentBranch !== info.branch
+        ? `${info.branch} and ${currentBranch}`
+        : info.branch;
+    logger.warn(
+      `Worktree directory survived removal — keeping ${keptBranches} so the leftover checkout stays reachable:`,
+      {
+        worktreePath: info.path,
+        residue: probeResidue(info.path),
+      },
+    );
+    return;
   }
 
   // Delete worktree branch

--- a/packages/agent-sdk/tests/utils/worktreeUtils.test.ts
+++ b/packages/agent-sdk/tests/utils/worktreeUtils.test.ts
@@ -49,6 +49,7 @@ vi.mock("node:fs", () => ({
   lstatSync: vi.fn(),
   realpathSync: vi.fn(),
   readFileSync: vi.fn(),
+  readdirSync: vi.fn(),
   appendFileSync: vi.fn(),
   rmSync: vi.fn(),
   promises: {
@@ -403,6 +404,9 @@ describe("worktreeUtils", () => {
     });
 
     it("removes worktree and branch", () => {
+      // git removed the directory successfully
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
       worktreeUtils.removeWorktree({
         name: "feat",
         path: "/test/repo/.wave/worktrees/feat",
@@ -431,6 +435,8 @@ describe("worktreeUtils", () => {
         }
         return "";
       });
+      // The fallback worked: the directory is gone once fs.rmSync returns
+      vi.mocked(fs.existsSync).mockReturnValue(false);
 
       expect(() =>
         worktreeUtils.removeWorktree({
@@ -467,7 +473,7 @@ describe("worktreeUtils", () => {
       );
     });
 
-    it("logs and still deletes the branch when git and fs.rmSync both fail", () => {
+    it("keeps the branch when the directory survived both removal attempts", () => {
       vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
         if (args?.includes("remove") && args?.includes("worktree")) {
           throw new Error("git failed");
@@ -477,6 +483,12 @@ describe("worktreeUtils", () => {
       vi.mocked(fs.rmSync).mockImplementation(() => {
         throw new Error("rm failed");
       });
+      // The directory is still there: its checkout (and any uncommitted work in
+      // it) would be stranded outside git if the branch were deleted too.
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        "node_modules",
+      ] as unknown as Awaited<ReturnType<typeof fs.readdirSync>>);
 
       expect(() =>
         worktreeUtils.removeWorktree({
@@ -488,7 +500,35 @@ describe("worktreeUtils", () => {
         }),
       ).not.toThrow();
 
-      // Branch deletion still runs even when both removal attempts fail
+      expect(execFileSync).not.toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["branch", "-D"]),
+        expect.anything(),
+      );
+    });
+
+    it("falls back to fs.rmSync when git reports success but the directory survived", () => {
+      // git exits 0 even when it could not delete the directory: on Windows it
+      // cannot remove the directory symlinks/junctions pnpm's node_modules is
+      // made of (which is also why the branch must be kept if it survives).
+      vi.mocked(fs.existsSync).mockReturnValueOnce(true).mockReturnValue(false);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        "node_modules",
+      ] as unknown as Awaited<ReturnType<typeof fs.readdirSync>>);
+
+      worktreeUtils.removeWorktree({
+        name: "feat",
+        path: "/test/repo/.wave/worktrees/feat",
+        branch: "worktree-feat",
+        repoRoot: "/test/repo",
+        isNew: true,
+      });
+
+      expect(fs.rmSync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ recursive: true, force: true }),
+      );
+      // The fallback deleted the directory, so the branch still goes away
       expect(execFileSync).toHaveBeenCalledWith(
         "git",
         expect.arrayContaining(["branch", "-D", "worktree-feat"]),

--- a/packages/code/src/utils/worktree.ts
+++ b/packages/code/src/utils/worktree.ts
@@ -409,7 +409,8 @@ function probeResidue(worktreePath: string): string {
  * is MAX_PATH-limited — deep paths (e.g. node_modules) can fail with "Filename
  * too long", leaving an orphan directory. When git fails we fall back to
  * fs.rmSync with an extended-length path (bypasses MAX_PATH) and prune stale
- * metadata. Failures are logged but never block branch deletion.
+ * metadata. Failures are logged; when the directory survives, its branch is
+ * deliberately kept so the leftover checkout stays reachable through git.
  */
 export async function removeWorktree(session: WorktreeSession): Promise<void> {
   // Hook-based worktrees are removed by the WorktreeRemove hook; wave never
@@ -507,6 +508,22 @@ export async function removeWorktree(session: WorktreeSession): Promise<void> {
     } catch {
       // Ignore errors pruning stale metadata
     }
+  }
+
+  // The directory, not any exit code, decides whether the removal happened. A
+  // surviving directory means its checkout (and any uncommitted work in it) is
+  // still on disk, and the branch is the only ref still leading back to it.
+  if (fs.existsSync(session.path)) {
+    const keptBranches =
+      currentBranch && currentBranch !== session.branch
+        ? `${session.branch} and ${currentBranch}`
+        : session.branch;
+    logger.warn(
+      `Worktree directory survived removal — keeping ${keptBranches} so the ` +
+        `leftover checkout stays reachable: path=${session.path} ` +
+        `residue=${probeResidue(session.path)}`,
+    );
+    return;
   }
 
   // Delete original branch

--- a/packages/code/tests/utils/worktree.test.ts
+++ b/packages/code/tests/utils/worktree.test.ts
@@ -421,6 +421,8 @@ describe("worktree utils", () => {
         }
         return { stdout: "", stderr: "" };
       };
+      // git removed the directory successfully
+      vi.mocked(fs.existsSync).mockReturnValue(false);
 
       await removeWorktree(session);
 
@@ -438,6 +440,7 @@ describe("worktree utils", () => {
         }
         return { stdout: "", stderr: "" };
       };
+      vi.mocked(fs.existsSync).mockReturnValue(false);
 
       await removeWorktree(session);
 
@@ -456,6 +459,7 @@ describe("worktree utils", () => {
         }
         return { stdout: "", stderr: "" };
       };
+      vi.mocked(fs.existsSync).mockReturnValue(false);
 
       await removeWorktree(session);
 
@@ -466,7 +470,7 @@ describe("worktree utils", () => {
       expect(gitCallsWith(["branch", "-D", "main"])).toHaveLength(0);
     });
 
-    it("should fall back to fs.rmSync and still delete the branch when git removal fails", async () => {
+    it("should fall back to fs.rmSync when git removal fails, then delete the branch", async () => {
       const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
       git.handler = (_cmd, args) => {
         if (args[0] === "worktree" && args[1] === "remove") {
@@ -474,6 +478,8 @@ describe("worktree utils", () => {
         }
         return { stdout: "", stderr: "" };
       };
+      // The fallback worked: the directory is gone once fs.rmSync returns
+      vi.mocked(fs.existsSync).mockReturnValue(false);
 
       await removeWorktree(session);
 
@@ -495,10 +501,13 @@ describe("worktree utils", () => {
       warnSpy.mockRestore();
     });
 
-    it("should log error but still delete the branch when git and fs.rmSync both fail", async () => {
+    it("should keep the branch when the directory survived both removal attempts", async () => {
       const loggerSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
       const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
       git.handler = (_cmd, args) => {
+        if (args[0] === "rev-parse") {
+          return { stdout: "worktree-my-feat\n", stderr: "" };
+        }
         if (args[0] === "worktree" && args[1] === "remove") {
           throw gitError("Filename too long", "");
         }
@@ -507,15 +516,55 @@ describe("worktree utils", () => {
       vi.mocked(fs.rmSync).mockImplementation(() => {
         throw new Error("rm failed");
       });
+      // The directory is still there, so its checkout (and any uncommitted work
+      // in it) would be stranded outside git if the branch were deleted too.
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        "node_modules",
+      ] as unknown as Awaited<ReturnType<typeof fs.readdirSync>>);
 
       await removeWorktree(session);
 
       expect(loggerSpy.mock.calls[0][0]).toContain(
         "Failed to remove worktree or branch",
       );
-      // Branch deletion still runs even when both removal attempts fail
+      expect(gitCallsWith(["branch", "-D"])).toHaveLength(0);
+      expect(warnSpy.mock.calls.map((c) => c[0]).join(" ")).toContain(
+        "Worktree directory survived removal",
+      );
+      loggerSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("should keep the branch checked out in the worktree as well", async () => {
+      vi.mocked(getDefaultRemoteBranch).mockReturnValue("origin/main");
+      git.handler = (_cmd, args) => {
+        if (args[0] === "rev-parse") {
+          return { stdout: "another-branch\n", stderr: "" };
+        }
+        if (args[0] === "worktree" && args[1] === "remove") {
+          throw gitError("Filename too long", "");
+        }
+        return { stdout: "", stderr: "" };
+      };
+      vi.mocked(fs.rmSync).mockImplementation(() => {
+        throw new Error("rm failed");
+      });
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        "node_modules",
+      ] as unknown as Awaited<ReturnType<typeof fs.readdirSync>>);
+      const loggerSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+      await removeWorktree(session);
+
       expect(gitCallsWith(["branch", "-D", "worktree-my-feat"])).toHaveLength(
-        1,
+        0,
+      );
+      expect(gitCallsWith(["branch", "-D", "another-branch"])).toHaveLength(0);
+      expect(warnSpy.mock.calls.map((c) => c[0]).join(" ")).toContain(
+        "worktree-my-feat and another-branch",
       );
       loggerSpy.mockRestore();
       warnSpy.mockRestore();
@@ -576,7 +625,8 @@ describe("worktree utils", () => {
         // is made of.
         return { stdout: "", stderr: "" };
       };
-      vi.mocked(fs.existsSync).mockReturnValue(true);
+      // Still there after git returned 0; gone once fs.rmSync deleted it
+      vi.mocked(fs.existsSync).mockReturnValueOnce(true).mockReturnValue(false);
       vi.mocked(fs.readdirSync).mockReturnValue([
         "node_modules",
       ] as unknown as Awaited<ReturnType<typeof fs.readdirSync>>);
@@ -592,10 +642,38 @@ describe("worktree utils", () => {
       expect(warnSpy.mock.calls[0][0]).toContain(
         "git worktree remove reported success but the directory survived",
       );
-      // Branch handling is unchanged
+      // The fallback deleted the directory, so the branch still goes away
       expect(gitCallsWith(["branch", "-D", "worktree-my-feat"])).toHaveLength(
         1,
       );
+      warnSpy.mockRestore();
+    });
+
+    it("should keep the branch when git reports success yet the directory survives", async () => {
+      git.handler = (_cmd, args) => {
+        if (args[0] === "rev-parse") {
+          return { stdout: "worktree-my-feat\n", stderr: "" };
+        }
+        return { stdout: "", stderr: "" };
+      };
+      // fs.rmSync cannot delete the skeleton either (locked directory)
+      vi.mocked(fs.rmSync).mockImplementation(() => {
+        throw new Error("EPERM: operation not permitted");
+      });
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        "node_modules",
+      ] as unknown as Awaited<ReturnType<typeof fs.readdirSync>>);
+      const loggerSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+      await removeWorktree(session);
+
+      expect(gitCallsWith(["branch", "-D"])).toHaveLength(0);
+      expect(warnSpy.mock.calls.map((c) => c[0]).join(" ")).toContain(
+        "Worktree directory survived removal",
+      );
+      loggerSpy.mockRestore();
       warnSpy.mockRestore();
     });
 


### PR DESCRIPTION
## 问题

残留目录（Windows 上被活进程 CWD 锁住，或 git 删不掉 junction 的那种）意味着那棵 checkout——连同里面未提交的改动——**还在磁盘上**，而 `worktree-<name>` 分支是唯一还能指回它的 ref。原来三条删除路径都在删完目录后**无条件** `git branch -D`，于是「目录删失败 + 分支删成功」= 源码树变成 git 管不着的孤儿，未提交的改动无从找回。

## 修复

把「目录是否真的消失」当作唯一判据：

- `packages/code/src/utils/worktree.ts`（desktop/CLI 共用）：删分支前检查 `fs.existsSync(session.path)`，目录还在就告警（打印保留的分支名与 residue）并返回，两条 `branch -D` 都不再执行
- `.wave/hooks/worktree-remove.mjs`：`git branch -D` 挪到 `removed = !existsSync(worktreePath)` 之后，目录存活直接 `exit(1)`，FAILED 行补 `branchKept=true`
- `packages/agent-sdk/src/utils/worktreeUtils.ts`（**第三条平行实现**，ExitWorktree 工具走的路径）：同样的守卫

顺带补上 SDK 这条路径缺失的「git 报成功但目录还在」校验（#2163 只覆盖了 code + hook 两条）：只加守卫的话 junction 场景仍会「删分支、留骨架」，又落回同一类危险，所以连同 `probeResidue` / `rmWorktreeDirWithFs` 一起补齐。

## 验证

- **TDD**：两包各先写红再实现，最终 code 38/38、sdk 37/37
- **真机**（scratch 仓库，两包各跑一遍，真实 junction + 活进程 CWD 锁两种占用）：
  - junction 残留 → git 报成功、目录存活 → 回退 `fs.rmSync` → 目录删净、分支删除
  - 目录被锁 → 目录存活 → **分支保留**（修复前会被删）；hook 退出码 1、`branchKept=true`
- **回归**：code 1484 passed；agent-sdk 3862 passed，1 个失败为**既有**问题（`configurationService.test.ts` 的 `getHookConfigPath` 断言路径不含 `~`，撞上 Windows 8.3 短名 `C:\Users\LIUYIQ~1\...`；在干净 main 上复跑同样失败，与本次改动无关）
- 全仓 type-check、lint 0/0

未改 spec：属安全缺陷修复，不改用户可见需求。