### PR TITLE
test(settings): 补设置页回归覆盖并抽取共享 e2e harness

### DIFF
--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -2166,6 +2166,31 @@ describe("configuration and status", () => {
     expect(payload).not.toHaveProperty("baseURL");
   });
 
+  /**
+   * Regression（Bug #2115：设置页关掉「自动记忆」后仍记忆）：
+   *
+   * `autoMemoryEnabled` / `autoMemoryFrequency` 都是可选参数，任何一环漏传都不会
+   * 编译报错，只在 SDK 侧静默回落到 settings.json / 默认值——开关看起来保存成功
+   * 却不起作用。桌面链路的最后一环是 `recreateAgentsForConfig` 组装的 stdio
+   * `updateConfig` 参数：关闭状态（false）与轮次必须真的出现在发给 CLI 的参数里
+   * （不能被 `||` / 缺字段吞掉）。
+   */
+  it("updateConfiguration forwards the auto-memory toggle to the CLI params", async () => {
+    const { host } = await readyHost();
+
+    await host.handleWebviewMessage({
+      command: "updateConfiguration",
+      configurationData: { autoMemoryEnabled: false, autoMemoryFrequency: 5 },
+    });
+
+    expect(lastAgent().updateConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        autoMemoryEnabled: false,
+        autoMemoryFrequency: 5,
+      }),
+    );
+  });
+
   it("getStatus replies with app version, session id and workdir", async () => {
     const { host, sent } = await readyHost();
     await host.handleWebviewMessage({ command: "getStatus" });
@@ -3318,6 +3343,25 @@ describe("misc commands", () => {
     expect(sent("skillMetadataResponse")).toHaveLength(0);
   });
 
+  it("deleteSkill failure surfaces a failure toast and skips the list refresh", async () => {
+    const { host, sent } = await readyHost();
+    lastAgent().deleteSkill = vi.fn(async () => {
+      throw new Error("permission denied");
+    });
+
+    await host.handleWebviewMessage({ command: "deleteSkill", name: "demo" });
+
+    expect(
+      shownToasts().some(
+        (t) =>
+          t.message.includes("删除技能失败") &&
+          t.message.includes("permission denied"),
+      ),
+    ).toBe(true);
+    // 删除没成功就不能回发「已刷新」的列表（否则 webview 会以为删掉了）
+    expect(sent("skillMetadataResponse")).toHaveLength(0);
+  });
+
   it("deleteSubagent success surfaces a global toast with the subagent name", async () => {
     const { host, sent } = await readyHost();
     const agent = lastAgent();
@@ -3331,6 +3375,39 @@ describe("misc commands", () => {
       true,
     );
     expect(sent("subagentConfigurationsResponse")).toHaveLength(1);
+  });
+
+  it("deleteSubagent without a live agent surfaces a failure toast, not a silent no-op", async () => {
+    const { host, sent } = await readyHost();
+
+    await host.handleWebviewMessage({
+      command: "deleteSubagent",
+      name: "sde",
+      paneId: "no-such-pane",
+    });
+
+    expect(
+      shownToasts().some((t) => t.message.includes("删除子代理失败")),
+    ).toBe(true);
+    expect(sent("subagentConfigurationsResponse")).toHaveLength(0);
+  });
+
+  it("deleteSubagent failure surfaces a failure toast and skips the list refresh", async () => {
+    const { host, sent } = await readyHost();
+    lastAgent().deleteSubagent = vi.fn(async () => {
+      throw new Error("no such file");
+    });
+
+    await host.handleWebviewMessage({ command: "deleteSubagent", name: "sde" });
+
+    expect(
+      shownToasts().some(
+        (t) =>
+          t.message.includes("删除子代理失败") &&
+          t.message.includes("no such file"),
+      ),
+    ).toBe(true);
+    expect(sent("subagentConfigurationsResponse")).toHaveLength(0);
   });
 
   it("deleteHook success surfaces a global toast with the hook name", async () => {
@@ -3355,6 +3432,44 @@ describe("misc commands", () => {
     expect(sent("hooksResponse")).toHaveLength(1);
   });
 
+  it("deleteHook without a live agent surfaces a failure toast, not a silent no-op", async () => {
+    const { host, sent } = await readyHost();
+
+    await host.handleWebviewMessage({
+      command: "deleteHook",
+      scope: "user",
+      hookName: "PreToolUse",
+      paneId: "no-such-pane",
+    });
+
+    expect(shownToasts().some((t) => t.message.includes("删除钩子失败"))).toBe(
+      true,
+    );
+    expect(sent("hooksResponse")).toHaveLength(0);
+  });
+
+  it("deleteHook failure surfaces a failure toast and skips the list refresh", async () => {
+    const { host, sent } = await readyHost();
+    lastAgent().deleteHook = vi.fn(async () => {
+      throw new Error("invalid hook name");
+    });
+
+    await host.handleWebviewMessage({
+      command: "deleteHook",
+      scope: "user",
+      hookName: "PreToolUse",
+    });
+
+    expect(
+      shownToasts().some(
+        (t) =>
+          t.message.includes("删除钩子失败") &&
+          t.message.includes("invalid hook name"),
+      ),
+    ).toBe(true);
+    expect(sent("hooksResponse")).toHaveLength(0);
+  });
+
   it("removeMcpServer success surfaces a global toast with the server name", async () => {
     const { host, sent } = await readyHost();
     const agent = lastAgent();
@@ -3371,6 +3486,44 @@ describe("misc commands", () => {
       shownToasts().some((t) => t.message === "已移除 MCP 服务器「files」"),
     ).toBe(true);
     expect(sent("mcpServersResponse")).toHaveLength(1);
+  });
+
+  it("removeMcpServer without a live agent surfaces a failure toast, not a silent no-op", async () => {
+    const { host, sent } = await readyHost();
+
+    await host.handleWebviewMessage({
+      command: "removeMcpServer",
+      scope: "user",
+      serverName: "files",
+      paneId: "no-such-pane",
+    });
+
+    expect(
+      shownToasts().some((t) => t.message.includes("移除 MCP 服务器失败")),
+    ).toBe(true);
+    expect(sent("mcpServersResponse")).toHaveLength(0);
+  });
+
+  it("removeMcpServer failure surfaces a failure toast and skips the list refresh", async () => {
+    const { host, sent } = await readyHost();
+    lastAgent().removeMcpServer = vi.fn(async () => {
+      throw new Error("mcp.json is read-only");
+    });
+
+    await host.handleWebviewMessage({
+      command: "removeMcpServer",
+      scope: "user",
+      serverName: "files",
+    });
+
+    expect(
+      shownToasts().some(
+        (t) =>
+          t.message.includes("移除 MCP 服务器失败") &&
+          t.message.includes("mcp.json is read-only"),
+      ),
+    ).toBe(true);
+    expect(sent("mcpServersResponse")).toHaveLength(0);
   });
 
   it("updateConfiguration success surfaces a 保存成功 toast", async () => {

--- a/packages/desktop/tests/integration/realHostHarness.ts
+++ b/packages/desktop/tests/integration/realHostHarness.ts
@@ -20,8 +20,15 @@ import { ConfigStore } from "../../src/main/configStore";
 import { DesktopHost } from "../../src/main/desktopHost";
 import { LOCAL_HOST } from "../../src/main/sshHosts";
 
-/** Must match `vitest.integration.config.ts`. */
-export const REALHOST_ROOT = path.join(os.tmpdir(), "wave-desktop-realhost");
+/**
+ * Scratch root shared with `vitest.integration.config.ts`. The config derives
+ * it from `os.tmpdir()` + the runner pid (so concurrent runs in separate
+ * worktrees cannot wipe each other's HOME) and passes it down as
+ * `WAVE_REALHOST_ROOT`; the worker's own pid differs, hence the env handoff.
+ */
+export const REALHOST_ROOT =
+  process.env.WAVE_REALHOST_ROOT ??
+  path.join(os.tmpdir(), "wave-desktop-realhost");
 export const REALHOST_HOME = path.join(REALHOST_ROOT, "home");
 export const STORE_PATH = path.join(
   REALHOST_ROOT,

--- a/packages/desktop/tests/integration/realHostSettings.integration.test.ts
+++ b/packages/desktop/tests/integration/realHostSettings.integration.test.ts
@@ -8,12 +8,13 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { existsSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import * as path from "path";
 import {
   assertNoUnexpectedRejections,
   clearFakeModelEndpoint,
   createRealHost,
+  REALHOST_HOME,
   resetRealHostState,
   startFakeModelServer,
   takeUnexpectedRejections,
@@ -96,6 +97,68 @@ async function projectSettings(paneId: string) {
 
 function projectSettingsFile(dir: string): string {
   return path.join(dir, ".wave", "settings.json");
+}
+
+/** Single pane on dirA holding one conversation (an agent must exist to delete). */
+async function onePane(): Promise<void> {
+  await ctx.host.handleWebviewMessage({ command: "desktopReady" });
+  await ctx.host.handleWebviewMessage({
+    command: "desktopSelectRecentWorkdir",
+    path: dirA,
+    host: "local",
+  });
+  await ctx.waitFor("setInitialState");
+  await ctx.turn("首条");
+}
+
+/**
+ * Create a user-level skill copy (`~/.wave/skills/<name>/SKILL.md` by default).
+ *
+ * `root` 可选 `.claude` / `.agents`：同名技能可以同时物理存在于多个用户级
+ * 技能目录（发现阶段会合并成一条），#2092 的后半段就是「只删了一份，下一次
+ * 重扫又冒出来」。
+ */
+function writeUserSkill(name: string, root = ".wave"): string {
+  const dir = path.join(REALHOST_HOME, root, "skills", name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    path.join(dir, "SKILL.md"),
+    `---\nname: ${name}\ndescription: ${name} 说明\n---\n\n${name} 正文\n`,
+    "utf-8",
+  );
+  return dir;
+}
+
+/** Skill names of one discovery type from a `skillMetadataResponse`. */
+function skillNames(message: { skills?: unknown }, type?: string): string[] {
+  return ((message.skills ?? []) as Array<{ name: string; type?: string }>)
+    .filter((s) => type === undefined || s.type === type)
+    .map((s) => s.name);
+}
+
+/**
+ * 连续读取技能列表，返回每轮采样到的个人技能名（已排序）。
+ *
+ * 设置页删除技能后会立刻再拉一次列表（`useSettingsList.refresh`），这次读取与
+ * SDK 的删除后收敛刷新 / 文件 watcher 重扫是并发的——#2092 正是这次读取落在
+ * 「重扫先清空共享缓存」的空窗口里，于是列表整段空白。逐轮采样能覆盖删除后那
+ * 一段时间内的多次读取，而不是只赌单次读取的时序。
+ */
+async function samplePersonalSkills(rounds: number): Promise<string[][]> {
+  const samples: string[][] = [];
+  for (let i = 0; i < rounds; i += 1) {
+    const start = ctx.messages.length;
+    await ctx.host.handleWebviewMessage({
+      command: "getSkillMetadata",
+      paneId: "pane-1",
+    });
+    const reply = ctx.messages
+      .slice(start)
+      .find((m) => m.command === "skillMetadataResponse");
+    if (reply) samples.push(skillNames(reply, "personal").sort());
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  return samples;
 }
 
 describe("real host · project settings follow the pane's project", () => {
@@ -260,5 +323,70 @@ describe("real host · project settings follow the pane's project", () => {
       predicate: (m) => m.scope === "project",
     });
     expect(reread.content).toBe("B 项目规则\n");
+  });
+
+  /**
+   * Regression（Bug #2092「删除技能后列表显示为空，切 tab 才恢复」）：
+   *
+   * 旧实现两条缺陷都在本用例的观测点上：①重扫先清空共享缓存再异步 discover
+   * （`refreshSkills` 非原子），删除后的回读会落在空窗口里 —— 列表整段空白；
+   * ②同名技能分布在多个用户级技能目录时只删一份，下一次重扫又冒出来（表现为
+   * 「切 tab 才恢复」的另一面：删不掉）。修复（b7c0899a）让重扫原子交换缓存、
+   * 删除后 await 收敛，并按作用域把同名副本一次删净。
+   *
+   * 本用例在**真 host + 真 CLI**上跑：同名技能同时放在 `~/.wave` 与 `~/.claude`
+   * 两个用户级技能目录，断言删除后 ①回发列表非空且不含该技能 ②删除后一段时间
+   * 内的连续读取都不含该技能、末轮恰好只剩另一个 ③两份目录都已从磁盘删除。
+   */
+  it("does not blank or resurrect the skill list after a delete (#2092)", async () => {
+    const skillAWave = writeUserSkill("skill-a");
+    const skillAClaude = writeUserSkill("skill-a", ".claude");
+    writeUserSkill("skill-b");
+    await onePane();
+
+    ctx.clear();
+    await ctx.host.handleWebviewMessage({
+      command: "getSkillMetadata",
+      paneId: "pane-1",
+    });
+    const before = await ctx.waitFor("skillMetadataResponse", {
+      predicate: (m) => m.paneId === "pane-1",
+    });
+    expect(skillNames(before, "personal").sort()).toEqual([
+      "skill-a",
+      "skill-b",
+    ]);
+
+    ctx.clear();
+    await ctx.host.handleWebviewMessage({
+      command: "deleteSkill",
+      paneId: "pane-1",
+      name: "skill-a",
+    });
+    const after = await ctx.waitFor("skillMetadataResponse", {
+      predicate: (m) => m.paneId === "pane-1",
+    });
+
+    // 删除后回发的列表必须已经反映删除结果，而不是瞬时空列表：
+    // 非空 + 不含已删技能 + 仍含剩余技能。
+    expect(after.skills as unknown[]).not.toHaveLength(0);
+    expect(skillNames(after, "personal")).toEqual(["skill-b"]);
+
+    // 删除后一段时间内连续读取（覆盖删除后重扫 / 文件 watcher 那一轮）：
+    // 任何一轮都不得为空，也不得让被删技能复活，末轮必须已收敛为只剩 skill-b。
+    const samples = await samplePersonalSkills(30);
+    expect(samples.filter((s) => s.length === 0)).toEqual([]);
+    expect(samples.filter((s) => s.includes("skill-a"))).toEqual([]);
+    expect(samples.at(-1)).toEqual(["skill-b"]);
+
+    // 磁盘上同名技能的所有副本都被删除（不是只从内存列表里消失，也不是只删一份）
+    expect(existsSync(skillAWave)).toBe(false);
+    expect(existsSync(skillAClaude)).toBe(false);
+    // 删除成功经全局 toast 提示（spec「设置页反馈语义」）
+    expect(
+      ctx
+        .of("showToast")
+        .some((m) => JSON.stringify(m.toast).includes("已删除技能「skill-a」")),
+    ).toBe(true);
   });
 });

--- a/packages/desktop/vitest.integration.config.ts
+++ b/packages/desktop/vitest.integration.config.ts
@@ -13,9 +13,17 @@ import os from "os";
  *
  * Everything runs against a throwaway HOME so the CLI never touches the
  * developer's ~/.wave state.
+ *
+ * The scratch root is namespaced by the runner's pid: `resetRealHostState()`
+ * wipes the whole tree in every `beforeEach`, so two runs sharing one machine
+ * (e.g. separate git worktrees) must not share a root or they delete each
+ * other's HOME mid-test.
  */
 
-const REALHOST_ROOT = path.join(os.tmpdir(), "wave-desktop-realhost");
+const REALHOST_ROOT = path.join(
+  os.tmpdir(),
+  `wave-desktop-realhost-${process.pid}`,
+);
 const REALHOST_HOME = path.join(REALHOST_ROOT, "home");
 
 export default defineConfig({
@@ -41,6 +49,9 @@ export default defineConfig({
     // `unhandledRejection` listener so the leak is attributed to a test
     // (`assertNoUnexpectedRejections`) instead of only failing the file.
     env: {
+      // Hands the pid-namespaced root to the harness, which derives
+      // STORE_PATH/DIR_A/DIR_B from it (the worker has a different pid).
+      WAVE_REALHOST_ROOT: REALHOST_ROOT,
       HOME: REALHOST_HOME,
       USERPROFILE: REALHOST_HOME,
       WAVE_LOGS_DIR: path.join(REALHOST_HOME, ".wave", "logs"),

--- a/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/session/SettingsHandlerTest.kt
+++ b/packages/jetbrains/src/test/kotlin/com/wave/jetbrains/session/SettingsHandlerTest.kt
@@ -1,0 +1,344 @@
+package com.wave.jetbrains.session
+
+import com.intellij.openapi.project.Project
+import com.wave.jetbrains.stdio.AgentCallbacks
+import com.wave.jetbrains.stdio.NotificationRouter
+import com.wave.jetbrains.stdio.StdioAgent
+import com.wave.jetbrains.stdio.StdioClient
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.lang.reflect.Proxy
+import java.nio.file.Path
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Tests for the settings-page commands handled by [MessageHandler]: the write
+ * commands that must reach a live agent over stdio ([MessageHandler.dispatch],
+ * branches `deleteSkill` / `deleteHook` / `removeMcpServer` / `setAgentsContent` /
+ * `setBuiltinPluginEnabled`) and the "no live session" fallback (agent == null).
+ *
+ * Harness: the handler is a normal class, so the test wires one up directly with
+ * a real [WaveSession] whose `agent` is a real [StdioAgent] talking over a real
+ * [StdioClient] to a tiny fake `wave --stdio` server (`node`, spawned per test).
+ * That exercises the genuine path — coroutine dispatch → StdioAgent → JSON-RPC wire
+ * → reply handling → `postMessage` — without the IntelliJ application.
+ *
+ * Why the two test doubles:
+ *  - `Project` is a reflective proxy: the settings handlers only touch it through
+ *    [com.wave.jetbrains.ide.IdeService] / `WaveBackendService`, and the JUnit5-only
+ *    test classpath has no mockk/Mockito and no usable project fixture.
+ *  - `WaveSession.agent` has a private setter with no public seam, so the fake
+ *    backend's real `StdioAgent` is injected reflectively.
+ *
+ * [com.wave.jetbrains.ide.IdeService] (an `object` calling platform statics) has no
+ * seam, so its showInfo/showError branch is NOT observable from a unit test — the
+ * commands that emit no `postMessage` (`deleteSkill`, `removeMcpServer`) are asserted
+ * on the RPC the fake CLI actually received.
+ */
+class SettingsHandlerTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private val openClients = mutableListOf<StdioClient>()
+
+    @AfterEach
+    fun closeFakeClients() {
+        openClients.forEach { runCatching { it.close() } }
+        openClients.clear()
+    }
+
+    // ── 成功路径 ────────────────────────────────────────────────────
+
+    @Test
+    fun `setAgentsContent forwards the edit to the agent and reports ok`() {
+        val fx = Fixture(connectAgent = true)
+
+        fx.send(
+            "setAgentsContent",
+            "scope" to JsonPrimitive("project"),
+            "content" to JsonPrimitive("# AGENTS.md"),
+            "workdir" to JsonPrimitive("/tmp/wave-wd"),
+        )
+
+        val payload = fx.awaitPosted("agentsContentSaved")
+        assertEquals("project", payload["scope"]?.jsonPrimitive?.content)
+        assertTrue(
+            payload["ok"]?.jsonPrimitive?.booleanOrNull == true,
+            "a live agent must report ok=true, payload was $payload",
+        )
+
+        val rpc = fx.awaitRpc("setAgentsContent")
+        assertEquals("project", rpc.params()["scope"]?.jsonPrimitive?.content)
+        assertEquals("# AGENTS.md", rpc.params()["content"]?.jsonPrimitive?.content)
+        assertEquals("/tmp/wave-wd", rpc.params()["workdir"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `deleteHook deletes the hook then re-pushes the scope-scoped hooks`() {
+        val fx = Fixture(connectAgent = true)
+
+        fx.send(
+            "deleteHook",
+            "scope" to JsonPrimitive("user"),
+            "hookName" to JsonPrimitive("PreToolUse"),
+        )
+
+        // Success path re-reads the scope and answers with hooksResponse.
+        val payload = fx.awaitPosted("hooksResponse")
+        assertEquals("user", payload["scope"]?.jsonPrimitive?.content)
+        assertEquals(
+            "user",
+            payload["hooks"]?.jsonObject?.get("scopedTo")?.jsonPrimitive?.content,
+            "hooks must be re-read from the same scope that was deleted",
+        )
+        assertEquals("/fake/settings.json", payload["configPath"]?.jsonPrimitive?.content)
+
+        val delete = fx.awaitRpc("deleteHook")
+        assertEquals("user", delete.params()["scope"]?.jsonPrimitive?.content)
+        assertEquals("PreToolUse", delete.params()["hookName"]?.jsonPrimitive?.content)
+        // The refresh is a second RPC, not a cached payload.
+        assertEquals("user", fx.awaitRpc("getHooksByScope").params()["scope"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `deleteSkill forwards the skill name to the agent`() {
+        val fx = Fixture(connectAgent = true)
+
+        fx.send("deleteSkill", "name" to JsonPrimitive("my-skill"))
+
+        val rpc = fx.awaitRpc("deleteSkill")
+        assertEquals("my-skill", rpc.params()["name"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `removeMcpServer forwards scope and server name to the agent`() {
+        val fx = Fixture(connectAgent = true)
+
+        fx.send(
+            "removeMcpServer",
+            "scope" to JsonPrimitive("user"),
+            "serverName" to JsonPrimitive("github"),
+        )
+
+        val rpc = fx.awaitRpc("removeMcpServer")
+        assertEquals("user", rpc.params()["scope"]?.jsonPrimitive?.content)
+        assertEquals("github", rpc.params()["serverName"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `setBuiltinPluginEnabled pushes projectSettings with the new toggle state`() {
+        val fx = Fixture(connectAgent = true)
+
+        fx.send(
+            "setBuiltinPluginEnabled",
+            "pluginId" to JsonPrimitive("sdd"),
+            "enabled" to JsonPrimitive(true),
+            "scope" to JsonPrimitive("project"),
+        )
+
+        val payload = fx.awaitPosted("projectSettings")
+        assertTrue(
+            payload["enabledPlugins"]?.jsonObject?.get("sdd")?.jsonPrimitive?.booleanOrNull == true,
+            "enabledPlugins must carry the toggled plugin, payload was $payload",
+        )
+        // No live workdir on the agent → the handler falls back to the JVM cwd
+        // (project.basePath is null for the test double).
+        val workdir = System.getProperty("user.dir")
+        assertEquals(workdir, payload["workdir"]?.jsonPrimitive?.content)
+
+        val rpc = fx.awaitRpc("setBuiltinPluginEnabled")
+        assertEquals("sdd", rpc.params()["pluginId"]?.jsonPrimitive?.content)
+        assertTrue(rpc.params()["enabled"]?.jsonPrimitive?.booleanOrNull == true)
+        assertEquals("project", rpc.params()["scope"]?.jsonPrimitive?.content)
+        assertEquals(workdir, rpc.params()["workdir"]?.jsonPrimitive?.content)
+    }
+
+    // ── 无 live session 回退（settings tab 独立打开、聊天会话未初始化）──────
+
+    @Test
+    fun `setAgentsContent without a live agent reports failure instead of a false ok`() {
+        val fx = Fixture(connectAgent = false)
+
+        fx.send(
+            "setAgentsContent",
+            "scope" to JsonPrimitive("user"),
+            "content" to JsonPrimitive("# AGENTS.md"),
+        )
+
+        val payload = fx.awaitPosted("agentsContentSaved")
+        assertEquals("user", payload["scope"]?.jsonPrimitive?.content)
+        assertTrue(
+            payload["ok"]?.jsonPrimitive?.booleanOrNull == false,
+            "no live agent must not fake an ok=true save, payload was $payload",
+        )
+        assertEquals("智能体未初始化", payload["error"]?.jsonPrimitive?.content)
+    }
+
+    // ── harness ─────────────────────────────────────────────────────
+
+    /**
+     * A [MessageHandler] wired to a real [WaveSession] over a fake stdio CLI.
+     * `connectAgent = false` leaves `session.agent` null (the settings tab opened
+     * without a chat session).
+     */
+    private inner class Fixture(connectAgent: Boolean) {
+
+        val posted = CopyOnWriteArrayList<Pair<String, JsonObject>>()
+        private val rpcLog = File(tempDir.toFile(), "fake-wave-rpc.log")
+        val handler: MessageHandler
+
+        init {
+            val project = fakeProject()
+            val session = WaveSession(project) { command, payload -> posted.add(command to payload) }
+            if (connectAgent) {
+                val script = File(tempDir.toFile(), "fake-wave-server.js").apply { writeText(FAKE_CLI_JS) }
+                val client = StdioClient(
+                    listOf("node", script.absolutePath),
+                    emptyList(),
+                    mapOf("WAVE_FAKE_LOG" to rpcLog.absolutePath),
+                )
+                openClients.add(client)
+                val router = NotificationRouter(client)
+                router.attach()
+                installAgent(session, StdioAgent(client, router, object : AgentCallbacks {}))
+            }
+            handler = MessageHandler(project, session) { command, payload -> posted.add(command to payload) }
+        }
+
+        /** Fire a webview command. `handle` returns before dispatch completes. */
+        fun send(command: String, vararg fields: Pair<String, JsonPrimitive>) {
+            handler.handle(
+                buildJsonObject {
+                    put("command", JsonPrimitive(command))
+                    fields.forEach { (key, value) -> put(key, value) }
+                },
+            )
+        }
+
+        fun awaitPosted(command: String): JsonObject {
+            await("postMessage '$command'") { posted.any { it.first == command } }
+            return posted.first { it.first == command }.second
+        }
+
+        fun awaitRpc(method: String): JsonObject {
+            await("stdio RPC '$method'") { rpcRecords().any { it["method"]?.jsonPrimitive?.content == method } }
+            return rpcRecords().first { it["method"]?.jsonPrimitive?.content == method }
+        }
+
+        /** Requests the fake CLI received, in arrival order. */
+        private fun rpcRecords(): List<JsonObject> {
+            if (!rpcLog.isFile) return emptyList()
+            return rpcLog.readLines().filter { it.isNotBlank() }.mapNotNull { line ->
+                runCatching { Json.parseToJsonElement(line).jsonObject }.getOrNull()
+            }
+        }
+    }
+
+    /** Bounded poll: `handle` dispatches on `Dispatchers.IO`, so effects arrive later. */
+    private fun await(what: String, condition: () -> Boolean) {
+        val deadline = System.nanoTime() + AWAIT_TIMEOUT_MS * 1_000_000
+        while (System.nanoTime() < deadline) {
+            if (condition()) return
+            Thread.sleep(POLL_INTERVAL_MS)
+        }
+        throw AssertionError("Timed out after ${AWAIT_TIMEOUT_MS}ms waiting for $what")
+    }
+
+    private fun JsonObject.params(): JsonObject = this["params"]?.jsonObject ?: JsonObject(emptyMap())
+
+    private companion object {
+        const val AWAIT_TIMEOUT_MS = 15_000L
+        const val POLL_INTERVAL_MS = 10L
+
+        /** Loads the fake `wave --stdio` server; replies per method and logs every request. */
+        val FAKE_CLI_JS = """
+            const fs = require("fs");
+            const readline = require("readline");
+            const logPath = process.env.WAVE_FAKE_LOG;
+
+            function buildResult(msg) {
+              const params = msg.params || {};
+              switch (msg.method) {
+                case "deleteSkill":
+                  return { success: true, deleted: params.name };
+                case "removeMcpServer":
+                  return { success: true, removed: params.serverName };
+                case "deleteHook":
+                  return { ok: true };
+                case "getHooksByScope":
+                  return { hooks: { scopedTo: params.scope }, configPath: "/fake/settings.json" };
+                case "setAgentsContent":
+                  return { ok: true };
+                case "setBuiltinPluginEnabled":
+                  const enabledPlugins = {};
+                  enabledPlugins[params.pluginId] = params.enabled;
+                  return { enabledPlugins: enabledPlugins };
+                default:
+                  return {};
+              }
+            }
+
+            readline.createInterface({ input: process.stdin }).on("line", function (line) {
+              let msg;
+              try { msg = JSON.parse(line); } catch (e) { return; }
+              if (msg.id === undefined) { return; }
+              if (logPath) {
+                fs.appendFileSync(logPath, JSON.stringify({
+                  method: msg.method,
+                  params: msg.params || null,
+                  sessionId: msg.sessionId || null,
+                }) + "\n");
+              }
+              process.stdout.write(JSON.stringify({ id: msg.id, result: buildResult(msg) }) + "\n");
+            });
+        """.trimIndent()
+    }
+}
+
+/**
+ * Minimal [Project] test double — see the class KDoc for why a proxy is used
+ * instead of a mocked/mockito project (neither is on the test classpath).
+ */
+private fun fakeProject(): Project = Proxy.newProxyInstance(
+    Project::class.java.classLoader,
+    arrayOf(Project::class.java),
+) { proxy, method, args ->
+    when (method.name) {
+        "hashCode" -> System.identityHashCode(proxy)
+        "equals" -> proxy === args?.firstOrNull()
+        "toString" -> "FakeProject"
+        else -> javaDefault(method.returnType)
+    }
+} as Project
+
+/** `WaveSession.agent` is `private set` with no public seam; inject the fake backend's agent. */
+private fun installAgent(session: WaveSession, agent: StdioAgent) {
+    val field = WaveSession::class.java.getDeclaredField("agent")
+    field.isAccessible = true
+    field.set(session, agent)
+}
+
+private fun javaDefault(type: Class<*>): Any? = when (type) {
+    java.lang.Boolean.TYPE -> false
+    java.lang.Byte.TYPE -> 0.toByte()
+    java.lang.Short.TYPE -> 0.toShort()
+    java.lang.Integer.TYPE -> 0
+    java.lang.Long.TYPE -> 0L
+    java.lang.Float.TYPE -> 0f
+    java.lang.Double.TYPE -> 0.0
+    java.lang.Character.TYPE -> '\u0000'
+    else -> null
+}

--- a/packages/vscode/tests/services/configurationService.autoMemory.test.ts
+++ b/packages/vscode/tests/services/configurationService.autoMemory.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import type * as vscode from "vscode";
+import { ConfigurationService } from "../../src/services/configurationService";
+
+/**
+ * Regression（Bug #2115：设置页关掉「自动记忆」后仍记忆）链路的第一个 hop——
+ * 宿主存储。`autoMemoryEnabled` / `autoMemoryFrequency` 是可选项，漏存或漏读都
+ * 不会报错，只会静默丢失：保存出来的配置看起来「成功」，但下一环拿不到这个值。
+ * 这里断言 globalState 往返后两个字段原样保留（含 `false`，不得被 `||` 吞掉）。
+ */
+
+/** In-memory stand-in for vscode's globalState (a Map with the Memento API). */
+function context(): vscode.ExtensionContext {
+  const state = new Map<string, unknown>();
+  return {
+    globalState: {
+      get: (key: string) => state.get(key),
+      update: async (key: string, value: unknown) => {
+        state.set(key, value);
+      },
+    },
+  } as unknown as vscode.ExtensionContext;
+}
+
+describe("ConfigurationService · auto-memory persistence", () => {
+  test("save/load round-trips the auto-memory toggle and frequency", async () => {
+    const service = new ConfigurationService(context());
+
+    await service.saveConfiguration({
+      autoMemoryEnabled: false,
+      autoMemoryFrequency: 5,
+    });
+
+    const loaded = await service.loadConfiguration();
+    expect(loaded.autoMemoryEnabled).toBe(false);
+    expect(loaded.autoMemoryFrequency).toBe(5);
+  });
+});

--- a/packages/vscode/tests/session/chatSession.test.ts
+++ b/packages/vscode/tests/session/chatSession.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ChatSession,
+  type ChatSessionCallbacks,
+} from "../../src/session/chatSession";
+import type { ConfigurationData } from "../../src/services/configurationService";
+import type { StdioClient } from "../../src/stdio/stdioClient";
+import type { NotificationRouter } from "wave-agent-sdk/stdio";
+
+/**
+ * Regression（Bug #2115：设置页关掉「自动记忆」后仍记忆）：
+ *
+ * `autoMemoryEnabled` / `autoMemoryFrequency` 全是可选参数，任何一环漏传都不报错，
+ * 只在 SDK 侧静默回落到 settings.json / 默认值——保存看起来成功却不起作用。VSCE
+ * 侧漏掉的正是这两个 hop：会话初始化（`initialize` params）与设置保存
+ * （`ChatSession.updateConfig` → stdio `updateConfig` params）。这里断言「发给 CLI
+ * 的参数里真的带了这个字段」，而不是断言某条内部分支。
+ */
+
+function callbacks(): ChatSessionCallbacks {
+  return {
+    onTasksChange: vi.fn(),
+    onSessionIdChange: vi.fn(),
+    onStreamingChange: vi.fn(),
+    onQueueChange: vi.fn(),
+    onCommandRunningChange: vi.fn(),
+    onPermissionModeChange: vi.fn(),
+    onWorkdirChange: vi.fn(),
+    onToolPermissionRequest: vi.fn(async () => ({
+      behavior: "allow" as const,
+    })),
+    onError: vi.fn(),
+  };
+}
+
+/** A fake JSON-RPC client: records the exact params of every CLI request. */
+function fakeClient() {
+  const request = vi.fn(
+    async (
+      method: string,
+      _params?: unknown,
+      _sessionId?: string,
+    ): Promise<unknown> => {
+      if (method === "initialize") {
+        return {
+          sessionId: "sess-1",
+          workingDirectory: "/test-workspace",
+          permissionMode: "default",
+          latestTotalTokens: 0,
+        };
+      }
+      if (method === "updateConfig") return { sessionId: "sess-1" };
+      return {};
+    },
+  );
+  return { request };
+}
+
+function fakeRouter() {
+  return { register: vi.fn(), unregister: vi.fn() };
+}
+
+/** The params the client received for `method` (the message body sent to the CLI). */
+function paramsFor(
+  request: ReturnType<typeof fakeClient>["request"],
+  method: string,
+): Record<string, unknown> {
+  const call = request.mock.calls.find(([m]) => m === method);
+  expect(call, `no "${method}" request was sent to the CLI`).toBeDefined();
+  return call?.[1] as Record<string, unknown>;
+}
+
+const config: ConfigurationData = {
+  model: "m",
+  autoMemoryEnabled: false,
+  autoMemoryFrequency: 5,
+};
+
+describe("ChatSession · auto-memory settings reach the CLI", () => {
+  it("initialize carries the auto-memory toggle in the CLI params", async () => {
+    const client = fakeClient();
+    const session = new ChatSession("sidebar", undefined, callbacks());
+
+    await session.initialize(
+      config,
+      undefined,
+      client as unknown as StdioClient,
+      fakeRouter() as unknown as NotificationRouter,
+    );
+
+    expect(paramsFor(client.request, "initialize")).toMatchObject({
+      autoMemoryEnabled: false,
+      autoMemoryFrequency: 5,
+    });
+  });
+
+  it("updateConfig carries the auto-memory toggle in the CLI params", async () => {
+    const client = fakeClient();
+    const session = new ChatSession("sidebar", undefined, callbacks());
+
+    await session.initialize(
+      config,
+      undefined,
+      client as unknown as StdioClient,
+      fakeRouter() as unknown as NotificationRouter,
+    );
+    await session.updateConfig(config);
+
+    // false 必须原样下发（写成 `config.autoMemoryEnabled || true` 之类会静默变 true）
+    expect(paramsFor(client.request, "updateConfig")).toMatchObject({
+      autoMemoryEnabled: false,
+      autoMemoryFrequency: 5,
+    });
+  });
+});

--- a/packages/vscode/tests/session/messageHandler.test.ts
+++ b/packages/vscode/tests/session/messageHandler.test.ts
@@ -1233,6 +1233,82 @@ describe("MessageHandler settings tab", () => {
     );
     expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
   });
+
+  // 保存「失败」半边此前无覆盖：saveConfiguration 抛错时必须给用户可见反馈，
+  // 且要把 configurationError 回发给设置页（而非静默停在内联提示状态）。
+  test("updateConfiguration save failure shows an error toast and replies configurationError", async () => {
+    const session = createReadySession();
+    const { handler, context, configService } = createReadyHandler(session);
+    configService.saveConfiguration.mockRejectedValue(new Error("boom"));
+
+    await handler.handleSettingsMessage({
+      command: "updateConfiguration",
+      configurationData: { language: "en-US" },
+    });
+
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      "保存失败：boom",
+    );
+    expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+    const commands = (
+      context.postSettingsMessage as ReturnType<typeof vi.fn>
+    ).mock.calls.map((call) => (call[0] as { command: string }).command);
+    expect(commands).toEqual(["configurationError"]);
+  });
+
+  // 删除「抛错」分支（catch）此前无覆盖：只有返回值 false 的路径被断言过。
+  test("deleteSkill failure thrown by the session surfaces an error toast", async () => {
+    const session = {
+      deleteSkill: vi.fn().mockRejectedValue(new Error("boom")),
+    } as unknown as ChatSession;
+    const { handler, context } = createHandler(session);
+
+    await handler.handleSettingsMessage({
+      command: "deleteSkill",
+      name: "my-skill",
+    });
+
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      "删除技能失败: Error: boom",
+    );
+    expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+    expect(context.postSettingsMessage).not.toHaveBeenCalled();
+  });
+
+  test("deleteSubagent failure thrown by the session surfaces an error toast", async () => {
+    const session = {
+      deleteSubagent: vi.fn().mockRejectedValue(new Error("boom")),
+    } as unknown as ChatSession;
+    const { handler } = createHandler(session);
+
+    await handler.handleSettingsMessage({
+      command: "deleteSubagent",
+      name: "expert",
+    });
+
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      "删除子代理失败: Error: boom",
+    );
+    expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+  });
+
+  test("removeMcpServer failure thrown by the session surfaces an error toast", async () => {
+    const session = {
+      removeMcpServer: vi.fn().mockRejectedValue(new Error("boom")),
+    } as unknown as ChatSession;
+    const { handler } = createHandler(session);
+
+    await handler.handleSettingsMessage({
+      command: "removeMcpServer",
+      scope: "user",
+      serverName: "redis",
+    });
+
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      "移除 MCP 服务器失败: Error: boom",
+    );
+    expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+  });
 });
 
 // Chat 路由的删除/保存反馈与 settings 路由同语义（#2086 式双 switch 漂移防线）
@@ -1348,5 +1424,117 @@ describe("MessageHandler chat-route deletion toasts", () => {
     );
     expect(session.deleteHook).not.toHaveBeenCalled();
     expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+  });
+
+  test("deleteSubagent shows an error toast when the subagent is not found", async () => {
+    const session = {
+      deleteSubagent: vi.fn().mockResolvedValue(false),
+    } as unknown as ChatSession;
+    const { handler } = createHandler(session);
+
+    await handler.handleMessage(
+      { command: "deleteSubagent", name: "ghost" },
+      "tab",
+    );
+
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      "删除子代理失败: 未找到子代理「ghost」或智能体未初始化",
+    );
+    expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+  });
+
+  test("removeMcpServer shows an error toast when the server is not found", async () => {
+    const session = {
+      removeMcpServer: vi.fn().mockResolvedValue(false),
+    } as unknown as ChatSession;
+    const { handler } = createHandler(session);
+
+    await handler.handleMessage(
+      { command: "removeMcpServer", scope: "project", serverName: "ghost" },
+      "tab",
+    );
+
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      "移除 MCP 服务器失败: 未找到服务器「ghost」或智能体未初始化",
+    );
+    expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+  });
+
+  test("deleteSkill failure thrown by the session surfaces an error toast", async () => {
+    const session = {
+      deleteSkill: vi.fn().mockRejectedValue(new Error("boom")),
+    } as unknown as ChatSession;
+    const { handler } = createHandler(session);
+
+    await handler.handleMessage(
+      { command: "deleteSkill", name: "my-skill" },
+      "tab",
+    );
+
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      "删除技能失败: Error: boom",
+    );
+    expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("MessageHandler chat-route configuration toasts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("updateConfiguration shows a success toast and nudges the chat webview", async () => {
+    const session = createReadySession();
+    const { handler, context, configService } = createReadyHandler(session);
+
+    await handler.handleMessage(
+      {
+        command: "updateConfiguration",
+        configurationData: { language: "en-US" },
+      },
+      "tab",
+    );
+
+    expect(configService.saveConfiguration).toHaveBeenCalledWith({
+      language: "en-US",
+    });
+    expect(context.updateAllSessionsConfig).toHaveBeenCalled();
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+      "保存成功",
+    );
+    expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+    const commands = (
+      context.postMessage as ReturnType<typeof vi.fn>
+    ).mock.calls.map((call) => (call[0] as { command: string }).command);
+    expect(commands).toEqual([
+      "configurationUpdated",
+      "focusInput",
+      "scrollToBottom",
+      // chat 路由保存后顺带重读配置（handleGetConfiguration），与 settings 路由
+      // 回发 configurationResponse 的语义对齐
+      "configurationResponse",
+    ]);
+  });
+
+  test("updateConfiguration save failure shows an error toast and posts configurationError", async () => {
+    const session = createReadySession();
+    const { handler, context, configService } = createReadyHandler(session);
+    configService.saveConfiguration.mockRejectedValue(new Error("boom"));
+
+    await handler.handleMessage(
+      {
+        command: "updateConfiguration",
+        configurationData: { language: "en-US" },
+      },
+      "sidebar",
+    );
+
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      "保存失败：boom",
+    );
+    expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+    const errors = sentPosts(context)("configurationError");
+    expect(errors).toHaveLength(1);
+    expect(errors[0].error).toContain("boom");
   });
 });

--- a/packages/webview/demo/agents-dialog.demo.ts
+++ b/packages/webview/demo/agents-dialog.demo.ts
@@ -1,7 +1,9 @@
 import { test, expect } from "../e2e/utils/webviewTestHarness.js";
 import { elementScreenshotWebp } from "../e2e/utils/screenshot.js";
-import fs from "node:fs";
-import path from "node:path";
+import {
+  openSettings,
+  simulateHostMessage,
+} from "../e2e/utils/settingsHarness.js";
 
 /**
  * 设置页「子代理」「技能」选项卡 demo（/agents、/skills 斜杠命令落地页）：
@@ -10,45 +12,6 @@ import path from "node:path";
  * skillMetadataResponse 展示 4 个来源 Tab（插件 / 内置 / 用户 / 项目）的
  * agent 定义与技能列表，以及项目技能在当前项目下的平铺列表形态。
  */
-
-// SettingsPage 的颜色全部走 --vscode-* 变量，独立 settings.html 没有宿主注入，
-// 必须手动带上深色主题变量集，否则截图为白底浅色（实测 2026-08-29）。
-const themeStyles = fs.readFileSync(
-  path.join(process.cwd(), "theme", "theme-base-dark.css"),
-  "utf8",
-);
-
-const mockVscodeApiJs = `
-    window.process = { env: { NODE_ENV: 'production' } };
-    window.acquireVsCodeApi = () => ({
-        postMessage: (message) => {
-            if (!window.testMessages) window.testMessages = [];
-            window.testMessages.push(message);
-        },
-        setState: () => {},
-        getState: () => ({})
-    });
-    window.simulateExtensionMessage = (message) => {
-        window.dispatchEvent(new MessageEvent('message', { data: message }));
-    };
-`;
-
-const settingsHtml = `
-<!DOCTYPE html>
-<html lang="zh-CN" data-theme="dark">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Wave Settings</title>
-    <style>${themeStyles}</style>
-    <link rel="stylesheet" href="vscode-webview://mock-extension-id/settings.css">
-</head>
-<body>
-    <div id="root"></div>
-    <script>${mockVscodeApiJs}</script>
-    <script src="vscode-webview://mock-extension-id/settings.js"></script>
-</body>
-</html>`;
 
 const WORKDIR = "/work/wave-agent";
 
@@ -118,40 +81,17 @@ test.describe("设置页子代理选项卡 Demo", () => {
   test("should show 4 source tabs, grouped list and detail", async ({
     webviewPage,
   }) => {
-    // Settings full-page is wider than the default 400px demo viewport
-    await webviewPage.setViewportSize({ width: 1000, height: 760 });
-
-    // Reload the harness page with the settings entry bundle
-    await webviewPage.setContent(settingsHtml);
-
-    // Wait for the settings page to render
-    await expect(webviewPage.locator(".settings-page")).toBeVisible();
-
-    // Host opens the settings tab with the subagents nav (mirrors /agents →
-    // openSettings(nav:"subagents") → settingsState)
-    await webviewPage.evaluate(() => {
-      window.simulateExtensionMessage({
-        command: "settingsState",
-        workdir: "/work/wave-agent",
-        nav: "subagents",
-      });
-    });
-
-    // The settings entry pulls config on open; reply so the page stays healthy
-    await webviewPage.evaluate(() => {
-      window.simulateExtensionMessage({
-        command: "configurationResponse",
-        configurationData: { language: "zh-CN", contextLength: 200 },
-      });
+    // Settings full-page is wider than the default 400px demo viewport；host 打开设置
+    // tab 时下发 settingsState(nav:"subagents")（mirrors /agents → openSettings(nav)）
+    await openSettings(webviewPage, {
+      settingsState: { workdir: "/work/wave-agent", nav: "subagents" },
     });
 
     // Simulate the host replying with subagent configurations
-    await webviewPage.evaluate((configurations) => {
-      window.simulateExtensionMessage({
-        command: "subagentConfigurationsResponse",
-        configurations,
-      });
-    }, agentConfigurations);
+    await simulateHostMessage(webviewPage, {
+      command: "subagentConfigurationsResponse",
+      configurations: agentConfigurations,
+    });
 
     // 4 source tabs exist and the default tab is 插件子代理
     await expect(webviewPage.getByText("插件子代理")).toBeVisible();
@@ -229,30 +169,14 @@ test.describe("设置页技能选项卡 Demo", () => {
   test("should show 4 source tabs with flat project skill list", async ({
     webviewPage,
   }) => {
-    await webviewPage.setViewportSize({ width: 1000, height: 760 });
-    await webviewPage.setContent(settingsHtml);
-    await expect(webviewPage.locator(".settings-page")).toBeVisible();
-
     // /skills → openSettings(nav:"skills") → settingsState
-    await webviewPage.evaluate((workdir) => {
-      window.simulateExtensionMessage({
-        command: "settingsState",
-        workdir,
-        nav: "skills",
-      });
-    }, WORKDIR);
-    await webviewPage.evaluate(() => {
-      window.simulateExtensionMessage({
-        command: "configurationResponse",
-        configurationData: { language: "zh-CN", contextLength: 200 },
-      });
+    await openSettings(webviewPage, {
+      settingsState: { workdir: WORKDIR, nav: "skills" },
     });
-    await webviewPage.evaluate((skillList) => {
-      window.simulateExtensionMessage({
-        command: "skillMetadataResponse",
-        skills: skillList,
-      });
-    }, skills);
+    await simulateHostMessage(webviewPage, {
+      command: "skillMetadataResponse",
+      skills,
+    });
 
     // 4 source tabs exist
     await expect(webviewPage.getByText("插件技能")).toBeVisible();

--- a/packages/webview/demo/settings-manage.demo.ts
+++ b/packages/webview/demo/settings-manage.demo.ts
@@ -1,8 +1,9 @@
-import type { Page } from "@playwright/test";
 import { test, expect } from "../e2e/utils/webviewTestHarness.js";
 import { elementScreenshotWebp } from "../e2e/utils/screenshot.js";
-import fs from "node:fs";
-import path from "node:path";
+import {
+  openSettings,
+  simulateHostMessage,
+} from "../e2e/utils/settingsHarness.js";
 
 /**
  * 设置页「钩子」「MCP 服务」选项卡 demo（/hooks、/mcp 斜杠命令落地页）：
@@ -10,63 +11,6 @@ import path from "node:path";
  * settingsState(nav) 选中选项卡，再回 hooksResponse / mcpServersResponse +
  * mcpConfigPathsResponse 展示来源 Tab 列表、钩子事件摘要与 MCP 连接状态。
  */
-
-// SettingsPage 的颜色全部走 --vscode-* 变量，独立 settings.html 没有宿主注入，
-// 必须手动带上深色主题变量集，否则截图为白底浅色（实测 2026-08-29）。
-const themeStyles = fs.readFileSync(
-  path.join(process.cwd(), "theme", "theme-base-dark.css"),
-  "utf8",
-);
-
-const mockVscodeApiJs = `
-    window.process = { env: { NODE_ENV: 'production' } };
-    window.acquireVsCodeApi = () => ({
-        postMessage: (message) => {
-            if (!window.testMessages) window.testMessages = [];
-            window.testMessages.push(message);
-        },
-        setState: () => {},
-        getState: () => ({})
-    });
-    window.simulateExtensionMessage = (message) => {
-        window.dispatchEvent(new MessageEvent('message', { data: message }));
-    };
-`;
-
-const settingsHtml = `
-<!DOCTYPE html>
-<html lang="zh-CN" data-theme="dark">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Wave Settings</title>
-    <style>${themeStyles}</style>
-    <link rel="stylesheet" href="vscode-webview://mock-extension-id/settings.css">
-</head>
-<body>
-    <div id="root"></div>
-    <script>${mockVscodeApiJs}</script>
-    <script src="vscode-webview://mock-extension-id/settings.js"></script>
-</body>
-</html>`;
-
-/** 打开设置页 + 初始化配置（settings entry 挂载时会请求 getConfiguration） */
-async function openSettings(webviewPage: Page, nav: string) {
-  await webviewPage.setViewportSize({ width: 1000, height: 760 });
-  await webviewPage.setContent(settingsHtml);
-  await expect(webviewPage.locator(".settings-page")).toBeVisible();
-  await webviewPage.evaluate((targetNav) => {
-    window.simulateExtensionMessage({
-      command: "settingsState",
-      workdir: "/work/wave-agent",
-      nav: targetNav,
-    });
-    window.simulateExtensionMessage({
-      command: "configurationResponse",
-      configurationData: { language: "zh-CN", contextLength: 200 },
-    });
-  }, nav);
-}
 
 const userHooks = {
   PreToolUse: [
@@ -101,19 +45,19 @@ test.describe("设置页钩子选项卡 Demo", () => {
   test("should show hook entries with event summary and actions", async ({
     webviewPage,
   }) => {
-    await openSettings(webviewPage, "hooks");
+    await openSettings(webviewPage, {
+      settingsState: { workdir: "/work/wave-agent", nav: "hooks" },
+    });
 
     // 等视图挂载（发出 getHooksByScope 请求）后再回数据，避免响应先于 listener
     await expect(webviewPage.getByText("新增钩子")).toBeVisible();
-    await webviewPage.evaluate((hooks) => {
-      window.simulateExtensionMessage({
-        command: "hooksResponse",
-        // 归属键：当前 Tab 为「用户级钩子」，回带 scope 才能通过过期即弃
-        scope: "user",
-        hooks,
-        configPath: "~/.wave/settings.json",
-      });
-    }, userHooks);
+    await simulateHostMessage(webviewPage, {
+      command: "hooksResponse",
+      // 归属键：当前 Tab 为「用户级钩子」，回带 scope 才能通过过期即弃
+      scope: "user",
+      hooks: userHooks,
+      configPath: "~/.wave/settings.json",
+    });
 
     // 3 source tabs + 钩子条目、事件摘要与命令
     await expect(webviewPage.getByText("用户级钩子")).toBeVisible();
@@ -174,21 +118,21 @@ test.describe("设置页 MCP 服务选项卡 Demo", () => {
   test("should show MCP servers by scope with connection status", async ({
     webviewPage,
   }) => {
-    await openSettings(webviewPage, "mcp");
+    await openSettings(webviewPage, {
+      settingsState: { workdir: "/work/wave-agent", nav: "mcp" },
+    });
 
     // 等视图挂载（发出 getMcpServers / getMcpConfigPaths 请求）后再回数据
     await expect(webviewPage.getByText("新增用户级 MCP 服务")).toBeVisible();
-    await webviewPage.evaluate((servers) => {
-      window.simulateExtensionMessage({
-        command: "mcpServersResponse",
-        servers,
-      });
-      window.simulateExtensionMessage({
-        command: "mcpConfigPathsResponse",
-        userPath: "~/.wave/mcp.json",
-        projectPath: null,
-      });
-    }, mcpServers);
+    await simulateHostMessage(webviewPage, {
+      command: "mcpServersResponse",
+      servers: mcpServers,
+    });
+    await simulateHostMessage(webviewPage, {
+      command: "mcpConfigPathsResponse",
+      userPath: "~/.wave/mcp.json",
+      projectPath: null,
+    });
 
     // 3 source tabs + 服务器连接状态
     await expect(

--- a/packages/webview/e2e/settings-delete-confirm.e2e.ts
+++ b/packages/webview/e2e/settings-delete-confirm.e2e.ts
@@ -1,0 +1,318 @@
+import type { Page } from "@playwright/test";
+import { test, expect } from "./utils/webviewTestHarness.js";
+import {
+  openSettings,
+  sentToHost,
+  simulateHostMessage,
+} from "./utils/settingsHarness.js";
+
+/**
+ * Regression（设置页删除后列表整段空白，Bug #2092）：
+ *
+ * 四个管理视图（技能 / 子代理 / 钩子 / MCP 服务）的删除是「二次确认 + 直接删
+ * 配置」，删完必须把**剩余条目**渲染出来。曾经出现「确认删除后列表整段空白」：
+ * host 回了新列表但视图没有写回（或写回时用了空值），用户须重进设置页才看到
+ * 真实列表。本文件驱动真实 settings.js bundle 跑完整链路
+ * 「点删除 → 确认框 → 点确认 → 发出 deleteXxx → host 回发新列表 → 剩余条目
+ * 仍在、空态占位不出现」，四个视图各一例。
+ */
+
+/** 列表行（.mcp-server-item）按名称定位后取其「删除」按钮。 */
+function rowDeleteButton(webviewPage: Page, name: string) {
+  return webviewPage
+    .locator(".mcp-server-item")
+    .filter({
+      has: webviewPage.locator(".mcp-server-name", { hasText: name }),
+    })
+    .getByRole("button", { name: "删除" });
+}
+
+/** 断言确认框标题并点「确认删除」（调用前应已点过该行的「删除」）。 */
+async function confirmDelete(webviewPage: Page, expectedTitle: string) {
+  const dialog = webviewPage.getByTestId("confirm-dialog-overlay");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.locator(".confirm-dialog-title")).toHaveText(
+    expectedTitle,
+  );
+  await webviewPage.getByTestId("confirm-dialog-confirm").click();
+  await expect(dialog).toHaveCount(0);
+}
+
+/** 断言 host 收到的消息里存在（且含指定字段的）某条命令。 */
+async function expectSentMessage(
+  webviewPage: Page,
+  expected: Record<string, unknown>,
+) {
+  await expect
+    .poll(async () => {
+      const messages = await sentToHost(webviewPage);
+      return messages.some((m) =>
+        Object.entries(expected).every(([k, v]) => m[k] === v),
+      );
+    })
+    .toBe(true);
+}
+
+/** 断言「剩余条目仍在、空态占位不出现」——即删除后列表没有整段空白。 */
+async function expectListNotBlank(
+  webviewPage: Page,
+  remainingName: string,
+  emptyStateText: string,
+) {
+  await expect(
+    webviewPage.getByText(remainingName, { exact: true }),
+  ).toBeVisible();
+  await expect(webviewPage.getByText(emptyStateText)).toHaveCount(0);
+}
+
+test.describe("设置页四视图删除后列表不空白（settings tab）", () => {
+  test("技能：确认删除后 host 回新列表，剩余技能仍渲染", async ({
+    webviewPage,
+  }) => {
+    await openSettings(webviewPage);
+    await webviewPage
+      .getByRole("button", { name: "技能", exact: true })
+      .click();
+    await simulateHostMessage(webviewPage, {
+      command: "skillMetadataResponse",
+      skills: [
+        {
+          name: "skill-a",
+          description: "a",
+          type: "personal",
+          skillPath: "/home/u/.wave/skills/skill-a",
+        },
+        {
+          name: "skill-b",
+          description: "b",
+          type: "personal",
+          skillPath: "/home/u/.wave/skills/skill-b",
+        },
+      ],
+    });
+    await webviewPage.getByRole("tab", { name: "用户技能" }).click();
+    await expect(
+      webviewPage.getByText("skill-a", { exact: true }),
+    ).toBeVisible();
+
+    await rowDeleteButton(webviewPage, "skill-a").click();
+    await confirmDelete(webviewPage, "删除技能「skill-a」");
+
+    // webview → host：删除请求 + 立即重新拉取列表（删除后刷新）
+    await expectSentMessage(webviewPage, {
+      command: "deleteSkill",
+      name: "skill-a",
+    });
+    await expect
+      .poll(async () => {
+        const messages = await sentToHost(webviewPage);
+        return messages.filter((m) => m.command === "getSkillMetadata").length;
+      })
+      .toBeGreaterThanOrEqual(2);
+
+    // host 回发删除后的新列表
+    await simulateHostMessage(webviewPage, {
+      command: "skillMetadataResponse",
+      skills: [
+        {
+          name: "skill-b",
+          description: "b",
+          type: "personal",
+          skillPath: "/home/u/.wave/skills/skill-b",
+        },
+      ],
+    });
+
+    await expect(webviewPage.getByText("skill-a", { exact: true })).toHaveCount(
+      0,
+    );
+    await expectListNotBlank(webviewPage, "skill-b", "用户技能暂无内容");
+  });
+
+  test("子代理：确认删除后 host 回新列表，剩余子代理仍渲染", async ({
+    webviewPage,
+  }) => {
+    await openSettings(webviewPage);
+    await webviewPage
+      .getByRole("button", { name: "子代理", exact: true })
+      .click();
+    await simulateHostMessage(webviewPage, {
+      command: "subagentConfigurationsResponse",
+      configurations: [
+        {
+          name: "agent-a",
+          description: "a",
+          scope: "user",
+          filePath: "/home/u/.wave/agents/agent-a.md",
+          systemPrompt: "x",
+        },
+        {
+          name: "agent-b",
+          description: "b",
+          scope: "user",
+          filePath: "/home/u/.wave/agents/agent-b.md",
+          systemPrompt: "y",
+        },
+      ],
+    });
+    await webviewPage.getByRole("tab", { name: "用户子代理" }).click();
+    await expect(
+      webviewPage.getByText("agent-a", { exact: true }),
+    ).toBeVisible();
+
+    await rowDeleteButton(webviewPage, "agent-a").click();
+    await confirmDelete(webviewPage, "删除子代理「agent-a」");
+
+    await expectSentMessage(webviewPage, {
+      command: "deleteSubagent",
+      name: "agent-a",
+    });
+    await expect
+      .poll(async () => {
+        const messages = await sentToHost(webviewPage);
+        return messages.filter((m) => m.command === "getSubagentConfigurations")
+          .length;
+      })
+      .toBeGreaterThanOrEqual(2);
+
+    await simulateHostMessage(webviewPage, {
+      command: "subagentConfigurationsResponse",
+      configurations: [
+        {
+          name: "agent-b",
+          description: "b",
+          scope: "user",
+          filePath: "/home/u/.wave/agents/agent-b.md",
+          systemPrompt: "y",
+        },
+      ],
+    });
+
+    await expect(webviewPage.getByText("agent-a", { exact: true })).toHaveCount(
+      0,
+    );
+    await expectListNotBlank(webviewPage, "agent-b", "用户子代理暂无内容");
+  });
+
+  test("钩子：确认删除后乐观移除，host 回新列表仍不空白", async ({
+    webviewPage,
+  }) => {
+    await openSettings(webviewPage);
+    await webviewPage
+      .getByRole("button", { name: "钩子", exact: true })
+      .click();
+    await simulateHostMessage(webviewPage, {
+      command: "hooksResponse",
+      scope: "user",
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [{ type: "command", command: "echo hi" }],
+          },
+        ],
+        PostToolUse: [
+          {
+            matcher: "Write",
+            hooks: [{ type: "command", command: "echo bye" }],
+          },
+        ],
+      },
+      configPath: "/home/u/.wave/settings.json",
+    });
+    await expect(
+      webviewPage.getByText("PreToolUse:Bash", { exact: true }),
+    ).toBeVisible();
+
+    await rowDeleteButton(webviewPage, "PreToolUse:Bash").click();
+    await confirmDelete(webviewPage, "删除钩子「PreToolUse:Bash」");
+
+    await expectSentMessage(webviewPage, {
+      command: "deleteHook",
+      scope: "user",
+      hookName: "PreToolUse:Bash",
+    });
+    // 乐观移除：不等 host 回包，被删钩子先消失
+    await expect(
+      webviewPage.getByText("PreToolUse:Bash", { exact: true }),
+    ).toHaveCount(0);
+
+    await simulateHostMessage(webviewPage, {
+      command: "hooksResponse",
+      scope: "user",
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: "Write",
+            hooks: [{ type: "command", command: "echo bye" }],
+          },
+        ],
+      },
+      configPath: "/home/u/.wave/settings.json",
+    });
+
+    await expectListNotBlank(
+      webviewPage,
+      "PostToolUse:Write",
+      "用户级钩子暂无内容",
+    );
+  });
+
+  test("MCP 服务：确认删除后乐观移除，host 回新列表仍不空白", async ({
+    webviewPage,
+  }) => {
+    await openSettings(webviewPage);
+    await webviewPage
+      .getByRole("button", { name: "MCP 服务", exact: true })
+      .click();
+    await simulateHostMessage(webviewPage, {
+      command: "mcpServersResponse",
+      servers: [
+        {
+          name: "mcp-a",
+          scope: "user",
+          status: "connected",
+          config: { command: "npx" },
+        },
+        {
+          name: "mcp-b",
+          scope: "user",
+          status: "connected",
+          config: { command: "npx" },
+        },
+      ],
+    });
+    await simulateHostMessage(webviewPage, {
+      command: "mcpConfigPathsResponse",
+      userPath: "/home/u/.wave/mcp.json",
+      projectPath: "/work/a/.mcp.json",
+    });
+    await expect(webviewPage.getByText("mcp-a", { exact: true })).toBeVisible();
+
+    await rowDeleteButton(webviewPage, "mcp-a").click();
+    await confirmDelete(webviewPage, "删除 MCP 服务「mcp-a」");
+
+    await expectSentMessage(webviewPage, {
+      command: "removeMcpServer",
+      scope: "user",
+      serverName: "mcp-a",
+    });
+    await expect(webviewPage.getByText("mcp-a", { exact: true })).toHaveCount(
+      0,
+    );
+
+    await simulateHostMessage(webviewPage, {
+      command: "mcpServersResponse",
+      servers: [
+        {
+          name: "mcp-b",
+          scope: "user",
+          status: "connected",
+          config: { command: "npx" },
+        },
+      ],
+    });
+
+    await expectListNotBlank(webviewPage, "mcp-b", "用户级 MCP暂无内容");
+  });
+});

--- a/packages/webview/e2e/settings-edit-openfile.e2e.ts
+++ b/packages/webview/e2e/settings-edit-openfile.e2e.ts
@@ -1,7 +1,10 @@
 import type { Page } from "@playwright/test";
 import { test, expect } from "./utils/webviewTestHarness.js";
-import fs from "node:fs";
-import path from "node:path";
+import {
+  openSettings,
+  sentToHost,
+  simulateHostMessage,
+} from "./utils/settingsHarness.js";
 
 /**
  * Regression（VS Code / JetBrains 设置页四个视图点「编辑」都不打开配置文件）：
@@ -17,67 +20,10 @@ import path from "node:path";
  * bundle 逐视图断言「openFile 先于 prefillPrompt」——修复前四个用例全红。
  */
 
-// SettingsPage 的颜色全部走 --vscode-* 变量，独立 settings.html 没有宿主注入，
-// 必须手动带上深色主题变量集（与 settings-project-toggle.e2e.ts 同法）。
-const themeStyles = fs.readFileSync(
-  path.join(process.cwd(), "theme", "theme-base-dark.css"),
-  "utf8",
-);
-
-const mockVscodeApiJs = `
-    window.process = { env: { NODE_ENV: 'production' } };
-    window.acquireVsCodeApi = () => ({
-        postMessage: (message) => {
-            if (!window.testMessages) window.testMessages = [];
-            window.testMessages.push(message);
-        },
-        setState: () => {},
-        getState: () => ({})
-    });
-    window.simulateExtensionMessage = (message) => {
-        window.dispatchEvent(new MessageEvent('message', { data: message }));
-    };
-`;
-
-const settingsHtml = `
-<!DOCTYPE html>
-<html lang="zh-CN" data-theme="dark">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Wave Settings</title>
-    <style>${themeStyles}</style>
-    <link rel="stylesheet" href="vscode-webview://mock-extension-id/settings.css">
-</head>
-<body>
-    <div id="root"></div>
-    <script>${mockVscodeApiJs}</script>
-    <script src="vscode-webview://mock-extension-id/settings.js"></script>
-</body>
-</html>`;
-
-async function openSettings(webviewPage: Page) {
-  await webviewPage.setViewportSize({ width: 1000, height: 760 });
-  await webviewPage.setContent(settingsHtml);
-  await expect(webviewPage.locator(".settings-page")).toBeVisible();
-  // 设置入口挂载时会请求 getConfiguration
-  await webviewPage.evaluate(() => {
-    window.simulateExtensionMessage({
-      command: "configurationResponse",
-      configurationData: { language: "zh-CN", contextLength: 200 },
-    });
-  });
-}
+type SentMessage = { command?: string; path?: string; prompt?: string };
 
 function sentMessages(webviewPage: Page) {
-  return webviewPage.evaluate(
-    () =>
-      (window.testMessages ?? []) as Array<{
-        command?: string;
-        path?: string;
-        prompt?: string;
-      }>,
-  );
+  return sentToHost<SentMessage>(webviewPage);
 }
 
 /** 断言最后两条消息是 openFile(path) → prefillPrompt，即 openFile 未被关闭丢弃。 */
@@ -108,21 +54,19 @@ test.describe("设置页「编辑」打开的配置文件顺序（settings tab�
   }) => {
     await openSettings(webviewPage);
     await webviewPage.getByRole("button", { name: "钩子" }).click();
-    await webviewPage.evaluate(() => {
-      window.simulateExtensionMessage({
-        command: "hooksResponse",
-        scope: "user",
-        hooks: {
-          PreToolUse: [
-            {
-              matcher: "Bash",
-              hooks: [{ type: "command", command: "echo hi" }],
-            },
-          ],
-        },
-        // host（CLI/SDK）解析出的绝对路径（见 getHookConfigPath）
-        configPath: "/home/u/.wave/settings.json",
-      });
+    await simulateHostMessage(webviewPage, {
+      command: "hooksResponse",
+      scope: "user",
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [{ type: "command", command: "echo hi" }],
+          },
+        ],
+      },
+      // host（CLI/SDK）解析出的绝对路径（见 getHookConfigPath）
+      configPath: "/home/u/.wave/settings.json",
     });
 
     await webviewPage.getByRole("button", { name: "编辑" }).first().click();
@@ -138,18 +82,16 @@ test.describe("设置页「编辑」打开的配置文件顺序（settings tab�
   }) => {
     await openSettings(webviewPage);
     await webviewPage.getByRole("button", { name: "技能" }).click();
-    await webviewPage.evaluate(() => {
-      window.simulateExtensionMessage({
-        command: "skillMetadataResponse",
-        skills: [
-          {
-            name: "my-skill",
-            description: "d",
-            type: "personal",
-            skillPath: "/home/u/.wave/skills/my-skill",
-          },
-        ],
-      });
+    await simulateHostMessage(webviewPage, {
+      command: "skillMetadataResponse",
+      skills: [
+        {
+          name: "my-skill",
+          description: "d",
+          type: "personal",
+          skillPath: "/home/u/.wave/skills/my-skill",
+        },
+      ],
     });
     await webviewPage.getByRole("tab", { name: "用户技能" }).click();
 
@@ -166,19 +108,17 @@ test.describe("设置页「编辑」打开的配置文件顺序（settings tab�
   }) => {
     await openSettings(webviewPage);
     await webviewPage.getByRole("button", { name: "子代理" }).click();
-    await webviewPage.evaluate(() => {
-      window.simulateExtensionMessage({
-        command: "subagentConfigurationsResponse",
-        configurations: [
-          {
-            name: "demo",
-            description: "d",
-            scope: "user",
-            filePath: "/home/u/.wave/agents/demo.md",
-            systemPrompt: "x",
-          },
-        ],
-      });
+    await simulateHostMessage(webviewPage, {
+      command: "subagentConfigurationsResponse",
+      configurations: [
+        {
+          name: "demo",
+          description: "d",
+          scope: "user",
+          filePath: "/home/u/.wave/agents/demo.md",
+          systemPrompt: "x",
+        },
+      ],
     });
     await webviewPage.getByRole("tab", { name: "用户子代理" }).click();
 
@@ -195,23 +135,21 @@ test.describe("设置页「编辑」打开的配置文件顺序（settings tab�
   }) => {
     await openSettings(webviewPage);
     await webviewPage.getByRole("button", { name: "MCP 服务" }).click();
-    await webviewPage.evaluate(() => {
-      window.simulateExtensionMessage({
-        command: "mcpServersResponse",
-        servers: [
-          {
-            name: "github",
-            config: { command: "npx" },
-            scope: "user",
-            status: "connected",
-          },
-        ],
-      });
-      window.simulateExtensionMessage({
-        command: "mcpConfigPathsResponse",
-        userPath: "/home/u/.wave/mcp.json",
-        projectPath: "/work/a/.mcp.json",
-      });
+    await simulateHostMessage(webviewPage, {
+      command: "mcpServersResponse",
+      servers: [
+        {
+          name: "github",
+          config: { command: "npx" },
+          scope: "user",
+          status: "connected",
+        },
+      ],
+    });
+    await simulateHostMessage(webviewPage, {
+      command: "mcpConfigPathsResponse",
+      userPath: "/home/u/.wave/mcp.json",
+      projectPath: "/work/a/.mcp.json",
     });
 
     await webviewPage.getByRole("button", { name: "编辑" }).first().click();

--- a/packages/webview/e2e/settings-project-toggle.e2e.ts
+++ b/packages/webview/e2e/settings-project-toggle.e2e.ts
@@ -1,7 +1,9 @@
-import type { Page } from "@playwright/test";
 import { test, expect } from "./utils/webviewTestHarness.js";
-import fs from "node:fs";
-import path from "node:path";
+import {
+  openSettings,
+  sentToHost,
+  simulateHostMessage,
+} from "./utils/settingsHarness.js";
 
 /**
  * Regression (VS Code 插件端「项目设置 → 内置插件」SDD 开关永久置灰):
@@ -15,62 +17,6 @@ import path from "node:path";
  * host 回 projectSettings 后开关应可点，点击应发出 setBuiltinPluginEnabled(project)。
  * 修复前：不发 getProjectSettings、开关保持禁用、点击无消息 —— 三段断言全部失败。
  */
-
-// SettingsPage 的颜色全部走 --vscode-* 变量，独立 settings.html 没有宿主注入，
-// 必须手动带上深色主题变量集，否则页面为白底浅色（与 settings-manage.demo.ts 同法）。
-const themeStyles = fs.readFileSync(
-  path.join(process.cwd(), "theme", "theme-base-dark.css"),
-  "utf8",
-);
-
-const mockVscodeApiJs = `
-    window.process = { env: { NODE_ENV: 'production' } };
-    window.acquireVsCodeApi = () => ({
-        postMessage: (message) => {
-            if (!window.testMessages) window.testMessages = [];
-            window.testMessages.push(message);
-        },
-        setState: () => {},
-        getState: () => ({})
-    });
-    window.simulateExtensionMessage = (message) => {
-        window.dispatchEvent(new MessageEvent('message', { data: message }));
-    };
-`;
-
-const settingsHtml = `
-<!DOCTYPE html>
-<html lang="zh-CN" data-theme="dark">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Wave Settings</title>
-    <style>${themeStyles}</style>
-    <link rel="stylesheet" href="vscode-webview://mock-extension-id/settings.css">
-</head>
-<body>
-    <div id="root"></div>
-    <script>${mockVscodeApiJs}</script>
-    <script src="vscode-webview://mock-extension-id/settings.js"></script>
-</body>
-</html>`;
-
-async function openSettings(webviewPage: Page) {
-  await webviewPage.setViewportSize({ width: 1000, height: 760 });
-  await webviewPage.setContent(settingsHtml);
-  await expect(webviewPage.locator(".settings-page")).toBeVisible();
-  // 初始化配置（settings entry 挂载时会请求 getConfiguration）
-  await webviewPage.evaluate(() => {
-    window.simulateExtensionMessage({
-      command: "configurationResponse",
-      configurationData: { language: "zh-CN", contextLength: 200 },
-    });
-  });
-}
-
-function sentToHost(webviewPage: Page) {
-  return webviewPage.evaluate(() => (window.testMessages ?? []) as unknown[]);
-}
 
 test.describe("设置页项目设置内置插件开关（settings tab）", () => {
   test("进入项目设置视图请求并回填 enabledPlugins，SDD 开关可切换", async ({
@@ -95,19 +41,15 @@ test.describe("设置页项目设置内置插件开关（settings tab）", () =>
     // 视图进入时应向 host 请求项目级 enabledPlugins（修复前永不发出）
     await expect
       .poll(async () => {
-        const messages = (await sentToHost(webviewPage)) as Array<{
-          command?: string;
-        }>;
+        const messages = await sentToHost<{ command?: string }>(webviewPage);
         return messages.some((m) => m.command === "getProjectSettings");
       })
       .toBe(true);
 
     // host 回发 projectSettings（.wave/settings.json 合并后，sdd@builtin 未启用）
-    await webviewPage.evaluate(() => {
-      window.simulateExtensionMessage({
-        command: "projectSettings",
-        enabledPlugins: {},
-      });
+    await simulateHostMessage(webviewPage, {
+      command: "projectSettings",
+      enabledPlugins: {},
     });
     await expect(sddSwitch).toBeEnabled();
 
@@ -117,12 +59,12 @@ test.describe("设置页项目设置内置插件开关（settings tab）", () =>
       .click();
     await expect
       .poll(async () => {
-        const messages = (await sentToHost(webviewPage)) as Array<{
+        const messages = await sentToHost<{
           command?: string;
           pluginId?: string;
           enabled?: boolean;
           scope?: string;
-        }>;
+        }>(webviewPage);
         return messages.find((m) => m.command === "setBuiltinPluginEnabled");
       })
       .toEqual({

--- a/packages/webview/e2e/settings-save-feedback.e2e.ts
+++ b/packages/webview/e2e/settings-save-feedback.e2e.ts
@@ -1,0 +1,243 @@
+import type { Locator, Page } from "@playwright/test";
+import { test, expect } from "./utils/webviewTestHarness.js";
+import {
+  openSettings,
+  sentToHost,
+  simulateHostMessage,
+} from "./utils/settingsHarness.js";
+
+/**
+ * Regression（设置页保存反馈，2026-09-09 拍板「走宿主全局 toast」）：
+ *
+ * 设置页此前自己渲染页面内提示（`.settings-save-message` 内联灰字，全局设置 /
+ * 个性化 / AGENTS.md 三处）。拍板后改为：保存结果的用户可见反馈由宿主（桌面
+ * showToast / VSCE showInformationMessage / JB IdeService.showInfo）给出，webview
+ * 只负责 ①发出正确的保存消息 ②维护「保存中」禁用态并在 host 回包后复位，
+ * **不再渲染任何页面内提示**。本文件驱动真实 settings.js bundle 覆盖这三件事，
+ * 同时补 AGENTS.md「键入 → 保存」的请求载荷（G8）。
+ *
+ * 断言口径：
+ * - 载荷 = 发给 host 的 `updateConfiguration` / `setAgentsContent` 消息内容；
+ * - 无页面内提示 = 旧类名 `.settings-save-message` 不存在，且 `.settings-actions`
+ *   容器里只有按钮文本（旧实现把提示文字追加在该容器内）；
+ * - 复位 = 回 `configurationResponse` / `configurationError` / `agentsContentSaved`
+ *   后保存按钮与文本区重新可用。
+ */
+
+/** 保存区块（按小标题定位，避免同一视图内多个 `.settings-actions` 撞车）。 */
+function saveSection(webviewPage: Page, heading: string): Locator {
+  return webviewPage
+    .locator(".settings-section")
+    .filter({ has: webviewPage.getByRole("heading", { name: heading }) });
+}
+
+/** 该保存区块内不得出现自建提示（旧实现的内联灰字 + 追加在动作行里的文案）。 */
+async function expectNoInlineSaveHint(section: Locator, actionText: string) {
+  await expect(section.locator(".settings-save-message")).toHaveCount(0);
+  // 旧实现把提示文字追加在保存按钮所在的动作行内：无提示时该行只有按钮文本
+  await expect(section.locator(".settings-actions")).toHaveText(actionText);
+}
+
+test.describe("设置页保存反馈（settings tab）", () => {
+  test("全局设置保存：发出 updateConfiguration 载荷、无页面内提示、回包后复位", async ({
+    webviewPage,
+  }) => {
+    await openSettings(webviewPage);
+
+    const saveButton = webviewPage.getByRole("button", {
+      name: "保存",
+      exact: true,
+    });
+    await expect(saveButton).toBeEnabled();
+    await webviewPage.getByLabel("AI 回复语言").selectOption("en-US");
+    await webviewPage.getByLabel("上下文长度").fill("300");
+
+    await saveButton.click();
+
+    // 发送「保存中」禁用态：host 未回包前不得再次点击
+    await expect(saveButton).toBeDisabled();
+
+    const saved = await sentToHost<{
+      command?: string;
+      configurationData?: Record<string, unknown>;
+    }>(webviewPage);
+    const request = saved.find((m) => m.command === "updateConfiguration");
+    expect(request?.configurationData).toMatchObject({
+      language: "en-US",
+      contextLength: 300,
+    });
+
+    // 页面内无自建提示（反馈由宿主全局 toast 承担）
+    await expectNoInlineSaveHint(saveSection(webviewPage, "基础设置"), "保存");
+
+    // 成功回包：saving 复位（按钮重新可用）
+    await simulateHostMessage(webviewPage, {
+      command: "configurationResponse",
+      configurationData: { language: "en-US", contextLength: 300 },
+    });
+    await expect(saveButton).toBeEnabled();
+    await expectNoInlineSaveHint(saveSection(webviewPage, "基础设置"), "保存");
+
+    // 失败回包（configurationError）：同样复位，且不出现页面内错误文案
+    await saveButton.click();
+    await expect(saveButton).toBeDisabled();
+    await simulateHostMessage(webviewPage, {
+      command: "configurationError",
+      error: "Failed to save configuration: boom",
+    });
+    await expect(saveButton).toBeEnabled();
+    await expect(webviewPage.getByText(/保存失败|保存出错/)).toHaveCount(0);
+    await expectNoInlineSaveHint(saveSection(webviewPage, "基础设置"), "保存");
+  });
+
+  test("个性化保存：自动记忆开关与轮次进入 updateConfiguration 载荷并复位", async ({
+    webviewPage,
+  }) => {
+    await openSettings(webviewPage);
+    await webviewPage
+      .getByRole("button", { name: "个性化", exact: true })
+      .click();
+
+    const toggle = webviewPage.getByLabel("开启自动记忆");
+    await expect(toggle).toBeChecked();
+    // 开关 input 是视觉隐藏（opacity: 0）的自绘 switch：点可视滑轨（label 内）切换
+    await saveSection(webviewPage, "自动记忆规则")
+      .locator(".settings-switch-slider")
+      .click();
+    await expect(toggle).not.toBeChecked();
+    await webviewPage.getByLabel("触发记忆提取会话轮次").fill("5");
+
+    const saveButton = webviewPage.getByRole("button", {
+      name: "保存",
+      exact: true,
+    });
+    await saveButton.click();
+    await expect(saveButton).toBeDisabled();
+
+    const saved = await sentToHost<{
+      command?: string;
+      configurationData?: Record<string, unknown>;
+    }>(webviewPage);
+    const request = saved.find((m) => m.command === "updateConfiguration");
+    // 关闭态（false）必须真的随载荷下发——#2115「关了还在记忆」的回归点
+    expect(request?.configurationData).toMatchObject({
+      autoMemoryEnabled: false,
+      autoMemoryFrequency: 5,
+    });
+
+    await expectNoInlineSaveHint(
+      saveSection(webviewPage, "自动记忆规则"),
+      "保存",
+    );
+
+    // 失败回包也要复位（旧实现失败时会留下内联错误文字）
+    await simulateHostMessage(webviewPage, {
+      command: "configurationError",
+      error: "Failed to save configuration: boom",
+    });
+    await expect(saveButton).toBeEnabled();
+    await expectNoInlineSaveHint(
+      saveSection(webviewPage, "自动记忆规则"),
+      "保存",
+    );
+  });
+
+  test("AGENTS.md：键入用户级内容后保存，发出 setAgentsContent（scope user）", async ({
+    webviewPage,
+  }) => {
+    await openSettings(webviewPage);
+    await webviewPage
+      .getByRole("button", { name: "个性化", exact: true })
+      .click();
+    await simulateHostMessage(webviewPage, {
+      command: "agentsContentResponse",
+      scope: "user",
+      content: "# 旧规则",
+    });
+
+    const textarea = webviewPage.getByLabel("用户级 AGENTS.md 内容");
+    await expect(textarea).toHaveValue("# 旧规则");
+    await textarea.fill("# 新规则\n- 测试覆盖");
+
+    const saveButton = webviewPage.getByRole("button", {
+      name: "保存用户级配置",
+    });
+    await saveButton.click();
+
+    // 保存中：文本区与按钮一并禁用（host 回包前不可再编辑）
+    await expect(textarea).toBeDisabled();
+    await expect(saveButton).toBeDisabled();
+
+    const saved = await sentToHost<{
+      command?: string;
+      scope?: string;
+      content?: string;
+      workdir?: string;
+    }>(webviewPage);
+    const request = saved.find((m) => m.command === "setAgentsContent");
+    expect(request).toMatchObject({
+      scope: "user",
+      content: "# 新规则\n- 测试覆盖",
+      workdir: undefined,
+    });
+
+    await expectNoInlineSaveHint(
+      saveSection(webviewPage, "AGENTS.md"),
+      "保存用户级配置",
+    );
+
+    // agentsContentSaved 复位：文本区与按钮重新可用
+    await simulateHostMessage(webviewPage, {
+      command: "agentsContentSaved",
+      scope: "user",
+      ok: true,
+    });
+    await expect(textarea).toBeEnabled();
+    await expect(saveButton).toBeEnabled();
+  });
+
+  test("AGENTS.md：项目级保存带当前 workdir（归属键）", async ({
+    webviewPage,
+  }) => {
+    await openSettings(webviewPage, {
+      settingsState: { workdir: "/work/wave-agent" },
+    });
+    await webviewPage
+      .getByRole("button", { name: "个性化", exact: true })
+      .click();
+    await webviewPage.getByRole("tab", { name: "项目级" }).click();
+    await simulateHostMessage(webviewPage, {
+      command: "agentsContentResponse",
+      scope: "project",
+      content: "# 项目规则",
+    });
+
+    // 先等 host 内容落地（回填 effect 会覆盖草稿），再键入
+    const textarea = webviewPage.getByLabel("项目级 AGENTS.md 内容");
+    await expect(textarea).toHaveValue("# 项目规则");
+    await textarea.fill("# 项目规则 v2");
+    await webviewPage.getByRole("button", { name: "保存项目级配置" }).click();
+
+    const saved = await sentToHost<{
+      command?: string;
+      scope?: string;
+      content?: string;
+      workdir?: string;
+    }>(webviewPage);
+
+    // 读取请求与写入请求都要带归属键：workdir 决定读写哪个项目的 AGENTS.md，
+    // 漏传就会被 host 兜底到 effectiveWorkdir（#2152/#2155 的错项目根因）。
+    expect(
+      saved.find(
+        (m) => m.command === "getAgentsContent" && m.scope === "project",
+      ),
+    ).toMatchObject({ scope: "project", workdir: "/work/wave-agent" });
+
+    const request = saved.find((m) => m.command === "setAgentsContent");
+    expect(request).toMatchObject({
+      scope: "project",
+      content: "# 项目规则 v2",
+      workdir: "/work/wave-agent",
+    });
+  });
+});

--- a/packages/webview/e2e/utils/settingsHarness.ts
+++ b/packages/webview/e2e/utils/settingsHarness.ts
@@ -1,0 +1,140 @@
+/**
+ * 设置页 e2e 公共 harness（IDE settings tab 场景）。
+ *
+ * 设置页由独立 bundle `settings.js`（src/settings-preview-entry.tsx）渲染，与聊天
+ * bundle 不同：宿主是 IDE 编辑器区的 WebviewPanel，页面需要自己带
+ * `<script src="vscode-webview://mock-extension-id/settings.js">` 与
+ * `window.acquireVsCodeApi`。此前 settings-edit-openfile / settings-project-toggle
+ * 两个 e2e 与 agents-dialog / settings-manage 两个 demo 各自抄了一份同样的
+ * settings.html 样板（theme 注入 + mockVscodeApi + openSettings + 消息收发），
+ * 本文件把它收拢为唯一来源，新用例一律复用，不要再抄第 N 份。
+ *
+ * `webviewPage` fixture（webviewTestHarness）会先把 chat.html 塞进页面，调用
+ * `openSettings` 时用 setContent 整体替换为 settings.html —— setContent 会重置
+ * 文档与全局对象，因此 `window.testMessages` 从空开始。
+ */
+import type { Page } from "@playwright/test";
+import { expect } from "./webviewTestHarness.js";
+import fs from "node:fs";
+import path from "node:path";
+
+// SettingsPage 的颜色全部走 --vscode-* 变量，独立 settings.html 没有宿主注入，
+// 必须手动带上深色主题变量集，否则页面为白底浅色（实测 2026-08-29）。
+const themeStyles = fs.readFileSync(
+  path.join(process.cwd(), "theme", "theme-base-dark.css"),
+  "utf8",
+);
+
+const mockVscodeApiJs = `
+    window.process = { env: { NODE_ENV: 'production' } };
+    window.acquireVsCodeApi = () => ({
+        postMessage: (message) => {
+            if (!window.testMessages) window.testMessages = [];
+            window.testMessages.push(message);
+        },
+        setState: () => {},
+        getState: () => ({})
+    });
+    window.simulateExtensionMessage = (message) => {
+        window.dispatchEvent(new MessageEvent('message', { data: message }));
+    };
+`;
+
+/** 独立 settings.html（settings.js bundle 的最小宿主页面）。 */
+export const settingsHtml = `
+<!DOCTYPE html>
+<html lang="zh-CN" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wave Settings</title>
+    <style>${themeStyles}</style>
+    <link rel="stylesheet" href="vscode-webview://mock-extension-id/settings.css">
+</head>
+<body>
+    <div id="root"></div>
+    <script>${mockVscodeApiJs}</script>
+    <script src="vscode-webview://mock-extension-id/settings.js"></script>
+</body>
+</html>`;
+
+/** webview → host 的消息（`command` 之外字段按用例自定）。 */
+export interface SettingsSentMessage {
+  command?: string;
+  [key: string]: unknown;
+}
+
+export interface OpenSettingsOptions {
+  width?: number;
+  height?: number;
+  /**
+   * 挂载后回 `configurationResponse`（默认 true）。settings entry 挂载时会发
+   * `getConfiguration`，不回包表单一直停在未加载态（保存按钮禁用）。
+   */
+  configuration?: boolean;
+  /** 模拟 host 下发 `settingsState`（直选某视图 / 设定 workdir）。 */
+  settingsState?: { workdir?: string; nav?: string };
+}
+
+/**
+ * 打开设置页并等到 `.settings-page` 渲染完成。
+ * 需要直达某个视图（/agents、/skills 场景）时传 `settingsState`。
+ */
+export async function openSettings(
+  page: Page,
+  options: OpenSettingsOptions = {},
+): Promise<void> {
+  const {
+    width = 1000,
+    height = 760,
+    configuration = true,
+    settingsState,
+  } = options;
+  await page.setViewportSize({ width, height });
+  await page.setContent(settingsHtml);
+  await expect(page.locator(".settings-page")).toBeVisible();
+  if (settingsState) {
+    await simulateHostMessage(page, {
+      command: "settingsState",
+      ...settingsState,
+    });
+  }
+  if (configuration) {
+    await simulateHostMessage(page, {
+      command: "configurationResponse",
+      configurationData: { language: "zh-CN", contextLength: 200 },
+    });
+  }
+}
+
+/** 模拟 host → webview 消息（等价于 IDE 侧 postMessage 到 webview）。 */
+export function simulateHostMessage(
+  page: Page,
+  message: Record<string, unknown>,
+): Promise<void> {
+  return page.evaluate((msg) => {
+    window.simulateExtensionMessage(msg);
+  }, message);
+}
+
+/** 设置页到目前为止发给 host 的全部消息。 */
+export function sentToHost<T = SettingsSentMessage>(page: Page): Promise<T[]> {
+  return page.evaluate(
+    () => (window.testMessages ?? []) as unknown[],
+  ) as Promise<T[]>;
+}
+
+/** 等到 host 收到指定 command 的消息，返回第一条。 */
+export async function waitForSentCommand<T = SettingsSentMessage>(
+  page: Page,
+  command: string,
+): Promise<T> {
+  await expect
+    .poll(async () => {
+      const messages = await sentToHost<SettingsSentMessage>(page);
+      return messages.filter((m) => m.command === command).length;
+    })
+    .toBeGreaterThan(0);
+  const messages = await sentToHost<SettingsSentMessage>(page);
+  return messages.find((m) => m.command === command) as T;
+}


### PR DESCRIPTION
## 背景

近一轮设置页修复（#2139 保存/删除反馈走全局 toast、#2092 技能刷新非原子、#2115 自动记忆开关透传、#2152/#2155 设置页归属键）落地后做了一次「这些修复是否真有回归覆盖」的审计，结论是只有跨项目切换族和「编辑」打开文件族落到了 e2e / 真 host，**JetBrains 设置页 handler 零测试**，保存/删除反馈与自动记忆透传也缺层次化覆盖。本 PR 补这些缺口，并把「每个可见结果的断言钉在它真正的产生者那一层」。

一个前置重构：`settings-*.e2e.ts` / `settings-*.demo.ts` 此前各自复制同一份 settings.html 样板（第 6 份），统一抽成 `e2e/utils/settingsHarness.ts`。

## 各层改了什么（7 个 commit）

| commit | 层 | 内容 |
|---|---|---|
| `b298b189` | webview 重构 | 抽 `e2e/utils/settingsHarness.ts`（`settingsHtml` / `openSettings` / `simulateHostMessage` / `sentToHost` / `waitForSentCommand`）；`settings-edit-openfile.e2e.ts`、`settings-project-toggle.e2e.ts`、`demo/settings-manage.demo.ts`、`demo/agents-dialog.demo.ts` 删本地样板改复用，用例数与断言不变 |
| `00fb29f8` | webview 新用例 | **G4/G8** `settings-save-feedback.e2e.ts`（4 例：全局设置保存载荷 + 无内联提示 + 回包复位；个性化记忆；AGENTS.md 用户级；AGENTS.md 项目级**读+写**双路径都带 `workdir` 归属键）；**G5** `settings-delete-confirm.e2e.ts`（4 例：技能/子代理/钩子/MCP 确认删除 → `deleteXxx` 载荷 → 回包后剩余行仍渲染、空态占位不出现） |
| `1e37c9e1` | desktop 真 host | **G6** `realHostSettings.integration.test.ts` 追加 1 例：真 SDK + 真 CLI 下同名技能跨 `.wave`/`.claude` 都被删净，连续 30 轮采样无空列表、无复活 |
| `825e1711` | desktop 单测 | **G2** 1 例（`updateConfig` 透传 `autoMemoryEnabled: false` / `autoMemoryFrequency`）；**G4** 7 例（四个 `deleteXxx` 失败时发失败 toast 且不刷新列表 + 三个「无 live agent」时发失败 toast 而非静默） |
| `08c783f1` | vscode | **G2** `chatSession.test.ts`（真 StdioAgent + 假 JSON-RPC，断言 stdio `updateConfig` 参数）；`configurationService.autoMemory.test.ts`（globalState 往返后 `false` 不被吞）；**G4** `messageHandler.test.ts` +9（settings 路由保存失败/删除异常，chat 路由成功与失败 toast） |
| `ff0f20c3` | jetbrains | **G7** `SettingsHandlerTest.kt`（6 例，真 `MessageHandler` → 假 `node` stdio CLI）：setAgentsContent + RPC 参数、deleteHook 后重推 hooksResponse、deleteSkill 名字、removeMcpServer scope/serverName、setBuiltinPluginEnabled → projectSettings、无 live agent 时 `ok:false` |
| `eb1b7ee2` | 测试基建 | 真 host 套件临时根目录按 runner pid 命名（见下） |

新增用例合计 35 个（webview 8 + desktop 9 + vscode 12 + JB 6），改动 15 个文件，**全部是测试/demo 代码，零生产源码改动**（diff 里唯一匹配 `src/` 的是 Kotlin 测试 `src/test/kotlin/...`）。

## 红转绿证据（原始输出）

逐项定点变异 → 先红后绿，红证原始输出：

| 项 | 变异点 | 红（原始断言） |
|---|---|---|
| G2 vscode | `autoMemoryEnabled: config.autoMemoryEnabled \|\| true` | `AssertionError: expected { model: 'm', …(3) } to match object { autoMemoryEnabled: false, …(1) }` |
| G2 desktop | 去掉 `updateConfig` 透传 | `AssertionError: expected "vi.fn()" to be called with arguments: [ ObjectContaining{…} ]` |
| G4 vscode | 去掉保存失败提示 | `AssertionError: expected "vi.fn()" to be called with arguments: [ '保存失败：boom' ]` |
| G4 desktop | 删掉失败 toast | `AssertionError: expected false to be true // Object.is equality` |
| G4/G8 webview | 保留内联保存提示 | `1 failed … expectNoInlineSaveHint (settings-save-feedback.e2e.ts:36)` |
| G8 webview 写路径 | 去掉 `setAgentsContent` 的 workdir | `1 failed … settings-save-feedback.e2e.ts:228` |
| G8 webview 读路径 | 去掉 `getAgentsContent` 的 workdir | `1 failed … settings-save-feedback.e2e.ts:234` |
| G5 webview | ①确认时清空列表 ②只变异技能视图 | ①`4 failed`（四个视图全红）②`1 failed` |
| G6 realhost | 还原预修 `skillManager.performRefresh` 就地 clear + 重建 sdk **与** `packages/code` bundle | `AssertionError: expected [ [] ] to deeply equal []` |
| G7 JB | 6 处定点变异 `MessageHandler` 分支 | XML `tests="6" failures="6"`，失败信息与原变异一一对应 |

诚实标注：G5 的 `setItems([])` 变异**不变红** —— 宿主回包会立刻重填列表，webview 层看不到「空窗」。该半场只能钉在 real-host 层（G6 的 30 轮采样），webview 层改钉「确认即发出 `deleteXxx`」+「回包后剩余条目仍渲染、空态不出现」。即**断言的层必须等于可见结果的产生层**。

## 各层全量测试（全绿）

- webview e2e：**87 passed** / demo：**4 passed**
- desktop 单测：**19 files / 618 passed**
- desktop 真 host：**3 files / 15 passed**（含并发两次同跑互不干扰，见下）
- vscode：**12 files / 154 passed**
- jetbrains：**73 tests / 2 skipped / 0 failures**（SettingsHandlerTest 6/0/0）
- `type-check` 6 工程全绿；触及包 oxlint 0 warnings / 0 errors；prettier all matched

## 测试基建：真 host 临时目录并发隔离（`eb1b7ee2`）

真 host 套件把 HOME / userData / workspaces 放在固定路径 `<tmp>/wave-desktop-realhost`，而 `resetRealHostState()` 在每个 `beforeEach` 里 `rmSync` 整棵树 —— 同机多 worktree 并行跑时两个 runner 会互清目录，症状随机（技能列表恒空、transcript 计数错位、两 pane 隔离用例红），看起来像真 bug。本轮就因此误中过一次假红。

改动只做目录隔离：config 侧 root 改为 `<tmp>/wave-desktop-realhost-<pid>` 并通过 `test.env.WAVE_REALHOST_ROOT` 交给 harness（worker pid 与主进程不同，必须 env 传递，否则 HOME 与 harness 读写目录会错位），harness 侧优先读该 env、缺省仍是原路径。**断言语义与收敛/轮询逻辑一行未动。**

验证：单跑 3 files / 15 passed 且只生成一个带 pid 的根（证明 env 传递生效）；并发两次同套件（不再需要手工 `TMPDIR=` 隔离）→ 两个不同 pid 根、两边各自 15 passed。

## 未包含项 / 已知边界

- **真 host 与 e2e 在 PR CI 中是跳过项**（`integration` / `real-host-e2e` / `webview-e2e` 非 PR 门禁），上面的真 host 与 e2e 数字来自本地实跑；CI 只跑单测层。
- **JB toast 分支不可单测**：`IdeService.showInfo/showError` 是无缝 platform `object`，无 application 时静默失败。G7 覆盖 handler + RPC 参数，不含 toast。
- **仓库级 oxlint 在其他包有既有报错**，与本轮无关；本轮只对触及包执行 oxlint。
- **pid 命名后 tmp 根会累积**：以前是固定目录、每次跑复用同一份，现在每次 `test:realhost` 都会留下一个 `wave-desktop-realhost-<pid>` 不再复用。这是刻意取舍——用「目录残留」换「同机并发不再互清目录」，当前做法是交给 OS 回收 tmp，**暂不在 run 结束时清理**（不为此在 harness 里加 cleanup 生命周期，避免把测试基建的复杂度上抬）。看到 `/tmp` 里堆了多个该前缀目录是预期现象，不是泄漏 bug。
- **既有 flake（非本 PR 引入）**：`realHostSessionFlow` 的「keeps two panes on different projects isolated」在机器高负载下 `transcriptFiles(dirB)` 偶发为空。已在干净 baseline（`0cba5e23`）同负载下复现到**更多**失败，判定为负载敏感的既有 flake，不在本 PR 修。
- 后续依赖：G2 锁的是 **stdio `updateConfig` 参数通道**。若后续「保存路径热生效」把用户偏好搬进 `settings.json`（`model`/`fastModel` 不再走 AgentOptions），这条断言需同步更新。
