### PR TITLE
fix(desktop): 删除 worktree 确认框的检查态可见且可自救

### DIFF
--- a/packages/webview/e2e/desktop-delete-session.e2e.ts
+++ b/packages/webview/e2e/desktop-delete-session.e2e.ts
@@ -202,6 +202,15 @@ test.describe("桌面删除会话", () => {
     await openDeleteConfirm(webviewPage, "sess-a2");
     const confirm = webviewPage.getByTestId("confirm-dialog-confirm");
     await expect(confirm).toBeDisabled();
+    // 禁用必须看得见：检查期间主按钮不得再画成可点击的实心蓝，否则用户只
+    // 能看到一个「点了没反应」的按钮（用户反馈）。jsdom 不计算 CSS，只能
+    // 在真实浏览器里断言。
+    const disabledStyle = await confirm.evaluate((el) => {
+      const s = getComputedStyle(el);
+      return { opacity: Number(s.opacity), cursor: s.cursor };
+    });
+    expect(disabledStyle.opacity).toBeLessThan(1);
+    expect(disabledStyle.cursor).toBe("not-allowed");
     // 检查期间主按钮不可用、接不住焦点——此时焦点仍在打开菜单的触发钮上，
     // 所以检查完成后绝不能把焦点留在那儿（Enter 会重开那一行的菜单）。
     await expect(
@@ -216,6 +225,10 @@ test.describe("桌面删除会话", () => {
 
     await expect(confirm).toBeEnabled();
     await expect(confirm).toBeFocused();
+    // 检查返回后必须恢复成正常可点的外观（禁用样式不得常驻）。
+    await expect
+      .poll(() => confirm.evaluate((el) => getComputedStyle(el).opacity))
+      .toBe("1");
 
     // 焦点在弹窗内 ⇒ Enter 是「确认删除」，不是重开行菜单
     await webviewPage.keyboard.press("Enter");

--- a/packages/webview/src/components/DesktopSidebar.tsx
+++ b/packages/webview/src/components/DesktopSidebar.tsx
@@ -336,10 +336,14 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
     if (message.command !== "desktopWorktreeChanges") return;
     if (String(message.requestId) !== String(worktreeChangesRequestRef.current))
       return;
+    // A reply describes exactly the dialog that asked for it. On a sessionId
+    // mismatch, leave everything alone — including the fallback timer, which is
+    // the only way out if the real reply never lands.
+    if (message.sessionId !== pendingDelete?.sessionId) return;
     // A timely reply beats the timeout — stop the fallback from firing.
     clearWorktreeChangesTimeout();
     setPendingDelete((prev) =>
-      prev && prev.sessionId === message.sessionId
+      prev
         ? {
             ...prev,
             checking: false,

--- a/packages/webview/src/styles/ConfirmDialog.css
+++ b/packages/webview/src/styles/ConfirmDialog.css
@@ -80,6 +80,14 @@
   white-space: nowrap;
 }
 
+/* A disabled action must read as disabled. The worktree delete dialog mounts
+   with confirm disabled while the host counts the changes at risk (see
+   DesktopSidebar); without this the blue primary button looks clickable. */
+.confirm-dialog-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .confirm-dialog-btn-cancel {
   background-color: var(--vscode-button-secondaryBackground, transparent);
   color: var(--vscode-button-secondaryForeground, #b1b1b1);
@@ -99,6 +107,6 @@
   border: none;
 }
 
-.confirm-dialog-btn-confirm:hover {
+.confirm-dialog-btn-confirm:hover:not(:disabled) {
   background-color: var(--vscode-button-hoverBackground, #2690c7);
 }

--- a/packages/webview/tests/webview/desktopApp.test.tsx
+++ b/packages/webview/tests/webview/desktopApp.test.tsx
@@ -1760,6 +1760,35 @@ describe("DesktopApp", () => {
         expect(dialog).not.toHaveTextContent("5 个未提交文件");
         expect(screen.getByTestId("confirm-dialog-confirm")).toBeEnabled();
       });
+
+      it("keeps its own timer when the reply names another session", () => {
+        const { vscode } = renderDesktopApp();
+        openWorktreeDelete(vscode);
+
+        // Matches the requestId but names a different session — it describes
+        // nothing this dialog asked for. Consuming it would also clear the
+        // fallback timer, stranding the dialog "checking" with a disabled
+        // confirm and no way out.
+        sendCommand("desktopWorktreeChanges", {
+          sessionId: "other",
+          requestId: worktreeChangesRequest(vscode).requestId,
+          changes: { files: 9, commits: 9 },
+        });
+
+        expect(screen.getByTestId("confirm-dialog-overlay")).toHaveTextContent(
+          "正在检查",
+        );
+
+        act(() => {
+          vi.advanceTimersByTime(WORKTREE_CHANGES_TIMEOUT_MS);
+        });
+
+        const dialog = screen.getByTestId("confirm-dialog-overlay");
+        expect(dialog).not.toHaveTextContent("正在检查");
+        expect(dialog).toHaveTextContent("未提交的改动将丢失");
+        expect(dialog).not.toHaveTextContent("9 个未提交文件");
+        expect(screen.getByTestId("confirm-dialog-confirm")).toBeEnabled();
+      });
     });
   });
 


### PR DESCRIPTION
## 背景

删除 worktree 会话时，确认框会先进入「正在检查该 worktree 的改动…」状态（宿主要跑 `git status`，远端还要走 SSH），此期间主按钮**已禁用**——但代码里从来没有 `:disabled` 样式，所以它照样是蓝色实心、`cursor: pointer`，hover 还会变亮。用户看到的是一个「点了没反应」的按钮。

## 改动

### 1. 禁用态可见（`ConfirmDialog.css`）

- 补 `.confirm-dialog-btn:disabled { opacity: 0.5; cursor: not-allowed; }`，对齐仓库既有约定（`ConfirmationDialog.css`、`SettingsPage.css`）
- `.confirm-dialog-btn-confirm:hover` → `:hover:not(:disabled)`，禁用时不再有 hover 反馈
- `desktop-delete-session.e2e.ts` 补断言：检查中 `opacity < 1` 且 `cursor: not-allowed`；回报后恢复 `opacity: 1`（防止禁用样式常驻）。纯 CSS 行为 jsdom 算不出来，只能落在真实浏览器层

保留「禁用」而不是「检查完再显示按钮」：按钮迟到会有布局跳动、取消必须一直在、平台惯例是按钮先渲染后禁用，且 spec 已写死该状态（`desktop-sessions.md` 场景 7 + `action-confirm-dialog.md` 场景 2）。

### 2. 收掉一条死路（`DesktopSidebar.tsx`）

应答先按 requestId 归属匹配，但 sessionId 校验写在 `setPendingDelete` 的 updater 里，而 `clearWorktreeChangesTimeout()` 跑在它**之前**——一条 requestId 匹配、sessionId 不匹配的应答会清掉超时兜底，把弹窗永久停在「正在检查」且确认不可用，会话从 UI 里再也删不掉。

改为 sessionId 不匹配即整条丢弃、定时器原样保留；`prev &&` 那半句同条件判据一并删除。

## 验证

- 新测试先跑红（修复前弹窗确实卡死）再转绿，放在已有的 `describe("worktree changes check timeout")` 内
- webview 全量单测 **1135 passed / 120 files**
- e2e `desktop-delete-session`（重编 dist 后）4 passed
- `tsc --noEmit`（src + tests + e2e）通过、`oxlint` 0 warnings 0 errors
- 真浏览器截图确认过检查中 / 检查完成 / 非 worktree 三档观感