### PR TITLE
fix(webview)+ci: 修复 worktree 改动检查的同步应答丢失，并把 demo 套件接进 PR gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,115 @@ jobs:
         if: steps.filter.outputs.code == 'true'
         run: pnpm -F wave-${{ matrix.pkg }} test:unit --shard=${{ matrix.shard }}/2
 
+  webview-demo:
+    runs-on: ubuntu-latest
+    # PR gate: the demo suites (packages/webview/demo/*.demo.ts) drive the built
+    # webview in a real browser. They exist to produce the docs screenshots, but
+    # they also assert UI behaviour the unit tests cannot reach — a webview
+    # regression reached main through exactly this gap while the suites ran only
+    # post-merge (pages.yml needs the screenshots), leaving main's docs deploy
+    # red with the pull request long merged. Sharded three ways on separate
+    # runners: the fixed cost (install + build + Chromium) is ~40s a shard and a
+    # shard is shorter than the check jobs, so the PR critical path is unchanged.
+    # Unlike `check` and `check-extras`, this job's filter must NOT exclude
+    # webview/demo — a demo-only change has to run the demos.
+    if: github.event_name != 'push'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Detect code changes
+        uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            code:
+              - '!**/*.md'
+              - '!**/*.txt'
+              - '!docs/**'
+              - '!scripts/**'
+              - '!LICENSE'
+
+      # Cache pnpm/action-setup's install dir so concurrent jobs skip
+      # re-downloading the action tarball from codeload (429 rate limits,
+      # pnpm/action-setup#177). On hit we skip the action and prepend its bin
+      # dirs to PATH ourselves. The key pins the pnpm version — keep it in
+      # sync with the `version` input below (package.json "packageManager").
+      - name: Cache pnpm install
+        if: steps.filter.outputs.code == 'true'
+        id: pnpm-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/setup-pnpm
+          key: pnpm-setup-v5-${{ runner.os }}-${{ runner.arch }}-11.9.0
+
+      - name: Add cached pnpm to PATH
+        if: steps.filter.outputs.code == 'true' && steps.pnpm-cache.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          # Mirror pnpm/action-setup's env: node_modules/.bin/bin holds the
+          # self-updated target version (higher precedence), node_modules/.bin
+          # the bootstrap symlink. GITHUB_PATH is used verbatim, so write
+          # native Windows paths on Windows runners.
+          PNPM_HOME="${USERPROFILE:-$HOME}/.cache/setup-pnpm/node_modules/.bin"
+          PNPM_BIN="$PNPM_HOME/bin"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            PNPM_HOME="${PNPM_HOME//\//\\}"
+            PNPM_BIN="${PNPM_BIN//\//\\}"
+          fi
+          echo "$PNPM_HOME" >> "$GITHUB_PATH"
+          echo "$PNPM_BIN" >> "$GITHUB_PATH"
+          echo "PNPM_HOME=$PNPM_HOME" >> "$GITHUB_ENV"
+
+      - name: Setup pnpm (cache miss)
+        if: steps.filter.outputs.code == 'true' && steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: pnpm/action-setup@v5
+        with:
+          version: 11.9.0
+          dest: ~/.cache/setup-pnpm
+          run_install: false
+
+      - name: Setup Node.js
+        if: steps.filter.outputs.code == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        if: steps.filter.outputs.code == 'true'
+        run: pnpm install --frozen-lockfile
+
+      # The demos load packages/webview/dist, so the webview must be built.
+      - name: Build
+        if: steps.filter.outputs.code == 'true'
+        run: pnpm build
+
+      - name: Cache Playwright browsers
+        if: steps.filter.outputs.code == 'true'
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-chromium-${{ runner.os }}-
+
+      - name: Install Playwright Chromium
+        if: steps.filter.outputs.code == 'true'
+        run: pnpm -F wave-webview exec playwright install --with-deps chromium
+
+      # Straight to playwright rather than `run test:demo`: the pretest hook
+      # re-runs the type-check that check-extras already covers.
+      - name: Demo suites (shard ${{ matrix.shard }}/3)
+        if: steps.filter.outputs.code == 'true'
+        run: pnpm -F wave-webview exec playwright test --project=demo --shard=${{ matrix.shard }}/3
+
   check-extras:
     runs-on: ubuntu-latest
     # PR gate, runs in parallel with check: type-check + lint (platform

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,7 +5,10 @@ name: Deploy VitePress to GitHub Pages
 # v1.2.0 failures (the demo mock host not answering the worktree-diff check, and raw
 # angle-bracket placeholders breaking VitePress) stay invisible to PR CI until the
 # release. Auto-trigger on push to main surfaces such failures early; workflow_dispatch
-# is kept for manual re-runs.
+# is kept for manual re-runs. The demo assertions themselves are now a PR gate
+# (ci.yml webview-demo), so this job is about producing the screenshots the docs
+# import; the e2e project it used to run alongside them is covered post-merge by
+# the webview-e2e job (e2e/utils/** still feeds the demos, hence the path trigger).
 on:
   push:
     branches: [main]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Always use `pnpm` as the package manager.
 
 ### CI Parity & Release
 
-- **Verify before pushing**: `pnpm run ci` (parallel type-check + lint + unit tests across packages — matches the CI PR gate).
+- **Verify before pushing**: `pnpm run ci` (parallel type-check + lint + unit tests across packages). It matches the CI PR gate's `check`/`check-extras` jobs, but not the gate's webview command audit or its sharded demo suites — see `.github/workflows/ci.yml`.
 - **Release**: `pnpm run release:patch` / `release:minor` / `release:major` (runs `scripts/release.js`, then the `publish.yml` GitHub workflow publishes to npm).
 
 ### JetBrains Plugin
@@ -113,4 +113,4 @@ Known legacy hotspots (duplication not yet deduplicated — check **both** copie
 
 - **Unit tests**: Vitest in `tests/` — `pnpm -F wave-vscode test`
 - **E2E tests**: real-browser Playwright tests in `packages/webview/e2e/` (`.e2e.ts`, requires Chromium) — `pnpm -F wave-webview run test:e2e`
-- **Demo/screenshot tests**: screenshot-only Playwright tests in `packages/webview/demo/` (`.demo.ts`); `pnpm -F wave-webview run test:demo` runs both projects and regenerates the gitignored screenshots under `docs/public/screenshots/`
+- **Demo/screenshot tests**: screenshot-only Playwright tests in `packages/webview/demo/` (`.demo.ts`); `pnpm -F wave-webview run test:demo` runs the `demo` project and regenerates the gitignored screenshots under `docs/public/screenshots/` (the `e2e` project has its own `test:e2e`)

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -26,7 +26,7 @@
     "test:unit": "vitest run",
     "test:unit:coverage": "vitest run --coverage",
     "pretest:demo": "pnpm run type-check && tsc -p e2e --noEmit && tsc -p demo --noEmit && pnpm run compile",
-    "test:demo": "playwright test --project=demo --project=e2e",
+    "test:demo": "playwright test --project=demo",
     "test:e2e": "playwright test --project=e2e"
   },
   "devDependencies": {

--- a/packages/webview/src/components/DesktopSidebar.tsx
+++ b/packages/webview/src/components/DesktopSidebar.tsx
@@ -302,9 +302,17 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
     description?: string;
     checking?: boolean;
   } | null>(null);
-  // requestId of the in-flight worktree-changes query — a late reply from a
-  // previously closed dialog must never describe the current one.
-  const worktreeChangesRequestRef = useRef(0);
+  // Identity of the in-flight worktree-changes query: its requestId, plus the
+  // session it describes (a late reply from a previously closed dialog must
+  // never describe the current one). The sessionId lives here rather than being
+  // read off `pendingDelete` so that attribution holds for a reply arriving in
+  // the same task as the request — the handler runs while React still has the
+  // previous render's state (null on the first open), so a state read there
+  // drops the reply and strands the dialog at "正在检查" until the fallback.
+  const worktreeChangesRequestRef = useRef<{
+    requestId: number;
+    sessionId: string;
+  } | null>(null);
   // Guards the worktree-changes check against a host that never answers: without
   // it the dialog would stay "checking" and unconfirmable forever, leaving the
   // session undeletable from the UI. On expiry we fall back to the generic
@@ -334,12 +342,16 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
   // cancelled dialog is dropped instead of describing the wrong session.
   useHostMessage((message) => {
     if (message.command !== "desktopWorktreeChanges") return;
-    if (String(message.requestId) !== String(worktreeChangesRequestRef.current))
+    const request = worktreeChangesRequestRef.current;
+    // A reply describes exactly the dialog that asked for it. On a mismatch,
+    // leave everything alone — including the fallback timer, which is the only
+    // way out if the real reply never lands.
+    if (
+      !request ||
+      String(message.requestId) !== String(request.requestId) ||
+      message.sessionId !== request.sessionId
+    )
       return;
-    // A reply describes exactly the dialog that asked for it. On a sessionId
-    // mismatch, leave everything alone — including the fallback timer, which is
-    // the only way out if the real reply never lands.
-    if (message.sessionId !== pendingDelete?.sessionId) return;
     // A timely reply beats the timeout — stop the fallback from firing.
     clearWorktreeChangesTimeout();
     setPendingDelete((prev) =>
@@ -632,8 +644,10 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
                 checking: session.hasWorktree,
               });
               if (session.hasWorktree) {
-                const requestId = String(++worktreeChangesRequestRef.current);
-                onRequestWorktreeChanges(sessionId, requestId);
+                const requestId =
+                  (worktreeChangesRequestRef.current?.requestId ?? 0) + 1;
+                worktreeChangesRequestRef.current = { requestId, sessionId };
+                onRequestWorktreeChanges(sessionId, String(requestId));
                 // No reply within the budget (host wedged, or a future
                 // early-return path forgot to answer): fall back to the generic
                 // warning and let the user confirm.
@@ -643,7 +657,10 @@ export const DesktopSidebar: React.FC<DesktopSidebarProps> = ({
                   // by the requestId guard above — otherwise it would flip the
                   // dialog back to "checking" and re-disable a confirm the user
                   // may already be clicking.
-                  worktreeChangesRequestRef.current += 1;
+                  worktreeChangesRequestRef.current = {
+                    requestId: requestId + 1,
+                    sessionId,
+                  };
                   setPendingDelete((prev) =>
                     prev && prev.sessionId === sessionId
                       ? {

--- a/packages/webview/tests/webview/desktopApp.test.tsx
+++ b/packages/webview/tests/webview/desktopApp.test.tsx
@@ -1572,6 +1572,34 @@ describe("DesktopApp", () => {
       expect(screen.getByTestId("confirm-dialog-confirm")).toBeEnabled();
     });
 
+    it("applies a reply that lands in the same task as the query", () => {
+      // Some hosts answer inside the postMessage call itself (the e2e/demo
+      // harnesses do; a real one could answer from cache). The reply must still
+      // be attributed to the dialog that asked — resolving that dialog's
+      // identity once React has re-rendered is too late for a same-task reply,
+      // and the dialog would sit at "正在检查" until the fallback timer.
+      const { vscode } = renderDesktopApp();
+      const reply = vscode.postMessage.getMockImplementation();
+      vscode.postMessage.mockImplementation((message) => {
+        reply?.(message);
+        if (message?.command === "desktopGetWorktreeChanges") {
+          sendCommand("desktopWorktreeChanges", {
+            sessionId: message.sessionId,
+            requestId: message.requestId,
+            changes: { files: 2, commits: 1 },
+          });
+        }
+      });
+
+      openWorktreeDelete(vscode);
+
+      const dialog = screen.getByTestId("confirm-dialog-overlay");
+      expect(dialog).not.toHaveTextContent("正在检查");
+      expect(dialog).toHaveTextContent("2 个未提交文件");
+      expect(dialog).toHaveTextContent("1 个未合并提交");
+      expect(screen.getByTestId("confirm-dialog-confirm")).toBeEnabled();
+    });
+
     it("blocks confirmation until the loss is known, then deletes on confirm", () => {
       const { vscode } = renderDesktopApp();
       openWorktreeDelete(vscode);


### PR DESCRIPTION
## 背景

合并到 main 后的 `Deploy VitePress to GitHub Pages` 连挂三次（34577605629 / 34581957609 / 34584165249），日志逐字相同：

```
demo/action-confirm-dialog.demo.ts:111
Expected: "worktree 目录与临时分支将一并删除"
Received: "确定删除会话「帮我修复登录页的样式问题」？正在检查该 worktree 的改动…"
```

## Commit 1 — 修复（webview）

ed919ace 把 sessionId 归属校验从 `setPendingDelete` 的 updater 里提到了 handler 顶部，读的是闭包里的 `pendingDelete`。`useHostMessage` 的 handler 走 latest-ref，而该 ref 只在 render 时刷新——宿主在**同一任务内**应答（demo/e2e 夹具即如此）时闭包仍是上一帧的值（首次打开为 null），回应被丢弃，弹窗停在「正在检查」直到 8s 兜底（断言超时 3s）。

修复：把「在途请求」的身份（requestId + sessionId）一起写进 `worktreeChangesRequestRef`，归属校验改读该 ref，与渲染时机解耦；同时保留 ed919ace 的意图（不匹配即整条丢弃，**不动**兜底定时器）。新增 jsdom 回归用例「同一任务内到达的应答仍被采纳」，先红后绿。

真实宿主（git 走 spawn，异步）不受影响，但这是真实的竞态：任何同任务应答的宿主都会踩。

## Commit 2 — CI

demo 用例此前只在合并后（`pages.yml` 出截图时）跑，于是 webview 回归带着已合并的 PR 把主分支文档部署挂红。改为 PR gate：

- `ci.yml` 新增 `webview-demo` job：`matrix.shard [1,2,3]` 分三个 runner 跑 `--project=demo`。固定开销约 40s/片、每片短于 `check` job（实测每片约 55s 跑测），PR 关键路径基本不变；paths-filter 不排除 `webview/demo`（与 `check`/`check-extras` 相反），demo-only 的改动也会真跑
- `test:demo` 不再连跑 e2e（e2e 的 post-merge 归属是 `webview-e2e` job），`pages.yml` 部署 job 从 4.5 分钟降到约 1.5 分钟；e2e 覆盖零损失
- `AGENTS.md`：`pnpm run ci` 与 PR gate 的对应关系、`test:demo` 语义一并校正

## 验证

- webview 单测 1176/1176、`tsc`、oxlint 全绿
- demo 分片 35 + 34 + 34 = 103 全覆盖，三片各自实跑通过
- `pnpm run docs:build` 端到端跑通：`103 passed (1.0m)` + `build complete in 12.39s`，截图与文档产物齐全
- 确认 `pretest:demo` 仍会编译 dist（pages.yml / publish.yml 不自己 build webview，只靠这个 pre 钩子）：挪走 dist 后跑脚本 → dist 重新生成且用例通过
- 已知 flaky：6 路并发下 `status-dialog.demo.ts` 偶发失败（单跑与 demo-only 6 workers 均通过）——这也正是走「固定分片」而非提高 CI workers 的原因，每片仍是 `workers: 1`