### PR TITLE
feat(desktop): 更新检查加 1 小时周期轮询

### DIFF
--- a/docs/specs/desktop/desktop-account-and-settings.md
+++ b/docs/specs/desktop/desktop-account-and-settings.md
@@ -205,7 +205,7 @@ planExhausted = used >= planTotal
 
 - `desktopUpdateDownload`（webview → host）：用户确认 S2 后通知宿主开始下载。
 - `desktopUpdateRestart`（webview → host）：用户在 S4/S5 选择立即重启后通知宿主安装并重启。
-- **宿主接线**：webview 侧 S0–S6 状态机调用上述两个命令；宿主（desktopHost.ts）把 electron-updater 事件映射为 `update.status` 随 `desktopAccountInfo` 推送并响应两命令；toast 更新链路不提供（`autoDownload=false`，下载仅在 S2 确认后启动）。降级边界见 [desktop-shell.md](./desktop-shell.md)「桌面端自动更新」故事场景 5。
+- **宿主接线**：webview 侧 S0–S6 状态机调用上述两个命令；宿主（desktopHost.ts）把 electron-updater 事件映射为 `update.status` 随 `desktopAccountInfo` 推送并响应两命令；toast 更新链路不提供（`autoDownload=false`，下载仅在 S2 确认后启动）。触发检查的时机（启动自动 / 手动 / 运行期固定间隔轮询，见 [desktop-shell.md](./desktop-shell.md)「桌面端自动更新」场景 11）不改变状态机语义——任一时机发现新版本都只置 idle（S1）。降级边界见 [desktop-shell.md](./desktop-shell.md)「桌面端自动更新」故事场景 5。
 
 ## 非目标（明确排除）
 

--- a/docs/specs/desktop/desktop-shell.md
+++ b/docs/specs/desktop/desktop-shell.md
@@ -123,7 +123,7 @@ order: 10
 
 **为什么是这个优先级**：应用更新是修复与功能到达用户的唯一通道；现状仅「提示 + 给下载 URL」，用户不主动访问下载页就拿不到修复。macOS 签名 + 公证已就绪（ed2d9bf7 + 6f00c44a），自动更新链路可以端到端闭环。企业版用户登录后 serverUrl 已知，更新源（codechat 的 file-center 更新元数据）运行时注入，构建期不写死。**交互承载已裁决（2026-09-03）**：删除 toast 自动下载/重启提醒链路，由账户卡片「更新按钮状态机 S0–S6」（见 [desktop-account-and-settings.md](./desktop-account-and-settings.md)「账户卡片 · 更新按钮状态机 S0–S6」故事）全权接管——检测发现新版本只把状态推为 idle（卡片出现「更新」按钮），下载须经用户在 S2 确认框确认，下载完成自动弹 S4 重启确认。本故事仅约束**更新源 / 分发 / 降级边界**，按钮文案、对话框步骤与状态流转语义不在此重复。
 
-**独立测试**：登录后触发检查，验证「发现更新（S1）→ S2 确认下载（S3 下载中禁用）→ 就绪自动弹重启确认（S4）→ 立即重启（S6 复位 + quitAndInstall）」全流程（按钮语义按 [desktop-account-and-settings.md](./desktop-account-and-settings.md)「账户卡片 · 更新按钮状态机 S0–S6」故事断言）；无 serverUrl 时验证不触发任何更新检查（启动自动检查静默、手动检查提示登录）；下载失败时验证按钮恢复「更新」可重试（不弹手动下载页 toast）；更新端点故障时验证手动检查给「检查更新失败」提示、启动自动检查静默。
+**独立测试**：登录后触发检查，验证「发现更新（S1）→ S2 确认下载（S3 下载中禁用）→ 就绪自动弹重启确认（S4）→ 立即重启（S6 复位 + quitAndInstall）」全流程（按钮语义按 [desktop-account-and-settings.md](./desktop-account-and-settings.md)「账户卡片 · 更新按钮状态机 S0–S6」故事断言）；无 serverUrl 时验证不触发任何更新检查（启动自动检查静默、手动检查提示登录）；下载失败时验证按钮恢复「更新」可重试（不弹手动下载页 toast）；更新端点故障时验证手动检查给「检查更新失败」提示、自动检查（启动与轮询）静默；应用持续运行跨过一个轮询间隔时验证按间隔再次自动触发检查（自动、静默），且不自动下载。
 
 **验收场景**：
 
@@ -131,12 +131,13 @@ order: 10
 2. **假设**用户未登录（无 serverUrl），**当**应用触发更新检查，**则** updateChannel 不生效，且不得执行任何更新检查：不得启动 electron-updater、不得查询 GitHub Releases（2026-09-09 拍板：未登录不查更新——曾有的 GitHub 回退手动提示链路与 checkForUpdate/updateChecker 代码一并删除），启动自动检查保持静默、手动检查提示「登录后可检查更新」；本地会话与其它功能不受影响。应用内 toast 基建（非模态，模仿 VS Code）保留，仅用于信息提示（登录引导、下载完成等），不再承载任何更新发现/下载/重启提醒。
 3. **假设**已登录企业版且检查发现新版本，**当**收到 update-available 事件，**则**不得自动开始后台下载，必须把更新状态置为 idle 并随 `desktopAccountInfo` 推送——账户卡片个人信息行右侧出现「更新」按钮（S1）；是否下载由用户在 S2 确认框决定（2026-09-03 裁决：账户卡片不提供更新 toast，toast 自动下载链路已删除）。
 4. **假设**用户在 S2 确认下载，**当** webview 下发 `desktopUpdateDownload` 命令，**则**宿主必须先把更新状态置为 downloading 并推送（卡片按钮转「正在下载更新…」并禁用，防重复下载，S3），再调用 electron-updater 开始后台下载；**当**下载完成收到 update-downloaded 事件，**则**必须把状态置为 ready 并推送（S4）——webview 据此自动弹出「重启应用」确认框（仅一次），选「稍后」后按钮转常驻「重启」（S5）。
-5. **假设**更新服务故障（端点不可达 / 元数据解析失败 / 下载失败 / downloadUpdate 抛错），**当**下载失败且状态为 downloading，**则**必须把状态回退为 idle 并推送——卡片按钮恢复「更新」，用户可重新走 S2 重试（见 [desktop-account-and-settings.md](./desktop-account-and-settings.md)「账户卡片 · 更新按钮状态机 S0–S6」场景 8），不得静默失败也不得弹手动下载页 toast；**当**失败发生在已就绪（ready）之后的安装阶段，**则**不得把状态降级（重启时机由用户决定，避免把已就绪更新重置回可下载造成重复下载），仅记录日志；**当**失败发生在尚未发现更新的检查阶段，**则**启动自动检查静默、手动检查给出「检查更新失败，请稍后重试」提示。
+5. **假设**更新服务故障（端点不可达 / 元数据解析失败 / 下载失败 / downloadUpdate 抛错），**当**下载失败且状态为 downloading，**则**必须把状态回退为 idle 并推送——卡片按钮恢复「更新」，用户可重新走 S2 重试（见 [desktop-account-and-settings.md](./desktop-account-and-settings.md)「账户卡片 · 更新按钮状态机 S0–S6」场景 8），不得静默失败也不得弹手动下载页 toast；**当**失败发生在已就绪（ready）之后的安装阶段，**则**不得把状态降级（重启时机由用户决定，避免把已就绪更新重置回可下载造成重复下载），仅记录日志；**当**失败发生在尚未发现更新的检查阶段，**则**自动检查（启动与轮询）静默、手动检查给出「检查更新失败，请稍后重试」提示。
 6. **假设**用户触发手动检查（`checkForUpdates` 命令），**当**检查执行，**则**必须复用本故事场景 1-5 链路：已登录走 electron-updater（按当前 updateChannel 对应 feed 查询；无更新时 toast 提示按 updateChannel 区分，stable 见「接收 Beta 版更新」场景 5、beta 提示「当前已是最新版本」）；未登录按场景 2 不执行检查，toast 提示「登录后可检查更新」。
 7. **假设**已登录企业版且 electron-updater 返回更新信息，**当**更新下载执行，**则**必须使用更新元数据中的真实文件入口下载安装包，不得指向 manifest.json / feed 目录自身。
 8. **假设** macOS 上应用运行于不可写位置（如非 /Applications），**当** S6 重启安装无法原地完成，**则**安装失败经 electron-updater error 事件上报，宿主按场景 5 处理（ready 态错误不降级、记录日志），用户仍可稍后再次执行重启安装或经手动渠道获取安装包，不得自动弹窗打断当前工作。
 9. **假设**构建安装包（mac/win），**当**electron-builder 打包完成，**则**产物 `resources/app-update.yml` 必须存在（afterPack 写入 `updaterCacheDirName`）——electron-updater 下载前会读取该文件（`configOnDisk`），缺失时下载阶段抛 ENOENT 并降级为下载页提示（修复：构建未声明 publish 配置时 electron-builder 不生成该文件）。
 10. **假设**用户在 S4 确认框选「立即重启」或点击 S5「重启」按钮，**当** webview 下发 `desktopUpdateRestart` 命令，**则**宿主必须立即复位更新状态并推送（按钮消失，S6）后调用 quitAndInstall 退出并安装新版本（Windows 静默安装 + `--force-run` 装完自动重启，不再弹二次确认对话框）。重启安装前应用即将退出，无需任何 toast/加载态反馈——按钮消失即反馈（toast 加载链路已随 2026-09-03 裁决删除）。
+11. **假设**应用已登录企业版且持续运行（不退出、不重启），**当**运行期跨过固定的检查间隔（首版 1 小时），**则**宿主必须再次自动触发更新检查（非手动，与启动自动检查同一路径：按当前 updateChannel 查对应 feed，见场景 1；未登录按场景 2 不执行检查，静默）；该轮询只负责「查」，仍必须遵守场景 3 的约束不得自动开始后台下载、不得自动安装——发现新版本只把更新状态置 idle 并随 `desktopAccountInfo` 推送（账户卡片出现「更新」按钮，S1），下载与重启由用户走 S2–S6；轮询检查失败按场景 5 静默处理（等同启动自动检查），不影响后续轮询；应用退出（dispose）后必须停止轮询，不得留下悬挂定时器。轮询发现新版本后的表现与手动检查完全一致。
 
 ---
 
@@ -231,6 +232,7 @@ order: 10
 - **desktop-beta feed 依赖 codechat 通道**：beta feed（`/api/downloads/desktop-beta/{mac|win}/`）由 vusion/codechat #33 提供；codechat 侧通道上线前，开启「接收 Beta 版更新」后的检查按自动更新故事场景 5 错误处理（启动静默、手动提示检查失败），不得静默回退 stable feed 或崩溃。
 - **updateChannel 不进共享配置**：「接收 Beta 版更新」开关持久化于桌面 configStore 顶层（userData/wave-desktop.json，theme 先例），不写入 settings.json、不同步到远程 CLI 或账号级配置；默认 stable。
 - **未登录不触发更新检查**：无 serverUrl 时，启动自动检查与手动 `checkForUpdates` 均不得执行更新检查（不查 GitHub Releases、不启动 electron-updater），手动检查 toast 提示「登录后可检查更新」；曾用于未登录回退的 checkForUpdate/updateChecker 链路已删除（2026-09-09 拍板）。
+- **运行期轮询只查不下载**：轮询与启动自动检查一样是「非手动」检查，发现新版本只置 idle（S1），绝不自动下载/安装（`autoDownload=false` 保持）；间隔为固定常量（首版 1 小时），与启动那次的「只跑一次」检查相互独立（轮询不得让它变成两次启动语义）；定时器生命周期随宿主 dispose 结束。
 
 ## 非目标（明确排除）
 

--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -347,6 +347,10 @@ export class DesktopHost {
   /** 60s 账户用量轮询 (spec 场景 8). Static so tests can shrink or disable it. */
   private static accountPollIntervalMs = 60_000;
   private accountPollTimer: NodeJS.Timeout | null = null;
+  /** 1h 更新检查轮询 (spec desktop-shell「桌面端自动更新」场景 11): 应用长期
+   *  运行也能发现新版本。Static so tests can shrink or disable it. */
+  private static updatePollIntervalMs = 60 * 60 * 1000;
+  private updatePollTimer: NodeJS.Timeout | null = null;
 
   /** Latest panel toggle state reported by each pane's webview (drives the 面板 menu). */
   private panePanelState = new Map<string, PanelKind[]>();
@@ -592,6 +596,10 @@ export class DesktopHost {
       clearInterval(this.accountPollTimer);
       this.accountPollTimer = null;
     }
+    if (this.updatePollTimer) {
+      clearInterval(this.updatePollTimer);
+      this.updatePollTimer = null;
+    }
   }
 
   /** Resolved appearance: the OS colors under nativeTheme.themeSource, honoring
@@ -750,6 +758,22 @@ export class DesktopHost {
     this.accountPollTimer = setInterval(() => {
       void this.refreshUsageForHost(this.currentHost);
     }, DesktopHost.accountPollIntervalMs);
+  }
+
+  /**
+   * 每 1h 轮询更新（spec desktop-shell「桌面端自动更新」场景 11）：应用持续
+   * 运行（不退出/不重启）也能发现新版本。复用自动检查路径
+   * handleCheckForUpdates(false) —— 只查不下载不安装（autoDownload=false，
+   * 发现更新只置 idle → S1「更新」按钮），失败与启动自动检查一样静默。与
+   * 启动那次「只跑一次」检查（updateCheckTriggered）相互独立。
+   */
+  private startUpdatePolling(): void {
+    if (this.updatePollTimer) return;
+    this.updatePollTimer = setInterval(() => {
+      this.handleCheckForUpdates(false).catch((err) => {
+        console.warn("[DesktopHost] Update check failed:", err);
+      });
+    }, DesktopHost.updatePollIntervalMs);
   }
 
   /** Insert a host-generated system message into a pane's chat stream (focused pane by default). */
@@ -3969,6 +3993,11 @@ export class DesktopHost {
 
       // Account usage poll: keep the sidebar card's 套餐用量/API 额度 fresh.
       this.startAccountPolling();
+
+      // Periodic update check: keep discovering new versions while the app
+      // stays running (spec desktop-shell 场景 11). Idempotent — a repeat
+      // webviewReady must not stack timers.
+      this.startUpdatePolling();
 
       // Auto update check: once per app launch after the first agent is ready.
       if (!this.updateCheckTriggered) {

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -2520,6 +2520,124 @@ describe("checkForUpdates with a configured serverUrl", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// periodic update polling (spec desktop-shell「桌面端自动更新」场景 11)
+// ---------------------------------------------------------------------------
+
+describe("periodic update polling", () => {
+  const SERVER = "https://codechat.example.com";
+  const POLL_MS = 60 * 60 * 1000;
+  const pollIntervalField = DesktopHost as unknown as {
+    updatePollIntervalMs: number;
+  };
+
+  /** Shrink the poll interval for a test; returns a restore fn for the finally. */
+  function setPollInterval(ms: number): () => void {
+    const original = pollIntervalField.updatePollIntervalMs;
+    pollIntervalField.updatePollIntervalMs = ms;
+    return () => {
+      pollIntervalField.updatePollIntervalMs = original;
+    };
+  }
+
+  // Like readyHost() but the serverUrl is in place BEFORE webviewReady so both
+  // the one-shot startup check and the poll timer take the updater path.
+  async function readyHostWithServerUrl() {
+    const ctx = createHost();
+    ctx.store.addRecentWorkdir({ host: "local", path: "/work/a" });
+    h.existingPaths.add("/work/a");
+    ctx.store.setConfiguration({ serverUrl: SERVER });
+    await ctx.host.handleWebviewMessage({ command: "desktopReady" });
+    await ctx.host.handleWebviewMessage({
+      command: "desktopSelectRecentWorkdir",
+      path: "/work/a",
+    });
+    await ctx.host.handleWebviewMessage({ command: "webviewReady" });
+    return ctx;
+  }
+
+  it("defaults the interval to 1 hour (spec 场景 11 首版取值)", () => {
+    expect(pollIntervalField.updatePollIntervalMs).toBe(POLL_MS);
+  });
+
+  it("re-checks on each interval and stops after dispose", async () => {
+    const restore = setPollInterval(POLL_MS);
+    vi.useFakeTimers();
+    try {
+      const ctx = await readyHostWithServerUrl();
+      // 启动那次「只跑一次」检查已经跑过（与轮询相互独立）。
+      expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(POLL_MS);
+      expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2);
+
+      vi.advanceTimersByTime(POLL_MS);
+      expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(3);
+
+      // dispose 后轮询停止：不得留下悬挂定时器再触发检查。
+      await ctx.host.dispose();
+      vi.advanceTimersByTime(POLL_MS * 5);
+      expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+      restore();
+    }
+  });
+
+  it("does not fire before the interval elapses and never doubles the startup check", async () => {
+    const restore = setPollInterval(POLL_MS);
+    vi.useFakeTimers();
+    try {
+      await readyHostWithServerUrl();
+      // 启动检查只跑一次（updateCheckTriggered 语义不变），轮询间隔未到不触发。
+      expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+      vi.advanceTimersByTime(POLL_MS - 1);
+      expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+      restore();
+    }
+  });
+
+  it("a repeat webviewReady does not stack a second poll timer", async () => {
+    const restore = setPollInterval(POLL_MS);
+    vi.useFakeTimers();
+    try {
+      const ctx = await readyHostWithServerUrl();
+      await ctx.host.handleWebviewMessage({ command: "webviewReady" });
+      // 启动检查仍只一次；重复 ready 不得叠加出第二个轮询定时器。
+      expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+      vi.advanceTimersByTime(POLL_MS);
+      expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+      restore();
+    }
+  });
+
+  it("polling stays silent on a failed check (like the startup check)", async () => {
+    const restore = setPollInterval(POLL_MS);
+    vi.useFakeTimers();
+    try {
+      await readyHostWithServerUrl();
+      vi.mocked(autoUpdater.checkForUpdates).mockRejectedValue(
+        new Error("ECONNREFUSED"),
+      );
+
+      // 异步推进并 flush：轮询触发的检查链路完整跑完。
+      await vi.advanceTimersByTimeAsync(POLL_MS);
+
+      // 非手动检查失败不 toast（场景 5：自动检查静默）。
+      expect(
+        shownToasts().filter((n) => n.message.includes("检查更新失败")),
+      ).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+      restore();
+    }
+  });
+});
+
 describe("account card (desktopAccountInfo)", () => {
   /** getAuthStatus/getAccountInfo/login return rich payloads (email + usage). */
   function stubAccountRpc(


### PR DESCRIPTION
## 改动内容

桌面端此前的自动更新检查只有两个触发点：启动后首次 webview ready 跑一次（由实例标志 `updateCheckTriggered` 一票否决），以及手动点「检查更新」（含切通道即时重查）。用户长期不关机/不关应用就永远等不到新版本。

本 PR 只做一件事：给更新检查加运行期周期轮询。

- **desktopHost**：新增 `startUpdatePolling()`，每 `DesktopHost.updatePollIntervalMs` 调用一次现有的 `handleCheckForUpdates(false)`（非手动）。间隔提为命名常量，首版 **1 小时**（对齐 VS Code 本体更新的 default 模式节奏），声明为 `static` 以便测试缩放/关闭（与账户用量轮询 `accountPollIntervalMs` 一致）。
- **生命周期**：定时器在 `handleWebviewReady` 里与 `startAccountPolling()` 并列启动（幂等，重复 ready 不叠加），并在 `dispose()` 里 `clearInterval`，应用退出不留悬挂 timer。
- **只查不下载不安装**：`autoDownload=false` 不变；轮询发现新版本沿用现有链路，只把状态置 idle 并推送 `desktopAccountInfo`（账户卡片 S1「更新」按钮），表现与手动检查一致，下载/重启仍由用户走 S2–S6。轮询失败与启动自动检查一样静默。
- **其余不动**：启动那次「只跑一次」检查的 `updateCheckTriggered` 语义与时序不变；手动检查、切通道重查、powerMonitor resume / 窗口 focus 触发本次都不加也不改。

## spec

- `docs/specs/desktop/desktop-shell.md`「桌面端自动更新」：新增**场景 11**（运行期按固定间隔周期检查；不自动后台下载/安装；发现更新置 idle 进 S1；失败静默；dispose 停止轮询），场景 5 与独立测试同步，边界补一条「运行期轮询只查不下载」。
- `docs/specs/desktop/desktop-account-and-settings.md`：宿主接线注明「启动自动 / 手动 / 运行期轮询」三种时机都不改变 S0–S6 状态机语义。

## 测试与验证

- `packages/desktop/tests/desktopHost.test.ts` 新增 5 例：默认常量 = 1h / 按间隔触发检查 / `dispose` 后不再触发 / 启动检查仍只跑一次且间隔未到不触发 / 重复 webviewReady 不叠加定时器 / 轮询失败静默。
- **fail-without-fix 双验**：注释掉 `startUpdatePolling()` → 2 例红；只注释 `dispose` 里的 `clearInterval` → dispose 例红（`called 3 times, but got 8 times`）。恢复后全绿。
- `packages/desktop` 全量：**19 files / 608 tests passed**。
- 全仓 `pnpm run type-check` ✅、`pnpm lint`（oxlint 0 warnings/errors）✅、prettier `--check` 4 个改动文件 ✅。
- spec 计数校验：`84 用户故事 / 467 / 2052`，0 warnings。

只描述本次改动，未合并。
