### PR TITLE
fix(webview): demo 截图夹具补登录态，修复 docs 部署用例失败

### DIFF
--- a/packages/webview/demo/bash-mode.demo.ts
+++ b/packages/webview/demo/bash-mode.demo.ts
@@ -9,6 +9,19 @@ test.describe("Bash Mode Demo", () => {
   }) => {
     const injector = new MessageInjector(webviewPage);
 
+    // Provide initial state for a logged-in user (auth gates the input area)
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [],
+      isStreaming: false,
+      sessions: [],
+      isAuthenticated: true,
+      configurationData: {
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
+
     // 1. Show a successful command with output
     await injector.updateMessages([
       MockDataGenerator.createBangMessage(

--- a/packages/webview/demo/model-command.demo.ts
+++ b/packages/webview/demo/model-command.demo.ts
@@ -7,6 +7,19 @@ test.describe("Product Spec: /model 命令", () => {
   test("should capture model popup screenshot", async ({ webviewPage }) => {
     const injector = new MessageInjector(webviewPage);
 
+    // Provide initial state for a logged-in user (auth gates the input area)
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [],
+      isStreaming: false,
+      sessions: [],
+      isAuthenticated: true,
+      configurationData: {
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
+
     // Setup a conversation
     const messages = [
       MockDataGenerator.createUserMessage(
@@ -62,6 +75,19 @@ test.describe("Product Spec: /model 命令", () => {
     webviewPage,
   }) => {
     const injector = new MessageInjector(webviewPage);
+
+    // Provide initial state for a logged-in user (auth gates the input area)
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [],
+      isStreaming: false,
+      sessions: [],
+      isAuthenticated: true,
+      configurationData: {
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
 
     // Setup a minimal conversation
     const messages = [MockDataGenerator.createUserMessage("你好")];

--- a/packages/webview/demo/product-spec-btw.demo.ts
+++ b/packages/webview/demo/product-spec-btw.demo.ts
@@ -12,6 +12,19 @@ test.describe("Product Spec: /btw side question", () => {
   }) => {
     const injector = new MessageInjector(webviewPage);
 
+    // Provide initial state for a logged-in user (auth gates the input area)
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [],
+      isStreaming: false,
+      sessions: [],
+      isAuthenticated: true,
+      configurationData: {
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
+
     // Setup a conversation so the panel shows above a real chat
     const messages = [
       MockDataGenerator.createUserMessage("帮我看下 PaymentService 的并发问题"),
@@ -64,6 +77,7 @@ test.describe("Product Spec: /btw side question", () => {
       messages: [],
       isStreaming: false,
       sessions: [],
+      isAuthenticated: true,
       configurationData: {
         model: "claude-sonnet-4-20250514",
         fastModel: "claude-haiku-4-20250514",

--- a/packages/webview/demo/product-spec-confirmations.demo.ts
+++ b/packages/webview/demo/product-spec-confirmations.demo.ts
@@ -27,6 +27,7 @@ test.describe("Product Specification Screenshots - Confirmations", () => {
       messages: [],
       isStreaming: false,
       sessions: [],
+      isAuthenticated: true,
       configurationData: {
         model: "claude-sonnet-4-20250514",
         fastModel: "claude-haiku-4-20250514",

--- a/packages/webview/demo/product-spec-history-search.demo.ts
+++ b/packages/webview/demo/product-spec-history-search.demo.ts
@@ -14,6 +14,7 @@ test.describe("Product Spec: History Search", () => {
       messages: [],
       isStreaming: false,
       sessions: [],
+      isAuthenticated: true,
       configurationData: {
         model: "claude-sonnet-4-20250514",
         fastModel: "claude-haiku-4-20250514",

--- a/packages/webview/demo/product-spec-message-queuing.demo.ts
+++ b/packages/webview/demo/product-spec-message-queuing.demo.ts
@@ -49,6 +49,7 @@ test.describe("Product Specification Screenshots - Message Queuing", () => {
       ],
       isStreaming: true,
       sessions: [],
+      isAuthenticated: true,
       configurationData: {
         model: "claude-sonnet-4-20250514",
         fastModel: "claude-haiku-4-20250514",

--- a/packages/webview/demo/product-spec-rewind.demo.ts
+++ b/packages/webview/demo/product-spec-rewind.demo.ts
@@ -45,6 +45,19 @@ test.describe("Product Spec: Rewind", () => {
   test("should capture /rewind popup screenshot", async ({ webviewPage }) => {
     const injector = new MessageInjector(webviewPage);
 
+    // Provide initial state for a logged-in user (auth gates the input area)
+    await injector.simulateExtensionMessage("setInitialState", {
+      messages: [],
+      isStreaming: false,
+      sessions: [],
+      isAuthenticated: true,
+      configurationData: {
+        model: "claude-sonnet-4-20250514",
+        fastModel: "claude-haiku-4-20250514",
+      },
+      permissionMode: "default",
+    });
+
     // Setup a conversation with several user messages
     const messages = [
       MockDataGenerator.createUserMessage(

--- a/packages/webview/demo/sdd-workflow-iterate.demo.ts
+++ b/packages/webview/demo/sdd-workflow-iterate.demo.ts
@@ -22,6 +22,7 @@ test.describe("SDD Workflow Iterate Screenshots", () => {
       messages: [],
       isStreaming: false,
       sessions: [],
+      isAuthenticated: true,
       configurationData: {
         model: "claude-sonnet-4-20250514",
         fastModel: "claude-haiku-4-20250514",

--- a/packages/webview/demo/sdd-workflow.demo.ts
+++ b/packages/webview/demo/sdd-workflow.demo.ts
@@ -23,6 +23,7 @@ test.describe("SDD Workflow Screenshots", () => {
       messages: [],
       isStreaming: false,
       sessions: [],
+      isAuthenticated: true,
       configurationData: {
         model: "claude-sonnet-4-20250514",
         fastModel: "claude-haiku-4-20250514",


### PR DESCRIPTION
## 背景

`Deploy VitePress to GitHub Pages`（run 34554605629，sha `770e8ca3`）的 `Build VitePress` 步骤在 main 上**连续 4 次失败**，只改 webview demo 测试夹具，不动产品行为。

## 根因

- `packages/webview/src/components/ChatApp.tsx:2111-2117`：

  ```ts
  const unauthenticated = !state.isAuthenticated;
  const inputDisabledReason = unauthenticated
    ? "请先登录后再发送消息"
    : host?.type === "desktop" && !effectiveWorkdir
      ? "请先选择项目目录"
      : undefined;
  const inputDisabled = inputDisabledReason !== undefined;
  ```

  `inputDisabled` 经 `disabled` 传入 `MessageInput`；reducer 的初始 `isAuthenticated: false`（`packages/webview/src/reducers/chatReducer.ts`）。
- **红绿分界 = PR #2179 的三个 commit**（`72d55456` 三端凭据链路下线 / `41916e06` 未认证+未选目录禁用发送入口 / `0adc2a0f` docs）。最后绿 = `0cba5e23`（09-10T11:06Z），其后 main push 连红：`0adc2a0f`、`9e202e14`、`2c21b163`、`770e8ca3`。
- 机制：驱动输入区（打字 / 点「加号」「快捷指令」「权限模式」「发送」）却未在 `setInitialState` 里置 `isAuthenticated: true` 的 demo 夹具，输入区整体 disabled ⇒ 斜杠命令/加号菜单不触发 ⇒ 等待宿主消息的 `waitForFunction` 5s 超时。8 条失败用例分布在 5 个 `[demo]` 文件，与「缺 `isAuthenticated` 的夹具」一一对应。

## 影响

- `build` job 失败 ⇒ `deploy`（`needs: build`）从不执行 ⇒ **GitHub Pages 文档站自 `0cba5e23` 起未再部署**。
- `publish.yml` 的 `Generate screenshots` 步骤同一命令（`pnpm -F wave-webview test:demo`），**下次发版流水线会同样挂在这里**。

## 改动清单（仅 `packages/webview/demo/**`，9 文件 +71 −0）

**A 组 — 修复 8 条失败用例的 5 个文件**

| 文件 | 改动 | 为什么 |
|---|---|---|
| `model-command.demo.ts` | 两个用例各**新增** `setInitialState`（`isAuthenticated: true`），置于既有 `updateMessages` 之前 | 原本完全没发 `setInitialState`；`SET_INITIAL_STATE(messages:[])` 先初始化、再 `updateMessages`（`SET_MESSAGES`）不破坏原流程 |
| `product-spec-rewind.demo.ts` | `/rewind` 用例**新增** `setInitialState` | 该用例驱动输入区但无初始化消息 |
| `product-spec-btw.demo.ts` | 用例 1 **新增** `setInitialState`；用例 2 既有 payload **补** `isAuthenticated` | 同上；用例 2 已有 payload，只差认证位 |
| `product-spec-history-search.demo.ts` | `initialize()` 既有 payload **补** `isAuthenticated` | 两用例都点输入区（Ctrl+R / 加号菜单） |
| `product-spec-message-queuing.demo.ts` | 既有 payload **补** `isAuthenticated` | 用例在流式中打字进输入区 |

**B 组 — 横向扫查发现的同类缺口（4 个文件，超出「驱动输入」字面范围）**

| 文件 | 改动 | 为什么 |
|---|---|---|
| `product-spec-confirmations.demo.ts` | 既有 payload **补** `isAuthenticated` | 焦点/截图输入区内的权限模式选择器，禁用态会污染截图 |
| `bash-mode.demo.ts` | **新增** `setInitialState` | 全页截图含输入区 |
| `sdd-workflow.demo.ts` | 既有 payload **补** `isAuthenticated` | 全页截图含输入区 |
| `sdd-workflow-iterate.demo.ts` | 既有 payload **补** `isAuthenticated` | 全页截图含输入区 |

> B 组不属于「驱动输入区」的字面范围，但套用 auth gate 后这些**全页/输入区截图**恒显示「请先登录后再发送消息」+ 按钮置灰（已截图实证：`bash-mode-success.webp` / `spec-sdd-workflow-spec.webp` / `spec-sdd-iterate-continue.webp` 修复前均命中）。因同属「demo 应模拟已登录用户的正常对话」这一根因、同为夹具一行改动且限同一目录，一并补上；修复后已恢复默认占位「快捷指令, @添加上下文…」。

## 产品行为

**未放宽/回退产品侧禁用 gate**。「未认证禁用发送入口」是 PR #2179 的有意设计，e2e 侧已有专门覆盖（`packages/webview/e2e/desktop-unauthenticated-input-disabled.e2e.ts`）。本 PR 只补 demo 夹具的认证态。未触碰 `src/`、`e2e/`、`docs/specs`、CI workflow。

## 验证

| 检查 | 结果 |
|---|---|
| `pnpm run compile && npx playwright test --project=demo --project=e2e` | **203 passed**（demo 99 + e2e 104），0 failed |
| `pnpm -F wave-webview run type-check` | 通过 |
| `pnpm -F wave-webview run lint`（oxlint） | 0 warnings / 0 errors |
| `prettier --check packages/webview/demo/**/*.ts` | 全部符合 Prettier |
| fail-without-fix 红证 | `model-command` 与 `product-spec-history-search` 各自把 `isAuthenticated` 临时改 `false` ⇒ **各 2 failed**，`error-context.md` 快照出现占位文案「请先登录后再发送消息」；还原后各 **2 passed** |
| `git diff --name-only` | 仅 `packages/webview/demo/**` |

> 说明：Playwright 生成的截图落在 `docs/public/screenshots/`，该目录被 gitignore，**不在本 PR diff 内**；CI 的 `docs:screenshots` 步骤会重新生成。
