### PR TITLE
fix(webview-test): mock 宿主回答 worktree 改动检查请求

### DIFF
--- a/packages/webview/e2e/utils/desktopTestHarness.ts
+++ b/packages/webview/e2e/utils/desktopTestHarness.ts
@@ -225,6 +225,19 @@ const mockDesktopApiJs = `
             if (message && message.command === 'desktopReady') {
                 deliver({ command: 'desktopPanes', panes: [{ paneId: 'pane-1', host: 'local', row: 0 }], focusedPaneId: 'pane-1' });
             }
+            // 真宿主（desktopHost.ts handleGetWorktreeChanges）会回答 worktree
+            // 改动检查，且原样回带 requestId/sessionId；mock 也必须回，否则
+            // 删除 worktree 会话的确认框永远停在「正在检查该 worktree 的改动…」
+            // （DesktopSidebar 按 requestId 丢弃不匹配的应答）。改动数取代表性
+            // 数值，让截图呈现「丢失改动」的最终态。
+            if (message && message.command === 'desktopGetWorktreeChanges') {
+                deliver({
+                    command: 'desktopWorktreeChanges',
+                    sessionId: message.sessionId,
+                    requestId: message.requestId,
+                    changes: { files: 2, commits: 1 },
+                });
+            }
             window.dispatchEvent(new CustomEvent('vscode-message', { detail: message }));
         },
         setState: (state) => {},


### PR DESCRIPTION
修复 publish.yml 的 Generate screenshots（`pnpm -F wave-webview run test:demo`）必然失败：`c173c4ef` 给删除 worktree 会话的确认框加了「先向宿主查询将丢失的改动」流程，但 e2e/demo 的 mock 宿主（`desktopTestHarness`）只回应 `desktopReady`，对 `desktopGetWorktreeChanges` 无任何应答 → 对话框永远停在「正在检查该 worktree 的改动…」，demo 断言必然超时。

本机确定性复现（非 flaky）：修前单用例 1 failed，修后 2 passed；`pnpm run test:demo` 168 passed；`pnpm run test` 1073 passed；type-check / lint / prettier clean。

改动仅测试基建 1 文件 +13 行（mock 按既有 `desktopReady → desktopPanes` 先例回 `desktopWorktreeChanges`，原样回带 requestId/sessionId，changes 取 {files:2, commits:1} 让截图呈现最终态），产品代码零改动。VSC mock（挂载 ChatApp）与其它 e2e 用例均不经过该桌面专属路径（已确认）。