### PR TITLE
ci: 恢复文档站 Pages 构建的 push main 自动触发（回滚 #2078）

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,9 +1,20 @@
 name: Deploy VitePress to GitHub Pages
 
-# Manual-only deploy: docs push no longer auto-triggers a GitHub Pages build
-# (docs:build installs Playwright and regenerates all screenshots every run,
-# which is wasteful). Trigger manually via "Run workflow" in the Actions tab.
+# docs:build runs `pnpm run docs:screenshots && vitepress build docs`, so it only
+# executes here and in the release publish.yml. Running it solely on release let two
+# v1.2.0 failures (the demo mock host not answering the worktree-diff check, and raw
+# angle-bracket placeholders breaking VitePress) stay invisible to PR CI until the
+# release. Auto-trigger on push to main surfaces such failures early; workflow_dispatch
+# is kept for manual re-runs.
 on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "packages/webview/demo/**"
+      - "packages/webview/e2e/**"
+      - "packages/vscode/LOGO.png"
+      - ".github/workflows/pages.yml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 背景

回滚 `ed4565be`（"chore(ci): 文档 Pages 部署改为手动触发 (#2078)"，2026-09-04）。

该提交把 `.github/workflows/pages.yml` 的 `on:` 从「push main 且改动 docs/webview-demo 相关路径」收窄为只剩 `workflow_dispatch`，当时的理由是「docs:build 每次都要装 Playwright 重新生成全部截图，太浪费」。

## 为什么要回滚

`docs:build` = `pnpm run docs:screenshots && vitepress build docs`，截图与 vitepress 构建只在发版 `publish.yml` 里跑，导致这类失败**结构性对 PR CI 不可见**，直到发版才炸。本次 v1.2.0 连续两个失败正是这样暴露的：

- demo mock 宿主不响应 worktree 改动检查请求（PR #2172 / 9897ac39）
- docs 里裸尖括号占位符破坏 vitepress 构建（PR #2173 / 27986243）

让文档站构建在每次 push main 后自动跑，即便问题在合并后才发现，也能第一时间知道。

## 改动内容

只改 `.github/workflows/pages.yml` 一个文件：

- 恢复 push 触发器（`branches: [main]` + 原 paths 列表），保留 `workflow_dispatch` 以便手动重跑
- 顶部注释更新为新语义（不保留原「Manual-only deploy」理由，它与新行为矛盾）

恢复后的 `on:` 块与 `ed4565be` 的父提交完全一致（已逐行 diff 核对）：

```yaml
on:
  push:
    branches: [main]
    paths:
      - "docs/**"
      - "packages/webview/demo/**"
      - "packages/webview/e2e/**"
      - "packages/vscode/LOGO.png"
      - ".github/workflows/pages.yml"
  workflow_dispatch:
```

未扩大 paths 列表，未触碰 `publish.yml` 或其他 workflow，未改 docs 内容。

## 验证方式

- YAML 语法校验通过（`on` 解析出 `push` + `workflow_dispatch` 两个触发器）
- `git diff --stat origin/main` 显示仅 `.github/workflows/pages.yml` 一个文件变更（+14/−3）
- `on:` 块与 `ed4565be^` 逐行 diff 一致
- 合并后 push main 会自行触发一次该 workflow，本身就是端到端验证（本次无需跑截图重活）
