### PR TITLE
fix(desktop): 外部链接打开失败时给出可见提示

### DIFF
--- a/packages/desktop/src/main/desktopHost.ts
+++ b/packages/desktop/src/main/desktopHost.ts
@@ -677,6 +677,17 @@ export class DesktopHost {
   }
 
   /**
+   * 打开外部链接失败（没有可用的浏览器、默认浏览器注册损坏等）时告知用户。
+   * 系统层面打不开时不提示的话，点击看起来就是「毫无反应」——失败与「已在后台
+   * 打开但没抢到焦点」无法区分。所有打开外部链接的入口都走这里。
+   */
+  reportExternalOpenFailure(error: unknown): void {
+    this.showToast({
+      message: `打开外部链接失败：${error instanceof Error ? error.message : String(error)}`,
+    });
+  }
+
+  /**
    * 推送 macOS 窗口全屏状态 (desktopFullScreen, spec「macOS 隐藏标题栏」场景 7)。
    * Window-global，无 paneId；webview 据此在全屏（红绿灯隐藏）时收起红绿灯让位。
    */
@@ -873,7 +884,11 @@ export class DesktopHost {
       this.router = new NotificationRouter(this.client);
       this.router.registerGlobal("authUrl", (params) => {
         const p = params as { url?: string };
-        if (p?.url) void shell.openExternal(p.url);
+        if (p?.url) {
+          void shell
+            .openExternal(p.url)
+            .catch((error) => this.reportExternalOpenFailure(error));
+        }
       });
       this.router.attach();
     })();
@@ -3995,13 +4010,14 @@ export class DesktopHost {
           try {
             await shell.openExternal(url);
           } catch (error) {
-            this.pushSystemMessage(`打开外部链接失败: ${error}`);
+            this.reportExternalOpenFailure(error);
           }
         } else {
           console.warn(
             "[DesktopHost] Refused to open external URL with unexpected scheme:",
             url,
           );
+          this.reportExternalOpenFailure("链接无效");
         }
         break;
       }
@@ -5433,7 +5449,9 @@ export class DesktopHost {
         url,
       );
       this.pendingAuthTunnels.set(host, forward);
-      void shell.openExternal(forward.authUrl);
+      void shell
+        .openExternal(forward.authUrl)
+        .catch((error) => this.reportExternalOpenFailure(error));
     } catch (error) {
       console.error(`[DesktopHost] ${host} 的 SSO 回调端口转发失败:`, error);
       this.pushSystemMessage(

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -322,7 +322,9 @@ function createWindow(): void {
   // External links always open in the system browser (FR-008).
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     if (/^https?:/.test(url)) {
-      void shell.openExternal(url);
+      void shell
+        .openExternal(url)
+        .catch((error) => host?.reportExternalOpenFailure(error));
     }
     return { action: "deny" };
   });
@@ -333,7 +335,9 @@ function createWindow(): void {
     if (url.startsWith("file:")) return;
     event.preventDefault();
     if (/^https?:/.test(url)) {
-      void shell.openExternal(url);
+      void shell
+        .openExternal(url)
+        .catch((error) => host?.reportExternalOpenFailure(error));
     }
   });
 
@@ -365,7 +369,9 @@ function createWindow(): void {
     // (The <webview> `new-window` DOM event was removed in Electron 39.)
     guest.setWindowOpenHandler(({ url }) => {
       if (/^https?:/.test(url)) {
-        void shell.openExternal(url);
+        void shell
+          .openExternal(url)
+          .catch((error) => host?.reportExternalOpenFailure(error));
       }
       return { action: "deny" };
     });
@@ -375,7 +381,9 @@ function createWindow(): void {
       if (isLocalhostUrl(url)) return;
       event.preventDefault();
       if (/^https?:/.test(url)) {
-        void shell.openExternal(url);
+        void shell
+          .openExternal(url)
+          .catch((error) => host?.reportExternalOpenFailure(error));
       }
     });
   });

--- a/packages/desktop/tests/desktopHost.test.ts
+++ b/packages/desktop/tests/desktopHost.test.ts
@@ -2220,21 +2220,40 @@ describe("configuration and status", () => {
   });
 
   it("openExternal allows https URLs (FR-008)", async () => {
-    const { host } = await readyHost();
+    const { host, sent } = await readyHost();
     await host.handleWebviewMessage({
       command: "openExternal",
       url: "https://example.com",
     });
     expect(shell.openExternal).toHaveBeenCalledWith("https://example.com");
+    // The browser coming forward is its own feedback — no toast on success.
+    expect(sent("showToast")).toHaveLength(0);
+  });
+
+  it("openExternal reports a failure the user can see", async () => {
+    const { host, sent } = await readyHost();
+    vi.mocked(shell.openExternal).mockRejectedValueOnce(
+      new Error("no browser"),
+    );
+    await host.handleWebviewMessage({
+      command: "openExternal",
+      url: "https://example.com",
+    });
+    expect(sent("showToast").at(-1)?.toast.message).toBe(
+      "打开外部链接失败：no browser",
+    );
   });
 
   it("openExternal refuses unexpected schemes", async () => {
-    const { host } = await readyHost();
+    const { host, sent } = await readyHost();
     await host.handleWebviewMessage({
       command: "openExternal",
       url: "file:///etc/passwd",
     });
     expect(shell.openExternal).not.toHaveBeenCalled();
+    expect(sent("showToast").at(-1)?.toast.message).toBe(
+      "打开外部链接失败：链接无效",
+    );
   });
 });
 


### PR DESCRIPTION
## 问题

桌面端点击预览面板的「在浏览器中打开」，或点击消息里的外部链接，若系统层面打不开（没有可用浏览器、默认浏览器注册损坏等），用户看不到任何反馈，点击看起来就是毫无反应。

原实现失败时走 pushSystemMessage —— 往聊天流里补一条系统消息，pane 处于新会话选择器状态时根本不可见；无效链接分支更是只有一行 console.warn。

## 改动

- desktopHost 新增 reportExternalOpenFailure(error)，失败统一经全局 toast 提示「打开外部链接失败：<原因>」
- 6 个打开外部链接的入口全部接入：openExternal RPC、authUrl 登录通知、远程 SSO 回调转发、主窗口 setWindowOpenHandler / will-navigate、预览 guest 的同两处兜底
- 无效链接提示「链接无效」，保留 console.warn 便于排查
- 成功时不提示，浏览器自身抢到焦点即是反馈

## 验证

- TDD：先写 2 个失败用例（失败提示、无效链接提示）再实现，另补成功路径「无 toast」断言
- pnpm -F wave-desktop test：629 passed
- type-check / oxlint / prettier 全绿